### PR TITLE
Correct UART reads to return error on timeout.

### DIFF
--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -269,6 +269,11 @@ size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t 
 #endif
     }
 
+    if (total_read == 0) {
+        *errcode = EAGAIN;
+        return MP_STREAM_ERROR;
+    }
+
     return total_read;
 }
 


### PR DESCRIPTION
This causes read to correctly return None instead of b''.

Fixes #874