### PR TITLE
atmel-samd: Update Feather M0 Express USB PID in 2.x

### DIFF
--- a/atmel-samd/boards/feather_m0_express/mpconfigboard.mk
+++ b/atmel-samd/boards/feather_m0_express/mpconfigboard.mk
@@ -1,6 +1,6 @@
 LD_FILE = boards/samd21x18-bootloader-external-flash.ld
 USB_VID = 0x239A
-USB_PID = 0x801b
+USB_PID = 0x8023
 
 SPI_FLASH_FILESYSTEM = 1
 

--- a/atmel-samd/boards/feather_m0_supersized/mpconfigboard.mk
+++ b/atmel-samd/boards/feather_m0_supersized/mpconfigboard.mk
@@ -1,7 +1,7 @@
 LD_FILE = boards/samd21x18-bootloader-external-flash.ld
 
 USB_VID = 0x239A
-USB_PID = 0x801b
+USB_PID = 0x8023
 
 SPI_FLASH_FILESYSTEM = 1
 


### PR DESCRIPTION
This makes it different from the bootloaders and Arduino.

Fixes #324.