### PR TITLE
 implement default busses for particle boards

### DIFF
--- a/ports/nrf/boards/particle_argon/pins.c
+++ b/ports/nrf/boards/particle_argon/pins.c
@@ -61,6 +61,12 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ESP_BOOT_MODE), MP_ROM_PTR(&pin_P0_16) },
     { MP_ROM_QSTR(MP_QSTR_ESP_WIFI_EN), MP_ROM_PTR(&pin_P0_24) },
     { MP_ROM_QSTR(MP_QSTR_ESP_HOST_WK), MP_ROM_PTR(&pin_P0_07) },
+
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
+    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
+    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+
+
 };
 
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/nrf/boards/particle_boron/pins.c
+++ b/ports/nrf/boards/particle_boron/pins.c
@@ -59,6 +59,14 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_UBLOX_POWER_MONITOR), MP_ROM_PTR(&pin_P0_02) },
     { MP_ROM_QSTR(MP_QSTR_UBLOX_RESET), MP_ROM_PTR(&pin_P0_12) },
     { MP_ROM_QSTR(MP_QSTR_UBLOX_POWER_ON), MP_ROM_PTR(&pin_P0_16) },
+
+
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
+    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
+    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+
+
+
 };
 
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/nrf/boards/particle_xenon/pins.c
+++ b/ports/nrf/boards/particle_xenon/pins.c
@@ -52,6 +52,14 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_ANTENNA_EXTERNAL), MP_ROM_PTR(&pin_P0_25) },
     { MP_ROM_QSTR(MP_QSTR_ANTENNA_PCB), MP_ROM_PTR(&pin_P0_24) },
+
+
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
+    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
+    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+
+
+
 };
 
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
implement board.I2C() board.SPI() and board.UART() for particle boards.
It just looks like these never got added. Is anything else needed?
I only tested I2C devices on a particle_argon