### PR TITLE
bleio: handle events sent by newer devices and by Android

### DIFF
--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -70,6 +70,8 @@ These libraries build on top of the low level APIs to simplify common tasks.
     miniQR Non-hardware QR code generator <https://circuitpython.readthedocs.io/projects/miniqr/en/latest/>
     Slideshow <https://circuitpython.readthedocs.io/projects/slideshow/en/latest/>
     LED Animation <https://circuitpython.readthedocs.io/projects/led-animation/en/latest/>
+    Bluetooth Low Energy (BLE)  <https://circuitpython.readthedocs.io/projects/ble/en/latest/>
+    Bluefruit LE Connect App  <https://circuitpython.readthedocs.io/projects/bluefruitconnect/en/latest/>
 
 Blinky
 --------

--- a/ports/nrf/common-hal/bleio/Peripheral.c
+++ b/ports/nrf/common-hal/bleio/Peripheral.c
@@ -266,6 +266,10 @@ STATIC void peripheral_on_ble_evt(ble_evt_t *ble_evt, void *self_in) {
         break;
     }
 
+    case BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST:
+        sd_ble_gap_data_length_update(self->conn_handle, NULL, NULL);
+        break;
+
     case BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST: {
         sd_ble_gatts_exchange_mtu_reply(self->conn_handle, BLE_GATT_ATT_MTU_DEFAULT);
         break;

--- a/ports/nrf/common-hal/bleio/Peripheral.c
+++ b/ports/nrf/common-hal/bleio/Peripheral.c
@@ -275,6 +275,10 @@ STATIC void peripheral_on_ble_evt(ble_evt_t *ble_evt, void *self_in) {
         break;
     }
 
+    case BLE_GATTS_EVT_SYS_ATTR_MISSING:
+        sd_ble_gatts_sys_attr_set(self->conn_handle, NULL, 0, 0);
+        break;
+
     default:
         // For debugging.
         // mp_printf(&mp_plat_print, "Unhandled peripheral event: 0x%04x\n", ble_evt->header.evt_id);

--- a/shared-bindings/bleio/Device.c
+++ b/shared-bindings/bleio/Device.c
@@ -48,6 +48,9 @@
 //| :class:`Device` -- BLE device
 //| =========================================================
 //|
+//| **IGNORE ``Device`` and all its documentation.
+//| It is being replaced by `Peripheral` and other classes.**
+//|
 //| Provides access a to BLE device, either in a Peripheral or Central role.
 //| When a device is created without any parameter passed to the constructor,
 //| it will be set to the Peripheral role. If a address is passed, the device

--- a/shared-bindings/bleio/Peripheral.c
+++ b/shared-bindings/bleio/Peripheral.c
@@ -70,7 +70,7 @@ static const char default_name[] = "CIRCUITPY";
 //|    periph = bleio.Peripheral([service])
 //|    periph.start_advertising()
 //|
-//|    while not periph.connected():
+//|    while not periph.connected:
 //|        # Wait for connection.
 //|        pass
 //|


### PR DESCRIPTION
Newer BLE devices may ask to lengthen the basic BLE packet size. This request was not being handled, and so the connection attempt from a central to CircuitPython Peripheral was hanging. Respond in the correct way to this request.

@jerryneedell This I believe will fix https://github.com/adafruit/Adafruit_CircuitPython_BLE/issues/2. I tested on a 2018 iPad. Didn't test on an Android device, but thanks for testing if you are able to do so.

iPhone 6s and lower did not send this request. iPhone 7 (and probably up) do.