### PR TITLE
Fixed issue with code in docs for audioio

### DIFF
--- a/shared-bindings/audioio/AudioOut.c
+++ b/shared-bindings/audioio/AudioOut.c
@@ -65,10 +65,10 @@
 //|         sine_wave[i] = int(math.sin(math.pi * 2 * i / 18) * (2 ** 15) + 2 ** 15)
 //|
 //|     dac = audioio.AudioOut(board.SPEAKER)
-//|     sine_wave = audioio.RawSample(sine_wave, mono=True, sample_rate=8000)
+//|     sine_wave = audioio.RawSample(sine_wave, sample_rate=8000)
 //|     dac.play(sine_wave, loop=True)
 //|     time.sleep(1)
-//|     sample.stop()
+//|     dac.stop()
 //|
 //|   Playing a wave file from flash::
 //|

--- a/shared-bindings/audioio/RawSample.c
+++ b/shared-bindings/audioio/RawSample.c
@@ -70,7 +70,7 @@
 //|     sine_wave = audioio.RawSample(sine_wave)
 //|     dac.play(sine_wave, loop=True)
 //|     time.sleep(1)
-//|     sample.stop()
+//|     dac.stop()
 //|
 STATIC mp_obj_t audioio_rawsample_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
     mp_arg_check_num(n_args, n_kw, 1, 2, true);


### PR DESCRIPTION
Removed incorrect arg from `RawSample` in `AudioOut` example code. Updated variable `sample` to `dac` to match earlier use in code example.