### PR TITLE
esp8266: fix "uos" includes in the boot process

### DIFF
--- a/esp8266/modules/_boot.py
+++ b/esp8266/modules/_boot.py
@@ -1,11 +1,12 @@
 import gc
 gc.threshold((gc.mem_free() + gc.mem_alloc()) // 4)
-import uos
 from flashbdev import bdev
+import storage
 
 try:
     if bdev:
-        uos.mount(bdev, '/')
+        vfs = storage.VfsFat(bdev)
+        storage.mount(vfs, '/')
 except OSError:
     import inisetup
     inisetup.setup()

--- a/esp8266/modules/inisetup.py
+++ b/esp8266/modules/inisetup.py
@@ -1,6 +1,6 @@
-import uos
-import network
 from flashbdev import bdev
+import network
+import storage
 
 def wifi():
     import ubinascii
@@ -36,9 +36,9 @@ def setup():
     check_bootsec()
     print("Performing initial setup")
     wifi()
-    uos.VfsFat.mkfs(bdev)
-    vfs = uos.VfsFat(bdev)
-    uos.mount(vfs, '/')
+    storage.VfsFat.mkfs(bdev)
+    vfs = storage.VfsFat(bdev)
+    storage.mount(vfs, '/')
     with open("boot.py", "w") as f:
         f.write("""\
 # This file is executed on every boot (including wake-boot from deepsleep)

--- a/esp8266/modules/webrepl_setup.py
+++ b/esp8266/modules/webrepl_setup.py
@@ -1,5 +1,4 @@
 import sys
-#import uos as os
 import os
 import machine
 


### PR DESCRIPTION
This fixes an exception coming from _boot.py during startup and enables the default startup behavior to happen.

The only remaining `uos` include is in `webrepl` module, but it needs `uos.dupterm_notify` which wasn't ported to the new shared `os` module.