### PR TITLE
When UART timeout of zero is given, make read() return data already a…

### DIFF
--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -249,7 +249,7 @@ size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t 
     uint64_t start_ticks = ticks_ms;
 
     // Busy-wait until timeout or until we've read enough chars.
-    while (ticks_ms - start_ticks < self->timeout_ms) {
+    while (ticks_ms - start_ticks <= self->timeout_ms) {
         // Read as many chars as we can right now, up to len.
         size_t num_read = io_read(io, data, len);
 
@@ -268,6 +268,10 @@ size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t 
 #ifdef MICROPY_VM_HOOK_LOOP
         MICROPY_VM_HOOK_LOOP
 #endif
+       // If we are zero timeout, make sure we don't loop again (in the event 
+       // we read in under 1ms)
+       if (self->timeout_ms == 0)
+            break;
     }
 
     if (total_read == 0) {


### PR DESCRIPTION
…vailable

Currently if you give a timeout of zero to UART, typically you'll get nothing as the comparison is < timeout and no time has passed. This makes that <= and makes sure only one pass of the read loop is performed. Now, when a timeout of 0 is given, it will return the data already available without waiting for any additional data.