### PR TITLE
Avoid gcc 7.2.1 compiler issues in nlr_push()

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -92,6 +92,7 @@ endif
 ifeq ($(DEBUG), 1)
   # Turn on Python modules useful for debugging (e.g. uheap, ustack).
   CFLAGS += -ggdb
+  CFLAGS += -flto
   ifeq ($(CHIP_FAMILY), samd21)
     CFLAGS += -DENABLE_MICRO_TRACE_BUFFER
   endif
@@ -122,8 +123,6 @@ ifeq ($(CHIP_FAMILY), samd51)
 CFLAGS += \
 	-mthumb \
 	-mabi=aapcs-linux \
-	-mlong-calls \
-	-mtune=cortex-m4 \
 	-mcpu=cortex-m4 \
 	-mfloat-abi=hard \
 	-mfpu=fpv4-sp-d16 \

--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -76,7 +76,10 @@ __attribute__((naked)) unsigned int nlr_push(nlr_buf_t *nlr) {
 #endif
     :                               // output operands
     : "r" (nlr)                     // input operands
-    : "r1", "r2", "r3"        // clobbers
+    // Do not use r1, r2, r3 as temporary saving registers.
+    // gcc 7.2.1 started doing this, and r3 got clobbered in nlr_push_tail.
+    // See https://github.com/adafruit/circuitpython/issues/500 for details.
+    : "r1", "r2", "r3"              // clobbers
                     );
 
     return 0; // needed to silence compiler warning

--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -74,7 +74,10 @@ __attribute__((naked)) unsigned int nlr_push(nlr_buf_t *nlr) {
 #else
     "b      nlr_push_tail       \n" // do the rest in C
 #endif
-    );
+    :                               // output operands
+    : "r" (nlr)                     // input operands
+    : "r1", "r2", "r3"        // clobbers
+                    );
 
     return 0; // needed to silence compiler warning
 }


### PR DESCRIPTION
Appears to fix #500. Extensive writeup there.

Also removed a couple of compiler flags that were not needed:
`-mtune=cortex-m4`    supposedly subsumed by `-mcpu=cortex-m4`
`-mlong-calls`   handles calls further away than 64MB. That's not an issue for us! Removing this saves about 12.5kB (!) in M4 image.

Also turned on `-flto` in `DEBUG=1` builds to make it more likely we'll hit issues, but made it easy to comment out.