### PR TITLE
add board.RX and .TX pins to metro_m4_express_revb

### DIFF
--- a/ports/atmel-samd/boards/metro_m4_express_revb/pins.c
+++ b/ports/atmel-samd/boards/metro_m4_express_revb/pins.c
@@ -13,7 +13,9 @@ STATIC const mp_map_elem_t board_global_dict_table[] = {
 
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_D0),  (mp_obj_t)&pin_PA23 },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_RX),  (mp_obj_t)&pin_PA23 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D1),  (mp_obj_t)&pin_PA22 },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_TX),  (mp_obj_t)&pin_PA22 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D2),  (mp_obj_t)&pin_PA08 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D3),  (mp_obj_t)&pin_PA10 },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D4),  (mp_obj_t)&pin_PB12 },


### PR DESCRIPTION
Noticed by @jerryneedell.