### PR TITLE
py: Prevent crash with LTO.

### DIFF
--- a/py/runtime_utils.c
+++ b/py/runtime_utils.c
@@ -25,9 +25,10 @@
  * THE SOFTWARE.
  */
 
+#include "py/mpconfig.h"
 #include "py/runtime.h"
 
-void mp_call_function_1_protected(mp_obj_t fun, mp_obj_t arg) {
+MP_NOINLINE void mp_call_function_1_protected(mp_obj_t fun, mp_obj_t arg) {
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
         mp_call_function_1(fun, arg);


### PR DESCRIPTION
The protected single function call saves stack values and LTO
breaks the expectations of nlr_push and pop.