### PR TITLE
Unrevert the revert below, in preparation for PR #425 (tannewt/circuitpython, align_usb branch).

### DIFF
--- a/ports/atmel-samd/usb_mass_storage.c
+++ b/ports/atmel-samd/usb_mass_storage.c
@@ -63,10 +63,10 @@ static fs_user_mount_t* get_vfs(int lun) {
 /* Inquiry Information */
 // This is designed to handle the common case where we have an internal file
 // system and an optional SD card.
-COMPILER_ALIGNED(4) static uint8_t inquiry_info[2][36];
+static uint8_t inquiry_info[2][36];
 
 /* Capacities of Disk */
-COMPILER_ALIGNED(4) static uint8_t format_capa[2][8];
+static uint8_t format_capa[2][8];
 
 /**
  * \brief Eject Disk
@@ -259,6 +259,9 @@ int32_t usb_msc_xfer_done(uint8_t lun) {
     if (active_read) {
         active_addr += 1;
         active_nblocks--;
+        if (active_nblocks == 0) {
+            active_read = false;
+        }
     }
 
     if (active_write) {
@@ -272,10 +275,6 @@ int32_t usb_msc_xfer_done(uint8_t lun) {
 // The start_read callback begins a read transaction which we accept but delay our response until the "main thread" calls usb_msc_background. Once it does, we read immediately from the drive into our cache and trigger the USB DMA to output the sector. Once the sector is transmitted, xfer_done will be called.
 void usb_msc_background(void) {
     if (active_read && !usb_busy) {
-        if (active_nblocks == 0) {
-            active_read = false;
-            return;
-        }
         fs_user_mount_t * vfs = get_vfs(active_lun);
         disk_read(vfs, sector_buffer, active_addr, 1);
         // TODO(tannewt): Check the read result.


### PR DESCRIPTION
Roll back to b4fc464a4dd260bae9c2a49f996ffeb96268228d:

git revert -m 1 -n b82cfcb064e7a01548abcde5983b6d4be6fd9e9c
git revert -n 0e6928b087805f95520de34647d2836278fcdbf9
git revert -n bfe7e055e9b1dac0411fe975fdf2412029f03b33
git commit