### PR TITLE
utilize travis's seemingly undocumented submodules_depth option #1253

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: c
 compiler:
   - gcc
 git:
-  depth: 1
+  submodules_depth: 1
 
 # Put a representative board from each port or sub-port near the top
 # to determine more quickly whether that port is going to build or not.


### PR DESCRIPTION
pretty sure this will help with the depth, although it seems like it's likely time consuming due to the number of submodules. You could potentially clone them in parallel, or perhaps utilize travis's caching features.