### PR TITLE
Bring back the _stage library

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -333,6 +333,9 @@ SRC_SHARED_MODULE = \
 	busio/OneWire.c \
 	gamepad/__init__.c \
 	gamepad/GamePad.c \
+	_stage/__init__.c \
+	_stage/Layer.c \
+	_stage/Text.c \
 	os/__init__.c \
 	random/__init__.c \
 	storage/__init__.c \

--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -173,6 +173,7 @@ extern const struct _mp_obj_module_t uheap_module;
 extern const struct _mp_obj_module_t ustack_module;
 extern const struct _mp_obj_module_t supervisor_module;
 extern const struct _mp_obj_module_t gamepad_module;
+extern const struct _mp_obj_module_t stage_module;
 extern const struct _mp_obj_module_t touchio_module;
 extern const struct _mp_obj_module_t usb_hid_module;
 
@@ -214,6 +215,7 @@ extern const struct _mp_obj_module_t usb_hid_module;
 //    { MP_OBJ_NEW_QSTR(MP_QSTR_analogio), (mp_obj_t)&analogio_module },
 
 //    { MP_OBJ_NEW_QSTR(MP_QSTR_gamepad),(mp_obj_t)&gamepad_module },
+//    { MP_OBJ_NEW_QSTR(MP_QSTR__stage), (mp_obj_t)&stage_module },
 //    { MP_OBJ_NEW_QSTR(MP_QSTR_usb_hid),(mp_obj_t)&usb_hid_module },
 
 


### PR DESCRIPTION
I have tested the _stage module, and it works fine, so I'm including it
in he sources again. It's still disabled by default in the
mpconfigport.h.