### PR TITLE
Add support for MakerDiary nRF52840 MDK board

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ git:
 # that SDK is shortest and add it there.  In the case of major re-organizations,
 # just try to make the builds "about equal in run time"
 env:
-  - TRAVIS_TESTS="unix docs translations" TRAVIS_BOARDS="feather_huzzah circuitplayground_express pca10056 pca10059 feather_nrf52832 feather_nrf52840_express" TRAVIS_SDK=arm:nrf:esp8266
+  - TRAVIS_TESTS="unix docs translations" TRAVIS_BOARDS="feather_huzzah circuitplayground_express pca10056 pca10059 feather_nrf52832 feather_nrf52840_express makerdiary_nrf52840_mdk" TRAVIS_SDK=arm:nrf:esp8266
   - TRAVIS_BOARDS="metro_m0_express metro_m4_express pirkey_m0 trellis_m4_express trinket_m0" TRAVIS_SDK=arm
   - TRAVIS_BOARDS="feather_radiofruit_zigbee gemma_m0 hallowing_m0_express itsybitsy_m0_express itsybitsy_m4_express" TRAVIS_SDK=arm
   - TRAVIS_BOARDS="feather_m0_express_crickit feather_m0_rfm69 feather_m0_rfm9x feather_m4_express arduino_zero" TRAVIS_SDK=arm

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -300,16 +300,16 @@ sd: $(BUILD)/$(OUTPUT_FILENAME).hex
 else ifeq ($(FLASHER), pyocd)
 
 flash: $(BUILD)/$(OUTPUT_FILENAME).hex
-	pyocd-flashtool -t $(MCU_SUB_VARIANT) $< --sector_erase
-	pyocd-tool -t $(MCU_SUB_VARIANT) erase $(BOOT_SETTING_ADDR)
-	pyocd-tool -t $(MCU_SUB_VARIANT) write32 $(BOOT_SETTING_ADDR) 0x00000001
-	pyocd-tool -t $(MCU_SUB_VARIANT) reset
+	pyocd-flashtool -t nrf52 $< # --sector_erase
+	#pyocd-tool -t nrf52 erase $(BOOT_SETTING_ADDR)
+	#pyocd-tool -t nrf52 write32 $(BOOT_SETTING_ADDR) 0x00000001
+	#pyocd-tool -t nrf52 reset
 
 sd: $(BUILD)/$(OUTPUT_FILENAME).hex
-	pyocd-flashtool -t $(MCU_SUB_VARIANT) --chip_erase
-	pyocd-flashtool -t $(MCU_SUB_VARIANT) $(SOFTDEV_HEX)
-	pyocd-flashtool -t $(MCU_SUB_VARIANT) $< --sector_erase
-	pyocd-tool -t $(MCU_SUB_VARIANT) reset $(BOOT_SETTING_ADDR)
+	pyocd-flashtool -t nrf52 --chip_erase
+	pyocd-flashtool -t nrf52 $(SOFTDEV_HEX)
+	pyocd-flashtool -t nrf52 $< --sector_erase
+	pyocd-tool -t nrf52 reset $(BOOT_SETTING_ADDR)
 
 endif
 

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -300,16 +300,16 @@ sd: $(BUILD)/$(OUTPUT_FILENAME).hex
 else ifeq ($(FLASHER), pyocd)
 
 flash: $(BUILD)/$(OUTPUT_FILENAME).hex
-	pyocd-flashtool -t nrf52 $< # --sector_erase
-	#pyocd-tool -t nrf52 erase $(BOOT_SETTING_ADDR)
-	#pyocd-tool -t nrf52 write32 $(BOOT_SETTING_ADDR) 0x00000001
-	#pyocd-tool -t nrf52 reset
+	pyocd-flashtool -t $(MCU_VARIANT) $< --sector_erase
+	#pyocd-tool -t $(MCU_VARIANT) erase $(BOOT_SETTING_ADDR)
+	pyocd-tool -t $(MCU_VARIANT) write32 $(BOOT_SETTING_ADDR) 0x00000001
+	pyocd-tool -t $(MCU_VARIANT) reset
 
 sd: $(BUILD)/$(OUTPUT_FILENAME).hex
-	pyocd-flashtool -t nrf52 --chip_erase
-	pyocd-flashtool -t nrf52 $(SOFTDEV_HEX)
-	pyocd-flashtool -t nrf52 $< --sector_erase
-	pyocd-tool -t nrf52 reset $(BOOT_SETTING_ADDR)
+	pyocd-flashtool -t $(MCU_VARIANT) --chip_erase
+	pyocd-flashtool -t $(MCU_VARIANT) $(SOFTDEV_HEX)
+	pyocd-flashtool -t $(MCU_VARIANT) $< --sector_erase
+	pyocd-tool -t $(MCU_VARIANT) reset $(BOOT_SETTING_ADDR)
 
 endif
 

--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -39,6 +39,7 @@ the following links:
 * Adafruit [Feather nRF52](boards/feather_nrf52832/README.md): 512KB Flash, 64KB SRAM
 * Adafruit [Feather nRF52840](boards/feather_nrf52840_express/README.md): 1MB Flash, 256KB SRAM
 * Nordic PCA10056 see [Feather nRF52840](boards/pca10056/README.md)
+* MakerDiary NRF52840 MDK see [its README](boards/makerdiary_nrf52840_mdk/README.md)
 
 For all other board targets, see the generic notes below.
 
@@ -80,6 +81,7 @@ pca10040                 | s132                    | Peripheral and Scanner | [S
 pca10056                 | s140                    | Peripheral and Scanner | [Segger](#segger-targets)
 feather_nrf52832         | s132                    | Peripheral and Scanner | [UART DFU](#dfu-targets)
 feather_nrf52840_express | s140                    | Peripheral and Scanner | UF2 bootloader
+makerdiary_nrf52840_mdk  | s140                    | Peripheral and Scanner | pyocd or ARM mbed DAPLink
 
 ## Segger Targets
 

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk/README.md
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk/README.md
@@ -1,0 +1,181 @@
+# Setup
+
+## Installing CircuitPython submodules
+
+Before you can build, you will need to run the following commands once, which
+will install the submodules that are part of the CircuitPython ecosystem, and
+build the `mpy-cross` tool:
+
+```
+$ cd circuitpython
+$ git submodule update --init
+$ make -C mpy-cross
+```
+
+You then need to download the SD and Nordic SDK files via:
+
+> This script relies on `wget`, which must be available from the command line.
+
+```
+$ cd ports/nrf
+$ ./drivers/bluetooth/download_ble_stack.sh
+```
+
+## Note about bootloaders
+
+While most Adafruit devices come with (or can easily be flashed with) an
+Adafruit-provided bootloader (supporting niceties like UF2 flashing)
+
+### Install `nrfjprog`
+
+Before you can install the bootloader, you will first need to install the
+`nrfjprog` tool from Nordic Semiconductors for your operating system. The
+binary files can be downloaded via the following links:
+
+- [nRF5x toolset tar for Linux 32-bit v9.7.2](http://www.nordicsemi.com/eng/nordic/Products/nRF52832/nRF5x-Command-Line-Tools-Linux32/52619)
+- [nRF5x toolset tar for Linux 64-bit v9.7.2](http://www.nordicsemi.com/eng/nordic/Products/nRF52832/nRF5x-Command-Line-Tools-Linux64/51388)
+- [nRF5x toolset tar for OSX v9.7.2](http://www.nordicsemi.com/eng/nordic/Products/nRF52832/nRF5x-Command-Line-Tools-OSX/53406)
+- [nRF5x toolset installer for Windows v9.7.2](http://www.nordicsemi.com/eng/nordic/Products/nRF52832/nRF5x-Command-Line-Tools-Win32/48768)
+
+You will then need to add the `nrfjprog` folder to your system `PATH` variable
+so that it is available from the command line. The exact process for this is
+OS specific, but on a POSIX type system like OS X or Linux, you can
+temporarily add the location to your `PATH` environment variables as follows:
+
+```
+$ export PATH=$PATH:YOURPATHHERE/nRF5x-Command-Line-Tools_9_7_2_OSX/nrfjprog/
+```
+
+You can test this by running the following command:
+
+```
+$ nrfjprog --version
+nrfjprog version: 9.7.2
+JLinkARM.dll version: 6.20f
+```
+
+### Flash the USB CDC Bootloader with 'nrfjprog'
+
+> This operation only needs to be done once, and only on boards that don't
+  already have the serial bootloader installed.
+
+Firstly clone the [Adafruit_nRF52_Bootloader](https://github.com/adafruit/Adafruit_nRF52_Bootloader.git) and enter its directory
+
+```
+$ git clone https://github.com/adafruit/Adafruit_nRF52_Bootloader.git
+$ cd Adafruit_nRF52_Bootloader
+```
+
+Once `nrfjprog` is installed and available in `PATH` you can flash your
+board with the serial bootloader via the following command:
+
+```
+make BOARD=feather_nrf52840_express VERSION=latest flash
+```
+
+This should give you the following (or very similar) output, and you will see
+a DFU blinky pattern on one of the board LEDs:
+
+```
+$ make BOARD=pca10056 VERSION=latest flash
+Flashing: bin/pca10056/6.0.0r0/pca10056_bootloader_s140_6.0.0r0.hex
+nrfjprog  --program bin/pca10056/6.0.0r0/pca10056_bootloader_s140_6.0.0r0.hex --chiperase -f nrf52 --reset
+Parsing hex file.
+Erasing user available code and UICR flash areas.
+Applying system reset.
+Checking that the area to write is not protected.
+Programing device.
+Applying system reset.
+Run.
+```
+
+From this point onward, you can now use a simple serial port for firmware
+updates.
+
+Note: You can specify other version that are available in the directory `Adafruit_nRF52_Bootloader/bin/feather_nrf52840_express/` . The `VERSION=latest` will use the latest bootloader available.
+
+### IMPORTANT: Disable Mass Storage on PCA10056 J-Link
+
+The J-Link firmware on the PCA10056 implement USB Mass Storage, but this
+causes a known conflict with reliable USB CDC serial port communication. In
+order to use the serial bootloader, **you must disable MSD support on the
+Segger J-Link**!
+
+To disable mass storage support, run the `JLinkExe` (or equivalent) command,
+and send `MSDDisable`. (You can re-enable MSD support via `MSDEnable`):
+
+```
+$ JLinkExe
+SEGGER J-Link Commander V6.20f (Compiled Oct 13 2017 17:20:01)
+DLL version V6.20f, compiled Oct 13 2017 17:19:52
+
+Connecting to J-Link via USB...O.K.
+Firmware: J-Link OB-SAM3U128-V2-NordicSemi compiled Jul 24 2017 17:30:12
+Hardware version: V1.00
+S/N: 683947110
+VTref = 3.300V
+
+
+Type "connect" to establish a target connection, '?' for help
+J-Link>MSDDisable
+Probe configured successfully.
+J-Link>exit
+```
+
+## Building and Flashing CircuitPython
+
+### Installing `adafruit-nrfutil`
+
+run follow command to install [adafruit-nrfutil](https://github.com/adafruit/Adafruit_nRF52_nrfutil) from PyPi
+
+```
+$ pip3 install adafruit-nrfutil --user
+```
+
+### Flashing CircuitPython with USB CDC
+
+With the serial bootloader present on your board, you first need to force your
+board into DFU mode by holding down BUTTON1 and RESETTING the board (with
+BUTTON1 still pressed as you come out of reset).
+
+This will give you a **fast blinky DFU pattern** to indicate you are in DFU
+mode.
+
+You can **build and flash** a CircuitPython binary via the following command:
+
+```
+$ make V=1 SD=s140 SERIAL=/dev/tty.usbmodem1411 BOARD=feather52840 all dfu-gen dfu-flash
+```
+
+This should give you the following results:
+
+```
+$make V=1 BOARD=feather52840 SD=s140 SERIAL=/dev/tty.usbmodem1411 dfu-gen dfu-flash
+nrfutil dfu genpkg --sd-req 0xFFFE --dev-type 0x0052 --application build-feather52840-s140/firmware.hex build-feather52840-s140/dfu-package.zip
+Zip created at build-feather52840-s140/dfu-package.zip
+nrfutil --verbose dfu serial --package build-feather52840-s140/dfu-package.zip -p /dev/ttyACM1 -b 115200 --singlebank
+Upgrading target on /dev/ttyACM1 with DFU package /home/hathach/Dropbox/adafruit/circuitpython/ada_cp/ports/nrf/build-feather52840-s140/dfu-package.zip. Flow control is disabled, Single bank mode
+Starting DFU upgrade of type 4, SoftDevice size: 0, bootloader size: 0, application size: 199840
+Sending DFU start packet
+Sending DFU init packet
+Sending firmware file
+#########################################################################################################################################################################################################################################################################################################################################################################################################
+Activating new firmware
+
+DFU upgrade took 8.50606513023s
+Device programmed.
+```
+
+### Flashing CircuitPython with MSC UF2
+
+uf2 file is generated last by `all` target
+
+```
+$ make V=1 SD=s140 SERIAL=/dev/tty.usbmodem1411 BOARD=feather52840 all
+Create firmware.uf2
+../../tools/uf2/utils/uf2conv.py -f 0xADA52840 -c -o "build-feather52840-s140/firmware.uf2" "build-feather52840-s140/firmware.hex"
+Converting to uf2, output size: 392192, start address: 0x26000
+Wrote 392192 bytes to build-feather52840-s140/firmware.uf2.
+```
+
+Simply drag and drop firmware.uf2 to the MSC, the nrf52840 will blink fast and reset after done.

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk/README.md
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk/README.md
@@ -4,10 +4,12 @@ Refer to https://github.com/makerdiary/nrf52840-mdk or
 https://wiki.makerdiary.com/nrf52840-mdk/ for more details about the device.
 
 Notably, CircuitPython does not currently support QSPI external flash on NRF
-devices, so neither does this port. Don't store anything you care to read in
-Python on that giant 64MB flash device for now - the 64MB drive that shows up on
-your computer is actually part of the MSC driver provided by the DAPLink
-debugger. You'll still have access to 256KB of the onboard flash, however, for
+devices, so neither does this port - the 64Mb flash device is not used for
+anything. Also, don't confuse this with the 64MiB drive that shows up on your
+computer - it's actually part of the MSC driver provided by the DAPLink
+debugger, and is inaccessible at all from Python land (this drive is where you
+can copy `firmware.hex` if you'd prefer to flash that way as opposed to with
+`pyocd`. You'll still have access to 256KB of the onboard flash, however, for
 storing your Python files, cat pictures, or whatever.
 
 It's also interesting to note that all three LEDs and the "user button" on this

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk/board.c
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk/board.c
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "boards/board.h"
+#include "usb.h"
+
+void board_init(void) {
+    usb_init();
+}
+
+bool board_requests_safe_mode(void) {
+  return false;
+}
+
+void reset_board(void) {
+
+}

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk/mpconfigboard.h
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk/mpconfigboard.h
@@ -25,7 +25,7 @@
  * THE SOFTWARE.
  */
 
-#define FEATHER52840
+#define MAKERDIARYNRF52840MDK
 
 #define MICROPY_HW_BOARD_NAME       "MakerDiary nRF52840 MDK"
 #define MICROPY_HW_MCU_NAME         "nRF52840"

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk/mpconfigboard.h
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk/mpconfigboard.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Glenn Ruben Bakke
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#define FEATHER52840
+
+#define MICROPY_HW_BOARD_NAME       "MakerDiary nRF52840 MDK"
+#define MICROPY_HW_MCU_NAME         "nRF52840"
+#define MICROPY_PY_SYS_PLATFORM     "MakerDiary52840MDK"
+
+#define MICROPY_QSPI_DATA0          (&pin_P1_05)
+#define MICROPY_QSPI_DATA1          (&pin_P1_04)
+#define MICROPY_QSPI_DATA2          (&pin_P1_02)
+#define MICROPY_QSPI_DATA3          (&pin_P1_01)
+#define MICROPY_QSPI_SCK            (&pin_P1_03)
+#define MICROPY_QSPI_CS             (&pin_P1_06)
+
+#define CIRCUITPY_AUTORELOAD_DELAY_MS 500
+
+// If you change this, then make sure to update the linker scripts as well to
+// make sure you don't overwrite code
+#define PORT_HEAP_SIZE              (128 * 1024)
+// TODO #define CIRCUITPY_INTERNAL_NVM_SIZE 8192
+
+#define BOARD_FLASH_SIZE (FLASH_SIZE - 0x4000 - CIRCUITPY_INTERNAL_NVM_SIZE)
+
+// TODO #include "external_flash/devices.h"
+
+#define EXTERNAL_FLASH_DEVICE_COUNT 1
+// Datasheet for when this is implemented:
+// http://www.mxic.com.tw/Lists/Datasheet/Attachments/7428/MX25R6435F,%20Wide%20Range,%2064Mb,%20v1.4.pdf
+#define EXTERNAL_FLASH_DEVICES MX25R6435F
+
+#define EXTERNAL_FLASH_QSPI_DUAL
+
+// TODO include "external_flash/external_flash.h"
+
+#define BOARD_HAS_CRYSTAL 0
+
+#define DEFAULT_UART_BUS_RX         (&pin_P0_19)
+#define DEFAULT_UART_BUS_TX         (&pin_P0_20)

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk/mpconfigboard.mk
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk/mpconfigboard.mk
@@ -1,0 +1,16 @@
+MCU_SERIES = m4
+MCU_VARIANT = nrf52
+MCU_SUB_VARIANT = nrf52840
+MCU_CHIP = nrf52840
+SD ?= s140
+SOFTDEV_VERSION ?= 6.1.0
+
+BOOT_SETTING_ADDR = 0xFF000
+
+ifeq ($(SD),)
+	LD_FILE = boards/nrf52840_1M_256k.ld
+else
+	LD_FILE = boards/adafruit_$(MCU_SUB_VARIANT)_$(SD_LOWER)_v$(firstword $(subst ., ,$(SOFTDEV_VERSION))).ld
+endif
+
+NRF_DEFINES += -DNRF52840_XXAA -DNRF52840

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk/pins.c
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk/pins.c
@@ -1,0 +1,63 @@
+#include "shared-bindings/board/__init__.h"
+
+#include "board_busses.h"
+
+STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
+  { MP_ROM_QSTR(MP_QSTR_AIN0), MP_ROM_PTR(&pin_P0_02) },
+  { MP_ROM_QSTR(MP_QSTR_AIN1), MP_ROM_PTR(&pin_P0_03) },
+  { MP_ROM_QSTR(MP_QSTR_AIN2), MP_ROM_PTR(&pin_P0_04) },
+  { MP_ROM_QSTR(MP_QSTR_AIN3), MP_ROM_PTR(&pin_P0_05) },
+  { MP_ROM_QSTR(MP_QSTR_AIN4), MP_ROM_PTR(&pin_P0_28) },
+  { MP_ROM_QSTR(MP_QSTR_AIN5), MP_ROM_PTR(&pin_P0_29) },
+  { MP_ROM_QSTR(MP_QSTR_AIN6), MP_ROM_PTR(&pin_P0_30) },
+  { MP_ROM_QSTR(MP_QSTR_AIN7), MP_ROM_PTR(&pin_P0_31) },
+
+  { MP_ROM_QSTR(MP_QSTR_AREF), MP_ROM_PTR(&pin_P0_04) },
+  { MP_ROM_QSTR(MP_QSTR_VDIV), MP_ROM_PTR(&pin_P0_05) },
+
+  { MP_ROM_QSTR(MP_QSTR_NFC1), MP_ROM_PTR(&pin_P0_09) },
+  { MP_ROM_QSTR(MP_QSTR_NFC2), MP_ROM_PTR(&pin_P0_10) },
+
+  { MP_ROM_QSTR(MP_QSTR_P2), MP_ROM_PTR(&pin_P0_02) },
+  { MP_ROM_QSTR(MP_QSTR_P3), MP_ROM_PTR(&pin_P0_03) },
+  { MP_ROM_QSTR(MP_QSTR_P4), MP_ROM_PTR(&pin_P0_04) },
+  { MP_ROM_QSTR(MP_QSTR_P5), MP_ROM_PTR(&pin_P0_05) },
+  { MP_ROM_QSTR(MP_QSTR_P6), MP_ROM_PTR(&pin_P0_06) },
+  { MP_ROM_QSTR(MP_QSTR_P7), MP_ROM_PTR(&pin_P0_07) },
+  { MP_ROM_QSTR(MP_QSTR_P8), MP_ROM_PTR(&pin_P0_08) },
+  { MP_ROM_QSTR(MP_QSTR_P9), MP_ROM_PTR(&pin_P0_09) },
+  { MP_ROM_QSTR(MP_QSTR_P10), MP_ROM_PTR(&pin_P0_10) },
+  { MP_ROM_QSTR(MP_QSTR_P11), MP_ROM_PTR(&pin_P0_11) },
+  { MP_ROM_QSTR(MP_QSTR_P12), MP_ROM_PTR(&pin_P0_12) },
+  { MP_ROM_QSTR(MP_QSTR_P13), MP_ROM_PTR(&pin_P0_13) },
+  { MP_ROM_QSTR(MP_QSTR_P14), MP_ROM_PTR(&pin_P0_14) },
+  { MP_ROM_QSTR(MP_QSTR_P15), MP_ROM_PTR(&pin_P0_15) },
+  { MP_ROM_QSTR(MP_QSTR_P16), MP_ROM_PTR(&pin_P0_16) },
+  { MP_ROM_QSTR(MP_QSTR_P17), MP_ROM_PTR(&pin_P0_17) },
+  { MP_ROM_QSTR(MP_QSTR_P21), MP_ROM_PTR(&pin_P0_21) },
+  { MP_ROM_QSTR(MP_QSTR_P25), MP_ROM_PTR(&pin_P0_25) },
+  { MP_ROM_QSTR(MP_QSTR_P26), MP_ROM_PTR(&pin_P0_26) },
+  { MP_ROM_QSTR(MP_QSTR_P27), MP_ROM_PTR(&pin_P0_27) },
+  { MP_ROM_QSTR(MP_QSTR_P28), MP_ROM_PTR(&pin_P0_28) },
+  { MP_ROM_QSTR(MP_QSTR_P29), MP_ROM_PTR(&pin_P0_29) },
+  { MP_ROM_QSTR(MP_QSTR_P30), MP_ROM_PTR(&pin_P0_30) },
+  { MP_ROM_QSTR(MP_QSTR_P31), MP_ROM_PTR(&pin_P0_31) },
+
+  { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_P1_03) },
+  { MP_ROM_QSTR(MP_QSTR_CSN), MP_ROM_PTR(&pin_P1_06) },
+  { MP_ROM_QSTR(MP_QSTR_IO0), MP_ROM_PTR(&pin_P1_05) },
+  { MP_ROM_QSTR(MP_QSTR_IO1), MP_ROM_PTR(&pin_P1_04) },
+  { MP_ROM_QSTR(MP_QSTR_IO2), MP_ROM_PTR(&pin_P1_02) },
+  { MP_ROM_QSTR(MP_QSTR_IO3), MP_ROM_PTR(&pin_P1_01) },
+
+  { MP_ROM_QSTR(MP_QSTR_TXD), MP_ROM_PTR(&pin_P0_20) },
+  { MP_ROM_QSTR(MP_QSTR_RXD), MP_ROM_PTR(&pin_P0_19) },
+
+  { MP_ROM_QSTR(MP_QSTR_LED_RED), MP_ROM_PTR(&pin_P0_23) },
+  { MP_ROM_QSTR(MP_QSTR_LED_GREEN), MP_ROM_PTR(&pin_P0_22) },
+  { MP_ROM_QSTR(MP_QSTR_LED_BLUE), MP_ROM_PTR(&pin_P0_24) },
+
+  { MP_ROM_QSTR(MP_QSTR_USR_BTN), MP_ROM_PTR(&pin_P1_00) },
+};
+
+MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/tools/build_adafruit_bins.sh
+++ b/tools/build_adafruit_bins.sh
@@ -25,6 +25,7 @@ grandcentral_m4_express \
 hallowing_m0_express \
 itsybitsy_m0_express \
 itsybitsy_m4_express \
+makerdiary_nrf52840_mdk \
 metro_m0_express \
 metro_m4_express \
 pca10056 \
@@ -81,6 +82,11 @@ for board in $boards; do
             (( exit_status = exit_status || $? ))
             temp_filename=ports/nrf/build-$board-s140/firmware.uf2
             extension=uf2
+        elif [[ $board == "makerdiary_nrf52840_mdk" ]]; then
+            make $PARALLEL -C ports/nrf TRANSLATION=$language BOARD=$board SD=s140
+            (( exit_status = exit_status || $? ))
+            temp_filename=ports/nrf/build-$board-s140/firmware.hex
+            extension=hex
         else
             time make $PARALLEL -C ports/atmel-samd TRANSLATION=$language BOARD=$board
             (( exit_status = exit_status || $? ))


### PR DESCRIPTION
This uses the Feather nRF52840 tree as a base - haven't yet noticed any real issues aside from the 64Mb QSPI flash not being accessible (which makes sense given NRF port doesn't have external flash support at all yet, from what I can tell)

Documented the "weird" bits of this device at least to some level. It's definitely a unique beast - so far it looks like it's the only board in the NRF tree that flashes with `pyocd` (I entirely skipped flashing hex files over the DAPLink MSC, but it's allegedly supported, and it's the first piece of Micro or CircuitPython hardware to truly trip me up and teach me new electronics terms - turns out the LEDs and user button are wired "backwards" from all the other dev boards in my house :)

I expose ALL the pin names as seen in https://github.com/makerdiary/nrf52840-mdk/blob/master/docs/hardware/nrf52840-mdk-pinout-diagram-v1_0.pdf. Some of these may not entirely make sense to expose (like QSPI?) but for a first pass I decided to leave them in there, and we can trim if needed.