### PR TITLE
RTC Fix: Revert To Using Internal Oscillator

### DIFF
--- a/ports/atmel-samd/asf4_conf/samd21/hpl_gclk_config.h
+++ b/ports/atmel-samd/asf4_conf/samd21/hpl_gclk_config.h
@@ -259,7 +259,7 @@
 // <i> This defines the clock source for generic clock generator 2
 // <id> gclk_gen_2_oscillator
 #ifndef CONF_GCLK_GEN_2_SRC
-#define CONF_GCLK_GEN_2_SRC GCLK_GENCTRL_SRC_XOSC32K
+#define CONF_GCLK_GEN_2_SRC GCLK_GENCTRL_SRC_OSC32K
 #endif
 // </h>
 

--- a/ports/atmel-samd/asf4_conf/samd21/hpl_sysctrl_config.h
+++ b/ports/atmel-samd/asf4_conf/samd21/hpl_sysctrl_config.h
@@ -197,7 +197,7 @@
 // <i> Indicates whether configuration for External 32K Osc is enabled or not
 // <id> enable_xosc32k
 #ifndef CONF_XOSC32K_CONFIG
-#define CONF_XOSC32K_CONFIG 1
+#define CONF_XOSC32K_CONFIG 0
 #endif
 
 // <h> 32kHz External Crystal Oscillator (XOSC32K) Control
@@ -205,7 +205,7 @@
 // <i> Indicates whether External 32K Oscillator is enabled or not
 // <id> xosc32k_arch_enable
 #ifndef CONF_XOSC32K_ENABLE
-#define CONF_XOSC32K_ENABLE 1
+#define CONF_XOSC32K_ENABLE 0
 #endif
 
 // <q> On Demand
@@ -223,7 +223,7 @@
 // <i> If this bit is 1: The oscillator is not stopped in standby sleep mode.
 // <id> xosc32k_arch_runstdby
 #ifndef CONF_XOSC32K_RUNSTDBY
-#define CONF_XOSC32K_RUNSTDBY 1
+#define CONF_XOSC32K_RUNSTDBY 0
 #endif
 
 // <q> Enable 1K
@@ -237,14 +237,14 @@
 // <i> Enable 32 Khz Output
 // <id> xosc32k_arch_en32k
 #ifndef CONF_XOSC32K_EN32K
-#define CONF_XOSC32K_EN32K 1
+#define CONF_XOSC32K_EN32K 0
 #endif
 
 // <q> Enable XTAL
 // <i> Enable XTAL
 // <id> xosc32k_arch_xtalen
 #ifndef CONF_XOSC32K_XTALEN
-#define CONF_XOSC32K_XTALEN 1
+#define CONF_XOSC32K_XTALEN 0
 #endif
 
 // <q> Write Lock

--- a/ports/atmel-samd/asf4_conf/samd51/hpl_gclk_config.h
+++ b/ports/atmel-samd/asf4_conf/samd51/hpl_gclk_config.h
@@ -188,7 +188,7 @@
 // <i> This defines the clock source for generic clock generator 2
 // <id> gclk_gen_2_oscillator
 #ifndef CONF_GCLK_GEN_2_SOURCE
-#define CONF_GCLK_GEN_2_SOURCE GCLK_GENCTRL_SRC_XOSC32K
+#define CONF_GCLK_GEN_2_SOURCE GCLK_GENCTRL_SRC_OSCULP32K
 #endif
 
 // <q> Run in Standby

--- a/ports/atmel-samd/asf4_conf/samd51/hpl_osc32kctrl_config.h
+++ b/ports/atmel-samd/asf4_conf/samd51/hpl_osc32kctrl_config.h
@@ -23,7 +23,7 @@
 // <q> Use 1 kHz output
 // <id> rtc_1khz_selection
 #ifndef CONF_RTCCTRL_1KHZ
-#define CONF_RTCCTRL_1KHZ 0
+#define CONF_RTCCTRL_1KHZ 1
 #endif
 
 #if CONF_RTCCTRL_SRC == GCLK_GENCTRL_SRC_OSCULP32K
@@ -62,7 +62,7 @@
 // <0x6=>8000092us
 // <id> xosc32k_arch_startup
 #ifndef CONF_XOSC32K_STARTUP
-#define CONF_XOSC32K_STARTUP 0x4
+#define CONF_XOSC32K_STARTUP 0x0
 #endif
 
 // <q> On Demand Control
@@ -76,7 +76,7 @@
 // <i> Indicates whether Run in Standby is enabled or not
 // <id> xosc32k_arch_runstdby
 #ifndef CONF_XOSC32K_RUNSTDBY
-#define CONF_XOSC32K_RUNSTDBY 1
+#define CONF_XOSC32K_RUNSTDBY 0
 #endif
 
 // <q> 1kHz Output Enable
@@ -90,7 +90,7 @@
 // <i> Indicates whether 32kHz Output is enabled or not
 // <id> xosc32k_arch_en32k
 #ifndef CONF_XOSC32K_EN32K
-#define CONF_XOSC32K_EN32K 1
+#define CONF_XOSC32K_EN32K 0
 #endif
 
 // <q> Clock Switch Back
@@ -118,7 +118,7 @@
 // <i> Indicates whether the connections between the I/O pads and the external clock or crystal oscillator is enabled or not
 // <id> xosc32k_arch_xtalen
 #ifndef CONF_XOSC32K_XTALEN
-#define CONF_XOSC32K_XTALEN 1
+#define CONF_XOSC32K_XTALEN 0
 #endif
 
 // <o> Control Gain Mode
@@ -137,7 +137,7 @@
 // <i> Indicates whether configuration for OSCULP32K is enabled or not
 // <id> enable_osculp32k
 #ifndef CONF_OSCULP32K_CONFIG
-#define CONF_OSCULP32K_CONFIG 0
+#define CONF_OSCULP32K_CONFIG 1
 #endif
 
 // <h> 32kHz Ultra Low Power Internal Oscillator Control


### PR DESCRIPTION
This reverts `asf4_config`s to use the internal 32Khz oscillator for the RTC clock. Use of external oscillator was causing crystalless boards (Trinket, Gemma, µGame, etc) to not boot properly. See Issue #767.

Tested this on both Trinket and Feather M0 Express (without external RTC source). Functions seem to still work properly, and the clock is human-accurate (well, for me thru 16 minutes). Reverted SAMD51 configs as well, but cannot test them yet.