### PR TITLE
Add OnDiskBitmap which loads pixel data straight from disk.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ before_script:
   # For coverage testing (upgrade is used to get latest urllib3 version)
   - ([[ -z "$TRAVIS_TEST" ]] || sudo apt-get install -y python3-pip)
   - ([[ -z "$TRAVIS_TEST" ]] || sudo pip install --upgrade cpp-coveralls)
-  - ([[ $TRAVIS_TEST != "docs" ]] || sudo pip install Sphinx sphinx-rtd-theme recommonmark)
+  - ([[ $TRAVIS_TEST != "docs" ]] || sudo pip install 'Sphinx<1.8.0' sphinx-rtd-theme recommonmark)
   - ([[ $TRAVIS_TEST != "translations" ]] || sudo pip3 install polib)
   - gcc --version
   - ([[ -z "$TRAVIS_BOARD" || $TRAVIS_BOARD = "feather_huzzah" ]] || arm-none-eabi-gcc --version)

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-06 14:55-0700\n"
+"POT-Creation-Date: 2018-09-12 16:24-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -123,7 +123,7 @@ msgstr ""
 msgid "queue overflow"
 msgstr ""
 
-#: extmod/moduzlib.c:97
+#: extmod/moduzlib.c:98
 msgid "compression header"
 msgstr ""
 
@@ -214,7 +214,7 @@ msgstr ""
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 
-#: main.c:415
+#: main.c:416
 msgid "soft reboot\n"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgid "No TX pin"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c:170
-#: ports/nrf/common-hal/digitalio/DigitalInOut.c:153
+#: ports/nrf/common-hal/digitalio/DigitalInOut.c:142
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -1960,6 +1960,7 @@ msgid "buffer must be a bytes-like object"
 msgstr ""
 
 #: shared-bindings/audioio/WaveFile.c:78
+#: shared-bindings/displayio/OnDiskBitmap.c:85
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
@@ -2034,6 +2035,10 @@ msgstr ""
 msgid "row data must be a buffer"
 msgstr ""
 
+#: shared-bindings/displayio/ColorConverter.c:72
+msgid "color should be an int"
+msgstr ""
+
 #: shared-bindings/displayio/FourWire.c:55
 #: shared-bindings/displayio/FourWire.c:64
 msgid "displayio is a work in progress"
@@ -2064,16 +2069,16 @@ msgstr ""
 msgid "palette_index should be an int"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:45
+#: shared-bindings/displayio/Sprite.c:48
 msgid "position must be 2-tuple"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:87
+#: shared-bindings/displayio/Sprite.c:97
 msgid "unsupported bitmap type"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:152
-msgid "palette must be displayio.Palette"
+#: shared-bindings/displayio/Sprite.c:162
+msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr ""
 
 #: shared-bindings/gamepad/GamePad.c:100
@@ -2300,6 +2305,24 @@ msgstr ""
 
 #: shared-module/displayio/Group.c:39
 msgid "Group full"
+msgstr ""
+
+#: shared-module/displayio/Group.c:48
+msgid "Group empty"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c:49
+msgid "Invalid BMP file"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c:59
+#, c-format
+msgid "Only Windows format, uncompressed BMP supported %d"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c:64
+#, c-format
+msgid "Only true color (24 bpp or higher) BMP supported %x"
 msgstr ""
 
 #: shared-module/struct/__init__.c:39

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-06 14:55-0700\n"
+"POT-Creation-Date: 2018-09-12 16:24-0700\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: Sebastian Plamauer\n"
 "Language-Team: \n"
@@ -123,7 +123,7 @@ msgstr "ungültiges cert"
 msgid "queue overflow"
 msgstr "Warteschlangenüberlauf"
 
-#: extmod/moduzlib.c:97
+#: extmod/moduzlib.c:98
 msgid "compression header"
 msgstr "kompression header"
 
@@ -223,7 +223,7 @@ msgstr ""
 "Drücke eine Taste um dich mit der REPL zu verbinden. Drücke Strg-D zum neu "
 "laden"
 
-#: main.c:415
+#: main.c:416
 msgid "soft reboot\n"
 msgstr "weicher reboot\n"
 
@@ -402,7 +402,7 @@ msgid "No TX pin"
 msgstr "Kein TX Pin"
 
 #: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c:170
-#: ports/nrf/common-hal/digitalio/DigitalInOut.c:153
+#: ports/nrf/common-hal/digitalio/DigitalInOut.c:142
 msgid "Cannot get pull while in output mode"
 msgstr "Pull up im Ausgabemodus nicht möglich"
 
@@ -1969,6 +1969,7 @@ msgid "buffer must be a bytes-like object"
 msgstr ""
 
 #: shared-bindings/audioio/WaveFile.c:78
+#: shared-bindings/displayio/OnDiskBitmap.c:85
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
@@ -2043,6 +2044,10 @@ msgstr ""
 msgid "row data must be a buffer"
 msgstr ""
 
+#: shared-bindings/displayio/ColorConverter.c:72
+msgid "color should be an int"
+msgstr ""
+
 #: shared-bindings/displayio/FourWire.c:55
 #: shared-bindings/displayio/FourWire.c:64
 msgid "displayio is a work in progress"
@@ -2073,17 +2078,17 @@ msgstr ""
 msgid "palette_index should be an int"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:45
+#: shared-bindings/displayio/Sprite.c:48
 msgid "position must be 2-tuple"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:87
+#: shared-bindings/displayio/Sprite.c:97
 #, fuzzy
 msgid "unsupported bitmap type"
 msgstr "Baudrate wird nicht unterstütz"
 
-#: shared-bindings/displayio/Sprite.c:152
-msgid "palette must be displayio.Palette"
+#: shared-bindings/displayio/Sprite.c:162
+msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr ""
 
 #: shared-bindings/gamepad/GamePad.c:100
@@ -2310,6 +2315,25 @@ msgstr ""
 
 #: shared-module/displayio/Group.c:39
 msgid "Group full"
+msgstr ""
+
+#: shared-module/displayio/Group.c:48
+msgid "Group empty"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c:49
+#, fuzzy
+msgid "Invalid BMP file"
+msgstr "Ungültiger Pin"
+
+#: shared-module/displayio/OnDiskBitmap.c:59
+#, c-format
+msgid "Only Windows format, uncompressed BMP supported %d"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c:64
+#, c-format
+msgid "Only true color (24 bpp or higher) BMP supported %x"
 msgstr ""
 
 #: shared-module/struct/__init__.c:39

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-06 14:55-0700\n"
+"POT-Creation-Date: 2018-09-12 16:24-0700\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -123,7 +123,7 @@ msgstr ""
 msgid "queue overflow"
 msgstr ""
 
-#: extmod/moduzlib.c:97
+#: extmod/moduzlib.c:98
 msgid "compression header"
 msgstr ""
 
@@ -214,7 +214,7 @@ msgstr ""
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 
-#: main.c:415
+#: main.c:416
 msgid "soft reboot\n"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgid "No TX pin"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c:170
-#: ports/nrf/common-hal/digitalio/DigitalInOut.c:153
+#: ports/nrf/common-hal/digitalio/DigitalInOut.c:142
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -1960,6 +1960,7 @@ msgid "buffer must be a bytes-like object"
 msgstr ""
 
 #: shared-bindings/audioio/WaveFile.c:78
+#: shared-bindings/displayio/OnDiskBitmap.c:85
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
@@ -2034,6 +2035,10 @@ msgstr ""
 msgid "row data must be a buffer"
 msgstr ""
 
+#: shared-bindings/displayio/ColorConverter.c:72
+msgid "color should be an int"
+msgstr ""
+
 #: shared-bindings/displayio/FourWire.c:55
 #: shared-bindings/displayio/FourWire.c:64
 msgid "displayio is a work in progress"
@@ -2064,16 +2069,16 @@ msgstr ""
 msgid "palette_index should be an int"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:45
+#: shared-bindings/displayio/Sprite.c:48
 msgid "position must be 2-tuple"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:87
+#: shared-bindings/displayio/Sprite.c:97
 msgid "unsupported bitmap type"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:152
-msgid "palette must be displayio.Palette"
+#: shared-bindings/displayio/Sprite.c:162
+msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr ""
 
 #: shared-bindings/gamepad/GamePad.c:100
@@ -2300,6 +2305,24 @@ msgstr ""
 
 #: shared-module/displayio/Group.c:39
 msgid "Group full"
+msgstr ""
+
+#: shared-module/displayio/Group.c:48
+msgid "Group empty"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c:49
+msgid "Invalid BMP file"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c:59
+#, c-format
+msgid "Only Windows format, uncompressed BMP supported %d"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c:64
+#, c-format
+msgid "Only true color (24 bpp or higher) BMP supported %x"
 msgstr ""
 
 #: shared-module/struct/__init__.c:39

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-06 14:55-0700\n"
+"POT-Creation-Date: 2018-09-12 16:24-0700\n"
 "PO-Revision-Date: 2018-08-24 22:56-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -123,7 +123,7 @@ msgstr "certificado inválido"
 msgid "queue overflow"
 msgstr "desborde de queue"
 
-#: extmod/moduzlib.c:97
+#: extmod/moduzlib.c:98
 msgid "compression header"
 msgstr "encabezado de compresión"
 
@@ -229,7 +229,7 @@ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 "Presiona cualquier tecla para entrar al REPL. Usa CTRL-D para recargar."
 
-#: main.c:415
+#: main.c:416
 msgid "soft reboot\n"
 msgstr "reinicio suave\n"
 
@@ -409,7 +409,7 @@ msgid "No TX pin"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c:170
-#: ports/nrf/common-hal/digitalio/DigitalInOut.c:153
+#: ports/nrf/common-hal/digitalio/DigitalInOut.c:142
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -2005,6 +2005,7 @@ msgid "buffer must be a bytes-like object"
 msgstr ""
 
 #: shared-bindings/audioio/WaveFile.c:78
+#: shared-bindings/displayio/OnDiskBitmap.c:85
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
@@ -2080,6 +2081,10 @@ msgstr ""
 msgid "row data must be a buffer"
 msgstr ""
 
+#: shared-bindings/displayio/ColorConverter.c:72
+msgid "color should be an int"
+msgstr ""
+
 #: shared-bindings/displayio/FourWire.c:55
 #: shared-bindings/displayio/FourWire.c:64
 msgid "displayio is a work in progress"
@@ -2110,16 +2115,16 @@ msgstr ""
 msgid "palette_index should be an int"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:45
+#: shared-bindings/displayio/Sprite.c:48
 msgid "position must be 2-tuple"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:87
+#: shared-bindings/displayio/Sprite.c:97
 msgid "unsupported bitmap type"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:152
-msgid "palette must be displayio.Palette"
+#: shared-bindings/displayio/Sprite.c:162
+msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr ""
 
 #: shared-bindings/gamepad/GamePad.c:100
@@ -2347,6 +2352,26 @@ msgstr ""
 
 #: shared-module/displayio/Group.c:39
 msgid "Group full"
+msgstr ""
+
+#: shared-module/displayio/Group.c:48
+#, fuzzy
+msgid "Group empty"
+msgstr "heap vacío"
+
+#: shared-module/displayio/OnDiskBitmap.c:49
+#, fuzzy
+msgid "Invalid BMP file"
+msgstr "pin inválido"
+
+#: shared-module/displayio/OnDiskBitmap.c:59
+#, c-format
+msgid "Only Windows format, uncompressed BMP supported %d"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c:64
+#, c-format
+msgid "Only true color (24 bpp or higher) BMP supported %x"
 msgstr ""
 
 #: shared-module/struct/__init__.c:39

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-06 14:55-0700\n"
+"POT-Creation-Date: 2018-09-12 16:24-0700\n"
 "PO-Revision-Date: 2018-08-30 23:04-0700\n"
 "Last-Translator: Timothy <me@timothygarcia.ca>\n"
 "Language-Team: fil\n"
@@ -123,7 +123,7 @@ msgstr "mali ang cert"
 msgid "queue overflow"
 msgstr "puno na ang pila (overflow)"
 
-#: extmod/moduzlib.c:97
+#: extmod/moduzlib.c:98
 msgid "compression header"
 msgstr "compression header"
 
@@ -226,7 +226,7 @@ msgstr ""
 "Pindutin ang anumang key upang ipasok ang REPL. Gamitin ang CTRL-D upang i-"
 "reload."
 
-#: main.c:415
+#: main.c:416
 msgid "soft reboot\n"
 msgstr "malambot na reboot\n"
 
@@ -405,7 +405,7 @@ msgid "No TX pin"
 msgstr "Walang TX pin"
 
 #: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c:170
-#: ports/nrf/common-hal/digitalio/DigitalInOut.c:153
+#: ports/nrf/common-hal/digitalio/DigitalInOut.c:142
 msgid "Cannot get pull while in output mode"
 msgstr "Hindi makakakuha ng pull habang nasa output mode"
 
@@ -1998,6 +1998,7 @@ msgid "buffer must be a bytes-like object"
 msgstr "buffer ay dapat bytes-like object"
 
 #: shared-bindings/audioio/WaveFile.c:78
+#: shared-bindings/displayio/OnDiskBitmap.c:85
 msgid "file must be a file opened in byte mode"
 msgstr "file ay dapat buksan sa byte mode"
 
@@ -2077,6 +2078,11 @@ msgstr ""
 msgid "row data must be a buffer"
 msgstr "constant ay dapat na integer"
 
+#: shared-bindings/displayio/ColorConverter.c:72
+#, fuzzy
+msgid "color should be an int"
+msgstr "Haba ay dapat int"
+
 #: shared-bindings/displayio/FourWire.c:55
 #: shared-bindings/displayio/FourWire.c:64
 msgid "displayio is a work in progress"
@@ -2113,20 +2119,19 @@ msgstr "buffer ay dapat bytes-like object"
 msgid "palette_index should be an int"
 msgstr ""
 
-#: shared-bindings/displayio/Sprite.c:45
+#: shared-bindings/displayio/Sprite.c:48
 #, fuzzy
 msgid "position must be 2-tuple"
 msgstr "stop dapat 1 o 2"
 
-#: shared-bindings/displayio/Sprite.c:87
+#: shared-bindings/displayio/Sprite.c:97
 #, fuzzy
 msgid "unsupported bitmap type"
 msgstr "Hindi supportadong baudrate"
 
-#: shared-bindings/displayio/Sprite.c:152
-#, fuzzy
-msgid "palette must be displayio.Palette"
-msgstr "ang palette ay dapat 32 bytes ang haba"
+#: shared-bindings/displayio/Sprite.c:162
+msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+msgstr ""
 
 #: shared-bindings/gamepad/GamePad.c:100
 msgid "too many arguments"
@@ -2357,6 +2362,26 @@ msgstr ""
 msgid "Group full"
 msgstr ""
 
+#: shared-module/displayio/Group.c:48
+#, fuzzy
+msgid "Group empty"
+msgstr "walang laman"
+
+#: shared-module/displayio/OnDiskBitmap.c:49
+#, fuzzy
+msgid "Invalid BMP file"
+msgstr "Mali ang file"
+
+#: shared-module/displayio/OnDiskBitmap.c:59
+#, c-format
+msgid "Only Windows format, uncompressed BMP supported %d"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c:64
+#, c-format
+msgid "Only true color (24 bpp or higher) BMP supported %x"
+msgstr ""
+
 #: shared-module/struct/__init__.c:39
 msgid "'S' and 'O' are not supported format types"
 msgstr "Ang 'S' at 'O' ay hindi suportadong uri ng format"
@@ -2364,3 +2389,7 @@ msgstr "Ang 'S' at 'O' ay hindi suportadong uri ng format"
 #: shared-module/struct/__init__.c:83
 msgid "too many arguments provided with the given format"
 msgstr "masyadong maraming mga argumento na ibinigay sa ibinigay na format"
+
+#, fuzzy
+#~ msgid "palette must be displayio.Palette"
+#~ msgstr "ang palette ay dapat 32 bytes ang haba"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-06 14:55-0700\n"
+"POT-Creation-Date: 2018-09-12 16:24-0700\n"
 "PO-Revision-Date: 2018-08-14 11:01+0200\n"
 "Last-Translator: Pierrick Couturier <arofarn@arofarn.info>\n"
 "Language-Team: fr\n"
@@ -122,7 +122,7 @@ msgstr "certificat invalide"
 msgid "queue overflow"
 msgstr "dépassement de file"
 
-#: extmod/moduzlib.c:97
+#: extmod/moduzlib.c:98
 msgid "compression header"
 msgstr "entête de compression"
 
@@ -221,7 +221,7 @@ msgstr ""
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr "Appuyez sur une touche pour entrer sur REPL ou CTRL-D pour recharger."
 
-#: main.c:415
+#: main.c:416
 msgid "soft reboot\n"
 msgstr "redémarrage logiciel\n"
 
@@ -400,7 +400,7 @@ msgid "No TX pin"
 msgstr "Pas de broche TX"
 
 #: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c:170
-#: ports/nrf/common-hal/digitalio/DigitalInOut.c:153
+#: ports/nrf/common-hal/digitalio/DigitalInOut.c:142
 msgid "Cannot get pull while in output mode"
 msgstr "Ne peux être tirer ('pull') en mode 'output'"
 
@@ -1989,6 +1989,7 @@ msgid "buffer must be a bytes-like object"
 msgstr "le tampon doit être un objet bytes-like"
 
 #: shared-bindings/audioio/WaveFile.c:78
+#: shared-bindings/displayio/OnDiskBitmap.c:85
 msgid "file must be a file opened in byte mode"
 msgstr "le fichier doit être un fichier ouvert en mode byte"
 
@@ -2068,6 +2069,11 @@ msgstr ""
 msgid "row data must be a buffer"
 msgstr "les constantes doivent être des entiers"
 
+#: shared-bindings/displayio/ColorConverter.c:72
+#, fuzzy
+msgid "color should be an int"
+msgstr "La longueur doit être entière"
+
 #: shared-bindings/displayio/FourWire.c:55
 #: shared-bindings/displayio/FourWire.c:64
 msgid "displayio is a work in progress"
@@ -2105,20 +2111,19 @@ msgstr "le tampon doit être un objet bytes-like"
 msgid "palette_index should be an int"
 msgstr "Les valeurs du tableau doivent être des octets simples 'bytes'"
 
-#: shared-bindings/displayio/Sprite.c:45
+#: shared-bindings/displayio/Sprite.c:48
 #, fuzzy
 msgid "position must be 2-tuple"
 msgstr "stop doit être 1 ou 2"
 
-#: shared-bindings/displayio/Sprite.c:87
+#: shared-bindings/displayio/Sprite.c:97
 #, fuzzy
 msgid "unsupported bitmap type"
 msgstr "Débit non supporté"
 
-#: shared-bindings/displayio/Sprite.c:152
-#, fuzzy
-msgid "palette must be displayio.Palette"
-msgstr "la palette doit être longue de 32 octets"
+#: shared-bindings/displayio/Sprite.c:162
+msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+msgstr ""
 
 #: shared-bindings/gamepad/GamePad.c:100
 msgid "too many arguments"
@@ -2353,6 +2358,26 @@ msgstr ""
 msgid "Group full"
 msgstr ""
 
+#: shared-module/displayio/Group.c:48
+#, fuzzy
+msgid "Group empty"
+msgstr "vide"
+
+#: shared-module/displayio/OnDiskBitmap.c:49
+#, fuzzy
+msgid "Invalid BMP file"
+msgstr "Fichier invalide"
+
+#: shared-module/displayio/OnDiskBitmap.c:59
+#, c-format
+msgid "Only Windows format, uncompressed BMP supported %d"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c:64
+#, c-format
+msgid "Only true color (24 bpp or higher) BMP supported %x"
+msgstr ""
+
 #: shared-module/struct/__init__.c:39
 msgid "'S' and 'O' are not supported format types"
 msgstr "'S' et 'O' ne sont pas des types de format supportés"
@@ -2364,3 +2389,7 @@ msgstr "trop d'arguments fournis avec ce format"
 #, fuzzy
 #~ msgid "value_size must be power of two"
 #~ msgstr "'len' doit être un multiple de 4"
+
+#, fuzzy
+#~ msgid "palette must be displayio.Palette"
+#~ msgstr "la palette doit être longue de 32 octets"

--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -384,7 +384,9 @@ SRC_SHARED_MODULE = \
 	busio/OneWire.c \
 	displayio/__init__.c \
 	displayio/Bitmap.c \
+	displayio/ColorConverter.c \
 	displayio/Group.c \
+	displayio/OnDiskBitmap.c \
 	displayio/Palette.c \
 	displayio/Sprite.c \
 	gamepad/__init__.c \

--- a/shared-bindings/displayio/ColorConverter.c
+++ b/shared-bindings/displayio/ColorConverter.c
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "shared-bindings/displayio/ColorConverter.h"
+
+#include <stdint.h>
+
+#include "lib/utils/context_manager_helpers.h"
+#include "py/binary.h"
+#include "py/objproperty.h"
+#include "py/runtime.h"
+#include "shared-bindings/microcontroller/Pin.h"
+#include "shared-bindings/util.h"
+#include "supervisor/shared/translate.h"
+
+//| .. currentmodule:: displayio
+//|
+//| :class:`ColorConverter` -- Converts one color format to another
+//| =========================================================================================
+//|
+//| Converts one color format to another.
+//|
+//| .. warning:: This will be changed before 4.0.0. Consider it very experimental.
+//|
+//| .. class:: ColorConverter()
+//|
+//|   Create a ColorConverter object to convert color formats. Only supports RGB888 to RGB565
+//|   currently.
+//|
+// TODO(tannewt): Add support for other color formats.
+//|
+STATIC mp_obj_t displayio_colorconverter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
+    mp_arg_check_num(n_args, n_kw, 0, 0, true);
+
+    displayio_colorconverter_t *self = m_new_obj(displayio_colorconverter_t);
+    self->base.type = &displayio_colorconverter_type;
+    common_hal_displayio_colorconverter_construct(self);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+//|   .. method:: convert(color)
+//|
+STATIC mp_obj_t displayio_colorconverter_obj_convert(mp_obj_t self_in, mp_obj_t color_obj) {
+    displayio_colorconverter_t *self = MP_OBJ_TO_PTR(self_in);
+
+    mp_int_t color;
+    if (!mp_obj_get_int_maybe(color_obj, &color)) {
+        mp_raise_ValueError(translate("color should be an int"));
+    }
+    uint16_t output_color;
+    common_hal_displayio_colorconverter_convert(self, color, &output_color);
+    return MP_OBJ_NEW_SMALL_INT(output_color);
+}
+MP_DEFINE_CONST_FUN_OBJ_2(displayio_colorconverter_convert_obj, displayio_colorconverter_obj_convert);
+
+STATIC const mp_rom_map_elem_t displayio_colorconverter_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_convert), MP_ROM_PTR(&displayio_colorconverter_convert_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(displayio_colorconverter_locals_dict, displayio_colorconverter_locals_dict_table);
+
+const mp_obj_type_t displayio_colorconverter_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_ColorConverter,
+    .make_new = displayio_colorconverter_make_new,
+    .locals_dict = (mp_obj_dict_t*)&displayio_colorconverter_locals_dict,
+};

--- a/shared-bindings/displayio/ColorConverter.h
+++ b/shared-bindings/displayio/ColorConverter.h
@@ -24,20 +24,14 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
-#define MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
+#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_COLORCONVERTER_H
+#define MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_COLORCONVERTER_H
 
-#include "shared-module/displayio/Sprite.h"
+#include "shared-module/displayio/ColorConverter.h"
 
-extern const mp_obj_type_t displayio_sprite_type;
+extern const mp_obj_type_t displayio_colorconverter_type;
 
-void common_hal_displayio_sprite_construct(displayio_sprite_t *self, mp_obj_t bitmap,
-        mp_obj_t pixel_shader, uint16_t width, uint16_t height, uint16_t x, uint16_t y);
+void common_hal_displayio_colorconverter_construct(displayio_colorconverter_t* self);
+bool common_hal_displayio_colorconverter_convert(displayio_colorconverter_t *colorconverter, uint32_t input_color, uint16_t* output_color);
 
-void common_hal_displayio_sprite_get_position(displayio_sprite_t *self, int16_t* x, int16_t* y);
-void common_hal_displayio_sprite_set_position(displayio_sprite_t *self, int16_t x, int16_t y);
-
-mp_obj_t common_hal_displayio_sprite_get_pixel_shader(displayio_sprite_t *self);
-void common_hal_displayio_sprite_set_pixel_shader(displayio_sprite_t *self, mp_obj_t pixel_shader);
-
-#endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
+#endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_COLORCONVERTER_H

--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -83,8 +83,19 @@ STATIC mp_obj_t displayio_group_obj_append(mp_obj_t self_in, mp_obj_t layer) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_group_append_obj, displayio_group_obj_append);
 
+//|   .. method:: pop()
+//|
+//|     Remove the last item and return it.
+//|
+STATIC mp_obj_t displayio_group_obj_pop(mp_obj_t self_in) {
+    displayio_group_t *self = MP_OBJ_TO_PTR(self_in);
+    return common_hal_displayio_group_pop(self);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(displayio_group_pop_obj, displayio_group_obj_pop);
+
 STATIC const mp_rom_map_elem_t displayio_group_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_append), MP_ROM_PTR(&displayio_group_append_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pop), MP_ROM_PTR(&displayio_group_pop_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(displayio_group_locals_dict, displayio_group_locals_dict_table);
 

--- a/shared-bindings/displayio/Group.h
+++ b/shared-bindings/displayio/Group.h
@@ -34,5 +34,6 @@ extern const mp_obj_type_t displayio_group_type;
 
 void common_hal_displayio_group_construct(displayio_group_t* self, uint32_t max_size);
 void common_hal_displayio_group_append(displayio_group_t* self, mp_obj_t layer);
+mp_obj_t common_hal_displayio_group_pop(displayio_group_t* self);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_GROUP_H

--- a/shared-bindings/displayio/OnDiskBitmap.c
+++ b/shared-bindings/displayio/OnDiskBitmap.c
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "shared-bindings/displayio/OnDiskBitmap.h"
+
+#include <stdint.h>
+
+#include "py/runtime.h"
+#include "supervisor/shared/translate.h"
+
+//| .. currentmodule:: displayio
+//|
+//| :class:`OnDiskBitmap` -- Loads pixels straight from disk
+//| ==========================================================================
+//|
+//| Loads values straight from disk. This minimizes memory use but can lead to
+//| much slower pixel load times. These load times may result in frame tearing where only part of
+//| the image is visible.
+//|
+//| .. warning:: This will likely be changed before 4.0.0. Consider it very experimental.
+//|
+//| It's easiest to use on a board with a built in display such as the `Hallowing M0 Express
+//| <https://www.adafruit.com/product/3900>`_.
+//|
+//| .. code-block:: Python
+//|
+//|   import board
+//|   import displayio
+//|   import time
+//|   import pulseio
+//|
+//|   backlight = pulseio.PWMOut(board.TFT_BACKLIGHT)
+//|   splash = displayio.Group()
+//|   board.DISPLAY.show(splash)
+//|
+//|   with open("/sample.bmp", "rb") as f:
+//|       odb = displayio.OnDiskBitmap(f)
+//|       face = displayio.Sprite(odb, pixel_shader=displayio.ColorConverter(), position=(0,0))
+//|       splash.append(face)
+//|       # Wait for the image to load.
+//|       board.DISPLAY.wait_for_frame()
+//|
+//|       # Fade up the backlight
+//|       for i in range(100):
+//|           backlight.duty_cycle = i * (2 ** 15) // 100
+//|           time.sleep(0.01)
+//|
+//|       # Wait forever
+//|       while True:
+//|           pass
+//|
+//| .. class:: OnDiskBitmap(file)
+//|
+//|   Create an OnDiskBitmap object with the given file.
+//|
+//|   :param file file: The open bitmap file
+//|
+STATIC mp_obj_t displayio_ondiskbitmap_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
+    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+
+    if (!MP_OBJ_IS_TYPE(pos_args[0], &mp_type_fileio)) {
+        mp_raise_TypeError(translate("file must be a file opened in byte mode"));
+    }
+
+    displayio_ondiskbitmap_t *self = m_new_obj(displayio_ondiskbitmap_t);
+    self->base.type = &displayio_ondiskbitmap_type;
+    common_hal_displayio_ondiskbitmap_construct(self, MP_OBJ_TO_PTR(pos_args[0]));
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+STATIC const mp_rom_map_elem_t displayio_ondiskbitmap_locals_dict_table[] = {
+};
+STATIC MP_DEFINE_CONST_DICT(displayio_ondiskbitmap_locals_dict, displayio_ondiskbitmap_locals_dict_table);
+
+const mp_obj_type_t displayio_ondiskbitmap_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_OnDiskBitmap,
+    .make_new = displayio_ondiskbitmap_make_new,
+    .locals_dict = (mp_obj_dict_t*)&displayio_ondiskbitmap_locals_dict,
+};

--- a/shared-bindings/displayio/OnDiskBitmap.h
+++ b/shared-bindings/displayio/OnDiskBitmap.h
@@ -24,20 +24,17 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
-#define MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
+#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_ONDISKBITMAP_H
+#define MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_ONDISKBITMAP_H
 
-#include "shared-module/displayio/Sprite.h"
+#include "shared-module/displayio/OnDiskBitmap.h"
+#include "extmod/vfs_fat.h"
 
-extern const mp_obj_type_t displayio_sprite_type;
+extern const mp_obj_type_t displayio_ondiskbitmap_type;
 
-void common_hal_displayio_sprite_construct(displayio_sprite_t *self, mp_obj_t bitmap,
-        mp_obj_t pixel_shader, uint16_t width, uint16_t height, uint16_t x, uint16_t y);
+void common_hal_displayio_ondiskbitmap_construct(displayio_ondiskbitmap_t *self, pyb_file_obj_t* file);
 
-void common_hal_displayio_sprite_get_position(displayio_sprite_t *self, int16_t* x, int16_t* y);
-void common_hal_displayio_sprite_set_position(displayio_sprite_t *self, int16_t x, int16_t y);
+uint32_t common_hal_displayio_ondiskbitmap_get_pixel(displayio_ondiskbitmap_t *bitmap,
+    int16_t x, int16_t y);
 
-mp_obj_t common_hal_displayio_sprite_get_pixel_shader(displayio_sprite_t *self);
-void common_hal_displayio_sprite_set_pixel_shader(displayio_sprite_t *self, mp_obj_t pixel_shader);
-
-#endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
+#endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_ONDISKBITMAP_H

--- a/shared-bindings/displayio/__init__.c
+++ b/shared-bindings/displayio/__init__.c
@@ -31,8 +31,10 @@
 
 #include "shared-bindings/displayio/__init__.h"
 #include "shared-bindings/displayio/Bitmap.h"
+#include "shared-bindings/displayio/ColorConverter.h"
 #include "shared-bindings/displayio/FourWire.h"
 #include "shared-bindings/displayio/Group.h"
+#include "shared-bindings/displayio/OnDiskBitmap.h"
 #include "shared-bindings/displayio/Palette.h"
 #include "shared-bindings/displayio/Sprite.h"
 
@@ -57,8 +59,10 @@
 //|     :maxdepth: 3
 //|
 //|     Bitmap
+//|     ColorConverter
 //|     FourWire
 //|     Group
+//|     OnDiskBitmap
 //|     Palette
 //|     Sprite
 //|
@@ -68,7 +72,9 @@
 STATIC const mp_rom_map_elem_t displayio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_displayio) },
     { MP_ROM_QSTR(MP_QSTR_Bitmap), MP_ROM_PTR(&displayio_bitmap_type) },
+    { MP_ROM_QSTR(MP_QSTR_ColorConverter), MP_ROM_PTR(&displayio_colorconverter_type) },
     { MP_ROM_QSTR(MP_QSTR_Group), MP_ROM_PTR(&displayio_group_type) },
+    { MP_ROM_QSTR(MP_QSTR_OnDiskBitmap), MP_ROM_PTR(&displayio_ondiskbitmap_type) },
     { MP_ROM_QSTR(MP_QSTR_Palette), MP_ROM_PTR(&displayio_palette_type) },
     { MP_ROM_QSTR(MP_QSTR_Sprite), MP_ROM_PTR(&displayio_sprite_type) },
 

--- a/shared-module/displayio/ColorConverter.c
+++ b/shared-module/displayio/ColorConverter.c
@@ -24,20 +24,18 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
-#define MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
+#include "shared-bindings/displayio/ColorConverter.h"
 
-#include "shared-module/displayio/Sprite.h"
+void common_hal_displayio_colorconverter_construct(displayio_colorconverter_t* self) {
+}
 
-extern const mp_obj_type_t displayio_sprite_type;
-
-void common_hal_displayio_sprite_construct(displayio_sprite_t *self, mp_obj_t bitmap,
-        mp_obj_t pixel_shader, uint16_t width, uint16_t height, uint16_t x, uint16_t y);
-
-void common_hal_displayio_sprite_get_position(displayio_sprite_t *self, int16_t* x, int16_t* y);
-void common_hal_displayio_sprite_set_position(displayio_sprite_t *self, int16_t x, int16_t y);
-
-mp_obj_t common_hal_displayio_sprite_get_pixel_shader(displayio_sprite_t *self);
-void common_hal_displayio_sprite_set_pixel_shader(displayio_sprite_t *self, mp_obj_t pixel_shader);
-
-#endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
+bool common_hal_displayio_colorconverter_convert(displayio_colorconverter_t *self, uint32_t input_color, uint16_t* output_color) {
+    // TODO(tannewt): Validate the color input against the input format.
+    uint32_t r5 = (input_color >> 19);
+    uint32_t g6 = (input_color >> 10) & 0x3f;
+    uint32_t b5 = (input_color >> 3) & 0x1f;
+    uint32_t packed = r5 << 11 | g6 << 5 | b5;
+    // swap bytes
+    *output_color = __builtin_bswap16(packed);
+    return true;
+}

--- a/shared-module/displayio/ColorConverter.h
+++ b/shared-module/displayio/ColorConverter.h
@@ -24,20 +24,16 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
-#define MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
+#ifndef MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_COLORCONVERTER_H
+#define MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_COLORCONVERTER_H
 
-#include "shared-module/displayio/Sprite.h"
+#include <stdbool.h>
+#include <stdint.h>
 
-extern const mp_obj_type_t displayio_sprite_type;
+#include "py/obj.h"
 
-void common_hal_displayio_sprite_construct(displayio_sprite_t *self, mp_obj_t bitmap,
-        mp_obj_t pixel_shader, uint16_t width, uint16_t height, uint16_t x, uint16_t y);
+typedef struct {
+    mp_obj_base_t base;
+} displayio_colorconverter_t;
 
-void common_hal_displayio_sprite_get_position(displayio_sprite_t *self, int16_t* x, int16_t* y);
-void common_hal_displayio_sprite_set_position(displayio_sprite_t *self, int16_t x, int16_t y);
-
-mp_obj_t common_hal_displayio_sprite_get_pixel_shader(displayio_sprite_t *self);
-void common_hal_displayio_sprite_set_pixel_shader(displayio_sprite_t *self, mp_obj_t pixel_shader);
-
-#endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
+#endif // MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_COLORCONVERTER_H

--- a/shared-module/displayio/Group.c
+++ b/shared-module/displayio/Group.c
@@ -56,9 +56,10 @@ mp_obj_t common_hal_displayio_group_pop(displayio_group_t* self) {
 
 void displayio_group_construct(displayio_group_t* self, mp_obj_t* child_array, uint32_t max_size) {
     self->x = 0;
-    self->y = 1;
+    self->y = 0;
     self->children = child_array;
     self->max_size = max_size;
+    self->needs_refresh = false;
 }
 
 bool displayio_group_get_pixel(displayio_group_t *self, int16_t x, int16_t y, uint16_t* pixel) {

--- a/shared-module/displayio/Group.h
+++ b/shared-module/displayio/Group.h
@@ -39,6 +39,7 @@ typedef struct {
     uint16_t size;
     uint16_t max_size;
     mp_obj_t* children;
+    bool needs_refresh;
 } displayio_group_t;
 
 

--- a/shared-module/displayio/OnDiskBitmap.c
+++ b/shared-module/displayio/OnDiskBitmap.c
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "shared-bindings/displayio/OnDiskBitmap.h"
+
+#include <string.h>
+
+#include "py/mperrno.h"
+#include "py/runtime.h"
+
+static uint32_t read_word(uint16_t* bmp_header, uint16_t index) {
+    return bmp_header[index] | bmp_header[index + 1] << 16;
+}
+
+void common_hal_displayio_ondiskbitmap_construct(displayio_ondiskbitmap_t *self, pyb_file_obj_t* file) {
+    // Load the wave
+    self->file = file;
+    uint16_t bmp_header[24];
+    f_rewind(&self->file->fp);
+    UINT bytes_read;
+    if (f_read(&self->file->fp, bmp_header, 48, &bytes_read) != FR_OK) {
+        mp_raise_OSError(MP_EIO);
+    }
+    if (bytes_read != 48 ||
+        memcmp(bmp_header, "BM", 2) != 0) {
+        mp_raise_ValueError(translate("Invalid BMP file"));
+    }
+
+    // We can't cast because we're not aligned.
+    self->data_offset = read_word(bmp_header, 5);
+
+    uint32_t header_size = read_word(bmp_header, 7);
+    uint32_t compression = read_word(bmp_header, 15);
+    if (!(header_size == 12 || header_size == 40 || header_size == 108 || header_size == 124) ||
+        !(compression == 0)) {
+        mp_raise_ValueError_varg(translate("Only Windows format, uncompressed BMP supported %d"), header_size);
+    }
+    // TODO(tannewt): Support bitfield compressed colors since RGB565 can be produced by the GIMP.
+    uint16_t bits_per_pixel = bmp_header[14];
+    if (bits_per_pixel < 24) {
+        mp_raise_ValueError_varg(translate("Only true color (24 bpp or higher) BMP supported %x"), bits_per_pixel);
+    }
+    self->bytes_per_pixel = bits_per_pixel / 8;
+    self->width = read_word(bmp_header, 9);
+    self->height = read_word(bmp_header, 11);
+    uint32_t byte_width = self->width * self->bytes_per_pixel;
+    self->stride = byte_width;
+    // Rows are word aligned.
+    if (self->stride % 4 != 0) {
+        self->stride += 4 - self->stride % 4;
+    }
+}
+
+
+uint32_t common_hal_displayio_ondiskbitmap_get_pixel(displayio_ondiskbitmap_t *self,
+        int16_t x, int16_t y) {
+    if (x < 0 || x >= self->width || y < 0 || y >= self->height) {
+        return 0;
+    }
+    uint32_t location = self->data_offset + (self->height - y) * self->stride + x * self->bytes_per_pixel;
+    // We don't cache here because the underlying FS caches sectors.
+    f_lseek(&self->file->fp, location);
+    UINT bytes_read;
+    uint32_t pixel = 0;
+    uint32_t result = f_read(&self->file->fp, &pixel, self->bytes_per_pixel, &bytes_read);
+    if (result == FR_OK) {
+        return pixel;
+    }
+    return 0;
+}

--- a/shared-module/displayio/OnDiskBitmap.h
+++ b/shared-module/displayio/OnDiskBitmap.h
@@ -24,20 +24,24 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
-#define MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
+#ifndef MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_ONDISKBITMAP_H
+#define MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_ONDISKBITMAP_H
 
-#include "shared-module/displayio/Sprite.h"
+#include <stdbool.h>
+#include <stdint.h>
 
-extern const mp_obj_type_t displayio_sprite_type;
+#include "py/obj.h"
 
-void common_hal_displayio_sprite_construct(displayio_sprite_t *self, mp_obj_t bitmap,
-        mp_obj_t pixel_shader, uint16_t width, uint16_t height, uint16_t x, uint16_t y);
+#include "extmod/vfs_fat.h"
 
-void common_hal_displayio_sprite_get_position(displayio_sprite_t *self, int16_t* x, int16_t* y);
-void common_hal_displayio_sprite_set_position(displayio_sprite_t *self, int16_t x, int16_t y);
+typedef struct {
+    mp_obj_base_t base;
+    uint16_t width;
+    uint16_t height;
+    uint16_t data_offset;
+    uint16_t stride;
+    pyb_file_obj_t* file;
+    uint8_t bytes_per_pixel;
+} displayio_ondiskbitmap_t;
 
-mp_obj_t common_hal_displayio_sprite_get_pixel_shader(displayio_sprite_t *self);
-void common_hal_displayio_sprite_set_pixel_shader(displayio_sprite_t *self, mp_obj_t pixel_shader);
-
-#endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SPRITE_H
+#endif // MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_ONDISKBITMAP_H

--- a/shared-module/displayio/Sprite.h
+++ b/shared-module/displayio/Sprite.h
@@ -31,12 +31,11 @@
 #include <stdint.h>
 
 #include "py/obj.h"
-#include "shared-bindings/displayio/Palette.h"
 
 typedef struct {
     mp_obj_base_t base;
     mp_obj_t bitmap;
-    displayio_palette_t* palette;
+    mp_obj_t pixel_shader;
     uint16_t x;
     uint16_t y;
     uint16_t width;


### PR DESCRIPTION
Also, renamed Sprite's palette to pixel_shader so it can be
anything that produces colors based on values (including color values).
Added a ColorConverter that converts RGB888 (found in bitmaps) to
RGB565 for the display.

Fixes #1182