### PR TITLE
2.x: handle bad power on reset better

### DIFF
--- a/atmel-samd/asf/sam0/drivers/tc/tc.h
+++ b/atmel-samd/asf/sam0/drivers/tc/tc.h
@@ -48,7 +48,7 @@
 #define TC_H_INCLUDED
 
 /**
- * \defgroup asfdoc_sam0_tc_group SAM Timer/Counter (TC) Driver 
+ * \defgroup asfdoc_sam0_tc_group SAM Timer/Counter (TC) Driver
  *
  * This driver for Atmel&reg; | SMART ARM&reg;-based microcontrollers provides an interface for the configuration
  * and management of the timer modules within the device, for waveform
@@ -1146,12 +1146,14 @@ static inline void tc_enable_events(
 	/* Sanity check arguments */
 	Assert(module_inst);
 	Assert(module_inst->hw);
-	Assert(events);
+        Assert(events);
 
 	Tc *const tc_module = module_inst->hw;
 
 	uint32_t event_mask = 0;
 
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 	if (events->invert_event_input == true) {
 		event_mask |= TC_EVCTRL_TCINV;
 	}
@@ -1171,6 +1173,7 @@ static inline void tc_enable_events(
 	}
 
 	tc_module->COUNT8.EVCTRL.reg |= event_mask | events->event_action;
+        #pragma GCC diagnostic pop
 }
 
 /**

--- a/atmel-samd/main.h
+++ b/atmel-samd/main.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,31 +24,7 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
+// Functions defined in main.c that are useful elsewhere.
+// Eventually they should be factored out.
 
-#include "flash_api.h"
-#include "main.h"
-#include "py/mperrno.h"
-#include "py/runtime.h"
-#include "shared-bindings/microcontroller/__init__.h"
-#include "shared-bindings/storage/__init__.h"
-
-extern volatile bool mp_msc_enabled;
-
-void common_hal_storage_remount(const char* mount_path, bool readonly) {
-    if (strcmp(mount_path, "/") != 0) {
-        mp_raise_OSError(MP_EINVAL);
-    }
-
-    if (mp_msc_enabled) {
-        mp_raise_RuntimeError("Cannot remount '/' when USB is active.");
-    }
-
-    flash_set_usb_writeable(readonly);
-}
-
-void common_hal_storage_erase_filesystem(void) {
-    init_flash_fs(false, true);   // Force a re-format.
-    common_hal_mcu_reset();
-    // We won't actually get here, since we're resetting.
-}
+void init_flash_fs(bool create_allowed, bool force_create);

--- a/esp8266/common-hal/storage/__init__.c
+++ b/esp8266/common-hal/storage/__init__.c
@@ -32,3 +32,7 @@
 void common_hal_storage_remount(const char* mount_path, bool readonly) {
     mp_raise_NotImplementedError("");
 }
+
+void common_hal_storage_erase_filesystem() {
+    mp_raise_NotImplementedError("Use esptool to erase flash and re-upload Python instead");
+}

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -115,12 +115,32 @@ mp_obj_t storage_remount(mp_obj_t mount_path, mp_obj_t readonly) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(storage_remount_obj, storage_remount);
 
+//| .. function:: erase_filesystem()
+//|
+//|   Erase and re-create the ``CIRCUITPY`` filesystem. Then call
+//|   `microcontroller.reset()` to restart CircuitPython and have the
+//|   host computer remount CIRCUITPY.
+//|
+//|   This function can be called from the REPL when ``CIRCUITPY``
+//|   has become corrupted.
+//|
+//|   .. warning:: All the data on ``CIRCUITPY`` will be lost, and
+//|        CircuitPython will restart.
+
+mp_obj_t storage_erase_filesystem(void) {
+    common_hal_storage_erase_filesystem();
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_0(storage_erase_filesystem_obj, storage_erase_filesystem);
+
+
 STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_storage) },
 
     { MP_ROM_QSTR(MP_QSTR_mount), MP_ROM_PTR(&storage_mount_obj) },
     { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&storage_umount_obj) },
     { MP_ROM_QSTR(MP_QSTR_remount), MP_ROM_PTR(&storage_remount_obj) },
+    { MP_ROM_QSTR(MP_QSTR_erase_filesystem), MP_ROM_PTR(&storage_erase_filesystem_obj) },
 
     //| .. class:: VfsFat(block_device)
     //|

--- a/shared-bindings/storage/__init__.h
+++ b/shared-bindings/storage/__init__.h
@@ -34,5 +34,6 @@ void common_hal_storage_mount(mp_obj_t vfs_obj, const char* path, bool readonly)
 void common_hal_storage_umount_path(const char* path);
 void common_hal_storage_umount_object(mp_obj_t vfs_obj);
 void common_hal_storage_remount(const char* path, bool readonly);
+void common_hal_storage_erase_filesystem(void);
 
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_STORAGE___INIT___H


### PR DESCRIPTION
Fixes #280.

1. Do not write `boot_out.txt` if there's no `boot.py` or equivalent, and the version info in `boot_out.txt` will not change.
2. If there is a `boot.py`, wait 1.5 seconds before running it and writing its output to `boot_out.txt`.
3. Add `storage.erase_filesystem()` for ease of erasing filesystem (already in 3.0).
4. Change BOD33 brownout threshold to 2.77V for SAMD21.

This makes bouncy switched and plugged power connections much less likely to erase the filesystem.

The `main.h` file is a bit silly, but it's not worth refactoring `init_flash_fs()` out of `main.c` now, since 2.x is in maintenance mode.

I will port this to 3.0.