### PR TITLE
gamepad: Enable the gamepad module for express boards in 3.x

### DIFF
--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -194,10 +194,10 @@ extern const struct _mp_obj_module_t usb_hid_module;
     #define CIRCUITPY_GAMEPAD_TICKS 0x1f
 
     #define EXTRA_BUILTIN_MODULES \
-        { MP_OBJ_NEW_QSTR(MP_QSTR_bitbangio), (mp_obj_t)&bitbangio_module }
+        { MP_OBJ_NEW_QSTR(MP_QSTR_bitbangio), (mp_obj_t)&bitbangio_module }, \
+        { MP_OBJ_NEW_QSTR(MP_QSTR_gamepad),(mp_obj_t)&gamepad_module }
 //        { MP_OBJ_NEW_QSTR(MP_QSTR_audioio), (mp_obj_t)&audioio_module },
 //        { MP_OBJ_NEW_QSTR(MP_QSTR_audiobusio), (mp_obj_t)&audiobusio_module },
-//    { MP_OBJ_NEW_QSTR(MP_QSTR_gamepad),(mp_obj_t)&gamepad_module },
     #define EXPRESS_BOARD
 #else
     #define MICROPY_PY_BUILTINS_REVERSED (0)

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -52,6 +52,10 @@
 #include "shared_dma.h"
 #include "tick.h"
 
+#ifdef CIRCUITPY_GAMEPAD_TICKS
+#include "shared-module/gamepad/__init__.h"
+#endif
+
 extern volatile bool mp_msc_enabled;
 
 #if defined(SAMD21) && defined(ENABLE_MICRO_TRACE_BUFFER)
@@ -198,10 +202,10 @@ void reset_port(void) {
 
     analogin_reset();
 
-// #ifdef CIRCUITPY_GAMEPAD_TICKS
-//     gamepad_reset();
-// #endif
-//
+#ifdef CIRCUITPY_GAMEPAD_TICKS
+    gamepad_reset();
+#endif
+
     analogout_reset();
 
     reset_all_pins();


### PR DESCRIPTION
With #664 closed, we can finally enable it.