### PR TITLE
Fix sphinx build issues; add better travis fold reporting; update aut…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ before_script:
   - sudo apt-get install -y python3-pip
   - pip3 install --user sh click
   - ([[ -z "$TRAVIS_TESTS" ]] || sudo pip install --upgrade cpp-coveralls)
-  - (! var_search "${TRAVIS_TESTS-}" docs || pip install --user 'Sphinx<1.8.0' sphinx-rtd-theme recommonmark)
+  - (! var_search "${TRAVIS_TESTS-}" docs || pip install --user Sphinx sphinx-rtd-theme recommonmark)
   - (! var_search "${TRAVIS_TESTS-}" translations || pip3 install --user polib)
 
   # report some good version numbers to the build
@@ -88,47 +88,47 @@ before_script:
 
 script:
   # Build mpy-cross first because other builds depend on it.
-  - echo 'Building mpy-cross' && echo -en 'travis_fold:start:mpy-cross\\r'
-  - make -C mpy-cross -j2
-  - echo -en 'travis_fold:end:mpy-cross\\r'
+  - echo 'Building mpy-cross' && echo 'travis_fold:start:mpy-cross'
+  - make -C mpy-cross -j2 ; echo $? > status
+  - echo 'travis_fold:end:mpy-cross' && tools/print_status.py status
 
   # Use unbuffered output because building all the releases can take a long time.
   # Travis will cancel the job if it sees no output for >10 minutes.
   - cd tools && python3 -u build_release_files.py
   - cd ..
 
-  - echo 'Building unix' && echo -en 'travis_fold:start:unix\\r'
-  - (! var_search "${TRAVIS_TESTS-}" unix || (make -C ports/unix deplibs -j2 && make -C ports/unix -j2 && make -C ports/unix coverage -j2))
-  - echo -en 'travis_fold:end:unix\\r'
+  - echo 'Building unix' && echo 'travis_fold:start:unix'
+  - (! var_search "${TRAVIS_TESTS-}" unix || (make -C ports/unix deplibs -j2 && make -C ports/unix -j2 && make -C ports/unix coverage -j2)) ; echo $? > status
+  - echo 'travis_fold:end:unix' && tools/print_status.py status
 
   # run tests without coverage info
   #- (cd tests && MICROPY_CPYTHON3=python3.4 ./run-tests -j1)
   #- (cd tests && MICROPY_CPYTHON3=python3.4 ./run-tests -j1 --emit native)
 
   # run tests with coverage info
-  - echo 'Test all' && echo -en 'travis_fold:start:test_all\\r'
-  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1))
-  - echo -en 'travis_fold:end:test_all\\r'
+  - echo 'Test all' && echo 'travis_fold:start:test_all'
+  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1)) ; echo $? > status
+  - echo 'travis_fold:end:test_all' && tools/print_status.py status
 
-  - echo 'Test threads' && echo -en 'travis_fold:start:test_threads\\r'
-  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 -d thread))
-  - echo -en 'travis_fold:end:test_threads\\r'
+  - echo 'Test threads' && echo 'travis_fold:start:test_threads'
+  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 -d thread)) ; echo $? >status
+  - echo 'travis_fold:end:test_threads' && tools/print_status.py status
 
-  - echo 'Testing with native' && echo -en 'travis_fold:start:test_native\\r'
-  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --emit native))
-  - echo -en 'travis_fold:end:test_native\\r'
+  - echo 'Testing with native' && echo 'travis_fold:start:test_native'
+  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --emit native)) ; echo $? >status
+  - echo 'travis_fold:end:test_native' && tools/print_status.py status
 
-  - (echo 'Testing with mpy' && echo -en 'travis_fold:start:test_mpy\\r')
-  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --via-mpy -d basics float))
-  - echo -en 'travis_fold:end:test_mpy\\r'
+  - (echo 'Testing with mpy' && echo 'travis_fold:start:test_mpy')
+  - (! var_search "${TRAVIS_TESTS-}" unix || (cd tests && MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --via-mpy -d basics float)) ; echo $? >status
+  - echo 'travis_fold:end:test_mpy' && tools/print_status.py status
 
-  - (echo 'Building docs' && echo -en 'travis_fold:start:build_docs\\r')
-  - (! var_search "${TRAVIS_TESTS-}" docs || sphinx-build -E -W -b html . _build/html)
-  - echo -en 'travis_fold:end:build_docs\\r'
+  - (echo 'Building docs' && echo 'travis_fold:start:build_docs')
+  - (! var_search "${TRAVIS_TESTS-}" docs || sphinx-build -E -W -b html . _build/html)  ; echo $? >status
+  - echo 'travis_fold:end:build_docs' && tools/print_status.py status
 
-  - (echo 'Building translations' && echo -en 'travis_fold:start:build_translations\\r')
-  - (! var_search "${TRAVIS_TESTS-}" translations || make check-translate)
-  - echo -en 'travis_fold:end:build_translations\\r'
+  - (echo 'Building translations' && echo 'travis_fold:start:build_translations')
+  - (! var_search "${TRAVIS_TESTS-}" translations || make check-translate)  ; echo $? >status
+  - echo 'travis_fold:end:build_translations' && tools/print_status.py status
 
   # run coveralls coverage analysis (try to, even if some builds/tests failed)
   #- (cd ports/unix && coveralls --root ../.. --build-root . --gcov $(which gcov) --gcov-options '\-o build-coverage/' --include py --include extmod)

--- a/conf.py
+++ b/conf.py
@@ -284,7 +284,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
   (master_doc, 'CircuitPython.tex', 'CircuitPython Documentation',
-   'Damien P. George, Paul Sokolovsky, and contributors', 'manual'),
+   'CircuitPython Contributors', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -314,7 +314,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'CircuitPython', 'CircuitPython Documentation',
-     ['Damien P. George, Paul Sokolovsky, and contributors'], 1),
+     ['CircuitPython contributors'], 1),
 ]
 
 # If true, show URL addresses after external links.
@@ -328,7 +328,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   (master_doc, 'CircuitPython', 'CircuitPython Documentation',
-   'Damien P. George, Paul Sokolovsky, and contributors', 'CircuitPython', 'One line description of project.',
+   'CircuitPython contributors', 'CircuitPython', 'Python for Microcontrollers.',
    'Miscellaneous'),
 ]
 

--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -36,10 +36,10 @@ the following links:
 > **NOTE**: These board specific readmes may be more up to date than the
   generic board-neutral documentation further down.
 
-* Adafruit [Feather nRF52](boards/feather_nrf52832/README.md): 512KB Flash, 64KB SRAM
-* Adafruit [Feather nRF52840](boards/feather_nrf52840_express/README.md): 1MB Flash, 256KB SRAM
-* Nordic PCA10056 see [Feather nRF52840](boards/pca10056/README.md)
-* MakerDiary NRF52840 MDK see [its README](boards/makerdiary_nrf52840_mdk/README.md)
+* Adafruit Feather nRF52: boards/feather_nrf52832/README.md: 512KB Flash, 64KB SRAM
+* Adafruit Feather nRF52840: boards/feather_nrf52840_express/README.md: 1MB Flash, 256KB SRAM
+* Nordic PCA10056 (uses nRF52840): boards/pca10056/README.md
+* MakerDiary NRF52840 MDK: boards/makerdiary_nrf52840_mdk/README.md
 
 For all other board targets, see the generic notes below.
 

--- a/tools/print_status.py
+++ b/tools/print_status.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import sys
+if len(sys.argv) != 2:
+    print("""\
+Usage: print_status.py STATUS_FILENAME
+    STATUS_FILENAME contains one line with an integer status."""
+    )
+    sys.exit(1)
+with open(sys.argv[1], 'r') as status_in:
+    status = int(status_in.readline())
+
+print('{} with status {}'.format(
+    "\033[32msucceeded\033[0m" if status == 0 else "\033[31mfailed\033[0m",
+    status))


### PR DESCRIPTION
- `recommonmark` updated versions a day ago, which made it stop working with the older version of sphinx (`Sphinx<1.8.0`) we were specifying in .travis.yml. This removes the version restrictions, and reworks some internal links in `ports/nrf/README.md` that were the only things that were failing with the newer versions.

I tried various features of `recommonmark` including `AutoStructify`, but was unable to get these links to work. These links were already broken in RTD anyway (they pointed to the `README.md` instead of the generated `README.html`).

- Added a simple idiom and printing script to allow commands inside folds to save their status and then print it out after the fold.

- Removed MicroPython-specific authors from author lists in `conf.py` to avoid confusion about who is responsible for CircuitPython documentaiton.