### PR TITLE
DM: added write_readinto to bitbangio

### DIFF
--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -244,23 +244,23 @@ STATIC mp_obj_t bitbangio_spi_write_readinto(size_t n_args, const mp_obj_t *args
     raise_error_if_deinited(shared_module_bitbangio_spi_deinited(self));
 
     mp_buffer_info_t bufinfoin;
-	mp_get_buffer_raise(args[2], &bufinfoin, MP_BUFFER_WRITE);
+    mp_get_buffer_raise(args[2], &bufinfoin, MP_BUFFER_WRITE);
 
-	if (bufinfoin.len == 0) {
-		return mp_const_none;
-	}
+    if (bufinfoin.len == 0) {
+        return mp_const_none;
+    }
 
-	mp_buffer_info_t bufinfoout;
-	mp_get_buffer_raise(args[1], &bufinfoout, MP_BUFFER_READ);
+    mp_buffer_info_t bufinfoout;
+    mp_get_buffer_raise(args[1], &bufinfoout, MP_BUFFER_READ);
 
-	if (bufinfoout.len != bufinfoin.len) {
-		mp_raise_ValueError("buffers must be of equal length");
-	}
+    if (bufinfoout.len != bufinfoin.len) {
+        mp_raise_ValueError("buffers must be of equal length");
+    }
 
     bool ok = shared_module_bitbangio_spi_transfer(self,
                                             ((uint8_t*)bufinfoout.buf),
                                             ((uint8_t*)bufinfoin.buf),
-											bufinfoin.len);
+                                            bufinfoin.len);
     if (!ok) {
         mp_raise_OSError(MP_EIO);
     }

--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -236,7 +236,7 @@ STATIC mp_obj_t bitbangio_spi_readinto(size_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitbangio_spi_readinto_obj, 2, 2, bitbangio_spi_readinto);
 
-//|   .. method:: SPI.write_readinto(buf_in, buf_out)
+//|   .. method:: SPI.write_readinto(buffer_out, buffer_in)
 //|
 //|     Write out the data in ``buffer_out`` while simultaneously reading data into ``buffer_in``.
 STATIC mp_obj_t bitbangio_spi_write_readinto(size_t n_args, const mp_obj_t *args) {
@@ -279,7 +279,7 @@ STATIC const mp_rom_map_elem_t bitbangio_spi_locals_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&bitbangio_spi_readinto_obj) },
     { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&bitbangio_spi_write_obj) },
-	{ MP_ROM_QSTR(MP_QSTR_write_readinto), MP_ROM_PTR(&bitbangio_spi_write_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write_readinto), MP_ROM_PTR(&bitbangio_spi_write_readinto_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(bitbangio_spi_locals_dict, bitbangio_spi_locals_dict_table);
 

--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -236,6 +236,38 @@ STATIC mp_obj_t bitbangio_spi_readinto(size_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitbangio_spi_readinto_obj, 2, 2, bitbangio_spi_readinto);
 
+//|   .. method:: SPI.write_readinto(buf_in, buf_out)
+//|
+//|     Write out the data in ``buffer_out`` while simultaneously reading data into ``buffer_in``.
+STATIC mp_obj_t bitbangio_spi_write_readinto(size_t n_args, const mp_obj_t *args) {
+    bitbangio_spi_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    raise_error_if_deinited(shared_module_bitbangio_spi_deinited(self));
+
+    mp_buffer_info_t bufinfoin;
+	mp_get_buffer_raise(args[2], &bufinfoin, MP_BUFFER_WRITE);
+
+	if (bufinfoin.len == 0) {
+		return mp_const_none;
+	}
+
+	mp_buffer_info_t bufinfoout;
+	mp_get_buffer_raise(args[1], &bufinfoout, MP_BUFFER_READ);
+
+	if (bufinfoout.len != bufinfoin.len) {
+		mp_raise_ValueError("buffers must be of equal length");
+	}
+
+    bool ok = shared_module_bitbangio_spi_transfer(self,
+                                            ((uint8_t*)bufinfoout.buf),
+                                            ((uint8_t*)bufinfoin.buf),
+											bufinfoin.len);
+    if (!ok) {
+        mp_raise_OSError(MP_EIO);
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitbangio_spi_write_readinto_obj, 3, 3, bitbangio_spi_write_readinto);
+
 STATIC const mp_rom_map_elem_t bitbangio_spi_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&bitbangio_spi_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&default___enter___obj) },
@@ -247,6 +279,7 @@ STATIC const mp_rom_map_elem_t bitbangio_spi_locals_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&bitbangio_spi_readinto_obj) },
     { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&bitbangio_spi_write_obj) },
+	{ MP_ROM_QSTR(MP_QSTR_write_readinto), MP_ROM_PTR(&bitbangio_spi_write_readinto_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(bitbangio_spi_locals_dict, bitbangio_spi_locals_dict_table);
 

--- a/shared-bindings/bitbangio/SPI.h
+++ b/shared-bindings/bitbangio/SPI.h
@@ -56,4 +56,7 @@ extern bool shared_module_bitbangio_spi_write(bitbangio_spi_obj_t *self, const u
 // Reads in len bytes while outputting zeroes.
 extern bool shared_module_bitbangio_spi_read(bitbangio_spi_obj_t *self, uint8_t *data, size_t len);
 
+// Transfer out len bytes while reading len bytes
+extern bool shared_module_bitbangio_spi_transfer(bitbangio_spi_obj_t *self, const uint8_t *dout, uint8_t *din, size_t len);
+
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_BITBANGIO_SPI_H

--- a/shared-module/bitbangio/SPI.c
+++ b/shared-module/bitbangio/SPI.c
@@ -257,13 +257,13 @@ bool shared_module_bitbangio_spi_transfer(bitbangio_spi_obj_t *self, const uint8
         for (size_t i = 0; i < len; ++i) {
             uint8_t data_out = dout[i];
             uint8_t data_in = 0;
-			for (int j = 0; j < 8; ++j, data_out <<= 1) {
-				common_hal_digitalio_digitalinout_set_value(&self->mosi, (data_out >> 7) & 1);
-				common_hal_digitalio_digitalinout_set_value(&self->clock, 1 - self->polarity);
-				data_in = (data_in << 1) | common_hal_digitalio_digitalinout_get_value(&self->miso);
-				common_hal_digitalio_digitalinout_set_value(&self->clock, self->polarity);
-			}
-			din[i] = data_in;
+            for (int j = 0; j < 8; ++j, data_out <<= 1) {
+                common_hal_digitalio_digitalinout_set_value(&self->mosi, (data_out >> 7) & 1);
+                common_hal_digitalio_digitalinout_set_value(&self->clock, 1 - self->polarity);
+                data_in = (data_in << 1) | common_hal_digitalio_digitalinout_get_value(&self->miso);
+                common_hal_digitalio_digitalinout_set_value(&self->clock, self->polarity);
+            }
+            din[i] = data_in;
 
             if (dest != NULL) {
                 dest[i] = data_in;
@@ -279,20 +279,20 @@ bool shared_module_bitbangio_spi_transfer(bitbangio_spi_obj_t *self, const uint8
         for (int j = 0; j < 8; ++j, data_out <<= 1) {
             common_hal_digitalio_digitalinout_set_value(&self->mosi, (data_out >> 7) & 1);
             if (self->phase == 0) {
-				common_hal_mcu_delay_us(delay_half);
-				common_hal_digitalio_digitalinout_set_value(&self->clock, 1 - self->polarity);
-			} else {
-				common_hal_digitalio_digitalinout_set_value(&self->clock, 1 - self->polarity);
-				common_hal_mcu_delay_us(delay_half);
-			}
-			data_in = (data_in << 1) | common_hal_digitalio_digitalinout_get_value(&self->miso);
-			if (self->phase == 0) {
-				common_hal_mcu_delay_us(delay_half);
-				common_hal_digitalio_digitalinout_set_value(&self->clock, self->polarity);
-			} else {
-				common_hal_digitalio_digitalinout_set_value(&self->clock, self->polarity);
-				common_hal_mcu_delay_us(delay_half);
-			}
+                common_hal_mcu_delay_us(delay_half);
+                common_hal_digitalio_digitalinout_set_value(&self->clock, 1 - self->polarity);
+            } else {
+                common_hal_digitalio_digitalinout_set_value(&self->clock, 1 - self->polarity);
+                common_hal_mcu_delay_us(delay_half);
+            }
+            data_in = (data_in << 1) | common_hal_digitalio_digitalinout_get_value(&self->miso);
+            if (self->phase == 0) {
+                common_hal_mcu_delay_us(delay_half);
+                common_hal_digitalio_digitalinout_set_value(&self->clock, self->polarity);
+            } else {
+                common_hal_digitalio_digitalinout_set_value(&self->clock, self->polarity);
+                common_hal_mcu_delay_us(delay_half);
+            }
         }
         din[i] = data_in;
 


### PR DESCRIPTION
add write_readinto support to bitbangio https://github.com/adafruit/circuitpython/issues/472

note that in the current master branch bitbangio module is not compiled in by default and will have to be added into the makefile

code sample:
```#to test this, connect mosi and miso together
import bitbangio
import board

spi = bitbangio.SPI(board.D10, board.D6, board.D9)

while not spi.try_lock():
    pass

a = bytearray(2)
spi.write_readinto(bytes([9, 88]), a)

#if mosi and miso are connected this should print 9, 88
for b in a:
    print(b)
```