### PR TITLE
Don't lose half of the processor's serial number

### DIFF
--- a/ports/atmel-samd/common-hal/microcontroller/Processor.c
+++ b/ports/atmel-samd/common-hal/microcontroller/Processor.c
@@ -243,7 +243,7 @@ void common_hal_mcu_processor_get_uid(uint8_t raw_id[]) {
 
     for (int i=0; i<4; i++) {
         for (int k=0; k<4; k++) {
-            raw_id[4 * i + k] = (*(id_addresses[i]) >> k * 8) & 0xf;
+            raw_id[4 * i + k] = (*(id_addresses[i]) >> k * 8) & 0xff;
         }
     }
 }

--- a/ports/nrf/common-hal/microcontroller/Processor.c
+++ b/ports/nrf/common-hal/microcontroller/Processor.c
@@ -76,7 +76,7 @@ void common_hal_mcu_processor_get_uid(uint8_t raw_id[]) {
 
     for (int i=0; i<2; i++) {
         for (int k=0; k<4; k++) {
-            raw_id[4 * i + k] = (*(id_addresses[i]) >> k * 8) & 0xf;
+            raw_id[4 * i + k] = (*(id_addresses[i]) >> k * 8) & 0xff;
         }
     }
 }


### PR DESCRIPTION
Before this change, `microcontroller.cpu.uid` returned values
where the top 4 bits of each byte were zero, because of
an incorrect bitmask used in this function.

Testing performed: Looked at the value on my Trinket M0
~~~~
>>> ''.join('%02X' % c for c in microcontroller.cpu.uid
'1B45FF004E4E4D5120202031251011FF'
~~~~

Before the fix, the value was shown as `0B050F000E0E0D01000000010500010F`, because 4 out of every 8 bits were lost.