### PR TITLE
Add a type check to the gamepad module

### DIFF
--- a/shared-bindings/gamepad/GamePad.c
+++ b/shared-bindings/gamepad/GamePad.c
@@ -27,6 +27,7 @@
 #include "py/runtime.h"
 #include "py/mphal.h"
 #include "shared-module/gamepad/GamePad.h"
+#include "shared-bindings/digitalio/DigitalInOut.h"
 #include "GamePad.h"
 
 
@@ -95,6 +96,12 @@ STATIC mp_obj_t gamepad_make_new(const mp_obj_type_t *type, size_t n_args,
     if (!gamepad_singleton) {
         gamepad_singleton = m_new_obj(gamepad_obj_t);
         gamepad_singleton->base.type = &gamepad_type;
+    }
+    for (size_t i = 0; i < n_args; ++i) {
+        if (!MP_OBJ_IS_TYPE(args[i], &digitalio_digitalinout_type)) {
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+                "Expected a %q", digitalio_digitalinout_type.name));
+        }
     }
     gamepad_init(n_args, args);
     return MP_OBJ_FROM_PTR(gamepad_singleton);


### PR DESCRIPTION
Make sure that all the arguments passed are indeed DigitalInOut.
This avoids crashes when the users pass something else.