### PR TITLE
Fix running the USB task on nRF.

### DIFF
--- a/main.c
+++ b/main.c
@@ -215,8 +215,8 @@ bool run_code_py(safe_mode_t safe_mode) {
     rgb_status_animation_t animation;
     prep_rgb_status_animation(&result, found_main, safe_mode, &animation);
     while (true) {
-        #ifdef CIRCUITPY_SUPERVISOR_BACKGROUND
-            CIRCUITPY_SUPERVISOR_BACKGROUND
+        #ifdef MICROPY_VM_HOOK_LOOP
+            MICROPY_VM_HOOK_LOOP
         #endif
         if (reload_requested) {
             return true;

--- a/ports/atmel-samd/background.c
+++ b/ports/atmel-samd/background.c
@@ -39,6 +39,7 @@ volatile uint64_t last_finished_tick = 0;
 bool stack_ok_so_far = true;
 
 void run_background_tasks(void) {
+    assert_heap_ok();
     #if (defined(SAMD21) && defined(PIN_PA02)) || defined(SAMD51)
     audio_dma_background();
     #endif
@@ -50,14 +51,9 @@ void run_background_tasks(void) {
     network_module_background();
     #endif
     usb_background();
+    assert_heap_ok();
 
     last_finished_tick = ticks_ms;
-}
-
-void run_background_vm_tasks(void) {
-    assert_heap_ok();
-    run_background_tasks();
-    assert_heap_ok();
 }
 
 bool background_tasks_ok(void) {

--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -451,10 +451,8 @@ extern const struct _mp_obj_module_t wiznet_module;
     NETWORK_ROOT_POINTERS \
 
 void run_background_tasks(void);
-void run_background_vm_tasks(void);
-#define MICROPY_VM_HOOK_LOOP run_background_vm_tasks();
-#define MICROPY_VM_HOOK_RETURN run_background_vm_tasks();
-#define CIRCUITPY_SUPERVISOR_BACKGROUND run_background_tasks();
+#define MICROPY_VM_HOOK_LOOP run_background_tasks();
+#define MICROPY_VM_HOOK_RETURN run_background_tasks();
 
 #define CIRCUITPY_AUTORELOAD_DELAY_MS 500
 #define CIRCUITPY_BOOT_OUTPUT_FILE "/boot_out.txt"

--- a/ports/nrf/background.c
+++ b/ports/nrf/background.c
@@ -28,8 +28,11 @@
 #include "supervisor/usb.h"
 #endif
 
+#include "supervisor/shared/stack.h"
+
 void run_background_tasks(void) {
     #ifdef NRF52840
         usb_background();
     #endif
+    assert_heap_ok();
 }


### PR DESCRIPTION
It wasn't being run due to a rework done only on the atmel-samd port.
The rework itself isn't needed now that the heap check triggers safe
mode instead of throwing a Python exception. So, I've removed the
rework.