### PR TITLE
esp8266/modnetwork: Allow to get ESSID of AP that STA is connected to.

### DIFF
--- a/ports/esp8266/modnetwork.c
+++ b/ports/esp8266/modnetwork.c
@@ -410,8 +410,11 @@ STATIC mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
             return mp_obj_new_bytes(mac, sizeof(mac));
         }
         case QS(MP_QSTR_essid):
-            req_if = SOFTAP_IF;
-            val = mp_obj_new_str((char*)cfg.ap.ssid, cfg.ap.ssid_len, false);
+            if (self->if_id == STATION_IF) {
+                val = mp_obj_new_str((char*)cfg.sta.ssid, strlen((char*)cfg.sta.ssid), false);
+            } else {
+                val = mp_obj_new_str((char*)cfg.ap.ssid, cfg.ap.ssid_len, false);
+            }
             break;
         case QS(MP_QSTR_hidden):
             req_if = SOFTAP_IF;


### PR DESCRIPTION
This patch enables iface.config('essid') to work for both AP and STA
interfaces.

(cherry picked from commit d8fdb77ac91b578d851b873a004b530b42313cf1)