### PR TITLE
UART changes: timeout in secs, write bytes, etc.

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-09 16:20-0800\n"
+"POT-Creation-Date: 2018-12-03 15:57-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "invalid dupterm index"
 msgstr ""
 
-#: extmod/vfs_fat.c:426 py/moduerrno.c:150
+#: extmod/vfs_fat.c:426 py/moduerrno.c:154
 msgid "Read-only filesystem"
 msgstr ""
 
@@ -151,70 +151,70 @@ msgstr ""
 msgid "script compilation not supported"
 msgstr ""
 
-#: main.c:154
+#: main.c:155
 msgid " output:\n"
 msgstr ""
 
-#: main.c:168 main.c:241
+#: main.c:169 main.c:242
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
 msgstr ""
 
-#: main.c:170
+#: main.c:171
 msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr ""
 
-#: main.c:172 main.c:243
+#: main.c:173 main.c:244
 msgid "Auto-reload is off.\n"
 msgstr ""
 
-#: main.c:186
+#: main.c:187
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr ""
 
-#: main.c:202
+#: main.c:203
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr ""
 
-#: main.c:250
+#: main.c:251
 msgid "You requested starting safe mode by "
 msgstr ""
 
-#: main.c:253
+#: main.c:254
 msgid "To exit, please reset the board without "
 msgstr ""
 
-#: main.c:260
+#: main.c:261
 msgid ""
 "You are running in safe mode which means something really bad happened.\n"
 msgstr ""
 
-#: main.c:262
+#: main.c:263
 msgid "Looks like our core CircuitPython code crashed hard. Whoops!\n"
 msgstr ""
 
-#: main.c:263
+#: main.c:264
 msgid "Please file an issue here with the contents of your CIRCUITPY drive:\n"
 msgstr ""
 
-#: main.c:266
+#: main.c:267
 msgid ""
 "The microcontroller's power dipped. Please make sure your power supply "
 "provides\n"
 msgstr ""
 
-#: main.c:267
+#: main.c:268
 msgid ""
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
 
-#: main.c:271
+#: main.c:272
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 
-#: main.c:429
+#: main.c:430
 msgid "soft reboot\n"
 msgstr ""
 
@@ -1325,27 +1325,27 @@ msgstr ""
 msgid "expecting a dict for keyword args"
 msgstr ""
 
-#: py/moduerrno.c:143 py/moduerrno.c:146
+#: py/moduerrno.c:147 py/moduerrno.c:150
 msgid "Permission denied"
 msgstr ""
 
-#: py/moduerrno.c:144
+#: py/moduerrno.c:148
 msgid "No such file/directory"
 msgstr ""
 
-#: py/moduerrno.c:145
+#: py/moduerrno.c:149
 msgid "Input/output error"
 msgstr ""
 
-#: py/moduerrno.c:147
+#: py/moduerrno.c:151
 msgid "File exists"
 msgstr ""
 
-#: py/moduerrno.c:148
+#: py/moduerrno.c:152
 msgid "Unsupported operation"
 msgstr ""
 
-#: py/moduerrno.c:149
+#: py/moduerrno.c:153
 msgid "Invalid argument"
 msgstr ""
 
@@ -1974,6 +1974,14 @@ msgstr ""
 msgid "stream operation not supported"
 msgstr ""
 
+#: py/stream.c:254
+msgid "string not supported; use bytes or bytearray"
+msgstr ""
+
+#: py/stream.c:289
+msgid "length argument not allowed for this type"
+msgstr ""
+
 #: py/vm.c:255
 msgid "local variable referenced before assignment"
 msgstr ""
@@ -2132,11 +2140,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr ""
 
-#: shared-bindings/busio/UART.c:102
+#: shared-bindings/busio/UART.c:104
 msgid "bits must be 7, 8 or 9"
 msgstr ""
 
-#: shared-bindings/busio/UART.c:114
+#: shared-bindings/busio/UART.c:116
 msgid "stop must be 1 or 2"
 msgstr ""
 
@@ -2361,15 +2369,15 @@ msgstr ""
 msgid "time.struct_time() takes a 9-sequence"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:264
+#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:263
 msgid "Tuple or struct_time argument required"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:269
+#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:268
 msgid "function takes exactly 9 arguments"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:240 shared-bindings/time/__init__.c:273
+#: shared-bindings/time/__init__.c:239 shared-bindings/time/__init__.c:272
 msgid "timestamp out of range for platform time_t"
 msgstr ""
 

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-09 16:20-0800\n"
+"POT-Creation-Date: 2018-12-03 15:57-0500\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: Sebastian Plamauer\n"
 "Language-Team: \n"
@@ -131,7 +131,7 @@ msgstr "kompression header"
 msgid "invalid dupterm index"
 msgstr "ungültiger dupterm index"
 
-#: extmod/vfs_fat.c:426 py/moduerrno.c:150
+#: extmod/vfs_fat.c:426 py/moduerrno.c:154
 msgid "Read-only filesystem"
 msgstr "Schreibgeschützte Dateisystem"
 
@@ -151,11 +151,11 @@ msgstr "ungültige argumente"
 msgid "script compilation not supported"
 msgstr "kompilieren von Skripten ist nicht unterstützt"
 
-#: main.c:154
+#: main.c:155
 msgid " output:\n"
 msgstr " Ausgabe:\n"
 
-#: main.c:168 main.c:241
+#: main.c:169 main.c:242
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
@@ -163,45 +163,45 @@ msgstr ""
 "Automatisches Neuladen ist aktiv. Speichere Dateien über USB um sie "
 "auszuführen oder verbinde dich mit der REPL um zu deaktivieren.\n"
 
-#: main.c:170
+#: main.c:171
 msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr "Sicherheitsmodus aktiv! Automatisches Neuladen ist deaktiviert.\n"
 
-#: main.c:172 main.c:243
+#: main.c:173 main.c:244
 msgid "Auto-reload is off.\n"
 msgstr "Automatisches Neuladen ist deaktiviert.\n"
 
-#: main.c:186
+#: main.c:187
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr "Sicherheitsmodus aktiv! Gespeicherter Code wird nicht ausgeführt\n"
 
-#: main.c:202
+#: main.c:203
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr "WARNUNG: Der Dateiname deines codes hat zwei Dateityperweiterungen\n"
 
-#: main.c:250
+#: main.c:251
 msgid "You requested starting safe mode by "
 msgstr "Du hast das Starten im Sicherheitsmodus ausgelöst durch "
 
-#: main.c:253
+#: main.c:254
 msgid "To exit, please reset the board without "
 msgstr "Zum beenden bitte resette das board ohne "
 
-#: main.c:260
+#: main.c:261
 msgid ""
 "You are running in safe mode which means something really bad happened.\n"
 msgstr "Sicherheitsmodus aktiv, etwas wirklich schlechtes ist passiert.\n"
 
-#: main.c:262
+#: main.c:263
 msgid "Looks like our core CircuitPython code crashed hard. Whoops!\n"
 msgstr "CircuitPython ist abgestürzt. Ups!\n"
 
-#: main.c:263
+#: main.c:264
 msgid "Please file an issue here with the contents of your CIRCUITPY drive:\n"
 msgstr ""
 "Bitte erstelle ein issue hier mit dem Inhalt deines CIRCUITPY-speichers:\n"
 
-#: main.c:266
+#: main.c:267
 msgid ""
 "The microcontroller's power dipped. Please make sure your power supply "
 "provides\n"
@@ -209,7 +209,7 @@ msgstr ""
 "Die Stromversorgung des Mikrocontrollers ist eingebrochen. Stelle sicher,"
 "dass deine Stromversorgung\n"
 
-#: main.c:267
+#: main.c:268
 msgid ""
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
@@ -217,13 +217,13 @@ msgstr ""
 "genug Strom für den ganzen Schaltkreis liefert und drücke reset (nach dem "
 "sicheren Auswerfen von CIRCUITPY.)\n"
 
-#: main.c:271
+#: main.c:272
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 "Drücke eine Taste um dich mit der REPL zu verbinden. Drücke Strg-D zum neu "
 "laden"
 
-#: main.c:429
+#: main.c:430
 msgid "soft reboot\n"
 msgstr "soft reboot\n"
 
@@ -1345,27 +1345,27 @@ msgstr ""
 msgid "expecting a dict for keyword args"
 msgstr ""
 
-#: py/moduerrno.c:143 py/moduerrno.c:146
+#: py/moduerrno.c:147 py/moduerrno.c:150
 msgid "Permission denied"
 msgstr ""
 
-#: py/moduerrno.c:144
+#: py/moduerrno.c:148
 msgid "No such file/directory"
 msgstr ""
 
-#: py/moduerrno.c:145
+#: py/moduerrno.c:149
 msgid "Input/output error"
 msgstr ""
 
-#: py/moduerrno.c:147
+#: py/moduerrno.c:151
 msgid "File exists"
 msgstr ""
 
-#: py/moduerrno.c:148
+#: py/moduerrno.c:152
 msgid "Unsupported operation"
 msgstr ""
 
-#: py/moduerrno.c:149
+#: py/moduerrno.c:153
 msgid "Invalid argument"
 msgstr ""
 
@@ -1994,6 +1994,14 @@ msgstr ""
 msgid "stream operation not supported"
 msgstr ""
 
+#: py/stream.c:254
+msgid "string not supported; use bytes or bytearray"
+msgstr ""
+
+#: py/stream.c:289
+msgid "length argument not allowed for this type"
+msgstr ""
+
 #: py/vm.c:255
 msgid "local variable referenced before assignment"
 msgstr ""
@@ -2155,11 +2163,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr ""
 
-#: shared-bindings/busio/UART.c:102
+#: shared-bindings/busio/UART.c:104
 msgid "bits must be 7, 8 or 9"
 msgstr ""
 
-#: shared-bindings/busio/UART.c:114
+#: shared-bindings/busio/UART.c:116
 msgid "stop must be 1 or 2"
 msgstr ""
 
@@ -2385,15 +2393,15 @@ msgstr ""
 msgid "time.struct_time() takes a 9-sequence"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:264
+#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:263
 msgid "Tuple or struct_time argument required"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:269
+#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:268
 msgid "function takes exactly 9 arguments"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:240 shared-bindings/time/__init__.c:273
+#: shared-bindings/time/__init__.c:239 shared-bindings/time/__init__.c:272
 msgid "timestamp out of range for platform time_t"
 msgstr ""
 
@@ -2538,32 +2546,32 @@ msgstr "USB beschäftigt"
 msgid "USB Error"
 msgstr "USB Fehler"
 
-#~ msgid "Invalid Service type"
-#~ msgstr "Ungültiger Diensttyp"
-
-#~ msgid "Can not query for the device address."
-#~ msgstr "Kann nicht nach der Geräteadresse suchen."
-
-#~ msgid "Cannot set PPCP parameters."
-#~ msgstr "Kann PPCP Parameter nicht setzen."
-
-#~ msgid "Cannot apply GAP parameters."
-#~ msgstr "Kann GAP Parameter nicht anwenden."
-
-#~ msgid "Can not encode UUID, to check length."
-#~ msgstr "Kann UUID nicht kodieren, um die Länge zu überprüfen."
-
-#~ msgid "Can encode UUID into the advertisement packet."
-#~ msgstr "Kann UUID in das advertisement packet kodieren."
-
-#~ msgid "Can not apply device name in the stack."
-#~ msgstr "Der Gerätename kann nicht im Stack verwendet werden."
-
-#~ msgid "Can not apply advertisement data. status: 0x%02x"
-#~ msgstr "Kann advertisement data nicht anwenden. Status: 0x%02x"
+#~ msgid "Can not add Characteristic."
+#~ msgstr "Kann das Merkmal nicht hinzufügen."
 
 #~ msgid "Can not add Service."
 #~ msgstr "Kann den Dienst nicht hinzufügen."
 
-#~ msgid "Can not add Characteristic."
-#~ msgstr "Kann das Merkmal nicht hinzufügen."
+#~ msgid "Can not apply advertisement data. status: 0x%02x"
+#~ msgstr "Kann advertisement data nicht anwenden. Status: 0x%02x"
+
+#~ msgid "Can not apply device name in the stack."
+#~ msgstr "Der Gerätename kann nicht im Stack verwendet werden."
+
+#~ msgid "Can encode UUID into the advertisement packet."
+#~ msgstr "Kann UUID in das advertisement packet kodieren."
+
+#~ msgid "Can not encode UUID, to check length."
+#~ msgstr "Kann UUID nicht kodieren, um die Länge zu überprüfen."
+
+#~ msgid "Cannot apply GAP parameters."
+#~ msgstr "Kann GAP Parameter nicht anwenden."
+
+#~ msgid "Cannot set PPCP parameters."
+#~ msgstr "Kann PPCP Parameter nicht setzen."
+
+#~ msgid "Can not query for the device address."
+#~ msgstr "Kann nicht nach der Geräteadresse suchen."
+
+#~ msgid "Invalid Service type"
+#~ msgstr "Ungültiger Diensttyp"

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-09 15:57-0800\n"
+"POT-Creation-Date: 2018-12-03 15:57-0500\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "invalid dupterm index"
 msgstr ""
 
-#: extmod/vfs_fat.c:426 py/moduerrno.c:150
+#: extmod/vfs_fat.c:426 py/moduerrno.c:154
 msgid "Read-only filesystem"
 msgstr ""
 
@@ -151,70 +151,70 @@ msgstr ""
 msgid "script compilation not supported"
 msgstr ""
 
-#: main.c:154
+#: main.c:155
 msgid " output:\n"
 msgstr ""
 
-#: main.c:168 main.c:241
+#: main.c:169 main.c:242
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
 msgstr ""
 
-#: main.c:170
+#: main.c:171
 msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr ""
 
-#: main.c:172 main.c:243
+#: main.c:173 main.c:244
 msgid "Auto-reload is off.\n"
 msgstr ""
 
-#: main.c:186
+#: main.c:187
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr ""
 
-#: main.c:202
+#: main.c:203
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr ""
 
-#: main.c:250
+#: main.c:251
 msgid "You requested starting safe mode by "
 msgstr ""
 
-#: main.c:253
+#: main.c:254
 msgid "To exit, please reset the board without "
 msgstr ""
 
-#: main.c:260
+#: main.c:261
 msgid ""
 "You are running in safe mode which means something really bad happened.\n"
 msgstr ""
 
-#: main.c:262
+#: main.c:263
 msgid "Looks like our core CircuitPython code crashed hard. Whoops!\n"
 msgstr ""
 
-#: main.c:263
+#: main.c:264
 msgid "Please file an issue here with the contents of your CIRCUITPY drive:\n"
 msgstr ""
 
-#: main.c:266
+#: main.c:267
 msgid ""
 "The microcontroller's power dipped. Please make sure your power supply "
 "provides\n"
 msgstr ""
 
-#: main.c:267
+#: main.c:268
 msgid ""
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
 
-#: main.c:271
+#: main.c:272
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 
-#: main.c:429
+#: main.c:430
 msgid "soft reboot\n"
 msgstr ""
 
@@ -1325,27 +1325,27 @@ msgstr ""
 msgid "expecting a dict for keyword args"
 msgstr ""
 
-#: py/moduerrno.c:143 py/moduerrno.c:146
+#: py/moduerrno.c:147 py/moduerrno.c:150
 msgid "Permission denied"
 msgstr ""
 
-#: py/moduerrno.c:144
+#: py/moduerrno.c:148
 msgid "No such file/directory"
 msgstr ""
 
-#: py/moduerrno.c:145
+#: py/moduerrno.c:149
 msgid "Input/output error"
 msgstr ""
 
-#: py/moduerrno.c:147
+#: py/moduerrno.c:151
 msgid "File exists"
 msgstr ""
 
-#: py/moduerrno.c:148
+#: py/moduerrno.c:152
 msgid "Unsupported operation"
 msgstr ""
 
-#: py/moduerrno.c:149
+#: py/moduerrno.c:153
 msgid "Invalid argument"
 msgstr ""
 
@@ -1974,6 +1974,14 @@ msgstr ""
 msgid "stream operation not supported"
 msgstr ""
 
+#: py/stream.c:254
+msgid "string not supported; use bytes or bytearray"
+msgstr ""
+
+#: py/stream.c:289
+msgid "length argument not allowed for this type"
+msgstr ""
+
 #: py/vm.c:255
 msgid "local variable referenced before assignment"
 msgstr ""
@@ -2132,11 +2140,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr ""
 
-#: shared-bindings/busio/UART.c:102
+#: shared-bindings/busio/UART.c:104
 msgid "bits must be 7, 8 or 9"
 msgstr ""
 
-#: shared-bindings/busio/UART.c:114
+#: shared-bindings/busio/UART.c:116
 msgid "stop must be 1 or 2"
 msgstr ""
 
@@ -2361,15 +2369,15 @@ msgstr ""
 msgid "time.struct_time() takes a 9-sequence"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:264
+#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:263
 msgid "Tuple or struct_time argument required"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:269
+#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:268
 msgid "function takes exactly 9 arguments"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:240 shared-bindings/time/__init__.c:273
+#: shared-bindings/time/__init__.c:239 shared-bindings/time/__init__.c:272
 msgid "timestamp out of range for platform time_t"
 msgstr ""
 

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-09 16:20-0800\n"
+"POT-Creation-Date: 2018-12-03 15:57-0500\n"
 "PO-Revision-Date: 2018-08-24 22:56-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -131,7 +131,7 @@ msgstr "encabezado de compresión"
 msgid "invalid dupterm index"
 msgstr "index dupterm inválido"
 
-#: extmod/vfs_fat.c:426 py/moduerrno.c:150
+#: extmod/vfs_fat.c:426 py/moduerrno.c:154
 msgid "Read-only filesystem"
 msgstr "Sistema de archivos de solo-Lectura"
 
@@ -151,11 +151,11 @@ msgstr "argumentos inválidos"
 msgid "script compilation not supported"
 msgstr "script de compilación no soportado"
 
-#: main.c:154
+#: main.c:155
 msgid " output:\n"
 msgstr " salida:\n"
 
-#: main.c:168 main.c:241
+#: main.c:169 main.c:242
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
@@ -163,49 +163,49 @@ msgstr ""
 "Auto-reload habilitado. Simplemente guarda los archivos via USB para "
 "ejecutarlos o entra al REPL para desabilitarlos.\n"
 
-#: main.c:170
+#: main.c:171
 msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr "Ejecutando en modo seguro! La auto-recarga esta deshabilitada.\n"
 
-#: main.c:172 main.c:243
+#: main.c:173 main.c:244
 msgid "Auto-reload is off.\n"
 msgstr "Auto-recarga deshabilitada.\n"
 
-#: main.c:186
+#: main.c:187
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr "Ejecutando en modo seguro! No se esta ejecutando el código guardado.\n"
 
-#: main.c:202
+#: main.c:203
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr "ADVERTENCIA: El nombre de archivo de tu código tiene dos extensiones\n"
 
-#: main.c:250
+#: main.c:251
 msgid "You requested starting safe mode by "
 msgstr "Solicitaste iniciar en modo seguro por "
 
-#: main.c:253
+#: main.c:254
 msgid "To exit, please reset the board without "
 msgstr "Para salir, por favor reinicia la tarjeta sin "
 
-#: main.c:260
+#: main.c:261
 msgid ""
 "You are running in safe mode which means something really bad happened.\n"
 msgstr ""
 "Estás ejecutando en modo seguro, lo cual significa que algo realmente malo "
 "ha sucedido.\n"
 
-#: main.c:262
+#: main.c:263
 msgid "Looks like our core CircuitPython code crashed hard. Whoops!\n"
 msgstr "Parece que nuestro código CircuitPython dejó de funcionar. Whoops!\n"
 
-#: main.c:263
+#: main.c:264
 #, fuzzy
 msgid "Please file an issue here with the contents of your CIRCUITPY drive:\n"
 msgstr ""
 "Por favor registra un issue en el siguiente URL con los contenidos de tu "
 "unidad de almacenamiento CIRCUITPY:\n"
 
-#: main.c:266
+#: main.c:267
 msgid ""
 "The microcontroller's power dipped. Please make sure your power supply "
 "provides\n"
@@ -213,7 +213,7 @@ msgstr ""
 "La alimentación del microcontrolador cayó. Por favor asegurate de que tu "
 "fuente de alimentación provee\n"
 
-#: main.c:267
+#: main.c:268
 msgid ""
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
@@ -221,12 +221,12 @@ msgstr ""
 "suficiente poder para todo el circuito y presiona reset (después de expulsar "
 "CIRCUITPY).\n"
 
-#: main.c:271
+#: main.c:272
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 "Presiona cualquier tecla para entrar al REPL. Usa CTRL-D para recargar."
 
-#: main.c:429
+#: main.c:430
 msgid "soft reboot\n"
 msgstr "reinicio suave\n"
 
@@ -1341,27 +1341,27 @@ msgstr "buffer demasiado pequeño"
 msgid "expecting a dict for keyword args"
 msgstr ""
 
-#: py/moduerrno.c:143 py/moduerrno.c:146
+#: py/moduerrno.c:147 py/moduerrno.c:150
 msgid "Permission denied"
 msgstr ""
 
-#: py/moduerrno.c:144
+#: py/moduerrno.c:148
 msgid "No such file/directory"
 msgstr ""
 
-#: py/moduerrno.c:145
+#: py/moduerrno.c:149
 msgid "Input/output error"
 msgstr ""
 
-#: py/moduerrno.c:147
+#: py/moduerrno.c:151
 msgid "File exists"
 msgstr ""
 
-#: py/moduerrno.c:148
+#: py/moduerrno.c:152
 msgid "Unsupported operation"
 msgstr "Operacion no soportada"
 
-#: py/moduerrno.c:149
+#: py/moduerrno.c:153
 msgid "Invalid argument"
 msgstr "Argumento inválido"
 
@@ -1990,6 +1990,14 @@ msgstr ""
 msgid "stream operation not supported"
 msgstr "operación stream no soportada"
 
+#: py/stream.c:254
+msgid "string not supported; use bytes or bytearray"
+msgstr ""
+
+#: py/stream.c:289
+msgid "length argument not allowed for this type"
+msgstr ""
+
 #: py/vm.c:255
 msgid "local variable referenced before assignment"
 msgstr ""
@@ -2150,11 +2158,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr ""
 
-#: shared-bindings/busio/UART.c:102
+#: shared-bindings/busio/UART.c:104
 msgid "bits must be 7, 8 or 9"
 msgstr ""
 
-#: shared-bindings/busio/UART.c:114
+#: shared-bindings/busio/UART.c:116
 msgid "stop must be 1 or 2"
 msgstr ""
 
@@ -2379,15 +2387,15 @@ msgstr ""
 msgid "time.struct_time() takes a 9-sequence"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:264
+#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:263
 msgid "Tuple or struct_time argument required"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:269
+#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:268
 msgid "function takes exactly 9 arguments"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:240 shared-bindings/time/__init__.c:273
+#: shared-bindings/time/__init__.c:239 shared-bindings/time/__init__.c:272
 msgid "timestamp out of range for platform time_t"
 msgstr ""
 
@@ -2531,35 +2539,35 @@ msgstr "USB ocupado"
 msgid "USB Error"
 msgstr "Error USB"
 
-#~ msgid "Baud rate too high for this SPI peripheral"
-#~ msgstr "Baud rate demasiado alto para este periférico SPI"
-
-#~ msgid "Invalid Service type"
-#~ msgstr "Tipo de Servicio inválido"
-
-#~ msgid "Can encode UUID into the advertisement packet."
-#~ msgstr "Se puede codificar el UUID en el paquete de anuncio."
-
-#~ msgid "Can not encode UUID, to check length."
-#~ msgstr "No se puede codificar el UUID, para revisar la longitud."
-
-#~ msgid "Can not query for the device address."
-#~ msgstr "No se puede consultar la dirección del dispositivo."
-
-#~ msgid "Can not apply advertisement data. status: 0x%02x"
-#~ msgstr "No se puede aplicar los datos de anuncio. status: 0x%02x"
-
-#~ msgid "Can not apply device name in the stack."
-#~ msgstr "No se puede aplicar el nombre del dispositivo en el stack."
-
-#~ msgid "Can not add Characteristic."
-#~ msgstr "No se puede agregar la Característica."
-
-#~ msgid "Cannot apply GAP parameters."
-#~ msgstr "No se pueden aplicar los parámetros GAP."
+#~ msgid "Can not add Service."
+#~ msgstr "No se puede agregar el Servicio."
 
 #~ msgid "Cannot set PPCP parameters."
 #~ msgstr "No se pueden establecer los parámetros PPCP."
 
-#~ msgid "Can not add Service."
-#~ msgstr "No se puede agregar el Servicio."
+#~ msgid "Cannot apply GAP parameters."
+#~ msgstr "No se pueden aplicar los parámetros GAP."
+
+#~ msgid "Can not add Characteristic."
+#~ msgstr "No se puede agregar la Característica."
+
+#~ msgid "Can not apply device name in the stack."
+#~ msgstr "No se puede aplicar el nombre del dispositivo en el stack."
+
+#~ msgid "Can not apply advertisement data. status: 0x%02x"
+#~ msgstr "No se puede aplicar los datos de anuncio. status: 0x%02x"
+
+#~ msgid "Can not query for the device address."
+#~ msgstr "No se puede consultar la dirección del dispositivo."
+
+#~ msgid "Can not encode UUID, to check length."
+#~ msgstr "No se puede codificar el UUID, para revisar la longitud."
+
+#~ msgid "Can encode UUID into the advertisement packet."
+#~ msgstr "Se puede codificar el UUID en el paquete de anuncio."
+
+#~ msgid "Invalid Service type"
+#~ msgstr "Tipo de Servicio inválido"
+
+#~ msgid "Baud rate too high for this SPI peripheral"
+#~ msgstr "Baud rate demasiado alto para este periférico SPI"

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-09 16:20-0800\n"
+"POT-Creation-Date: 2018-12-03 15:57-0500\n"
 "PO-Revision-Date: 2018-08-30 23:04-0700\n"
 "Last-Translator: Timothy <me@timothygarcia.ca>\n"
 "Language-Team: fil\n"
@@ -131,7 +131,7 @@ msgstr "compression header"
 msgid "invalid dupterm index"
 msgstr "mali ang dupterm index"
 
-#: extmod/vfs_fat.c:426 py/moduerrno.c:150
+#: extmod/vfs_fat.c:426 py/moduerrno.c:154
 msgid "Read-only filesystem"
 msgstr "Basahin-lamang mode"
 
@@ -151,11 +151,11 @@ msgstr "mali ang mga argumento"
 msgid "script compilation not supported"
 msgstr "script kompilasyon hindi supportado"
 
-#: main.c:154
+#: main.c:155
 msgid " output:\n"
 msgstr " output:\n"
 
-#: main.c:168 main.c:241
+#: main.c:169 main.c:242
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
@@ -163,48 +163,48 @@ msgstr ""
 "Ang awtomatikong pag re-reload ay ON. i-save lamang ang mga files sa USB "
 "para patakbuhin sila o pasukin ang REPL para i-disable ito.\n"
 
-#: main.c:170
+#: main.c:171
 msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr "Tumatakbo sa safe mode! Awtomatikong pag re-reload ay OFF.\n"
 
-#: main.c:172 main.c:243
+#: main.c:173 main.c:244
 msgid "Auto-reload is off.\n"
 msgstr "Awtomatikong pag re-reload ay OFF.\n"
 
-#: main.c:186
+#: main.c:187
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr "Tumatakbo sa safe mode! Hindi tumatakbo ang nai-save na code.\n"
 
-#: main.c:202
+#: main.c:203
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr "BABALA: Ang pangalan ng file ay may dalawang extension\n"
 
-#: main.c:250
+#: main.c:251
 msgid "You requested starting safe mode by "
 msgstr "Ikaw ang humiling sa safe mode sa pamamagitan ng "
 
-#: main.c:253
+#: main.c:254
 msgid "To exit, please reset the board without "
 msgstr "Para lumabas, paki-reset ang board na wala ang "
 
-#: main.c:260
+#: main.c:261
 msgid ""
 "You are running in safe mode which means something really bad happened.\n"
 msgstr ""
 "Ikaw ay tumatakbo sa safe mode, ang ibig sabihin nito ay may masamang "
 "nangyari.\n"
 
-#: main.c:262
+#: main.c:263
 msgid "Looks like our core CircuitPython code crashed hard. Whoops!\n"
 msgstr "Mukhang ang core CircuitPython code ay nag-crash ng malakas. Aray!\n"
 
-#: main.c:263
+#: main.c:264
 msgid "Please file an issue here with the contents of your CIRCUITPY drive:\n"
 msgstr ""
 "Mag-file ng isang isyu dito gamit ang mga nilalaman ng iyong CIRCUITPY "
 "drive:\n"
 
-#: main.c:266
+#: main.c:267
 msgid ""
 "The microcontroller's power dipped. Please make sure your power supply "
 "provides\n"
@@ -212,7 +212,7 @@ msgstr ""
 "Ang kapangyarihan ng mikrokontroller ay bumaba. Mangyaring suriin ang power "
 "supply \n"
 
-#: main.c:267
+#: main.c:268
 msgid ""
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
@@ -220,13 +220,13 @@ msgstr ""
 "ay nagbibigay ng sapat na power para sa buong circuit at i-press ang reset "
 "(pagkatapos i-eject ang CIRCUITPY).\n"
 
-#: main.c:271
+#: main.c:272
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 "Pindutin ang anumang key upang ipasok ang REPL. Gamitin ang CTRL-D upang i-"
 "reload."
 
-#: main.c:429
+#: main.c:430
 msgid "soft reboot\n"
 msgstr "malambot na reboot\n"
 
@@ -1356,27 +1356,27 @@ msgstr "masyadong maliit ang buffer"
 msgid "expecting a dict for keyword args"
 msgstr "umaasa ng dict para sa keyword args"
 
-#: py/moduerrno.c:143 py/moduerrno.c:146
+#: py/moduerrno.c:147 py/moduerrno.c:150
 msgid "Permission denied"
 msgstr "Walang pahintulot"
 
-#: py/moduerrno.c:144
+#: py/moduerrno.c:148
 msgid "No such file/directory"
 msgstr "Walang file/directory"
 
-#: py/moduerrno.c:145
+#: py/moduerrno.c:149
 msgid "Input/output error"
 msgstr "May mali sa Input/Output"
 
-#: py/moduerrno.c:147
+#: py/moduerrno.c:151
 msgid "File exists"
 msgstr "Mayroong file"
 
-#: py/moduerrno.c:148
+#: py/moduerrno.c:152
 msgid "Unsupported operation"
 msgstr "Hindi sinusuportahang operasyon"
 
-#: py/moduerrno.c:149
+#: py/moduerrno.c:153
 msgid "Invalid argument"
 msgstr "Maling argumento"
 
@@ -2015,6 +2015,14 @@ msgstr "object wala sa sequence"
 msgid "stream operation not supported"
 msgstr "stream operation hindi sinusuportahan"
 
+#: py/stream.c:254
+msgid "string not supported; use bytes or bytearray"
+msgstr ""
+
+#: py/stream.c:289
+msgid "length argument not allowed for this type"
+msgstr ""
+
 #: py/vm.c:255
 msgid "local variable referenced before assignment"
 msgstr "local variable na reference bago na i-assign"
@@ -2185,11 +2193,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr "Kailangan ng lock ang function."
 
-#: shared-bindings/busio/UART.c:102
+#: shared-bindings/busio/UART.c:104
 msgid "bits must be 7, 8 or 9"
 msgstr "bits ay dapat 7, 8 o 9"
 
-#: shared-bindings/busio/UART.c:114
+#: shared-bindings/busio/UART.c:116
 msgid "stop must be 1 or 2"
 msgstr "stop dapat 1 o 2"
 
@@ -2430,15 +2438,15 @@ msgstr "time.struct_time() kumukuha ng 1 argument"
 msgid "time.struct_time() takes a 9-sequence"
 msgstr "time.struct_time() kumukuha ng 9-sequence"
 
-#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:264
+#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:263
 msgid "Tuple or struct_time argument required"
 msgstr "Tuple o struct_time argument kailangan"
 
-#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:269
+#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:268
 msgid "function takes exactly 9 arguments"
 msgstr "function kumukuha ng 9 arguments"
 
-#: shared-bindings/time/__init__.c:240 shared-bindings/time/__init__.c:273
+#: shared-bindings/time/__init__.c:239 shared-bindings/time/__init__.c:272
 msgid "timestamp out of range for platform time_t"
 msgstr "wala sa sakop ng timestamp ang platform time_t"
 
@@ -2586,36 +2594,36 @@ msgstr "Busy ang USB"
 msgid "USB Error"
 msgstr "May pagkakamali ang USB"
 
-#, fuzzy
-#~ msgid "palette must be displayio.Palette"
-#~ msgstr "ang palette ay dapat 32 bytes ang haba"
-
-#~ msgid "Invalid Service type"
-#~ msgstr "Mali ang tipo ng serbisyo"
-
-#~ msgid "Can encode UUID into the advertisement packet."
-#~ msgstr "Maaring i-encode ang UUID sa advertisement packet."
-
-#~ msgid "Can not encode UUID, to check length."
-#~ msgstr "Hindi ma-encode UUID, para suriin ang haba."
-
-#~ msgid "Can not query for the device address."
-#~ msgstr "Hindi maaaring mag-query para sa address ng device."
-
-#~ msgid "Can not apply advertisement data. status: 0x%02x"
-#~ msgstr "Hindi ma i-apply ang advertisement data. status: 0x%02x"
-
-#~ msgid "Can not apply device name in the stack."
-#~ msgstr "Hindi maaaring ma-aplay ang device name sa stack."
-
-#~ msgid "Can not add Characteristic."
-#~ msgstr "Hindi mabasa and Characteristic."
-
-#~ msgid "Cannot apply GAP parameters."
-#~ msgstr "Hindi ma-apply ang GAP parameters."
+#~ msgid "Can not add Service."
+#~ msgstr "Hindi maidaragdag ang serbisyo."
 
 #~ msgid "Cannot set PPCP parameters."
 #~ msgstr "Hindi ma-set ang PPCP parameters."
 
-#~ msgid "Can not add Service."
-#~ msgstr "Hindi maidaragdag ang serbisyo."
+#~ msgid "Cannot apply GAP parameters."
+#~ msgstr "Hindi ma-apply ang GAP parameters."
+
+#~ msgid "Can not add Characteristic."
+#~ msgstr "Hindi mabasa and Characteristic."
+
+#~ msgid "Can not apply device name in the stack."
+#~ msgstr "Hindi maaaring ma-aplay ang device name sa stack."
+
+#~ msgid "Can not apply advertisement data. status: 0x%02x"
+#~ msgstr "Hindi ma i-apply ang advertisement data. status: 0x%02x"
+
+#~ msgid "Can not query for the device address."
+#~ msgstr "Hindi maaaring mag-query para sa address ng device."
+
+#~ msgid "Can not encode UUID, to check length."
+#~ msgstr "Hindi ma-encode UUID, para suriin ang haba."
+
+#~ msgid "Can encode UUID into the advertisement packet."
+#~ msgstr "Maaring i-encode ang UUID sa advertisement packet."
+
+#~ msgid "Invalid Service type"
+#~ msgstr "Mali ang tipo ng serbisyo"
+
+#, fuzzy
+#~ msgid "palette must be displayio.Palette"
+#~ msgstr "ang palette ay dapat 32 bytes ang haba"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-09 16:20-0800\n"
+"POT-Creation-Date: 2018-12-03 15:57-0500\n"
 "PO-Revision-Date: 2018-08-14 11:01+0200\n"
 "Last-Translator: Pierrick Couturier <arofarn@arofarn.info>\n"
 "Language-Team: fr\n"
@@ -130,7 +130,7 @@ msgstr "entête de compression"
 msgid "invalid dupterm index"
 msgstr "index invalide pour dupterm"
 
-#: extmod/vfs_fat.c:426 py/moduerrno.c:150
+#: extmod/vfs_fat.c:426 py/moduerrno.c:154
 msgid "Read-only filesystem"
 msgstr "Système de fichier en lecture seule"
 
@@ -150,11 +150,11 @@ msgstr "arguments invalides"
 msgid "script compilation not supported"
 msgstr "compilation du script non supporté"
 
-#: main.c:154
+#: main.c:155
 msgid " output:\n"
 msgstr " sortie:\n"
 
-#: main.c:168 main.c:241
+#: main.c:169 main.c:242
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
@@ -162,46 +162,46 @@ msgstr ""
 "Auto-chargement activé. Copiez simplement les fichiers en USB pour les "
 "lancer ou entrez sur REPL pour le désactiver.\n"
 
-#: main.c:170
+#: main.c:171
 msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr "Mode sans-échec. Auto-rechargement désactivé.\n"
 
-#: main.c:172 main.c:243
+#: main.c:173 main.c:244
 msgid "Auto-reload is off.\n"
 msgstr "Auto-rechargement désactivé.\n"
 
-#: main.c:186
+#: main.c:187
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr "Mode sans-échec! Le code sauvegardé ne s'éxecute pas.\n"
 
-#: main.c:202
+#: main.c:203
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr "ATTENTION: le nom de fichier de votre code a deux extensions\n"
 
-#: main.c:250
+#: main.c:251
 msgid "You requested starting safe mode by "
 msgstr "Vous avez demandé à démarrer en mode sans-échec par "
 
-#: main.c:253
+#: main.c:254
 msgid "To exit, please reset the board without "
 msgstr "Pour quitter, redémarrez la carte SVP sans "
 
-#: main.c:260
+#: main.c:261
 msgid ""
 "You are running in safe mode which means something really bad happened.\n"
 msgstr ""
 "Vous êtes en mode sans-échec ce qui signifie que quelque chose demauvais est "
 "arrivé.\n"
 
-#: main.c:262
+#: main.c:263
 msgid "Looks like our core CircuitPython code crashed hard. Whoops!\n"
 msgstr "Il semblerait que votre code CircuitPython a durement planté. Oups!\n"
 
-#: main.c:263
+#: main.c:264
 msgid "Please file an issue here with the contents of your CIRCUITPY drive:\n"
 msgstr "SVP, remontez le problème là avec le contenu du lecteur CIRCUITPY:\n"
 
-#: main.c:266
+#: main.c:267
 msgid ""
 "The microcontroller's power dipped. Please make sure your power supply "
 "provides\n"
@@ -209,7 +209,7 @@ msgstr ""
 "L'alimentation du microcontroleur a chuté. Merci de vérifier que votre "
 "alimentation fournit\n"
 
-#: main.c:267
+#: main.c:268
 msgid ""
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
@@ -217,11 +217,11 @@ msgstr ""
 "assez de puissance pour l'ensemble du circuit et appuyez sur 'reset' (après "
 "avoir éjecter CIRCUITPY).\n"
 
-#: main.c:271
+#: main.c:272
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr "Appuyez sur une touche pour entrer sur REPL ou CTRL-D pour recharger."
 
-#: main.c:429
+#: main.c:430
 msgid "soft reboot\n"
 msgstr "redémarrage logiciel\n"
 
@@ -1346,27 +1346,27 @@ msgstr "tampon trop petit"
 msgid "expecting a dict for keyword args"
 msgstr "un dict est attendu pour les arguments nommés"
 
-#: py/moduerrno.c:143 py/moduerrno.c:146
+#: py/moduerrno.c:147 py/moduerrno.c:150
 msgid "Permission denied"
 msgstr "Permission refusée"
 
-#: py/moduerrno.c:144
+#: py/moduerrno.c:148
 msgid "No such file/directory"
 msgstr "Fichier/dossier introuvable"
 
-#: py/moduerrno.c:145
+#: py/moduerrno.c:149
 msgid "Input/output error"
 msgstr "Erreur d'entrée/sortie"
 
-#: py/moduerrno.c:147
+#: py/moduerrno.c:151
 msgid "File exists"
 msgstr "Le fichier existe"
 
-#: py/moduerrno.c:148
+#: py/moduerrno.c:152
 msgid "Unsupported operation"
 msgstr "Opération non supportée"
 
-#: py/moduerrno.c:149
+#: py/moduerrno.c:153
 msgid "Invalid argument"
 msgstr "Argument invalide"
 
@@ -2006,6 +2006,14 @@ msgstr "l'objet n'est pas dans la séquence"
 msgid "stream operation not supported"
 msgstr "opération de flux non supportée"
 
+#: py/stream.c:254
+msgid "string not supported; use bytes or bytearray"
+msgstr ""
+
+#: py/stream.c:289
+msgid "length argument not allowed for this type"
+msgstr ""
+
 #: py/vm.c:255
 msgid "local variable referenced before assignment"
 msgstr "variable locale référencée avant d'être assignée"
@@ -2175,11 +2183,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr "La fonction nécessite un verrou."
 
-#: shared-bindings/busio/UART.c:102
+#: shared-bindings/busio/UART.c:104
 msgid "bits must be 7, 8 or 9"
 msgstr "bits doivent être 7, 8 ou 9"
 
-#: shared-bindings/busio/UART.c:114
+#: shared-bindings/busio/UART.c:116
 msgid "stop must be 1 or 2"
 msgstr "stop doit être 1 ou 2"
 
@@ -2428,15 +2436,15 @@ msgstr "time.struct_time() prend exactement 1 argument"
 msgid "time.struct_time() takes a 9-sequence"
 msgstr "time.struct_time() prend une séquence de longueur 9"
 
-#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:264
+#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:263
 msgid "Tuple or struct_time argument required"
 msgstr "Argument de type tuple ou struct_time nécessaire"
 
-#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:269
+#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:268
 msgid "function takes exactly 9 arguments"
 msgstr "la fonction prend exactement 9 arguments"
 
-#: shared-bindings/time/__init__.c:240 shared-bindings/time/__init__.c:273
+#: shared-bindings/time/__init__.c:239 shared-bindings/time/__init__.c:272
 msgid "timestamp out of range for platform time_t"
 msgstr "timestamp hors gamme pour la plateforme time_t"
 
@@ -2584,34 +2592,34 @@ msgstr "USB occupé"
 msgid "USB Error"
 msgstr "Erreur USB"
 
-#, fuzzy
-#~ msgid "palette must be displayio.Palette"
-#~ msgstr "palettre doit être displayio.Palette"
+#~ msgid "Can not add Characteristic."
+#~ msgstr "Impossible d'ajouter la Characteristic."
 
-#~ msgid "Can not query for the device address."
-#~ msgstr "Impossible d'obtenir l'adresse du périphérique"
-
-#~ msgid "Cannot set PPCP parameters."
-#~ msgstr "Impossible d'appliquer les paramètres PPCP"
-
-#~ msgid "Cannot apply GAP parameters."
-#~ msgstr "Impossible d'appliquer les paramètres GAP"
-
-#~ msgid "Can not encode UUID, to check length."
-#~ msgstr "Impossible d'encoder l'UUID pour vérifier la longueur."
-
-#~ msgid "Invalid Service type"
-#~ msgstr "Type de service invalide"
-
-#~ msgid "Can not apply device name in the stack."
-#~ msgstr "Impossible d'appliquer le nom de périphérique dans la pile"
+#~ msgid "Can not add Service."
+#~ msgstr "Impossible d'ajouter le Service"
 
 #, fuzzy
 #~ msgid "value_size must be power of two"
 #~ msgstr "value_size est une puissance de deux"
 
-#~ msgid "Can not add Service."
-#~ msgstr "Impossible d'ajouter le Service"
+#~ msgid "Can not apply device name in the stack."
+#~ msgstr "Impossible d'appliquer le nom de périphérique dans la pile"
 
-#~ msgid "Can not add Characteristic."
-#~ msgstr "Impossible d'ajouter la Characteristic."
+#~ msgid "Invalid Service type"
+#~ msgstr "Type de service invalide"
+
+#~ msgid "Can not encode UUID, to check length."
+#~ msgstr "Impossible d'encoder l'UUID pour vérifier la longueur."
+
+#~ msgid "Cannot apply GAP parameters."
+#~ msgstr "Impossible d'appliquer les paramètres GAP"
+
+#~ msgid "Cannot set PPCP parameters."
+#~ msgstr "Impossible d'appliquer les paramètres PPCP"
+
+#~ msgid "Can not query for the device address."
+#~ msgstr "Impossible d'obtenir l'adresse du périphérique"
+
+#, fuzzy
+#~ msgid "palette must be displayio.Palette"
+#~ msgstr "palettre doit être displayio.Palette"

--- a/locale/it_IT.po
+++ b/locale/it_IT.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-09 16:20-0800\n"
+"POT-Creation-Date: 2018-12-03 15:57-0500\n"
 "PO-Revision-Date: 2018-10-02 16:27+0200\n"
 "Last-Translator: Enrico Paganin <enrico.paganin@mail.com>\n"
 "Language-Team: \n"
@@ -131,7 +131,7 @@ msgstr "compressione dell'header"
 msgid "invalid dupterm index"
 msgstr "indice dupterm non valido"
 
-#: extmod/vfs_fat.c:426 py/moduerrno.c:150
+#: extmod/vfs_fat.c:426 py/moduerrno.c:154
 msgid "Read-only filesystem"
 msgstr "Filesystem in sola lettura"
 
@@ -151,11 +151,11 @@ msgstr "argomenti non validi"
 msgid "script compilation not supported"
 msgstr "compilazione dello scrip non suportata"
 
-#: main.c:154
+#: main.c:155
 msgid " output:\n"
 msgstr " output:\n"
 
-#: main.c:168 main.c:241
+#: main.c:169 main.c:242
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
@@ -163,50 +163,50 @@ msgstr ""
 "L'auto-reload è attivo. Salva i file su USB per eseguirli o entra nel REPL "
 "per disabilitarlo.\n"
 
-#: main.c:170
+#: main.c:171
 msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr "Modalità sicura in esecuzione! Auto-reload disattivato.\n"
 
-#: main.c:172 main.c:243
+#: main.c:173 main.c:244
 msgid "Auto-reload is off.\n"
 msgstr "Auto-reload disattivato.\n"
 
-#: main.c:186
+#: main.c:187
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr "Modalità sicura in esecuzione! Codice salvato non in esecuzione.\n"
 
-#: main.c:202
+#: main.c:203
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr "ATTENZIONE: Il nome del sorgente ha due estensioni\n"
 
-#: main.c:250
+#: main.c:251
 msgid "You requested starting safe mode by "
 msgstr "È stato richiesto l'avvio in modalità sicura da "
 
-#: main.c:253
+#: main.c:254
 msgid "To exit, please reset the board without "
 msgstr "Per uscire resettare la scheda senza "
 
-#: main.c:260
+#: main.c:261
 msgid ""
 "You are running in safe mode which means something really bad happened.\n"
 msgstr ""
 "Sei nella modalità sicura che significa che qualcosa di molto brutto è "
 "successo.\n"
 
-#: main.c:262
+#: main.c:263
 msgid "Looks like our core CircuitPython code crashed hard. Whoops!\n"
 msgstr ""
 "Sembra che il codice del core di CircuitPython sia crashato malamente. "
 "Whoops!\n"
 
-#: main.c:263
+#: main.c:264
 msgid "Please file an issue here with the contents of your CIRCUITPY drive:\n"
 msgstr ""
 "Ti preghiamo di compilare una issue con il contenuto del tuo drie "
 "CIRCUITPY:\n"
 
-#: main.c:266
+#: main.c:267
 msgid ""
 "The microcontroller's power dipped. Please make sure your power supply "
 "provides\n"
@@ -214,7 +214,7 @@ msgstr ""
 "La potenza del microcontrollore è calata. Assicurati che l'alimentazione sia "
 "attaccata correttamente\n"
 
-#: main.c:267
+#: main.c:268
 msgid ""
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
@@ -222,12 +222,12 @@ msgstr ""
 "abbastanza potenza per l'intero circuito e premere reset (dopo aver espulso "
 "CIRCUITPY).\n"
 
-#: main.c:271
+#: main.c:272
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 "Premi un qualunque tasto per entrare nel REPL. Usa CTRL-D per ricaricare."
 
-#: main.c:429
+#: main.c:430
 msgid "soft reboot\n"
 msgstr "soft reboot\n"
 
@@ -1355,27 +1355,27 @@ msgstr "buffer troppo piccolo"
 msgid "expecting a dict for keyword args"
 msgstr "argomenti nominati necessitano un dizionario"
 
-#: py/moduerrno.c:143 py/moduerrno.c:146
+#: py/moduerrno.c:147 py/moduerrno.c:150
 msgid "Permission denied"
 msgstr "Permesso negato"
 
-#: py/moduerrno.c:144
+#: py/moduerrno.c:148
 msgid "No such file/directory"
 msgstr "Nessun file/directory esistente"
 
-#: py/moduerrno.c:145
+#: py/moduerrno.c:149
 msgid "Input/output error"
 msgstr "Errore input/output"
 
-#: py/moduerrno.c:147
+#: py/moduerrno.c:151
 msgid "File exists"
 msgstr "File esistente"
 
-#: py/moduerrno.c:148
+#: py/moduerrno.c:152
 msgid "Unsupported operation"
 msgstr "Operazione non supportata"
 
-#: py/moduerrno.c:149
+#: py/moduerrno.c:153
 msgid "Invalid argument"
 msgstr "Argomento non valido"
 
@@ -2011,6 +2011,14 @@ msgstr "oggetto non in sequenza"
 msgid "stream operation not supported"
 msgstr "operazione di stream non supportata"
 
+#: py/stream.c:254
+msgid "string not supported; use bytes or bytearray"
+msgstr ""
+
+#: py/stream.c:289
+msgid "length argument not allowed for this type"
+msgstr ""
+
 #: py/vm.c:255
 msgid "local variable referenced before assignment"
 msgstr "variabile locale richiamata prima di un assegnamento"
@@ -2180,11 +2188,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr ""
 
-#: shared-bindings/busio/UART.c:102
+#: shared-bindings/busio/UART.c:104
 msgid "bits must be 7, 8 or 9"
 msgstr "i bit devono essere 7, 8 o 9"
 
-#: shared-bindings/busio/UART.c:114
+#: shared-bindings/busio/UART.c:116
 msgid "stop must be 1 or 2"
 msgstr ""
 
@@ -2417,15 +2425,15 @@ msgstr "time.struct_time() prende esattamente un argomento"
 msgid "time.struct_time() takes a 9-sequence"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:264
+#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:263
 msgid "Tuple or struct_time argument required"
 msgstr "Tupla o struct_time richiesto come argomento"
 
-#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:269
+#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:268
 msgid "function takes exactly 9 arguments"
 msgstr "la funzione prende esattamente 9 argomenti"
 
-#: shared-bindings/time/__init__.c:240 shared-bindings/time/__init__.c:273
+#: shared-bindings/time/__init__.c:239 shared-bindings/time/__init__.c:272
 msgid "timestamp out of range for platform time_t"
 msgstr "timestamp è fuori intervallo per il time_t della piattaforma"
 
@@ -2571,32 +2579,32 @@ msgstr "USB occupata"
 msgid "USB Error"
 msgstr "Errore USB"
 
-#~ msgid "Invalid Service type"
-#~ msgstr "Tipo di servizio non valido"
-
-#~ msgid "Can not query for the device address."
-#~ msgstr "Non è possibile trovare l'indirizzo del dispositivo."
-
-#~ msgid "Cannot set PPCP parameters."
-#~ msgstr "Impossibile impostare i parametri PPCP."
-
-#~ msgid "Cannot apply GAP parameters."
-#~ msgstr "Impossibile applicare i parametri GAP."
-
-#~ msgid "Can not encode UUID, to check length."
-#~ msgstr "Non è possibile codificare l'UUID, lunghezza da controllare."
-
-#~ msgid "Can encode UUID into the advertisement packet."
-#~ msgstr "È possibile codificare l'UUID nel pacchetto di advertisement."
-
-#~ msgid "Can not apply device name in the stack."
-#~ msgstr "Non è possibile inserire il nome del dipositivo nella lista."
-
-#~ msgid "Can not apply advertisement data. status: 0x%02x"
-#~ msgstr "Impossible inserire dati advertisement. status: 0x%02x"
+#~ msgid "Can not add Characteristic."
+#~ msgstr "Non è possibile aggiungere Characteristic."
 
 #~ msgid "Can not add Service."
 #~ msgstr "Non è possibile aggiungere Service."
 
-#~ msgid "Can not add Characteristic."
-#~ msgstr "Non è possibile aggiungere Characteristic."
+#~ msgid "Can not apply advertisement data. status: 0x%02x"
+#~ msgstr "Impossible inserire dati advertisement. status: 0x%02x"
+
+#~ msgid "Can not apply device name in the stack."
+#~ msgstr "Non è possibile inserire il nome del dipositivo nella lista."
+
+#~ msgid "Can encode UUID into the advertisement packet."
+#~ msgstr "È possibile codificare l'UUID nel pacchetto di advertisement."
+
+#~ msgid "Can not encode UUID, to check length."
+#~ msgstr "Non è possibile codificare l'UUID, lunghezza da controllare."
+
+#~ msgid "Cannot apply GAP parameters."
+#~ msgstr "Impossibile applicare i parametri GAP."
+
+#~ msgid "Cannot set PPCP parameters."
+#~ msgstr "Impossibile impostare i parametri PPCP."
+
+#~ msgid "Can not query for the device address."
+#~ msgstr "Non è possibile trovare l'indirizzo del dispositivo."
+
+#~ msgid "Invalid Service type"
+#~ msgstr "Tipo di servizio non valido"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-09 16:20-0800\n"
+"POT-Creation-Date: 2018-12-03 15:57-0500\n"
 "PO-Revision-Date: 2018-10-02 21:14-0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "invalid dupterm index"
 msgstr "Índice de dupterm inválido"
 
-#: extmod/vfs_fat.c:426 py/moduerrno.c:150
+#: extmod/vfs_fat.c:426 py/moduerrno.c:154
 msgid "Read-only filesystem"
 msgstr "Sistema de arquivos somente leitura"
 
@@ -151,70 +151,70 @@ msgstr "argumentos inválidos"
 msgid "script compilation not supported"
 msgstr "compilação de script não suportada"
 
-#: main.c:154
+#: main.c:155
 msgid " output:\n"
 msgstr " saída:\n"
 
-#: main.c:168 main.c:241
+#: main.c:169 main.c:242
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
 msgstr ""
 
-#: main.c:170
+#: main.c:171
 msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr "Rodando em modo seguro! Atualização automática está desligada.\n"
 
-#: main.c:172 main.c:243
+#: main.c:173 main.c:244
 msgid "Auto-reload is off.\n"
 msgstr "A atualização automática está desligada.\n"
 
-#: main.c:186
+#: main.c:187
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr "Rodando em modo seguro! Não está executando o código salvo.\n"
 
-#: main.c:202
+#: main.c:203
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr "AVISO: Seu arquivo de código tem duas extensões\n"
 
-#: main.c:250
+#: main.c:251
 msgid "You requested starting safe mode by "
 msgstr "Você solicitou o início do modo de segurança"
 
-#: main.c:253
+#: main.c:254
 msgid "To exit, please reset the board without "
 msgstr "Para sair, por favor, reinicie a placa sem "
 
-#: main.c:260
+#: main.c:261
 msgid ""
 "You are running in safe mode which means something really bad happened.\n"
 msgstr ""
 
-#: main.c:262
+#: main.c:263
 msgid "Looks like our core CircuitPython code crashed hard. Whoops!\n"
 msgstr ""
 
-#: main.c:263
+#: main.c:264
 msgid "Please file an issue here with the contents of your CIRCUITPY drive:\n"
 msgstr ""
 
-#: main.c:266
+#: main.c:267
 msgid ""
 "The microcontroller's power dipped. Please make sure your power supply "
 "provides\n"
 msgstr ""
 
-#: main.c:267
+#: main.c:268
 msgid ""
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
 
-#: main.c:271
+#: main.c:272
 msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 msgstr ""
 
-#: main.c:429
+#: main.c:430
 msgid "soft reboot\n"
 msgstr ""
 
@@ -1331,27 +1331,27 @@ msgstr ""
 msgid "expecting a dict for keyword args"
 msgstr ""
 
-#: py/moduerrno.c:143 py/moduerrno.c:146
+#: py/moduerrno.c:147 py/moduerrno.c:150
 msgid "Permission denied"
 msgstr "Permissão negada"
 
-#: py/moduerrno.c:144
+#: py/moduerrno.c:148
 msgid "No such file/directory"
 msgstr ""
 
-#: py/moduerrno.c:145
+#: py/moduerrno.c:149
 msgid "Input/output error"
 msgstr ""
 
-#: py/moduerrno.c:147
+#: py/moduerrno.c:151
 msgid "File exists"
 msgstr "Arquivo já existe"
 
-#: py/moduerrno.c:148
+#: py/moduerrno.c:152
 msgid "Unsupported operation"
 msgstr ""
 
-#: py/moduerrno.c:149
+#: py/moduerrno.c:153
 msgid "Invalid argument"
 msgstr "Argumento inválido"
 
@@ -1980,6 +1980,14 @@ msgstr "objeto não em seqüência"
 msgid "stream operation not supported"
 msgstr ""
 
+#: py/stream.c:254
+msgid "string not supported; use bytes or bytearray"
+msgstr ""
+
+#: py/stream.c:289
+msgid "length argument not allowed for this type"
+msgstr ""
+
 #: py/vm.c:255
 msgid "local variable referenced before assignment"
 msgstr ""
@@ -2141,11 +2149,11 @@ msgstr ""
 msgid "Function requires lock."
 msgstr ""
 
-#: shared-bindings/busio/UART.c:102
+#: shared-bindings/busio/UART.c:104
 msgid "bits must be 7, 8 or 9"
 msgstr ""
 
-#: shared-bindings/busio/UART.c:114
+#: shared-bindings/busio/UART.c:116
 msgid "stop must be 1 or 2"
 msgstr ""
 
@@ -2370,15 +2378,15 @@ msgstr ""
 msgid "time.struct_time() takes a 9-sequence"
 msgstr ""
 
-#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:264
+#: shared-bindings/time/__init__.c:169 shared-bindings/time/__init__.c:263
 msgid "Tuple or struct_time argument required"
 msgstr "Tuple or struct_time argument required"
 
-#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:269
+#: shared-bindings/time/__init__.c:174 shared-bindings/time/__init__.c:268
 msgid "function takes exactly 9 arguments"
 msgstr "função leva exatamente 9 argumentos"
 
-#: shared-bindings/time/__init__.c:240 shared-bindings/time/__init__.c:273
+#: shared-bindings/time/__init__.c:239 shared-bindings/time/__init__.c:272
 msgid "timestamp out of range for platform time_t"
 msgstr "timestamp fora do intervalo para a plataforma time_t"
 
@@ -2523,32 +2531,32 @@ msgstr "USB ocupada"
 msgid "USB Error"
 msgstr "Erro na USB"
 
-#~ msgid "Baud rate too high for this SPI peripheral"
-#~ msgstr "Taxa de transmissão muito alta para esse periférico SPI"
-
-#~ msgid "Can not query for the device address."
-#~ msgstr "Não é possível consultar o endereço do dispositivo."
-
-#~ msgid "Cannot set PPCP parameters."
-#~ msgstr "Não é possível definir parâmetros PPCP."
-
-#~ msgid "Cannot apply GAP parameters."
-#~ msgstr "Não é possível aplicar parâmetros GAP."
-
-#~ msgid "Can encode UUID into the advertisement packet."
-#~ msgstr "Pode codificar o UUID no pacote de anúncios."
-
-#~ msgid "Can not apply advertisement data. status: 0x%02x"
-#~ msgstr "Não é possível aplicar dados de anúncio. status: 0x%02x"
-
-#~ msgid "Can not apply device name in the stack."
-#~ msgstr "Não é possível aplicar o nome do dispositivo na pilha."
-
-#~ msgid "Invalid Service type"
-#~ msgstr "Tipo de serviço inválido"
+#~ msgid "Can not add Characteristic."
+#~ msgstr "Não é possível adicionar Característica."
 
 #~ msgid "Can not add Service."
 #~ msgstr "Não é possível adicionar o serviço."
 
-#~ msgid "Can not add Characteristic."
-#~ msgstr "Não é possível adicionar Característica."
+#~ msgid "Invalid Service type"
+#~ msgstr "Tipo de serviço inválido"
+
+#~ msgid "Can not apply device name in the stack."
+#~ msgstr "Não é possível aplicar o nome do dispositivo na pilha."
+
+#~ msgid "Can not apply advertisement data. status: 0x%02x"
+#~ msgstr "Não é possível aplicar dados de anúncio. status: 0x%02x"
+
+#~ msgid "Can encode UUID into the advertisement packet."
+#~ msgstr "Pode codificar o UUID no pacote de anúncios."
+
+#~ msgid "Cannot apply GAP parameters."
+#~ msgstr "Não é possível aplicar parâmetros GAP."
+
+#~ msgid "Cannot set PPCP parameters."
+#~ msgstr "Não é possível definir parâmetros PPCP."
+
+#~ msgid "Can not query for the device address."
+#~ msgstr "Não é possível consultar o endereço do dispositivo."
+
+#~ msgid "Baud rate too high for this SPI peripheral"
+#~ msgstr "Taxa de transmissão muito alta para esse periférico SPI"

--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -53,7 +53,7 @@ static void usart_async_rxc_callback(const struct usart_async_descriptor *const 
 
 void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         const mcu_pin_obj_t * tx, const mcu_pin_obj_t * rx, uint32_t baudrate,
-        uint8_t bits, uart_parity_t parity, uint8_t stop, uint32_t timeout,
+        uint8_t bits, uart_parity_t parity, uint8_t stop, mp_float_t timeout,
         uint8_t receiver_buffer_size) {
     Sercom* sercom = NULL;
     uint8_t sercom_index = 255; // Unset index
@@ -74,7 +74,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
 
     self->baudrate = baudrate;
     self->character_bits = bits;
-    self->timeout_ms = timeout;
+    self->timeout_ms = timeout * 1000;
 
     // This assignment is only here because the usart_async routines take a *const argument.
     struct usart_async_descriptor * const usart_desc_p = (struct usart_async_descriptor * const) &self->usart_desc;
@@ -324,10 +324,8 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, 
         return MP_STREAM_ERROR;
     }
 
-    struct usart_async_status async_status;
-    // Could return ERR_BUSY, but if that's true there's already a problem.
-    usart_async_get_status(usart_desc_p, &async_status);
-    return async_status.txcnt;
+    // All the characters got written.
+    return len;
 }
 
 uint32_t common_hal_busio_uart_get_baudrate(busio_uart_obj_t *self) {

--- a/ports/esp8266/common-hal/busio/UART.c
+++ b/ports/esp8266/common-hal/busio/UART.c
@@ -39,7 +39,7 @@ extern UartDevice UartDev;
 
 void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         const mcu_pin_obj_t * tx, const mcu_pin_obj_t * rx, uint32_t baudrate,
-        uint8_t bits, uart_parity_t parity, uint8_t stop, uint32_t timeout,
+        uint8_t bits, uart_parity_t parity, uint8_t stop, mp_float_t timeout,
         uint8_t receiver_buffer_size) {
     if (rx != mp_const_none || tx != &pin_GPIO2) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_OSError, translate("Only tx supported on UART1 (GPIO2).")));

--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -76,7 +76,7 @@ static void uart_callback_irq (const nrfx_uarte_event_t * event, void * context)
 
 void common_hal_busio_uart_construct (busio_uart_obj_t *self,
                                       const mcu_pin_obj_t * tx, const mcu_pin_obj_t * rx, uint32_t baudrate,
-                                      uint8_t bits, uart_parity_t parity, uint8_t stop, uint32_t timeout,
+                                      uint8_t bits, uart_parity_t parity, uint8_t stop, mp_float_t timeout,
                                       uint8_t receiver_buffer_size) {
     if ( (tx == mp_const_none) && (rx == mp_const_none) ) {
         mp_raise_ValueError(translate("tx and rx cannot both be None"));
@@ -124,7 +124,7 @@ void common_hal_busio_uart_construct (busio_uart_obj_t *self,
     }
 
     self->baudrate = baudrate;
-    self->timeout_ms = timeout;
+    self->timeout_ms = timeout * 1000;
 
     // queue 1-byte transfer for rx_characters_available()
     self->rx_count = -1;
@@ -317,7 +317,7 @@ static uint32_t get_nrf_baud (uint32_t baudrate)
 
 void common_hal_busio_uart_construct (busio_uart_obj_t *self,
                                       const mcu_pin_obj_t * tx, const mcu_pin_obj_t * rx, uint32_t baudrate,
-                                      uint8_t bits, uart_parity_t parity, uint8_t stop, uint32_t timeout,
+                                      uint8_t bits, uart_parity_t parity, uint8_t stop, float timeout,
                                       uint8_t receiver_buffer_size) {
     mp_raise_NotImplementedError(translate("busio.UART not available"));
 }

--- a/py/stream.c
+++ b/py/stream.c
@@ -250,6 +250,9 @@ void mp_stream_write_adaptor(void *self, const char *buf, size_t len) {
 STATIC mp_obj_t stream_write_method(size_t n_args, const mp_obj_t *args) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
+    if (!mp_get_stream(args[0])->is_text && MP_OBJ_IS_STR(args[1])) {
+        mp_raise_ValueError(translate("string not supported; use bytes or bytearray"));
+    }
     size_t max_len = (size_t)-1;
     size_t off = 0;
     if (n_args == 3) {
@@ -282,6 +285,9 @@ STATIC mp_obj_t stream_readinto(size_t n_args, const mp_obj_t *args) {
     // https://docs.python.org/3/library/socket.html#socket.socket.recv_into
     mp_uint_t len = bufinfo.len;
     if (n_args > 2) {
+        if (mp_get_stream(args[0])->pyserial_compatibility) {
+            mp_raise_ValueError(translate("length argument not allowed for this type"));
+        }
         len = mp_obj_get_int(args[2]);
         if (len > bufinfo.len) {
             len = bufinfo.len;

--- a/py/stream.h
+++ b/py/stream.h
@@ -70,6 +70,7 @@ typedef struct _mp_stream_p_t {
     mp_uint_t (*write)(mp_obj_t obj, const void *buf, mp_uint_t size, int *errcode);
     mp_uint_t (*ioctl)(mp_obj_t obj, mp_uint_t request, uintptr_t arg, int *errcode);
     mp_uint_t is_text : 1; // default is bytes, set this for text stream
+    bool pyserial_compatibility: 1;  // adjust API to match pyserial more closely
 } mp_stream_p_t;
 
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(mp_stream_read_obj);

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -58,7 +58,7 @@
 //|   :param ~microcontroller.Pin scl: The clock pin
 //|   :param ~microcontroller.Pin sda: The data pin
 //|   :param int frequency: The clock frequency in Hertz
-//|   :param int timeout: The maximum clock stretching timeut - only for bitbang
+//|   :param int timeout: The maximum clock stretching timeut - (used only for bitbangio.I2C; ignored for busio.I2C)
 //|
 STATIC mp_obj_t busio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
     mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -45,7 +45,7 @@
 //| =================================================
 //|
 //|
-//| .. class:: UART(tx, rx, \*, baudrate=9600, bits=8, parity=None, stop=1, timeout=1000, receiver_buffer_size=64)
+//| .. class:: UART(tx, rx, \*, baudrate=9600, bits=8, parity=None, stop=1, timeout=1, receiver_buffer_size=64)
 //|
 //|   A common bidirectional serial protocol that uses an an agreed upon speed
 //|   rather than a shared clock line.
@@ -53,12 +53,14 @@
 //|   :param ~microcontroller.Pin tx: the pin to transmit with, or ``None`` if this ``UART`` is receive-only.
 //|   :param ~microcontroller.Pin rx: the pin to receive on, or ``None`` if this ``UART`` is transmit-only.
 //|   :param int baudrate: the transmit and receive speed.
-///   :param int bits:  the number of bits per byte, 7, 8 or 9.
-///   :param Parity parity:  the parity used for error checking.
-///   :param int stop:  the number of stop bits, 1 or 2.
-///   :param int timeout:  the timeout in milliseconds to wait for the first character and between subsequent characters.
-///   :param int receiver_buffer_size: the character length of the read buffer (0 to disable). (When a character is 9 bits the buffer will be 2 * receiver_buffer_size bytes.)
+//|   :param int bits:  the number of bits per byte, 7, 8 or 9.
+//|   :param Parity parity:  the parity used for error checking.
+//|   :param int stop:  the number of stop bits, 1 or 2.
+//|   :param int timeout:  the timeout in seconds to wait for the first character and between subsequent characters.
+//|   :param int receiver_buffer_size: the character length of the read buffer (0 to disable). (When a character is 9 bits the buffer will be 2 * receiver_buffer_size bytes.)
 //|
+//|   *New in CircuitPython 4.0:* ``timeout`` has incompatibly changed units from milliseconds to seconds.
+
 typedef struct {
     mp_obj_base_t base;
 } busio_uart_parity_obj_t;
@@ -83,7 +85,7 @@ STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, si
         { MP_QSTR_bits, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 8} },
         { MP_QSTR_parity, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_stop, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
-        { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1000} },
+        { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_SMALL_INT(1)} },
         { MP_QSTR_receiver_buffer_size, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 64} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -115,8 +117,9 @@ STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, si
     }
 
     common_hal_busio_uart_construct(self, tx, rx,
-        args[ARG_baudrate].u_int, bits, parity, stop, args[ARG_timeout].u_int,
-        args[ARG_receiver_buffer_size].u_int);
+                                    args[ARG_baudrate].u_int, bits, parity, stop,
+                                    mp_obj_get_float(args[ARG_timeout].u_obj),
+                                    args[ARG_receiver_buffer_size].u_int);
     return (mp_obj_t)self;
 }
 
@@ -161,14 +164,15 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_uart___exit___obj, 4, 4, busio_
 //|     :return: Data read
 //|     :rtype: bytes or None
 //|
-//|   .. method:: readinto(buf, nbytes=None)
+//|   .. method:: readinto(buf)
 //|
-//|     Read bytes into the ``buf``.  If ``nbytes`` is specified then read at most
-//|     that many bytes.  Otherwise, read at most ``len(buf)`` bytes.
+//|     Read bytes into the ``buf``. Read at most ``len(buf)`` bytes.
 //|
 //|     :return: number of bytes read and stored into ``buf``
 //|     :rtype: bytes or None
 //|
+//|     *New in CircuitPython 4.0:* No length parameter is permitted.
+
 //|   .. method:: readline()
 //|
 //|     Read a line, ending in a newline character.
@@ -179,6 +183,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_uart___exit___obj, 4, 4, busio_
 //|   .. method:: write(buf)
 //|
 //|     Write the buffer of bytes to the bus.
+//|
+//|     *New in CircuitPython 4.0:* ``buf`` must be bytes, not a string.
 //|
 //|     :return: the number of bytes written
 //|     :rtype: int or None
@@ -353,6 +359,8 @@ STATIC const mp_stream_p_t uart_stream_p = {
     .write = busio_uart_write,
     .ioctl = busio_uart_ioctl,
     .is_text = false,
+    // Match PySerial when possible, such as disallowing optional length argument for .readinto()
+    .pyserial_compatibility = true,
 };
 
 const mp_obj_type_t busio_uart_type = {

--- a/shared-bindings/busio/UART.h
+++ b/shared-bindings/busio/UART.h
@@ -41,7 +41,7 @@ typedef enum {
 // Construct an underlying UART object.
 extern void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     const mcu_pin_obj_t * tx, const mcu_pin_obj_t * rx, uint32_t baudrate,
-    uint8_t bits, uart_parity_t parity, uint8_t stop, uint32_t timeout,
+    uint8_t bits, uart_parity_t parity, uint8_t stop, mp_float_t timeout,
     uint8_t receiver_buffer_size);
 
 extern void common_hal_busio_uart_deinit(busio_uart_obj_t *self);


### PR DESCRIPTION
Fixes the remaining items in #1128:
- **Breaking Change**: `busio.UART` constructor `timeout` parameter is now in seconds instead of msecs
- `UART.readinto(buf)` now does not allow an optional length parameter `UART.readinto(buf, len)`
- `UART.write(...)` no longer allows strings to be written. The bytes written must be `bytes` or `bytearray` or an `array.array`.

The fixes are to make `UART` more compatible with `PySerial`, so that `PySerial` can substitute for `UART` on Linux platforms.