### PR TITLE
esp8266: restore machine module

### DIFF
--- a/esp8266/mpconfigport.h
+++ b/esp8266/mpconfigport.h
@@ -178,6 +178,7 @@ extern const struct _mp_obj_module_t multiterminal_module;
     { MP_OBJ_NEW_QSTR(MP_QSTR_usocket), (mp_obj_t)&mp_module_lwip }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_network), (mp_obj_t)&network_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_os), (mp_obj_t)&os_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_machine), (mp_obj_t)&mp_module_machine }, \
     { MP_ROM_QSTR(MP_QSTR__onewire), MP_ROM_PTR(&mp_module_onewire) }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_microcontroller), (mp_obj_t)&microcontroller_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_board), (mp_obj_t)&board_module }, \


### PR DESCRIPTION
The machine module got dropped from `esp8266/mpconfigport.h` during the v1.9.2 merge. Not sure how that happened but it appears to have been during an automatic merge, or else I did something wrong when resolving a merge conflict. Fixes #224.