### PR TITLE
HID gamepad support

### DIFF
--- a/ports/atmel-samd/common-hal/usb_hid/__init__.c
+++ b/ports/atmel-samd/common-hal/usb_hid/__init__.c
@@ -35,12 +35,27 @@
 #include "genhdr/autogen_usb_descriptor.h"
 
 // Buffers are report size + 1 to include the Report ID prefix byte if needed.
+#ifdef USB_HID_REPORT_LENGTH_KEYBOARD
 static uint8_t keyboard_report_buffer[USB_HID_REPORT_LENGTH_KEYBOARD + 1];
+#endif
+#ifdef USB_HID_REPORT_ID_MOUSE
 static uint8_t mouse_report_buffer[USB_HID_REPORT_LENGTH_MOUSE + 1];
+#endif
+#ifdef USB_HID_REPORT_ID_CONSUMER
 static uint8_t consumer_report_buffer[USB_HID_REPORT_LENGTH_CONSUMER + 1];
+#endif
+#ifdef USB_HID_REPORT_ID_SYS_CONTROL
 static uint8_t sys_control_report_buffer[USB_HID_REPORT_LENGTH_SYS_CONTROL + 1];
+#endif
+#ifdef USB_HID_REPORT_ID_GAMEPAD
+static uint8_t gamepad_report_buffer[USB_HID_REPORT_LENGTH_GAMEPAD + 1];
+#endif
+#ifdef USB_HID_REPORT_ID_DIGITIZER
+static uint8_t digitizer_report_buffer[USB_HID_REPORT_LENGTH_DIGITIZER + 1];
+#endif
 
 usb_hid_device_obj_t usb_hid_devices[USB_HID_NUM_DEVICES] = {
+#ifdef USB_HID_REPORT_LENGTH_KEYBOARD
     {
         .base = { .type = &usb_hid_device_type },
         .report_buffer = keyboard_report_buffer,
@@ -50,6 +65,8 @@ usb_hid_device_obj_t usb_hid_devices[USB_HID_NUM_DEVICES] = {
         .usage_page = 0x01,
         .usage = 0x06,
     },
+#endif
+#ifdef USB_HID_REPORT_ID_MOUSE
     {
         .base = { .type = &usb_hid_device_type },
         .report_buffer = mouse_report_buffer,
@@ -59,6 +76,8 @@ usb_hid_device_obj_t usb_hid_devices[USB_HID_NUM_DEVICES] = {
         .usage_page = 0x01,
         .usage = 0x02,
     },
+#endif
+#ifdef USB_HID_REPORT_ID_CONSUMER
     {
         .base = { .type = &usb_hid_device_type },
         .report_buffer = consumer_report_buffer,
@@ -68,6 +87,8 @@ usb_hid_device_obj_t usb_hid_devices[USB_HID_NUM_DEVICES] = {
         .usage_page = 0x0C,
         .usage = 0x01,
     },
+#endif
+#ifdef USB_HID_REPORT_ID_SYS_CONTROL
     {
         .base = { .type = &usb_hid_device_type },
         .report_buffer = sys_control_report_buffer,
@@ -77,6 +98,29 @@ usb_hid_device_obj_t usb_hid_devices[USB_HID_NUM_DEVICES] = {
         .usage_page = 0x01,
         .usage = 0x80,
     },
+#endif
+#ifdef USB_HID_REPORT_ID_GAMEPAD
+    {
+        .base = { .type = &usb_hid_device_type },
+        .report_buffer = gamepad_report_buffer,
+        .endpoint = USB_HID_ENDPOINT_IN,
+        .report_id = USB_HID_REPORT_ID_GAMEPAD,
+        .report_length = USB_HID_REPORT_LENGTH_GAMEPAD,
+        .usage_page = 0x01,
+        .usage = 0x05,
+    },
+#endif
+#ifdef USB_HID_REPORT_ID_DIGITIZER
+    {
+        .base = { .type = &usb_hid_device_type },
+        .report_buffer = digitizer_report_buffer,
+        .endpoint = USB_HID_ENDPOINT_IN,
+        .report_id = USB_HID_REPORT_ID_DIGITIZER,
+        .report_length = USB_HID_REPORT_LENGTH_DIGITIZER,
+        .usage_page = 0x0D,
+        .usage = 0x02,
+    },
+#endif
 };
 
 
@@ -86,9 +130,23 @@ mp_obj_tuple_t common_hal_usb_hid_devices = {
     },
     .len = USB_HID_NUM_DEVICES,
     .items = {
+#if USB_HID_NUM_DEVICES >= 1
         (mp_obj_t) &usb_hid_devices[0],
+#endif
+#if USB_HID_NUM_DEVICES >= 2
         (mp_obj_t) &usb_hid_devices[1],
+#endif
+#if USB_HID_NUM_DEVICES >= 3
         (mp_obj_t) &usb_hid_devices[2],
+#endif
+#if USB_HID_NUM_DEVICES >= 4
         (mp_obj_t) &usb_hid_devices[3],
+#endif
+#if USB_HID_NUM_DEVICES >= 5
+        (mp_obj_t) &usb_hid_devices[4],
+#endif
+#if USB_HID_NUM_DEVICES >= 6
+        (mp_obj_t) &usb_hid_devices[5],
+#endif
     }
 };

--- a/ports/atmel-samd/tools/gen_usb_descriptor.py
+++ b/ports/atmel-samd/tools/gen_usb_descriptor.py
@@ -7,7 +7,7 @@ import sys
 sys.path.append("../../tools/usb_descriptor")
 
 from adafruit_usb_descriptor import cdc, hid, msc, standard, util
-from hid_report_descriptors import HIDReportDescriptors
+import hid_report_descriptors
 
 parser = argparse.ArgumentParser(description='Generate USB descriptors.')
 parser.add_argument('--manufacturer', type=str,
@@ -141,10 +141,10 @@ hid_devices = ("KEYBOARD", "MOUSE", "CONSUMER", "GAMEPAD")
 combined_hid_report_descriptor = hid.ReportDescriptor(
     description="MULTIDEVICE",
     report_descriptor=b''.join(
-        HIDReportDescriptors.REPORT_DESCRIPTORS[name].report_descriptor for name in hid_devices ))
+        hid_report_descriptors.REPORT_DESCRIPTORS[name].report_descriptor for name in hid_devices ))
 
-hid_report_ids_dict = { name: HIDReportDescriptors.REPORT_IDS[name] for name in hid_devices }
-hid_report_lengths_dict = { name: HIDReportDescriptors.REPORT_LENGTHS[name] for name in hid_devices }
+hid_report_ids_dict = { name: hid_report_descriptors.REPORT_IDS[name] for name in hid_devices }
+hid_report_lengths_dict = { name: hid_report_descriptors.REPORT_LENGTHS[name] for name in hid_devices }
 hid_max_report_length = max(hid_report_lengths_dict.values())
 
 # ASF4 expects keyboard and generic devices to have both in and out endpoints,

--- a/ports/atmel-samd/tools/hid_report_descriptors.py
+++ b/ports/atmel-samd/tools/hid_report_descriptors.py
@@ -1,0 +1,242 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Dan Halbert for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import struct
+
+"""
+HID specific descriptors
+========================
+
+* Author(s): Dan Halbert
+"""
+
+from adafruit_usb_descriptor import hid
+
+class HIDReportDescriptors:
+    pass
+
+HIDReportDescriptors.REPORT_IDS = {
+    "KEYBOARD" : 1,
+    "MOUSE" : 2,
+    "CONSUMER" : 3,
+    "SYS_CONTROL" : 4,
+    "GAMEPAD" : 5,
+    "DIGITIZER" : 6,
+    }
+
+# Byte count for each kind of report. Length does not include report ID in first byte.
+HIDReportDescriptors.REPORT_LENGTHS = {
+    "KEYBOARD" : 8,
+    "MOUSE" : 4,
+    "CONSUMER" : 2,
+    "SYS_CONTROL" : 1,
+    "GAMEPAD" : 6,
+    "DIGITIZER" : 5,
+    }
+
+HIDReportDescriptors.KEYBOARD_WITH_ID = hid.ReportDescriptor(
+    description="KEYBOARD",
+    report_descriptor=bytes([
+        # Regular keyboard
+        0x05, 0x01,                 # Usage Page (Generic Desktop)
+        0x09, 0x06,                 # Usage (Keyboard)
+        0xA1, 0x01,                 # Collection (Application)
+        0x85, HIDReportDescriptors.REPORT_IDS["KEYBOARD"], #   Report ID (1)
+        0x05, 0x07,                 #   Usage Page (Keyboard)
+        0x19, 224,                  #   Usage Minimum (224)
+        0x29, 231,                  #   Usage Maximum (231)
+        0x15, 0x00,                 #   Logical Minimum (0)
+        0x25, 0x01,                 #   Logical Maximum (1)
+        0x75, 0x01,                 #   Report Size (1)
+        0x95, 0x08,                 #   Report Count (8)
+        0x81, 0x02,                 #   Input (Data, Variable, Absolute)
+        0x81, 0x01,                 #   Input (Constant)
+        0x19, 0x00,                 #   Usage Minimum (0)
+        0x29, 101,                  #   Usage Maximum (101)
+        0x15, 0x00,                 #   Logical Minimum (0)
+        0x25, 101,                  #   Logical Maximum (101)
+        0x75, 0x08,                 #   Report Size (8)
+        0x95, 0x06,                 #   Report Count (6)
+        0x81, 0x00,                 #   Input (Data, Array)
+        0x05, 0x08,                 #   Usage Page (LED)
+        0x19, 0x01,                 #   Usage Minimum (1)
+        0x29, 0x05,                 #   Usage Maximum (5)
+        0x15, 0x00,                 #   Logical Minimum (0)
+        0x25, 0x01,                 #   Logical Maximum (1)
+        0x75, 0x01,                 #   Report Size (1)
+        0x95, 0x05,                 #   Report Count (5)
+        0x91, 0x02,                 #   Output (Data, Variable, Absolute)
+        0x95, 0x03,                 #   Report Count (3)
+        0x91, 0x01,                 #   Output (Constant)
+        0xC0,                       # End Collection
+    ]))
+
+HIDReportDescriptors.MOUSE_WITH_ID = hid.ReportDescriptor(
+    description="MOUSE",
+    report_descriptor=bytes([
+        # Regular mouse
+        0x05, 0x01,        # Usage Page (Generic Desktop)
+        0x09, 0x02,        # Usage (Mouse)
+        0xA1, 0x01,        # Collection (Application)
+        0x09, 0x01,        #   Usage (Pointer)
+        0xA1, 0x00,        #   Collection (Physical)
+        0x85, HIDReportDescriptors.REPORT_IDS["MOUSE"], # Report ID (n)
+        0x05, 0x09,        #     Usage Page (Button)
+        0x19, 0x01,        #     Usage Minimum (0x01)
+        0x29, 0x05,        #     Usage Maximum (0x05)
+        0x15, 0x00,        #     Logical Minimum (0)
+        0x25, 0x01,        #     Logical Maximum (1)
+        0x95, 0x05,        #     Report Count (5)
+        0x75, 0x01,        #     Report Size (1)
+        0x81, 0x02,        #     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+        0x95, 0x01,        #     Report Count (1)
+        0x75, 0x03,        #     Report Size (3)
+        0x81, 0x01,        #     Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+        0x05, 0x01,        #     Usage Page (Generic Desktop Ctrls)
+        0x09, 0x30,        #     Usage (X)
+        0x09, 0x31,        #     Usage (Y)
+        0x15, 0x81,        #     Logical Minimum (-127)
+        0x25, 0x7F,        #     Logical Maximum (127)
+        0x75, 0x08,        #     Report Size (8)
+        0x95, 0x02,        #     Report Count (2)
+        0x81, 0x06,        #     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+        0x09, 0x38,        #     Usage (Wheel)
+        0x15, 0x81,        #     Logical Minimum (-127)
+        0x25, 0x7F,        #     Logical Maximum (127)
+        0x75, 0x08,        #     Report Size (8)
+        0x95, 0x01,        #     Report Count (1)
+        0x81, 0x06,        #     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+        0xC0,              #   End Collection
+        0xC0,              # End Collection
+    ]))
+
+HIDReportDescriptors.CONSUMER_WITH_ID = hid.ReportDescriptor(
+    description="CONSUMER",
+    report_descriptor=bytes([
+        # Consumer ("multimedia") keys
+        0x05, 0x0C,        # Usage Page (Consumer)
+        0x09, 0x01,        # Usage (Consumer Control)
+        0xA1, 0x01,        # Collection (Application)
+        0x85, HIDReportDescriptors.REPORT_IDS["CONSUMER"], # Report ID (n)
+        0x75, 0x10,        #   Report Size (16)
+        0x95, 0x01,        #   Report Count (1)
+        0x15, 0x01,        #   Logical Minimum (1)
+        0x26, 0x8C, 0x02,  #   Logical Maximum (652)
+        0x19, 0x01,        #   Usage Minimum (Consumer Control)
+        0x2A, 0x8C, 0x02,  #   Usage Maximum (AC Send)
+        0x81, 0x00,        #   Input (Data,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+        0xC0,              # End Collection
+    ]))
+
+HIDReportDescriptors.SYS_CONTROL_WITH_ID = hid.ReportDescriptor(
+    description="SYS_CONTROL",
+    report_descriptor=bytes([
+        # Power controls
+        0x05, 0x01,        # Usage Page (Generic Desktop Ctrls)
+        0x09, 0x80,        # Usage (Sys Control)
+        0xA1, 0x01,        # Collection (Application)
+        0x85, HIDReportDescriptors.REPORT_IDS["SYS_CONTROL"], # Report ID (n)
+        0x75, 0x02,        #   Report Size (2)
+        0x95, 0x01,        #   Report Count (1)
+        0x15, 0x01,        #   Logical Minimum (1)
+        0x25, 0x03,        #   Logical Maximum (3)
+        0x09, 0x82,        #   Usage (Sys Sleep)
+        0x09, 0x81,        #   Usage (Sys Power Down)
+        0x09, 0x83,        #   Usage (Sys Wake Up)
+        0x81, 0x60,        #   Input (Data,Array,Abs,No Wrap,Linear,No Preferred State,Null State)
+        0x75, 0x06,        #   Report Size (6)
+        0x81, 0x03,        #   Input (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+        0xC0,              # End Collection
+    ]))
+
+HIDReportDescriptors.GAMEPAD_WITH_ID = hid.ReportDescriptor(
+    description="GAMEPAD",
+    report_descriptor=bytes([
+        # Gamepad with 16 buttons and two joysticks
+        0x05, 0x01,        # Usage Page (Generic Desktop Ctrls)
+        0x09, 0x05,        # Usage (Game Pad)
+        0xA1, 0x01,        # Collection (Application)
+        0x85, HIDReportDescriptors.REPORT_IDS["GAMEPAD"], # Report ID (n)
+        0x05, 0x09,        #   Usage Page (Button)
+        0x19, 0x01,        #   Usage Minimum (Button 1)
+        0x29, 0x10,        #   Usage Maximum (Button 16)
+        0x15, 0x00,        #   Logical Minimum (0)
+        0x25, 0x01,        #   Logical Maximum (1)
+        0x75, 0x01,        #   Report Size (1)
+        0x95, 0x10,        #   Report Count (16)
+        0x81, 0x02,        #   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+        0x05, 0x01,        #   Usage Page (Generic Desktop Ctrls)
+        0x15, 0x81,        #   Logical Minimum (-127)
+        0x25, 0x7F,        #   Logical Maximum (127)
+        0x09, 0x30,        #   Usage (X)
+        0x09, 0x31,        #   Usage (Y)
+        0x09, 0x32,        #   Usage (Z)
+        0x09, 0x35,        #   Usage (Rz)
+        0x75, 0x08,        #   Report Size (8)
+        0x95, 0x04,        #   Report Count (4)
+        0x81, 0x02,        #   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+        0xC0,              # End Collection
+    ]))
+
+HIDReportDescriptors.DIGITIZER_WITH_ID = hid.ReportDescriptor(
+    description="DIGITIZER",
+    report_descriptor=bytes([
+        # Digitizer (used as an absolute pointer)
+        0x05, 0x0D,        # Usage Page (Digitizers)
+        0x09, 0x02,        # Usage (Pen)
+        0xA1, 0x01,        # Collection (Application)
+        0x85, HIDReportDescriptors.REPORT_IDS["DIGITIZER"], # Report ID (n)
+        0x09, 0x01,        #   Usage (Stylus)
+        0xA1, 0x00,        #   Collection (Physical)
+        0x09, 0x32,        #     Usage (In-Range)
+        0x09, 0x42,        #     Usage (Tip Switch)
+        0x09, 0x44,        #     Usage (Barrel Switch)
+        0x09, 0x45,        #     Usage (Eraser Switch)
+        0x15, 0x00,        #     Logical Minimum (0)
+        0x25, 0x01,        #     Logical Maximum (1)
+        0x75, 0x01,        #     Report Size (1)
+        0x95, 0x04,        #     Report Count (4)
+        0x81, 0x02,        #     Input (Data,Var,Abs)
+        0x75, 0x04,        #     Report Size (4) -- Filler
+        0x95, 0x01,        #     Report Count (1) -- Filler
+        0x81, 0x01,        #     Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+        0x05, 0x01,        #     Usage Page (Generic Desktop Ctrls)
+        0x15, 0x00,        #     Logical Minimum (0)
+        0x26, 0xff, 0x7f,  #     Logical Maximum (32767)
+        0x09, 0x30,        #     Usage (X)
+        0x09, 0x31,        #     Usage (Y)
+        0x75, 0x10,        #     Report Size (16)
+        0x95, 0x02,        #     Report Count (2)
+        0x81, 0x02,        #     Input (Data,Var,Abs)
+        0xC0,              #   End Collection
+        0xC0,              # End Collection
+    ]))
+
+# Byte count for each kind of report. Length does not include report ID in first byte.
+HIDReportDescriptors.REPORT_DESCRIPTORS = {
+    "KEYBOARD" : HIDReportDescriptors.KEYBOARD_WITH_ID,
+    "MOUSE" : HIDReportDescriptors.MOUSE_WITH_ID,
+    "CONSUMER" : HIDReportDescriptors.CONSUMER_WITH_ID,
+    "SYS_CONTROL" : HIDReportDescriptors.SYS_CONTROL_WITH_ID,
+    "GAMEPAD" : HIDReportDescriptors.GAMEPAD_WITH_ID,
+    "DIGITIZER" : HIDReportDescriptors.DIGITIZER_WITH_ID,
+    }

--- a/ports/atmel-samd/tools/hid_report_descriptors.py
+++ b/ports/atmel-samd/tools/hid_report_descriptors.py
@@ -31,10 +31,7 @@ HID specific descriptors
 
 from adafruit_usb_descriptor import hid
 
-class HIDReportDescriptors:
-    pass
-
-HIDReportDescriptors.REPORT_IDS = {
+REPORT_IDS = {
     "KEYBOARD" : 1,
     "MOUSE" : 2,
     "CONSUMER" : 3,
@@ -44,7 +41,7 @@ HIDReportDescriptors.REPORT_IDS = {
     }
 
 # Byte count for each kind of report. Length does not include report ID in first byte.
-HIDReportDescriptors.REPORT_LENGTHS = {
+REPORT_LENGTHS = {
     "KEYBOARD" : 8,
     "MOUSE" : 4,
     "CONSUMER" : 2,
@@ -53,14 +50,14 @@ HIDReportDescriptors.REPORT_LENGTHS = {
     "DIGITIZER" : 5,
     }
 
-HIDReportDescriptors.KEYBOARD_WITH_ID = hid.ReportDescriptor(
+KEYBOARD_WITH_ID = hid.ReportDescriptor(
     description="KEYBOARD",
     report_descriptor=bytes([
         # Regular keyboard
         0x05, 0x01,                 # Usage Page (Generic Desktop)
         0x09, 0x06,                 # Usage (Keyboard)
         0xA1, 0x01,                 # Collection (Application)
-        0x85, HIDReportDescriptors.REPORT_IDS["KEYBOARD"], #   Report ID (1)
+        0x85, REPORT_IDS["KEYBOARD"], #   Report ID (1)
         0x05, 0x07,                 #   Usage Page (Keyboard)
         0x19, 224,                  #   Usage Minimum (224)
         0x29, 231,                  #   Usage Maximum (231)
@@ -90,7 +87,7 @@ HIDReportDescriptors.KEYBOARD_WITH_ID = hid.ReportDescriptor(
         0xC0,                       # End Collection
     ]))
 
-HIDReportDescriptors.MOUSE_WITH_ID = hid.ReportDescriptor(
+MOUSE_WITH_ID = hid.ReportDescriptor(
     description="MOUSE",
     report_descriptor=bytes([
         # Regular mouse
@@ -99,7 +96,7 @@ HIDReportDescriptors.MOUSE_WITH_ID = hid.ReportDescriptor(
         0xA1, 0x01,        # Collection (Application)
         0x09, 0x01,        #   Usage (Pointer)
         0xA1, 0x00,        #   Collection (Physical)
-        0x85, HIDReportDescriptors.REPORT_IDS["MOUSE"], # Report ID (n)
+        0x85, REPORT_IDS["MOUSE"], # Report ID (n)
         0x05, 0x09,        #     Usage Page (Button)
         0x19, 0x01,        #     Usage Minimum (0x01)
         0x29, 0x05,        #     Usage Maximum (0x05)
@@ -129,14 +126,14 @@ HIDReportDescriptors.MOUSE_WITH_ID = hid.ReportDescriptor(
         0xC0,              # End Collection
     ]))
 
-HIDReportDescriptors.CONSUMER_WITH_ID = hid.ReportDescriptor(
+CONSUMER_WITH_ID = hid.ReportDescriptor(
     description="CONSUMER",
     report_descriptor=bytes([
         # Consumer ("multimedia") keys
         0x05, 0x0C,        # Usage Page (Consumer)
         0x09, 0x01,        # Usage (Consumer Control)
         0xA1, 0x01,        # Collection (Application)
-        0x85, HIDReportDescriptors.REPORT_IDS["CONSUMER"], # Report ID (n)
+        0x85, REPORT_IDS["CONSUMER"], # Report ID (n)
         0x75, 0x10,        #   Report Size (16)
         0x95, 0x01,        #   Report Count (1)
         0x15, 0x01,        #   Logical Minimum (1)
@@ -147,14 +144,14 @@ HIDReportDescriptors.CONSUMER_WITH_ID = hid.ReportDescriptor(
         0xC0,              # End Collection
     ]))
 
-HIDReportDescriptors.SYS_CONTROL_WITH_ID = hid.ReportDescriptor(
+SYS_CONTROL_WITH_ID = hid.ReportDescriptor(
     description="SYS_CONTROL",
     report_descriptor=bytes([
         # Power controls
         0x05, 0x01,        # Usage Page (Generic Desktop Ctrls)
         0x09, 0x80,        # Usage (Sys Control)
         0xA1, 0x01,        # Collection (Application)
-        0x85, HIDReportDescriptors.REPORT_IDS["SYS_CONTROL"], # Report ID (n)
+        0x85, REPORT_IDS["SYS_CONTROL"], # Report ID (n)
         0x75, 0x02,        #   Report Size (2)
         0x95, 0x01,        #   Report Count (1)
         0x15, 0x01,        #   Logical Minimum (1)
@@ -168,14 +165,14 @@ HIDReportDescriptors.SYS_CONTROL_WITH_ID = hid.ReportDescriptor(
         0xC0,              # End Collection
     ]))
 
-HIDReportDescriptors.GAMEPAD_WITH_ID = hid.ReportDescriptor(
+GAMEPAD_WITH_ID = hid.ReportDescriptor(
     description="GAMEPAD",
     report_descriptor=bytes([
         # Gamepad with 16 buttons and two joysticks
         0x05, 0x01,        # Usage Page (Generic Desktop Ctrls)
         0x09, 0x05,        # Usage (Game Pad)
         0xA1, 0x01,        # Collection (Application)
-        0x85, HIDReportDescriptors.REPORT_IDS["GAMEPAD"], # Report ID (n)
+        0x85, REPORT_IDS["GAMEPAD"], # Report ID (n)
         0x05, 0x09,        #   Usage Page (Button)
         0x19, 0x01,        #   Usage Minimum (Button 1)
         0x29, 0x10,        #   Usage Maximum (Button 16)
@@ -197,14 +194,14 @@ HIDReportDescriptors.GAMEPAD_WITH_ID = hid.ReportDescriptor(
         0xC0,              # End Collection
     ]))
 
-HIDReportDescriptors.DIGITIZER_WITH_ID = hid.ReportDescriptor(
+DIGITIZER_WITH_ID = hid.ReportDescriptor(
     description="DIGITIZER",
     report_descriptor=bytes([
         # Digitizer (used as an absolute pointer)
         0x05, 0x0D,        # Usage Page (Digitizers)
         0x09, 0x02,        # Usage (Pen)
         0xA1, 0x01,        # Collection (Application)
-        0x85, HIDReportDescriptors.REPORT_IDS["DIGITIZER"], # Report ID (n)
+        0x85, REPORT_IDS["DIGITIZER"], # Report ID (n)
         0x09, 0x01,        #   Usage (Stylus)
         0xA1, 0x00,        #   Collection (Physical)
         0x09, 0x32,        #     Usage (In-Range)
@@ -232,11 +229,11 @@ HIDReportDescriptors.DIGITIZER_WITH_ID = hid.ReportDescriptor(
     ]))
 
 # Byte count for each kind of report. Length does not include report ID in first byte.
-HIDReportDescriptors.REPORT_DESCRIPTORS = {
-    "KEYBOARD" : HIDReportDescriptors.KEYBOARD_WITH_ID,
-    "MOUSE" : HIDReportDescriptors.MOUSE_WITH_ID,
-    "CONSUMER" : HIDReportDescriptors.CONSUMER_WITH_ID,
-    "SYS_CONTROL" : HIDReportDescriptors.SYS_CONTROL_WITH_ID,
-    "GAMEPAD" : HIDReportDescriptors.GAMEPAD_WITH_ID,
-    "DIGITIZER" : HIDReportDescriptors.DIGITIZER_WITH_ID,
+REPORT_DESCRIPTORS = {
+    "KEYBOARD" : KEYBOARD_WITH_ID,
+    "MOUSE" : MOUSE_WITH_ID,
+    "CONSUMER" : CONSUMER_WITH_ID,
+    "SYS_CONTROL" : SYS_CONTROL_WITH_ID,
+    "GAMEPAD" : GAMEPAD_WITH_ID,
+    "DIGITIZER" : DIGITIZER_WITH_ID,
     }


### PR DESCRIPTION
Adds a simple gamepad HID device to the devices that share a common endpoint: mouse, keyboard, consumer controls, and now gamepad.

The gamepad shows up to varying degrees in various operating systems:

* **Linux**: visible as a `/dev/input/js*` device and a `/dev/input/event*` device. Events can be seen via `evtest` and `jstest`. Firefox and Chrome do not see the gamepad via https://html5gamepad.com, but that appears to be due to limited gamepad support/compatibility between the browsers and Linux
* **Windows**: can be seen via Control Panel > Hardware and Sound > Devices and Printers > Metro M4 Express (for example). It appears as a keyboard icon, but if you right-click, you'll see a choice of HID devices, and can choose the game controller and get dialog boxes.
Firefox and Chrome _can_ see the gamepad via http://html5gamepad.com. You may need to send some events before it shows up.
* **MacOS**: Firefox and Chrome _can_ see the gamepad via http://html5gamepad.com. You may need to send some events before it shows up.

This PR also includes latent support for a stylus-based digitizer as well, but it conflicts with other devices, so it's turned off until we have dynamic USB HID devices. I had hoped to add a little dynamic `boot.py` support to allow turning the HID devices on and off before USB comes up, but this requires dynamic construction of both the report descriptors and the HID descriptor, so deferred for now.

Needs https://github.com/adafruit/Adafruit_CircuitPython_HID/pull/19 to have a Python library for the gamepad support.