### PR TITLE
Add STATIC_BUILD make flag for mpy-cross to build a static executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,8 @@ TAGS
 #################
 *.orig
 
+# Emacs backup files
+####################
+*~
+
 *.DS_Store

--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -35,6 +35,13 @@ CWARN += -Wpointer-arith -Wuninitialized
 CFLAGS = $(INC) $(CWARN) -std=gnu99 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
 CFLAGS += -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables
 
+# Build a static executable.
+# Useful for Windows builds, etc., that must run on multiple operating system versions.
+ifdef STATIC_BUILD
+CFLAGS += -static -static-libgcc -static-libstdc++
+endif
+
+
 # Debugging/Optimization
 ifdef DEBUG
 CFLAGS += -g
@@ -56,6 +63,10 @@ else
 LDFLAGS_ARCH = -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 endif
 LDFLAGS = $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
+
+ifdef STATIC_BUILD
+LDFLAGS += -static -static-libgcc -static-libstdc++
+endif
 
 # source files
 SRC_C = \

--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -14,7 +14,13 @@ endif
 include ../py/mkenv.mk
 
 # define main target
+
+ifeq ($(OS),Windows_NT)
+# Detect a MINGW32 build, and change the name of the final executable.
+PROG = mpy-cross.exe
+else
 PROG = mpy-cross
+endif
 
 # qstr definitions (must come before including py.mk)
 QSTR_DEFS = qstrdefsport.h

--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -85,6 +85,50 @@
 #define MICROPY_PY_IO               (0)
 #define MICROPY_PY_SYS              (0)
 
+// MINGW only handles these errno names.
+#ifdef __MINGW32__
+#define MICROPY_PY_UERRNO_LIST \
+  X(EPERM) \
+  X(ENOENT) \
+  X(ESRCH) \
+  X(EINTR) \
+  X(EIO) \
+  X(ENXIO) \
+  X(E2BIG) \
+  X(ENOEXEC) \
+  X(EBADF) \
+  X(ECHILD) \
+  X(EAGAIN) \
+  X(ENOMEM) \
+  X(EACCES) \
+  X(EFAULT) \
+  X(EBUSY) \
+  X(EEXIST) \
+  X(EXDEV) \
+  X(ENODEV) \
+  X(ENOTDIR) \
+  X(EISDIR) \
+  X(EINVAL) \
+  X(ENFILE) \
+  X(EMFILE) \
+  X(ENOTTY) \
+  X(EFBIG) \
+  X(ENOSPC) \
+  X(ESPIPE) \
+  X(EROFS) \
+  X(EMLINK) \
+  X(EPIPE) \
+  X(EDOM) \
+  X(ERANGE) \
+  X(EDEADLOCK) \
+  X(EDEADLK) \
+  X(ENAMETOOLONG) \
+  X(ENOLCK) \
+  X(ENOSYS) \
+  X(ENOTEMPTY) \
+  X(EILSEQ)
+#endif
+  
 // type definitions for the specific machine
 
 #ifdef __LP64__


### PR DESCRIPTION
I have been building Windows versions of `mpy-cross` statically with mingw32, so that they don't depend on any DLL's and can be used on multiple versions of Windows. This makes my hacky edit more formal and records it. This might be useful on other OS's too, so that we can have a general MacOS or a general Linux version.