### PR TITLE
Fix PWM Support on port 1 of NRF52840

### DIFF
--- a/ports/nrf/common-hal/pulseio/PWMOut.c
+++ b/ports/nrf/common-hal/pulseio/PWMOut.c
@@ -146,7 +146,7 @@ void common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self,
   // check if mapped to PWM channel already
   for(int i=0; i<PWM_MAX_MODULE; i++)
   {
-    int ch = pin2channel(pwm_arr[i], pin->pin);
+    int ch = pin2channel(pwm_arr[i], NRF_GPIO_PIN_MAP(pin->port, pin->pin));
     if ( ch >= 0 )
     {
       self->pwm = pwm_arr[i];
@@ -168,7 +168,7 @@ void common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self,
     // disable before mapping pin channel
     self->pwm->ENABLE = 0;
 
-    self->pwm->PSEL.OUT[self->channel] = pin->pin;
+    self->pwm->PSEL.OUT[self->channel] = NRF_GPIO_PIN_MAP(pin->port, pin->pin);
 
     self->pwm->COUNTERTOP = (PWM_MAX_FREQ/frequency);
     self->freq = frequency;


### PR DESCRIPTION
Replace usage of pin number alone with port+pin combination in NRF port of PWMOut