### PR TITLE
Correct _etext location; clean up .ld files

### DIFF
--- a/ports/atmel-samd/boards/samd21x18-bootloader-crystalless.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader-crystalless.ld
@@ -1,13 +1,13 @@
 /*
-    GNU linker script for SAMD21
+    GNU linker script for SAMD21x18 (256K flash, 32K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
     /* Leave 8KiB for the bootloader, 256b for persistent config (clock), 64k for the flash file system and 256b for the user config. */
-    FLASH (rx) : ORIGIN = 0x00000000+0x2000, LENGTH = 0x00040000 - 0x2000 - 0x100 - 0x010000 - 0x100
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x008000 /* 32 KiB */
+    FLASH (rx) : ORIGIN = 0x00000000 + 8K, LENGTH = 256K - 8K - 256 - 64K - 256
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 /* top end of the stack */
@@ -30,14 +30,14 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
@@ -76,7 +76,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd21x18-bootloader-external-flash-crystalless.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader-external-flash-crystalless.ld
@@ -1,13 +1,13 @@
 /*
-    GNU linker script for SAMD21
+    GNU linker script for SAMD21x18 (256K flash, 32K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
     /* Leave 8KiB for the bootloader, 256b for internal config and 256b for user config. */
-    FLASH (rx) : ORIGIN = 0x00000000 + 0x2000, LENGTH = 0x00040000 - 0x2000 - 0x100 - 0x100
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x008000 /* 32 KiB */
+    FLASH (rx) : ORIGIN = 0x00000000 + 8K, LENGTH = 256K - 8K - 256 - 256
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 /* top end of the stack */
@@ -30,14 +30,14 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
@@ -76,7 +76,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd21x18-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader-external-flash.ld
@@ -1,12 +1,13 @@
 /*
-    GNU linker script for SAMD21
+    GNU linker script for SAMD21x18 (256K flash, 32K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx) : ORIGIN = 0x00000000 + 0x2000, LENGTH = 0x00040000 - 0x2000 - 0x100 /* Leave 8KiB for the bootloader and 256b for user config. */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x008000 /* 32 KiB */
+    /* Leave 8KiB for the bootloader and 256b for user config. */
+    FLASH (rx) : ORIGIN = 0x00000000 + 8K, LENGTH = 256K - 8K - 256
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 32K /* 32 KiB RAM */
 }
 
 /* top end of the stack */
@@ -29,21 +30,21 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
     The program executes knowing that the data is in the RAM
     but the loader puts the initial values in the FLASH (inidata).
     It is one task of the startup to copy the initial values from FLASH to RAM. */
-    .data : AT ( _sidata )
+    .data : AT ( _etext )
     {
         . = ALIGN(4);
         _srelocate = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
@@ -75,7 +76,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd21x18-bootloader.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader.ld
@@ -1,13 +1,13 @@
 /*
-    GNU linker script for SAMD21
+    GNU linker script for SAMD21x18 (256K flash, 32K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
     /* Leave 8KiB for the bootloader, and 64k for the flash file system. */
-    FLASH (rx) : ORIGIN = 0x00000000+0x2000, LENGTH = 0x00040000 - 0x2000 - 0x010000
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x008000 /* 32 KiB */
+    FLASH (rx) : ORIGIN = 0x00000000 + 8K, LENGTH = 256K - 8K - 64K
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 /* top end of the stack */
@@ -30,14 +30,14 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
@@ -76,7 +76,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd21x18-external-flash.ld
+++ b/ports/atmel-samd/boards/samd21x18-external-flash.ld
@@ -1,13 +1,13 @@
 /*
-    GNU linker script for SAMD21
+    GNU linker script for SAMD21x18 (256K flash, 32K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
     /* 256 KiB but leave 256b for internal config and 256b for user config (protected eeprom) */
-    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x00040000 - 0x100 - 0x100
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x008000 /* 32 KiB */
+    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 256K - 256 - 256
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 /* top end of the stack */
@@ -29,14 +29,14 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
@@ -75,7 +75,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd21x18.ld
+++ b/ports/atmel-samd/boards/samd21x18.ld
@@ -1,13 +1,13 @@
 /*
-    GNU linker script for SAMD21
+    GNU linker script for SAMD21x18 (256K flash, 32K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
     /* Leave 256b for internal config, 64k for the flash file system and 256b for user config. */
-    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x00040000 - 0x100 - 0x010000
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x008000 /* 32 KiB */
+    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 256K - 256 - 64K
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 /* top end of the stack */
@@ -29,11 +29,17 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
-        _sidata = _etext;  /* This is used by the startup in order to initialize the .data section */
     } >FLASH
 
-    /* This is the initialized data section
+    .ARM.exidx :
+    {
+        *(.ARM.exidx*)
+        *(.gnu.linkonce.armexidx.*)
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
+    } > FLASH
+
+/* This is the initialized data section
     The program executes knowing that the data is in the RAM
     but the loader puts the initial values in the FLASH (inidata).
     It is one task of the startup to copy the initial values from FLASH to RAM. */
@@ -69,7 +75,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd51x18-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd51x18-bootloader-external-flash.ld
@@ -1,12 +1,13 @@
 /*
-    GNU linker script for SAMD51
+    GNU linker script for SAMD51x18 (256K flash, 128K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx) : ORIGIN = 0x00000000 + 0x4000, LENGTH = 0x00040000 - 0x4000 /* Leave 16KiB for the bootloader. */
-    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 0x00020000 /* 128 KiB */
+    /* Leave 16KiB for the bootloader. */
+    FLASH (rx) : ORIGIN = 0x00000000 + 16K, LENGTH = 256K - 16K
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
 /* top end of the stack */
@@ -29,14 +30,14 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
@@ -75,7 +76,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd51x19-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd51x19-bootloader-external-flash.ld
@@ -1,12 +1,13 @@
 /*
-    GNU linker script for SAMD51
+    GNU linker script for SAMD51x19 (512K flash, 192K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx) : ORIGIN = 0x00000000 + 0x4000, LENGTH = 0x00080000 - 0x4000 /* Leave 16KiB for the bootloader. */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x00030000 /* 192 KiB */
+    /* Leave 16KiB for the bootloader. */
+    FLASH (rx) : ORIGIN = 0x00000000 + 16K, LENGTH = 512K - 16K
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 192K
 }
 
 /* top end of the stack */
@@ -29,14 +30,14 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
@@ -75,7 +76,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd51x19-bootloader.ld
+++ b/ports/atmel-samd/boards/samd51x19-bootloader.ld
@@ -1,12 +1,13 @@
 /*
-    GNU linker script for SAMD51
+    GNU linker script for SAMD51x19 (512K flash, 192K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx) : ORIGIN = 0x00000000 + 0x4000, LENGTH = 0x00080000 - 0x4000 - 0x00040000 /* Leave 16KiB for the bootloader and 256KiB for the internal file system. */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x00030000 /* 192 KiB */
+    /* Leave 16KiB for the bootloader and 256KiB for the internal file system. */
+    FLASH (rx) : ORIGIN = 0x00000000 + 16K, LENGTH = 512K - 16K - 256K
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 192K
 }
 
 /* top end of the stack */
@@ -29,14 +30,14 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
@@ -75,7 +76,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd51x20-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd51x20-bootloader-external-flash.ld
@@ -1,12 +1,13 @@
 /*
-    GNU linker script for SAMD51
+    GNU linker script for SAMD51x20 (1MB flash, 256K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx) : ORIGIN = 0x00000000 + 0x4000, LENGTH = 0x00100000 - 0x4000 /* Leave 16KiB for the bootloader. */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x00040000 /* 256 KiB */
+    /* Leave 16KiB for the bootloader. */
+    FLASH (rx) : ORIGIN = 0x00000000 + 16K, LENGTH = 1M - 16K
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 /* top end of the stack */
@@ -29,14 +30,14 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
@@ -75,7 +76,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd51x20-bootloader.ld
+++ b/ports/atmel-samd/boards/samd51x20-bootloader.ld
@@ -1,12 +1,13 @@
 /*
-    GNU linker script for SAMD51
+    GNU linker script for SAMD51x20 (1MB flash, 256K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx) : ORIGIN = 0x00000000 + 0x4000, LENGTH = 0x00100000 - 0x4000  - 0x80000 /* Leave 16KiB for the bootloader and 512k for the filesystem. */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x00040000 /* 256 KiB */
+    /* Leave 16KiB for the bootloader and 512k for the filesystem. */
+    FLASH (rx) : ORIGIN = 0x00000000 + 16K, LENGTH = 1M - 16K - 512K
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 /* top end of the stack */
@@ -29,14 +30,14 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
@@ -75,7 +76,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd51x20-external-flash.ld
+++ b/ports/atmel-samd/boards/samd51x20-external-flash.ld
@@ -1,12 +1,12 @@
 /*
-    GNU linker script for SAMD51
+    GNU linker script for SAMD51x20 (1MB flash, 256K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x00100000
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x00040000 /* 256 KiB */
+    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 1M
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 /* top end of the stack */
@@ -28,14 +28,14 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
@@ -74,7 +74,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/ports/atmel-samd/boards/samd51x20.ld
+++ b/ports/atmel-samd/boards/samd51x20.ld
@@ -1,12 +1,13 @@
 /*
-    GNU linker script for SAMD51
+    GNU linker script for SAMD51x20 (1MB flash, 256K RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x00100000 - 0x80000 /* 1024 KiB minus 512KiB for the internal file system. */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x00040000 /* 256 KiB */
+    /* 1024 KiB minus 512KiB for the internal file system. */
+    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 1M - 512K
+    RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 /* top end of the stack */
@@ -28,14 +29,14 @@ SECTIONS
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
 
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
     } >FLASH
 
     .ARM.exidx :
     {
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)
-        _sidata = .;  /* This is used by the startup in order to initialize the .data section */
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = .;       /* start of .data section */
     } > FLASH
 
     /* This is the initialized data section
@@ -74,7 +75,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + 0x800; /* Reserve a minimum of 2K for the stack. */
+        . = . + 2K; /* Reserve a minimum of 2K for the stack. */
         . = ALIGN(4);
     } >RAM
 

--- a/tools/build_memory_info.py
+++ b/tools/build_memory_info.py
@@ -24,7 +24,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import re
 import sys
+
+# Handle size constants with K or M suffixes (allowed in .ld but not in Python).
+K_PATTERN = re.compile(r'([0-9]+)K')
+K_REPLACE = r'(\1*1024)'
+
+M_PATTERN = re.compile(r'([0-9]+)M')
+M_REPLACE = r'(\1*1024*1024)'
 
 print()
 
@@ -49,6 +57,8 @@ for region in regions:
     space = regions[region]
     if "/*" in space:
         space = space.split("/*")[0]
+    space = K_PATTERN.sub(K_REPLACE, space)
+    space = M_PATTERN.sub(M_REPLACE, space)
     regions[region] = eval(space)
 
 free_flash = regions["FLASH"] - text - data


### PR DESCRIPTION
1. Make `_etext` and `_sidata` coincide. Old _etext location did not include .ARM.exidx sections, which were usually absent but not always. So flash data was copied to RAM in wrong place.

2. Use decimal constants with "K" and "M" suffixes in .ld files instead of hex constants, to make them easier to read and check for accuracy. Had to enhance a Python script that reads the .ld files to handle the suffixes.