### PR TITLE
 adjust SAMD51 neopixel_write timing

### DIFF
--- a/ports/atmel-samd/common-hal/neopixel_write/__init__.c
+++ b/ports/atmel-samd/common-hal/neopixel_write/__init__.c
@@ -109,7 +109,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
         asm("nop; nop;");
         #endif
         #ifdef SAMD51
-        delay_cycles(1);
+        delay_cycles(2);
         #endif
         if((p & bitMask) != 0) {
             // This is the high delay unique to a one bit.
@@ -129,7 +129,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
             asm("nop; nop;");
             #endif
             #ifdef SAMD51
-            delay_cycles(1);
+            delay_cycles(2);
             #endif
         }
         if((bitMask >>= 1) != 0) {


### PR DESCRIPTION
This works with the "onboard" neopixels on a metro_m4_express and feather_m4 express. It also works with the RGBW 8 pixel strip using VUSB and D5(5v) on my itsy_bitsy_m4_express.
I also tested running a "jewel" and the strip at 3V on the metro_m4_express. both worked.

I measured the write frequency on the itsybitsy_m4_express and saw ~757kHz