### PR TITLE
nrf: Disable SPIM3; add SPIM1; remove TWIM1

### DIFF
--- a/ports/nrf/nrfx_config.h
+++ b/ports/nrf/nrfx_config.h
@@ -10,9 +10,10 @@
     #define NRFX_SPIS_NRF52_ANOMALY_109_WORKAROUND_ENABLED 1
 #endif
 
+// NOTE: THIS WORKAROUND CAUSES BLE CODE TO CRASH; tested on 2019-03-11.
 // Turn on nrfx supported workarounds for errata in Rev1 of nRF52840
 #ifdef NRF52840_XXAA
-    #define NRFX_SPIM3_NRF52840_ANOMALY_198_WORKAROUND_ENABLED 1
+//    #define NRFX_SPIM3_NRF52840_ANOMALY_198_WORKAROUND_ENABLED 1
 #endif
 
 // SPI
@@ -25,13 +26,17 @@
 // We could write an interrupt handler that checks whether it's
 // being used for SPI or I2C, but perhaps two I2C's and 1-2 SPI's are good enough for now.
 
-// Enable SPIM2 and SPIM3 (if available)
+// Enable SPIM1, SPIM2 and SPIM3 (if available)
+// No conflict with TWIM0.
+#define NRFX_SPIM1_ENABLED 1
 #define NRFX_SPIM2_ENABLED 1
-#ifdef NRF_SPIM3
-    #define NRFX_SPIM3_ENABLED 1
-#else
-    #define NRFX_SPIM3_ENABLED 0
-#endif
+// DON'T ENABLE SPIM3 DUE TO ANOMALY WORKAROUND FAILURE (SEE ABOVE).
+// #ifdef NRF52840_XXAA
+//     #define NRFX_SPIM_EXTENDED_ENABLED 1
+//     #define NRFX_SPIM3_ENABLED 1
+// #else
+//     #define NRFX_SPIM3_ENABLED 0
+// #endif
 
 
 #define NRFX_SPIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
@@ -40,10 +45,10 @@
 // QSPI
 #define NRFX_QSPI_ENABLED                          1
 
-// TWI aka. I2C; enable TWIM0 and TWIM1 (no conflict with SPIM choices)
+// TWI aka. I2C; enable a single bus: TWIM0 (no conflict with SPIM1 and SPIM2)
 #define NRFX_TWIM_ENABLED 1
 #define NRFX_TWIM0_ENABLED 1
-#define NRFX_TWIM1_ENABLED 1
+//#define NRFX_TWIM1_ENABLED 1
 
 #define NRFX_TWIM_DEFAULT_CONFIG_IRQ_PRIORITY 7
 #define NRFX_TWIM_DEFAULT_CONFIG_FREQUENCY NRF_TWIM_FREQ_400K


### PR DESCRIPTION
SPIM3 has a hardware bug in rev1 nRF52840 (see errata). There's a workaround in nrfx, but it causes BLE to fail.

Reconfigured busio choices to use SPIM1 and SPIM2, disabling SPIM3. TWIM0 and TWIM1 are shared peripherals with SPIM0 and SPIM1, and it's not possible to shared dynamically right now due to static nrfx interrupt handler allocation. So choose to have one I2C bus available, and two SPI buses.

Later we may allow dynamic reconfig, try to fix the SPIM3 anomaly-fix bug (or at least report it with a small test case), and/or have some kind of compilation flags to allow choosing bus allocation, but this is good enough for 4.0.0.

Another bug was the use of `#ifdef NRF_SPIM3` in `nrfx_config.h`. This macro is not consistently set due to include file order, so avoid using it. That was causing conflicting definitions of macros in different files.

Fixes #1628.