### PR TITLE
 Compress all translated strings with Huffman coding.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -80,3 +80,6 @@
 	path = lib/tinyusb
 	url = https://github.com/hathach/tinyusb.git
 	branch = develop
+[submodule "tools/huffman"]
+	path = tools/huffman
+	url = https://github.com/tannewt/huffman.git

--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -33,6 +33,8 @@
 #include "py/runtime.h"
 #include "extmod/machine_i2c.h"
 
+#include "supervisor/shared/translate.h"
+
 #if MICROPY_PY_MACHINE_I2C
 
 typedef mp_machine_soft_i2c_obj_t machine_i2c_obj_t;
@@ -294,7 +296,7 @@ STATIC mp_obj_t machine_i2c_make_new(const mp_obj_type_t *type, size_t n_args, s
             extern mp_obj_t MICROPY_PY_MACHINE_I2C_MAKE_NEW(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
             return MICROPY_PY_MACHINE_I2C_MAKE_NEW(type, n_args, n_kw, args);
             #else
-            mp_raise_ValueError("invalid I2C peripheral");
+            mp_raise_ValueError(translate("invalid I2C peripheral"));
             #endif
         }
         --n_args;
@@ -335,7 +337,7 @@ STATIC mp_obj_t machine_i2c_start(mp_obj_t self_in) {
     mp_obj_base_t *self = (mp_obj_base_t*)MP_OBJ_TO_PTR(self_in);
     mp_machine_i2c_p_t *i2c_p = (mp_machine_i2c_p_t*)self->type->protocol;
     if (i2c_p->start == NULL) {
-        mp_raise_msg(&mp_type_OSError, "I2C operation not supported");
+        mp_raise_msg(&mp_type_OSError, translate("I2C operation not supported"));
     }
     int ret = i2c_p->start(self);
     if (ret != 0) {
@@ -349,7 +351,7 @@ STATIC mp_obj_t machine_i2c_stop(mp_obj_t self_in) {
     mp_obj_base_t *self = (mp_obj_base_t*)MP_OBJ_TO_PTR(self_in);
     mp_machine_i2c_p_t *i2c_p = (mp_machine_i2c_p_t*)self->type->protocol;
     if (i2c_p->stop == NULL) {
-        mp_raise_msg(&mp_type_OSError, "I2C operation not supported");
+        mp_raise_msg(&mp_type_OSError, translate("I2C operation not supported"));
     }
     int ret = i2c_p->stop(self);
     if (ret != 0) {
@@ -363,7 +365,7 @@ STATIC mp_obj_t machine_i2c_readinto(size_t n_args, const mp_obj_t *args) {
     mp_obj_base_t *self = (mp_obj_base_t*)MP_OBJ_TO_PTR(args[0]);
     mp_machine_i2c_p_t *i2c_p = (mp_machine_i2c_p_t*)self->type->protocol;
     if (i2c_p->read == NULL) {
-        mp_raise_msg(&mp_type_OSError, "I2C operation not supported");
+        mp_raise_msg(&mp_type_OSError, translate("I2C operation not supported"));
     }
 
     // get the buffer to read into
@@ -387,7 +389,7 @@ STATIC mp_obj_t machine_i2c_write(mp_obj_t self_in, mp_obj_t buf_in) {
     mp_obj_base_t *self = (mp_obj_base_t*)MP_OBJ_TO_PTR(self_in);
     mp_machine_i2c_p_t *i2c_p = (mp_machine_i2c_p_t*)self->type->protocol;
     if (i2c_p->write == NULL) {
-        mp_raise_msg(&mp_type_OSError, "I2C operation not supported");
+        mp_raise_msg(&mp_type_OSError, translate("I2C operation not supported"));
     }
 
     // get the buffer to write from

--- a/extmod/machine_mem.c
+++ b/extmod/machine_mem.c
@@ -42,7 +42,7 @@
 STATIC uintptr_t machine_mem_get_addr(mp_obj_t addr_o, uint align) {
     uintptr_t addr = mp_obj_int_get_truncated(addr_o);
     if ((addr & (align - 1)) != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "address %08x is not aligned to %d bytes", addr, align));
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, translate("address %08x is not aligned to %d bytes"), addr, align));
     }
     return addr;
 }

--- a/extmod/machine_spi.c
+++ b/extmod/machine_spi.c
@@ -30,6 +30,8 @@
 #include "py/runtime.h"
 #include "extmod/machine_spi.h"
 
+#include "supervisor/shared/translate.h"
+
 #if MICROPY_PY_MACHINE_SPI
 
 // if a port didn't define MSB/LSB constants then provide them
@@ -52,7 +54,7 @@ mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_
             extern mp_obj_t MICROPY_PY_MACHINE_SPI_MAKE_NEW(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
             return MICROPY_PY_MACHINE_SPI_MAKE_NEW(type, n_args, n_kw, args);
             #else
-            mp_raise_ValueError("invalid SPI peripheral");
+            mp_raise_ValueError(translate("invalid SPI peripheral"));
             #endif
         }
         --n_args;
@@ -119,7 +121,7 @@ STATIC mp_obj_t mp_machine_spi_write_readinto(mp_obj_t self, mp_obj_t wr_buf, mp
     mp_buffer_info_t dest;
     mp_get_buffer_raise(rd_buf, &dest, MP_BUFFER_WRITE);
     if (src.len != dest.len) {
-        mp_raise_ValueError("buffers must be the same length");
+        mp_raise_ValueError(translate("buffers must be the same length"));
     }
     mp_machine_spi_transfer(self, src.len, src.buf, dest.buf);
     return mp_const_none;
@@ -202,15 +204,15 @@ STATIC mp_obj_t mp_machine_soft_spi_make_new(const mp_obj_type_t *type, size_t n
     self->spi.polarity = args[ARG_polarity].u_int;
     self->spi.phase = args[ARG_phase].u_int;
     if (args[ARG_bits].u_int != 8) {
-        mp_raise_ValueError("bits must be 8");
+        mp_raise_ValueError(translate("bits must be 8"));
     }
     if (args[ARG_firstbit].u_int != MICROPY_PY_MACHINE_SPI_MSB) {
-        mp_raise_ValueError("firstbit must be MSB");
+        mp_raise_ValueError(translate("firstbit must be MSB"));
     }
     if (args[ARG_sck].u_obj == MP_OBJ_NULL
         || args[ARG_mosi].u_obj == MP_OBJ_NULL
         || args[ARG_miso].u_obj == MP_OBJ_NULL) {
-        mp_raise_ValueError("must specify all of sck/mosi/miso");
+        mp_raise_ValueError(translate("must specify all of sck/mosi/miso"));
     }
     self->spi.sck = mp_hal_get_pin_obj(args[ARG_sck].u_obj);
     self->spi.mosi = mp_hal_get_pin_obj(args[ARG_mosi].u_obj);

--- a/extmod/modframebuf.c
+++ b/extmod/modframebuf.c
@@ -296,7 +296,7 @@ STATIC mp_obj_t framebuf_make_new(const mp_obj_type_t *type, size_t n_args, size
         case FRAMEBUF_GS8:
             break;
         default:
-            mp_raise_ValueError("invalid format");
+            mp_raise_ValueError(translate("invalid format"));
     }
 
     return MP_OBJ_FROM_PTR(o);

--- a/extmod/modubinascii.c
+++ b/extmod/modubinascii.c
@@ -35,7 +35,7 @@
 static void check_not_unicode(const mp_obj_t arg) {
 #if MICROPY_CPYTHON_COMPAT
     if (MP_OBJ_IS_STR(arg)) {
-        mp_raise_TypeError("a bytes-like object is required");
+        mp_raise_TypeError(translate("a bytes-like object is required"));
     }
 #endif
 }
@@ -87,7 +87,7 @@ mp_obj_t mod_binascii_unhexlify(mp_obj_t data) {
     mp_get_buffer_raise(data, &bufinfo, MP_BUFFER_READ);
 
     if ((bufinfo.len & 1) != 0) {
-        mp_raise_ValueError("odd-length string");
+        mp_raise_ValueError(translate("odd-length string"));
     }
     vstr_t vstr;
     vstr_init_len(&vstr, bufinfo.len / 2);
@@ -98,7 +98,7 @@ mp_obj_t mod_binascii_unhexlify(mp_obj_t data) {
         if (unichar_isxdigit(hex_ch)) {
             hex_byte += unichar_xdigit_value(hex_ch);
         } else {
-            mp_raise_ValueError("non-hex digit found");
+            mp_raise_ValueError(translate("non-hex digit found"));
         }
         if (i & 1) {
             hex_byte <<= 4;
@@ -166,7 +166,7 @@ mp_obj_t mod_binascii_a2b_base64(mp_obj_t data) {
     }
 
     if (nbits) {
-        mp_raise_ValueError("incorrect padding");
+        mp_raise_ValueError(translate("incorrect padding"));
     }
 
     return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);

--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -32,6 +32,8 @@
 #include "py/objtuple.h"
 #include "py/binary.h"
 
+#include "supervisor/shared/translate.h"
+
 #if MICROPY_PY_UCTYPES
 
 /// \module uctypes - Access data structures in memory
@@ -117,7 +119,7 @@ typedef struct _mp_obj_uctypes_struct_t {
 } mp_obj_uctypes_struct_t;
 
 STATIC NORETURN void syntax_error(void) {
-    mp_raise_TypeError("syntax error in uctypes descriptor");
+    mp_raise_TypeError(translate("syntax error in uctypes descriptor"));
 }
 
 STATIC mp_obj_t uctypes_struct_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
@@ -214,7 +216,7 @@ STATIC mp_uint_t uctypes_struct_size(mp_obj_t desc_in, int layout_type, mp_uint_
             // but scalar structure field is lowered into native Python int, so all
             // type info is lost. So, we cannot say if it's scalar type description,
             // or such lowered scalar.
-            mp_raise_TypeError("Cannot unambiguously get sizeof scalar");
+            mp_raise_TypeError(translate("Cannot unambiguously get sizeof scalar"));
         }
         syntax_error();
     }
@@ -392,7 +394,7 @@ STATIC mp_obj_t uctypes_struct_attr_op(mp_obj_t self_in, qstr attr, mp_obj_t set
 
     // TODO: Support at least OrderedDict in addition
     if (!MP_OBJ_IS_TYPE(self->desc, &mp_type_dict)) {
-            mp_raise_TypeError("struct: no fields");
+            mp_raise_TypeError(translate("struct: no fields"));
     }
 
     mp_obj_t deref = mp_obj_dict_get(self->desc, MP_OBJ_NEW_QSTR(attr));
@@ -525,7 +527,7 @@ STATIC mp_obj_t uctypes_struct_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_ob
     } else {
         // load / store
         if (!MP_OBJ_IS_TYPE(self->desc, &mp_type_tuple)) {
-            mp_raise_TypeError("struct: cannot index");
+            mp_raise_TypeError(translate("struct: cannot index"));
         }
 
         mp_obj_tuple_t *t = MP_OBJ_TO_PTR(self->desc);
@@ -539,7 +541,7 @@ STATIC mp_obj_t uctypes_struct_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_ob
             uint val_type = GET_TYPE(arr_sz, VAL_TYPE_BITS);
             arr_sz &= VALUE_MASK(VAL_TYPE_BITS);
             if (index >= arr_sz) {
-                nlr_raise(mp_obj_new_exception_msg(&mp_type_IndexError, "struct: index out of range"));
+                nlr_raise(mp_obj_new_exception_msg(&mp_type_IndexError, translate("struct: index out of range")));
             }
 
             if (t->len == 2) {

--- a/extmod/moduhashlib.c
+++ b/extmod/moduhashlib.c
@@ -29,6 +29,8 @@
 
 #include "py/runtime.h"
 
+#include "supervisor/shared/translate.h"
+
 #if MICROPY_PY_UHASHLIB
 
 #if MICROPY_PY_UHASHLIB_SHA256
@@ -97,7 +99,7 @@ STATIC mp_obj_t uhashlib_sha256_digest(mp_obj_t self_in) {
 static void check_not_unicode(const mp_obj_t arg) {
 #if MICROPY_CPYTHON_COMPAT
     if (MP_OBJ_IS_STR(arg)) {
-        mp_raise_TypeError("a bytes-like object is required");
+        mp_raise_TypeError(translate("a bytes-like object is required"));
     }
 #endif
 }

--- a/extmod/moduheapq.c
+++ b/extmod/moduheapq.c
@@ -27,13 +27,15 @@
 #include "py/objlist.h"
 #include "py/runtime.h"
 
+#include "supervisor/shared/translate.h"
+
 #if MICROPY_PY_UHEAPQ
 
 // the algorithm here is modelled on CPython's heapq.py
 
 STATIC mp_obj_list_t *get_heap(mp_obj_t heap_in) {
     if (!MP_OBJ_IS_TYPE(heap_in, &mp_type_list)) {
-        mp_raise_TypeError("heap must be a list");
+        mp_raise_TypeError(translate("heap must be a list"));
     }
     return MP_OBJ_TO_PTR(heap_in);
 }
@@ -81,7 +83,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_uheapq_heappush_obj, mod_uheapq_heappush);
 STATIC mp_obj_t mod_uheapq_heappop(mp_obj_t heap_in) {
     mp_obj_list_t *heap = get_heap(heap_in);
     if (heap->len == 0) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_IndexError, "empty heap"));
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_IndexError, translate("empty heap")));
     }
     mp_obj_t item = heap->items[0];
     heap->len -= 1;

--- a/extmod/modujson.c
+++ b/extmod/modujson.c
@@ -32,6 +32,8 @@
 #include "py/runtime.h"
 #include "py/stream.h"
 
+#include "supervisor/shared/translate.h"
+
 #if MICROPY_PY_UJSON
 
 STATIC mp_obj_t mod_ujson_dump(mp_obj_t obj, mp_obj_t stream) {
@@ -276,7 +278,7 @@ STATIC mp_obj_t mod_ujson_load(mp_obj_t stream_obj) {
     return stack_top;
 
     fail:
-    mp_raise_ValueError("syntax error in JSON");
+    mp_raise_ValueError(translate("syntax error in JSON"));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_ujson_load_obj, mod_ujson_load);
 

--- a/extmod/modure.c
+++ b/extmod/modure.c
@@ -158,7 +158,7 @@ STATIC mp_obj_t re_split(size_t n_args, const mp_obj_t *args) {
         mp_obj_t s = mp_obj_new_str_of_type(str_type, (const byte*)subj.begin, caps[0] - subj.begin);
         mp_obj_list_append(retval, s);
         if (self->re.sub > 0) {
-            mp_raise_NotImplementedError("Splitting with sub-captures");
+            mp_raise_NotImplementedError(translate("Splitting with sub-captures"));
         }
         subj.begin = caps[1];
         if (maxsplit > 0 && --maxsplit == 0) {
@@ -204,7 +204,7 @@ STATIC mp_obj_t mod_re_compile(size_t n_args, const mp_obj_t *args) {
     int error = re1_5_compilecode(&o->re, re_str);
     if (error != 0) {
 error:
-        mp_raise_ValueError("Error in regex");
+        mp_raise_ValueError(translate("Error in regex"));
     }
     if (flags & FLAG_DEBUG) {
         re1_5_dumpcode(&o->re);

--- a/extmod/modussl_axtls.c
+++ b/extmod/modussl_axtls.c
@@ -30,6 +30,8 @@
 #include "py/runtime.h"
 #include "py/stream.h"
 
+#include "supervisor/shared/translate.h"
+
 #if MICROPY_PY_USSL && MICROPY_SSL_AXTLS
 
 #include "ssl.h"
@@ -76,13 +78,13 @@ STATIC mp_obj_ssl_socket_t *socket_new(mp_obj_t sock, struct ssl_args *args) {
         const byte *data = (const byte*)mp_obj_str_get_data(args->key.u_obj, &len);
         int res = ssl_obj_memory_load(o->ssl_ctx, SSL_OBJ_RSA_KEY, data, len, NULL);
         if (res != SSL_OK) {
-            mp_raise_ValueError("invalid key");
+            mp_raise_ValueError(translate("invalid key"));
         }
 
         data = (const byte*)mp_obj_str_get_data(args->cert.u_obj, &len);
         res = ssl_obj_memory_load(o->ssl_ctx, SSL_OBJ_X509_CERT, data, len, NULL);
         if (res != SSL_OK) {
-            mp_raise_ValueError("invalid cert");
+            mp_raise_ValueError(translate("invalid cert"));
         }
     }
 

--- a/extmod/modutimeq.c
+++ b/extmod/modutimeq.c
@@ -31,6 +31,8 @@
 #include "py/runtime.h"
 #include "py/smallint.h"
 
+#include "supervisor/shared/translate.h"
+
 #if MICROPY_PY_UTIMEQ
 
 #define MODULO MICROPY_PY_UTIME_TICKS_PERIOD
@@ -126,7 +128,7 @@ STATIC mp_obj_t mod_utimeq_heappush(size_t n_args, const mp_obj_t *args) {
     mp_obj_t heap_in = args[0];
     mp_obj_utimeq_t *heap = get_heap(heap_in);
     if (heap->len == heap->alloc) {
-        mp_raise_IndexError("queue overflow");
+        mp_raise_IndexError(translate("queue overflow"));
     }
     mp_uint_t l = heap->len;
     heap->items[l].time = MP_OBJ_SMALL_INT_VALUE(args[1]);
@@ -142,7 +144,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_utimeq_heappush_obj, 4, 4, mod_ut
 STATIC mp_obj_t mod_utimeq_heappop(mp_obj_t heap_in, mp_obj_t list_ref) {
     mp_obj_utimeq_t *heap = get_heap(heap_in);
     if (heap->len == 0) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_IndexError, "empty heap"));
+        mp_raise_IndexError(translate("empty heap"));
     }
     mp_obj_list_t *ret = MP_OBJ_TO_PTR(list_ref);
     if (!MP_OBJ_IS_TYPE(list_ref, &mp_type_list) || ret->len < 3) {
@@ -167,7 +169,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_utimeq_heappop_obj, mod_utimeq_heappop);
 STATIC mp_obj_t mod_utimeq_peektime(mp_obj_t heap_in) {
     mp_obj_utimeq_t *heap = get_heap(heap_in);
     if (heap->len == 0) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_IndexError, "empty heap"));
+        mp_raise_IndexError(translate("empty heap"));
     }
 
     struct qentry *item = &heap->items[0];

--- a/extmod/moduzlib.c
+++ b/extmod/moduzlib.c
@@ -31,6 +31,8 @@
 #include "py/stream.h"
 #include "py/mperrno.h"
 
+#include "supervisor/shared/translate.h"
+
 #if MICROPY_PY_UZLIB
 
 #include "../../lib/uzlib/src/tinf.h"
@@ -92,7 +94,7 @@ STATIC mp_obj_t decompio_make_new(const mp_obj_type_t *type, size_t n_args, size
         dict_opt = uzlib_zlib_parse_header(&o->decomp);
         if (dict_opt < 0) {
 header_error:
-            mp_raise_ValueError("compression header");
+            mp_raise_ValueError(translate("compression header"));
         }
         dict_sz = 1 << dict_opt;
     } else {

--- a/extmod/uos_dupterm.c
+++ b/extmod/uos_dupterm.c
@@ -34,6 +34,8 @@
 #include "py/stream.h"
 #include "lib/utils/interrupt_char.h"
 
+#include "supervisor/shared/translate.h"
+
 #if MICROPY_PY_OS_DUPTERM
 
 void mp_uos_deactivate(size_t dupterm_idx, const char *msg, mp_obj_t exc) {
@@ -115,7 +117,7 @@ STATIC mp_obj_t mp_uos_dupterm(size_t n_args, const mp_obj_t *args) {
     }
 
     if (idx < 0 || idx >= MICROPY_PY_OS_DUPTERM) {
-        mp_raise_ValueError("invalid dupterm index");
+        mp_raise_ValueError(translate("invalid dupterm index"));
     }
 
     mp_obj_t previous_obj = MP_STATE_VM(dupterm_objs[idx]);

--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -31,6 +31,7 @@
 
 #if defined(MICROPY_VFS_POSIX) && MICROPY_VFS_POSIX
 
+#include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <dirent.h>

--- a/extmod/vfs_posix_file.c
+++ b/extmod/vfs_posix_file.c
@@ -27,6 +27,7 @@
 #include "py/runtime.h"
 #include "py/stream.h"
 #include "extmod/vfs_posix.h"
+#include "supervisor/shared/translate.h"
 
 #if defined(MICROPY_VFS_POSIX) && MICROPY_VFS_POSIX
 
@@ -44,7 +45,7 @@ typedef struct _mp_obj_vfs_posix_file_t {
 #ifdef MICROPY_CPYTHON_COMPAT
 STATIC void check_fd_is_open(const mp_obj_vfs_posix_file_t *o) {
     if (o->fd < 0) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, "I/O operation on closed file"));
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, translate("I/O operation on closed file")));
     }
 }
 #else

--- a/lib/netutils/netutils.c
+++ b/lib/netutils/netutils.c
@@ -31,6 +31,7 @@
 
 #include "py/runtime.h"
 #include "lib/netutils/netutils.h"
+#include "supervisor/shared/translate.h"
 
 // Takes an array with a raw IPv4 address and returns something like '192.168.0.1'.
 mp_obj_t netutils_format_ipv4_addr(uint8_t *ip, netutils_endian_t endian) {
@@ -79,7 +80,7 @@ void netutils_parse_ipv4_addr(mp_obj_t addr_in, uint8_t *out_ip, netutils_endian
         } else if (i > 0 && s < s_top && *s == '.') {
             s++;
         } else {
-            mp_raise_ValueError("invalid arguments");
+            mp_raise_ValueError(translate("invalid arguments"));
         }
     }
 }

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-16 13:33-0700\n"
+"POT-Creation-Date: 2018-08-16 14:36-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr ""
 msgid "I2C operation not supported"
 msgstr ""
 
-#: extmod/machine_mem.c:45
+#: extmod/machine_mem.c:45 ports/unix/modmachine.c:53
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr ""
@@ -135,6 +135,10 @@ msgstr ""
 msgid "Read-only filesystem"
 msgstr ""
 
+#: extmod/vfs_posix_file.c:48 ports/unix/file.c:50 py/objstringio.c:43
+msgid "I/O operation on closed file"
+msgstr ""
+
 #: lib/embed/abort_.c:8
 msgid "abort() called"
 msgstr ""
@@ -240,6 +244,7 @@ msgid "No default UART bus"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/analogio/AnalogIn.c:63
+#: ports/nrf/common-hal/analogio/AnalogIn.c:39
 msgid "Pin does not have ADC capabilities"
 msgstr ""
 
@@ -350,6 +355,7 @@ msgstr ""
 #: ports/atmel-samd/common-hal/busio/I2C.c:76
 #: ports/atmel-samd/common-hal/busio/SPI.c:132
 #: ports/atmel-samd/common-hal/busio/UART.c:119
+#: ports/nrf/common-hal/busio/I2C.c:58
 msgid "Invalid pins"
 msgstr ""
 
@@ -386,6 +392,7 @@ msgid "No TX pin"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c:168
+#: ports/nrf/common-hal/digitalio/DigitalInOut.c:158
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -396,6 +403,7 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:120
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:366
+#: ports/nrf/common-hal/pulseio/PWMOut.c:227
 msgid "Invalid PWM frequency"
 msgstr ""
 
@@ -452,15 +460,18 @@ msgid "No free GCLKs"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:78
+#: ports/nrf/common-hal/usb_hid/Device.c:45
 #, c-format
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:82
+#: ports/nrf/common-hal/usb_hid/Device.c:53
 msgid "USB Busy"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:82
+#: ports/nrf/common-hal/usb_hid/Device.c:59
 msgid "USB Error"
 msgstr ""
 
@@ -669,12 +680,33 @@ msgstr ""
 msgid "unknown config param"
 msgstr ""
 
+#: ports/nrf/common-hal/analogio/AnalogOut.c:37
+msgid "AnalogOut functionality not supported"
+msgstr ""
+
+#: ports/nrf/common-hal/busio/UART.c:45 ports/nrf/common-hal/busio/UART.c:49
+#: ports/nrf/common-hal/busio/UART.c:53 ports/nrf/common-hal/busio/UART.c:62
+#: ports/nrf/common-hal/busio/UART.c:68 ports/nrf/common-hal/busio/UART.c:73
+#: ports/nrf/common-hal/busio/UART.c:78 ports/nrf/common-hal/busio/UART.c:83
+#: ports/nrf/common-hal/busio/UART.c:88
+msgid "busio.UART not yet implemented"
+msgstr ""
+
+#: ports/nrf/common-hal/microcontroller/Processor.c:49
+#, c-format
+msgid "Can not get temperature. status: 0x%02x"
+msgstr ""
+
 #: ports/nrf/drivers/bluetooth/ble_drv.c:199
 msgid "Cannot apply GAP parameters."
 msgstr ""
 
 #: ports/nrf/drivers/bluetooth/ble_drv.c:213
 msgid "Cannot set PPCP parameters."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:245
+msgid "Can not query for the device address."
 msgstr ""
 
 #: ports/nrf/drivers/bluetooth/ble_drv.c:264
@@ -749,6 +781,42 @@ msgstr ""
 #: ports/nrf/drivers/bluetooth/ble_drv.c:829
 #, c-format
 msgid "Can not connect. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/modules/ubluepy/ubluepy_characteristic.c:68
+#: ports/nrf/modules/ubluepy/ubluepy_service.c:80
+#: ports/nrf/modules/ubluepy/ubluepy_service.c:132
+#: ports/nrf/modules/ubluepy/ubluepy_uuid.c:137
+msgid "Invalid UUID parameter"
+msgstr ""
+
+#: ports/nrf/modules/ubluepy/ubluepy_service.c:73
+msgid "Invalid Service type"
+msgstr ""
+
+#: ports/nrf/modules/ubluepy/ubluepy_uuid.c:127
+msgid "Invalid UUID string length"
+msgstr ""
+
+#: ports/unix/modffi.c:138
+msgid "Unknown type"
+msgstr ""
+
+#: ports/unix/modffi.c:207 ports/unix/modffi.c:265
+msgid "Error in ffi_prep_cif"
+msgstr ""
+
+#: ports/unix/modffi.c:270
+msgid "ffi_prep_closure_loc"
+msgstr ""
+
+#: ports/unix/modffi.c:413
+msgid "Don't know how to pass object to native function"
+msgstr ""
+
+#: ports/unix/modusocket.c:474
+#, c-format
+msgid "[addrinfo error %d]"
 msgstr ""
 
 #: py/argcheck.c:44
@@ -1581,10 +1649,6 @@ msgstr ""
 
 #: py/objstr.c:2106
 msgid "can't convert '%q' object to %q implicitly"
-msgstr ""
-
-#: py/objstringio.c:43
-msgid "I/O operation on closed file"
 msgstr ""
 
 #: py/objstrunicode.c:134

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-09 14:14-0700\n"
+"POT-Creation-Date: 2018-08-16 13:33-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,121 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extmod/vfs_fat.c:426 py/moduerrno.c:115
+#: extmod/machine_i2c.c:299
+msgid "invalid I2C peripheral"
+msgstr ""
+
+#: extmod/machine_i2c.c:340 extmod/machine_i2c.c:354 extmod/machine_i2c.c:368
+#: extmod/machine_i2c.c:392
+msgid "I2C operation not supported"
+msgstr ""
+
+#: extmod/machine_mem.c:45
+#, c-format
+msgid "address %08x is not aligned to %d bytes"
+msgstr ""
+
+#: extmod/machine_spi.c:57
+msgid "invalid SPI peripheral"
+msgstr ""
+
+#: extmod/machine_spi.c:124
+msgid "buffers must be the same length"
+msgstr ""
+
+#: extmod/machine_spi.c:207
+msgid "bits must be 8"
+msgstr ""
+
+#: extmod/machine_spi.c:210
+msgid "firstbit must be MSB"
+msgstr ""
+
+#: extmod/machine_spi.c:215
+msgid "must specify all of sck/mosi/miso"
+msgstr ""
+
+#: extmod/modframebuf.c:299
+msgid "invalid format"
+msgstr ""
+
+#: extmod/modubinascii.c:38 extmod/moduhashlib.c:102
+msgid "a bytes-like object is required"
+msgstr ""
+
+#: extmod/modubinascii.c:90
+msgid "odd-length string"
+msgstr ""
+
+#: extmod/modubinascii.c:101
+msgid "non-hex digit found"
+msgstr ""
+
+#: extmod/modubinascii.c:169
+msgid "incorrect padding"
+msgstr ""
+
+#: extmod/moductypes.c:122
+msgid "syntax error in uctypes descriptor"
+msgstr ""
+
+#: extmod/moductypes.c:219
+msgid "Cannot unambiguously get sizeof scalar"
+msgstr ""
+
+#: extmod/moductypes.c:397
+msgid "struct: no fields"
+msgstr ""
+
+#: extmod/moductypes.c:530
+msgid "struct: cannot index"
+msgstr ""
+
+#: extmod/moductypes.c:544
+msgid "struct: index out of range"
+msgstr ""
+
+#: extmod/moduheapq.c:38
+msgid "heap must be a list"
+msgstr ""
+
+#: extmod/moduheapq.c:86 extmod/modutimeq.c:147 extmod/modutimeq.c:172
+msgid "empty heap"
+msgstr ""
+
+#: extmod/modujson.c:281
+msgid "syntax error in JSON"
+msgstr ""
+
+#: extmod/modure.c:161
+msgid "Splitting with sub-captures"
+msgstr ""
+
+#: extmod/modure.c:207
+msgid "Error in regex"
+msgstr ""
+
+#: extmod/modussl_axtls.c:81
+msgid "invalid key"
+msgstr ""
+
+#: extmod/modussl_axtls.c:87
+msgid "invalid cert"
+msgstr ""
+
+#: extmod/modutimeq.c:131
+msgid "queue overflow"
+msgstr ""
+
+#: extmod/moduzlib.c:97
+msgid "compression header"
+msgstr ""
+
+#: extmod/uos_dupterm.c:120
+msgid "invalid dupterm index"
+msgstr ""
+
+#: extmod/vfs_fat.c:426 py/moduerrno.c:150
 msgid "Read-only filesystem"
 msgstr ""
 
@@ -25,82 +139,115 @@ msgstr ""
 msgid "abort() called"
 msgstr ""
 
+#: lib/netutils/netutils.c:83
+msgid "invalid arguments"
+msgstr ""
+
 #: lib/utils/pyexec.c:97 py/builtinimport.c:253
 msgid "script compilation not supported"
 msgstr ""
 
-#: main.c:137
+#: main.c:143
 msgid " output:\n"
 msgstr ""
 
-#: main.c:148 main.c:221
+#: main.c:157 main.c:230
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
 msgstr ""
 
-#: main.c:150
+#: main.c:159
 msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr ""
 
-#: main.c:152 main.c:223
+#: main.c:161 main.c:232
 msgid "Auto-reload is off.\n"
 msgstr ""
 
-#: main.c:166
+#: main.c:175
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr ""
 
-#: main.c:182
+#: main.c:191
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr ""
 
-#: main.c:230
+#: main.c:239
 msgid "You requested starting safe mode by "
 msgstr ""
 
-#: main.c:233
+#: main.c:242
 msgid "To exit, please reset the board without "
 msgstr ""
 
-#: main.c:240
+#: main.c:249
 msgid ""
 "You are running in safe mode which means something really bad happened.\n"
 msgstr ""
 
-#: main.c:242
+#: main.c:251
 msgid "Looks like our core CircuitPython code crashed hard. Whoops!\n"
 msgstr ""
 
-#: main.c:243
+#: main.c:252
 msgid "Please file an issue here with the contents of your CIRCUITPY drive:\n"
 msgstr ""
 
-#: main.c:246
+#: main.c:255
 msgid ""
 "The microcontroller's power dipped. Please make sure your power supply "
 "provides\n"
 msgstr ""
 
-#: main.c:247
+#: main.c:256
 msgid ""
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
 
-#: main.c:251
+#: main.c:260
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 
-#: main.c:406
+#: main.c:415
 msgid "soft reboot\n"
+msgstr ""
+
+#: ports/atmel-samd/audio_dma.c:285
+#: ports/atmel-samd/common-hal/audiobusio/PDMIn.c:361
+msgid "All sync event channels in use"
+msgstr ""
+
+#: ports/atmel-samd/bindings/samd/Clock.c:135
+msgid "calibration is read only"
+msgstr ""
+
+#: ports/atmel-samd/bindings/samd/Clock.c:137
+msgid "calibration is out of range"
+msgstr ""
+
+#: ports/atmel-samd/board_busses.c:39
+msgid "No default I2C bus"
+msgstr ""
+
+#: ports/atmel-samd/board_busses.c:64
+msgid "No default SPI bus"
+msgstr ""
+
+#: ports/atmel-samd/board_busses.c:91
+msgid "No default UART bus"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/analogio/AnalogIn.c:63
 msgid "Pin does not have ADC capabilities"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/analogio/AnalogOut.c:53
+#: ports/atmel-samd/common-hal/analogio/AnalogOut.c:49
+msgid "No DAC on chip"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/analogio/AnalogOut.c:56
 msgid "AnalogOut not supported on given pin"
 msgstr ""
 
@@ -139,12 +286,12 @@ msgid "Too many channels in sample."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c:305
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c:322
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c:326
 msgid "No DMA channel found"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c:308
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c:324
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c:328
 msgid "Unable to allocate buffers for signed conversion"
 msgstr ""
 
@@ -192,11 +339,16 @@ msgstr ""
 msgid "All timers in use"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c:215
+msgid "All event channels in use"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/busio/I2C.c:45
 msgid "Not enough pins available"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c:76
+#: ports/atmel-samd/common-hal/busio/SPI.c:132
 #: ports/atmel-samd/common-hal/busio/UART.c:119
 msgid "Invalid pins"
 msgstr ""
@@ -238,6 +390,7 @@ msgid "Cannot get pull while in output mode"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/microcontroller/__init__.c:74
+#: ports/esp8266/common-hal/microcontroller/__init__.c:64
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 
@@ -259,15 +412,18 @@ msgid "EXTINT channel already in use"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c:118
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:86
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c:203
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:151
 msgid "pop from an empty PulseIn"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c:235 py/obj.c:404
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c:235
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:182 py/obj.c:420
 msgid "index out of range"
 msgstr ""
 
@@ -306,6 +462,293 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:82
 msgid "USB Error"
+msgstr ""
+
+#: ports/esp8266/common-hal/analogio/AnalogIn.c:43
+msgid "Pin %q does not have ADC capabilities"
+msgstr ""
+
+#: ports/esp8266/common-hal/analogio/AnalogOut.c:39
+msgid "No hardware support for analog out."
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/SPI.c:72
+msgid "Pins not valid for SPI"
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/UART.c:45
+msgid "Only tx supported on UART1 (GPIO2)."
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/UART.c:67 ports/esp8266/machine_uart.c:108
+msgid "invalid data bits"
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/UART.c:91 ports/esp8266/machine_uart.c:144
+msgid "invalid stop bits"
+msgstr ""
+
+#: ports/esp8266/common-hal/digitalio/DigitalInOut.c:200
+msgid "ESP8266 does not support pull down."
+msgstr ""
+
+#: ports/esp8266/common-hal/digitalio/DigitalInOut.c:210
+msgid "GPIO16 does not support pull up."
+msgstr ""
+
+#: ports/esp8266/common-hal/microcontroller/__init__.c:66
+msgid "ESP8226 does not support safe mode."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:54
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:113
+#, c-format
+msgid "Maximum PWM frequency is %dhz."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:57
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:116
+msgid "Minimum PWM frequency is 1hz."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:68
+#, c-format
+msgid "Multiple PWM frequencies not supported. PWM already set to %dhz."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:77 ports/esp8266/machine_pwm.c:70
+#, c-format
+msgid "PWM not supported on pin %d"
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:78
+msgid "No PulseIn support for %q"
+msgstr ""
+
+#: ports/esp8266/common-hal/storage/__init__.c:34
+msgid "Unable to remount filesystem"
+msgstr ""
+
+#: ports/esp8266/common-hal/storage/__init__.c:38
+msgid "Use esptool to erase flash and re-upload Python instead"
+msgstr ""
+
+#: ports/esp8266/esp_mphal.c:154
+msgid "C-level assert"
+msgstr ""
+
+#: ports/esp8266/machine_adc.c:57
+#, c-format
+msgid "not a valid ADC Channel: %d"
+msgstr ""
+
+#: ports/esp8266/machine_hspi.c:131 ports/esp8266/machine_hspi.c:137
+msgid "impossible baudrate"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:129
+msgid "expecting a pin"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:284
+msgid "Pin(16) doesn't support pull"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:323
+msgid "invalid pin"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:389
+msgid "pin does not have IRQ capabilities"
+msgstr ""
+
+#: ports/esp8266/machine_rtc.c:185
+msgid "buffer too long"
+msgstr ""
+
+#: ports/esp8266/machine_rtc.c:209 ports/esp8266/machine_rtc.c:223
+#: ports/esp8266/machine_rtc.c:246
+msgid "invalid alarm"
+msgstr ""
+
+#: ports/esp8266/machine_uart.c:169
+#, c-format
+msgid "UART(%d) does not exist"
+msgstr ""
+
+#: ports/esp8266/machine_uart.c:219
+msgid "UART(1) can't read"
+msgstr ""
+
+#: ports/esp8266/modesp.c:119
+msgid "len must be multiple of 4"
+msgstr ""
+
+#: ports/esp8266/modesp.c:274
+#, c-format
+msgid "memory allocation failed, allocating %u bytes for native code"
+msgstr ""
+
+#: ports/esp8266/modesp.c:317
+msgid "flash location must be below 1MByte"
+msgstr ""
+
+#: ports/esp8266/modmachine.c:63
+msgid "frequency can only be either 80Mhz or 160MHz"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:61
+msgid "STA required"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:61
+msgid "AP required"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:87
+msgid "Cannot update i/f status"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:142
+msgid "Cannot set STA config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:144
+msgid "Cannot connect to AP"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:152
+msgid "Cannot disconnect from AP"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:173
+msgid "unknown status param"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:222
+msgid "STA must be active"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:239
+msgid "scan failed"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:306
+msgid "wifi_set_ip_info() failed"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:319
+msgid "either pos or kw args are allowed"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:329
+msgid "can't get STA config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:331
+msgid "can't get AP config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:346
+msgid "invalid buffer length"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:405
+msgid "can't set STA config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:407
+msgid "can't set AP config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:416
+msgid "can query only one param"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:469
+msgid "unknown config param"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:199
+msgid "Cannot apply GAP parameters."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:213
+msgid "Cannot set PPCP parameters."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:264
+msgid "Can not add Vendor Specific 128-bit UUID."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:284
+#: ports/nrf/drivers/bluetooth/ble_drv.c:298
+msgid "Can not add Service."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:373
+msgid "Can not add Characteristic."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:400
+msgid "Can not apply device name in the stack."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:464
+#: ports/nrf/drivers/bluetooth/ble_drv.c:514
+msgid "Can not encode UUID, to check length."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:470
+#: ports/nrf/drivers/bluetooth/ble_drv.c:520
+msgid "Can encode UUID into the advertisment packet."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:545
+msgid "Can not fit data into the advertisment packet."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:558
+#: ports/nrf/drivers/bluetooth/ble_drv.c:604
+#, c-format
+msgid "Can not apply advertisment data. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:614
+#, c-format
+msgid "Can not start advertisment. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:631
+#, c-format
+msgid "Can not stop advertisment. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:650
+#: ports/nrf/drivers/bluetooth/ble_drv.c:726
+#, c-format
+msgid "Can not read attribute value. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:667
+#: ports/nrf/drivers/bluetooth/ble_drv.c:756
+#, c-format
+msgid "Can not write attribute value. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:691
+#, c-format
+msgid "Can not notify attribute value. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:784
+#, c-format
+msgid "Can not start scanning. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:829
+#, c-format
+msgid "Can not connect. status: 0x%02x"
 msgstr ""
 
 #: py/argcheck.c:44
@@ -549,12 +992,109 @@ msgstr ""
 msgid "'data' requires integer arguments"
 msgstr ""
 
+#: py/emitinlinextensa.c:86
+msgid "can only have up to 4 parameters to Xtensa assembly"
+msgstr ""
+
+#: py/emitinlinextensa.c:91 py/emitinlinextensa.c:96
+msgid "parameters must be registers in sequence a2 to a5"
+msgstr ""
+
+#: py/emitinlinextensa.c:162
+#, c-format
+msgid "'%s' expects a register"
+msgstr ""
+
+#: py/emitinlinextensa.c:169
+#, c-format
+msgid "'%s' expects an integer"
+msgstr ""
+
+#: py/emitinlinextensa.c:174
+#, c-format
+msgid "'%s' integer %d is not within range %d..%d"
+msgstr ""
+
+#: py/emitinlinextensa.c:182
+#, c-format
+msgid "'%s' expects a label"
+msgstr ""
+
+#: py/emitinlinextensa.c:193
+msgid "label '%q' not defined"
+msgstr ""
+
+#: py/emitinlinextensa.c:327
+#, c-format
+msgid "unsupported Xtensa instruction '%s' with %d arguments"
+msgstr ""
+
+#: py/emitnative.c:183
+msgid "unknown type '%q'"
+msgstr ""
+
+#: py/emitnative.c:260
+msgid "Viper functions don't currently support more than 4 arguments"
+msgstr ""
+
 #: py/emitnative.c:742
 msgid "conversion to object"
 msgstr ""
 
+#: py/emitnative.c:921
+msgid "local '%q' used before type known"
+msgstr ""
+
+#: py/emitnative.c:1118 py/emitnative.c:1156
+msgid "can't load from '%q'"
+msgstr ""
+
+#: py/emitnative.c:1128
+msgid "can't load with '%q' index"
+msgstr ""
+
+#: py/emitnative.c:1188
+msgid "local '%q' has type '%q' but source is '%q'"
+msgstr ""
+
+#: py/emitnative.c:1289 py/emitnative.c:1379
+msgid "can't store '%q'"
+msgstr ""
+
+#: py/emitnative.c:1358 py/emitnative.c:1419
+msgid "can't store to '%q'"
+msgstr ""
+
+#: py/emitnative.c:1369
+msgid "can't store with '%q' index"
+msgstr ""
+
+#: py/emitnative.c:1540
+msgid "can't implicitly convert '%q' to 'bool'"
+msgstr ""
+
+#: py/emitnative.c:1774
+msgid "unary op %q not implemented"
+msgstr ""
+
+#: py/emitnative.c:1930
+msgid "binary op %q not implemented"
+msgstr ""
+
+#: py/emitnative.c:1951
+msgid "can't do binary op between '%q' and '%q'"
+msgstr ""
+
 #: py/emitnative.c:2126
 msgid "casting"
+msgstr ""
+
+#: py/emitnative.c:2173
+msgid "return expected '%q' but got '%q'"
+msgstr ""
+
+#: py/emitnative.c:2191
+msgid "must raise an object"
 msgstr ""
 
 #: py/emitnative.c:2201
@@ -617,140 +1157,140 @@ msgstr ""
 msgid "expecting a dict for keyword args"
 msgstr ""
 
-#: py/moduerrno.c:108 py/moduerrno.c:111
+#: py/moduerrno.c:143 py/moduerrno.c:146
 msgid "Permission denied"
 msgstr ""
 
-#: py/moduerrno.c:109
+#: py/moduerrno.c:144
 msgid "No such file/directory"
 msgstr ""
 
-#: py/moduerrno.c:110
+#: py/moduerrno.c:145
 msgid "Input/output error"
 msgstr ""
 
-#: py/moduerrno.c:112
+#: py/moduerrno.c:147
 msgid "File exists"
 msgstr ""
 
-#: py/moduerrno.c:113
+#: py/moduerrno.c:148
 msgid "Unsupported operation"
 msgstr ""
 
-#: py/moduerrno.c:114
+#: py/moduerrno.c:149
 msgid "Invalid argument"
 msgstr ""
 
-#: py/obj.c:89
+#: py/obj.c:90
 msgid "Traceback (most recent call last):\n"
 msgstr ""
 
-#: py/obj.c:92
+#: py/obj.c:94
 msgid "  File \"%q\", line %d"
 msgstr ""
 
-#: py/obj.c:94
+#: py/obj.c:96
 msgid "  File \"%q\""
 msgstr ""
 
-#: py/obj.c:101
+#: py/obj.c:100
 msgid ", in %q\n"
 msgstr ""
 
-#: py/obj.c:241
+#: py/obj.c:257
 msgid "can't convert to int"
 msgstr ""
 
-#: py/obj.c:244
+#: py/obj.c:260
 #, c-format
 msgid "can't convert %s to int"
 msgstr ""
 
-#: py/obj.c:304
+#: py/obj.c:320
 msgid "can't convert to float"
 msgstr ""
 
-#: py/obj.c:307
+#: py/obj.c:323
 #, c-format
 msgid "can't convert %s to float"
 msgstr ""
 
-#: py/obj.c:337
+#: py/obj.c:353
 msgid "can't convert to complex"
 msgstr ""
 
-#: py/obj.c:340
+#: py/obj.c:356
 #, c-format
 msgid "can't convert %s to complex"
 msgstr ""
 
-#: py/obj.c:355
+#: py/obj.c:371
 msgid "expected tuple/list"
 msgstr ""
 
-#: py/obj.c:358
+#: py/obj.c:374
 #, c-format
 msgid "object '%s' is not a tuple or list"
 msgstr ""
 
-#: py/obj.c:369
+#: py/obj.c:385
 msgid "tuple/list has wrong length"
 msgstr ""
 
-#: py/obj.c:371
+#: py/obj.c:387
 #, c-format
 msgid "requested length %d but object has length %d"
 msgstr ""
 
-#: py/obj.c:384
+#: py/obj.c:400
 msgid "indices must be integers"
 msgstr ""
 
-#: py/obj.c:387
+#: py/obj.c:403
 msgid "%q indices must be integers, not %s"
 msgstr ""
 
-#: py/obj.c:407
+#: py/obj.c:423
 msgid "%q index out of range"
 msgstr ""
 
-#: py/obj.c:439
+#: py/obj.c:455
 msgid "object has no len"
 msgstr ""
 
-#: py/obj.c:442
+#: py/obj.c:458
 #, c-format
 msgid "object of type '%s' has no len()"
 msgstr ""
 
-#: py/obj.c:480
+#: py/obj.c:496
 msgid "object does not support item deletion"
 msgstr ""
 
-#: py/obj.c:483
+#: py/obj.c:499
 #, c-format
 msgid "'%s' object does not support item deletion"
 msgstr ""
 
-#: py/obj.c:487
+#: py/obj.c:503
 msgid "object is not subscriptable"
 msgstr ""
 
-#: py/obj.c:490
+#: py/obj.c:506
 #, c-format
 msgid "'%s' object is not subscriptable"
 msgstr ""
 
-#: py/obj.c:494
+#: py/obj.c:510
 msgid "object does not support item assignment"
 msgstr ""
 
-#: py/obj.c:497
+#: py/obj.c:513
 #, c-format
 msgid "'%s' object does not support item assignment"
 msgstr ""
 
-#: py/obj.c:528
+#: py/obj.c:544
 msgid "object with buffer protocol required"
 msgstr ""
 
@@ -795,7 +1335,7 @@ msgstr ""
 msgid "dict update sequence has wrong length"
 msgstr ""
 
-#: py/objfloat.c:308
+#: py/objfloat.c:308 py/parsenum.c:331
 msgid "complex values not supported"
 msgstr ""
 
@@ -1142,6 +1682,23 @@ msgstr ""
 msgid "int() arg 2 must be >= 2 and <= 36"
 msgstr ""
 
+#: py/parsenum.c:151
+msgid "invalid syntax for integer"
+msgstr ""
+
+#: py/parsenum.c:155
+#, c-format
+msgid "invalid syntax for integer with base %d"
+msgstr ""
+
+#: py/parsenum.c:339
+msgid "invalid syntax for number"
+msgstr ""
+
+#: py/parsenum.c:342
+msgid "decimal numbers not supported"
+msgstr ""
+
 #: py/persistentcode.c:223
 msgid ""
 "Incompatible .mpy file. Please update all .mpy files. See http://adafru.it/"
@@ -1253,6 +1810,18 @@ msgstr ""
 msgid "stream operation not supported"
 msgstr ""
 
+#: py/vm.c:255
+msgid "local variable referenced before assignment"
+msgstr ""
+
+#: py/vm.c:1142
+msgid "no active exception to reraise"
+msgstr ""
+
+#: py/vm.c:1284
+msgid "byte code not implemented"
+msgstr ""
+
 #: shared-bindings/_stage/Layer.c:71
 msgid "graphic must be 2048 bytes long"
 msgstr ""
@@ -1296,6 +1865,10 @@ msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c:193
 msgid "destination_length must be an int >= 0"
+msgstr ""
+
+#: shared-bindings/audiobusio/PDMIn.c:199
+msgid "Cannot record to a file"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c:202
@@ -1426,6 +1999,10 @@ msgstr ""
 msgid "Bytes must be between 0 and 255."
 msgstr ""
 
+#: shared-bindings/os/__init__.c:200
+msgid "No hardware random available"
+msgstr ""
+
 #: shared-bindings/pulseio/PWMOut.c:164
 msgid ""
 "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
@@ -1544,6 +2121,14 @@ msgstr ""
 
 #: shared-module/audioio/WaveFile.c:107
 msgid "Invalid file"
+msgstr ""
+
+#: shared-module/audioio/WaveFile.c:117
+msgid "Couldn't allocate first buffer"
+msgstr ""
+
+#: shared-module/audioio/WaveFile.c:123
+msgid "Couldn't allocate second buffer"
 msgstr ""
 
 #: shared-module/bitbangio/I2C.c:58

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-09 13:43-0700\n"
+"POT-Creation-Date: 2018-08-16 13:33-0700\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,7 +17,121 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: extmod/vfs_fat.c:426 py/moduerrno.c:115
+#: extmod/machine_i2c.c:299
+msgid "invalid I2C peripheral"
+msgstr ""
+
+#: extmod/machine_i2c.c:340 extmod/machine_i2c.c:354 extmod/machine_i2c.c:368
+#: extmod/machine_i2c.c:392
+msgid "I2C operation not supported"
+msgstr ""
+
+#: extmod/machine_mem.c:45
+#, c-format
+msgid "address %08x is not aligned to %d bytes"
+msgstr ""
+
+#: extmod/machine_spi.c:57
+msgid "invalid SPI peripheral"
+msgstr ""
+
+#: extmod/machine_spi.c:124
+msgid "buffers must be the same length"
+msgstr ""
+
+#: extmod/machine_spi.c:207
+msgid "bits must be 8"
+msgstr ""
+
+#: extmod/machine_spi.c:210
+msgid "firstbit must be MSB"
+msgstr ""
+
+#: extmod/machine_spi.c:215
+msgid "must specify all of sck/mosi/miso"
+msgstr ""
+
+#: extmod/modframebuf.c:299
+msgid "invalid format"
+msgstr ""
+
+#: extmod/modubinascii.c:38 extmod/moduhashlib.c:102
+msgid "a bytes-like object is required"
+msgstr ""
+
+#: extmod/modubinascii.c:90
+msgid "odd-length string"
+msgstr ""
+
+#: extmod/modubinascii.c:101
+msgid "non-hex digit found"
+msgstr ""
+
+#: extmod/modubinascii.c:169
+msgid "incorrect padding"
+msgstr ""
+
+#: extmod/moductypes.c:122
+msgid "syntax error in uctypes descriptor"
+msgstr ""
+
+#: extmod/moductypes.c:219
+msgid "Cannot unambiguously get sizeof scalar"
+msgstr ""
+
+#: extmod/moductypes.c:397
+msgid "struct: no fields"
+msgstr ""
+
+#: extmod/moductypes.c:530
+msgid "struct: cannot index"
+msgstr ""
+
+#: extmod/moductypes.c:544
+msgid "struct: index out of range"
+msgstr ""
+
+#: extmod/moduheapq.c:38
+msgid "heap must be a list"
+msgstr ""
+
+#: extmod/moduheapq.c:86 extmod/modutimeq.c:147 extmod/modutimeq.c:172
+msgid "empty heap"
+msgstr ""
+
+#: extmod/modujson.c:281
+msgid "syntax error in JSON"
+msgstr ""
+
+#: extmod/modure.c:161
+msgid "Splitting with sub-captures"
+msgstr ""
+
+#: extmod/modure.c:207
+msgid "Error in regex"
+msgstr ""
+
+#: extmod/modussl_axtls.c:81
+msgid "invalid key"
+msgstr ""
+
+#: extmod/modussl_axtls.c:87
+msgid "invalid cert"
+msgstr ""
+
+#: extmod/modutimeq.c:131
+msgid "queue overflow"
+msgstr ""
+
+#: extmod/moduzlib.c:97
+msgid "compression header"
+msgstr ""
+
+#: extmod/uos_dupterm.c:120
+msgid "invalid dupterm index"
+msgstr ""
+
+#: extmod/vfs_fat.c:426 py/moduerrno.c:150
 msgid "Read-only filesystem"
 msgstr ""
 
@@ -25,82 +139,115 @@ msgstr ""
 msgid "abort() called"
 msgstr ""
 
+#: lib/netutils/netutils.c:83
+msgid "invalid arguments"
+msgstr ""
+
 #: lib/utils/pyexec.c:97 py/builtinimport.c:253
 msgid "script compilation not supported"
 msgstr ""
 
-#: main.c:137
+#: main.c:143
 msgid " output:\n"
 msgstr ""
 
-#: main.c:148 main.c:221
+#: main.c:157 main.c:230
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
 msgstr ""
 
-#: main.c:150
+#: main.c:159
 msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr ""
 
-#: main.c:152 main.c:223
+#: main.c:161 main.c:232
 msgid "Auto-reload is off.\n"
 msgstr ""
 
-#: main.c:166
+#: main.c:175
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr ""
 
-#: main.c:182
+#: main.c:191
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr ""
 
-#: main.c:230
+#: main.c:239
 msgid "You requested starting safe mode by "
 msgstr ""
 
-#: main.c:233
+#: main.c:242
 msgid "To exit, please reset the board without "
 msgstr ""
 
-#: main.c:240
+#: main.c:249
 msgid ""
 "You are running in safe mode which means something really bad happened.\n"
 msgstr ""
 
-#: main.c:242
+#: main.c:251
 msgid "Looks like our core CircuitPython code crashed hard. Whoops!\n"
 msgstr ""
 
-#: main.c:243
+#: main.c:252
 msgid "Please file an issue here with the contents of your CIRCUITPY drive:\n"
 msgstr ""
 
-#: main.c:246
+#: main.c:255
 msgid ""
 "The microcontroller's power dipped. Please make sure your power supply "
 "provides\n"
 msgstr ""
 
-#: main.c:247
+#: main.c:256
 msgid ""
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
 
-#: main.c:251
+#: main.c:260
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 
-#: main.c:406
+#: main.c:415
 msgid "soft reboot\n"
+msgstr ""
+
+#: ports/atmel-samd/audio_dma.c:285
+#: ports/atmel-samd/common-hal/audiobusio/PDMIn.c:361
+msgid "All sync event channels in use"
+msgstr ""
+
+#: ports/atmel-samd/bindings/samd/Clock.c:135
+msgid "calibration is read only"
+msgstr ""
+
+#: ports/atmel-samd/bindings/samd/Clock.c:137
+msgid "calibration is out of range"
+msgstr ""
+
+#: ports/atmel-samd/board_busses.c:39
+msgid "No default I2C bus"
+msgstr ""
+
+#: ports/atmel-samd/board_busses.c:64
+msgid "No default SPI bus"
+msgstr ""
+
+#: ports/atmel-samd/board_busses.c:91
+msgid "No default UART bus"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/analogio/AnalogIn.c:63
 msgid "Pin does not have ADC capabilities"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/analogio/AnalogOut.c:53
+#: ports/atmel-samd/common-hal/analogio/AnalogOut.c:49
+msgid "No DAC on chip"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/analogio/AnalogOut.c:56
 msgid "AnalogOut not supported on given pin"
 msgstr ""
 
@@ -139,12 +286,12 @@ msgid "Too many channels in sample."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c:305
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c:322
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c:326
 msgid "No DMA channel found"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c:308
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c:324
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c:328
 msgid "Unable to allocate buffers for signed conversion"
 msgstr ""
 
@@ -192,11 +339,16 @@ msgstr ""
 msgid "All timers in use"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c:215
+msgid "All event channels in use"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/busio/I2C.c:45
 msgid "Not enough pins available"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c:76
+#: ports/atmel-samd/common-hal/busio/SPI.c:132
 #: ports/atmel-samd/common-hal/busio/UART.c:119
 msgid "Invalid pins"
 msgstr ""
@@ -238,6 +390,7 @@ msgid "Cannot get pull while in output mode"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/microcontroller/__init__.c:74
+#: ports/esp8266/common-hal/microcontroller/__init__.c:64
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 
@@ -259,15 +412,18 @@ msgid "EXTINT channel already in use"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c:118
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:86
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c:203
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:151
 msgid "pop from an empty PulseIn"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c:235 py/obj.c:404
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c:235
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:182 py/obj.c:420
 msgid "index out of range"
 msgstr ""
 
@@ -306,6 +462,293 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:82
 msgid "USB Error"
+msgstr ""
+
+#: ports/esp8266/common-hal/analogio/AnalogIn.c:43
+msgid "Pin %q does not have ADC capabilities"
+msgstr ""
+
+#: ports/esp8266/common-hal/analogio/AnalogOut.c:39
+msgid "No hardware support for analog out."
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/SPI.c:72
+msgid "Pins not valid for SPI"
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/UART.c:45
+msgid "Only tx supported on UART1 (GPIO2)."
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/UART.c:67 ports/esp8266/machine_uart.c:108
+msgid "invalid data bits"
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/UART.c:91 ports/esp8266/machine_uart.c:144
+msgid "invalid stop bits"
+msgstr ""
+
+#: ports/esp8266/common-hal/digitalio/DigitalInOut.c:200
+msgid "ESP8266 does not support pull down."
+msgstr ""
+
+#: ports/esp8266/common-hal/digitalio/DigitalInOut.c:210
+msgid "GPIO16 does not support pull up."
+msgstr ""
+
+#: ports/esp8266/common-hal/microcontroller/__init__.c:66
+msgid "ESP8226 does not support safe mode."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:54
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:113
+#, c-format
+msgid "Maximum PWM frequency is %dhz."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:57
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:116
+msgid "Minimum PWM frequency is 1hz."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:68
+#, c-format
+msgid "Multiple PWM frequencies not supported. PWM already set to %dhz."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:77 ports/esp8266/machine_pwm.c:70
+#, c-format
+msgid "PWM not supported on pin %d"
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:78
+msgid "No PulseIn support for %q"
+msgstr ""
+
+#: ports/esp8266/common-hal/storage/__init__.c:34
+msgid "Unable to remount filesystem"
+msgstr ""
+
+#: ports/esp8266/common-hal/storage/__init__.c:38
+msgid "Use esptool to erase flash and re-upload Python instead"
+msgstr ""
+
+#: ports/esp8266/esp_mphal.c:154
+msgid "C-level assert"
+msgstr ""
+
+#: ports/esp8266/machine_adc.c:57
+#, c-format
+msgid "not a valid ADC Channel: %d"
+msgstr ""
+
+#: ports/esp8266/machine_hspi.c:131 ports/esp8266/machine_hspi.c:137
+msgid "impossible baudrate"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:129
+msgid "expecting a pin"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:284
+msgid "Pin(16) doesn't support pull"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:323
+msgid "invalid pin"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:389
+msgid "pin does not have IRQ capabilities"
+msgstr ""
+
+#: ports/esp8266/machine_rtc.c:185
+msgid "buffer too long"
+msgstr ""
+
+#: ports/esp8266/machine_rtc.c:209 ports/esp8266/machine_rtc.c:223
+#: ports/esp8266/machine_rtc.c:246
+msgid "invalid alarm"
+msgstr ""
+
+#: ports/esp8266/machine_uart.c:169
+#, c-format
+msgid "UART(%d) does not exist"
+msgstr ""
+
+#: ports/esp8266/machine_uart.c:219
+msgid "UART(1) can't read"
+msgstr ""
+
+#: ports/esp8266/modesp.c:119
+msgid "len must be multiple of 4"
+msgstr ""
+
+#: ports/esp8266/modesp.c:274
+#, c-format
+msgid "memory allocation failed, allocating %u bytes for native code"
+msgstr ""
+
+#: ports/esp8266/modesp.c:317
+msgid "flash location must be below 1MByte"
+msgstr ""
+
+#: ports/esp8266/modmachine.c:63
+msgid "frequency can only be either 80Mhz or 160MHz"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:61
+msgid "STA required"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:61
+msgid "AP required"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:87
+msgid "Cannot update i/f status"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:142
+msgid "Cannot set STA config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:144
+msgid "Cannot connect to AP"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:152
+msgid "Cannot disconnect from AP"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:173
+msgid "unknown status param"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:222
+msgid "STA must be active"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:239
+msgid "scan failed"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:306
+msgid "wifi_set_ip_info() failed"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:319
+msgid "either pos or kw args are allowed"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:329
+msgid "can't get STA config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:331
+msgid "can't get AP config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:346
+msgid "invalid buffer length"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:405
+msgid "can't set STA config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:407
+msgid "can't set AP config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:416
+msgid "can query only one param"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:469
+msgid "unknown config param"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:199
+msgid "Cannot apply GAP parameters."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:213
+msgid "Cannot set PPCP parameters."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:264
+msgid "Can not add Vendor Specific 128-bit UUID."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:284
+#: ports/nrf/drivers/bluetooth/ble_drv.c:298
+msgid "Can not add Service."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:373
+msgid "Can not add Characteristic."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:400
+msgid "Can not apply device name in the stack."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:464
+#: ports/nrf/drivers/bluetooth/ble_drv.c:514
+msgid "Can not encode UUID, to check length."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:470
+#: ports/nrf/drivers/bluetooth/ble_drv.c:520
+msgid "Can encode UUID into the advertisment packet."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:545
+msgid "Can not fit data into the advertisment packet."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:558
+#: ports/nrf/drivers/bluetooth/ble_drv.c:604
+#, c-format
+msgid "Can not apply advertisment data. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:614
+#, c-format
+msgid "Can not start advertisment. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:631
+#, c-format
+msgid "Can not stop advertisment. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:650
+#: ports/nrf/drivers/bluetooth/ble_drv.c:726
+#, c-format
+msgid "Can not read attribute value. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:667
+#: ports/nrf/drivers/bluetooth/ble_drv.c:756
+#, c-format
+msgid "Can not write attribute value. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:691
+#, c-format
+msgid "Can not notify attribute value. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:784
+#, c-format
+msgid "Can not start scanning. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:829
+#, c-format
+msgid "Can not connect. status: 0x%02x"
 msgstr ""
 
 #: py/argcheck.c:44
@@ -549,12 +992,109 @@ msgstr ""
 msgid "'data' requires integer arguments"
 msgstr ""
 
+#: py/emitinlinextensa.c:86
+msgid "can only have up to 4 parameters to Xtensa assembly"
+msgstr ""
+
+#: py/emitinlinextensa.c:91 py/emitinlinextensa.c:96
+msgid "parameters must be registers in sequence a2 to a5"
+msgstr ""
+
+#: py/emitinlinextensa.c:162
+#, c-format
+msgid "'%s' expects a register"
+msgstr ""
+
+#: py/emitinlinextensa.c:169
+#, c-format
+msgid "'%s' expects an integer"
+msgstr ""
+
+#: py/emitinlinextensa.c:174
+#, c-format
+msgid "'%s' integer %d is not within range %d..%d"
+msgstr ""
+
+#: py/emitinlinextensa.c:182
+#, c-format
+msgid "'%s' expects a label"
+msgstr ""
+
+#: py/emitinlinextensa.c:193
+msgid "label '%q' not defined"
+msgstr ""
+
+#: py/emitinlinextensa.c:327
+#, c-format
+msgid "unsupported Xtensa instruction '%s' with %d arguments"
+msgstr ""
+
+#: py/emitnative.c:183
+msgid "unknown type '%q'"
+msgstr ""
+
+#: py/emitnative.c:260
+msgid "Viper functions don't currently support more than 4 arguments"
+msgstr ""
+
 #: py/emitnative.c:742
 msgid "conversion to object"
 msgstr ""
 
+#: py/emitnative.c:921
+msgid "local '%q' used before type known"
+msgstr ""
+
+#: py/emitnative.c:1118 py/emitnative.c:1156
+msgid "can't load from '%q'"
+msgstr ""
+
+#: py/emitnative.c:1128
+msgid "can't load with '%q' index"
+msgstr ""
+
+#: py/emitnative.c:1188
+msgid "local '%q' has type '%q' but source is '%q'"
+msgstr ""
+
+#: py/emitnative.c:1289 py/emitnative.c:1379
+msgid "can't store '%q'"
+msgstr ""
+
+#: py/emitnative.c:1358 py/emitnative.c:1419
+msgid "can't store to '%q'"
+msgstr ""
+
+#: py/emitnative.c:1369
+msgid "can't store with '%q' index"
+msgstr ""
+
+#: py/emitnative.c:1540
+msgid "can't implicitly convert '%q' to 'bool'"
+msgstr ""
+
+#: py/emitnative.c:1774
+msgid "unary op %q not implemented"
+msgstr ""
+
+#: py/emitnative.c:1930
+msgid "binary op %q not implemented"
+msgstr ""
+
+#: py/emitnative.c:1951
+msgid "can't do binary op between '%q' and '%q'"
+msgstr ""
+
 #: py/emitnative.c:2126
 msgid "casting"
+msgstr ""
+
+#: py/emitnative.c:2173
+msgid "return expected '%q' but got '%q'"
+msgstr ""
+
+#: py/emitnative.c:2191
+msgid "must raise an object"
 msgstr ""
 
 #: py/emitnative.c:2201
@@ -617,140 +1157,140 @@ msgstr ""
 msgid "expecting a dict for keyword args"
 msgstr ""
 
-#: py/moduerrno.c:108 py/moduerrno.c:111
+#: py/moduerrno.c:143 py/moduerrno.c:146
 msgid "Permission denied"
 msgstr ""
 
-#: py/moduerrno.c:109
+#: py/moduerrno.c:144
 msgid "No such file/directory"
 msgstr ""
 
-#: py/moduerrno.c:110
+#: py/moduerrno.c:145
 msgid "Input/output error"
 msgstr ""
 
-#: py/moduerrno.c:112
+#: py/moduerrno.c:147
 msgid "File exists"
 msgstr ""
 
-#: py/moduerrno.c:113
+#: py/moduerrno.c:148
 msgid "Unsupported operation"
 msgstr ""
 
-#: py/moduerrno.c:114
+#: py/moduerrno.c:149
 msgid "Invalid argument"
 msgstr ""
 
-#: py/obj.c:89
+#: py/obj.c:90
 msgid "Traceback (most recent call last):\n"
 msgstr ""
 
-#: py/obj.c:92
+#: py/obj.c:94
 msgid "  File \"%q\", line %d"
 msgstr ""
 
-#: py/obj.c:94
+#: py/obj.c:96
 msgid "  File \"%q\""
 msgstr ""
 
-#: py/obj.c:101
+#: py/obj.c:100
 msgid ", in %q\n"
 msgstr ""
 
-#: py/obj.c:241
+#: py/obj.c:257
 msgid "can't convert to int"
 msgstr ""
 
-#: py/obj.c:244
+#: py/obj.c:260
 #, c-format
 msgid "can't convert %s to int"
 msgstr ""
 
-#: py/obj.c:304
+#: py/obj.c:320
 msgid "can't convert to float"
 msgstr ""
 
-#: py/obj.c:307
+#: py/obj.c:323
 #, c-format
 msgid "can't convert %s to float"
 msgstr ""
 
-#: py/obj.c:337
+#: py/obj.c:353
 msgid "can't convert to complex"
 msgstr ""
 
-#: py/obj.c:340
+#: py/obj.c:356
 #, c-format
 msgid "can't convert %s to complex"
 msgstr ""
 
-#: py/obj.c:355
+#: py/obj.c:371
 msgid "expected tuple/list"
 msgstr ""
 
-#: py/obj.c:358
+#: py/obj.c:374
 #, c-format
 msgid "object '%s' is not a tuple or list"
 msgstr ""
 
-#: py/obj.c:369
+#: py/obj.c:385
 msgid "tuple/list has wrong length"
 msgstr ""
 
-#: py/obj.c:371
+#: py/obj.c:387
 #, c-format
 msgid "requested length %d but object has length %d"
 msgstr ""
 
-#: py/obj.c:384
+#: py/obj.c:400
 msgid "indices must be integers"
 msgstr ""
 
-#: py/obj.c:387
+#: py/obj.c:403
 msgid "%q indices must be integers, not %s"
 msgstr ""
 
-#: py/obj.c:407
+#: py/obj.c:423
 msgid "%q index out of range"
 msgstr ""
 
-#: py/obj.c:439
+#: py/obj.c:455
 msgid "object has no len"
 msgstr ""
 
-#: py/obj.c:442
+#: py/obj.c:458
 #, c-format
 msgid "object of type '%s' has no len()"
 msgstr ""
 
-#: py/obj.c:480
+#: py/obj.c:496
 msgid "object does not support item deletion"
 msgstr ""
 
-#: py/obj.c:483
+#: py/obj.c:499
 #, c-format
 msgid "'%s' object does not support item deletion"
 msgstr ""
 
-#: py/obj.c:487
+#: py/obj.c:503
 msgid "object is not subscriptable"
 msgstr ""
 
-#: py/obj.c:490
+#: py/obj.c:506
 #, c-format
 msgid "'%s' object is not subscriptable"
 msgstr ""
 
-#: py/obj.c:494
+#: py/obj.c:510
 msgid "object does not support item assignment"
 msgstr ""
 
-#: py/obj.c:497
+#: py/obj.c:513
 #, c-format
 msgid "'%s' object does not support item assignment"
 msgstr ""
 
-#: py/obj.c:528
+#: py/obj.c:544
 msgid "object with buffer protocol required"
 msgstr ""
 
@@ -795,7 +1335,7 @@ msgstr ""
 msgid "dict update sequence has wrong length"
 msgstr ""
 
-#: py/objfloat.c:308
+#: py/objfloat.c:308 py/parsenum.c:331
 msgid "complex values not supported"
 msgstr ""
 
@@ -1142,6 +1682,23 @@ msgstr ""
 msgid "int() arg 2 must be >= 2 and <= 36"
 msgstr ""
 
+#: py/parsenum.c:151
+msgid "invalid syntax for integer"
+msgstr ""
+
+#: py/parsenum.c:155
+#, c-format
+msgid "invalid syntax for integer with base %d"
+msgstr ""
+
+#: py/parsenum.c:339
+msgid "invalid syntax for number"
+msgstr ""
+
+#: py/parsenum.c:342
+msgid "decimal numbers not supported"
+msgstr ""
+
 #: py/persistentcode.c:223
 msgid ""
 "Incompatible .mpy file. Please update all .mpy files. See http://adafru.it/"
@@ -1253,6 +1810,18 @@ msgstr ""
 msgid "stream operation not supported"
 msgstr ""
 
+#: py/vm.c:255
+msgid "local variable referenced before assignment"
+msgstr ""
+
+#: py/vm.c:1142
+msgid "no active exception to reraise"
+msgstr ""
+
+#: py/vm.c:1284
+msgid "byte code not implemented"
+msgstr ""
+
 #: shared-bindings/_stage/Layer.c:71
 msgid "graphic must be 2048 bytes long"
 msgstr ""
@@ -1296,6 +1865,10 @@ msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c:193
 msgid "destination_length must be an int >= 0"
+msgstr ""
+
+#: shared-bindings/audiobusio/PDMIn.c:199
+msgid "Cannot record to a file"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c:202
@@ -1426,6 +1999,10 @@ msgstr ""
 msgid "Bytes must be between 0 and 255."
 msgstr ""
 
+#: shared-bindings/os/__init__.c:200
+msgid "No hardware random available"
+msgstr ""
+
 #: shared-bindings/pulseio/PWMOut.c:164
 msgid ""
 "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
@@ -1544,6 +2121,14 @@ msgstr ""
 
 #: shared-module/audioio/WaveFile.c:107
 msgid "Invalid file"
+msgstr ""
+
+#: shared-module/audioio/WaveFile.c:117
+msgid "Couldn't allocate first buffer"
+msgstr ""
+
+#: shared-module/audioio/WaveFile.c:123
+msgid "Couldn't allocate second buffer"
 msgstr ""
 
 #: shared-module/bitbangio/I2C.c:58

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-16 13:33-0700\n"
+"POT-Creation-Date: 2018-08-16 14:36-0700\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -26,7 +26,7 @@ msgstr ""
 msgid "I2C operation not supported"
 msgstr ""
 
-#: extmod/machine_mem.c:45
+#: extmod/machine_mem.c:45 ports/unix/modmachine.c:53
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr ""
@@ -135,6 +135,10 @@ msgstr ""
 msgid "Read-only filesystem"
 msgstr ""
 
+#: extmod/vfs_posix_file.c:48 ports/unix/file.c:50 py/objstringio.c:43
+msgid "I/O operation on closed file"
+msgstr ""
+
 #: lib/embed/abort_.c:8
 msgid "abort() called"
 msgstr ""
@@ -240,6 +244,7 @@ msgid "No default UART bus"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/analogio/AnalogIn.c:63
+#: ports/nrf/common-hal/analogio/AnalogIn.c:39
 msgid "Pin does not have ADC capabilities"
 msgstr ""
 
@@ -350,6 +355,7 @@ msgstr ""
 #: ports/atmel-samd/common-hal/busio/I2C.c:76
 #: ports/atmel-samd/common-hal/busio/SPI.c:132
 #: ports/atmel-samd/common-hal/busio/UART.c:119
+#: ports/nrf/common-hal/busio/I2C.c:58
 msgid "Invalid pins"
 msgstr ""
 
@@ -386,6 +392,7 @@ msgid "No TX pin"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c:168
+#: ports/nrf/common-hal/digitalio/DigitalInOut.c:158
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -396,6 +403,7 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:120
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:366
+#: ports/nrf/common-hal/pulseio/PWMOut.c:227
 msgid "Invalid PWM frequency"
 msgstr ""
 
@@ -452,15 +460,18 @@ msgid "No free GCLKs"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:78
+#: ports/nrf/common-hal/usb_hid/Device.c:45
 #, c-format
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:82
+#: ports/nrf/common-hal/usb_hid/Device.c:53
 msgid "USB Busy"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:82
+#: ports/nrf/common-hal/usb_hid/Device.c:59
 msgid "USB Error"
 msgstr ""
 
@@ -669,12 +680,33 @@ msgstr ""
 msgid "unknown config param"
 msgstr ""
 
+#: ports/nrf/common-hal/analogio/AnalogOut.c:37
+msgid "AnalogOut functionality not supported"
+msgstr ""
+
+#: ports/nrf/common-hal/busio/UART.c:45 ports/nrf/common-hal/busio/UART.c:49
+#: ports/nrf/common-hal/busio/UART.c:53 ports/nrf/common-hal/busio/UART.c:62
+#: ports/nrf/common-hal/busio/UART.c:68 ports/nrf/common-hal/busio/UART.c:73
+#: ports/nrf/common-hal/busio/UART.c:78 ports/nrf/common-hal/busio/UART.c:83
+#: ports/nrf/common-hal/busio/UART.c:88
+msgid "busio.UART not yet implemented"
+msgstr ""
+
+#: ports/nrf/common-hal/microcontroller/Processor.c:49
+#, c-format
+msgid "Can not get temperature. status: 0x%02x"
+msgstr ""
+
 #: ports/nrf/drivers/bluetooth/ble_drv.c:199
 msgid "Cannot apply GAP parameters."
 msgstr ""
 
 #: ports/nrf/drivers/bluetooth/ble_drv.c:213
 msgid "Cannot set PPCP parameters."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:245
+msgid "Can not query for the device address."
 msgstr ""
 
 #: ports/nrf/drivers/bluetooth/ble_drv.c:264
@@ -749,6 +781,42 @@ msgstr ""
 #: ports/nrf/drivers/bluetooth/ble_drv.c:829
 #, c-format
 msgid "Can not connect. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/modules/ubluepy/ubluepy_characteristic.c:68
+#: ports/nrf/modules/ubluepy/ubluepy_service.c:80
+#: ports/nrf/modules/ubluepy/ubluepy_service.c:132
+#: ports/nrf/modules/ubluepy/ubluepy_uuid.c:137
+msgid "Invalid UUID parameter"
+msgstr ""
+
+#: ports/nrf/modules/ubluepy/ubluepy_service.c:73
+msgid "Invalid Service type"
+msgstr ""
+
+#: ports/nrf/modules/ubluepy/ubluepy_uuid.c:127
+msgid "Invalid UUID string length"
+msgstr ""
+
+#: ports/unix/modffi.c:138
+msgid "Unknown type"
+msgstr ""
+
+#: ports/unix/modffi.c:207 ports/unix/modffi.c:265
+msgid "Error in ffi_prep_cif"
+msgstr ""
+
+#: ports/unix/modffi.c:270
+msgid "ffi_prep_closure_loc"
+msgstr ""
+
+#: ports/unix/modffi.c:413
+msgid "Don't know how to pass object to native function"
+msgstr ""
+
+#: ports/unix/modusocket.c:474
+#, c-format
+msgid "[addrinfo error %d]"
 msgstr ""
 
 #: py/argcheck.c:44
@@ -1581,10 +1649,6 @@ msgstr ""
 
 #: py/objstr.c:2106
 msgid "can't convert '%q' object to %q implicitly"
-msgstr ""
-
-#: py/objstringio.c:43
-msgid "I/O operation on closed file"
 msgstr ""
 
 #: py/objstrunicode.c:134

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-09 13:43-0700\n"
+"POT-Creation-Date: 2018-08-16 13:33-0700\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,7 +17,121 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: extmod/vfs_fat.c:426 py/moduerrno.c:115
+#: extmod/machine_i2c.c:299
+msgid "invalid I2C peripheral"
+msgstr ""
+
+#: extmod/machine_i2c.c:340 extmod/machine_i2c.c:354 extmod/machine_i2c.c:368
+#: extmod/machine_i2c.c:392
+msgid "I2C operation not supported"
+msgstr ""
+
+#: extmod/machine_mem.c:45
+#, c-format
+msgid "address %08x is not aligned to %d bytes"
+msgstr ""
+
+#: extmod/machine_spi.c:57
+msgid "invalid SPI peripheral"
+msgstr ""
+
+#: extmod/machine_spi.c:124
+msgid "buffers must be the same length"
+msgstr ""
+
+#: extmod/machine_spi.c:207
+msgid "bits must be 8"
+msgstr ""
+
+#: extmod/machine_spi.c:210
+msgid "firstbit must be MSB"
+msgstr ""
+
+#: extmod/machine_spi.c:215
+msgid "must specify all of sck/mosi/miso"
+msgstr ""
+
+#: extmod/modframebuf.c:299
+msgid "invalid format"
+msgstr ""
+
+#: extmod/modubinascii.c:38 extmod/moduhashlib.c:102
+msgid "a bytes-like object is required"
+msgstr ""
+
+#: extmod/modubinascii.c:90
+msgid "odd-length string"
+msgstr ""
+
+#: extmod/modubinascii.c:101
+msgid "non-hex digit found"
+msgstr ""
+
+#: extmod/modubinascii.c:169
+msgid "incorrect padding"
+msgstr ""
+
+#: extmod/moductypes.c:122
+msgid "syntax error in uctypes descriptor"
+msgstr ""
+
+#: extmod/moductypes.c:219
+msgid "Cannot unambiguously get sizeof scalar"
+msgstr ""
+
+#: extmod/moductypes.c:397
+msgid "struct: no fields"
+msgstr ""
+
+#: extmod/moductypes.c:530
+msgid "struct: cannot index"
+msgstr ""
+
+#: extmod/moductypes.c:544
+msgid "struct: index out of range"
+msgstr ""
+
+#: extmod/moduheapq.c:38
+msgid "heap must be a list"
+msgstr ""
+
+#: extmod/moduheapq.c:86 extmod/modutimeq.c:147 extmod/modutimeq.c:172
+msgid "empty heap"
+msgstr ""
+
+#: extmod/modujson.c:281
+msgid "syntax error in JSON"
+msgstr ""
+
+#: extmod/modure.c:161
+msgid "Splitting with sub-captures"
+msgstr ""
+
+#: extmod/modure.c:207
+msgid "Error in regex"
+msgstr ""
+
+#: extmod/modussl_axtls.c:81
+msgid "invalid key"
+msgstr ""
+
+#: extmod/modussl_axtls.c:87
+msgid "invalid cert"
+msgstr ""
+
+#: extmod/modutimeq.c:131
+msgid "queue overflow"
+msgstr ""
+
+#: extmod/moduzlib.c:97
+msgid "compression header"
+msgstr ""
+
+#: extmod/uos_dupterm.c:120
+msgid "invalid dupterm index"
+msgstr ""
+
+#: extmod/vfs_fat.c:426 py/moduerrno.c:150
 msgid "Read-only filesystem"
 msgstr ""
 
@@ -25,82 +139,115 @@ msgstr ""
 msgid "abort() called"
 msgstr ""
 
+#: lib/netutils/netutils.c:83
+msgid "invalid arguments"
+msgstr ""
+
 #: lib/utils/pyexec.c:97 py/builtinimport.c:253
 msgid "script compilation not supported"
 msgstr ""
 
-#: main.c:137
+#: main.c:143
 msgid " output:\n"
 msgstr ""
 
-#: main.c:148 main.c:221
+#: main.c:157 main.c:230
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
 msgstr ""
 
-#: main.c:150
+#: main.c:159
 msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr ""
 
-#: main.c:152 main.c:223
+#: main.c:161 main.c:232
 msgid "Auto-reload is off.\n"
 msgstr ""
 
-#: main.c:166
+#: main.c:175
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr ""
 
-#: main.c:182
+#: main.c:191
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr ""
 
-#: main.c:230
+#: main.c:239
 msgid "You requested starting safe mode by "
 msgstr ""
 
-#: main.c:233
+#: main.c:242
 msgid "To exit, please reset the board without "
 msgstr ""
 
-#: main.c:240
+#: main.c:249
 msgid ""
 "You are running in safe mode which means something really bad happened.\n"
 msgstr ""
 
-#: main.c:242
+#: main.c:251
 msgid "Looks like our core CircuitPython code crashed hard. Whoops!\n"
 msgstr ""
 
-#: main.c:243
+#: main.c:252
 msgid "Please file an issue here with the contents of your CIRCUITPY drive:\n"
 msgstr ""
 
-#: main.c:246
+#: main.c:255
 msgid ""
 "The microcontroller's power dipped. Please make sure your power supply "
 "provides\n"
 msgstr ""
 
-#: main.c:247
+#: main.c:256
 msgid ""
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
 
-#: main.c:251
+#: main.c:260
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 
-#: main.c:406
+#: main.c:415
 msgid "soft reboot\n"
+msgstr ""
+
+#: ports/atmel-samd/audio_dma.c:285
+#: ports/atmel-samd/common-hal/audiobusio/PDMIn.c:361
+msgid "All sync event channels in use"
+msgstr ""
+
+#: ports/atmel-samd/bindings/samd/Clock.c:135
+msgid "calibration is read only"
+msgstr ""
+
+#: ports/atmel-samd/bindings/samd/Clock.c:137
+msgid "calibration is out of range"
+msgstr ""
+
+#: ports/atmel-samd/board_busses.c:39
+msgid "No default I2C bus"
+msgstr ""
+
+#: ports/atmel-samd/board_busses.c:64
+msgid "No default SPI bus"
+msgstr ""
+
+#: ports/atmel-samd/board_busses.c:91
+msgid "No default UART bus"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/analogio/AnalogIn.c:63
 msgid "Pin does not have ADC capabilities"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/analogio/AnalogOut.c:53
+#: ports/atmel-samd/common-hal/analogio/AnalogOut.c:49
+msgid "No DAC on chip"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/analogio/AnalogOut.c:56
 msgid "AnalogOut not supported on given pin"
 msgstr ""
 
@@ -139,12 +286,12 @@ msgid "Too many channels in sample."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c:305
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c:322
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c:326
 msgid "No DMA channel found"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c:308
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c:324
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c:328
 msgid "Unable to allocate buffers for signed conversion"
 msgstr ""
 
@@ -192,11 +339,16 @@ msgstr ""
 msgid "All timers in use"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c:215
+msgid "All event channels in use"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/busio/I2C.c:45
 msgid "Not enough pins available"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c:76
+#: ports/atmel-samd/common-hal/busio/SPI.c:132
 #: ports/atmel-samd/common-hal/busio/UART.c:119
 msgid "Invalid pins"
 msgstr ""
@@ -238,6 +390,7 @@ msgid "Cannot get pull while in output mode"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/microcontroller/__init__.c:74
+#: ports/esp8266/common-hal/microcontroller/__init__.c:64
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 
@@ -259,15 +412,18 @@ msgid "EXTINT channel already in use"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c:118
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:86
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c:203
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:151
 msgid "pop from an empty PulseIn"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c:235 py/obj.c:404
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c:235
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:182 py/obj.c:420
 msgid "index out of range"
 msgstr ""
 
@@ -306,6 +462,293 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:82
 msgid "USB Error"
+msgstr ""
+
+#: ports/esp8266/common-hal/analogio/AnalogIn.c:43
+msgid "Pin %q does not have ADC capabilities"
+msgstr ""
+
+#: ports/esp8266/common-hal/analogio/AnalogOut.c:39
+msgid "No hardware support for analog out."
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/SPI.c:72
+msgid "Pins not valid for SPI"
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/UART.c:45
+msgid "Only tx supported on UART1 (GPIO2)."
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/UART.c:67 ports/esp8266/machine_uart.c:108
+msgid "invalid data bits"
+msgstr ""
+
+#: ports/esp8266/common-hal/busio/UART.c:91 ports/esp8266/machine_uart.c:144
+msgid "invalid stop bits"
+msgstr ""
+
+#: ports/esp8266/common-hal/digitalio/DigitalInOut.c:200
+msgid "ESP8266 does not support pull down."
+msgstr ""
+
+#: ports/esp8266/common-hal/digitalio/DigitalInOut.c:210
+msgid "GPIO16 does not support pull up."
+msgstr ""
+
+#: ports/esp8266/common-hal/microcontroller/__init__.c:66
+msgid "ESP8226 does not support safe mode."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:54
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:113
+#, c-format
+msgid "Maximum PWM frequency is %dhz."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:57
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:116
+msgid "Minimum PWM frequency is 1hz."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:68
+#, c-format
+msgid "Multiple PWM frequencies not supported. PWM already set to %dhz."
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PWMOut.c:77 ports/esp8266/machine_pwm.c:70
+#, c-format
+msgid "PWM not supported on pin %d"
+msgstr ""
+
+#: ports/esp8266/common-hal/pulseio/PulseIn.c:78
+msgid "No PulseIn support for %q"
+msgstr ""
+
+#: ports/esp8266/common-hal/storage/__init__.c:34
+msgid "Unable to remount filesystem"
+msgstr ""
+
+#: ports/esp8266/common-hal/storage/__init__.c:38
+msgid "Use esptool to erase flash and re-upload Python instead"
+msgstr ""
+
+#: ports/esp8266/esp_mphal.c:154
+msgid "C-level assert"
+msgstr ""
+
+#: ports/esp8266/machine_adc.c:57
+#, c-format
+msgid "not a valid ADC Channel: %d"
+msgstr ""
+
+#: ports/esp8266/machine_hspi.c:131 ports/esp8266/machine_hspi.c:137
+msgid "impossible baudrate"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:129
+msgid "expecting a pin"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:284
+msgid "Pin(16) doesn't support pull"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:323
+msgid "invalid pin"
+msgstr ""
+
+#: ports/esp8266/machine_pin.c:389
+msgid "pin does not have IRQ capabilities"
+msgstr ""
+
+#: ports/esp8266/machine_rtc.c:185
+msgid "buffer too long"
+msgstr ""
+
+#: ports/esp8266/machine_rtc.c:209 ports/esp8266/machine_rtc.c:223
+#: ports/esp8266/machine_rtc.c:246
+msgid "invalid alarm"
+msgstr ""
+
+#: ports/esp8266/machine_uart.c:169
+#, c-format
+msgid "UART(%d) does not exist"
+msgstr ""
+
+#: ports/esp8266/machine_uart.c:219
+msgid "UART(1) can't read"
+msgstr ""
+
+#: ports/esp8266/modesp.c:119
+msgid "len must be multiple of 4"
+msgstr ""
+
+#: ports/esp8266/modesp.c:274
+#, c-format
+msgid "memory allocation failed, allocating %u bytes for native code"
+msgstr ""
+
+#: ports/esp8266/modesp.c:317
+msgid "flash location must be below 1MByte"
+msgstr ""
+
+#: ports/esp8266/modmachine.c:63
+msgid "frequency can only be either 80Mhz or 160MHz"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:61
+msgid "STA required"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:61
+msgid "AP required"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:87
+msgid "Cannot update i/f status"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:142
+msgid "Cannot set STA config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:144
+msgid "Cannot connect to AP"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:152
+msgid "Cannot disconnect from AP"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:173
+msgid "unknown status param"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:222
+msgid "STA must be active"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:239
+msgid "scan failed"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:306
+msgid "wifi_set_ip_info() failed"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:319
+msgid "either pos or kw args are allowed"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:329
+msgid "can't get STA config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:331
+msgid "can't get AP config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:346
+msgid "invalid buffer length"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:405
+msgid "can't set STA config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:407
+msgid "can't set AP config"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:416
+msgid "can query only one param"
+msgstr ""
+
+#: ports/esp8266/modnetwork.c:469
+msgid "unknown config param"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:199
+msgid "Cannot apply GAP parameters."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:213
+msgid "Cannot set PPCP parameters."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:264
+msgid "Can not add Vendor Specific 128-bit UUID."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:284
+#: ports/nrf/drivers/bluetooth/ble_drv.c:298
+msgid "Can not add Service."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:373
+msgid "Can not add Characteristic."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:400
+msgid "Can not apply device name in the stack."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:464
+#: ports/nrf/drivers/bluetooth/ble_drv.c:514
+msgid "Can not encode UUID, to check length."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:470
+#: ports/nrf/drivers/bluetooth/ble_drv.c:520
+msgid "Can encode UUID into the advertisment packet."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:545
+msgid "Can not fit data into the advertisment packet."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:558
+#: ports/nrf/drivers/bluetooth/ble_drv.c:604
+#, c-format
+msgid "Can not apply advertisment data. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:614
+#, c-format
+msgid "Can not start advertisment. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:631
+#, c-format
+msgid "Can not stop advertisment. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:650
+#: ports/nrf/drivers/bluetooth/ble_drv.c:726
+#, c-format
+msgid "Can not read attribute value. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:667
+#: ports/nrf/drivers/bluetooth/ble_drv.c:756
+#, c-format
+msgid "Can not write attribute value. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:691
+#, c-format
+msgid "Can not notify attribute value. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:784
+#, c-format
+msgid "Can not start scanning. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:829
+#, c-format
+msgid "Can not connect. status: 0x%02x"
 msgstr ""
 
 #: py/argcheck.c:44
@@ -549,12 +992,109 @@ msgstr ""
 msgid "'data' requires integer arguments"
 msgstr ""
 
+#: py/emitinlinextensa.c:86
+msgid "can only have up to 4 parameters to Xtensa assembly"
+msgstr ""
+
+#: py/emitinlinextensa.c:91 py/emitinlinextensa.c:96
+msgid "parameters must be registers in sequence a2 to a5"
+msgstr ""
+
+#: py/emitinlinextensa.c:162
+#, c-format
+msgid "'%s' expects a register"
+msgstr ""
+
+#: py/emitinlinextensa.c:169
+#, c-format
+msgid "'%s' expects an integer"
+msgstr ""
+
+#: py/emitinlinextensa.c:174
+#, c-format
+msgid "'%s' integer %d is not within range %d..%d"
+msgstr ""
+
+#: py/emitinlinextensa.c:182
+#, c-format
+msgid "'%s' expects a label"
+msgstr ""
+
+#: py/emitinlinextensa.c:193
+msgid "label '%q' not defined"
+msgstr ""
+
+#: py/emitinlinextensa.c:327
+#, c-format
+msgid "unsupported Xtensa instruction '%s' with %d arguments"
+msgstr ""
+
+#: py/emitnative.c:183
+msgid "unknown type '%q'"
+msgstr ""
+
+#: py/emitnative.c:260
+msgid "Viper functions don't currently support more than 4 arguments"
+msgstr ""
+
 #: py/emitnative.c:742
 msgid "conversion to object"
 msgstr ""
 
+#: py/emitnative.c:921
+msgid "local '%q' used before type known"
+msgstr ""
+
+#: py/emitnative.c:1118 py/emitnative.c:1156
+msgid "can't load from '%q'"
+msgstr ""
+
+#: py/emitnative.c:1128
+msgid "can't load with '%q' index"
+msgstr ""
+
+#: py/emitnative.c:1188
+msgid "local '%q' has type '%q' but source is '%q'"
+msgstr ""
+
+#: py/emitnative.c:1289 py/emitnative.c:1379
+msgid "can't store '%q'"
+msgstr ""
+
+#: py/emitnative.c:1358 py/emitnative.c:1419
+msgid "can't store to '%q'"
+msgstr ""
+
+#: py/emitnative.c:1369
+msgid "can't store with '%q' index"
+msgstr ""
+
+#: py/emitnative.c:1540
+msgid "can't implicitly convert '%q' to 'bool'"
+msgstr ""
+
+#: py/emitnative.c:1774
+msgid "unary op %q not implemented"
+msgstr ""
+
+#: py/emitnative.c:1930
+msgid "binary op %q not implemented"
+msgstr ""
+
+#: py/emitnative.c:1951
+msgid "can't do binary op between '%q' and '%q'"
+msgstr ""
+
 #: py/emitnative.c:2126
 msgid "casting"
+msgstr ""
+
+#: py/emitnative.c:2173
+msgid "return expected '%q' but got '%q'"
+msgstr ""
+
+#: py/emitnative.c:2191
+msgid "must raise an object"
 msgstr ""
 
 #: py/emitnative.c:2201
@@ -617,140 +1157,140 @@ msgstr ""
 msgid "expecting a dict for keyword args"
 msgstr ""
 
-#: py/moduerrno.c:108 py/moduerrno.c:111
+#: py/moduerrno.c:143 py/moduerrno.c:146
 msgid "Permission denied"
 msgstr ""
 
-#: py/moduerrno.c:109
+#: py/moduerrno.c:144
 msgid "No such file/directory"
 msgstr ""
 
-#: py/moduerrno.c:110
+#: py/moduerrno.c:145
 msgid "Input/output error"
 msgstr ""
 
-#: py/moduerrno.c:112
+#: py/moduerrno.c:147
 msgid "File exists"
 msgstr ""
 
-#: py/moduerrno.c:113
+#: py/moduerrno.c:148
 msgid "Unsupported operation"
 msgstr ""
 
-#: py/moduerrno.c:114
+#: py/moduerrno.c:149
 msgid "Invalid argument"
 msgstr ""
 
-#: py/obj.c:89
+#: py/obj.c:90
 msgid "Traceback (most recent call last):\n"
 msgstr ""
 
-#: py/obj.c:92
+#: py/obj.c:94
 msgid "  File \"%q\", line %d"
 msgstr ""
 
-#: py/obj.c:94
+#: py/obj.c:96
 msgid "  File \"%q\""
 msgstr ""
 
-#: py/obj.c:101
+#: py/obj.c:100
 msgid ", in %q\n"
 msgstr ""
 
-#: py/obj.c:241
+#: py/obj.c:257
 msgid "can't convert to int"
 msgstr ""
 
-#: py/obj.c:244
+#: py/obj.c:260
 #, c-format
 msgid "can't convert %s to int"
 msgstr ""
 
-#: py/obj.c:304
+#: py/obj.c:320
 msgid "can't convert to float"
 msgstr ""
 
-#: py/obj.c:307
+#: py/obj.c:323
 #, c-format
 msgid "can't convert %s to float"
 msgstr ""
 
-#: py/obj.c:337
+#: py/obj.c:353
 msgid "can't convert to complex"
 msgstr ""
 
-#: py/obj.c:340
+#: py/obj.c:356
 #, c-format
 msgid "can't convert %s to complex"
 msgstr ""
 
-#: py/obj.c:355
+#: py/obj.c:371
 msgid "expected tuple/list"
 msgstr ""
 
-#: py/obj.c:358
+#: py/obj.c:374
 #, c-format
 msgid "object '%s' is not a tuple or list"
 msgstr ""
 
-#: py/obj.c:369
+#: py/obj.c:385
 msgid "tuple/list has wrong length"
 msgstr ""
 
-#: py/obj.c:371
+#: py/obj.c:387
 #, c-format
 msgid "requested length %d but object has length %d"
 msgstr ""
 
-#: py/obj.c:384
+#: py/obj.c:400
 msgid "indices must be integers"
 msgstr ""
 
-#: py/obj.c:387
+#: py/obj.c:403
 msgid "%q indices must be integers, not %s"
 msgstr ""
 
-#: py/obj.c:407
+#: py/obj.c:423
 msgid "%q index out of range"
 msgstr ""
 
-#: py/obj.c:439
+#: py/obj.c:455
 msgid "object has no len"
 msgstr ""
 
-#: py/obj.c:442
+#: py/obj.c:458
 #, c-format
 msgid "object of type '%s' has no len()"
 msgstr ""
 
-#: py/obj.c:480
+#: py/obj.c:496
 msgid "object does not support item deletion"
 msgstr ""
 
-#: py/obj.c:483
+#: py/obj.c:499
 #, c-format
 msgid "'%s' object does not support item deletion"
 msgstr ""
 
-#: py/obj.c:487
+#: py/obj.c:503
 msgid "object is not subscriptable"
 msgstr ""
 
-#: py/obj.c:490
+#: py/obj.c:506
 #, c-format
 msgid "'%s' object is not subscriptable"
 msgstr ""
 
-#: py/obj.c:494
+#: py/obj.c:510
 msgid "object does not support item assignment"
 msgstr ""
 
-#: py/obj.c:497
+#: py/obj.c:513
 #, c-format
 msgid "'%s' object does not support item assignment"
 msgstr ""
 
-#: py/obj.c:528
+#: py/obj.c:544
 msgid "object with buffer protocol required"
 msgstr ""
 
@@ -795,7 +1335,7 @@ msgstr ""
 msgid "dict update sequence has wrong length"
 msgstr ""
 
-#: py/objfloat.c:308
+#: py/objfloat.c:308 py/parsenum.c:331
 msgid "complex values not supported"
 msgstr ""
 
@@ -1142,6 +1682,23 @@ msgstr ""
 msgid "int() arg 2 must be >= 2 and <= 36"
 msgstr ""
 
+#: py/parsenum.c:151
+msgid "invalid syntax for integer"
+msgstr ""
+
+#: py/parsenum.c:155
+#, c-format
+msgid "invalid syntax for integer with base %d"
+msgstr ""
+
+#: py/parsenum.c:339
+msgid "invalid syntax for number"
+msgstr ""
+
+#: py/parsenum.c:342
+msgid "decimal numbers not supported"
+msgstr ""
+
 #: py/persistentcode.c:223
 msgid ""
 "Incompatible .mpy file. Please update all .mpy files. See http://adafru.it/"
@@ -1253,6 +1810,18 @@ msgstr ""
 msgid "stream operation not supported"
 msgstr ""
 
+#: py/vm.c:255
+msgid "local variable referenced before assignment"
+msgstr ""
+
+#: py/vm.c:1142
+msgid "no active exception to reraise"
+msgstr ""
+
+#: py/vm.c:1284
+msgid "byte code not implemented"
+msgstr ""
+
 #: shared-bindings/_stage/Layer.c:71
 msgid "graphic must be 2048 bytes long"
 msgstr ""
@@ -1296,6 +1865,10 @@ msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c:193
 msgid "destination_length must be an int >= 0"
+msgstr ""
+
+#: shared-bindings/audiobusio/PDMIn.c:199
+msgid "Cannot record to a file"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c:202
@@ -1426,6 +1999,10 @@ msgstr ""
 msgid "Bytes must be between 0 and 255."
 msgstr ""
 
+#: shared-bindings/os/__init__.c:200
+msgid "No hardware random available"
+msgstr ""
+
 #: shared-bindings/pulseio/PWMOut.c:164
 msgid ""
 "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
@@ -1544,6 +2121,14 @@ msgstr ""
 
 #: shared-module/audioio/WaveFile.c:107
 msgid "Invalid file"
+msgstr ""
+
+#: shared-module/audioio/WaveFile.c:117
+msgid "Couldn't allocate first buffer"
+msgstr ""
+
+#: shared-module/audioio/WaveFile.c:123
+msgid "Couldn't allocate second buffer"
 msgstr ""
 
 #: shared-module/bitbangio/I2C.c:58

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-16 13:33-0700\n"
+"POT-Creation-Date: 2018-08-16 14:36-0700\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -26,7 +26,7 @@ msgstr ""
 msgid "I2C operation not supported"
 msgstr ""
 
-#: extmod/machine_mem.c:45
+#: extmod/machine_mem.c:45 ports/unix/modmachine.c:53
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr ""
@@ -135,6 +135,10 @@ msgstr ""
 msgid "Read-only filesystem"
 msgstr ""
 
+#: extmod/vfs_posix_file.c:48 ports/unix/file.c:50 py/objstringio.c:43
+msgid "I/O operation on closed file"
+msgstr ""
+
 #: lib/embed/abort_.c:8
 msgid "abort() called"
 msgstr ""
@@ -240,6 +244,7 @@ msgid "No default UART bus"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/analogio/AnalogIn.c:63
+#: ports/nrf/common-hal/analogio/AnalogIn.c:39
 msgid "Pin does not have ADC capabilities"
 msgstr ""
 
@@ -350,6 +355,7 @@ msgstr ""
 #: ports/atmel-samd/common-hal/busio/I2C.c:76
 #: ports/atmel-samd/common-hal/busio/SPI.c:132
 #: ports/atmel-samd/common-hal/busio/UART.c:119
+#: ports/nrf/common-hal/busio/I2C.c:58
 msgid "Invalid pins"
 msgstr ""
 
@@ -386,6 +392,7 @@ msgid "No TX pin"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c:168
+#: ports/nrf/common-hal/digitalio/DigitalInOut.c:158
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -396,6 +403,7 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:120
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:366
+#: ports/nrf/common-hal/pulseio/PWMOut.c:227
 msgid "Invalid PWM frequency"
 msgstr ""
 
@@ -452,15 +460,18 @@ msgid "No free GCLKs"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:78
+#: ports/nrf/common-hal/usb_hid/Device.c:45
 #, c-format
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:82
+#: ports/nrf/common-hal/usb_hid/Device.c:53
 msgid "USB Busy"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/usb_hid/Device.c:82
+#: ports/nrf/common-hal/usb_hid/Device.c:59
 msgid "USB Error"
 msgstr ""
 
@@ -669,12 +680,33 @@ msgstr ""
 msgid "unknown config param"
 msgstr ""
 
+#: ports/nrf/common-hal/analogio/AnalogOut.c:37
+msgid "AnalogOut functionality not supported"
+msgstr ""
+
+#: ports/nrf/common-hal/busio/UART.c:45 ports/nrf/common-hal/busio/UART.c:49
+#: ports/nrf/common-hal/busio/UART.c:53 ports/nrf/common-hal/busio/UART.c:62
+#: ports/nrf/common-hal/busio/UART.c:68 ports/nrf/common-hal/busio/UART.c:73
+#: ports/nrf/common-hal/busio/UART.c:78 ports/nrf/common-hal/busio/UART.c:83
+#: ports/nrf/common-hal/busio/UART.c:88
+msgid "busio.UART not yet implemented"
+msgstr ""
+
+#: ports/nrf/common-hal/microcontroller/Processor.c:49
+#, c-format
+msgid "Can not get temperature. status: 0x%02x"
+msgstr ""
+
 #: ports/nrf/drivers/bluetooth/ble_drv.c:199
 msgid "Cannot apply GAP parameters."
 msgstr ""
 
 #: ports/nrf/drivers/bluetooth/ble_drv.c:213
 msgid "Cannot set PPCP parameters."
+msgstr ""
+
+#: ports/nrf/drivers/bluetooth/ble_drv.c:245
+msgid "Can not query for the device address."
 msgstr ""
 
 #: ports/nrf/drivers/bluetooth/ble_drv.c:264
@@ -749,6 +781,42 @@ msgstr ""
 #: ports/nrf/drivers/bluetooth/ble_drv.c:829
 #, c-format
 msgid "Can not connect. status: 0x%02x"
+msgstr ""
+
+#: ports/nrf/modules/ubluepy/ubluepy_characteristic.c:68
+#: ports/nrf/modules/ubluepy/ubluepy_service.c:80
+#: ports/nrf/modules/ubluepy/ubluepy_service.c:132
+#: ports/nrf/modules/ubluepy/ubluepy_uuid.c:137
+msgid "Invalid UUID parameter"
+msgstr ""
+
+#: ports/nrf/modules/ubluepy/ubluepy_service.c:73
+msgid "Invalid Service type"
+msgstr ""
+
+#: ports/nrf/modules/ubluepy/ubluepy_uuid.c:127
+msgid "Invalid UUID string length"
+msgstr ""
+
+#: ports/unix/modffi.c:138
+msgid "Unknown type"
+msgstr ""
+
+#: ports/unix/modffi.c:207 ports/unix/modffi.c:265
+msgid "Error in ffi_prep_cif"
+msgstr ""
+
+#: ports/unix/modffi.c:270
+msgid "ffi_prep_closure_loc"
+msgstr ""
+
+#: ports/unix/modffi.c:413
+msgid "Don't know how to pass object to native function"
+msgstr ""
+
+#: ports/unix/modusocket.c:474
+#, c-format
+msgid "[addrinfo error %d]"
 msgstr ""
 
 #: py/argcheck.c:44
@@ -1581,10 +1649,6 @@ msgstr ""
 
 #: py/objstr.c:2106
 msgid "can't convert '%q' object to %q implicitly"
-msgstr ""
-
-#: py/objstringio.c:43
-msgid "I/O operation on closed file"
 msgstr ""
 
 #: py/objstrunicode.c:134

--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -33,6 +33,7 @@
 #include "shared-bindings/audioio/WaveFile.h"
 
 #include "py/mpstate.h"
+#include "py/runtime.h"
 
 static audio_dma_t* audio_dma_state[AUDIO_DMA_CHANNEL_COUNT];
 
@@ -279,6 +280,10 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t* dma,
         // We're likely double buffering so set up the block interrupts.
         turn_on_event_system();
         dma->event_channel = find_sync_event_channel();
+
+        if (dma->event_channel >= EVSYS_SYNCH_NUM) {
+            mp_raise_RuntimeError(translate("All sync event channels in use"));
+        }
         init_event_channel_interrupt(dma->event_channel, CORE_GCLK, EVSYS_ID_GEN_DMAC_CH_0 + dma_channel);
 
         // We keep the audio_dma_t for internal use and the sample as a root pointer because it

--- a/ports/atmel-samd/bindings/samd/Clock.c
+++ b/ports/atmel-samd/bindings/samd/Clock.c
@@ -132,9 +132,9 @@ STATIC mp_obj_t samd_clock_set_calibration(mp_obj_t self_in, mp_obj_t calibratio
     samd_clock_obj_t *self = MP_OBJ_TO_PTR(self_in);
     int ret = clock_set_calibration(self->type, self->index, mp_obj_get_int(calibration));
     if (ret == -2)
-        mp_raise_AttributeError("calibration is read only");
+        mp_raise_AttributeError(translate("calibration is read only"));
     if (ret == -1)
-        mp_raise_ValueError("calibration is out of range");
+        mp_raise_ValueError(translate("calibration is out of range"));
     return mp_const_none;
 }
 

--- a/ports/atmel-samd/board_busses.c
+++ b/ports/atmel-samd/board_busses.c
@@ -29,13 +29,14 @@
 #include "shared-bindings/busio/UART.h"
 
 #include "shared-bindings/microcontroller/Pin.h"
+#include "supervisor/shared/translate.h"
 #include "mpconfigboard.h"
 #include "samd/pins.h"
 #include "py/runtime.h"
 
 #if !defined(DEFAULT_I2C_BUS_SDA) || !defined(DEFAULT_I2C_BUS_SCL)
     STATIC mp_obj_t board_i2c(void) {
-        mp_raise_NotImplementedError("No default I2C bus");
+        mp_raise_NotImplementedError(translate("No default I2C bus"));
         return NULL;
     }
 #else
@@ -60,7 +61,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(board_i2c_obj, board_i2c);
 
 #if !defined(DEFAULT_SPI_BUS_SCK) || !defined(DEFAULT_SPI_BUS_MISO) || !defined(DEFAULT_SPI_BUS_MOSI)
     STATIC mp_obj_t board_spi(void) {
-        mp_raise_NotImplementedError("No default SPI bus");
+        mp_raise_NotImplementedError(translate("No default SPI bus"));
         return NULL;
     }
 #else
@@ -87,7 +88,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(board_spi_obj, board_spi);
 
 #if !defined(DEFAULT_UART_BUS_RX) || !defined(DEFAULT_UART_BUS_TX)
     STATIC mp_obj_t board_uart(void) {
-        mp_raise_NotImplementedError("No default UART bus");
+        mp_raise_NotImplementedError(translate("No default UART bus"));
         return NULL;
     }
 #else

--- a/ports/atmel-samd/common-hal/analogio/AnalogOut.c
+++ b/ports/atmel-samd/common-hal/analogio/AnalogOut.c
@@ -46,7 +46,7 @@
 void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self,
         const mcu_pin_obj_t *pin) {
     #if defined(SAMD21) && !defined(PIN_PA02)
-    mp_raise_NotImplementedError("No DAC on chip");
+    mp_raise_NotImplementedError(translate("No DAC on chip"));
     #else
     if (pin->number != PIN_PA02
     #ifdef SAMD51

--- a/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+++ b/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
@@ -357,6 +357,9 @@ uint32_t common_hal_audiobusio_pdmin_record_to_buffer(audiobusio_pdmin_obj_t* se
         uint16_t* output_buffer, uint32_t output_buffer_length) {
     uint8_t dma_channel = find_free_audio_dma_channel();
     uint8_t event_channel = find_sync_event_channel();
+    if (event_channel >= EVSYS_SYNCH_NUM) {
+        mp_raise_RuntimeError(translate("All sync event channels in use"));
+    }
 
     // We allocate two buffers on the stack to use for double buffering.
     const uint8_t samples_per_buffer = SAMPLES_PER_BUFFER;

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -211,6 +211,10 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t* self,
     // Find a free event channel. We start at the highest channels because we only need and async
     // path.
     uint8_t channel = find_async_event_channel();
+    if (channel >= EVSYS_CHANNELS) {
+        mp_raise_RuntimeError(translate("All event channels in use"));
+    }
+
     #ifdef SAMD51
     connect_event_user_to_channel(EVSYS_ID_USER_DAC_START_1, channel);
     #define EVSYS_ID_USER_DAC_START EVSYS_ID_USER_DAC_START_0

--- a/ports/atmel-samd/common-hal/busio/SPI.c
+++ b/ports/atmel-samd/common-hal/busio/SPI.c
@@ -129,7 +129,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     }
     #endif
     if (sercom == NULL) {
-        mp_raise_ValueError("Invalid pins");
+        mp_raise_ValueError(translate("Invalid pins"));
     }
 
     // Set up SPI clocks on SERCOM.

--- a/ports/esp8266/common-hal/analogio/AnalogIn.c
+++ b/ports/esp8266/common-hal/analogio/AnalogIn.c
@@ -33,13 +33,14 @@
 #include "py/mphal.h"
 #include "common-hal/microcontroller/__init__.h"
 #include "shared-bindings/analogio/AnalogIn.h"
+#include "supervisor/shared/translate.h"
 
 #include "user_interface.h"
 
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t* self,
         const mcu_pin_obj_t *pin) {
     if (pin != &pin_TOUT) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "Pin %q does not have ADC capabilities", pin->name));
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, translate("Pin %q does not have ADC capabilities"), pin->name));
     }
     claim_pin(pin);
 }

--- a/ports/esp8266/common-hal/analogio/AnalogOut.c
+++ b/ports/esp8266/common-hal/analogio/AnalogOut.c
@@ -24,18 +24,19 @@
  * THE SOFTWARE.
  */
 
+#include "shared-bindings/analogio/AnalogOut.h"
+
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
 
 #include "py/runtime.h"
-
-#include "shared-bindings/analogio/AnalogOut.h"
+#include "supervisor/shared/translate.h"
 
 void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self,
         const mcu_pin_obj_t *pin) {
     nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError,
-        "No hardware support for analog out."));
+        translate("No hardware support for analog out.")));
 }
 
 bool common_hal_analogio_analogout_deinited(analogio_analogout_obj_t *self) {

--- a/ports/esp8266/common-hal/busio/SPI.c
+++ b/ports/esp8266/common-hal/busio/SPI.c
@@ -27,6 +27,7 @@
 #include "shared-bindings/microcontroller/__init__.h"
 #include "common-hal/busio/SPI.h"
 #include "py/nlr.h"
+#include "supervisor/shared/translate.h"
 
 #include "eagle_soc.h"
 #include "ets_alt_task.h"
@@ -68,7 +69,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
                                 (mosi == MP_OBJ_TO_PTR(mp_const_none) && miso == &pin_MTDI) ||
                                 (mosi == &pin_MTCK && miso == &pin_MTDI))) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-            "Pins not valid for SPI"));
+            translate("Pins not valid for SPI")));
     }
 
     busio_spi_init_gpio(SPI_CLK_USE_DIV, clock, mosi, miso);

--- a/ports/esp8266/common-hal/busio/UART.c
+++ b/ports/esp8266/common-hal/busio/UART.c
@@ -27,6 +27,7 @@
 #include "common-hal/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/busio/UART.h"
+#include "supervisor/shared/translate.h"
 
 #include "ets_sys.h"
 #include "uart.h"
@@ -41,7 +42,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         uint8_t bits, uart_parity_t parity, uint8_t stop, uint32_t timeout,
         uint8_t receiver_buffer_size) {
     if (rx != mp_const_none || tx != &pin_GPIO2) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "Only tx supported on UART1 (GPIO2)."));
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, translate("Only tx supported on UART1 (GPIO2).")));
     }
 
     // set baudrate
@@ -63,7 +64,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             UartDev.data_bits = UART_EIGHT_BITS;
             break;
         default:
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid data bits"));
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, translate("invalid data bits")));
             break;
     }
 
@@ -87,7 +88,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             UartDev.stop_bits = UART_TWO_STOP_BIT;
             break;
         default:
-            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "invalid stop bits"));
+            nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, translate("invalid stop bits")));
             break;
     }
 

--- a/ports/esp8266/common-hal/digitalio/DigitalInOut.c
+++ b/ports/esp8266/common-hal/digitalio/DigitalInOut.c
@@ -33,6 +33,7 @@
 #include "py/mphal.h"
 
 #include "shared-bindings/digitalio/DigitalInOut.h"
+#include "supervisor/shared/translate.h"
 #include "common-hal/microcontroller/Pin.h"
 
 extern volatile bool gpio16_in_use;
@@ -45,9 +46,9 @@ digitalinout_result_t common_hal_digitalio_digitalinout_construct(
         WRITE_PERI_REG(RTC_GPIO_CONF, READ_PERI_REG(RTC_GPIO_CONF) & ~1);	//mux configuration for out enable
         WRITE_PERI_REG(RTC_GPIO_ENABLE, READ_PERI_REG(RTC_GPIO_ENABLE) & ~1);	//out disable
         claim_pin(pin);
-    } else {    
+    } else {
         PIN_FUNC_SELECT(self->pin->peripheral, self->pin->gpio_function);
-    }    
+    }
     return DIGITALINOUT_OK;
 }
 
@@ -196,7 +197,7 @@ void common_hal_digitalio_digitalinout_set_pull(
         digitalio_digitalinout_obj_t* self, digitalio_pull_t pull) {
     if (pull == PULL_DOWN) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError,
-            "ESP8266 does not support pull down."));
+            translate("ESP8266 does not support pull down.")));
         return;
     }
     if (self->pin->gpio_number == 16) {
@@ -206,7 +207,7 @@ void common_hal_digitalio_digitalinout_set_pull(
         // raise the exception so the user knows PULL_UP is not available
         if (pull != PULL_NONE){
             nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError,
-            "GPIO16 does not support pull up."));
+            translate("GPIO16 does not support pull up.")));
         }
         return;
     }

--- a/ports/esp8266/common-hal/microcontroller/__init__.c
+++ b/ports/esp8266/common-hal/microcontroller/__init__.c
@@ -32,6 +32,7 @@
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/Processor.h"
+#include "supervisor/shared/translate.h"
 
 #include "eagle_soc.h"
 #include "ets_alt_task.h"
@@ -60,9 +61,9 @@ void common_hal_mcu_enable_interrupts() {
 
 void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
     if (runmode == RUNMODE_BOOTLOADER) {
-        mp_raise_ValueError("Cannot reset into bootloader because no bootloader is present.");
+        mp_raise_ValueError(translate("Cannot reset into bootloader because no bootloader is present."));
     } else if (runmode == RUNMODE_SAFE_MODE) {
-        mp_raise_ValueError("ESP8226 does not support safe mode.");
+        mp_raise_ValueError(translate("ESP8226 does not support safe mode."));
     }
 }
 

--- a/ports/esp8266/common-hal/pulseio/PWMOut.c
+++ b/ports/esp8266/common-hal/pulseio/PWMOut.c
@@ -31,6 +31,7 @@
 
 #include "py/runtime.h"
 #include "shared-bindings/pulseio/PWMOut.h"
+#include "supervisor/shared/translate.h"
 
 #include "eagle_soc.h"
 #include "c_types.h"
@@ -50,10 +51,10 @@ void common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self, const mcu_p
         bool variable_frequency) {
     if (frequency > PWM_FREQ_MAX) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-            "Maximum PWM frequency is %dhz.", PWM_FREQ_MAX));
+            translate("Maximum PWM frequency is %dhz."), PWM_FREQ_MAX));
     } else if (frequency < 1) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError,
-            "Minimum PWM frequency is 1hz."));
+            translate("Minimum PWM frequency is 1hz.")));
     }
 
     // start the PWM subsystem if it's not already running
@@ -64,7 +65,7 @@ void common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self, const mcu_p
         first_channel_variable = variable_frequency;
     } else if (first_channel_variable || pwm_get_freq(0) != frequency) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-            "Multiple PWM frequencies not supported. PWM already set to %dhz.", pwm_get_freq(0)));
+            translate("Multiple PWM frequencies not supported. PWM already set to %dhz."), pwm_get_freq(0)));
     }
 
     self->channel = pwm_add(pin->gpio_number,
@@ -73,7 +74,7 @@ void common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self, const mcu_p
     self->pin = pin;
     if (self->channel == -1) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-            "PWM not supported on pin %d", pin->gpio_number));
+            translate("PWM not supported on pin %d"), pin->gpio_number));
     }
 }
 
@@ -109,10 +110,10 @@ uint16_t common_hal_pulseio_pwmout_get_duty_cycle(pulseio_pwmout_obj_t* self) {
 void common_hal_pulseio_pwmout_set_frequency(pulseio_pwmout_obj_t* self, uint32_t frequency) {
     if (frequency > PWM_FREQ_MAX) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-            "Maximum PWM frequency is %dhz.", PWM_FREQ_MAX));
+            translate("Maximum PWM frequency is %dhz."), PWM_FREQ_MAX));
     } else if (frequency < 1) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError,
-            "Minimum PWM frequency is 1hz."));
+            translate("Minimum PWM frequency is 1hz.")));
     }
     pwm_set_freq(frequency, 0);
 }

--- a/ports/esp8266/common-hal/pulseio/PulseIn.c
+++ b/ports/esp8266/common-hal/pulseio/PulseIn.c
@@ -35,6 +35,7 @@
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/pulseio/PulseIn.h"
+#include "supervisor/shared/translate.h"
 #include "common-hal/microcontroller/__init__.h"
 
 static void pulsein_set_interrupt(pulseio_pulsein_obj_t *self, bool rising, bool falling) {
@@ -74,7 +75,7 @@ void pulseio_pulsein_interrupt_handler(void *data) {
 void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
         const mcu_pin_obj_t* pin, uint16_t maxlen, bool idle_state) {
     if (pin->gpio_number == NO_GPIO || pin->gpio_function == SPECIAL_CASE) {
-        mp_raise_msg_varg(&mp_type_ValueError, "No PulseIn support for %q", pin->name );
+        mp_raise_msg_varg(&mp_type_ValueError, translate("No PulseIn support for %q"), pin->name );
     }
     PIN_FUNC_SELECT(pin->peripheral, pin->gpio_function);
     PIN_PULLUP_DIS(pin->peripheral);
@@ -82,7 +83,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
 
     self->buffer = (uint16_t *) m_malloc(maxlen * sizeof(uint16_t), false);
     if (self->buffer == NULL) {
-        mp_raise_msg_varg(&mp_type_MemoryError, "Failed to allocate RX buffer of %d bytes", maxlen * sizeof(uint16_t));
+        mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"), maxlen * sizeof(uint16_t));
     }
 
     self->maxlen = maxlen;
@@ -147,7 +148,7 @@ void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t* self) {
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
     if (self->len == 0) {
-        mp_raise_IndexError("pop from an empty PulseIn");
+        mp_raise_IndexError(translate("pop from an empty PulseIn"));
     }
     common_hal_mcu_disable_interrupts();
     uint16_t value = self->buffer[self->start];
@@ -178,7 +179,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t* self,
     }
     if (index < 0 || index >= self->len) {
         common_hal_mcu_enable_interrupts();
-        mp_raise_IndexError("index out of range");
+        mp_raise_IndexError(translate("index out of range"));
     }
     uint16_t value = self->buffer[(self->start + index) % self->maxlen];
     common_hal_mcu_enable_interrupts();

--- a/ports/esp8266/common-hal/storage/__init__.c
+++ b/ports/esp8266/common-hal/storage/__init__.c
@@ -28,11 +28,12 @@
 
 #include "py/runtime.h"
 #include "shared-bindings/storage/__init__.h"
+#include "supervisor/shared/translate.h"
 
 void common_hal_storage_remount(const char* mount_path, bool readonly) {
-    mp_raise_NotImplementedError("");
+    mp_raise_NotImplementedError(translate("Unable to remount filesystem"));
 }
 
 void common_hal_storage_erase_filesystem() {
-    mp_raise_NotImplementedError("Use esptool to erase flash and re-upload Python instead");
+    mp_raise_NotImplementedError(translate("Use esptool to erase flash and re-upload Python instead"));
 }

--- a/ports/esp8266/esp8266.ld
+++ b/ports/esp8266/esp8266.ld
@@ -5,7 +5,7 @@ MEMORY
     dport0_0_seg : org = 0x3ff00000, len = 0x10
     dram0_0_seg :  org = 0x3ffe8000, len = 0x14000
     iram1_0_seg :  org = 0x40100000, len = 0x8000
-    irom0_0_seg :  org = 0x40209000, len = 0x8f000
+    irom0_0_seg :  org = 0x40209000, len = 0x91000
 }
 
 /* define common sections and symbols */

--- a/ports/esp8266/esp_mphal.c
+++ b/ports/esp8266/esp_mphal.c
@@ -34,6 +34,7 @@
 #include "py/runtime.h"
 #include "extmod/misc.h"
 #include "lib/utils/pyexec.h"
+#include "supervisor/shared/translate.h"
 
 STATIC byte input_buf_array[256];
 ringbuf_t stdin_ringbuf = {input_buf_array, sizeof(input_buf_array)};
@@ -150,7 +151,7 @@ void ets_event_poll(void) {
 void __assert_func(const char *file, int line, const char *func, const char *expr) {
     printf("assert:%s:%d:%s: %s\n", file, line, func, expr);
     nlr_raise(mp_obj_new_exception_msg(&mp_type_AssertionError,
-        "C-level assert"));
+        translate("C-level assert")));
 }
 
 void mp_hal_signal_input(void) {

--- a/ports/esp8266/machine_adc.c
+++ b/ports/esp8266/machine_adc.c
@@ -28,6 +28,7 @@
 #include <string.h>
 
 #include "py/runtime.h"
+#include "supervisor/shared/translate.h"
 #include "user_interface.h"
 
 const mp_obj_type_t pyb_adc_type;
@@ -53,7 +54,7 @@ STATIC mp_obj_t pyb_adc_make_new(const mp_obj_type_t *type_in, size_t n_args, si
         return &pyb_adc_vdd3;
     default:
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-            "not a valid ADC Channel: %d", chn));
+            translate("not a valid ADC Channel: %d"), chn));
     }
 }
 

--- a/ports/esp8266/machine_hspi.c
+++ b/ports/esp8266/machine_hspi.c
@@ -37,6 +37,7 @@
 #include "py/mphal.h"
 #include "extmod/machine_spi.h"
 #include "modmachine.h"
+#include "supervisor/shared/translate.h"
 #include "hspi.h"
 
 #if MICROPY_PY_MACHINE_SPI
@@ -127,13 +128,13 @@ STATIC void machine_hspi_init(mp_obj_base_t *self_in, size_t n_args, const mp_ob
         spi_init_gpio(HSPI, SPI_CLK_80MHZ_NODIV);
         spi_clock(HSPI, 0, 0);
     } else if (self->baudrate > 40000000L) {
-        mp_raise_ValueError("impossible baudrate");
+        mp_raise_ValueError(translate("impossible baudrate"));
     } else {
         uint32_t divider = 40000000L / self->baudrate;
         uint16_t prediv = MIN(divider, SPI_CLKDIV_PRE + 1);
         uint16_t cntdiv = (divider / prediv) * 2; // cntdiv has to be even
         if (cntdiv > SPI_CLKCNT_N + 1 || cntdiv == 0 || prediv == 0) {
-            mp_raise_ValueError("impossible baudrate");
+            mp_raise_ValueError(translate("impossible baudrate"));
         }
         self->baudrate = 80000000L / (prediv * cntdiv);
         spi_init_gpio(HSPI, SPI_CLK_USE_DIV);

--- a/ports/esp8266/machine_pin.c
+++ b/ports/esp8266/machine_pin.c
@@ -39,6 +39,8 @@
 #include "extmod/virtpin.h"
 #include "modmachine.h"
 
+#include "supervisor/shared/translate.h"
+
 #define GET_TRIGGER(phys_port) \
     GPIO_PIN_INT_TYPE_GET(GPIO_REG_READ(GPIO_PIN_ADDR(phys_port)))
 #define SET_TRIGGER(phys_port, trig) \
@@ -124,7 +126,7 @@ void pin_intr_handler(uint32_t status) {
 
 pyb_pin_obj_t *mp_obj_get_pin_obj(mp_obj_t pin_in) {
     if (mp_obj_get_type(pin_in) != &pyb_pin_type) {
-        mp_raise_ValueError("expecting a pin");
+        mp_raise_ValueError(translate("expecting a pin"));
     }
     pyb_pin_obj_t *self = pin_in;
     return self;
@@ -279,7 +281,7 @@ STATIC mp_obj_t pyb_pin_obj_init_helper(pyb_pin_obj_t *self, size_t n_args, cons
         // only pull-down seems to be supported by the hardware, and
         // we only expose pull-up behaviour in software
         if (pull != GPIO_PULL_NONE) {
-            mp_raise_ValueError("Pin(16) doesn't support pull");
+            mp_raise_ValueError(translate("Pin(16) doesn't support pull"));
         }
     } else {
         PIN_FUNC_SELECT(self->periph, self->func);
@@ -318,7 +320,7 @@ mp_obj_t mp_pin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, 
         pin = (pyb_pin_obj_t*)&pyb_pin_obj[wanted_pin];
     }
     if (pin == NULL || pin->base.type == NULL) {
-        mp_raise_ValueError("invalid pin");
+        mp_raise_ValueError(translate("invalid pin"));
     }
 
     if (n_args > 1 || n_kw > 0) {
@@ -384,7 +386,7 @@ STATIC mp_obj_t pyb_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     if (self->phys_port >= 16) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, "pin does not have IRQ capabilities"));
+        nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, translate("pin does not have IRQ capabilities")));
     }
 
     if (n_args > 1 || kw_args->used != 0) {

--- a/ports/esp8266/machine_pwm.c
+++ b/ports/esp8266/machine_pwm.c
@@ -31,6 +31,7 @@
 
 #include "py/runtime.h"
 #include "modmachine.h"
+#include "supervisor/shared/translate.h"
 
 typedef struct _pyb_pwm_obj_t {
     mp_obj_base_t base;
@@ -66,7 +67,7 @@ STATIC void pyb_pwm_init_helper(pyb_pwm_obj_t *self, size_t n_args, const mp_obj
     int channel = pwm_add(self->pin->phys_port, self->pin->periph, self->pin->func);
     if (channel == -1) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-            "PWM not supported on pin %d", self->pin->phys_port));
+            translate("PWM not supported on pin %d"), self->pin->phys_port));
     }
 
     self->channel = channel;

--- a/ports/esp8266/machine_rtc.c
+++ b/ports/esp8266/machine_rtc.c
@@ -29,6 +29,7 @@
 
 #include "py/runtime.h"
 #include "lib/timeutils/timeutils.h"
+#include "supervisor/shared/translate.h"
 #include "user_interface.h"
 #include "modmachine.h"
 
@@ -181,7 +182,7 @@ STATIC mp_obj_t pyb_rtc_memory(size_t n_args, const mp_obj_t *args) {
         mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
 
         if (bufinfo.len > MEM_USER_MAXLEN) {
-            mp_raise_ValueError("buffer too long");
+            mp_raise_ValueError(translate("buffer too long"));
         }
 
         len = bufinfo.len;
@@ -205,7 +206,7 @@ STATIC mp_obj_t pyb_rtc_alarm(mp_obj_t self_in, mp_obj_t alarm_id, mp_obj_t time
 
     // check we want alarm0
     if (mp_obj_get_int(alarm_id) != 0) {
-        mp_raise_ValueError("invalid alarm");
+        mp_raise_ValueError(translate("invalid alarm"));
     }
 
     // set expiry time (in microseconds)
@@ -219,7 +220,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(pyb_rtc_alarm_obj, pyb_rtc_alarm);
 STATIC mp_obj_t pyb_rtc_alarm_left(size_t n_args, const mp_obj_t *args) {
     // check we want alarm0
     if (n_args > 1 && mp_obj_get_int(args[1]) != 0) {
-        mp_raise_ValueError("invalid alarm");
+        mp_raise_ValueError(translate("invalid alarm"));
     }
 
     uint64_t now = pyb_rtc_get_us_since_2000();
@@ -242,7 +243,7 @@ STATIC mp_obj_t pyb_rtc_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
 
     // check we want alarm0
     if (args[ARG_trigger].u_int != 0) {
-        mp_raise_ValueError("invalid alarm");
+        mp_raise_ValueError(translate("invalid alarm"));
     }
 
     // set the wake value

--- a/ports/esp8266/machine_uart.c
+++ b/ports/esp8266/machine_uart.c
@@ -34,6 +34,7 @@
 #include "py/runtime.h"
 #include "py/stream.h"
 #include "py/mperrno.h"
+#include "supervisor/shared/translate.h"
 #include "modmachine.h"
 
 // UartDev is defined and initialized in rom code.
@@ -104,7 +105,7 @@ STATIC void pyb_uart_init_helper(pyb_uart_obj_t *self, size_t n_args, const mp_o
             self->bits = 8;
             break;
         default:
-            mp_raise_ValueError("invalid data bits");
+            mp_raise_ValueError(translate("invalid data bits"));
             break;
     }
 
@@ -140,7 +141,7 @@ STATIC void pyb_uart_init_helper(pyb_uart_obj_t *self, size_t n_args, const mp_o
             self->stop = 2;
             break;
         default:
-            mp_raise_ValueError("invalid stop bits");
+            mp_raise_ValueError(translate("invalid stop bits"));
             break;
     }
 
@@ -165,7 +166,7 @@ STATIC mp_obj_t pyb_uart_make_new(const mp_obj_type_t *type, size_t n_args, size
     // get uart id
     mp_int_t uart_id = mp_obj_get_int(args[0]);
     if (uart_id != 0 && uart_id != 1) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "UART(%d) does not exist", uart_id));
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, translate("UART(%d) does not exist"), uart_id));
     }
 
     // create instance
@@ -215,7 +216,7 @@ STATIC mp_uint_t pyb_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, i
     pyb_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     if (self->uart_id == 1) {
-        mp_raise_msg(&mp_type_OSError, "UART(1) can't read");
+        mp_raise_msg(&mp_type_OSError, translate("UART(1) can't read"));
     }
 
     // make sure we want at least 1 char

--- a/ports/esp8266/makeimg.py
+++ b/ports/esp8266/makeimg.py
@@ -21,6 +21,7 @@ with open(sys.argv[3], 'wb') as fout:
     with open(sys.argv[2], 'rb') as f:
         data_rom = f.read()
 
+    print(SEGS_MAX_SIZE, len(data_flash))
     pad = b'\xff' * (SEGS_MAX_SIZE - len(data_flash))
     assert len(pad) >= 4
     fout.write(pad[:-4])

--- a/ports/esp8266/modesp.c
+++ b/ports/esp8266/modesp.c
@@ -30,6 +30,7 @@
 #include "py/runtime.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
+#include "supervisor/shared/translate.h"
 #include "uart.h"
 #include "user_interface.h"
 #include "mem.h"
@@ -37,7 +38,7 @@
 
 #define MODESP_INCLUDE_CONSTANTS (1)
 
-void error_check(bool status, const char *msg) {
+void error_check(bool status, const compressed_string_t *msg) {
     if (!status) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, msg));
     }
@@ -115,7 +116,7 @@ STATIC mp_obj_t esp_flash_write(mp_obj_t offset_in, const mp_obj_t buf_in) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
     if (bufinfo.len & 0x3) {
-        mp_raise_ValueError("len must be multiple of 4");
+        mp_raise_ValueError(translate("len must be multiple of 4"));
     }
     SpiFlashOpResult res = spi_flash_write(offset, bufinfo.buf, bufinfo.len);
     if (res == SPI_FLASH_RESULT_OK) {
@@ -270,7 +271,7 @@ void *esp_native_code_commit(void *buf, size_t len) {
     len = (len + 3) & ~3;
     if (esp_native_code_cur + len > esp_native_code_end) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_MemoryError,
-            "memory allocation failed, allocating %u bytes for native code", (uint)len));
+            translate("memory allocation failed, allocating %u bytes for native code"), (uint)len));
     }
 
     void *dest;
@@ -313,7 +314,7 @@ STATIC mp_obj_t esp_set_native_code_location(mp_obj_t start_in, mp_obj_t len_in)
         esp_native_code_erased = esp_native_code_start;
         // memory-mapped flash is limited in extents to 1MByte
         if (esp_native_code_end > FLASH_END - FLASH_START) {
-            mp_raise_ValueError("flash location must be below 1MByte");
+            mp_raise_ValueError(translate("flash location must be below 1MByte"));
         }
     }
     return mp_const_none;

--- a/ports/esp8266/modmachine.c
+++ b/ports/esp8266/modmachine.c
@@ -35,6 +35,7 @@
 #include "extmod/machine_pulse.h"
 #include "extmod/machine_i2c.h"
 #include "modmachine.h"
+#include "supervisor/shared/translate.h"
 
 #include "xtirq.h"
 #include "os_type.h"
@@ -59,7 +60,7 @@ STATIC mp_obj_t machine_freq(size_t n_args, const mp_obj_t *args) {
         // set
         mp_int_t freq = mp_obj_get_int(args[0]) / 1000000;
         if (freq != 80 && freq != 160) {
-            mp_raise_ValueError("frequency can only be either 80Mhz or 160MHz");
+            mp_raise_ValueError(translate("frequency can only be either 80Mhz or 160MHz"));
         }
         system_update_cpu_freq(freq);
         return mp_const_none;

--- a/ports/nrf/common-hal/analogio/AnalogIn.c
+++ b/ports/nrf/common-hal/analogio/AnalogIn.c
@@ -27,6 +27,7 @@
 
 #include "common-hal/analogio/AnalogIn.h"
 #include "py/runtime.h"
+#include "supervisor/shared/translate.h"
 
 #include "nrfx_saadc.h"
 #include "nrf_gpio.h"
@@ -35,7 +36,7 @@
 
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self, const mcu_pin_obj_t *pin) {
     if (pin->adc_channel == 0)
-        mp_raise_ValueError("Pin does not have ADC capabilities");
+        mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
 
     nrf_gpio_cfg_default(NRF_GPIO_PIN_MAP(pin->port, pin->pin));
 

--- a/ports/nrf/common-hal/analogio/AnalogOut.c
+++ b/ports/nrf/common-hal/analogio/AnalogOut.c
@@ -24,17 +24,17 @@
  * THE SOFTWARE.
  */
 
+#include "shared-bindings/analogio/AnalogOut.h"
+
 #include <stdint.h>
 #include <string.h>
 
 #include "py/mperrno.h"
 #include "py/runtime.h"
-
-#include "shared-bindings/analogio/AnalogOut.h"
-
+#include "supervisor/shared/translate.h"
 
 void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self, const mcu_pin_obj_t *pin) {
-    mp_raise_RuntimeError("AnalogOut functionality not supported");
+    mp_raise_RuntimeError(translate("AnalogOut functionality not supported"));
 }
 
 bool common_hal_analogio_analogout_deinited(analogio_analogout_obj_t *self) {

--- a/ports/nrf/common-hal/busio/I2C.c
+++ b/ports/nrf/common-hal/busio/I2C.c
@@ -29,6 +29,7 @@
 #include "shared-bindings/busio/I2C.h"
 #include "py/mperrno.h"
 #include "py/runtime.h"
+#include "supervisor/shared/translate.h"
 
 #include "nrfx_twim.h"
 #include "nrf_gpio.h"
@@ -54,7 +55,7 @@ static uint8_t twi_error_to_mp(const nrfx_err_t err) {
 
 void common_hal_busio_i2c_construct(busio_i2c_obj_t *self, const mcu_pin_obj_t *scl, const mcu_pin_obj_t *sda, uint32_t frequency, uint32_t timeout) {
     if (scl->pin == sda->pin)
-        mp_raise_ValueError("Invalid pins");
+        mp_raise_ValueError(translate("Invalid pins"));
 
     const nrfx_twim_t instance = NRFX_TWIM_INSTANCE(INST_NO);
     self->twim = instance;

--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -32,6 +32,7 @@
 #include "py/mperrno.h"
 #include "py/runtime.h"
 #include "py/stream.h"
+#include "supervisor/shared/translate.h"
 
 #include "tick.h"
 
@@ -41,15 +42,15 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         const mcu_pin_obj_t * tx, const mcu_pin_obj_t * rx, uint32_t baudrate,
         uint8_t bits, uart_parity_t parity, uint8_t stop, uint32_t timeout,
         uint8_t receiver_buffer_size) {
-    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    mp_raise_NotImplementedError(translate("busio.UART not yet implemented"));
 }
 
 bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {
-    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    mp_raise_NotImplementedError(translate("busio.UART not yet implemented"));
 }
 
 void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
-    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    mp_raise_NotImplementedError(translate("busio.UART not yet implemented"));
     if (common_hal_busio_uart_deinited(self)) {
         return;
     }
@@ -58,32 +59,32 @@ void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
 
 // Read characters.
 size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t len, int *errcode) {
-    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    mp_raise_NotImplementedError(translate("busio.UART not yet implemented"));
     return 0;
 }
 
 // Write characters.
 size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, size_t len, int *errcode) {
-    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    mp_raise_NotImplementedError(translate("busio.UART not yet implemented"));
     return 0;
 }
 
 uint32_t common_hal_busio_uart_get_baudrate(busio_uart_obj_t *self) {
-    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    mp_raise_NotImplementedError(translate("busio.UART not yet implemented"));
     return self->baudrate;
 }
 
 void common_hal_busio_uart_set_baudrate(busio_uart_obj_t *self, uint32_t baudrate) {
-    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    mp_raise_NotImplementedError(translate("busio.UART not yet implemented"));
     self->baudrate = baudrate;
 }
 
 uint32_t common_hal_busio_uart_rx_characters_available(busio_uart_obj_t *self) {
-    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    mp_raise_NotImplementedError(translate("busio.UART not yet implemented"));
     return 0;
 }
 
 bool common_hal_busio_uart_ready_to_tx(busio_uart_obj_t *self) {
-    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    mp_raise_NotImplementedError(translate("busio.UART not yet implemented"));
     return false;
 }

--- a/ports/nrf/common-hal/digitalio/DigitalInOut.c
+++ b/ports/nrf/common-hal/digitalio/DigitalInOut.c
@@ -26,6 +26,7 @@
 
 #include "shared-bindings/digitalio/DigitalInOut.h"
 #include "py/runtime.h"
+#include "supervisor/shared/translate.h"
 
 #include "nrf_gpio.h"
 
@@ -154,7 +155,7 @@ digitalio_pull_t common_hal_digitalio_digitalinout_get_pull(
     NRF_GPIO_Type *reg = nrf_gpio_pin_port_decode(&pin);
 
     if (nrf_gpio_pin_dir_get(pin) == NRF_GPIO_PIN_DIR_OUTPUT) {
-        mp_raise_AttributeError("Cannot get pull while in output mode");
+        mp_raise_AttributeError(translate("Cannot get pull while in output mode"));
         return PULL_NONE;
     }
 

--- a/ports/nrf/common-hal/microcontroller/Processor.c
+++ b/ports/nrf/common-hal/microcontroller/Processor.c
@@ -26,6 +26,7 @@
 
 #include "common-hal/microcontroller/Processor.h"
 #include "py/runtime.h"
+#include "supervisor/shared/translate.h"
 
 #ifdef BLUETOOTH_SD
 #include "nrf_sdm.h"
@@ -45,7 +46,7 @@ float common_hal_mcu_processor_get_temperature(void) {
         uint32_t err_code = sd_temp_get(&temp);
         if (err_code != NRF_SUCCESS) {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                      "Can not get temperature. status: 0x" HEX2_FMT, (uint16_t)err_code));
+                      translate("Can not get temperature. status: 0x%02x"), (uint16_t)err_code));
 
             return 0;
         }

--- a/ports/nrf/common-hal/pulseio/PWMOut.c
+++ b/ports/nrf/common-hal/pulseio/PWMOut.c
@@ -32,6 +32,7 @@
 #include "common-hal/pulseio/PWMOut.h"
 #include "nrf_gpio.h"
 #include "shared-bindings/pulseio/PWMOut.h"
+#include "supervisor/shared/translate.h"
 
 #define PWM_MAX_MODULE    3
 #define PWM_MAX_CHANNEL   4
@@ -223,7 +224,7 @@ uint16_t common_hal_pulseio_pwmout_get_duty_cycle(pulseio_pwmout_obj_t* self) {
 
 void common_hal_pulseio_pwmout_set_frequency(pulseio_pwmout_obj_t* self, uint32_t frequency) {
   if (frequency == 0 || frequency > 16000000) {
-    mp_raise_ValueError("Invalid PWM frequency");
+    mp_raise_ValueError(translate("Invalid PWM frequency"));
   }
 
   self->freq = frequency;
@@ -238,4 +239,3 @@ uint32_t common_hal_pulseio_pwmout_get_frequency(pulseio_pwmout_obj_t* self) {
 bool common_hal_pulseio_pwmout_get_variable_frequency(pulseio_pwmout_obj_t* self) {
   return self->variable_freq;
 }
-

--- a/ports/nrf/common-hal/usb_hid/Device.c
+++ b/ports/nrf/common-hal/usb_hid/Device.c
@@ -29,6 +29,7 @@
 #include "common-hal/usb_hid/Device.h"
 #include "py/runtime.h"
 #include "shared-bindings/usb_hid/Device.h"
+#include "supervisor/shared/translate.h"
 #include "tusb.h"
 
 uint8_t common_hal_usb_hid_device_get_usage_page(usb_hid_device_obj_t *self) {
@@ -41,7 +42,7 @@ uint8_t common_hal_usb_hid_device_get_usage(usb_hid_device_obj_t *self) {
 
 void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t* report, uint8_t len) {
     if (len != self->report_length) {
-        mp_raise_ValueError_varg("Buffer incorrect size. Should be %d bytes.", self->report_length);
+        mp_raise_ValueError_varg(translate("Buffer incorrect size. Should be %d bytes."), self->report_length);
     }
 
     // Wait until interface is ready, timeout = 2 seconds
@@ -49,13 +50,13 @@ void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t* 
     while ( (ticks_ms < end_ticks) && !tud_hid_generic_ready() ) { }
 
     if ( !tud_hid_generic_ready() ) {
-        mp_raise_msg(&mp_type_OSError,  "USB Busy");
+        mp_raise_msg(&mp_type_OSError,  translate("USB Busy"));
     }
 
     memcpy(self->report_buffer, report, len);
 
     if ( !tud_hid_generic_report(self->report_id, self->report_buffer, len) ) {
-        mp_raise_msg(&mp_type_OSError, "USB Error");
+        mp_raise_msg(&mp_type_OSError, translate("USB Error"));
     }
 }
 
@@ -85,4 +86,3 @@ void tud_hid_generic_set_report_cb(uint8_t report_id, hid_report_type_t report_t
         }
     }
 }
-

--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -242,7 +242,7 @@ void ble_drv_address_get(ble_drv_addr_t * p_addr) {
 
     if (err_code != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not query for the device address."));
+                  translate("Can not query for the device address.")));
     }
 
     BLE_DRIVER_LOG("ble address, type: " HEX2_FMT ", " \

--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -35,6 +35,7 @@
 #endif
 
 #include "py/runtime.h"
+#include "supervisor/shared/translate.h"
 #include "ble_drv.h"
 #include "mpconfigport.h"
 #include "nrf_sdm.h"
@@ -195,7 +196,7 @@ uint32_t ble_drv_stack_enable(void) {
                                                (const uint8_t *)device_name,
                                                 strlen(device_name))) != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Cannot apply GAP parameters."));
+                  translate("Cannot apply GAP parameters.")));
     }
 
     // set connection parameters
@@ -209,7 +210,7 @@ uint32_t ble_drv_stack_enable(void) {
     if (sd_ble_gap_ppcp_set(&gap_conn_params) != 0) {
 
     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-              "Cannot set PPCP parameters."));
+              translate("Cannot set PPCP parameters.")));
     }
 
     return err_code;
@@ -260,7 +261,7 @@ bool ble_drv_uuid_add_vs(uint8_t * p_uuid, uint8_t * idx) {
 
     if (sd_ble_uuid_vs_add((ble_uuid128_t const *)p_uuid, idx) != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not add Vendor Specific 128-bit UUID."));
+                  translate("Can not add Vendor Specific 128-bit UUID.")));
     }
 
     return true;
@@ -280,7 +281,7 @@ bool ble_drv_service_add(ubluepy_service_obj_t * p_service_obj) {
                                      &uuid,
                                      &p_service_obj->handle) != 0) {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                      "Can not add Service."));
+                      translate("Can not add Service.")));
         }
     } else if (p_service_obj->p_uuid->type == BLE_UUID_TYPE_BLE) {
         BLE_DRIVER_LOG("adding service\n");
@@ -294,7 +295,7 @@ bool ble_drv_service_add(ubluepy_service_obj_t * p_service_obj) {
                                      &uuid,
                                      &p_service_obj->handle) != 0) {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                      "Can not add Service."));
+                      translate("Can not add Service.")));
         }
     }
     return true;
@@ -369,7 +370,7 @@ bool ble_drv_characteristic_add(ubluepy_characteristic_obj_t * p_char_obj) {
                                         &attr_char_value,
                                         &handles) != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not add Characteristic."));
+                  translate("Can not add Characteristic.")));
     }
 
     // apply handles to object instance
@@ -396,7 +397,7 @@ bool ble_drv_advertise_data(ubluepy_advertise_data_t * p_adv_params) {
                                        p_adv_params->p_device_name,
                                        p_adv_params->device_name_len) != 0) {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-	              "Can not apply device name in the stack."));
+	              translate("Can not apply device name in the stack.")));
         }
 
         BLE_DRIVER_LOG("Device name applied\n");
@@ -460,13 +461,13 @@ bool ble_drv_advertise_data(ubluepy_advertise_data_t * p_adv_params) {
                 // calculate total size of uuids
                 if (sd_ble_uuid_encode(&uuid, &encoded_size, NULL) != 0) {
                     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                              "Can not encode UUID, to check length."));
+                              translate("Can not encode UUID, to check length.")));
                 }
 
                 // do encoding into the adv buffer
                 if (sd_ble_uuid_encode(&uuid, &encoded_size, &adv_data[byte_pos]) != 0) {
                     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                              "Can encode UUID into the advertisment packet."));
+                              translate("Can encode UUID into the advertisment packet.")));
                 }
 
                 BLE_DRIVER_LOG("encoded uuid for service %u: ", 0);
@@ -510,13 +511,13 @@ bool ble_drv_advertise_data(ubluepy_advertise_data_t * p_adv_params) {
                 // calculate total size of uuids
                 if (sd_ble_uuid_encode(&uuid, &encoded_size, NULL) != 0) {
                     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                              "Can not encode UUID, to check length."));
+                              translate("Can not encode UUID, to check length.")));
                 }
 
                 // do encoding into the adv buffer
                 if (sd_ble_uuid_encode(&uuid, &encoded_size, &adv_data[byte_pos]) != 0) {
                     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                              "Can encode UUID into the advertisment packet."));
+                              translate("Can encode UUID into the advertisment packet.")));
                 }
 
                 BLE_DRIVER_LOG("encoded uuid for service %u: ", 0);
@@ -541,7 +542,7 @@ bool ble_drv_advertise_data(ubluepy_advertise_data_t * p_adv_params) {
     if ((p_adv_params->data_len > 0) && (p_adv_params->p_data != NULL)) {
         if (p_adv_params->data_len + byte_pos > BLE_GAP_ADV_MAX_SIZE) {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                      "Can not fit data into the advertisment packet."));
+                      translate("Can not fit data into the advertisment packet.")));
         }
 
         memcpy(adv_data, p_adv_params->p_data, p_adv_params->data_len);
@@ -554,7 +555,7 @@ bool ble_drv_advertise_data(ubluepy_advertise_data_t * p_adv_params) {
     if ((err_code = sd_ble_gap_adv_data_set(adv_data, byte_pos, NULL, 0)) != 0) {
 
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not apply advertisment data. status: 0x" HEX2_FMT, (uint16_t)err_code));
+                  translate("Can not apply advertisment data. status: 0x%02x"), (uint16_t)err_code));
     }
     BLE_DRIVER_LOG("Set Adv data size: " UINT_FMT "\n", byte_pos);
 #endif
@@ -600,7 +601,7 @@ bool ble_drv_advertise_data(ubluepy_advertise_data_t * p_adv_params) {
 
     if ((err_code = sd_ble_gap_adv_set_configure(&m_adv_handle, &ble_gap_adv_data, &m_adv_params)) != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not apply advertisment data. status: 0x" HEX2_FMT, (uint16_t)err_code));
+                  translate("Can not apply advertisment data. status: 0x%02x"), (uint16_t)err_code));
     }
     err_code = sd_ble_gap_adv_start(m_adv_handle, BLE_CONN_CFG_TAG_DEFAULT);
 #elif (BLUETOOTH_SD == 132 && BLE_API_VERSION == 4)
@@ -610,7 +611,7 @@ bool ble_drv_advertise_data(ubluepy_advertise_data_t * p_adv_params) {
 #endif
     if (err_code != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not start advertisment. status: 0x" HEX2_FMT, (uint16_t)err_code));
+                  translate("Can not start advertisment. status: 0x%02x"), (uint16_t)err_code));
     }
 
     m_adv_in_progress = true;
@@ -627,7 +628,7 @@ void ble_drv_advertise_stop(void) {
         if ((err_code = sd_ble_gap_adv_stop()) != 0) {
 #endif
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                      "Can not stop advertisment. status: 0x" HEX2_FMT, (uint16_t)err_code));
+                      translate("Can not stop advertisment. status: 0x%02x"), (uint16_t)err_code));
         }
     }
     m_adv_in_progress = false;
@@ -646,7 +647,7 @@ void ble_drv_attr_s_read(uint16_t conn_handle, uint16_t handle, uint16_t len, ui
                                                &gatts_value);
     if (err_code != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not read attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code));
+                  translate("Can not read attribute value. status: 0x%02x"), (uint16_t)err_code));
     }
 
 }
@@ -663,7 +664,7 @@ void ble_drv_attr_s_write(uint16_t conn_handle, uint16_t handle, uint16_t len, u
 
     if (err_code != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not write attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code));
+                  translate("Can not write attribute value. status: 0x%02x"), (uint16_t)err_code));
     }
 }
 
@@ -687,7 +688,7 @@ void ble_drv_attr_s_notify(uint16_t conn_handle, uint16_t handle, uint16_t len, 
     uint32_t err_code;
     if ((err_code = sd_ble_gatts_hvx(conn_handle, &hvx_params)) != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not notify attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code));
+                  translate("Can not notify attribute value. status: 0x%02x"), (uint16_t)err_code));
     }
 }
 
@@ -722,7 +723,7 @@ void ble_drv_attr_c_read(uint16_t conn_handle, uint16_t handle, mp_obj_t obj, bl
                                           0);
     if (err_code != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not read attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code));
+                  translate("Can not read attribute value. status: 0x%02x"), (uint16_t)err_code));
     }
 
     while (gattc_char_data_handle != NULL) {
@@ -752,7 +753,7 @@ void ble_drv_attr_c_write(uint16_t conn_handle, uint16_t handle, uint16_t len, u
 
     if (err_code != 0) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-            "Can not write attribute value. status: 0x" HEX2_FMT, (uint16_t)err_code));
+            translate("Can not write attribute value. status: 0x%02x"), (uint16_t)err_code));
     }
 
     while (m_write_done != true) {
@@ -780,7 +781,7 @@ void ble_drv_scan_start(void) {
     if ((err_code = sd_ble_gap_scan_start(&scan_params)) != 0) {
 #endif
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not start scanning. status: 0x" HEX2_FMT, (uint16_t)err_code));
+                  translate("Can not start scanning. status: 0x%02x"), (uint16_t)err_code));
     }
 }
 
@@ -825,7 +826,7 @@ void ble_drv_connect(uint8_t * p_addr, uint8_t addr_type) {
     if ((err_code = sd_ble_gap_connect(&addr, &scan_params, &conn_params, BLE_CONN_CFG_TAG_DEFAULT)) != 0) {
 #endif
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError,
-                  "Can not connect. status: 0x" HEX2_FMT, (uint16_t)err_code));
+                  translate("Can not connect. status: 0x%02x"), (uint16_t)err_code));
     }
 }
 

--- a/ports/nrf/modules/ubluepy/ubluepy_characteristic.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_characteristic.c
@@ -26,6 +26,7 @@
 
 #include "py/obj.h"
 #include "py/runtime.h"
+#include "supervisor/shared/translate.h"
 
 #if MICROPY_PY_UBLUEPY_PERIPHERAL || MICROPY_PY_UBLUEPY_CENTRAL
 
@@ -64,7 +65,7 @@ STATIC mp_obj_t ubluepy_characteristic_make_new(const mp_obj_type_t *type, size_
         // (void)sd_characterstic_add(s);
     } else {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                  "Invalid UUID parameter"));
+                  translate("Invalid UUID parameter")));
     }
 
     if (args[1].u_int > 0) {

--- a/ports/nrf/modules/ubluepy/ubluepy_service.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_service.c
@@ -27,6 +27,7 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "py/objlist.h"
+#include "supervisor/shared/translate.h"
 
 #if MICROPY_PY_UBLUEPY_PERIPHERAL || MICROPY_PY_UBLUEPY_CENTRAL
 
@@ -69,14 +70,14 @@ STATIC mp_obj_t ubluepy_service_make_new(const mp_obj_type_t *type, size_t n_arg
             s->type = type;
         } else {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                      "Invalid Service type"));
+                      translate("Invalid Service type")));
         }
 
         (void)ble_drv_service_add(s);
 
     } else {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                  "Invalid UUID parameter"));
+                  translate("Invalid UUID parameter")));
     }
 
     // clear reference to peripheral
@@ -128,7 +129,7 @@ STATIC mp_obj_t service_get_characteristic(mp_obj_t self_in, mp_obj_t uuid) {
     // validate that there is an UUID object passed in as parameter
     if (!(MP_OBJ_IS_TYPE(uuid, &ubluepy_uuid_type))) {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                  "Invalid UUID parameter"));
+                  translate("Invalid UUID parameter")));
     }
 
     mp_obj_t * chars     = NULL;

--- a/ports/nrf/modules/ubluepy/ubluepy_uuid.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_uuid.c
@@ -28,6 +28,7 @@
 #include "py/runtime.h"
 #include "py/objstr.h"
 #include "py/misc.h"
+#include "supervisor/shared/translate.h"
 
 #if MICROPY_PY_UBLUEPY
 
@@ -123,7 +124,7 @@ STATIC mp_obj_t ubluepy_uuid_make_new(const mp_obj_type_t *type, size_t n_args, 
             ble_drv_uuid_add_vs(buffer, &s->uuid_vs_idx);
         } else {
             nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                      "Invalid UUID string length"));
+                      translate("Invalid UUID string length")));
         }
     } else if (MP_OBJ_IS_TYPE(uuid_obj, &ubluepy_uuid_type)) {
         // deep copy instance
@@ -133,7 +134,7 @@ STATIC mp_obj_t ubluepy_uuid_make_new(const mp_obj_type_t *type, size_t n_args, 
         s->value[1] = p_old->value[1];
     } else {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-                  "Invalid UUID parameter"));
+                  translate("Invalid UUID parameter")));
     }
 
     return MP_OBJ_FROM_PTR(s);

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -242,7 +242,7 @@ freedos:
 
 # build an interpreter for coverage testing and do the testing
 coverage:
-	$(MAKE) V=2 \
+	$(MAKE) \
 	    COPT="-O0" CFLAGS_EXTRA='$(CFLAGS_EXTRA) -DMP_CONFIGFILE="<mpconfigport_coverage.h>" \
 	    -fprofile-arcs -ftest-coverage \
 	    -Wdouble-promotion -Wformat -Wmissing-declarations -Wmissing-prototypes -Wsign-compare \

--- a/ports/unix/file.c
+++ b/ports/unix/file.c
@@ -35,6 +35,7 @@
 #include "py/stream.h"
 #include "py/builtin.h"
 #include "py/mphal.h"
+#include "supervisor/shared/translate.h"
 #include "fdfile.h"
 
 #if MICROPY_PY_IO && !MICROPY_VFS
@@ -46,7 +47,7 @@
 #ifdef MICROPY_CPYTHON_COMPAT
 STATIC void check_fd_is_open(const mp_obj_fdfile_t *o) {
     if (o->fd < 0) {
-        mp_raise_ValueError("I/O operation on closed file");
+        mp_raise_ValueError(translate("I/O operation on closed file"));
     }
 }
 #else

--- a/ports/unix/modffi.c
+++ b/ports/unix/modffi.c
@@ -36,6 +36,8 @@
 #include "py/binary.h"
 #include "py/mperrno.h"
 
+#include "supervisor/shared/translate.h"
+
 /*
  * modffi uses character codes to encode a value type, based on "struct"
  * module type codes, with some extensions and overridings.
@@ -133,7 +135,7 @@ STATIC ffi_type *get_ffi_type(mp_obj_t o_in)
     }
     // TODO: Support actual libffi type objects
 
-    mp_raise_TypeError("Unknown type");
+    mp_raise_TypeError(translate("Unknown type"));
 }
 
 STATIC mp_obj_t return_ffi_value(ffi_arg val, char type)
@@ -202,7 +204,7 @@ STATIC mp_obj_t make_func(mp_obj_t rettype_in, void *func, mp_obj_t argtypes_in)
 
     int res = ffi_prep_cif(&o->cif, FFI_DEFAULT_ABI, nparams, char2ffi_type(*rettype), o->params);
     if (res != FFI_OK) {
-        mp_raise_ValueError("Error in ffi_prep_cif");
+        mp_raise_ValueError(translate("Error in ffi_prep_cif"));
     }
 
     return MP_OBJ_FROM_PTR(o);
@@ -260,12 +262,12 @@ STATIC mp_obj_t mod_ffi_callback(mp_obj_t rettype_in, mp_obj_t func_in, mp_obj_t
 
     int res = ffi_prep_cif(&o->cif, FFI_DEFAULT_ABI, nparams, char2ffi_type(*rettype), o->params);
     if (res != FFI_OK) {
-        mp_raise_ValueError("Error in ffi_prep_cif");
+        mp_raise_ValueError(translate("Error in ffi_prep_cif"));
     }
 
     res = ffi_prep_closure_loc(o->clo, &o->cif, call_py_func, MP_OBJ_TO_PTR(func_in), o->func);
     if (res != FFI_OK) {
-        mp_raise_ValueError("ffi_prep_closure_loc");
+        mp_raise_ValueError(translate("ffi_prep_closure_loc"));
     }
 
     return MP_OBJ_FROM_PTR(o);
@@ -408,7 +410,7 @@ STATIC mp_obj_t ffifunc_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const
     }
 
 error:
-    mp_raise_TypeError("Don't know how to pass object to native function");
+    mp_raise_TypeError(translate("Don't know how to pass object to native function"));
 }
 
 STATIC const mp_obj_type_t ffifunc_type = {

--- a/ports/unix/modmachine.c
+++ b/ports/unix/modmachine.c
@@ -35,6 +35,8 @@
 #include "extmod/machine_signal.h"
 #include "extmod/machine_pulse.h"
 
+#include "supervisor/shared/translate.h"
+
 #if MICROPY_PLAT_DEV_MEM
 #include <errno.h>
 #include <fcntl.h>
@@ -48,7 +50,7 @@
 uintptr_t mod_machine_mem_get_addr(mp_obj_t addr_o, uint align) {
     uintptr_t addr = mp_obj_int_get_truncated(addr_o);
     if ((addr & (align - 1)) != 0) {
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "address %08x is not aligned to %d bytes", addr, align));
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, translate("address %08x is not aligned to %d bytes"), addr, align));
     }
     #if MICROPY_PLAT_DEV_MEM
     {

--- a/ports/unix/modusocket.c
+++ b/ports/unix/modusocket.c
@@ -45,6 +45,8 @@
 #include "py/builtin.h"
 #include "py/mphal.h"
 
+#include "supervisor/shared/translate.h"
+
 /*
   The idea of this module is to implement reasonable minimum of
   socket-related functions to write typical clients and servers.
@@ -469,7 +471,7 @@ STATIC mp_obj_t mod_socket_getaddrinfo(size_t n_args, const mp_obj_t *args) {
 
     if (res != 0) {
         // CPython: socket.gaierror
-        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, "[addrinfo error %d]", res));
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_OSError, translate("[addrinfo error %d]"), res));
     }
     assert(addr_list);
 

--- a/py/compile.c
+++ b/py/compile.c
@@ -156,7 +156,7 @@ STATIC void compile_error_set_line(compiler_t *comp, mp_parse_node_t pn) {
     }
 }
 
-STATIC void compile_syntax_error(compiler_t *comp, mp_parse_node_t pn, const char *msg) {
+STATIC void compile_syntax_error(compiler_t *comp, mp_parse_node_t pn, const compressed_string_t *msg) {
     // only register the error if there has been no other error
     if (comp->compile_error == MP_OBJ_NULL) {
         comp->compile_error = mp_obj_new_exception_msg(&mp_type_SyntaxError, msg);
@@ -949,7 +949,7 @@ STATIC void compile_del_stmt(compiler_t *comp, mp_parse_node_struct_t *pns) {
 
 STATIC void compile_break_cont_stmt(compiler_t *comp, mp_parse_node_struct_t *pns) {
     uint16_t label;
-    const char *error_msg;
+    const compressed_string_t *error_msg;
     if (MP_PARSE_NODE_STRUCT_KIND(pns) == PN_break_stmt) {
         label = comp->break_label;
         error_msg = translate("'break' outside loop");

--- a/py/emitinlinextensa.c
+++ b/py/emitinlinextensa.c
@@ -43,7 +43,7 @@ struct _emit_inline_asm_t {
     qstr *label_lookup;
 };
 
-STATIC void emit_inline_xtensa_error_msg(emit_inline_asm_t *emit, const char *msg) {
+STATIC void emit_inline_xtensa_error_msg(emit_inline_asm_t *emit, const compressed_string_t *msg) {
     *emit->error_slot = mp_obj_new_exception_msg(&mp_type_SyntaxError, msg);
 }
 
@@ -83,17 +83,17 @@ STATIC void emit_inline_xtensa_end_pass(emit_inline_asm_t *emit, mp_uint_t type_
 
 STATIC mp_uint_t emit_inline_xtensa_count_params(emit_inline_asm_t *emit, mp_uint_t n_params, mp_parse_node_t *pn_params) {
     if (n_params > 4) {
-        emit_inline_xtensa_error_msg(emit, "can only have up to 4 parameters to Xtensa assembly");
+        emit_inline_xtensa_error_msg(emit, translate("can only have up to 4 parameters to Xtensa assembly"));
         return 0;
     }
     for (mp_uint_t i = 0; i < n_params; i++) {
         if (!MP_PARSE_NODE_IS_ID(pn_params[i])) {
-            emit_inline_xtensa_error_msg(emit, "parameters must be registers in sequence a2 to a5");
+            emit_inline_xtensa_error_msg(emit, translate("parameters must be registers in sequence a2 to a5"));
             return 0;
         }
         const char *p = qstr_str(MP_PARSE_NODE_LEAF_ARG(pn_params[i]));
         if (!(strlen(p) == 2 && p[0] == 'a' && p[1] == '2' + i)) {
-            emit_inline_xtensa_error_msg(emit, "parameters must be registers in sequence a2 to a5");
+            emit_inline_xtensa_error_msg(emit, translate("parameters must be registers in sequence a2 to a5"));
             return 0;
         }
     }
@@ -159,19 +159,19 @@ STATIC mp_uint_t get_arg_reg(emit_inline_asm_t *emit, const char *op, mp_parse_n
     }
     emit_inline_xtensa_error_exc(emit,
         mp_obj_new_exception_msg_varg(&mp_type_SyntaxError,
-            "'%s' expects a register", op));
+            translate("'%s' expects a register"), op));
     return 0;
 }
 
 STATIC uint32_t get_arg_i(emit_inline_asm_t *emit, const char *op, mp_parse_node_t pn, int min, int max) {
     mp_obj_t o;
     if (!mp_parse_node_get_int_maybe(pn, &o)) {
-        emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "'%s' expects an integer", op));
+        emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, translate("'%s' expects an integer"), op));
         return 0;
     }
     uint32_t i = mp_obj_get_int_truncated(o);
     if (min != max && ((int)i < min || (int)i > max)) {
-        emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "'%s' integer %d is not within range %d..%d", op, i, min, max));
+        emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, translate("'%s' integer %d is not within range %d..%d"), op, i, min, max));
         return 0;
     }
     return i;
@@ -179,7 +179,7 @@ STATIC uint32_t get_arg_i(emit_inline_asm_t *emit, const char *op, mp_parse_node
 
 STATIC int get_arg_label(emit_inline_asm_t *emit, const char *op, mp_parse_node_t pn) {
     if (!MP_PARSE_NODE_IS_ID(pn)) {
-        emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "'%s' expects a label", op));
+        emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, translate("'%s' expects a label"), op));
         return 0;
     }
     qstr label_qstr = MP_PARSE_NODE_LEAF_ARG(pn);
@@ -190,7 +190,7 @@ STATIC int get_arg_label(emit_inline_asm_t *emit, const char *op, mp_parse_node_
     }
     // only need to have the labels on the last pass
     if (emit->pass == MP_PASS_EMIT) {
-        emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "label '%q' not defined", label_qstr));
+        emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, translate("label '%q' not defined"), label_qstr));
     }
     return 0;
 }
@@ -324,12 +324,12 @@ STATIC void emit_inline_xtensa_op(emit_inline_asm_t *emit, qstr op, mp_uint_t n_
     return;
 
 unknown_op:
-    emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, "unsupported Xtensa instruction '%s' with %d arguments", op_str, n_args));
+    emit_inline_xtensa_error_exc(emit, mp_obj_new_exception_msg_varg(&mp_type_SyntaxError, translate("unsupported Xtensa instruction '%s' with %d arguments"), op_str, n_args));
     return;
 
     /*
 branch_not_in_range:
-    emit_inline_xtensa_error_msg(emit, "branch not in range");
+    emit_inline_xtensa_error_msg(emit, translate("branch not in range"));
     return;
     */
 }

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -180,7 +180,7 @@ STATIC void emit_native_set_native_type(emit_t *emit, mp_uint_t op, mp_uint_t ar
                 case MP_QSTR_ptr8: type = VTYPE_PTR8; break;
                 case MP_QSTR_ptr16: type = VTYPE_PTR16; break;
                 case MP_QSTR_ptr32: type = VTYPE_PTR32; break;
-                default: EMIT_NATIVE_VIPER_TYPE_ERROR(emit, "unknown type '%q'", arg2); return;
+                default: EMIT_NATIVE_VIPER_TYPE_ERROR(emit, translate("unknown type '%q'"), arg2); return;
             }
             if (op == MP_EMIT_NATIVE_TYPE_RETURN) {
                 emit->return_vtype = type;
@@ -257,7 +257,7 @@ STATIC void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scop
 
         // right now we have a restriction of maximum of 4 arguments
         if (scope->num_pos_args >= 5) {
-            EMIT_NATIVE_VIPER_TYPE_ERROR(emit, "Viper functions don't currently support more than 4 arguments");
+            EMIT_NATIVE_VIPER_TYPE_ERROR(emit, translate("Viper functions don't currently support more than 4 arguments"));
             return;
         }
 
@@ -918,7 +918,7 @@ STATIC void emit_native_load_fast(emit_t *emit, qstr qst, mp_uint_t local_num) {
     DEBUG_printf("load_fast(%s, " UINT_FMT ")\n", qstr_str(qst), local_num);
     vtype_kind_t vtype = emit->local_vtype[local_num];
     if (vtype == VTYPE_UNBOUND) {
-        EMIT_NATIVE_VIPER_TYPE_ERROR(emit, "local '%q' used before type known", qst);
+        EMIT_NATIVE_VIPER_TYPE_ERROR(emit, translate("local '%q' used before type known"), qst);
     }
     emit_native_pre(emit);
     if (local_num == 0) {
@@ -1115,7 +1115,7 @@ STATIC void emit_native_load_subscr(emit_t *emit) {
                 }
                 default:
                     EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-                        "can't load from '%q'", vtype_to_qstr(vtype_base));
+                        translate("can't load from '%q'"), vtype_to_qstr(vtype_base));
             }
         } else {
             // index is not an immediate
@@ -1125,7 +1125,7 @@ STATIC void emit_native_load_subscr(emit_t *emit) {
             emit_pre_pop_reg(emit, &vtype_base, REG_ARG_1);
             if (vtype_index != VTYPE_INT && vtype_index != VTYPE_UINT) {
                 EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-                    "can't load with '%q' index", vtype_to_qstr(vtype_index));
+                    translate("can't load with '%q' index"), vtype_to_qstr(vtype_index));
             }
             switch (vtype_base) {
                 case VTYPE_PTR8: {
@@ -1153,7 +1153,7 @@ STATIC void emit_native_load_subscr(emit_t *emit) {
                 }
                 default:
                     EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-                        "can't load from '%q'", vtype_to_qstr(vtype_base));
+                        translate("can't load from '%q'"), vtype_to_qstr(vtype_base));
             }
         }
         emit_post_push_reg(emit, VTYPE_INT, REG_RET);
@@ -1185,7 +1185,7 @@ STATIC void emit_native_store_fast(emit_t *emit, qstr qst, mp_uint_t local_num) 
     } else if (emit->local_vtype[local_num] != vtype) {
         // type of local is not the same as object stored in it
         EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-            "local '%q' has type '%q' but source is '%q'",
+            translate("local '%q' has type '%q' but source is '%q'"),
             qst, vtype_to_qstr(emit->local_vtype[local_num]), vtype_to_qstr(vtype));
     }
 }
@@ -1286,7 +1286,7 @@ STATIC void emit_native_store_subscr(emit_t *emit) {
             #endif
             if (vtype_value != VTYPE_BOOL && vtype_value != VTYPE_INT && vtype_value != VTYPE_UINT) {
                 EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-                    "can't store '%q'", vtype_to_qstr(vtype_value));
+                    translate("can't store '%q'"), vtype_to_qstr(vtype_value));
             }
             switch (vtype_base) {
                 case VTYPE_PTR8: {
@@ -1355,7 +1355,7 @@ STATIC void emit_native_store_subscr(emit_t *emit) {
                 }
                 default:
                     EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-                        "can't store to '%q'", vtype_to_qstr(vtype_base));
+                        translate("can't store to '%q'"), vtype_to_qstr(vtype_base));
             }
         } else {
             // index is not an immediate
@@ -1366,7 +1366,7 @@ STATIC void emit_native_store_subscr(emit_t *emit) {
             emit_pre_pop_reg(emit, &vtype_base, REG_ARG_1);
             if (vtype_index != VTYPE_INT && vtype_index != VTYPE_UINT) {
                 EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-                    "can't store with '%q' index", vtype_to_qstr(vtype_index));
+                    translate("can't store with '%q' index"), vtype_to_qstr(vtype_index));
             }
             #if N_X86
             // special case: x86 needs byte stores to be from lower 4 regs (REG_ARG_3 is EDX)
@@ -1376,7 +1376,7 @@ STATIC void emit_native_store_subscr(emit_t *emit) {
             #endif
             if (vtype_value != VTYPE_BOOL && vtype_value != VTYPE_INT && vtype_value != VTYPE_UINT) {
                 EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-                    "can't store '%q'", vtype_to_qstr(vtype_value));
+                    translate("can't store '%q'"), vtype_to_qstr(vtype_value));
             }
             switch (vtype_base) {
                 case VTYPE_PTR8: {
@@ -1416,7 +1416,7 @@ STATIC void emit_native_store_subscr(emit_t *emit) {
                 }
                 default:
                     EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-                        "can't store to '%q'", vtype_to_qstr(vtype_base));
+                        translate("can't store to '%q'"), vtype_to_qstr(vtype_base));
             }
         }
 
@@ -1537,7 +1537,7 @@ STATIC void emit_native_jump_helper(emit_t *emit, bool pop) {
         }
         if (!(vtype == VTYPE_BOOL || vtype == VTYPE_INT || vtype == VTYPE_UINT)) {
             EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-                "can't implicitly convert '%q' to 'bool'", vtype_to_qstr(vtype));
+                translate("can't implicitly convert '%q' to 'bool'"), vtype_to_qstr(vtype));
         }
     }
     // For non-pop need to save the vtype so that emit_native_adjust_stack_size
@@ -1771,7 +1771,7 @@ STATIC void emit_native_unary_op(emit_t *emit, mp_unary_op_t op) {
     } else {
         adjust_stack(emit, 1);
         EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-            "unary op %q not implemented", mp_unary_op_method_name[op]);
+            translate("unary op %q not implemented"), mp_unary_op_method_name[op]);
     }
 }
 
@@ -1927,7 +1927,7 @@ STATIC void emit_native_binary_op(emit_t *emit, mp_binary_op_t op) {
             // TODO other ops not yet implemented
             adjust_stack(emit, 1);
             EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-                "binary op %q not implemented", mp_binary_op_method_name[op]);
+                translate("binary op %q not implemented"), mp_binary_op_method_name[op]);
         }
     } else if (vtype_lhs == VTYPE_PYOBJ && vtype_rhs == VTYPE_PYOBJ) {
         emit_pre_pop_reg_reg(emit, &vtype_rhs, REG_ARG_3, &vtype_lhs, REG_ARG_2);
@@ -1948,7 +1948,7 @@ STATIC void emit_native_binary_op(emit_t *emit, mp_binary_op_t op) {
     } else {
         adjust_stack(emit, -1);
         EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-            "can't do binary op between '%q' and '%q'",
+            translate("can't do binary op between '%q' and '%q'"),
             vtype_to_qstr(vtype_lhs), vtype_to_qstr(vtype_rhs));
     }
 }
@@ -2170,7 +2170,7 @@ STATIC void emit_native_return_value(emit_t *emit) {
             emit_pre_pop_reg(emit, &vtype, REG_RET);
             if (vtype != emit->return_vtype) {
                 EMIT_NATIVE_VIPER_TYPE_ERROR(emit,
-                    "return expected '%q' but got '%q'",
+                    translate("return expected '%q' but got '%q'"),
                     vtype_to_qstr(emit->return_vtype), vtype_to_qstr(vtype));
             }
         }
@@ -2188,7 +2188,7 @@ STATIC void emit_native_raise_varargs(emit_t *emit, mp_uint_t n_args) {
     vtype_kind_t vtype_exc;
     emit_pre_pop_reg(emit, &vtype_exc, REG_ARG_1); // arg1 = object to raise
     if (vtype_exc != VTYPE_PYOBJ) {
-        EMIT_NATIVE_VIPER_TYPE_ERROR(emit, "must raise an object");
+        EMIT_NATIVE_VIPER_TYPE_ERROR(emit, translate("must raise an object"));
     }
     // TODO probably make this 1 call to the runtime (which could even call convert, native_raise(obj, type))
     emit_call(emit, MP_F_NATIVE_RAISE);

--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -12,6 +12,10 @@ import sys
 import collections
 import gettext
 
+sys.path.append("../../tools/huffman")
+
+import huffman
+
 # Python 2/3 compatibility:
 #   - iterating through bytes is different
 #   - codepoint2name lives in a different module
@@ -83,8 +87,143 @@ def translate(translation_file, i18ns):
             unescaped = original
             for s in C_ESCAPES:
                 unescaped = unescaped.replace(C_ESCAPES[s], s)
-            translations.append((original, table.gettext(unescaped)))
+            translation = table.gettext(unescaped)
+            # Add in carriage returns to work in terminals
+            translation = translation.replace("\n", "\r\n")
+            translations.append((original, translation))
         return translations
+
+def compute_huffman_coding(translations, qstrs, compression_filename):
+    all_strings = [x[1] for x in translations]
+
+    # go through each qstr and print it out
+    for _, _, qstr in qstrs.values():
+        all_strings.append(qstr)
+    all_strings_concat = "".join(all_strings).encode("utf-8")
+    counts = collections.Counter(all_strings_concat)
+    # add other values
+    for i in range(256):
+        if i not in counts:
+            counts[i] = 0
+    cb = huffman.codebook(counts.items())
+    values = bytearray()
+    length_count = {}
+    renumbered = 0
+    last_l = None
+    canonical = {}
+    for ch, code in sorted(cb.items(), key=lambda x: (len(x[1]), x[0])):
+        values.append(ch)
+        l = len(code)
+        if l not in length_count:
+            length_count[l] = 0
+        length_count[l] += 1
+        if last_l:
+            renumbered <<= (l - last_l)
+        canonical[ch] = '{0:0{width}b}'.format(renumbered, width=l)
+        if chr(ch) in C_ESCAPES:
+            s = C_ESCAPES[chr(ch)]
+        else:
+            s = chr(ch)
+        print("//", ch, s, counts[ch], canonical[ch], renumbered)
+        renumbered += 1
+        last_l = l
+    lengths = bytearray()
+    for i in range(1, max(length_count) + 1):
+        lengths.append(length_count.get(i, 0))
+    print("//", values, lengths)
+    with open(compression_filename, "w") as f:
+        f.write("const uint8_t lengths[] = {{ {} }};\n".format(", ".join(map(str, lengths))))
+        f.write("const uint8_t values[256] = {{ {} }};\n".format(", ".join(map(str, values))))
+    return values, lengths
+
+def decompress(encoding_table, length, encoded):
+    values, lengths = encoding_table
+    #print(l, encoded)
+    dec = bytearray(length)
+    this_byte = 0
+    this_bit = 7
+    b = encoded[this_byte]
+    for i in range(length):
+        bits = 0
+        bit_length = 0
+        max_code = lengths[0]
+        searched_length = lengths[0]
+        while True:
+            bits <<= 1
+            if 0x80 & b:
+                bits |= 1
+
+            b <<= 1
+            bit_length += 1
+            if this_bit == 0:
+                this_bit = 7
+                this_byte += 1
+                if this_byte < len(encoded):
+                    b = encoded[this_byte]
+            else:
+                this_bit -= 1
+            if max_code > 0 and bits < max_code:
+                #print('{0:0{width}b}'.format(bits, width=bit_length))
+                break
+            max_code = (max_code << 1) + lengths[bit_length]
+            searched_length += lengths[bit_length]
+
+        v = values[searched_length + bits - max_code]
+        dec[i] = v
+    return dec
+
+def compress(encoding_table, decompressed):
+    if not isinstance(decompressed, bytes):
+        raise TypeError()
+    values, lengths = encoding_table
+    enc = bytearray(len(decompressed))
+    #print(decompressed)
+    #print(lengths)
+    current_bit = 7
+    current_byte = 0
+    for c in decompressed:
+        #print()
+        #print("char", c, values.index(c))
+        start = 0
+        end = lengths[0]
+        bits = 1
+        compressed = None
+        code = 0
+        while compressed is None:
+            s = start
+            e = end
+            #print("{0:0{width}b}".format(code, width=bits))
+            # Binary search!
+            while e > s:
+                midpoint = (s + e) // 2
+                #print(s, e, midpoint)
+                if values[midpoint] == c:
+                    compressed = code + (midpoint - start)
+                    #print("found {0:0{width}b}".format(compressed, width=bits))
+                    break
+                elif c < values[midpoint]:
+                    e = midpoint
+                else:
+                    s = midpoint + 1
+            code += end - start
+            code <<= 1
+            start = end
+            end += lengths[bits]
+            bits += 1
+            #print("next bit", bits)
+
+        for i in range(bits - 1, 0, -1):
+            if compressed & (1 << (i - 1)):
+                enc[current_byte] |= 1 << current_bit
+            if current_bit == 0:
+                current_bit = 7
+                #print("packed {0:0{width}b}".format(enc[current_byte], width=8))
+                current_byte += 1
+            else:
+                current_bit -= 1
+    if current_bit != 7:
+        current_byte += 1
+    return enc[:current_byte]
 
 def qstr_escape(qst):
     def esc_char(m):
@@ -178,7 +317,7 @@ def make_bytes(cfg_bytes_len, cfg_bytes_hash, qstr):
     qhash_str = ('\\x%02x' * cfg_bytes_hash) % tuple(((qhash >> (8 * i)) & 0xff) for i in range(cfg_bytes_hash))
     return '(const byte*)"%s%s" "%s"' % (qhash_str, qlen_str, qdata)
 
-def print_qstr_data(qcfgs, qstrs, i18ns):
+def print_qstr_data(encoding_table, qcfgs, qstrs, i18ns):
     # get config variables
     cfg_bytes_len = int(qcfgs['BYTES_IN_LEN'])
     cfg_bytes_hash = int(qcfgs['BYTES_IN_HASH'])
@@ -191,6 +330,7 @@ def print_qstr_data(qcfgs, qstrs, i18ns):
     print('QDEF(MP_QSTR_NULL, (const byte*)"%s%s" "")' % ('\\x00' * cfg_bytes_hash, '\\x00' * cfg_bytes_len))
 
     total_qstr_size = 0
+    total_qstr_compressed_size = 0
     # go through each qstr and print it out
     for order, ident, qstr in sorted(qstrs.values(), key=lambda x: x[0]):
         qbytes = make_bytes(cfg_bytes_len, cfg_bytes_hash, qstr)
@@ -198,17 +338,23 @@ def print_qstr_data(qcfgs, qstrs, i18ns):
         total_qstr_size += len(qstr)
 
     total_text_size = 0
+    total_text_compressed_size = 0
     for original, translation in i18ns:
-        # Add in carriage returns to work in terminals
-        translation = translation.replace("\n", "\r\n")
-        for s in C_ESCAPES:
-            translation = translation.replace(s, C_ESCAPES[s])
-        print("TRANSLATION(\"{}\", \"{}\")".format(original, translation))
-        total_text_size += len(translation)
+        translation_encoded = translation.encode("utf-8")
+        compressed = compress(encoding_table, translation_encoded)
+        total_text_compressed_size += len(compressed)
+        decompressed = decompress(encoding_table, len(translation_encoded), compressed).decode("utf-8")
+        for c in C_ESCAPES:
+            decompressed.replace(c, C_ESCAPES[c])
+        #print("// \"{}\"".format(translation))
+        print("TRANSLATION(\"{}\", {}, {{ {} }}) // {}".format(original, len(translation_encoded)+1, ", ".join(["0x{:02x}".format(x) for x in compressed]), decompressed))
+        total_text_size += len(translation.encode("utf-8"))
 
     print()
     print("// {} bytes worth of qstr".format(total_qstr_size))
     print("// {} bytes worth of translations".format(total_text_size))
+    print("// {} bytes worth of translations compressed".format(total_text_compressed_size))
+    print("// {} bytes saved".format(total_text_size - total_text_compressed_size))
 
 def print_qstr_enums(qstrs):
     # print out the starter of the generated C header file
@@ -230,12 +376,15 @@ if __name__ == "__main__":
                         help='an integer for the accumulator')
     parser.add_argument('--translation', default=None, type=str,
                         help='translations for i18n() items')
+    parser.add_argument('--compression_filename', default=None, type=str,
+                        help='header for compression info')
 
     args = parser.parse_args()
 
     qcfgs, qstrs, i18ns = parse_input_headers(args.infiles)
     if args.translation:
         translations = translate(args.translation, i18ns)
-        print_qstr_data(qcfgs, qstrs, translations)
+        encoding_table = compute_huffman_coding(translations, qstrs, args.compression_filename)
+        print_qstr_data(encoding_table, qcfgs, qstrs, translations)
     else:
         print_qstr_enums(qstrs)

--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -11,8 +11,12 @@ import sys
 
 import collections
 import gettext
+import os.path
 
-sys.path.append("../../tools/huffman")
+py = os.path.dirname(sys.argv[0])
+top = os.path.dirname(py)
+
+sys.path.append(os.path.join(top, "tools/huffman"))
 
 import huffman
 

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -316,7 +316,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_min_obj, 1, mp_builtin_min);
 STATIC mp_obj_t mp_builtin_next(mp_obj_t o) {
     mp_obj_t ret = mp_iternext_allow_raise(o);
     if (ret == MP_OBJ_STOP_ITERATION) {
-        mp_raise_msg(&mp_type_StopIteration, "");
+        mp_raise_msg(&mp_type_StopIteration, NULL);
     } else {
         return ret;
     }

--- a/py/moduerrno.c
+++ b/py/moduerrno.c
@@ -102,20 +102,6 @@ const mp_obj_module_t mp_module_uerrno = {
 };
 
 const char* mp_errno_to_str(mp_obj_t errno_val) {
-    // For commonly encountered errors, return human readable strings
-    if (MP_OBJ_IS_SMALL_INT(errno_val)) {
-        switch (MP_OBJ_SMALL_INT_VALUE(errno_val)) {
-            case EPERM:  return translate("Permission denied");
-            case ENOENT: return translate("No such file/directory");
-            case EIO:    return translate("Input/output error");
-            case EACCES: return translate("Permission denied");
-            case EEXIST: return translate("File exists");
-            case ENODEV: return translate("Unsupported operation");
-            case EINVAL: return translate("Invalid argument");
-            case EROFS:  return translate("Read-only filesystem");
-        }
-    }
-
     // Otherwise, return the Exxxx string for that error code
     #if MICROPY_PY_UERRNO_ERRORCODE
     // We have the errorcode dict so can do a lookup using the hash map
@@ -148,3 +134,21 @@ const char* mp_errno_to_str(mp_obj_t errno_val) {
 }
 
 #endif //MICROPY_PY_UERRNO
+
+
+// For commonly encountered errors, return human readable strings
+const compressed_string_t* mp_common_errno_to_str(mp_obj_t errno_val) {
+    if (MP_OBJ_IS_SMALL_INT(errno_val)) {
+        switch (MP_OBJ_SMALL_INT_VALUE(errno_val)) {
+            case EPERM:  return translate("Permission denied");
+            case ENOENT: return translate("No such file/directory");
+            case EIO:    return translate("Input/output error");
+            case EACCES: return translate("Permission denied");
+            case EEXIST: return translate("File exists");
+            case ENODEV: return translate("Unsupported operation");
+            case EINVAL: return translate("Invalid argument");
+            case EROFS:  return translate("Read-only filesystem");
+        }
+    }
+    return NULL;
+}

--- a/py/mperrno.h
+++ b/py/mperrno.h
@@ -141,5 +141,7 @@
 #endif
 
 const char* mp_errno_to_str(mp_obj_t errno_val);
+// For commonly encountered errors, return compressed human readable strings
+const compressed_string_t* mp_common_errno_to_str(mp_obj_t errno_val);
 
 #endif // MICROPY_INCLUDED_PY_MPERRNO_H

--- a/py/obj.c
+++ b/py/obj.c
@@ -86,19 +86,35 @@ void mp_obj_print_exception(const mp_print_t *print, mp_obj_t exc) {
         mp_obj_exception_get_traceback(exc, &n, &values);
         if (n > 0) {
             assert(n % 3 == 0);
-            mp_print_str(print, translate("Traceback (most recent call last):\n"));
+            // Decompress the format strings
+            const compressed_string_t* traceback = translate("Traceback (most recent call last):\n");
+            char decompressed[traceback->length];
+            decompress(traceback, decompressed);
+#if MICROPY_ENABLE_SOURCE_LINE
+            const compressed_string_t* frame = translate("  File \"%q\", line %d");
+#else
+            const compressed_string_t* frame = translate("  File \"%q\"");
+#endif
+            char decompressed_frame[frame->length];
+            decompress(frame, decompressed_frame);
+            const compressed_string_t* block_fmt = translate(", in %q\n");
+            char decompressed_block[block_fmt->length];
+            decompress(block_fmt, decompressed_block);
+
+            // Print the traceback
+            mp_print_str(print, decompressed);
             for (int i = n - 3; i >= 0; i -= 3) {
 #if MICROPY_ENABLE_SOURCE_LINE
-                mp_printf(print, translate("  File \"%q\", line %d"), values[i], (int)values[i + 1]);
+                mp_printf(print, decompressed_frame, values[i], (int)values[i + 1]);
 #else
-                mp_printf(print, translate("  File \"%q\""), values[i]);
+                mp_printf(print, decompressed_frame, values[i]);
 #endif
                 // the block name can be NULL if it's unknown
                 qstr block = values[i + 2];
                 if (block == MP_QSTR_NULL) {
                     mp_print_str(print, "\n");
                 } else {
-                    mp_printf(print, translate(", in %q\n"), block);
+                    mp_printf(print, decompressed_block, block);
                 }
             }
         }

--- a/py/obj.h
+++ b/py/obj.h
@@ -34,6 +34,8 @@
 #include "py/mpprint.h"
 #include "py/runtime0.h"
 
+#include "supervisor/shared/translate.h"
+
 // This is the definition of the opaque MicroPython object type.
 // All concrete objects have an encoding within this type and the
 // particular encoding is specified by MICROPY_OBJ_REPR.
@@ -639,9 +641,9 @@ mp_obj_t mp_obj_new_complex(mp_float_t real, mp_float_t imag);
 mp_obj_t mp_obj_new_exception(const mp_obj_type_t *exc_type);
 mp_obj_t mp_obj_new_exception_arg1(const mp_obj_type_t *exc_type, mp_obj_t arg);
 mp_obj_t mp_obj_new_exception_args(const mp_obj_type_t *exc_type, size_t n_args, const mp_obj_t *args);
-mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const char *msg);
-mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const char *fmt, ...); // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
-mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, const char *fmt, va_list ap); // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
+mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const compressed_string_t *msg);
+mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, ...); // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
+mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, va_list ap); // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
 mp_obj_t mp_obj_new_fun_bc(mp_obj_t def_args, mp_obj_t def_kw_args, const byte *code, const mp_uint_t *const_table);
 mp_obj_t mp_obj_new_fun_native(mp_obj_t def_args_in, mp_obj_t def_kw_args, const void *fun_data, const mp_uint_t *const_table);
 mp_obj_t mp_obj_new_fun_viper(size_t n_args, void *fun_data, mp_uint_t type_sig);

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -116,8 +116,8 @@ void mp_obj_exception_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kin
             if (o->base.type == &mp_type_OSError && MP_OBJ_IS_SMALL_INT(o->args->items[0])) {
                 const compressed_string_t* common = mp_common_errno_to_str(o->args->items[0]);
                 const char* msg;
-                if (common != NULL) {
-                    char decompressed[common->length];
+                char decompressed[50];
+                if (common != NULL && common->length <= 50) {
                     decompress(common, decompressed);
                     msg = decompressed;
                 } else {

--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -148,11 +148,11 @@ overflow:
 value_error:
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_obj_t exc = mp_obj_new_exception_msg(&mp_type_ValueError,
-            "invalid syntax for integer");
+            translate("invalid syntax for integer"));
         raise_exc(exc, lex);
     } else if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_NORMAL) {
         mp_obj_t exc = mp_obj_new_exception_msg_varg(&mp_type_ValueError,
-            "invalid syntax for integer with base %d", base);
+            translate("invalid syntax for integer with base %d"), base);
         raise_exc(exc, lex);
     } else {
         vstr_t vstr;
@@ -328,7 +328,7 @@ mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool
     }
 #else
     if (imag || force_complex) {
-        raise_exc(mp_obj_new_exception_msg(&mp_type_ValueError, "complex values not supported"), lex);
+        raise_exc(mp_obj_new_exception_msg(&mp_type_ValueError, translate("complex values not supported")), lex);
     }
 #endif
     else {
@@ -336,9 +336,9 @@ mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool
     }
 
 value_error:
-    raise_exc(mp_obj_new_exception_msg(&mp_type_ValueError, "invalid syntax for number"), lex);
+    raise_exc(mp_obj_new_exception_msg(&mp_type_ValueError, translate("invalid syntax for number")), lex);
 
 #else
-    raise_exc(mp_obj_new_exception_msg(&mp_type_ValueError, "decimal numbers not supported"), lex);
+    raise_exc(mp_obj_new_exception_msg(&mp_type_ValueError, translate("decimal numbers not supported")), lex);
 #endif
 }

--- a/py/py.mk
+++ b/py/py.mk
@@ -315,7 +315,7 @@ $(HEADER_BUILD)/qstrdefs.enum.h: $(PY_SRC)/makeqstrdata.py $(HEADER_BUILD)/qstrd
 # the lines in "" and then unwrap after the preprocessor is finished.
 $(HEADER_BUILD)/qstrdefs.generated.h: $(PY_SRC)/makeqstrdata.py $(HEADER_BUILD)/$(TRANSLATION).mo $(HEADER_BUILD)/qstrdefs.preprocessed.h
 	$(STEPECHO) "GEN $@"
-	$(PYTHON3) $(PY_SRC)/makeqstrdata.py --translation $(HEADER_BUILD)/$(TRANSLATION).mo $(HEADER_BUILD)/qstrdefs.preprocessed.h > $@
+	$(PYTHON3) $(PY_SRC)/makeqstrdata.py --compression_filename $(HEADER_BUILD)/compression.generated.h --translation $(HEADER_BUILD)/$(TRANSLATION).mo $(HEADER_BUILD)/qstrdefs.preprocessed.h > $@
 
 $(PY_BUILD)/qstr.o: $(HEADER_BUILD)/qstrdefs.generated.h
 

--- a/py/qstr.c
+++ b/py/qstr.c
@@ -104,7 +104,7 @@ const qstr_pool_t mp_qstr_const_pool = {
     {
 #ifndef NO_QSTR
 #define QDEF(id, str) str,
-#define TRANSLATION(id, str)
+#define TRANSLATION(id, length, compressed...)
 #include "genhdr/qstrdefs.generated.h"
 #undef TRANSLATION
 #undef QDEF

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1539,7 +1539,7 @@ NORETURN void m_malloc_fail(size_t num_bytes) {
         translate("memory allocation failed, allocating %u bytes"), (uint)num_bytes);
 }
 
-NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const char *msg) {
+NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const compressed_string_t *msg) {
     if (msg == NULL) {
         nlr_raise(mp_obj_new_exception(exc_type));
     } else {
@@ -1547,7 +1547,7 @@ NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const char *msg) {
     }
 }
 
-NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const char *fmt, ...) {
+NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, ...) {
     va_list argptr;
     va_start(argptr,fmt);
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(exc_type, fmt, argptr);
@@ -1555,27 +1555,27 @@ NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const char *fmt, 
     nlr_raise(exception);
 }
 
-NORETURN void mp_raise_AttributeError(const char *msg) {
+NORETURN void mp_raise_AttributeError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_AttributeError, msg);
 }
 
-NORETURN void mp_raise_RuntimeError(const char *msg) {
+NORETURN void mp_raise_RuntimeError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_RuntimeError, msg);
 }
 
-NORETURN void mp_raise_ImportError(const char *msg) {
+NORETURN void mp_raise_ImportError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_ImportError, msg);
 }
 
-NORETURN void mp_raise_IndexError(const char *msg) {
+NORETURN void mp_raise_IndexError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_IndexError, msg);
 }
 
-NORETURN void mp_raise_ValueError(const char *msg) {
+NORETURN void mp_raise_ValueError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_ValueError, msg);
 }
 
-NORETURN void mp_raise_ValueError_varg(const char *fmt, ...) {
+NORETURN void mp_raise_ValueError_varg(const compressed_string_t *fmt, ...) {
     va_list argptr;
     va_start(argptr,fmt);
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_ValueError, fmt, argptr);
@@ -1583,11 +1583,11 @@ NORETURN void mp_raise_ValueError_varg(const char *fmt, ...) {
     nlr_raise(exception);
 }
 
-NORETURN void mp_raise_TypeError(const char *msg) {
+NORETURN void mp_raise_TypeError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_TypeError, msg);
 }
 
-NORETURN void mp_raise_TypeError_varg(const char *fmt, ...) {
+NORETURN void mp_raise_TypeError_varg(const compressed_string_t *fmt, ...) {
     va_list argptr;
     va_start(argptr,fmt);
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_TypeError, fmt, argptr);
@@ -1600,7 +1600,7 @@ NORETURN void mp_raise_OSError(int errno_) {
 }
 
 
-NORETURN void mp_raise_NotImplementedError(const char *msg) {
+NORETURN void mp_raise_NotImplementedError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_NotImplementedError, msg);
 }
 

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -147,18 +147,18 @@ mp_obj_t mp_import_name(qstr name, mp_obj_t fromlist, mp_obj_t level);
 mp_obj_t mp_import_from(mp_obj_t module, qstr name);
 void mp_import_all(mp_obj_t module);
 
-NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const char *msg);
-NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const char *fmt, ...);
-NORETURN void mp_raise_ValueError(const char *msg);
-NORETURN void mp_raise_ValueError_varg(const char *fmt, ...);
-NORETURN void mp_raise_TypeError(const char *msg);
-NORETURN void mp_raise_TypeError_varg(const char *fmt, ...);
-NORETURN void mp_raise_AttributeError(const char *msg);
-NORETURN void mp_raise_RuntimeError(const char *msg);
-NORETURN void mp_raise_ImportError(const char *msg);
-NORETURN void mp_raise_IndexError(const char *msg);
+NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const compressed_string_t *msg);
+NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, ...);
+NORETURN void mp_raise_ValueError(const compressed_string_t *msg);
+NORETURN void mp_raise_ValueError_varg(const compressed_string_t *fmt, ...);
+NORETURN void mp_raise_TypeError(const compressed_string_t *msg);
+NORETURN void mp_raise_TypeError_varg(const compressed_string_t *fmt, ...);
+NORETURN void mp_raise_AttributeError(const compressed_string_t *msg);
+NORETURN void mp_raise_RuntimeError(const compressed_string_t *msg);
+NORETURN void mp_raise_ImportError(const compressed_string_t *msg);
+NORETURN void mp_raise_IndexError(const compressed_string_t *msg);
 NORETURN void mp_raise_OSError(int errno_);
-NORETURN void mp_raise_NotImplementedError(const char *msg);
+NORETURN void mp_raise_NotImplementedError(const compressed_string_t *msg);
 NORETURN void mp_raise_recursion_depth(void);
 
 #if MICROPY_BUILTIN_METHOD_CHECK_SELF_ARG

--- a/py/vm.c
+++ b/py/vm.c
@@ -252,7 +252,7 @@ dispatch_loop:
                     if (obj_shared == MP_OBJ_NULL) {
                         local_name_error: {
                             MARK_EXC_IP_SELECTIVE();
-                            mp_obj_t obj = mp_obj_new_exception_msg(&mp_type_NameError, "local variable referenced before assignment");
+                            mp_obj_t obj = mp_obj_new_exception_msg(&mp_type_NameError, translate("local variable referenced before assignment"));
                             RAISE(obj);
                         }
                     }
@@ -1139,7 +1139,7 @@ unwind_return:
                             }
                         }
                         if (obj == MP_OBJ_NULL) {
-                            obj = mp_obj_new_exception_msg(&mp_type_RuntimeError, "no active exception to reraise");
+                            obj = mp_obj_new_exception_msg(&mp_type_RuntimeError, translate("no active exception to reraise"));
                             RAISE(obj);
                         }
                     } else {
@@ -1281,7 +1281,7 @@ yield:
                     } else
 #endif
                 {
-                    mp_obj_t obj = mp_obj_new_exception_msg(&mp_type_NotImplementedError, "byte code not implemented");
+                    mp_obj_t obj = mp_obj_new_exception_msg(&mp_type_NotImplementedError, translate("byte code not implemented"));
                     nlr_pop();
                     fastn[0] = obj;
                     return MP_VM_RETURN_EXCEPTION;

--- a/shared-bindings/audiobusio/PDMIn.c
+++ b/shared-bindings/audiobusio/PDMIn.c
@@ -196,7 +196,7 @@ STATIC mp_obj_t audiobusio_pdmin_obj_record(mp_obj_t self_obj, mp_obj_t destinat
 
     mp_buffer_info_t bufinfo;
     if (MP_OBJ_IS_TYPE(destination, &mp_type_fileio)) {
-        mp_raise_NotImplementedError("");
+        mp_raise_NotImplementedError(translate("Cannot record to a file"));
     } else if (mp_get_buffer(destination, &bufinfo, MP_BUFFER_WRITE)) {
         if (bufinfo.len / mp_binary_get_size('@', bufinfo.typecode, NULL) < length) {
             mp_raise_ValueError(translate("Destination capacity is smaller than destination_length."));

--- a/shared-bindings/os/__init__.c
+++ b/shared-bindings/os/__init__.c
@@ -197,7 +197,7 @@ STATIC mp_obj_t os_urandom(mp_obj_t size_in) {
     mp_int_t size = mp_obj_get_int(size_in);
     uint8_t tmp[size];
     if (!common_hal_os_urandom(tmp, size)) {
-        mp_raise_NotImplementedError("");
+        mp_raise_NotImplementedError(translate("No hardware random available"));
     }
     return mp_obj_new_bytes(tmp, size);
 }

--- a/shared-module/audioio/WaveFile.c
+++ b/shared-module/audioio/WaveFile.c
@@ -84,7 +84,7 @@ void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t* self,
     }
     // Get the sample_rate
     self->sample_rate = format.sample_rate;
-    self->len = 512;
+    self->len = 256;
     self->channel_count = format.num_channels;
     self->bits_per_sample = format.bits_per_sample;
 
@@ -114,13 +114,13 @@ void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t* self,
     self->buffer = m_malloc(self->len, false);
     if (self->buffer == NULL) {
         common_hal_audioio_wavefile_deinit(self);
-        mp_raise_msg(&mp_type_MemoryError, "");
+        mp_raise_msg(&mp_type_MemoryError, translate("Couldn't allocate first buffer"));
     }
 
     self->second_buffer = m_malloc(self->len, false);
     if (self->second_buffer == NULL) {
         common_hal_audioio_wavefile_deinit(self);
-        mp_raise_msg(&mp_type_MemoryError, "");
+        mp_raise_msg(&mp_type_MemoryError, translate("Couldn't allocate second buffer"));
     }
 }
 

--- a/supervisor/shared/translate.c
+++ b/supervisor/shared/translate.c
@@ -71,8 +71,6 @@ char* decompress(const compressed_string_t* compressed, char* decompressed) {
     return decompressed;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wreturn-local-addr"
 inline __attribute__((always_inline)) const compressed_string_t* translate(const char* original) {
     #ifndef NO_QSTR
     #define QDEF(id, str)
@@ -83,4 +81,3 @@ inline __attribute__((always_inline)) const compressed_string_t* translate(const
     #endif
     return NULL;
 }
-#pragma GCC diagnostic pop

--- a/supervisor/shared/translate.c
+++ b/supervisor/shared/translate.c
@@ -26,17 +26,61 @@
 
 #include "supervisor/shared/translate.h"
 
+#include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 
-inline __attribute__((always_inline)) const char* translate(const char* c) {
+#ifndef NO_QSTR
+#include "genhdr/compression.generated.h"
+#endif
+
+char* decompress(const compressed_string_t* compressed, char* decompressed) {
+    uint8_t this_byte = 0;
+    uint8_t this_bit = 7;
+    uint8_t b = compressed->data[this_byte];
+    // Stop one early because the last byte is always NULL.
+    for (uint16_t i = 0; i < compressed->length - 1; i++) {
+        uint32_t bits = 0;
+        uint8_t bit_length = 0;
+        uint32_t max_code = lengths[0];
+        uint32_t searched_length = lengths[0];
+        while (true) {
+            bits <<= 1;
+            if ((0x80 & b) != 0) {
+                bits |= 1;
+            }
+            b <<= 1;
+            bit_length += 1;
+            if (this_bit == 0) {
+                this_bit = 7;
+                this_byte += 1;
+                b = compressed->data[this_byte]; // This may read past the end but its never used.
+            } else {
+                this_bit -= 1;
+            }
+            if (max_code > 0 && bits < max_code) {
+                break;
+            }
+            max_code = (max_code << 1) + lengths[bit_length];
+            searched_length += lengths[bit_length];
+        }
+        decompressed[i] = values[searched_length + bits - max_code];
+    }
+
+    decompressed[compressed->length-1] = '\0';
+    return decompressed;
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreturn-local-addr"
+inline __attribute__((always_inline)) const compressed_string_t* translate(const char* original) {
     #ifndef NO_QSTR
     #define QDEF(id, str)
-    #define TRANSLATION(id, str) if (strcmp(c, id) == 0) { return str; } else
+    #define TRANSLATION(id, len, compressed...) if (strcmp(original, id) == 0) { static compressed_string_t v = {.length = len, .data = compressed}; return &v; } else
     #include "genhdr/qstrdefs.generated.h"
     #undef TRANSLATION
     #undef QDEF
     #endif
-    {
-        return "";
-    }
+    return NULL;
 }
+#pragma GCC diagnostic pop

--- a/supervisor/shared/translate.c
+++ b/supervisor/shared/translate.c
@@ -74,7 +74,7 @@ char* decompress(const compressed_string_t* compressed, char* decompressed) {
 inline __attribute__((always_inline)) const compressed_string_t* translate(const char* original) {
     #ifndef NO_QSTR
     #define QDEF(id, str)
-    #define TRANSLATION(id, len, compressed...) if (strcmp(original, id) == 0) { static compressed_string_t v = {.length = len, .data = compressed}; return &v; } else
+    #define TRANSLATION(id, len, compressed...) if (strcmp(original, id) == 0) { static const compressed_string_t v = {.length = len, .data = compressed}; return &v; } else
     #include "genhdr/qstrdefs.generated.h"
     #undef TRANSLATION
     #undef QDEF

--- a/supervisor/shared/translate.h
+++ b/supervisor/shared/translate.h
@@ -27,6 +27,15 @@
 #ifndef MICROPY_INCLUDED_SUPERVISOR_TRANSLATE_H
 #define MICROPY_INCLUDED_SUPERVISOR_TRANSLATE_H
 
-const char* translate(const char* c);
+#include <stdint.h>
+
+typedef struct {
+    uint16_t length;
+    const uint8_t data[];
+} compressed_string_t;
+
+const compressed_string_t* translate(const char* c);
+
+char* decompress(const compressed_string_t* compressed, char* decompressed);
 
 #endif  // MICROPY_INCLUDED_SUPERVISOR_TRANSLATE_H


### PR DESCRIPTION
This saves code space in builds which use link-time optimization.
The optimization drops the untranslated strings and replaces them
with a compressed_string_t struct. It can then be decompressed to
a c string.

Builds without LTO work as well but include both untranslated
strings and compressed strings.

This work could be expanded to include QSTRs and loaded strings if
a compress method is added to C. Its tracked in #531.