### PR TITLE
Human readable OSError messages

### DIFF
--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -188,6 +188,8 @@ extern const struct _mp_obj_module_t usb_hid_module;
     #define MICROPY_PY_BUILTINS_FROZENSET (1)
     #define MICROPY_PY_BUILTINS_STR_SPLITLINES (1)
     #define MICROPY_PY_BUILTINS_REVERSED (1)
+    #define MICROPY_PY_UERRNO (1)
+    #define MICROPY_PY_UERRNO_ERRORCODE (0)
     #define MICROPY_PY_URE (1)
     #define MICROPY_PY_MICROPYTHON_MEM_INFO (1)
     #define MICROPY_PY_FRAMEBUF         (1)

--- a/py/moduerrno.c
+++ b/py/moduerrno.c
@@ -100,6 +100,20 @@ const mp_obj_module_t mp_module_uerrno = {
 };
 
 qstr mp_errno_to_str(mp_obj_t errno_val) {
+    // For commonly encountered errors, return human readable strings
+    if (MP_OBJ_IS_SMALL_INT(errno_val)) {
+        switch (MP_OBJ_SMALL_INT_VALUE(errno_val)) {
+            case EPERM:  return MP_QSTR_Permission_space_denied;
+            case ENOENT: return MP_QSTR_No_space_such_space_file_slash_directory;
+            case EIO:    return MP_QSTR_Input_slash_output_space_error;
+            case EACCES: return MP_QSTR_Permission_space_denied;
+            case EEXIST: return MP_QSTR_File_space_exists;
+            case ENODEV: return MP_QSTR_Unsupported_space_operation;
+            case EINVAL: return MP_QSTR_Invalid_space_argument;
+        }
+    }
+
+    // Otherwise, return the Exxxx string for that error code
     #if MICROPY_PY_UERRNO_ERRORCODE
     // We have the errorcode dict so can do a lookup using the hash map
     mp_map_elem_t *elem = mp_map_lookup((mp_map_t*)&errorcode_dict.map, errno_val, MP_MAP_LOOKUP);

--- a/tests/basics/errno1.py
+++ b/tests/basics/errno1.py
@@ -11,7 +11,10 @@ print(type(uerrno.EIO))
 
 # check that errors are rendered in a nice way
 msg = str(OSError(uerrno.EIO))
-print(msg[:7], msg[-5:])
+print(msg[:7], msg[msg.find(']'):])
+
+msg = str(OSError(uerrno.ENOBUFS))
+print(msg[:7], msg[msg.find(']'):])
 
 # check that unknown errno is still rendered
 print(str(OSError(9999)))

--- a/tests/basics/errno1.py.exp
+++ b/tests/basics/errno1.py.exp
@@ -1,3 +1,4 @@
 <class 'int'>
-[Errno  ] EIO
+[Errno  ] Input/output error
+[Errno  ] ENOBUFS
 9999


### PR DESCRIPTION
For several common errnos, include a human-friendly string in the exception string.  For now, only enable this on boards with external SPI flash, because pulling the `uerrno` module in eats up an extra 1kb of flash.

Likewise, this only adds error strings for common exceptions to avoid using flash unnecessarily - others will just show up as the EXXX string, but meaningful descriptions can be added later if needed.

Tested with a Feather M0 Express REPL:

    Adafruit CircuitPython 3.0.0-alpha.6-75-gcb8c159-dirty on 2018-05-14; Adafruit Feather M0 Express with samd21g18
    >>> import uerrno
    >>> for err in dir(uerrno):
    ...     if err.startswith('E'):
    ...         print(OSError(getattr(uerrno, err)))
    ...
    ...
    ...
    [Errno 1] Permission denied
    [Errno 2] No such file/directory
    [Errno 5] Input/output error
    [Errno 9] EBADF
    [Errno 11] EAGAIN
    [Errno 12] ENOMEM
    [Errno 13] Permission denied
    [Errno 17] File exists
    [Errno 19] Unsupported operation
    [Errno 21] EISDIR
    [Errno 22] Invalid argument
    [Errno 95] EOPNOTSUPP
    [Errno 112] EADDRINUSE
    [Errno 113] ECONNABORTED
    [Errno 104] ECONNRESET
    [Errno 105] ENOBUFS
    [Errno 128] ENOTCONN
    [Errno 116] ETIMEDOUT
    [Errno 111] ECONNREFUSED
    [Errno 118] EHOSTUNREACH
    [Errno 120] EALREADY
    [Errno 119] EINPROGRESS

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>