### PR TITLE
usb_write() output_len was uint8_t instead of uint32_t

### DIFF
--- a/ports/atmel-samd/usb.c
+++ b/ports/atmel-samd/usb.c
@@ -288,7 +288,7 @@ void usb_write(const char* buffer, uint32_t len) {
         return;
     }
     uint8_t * output_buffer;
-    uint8_t output_len;
+    uint32_t output_len;
     while (len > 0) {
         while (usb_transmitting) {}
         output_buffer = (uint8_t *) buffer;


### PR DESCRIPTION
`usb_write()` was only using 8 bits to represent buffer length. If buffer was larger, length would be wrong.

Fixes #1181, and might fix some other mysterious USB output bugs.