### PR TITLE
Make touch more sensitive. Add .raw_value and .threshold attributes.

### DIFF
--- a/atmel-samd/Makefile
+++ b/atmel-samd/Makefile
@@ -137,7 +137,7 @@ CFLAGS += -Os -ggdb -DNDEBUG -DENABLE_MICRO_TRACE_BUFFER -DMICROPY_DEBUG_MODULES
 else
 # -finline-limit can shrink the image size. -finline-limit=80 or so is similar to not having it on.
 # There is no simple default value, though.
-CFLAGS += -Os -DNDEBUG -flto -finline-limit=49
+CFLAGS += -Os -DNDEBUG -flto -finline-limit=39
 endif
 
 ifneq ($(FROZEN_DIR),)

--- a/atmel-samd/common-hal/touchio/TouchIn.c
+++ b/atmel-samd/common-hal/touchio/TouchIn.c
@@ -71,7 +71,14 @@ void common_hal_touchio_touchin_construct(touchio_touchin_obj_t* self,
 
     adafruit_ptc_init(PTC, &self->config);
 
-    self->threshold = 2 * get_raw_reading(self);
+    // Initial values for pins will vary, depending on what peripherals the pins
+    // share on-chip.
+    //
+    // Set a "touched" threshold not too far above the initial value.
+    // For simple finger touch, the values may vary as much as a factor of two,
+    // but for touches using fruit or other objects, the difference is much less.
+
+    self->threshold = get_raw_reading(self) + 100;
 }
 
 void common_hal_touchio_touchin_deinit(touchio_touchin_obj_t* self) {
@@ -86,4 +93,16 @@ void touchin_reset() {
 bool common_hal_touchio_touchin_get_value(touchio_touchin_obj_t *self) {
     uint16_t reading = get_raw_reading(self);
     return reading > self->threshold;
+}
+
+uint16_t common_hal_touchio_touchin_get_raw_value(touchio_touchin_obj_t *self) {
+    return get_raw_reading(self);
+}
+
+uint16_t common_hal_touchio_touchin_get_threshold(touchio_touchin_obj_t *self) {
+    return self->threshold;
+}
+
+void common_hal_touchio_touchin_set_threshold(touchio_touchin_obj_t *self, uint16_t new_threshold) {
+    self->threshold = new_threshold;
 }

--- a/shared-bindings/touchio/TouchIn.c
+++ b/shared-bindings/touchio/TouchIn.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include <stdint.h>
 #include <string.h>
 
 #include "lib/utils/context_manager_helpers.h"
@@ -106,6 +107,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(touchio_touchin___exit___obj, 4, 4, t
 //|   .. attribute:: value
 //|
 //|     Whether the touch pad is being touched or not.
+//|     True if `raw_value` > `threshold`.
 //|
 //|     :return: True when touched, False otherwise.
 //|     :rtype: bool
@@ -123,12 +125,76 @@ const mp_obj_property_t touchio_touchin_value_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
+
+//|   .. attribute:: raw_value
+//|
+//|     The raw touch measurement. Not settable.
+//|
+//|     :return: an integer >= 0
+//|     :rtype: int
+//|
+STATIC mp_obj_t touchio_touchin_obj_get_raw_value(mp_obj_t self_in) {
+	touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+	return MP_OBJ_NEW_SMALL_INT(common_hal_touchio_touchin_get_raw_value(self));
+}
+
+MP_DEFINE_CONST_FUN_OBJ_1(touchio_touchin_get_raw_value_obj, touchio_touchin_obj_get_raw_value);
+
+const mp_obj_property_t touchio_touchin_raw_value_obj = {
+	.base.type = &mp_type_property,
+	.proxy = {(mp_obj_t)&touchio_touchin_get_raw_value_obj,
+                  (mp_obj_t)&mp_const_none_obj,
+                  (mp_obj_t)&mp_const_none_obj},
+ };
+
+
+//|   .. attribute:: threshold
+//|
+//|     `value` will return True if `raw_value` is greater than than this threshold.
+//|     When the **TouchIn** object is created, an initial `raw_value` is read from the pin,
+//|     and then `threshold` is set to be 100 + that value.
+//|
+//|     You can set the threshold to a different value to make the pin more or less sensitive.
+//|
+//|     :return: an integer >= 0
+//|     :rtype: int
+//|
+STATIC mp_obj_t touchio_touchin_obj_get_threshold(mp_obj_t self_in) {
+	touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+	return MP_OBJ_NEW_SMALL_INT(common_hal_touchio_touchin_get_threshold(self));
+}
+
+MP_DEFINE_CONST_FUN_OBJ_1(touchio_touchin_get_threshold_obj, touchio_touchin_obj_get_threshold);
+
+STATIC mp_obj_t touchio_touchin_obj_set_threshold(mp_obj_t self_in, mp_obj_t threshold_obj) {
+	touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+        uint32_t new_threshold = mp_obj_get_int(threshold_obj);
+        if (new_threshold < 0 || new_threshold > UINT16_MAX) {
+            // I would use MP_STRINGIFY(UINT16_MAX), but that prints "0xffff" instead of 65536.
+            mp_raise_ValueError("threshold must be in the range 0-65536");
+        }
+	common_hal_touchio_touchin_set_threshold(self, new_threshold);
+        return mp_const_none;
+}
+
+MP_DEFINE_CONST_FUN_OBJ_2(touchio_touchin_set_threshold_obj, touchio_touchin_obj_set_threshold);
+
+const mp_obj_property_t touchio_touchin_threshold_obj = {
+	.base.type = &mp_type_property,
+	.proxy = {(mp_obj_t)&touchio_touchin_get_threshold_obj,
+                  (mp_obj_t)&touchio_touchin_set_threshold_obj,
+                  (mp_obj_t)&mp_const_none_obj},
+ };
+
+
 STATIC const mp_rom_map_elem_t touchio_touchin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&default___enter___obj) },
     { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&touchio_touchin___exit___obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&touchio_touchin_deinit_obj) },
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_value), MP_ROM_PTR(&touchio_touchin_value_obj)},
+    { MP_OBJ_NEW_QSTR(MP_QSTR_raw_value), MP_ROM_PTR(&touchio_touchin_raw_value_obj)},
+    { MP_OBJ_NEW_QSTR(MP_QSTR_threshold), MP_ROM_PTR(&touchio_touchin_threshold_obj)},
 };
 
 STATIC MP_DEFINE_CONST_DICT(touchio_touchin_locals_dict, touchio_touchin_locals_dict_table);

--- a/shared-bindings/touchio/TouchIn.h
+++ b/shared-bindings/touchio/TouchIn.h
@@ -35,5 +35,8 @@ extern const mp_obj_type_t touchio_touchin_type;
 void common_hal_touchio_touchin_construct(touchio_touchin_obj_t* self, const mcu_pin_obj_t *pin);
 void common_hal_touchio_touchin_deinit(touchio_touchin_obj_t* self);
 bool common_hal_touchio_touchin_get_value(touchio_touchin_obj_t *self);
+uint16_t common_hal_touchio_touchin_get_raw_value(touchio_touchin_obj_t *self);
+uint16_t common_hal_touchio_touchin_get_threshold(touchio_touchin_obj_t *self);
+void common_hal_touchio_touchin_set_threshold(touchio_touchin_obj_t *self, uint16_t new_threshold);
 
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_TOUCHIO_TOUCHIN_H


### PR DESCRIPTION
Fixes #297. Makes the threshold be 100 above the initial value, instead of 2 times the initial value. Works better for attached objects such as fruit. Add `.raw_value` and `.threshold` attributes to allow debugging and fine-tuning of touch sensitivity.