### PR TITLE
wrong arg type for PWMOut variable_frequency

### DIFF
--- a/ports/atmel-samd/common-hal/pulseio/PWMOut.c
+++ b/ports/atmel-samd/common-hal/pulseio/PWMOut.c
@@ -102,6 +102,8 @@ void pwmout_reset(void) {
         }
         tcc_channels[i] = mask;
         tccs[i]->CTRLA.bit.SWRST = 1;
+        while (tccs[i]->CTRLA.bit.SWRST == 1) {
+        }
     }
     Tc *tcs[TC_INST_NUM] = TC_INSTS;
     for (int i = 0; i < TC_INST_NUM; i++) {

--- a/shared-bindings/pulseio/PWMOut.c
+++ b/shared-bindings/pulseio/PWMOut.c
@@ -103,7 +103,7 @@ STATIC mp_obj_t pulseio_pwmout_make_new(const mp_obj_type_t *type, size_t n_args
 
     uint16_t duty_cycle = parsed_args[ARG_duty_cycle].u_int;
     uint32_t frequency = parsed_args[ARG_frequency].u_int;
-    bool variable_frequency = parsed_args[ARG_variable_frequency].u_int;
+    bool variable_frequency = parsed_args[ARG_variable_frequency].u_bool;
 
     // create PWM object from the given pin
     pulseio_pwmout_obj_t *self = m_new_obj(pulseio_pwmout_obj_t);


### PR DESCRIPTION
PWMOut was reading a supplied bool arg as an int, so it was always True.

Also minor fix to make sure SWRESET is finished before proceeding.

Fixes #1626.