### PR TITLE
.travis.yml: try to dice up parallelism differently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,36 +9,15 @@ git:
 # Put a representative board from each port or sub-port near the top
 # to determine more quickly whether that port is going to build or not.
 env:
-  - TRAVIS_TEST=unix
-  - TRAVIS_TEST=docs
-  - TRAVIS_TEST=translations
-  - TRAVIS_BOARD=feather_huzzah
-  - TRAVIS_BOARD=circuitplayground_express
-  - TRAVIS_BOARD=pca10056
-  # The rest of the boards, in alphabetical order.
-  - TRAVIS_BOARD=trinket_m0
-  - TRAVIS_BOARD=feather_m4_express
-  - TRAVIS_BOARD=grandcentral_m4_express
-  - TRAVIS_BOARD=arduino_zero
-  - TRAVIS_BOARD=circuitplayground_express_crickit
-  - TRAVIS_BOARD=feather_m0_adalogger
-  - TRAVIS_BOARD=feather_m0_basic
-  - TRAVIS_BOARD=feather_m0_express
-  - TRAVIS_BOARD=feather_m0_express_crickit
-  - TRAVIS_BOARD=feather_m0_rfm69
-  - TRAVIS_BOARD=feather_m0_rfm9x
-  - TRAVIS_BOARD=feather_nrf52832
-  - TRAVIS_BOARD=feather_nrf52840_express
-  - TRAVIS_BOARD=feather_radiofruit_zigbee
-  - TRAVIS_BOARD=gemma_m0
-  - TRAVIS_BOARD=hallowing_m0_express
-  - TRAVIS_BOARD=itsybitsy_m0_express
-  - TRAVIS_BOARD=itsybitsy_m4_express
-  - TRAVIS_BOARD=metro_m0_express
-  - TRAVIS_BOARD=metro_m4_express
-  - TRAVIS_BOARD=pca10059
-  - TRAVIS_BOARD=pirkey_m0
-  - TRAVIS_BOARD=trellis_m4_express
+  - TRAVIS_TESTS="unix docs translations"
+  - TRAVIS_BOARDS="feather_huzzah circuitplayground_express pca10056" TRAVIS_SDK=arm:nrf:esp8266
+  # Group nrf builds together..
+  - TRAVIS_BOARDS="pca10056 pca10059 feather_nrf52832 feather_nrf52840_express" TRAVIS_SDK=arm:nrf
+  # The rest of the M0/M4 boards, in arbitrary order.
+  - TRAVIS_BOARDS="metro_m0_express metro_m4_express pirkey_m0 trellis_m4_express trinket_m0" TRAVIS_SDK=arm
+  - TRAVIS_BOARDS="feather_radiofruit_zigbee gemma_m0 hallowing_m0_express itsybitsy_m0_express itsybitsy_m4_express" TRAVIS_SDK=arm
+  - TRAVIS_BOARDS="feather_m0_express_crickit feather_m0_rfm69 feather_m0_rfm9x feather_m4_express arduino_zero" TRAVIS_SDK=arm
+  - TRAVIS_BOARDS="circuitplayground_express_crickit feather_m0_adalogger feather_m0_basic feather_m0_express" TRAVIS_SDK=arm
 
 addons:
   artifacts:
@@ -57,21 +36,28 @@ notifications:
     on_error: always
 
 before_script:
+  - function var_search () { case "$1" in *$2*) true;; *) false;; esac; }
   - sudo dpkg --add-architecture i386
 
-  - ([[ -z "$TRAVIS_BOARD" || $TRAVIS_BOARD = "feather_huzzah" ]] || (wget https://s3.amazonaws.com/adafruit-circuit-python/gcc-arm-embedded_7-2018q2-1~trusty1_amd64.deb && sudo dpkg -i gcc-arm-embedded*_amd64.deb))
+  - (! var_search "${TRAVIS_SDK-}" arm || (wget https://s3.amazonaws.com/adafruit-circuit-python/gcc-arm-embedded_7-2018q2-1~trusty1_amd64.deb && sudo dpkg -i gcc-arm-embedded*_amd64.deb))
 
   # For nrf builds
-  - ([[ $TRAVIS_BOARD != "feather_nrf52832" && $TRAVIS_BOARD != "feather_nrf52840_express" && $TRAVIS_BOARD != "pca10056" && $TRAVIS_BOARD != "pca10059" ]] || sudo ports/nrf/drivers/bluetooth/download_ble_stack.sh)
+  - (! var_search "${TRAVIS_SDK-}" nrf || sudo ports/nrf/drivers/bluetooth/download_ble_stack.sh)
+
   # For huzzah builds
-  - if [[ $TRAVIS_BOARD = "feather_huzzah" ]]; then wget https://github.com/jepler/esp-open-sdk/releases/download/2018-06-10/xtensa-lx106-elf-standalone.tar.gz && tar xavf xtensa-lx106-elf-standalone.tar.gz; PATH=$(readlink -f xtensa-lx106-elf/bin):$PATH; fi
+  - (! var_search "${TRAVIS_SDK-}" esp8266 || (wget https://github.com/jepler/esp-open-sdk/releases/download/2018-06-10/xtensa-lx106-elf-standalone.tar.gz && tar xavf xtensa-lx106-elf-standalone.tar.gz))
+  - if var_search "${TRAVIS_SDK-}" esp8266 ; then PATH=$(readlink -f xtensa-lx106-elf/bin):$PATH; fi
+
   # For coverage testing (upgrade is used to get latest urllib3 version)
-  - ([[ -z "$TRAVIS_TEST" ]] || sudo apt-get install -y python3-pip)
-  - ([[ -z "$TRAVIS_TEST" ]] || sudo pip install --upgrade cpp-coveralls)
-  - ([[ $TRAVIS_TEST != "docs" ]] || sudo pip install 'Sphinx<1.8.0' sphinx-rtd-theme recommonmark)
-  - ([[ $TRAVIS_TEST != "translations" ]] || sudo pip3 install polib)
+  - ([[ -z "$TRAVIS_TESTS" ]] || sudo apt-get install -y python3-pip)
+  - ([[ -z "$TRAVIS_TESTS" ]] || sudo pip install --upgrade cpp-coveralls)
+  - (! var_search "${TRAVIS_TESTS-}" docs || sudo pip install 'Sphinx<1.8.0' sphinx-rtd-theme recommonmark)
+  - (! var_search "${TRAVIS_TESTS-}" translations || sudo pip3 install polib)
+
+  # report some good version numbers to the buil
   - gcc --version
-  - ([[ -z "$TRAVIS_BOARD" || $TRAVIS_BOARD = "feather_huzzah" ]] || arm-none-eabi-gcc --version)
+  - (! var_search "${TRAVIS_SDK-}" elf || arm-none-eabi-gcc --version)
+  - (! var_search "${TRAVIS_SDK-}" esp8266 || xtensa-lx106-elf-gcc --version)
   - python3 --version
 
 script:
@@ -81,13 +67,11 @@ script:
   - echo -en 'travis_fold:end:mpy-cross\\r'
 
   - echo 'Building Adafruit binaries' && echo -en 'travis_fold:start:adafruit-bins\\r'
-  - ([[ -z "$TRAVIS_BOARD" ]] || tools/build_adafruit_bins.sh)
+  - (for board in $TRAVIS_BOARDS; do TRAVIS_BOARD=$board tools/build_adafruit_bins.sh || exit $?; done)
   - echo -en 'travis_fold:end:adafruit-bins\\r'
 
   - echo 'Building unix' && echo -en 'travis_fold:start:unix\\r'
-  - ([[ $TRAVIS_TEST != "unix" ]] || make -C ports/unix deplibs -j2)
-  - ([[ $TRAVIS_TEST != "unix" ]] || make -C ports/unix -j2)
-  - ([[ $TRAVIS_TEST != "unix" ]] || make -C ports/unix coverage -j2)
+  - (! var_search "${TRAVIS_TESTS-}" unix || (make -C ports/unix deplibs -j2 && make -C ports/unix -j2 && make -C ports/unix coverage -j2))
   - echo -en 'travis_fold:end:unix\\r'
 
   # run tests without coverage info
@@ -96,27 +80,27 @@ script:
 
   # run tests with coverage info
   - echo 'Test all' && echo -en 'travis_fold:start:test_all\\r'
-  - ([[ $TRAVIS_TEST != "unix" ]] || (cd tests && MICROPY_CPYTHON3=python3.4 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1))
+  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.4 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1))
   - echo -en 'travis_fold:end:test_all\\r'
 
   - echo 'Test threads' && echo -en 'travis_fold:start:test_threads\\r'
-  - ([[ $TRAVIS_TEST != "unix" ]] || (cd tests && MICROPY_CPYTHON3=python3.4 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 -d thread))
+  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.4 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 -d thread))
   - echo -en 'travis_fold:end:test_threads\\r'
 
   - echo 'Testing with native' && echo -en 'travis_fold:start:test_native\\r'
-  - ([[ $TRAVIS_TEST != "unix" ]] || (cd tests && MICROPY_CPYTHON3=python3.4 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --emit native))
+  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.4 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --emit native))
   - echo -en 'travis_fold:end:test_native\\r'
 
   - (echo 'Testing with mpy' && echo -en 'travis_fold:start:test_mpy\\r')
-  - ([[ $TRAVIS_TEST != "unix" ]] || (cd tests && MICROPY_CPYTHON3=python3.4 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --via-mpy -d basics float))
+  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.4 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --via-mpy -d basics float))
   - echo -en 'travis_fold:end:test_mpy\\r'
 
   - (echo 'Building docs' && echo -en 'travis_fold:start:build_docs\\r')
-  - ([[ $TRAVIS_TEST != "docs" ]] || sphinx-build -E -W -b html . _build/html)
+  - (! var_search "${TRAVIS_TESTS-}" docs || sphinx-build -E -W -b html . _build/html)
   - echo -en 'travis_fold:end:build_docs\\r'
 
   - (echo 'Building translations' && echo -en 'travis_fold:start:build_translations\\r')
-  - ([[ $TRAVIS_TEST != "translations" ]] || make check-translate)
+  - (! var_search "${TRAVIS_TESTS-}" translations || make check-translate)
   - echo -en 'travis_fold:end:build_translations\\r'
 
   # run coveralls coverage analysis (try to, even if some builds/tests failed)


### PR DESCRIPTION
Building this PR: https://travis-ci.org/adafruit/circuitpython/builds/439447949
Comparable adafruit master branch build: https://travis-ci.org/adafruit/circuitpython/builds/439401711

| | Elapsed time | Total time |
| -- | -- | -- |
| master | 26m55s | 105m14s |
| this PR | 19m57s | 63m2 |
| improvement | 25% 6m58s | 40% 42m12s |

Potentially the tasks could be juggled a little more to lower the elapsed build time in this PR, the first 3 jobs take much less time than the last 4.

I'm not sure how to evaluate that this PR doesn't regress, other than looking carefully at the list of all TRAVIS_BOARDs.  Are rosie-ci and the "artifact" uploads ready to handle building multiple TRAVIS_BOARDs in one travis-ci sub-job?

Closes: #1254 
