### PR TITLE
Add precise_time module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ Modules
    Therefore, code from CircuitPython is runnable on CPython but not
    necessarily the reverse.
 -  tick count is available as
-   `time.monotonic() <https://circuitpython.readthedocs.io/en/latest/shared-bindings/time/__init__.html#time.monotonic>`__
+   `time.monotonic() <https://circuitpython.readthedocs.io/en/latest/shared-bindings/time/__init__.html#time.monotonic>`__ (returns a float) or `precise_time.monotonic() <https://circuitpython.readthedocs.io/en/latest/shared-bindings/precise_time/__init__.html#precise_time.monotonic>`__ (returns an int).
 
 atmel-samd21 features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -298,6 +298,7 @@ SRC_COMMON_HAL = \
 	analogio/AnalogOut.c \
 	nvm/__init__.c \
 	nvm/ByteArray.c \
+	precise_time/__init__.c \
 	pulseio/__init__.c \
 	pulseio/PulseIn.c \
 	pulseio/PulseOut.c \

--- a/ports/atmel-samd/common-hal/precise_time/__init__.c
+++ b/ports/atmel-samd/common-hal/precise_time/__init__.c
@@ -24,12 +24,16 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_PRECISE_TIME__INIT__H
-#define MICROPY_INCLUDED_SHARED_BINDINGS_PRECISE_TIME__INIT__H
+#include "py/mphal.h"
 
-#include <stdint.h>
+#include "shared-bindings/precise_time/__init__.h"
 
-extern uint64_t common_hal_precise_time_monotonic(void);
-extern void common_hal_precise_time_delay_ms(uint32_t);
+#include "tick.h"
 
-#endif  // MICROPY_INCLUDED_SHARED_BINDINGS_PRECISE_TIME__INIT__H
+inline uint64_t common_hal_precise_time_monotonic() {
+    return ticks_ms;
+}
+
+void common_hal_precise_time_delay_ms(uint32_t delay) {
+    mp_hal_delay_ms(delay);
+}

--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -165,6 +165,7 @@ extern const struct _mp_obj_module_t busio_module;
 extern const struct _mp_obj_module_t board_module;
 extern const struct _mp_obj_module_t math_module;
 extern const struct _mp_obj_module_t os_module;
+extern const struct _mp_obj_module_t precise_time_module;
 extern const struct _mp_obj_module_t random_module;
 extern const struct _mp_obj_module_t rtc_module;
 extern const struct _mp_obj_module_t samd_module;
@@ -243,6 +244,7 @@ extern const struct _mp_obj_module_t usb_hid_module;
     { MP_OBJ_NEW_QSTR(MP_QSTR_supervisor), (mp_obj_t)&supervisor_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_math), (mp_obj_t)&math_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_time), (mp_obj_t)&time_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_precise_time), (mp_obj_t)&precise_time_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_usb_hid),(mp_obj_t)&usb_hid_module }, \
     EXTRA_BUILTIN_MODULES
 

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -118,6 +118,7 @@ SRC_COMMON_HAL = \
 	multiterminal/__init__.c \
 	neopixel_write/__init__.c \
 	os/__init__.c \
+	precise_time/__init__.c \
 	storage/__init__.c \
 	time/__init__.c \
 	board/__init__.c

--- a/ports/esp8266/common-hal/precise_time/__init__.c
+++ b/ports/esp8266/common-hal/precise_time/__init__.c
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Margaret Sy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mphal.h"
+
+#include "shared-bindings/precise_time/__init__.h"
+
+#include "ets_alt_task.h"
+#include "user_interface.h"
+
+inline uint64_t common_hal_precise_time_monotonic() {
+    return ((uint64_t)system_time_high_word << 32 | (uint64_t)system_get_time()) / 1000;
+}
+
+void common_hal_precise_time_delay_ms(uint32_t delay) {
+    mp_hal_delay_ms(delay);
+}

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -173,6 +173,7 @@ extern const struct _mp_obj_module_t pulseio_module;
 extern const struct _mp_obj_module_t busio_module;
 extern const struct _mp_obj_module_t bitbangio_module;
 extern const struct _mp_obj_module_t time_module;
+extern const struct _mp_obj_module_t precise_time_module;
 extern const struct _mp_obj_module_t multiterminal_module;
 extern const struct _mp_obj_module_t neopixel_write_module;
 
@@ -196,6 +197,7 @@ extern const struct _mp_obj_module_t neopixel_write_module;
     { MP_OBJ_NEW_QSTR(MP_QSTR_struct), (mp_obj_t)&struct_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_math), (mp_obj_t)&math_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_time), (mp_obj_t)&time_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_precise_time), (mp_obj_t)&precise_time_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_multiterminal), (mp_obj_t)&multiterminal_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_neopixel_write),(mp_obj_t)&neopixel_write_module }, \
 

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -196,6 +196,7 @@ SRC_COMMON_HAL += \
 	microcontroller/Processor.c \
 	os/__init__.c \
 	time/__init__.c \
+	precise_time/__init__.c \
 	analogio/__init__.c \
 	analogio/AnalogIn.c \
 	analogio/AnalogOut.c \

--- a/ports/nrf/common-hal/precise_time/__init__.c
+++ b/ports/nrf/common-hal/precise_time/__init__.c
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Margaret Sy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mphal.h"
+
+#include "shared-bindings/precise_time/__init__.h"
+#include "tick.h"
+
+inline uint64_t common_hal_precise_time_monotonic() {
+  return ticks_ms;
+}
+
+void common_hal_precise_time_delay_ms(uint32_t delay) {
+    mp_hal_delay_ms(delay);
+}

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -221,6 +221,7 @@ extern const struct _mp_obj_module_t pulseio_module;
 extern const struct _mp_obj_module_t busio_module;
 extern const struct _mp_obj_module_t board_module;
 extern const struct _mp_obj_module_t os_module;
+extern const struct _mp_obj_module_t precise_time;
 extern const struct _mp_obj_module_t random_module;
 extern const struct _mp_obj_module_t storage_module;
 extern const struct _mp_obj_module_t struct_module;
@@ -271,8 +272,9 @@ extern const struct _mp_obj_module_t ble_module;
     { MP_OBJ_NEW_QSTR (MP_QSTR_microcontroller ), (mp_obj_t)&microcontroller_module }, \
     { MP_OBJ_NEW_QSTR (MP_QSTR_bitbangio       ), (mp_obj_t)&bitbangio_module       }, \
     { MP_OBJ_NEW_QSTR (MP_QSTR_os              ), (mp_obj_t)&os_module              }, \
+    { MP_OBJ_NEW_QSTR (MP_QSTR_precise_time    ), (mp_obj_t)&precise_time_module    }, \
     { MP_OBJ_NEW_QSTR (MP_QSTR_random          ), (mp_obj_t)&random_module          }, \
-    { MP_OBJ_NEW_QSTR (MP_QSTR_storage         ), (mp_obj_t)&storage_module         },\
+    { MP_OBJ_NEW_QSTR (MP_QSTR_storage         ), (mp_obj_t)&storage_module         }, \
     { MP_OBJ_NEW_QSTR (MP_QSTR_struct          ), (mp_obj_t)&struct_module          }, \
     { MP_OBJ_NEW_QSTR (MP_QSTR_supervisor      ), (mp_obj_t)&supervisor_module      }, \
     { MP_OBJ_NEW_QSTR (MP_QSTR_gamepad         ), (mp_obj_t)&gamepad_module         }, \

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -221,7 +221,7 @@ extern const struct _mp_obj_module_t pulseio_module;
 extern const struct _mp_obj_module_t busio_module;
 extern const struct _mp_obj_module_t board_module;
 extern const struct _mp_obj_module_t os_module;
-extern const struct _mp_obj_module_t precise_time;
+extern const struct _mp_obj_module_t precise_time_module;
 extern const struct _mp_obj_module_t random_module;
 extern const struct _mp_obj_module_t storage_module;
 extern const struct _mp_obj_module_t struct_module;

--- a/shared-bindings/precise_time/__init__.c
+++ b/shared-bindings/precise_time/__init__.c
@@ -30,11 +30,11 @@
 #include "shared-bindings/precise_time/__init__.h"
 
 //| :mod: `precise_time` --- integer time and timing related functions
-//| ====================================================================
+//| =======================================================================
 //|
 //| .. module:: precise_time
-//|    :synopsis: integer time related functions
-//|    :platform: SAMD21
+//|   :synopsis: integer time related functions
+//|   :platform: SAMD21
 //|
 //| The `precise_time` module. See the `time` module instead for an API that is
 //| also available in CPython.

--- a/shared-bindings/precise_time/__init__.c
+++ b/shared-bindings/precise_time/__init__.c
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Margaret Sy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "shared-bindings/precise_time/__init__.h"
+
+//| :mod: `precise_time` --- integer time and timing related functions
+//| ====================================================================
+//|
+//| .. module:: precise_time
+//|    :synopsis: integer time related functions
+//|    :platform: SAMD21
+//|
+//| The `precise_time` module 
+//|
+//| .. method:: monotonic()
+//|
+//|   Returns an always increasing value of time with an unknown reference
+//|   point. Only use it to compare against other values from `monotonic`.
+//|   Unlike time.monotonic, which is a float, the precision of this does not
+//|   degrade over time.
+//|
+//|   :return: the current monotonic time
+//|   :rtype: int
+//|
+STATIC mp_obj_t precise_time_monotonic(void) {
+    return common_hal_time_monotonic();
+}
+MP_DEFINE_CONST_FUN_OBJ_0(precise_time_monotonic_obj, precise_time_monotonic)
+
+STATIC const mp_rom_map_elem_t precise_time_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR__name__), MP_ROM_QSTR(MP_QSTR_precise_time) },
+
+    { MP_ROM_QSTR(MP_QSTR_monotonic), MP_ROM_PTR(&precise_time_monotonic_obj) }
+};
+
+STATIC MP_DEFINE_CONST_DICT(precise_time_module_globals, precise_time_module_globals_table);
+
+const mp_obj_module_t precise_time_module = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&time_module_globals,
+};

--- a/shared-bindings/precise_time/__init__.c
+++ b/shared-bindings/precise_time/__init__.c
@@ -27,6 +27,7 @@
 #include <string.h>
 
 #include "py/obj.h"
+#include "py/runtime.h"
 #include "shared-bindings/precise_time/__init__.h"
 
 //| :mod: `precise_time` --- integer time and timing related functions
@@ -54,10 +55,27 @@ STATIC mp_obj_t precise_time_monotonic(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(precise_time_monotonic_obj, precise_time_monotonic);
 
+//| .. method:: sleep(milliseconds)
+//|
+//|   Sleep for a given number of milliseconds.
+//|
+//|   :param int seconds: the time to sleep in milliseconds
+//|
+STATIC mp_obj_t precise_time_sleep(mp_obj_t milliseconds_o) {
+    int milliseconds = mp_obj_get_int(milliseconds_o);
+    if (milliseconds < 0) {
+        mp_raise_ValueError("sleep length must be non-negative");
+    }
+    common_hal_precise_time_delay_ms(milliseconds);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(precise_time_sleep_obj, precise_time_sleep);
+
 STATIC const mp_rom_map_elem_t precise_time_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR__name__), MP_ROM_QSTR(MP_QSTR_precise_time) },
 
-    { MP_ROM_QSTR(MP_QSTR_monotonic), MP_ROM_PTR(&precise_time_monotonic_obj) }
+    { MP_ROM_QSTR(MP_QSTR_monotonic), MP_ROM_PTR(&precise_time_monotonic_obj) },
+    { MP_ROM_QSTR(MP_QSTR_sleep), MP_ROM_PTR(&precise_time_sleep_obj) }
 };
 
 STATIC MP_DEFINE_CONST_DICT(precise_time_module_globals, precise_time_module_globals_table);

--- a/shared-bindings/precise_time/__init__.c
+++ b/shared-bindings/precise_time/__init__.c
@@ -33,14 +33,15 @@
 //|    :synopsis: integer time related functions
 //|    :platform: SAMD21
 //|
-//| The `precise_time` module 
+//| The `precise_time` module. See the `time` module instead for an API that is
+//| also available in CPython.
 //|
 //| .. method:: monotonic()
 //|
 //|   Returns an always increasing value of time with an unknown reference
 //|   point. Only use it to compare against other values from `monotonic`.
-//|   Unlike time.monotonic, which is a float, the precision of this does not
-//|   degrade over time.
+//|   Unlike time.monotonic, which is a float, precise_time.monotonic returns an
+//|   int so precision will not degrade over time.
 //|
 //|   :return: the current monotonic time
 //|   :rtype: int

--- a/shared-bindings/precise_time/__init__.c
+++ b/shared-bindings/precise_time/__init__.c
@@ -24,6 +24,9 @@
  * THE SOFTWARE.
  */
 
+#include <string.h>
+
+#include "py/obj.h"
 #include "shared-bindings/precise_time/__init__.h"
 
 //| :mod: `precise_time` --- integer time and timing related functions
@@ -47,9 +50,9 @@
 //|   :rtype: int
 //|
 STATIC mp_obj_t precise_time_monotonic(void) {
-    return common_hal_time_monotonic();
+    return mp_obj_new_int_from_uint(common_hal_precise_time_monotonic());
 }
-MP_DEFINE_CONST_FUN_OBJ_0(precise_time_monotonic_obj, precise_time_monotonic)
+MP_DEFINE_CONST_FUN_OBJ_0(precise_time_monotonic_obj, precise_time_monotonic);
 
 STATIC const mp_rom_map_elem_t precise_time_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR__name__), MP_ROM_QSTR(MP_QSTR_precise_time) },
@@ -61,5 +64,5 @@ STATIC MP_DEFINE_CONST_DICT(precise_time_module_globals, precise_time_module_glo
 
 const mp_obj_module_t precise_time_module = {
     .base = { &mp_type_module },
-    .globals = (mp_obj_dict_t*)&time_module_globals,
+    .globals = (mp_obj_dict_t*)&precise_time_module_globals,
 };

--- a/shared-bindings/precise_time/__init__.c
+++ b/shared-bindings/precise_time/__init__.c
@@ -30,7 +30,7 @@
 #include "py/runtime.h"
 #include "shared-bindings/precise_time/__init__.h"
 
-//| :mod: `precise_time` --- integer time and timing related functions
+//| :mod:`precise_time` --- integer time and timing related functions
 //| =======================================================================
 //|
 //| .. module:: precise_time

--- a/shared-bindings/precise_time/__init__.h
+++ b/shared-bindings/precise_time/__init__.h
@@ -29,7 +29,7 @@
 
 #include <stdint.h>
 
-extern uint63_t common_hal_time_monotonic(void)
-extern void common_hal_time_delay_ms(uint32_t)
+extern uint63_t common_hal_time_monotonic(void);
+extern void common_hal_time_delay_ms(uint32_t);
 
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_PRECISE_TIME__INIT__H

--- a/shared-bindings/precise_time/__init__.h
+++ b/shared-bindings/precise_time/__init__.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Margaret Sy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_PRECISE_TIME__INIT__H
+#define MICROPY_INCLUDED_SHARED_BINDINGS_PRECISE_TIME__INIT__H
+
+#include <stdint.h>
+
+extern uint63_t common_hal_time_monotonic(void)
+extern void common_hal_time_delay_ms(uint32_t)
+
+#endif  // MICROPY_INCLUDED_SHARED_BINDINGS_PRECISE_TIME__INIT__H


### PR DESCRIPTION
## Changes
This adds the `precise_time` module which exposes system ticks as an int.

I'm pretty much just going off of `shared-bindings/time/` and https://github.com/adafruit/circuitpython/blob/master/docs/common_hal.md 

I basically copy-pasted the `common-hal/time/__init__.*` to `common-hal/precise_time/__init__.*`. Not sure if there's a way to get the `shared_bindings/precise_time` files to use the ones from `common-hal/time/` instead.

## Testing
See comments. Manually tested only on gemma m0 board (that is the board I have).

## Status 👀 
Addressing review comments.

Edit 2018-06-01: planning to finish this this weekend 🐌 

## Issue
https://github.com/adafruit/circuitpython/issues/519 – More accurate time reporting