### PR TITLE
Fix displaying images off of SD cards.

### DIFF
--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -186,12 +186,15 @@ STATIC mp_obj_t file_open(fs_user_mount_t *vfs, const mp_obj_type_t *type, mp_ar
                 break;
         }
     }
+    assert(vfs != NULL);
+    if ((vfs->flags & FSUSER_USB_WRITABLE) != 0 && (mode & FA_WRITE) != 0) {
+        mp_raise_OSError(MP_EROFS);
+    }
 
     pyb_file_obj_t *o = m_new_obj_with_finaliser(pyb_file_obj_t);
     o->base.type = type;
 
     const char *fname = mp_obj_str_get_str(args[0].u_obj);
-    assert(vfs != NULL);
     FRESULT res = f_open(&vfs->fatfs, &o->fp, fname, mode);
     if (res != FR_OK) {
         m_del_obj(pyb_file_obj_t, o);

--- a/ports/atmel-samd/boards/pyportal/board.c
+++ b/ports/atmel-samd/boards/pyportal/board.c
@@ -48,7 +48,7 @@ uint8_t display_init_sequence[] = {
     0xc1, 1, 0x10,             // Power control SAP[2:0];BT[3:0]
     0xc5, 2, 0x3e, 0x28,       // VCM control
     0xc7, 1, 0x86,             // VCM control2
-    0x36, 1, 0x08,             // Memory Access Control
+    0x36, 1, 0xa8,             // Memory Access Control
     0x37, 1, 0x00,             // Vertical scroll zero
     0x3a, 1, 0x55,             // COLMOD: Pixel Format Set
     0xb1, 2, 0x00, 0x18,       // Frame Rate Control (In Normal Mode/Full Colors)
@@ -82,7 +82,7 @@ void board_init(void) {
         240, // Height
         0, // column start
         0, // row start
-        270, // rotation
+        0, // rotation
         16, // Color depth
         MIPI_COMMAND_SET_COLUMN_ADDRESS, // Set column command
         MIPI_COMMAND_SET_PAGE_ADDRESS, // Set row command

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -123,7 +123,6 @@
 #define MICROPY_FATFS_USE_LABEL       (1)
 #define MICROPY_FATFS_RPATH           (2)
 #define MICROPY_FATFS_MULTI_PARTITION (1)
-#define MICROPY_FATFS_NUM_PERSISTENT  (1)
 
 // Only enable this if you really need it. It allocates a byte cache of this size.
 // #define MICROPY_FATFS_MAX_SS           (4096)

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -131,31 +131,6 @@ void mp_init(void) {
            sizeof(MP_STATE_VM(fs_user_mount)) - MICROPY_FATFS_NUM_PERSISTENT);
     #endif
 
-    #if MICROPY_VFS
-    #if MICROPY_FATFS_NUM_PERSISTENT > 0
-    // We preserve the last MICROPY_FATFS_NUM_PERSISTENT mounts because newer
-    // mounts are put at the front of the list.
-    mp_vfs_mount_t *vfs = MP_STATE_VM(vfs_mount_table);
-    // Count how many mounts we have.
-    uint8_t count = 0;
-    while (vfs != NULL) {
-        vfs = vfs->next;
-        count++;
-    }
-    // Find the vfs MICROPY_FATFS_NUM_PERSISTENT mounts from the end.
-    vfs = MP_STATE_VM(vfs_mount_table);
-    for (uint8_t j = 0; j < count - MICROPY_FATFS_NUM_PERSISTENT; j++) {
-        vfs = vfs->next;
-    }
-    MP_STATE_VM(vfs_mount_table) = vfs;
-    MP_STATE_VM(vfs_cur) = vfs;
-    #else
-    // initialise the VFS sub-system
-    MP_STATE_VM(vfs_cur) = NULL;
-    MP_STATE_VM(vfs_mount_table) = NULL;
-    #endif
-    #endif
-
     #if MICROPY_PY_THREAD_GIL
     mp_thread_mutex_init(&MP_STATE_VM(gil_mutex));
     #endif

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include "shared-module/displayio/__init__.h"
 
+#include "py/reload.h"
 #include "shared-bindings/displayio/Bitmap.h"
 #include "shared-bindings/displayio/Display.h"
 #include "shared-bindings/displayio/Group.h"
@@ -22,6 +23,12 @@ static inline void swap(uint16_t* a, uint16_t* b) {
 bool refreshing_displays = false;
 
 void displayio_refresh_displays(void) {
+    // Somehow reloads from the sdcard are being lost. So, cheat and reraise.
+    if (reload_requested) {
+        mp_raise_reload_exception();
+        return;
+    }
+
     if (refreshing_displays) {
         return;
     }

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -95,7 +95,7 @@ void filesystem_flush(void) {
 void filesystem_writable_by_python(bool writable) {
     fs_user_mount_t *vfs = &_internal_vfs;
 
-    if (writable) {
+    if (!writable) {
         vfs->flags |= FSUSER_USB_WRITABLE;
     } else {
         vfs->flags &= ~FSUSER_USB_WRITABLE;


### PR DESCRIPTION
This also fixes writability checks so the internal filesystem is no longer writable with a storage.remount. Use the SD card for caching.

The pyportal init has been changed to speed up displaying bitmaps by aligning their access pattern with their orientation.