### PR TITLE
add SPEAKER pin alias for PyPortal

### DIFF
--- a/ports/atmel-samd/boards/pyportal/pins.c
+++ b/ports/atmel-samd/boards/pyportal/pins.c
@@ -8,8 +8,8 @@
 // out on connectors are labeled with their MCU name available from
 // microcontroller.pin.
 STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
-    { MP_OBJ_NEW_QSTR(MP_QSTR_AUDIO_OUT), MP_ROM_PTR(&pin_PA02) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_SPEAKER), MP_ROM_PTR(&pin_PA02) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_AUDIO_OUT), MP_ROM_PTR(&pin_PA02) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_PA02) }, // analog out/in
     { MP_OBJ_NEW_QSTR(MP_QSTR_SPEAKER_ENABLE), MP_ROM_PTR(&pin_PA27) },
 

--- a/ports/atmel-samd/boards/pyportal/pins.c
+++ b/ports/atmel-samd/boards/pyportal/pins.c
@@ -9,6 +9,7 @@
 // microcontroller.pin.
 STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_AUDIO_OUT), MP_ROM_PTR(&pin_PA02) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SPEAKER), MP_ROM_PTR(&pin_PA02) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_PA02) }, // analog out/in
     { MP_OBJ_NEW_QSTR(MP_QSTR_SPEAKER_ENABLE), MP_ROM_PTR(&pin_PA27) },
 


### PR DESCRIPTION
```python
Adafruit CircuitPython 4.0.0-alpha.2-807-g186e31591-dirty on 2019-03-11; Adafruit PyPortal with samd51j20
>>> import board
>>> dir(board)
['__class__', 'A0', 'A1', 'A2', 'A4', 'AUDIO_OUT', 'D13', 'D3', 'D4', 'DISPLAY', 'ESP_BUSY', 'ESP_CS', 'ESP_GPIO0', 'ESP_RESET', 'ESP_RTS', 'I2C', 'L', 'LCD_DATA0', 'LCD_DATA1', 'LCD_DATA2', 'LCD_DATA3', 'LCD_DATA4', 'LCD_DATA5', 'LCD_DATA6', 'LCD_DATA7', 'LIGHT', 'MISO', 'MOSI', 'NEOPIXEL', 'RX', 'SCK', 'SCL', 'SDA', 'SD_CARD_DETECT', 'SD_CS', 'SPEAKER', 'SPEAKER_ENABLE', 'SPI', 'TFT_BACKLIGHT', 'TFT_CS', 'TFT_DC', 'TFT_RD', 'TFT_RESET', 'TFT_RS', 'TFT_TE', 'TFT_WR', 'TOUCH_XL', 'TOUCH_XR', 'TOUCH_YD', 'TOUCH_YU', 'TX', 'UART']
```

Also tested with this program:
```python
import time
import math
import array
import board
import audioio
import digitalio

length = 8000 // 440
sine_wave = array.array("H", [0] * length)
for i in range(length):
    sine_wave[i] = int(math.sin(math.pi * 2 * i / 18) * (2 ** 15) + 2 ** 15)

dac = audioio.AudioOut(board.SPEAKER)
sine_wave = audioio.RawSample(sine_wave, sample_rate=8000)

speaker_enable = digitalio.DigitalInOut(board.SPEAKER_ENABLE)
speaker_enable.direction = digitalio.Direction.OUTPUT

speaker_enable.value = True
dac.play(sine_wave, loop=True)
time.sleep(1)
speaker_enable.value = False
dac.stop()
```