### PR TITLE
A safe mode fix and displayio fixes

### DIFF
--- a/main.c
+++ b/main.c
@@ -229,6 +229,7 @@ bool run_code_py(safe_mode_t safe_mode) {
             MICROPY_VM_HOOK_LOOP
         #endif
         if (reload_requested) {
+            reload_requested = false;
             return true;
         }
 

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -248,14 +248,20 @@ void reset_cpu(void) {
     reset();
 }
 
-extern uint32_t _ebss;
-// Place the word to save just after our BSS section that gets blanked.
+// Place the word to save 8k from the end of RAM so we and the bootloader don't clobber it.
+#ifdef SAMD21
+uint32_t* safe_word = (uint32_t*) (HMCRAMC0_ADDR + HMCRAMC0_SIZE - 0x2000);
+#endif
+#ifdef SAMD51
+uint32_t* safe_word = (uint32_t*) (HSRAM_ADDR + HSRAM_SIZE - 0x2000);
+#endif
+
 void port_set_saved_word(uint32_t value) {
-    _ebss = value;
+    *safe_word = value;
 }
 
 uint32_t port_get_saved_word(void) {
-    return _ebss;
+    return *safe_word;
 }
 
 /**

--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -256,7 +256,7 @@ STATIC mp_obj_t group_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t valu
 
         if (value == MP_OBJ_SENTINEL) {
             // load
-            return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_group_get(self, index));
+            return common_hal_displayio_group_get(self, index);
         } else if (value == mp_const_none) {
             common_hal_displayio_group_pop(self, index);
         } else {

--- a/shared-module/displayio/Group.c
+++ b/shared-module/displayio/Group.c
@@ -98,7 +98,7 @@ size_t common_hal_displayio_group_get_len(displayio_group_t* self) {
 }
 
 mp_obj_t common_hal_displayio_group_get(displayio_group_t* self, size_t index) {
-    return self->children[index];
+    return MP_OBJ_FROM_PTR(self->children[index]);
 }
 
 void common_hal_displayio_group_set(displayio_group_t* self, size_t index, mp_obj_t layer) {

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -72,9 +72,9 @@ void common_hal_displayio_tilegrid_get_position(displayio_tilegrid_t *self, int1
 }
 
 void common_hal_displayio_tilegrid_set_position(displayio_tilegrid_t *self, int16_t x, int16_t y) {
+    self->needs_refresh = self->x != x || self->y != y;
     self->x = x;
     self->y = y;
-    self->needs_refresh = true;
 }
 
 mp_obj_t common_hal_displayio_tilegrid_get_pixel_shader(displayio_tilegrid_t *self) {


### PR DESCRIPTION
* Fixes safe mode on the SAMD51. The "preserved" value was being
clobbered by the bootloader.
* Fixes auto-reload loop when in safe mode.
* Fixes reading Group children with [].
* Check that a TileGrid actually moves before queueing a refresh.