### PR TITLE
fix dotstar for Gemma_M0 in CP3.0

### DIFF
--- a/ports/atmel-samd/boards/gemma_m0/mpconfigboard.h
+++ b/ports/atmel-samd/boards/gemma_m0/mpconfigboard.h
@@ -1,8 +1,8 @@
 #define MICROPY_HW_BOARD_NAME "Adafruit Gemma M0"
 #define MICROPY_HW_MCU_NAME "samd21e18"
 
-// #define MICROPY_HW_APA102_MOSI   (&pin_PA00)
-// #define MICROPY_HW_APA102_SCK    (&pin_PA01)
+#define MICROPY_HW_APA102_MOSI   (&pin_PA00)
+#define MICROPY_HW_APA102_SCK    (&pin_PA01)
 
 // #define CIRCUITPY_BITBANG_APA102
 


### PR DESCRIPTION
Uncomment lines in mpconfigport.h for gemma_m0 to allow dotstar access.  same issue as #514 for trinket_m0

This seems to work - is anything else missing?