### PR TITLE
RFC: Add pulseio.Counter

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -327,6 +327,7 @@ SRC_COMMON_HAL = \
 	nvm/__init__.c \
 	nvm/ByteArray.c \
 	pulseio/__init__.c \
+	pulseio/Counter.c \
 	pulseio/PulseIn.c \
 	pulseio/PulseOut.c \
 	pulseio/PWMOut.c \

--- a/ports/atmel-samd/common-hal/pulseio/Counter.c
+++ b/ports/atmel-samd/common-hal/pulseio/Counter.c
@@ -1,0 +1,113 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Noralf Trønnes
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "common-hal/pulseio/Counter.h"
+
+#include <stdint.h>
+
+#include "atmel_start_pins.h"
+#include "hal/include/hal_gpio.h"
+
+#include "background.h"
+#include "mpconfigport.h"
+#include "py/gc.h"
+#include "py/runtime.h"
+#include "samd/external_interrupts.h"
+#include "samd/pins.h"
+#include "shared-bindings/microcontroller/__init__.h"
+#include "shared-bindings/pulseio/Counter.h"
+#include "supervisor/shared/translate.h"
+
+static void counter_interrupt_handler(uint8_t channel) {
+    pulseio_counter_obj_t* self = get_eic_channel_data(channel);
+    self->count++;
+}
+
+void common_hal_pulseio_counter_construct(pulseio_counter_obj_t* self, const mcu_pin_obj_t* pin) {
+    if (!pin->has_extint) {
+        mp_raise_RuntimeError(translate("No hardware support on pin"));
+    }
+    if (eic_get_enable() && !eic_channel_free(pin->extint_channel)) {
+        mp_raise_RuntimeError(translate("EXTINT channel already in use"));
+    }
+
+    self->channel = pin->extint_channel;
+    self->pin = pin->number;
+    self->count = 0;
+
+    set_eic_channel_handler(pin->extint_channel, counter_interrupt_handler);
+    set_eic_channel_data(pin->extint_channel, (void*) self);
+
+    // Check to see if the EIC is enabled and start it up if its not.'
+    if (eic_get_enable() == 0) {
+        turn_on_external_interrupt_controller();
+    }
+
+    gpio_set_pin_function(pin->number, GPIO_PIN_FUNCTION_A);
+
+    // TODO: Make this configurable
+    enum gpio_pull_mode asf_pull = GPIO_PULL_UP;
+    gpio_set_pin_pull_mode(pin->number, asf_pull);
+
+    turn_on_cpu_interrupt(self->channel);
+
+    claim_pin(pin);
+
+    // TODO: Make this configurable
+    uint32_t sense_setting;
+    sense_setting = EIC_CONFIG_SENSE0_BOTH_Val;
+//  sense_setting = EIC_CONFIG_SENSE0_FALL_Val;
+//  sense_setting = EIC_CONFIG_SENSE0_RISE_Val;
+
+    turn_on_eic_channel(self->channel, sense_setting, EIC_HANDLER_FUNC);
+}
+
+bool common_hal_pulseio_counter_deinited(pulseio_counter_obj_t* self) {
+    return self->pin == NO_PIN;
+}
+
+void common_hal_pulseio_counter_deinit(pulseio_counter_obj_t* self) {
+    if (common_hal_pulseio_counter_deinited(self)) {
+        return;
+    }
+    turn_off_eic_channel(self->channel);
+    reset_pin_number(self->pin);
+    self->pin = NO_PIN;
+}
+
+uint32_t common_hal_pulseio_counter_get_count(pulseio_counter_obj_t* self, bool clear) {
+    common_hal_mcu_disable_interrupts();
+    uint32_t count = self->count;
+    if (clear) {
+        self->count = 0;
+    }
+    common_hal_mcu_enable_interrupts();
+    return count;
+}
+
+bool common_hal_pulseio_counter_get_pinvalue(pulseio_counter_obj_t* self) {
+    return gpio_get_pin_level(self->pin);
+}

--- a/ports/atmel-samd/common-hal/pulseio/Counter.h
+++ b/ports/atmel-samd/common-hal/pulseio/Counter.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Noralf Trønnes
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_PULSEIO_COUNTER_H
+#define MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_PULSEIO_COUNTER_H
+
+#include "common-hal/microcontroller/Pin.h"
+
+#include "py/obj.h"
+
+typedef struct {
+    mp_obj_base_t base;
+    uint8_t channel;
+    uint8_t pin;
+    volatile uint32_t count;
+} pulseio_counter_obj_t;
+
+#endif // MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_PULSEIO_COUNTER_H

--- a/shared-bindings/pulseio/Counter.c
+++ b/shared-bindings/pulseio/Counter.c
@@ -1,0 +1,169 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Noralf Trønnes
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+
+#include "lib/utils/context_manager_helpers.h"
+#include "py/objproperty.h"
+#include "py/runtime.h"
+#include "py/runtime0.h"
+#include "py/stream.h"
+#include "shared-bindings/microcontroller/Pin.h"
+#include "shared-bindings/pulseio/Counter.h"
+#include "shared-bindings/util.h"
+#include "supervisor/shared/translate.h"
+
+//| .. currentmodule:: pulseio
+//|
+//| :class:`Counter` -- Count pulses
+//| ================================
+//|
+//| Counter is used to count edges on a pulse train.
+//|
+//| .. class:: Counter(pin, ...)
+//|
+//|   Create a Counter object associated with the given pin.
+//|
+//|   :param ~microcontroller.Pin pin: Pin to read pulses from.
+//|
+STATIC mp_obj_t pulseio_counter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
+    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+    enum { ARG_pin, ARG_edges, ARG_pull };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_pin, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_edges, MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_pull, MP_ARG_OBJ, {.u_obj = mp_const_none} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    assert_pin(args[ARG_pin].u_obj, false);
+    const mcu_pin_obj_t* pin = MP_OBJ_TO_PTR(args[ARG_pin].u_obj);
+    assert_pin_free(pin);
+
+    pulseio_counter_obj_t *self = m_new_obj(pulseio_counter_obj_t);
+    self->base.type = &pulseio_counter_type;
+
+    common_hal_pulseio_counter_construct(self, pin);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+//|   .. method:: deinit()
+//|
+//|      Deinitialises the Counter and releases any hardware resources for reuse.
+//|
+STATIC mp_obj_t pulseio_counter_deinit(mp_obj_t self_in) {
+    pulseio_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_pulseio_counter_deinit(self);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(pulseio_counter_deinit_obj, pulseio_counter_deinit);
+
+//|   .. method:: __enter__()
+//|
+//|      No-op used by Context Managers.
+//|
+//  Provided by context manager helper.
+
+//|   .. method:: __exit__()
+//|
+//|      Automatically deinitializes the hardware when exiting a context. See
+//|      :ref:`lifetime-and-contextmanagers` for more info.
+//|
+STATIC mp_obj_t pulseio_counter_obj___exit__(size_t n_args, const mp_obj_t *args) {
+    (void)n_args;
+    common_hal_pulseio_counter_deinit(args[0]);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pulseio_counter___exit___obj, 4, 4, pulseio_counter_obj___exit__);
+
+//|   .. method:: clear()
+//|
+//|     Clears counter and returns its value.
+//|
+STATIC mp_obj_t pulseio_counter_obj_clear(mp_obj_t self_in) {
+    pulseio_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_counter_deinited(self));
+
+    return mp_obj_new_int_from_uint(common_hal_pulseio_counter_get_count(self, true));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(pulseio_counter_clear_obj, pulseio_counter_obj_clear);
+
+STATIC mp_obj_t pulseio_counter_get_count(mp_obj_t self_in) {
+    pulseio_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_counter_deinited(self));
+
+    return mp_obj_new_int_from_uint(common_hal_pulseio_counter_get_count(self, false));
+}
+MP_DEFINE_CONST_PROP_GET(pulseio_counter_count_obj, pulseio_counter_get_count);
+
+STATIC mp_obj_t pulseio_counter_get_pinvalue(mp_obj_t self_in) {
+    pulseio_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_counter_deinited(self));
+
+    return mp_obj_new_int_from_uint(common_hal_pulseio_counter_get_pinvalue(self));
+}
+MP_DEFINE_CONST_PROP_GET(pulseio_counter_pinvalue_obj, pulseio_counter_get_pinvalue);
+
+STATIC mp_uint_t pulseio_counter_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    pulseio_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    raise_error_if_deinited(common_hal_pulseio_counter_deinited(self));
+
+    if (request != MP_STREAM_POLL) {
+        *errcode = MP_EINVAL;
+        return MP_STREAM_ERROR;
+    }
+
+    uint32_t count = common_hal_pulseio_counter_get_count(self, false);
+    return count > 0 ? 1 : 0;
+}
+
+STATIC const mp_stream_p_t pulseio_counter_p = {
+    .ioctl = pulseio_counter_ioctl,
+};
+
+STATIC const mp_rom_map_elem_t pulseio_counter_locals_dict_table[] = {
+    // Methods
+    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&pulseio_counter_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&default___enter___obj) },
+    { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&pulseio_counter___exit___obj) },
+    { MP_ROM_QSTR(MP_QSTR_clear), MP_ROM_PTR(&pulseio_counter_clear_obj) },
+
+    // Properties
+    { MP_ROM_QSTR(MP_QSTR_count), MP_ROM_PTR(&pulseio_counter_count_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pinvalue), MP_ROM_PTR(&pulseio_counter_pinvalue_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(pulseio_counter_locals_dict, pulseio_counter_locals_dict_table);
+
+const mp_obj_type_t pulseio_counter_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_PulseIn,
+    .make_new = pulseio_counter_make_new,
+    .protocol = &pulseio_counter_p,
+    .locals_dict = (mp_obj_dict_t*)&pulseio_counter_locals_dict,
+};

--- a/shared-bindings/pulseio/Counter.h
+++ b/shared-bindings/pulseio/Counter.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Noralf Trønnes
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_PULSEIO_COUNTER_H
+#define MICROPY_INCLUDED_SHARED_BINDINGS_PULSEIO_COUNTER_H
+
+#include "common-hal/microcontroller/Pin.h"
+#include "common-hal/pulseio/Counter.h"
+
+extern const mp_obj_type_t pulseio_counter_type;
+
+extern void common_hal_pulseio_counter_construct(pulseio_counter_obj_t* self, const mcu_pin_obj_t* pin);
+extern void common_hal_pulseio_counter_deinit(pulseio_counter_obj_t* self);
+extern bool common_hal_pulseio_counter_deinited(pulseio_counter_obj_t* self);
+extern uint32_t common_hal_pulseio_counter_get_count(pulseio_counter_obj_t* self, bool clear);
+extern bool common_hal_pulseio_counter_get_pinvalue(pulseio_counter_obj_t* self);
+
+#endif // MICROPY_INCLUDED_SHARED_BINDINGS_PULSEIO_COUNTER_H

--- a/shared-bindings/pulseio/__init__.c
+++ b/shared-bindings/pulseio/__init__.c
@@ -31,6 +31,7 @@
 
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/pulseio/__init__.h"
+#include "shared-bindings/pulseio/Counter.h"
 #include "shared-bindings/pulseio/PulseIn.h"
 #include "shared-bindings/pulseio/PulseOut.h"
 #include "shared-bindings/pulseio/PWMOut.h"
@@ -82,6 +83,7 @@
 
 STATIC const mp_rom_map_elem_t pulseio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_pulseio) },
+    { MP_ROM_QSTR(MP_QSTR_Counter), MP_ROM_PTR(&pulseio_counter_type) },
     { MP_ROM_QSTR(MP_QSTR_PulseIn), MP_ROM_PTR(&pulseio_pulsein_type) },
     { MP_ROM_QSTR(MP_QSTR_PulseOut), MP_ROM_PTR(&pulseio_pulseout_type) },
     { MP_ROM_QSTR(MP_QSTR_PWMOut), MP_ROM_PTR(&pulseio_pwmout_type) },


### PR DESCRIPTION
I need pin interrupt support for a project and this is one way of achieving that if we don't end up supporting pin interrupts directly (latency is not a problem for this project since the signal is sent over i2c to a Raspberry Pi).

I have previously wondered if PulseIn (#1072) could be used, but I think a Counter abstraction is a much better fit and has other use cases too. Of course there's that feature creep syndrome and flash is scarce on some boards.

@tannewt was unsure about pull support:
> I don't think the samd can pull up when EXTI is active because the pinmux is enabled.

But at least pull up is working on a samd51.

See #1415 for how this Counter can be used with async/await.

This samd-peripherals change is also necessary: https://gist.github.com/notro/2558d4fe1b0699e175c7dc33b9a74d22
