### PR TITLE
Store the original layer in Group

### DIFF
--- a/shared-module/displayio/Group.h
+++ b/shared-module/displayio/Group.h
@@ -33,17 +33,22 @@
 #include "py/obj.h"
 
 typedef struct {
+    mp_obj_t native;
+    mp_obj_t original;
+} displayio_group_child_t;
+
+typedef struct {
     mp_obj_base_t base;
     int16_t x;
     int16_t y;
     uint16_t scale;
     uint16_t size;
     uint16_t max_size;
-    mp_obj_t* children;
+    displayio_group_child_t* children;
     bool needs_refresh;
 } displayio_group_t;
 
-void displayio_group_construct(displayio_group_t* self, mp_obj_t* child_array, uint32_t max_size, uint32_t scale);
+void displayio_group_construct(displayio_group_t* self, displayio_group_child_t* child_array, uint32_t max_size, uint32_t scale);
 bool displayio_group_get_pixel(displayio_group_t *group, int16_t x, int16_t y, uint16_t *pixel);
 bool displayio_group_needs_refresh(displayio_group_t *self);
 void displayio_group_finish_refresh(displayio_group_t *self);

--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -172,9 +172,9 @@ displayio_tilegrid_t blinka_sprite = {
     .inline_tiles = true
 };
 
-mp_obj_t splash_children[2] = {
-    &blinka_sprite,
-    &supervisor_terminal_text_grid
+displayio_group_child_t splash_children[2] = {
+    {&blinka_sprite, &blinka_sprite},
+    {&supervisor_terminal_text_grid, &supervisor_terminal_text_grid}
 };
 
 displayio_group_t circuitpython_splash = {


### PR DESCRIPTION
As is we would return the native superclass object only.

Fixes #1551