### PR TITLE
atmel-samd: Fix a tick hang when we hit the exact timing we're going for

### DIFF
--- a/ports/atmel-samd/tick.c
+++ b/ports/atmel-samd/tick.c
@@ -66,6 +66,9 @@ void tick_delay(uint32_t us) {
         start_ms = ticks_ms;
         us_between_ticks = 1000;
     }
+    if (us_between_ticks == us) {
+        return;
+    }
     while (SysTick->VAL > ((us_between_ticks - us) * ticks_per_us)) {}
 }
 


### PR DESCRIPTION
The SysTick interrupt happens when the value is 0 so its never
readable when 0 and interrupts are enabled.