### PR TITLE
add keyword timeout to I2C -- only used for bitbangioi

### DIFF
--- a/ports/atmel-samd/common-hal/busio/I2C.c
+++ b/ports/atmel-samd/common-hal/busio/I2C.c
@@ -41,7 +41,7 @@
 #define ATTEMPTS 2
 
 void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
-        const mcu_pin_obj_t* scl, const mcu_pin_obj_t* sda, uint32_t frequency) {
+        const mcu_pin_obj_t* scl, const mcu_pin_obj_t* sda, uint32_t frequency, uint32_t timeout) {
     Sercom* sercom = NULL;
     uint8_t sercom_index;
     uint32_t sda_pinmux = 0;

--- a/ports/nrf/common-hal/busio/I2C.c
+++ b/ports/nrf/common-hal/busio/I2C.c
@@ -32,7 +32,7 @@
 #include "pins.h"
 #include "nrf.h"
 
-void common_hal_busio_i2c_construct(busio_i2c_obj_t *self, const mcu_pin_obj_t* scl, const mcu_pin_obj_t* sda, uint32_t frequency) {
+void common_hal_busio_i2c_construct(busio_i2c_obj_t *self, const mcu_pin_obj_t* scl, const mcu_pin_obj_t* sda, uint32_t frequency, uint32_t timeout ) {
     if (scl->pin == sda->pin) {
         mp_raise_ValueError("Invalid pins");
     }

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -275,9 +275,7 @@ MP_DEFINE_EXCEPTION(Exception, BaseException)
     MP_DEFINE_EXCEPTION(UnboundLocalError, NameError)
     */
   MP_DEFINE_EXCEPTION(OSError, Exception)
-#if MICROPY_PY_BUILTINS_TIMEOUTERROR
-    MP_DEFINE_EXCEPTION(TimeoutError, OSError)
-#endif
+  MP_DEFINE_EXCEPTION(TimeoutError, OSError)
     /*
     MP_DEFINE_EXCEPTION(BlockingIOError, OSError)
     MP_DEFINE_EXCEPTION(ChildProcessError, OSError)

--- a/shared-bindings/bitbangio/I2C.c
+++ b/shared-bindings/bitbangio/I2C.c
@@ -35,6 +35,7 @@
 #include "lib/utils/context_manager_helpers.h"
 #include "py/mperrno.h"
 #include "py/runtime.h"
+
 //| .. currentmodule:: bitbangio
 //|
 //| :class:`I2C` --- Two wire serial protocol
@@ -49,6 +50,7 @@
 //|   :param ~microcontroller.Pin scl: The clock pin
 //|   :param ~microcontroller.Pin sda: The data pin
 //|   :param int frequency: The clock frequency of the bus
+//|   :param int timeout: The maximum clock stretching timeout in microseconds
 //|
 STATIC mp_obj_t bitbangio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
     mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
@@ -57,11 +59,12 @@ STATIC mp_obj_t bitbangio_i2c_make_new(const mp_obj_type_t *type, size_t n_args,
     self->base.type = &bitbangio_i2c_type;
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
-    enum { ARG_scl, ARG_sda, ARG_frequency };
+    enum { ARG_scl, ARG_sda, ARG_frequency, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_frequency, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 400000} },
+        { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 255} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -69,7 +72,7 @@ STATIC mp_obj_t bitbangio_i2c_make_new(const mp_obj_type_t *type, size_t n_args,
     assert_pin(args[ARG_sda].u_obj, false);
     const mcu_pin_obj_t* scl = MP_OBJ_TO_PTR(args[ARG_scl].u_obj);
     const mcu_pin_obj_t* sda = MP_OBJ_TO_PTR(args[ARG_sda].u_obj);
-    shared_module_bitbangio_i2c_construct(self, scl, sda, args[ARG_frequency].u_int);
+    shared_module_bitbangio_i2c_construct(self, scl, sda, args[ARG_frequency].u_int, args[ARG_timeout].u_int);
     return (mp_obj_t)self;
 }
 

--- a/shared-bindings/bitbangio/I2C.h
+++ b/shared-bindings/bitbangio/I2C.h
@@ -39,7 +39,8 @@ extern const mp_obj_type_t bitbangio_i2c_type;
 extern void shared_module_bitbangio_i2c_construct(bitbangio_i2c_obj_t *self,
                                                   const mcu_pin_obj_t * scl,
                                                   const mcu_pin_obj_t * sda,
-                                                  uint32_t frequency);
+                                                  uint32_t frequency,
+                                                  uint32_t us_timeout);
 
 extern void shared_module_bitbangio_i2c_deinit(bitbangio_i2c_obj_t *self);
 extern bool shared_module_bitbangio_i2c_deinited(bitbangio_i2c_obj_t *self);

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -56,6 +56,7 @@
 //|   :param ~microcontroller.Pin scl: The clock pin
 //|   :param ~microcontroller.Pin sda: The data pin
 //|   :param int frequency: The clock frequency in Hertz
+//|   :param int timeout: The maximum clock stretching timeut - only for bitbang
 //|
 STATIC mp_obj_t busio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
     mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
@@ -63,11 +64,12 @@ STATIC mp_obj_t busio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
     self->base.type = &busio_i2c_type;
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
-    enum { ARG_scl, ARG_sda, ARG_frequency };
+    enum { ARG_scl, ARG_sda, ARG_frequency, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_frequency, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 400000} },
+        { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 255} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -77,7 +79,7 @@ STATIC mp_obj_t busio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
     assert_pin_free(scl);
     const mcu_pin_obj_t* sda = MP_OBJ_TO_PTR(args[ARG_sda].u_obj);
     assert_pin_free(sda);
-    common_hal_busio_i2c_construct(self, scl, sda, args[ARG_frequency].u_int);
+    common_hal_busio_i2c_construct(self, scl, sda, args[ARG_frequency].u_int, args[ARG_timeout].u_int);
     return (mp_obj_t)self;
 }
 

--- a/shared-bindings/busio/I2C.h
+++ b/shared-bindings/busio/I2C.h
@@ -46,7 +46,8 @@ extern const mp_obj_type_t busio_i2c_type;
 extern void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
                                               const mcu_pin_obj_t * scl,
                                               const mcu_pin_obj_t * sda,
-                                              uint32_t frequency);
+                                              uint32_t frequency,
+                                              uint32_t timeout);
 
 extern void common_hal_busio_i2c_deinit(busio_i2c_obj_t *self);
 extern bool common_hal_busio_i2c_deinited(busio_i2c_obj_t *self);

--- a/shared-module/bitbangio/I2C.c
+++ b/shared-module/bitbangio/I2C.c
@@ -28,6 +28,7 @@
 #include "py/mperrno.h"
 #include "py/nlr.h"
 #include "py/obj.h"
+#include "py/runtime.h"
 
 #include "common-hal/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/__init__.h"
@@ -54,8 +55,8 @@ STATIC void scl_release(bitbangio_i2c_obj_t *self) {
         common_hal_mcu_delay_us(1);
     }
     if(count==0) { /// raise exception on timeout
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_TimeoutError,
-            "Clock Stretching Timeout."));
+        mp_raise_msg(&mp_type_TimeoutError,
+           "Clock Stretching Timeout.");
     }
 }
 

--- a/shared-module/bitbangio/I2C.c
+++ b/shared-module/bitbangio/I2C.c
@@ -26,7 +26,6 @@
 
 #include "shared-bindings/bitbangio/I2C.h"
 #include "py/mperrno.h"
-#include "py/nlr.h"
 #include "py/obj.h"
 #include "py/runtime.h"
 

--- a/shared-module/bitbangio/types.h
+++ b/shared-module/bitbangio/types.h
@@ -36,6 +36,7 @@ typedef struct {
     digitalio_digitalinout_obj_t scl;
     digitalio_digitalinout_obj_t sda;
     uint32_t us_delay;
+    uint32_t us_timeout;
     volatile bool locked;
 } bitbangio_i2c_obj_t;
 

--- a/shared-module/busio/I2C.c
+++ b/shared-module/busio/I2C.c
@@ -30,8 +30,8 @@
 #include "py/nlr.h"
 
 void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
-        const mcu_pin_obj_t* scl, const mcu_pin_obj_t* sda, uint32_t freq) {
-    shared_module_bitbangio_i2c_construct(&self->bitbang, scl, sda, freq);
+        const mcu_pin_obj_t* scl, const mcu_pin_obj_t* sda, uint32_t freq, uint32_t timeout) {
+    shared_module_bitbangio_i2c_construct(&self->bitbang, scl, sda, freq, timeout);
 }
 
 bool common_hal_busio_i2c_deinited(busio_i2c_obj_t *self) {


### PR DESCRIPTION
Implemented the keyword "timeout" for bitbangio I2C clock-stretching  ( based on code in extmod/machine_i2c.c)  --- also added the keyword to busio to keep the API consistent, but it is ignored for busio.

If a timeout occurs a TimeoutError Exception is thrown.