### PR TITLE
update tinyusb to fix #1007 serial issue

### DIFF
--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -110,7 +110,7 @@ run follow command to install [adafruit-nrfutil](https://github.com/adafruit/Ada
 Example on how to generate and flash feather_nrf52832 target:
 
     make BOARD=feather_nrf52832 SD=s132
-    make BOARD=feather52832 SD=s132 dfu-gen dfu-flash
+    make BOARD=feather_nrf52832 SD=s132 dfu-gen dfu-flash
 
 ## Bluetooth LE REPL
 


### PR DESCRIPTION
This should fix the issue with mac/windows serial connectuon timeout. The root cause is a bit complicated, but require only a few lines to fix as expected. The issue is EP0STATUS to send control status also require Easy DMA access. This seems to be missing from Nordic documents

https://github.com/hathach/tinyusb/compare/7b35cd0203bc409d7c1aefc075672103cb4a913e...583326e535454f16b06ebdb9cc06869602a5564c#diff-9b5241cf0c81e9eb639b442c58170472R220