### PR TITLE
allow esptool.py invocation to be set via make vars

### DIFF
--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -32,6 +32,7 @@ FLASH_MODE ?= qio
 FLASH_SIZE ?= detect
 CROSS_COMPILE = xtensa-lx106-elf-
 ESP_SDK = $(shell $(CC) -print-sysroot)/usr
+ESPTOOL = esptool.py
 
 INC += -I.
 INC += -I$(TOP)
@@ -230,18 +231,18 @@ FROZEN_EXTRA_DEPS = $(CONFVARS_FILE)
 
 deploy: $(BUILD)/firmware-combined.bin
 	$(ECHO) "Writing $< to the board"
-	$(Q)esptool.py --port $(PORT) --baud $(BAUD) write_flash --verify --flash_size=$(FLASH_SIZE) --flash_mode=$(FLASH_MODE) 0 $<
+	$(Q)$(ESPTOOL) --port $(PORT) --baud $(BAUD) write_flash --verify --flash_size=$(FLASH_SIZE) --flash_mode=$(FLASH_MODE) 0 $<
 
 erase:
 	$(ECHO) "Erase flash"
-	$(Q)esptool.py --port $(PORT) --baud $(BAUD) erase_flash
+	$(Q)$(ESPTOOL) --port $(PORT) --baud $(BAUD) erase_flash
 
 reset:
 	echo -e "\r\nimport machine; machine.reset()\r\n" >$(PORT)
 
 $(FWBIN): $(BUILD)/firmware.elf
 	$(ECHO) "Create $@"
-	$(Q)python2 $(shell which esptool.py) elf2image $^
+	$(Q)$(ESPTOOL) elf2image $^
 	$(Q)$(PYTHON) makeimg.py $(BUILD)/firmware.elf-0x00000.bin $(BUILD)/firmware.elf-0x[0-5][1-f]000.bin $@
 
 


### PR DESCRIPTION
This commit replaces the literal calls to `esptool.py` with the
`$(ESPTOOL)` Makefile variable. This allows one to set the esptool
invocation on the Make command line:

    make ESPTOOL="python2 $(which esptool.py)"

(or via the environment, an include file, etc)

Closes #793