### PR TITLE
Add user facing structure via toc captions

### DIFF
--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -1,5 +1,7 @@
-Additional Libraries on GitHub
-========================================
+.. _adafruit-libndrivers:
+
+Additional Adafruit Libraries and Drivers on GitHub
+===================================================
 
 These are libraries and drivers available in separate GitHub repos. They are
 designed for use with CircuitPython and may or may not work with
@@ -20,7 +22,8 @@ The bundles are available `on GitHub <https://github.com/adafruit/Adafruit_Circu
 
 To install them:
 
-#. `Download <https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases>`_ and unzip the latest zip thats not a source zip.
+#. `Download <https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases>`_
+   and unzip the latest zip that's not a source zip.
 #. Copy the ``lib`` folder to the ``CIRCUITPY`` or ``MICROPYTHON``.
 
 Foundational Libraries
@@ -32,16 +35,17 @@ the ``lib/`` directory. Some drivers may not work without them.
 
 .. toctree::
 
-    Register Library <https://circuitpython.readthedocs.io/projects/register/en/latest/>
-    BusDevice Library <https://circuitpython.readthedocs.io/projects/bus_device/en/latest/>
+   Register Library <https://circuitpython.readthedocs.io/projects/register/en/latest/>
+   BusDevice Library <https://circuitpython.readthedocs.io/projects/bus_device/en/latest/>
 
 Helper Libraries
--------
+----------------
 
 These libraries build on top of the low level APIs to simplify common tasks.
 
 .. toctree::
-    USB Human Interface Device (Keyboard and Mouse) <https://circuitpython.readthedocs.io/projects/hid/en/latest/>
+
+   USB Human Interface Device (Keyboard and Mouse) <https://circuitpython.readthedocs.io/projects/hid/en/latest/>
 
 Drivers
 -------
@@ -50,17 +54,18 @@ Drivers provide easy access to sensors and other chips without requiring a
 knowledge of the interface details of the chip itself.
 
 .. toctree::
-    NeoPixel <https://circuitpython.readthedocs.io/projects/neopixel/en/latest/>
-    SimpleIO <https://circuitpython.readthedocs.io/projects/simpleio/en/latest/>
-    RGB Displays <http://micropython-rgb.readthedocs.io/>
-    SD Card <https://circuitpython.readthedocs.io/projects/sdcard/en/latest/>
-    Analog-to-digital converters: ADS1015 and ADS1115 <http://micropython-ads1015.readthedocs.io/>
-    DS3231 Real-time Clock (Precision RTC) <https://circuitpython.readthedocs.io/projects/ds3231/en/latest/>
-    DS1307 Real-time Clock (5V RTC Breakout) <https://circuitpython.readthedocs.io/projects/ds1307/en/latest/>
-    PCF8523 Real-time Clock (Adalogger RTC) <https://circuitpython.readthedocs.io/projects/pcf8523/en/latest/>
-    TCS34725 Color Sensor <http://micropython-tcs34725.readthedocs.io/>
-    TSL2561 Light Sensor <http://micropython-tsl2561.readthedocs.io/>
-    PCA9685 Motor and Servo Controllers <http://micropython-pca9685.readthedocs.io/>
-    HT16K33 LED Matrices and Segment Displays <http://micropython-ht16k33.readthedocs.io/>
-    IS31FL3731 Charlieplexed LED Matrix <http://micropython-is31fl3731.readthedocs.io/>
-    MAX7219 LED Matrix <http://micropython-max7219.readthedocs.io/>
+
+   NeoPixel <https://circuitpython.readthedocs.io/projects/neopixel/en/latest/>
+   SimpleIO <https://circuitpython.readthedocs.io/projects/simpleio/en/latest/>
+   RGB Displays <http://micropython-rgb.readthedocs.io/>
+   SD Card <https://circuitpython.readthedocs.io/projects/sdcard/en/latest/>
+   Analog-to-digital converters: ADS1015 and ADS1115 <http://micropython-ads1015.readthedocs.io/>
+   DS3231 Real-time Clock (Precision RTC) <https://circuitpython.readthedocs.io/projects/ds3231/en/latest/>
+   DS1307 Real-time Clock (5V RTC Breakout) <https://circuitpython.readthedocs.io/projects/ds1307/en/latest/>
+   PCF8523 Real-time Clock (Adalogger RTC) <https://circuitpython.readthedocs.io/projects/pcf8523/en/latest/>
+   TCS34725 Color Sensor <http://micropython-tcs34725.readthedocs.io/>
+   TSL2561 Light Sensor <http://micropython-tsl2561.readthedocs.io/>
+   PCA9685 Motor and Servo Controllers <http://micropython-pca9685.readthedocs.io/>
+   HT16K33 LED Matrices and Segment Displays <http://micropython-ht16k33.readthedocs.io/>
+   IS31FL3731 Charlieplexed LED Matrix <http://micropython-is31fl3731.readthedocs.io/>
+   MAX7219 LED Matrix <http://micropython-max7219.readthedocs.io/>

--- a/index.rst
+++ b/index.rst
@@ -1,5 +1,5 @@
 Adafruit CircuitPython API Reference
-========================================
+====================================
 
 .. image:: https://travis-ci.org/adafruit/circuitpython.svg?branch=master
     :target: https://travis-ci.org/adafruit/circuitpython
@@ -17,37 +17,64 @@ Adafruit CircuitPython API Reference
     :target: https://adafru.it/discord
     :alt: Discord
 
-Welcome! This is the documentation for Adafruit CircuitPython. It is an open
-source derivative of `MicroPython <https://micropython.org>`_ for use on
-educational development boards designed and sold by `Adafruit
-<https://adafruit.com>`_. Adafruit CircuitPython features unified Python core
-APIs and a growing list of drivers that work with it.
+Welcome to the API reference documentation for Adafruit CircuitPython.
+This contains low-level API docs, and these docs may link out to separate
+*"getting started"* guides. `Adafruit <https://adafruit.com>`_ has many 
+excellent tutorials available through the
+`Adafruit Learning System <https://learn.adafruit.com/>`_.
+
+What is CircuitPython?
+----------------------
+
+**CircuitPython** is an open source derivative of 
+`MicroPython <https://micropython.org>`_ for use on educational development
+boards designed and sold by `Adafruit <https://adafruit.com>`_. Adafruit
+CircuitPython features unified Python core APIs and a growing list of drivers
+of that work with CircuitPython.
+
+What boards use CircuitPython?
+------------------------------
 
 The Adafruit Express line of boards are specifically
-designed for use with CircuitPython. They are the
-`CircuitPlayground Express <https://www.adafruit.com/product/3333>`_,
-`Feather M0 Express <https://www.adafruit.com/product/3403>`_,
-and `Metro M0 Express <https://www.adafruit.com/product/3505>`_.
-Other supported boards include the `Arduino Zero
-<https://www.arduino.cc/en/Main/ArduinoBoardZero>`_, `Adafruit Feather M0 Basic
-<https://www.adafruit.com/product/2772>`_, `Adafruit Feather HUZZAH
-<https://www.adafruit.com/products/2821>`_ and `Adafruit Feather M0 Bluefruit LE
-<https://www.adafruit.com/products/2995>`_.
+designed for use with CircuitPython. This line includes:
 
-`Adafruit <https://adafruit.com>`_ has many excellent tutorials available
-through the `Adafruit Learning System <https://learn.adafruit.com/>`_. These
-docs are low-level API docs and may link out to separate getting started guides.
+* `CircuitPlayground Express <https://www.adafruit.com/product/3333>`_
+* `Feather M0 Express <https://www.adafruit.com/product/3403>`_
+* `Metro M0 Express <https://www.adafruit.com/product/3505>`_
+
+Other supported boards include:
+
+* `Arduino Zero <https://www.arduino.cc/en/Main/ArduinoBoardZero>`_
+* `Adafruit Feather M0 Basic <https://www.adafruit.com/product/2772>`_
+*  `Adafruit Feather HUZZAH <https://www.adafruit.com/products/2821>`_
+* `Adafruit Feather M0 Bluefruit LE <https://www.adafruit.com/products/2995>`_
+
+.. _contents:
+
+Full Table of Contents
+----------------------
 
 .. toctree::
     :maxdepth: 3
+    :caption: API and Usage
 
     shared-bindings/index.rst
     docs/supported_ports.rst
     docs/troubleshooting.rst
     docs/drivers.rst
+
+.. toctree::
+    :maxdepth: 3
+    :caption: Developer reference
+
     docs/design_guide
     docs/common_hal
     docs/library/index.rst
+
+.. toctree::
+    :maxdepth: 3
+    :caption: About the project
+
     README
     CONTRIBUTING
     CODE_OF_CONDUCT

--- a/index.rst
+++ b/index.rst
@@ -18,7 +18,7 @@ Adafruit CircuitPython API Reference
     :alt: Discord
 
 Welcome to the API reference documentation for Adafruit CircuitPython.
-This contains low-level API docs, and these docs may link out to separate
+This contains low-level API reference docs which may link out to separate
 *"getting started"* guides. `Adafruit <https://adafruit.com>`_ has many 
 excellent tutorials available through the
 `Adafruit Learning System <https://learn.adafruit.com/>`_.
@@ -26,11 +26,11 @@ excellent tutorials available through the
 What is CircuitPython?
 ----------------------
 
-**CircuitPython** is an open source derivative of 
-`MicroPython <https://micropython.org>`_ for use on educational development
-boards designed and sold by `Adafruit <https://adafruit.com>`_. Adafruit
-CircuitPython features unified Python core APIs and a growing list of drivers
-of that work with CircuitPython.
+**CircuitPython** is an *education friendly* open source derivative of 
+`MicroPython <https://micropython.org>`_. CircuitPython supports use on
+educational development boards designed and sold by
+`Adafruit <https://adafruit.com>`_. Adafruit CircuitPython features unified
+Python core APIs and a growing list of drivers of that work with it.
 
 What boards use CircuitPython?
 ------------------------------
@@ -46,7 +46,7 @@ Other supported boards include:
 
 * `Arduino Zero <https://www.arduino.cc/en/Main/ArduinoBoardZero>`_
 * `Adafruit Feather M0 Basic <https://www.adafruit.com/product/2772>`_
-*  `Adafruit Feather HUZZAH <https://www.adafruit.com/products/2821>`_
+* `Adafruit Feather HUZZAH <https://www.adafruit.com/products/2821>`_
 * `Adafruit Feather M0 Bluefruit LE <https://www.adafruit.com/products/2995>`_
 
 .. _contents:
@@ -55,30 +55,35 @@ Full Table of Contents
 ----------------------
 
 .. toctree::
-    :maxdepth: 3
-    :caption: API and Usage
+   :maxdepth: 3
+   :caption: API and Usage
 
-    shared-bindings/index.rst
-    docs/supported_ports.rst
-    docs/troubleshooting.rst
-    docs/drivers.rst
-
-.. toctree::
-    :maxdepth: 3
-    :caption: Developer reference
-
-    docs/design_guide
-    docs/common_hal
-    docs/library/index.rst
+   shared-bindings/index.rst
+   docs/supported_ports.rst
+   docs/troubleshooting.rst
+   docs/drivers.rst
 
 .. toctree::
-    :maxdepth: 3
-    :caption: About the project
+   :maxdepth: 3
+   :caption: Developer reference
 
-    README
-    CONTRIBUTING
-    CODE_OF_CONDUCT
-    license.rst
+   docs/design_guide
+   docs/common_hal
+
+.. toctree::
+   :maxdepth: 3
+   :caption: MicroPython specific docs
+
+   docs/library/index.rst
+
+.. toctree::
+   :maxdepth: 3
+   :caption: About the project
+
+   README
+   CONTRIBUTING
+   CODE_OF_CONDUCT
+   license.rst
 
 Indices and tables
 ==================

--- a/index.rst
+++ b/index.rst
@@ -37,17 +37,15 @@ What boards use CircuitPython?
 
 The Adafruit Express line of boards are specifically
 designed for use with CircuitPython. This line includes:
-
-* `CircuitPlayground Express <https://www.adafruit.com/product/3333>`_
-* `Feather M0 Express <https://www.adafruit.com/product/3403>`_
+* `CircuitPlayground Express <https://www.adafruit.com/product/3333>`_,
+* `Feather M0 Express <https://www.adafruit.com/product/3403>`_, and
 * `Metro M0 Express <https://www.adafruit.com/product/3505>`_
 
 Other supported boards include:
-
-* `Arduino Zero <https://www.arduino.cc/en/Main/ArduinoBoardZero>`_
-* `Adafruit Feather M0 Basic <https://www.adafruit.com/product/2772>`_
-* `Adafruit Feather HUZZAH <https://www.adafruit.com/products/2821>`_
-* `Adafruit Feather M0 Bluefruit LE <https://www.adafruit.com/products/2995>`_
+* `Arduino Zero <https://www.arduino.cc/en/Main/ArduinoBoardZero>`_,
+* `Adafruit Feather M0 Basic <https://www.adafruit.com/product/2772>`_,
+* `Adafruit Feather HUZZAH <https://www.adafruit.com/products/2821>`_, and
+* `Adafruit Feather M0 Bluefruit LE <https://www.adafruit.com/products/2995>`_.
 
 .. _contents:
 

--- a/index.rst
+++ b/index.rst
@@ -13,7 +13,7 @@ Adafruit CircuitPython API Reference
     :target: https://gitter.im/adafruit/circuitpython?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
     :alt: Gitter
 
-.. image :: https://img.shields.io/discord/327254708534116352.svg
+.. image:: https://img.shields.io/discord/327254708534116352.svg
     :target: https://adafru.it/discord
     :alt: Discord
 
@@ -63,20 +63,20 @@ Full Table of Contents
    docs/drivers.rst
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 1
    :caption: Design and porting reference
 
    docs/design_guide
    docs/common_hal
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
    :caption: MicroPython specific
 
    docs/library/index.rst
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 1
    :caption: About the project
 
    README

--- a/index.rst
+++ b/index.rst
@@ -30,22 +30,23 @@ What is CircuitPython?
 `MicroPython <https://micropython.org>`_. CircuitPython supports use on
 educational development boards designed and sold by
 `Adafruit <https://adafruit.com>`_. Adafruit CircuitPython features unified
-Python core APIs and a growing list of drivers of that work with it.
+Python core APIs and a growing list of Adafruit libraries and drivers of
+that work with it.
 
 What boards use CircuitPython?
 ------------------------------
 
-The Adafruit Express line of boards are specifically
+The Adafruit Express line of boards is specifically
 designed for use with CircuitPython. This line includes:
-* `CircuitPlayground Express <https://www.adafruit.com/product/3333>`_,
-* `Feather M0 Express <https://www.adafruit.com/product/3403>`_, and
-* `Metro M0 Express <https://www.adafruit.com/product/3505>`_
+`CircuitPlayground Express <https://www.adafruit.com/product/3333>`_;
+`Feather M0 Express <https://www.adafruit.com/product/3403>`_; and
+`Metro M0 Express <https://www.adafruit.com/product/3505>`_
 
 Other supported boards include:
-* `Arduino Zero <https://www.arduino.cc/en/Main/ArduinoBoardZero>`_,
-* `Adafruit Feather M0 Basic <https://www.adafruit.com/product/2772>`_,
-* `Adafruit Feather HUZZAH <https://www.adafruit.com/products/2821>`_, and
-* `Adafruit Feather M0 Bluefruit LE <https://www.adafruit.com/products/2995>`_.
+`Arduino Zero <https://www.arduino.cc/en/Main/ArduinoBoardZero>`_;
+`Adafruit Feather M0 Basic <https://www.adafruit.com/product/2772>`_;
+`Adafruit Feather HUZZAH <https://www.adafruit.com/products/2821>`_; and
+`Adafruit Feather M0 Bluefruit LE <https://www.adafruit.com/products/2995>`_.
 
 .. _contents:
 
@@ -63,14 +64,14 @@ Full Table of Contents
 
 .. toctree::
    :maxdepth: 3
-   :caption: Developer reference
+   :caption: Design and porting reference
 
    docs/design_guide
    docs/common_hal
 
 .. toctree::
    :maxdepth: 3
-   :caption: MicroPython specific docs
+   :caption: MicroPython specific
 
    docs/library/index.rst
 


### PR DESCRIPTION
This is the first of several PRs to update the docs and the doc build process. The current build process is non-standard which makes it difficult to maintain or be used by contributors. Partially addresses #215.

Ref: [Rendered docs on my RTD test account](http://test-circuitpython.readthedocs.io/en/caption-contents/)

<img width="261" alt="screenshot 2017-09-02 09 29 49" src="https://user-images.githubusercontent.com/2680980/29996271-5b68ad68-8fc1-11e7-88e1-e1e3a06bf5c2.png">
