### PR TITLE
Retune neopixel timings on SAMD51. They were too slow.

### DIFF
--- a/ports/atmel-samd/common-hal/neopixel_write/__init__.c
+++ b/ports/atmel-samd/common-hal/neopixel_write/__init__.c
@@ -111,14 +111,14 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
         #ifdef SAMD51
         delay_cycles(3);
         #endif
-        if(p & bitMask) {
+        if((p & bitMask) != 0) {
             // This is the high delay unique to a one bit.
             // For the SK6812 its 0.3us
             #ifdef SAMD21
             asm("nop; nop; nop; nop; nop; nop; nop;");
             #endif
             #ifdef SAMD51
-            delay_cycles(11);
+            delay_cycles(3);
             #endif
             *clr = pinMask;
         } else {
@@ -140,7 +140,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
             asm("nop; nop; nop; nop; nop;");
             #endif
             #ifdef SAMD51
-            delay_cycles(20);
+            delay_cycles(4);
             #endif
         } else {
             if(ptr >= end) break;
@@ -151,7 +151,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
             // above operations take.
             // For the SK6812 its 0.6us +- 0.15us
             #ifdef SAMD51
-            delay_cycles(15);
+            delay_cycles(3);
             #endif
         }
     }


### PR DESCRIPTION
Test the timings a reference PWM output because CPU clock isn't perfect.

```python
import neopixel_write
import digitalio
import time
import board
import pulseio

pwm = pulseio.PWMOut(board.D10)
pwm.duty_cycle = 2 ** 15

pin = digitalio.DigitalInOut(board.D12)
pin.direction=digitalio.Direction.OUTPUT
pixel_off=bytearray([0,0,0,0])
pixel_on=bytearray([0,255,0,0])
while True:
    neopixel_write.neopixel_write(pin,pixel_off)
    time.sleep(1)
    neopixel_write.neopixel_write(pin,pixel_on)
    time.sleep(1)
```

Fixes #1083