### PR TITLE
README: delete reference to gitter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,7 @@ so will result in corrective actions such as time out or ban from the project.
 ## Developer contact
 [@tannewt](https://github.com/tannewt) is the main developer of CircuitPython
 and is sponsored by [Adafruit Industries LLC](https://adafruit.com). He is
-reachable on [Discord](https://adafru.it/discord) as tannewt and
-[Gitter](gitter.im/adafruit/circuitpython) as tannewt during US West Coast
+reachable on [Discord](https://adafru.it/discord) as tannewt during US West Coast
 working hours. He also checks GitHub issues and the [Adafruit support forum](https://forums.adafruit.com/viewforum.php?f=60).
 
 ## Licensing

--- a/README.rst
+++ b/README.rst
@@ -83,8 +83,7 @@ Conduct <https://github.com/adafruit/circuitpython/blob/master/CODE_OF_CONDUCT.m
 Contributors who follow the `Code of
 Conduct <https://github.com/adafruit/circuitpython/blob/master/CODE_OF_CONDUCT.md>`__
 are welcome to submit pull requests and they will be promptly reviewed
-by project admins. Please join the `Gitter
-chat <https://gitter.im/adafruit/circuitpython>`__ or
+by project admins. Please join the
 `Discord <https://discord.gg/nBQh6qu>`__ too.
 
 --------------


### PR DESCRIPTION
"We don't use gitter anymore" -- the last message on
https://gitter.im/adafruit/circuitpython on February 18

@tannewt there's also a reference in `CONTRIBUTING.md` to your personal handle on gitter.  Should I offer a PR to delete that too, or should I leave it?