### PR TITLE
Add Makerdiary nRF52840 MDK USB dongle support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ git:
 # that SDK is shortest and add it there.  In the case of major re-organizations,
 # just try to make the builds "about equal in run time"
 env:
-  - TRAVIS_TESTS="unix docs translations website" TRAVIS_BOARDS="circuitplayground_express mini_sam_m4 grandcentral_m4_express pca10056 pca10059 feather_nrf52840_express makerdiary_nrf52840_mdk particle_boron particle_argon particle_xenon sparkfun_nrf52840_mini" TRAVIS_SDK=arm:nrf
+  - TRAVIS_TESTS="unix docs translations website" TRAVIS_BOARDS="circuitplayground_express mini_sam_m4 grandcentral_m4_express pca10056 pca10059 feather_nrf52840_express makerdiary_nrf52840_mdk makerdiary_nrf52840_mdk_usb_dongle particle_boron particle_argon particle_xenon sparkfun_nrf52840_mini" TRAVIS_SDK=arm:nrf
   - TRAVIS_BOARDS="metro_m0_express metro_m4_express pirkey_m0 trellis_m4_express trinket_m0" TRAVIS_SDK=arm
   - TRAVIS_BOARDS="feather_radiofruit_zigbee gemma_m0 hallowing_m0_express itsybitsy_m0_express itsybitsy_m4_express meowmeow" TRAVIS_SDK=arm
   - TRAVIS_BOARDS="feather_m0_express_crickit feather_m0_rfm69 feather_m0_rfm9x feather_m4_express arduino_zero arduino_mkr1300 arduino_mkrzero" TRAVIS_SDK=arm

--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -35,7 +35,8 @@ the following links:
 
 * Adafruit Feather nRF52840: `boards/feather_nrf52840_express/README.md`: 1MB Flash, 256KB SRAM
 * Nordic PCA10056 (uses nRF52840): `boards/pca10056/README.md`
-* MakerDiary NRF52840 MDK: `boards/makerdiary_nrf52840_mdk/README.md`
+* MakerDiary nRF52840 MDK: `boards/makerdiary_nrf52840_mdk/README.md`
+* MakerDiary nRF52840 MDK USB Dongle: `boards/makerdiary_nrf52840_mdk_usb_dongle/README.md`
 
 For all other board targets, see the generic notes below.
 
@@ -76,6 +77,7 @@ Target Board (BOARD)     | Bluetooth Stack (SD)    | Bluetooth Support      | Fl
 pca10056                 | s140                    | Peripheral and Scanner | [Segger](#segger-targets)
 feather_nrf52840_express | s140                    | Peripheral and Scanner | UF2 bootloader
 makerdiary_nrf52840_mdk  | s140                    | Peripheral and Scanner | pyocd or ARM mbed DAPLink
+makerdiary_nrf52840_mdk_usb_dongle | s140          | Peripheral and Scanner | DFU bootloader & nrfutil
 
 ## Segger Targets
 

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/README.md
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/README.md
@@ -1,0 +1,96 @@
+# MakerDiary NRF52840 MDK USB Dongle
+
+Refer to [The makerdiary Github repo](https://github.com/makerdiary/nrf52840-mdk-usb-dongle)
+or [The nrf52840-mdk-usb-dongle wiki](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/)
+for more details about the device.
+
+This is pretty much just the nRF52840 with a useful number of pins exposed for
+your pleasure along with one RGB LED and an onboard antenna in a USB stick form
+factor with room for headers on the sides.
+
+Note that all three LEDs on this device are wired through sinks, not sources,
+so flip your boolean expectations when dealing with `DigitalInOut` or `PWMOut`
+on this device --
+`led.value = True` or `led.duty_cycle = 0xffff` turns the LED off!
+
+The onboard button is hard wired to the Reset pin so you cannot use it yourself.
+
+## Installing CircuitPython submodules
+
+Before you can build, you will need to run the following commands once, which
+will install the submodules that are part of the CircuitPython ecosystem, and
+build the `mpy-cross` tool:
+
+```
+$ cd circuitpython
+$ git submodule update --init
+$ make -C mpy-cross
+```
+
+## Note about bootloaders
+
+While most Adafruit devices come with (or can easily be flashed with) an
+Adafruit-provided bootloader (supporting niceties like UF2 flashing), this
+board comes with one that supports DFU via nrfutil.  If you ever need to
+restore the DFU bootloader via a SWD debugger, use
+[the nRF52 open bootloader hex file](https://github.com/makerdiary/nrf52840-mdk-usb-dongle/tree/master/firmware/open_bootloader).
+
+## Building and Flashing CircuitPython
+
+```
+$ cd ports/nrf
+```
+
+### Build CircuitPython for the MDK USB Dongle
+
+```
+make BOARD=makerdiary_nrf52840_mdk_usb_dongle SD=s140 V=1 -j4 hex
+```
+
+This should produce a `build-makerdiary_nrf52840_mdk_usb_dongle-s140/firmware.hex` file.
+
+### Install nrfutil
+
+You'll need to have [nrfutil](https://pypi.org/project/nrfutil/) installed as
+appropriate for your system.
+As of 2019-01, _nrfutil still requires Python 2.7_... ugh!
+
+### Flash the nRF52 Radio Soft Device
+
+Build a DFU package from the softdevice hex file and flash it:
+
+```sh
+nrfutil pkg generate --hw-version 52 --sd-req 0x00 --sd-id 0xAE --softdevice bluetooth/s140_nrf52_6.1.0/s140_nrf52_6.1.0_softdevice.hex dfu_sd140-6.1.0.zip
+nrfutil dfu usb-serial -pkg dfu_sd140-6.1.0.zip -p /dev/tty.usbmodemABRACADBRA  # likely /dev/ttyACM0 on Linux
+```
+
+Note that the `--sd=id 0xAE` comes from the Nordic nRF52 manual for SoftDevice
+6.1.0.  When the SoftDevice is changed, read the Nordic manual to find the
+correct value and use it on all of the `nrfutil pkg generate` commands.
+
+`/dev/tty.usbmodem*` is a macOS name.  On Linux it'll likely be `/dev/ttyACM*`.  On Windows probably a COM port.
+
+### Flash CircuitPython
+
+Build a DFU package from the hex application file and flash it:
+
+```
+nrfutil pkg generate --sd-req 0xAE --application build-makerdiary_nrf52840_mdk_usb_dongle-s140/firmware.hex --hw-version 52 --application-version 1 dfu_circuitpython.zip
+nrfutil dfu usb-serial -pkg dfu_circuitpython.zip -p /dev/tty.usbmodemABRACADBRA
+```
+
+I'm not sure if `--application-version 1` is actually meaningful or required.
+
+After this, your device should be up and running CircuitPython.  When it
+resets, you'll see the CIRCUITPY USB filesystem and a new console usb modem
+serial port show up.
+
+```
+Adafruit CircuitPython 4.0.0-alpha.5-139-g10ceb6716 on 2019-01-14; MakerDiary nRF52840 MDK USB Dongle with nRF52840
+>>>
+```
+
+### TODO items
+
+* Update the Makefile to do the above DFU .zip building and nrfutil flashing.
+* Create a UF2 bootloader for this. It is already a USB stick form factor, it deserves to behave like one.

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/board.c
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/board.c
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "boards/board.h"
+
+void board_init(void) {
+}
+
+bool board_requests_safe_mode(void) {
+  return false;
+}
+
+void reset_board(void) {
+
+}

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/mpconfigboard.h
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/mpconfigboard.h
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Glenn Ruben Bakke
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "nrfx/hal/nrf_gpio.h"
+
+#define MAKERDIARY_NRF52840_MDK_DONGLE
+
+#define MICROPY_HW_BOARD_NAME       "MakerDiary nRF52840 MDK USB Dongle"
+#define MICROPY_HW_MCU_NAME         "nRF52840"
+#define MICROPY_PY_SYS_PLATFORM     "MakerDiary52840MDKDongle"
+
+#define CIRCUITPY_AUTORELOAD_DELAY_MS 500
+
+// If you change this, then make sure to update the linker scripts as well to
+// make sure you don't overwrite code
+#define PORT_HEAP_SIZE              (128 * 1024)
+// TODO #define CIRCUITPY_INTERNAL_NVM_SIZE 8192
+
+#define BOARD_FLASH_SIZE (FLASH_SIZE - 0x4000 - CIRCUITPY_INTERNAL_NVM_SIZE)
+
+#define BOARD_HAS_CRYSTAL 1  // according to the schematic we do
+
+// See https://github.com/adafruit/circuitpython/issues/1300, circuitpython
+// doesn't yet support NFC so just force those pins to be GPIO.
+#define CONFIG_NFCT_PINS_AS_GPIOS

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/mpconfigboard.mk
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/mpconfigboard.mk
@@ -1,0 +1,22 @@
+USB_VID = 0x239A
+USB_PID = 0x802A
+USB_PRODUCT = "nRF52840-MDK-Dongle"
+USB_MANUFACTURER = "makerdiary"
+
+MCU_SERIES = m4
+MCU_VARIANT = nrf52
+MCU_SUB_VARIANT = nrf52840
+MCU_CHIP = nrf52840
+SD ?= s140
+SOFTDEV_VERSION ?= 6.1.0
+
+BOOT_SETTING_ADDR = 0xFF000
+BOOT_FILE = boards/$(BOARD)/bootloader/$(SOFTDEV_VERSION)/$(BOARD)_bootloader_$(SOFTDEV_VERSION)_s140
+
+ifeq ($(SD),)
+	LD_FILE = boards/nrf52840_1M_256k.ld
+else
+	LD_FILE = boards/adafruit_$(MCU_SUB_VARIANT)_$(SD_LOWER)_v$(firstword $(subst ., ,$(SOFTDEV_VERSION))).ld
+endif
+
+NRF_DEFINES += -DNRF52840_XXAA -DNRF52840

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/pins.c
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/pins.c
@@ -1,0 +1,41 @@
+#include "shared-bindings/board/__init__.h"
+
+#include "board_busses.h"
+
+STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
+  { MP_ROM_QSTR(MP_QSTR_AIN0), MP_ROM_PTR(&pin_P0_02) },
+  { MP_ROM_QSTR(MP_QSTR_AIN1), MP_ROM_PTR(&pin_P0_03) },
+  { MP_ROM_QSTR(MP_QSTR_AIN2), MP_ROM_PTR(&pin_P0_04) },
+  { MP_ROM_QSTR(MP_QSTR_AIN3), MP_ROM_PTR(&pin_P0_05) },
+
+  { MP_ROM_QSTR(MP_QSTR_AREF), MP_ROM_PTR(&pin_P0_04) },  // User must connect manually.
+  { MP_ROM_QSTR(MP_QSTR_VDIV), MP_ROM_PTR(&pin_P0_05) },  // User must connect manually.
+
+// Not defining the NFC names until CircuitPython supports NFC.
+//  { MP_ROM_QSTR(MP_QSTR_NFC1), MP_ROM_PTR(&pin_P0_09) },
+//  { MP_ROM_QSTR(MP_QSTR_NFC2), MP_ROM_PTR(&pin_P0_10) },
+
+  { MP_ROM_QSTR(MP_QSTR_P2), MP_ROM_PTR(&pin_P0_02) },
+  { MP_ROM_QSTR(MP_QSTR_P3), MP_ROM_PTR(&pin_P0_03) },
+  { MP_ROM_QSTR(MP_QSTR_P4), MP_ROM_PTR(&pin_P0_04) },
+  { MP_ROM_QSTR(MP_QSTR_P5), MP_ROM_PTR(&pin_P0_05) },
+  { MP_ROM_QSTR(MP_QSTR_P6), MP_ROM_PTR(&pin_P0_06) },
+  { MP_ROM_QSTR(MP_QSTR_P7), MP_ROM_PTR(&pin_P0_07) },
+  { MP_ROM_QSTR(MP_QSTR_P8), MP_ROM_PTR(&pin_P0_08) },
+  { MP_ROM_QSTR(MP_QSTR_P9), MP_ROM_PTR(&pin_P0_09) },
+  { MP_ROM_QSTR(MP_QSTR_P10), MP_ROM_PTR(&pin_P0_10) },
+  { MP_ROM_QSTR(MP_QSTR_P18), MP_ROM_PTR(&pin_P0_18) },  // !Reset button.
+  { MP_ROM_QSTR(MP_QSTR_P19), MP_ROM_PTR(&pin_P0_19) },
+  { MP_ROM_QSTR(MP_QSTR_P22), MP_ROM_PTR(&pin_P0_22) },  // green led, low is on.
+  { MP_ROM_QSTR(MP_QSTR_P23), MP_ROM_PTR(&pin_P0_23) },  // red led, low is on.
+  { MP_ROM_QSTR(MP_QSTR_P24), MP_ROM_PTR(&pin_P0_24) },  // blue led, low is on.
+
+  { MP_ROM_QSTR(MP_QSTR_LED_RED), MP_ROM_PTR(&pin_P0_23) },  // Low is on.
+  { MP_ROM_QSTR(MP_QSTR_LED_GREEN), MP_ROM_PTR(&pin_P0_22) },  // Low is on.
+  { MP_ROM_QSTR(MP_QSTR_LED_BLUE), MP_ROM_PTR(&pin_P0_24) },  // Low is on.
+
+  // BUT this is the RESET pin so we can't really use it.
+  { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_P0_18) },  // Low is pressed.
+};
+
+MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -37,6 +37,7 @@ extension_by_board = {
 
     # nRF52840 dev kits that may not have UF2 bootloaders,
     "makerdiary_nrf52840_mdk": HEX,
+    "makerdiary_nrf52840_mdk_usb_dongle": HEX,
     "pca10056": BIN_UF2,
     "pca10059": BIN_UF2
 }


### PR DESCRIPTION
Adds support for https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/.

A cheap nRF52840 USB stick with optional headers, very Trinket and Itsy like.