### PR TITLE
Added ability to freeze multiple directories; freeze neopixel library in cpx build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,5 +18,5 @@
 	path = tools/uf2
 	url = https://github.com/Microsoft/uf2.git
 [submodule "atmel-samd/frozen/Adafruit_CircuitPython_NeoPixel"]
-	path = atmel-samd/frozen/Adafruit_CircuitPython_NeoPixel
+	path = frozen/Adafruit_CircuitPython_NeoPixel
 	url = https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "tools/uf2"]
 	path = tools/uf2
 	url = https://github.com/Microsoft/uf2.git
+[submodule "atmel-samd/frozen/Adafruit_CircuitPython_NeoPixel"]
+	path = atmel-samd/frozen/Adafruit_CircuitPython_NeoPixel
+	url = https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel

--- a/atmel-samd/Makefile
+++ b/atmel-samd/Makefile
@@ -145,9 +145,11 @@ CFLAGS += -DMICROPY_MODULE_FROZEN_STR
 CFLAGS += -Wno-error=lto-type-mismatch
 endif
 
-ifneq ($(FROZEN_MPY_DIR),)
 # To use frozen bytecode, put your .py files in a subdirectory (eg frozen/) and
-# then invoke make with FROZEN_MPY_DIR=frozen (be sure to build from scratch).
+# then invoke make with FROZEN_MPY_DIR=frozen or FROZEN_MPY_DIRS="dir1 dir2"
+# (be sure to build from scratch).
+
+ifneq ($(FROZEN_MPY_DIRS),)
 CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
 CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
 CFLAGS += -Wno-error=lto-type-mismatch

--- a/atmel-samd/boards/circuitplayground_express/mpconfigboard.mk
+++ b/atmel-samd/boards/circuitplayground_express/mpconfigboard.mk
@@ -7,4 +7,4 @@ FLASH_IMPL = spi_flash.c
 CHIP_VARIANT = SAMD21G18A
 
 # Include these Python libraries in firmware.
-FROZEN_MPY_DIRS += frozen/Adafruit_CircuitPython_NeoPixel
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel

--- a/atmel-samd/boards/circuitplayground_express/mpconfigboard.mk
+++ b/atmel-samd/boards/circuitplayground_express/mpconfigboard.mk
@@ -5,3 +5,6 @@ USB_PID = 0x8019
 FLASH_IMPL = spi_flash.c
 
 CHIP_VARIANT = SAMD21G18A
+
+# Include these Python libraries in firmware.
+FROZEN_MPY_DIRS += frozen/Adafruit_CircuitPython_NeoPixel

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -42,12 +42,16 @@ endif
 PY_SRC ?= $(TOP)/py
 BUILD ?= build
 
-RM = rm
 ECHO = @echo
+
+CD = cd
 CP = cp
+FIND = find
 MKDIR = mkdir
-SED = sed
 PYTHON = python
+RM = rm
+RSYNC = rsync
+SED = sed
 
 AS = $(CROSS_COMPILE)as
 CC = $(CROSS_COMPILE)gcc

--- a/py/py.mk
+++ b/py/py.mk
@@ -247,12 +247,15 @@ PY_O = $(addprefix $(PY_BUILD)/, $(PY_O_BASENAME))
 
 # object file for frozen files
 ifneq ($(FROZEN_DIR),)
-PY_O += $(BUILD)/$(BUILD)/frozen.o
+PY_O += $(BUILD)/frozen.o
 endif
 
+# Combine old singular FROZEN_MPY_DIR with new multiple value form.
+FROZEN_MPY_DIRS += $(FROZEN_MPY_DIR)
+
 # object file for frozen bytecode (frozen .mpy files)
-ifneq ($(FROZEN_MPY_DIR),)
-PY_O += $(BUILD)/$(BUILD)/frozen_mpy.o
+ifneq ($(FROZEN_MPY_DIRS),)
+PY_O += $(BUILD)/frozen_mpy.o
 endif
 
 # Sources that may contain qstrings


### PR DESCRIPTION
Freeze neopixel library in CPX build. 

In order to generalize this:

Added ability to freeze multiple directories. Modules to freeze are included as git submodules. Submodules do not need to be duplicated if they are used for multiple builds.

In addition to `FROZEN_MPY_DIR`, there is now a `FROZEN_MPY_DIRS` variable, which includes `FROZEN_MPY_DIR` for backwards compatibility. Modules to freeze for a particular board can be specified in `mpconfigboard.mk` for that board by defining `FROZEN_MPY_DIRS`

In the process, reworked `py/mkrules.mk` rules to build frozen modules in a more straightforward way.

Cleanup: fix odd `$(BUILD)/$(BUILD) ` subdirectory structure that showed up for frozen modules.

