### PR TITLE
Allow main.py to be interrupted by ctrl-C

### DIFF
--- a/main.c
+++ b/main.c
@@ -127,6 +127,7 @@ bool start_mp(safe_mode_t safe_mode) {
 
     pyexec_result_t result;
     bool found_main = false;
+
     if (safe_mode != NO_SAFE_MODE) {
         serial_write(MSG_SAFE_MODE_NO_MAIN);
     } else {

--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -238,10 +238,10 @@ SRC_C = \
 # Choose which flash filesystem impl to use.
 # (Right now INTERNAL_FLASH_FILESYSTEM and SPI_FLASH_FILESYSTEM are mutually exclusive.
 # But that might not be true in the future.)
-ifdef INTERNAL_FLASH_FILESYSTEM
+ifeq ($(INTERNAL_FLASH_FILESYSTEM),1)
 SRC_C += internal_flash.c
 endif
-ifdef SPI_FLASH_FILESYSTEM
+ifeq ($(SPI_FLASH_FILESYSTEM),1)
 SRC_C += spi_flash.c
 endif
 
@@ -278,7 +278,7 @@ SRC_COMMON_HAL = \
 	usb_hid/__init__.c \
 	usb_hid/Device.c
 
-ifdef INTERNAL_LIBM
+ifeq ($(INTERNAL_LIBM),1)
 SRC_LIBM = $(addprefix lib/,\
 	libm/math.c \
 	libm/fmodf.c \
@@ -338,7 +338,7 @@ OBJ = $(PY_O) $(SUPERVISOR_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_ASF:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_COMMON_HAL_EXPANDED:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_SHARED_MODULE_EXPANDED:.c=.o))
-ifdef INTERNAL_LIBM
+ifeq ($(INTERNAL_LIBM),1)
 OBJ += $(addprefix $(BUILD)/, $(SRC_LIBM:.c=.o))
 endif
 

--- a/ports/atmel-samd/background.c
+++ b/ports/atmel-samd/background.c
@@ -26,9 +26,11 @@
 #include "background.h"
 
 // #include "common-hal/audioio/AudioOut.h"
+#include "usb.h"
 #include "usb_mass_storage.h"
 
 void run_background_tasks(void) {
     // audioout_background();
     usb_msc_background();
+    usb_cdc_background();
 }

--- a/ports/atmel-samd/mpconfigport.mk
+++ b/ports/atmel-samd/mpconfigport.mk
@@ -3,5 +3,5 @@
 # This should correspond to the MICROPY_LONGINT_IMPL definition in mpconfigport.h.
 MPY_TOOL_LONGINT_IMPL = -mlongint-impl=none
 
-INTERNAL_LIBM = (1)
+INTERNAL_LIBM = 1
 

--- a/ports/atmel-samd/usb.h
+++ b/ports/atmel-samd/usb.h
@@ -37,5 +37,6 @@ int usb_read(void);
 void usb_write(const char* buffer, uint32_t len);
 bool usb_bytes_available(void);
 bool usb_connected(void);
+void usb_cdc_background(void);
 
 #endif  // __MICROPY_INCLUDED_ATMEL_SAMD_USB_H__


### PR DESCRIPTION
Read USB input as a background task when the interrupt character is enabled. The interrupt character is already handled in the course of doing input. All input is flushed when interrupt character is read, and a `KeyboardInterrupt` exception is raised at the next safe time. 

Tested on Metro M0 under Linux: `main.py` contains a blinky program
Reset board. Enter repl. Type ctrl-C.

Not tested on MacOS.

This works most of the time. When it doesn't work, it appears to be because there's something messed up about the device on the Linux side, and not an issue with CDC on the board side. A unplug/replug seems to fix. This may be fixed by the descriptor fixes @tannewt  is working on.