### PR TITLE
Do not allow a *io object to be used after deinit().

### DIFF
--- a/atmel-samd/Makefile
+++ b/atmel-samd/Makefile
@@ -135,9 +135,13 @@ ifeq ($(DEBUG), 1)
 # -DMICROPY_DEBUG_MODULES may also be added to an -flto build, if you wish.
 CFLAGS += -Os -ggdb -DNDEBUG -DENABLE_MICRO_TRACE_BUFFER -DMICROPY_DEBUG_MODULES
 else
-# -finline-limit can shrink the image size. -finline-limit=80 or so is similar to not having it on.
+# GCC_INLINE_LIMIT specifies -finline-limit, which can shrink the image size.
+# -finline-limit=80 or so is similar to not having it on.
 # There is no simple default value, though.
-CFLAGS += -Os -DNDEBUG -flto -finline-limit=39
+ifeq ($(FLASH_IMPL),internal_flash.c)
+GCC_INLINE_LIMIT = -finline-limit=19
+endif
+CFLAGS += -Os -DNDEBUG -flto $(GCC_INLINE_LIMIT)
 endif
 
 ifneq ($(FROZEN_DIR),)
@@ -272,7 +276,8 @@ SRC_BINDINGS_ENUMS = \
 	digitalio/Direction.c \
 	digitalio/DriveMode.c \
 	digitalio/Pull.c \
-	help.c
+	help.c \
+	util.c
 
 SRC_COMMON_HAL_EXPANDED = $(addprefix shared-bindings/, $(SRC_COMMON_HAL)) \
                           $(addprefix shared-bindings/, $(SRC_BINDINGS_ENUMS)) \

--- a/atmel-samd/boards/feather_m0_basic/mpconfigboard.mk
+++ b/atmel-samd/boards/feather_m0_basic/mpconfigboard.mk
@@ -5,3 +5,4 @@ USB_PID = 0x8015
 FLASH_IMPL = internal_flash.c
 
 CHIP_VARIANT = SAMD21G18A
+

--- a/atmel-samd/common-hal/analogio/AnalogIn.c
+++ b/atmel-samd/common-hal/analogio/AnalogIn.c
@@ -77,7 +77,14 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t* self,
     active_channel_count++;
 }
 
+bool common_hal_analogio_analogin_deinited(analogio_analogin_obj_t *self) {
+    return self->pin == mp_const_none;
+}
+
 void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self) {
+    if (common_hal_analogio_analogin_deinited(self)) {
+        return;
+    }
     active_channel_count--;
     if (active_channel_count == 0) {
         adc_reset(adc_instance);
@@ -89,6 +96,7 @@ void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self) {
         config_adc = NULL;
     }
     reset_pin(self->pin->pin);
+    self->pin = mp_const_none;
 }
 
 void analogin_reset() {

--- a/atmel-samd/common-hal/analogio/AnalogOut.c
+++ b/atmel-samd/common-hal/analogio/AnalogOut.c
@@ -59,10 +59,18 @@ void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self,
     dac_enable(&self->dac_instance);
 }
 
+bool common_hal_analogio_analogout_deinited(analogio_analogout_obj_t *self) {
+    return self->deinited;
+}
+
 void common_hal_analogio_analogout_deinit(analogio_analogout_obj_t *self) {
+    if (common_hal_analogio_analogout_deinited(self)) {
+        return;
+    }
     dac_disable(&self->dac_instance);
     dac_chan_disable(&self->dac_instance, DAC_CHANNEL_0);
     reset_pin(PIN_PA02);
+    self->deinited = true;
 }
 
 void common_hal_analogio_analogout_set_value(analogio_analogout_obj_t *self,

--- a/atmel-samd/common-hal/analogio/AnalogOut.h
+++ b/atmel-samd/common-hal/analogio/AnalogOut.h
@@ -36,6 +36,7 @@
 typedef struct {
     mp_obj_base_t base;
     struct dac_module dac_instance;
+    bool deinited;
 } analogio_analogout_obj_t;
 
 #endif // MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_ANALOGIO_ANALOGOUT_H

--- a/atmel-samd/common-hal/audiobusio/PDMIn.c
+++ b/atmel-samd/common-hal/audiobusio/PDMIn.c
@@ -145,11 +145,20 @@ void common_hal_audiobusio_pdmin_construct(audiobusio_pdmin_obj_t* self,
     self->bit_depth = bit_depth;
 }
 
+bool common_hal_audiobusio_pdmin_deinited(audiobusio_pdmin_obj_t* self) {
+    return self->clock_pin == mp_const_none;
+}
+
 void common_hal_audiobusio_pdmin_deinit(audiobusio_pdmin_obj_t* self) {
+    if (common_hal_audiobusio_pdmin_deinited(self)) {
+        return;
+    }
     i2s_disable(&self->i2s_instance);
     i2s_reset(&self->i2s_instance);
     reset_pin(self->clock_pin->pin);
     reset_pin(self->data_pin->pin);
+    self->clock_pin = mp_const_none;
+    self->data_pin = mp_const_none;
 }
 
 uint8_t common_hal_audiobusio_pdmin_get_bit_depth(audiobusio_pdmin_obj_t* self) {

--- a/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/atmel-samd/common-hal/audioio/AudioOut.c
@@ -381,7 +381,14 @@ void common_hal_audioio_audioout_construct_from_file(audioio_audioout_obj_t* sel
     }
 }
 
+bool common_hal_audioio_audioout_deinited(audioio_audioout_obj_t* self) {
+    return self->pin == mp_const_none;
+}
+
 void common_hal_audioio_audioout_deinit(audioio_audioout_obj_t* self) {
+    if (common_hal_audioio_audioout_deinited(self)) {
+        return;
+    }
     refcount--;
     if (refcount == 0) {
         if (MP_STATE_VM(audioout_sample_timer) != NULL) {
@@ -407,6 +414,8 @@ void common_hal_audioio_audioout_deinit(audioio_audioout_obj_t* self) {
         }
         reset_pin(self->pin->pin);
     }
+
+    self->pin = mp_const_none;
 }
 
 static void set_timer_frequency(uint32_t frequency) {

--- a/atmel-samd/common-hal/busio/I2C.c
+++ b/atmel-samd/common-hal/busio/I2C.c
@@ -95,10 +95,19 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     i2c_master_enable(&self->i2c_master_instance);
 }
 
+bool common_hal_busio_i2c_deinited(busio_i2c_obj_t *self) {
+    return self->sda_pin == NO_PIN;
+}
+
 void common_hal_busio_i2c_deinit(busio_i2c_obj_t *self) {
+    if (common_hal_busio_i2c_deinited(self)) {
+        return;
+    }
     i2c_master_reset(&self->i2c_master_instance);
     reset_pin(self->sda_pin);
     reset_pin(self->scl_pin);
+    self->sda_pin = NO_PIN;
+    self->scl_pin = NO_PIN;
 }
 
 bool common_hal_busio_i2c_probe(busio_i2c_obj_t *self, uint8_t addr) {

--- a/atmel-samd/common-hal/busio/SPI.c
+++ b/atmel-samd/common-hal/busio/SPI.c
@@ -159,11 +159,19 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     spi_enable(&self->spi_master_instance);
 }
 
+bool common_hal_busio_spi_deinited(busio_spi_obj_t *self) {
+    return self->clock_pin == NO_PIN;
+}
+
 void common_hal_busio_spi_deinit(busio_spi_obj_t *self) {
+    if (common_hal_busio_spi_deinited(self)) {
+        return;
+    }
     spi_disable(&self->spi_master_instance);
     reset_pin(self->clock_pin);
     reset_pin(self->MOSI_pin);
     reset_pin(self->MISO_pin);
+    self->clock_pin = NO_PIN;
 }
 
 bool common_hal_busio_spi_configure(busio_spi_obj_t *self,

--- a/atmel-samd/common-hal/busio/UART.c
+++ b/atmel-samd/common-hal/busio/UART.c
@@ -243,7 +243,14 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     self->uart_instance.hw->USART.INTENSET.bit.RXC = true;
 }
 
+bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {
+    return self->rx_pin == NO_PIN && self->tx_pin == NO_PIN;
+}
+
 void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
+    if (common_hal_busio_uart_deinited(self)) {
+        return;
+    }
     self->uart_instance.hw->USART.INTENCLR.bit.RXC = true;
 
     uint8_t instance_index = _sercom_get_sercom_inst_index(self->uart_instance.hw);
@@ -256,6 +263,8 @@ void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
     usart_disable(&self->uart_instance);
     reset_pin(self->rx_pin);
     reset_pin(self->tx_pin);
+    self->rx_pin = NO_PIN;
+    self->tx_pin = NO_PIN;
 }
 
 // Read characters.

--- a/atmel-samd/common-hal/digitalio/DigitalInOut.c
+++ b/atmel-samd/common-hal/digitalio/DigitalInOut.c
@@ -51,8 +51,16 @@ digitalinout_result_t common_hal_digitalio_digitalinout_construct(
     return DIGITALINOUT_OK;
 }
 
+bool common_hal_digitalio_digitalinout_deinited(digitalio_digitalinout_obj_t* self) {
+    return self->pin == mp_const_none;
+}
+
 void common_hal_digitalio_digitalinout_deinit(digitalio_digitalinout_obj_t* self) {
+    if (common_hal_digitalio_digitalinout_deinited(self)) {
+        return;
+    }
     reset_pin(self->pin->pin);
+    self->pin = mp_const_none;
 }
 
 void common_hal_digitalio_digitalinout_switch_to_input(

--- a/atmel-samd/common-hal/pulseio/PWMOut.c
+++ b/atmel-samd/common-hal/pulseio/PWMOut.c
@@ -238,7 +238,14 @@ void common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self,
     common_hal_pulseio_pwmout_set_duty_cycle(self, duty);
 }
 
-extern void common_hal_pulseio_pwmout_deinit(pulseio_pwmout_obj_t* self) {
+bool common_hal_pulseio_pwmout_deinited(pulseio_pwmout_obj_t* self) {
+    return self->pin == mp_const_none;
+}
+
+void common_hal_pulseio_pwmout_deinit(pulseio_pwmout_obj_t* self) {
+    if (common_hal_pulseio_pwmout_deinited(self)) {
+        return;
+    }
     const pin_timer_t* t = self->timer;
     uint8_t index = (((uint32_t) t->tcc) - ((uint32_t) TCC0)) / 0x400;
     timer_refcount[index]--;
@@ -260,6 +267,7 @@ extern void common_hal_pulseio_pwmout_deinit(pulseio_pwmout_obj_t* self) {
         }
     }
     reset_pin(self->pin->pin);
+    self->pin = mp_const_none;
 }
 
 extern void common_hal_pulseio_pwmout_set_duty_cycle(pulseio_pwmout_obj_t* self, uint16_t duty) {

--- a/atmel-samd/common-hal/pulseio/PulseIn.c
+++ b/atmel-samd/common-hal/pulseio/PulseIn.c
@@ -152,10 +152,18 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
     extint_chan_enable_callback(self->channel, EXTINT_CALLBACK_TYPE_DETECT);
 }
 
+bool common_hal_pulseio_pulsein_deinited(pulseio_pulsein_obj_t* self) {
+    return self->pin == NO_PIN;
+}
+
 void common_hal_pulseio_pulsein_deinit(pulseio_pulsein_obj_t* self) {
+    if (common_hal_pulseio_pulsein_deinited(self)) {
+        return;
+    }
     extint_chan_disable_callback(self->channel, EXTINT_CALLBACK_TYPE_DETECT);
     active_pulseins[self->channel] = NULL;
     reset_pin(self->pin);
+    self->pin = NO_PIN;
 }
 
 void common_hal_pulseio_pulsein_pause(pulseio_pulsein_obj_t* self) {

--- a/atmel-samd/common-hal/pulseio/PulseOut.c
+++ b/atmel-samd/common-hal/pulseio/PulseOut.c
@@ -34,6 +34,7 @@
 #include "mpconfigport.h"
 #include "py/gc.h"
 #include "py/runtime.h"
+#include "samd21_pins.h"
 #include "shared-bindings/pulseio/PulseOut.h"
 
 #undef ENABLE
@@ -128,7 +129,14 @@ void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
     turn_off(self->pincfg);
 }
 
+bool common_hal_pulseio_pulseout_deinited(pulseio_pulseout_obj_t* self) {
+    return self->pin == NO_PIN;
+}
+
 void common_hal_pulseio_pulseout_deinit(pulseio_pulseout_obj_t* self) {
+    if (common_hal_pulseio_pulseout_deinited(self)) {
+        return;
+    }
     PortGroup *const port_base = port_get_group_from_gpio_pin(self->pin);
     port_base->DIRCLR.reg = 1 << (self->pin % 32);
 
@@ -140,6 +148,7 @@ void common_hal_pulseio_pulseout_deinit(pulseio_pulseout_obj_t* self) {
         gc_free(MP_STATE_VM(pulseout_tc_instance));
         MP_STATE_VM(pulseout_tc_instance) = NULL;
     }
+    self->pin = NO_PIN;
 }
 
 void common_hal_pulseio_pulseout_send(pulseio_pulseout_obj_t* self, uint16_t* pulses, uint16_t length) {

--- a/atmel-samd/common-hal/touchio/TouchIn.c
+++ b/atmel-samd/common-hal/touchio/TouchIn.c
@@ -33,6 +33,7 @@
 #include "py/mphal.h"
 #include "shared-bindings/touchio/TouchIn.h"
 
+#include "samd21_pins.h"
 #include "tick.h"
 
 #include "adafruit_ptc.h"
@@ -81,9 +82,17 @@ void common_hal_touchio_touchin_construct(touchio_touchin_obj_t* self,
     self->threshold = get_raw_reading(self) + 100;
 }
 
+bool common_hal_touchio_touchin_deinited(touchio_touchin_obj_t* self) {
+    return self->config.pin == NO_PIN;
+}
+
 void common_hal_touchio_touchin_deinit(touchio_touchin_obj_t* self) {
     // TODO(tannewt): Reset the PTC.
-    reset_pin(self->pin->pin);
+    if (common_hal_touchio_touchin_deinited(self)) {
+        return;
+    }
+    reset_pin(self->config.pin);
+    self->config.pin = NO_PIN;
 }
 
 void touchin_reset() {

--- a/atmel-samd/common-hal/touchio/TouchIn.h
+++ b/atmel-samd/common-hal/touchio/TouchIn.h
@@ -36,7 +36,6 @@
 
 typedef struct {
     mp_obj_base_t base;
-    const mcu_pin_obj_t * pin;
     struct adafruit_ptc_config config;
     uint16_t threshold;
 } touchio_touchin_obj_t;

--- a/esp8266/Makefile
+++ b/esp8266/Makefile
@@ -121,12 +121,14 @@ SRC_COMMON_HAL = \
 	time/__init__.c \
 	board/__init__.c
 
+
 # These don't have corresponding files in each port but are still located in
 # shared-bindings to make it clear what the contents of the modules are.
 SRC_BINDINGS_ENUMS = \
 	digitalio/Direction.c \
 	digitalio/DriveMode.c \
-	digitalio/Pull.c
+	digitalio/Pull.c \
+	util.c
 
 SRC_COMMON_HAL_EXPANDED = $(addprefix shared-bindings/, $(SRC_COMMON_HAL)) \
                           $(addprefix shared-bindings/, $(SRC_BINDINGS_ENUMS)) \
@@ -141,7 +143,7 @@ SRC_SHARED_MODULE = \
 	multiterminal/__init__.c \
 	os/__init__.c \
 	random/__init__.c \
-	storage/__init__.c \
+	storage/__init__.c
 
 SRC_SHARED_MODULE_EXPANDED = $(addprefix shared-bindings/, $(SRC_SHARED_MODULE)) \
                              $(addprefix shared-module/, $(SRC_SHARED_MODULE))

--- a/esp8266/common-hal/analogio/AnalogIn.c
+++ b/esp8266/common-hal/analogio/AnalogIn.c
@@ -46,8 +46,16 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t* self,
     adc_in_use = true;
 }
 
+bool common_hal_analogio_analogin_deinited(analogio_analogin_obj_t* self) {
+    return self->deinited;
+}
+
 void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t* self) {
+    if (common_hal_analogio_analogin_deinited(self)) {
+        return;
+    }
     adc_in_use = false;
+    self->deinited = true;
 }
 
 uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {

--- a/esp8266/common-hal/analogio/AnalogIn.h
+++ b/esp8266/common-hal/analogio/AnalogIn.h
@@ -33,7 +33,7 @@
 
 typedef struct {
     mp_obj_base_t base;
-    const mcu_pin_obj_t * pin;
+    bool deinited;
 } analogio_analogin_obj_t;
 
 #endif // MICROPY_INCLUDED_ESP8266_COMMON_HAL_ANALOGIO_ANALOGIN_H

--- a/esp8266/common-hal/busio/SPI.c
+++ b/esp8266/common-hal/busio/SPI.c
@@ -74,7 +74,15 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     CLEAR_PERI_REG_MASK(SPI_USER(HSPI), SPI_FLASH_MODE);
 }
 
+bool common_hal_busio_spi_deinited(busio_spi_obj_t *self) {
+    return self->deinited;
+}
+
 void common_hal_busio_spi_deinit(busio_spi_obj_t *self) {
+    if (common_hal_busio_spi_deinited(self)) {
+        return;
+    }
+
     PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDI_U, 0);
     PIN_PULLUP_DIS(PERIPHS_IO_MUX_MTDI_U);
 
@@ -86,6 +94,8 @@ void common_hal_busio_spi_deinit(busio_spi_obj_t *self) {
 
     // Turn off outputs 12 - 14.
     gpio_output_set(0x0, 0x0, 0x0, 0x7 << 12);
+
+    self->deinited = true;
 }
 
 bool common_hal_busio_spi_configure(busio_spi_obj_t *self,

--- a/esp8266/common-hal/busio/SPI.h
+++ b/esp8266/common-hal/busio/SPI.h
@@ -34,6 +34,7 @@
 typedef struct {
     mp_obj_base_t base;
     bool locked;
+    bool deinited;
 } busio_spi_obj_t;
 
 #endif // MICROPY_INCLUDED_ESP8266_COMMON_HAL_BUSIO_SPI_H

--- a/esp8266/common-hal/busio/UART.c
+++ b/esp8266/common-hal/busio/UART.c
@@ -92,8 +92,16 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     uart_setup(UART1);
 }
 
+bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {
+    return self->deinited;
+}
+
 void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
+    if (common_hal_busio_uart_deinited(self)) {
+        return;
+    }
     PIN_FUNC_SELECT(FUNC_U1TXD_BK, 0);
+    self->deinited = true;
 }
 
 size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t len, int *errcode) {

--- a/esp8266/common-hal/busio/UART.h
+++ b/esp8266/common-hal/busio/UART.h
@@ -32,7 +32,8 @@
 #include "py/obj.h"
 
 typedef struct {
-  mp_obj_base_t base;
+    mp_obj_base_t base;
+    bool deinited;
 } busio_uart_obj_t;
 
 #endif // MICROPY_INCLUDED_ESP8266_COMMON_HAL_BUSIO_UART_H

--- a/esp8266/common-hal/digitalio/DigitalInOut.c
+++ b/esp8266/common-hal/digitalio/DigitalInOut.c
@@ -41,13 +41,21 @@ digitalinout_result_t common_hal_digitalio_digitalinout_construct(
     return DIGITALINOUT_OK;
 }
 
+bool common_hal_digitalio_digitalinout_deinited(digitalio_digitalinout_obj_t* self) {
+    return self->pin == mp_const_none;
+}
+
 void common_hal_digitalio_digitalinout_deinit(digitalio_digitalinout_obj_t* self) {
+    if (common_hal_digitalio_digitalinout_deinited(self)) {
+        return;
+    }
     if (self->pin->gpio_number < 16) {
         uint32_t pin_mask = 1 << self->pin->gpio_number;
         gpio_output_set(0x0, 0x0, 0x0, pin_mask);
         PIN_FUNC_SELECT(self->pin->peripheral, 0);
         PIN_PULLUP_DIS(self->pin->peripheral);
     }
+    self->pin = mp_const_none;
 }
 
 void common_hal_digitalio_digitalinout_switch_to_input(

--- a/esp8266/common-hal/pulseio/PWMOut.c
+++ b/esp8266/common-hal/pulseio/PWMOut.c
@@ -77,7 +77,14 @@ void common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self, const mcu_p
     }
 }
 
-extern void common_hal_pulseio_pwmout_deinit(pulseio_pwmout_obj_t* self) {
+bool common_hal_pulseio_pwmout_deinited(pulseio_pwmout_obj_t* self) {
+    return self->pin == mp_const_none;
+}
+
+void common_hal_pulseio_pwmout_deinit(pulseio_pwmout_obj_t* self) {
+    if (common_hal_pulseio_pwmout_deinited(self)) {
+        return;
+    }
     pwm_delete(self->channel);
     pwm_start();
     if (self->pin->gpio_number < 16) {
@@ -86,9 +93,10 @@ extern void common_hal_pulseio_pwmout_deinit(pulseio_pwmout_obj_t* self) {
         PIN_FUNC_SELECT(self->pin->peripheral, 0);
         PIN_PULLUP_DIS(self->pin->peripheral);
     }
+    self->pin = mp_const_none;
 }
 
-extern void common_hal_pulseio_pwmout_set_duty_cycle(pulseio_pwmout_obj_t* self, uint16_t duty) {
+void common_hal_pulseio_pwmout_set_duty_cycle(pulseio_pwmout_obj_t* self, uint16_t duty) {
     // We get 16 bits of duty in but the underlying code is only ten bit.
     pwm_set_duty(duty >> 6, self->channel);
     pwm_start();

--- a/esp8266/common-hal/pulseio/PulseIn.c
+++ b/esp8266/common-hal/pulseio/PulseIn.c
@@ -37,8 +37,11 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
     mp_raise_NotImplementedError("");
 }
 
-void common_hal_pulseio_pulsein_deinit(pulseio_pulsein_obj_t* self) {
+bool common_hal_pulseio_pulsein_deinited(pulseio_pulsein_obj_t* self) {
+    return true;
+}
 
+void common_hal_pulseio_pulsein_deinit(pulseio_pulsein_obj_t* self) {
 }
 
 void common_hal_pulseio_pulsein_pause(pulseio_pulsein_obj_t* self) {

--- a/esp8266/common-hal/pulseio/PulseOut.c
+++ b/esp8266/common-hal/pulseio/PulseOut.c
@@ -35,6 +35,10 @@ void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
     nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "No hardware support for PulseOut."));
 }
 
+bool common_hal_pulseio_pulseout_deinited(pulseio_pulseout_obj_t* self) {
+    return true;
+}
+
 void common_hal_pulseio_pulseout_deinit(pulseio_pulseout_obj_t* self) {
 }
 

--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -34,6 +34,7 @@
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/analogio/AnalogIn.h"
+#include "shared-bindings/util.h"
 
 //| .. currentmodule:: analogio
 //|
@@ -114,8 +115,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(analogio_analogin___exit___obj, 4, 4,
 //|     :rtype: int
 //|
 STATIC mp_obj_t analogio_analogin_obj_get_value(mp_obj_t self_in) {
-   analogio_analogin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-   return MP_OBJ_NEW_SMALL_INT(common_hal_analogio_analogin_get_value(self));
+    analogio_analogin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_analogio_analogin_deinited(self));
+    return MP_OBJ_NEW_SMALL_INT(common_hal_analogio_analogin_get_value(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(analogio_analogin_get_value_obj, analogio_analogin_obj_get_value);
 
@@ -134,8 +136,9 @@ const mp_obj_property_t analogio_analogin_value_obj = {
 //|     :rtype: float
 //|
 STATIC mp_obj_t analogio_analogin_obj_get_reference_voltage(mp_obj_t self_in) {
-   analogio_analogin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-   return mp_obj_new_float(common_hal_analogio_analogin_get_reference_voltage(self));
+    analogio_analogin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_analogio_analogin_deinited(self));
+    return mp_obj_new_float(common_hal_analogio_analogin_get_reference_voltage(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(analogio_analogin_get_reference_voltage_obj,
                           analogio_analogin_obj_get_reference_voltage);

--- a/shared-bindings/analogio/AnalogIn.h
+++ b/shared-bindings/analogio/AnalogIn.h
@@ -34,6 +34,7 @@ extern const mp_obj_type_t analogio_analogin_type;
 
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t* self, const mcu_pin_obj_t *pin);
 void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t* self);
+bool common_hal_analogio_analogin_deinited(analogio_analogin_obj_t* self);
 uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t* self);
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t* self);
 

--- a/shared-bindings/analogio/AnalogOut.c
+++ b/shared-bindings/analogio/AnalogOut.c
@@ -30,8 +30,10 @@
 #include "lib/utils/context_manager_helpers.h"
 #include "py/objproperty.h"
 #include "py/runtime.h"
+
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/analogio/AnalogOut.h"
+#include "shared-bindings/util.h"
 
 //| .. currentmodule:: analogio
 //|
@@ -112,6 +114,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(analogio_analogout___exit___obj, 4, 4
 //|
 STATIC mp_obj_t analogio_analogout_obj_set_value(mp_obj_t self_in, mp_obj_t value) {
    analogio_analogout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+   raise_error_if_deinited(common_hal_analogio_analogout_deinited(self));
    uint32_t v = mp_obj_get_int(value);
    if (v >= (1 << 16)) {
        mp_raise_ValueError("AnalogOut is only 16 bits. Value must be less than 65536.");

--- a/shared-bindings/analogio/AnalogOut.h
+++ b/shared-bindings/analogio/AnalogOut.h
@@ -34,6 +34,7 @@ extern const mp_obj_type_t analogio_analogout_type;
 
 void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self, const mcu_pin_obj_t *pin);
 void common_hal_analogio_analogout_deinit(analogio_analogout_obj_t *self);
+bool common_hal_analogio_analogout_deinited(analogio_analogout_obj_t *self);
 void common_hal_analogio_analogout_set_value(analogio_analogout_obj_t *self, uint16_t value);
 
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_ANALOGIO_ANALOGOUT_H

--- a/shared-bindings/audiobusio/PDMIn.c
+++ b/shared-bindings/audiobusio/PDMIn.c
@@ -32,6 +32,7 @@
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/audiobusio/PDMIn.h"
+#include "shared-bindings/util.h"
 
 //| .. currentmodule:: audiobusio
 //|
@@ -161,7 +162,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiobusio_pdmin___exit___obj, 4, 4, 
 //|
 STATIC mp_obj_t audiobusio_pdmin_obj_record(mp_obj_t self_obj, mp_obj_t destination, mp_obj_t destination_length) {
     audiobusio_pdmin_obj_t *self = MP_OBJ_TO_PTR(self_obj);
-
+    raise_error_if_deinited(common_hal_audiobusio_pdmin_deinited(self));
     if (!MP_OBJ_IS_SMALL_INT(destination_length)) {
         mp_raise_TypeError("destination_length must be int");
     }
@@ -198,6 +199,7 @@ MP_DEFINE_CONST_FUN_OBJ_3(audiobusio_pdmin_record_obj, audiobusio_pdmin_obj_reco
 //|
 STATIC mp_obj_t audiobusio_pdmin_obj_get_frequency(mp_obj_t self_in) {
     audiobusio_pdmin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_audiobusio_pdmin_deinited(self));
     return MP_OBJ_NEW_SMALL_INT(common_hal_audiobusio_pdmin_get_frequency(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audiobusio_pdmin_get_frequency_obj, audiobusio_pdmin_obj_get_frequency);

--- a/shared-bindings/audiobusio/PDMIn.h
+++ b/shared-bindings/audiobusio/PDMIn.h
@@ -37,6 +37,7 @@ void common_hal_audiobusio_pdmin_construct(audiobusio_pdmin_obj_t* self,
     const mcu_pin_obj_t* clock_pin, const mcu_pin_obj_t* data_pin,
     uint32_t frequency, uint8_t bit_depth, bool mono, uint8_t oversample);
 void common_hal_audiobusio_pdmin_deinit(audiobusio_pdmin_obj_t* self);
+bool common_hal_audiobusio_pdmin_deinited(audiobusio_pdmin_obj_t* self);
 uint32_t common_hal_audiobusio_pdmin_record_to_buffer(audiobusio_pdmin_obj_t* self,
     uint16_t* buffer, uint32_t length);
 uint8_t common_hal_audiobusio_pdmin_get_bit_depth(audiobusio_pdmin_obj_t* self);

--- a/shared-bindings/audioio/AudioOut.c
+++ b/shared-bindings/audioio/AudioOut.c
@@ -32,6 +32,7 @@
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/audioio/AudioOut.h"
+#include "shared-bindings/util.h"
 
 //| .. currentmodule:: audioio
 //|
@@ -162,6 +163,7 @@ STATIC mp_obj_t audioio_audioout_obj_play(size_t n_args, const mp_obj_t *pos_arg
         { MP_QSTR_loop,      MP_ARG_BOOL, {.u_bool = false} },
     };
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    raise_error_if_deinited(common_hal_audioio_audioout_deinited(self));
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
@@ -177,6 +179,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audioio_audioout_play_obj, 1, audioio_audioout_obj_pl
 //|
 STATIC mp_obj_t audioio_audioout_obj_stop(mp_obj_t self_in) {
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_audioio_audioout_deinited(self));
     common_hal_audioio_audioout_stop(self);
     return mp_const_none;
 }
@@ -188,6 +191,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(audioio_audioout_stop_obj, audioio_audioout_obj_stop);
 //|
 STATIC mp_obj_t audioio_audioout_obj_get_playing(mp_obj_t self_in) {
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_audioio_audioout_deinited(self));
     return mp_obj_new_bool(common_hal_audioio_audioout_get_playing(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audioio_audioout_get_playing_obj, audioio_audioout_obj_get_playing);
@@ -207,12 +211,14 @@ const mp_obj_property_t audioio_audioout_playing_obj = {
 //|
 STATIC mp_obj_t audioio_audioout_obj_get_frequency(mp_obj_t self_in) {
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_audioio_audioout_deinited(self));
     return MP_OBJ_NEW_SMALL_INT(common_hal_audioio_audioout_get_frequency(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audioio_audioout_get_frequency_obj, audioio_audioout_obj_get_frequency);
 
 STATIC mp_obj_t audioio_audioout_obj_set_frequency(mp_obj_t self_in, mp_obj_t frequency) {
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_audioio_audioout_deinited(self));
     common_hal_audioio_audioout_set_frequency(self, mp_obj_get_int(frequency));
     return mp_const_none;
 }

--- a/shared-bindings/audioio/AudioOut.h
+++ b/shared-bindings/audioio/AudioOut.h
@@ -39,6 +39,7 @@ void common_hal_audioio_audioout_construct_from_file(audioio_audioout_obj_t* sel
     const mcu_pin_obj_t* pin, pyb_file_obj_t* file);
 
 void common_hal_audioio_audioout_deinit(audioio_audioout_obj_t* self);
+bool common_hal_audioio_audioout_deinited(audioio_audioout_obj_t* self);
 void common_hal_audioio_audioout_play(audioio_audioout_obj_t* self, bool loop);
 void common_hal_audioio_audioout_stop(audioio_audioout_obj_t* self);
 bool common_hal_audioio_audioout_get_playing(audioio_audioout_obj_t* self);

--- a/shared-bindings/bitbangio/I2C.c
+++ b/shared-bindings/bitbangio/I2C.c
@@ -29,6 +29,7 @@
 
 #include "shared-bindings/bitbangio/I2C.h"
 #include "shared-bindings/microcontroller/Pin.h"
+#include "shared-bindings/util.h"
 
 #include "lib/utils/buffer_helper.h"
 #include "lib/utils/context_manager_helpers.h"
@@ -52,6 +53,7 @@
 STATIC mp_obj_t bitbangio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
     mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
     bitbangio_i2c_obj_t *self = m_new_obj(bitbangio_i2c_obj_t);
+    raise_error_if_deinited(shared_module_bitbangio_i2c_deinited(self));
     self->base.type = &bitbangio_i2c_type;
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
@@ -114,6 +116,7 @@ static void check_lock(bitbangio_i2c_obj_t *self) {
 //|
 STATIC mp_obj_t bitbangio_i2c_scan(mp_obj_t self_in) {
     bitbangio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(shared_module_bitbangio_i2c_deinited(self));
     check_lock(self);
     mp_obj_t list = mp_obj_new_list(0, NULL);
     // 7-bit addresses 0b0000xxx and 0b1111xxx are reserved
@@ -132,7 +135,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_i2c_scan_obj, bitbangio_i2c_scan);
 //|     Attempts to grab the I2C lock. Returns True on success.
 //|
 STATIC mp_obj_t bitbangio_i2c_obj_try_lock(mp_obj_t self_in) {
-    return mp_obj_new_bool(shared_module_bitbangio_i2c_try_lock(MP_OBJ_TO_PTR(self_in)));
+    bitbangio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(shared_module_bitbangio_i2c_deinited(self));
+    return mp_obj_new_bool(shared_module_bitbangio_i2c_try_lock(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_i2c_try_lock_obj, bitbangio_i2c_obj_try_lock);
 
@@ -141,7 +146,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_i2c_try_lock_obj, bitbangio_i2c_obj_try_lock
 //|     Releases the I2C lock.
 //|
 STATIC mp_obj_t bitbangio_i2c_obj_unlock(mp_obj_t self_in) {
-    shared_module_bitbangio_i2c_unlock(MP_OBJ_TO_PTR(self_in));
+    bitbangio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(shared_module_bitbangio_i2c_deinited(self));
+    shared_module_bitbangio_i2c_unlock(self);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_i2c_unlock_obj, bitbangio_i2c_obj_unlock);
@@ -169,6 +176,7 @@ STATIC mp_obj_t bitbangio_i2c_readfrom_into(size_t n_args, const mp_obj_t *pos_a
         { MP_QSTR_end,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = INT_MAX} },
     };
     bitbangio_i2c_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    raise_error_if_deinited(shared_module_bitbangio_i2c_deinited(self));
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     check_lock(self);
@@ -215,6 +223,7 @@ STATIC mp_obj_t bitbangio_i2c_writeto(size_t n_args, const mp_obj_t *pos_args, m
         { MP_QSTR_stop,       MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = true} },
     };
     bitbangio_i2c_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    raise_error_if_deinited(shared_module_bitbangio_i2c_deinited(self));
     check_lock(self);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);

--- a/shared-bindings/bitbangio/I2C.h
+++ b/shared-bindings/bitbangio/I2C.h
@@ -42,6 +42,7 @@ extern void shared_module_bitbangio_i2c_construct(bitbangio_i2c_obj_t *self,
                                                   uint32_t frequency);
 
 extern void shared_module_bitbangio_i2c_deinit(bitbangio_i2c_obj_t *self);
+extern bool shared_module_bitbangio_i2c_deinited(bitbangio_i2c_obj_t *self);
 
 extern bool shared_module_bitbangio_i2c_try_lock(bitbangio_i2c_obj_t *self);
 extern bool shared_module_bitbangio_i2c_has_lock(bitbangio_i2c_obj_t *self);

--- a/shared-bindings/bitbangio/OneWire.c
+++ b/shared-bindings/bitbangio/OneWire.c
@@ -32,6 +32,7 @@
 #include "py/runtime0.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/bitbangio/OneWire.h"
+#include "shared-bindings/util.h"
 
 //| .. currentmodule:: bitbangio
 //|
@@ -117,6 +118,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitbangio_onewire___exit___obj, 4, 4,
 //|
 STATIC mp_obj_t bitbangio_onewire_obj_reset(mp_obj_t self_in) {
     bitbangio_onewire_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(shared_module_bitbangio_onewire_deinited(self));
 
     return mp_obj_new_bool(shared_module_bitbangio_onewire_reset(self));
 }
@@ -131,6 +133,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_onewire_reset_obj, bitbangio_onewire_obj_res
 //|
 STATIC mp_obj_t bitbangio_onewire_obj_read_bit(mp_obj_t self_in) {
     bitbangio_onewire_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(shared_module_bitbangio_onewire_deinited(self));
 
     return mp_obj_new_bool(shared_module_bitbangio_onewire_read_bit(self));
 }
@@ -142,6 +145,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_onewire_read_bit_obj, bitbangio_onewire_obj_
 //|
 STATIC mp_obj_t bitbangio_onewire_obj_write_bit(mp_obj_t self_in, mp_obj_t bool_obj) {
     bitbangio_onewire_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(shared_module_bitbangio_onewire_deinited(self));
 
     shared_module_bitbangio_onewire_write_bit(self, mp_obj_is_true(bool_obj));
     return mp_const_none;

--- a/shared-bindings/bitbangio/OneWire.h
+++ b/shared-bindings/bitbangio/OneWire.h
@@ -35,6 +35,7 @@ extern const mp_obj_type_t bitbangio_onewire_type;
 extern void shared_module_bitbangio_onewire_construct(bitbangio_onewire_obj_t* self,
     const mcu_pin_obj_t* pin);
 extern void shared_module_bitbangio_onewire_deinit(bitbangio_onewire_obj_t* self);
+extern bool shared_module_bitbangio_onewire_deinited(bitbangio_onewire_obj_t* self);
 extern bool shared_module_bitbangio_onewire_reset(bitbangio_onewire_obj_t* self);
 extern bool shared_module_bitbangio_onewire_read_bit(bitbangio_onewire_obj_t* self);
 extern void shared_module_bitbangio_onewire_write_bit(bitbangio_onewire_obj_t* self, bool bit);

--- a/shared-bindings/bitbangio/SPI.h
+++ b/shared-bindings/bitbangio/SPI.h
@@ -41,6 +41,7 @@ extern void shared_module_bitbangio_spi_construct(bitbangio_spi_obj_t *self,
     const mcu_pin_obj_t * miso);
 
 extern void shared_module_bitbangio_spi_deinit(bitbangio_spi_obj_t *self);
+extern bool shared_module_bitbangio_spi_deinited(bitbangio_spi_obj_t *self);
 
 extern void shared_module_bitbangio_spi_configure(bitbangio_spi_obj_t *self,
     uint32_t baudrate, uint8_t polarity, uint8_t phase, uint8_t bits);

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -29,6 +29,7 @@
 
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/busio/I2C.h"
+#include "shared-bindings/util.h"
 
 #include "lib/utils/buffer_helper.h"
 #include "lib/utils/context_manager_helpers.h"
@@ -126,6 +127,7 @@ static void check_lock(busio_i2c_obj_t *self) {
 //|
 STATIC mp_obj_t busio_i2c_scan(mp_obj_t self_in) {
     busio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_i2c_deinited(self));
     check_lock(self);
     mp_obj_t list = mp_obj_new_list(0, NULL);
     // 7-bit addresses 0b0000xxx and 0b1111xxx are reserved
@@ -147,7 +149,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_i2c_scan_obj, busio_i2c_scan);
 //|     :rtype: bool
 //|
 STATIC mp_obj_t busio_i2c_obj_try_lock(mp_obj_t self_in) {
-    return mp_obj_new_bool(common_hal_busio_i2c_try_lock(MP_OBJ_TO_PTR(self_in)));
+    busio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_i2c_deinited(self));
+    return mp_obj_new_bool(common_hal_busio_i2c_try_lock(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(busio_i2c_try_lock_obj, busio_i2c_obj_try_lock);
 
@@ -156,7 +160,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_i2c_try_lock_obj, busio_i2c_obj_try_lock);
 //|     Releases the I2C lock.
 //|
 STATIC mp_obj_t busio_i2c_obj_unlock(mp_obj_t self_in) {
-    common_hal_busio_i2c_unlock(MP_OBJ_TO_PTR(self_in));
+    busio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_i2c_deinited(self));
+    common_hal_busio_i2c_unlock(self);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_1(busio_i2c_unlock_obj, busio_i2c_obj_unlock);
@@ -184,6 +190,7 @@ STATIC mp_obj_t busio_i2c_readfrom_into(size_t n_args, const mp_obj_t *pos_args,
         { MP_QSTR_end,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = INT_MAX} },
     };
     busio_i2c_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    raise_error_if_deinited(common_hal_busio_i2c_deinited(self));
     check_lock(self);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -229,6 +236,7 @@ STATIC mp_obj_t busio_i2c_writeto(size_t n_args, const mp_obj_t *pos_args, mp_ma
         { MP_QSTR_stop,       MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = true} },
     };
     busio_i2c_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    raise_error_if_deinited(common_hal_busio_i2c_deinited(self));
     check_lock(self);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);

--- a/shared-bindings/busio/I2C.h
+++ b/shared-bindings/busio/I2C.h
@@ -49,6 +49,7 @@ extern void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
                                               uint32_t frequency);
 
 extern void common_hal_busio_i2c_deinit(busio_i2c_obj_t *self);
+extern bool common_hal_busio_i2c_deinited(busio_i2c_obj_t *self);
 
 extern bool common_hal_busio_i2c_try_lock(busio_i2c_obj_t *self);
 extern bool common_hal_busio_i2c_has_lock(busio_i2c_obj_t *self);

--- a/shared-bindings/busio/OneWire.c
+++ b/shared-bindings/busio/OneWire.c
@@ -32,6 +32,7 @@
 #include "py/runtime0.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/busio/OneWire.h"
+#include "shared-bindings/util.h"
 
 //| .. currentmodule:: busio
 //|
@@ -120,6 +121,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_onewire___exit___obj, 4, 4, bus
 //|
 STATIC mp_obj_t busio_onewire_obj_reset(mp_obj_t self_in) {
     busio_onewire_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_onewire_deinited(self));
 
     return mp_obj_new_bool(common_hal_busio_onewire_reset(self));
 }
@@ -134,6 +136,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_onewire_reset_obj, busio_onewire_obj_reset);
 //|
 STATIC mp_obj_t busio_onewire_obj_read_bit(mp_obj_t self_in) {
     busio_onewire_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_onewire_deinited(self));
 
     return mp_obj_new_bool(common_hal_busio_onewire_read_bit(self));
 }
@@ -145,6 +148,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_onewire_read_bit_obj, busio_onewire_obj_read_bit
 //|
 STATIC mp_obj_t busio_onewire_obj_write_bit(mp_obj_t self_in, mp_obj_t bool_obj) {
     busio_onewire_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_onewire_deinited(self));
 
     common_hal_busio_onewire_write_bit(self, mp_obj_is_true(bool_obj));
     return mp_const_none;

--- a/shared-bindings/busio/OneWire.h
+++ b/shared-bindings/busio/OneWire.h
@@ -35,6 +35,7 @@ extern const mp_obj_type_t busio_onewire_type;
 extern void common_hal_busio_onewire_construct(busio_onewire_obj_t* self,
     const mcu_pin_obj_t* pin);
 extern void common_hal_busio_onewire_deinit(busio_onewire_obj_t* self);
+extern bool common_hal_busio_onewire_deinited(busio_onewire_obj_t* self);
 extern bool common_hal_busio_onewire_reset(busio_onewire_obj_t* self);
 extern bool common_hal_busio_onewire_read_bit(busio_onewire_obj_t* self);
 extern void common_hal_busio_onewire_write_bit(busio_onewire_obj_t* self, bool bit);

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -31,6 +31,7 @@
 
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/busio/SPI.h"
+#include "shared-bindings/util.h"
 
 #include "lib/utils/buffer_helper.h"
 #include "lib/utils/context_manager_helpers.h"
@@ -151,6 +152,7 @@ STATIC mp_obj_t busio_spi_configure(size_t n_args, const mp_obj_t *pos_args, mp_
         { MP_QSTR_bits, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 8} },
     };
     busio_spi_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    raise_error_if_deinited(common_hal_busio_spi_deinited(self));
     check_lock(self);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -184,7 +186,9 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_configure_obj, 1, busio_spi_configure);
 //|     :rtype: bool
 //|
 STATIC mp_obj_t busio_spi_obj_try_lock(mp_obj_t self_in) {
-    return mp_obj_new_bool(common_hal_busio_spi_try_lock(MP_OBJ_TO_PTR(self_in)));
+    busio_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_spi_deinited(self));
+    return mp_obj_new_bool(common_hal_busio_spi_try_lock(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(busio_spi_try_lock_obj, busio_spi_obj_try_lock);
 
@@ -193,7 +197,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_spi_try_lock_obj, busio_spi_obj_try_lock);
 //|     Releases the SPI lock.
 //|
 STATIC mp_obj_t busio_spi_obj_unlock(mp_obj_t self_in) {
-    common_hal_busio_spi_unlock(MP_OBJ_TO_PTR(self_in));
+    busio_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_spi_deinited(self));
+    common_hal_busio_spi_unlock(self);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_1(busio_spi_unlock_obj, busio_spi_obj_unlock);
@@ -214,6 +220,7 @@ STATIC mp_obj_t busio_spi_write(size_t n_args, const mp_obj_t *pos_args, mp_map_
         { MP_QSTR_end,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = INT_MAX} },
     };
     busio_spi_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    raise_error_if_deinited(common_hal_busio_spi_deinited(self));
     check_lock(self);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -251,6 +258,7 @@ STATIC mp_obj_t busio_spi_readinto(size_t n_args, const mp_obj_t *pos_args, mp_m
         { MP_QSTR_write_value,MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
     };
     busio_spi_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    raise_error_if_deinited(common_hal_busio_spi_deinited(self));
     check_lock(self);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);

--- a/shared-bindings/busio/SPI.h
+++ b/shared-bindings/busio/SPI.h
@@ -41,6 +41,7 @@ extern void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     const mcu_pin_obj_t * miso);
 
 extern void common_hal_busio_spi_deinit(busio_spi_obj_t *self);
+extern bool common_hal_busio_spi_deinited(busio_spi_obj_t *self);
 
 extern bool common_hal_busio_spi_configure(busio_spi_obj_t *self, uint32_t baudrate, uint8_t polarity, uint8_t phase, uint8_t bits);
 

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -27,6 +27,8 @@
 #include <stdint.h>
 
 #include "shared-bindings/busio/UART.h"
+#include "shared-bindings/microcontroller/Pin.h"
+#include "shared-bindings/util.h"
 
 #include "lib/utils/context_manager_helpers.h"
 
@@ -34,7 +36,6 @@
 #include "py/runtime.h"
 #include "py/stream.h"
 
-#include "shared-bindings/microcontroller/Pin.h"
 
 //| .. currentmodule:: busio
 //|
@@ -179,7 +180,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_uart___exit___obj, 4, 4, busio_
 
 // These three methods are used by the shared stream methods.
 STATIC mp_uint_t busio_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
-    busio_uart_obj_t *self = self_in;
+    busio_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_uart_deinited(self));
     byte *buf = buf_in;
 
     // make sure we want at least 1 char
@@ -191,14 +193,16 @@ STATIC mp_uint_t busio_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size,
 }
 
 STATIC mp_uint_t busio_uart_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
-    busio_uart_obj_t *self = self_in;
+    busio_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_uart_deinited(self));
     const byte *buf = buf_in;
 
     return common_hal_busio_uart_write(self, buf, size, errcode);
 }
 
 STATIC mp_uint_t busio_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_t arg, int *errcode) {
-    busio_uart_obj_t *self = self_in;
+    busio_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_uart_deinited(self));
     mp_uint_t ret;
     if (request == MP_IOCTL_POLL) {
         mp_uint_t flags = arg;

--- a/shared-bindings/busio/UART.h
+++ b/shared-bindings/busio/UART.h
@@ -45,6 +45,7 @@ extern void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     uint8_t receiver_buffer_size);
 
 extern void common_hal_busio_uart_deinit(busio_uart_obj_t *self);
+extern bool common_hal_busio_uart_deinited(busio_uart_obj_t *self);
 
 // Read characters. len is in characters NOT bytes!
 extern size_t common_hal_busio_uart_read(busio_uart_obj_t *self,

--- a/shared-bindings/digitalio/DigitalInOut.c
+++ b/shared-bindings/digitalio/DigitalInOut.c
@@ -40,6 +40,7 @@
 #include "shared-bindings/digitalio/Direction.h"
 #include "shared-bindings/digitalio/DriveMode.h"
 #include "shared-bindings/digitalio/Pull.h"
+#include "shared-bindings/util.h"
 
 //| .. currentmodule:: digitalio
 //|
@@ -119,6 +120,7 @@ STATIC mp_obj_t digitalio_digitalinout_switch_to_output(size_t n_args, const mp_
         { MP_QSTR_drive_mode, MP_ARG_OBJ, {.u_rom_obj = &digitalio_drive_mode_push_pull_obj} },
     };
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(self));
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
@@ -155,6 +157,7 @@ STATIC mp_obj_t digitalio_digitalinout_switch_to_input(size_t n_args, const mp_o
         { MP_QSTR_pull, MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
     };
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(self));
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
@@ -187,6 +190,7 @@ extern const digitalio_digitalio_direction_obj_t digitalio_digitalio_direction_o
 
 STATIC mp_obj_t digitalio_digitalinout_obj_get_direction(mp_obj_t self_in) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(self));
     enum digitalio_direction_t direction = common_hal_digitalio_digitalinout_get_direction(self);
     if (direction == DIRECTION_INPUT) {
         return (mp_obj_t)&digitalio_direction_input_obj;
@@ -197,6 +201,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(digitalio_digitalinout_get_direction_obj, digitalio_di
 
 STATIC mp_obj_t digitalio_digitalinout_obj_set_direction(mp_obj_t self_in, mp_obj_t value) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(self));
     if (value == &digitalio_direction_input_obj) {
         common_hal_digitalio_digitalinout_switch_to_input(self, PULL_NONE);
     } else if (value == &digitalio_direction_output_obj) {
@@ -221,6 +226,7 @@ const mp_obj_property_t digitalio_digitalio_direction_obj = {
 //|
 STATIC mp_obj_t digitalio_digitalinout_obj_get_value(mp_obj_t self_in) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(self));
     bool value = common_hal_digitalio_digitalinout_get_value(self);
     return mp_obj_new_bool(value);
 }
@@ -228,6 +234,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(digitalio_digitalinout_get_value_obj, digitalio_digita
 
 STATIC mp_obj_t digitalio_digitalinout_obj_set_value(mp_obj_t self_in, mp_obj_t value) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(self));
     if (common_hal_digitalio_digitalinout_get_direction(self) == DIRECTION_INPUT) {
         mp_raise_AttributeError("Cannot set value when direction is input.");
         return mp_const_none;
@@ -250,6 +257,7 @@ const mp_obj_property_t digitalio_digitalinout_value_obj = {
 //|
 STATIC mp_obj_t digitalio_digitalinout_obj_get_drive_mode(mp_obj_t self_in) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(self));
     if (common_hal_digitalio_digitalinout_get_direction(self) == DIRECTION_INPUT) {
         mp_raise_AttributeError("Drive mode not used when direction is input.");
         return mp_const_none;
@@ -264,6 +272,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(digitalio_digitalinout_get_drive_mode_obj, digitalio_d
 
 STATIC mp_obj_t digitalio_digitalinout_obj_set_drive_mode(mp_obj_t self_in, mp_obj_t drive_mode) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(self));
     if (common_hal_digitalio_digitalinout_get_direction(self) == DIRECTION_INPUT) {
         mp_raise_AttributeError("Drive mode not used when direction is input.");
         return mp_const_none;
@@ -293,6 +302,7 @@ const mp_obj_property_t digitalio_digitalio_drive_mode_obj = {
 //|
 STATIC mp_obj_t digitalio_digitalinout_obj_get_pull(mp_obj_t self_in) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(self));
     if (common_hal_digitalio_digitalinout_get_direction(self) == DIRECTION_OUTPUT) {
         mp_raise_AttributeError("Pull not used when direction is output.");
         return mp_const_none;
@@ -309,6 +319,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(digitalio_digitalinout_get_pull_obj, digitalio_digital
 
 STATIC mp_obj_t digitalio_digitalinout_obj_set_pull(mp_obj_t self_in, mp_obj_t pull_obj) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(self));
     if (common_hal_digitalio_digitalinout_get_direction(self) == DIRECTION_OUTPUT) {
         mp_raise_AttributeError("Pull not used when direction is output.");
         return mp_const_none;

--- a/shared-bindings/digitalio/DigitalInOut.h
+++ b/shared-bindings/digitalio/DigitalInOut.h
@@ -42,6 +42,7 @@ typedef enum {
 
 digitalinout_result_t common_hal_digitalio_digitalinout_construct(digitalio_digitalinout_obj_t* self, const mcu_pin_obj_t* pin);
 void common_hal_digitalio_digitalinout_deinit(digitalio_digitalinout_obj_t* self);
+bool common_hal_digitalio_digitalinout_deinited(digitalio_digitalinout_obj_t* self);
 void common_hal_digitalio_digitalinout_switch_to_input(digitalio_digitalinout_obj_t* self, enum digitalio_pull_t pull);
 void common_hal_digitalio_digitalinout_switch_to_output(digitalio_digitalinout_obj_t* self, bool value, enum digitalio_drive_mode_t drive_mode);
 enum digitalio_direction_t common_hal_digitalio_digitalinout_get_direction(digitalio_digitalinout_obj_t* self);

--- a/shared-bindings/pulseio/PWMOut.c
+++ b/shared-bindings/pulseio/PWMOut.c
@@ -29,8 +29,10 @@
 #include "lib/utils/context_manager_helpers.h"
 #include "py/objproperty.h"
 #include "py/runtime.h"
+
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/pulseio/PWMOut.h"
+#include "shared-bindings/util.h"
 
 //| .. currentmodule:: pulseio
 //|
@@ -147,13 +149,15 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pulseio_pwmout___exit___obj, 4, 4, pu
 //|      (0). 0xffff will always be high, 0 will always be low and 0x7fff will
 //|      be half high and then half low.
 STATIC mp_obj_t pulseio_pwmout_obj_get_duty_cycle(mp_obj_t self_in) {
-   pulseio_pwmout_obj_t *self = MP_OBJ_TO_PTR(self_in);
-   return MP_OBJ_NEW_SMALL_INT(common_hal_pulseio_pwmout_get_duty_cycle(self));
+    pulseio_pwmout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_pwmout_deinited(self));
+    return MP_OBJ_NEW_SMALL_INT(common_hal_pulseio_pwmout_get_duty_cycle(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pulseio_pwmout_get_duty_cycle_obj, pulseio_pwmout_obj_get_duty_cycle);
 
 STATIC mp_obj_t pulseio_pwmout_obj_set_duty_cycle(mp_obj_t self_in, mp_obj_t duty_cycle) {
     pulseio_pwmout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_pwmout_deinited(self));
     mp_int_t duty = mp_obj_get_int(duty_cycle);
     if (duty < 0 || duty > 0xffff) {
         mp_raise_ValueError("PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)");
@@ -176,13 +180,15 @@ const mp_obj_property_t pulseio_pwmout_duty_cycle_obj = {
 //|     second). Only writeable when constructed with ``variable_frequency=True``.
 //|
 STATIC mp_obj_t pulseio_pwmout_obj_get_frequency(mp_obj_t self_in) {
-   pulseio_pwmout_obj_t *self = MP_OBJ_TO_PTR(self_in);
-   return MP_OBJ_NEW_SMALL_INT(common_hal_pulseio_pwmout_get_frequency(self));
+    pulseio_pwmout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_pwmout_deinited(self));
+    return MP_OBJ_NEW_SMALL_INT(common_hal_pulseio_pwmout_get_frequency(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pulseio_pwmout_get_frequency_obj, pulseio_pwmout_obj_get_frequency);
 
 STATIC mp_obj_t pulseio_pwmout_obj_set_frequency(mp_obj_t self_in, mp_obj_t frequency) {
     pulseio_pwmout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_pwmout_deinited(self));
     if (!common_hal_pulseio_pwmout_get_variable_frequency(self)) {
         mp_raise_AttributeError(
             "PWM frequency not writeable when variable_frequency is False on "

--- a/shared-bindings/pulseio/PWMOut.h
+++ b/shared-bindings/pulseio/PWMOut.h
@@ -36,6 +36,7 @@ extern void common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self,
     const mcu_pin_obj_t* pin, uint16_t duty, uint32_t frequency,
     bool variable_frequency);
 extern void common_hal_pulseio_pwmout_deinit(pulseio_pwmout_obj_t* self);
+extern bool common_hal_pulseio_pwmout_deinited(pulseio_pwmout_obj_t* self);
 extern void common_hal_pulseio_pwmout_set_duty_cycle(pulseio_pwmout_obj_t* self, uint16_t duty);
 extern uint16_t common_hal_pulseio_pwmout_get_duty_cycle(pulseio_pwmout_obj_t* self);
 extern void common_hal_pulseio_pwmout_set_frequency(pulseio_pwmout_obj_t* self, uint32_t frequency);

--- a/shared-bindings/pulseio/PulseIn.c
+++ b/shared-bindings/pulseio/PulseIn.c
@@ -32,6 +32,7 @@
 #include "py/runtime0.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/pulseio/PulseIn.h"
+#include "shared-bindings/util.h"
 
 //| .. currentmodule:: pulseio
 //|
@@ -139,6 +140,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pulseio_pulsein___exit___obj, 4, 4, p
 //|
 STATIC mp_obj_t pulseio_pulsein_obj_pause(mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_pulsein_deinited(self));
 
     common_hal_pulseio_pulsein_pause(self);
     return mp_const_none;
@@ -162,6 +164,8 @@ STATIC mp_obj_t pulseio_pulsein_obj_resume(size_t n_args, const mp_obj_t *pos_ar
         { MP_QSTR_trigger_duration, MP_ARG_INT, {.u_int = 0} },
     };
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    raise_error_if_deinited(common_hal_pulseio_pulsein_deinited(self));
+
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
@@ -176,6 +180,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(pulseio_pulsein_resume_obj, 1, pulseio_pulsein_obj_re
 //|
 STATIC mp_obj_t pulseio_pulsein_obj_clear(mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_pulsein_deinited(self));
 
     common_hal_pulseio_pulsein_clear(self);
     return mp_const_none;
@@ -188,6 +193,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(pulseio_pulsein_clear_obj, pulseio_pulsein_obj_clear);
 //|
 STATIC mp_obj_t pulseio_pulsein_obj_popleft(mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_pulsein_deinited(self));
+
     return MP_OBJ_NEW_SMALL_INT(common_hal_pulseio_pulsein_popleft(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pulseio_pulsein_popleft_obj, pulseio_pulsein_obj_popleft);
@@ -199,6 +206,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(pulseio_pulsein_popleft_obj, pulseio_pulsein_obj_pople
 //|
 STATIC mp_obj_t pulseio_pulsein_obj_get_maxlen(mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_pulsein_deinited(self));
+
     return MP_OBJ_NEW_SMALL_INT(common_hal_pulseio_pulsein_get_maxlen(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(pulseio_pulsein_get_maxlen_obj, pulseio_pulsein_obj_get_maxlen);
@@ -221,6 +230,7 @@ const mp_obj_property_t pulseio_pulsein_maxlen_obj = {
 //|
 STATIC mp_obj_t pulsein_unary_op(mp_uint_t op, mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_pulsein_deinited(self));
     uint16_t len = common_hal_pulseio_pulsein_get_len(self);
     switch (op) {
         case MP_UNARY_OP_BOOL: return mp_obj_new_bool(len != 0);
@@ -244,6 +254,8 @@ STATIC mp_obj_t pulsein_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t va
         mp_raise_AttributeError("Cannot delete values");
     } else {
         pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
+        raise_error_if_deinited(common_hal_pulseio_pulsein_deinited(self));
+
         if (MP_OBJ_IS_TYPE(index_obj, &mp_type_slice)) {
             mp_raise_NotImplementedError("Slices not supported");
         } else {

--- a/shared-bindings/pulseio/PulseIn.h
+++ b/shared-bindings/pulseio/PulseIn.h
@@ -35,6 +35,7 @@ extern const mp_obj_type_t pulseio_pulsein_type;
 extern void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
     const mcu_pin_obj_t* pin, uint16_t maxlen, bool idle_state);
 extern void common_hal_pulseio_pulsein_deinit(pulseio_pulsein_obj_t* self);
+extern bool common_hal_pulseio_pulsein_deinited(pulseio_pulsein_obj_t* self);
 extern void common_hal_pulseio_pulsein_pause(pulseio_pulsein_obj_t* self);
 extern void common_hal_pulseio_pulsein_resume(pulseio_pulsein_obj_t* self, uint16_t trigger_duration);
 extern void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t* self);

--- a/shared-bindings/pulseio/PulseOut.c
+++ b/shared-bindings/pulseio/PulseOut.c
@@ -29,9 +29,11 @@
 #include "lib/utils/context_manager_helpers.h"
 #include "py/objproperty.h"
 #include "py/runtime.h"
+
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/pulseio/PulseOut.h"
 #include "shared-bindings/pulseio/PWMOut.h"
+#include "shared-bindings/util.h"
 
 //| .. currentmodule:: pulseio
 //|
@@ -123,6 +125,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pulseio_pulseout___exit___obj, 4, 4, 
 //|
 STATIC mp_obj_t pulseio_pulseout_obj_send(mp_obj_t self_in, mp_obj_t pulses) {
     pulseio_pulseout_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_pulseout_deinited(self));
 
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(pulses, &bufinfo, MP_BUFFER_READ);

--- a/shared-bindings/pulseio/PulseOut.h
+++ b/shared-bindings/pulseio/PulseOut.h
@@ -36,6 +36,7 @@ extern const mp_obj_type_t pulseio_pulseout_type;
 extern void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
     const pulseio_pwmout_obj_t* carrier);
 extern void common_hal_pulseio_pulseout_deinit(pulseio_pulseout_obj_t* self);
+extern bool common_hal_pulseio_pulseout_deinited(pulseio_pulseout_obj_t* self);
 extern void common_hal_pulseio_pulseout_send(pulseio_pulseout_obj_t* self,
     uint16_t* pulses, uint16_t len);
 

--- a/shared-bindings/touchio/TouchIn.c
+++ b/shared-bindings/touchio/TouchIn.c
@@ -35,6 +35,7 @@
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/touchio/TouchIn.h"
+#include "shared-bindings/util.h"
 
 //| .. currentmodule:: touchio
 //|
@@ -113,8 +114,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(touchio_touchin___exit___obj, 4, 4, t
 //|     :rtype: bool
 //|
 STATIC mp_obj_t touchio_touchin_obj_get_value(mp_obj_t self_in) {
-   touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-   return mp_obj_new_bool(common_hal_touchio_touchin_get_value(self));
+    touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_touchio_touchin_deinited(self));
+    return mp_obj_new_bool(common_hal_touchio_touchin_get_value(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(touchio_touchin_get_value_obj, touchio_touchin_obj_get_value);
 
@@ -134,17 +136,18 @@ const mp_obj_property_t touchio_touchin_value_obj = {
 //|     :rtype: int
 //|
 STATIC mp_obj_t touchio_touchin_obj_get_raw_value(mp_obj_t self_in) {
-	touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-	return MP_OBJ_NEW_SMALL_INT(common_hal_touchio_touchin_get_raw_value(self));
+    touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_touchio_touchin_deinited(self));
+    return MP_OBJ_NEW_SMALL_INT(common_hal_touchio_touchin_get_raw_value(self));
 }
 
 MP_DEFINE_CONST_FUN_OBJ_1(touchio_touchin_get_raw_value_obj, touchio_touchin_obj_get_raw_value);
 
 const mp_obj_property_t touchio_touchin_raw_value_obj = {
-	.base.type = &mp_type_property,
-	.proxy = {(mp_obj_t)&touchio_touchin_get_raw_value_obj,
-                  (mp_obj_t)&mp_const_none_obj,
-                  (mp_obj_t)&mp_const_none_obj},
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&touchio_touchin_get_raw_value_obj,
+              (mp_obj_t)&mp_const_none_obj,
+              (mp_obj_t)&mp_const_none_obj},
  };
 
 
@@ -160,31 +163,33 @@ const mp_obj_property_t touchio_touchin_raw_value_obj = {
 //|     :rtype: int
 //|
 STATIC mp_obj_t touchio_touchin_obj_get_threshold(mp_obj_t self_in) {
-	touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-	return MP_OBJ_NEW_SMALL_INT(common_hal_touchio_touchin_get_threshold(self));
+    touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_touchio_touchin_deinited(self));
+    return MP_OBJ_NEW_SMALL_INT(common_hal_touchio_touchin_get_threshold(self));
 }
 
 MP_DEFINE_CONST_FUN_OBJ_1(touchio_touchin_get_threshold_obj, touchio_touchin_obj_get_threshold);
 
 STATIC mp_obj_t touchio_touchin_obj_set_threshold(mp_obj_t self_in, mp_obj_t threshold_obj) {
-	touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-        uint32_t new_threshold = mp_obj_get_int(threshold_obj);
-        if (new_threshold < 0 || new_threshold > UINT16_MAX) {
-            // I would use MP_STRINGIFY(UINT16_MAX), but that prints "0xffff" instead of 65536.
-            mp_raise_ValueError("threshold must be in the range 0-65536");
-        }
-	common_hal_touchio_touchin_set_threshold(self, new_threshold);
-        return mp_const_none;
+    touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_touchio_touchin_deinited(self));
+    uint32_t new_threshold = mp_obj_get_int(threshold_obj);
+    if (new_threshold < 0 || new_threshold > UINT16_MAX) {
+        // I would use MP_STRINGIFY(UINT16_MAX), but that prints "0xffff" instead of 65536.
+        mp_raise_ValueError("threshold must be in the range 0-65536");
+    }
+    common_hal_touchio_touchin_set_threshold(self, new_threshold);
+    return mp_const_none;
 }
 
 MP_DEFINE_CONST_FUN_OBJ_2(touchio_touchin_set_threshold_obj, touchio_touchin_obj_set_threshold);
 
 const mp_obj_property_t touchio_touchin_threshold_obj = {
-	.base.type = &mp_type_property,
-	.proxy = {(mp_obj_t)&touchio_touchin_get_threshold_obj,
-                  (mp_obj_t)&touchio_touchin_set_threshold_obj,
-                  (mp_obj_t)&mp_const_none_obj},
- };
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&touchio_touchin_get_threshold_obj,
+              (mp_obj_t)&touchio_touchin_set_threshold_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
 
 
 STATIC const mp_rom_map_elem_t touchio_touchin_locals_dict_table[] = {

--- a/shared-bindings/touchio/TouchIn.h
+++ b/shared-bindings/touchio/TouchIn.h
@@ -34,6 +34,7 @@ extern const mp_obj_type_t touchio_touchin_type;
 
 void common_hal_touchio_touchin_construct(touchio_touchin_obj_t* self, const mcu_pin_obj_t *pin);
 void common_hal_touchio_touchin_deinit(touchio_touchin_obj_t* self);
+bool common_hal_touchio_touchin_deinited(touchio_touchin_obj_t* self);
 bool common_hal_touchio_touchin_get_value(touchio_touchin_obj_t *self);
 uint16_t common_hal_touchio_touchin_get_raw_value(touchio_touchin_obj_t *self);
 uint16_t common_hal_touchio_touchin_get_threshold(touchio_touchin_obj_t *self);

--- a/shared-bindings/util.c
+++ b/shared-bindings/util.c
@@ -1,9 +1,9 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013, 2014 Damien P. George
+ * Copyright (c) 2017 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,19 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
-#include <stdint.h>
-#include <string.h>
+#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_UTIL_H
+#define MICROPY_INCLUDED_SHARED_BINDINGS_UTIL_H
 
 #include "py/runtime.h"
 
-#include "shared-bindings/analogio/AnalogOut.h"
+#include "shared-bindings/util.h"
 
-void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self,
-        const mcu_pin_obj_t *pin) {
-    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError,
-        "No hardware support for analog out."));
+// Check if pin is None. If so, deinit() has already been called on the object, so complain.
+void raise_error_if_deinited(bool deinited) {
+    if (deinited) {
+        mp_raise_ValueError("Object has been deinitialized and can no longer be used. Create a new object.");
+    }
 }
 
-bool common_hal_analogio_analogout_deinited(analogio_analogout_obj_t *self) {
-    return true;
-}
 
-void common_hal_analogio_analogout_deinit(analogio_analogout_obj_t *self) {
-}
-
-void common_hal_analogio_analogout_set_value(analogio_analogout_obj_t *self,
-        uint16_t value) {
-}
+#endif // MICROPY_INCLUDED_SHARED_BINDINGS_UTIL_H

--- a/shared-bindings/util.h
+++ b/shared-bindings/util.h
@@ -1,9 +1,9 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013, 2014 Damien P. George
+ * Copyright (c) 2017 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,27 +24,10 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
-#include <stdint.h>
-#include <string.h>
+#ifndef MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_UTIL_H
+#define MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_UTIL_H
 
-#include "py/runtime.h"
+void raise_error_if_deinited(bool deinited);
 
-#include "shared-bindings/analogio/AnalogOut.h"
 
-void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self,
-        const mcu_pin_obj_t *pin) {
-    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError,
-        "No hardware support for analog out."));
-}
-
-bool common_hal_analogio_analogout_deinited(analogio_analogout_obj_t *self) {
-    return true;
-}
-
-void common_hal_analogio_analogout_deinit(analogio_analogout_obj_t *self) {
-}
-
-void common_hal_analogio_analogout_set_value(analogio_analogout_obj_t *self,
-        uint16_t value) {
-}
+#endif // MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_UTIL_H

--- a/shared-module/bitbangio/I2C.c
+++ b/shared-module/bitbangio/I2C.c
@@ -162,7 +162,15 @@ void shared_module_bitbangio_i2c_construct(bitbangio_i2c_obj_t *self,
     stop(self);
 }
 
+bool shared_module_bitbangio_i2c_deinited(bitbangio_i2c_obj_t *self) {
+    // If one is deinited, both will be.
+    return common_hal_digitalio_digitalinout_deinited(&self->scl);
+}
+
 void shared_module_bitbangio_i2c_deinit(bitbangio_i2c_obj_t *self) {
+    if (shared_module_bitbangio_i2c_deinited(self)) {
+        return;
+    }
     common_hal_digitalio_digitalinout_deinit(&self->scl);
     common_hal_digitalio_digitalinout_deinit(&self->sda);
 }

--- a/shared-module/bitbangio/OneWire.c
+++ b/shared-module/bitbangio/OneWire.c
@@ -38,7 +38,14 @@ void shared_module_bitbangio_onewire_construct(bitbangio_onewire_obj_t* self,
     common_hal_digitalio_digitalinout_construct(&self->pin, pin);
 }
 
+bool shared_module_bitbangio_onewire_deinited(bitbangio_onewire_obj_t* self) {
+    return common_hal_digitalio_digitalinout_deinited(&self->pin);
+}
+
 void shared_module_bitbangio_onewire_deinit(bitbangio_onewire_obj_t* self) {
+    if (shared_module_bitbangio_onewire_deinited(self)) {
+        return;
+    }
     common_hal_digitalio_digitalinout_deinit(&self->pin);
 }
 

--- a/shared-module/bitbangio/SPI.c
+++ b/shared-module/bitbangio/SPI.c
@@ -70,7 +70,14 @@ void shared_module_bitbangio_spi_construct(bitbangio_spi_obj_t *self,
     self->phase = 0;
 }
 
+bool shared_module_bitbangio_spi_deinited(bitbangio_spi_obj_t *self) {
+    return common_hal_digitalio_digitalinout_deinited(&self->clock);
+}
+
 void shared_module_bitbangio_spi_deinit(bitbangio_spi_obj_t *self) {
+    if (shared_module_bitbangio_spi_deinited(self)) {
+        return;
+    }
     common_hal_digitalio_digitalinout_deinit(&self->clock);
     if (self->has_mosi) {
         common_hal_digitalio_digitalinout_deinit(&self->mosi);

--- a/shared-module/busio/I2C.c
+++ b/shared-module/busio/I2C.c
@@ -34,6 +34,10 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     shared_module_bitbangio_i2c_construct(&self->bitbang, scl, sda, freq);
 }
 
+bool common_hal_busio_i2c_deinited(busio_i2c_obj_t *self) {
+    return shared_module_bitbangio_i2c_deinited(&self->bitbang);
+}
+
 void common_hal_busio_i2c_deinit(busio_i2c_obj_t *self) {
     shared_module_bitbangio_i2c_deinit(&self->bitbang);
 }

--- a/shared-module/busio/OneWire.c
+++ b/shared-module/busio/OneWire.c
@@ -34,7 +34,14 @@ void common_hal_busio_onewire_construct(busio_onewire_obj_t* self,
     shared_module_bitbangio_onewire_construct(&self->bitbang, pin);
 }
 
+bool common_hal_busio_onewire_deinited(busio_onewire_obj_t* self) {
+    return shared_module_bitbangio_onewire_deinited(&self->bitbang);
+}
+
 void common_hal_busio_onewire_deinit(busio_onewire_obj_t* self) {
+    if (common_hal_busio_onewire_deinited(self)) {
+        return;
+    }
     shared_module_bitbangio_onewire_deinit(&self->bitbang);
 }
 


### PR DESCRIPTION
Fixes #278, #277, #276, #275.

Had to reduce `-ifinline-limit` to almost the minimum to get this to fit on non-Express boards.
Enhanced Makefile so that `-finline-limit` is not used on Express boards.

Tested by hand in a straightfoward way for the various *io modules on both `atmel-samd` and `esp8266`. `analogio` and `digitalio` were tested electrically as well (with a voltmeter). Speaker output and mic input on CPX also checked.