### PR TITLE
Implement pulseio.PulseIn and PulseOut for ESP8266 #716

### DIFF
--- a/ports/esp8266/common-hal/microcontroller/Pin.h
+++ b/ports/esp8266/common-hal/microcontroller/Pin.h
@@ -45,4 +45,7 @@ void claim_pin(const mcu_pin_obj_t* pin);
 void reset_pin(const mcu_pin_obj_t* pin);
 void reset_pins(void);
 
+void microcontroller_pin_register_intr_handler(uint8_t gpio_number, void (*func)(void *), void *data);
+void microcontroller_pin_call_intr_handlers(uint32_t status);
+
 #endif  // MICROPY_INCLUDED_ESP8266_COMMON_HAL_MICROCONTROLLER_PIN_H

--- a/ports/esp8266/common-hal/pulseio/PulseIn.c
+++ b/ports/esp8266/common-hal/pulseio/PulseIn.c
@@ -26,47 +26,164 @@
 
 #include <stdint.h>
 
+#include <user_interface.h>
+#include <eagle_soc.h>
+#include "esp_mphal.h"
+
 #include "mpconfigport.h"
 #include "py/gc.h"
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/pulseio/PulseIn.h"
+#include "common-hal/microcontroller/__init__.h"
+
+// XXX map gpio pins to pulsein objects: kinda clumsy.
+static pulseio_pulsein_obj_t *pulseio_pulsein_objs[GPIO_PIN_COUNT] = {0};
+
+static void pulsein_set_interrupt(pulseio_pulsein_obj_t *self, bool rising, bool falling) {
+    ETS_GPIO_INTR_DISABLE();
+    // Set interrupt mode
+    GPIO_REG_WRITE(
+        GPIO_PIN_ADDR(self->pin->gpio_number),
+        (GPIO_REG_READ(GPIO_PIN_ADDR(self->pin->gpio_number) & ~GPIO_PIN_INT_TYPE_MASK)) |
+        GPIO_PIN_INT_TYPE_SET(
+            (rising ? GPIO_PIN_INTR_POSEDGE : 0) | (falling ? GPIO_PIN_INTR_NEGEDGE : 0)
+        )
+    );
+    // Clear interrupt status
+    GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, 1 << self->pin->gpio_number);
+    ETS_GPIO_INTR_ENABLE();
+}
+
+void pulseio_pulsein_interrupt_handler(pulseio_pulsein_obj_t *self, uint32_t time_us) {
+    if (self->first_edge) {
+        self->first_edge = false;
+        pulsein_set_interrupt(self, true, true);
+    } else {
+        uint16_t elapsed_us = (uint16_t)(time_us - self->last_us);
+        uint16_t i = (self->start + self->len) % self->maxlen;
+        self->buffer[i] = elapsed_us;
+        if (self->len < self->maxlen) {
+            self->len++;
+        } else {
+            self->start++;
+        }
+    }
+    self->last_us = time_us;
+}
+
+// XXX needs a better name, or a better abstraction
+// XXX called from intr.c:pin_intr_handler_iram ... inelegantly
+void pulsein_interrupt_handler(uint32_t status) {
+    uint32_t time_us = system_get_time();
+    for (int i=0; i<GPIO_PIN_COUNT; i++) {
+        if (status & 1<<i) {
+            pulseio_pulsein_obj_t *self = pulseio_pulsein_objs[i];
+            if (self) pulseio_pulsein_interrupt_handler(self, time_us);
+        }
+    }
+}
 
 void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
         const mcu_pin_obj_t* pin, uint16_t maxlen, bool idle_state) {
-    mp_raise_NotImplementedError("");
+    if (pin->gpio_number == NO_GPIO || pin->gpio_function == SPECIAL_CASE) {
+        mp_raise_msg_varg(&mp_type_ValueError, "No PulseIn support for %q", pin->name );
+    }
+    PIN_FUNC_SELECT(pin->peripheral, pin->gpio_function);
+    PIN_PULLUP_DIS(pin->peripheral);
+    self->pin = pin;
+
+    self->buffer = (uint16_t *) m_malloc(maxlen * sizeof(uint16_t), false);
+    if (self->buffer == NULL) {
+        mp_raise_msg_varg(&mp_type_MemoryError, "Failed to allocate RX buffer of %d bytes", maxlen * sizeof(uint16_t));
+    }
+
+    self->maxlen = maxlen;
+    self->idle_state = idle_state;
+    self->start = 0;
+    self->len = 0;
+    self->first_edge = true;
+    self->last_us = 0;
+    pulseio_pulsein_objs[self->pin->gpio_number] = self;
+    pulsein_set_interrupt(self, !idle_state, idle_state);
 }
 
 bool common_hal_pulseio_pulsein_deinited(pulseio_pulsein_obj_t* self) {
-    return true;
+    return pulseio_pulsein_objs[self->pin->gpio_number] == NULL;
 }
 
 void common_hal_pulseio_pulsein_deinit(pulseio_pulsein_obj_t* self) {
+    pulsein_set_interrupt(self, false, false);
+    pulseio_pulsein_objs[self->pin->gpio_number] = NULL;
+    PIN_FUNC_SELECT(self->pin->peripheral, 0);
+    m_free(self->buffer);
 }
 
 void common_hal_pulseio_pulsein_pause(pulseio_pulsein_obj_t* self) {
+    pulsein_set_interrupt(self, false, false);
 }
 
 void common_hal_pulseio_pulsein_resume(pulseio_pulsein_obj_t* self,
         uint16_t trigger_duration) {
+    // Make sure we're paused.
+    common_hal_pulseio_pulsein_pause(self);
+
+    // Send the trigger pulse.
+    if (trigger_duration > 0) {
+        uint32_t mask = 1 << self->pin->gpio_number;
+        // switch pin to an output with state opposite idle state
+        gpio_output_set(self->idle_state ? 0 : mask, self->idle_state ? mask : 0, 0, 0);
+        gpio_output_set(0, 0, mask, 0);
+        common_hal_mcu_delay_us((uint32_t)trigger_duration);
+        // switch pin back to an open input
+        gpio_output_set(0, 0, 0, mask);
+    }
+
+    common_hal_mcu_disable_interrupts();
+    self->first_edge = true;
+    pulsein_set_interrupt(self, !self->idle_state, self->idle_state);
+    common_hal_mcu_enable_interrupts();
 }
 
 void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t* self) {
+    common_hal_mcu_disable_interrupts();
+    self->start = 0;
+    self->len = 0;
+    common_hal_mcu_enable_interrupts();
 }
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
-    return 0;
+    if (self->len == 0) {
+        mp_raise_IndexError("pop from an empty PulseIn");
+    }
+    common_hal_mcu_disable_interrupts();
+    uint16_t value = self->buffer[self->start];
+    self->start = (self->start + 1) % self->maxlen;
+    self->len--;
+    common_hal_mcu_enable_interrupts();
+
+    return value;
 }
 
 uint16_t common_hal_pulseio_pulsein_get_maxlen(pulseio_pulsein_obj_t* self) {
-    return 0;
+    return self->maxlen;
 }
 
 uint16_t common_hal_pulseio_pulsein_get_len(pulseio_pulsein_obj_t* self) {
-    return 0;
+    return self->len;
 }
 
 uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t* self,
         int16_t index) {
-    return 0;
+    common_hal_mcu_disable_interrupts();
+    if (index < 0) {
+        index += self->len;
+    }
+    if (index < 0 || index >= self->len) {
+        common_hal_mcu_enable_interrupts();
+        mp_raise_IndexError("index out of range");
+    }
+    uint16_t value = self->buffer[(self->start + index) % self->maxlen];
+    common_hal_mcu_enable_interrupts();
+    return value;
 }

--- a/ports/esp8266/common-hal/pulseio/PulseIn.c
+++ b/ports/esp8266/common-hal/pulseio/PulseIn.c
@@ -91,6 +91,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
     self->len = 0;
     self->first_edge = true;
     self->last_us = 0;
+    self->paused = false;
 
     microcontroller_pin_register_intr_handler(self->pin->gpio_number,
             pulseio_pulsein_interrupt_handler, (void *)self);
@@ -111,6 +112,7 @@ void common_hal_pulseio_pulsein_deinit(pulseio_pulsein_obj_t* self) {
 
 void common_hal_pulseio_pulsein_pause(pulseio_pulsein_obj_t* self) {
     pulsein_set_interrupt(self, false, false);
+    self->paused = true;
 }
 
 void common_hal_pulseio_pulsein_resume(pulseio_pulsein_obj_t* self,
@@ -133,6 +135,7 @@ void common_hal_pulseio_pulsein_resume(pulseio_pulsein_obj_t* self,
     self->first_edge = true;
     pulsein_set_interrupt(self, !self->idle_state, self->idle_state);
     common_hal_mcu_enable_interrupts();
+    self->paused = false;
 }
 
 void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t* self) {
@@ -160,7 +163,7 @@ uint16_t common_hal_pulseio_pulsein_get_maxlen(pulseio_pulsein_obj_t* self) {
 }
 
 bool common_hal_pulseio_pulsein_get_paused(pulseio_pulsein_obj_t* self) {
-    return false;
+    return self->paused;
 }
 
 uint16_t common_hal_pulseio_pulsein_get_len(pulseio_pulsein_obj_t* self) {

--- a/ports/esp8266/common-hal/pulseio/PulseIn.h
+++ b/ports/esp8266/common-hal/pulseio/PulseIn.h
@@ -28,11 +28,22 @@
 #define MICROPY_INCLUDED_ESP8266_COMMON_HAL_PULSEIO_PULSEIN_H
 
 #include "py/obj.h"
+#include "common-hal/microcontroller/Pin.h"
 
 typedef struct {
     mp_obj_base_t base;
+    const mcu_pin_obj_t *pin;
+    uint16_t *buffer;
+    uint16_t maxlen;
+    bool idle_state;
+    volatile uint16_t start;
+    volatile uint16_t len;
+    volatile bool first_edge;
+    volatile uint32_t last_us;
 } pulseio_pulsein_obj_t;
 
-void pwmout_reset(void);
+void pulsein_reset(void);
+
+void pulsein_interrupt_handler(uint32_t);
 
 #endif // MICROPY_INCLUDED_ESP8266_COMMON_HAL_PULSEIO_PULSEIN_H

--- a/ports/esp8266/common-hal/pulseio/PulseIn.h
+++ b/ports/esp8266/common-hal/pulseio/PulseIn.h
@@ -36,6 +36,7 @@ typedef struct {
     uint16_t *buffer;
     uint16_t maxlen;
     bool idle_state;
+    bool paused;
     volatile uint16_t start;
     volatile uint16_t len;
     volatile bool first_edge;

--- a/ports/esp8266/common-hal/pulseio/PulseOut.c
+++ b/ports/esp8266/common-hal/pulseio/PulseOut.c
@@ -24,23 +24,85 @@
  * THE SOFTWARE.
  */
 
+#include "common-hal/pulseio/PulseOut.h"
 
 #include <stdint.h>
 
+#include <pwm.h>
+
+#include "ets_alt_task.h"
+#include "py/obj.h"
 #include "py/runtime.h"
+#include "mpconfigport.h"
 #include "shared-bindings/pulseio/PulseOut.h"
+
+#define NO_CHANNEL (255)
+
+static uint16_t *pulse_buffer = NULL;
+static volatile uint16_t pulse_index = 0;
+static uint16_t pulse_length;
+static volatile uint32_t current_compare = 0;
+
+void pulseout_set(pulseio_pulseout_obj_t *self, bool state) {
+    // XXX double kludge
+    //uint32_t duty = state ? pwm_get_period() * 11 : 0;
+    uint32_t duty = state ? 1000 : 500;
+    pwm_set_duty(duty, self->channel);
+    pwm_start();
+}
+
+void pulseout_interrupt_handler(void *data) {
+    pulseio_pulseout_obj_t *self = data;
+
+    if (pulse_buffer == NULL || self->channel == NO_CHANNEL) return;
+    if (pulse_index >= pulse_length) return;
+    pulse_index++;
+    pulseout_set(self, pulse_index % 2 == 0);
+
+    os_timer_arm(&self->timer, pulse_buffer[pulse_index], 0);
+}
+
+void pulseout_reset() {
+    pulse_buffer = NULL;
+}
 
 void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
                                             const pulseio_pwmout_obj_t* carrier) {
-    nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "No hardware support for PulseOut."));
+    self->channel = carrier->channel;
 }
 
 bool common_hal_pulseio_pulseout_deinited(pulseio_pulseout_obj_t* self) {
-    return true;
+    return self->channel == NO_CHANNEL;
 }
 
 void common_hal_pulseio_pulseout_deinit(pulseio_pulseout_obj_t* self) {
+    os_timer_disarm(&self->timer);
+    self->channel = NO_CHANNEL;
+    pulseout_set(self, true);
 }
 
 void common_hal_pulseio_pulseout_send(pulseio_pulseout_obj_t* self, uint16_t* pulses, uint16_t length) {
+    if (pulse_buffer != NULL) {
+        mp_raise_RuntimeError("Another send is already active");
+    }
+    pulse_buffer = pulses;
+    pulse_index = 0;
+    pulse_length = length;
+
+    os_timer_disarm(&self->timer);
+    os_timer_setfn(&self->timer, pulseout_interrupt_handler, self);
+    os_timer_arm(&self->timer, pulse_buffer[0], 0);
+    pulseout_set(self, true);
+
+    // XXX in the circumstances, is it worth messing with os_timer?
+    // it isn't especially accurate anyway ...
+    // might it not be simpler to just call mp_hal_delay_us() a lot?
+    while(pulse_index < length) {
+        ets_loop_iter();
+    }
+
+    os_timer_disarm(&self->timer);
+    pulseout_set(self, false);
+
+    pulse_buffer = NULL;
 }

--- a/ports/esp8266/common-hal/pulseio/PulseOut.h
+++ b/ports/esp8266/common-hal/pulseio/PulseOut.h
@@ -27,12 +27,19 @@
 #ifndef MICROPY_INCLUDED_ESP8266_COMMON_HAL_PULSEIO_PULSEOUT_H
 #define MICROPY_INCLUDED_ESP8266_COMMON_HAL_PULSEIO_PULSEOUT_H
 
+#include "common-hal/microcontroller/Pin.h"
+
+#include "esp_mphal.h"
+
 #include "py/obj.h"
 
 typedef struct {
     mp_obj_base_t base;
+    os_timer_t timer;
+    uint8_t channel;
 } pulseio_pulseout_obj_t;
 
-void pwmout_reset(void);
+void pulseout_reset(void);
+void pulseout_interrupt_handler(void *);
 
 #endif // MICROPY_INCLUDED_ESP8266_COMMON_HAL_PULSEIO_PULSEOUT_H

--- a/ports/esp8266/common-hal/pulseio/PulseOut.h
+++ b/ports/esp8266/common-hal/pulseio/PulseOut.h
@@ -36,7 +36,7 @@
 typedef struct {
     mp_obj_base_t base;
     os_timer_t timer;
-    uint8_t channel;
+    const mcu_pin_obj_t *pin;
 } pulseio_pulseout_obj_t;
 
 void pulseout_reset(void);

--- a/ports/esp8266/intr.c
+++ b/ports/esp8266/intr.c
@@ -34,8 +34,10 @@
 void pin_intr_handler_iram(void *arg) {
     uint32_t status = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
     GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, status);
+
+    // machine.Pin handlers
     pin_intr_handler(status);
 
-    // XXX bit of a hack
-    pulsein_interrupt_handler(status);
+    // microcontroller.Pin handlers
+    microcontroller_pin_call_intr_handlers(status);
 }

--- a/ports/esp8266/intr.c
+++ b/ports/esp8266/intr.c
@@ -28,10 +28,14 @@
 #include "ets_alt_task.h"
 
 #include "modmachine.h"
+#include "common-hal/pulseio/PulseIn.h"
 
 // this is in a separate file so it can go in iRAM
 void pin_intr_handler_iram(void *arg) {
     uint32_t status = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
     GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, status);
     pin_intr_handler(status);
+
+    // XXX bit of a hack
+    pulsein_interrupt_handler(status);
 }


### PR DESCRIPTION
Implements pulseio.PulseIn and pulseio.PulseOut for ESP8266 as per #716:

PulseIn:
* Tested to work with adafruit_dht library and DHT11.
* Tested to work receiving IR remote control codes from a IR demodulator
* Also includes fix for #918

PulseOut;
* Unfortunately very limited by the ESP's 1kHz-max software PWM.
* Tested on a 'scope and seems okay, within that limitation.

It also implements a generic gpio interrupt callback registration mechanism under microcontroller.Pin: this would allow the other *io libraries to register to receive GPIO interrupts.  This possibly should be moved elsewhere, see also https://github.com/nickzoic/micropython/tree/circuitpython-nickzoic-rethink-gpio-interrupts
I'd be interested in feedback on this approach. 