### PR TITLE
issue #536 CPX change SPI pin designations to externally available pins

### DIFF
--- a/ports/atmel-samd/boards/circuitplayground_express/pins.c
+++ b/ports/atmel-samd/boards/circuitplayground_express/pins.c
@@ -45,9 +45,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_SPEAKER_ENABLE), MP_ROM_PTR(&pin_PA30) },
 
-    { MP_ROM_QSTR(MP_QSTR_SCK),  MP_ROM_PTR(&pin_PA21) },
-    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_PA20) },
-    { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_PA16) },
-    { MP_ROM_QSTR(MP_QSTR_FLASH_CS),   MP_ROM_PTR(&pin_PB22) },
+    { MP_ROM_QSTR(MP_QSTR_SCK),  MP_ROM_PTR(&pin_PA07) },
+    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_PA05) },
+    { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_PA06) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);

--- a/ports/atmel-samd/boards/circuitplayground_express/pins.c
+++ b/ports/atmel-samd/boards/circuitplayground_express/pins.c
@@ -45,8 +45,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_SPEAKER_ENABLE), MP_ROM_PTR(&pin_PA30) },
 
-    { MP_ROM_QSTR(MP_QSTR_SCK),  MP_ROM_PTR(&pin_PA07) },
-    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_PA05) },
+    { MP_ROM_QSTR(MP_QSTR_SCK),  MP_ROM_PTR(&pin_PA05) },
+    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_PA07) },
     { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_PA06) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);


### PR DESCRIPTION
Reassigned A1, A2, A3 to MOSI/MISO/SCK. Removed FLASH_CS. 
#536 