### PR TITLE
Clear Trellis NeoPixels on board reset.

### DIFF
--- a/ports/atmel-samd/boards/trellis_m4_express/board.c
+++ b/ports/atmel-samd/boards/trellis_m4_express/board.c
@@ -24,9 +24,14 @@
  * THE SOFTWARE.
  */
 
+#include <string.h>
+
 #include "boards/board.h"
-#include "mpconfigboard.h"
-#include "hal/include/hal_gpio.h"
+#include "py/mpconfig.h"
+
+#include "common-hal/digitalio/DigitalInOut.h"
+#include "shared-bindings/digitalio/DigitalInOut.h"
+#include "shared-bindings/neopixel_write/__init__.h"
 
 void board_init(void) {
 }
@@ -36,4 +41,11 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
+    uint8_t zeroes[96];
+    memset(zeroes, 0, 96);
+    digitalio_digitalinout_obj_t neopixel;
+    common_hal_digitalio_digitalinout_construct(&neopixel, &pin_PA27);
+    common_hal_digitalio_digitalinout_switch_to_output(&neopixel, false, DRIVE_MODE_PUSH_PULL);
+    common_hal_neopixel_write(&neopixel, zeroes, 96);
+    common_hal_digitalio_digitalinout_deinit(&neopixel);
 }


### PR DESCRIPTION
This makes it easier to change code in cases where the pixels may
cause a brownout.