### PR TITLE
Ctrl-C was causing a soft-reset in REPL.

### DIFF
--- a/atmel-samd/mphalport.c
+++ b/atmel-samd/mphalport.c
@@ -11,6 +11,7 @@
 #include "lib/utils/interrupt_char.h"
 #include "py/mphal.h"
 #include "py/mpstate.h"
+#include "py/runtime.h"
 #include "py/smallint.h"
 #include "shared-bindings/time/__init__.h"
 
@@ -157,6 +158,11 @@ int mp_hal_stdin_rx_chr(void) {
         #ifdef MICROPY_VM_HOOK_LOOP
             MICROPY_VM_HOOK_LOOP
         #endif
+        // Check to see if we've been CTRL-Ced by autoreload or the user. Raise the exception if so.
+        if(MP_STATE_VM(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception))) {
+            mp_handle_pending();
+        }
+
         #ifdef USB_REPL
         if (reload_next_character) {
             return CHAR_CTRL_D;

--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -121,9 +121,6 @@ STATIC int parse_compile_execute(const void *source, mp_parse_input_kind_t input
         } else {
             mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
             ret = PYEXEC_EXCEPTION;
-            if (mp_obj_is_subclass_fast(mp_obj_get_type((mp_obj_t)nlr.ret_val), &mp_type_KeyboardInterrupt)) {
-                ret = PYEXEC_FORCED_EXIT;
-            }
         }
     }
     if (result != NULL) {


### PR DESCRIPTION
Also allow an immediate ctrl-c in `input()`.

Removed special-case handling of KeyboardInterrupt in pyexec.c: that was causing a soft reset.