### PR TITLE
fix markdown-styled link in design_guide.rst

### DIFF
--- a/docs/design_guide.rst
+++ b/docs/design_guide.rst
@@ -235,7 +235,7 @@ Renders as:
 Use BusDevice
 --------------------------------------------------------------------------------
 
-[BusDevice](https://github.com/adafruit/Adafruit_CircuitPython_BusDevice) is an
+`BusDevice <https://github.com/adafruit/Adafruit_CircuitPython_BusDevice>`_ is an
 awesome foundational library that manages talking on a shared I2C or SPI device
 for you. The devices manage locking which ensures that a transfer is done as a
 single unit despite CircuitPython internals and, in the future, other Python


### PR DESCRIPTION
fixes this problem 
![image](https://user-images.githubusercontent.com/924465/33520263-4934b748-d76c-11e7-8116-73fa44a7db23.png)
