### PR TITLE
extmod/vfs_fat_file: Implement SEEK_CUR for non-zero offset.

### DIFF
--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -125,11 +125,7 @@ STATIC mp_uint_t file_obj_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg,
                 break;
 
             case 1: // SEEK_CUR
-                if (s->offset != 0) {
-                    *errcode = MP_EOPNOTSUPP;
-                    return MP_STREAM_ERROR;
-                }
-                // no-operation
+                f_lseek(&self->fp, f_tell(&self->fp) + s->offset);
                 break;
 
             case 2: // SEEK_END

--- a/tests/extmod/vfs_fat_fileio1.py
+++ b/tests/extmod/vfs_fat_fileio1.py
@@ -91,10 +91,8 @@ with open("foo_file.txt") as f2:
 
     f2.seek(0, 1) # SEEK_CUR
     print(f2.read(1))
-    try:
-        f2.seek(1, 1) # SEEK_END
-    except OSError as e:
-        print(e.args[0] == uerrno.EOPNOTSUPP)
+    f2.seek(2, 1) # SEEK_CUR
+    print(f2.read(1))
 
     f2.seek(-2, 2) # SEEK_END
     print(f2.read(1))

--- a/tests/extmod/vfs_fat_fileio1.py.exp
+++ b/tests/extmod/vfs_fat_fileio1.py.exp
@@ -7,7 +7,7 @@ hello!world!
 12
 h
 e
-True
+o
 d
 True
 [('foo_dir', 16384, 0)]


### PR DESCRIPTION
I noticed that this functionality was now added in uPy and cherry-picked the fix.

As far as testing goes, there is an added test case but unfortunately it looks like the related test is skipped during the unix and qemu builds. ☹️ 

Closes: #501 