### PR TITLE
nrf: Cleanup AnalogOut and throw an exception in constructor

### DIFF
--- a/ports/nrf/common-hal/analogio/AnalogOut.c
+++ b/ports/nrf/common-hal/analogio/AnalogOut.c
@@ -34,43 +34,17 @@
 
 
 void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self, const mcu_pin_obj_t *pin) {
-//    if (pin->pin != PIN_PA02) {
-//        mp_raise_ValueError("AnalogOut not supported on given pin");
-//        return;
-//    }
-//    struct dac_config config_dac;
-//    dac_get_config_defaults(&config_dac);
-//    config_dac.reference = DAC_REFERENCE_AVCC;
-//    enum status_code status = dac_init(&self->dac_instance, DAC, &config_dac);
-//    if (status != STATUS_OK) {
-//        mp_raise_OSError(MP_EIO);
-//        return;
-//    }
-//    claim_pin(pin);
-//
-//    struct dac_chan_config config_analogout_chan;
-//    dac_chan_get_config_defaults(&config_analogout_chan);
-//    dac_chan_set_config(&self->dac_instance, DAC_CHANNEL_0, &config_analogout_chan);
-//    dac_chan_enable(&self->dac_instance, DAC_CHANNEL_0);
-//
-//    dac_enable(&self->dac_instance);
+    mp_raise_RuntimeError("AnalogOut functionality not supported");
 }
 
 bool common_hal_analogio_analogout_deinited(analogio_analogout_obj_t *self) {
-    return self->deinited;
+    return true;
 }
 
 void common_hal_analogio_analogout_deinit(analogio_analogout_obj_t *self) {
-//    if (common_hal_analogio_analogout_deinited(self)) {
-//        return;
-//    }
-//    dac_disable(&self->dac_instance);
-//    dac_chan_disable(&self->dac_instance, DAC_CHANNEL_0);
-//    reset_pin(PIN_PA02);
-//    self->deinited = true;
+
 }
 
 void common_hal_analogio_analogout_set_value(analogio_analogout_obj_t *self, uint16_t value) {
-    // Input is 16 bit but we only support 10 bit so we shift the input.
-//    dac_chan_write(&self->dac_instance, DAC_CHANNEL_0, value >> 6);
+
 }

--- a/ports/nrf/common-hal/analogio/AnalogOut.h
+++ b/ports/nrf/common-hal/analogio/AnalogOut.h
@@ -27,16 +27,10 @@
 #ifndef MICROPY_INCLUDED_NRF_COMMON_HAL_ANALOGIO_ANALOGOUT_H
 #define MICROPY_INCLUDED_NRF_COMMON_HAL_ANALOGIO_ANALOGOUT_H
 
-#include "common-hal/microcontroller/Pin.h"
-
-//#include "asf/sam0/drivers/dac/dac.h"
-
 #include "py/obj.h"
 
 typedef struct {
     mp_obj_base_t base;
-//    struct dac_module dac_instance;
-    bool deinited;
 } analogio_analogout_obj_t;
 
 #endif // MICROPY_INCLUDED_NRF_COMMON_HAL_ANALOGIO_ANALOGOUT_H


### PR DESCRIPTION
The nRF MCUs do not support analog output. Throwing an exception
in the constructor will stop users from creating an instance of
the AnalogOut class.

In the future we can ifdef-out the whole class so it is not available
in the module at all.