### PR TITLE
Minor fixes

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -204,6 +204,7 @@ typedef long mp_off_t;
 
 #ifdef LONGINT_IMPL_LONGLONG
 #define MICROPY_LONGINT_IMPL (MICROPY_LONGINT_IMPL_LONGLONG)
+#define MP_SSIZE_MAX (0x7fffffff)
 #endif
 
 

--- a/shared-bindings/audiobusio/PDMIn.c
+++ b/shared-bindings/audiobusio/PDMIn.c
@@ -129,8 +129,8 @@ STATIC mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_ar
     }
     bool mono = args[ARG_mono].u_bool;
 
-    float startup_delay = (args[ARG_startup_delay].u_obj == MP_OBJ_NULL)
-        ? STARTUP_DELAY_DEFAULT
+    mp_float_t startup_delay = (args[ARG_startup_delay].u_obj == MP_OBJ_NULL)
+        ? (mp_float_t)STARTUP_DELAY_DEFAULT
         : mp_obj_get_float(args[ARG_startup_delay].u_obj);
     if (startup_delay < 0.0 || startup_delay > 1.0) {
         mp_raise_ValueError(translate("Microphone startup delay must be in range 0.0 to 1.0"));

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -116,7 +116,7 @@ STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, co
     }
 
     mp_float_t timeout = mp_obj_get_float(args[ARG_timeout].u_obj);
-    if (timeout > 100.0f) {
+    if (timeout > (mp_float_t)100.0) {
         mp_raise_ValueError(translate("timeout >100 (units are now seconds, not msecs)"));
     }
 


### PR DESCRIPTION
Here are simple fixes for 3 build issues I encountered while working on my unofficial firmware images for the TI-Python Adapter (basically stripped-down Trinket-M0), featuring DPFP + cmath + special math functions + longint. Clearly, such changes belong upstream, under some form :)