### PR TITLE
atmel-samd: Fix rebooting to bootloader

### DIFF
--- a/ports/atmel-samd/boards/samd21x18-bootloader-crystalless.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader-crystalless.ld
@@ -13,7 +13,7 @@ MEMORY
 /* top end of the stack */
 /* stack must be double-word (8 byte) aligned */
 _estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
-_bootloader_dbl_tap = _estack;
+_bootloader_dbl_tap = ORIGIN(RAM) + LENGTH(RAM) - 4;
 
 /* define output sections */
 SECTIONS

--- a/ports/atmel-samd/boards/samd21x18-bootloader-external-flash-crystalless.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader-external-flash-crystalless.ld
@@ -13,7 +13,7 @@ MEMORY
 /* top end of the stack */
 /* stack must be double-word (8 byte) aligned */
 _estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
-_bootloader_dbl_tap = _estack;
+_bootloader_dbl_tap = ORIGIN(RAM) + LENGTH(RAM) - 4;
 
 /* define output sections */
 SECTIONS

--- a/ports/atmel-samd/boards/samd21x18-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader-external-flash.ld
@@ -13,7 +13,7 @@ MEMORY
 /* top end of the stack */
 /* stack must be double-word (8 byte) aligned */
 _estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
-_bootloader_dbl_tap = _estack;
+_bootloader_dbl_tap = ORIGIN(RAM) + LENGTH(RAM) - 4;
 
 /* define output sections */
 SECTIONS

--- a/ports/atmel-samd/boards/samd21x18-bootloader.ld
+++ b/ports/atmel-samd/boards/samd21x18-bootloader.ld
@@ -13,7 +13,7 @@ MEMORY
 /* top end of the stack */
 /* stack must be double-word (8 byte) aligned */
 _estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
-_bootloader_dbl_tap = _estack;
+_bootloader_dbl_tap = ORIGIN(RAM) + LENGTH(RAM) - 4;
 
 /* define output sections */
 SECTIONS

--- a/ports/atmel-samd/boards/samd51x18-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd51x18-bootloader-external-flash.ld
@@ -13,7 +13,7 @@ MEMORY
 /* top end of the stack */
 /* stack must be double-word (8 byte) aligned */
 _estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
-_bootloader_dbl_tap = _estack;
+_bootloader_dbl_tap = ORIGIN(RAM) + LENGTH(RAM) - 4;
 
 /* define output sections */
 SECTIONS

--- a/ports/atmel-samd/boards/samd51x19-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd51x19-bootloader-external-flash.ld
@@ -13,7 +13,7 @@ MEMORY
 /* top end of the stack */
 /* stack must be double-word (8 byte) aligned */
 _estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
-_bootloader_dbl_tap = _estack;
+_bootloader_dbl_tap = ORIGIN(RAM) + LENGTH(RAM) - 4;
 
 /* define output sections */
 SECTIONS

--- a/ports/atmel-samd/boards/samd51x19-bootloader.ld
+++ b/ports/atmel-samd/boards/samd51x19-bootloader.ld
@@ -13,7 +13,7 @@ MEMORY
 /* top end of the stack */
 /* stack must be double-word (8 byte) aligned */
 _estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
-_bootloader_dbl_tap = _estack;
+_bootloader_dbl_tap = ORIGIN(RAM) + LENGTH(RAM) - 4;
 
 /* define output sections */
 SECTIONS

--- a/ports/atmel-samd/boards/samd51x20-bootloader-external-flash.ld
+++ b/ports/atmel-samd/boards/samd51x20-bootloader-external-flash.ld
@@ -13,7 +13,7 @@ MEMORY
 /* top end of the stack */
 /* stack must be double-word (8 byte) aligned */
 _estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
-_bootloader_dbl_tap = _estack;
+_bootloader_dbl_tap = ORIGIN(RAM) + LENGTH(RAM) - 4;
 
 /* define output sections */
 SECTIONS

--- a/ports/atmel-samd/boards/samd51x20-bootloader.ld
+++ b/ports/atmel-samd/boards/samd51x20-bootloader.ld
@@ -13,7 +13,7 @@ MEMORY
 /* top end of the stack */
 /* stack must be double-word (8 byte) aligned */
 _estack = ORIGIN(RAM) + LENGTH(RAM) - 8;
-_bootloader_dbl_tap = _estack;
+_bootloader_dbl_tap = ORIGIN(RAM) + LENGTH(RAM) - 4;
 
 /* define output sections */
 SECTIONS


### PR DESCRIPTION
Commit efbf08266b6 moved _estack in order to ensure 8-byte alignment
of the stack, but the address of _bootloader_dbl_tap must remain
right at the end of SRAM.

I verified by reading the source that the 4-byte-aligned address is
used for all samd21 / samd51 boards in
adafruit/circuitpython@efbf08266b.  However, I only tested on
trinket_m0.

Closes: #739