### PR TITLE
atmel-samd: Add empty line for RST docs

### DIFF
--- a/shared-bindings/struct/__init__.c
+++ b/shared-bindings/struct/__init__.c
@@ -52,6 +52,7 @@
 //|
 //| Supported format codes: *b*, *B*, *h*, *H*, *i*, *I*, *l*, *L*, *q*, *Q*,
 //| *s*, *P*, *f*, *d* (the latter 2 depending on the floating-point support).
+//|
 
 
 //| .. function:: calcsize(fmt)


### PR DESCRIPTION
Right now calcsize is being grouped with the doc above: https://circuitpython.readthedocs.io/en/latest/shared-bindings/struct/__init__.html