### PR TITLE
Write version info to boot_out.txt

### DIFF
--- a/atmel-samd/main.c
+++ b/atmel-samd/main.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "genhdr/mpversion.h"
 #include "py/nlr.h"
 #include "py/compile.h"
 #include "py/frozenmod.h"
@@ -700,6 +701,9 @@ int main(void) {
         f_open(&((fs_user_mount_t *) MP_STATE_VM(vfs_mount_table)->obj)->fatfs,
             boot_output_file, CIRCUITPY_BOOT_OUTPUT_FILE, FA_WRITE | FA_CREATE_ALWAYS);
         flash_set_usb_writeable(true);
+        // Write version info to boot_out.txt.
+        mp_hal_stdout_tx_str(MICROPY_FULL_VERSION_INFO);
+        mp_hal_stdout_tx_str("\r\n");
         #endif
 
         // TODO(tannewt): Re-add support for flashing boot error output.

--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -256,7 +256,8 @@ STATIC int pyexec_friendly_repl_process_char(int c) {
         } else if (ret == CHAR_CTRL_B) {
             // reset friendly REPL
             mp_hal_stdout_tx_str("\r\n");
-            mp_hal_stdout_tx_str("Adafruit CircuitPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME "\r\n");
+            mp_hal_stdout_tx_str(MICROPY_FULL_VERSION_INFO);
+            mp_hal_stdout_tx_str("\r\n");
             // mp_hal_stdout_tx_str("Type \"help()\" for more information.\r\n");
             goto input_restart;
         } else if (ret == CHAR_CTRL_C) {
@@ -395,7 +396,9 @@ int pyexec_friendly_repl(void) {
 #endif
 
 friendly_repl_reset:
-    mp_hal_stdout_tx_str("\r\nAdafruit CircuitPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME "\r\n");
+    mp_hal_stdout_tx_str("\r\n");
+    mp_hal_stdout_tx_str(MICROPY_FULL_VERSION_INFO);
+    mp_hal_stdout_tx_str("\r\n");
     // mp_hal_stdout_tx_str("Type \"help()\" for more information.\r\n");
 
     // to test ctrl-C

--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -86,6 +86,7 @@ def make_version_header(filename):
 #define MICROPY_VERSION_MINOR (%s)
 #define MICROPY_VERSION_MICRO (%s)
 #define MICROPY_VERSION_STRING "%s"
+#define MICROPY_FULL_VERSION_INFO ("Adafruit CircuitPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME)
 """ % (git_tag, git_hash, datetime.date.today().strftime("%Y-%m-%d"),
     ver[0].replace('v', ''), ver[1], ver[2], version_string)
 


### PR DESCRIPTION
Fixes #449.

Before boot.py is run, write version info to boot_out.txt.
Consolidates long version string into mpversion.h, since it's printed a couple of different places.

I was worried about flash wear, but it turns out boot_out.txt is already rewriten every time, even if it's empty. We could fix that sometime in the future, but this change doesn't make it worse.

