### PR TITLE
atmel-samd: Stop double CSW after MSC reads

### DIFF
--- a/ports/atmel-samd/usb_mass_storage.c
+++ b/ports/atmel-samd/usb_mass_storage.c
@@ -273,7 +273,6 @@ int32_t usb_msc_xfer_done(uint8_t lun) {
 void usb_msc_background(void) {
     if (active_read && !usb_busy) {
         if (active_nblocks == 0) {
-            mscdf_xfer_blocks(false, NULL, 0);
             active_read = false;
             return;
         }


### PR DESCRIPTION
This explicit zero length xfer leads to a second CSW packet. If
another read was started between the two CSWs then the host gets
confused and resets the device.

On reads, the CSW is automatically sent when we reply with the
total length. Writes must do it manually so they can wait for the
disk to flush the data.