### PR TITLE
2.x: wasn't always clearing boot_output_file

### DIFF
--- a/atmel-samd/main.c
+++ b/atmel-samd/main.c
@@ -782,8 +782,8 @@ int main(void) {
         if (!skip_boot_output) {
             f_close(boot_output_file);
             flash_flush();
-            boot_output_file = NULL;
         }
+        boot_output_file = NULL;
         #endif
 
         // Reset to remove any state that boot.py setup. It should only be used to


### PR DESCRIPTION
2.x version of #848.

This didn't actually cause 2.x crashes, but it's still wrong and needs to be fixed.