### PR TITLE
Add displayio.Shape

### DIFF
--- a/extmod/moduhashlib.c
+++ b/extmod/moduhashlib.c
@@ -66,8 +66,8 @@ STATIC mp_obj_t uhashlib_sha256_update(mp_obj_t self_in, mp_obj_t arg);
 
 #if MICROPY_SSL_MBEDTLS
 
-STATIC mp_obj_t uhashlib_sha256_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+STATIC mp_obj_t uhashlib_sha256_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 0, 1, false);
     mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(mbedtls_sha256_context));
     o->base.type = type;
     mbedtls_sha256_init((mbedtls_sha256_context*)&o->state);
@@ -104,8 +104,8 @@ static void check_not_unicode(const mp_obj_t arg) {
 #endif
 }
 
-STATIC mp_obj_t uhashlib_sha256_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+STATIC mp_obj_t uhashlib_sha256_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 0, 1, false);
     mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(CRYAL_SHA256_CTX));
     o->base.type = type;
     sha256_init((CRYAL_SHA256_CTX*)o->state);
@@ -155,8 +155,8 @@ STATIC const mp_obj_type_t uhashlib_sha256_type = {
 STATIC mp_obj_t uhashlib_sha1_update(mp_obj_t self_in, mp_obj_t arg);
 
 #if MICROPY_SSL_AXTLS
-STATIC mp_obj_t uhashlib_sha1_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+STATIC mp_obj_t uhashlib_sha1_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 0, 1, false);
     mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, char, sizeof(SHA1_CTX));
     o->base.type = type;
     SHA1_Init((SHA1_CTX*)o->state);

--- a/extmod/vfs.c
+++ b/extmod/vfs.c
@@ -176,7 +176,7 @@ mp_obj_t mp_vfs_mount(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args
         // auto-detect the filesystem and create the corresponding VFS entity.
         // (At the moment we only support FAT filesystems.)
         #if MICROPY_VFS_FAT
-        vfs_obj = mp_fat_vfs_type.make_new(&mp_fat_vfs_type, 1, 0, &vfs_obj);
+        vfs_obj = mp_fat_vfs_type.make_new(&mp_fat_vfs_type, 1, &vfs_obj, NULL);
         #endif
     }
 

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -65,8 +65,8 @@ mp_import_stat_t fat_vfs_import_stat(void *vfs_in, const char *path) {
     return MP_IMPORT_STAT_NO_EXIST;
 }
 
-STATIC mp_obj_t fat_vfs_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+STATIC mp_obj_t fat_vfs_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     // create new object
     fs_user_mount_t *vfs = m_new_obj(fs_user_mount_t);
@@ -111,7 +111,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(fat_vfs_del_obj, fat_vfs_del);
 
 STATIC mp_obj_t fat_vfs_mkfs(mp_obj_t bdev_in) {
     // create new object
-    fs_user_mount_t *vfs = MP_OBJ_TO_PTR(fat_vfs_make_new(&mp_fat_vfs_type, 1, 0, &bdev_in));
+    fs_user_mount_t *vfs = MP_OBJ_TO_PTR(fat_vfs_make_new(&mp_fat_vfs_type, 1, &bdev_in, NULL));
 
     // make the filesystem
     uint8_t working_buf[_MAX_SS];

--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -206,9 +206,9 @@ STATIC mp_obj_t file_open(fs_user_mount_t *vfs, const mp_obj_type_t *type, mp_ar
     return MP_OBJ_FROM_PTR(o);
 }
 
-STATIC mp_obj_t file_obj_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t file_obj_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     mp_arg_val_t arg_vals[FILE_OPEN_NUM_ARGS];
-    mp_arg_parse_all_kw_array(n_args, n_kw, args, FILE_OPEN_NUM_ARGS, file_open_args, arg_vals);
+    mp_arg_parse_all(n_args, args, kw_args, FILE_OPEN_NUM_ARGS, file_open_args, arg_vals);
     return file_open(NULL, type, arg_vals);
 }
 

--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -382,6 +382,7 @@ SRC_SHARED_MODULE = \
 	displayio/Group.c \
 	displayio/OnDiskBitmap.c \
 	displayio/Palette.c \
+	displayio/Shape.c \
 	displayio/Sprite.c \
 	gamepad/__init__.c \
 	gamepad/GamePad.c \

--- a/ports/atmel-samd/common-hal/displayio/FourWire.c
+++ b/ports/atmel-samd/common-hal/displayio/FourWire.c
@@ -70,7 +70,7 @@ bool common_hal_displayio_fourwire_begin_transaction(displayio_fourwire_obj_t* s
         return false;
     }
     // TODO(tannewt): Stop hardcoding SPI frequency, polarity and phase.
-    common_hal_busio_spi_configure(&self->bus, 12000000, 0, 0, 8);
+    common_hal_busio_spi_configure(&self->bus, 48000000, 0, 0, 8);
     common_hal_digitalio_digitalinout_set_value(&self->chip_select, false);
     return true;
 }

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -31,13 +31,22 @@
 
 #include "supervisor/shared/translate.h"
 
-void mp_arg_check_num(size_t n_args, size_t n_kw, size_t n_args_min, size_t n_args_max, bool takes_kw) {
+
+void mp_arg_check_num(size_t n_args, mp_map_t *kw_args, size_t n_args_min, size_t n_args_max, bool takes_kw) {
+    size_t n_kw = 0;
+    if (kw_args != NULL) {
+        n_kw = kw_args->used;
+    }
+    mp_arg_check_num_kw_array(n_args, n_kw, n_args_min, n_args_max, takes_kw);
+}
+
+void mp_arg_check_num_kw_array(size_t n_args, size_t n_kw, size_t n_args_min, size_t n_args_max, bool takes_kw) {
     // NOTE(tannewt): This prevents this function from being optimized away.
     // Without it, functions can crash when reading invalid args.
     __asm volatile ("");
     // TODO maybe take the function name as an argument so we can print nicer error messages
 
-    if (n_kw && !takes_kw) {
+    if (n_kw > 0 && !takes_kw) {
         #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE
             mp_arg_error_terse_mismatch();
         #else

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -516,7 +516,7 @@ STATIC mp_obj_t mp_builtin_sorted(size_t n_args, const mp_obj_t *args, mp_map_t 
     if (n_args > 1) {
         mp_raise_TypeError(translate("must use keyword argument for key function"));
     }
-    mp_obj_t self = mp_type_list.make_new(&mp_type_list, 1, 0, args);
+    mp_obj_t self = mp_type_list.make_new(&mp_type_list, 1, args, NULL);
     mp_obj_list_sort(1, &self, kwargs);
 
     return self;

--- a/py/obj.h
+++ b/py/obj.h
@@ -432,7 +432,7 @@ typedef struct _mp_obj_iter_buf_t {
 #define MP_OBJ_ITER_BUF_NSLOTS ((sizeof(mp_obj_iter_buf_t) + sizeof(mp_obj_t) - 1) / sizeof(mp_obj_t))
 
 typedef void (*mp_print_fun_t)(const mp_print_t *print, mp_obj_t o, mp_print_kind_t kind);
-typedef mp_obj_t (*mp_make_new_fun_t)(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args);
+typedef mp_obj_t (*mp_make_new_fun_t)(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args);
 typedef mp_obj_t (*mp_call_fun_t)(mp_obj_t fun, size_t n_args, size_t n_kw, const mp_obj_t *args);
 typedef mp_obj_t (*mp_unary_op_fun_t)(mp_unary_op_t op, mp_obj_t);
 typedef mp_obj_t (*mp_binary_op_fun_t)(mp_binary_op_t op, mp_obj_t, mp_obj_t);
@@ -671,7 +671,7 @@ mp_obj_t mp_obj_new_memoryview(byte typecode, size_t nitems, void *items);
 mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in);
 const char *mp_obj_get_type_str(mp_const_obj_t o_in);
 bool mp_obj_is_subclass_fast(mp_const_obj_t object, mp_const_obj_t classinfo); // arguments should be type objects
-mp_obj_t mp_instance_cast_to_native_base(mp_const_obj_t self_in, mp_const_obj_t native_type);
+mp_obj_t mp_instance_cast_to_native_base(mp_obj_t self_in, mp_const_obj_t native_type);
 
 void mp_obj_print_helper(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind);
 void mp_obj_print(mp_obj_t o, mp_print_kind_t kind);
@@ -720,7 +720,7 @@ void mp_obj_exception_add_traceback(mp_obj_t self_in, qstr file, size_t line, qs
 void mp_obj_exception_get_traceback(mp_obj_t self_in, size_t *n, size_t **values);
 mp_obj_t mp_obj_exception_get_traceback_obj(mp_obj_t self_in);
 mp_obj_t mp_obj_exception_get_value(mp_obj_t self_in);
-mp_obj_t mp_obj_exception_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
+mp_obj_t mp_obj_exception_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args);
 mp_obj_t mp_alloc_emergency_exception_buf(mp_obj_t size_in);
 void mp_init_emergency_exception_buf(void);
 

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -157,9 +157,9 @@ STATIC mp_obj_t array_construct(char typecode, mp_obj_t initializer) {
 #endif
 
 #if MICROPY_PY_ARRAY
-STATIC mp_obj_t array_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t array_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
-    mp_arg_check_num(n_args, n_kw, 1, 2, false);
+    mp_arg_check_num(n_args, kw_args, 1, 2, false);
 
     // get typecode
     const char *typecode = mp_obj_str_get_str(args[0]);
@@ -175,9 +175,9 @@ STATIC mp_obj_t array_make_new(const mp_obj_type_t *type_in, size_t n_args, size
 #endif
 
 #if MICROPY_PY_BUILTINS_BYTEARRAY
-STATIC mp_obj_t bytearray_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t bytearray_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
-    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    mp_arg_check_num(n_args, kw_args, 0, 1, false);
 
     if (n_args == 0) {
         // no args: construct an empty bytearray
@@ -207,13 +207,13 @@ mp_obj_t mp_obj_new_memoryview(byte typecode, size_t nitems, void *items) {
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC mp_obj_t memoryview_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t memoryview_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
 
     // TODO possibly allow memoryview constructor to take start/stop so that one
     // can do memoryview(b, 4, 8) instead of memoryview(b)[4:8] (uses less RAM)
 
-    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);

--- a/py/objbool.c
+++ b/py/objbool.c
@@ -50,9 +50,9 @@ STATIC void bool_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
     }
 }
 
-STATIC mp_obj_t bool_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t bool_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
-    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    mp_arg_check_num(n_args, kw_args, 0, 1, false);
 
     if (n_args == 0) {
         return mp_const_false;

--- a/py/objcomplex.c
+++ b/py/objcomplex.c
@@ -75,9 +75,9 @@ STATIC void complex_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_
     }
 }
 
-STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t complex_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
-    mp_arg_check_num(n_args, n_kw, 0, 2, false);
+    mp_arg_check_num(n_args, kw_args, 0, 2, false);
 
     switch (n_args) {
         case 0:

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -81,7 +81,7 @@ STATIC void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
     }
 }
 
-STATIC mp_obj_t dict_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t dict_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     mp_obj_t dict_out = mp_obj_new_dict(0);
     mp_obj_dict_t *dict = MP_OBJ_TO_PTR(dict_out);
     dict->base.type = type;
@@ -90,11 +90,9 @@ STATIC mp_obj_t dict_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
         dict->map.is_ordered = 1;
     }
     #endif
-    if (n_args > 0 || n_kw > 0) {
+    if (n_args > 0 || kw_args != NULL) {
         mp_obj_t args2[2] = {dict_out, args[0]}; // args[0] is always valid, even if it's not a positional arg
-        mp_map_t kwargs;
-        mp_map_init_fixed_table(&kwargs, n_kw, args + n_args);
-        dict_update(n_args + 1, args2, &kwargs); // dict_update will check that n_args + 1 == 1 or 2
+        dict_update(n_args + 1, args2, kw_args); // dict_update will check that n_args + 1 == 1 or 2
     }
     return dict_out;
 }
@@ -328,7 +326,7 @@ STATIC mp_obj_t dict_update(size_t n_args, const mp_obj_t *args, mp_map_t *kwarg
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(args[0]);
     mp_ensure_not_fixed(self);
 
-    mp_arg_check_num(n_args, kwargs->used, 1, 2, true);
+    mp_arg_check_num(n_args, kwargs, 1, 2, true);
 
     if (n_args == 2) {
         // given a positional argument

--- a/py/objenumerate.c
+++ b/py/objenumerate.c
@@ -59,7 +59,7 @@ STATIC mp_obj_t enumerate_make_new(const mp_obj_type_t *type, size_t n_args, con
     o->iter = mp_getiter(arg_vals.iterable.u_obj, NULL);
     o->cur = arg_vals.start.u_int;
 #else
-    (void)n_kw;
+    (void)kw_args;
     mp_obj_enumerate_t *o = m_new_obj(mp_obj_enumerate_t);
     o->base.type = type;
     o->iter = mp_getiter(args[0], NULL);

--- a/py/objenumerate.c
+++ b/py/objenumerate.c
@@ -39,7 +39,7 @@ typedef struct _mp_obj_enumerate_t {
 
 STATIC mp_obj_t enumerate_iternext(mp_obj_t self_in);
 
-STATIC mp_obj_t enumerate_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t enumerate_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
 #if MICROPY_CPYTHON_COMPAT
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_iterable, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
@@ -50,7 +50,7 @@ STATIC mp_obj_t enumerate_make_new(const mp_obj_type_t *type, size_t n_args, siz
     struct {
         mp_arg_val_t iterable, start;
     } arg_vals;
-    mp_arg_parse_all_kw_array(n_args, n_kw, args,
+    mp_arg_parse_all(n_args, args, kw_args,
         MP_ARRAY_SIZE(allowed_args), allowed_args, (mp_arg_val_t*)&arg_vals);
 
     // create enumerate object

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -130,8 +130,8 @@ void mp_obj_exception_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kin
     mp_obj_tuple_print(print, MP_OBJ_FROM_PTR(o->args), kind);
 }
 
-mp_obj_t mp_obj_exception_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, false);
+mp_obj_t mp_obj_exception_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 0, MP_OBJ_FUN_ARGS_MAX, false);
 
     // Try to allocate memory for the exception, with fallback to emergency exception object
     mp_obj_exception_t *o_exc = m_new_obj_maybe(mp_obj_exception_t);
@@ -336,7 +336,7 @@ mp_obj_t mp_obj_new_exception_arg1(const mp_obj_type_t *exc_type, mp_obj_t arg) 
 
 mp_obj_t mp_obj_new_exception_args(const mp_obj_type_t *exc_type, size_t n_args, const mp_obj_t *args) {
     assert(exc_type->make_new == mp_obj_exception_make_new);
-    return exc_type->make_new(exc_type, n_args, 0, args);
+    return exc_type->make_new(exc_type, n_args, args, NULL);
 }
 
 mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const compressed_string_t *msg) {
@@ -438,7 +438,7 @@ mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, const com
     o_str->base.type = &mp_type_str;
     o_str->hash = qstr_compute_hash(o_str->data, o_str->len);
     mp_obj_t arg = MP_OBJ_FROM_PTR(o_str);
-    return mp_obj_exception_make_new(exc_type, 1, 0, &arg);
+    return mp_obj_exception_make_new(exc_type, 1, &arg, NULL);
 }
 
 // return true if the given object is an exception type
@@ -607,7 +607,7 @@ STATIC mp_obj_t code_make_new(qstr file, qstr block) {
         mp_obj_new_bytearray(0, NULL), // co_lnotab
     };
 
-    return namedtuple_make_new((const mp_obj_type_t*)&code_type_obj, 15, 0, elems);
+    return namedtuple_make_new((const mp_obj_type_t*)&code_type_obj, 15, elems, NULL);
 }
 
 STATIC const mp_obj_namedtuple_type_t frame_type_obj = {
@@ -650,7 +650,7 @@ STATIC mp_obj_t frame_make_new(mp_obj_t f_code, int f_lineno) {
         mp_const_none,             // f_trace
     };
 
-    return namedtuple_make_new((const mp_obj_type_t*)&frame_type_obj, 8, 0, elems);
+    return namedtuple_make_new((const mp_obj_type_t*)&frame_type_obj, 8, elems, NULL);
 }
 
 STATIC const mp_obj_namedtuple_type_t traceback_type_obj = {
@@ -687,7 +687,7 @@ STATIC mp_obj_t traceback_from_values(size_t *values, mp_obj_t tb_next) {
         tb_next,
     };
 
-    return namedtuple_make_new((const mp_obj_type_t*)&traceback_type_obj, 4, 0, elems);
+    return namedtuple_make_new((const mp_obj_type_t*)&traceback_type_obj, 4, elems, NULL);
 };
 
 mp_obj_t mp_obj_exception_get_traceback_obj(mp_obj_t self_in) {

--- a/py/objfilter.c
+++ b/py/objfilter.c
@@ -34,8 +34,8 @@ typedef struct _mp_obj_filter_t {
     mp_obj_t iter;
 } mp_obj_filter_t;
 
-STATIC mp_obj_t filter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 2, 2, false);
+STATIC mp_obj_t filter_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 2, 2, false);
     mp_obj_filter_t *o = m_new_obj(mp_obj_filter_t);
     o->base.type = type;
     o->fun = args[0];

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -133,9 +133,9 @@ STATIC void float_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t 
     }
 }
 
-STATIC mp_obj_t float_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t float_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
-    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    mp_arg_check_num(n_args, kw_args, 0, 1, false);
 
     switch (n_args) {
         case 0:

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -52,7 +52,7 @@ STATIC mp_obj_t fun_builtin_0_call(mp_obj_t self_in, size_t n_args, size_t n_kw,
     (void)args;
     assert(MP_OBJ_IS_TYPE(self_in, &mp_type_fun_builtin_0));
     mp_obj_fun_builtin_fixed_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    mp_arg_check_num_kw_array(n_args, n_kw, 0, 0, false);
     return self->fun._0();
 }
 
@@ -66,7 +66,7 @@ const mp_obj_type_t mp_type_fun_builtin_0 = {
 STATIC mp_obj_t fun_builtin_1_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     assert(MP_OBJ_IS_TYPE(self_in, &mp_type_fun_builtin_1));
     mp_obj_fun_builtin_fixed_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+    mp_arg_check_num_kw_array(n_args, n_kw, 1, 1, false);
     return self->fun._1(args[0]);
 }
 
@@ -80,7 +80,7 @@ const mp_obj_type_t mp_type_fun_builtin_1 = {
 STATIC mp_obj_t fun_builtin_2_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     assert(MP_OBJ_IS_TYPE(self_in, &mp_type_fun_builtin_2));
     mp_obj_fun_builtin_fixed_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_arg_check_num(n_args, n_kw, 2, 2, false);
+    mp_arg_check_num_kw_array(n_args, n_kw, 2, 2, false);
     return self->fun._2(args[0], args[1]);
 }
 
@@ -94,7 +94,7 @@ const mp_obj_type_t mp_type_fun_builtin_2 = {
 STATIC mp_obj_t fun_builtin_3_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     assert(MP_OBJ_IS_TYPE(self_in, &mp_type_fun_builtin_3));
     mp_obj_fun_builtin_fixed_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_arg_check_num(n_args, n_kw, 3, 3, false);
+    mp_arg_check_num_kw_array(n_args, n_kw, 3, 3, false);
     return self->fun._3(args[0], args[1], args[2]);
 }
 
@@ -110,7 +110,7 @@ STATIC mp_obj_t fun_builtin_var_call(mp_obj_t self_in, size_t n_args, size_t n_k
     mp_obj_fun_builtin_var_t *self = MP_OBJ_TO_PTR(self_in);
 
     // check number of arguments
-    mp_arg_check_num(n_args, n_kw, self->n_args_min, self->n_args_max, self->is_kw);
+    mp_arg_check_num_kw_array(n_args, n_kw, self->n_args_min, self->n_args_max, self->is_kw);
 
     if (self->is_kw) {
         // function allows keywords

--- a/py/objint.c
+++ b/py/objint.c
@@ -42,9 +42,9 @@
 #endif
 
 // This dispatcher function is expected to be independent of the implementation of long int
-STATIC mp_obj_t mp_obj_int_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t mp_obj_int_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
-    mp_arg_check_num(n_args, n_kw, 0, 2, false);
+    mp_arg_check_num(n_args, kw_args, 0, 2, false);
 
     switch (n_args) {
         case 0:

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -68,9 +68,9 @@ STATIC mp_obj_t list_extend_from_iter(mp_obj_t list, mp_obj_t iterable) {
     return list;
 }
 
-STATIC mp_obj_t list_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t list_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
-    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    mp_arg_check_num(n_args, kw_args, 0, 1, false);
 
     switch (n_args) {
         case 0:

--- a/py/objmap.c
+++ b/py/objmap.c
@@ -36,8 +36,8 @@ typedef struct _mp_obj_map_t {
     mp_obj_t iters[];
 } mp_obj_map_t;
 
-STATIC mp_obj_t map_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 2, MP_OBJ_FUN_ARGS_MAX, false);
+STATIC mp_obj_t map_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 2, MP_OBJ_FUN_ARGS_MAX, false);
     mp_obj_map_t *o = m_new_obj_var(mp_obj_map_t, mp_obj_t, n_args - 1);
     o->base.type = type;
     o->n_iters = n_args - 1;

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -93,9 +93,10 @@ void namedtuple_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     }
 }
 
-mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     const mp_obj_namedtuple_type_t *type = (const mp_obj_namedtuple_type_t*)type_in;
     size_t num_fields = type->n_fields;
+    size_t n_kw = kw_args->used;
     if (n_args + n_kw != num_fields) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_arg_error_terse_mismatch();
@@ -119,8 +120,8 @@ mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t
 
     // Fill in the remaining slots with the keyword args
     memset(&tuple->items[n_args], 0, sizeof(mp_obj_t) * n_kw);
-    for (size_t i = n_args; i < n_args + 2 * n_kw; i += 2) {
-        qstr kw = mp_obj_str_get_qstr(args[i]);
+    for (size_t i = 0; i < n_kw; i++) {
+        qstr kw = mp_obj_str_get_qstr(kw_args->table[i].key);
         size_t id = mp_obj_namedtuple_find_field(type, kw);
         if (id == (size_t)-1) {
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
@@ -138,7 +139,7 @@ mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t
                     translate("function got multiple values for argument '%q'"), kw);
             }
         }
-        tuple->items[id] = args[i + 1];
+        tuple->items[id] = kw_args->table[i].value;
     }
 
     return MP_OBJ_FROM_PTR(tuple);

--- a/py/objnamedtuple.h
+++ b/py/objnamedtuple.h
@@ -51,7 +51,7 @@ void namedtuple_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t ki
 size_t mp_obj_namedtuple_find_field(const mp_obj_namedtuple_type_t *type, qstr name);
 void namedtuple_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
 mp_obj_namedtuple_type_t *mp_obj_new_namedtuple_base(size_t n_fields, mp_obj_t *fields);
-mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
+mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args);
 
 #endif // MICROPY_PY_COLLECTIONS
 

--- a/py/objobject.c
+++ b/py/objobject.c
@@ -35,9 +35,9 @@ typedef struct _mp_obj_object_t {
     mp_obj_base_t base;
 } mp_obj_object_t;
 
-STATIC mp_obj_t object_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t object_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)args;
-    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    mp_arg_check_num(n_args, kw_args, 0, 0, false);
     mp_obj_object_t *o = m_new_obj(mp_obj_object_t);
     o->base.type = type;
     return MP_OBJ_FROM_PTR(o);

--- a/py/objproperty.c
+++ b/py/objproperty.c
@@ -33,7 +33,7 @@
 
 #if MICROPY_PY_BUILTINS_PROPERTY
 
-STATIC mp_obj_t property_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t property_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     enum { ARG_fget, ARG_fset, ARG_fdel, ARG_doc };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_PTR(&mp_const_none_obj)} },
@@ -42,7 +42,7 @@ STATIC mp_obj_t property_make_new(const mp_obj_type_t *type, size_t n_args, size
         { MP_QSTR_doc, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_PTR(&mp_const_none_obj)} },
     };
     mp_arg_val_t vals[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all_kw_array(n_args, n_kw, args, MP_ARRAY_SIZE(allowed_args), allowed_args, vals);
+    mp_arg_parse_all(n_args, args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, vals);
 
     mp_obj_property_t *o = m_new_obj(mp_obj_property_t);
     o->base.type = type;

--- a/py/objrange.c
+++ b/py/objrange.c
@@ -91,8 +91,8 @@ STATIC void range_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind
     }
 }
 
-STATIC mp_obj_t range_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 1, 3, false);
+STATIC mp_obj_t range_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 1, 3, false);
 
     mp_obj_range_t *o = m_new_obj(mp_obj_range_t);
     o->base.type = type;

--- a/py/objreversed.c
+++ b/py/objreversed.c
@@ -37,8 +37,8 @@ typedef struct _mp_obj_reversed_t {
     mp_uint_t cur_index;    // current index, plus 1; 0=no more, 1=last one (index 0)
 } mp_obj_reversed_t;
 
-STATIC mp_obj_t reversed_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+STATIC mp_obj_t reversed_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     // check if __reversed__ exists, and if so delegate to it
     mp_obj_t dest[2];

--- a/py/objset.c
+++ b/py/objset.c
@@ -103,8 +103,8 @@ STATIC void set_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
     #endif
 }
 
-STATIC mp_obj_t set_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+STATIC mp_obj_t set_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 0, 1, false);
 
     switch (n_args) {
         case 0: {
@@ -299,7 +299,7 @@ STATIC mp_obj_t set_issubset_internal(mp_obj_t self_in, mp_obj_t other_in, bool 
     if (is_set_or_frozenset(self_in)) {
         self = MP_OBJ_TO_PTR(self_in);
     } else {
-        self = MP_OBJ_TO_PTR(set_make_new(&mp_type_set, 1, 0, &self_in));
+        self = MP_OBJ_TO_PTR(set_make_new(&mp_type_set, 1, &self_in, NULL));
         cleanup_self = true;
     }
 
@@ -308,7 +308,7 @@ STATIC mp_obj_t set_issubset_internal(mp_obj_t self_in, mp_obj_t other_in, bool 
     if (is_set_or_frozenset(other_in)) {
         other = MP_OBJ_TO_PTR(other_in);
     } else {
-        other = MP_OBJ_TO_PTR(set_make_new(&mp_type_set, 1, 0, &other_in));
+        other = MP_OBJ_TO_PTR(set_make_new(&mp_type_set, 1, &other_in, NULL));
         cleanup_other = true;
     }
     mp_obj_t out = mp_const_true;

--- a/py/objslice.c
+++ b/py/objslice.c
@@ -130,7 +130,7 @@ STATIC void slice_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 }
 
 STATIC mp_obj_t slice_make_new(const mp_obj_type_t *type,
-        size_t n_args, size_t n_kw, const mp_obj_t *args);
+        size_t n_args, const mp_obj_t *args, mp_map_t *kw_args);
 #endif
 
 const mp_obj_type_t mp_type_slice = {
@@ -154,12 +154,12 @@ mp_obj_t mp_obj_new_slice(mp_obj_t ostart, mp_obj_t ostop, mp_obj_t ostep) {
 
 #if MICROPY_PY_BUILTINS_SLICE_ATTRS
 STATIC mp_obj_t slice_make_new(const mp_obj_type_t *type,
-        size_t n_args, size_t n_kw, const mp_obj_t *args) {
+        size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     if (type != &mp_type_slice) {
         mp_raise_NotImplementedError(translate("Cannot subclass slice"));
     }
     // check number of arguments
-    mp_arg_check_num(n_args, n_kw, 1, 3, false);
+    mp_arg_check_num(n_args, kw_args, 1, 3, false);
 
     // 1st argument is the pin
     mp_obj_t start = mp_const_none;

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -132,14 +132,14 @@ STATIC void str_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
     }
 }
 
-mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
 #if MICROPY_CPYTHON_COMPAT
-    if (n_kw != 0) {
+    if (kw_args != NULL && kw_args->used != 0) {
         mp_arg_error_unimpl_kw();
     }
 #endif
 
-    mp_arg_check_num(n_args, n_kw, 0, 3, false);
+    mp_arg_check_num(n_args, kw_args, 0, 3, false);
 
     switch (n_args) {
         case 0:
@@ -190,11 +190,11 @@ mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
     }
 }
 
-STATIC mp_obj_t bytes_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t bytes_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
 
     #if MICROPY_CPYTHON_COMPAT
-    if (n_kw != 0) {
+    if (kw_args != NULL && kw_args->used != 0) {
         mp_arg_error_unimpl_kw();
     }
     #else
@@ -455,7 +455,7 @@ STATIC mp_obj_t str_join(mp_obj_t self_in, mp_obj_t arg) {
     if (!MP_OBJ_IS_TYPE(arg, &mp_type_list) && !MP_OBJ_IS_TYPE(arg, &mp_type_tuple)) {
         // arg is not a list nor a tuple, try to convert it to a list
         // TODO: Try to optimize?
-        arg = mp_type_list.make_new(&mp_type_list, 1, 0, &arg);
+        arg = mp_type_list.make_new(&mp_type_list, 1, &arg, NULL);
     }
     mp_obj_get_array(arg, &seq_len, &seq_items);
 
@@ -1875,7 +1875,7 @@ STATIC mp_obj_t bytes_decode(size_t n_args, const mp_obj_t *args) {
         args = new_args;
         n_args++;
     }
-    return mp_obj_str_make_new(&mp_type_str, n_args, 0, args);
+    return mp_obj_str_make_new(&mp_type_str, n_args, args, NULL);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bytes_decode_obj, 1, 3, bytes_decode);
 
@@ -1888,7 +1888,7 @@ STATIC mp_obj_t str_encode(size_t n_args, const mp_obj_t *args) {
         args = new_args;
         n_args++;
     }
-    return bytes_make_new(NULL, n_args, 0, args);
+    return bytes_make_new(NULL, n_args, args, NULL);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(str_encode_obj, 1, 3, str_encode);
 #endif

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -198,7 +198,7 @@ STATIC mp_obj_t bytes_make_new(const mp_obj_type_t *type_in, size_t n_args, cons
         mp_arg_error_unimpl_kw();
     }
     #else
-    (void)n_kw;
+    (void)kw_args;
     #endif
 
     if (n_args == 0) {

--- a/py/objstr.h
+++ b/py/objstr.h
@@ -61,7 +61,7 @@ const byte *mp_obj_str_get_data_no_check(mp_obj_t self_in, size_t *len);
     else { str_len = ((mp_obj_str_t*)MP_OBJ_TO_PTR(str_obj_in))->len; str_data = ((mp_obj_str_t*)MP_OBJ_TO_PTR(str_obj_in))->data; }
 #endif
 
-mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
+mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args);
 void mp_str_print_json(const mp_print_t *print, const byte *str_data, size_t str_len);
 mp_obj_t mp_obj_str_format(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
 mp_obj_t mp_obj_str_split(size_t n_args, const mp_obj_t *args);

--- a/py/objstringio.c
+++ b/py/objstringio.c
@@ -186,8 +186,8 @@ STATIC mp_obj_stringio_t *stringio_new(const mp_obj_type_t *type) {
     return o;
 }
 
-STATIC mp_obj_t stringio_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    (void)n_kw; // TODO check n_kw==0
+STATIC mp_obj_t stringio_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    (void)kw_args; // TODO check kw_args->used == 0
 
     mp_uint_t sz = 16;
     bool initdata = false;

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -59,10 +59,10 @@ void mp_obj_tuple_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t 
     }
 }
 
-STATIC mp_obj_t mp_obj_tuple_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t mp_obj_tuple_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
 
-    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    mp_arg_check_num(n_args, kw_args, 0, 1, false);
 
     switch (n_args) {
         case 0:

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -50,7 +50,7 @@
 #define TYPE_FLAG_IS_SUBCLASSED (0x0001)
 #define TYPE_FLAG_HAS_SPECIAL_ACCESSORS (0x0002)
 
-STATIC mp_obj_t static_class_method_make_new(const mp_obj_type_t *self_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
+STATIC mp_obj_t static_class_method_make_new(const mp_obj_type_t *self_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args);
 
 /******************************************************************************/
 // instance object
@@ -90,14 +90,14 @@ STATIC int instance_count_native_bases(const mp_obj_type_t *type, const mp_obj_t
 
 // This wrapper function is allows a subclass of a native type to call the
 // __init__() method (corresponding to type->make_new) of the native type.
-STATIC mp_obj_t native_base_init_wrapper(size_t n_args, const mp_obj_t *args) {
-    mp_obj_instance_t *self = MP_OBJ_TO_PTR(args[0]);
+STATIC mp_obj_t native_base_init_wrapper(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    mp_obj_instance_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     const mp_obj_type_t *native_base = NULL;
     instance_count_native_bases(self->base.type, &native_base);
-    self->subobj[0] = native_base->make_new(native_base, n_args - 1, 0, args + 1);
+    self->subobj[0] = native_base->make_new(native_base, n_args - 1, pos_args + 1, kw_args);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(native_base_init_wrapper_obj, 1, MP_OBJ_FUN_ARGS_MAX, native_base_init_wrapper);
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(native_base_init_wrapper_obj, 1, native_base_init_wrapper);
 
 #if !MICROPY_CPYTHON_COMPAT
 STATIC
@@ -281,7 +281,7 @@ STATIC void instance_print(const mp_print_t *print, mp_obj_t self_in, mp_print_k
     mp_printf(print, "<%s object at %p>", mp_obj_get_type_str(self_in), self);
 }
 
-mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     assert(mp_obj_is_instance_type(self));
 
     // look for __new__ function
@@ -297,6 +297,10 @@ mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_args, size
 
     const mp_obj_type_t *native_base = NULL;
     mp_obj_instance_t *o;
+    size_t n_kw = 0;
+    if (kw_args != 0) {
+        n_kw = kw_args->used;
+    }
     if (init_fn[0] == MP_OBJ_NULL || init_fn[0] == MP_OBJ_SENTINEL) {
         // Either there is no __new__() method defined or there is a native
         // constructor.  In both cases create a blank instance.
@@ -315,9 +319,12 @@ mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_args, size
             mp_obj_t args2[1] = {MP_OBJ_FROM_PTR(self)};
             new_ret = mp_call_function_n_kw(init_fn[0], 1, 0, args2);
         } else {
+            // TODO(tannewt): Could this be on the stack? It's deleted below.
             mp_obj_t *args2 = m_new(mp_obj_t, 1 + n_args + 2 * n_kw);
             args2[0] = MP_OBJ_FROM_PTR(self);
-            memcpy(args2 + 1, args, (n_args + 2 * n_kw) * sizeof(mp_obj_t));
+            memcpy(args2 + 1, args, n_args * sizeof(mp_obj_t));
+            // copy in kwargs
+            memcpy(args2 + 1 + n_args, kw_args->table, 2 * n_kw * sizeof(mp_obj_t));
             new_ret = mp_call_function_n_kw(init_fn[0], n_args + 1, n_kw, args2);
             m_del(mp_obj_t, args2, 1 + n_args + 2 * n_kw);
         }
@@ -343,13 +350,16 @@ mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_args, size
     mp_obj_class_lookup(&lookup, self);
     if (init_fn[0] != MP_OBJ_NULL) {
         mp_obj_t init_ret;
-        if (n_args == 0 && n_kw == 0) {
+        if (n_args == 0 && kw_args == NULL) {
             init_ret = mp_call_method_n_kw(0, 0, init_fn);
         } else {
+            // TODO(tannewt): Could this be on the stack? It's deleted below.
             mp_obj_t *args2 = m_new(mp_obj_t, 2 + n_args + 2 * n_kw);
             args2[0] = init_fn[0];
             args2[1] = init_fn[1];
-            memcpy(args2 + 2, args, (n_args + 2 * n_kw) * sizeof(mp_obj_t));
+            // copy in kwargs
+            memcpy(args2 + 2, args, n_args * sizeof(mp_obj_t));
+            memcpy(args2 + 2 + n_args, kw_args->table, 2 * n_kw * sizeof(mp_obj_t));
             init_ret = mp_call_method_n_kw(n_args, n_kw, args2);
             m_del(mp_obj_t, args2, 2 + n_args + 2 * n_kw);
         }
@@ -367,7 +377,7 @@ mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_args, size
     // If the type had a native base that was not explicitly initialised
     // (constructed) by the Python __init__() method then construct it now.
     if (native_base != NULL && o->subobj[0] == MP_OBJ_FROM_PTR(&native_base_init_wrapper_obj)) {
-        o->subobj[0] = native_base->make_new(native_base, n_args, n_kw, args);
+        o->subobj[0] = native_base->make_new(native_base, n_args, args, kw_args);
     }
 
     return MP_OBJ_FROM_PTR(o);
@@ -959,10 +969,10 @@ STATIC void type_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
     mp_printf(print, "<class '%q'>", self->name);
 }
 
-STATIC mp_obj_t type_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t type_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
 
-    mp_arg_check_num(n_args, n_kw, 1, 3, false);
+    mp_arg_check_num(n_args, kw_args, 1, 3, false);
 
     switch (n_args) {
         case 1:
@@ -992,8 +1002,10 @@ STATIC mp_obj_t type_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp
         }
     }
 
-    // make new instance
-    mp_obj_t o = self->make_new(self, n_args, n_kw, args);
+    // create a map directly from the given args array and make a new instance
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+    mp_obj_t o = self->make_new(self, n_args, args, &kw_args);
 
     // return new instance
     return o;
@@ -1170,7 +1182,7 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
         // __new__ slot exists; check if it is a function
         if (MP_OBJ_IS_FUN(elem->value)) {
             // __new__ is a function, wrap it in a staticmethod decorator
-            elem->value = static_class_method_make_new(&mp_type_staticmethod, 1, 0, &elem->value);
+            elem->value = static_class_method_make_new(&mp_type_staticmethod, 1, &elem->value, NULL);
         }
     }
 
@@ -1196,11 +1208,11 @@ STATIC void super_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind
     mp_print_str(print, ">");
 }
 
-STATIC mp_obj_t super_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t super_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     (void)type_in;
     // 0 arguments are turned into 2 in the compiler
     // 1 argument is not yet implemented
-    mp_arg_check_num(n_args, n_kw, 2, 2, false);
+    mp_arg_check_num(n_args, kw_args, 2, 2, false);
     if(!MP_OBJ_IS_TYPE(args[0], &mp_type_type)) {
         mp_raise_TypeError(translate("first argument to super() must be type"));
     }
@@ -1394,10 +1406,13 @@ STATIC mp_obj_t mp_builtin_isinstance(mp_obj_t object, mp_obj_t classinfo) {
 
 MP_DEFINE_CONST_FUN_OBJ_2(mp_builtin_isinstance_obj, mp_builtin_isinstance);
 
-mp_obj_t mp_instance_cast_to_native_base(mp_const_obj_t self_in, mp_const_obj_t native_type) {
+mp_obj_t mp_instance_cast_to_native_base(mp_obj_t self_in, mp_const_obj_t native_type) {
     mp_obj_type_t *self_type = mp_obj_get_type(self_in);
     if (!mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(self_type), native_type)) {
         return MP_OBJ_NULL;
+    }
+    if (MP_OBJ_FROM_PTR(self_type) == native_type) {
+        return self_in;
     }
     mp_obj_instance_t *self = (mp_obj_instance_t*)MP_OBJ_TO_PTR(self_in);
     return self->subobj[0];
@@ -1406,10 +1421,10 @@ mp_obj_t mp_instance_cast_to_native_base(mp_const_obj_t self_in, mp_const_obj_t 
 /******************************************************************************/
 // staticmethod and classmethod types (probably should go in a different file)
 
-STATIC mp_obj_t static_class_method_make_new(const mp_obj_type_t *self, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t static_class_method_make_new(const mp_obj_type_t *self, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     assert(self == &mp_type_staticmethod || self == &mp_type_classmethod);
 
-    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     mp_obj_static_class_method_t *o = m_new_obj(mp_obj_static_class_method_t);
     *o = (mp_obj_static_class_method_t){{self}, args[0]};

--- a/py/objtype.h
+++ b/py/objtype.h
@@ -49,6 +49,6 @@ mp_obj_t mp_obj_instance_call(mp_obj_t self_in, size_t n_args, size_t n_kw, cons
 #define mp_obj_is_instance_type(type) ((type)->make_new == mp_obj_instance_make_new)
 #define mp_obj_is_native_type(type) ((type)->make_new != mp_obj_instance_make_new)
 // this needs to be exposed for the above macros to work correctly
-mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
+mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args);
 
 #endif // MICROPY_INCLUDED_PY_OBJTYPE_H

--- a/py/objzip.c
+++ b/py/objzip.c
@@ -36,8 +36,8 @@ typedef struct _mp_obj_zip_t {
     mp_obj_t iters[];
 } mp_obj_zip_t;
 
-STATIC mp_obj_t zip_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, false);
+STATIC mp_obj_t zip_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 0, MP_OBJ_FUN_ARGS_MAX, false);
 
     mp_obj_zip_t *o = m_new_obj_var(mp_obj_zip_t, mp_obj_t, n_args);
     o->base.type = type;

--- a/py/py.mk
+++ b/py/py.mk
@@ -233,12 +233,6 @@ PY_EXTMOD_O_BASENAME = \
 	extmod/moduhashlib.o \
 	extmod/modubinascii.o \
 	extmod/virtpin.o \
-	extmod/machine_mem.o \
-	extmod/machine_pinbase.o \
-	extmod/machine_signal.o \
-	extmod/machine_pulse.o \
-	extmod/machine_i2c.o \
-	extmod/machine_spi.o \
 	extmod/modussl_axtls.o \
 	extmod/modussl_mbedtls.o \
 	extmod/modurandom.o \

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -77,8 +77,9 @@ bool mp_sched_schedule(mp_obj_t function, mp_obj_t arg);
 // extra printing method specifically for mp_obj_t's which are integral type
 int mp_print_mp_int(const mp_print_t *print, mp_obj_t x, int base, int base_char, int flags, char fill, int width, int prec);
 
-void mp_arg_check_num(size_t n_args, size_t n_kw, size_t n_args_min, size_t n_args_max, bool takes_kw);
+void mp_arg_check_num(size_t n_args, mp_map_t *kw_args, size_t n_args_min, size_t n_args_max, bool takes_kw);
 void mp_arg_parse_all(size_t n_pos, const mp_obj_t *pos, mp_map_t *kws, size_t n_allowed, const mp_arg_t *allowed, mp_arg_val_t *out_vals);
+void mp_arg_check_num_kw_array(size_t n_args, size_t n_kw, size_t n_args_min, size_t n_args_max, bool takes_kw);
 void mp_arg_parse_all_kw_array(size_t n_pos, size_t n_kw, const mp_obj_t *args, size_t n_allowed, const mp_arg_t *allowed, mp_arg_val_t *out_vals);
 NORETURN void mp_arg_error_terse_mismatch(void);
 NORETURN void mp_arg_error_unimpl_kw(void);

--- a/shared-bindings/_stage/Layer.c
+++ b/shared-bindings/_stage/Layer.c
@@ -51,8 +51,8 @@
 //|     it shouldn't be used on its own.
 //|
 STATIC mp_obj_t layer_make_new(const mp_obj_type_t *type, size_t n_args,
-        size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 4, 5, false);
+        const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 4, 5, false);
 
     layer_obj_t *self = m_new_obj(layer_obj_t);
     self->base.type = type;

--- a/shared-bindings/_stage/Text.c
+++ b/shared-bindings/_stage/Text.c
@@ -51,8 +51,8 @@
 //|     it shouldn't be used on its own.
 //|
 STATIC mp_obj_t text_make_new(const mp_obj_type_t *type, size_t n_args,
-        size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 5, 5, false);
+        const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 5, 5, false);
 
     text_obj_t *self = m_new_obj(text_obj_t);
     self->base.type = type;

--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -58,9 +58,9 @@
 //|   :param ~microcontroller.Pin pin: the pin to read from
 //|
 STATIC mp_obj_t analogio_analogin_make_new(const mp_obj_type_t *type,
-        mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+        mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     // check number of arguments
-    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     // 1st argument is the pin
     mp_obj_t pin_obj = args[0];

--- a/shared-bindings/analogio/AnalogOut.c
+++ b/shared-bindings/analogio/AnalogOut.c
@@ -58,9 +58,9 @@
 //|
 //|   :param ~microcontroller.Pin pin: the pin to output to
 //|
-STATIC mp_obj_t analogio_analogout_make_new(const mp_obj_type_t *type, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t analogio_analogout_make_new(const mp_obj_type_t *type, mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     // check arguments
-    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     assert_pin(args[0], false);
     const mcu_pin_obj_t *pin = MP_OBJ_TO_PTR(args[0]);

--- a/shared-bindings/audiobusio/I2SOut.c
+++ b/shared-bindings/audiobusio/I2SOut.c
@@ -93,10 +93,7 @@
 //|       pass
 //|     print("stopped")
 //|
-STATIC mp_obj_t audiobusio_i2sout_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 3, 4, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t audiobusio_i2sout_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bit_clock, ARG_word_select, ARG_data, ARG_left_justified };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_bit_clock, MP_ARG_OBJ | MP_ARG_REQUIRED },
@@ -105,7 +102,7 @@ STATIC mp_obj_t audiobusio_i2sout_make_new(const mp_obj_type_t *type, size_t n_a
         { MP_QSTR_left_justified, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_bool = false} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_obj_t bit_clock_obj = args[ARG_bit_clock].u_obj;
     assert_pin(bit_clock_obj, false);

--- a/shared-bindings/audiobusio/PDMIn.c
+++ b/shared-bindings/audiobusio/PDMIn.c
@@ -87,12 +87,12 @@
 //|     with audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA, sample_rate=16000, bit_depth=16) as mic:
 //|         mic.record(b, len(b))
 //|
-STATIC mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    enum { ARG_sample_rate, ARG_bit_depth, ARG_mono, ARG_oversample, ARG_startup_delay };
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_clock_pin, ARG_data_pin, ARG_sample_rate, ARG_bit_depth, ARG_mono, ARG_oversample, ARG_startup_delay };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_sample_rate,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 16000} },
+        { MP_QSTR_clock_pin,     MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_data_pin,      MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_sample_rate,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 16000} },
         { MP_QSTR_bit_depth,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 8} },
         { MP_QSTR_mono,          MP_ARG_KW_ONLY | MP_ARG_BOOL,{.u_bool = true} },
         { MP_QSTR_oversample,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 64} },
@@ -102,14 +102,14 @@ STATIC mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_ar
     static const float STARTUP_DELAY_DEFAULT = 0.110F;
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 2, pos_args + 2, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_obj_t clock_pin_obj = pos_args[0];
+    mp_obj_t clock_pin_obj = args[ARG_clock_pin].u_obj;
     assert_pin(clock_pin_obj, false);
     const mcu_pin_obj_t *clock_pin = MP_OBJ_TO_PTR(clock_pin_obj);
     assert_pin_free(clock_pin);
 
-    mp_obj_t data_pin_obj = pos_args[1];
+    mp_obj_t data_pin_obj = args[ARG_data_pin].u_obj;
     assert_pin(data_pin_obj, false);
     const mcu_pin_obj_t *data_pin = MP_OBJ_TO_PTR(data_pin_obj);
     assert_pin_free(data_pin);

--- a/shared-bindings/audioio/AudioOut.c
+++ b/shared-bindings/audioio/AudioOut.c
@@ -93,10 +93,7 @@
 //|       pass
 //|     print("stopped")
 //|
-STATIC mp_obj_t audioio_audioout_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, 2, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t audioio_audioout_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_left_channel, ARG_right_channel, ARG_quiescent_value };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_left_channel, MP_ARG_OBJ | MP_ARG_REQUIRED },
@@ -104,7 +101,7 @@ STATIC mp_obj_t audioio_audioout_make_new(const mp_obj_type_t *type, size_t n_ar
         { MP_QSTR_quiescent_value, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0x8000} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_obj_t left_channel_obj = args[ARG_left_channel].u_obj;
     assert_pin(left_channel_obj, false);

--- a/shared-bindings/audioio/Mixer.c
+++ b/shared-bindings/audioio/Mixer.c
@@ -73,10 +73,7 @@
 //|       time.sleep(1)
 //|     print("stopped")
 //|
-STATIC mp_obj_t audioio_mixer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, 2, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t audioio_mixer_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_voice_count, ARG_buffer_size, ARG_channel_count, ARG_bits_per_sample, ARG_samples_signed, ARG_sample_rate };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_voice_count, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 2} },
@@ -87,7 +84,7 @@ STATIC mp_obj_t audioio_mixer_make_new(const mp_obj_type_t *type, size_t n_args,
         { MP_QSTR_sample_rate, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 8000} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_int_t voice_count = args[ARG_voice_count].u_int;
     if (voice_count < 1 || voice_count > 255) {

--- a/shared-bindings/audioio/RawSample.c
+++ b/shared-bindings/audioio/RawSample.c
@@ -73,10 +73,7 @@
 //|     time.sleep(1)
 //|     dac.stop()
 //|
-STATIC mp_obj_t audioio_rawsample_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, 2, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t audioio_rawsample_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_channel_count, ARG_sample_rate };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_buffer, MP_ARG_OBJ | MP_ARG_REQUIRED },
@@ -84,7 +81,7 @@ STATIC mp_obj_t audioio_rawsample_make_new(const mp_obj_type_t *type, size_t n_a
         { MP_QSTR_sample_rate, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 8000} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     audioio_rawsample_obj_t *self = m_new_obj(audioio_rawsample_obj_t);
     self->base.type = &audioio_rawsample_type;

--- a/shared-bindings/audioio/WaveFile.c
+++ b/shared-bindings/audioio/WaveFile.c
@@ -67,8 +67,8 @@
 //|       pass
 //|     print("stopped")
 //|
-STATIC mp_obj_t audioio_wavefile_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 1, 1, true);
+STATIC mp_obj_t audioio_wavefile_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     audioio_wavefile_obj_t *self = m_new_obj(audioio_wavefile_obj_t);
     self->base.type = &audioio_wavefile_type;

--- a/shared-bindings/bitbangio/I2C.c
+++ b/shared-bindings/bitbangio/I2C.c
@@ -53,13 +53,7 @@
 //|   :param int frequency: The clock frequency of the bus
 //|   :param int timeout: The maximum clock stretching timeout in microseconds
 //|
-STATIC mp_obj_t bitbangio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
-    bitbangio_i2c_obj_t *self = m_new_obj(bitbangio_i2c_obj_t);
-    raise_error_if_deinited(shared_module_bitbangio_i2c_deinited(self));
-    self->base.type = &bitbangio_i2c_type;
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t bitbangio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_scl, ARG_sda, ARG_frequency, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -68,11 +62,15 @@ STATIC mp_obj_t bitbangio_i2c_make_new(const mp_obj_type_t *type, size_t n_args,
         { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 255} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     assert_pin(args[ARG_scl].u_obj, false);
     assert_pin(args[ARG_sda].u_obj, false);
     const mcu_pin_obj_t* scl = MP_OBJ_TO_PTR(args[ARG_scl].u_obj);
     const mcu_pin_obj_t* sda = MP_OBJ_TO_PTR(args[ARG_sda].u_obj);
+
+    bitbangio_i2c_obj_t *self = m_new_obj(bitbangio_i2c_obj_t);
+    raise_error_if_deinited(shared_module_bitbangio_i2c_deinited(self));
+    self->base.type = &bitbangio_i2c_type;
     shared_module_bitbangio_i2c_construct(self, scl, sda, args[ARG_frequency].u_int, args[ARG_timeout].u_int);
     return (mp_obj_t)self;
 }

--- a/shared-bindings/bitbangio/OneWire.c
+++ b/shared-bindings/bitbangio/OneWire.c
@@ -62,16 +62,13 @@
 //|     onewire.write_bit(False)
 //|     print(onewire.read_bit())
 //|
-STATIC mp_obj_t bitbangio_onewire_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t bitbangio_onewire_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_pin };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pin, MP_ARG_REQUIRED | MP_ARG_OBJ },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     assert_pin(args[ARG_pin].u_obj, false);
     const mcu_pin_obj_t* pin = MP_OBJ_TO_PTR(args[ARG_pin].u_obj);
     assert_pin_free(pin);

--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -62,12 +62,7 @@
 //|
 
 // TODO(tannewt): Support LSB SPI.
-STATIC mp_obj_t bitbangio_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
-    bitbangio_spi_obj_t *self = m_new_obj(bitbangio_spi_obj_t);
-    self->base.type = &bitbangio_spi_type;
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t bitbangio_spi_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_clock, ARG_MOSI, ARG_MISO, ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits, ARG_firstbit };
     static const mp_arg_t allowed_args[] = {
        { MP_QSTR_clock, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -75,13 +70,16 @@ STATIC mp_obj_t bitbangio_spi_make_new(const mp_obj_type_t *type, size_t n_args,
        { MP_QSTR_MISO, MP_ARG_OBJ, {.u_obj = mp_const_none} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     assert_pin(args[ARG_clock].u_obj, false);
     assert_pin(args[ARG_MOSI].u_obj, true);
     assert_pin(args[ARG_MISO].u_obj, true);
     const mcu_pin_obj_t* clock = MP_OBJ_TO_PTR(args[ARG_clock].u_obj);
     const mcu_pin_obj_t* mosi = MP_OBJ_TO_PTR(args[ARG_MOSI].u_obj);
     const mcu_pin_obj_t* miso = MP_OBJ_TO_PTR(args[ARG_MISO].u_obj);
+
+    bitbangio_spi_obj_t *self = m_new_obj(bitbangio_spi_obj_t);
+    self->base.type = &bitbangio_spi_type;
     shared_module_bitbangio_spi_construct(self, clock, mosi, miso);
     return (mp_obj_t)self;
 }

--- a/shared-bindings/bleio/Address.c
+++ b/shared-bindings/bleio/Address.c
@@ -69,22 +69,18 @@ STATIC uint8_t xdigit_8b_value(byte nibble1, byte nibble2) {
 //|     - `bleio.AddressType.RANDOM_PRIVATE_RESOLVABLE`
 //|     - `bleio.AddressType.RANDOM_PRIVATE_NON_RESOLVABLE`
 //|
-STATIC mp_obj_t bleio_address_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, 1, true);
-    bleio_address_obj_t *self = m_new_obj(bleio_address_obj_t);
-    self->base.type = &bleio_address_type;
-    self->type = ADDRESS_PUBLIC;
-
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
-
+STATIC mp_obj_t bleio_address_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_address };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    bleio_address_obj_t *self = m_new_obj(bleio_address_obj_t);
+    self->base.type = &bleio_address_type;
+    self->type = ADDRESS_PUBLIC;
 
     const mp_obj_t address = args[ARG_address].u_obj;
 

--- a/shared-bindings/bleio/Broadcaster.c
+++ b/shared-bindings/bleio/Broadcaster.c
@@ -59,24 +59,19 @@
 //|   :param float interval: how often to broadcast
 //|
 
-STATIC mp_obj_t bleio_broadcaster_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, 1, true);
-    bleio_broadcaster_obj_t *self = m_new_obj(bleio_broadcaster_obj_t);
-    self->base.type = &bleio_broadcaster_type;
-
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
-
+STATIC mp_obj_t bleio_broadcaster_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_interval };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_interval, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_SMALL_INT(1)} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_float_t interval = mp_obj_get_float(args[ARG_interval].u_obj);
 
+    bleio_broadcaster_obj_t *self = m_new_obj(bleio_broadcaster_obj_t);
+    self->base.type = &bleio_broadcaster_type;
     // Do port-specific initialization. interval will be validated.
     common_hal_bleio_broadcaster_construct(self, interval);
 

--- a/shared-bindings/bleio/Characteristic.c
+++ b/shared-bindings/bleio/Characteristic.c
@@ -51,14 +51,7 @@
 //|   :param bool write: Clients may write this characteristic; a response will be sent back
 //|   :param bool write_no_response: Clients may write this characteristic; no response will be sent back
 //|
-STATIC mp_obj_t bleio_characteristic_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, 1, true);
-    bleio_characteristic_obj_t *self = m_new_obj(bleio_characteristic_obj_t);
-    self->base.type = &bleio_characteristic_type;
-
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
-
+STATIC mp_obj_t bleio_characteristic_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {
         ARG_uuid, ARG_broadcast, ARG_indicate, ARG_notify, ARG_read, ARG_write, ARG_write_no_response,
     };
@@ -73,7 +66,7 @@ STATIC mp_obj_t bleio_characteristic_make_new(const mp_obj_type_t *type, size_t 
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     const mp_obj_t uuid = args[ARG_uuid].u_obj;
 
@@ -81,6 +74,8 @@ STATIC mp_obj_t bleio_characteristic_make_new(const mp_obj_type_t *type, size_t 
         mp_raise_ValueError(translate("Expected a UUID"));
     }
 
+    bleio_characteristic_obj_t *self = m_new_obj(bleio_characteristic_obj_t);
+    self->base.type = &bleio_characteristic_type;
     self->uuid = MP_OBJ_TO_PTR(uuid);
 
     bleio_characteristic_properties_t properties;

--- a/shared-bindings/bleio/CharacteristicBuffer.c
+++ b/shared-bindings/bleio/CharacteristicBuffer.c
@@ -44,14 +44,7 @@
 //|   :param int buffer_size: Size of ring buffer that stores incoming data coming from client.
 //|     Must be >= 1.
 //|
-STATIC mp_obj_t bleio_characteristic_buffer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, 2, true);
-    bleio_characteristic_buffer_obj_t *self = m_new_obj(bleio_characteristic_buffer_obj_t);
-    self->base.type = &bleio_characteristic_buffer_type;
-
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
-
+STATIC mp_obj_t bleio_characteristic_buffer_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_characteristic, ARG_buffer_size, };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_characteristic,  MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -59,7 +52,7 @@ STATIC mp_obj_t bleio_characteristic_buffer_make_new(const mp_obj_type_t *type, 
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     const mp_obj_t characteristic = args[ARG_characteristic].u_obj;
     const int buffer_size = args[ARG_buffer_size].u_int;
@@ -72,6 +65,8 @@ STATIC mp_obj_t bleio_characteristic_buffer_make_new(const mp_obj_type_t *type, 
         mp_raise_ValueError(translate("Expected a Characteristic"));
     }
 
+    bleio_characteristic_buffer_obj_t *self = m_new_obj(bleio_characteristic_buffer_obj_t);
+    self->base.type = &bleio_characteristic_buffer_type;
     self->characteristic = MP_OBJ_TO_PTR(characteristic);
 
     common_hal_bleio_characteristic_buffer_construct(self, self->characteristic, buffer_size);

--- a/shared-bindings/bleio/Descriptor.c
+++ b/shared-bindings/bleio/Descriptor.c
@@ -71,21 +71,14 @@ enum {
 //|
 //|     The descriptor uuid. (read-only)
 //|
-STATIC mp_obj_t bleio_descriptor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, 1, true);
-    bleio_descriptor_obj_t *self = m_new_obj(bleio_descriptor_obj_t);
-    self->base.type = type;
-
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
-
+STATIC mp_obj_t bleio_descriptor_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_uuid };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_uuid, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     const mp_obj_t uuid_arg = args[ARG_uuid].u_obj;
 
@@ -93,6 +86,8 @@ STATIC mp_obj_t bleio_descriptor_make_new(const mp_obj_type_t *type, size_t n_ar
         mp_raise_ValueError(translate("Expected a UUID"));
     }
 
+    bleio_descriptor_obj_t *self = m_new_obj(bleio_descriptor_obj_t);
+    self->base.type = type;
     bleio_uuid_obj_t *uuid = MP_OBJ_TO_PTR(uuid_arg);
     common_hal_bleio_descriptor_construct(self, uuid);
 

--- a/shared-bindings/bleio/Peripheral.c
+++ b/shared-bindings/bleio/Peripheral.c
@@ -82,16 +82,7 @@ static const char default_name[] = "CIRCUITPY";
 //|   :param str name: The name used when advertising this peripheral
 //|
 
-STATIC mp_obj_t bleio_peripheral_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, 1, true);
-    bleio_peripheral_obj_t *self = m_new_obj(bleio_peripheral_obj_t);
-    self->base.type = &bleio_peripheral_type;
-    self->service_list = mp_obj_new_list(0, NULL);
-    self->notif_handler = mp_const_none;
-
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
-
+STATIC mp_obj_t bleio_peripheral_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_services, ARG_name };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_services, MP_ARG_OBJ, {.u_obj = mp_const_none} },
@@ -99,13 +90,17 @@ STATIC mp_obj_t bleio_peripheral_make_new(const mp_obj_type_t *type, size_t n_ar
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // If services is not an iterable, an exception will be thrown.
     mp_obj_iter_buf_t iter_buf;
     mp_obj_t iterable = mp_getiter(args[ARG_services].u_obj, &iter_buf);
     mp_obj_t service;
 
+    bleio_peripheral_obj_t *self = m_new_obj(bleio_peripheral_obj_t);
+    self->base.type = &bleio_peripheral_type;
+    self->service_list = mp_obj_new_list(0, NULL);
+    self->notif_handler = mp_const_none;
     while ((service = mp_iternext(iterable)) != MP_OBJ_STOP_ITERATION) {
         if (!MP_OBJ_IS_TYPE(service, &bleio_service_type)) {
             mp_raise_ValueError(translate("services includes an object that is not a Service"));

--- a/shared-bindings/bleio/ScanEntry.c
+++ b/shared-bindings/bleio/ScanEntry.c
@@ -248,7 +248,7 @@ STATIC mp_obj_t scanentry_get_service_uuids(mp_obj_t self_in) {
     mp_obj_t entries = mp_obj_new_list(0, NULL);
     for (size_t i = 0; i < uuids_len / sizeof(uint16_t); ++i) {
         const mp_obj_t uuid_int = mp_obj_new_int(uuids[sizeof(uint16_t) * i] | (uuids[sizeof(uint16_t) * i + 1] << 8));
-        const mp_obj_t uuid_obj = bleio_uuid_type.make_new(&bleio_uuid_type, 1, 0, &uuid_int);
+        const mp_obj_t uuid_obj = bleio_uuid_type.make_new(&bleio_uuid_type, 1, &uuid_int, NULL);
 
         mp_obj_list_append(entries, uuid_obj);
     }

--- a/shared-bindings/bleio/Scanner.c
+++ b/shared-bindings/bleio/Scanner.c
@@ -25,6 +25,7 @@
  */
 
 #include "py/objproperty.h"
+#include "py/runtime.h"
 #include "shared-bindings/bleio/ScanEntry.h"
 #include "shared-bindings/bleio/Scanner.h"
 
@@ -77,7 +78,9 @@ STATIC void bleio_scanner_print(const mp_print_t *print, mp_obj_t self_in, mp_pr
     mp_printf(print, "Scanner(interval: %d window: %d)", self->interval, self->window);
 }
 
-STATIC mp_obj_t bleio_scanner_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+STATIC mp_obj_t bleio_scanner_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *all_args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 0, 0, false);
+
     bleio_scanner_obj_t *self = m_new_obj(bleio_scanner_obj_t);
     self->base.type = type;
 

--- a/shared-bindings/bleio/Service.c
+++ b/shared-bindings/bleio/Service.c
@@ -49,17 +49,7 @@
 //|   :param bool secondary: If the service is a secondary one
 //|
 
-STATIC mp_obj_t bleio_service_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 2, 3, true);
-    bleio_service_obj_t *self = m_new_obj(bleio_service_obj_t);
-    self->char_list = mp_obj_new_list(0, NULL);
-    self->base.type = &bleio_service_type;
-    self->device = mp_const_none;
-    self->handle = 0xFFFF;
-
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
-
+STATIC mp_obj_t bleio_service_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_uuid, ARG_characteristics, ARG_secondary };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_uuid, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = mp_const_none} },
@@ -68,9 +58,7 @@ STATIC mp_obj_t bleio_service_make_new(const mp_obj_type_t *type, size_t n_args,
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-    self->is_secondary = args[ARG_secondary].u_bool;
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     const mp_obj_t uuid = args[ARG_uuid].u_obj;
 
@@ -78,6 +66,12 @@ STATIC mp_obj_t bleio_service_make_new(const mp_obj_type_t *type, size_t n_args,
         mp_raise_ValueError(translate("Expected a UUID"));
     }
 
+    bleio_service_obj_t *self = m_new_obj(bleio_service_obj_t);
+    self->char_list = mp_obj_new_list(0, NULL);
+    self->base.type = &bleio_service_type;
+    self->device = mp_const_none;
+    self->handle = 0xFFFF;
+    self->is_secondary = args[ARG_secondary].u_bool;
     self->uuid = MP_OBJ_TO_PTR(uuid);
 
     // If characteristics is not an iterable, an exception will be thrown.

--- a/shared-bindings/bleio/UUID.c
+++ b/shared-bindings/bleio/UUID.c
@@ -51,8 +51,8 @@
 //|
 //|   :param int/buffer value: The uuid value to encapsulate
 //|
-STATIC mp_obj_t bleio_uuid_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+STATIC mp_obj_t bleio_uuid_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     bleio_uuid_obj_t *self = m_new_obj(bleio_uuid_obj_t);
     self->base.type = type;

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -60,12 +60,9 @@
 //|   :param int frequency: The clock frequency in Hertz
 //|   :param int timeout: The maximum clock stretching timeut - (used only for bitbangio.I2C; ignored for busio.I2C)
 //|
-STATIC mp_obj_t busio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
+STATIC mp_obj_t busio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     busio_i2c_obj_t *self = m_new_obj(busio_i2c_obj_t);
     self->base.type = &busio_i2c_type;
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
     enum { ARG_scl, ARG_sda, ARG_frequency, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -74,7 +71,7 @@ STATIC mp_obj_t busio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
         { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 255} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     assert_pin(args[ARG_scl].u_obj, false);
     assert_pin(args[ARG_sda].u_obj, false);
     const mcu_pin_obj_t* scl = MP_OBJ_TO_PTR(args[ARG_scl].u_obj);

--- a/shared-bindings/busio/OneWire.c
+++ b/shared-bindings/busio/OneWire.c
@@ -62,16 +62,13 @@
 //|     onewire.write_bit(False)
 //|     print(onewire.read_bit())
 //|
-STATIC mp_obj_t busio_onewire_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t busio_onewire_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_pin };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pin, MP_ARG_REQUIRED | MP_ARG_OBJ },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     assert_pin(args[ARG_pin].u_obj, false);
     const mcu_pin_obj_t* pin = MP_OBJ_TO_PTR(args[ARG_pin].u_obj);
     assert_pin_free(pin);

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -71,12 +71,9 @@
 //|
 
 // TODO(tannewt): Support LSB SPI.
-STATIC mp_obj_t busio_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
+STATIC mp_obj_t busio_spi_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     busio_spi_obj_t *self = m_new_obj(busio_spi_obj_t);
     self->base.type = &busio_spi_type;
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
     enum { ARG_clock, ARG_MOSI, ARG_MISO };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_clock, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -84,7 +81,7 @@ STATIC mp_obj_t busio_spi_make_new(const mp_obj_type_t *type, size_t n_args, siz
         { MP_QSTR_MISO, MP_ARG_OBJ, {.u_obj = mp_const_none} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     assert_pin(args[ARG_clock].u_obj, false);
     assert_pin(args[ARG_MOSI].u_obj, true);
     assert_pin(args[ARG_MISO].u_obj, true);

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -69,16 +69,13 @@ typedef struct {
 extern const busio_uart_parity_obj_t busio_uart_parity_even_obj;
 extern const busio_uart_parity_obj_t busio_uart_parity_odd_obj;
 
-STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
+STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // Always initially allocate the UART object within the long-lived heap.
     // This is needed to avoid crashes with certain UART implementations which
     // cannot accomodate being moved after creation. (See
     // https://github.com/adafruit/circuitpython/issues/1056)
     busio_uart_obj_t *self = m_new_ll_obj(busio_uart_obj_t);
     self->base.type = &busio_uart_type;
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
     enum { ARG_tx, ARG_rx, ARG_baudrate, ARG_bits, ARG_parity, ARG_stop, ARG_timeout, ARG_receiver_buffer_size};
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_tx, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -91,7 +88,7 @@ STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, si
         { MP_QSTR_receiver_buffer_size, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 64} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     assert_pin(args[ARG_rx].u_obj, true);
     const mcu_pin_obj_t* rx = MP_OBJ_TO_PTR(args[ARG_rx].u_obj);

--- a/shared-bindings/digitalio/DigitalInOut.c
+++ b/shared-bindings/digitalio/DigitalInOut.c
@@ -62,8 +62,8 @@
 //|   :param ~microcontroller.Pin pin: The pin to control
 //|
 STATIC mp_obj_t digitalio_digitalinout_make_new(const mp_obj_type_t *type,
-        mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 1, 1, true);
+        mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     digitalio_digitalinout_obj_t *self = m_new_obj(digitalio_digitalinout_obj_t);
     self->base.type = &digitalio_digitalinout_type;

--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -55,8 +55,8 @@
 //|   :param int height: The number of values high
 //|   :param int value_count: The number of possible pixel values.
 //|
-STATIC mp_obj_t displayio_bitmap_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 3, 3, false);
+STATIC mp_obj_t displayio_bitmap_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 3, 3, false);
     uint32_t width = mp_obj_get_int(pos_args[0]);
     uint32_t height = mp_obj_get_int(pos_args[1]);
     uint32_t value_count = mp_obj_get_int(pos_args[2]);

--- a/shared-bindings/displayio/ColorConverter.c
+++ b/shared-bindings/displayio/ColorConverter.c
@@ -52,8 +52,8 @@
 //|
 // TODO(tannewt): Add support for other color formats.
 //|
-STATIC mp_obj_t displayio_colorconverter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, 0, true);
+STATIC mp_obj_t displayio_colorconverter_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 0, 0, false);
 
     displayio_colorconverter_t *self = m_new_obj(displayio_colorconverter_t);
     self->base.type = &displayio_colorconverter_type;

--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -32,6 +32,7 @@
 #include "py/binary.h"
 #include "py/objproperty.h"
 #include "py/runtime.h"
+#include "shared-bindings/displayio/Group.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/util.h"
 #include "supervisor/shared/translate.h"
@@ -51,7 +52,7 @@
 //|
 //|   Create a FourWire object associated with the given pins.
 //|
-STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
+STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mp_raise_NotImplementedError(translate("displayio is a work in progress"));
     return mp_const_none;
 }
@@ -73,7 +74,11 @@ MP_DEFINE_CONST_FUN_OBJ_KW(displayio_fourwire_send_obj, 1, displayio_fourwire_ob
 //|
 STATIC mp_obj_t displayio_fourwire_obj_show(mp_obj_t self_in, mp_obj_t group_in) {
     displayio_fourwire_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    displayio_group_t* group = MP_OBJ_TO_PTR(group_in);
+    mp_obj_t native_layer = mp_instance_cast_to_native_base(group_in, &displayio_group_type);
+    if (native_layer == MP_OBJ_NULL) {
+        mp_raise_ValueError(translate("Must be a Group subclass."));
+    }
+    displayio_group_t* group = MP_OBJ_TO_PTR(native_layer);
     common_hal_displayio_fourwire_show(self, group);
     return mp_const_none;
 }

--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -49,16 +49,13 @@
 //|
 //|   :param int max_size: The maximum group size.
 //|
-STATIC mp_obj_t displayio_group_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, 0, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t displayio_group_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_max_size };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_max_size, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 4} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_int_t max_size = args[ARG_max_size].u_int;
     if (max_size < 1) {

--- a/shared-bindings/displayio/OnDiskBitmap.c
+++ b/shared-bindings/displayio/OnDiskBitmap.c
@@ -78,8 +78,8 @@
 //|
 //|   :param file file: The open bitmap file
 //|
-STATIC mp_obj_t displayio_ondiskbitmap_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+STATIC mp_obj_t displayio_ondiskbitmap_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     if (!MP_OBJ_IS_TYPE(pos_args[0], &mp_type_fileio)) {
         mp_raise_TypeError(translate("file must be a file opened in byte mode"));

--- a/shared-bindings/displayio/Palette.c
+++ b/shared-bindings/displayio/Palette.c
@@ -54,16 +54,13 @@
 // TODO(tannewt): Add support for other color formats.
 // TODO(tannewt): Add support for 8-bit alpha blending.
 //|
-STATIC mp_obj_t displayio_palette_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, 1, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t displayio_palette_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_color_count };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_color_count, MP_ARG_INT | MP_ARG_REQUIRED },
+        { MP_QSTR_color_count, MP_ARG_REQUIRED | MP_ARG_INT },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     displayio_palette_t *self = m_new_obj(displayio_palette_t);
     self->base.type = &displayio_palette_type;

--- a/shared-bindings/displayio/Shape.c
+++ b/shared-bindings/displayio/Shape.c
@@ -53,19 +53,16 @@
 //|   :param bool mirror_x: When true the left boundary is mirrored to the right.
 //|   :param bool mirror_y: When true the top boundary is mirrored to the bottom.
 //|
-STATIC mp_obj_t displayio_shape_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 2, 4, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t displayio_shape_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_width, ARG_height, ARG_mirror_x, ARG_mirror_y };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_width, MP_ARG_INT | MP_ARG_REQUIRED },
-        { MP_QSTR_height, MP_ARG_INT | MP_ARG_REQUIRED },
+        { MP_QSTR_width, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_height, MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_mirror_x, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
         { MP_QSTR_mirror_y, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     displayio_shape_t *self = m_new_obj(displayio_shape_t);
     self->base.type = &displayio_shape_type;

--- a/shared-bindings/displayio/Shape.c
+++ b/shared-bindings/displayio/Shape.c
@@ -1,0 +1,117 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "shared-bindings/displayio/Shape.h"
+
+#include <stdint.h>
+
+#include "py/binary.h"
+#include "py/objproperty.h"
+#include "py/runtime.h"
+#include "shared-bindings/util.h"
+#include "supervisor/shared/translate.h"
+
+//| .. currentmodule:: displayio
+//|
+//| :class:`Shape` -- Represents a shape by defining its bounds on each row
+//| ==========================================================================
+//|
+//| Represents any shape made by defining boundaries that may be mirrored.
+//|
+//| .. warning:: This will likely be changed before 4.0.0. Consider it very experimental.
+//|
+//| .. class:: Shape(width, height, *, mirror_x=False, mirrored_y=False)
+//|
+//|   Create a Shape object with the given fixed size. Each pixel is one bit and is stored by the
+//|   column boundaries of the shape on each row. Each row's boundary defaults to the full row.
+//|
+//|   :param int width: The number of pixels wide
+//|   :param int height: The number of pixels high
+//|   :param bool mirror_x: When true the left boundary is mirrored to the right.
+//|   :param bool mirror_y: When true the top boundary is mirrored to the bottom.
+//|
+STATIC mp_obj_t displayio_shape_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
+    mp_arg_check_num(n_args, n_kw, 2, 4, true);
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+    enum { ARG_width, ARG_height, ARG_mirror_x, ARG_mirror_y };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_width, MP_ARG_INT | MP_ARG_REQUIRED },
+        { MP_QSTR_height, MP_ARG_INT | MP_ARG_REQUIRED },
+        { MP_QSTR_mirror_x, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
+        { MP_QSTR_mirror_y, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    displayio_shape_t *self = m_new_obj(displayio_shape_t);
+    self->base.type = &displayio_shape_type;
+    common_hal_displayio_shape_construct(self,
+        args[ARG_width].u_int,
+        args[ARG_height].u_int,
+        args[ARG_mirror_x].u_bool,
+        args[ARG_mirror_y].u_bool);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+
+//|   .. method:: set_boundary(y, start_x, end_x)
+//|
+//|     Loads pre-packed data into the given row.
+//|
+STATIC mp_obj_t displayio_shape_obj_set_boundary(size_t n_args, const mp_obj_t *args) {
+    (void) n_args;
+    displayio_shape_t *self = MP_OBJ_TO_PTR(args[0]);
+    mp_int_t y;
+    if (!mp_obj_get_int_maybe(args[1], &y)) {
+        mp_raise_ValueError(translate("y should be an int"));
+    }
+    mp_int_t start_x;
+    if (!mp_obj_get_int_maybe(args[2], &start_x)) {
+        mp_raise_ValueError(translate("start_x should be an int"));
+    }
+    mp_int_t end_x;
+    if (!mp_obj_get_int_maybe(args[3], &end_x)) {
+        mp_raise_ValueError(translate("end_x should be an int"));
+    }
+    common_hal_displayio_shape_set_boundary(self, y, start_x, end_x);
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(displayio_shape_set_boundary_obj, 4, 4, displayio_shape_obj_set_boundary);
+
+STATIC const mp_rom_map_elem_t displayio_shape_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_set_boundary), MP_ROM_PTR(&displayio_shape_set_boundary_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(displayio_shape_locals_dict, displayio_shape_locals_dict_table);
+
+const mp_obj_type_t displayio_shape_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_Shape,
+    .make_new = displayio_shape_make_new,
+    .locals_dict = (mp_obj_dict_t*)&displayio_shape_locals_dict,
+};

--- a/shared-bindings/displayio/Shape.h
+++ b/shared-bindings/displayio/Shape.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SHAPE_H
+#define MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SHAPE_H
+
+#include "shared-module/displayio/Shape.h"
+
+extern const mp_obj_type_t displayio_shape_type;
+
+void common_hal_displayio_shape_construct(displayio_shape_t *self, uint32_t width,
+    uint32_t height, bool mirror_x, bool mirror_y);
+
+void common_hal_displayio_shape_set_boundary(displayio_shape_t *self, uint16_t y, uint16_t start_x,
+                                             uint16_t end_x);
+uint32_t common_hal_displayio_shape_get_pixel(void *shape, int16_t x, int16_t y);
+
+#endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_SHAPE_H

--- a/shared-bindings/displayio/Sprite.c
+++ b/shared-bindings/displayio/Sprite.c
@@ -36,6 +36,7 @@
 #include "shared-bindings/displayio/ColorConverter.h"
 #include "shared-bindings/displayio/OnDiskBitmap.h"
 #include "shared-bindings/displayio/Palette.h"
+#include "shared-bindings/displayio/Shape.h"
 #include "supervisor/shared/translate.h"
 
 void unpack_position(mp_obj_t position_obj, int16_t* x, int16_t* y) {
@@ -91,6 +92,10 @@ STATIC mp_obj_t displayio_sprite_make_new(const mp_obj_type_t *type, size_t n_ar
         height = bmp->height;
     } else if (MP_OBJ_IS_TYPE(bitmap, &displayio_ondiskbitmap_type)) {
         displayio_ondiskbitmap_t* bmp = MP_OBJ_TO_PTR(bitmap);
+        width = bmp->width;
+        height = bmp->height;
+    } else if (MP_OBJ_IS_TYPE(bitmap, &displayio_shape_type)) {
+        displayio_shape_t* bmp = MP_OBJ_TO_PTR(bitmap);
         width = bmp->width;
         height = bmp->height;
     } else {

--- a/shared-bindings/displayio/Sprite.c
+++ b/shared-bindings/displayio/Sprite.c
@@ -67,20 +67,17 @@ void unpack_position(mp_obj_t position_obj, int16_t* x, int16_t* y) {
 //|   palette lookup, a gradient, a pattern or a color transformer.
 //|
 //|
-STATIC mp_obj_t displayio_sprite_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, 4, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t displayio_sprite_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bitmap, ARG_pixel_shader, ARG_position, ARG_width, ARG_height };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_bitmap, MP_ARG_OBJ | MP_ARG_REQUIRED },
+        { MP_QSTR_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_pixel_shader, MP_ARG_OBJ | MP_ARG_KW_ONLY },
         { MP_QSTR_position, MP_ARG_OBJ | MP_ARG_KW_ONLY },
         { MP_QSTR_width, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = -1} },
         { MP_QSTR_height, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = -1} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_obj_t bitmap = args[ARG_bitmap].u_obj;
 

--- a/shared-bindings/displayio/Sprite.c
+++ b/shared-bindings/displayio/Sprite.c
@@ -86,16 +86,19 @@ STATIC mp_obj_t displayio_sprite_make_new(const mp_obj_type_t *type, size_t n_ar
 
     uint16_t width;
     uint16_t height;
-    if (MP_OBJ_IS_TYPE(bitmap, &displayio_bitmap_type)) {
+    mp_obj_t native = mp_instance_cast_to_native_base(bitmap, &displayio_shape_type);
+    if (native != MP_OBJ_NULL) {
+        displayio_shape_t* bmp = MP_OBJ_TO_PTR(native);
+        width = bmp->width;
+        height = bmp->height;
+    } else if (MP_OBJ_IS_TYPE(bitmap, &displayio_bitmap_type)) {
         displayio_bitmap_t* bmp = MP_OBJ_TO_PTR(bitmap);
+        native = bitmap;
         width = bmp->width;
         height = bmp->height;
     } else if (MP_OBJ_IS_TYPE(bitmap, &displayio_ondiskbitmap_type)) {
         displayio_ondiskbitmap_t* bmp = MP_OBJ_TO_PTR(bitmap);
-        width = bmp->width;
-        height = bmp->height;
-    } else if (MP_OBJ_IS_TYPE(bitmap, &displayio_shape_type)) {
-        displayio_shape_t* bmp = MP_OBJ_TO_PTR(bitmap);
+        native = bitmap;
         width = bmp->width;
         height = bmp->height;
     } else {
@@ -108,7 +111,7 @@ STATIC mp_obj_t displayio_sprite_make_new(const mp_obj_type_t *type, size_t n_ar
 
     displayio_sprite_t *self = m_new_obj(displayio_sprite_t);
     self->base.type = &displayio_sprite_type;
-    common_hal_displayio_sprite_construct(self, bitmap, args[ARG_pixel_shader].u_obj,
+    common_hal_displayio_sprite_construct(self, native, args[ARG_pixel_shader].u_obj,
             width, height, x, y);
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/displayio/__init__.c
+++ b/shared-bindings/displayio/__init__.c
@@ -36,6 +36,7 @@
 #include "shared-bindings/displayio/Group.h"
 #include "shared-bindings/displayio/OnDiskBitmap.h"
 #include "shared-bindings/displayio/Palette.h"
+#include "shared-bindings/displayio/Shape.h"
 #include "shared-bindings/displayio/Sprite.h"
 
 //| :mod:`displayio` --- Native display driving
@@ -64,6 +65,7 @@
 //|     Group
 //|     OnDiskBitmap
 //|     Palette
+//|     Shape
 //|     Sprite
 //|
 //| All libraries change hardware state but are never deinit
@@ -76,6 +78,7 @@ STATIC const mp_rom_map_elem_t displayio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_Group), MP_ROM_PTR(&displayio_group_type) },
     { MP_ROM_QSTR(MP_QSTR_OnDiskBitmap), MP_ROM_PTR(&displayio_ondiskbitmap_type) },
     { MP_ROM_QSTR(MP_QSTR_Palette), MP_ROM_PTR(&displayio_palette_type) },
+    { MP_ROM_QSTR(MP_QSTR_Shape), MP_ROM_PTR(&displayio_shape_type) },
     { MP_ROM_QSTR(MP_QSTR_Sprite), MP_ROM_PTR(&displayio_sprite_type) },
 
     { MP_ROM_QSTR(MP_QSTR_FourWire), MP_ROM_PTR(&displayio_fourwire_type) },

--- a/shared-bindings/gamepad/GamePad.c
+++ b/shared-bindings/gamepad/GamePad.c
@@ -95,7 +95,7 @@
 //|     button presses start to be recorded.
 //|
 STATIC mp_obj_t gamepad_make_new(const mp_obj_type_t *type, size_t n_args,
-        size_t n_kw, const mp_obj_t *args) {
+        const mp_obj_t *args, mp_map_t *kw_args) {
     if (n_args > 8) {
         mp_raise_TypeError(translate("too many arguments"));
     }

--- a/shared-bindings/i2cslave/I2CSlave.c
+++ b/shared-bindings/i2cslave/I2CSlave.c
@@ -64,12 +64,9 @@ STATIC mp_obj_t mp_obj_new_i2cslave_i2c_slave_request(i2cslave_i2c_slave_obj_t *
 //|   :param tuple addresses: The I2C addresses to respond to (how many is hw dependent).
 //|   :param bool smbus: Use SMBUS timings if the hardware supports it
 //|
-STATIC mp_obj_t i2cslave_i2c_slave_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
+STATIC mp_obj_t i2cslave_i2c_slave_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     i2cslave_i2c_slave_obj_t *self = m_new_obj(i2cslave_i2c_slave_obj_t);
     self->base.type = &i2cslave_i2c_slave_type;
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
     enum { ARG_scl, ARG_sda, ARG_addresses, ARG_smbus };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -78,7 +75,7 @@ STATIC mp_obj_t i2cslave_i2c_slave_make_new(const mp_obj_type_t *type, size_t n_
         { MP_QSTR_smbus, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     assert_pin(args[ARG_scl].u_obj, false);
     assert_pin(args[ARG_sda].u_obj, false);
@@ -247,8 +244,8 @@ const mp_obj_type_t i2cslave_i2c_slave_type = {
 //|   :param bool is_read: I2C Master read request
 //|   :param bool is_restart: Repeated Start Condition
 //|
-STATIC mp_obj_t i2cslave_i2c_slave_request_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 4, 4, false);
+STATIC mp_obj_t i2cslave_i2c_slave_request_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 4, 4, false);
     return mp_obj_new_i2cslave_i2c_slave_request(args[0], mp_obj_get_int(args[1]), mp_obj_is_true(args[2]), mp_obj_is_true(args[3]));
 }
 

--- a/shared-bindings/pulseio/PWMOut.c
+++ b/shared-bindings/pulseio/PWMOut.c
@@ -85,31 +85,29 @@
 //|     pwm.frequency = 880
 //|     time.sleep(0.1)
 //|
-STATIC mp_obj_t pulseio_pwmout_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
-    mp_obj_t pin_obj = args[0];
-    assert_pin(pin_obj, false);
-    const mcu_pin_obj_t *pin = MP_OBJ_TO_PTR(pin_obj);
-    assert_pin_free(pin);
-
-    // create PWM object from the given pin
-    pulseio_pwmout_obj_t *self = m_new_obj(pulseio_pwmout_obj_t);
-    self->base.type = &pulseio_pwmout_type;
-
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
-    enum { ARG_duty_cycle, ARG_frequency, ARG_variable_frequency };
+STATIC mp_obj_t pulseio_pwmout_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    enum { ARG_pin, ARG_duty_cycle, ARG_frequency, ARG_variable_frequency };
     static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_pin, MP_ARG_REQUIRED | MP_ARG_OBJ, },
         { MP_QSTR_duty_cycle, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_frequency, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 500} },
         { MP_QSTR_variable_frequency, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
     };
     mp_arg_val_t parsed_args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, args + 1, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, parsed_args);
+    mp_arg_parse_all(n_args, args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, parsed_args);
+
+    mp_obj_t pin_obj = parsed_args[ARG_pin].u_obj;
+    assert_pin(pin_obj, false);
+    const mcu_pin_obj_t *pin = MP_OBJ_TO_PTR(pin_obj);
+    assert_pin_free(pin);
+
     uint16_t duty_cycle = parsed_args[ARG_duty_cycle].u_int;
     uint32_t frequency = parsed_args[ARG_frequency].u_int;
     bool variable_frequency = parsed_args[ARG_variable_frequency].u_int;
 
+    // create PWM object from the given pin
+    pulseio_pwmout_obj_t *self = m_new_obj(pulseio_pwmout_obj_t);
+    self->base.type = &pulseio_pwmout_type;
     common_hal_pulseio_pwmout_construct(self, pin, duty_cycle, frequency, variable_frequency);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/pulseio/PulseIn.c
+++ b/shared-bindings/pulseio/PulseIn.c
@@ -81,10 +81,7 @@
 //|     # Resume with an 80 microsecond active pulse
 //|     pulses.resume(80)
 //|
-STATIC mp_obj_t pulseio_pulsein_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t pulseio_pulsein_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_pin, ARG_maxlen, ARG_idle_state };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pin, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -92,7 +89,7 @@ STATIC mp_obj_t pulseio_pulsein_make_new(const mp_obj_type_t *type, size_t n_arg
         { MP_QSTR_idle_state, MP_ARG_BOOL, {.u_bool = false} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     assert_pin(args[ARG_pin].u_obj, false);
     const mcu_pin_obj_t* pin = MP_OBJ_TO_PTR(args[ARG_pin].u_obj);
     assert_pin_free(pin);

--- a/shared-bindings/pulseio/PulseOut.c
+++ b/shared-bindings/pulseio/PulseOut.c
@@ -68,8 +68,8 @@
 //|     pulses[0] = 200
 //|     pulse.send(pulses)
 //|
-STATIC mp_obj_t pulseio_pulseout_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 1, 1, true);
+STATIC mp_obj_t pulseio_pulseout_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
     mp_obj_t carrier_obj = args[0];
 
     if (!MP_OBJ_IS_TYPE(carrier_obj, &pulseio_pwmout_type)) {

--- a/shared-bindings/rotaryio/IncrementalEncoder.c
+++ b/shared-bindings/rotaryio/IncrementalEncoder.c
@@ -64,17 +64,14 @@
 //|             print(position)
 //|         last_position = position
 //|
-STATIC mp_obj_t rotaryio_incrementalencoder_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
-    mp_arg_check_num(n_args, n_kw, 2, 2, true);
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, pos_args + n_args);
+STATIC mp_obj_t rotaryio_incrementalencoder_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_pin_a, ARG_pin_b };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pin_a, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_pin_b, MP_ARG_REQUIRED | MP_ARG_OBJ },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, &kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     assert_pin(args[ARG_pin_a].u_obj, false);
     const mcu_pin_obj_t* pin_a = MP_OBJ_TO_PTR(args[ARG_pin_a].u_obj);

--- a/shared-bindings/rtc/RTC.c
+++ b/shared-bindings/rtc/RTC.c
@@ -63,9 +63,9 @@ const rtc_rtc_obj_t rtc_rtc_obj = {{&rtc_rtc_type}};
 //|
 //|   This class represents the onboard Real Time Clock. It is a singleton and will always return the same instance.
 //|
-STATIC mp_obj_t rtc_rtc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t rtc_rtc_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     // No arguments
-    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    mp_arg_check_num(n_args, kw_args, 0, 0, false);
 
     // return constant object
     return (mp_obj_t)&rtc_rtc_obj;

--- a/shared-bindings/socket/__init__.c
+++ b/shared-bindings/socket/__init__.c
@@ -39,20 +39,20 @@
 
 //| :mod:`socket` --- TCP, UDP and RAW socket support
 //| =================================================
-//| 
+//|
 //| .. module:: socket
 //|   :synopsis: TCP, UDP and RAW sockets
 //|   :platform: SAMD21, SAMD51
 //|
 //| Create TCP, UDP and RAW sockets for communicating over the Internet.
-//|   
+//|
 
 STATIC const mp_obj_type_t socket_type;
 
 //| .. currentmodule:: socket
 //|
 //| .. class:: socket(family, type, proto, ...)
-//|   
+//|
 //|   Create a new socket
 //|
 //|   :param ~int family: AF_INET or AF_INET6
@@ -60,8 +60,8 @@ STATIC const mp_obj_type_t socket_type;
 //|   :param ~int proto: IPPROTO_TCP, IPPROTO_UDP or IPPROTO_RAW (ignored)
 //|
 
-STATIC mp_obj_t socket_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 0, 4, false);
+STATIC mp_obj_t socket_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    mp_arg_check_num(n_args, kw_args, 0, 4, false);
 
     // create socket object (not bound to any NIC yet)
     mod_network_socket_obj_t *s = m_new_obj_with_finaliser(mod_network_socket_obj_t);
@@ -245,8 +245,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_send_obj, socket_send);
 //|   Reads some bytes from the connected remote address.
 //|   Suits sockets of type SOCK_STREAM
 //|   Returns a bytes() of length <= bufsize
-//| 
-//|   :param ~int bufsize: maximum number of bytes to receive  
+//|
+//|   :param ~int bufsize: maximum number of bytes to receive
 
 STATIC mp_obj_t socket_recv(mp_obj_t self_in, mp_obj_t len_in) {
     mod_network_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -313,7 +313,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(socket_sendto_obj, socket_sendto);
 //|   * a bytes() of length <= bufsize
 //|   * a remote_address, which is a tuple of ip address and port number
 //|
-//|   :param ~int bufsize: maximum number of bytes to receive  
+//|   :param ~int bufsize: maximum number of bytes to receive
 //|
 
 STATIC mp_obj_t socket_recvfrom(mp_obj_t self_in, mp_obj_t len_in) {
@@ -469,10 +469,10 @@ STATIC const mp_obj_type_t socket_type = {
 };
 
 //| .. function:: getaddrinfo(host, port)
-//| 
+//|
 //|   Gets the address information for a hostname and port
 //|
-//|   Returns the appropriate family, socket type, socket protocol and 
+//|   Returns the appropriate family, socket type, socket protocol and
 //|   address information to call socket.socket() and socket.connect() with,
 //|   as a tuple.
 //|

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -83,8 +83,8 @@ STATIC mp_obj_t time_sleep(mp_obj_t seconds_o) {
 MP_DEFINE_CONST_FUN_OBJ_1(time_sleep_obj, time_sleep);
 
 #if MICROPY_PY_COLLECTIONS
-mp_obj_t struct_time_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    if (n_args != 1) {
+mp_obj_t struct_time_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    if (n_args != 1 || kw_args != NULL || kw_args->used > 0) {
         mp_raise_TypeError(translate("time.struct_time() takes exactly 1 argument"));
     }
     if (!MP_OBJ_IS_TYPE(args[0], &mp_type_tuple) || ((mp_obj_tuple_t*) MP_OBJ_TO_PTR(args[0]))->len != 9) {
@@ -92,7 +92,7 @@ mp_obj_t struct_time_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     }
 
     mp_obj_tuple_t* tuple = MP_OBJ_TO_PTR(args[0]);
-    return namedtuple_make_new(type, 9, 0, tuple->items);
+    return namedtuple_make_new(type, 9, tuple->items, NULL);
 }
 
 //| .. class:: struct_time((tm_year, tm_mon, tm_mday, tm_hour, tm_min, tm_sec, tm_wday, tm_yday, tm_isdst))
@@ -158,7 +158,7 @@ mp_obj_t struct_time_from_tm(timeutils_struct_time_t *tm) {
         mp_obj_new_int(-1), // tm_isdst is not supported
     };
 
-    return namedtuple_make_new((const mp_obj_type_t*)&struct_time_type_obj, 9, 0, elems);
+    return namedtuple_make_new((const mp_obj_type_t*)&struct_time_type_obj, 9, elems, NULL);
 };
 
 void struct_time_to_tm(mp_obj_t t, timeutils_struct_time_t *tm) {

--- a/shared-bindings/touchio/TouchIn.c
+++ b/shared-bindings/touchio/TouchIn.c
@@ -61,9 +61,9 @@
 //|   :param ~microcontroller.Pin pin: the pin to read from
 //|
 STATIC mp_obj_t touchio_touchin_make_new(const mp_obj_type_t *type,
-        mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+        mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     // check number of arguments
-    mp_arg_check_num(n_args, n_kw, 1, 1, false);
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     // 1st argument is the pin
     mp_obj_t pin_obj = args[0];

--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -46,7 +46,7 @@
 //|   Not currently dynamically supported.
 //|
 STATIC mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type,
-        mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+        mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     return mp_const_none;
 }
 

--- a/shared-bindings/usb_midi/PortIn.c
+++ b/shared-bindings/usb_midi/PortIn.c
@@ -49,7 +49,7 @@
 //|   to the ``usb_midi.ports`` tuple.
 //|
 
-STATIC mp_obj_t usb_midi_portin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
+STATIC mp_obj_t usb_midi_portin_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     return mp_const_none;
 }
 

--- a/shared-bindings/usb_midi/PortOut.c
+++ b/shared-bindings/usb_midi/PortOut.c
@@ -49,7 +49,7 @@
 //|   to the ``usb_midi.ports`` tuple.
 //|
 
-STATIC mp_obj_t usb_midi_portout_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *pos_args) {
+STATIC mp_obj_t usb_midi_portout_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     return mp_const_none;
 }
 

--- a/shared-bindings/wiznet/wiznet5k.c
+++ b/shared-bindings/wiznet/wiznet5k.c
@@ -46,22 +46,22 @@
 #include "shared-module/wiznet/wiznet5k.h"
 
 //| .. currentmodule:: wiznet
-//| 
+//|
 //| :class:`WIZNET5K` -- wrapper for Wiznet 5500 Ethernet interface
 //| ===============================================================
 //|
 //| .. class:: WIZNET5K(spi, cs, rst)
 //|
 //|   Create a new WIZNET5500 interface using the specified pins
-//|   
+//|
 //|   :param spi: spi bus to use
 //|   :param cs: pin to use for Chip Select
-//|   :param rst: pin to sue for Reset 
+//|   :param rst: pin to sue for Reset
 //|
 
-STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     // check arguments
-    mp_arg_check_num(n_args, n_kw, 3, 3, false);
+    mp_arg_check_num(n_args, kw_args, 3, 3, false);
 
     return wiznet5k_create(args[0], args[1], args[2]);
 }

--- a/shared-module/displayio/Group.c
+++ b/shared-module/displayio/Group.c
@@ -38,6 +38,13 @@ void common_hal_displayio_group_append(displayio_group_t* self, mp_obj_t layer) 
     if (self->size == self->max_size) {
         mp_raise_RuntimeError(translate("Group full"));
     }
+    mp_obj_t native_layer = mp_instance_cast_to_native_base(layer, &displayio_group_type);
+    if (native_layer == MP_OBJ_NULL) {
+        native_layer = mp_instance_cast_to_native_base(layer, &displayio_sprite_type);
+    }
+    if (native_layer == MP_OBJ_NULL) {
+        mp_raise_ValueError(translate("Layer must be a Group or Sprite subclass."));
+    }
     self->children[self->size] = layer;
     self->size++;
     self->needs_refresh = true;

--- a/shared-module/displayio/Shape.c
+++ b/shared-module/displayio/Shape.c
@@ -49,7 +49,7 @@ void common_hal_displayio_shape_construct(displayio_shape_t *self, uint32_t widt
     self->half_height = height;
 
     self->data = m_malloc(height * sizeof(uint32_t), false);
-    for (uint16_t i = 0; i < height; i++) {
+    for (uint16_t i = 0; i <= height; i++) {
         self->data[2 * i] = 0;
         self->data[2 * i + 1] = width;
     }

--- a/shared-module/displayio/Shape.c
+++ b/shared-module/displayio/Shape.c
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "shared-bindings/displayio/Shape.h"
+
+#include <string.h>
+
+#include "py/runtime.h"
+
+void common_hal_displayio_shape_construct(displayio_shape_t *self, uint32_t width,
+    uint32_t height, bool mirror_x, bool mirror_y) {
+    self->mirror_x = mirror_x;
+    self->mirror_y = mirror_y;
+    self->width = width;
+    if (self->mirror_x) {
+        width /= 2;
+        width += self->width % 2 - 1;
+    }
+    self->half_width = width;
+
+    self->height = height;
+    if (self->mirror_y) {
+        height /= 2;
+        height += self->height % 2 - 1;
+    }
+    self->half_height = height;
+
+    self->data = m_malloc(height * sizeof(uint32_t), false);
+    for (uint16_t i = 0; i < height; i++) {
+        self->data[2 * i] = 0;
+        self->data[2 * i + 1] = width;
+    }
+}
+
+void common_hal_displayio_shape_set_boundary(displayio_shape_t *self, uint16_t y, uint16_t start_x, uint16_t end_x) {
+    if (y < 0 || y >= self->height || (self->mirror_y && y > self->half_height)) {
+        mp_raise_ValueError(translate("y value out of bounds"));
+    }
+    if (start_x < 0 || start_x > self->width || end_x < 0 || end_x > self->height) {
+        mp_raise_ValueError(translate("x value out of bounds"));
+    }
+    uint16_t half_width = self->width / 2 - 1 + self->width % 2;
+    if (self->mirror_x && (start_x > half_width || end_x > half_width)) {
+        mp_raise_ValueError_varg(translate("Maximum x value when mirrored is %d"), half_width);
+    }
+    self->data[2 * y] = start_x;
+    self->data[2 * y + 1] = end_x;
+}
+
+uint32_t common_hal_displayio_shape_get_pixel(void *obj, int16_t x, int16_t y) {
+    displayio_shape_t *self = obj;
+    if (x >= self->width || x < 0 || y >= self->height || y < 0) {
+        return 0;
+    }
+    if (self->mirror_x && x > self->half_width) {
+        x = self->width - 1 - x;
+    }
+    if (self->mirror_y && y > self->half_height) {
+        y = self->height - y - 1;
+    }
+    uint16_t start_x = self->data[2 * y];
+    uint16_t end_x = self->data[2 * y + 1];
+    if (x < start_x || x > end_x) {
+        return 0;
+    }
+    return 1;
+}

--- a/shared-module/displayio/Shape.h
+++ b/shared-module/displayio/Shape.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_SHAPE_H
+#define MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_SHAPE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "py/obj.h"
+
+typedef struct {
+    mp_obj_base_t base;
+    uint16_t width;
+    uint16_t height;
+    uint16_t half_width;
+    uint16_t half_height;
+    uint16_t* data;
+    bool mirror_x;
+    bool mirror_y;
+} displayio_shape_t;
+
+#endif // MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_SHAPE_H

--- a/shared-module/displayio/Sprite.c
+++ b/shared-module/displayio/Sprite.c
@@ -30,6 +30,7 @@
 #include "shared-bindings/displayio/ColorConverter.h"
 #include "shared-bindings/displayio/OnDiskBitmap.h"
 #include "shared-bindings/displayio/Palette.h"
+#include "shared-bindings/displayio/Shape.h"
 
 void common_hal_displayio_sprite_construct(displayio_sprite_t *self, mp_obj_t bitmap,
         mp_obj_t pixel_shader, uint16_t width, uint16_t height, uint16_t x, uint16_t y) {
@@ -71,6 +72,8 @@ bool displayio_sprite_get_pixel(displayio_sprite_t *self, int16_t x, int16_t y, 
     uint32_t value = 0;
     if (MP_OBJ_IS_TYPE(self->bitmap, &displayio_bitmap_type)) {
         value = common_hal_displayio_bitmap_get_pixel(self->bitmap, x, y);
+    } else if (MP_OBJ_IS_TYPE(self->bitmap, &displayio_shape_type)) {
+        value = common_hal_displayio_shape_get_pixel(self->bitmap, x, y);
     } else if (MP_OBJ_IS_TYPE(self->bitmap, &displayio_ondiskbitmap_type)) {
         value = common_hal_displayio_ondiskbitmap_get_pixel(self->bitmap, x, y);
     }

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -39,6 +39,8 @@ void displayio_refresh_display(void) {
         return;
     }
     if (refresh_queued(display)) {
+        PORT->Group[1].DIRSET.reg = 1 << 22;
+
         // We compute the pixels
         uint16_t x0 = 0;
         uint16_t y0 = 0;
@@ -53,10 +55,19 @@ void displayio_refresh_display(void) {
             for (uint16_t x = x0; x < x1; ++x) {
                 uint16_t* pixel = &(((uint16_t*)buffer)[index]);
                 *pixel = 0;
-                if (display->current_group != NULL) {
-                    displayio_group_get_pixel(display->current_group, x, y, pixel);
-                }
 
+                PORT->Group[1].OUTTGL.reg = 1 << 22;
+
+                //if (index == 0) {
+                    if (display->current_group != NULL) {
+                        displayio_group_get_pixel(display->current_group, x, y, pixel);
+                    }
+                // } else {
+                //     *pixel = (((uint16_t*)buffer)[0]);
+                // }
+
+
+                PORT->Group[1].OUTTGL.reg = 1 << 22;
 
                 index += 1;
                 // The buffer is full, send it.

--- a/supervisor/shared/flash.c
+++ b/supervisor/shared/flash.c
@@ -57,9 +57,9 @@ void supervisor_flash_set_usb_writable(bool usb_writable) {
 const mp_obj_type_t supervisor_flash_type;
 STATIC const mp_obj_base_t supervisor_flash_obj = {&supervisor_flash_type};
 
-STATIC mp_obj_t supervisor_flash_obj_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+STATIC mp_obj_t supervisor_flash_obj_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     // check arguments
-    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    mp_arg_check_num(n_args, kw_args, 0, 0, false);
 
     // return singleton object
     return (mp_obj_t)&supervisor_flash_obj;


### PR DESCRIPTION
displayio.Shape is a subclassable class that stores shapes by storing boundaries of the shape for each row of pixels. It also allows for mirroring to save memory.

Most of the changes are to enable subclassing native classes which take keyword args. To do so, the signature of make_new changed to take a separate kw_arg map. The basic argument checking changed as a result as well.

FourWire and Group now handle accepting subclasses as well by calling `mp_instance_cast_to_native_base` to get the native root object.