### PR TITLE
Add ability to get, set filesystem label from CircuitPython

### DIFF
--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -33,6 +33,7 @@
 #endif
 
 #include <string.h>
+#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "py/mperrno.h"
 #include "lib/oofatfs/ff.h"
@@ -317,6 +318,36 @@ STATIC mp_obj_t vfs_fat_umount(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(fat_vfs_umount_obj, vfs_fat_umount);
 
+#if MICROPY_FATFS_USE_LABEL
+STATIC mp_obj_t vfs_fat_getlabel(mp_obj_t self_in) {
+    fs_user_mount_t *self = MP_OBJ_TO_PTR(self_in);
+    char working_buf[12];
+    FRESULT res = f_getlabel(&self->fatfs, working_buf, NULL);
+    if (res != FR_OK) {
+        mp_raise_OSError(fresult_to_errno_table[res]);
+    }
+    return mp_obj_new_str(working_buf, strlen(working_buf), false);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(fat_vfs_getlabel_obj, vfs_fat_getlabel);
+
+static mp_obj_t vfs_fat_setlabel(mp_obj_t self_in, mp_obj_t label_in) {
+    fs_user_mount_t *self = MP_OBJ_TO_PTR(self_in);
+    const char *label_str = mp_obj_str_get_str(label_in);
+    FRESULT res = f_setlabel(&self->fatfs, label_str);
+    if (res != FR_OK) {
+        mp_raise_OSError(fresult_to_errno_table[res]);
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_setlabel_obj, vfs_fat_setlabel);
+STATIC const mp_obj_property_t fat_vfs_label_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&fat_vfs_getlabel_obj,
+              (mp_obj_t)&fat_vfs_setlabel_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
+#endif
+
 STATIC const mp_rom_map_elem_t fat_vfs_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_mkfs), MP_ROM_PTR(&fat_vfs_mkfs_obj) },
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&fat_vfs_open_obj) },
@@ -331,6 +362,9 @@ STATIC const mp_rom_map_elem_t fat_vfs_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_statvfs), MP_ROM_PTR(&fat_vfs_statvfs_obj) },
     { MP_ROM_QSTR(MP_QSTR_mount), MP_ROM_PTR(&vfs_fat_mount_obj) },
     { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&fat_vfs_umount_obj) },
+#if MICROPY_FATFS_USE_LABEL
+    { MP_ROM_QSTR(MP_QSTR_label), MP_ROM_PTR(&fat_vfs_label_obj) },
+#endif
 };
 STATIC MP_DEFINE_CONST_DICT(fat_vfs_locals_dict, fat_vfs_locals_dict_table);
 

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -335,6 +335,9 @@ static mp_obj_t vfs_fat_setlabel(mp_obj_t self_in, mp_obj_t label_in) {
     const char *label_str = mp_obj_str_get_str(label_in);
     FRESULT res = f_setlabel(&self->fatfs, label_str);
     if (res != FR_OK) {
+        if(res == FR_WRITE_PROTECTED) {
+            mp_raise_msg(&mp_type_OSError, "Read-only filesystem");
+        }
         mp_raise_OSError(fresult_to_errno_table[res]);
     }
     return mp_const_none;

--- a/ports/unix/mpconfigport_coverage.h
+++ b/ports/unix/mpconfigport_coverage.h
@@ -43,4 +43,5 @@
 #define MICROPY_PY_IO_BUFFEREDWRITER (1)
 #undef MICROPY_VFS_FAT
 #define MICROPY_VFS_FAT                (1)
+#define MICROPY_FATFS_USE_LABEL        (1)
 #define MICROPY_PY_FRAMEBUF            (1)

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -145,6 +145,49 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
     //|
     //|   :param block_device: Block device the the filesystem lives on
     //|
+    //|   .. attribute:: label
+    //|
+    //|     The filesystem label, up to 11 case-insensitive bytes.  Note that
+    //|     this property can only be set when the device is writable by the
+    //|     microcontroller.
+    //|
+    //|   .. method:: mkfs
+    //|
+    //|     Format the block device, deleting any data that may have been there
+    //|
+    //|   .. method:: open(path, mode)
+    //|
+    //|     Like builtin ``open()``
+    //|
+    //|   .. method:: ilistdir([path])
+    //|
+    //|     Return an iterator whose values describe files and folders within
+    //|     ``path``
+    //|
+    //|   .. method:: mkdir(path)
+    //|
+    //|     Like `os.mkdir`
+    //|
+    //|   .. method:: rmdir(path)
+    //|
+    //|     Like `os.rmdir`
+    //|
+    //|   .. method:: stat(path)
+    //|
+    //|     Like `os.stat`
+    //|
+    //|   .. method:: statvfs(path)
+    //|
+    //|     Like `os.statvfs`
+    //|
+    //|   .. method:: mount(readonly, mkfs)
+    //|
+    //|     Don't call this directly, call `storage.mount`.
+    //|
+    //|   .. method:: umount
+    //|
+    //|     Don't call this directly, call `storage.umount`.
+    //|
     { MP_ROM_QSTR(MP_QSTR_VfsFat), MP_ROM_PTR(&mp_fat_vfs_type) },
 };
 

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -122,12 +122,22 @@ mp_obj_t storage_remount(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(storage_remount_obj, 1, storage_remount);
 
+//| .. function:: getmount(mount_path)
+//|
+//|   Retrieves the mount object associated with the mount path
+//|
+mp_obj_t storage_getmount(const mp_obj_t mnt_in) {
+    return common_hal_storage_getmount(mp_obj_str_get_str(mnt_in));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(storage_getmount_obj, storage_getmount);
+
 STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_storage) },
 
     { MP_ROM_QSTR(MP_QSTR_mount), MP_ROM_PTR(&storage_mount_obj) },
     { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&storage_umount_obj) },
     { MP_ROM_QSTR(MP_QSTR_remount), MP_ROM_PTR(&storage_remount_obj) },
+    { MP_ROM_QSTR(MP_QSTR_getmount), MP_ROM_PTR(&storage_getmount_obj) },
 
     //| .. class:: VfsFat(block_device)
     //|

--- a/shared-bindings/storage/__init__.h
+++ b/shared-bindings/storage/__init__.h
@@ -34,5 +34,6 @@ void common_hal_storage_mount(mp_obj_t vfs_obj, const char* path, bool readonly)
 void common_hal_storage_umount_path(const char* path);
 void common_hal_storage_umount_object(mp_obj_t vfs_obj);
 void common_hal_storage_remount(const char* path, bool readonly);
+mp_obj_t common_hal_storage_getmount(const char* path);
 
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_STORAGE___INIT___H

--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -109,19 +109,15 @@ void common_hal_storage_umount_object(mp_obj_t vfs_obj) {
     mp_vfs_proxy_call(vfs, MP_QSTR_umount, 0, NULL);
 }
 
-void common_hal_storage_umount_path(const char* mount_path) {
-    // remove vfs from the mount table
-    mp_obj_t *vfs_obj = NULL;
+STATIC mp_obj_t storage_object_from_path(const char* mount_path) {
     for (mp_vfs_mount_t **vfsp = &MP_STATE_VM(vfs_mount_table); *vfsp != NULL; vfsp = &(*vfsp)->next) {
         if (strcmp(mount_path, (*vfsp)->str) == 0) {
-            vfs_obj = (*vfsp)->obj;
-            break;
+            return (*vfsp)->obj;
         }
     }
+    mp_raise_OSError(MP_EINVAL);
+}
 
-    if (vfs_obj == NULL) {
-        mp_raise_OSError(MP_EINVAL);
-    }
-
-    common_hal_storage_umount_object(vfs_obj);
+void common_hal_storage_umount_path(const char* mount_path) {
+    common_hal_storage_umount_object(storage_object_from_path(mount_path));
 }

--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -121,3 +121,7 @@ STATIC mp_obj_t storage_object_from_path(const char* mount_path) {
 void common_hal_storage_umount_path(const char* mount_path) {
     common_hal_storage_umount_object(storage_object_from_path(mount_path));
 }
+
+mp_obj_t common_hal_storage_getmount(const char *mount_path) {
+    return storage_object_from_path(mount_path);
+}

--- a/tests/extmod/vfs_fat_ramdisk.py
+++ b/tests/extmod/vfs_fat_ramdisk.py
@@ -54,6 +54,8 @@ print(b"hello!" not in bdev.data)
 vfs = uos.VfsFat(bdev)
 uos.mount(vfs, "/ramdisk")
 
+vfs.label = 'label test'
+print("label:", vfs.label)
 print("statvfs:", vfs.statvfs("/ramdisk"))
 print("getcwd:", vfs.getcwd())
 

--- a/tests/extmod/vfs_fat_ramdisk.py.exp
+++ b/tests/extmod/vfs_fat_ramdisk.py.exp
@@ -1,5 +1,6 @@
 True
 True
+label: LABEL TEST
 statvfs: (512, 512, 16, 16, 16, 0, 0, 0, 0, 255)
 getcwd: /
 True


### PR DESCRIPTION
In #530 we discussed the idea of setting the device's label to something other than CIRCUITPYTHON (for instance, named after the board type or incorporating part of the board's unique serial number).  This PR adds the ability to get and set the filesystem label with a sequence like `storage.getmount("/").label`

However, it's not particularly satisfactory as in normal usage you can't setlabel the main storage from main.py, since it is mounted to the PC and is readonly to CircuitPython during normal operation.  Doing it from boot.py seems about 1000% fiddlier than doing it via your favorite desktop envirionment's GUI or commandline.