### PR TITLE
Use critical section, not lock, in CharacteristicBuffer; use a root pointer for ble_drv list

### DIFF
--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -79,11 +79,10 @@
 
 #include "peripherals/samd/dma.h"
 
+#include "py/circuitpy_mpconfig.h"
+
 #define MICROPY_PORT_ROOT_POINTERS \
     CIRCUITPY_COMMON_ROOT_POINTERS \
-    mp_obj_t playing_audio[AUDIO_DMA_CHANNEL_COUNT] \
-    ;
-
-#include "py/circuitpy_mpconfig.h"
+    mp_obj_t playing_audio[AUDIO_DMA_CHANNEL_COUNT];
 
 #endif  // __INCLUDED_MPCONFIGPORT_H

--- a/ports/nrf/bluetooth/ble_drv.h
+++ b/ports/nrf/bluetooth/ble_drv.h
@@ -50,6 +50,12 @@
 
 typedef void (*ble_drv_evt_handler_t)(ble_evt_t*, void*);
 
+typedef struct ble_drv_evt_handler_entry {
+    struct ble_drv_evt_handler_entry *next;
+    void *param;
+    ble_drv_evt_handler_t func;
+} ble_drv_evt_handler_entry_t;
+
 void ble_drv_reset(void);
 void ble_drv_add_event_handler(ble_drv_evt_handler_t func, void *param);
 void ble_drv_remove_event_handler(ble_drv_evt_handler_t func, void *param);

--- a/ports/nrf/common-hal/bleio/CharacteristicBuffer.h
+++ b/ports/nrf/common-hal/bleio/CharacteristicBuffer.h
@@ -38,7 +38,6 @@ typedef struct {
     uint32_t timeout_ms;
     // Ring buffer storing consecutive incoming values.
     ringbuf_t ringbuf;
-    nrf_mutex_t ringbuf_mutex;
 } bleio_characteristic_buffer_obj_t;
 
 #endif // MICROPY_INCLUDED_COMMON_HAL_BLEIO_CHARACTERISTICBUFFER_H

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -28,6 +28,8 @@
 #ifndef NRF5_MPCONFIGPORT_H__
 #define NRF5_MPCONFIGPORT_H__
 
+#include "ble_drv.h"
+
 #define MICROPY_CPYTHON_COMPAT                   (1)
 //#define MICROPY_MODULE_BUILTIN_INIT              (1)  // TODO check this
 //#define MICROPY_MODULE_WEAK_LINKS                (1)  // TODO check this
@@ -52,10 +54,11 @@
 // 24kiB stack
 #define CIRCUITPY_DEFAULT_STACK_SIZE            0x6000
 
+#include "py/circuitpy_mpconfig.h"
+
 #define MICROPY_PORT_ROOT_POINTERS \
     CIRCUITPY_COMMON_ROOT_POINTERS \
-    ;
+    ble_drv_evt_handler_entry_t* ble_drv_evt_handler_entries; \
 
-#include "py/circuitpy_mpconfig.h"
 
 #endif  // NRF5_MPCONFIGPORT_H__


### PR DESCRIPTION
Two problems with BLE:
- Used a lock instead of critical section in an interrupt routine, causing a deadlock.
- Needed to make the `ble_drv` linked list start with a root pointer. Its allocated storage was getting gc'd and reused.

I reordered some `#include`'s for clarity, but the order doesn't matter (I thought it did).

Partly fixes #1568. The other part is https://github.com/adafruit/Adafruit_CircuitPython_BluefruitConnect/pull/10.