### PR TITLE
Add default devices and tweak brightness in boards/pewpew10

### DIFF
--- a/ports/atmel-samd/boards/pewpew10/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pewpew10/mpconfigboard.h
@@ -32,3 +32,19 @@
 #define IGNORE_PIN_PB23     1
 #define IGNORE_PIN_PB30     1
 #define IGNORE_PIN_PB31     1
+
+// USB is always used internally so skip the pin objects for it.
+#define IGNORE_PIN_PA24     1
+#define IGNORE_PIN_PA25     1
+
+// Default protocol pins.
+
+#define DEFAULT_I2C_BUS_SCL (&pin_PA01)
+#define DEFAULT_I2C_BUS_SDA (&pin_PA00)
+
+#define DEFAULT_SPI_BUS_SCK (&pin_PA31)
+#define DEFAULT_SPI_BUS_MOSI (&pin_PA30)
+#define DEFAULT_SPI_BUS_MISO (&pin_PA04)
+
+#define DEFAULT_UART_BUS_RX (&pin_PA01)
+#define DEFAULT_UART_BUS_TX (&pin_PA00)

--- a/ports/atmel-samd/boards/pewpew10/pins.c
+++ b/ports/atmel-samd/boards/pewpew10/pins.c
@@ -3,6 +3,7 @@
 #include "supervisor/shared/board_busses.h"
 
 STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
+    // Pins for internal use.
     { MP_ROM_QSTR(MP_QSTR__R1),  MP_ROM_PTR(&pin_PA05) },
     { MP_ROM_QSTR(MP_QSTR__R2),  MP_ROM_PTR(&pin_PA11) },
     { MP_ROM_QSTR(MP_QSTR__R3),  MP_ROM_PTR(&pin_PA28) },
@@ -21,6 +22,9 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR__C2),  MP_ROM_PTR(&pin_PA14) },
     { MP_ROM_QSTR(MP_QSTR__C1),  MP_ROM_PTR(&pin_PA15) },
 
+    { MP_ROM_QSTR(MP_QSTR__BUTTONS),  MP_ROM_PTR(&pin_PA08) },
+
+    // User pins.
     { MP_ROM_QSTR(MP_QSTR_P1),  MP_ROM_PTR(&pin_PA30) },
     { MP_ROM_QSTR(MP_QSTR_P2),  MP_ROM_PTR(&pin_PA31) },
     { MP_ROM_QSTR(MP_QSTR_P3),  MP_ROM_PTR(&pin_PA00) },
@@ -29,7 +33,21 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_P6),  MP_ROM_PTR(&pin_PA03) },
     { MP_ROM_QSTR(MP_QSTR_P7),  MP_ROM_PTR(&pin_PA04) },
 
-    { MP_ROM_QSTR(MP_QSTR__BUTTONS),  MP_ROM_PTR(&pin_PA08) },
+    // Protocol aliases.
+    { MP_ROM_QSTR(MP_QSTR_SDA),  MP_ROM_PTR(&pin_PA00) },
+    { MP_ROM_QSTR(MP_QSTR_SCL),  MP_ROM_PTR(&pin_PA01) },
 
+    { MP_ROM_QSTR(MP_QSTR_TX),  MP_ROM_PTR(&pin_PA00) },
+    { MP_ROM_QSTR(MP_QSTR_RX),  MP_ROM_PTR(&pin_PA01) },
+
+    { MP_ROM_QSTR(MP_QSTR_MISO),  MP_ROM_PTR(&pin_PA04) },
+    { MP_ROM_QSTR(MP_QSTR_MOSI),  MP_ROM_PTR(&pin_PA30) },
+    { MP_ROM_QSTR(MP_QSTR_SCK),  MP_ROM_PTR(&pin_PA31) },
+
+    { MP_ROM_QSTR(MP_QSTR_DAC),  MP_ROM_PTR(&pin_PA02) },
+
+    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);

--- a/shared-module/_pew/PewPew.c
+++ b/shared-module/_pew/PewPew.c
@@ -107,7 +107,7 @@ void pew_init() {
         #endif
 
         tc_set_enable(tc, true);
-        tc->COUNT16.CC[0].reg = 160;
+        tc->COUNT16.CC[0].reg = 64;
 
         // Clear our interrupt in case it was set earlier
         tc->COUNT16.INTFLAG.reg = TC_INTFLAG_MC0;

--- a/shared-module/_pew/__init__.c
+++ b/shared-module/_pew/__init__.c
@@ -51,7 +51,7 @@ void pew_tick(void) {
         pressed = 0;
         col = 0;
         ++turn;
-        if (turn >= 8) {
+        if (turn > 11) {
             turn = 0;
         }
     }
@@ -68,13 +68,15 @@ void pew_tick(void) {
                 value = true;
                 break;
             case 2:
-                if (turn == 2 || turn == 4 || turn == 6) {
-                    value = true;
+                if (turn == 2 || turn == 5 || turn == 8 || turn == 11) {
+                        value = true;
                 }
+                break;
             case 1:
                 if (turn == 0) {
                     value = true;
                 }
+                break;
             case 0:
                 break;
         }


### PR DESCRIPTION
* add default pins for i2c, spi and uart
* add default i2c, spi and uart devices
* ignore usb pins
* tweak brightness and refresh rate of the display matrix