### PR TITLE
Rename LEFT_BUTTON -> BUTTON_A, RIGHT_BUTTON -> BUTTON_B.

### DIFF
--- a/atmel-samd/boards/circuitplayground_express/pins.c
+++ b/atmel-samd/boards/circuitplayground_express/pins.c
@@ -70,9 +70,9 @@ STATIC const mp_map_elem_t board_global_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_TEMPERATURE), (mp_obj_t)&pin_PA09 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_A9), (mp_obj_t)&pin_PA09 },
 
-    { MP_OBJ_NEW_QSTR(MP_QSTR_LEFT_BUTTON), (mp_obj_t)&pin_PA28 },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_BUTTON_A), (mp_obj_t)&pin_PA28 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D4), (mp_obj_t)&pin_PA28 },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_RIGHT_BUTTON), (mp_obj_t)&pin_PA14 },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_BUTTON_B), (mp_obj_t)&pin_PA14 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D5), (mp_obj_t)&pin_PA14 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_SLIDE_SWITCH), (mp_obj_t)&pin_PA15 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D7), (mp_obj_t)&pin_PA15 },


### PR DESCRIPTION
As per the labelling on the physical board, the buttons are no longer "left" or "right" but "A" and "B". This also means it's familiar to micro:bit users too.

Mark this as a self-inflicted breaking change for the upcoming O'Reilly book. ;-)