### PR TITLE
Correct NO_TIMER index value for SAMD21.

### DIFF
--- a/ports/atmel-samd/common-hal/busio/I2C.c
+++ b/ports/atmel-samd/common-hal/busio/I2C.c
@@ -46,19 +46,21 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     uint32_t sda_pinmux = 0;
     uint32_t scl_pinmux = 0;
     for (int i = 0; i < NUM_SERCOMS_PER_PIN; i++) {
-        Sercom* potential_sercom = sda->sercom[i].sercom;
-        if (potential_sercom == NULL ||
-            potential_sercom->I2CM.CTRLA.bit.ENABLE != 0 ||
+        sercom_index = sda->sercom[i].index;
+        if (sercom_index >= SERCOM_INST_NUM) {
+            continue;
+        }
+        Sercom* potential_sercom = sercom_insts[sercom_index];
+        if (potential_sercom->I2CM.CTRLA.bit.ENABLE != 0 ||
             sda->sercom[i].pad != 0) {
             continue;
         }
         sda_pinmux = PINMUX(sda->pin, (i == 0) ? MUX_C : MUX_D);
         for (int j = 0; j < NUM_SERCOMS_PER_PIN; j++) {
-            if (potential_sercom == scl->sercom[j].sercom &&
+            if (sercom_index == scl->sercom[j].index &&
                 scl->sercom[j].pad == 1) {
                 scl_pinmux = PINMUX(scl->pin, (j == 0) ? MUX_C : MUX_D);
                 sercom = potential_sercom;
-                sercom_index = scl->sercom[j].index; // 2 for SERCOM2, etc.
                 break;
             }
         }
@@ -77,7 +79,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     if (i2c_m_sync_init(&self->i2c_desc, sercom) != ERR_NONE) {
             mp_raise_OSError(MP_EIO);
     }
-        
+
     gpio_set_pin_pull_mode(sda->pin, GPIO_PULL_OFF);
     gpio_set_pin_function(sda->pin, sda_pinmux);
 
@@ -85,7 +87,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     gpio_set_pin_function(scl->pin, scl_pinmux);
 
     // clkrate is always 0. baud_rate is in kHz.
-    
+
     // Frequency must be set before the I2C device is enabled.
     if (i2c_m_sync_set_baudrate(&self->i2c_desc, 0, frequency / 1000) != ERR_NONE) {
         mp_raise_ValueError("Unsupported baudrate");
@@ -113,7 +115,7 @@ void common_hal_busio_i2c_deinit(busio_i2c_obj_t *self) {
 
     i2c_m_sync_disable(&self->i2c_desc);
     i2c_m_sync_deinit(&self->i2c_desc);
-    
+
     reset_pin(self->sda_pin);
     reset_pin(self->scl_pin);
     self->sda_pin = NO_PIN;

--- a/ports/atmel-samd/common-hal/busio/SPI.c
+++ b/ports/atmel-samd/common-hal/busio/SPI.c
@@ -55,9 +55,12 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     uint8_t miso_pad = 0;
     uint8_t dopo = 255;
     for (int i = 0; i < NUM_SERCOMS_PER_PIN; i++) {
-        Sercom* potential_sercom = clock->sercom[i].sercom;
         sercom_index = clock->sercom[i].index; // 2 for SERCOM2, etc.
-        if (potential_sercom == NULL ||
+        if (sercom_index >= SERCOM_INST_NUM) {
+            continue;
+        }
+        Sercom* potential_sercom = sercom_insts[sercom_index];
+        if (
         #if defined(MICROPY_HW_APA102_SCK) && defined(MICROPY_HW_APA102_MOSI) && !defined(CIRCUITPY_BITBANG_APA102)
             (potential_sercom->SPI.CTRLA.bit.ENABLE != 0 &&
              potential_sercom != status_apa102.spi_desc.dev.prvt &&
@@ -74,7 +77,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         }
         for (int j = 0; j < NUM_SERCOMS_PER_PIN; j++) {
             if (!mosi_none) {
-                if(potential_sercom == mosi->sercom[j].sercom) {
+                if (sercom_index == mosi->sercom[j].index) {
                     mosi_pinmux = PINMUX(mosi->pin, (j == 0) ? MUX_C : MUX_D);
                     mosi_pad = mosi->sercom[j].pad;
                     dopo = samd_peripherals_get_spi_dopo(clock_pad, mosi_pad);
@@ -91,7 +94,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
             }
             if (!miso_none) {
                 for (int k = 0; k < NUM_SERCOMS_PER_PIN; k++) {
-                    if (potential_sercom == miso->sercom[k].sercom) {
+                    if (sercom_index == miso->sercom[k].index) {
                         miso_pinmux = PINMUX(miso->pin, (k == 0) ? MUX_C : MUX_D);
                         miso_pad = miso->sercom[k].pad;
                         sercom = potential_sercom;

--- a/ports/atmel-samd/common-hal/microcontroller/Pin.h
+++ b/ports/atmel-samd/common-hal/microcontroller/Pin.h
@@ -34,9 +34,8 @@
 #include "include/component/sercom.h"
 
 typedef struct {
-    Sercom *const sercom;     // SERCOM0, SERCOM1, etc.
-    uint8_t index;            // 0, 1, etc. corresponding to SERCOM<n>.
-    uint8_t pad;              // which of the four SERCOM pads to use
+    uint8_t index:6;            // 0, 1, etc. corresponding to SERCOM<n>.
+    uint8_t pad:2;              // which of the four SERCOM pads to use
 } pin_sercom_t;
 
 typedef struct {

--- a/ports/atmel-samd/peripherals.h
+++ b/ports/atmel-samd/peripherals.h
@@ -35,6 +35,8 @@
 uint8_t samd_peripherals_spi_baudrate_to_baud_reg_value(const uint32_t baudrate);
 uint32_t samd_peripherals_spi_baud_reg_value_to_baudrate(const uint8_t baud_reg_value);
 
+Sercom* sercom_insts[SERCOM_INST_NUM];
+
 #ifdef SAMD21
 #include "samd21_peripherals.h"
 #endif

--- a/ports/atmel-samd/samd21_peripherals.c
+++ b/ports/atmel-samd/samd21_peripherals.c
@@ -56,7 +56,8 @@ static const uint8_t SERCOMx_GCLK_ID_SLOW[] = {
 #endif
 };
 
-    
+Sercom* sercom_insts[SERCOM_INST_NUM] = SERCOM_INSTS;
+
 // Clock initialization as done in Atmel START.
 void samd_peripherals_sercom_clock_init(Sercom* sercom, uint8_t sercom_index) {
     _pm_enable_bus_clock(PM_BUS_APBC, sercom);

--- a/ports/atmel-samd/samd21_pins.c
+++ b/ports/atmel-samd/samd21_pins.c
@@ -57,7 +57,7 @@
   .wave_output = p_wave_output \
 }
 
-#define NO_TIMER TCC(0, 0)
+#define NO_TIMER TCC(0xff, 0)
 
 #define TOUCH(y_line) \
     .has_touch = true, \

--- a/ports/atmel-samd/samd21_pins.c
+++ b/ports/atmel-samd/samd21_pins.c
@@ -30,15 +30,13 @@
 
 #define SERCOM(sercom_index, p_pad)     \
 { \
-  .sercom = SERCOM## sercom_index, \
   .index = sercom_index,   \
   .pad = p_pad \
 }
 
 #define NO_SERCOM \
 { \
-  .sercom = 0, \
-  .index = 0, \
+  .index = 0x3f, \
   .pad = 0 \
 }
 
@@ -91,8 +89,6 @@ const mcu_pin_obj_t pin_## p_name = { \
     .timer = { p_primary_timer, p_secondary_timer}, \
     .sercom = {p_primary_sercom, p_secondary_sercom}, \
 }
-
-#define NO_ADC_INPUT (0)
 
 // Pins in datasheet order.
 // NOTE(tannewt): TC wave out 0 is commented out because the first channel is

--- a/ports/atmel-samd/samd51_peripherals.c
+++ b/ports/atmel-samd/samd51_peripherals.c
@@ -60,7 +60,8 @@ static const uint8_t SERCOMx_GCLK_ID_SLOW[] = {
 #endif
 };
 
-    
+Sercom* sercom_insts[SERCOM_INST_NUM] = SERCOM_INSTS;
+
 // Clock initialization as done in Atmel START.
 void samd_peripherals_sercom_clock_init(Sercom* sercom, uint8_t sercom_index) {
 	hri_gclk_write_PCHCTRL_reg(GCLK,

--- a/ports/atmel-samd/samd51_pins.c
+++ b/ports/atmel-samd/samd51_pins.c
@@ -30,15 +30,13 @@
 
 #define SERCOM(sercom_index, p_pad)     \
 { \
-  .sercom = SERCOM## sercom_index, \
   .index = sercom_index,   \
   .pad = p_pad \
 }
 
 #define NO_SERCOM \
 { \
-  .sercom = 0, \
-  .index = 0, \
+  .index = 0x3f, \
   .pad = 0 \
 }
 
@@ -90,8 +88,6 @@ const mcu_pin_obj_t pin_## p_name = { \
     .timer = {p_primary_timer, p_secondary_timer, p_tertiary_timer}, \
     .sercom = {p_primary_sercom, p_secondary_sercom}, \
 }
-
-#define NO_ADC_INPUT (0)
 
 // Pins in datasheet order.
 // NOTE(tannewt): TC wave out 0 is commented out because the first channel is
@@ -1139,7 +1135,7 @@ PIN(PA31, EXTINT_CHANNEL(15), NO_ADC, NO_ADC, NO_TOUCH,
     #else
     NO_SERCOM,
     #endif
-    SERCOM(1, 23),
+    SERCOM(1, 3),
     #ifdef TC6
     TC(6, 1),
     #else


### PR DESCRIPTION
We check validity by ensuring it's lower than the total number of
timers. 0 is a terrible number for the NO_TIMER value because its
valid even though it shouldn't be.

Fixes https://github.com/adafruit/Adafruit_CircuitPython_SimpleIO/issues/29