### PR TITLE
Build for feather huzzah on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: c
 compiler:
   - gcc
 env:
+  - TRAVIS_BOARD=feather_huzzah
   - TRAVIS_BOARD=arduino_zero
   - TRAVIS_BOARD=circuitplayground_express
   - TRAVIS_BOARD=circuitplayground_express_crickit
@@ -57,6 +58,8 @@ before_script:
   - sudo apt-get install realpath
   # For nrf builds
   - ([[ $TRAVIS_BOARD != "feather52" ]] || sudo ports/nrf/drivers/bluetooth/download_ble_stack.sh)
+  # For huzzah builds
+  - if [[ $TRAVIS_BOARD = "feather_huzzah" ]]; then wget https://github.com/jepler/esp-open-sdk/releases/download/2018-06-10/xtensa-lx106-elf-standalone.tar.gz && tar xavf xtensa-lx106-elf-standalone.tar.gz; PATH=$(readlink -f xtensa-lx106-elf/bin):$PATH; fi
   # For coverage testing (upgrade is used to get latest urllib3 version)
   - ([[ -z "$TRAVIS_TEST" ]] || sudo pip install --upgrade cpp-coveralls)
   - ([[ $TRAVIS_TEST != "docs" ]] || sudo pip install Sphinx sphinx-rtd-theme recommonmark)


### PR DESCRIPTION
My primary motivation is that in the recent past, it has occurred several times that the huzzah build has been broken for days before a developer discovers it themselves.

In [jepler/esp-open-sdk](https://github.com/jepler/esp-open-sdk), there is now a travis integration which uploads the toolchain to github.  There's a release (which is just a date tag) with a toolchain attached that seems to work on trusty and on debian stretch. (it's built on trusty, same as circuitpython uses for its travis builds)

In this pull request, the travis integration fetches that toolchain and builds for feather_huzzah in addition to all the other boards.