### PR TITLE
nrf52: Use -flto

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -81,11 +81,11 @@ CFLAGS += -fstack-usage
 CFLAGS += -fdata-sections -ffunction-sections
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'
+CFLAGS += -flto -Wno-error=lto-type-mismatch
 
 LDFLAGS = $(CFLAGS)
 LDFLAGS += -Xlinker -Map=$(@:.elf=.map)
 LDFLAGS += -mthumb -mabi=aapcs -T $(LD_FILE) -L boards/
-LDFLAGS += -Wl,--gc-sections
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)


### PR DESCRIPTION
This gets an improvement in binary size, but it is modest (just shy of 6kB)

Before the change, on travis:

   text    data     bss     dec     hex filename
 189048    1184   36972  227204   37784 build-feather52-s132/firmware.elf

After:

   text    data     bss     dec     hex filename
 183068    1120   36876  221064   35f88 build-feather52-s132/firmware.elf

Note: I haven't actually tested the resulting firmware yet, and what I build locally is coming from a different (older) arm-non-eabi toolchain.