### PR TITLE
Add a _stage module

### DIFF
--- a/atmel-samd/Makefile
+++ b/atmel-samd/Makefile
@@ -333,6 +333,7 @@ SRC_SHARED_MODULE = \
 	os/__init__.c \
 	random/__init__.c \
 	storage/__init__.c \
+	_stage/__init__.c \
 	uheap/__init__.c \
 	ustack/__init__.c
 

--- a/atmel-samd/Makefile
+++ b/atmel-samd/Makefile
@@ -335,6 +335,7 @@ SRC_SHARED_MODULE = \
 	storage/__init__.c \
 	_stage/__init__.c \
 	_stage/Layer.c \
+	_stage/Text.c \
 	uheap/__init__.c \
 	ustack/__init__.c
 

--- a/atmel-samd/Makefile
+++ b/atmel-samd/Makefile
@@ -334,6 +334,7 @@ SRC_SHARED_MODULE = \
 	random/__init__.c \
 	storage/__init__.c \
 	_stage/__init__.c \
+	_stage/Layer.c \
 	uheap/__init__.c \
 	ustack/__init__.c
 

--- a/atmel-samd/mpconfigport.h
+++ b/atmel-samd/mpconfigport.h
@@ -195,14 +195,18 @@ extern const struct _mp_obj_module_t usb_hid_module;
 #endif
 
 #define MICROPY_PORT_BUILTIN_MODULES \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_touchio), (mp_obj_t)&touchio_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_microcontroller), (mp_obj_t)&microcontroller_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_analogio), (mp_obj_t)&analogio_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_digitalio), (mp_obj_t)&digitalio_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_busio), (mp_obj_t)&busio_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_pulseio), (mp_obj_t)&pulseio_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_board), (mp_obj_t)&board_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_os), (mp_obj_t)&os_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_random), (mp_obj_t)&random_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_storage), (mp_obj_t)&storage_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_time), (mp_obj_t)&time_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_neopixel_write),(mp_obj_t)&neopixel_write_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_samd),(mp_obj_t)&samd_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_usb_hid),(mp_obj_t)&usb_hid_module }, \
     EXTRA_BUILTIN_MODULES

--- a/atmel-samd/mpconfigport.h
+++ b/atmel-samd/mpconfigport.h
@@ -195,18 +195,14 @@ extern const struct _mp_obj_module_t usb_hid_module;
 #endif
 
 #define MICROPY_PORT_BUILTIN_MODULES \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_touchio), (mp_obj_t)&touchio_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_microcontroller), (mp_obj_t)&microcontroller_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_analogio), (mp_obj_t)&analogio_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_digitalio), (mp_obj_t)&digitalio_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_busio), (mp_obj_t)&busio_module }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_pulseio), (mp_obj_t)&pulseio_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_board), (mp_obj_t)&board_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_os), (mp_obj_t)&os_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_random), (mp_obj_t)&random_module }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_storage), (mp_obj_t)&storage_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_time), (mp_obj_t)&time_module }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_neopixel_write),(mp_obj_t)&neopixel_write_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_samd),(mp_obj_t)&samd_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_usb_hid),(mp_obj_t)&usb_hid_module }, \
     EXTRA_BUILTIN_MODULES

--- a/shared-bindings/_stage/Layer.c
+++ b/shared-bindings/_stage/Layer.c
@@ -1,0 +1,102 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "__init__.h"
+#include "Layer.h"
+
+
+STATIC mp_obj_t layer_make_new(const mp_obj_type_t *type, size_t n_args,
+        size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 4, 5, false);
+
+    layer_obj_t *self = m_new_obj(layer_obj_t);
+    self->base.type = type;
+
+    self->width = mp_obj_get_int(args[0]);
+    self->height = mp_obj_get_int(args[1]);
+    self->x = 0;
+    self->y = 0;
+    self->frame = 0;
+    self->mirror = false;
+
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
+    self->graphic = bufinfo.buf;
+    if (bufinfo.len != 2048) {
+        mp_raise_ValueError("graphic must be 2048 bytes long");
+    }
+
+    mp_get_buffer_raise(args[3], &bufinfo, MP_BUFFER_READ);
+    self->palette = bufinfo.buf;
+    if (bufinfo.len != 32) {
+        mp_raise_ValueError("palette must be 32 bytes long");
+    }
+
+    if (n_args > 4) {
+        mp_get_buffer_raise(args[4], &bufinfo, MP_BUFFER_READ);
+        self->map = bufinfo.buf;
+        if (bufinfo.len < (self->width * self->height) / 2) {
+            mp_raise_ValueError("map buffer too small");
+        }
+    } else {
+        self-> map = NULL;
+    }
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+
+STATIC mp_obj_t layer_move(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in) {
+    layer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    self->x = mp_obj_get_int(x_in);
+    self->y = mp_obj_get_int(y_in);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(layer_move_obj, layer_move);
+
+
+STATIC mp_obj_t layer_frame(mp_obj_t self_in, mp_obj_t frame_in,
+                            mp_obj_t mirror_in) {
+    layer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    self->frame = mp_obj_get_int(frame_in);
+    self->mirror = mp_obj_get_int(mirror_in);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(layer_frame_obj, layer_frame);
+
+
+STATIC const mp_rom_map_elem_t layer_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_move), MP_ROM_PTR(&layer_move_obj) },
+    { MP_ROM_QSTR(MP_QSTR_frame), MP_ROM_PTR(&layer_frame_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(layer_locals_dict, layer_locals_dict_table);
+
+const mp_obj_type_t mp_type_layer = {
+    { &mp_type_type },
+    .name = MP_QSTR_Layer,
+    .make_new = layer_make_new,
+    .locals_dict = (mp_obj_dict_t*)&layer_locals_dict,
+};

--- a/shared-bindings/_stage/Layer.c
+++ b/shared-bindings/_stage/Layer.c
@@ -24,6 +24,8 @@
  * THE SOFTWARE.
  */
 
+#include <py/runtime.h>
+
 #include "__init__.h"
 #include "Layer.h"
 

--- a/shared-bindings/_stage/Layer.c
+++ b/shared-bindings/_stage/Layer.c
@@ -27,7 +27,26 @@
 #include "__init__.h"
 #include "Layer.h"
 
-
+//| .. currentmodule:: _stage
+//|
+//| :class:`Layer` -- Keep information about a single layer of graphics
+//| ===================================================================
+//|
+//| .. class:: Layer(width, height, graphic, palette, [grid])
+//|
+//|     Keep internal information about a layer of graphics (either a
+//|     ``Grid`` or a ``Sprite``) in a format suitable for fast rendering
+//|     with the ``render()`` function.
+//|
+//|     :param int width: The width of the grid in tiles, or 1 for sprites.
+//|     :param int height: The height of the grid in tiles, or 1 for sprites.
+//|     :param bytearray graphic: The graphic data of the tiles.
+//|     :param bytearray palette: The color palette to be used.
+//|     :param bytearray grid: The contents of the grid map.
+//|
+//|     This class is intended for internal use in the ``stage`` library and
+//|     it shouldn't be used on its own.
+//|
 STATIC mp_obj_t layer_make_new(const mp_obj_type_t *type, size_t n_args,
         size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 4, 5, false);
@@ -68,7 +87,10 @@ STATIC mp_obj_t layer_make_new(const mp_obj_type_t *type, size_t n_args,
     return MP_OBJ_FROM_PTR(self);
 }
 
-
+//|     .. method:: move(x, y)
+//|
+//|     Set the offset of the layer to the specified values.
+//|
 STATIC mp_obj_t layer_move(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in) {
     layer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     self->x = mp_obj_get_int(x_in);
@@ -77,7 +99,11 @@ STATIC mp_obj_t layer_move(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(layer_move_obj, layer_move);
 
-
+//|     .. method:: frame(frame, mirror)
+//|
+//|     Set the animation frame of the sprite, and optionally mirror its
+//|     graphic.
+//|
 STATIC mp_obj_t layer_frame(mp_obj_t self_in, mp_obj_t frame_in,
                             mp_obj_t mirror_in) {
     layer_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/_stage/Layer.c
+++ b/shared-bindings/_stage/Layer.c
@@ -59,7 +59,7 @@ STATIC mp_obj_t layer_make_new(const mp_obj_type_t *type, size_t n_args,
     self->x = 0;
     self->y = 0;
     self->frame = 0;
-    self->mirror = false;
+    self->rotation = false;
 
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
@@ -99,16 +99,16 @@ STATIC mp_obj_t layer_move(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(layer_move_obj, layer_move);
 
-//|     .. method:: frame(frame, mirror)
+//|     .. method:: frame(frame, rotation)
 //|
-//|     Set the animation frame of the sprite, and optionally mirror its
+//|     Set the animation frame of the sprite, and optionally rotation its
 //|     graphic.
 //|
 STATIC mp_obj_t layer_frame(mp_obj_t self_in, mp_obj_t frame_in,
-                            mp_obj_t mirror_in) {
+                            mp_obj_t rotation_in) {
     layer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     self->frame = mp_obj_get_int(frame_in);
-    self->mirror = mp_obj_get_int(mirror_in);
+    self->rotation = mp_obj_get_int(rotation_in);
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(layer_frame_obj, layer_frame);

--- a/shared-bindings/_stage/Layer.h
+++ b/shared-bindings/_stage/Layer.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED__STAGE_LAYER_H
+#define MICROPY_INCLUDED__STAGE_LAYER_H
+
+#include "shared-module/_stage/Layer.h"
+
+extern const mp_obj_type_t mp_type_layer;
+
+#endif  // MICROPY_INCLUDED__STAGE_LAYER

--- a/shared-bindings/_stage/Text.c
+++ b/shared-bindings/_stage/Text.c
@@ -1,0 +1,109 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <py/runtime.h>
+
+#include "__init__.h"
+#include "Text.h"
+
+//| .. currentmodule:: _stage
+//|
+//| :class:`Text` -- Keep information about a single text of text
+//| ==============================================================
+//|
+//| .. class:: Text(width, height, font, palette, chars)
+//|
+//|     Keep internal information about a text of text
+//|     in a format suitable for fast rendering
+//|     with the ``render()`` function.
+//|
+//|     :param int width: The width of the grid in tiles, or 1 for sprites.
+//|     :param int height: The height of the grid in tiles, or 1 for sprites.
+//|     :param bytearray font: The font data of the characters.
+//|     :param bytearray palette: The color palette to be used.
+//|     :param bytearray chars: The contents of the character grid.
+//|
+//|     This class is intended for internal use in the ``stage`` library and
+//|     it shouldn't be used on its own.
+//|
+STATIC mp_obj_t text_make_new(const mp_obj_type_t *type, size_t n_args,
+        size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 5, 5, false);
+
+    text_obj_t *self = m_new_obj(text_obj_t);
+    self->base.type = type;
+
+    self->width = mp_obj_get_int(args[0]);
+    self->height = mp_obj_get_int(args[1]);
+    self->x = 0;
+    self->y = 0;
+
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
+    self->font = bufinfo.buf;
+    if (bufinfo.len != 1536) {
+        mp_raise_ValueError("font must be 1536 bytes long");
+    }
+
+    mp_get_buffer_raise(args[3], &bufinfo, MP_BUFFER_READ);
+    self->palette = bufinfo.buf;
+    if (bufinfo.len != 32) {
+        mp_raise_ValueError("palette must be 32 bytes long");
+    }
+
+    mp_get_buffer_raise(args[4], &bufinfo, MP_BUFFER_READ);
+    self->chars = bufinfo.buf;
+    if (bufinfo.len < self->width * self->height) {
+        mp_raise_ValueError("chars buffer too small");
+    }
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+//|     .. method:: move(x, y)
+//|
+//|     Set the offset of the text to the specified values.
+//|
+STATIC mp_obj_t text_move(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in) {
+    text_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    self->x = mp_obj_get_int(x_in);
+    self->y = mp_obj_get_int(y_in);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(text_move_obj, text_move);
+
+
+STATIC const mp_rom_map_elem_t text_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_move), MP_ROM_PTR(&text_move_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(text_locals_dict, text_locals_dict_table);
+
+const mp_obj_type_t mp_type_text = {
+    { &mp_type_type },
+    .name = MP_QSTR_Text,
+    .make_new = text_make_new,
+    .locals_dict = (mp_obj_dict_t*)&text_locals_dict,
+};

--- a/shared-bindings/_stage/Text.c
+++ b/shared-bindings/_stage/Text.c
@@ -64,8 +64,8 @@ STATIC mp_obj_t text_make_new(const mp_obj_type_t *type, size_t n_args,
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
     self->font = bufinfo.buf;
-    if (bufinfo.len != 1536) {
-        mp_raise_ValueError("font must be 1536 bytes long");
+    if (bufinfo.len != 2048) {
+        mp_raise_ValueError("font must be 2048 bytes long");
     }
 
     mp_get_buffer_raise(args[3], &bufinfo, MP_BUFFER_READ);

--- a/shared-bindings/_stage/Text.h
+++ b/shared-bindings/_stage/Text.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED__STAGE_TEXT_H
+#define MICROPY_INCLUDED__STAGE_TEXT_H
+
+#include "shared-module/_stage/Text.h"
+
+extern const mp_obj_type_t mp_type_text;
+
+#endif  // MICROPY_INCLUDED__STAGE_TEXT

--- a/shared-bindings/_stage/__init__.c
+++ b/shared-bindings/_stage/__init__.c
@@ -30,6 +30,7 @@
 #include "shared-bindings/busio/SPI.h"
 #include "shared-module/_stage/__init__.h"
 #include "Layer.h"
+#include "Text.h"
 
 //| .. currentmodule:: _stage
 //|
@@ -84,6 +85,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(stage_render_obj, 7, 7, stage_render);
 STATIC const mp_rom_map_elem_t stage_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR__stage) },
     { MP_ROM_QSTR(MP_QSTR_Layer), MP_ROM_PTR(&mp_type_layer) },
+    { MP_ROM_QSTR(MP_QSTR_Text), MP_ROM_PTR(&mp_type_text) },
     { MP_ROM_QSTR(MP_QSTR_render), MP_ROM_PTR(&stage_render_obj) },
 };
 

--- a/shared-bindings/_stage/__init__.c
+++ b/shared-bindings/_stage/__init__.c
@@ -108,7 +108,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(stage_render_obj, 7, 7, stage_render);
 
 
 STATIC const mp_rom_map_elem_t stage_module_globals_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_layer) },
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR__stage) },
     { MP_ROM_QSTR(MP_QSTR_Layer), MP_ROM_PTR(&mp_type_layer) },
     { MP_ROM_QSTR(MP_QSTR_render), MP_ROM_PTR(&stage_render_obj) },
 };

--- a/shared-bindings/_stage/__init__.c
+++ b/shared-bindings/_stage/__init__.c
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "__init__.h"
+#include "Layer.h"
+#include "shared-bindings/busio/SPI.h"
+#include "py/mperrno.h"
+#include "py/runtime.h"
+
+
+// Render a rectangle of the screen, and send it over SPI to the display.
+STATIC mp_obj_t stage_render(size_t n_args, const mp_obj_t *args) {
+    uint8_t x0 = mp_obj_get_int(args[0]);
+    uint8_t y0 = mp_obj_get_int(args[1]);
+    uint8_t x1 = mp_obj_get_int(args[2]);
+    uint8_t y1 = mp_obj_get_int(args[3]);
+
+    size_t layers_size = 0;
+    mp_obj_t *layers;
+    mp_obj_get_array(args[4], &layers_size, &layers);
+
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[5], &bufinfo, MP_BUFFER_WRITE);
+    uint16_t *buffer = bufinfo.buf;
+    size_t buffer_size = bufinfo.len / 2; // 16-bit indexing
+
+    busio_spi_obj_t *spi = MP_OBJ_TO_PTR(args[6]);
+
+    // TODO(deshipu): Do a collision check of each layer with the
+    // rectangle, and only process the layers that overlap with it.
+
+    size_t index = 0;
+    for (uint8_t y = y0; y < y1; ++y) {
+        for (uint8_t x = x0; x < x1; ++x) {
+            for (size_t layer = 0; layer < layers_size; ++layer) {
+                uint16_t c = get_layer_pixel(MP_OBJ_TO_PTR(layers[layer]),
+                        x, y);
+                if (c != TRANSPARENT) {
+                    buffer[index] = c;
+                    break;
+                }
+            }
+            index += 1;
+            // The buffer is full, send it.
+            if (index >= buffer_size) {
+                if (!common_hal_busio_spi_write(spi,
+                        ((uint8_t*)bufinfo.buf), bufinfo.len)) {
+                    mp_raise_OSError(MP_EIO);
+                }
+                index = 0;
+            }
+        }
+    }
+    // Send the remaining data.
+    if (index) {
+        if (!common_hal_busio_spi_write(spi,
+                ((uint8_t*)bufinfo.buf), index * 2)) {
+            mp_raise_OSError(MP_EIO);
+        }
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(stage_render_obj, 7, 7, stage_render);
+
+
+STATIC const mp_rom_map_elem_t stage_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_layer) },
+    { MP_ROM_QSTR(MP_QSTR_Layer), MP_ROM_PTR(&mp_type_layer) },
+    { MP_ROM_QSTR(MP_QSTR_render), MP_ROM_PTR(&stage_render_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(stage_module_globals, stage_module_globals_table);
+
+const mp_obj_module_t stage_module = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&stage_module_globals,
+};

--- a/shared-bindings/_stage/__init__.c
+++ b/shared-bindings/_stage/__init__.c
@@ -30,8 +30,29 @@
 #include "py/mperrno.h"
 #include "py/runtime.h"
 
-
-// Render a rectangle of the screen, and send it over SPI to the display.
+//| .. currentmodule:: _stage
+//|
+//| .. function:: render(x0, y0, x1, y1, layers, buffer, spi)
+//|
+//|     Render and send to the display a fragment of the screen.
+//|
+//|     :param int x0: Left edge of the fragment.
+//|     :param int y0: Top edge of the fragment.
+//|     :param int x1: Right edge of the fragment.
+//|     :param int y1: Bottom edge of the fragment.
+//|     :param list layers: A list of the `Layer` objects.
+//|     :param bytearray buffer: A buffer to use for rendering.
+//|     :param SPI spi: The SPI device to use.
+//|
+//|     Note that this function only sends the raw pixel data. Setting up
+//|     the display for receiving it and handling the chip-select and
+//|     data-command pins has to be done outside of it.
+//|     There are also no sanity checks, outside of the basic overflow
+//|     checking. The caller is responsible for making the passed parameters
+//|     valid.
+//|
+//|     This function is intended for internal use in the ``stage`` library
+//|     and all the necessary checks are performed there.
 STATIC mp_obj_t stage_render(size_t n_args, const mp_obj_t *args) {
     uint8_t x0 = mp_obj_get_int(args[0]);
     uint8_t y0 = mp_obj_get_int(args[1]);

--- a/shared-bindings/_stage/__init__.h
+++ b/shared-bindings/_stage/__init__.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED__STAGE_H
+#define MICROPY_INCLUDED__STAGE_H
+
+#include "shared-module/_stage/__init__.h"
+
+#endif  // MICROPY_INCLUDED__STAGE

--- a/shared-module/_stage/Layer.c
+++ b/shared-module/_stage/Layer.c
@@ -1,0 +1,105 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "Layer.h"
+#include "__init__.h"
+
+
+// Get the color of the pixel on the layer.
+uint16_t get_layer_pixel(layer_obj_t *layer, int16_t x, uint16_t y) {
+
+    // Shift by the layer's position offset.
+    x -= layer->x;
+    y -= layer->y;
+
+    // Bounds check.
+    if ((x < 0) || (x >= layer->width << 4) ||
+            (y < 0) || (y >= layer->height << 4)) {
+        return TRANSPARENT;
+    }
+
+    // Get the tile from the grid location or from sprite frame.
+    uint8_t frame = layer->frame;
+    if (layer->map) {
+        uint8_t tx = x >> 4;
+        uint8_t ty = y >> 4;
+
+        frame = layer->map[(tx * layer->width + ty) >> 1];
+        if (ty & 0x01) {
+            frame &= 0x0f;
+        } else {
+            frame >>= 4;
+        }
+    }
+
+    // Get the position within the tile.
+    x &= 0x0f;
+    y &= 0x0f;
+
+    // Rotate the image.
+    uint8_t tx = x; // Temporary variable for swapping.
+    switch (layer->rotation) {
+        case 1: // 90 degrees clockwise
+            x = 15 - y;
+            y = tx;
+            break;
+        case 2: // 180 degrees
+            x = 15 - tx;
+            y = 15 - y;
+            break;
+        case 3: // 90 degrees counter-clockwise
+            x = y;
+            y = 15 - tx;
+            break;
+        case 4: // 0 degrees, mirrored
+            y = 15 - y;
+            break;
+        case 5: // 90 degrees clockwise, mirrored
+            x = y;
+            y = tx;
+            break;
+        case 6: // 180 degrees, mirrored
+            x = 15 - tx;
+            break;
+        case 7: // 90 degrees counter-clockwise, mirrored
+            x = 15 - y;
+            y = 15 - tx;
+            break;
+        default: // 0 degrees
+            break;
+    }
+
+    // Get the value of the pixel.
+    uint8_t pixel = layer->graphic[(frame << 7) + (x << 3) + (y >> 1)];
+    if (y & 0x01) {
+        pixel &= 0x0f;
+    } else {
+        pixel >>= 4;
+    }
+
+    // Convert to 16-bit color using the palette.
+    return layer->palette[pixel];
+}

--- a/shared-module/_stage/Layer.c
+++ b/shared-module/_stage/Layer.c
@@ -101,5 +101,5 @@ uint16_t get_layer_pixel(layer_obj_t *layer, int16_t x, uint16_t y) {
     }
 
     // Convert to 16-bit color using the palette.
-    return layer->palette[pixel];
+    return layer->palette[pixel << 1] | layer->palette[(pixel << 1) + 1] << 8;
 }

--- a/shared-module/_stage/Layer.h
+++ b/shared-module/_stage/Layer.h
@@ -40,7 +40,7 @@ typedef struct {
     uint16_t width, height;
     int16_t x, y, z;
     uint8_t frame;
-    bool mirror;
+    uint8_t rotation;
 } layer_obj_t;
 
 #endif  // MICROPY_INCLUDED_SHARED_MODULE__STAGE_LAYER

--- a/shared-module/_stage/Layer.h
+++ b/shared-module/_stage/Layer.h
@@ -36,7 +36,7 @@ typedef struct {
     mp_obj_base_t base;
     uint8_t *map;
     uint8_t *graphic;
-    uint16_t *palette;
+    uint8_t *palette;
     int16_t x, y;
     uint8_t width, height;
     uint8_t frame;

--- a/shared-module/_stage/Layer.h
+++ b/shared-module/_stage/Layer.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_MODULE__STAGE_LAYER_H
+#define MICROPY_INCLUDED_SHARED_MODULE__STAGE_LAYER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "py/obj.h"
+
+typedef struct {
+    mp_obj_base_t base;
+    uint8_t *map;
+    uint8_t *graphic;
+    uint16_t *palette;
+    uint16_t width, height;
+    int16_t x, y, z;
+    uint8_t frame;
+    bool mirror;
+} layer_obj_t;
+
+#endif  // MICROPY_INCLUDED_SHARED_MODULE__STAGE_LAYER

--- a/shared-module/_stage/Layer.h
+++ b/shared-module/_stage/Layer.h
@@ -37,10 +37,12 @@ typedef struct {
     uint8_t *map;
     uint8_t *graphic;
     uint16_t *palette;
-    uint16_t width, height;
-    int16_t x, y, z;
+    int16_t x, y;
+    uint8_t width, height;
     uint8_t frame;
     uint8_t rotation;
 } layer_obj_t;
+
+uint16_t get_layer_pixel(layer_obj_t *layer, int16_t x, uint16_t y);
 
 #endif  // MICROPY_INCLUDED_SHARED_MODULE__STAGE_LAYER

--- a/shared-module/_stage/Text.c
+++ b/shared-module/_stage/Text.c
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "Text.h"
+#include "__init__.h"
+
+
+// Get the color of the pixel on the text.
+uint16_t get_text_pixel(text_obj_t *text, int16_t x, uint16_t y) {
+
+    // Shift by the text's position offset.
+    x -= text->x;
+    y -= text->y;
+
+    // Bounds check.
+    if ((x < 0) || (x >= text->width << 3) ||
+            (y < 0) || (y >= text->height << 3)) {
+        return TRANSPARENT;
+    }
+
+    // Get the tile from the grid location or from sprite frame.
+    uint8_t tx = x >> 3;
+    uint8_t ty = y >> 3;
+    uint8_t c = text->chars[tx * text->width + ty];
+    uint8_t color_offset = 0;
+    if (c & 0x80) {
+        color_offset = 4;
+    }
+    c &= 0x7f;
+    if (c < 32) {
+        return TRANSPARENT;
+    }
+    c -= 32;
+
+    // Get the position within the char.
+    x &= 0x07;
+    y &= 0x07;
+
+    // Get the value of the pixel.
+    uint8_t pixel = text->font[(c << 4) + (x << 1) + (y >> 2)];
+    pixel = (pixel >> ((y & 0x03) << 1)) & 0x03;
+
+    // Convert to 16-bit color using the palette.
+    return text->palette[pixel + color_offset];
+}

--- a/shared-module/_stage/Text.c
+++ b/shared-module/_stage/Text.c
@@ -44,7 +44,7 @@ uint16_t get_text_pixel(text_obj_t *text, int16_t x, uint16_t y) {
     // Get the tile from the grid location or from sprite frame.
     uint8_t tx = x >> 3;
     uint8_t ty = y >> 3;
-    uint8_t c = text->chars[tx * text->width + ty];
+    uint8_t c = text->chars[ty * text->width + tx];
     uint8_t color_offset = 0;
     if (c & 0x80) {
         color_offset = 4;

--- a/shared-module/_stage/Text.c
+++ b/shared-module/_stage/Text.c
@@ -61,8 +61,8 @@ uint16_t get_text_pixel(text_obj_t *text, int16_t x, uint16_t y) {
 
     // Get the value of the pixel.
     uint8_t pixel = text->font[(c << 4) + (x << 1) + (y >> 2)];
-    pixel = (pixel >> ((y & 0x03) << 1)) & 0x03;
+    pixel = ((pixel >> ((y & 0x03) << 1)) & 0x03) + color_offset;
 
     // Convert to 16-bit color using the palette.
-    return text->palette[pixel + color_offset];
+    return text->palette[pixel << 1] | text->palette[(pixel << 1) + 1] << 8;
 }

--- a/shared-module/_stage/Text.c
+++ b/shared-module/_stage/Text.c
@@ -50,10 +50,9 @@ uint16_t get_text_pixel(text_obj_t *text, int16_t x, uint16_t y) {
         color_offset = 4;
     }
     c &= 0x7f;
-    if (c < 32) {
+    if (!c) {
         return TRANSPARENT;
     }
-    c -= 32;
 
     // Get the position within the char.
     x &= 0x07;

--- a/shared-module/_stage/Text.h
+++ b/shared-module/_stage/Text.h
@@ -36,7 +36,7 @@ typedef struct {
     mp_obj_base_t base;
     uint8_t *chars;
     uint8_t *font;
-    uint16_t *palette;
+    uint8_t *palette;
     int16_t x, y;
     uint8_t width, height;
 } text_obj_t;

--- a/shared-module/_stage/Text.h
+++ b/shared-module/_stage/Text.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_MODULE__STAGE_TEXT_H
+#define MICROPY_INCLUDED_SHARED_MODULE__STAGE_TEXT_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "py/obj.h"
+
+typedef struct {
+    mp_obj_base_t base;
+    uint8_t *chars;
+    uint8_t *font;
+    uint16_t *palette;
+    int16_t x, y;
+    uint8_t width, height;
+} text_obj_t;
+
+uint16_t get_text_pixel(text_obj_t *text, int16_t x, uint16_t y);
+
+#endif  // MICROPY_INCLUDED_SHARED_MODULE__STAGE_TEXT

--- a/shared-module/_stage/__init__.c
+++ b/shared-module/_stage/__init__.c
@@ -25,8 +25,10 @@
  */
 
 #include "Layer.h"
+#include "Text.h"
 #include "__init__.h"
 #include "shared-bindings/_stage/Layer.h"
+#include "shared-bindings/_stage/Text.h"
 
 
 bool render_stage(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1,
@@ -45,6 +47,8 @@ bool render_stage(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1,
                 layer_obj_t *obj = MP_OBJ_TO_PTR(layers[layer]);
                 if (obj->base.type == &mp_type_layer) {
                     c = get_layer_pixel(obj, x, y);
+                } else if (obj->base.type == &mp_type_text) {
+                    c = get_text_pixel((text_obj_t *)obj, x, y);
                 }
                 if (c != TRANSPARENT) {
                     buffer[index] = c;

--- a/shared-module/_stage/__init__.c
+++ b/shared-module/_stage/__init__.c
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "Layer.h"
+#include "__init__.h"
+
+
+// Get the color of the pixel on the layer.
+uint16_t get_layer_pixel(layer_obj_t *layer, int16_t x, uint16_t y) {
+
+    // Shift by the layer's position offset.
+    x -= layer->x;
+    y -= layer->y;
+
+    // Bounds check.
+    if ((x < 0) || (x >= layer->width << 4) ||
+            (y < 0) || (y >= layer->height << 4)) {
+        return TRANSPARENT;
+    }
+
+    // Get the tile from the grid location or from sprite frame.
+    uint8_t frame = layer->frame;
+    if (layer->map) {
+        uint8_t tx = x >> 4;
+        uint8_t ty = y >> 4;
+
+        frame = layer->map[(tx * layer->width + ty) >> 1];
+        if (ty & 0x01) {
+            frame &= 0x0f;
+        } else {
+            frame >>= 4;
+        }
+    }
+
+    // Get the position within the tile.
+    x &= 0x0f;
+    y &= 0x0f;
+
+    // Mirror the image if needed.
+    if (layer->mirror) {
+        y = 15 - y;
+    }
+
+    // Get the value of the pixel.
+    uint8_t pixel = layer->graphic[(frame << 7) + (x << 3) + (y >> 1)];
+    if (y & 0x01) {
+        pixel &= 0x0f;
+    } else {
+        pixel >>= 4;
+    }
+
+    // Convert to 16-bit color using the palette.
+    return layer->palette[pixel];
+}

--- a/shared-module/_stage/__init__.c
+++ b/shared-module/_stage/__init__.c
@@ -26,6 +26,7 @@
 
 #include "Layer.h"
 #include "__init__.h"
+#include "shared-bindings/_stage/Layer.h"
 
 
 bool render_stage(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1,
@@ -40,8 +41,11 @@ bool render_stage(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1,
     for (uint8_t y = y0; y < y1; ++y) {
         for (uint8_t x = x0; x < x1; ++x) {
             for (size_t layer = 0; layer < layers_size; ++layer) {
-                uint16_t c = get_layer_pixel(MP_OBJ_TO_PTR(layers[layer]),
-                        x, y);
+                uint16_t c = TRANSPARENT;
+                layer_obj_t *obj = MP_OBJ_TO_PTR(layers[layer]);
+                if (obj->base.type == &mp_type_layer) {
+                    c = get_layer_pixel(obj, x, y);
+                }
                 if (c != TRANSPARENT) {
                     buffer[index] = c;
                     break;

--- a/shared-module/_stage/__init__.c
+++ b/shared-module/_stage/__init__.c
@@ -59,9 +59,37 @@ uint16_t get_layer_pixel(layer_obj_t *layer, int16_t x, uint16_t y) {
     x &= 0x0f;
     y &= 0x0f;
 
-    // Mirror the image if needed.
-    if (layer->mirror) {
-        y = 15 - y;
+    // Rotate the image.
+    uint8_t tx = x; // Temporary variable for swapping.
+    switch (layer->rotation) {
+        case 1: // 90 degrees clockwise
+            x = 15 - y;
+            y = tx;
+            break;
+        case 2: // 180 degrees
+            x = 15 - tx;
+            y = 15 - y;
+            break;
+        case 3: // 90 degrees counter-clockwise
+            x = y;
+            y = 15 - tx;
+            break;
+        case 4: // 0 degrees, mirrored
+            y = 15 - y;
+            break;
+        case 5: // 90 degrees clockwise, mirrored
+            x = y;
+            y = tx;
+            break;
+        case 6: // 180 degrees, mirrored
+            x = 15 - tx;
+            break;
+        case 7: // 90 degrees counter-clockwise, mirrored
+            x = 15 - y;
+            y = 15 - tx;
+            break;
+        default: // 0 degrees
+            break;
     }
 
     // Get the value of the pixel.

--- a/shared-module/_stage/__init__.h
+++ b/shared-module/_stage/__init__.h
@@ -27,12 +27,16 @@
 #ifndef MICROPY_INCLUDED_SHARED_MODULE__STAGE_H
 #define MICROPY_INCLUDED_SHARED_MODULE__STAGE_H
 
+#include "shared-bindings/busio/SPI.h"
 #include <stdint.h>
-
-#include "Layer.h"
+#include <stdbool.h>
+#include "py/obj.h"
 
 #define TRANSPARENT (0x1ff8)
 
-uint16_t get_layer_pixel(layer_obj_t *layer, int16_t x, uint16_t y);
+bool render_stage(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1,
+        mp_obj_t *layers, size_t layers_size,
+        uint16_t *buffer, size_t buffer_size,
+        busio_spi_obj_t *spi);
 
 #endif  // MICROPY_INCLUDED_SHARED_MODULE__STAGE

--- a/shared-module/_stage/__init__.h
+++ b/shared-module/_stage/__init__.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Radomir Dopieralski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_MODULE__STAGE_H
+#define MICROPY_INCLUDED_SHARED_MODULE__STAGE_H
+
+#include <stdint.h>
+
+#include "Layer.h"
+
+#define TRANSPARENT (0x1ff8)
+
+uint16_t get_layer_pixel(layer_obj_t *layer, int16_t x, uint16_t y);
+
+#endif  // MICROPY_INCLUDED_SHARED_MODULE__STAGE


### PR DESCRIPTION
This module is a part of the "stage" library, which is a tile and sprite engine for games using SPI-based RGB displays. The library is part of the µGame project (https://hackaday.io/project/27629-game), and contains optimized low-level code for rendering the data and sending it to the display as fast as possible. It's not enabled by default in any ports, even though in general it could be useful outside the µGame.