### PR TITLE
(u)binascii: better python3 compatibility

### DIFF
--- a/extmod/modubinascii.c
+++ b/extmod/modubinascii.c
@@ -244,7 +244,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_binascii_crc32_obj, 1, 2, mod_binascii_c
 #if MICROPY_PY_UBINASCII
 
 STATIC const mp_rom_map_elem_t mp_module_binascii_globals_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ubinascii) },
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_binascii) },
     { MP_ROM_QSTR(MP_QSTR_hexlify), MP_ROM_PTR(&mod_binascii_hexlify_obj) },
     { MP_ROM_QSTR(MP_QSTR_unhexlify), MP_ROM_PTR(&mod_binascii_unhexlify_obj) },
     { MP_ROM_QSTR(MP_QSTR_a2b_base64), MP_ROM_PTR(&mod_binascii_a2b_base64_obj) },

--- a/extmod/modubinascii.c
+++ b/extmod/modubinascii.c
@@ -32,11 +32,20 @@
 #include "py/binary.h"
 #include "extmod/modubinascii.h"
 
+static void check_not_unicode(const mp_obj_t arg) {
+#if MICROPY_CPYTHON_COMPAT
+    if (MP_OBJ_IS_STR(arg)) {
+        mp_raise_TypeError("a bytes-like object is required");
+    }
+#endif
+}
+
 mp_obj_t mod_binascii_hexlify(size_t n_args, const mp_obj_t *args) {
     // Second argument is for an extension to allow a separator to be used
     // between values.
     const char *sep = NULL;
     mp_buffer_info_t bufinfo;
+    check_not_unicode(args[0]);
     mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);
 
     // Code below assumes non-zero buffer length when computing size with
@@ -165,6 +174,7 @@ mp_obj_t mod_binascii_a2b_base64(mp_obj_t data) {
 MP_DEFINE_CONST_FUN_OBJ_1(mod_binascii_a2b_base64_obj, mod_binascii_a2b_base64);
 
 mp_obj_t mod_binascii_b2a_base64(mp_obj_t data) {
+    check_not_unicode(data);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(data, &bufinfo, MP_BUFFER_READ);
 
@@ -222,6 +232,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(mod_binascii_b2a_base64_obj, mod_binascii_b2a_base64);
 
 mp_obj_t mod_binascii_crc32(size_t n_args, const mp_obj_t *args) {
     mp_buffer_info_t bufinfo;
+    check_not_unicode(args[0]);
     mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);
     uint32_t crc = (n_args > 1) ? mp_obj_get_int_truncated(args[1]) : 0;
     crc = uzlib_crc32(bufinfo.buf, bufinfo.len, crc ^ 0xffffffff);

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -202,7 +202,7 @@ STATIC const mp_rom_map_elem_t mp_builtin_module_table[] = {
     { MP_ROM_QSTR(MP_QSTR_uhashlib), MP_ROM_PTR(&mp_module_uhashlib) },
 #endif
 #if MICROPY_PY_UBINASCII
-    { MP_ROM_QSTR(MP_QSTR_ubinascii), MP_ROM_PTR(&mp_module_ubinascii) },
+    { MP_ROM_QSTR(MP_QSTR_binascii), MP_ROM_PTR(&mp_module_ubinascii) },
 #endif
 #if MICROPY_PY_URANDOM
     { MP_ROM_QSTR(MP_QSTR_urandom), MP_ROM_PTR(&mp_module_urandom) },

--- a/tests/extmod/ubinascii_a2b_base64.py
+++ b/tests/extmod/ubinascii_a2b_base64.py
@@ -28,6 +28,9 @@ print(binascii.a2b_base64(b'Zm9v=='))
 print(binascii.a2b_base64(b'Zm9v==='))
 print(binascii.a2b_base64(b'Zm9v===YmFy'))
 
+# Unicode strings can be decoded
+print(binascii.a2b_base64(u'Zm9v===YmFy'))
+
 try:
     print(binascii.a2b_base64(b'abc'))
 except ValueError:

--- a/tests/extmod/ubinascii_b2a_base64.py
+++ b/tests/extmod/ubinascii_b2a_base64.py
@@ -20,3 +20,7 @@ print(binascii.b2a_base64(b'\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f'))
 print(binascii.b2a_base64(b'\x7f\x80\xff'))
 print(binascii.b2a_base64(b'1234ABCDabcd'))
 print(binascii.b2a_base64(b'\x00\x00>')) # convert into '+'
+try:
+    print(binascii.b2a_base64(''))
+except TypeError:
+    print("TypeError")

--- a/tests/extmod/ubinascii_crc32.py
+++ b/tests/extmod/ubinascii_crc32.py
@@ -22,3 +22,7 @@ print(hex(binascii.crc32(b' over the lazy dog', binascii.crc32(b'The quick brown
 print(hex(binascii.crc32(b'\x00' * 16, binascii.crc32(b'\x00' * 16))))
 print(hex(binascii.crc32(b'\xff' * 16, binascii.crc32(b'\xff' * 16))))
 print(hex(binascii.crc32(bytes(range(16, 32)), binascii.crc32(bytes(range(16))))))
+try:
+    binascii.crc32('')
+except TypeError:
+    print("TypeError")

--- a/tests/extmod/ubinascii_hexlify.py
+++ b/tests/extmod/ubinascii_hexlify.py
@@ -11,3 +11,7 @@ print(binascii.hexlify(b'\x00\x01\x02\x03\x04\x05\x06\x07'))
 print(binascii.hexlify(b'\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f'))
 print(binascii.hexlify(b'\x7f\x80\xff'))
 print(binascii.hexlify(b'1234ABCDabcd'))
+try:
+    binascii.hexlify('')
+except TypeError:
+    print("TypeError")

--- a/tests/extmod/ubinascii_unhexlify.py
+++ b/tests/extmod/ubinascii_unhexlify.py
@@ -12,6 +12,9 @@ print(binascii.unhexlify(b'08090a0b0c0d0e0f'))
 print(binascii.unhexlify(b'7f80ff'))
 print(binascii.unhexlify(b'313233344142434461626364'))
 
+# Unicode strings can be decoded
+print(binascii.unhexlify('313233344142434461626364'))
+
 try:
     a = binascii.unhexlify(b'0') # odd buffer length
 except ValueError:


### PR DESCRIPTION
This improves the python3 compatibility of the 'ubinascii' module as it relates to treatment of unicode (not bytes) inputs and aliases it as 'binascii'.  It adds additional tests for bytes vs unicode behavior.