### PR TITLE
reset I2C and SPI on ctrl-D

### DIFF
--- a/ports/nrf/common-hal/busio/I2C.c
+++ b/ports/nrf/common-hal/busio/I2C.c
@@ -54,7 +54,11 @@ STATIC twim_peripheral_t twim_peripherals[] = {
 #endif
 };
 
-#define INST_NO 0
+void i2c_reset(void) {
+    for (size_t i = 0 ; i < MP_ARRAY_SIZE(twim_peripherals); i++) {
+        twim_peripherals[i].in_use = false;
+    }
+}
 
 static uint8_t twi_error_to_mp(const nrfx_err_t err) {
     switch (err) {

--- a/ports/nrf/common-hal/busio/I2C.h
+++ b/ports/nrf/common-hal/busio/I2C.h
@@ -45,4 +45,6 @@ typedef struct {
     uint8_t sda_pin_number;
 } busio_i2c_obj_t;
 
+void i2c_reset(void);
+
 #endif // MICROPY_INCLUDED_NRF_COMMON_HAL_BUSIO_I2C_H

--- a/ports/nrf/common-hal/busio/SPI.c
+++ b/ports/nrf/common-hal/busio/SPI.c
@@ -59,6 +59,12 @@ STATIC spim_peripheral_t spim_peripherals[] = {
 #endif
 };
 
+void spi_reset(void) {
+    for (size_t i = 0 ; i < MP_ARRAY_SIZE(spim_peripherals); i++) {
+        nrfx_spim_uninit(&spim_peripherals[i].spim);
+    }
+}
+
 // Convert frequency to clock-speed-dependent value
 static nrf_spim_frequency_t baudrate_to_spim_frequency(const uint32_t baudrate) {
     if (baudrate <= 125000) {

--- a/ports/nrf/common-hal/busio/SPI.h
+++ b/ports/nrf/common-hal/busio/SPI.h
@@ -45,4 +45,6 @@ typedef struct {
     uint8_t MISO_pin_number;
 } busio_spi_obj_t;
 
+void spi_reset(void);
+
 #endif // MICROPY_INCLUDED_NRF_COMMON_HAL_BUSIO_SPI_H

--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -34,6 +34,8 @@
 
 #include "shared-module/gamepad/__init__.h"
 #include "common-hal/microcontroller/Pin.h"
+#include "common-hal/busio/I2C.h"
+#include "common-hal/busio/SPI.h"
 #include "common-hal/pulseio/PWMOut.h"
 #include "tick.h"
 
@@ -72,11 +74,14 @@ safe_mode_t port_init(void) {
 }
 
 void reset_port(void) {
- #ifdef CIRCUITPY_GAMEPAD_TICKS
-     gamepad_reset();
- #endif
+#ifdef CIRCUITPY_GAMEPAD_TICKS
+    gamepad_reset();
+#endif
 
+    i2c_reset();
+    spi_reset();
     pwmout_reset();
+
     reset_all_pins();
 }
 


### PR DESCRIPTION
Peripheral-in-use status was not being reset on soft-reload. Fix for I2C and SPI. Will need to add further peripherals as they are added.

@jerryneedell Could you test? Thanks I did try and it seems to work.

(Workspace courtesy Amtrak)