### PR TITLE
added timeout to input()

### DIFF
--- a/ports/atmel-samd/common-hal/supervisor/Runtime.c
+++ b/ports/atmel-samd/common-hal/supervisor/Runtime.c
@@ -32,3 +32,7 @@ bool common_hal_get_serial_connected(void) {
     return (bool) usb_connected();
 }
 
+bool common_hal_get_serial_bytes_available(void) {
+    return (bool) usb_bytes_available();
+}
+

--- a/ports/nrf/common-hal/supervisor/Runtime.c
+++ b/ports/nrf/common-hal/supervisor/Runtime.c
@@ -32,3 +32,7 @@ bool common_hal_get_serial_connected(void) {
     return (bool) serial_connected();
 }
 
+bool common_hal_get_serial_bytes_available(void) {
+  return (bool) serial_bytes_available();
+}
+

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -34,7 +34,6 @@
 #include "py/runtime.h"
 #include "py/builtin.h"
 #include "py/stream.h"
-#include "py/obj.h" /* For get_int */
 
 #include "supervisor/shared/translate.h"
 
@@ -234,41 +233,10 @@ MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin_hex_obj, mp_builtin_hex);
 #define mp_hal_readline readline
 #endif
 
-#include "usb.h"
-
 STATIC mp_obj_t mp_builtin_input(size_t n_args, const mp_obj_t *args) {
-    if (n_args >= 1) {
+    if (n_args == 1) {
         mp_obj_print(args[0], PRINT_STR);
     }
-    if (n_args == 2)
-      {
-	if (!mp_obj_is_true(args[1]))
-	  { /* If they pass 0 or False, return immediately if there's no text available */
-	    if (!usb_bytes_available())
-	      {
-		return mp_const_none;
-	      }
-	  }
-	else if (MP_OBJ_IS_INT(args[1]))
-	  {
-	    /* Timeout has been sent... check for USB input for that # of millis */
-	    mp_uint_t target = mp_hal_ticks_ms() + mp_obj_get_int(args[1]);
-	    bool bytesAvaliable = false;
-	    
-	    while (mp_hal_ticks_ms() < target)
-	      {
-		if (usb_bytes_available())
-		  {
-		    bytesAvaliable = true;
-		    break;
-		  }
-	      }
-	    if (!bytesAvaliable)
-	      return mp_const_none;
-	  }
-      }
-
-    
     vstr_t line;
     vstr_init(&line, 16);
     int ret = mp_hal_readline(&line, "");
@@ -280,7 +248,7 @@ STATIC mp_obj_t mp_builtin_input(size_t n_args, const mp_obj_t *args) {
     }
     return mp_obj_new_str_from_vstr(&mp_type_str, &line);
 }
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_input_obj, 0, 2, mp_builtin_input);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_input_obj, 0, 1, mp_builtin_input);
 
 #endif
 

--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -53,6 +53,12 @@
 //|
 //|         Returns the USB serial communication status (read-only).
 //|
+//|     .. attribute:: runtime.serial_bytes_available
+//|
+//|         Returns the whether any bytes are available to read
+//|         on the USB serial input.  Allows for polling to see whether
+//|         to call the built-in input() or wait. (read-only)
+//|
 //|     .. note::
 //|
 //|         SAMD: Will return ``True`` if the USB serial connection

--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -53,12 +53,6 @@
 //|
 //|         Returns the USB serial communication status (read-only).
 //|
-//|     .. attribute:: runtime.serial_bytes_available
-//|
-//|         Returns the whether any bytes are available to read
-//|         on the USB serial input.  Allows for polling to see whether
-//|         to call the built-in input() or wait. (read-only)
-//|
 //|     .. note::
 //|
 //|         SAMD: Will return ``True`` if the USB serial connection
@@ -86,7 +80,13 @@ const mp_obj_property_t supervisor_serial_connected_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
-/*Added to allow for polling of USB Console*/
+
+//|     .. attribute:: runtime.serial_bytes_available
+//|
+//|         Returns the whether any bytes are available to read
+//|         on the USB serial input.  Allows for polling to see whether
+//|         to call the built-in input() or wait. (read-only)
+//|
 STATIC mp_obj_t supervisor_get_serial_bytes_available(mp_obj_t self){
     if (!common_hal_get_serial_bytes_available()) {
         return mp_const_false;

--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -80,8 +80,28 @@ const mp_obj_property_t supervisor_serial_connected_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
+/*Added to allow for polling of USB Console*/
+STATIC mp_obj_t supervisor_get_serial_bytes_available(mp_obj_t self){
+    if (!common_hal_get_serial_bytes_available()) {
+        return mp_const_false;
+    }
+    else {
+        return mp_const_true;
+    }
+}
+MP_DEFINE_CONST_FUN_OBJ_1(supervisor_get_serial_bytes_available_obj, supervisor_get_serial_bytes_available);
+
+const mp_obj_property_t supervisor_serial_bytes_available_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&supervisor_get_serial_bytes_available_obj,
+              (mp_obj_t)&mp_const_none_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
+
+
 STATIC const mp_rom_map_elem_t supervisor_runtime_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_serial_connected), MP_ROM_PTR(&supervisor_serial_connected_obj) },
+    { MP_ROM_QSTR(MP_QSTR_serial_bytes_available), MP_ROM_PTR(&supervisor_serial_bytes_available_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(supervisor_runtime_locals_dict, supervisor_runtime_locals_dict_table);

--- a/shared-bindings/supervisor/Runtime.h
+++ b/shared-bindings/supervisor/Runtime.h
@@ -35,6 +35,8 @@ const mp_obj_type_t supervisor_runtime_type;
 
 bool common_hal_get_serial_connected(void);
 
+bool common_hal_get_serial_bytes_available(void);
+
 //TODO: placeholders for future functions
 //bool common_hal_get_repl_active(void);
 //bool common_hal_get_usb_enumerated(void);


### PR DESCRIPTION
I have added a second optional parameter to input() that acts like a timeout.

When input("PROMPT>", 10) is called with a timeout parameter, it will return in that number of milliseconds if there is no data available on the USB serial connection.  

This is **not** a true async serial read, it's just a workaround to let allow other tasks to occur while waiting for serial input to **start**.  Once a keystroke is read, the method drops into readline processing allowing for command history etc.  And whatever activity is in the loop will stop.

However, this bridges a gap that caused problems for one of our projects. We want to be able to take serial commands over USB to change colors as well as have modes like blink, "throb", "wheel", "cycle" etc. that run between changes.  

With this change, we can do that with the following code:

```
while True:
    inColor = input("", 0)
#result will be None if timeout occurs
    if (inColor is None):
        runMode()
        continue
    if (inColor.lower().startswith("red")):
        targetColor = (255, 0, 0)
        if (mode == "wheel"):
            mode="solid"
    elif (inColor.lower().startswith("green")):
        targetColor = (0, 255, 0)
        if (mode == "wheel"):
            mode="solid"
    elif (inColor.lower().startswith("yellow")):
        targetColor = (200, 200, 0)
        if (mode == "wheel"):
            mode="solid"
    elif (inColor.lower().startswith("@")):
        mode= inColor[1:]
    elif (inColor.startswith("#")):
        hexcode = inColor[1:]
        targetColor = hex2rgb(hexcode)
        if (mode == "wheel"):
            mode="solid"
    else:
        targetColor =(50, 50, 50)
        if (mode == "wheel"):
            mode="solid"
    pixels.fill(targetColor)
    pixels.show()
```
In our case, we used a timeout of zero, but any positive time works.  Sending False is identical to sending 0.  If the parameter is omitted, input() behaves exactly like the original.

An alternative approach (arguably better) would be to add a builtin function that is a passthrough to "usb_bytes_available()".  I'm fine with that approach as well.

I'd love any feedback.