### PR TITLE
Allow max stack checking to be used with -flto build by determining top

### DIFF
--- a/atmel-samd/Makefile
+++ b/atmel-samd/Makefile
@@ -132,6 +132,7 @@ CFLAGS = $(INC) -Wall -Werror -std=gnu11 -nostdlib $(CFLAGS_CORTEX_M0) $(CFLAGS_
 ifeq ($(DEBUG), 1)
 # NDEBUG disables assert() statements. This reduces code size pretty dramatically, per tannewt.
 # Turn on Python modules useful for debugging (e.g. uheap, ustack).
+# -DMICROPY_DEBUG_MODULES may also be added to an -flto build, if you wish.
 CFLAGS += -Os -ggdb -DNDEBUG -DENABLE_MICRO_TRACE_BUFFER -DMICROPY_DEBUG_MODULES
 else
 CFLAGS += -Os -DNDEBUG -flto


### PR DESCRIPTION
of stack in a different way.

The old way used the address of a variable on the stack, starting just below that variable. But that didn't work with -flto for some reason: I had to subtract something like 40 to not smash the stack. The new method gets a safe value of the stack pointer in a more reliable way.