### PR TITLE
Adding the serial_bytes_available() method to the 3.x branch

### DIFF
--- a/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.mk
@@ -17,3 +17,6 @@ FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_HID
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_LIS3DH
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Thermistor
+
+#Adding per @danh to reduce memory usage and get the latest changes in
+CFLAGS_INLINE_LIMIT = 55

--- a/ports/atmel-samd/common-hal/supervisor/Runtime.c
+++ b/ports/atmel-samd/common-hal/supervisor/Runtime.c
@@ -32,3 +32,7 @@ bool common_hal_get_serial_connected(void) {
     return (bool) usb_connected();
 }
 
+bool common_hal_get_serial_bytes_available(void) {
+    return (bool) usb_bytes_available();
+}
+

--- a/ports/nrf/common-hal/supervisor/Runtime.c
+++ b/ports/nrf/common-hal/supervisor/Runtime.c
@@ -32,3 +32,7 @@ bool common_hal_get_serial_connected(void) {
     return (bool) serial_connected();
 }
 
+bool common_hal_get_serial_bytes_available(void) {
+  return (bool) serial_bytes_available();
+}
+

--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -53,6 +53,12 @@
 //|
 //|         Returns the USB serial communication status (read-only).
 //|
+//|     .. attribute:: runtime.serial_bytes_available
+//|
+//|         Returns the whether any bytes are available to read
+//|         on the USB serial input.  Allows for polling to see whether
+//|         to call the built-in input() or wait. (read-only)
+//|
 //|     .. note::
 //|
 //|         SAMD: Will return ``True`` if the USB serial connection
@@ -80,8 +86,28 @@ const mp_obj_property_t supervisor_serial_connected_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
+/*Added to allow for polling of USB Console*/
+STATIC mp_obj_t supervisor_get_serial_bytes_available(mp_obj_t self){
+    if (!common_hal_get_serial_bytes_available()) {
+        return mp_const_false;
+    }
+    else {
+        return mp_const_true;
+    }
+}
+MP_DEFINE_CONST_FUN_OBJ_1(supervisor_get_serial_bytes_available_obj, supervisor_get_serial_bytes_available);
+
+const mp_obj_property_t supervisor_serial_bytes_available_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&supervisor_get_serial_bytes_available_obj,
+              (mp_obj_t)&mp_const_none_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
+
+
 STATIC const mp_rom_map_elem_t supervisor_runtime_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_serial_connected), MP_ROM_PTR(&supervisor_serial_connected_obj) },
+    { MP_ROM_QSTR(MP_QSTR_serial_bytes_available), MP_ROM_PTR(&supervisor_serial_bytes_available_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(supervisor_runtime_locals_dict, supervisor_runtime_locals_dict_table);

--- a/shared-bindings/supervisor/Runtime.h
+++ b/shared-bindings/supervisor/Runtime.h
@@ -35,6 +35,8 @@ const mp_obj_type_t supervisor_runtime_type;
 
 bool common_hal_get_serial_connected(void);
 
+bool common_hal_get_serial_bytes_available(void);
+
 //TODO: placeholders for future functions
 //bool common_hal_get_repl_active(void);
 //bool common_hal_get_usb_enumerated(void);


### PR DESCRIPTION
This PR adds the serial_bytes_available() code to the 3.x branch so that we don't have to wait for the 4.0 release to use it.  This is important because it is essentially a stop-gap to make interactive serial usage possible until the secondary Serial connection is available in 4.x.

The code here should be identical to that in master (as of 11/3) including comments, etc.