### PR TITLE
Re-added header inlcusion for system_get_chip_id

### DIFF
--- a/ports/esp8266/common-hal/microcontroller/Processor.c
+++ b/ports/esp8266/common-hal/microcontroller/Processor.c
@@ -29,6 +29,7 @@
 #include <math.h>
 
 #include "esp_mphal.h"
+#include "user_interface.h"
 
 
 float common_hal_mcu_processor_get_temperature(void) {


### PR DESCRIPTION
During the PR merge for the `UID` functions, seems like a required header inclusion was dropped off for the ESP8266. This caused a build error. See Issue #543.

Thanks to @jerryneedell for finding and reporting!

