### PR TITLE
Support OSError subclasses and attributes

### DIFF
--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -163,6 +163,18 @@ typedef long mp_off_t;
 #define MICROPY_PY_IO                               (0)
 #define MICROPY_PY_REVERSE_SPECIAL_METHODS          (0)
 #define MICROPY_PY_SYS_EXC_INFO                     (0)
+#define MICROPY_PY_UERRNO_LIST \
+    X(EPERM) \
+    X(ENOENT) \
+    X(EIO) \
+    X(EAGAIN) \
+    X(ENOMEM) \
+    X(EACCES) \
+    X(EEXIST) \
+    X(ENODEV) \
+    X(EISDIR) \
+    X(EINVAL) \
+
 #endif
 
 #ifdef SAMD51
@@ -179,6 +191,7 @@ typedef long mp_off_t;
 #define MICROPY_PY_IO                               (1)
 #define MICROPY_PY_REVERSE_SPECIAL_METHODS          (1)
 #define MICROPY_PY_SYS_EXC_INFO                     (1)
+//      MICROPY_PY_UERRNO_LIST - Use the default
 #endif
 
 #ifdef LONGINT_IMPL_NONE
@@ -395,18 +408,6 @@ extern const struct _mp_obj_module_t wiznet_module;
 #define MICROPY_PORT_BUILTIN_DEBUG_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_uheap),(mp_obj_t)&uheap_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_ustack),(mp_obj_t)&ustack_module }
-
-#define MICROPY_PY_UERRNO_LIST \
-    X(EPERM) \
-    X(ENOENT) \
-    X(EIO) \
-    X(EAGAIN) \
-    X(ENOMEM) \
-    X(EACCES) \
-    X(EEXIST) \
-    X(ENODEV) \
-    X(EISDIR) \
-    X(EINVAL) \
 
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>

--- a/py/mperrno.h
+++ b/py/mperrno.h
@@ -141,7 +141,6 @@
 #endif
 
 const char* mp_errno_to_str(mp_obj_t errno_val);
-// For commonly encountered errors, return compressed human readable strings
-const compressed_string_t* mp_common_errno_to_str(mp_obj_t errno_val);
+const char *mp_common_errno_to_str(mp_obj_t errno_val, char *buf, size_t len);
 
 #endif // MICROPY_INCLUDED_PY_MPERRNO_H


### PR DESCRIPTION
This adds support for the OSError subclasses listed in the [Python docs](https://docs.python.org/3/library/exceptions.html):
```
      +-- OSError
      |    +-- BlockingIOError
      |    +-- ChildProcessError
      |    +-- ConnectionError
      |    |    +-- BrokenPipeError
      |    |    +-- ConnectionAbortedError
      |    |    +-- ConnectionRefusedError
      |    |    +-- ConnectionResetError
      |    +-- FileExistsError
      |    +-- FileNotFoundError
      |    +-- InterruptedError
      |    +-- IsADirectoryError
      |    +-- NotADirectoryError
      |    +-- PermissionError
      |    +-- ProcessLookupError
      |    +-- TimeoutError
```

When OSError is raised, the errno value is checked to see if a subclass should be used following the
CPython rules in [Objects/exceptions.c:_PyExc_Init()](https://github.com/python/cpython/blob/v3.4.9/Objects/exceptions.c#L2597-L2632).

These [OSError](https://docs.python.org/3/library/exceptions.html#OSError) attributes are added: errno, strerror, filename and filename2.

samd51 has MICROPY_CPYTHON_COMPAT enabled and will get these additions.

On samd51 use the default MICROPY_PY_UERRNO_LIST to give libraries access to all the errno values:
```
>>> import errno
>>> print('\n'.join(dir(errno)))
__class__
__name__
EACCES
EADDRINUSE
EAGAIN
EALREADY
EBADF
ECONNABORTED
ECONNREFUSED
ECONNRESET
EEXIST
EHOSTUNREACH
EINPROGRESS
EINVAL
EIO
EISDIR
ENOBUFS
ENODEV
ENOENT
ENOMEM
ENOTCONN
EOPNOTSUPP
EPERM
ETIMEDOUT
```

Test coverage in the ported stdlib: [lib/test/test_pep3151.py](https://github.com/notro/tmp_CircuitPython_stdlib/blob/master/lib/test/test_pep3151.py) and [lib/test/test_exceptions.py](https://github.com/notro/tmp_CircuitPython_stdlib/blob/master/lib/test/test_exceptions.py)