### PR TITLE
UART: Fix maybe-uninitialized diagnostic

### DIFF
--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -56,7 +56,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         uint8_t bits, uart_parity_t parity, uint8_t stop, uint32_t timeout,
         uint8_t receiver_buffer_size) {
     Sercom* sercom = NULL;
-    uint8_t sercom_index;
+    uint8_t sercom_index = 255; // Unset index
     uint32_t rx_pinmux = 0;
     uint8_t rx_pad = 255; // Unset pad
     uint32_t tx_pinmux = 0;


### PR DESCRIPTION
The following error occurs when building with gcc 5.4.1 (debian stretch) while building the atmel-samd port:

~~~~
common-hal/busio/UART.c:104:83: error: 'sercom_index' may be used uninitialized in this function [-Werror=maybe-uninitialized]
                   sercom_insts[rx->sercom[j].index]->USART.CTRLA.bit.ENABLE == 0) ||
~~~~

It may be related to the addition of rx-only UARTs; gcc is unable
to infer the intended relationship between have_tx and sercom_index
being set (I am still not entirely confident of it myself)