### PR TITLE
adding support for the CP32-M4

### DIFF
--- a/ports/atmel-samd/boards/cp32-m4/board.c
+++ b/ports/atmel-samd/boards/cp32-m4/board.c
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "boards/board.h"
+#include "mpconfigboard.h"
+#include "hal/include/hal_gpio.h"
+
+void board_init(void) {
+}
+
+bool board_requests_safe_mode(void) {
+    return false;
+}
+
+void reset_board(void) {
+}

--- a/ports/atmel-samd/boards/cp32-m4/mpconfigboard.h
+++ b/ports/atmel-samd/boards/cp32-m4/mpconfigboard.h
@@ -1,0 +1,39 @@
+#define MICROPY_HW_BOARD_NAME "CP32-M4"
+#define MICROPY_HW_MCU_NAME "samd51g19"
+
+#define MICROPY_HW_APA102_MOSI   (&pin_PA17)
+#define MICROPY_HW_APA102_SCK    (&pin_PA16)
+
+
+#define CIRCUITPY_MCU_FAMILY samd51
+
+#define MICROPY_PORT_A (PORT_PA08 | PORT_PA09 | PORT_PA10 | PORT_PA11| PORT_PA16| PORT_PA17)
+#define MICROPY_PORT_B        ( PORT_PB10 | PORT_PB11)
+#define MICROPY_PORT_C        (0)
+#define MICROPY_PORT_D        (0)
+
+#define AUTORESET_DELAY_MS 500
+
+// If you change this, then make sure to update the linker scripts as well to
+// make sure you don't overwrite code
+#define CIRCUITPY_INTERNAL_NVM_SIZE 8192
+
+#define BOARD_FLASH_SIZE (FLASH_SIZE - 0x4000 - CIRCUITPY_INTERNAL_NVM_SIZE)
+
+#include "external_flash/devices.h"
+
+// these are the labeled pins (SDA, SCL, SCK, MOSI, MISO, etc)
+#define EXTERNAL_FLASH_DEVICE_COUNT 1
+#define EXTERNAL_FLASH_DEVICES W25Q128JV_PM
+
+#include "external_flash/external_flash.h"
+
+#define DEFAULT_I2C_BUS_SCL (&pin_PB09)
+#define DEFAULT_I2C_BUS_SDA (&pin_PB08)
+
+#define DEFAULT_SPI_BUS_SCK (&pin_PA22)
+#define DEFAULT_SPI_BUS_MOSI (&pin_PA23)
+#define DEFAULT_SPI_BUS_MISO (&pin_PA21)
+
+#define DEFAULT_UART_BUS_RX (&pin_PA12)
+#define DEFAULT_UART_BUS_TX (&pin_PA13)

--- a/ports/atmel-samd/boards/cp32-m4/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/cp32-m4/mpconfigboard.mk
@@ -1,0 +1,10 @@
+LD_FILE = boards/samd51x19-bootloader-external-flash.ld
+USB_VID = 0x239A
+USB_PID = 0x8021
+USB_PRODUCT = "CP32-M4"
+USB_MANUFACTURER = "Nadda-Reel Company LLC"
+
+QSPI_FLASH_FILESYSTEM = 1
+
+CHIP_VARIANT = SAMD51G19A
+CHIP_FAMILY = samd51

--- a/ports/atmel-samd/boards/cp32-m4/pins.c
+++ b/ports/atmel-samd/boards/cp32-m4/pins.c
@@ -1,0 +1,41 @@
+#include "shared-bindings/board/__init__.h"
+
+#include "board_busses.h"
+
+// This mapping only includes functional names because pins broken
+// out on connectors are labeled with their MCU name available from
+// microcontroller.pin.
+STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SPEAKER_P),  MP_ROM_PTR(&pin_PA02) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_BATTERY),  MP_ROM_PTR(&pin_PB08) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SW3_4),  MP_ROM_PTR(&pin_PB09) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SW1_2),  MP_ROM_PTR(&pin_PA04) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SPEAKER_N),  MP_ROM_PTR(&pin_PA05) },
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SW9), MP_ROM_PTR(&pin_PA06) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SW7), MP_ROM_PTR(&pin_PA07) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_BACKLIGHT_PWM), MP_ROM_PTR(&pin_PA12) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_EXT_HDR3), MP_ROM_PTR(&pin_PA13) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SW5), MP_ROM_PTR(&pin_PA14) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_EXT_HDR4), MP_ROM_PTR(&pin_PA15) },
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_APA102_SCK), MP_ROM_PTR(&pin_PA16) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_APA102_MOSI), MP_ROM_PTR(&pin_PA17) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_STATUS_LED),  MP_ROM_PTR(&pin_PA18) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SW6),  MP_ROM_PTR(&pin_PA19) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_VSPI_CS0),  MP_ROM_PTR(&pin_PA20) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_VSPI_MISO),  MP_ROM_PTR(&pin_PA21) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_VSPI_SCK),  MP_ROM_PTR(&pin_PA22) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_VSPI_MOSI),  MP_ROM_PTR(&pin_PA23) },
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_VSPI_CS1),  MP_ROM_PTR(&pin_PB22) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_EXT_HDR5),  MP_ROM_PTR(&pin_PB23) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_LCD_DC),  MP_ROM_PTR(&pin_PA27) },
+    { MP_ROM_QSTR(MP_QSTR_SW8), MP_ROM_PTR(&pin_PB02) },
+    { MP_ROM_QSTR(MP_QSTR_SW10), MP_ROM_PTR(&pin_PB03) },
+
+    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
+};
+MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);

--- a/ports/atmel-samd/external_flash/devices.h
+++ b/ports/atmel-samd/external_flash/devices.h
@@ -302,7 +302,7 @@ typedef struct {
 // Settings for the Winbond W25Q128JV-SQ 16MiB SPI flash. Note that JV-IM has a different .memory_type (0x70)
 // Datasheet: https://www.winbond.com/resource-files/w25q128jv%20revf%2003272018%20plus.pdf
 #define W25Q128JV_SQ {\
-    .total_size = (1 << 23), /* 16 MiB */ \
+    .total_size = (1 << 24), /* 16 MiB */ \
     .start_up_time_us = 5000, \
     .manufacturer_id = 0xef, \
     .memory_type = 0x40, \
@@ -317,5 +317,21 @@ typedef struct {
 }
 
 
+// Settings for the Winbond W25Q128JV-PM 16MiB SPI flash. Note that JV-IM has a different .memory_type (0x70)
+// Datasheet: https://www.winbond.com/resource-files/w25q128jv%20revf%2003272018%20plus.pdf
+#define W25Q128JV_PM {\
+    .total_size = (1 << 24), /* 16 MiB */ \
+    .start_up_time_us = 5000, \
+    .manufacturer_id = 0xef, \
+    .memory_type = 0x70, \
+    .capacity = 0x18, \
+    .max_clock_speed_mhz = 133, \
+    .has_sector_protection = false, \
+    .supports_fast_read = true, \
+    .supports_qspi = true, \
+    .has_quad_enable = true, \
+    .supports_qspi_writes = true, \
+    .write_status_register_split = false, \
+}
 
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_EXTERNAL_FLASH_DEVICES_H


### PR DESCRIPTION
CP32-M4 support, yay! As I mentioned, I'm only seeing 8MB of flash instead of the expected 16. I'm not sure if it's a config issue or something with CP but it works well enough to commit.

The current pins are specific to the ODroid, so I'll probably want to update that some time in the future