### PR TITLE
Allow building on gcc 5.4, while preserving ability to build with 7.2

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -72,7 +72,6 @@ BASE_CFLAGS = \
 	-Wnested-externs \
 	-Wunreachable-code \
 	-Wcast-align \
-	-Wno-error=lto-type-mismatch \
 	-D__$(CHIP_VARIANT)__ \
 	-ffunction-sections \
 	-fdata-sections \


### PR DESCRIPTION
This change adds the `-Wno-error=lto-type-mismatch` only when supported by the underlying gcc (7.2 supports and needs it, 5.4 doesn't support or need it).

It also removes one `-Wno-error=lto-type-mismatch` that is unnecessary since #686 was merged.