### PR TITLE
esp8266: Correct SPI functionality when write_value is provided.

### DIFF
--- a/esp8266/common-hal/busio/SPI.c
+++ b/esp8266/common-hal/busio/SPI.c
@@ -174,13 +174,13 @@ bool common_hal_busio_spi_read(busio_spi_obj_t *self,
                                 write_value;
     for (size_t j = 0; j < count; ++j) {
         for (size_t k = 0; k < chunk_size; ++k) {
-            data[i] = spi_transaction(HSPI, 0, 0, 0, 0, 0, 0, 8, long_write_value);
+            data[i] = spi_transaction(HSPI, 0, 0, 0, 0, 8, long_write_value, 8, 0);
             ++i;
         }
         ets_loop_iter();
     }
     while (i < len) {
-        data[i] = spi_transaction(HSPI, 0, 0, 0, 0, 0, 0, 8, long_write_value);
+        data[i] = spi_transaction(HSPI, 0, 0, 0, 0, 8, long_write_value, 8, 0);
         ++i;
     }
     return true;


### PR DESCRIPTION
It used to introduce extra clocks to the bus rather than changing the
value output.

This fixes SD cards.