### PR TITLE
Circuitpython nickzoic 1042 nrf nvm bytearray

### DIFF
--- a/ports/nrf/boards/feather_nrf52840_express/mpconfigboard.h
+++ b/ports/nrf/boards/feather_nrf52840_express/mpconfigboard.h
@@ -32,6 +32,7 @@
 #define MICROPY_HW_BOARD_NAME       "Adafruit Feather nRF52840 Express"
 #define MICROPY_HW_MCU_NAME         "nRF52840"
 #define MICROPY_PY_SYS_PLATFORM     "Feather52840Express"
+#define FLASH_SIZE                  (0x100000)
 
 #define MICROPY_HW_NEOPIXEL         (&pin_P0_16)
 

--- a/ports/nrf/boards/feather_nrf52840_express/mpconfigboard.h
+++ b/ports/nrf/boards/feather_nrf52840_express/mpconfigboard.h
@@ -55,7 +55,10 @@
 
 #define CIRCUITPY_AUTORELOAD_DELAY_MS 500
 
-// TODO #define CIRCUITPY_INTERNAL_NVM_SIZE 8192
+// If you change this, then make sure to update the linker scripts as well to
+// make sure you don't overwrite code
+#define PORT_HEAP_SIZE              (128 * 1024)
+#define CIRCUITPY_INTERNAL_NVM_SIZE (4096)
 
 #define BOARD_FLASH_SIZE (FLASH_SIZE - 0x4000 - CIRCUITPY_INTERNAL_NVM_SIZE)
 

--- a/ports/nrf/boards/feather_nrf52840_express/mpconfigboard.h
+++ b/ports/nrf/boards/feather_nrf52840_express/mpconfigboard.h
@@ -32,7 +32,9 @@
 #define MICROPY_HW_BOARD_NAME       "Adafruit Feather nRF52840 Express"
 #define MICROPY_HW_MCU_NAME         "nRF52840"
 #define MICROPY_PY_SYS_PLATFORM     "Feather52840Express"
+
 #define FLASH_SIZE                  (0x100000)
+#define FLASH_PAGE_SIZE             (4096)
 
 #define MICROPY_HW_NEOPIXEL         (&pin_P0_16)
 

--- a/ports/nrf/common-hal/microcontroller/__init__.c
+++ b/ports/nrf/common-hal/microcontroller/__init__.c
@@ -76,7 +76,7 @@ const nvm_bytearray_obj_t common_hal_mcu_nvm_obj = {
         .type = &nvm_bytearray_type,
     },
     .len = CIRCUITPY_INTERNAL_NVM_SIZE,
-    .start_address = 0
+    .start_address = FLASH_SIZE - CIRCUITPY_INTERNAL_NVM_SIZE
 };
 #endif
 

--- a/ports/nrf/common-hal/microcontroller/__init__.c
+++ b/ports/nrf/common-hal/microcontroller/__init__.c
@@ -24,9 +24,14 @@
  * THE SOFTWARE.
  */
 
+#include "py/mphal.h"
+#include "py/obj.h"
+#include "py/runtime.h"
+
 #include "common-hal/microcontroller/Pin.h"
 #include "common-hal/microcontroller/Processor.h"
 
+#include "shared-bindings/nvm/ByteArray.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/Processor.h"
@@ -62,6 +67,18 @@ const mcu_processor_obj_t common_hal_mcu_processor_obj = {
         .type = &mcu_processor_type,
     },
 };
+
+// NVM is only available on Express boards for now.
+#if CIRCUITPY_INTERNAL_NVM_SIZE > 0
+// The singleton nvm.ByteArray object.
+const nvm_bytearray_obj_t common_hal_mcu_nvm_obj = {
+    .base = {
+        .type = &nvm_bytearray_type,
+    },
+    .len = CIRCUITPY_INTERNAL_NVM_SIZE,
+    .start_address = 0
+};
+#endif
 
 
 STATIC const mp_rom_map_elem_t mcu_pin_globals_table[] = {

--- a/ports/nrf/common-hal/nvm/ByteArray.c
+++ b/ports/nrf/common-hal/nvm/ByteArray.c
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Nick Moore for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "common-hal/nvm/ByteArray.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "nrf_nvmc.h"
+
+uint32_t common_hal_nvm_bytearray_get_length(nvm_bytearray_obj_t *self) {
+    return self->len;
+}
+
+bool common_hal_nvm_bytearray_set_bytes(nvm_bytearray_obj_t *self,
+        uint32_t start_index, uint8_t* values, uint32_t len) {
+    printf("%ld %ld\n", start_index, len);
+    nrf_nvmc_page_erase(self->start_address);
+    nrf_nvmc_write_bytes(self->start_address + start_index, values, len);    
+    return true;
+}
+
+void common_hal_nvm_bytearray_get_bytes(nvm_bytearray_obj_t *self,
+    uint32_t start_index, uint32_t len, uint8_t* values) {
+    memcpy(values, (uint8_t *)(self->start_address + start_index), len);
+}

--- a/ports/nrf/common-hal/nvm/ByteArray.h
+++ b/ports/nrf/common-hal/nvm/ByteArray.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Nick Moore for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_NRF_COMMON_HAL_NVM_BYTEARRAY_H
+#define MICROPY_INCLUDED_NRF_COMMON_HAL_NVM_BYTEARRAY_H
+
+#include "py/obj.h"
+
+typedef struct {
+    mp_obj_base_t base;
+    uint32_t start_address;
+    uint32_t len;
+} nvm_bytearray_obj_t;
+
+#endif // MICROPY_INCLUDED_NRF_COMMON_HAL_NVM_BYTEARRAY_H

--- a/ports/nrf/common-hal/nvm/__init__.c
+++ b/ports/nrf/common-hal/nvm/__init__.c
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Nick Moore for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// No nvm module functions.

--- a/ports/nrf/mpconfigport.mk
+++ b/ports/nrf/mpconfigport.mk
@@ -19,9 +19,6 @@ CIRCUITPY_AUDIOBUSIO = 0
 # No I2CSlave implementation
 CIRCUITPY_I2CSLAVE = 0
 
-# nvm not yet implemented
-CIRCUITPY_NVM = 0
-
 # rtc not yet implemented
 CIRCUITPY_RTC = 0
 


### PR DESCRIPTION
An implementation for #1042 for non-volatile memory.

Some example code:

```
import microcontroller
    
def dump(n = microcontroller.nvm):
    for i in range(0,len(n)):
        print ("%02X " % n[i], end="")
        if i % 16 == 15: print('')
    
microcontroller.nvm[0:4096] = bytes([1,2,3,4,5,6,7,8]) * 512
microcontroller.nvm[107:120] = b"hello, world!"
dump()
```