### PR TITLE
Re-initialize ADC before every AnalogIn read.

### DIFF
--- a/atmel-samd/common-hal/analogio/AnalogIn.h
+++ b/atmel-samd/common-hal/analogio/AnalogIn.h
@@ -42,6 +42,7 @@ typedef struct {
     mp_obj_base_t base;
     const mcu_pin_obj_t * pin;
     struct adc_module * adc_instance;
+    struct adc_config * config_adc;
 } analogio_analogin_obj_t;
 
 void analogin_reset(void);

--- a/atmel-samd/common-hal/microcontroller/Processor.c
+++ b/atmel-samd/common-hal/microcontroller/Processor.c
@@ -226,6 +226,8 @@ float common_hal_mcu_processor_get_temperature(void) {
         status = adc_read(&adc_instance_struct, &data);
     } while (status == STATUS_BUSY);
 
+    // Disable so that someone else can use the adc with different settings.
+    adc_disable(&adc_instance_struct);
     return calculate_temperature(data, &nvm_calibration_data);
 }
 


### PR DESCRIPTION
`microcontroller.cpu.temperature` uses different ADC settings, and caused
AnalogIn to give wrong answers. AnalogIn can no longer assume it's the
only user of the ADC.

This fixes #253, at the expense of re-initing the ADC on every read, and also doing double reads to ensure accuracy of the result.

A more sophisticated implementation would remember the last ADC settings and not re-init if they were the same. If we're not going to do that, the AnalogIn code could be simplified to not save the ADC structs on the heap, but simply re-create them each time.

@tannewt -- do you have an opinion? Maybe it's not worth cleaning up because it will all change with ASF4.