### PR TITLE
Respect pin's pull in gamepad

### DIFF
--- a/shared-module/gamepad/GamePad.c
+++ b/shared-module/gamepad/GamePad.c
@@ -31,6 +31,7 @@
 
 #include "shared-bindings/digitalio/Pull.h"
 #include "shared-bindings/digitalio/DigitalInOut.h"
+#include "shared-bindings/util.h"
 
 
 void gamepad_init(size_t n_pins, const mp_obj_t* pins) {
@@ -39,8 +40,13 @@ void gamepad_init(size_t n_pins, const mp_obj_t* pins) {
     }
     for (size_t i=0; i<n_pins; ++i) {
         digitalio_digitalinout_obj_t *pin = MP_OBJ_TO_PTR(pins[i]);
+        raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(pin));
+        digitalio_direction_t direction = common_hal_digitalio_digitalinout_get_direction(pin);
+        digitalio_pull_t pull = common_hal_digitalio_digitalinout_get_pull(pin);
+        if (direction != DIRECTION_INPUT || pull == PULL_NONE) {
+            common_hal_digitalio_digitalinout_switch_to_input(pin, PULL_UP);
+        }
         gamepad_singleton->pins[i] = pin;
-        common_hal_digitalio_digitalinout_switch_to_input(pin, PULL_UP);
     }
     gamepad_singleton->last = 0;
 }

--- a/shared-module/gamepad/__init__.c
+++ b/shared-module/gamepad/__init__.c
@@ -42,8 +42,10 @@ void gamepad_tick(void) {
         if (!pin) {
             break;
         }
-        if (!common_hal_digitalio_digitalinout_get_value(pin)) {
-            gamepad_current |= 1<<i;
+        digitalio_pull_t pull = common_hal_digitalio_digitalinout_get_pull(pin);
+        bool value = common_hal_digitalio_digitalinout_get_value(pin);
+        if ((pull == PULL_UP && !value) || (pull == PULL_DOWN && value)) {
+            gamepad_current |= 1 << i;
         }
     }
     gamepad_singleton->pressed |= gamepad_singleton->last & gamepad_current;


### PR DESCRIPTION
While it is traditional to have buttons on pins that are pulled up, and
have the button connect them to the ground, some CircuitPython boards
(notably the CPX) have the button pins pulled low and the button
connects them to VCC.

This patch makes the gamepad only change the pin's pull if it wasn't
already set when passed to the constructor, and also makes it consider
a button pressed when its value is the opposite of its pull.