### PR TITLE
Use adafruit/nrfx fork of NordicSemiconductor/nrfx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -75,7 +75,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Crickit
 [submodule "ports/nrf/nrfx"]
 	path = ports/nrf/nrfx
-	url = https://github.com/NordicSemiconductor/nrfx.git
+	url = https://github.com/adafruit/nrfx.git
 [submodule "lib/tinyusb"]
 	path = lib/tinyusb
 	url = https://github.com/hathach/tinyusb.git


### PR DESCRIPTION
Fixes #1273 by switching to `adafruit/nrfx`. That fork includes a fix allowing `nrfx` driver `uninit()` operations to be called repeatedly. See https://github.com/adafruit/nrfx/pull/1. That fork also is updated to nrfx v1.3.1, which we would have done anyway.