### PR TITLE
Multiple fixes in gamepad

### DIFF
--- a/shared-bindings/gamepad/GamePad.c
+++ b/shared-bindings/gamepad/GamePad.c
@@ -94,9 +94,12 @@ gamepad_obj_t* volatile gamepad_singleton = NULL;
 //|
 STATIC mp_obj_t gamepad_make_new(const mp_obj_type_t *type, size_t n_args,
         size_t n_kw, const mp_obj_t *args) {
+    if (n_args > 8) {
+        mp_raise_TypeError("too many arguments");
+    }
     for (size_t i = 0; i < n_args; ++i) {
         if (!MP_OBJ_IS_TYPE(args[i], &digitalio_digitalinout_type)) {
-            mp_raise_TypeError("Expected a DigitalInOut");
+            mp_raise_TypeError("expected a DigitalInOut");
         }
         digitalio_digitalinout_obj_t *pin = MP_OBJ_TO_PTR(args[i]);
         raise_error_if_deinited(

--- a/shared-bindings/gamepad/GamePad.c
+++ b/shared-bindings/gamepad/GamePad.c
@@ -31,7 +31,7 @@
 #include "GamePad.h"
 
 
-gamepad_obj_t* gamepad_singleton = NULL;
+gamepad_obj_t* volatile gamepad_singleton = NULL;
 
 //| .. currentmodule:: gamepad
 //|

--- a/shared-bindings/gamepad/GamePad.c
+++ b/shared-bindings/gamepad/GamePad.c
@@ -32,7 +32,7 @@
 #include "GamePad.h"
 
 
-gamepad_obj_t* volatile gamepad_singleton = NULL;
+gamepad_obj_t* gamepad_singleton = NULL;
 
 //| .. currentmodule:: gamepad
 //|

--- a/shared-bindings/gamepad/GamePad.c
+++ b/shared-bindings/gamepad/GamePad.c
@@ -119,9 +119,8 @@ STATIC mp_obj_t gamepad_make_new(const mp_obj_type_t *type, size_t n_args,
 //|         held down) can be recorded for the next call.
 //|
 STATIC mp_obj_t gamepad_get_pressed(mp_obj_t self_in) {
-    gamepad_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_obj_t gamepad = MP_OBJ_NEW_SMALL_INT(self->pressed);
-    self->pressed = 0;
+    mp_obj_t gamepad = MP_OBJ_NEW_SMALL_INT(gamepad_singleton->pressed);
+    gamepad_singleton->pressed = 0;
     return gamepad;
 }
 MP_DEFINE_CONST_FUN_OBJ_1(gamepad_get_pressed_obj, gamepad_get_pressed);

--- a/shared-module/gamepad/GamePad.c
+++ b/shared-module/gamepad/GamePad.c
@@ -35,13 +35,12 @@
 
 
 void gamepad_init(size_t n_pins, const mp_obj_t* pins) {
-    for (size_t i=0; i<8; ++i) {
+    for (size_t i = 0; i < 8; ++i) {
         gamepad_singleton->pins[i] = NULL;
     }
     gamepad_singleton->pulls = 0;
-    for (size_t i=0; i<n_pins; ++i) {
+    for (size_t i = 0; i < n_pins; ++i) {
         digitalio_digitalinout_obj_t *pin = MP_OBJ_TO_PTR(pins[i]);
-        raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(pin));
         digitalio_direction_t direction = common_hal_digitalio_digitalinout_get_direction(pin);
         if (direction != DIRECTION_INPUT) {
             common_hal_digitalio_digitalinout_switch_to_input(pin, PULL_UP);

--- a/shared-module/gamepad/GamePad.c
+++ b/shared-module/gamepad/GamePad.c
@@ -38,13 +38,20 @@ void gamepad_init(size_t n_pins, const mp_obj_t* pins) {
     for (size_t i=0; i<8; ++i) {
         gamepad_singleton->pins[i] = NULL;
     }
+    gamepad_singleton->pulls = 0;
     for (size_t i=0; i<n_pins; ++i) {
         digitalio_digitalinout_obj_t *pin = MP_OBJ_TO_PTR(pins[i]);
         raise_error_if_deinited(common_hal_digitalio_digitalinout_deinited(pin));
         digitalio_direction_t direction = common_hal_digitalio_digitalinout_get_direction(pin);
-        digitalio_pull_t pull = common_hal_digitalio_digitalinout_get_pull(pin);
-        if (direction != DIRECTION_INPUT || pull == PULL_NONE) {
+        if (direction != DIRECTION_INPUT) {
             common_hal_digitalio_digitalinout_switch_to_input(pin, PULL_UP);
+        }
+        digitalio_pull_t pull = common_hal_digitalio_digitalinout_get_pull(pin);
+        if (pull == PULL_NONE) {
+            common_hal_digitalio_digitalinout_set_pull(pin, PULL_UP);
+        }
+        if (pull != PULL_DOWN) {
+            gamepad_singleton->pulls |= 1 << i;
         }
         gamepad_singleton->pins[i] = pin;
     }

--- a/shared-module/gamepad/GamePad.h
+++ b/shared-module/gamepad/GamePad.h
@@ -36,9 +36,10 @@ typedef struct {
     digitalio_digitalinout_obj_t* pins[8];
     volatile uint8_t last;
     volatile uint8_t pressed;
+    uint8_t pulls;
 } gamepad_obj_t;
 
-extern gamepad_obj_t* gamepad_singleton;
+extern gamepad_obj_t* volatile gamepad_singleton;
 
 void gamepad_init(size_t n_pins, const mp_obj_t* pins);
 

--- a/shared-module/gamepad/GamePad.h
+++ b/shared-module/gamepad/GamePad.h
@@ -39,7 +39,7 @@ typedef struct {
     uint8_t pulls;
 } gamepad_obj_t;
 
-extern gamepad_obj_t* volatile gamepad_singleton;
+extern gamepad_obj_t* gamepad_singleton;
 
 void gamepad_init(size_t n_pins, const mp_obj_t* pins);
 

--- a/shared-module/gamepad/__init__.c
+++ b/shared-module/gamepad/__init__.c
@@ -37,17 +37,18 @@ void gamepad_tick(void) {
         return;
     }
     uint8_t gamepad_current = 0;
-    for (int i=0; i<8; ++i) {
+    uint8_t bit = 1;
+    for (int i = 0; i < 8; ++i) {
         digitalio_digitalinout_obj_t* pin = gamepad_singleton->pins[i];
         if (!pin) {
             break;
         }
-        digitalio_pull_t pull = common_hal_digitalio_digitalinout_get_pull(pin);
-        bool value = common_hal_digitalio_digitalinout_get_value(pin);
-        if ((pull == PULL_UP && !value) || (pull == PULL_DOWN && value)) {
-            gamepad_current |= 1 << i;
+        if (common_hal_digitalio_digitalinout_get_value(pin)) {
+            gamepad_current |= bit;
         }
+        bit <<= 1;
     }
+    gamepad_current ^= gamepad_singleton->pulls;
     gamepad_singleton->pressed |= gamepad_singleton->last & gamepad_current;
     gamepad_singleton->last = gamepad_current;
 }


### PR DESCRIPTION
Don't check the pin's pull direction on every tick, instead cache it
at the beginning. Also avoid a "can't get pull of output pin" error
when one of the pins passed is in output mode.