### PR TITLE
Wait 2 secs before creating new filesystem in case power is jittery

### DIFF
--- a/atmel-samd/main.c
+++ b/atmel-samd/main.c
@@ -120,6 +120,11 @@ void init_flash_fs(bool create_allowed) {
     if (res == FR_NO_FILESYSTEM && create_allowed) {
         // no filesystem so create a fresh one
 
+        // Wait two seconds before creating. Jittery power might
+        // fail before we're ready. This can happen if someone
+        // is bobbling a bit when plugging in a battery.
+        mp_hal_delay_ms(2000);
+
         uint8_t working_buf[_MAX_SS];
         res = f_mkfs(&vfs_fat->fatfs, FM_FAT, 0, working_buf, sizeof(working_buf));
         // Flush the new file system to make sure its repaired immediately.


### PR DESCRIPTION
Wait a couple of seconds before creating a new filesystem if it appears the current filesystem is non-existent or severely corrupted. This will reduce the chance of erasing the filesystem on jittery power.

@tdicola could you try this? I tested with a CPX and a battery. Before this it was easy to erase the filesystem. Now it takes a lot more effort: I have to be really jittery when plugging in the battery and bobble the connector way beyond what would happen normally. I can lengthen the delay further.

If you need a build I can drop you one.