### PR TITLE
Have the build script upload artifacts to Rosie

### DIFF
--- a/.rosie.yml
+++ b/.rosie.yml
@@ -2,8 +2,11 @@
 # builds them) and where to find the tests.
 
 binaries:
-    prebuilt_s3: adafruit-circuit-python
-    file_pattern: bin/{board}/adafruit-circuitpython-{board}-*-{short_sha}.{extension}
+    prebuilt_s3:
+        bucket: adafruit-circuit-python
+        file_pattern: bin/{board}/adafruit-circuitpython-{board}-*-{short_sha}.{extension}
+    rosie_upload:
+        file_pattern: adafruit-circuitpython-{board}-{short_sha}.{extension}
 
 circuitpython_tests:
     test_directories:


### PR DESCRIPTION
This skirts the issue of third-party pulls having access to the Adafruit S3 credentials.