### PR TITLE
Fix USB Busy error for kbd hid. Made kbd USB report descriptor be

### DIFF
--- a/atmel-samd/asf/common/services/usb/class/cdc/device/udi_cdc.c
+++ b/atmel-samd/asf/common/services/usb/class/cdc/device/udi_cdc.c
@@ -90,12 +90,14 @@ void udi_cdc_data_disable(void);
 bool udi_cdc_data_setup(void);
 uint8_t udi_cdc_getsetting(void);
 void udi_cdc_data_sof_notify(void);
+COMPILER_WORD_ALIGNED
 UDC_DESC_STORAGE udi_api_t udi_api_cdc_comm = {
 	.enable = udi_cdc_comm_enable,
 	.disable = udi_cdc_comm_disable,
 	.setup = udi_cdc_comm_setup,
 	.getsetting = udi_cdc_getsetting,
 };
+COMPILER_WORD_ALIGNED
 UDC_DESC_STORAGE udi_api_t udi_api_cdc_data = {
 	.enable = udi_cdc_data_enable,
 	.disable = udi_cdc_data_disable,

--- a/atmel-samd/asf/common/services/usb/class/hid/device/generic/udi_hid_generic_desc.c
+++ b/atmel-samd/asf/common/services/usb/class/hid/device/generic/udi_hid_generic_desc.c
@@ -154,6 +154,7 @@ UDC_DESC_STORAGE udc_config_speed_t udc_config_fshs[1] = { {
 }};
 
 //! Add all information about USB Device in global structure for UDC
+COMPILER_WORD_ALIGNED
 UDC_DESC_STORAGE udc_config_t udc_config = {
 	.confdev_lsfs = &udc_device_desc,
 	.conf_lsfs = udc_config_fshs,

--- a/atmel-samd/asf/common/services/usb/class/hid/device/kbd/udi_hid_kbd.c
+++ b/atmel-samd/asf/common/services/usb/class/hid/device/kbd/udi_hid_kbd.c
@@ -67,6 +67,8 @@ bool udi_hid_kbd_setup(void);
 uint8_t udi_hid_kbd_getsetting(void);
 
 //! Global structure which contains standard UDI interface for UDC
+// CircuitPython fix: UDC_DESC_STORAGE must be COMPILER_WORD_ALIGNED
+COMPILER_WORD_ALIGNED
 UDC_DESC_STORAGE udi_api_t udi_api_hid_kbd = {
 	.enable = (bool(*)(void))udi_hid_kbd_enable,
 	.disable = (void (*)(void))udi_hid_kbd_disable,
@@ -117,6 +119,8 @@ COMPILER_WORD_ALIGNED
 //@}
 
 //! HID report descriptor for standard HID keyboard
+// CircuitPython fix: UDC_DESC_STORAGE must be COMPILER_WORD_ALIGNED
+COMPILER_WORD_ALIGNED
 UDC_DESC_STORAGE udi_hid_kbd_report_desc_t udi_hid_kbd_report_desc = {
 	{
 				0x05, 0x01,	/* Usage Page (Generic Desktop)      */

--- a/atmel-samd/asf/common/services/usb/class/hid/device/mouse/udi_hid_mouse.c
+++ b/atmel-samd/asf/common/services/usb/class/hid/device/mouse/udi_hid_mouse.c
@@ -66,6 +66,7 @@ bool udi_hid_mouse_setup(void);
 uint8_t udi_hid_mouse_getsetting(void);
 
 //! Global structure which contains standard UDI interface for UDC
+COMPILER_WORD_ALIGNED
 UDC_DESC_STORAGE udi_api_t udi_api_hid_mouse = {
 	.enable = (bool(*)(void))udi_hid_mouse_enable,
 	.disable = (void (*)(void))udi_hid_mouse_disable,

--- a/atmel-samd/asf/common/services/usb/udc/udc_dfu_small.c
+++ b/atmel-samd/asf/common/services/usb/udc/udc_dfu_small.c
@@ -134,6 +134,7 @@ struct udc_string_desc_t {
 	le16_t string[Max(Max(USB_DEVICE_MANUFACTURE_NAME_SIZE, \
 		USB_DEVICE_PRODUCT_NAME_SIZE), USB_DEVICE_SERIAL_NAME_SIZE)];
 };
+COMPILER_WORD_ALIGNED
 static UDC_DESC_STORAGE struct udc_string_desc_t udc_string_desc = {
 	.header.bDescriptorType = USB_DT_STRING
 };
@@ -141,6 +142,7 @@ static UDC_DESC_STORAGE struct udc_string_desc_t udc_string_desc = {
 /**
  * \brief Language ID of USB device (US ID by default)
  */
+COMPILER_WORD_ALIGNED
 static UDC_DESC_STORAGE usb_str_lgid_desc_t udc_string_desc_languageid = {
 	.desc.bLength = sizeof(usb_str_lgid_desc_t),
 	.desc.bDescriptorType = USB_DT_STRING,


### PR DESCRIPTION
COMPILER_WORD_ALIGNED as done in #118 for mouse. Added COMPILER_WORD_ALIGNED
to other UDC_DESC_STORAGE declarations that might have the same issue in the future.