### PR TITLE
flush filesystem before resetting heap

### DIFF
--- a/main.c
+++ b/main.c
@@ -213,10 +213,11 @@ bool run_code_py(safe_mode_t safe_mode) {
                 serial_write_compressed(translate("WARNING: Your code filename has two extensions\n"));
             }
         }
-        // Turn off the display before the heap disappears.
+        // Turn off the display and flush the fileystem before the heap disappears.
         #if CIRCUITPY_DISPLAYIO
         reset_displays();
         #endif
+        filesystem_flush();
         stop_mp();
         free_memory(heap);
         supervisor_move_memory();

--- a/main.c
+++ b/main.c
@@ -376,6 +376,7 @@ int run_repl(void) {
     } else {
         exit_code = pyexec_friendly_repl();
     }
+    filesystem_flush();
     reset_port();
     reset_board();
     stop_mp();

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -29,10 +29,8 @@ void displayio_refresh_displays(void) {
     if (mp_hal_is_interrupted()) {
         return;
     }
-    // Somehow reloads from the sdcard are being lost. So, cheat and reraise.
-    // But don't re-raise if already pending.
-    if (reload_requested && MP_STATE_VM(mp_pending_exception) == MP_OBJ_NULL) {
-        mp_raise_reload_exception();
+    if (reload_requested) {
+        // Reload is about to happen, so don't redisplay.
         return;
     }
 


### PR DESCRIPTION
I think this fixes #1643.

There's a RAM filesystem cache on the heap, in some circumstances, and it was not flushed and discarded before the heap was reset.

Also fixed minor problem in display background task, setting reload exception after it was already set.