### PR TITLE
Make test core_class_superproperty.py succeed

### DIFF
--- a/py/gc_long_lived.c
+++ b/py/gc_long_lived.c
@@ -78,9 +78,9 @@ mp_obj_property_t *make_property_long_lived(mp_obj_property_t *prop, uint8_t max
     if (max_depth == 0) {
         return prop;
     }
-    prop->proxy[0] = make_fun_bc_long_lived((mp_obj_fun_bc_t*) prop->proxy[0], max_depth - 1);
-    prop->proxy[1] = make_fun_bc_long_lived((mp_obj_fun_bc_t*) prop->proxy[1], max_depth - 1);
-    prop->proxy[2] = make_fun_bc_long_lived((mp_obj_fun_bc_t*) prop->proxy[2], max_depth - 1);
+    prop->proxy[0] = make_obj_long_lived((mp_obj_fun_bc_t*) prop->proxy[0], max_depth - 1);
+    prop->proxy[1] = make_obj_long_lived((mp_obj_fun_bc_t*) prop->proxy[1], max_depth - 1);
+    prop->proxy[2] = make_obj_long_lived((mp_obj_fun_bc_t*) prop->proxy[2], max_depth - 1);
     return gc_make_long_lived(prop);
 }
 

--- a/tests/basics/core_class_superproperty.py
+++ b/tests/basics/core_class_superproperty.py
@@ -1,8 +1,5 @@
 """
-categories: Core,Classes
-description: Calling super() getter property in subclass will return a property object, not the value
-cause: Unknown
-workaround: Unknown
+test that calling super() getter property in subclass will return the value
 """
 class A:
     @property


### PR DESCRIPTION
This was a failing test for several reasons.  One of the reasons was the #705 crash, another was lack of handling of properties and descriptors by `super()` objects.  Fix both problems and put `core_class_superproperty.py` into the set of tests that get run.