### PR TITLE
fixes hardware dotstar support for 3.0 and addresses issue #514

### DIFF
--- a/ports/atmel-samd/boards/trinket_m0/mpconfigboard.h
+++ b/ports/atmel-samd/boards/trinket_m0/mpconfigboard.h
@@ -2,8 +2,8 @@
 #define MICROPY_HW_MCU_NAME "samd21e18"
 
 // Rev B - Black
-// #define MICROPY_HW_APA102_MOSI   (&pin_PA00)
-// #define MICROPY_HW_APA102_SCK    (&pin_PA01)
+#define MICROPY_HW_APA102_MOSI   (&pin_PA00)
+#define MICROPY_HW_APA102_SCK    (&pin_PA01)
 
 #define MICROPY_PORT_A        (PORT_PA00 | PORT_PA01 | PORT_PA24 | PORT_PA25)
 #define MICROPY_PORT_B        (0)

--- a/supervisor/shared/rgb_led_status.c
+++ b/supervisor/shared/rgb_led_status.c
@@ -70,11 +70,11 @@ void rgb_led_status_init() {
                                               MICROPY_HW_APA102_MOSI,
                                               mp_const_none);
         #else
-        if (status_apa102.current_baudrate > 0) {
+        if (!common_hal_busio_spi_deinited(&status_apa102)) {
             // Don't use spi_deinit because that leads to infinite
             // recursion because reset_pin may call
             // rgb_led_status_init.
-            spi_disable(&status_apa102.spi_master_instance);
+            spi_m_sync_disable(&status_apa102.spi_desc);
         }
         common_hal_busio_spi_construct(&status_apa102,
                                       MICROPY_HW_APA102_SCK,


### PR DESCRIPTION
Some time time and many dead ends later I finally got it working, as far as I can tell. Tested on my m4 board and trinket m0 both of which have a dotstar. The itsy bitsy m0 can't use a sercom because of how it's wired (dotstar clock to a sercom 1 pad 0 which can't be a clock).