### PR TITLE
Fix broken mp_stack_check() when using -flto

### DIFF
--- a/py/stackctrl.c
+++ b/py/stackctrl.c
@@ -31,6 +31,8 @@
 #include "py/stackctrl.h"
 
 void mp_stack_ctrl_init(void) {
+    // Force routine to not be inlined. Better guarantee than MP_NOINLINE for -flto.
+    asm("");
     volatile int stack_dummy;
     MP_STATE_THREAD(stack_top) = (char*)&stack_dummy;
 }
@@ -41,6 +43,8 @@ void mp_stack_set_top(void *top) {
 
 mp_uint_t mp_stack_usage(void) {
     // Assumes descending stack
+    // Force routine to not be inlined. Better guarantee than MP_NOINLINE for -flto.
+    asm("");
     volatile int stack_dummy;
     return MP_STATE_THREAD(stack_top) - (char*)&stack_dummy;
 }


### PR DESCRIPTION
Fixes #144. Force `py/stackctrl.c` routines that effectively read the $sp not be to inlined, by using `asm("")`. `MP_NOINLINE` is not effective to prevent inlining in this case. Something about `-flto` makes these routines not work correctly. They work fine without `-flto`.

With this fix, `MP_STACK_CHECK()` stack overflow checking works again with `-flto`.