### PR TITLE
Remove bleio classes that aren't done yet.

### DIFF
--- a/shared-bindings/bleio/Descriptor.c
+++ b/shared-bindings/bleio/Descriptor.c
@@ -48,6 +48,9 @@ enum {
     DescriptorUuidTimeTriggerSetting = 0x290E,
 };
 
+// Work-in-progress: orphaned for now.
+//| :orphan:
+//|
 //| .. currentmodule:: bleio
 //|
 //| :class:`Descriptor` -- BLE descriptor

--- a/shared-bindings/bleio/Device.c
+++ b/shared-bindings/bleio/Device.c
@@ -43,6 +43,9 @@
 #include "shared-module/bleio/Device.h"
 #include "shared-module/bleio/ScanEntry.h"
 
+// Work-in-progress: orphaned for now.
+//| :orphan:
+//|
 //| .. currentmodule:: bleio
 //|
 //| :class:`Device` -- BLE device

--- a/shared-bindings/bleio/ScanEntry.c
+++ b/shared-bindings/bleio/ScanEntry.c
@@ -37,6 +37,9 @@
 #include "shared-module/bleio/AdvertisementData.h"
 #include "shared-module/bleio/ScanEntry.h"
 
+// Work-in-progress: orphaned for now.
+//| :orphan:
+//|
 //| .. currentmodule:: bleio
 //|
 //| :class:`ScanEntry` -- BLE scan response entry

--- a/shared-bindings/bleio/Scanner.c
+++ b/shared-bindings/bleio/Scanner.c
@@ -32,6 +32,9 @@
 #define DEFAULT_INTERVAL 100
 #define DEFAULT_WINDOW 100
 
+// Work-in-progress: orphaned for now.
+//| :orphan:
+//|
 //| .. currentmodule:: bleio
 //|
 //| :class:`Scanner` -- scan for nearby BLE devices

--- a/shared-bindings/bleio/__init__.c
+++ b/shared-bindings/bleio/__init__.c
@@ -60,11 +60,12 @@
 //|     Broadcaster
 //|     Characteristic
 //|     CharacteristicBuffer
-//|     Descriptor
-//|     Device
+// Work-in-progress classes are omitted, and marked as :orphan: in their files.
+//     Descriptor
+//     Device
 //|     Peripheral
-//|     ScanEntry
-//|     Scanner
+//    ScanEntry
+//    Scanner
 //|     Service
 //|     UUID
 //|
@@ -82,10 +83,11 @@ STATIC const mp_rom_map_elem_t bleio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_Broadcaster),       MP_ROM_PTR(&bleio_broadcaster_type) },
     { MP_ROM_QSTR(MP_QSTR_Characteristic),    MP_ROM_PTR(&bleio_characteristic_type) },
     { MP_ROM_QSTR(MP_QSTR_CharacteristicBuffer),    MP_ROM_PTR(&bleio_characteristic_buffer_type) },
-    { MP_ROM_QSTR(MP_QSTR_Descriptor),        MP_ROM_PTR(&bleio_descriptor_type) },
+//    { MP_ROM_QSTR(MP_QSTR_Descriptor),        MP_ROM_PTR(&bleio_descriptor_type) },
     { MP_ROM_QSTR(MP_QSTR_Peripheral),        MP_ROM_PTR(&bleio_peripheral_type) },
-    { MP_ROM_QSTR(MP_QSTR_ScanEntry),         MP_ROM_PTR(&bleio_scanentry_type) },
-    { MP_ROM_QSTR(MP_QSTR_Scanner),           MP_ROM_PTR(&bleio_scanner_type) },
+// Hide work-in-progress.
+//    { MP_ROM_QSTR(MP_QSTR_ScanEntry),         MP_ROM_PTR(&bleio_scanentry_type) },
+//    { MP_ROM_QSTR(MP_QSTR_Scanner),           MP_ROM_PTR(&bleio_scanner_type) },
     { MP_ROM_QSTR(MP_QSTR_Service),           MP_ROM_PTR(&bleio_service_type) },
     { MP_ROM_QSTR(MP_QSTR_UUID),              MP_ROM_PTR(&bleio_uuid_type) },
 


### PR DESCRIPTION
Hide `bleio` classes that aren't usable yet, and that may change. Also turn off their RST documentation entries, which is a bit involved: Remove their TOC entries, and to avoid warnings, mark source files containing their RST as `:orphan:`. They could also be excluded in `conf.py`, but this is easier.

Fixes #1591.