### PR TITLE
Nickzoic/circuitpython nrf touchin 1048

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -165,6 +165,8 @@ SRC_COMMON_HAL += \
 	supervisor/Runtime.c \
 	supervisor/__init__.c \
 	time/__init__.c \
+	touchio/__init__.c \
+	touchio/TouchIn.c \
 
 ifneq ($(SD), )
 SRC_COMMON_HAL += \

--- a/ports/nrf/common-hal/touchio/TouchIn.c
+++ b/ports/nrf/common-hal/touchio/TouchIn.c
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2018 Nick Moore for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <string.h>
+
+#include "py/nlr.h"
+#include "py/mperrno.h"
+#include "py/runtime.h"
+#include "py/binary.h"
+#include "py/mphal.h"
+#include "shared-bindings/touchio/TouchIn.h"
+#include "supervisor/shared/translate.h"
+
+#include "tick.h"
+
+bool touch_enabled = false;
+
+static uint16_t get_raw_reading(touchio_touchin_obj_t *self) {
+    return 4242;
+}
+
+void common_hal_touchio_touchin_construct(touchio_touchin_obj_t* self,
+        const mcu_pin_obj_t *pin) {
+//    if (!pin->has_touch) {
+        mp_raise_ValueError(translate("Invalid pin"));
+//    }
+//    claim_pin(pin);
+}
+
+bool common_hal_touchio_touchin_deinited(touchio_touchin_obj_t* self) {
+    return self->config.pin == NO_PIN;
+}
+
+void common_hal_touchio_touchin_deinit(touchio_touchin_obj_t* self) {
+    if (common_hal_touchio_touchin_deinited(self)) {
+        return;
+    }
+
+    reset_pin_number(self->config.pin);
+    self->config.pin = NO_PIN;
+}
+
+void touchin_reset() {
+}
+
+bool common_hal_touchio_touchin_get_value(touchio_touchin_obj_t *self) {
+    uint16_t reading = get_raw_reading(self);
+    return reading > self->threshold;
+}
+
+uint16_t common_hal_touchio_touchin_get_raw_value(touchio_touchin_obj_t *self) {
+    return get_raw_reading(self);
+}
+
+uint16_t common_hal_touchio_touchin_get_threshold(touchio_touchin_obj_t *self) {
+    return self->threshold;
+}
+
+void common_hal_touchio_touchin_set_threshold(touchio_touchin_obj_t *self, uint16_t new_threshold) {
+    self->threshold = new_threshold;
+}

--- a/ports/nrf/common-hal/touchio/TouchIn.h
+++ b/ports/nrf/common-hal/touchio/TouchIn.h
@@ -34,9 +34,7 @@
 
 typedef struct {
     mp_obj_base_t base;
-    struct {
-        uint8_t pin;
-    } config;
+    const mcu_pin_obj_t *pin;
     uint16_t threshold;
 } touchio_touchin_obj_t;
 

--- a/ports/nrf/common-hal/touchio/TouchIn.h
+++ b/ports/nrf/common-hal/touchio/TouchIn.h
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Scott Shawcroft
+ * Copyright (c) 2018 Nick Moore for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_NRF_COMMON_HAL_TOUCHIO_TOUCHIN_H
+#define MICROPY_INCLUDED_NRF_COMMON_HAL_TOUCHIO_TOUCHIN_H
+
+#include "common-hal/microcontroller/Pin.h"
+
+#include "py/obj.h"
+
+typedef struct {
+    mp_obj_base_t base;
+    struct {
+        uint8_t pin;
+    } config;
+    uint16_t threshold;
+} touchio_touchin_obj_t;
+
+void touchin_reset(void);
+
+#endif // MICROPY_INCLUDED_NRF_COMMON_HAL_TOUCHIO_TOUCHIN_H

--- a/ports/nrf/common-hal/touchio/__init__.c
+++ b/ports/nrf/common-hal/touchio/__init__.c
@@ -1,0 +1,1 @@
+// No touchio module functions.

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -175,6 +175,8 @@ extern const struct _mp_obj_module_t gamepad_module;
 extern const struct _mp_obj_module_t neopixel_write_module;
 extern const struct _mp_obj_module_t usb_hid_module;
 extern const struct _mp_obj_module_t bleio_module;
+extern const struct _mp_obj_module_t touchio_module;
+
 
 #if MICROPY_PY_BLEIO
 #define BLEIO_MODULE { MP_ROM_QSTR(MP_QSTR_bleio), MP_ROM_PTR(&bleio_module) },
@@ -205,6 +207,7 @@ extern const struct _mp_obj_module_t bleio_module;
     { MP_OBJ_NEW_QSTR (MP_QSTR_gamepad         ), (mp_obj_t)&gamepad_module         }, \
     { MP_OBJ_NEW_QSTR (MP_QSTR_time            ), (mp_obj_t)&time_module            }, \
     { MP_OBJ_NEW_QSTR (MP_QSTR_json            ), (mp_obj_t)&mp_module_ujson        }, \
+    { MP_OBJ_NEW_QSTR (MP_QSTR_touchio         ), (mp_obj_t)&touchio_module         }, \
     USBHID_MODULE  \
     BLEIO_MODULE
 


### PR DESCRIPTION
Adds touchio.TouchIn to the NRF port.  Works by driving an analog-capabile pin high and then measuring the rate of discharge through a 1Mohm resistor to ground.  See #1048 for details of implementation.