### PR TITLE
nrf: Use -O1 for debug builds

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -89,8 +89,8 @@ LDFLAGS += -Wl,--gc-sections
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)
 #ASMFLAGS += -g -gtabs+
-CFLAGS += -O0 -ggdb
-LDFLAGS += -O0
+CFLAGS += -O1 -ggdb
+LDFLAGS += -O1
 else
 CFLAGS += -Os -DNDEBUG
 LDFLAGS += -Os


### PR DESCRIPTION
While O0 is great for debugging, the produced binary doesn't fit on the
feather52 anymore.