### PR TITLE
nrf: Change the exception that AnalogOut throws

### DIFF
--- a/ports/nrf/common-hal/analogio/AnalogOut.c
+++ b/ports/nrf/common-hal/analogio/AnalogOut.c
@@ -34,7 +34,7 @@
 
 
 void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self, const mcu_pin_obj_t *pin) {
-    mp_raise_RuntimeError("AnalogOut functionality not supported");
+    mp_raise_OSError("No hardware support for analog out");
 }
 
 bool common_hal_analogio_analogout_deinited(analogio_analogout_obj_t *self) {


### PR DESCRIPTION
To comply with the one thrown in the ESP port.