### PR TITLE
Don't wait for display frame if interrupt pending

### DIFF
--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -147,7 +147,8 @@ void common_hal_displayio_display_refresh_soon(displayio_display_obj_t* self) {
 
 int32_t common_hal_displayio_display_wait_for_frame(displayio_display_obj_t* self) {
     uint64_t last_refresh = self->last_refresh;
-    while (last_refresh == self->last_refresh) {
+    // Don't try to refresh if we got an exception.
+    while (last_refresh == self->last_refresh && MP_STATE_VM(mp_pending_exception) == NULL) {
         MICROPY_VM_HOOK_LOOP
     }
     return 0;


### PR DESCRIPTION
`common_hal_displayio_display_wait_for_frame()` would call the background tasks over and over. If a reload was pending, `displayio_refresh_displays()` would stop refreshing, but `common_hal_displayio_display_wait_for_frame()` didn't know that.

The effect was that writes to CIRCUITPY would cause the board to apparently freeze (because the display was frozen). It was really cycling in the background task, never to return.

Details:

- Check for pending interrupts in `common_hal_displayio_display_wait_for_frame()`.
- In `displayio_refresh_displays()`:
  - Check for `KeyboardInterrupt` immediately (otherwise sometimes two ctrl-C's were needed)
  - Don't bother to re- raise `ReloadException` if it was already raised.

I believe this fixes freezes seen by @ladyada, who will test in a few days.

This may or may not have something to do with #1577.