### PR TITLE
Add board definition for the uGame handheld console

### DIFF
--- a/atmel-samd/boards/ugame/board.c
+++ b/atmel-samd/boards/ugame/board.c
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "boards/board.h"
+
+void board_init(void) {
+}
+
+bool board_requests_safe_mode(void) {
+    return false;
+}
+
+void reset_board(void) {
+}

--- a/atmel-samd/boards/ugame/conf_access.h
+++ b/atmel-samd/boards/ugame/conf_access.h
@@ -1,0 +1,115 @@
+/**
+ * \file
+ *
+ * \brief Memory access control configuration file.
+ *
+ * Copyright (c) 2014-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _CONF_ACCESS_H_
+#define _CONF_ACCESS_H_
+
+#include "compiler.h"
+#include "board.h"
+
+
+/*! \name Activation of Logical Unit Numbers
+ */
+//! @{
+#define LUN_0                ENABLE    //!< On-Chip Virtual Memory.
+#define LUN_1                DISABLE   //!< AT45DBX Data Flash.
+#define LUN_2                DISABLE   //!< SD/MMC Card over SPI.
+#define LUN_3                DISABLE   //!< SD/MMC Card over MCI Slot 0.
+#define LUN_4                DISABLE
+#define LUN_5                DISABLE
+#define LUN_6                DISABLE
+#define LUN_7                DISABLE
+#define LUN_USB              DISABLE   //!< Host Mass-Storage Memory.
+//! @}
+
+/*! \name LUN 0 Definitions
+ */
+//! @{
+#define LUN_0_INCLUDE                           "access_vfs.h"
+#define Lun_0_test_unit_ready                   vfs_test_unit_ready
+#define Lun_0_read_capacity                     vfs_read_capacity
+#define Lun_0_unload                            NULL
+#define Lun_0_wr_protect                        vfs_wr_protect
+#define Lun_0_removal                           vfs_removal
+#define Lun_0_usb_read_10                       vfs_usb_read_10
+#define Lun_0_usb_write_10                      vfs_usb_write_10
+#define LUN_0_NAME                              "\"CircuitPython VFS[0]\""
+//! @}
+
+#define MEM_USB                                 LUN_USB
+
+/*! \name Actions Associated with Memory Accesses
+ *
+ * Write here the action to associate with each memory access.
+ *
+ * \warning Be careful not to waste time in order not to disturb the functions.
+ */
+//! @{
+#define memory_start_read_action(nb_sectors)
+#define memory_stop_read_action()
+#define memory_start_write_action(nb_sectors)
+#define memory_stop_write_action()
+//! @}
+
+/*! \name Activation of Interface Features
+ */
+//! @{
+#define ACCESS_USB           true    //!< MEM <-> USB interface.
+#define ACCESS_MEM_TO_RAM    false   //!< MEM <-> RAM interface.
+#define ACCESS_STREAM        false   //!< Streaming MEM <-> MEM interface.
+#define ACCESS_STREAM_RECORD false   //!< Streaming MEM <-> MEM interface in record mode.
+#define ACCESS_MEM_TO_MEM    false   //!< MEM <-> MEM interface.
+#define ACCESS_CODEC         false   //!< Codec interface.
+//! @}
+
+/*! \name Specific Options for Access Control
+ */
+//! @{
+#define GLOBAL_WR_PROTECT    false   //!< Management of a global write protection.
+//! @}
+
+
+#endif // _CONF_ACCESS_H_

--- a/atmel-samd/boards/ugame/conf_board.h
+++ b/atmel-samd/boards/ugame/conf_board.h
@@ -1,0 +1,14 @@
+/**
+ * \file
+ *
+ * \brief User board configuration template
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef CONF_BOARD_H
+#define CONF_BOARD_H
+
+#endif // CONF_BOARD_H

--- a/atmel-samd/boards/ugame/conf_clocks.h
+++ b/atmel-samd/boards/ugame/conf_clocks.h
@@ -1,0 +1,1 @@
+#include "conf_clocks_crystalless.h"

--- a/atmel-samd/boards/ugame/conf_usb.h
+++ b/atmel-samd/boards/ugame/conf_usb.h
@@ -1,0 +1,221 @@
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "asf/common/services/usb/class/cdc/usb_protocol_cdc.h"
+
+#ifndef CONF_USB_H_INCLUDED
+#define CONF_USB_H_INCLUDED
+
+#define  USB_DEVICE_MAJOR_VERSION         1
+#define  USB_DEVICE_MINOR_VERSION         0
+#define  USB_DEVICE_POWER                 100 // Consumption on Vbus line (mA)
+#define  USB_DEVICE_ATTR                  \
+	(USB_CONFIG_ATTR_BUS_POWERED)
+//	(USB_CONFIG_ATTR_REMOTE_WAKEUP|USB_CONFIG_ATTR_SELF_POWERED)
+//	(USB_CONFIG_ATTR_REMOTE_WAKEUP|USB_CONFIG_ATTR_BUS_POWERED)
+
+//! USB Device string definitions (Optional)
+#ifndef USB_DEVICE_MANUFACTURE_NAME
+#  define USB_DEVICE_MANUFACTURE_NAME "Radomir Dopieralski"
+#endif
+
+#ifndef USB_DEVICE_PRODUCT_NAME
+#  define USB_DEVICE_PRODUCT_NAME "uGame"
+#endif
+// #define  USB_DEVICE_SERIAL_NAME           "12...EF"
+#define  USB_DEVICE_GET_SERIAL_NAME_POINTER  serial_number
+#define  USB_DEVICE_GET_SERIAL_NAME_LENGTH   32
+extern char serial_number[USB_DEVICE_GET_SERIAL_NAME_LENGTH];
+
+//! Control endpoint size
+#define  USB_DEVICE_EP_CTRL_SIZE       64
+
+//! Interfaces for this device (CDC COM + CDC DATA + MSC + HID mouse + HID kbd)
+#define  USB_DEVICE_NB_INTERFACE       5
+
+// (3 | USB_EP_DIR_IN)  // CDC Notify endpoint
+// (4 | USB_EP_DIR_IN)  // CDC TX
+// (5 | USB_EP_DIR_OUT) // CDC RX
+// (1 | USB_EP_DIR_IN)  // MSC IN
+// (2 | USB_EP_DIR_OUT) // MSC OUT
+// (6 | USB_EP_DIR_IN)  // HID mouse report
+// (7 | USB_EP_DIR_IN)  // HID keyboard report
+#define  USB_DEVICE_MAX_EP           7
+
+#define UDI_CDC_PORT_NB 1
+#define UDI_CDC_ENABLE_EXT(port) mp_cdc_enable(port)
+extern bool mp_cdc_enable(uint8_t port);
+#define UDI_CDC_DISABLE_EXT(port) mp_cdc_disable(port)
+extern void mp_cdc_disable(uint8_t port);
+#define  UDI_CDC_LOW_RATE
+
+#define  UDI_CDC_DEFAULT_RATE             115200
+#define  UDI_CDC_DEFAULT_STOPBITS         CDC_STOP_BITS_1
+#define  UDI_CDC_DEFAULT_PARITY           CDC_PAR_NONE
+#define  UDI_CDC_DEFAULT_DATABITS         8
+
+#define  UDI_CDC_RX_NOTIFY(port)           usb_rx_notify()
+void usb_rx_notify(void);
+
+#define  UDI_CDC_SET_CODING_EXT(port,cfg) usb_coding_notify(port, cfg)
+void usb_coding_notify(uint8_t port, usb_cdc_line_coding_t* coding);
+#define  UDI_CDC_SET_DTR_EXT(port,set) usb_dtr_notify(port, set)
+void usb_dtr_notify(uint8_t port, bool set);
+#define  UDI_CDC_SET_RTS_EXT(port,set) usb_rts_notify(port, set)
+void usb_rts_notify(uint8_t port, bool set);
+
+/**
+ * USB CDC low level configuration
+ * In standalone these configurations are defined by the CDC module.
+ * For composite device, these configuration must be defined here
+ * @{
+ */
+//! Endpoint numbers definition
+
+#define  UDI_CDC_COMM_EP_0             (3 | USB_EP_DIR_IN)  // Notify endpoint
+#define  UDI_CDC_DATA_EP_IN_0          (4 | USB_EP_DIR_IN)  // TX
+#define  UDI_CDC_DATA_EP_OUT_0         (5 | USB_EP_DIR_OUT) // RX
+
+//! Interface numbers
+#define  UDI_CDC_COMM_IFACE_NUMBER_0   0
+#define  UDI_CDC_DATA_IFACE_NUMBER_0   1
+
+/**
+ * Configuration of MSC interface
+ * @{
+ */
+//! Vendor name and Product version of MSC interface
+#define UDI_MSC_GLOBAL_VENDOR_ID            \
+   'A', 'T', 'M', 'E', 'L', ' ', ' ', ' '
+#define UDI_MSC_GLOBAL_PRODUCT_VERSION            \
+   '1', '.', '0', '0'
+
+//! Interface callback definition
+#define  UDI_MSC_ENABLE_EXT()          mp_msc_enable()
+extern bool mp_msc_enable(void);
+#define  UDI_MSC_DISABLE_EXT()         mp_msc_disable()
+extern void mp_msc_disable(void);
+
+//! Enable id string of interface to add an extra USB string
+#define  UDI_MSC_STRING_ID                5
+
+/**
+ * USB MSC low level configuration
+ * In standalone these configurations are defined by the MSC module.
+ * For composite device, these configuration must be defined here
+ * @{
+ */
+//! Endpoint numbers definition
+#define  UDI_MSC_EP_IN                 (1 | USB_EP_DIR_IN)
+#define  UDI_MSC_EP_OUT                (2 | USB_EP_DIR_OUT)
+
+//! Interface number
+#define  UDI_MSC_IFACE_NUMBER          2
+/**
+ * Configuration of HID Mouse interface
+ * @{
+ */
+//! Interface callback definition
+#define  UDI_HID_MOUSE_ENABLE_EXT()       mp_mouse_enable()
+extern bool mp_mouse_enable(void);
+#define  UDI_HID_MOUSE_DISABLE_EXT()      mp_mouse_disable()
+extern void mp_mouse_disable(void);
+
+//! Enable id string of interface to add an extra USB string
+#define  UDI_HID_MOUSE_STRING_ID          6
+
+/**
+ * USB HID Mouse low level configuration
+ * In standalone these configurations are defined by the HID Mouse module.
+ * For composite device, these configuration must be defined here
+ * @{
+ */
+//! Endpoint numbers definition
+#define  UDI_HID_MOUSE_EP_IN           (6 | USB_EP_DIR_IN)
+
+//! Interface number
+#define  UDI_HID_MOUSE_IFACE_NUMBER    3
+//@}
+//@}
+
+/**
+ * Configuration of HID Keyboard interface
+ * @{
+ */
+//! Interface callback definition
+#define  UDI_HID_KBD_ENABLE_EXT()       mp_keyboard_enable()
+extern bool mp_keyboard_enable(void);
+#define  UDI_HID_KBD_DISABLE_EXT()      mp_keyboard_disable()
+extern void mp_keyboard_disable(void);
+#define  UDI_HID_KBD_CHANGE_LED(value)  mp_keyboard_led(value)
+extern void mp_keyboard_led(uint8_t);
+
+//! Enable id string of interface to add an extra USB string
+#define  UDI_HID_KBD_STRING_ID            7
+
+/**
+ * USB HID Keyboard low level configuration
+ * In standalone these configurations are defined by the HID Keyboard module.
+ * For composite device, these configuration must be defined here
+ * @{
+ */
+//! Endpoint numbers definition
+#define  UDI_HID_KBD_EP_IN           (7 | USB_EP_DIR_IN)
+
+//! Interface number
+#define  UDI_HID_KBD_IFACE_NUMBER    4
+
+/**
+ * Description of Composite Device
+ * @{
+ */
+//! USB Interfaces descriptor structure
+#define UDI_COMPOSITE_DESC_T \
+	usb_iad_desc_t       udi_cdc_iad; \
+	udi_cdc_comm_desc_t  udi_cdc_comm; \
+	udi_cdc_data_desc_t  udi_cdc_data; \
+	udi_msc_desc_t       udi_msc; \
+	udi_hid_mouse_desc_t udi_hid_mouse; \
+	udi_hid_kbd_desc_t   udi_hid_kbd
+
+//! USB Interfaces descriptor value for Full Speed
+#define UDI_COMPOSITE_DESC_FS \
+	.udi_cdc_iad   = UDI_CDC_IAD_DESC_0, \
+	.udi_cdc_comm  = UDI_CDC_COMM_DESC_0, \
+	.udi_cdc_data  = UDI_CDC_DATA_DESC_0_FS, \
+	.udi_msc       = UDI_MSC_DESC_FS, \
+	.udi_hid_mouse = UDI_HID_MOUSE_DESC, \
+	.udi_hid_kbd   = UDI_HID_KBD_DESC
+
+//! USB Interfaces descriptor value for High Speed
+#define UDI_COMPOSITE_DESC_HS \
+	.udi_cdc_iad   = UDI_CDC_IAD_DESC_0, \
+	.udi_cdc_comm  = UDI_CDC_COMM_DESC_0, \
+	.udi_cdc_data  = UDI_CDC_DATA_DESC_0_HS, \
+	.udi_msc       = UDI_MSC_DESC_HS, \
+	.udi_hid_mouse = UDI_HID_MOUSE_DESC, \
+	.udi_hid_kbd   = UDI_HID_KBD_DESC
+
+//! USB Interface APIs
+#define UDI_COMPOSITE_API \
+	&udi_api_cdc_comm, \
+	&udi_api_cdc_data, \
+	&udi_api_msc, \
+	&udi_api_hid_mouse, \
+	&udi_api_hid_kbd
+//@}
+
+/**
+ * USB Device Driver Configuration
+ * @{
+ */
+//@}
+
+//! The includes of classes and other headers must be done at the end of this file to avoid compile error
+#include "udi_cdc.h"
+#include "udi_msc.h"
+#include "udi_hid_mouse.h"
+#include "udi_hid_kbd.h"
+
+#endif

--- a/atmel-samd/boards/ugame/mpconfigboard.h
+++ b/atmel-samd/boards/ugame/mpconfigboard.h
@@ -1,0 +1,48 @@
+#define USB_REPL
+
+#define MICROPY_HW_BOARD_NAME "uGame"
+#define MICROPY_HW_MCU_NAME "samd21e18"
+
+#if 1
+// Salae reads 12mhz which is the limit even though we set it to the
+// safer 8mhz.
+#define SPI_FLASH_BAUDRATE (8000000)
+
+#define SPI_FLASH_MUX_SETTING SPI_SIGNAL_MUX_SETTING_D
+#define SPI_FLASH_PAD0_PINMUX PINMUX_PA16D_SERCOM3_PAD0 // MOSI
+#define SPI_FLASH_PAD1_PINMUX PINMUX_PA17D_SERCOM3_PAD1 // SCK
+#define SPI_FLASH_PAD2_PINMUX PINMUX_UNUSED // Use default pinmux for the chip
+                                            // select since we manage it
+                                            // ourselves.
+#define SPI_FLASH_PAD3_PINMUX PINMUX_PA19D_SERCOM3_PAD3 // MISO
+#define SPI_FLASH_SERCOM SERCOM3
+
+#define SPI_FLASH_CS PIN_PA11
+
+#define MICROPY_PORT_A        (PORT_PA11 | PORT_PA16 |\
+                               PORT_PA17 | PORT_PA18 | PORT_PA19 | PORT_PA24 |\
+                               PORT_PA25)
+#define MICROPY_PORT_B        (0)
+
+#define CALIBRATE_CRYSTALLESS 1
+
+#include "spi_flash.h"
+
+#define CIRCUITPY_INTERNAL_NVM_SIZE 256
+#define BOARD_FLASH_SIZE (0x00040000 - 0x2000 - CIRCUITPY_INTERNAL_NVM_SIZE)
+
+//#include "flash_W25Q32BV.h"
+#include "flash_S25FL216K.h"
+
+#else
+
+#define MICROPY_PORT_A        (PORT_PA24 | PORT_PA25)
+#define MICROPY_PORT_B        (0)
+
+#include "internal_flash.h"
+
+#define CIRCUITPY_INTERNAL_NVM_SIZE 0
+#define BOARD_FLASH_SIZE (0x00040000 - 0x2000 - 0x010000)
+
+#endif
+

--- a/atmel-samd/boards/ugame/mpconfigboard.mk
+++ b/atmel-samd/boards/ugame/mpconfigboard.mk
@@ -1,0 +1,10 @@
+LD_FILE = boards/samd21x18-bootloader-external-flash-crystalless.ld
+#LD_FILE = boards/samd21x18-bootloader.ld
+USB_VID = 0x239A
+USB_PID = 0x801F
+
+#FLASH_IMPL = internal_flash.c
+FLASH_IMPL = spi_flash.c
+
+CHIP_VARIANT = SAMD21E18A
+CHIP_FAMILY = samd21

--- a/atmel-samd/boards/ugame/pins.c
+++ b/atmel-samd/boards/ugame/pins.c
@@ -1,0 +1,18 @@
+#include "samd21_pins.h"
+
+STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_X), MP_ROM_PTR(&pin_PA00) },
+    { MP_ROM_QSTR(MP_QSTR_O), MP_ROM_PTR(&pin_PA01) },
+
+    { MP_ROM_QSTR(MP_QSTR_SPEAKER), MP_ROM_PTR(&pin_PA02) },
+
+    { MP_ROM_QSTR(MP_QSTR_UP), MP_ROM_PTR(&pin_PA03) },
+    { MP_ROM_QSTR(MP_QSTR_LEFT), MP_ROM_PTR(&pin_PA04) },
+    { MP_ROM_QSTR(MP_QSTR_DOWN), MP_ROM_PTR(&pin_PA23) },
+    { MP_ROM_QSTR(MP_QSTR_RIGHT), MP_ROM_PTR(&pin_PA05) },
+
+    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_PA06) },
+    { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_PA07) },
+    { MP_ROM_QSTR(MP_QSTR_DC), MP_ROM_PTR(&pin_PA08) },
+};
+MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);


### PR DESCRIPTION
This is a board definition for the uGame project:
https://hackaday.io/project/27629-game

uGame is a small handheld game console programmable with
CircuitPython. The hardware part of the project is pretty
much stable by now.