### PR TITLE
Add git version info to frozen modules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,6 @@
 [submodule "frozen/Adafruit_CircuitPython_BusDevice"]
 	path = frozen/Adafruit_CircuitPython_BusDevice
 	url = https://github.com/adafruit/Adafruit_CircuitPython_BusDevice.git
+[submodule "tools/python-semver"]
+	path = tools/python-semver
+	url = https://github.com/k-bx/python-semver.git

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -70,6 +70,7 @@ endif
 MAKE_FROZEN = $(TOP)/tools/make-frozen.py
 MPY_CROSS = $(TOP)/mpy-cross/mpy-cross
 MPY_TOOL = $(TOP)/tools/mpy-tool.py
+PREPROCESS_FROZEN_MODULES = PYTHONPATH=$(TOP)/tools/python-semver $(TOP)/tools/preprocess_frozen_modules.py
 
 all:
 .PHONY: all

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -114,14 +114,13 @@ $(MPY_CROSS): $(TOP)/py/*.[ch] $(TOP)/mpy-cross/*.[ch] $(TOP)/windows/fmode.c
 	$(Q)$(MAKE) -C $(TOP)/mpy-cross
 
 # Copy all the modules and single python files to freeze to a common area, omitting top-level dirs (the repo names).
-# Remove any conf.py (sphinx config) and setup.py (module install info) files, which are not meant to be frozen.
-# Also remove the library examples directory, so it won't be included.
+# Do any preprocessing necessary: currently, this adds version information, removes examples, and
+# non-library .py files in the modules (setup.py and conf.py)
 # Then compile .mpy files from all the .py files, placing them in the same directories as the .py files.
 $(BUILD)/frozen_mpy: $(FROZEN_MPY_DIRS)
 	$(ECHO) FREEZE $(FROZEN_MPY_DIRS)
 	$(Q)$(MKDIR) -p $@
-	$(Q)$(RSYNC) -rL --include="*/" --include='*.py' --exclude="*" $(addsuffix /*,$(FROZEN_MPY_DIRS)) $@
-	$(Q)$(RM) -rf $@/conf.py $@/setup.py $@/examples
+	$(Q)$(PREPROCESS_FROZEN_MODULES) -o $@ $(FROZEN_MPY_DIRS)
 	$(Q)$(CD) $@ && \
 $(FIND) -L . -type f -name '*.py' | sed 's=^\./==' | \
 xargs -n1 $(abspath $(MPY_CROSS)) $(MPY_CROSS_FLAGS)

--- a/tools/preprocess_frozen_modules.py
+++ b/tools/preprocess_frozen_modules.py
@@ -45,7 +45,9 @@ def copy_and_process(in_dir, out_dir):
             output_file_path = Path(out_dir, input_file_path.relative_to(in_dir))
 
             if file.endswith(".py"):
-                output_file_path.parent.mkdir(parents=True, exist_ok=True)
+                # mkdir() takes an exists_ok=True, but not until Python 3.5.
+                if not output_file_path.parent.exists():
+                    output_file_path.parent.mkdir(parents=True)
                 with input_file_path.open("r") as input, output_file_path.open("w") as output:
                     for line in input:
                         if line.startswith("__version__"):


### PR DESCRIPTION
Fill in `__version__` when freezing modules. This mimics `__version__` processing done when building library bundles.

Added https://github.com/k-bx/python-semver as a submodule, so it doesn't have to be installed by hand.

Pulled all frozen module preprocessing into a single Python script, including the above, and also removing `examples/` and `conf.py` and `setup.py`