### PR TITLE
redo time.monotonic() to avoid double precision

### DIFF
--- a/atmel-samd/common-hal/digitalio/DigitalInOut.c
+++ b/atmel-samd/common-hal/digitalio/DigitalInOut.c
@@ -80,6 +80,9 @@ void common_hal_digitalio_digitalinout_switch_to_output(
     pin_conf.input_pull = PORT_PIN_PULL_NONE;
     port_pin_set_config(self->pin->pin, &pin_conf);
 
+    // Turn on "strong" pin driving (more current available). See DRVSTR doc in datasheet.
+    system_pinmux_pin_set_output_strength(self->pin->pin, SYSTEM_PINMUX_PIN_STRENGTH_HIGH);
+
     self->output = true;
     self->open_drain = drive_mode == DRIVE_MODE_OPEN_DRAIN;
     common_hal_digitalio_digitalinout_set_value(self, value);

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -52,7 +52,9 @@
 //|   :rtype: float
 //|
 STATIC mp_obj_t time_monotonic(void) {
-    return mp_obj_new_float(common_hal_time_monotonic() / 1000.0);
+    uint64_t time64 = common_hal_time_monotonic();
+    // 4294967296 = 2^32
+    return mp_obj_new_float(((uint32_t) (time64 >> 32) * 4294967296.0f + (uint32_t) (time64 & 0xffffffff)) / 1000.0f);
 }
 MP_DEFINE_CONST_FUN_OBJ_0(time_monotonic_obj, time_monotonic);
 


### PR DESCRIPTION
Gains back 3044 bytes! Framebuf would now fit in non-Express, with 56 bytes to spare, before any `-finline-limit` trickery. Implements #342.