### PR TITLE
Add code to delay reformatting filesystem and recheck before doing that

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,12 @@ _build
 # Generated rst files
 ######################
 genrst/
+
+# ctags and similar
+###################
+TAGS
+
+# Merge leftovers
+#################
+*.orig
+

--- a/atmel-samd/main.c
+++ b/atmel-samd/main.c
@@ -120,6 +120,11 @@ void init_flash_fs(bool create_allowed) {
     if (res == FR_NO_FILESYSTEM && create_allowed) {
         // no filesystem so create a fresh one
 
+        // Wait two seconds before creating. Jittery power might
+        // fail before we're ready. This can happen if someone
+        // is bobbling a bit when plugging in a battery.
+        mp_hal_delay_ms(2000);
+
         uint8_t working_buf[_MAX_SS];
         res = f_mkfs(&vfs_fat->fatfs, FM_FAT, 0, working_buf, sizeof(working_buf));
         // Flush the new file system to make sure its repaired immediately.

--- a/atmel-samd/main.c
+++ b/atmel-samd/main.c
@@ -125,16 +125,20 @@ void init_flash_fs(bool create_allowed) {
         // is bobbling a bit when plugging in a battery.
         mp_hal_delay_ms(2000);
 
-        uint8_t working_buf[_MAX_SS];
-        res = f_mkfs(&vfs_fat->fatfs, FM_FAT, 0, working_buf, sizeof(working_buf));
-        // Flush the new file system to make sure its repaired immediately.
-        flash_flush();
-        if (res != FR_OK) {
-            return;
-        }
+        // Then try one more time to mount the flash in case it was late coming up.
+        res = f_mount(&vfs_fat->fatfs);
+        if (res == FR_NO_FILESYSTEM) {
+            uint8_t working_buf[_MAX_SS];
+            res = f_mkfs(&vfs_fat->fatfs, FM_FAT, 0, working_buf, sizeof(working_buf));
+            // Flush the new file system to make sure its repaired immediately.
+            flash_flush();
+            if (res != FR_OK) {
+                return;
+            }
 
-        // set label
-        f_setlabel(&vfs_fat->fatfs, "CIRCUITPY");
+            // set label
+            f_setlabel(&vfs_fat->fatfs, "CIRCUITPY");
+        }
     } else if (res != FR_OK) {
         return;
     }


### PR DESCRIPTION
Helps #386. I can still erase the filesystem in pathological cases, but this is a lot better than not checking. Besides @tdicola, @ladyada had this happen once, apparently with USB.