### PR TITLE
mp_map_lookup: Throw exception in this case

### DIFF
--- a/py/map.c
+++ b/py/map.c
@@ -137,7 +137,10 @@ STATIC void mp_map_rehash(mp_map_t *map) {
 //  - returns NULL if not found, else the slot if was found in with key null and value non-null
 mp_map_elem_t *mp_map_lookup(mp_map_t *map, mp_obj_t index, mp_map_lookup_kind_t lookup_kind) {
     // If the map is a fixed array then we must only be called for a lookup
-    assert(!map->is_fixed || lookup_kind == MP_MAP_LOOKUP);
+    if (MP_UNLIKELY(map->is_fixed && lookup_kind == MP_MAP_LOOKUP)) {
+        mp_raise_TypeError("unsupported operation on fixed map");
+    }
+
 
     // Work out if we can compare just pointers
     bool compare_only_ptrs = map->all_keys_are_qstrs;


### PR DESCRIPTION
This assertion could be triggered by a number of patterns found by afl-fuzz, such as `del str.partition`, `property.start = 0`, etc.