### PR TITLE
Increase heap size at the expense of stack size, from 16k to 16k+4k.

### DIFF
--- a/atmel-samd/main.c
+++ b/atmel-samd/main.c
@@ -117,7 +117,7 @@ void init_flash_fs(void) {
     MP_STATE_PORT(vfs_cur) = vfs;
 }
 
-static char heap[16384];
+static char heap[16384 + 4096];
 
 void reset_mp(void) {
     reset_status_led();


### PR DESCRIPTION
Did some experimentation about how much stack we could give up, to increase the heap size. I used my project https://github.com/dhalbert/SwitchBox as a "typical" piece of code. It could not be loaded from .py or run without running out of heap. Adding 4k to the heap worked, and still left about 1k of unused stack when running.

I wish I had more examples, since it's possible other "typical" code needs more stack. But we can tune this. Let's see how it does with the test suite.