### PR TITLE
Re-enable PDMIn without ASF

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -299,13 +299,13 @@ SRC_COMMON_HAL = \
 	usb_hid/Device.c \
 	audioio/__init__.c \
 	audioio/AudioOut.c \
-#	audiobusio/PDMIn.c \
-	touchio/__init__.c \
+#	touchio/__init__.c \
 	touchio/TouchIn.c \
 
 ifeq ($(INTERNAL_LIBM),1)
 SRC_LIBM = $(addprefix lib/,\
 	libm/math.c \
+	libm/roundf.c \
 	libm/fmodf.c \
 	libm/nearbyintf.c \
 	libm/ef_sqrt.c \
@@ -363,16 +363,14 @@ SRC_SHARED_MODULE = \
 	uheap/__init__.c \
 	ustack/__init__.c
 
-ifeq ($(CHIP_FAMILY),samd21)
-SRC_COMMON_HAL += \
-	audiobusio/__init__.c \
-	audiobusio/I2SOut.c
-endif
+# The smallest SAMD51 packages don't have I2S. Everything else does.
 ifneq ($(CHIP_VARIANT),SAMD51G18A)
 	ifneq ($(CHIP_VARIANT),SAMD51G19A)
 		SRC_COMMON_HAL += \
 			audiobusio/__init__.c \
-			audiobusio/I2SOut.c
+			audiobusio/I2SOut.c \
+			audiobusio/PDMIn.c
+		SRC_C += i2s.c
 	endif
 endif
 

--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -267,7 +267,6 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t* dma,
         turn_on_event_system();
         dma->event_channel = find_sync_event_channel();
         init_event_channel_interrupt(dma->event_channel, CORE_GCLK, EVSYS_ID_GEN_DMAC_CH_0 + dma_channel);
-        find_sync_event_channel();
 
         // We keep the audio_dma_t for internal use and the sample as a root pointer because it
         // contains the audiodma structure.

--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -274,11 +274,16 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t* dma,
         MP_STATE_PORT(playing_audio)[dma->dma_channel] = dma->sample;
     }
 
-    dma->beat_size = 1;
-    dma->bytes_per_sample = 1;
+
     if (audiosample_bits_per_sample(sample) == 16) {
         dma->beat_size = 2;
         dma->bytes_per_sample = 2;
+    } else {
+        dma->beat_size = 1;
+        dma->bytes_per_sample = 1;
+        if (single_channel) {
+            output_register_address += 1;
+        }
     }
     // Transfer both channels at once.
     if (!single_channel && audiosample_channel_count(sample) == 2) {

--- a/ports/atmel-samd/audio_dma.h
+++ b/ports/atmel-samd/audio_dma.h
@@ -64,6 +64,8 @@ uint8_t audiosample_channel_count(mp_obj_t sample_obj);
 void audio_dma_init(audio_dma_t* dma);
 void audio_dma_reset(void);
 
+uint8_t find_free_audio_dma_channel(void);
+
 // This sets everything up but doesn't start the timer.
 // Sample is the python object for the sample to play.
 // loop is true if we should loop the sample.

--- a/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+++ b/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
@@ -371,7 +371,12 @@ uint32_t common_hal_audiobusio_pdmin_record_to_buffer(audiobusio_pdmin_obj_t* se
     setup_dma(self, output_buffer_length, dma_descriptor(dma_channel), &second_descriptor,
               words_per_buffer, words_per_sample, first_buffer, second_buffer);
 
-    dma_configure(dma_channel, I2S_DMAC_ID_RX_0, true);
+    uint8_t trigger_source = I2S_DMAC_ID_RX_0;
+    #ifdef SAMD21
+    trigger_source += self->serializer;
+    #endif
+
+    dma_configure(dma_channel, trigger_source, true);
     init_event_channel_interrupt(event_channel, CORE_GCLK, EVSYS_ID_GEN_DMAC_CH_0 + dma_channel);
     dma_enable_channel(dma_channel);
 

--- a/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+++ b/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
@@ -50,7 +50,7 @@
 #include "tick.h"
 
 #define OVERSAMPLING 64
-#define SAMPLES_PER_BUFFER 64
+#define SAMPLES_PER_BUFFER 32
 
 // MEMS microphones must be clocked at at least 1MHz.
 #define MIN_MIC_CLOCK 1000000

--- a/ports/atmel-samd/events.h
+++ b/ports/atmel-samd/events.h
@@ -42,5 +42,6 @@ void connect_event_user_to_channel(uint8_t user, uint8_t channel);
 void init_async_event_channel(uint8_t channel, uint8_t generator);
 void init_event_channel_interrupt(uint8_t channel, uint8_t gclk, uint8_t generator);
 bool event_interrupt_active(uint8_t channel);
+bool event_interrupt_overflow(uint8_t channel);
 
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_EVENTS_H

--- a/ports/atmel-samd/i2s.c
+++ b/ports/atmel-samd/i2s.c
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "i2s.h"
+
+#include "clocks.h"
+
+#include "hpl/gclk/hpl_gclk_base.h"
+#ifdef SAMD21
+#include "hpl/pm/hpl_pm_base.h"
+#endif
+
+void turn_on_i2s(void) {
+    // Make sure the I2S peripheral is running so we can see if the resources we need are free.
+    #ifdef SAMD51
+    hri_mclk_set_APBDMASK_I2S_bit(MCLK);
+
+    // Connect the clock units to the 2mhz clock by default. They can't reset without it.
+    connect_gclk_to_peripheral(5, I2S_GCLK_ID_0);
+    connect_gclk_to_peripheral(5, I2S_GCLK_ID_1);
+    #endif
+
+    #ifdef SAMD21
+    _pm_enable_bus_clock(PM_BUS_APBC, I2S);
+    #endif
+}
+
+void i2s_set_enable(bool enable) {
+    while (I2S->SYNCBUSY.bit.ENABLE == 1) {}
+    I2S->CTRLA.bit.ENABLE = enable;
+    while (I2S->SYNCBUSY.bit.ENABLE == 1) {}
+}
+
+void i2s_set_clock_unit_enable(uint8_t clock_unit, bool enable) {
+    while ((I2S->SYNCBUSY.vec.CKEN & (1 << clock_unit)) != 0) {}
+    I2S->CTRLA.vec.CKEN = 1 << clock_unit;
+    while ((I2S->SYNCBUSY.vec.CKEN & (1 << clock_unit)) != 0) {}
+}
+
+void i2s_set_serializer_enable(uint8_t serializer, bool enable) {
+    #ifdef SAMD21
+    while ((I2S->SYNCBUSY.vec.SEREN & (1 << serializer)) != 0) {}
+    if (enable) {
+        I2S->CTRLA.vec.SEREN = 1 << serializer;
+    } else {
+        I2S->CTRLA.vec.SEREN &= ~(1 << serializer);
+    }
+    while ((I2S->SYNCBUSY.vec.SEREN & (1 << serializer)) != 0) {}
+    #endif
+    #ifdef SAMD51
+    if (serializer == 0) {
+        while (I2S->SYNCBUSY.bit.TXEN == 1) {}
+        I2S->CTRLA.bit.TXEN = enable;
+        while (I2S->SYNCBUSY.bit.TXEN == 1) {}
+    } else {
+        while (I2S->SYNCBUSY.bit.RXEN == 1) {}
+        I2S->CTRLA.bit.RXEN = enable;
+        while (I2S->SYNCBUSY.bit.RXEN == 1) {}
+    }
+    #endif
+}

--- a/ports/atmel-samd/i2s.h
+++ b/ports/atmel-samd/i2s.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2018 Scott Shawcroft for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,28 +24,18 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_AUDIOBUSIO_AUDIOOUT_H
-#define MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_AUDIOBUSIO_AUDIOOUT_H
+#ifndef MICROPY_INCLUDED_ATMEL_SAMD_I2S_H
+#define MICROPY_INCLUDED_ATMEL_SAMD_I2S_H
 
-#include "common-hal/microcontroller/Pin.h"
+#include <stdbool.h>
+#include <stdint.h>
 
-#include "extmod/vfs_fat_file.h"
-#include "py/obj.h"
+#include "include/sam.h"
 
-typedef struct {
-    mp_obj_base_t base;
-    const mcu_pin_obj_t *clock_pin;
-    const mcu_pin_obj_t *data_pin;
-    uint32_t sample_rate;
-    uint8_t serializer;
-    uint8_t clock_unit;
-    uint8_t bytes_per_sample;
-    uint8_t bit_depth;
-    uint8_t gclk;
-} audiobusio_pdmin_obj_t;
+void turn_on_i2s(void);
 
-void pdmin_reset(void);
+void i2s_set_enable(bool enable);
+void i2s_set_clock_unit_enable(uint8_t clock, bool enable);
+void i2s_set_serializer_enable(uint8_t serializer, bool enable);
 
-void pdmin_background(void);
-
-#endif // MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_AUDIOBUSIO_AUDIOOUT_H
+#endif  // MICROPY_INCLUDED_ATMEL_SAMD_I2S_H

--- a/ports/atmel-samd/shared_dma.c
+++ b/ports/atmel-samd/shared_dma.c
@@ -99,6 +99,8 @@ void dma_enable_channel(uint8_t channel_number) {
     common_hal_mcu_disable_interrupts();
     /** Select the DMA channel and clear software trigger */
     DMAC->CHID.reg = DMAC_CHID_ID(channel_number);
+    // Clear any previous interrupts.
+    DMAC->CHINTFLAG.reg = DMAC_CHINTFLAG_MASK;
     DMAC->CHCTRLA.bit.ENABLE = true;
     common_hal_mcu_enable_interrupts();
     #endif
@@ -106,6 +108,8 @@ void dma_enable_channel(uint8_t channel_number) {
     #ifdef SAMD51
     DmacChannel* channel = &DMAC->Channel[channel_number];
     channel->CHCTRLA.bit.ENABLE = true;
+    // Clear any previous interrupts.
+    channel->CHINTFLAG.reg = DMAC_CHINTFLAG_MASK;
     #endif
 }
 

--- a/shared-bindings/audiobusio/PDMIn.c
+++ b/shared-bindings/audiobusio/PDMIn.c
@@ -42,18 +42,18 @@
 //|
 //| PDMIn can be used to record an input audio signal on a given set of pins.
 //|
-//| .. class:: PDMIn(clock_pin, data_pin, \*, frequency=16000, bit_depth=8, mono=True, oversample=64, startup_delay=0.11)
+//| .. class:: PDMIn(clock_pin, data_pin, \*, sample_rate=16000, bit_depth=8, mono=True, oversample=64, startup_delay=0.11)
 //|
 //|   Create a PDMIn object associated with the given pins. This allows you to
 //|   record audio signals from the given pins. Individual ports may put further
-//|   restrictions on the recording parameters. The overall frequency is
-//|   determined by `frequency` x ``oversample``, and the total must be 1MHz or
-//|   higher, so `frequency` must be a minimum of 16000.
+//|   restrictions on the recording parameters. The overall sample rate is
+//|   determined by `sample_rate` x ``oversample``, and the total must be 1MHz or
+//|   higher, so `sample_rate` must be a minimum of 16000.
 //|
 //|   :param ~microcontroller.Pin clock_pin: The pin to output the clock to
 //|   :param ~microcontroller.Pin data_pin: The pin to read the data from
-//|   :param int frequency: Target frequency of the resulting samples. Check `frequency` for actual value.
-//|     Minimum frequency is about 16000 Hz.
+//|   :param int sample_rate: Target sample_rate of the resulting samples. Check `sample_rate` for actual value.
+//|     Minimum sample_rate is about 16000 Hz.
 //|   :param int bit_depth: Final number of bits per sample. Must be divisible by 8
 //|   :param bool mono: True when capturing a single channel of audio, captures two channels otherwise
 //|   :param int oversample: Number of single bit samples to decimate into a final sample. Must be divisible by 8
@@ -69,7 +69,7 @@
 //|
 //|     # Prep a buffer to record into
 //|     b = bytearray(200)
-//|     with audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA, frequency=16000) as mic:
+//|     with audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA, sample_rate=16000) as mic:
 //|         mic.record(b, len(b))
 //|
 //|   Record 16-bit unsigned samples to buffer::
@@ -83,15 +83,15 @@
 //|     b = array.array("H")
 //|     for i in range(200):
 //|         b.append(0)
-//|     with audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA, frequency=16000, bit_depth=16) as mic:
+//|     with audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA, sample_rate=16000, bit_depth=16) as mic:
 //|         mic.record(b, len(b))
 //|
 STATIC mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    enum { ARG_frequency, ARG_bit_depth, ARG_mono, ARG_oversample, ARG_startup_delay };
+    enum { ARG_sample_rate, ARG_bit_depth, ARG_mono, ARG_oversample, ARG_startup_delay };
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_frequency,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 16000} },
+        { MP_QSTR_sample_rate,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 16000} },
         { MP_QSTR_bit_depth,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 8} },
         { MP_QSTR_mono,          MP_ARG_KW_ONLY | MP_ARG_BOOL,{.u_bool = true} },
         { MP_QSTR_oversample,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 64} },
@@ -117,7 +117,7 @@ STATIC mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_ar
     audiobusio_pdmin_obj_t *self = m_new_obj(audiobusio_pdmin_obj_t);
     self->base.type = &audiobusio_pdmin_type;
 
-    uint32_t frequency = args[ARG_frequency].u_int;
+    uint32_t sample_rate = args[ARG_sample_rate].u_int;
     uint8_t bit_depth = args[ARG_bit_depth].u_int;
     if (bit_depth % 8 != 0) {
         mp_raise_ValueError("Bit depth must be multiple of 8.");
@@ -135,7 +135,7 @@ STATIC mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_ar
         mp_raise_ValueError("Microphone startup delay must be in range 0.0 to 1.0");
     }
 
-    common_hal_audiobusio_pdmin_construct(self, clock_pin, data_pin, frequency,
+    common_hal_audiobusio_pdmin_construct(self, clock_pin, data_pin, sample_rate,
                                           bit_depth, mono, oversample);
 
     // Wait for the microphone to start up. Some start in 10 msecs; some take as much as 100 msecs.
@@ -215,21 +215,21 @@ STATIC mp_obj_t audiobusio_pdmin_obj_record(mp_obj_t self_obj, mp_obj_t destinat
 }
 MP_DEFINE_CONST_FUN_OBJ_3(audiobusio_pdmin_record_obj, audiobusio_pdmin_obj_record);
 
-//|   .. attribute:: frequency
+//|   .. attribute:: sample_rate
 //|
-//|     The actual frequency of the recording. This may not match the constructed
-//|     frequency due to internal clock limitations.
+//|     The actual sample_rate of the recording. This may not match the constructed
+//|     sample rate due to internal clock limitations.
 //|
-STATIC mp_obj_t audiobusio_pdmin_obj_get_frequency(mp_obj_t self_in) {
+STATIC mp_obj_t audiobusio_pdmin_obj_get_sample_rate(mp_obj_t self_in) {
     audiobusio_pdmin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     raise_error_if_deinited(common_hal_audiobusio_pdmin_deinited(self));
-    return MP_OBJ_NEW_SMALL_INT(common_hal_audiobusio_pdmin_get_frequency(self));
+    return MP_OBJ_NEW_SMALL_INT(common_hal_audiobusio_pdmin_get_sample_rate(self));
 }
-MP_DEFINE_CONST_FUN_OBJ_1(audiobusio_pdmin_get_frequency_obj, audiobusio_pdmin_obj_get_frequency);
+MP_DEFINE_CONST_FUN_OBJ_1(audiobusio_pdmin_get_sample_rate_obj, audiobusio_pdmin_obj_get_sample_rate);
 
-const mp_obj_property_t audiobusio_pdmin_frequency_obj = {
+const mp_obj_property_t audiobusio_pdmin_sample_rate_obj = {
     .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audiobusio_pdmin_get_frequency_obj,
+    .proxy = {(mp_obj_t)&audiobusio_pdmin_get_sample_rate_obj,
               (mp_obj_t)&mp_const_none_obj,
               (mp_obj_t)&mp_const_none_obj},
 };
@@ -240,7 +240,7 @@ STATIC const mp_rom_map_elem_t audiobusio_pdmin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&default___enter___obj) },
     { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&audiobusio_pdmin___exit___obj) },
     { MP_ROM_QSTR(MP_QSTR_record), MP_ROM_PTR(&audiobusio_pdmin_record_obj) },
-    { MP_ROM_QSTR(MP_QSTR_frequency), MP_ROM_PTR(&audiobusio_pdmin_frequency_obj) }
+    { MP_ROM_QSTR(MP_QSTR_sample_rate), MP_ROM_PTR(&audiobusio_pdmin_sample_rate_obj) }
 };
 STATIC MP_DEFINE_CONST_DICT(audiobusio_pdmin_locals_dict, audiobusio_pdmin_locals_dict_table);
 

--- a/shared-bindings/audiobusio/PDMIn.h
+++ b/shared-bindings/audiobusio/PDMIn.h
@@ -35,13 +35,13 @@ extern const mp_obj_type_t audiobusio_pdmin_type;
 
 void common_hal_audiobusio_pdmin_construct(audiobusio_pdmin_obj_t* self,
     const mcu_pin_obj_t* clock_pin, const mcu_pin_obj_t* data_pin,
-    uint32_t frequency, uint8_t bit_depth, bool mono, uint8_t oversample);
+    uint32_t sample_rate, uint8_t bit_depth, bool mono, uint8_t oversample);
 void common_hal_audiobusio_pdmin_deinit(audiobusio_pdmin_obj_t* self);
 bool common_hal_audiobusio_pdmin_deinited(audiobusio_pdmin_obj_t* self);
 uint32_t common_hal_audiobusio_pdmin_record_to_buffer(audiobusio_pdmin_obj_t* self,
     uint16_t* buffer, uint32_t length);
 uint8_t common_hal_audiobusio_pdmin_get_bit_depth(audiobusio_pdmin_obj_t* self);
-uint32_t common_hal_audiobusio_pdmin_get_frequency(audiobusio_pdmin_obj_t* self);
+uint32_t common_hal_audiobusio_pdmin_get_sample_rate(audiobusio_pdmin_obj_t* self);
 // TODO(tannewt): Add record to file
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_AUDIOBUSIO_AUDIOOUT_H

--- a/shared-bindings/audiobusio/__init__.c
+++ b/shared-bindings/audiobusio/__init__.c
@@ -62,7 +62,7 @@
 STATIC const mp_rom_map_elem_t audiobusio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audiobusio) },
     { MP_ROM_QSTR(MP_QSTR_I2SOut), MP_ROM_PTR(&audiobusio_i2sout_type) },
-    //{ MP_ROM_QSTR(MP_QSTR_PDMIn), MP_ROM_PTR(&audiobusio_pdmin_type) },
+    { MP_ROM_QSTR(MP_QSTR_PDMIn), MP_ROM_PTR(&audiobusio_pdmin_type) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(audiobusio_module_globals, audiobusio_module_globals_table);


### PR DESCRIPTION
The API is almost the same except the `frequency` attribute has been
renamed to `sample_rate` so that its less likely to be confused with
frequencies within the audio itself.

Fixes #263.