### PR TITLE
Check for PDMIn DMA getting stuck.

### DIFF
--- a/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+++ b/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
@@ -392,7 +392,18 @@ uint32_t common_hal_audiobusio_pdmin_record_to_buffer(audiobusio_pdmin_obj_t* se
             break;
         }
         // Wait for the next buffer to fill
+        uint32_t wait_counts = 0;
+        #ifdef SAMD21
+          #define MAX_WAIT_COUNTS 1000
+        #endif
+        #ifdef SAMD51
+          #define MAX_WAIT_COUNTS 6000
+        #endif
         while (!event_interrupt_active(event_channel)) {
+            if (wait_counts++ > MAX_WAIT_COUNTS) {
+                // Buffer has stopped filling; DMA may have missed an I2S trigger event.
+                break;
+            }
             #ifdef MICROPY_VM_HOOK_LOOP
                 MICROPY_VM_HOOK_LOOP
             #endif


### PR DESCRIPTION
The DMA transfer in PDMIn occasionally seems to lose a trigger from the I2S peripheral, and stops transferring. PDMIn record would hang waiting for DMA to finish. This puts a counter "timeout" on the number of times we check for DMA not being done. If the counter is exceeded, we give up and try again.

It would be nice to know _why_ the trigger is being lost, but this prevents a hang, which is a lot better than nothing.

Sorta fixes #879.