### PR TITLE
Revert "py/vm: Improve performance of opcode dispatch when using switch stmt."

### DIFF
--- a/py/vm.c
+++ b/py/vm.c
@@ -136,7 +136,7 @@ mp_vm_return_kind_t mp_execute_bytecode(mp_code_state_t *code_state, volatile mp
     #define ENTRY(op) entry_##op
     #define ENTRY_DEFAULT entry_default
 #else
-    #define DISPATCH() goto dispatch_loop
+    #define DISPATCH() break
     #define DISPATCH_WITH_PEND_EXC_CHECK() goto pending_exception_check
     #define ENTRY(op) case op
     #define ENTRY_DEFAULT default


### PR DESCRIPTION

This reverts commit 869024dd6e62905b7e1069b547856a769b3b24ba.

Ctrl-C stopped producing KeyboardInterrupt with this change on CircuitPython.

The Unix and stm32 ports handles Ctrl-C differently with a handler which is
probably why they where not affected.

Fixes #1092