### PR TITLE
Samd reset modes

### DIFF
--- a/ports/atmel-samd/common-hal/microcontroller/__init__.c
+++ b/ports/atmel-samd/common-hal/microcontroller/__init__.c
@@ -55,7 +55,7 @@ extern uint32_t _ezero;
 
 void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
     // Set up the defaults.
-    _bootloader_dbl_tap = DBL_TAP_MAGIC;
+    _bootloader_dbl_tap = DBL_TAP_MAGIC_QUICK_BOOT;
     _ezero = CIRCUITPY_CANARY_WORD;
 
     if (runmode == RUNMODE_BOOTLOADER) {

--- a/ports/atmel-samd/reset.h
+++ b/ports/atmel-samd/reset.h
@@ -31,6 +31,7 @@
 
 // Copied from inc/uf2.h in https://github.com/Microsoft/uf2-samd21
 #define DBL_TAP_MAGIC 0xf01669ef // Randomly selected, adjusted to have first and last bit set
+#define DBL_TAP_MAGIC_QUICK_BOOT 0xf02669ef
 
 extern uint32_t _bootloader_dbl_tap;
 

--- a/shared-bindings/microcontroller/RunMode.c
+++ b/shared-bindings/microcontroller/RunMode.c
@@ -76,7 +76,7 @@ STATIC void mcu_runmode_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
         runmode = MP_QSTR_SAFE_MODE;
     } else if (MP_OBJ_TO_PTR(self_in) ==
                MP_ROM_PTR(&mcu_runmode_bootloader_obj)) {
-        runmode = MP_QSTR_SAFE_MODE;
+        runmode = MP_QSTR_BOOTLOADER;
     }
     mp_printf(print, "%q.%q.%q", MP_QSTR_microcontroller, MP_QSTR_RunMode,
               runmode);


### PR DESCRIPTION
This fixes a couple of problems with reset modes that I encountered:
 * The 'BOOTLOADER' mode's repr said 'SAFE_MODE'
 * All reset modes were acting like 'BOOTLOADER'