### PR TITLE
3.0: wasn't always clearing boot_output_file

### DIFF
--- a/main.c
+++ b/main.c
@@ -329,8 +329,8 @@ int __attribute__((used)) main(void) {
         if (!skip_boot_output) {
             f_close(boot_output_file);
             filesystem_flush();
-            boot_output_file = NULL;
         }
+        boot_output_file = NULL;
         #endif
 
         // Reset to remove any state that boot.py setup. It should only be used to


### PR DESCRIPTION
`boot_output_file` was not set to NULL after if `boot_out.txt` did not need to be written, so running `code.py` would try to write to `boot_out.txt` with a file descriptor that had junk in it. Usually this caused no problem, but recent merges apparently made this more likely to cause a hard fault.

Fixes #847