### PR TITLE
Fix time.monotonic_ns docstring

### DIFF
--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -206,7 +206,7 @@ STATIC mp_obj_t time_time(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 
-//| .. method:: monotonic_ns(clk_id)
+//| .. method:: monotonic_ns()
 //|
 //|   Return the time of the specified clock clk_id in nanoseconds. Refer to
 //|   Clock ID Constants for a list of accepted values for clk_id.

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -208,8 +208,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 
 //| .. method:: monotonic_ns()
 //|
-//|   Return the time of the specified clock clk_id in nanoseconds. Refer to
-//|   Clock ID Constants for a list of accepted values for clk_id.
+//|   Return the time of the specified clock clk_id in nanoseconds.
 //|
 //|   :return: the current time
 //|   :rtype: int


### PR DESCRIPTION
Fix #1343.
Removed the clk_id from the function parameter list and removed the reference to it on the function description.