### PR TITLE
Use the external crystal on SAMD21 again.

### DIFF
--- a/ports/atmel-samd/peripherals/clocks.h
+++ b/ports/atmel-samd/peripherals/clocks.h
@@ -70,5 +70,6 @@ bool clock_get_parent(uint8_t type, uint8_t index, uint8_t *p_type, uint8_t *p_i
 uint32_t clock_get_frequency(uint8_t type, uint8_t index);
 uint32_t clock_get_calibration(uint8_t type, uint8_t index);
 int clock_set_calibration(uint8_t type, uint8_t index, uint32_t val);
+void save_usb_clock_calibration(void);
 
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_CLOCKS_H

--- a/ports/atmel-samd/peripherals/samd51/clocks.c
+++ b/ports/atmel-samd/peripherals/samd51/clocks.c
@@ -123,6 +123,9 @@ void clock_init(void) {
     enable_clock_generator_sync(5, GCLK_GENCTRL_SRC_DFLL_Val, 24, false);
 
     init_clock_source_dpll0();
+
+    // Do this after all static clock init so that they aren't used dynamically.
+    init_dynamic_clocks();
 }
 
 static bool clk_enabled(uint8_t clk) {
@@ -203,6 +206,7 @@ static uint32_t dpll_get_frequency(uint8_t index) {
             break;
         case 0x2: // XOSC0
         case 0x3: // XOSC1
+        default:
             return 0; // unknown
     }
 
@@ -333,6 +337,10 @@ int clock_set_calibration(uint8_t type, uint8_t index, uint32_t val) {
         return 0;
     }
     return -2;
+}
+
+
+void save_usb_clock_calibration(void) {
 }
 
 #include <instance/can0.h>

--- a/ports/atmel-samd/supervisor/filesystem.c
+++ b/ports/atmel-samd/supervisor/filesystem.c
@@ -32,13 +32,6 @@
 
 #include "flash_api.h"
 
-#ifdef EXPRESS_BOARD
-// #include "common-hal/touchio/TouchIn.h"
-#define INTERNAL_CIRCUITPY_CONFIG_START_ADDR (0x00040000 - 0x100 - CIRCUITPY_INTERNAL_NVM_SIZE)
-#else
-#define INTERNAL_CIRCUITPY_CONFIG_START_ADDR (0x00040000 - 0x010000 - 0x100 - CIRCUITPY_INTERNAL_NVM_SIZE)
-#endif
-
 fs_user_mount_t fs_user_mount_flash;
 mp_vfs_mount_t mp_vfs_mount_flash;
 


### PR DESCRIPTION
Also, re-enable calibration storage for CircuitPlayground Express.
Tested with a 500hz PWMOut on Metro M0 with Saleae:
 * with crystal 500hz
 * with usb 500hz +- 0.1hz
 * without either 487hz += 0.1hz

SAMD51 is skipped due to DFLL errata and the fact it defaults to a
factory calibrated 48mhz that works fine for USB.

Fixes #648