### PR TITLE
make sure travis sees some output in time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,9 @@ script:
   - make -C mpy-cross -j2
   - echo -en 'travis_fold:end:mpy-cross\\r'
 
-  - cd tools && python3 build_release_files.py
+  # Use unbuffered output because building all the releases can take a long time.
+  # Travis will cancel the job if it sees no output for >10 minutes.
+  - cd tools && python3 -u build_release_files.py
   - cd ..
 
   - echo 'Building unix' && echo -en 'travis_fold:start:unix\\r'

--- a/tools/build_release_files.py
+++ b/tools/build_release_files.py
@@ -71,6 +71,7 @@ for board in build_boards:
         if travis:
             print('travis_fold:end:adafruit-bins-{}-{}\\r'.format(language, board))
 
-        print()
+        # Flush so travis will see something before 10 minutes has passed.
+        print(flush=True)
 
 sys.exit(exit_status)


### PR DESCRIPTION
Travis was getting upset that it saw no output in 10 minutes. Building all the translations took a lot longer than that, and the new python build script was buffering output. Have the script flush its output and also run python3 in unbuffered output mode.