### PR TITLE
Gracefully reset the gamepad module

### DIFF
--- a/atmel-samd/supervisor/port.c
+++ b/atmel-samd/supervisor/port.c
@@ -193,6 +193,9 @@ void reset_port(void) {
 //
 //     analogin_reset();
 //
+// #ifdef CIRCUITPY_GAMEPAD_TICKS
+//     gamepad_reset();
+// #endif
 //
 //     // Wait for the DAC to sync then reset.
 //     while (DAC->STATUS.reg & DAC_STATUS_SYNCBUSY) {}

--- a/shared-module/gamepad/__init__.c
+++ b/shared-module/gamepad/__init__.c
@@ -49,3 +49,7 @@ void gamepad_tick(void) {
     gamepad_singleton->pressed |= gamepad_singleton->last & gamepad_current;
     gamepad_singleton->last = gamepad_current;
 }
+
+void gamepad_reset(void) {
+    gamepad_singleton = NULL;
+}

--- a/shared-module/gamepad/__init__.h
+++ b/shared-module/gamepad/__init__.h
@@ -28,5 +28,6 @@
 #define MICROPY_INCLUDED_GAMEPAD_H
 
 void gamepad_tick(void);
+void gamepad_reset(void);
 
 #endif  // MICROPY_INCLUDED_GAMEPAD_H


### PR DESCRIPTION
If a soft reset happens while the gamepad module is scanning for button
presses, there is a moment when the pins get de-initialized, but the
gamepad module is still trying to read them, which ends in a crash.
We can avoid it by disabling scanning on reset.

(cherry picked from commit 470a23d4c9345785bbaa830fdc036b4e982496c6)

Conflicts:
	atmel-samd/main.c