### PR TITLE
atmel-samd: Switch Metro M4 Express to SAMD51J19.

### DIFF
--- a/atmel-samd/boards/metro_m4_express/mpconfigboard.h
+++ b/atmel-samd/boards/metro_m4_express/mpconfigboard.h
@@ -1,5 +1,5 @@
 #define MICROPY_HW_BOARD_NAME "Metro M4 Express"
-#define MICROPY_HW_MCU_NAME "samd51j20"
+#define MICROPY_HW_MCU_NAME "samd51j19"
 
 #define CIRCUITPY_MCU_FAMILY samd51
 
@@ -24,8 +24,6 @@
 #define MICROPY_PORT_B        (PORT_PB06 | PORT_PB08 | PORT_PB09 | PORT_PB11 | PORT_PB17)
 #define MICROPY_PORT_C        (0)
 #define MICROPY_PORT_D        (0)
-
-#define CONF_USB_COMPOSITE_CDC_ACM_EN 1
 
 #define AUTORESET_DELAY_MS 500
 

--- a/atmel-samd/boards/metro_m4_express/mpconfigboard.mk
+++ b/atmel-samd/boards/metro_m4_express/mpconfigboard.mk
@@ -1,9 +1,9 @@
-LD_FILE = boards/samd51x20-bootloader.ld
+LD_FILE = boards/samd51x19-bootloader.ld
 USB_VID = 0x239A
 USB_PID = 0x8015
 
 #FLASH_IMPL = spi_flash.c
 FLASH_IMPL = internal_flash.c
 
-CHIP_VARIANT = SAMD51J20A
+CHIP_VARIANT = SAMD51J19A
 CHIP_FAMILY = samd51

--- a/atmel-samd/boards/samd51x19-bootloader.ld
+++ b/atmel-samd/boards/samd51x19-bootloader.ld
@@ -1,0 +1,81 @@
+/*
+    GNU linker script for SAMD51
+*/
+
+/* Specify the memory areas */
+MEMORY
+{
+    FLASH (rx) : ORIGIN = 0x00000000 + 0x4000, LENGTH = 0x00080000 - 0x4000 - 0x00040000 /* Leave 16KiB for the bootloader and 256KiB for the internal file system. */
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x00030000 /* 192 KiB */
+}
+
+/* top end of the stack */
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+/* define output sections */
+SECTIONS
+{
+    /* The program code and other data goes into FLASH */
+    .text :
+    {
+        . = ALIGN(4);
+        _sfixed = .;
+        KEEP(*(.vectors)) /* isr vector table */
+        *(.text)           /* .text sections (code) */
+        *(.text*)          /* .text* sections (code) */
+        *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+
+        . = ALIGN(4);
+        _etext = .;        /* define a global symbol at end of code */
+    } >FLASH
+
+    .ARM.exidx :
+    {
+        *(.ARM.exidx*)
+        *(.gnu.linkonce.armexidx.*)
+        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+    } > FLASH
+
+    /* This is the initialized data section
+    The program executes knowing that the data is in the RAM
+    but the loader puts the initial values in the FLASH (inidata).
+    It is one task of the startup to copy the initial values from FLASH to RAM. */
+    .data : AT ( _sidata )
+    {
+        . = ALIGN(4);
+        _srelocate = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
+        *(.ramfunc)
+        *(.ramfunc*)
+        *(.data)           /* .data sections */
+        *(.data*)          /* .data* sections */
+
+        . = ALIGN(4);
+        _erelocate = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
+    } >RAM
+
+    /* Uninitialized data section */
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        _szero = .;         /* define a global symbol at bss start; used by startup code */
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+
+        . = ALIGN(4);
+        _ezero = .;         /* define a global symbol at bss end; used by startup code */
+        _ebss = .;
+    } >RAM
+
+    /* this just checks there is enough RAM for a minimal stack */
+    .stack :
+    {
+        . = ALIGN(4);
+        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = ALIGN(4);
+    } >RAM
+
+    .ARM.attributes 0 : { *(.ARM.attributes) }
+}


### PR DESCRIPTION
The CDC removal is unrelated cleanup I spotted as doing this. Its redundant to mpconfigport.h where I moved it.