### PR TITLE
fix os.listdir() when current dir is '/'

### DIFF
--- a/shared-bindings/os/__init__.c
+++ b/shared-bindings/os/__init__.c
@@ -87,7 +87,7 @@ mp_obj_t os_listdir(size_t n_args, const mp_obj_t *args) {
     if (n_args == 1) {
         path = mp_obj_str_get_str(args[0]);
     } else {
-        path = "";
+        path = mp_obj_str_get_str(common_hal_os_getcwd());
     }
     return common_hal_os_listdir(path);
 }

--- a/shared-module/os/__init__.c
+++ b/shared-module/os/__init__.c
@@ -103,7 +103,7 @@ mp_obj_t common_hal_os_listdir(const char* path) {
         iter.base.type = &mp_type_polymorph_iter;
         iter.iternext = mp_vfs_ilistdir_it_iternext;
         iter.cur.vfs = MP_STATE_VM(vfs_mount_table);
-        iter.is_str = mp_obj_get_type(path) == &mp_type_str;
+        iter.is_str = true;
         iter.is_iter = false;
     } else {
         iter_obj = mp_vfs_proxy_call(vfs, MP_QSTR_ilistdir, 1, &path_out);


### PR DESCRIPTION
This makes `os.listdir()` include mounted filesystems when the current directory is `/`.

Also fixes the mounted filesystem sometimes showing up as, e.g., `b'sd'` instead of `'sd'`. Some code was treating a `char *` as an `mp_obj_t` by accident.

The handling of `""` by `mp_vfs_lookup_path()` is not ideal when the main filesystem is mounted at `/`. This avoids that by actually passing in the current directory instead of `""`.

Note that `os.listdir('.')` when the current directory is `/` still does not include mounted filesystems, because all the path lookup code is pretty fragile. `../.` wouldn't be handled properly either. We probably need functionality like `os.path.abspath()` to fix these properly, instead of having special-case code in the path lookup code now.

Fixes #249 adequately for now.