### PR TITLE
use unique DevicID for usb serial

### DIFF
--- a/ports/nrf/usb/usb_desc.c
+++ b/ports/nrf/usb/usb_desc.c
@@ -78,6 +78,8 @@ enum {
 // STRING DESCRIPTORS
 //--------------------------------------------------------------------+
 
+uint16_t usb_desc_str_serial[1+16] = { TUD_DESC_STR_HEADER(16) };
+
 // array of pointer to string descriptors
 uint16_t const * const string_desc_arr [] =
 {
@@ -91,7 +93,7 @@ uint16_t const * const string_desc_arr [] =
     TUD_DESC_STRCONV('C','i','r','c','u','i','t','P','y',' ','n','R','F','5','2'),
 
     // 3 Serials TODO use chip ID
-    TUD_DESC_STRCONV('1', '2', '3', '4', '5'),
+    usb_desc_str_serial,
 
     // 4 CDC Interface
     TUD_DESC_STRCONV('C','i','r','c','u','i','t','P','y',' ','S','e','r','i','a','l'),


### PR DESCRIPTION
Serial string = 64-bit DeviceID

```
$ lsusb -v -d 239a:

Bus 001 Device 050: ID 239a:802a  
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.00
  bDeviceClass          239 Miscellaneous Device
  bDeviceSubClass         2 ?
  bDeviceProtocol         1 Interface Association
  bMaxPacketSize0        64
  idVendor           0x239a 
  idProduct          0x802a 
  bcdDevice            1.00
  iManufacturer           1 Adafruit Industries
  iProduct                2 CircuitPy nRF52
  iSerial                 3 2467EB236E0E4F2D
```