### PR TITLE
ports/esp8266: optionally include local Makefile settings

### DIFF
--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -59,6 +59,8 @@ LIBS = -L$(ESP_SDK)/lib -lmain -ljson -llwip_open -lpp -lnet80211 -lwpa -lphy -l
 LIBGCC_FILE_NAME = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 LIBS += -L$(dir $(LIBGCC_FILE_NAME)) -lgcc
 
+-include local.mk
+
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
 CFLAGS += -g


### PR DESCRIPTION
This commit modifies the Makefile so that it will load the file
`local.mk` if it exists. This permits one to persistently set things
like port, speed, and flash mode.

This is the same as micropython/micropython#3757.