### PR TITLE
Remove Rev B Metro M4 from Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
   - TRAVIS_BOARD=itsybitsy_m4_express
   - TRAVIS_BOARD=metro_m0_express
   - TRAVIS_BOARD=metro_m4_express
-  - TRAVIS_BOARD=metro_m4_express_revb
   - TRAVIS_BOARD=pirkey_m0
   - TRAVIS_BOARD=trinket_m0
   - TRAVIS_BOARD=gemma_m0


### PR DESCRIPTION
Testers should have production boards on the way.