### PR TITLE
3.x master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ compiler:
   - gcc
 git:
   depth: 1
+
+# Put a representative board from each port or sub-port near the top
+# to determine more quickly whether that port is going to build or not.
 env:
   - TRAVIS_TEST=unix
   - TRAVIS_TEST=docs
@@ -15,24 +18,25 @@ env:
   - TRAVIS_BOARD=trinket_m0
   - TRAVIS_BOARD=feather_m4_express
   - TRAVIS_BOARD=grandcentral_m4_express
-  - TRAVIS_BOARD=feather_radiofruit_zigbee
   - TRAVIS_BOARD=arduino_zero
   - TRAVIS_BOARD=circuitplayground_express_crickit
-  - TRAVIS_BOARD=feather_m0_basic
   - TRAVIS_BOARD=feather_m0_adalogger
-  - TRAVIS_BOARD=feather_m0_rfm69
-  - TRAVIS_BOARD=feather_m0_rfm9x
+  - TRAVIS_BOARD=feather_m0_basic
   - TRAVIS_BOARD=feather_m0_express
   - TRAVIS_BOARD=feather_m0_express_crickit
+  - TRAVIS_BOARD=feather_m0_rfm69
+  - TRAVIS_BOARD=feather_m0_rfm9x
+  - TRAVIS_BOARD=feather_nrf52832
+  - TRAVIS_BOARD=feather_nrf52840_express
+  - TRAVIS_BOARD=feather_radiofruit_zigbee
+  - TRAVIS_BOARD=gemma_m0
+  - TRAVIS_BOARD=hallowing_m0_express
   - TRAVIS_BOARD=itsybitsy_m0_express
   - TRAVIS_BOARD=itsybitsy_m4_express
   - TRAVIS_BOARD=metro_m0_express
   - TRAVIS_BOARD=metro_m4_express
+  - TRAVIS_BOARD=pca10059
   - TRAVIS_BOARD=pirkey_m0
-  - TRAVIS_BOARD=gemma_m0
-  - TRAVIS_BOARD=hallowing_m0_express
-  - TRAVIS_BOARD=feather_nrf52832
-  - TRAVIS_BOARD=feather_nrf52840_express
   - TRAVIS_BOARD=trellis_m4_express
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ before_script:
   - ([[ -z "$TRAVIS_BOARD" || $TRAVIS_BOARD = "feather_huzzah" ]] || (wget https://s3.amazonaws.com/adafruit-circuit-python/gcc-arm-embedded_7-2018q2-1~trusty1_amd64.deb && sudo dpkg -i gcc-arm-embedded*_amd64.deb))
 
   # For nrf builds
-  - ([[ $TRAVIS_BOARD != "feather_nrf52832" && $TRAVIS_BOARD != "feather_nrf52840_express" && $TRAVIS_BOARD != "pca10056" && TRAVIS_BOARD != "pca10059" ]] || sudo ports/nrf/drivers/bluetooth/download_ble_stack.sh)
+  - ([[ $TRAVIS_BOARD != "feather_nrf52832" && $TRAVIS_BOARD != "feather_nrf52840_express" && $TRAVIS_BOARD != "pca10056" && $TRAVIS_BOARD != "pca10059" ]] || sudo ports/nrf/drivers/bluetooth/download_ble_stack.sh)
   # For huzzah builds
   - if [[ $TRAVIS_BOARD = "feather_huzzah" ]]; then wget https://github.com/jepler/esp-open-sdk/releases/download/2018-06-10/xtensa-lx106-elf-standalone.tar.gz && tar xavf xtensa-lx106-elf-standalone.tar.gz; PATH=$(readlink -f xtensa-lx106-elf/bin):$PATH; fi
   # For coverage testing (upgrade is used to get latest urllib3 version)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - TRAVIS_BOARD=feather_huzzah
   - TRAVIS_BOARD=circuitplayground_express
   - TRAVIS_BOARD=pca10056
+  # The rest of the boards, in alphabetical order.
   - TRAVIS_BOARD=trinket_m0
   - TRAVIS_BOARD=feather_m4_express
   - TRAVIS_BOARD=grandcentral_m4_express
@@ -61,7 +62,7 @@ before_script:
   - ([[ -z "$TRAVIS_BOARD" || $TRAVIS_BOARD = "feather_huzzah" ]] || (wget https://s3.amazonaws.com/adafruit-circuit-python/gcc-arm-embedded_7-2018q2-1~trusty1_amd64.deb && sudo dpkg -i gcc-arm-embedded*_amd64.deb))
 
   # For nrf builds
-  - ([[ $TRAVIS_BOARD != "feather_nrf52832" && $TRAVIS_BOARD != "feather_nrf52840_express" && $TRAVIS_BOARD != "pca10056" ]] || sudo ports/nrf/drivers/bluetooth/download_ble_stack.sh)
+  - ([[ $TRAVIS_BOARD != "feather_nrf52832" && $TRAVIS_BOARD != "feather_nrf52840_express" && $TRAVIS_BOARD != "pca10056" && TRAVIS_BOARD != "pca10059" ]] || sudo ports/nrf/drivers/bluetooth/download_ble_stack.sh)
   # For huzzah builds
   - if [[ $TRAVIS_BOARD = "feather_huzzah" ]]; then wget https://github.com/jepler/esp-open-sdk/releases/download/2018-06-10/xtensa-lx106-elf-standalone.tar.gz && tar xavf xtensa-lx106-elf-standalone.tar.gz; PATH=$(readlink -f xtensa-lx106-elf/bin):$PATH; fi
   # For coverage testing (upgrade is used to get latest urllib3 version)

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-12 16:24-0700\n"
+"POT-Creation-Date: 2018-09-18 15:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -231,15 +231,15 @@ msgstr ""
 msgid "calibration is out of range"
 msgstr ""
 
-#: ports/atmel-samd/board_busses.c:39 ports/nrf/board_busses.c:39
+#: ports/atmel-samd/board_busses.c:59 ports/nrf/board_busses.c:39
 msgid "No default I2C bus"
 msgstr ""
 
-#: ports/atmel-samd/board_busses.c:64 ports/nrf/board_busses.c:64
+#: ports/atmel-samd/board_busses.c:85 ports/nrf/board_busses.c:64
 msgid "No default SPI bus"
 msgstr ""
 
-#: ports/atmel-samd/board_busses.c:91 ports/nrf/board_busses.c:91
+#: ports/atmel-samd/board_busses.c:112 ports/nrf/board_busses.c:91
 msgid "No default UART bus"
 msgstr ""
 
@@ -339,7 +339,7 @@ msgid "Cannot output both channels on the same pin"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c:173
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:186
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:189
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c:110
 msgid "All timers in use"
 msgstr ""
@@ -376,19 +376,19 @@ msgstr ""
 msgid "tx and rx cannot both be None"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c:139
+#: ports/atmel-samd/common-hal/busio/UART.c:145
 msgid "Failed to allocate RX buffer"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c:147
+#: ports/atmel-samd/common-hal/busio/UART.c:153
 msgid "Could not initialize UART"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c:234
+#: ports/atmel-samd/common-hal/busio/UART.c:240
 msgid "No RX pin"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c:288
+#: ports/atmel-samd/common-hal/busio/UART.c:294
 msgid "No TX pin"
 msgstr ""
 
@@ -403,12 +403,12 @@ msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:120
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:366
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:369
 #: ports/nrf/common-hal/pulseio/PWMOut.c:227
 msgid "Invalid PWM frequency"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:184
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:187
 msgid "All timers for this pin are in use"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:86
+#: ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr ""
 
@@ -1993,11 +1993,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr ""
 
-#: shared-bindings/busio/UART.c:98
+#: shared-bindings/busio/UART.c:102
 msgid "bits must be 7, 8 or 9"
 msgstr ""
 
-#: shared-bindings/busio/UART.c:110
+#: shared-bindings/busio/UART.c:114
 msgid "stop must be 1 or 2"
 msgstr ""
 

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-18 15:38-0400\n"
+"POT-Creation-Date: 2018-09-18 22:20-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -689,7 +689,7 @@ msgstr ""
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:90
+#: ports/nrf/common-hal/busio/UART.c:86 ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr ""
 

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-18 15:38-0400\n"
+"POT-Creation-Date: 2018-09-18 22:20-0400\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: Sebastian Plamauer\n"
 "Language-Team: \n"
@@ -698,7 +698,7 @@ msgstr ""
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:90
+#: ports/nrf/common-hal/busio/UART.c:86 ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr ""
 

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-12 16:24-0700\n"
+"POT-Creation-Date: 2018-09-18 15:38-0400\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: Sebastian Plamauer\n"
 "Language-Team: \n"
@@ -240,15 +240,15 @@ msgstr "Kalibrierung ist Schreibgeschützt"
 msgid "calibration is out of range"
 msgstr "Kalibrierung ist außerhalb der Reichweite"
 
-#: ports/atmel-samd/board_busses.c:39 ports/nrf/board_busses.c:39
+#: ports/atmel-samd/board_busses.c:59 ports/nrf/board_busses.c:39
 msgid "No default I2C bus"
 msgstr "Kein Standard I2C Bus"
 
-#: ports/atmel-samd/board_busses.c:64 ports/nrf/board_busses.c:64
+#: ports/atmel-samd/board_busses.c:85 ports/nrf/board_busses.c:64
 msgid "No default SPI bus"
 msgstr "Kein Standard SPI Bus"
 
-#: ports/atmel-samd/board_busses.c:91 ports/nrf/board_busses.c:91
+#: ports/atmel-samd/board_busses.c:112 ports/nrf/board_busses.c:91
 msgid "No default UART bus"
 msgstr "Kein Standard UART Bus"
 
@@ -348,7 +348,7 @@ msgid "Cannot output both channels on the same pin"
 msgstr "Kann nicht beite Kanäle auf dem gleichen Pin ausgeben"
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c:173
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:186
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:189
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c:110
 msgid "All timers in use"
 msgstr "Alle timer werden benutzt"
@@ -385,19 +385,19 @@ msgstr "bytes mit merh als 8 bits werden nicht unterstützt"
 msgid "tx and rx cannot both be None"
 msgstr "tx und rx können nicht beide None sein"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:139
+#: ports/atmel-samd/common-hal/busio/UART.c:145
 msgid "Failed to allocate RX buffer"
 msgstr "Konnte keinen RX Buffer allozieren"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:147
+#: ports/atmel-samd/common-hal/busio/UART.c:153
 msgid "Could not initialize UART"
 msgstr "Konnte UART nicht initialisieren"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:234
+#: ports/atmel-samd/common-hal/busio/UART.c:240
 msgid "No RX pin"
 msgstr "Kein RX Pin"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:288
+#: ports/atmel-samd/common-hal/busio/UART.c:294
 msgid "No TX pin"
 msgstr "Kein TX Pin"
 
@@ -412,12 +412,12 @@ msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr "Reset zum bootloader nicht möglich da bootloader nicht vorhanden"
 
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:120
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:366
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:369
 #: ports/nrf/common-hal/pulseio/PWMOut.c:227
 msgid "Invalid PWM frequency"
 msgstr "Ungültige PWM Frequenz"
 
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:184
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:187
 msgid "All timers for this pin are in use"
 msgstr "Alle timer für diesen Pin werden benutzt"
 
@@ -698,7 +698,7 @@ msgstr ""
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:86
+#: ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr ""
 
@@ -2002,11 +2002,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr ""
 
-#: shared-bindings/busio/UART.c:98
+#: shared-bindings/busio/UART.c:102
 msgid "bits must be 7, 8 or 9"
 msgstr ""
 
-#: shared-bindings/busio/UART.c:110
+#: shared-bindings/busio/UART.c:114
 msgid "stop must be 1 or 2"
 msgstr ""
 

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-18 15:38-0400\n"
+"POT-Creation-Date: 2018-09-18 22:20-0400\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -689,7 +689,7 @@ msgstr ""
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:90
+#: ports/nrf/common-hal/busio/UART.c:86 ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr ""
 

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-12 16:24-0700\n"
+"POT-Creation-Date: 2018-09-18 15:38-0400\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -231,15 +231,15 @@ msgstr ""
 msgid "calibration is out of range"
 msgstr ""
 
-#: ports/atmel-samd/board_busses.c:39 ports/nrf/board_busses.c:39
+#: ports/atmel-samd/board_busses.c:59 ports/nrf/board_busses.c:39
 msgid "No default I2C bus"
 msgstr ""
 
-#: ports/atmel-samd/board_busses.c:64 ports/nrf/board_busses.c:64
+#: ports/atmel-samd/board_busses.c:85 ports/nrf/board_busses.c:64
 msgid "No default SPI bus"
 msgstr ""
 
-#: ports/atmel-samd/board_busses.c:91 ports/nrf/board_busses.c:91
+#: ports/atmel-samd/board_busses.c:112 ports/nrf/board_busses.c:91
 msgid "No default UART bus"
 msgstr ""
 
@@ -339,7 +339,7 @@ msgid "Cannot output both channels on the same pin"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c:173
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:186
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:189
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c:110
 msgid "All timers in use"
 msgstr ""
@@ -376,19 +376,19 @@ msgstr ""
 msgid "tx and rx cannot both be None"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c:139
+#: ports/atmel-samd/common-hal/busio/UART.c:145
 msgid "Failed to allocate RX buffer"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c:147
+#: ports/atmel-samd/common-hal/busio/UART.c:153
 msgid "Could not initialize UART"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c:234
+#: ports/atmel-samd/common-hal/busio/UART.c:240
 msgid "No RX pin"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c:288
+#: ports/atmel-samd/common-hal/busio/UART.c:294
 msgid "No TX pin"
 msgstr ""
 
@@ -403,12 +403,12 @@ msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:120
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:366
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:369
 #: ports/nrf/common-hal/pulseio/PWMOut.c:227
 msgid "Invalid PWM frequency"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:184
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:187
 msgid "All timers for this pin are in use"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:86
+#: ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr ""
 
@@ -1993,11 +1993,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr ""
 
-#: shared-bindings/busio/UART.c:98
+#: shared-bindings/busio/UART.c:102
 msgid "bits must be 7, 8 or 9"
 msgstr ""
 
-#: shared-bindings/busio/UART.c:110
+#: shared-bindings/busio/UART.c:114
 msgid "stop must be 1 or 2"
 msgstr ""
 

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-12 16:24-0700\n"
+"POT-Creation-Date: 2018-09-18 15:38-0400\n"
 "PO-Revision-Date: 2018-08-24 22:56-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -246,15 +246,15 @@ msgstr ""
 msgid "calibration is out of range"
 msgstr ""
 
-#: ports/atmel-samd/board_busses.c:39 ports/nrf/board_busses.c:39
+#: ports/atmel-samd/board_busses.c:59 ports/nrf/board_busses.c:39
 msgid "No default I2C bus"
 msgstr ""
 
-#: ports/atmel-samd/board_busses.c:64 ports/nrf/board_busses.c:64
+#: ports/atmel-samd/board_busses.c:85 ports/nrf/board_busses.c:64
 msgid "No default SPI bus"
 msgstr ""
 
-#: ports/atmel-samd/board_busses.c:91 ports/nrf/board_busses.c:91
+#: ports/atmel-samd/board_busses.c:112 ports/nrf/board_busses.c:91
 msgid "No default UART bus"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgid "Cannot output both channels on the same pin"
 msgstr "No es posible utilizar el mismo pin para ambos canales"
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c:173
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:186
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:189
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c:110
 msgid "All timers in use"
 msgstr "Todos los timers estan siendo utilizados"
@@ -392,19 +392,19 @@ msgstr "bytes > 8 bits no son soportados"
 msgid "tx and rx cannot both be None"
 msgstr "tx y rx no pueden ser ambos None"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:139
+#: ports/atmel-samd/common-hal/busio/UART.c:145
 msgid "Failed to allocate RX buffer"
 msgstr "Fallo la asignación del buffer RX"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:147
+#: ports/atmel-samd/common-hal/busio/UART.c:153
 msgid "Could not initialize UART"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c:234
+#: ports/atmel-samd/common-hal/busio/UART.c:240
 msgid "No RX pin"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c:288
+#: ports/atmel-samd/common-hal/busio/UART.c:294
 msgid "No TX pin"
 msgstr ""
 
@@ -419,12 +419,12 @@ msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:120
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:366
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:369
 #: ports/nrf/common-hal/pulseio/PWMOut.c:227
 msgid "Invalid PWM frequency"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:184
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:187
 msgid "All timers for this pin are in use"
 msgstr "Todos los timers para este pin están siendo utilizado"
 
@@ -707,7 +707,7 @@ msgstr ""
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:86
+#: ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr ""
 
@@ -2038,11 +2038,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr ""
 
-#: shared-bindings/busio/UART.c:98
+#: shared-bindings/busio/UART.c:102
 msgid "bits must be 7, 8 or 9"
 msgstr ""
 
-#: shared-bindings/busio/UART.c:110
+#: shared-bindings/busio/UART.c:114
 msgid "stop must be 1 or 2"
 msgstr ""
 

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-18 15:38-0400\n"
+"POT-Creation-Date: 2018-09-18 22:20-0400\n"
 "PO-Revision-Date: 2018-08-24 22:56-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -707,7 +707,7 @@ msgstr ""
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:90
+#: ports/nrf/common-hal/busio/UART.c:86 ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr ""
 

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-12 16:24-0700\n"
+"POT-Creation-Date: 2018-09-18 15:38-0400\n"
 "PO-Revision-Date: 2018-08-30 23:04-0700\n"
 "Last-Translator: Timothy <me@timothygarcia.ca>\n"
 "Language-Team: fil\n"
@@ -243,15 +243,15 @@ msgstr "pagkakalibrate ay basahin lamang"
 msgid "calibration is out of range"
 msgstr "kalibrasion ay wala sa sakop"
 
-#: ports/atmel-samd/board_busses.c:39 ports/nrf/board_busses.c:39
+#: ports/atmel-samd/board_busses.c:59 ports/nrf/board_busses.c:39
 msgid "No default I2C bus"
 msgstr "Walang default na I2C bus"
 
-#: ports/atmel-samd/board_busses.c:64 ports/nrf/board_busses.c:64
+#: ports/atmel-samd/board_busses.c:85 ports/nrf/board_busses.c:64
 msgid "No default SPI bus"
 msgstr "Walang default SPI bus"
 
-#: ports/atmel-samd/board_busses.c:91 ports/nrf/board_busses.c:91
+#: ports/atmel-samd/board_busses.c:112 ports/nrf/board_busses.c:91
 msgid "No default UART bus"
 msgstr "Walang default UART bus"
 
@@ -351,7 +351,7 @@ msgid "Cannot output both channels on the same pin"
 msgstr "Hindi maaaring output ang mga parehong channel sa parehong pin"
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c:173
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:186
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:189
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c:110
 msgid "All timers in use"
 msgstr "Lahat ng timer ginagamit"
@@ -388,19 +388,19 @@ msgstr "hindi sinusuportahan ang bytes > 8 bits"
 msgid "tx and rx cannot both be None"
 msgstr "tx at rx hindi pwedeng parehas na None"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:139
+#: ports/atmel-samd/common-hal/busio/UART.c:145
 msgid "Failed to allocate RX buffer"
 msgstr "Nabigong ilaan ang RX buffer"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:147
+#: ports/atmel-samd/common-hal/busio/UART.c:153
 msgid "Could not initialize UART"
 msgstr "Hindi ma-initialize ang UART"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:234
+#: ports/atmel-samd/common-hal/busio/UART.c:240
 msgid "No RX pin"
 msgstr "Walang RX pin"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:288
+#: ports/atmel-samd/common-hal/busio/UART.c:294
 msgid "No TX pin"
 msgstr "Walang TX pin"
 
@@ -415,12 +415,12 @@ msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr "Hindi ma-reset sa bootloader dahil walang bootloader."
 
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:120
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:366
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:369
 #: ports/nrf/common-hal/pulseio/PWMOut.c:227
 msgid "Invalid PWM frequency"
 msgstr "Mali ang PWM frequency"
 
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:184
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:187
 msgid "All timers for this pin are in use"
 msgstr "Lahat ng timers para sa pin na ito ay ginagamit"
 
@@ -704,7 +704,7 @@ msgstr "Hindi supportado ang AnalogOut"
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:86
+#: ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr "hindi pa implemented ang busio.UART"
 
@@ -2031,11 +2031,11 @@ msgstr "aarehas na haba dapat ang buffer slices"
 msgid "Function requires lock."
 msgstr "Kailangan ng lock ang function."
 
-#: shared-bindings/busio/UART.c:98
+#: shared-bindings/busio/UART.c:102
 msgid "bits must be 7, 8 or 9"
 msgstr "bits ay dapat 7, 8 o 9"
 
-#: shared-bindings/busio/UART.c:110
+#: shared-bindings/busio/UART.c:114
 msgid "stop must be 1 or 2"
 msgstr "stop dapat 1 o 2"
 

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-18 15:38-0400\n"
+"POT-Creation-Date: 2018-09-18 22:20-0400\n"
 "PO-Revision-Date: 2018-08-30 23:04-0700\n"
 "Last-Translator: Timothy <me@timothygarcia.ca>\n"
 "Language-Team: fil\n"
@@ -704,7 +704,7 @@ msgstr "Hindi supportado ang AnalogOut"
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:90
+#: ports/nrf/common-hal/busio/UART.c:86 ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr "hindi pa implemented ang busio.UART"
 

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-18 15:38-0400\n"
+"POT-Creation-Date: 2018-09-18 22:20-0400\n"
 "PO-Revision-Date: 2018-08-14 11:01+0200\n"
 "Last-Translator: Pierrick Couturier <arofarn@arofarn.info>\n"
 "Language-Team: fr\n"
@@ -700,7 +700,7 @@ msgstr "AnalogOut non supporté"
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:90
+#: ports/nrf/common-hal/busio/UART.c:86 ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr "busio.UART pas encore implémenté"
 
@@ -2387,9 +2387,9 @@ msgid "too many arguments provided with the given format"
 msgstr "trop d'arguments fournis avec ce format"
 
 #, fuzzy
-#~ msgid "palette must be displayio.Palette"
-#~ msgstr "la palette doit être longue de 32 octets"
-
-#, fuzzy
 #~ msgid "value_size must be power of two"
 #~ msgstr "'len' doit être un multiple de 4"
+
+#, fuzzy
+#~ msgid "palette must be displayio.Palette"
+#~ msgstr "la palette doit être longue de 32 octets"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-12 16:24-0700\n"
+"POT-Creation-Date: 2018-09-18 15:38-0400\n"
 "PO-Revision-Date: 2018-08-14 11:01+0200\n"
 "Last-Translator: Pierrick Couturier <arofarn@arofarn.info>\n"
 "Language-Team: fr\n"
@@ -238,15 +238,15 @@ msgstr "la calibration est en lecture seule"
 msgid "calibration is out of range"
 msgstr "la calibration est hors gamme"
 
-#: ports/atmel-samd/board_busses.c:39 ports/nrf/board_busses.c:39
+#: ports/atmel-samd/board_busses.c:59 ports/nrf/board_busses.c:39
 msgid "No default I2C bus"
 msgstr "Pas de bus I2C par défaut"
 
-#: ports/atmel-samd/board_busses.c:64 ports/nrf/board_busses.c:64
+#: ports/atmel-samd/board_busses.c:85 ports/nrf/board_busses.c:64
 msgid "No default SPI bus"
 msgstr "Pas de bus SPI par défaut"
 
-#: ports/atmel-samd/board_busses.c:91 ports/nrf/board_busses.c:91
+#: ports/atmel-samd/board_busses.c:112 ports/nrf/board_busses.c:91
 msgid "No default UART bus"
 msgstr "Pas de bus UART par défaut"
 
@@ -346,7 +346,7 @@ msgid "Cannot output both channels on the same pin"
 msgstr "On ne peut mettre les deux canaux sur la même broche"
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c:173
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:186
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:189
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c:110
 msgid "All timers in use"
 msgstr "Tous les timers sont utilisés"
@@ -383,19 +383,19 @@ msgstr "octets > 8 bits non supporté"
 msgid "tx and rx cannot both be None"
 msgstr "TX et RX ne peuvent être None tous les deux"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:139
+#: ports/atmel-samd/common-hal/busio/UART.c:145
 msgid "Failed to allocate RX buffer"
 msgstr "Echec de l'allocation du tampon RX"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:147
+#: ports/atmel-samd/common-hal/busio/UART.c:153
 msgid "Could not initialize UART"
 msgstr "L'UART n'a pu être initialisé"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:234
+#: ports/atmel-samd/common-hal/busio/UART.c:240
 msgid "No RX pin"
 msgstr "Pas de broche RX"
 
-#: ports/atmel-samd/common-hal/busio/UART.c:288
+#: ports/atmel-samd/common-hal/busio/UART.c:294
 msgid "No TX pin"
 msgstr "Pas de broche TX"
 
@@ -411,12 +411,12 @@ msgstr ""
 "Ne peut être redémarré vers le bootloader car il n'y a pas de bootloader."
 
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c:120
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:366
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:369
 #: ports/nrf/common-hal/pulseio/PWMOut.c:227
 msgid "Invalid PWM frequency"
 msgstr "Fréquence de PWM invalide"
 
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:184
+#: ports/atmel-samd/common-hal/pulseio/PWMOut.c:187
 msgid "All timers for this pin are in use"
 msgstr "Tous les timers pour cette broche sont utilisés"
 
@@ -700,7 +700,7 @@ msgstr "AnalogOut non supporté"
 #: ports/nrf/common-hal/busio/UART.c:51 ports/nrf/common-hal/busio/UART.c:60
 #: ports/nrf/common-hal/busio/UART.c:66 ports/nrf/common-hal/busio/UART.c:71
 #: ports/nrf/common-hal/busio/UART.c:76 ports/nrf/common-hal/busio/UART.c:81
-#: ports/nrf/common-hal/busio/UART.c:86
+#: ports/nrf/common-hal/busio/UART.c:90
 msgid "busio.UART not yet implemented"
 msgstr "busio.UART pas encore implémenté"
 
@@ -2022,11 +2022,11 @@ msgstr "les slices de tampon doivent être de longueurs égales"
 msgid "Function requires lock."
 msgstr "La fonction nécessite un verrou."
 
-#: shared-bindings/busio/UART.c:98
+#: shared-bindings/busio/UART.c:102
 msgid "bits must be 7, 8 or 9"
 msgstr "bits doivent être 7, 8 ou 9"
 
-#: shared-bindings/busio/UART.c:110
+#: shared-bindings/busio/UART.c:114
 msgid "stop must be 1 or 2"
 msgstr "stop doit être 1 ou 2"
 
@@ -2387,9 +2387,9 @@ msgid "too many arguments provided with the given format"
 msgstr "trop d'arguments fournis avec ce format"
 
 #, fuzzy
-#~ msgid "value_size must be power of two"
-#~ msgstr "'len' doit être un multiple de 4"
-
-#, fuzzy
 #~ msgid "palette must be displayio.Palette"
 #~ msgstr "la palette doit être longue de 32 octets"
+
+#, fuzzy
+#~ msgid "value_size must be power of two"
+#~ msgstr "'len' doit être un multiple de 4"

--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -113,7 +113,7 @@ else
   # -finline-limit=80 or so is similar to not having it on.
   # There is no simple default value, though.
   ifdef INTERNAL_FLASH_FILESYSTEM
-    CFLAGS += -finline-limit=55
+    CFLAGS += -finline-limit=50
   endif
   ifdef CFLAGS_INLINE_LIMIT
     CFLAGS += -finline-limit=$(CFLAGS_INLINE_LIMIT)

--- a/ports/atmel-samd/board_busses.c
+++ b/ports/atmel-samd/board_busses.c
@@ -34,81 +34,96 @@
 #include "samd/pins.h"
 #include "py/runtime.h"
 
-#if !defined(DEFAULT_I2C_BUS_SDA) || !defined(DEFAULT_I2C_BUS_SCL)
-    STATIC mp_obj_t board_i2c(void) {
-        mp_raise_NotImplementedError(translate("No default I2C bus"));
-        return NULL;
+#define BOARD_I2C (defined(DEFAULT_I2C_BUS_SDA) && defined(DEFAULT_I2C_BUS_SCL))
+#define BOARD_SPI (defined(DEFAULT_SPI_BUS_SCK) && defined(DEFAULT_SPI_BUS_MISO) && defined(DEFAULT_SPI_BUS_MOSI))
+#define BOARD_UART (defined(DEFAULT_UART_BUS_RX) && defined(DEFAULT_UART_BUS_TX))
+
+#if BOARD_I2C
+STATIC mp_obj_t i2c_singleton = NULL;
+
+STATIC mp_obj_t board_i2c(void) {
+
+    if (i2c_singleton == NULL) {
+        busio_i2c_obj_t *self = m_new_obj(busio_i2c_obj_t);
+        self->base.type = &busio_i2c_type;
+
+        assert_pin_free(DEFAULT_I2C_BUS_SDA);
+        assert_pin_free(DEFAULT_I2C_BUS_SCL);
+        common_hal_busio_i2c_construct(self, DEFAULT_I2C_BUS_SCL, DEFAULT_I2C_BUS_SDA, 400000, 0);
+        i2c_singleton = (mp_obj_t)self;
     }
+    return i2c_singleton;
+}
 #else
-    STATIC mp_obj_t i2c_singleton = NULL;
-
-    STATIC mp_obj_t board_i2c(void) {
-
-        if (i2c_singleton == NULL) {
-            busio_i2c_obj_t *self = m_new_obj(busio_i2c_obj_t);
-            self->base.type = &busio_i2c_type;
-
-            assert_pin_free(DEFAULT_I2C_BUS_SDA);
-            assert_pin_free(DEFAULT_I2C_BUS_SCL);
-            common_hal_busio_i2c_construct(self, DEFAULT_I2C_BUS_SCL, DEFAULT_I2C_BUS_SDA, 400000, 0);
-            i2c_singleton = (mp_obj_t)self;
-        }
-        return i2c_singleton;
-
-    }
+STATIC mp_obj_t board_i2c(void) {
+    mp_raise_NotImplementedError(translate("No default I2C bus"));
+    return NULL;
+}
 #endif
 MP_DEFINE_CONST_FUN_OBJ_0(board_i2c_obj, board_i2c);
 
-#if !defined(DEFAULT_SPI_BUS_SCK) || !defined(DEFAULT_SPI_BUS_MISO) || !defined(DEFAULT_SPI_BUS_MOSI)
-    STATIC mp_obj_t board_spi(void) {
-        mp_raise_NotImplementedError(translate("No default SPI bus"));
-        return NULL;
+#if BOARD_SPI
+STATIC mp_obj_t spi_singleton = NULL;
+
+STATIC mp_obj_t board_spi(void) {
+    if (spi_singleton == NULL) {
+        busio_spi_obj_t *self = m_new_obj(busio_spi_obj_t);
+        self->base.type = &busio_spi_type;
+        assert_pin_free(DEFAULT_SPI_BUS_SCK);
+        assert_pin_free(DEFAULT_SPI_BUS_MOSI);
+        assert_pin_free(DEFAULT_SPI_BUS_MISO);
+        const mcu_pin_obj_t* clock = MP_OBJ_TO_PTR(DEFAULT_SPI_BUS_SCK);
+        const mcu_pin_obj_t* mosi = MP_OBJ_TO_PTR(DEFAULT_SPI_BUS_MOSI);
+        const mcu_pin_obj_t* miso = MP_OBJ_TO_PTR(DEFAULT_SPI_BUS_MISO);
+        common_hal_busio_spi_construct(self, clock, mosi, miso);
+        spi_singleton = (mp_obj_t)self;
     }
+    return spi_singleton;
+}
 #else
-    STATIC mp_obj_t spi_singleton = NULL;
-
-    STATIC mp_obj_t board_spi(void) {
-
-        if (spi_singleton == NULL) {
-            busio_spi_obj_t *self = m_new_obj(busio_spi_obj_t);
-            self->base.type = &busio_spi_type;
-            assert_pin_free(DEFAULT_SPI_BUS_SCK);
-            assert_pin_free(DEFAULT_SPI_BUS_MOSI);
-            assert_pin_free(DEFAULT_SPI_BUS_MISO);
-            const mcu_pin_obj_t* clock = MP_OBJ_TO_PTR(DEFAULT_SPI_BUS_SCK);
-            const mcu_pin_obj_t* mosi = MP_OBJ_TO_PTR(DEFAULT_SPI_BUS_MOSI);
-            const mcu_pin_obj_t* miso = MP_OBJ_TO_PTR(DEFAULT_SPI_BUS_MISO);
-            common_hal_busio_spi_construct(self, clock, mosi, miso);
-            spi_singleton = (mp_obj_t)self;
-        }
-        return spi_singleton;
-    }
+STATIC mp_obj_t board_spi(void) {
+    mp_raise_NotImplementedError(translate("No default SPI bus"));
+    return NULL;
+}
 #endif
 MP_DEFINE_CONST_FUN_OBJ_0(board_spi_obj, board_spi);
 
-#if !defined(DEFAULT_UART_BUS_RX) || !defined(DEFAULT_UART_BUS_TX)
-    STATIC mp_obj_t board_uart(void) {
-        mp_raise_NotImplementedError(translate("No default UART bus"));
-        return NULL;
+#if BOARD_UART
+STATIC mp_obj_t uart_singleton = NULL;
+
+STATIC mp_obj_t board_uart(void) {
+    if (uart_singleton == NULL) {
+        busio_uart_obj_t *self = m_new_obj(busio_uart_obj_t);
+        self->base.type = &busio_uart_type;
+
+        assert_pin_free(DEFAULT_UART_BUS_RX);
+        assert_pin_free(DEFAULT_UART_BUS_TX);
+
+        const mcu_pin_obj_t* rx = MP_OBJ_TO_PTR(DEFAULT_UART_BUS_RX);
+        const mcu_pin_obj_t* tx = MP_OBJ_TO_PTR(DEFAULT_UART_BUS_TX);
+
+        common_hal_busio_uart_construct(self, tx, rx, 9600, 8, PARITY_NONE, 1, 1000, 64);
+        uart_singleton = (mp_obj_t)self;
     }
+    return uart_singleton;
+}
 #else
-    STATIC mp_obj_t uart_singleton = NULL;
-
-    STATIC mp_obj_t board_uart(void) {
-        if (uart_singleton == NULL) {
-            busio_uart_obj_t *self = m_new_obj(busio_uart_obj_t);
-            self->base.type = &busio_uart_type;
-
-            assert_pin_free(DEFAULT_UART_BUS_RX);
-            assert_pin_free(DEFAULT_UART_BUS_TX);
-
-            const mcu_pin_obj_t* rx = MP_OBJ_TO_PTR(DEFAULT_UART_BUS_RX);
-            const mcu_pin_obj_t* tx = MP_OBJ_TO_PTR(DEFAULT_UART_BUS_TX);
-
-            common_hal_busio_uart_construct(self, tx, rx, 9600, 8, PARITY_NONE, 1, 1000, 64);
-            uart_singleton = (mp_obj_t)self;
-        }
-        return uart_singleton;
-    }
+STATIC mp_obj_t board_uart(void) {
+    mp_raise_NotImplementedError(translate("No default UART bus"));
+    return NULL;
+}
 #endif
 MP_DEFINE_CONST_FUN_OBJ_0(board_uart_obj, board_uart);
+
+
+void reset_board_busses(void) {
+#if BOARD_I2C
+    i2c_singleton = NULL;
+#endif
+#if BOARD_SPI
+    spi_singleton = NULL;
+#endif
+#if BOARD_UART
+    uart_singleton = NULL;
+#endif
+}

--- a/ports/atmel-samd/board_busses.h
+++ b/ports/atmel-samd/board_busses.h
@@ -36,4 +36,6 @@ extern mp_obj_fun_builtin_fixed_t board_spi_obj;
 void board_uart(void);
 extern mp_obj_fun_builtin_fixed_t board_uart_obj;
 
+void reset_board_busses(void);
+
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_BOARD_BUSSES_H

--- a/ports/atmel-samd/boards/hallowing_m0_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/hallowing_m0_express/mpconfigboard.h
@@ -62,4 +62,4 @@
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1
 
-#define CIRCUITPY_DISPLAYIO
+#define CIRCUITPY_DISPLAYIO    (1)

--- a/ports/atmel-samd/common-hal/busio/UART.h
+++ b/ports/atmel-samd/common-hal/busio/UART.h
@@ -42,10 +42,6 @@ typedef struct {
     bool rx_error;
     uint32_t baudrate;
     uint32_t timeout_ms;
-    // Index of the oldest received character.
-    uint32_t buffer_start;
-    // Index of the next available spot to store a character.
-    uint32_t buffer_size;
     uint32_t buffer_length;
     uint8_t* buffer;
 } busio_uart_obj_t;

--- a/ports/atmel-samd/common-hal/neopixel_write/__init__.c
+++ b/ports/atmel-samd/common-hal/neopixel_write/__init__.c
@@ -109,16 +109,16 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
         asm("nop; nop;");
         #endif
         #ifdef SAMD51
-        delay_cycles(3);
+        delay_cycles(2);
         #endif
-        if(p & bitMask) {
+        if((p & bitMask) != 0) {
             // This is the high delay unique to a one bit.
             // For the SK6812 its 0.3us
             #ifdef SAMD21
             asm("nop; nop; nop; nop; nop; nop; nop;");
             #endif
             #ifdef SAMD51
-            delay_cycles(11);
+            delay_cycles(3);
             #endif
             *clr = pinMask;
         } else {
@@ -129,7 +129,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
             asm("nop; nop;");
             #endif
             #ifdef SAMD51
-            delay_cycles(3);
+            delay_cycles(2);
             #endif
         }
         if((bitMask >>= 1) != 0) {
@@ -140,7 +140,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
             asm("nop; nop; nop; nop; nop;");
             #endif
             #ifdef SAMD51
-            delay_cycles(20);
+            delay_cycles(4);
             #endif
         } else {
             if(ptr >= end) break;
@@ -151,7 +151,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t* digitalinout,
             // above operations take.
             // For the SK6812 its 0.6us +- 0.15us
             #ifdef SAMD51
-            delay_cycles(15);
+            delay_cycles(3);
             #endif
         }
     }

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -61,6 +61,7 @@
 #include "samd/external_interrupts.h"
 #include "samd/dma.h"
 #include "shared-bindings/rtc/__init__.h"
+#include "board_busses.h"
 #include "tick.h"
 #include "usb.h"
 
@@ -277,6 +278,8 @@ void reset_port(void) {
     reset_event_system();
 
     reset_all_pins();
+
+    reset_board_busses();
 
     // Output clocks for debugging.
     // not supported by SAMD51G; uncomment for SAMD51J or update for 51G

--- a/ports/atmel-samd/usb.c
+++ b/ports/atmel-samd/usb.c
@@ -288,7 +288,7 @@ void usb_write(const char* buffer, uint32_t len) {
         return;
     }
     uint8_t * output_buffer;
-    uint8_t output_len;
+    uint32_t output_len;
     while (len > 0) {
         while (usb_transmitting) {}
         output_buffer = (uint8_t *) buffer;

--- a/ports/esp8266/common-hal/busio/UART.c
+++ b/ports/esp8266/common-hal/busio/UART.c
@@ -138,6 +138,9 @@ uint32_t common_hal_busio_uart_rx_characters_available(busio_uart_obj_t *self) {
     return 0;
 }
 
+void common_hal_busio_uart_clear_rx_buffer(busio_uart_obj_t *self) {
+}
+
 bool common_hal_busio_uart_ready_to_tx(busio_uart_obj_t *self) {
     return true;
 }

--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -82,6 +82,10 @@ uint32_t common_hal_busio_uart_rx_characters_available(busio_uart_obj_t *self) {
     return 0;
 }
 
+void common_hal_busio_uart_clear_rx_buffer(busio_uart_obj_t *self) {
+    mp_raise_NotImplementedError("busio.UART not yet implemented");
+}
+
 bool common_hal_busio_uart_ready_to_tx(busio_uart_obj_t *self) {
     mp_raise_NotImplementedError(translate("busio.UART not yet implemented"));
     return false;

--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -83,7 +83,7 @@ uint32_t common_hal_busio_uart_rx_characters_available(busio_uart_obj_t *self) {
 }
 
 void common_hal_busio_uart_clear_rx_buffer(busio_uart_obj_t *self) {
-    mp_raise_NotImplementedError("busio.UART not yet implemented");
+    mp_raise_NotImplementedError(translate("busio.UART not yet implemented"));
 }
 
 bool common_hal_busio_uart_ready_to_tx(busio_uart_obj_t *self) {

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -67,7 +67,11 @@ extern const busio_uart_parity_obj_t busio_uart_parity_odd_obj;
 
 STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
     mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
-    busio_uart_obj_t *self = m_new_obj(busio_uart_obj_t);
+    // Always initially allocate the UART object within the long-lived heap.
+    // This is needed to avoid crashes with certain UART implementations which
+    // cannot accomodate being moved after creation. (See
+    // https://github.com/adafruit/circuitpython/issues/1056)
+    busio_uart_obj_t *self = m_new_ll_obj(busio_uart_obj_t);
     self->base.type = &busio_uart_type;
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
@@ -249,6 +253,36 @@ const mp_obj_property_t busio_uart_baudrate_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
+//|   .. attribute:: in_waiting
+//|
+//|     The number of bytes in the input buffer, available to be read
+//|
+STATIC mp_obj_t busio_uart_obj_get_in_waiting(mp_obj_t self_in) {
+    busio_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_uart_deinited(self));
+    return MP_OBJ_NEW_SMALL_INT(common_hal_busio_uart_rx_characters_available(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(busio_uart_get_in_waiting_obj, busio_uart_obj_get_in_waiting);
+
+const mp_obj_property_t busio_uart_in_waiting_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&busio_uart_get_in_waiting_obj,
+              (mp_obj_t)&mp_const_none_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
+
+//|   .. method:: reset_input_buffer()
+//|
+//|     Discard any unread characters in the input buffer.
+//|
+STATIC mp_obj_t busio_uart_obj_reset_input_buffer(mp_obj_t self_in) {
+    busio_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_busio_uart_deinited(self));
+    common_hal_busio_uart_clear_rx_buffer(self);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(busio_uart_reset_input_buffer_obj, busio_uart_obj_reset_input_buffer);
+
 //| .. class:: busio.UART.Parity
 //|
 //|     Enum-like class to define the parity used to verify correct data transfer.
@@ -303,8 +337,11 @@ STATIC const mp_rom_map_elem_t busio_uart_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&mp_stream_readinto_obj) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_write),    MP_ROM_PTR(&mp_stream_write_obj) },
 
+    { MP_OBJ_NEW_QSTR(MP_QSTR_reset_input_buffer), MP_ROM_PTR(&busio_uart_reset_input_buffer_obj) },
+
     // Properties
     { MP_ROM_QSTR(MP_QSTR_baudrate), MP_ROM_PTR(&busio_uart_baudrate_obj) },
+    { MP_ROM_QSTR(MP_QSTR_in_waiting), MP_ROM_PTR(&busio_uart_in_waiting_obj) },
 
     // Nested Enum-like Classes.
     { MP_ROM_QSTR(MP_QSTR_Parity),       MP_ROM_PTR(&busio_uart_parity_type) },

--- a/shared-bindings/busio/UART.h
+++ b/shared-bindings/busio/UART.h
@@ -60,6 +60,7 @@ extern void common_hal_busio_uart_set_baudrate(busio_uart_obj_t *self, uint32_t 
 
 
 extern uint32_t common_hal_busio_uart_rx_characters_available(busio_uart_obj_t *self);
+extern void common_hal_busio_uart_clear_rx_buffer(busio_uart_obj_t *self);
 extern bool common_hal_busio_uart_ready_to_tx(busio_uart_obj_t *self);
 
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_BUSIO_UART_H

--- a/tools/build_adafruit_bins.sh
+++ b/tools/build_adafruit_bins.sh
@@ -2,6 +2,7 @@ rm -rf ports/atmel-samd/build*
 rm -rf ports/esp8266/build*
 rm -rf ports/nrf/build*
 
+# Alphabetical.
 HW_BOARDS="\
 arduino_zero \
 circuitplayground_express \
@@ -16,18 +17,19 @@ feather_m0_rfm9x \
 feather_m4_express \
 feather_nrf52832 \
 feather_nrf52840_express \
-grandcentral_m4_express \
-pca10056 \
 feather_radiofruit_zigbee \
 gemma_m0 \
+grandcentral_m4_express \
 hallowing_m0_express \
 itsybitsy_m0_express \
 itsybitsy_m4_express \
 metro_m0_express \
 metro_m4_express \
+pca10056 \
+pca10059 \
 pirkey_m0 \
-trinket_m0 \
 trellis_m4_express \
+trinket_m0 \
 "
 ROSIE_SETUPS="rosie-ci"
 

--- a/tools/build_adafruit_bins.sh
+++ b/tools/build_adafruit_bins.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 rm -rf ports/atmel-samd/build*
 rm -rf ports/esp8266/build*
 rm -rf ports/nrf/build*
@@ -34,25 +36,25 @@ trinket_m0 \
 ROSIE_SETUPS="rosie-ci"
 
 PARALLEL="-j 5"
-if [ "$TRAVIS" == "true" ]; then
+if [[ "$TRAVIS" == "true" ]]; then
     PARALLEL="-j 2"
 fi
 
-if [ -z "$TRAVIS_BOARD" ]; then
+if [[ -z "$TRAVIS_BOARD" ]]; then
     boards=$HW_BOARDS
 else
     boards=$TRAVIS_BOARD
 fi
 
 version=`git describe --tags --exact-match`
-if [ $? -ne 0 ]; then
+if [[ $? -ne 0 ]]; then
     version=`date +%Y%m%d`-`git rev-parse --short HEAD`
 fi
 
 
-if [ "$TRAVIS" == "true" ]; then
+if [[ "$TRAVIS" == "true" ]]; then
     sha=$TRAVIS_COMMIT
-    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
        version=`date +%Y%m%d`-`echo $TRAVIS_PULL_REQUEST_SHA | cut -c1-7`
        sha=$TRAVIS_PULL_REQUEST_SHA
     fi
@@ -64,23 +66,18 @@ for board in $boards; do
     for language_file in $(ls locale/*.po); do
         language=$(basename -s .po $language_file)
         echo "Building $board for $language"
-        if [ $board == "feather_huzzah" ]; then
-            make $PARALLEL -C ports/esp8266 TRANSLATION=$language BOARD=feather_huzzah
+        if [[ $board == "feather_huzzah" ]]; then
+            make $PARALLEL -C ports/esp8266 TRANSLATION=$language BOARD=$board
             (( exit_status = exit_status || $? ))
             temp_filename=ports/esp8266/build/firmware-combined.bin
             extension=bin
-        elif [ $board == "feather_nrf52832" ]; then
-            make $PARALLEL -C ports/nrf TRANSLATION=$language BOARD=feather_nrf52832
+        elif [[ $board == "feather_nrf52832" ]]; then
+            make $PARALLEL -C ports/nrf TRANSLATION=$language BOARD=$board
             (( exit_status = exit_status || $? ))
             temp_filename=ports/nrf/build-$board-s132/firmware.bin
             extension=bin
-        elif [ $board == "feather_nrf52840_express" ]; then
-            make $PARALLEL -C ports/nrf TRANSLATION=$language BOARD=feather_nrf52840_express SD=s140
-            (( exit_status = exit_status || $? ))
-            temp_filename=ports/nrf/build-$board-s140/firmware.uf2
-            extension=uf2
-        elif [ $board == "pca10056" ]; then
-            make $PARALLEL -C ports/nrf TRANSLATION=$language BOARD=pca10056 SD=s140
+        elif [[ $board == "feather_nrf52840_express" || $board == "pca10056" || $board == "pca10059" ]]; then
+            make $PARALLEL -C ports/nrf TRANSLATION=$language BOARD=$board SD=s140
             (( exit_status = exit_status || $? ))
             temp_filename=ports/nrf/build-$board-s140/firmware.uf2
             extension=uf2
@@ -96,7 +93,7 @@ for board in $boards; do
         cp $temp_filename $final_filename
         (( exit_status = exit_status || $? ))
         # Only upload to Rosie if its a pull request.
-        if [ "$TRAVIS" == "true" ]; then
+        if [[ "$TRAVIS" == "true" ]]; then
             for rosie in $ROSIE_SETUPS; do
                 echo "Uploading to https://$rosie.ngrok.io/upload/$sha"
                 curl -F "file=@$final_filename" https://$rosie.ngrok.io/upload/$sha


### PR DESCRIPTION
- Merge latest 3.x (3.0.2) changes and fixes into master. This includes UART additions and fixes, PWM fixes, UART long-lived buffer, NeoPixel timing fixes.
- Add pca10059 as a board to build regularly.
- Reorganize board build lists.
- `make translate`