### PR TITLE
try both binascii and ubinascii in inisetup.py

### DIFF
--- a/ports/esp8266/modules/inisetup.py
+++ b/ports/esp8266/modules/inisetup.py
@@ -3,9 +3,13 @@ import network
 import storage
 
 def wifi():
-    import ubinascii
+    try:
+        import ubinascii as binascii
+    except ImportError:
+        import binascii
+
     ap_if = network.WLAN(network.AP_IF)
-    essid = b"MicroPython-%s" % ubinascii.hexlify(ap_if.config("mac")[-3:])
+    essid = b"MicroPython-%s" % binascii.hexlify(ap_if.config("mac")[-3:])
     ap_if.config(essid=essid, authmode=network.AUTH_WPA_WPA2_PSK, password=b"micropythoN")
 
 def check_bootsec():


### PR DESCRIPTION
in recent circuitpython builds, `ubinascii` is available as
`binascii`.  This modifies `modules/inisetup.py` to use the same
import semantics as `modules/websocket_helper.py`: first try importing
`ubinascii`, and if that fails, fall back to importing `binascii`.

Closes adafruit/circuitpython#795