### PR TITLE
shared-bindings: Expect a single arg to DigitalInOut.

### DIFF
--- a/shared-bindings/digitalio/DigitalInOut.c
+++ b/shared-bindings/digitalio/DigitalInOut.c
@@ -61,7 +61,7 @@
 //|
 STATIC mp_obj_t digitalio_digitalinout_make_new(const mp_obj_type_t *type,
         mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+    mp_arg_check_num(n_args, n_kw, 1, 1, true);
 
     digitalio_digitalinout_obj_t *self = m_new_obj(digitalio_digitalinout_obj_t);
     self->base.type = &digitalio_digitalinout_type;


### PR DESCRIPTION
Check that extra args aren't provided to digitalio.DigitalInOut on construction.