### PR TITLE
Add channels and bits_per_sample to audioio.WaveFile

### DIFF
--- a/shared-bindings/audioio/WaveFile.c
+++ b/shared-bindings/audioio/WaveFile.c
@@ -184,7 +184,7 @@ STATIC const mp_rom_map_elem_t audioio_wavefile_locals_dict_table[] = {
     // Properties
     { MP_ROM_QSTR(MP_QSTR_sample_rate), MP_ROM_PTR(&audioio_wavefile_sample_rate_obj) },
     { MP_ROM_QSTR(MP_QSTR_bits_per_sample), MP_ROM_PTR(&audioio_wavefile_bits_per_sample_obj) },
-    { MP_ROM_QSTR(MP_QSTR_channels), MP_ROM_PTR(&audioio_wavefile_channel_count_obj) },
+    { MP_ROM_QSTR(MP_QSTR_channel_count), MP_ROM_PTR(&audioio_wavefile_channel_count_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(audioio_wavefile_locals_dict, audioio_wavefile_locals_dict_table);
 

--- a/shared-bindings/audioio/WaveFile.c
+++ b/shared-bindings/audioio/WaveFile.c
@@ -156,7 +156,7 @@ const mp_obj_property_t audioio_wavefile_bits_per_sample_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
-//|   .. attribute:: channels
+//|   .. attribute:: channel_count
 //|
 //|     Number of audio channels. (read only)
 //|

--- a/shared-bindings/audioio/WaveFile.c
+++ b/shared-bindings/audioio/WaveFile.c
@@ -138,6 +138,43 @@ const mp_obj_property_t audioio_wavefile_sample_rate_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
+//|   .. attribute:: bits_per_sample
+//|
+//|     Bits per sample. (read only)
+//|
+STATIC mp_obj_t audioio_wavefile_obj_get_bits_per_sample(mp_obj_t self_in) {
+    audioio_wavefile_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_audioio_wavefile_deinited(self));
+    return MP_OBJ_NEW_SMALL_INT(common_hal_audioio_wavefile_get_bits_per_sample(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(audioio_wavefile_get_bits_per_sample_obj, audioio_wavefile_obj_get_bits_per_sample);
+
+const mp_obj_property_t audioio_wavefile_bits_per_sample_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&audioio_wavefile_get_bits_per_sample_obj,
+              (mp_obj_t)&mp_const_none_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
+
+//|   .. attribute:: channels
+//|
+//|     Number of audio channels. (read only)
+//|
+STATIC mp_obj_t audioio_wavefile_obj_get_channel_count(mp_obj_t self_in) {
+    audioio_wavefile_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_audioio_wavefile_deinited(self));
+    return MP_OBJ_NEW_SMALL_INT(common_hal_audioio_wavefile_get_channel_count(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(audioio_wavefile_get_channel_count_obj, audioio_wavefile_obj_get_channel_count);
+
+const mp_obj_property_t audioio_wavefile_channel_count_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&audioio_wavefile_get_channel_count_obj,
+              (mp_obj_t)&mp_const_none_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
+
+
 STATIC const mp_rom_map_elem_t audioio_wavefile_locals_dict_table[] = {
     // Methods
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&audioio_wavefile_deinit_obj) },
@@ -146,6 +183,8 @@ STATIC const mp_rom_map_elem_t audioio_wavefile_locals_dict_table[] = {
 
     // Properties
     { MP_ROM_QSTR(MP_QSTR_sample_rate), MP_ROM_PTR(&audioio_wavefile_sample_rate_obj) },
+    { MP_ROM_QSTR(MP_QSTR_bits_per_sample), MP_ROM_PTR(&audioio_wavefile_bits_per_sample_obj) },
+    { MP_ROM_QSTR(MP_QSTR_channels), MP_ROM_PTR(&audioio_wavefile_channel_count_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(audioio_wavefile_locals_dict, audioio_wavefile_locals_dict_table);
 

--- a/shared-bindings/audioio/WaveFile.h
+++ b/shared-bindings/audioio/WaveFile.h
@@ -40,5 +40,7 @@ void common_hal_audioio_wavefile_deinit(audioio_wavefile_obj_t* self);
 bool common_hal_audioio_wavefile_deinited(audioio_wavefile_obj_t* self);
 uint32_t common_hal_audioio_wavefile_get_sample_rate(audioio_wavefile_obj_t* self);
 void common_hal_audioio_wavefile_set_sample_rate(audioio_wavefile_obj_t* self, uint32_t sample_rate);
+uint8_t common_hal_audioio_wavefile_get_bits_per_sample(audioio_wavefile_obj_t* self);
+uint8_t common_hal_audioio_wavefile_get_channel_count(audioio_wavefile_obj_t* self);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_AUDIOIO_WAVEFILE_H

--- a/shared-module/audioio/WaveFile.c
+++ b/shared-module/audioio/WaveFile.c
@@ -141,6 +141,14 @@ void common_hal_audioio_wavefile_set_sample_rate(audioio_wavefile_obj_t* self,
     self->sample_rate = sample_rate;
 }
 
+uint8_t common_hal_audioio_wavefile_get_bits_per_sample(audioio_wavefile_obj_t* self) {
+    return self->bits_per_sample;
+}
+
+uint8_t common_hal_audioio_wavefile_get_channel_count(audioio_wavefile_obj_t* self) {
+    return self->channel_count;
+}
+
 bool audioio_wavefile_samples_signed(audioio_wavefile_obj_t* self) {
     return self->bits_per_sample > 8;
 }


### PR DESCRIPTION
As requested in #1303.
```python
Adafruit CircuitPython 4.0.0-alpha.2-89-g7dc6b1da0-dirty on 2018-10-31; Adafruit CircuitPlayground Express with samd21g18
>>> import audioio
>>> wave_file = open("StreetChicken.wav", "rb")
>>> wav = audioio.WaveFile(wave_file)
>>> dir(wav)
['__enter__', '__exit__', 'bits_per_sample', 'channels', 'deinit', 'sample_rate']
>>> wav.channels
1
>>> wav.bits_per_sample
16
>>> 
```