### PR TITLE
Move usb read finish into interrupt.

### DIFF
--- a/ports/atmel-samd/usb_mass_storage.c
+++ b/ports/atmel-samd/usb_mass_storage.c
@@ -260,6 +260,9 @@ int32_t usb_msc_xfer_done(uint8_t lun) {
     if (active_read) {
         active_addr += 1;
         active_nblocks--;
+        if (active_nblocks == 0) {
+            active_read = false;
+        }
     }
 
     if (active_write) {
@@ -278,10 +281,6 @@ int32_t usb_msc_xfer_done(uint8_t lun) {
 // sector. Once the sector is transmitted, xfer_done will be called.
 void usb_msc_background(void) {
     if (active_read && !usb_busy) {
-        if (active_nblocks == 0) {
-            active_read = false;
-            return;
-        }
         fs_user_mount_t * vfs = get_vfs(active_lun);
         disk_read(vfs, sector_buffer, active_addr, 1);
         CRITICAL_SECTION_ENTER();


### PR DESCRIPTION
Having the `active_read = false` in the background function left
a chance that a new_write occurs before active_read is set to false.

In that case, we'll read the appropriate data rather than write it
and never clear the active write.

Hopefully fixes #655.