### PR TITLE
Documentation Updates (mcu.delay() and Design Guide)

### DIFF
--- a/docs/design_guide.rst
+++ b/docs/design_guide.rst
@@ -419,8 +419,8 @@ mimic the structure in ``shared-bindings``.
 To test your native modules or core enhancements, follow these Adafruit Learning Guides
 for building local firmware to flash onto your device(s):
 
-`SAMD21 - Build Firmware https://learn.adafruit.com/micropython-for-samd21/build-firmware`
-`ESP8266 - Build Firmware https://learn.adafruit.com/building-and-running-micropython-on-the-esp8266/overview`
+|`SAMD21 - Build Firmware <https://learn.adafruit.com/micropython-for-samd21/build-firmware>`
+|`ESP8266 - Build Firmware <https://learn.adafruit.com/building-and-running-micropython-on-the-esp8266/overview>`
 
 MicroPython compatibility
 --------------------------------------------------------------------------------

--- a/docs/design_guide.rst
+++ b/docs/design_guide.rst
@@ -416,6 +416,12 @@ live in ``shared-module``. If it is port specific then it should live in ``commo
 within the port's folder. In either case, the file and folder structure should
 mimic the structure in ``shared-bindings``.
 
+To test your native modules or core enhancements, follow these Adafruit Learning Guides
+for building local firmware to flash onto your device(s):
+
+`SAMD21 - Build Firmware https://learn.adafruit.com/micropython-for-samd21/build-firmware`
+`ESP8266 - Build Firmware https://learn.adafruit.com/building-and-running-micropython-on-the-esp8266/overview`
+
 MicroPython compatibility
 --------------------------------------------------------------------------------
 

--- a/docs/design_guide.rst
+++ b/docs/design_guide.rst
@@ -419,8 +419,8 @@ mimic the structure in ``shared-bindings``.
 To test your native modules or core enhancements, follow these Adafruit Learning Guides
 for building local firmware to flash onto your device(s):
 
-|`SAMD21 - Build Firmware <https://learn.adafruit.com/micropython-for-samd21/build-firmware>`
-|`ESP8266 - Build Firmware <https://learn.adafruit.com/building-and-running-micropython-on-the-esp8266/overview>`
+`SAMD21 - Build Firmware <https://learn.adafruit.com/micropython-for-samd21/build-firmware>`_
+`ESP8266 - Build Firmware <https://learn.adafruit.com/building-and-running-micropython-on-the-esp8266/overview>`_
 
 MicroPython compatibility
 --------------------------------------------------------------------------------

--- a/docs/design_guide.rst
+++ b/docs/design_guide.rst
@@ -419,8 +419,9 @@ mimic the structure in ``shared-bindings``.
 To test your native modules or core enhancements, follow these Adafruit Learning Guides
 for building local firmware to flash onto your device(s):
 
-`SAMD21 - Build Firmware <https://learn.adafruit.com/micropython-for-samd21/build-firmware>`_
-`ESP8266 - Build Firmware <https://learn.adafruit.com/building-and-running-micropython-on-the-esp8266/overview>`_
+`SAMD21 - Build Firmware Learning Guide <https://learn.adafruit.com/micropython-for-samd21/build-firmware>`_
+
+`ESP8266 - Build Firmware Learning Guide <https://learn.adafruit.com/building-and-running-micropython-on-the-esp8266/overview>`_
 
 MicroPython compatibility
 --------------------------------------------------------------------------------

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -71,7 +71,11 @@
 //| .. method:: delay_us(delay)
 //|
 //|   Dedicated delay method used for very short delays. **Do not** do long delays
-//|   because it will stall any concurrent code.
+//|   because this stops all other functions from completing. Think of this as an empty
+//|   `while` loop that runs for the specified `(delay)` time. If you have other
+//|   code or peripherals that require specific timing or processing while you are waiting,
+//|   explore a different avenue such as using `time.monotonic()` to evaluate time
+//|   in a loop.
 //|
 STATIC mp_obj_t mcu_delay_us(mp_obj_t delay_obj) {
     uint32_t delay = mp_obj_get_int(delay_obj);

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -73,9 +73,9 @@
 //|   Dedicated delay method used for very short delays. **Do not** do long delays
 //|   because this stops all other functions from completing. Think of this as an empty
 //|   `while` loop that runs for the specified `(delay)` time. If you have other
-//|   code or peripherals that require specific timing or processing while you are waiting,
-//|   explore a different avenue such as using `time.monotonic()` to evaluate time
-//|   in a loop.
+//|   code or peripherals (e.g audio recording) that require specific timing or
+//|   processing while you are waiting, explore a different avenue such as using 
+//|   `time.sleep()`.
 //|
 STATIC mp_obj_t mcu_delay_us(mp_obj_t delay_obj) {
     uint32_t delay = mp_obj_get_int(delay_obj);

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -72,7 +72,7 @@
 //|
 //|   Dedicated delay method used for very short delays. **Do not** do long delays
 //|   because this stops all other functions from completing. Think of this as an empty
-//|   `while` loop that runs for the specified `(delay)` time. If you have other
+//|   ``while`` loop that runs for the specified ``(delay)`` time. If you have other
 //|   code or peripherals (e.g audio recording) that require specific timing or
 //|   processing while you are waiting, explore a different avenue such as using 
 //|   `time.sleep()`.


### PR DESCRIPTION
shared-bindings/microcontroller/__init.c__: updated documentation for `delay()`, per issue #243.
docs/design_guide: added links to learning guides for building firmware (SAMD21 & ESP8266).