### PR TITLE
main: Explicitly set the stack top based on _estack

### DIFF
--- a/main.c
+++ b/main.c
@@ -241,7 +241,7 @@ int __attribute__((used)) main(void) {
 
     // Stack limit should be less than real stack size, so we have a chance
     // to recover from limit hit.  (Limit is measured in bytes.)
-    mp_stack_ctrl_init();
+    mp_stack_set_top((char*)&_estack);
     mp_stack_set_limit((char*)&_estack - (char*)&_ebss - 1024);
 
 #if MICROPY_MAX_STACK_USAGE


### PR DESCRIPTION
.. setting it based on the ad-hoc stack pointer calculation of `mp_stack_ctrl_init()` meant that the stack used above `main()` counts against the 1KiB safety factor that the `mp_stack_set_limit` call tries to establish.  It turns out, at least on M4, that over half of the safety factor is used up by stack-above-main()!

In the case of the `basics/gen_stack_overflow.py` test, which blows the stack on purpose, it turns out that gc would be called while handling the "maximum recursion depth exceeded" error, and this needed more stack than was left.

Closes: #900