### PR TITLE
Allow mounting '/' on '/'

### DIFF
--- a/extmod/vfs_fat_diskio.c
+++ b/extmod/vfs_fat_diskio.c
@@ -135,7 +135,7 @@ DRESULT disk_read (
         if (nlr_push(&nlr) == 0) {
             mp_obj_t ret = mp_call_method_n_kw(2, 0, vfs->readblocks);
             nlr_pop();
-            if (mp_obj_get_int(ret) != 0) {
+            if (ret != mp_const_none && MP_OBJ_SMALL_INT_VALUE(ret) != 0) {
                 return RES_ERROR;
             }
         } else {
@@ -180,7 +180,7 @@ DRESULT disk_write (
         if (nlr_push(&nlr) == 0) {
             mp_obj_t ret = mp_call_method_n_kw(2, 0, vfs->writeblocks);
             nlr_pop();
-            if (mp_obj_get_int(ret) != 0) {
+            if (ret != mp_const_none && MP_OBJ_SMALL_INT_VALUE(ret) != 0) {
                 return RES_ERROR;
             }
         } else {

--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -65,12 +65,15 @@ void common_hal_storage_mount(mp_obj_t vfs_obj, const char* mount_path, bool rea
     args[1] = mp_const_false; // Don't make the file system automatically when mounting.
 
     // Check that there's no file or directory with the same name as the mount point.
-    nlr_buf_t nlr;
-    if (nlr_push(&nlr) == 0) {
-        common_hal_os_stat(mount_path);
-        nlr_pop();
-        // Something with the same name exists.
-        mp_raise_OSError(MP_EEXIST);
+    // But it's ok to mount '/' in any case.
+    if (strcmp(vfs->str, "/") != 0) {
+        nlr_buf_t nlr;
+        if (nlr_push(&nlr) == 0) {
+            common_hal_os_stat(mount_path);
+            nlr_pop();
+            // Something with the same name exists.
+            mp_raise_OSError(MP_EEXIST);
+        }
     }
 
     // check that the destination mount point is unused


### PR DESCRIPTION
Allow mounting '/' on '/'. This was done in C code in atmel-samd, but esp8266 does it in Python code, which fell afoul of #935.

Also relaxes requirement that filesystem operations `readblocks()` and `writeblocks()` return `0` on success. They can return `None` or `0`. Any other return is considered to be an error status code.

@jerryneedell may test this afternoon after 4pm ET.

Fixes #947.

