### PR TITLE
Fix problems that prevented use of internal frozen modules:

### DIFF
--- a/atmel-samd/Makefile
+++ b/atmel-samd/Makefile
@@ -140,6 +140,7 @@ ifneq ($(FROZEN_DIR),)
 # To use frozen source modules, put your .py files in a subdirectory (eg scripts/)
 # and then invoke make with FROZEN_DIR=scripts (be sure to build from scratch).
 CFLAGS += -DMICROPY_MODULE_FROZEN_STR
+CFLAGS += -Wno-error=lto-type-mismatch
 endif
 
 ifneq ($(FROZEN_MPY_DIR),)
@@ -147,6 +148,7 @@ ifneq ($(FROZEN_MPY_DIR),)
 # then invoke make with FROZEN_MPY_DIR=frozen (be sure to build from scratch).
 CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
 CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
+CFLAGS += -Wno-error=lto-type-mismatch
 endif
 
 #LIBM_FILE_NAME   = $(shell $(CC) $(CFLAGS) -print-file-name=libm.a)

--- a/atmel-samd/mpconfigport.h
+++ b/atmel-samd/mpconfigport.h
@@ -62,6 +62,7 @@
 #define MICROPY_PY_STRUCT           (1)
 #define MICROPY_PY_SYS              (1)
 #define MICROPY_CPYTHON_COMPAT      (0)
+// If you change MICROPY_LONGINT_IMPL, also change MPY_TOOL_LONGINT_IMPL in mpconfigport.mk.
 #define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_NONE)
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_FLOAT)
 #define MICROPY_STREAMS_NON_BLOCK   (1)

--- a/atmel-samd/mpconfigport.mk
+++ b/atmel-samd/mpconfigport.mk
@@ -1,0 +1,4 @@
+# Define an equivalent for MICROPY_LONGINT_IMPL, to pass to $(MPY-TOOL) in py/mkrules.mk
+# $(MPY-TOOL) needs to know what kind of longint to use (if any) to freeze long integers.
+# This should correspond to the MICROPY_LONGINT_IMPL definition in mpconfigport.h.
+MPY_TOOL_LONGINT_IMPL = -mlongint-impl=none

--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -76,6 +76,16 @@ STATIC void mp_help_add_from_names(mp_obj_t list, const char *name) {
 }
 #endif
 
+// These externs were originally declared inside mp_help_print_modules(),
+// but they triggered -Wnested-externs, so they were moved outside.
+#if MICROPY_MODULE_FROZEN_STR
+extern const char mp_frozen_str_names[];
+#endif
+
+#if MICROPY_MODULE_FROZEN_MPY
+extern const char mp_frozen_mpy_names[];
+#endif
+
 STATIC void mp_help_print_modules(void) {
     mp_obj_t list = mp_obj_new_list(0, NULL);
 
@@ -86,12 +96,10 @@ STATIC void mp_help_print_modules(void) {
     #endif
 
     #if MICROPY_MODULE_FROZEN_STR
-    extern const char mp_frozen_str_names[];
     mp_help_add_from_names(list, mp_frozen_str_names);
     #endif
 
     #if MICROPY_MODULE_FROZEN_MPY
-    extern const char mp_frozen_mpy_names[];
     mp_help_add_from_names(list, mp_frozen_mpy_names);
     #endif
 

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -118,9 +118,11 @@ $(BUILD)/frozen_mpy/%.mpy: $(FROZEN_MPY_DIR)/%.py $(TOP)/mpy-cross/mpy-cross
 	$(Q)$(MPY_CROSS) -o $@ -s $(<:$(FROZEN_MPY_DIR)/%=%) $(MPY_CROSS_FLAGS) $<
 
 # to build frozen_mpy.c from all .mpy files
+# You need to define MPY_TOOL_LONGINT_IMPL in mpconfigport.mk
+# if the default will not work (mpz is the default).
 $(BUILD)/frozen_mpy.c: $(FROZEN_MPY_MPY_FILES) $(BUILD)/genhdr/qstrdefs.generated.h
 	$(STEPECHO) "Creating $@"
-	$(Q)$(PYTHON) $(MPY_TOOL) -f -q $(BUILD)/genhdr/qstrdefs.preprocessed.h $(FROZEN_MPY_MPY_FILES) > $@
+	$(Q)$(PYTHON) $(MPY_TOOL) $(MPY_TOOL_LONGINT_IMPL) -f -q $(BUILD)/genhdr/qstrdefs.preprocessed.h $(FROZEN_MPY_MPY_FILES) > $@
 endif
 
 ifneq ($(PROG),)


### PR DESCRIPTION
1. Allow -Wlto-type-mismatch to be just a warning when building with frozen modules.
2. Fix extern decls that triggered -Wnested-externs when building with frozen modules.
3. Pass the correct value of -mlongint-impl to $(MPY_TOOL). New file mpconfigport.mk to do this.