### PR TITLE
Implement UART for 3.0 + related fixes.

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -36,6 +36,7 @@ INC += -I. \
        -Iasf4/$(CHIP_FAMILY)/hal/utils/include \
        -Iasf4/$(CHIP_FAMILY)/hri \
        -Iasf4/$(CHIP_FAMILY)/hpl/core \
+       -Iasf4/$(CHIP_FAMILY)/hpl/gclk \
        -Iasf4/$(CHIP_FAMILY)/hpl/pm \
        -Iasf4/$(CHIP_FAMILY)/hpl/port \
        -Iasf4/$(CHIP_FAMILY)/hpl/tc \
@@ -96,6 +97,7 @@ ifeq ($(DEBUG), 1)
   # Turn on Python modules useful for debugging (e.g. uheap, ustack).
   CFLAGS += -ggdb
   CFLAGS += -flto
+  ## CFLAGS += -fno-inline
   ifeq ($(CHIP_FAMILY), samd21)
     CFLAGS += -DENABLE_MICRO_TRACE_BUFFER
   endif
@@ -178,6 +180,7 @@ SRC_ASF := \
 	hal/src/hal_sleep.c \
 	hal/src/hal_spi_m_sync.c \
 	hal/src/hal_timer.c \
+	hal/src/hal_usart_async.c \
 	hal/src/hal_usb_device.c \
 	hpl/adc/hpl_adc.c \
 	hpl/core/hpl_init.c \
@@ -194,6 +197,7 @@ SRC_ASF := \
 	usb/device/usbdc.c \
 	usb/usb_protocol.c \
 	hal/utils/src/utils_list.c \
+	hal/utils/src/utils_ringbuffer.c \
 
 ifeq ($(CHIP_FAMILY), samd21)
 SRC_ASF += \
@@ -263,6 +267,7 @@ SRC_COMMON_HAL = \
 	busio/__init__.c \
 	busio/I2C.c \
 	busio/SPI.c \
+	busio/UART.c \
 	digitalio/__init__.c \
 	digitalio/DigitalInOut.c \
 	microcontroller/__init__.c \
@@ -283,7 +288,6 @@ SRC_COMMON_HAL = \
 	audiobusio/PDMIn.c \
 	audioio/__init__.c \
 	audioio/AudioOut.c \
-	busio/UART.c \
 	nvm/__init__.c \
 	nvm/ByteArray.c \
 	touchio/__init__.c \

--- a/ports/atmel-samd/asf4_conf/samd21/hpl_gclk_config.h
+++ b/ports/atmel-samd/asf4_conf/samd21/hpl_gclk_config.h
@@ -1,3 +1,14 @@
+// Circuit Python SAMD21 clock tree:
+// DFLL48M (with USBCRM on to sync with external USB ref) -> GCLK0
+//   GCLK0 (48MHz) -> peripherals
+
+// We'd like to use XOSC32K as a ref for DFLL48M on boards with a 32kHz crystal,
+// but haven't figured that out yet.
+
+// Used in hpl/core/hpl_init.c to define which clocks should be initialized first.
+#define CIRCUITPY_GCLK_INIT_1ST (1 << 0)
+
+
 /* Auto-generated config file hpl_gclk_config.h */
 #ifndef HPL_GCLK_CONFIG_H
 #define HPL_GCLK_CONFIG_H

--- a/ports/atmel-samd/asf4_conf/samd21/hpl_sercom_config.h
+++ b/ports/atmel-samd/asf4_conf/samd21/hpl_sercom_config.h
@@ -3,14 +3,16 @@
 //
 // SERCOM0: SPI with hal_spi_m_sync.c driver: spi master synchronous
 // SERCOM1: I2C with hal_i2c_m_sync.c driver: i2c master synchronous
-// SERCOM2: USART with hal_usart_sync.c driver: usart synchronous
+// SERCOM2: USART with hal_usart_async.c driver: usart asynchronous
+// SERCOM3: SPI with hal_spi_m_dma.c: spi master DMA
 
 #define PROTOTYPE_SERCOM_SPI_M_SYNC SERCOM0
 #define PROTOTYPE_SERCOM_SPI_M_SYNC_CLOCK_FREQUENCY CONF_GCLK_SERCOM0_CORE_FREQUENCY
 
 #define PROTOTYPE_SERCOM_I2CM_SYNC SERCOM1
-#define PROTOTYPE_SERCOM_USART_SYNC SERCOM2
 
+#define PROTOTYPE_SERCOM_USART_ASYNC SERCOM2
+#define PROTOTYPE_SERCOM_USART_ASYNC_CLOCK_FREQUENCY CONF_GCLK_SERCOM2_CORE_FREQUENCY
 
 /* Auto-generated config file hpl_sercom_config.h */
 #ifndef HPL_SERCOM_CONFIG_H
@@ -541,6 +543,188 @@
 #ifndef CONF_SERCOM_2_USART_RECEIVE_PULSE_LENGTH
 #define CONF_SERCOM_2_USART_RECEIVE_PULSE_LENGTH 0
 #endif
+#endif
+
+#include <peripheral_clk_config.h>
+
+// Enable configuration of module
+#ifndef CONF_SERCOM_3_SPI_ENABLE
+#define CONF_SERCOM_3_SPI_ENABLE 1
+#endif
+
+//<o> SPI DMA TX Channel <0-32>
+//<i> This defines DMA channel to be used
+//<id> spi_master_dma_tx_channel
+#ifndef CONF_SERCOM_3_SPI_M_DMA_TX_CHANNEL
+#define CONF_SERCOM_3_SPI_M_DMA_TX_CHANNEL 0
+#endif
+
+// <e> SPI RX Channel Enable
+// <id> spi_master_rx_channel
+#ifndef CONF_SERCOM_3_SPI_RX_CHANNEL
+#define CONF_SERCOM_3_SPI_RX_CHANNEL 1
+#endif
+
+//<o> DMA Channel <0-32>
+//<i> This defines DMA channel to be used
+//<id> spi_master_dma_rx_channel
+#ifndef CONF_SERCOM_3_SPI_M_DMA_RX_CHANNEL
+#define CONF_SERCOM_3_SPI_M_DMA_RX_CHANNEL 1
+#endif
+
+// </e>
+
+// Set module in SPI Master mode
+#ifndef CONF_SERCOM_3_SPI_MODE
+#define CONF_SERCOM_3_SPI_MODE 0x03
+#endif
+
+// <h> Basic Configuration
+
+// <q> Receive buffer enable
+// <i> Enable receive buffer to receive data from slave (RXEN)
+// <id> spi_master_rx_enable
+#ifndef CONF_SERCOM_3_SPI_RXEN
+#define CONF_SERCOM_3_SPI_RXEN 0x1
+#endif
+
+// <o> Character Size
+// <i> Bit size for all characters sent over the SPI bus (CHSIZE)
+// <0x0=>8 bits
+// <0x1=>9 bits
+// <id> spi_master_character_size
+#ifndef CONF_SERCOM_3_SPI_CHSIZE
+#define CONF_SERCOM_3_SPI_CHSIZE 0x0
+#endif
+
+// <o> Baud rate <1-12000000>
+// <i> The SPI data transfer rate
+// <id> spi_master_baud_rate
+#ifndef CONF_SERCOM_3_SPI_BAUD
+#define CONF_SERCOM_3_SPI_BAUD 50000
+#endif
+
+// </h>
+
+// <e> Advanced Configuration
+// <id> spi_master_advanced
+#ifndef CONF_SERCOM_3_SPI_ADVANCED
+#define CONF_SERCOM_3_SPI_ADVANCED 0
+#endif
+
+// <o> Dummy byte <0x00-0x1ff>
+// <id> spi_master_dummybyte
+// <i> Dummy byte used when reading data from the slave without sending any data
+#ifndef CONF_SERCOM_3_SPI_DUMMYBYTE
+#define CONF_SERCOM_3_SPI_DUMMYBYTE 0x1ff
+#endif
+
+// <o> Data Order
+// <0=>MSB first
+// <1=>LSB first
+// <i> I least significant or most significant bit is shifted out first (DORD)
+// <id> spi_master_arch_dord
+#ifndef CONF_SERCOM_3_SPI_DORD
+#define CONF_SERCOM_3_SPI_DORD 0x0
+#endif
+
+// <o> Clock Polarity
+// <0=>SCK is low when idle
+// <1=>SCK is high when idle
+// <i> Determines if the leading edge is rising or falling with a corresponding opposite edge at the trailing edge. (CPOL)
+// <id> spi_master_arch_cpol
+#ifndef CONF_SERCOM_3_SPI_CPOL
+#define CONF_SERCOM_3_SPI_CPOL 0x0
+#endif
+
+// <o> Clock Phase
+// <0x0=>Sample input on leading edge
+// <0x1=>Sample input on trailing edge
+// <i> Determines if input data is sampled on leading or trailing SCK edge. (CPHA)
+// <id> spi_master_arch_cpha
+#ifndef CONF_SERCOM_3_SPI_CPHA
+#define CONF_SERCOM_3_SPI_CPHA 0x0
+#endif
+
+// <o> Immediate Buffer Overflow Notification
+// <i> Controls when OVF is asserted (IBON)
+// <0x0=>In data stream
+// <0x1=>On buffer overflow
+// <id> spi_master_arch_ibon
+#ifndef CONF_SERCOM_3_SPI_IBON
+#define CONF_SERCOM_3_SPI_IBON 0x0
+#endif
+
+// <q> Run in stand-by
+// <i> Module stays active in stand-by sleep mode. (RUNSTDBY)
+// <id> spi_master_arch_runstdby
+#ifndef CONF_SERCOM_3_SPI_RUNSTDBY
+#define CONF_SERCOM_3_SPI_RUNSTDBY 0x0
+#endif
+
+// <o> Debug Stop Mode
+// <i> Behavior of the baud-rate generator when CPU is halted by external debugger. (DBGSTOP)
+// <0=>Keep running
+// <1=>Halt
+// <id> spi_master_arch_dbgstop
+#ifndef CONF_SERCOM_3_SPI_DBGSTOP
+#define CONF_SERCOM_3_SPI_DBGSTOP 0
+#endif
+
+// </e>
+
+// Address mode disabled in master mode
+#ifndef CONF_SERCOM_3_SPI_AMODE_EN
+#define CONF_SERCOM_3_SPI_AMODE_EN 0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_AMODE
+#define CONF_SERCOM_3_SPI_AMODE 0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_ADDR
+#define CONF_SERCOM_3_SPI_ADDR 0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_ADDRMASK
+#define CONF_SERCOM_3_SPI_ADDRMASK 0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_SSDE
+#define CONF_SERCOM_3_SPI_SSDE 0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_MSSEN
+#define CONF_SERCOM_3_SPI_MSSEN 0x0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_PLOADEN
+#define CONF_SERCOM_3_SPI_PLOADEN 0
+#endif
+
+// <o> Receive Data Pinout
+// <0x0=>PAD[0]
+// <0x1=>PAD[1]
+// <0x2=>PAD[2]
+// <0x3=>PAD[3]
+// <id> spi_master_rxpo
+#ifndef CONF_SERCOM_3_SPI_RXPO
+#define CONF_SERCOM_3_SPI_RXPO 0
+#endif
+
+// <o> Transmit Data Pinout
+// <0x0=>PAD[0,1]_DO_SCK
+// <0x1=>PAD[2,3]_DO_SCK
+// <0x2=>PAD[3,1]_DO_SCK
+// <0x3=>PAD[0,3]_DO_SCK
+// <id> spi_master_txpo
+#ifndef CONF_SERCOM_3_SPI_TXPO
+#define CONF_SERCOM_3_SPI_TXPO 1
+#endif
+
+// Calculate baud register value from requested baudrate value
+#ifndef CONF_SERCOM_3_SPI_BAUD_RATE
+#define CONF_SERCOM_3_SPI_BAUD_RATE ((float)CONF_GCLK_SERCOM3_CORE_FREQUENCY / (float)(2 * CONF_SERCOM_3_SPI_BAUD)) - 1
 #endif
 
 // <<< end of configuration section >>>

--- a/ports/atmel-samd/asf4_conf/samd21/peripheral_clk_config.h
+++ b/ports/atmel-samd/asf4_conf/samd21/peripheral_clk_config.h
@@ -4,6 +4,38 @@
 
 // <<< Use Configuration Wizard in Context Menu >>>
 
+// <y> ADC Clock Source
+// <id> adc_gclk_selection
+
+// <GCLK_CLKCTRL_GEN_GCLK0_Val"> Generic clock generator 0
+
+// <GCLK_CLKCTRL_GEN_GCLK1_Val"> Generic clock generator 1
+
+// <GCLK_CLKCTRL_GEN_GCLK2_Val"> Generic clock generator 2
+
+// <GCLK_CLKCTRL_GEN_GCLK3_Val"> Generic clock generator 3
+
+// <GCLK_CLKCTRL_GEN_GCLK4_Val"> Generic clock generator 4
+
+// <GCLK_CLKCTRL_GEN_GCLK5_Val"> Generic clock generator 5
+
+// <GCLK_CLKCTRL_GEN_GCLK6_Val"> Generic clock generator 6
+
+// <GCLK_CLKCTRL_GEN_GCLK7_Val"> Generic clock generator 7
+
+// <i> Select the clock source for ADC.
+#ifndef CONF_GCLK_ADC_SRC
+#define CONF_GCLK_ADC_SRC GCLK_CLKCTRL_GEN_GCLK0_Val
+#endif
+
+/**
+ * \def CONF_GCLK_ADC_FREQUENCY
+ * \brief ADC's Clock frequency
+ */
+#ifndef CONF_GCLK_ADC_FREQUENCY
+#define CONF_GCLK_ADC_FREQUENCY 48000000
+#endif
+
 /**
  * \def CONF_CPU_FREQUENCY
  * \brief CPU's Clock frequency
@@ -268,134 +300,6 @@
 #define CONF_GCLK_SERCOM3_SLOW_FREQUENCY 400000
 #endif
 
-// <y> Core Clock Source
-// <id> core_gclk_selection
-
-// <GCLK_CLKCTRL_GEN_GCLK0_Val"> Generic clock generator 0
-
-// <GCLK_CLKCTRL_GEN_GCLK1_Val"> Generic clock generator 1
-
-// <GCLK_CLKCTRL_GEN_GCLK2_Val"> Generic clock generator 2
-
-// <GCLK_CLKCTRL_GEN_GCLK3_Val"> Generic clock generator 3
-
-// <GCLK_CLKCTRL_GEN_GCLK4_Val"> Generic clock generator 4
-
-// <GCLK_CLKCTRL_GEN_GCLK5_Val"> Generic clock generator 5
-
-// <GCLK_CLKCTRL_GEN_GCLK6_Val"> Generic clock generator 6
-
-// <GCLK_CLKCTRL_GEN_GCLK7_Val"> Generic clock generator 7
-
-// <i> Select the clock source for CORE.
-#ifndef CONF_GCLK_SERCOM4_CORE_SRC
-#define CONF_GCLK_SERCOM4_CORE_SRC GCLK_CLKCTRL_GEN_GCLK0_Val
-#endif
-
-// <y> Slow Clock Source
-// <id> slow_gclk_selection
-
-// <GCLK_CLKCTRL_GEN_GCLK0_Val"> Generic clock generator 0
-
-// <GCLK_CLKCTRL_GEN_GCLK1_Val"> Generic clock generator 1
-
-// <GCLK_CLKCTRL_GEN_GCLK2_Val"> Generic clock generator 2
-
-// <GCLK_CLKCTRL_GEN_GCLK3_Val"> Generic clock generator 3
-
-// <GCLK_CLKCTRL_GEN_GCLK4_Val"> Generic clock generator 4
-
-// <GCLK_CLKCTRL_GEN_GCLK5_Val"> Generic clock generator 5
-
-// <GCLK_CLKCTRL_GEN_GCLK6_Val"> Generic clock generator 6
-
-// <GCLK_CLKCTRL_GEN_GCLK7_Val"> Generic clock generator 7
-
-// <i> Select the slow clock source.
-#ifndef CONF_GCLK_SERCOM4_SLOW_SRC
-#define CONF_GCLK_SERCOM4_SLOW_SRC GCLK_CLKCTRL_GEN_GCLK3_Val
-#endif
-
-/**
- * \def CONF_GCLK_SERCOM4_CORE_FREQUENCY
- * \brief SERCOM4's Core Clock frequency
- */
-#ifndef CONF_GCLK_SERCOM4_CORE_FREQUENCY
-#define CONF_GCLK_SERCOM4_CORE_FREQUENCY 48000000
-#endif
-
-/**
- * \def CONF_GCLK_SERCOM4_SLOW_FREQUENCY
- * \brief SERCOM4's Slow Clock frequency
- */
-#ifndef CONF_GCLK_SERCOM4_SLOW_FREQUENCY
-#define CONF_GCLK_SERCOM4_SLOW_FREQUENCY 400000
-#endif
-
-// <y> Core Clock Source
-// <id> core_gclk_selection
-
-// <GCLK_CLKCTRL_GEN_GCLK0_Val"> Generic clock generator 0
-
-// <GCLK_CLKCTRL_GEN_GCLK1_Val"> Generic clock generator 1
-
-// <GCLK_CLKCTRL_GEN_GCLK2_Val"> Generic clock generator 2
-
-// <GCLK_CLKCTRL_GEN_GCLK3_Val"> Generic clock generator 3
-
-// <GCLK_CLKCTRL_GEN_GCLK4_Val"> Generic clock generator 4
-
-// <GCLK_CLKCTRL_GEN_GCLK5_Val"> Generic clock generator 5
-
-// <GCLK_CLKCTRL_GEN_GCLK6_Val"> Generic clock generator 6
-
-// <GCLK_CLKCTRL_GEN_GCLK7_Val"> Generic clock generator 7
-
-// <i> Select the clock source for CORE.
-#ifndef CONF_GCLK_SERCOM5_CORE_SRC
-#define CONF_GCLK_SERCOM5_CORE_SRC GCLK_CLKCTRL_GEN_GCLK0_Val
-#endif
-
-// <y> Slow Clock Source
-// <id> slow_gclk_selection
-
-// <GCLK_CLKCTRL_GEN_GCLK0_Val"> Generic clock generator 0
-
-// <GCLK_CLKCTRL_GEN_GCLK1_Val"> Generic clock generator 1
-
-// <GCLK_CLKCTRL_GEN_GCLK2_Val"> Generic clock generator 2
-
-// <GCLK_CLKCTRL_GEN_GCLK3_Val"> Generic clock generator 3
-
-// <GCLK_CLKCTRL_GEN_GCLK4_Val"> Generic clock generator 4
-
-// <GCLK_CLKCTRL_GEN_GCLK5_Val"> Generic clock generator 5
-
-// <GCLK_CLKCTRL_GEN_GCLK6_Val"> Generic clock generator 6
-
-// <GCLK_CLKCTRL_GEN_GCLK7_Val"> Generic clock generator 7
-
-// <i> Select the slow clock source.
-#ifndef CONF_GCLK_SERCOM5_SLOW_SRC
-#define CONF_GCLK_SERCOM5_SLOW_SRC GCLK_CLKCTRL_GEN_GCLK3_Val
-#endif
-
-/**
- * \def CONF_GCLK_SERCOM5_CORE_FREQUENCY
- * \brief SERCOM5's Core Clock frequency
- */
-#ifndef CONF_GCLK_SERCOM5_CORE_FREQUENCY
-#define CONF_GCLK_SERCOM5_CORE_FREQUENCY 48000000
-#endif
-
-/**
- * \def CONF_GCLK_SERCOM5_SLOW_FREQUENCY
- * \brief SERCOM5's Slow Clock frequency
- */
-#ifndef CONF_GCLK_SERCOM5_SLOW_FREQUENCY
-#define CONF_GCLK_SERCOM5_SLOW_FREQUENCY 400000
-#endif
-
 // <y> RTC Clock Source
 // <id> rtc_clk_selection
 
@@ -425,7 +329,7 @@
  * \brief RTC's Clock frequency
  */
 #ifndef CONF_GCLK_RTC_FREQUENCY
-#define CONF_GCLK_RTC_FREQUENCY 1000000
+#define CONF_GCLK_RTC_FREQUENCY 48000000
 #endif
 
 // <y> TC Clock Source
@@ -457,7 +361,7 @@
  * \brief TC3's Clock frequency
  */
 #ifndef CONF_GCLK_TC3_FREQUENCY
-#define CONF_GCLK_TC3_FREQUENCY 1000000
+#define CONF_GCLK_TC3_FREQUENCY 48000000
 #endif
 
 // <y> DAC Clock Source
@@ -489,7 +393,7 @@
  * \brief DAC's Clock frequency
  */
 #ifndef CONF_GCLK_DAC_FREQUENCY
-#define CONF_GCLK_DAC_FREQUENCY 1000000
+#define CONF_GCLK_DAC_FREQUENCY 48000000
 #endif
 
 // <y> USB Clock Source

--- a/ports/atmel-samd/asf4_conf/samd51/hpl_gclk_config.h
+++ b/ports/atmel-samd/asf4_conf/samd51/hpl_gclk_config.h
@@ -1,7 +1,17 @@
-// The clock tree starts with 48mhz DFLL48M based on USB. GCLK5 divides it down
-// to 2mhz which DPLL0 boosts to 120mhz. This is then used by GCLK0 to clock the
-// core and main bus. GCLK1 is 48mhz based on DFLL48M which is used for USB.
-// GCLK4 also outputs the 120mhz clock for monitoring.
+// Circuit Python SAMD51 clock tree:
+// DFLL48M (with USBCRM on to sync with external USB ref) -> GCLK1, GCLK5
+//   GCLK1 (48MHz) -> peripherals
+//   GCLK5 (divided down to 2 MHz) -> DPLL0
+//     DPLL0 (multiplied up to 120 MHz) -> GCLK0, GCLK4 (output for monitoring)
+
+// We'd like to use XOSC32K as a ref for DFLL48M on boards with a 32kHz crystal,
+// but haven't figured that out yet.
+
+// Used in hpl/core/hpl_init.c to define which clocks should be initialized first.
+// Not clear why all these need to be specified, but it doesn't work properly otherwise.
+
+//#define CIRCUITPY_GCLK_INIT_1ST (1 << 0 | 1 << 1 | 1 << 3 | 1 <<5)
+#define CIRCUITPY_GCLK_INIT_1ST 0xffff
 
 /* Auto-generated config file hpl_gclk_config.h */
 #ifndef HPL_GCLK_CONFIG_H

--- a/ports/atmel-samd/asf4_conf/samd51/hpl_sercom_config.h
+++ b/ports/atmel-samd/asf4_conf/samd51/hpl_sercom_config.h
@@ -3,13 +3,16 @@
 //
 // SERCOM0: SPI with hal_spi_m_sync.c driver: spi master synchronous
 // SERCOM1: I2C with hal_i2c_m_sync.c driver: i2c master synchronous
-// SERCOM2: USART with hal_usart_sync.c driver: usart synchronous
+// SERCOM2: USART with hal_usart_async.c driver: usart asynchronous
+// SERCOM3: SPI with hal_spi_m_dma.c: spi master DMA
 
 #define PROTOTYPE_SERCOM_SPI_M_SYNC SERCOM0
 #define PROTOTYPE_SERCOM_SPI_M_SYNC_CLOCK_FREQUENCY CONF_GCLK_SERCOM0_CORE_FREQUENCY
 
 #define PROTOTYPE_SERCOM_I2CM_SYNC SERCOM1
-#define PROTOTYPE_SERCOM_USART_SYNC SERCOM2
+
+#define PROTOTYPE_SERCOM_USART_ASYNC SERCOM2
+#define PROTOTYPE_SERCOM_USART_ASYNC_CLOCK_FREQUENCY CONF_GCLK_SERCOM2_CORE_FREQUENCY
 
 /* Auto-generated config file hpl_sercom_config.h */
 #ifndef HPL_SERCOM_CONFIG_H
@@ -59,7 +62,7 @@
 // <e> Advanced Configuration
 // <id> spi_master_advanced
 #ifndef CONF_SERCOM_0_SPI_ADVANCED
-#define CONF_SERCOM_0_SPI_ADVANCED 0
+#define CONF_SERCOM_0_SPI_ADVANCED 1
 #endif
 
 // <o> Dummy byte <0x00-0x1ff>
@@ -201,7 +204,7 @@
 // <e> Advanced
 // <id> i2c_master_advanced
 #ifndef CONF_SERCOM_1_I2CM_ADVANCED_CONFIG
-#define CONF_SERCOM_1_I2CM_ADVANCED_CONFIG 0
+#define CONF_SERCOM_1_I2CM_ADVANCED_CONFIG 1
 #endif
 
 // <o> TRise (ns) <0-300>
@@ -377,7 +380,7 @@
 // <e> Advanced configuration
 // <id> usart_advanced
 #ifndef CONF_SERCOM_2_USART_ADVANCED_CONFIG
-#define CONF_SERCOM_2_USART_ADVANCED_CONFIG 0
+#define CONF_SERCOM_2_USART_ADVANCED_CONFIG 1
 #endif
 
 // <q> Run in stand-by
@@ -559,6 +562,188 @@
 #ifndef CONF_SERCOM_2_USART_RECEIVE_PULSE_LENGTH
 #define CONF_SERCOM_2_USART_RECEIVE_PULSE_LENGTH 0
 #endif
+#endif
+
+#include <peripheral_clk_config.h>
+
+// Enable configuration of module
+#ifndef CONF_SERCOM_3_SPI_ENABLE
+#define CONF_SERCOM_3_SPI_ENABLE 1
+#endif
+
+//<o> SPI DMA TX Channel <0-32>
+//<i> This defines DMA channel to be used
+//<id> spi_master_dma_tx_channel
+#ifndef CONF_SERCOM_3_SPI_M_DMA_TX_CHANNEL
+#define CONF_SERCOM_3_SPI_M_DMA_TX_CHANNEL 0
+#endif
+
+// <e> SPI RX Channel Enable
+// <id> spi_master_rx_channel
+#ifndef CONF_SERCOM_3_SPI_RX_CHANNEL
+#define CONF_SERCOM_3_SPI_RX_CHANNEL 1
+#endif
+
+//<o> DMA Channel <0-32>
+//<i> This defines DMA channel to be used
+//<id> spi_master_dma_rx_channel
+#ifndef CONF_SERCOM_3_SPI_M_DMA_RX_CHANNEL
+#define CONF_SERCOM_3_SPI_M_DMA_RX_CHANNEL 1
+#endif
+
+// </e>
+
+// Set module in SPI Master mode
+#ifndef CONF_SERCOM_3_SPI_MODE
+#define CONF_SERCOM_3_SPI_MODE 0x03
+#endif
+
+// <h> Basic Configuration
+
+// <q> Receive buffer enable
+// <i> Enable receive buffer to receive data from slave (RXEN)
+// <id> spi_master_rx_enable
+#ifndef CONF_SERCOM_3_SPI_RXEN
+#define CONF_SERCOM_3_SPI_RXEN 0x1
+#endif
+
+// <o> Character Size
+// <i> Bit size for all characters sent over the SPI bus (CHSIZE)
+// <0x0=>8 bits
+// <0x1=>9 bits
+// <id> spi_master_character_size
+#ifndef CONF_SERCOM_3_SPI_CHSIZE
+#define CONF_SERCOM_3_SPI_CHSIZE 0x0
+#endif
+
+// <o> Baud rate <1-12000000>
+// <i> The SPI data transfer rate
+// <id> spi_master_baud_rate
+#ifndef CONF_SERCOM_3_SPI_BAUD
+#define CONF_SERCOM_3_SPI_BAUD 50000
+#endif
+
+// </h>
+
+// <e> Advanced Configuration
+// <id> spi_master_advanced
+#ifndef CONF_SERCOM_3_SPI_ADVANCED
+#define CONF_SERCOM_3_SPI_ADVANCED 0
+#endif
+
+// <o> Dummy byte <0x00-0x1ff>
+// <id> spi_master_dummybyte
+// <i> Dummy byte used when reading data from the slave without sending any data
+#ifndef CONF_SERCOM_3_SPI_DUMMYBYTE
+#define CONF_SERCOM_3_SPI_DUMMYBYTE 0x1ff
+#endif
+
+// <o> Data Order
+// <0=>MSB first
+// <1=>LSB first
+// <i> I least significant or most significant bit is shifted out first (DORD)
+// <id> spi_master_arch_dord
+#ifndef CONF_SERCOM_3_SPI_DORD
+#define CONF_SERCOM_3_SPI_DORD 0x0
+#endif
+
+// <o> Clock Polarity
+// <0=>SCK is low when idle
+// <1=>SCK is high when idle
+// <i> Determines if the leading edge is rising or falling with a corresponding opposite edge at the trailing edge. (CPOL)
+// <id> spi_master_arch_cpol
+#ifndef CONF_SERCOM_3_SPI_CPOL
+#define CONF_SERCOM_3_SPI_CPOL 0x0
+#endif
+
+// <o> Clock Phase
+// <0x0=>Sample input on leading edge
+// <0x1=>Sample input on trailing edge
+// <i> Determines if input data is sampled on leading or trailing SCK edge. (CPHA)
+// <id> spi_master_arch_cpha
+#ifndef CONF_SERCOM_3_SPI_CPHA
+#define CONF_SERCOM_3_SPI_CPHA 0x0
+#endif
+
+// <o> Immediate Buffer Overflow Notification
+// <i> Controls when OVF is asserted (IBON)
+// <0x0=>In data stream
+// <0x1=>On buffer overflow
+// <id> spi_master_arch_ibon
+#ifndef CONF_SERCOM_3_SPI_IBON
+#define CONF_SERCOM_3_SPI_IBON 0x0
+#endif
+
+// <q> Run in stand-by
+// <i> Module stays active in stand-by sleep mode. (RUNSTDBY)
+// <id> spi_master_arch_runstdby
+#ifndef CONF_SERCOM_3_SPI_RUNSTDBY
+#define CONF_SERCOM_3_SPI_RUNSTDBY 0x0
+#endif
+
+// <o> Debug Stop Mode
+// <i> Behavior of the baud-rate generator when CPU is halted by external debugger. (DBGSTOP)
+// <0=>Keep running
+// <1=>Halt
+// <id> spi_master_arch_dbgstop
+#ifndef CONF_SERCOM_3_SPI_DBGSTOP
+#define CONF_SERCOM_3_SPI_DBGSTOP 0
+#endif
+
+// </e>
+
+// Address mode disabled in master mode
+#ifndef CONF_SERCOM_3_SPI_AMODE_EN
+#define CONF_SERCOM_3_SPI_AMODE_EN 0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_AMODE
+#define CONF_SERCOM_3_SPI_AMODE 0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_ADDR
+#define CONF_SERCOM_3_SPI_ADDR 0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_ADDRMASK
+#define CONF_SERCOM_3_SPI_ADDRMASK 0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_SSDE
+#define CONF_SERCOM_3_SPI_SSDE 0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_MSSEN
+#define CONF_SERCOM_3_SPI_MSSEN 0x0
+#endif
+
+#ifndef CONF_SERCOM_3_SPI_PLOADEN
+#define CONF_SERCOM_3_SPI_PLOADEN 0
+#endif
+
+// <o> Receive Data Pinout
+// <0x0=>PAD[0]
+// <0x1=>PAD[1]
+// <0x2=>PAD[2]
+// <0x3=>PAD[3]
+// <id> spi_master_rxpo
+#ifndef CONF_SERCOM_3_SPI_RXPO
+#define CONF_SERCOM_3_SPI_RXPO 2
+#endif
+
+// <o> Transmit Data Pinout
+// <0x0=>PAD[0,1]_DO_SCK
+// <0x1=>PAD[2,3]_DO_SCK
+// <0x2=>PAD[3,1]_DO_SCK
+// <0x3=>PAD[0,3]_DO_SCK
+// <id> spi_master_txpo
+#ifndef CONF_SERCOM_3_SPI_TXPO
+#define CONF_SERCOM_3_SPI_TXPO 0
+#endif
+
+// Calculate baud register value from requested baudrate value
+#ifndef CONF_SERCOM_3_SPI_BAUD_RATE
+#define CONF_SERCOM_3_SPI_BAUD_RATE ((float)CONF_GCLK_SERCOM3_CORE_FREQUENCY / (float)(2 * CONF_SERCOM_3_SPI_BAUD)) - 1
 #endif
 
 // <<< end of configuration section >>>

--- a/ports/atmel-samd/asf4_conf/samd51/peripheral_clk_config.h
+++ b/ports/atmel-samd/asf4_conf/samd51/peripheral_clk_config.h
@@ -33,7 +33,7 @@
 
 // <i> Select the clock source for ADC.
 #ifndef CONF_GCLK_ADC0_SRC
-#define CONF_GCLK_ADC0_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_ADC0_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -41,7 +41,7 @@
  * \brief ADC0's Clock frequency
  */
 #ifndef CONF_GCLK_ADC0_FREQUENCY
-#define CONF_GCLK_ADC0_FREQUENCY 120000000
+#define CONF_GCLK_ADC0_FREQUENCY 48000000
 #endif
 
 // <y> DAC Clock Source
@@ -73,7 +73,7 @@
 // <id> dac_gclk_selection
 // <i> Select the clock source for DAC.
 #ifndef CONF_GCLK_DAC_SRC
-#define CONF_GCLK_DAC_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_DAC_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -81,7 +81,7 @@
  * \brief DAC's Clock frequency
  */
 #ifndef CONF_GCLK_DAC_FREQUENCY
-#define CONF_GCLK_DAC_FREQUENCY 120000000
+#define CONF_GCLK_DAC_FREQUENCY 48000000
 #endif
 
 // <y> EVSYS Channel 0 Clock Source
@@ -113,7 +113,7 @@
 
 // <i> Select the clock source for channel 0.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_0_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_0_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_0_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -122,7 +122,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_0_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_0_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_0_FREQUENCY 48000000.0
 #endif
 
 // <y> EVSYS Channel 1 Clock Source
@@ -154,7 +154,7 @@
 
 // <i> Select the clock source for channel 1.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_1_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_1_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_1_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -163,7 +163,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_1_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_1_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_1_FREQUENCY 48000000.0
 #endif
 
 // <y> EVSYS Channel 2 Clock Source
@@ -195,7 +195,7 @@
 
 // <i> Select the clock source for channel 2.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_2_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_2_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_2_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -204,7 +204,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_2_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_2_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_2_FREQUENCY 48000000.0
 #endif
 
 // <y> EVSYS Channel 3 Clock Source
@@ -236,7 +236,7 @@
 
 // <i> Select the clock source for channel 3.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_3_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_3_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_3_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -245,7 +245,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_3_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_3_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_3_FREQUENCY 48000000.0
 #endif
 
 // <y> EVSYS Channel 4 Clock Source
@@ -277,7 +277,7 @@
 
 // <i> Select the clock source for channel 4.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_4_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_4_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_4_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -286,7 +286,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_4_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_4_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_4_FREQUENCY 48000000.0
 #endif
 
 // <y> EVSYS Channel 5 Clock Source
@@ -318,7 +318,7 @@
 
 // <i> Select the clock source for channel 5.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_5_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_5_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_5_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -327,7 +327,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_5_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_5_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_5_FREQUENCY 48000000.0
 #endif
 
 // <y> EVSYS Channel 6 Clock Source
@@ -359,7 +359,7 @@
 
 // <i> Select the clock source for channel 6.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_6_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_6_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_6_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -368,7 +368,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_6_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_6_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_6_FREQUENCY 48000000.0
 #endif
 
 // <y> EVSYS Channel 7 Clock Source
@@ -400,7 +400,7 @@
 
 // <i> Select the clock source for channel 7.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_7_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_7_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_7_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -409,7 +409,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_7_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_7_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_7_FREQUENCY 48000000.0
 #endif
 
 // <y> EVSYS Channel 8 Clock Source
@@ -441,7 +441,7 @@
 
 // <i> Select the clock source for channel 8.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_8_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_8_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_8_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -450,7 +450,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_8_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_8_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_8_FREQUENCY 48000000.0
 #endif
 
 // <y> EVSYS Channel 9 Clock Source
@@ -482,7 +482,7 @@
 
 // <i> Select the clock source for channel 9.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_9_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_9_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_9_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -491,7 +491,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_9_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_9_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_9_FREQUENCY 48000000.0
 #endif
 
 // <y> EVSYS Channel 10 Clock Source
@@ -523,7 +523,7 @@
 
 // <i> Select the clock source for channel 10.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_10_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_10_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_10_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -532,7 +532,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_10_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_10_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_10_FREQUENCY 48000000.0
 #endif
 
 // <y> EVSYS Channel 11 Clock Source
@@ -564,7 +564,7 @@
 
 // <i> Select the clock source for channel 11.
 #ifndef CONF_GCLK_EVSYS_CHANNEL_11_SRC
-#define CONF_GCLK_EVSYS_CHANNEL_11_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_EVSYS_CHANNEL_11_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -573,7 +573,7 @@
  */
 
 #ifndef CONF_GCLK_EVSYS_CHANNEL_11_FREQUENCY
-#define CONF_GCLK_EVSYS_CHANNEL_11_FREQUENCY 120000000.0
+#define CONF_GCLK_EVSYS_CHANNEL_11_FREQUENCY 48000000.0
 #endif
 
 /**
@@ -840,6 +840,86 @@
 #define CONF_GCLK_SERCOM2_SLOW_FREQUENCY 32768
 #endif
 
+// <y> Core Clock Source
+// <id> core_gclk_selection
+
+// <GCLK_PCHCTRL_GEN_GCLK0_Val"> Generic clock generator 0
+
+// <GCLK_PCHCTRL_GEN_GCLK1_Val"> Generic clock generator 1
+
+// <GCLK_PCHCTRL_GEN_GCLK2_Val"> Generic clock generator 2
+
+// <GCLK_PCHCTRL_GEN_GCLK3_Val"> Generic clock generator 3
+
+// <GCLK_PCHCTRL_GEN_GCLK4_Val"> Generic clock generator 4
+
+// <GCLK_PCHCTRL_GEN_GCLK5_Val"> Generic clock generator 5
+
+// <GCLK_PCHCTRL_GEN_GCLK6_Val"> Generic clock generator 6
+
+// <GCLK_PCHCTRL_GEN_GCLK7_Val"> Generic clock generator 7
+
+// <GCLK_PCHCTRL_GEN_GCLK8_Val"> Generic clock generator 8
+
+// <GCLK_PCHCTRL_GEN_GCLK9_Val"> Generic clock generator 9
+
+// <GCLK_PCHCTRL_GEN_GCLK10_Val"> Generic clock generator 10
+
+// <GCLK_PCHCTRL_GEN_GCLK11_Val"> Generic clock generator 11
+
+// <i> Select the clock source for CORE.
+#ifndef CONF_GCLK_SERCOM3_CORE_SRC
+#define CONF_GCLK_SERCOM3_CORE_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
+#endif
+
+// <y> Slow Clock Source
+// <id> slow_gclk_selection
+
+// <GCLK_PCHCTRL_GEN_GCLK0_Val"> Generic clock generator 0
+
+// <GCLK_PCHCTRL_GEN_GCLK1_Val"> Generic clock generator 1
+
+// <GCLK_PCHCTRL_GEN_GCLK2_Val"> Generic clock generator 2
+
+// <GCLK_PCHCTRL_GEN_GCLK3_Val"> Generic clock generator 3
+
+// <GCLK_PCHCTRL_GEN_GCLK4_Val"> Generic clock generator 4
+
+// <GCLK_PCHCTRL_GEN_GCLK5_Val"> Generic clock generator 5
+
+// <GCLK_PCHCTRL_GEN_GCLK6_Val"> Generic clock generator 6
+
+// <GCLK_PCHCTRL_GEN_GCLK7_Val"> Generic clock generator 7
+
+// <GCLK_PCHCTRL_GEN_GCLK8_Val"> Generic clock generator 8
+
+// <GCLK_PCHCTRL_GEN_GCLK9_Val"> Generic clock generator 9
+
+// <GCLK_PCHCTRL_GEN_GCLK10_Val"> Generic clock generator 10
+
+// <GCLK_PCHCTRL_GEN_GCLK11_Val"> Generic clock generator 11
+
+// <i> Select the slow clock source.
+#ifndef CONF_GCLK_SERCOM3_SLOW_SRC
+#define CONF_GCLK_SERCOM3_SLOW_SRC GCLK_PCHCTRL_GEN_GCLK3_Val
+#endif
+
+/**
+ * \def CONF_GCLK_SERCOM3_CORE_FREQUENCY
+ * \brief SERCOM3's Core Clock frequency
+ */
+#ifndef CONF_GCLK_SERCOM3_CORE_FREQUENCY
+#define CONF_GCLK_SERCOM3_CORE_FREQUENCY 48000000
+#endif
+
+/**
+ * \def CONF_GCLK_SERCOM3_SLOW_FREQUENCY
+ * \brief SERCOM3's Slow Clock frequency
+ */
+#ifndef CONF_GCLK_SERCOM3_SLOW_FREQUENCY
+#define CONF_GCLK_SERCOM3_SLOW_FREQUENCY 32768
+#endif
+
 // <y> TC Clock Source
 // <id> tc_gclk_selection
 
@@ -869,7 +949,7 @@
 
 // <i> Select the clock source for TC.
 #ifndef CONF_GCLK_TC0_SRC
-#define CONF_GCLK_TC0_SRC GCLK_PCHCTRL_GEN_GCLK0_Val
+#define CONF_GCLK_TC0_SRC GCLK_PCHCTRL_GEN_GCLK1_Val
 #endif
 
 /**
@@ -877,7 +957,7 @@
  * \brief TC0's Clock frequency
  */
 #ifndef CONF_GCLK_TC0_FREQUENCY
-#define CONF_GCLK_TC0_FREQUENCY 120000000
+#define CONF_GCLK_TC0_FREQUENCY 48000000
 #endif
 
 // <y> USB Clock Source

--- a/ports/atmel-samd/boards/metro_m4_express/pins.c
+++ b/ports/atmel-samd/boards/metro_m4_express/pins.c
@@ -13,7 +13,9 @@ STATIC const mp_map_elem_t board_global_dict_table[] = {
 
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_D0),  (mp_obj_t)&pin_PA23 },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_RX),  (mp_obj_t)&pin_PA23 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D1),  (mp_obj_t)&pin_PA22 },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_TX),  (mp_obj_t)&pin_PA22 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D2),  (mp_obj_t)&pin_PA04 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D3),  (mp_obj_t)&pin_PB16 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D4),  (mp_obj_t)&pin_PB13 },

--- a/ports/atmel-samd/common-hal/busio/SPI.c
+++ b/ports/atmel-samd/common-hal/busio/SPI.c
@@ -117,6 +117,8 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         mp_raise_OSError(MP_EIO);
     }
     
+    // Pads must be set after spi_m_sync_init(), which uses default values from
+    // the prototypical SERCOM.
     hri_sercomspi_write_CTRLA_DOPO_bf(sercom, dopo);
     hri_sercomspi_write_CTRLA_DIPO_bf(sercom, miso_pad);
 

--- a/ports/atmel-samd/common-hal/busio/UART.h
+++ b/ports/atmel-samd/common-hal/busio/UART.h
@@ -29,22 +29,25 @@
 
 #include "common-hal/microcontroller/Pin.h"
 
-#include "asf/sam0/drivers/sercom/usart/usart.h"
+#include "hal/include/hal_usart_async.h"
+
 #include "py/obj.h"
 
 typedef struct {
-  mp_obj_base_t base;
-  struct usart_module uart_instance;
-  uint8_t rx_pin;
-  uint8_t tx_pin;
-  uint32_t timeout_ms;
-  bool rx_error;
-  // Index of the oldest received character.
-  uint32_t buffer_start;
-  // Index of the next available spot to store a character.
-  uint32_t buffer_size;
-  uint32_t buffer_length;
-  uint8_t* buffer;
+    mp_obj_base_t base;
+    struct usart_async_descriptor usart_desc;
+    uint8_t rx_pin;
+    uint8_t tx_pin;
+    uint8_t character_bits;
+    bool rx_error;
+    uint32_t baudrate;
+    uint32_t timeout_ms;
+    // Index of the oldest received character.
+    uint32_t buffer_start;
+    // Index of the next available spot to store a character.
+    uint32_t buffer_size;
+    uint32_t buffer_length;
+    uint8_t* buffer;
 } busio_uart_obj_t;
 
 #endif // MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_BUSIO_UART_H

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -114,23 +114,6 @@ safe_mode_t port_init(void) {
     // Configure millisecond timer initialization.
     tick_init();
 
-    // Uncomment to init PIN_PA17 for debugging.
-    // struct port_config pin_conf;
-    // port_get_config_defaults(&pin_conf);
-    //
-    // pin_conf.direction  = PORT_PIN_DIR_OUTPUT;
-    // port_pin_set_config(MICROPY_HW_LED1, &pin_conf);
-    // port_pin_set_output_level(MICROPY_HW_LED1, false);
-
-    // Output clocks for debugging.
-    // not supported by SAMD51G; uncomment for SAMD51J or update for 51G
-    // #ifdef SAMD51
-    // gpio_set_pin_function(PIN_PA10, GPIO_PIN_FUNCTION_M); // GCLK4, D3
-    // gpio_set_pin_function(PIN_PA11, GPIO_PIN_FUNCTION_M); // GCLK5, A4
-    // gpio_set_pin_function(PIN_PB14, GPIO_PIN_FUNCTION_M); // GCLK0, D5
-    // gpio_set_pin_function(PIN_PB15, GPIO_PIN_FUNCTION_M); // GCLK1, D6
-    // #endif
-
     // Init the nvm controller.
     // struct nvm_config config_nvm;
     // nvm_get_config_defaults(&config_nvm);
@@ -221,7 +204,26 @@ void reset_port(void) {
     analogout_reset();
 
     reset_all_pins();
-//
+
+    // Set up debugging pins after reset_all_pins().
+    
+    // Uncomment to init PIN_PA17 for debugging.
+    // struct port_config pin_conf;
+    // port_get_config_defaults(&pin_conf);
+    //
+    // pin_conf.direction  = PORT_PIN_DIR_OUTPUT;
+    // port_pin_set_config(MICROPY_HW_LED1, &pin_conf);
+    // port_pin_set_output_level(MICROPY_HW_LED1, false);
+
+    // Output clocks for debugging.
+    // not supported by SAMD51G; uncomment for SAMD51J or update for 51G
+    // #ifdef SAMD51
+    // gpio_set_pin_function(PIN_PA10, GPIO_PIN_FUNCTION_M); // GCLK4, D3
+    // gpio_set_pin_function(PIN_PA11, GPIO_PIN_FUNCTION_M); // GCLK5, A4
+    // gpio_set_pin_function(PIN_PB14, GPIO_PIN_FUNCTION_M); // GCLK0, D5
+    // gpio_set_pin_function(PIN_PB15, GPIO_PIN_FUNCTION_M); // GCLK1, D6
+    // #endif
+
 //
 //     usb_hid_reset();
 //

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -202,6 +202,7 @@ SRC_COMMON_HAL += \
 	busio/__init__.c\
 	busio/I2C.c \
 	busio/SPI.c \
+	busio/UART.c \
 	pulseio/__init__.c \
 	pulseio/PulseIn.c \
 	pulseio/PulseOut.c \
@@ -211,6 +212,7 @@ SRC_COMMON_HAL += \
 # These don't have corresponding files in each port but are still located in
 # shared-bindings to make it clear what the contents of the modules are.
 SRC_BINDINGS_ENUMS = \
+	busio/OneWire.c \
 	digitalio/Direction.c \
 	digitalio/DriveMode.c \
 	digitalio/Pull.c \
@@ -234,10 +236,10 @@ SRC_SHARED_MODULE = \
 	bitbangio/__init__.c \
 	bitbangio/I2C.c \
 	bitbangio/OneWire.c \
-	bitbangio/SPI.c
+	bitbangio/SPI.c \
+	busio/OneWire.c \
 
-#  busio/OneWire.c \
-	uheap/__init__.c \
+#	uheap/__init__.c \
 	ustack/__init__.c
 
 SRC_SHARED_BINDINGS = \

--- a/ports/nrf/common-hal/busio/OneWire.h
+++ b/ports/nrf/common-hal/busio/OneWire.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Scott Shawcroft
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_NRF_COMMON_HAL_BUSIO_ONEWIRE_H
+#define MICROPY_INCLUDED_NRF_COMMON_HAL_BUSIO_ONEWIRE_H
+
+// Use bitbangio.
+#include "shared-module/busio/OneWire.h"
+
+#endif // MICROPY_INCLUDED_NRF_COMMON_HAL_BUSIO_ONEWIRE_H

--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -1,0 +1,89 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "shared-bindings/microcontroller/__init__.h"
+#include "shared-bindings/busio/UART.h"
+
+#include "mpconfigport.h"
+#include "py/gc.h"
+#include "py/mperrno.h"
+#include "py/runtime.h"
+#include "py/stream.h"
+
+#include "tick.h"
+
+#include "pins.h"
+
+void common_hal_busio_uart_construct(busio_uart_obj_t *self,
+        const mcu_pin_obj_t * tx, const mcu_pin_obj_t * rx, uint32_t baudrate,
+        uint8_t bits, uart_parity_t parity, uint8_t stop, uint32_t timeout,
+        uint8_t receiver_buffer_size) {
+    mp_raise_NotImplementedError("busio.UART not yet implemented");
+}
+
+bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {
+    mp_raise_NotImplementedError("busio.UART not yet implemented");
+}
+
+void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
+    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    if (common_hal_busio_uart_deinited(self)) {
+        return;
+    }
+    // Do deinit;
+}
+
+// Read characters.
+size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t len, int *errcode) {
+    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    return 0;
+}
+
+// Write characters.
+size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, size_t len, int *errcode) {
+    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    return 0;
+}
+
+uint32_t common_hal_busio_uart_get_baudrate(busio_uart_obj_t *self) {
+    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    return self->baudrate;
+}
+
+void common_hal_busio_uart_set_baudrate(busio_uart_obj_t *self, uint32_t baudrate) {
+    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    self->baudrate = baudrate;
+}
+
+uint32_t common_hal_busio_uart_rx_characters_available(busio_uart_obj_t *self) {
+    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    return 0;
+}
+
+bool common_hal_busio_uart_ready_to_tx(busio_uart_obj_t *self) {
+    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    return false;
+}

--- a/ports/nrf/common-hal/busio/UART.h
+++ b/ports/nrf/common-hal/busio/UART.h
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Scott Shawcroft
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_NRF_COMMON_HAL_BUSIO_UART_H
+#define MICROPY_INCLUDED_NRF_COMMON_HAL_BUSIO_UART_H
+
+#include "common-hal/microcontroller/Pin.h"
+
+#include "py/obj.h"
+
+typedef struct {
+    mp_obj_base_t base;
+    uint8_t rx_pin;
+    uint8_t tx_pin;
+    uint8_t character_bits;
+    bool rx_error;
+    uint32_t baudrate;
+    uint32_t timeout_ms;
+    // Index of the oldest received character.
+    uint32_t buffer_start;
+    // Index of the next available spot to store a character.
+    uint32_t buffer_size;
+    uint32_t buffer_length;
+    uint8_t* buffer;
+} busio_uart_obj_t;
+
+#endif // MICROPY_INCLUDED_NRF_COMMON_HAL_BUSIO_UART_H

--- a/shared-bindings/busio/UART.h
+++ b/shared-bindings/busio/UART.h
@@ -55,6 +55,10 @@ extern size_t common_hal_busio_uart_read(busio_uart_obj_t *self,
 extern size_t common_hal_busio_uart_write(busio_uart_obj_t *self,
                               const uint8_t *data, size_t len, int *errcode);
 
+extern uint32_t common_hal_busio_uart_get_baudrate(busio_uart_obj_t *self);
+extern void common_hal_busio_uart_set_baudrate(busio_uart_obj_t *self, uint32_t baudrate);
+
+
 extern uint32_t common_hal_busio_uart_rx_characters_available(busio_uart_obj_t *self);
 extern bool common_hal_busio_uart_ready_to_tx(busio_uart_obj_t *self);
 

--- a/shared-bindings/busio/__init__.c
+++ b/shared-bindings/busio/__init__.c
@@ -32,9 +32,9 @@
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/busio/__init__.h"
 #include "shared-bindings/busio/I2C.h"
-//xxxx #include "shared-bindings/busio/OneWire.h"
+#include "shared-bindings/busio/OneWire.h"
 #include "shared-bindings/busio/SPI.h"
-//xxxx #include "shared-bindings/busio/UART.h"
+#include "shared-bindings/busio/UART.h"
 #include "shared-bindings/busio/__init__.h"
 
 #include "py/runtime.h"
@@ -89,8 +89,8 @@ STATIC const mp_rom_map_elem_t busio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_busio) },
     { MP_ROM_QSTR(MP_QSTR_I2C),   MP_ROM_PTR(&busio_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI),   MP_ROM_PTR(&busio_spi_type) },
-    //xxxx    { MP_ROM_QSTR(MP_QSTR_OneWire),   MP_ROM_PTR(&busio_onewire_type) },
-    //xxxx    { MP_ROM_QSTR(MP_QSTR_UART),   MP_ROM_PTR(&busio_uart_type) },
+    { MP_ROM_QSTR(MP_QSTR_OneWire),   MP_ROM_PTR(&busio_onewire_type) },
+    { MP_ROM_QSTR(MP_QSTR_UART),   MP_ROM_PTR(&busio_uart_type) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(busio_module_globals, busio_module_globals_table);


### PR DESCRIPTION
1. `busio.UART`: ported to ASF4. Allow rx-only and tx-only. Add `.baudrate` r/w property.

2. Make NeoPixel timing deterministic by turning off caches during NeoPixel writes.
3. Incorporate asf4 updates:
  a. async USART driver
  b. bringing Atmel START configuration closer to what we use
  c. Clock initialization order now specified by `CIRCUITPY_GCLK_INIT_1ST` and `_LAST`.
4. `supervisor/port.c`: Move commented-out clock-test pin setting to correct location.
5. Turn on `busio.OneWire` (implemented by `bitbangio`) (not tested).

Checks off more of #259 (busio support).
Fixes #228 (uart single direction).
Fixes #198 (change baudrate).