### PR TITLE
Gracefully reset the gamepad module

### DIFF
--- a/atmel-samd/main.c
+++ b/atmel-samd/main.c
@@ -61,6 +61,7 @@
 #include "common-hal/pulseio/PWMOut.h"
 #include "common-hal/touchio/TouchIn.h"
 #include "common-hal/usb_hid/__init__.h"
+#include "shared-module/gamepad/__init__.h"
 
 #include "autoreload.h"
 #include "flash_api.h"
@@ -202,6 +203,9 @@ void reset_samd21(void) {
     pwmout_reset();
     analogin_reset();
 
+#ifdef CIRCUITPY_GAMEPAD_TICKS
+    gamepad_reset();
+#endif
 
     // TODO: move this to analogout_reset()
     // Wait for the DAC to sync then reset.

--- a/shared-module/gamepad/__init__.c
+++ b/shared-module/gamepad/__init__.c
@@ -49,3 +49,7 @@ void gamepad_tick(void) {
     gamepad_singleton->pressed |= gamepad_singleton->last & gamepad_current;
     gamepad_singleton->last = gamepad_current;
 }
+
+void gamepad_reset(void) {
+    gamepad_singleton = NULL;
+}

--- a/shared-module/gamepad/__init__.h
+++ b/shared-module/gamepad/__init__.h
@@ -28,5 +28,6 @@
 #define MICROPY_INCLUDED_GAMEPAD_H
 
 void gamepad_tick(void);
+void gamepad_reset(void);
 
 #endif  // MICROPY_INCLUDED_GAMEPAD_H


### PR DESCRIPTION
If a soft reset happens while the gamepad module is scanning for button
presses, there is a moment when the pins get de-initialized, but the
gamepad module is still trying to read them, which ends in a crash.
We can avoid it by disabling scanning on reset.