### PR TITLE
shared-bindings/index.rst: added audiobusio

### DIFF
--- a/shared-bindings/index.rst
+++ b/shared-bindings/index.rst
@@ -16,6 +16,7 @@ Support Matrix
 Module / Port      SAMD21   SAMD21 Express  ESP8266
 =================  =======  ==============  =======
 `analogio`         **Yes**  **Yes**         **Yes**
+`audiobusio`       **Yes**  **Yes**         No
 `audioio`          No       **Yes**         No
 `bitbangio`        No       **Yes**         **Yes**
 `board`            **Yes**  **Yes**         **Yes**


### PR DESCRIPTION
shared-bindings/index.rst: added `aduiobusio` to Support Matrix. Used `audiobusio/_init_.c` to verify applicable ports; SAMD21 was the only one listed...ESP8266 wasn't. This fixes issue #448.