### PR TITLE
WIP/RFC: Introduce a display module for driving ILI9341 over SPI

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -233,6 +233,7 @@ SRC_SHARED_MODULE = \
 	storage/__init__.c \
 	struct/__init__.c \
 	gamepad/__init__.c \
+	display/ili9341.c \
 	gamepad/GamePad.c \
 	bitbangio/__init__.c \
 	bitbangio/I2C.c \
@@ -245,6 +246,9 @@ SRC_SHARED_MODULE = \
 
 SRC_SHARED_BINDINGS = \
 	struct/__init__.c \
+	display/__init__.c \
+	display/ili9341.c \
+	display/rotation.c \
 	gamepad/__init__.c \
 	gamepad/GamePad.c \
 	bitbangio/__init__.c \

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -226,6 +226,7 @@ extern const struct _mp_obj_module_t storage_module;
 extern const struct _mp_obj_module_t struct_module;
 extern const struct _mp_obj_module_t time_module;
 extern const struct _mp_obj_module_t supervisor_module;
+extern const struct _mp_obj_module_t display_module;
 extern const struct _mp_obj_module_t gamepad_module;
 
 extern const struct _mp_obj_module_t pyb_module;
@@ -275,6 +276,7 @@ extern const struct _mp_obj_module_t ble_module;
     { MP_OBJ_NEW_QSTR (MP_QSTR_storage         ), (mp_obj_t)&storage_module         },\
     { MP_OBJ_NEW_QSTR (MP_QSTR_struct          ), (mp_obj_t)&struct_module          }, \
     { MP_OBJ_NEW_QSTR (MP_QSTR_supervisor      ), (mp_obj_t)&supervisor_module      }, \
+    { MP_OBJ_NEW_QSTR (MP_QSTR_display         ), (mp_obj_t)&display_module         }, \
     { MP_OBJ_NEW_QSTR (MP_QSTR_gamepad         ), (mp_obj_t)&gamepad_module         }, \
     { MP_OBJ_NEW_QSTR (MP_QSTR_time            ), (mp_obj_t)&time_module            }, \
     { MP_ROM_QSTR     (MP_QSTR_pyb             ), MP_ROM_PTR(&pyb_module)           }, \

--- a/shared-bindings/display/__init__.c
+++ b/shared-bindings/display/__init__.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Artur Pacholec
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "ili9341.h"
+#include "py/obj.h"
+#include "rotation.h"
+
+STATIC const mp_rom_map_elem_t display_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_display) },
+
+    { MP_ROM_QSTR(MP_QSTR_ILI9341), MP_ROM_PTR(&display_ili9341_type) },
+    { MP_ROM_QSTR(MP_QSTR_Rotation), MP_ROM_PTR(&display_rotation_type) },
+};
+STATIC MP_DEFINE_CONST_DICT(display_module_globals, display_module_globals_table);
+
+const mp_obj_module_t display_module = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&display_module_globals,
+};

--- a/shared-bindings/display/ili9341.c
+++ b/shared-bindings/display/ili9341.c
@@ -1,0 +1,147 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Artur Pacholec
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ili9341.h"
+#include "py/objproperty.h"
+#include "py/runtime.h"
+#include "rotation.h"
+#include "shared-module/display/ili9341.h"
+
+#define DISP_WIDTH  320
+#define DISP_HEIGHT 240
+
+STATIC mp_obj_t ili9341_make_new(const mp_obj_type_t *type, size_t n_args,
+        size_t n_kw, const mp_obj_t *args) {
+
+    ili9341_obj_t *self = m_new_obj(ili9341_obj_t);
+    self->base.type = &display_ili9341_type;
+    self->rotation = ROTATION_0;
+    self->spi = MP_OBJ_TO_PTR(args[0]);
+    self->dc = MP_OBJ_TO_PTR(args[1]);
+    self->cs = MP_OBJ_TO_PTR(args[2]);
+
+    display_init9341_write_init(self);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+STATIC mp_obj_t ili9341_pixel(size_t n_args, const mp_obj_t *args) {
+    ili9341_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    const uint16_t x = mp_obj_get_int(args[1]);
+    const uint16_t y = mp_obj_get_int(args[2]);
+    const uint32_t color = mp_obj_get_int(args[3]);
+
+    display_ili9341_pixel(self, x, y, color);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ili9341_pixel_obj, 4, 4, ili9341_pixel);
+
+STATIC mp_obj_t ili9341_fill(mp_obj_t self_in, mp_obj_t color_in) {
+    ili9341_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    const uint32_t color = mp_obj_get_int(color_in);
+
+    display_ili9341_rect(self, 0, 0, DISP_WIDTH, DISP_HEIGHT, color);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(ili9341_fill_obj, ili9341_fill);
+
+STATIC mp_obj_t ili9341_fill_rectangle(size_t n_args, const mp_obj_t *args) {
+    ili9341_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    const uint16_t x = mp_obj_get_int(args[1]);
+    const uint16_t y = mp_obj_get_int(args[2]);
+    const uint16_t width = mp_obj_get_int(args[3]);
+    const uint16_t height = mp_obj_get_int(args[4]);
+    const uint32_t color = mp_obj_get_int(args[5]);
+
+    display_ili9341_rect(self, x, y, width, height, color);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ili9341_fill_rectangle_obj, 6, 6, ili9341_fill_rectangle);
+
+STATIC mp_obj_t ili9341_obj_get_rotation(mp_obj_t self_in) {
+    ili9341_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    switch (self->rotation) {
+        case ROTATION_0:   return (mp_obj_t)&display_rotation_0_obj;
+        case ROTATION_90:  return (mp_obj_t)&display_rotation_90_obj;
+        case ROTATION_180: return (mp_obj_t)&display_rotation_180_obj;
+        case ROTATION_270: return (mp_obj_t)&display_rotation_270_obj;
+    }
+
+    return (mp_obj_t)&mp_const_none_obj;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(ili9341_get_rotation_obj, ili9341_obj_get_rotation);
+
+STATIC mp_obj_t ili9341_obj_set_rotation(mp_obj_t self_in, mp_obj_t rotation_obj) {
+    ili9341_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    display_rotation_t rotation = ROTATION_0;
+    if (rotation_obj == &display_rotation_0_obj) {
+        rotation = ROTATION_0;
+    } else if (rotation_obj == &display_rotation_90_obj) {
+        rotation = ROTATION_90;
+    } else if (rotation_obj == &display_rotation_180_obj) {
+        rotation = ROTATION_180;
+    } else if (rotation_obj == &display_rotation_270_obj) {
+        rotation = ROTATION_270;
+    } else if (rotation_obj != mp_const_none) {
+        mp_raise_ValueError("Unsupported rotation value.");
+    }
+
+    display_ili9341_set_rotation(self, rotation);
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(ili9341_set_rotation_obj, ili9341_obj_set_rotation);
+
+const mp_obj_property_t ili9341_rotation_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&ili9341_get_rotation_obj,
+              (mp_obj_t)&ili9341_set_rotation_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
+
+STATIC const mp_rom_map_elem_t ili9341_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_fill),           MP_ROM_PTR(&ili9341_fill_obj) },
+    { MP_ROM_QSTR(MP_QSTR_fill_rectangle), MP_ROM_PTR(&ili9341_fill_rectangle_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pixel),          MP_ROM_PTR(&ili9341_pixel_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_rotation),       MP_ROM_PTR(&ili9341_rotation_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(ili9341_locals_dict, ili9341_locals_dict_table);
+
+const mp_obj_type_t display_ili9341_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_ILI9341,
+    .make_new = ili9341_make_new,
+    .locals_dict = (mp_obj_dict_t*)&ili9341_locals_dict,
+};

--- a/shared-bindings/display/ili9341.h
+++ b/shared-bindings/display/ili9341.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Artur Pacholec
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_DISPLAY_ILI9341_H
+#define MICROPY_INCLUDED_DISPLAY_ILI9341_H
+
+#include "py/obj.h"
+
+extern const mp_obj_type_t display_ili9341_type;
+
+#endif  // MICROPY_INCLUDED_DISPLAY_ILI9341_H

--- a/shared-bindings/display/rotation.c
+++ b/shared-bindings/display/rotation.c
@@ -1,0 +1,72 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Artur Pacholec
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "rotation.h"
+
+const mp_obj_type_t display_rotation_type;
+
+const display_rotation_obj_t display_rotation_0_obj = {
+    { &display_rotation_type },
+};
+
+const display_rotation_obj_t display_rotation_90_obj = {
+    { &display_rotation_type },
+};
+
+const display_rotation_obj_t display_rotation_180_obj = {
+    { &display_rotation_type },
+};
+
+const display_rotation_obj_t display_rotation_270_obj = {
+    { &display_rotation_type },
+};
+
+STATIC const mp_rom_map_elem_t rotation_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_R0),    MP_ROM_PTR(&display_rotation_0_obj) },
+    { MP_ROM_QSTR(MP_QSTR_R90),   MP_ROM_PTR(&display_rotation_90_obj) },
+    { MP_ROM_QSTR(MP_QSTR_R180),  MP_ROM_PTR(&display_rotation_180_obj) },
+    { MP_ROM_QSTR(MP_QSTR_R270),  MP_ROM_PTR(&display_rotation_270_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(rotation_locals_dict, rotation_locals_dict_table);
+
+STATIC void rotation_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    qstr rotation = MP_QSTR_R0;
+    if (MP_OBJ_TO_PTR(self_in) == MP_ROM_PTR(&display_rotation_90_obj)) {
+        rotation = MP_QSTR_R90;
+    } else if (MP_OBJ_TO_PTR(self_in) == MP_ROM_PTR(&display_rotation_180_obj)) {
+        rotation = MP_QSTR_R180;
+    } else if (MP_OBJ_TO_PTR(self_in) == MP_ROM_PTR(&display_rotation_270_obj)) {
+        rotation = MP_QSTR_R270;
+    }
+
+    mp_printf(print, "%q.%q.%q", MP_QSTR_display, MP_QSTR_Rotation, rotation);
+}
+
+const mp_obj_type_t display_rotation_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_Rotation,
+    .print = rotation_print,
+    .locals_dict = (mp_obj_t)&rotation_locals_dict,
+};

--- a/shared-bindings/display/rotation.h
+++ b/shared-bindings/display/rotation.h
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Artur Pacholec
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_DISPLAY_ROTATION_H
+#define MICROPY_INCLUDED_DISPLAY_ROTATION_H
+
+#include "py/obj.h"
+
+typedef enum {
+    ROTATION_0 = 0,
+    ROTATION_90,
+    ROTATION_180,
+    ROTATION_270
+} display_rotation_t;
+
+typedef struct {
+    mp_obj_base_t base;
+} display_rotation_obj_t;
+
+const mp_obj_type_t display_rotation_type;
+
+extern const display_rotation_obj_t display_rotation_0_obj;
+extern const display_rotation_obj_t display_rotation_90_obj;
+extern const display_rotation_obj_t display_rotation_180_obj;
+extern const display_rotation_obj_t display_rotation_270_obj;
+
+#endif  // MICROPY_INCLUDED_DISPLAY_ROTATION_H

--- a/shared-module/display/ili9341.c
+++ b/shared-module/display/ili9341.c
@@ -1,0 +1,229 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Artur Pacholec
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ili9341.h"
+
+inline void spi_write(ili9341_obj_t *self, const void * data,
+        size_t size) {
+    common_hal_digitalio_digitalinout_set_value(self->cs, false);
+
+    common_hal_busio_spi_write(self->spi, data, size);
+
+    common_hal_digitalio_digitalinout_set_value(self->cs, true);
+}
+
+inline void write_command(ili9341_obj_t *self, uint8_t c) {
+    common_hal_digitalio_digitalinout_set_value(self->dc, false);
+
+    spi_write(self, &c, sizeof(c));
+}
+
+inline void write_data(ili9341_obj_t *self, uint8_t c) {
+    common_hal_digitalio_digitalinout_set_value(self->dc, true);
+
+    spi_write(self, &c, sizeof(c));
+}
+
+void display_init9341_write_init(ili9341_obj_t *self) {
+    write_command(self, ILI9341_SWRESET);
+    mp_hal_delay_ms(120);
+
+    write_command(self, ILI9341_DISPOFF);
+    mp_hal_delay_ms(120);
+
+    write_command(self, ILI9341_PWCTRB);
+    write_data(self, 0x00);
+    write_data(self, 0XC1);
+    write_data(self, 0X30);
+
+    write_command(self, ILI9341_TIMCTRA);
+    write_data(self, 0x85);
+    write_data(self, 0x00);
+    write_data(self, 0x78);
+
+    write_command(self, ILI9341_PWCTRSEQ);
+    write_data(self, 0x39);
+    write_data(self, 0x2C);
+    write_data(self, 0x00);
+    write_data(self, 0x34);
+    write_data(self, 0x02);
+
+    write_command(self, ILI9341_PUMP);
+    write_data(self, 0x20);
+
+    write_command(self, ILI9341_TIMCTRB);
+    write_data(self, 0x00);
+    write_data(self, 0x00);
+
+    write_command(self, ILI9341_PWCTR1);
+    write_data(self, 0x23);
+
+    write_command(self, ILI9341_PWCTR2);
+    write_data(self, 0x10);
+
+    write_command(self, ILI9341_VMCTR1);
+    write_data(self, 0x3e);
+    write_data(self, 0x28);
+
+    write_command(self, ILI9341_VMCTR2);
+    write_data(self, 0x86);
+
+    write_command(self, ILI9341_MADCTL);
+    write_data(self, 0x48);
+
+    write_command(self, ILI9341_PIXFMT);
+    write_data(self, 0x55);
+
+    write_command(self, ILI9341_FRMCTR1);
+    write_data(self, 0x00);
+    write_data(self, 0x18);
+
+    write_command(self, ILI9341_DFUNCTR);
+    write_data(self, 0x08);
+    write_data(self, 0x82);
+    write_data(self, 0x27);
+
+    write_command(self, ILI9341_ENGMCTR);
+    write_data(self, 0x00);
+
+    write_command(self, ILI9341_GAMMASET);
+    write_data(self, 0x01);
+
+    write_command(self, ILI9341_GMCTRP1);
+    write_data(self, 0x0F);
+    write_data(self, 0x31);
+    write_data(self, 0x2B);
+    write_data(self, 0x0C);
+    write_data(self, 0x0E);
+    write_data(self, 0x08);
+    write_data(self, 0x4E);
+    write_data(self, 0xF1);
+    write_data(self, 0x37);
+    write_data(self, 0x07);
+    write_data(self, 0x10);
+    write_data(self, 0x03);
+    write_data(self, 0x0E);
+    write_data(self, 0x09);
+    write_data(self, 0x00);
+
+    write_command(self, ILI9341_GMCTRN1);
+    write_data(self, 0x00);
+    write_data(self, 0x0E);
+    write_data(self, 0x14);
+    write_data(self, 0x03);
+    write_data(self, 0x11);
+    write_data(self, 0x07);
+    write_data(self, 0x31);
+    write_data(self, 0xC1);
+    write_data(self, 0x48);
+    write_data(self, 0x08);
+    write_data(self, 0x0F);
+    write_data(self, 0x0C);
+    write_data(self, 0x31);
+    write_data(self, 0x36);
+    write_data(self, 0x0F);
+
+    write_command(self, ILI9341_SLPOUT);
+    mp_hal_delay_ms(120);
+
+    write_command(self, ILI9341_DISPON);
+}
+
+void display_ili9341_set_rotation(ili9341_obj_t *self,
+        display_rotation_t rotation)
+{
+    uint8_t data;
+
+    self->rotation = rotation;
+
+    write_command(self, ILI9341_MADCTL);
+
+    switch (self->rotation) {
+        case ROTATION_90:  data = (ILI9341_MADCTL_MV | ILI9341_MADCTL_BGR); break;
+        case ROTATION_180: data = (ILI9341_MADCTL_MY | ILI9341_MADCTL_BGR); break;
+        case ROTATION_270: data = (ILI9341_MADCTL_MX | ILI9341_MADCTL_MY | ILI9341_MADCTL_MV | ILI9341_MADCTL_BGR); break;
+        default:           data = (ILI9341_MADCTL_MX | ILI9341_MADCTL_BGR); break;
+    }
+
+    write_data(self, data);
+}
+
+void display_ili9341_set_addr_window(ili9341_obj_t *self, uint16_t x_0,
+        uint16_t y_0, uint16_t x_1, uint16_t y_1) {
+    write_command(self, ILI9341_CASET);
+    write_data(self, x_0 >> 8);
+    write_data(self, x_0);
+    write_data(self, x_1 >> 8);
+    write_data(self, x_1);
+
+    write_command(self, ILI9341_PASET);
+    write_data(self, y_0 >> 8);
+    write_data(self, y_0);
+    write_data(self, y_1 >> 8);
+    write_data(self, y_1);
+
+    write_command(self, ILI9341_RAMWR);
+}
+
+void display_ili9341_pixel(ili9341_obj_t *self, uint16_t x, uint16_t y,
+        uint32_t color) {
+    const uint8_t data[2] = {color >> 8, color};
+
+    display_ili9341_set_addr_window(self, x, y, x, y);
+
+    common_hal_digitalio_digitalinout_set_value(self->dc, true);
+
+    spi_write(self, data, sizeof(data));
+
+    common_hal_digitalio_digitalinout_set_value(self->dc, false);
+}
+
+void display_ili9341_rect(ili9341_obj_t *self, uint16_t x, uint16_t y,
+        uint16_t width, uint16_t height, uint32_t color)
+{
+    const uint8_t data[2] = { color >> 8, color };
+
+    display_ili9341_set_addr_window(self, x, y, x + width - 1, y + height - 1);
+
+    common_hal_digitalio_digitalinout_set_value(self->dc, true);
+
+    // Duff's device algorithm
+    uint32_t i = (height * width + 7) / 8;
+
+    switch ((height * width) % 8) {
+        case 0: do { spi_write(self, data, sizeof(data));
+        case 7:      spi_write(self, data, sizeof(data));
+        case 6:      spi_write(self, data, sizeof(data));
+        case 5:      spi_write(self, data, sizeof(data));
+        case 4:      spi_write(self, data, sizeof(data));
+        case 3:      spi_write(self, data, sizeof(data));
+        case 2:      spi_write(self, data, sizeof(data));
+        case 1:      spi_write(self, data, sizeof(data));
+                } while (--i > 0);
+    }
+
+    common_hal_digitalio_digitalinout_set_value(self->dc, false);
+}

--- a/shared-module/display/ili9341.h
+++ b/shared-module/display/ili9341.h
@@ -1,0 +1,125 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Artur Pacholec
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_MODULE_DISPLAY_ILI9341_H
+#define MICROPY_INCLUDED_SHARED_MODULE_DISPLAY_ILI9341_H
+
+#include "py/obj.h"
+#include "shared-bindings/busio/SPI.h"
+#include "shared-bindings/digitalio/DigitalInOut.h"
+#include "shared-bindings/display/rotation.h"
+
+#define ILI9341_NOP         0x00
+#define ILI9341_SWRESET     0x01
+#define ILI9341_RDDID       0x04
+#define ILI9341_RDDST       0x09
+
+#define ILI9341_SLPIN       0x10
+#define ILI9341_SLPOUT      0x11
+#define ILI9341_PTLON       0x12
+#define ILI9341_NORON       0x13
+
+#define ILI9341_RDMODE      0x0A
+#define ILI9341_RDMADCTL    0x0B
+#define ILI9341_RDPIXFMT    0x0C
+#define ILI9341_RDIMGFMT    0x0D
+#define ILI9341_RDSELFDIAG  0x0F
+
+#define ILI9341_INVOFF      0x20
+#define ILI9341_INVON       0x21
+#define ILI9341_GAMMASET    0x26
+#define ILI9341_DISPOFF     0x28
+#define ILI9341_DISPON      0x29
+
+#define ILI9341_CASET       0x2A
+#define ILI9341_PASET       0x2B
+#define ILI9341_RAMWR       0x2C
+#define ILI9341_RAMRD       0x2E
+
+#define ILI9341_PTLAR       0x30
+#define ILI9341_MADCTL      0x36
+#define ILI9341_PIXFMT      0x3A
+
+#define ILI9341_FRMCTR1     0xB1
+#define ILI9341_FRMCTR2     0xB2
+#define ILI9341_FRMCTR3     0xB3
+#define ILI9341_INVCTR      0xB4
+#define ILI9341_DFUNCTR     0xB6
+
+#define ILI9341_PWCTR1      0xC0
+#define ILI9341_PWCTR2      0xC1
+#define ILI9341_PWCTR3      0xC2
+#define ILI9341_PWCTR4      0xC3
+#define ILI9341_PWCTR5      0xC4
+#define ILI9341_VMCTR1      0xC5
+#define ILI9341_VMCTR2      0xC7
+#define ILI9341_PWCTRSEQ    0xCB
+#define ILI9341_PWCTRA      0xCD
+#define ILI9341_PWCTRB      0xCF
+
+#define ILI9341_RDID1       0xDA
+#define ILI9341_RDID2       0xDB
+#define ILI9341_RDID3       0xDC
+#define ILI9341_RDID4       0xDD
+
+#define ILI9341_GMCTRP1     0xE0
+#define ILI9341_GMCTRN1     0xE1
+#define ILI9341_DGMCTR1     0xE2
+#define ILI9341_DGMCTR2     0xE3
+#define ILI9341_TIMCTRA     0xE8
+#define ILI9341_TIMCTRB     0xEA
+
+#define ILI9341_ENGMCTR     0xF2
+#define ILI9341_INCTR       0xF6
+#define ILI9341_PUMP        0xF7
+
+#define ILI9341_MADCTL_MY   0x80
+#define ILI9341_MADCTL_MX   0x40
+#define ILI9341_MADCTL_MV   0x20
+#define ILI9341_MADCTL_ML   0x10
+#define ILI9341_MADCTL_RGB  0x00
+#define ILI9341_MADCTL_BGR  0x08
+#define ILI9341_MADCTL_MH   0x04
+
+typedef struct {
+    mp_obj_base_t base;
+    display_rotation_t rotation;
+    busio_spi_obj_t *spi;
+    digitalio_digitalinout_obj_t *cs;
+    digitalio_digitalinout_obj_t *dc;
+} ili9341_obj_t;
+
+void display_init9341_write_init(ili9341_obj_t *self);
+void display_ili9341_set_rotation(ili9341_obj_t *self,
+        display_rotation_t rotation);
+void display_ili9341_set_addr_window(ili9341_obj_t *self, uint16_t x_0,
+        uint16_t y_0, uint16_t x_1, uint16_t y_1);
+void display_ili9341_pixel(ili9341_obj_t *self, uint16_t x, uint16_t y,
+        uint32_t color);
+void display_ili9341_rect(ili9341_obj_t *self, uint16_t x, uint16_t y,
+        uint16_t width, uint16_t height, uint32_t color);
+
+#endif  // MICROPY_INCLUDED_SHARED_MODULE_DISPLAY_ILI9341_H


### PR DESCRIPTION
This is just a RFC, there is no documentation and error-checking yet, please ignore that :)

The idea is to be compatible with https://github.com/adafruit/Adafruit_CircuitPython_RGB_Display (Also TODO).

Example usage:
```
import busio
import digitalio
import display
import board

cs = digitalio.DigitalInOut(board.P1_12)
cs.switch_to_output()
cs.value = 1

dc = digitalio.DigitalInOut(board.P1_11)
dc.switch_to_output()

spi = busio.SPI(board.P1_15, MOSI=board.P1_13)
spi.try_lock()
spi.configure(baudrate=10000000, phase=0, polarity=0) # Required (?) for nRF

ili = display.ILI9341(spi, dc, cs)
ili.fill(123)
```