### PR TITLE
Minor improvements

### DIFF
--- a/lib/libm_dbl/pow.c
+++ b/lib/libm_dbl/pow.c
@@ -125,13 +125,13 @@ double pow(double x, double y)
 		else if (iy >= 0x3ff00000) {
 			k = (iy>>20) - 0x3ff;  /* exponent */
 			if (k > 20) {
-				uint32_t j = ly>>(52-k);
-				if ((j<<(52-k)) == ly)
-					yisint = 2 - (j&1);
+				uint32_t j2 = ly>>(52-k);
+				if ((j2<<(52-k)) == ly)
+					yisint = 2 - (j2&1);
 			} else if (ly == 0) {
-				uint32_t j = iy>>(20-k);
-				if ((j<<(20-k)) == iy)
-					yisint = 2 - (j&1);
+				uint32_t j2 = iy>>(20-k);
+				if ((j2<<(20-k)) == (uint32_t)iy)
+					yisint = 2 - (j2&1);
 			}
 		}
 	}

--- a/main.c
+++ b/main.c
@@ -185,8 +185,8 @@ bool run_code_py(safe_mode_t safe_mode) {
     } else {
         new_status_color(MAIN_RUNNING);
 
-        const char *supported_filenames[] = STRING_LIST("code.txt", "code.py", "main.py", "main.txt");
-        const char *double_extension_filenames[] = STRING_LIST("code.txt.py", "code.py.txt", "code.txt.txt","code.py.py",
+        static const char *supported_filenames[] = STRING_LIST("code.txt", "code.py", "main.py", "main.txt");
+        static const char *double_extension_filenames[] = STRING_LIST("code.txt.py", "code.py.txt", "code.txt.txt","code.py.py",
                                                     "main.txt.py", "main.py.txt", "main.txt.txt","main.py.py");
 
         stack_resize();

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -43,7 +43,7 @@ void load_serial_number(void) {
     uint8_t raw_id[COMMON_HAL_MCU_PROCESSOR_UID_LENGTH];
     common_hal_mcu_processor_get_uid(raw_id);
 
-    const char nibble_to_hex[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    static const char nibble_to_hex[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
                                     'A', 'B', 'C', 'D', 'E', 'F'};
     for (int i = 0; i < COMMON_HAL_MCU_PROCESSOR_UID_LENGTH; i++) {
         for (int j = 0; j < 2; j++) {


### PR DESCRIPTION
While trying to hack up a *third-party* DPFP-based version of CircuitPython for the Trinket M0 compatible **TI-Python Adapter**, because SPFP just doesn't make the cut for math purposes (it can easily yield wrong results for high school level math problems, i.e. the target audience of this thing; all other calculator-based implementations of Python use DPFP, for excellent reason !), I stumbled across a couple *shadowing variables*, and most of all, several *variables which can be made "static"* to save a bit of space: 100+ bytes in my build with Debian sid's arm-non-eabi-gcc (GCC 7.3). So I'm sending a quick PR to improve those.

I know little about the code of MicroPython or CircuitPython. I'm doing that work on my free time for users who bought this underwhelming thing (at least, when equipped with the version of the official firmware contained in the first TI-Python Adapters which reached buyers last week) which cannot even be used from a TI-83 Premium CE calculator yet because the "PyAdaptr" software isn't available. Of course, I'm also indirectly working for TI if they pull in some of these changes...
While working on various pieces of OSS related to TI graphing calculators for 17+ years, I've never signed a NDA with TI EdTech, or received *money* from TI. At the time of this writing, I don't own a TI-Python Adapter, or a Trinket M0.

If you're curious about what kind of a hacky job I did to cram a DPFP-based build onto a Trinket M0-class platform, you can check the master branch in my repo. At least, it builds, the binary running on a TI-Python Adapter or a Trinket M0 produces reasonable results for FP operations, and benchmarks can be made. My work can certainly be made better, I'm all ears :)