### PR TITLE
Enable ure, center, partition, frozenset, splitlines, reversed for Express builds.

### DIFF
--- a/atmel-samd/mpconfigport.h
+++ b/atmel-samd/mpconfigport.h
@@ -39,8 +39,6 @@
 #define MICROPY_PY_BUILTINS_MEMORYVIEW (1)
 #define MICROPY_PY_BUILTINS_ENUMERATE (1)
 #define MICROPY_PY_BUILTINS_FILTER  (1)
-#define MICROPY_PY_BUILTINS_FROZENSET (0)
-#define MICROPY_PY_BUILTINS_REVERSED (0)
 #define MICROPY_PY_BUILTINS_SET     (1)
 #define MICROPY_PY_BUILTINS_SLICE   (1)
 #define MICROPY_PY_BUILTINS_SLICE_ATTRS (1)
@@ -141,6 +139,12 @@ extern const struct _mp_obj_module_t usb_hid_module;
 
 // Internal flash size dependent settings.
 #if BOARD_FLASH_SIZE > 192000
+    #define MICROPY_PY_BUILTINS_STR_CENTER (1)
+    #define MICROPY_PY_BUILTINS_STR_PARTITION (1)
+    #define MICROPY_PY_BUILTINS_FROZENSET (1)
+    #define MICROPY_PY_BUILTINS_STR_SPLITLINES (1)
+    #define MICROPY_PY_BUILTINS_REVERSED (1)
+    #define MICROPY_PY_URE (1)
     #define MICROPY_PY_MICROPYTHON_MEM_INFO (1)
     #define MICROPY_PY_FRAMEBUF         (1)
     #define EXTRA_BUILTIN_MODULES \
@@ -149,6 +153,7 @@ extern const struct _mp_obj_module_t usb_hid_module;
         { MP_OBJ_NEW_QSTR(MP_QSTR_bitbangio), (mp_obj_t)&bitbangio_module }
     #define EXPRESS_BOARD
 #else
+    #define MICROPY_PY_BUILTINS_REVERSED (0)
     #define MICROPY_PY_MICROPYTHON_MEM_INFO (0)
     #define MICROPY_PY_FRAMEBUF         (0)
     #define EXTRA_BUILTIN_MODULES


### PR DESCRIPTION
The Express builds have >40k free in flash. I've added several minor Python features that were turned off, but are small and convenient. I also turned on one major extra: the `ure` module, which is very useful for reducing the size of ad hoc parsing code.

Bytes used for each addition (measured in 0.9.7 builds):
47588 bytes free in flash
`MICROPY_PY_BUILTINS_STR_CENTER`: 120 bytes
`MICROPY_PY_BUILTINS_STR_PARTITION`: 264 bytes
`MICROPY_PY_BUILTINS_STR_FROZENSET`: 272 bytes
`MICROPY_PY_BUILTINS_STR_SPLITLINES`: 200 bytes
`MICROPY_PY_BUILTINS_REVERSED`: 176 bytes
`MICROPY_PY_URE`: 2944 bytes
total 4096
before additions: 47588 bytes free
after: 43592 bytes free

A couple of notes:
1. `frozenset` is actually slightly broken: the sets aren't immutable (fixed in a later version of micropython).
2. I also tried adding `ujson`, but there were errors building due to some #defines in `vfs_fat_file.h` [(here)](https://github.com/adafruit/circuitpython/blob/master/extmod/vfs_fat_file.h#L38) that cause undefined symbols. This is also fixed in a later version of micropython: the vfs code was refactored significantly.