### PR TITLE
shared-module/os: Fix os.mkdir('a/b')

### DIFF
--- a/lib/oofatfs/ff.c
+++ b/lib/oofatfs/ff.c
@@ -2579,8 +2579,8 @@ FRESULT create_name (   /* FR_OK: successful, FR_INVALID_NAME: could not create 
         if (w < 0x80 && chk_chr("\"*:<>\?|\x7F", w)) return FR_INVALID_NAME;    /* Reject illegal characters for LFN */
         lfn[di++] = w;                  /* Store the Unicode character */
     }
-    cf = ((w < ' ') || ((w == '/' || w == '\\') && p[si+1] < ' ')) ? NS_LAST : 0;   /* Set last segment flag if end of the path */
     *path = &p[si];                     /* Return pointer to the next segment */
+    cf = (w < ' ') ? NS_LAST : 0;       /* Set last segment flag if end of the path */
 #if _FS_RPATH != 0
     if ((di == 1 && lfn[di - 1] == '.') ||
         (di == 2 && lfn[di - 1] == '.' && lfn[di - 2] == '.')) {    /* Is this segment a dot name? */


### PR DESCRIPTION
This fixes commit a99f9427420d("'/' and '\\' are also acceptable ends of the path now") which broke mkdir.
The problem is where the directory name is a single letter like this:
```
>>> os.mkdir('a')
>>> os.mkdir('a/b')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: [Errno 17] File exists
>>> os.mkdir('a/bb')
>>>
```

I wasn't smart enough to fix this in the oofatfs library, so I did it in the os shared module by
creating a path lookup function for the os methods that only deals with directories. I reverted
the library change introduced by the aforementioned commit.

This means that os.stat and os.rename can't handle trailing slashes. This is to avoid allowing
filenames with trailing slashes to pass through. In order to handle trailing slashes for these
it would be necessary to check if it really is a directory before stripping. I didn't do this
since the original issue was to make os.chdir tolerate trailing slashes.

There's an open MicroPython issue #2929 wrt. trailing slashes and mkdir.