### PR TITLE
use open-drain capabilities on GPIO; clean up board init; set correct GPIO voltage

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -118,7 +118,10 @@ SRC_C += \
 	lib/utils/sys_stdio_mphal.c \
 	nrfx/hal/nrf_nvmc.c \
 	nrfx/mdk/system_$(MCU_SUB_VARIANT).c \
+	peripherals/nrf/cache.c \
+	peripherals/nrf/clocks.c \
 	peripherals/nrf/$(MCU_CHIP)/pins.c \
+	peripherals/nrf/$(MCU_CHIP)/power.c \
 	supervisor/shared/memory.c
 
 DRIVERS_SRC_C += $(addprefix modules/,\

--- a/ports/nrf/boards/feather_nrf52840_express/board.c
+++ b/ports/nrf/boards/feather_nrf52840_express/board.c
@@ -24,15 +24,11 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
-#include <stdbool.h>
-
-#include "nrf.h"
-
 #include "boards/board.h"
+#include "usb.h"
 
 void board_init(void) {
-
+    usb_init();
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/nrf/boards/pca10040/board.c
+++ b/ports/nrf/boards/pca10040/board.c
@@ -32,7 +32,6 @@
 #include "boards/board.h"
 
 void board_init(void) {
-
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/nrf/boards/pca10056/board.c
+++ b/ports/nrf/boards/pca10056/board.c
@@ -24,18 +24,10 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
-#include <stdbool.h>
 #include "boards/board.h"
-#include "nrfx.h"
 #include "usb.h"
 
 void board_init(void) {
-
-    // Clock
-    NRF_CLOCK->LFCLKSRC = (uint32_t)((CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos) & CLOCK_LFCLKSRC_SRC_Msk);
-    NRF_CLOCK->TASKS_LFCLKSTART = 1UL;
-
     usb_init();
 }
 
@@ -46,8 +38,3 @@ bool board_requests_safe_mode(void) {
 void reset_board(void) {
 
 }
-
-
-
-
-

--- a/ports/nrf/boards/pca10059/board.c
+++ b/ports/nrf/boards/pca10059/board.c
@@ -31,11 +31,6 @@
 #include "usb.h"
 
 void board_init(void) {
-
-    // Clock
-    NRF_CLOCK->LFCLKSRC = (uint32_t)((CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos) & CLOCK_LFCLKSRC_SRC_Msk);
-    NRF_CLOCK->TASKS_LFCLKSTART = 1UL;
-
     usb_init();
 }
 
@@ -46,8 +41,3 @@ bool board_requests_safe_mode(void) {
 void reset_board(void) {
 
 }
-
-
-
-
-

--- a/ports/nrf/common-hal/digitalio/DigitalInOut.h
+++ b/ports/nrf/common-hal/digitalio/DigitalInOut.h
@@ -32,8 +32,6 @@
 typedef struct {
     mp_obj_base_t base;
     const mcu_pin_obj_t *pin;
-    bool output;
-    bool open_drain;
 } digitalio_digitalinout_obj_t;
 
 #endif // MICROPY_INCLUDED_NRF_COMMON_HAL_DIGITALIO_DIGITALINOUT_H

--- a/ports/nrf/peripherals/nrf/cache.c
+++ b/ports/nrf/peripherals/nrf/cache.c
@@ -1,9 +1,9 @@
 /*
- * This file is part of the MicroPython project, http://micropython.org/
+ * This file is part of the Micro Python project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,19 +24,15 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
-#include <stdbool.h>
+#include "nrfx.h"
 
-#include "nrf.h"
-
-#include "boards/board.h"
-
-void board_init(void) {
+// Turn off cache and invalidate all data in it.
+void nrf_peripherals_disable_and_clear_cache(void) {
+    // Disabling cache also invalidates all cache entries.
+    NRF_NVMC->ICACHECNF &= ~(1 << NVMC_ICACHECNF_CACHEEN_Pos);
 }
 
-bool board_requests_safe_mode(void) {
-    return false;
-}
-
-void reset_board(void) {
+// Enable cache
+void nrf_peripherals_enable_cache(void) {
+    NRF_NVMC->ICACHECNF |= 1 << NVMC_ICACHECNF_CACHEEN_Pos;
 }

--- a/ports/nrf/peripherals/nrf/cache.h
+++ b/ports/nrf/peripherals/nrf/cache.h
@@ -1,9 +1,9 @@
 /*
- * This file is part of the MicroPython project, http://micropython.org/
+ * This file is part of the Micro Python project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,19 +24,5 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
-#include <stdbool.h>
-
-#include "nrf.h"
-
-#include "boards/board.h"
-
-void board_init(void) {
-}
-
-bool board_requests_safe_mode(void) {
-    return false;
-}
-
-void reset_board(void) {
-}
+void nrf_peripherals_disable_and_clear_cache(void);
+void nrf_peripherals_enable_cache(void);

--- a/ports/nrf/peripherals/nrf/clocks.c
+++ b/ports/nrf/peripherals/nrf/clocks.c
@@ -1,9 +1,10 @@
+
 /*
- * This file is part of the MicroPython project, http://micropython.org/
+ * This file is part of the Micro Python project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,19 +25,11 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
-#include <stdbool.h>
+#include "nrfx.h"
 
-#include "nrf.h"
-
-#include "boards/board.h"
-
-void board_init(void) {
-}
-
-bool board_requests_safe_mode(void) {
-    return false;
-}
-
-void reset_board(void) {
+void nrf_peripherals_clocks_init(void) {
+    // Set low-frequency clock source to be crystal. If there's a crystalless board, this will need to be
+    // generalized.
+    NRF_CLOCK->LFCLKSRC = (uint32_t)((CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos) & CLOCK_LFCLKSRC_SRC_Msk);
+    NRF_CLOCK->TASKS_LFCLKSTART = 1UL;
 }

--- a/ports/nrf/peripherals/nrf/clocks.h
+++ b/ports/nrf/peripherals/nrf/clocks.h
@@ -1,9 +1,9 @@
 /*
- * This file is part of the MicroPython project, http://micropython.org/
+ * This file is part of the Micro Python project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,19 +24,4 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
-#include <stdbool.h>
-
-#include "nrf.h"
-
-#include "boards/board.h"
-
-void board_init(void) {
-}
-
-bool board_requests_safe_mode(void) {
-    return false;
-}
-
-void reset_board(void) {
-}
+void nrf_peripherals_clocks_init(void);

--- a/ports/nrf/peripherals/nrf/nrf52832/power.c
+++ b/ports/nrf/peripherals/nrf/nrf52832/power.c
@@ -1,9 +1,9 @@
 /*
- * This file is part of the MicroPython project, http://micropython.org/
+ * This file is part of the Micro Python project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,19 +24,7 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
-#include <stdbool.h>
+#include "nrfx.h"
 
-#include "nrf.h"
-
-#include "boards/board.h"
-
-void board_init(void) {
-}
-
-bool board_requests_safe_mode(void) {
-    return false;
-}
-
-void reset_board(void) {
+void nrf_peripherals_power_init(void) {
 }

--- a/ports/nrf/peripherals/nrf/nrf52840/power.c
+++ b/ports/nrf/peripherals/nrf/nrf52840/power.c
@@ -1,9 +1,9 @@
 /*
- * This file is part of the MicroPython project, http://micropython.org/
+ * This file is part of the Micro Python project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,19 +24,17 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
-#include <stdbool.h>
+#include "nrfx.h"
+#include "nrf_nvmc.h"
 
-#include "nrf.h"
-
-#include "boards/board.h"
-
-void board_init(void) {
-}
-
-bool board_requests_safe_mode(void) {
-    return false;
-}
-
-void reset_board(void) {
+void nrf_peripherals_power_init(void) {
+    // Set GPIO reference voltage to 3.3V if it isn't already. REGOUT0 will get reset to 0xfffffff
+    // if flash is erased, which sets the default to 1.8V
+    // This matters only when "high voltage mode" is enabled, which is true on the PCA10059,
+    // and might be true on other boards.
+    if (NRF_UICR->REGOUT0 == 0xffffffff) {
+        nrf_nvmc_write_word((uint32_t) &NRF_UICR->REGOUT0, UICR_REGOUT0_VOUT_3V3 << UICR_REGOUT0_VOUT_Pos);
+        // Must reset to make enable change.
+        NVIC_SystemReset();
+    }
 }

--- a/ports/nrf/peripherals/nrf/power.h
+++ b/ports/nrf/peripherals/nrf/power.h
@@ -1,9 +1,9 @@
 /*
- * This file is part of the MicroPython project, http://micropython.org/
+ * This file is part of the Micro Python project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,19 +24,4 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
-#include <stdbool.h>
-
-#include "nrf.h"
-
-#include "boards/board.h"
-
-void board_init(void) {
-}
-
-bool board_requests_safe_mode(void) {
-    return false;
-}
-
-void reset_board(void) {
-}
+void nrf_peripherals_power_init(void);

--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -28,13 +28,24 @@
 #include "supervisor/port.h"
 #include "boards/board.h"
 
+#include "nrf/cache.h"
+#include "nrf/clocks.h"
+#include "nrf/power.h"
+
 #include "shared-module/gamepad/__init__.h"
 #include "common-hal/microcontroller/Pin.h"
 #include "common-hal/pulseio/PWMOut.h"
 #include "tick.h"
 
 safe_mode_t port_init(void) {
-    board_init();
+
+    nrf_peripherals_clocks_init();
+
+    // If GPIO voltage is set wrong in UICR, this will fix it, and
+    // will also do a reset to make the change take effect.
+    nrf_peripherals_power_init();
+
+    nrf_peripherals_enable_cache();
 
     // Configure millisecond timer initialization.
     tick_init();
@@ -46,7 +57,12 @@ safe_mode_t port_init(void) {
         return HARD_CRASH;
     }
     #endif
+#endif
 
+    // Will do usb_init() if chip supports USB.
+    board_init();
+
+#if 0
     if (board_requests_safe_mode()) {
         return USER_SAFE_MODE;
     }
@@ -80,4 +96,3 @@ void HardFault_Handler(void)
 //		(void)bfar;
 //	}
 }
-


### PR DESCRIPTION
- Use native GPIO capabilities in `common-hal/digitalio/DigitalInOut.c` instead of simulating open drain outputs with inputs.
- Make sure GPIO voltage is 3.3V. It will be 1.8V if `UICR->REGOUT0` has been cleared.
- Some refactoring of `board_init()` into other places.
- Make sure instruction cache is on. SoftDevice is supposed to turn it on, but let's make sure.