### PR TITLE
Don't check for corrupt heap too early; Fix QSPI timing

### DIFF
--- a/supervisor/shared/stack.c
+++ b/supervisor/shared/stack.c
@@ -56,7 +56,7 @@ void allocate_stack(void) {
 }
 
 inline bool stack_ok(void) {
-    return *stack_alloc->ptr == STACK_CANARY_VALUE;
+    return stack_alloc == NULL || *stack_alloc->ptr == STACK_CANARY_VALUE;
 }
 
 inline void assert_heap_ok(void) {


### PR DESCRIPTION
1. RGB led was being used before `stack_init()`, so `assert_heap_ok()` was being called too early. Ignore heap check if stack not allocated yet.

2. Multiple issues with nrf `qspi_flash.c`:
- Two bitfield setting bugs: wrong or missing `Pos` values.
- read function didn't return false if error
- minor cleanup.
- 32 MHz QSPI frequency was too fast when paired with GD25Q16C, even though that chip is supposed to be good up to 104 MHz. Not clear if it was SPI flash chip's fault or an issue with the peripheral or the driving pins. It's not clear to me that the nrfx QSPI driver sets the pins to high drive even though that's recommended. Made frequency be a max of 16 MHz for any chip.

Symptoms are that MSC gives errors on enumeration. May appear as an unlabeled drive or not at all.

PCA10056 flash chip is only 8MHz, so we didn't see this problem.

@hathach and @ladyada: either or both review.