### PR TITLE
Adapt to incompatible changes in the ESP8266 SDK

### DIFF
--- a/ports/esp8266/esp8266_common.ld
+++ b/ports/esp8266/esp8266_common.ld
@@ -73,6 +73,17 @@ SECTIONS
         _irom0_text_start = ABSOLUTE(.);
         *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text)
 
+        /* Vendor SDK in v2.1.0-7-gb8fd588 started to build these with
+           -ffunction-sections -fdata-sections, and require routing to
+           irom via linker:
+           https://github.com/espressif/ESP8266_NONOS_SDK/commit/b8fd588a33f0319dc135523b51655e97b483b205
+         */
+
+        *libcrypto.a:(.literal.* .text.*)
+        *libnet80211.a:(.literal.* .text.*)
+        *libwpa.a:(.literal.* .text.*)
+        *libwpa2.a:(.literal.* .text.*)
+
         /* we put some specific text in this section */
 
         *common-hal/*.o*(.literal* .text*)

--- a/ports/esp8266/etshal.h
+++ b/ports/esp8266/etshal.h
@@ -6,14 +6,12 @@
 // see http://esp8266-re.foogod.com/wiki/Random_Number_Generator
 #define WDEV_HWRNG ((volatile uint32_t*)0x3ff20e44)
 
-void ets_delay_us();
 void ets_intr_lock(void);
 void ets_intr_unlock(void);
 void ets_isr_mask(uint32_t mask);
 void ets_isr_unmask(uint32_t mask);
 void ets_isr_attach(int irq_no, void (*handler)(void *), void *arg);
 void ets_install_putc1();
-void uart_div_modify();
 void ets_set_idle_cb(void (*handler)(void *), void *arg);
 
 void ets_timer_arm_new(os_timer_t *tim, uint32_t millis, bool repeat, bool is_milli_timer);
@@ -31,12 +29,6 @@ typedef char MD5_CTX[88];
 void MD5Init(MD5_CTX *context);
 void MD5Update(MD5_CTX *context, const void *data, unsigned int len);
 void MD5Final(unsigned char digest[16], MD5_CTX *context);
-
-// These prototypes are for recent SDKs with "malloc tracking"
-void *pvPortMalloc(unsigned sz, const char *fname, int line);
-void *pvPortZalloc(unsigned sz, const char *fname, int line);
-void *pvPortRealloc(void *p, unsigned sz, const char *fname, int line);
-void vPortFree(void *p, const char *fname, int line);
 
 uint32_t SPIRead(uint32_t offset, void *buf, uint32_t len);
 uint32_t SPIWrite(uint32_t offset, const void *buf, uint32_t len);


### PR DESCRIPTION
One commit is from micropython/micropython#1254, see that issue for more background info.

With these changes, I am able to build and run on a fresh SDK from today.