### PR TITLE
Move shared_timer_handler

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -245,6 +245,7 @@ SRC_C = \
 	reset.c \
 	supervisor/shared/memory.c \
 	tick.c \
+	timer_handler.c \
 
 
 ifeq ($(CIRCUITPY_NETWORK),1)

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -252,7 +252,8 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t* self,
     tc_gclk = 1;
     #endif
 
-    turn_on_clocks(true, tc_index, tc_gclk, TC_HANDLER_NO_INTERRUPT);
+    set_timer_handler(true, tc_index, TC_HANDLER_NO_INTERRUPT);
+    turn_on_clocks(true, tc_index, tc_gclk);
 
     // Don't bother setting the period. We set it before you playback anything.
     tc_set_enable(t, false);

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -47,6 +47,7 @@
 #endif
 
 #include "audio_dma.h"
+#include "timer_handler.h"
 
 #include "samd/dma.h"
 #include "samd/events.h"
@@ -251,7 +252,7 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t* self,
     tc_gclk = 1;
     #endif
 
-    turn_on_clocks(true, tc_index, tc_gclk);
+    turn_on_clocks(true, tc_index, tc_gclk, TC_HANDLER_NO_INTERRUPT);
 
     // Don't bother setting the period. We set it before you playback anything.
     tc_set_enable(t, false);

--- a/ports/atmel-samd/common-hal/pulseio/PWMOut.c
+++ b/ports/atmel-samd/common-hal/pulseio/PWMOut.c
@@ -31,6 +31,7 @@
 #include "common-hal/pulseio/PWMOut.h"
 #include "shared-bindings/pulseio/PWMOut.h"
 #include "shared-bindings/microcontroller/Processor.h"
+#include "timer_handler.h"
 
 #include "atmel_start_pins.h"
 #include "hal/utils/include/utils_repeat_macro.h"
@@ -235,7 +236,7 @@ pwmout_result_t common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self,
         }
 
         // We use the zeroeth clock on either port to go full speed.
-        turn_on_clocks(timer->is_tc, timer->index, 0);
+        turn_on_clocks(timer->is_tc, timer->index, 0, TC_HANDLER_NO_INTERRUPT);
 
         if (timer->is_tc) {
             tc_periods[timer->index] = top;

--- a/ports/atmel-samd/common-hal/pulseio/PWMOut.c
+++ b/ports/atmel-samd/common-hal/pulseio/PWMOut.c
@@ -235,8 +235,9 @@ pwmout_result_t common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self,
             }
         }
 
+        set_timer_handler(timer->is_tc, timer->index, TC_HANDLER_NO_INTERRUPT);
         // We use the zeroeth clock on either port to go full speed.
-        turn_on_clocks(timer->is_tc, timer->index, 0, TC_HANDLER_NO_INTERRUPT);
+        turn_on_clocks(timer->is_tc, timer->index, 0);
 
         if (timer->is_tc) {
             tc_periods[timer->index] = top;

--- a/ports/atmel-samd/common-hal/pulseio/PulseOut.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseOut.c
@@ -37,6 +37,7 @@
 #include "py/runtime.h"
 #include "shared-bindings/pulseio/PulseOut.h"
 #include "supervisor/shared/translate.h"
+#include "timer_handler.h"
 
 // This timer is shared amongst all PulseOut objects under the assumption that
 // the code is single threaded.
@@ -115,10 +116,10 @@ void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
         // We use GCLK0 for SAMD21 and GCLK1 for SAMD51 because they both run at 48mhz making our
         // math the same across the boards.
         #ifdef SAMD21
-        turn_on_clocks(true, index, 0);
+        turn_on_clocks(true, index, 0, TC_HANDLER_PULSEOUT);
         #endif
         #ifdef SAMD51
-        turn_on_clocks(true, index, 1);
+        turn_on_clocks(true, index, 1, TC_HANDLER_PULSEOUT);
         #endif
 
 

--- a/ports/atmel-samd/common-hal/pulseio/PulseOut.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseOut.c
@@ -113,13 +113,14 @@ void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
 
         pulseout_tc_index = index;
 
+        set_timer_handler(true, index, TC_HANDLER_PULSEOUT);
         // We use GCLK0 for SAMD21 and GCLK1 for SAMD51 because they both run at 48mhz making our
         // math the same across the boards.
         #ifdef SAMD21
-        turn_on_clocks(true, index, 0, TC_HANDLER_PULSEOUT);
+        turn_on_clocks(true, index, 0);
         #endif
         #ifdef SAMD51
-        turn_on_clocks(true, index, 1, TC_HANDLER_PULSEOUT);
+        turn_on_clocks(true, index, 1);
         #endif
 
 

--- a/ports/atmel-samd/timer_handler.c
+++ b/ports/atmel-samd/timer_handler.c
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "timer_handler.h"
+
+#include "common-hal/pulseio/PulseOut.h"
+#include "common-hal/pulseio/FrequencyIn.h"
+
+static uint8_t tc_handler[TC_INST_NUM];
+
+void set_timer_handler(uint8_t index, uint8_t timer_handler) {
+    tc_handler[index] = timer_handler;
+}
+
+void shared_timer_handler(bool is_tc, uint8_t index) {
+    // Add calls to interrupt handlers for specific functionality here.
+    // Make sure to add the handler #define to timer_handler.h
+    if (is_tc) {
+        uint8_t handler = tc_handler[index];
+        if (handler == TC_HANDLER_PULSEOUT) {
+            pulseout_interrupt_handler(index);
+        } else if (handler == TC_HANDLER_FREQUENCYIN) {
+            frequencyin_interrupt_handler(index);
+        }
+    }
+}

--- a/ports/atmel-samd/timer_handler.c
+++ b/ports/atmel-samd/timer_handler.c
@@ -34,8 +34,10 @@
 
 static uint8_t tc_handler[TC_INST_NUM];
 
-void set_timer_handler(uint8_t index, uint8_t timer_handler) {
-    tc_handler[index] = timer_handler;
+void set_timer_handler(bool is_tc, uint8_t index, uint8_t timer_handler) {
+    if (is_tc) {
+        tc_handler[index] = timer_handler;
+    }
 }
 
 void shared_timer_handler(bool is_tc, uint8_t index) {

--- a/ports/atmel-samd/timer_handler.c
+++ b/ports/atmel-samd/timer_handler.c
@@ -30,7 +30,6 @@
 #include "timer_handler.h"
 
 #include "common-hal/pulseio/PulseOut.h"
-#include "common-hal/pulseio/FrequencyIn.h"
 
 static uint8_t tc_handler[TC_INST_NUM];
 
@@ -47,8 +46,6 @@ void shared_timer_handler(bool is_tc, uint8_t index) {
         uint8_t handler = tc_handler[index];
         if (handler == TC_HANDLER_PULSEOUT) {
             pulseout_interrupt_handler(index);
-        } else if (handler == TC_HANDLER_FREQUENCYIN) {
-            frequencyin_interrupt_handler(index);
         }
     }
 }

--- a/ports/atmel-samd/timer_handler.h
+++ b/ports/atmel-samd/timer_handler.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_ATMEL_SAMD_TIMER_HANDLER_H
+#define MICROPY_INCLUDED_ATMEL_SAMD_TIMER_HANDLER_H
+
+#define TC_HANDLER_NO_INTERRUPT 0x0
+#define TC_HANDLER_PULSEOUT 0x1
+#define TC_HANDLER_FREQUENCYIN 0x2
+
+void set_timer_handler(uint8_t index, uint8_t timer_handler);
+void shared_timer_handler(bool is_tc, uint8_t index);
+
+#endif  // MICROPY_INCLUDED_ATMEL_SAMD_TIMER_HANDLER_H

--- a/ports/atmel-samd/timer_handler.h
+++ b/ports/atmel-samd/timer_handler.h
@@ -30,7 +30,7 @@
 #define TC_HANDLER_PULSEOUT 0x1
 #define TC_HANDLER_FREQUENCYIN 0x2
 
-void set_timer_handler(uint8_t index, uint8_t timer_handler);
+void set_timer_handler(bool is_tc, uint8_t index, uint8_t timer_handler);
 void shared_timer_handler(bool is_tc, uint8_t index);
 
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_TIMER_HANDLER_H

--- a/ports/atmel-samd/timer_handler.h
+++ b/ports/atmel-samd/timer_handler.h
@@ -28,7 +28,6 @@
 
 #define TC_HANDLER_NO_INTERRUPT 0x0
 #define TC_HANDLER_PULSEOUT 0x1
-#define TC_HANDLER_FREQUENCYIN 0x2
 
 void set_timer_handler(bool is_tc, uint8_t index, uint8_t timer_handler);
 void shared_timer_handler(bool is_tc, uint8_t index);


### PR DESCRIPTION
Fixes #1109.

Part 2, which includes the updated `samd-peripherals`, adds `timer_handler.c/.h`, and updates `common-hal` usage.

Metro M0 Express French was the only failure on my Travis run; hoping I'm missing something and it passes here. 😬 