### PR TITLE
atmel-samd: HID report descriptor for mouse had to be COMPILER_WORD_ALIGNED

### DIFF
--- a/atmel-samd/asf/common/services/usb/class/hid/device/mouse/udi_hid_mouse.c
+++ b/atmel-samd/asf/common/services/usb/class/hid/device/mouse/udi_hid_mouse.c
@@ -119,6 +119,12 @@ static bool udi_hid_mouse_setreport(void);
 //@}
 
 //! HID report descriptor for standard HID mouse
+//*** CircuitPython: added COMPILER_WORD_ALIGNED to ensure descriptor is word aligned.
+// Without this, descriptor sent to host was garbled.
+// It appears this is necessary but frequently omitted in UDC_DESC_STORAGE declarations
+// in ASF code.
+// See comments about buffer alignment in asf/common/services/usb/udc/udd.h
+COMPILER_WORD_ALIGNED
 UDC_DESC_STORAGE udi_hid_mouse_report_desc_t udi_hid_mouse_report_desc = {
 	{
 				0x05, 0x01,	/* Usage Page (Generic Desktop),       */


### PR DESCRIPTION
This fixes #114. When the USB HID descriptor for the mouse was sent to the host, it was garbled. I forced the descriptor to be word-aligned, and then it was sent back properly.

There are hints that descriptors should be word-aligned. See for instance https://github.com/adafruit/circuitpython/blob/master/atmel-samd/asf/common/services/usb/udc/udd.h#L312. In many but not all places in the ASF library, `USB_DESC_STORAGE` declarations are `COMPILER_WORD_ALIGNED`, but not all. Perhaps it's an accident that most of them work: the preceeding declarations might make this so.

(Would LTO maybe have rearranged things to accidentally cause this?)

I did _not_ fix other places that might have this problem, such as https://github.com/adafruit/circuitpython/blob/master/atmel-samd/asf/common/services/usb/class/hid/device/kbd/udi_hid_kbd.c#L120.
