### PR TITLE
added height and width attributes for displayio

### DIFF
--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -260,8 +260,7 @@ const mp_obj_property_t displayio_display_auto_brightness_obj = {
 //|
 STATIC mp_obj_t displayio_display_obj_get_width(mp_obj_t self_in) {
     displayio_display_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_int_t width = common_hal_displayio_display_get_width(self);
-    return mp_obj_new_int(width);
+    return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_display_get_width(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_get_width_obj, displayio_display_obj_get_width);
 
@@ -279,8 +278,7 @@ const mp_obj_property_t displayio_display_width_obj = {
 //|
 STATIC mp_obj_t displayio_display_obj_get_height(mp_obj_t self_in) {
     displayio_display_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_float_t height = common_hal_displayio_display_get_height(self);
-    return mp_obj_new_int(height);
+    return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_display_get_height(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_get_height_obj, displayio_display_obj_get_height);
 

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -246,6 +246,30 @@ STATIC mp_obj_t displayio_display_obj_set_auto_brightness(mp_obj_t self_in, mp_o
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_display_set_auto_brightness_obj, displayio_display_obj_set_auto_brightness);
 
+//|   .. attribute:: width
+//|
+//|	Gets the width of the board
+//|
+//|
+STATIC mp_obj_t displayio_display_obj_get_width(mp_obj_t self_in) {
+    displayio_display_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_int_t width = common_hal_displayio_display_get_width(self);
+    return mp_obj_new_int(width);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_get_width_obj, displayio_display_obj_get_width);
+
+//|   .. attribute:: height
+//|
+//|	Gets the height of the board
+//|
+//|
+STATIC mp_obj_t displayio_display_obj_get_height(mp_obj_t self_in) {
+    displayio_display_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_float_t height = common_hal_displayio_display_get_height(self);
+    return mp_obj_new_int(height);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_get_height_obj, displayio_display_obj_get_height);
+
 const mp_obj_property_t displayio_display_auto_brightness_obj = {
     .base.type = &mp_type_property,
     .proxy = {(mp_obj_t)&displayio_display_get_auto_brightness_obj,
@@ -260,6 +284,9 @@ STATIC const mp_rom_map_elem_t displayio_display_locals_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_brightness), MP_ROM_PTR(&displayio_display_brightness_obj) },
     { MP_ROM_QSTR(MP_QSTR_auto_brightness), MP_ROM_PTR(&displayio_display_auto_brightness_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&displayio_display_get_width_obj) },
+    { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&displayio_display_get_height_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(displayio_display_locals_dict, displayio_display_locals_dict_table);
 

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -246,6 +246,13 @@ STATIC mp_obj_t displayio_display_obj_set_auto_brightness(mp_obj_t self_in, mp_o
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_display_set_auto_brightness_obj, displayio_display_obj_set_auto_brightness);
 
+const mp_obj_property_t displayio_display_auto_brightness_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&displayio_display_get_auto_brightness_obj,
+              (mp_obj_t)&displayio_display_set_auto_brightness_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
+
 //|   .. attribute:: width
 //|
 //|	Gets the width of the board
@@ -257,6 +264,13 @@ STATIC mp_obj_t displayio_display_obj_get_width(mp_obj_t self_in) {
     return mp_obj_new_int(width);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_get_width_obj, displayio_display_obj_get_width);
+
+const mp_obj_property_t displayio_display_width_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&displayio_display_get_width_obj,
+              (mp_obj_t)&mp_const_none_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
 
 //|   .. attribute:: height
 //|
@@ -270,10 +284,10 @@ STATIC mp_obj_t displayio_display_obj_get_height(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_get_height_obj, displayio_display_obj_get_height);
 
-const mp_obj_property_t displayio_display_auto_brightness_obj = {
+const mp_obj_property_t displayio_display_height_obj = {
     .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&displayio_display_get_auto_brightness_obj,
-              (mp_obj_t)&displayio_display_set_auto_brightness_obj,
+    .proxy = {(mp_obj_t)&displayio_display_get_height_obj,
+              (mp_obj_t)&mp_const_none_obj,
               (mp_obj_t)&mp_const_none_obj},
 };
 
@@ -285,8 +299,8 @@ STATIC const mp_rom_map_elem_t displayio_display_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_brightness), MP_ROM_PTR(&displayio_display_brightness_obj) },
     { MP_ROM_QSTR(MP_QSTR_auto_brightness), MP_ROM_PTR(&displayio_display_auto_brightness_obj) },
 
-    { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&displayio_display_get_width_obj) },
-    { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&displayio_display_get_height_obj) },
+    { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&displayio_display_width_obj) },
+    { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&displayio_display_height_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(displayio_display_locals_dict, displayio_display_locals_dict_table);
 

--- a/shared-bindings/displayio/Display.h
+++ b/shared-bindings/displayio/Display.h
@@ -59,6 +59,9 @@ bool displayio_display_send_pixels(displayio_display_obj_t* self, uint32_t* pixe
 bool common_hal_displayio_display_get_auto_brightness(displayio_display_obj_t* self);
 void common_hal_displayio_display_set_auto_brightness(displayio_display_obj_t* self, bool auto_brightness);
 
+mp_int_t common_hal_displayio_display_get_width(displayio_display_obj_t* self);
+mp_int_t common_hal_displayio_display_get_height(displayio_display_obj_t* self);
+
 mp_float_t common_hal_displayio_display_get_brightness(displayio_display_obj_t* self);
 bool common_hal_displayio_display_set_brightness(displayio_display_obj_t* self, mp_float_t brightness);
 

--- a/shared-bindings/displayio/Display.h
+++ b/shared-bindings/displayio/Display.h
@@ -59,8 +59,8 @@ bool displayio_display_send_pixels(displayio_display_obj_t* self, uint32_t* pixe
 bool common_hal_displayio_display_get_auto_brightness(displayio_display_obj_t* self);
 void common_hal_displayio_display_set_auto_brightness(displayio_display_obj_t* self, bool auto_brightness);
 
-mp_int_t common_hal_displayio_display_get_width(displayio_display_obj_t* self);
-mp_int_t common_hal_displayio_display_get_height(displayio_display_obj_t* self);
+uint16_t common_hal_displayio_display_get_width(displayio_display_obj_t* self);
+uint16_t common_hal_displayio_display_get_height(displayio_display_obj_t* self);
 
 mp_float_t common_hal_displayio_display_get_brightness(displayio_display_obj_t* self);
 bool common_hal_displayio_display_set_brightness(displayio_display_obj_t* self, mp_float_t brightness);

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -157,6 +157,14 @@ bool common_hal_displayio_display_get_auto_brightness(displayio_display_obj_t* s
     return self->auto_brightness;
 }
 
+mp_int_t common_hal_displayio_display_get_width(displayio_display_obj_t* self){
+    return self->width;
+}
+
+mp_int_t common_hal_displayio_display_get_height(displayio_display_obj_t* self){
+    return self->height;
+}
+
 void common_hal_displayio_display_set_auto_brightness(displayio_display_obj_t* self, bool auto_brightness) {
     self->auto_brightness = auto_brightness;
 }

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -157,11 +157,11 @@ bool common_hal_displayio_display_get_auto_brightness(displayio_display_obj_t* s
     return self->auto_brightness;
 }
 
-mp_int_t common_hal_displayio_display_get_width(displayio_display_obj_t* self){
+uint16_t common_hal_displayio_display_get_width(displayio_display_obj_t* self){
     return self->width;
 }
 
-mp_int_t common_hal_displayio_display_get_height(displayio_display_obj_t* self){
+uint16_t common_hal_displayio_display_get_height(displayio_display_obj_t* self){
     return self->height;
 }
 


### PR DESCRIPTION
Tested with the following:

```
import time
import board
import displayio

print(board.DISPLAY.width())
print(board.DISPLAY.height())
```

relates to #1588 