### PR TITLE
update tinyusb, work better with sd

### DIFF
--- a/ports/nrf/bluetooth/ble_drv.c
+++ b/ports/nrf/bluetooth/ble_drv.c
@@ -32,6 +32,8 @@
 #include "ble_drv.h"
 #include "nrf_nvic.h"
 #include "nrf_sdm.h"
+#include "nrf_soc.h"
+#include "nrfx_power.h"
 #include "py/misc.h"
 
 nrf_nvic_state_t nrf_nvic_state = { 0 };
@@ -89,6 +91,23 @@ void SD_EVT_IRQHandler(void) {
     uint32_t evt_id;
     while (sd_evt_get(&evt_id) != NRF_ERROR_NOT_FOUND) {
 //        sd_evt_handler(evt_id);
+
+        switch (evt_id) {
+            // usb power event
+            case NRF_EVT_POWER_USB_DETECTED:
+            case NRF_EVT_POWER_USB_POWER_READY:
+            case NRF_EVT_POWER_USB_REMOVED: {
+                int32_t usbevt = (evt_id == NRF_EVT_POWER_USB_DETECTED   ) ? NRFX_POWER_USB_EVT_DETECTED:
+                                 (evt_id == NRF_EVT_POWER_USB_POWER_READY) ? NRFX_POWER_USB_EVT_READY   :
+                                 (evt_id == NRF_EVT_POWER_USB_REMOVED    ) ? NRFX_POWER_USB_EVT_REMOVED : -1;
+
+                extern void tusb_hal_nrf_power_event (uint32_t event);
+                tusb_hal_nrf_power_event(usbevt);
+            }
+            break;
+
+            default: break;
+        }
     }
 
     while (1) {

--- a/ports/nrf/bluetooth/bluetooth_common.mk
+++ b/ports/nrf/bluetooth/bluetooth_common.mk
@@ -6,6 +6,7 @@ $(error Incorrect softdevice set flag)
 endif
 
 CFLAGS += -DBLUETOOTH_SD_DEBUG=1
+CFLAGS += -DSOFTDEVICE_PRESENT
 
 INC += -Ibluetooth/$(SD)_$(MCU_VARIANT)_$(SOFTDEV_VERSION)/$(SD)_$(MCU_VARIANT)_$(SOFTDEV_VERSION)_API/include
 INC += -Ibluetooth/$(SD)_$(MCU_VARIANT)_$(SOFTDEV_VERSION)/$(SD)_$(MCU_VARIANT)_$(SOFTDEV_VERSION)_API/include/$(MCU_VARIANT)

--- a/ports/nrf/supervisor/usb.c
+++ b/ports/nrf/supervisor/usb.c
@@ -43,6 +43,9 @@ extern void tusb_hal_nrf_power_event(uint32_t event);
 
 void init_usb_hardware(void) {
 
+    // 2 is max priority (0, 1 are reserved for SD)
+    NVIC_SetPriority(USBD_IRQn, 2);
+
     // USB power may already be ready at this time -> no event generated
     // We need to invoke the handler based on the status initially
     uint32_t usb_reg;

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -54,10 +54,8 @@ void load_serial_number(void) {
     }
 }
 
-bool _usb_enabled = false;
-
 bool usb_enabled(void) {
-    return _usb_enabled;
+    return tusb_inited();
 }
 
 void usb_init(void) {
@@ -65,7 +63,6 @@ void usb_init(void) {
     load_serial_number();
 
     tusb_init();
-    _usb_enabled = true;
 
 #if MICROPY_KBD_EXCEPTION
     // Set Ctrl+C as wanted char, tud_cdc_rx_wanted_cb() callback will be invoked when Ctrl+C is received
@@ -77,7 +74,7 @@ void usb_init(void) {
 }
 
 void usb_background(void) {
-    if (usb_enabled()) {
+    if (tusb_inited()) {
         tud_task();
         tud_cdc_write_flush();
     }


### PR DESCRIPTION
@dhalbert this PR may not fix all the scenario, since I don't know how to make them. But it will fix the test in your tinyusb-sd-work branch. Here is the finding I come to
- Tinyusb need tusb_hal_nrf_power_event() to be called when usb bus power : detect, ready, removed
- When sd is not enabled (or not present): nrfx_power_usbevt_init()  is called to set tusb_hal_ as event handler https://github.com/adafruit/circuitpython/blob/master/ports/nrf/supervisor/usb.c#L69
- However when SD is enabled, nrf power is exclusive used by SD, tusb_hal_ cannot be set as event handler directly, and must be called within SOC event of SD_EVT_IRQHandler: sd_evt_get(&evt_id). These SD event must be enabled previously with sd_power_usbdetected_enable/sd_power_usbpwrrdy_enable/sd_power_usbremoved_enable

To fully independent to each other, it should:
- When USB is init : current init_usb_hardware() should be OK
- when SD is inited, power module is uninit (currently), then init SD, and enable the  sd_power_usbdetected/pwrdy/removed
- when SD is disabled, nrfx_power_usbevt_init() must be called to set up tusb_hal for event handler (otherwise usb transfer can take place, but we won't be able to detect unplug,replug).

Don't merge it yet, I will poke around to complete the PR.