### PR TITLE
atmel-samd: Remember SPI baudrate.

### DIFF
--- a/atmel-samd/common-hal/busio/SPI.c
+++ b/atmel-samd/common-hal/busio/SPI.c
@@ -174,6 +174,7 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
         if (status != STATUS_OK) {
             return false;
         }
+        self->current_baudrate = baudrate;
     }
 
     SercomSpi *const spi_module = &(self->spi_master_instance.hw->SPI);


### PR DESCRIPTION
This prevents the SERCOM from blipping the data line on each
transaction and therefore fixes #219.