### PR TITLE
ESP8266: Fix pin locking during busio.SPI.configure

### DIFF
--- a/ports/esp8266/common-hal/busio/SPI.h
+++ b/ports/esp8266/common-hal/busio/SPI.h
@@ -36,6 +36,9 @@ typedef struct {
     uint32_t frequency;
     bool locked;
     bool deinited;
+    const mcu_pin_obj_t * mosi;
+    const mcu_pin_obj_t * miso;
+    const mcu_pin_obj_t * clock;
 } busio_spi_obj_t;
 
 #endif // MICROPY_INCLUDED_ESP8266_COMMON_HAL_BUSIO_SPI_H


### PR DESCRIPTION
Fixes Issue #642. 

`hspi.c->spi_init_gpio()` is now bypassed for both `construct` and `configure`.

Tested pin locking for MOSI & MISO. Passes. Tested that SPI still works with a TFT display. Passes.