### PR TITLE
Suppress A0 (PA02) as a TouchIn-capable pin on CPX.

### DIFF
--- a/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+++ b/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
@@ -3,6 +3,9 @@
 #define MICROPY_HW_BOARD_NAME "Adafruit CircuitPlayground Express"
 #define MICROPY_HW_MCU_NAME "samd21g18"
 
+// Don't allow touch on A0 (PA02), because it's connected to the speaker.
+#define PA02_NO_TOUCH       (true)
+
 // Salae reads 12mhz which is the limit even though we set it to the safer 8mhz.
 #define SPI_FLASH_BAUDRATE  (8000000)
 

--- a/atmel-samd/samd21_pins.c
+++ b/atmel-samd/samd21_pins.c
@@ -84,7 +84,13 @@ PIN(PA01, EXTINT_CHANNEL(1), NO_ADC, NO_TOUCH,
     SERCOM(SERCOM1, 1));
 #endif
 #ifdef PIN_PA02
-PIN(PA02, EXTINT_CHANNEL(2), ADC_INPUT(ADC_POSITIVE_INPUT_PIN0), TOUCH(0),
+// Touch is not allowed on A0 (PA02) on Circuit Playground Express.
+PIN(PA02, EXTINT_CHANNEL(2), ADC_INPUT(ADC_POSITIVE_INPUT_PIN0),
+    #ifdef PA02_NO_TOUCH
+      NO_TOUCH,
+    #else
+      TOUCH(0),
+    #endif
     NO_TIMER,
     NO_TIMER,
     NO_SERCOM,


### PR DESCRIPTION
Maybe we need a better coding mechanism to do board-specific pin stuff in the long run.