### PR TITLE
Add Analog Pin aliases to trinket_m0 pins.c

### DIFF
--- a/atmel-samd/boards/trinket_m0/pins.c
+++ b/atmel-samd/boards/trinket_m0/pins.c
@@ -2,20 +2,24 @@
 
 STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_PA08) },
+    { MP_ROM_QSTR(MP_QSTR_A2), MP_ROM_PTR(&pin_PA08) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_PA08) },
 
     { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_PA02) },
     { MP_ROM_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_PA02) },
 
     { MP_ROM_QSTR(MP_QSTR_D2), MP_ROM_PTR(&pin_PA09) },
+    { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_PA09) },
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_PA09) },
     { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_PA09) },
 
     { MP_ROM_QSTR(MP_QSTR_D4), MP_ROM_PTR(&pin_PA06) },
+    { MP_ROM_QSTR(MP_QSTR_A4), MP_ROM_PTR(&pin_PA06) },
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_PA06) },
     { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_PA06) },
 
     { MP_ROM_QSTR(MP_QSTR_D3), MP_ROM_PTR(&pin_PA07) },
+    { MP_ROM_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_PA07) },
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_PA07) },
     { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_PA07) },
 


### PR DESCRIPTION
modified trinket_m0/pins.c to include pin aliases for A1,A2,A3,A4