### PR TITLE
fix Trellis M4 DotStar pin assignments.

### DIFF
--- a/ports/atmel-samd/boards/trellis_m4_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/trellis_m4_express/mpconfigboard.h
@@ -1,19 +1,20 @@
+
 #define MICROPY_HW_BOARD_NAME "Adafruit Trellis M4 Express"
 #define MICROPY_HW_MCU_NAME "samd51g19"
 
 #define CIRCUITPY_MCU_FAMILY samd51
 
 // This is for Rev D
-#define MICROPY_HW_APA102_MOSI   (&pin_PA01)
-#define MICROPY_HW_APA102_SCK    (&pin_PA00)
+#define MICROPY_HW_APA102_MOSI   (&pin_PB03)
+#define MICROPY_HW_APA102_SCK    (&pin_PB02)
 
 #define CIRCUITPY_BITBANG_APA102
 
 // These are pins not to reset.
-// QSPI Data pins & DotStar pins
-#define MICROPY_PORT_A (PORT_PA00 | PORT_PA01 | PORT_PA08 | PORT_PA09 | PORT_PA10 | PORT_PA11)
-// QSPI CS, and QSPI SCK
-#define MICROPY_PORT_B (PORT_PB10 | PORT_PB11)
+// QSPI Data pins
+#define MICROPY_PORT_A (PORT_PA08 | PORT_PA09 | PORT_PA10 | PORT_PA11)
+// DotStar Pins, QSPI CS, and QSPI SCK
+#define MICROPY_PORT_B (PORT_PB02 | PORT_PB03 | PORT_PB10 | PORT_PB11)
 #define MICROPY_PORT_C (0)
 #define MICROPY_PORT_D (0)
 

--- a/ports/atmel-samd/boards/trellis_m4_express/pins.c
+++ b/ports/atmel-samd/boards/trellis_m4_express/pins.c
@@ -39,8 +39,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     // NeoPixels
     { MP_OBJ_NEW_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_PA27) },
 
-    { MP_ROM_QSTR(MP_QSTR_APA102_MOSI), MP_ROM_PTR(&pin_PA01) },
-    { MP_ROM_QSTR(MP_QSTR_APA102_SCK), MP_ROM_PTR(&pin_PA00) },
+    { MP_ROM_QSTR(MP_QSTR_APA102_MOSI), MP_ROM_PTR(&pin_PB03) },
+    { MP_ROM_QSTR(MP_QSTR_APA102_SCK), MP_ROM_PTR(&pin_PB02) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
 };


### PR DESCRIPTION
Trellis DotStar pins were PA00 and PA01, but should be PB02 and PB03 shipping version. Still need to be bitbang; turning that off does not work.

Discovered by @kattni. I tested with a board shipped this week.