### PR TITLE
correct path to conf.py in makeversionhdr.py

### DIFF
--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -52,7 +52,7 @@ def get_version_info_from_git():
     return git_tag, git_hash, ver
 
 def get_version_info_from_docs_conf():
-    with open(os.path.join(os.path.dirname(sys.argv[0]), "..", "docs", "conf.py")) as f:
+    with open(os.path.join(os.path.dirname(sys.argv[0]), "..", "conf.py")) as f:
         for line in f:
             if line.startswith("version = release = '"):
                 ver = line.strip().split(" = ")[2].strip("'")


### PR DESCRIPTION
the py/makeversionhdr.py script was looking for `conf.py` in the `docs/` directory, but this was relocated in 46e7f8e.  This used by the fallback `get_version_info_from_docs_conf` method, which is only used when `git` isn't available in the build environment, which is probably why nobody ever noticed this bug before.

Closes #791.