### PR TITLE
Speed up zero neopixel pulses.

### DIFF
--- a/ports/atmel-samd/common-hal/neopixel_write/__init__.c
+++ b/ports/atmel-samd/common-hal/neopixel_write/__init__.c
@@ -109,7 +109,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
         asm("nop; nop;");
         #endif
         #ifdef SAMD51
-        delay_cycles(3);
+        delay_cycles(1);
         #endif
         if((p & bitMask) != 0) {
             // This is the high delay unique to a one bit.
@@ -129,7 +129,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
             asm("nop; nop;");
             #endif
             #ifdef SAMD51
-            delay_cycles(3);
+            delay_cycles(1);
             #endif
         }
         if((bitMask >>= 1) != 0) {


### PR DESCRIPTION
SK6812 on 5v is pickier than WS2812 on 5v.

Hopefully fixes #1083.