### PR TITLE
enable cache in SAMD51

### DIFF
--- a/ports/atmel-samd/samd51_peripherals.c
+++ b/ports/atmel-samd/samd51_peripherals.c
@@ -163,3 +163,15 @@ void samd_peripherals_adc_setup(struct adc_sync_descriptor *adc, Adc *instance) 
     hri_adc_write_CALIB_BIASR2R_bf(instance, biasr2r);
     hri_adc_write_CALIB_BIASCOMP_bf(instance, biascomp);
 }
+
+// Turn off cache and invalidate all data in it.
+void samd_peripherals_disable_and_clear_cache(void) {
+    CMCC->CTRL.bit.CEN = 0;
+    while (CMCC->SR.bit.CSTS) {}
+    CMCC->MAINT0.bit.INVALL = 1;
+}
+
+// Enable cache
+void samd_peripherals_enable_cache(void) {
+    CMCC->CTRL.bit.CEN = 1;
+}

--- a/ports/atmel-samd/samd51_peripherals.h
+++ b/ports/atmel-samd/samd51_peripherals.h
@@ -35,4 +35,7 @@ uint8_t samd_peripherals_get_spi_dopo(uint8_t clock_pad, uint8_t mosi_pad);
 bool samd_peripherals_valid_spi_clock_pad(uint8_t clock_pad);
 void samd_peripherals_adc_setup(struct adc_sync_descriptor *adc, Adc *instance);
 
+void samd_peripherals_disable_and_clear_cache(void);
+void samd_peripherals_enable_cache(void);
+
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_SAMD51_PERIPHERALS_H

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -57,6 +57,7 @@
 #include "shared-bindings/rtc/__init__.h"
 #include "clocks.h"
 #include "events.h"
+#include "peripherals.h"
 #include "shared_dma.h"
 #include "tick.h"
 
@@ -105,9 +106,47 @@ safe_mode_t port_init(void) {
     SUPC->BOD33.bit.ENABLE = 0;
     SUPC->BOD33.bit.LEVEL = 200;  // 2.7V: 1.5V + LEVEL * 6mV.
     SUPC->BOD33.bit.ENABLE = 1;
+
+    // MPU (Memory Protection Unit) setup.
+    // We hoped we could make the QSPI region be non-cachable with the MPU,
+    // but the CMCC doesn't seem to pay attention to the MPU settings.
+    // Leaving this code here disabled,
+    // because it was hard enough to figure out, and maybe there's
+    // a mistake that could make it work in the future.
+#if 0
+    // Designate QSPI memory mapped region as not cachable.
+
+    // Turn off MPU in case it is on.
+    MPU->CTRL = 0;
+    // Configure region 0.
+    MPU->RNR = 0;
+    // Region base: start of QSPI mapping area.
+    // QSPI region runs from 0x04000000 up to and not including 0x05000000: 16 megabytes
+    MPU->RBAR = QSPI_AHB;
+    MPU->RASR =
+        0b011 << MPU_RASR_AP_Pos |     // full read/write access for privileged and user mode
+        0b000 << MPU_RASR_TEX_Pos |    // caching not allowed, strongly ordered
+        1 << MPU_RASR_S_Pos |          // sharable
+        0 << MPU_RASR_C_Pos |          // not cachable
+        0 << MPU_RASR_B_Pos |          // not bufferable
+        0b10111 << MPU_RASR_SIZE_Pos | // 16MB region size
+        1 << MPU_RASR_ENABLE_Pos       // enable this region
+        ;
+    // Turn off regions 1-7.
+    for (uint32_t i = 1; i < 8; i ++) {
+        MPU->RNR = i;
+        MPU->RBAR = 0;
+        MPU->RASR = 0;
+    }
+
+    // Turn on MPU. Turn on PRIVDEFENA, which defines a default memory
+    // map for all privileged access, so we don't have to set up other regions
+    // besides QSPI.
+    MPU->CTRL = MPU_CTRL_PRIVDEFENA_Msk | MPU_CTRL_ENABLE_Msk;
 #endif
 
-
+    samd_peripherals_enable_cache();
+#endif
 
 // On power on start or external reset, set _ezero to the canary word. If it
 // gets killed, we boot in safe mode. _ezero is the boundary between statically


### PR DESCRIPTION
Enable instruction/data cache.

I did some smoke testing on this: CIRCUITPY seems OK (read and wrote files) and I tested a BMP280 in I2C mode.

Helper routines added to enable cache and disable-and-clear cache.

QSPI memory mapping does not play well with cache. Turn cache off and clear before any QSPI memory reads/writes, and re-enable when done.

I tried to use the MPU peripheral (built into the CPU) to disable cache in the QSPI_AHB region, but that did not seem to work. Cache seemed to be enabled there anyway. The MPU does seem to work in the way I would expect it to. Left MPU code in, disabled by `#if 0`, in case it would be useful in the future, since it was tedious to figure out.

Tidied up setting of QSPI.INSTRFRAME register in one place. It's supposed to be set all in one go, because setting it can initiate actions. Also, it's supposed to be read to force a synchronization in certain places. Didn't seem to matter, but I'm following what the datasheet says.