### PR TITLE
Fix issue #207, esp8266 file operations problems

### DIFF
--- a/atmel-samd/main.c
+++ b/atmel-samd/main.c
@@ -29,6 +29,7 @@
 
 #include "py/nlr.h"
 #include "py/compile.h"
+#include "py/frozenmod.h"
 #include "py/mphal.h"
 #include "py/runtime.h"
 #include "py/repl.h"
@@ -165,8 +166,8 @@ void reset_mp(void) {
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_)); // current dir (or base dir of the script)
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_));
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_lib));
-    // Frozen modules are in their own pseudo-dir, ".frozen".
-    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__dot_frozen));
+    // Frozen modules are in their own pseudo-dir, e.g., ".frozen".
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_FROZEN_FAKE_DIR_QSTR));
 
     mp_obj_list_init(mp_sys_argv, 0);
 }

--- a/esp8266/main.c
+++ b/esp8266/main.c
@@ -29,6 +29,7 @@
 
 #include "py/nlr.h"
 #include "py/compile.h"
+#include "py/frozenmod.h"
 #include "py/runtime0.h"
 #include "py/runtime.h"
 #include "py/stackctrl.h"
@@ -98,8 +99,8 @@ STATIC void mp_reset(void) {
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_)); // current dir (or base dir of the script)
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_lib));
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_));
-    // Frozen modules are in their own pseudo-dir, ".frozen".
-    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__dot_frozen));
+    // Frozen modules are in their own pseudo-dir, e.g., ".frozen".
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_FROZEN_FAKE_DIR_QSTR));
 
     mp_obj_list_init(mp_sys_argv, 0);
     MP_STATE_PORT(term_obj) = MP_OBJ_NULL;

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -57,8 +57,10 @@ bool mp_obj_is_package(mp_obj_t module) {
 // (whatever is available, if at all).
 STATIC mp_import_stat_t mp_import_stat_any(const char *path) {
     #if MICROPY_MODULE_FROZEN
-    if (strlen(path) > 8 && strncmp(".frozen/", path, 8) == 0) {
-        mp_import_stat_t st = mp_frozen_stat(path + 8);
+    if (strncmp(MP_FROZEN_FAKE_DIR_SLASH,
+                path,
+                MP_FROZEN_FAKE_DIR_SLASH_LENGTH) == 0) {
+        mp_import_stat_t st = mp_frozen_stat(path + MP_FROZEN_FAKE_DIR_SLASH_LENGTH);
         if (st != MP_IMPORT_STAT_NO_EXIST) {
             return st;
         }

--- a/py/frozenmod.c
+++ b/py/frozenmod.c
@@ -135,16 +135,21 @@ mp_import_stat_t mp_frozen_stat(const char *str) {
 }
 
 int mp_find_frozen_module(const char *str, size_t len, void **data) {
-    // The +8/-8 account for the .frozen/ path prefix used on frozen modules.
+    // If the frozen module pseudo dir (e.g., ".frozen/") is a prefix of str, remove it.
+    if (strncmp(str, MP_FROZEN_FAKE_DIR_SLASH, MP_FROZEN_FAKE_DIR_SLASH_LENGTH) == 0) {
+        str = str + MP_FROZEN_FAKE_DIR_SLASH_LENGTH;
+        len = len - MP_FROZEN_FAKE_DIR_SLASH_LENGTH;
+    }
+
     #if MICROPY_MODULE_FROZEN_STR
-    mp_lexer_t *lex = mp_lexer_frozen_str(str + 8, len - 8);
+    mp_lexer_t *lex = mp_lexer_frozen_str(str, len);
     if (lex != NULL) {
         *data = lex;
         return MP_FROZEN_STR;
     }
     #endif
     #if MICROPY_MODULE_FROZEN_MPY
-    const mp_raw_code_t *rc = mp_find_frozen_mpy(str + 8, len - 8);
+    const mp_raw_code_t *rc = mp_find_frozen_mpy(str, len);
     if (rc != NULL) {
         *data = (void*)rc;
         return MP_FROZEN_MPY;

--- a/py/frozenmod.h
+++ b/py/frozenmod.h
@@ -34,6 +34,16 @@ enum {
     MP_FROZEN_MPY,
 };
 
+// Frozen modules are in a pseudo-directory, so sys.path can control how they're found.
+#define MP_FROZEN_FAKE_DIR ".frozen"
+#define MP_FROZEN_FAKE_DIR_LENGTH (sizeof(MP_FROZEN_FAKE_DIR)-1)
+
+#define MP_FROZEN_FAKE_DIR_SLASH (MP_FROZEN_FAKE_DIR "/")
+#define MP_FROZEN_FAKE_DIR_SLASH_LENGTH (sizeof(MP_FROZEN_FAKE_DIR_SLASH)-1)
+
+// This should match MP_FROZEN_FAKE_DIR.
+#define MP_FROZEN_FAKE_DIR_QSTR MP_QSTR__dot_frozen
+
 int mp_find_frozen_module(const char *str, size_t len, void **data);
 const char *mp_find_frozen_str(const char *str, size_t str_len, size_t *len);
 mp_import_stat_t mp_frozen_stat(const char *str);

--- a/unix/main.c
+++ b/unix/main.c
@@ -40,6 +40,7 @@
 #include "py/mpstate.h"
 #include "py/nlr.h"
 #include "py/compile.h"
+#include "py/frozenmod.h"
 #include "py/runtime.h"
 #include "py/builtin.h"
 #include "py/repl.h"
@@ -469,7 +470,8 @@ MP_NOINLINE int main_(int argc, char **argv) {
     mp_obj_t *path_items;
     mp_obj_list_get(mp_sys_path, &path_num, &path_items);
     path_items[0] = MP_OBJ_NEW_QSTR(MP_QSTR_);
-    path_items[1] = MP_OBJ_NEW_QSTR(MP_QSTR__dot_frozen);
+    // Frozen modules are in their own pseudo-dir, e.g., ".frozen".
+    path_items[1] = MP_OBJ_NEW_QSTR(MP_FROZEN_FAKE_DIR_QSTR);
     {
     char *p = path;
     for (mp_uint_t i = builtin_path_count; i < path_num; i++) {


### PR DESCRIPTION
The frozen module `_boot.py` was not being loaded on restart
because `pyexec_frozen_module()` did not know about the new `.frozen`
pseudo-directory. Updated lower-level routine to look in the right place.
Also made ".frozen" and related values be `#define`s.