### PR TITLE
Fix playing audio from SD card

### DIFF
--- a/extmod/vfs_fat_diskio.c
+++ b/extmod/vfs_fat_diskio.c
@@ -131,8 +131,17 @@ DRESULT disk_read (
     } else {
         vfs->readblocks[2] = MP_OBJ_NEW_SMALL_INT(sector);
         vfs->readblocks[3] = mp_obj_new_bytearray_by_ref(count * SECSIZE(&vfs->fatfs), buff);
-        mp_call_method_n_kw(2, 0, vfs->readblocks);
-        // TODO handle error return
+        nlr_buf_t nlr;
+        if (nlr_push(&nlr) == 0) {
+            mp_obj_t ret = mp_call_method_n_kw(2, 0, vfs->readblocks);
+            nlr_pop();
+            if (mp_obj_get_int(ret) != 0) {
+                return RES_ERROR;
+            }
+        } else {
+            // Exception thrown by readblocks or something it calls.
+            return RES_ERROR;
+        }
     }
 
     return RES_OK;
@@ -167,8 +176,17 @@ DRESULT disk_write (
     } else {
         vfs->writeblocks[2] = MP_OBJ_NEW_SMALL_INT(sector);
         vfs->writeblocks[3] = mp_obj_new_bytearray_by_ref(count * SECSIZE(&vfs->fatfs), (void*)buff);
-        mp_call_method_n_kw(2, 0, vfs->writeblocks);
-        // TODO handle error return
+        nlr_buf_t nlr;
+        if (nlr_push(&nlr) == 0) {
+            mp_obj_t ret = mp_call_method_n_kw(2, 0, vfs->writeblocks);
+            nlr_pop();
+            if (mp_obj_get_int(ret) != 0) {
+                return RES_ERROR;
+            }
+        } else {
+            // Exception thrown by writeblocks or something it calls.
+            return RES_ERROR;
+        }
     }
 
     return RES_OK;

--- a/main.c
+++ b/main.c
@@ -233,7 +233,7 @@ bool start_mp(safe_mode_t safe_mode) {
     }
 }
 
-void run_boot_py(safe_mode_t safe_mode) {
+void __attribute__ ((noinline)) run_boot_py(safe_mode_t safe_mode) {
     // If not in safe mode, run boot before initing USB and capture output in a
     // file.
     if (filesystem_present() && safe_mode == NO_SAFE_MODE && MP_STATE_VM(vfs_mount_table) != NULL) {
@@ -258,10 +258,12 @@ void run_boot_py(safe_mode_t safe_mode) {
         // This saves wear and tear on the flash and also prevents filesystem damage if power is lost
         // during the write, which may happen due to bobbling the power connector or weak power.
 
+        static const size_t NUM_CHARS_TO_COMPARE = 160;
         if (!have_boot_py && f_open(fs, boot_output_file, CIRCUITPY_BOOT_OUTPUT_FILE, FA_READ) == FR_OK) {
-            char file_contents[512];
+
+            char file_contents[NUM_CHARS_TO_COMPARE];
             UINT chars_read = 0;
-            f_read(boot_output_file, file_contents, 512, &chars_read);
+            f_read(boot_output_file, file_contents, NUM_CHARS_TO_COMPARE, &chars_read);
             f_close(boot_output_file);
             skip_boot_output =
                 // + 2 accounts for  \r\n.

--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -102,8 +102,10 @@ endif
 ifeq ($(DEBUG), 1)
   # Turn on Python modules useful for debugging (e.g. uheap, ustack).
   CFLAGS += -ggdb
-##  CFLAGS += -flto
-  CFLAGS += -fno-inline -fno-ipa-sra
+  # You may want to disable -flto if it interferes with debugging.
+  CFLAGS += -flto
+  # You may want to enable these flags to make setting breakpoints easier.
+##   CFLAGS += -fno-inline -fno-ipa-sra
   ifeq ($(CHIP_FAMILY), samd21)
     CFLAGS += -DENABLE_MICRO_TRACE_BUFFER
   endif

--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -114,7 +114,7 @@ else
   # -finline-limit=80 or so is similar to not having it on.
   # There is no simple default value, though.
   ifdef INTERNAL_FLASH_FILESYSTEM
-    CFLAGS += -finline-limit=60
+    CFLAGS += -finline-limit=55
   endif
   CFLAGS += -flto
 endif

--- a/shared-module/audioio/RawSample.c
+++ b/shared-module/audioio/RawSample.c
@@ -66,18 +66,18 @@ void audioio_rawsample_reset_buffer(audioio_rawsample_obj_t* self,
                                     uint8_t channel) {
 }
 
-bool audioio_rawsample_get_buffer(audioio_rawsample_obj_t* self,
-                                  bool single_channel,
-                                  uint8_t channel,
-                                  uint8_t** buffer,
-                                  uint32_t* buffer_length) {
+audioio_get_buffer_result_t audioio_rawsample_get_buffer(audioio_rawsample_obj_t* self,
+                                                         bool single_channel,
+                                                         uint8_t channel,
+                                                         uint8_t** buffer,
+                                                         uint32_t* buffer_length) {
     *buffer_length = self->len;
     if (single_channel) {
         *buffer = self->buffer + (channel % self->channel_count) * (self->bits_per_sample / 8);
     } else {
         *buffer = self->buffer;
     }
-    return true;
+    return GET_BUFFER_DONE;
 }
 
 void audioio_rawsample_get_buffer_structure(audioio_rawsample_obj_t* self, bool single_channel,

--- a/shared-module/audioio/RawSample.h
+++ b/shared-module/audioio/RawSample.h
@@ -29,6 +29,8 @@
 
 #include "py/obj.h"
 
+#include "shared-module/audioio/__init__.h"
+
 typedef struct {
     mp_obj_base_t base;
     uint8_t* buffer;
@@ -45,11 +47,11 @@ typedef struct {
 void audioio_rawsample_reset_buffer(audioio_rawsample_obj_t* self,
                                     bool single_channel,
                                     uint8_t channel);
-bool audioio_rawsample_get_buffer(audioio_rawsample_obj_t* self,
-                                  bool single_channel,
-                                  uint8_t channel,
-                                  uint8_t** buffer,
-                                  uint32_t* buffer_length); // length in bytes
+audioio_get_buffer_result_t audioio_rawsample_get_buffer(audioio_rawsample_obj_t* self,
+                                                         bool single_channel,
+                                                         uint8_t channel,
+                                                         uint8_t** buffer,
+                                                         uint32_t* buffer_length); // length in bytes
 void audioio_rawsample_get_buffer_structure(audioio_rawsample_obj_t* self, bool single_channel,
                                             bool* single_buffer, bool* samples_signed,
                                             uint32_t* max_buffer_length, uint8_t* spacing);

--- a/shared-module/audioio/WaveFile.h
+++ b/shared-module/audioio/WaveFile.h
@@ -29,6 +29,8 @@
 
 #include "py/obj.h"
 
+#include "shared-module/audioio/__init__.h"
+
 typedef struct {
     mp_obj_base_t base;
     uint8_t* buffer;
@@ -56,11 +58,11 @@ typedef struct {
 void audioio_wavefile_reset_buffer(audioio_wavefile_obj_t* self,
                                    bool single_channel,
                                    uint8_t channel);
-bool audioio_wavefile_get_buffer(audioio_wavefile_obj_t* self,
-                                 bool single_channel,
-                                 uint8_t channel,
-                                 uint8_t** buffer,
-                                 uint32_t* buffer_length); // length in bytes
+audioio_get_buffer_result_t audioio_wavefile_get_buffer(audioio_wavefile_obj_t* self,
+                                                        bool single_channel,
+                                                        uint8_t channel,
+                                                        uint8_t** buffer,
+                                                        uint32_t* buffer_length); // length in bytes
 void audioio_wavefile_get_buffer_structure(audioio_wavefile_obj_t* self, bool single_channel,
                                            bool* single_buffer, bool* samples_signed,
                                            uint32_t* max_buffer_length, uint8_t* spacing);

--- a/shared-module/audioio/__init__.h
+++ b/shared-module/audioio/__init__.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_MODULE_AUDIOIO__INIT__H
+#define MICROPY_INCLUDED_SHARED_MODULE_AUDIOIO__INIT__H
+
+typedef enum {
+    GET_BUFFER_DONE,            // No more data to read
+    GET_BUFFER_MORE_DATA,       // More data to read.
+    GET_BUFFER_ERROR,           // Error while reading data.
+} audioio_get_buffer_result_t;
+
+#endif  // MICROPY_INCLUDED_SHARED_MODULE_AUDIOIO__INIT__H

--- a/tests/extmod/vfs_fat_fileio1.py
+++ b/tests/extmod/vfs_fat_fileio1.py
@@ -27,11 +27,13 @@ class RAMFS:
         #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
         for i in range(len(buf)):
             buf[i] = self.data[n * self.SEC_SIZE + i]
+        return 0
 
     def writeblocks(self, n, buf):
         #print("writeblocks(%s, %x)" % (n, id(buf)))
         for i in range(len(buf)):
             self.data[n * self.SEC_SIZE + i] = buf[i]
+        return 0
 
     def ioctl(self, op, arg):
         #print("ioctl(%d, %r)" % (op, arg))

--- a/tests/extmod/vfs_fat_fileio2.py
+++ b/tests/extmod/vfs_fat_fileio2.py
@@ -27,11 +27,13 @@ class RAMFS:
         #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
         for i in range(len(buf)):
             buf[i] = self.data[n * self.SEC_SIZE + i]
+        return 0
 
     def writeblocks(self, n, buf):
         #print("writeblocks(%s, %x)" % (n, id(buf)))
         for i in range(len(buf)):
             self.data[n * self.SEC_SIZE + i] = buf[i]
+        return 0
 
     def ioctl(self, op, arg):
         #print("ioctl(%d, %r)" % (op, arg))

--- a/tests/extmod/vfs_fat_more.py
+++ b/tests/extmod/vfs_fat_more.py
@@ -27,11 +27,13 @@ class RAMFS:
         #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
         for i in range(len(buf)):
             buf[i] = self.data[n * self.SEC_SIZE + i]
+        return 0
 
     def writeblocks(self, n, buf):
         #print("writeblocks(%s, %x)" % (n, id(buf)))
         for i in range(len(buf)):
             self.data[n * self.SEC_SIZE + i] = buf[i]
+        return 0
 
     def ioctl(self, op, arg):
         #print("ioctl(%d, %r)" % (op, arg))

--- a/tests/extmod/vfs_fat_oldproto.py
+++ b/tests/extmod/vfs_fat_oldproto.py
@@ -25,11 +25,13 @@ class RAMFS_OLD:
         #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
         for i in range(len(buf)):
             buf[i] = self.data[n * self.SEC_SIZE + i]
+        return 0
 
     def writeblocks(self, n, buf):
         #print("writeblocks(%s, %x)" % (n, id(buf)))
         for i in range(len(buf)):
             self.data[n * self.SEC_SIZE + i] = buf[i]
+        return 0
 
     def sync(self):
         pass

--- a/tests/extmod/vfs_fat_ramdisk.py
+++ b/tests/extmod/vfs_fat_ramdisk.py
@@ -26,11 +26,13 @@ class RAMFS:
         #print("readblocks(%s, %x(%d))" % (n, id(buf), len(buf)))
         for i in range(len(buf)):
             buf[i] = self.data[n * self.SEC_SIZE + i]
+        return 0
 
     def writeblocks(self, n, buf):
         #print("writeblocks(%s, %x)" % (n, id(buf)))
         for i in range(len(buf)):
             self.data[n * self.SEC_SIZE + i] = buf[i]
+        return 0
 
     def ioctl(self, op, arg):
         #print("ioctl(%d, %r)" % (op, arg))


### PR DESCRIPTION
Fixes #289.

Playing audio is done in the background, in `audio_dma_background()`. Playing from the SD card will invoked the Python-based `adafruit_sdcard` library, which may run for long enough to invoke `audio_dma_background()` again, recursively. This caused some havoc. Added code to prevent recursive call from repeating work.

Also  cleaned up error handling in audio code

Unrelated minor fixes:
- reduced size of buffer used to compare whether `boot_out.txt` is identical or not and rewrite it only if it's different
- changed default values of some compiler flags when compiling `DEBUG`