### PR TITLE
PWMOut was not claming channels on shared TCCs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ before_script:
     sudo apt-get install -y python3 gcc-multilib pkg-config libffi-dev libffi-dev:i386 qemu-system
 
   - ([[ -z "$TRAVIS_TEST" ]] || sudo apt-get install -y qemu-system)
-  - ([[ -z "$TRAVIS_BOARD" ]] || (wget https://s3.amazonaws.com/adafruit-circuit-python/gcc-arm-embedded_7-2017q4-1~trusty3_amd64.deb && sudo dpkg -i gcc-arm-embedded*_amd64.deb))
-  - ([[ $TRAVIS_TEST != "qemu" ]] || (wget https://s3.amazonaws.com/adafruit-circuit-python/gcc-arm-embedded_7-2017q4-1~trusty3_amd64.deb && sudo dpkg -i gcc-arm-embedded*_amd64.deb))
+  - ([[ -z "$TRAVIS_BOARD" ]] || (wget https://s3.amazonaws.com/adafruit-circuit-python/gcc-arm-embedded_7-2018q2-1~trusty1_amd64.deb && sudo dpkg -i gcc-arm-embedded*_amd64.deb))
+  - ([[ $TRAVIS_TEST != "qemu" ]] || (wget https://s3.amazonaws.com/adafruit-circuit-python/gcc-arm-embedded_7-2018q2-1~trusty1_amd64.deb && sudo dpkg -i gcc-arm-embedded*_amd64.deb))
 
   # For teensy build
   - sudo apt-get install realpath

--- a/ports/atmel-samd/common-hal/pulseio/PWMOut.c
+++ b/ports/atmel-samd/common-hal/pulseio/PWMOut.c
@@ -51,10 +51,10 @@ uint8_t tcc_refcount[TCC_INST_NUM];
 
 // This bitmask keeps track of which channels of a TCC are currently claimed.
 #ifdef SAMD21
-uint8_t tcc_channels[3] = {0xf0, 0xfc, 0xfc};
+uint8_t tcc_channels[3];   // Set by pwmout_reset() to {0xf0, 0xfc, 0xfc} initially.
 #endif
 #ifdef SAMD51
-uint8_t tcc_channels[5] = {0xc0, 0xf0, 0xf8, 0xfc, 0xfc};
+uint8_t tcc_channels[5];   // Set by pwmout_reset() to {0xc0, 0xf0, 0xf8, 0xfc, 0xfc} initially.
 #endif
 
 void pwmout_reset(void) {
@@ -75,7 +75,7 @@ void pwmout_reset(void) {
         for (uint8_t j = 0; j < tcc_cc_num[i]; j++) {
             mask <<= 1;
         }
-        tcc_channels[i] = 0xf0;
+        tcc_channels[i] = mask;
         tccs[i]->CTRLA.bit.SWRST = 1;
     }
     Tc *tcs[TC_INST_NUM] = TC_INSTS;
@@ -122,7 +122,7 @@ void common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self,
     // Figure out which timer we are using.
 
     // First see if a tcc is already going with the frequency we want and our
-    // channel is unused. tc's don't have neough channels to share.
+    // channel is unused. tc's don't have enough channels to share.
     const pin_timer_t* timer = NULL;
     uint8_t mux_position = 0;
     if (!variable_frequency) {
@@ -139,6 +139,9 @@ void common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self,
                 if (tcc->CTRLA.bit.ENABLE == 1 && channel_ok(t)) {
                     timer = t;
                     mux_position = j;
+                    // Claim channel.
+                    tcc_channels[timer->index] |= (1 << tcc_channel(timer));
+
                 }
             }
         }


### PR DESCRIPTION
Fixes #1106.

@deshipu - you may want to test this. I did try a test case similar to yours. The code was allocating the same TCC channel to multiple pins. This means that you may run out of timers earlier previously, because we were allocating the same TCC and channel to multiple pins by accident.