### PR TITLE
Add .baudrate support to ESP8266.

### DIFF
--- a/ports/esp8266/common-hal/busio/UART.h
+++ b/ports/esp8266/common-hal/busio/UART.h
@@ -33,6 +33,7 @@
 
 typedef struct {
     mp_obj_base_t base;
+    uint32_t baudrate;
     bool deinited;
 } busio_uart_obj_t;
 


### PR DESCRIPTION
busio.UART on ESP8266 provides a TX-only UART on GPIO2.
Fixed some bugs in the implementation. (Not clear if it was previously usable.)

Fixes #638.