### PR TITLE
3.0 double word stack align

### DIFF
--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -144,7 +144,7 @@ STATIC mp_obj_t re_split(size_t n_args, const mp_obj_t *args) {
     }
 
     mp_obj_t retval = mp_obj_new_list(0, NULL);
-    const char* caps[caps_num];
+    const char **caps = alloca(caps_num * sizeof(char*));
     while (true) {
         // cast is a workaround for a bug in msvc: it treats const char** as a const pointer instead of a pointer to pointer to const char
         memset((char**)caps, 0, caps_num * sizeof(char*));

--- a/ports/atmel-samd/boards/samd21x18-bootloader-crystalless.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader-crystalless.ld
@@ -11,7 +11,8 @@ MEMORY
 }
 
 /* top end of the stack */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - 4;
+/* stack must be double-word (8 byte) aligned */
+_estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
 _bootloader_dbl_tap = _estack;
 
 /* define output sections */

--- a/ports/atmel-samd/boards/samd21x18-bootloader-external-flash-crystalless.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader-external-flash-crystalless.ld
@@ -11,7 +11,8 @@ MEMORY
 }
 
 /* top end of the stack */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - 4;
+/* stack must be double-word (8 byte) aligned */
+_estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
 _bootloader_dbl_tap = _estack;
 
 /* define output sections */

--- a/ports/atmel-samd/boards/samd21x18-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader-external-flash.ld
@@ -10,7 +10,8 @@ MEMORY
 }
 
 /* top end of the stack */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - 4;
+/* stack must be double-word (8 byte) aligned */
+_estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
 _bootloader_dbl_tap = _estack;
 
 /* define output sections */

--- a/ports/atmel-samd/boards/samd21x18-bootloader.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader.ld
@@ -11,7 +11,8 @@ MEMORY
 }
 
 /* top end of the stack */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - 4;
+/* stack must be double-word (8 byte) aligned */
+_estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
 _bootloader_dbl_tap = _estack;
 
 /* define output sections */

--- a/ports/atmel-samd/boards/samd51x18-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd51x18-bootloader-external-flash.ld
@@ -10,7 +10,8 @@ MEMORY
 }
 
 /* top end of the stack */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - 4;
+/* stack must be double-word (8 byte) aligned */
+_estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
 _bootloader_dbl_tap = _estack;
 
 /* define output sections */

--- a/ports/atmel-samd/boards/samd51x19-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd51x19-bootloader-external-flash.ld
@@ -10,7 +10,8 @@ MEMORY
 }
 
 /* top end of the stack */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - 4;
+/* stack must be double-word (8 byte) aligned */
+_estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
 _bootloader_dbl_tap = _estack;
 
 /* define output sections */

--- a/ports/atmel-samd/boards/samd51x19-bootloader.ld
+++ b/ports/atmel-samd/boards/samd51x19-bootloader.ld
@@ -10,7 +10,8 @@ MEMORY
 }
 
 /* top end of the stack */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - 4;
+/* stack must be double-word (8 byte) aligned */
+_estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
 _bootloader_dbl_tap = _estack;
 
 /* define output sections */

--- a/ports/atmel-samd/boards/samd51x20-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd51x20-bootloader-external-flash.ld
@@ -10,7 +10,8 @@ MEMORY
 }
 
 /* top end of the stack */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - 4;
+/* stack must be double-word (8 byte) aligned */
+_estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
 _bootloader_dbl_tap = _estack;
 
 /* define output sections */

--- a/ports/atmel-samd/boards/samd51x20-bootloader.ld
+++ b/ports/atmel-samd/boards/samd51x20-bootloader.ld
@@ -10,7 +10,8 @@ MEMORY
 }
 
 /* top end of the stack */
-_estack = ORIGIN(RAM) + LENGTH(RAM) - 4;
+/* stack must be double-word (8 byte) aligned */
+_estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
 _bootloader_dbl_tap = _estack;
 
 /* define output sections */

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1428,10 +1428,9 @@ import_error:
     mp_load_method_maybe(module, MP_QSTR___name__, dest);
     size_t pkg_name_len;
     const char *pkg_name = mp_obj_str_get_data(dest[0], &pkg_name_len);
+
     const uint dot_name_len = pkg_name_len + 1 + qstr_len(name);
-    // Previously dot_name was created using alloca(), but that caused run-time crashes on M4 due to
-    // stack corruption (compiler bug, it appears), so use an array instead.
-    char dot_name[dot_name_len];
+    char *dot_name = alloca(dot_name_len);
     memcpy(dot_name, pkg_name, pkg_name_len);
     dot_name[pkg_name_len] = '.';
     memcpy(dot_name + pkg_name_len + 1, qstr_str(name), qstr_len(name));


### PR DESCRIPTION
Undo #548 with a revert and replace with a better fix. Fixes #549: align stack on a double-word (8 byte boundary).