### PR TITLE
RFC: async/await + uselect + i2cslave

### DIFF
--- a/extmod/moduselect.c
+++ b/extmod/moduselect.c
@@ -121,7 +121,7 @@ STATIC mp_obj_t select_select(uint n_args, const mp_obj_t *args) {
     mp_obj_get_array(args[2], &rwx_len[2], &x_array);
 
     // get timeout
-    mp_uint_t timeout = -1;
+    mp_uint_t timeout = UINT_MAX;
     if (n_args == 4) {
         if (args[3] != mp_const_none) {
             #if MICROPY_PY_BUILTINS_FLOAT
@@ -148,7 +148,7 @@ STATIC mp_obj_t select_select(uint n_args, const mp_obj_t *args) {
         // poll the objects
         mp_uint_t n_ready = poll_map_poll(&poll_map, rwx_len);
 
-        if (n_ready > 0 || (timeout != -1 && mp_hal_ticks_ms() - start_tick >= timeout)) {
+        if (n_ready > 0 || (timeout != UINT_MAX && mp_hal_ticks_ms() - start_tick >= timeout)) {
             // one or more objects are ready, or we had a timeout
             mp_obj_t list_array[3];
             list_array[0] = mp_obj_new_list(rwx_len[0], NULL);
@@ -229,7 +229,7 @@ STATIC mp_uint_t poll_poll_internal(uint n_args, const mp_obj_t *args) {
     mp_obj_poll_t *self = args[0];
 
     // work out timeout (its given already in ms)
-    mp_uint_t timeout = -1;
+    mp_uint_t timeout = UINT_MAX;
     int flags = 0;
     if (n_args >= 2) {
         if (args[1] != mp_const_none) {
@@ -250,7 +250,7 @@ STATIC mp_uint_t poll_poll_internal(uint n_args, const mp_obj_t *args) {
     for (;;) {
         // poll the objects
         n_ready = poll_map_poll(&self->poll_map, NULL);
-        if (n_ready > 0 || (timeout != -1 && mp_hal_ticks_ms() - start_tick >= timeout)) {
+        if (n_ready > 0 || (timeout != UINT_MAX && mp_hal_ticks_ms() - start_tick >= timeout)) {
             break;
         }
         MICROPY_EVENT_POLL_HOOK

--- a/ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
+++ b/ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
@@ -143,13 +143,22 @@ int common_hal_i2cslave_i2c_slave_is_addressed(i2cslave_i2c_slave_obj_t *self, u
 
     self->writing = false;
 
-    *address = self->sercom->I2CS.DATA.reg >> 1;
-    *is_read = self->sercom->I2CS.STATUS.bit.DIR;
-    *is_restart = self->sercom->I2CS.STATUS.bit.SR;
+    uint8_t addr = self->sercom->I2CS.DATA.reg >> 1;
+    if (address) {
+        *address = addr;
+    }
+    if (is_read) {
+        *is_read = self->sercom->I2CS.STATUS.bit.DIR;
+    }
+    if (is_restart) {
+        *is_restart = self->sercom->I2CS.STATUS.bit.SR;
+    }
 
     for (unsigned int i = 0; i < self->num_addresses; i++) {
-        if (*address == self->addresses[i]) {
-            common_hal_i2cslave_i2c_slave_ack(self, true);
+        if (addr == self->addresses[i]) {
+            if (address) {
+                common_hal_i2cslave_i2c_slave_ack(self, true);
+            }
             return 1;
         }
     }

--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -31,7 +31,6 @@
 #define MICROPY_ENABLE_DOC_STRING   (0)
 //#define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_TERSE)
 #define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_NORMAL)
-#define MICROPY_PY_ASYNC_AWAIT      (0)
 #define MICROPY_PY_BUILTINS_BYTEARRAY (1)
 #define MICROPY_PY_BUILTINS_MEMORYVIEW (1)
 #define MICROPY_PY_BUILTINS_ENUMERATE (1)
@@ -157,6 +156,7 @@ typedef long mp_off_t;
 #define CIRCUITPY_DEFAULT_STACK_SIZE                4096
 #define MICROPY_CPYTHON_COMPAT                      (0)
 #define MICROPY_MODULE_WEAK_LINKS                   (0)
+#define MICROPY_PY_ASYNC_AWAIT                      (0)
 #define MICROPY_PY_BUILTINS_NOTIMPLEMENTED          (0)
 #define MICROPY_PY_COLLECTIONS_ORDEREDDICT          (0)
 #define MICROPY_PY_FUNCTION_ATTRS                   (0)
@@ -175,6 +175,7 @@ typedef long mp_off_t;
     X(EISDIR) \
     X(EINVAL) \
 
+#define MICROPY_PY_USELECT                          (0)
 #endif
 
 #ifdef SAMD51
@@ -185,13 +186,16 @@ typedef long mp_off_t;
 #define CIRCUITPY_DEFAULT_STACK_SIZE                0x6000
 #define MICROPY_CPYTHON_COMPAT                      (1)
 #define MICROPY_MODULE_WEAK_LINKS                   (1)
+#define MICROPY_PY_ASYNC_AWAIT                      (1)
 #define MICROPY_PY_BUILTINS_NOTIMPLEMENTED          (1)
 #define MICROPY_PY_COLLECTIONS_ORDEREDDICT          (1)
 #define MICROPY_PY_FUNCTION_ATTRS                   (1)
 #define MICROPY_PY_IO                               (1)
+#define MICROPY_PY_IO_IOBASE                        (1)
 #define MICROPY_PY_REVERSE_SPECIAL_METHODS          (1)
 #define MICROPY_PY_SYS_EXC_INFO                     (1)
 //      MICROPY_PY_UERRNO_LIST - Use the default
+#define MICROPY_PY_USELECT                          (1)
 #endif
 
 #ifdef LONGINT_IMPL_NONE
@@ -451,6 +455,7 @@ extern const struct _mp_obj_module_t wiznet_module;
     NETWORK_ROOT_POINTERS \
 
 void run_background_tasks(void);
+#define MICROPY_EVENT_POLL_HOOK run_background_tasks();
 #define MICROPY_VM_HOOK_LOOP run_background_tasks();
 #define MICROPY_VM_HOOK_RETURN run_background_tasks();
 

--- a/shared-bindings/i2cslave/I2CSlave.c
+++ b/shared-bindings/i2cslave/I2CSlave.c
@@ -38,6 +38,7 @@
 #include "py/obj.h"
 #include "py/objproperty.h"
 #include "py/runtime.h"
+#include "py/stream.h"
 
 STATIC mp_obj_t mp_obj_new_i2cslave_i2c_slave_request(i2cslave_i2c_slave_obj_t *slave, uint8_t address, bool is_read, bool is_restart) {
     i2cslave_i2c_slave_request_obj_t *self = m_new_obj(i2cslave_i2c_slave_request_obj_t);
@@ -226,10 +227,28 @@ STATIC const mp_rom_map_elem_t i2cslave_i2c_slave_locals_dict_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(i2cslave_i2c_slave_locals_dict, i2cslave_i2c_slave_locals_dict_table);
 
+STATIC mp_uint_t i2cslave_ioctl(mp_obj_t obj, mp_uint_t request, uintptr_t arg, int *errcode) {
+    i2cslave_i2c_slave_obj_t *self = MP_OBJ_TO_PTR(obj);
+    int status = -MP_EINVAL;
+    if (request == MP_STREAM_POLL) {
+        status = common_hal_i2cslave_i2c_slave_is_addressed(self, NULL, NULL, NULL);
+    }
+    if (status < 0) {
+        *errcode = -status;
+        return MP_STREAM_ERROR;
+    }
+    return status;
+}
+
+STATIC const mp_stream_p_t i2cslave_p = {
+    .ioctl = i2cslave_ioctl,
+};
+
 const mp_obj_type_t i2cslave_i2c_slave_type = {
    { &mp_type_type },
    .name = MP_QSTR_I2CSlave,
    .make_new = i2cslave_i2c_slave_make_new,
+   .protocol = &i2cslave_p,
    .locals_dict = (mp_obj_dict_t*)&i2cslave_i2c_slave_locals_dict,
 };
 


### PR DESCRIPTION
I've had a longterm goal to try and use i2cslave with async/await since it looked like a simple way of gettting multitasking in CircuitPython.
Inspired by issue #1380 I set out to see what it could look like.

I haven't done much testing, the main purpose at this stage is to serve as an async/await example in the async discussion.

I was pleased to find that uselect had a flexible signalling mechanism for I/O. I think it can also be used for pin interrupts.

This scheduler/eventloop is based on [an example](https://curio.readthedocs.io/en/latest/devel.html#coroutines-and-multitasking) in the curio docs:

```python
import time
import uselect

def insort(a, x, lo=0, hi=None):
    lo = 0
    hi = len(a)
    while lo < hi:
        mid = (lo+hi)//2
        if x[0] < a[mid][0]: hi = mid
        else: lo = mid+1
    a.insert(lo, x)


def switch():
    yield ('switch',)

def sleep(seconds):
    yield ('sleep', seconds)

def poll(obj):
    yield ('poll', obj)

tasks = []
sleeping = []
polling = []

def run():
    poller = uselect.poll()
    while tasks or polling:
        if tasks:
            coro = tasks.pop(0)
            try:
                request, *args = coro.send(None)
                if request == 'switch':
                    tasks.append(coro)
                elif request == 'sleep':
                    seconds = args[0]
                    deadline = time.monotonic_ns() + seconds * 1000000000
                    insort(sleeping, (deadline, coro))
                elif request == 'poll':
                    obj = args[0]
                    poller.register(obj)
                    polling.append((obj, coro))
                else:
                    print('Unknown request:', request)
            except StopIteration as e:
                print('Task done:', coro)

        if tasks and not polling:
            continue

        if polling:
            if not tasks and sleeping:
                now = time.monotonic_ns()
                duration_ms = int((sleeping[0][0] - now) / 1000000)
                if duration_ms < 0:
                    duration_ms = 0
            elif not tasks:
                duration_ms = -1
            else:
                duration_ms = 0
            print('poll({}): {!r}'.format(duration_ms, [x[1] for x in polling]))
            ready = poller.poll(duration_ms)
            if ready:
                for obj, *args in ready:
                    poller.unregister(obj)
                    for x in polling:
                        if x[0] == obj:
                            polling.remove(x)
                            tasks.append(x[1])
                            break

        now = time.monotonic_ns()
        while sleeping:
            duration = sleeping[0][0] - now
            if duration > 0:
                if tasks:
                    break
                print('sleep({})'.format(duration / 1000000000))
                time.sleep(duration / 1000000000)
            _, coro = sleeping.pop(0)
            tasks.append(coro)

```

Some tasks:
```python
async def countdown(n):
    while n > 0:
        print('T-minus', n)
        await sleep(2)
        n -= 1

async def countup(stop):
    n = 1
    while n <= stop:
        print('Up we go', n)
        await sleep(1)
        n += 1

async def blink(n):
    import board
    import digitalio
    with digitalio.DigitalInOut(board.D13) as red:
        red.switch_to_output(0)
        while n > 0:
            red.value = n & 1
            await sleep(0.1)
            n -= 1

async def i2c(address):
    import board
    import i2cslave
    regs = [0] * 16
    index = 0
    stop = False
    with i2cslave.I2CSlave(board.SCL, board.SDA, (address,)) as slave:
        while True:
            await poll(slave)
            r = slave.request()
            with r:
                if r.address == address:
                    if not r.is_read:
                        b = r.read(1)
                        if not b or b[0] > 15:
                            break
                        index = b[0]
                        b = r.read(1)
                        if b:
                            regs[index] = b[0]
                            print('i2c regs[{}] = {}'.format(index, regs[index]))
                            if index == 0 and b[0] == 1:
                                stop = True
                    elif r.is_restart:
                        n = r.write(bytes([regs[index]]))
                        print('i2c regs[{}] == {}'.format(index, regs[index]))
            if stop:
                break

import uio
class Stream(uio.IOBase):
    def __init__(self):
        self.buf = bytearray()

    def ioctl(self, request, arg):
        return 1 if self.buf else 0

    def write(self, b):
        self.buf += b

    def read(self, n=-1):
        if n == -1:
            n = len(self.buf)
        b = self.buf[:n]
        self.buf = self.buf[n:]
        return b

s = Stream()

async def reader():
    for _ in range(2):
        await poll(s)
        print('reader:', s.read())

async def writer():
    await sleep(2)
    s.write(b'Hello')
    print('writer:', s.buf)
    await sleep(1)
    s.write(b'World')
    print('writer:', s.buf)

tasks.append(countdown(10))
tasks.append(countup(15))
tasks.append(blink(50))
tasks.append(reader())
tasks.append(writer())
tasks.append(i2c(0x30))

run()

```

uio.IOBase gives access to the streaming protocol from python making it possible to hook python code into uselect.poll.

