### PR TITLE
Fix display orientation for _stage module

### DIFF
--- a/shared-module/_stage/Layer.c
+++ b/shared-module/_stage/Layer.c
@@ -47,8 +47,8 @@ uint16_t get_layer_pixel(layer_obj_t *layer, int16_t x, uint16_t y) {
         uint8_t tx = x >> 4;
         uint8_t ty = y >> 4;
 
-        frame = layer->map[(tx * layer->width + ty) >> 1];
-        if (ty & 0x01) {
+        frame = layer->map[(ty * layer->width + tx) >> 1];
+        if (tx & 0x01) {
             frame &= 0x0f;
         } else {
             frame >>= 4;
@@ -60,41 +60,41 @@ uint16_t get_layer_pixel(layer_obj_t *layer, int16_t x, uint16_t y) {
     y &= 0x0f;
 
     // Rotate the image.
-    uint8_t tx = x; // Temporary variable for swapping.
+    uint8_t ty = y; // Temporary variable for swapping.
     switch (layer->rotation) {
         case 1: // 90 degrees clockwise
-            x = 15 - y;
-            y = tx;
+            y = 15 - x;
+            x = ty;
             break;
         case 2: // 180 degrees
-            x = 15 - tx;
-            y = 15 - y;
+            y = 15 - ty;
+            x = 15 - x;
             break;
         case 3: // 90 degrees counter-clockwise
-            x = y;
-            y = 15 - tx;
+            y = x;
+            x = 15 - ty;
             break;
         case 4: // 0 degrees, mirrored
-            y = 15 - y;
+            x = 15 - x;
             break;
         case 5: // 90 degrees clockwise, mirrored
-            x = y;
-            y = tx;
+            y = x;
+            x = ty;
             break;
         case 6: // 180 degrees, mirrored
-            x = 15 - tx;
+            y = 15 - ty;
             break;
         case 7: // 90 degrees counter-clockwise, mirrored
-            x = 15 - y;
-            y = 15 - tx;
+            y = 15 - x;
+            x = 15 - ty;
             break;
         default: // 0 degrees
             break;
     }
 
     // Get the value of the pixel.
-    uint8_t pixel = layer->graphic[(frame << 7) + (x << 3) + (y >> 1)];
-    if (y & 0x01) {
+    uint8_t pixel = layer->graphic[(frame << 7) + (y << 3) + (x >> 1)];
+    if (x & 0x01) {
         pixel &= 0x0f;
     } else {
         pixel >>= 4;

--- a/shared-module/_stage/Text.c
+++ b/shared-module/_stage/Text.c
@@ -59,8 +59,8 @@ uint16_t get_text_pixel(text_obj_t *text, int16_t x, uint16_t y) {
     y &= 0x07;
 
     // Get the value of the pixel.
-    uint8_t pixel = text->font[(c << 4) + (x << 1) + (y >> 2)];
-    pixel = ((pixel >> ((y & 0x03) << 1)) & 0x03) + color_offset;
+    uint8_t pixel = text->font[(c << 4) + (y << 1) + (x >> 2)];
+    pixel = ((pixel >> ((x & 0x03) << 1)) & 0x03) + color_offset;
 
     // Convert to 16-bit color using the palette.
     return text->palette[pixel << 1] | text->palette[(pixel << 1) + 1] << 8;


### PR DESCRIPTION
Initially this library assumed the display is rotated by 90 degrees, so
the x and y were swapped. I'm now handling the display rotation in the
driver, with the hardware display settings, so the library should use
a sane order of x and y. This way it will work with any display
orientation.