### PR TITLE
Fix 128 Character Max Paste Into REPL

### DIFF
--- a/ports/atmel-samd/usb.c
+++ b/ports/atmel-samd/usb.c
@@ -25,7 +25,6 @@
  */
 
 #include "usb.h"
-#include <stdio.h>
 
 #include <stdint.h>
 
@@ -50,7 +49,6 @@
 #include "usb_mass_storage.h"
 
 #include "supervisor/shared/autoreload.h"
-#include "supervisor/serial.h"
 
 // Store received characters on our own so that we can filter control characters
 // and act immediately on CTRL-C for example.
@@ -128,7 +126,7 @@ static bool read_complete(const uint8_t ep, const enum usb_xfer_code rc, const u
         atomic_leave_critical(&flags);
         return true;
     }
-    
+
     for (uint16_t i = 0; i < count; i++) {
         uint8_t c = cdc_packet_buffer[i];
         if (c == mp_interrupt_char) {
@@ -152,7 +150,7 @@ static bool read_complete(const uint8_t ep, const enum usb_xfer_code rc, const u
         }
     }
     atomic_leave_critical(&flags);
-    
+
     // Trigger a follow up read if we have space.
     /*if (usb_rx_count < USB_RX_BUF_SIZE - 64) {
         int32_t result = start_read();
@@ -160,7 +158,7 @@ static bool read_complete(const uint8_t ep, const enum usb_xfer_code rc, const u
             return true;
         }
     }*/
-    
+
     /* No error. */
     return false;
 }
@@ -283,7 +281,7 @@ int usb_read(void) {
     /*if (!pending_read && usb_rx_count == USB_RX_BUF_SIZE - 1) {
         start_read();
     }*/
-     
+
     return data;
 }
 

--- a/ports/atmel-samd/usb.c
+++ b/ports/atmel-samd/usb.c
@@ -241,7 +241,7 @@ bool usb_bytes_available(void) {
     // Check if the buffer has data, but not enough
     // space to hold another read.
     if (usb_rx_count > USB_RX_BUF_SIZE - CDC_BULKOUT_SIZE) {
-        return usb_rx_count > 0;
+        return true;
     }
     // Buffer has enough room
     if (cdc_enabled() && !pending_read) {

--- a/ports/atmel-samd/usb.c
+++ b/ports/atmel-samd/usb.c
@@ -102,12 +102,13 @@ static void init_hardware(void) {
     #endif
 }
 
-COMPILER_ALIGNED(4) uint8_t cdc_packet_buffer[64];
+#define CDC_BULKOUT_SIZE CONF_USB_COMPOSITE_CDC_ACM_DATA_BULKOUT_MAXPKSZ
+COMPILER_ALIGNED(4) uint8_t cdc_packet_buffer[CDC_BULKOUT_SIZE];
 static volatile bool pending_read;
 
 static int32_t start_read(void) {
     pending_read = true;
-    int32_t result = cdcdf_acm_read(cdc_packet_buffer, 64);
+    int32_t result = cdcdf_acm_read(cdc_packet_buffer, CDC_BULKOUT_SIZE);
     if (result != ERR_NONE) {
         pending_read = false;
     }
@@ -150,14 +151,6 @@ static bool read_complete(const uint8_t ep, const enum usb_xfer_code rc, const u
         }
     }
     atomic_leave_critical(&flags);
-
-    // Trigger a follow up read if we have space.
-    /*if (usb_rx_count < USB_RX_BUF_SIZE - 64) {
-        int32_t result = start_read();
-        if (result != ERR_NONE) {
-            return true;
-        }
-    }*/
 
     /* No error. */
     return false;
@@ -247,7 +240,7 @@ static bool cdc_enabled(void) {
 bool usb_bytes_available(void) {
     // Check if the buffer has data, but not enough
     // space to hold another read.
-    if (usb_rx_count > 64) {
+    if (usb_rx_count > CDC_BULKOUT_SIZE) {
         return usb_rx_count > 0;
     }
     // Buffer has enough room
@@ -276,11 +269,6 @@ int usb_read(void) {
       usb_rx_buf_head = 0;
     }
     CRITICAL_SECTION_LEAVE();
-
-    // Trigger a new read because we just cleared some space.
-    /*if (!pending_read && usb_rx_count == USB_RX_BUF_SIZE - 1) {
-        start_read();
-    }*/
 
     return data;
 }
@@ -328,12 +316,10 @@ bool usb_connected(void) {
 
 // Poll for input if keyboard interrupts are enabled,
 // so that we can check for the interrupt char. read_complete() does the checking.
+// also make sure we have enough room in the local buffer
 void usb_cdc_background() {
     //
-    if (mp_interrupt_char != -1 && cdc_enabled() && !pending_read) {
-        // Make sure we have space in the buffer
-        if (usb_rx_count < 64) {
-            start_read();
-        }        
+    if (mp_interrupt_char != -1 && cdc_enabled() && !pending_read && usb_rx_count < CDC_BULKOUT_SIZE) {
+        start_read();
     }
 }

--- a/ports/atmel-samd/usb.c
+++ b/ports/atmel-samd/usb.c
@@ -331,6 +331,9 @@ bool usb_connected(void) {
 void usb_cdc_background() {
     //
     if (mp_interrupt_char != -1 && cdc_enabled() && !pending_read) {
-        start_read();
+        // Make sure we have space in the buffer
+        if (usb_rx_count < 64) {
+            start_read();
+        }        
     }
 }


### PR DESCRIPTION
See Issue #417.

After all that digging through the USB read functions and ASF4, turns out we were just reading to often, before clearing the local USB buffer. `usb_bytes_available` now checks if the local USB buffer 1) has data per `usb_rx_count`, and 2) if we have space for a new USB read (64 bytes max).

I also commented out the recurring calls to `start_read` in both `usb_read` and `read_complete`. I don't think we need them, since `usb_bytes_available` and `usb_cdc_background` will always call it. Makes it easier to debug in the future, and keeps from having too many hands in the cookie jar. If anyone has objections, easy enough to uncomment. Likewise, if we want to delete them...just as easy.