### PR TITLE
2.x: Fix regression preventing remount as readwrite in boot.py

### DIFF
--- a/atmel-samd/main.c
+++ b/atmel-samd/main.c
@@ -762,6 +762,11 @@ int main(void) {
             // USB isn't up, so we can write the file.
             flash_set_usb_writeable(false);
             f_open(fs, boot_output_file, CIRCUITPY_BOOT_OUTPUT_FILE, FA_WRITE | FA_CREATE_ALWAYS);
+
+            // Switch the filesystem back to non-writable by Python now instead of later,
+            // since boot.py might change it back to writable.
+            flash_set_usb_writeable(true);
+
             // Write version info to boot_out.txt.
             mp_hal_stdout_tx_str(MICROPY_FULL_VERSION_INFO);
             mp_hal_stdout_tx_str("\r\n");
@@ -779,7 +784,6 @@ int main(void) {
             flash_flush();
             boot_output_file = NULL;
         }
-        flash_set_usb_writeable(true);
         #endif
 
         // Reset to remove any state that boot.py setup. It should only be used to


### PR DESCRIPTION
2.3.0 moved a call setting root filesystem to readonly to _after_ `boot.py` execution, which meant that `boot.py` couldn't change the filesystem permission using `storage.remount()`. Fix this regression :(