### PR TITLE
alloca seems buggy on M4

### DIFF
--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -144,7 +144,7 @@ STATIC mp_obj_t re_split(size_t n_args, const mp_obj_t *args) {
     }
 
     mp_obj_t retval = mp_obj_new_list(0, NULL);
-    const char **caps = alloca(caps_num * sizeof(char*));
+    const char* caps[caps_num];
     while (true) {
         // cast is a workaround for a bug in msvc: it treats const char** as a const pointer instead of a pointer to pointer to const char
         memset((char**)caps, 0, caps_num * sizeof(char*));

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -330,7 +330,7 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
         }
 
         uint new_mod_l = (mod_len == 0 ? (size_t)(p - this_name) : (size_t)(p - this_name) + 1 + mod_len);
-        char *new_mod = alloca(new_mod_l);
+        char new_mod[new_mod_l];
         memcpy(new_mod, this_name, p - this_name);
         if (mod_len != 0) {
             new_mod[p - this_name] = '.';

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -330,7 +330,7 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
         }
 
         uint new_mod_l = (mod_len == 0 ? (size_t)(p - this_name) : (size_t)(p - this_name) + 1 + mod_len);
-        char new_mod[new_mod_l];
+        char *new_mod = alloca(new_mod_l);
         memcpy(new_mod, this_name, p - this_name);
         if (mod_len != 0) {
             new_mod[p - this_name] = '.';

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1428,9 +1428,10 @@ import_error:
     mp_load_method_maybe(module, MP_QSTR___name__, dest);
     size_t pkg_name_len;
     const char *pkg_name = mp_obj_str_get_data(dest[0], &pkg_name_len);
-
     const uint dot_name_len = pkg_name_len + 1 + qstr_len(name);
-    char *dot_name = alloca(dot_name_len);
+    // Previously dot_name was created using alloca(), but that caused run-time crashes on M4 due to
+    // stack corruption (compiler bug, it appears), so use an array instead.
+    char dot_name[dot_name_len];
     memcpy(dot_name, pkg_name, pkg_name_len);
     dot_name[pkg_name_len] = '.';
     memcpy(dot_name + pkg_name_len + 1, qstr_str(name), qstr_len(name));


### PR DESCRIPTION
Fixes #521. The problem appears to be bad compilation of `alloca()`. `alloca()` can be replaced with a run-time variable array: that works.

I replaced a few other uses of `alloca()` that were similar, just in case they might also be problematic. There are some uses where `alloca()` is not done at the point of declaration, and those are harder to change. Also there are submodules with lots of uses of `alloca()` that I didn't change.

Eventually I will try to come up with a small test case and submit a gcc bug report.