### PR TITLE
Speed up AnalogIn.value.

### DIFF
--- a/atmel-samd/common-hal/analogio/AnalogIn.c
+++ b/atmel-samd/common-hal/analogio/AnalogIn.c
@@ -74,8 +74,10 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     config_adc.reference = ADC_REFERENCE_INTVCC1;
     config_adc.gain_factor = ADC_GAIN_FACTOR_DIV2;
     config_adc.positive_input = self->pin->adc_input;
-    config_adc.resolution = ADC_RESOLUTION_16BIT;
-    config_adc.clock_prescaler = ADC_CLOCK_PRESCALER_DIV128;
+    config_adc.resolution = ADC_RESOLUTION_12BIT;
+    // Default input clock is GCLK0 (48 MHz)
+    // 48Mhz / 32 = 1.5MHz. Max ADC clock is 2.1MHz
+    config_adc.clock_prescaler = ADC_CLOCK_PRESCALER_DIV32;
 
     struct adc_module adc_instance;
     // ADC must have been disabled before adc_init() is called.
@@ -108,7 +110,8 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     }
 
     adc_disable(&adc_instance);
-    return data;
+    // Scale to 16 bits. In the future we might make this be this be under API control.
+    return data * 16;
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {

--- a/atmel-samd/common-hal/microcontroller/Processor.c
+++ b/atmel-samd/common-hal/microcontroller/Processor.c
@@ -111,7 +111,9 @@ STATIC void configure_adc_temp(struct adc_module *adc_instance) {
     // "Discard the first conversion result whenever there is a change
     // in ADC configuration like voltage reference / ADC channel change."
 
-    config_adc.clock_prescaler = ADC_CLOCK_PRESCALER_DIV16;
+    // Default input clock is GCLK0 (48 MHz)
+    // 48Mhz / 32 = 1.5MHz. Max ADC clock is 2.1MHz
+    config_adc.clock_prescaler = ADC_CLOCK_PRESCALER_DIV32;
     config_adc.reference = ADC_REFERENCE_INT1V;
     config_adc.positive_input = ADC_POSITIVE_INPUT_TEMP;
     config_adc.negative_input = ADC_NEGATIVE_INPUT_GND;


### PR DESCRIPTION
Lower ADC prescaler divisor from 128 to 32. Lower resolution from 16 bit to 12 bit. Fixes #484.