### PR TITLE
Reduce pin object size by removing the QSTR

### DIFF
--- a/ports/atmel-samd/common-hal/analogio/AnalogIn.c
+++ b/ports/atmel-samd/common-hal/analogio/AnalogIn.c
@@ -63,7 +63,7 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t* self,
     }
     claim_pin(pin);
 
-    gpio_set_pin_function(pin->pin, GPIO_PIN_FUNCTION_B);
+    gpio_set_pin_function(pin->number, GPIO_PIN_FUNCTION_B);
 
     static Adc* adc_insts[] = ADC_INSTS;
     self->instance = adc_insts[adc_index];
@@ -79,7 +79,7 @@ void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self) {
     if (common_hal_analogio_analogin_deinited(self)) {
         return;
     }
-    reset_pin(self->pin->pin);
+    reset_pin(self->pin->number);
     self->pin = mp_const_none;
 }
 

--- a/ports/atmel-samd/common-hal/analogio/AnalogOut.c
+++ b/ports/atmel-samd/common-hal/analogio/AnalogOut.c
@@ -44,9 +44,9 @@
 
 void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self,
         const mcu_pin_obj_t *pin) {
-    if (pin->pin != PIN_PA02
+    if (pin->number != PIN_PA02
     #ifdef SAMD51
-        && pin->pin != PIN_PA05
+        && pin->number != PIN_PA05
     #endif
     ) {
         mp_raise_ValueError("AnalogOut not supported on given pin");
@@ -55,7 +55,7 @@ void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self,
 
     self->channel = 0;
     #ifdef SAMD51
-    if (pin->pin == PIN_PA05) {
+    if (pin->number == PIN_PA05) {
         self->channel = 1;
     }
     #endif
@@ -93,7 +93,7 @@ void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self,
     }
     claim_pin(pin);
 
-    gpio_set_pin_function(pin->pin, GPIO_PIN_FUNCTION_B);
+    gpio_set_pin_function(pin->number, GPIO_PIN_FUNCTION_B);
 
     dac_sync_enable_channel(&self->descriptor, self->channel);
 }

--- a/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
+++ b/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -193,9 +193,9 @@ void common_hal_audiobusio_i2sout_construct(audiobusio_i2sout_obj_t* self,
     claim_pin(word_select);
     claim_pin(data);
 
-    gpio_set_pin_function(self->bit_clock->pin, GPIO_I2S_FUNCTION);
-    gpio_set_pin_function(self->word_select->pin, GPIO_I2S_FUNCTION);
-    gpio_set_pin_function(self->data->pin, GPIO_I2S_FUNCTION);
+    gpio_set_pin_function(self->bit_clock->number, GPIO_I2S_FUNCTION);
+    gpio_set_pin_function(self->word_select->number, GPIO_I2S_FUNCTION);
+    gpio_set_pin_function(self->data->number, GPIO_I2S_FUNCTION);
 
     self->left_justified = left_justified;
     self->playing = false;
@@ -211,11 +211,11 @@ void common_hal_audiobusio_i2sout_deinit(audiobusio_i2sout_obj_t* self) {
         return;
     }
 
-    reset_pin(self->bit_clock->pin);
+    reset_pin(self->bit_clock->number);
     self->bit_clock = mp_const_none;
-    reset_pin(self->word_select->pin);
+    reset_pin(self->word_select->number);
     self->word_select = mp_const_none;
-    reset_pin(self->data->pin);
+    reset_pin(self->data->number);
     self->data = mp_const_none;
 }
 

--- a/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+++ b/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
@@ -210,8 +210,8 @@ void common_hal_audiobusio_pdmin_construct(audiobusio_pdmin_obj_t* self,
     claim_pin(clock_pin);
     claim_pin(data_pin);
 
-    gpio_set_pin_function(self->clock_pin->pin, GPIO_I2S_FUNCTION);
-    gpio_set_pin_function(self->data_pin->pin, GPIO_I2S_FUNCTION);
+    gpio_set_pin_function(self->clock_pin->number, GPIO_I2S_FUNCTION);
+    gpio_set_pin_function(self->data_pin->number, GPIO_I2S_FUNCTION);
 
     self->bytes_per_sample = oversample >> 3;
     self->bit_depth = bit_depth;
@@ -234,8 +234,8 @@ void common_hal_audiobusio_pdmin_deinit(audiobusio_pdmin_obj_t* self) {
     disconnect_gclk_from_peripheral(self->gclk, I2S_GCLK_ID_0 + self->clock_unit);
     disable_clock_generator(self->gclk);
 
-    reset_pin(self->clock_pin->pin);
-    reset_pin(self->data_pin->pin);
+    reset_pin(self->clock_pin->number);
+    reset_pin(self->data_pin->number);
     self->clock_pin = mp_const_none;
     self->data_pin = mp_const_none;
 }

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -93,12 +93,12 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t* self,
     if (right_channel != NULL) {
         claim_pin(right_channel);
         self->right_channel = right_channel;
-        gpio_set_pin_function(self->right_channel->pin, GPIO_PIN_FUNCTION_B);
+        gpio_set_pin_function(self->right_channel->number, GPIO_PIN_FUNCTION_B);
         audio_dma_init(&self->right_dma);
     }
     #endif
     self->left_channel = left_channel;
-    gpio_set_pin_function(self->left_channel->pin, GPIO_PIN_FUNCTION_B);
+    gpio_set_pin_function(self->left_channel->number, GPIO_PIN_FUNCTION_B);
     audio_dma_init(&self->left_dma);
 
     #ifdef SAMD51
@@ -243,10 +243,10 @@ void common_hal_audioio_audioout_deinit(audioio_audioout_obj_t* self) {
 
     tc_set_enable(tc_insts[self->tc_index], false);
 
-    reset_pin(self->left_channel->pin);
+    reset_pin(self->left_channel->number);
     self->left_channel = mp_const_none;
     #ifdef SAMD51
-    reset_pin(self->right_channel->pin);
+    reset_pin(self->right_channel->number);
     self->right_channel = mp_const_none;
     #endif
 }

--- a/ports/atmel-samd/common-hal/busio/I2C.c
+++ b/ports/atmel-samd/common-hal/busio/I2C.c
@@ -59,11 +59,11 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
             sda->sercom[i].pad != 0) {
             continue;
         }
-        sda_pinmux = PINMUX(sda->pin, (i == 0) ? MUX_C : MUX_D);
+        sda_pinmux = PINMUX(sda->number, (i == 0) ? MUX_C : MUX_D);
         for (int j = 0; j < NUM_SERCOMS_PER_PIN; j++) {
             if (sercom_index == scl->sercom[j].index &&
                 scl->sercom[j].pad == 1) {
-                scl_pinmux = PINMUX(scl->pin, (j == 0) ? MUX_C : MUX_D);
+                scl_pinmux = PINMUX(scl->number, (j == 0) ? MUX_C : MUX_D);
                 sercom = potential_sercom;
                 break;
             }
@@ -77,36 +77,36 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     }
 
     // Test that the pins are in a high state. (Hopefully indicating they are pulled up.)
-    gpio_set_pin_function(sda->pin, GPIO_PIN_FUNCTION_OFF);
-    gpio_set_pin_function(scl->pin, GPIO_PIN_FUNCTION_OFF);
-    gpio_set_pin_direction(sda->pin, GPIO_DIRECTION_IN);
-    gpio_set_pin_direction(scl->pin, GPIO_DIRECTION_IN);
+    gpio_set_pin_function(sda->number, GPIO_PIN_FUNCTION_OFF);
+    gpio_set_pin_function(scl->number, GPIO_PIN_FUNCTION_OFF);
+    gpio_set_pin_direction(sda->number, GPIO_DIRECTION_IN);
+    gpio_set_pin_direction(scl->number, GPIO_DIRECTION_IN);
 
-    gpio_set_pin_pull_mode(sda->pin, GPIO_PULL_DOWN);
-    gpio_set_pin_pull_mode(scl->pin, GPIO_PULL_DOWN);
+    gpio_set_pin_pull_mode(sda->number, GPIO_PULL_DOWN);
+    gpio_set_pin_pull_mode(scl->number, GPIO_PULL_DOWN);
 
     common_hal_mcu_delay_us(10);
 
-    gpio_set_pin_pull_mode(sda->pin, GPIO_PULL_OFF);
-    gpio_set_pin_pull_mode(scl->pin, GPIO_PULL_OFF);
+    gpio_set_pin_pull_mode(sda->number, GPIO_PULL_OFF);
+    gpio_set_pin_pull_mode(scl->number, GPIO_PULL_OFF);
 
     // We must pull up within 3us to achieve 400khz.
     common_hal_mcu_delay_us(3);
 
-    if (!gpio_get_pin_level(sda->pin) || !gpio_get_pin_level(scl->pin)) {
-        reset_pin(sda->pin);
-        reset_pin(scl->pin);
+    if (!gpio_get_pin_level(sda->number) || !gpio_get_pin_level(scl->number)) {
+        reset_pin(sda->number);
+        reset_pin(scl->number);
         mp_raise_RuntimeError("SDA or SCL needs a pull up");
     }
-    gpio_set_pin_function(sda->pin, sda_pinmux);
-    gpio_set_pin_function(scl->pin, scl_pinmux);
+    gpio_set_pin_function(sda->number, sda_pinmux);
+    gpio_set_pin_function(scl->number, scl_pinmux);
 
     // Set up I2C clocks on sercom.
     samd_peripherals_sercom_clock_init(sercom, sercom_index);
 
     if (i2c_m_sync_init(&self->i2c_desc, sercom) != ERR_NONE) {
-        reset_pin(sda->pin);
-        reset_pin(scl->pin);
+        reset_pin(sda->number);
+        reset_pin(scl->number);
         mp_raise_OSError(MP_EIO);
     }
 
@@ -114,13 +114,13 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
 
     // Frequency must be set before the I2C device is enabled.
     if (i2c_m_sync_set_baudrate(&self->i2c_desc, 0, frequency / 1000) != ERR_NONE) {
-        reset_pin(sda->pin);
-        reset_pin(scl->pin);
+        reset_pin(sda->number);
+        reset_pin(scl->number);
         mp_raise_ValueError("Unsupported baudrate");
     }
 
-    self->sda_pin = sda->pin;
-    self->scl_pin = scl->pin;
+    self->sda_pin = sda->number;
+    self->scl_pin = scl->number;
     claim_pin(sda);
     claim_pin(scl);
 

--- a/ports/atmel-samd/common-hal/busio/SPI.c
+++ b/ports/atmel-samd/common-hal/busio/SPI.c
@@ -69,7 +69,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         #endif
             continue;
         }
-        clock_pinmux = PINMUX(clock->pin, (i == 0) ? MUX_C : MUX_D);
+        clock_pinmux = PINMUX(clock->number, (i == 0) ? MUX_C : MUX_D);
         clock_pad = clock->sercom[i].pad;
         if (!samd_peripherals_valid_spi_clock_pad(clock_pad)) {
             continue;
@@ -77,7 +77,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         for (int j = 0; j < NUM_SERCOMS_PER_PIN; j++) {
             if (!mosi_none) {
                 if (sercom_index == mosi->sercom[j].index) {
-                    mosi_pinmux = PINMUX(mosi->pin, (j == 0) ? MUX_C : MUX_D);
+                    mosi_pinmux = PINMUX(mosi->number, (j == 0) ? MUX_C : MUX_D);
                     mosi_pad = mosi->sercom[j].pad;
                     dopo = samd_peripherals_get_spi_dopo(clock_pad, mosi_pad);
                     if (dopo > 0x3) {
@@ -94,7 +94,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
             if (!miso_none) {
                 for (int k = 0; k < NUM_SERCOMS_PER_PIN; k++) {
                     if (sercom_index == miso->sercom[k].index) {
-                        miso_pinmux = PINMUX(miso->pin, (k == 0) ? MUX_C : MUX_D);
+                        miso_pinmux = PINMUX(miso->number, (k == 0) ? MUX_C : MUX_D);
                         miso_pad = miso->sercom[k].pad;
                         sercom = potential_sercom;
                         break;
@@ -138,29 +138,29 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         mp_raise_OSError(MP_EIO);
     }
 
-    gpio_set_pin_direction(clock->pin, GPIO_DIRECTION_OUT);
-    gpio_set_pin_pull_mode(clock->pin, GPIO_PULL_OFF);
-    gpio_set_pin_function(clock->pin, clock_pinmux);
+    gpio_set_pin_direction(clock->number, GPIO_DIRECTION_OUT);
+    gpio_set_pin_pull_mode(clock->number, GPIO_PULL_OFF);
+    gpio_set_pin_function(clock->number, clock_pinmux);
     claim_pin(clock);
-    self->clock_pin = clock->pin;
+    self->clock_pin = clock->number;
 
     if (mosi_none) {
         self->MOSI_pin = NO_PIN;
     } else {
-        gpio_set_pin_direction(mosi->pin, GPIO_DIRECTION_OUT);
-        gpio_set_pin_pull_mode(mosi->pin, GPIO_PULL_OFF);
-        gpio_set_pin_function(mosi->pin, mosi_pinmux);
-        self->MOSI_pin = mosi->pin;
+        gpio_set_pin_direction(mosi->number, GPIO_DIRECTION_OUT);
+        gpio_set_pin_pull_mode(mosi->number, GPIO_PULL_OFF);
+        gpio_set_pin_function(mosi->number, mosi_pinmux);
+        self->MOSI_pin = mosi->number;
         claim_pin(mosi);
     }
 
     if (miso_none) {
         self->MISO_pin = NO_PIN;
     } else {
-        gpio_set_pin_direction(miso->pin, GPIO_DIRECTION_IN);
-        gpio_set_pin_pull_mode(miso->pin, GPIO_PULL_OFF);
-        gpio_set_pin_function(miso->pin, miso_pinmux);
-        self->MISO_pin = miso->pin;
+        gpio_set_pin_direction(miso->number, GPIO_DIRECTION_IN);
+        gpio_set_pin_pull_mode(miso->number, GPIO_PULL_OFF);
+        gpio_set_pin_function(miso->number, miso_pinmux);
+        self->MISO_pin = miso->number;
         claim_pin(miso);
     }
 

--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -91,7 +91,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
                   tx->sercom[i].pad == 2)) {
                 continue;
             }
-            tx_pinmux = PINMUX(tx->pin, (i == 0) ? MUX_C : MUX_D);
+            tx_pinmux = PINMUX(tx->number, (i == 0) ? MUX_C : MUX_D);
             tx_pad = tx->sercom[i].pad;
             if (rx == mp_const_none) {
                 sercom = potential_sercom;
@@ -103,7 +103,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
                   sercom_insts[rx->sercom[j].index]->USART.CTRLA.bit.ENABLE == 0) ||
                  sercom_index == rx->sercom[j].index) &&
                 rx->sercom[j].pad != tx_pad) {
-                rx_pinmux = PINMUX(rx->pin, (j == 0) ? MUX_C : MUX_D);
+                rx_pinmux = PINMUX(rx->number, (j == 0) ? MUX_C : MUX_D);
                 rx_pad = rx->sercom[j].pad;
                 sercom = sercom_insts[rx->sercom[j].index];
                 sercom_index = rx->sercom[j].index;
@@ -187,20 +187,20 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
 
 
     if (have_tx) {
-        gpio_set_pin_direction(tx->pin, GPIO_DIRECTION_OUT);
-        gpio_set_pin_pull_mode(tx->pin, GPIO_PULL_OFF);
-        gpio_set_pin_function(tx->pin, tx_pinmux);
-        self->tx_pin  = tx->pin;
+        gpio_set_pin_direction(tx->number, GPIO_DIRECTION_OUT);
+        gpio_set_pin_pull_mode(tx->number, GPIO_PULL_OFF);
+        gpio_set_pin_function(tx->number, tx_pinmux);
+        self->tx_pin  = tx->number;
         claim_pin(tx);
     } else {
         self->tx_pin = NO_PIN;
     }
 
     if (have_rx) {
-        gpio_set_pin_direction(rx->pin, GPIO_DIRECTION_IN);
-        gpio_set_pin_pull_mode(rx->pin, GPIO_PULL_OFF);
-        gpio_set_pin_function(rx->pin, rx_pinmux);
-        self->rx_pin  = rx->pin;
+        gpio_set_pin_direction(rx->number, GPIO_DIRECTION_IN);
+        gpio_set_pin_pull_mode(rx->number, GPIO_PULL_OFF);
+        gpio_set_pin_function(rx->number, rx_pinmux);
+        self->rx_pin  = rx->number;
         claim_pin(rx);
     } else {
         self->rx_pin = NO_PIN;

--- a/ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
+++ b/ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
@@ -41,8 +41,8 @@ digitalinout_result_t common_hal_digitalio_digitalinout_construct(
     self->pin = pin;
 
     // Must set pull after setting direction.
-    gpio_set_pin_direction(pin->pin, GPIO_DIRECTION_IN);
-    gpio_set_pin_pull_mode(pin->pin, GPIO_PULL_OFF);
+    gpio_set_pin_direction(pin->number, GPIO_DIRECTION_IN);
+    gpio_set_pin_pull_mode(pin->number, GPIO_PULL_OFF);
     return DIGITALINOUT_OK;
 }
 
@@ -54,7 +54,7 @@ void common_hal_digitalio_digitalinout_deinit(digitalio_digitalinout_obj_t* self
     if (common_hal_digitalio_digitalinout_deinited(self)) {
         return;
     }
-    reset_pin(self->pin->pin);
+    reset_pin(self->pin->number);
     self->pin = mp_const_none;
 }
 
@@ -68,7 +68,7 @@ void common_hal_digitalio_digitalinout_switch_to_input(
 void common_hal_digitalio_digitalinout_switch_to_output(
         digitalio_digitalinout_obj_t* self, bool value,
         digitalio_drive_mode_t drive_mode) {
-    const uint8_t pin = self->pin->pin;
+    const uint8_t pin = self->pin->number;
     gpio_set_pin_pull_mode(pin, GPIO_PULL_OFF);
     // Turn on "strong" pin driving (more current available). See DRVSTR doc in datasheet.
     hri_port_set_PINCFG_DRVSTR_bit(PORT, (enum gpio_port)GPIO_PORT(pin), GPIO_PIN(pin));
@@ -87,7 +87,7 @@ digitalio_direction_t common_hal_digitalio_digitalinout_get_direction(
 
 void common_hal_digitalio_digitalinout_set_value(
         digitalio_digitalinout_obj_t* self, bool value) {
-    const uint8_t pin = self->pin->pin;
+    const uint8_t pin = self->pin->number;
     const uint8_t port = GPIO_PORT(pin);
     const uint32_t pin_mask = 1U << GPIO_PIN(pin);
     if (value) {
@@ -108,7 +108,7 @@ void common_hal_digitalio_digitalinout_set_value(
 
 bool common_hal_digitalio_digitalinout_get_value(
         digitalio_digitalinout_obj_t* self) {
-    const uint8_t pin = self->pin->pin;
+    const uint8_t pin = self->pin->number;
     if (!self->output) {
         return gpio_get_pin_level(pin);
     } else {
@@ -156,13 +156,13 @@ void common_hal_digitalio_digitalinout_set_pull(
             break;
     }
     // Must set pull after setting direction.
-    gpio_set_pin_direction(self->pin->pin, GPIO_DIRECTION_IN);
-    gpio_set_pin_pull_mode(self->pin->pin, asf_pull);
+    gpio_set_pin_direction(self->pin->number, GPIO_DIRECTION_IN);
+    gpio_set_pin_pull_mode(self->pin->number, asf_pull);
 }
 
 digitalio_pull_t common_hal_digitalio_digitalinout_get_pull(
         digitalio_digitalinout_obj_t* self) {
-    uint32_t pin = self->pin->pin;
+    uint32_t pin = self->pin->number;
     if (self->output) {
         mp_raise_AttributeError("Cannot get pull while in output mode");
         return PULL_NONE;

--- a/ports/atmel-samd/common-hal/microcontroller/Pin.c
+++ b/ports/atmel-samd/common-hal/microcontroller/Pin.c
@@ -85,9 +85,9 @@ void reset_all_pins(void) {
     // After configuring SWD because it may be shared.
     #ifdef SPEAKER_ENABLE_PIN
     speaker_enable_in_use = false;
-    gpio_set_pin_function(SPEAKER_ENABLE_PIN->pin, GPIO_PIN_FUNCTION_OFF);
-    gpio_set_pin_direction(SPEAKER_ENABLE_PIN->pin, GPIO_DIRECTION_OUT);
-    gpio_set_pin_level(SPEAKER_ENABLE_PIN->pin, false);
+    gpio_set_pin_function(SPEAKER_ENABLE_PIN->number, GPIO_PIN_FUNCTION_OFF);
+    gpio_set_pin_direction(SPEAKER_ENABLE_PIN->number, GPIO_DIRECTION_OUT);
+    gpio_set_pin_level(SPEAKER_ENABLE_PIN->number, false);
     #endif
 }
 
@@ -97,17 +97,17 @@ void reset_pin(uint8_t pin) {
     }
 
     #ifdef MICROPY_HW_NEOPIXEL
-    if (pin == MICROPY_HW_NEOPIXEL->pin) {
+    if (pin == MICROPY_HW_NEOPIXEL->number) {
         neopixel_in_use = false;
         rgb_led_status_init();
         return;
     }
     #endif
     #ifdef MICROPY_HW_APA102_MOSI
-    if (pin == MICROPY_HW_APA102_MOSI->pin ||
-        pin == MICROPY_HW_APA102_SCK->pin) {
-        apa102_mosi_in_use = apa102_mosi_in_use && pin != MICROPY_HW_APA102_MOSI->pin;
-        apa102_sck_in_use = apa102_sck_in_use && pin != MICROPY_HW_APA102_SCK->pin;
+    if (pin == MICROPY_HW_APA102_MOSI->number ||
+        pin == MICROPY_HW_APA102_SCK->number) {
+        apa102_mosi_in_use = apa102_mosi_in_use && pin != MICROPY_HW_APA102_MOSI->number;
+        apa102_sck_in_use = apa102_sck_in_use && pin != MICROPY_HW_APA102_SCK->number;
         if (!apa102_sck_in_use && !apa102_mosi_in_use) {
             rgb_led_status_init();
         }
@@ -130,11 +130,11 @@ void reset_pin(uint8_t pin) {
     }
 
     #ifdef SPEAKER_ENABLE_PIN
-    if (pin == SPEAKER_ENABLE_PIN->pin) {
+    if (pin == SPEAKER_ENABLE_PIN->number) {
         speaker_enable_in_use = false;
         gpio_set_pin_function(pin, GPIO_PIN_FUNCTION_OFF);
-        gpio_set_pin_direction(SPEAKER_ENABLE_PIN->pin, GPIO_DIRECTION_OUT);
-        gpio_set_pin_level(SPEAKER_ENABLE_PIN->pin, false);
+        gpio_set_pin_direction(SPEAKER_ENABLE_PIN->number, GPIO_DIRECTION_OUT);
+        gpio_set_pin_level(SPEAKER_ENABLE_PIN->number, false);
     }
     #endif
 }
@@ -182,12 +182,12 @@ bool common_hal_mcu_pin_is_free(const mcu_pin_obj_t* pin) {
     }
     #endif
 
-    PortGroup *const port = &PORT->Group[(enum gpio_port)GPIO_PORT(pin->pin)];
-    uint8_t pin_index = GPIO_PIN(pin->pin);
+    PortGroup *const port = &PORT->Group[(enum gpio_port)GPIO_PORT(pin->number)];
+    uint8_t pin_index = GPIO_PIN(pin->number);
     volatile PORT_PINCFG_Type *state = &port->PINCFG[pin_index];
     volatile PORT_PMUX_Type *pmux = &port->PMUX[pin_index / 2];
 
-    if (pin->pin == PIN_PA30 || pin->pin == PIN_PA31) {
+    if (pin->number == PIN_PA30 || pin->number == PIN_PA31) {
         return state->bit.PMUXEN == 1 && ((pmux->reg >> (4 * pin_index % 2)) & 0xf) == 0x6;
     }
 

--- a/ports/atmel-samd/common-hal/neopixel_write/__init__.c
+++ b/ports/atmel-samd/common-hal/neopixel_write/__init__.c
@@ -90,7 +90,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
     hri_nvmctrl_set_CTRLA_CACHEDIS1_bit(NVMCTRL);
    #endif
 
-    uint32_t pin = digitalinout->pin->pin;
+    uint32_t pin = digitalinout->pin->number;
     port    =  &PORT->Group[GPIO_PORT(pin)];  // Convert GPIO # to port register
     pinMask =  (1UL << (pin % 32));  // From port_pin_set_output_level ASF code.
     ptr     =  pixels;

--- a/ports/atmel-samd/common-hal/pulseio/PWMOut.c
+++ b/ports/atmel-samd/common-hal/pulseio/PWMOut.c
@@ -252,7 +252,7 @@ void common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self,
 
     self->timer = timer;
 
-    gpio_set_pin_function(pin->pin, GPIO_PIN_FUNCTION_E + mux_position);
+    gpio_set_pin_function(pin->number, GPIO_PIN_FUNCTION_E + mux_position);
 
     common_hal_pulseio_pwmout_set_duty_cycle(self, duty);
 }
@@ -284,7 +284,7 @@ void common_hal_pulseio_pwmout_deinit(pulseio_pwmout_obj_t* self) {
             }
         }
     }
-    reset_pin(self->pin->pin);
+    reset_pin(self->pin->number);
     self->pin = mp_const_none;
 }
 

--- a/ports/atmel-samd/common-hal/pulseio/PulseIn.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseIn.c
@@ -117,7 +117,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
         mp_raise_msg_varg(&mp_type_MemoryError, "Failed to allocate RX buffer of %d bytes", maxlen * sizeof(uint16_t));
     }
     self->channel = pin->extint_channel;
-    self->pin = pin->pin;
+    self->pin = pin->number;
     self->maxlen = maxlen;
     self->idle_state = idle_state;
     self->start = 0;
@@ -134,7 +134,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
         turn_on_external_interrupt_controller();
     }
 
-    gpio_set_pin_function(pin->pin, GPIO_PIN_FUNCTION_A);
+    gpio_set_pin_function(pin->number, GPIO_PIN_FUNCTION_A);
 
     turn_on_cpu_interrupt(self->channel);
 

--- a/ports/atmel-samd/common-hal/pulseio/PulseOut.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseOut.c
@@ -138,7 +138,7 @@ void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
     }
     refcount++;
 
-    self->pin = carrier->pin->pin;
+    self->pin = carrier->pin->number;
 
     PortGroup *const port_base = &PORT->Group[GPIO_PORT(self->pin)];
     self->pincfg = &port_base->PINCFG[self->pin % 32];

--- a/ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
@@ -51,8 +51,8 @@ void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencode
     // These default settings apply when the EIC isn't yet enabled.
     self->eic_channel_a = pin_a->extint_channel;
     self->eic_channel_b = pin_b->extint_channel;
-    self->pin_a = pin_a->pin;
-    self->pin_b = pin_b->pin;
+    self->pin_a = pin_a->number;
+    self->pin_b = pin_b->number;
 
     gpio_set_pin_function(self->pin_a, GPIO_PIN_FUNCTION_A);
     gpio_set_pin_pull_mode(self->pin_a, GPIO_PULL_UP);

--- a/ports/atmel-samd/common-hal/touchio/TouchIn.c
+++ b/ports/atmel-samd/common-hal/touchio/TouchIn.c
@@ -82,7 +82,7 @@ void common_hal_touchio_touchin_construct(touchio_touchin_obj_t* self,
     }
 
     adafruit_ptc_get_config_default(&self->config);
-    self->config.pin = pin->pin;
+    self->config.pin = pin->number;
     self->config.yline = pin->touch_y_line;
 
     adafruit_ptc_init(PTC, &self->config);

--- a/ports/atmel-samd/samd_peripherals_config.h
+++ b/ports/atmel-samd/samd_peripherals_config.h
@@ -1,9 +1,9 @@
 /*
- * This file is part of the MicroPython project, http://micropython.org/
+ * This file is part of the Micro Python project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Scott Shawcroft
+ * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,25 +24,15 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_MICROCONTROLLER_PIN_H
-#define MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_MICROCONTROLLER_PIN_H
+#ifndef MICROPY_INCLUDED_ATMEL_SAMD_SAMD_PERIPHERALS_CONFIG_H
+#define MICROPY_INCLUDED_ATMEL_SAMD_SAMD_PERIPHERALS_CONFIG_H
 
-#include <assert.h>
+#include "py/obj.h"
 
-#include "peripherals/samd/pins.h"
+extern const mp_obj_type_t mcu_pin_type;
 
-#ifdef MICROPY_HW_NEOPIXEL
-extern bool neopixel_in_use;
-#endif
-#ifdef MICROPY_HW_APA102_MOSI
-extern bool apa102_sck_in_use;
-extern bool apa102_mosi_in_use;
-#endif
+#define PIN_PREFIX_VALUES { &mcu_pin_type },
+#define PIN_PREFIX_FIELDS mp_obj_base_t base;
 
-void reset_all_pins(void);
-// reset_pin takes the pin number instead of the pointer so that objects don't
-// need to store a full pointer.
-void reset_pin(uint8_t pin);
-void claim_pin(const mcu_pin_obj_t* pin);
 
-#endif // MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_MICROCONTROLLER_PIN_H
+#endif // MICROPY_INCLUDED_ATMEL_SAMD_SAMD_PERIPHERALS_CONFIG_H

--- a/supervisor/shared/rgb_led_status.c
+++ b/supervisor/shared/rgb_led_status.c
@@ -103,11 +103,11 @@ void rgb_led_status_init() {
 
 void reset_status_led() {
     #ifdef MICROPY_HW_NEOPIXEL
-        reset_pin(MICROPY_HW_NEOPIXEL->pin);
+        reset_pin(MICROPY_HW_NEOPIXEL->number);
     #endif
     #if defined(MICROPY_HW_APA102_MOSI) && defined(MICROPY_HW_APA102_SCK)
-        reset_pin(MICROPY_HW_APA102_MOSI->pin);
-        reset_pin(MICROPY_HW_APA102_SCK->pin);
+        reset_pin(MICROPY_HW_APA102_MOSI->number);
+        reset_pin(MICROPY_HW_APA102_SCK->number);
     #endif
 }
 


### PR DESCRIPTION
We also now use the version from the peripherals library. It renames the pin number field from `pin` to `number`.