### PR TITLE
nrf: fix internal flash writes

### DIFF
--- a/locale/ID.po
+++ b/locale/ID.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-12 11:17-0700\n"
+"POT-Creation-Date: 2019-03-18 09:56-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -52,8 +52,8 @@ msgstr ""
 msgid "%q indices must be integers, not %s"
 msgstr ""
 
+#: shared-bindings/displayio/Shape.c shared-bindings/displayio/Group.c
 #: shared-bindings/bleio/CharacteristicBuffer.c
-#: shared-bindings/displayio/Group.c shared-bindings/displayio/Shape.c
 #, fuzzy
 msgid "%q must be >= 1"
 msgstr "buffers harus mempunyai panjang yang sama"
@@ -70,12 +70,12 @@ msgstr "%q() mengambil posisi argumen %d tapi %d yang diberikan"
 msgid "'%q' argument required"
 msgstr "'%q' argumen dibutuhkan"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a label"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a register"
 msgstr "'%s' mengharapkan sebuah register"
@@ -95,7 +95,7 @@ msgstr "'%s' mengharapkan sebuah FPU register"
 msgid "'%s' expects an address of the form [a, b]"
 msgstr "'%s' mengharapkan sebuah alamat dengan bentuk [a, b]"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects an integer"
 msgstr "'%s' mengharapkan integer"
@@ -257,11 +257,10 @@ msgstr "Semua channel event yang disinkronisasi sedang digunakan"
 msgid "All timers for this pin are in use"
 msgstr "Semua timer untuk pin ini sedang digunakan"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PulseOut.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
-#: ports/nrf/common-hal/pulseio/PulseOut.c shared-bindings/pulseio/PWMOut.c
-#: shared-module/_pew/PewPew.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c shared-module/_pew/PewPew.c
 msgid "All timers in use"
 msgstr "Semua timer sedang digunakan"
 
@@ -330,12 +329,12 @@ msgstr ""
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
+#: shared-bindings/busio/I2C.c shared-bindings/bitbangio/I2C.c
 msgid "Buffer must be at least length 1"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, fuzzy, c-format
 msgid "Bus pin %d is already in use"
 msgstr "DAC sudah digunakan"
@@ -378,7 +377,7 @@ msgstr ""
 msgid "Cannot connect to AP"
 msgstr "Tidak dapat menyambungkan ke AP"
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
 msgid "Cannot delete values"
 msgstr ""
 
@@ -386,8 +385,8 @@ msgstr ""
 msgid "Cannot disconnect from AP"
 msgstr "Tidak dapat memutuskna dari AP"
 
-#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr "Tidak bisa mendapatkan pull pada saat mode output"
 
@@ -414,8 +413,8 @@ msgstr ""
 msgid "Cannot remount '/' when USB is active."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/esp8266/common-hal/microcontroller/__init__.c
+#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 "Tidak dapat melakukan reset ke bootloader karena tidak ada bootloader yang "
@@ -477,7 +476,7 @@ msgstr "Clock unit sedang digunakan"
 msgid "Column entry must be digitalio.DigitalInOut"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Command must be an int between 0 and 255"
 msgstr ""
 
@@ -506,8 +505,8 @@ msgstr ""
 msgid "DAC already in use"
 msgstr "DAC sudah digunakan"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 msgid "Data 0 pin must be byte aligned"
 msgstr ""
 
@@ -515,8 +514,8 @@ msgstr ""
 msgid "Data chunk must follow fmt chunk"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy
 msgid "Data too large for advertisement packet"
 msgstr "Tidak bisa menyesuaikan data ke dalam paket advertisment"
@@ -550,8 +549,8 @@ msgstr "ESP8266 tidak mendukung safe mode"
 msgid "ESP8266 does not support pull down."
 msgstr "ESP866 tidak mendukung pull down"
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "EXTINT channel already in use"
 msgstr "Channel EXTINT sedang digunakan"
 
@@ -563,8 +562,8 @@ msgstr "Errod pada ffi_prep_cif"
 msgid "Error in regex"
 msgstr "Error pada regex"
 
-#: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/microcontroller/Pin.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/neopixel_write/__init__.c
 #: shared-bindings/terminalio/Terminal.c
 msgid "Expected a %q"
 msgstr ""
@@ -573,8 +572,8 @@ msgstr ""
 msgid "Expected a Characteristic"
 msgstr ""
 
-#: shared-bindings/bleio/Characteristic.c shared-bindings/bleio/Descriptor.c
-#: shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Descriptor.c shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Characteristic.c
 msgid "Expected a UUID"
 msgstr ""
 
@@ -608,13 +607,13 @@ msgstr "Gagal untuk menambahkan layanan, status: 0x%08lX"
 msgid "Failed to add service, err 0x%04x"
 msgstr "Gagal untuk menambahkan layanan, status: 0x%08lX"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "Failed to allocate RX buffer"
 msgstr "Gagal untuk mengalokasikan buffer RX"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr "Gagal untuk megalokasikan buffer RX dari %d byte"
@@ -699,8 +698,8 @@ msgstr "Gagal untuk melepaskan mutex, status: 0x%08lX"
 msgid "Failed to start advertising"
 msgstr "Gagal untuk memulai advertisement, status: 0x%08lX"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to start advertising, err 0x%04x"
 msgstr "Gagal untuk memulai advertisement, status: 0x%08lX"
@@ -720,8 +719,8 @@ msgstr "Gagal untuk melakukan scanning, status: 0x%08lX"
 msgid "Failed to stop advertising"
 msgstr "Gagal untuk memberhentikan advertisement, status: 0x%08lX"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to stop advertising, err 0x%04x"
 msgstr "Gagal untuk memberhentikan advertisement, status: 0x%08lX"
@@ -740,12 +739,30 @@ msgstr "Gagal untuk menulis nilai gatts, status: 0x%08lX"
 msgid "File exists"
 msgstr ""
 
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash erase failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash erase failed to start, err 0x%04x"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash write failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash write failed to start, err 0x%04x"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/bitbangio/SPI.c
-#: shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/I2C.c
+#: shared-bindings/bitbangio/SPI.c
 msgid "Function requires lock"
 msgstr ""
 
@@ -761,7 +778,7 @@ msgstr "GPIO16 tidak mendukung pull up"
 msgid "Group full"
 msgstr ""
 
-#: extmod/vfs_posix_file.c ports/unix/file.c py/objstringio.c
+#: py/objstringio.c ports/unix/file.c extmod/vfs_posix_file.c
 msgid "I/O operation on closed file"
 msgstr "operasi I/O pada file tertutup"
 
@@ -787,8 +804,8 @@ msgstr ""
 msgid "Invalid BMP file"
 msgstr ""
 
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PWMOut.c
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
 msgid "Invalid PWM frequency"
 msgstr "Frekuensi PWM tidak valid"
 
@@ -833,17 +850,17 @@ msgstr ""
 msgid "Invalid format chunk size"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid number of bits"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid phase"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
 #: shared-bindings/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/touchio/TouchIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Invalid pin"
 msgstr "Pin tidak valid"
 
@@ -855,15 +872,14 @@ msgstr "Pin untuk channel kiri tidak valid"
 msgid "Invalid pin for right channel"
 msgstr "Pin untuk channel kanan tidak valid"
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/nrf/common-hal/busio/I2C.c ports/atmel-samd/common-hal/busio/I2C.c
 #: ports/atmel-samd/common-hal/busio/SPI.c
 #: ports/atmel-samd/common-hal/busio/UART.c
 #: ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
-#: ports/nrf/common-hal/busio/I2C.c
 msgid "Invalid pins"
 msgstr "Pin-pin tidak valid"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid polarity"
 msgstr ""
 
@@ -958,11 +974,11 @@ msgstr "tidak ada channel DMA ditemukan"
 msgid "No PulseIn support for %q"
 msgstr "Tidak ada dukungan PulseIn untuk %q"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No RX pin"
 msgstr "Tidak pin RX"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No TX pin"
 msgstr "Tidak ada pin TX"
 
@@ -994,8 +1010,8 @@ msgstr ""
 msgid "No hardware support for analog out."
 msgstr "Tidak dukungan hardware untuk analog out."
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No hardware support on pin"
 msgstr "Tidak ada dukungan hardware untuk pin"
 
@@ -1072,7 +1088,7 @@ msgid ""
 "PWM frequency not writable when variable_frequency is False on construction."
 msgstr ""
 
-#: ports/esp8266/common-hal/pulseio/PWMOut.c ports/esp8266/machine_pwm.c
+#: ports/esp8266/machine_pwm.c ports/esp8266/common-hal/pulseio/PWMOut.c
 #, c-format
 msgid "PWM not supported on pin %d"
 msgstr "PWM tidak didukung pada pin %d"
@@ -1085,8 +1101,8 @@ msgstr ""
 msgid "Pin %q does not have ADC capabilities"
 msgstr "Pin %q tidak memiliki kemampuan ADC"
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 #: ports/nrf/common-hal/analogio/AnalogIn.c
+#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 msgid "Pin does not have ADC capabilities"
 msgstr "Pin tidak mempunya kemampuan untuk ADC (Analog Digital Converter)"
 
@@ -1120,7 +1136,7 @@ msgstr ""
 msgid "RTC calibration is not supported on this board"
 msgstr ""
 
-#: shared-bindings/rtc/RTC.c shared-bindings/time/__init__.c
+#: shared-bindings/time/__init__.c shared-bindings/rtc/RTC.c
 msgid "RTC is not supported on this board"
 msgstr ""
 
@@ -1132,7 +1148,7 @@ msgstr ""
 msgid "Read-only"
 msgstr ""
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: py/moduerrno.c extmod/vfs_fat.c
 msgid "Read-only filesystem"
 msgstr "sistem file (filesystem) bersifat Read-only"
 
@@ -1188,8 +1204,8 @@ msgstr "Serializer sedang digunakan"
 msgid "Slice and value different lengths."
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/displayio/Group.c
 msgid "Slices not supported"
 msgstr ""
 
@@ -1272,7 +1288,7 @@ msgstr "Untuk keluar, silahkan reset board tanpa "
 msgid "Too many channels in sample."
 msgstr "Terlalu banyak channel dalam sampel"
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Too many display busses"
 msgstr ""
 
@@ -1449,7 +1465,7 @@ msgstr "sebuah objek menyerupai byte (bytes-like) dibutuhkan"
 msgid "abort() called"
 msgstr "abort() dipanggil"
 
-#: extmod/machine_mem.c ports/unix/modmachine.c
+#: ports/unix/modmachine.c extmod/machine_mem.c
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr "alamat %08x tidak selaras dengan %d bytes"
@@ -1478,7 +1494,7 @@ msgstr "argumen num/types tidak cocok"
 msgid "argument should be a '%q' not a '%q'"
 msgstr ""
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objarray.c
 msgid "array/bytes required on right side"
 msgstr ""
 
@@ -1540,7 +1556,7 @@ msgstr ""
 msgid "buffer size must match format"
 msgstr "buffers harus mempunyai panjang yang sama"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "buffer slices must be of equal length"
 msgstr ""
 
@@ -1548,7 +1564,7 @@ msgstr ""
 msgid "buffer too long"
 msgstr "buffer terlalu panjang"
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
+#: shared-bindings/struct/__init__.c py/modstruct.c
 #: shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr ""
@@ -1848,8 +1864,8 @@ msgstr ""
 msgid "dict update sequence has wrong length"
 msgstr ""
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/objfloat.c py/runtime.c py/modmath.c
+#: py/objint_longlong.c py/objint_mpz.c
 msgid "division by zero"
 msgstr ""
 
@@ -1861,7 +1877,7 @@ msgstr "hanya antar pos atau kw args yang diperbolehkan"
 msgid "empty"
 msgstr ""
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/modutimeq.c extmod/moduheapq.c
 msgid "empty heap"
 msgstr "heap kosong"
 
@@ -1934,7 +1950,7 @@ msgstr "argumen posisi ekstra telah diberikan"
 msgid "ffi_prep_closure_loc"
 msgstr "ffi_prep_closure_loc"
 
-#: shared-bindings/audioio/WaveFile.c shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/audioio/WaveFile.c
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
@@ -2054,9 +2070,9 @@ msgstr ""
 msgid "incorrect padding"
 msgstr "lapisan (padding) tidak benar"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: py/obj.c ports/nrf/common-hal/pulseio/PulseIn.c
 #: ports/esp8266/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c py/obj.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "index out of range"
 msgstr "index keluar dari jangkauan"
 
@@ -2104,7 +2120,7 @@ msgstr "panjang buffer tidak valid"
 msgid "invalid cert"
 msgstr "cert tidak valid"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid data bits"
 msgstr "bit data tidak valid"
 
@@ -2136,11 +2152,11 @@ msgstr "pin tidak valid"
 msgid "invalid step"
 msgstr ""
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid stop bits"
 msgstr "stop bit tidak valid"
 
-#: py/compile.c py/parse.c
+#: py/parse.c py/compile.c
 msgid "invalid syntax"
 msgstr "syntax tidak valid"
 
@@ -2177,7 +2193,7 @@ msgstr "argumen keyword belum diimplementasi - gunakan args normal"
 msgid "keywords must be strings"
 msgstr "keyword harus berupa string"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 msgid "label '%q' not defined"
 msgstr ""
 
@@ -2217,7 +2233,7 @@ msgstr ""
 msgid "map buffer too small"
 msgstr ""
 
-#: py/modmath.c shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/modmath.c
 msgid "math domain error"
 msgstr ""
 
@@ -2293,11 +2309,11 @@ msgstr ""
 msgid "need more than %d values to unpack"
 msgstr ""
 
-#: py/objint_longlong.c py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_longlong.c py/objint_mpz.c
 msgid "negative power with no float support"
 msgstr ""
 
-#: py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_mpz.c
 msgid "negative shift count"
 msgstr ""
 
@@ -2317,7 +2333,7 @@ msgstr "tidak ada ikatan/bind pada temuan nonlocal"
 msgid "no module named '%q'"
 msgstr "tidak ada modul yang bernama '%q'"
 
-#: py/runtime.c shared-bindings/_pixelbuf/__init__.c
+#: shared-bindings/_pixelbuf/__init__.c py/runtime.c
 msgid "no such attribute"
 msgstr ""
 
@@ -2409,8 +2425,8 @@ msgstr "panjang data string memiliki keganjilan (odd-length)"
 msgid "offset out of bounds"
 msgstr "modul tidak ditemukan"
 
-#: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objstr.c py/objarray.c py/objstrunicode.c
+#: py/objtuple.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr ""
 
@@ -2463,9 +2479,9 @@ msgstr ""
 msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "pop from an empty PulseIn"
 msgstr "Muncul dari PulseIn yang kosong"
 
@@ -2544,7 +2560,7 @@ msgstr "scan gagal"
 msgid "schedule stack full"
 msgstr ""
 
-#: lib/utils/pyexec.c py/builtinimport.c
+#: py/builtinimport.c lib/utils/pyexec.c
 msgid "script compilation not supported"
 msgstr "kompilasi script tidak didukung"
 
@@ -2572,7 +2588,7 @@ msgstr ""
 msgid "slice step cannot be zero"
 msgstr ""
 
-#: py/objint.c py/sequence.c
+#: py/sequence.c py/objint.c
 msgid "small int overflow"
 msgstr ""
 
@@ -2699,7 +2715,7 @@ msgstr ""
 msgid "tuple/list required on RHS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "tx and rx cannot both be None"
 msgstr "tx dan rx keduanya tidak boleh kosong"
 

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-12 17:20-0700\n"
+"POT-Creation-Date: 2019-03-18 09:56-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -52,8 +52,8 @@ msgstr ""
 msgid "%q indices must be integers, not %s"
 msgstr ""
 
+#: shared-bindings/displayio/Shape.c shared-bindings/displayio/Group.c
 #: shared-bindings/bleio/CharacteristicBuffer.c
-#: shared-bindings/displayio/Group.c shared-bindings/displayio/Shape.c
 msgid "%q must be >= 1"
 msgstr ""
 
@@ -69,12 +69,12 @@ msgstr ""
 msgid "'%q' argument required"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a label"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a register"
 msgstr ""
@@ -94,7 +94,7 @@ msgstr ""
 msgid "'%s' expects an address of the form [a, b]"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects an integer"
 msgstr ""
@@ -255,11 +255,10 @@ msgstr ""
 msgid "All timers for this pin are in use"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PulseOut.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
-#: ports/nrf/common-hal/pulseio/PulseOut.c shared-bindings/pulseio/PWMOut.c
-#: shared-module/_pew/PewPew.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c shared-module/_pew/PewPew.c
 msgid "All timers in use"
 msgstr ""
 
@@ -326,12 +325,12 @@ msgstr ""
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
+#: shared-bindings/busio/I2C.c shared-bindings/bitbangio/I2C.c
 msgid "Buffer must be at least length 1"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, c-format
 msgid "Bus pin %d is already in use"
 msgstr ""
@@ -373,7 +372,7 @@ msgstr ""
 msgid "Cannot connect to AP"
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
 msgid "Cannot delete values"
 msgstr ""
 
@@ -381,8 +380,8 @@ msgstr ""
 msgid "Cannot disconnect from AP"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -406,8 +405,8 @@ msgstr ""
 msgid "Cannot remount '/' when USB is active."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/esp8266/common-hal/microcontroller/__init__.c
+#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 
@@ -467,7 +466,7 @@ msgstr ""
 msgid "Column entry must be digitalio.DigitalInOut"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Command must be an int between 0 and 255"
 msgstr ""
 
@@ -496,8 +495,8 @@ msgstr ""
 msgid "DAC already in use"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 msgid "Data 0 pin must be byte aligned"
 msgstr ""
 
@@ -505,8 +504,8 @@ msgstr ""
 msgid "Data chunk must follow fmt chunk"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 msgid "Data too large for advertisement packet"
 msgstr ""
 
@@ -538,8 +537,8 @@ msgstr ""
 msgid "ESP8266 does not support pull down."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "EXTINT channel already in use"
 msgstr ""
 
@@ -551,8 +550,8 @@ msgstr ""
 msgid "Error in regex"
 msgstr ""
 
-#: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/microcontroller/Pin.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/neopixel_write/__init__.c
 #: shared-bindings/terminalio/Terminal.c
 msgid "Expected a %q"
 msgstr ""
@@ -561,8 +560,8 @@ msgstr ""
 msgid "Expected a Characteristic"
 msgstr ""
 
-#: shared-bindings/bleio/Characteristic.c shared-bindings/bleio/Descriptor.c
-#: shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Descriptor.c shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Characteristic.c
 msgid "Expected a UUID"
 msgstr ""
 
@@ -594,13 +593,13 @@ msgstr ""
 msgid "Failed to add service, err 0x%04x"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "Failed to allocate RX buffer"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr ""
@@ -676,8 +675,8 @@ msgstr ""
 msgid "Failed to start advertising"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, c-format
 msgid "Failed to start advertising, err 0x%04x"
 msgstr ""
@@ -695,8 +694,8 @@ msgstr ""
 msgid "Failed to stop advertising"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, c-format
 msgid "Failed to stop advertising, err 0x%04x"
 msgstr ""
@@ -715,12 +714,30 @@ msgstr ""
 msgid "File exists"
 msgstr ""
 
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash erase failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash erase failed to start, err 0x%04x"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash write failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash write failed to start, err 0x%04x"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/bitbangio/SPI.c
-#: shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/I2C.c
+#: shared-bindings/bitbangio/SPI.c
 msgid "Function requires lock"
 msgstr ""
 
@@ -736,7 +753,7 @@ msgstr ""
 msgid "Group full"
 msgstr ""
 
-#: extmod/vfs_posix_file.c ports/unix/file.c py/objstringio.c
+#: py/objstringio.c ports/unix/file.c extmod/vfs_posix_file.c
 msgid "I/O operation on closed file"
 msgstr ""
 
@@ -762,8 +779,8 @@ msgstr ""
 msgid "Invalid BMP file"
 msgstr ""
 
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PWMOut.c
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
 msgid "Invalid PWM frequency"
 msgstr ""
 
@@ -808,17 +825,17 @@ msgstr ""
 msgid "Invalid format chunk size"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid number of bits"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid phase"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
 #: shared-bindings/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/touchio/TouchIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Invalid pin"
 msgstr ""
 
@@ -830,15 +847,14 @@ msgstr ""
 msgid "Invalid pin for right channel"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/nrf/common-hal/busio/I2C.c ports/atmel-samd/common-hal/busio/I2C.c
 #: ports/atmel-samd/common-hal/busio/SPI.c
 #: ports/atmel-samd/common-hal/busio/UART.c
 #: ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
-#: ports/nrf/common-hal/busio/I2C.c
 msgid "Invalid pins"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid polarity"
 msgstr ""
 
@@ -933,11 +949,11 @@ msgstr ""
 msgid "No PulseIn support for %q"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No RX pin"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No TX pin"
 msgstr ""
 
@@ -969,8 +985,8 @@ msgstr ""
 msgid "No hardware support for analog out."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No hardware support on pin"
 msgstr ""
 
@@ -1046,7 +1062,7 @@ msgid ""
 "PWM frequency not writable when variable_frequency is False on construction."
 msgstr ""
 
-#: ports/esp8266/common-hal/pulseio/PWMOut.c ports/esp8266/machine_pwm.c
+#: ports/esp8266/machine_pwm.c ports/esp8266/common-hal/pulseio/PWMOut.c
 #, c-format
 msgid "PWM not supported on pin %d"
 msgstr ""
@@ -1059,8 +1075,8 @@ msgstr ""
 msgid "Pin %q does not have ADC capabilities"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 #: ports/nrf/common-hal/analogio/AnalogIn.c
+#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 msgid "Pin does not have ADC capabilities"
 msgstr ""
 
@@ -1092,7 +1108,7 @@ msgstr ""
 msgid "RTC calibration is not supported on this board"
 msgstr ""
 
-#: shared-bindings/rtc/RTC.c shared-bindings/time/__init__.c
+#: shared-bindings/time/__init__.c shared-bindings/rtc/RTC.c
 msgid "RTC is not supported on this board"
 msgstr ""
 
@@ -1104,7 +1120,7 @@ msgstr ""
 msgid "Read-only"
 msgstr ""
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: py/moduerrno.c extmod/vfs_fat.c
 msgid "Read-only filesystem"
 msgstr ""
 
@@ -1158,8 +1174,8 @@ msgstr ""
 msgid "Slice and value different lengths."
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/displayio/Group.c
 msgid "Slices not supported"
 msgstr ""
 
@@ -1239,7 +1255,7 @@ msgstr ""
 msgid "Too many channels in sample."
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Too many display busses"
 msgstr ""
 
@@ -1404,7 +1420,7 @@ msgstr ""
 msgid "abort() called"
 msgstr ""
 
-#: extmod/machine_mem.c ports/unix/modmachine.c
+#: ports/unix/modmachine.c extmod/machine_mem.c
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr ""
@@ -1433,7 +1449,7 @@ msgstr ""
 msgid "argument should be a '%q' not a '%q'"
 msgstr ""
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objarray.c
 msgid "array/bytes required on right side"
 msgstr ""
 
@@ -1494,7 +1510,7 @@ msgstr ""
 msgid "buffer size must match format"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "buffer slices must be of equal length"
 msgstr ""
 
@@ -1502,7 +1518,7 @@ msgstr ""
 msgid "buffer too long"
 msgstr ""
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
+#: shared-bindings/struct/__init__.c py/modstruct.c
 #: shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr ""
@@ -1802,8 +1818,8 @@ msgstr ""
 msgid "dict update sequence has wrong length"
 msgstr ""
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/objfloat.c py/runtime.c py/modmath.c
+#: py/objint_longlong.c py/objint_mpz.c
 msgid "division by zero"
 msgstr ""
 
@@ -1815,7 +1831,7 @@ msgstr ""
 msgid "empty"
 msgstr ""
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/modutimeq.c extmod/moduheapq.c
 msgid "empty heap"
 msgstr ""
 
@@ -1888,7 +1904,7 @@ msgstr ""
 msgid "ffi_prep_closure_loc"
 msgstr ""
 
-#: shared-bindings/audioio/WaveFile.c shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/audioio/WaveFile.c
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
@@ -2008,9 +2024,9 @@ msgstr ""
 msgid "incorrect padding"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: py/obj.c ports/nrf/common-hal/pulseio/PulseIn.c
 #: ports/esp8266/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c py/obj.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "index out of range"
 msgstr ""
 
@@ -2058,7 +2074,7 @@ msgstr ""
 msgid "invalid cert"
 msgstr ""
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid data bits"
 msgstr ""
 
@@ -2090,11 +2106,11 @@ msgstr ""
 msgid "invalid step"
 msgstr ""
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid stop bits"
 msgstr ""
 
-#: py/compile.c py/parse.c
+#: py/parse.c py/compile.c
 msgid "invalid syntax"
 msgstr ""
 
@@ -2131,7 +2147,7 @@ msgstr ""
 msgid "keywords must be strings"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 msgid "label '%q' not defined"
 msgstr ""
 
@@ -2171,7 +2187,7 @@ msgstr ""
 msgid "map buffer too small"
 msgstr ""
 
-#: py/modmath.c shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/modmath.c
 msgid "math domain error"
 msgstr ""
 
@@ -2246,11 +2262,11 @@ msgstr ""
 msgid "need more than %d values to unpack"
 msgstr ""
 
-#: py/objint_longlong.c py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_longlong.c py/objint_mpz.c
 msgid "negative power with no float support"
 msgstr ""
 
-#: py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_mpz.c
 msgid "negative shift count"
 msgstr ""
 
@@ -2270,7 +2286,7 @@ msgstr ""
 msgid "no module named '%q'"
 msgstr ""
 
-#: py/runtime.c shared-bindings/_pixelbuf/__init__.c
+#: shared-bindings/_pixelbuf/__init__.c py/runtime.c
 msgid "no such attribute"
 msgstr ""
 
@@ -2361,8 +2377,8 @@ msgstr ""
 msgid "offset out of bounds"
 msgstr ""
 
-#: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objstr.c py/objarray.c py/objstrunicode.c
+#: py/objtuple.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr ""
 
@@ -2415,9 +2431,9 @@ msgstr ""
 msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "pop from an empty PulseIn"
 msgstr ""
 
@@ -2496,7 +2512,7 @@ msgstr ""
 msgid "schedule stack full"
 msgstr ""
 
-#: lib/utils/pyexec.c py/builtinimport.c
+#: py/builtinimport.c lib/utils/pyexec.c
 msgid "script compilation not supported"
 msgstr ""
 
@@ -2524,7 +2540,7 @@ msgstr ""
 msgid "slice step cannot be zero"
 msgstr ""
 
-#: py/objint.c py/sequence.c
+#: py/sequence.c py/objint.c
 msgid "small int overflow"
 msgstr ""
 
@@ -2650,7 +2666,7 @@ msgstr ""
 msgid "tuple/list required on RHS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "tx and rx cannot both be None"
 msgstr ""
 

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-12 11:17-0700\n"
+"POT-Creation-Date: 2019-03-18 09:56-0400\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: Pascal Deneaux\n"
 "Language-Team: Sebastian Plamauer, Pascal Deneaux\n"
@@ -54,8 +54,8 @@ msgstr "Der Index %q befindet sich außerhalb der Reihung"
 msgid "%q indices must be integers, not %s"
 msgstr "%q Indizes müssen ganze Zahlen sein, nicht %s"
 
+#: shared-bindings/displayio/Shape.c shared-bindings/displayio/Group.c
 #: shared-bindings/bleio/CharacteristicBuffer.c
-#: shared-bindings/displayio/Group.c shared-bindings/displayio/Shape.c
 msgid "%q must be >= 1"
 msgstr "%q muss >= 1 sein"
 
@@ -71,12 +71,12 @@ msgstr "%q() nimmt %d Argumente ohne Keyword an, aber es wurden %d angegeben"
 msgid "'%q' argument required"
 msgstr "'%q' Argument erforderlich"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a label"
 msgstr "'%s' erwartet ein Label"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a register"
 msgstr "'%s' erwartet ein Register"
@@ -96,7 +96,7 @@ msgstr "'%s' erwartet ein FPU-Register"
 msgid "'%s' expects an address of the form [a, b]"
 msgstr "'%s' erwartet eine Adresse in der Form [a, b]"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects an integer"
 msgstr "'%s' erwartet ein Integer"
@@ -257,11 +257,10 @@ msgstr "Alle sync event Kanäle werden benutzt"
 msgid "All timers for this pin are in use"
 msgstr "Alle timer für diesen Pin werden bereits benutzt"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PulseOut.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
-#: ports/nrf/common-hal/pulseio/PulseOut.c shared-bindings/pulseio/PWMOut.c
-#: shared-module/_pew/PewPew.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c shared-module/_pew/PewPew.c
 msgid "All timers in use"
 msgstr "Alle timer werden benutzt"
 
@@ -330,12 +329,12 @@ msgstr "Die Helligkeit ist nicht einstellbar"
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr "Der Puffergröße ist inkorrekt. Sie sollte %d bytes haben."
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
+#: shared-bindings/busio/I2C.c shared-bindings/bitbangio/I2C.c
 msgid "Buffer must be at least length 1"
 msgstr "Der Puffer muss eine Mindestenslänge von 1 haben"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, c-format
 msgid "Bus pin %d is already in use"
 msgstr "Bus pin %d wird schon benutzt"
@@ -377,7 +376,7 @@ msgstr "Im Peripheral mode kann keine Verbindung hergestellt werden"
 msgid "Cannot connect to AP"
 msgstr "Kann nicht zu AP verbinden"
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
 msgid "Cannot delete values"
 msgstr "Kann Werte nicht löschen"
 
@@ -385,8 +384,8 @@ msgstr "Kann Werte nicht löschen"
 msgid "Cannot disconnect from AP"
 msgstr "Kann nicht trennen von AP"
 
-#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr "Pull up im Ausgabemodus nicht möglich"
 
@@ -410,8 +409,8 @@ msgstr "Aufnahme in eine Datei nicht möglich"
 msgid "Cannot remount '/' when USB is active."
 msgstr "Kann '/' nicht remounten when USB aktiv ist"
 
-#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/esp8266/common-hal/microcontroller/__init__.c
+#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr "Reset zum bootloader nicht möglich da bootloader nicht vorhanden"
 
@@ -471,7 +470,7 @@ msgstr "Clock unit wird benutzt"
 msgid "Column entry must be digitalio.DigitalInOut"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Command must be an int between 0 and 255"
 msgstr "Der Befehl muss ein int zwischen 0 und 255 sein"
 
@@ -500,8 +499,8 @@ msgstr "Absturz in HardFault_Handler.\n"
 msgid "DAC already in use"
 msgstr "DAC wird schon benutzt"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 msgid "Data 0 pin must be byte aligned"
 msgstr "Data 0 pin muss am Byte ausgerichtet sein"
 
@@ -509,8 +508,8 @@ msgstr "Data 0 pin muss am Byte ausgerichtet sein"
 msgid "Data chunk must follow fmt chunk"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 msgid "Data too large for advertisement packet"
 msgstr "Zu vielen Daten für das advertisement packet"
 
@@ -543,8 +542,8 @@ msgstr "ESP8226 hat keinen Sicherheitsmodus"
 msgid "ESP8266 does not support pull down."
 msgstr "ESP8266 unterstützt pull down nicht"
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "EXTINT channel already in use"
 msgstr "EXTINT Kanal ist schon in Benutzung"
 
@@ -556,8 +555,8 @@ msgstr "Fehler in ffi_prep_cif"
 msgid "Error in regex"
 msgstr "Fehler in regex"
 
-#: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/microcontroller/Pin.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/neopixel_write/__init__.c
 #: shared-bindings/terminalio/Terminal.c
 msgid "Expected a %q"
 msgstr "Erwartet ein(e) %q"
@@ -566,8 +565,8 @@ msgstr "Erwartet ein(e) %q"
 msgid "Expected a Characteristic"
 msgstr "Characteristic wird erwartet"
 
-#: shared-bindings/bleio/Characteristic.c shared-bindings/bleio/Descriptor.c
-#: shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Descriptor.c shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Characteristic.c
 msgid "Expected a UUID"
 msgstr "Eine UUID wird erwartet"
 
@@ -599,13 +598,13 @@ msgstr "Dienst konnte nicht hinzugefügt werden"
 msgid "Failed to add service, err 0x%04x"
 msgstr "Dienst konnte nicht hinzugefügt werden. Status: 0x%04x"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "Failed to allocate RX buffer"
 msgstr "Konnte keinen RX Buffer allozieren"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr "Konnte keine RX Buffer mit %d allozieren"
@@ -681,8 +680,8 @@ msgstr "Mutex konnte nicht freigegeben werden. Status: 0x%04x"
 msgid "Failed to start advertising"
 msgstr "Kann advertisement nicht starten"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, c-format
 msgid "Failed to start advertising, err 0x%04x"
 msgstr "Kann advertisement nicht starten. Status: 0x%04x"
@@ -700,8 +699,8 @@ msgstr "Der Scanvorgang kann nicht gestartet werden. Status: 0x%04x"
 msgid "Failed to stop advertising"
 msgstr "Kann advertisement nicht stoppen"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, c-format
 msgid "Failed to stop advertising, err 0x%04x"
 msgstr "Kann advertisement nicht stoppen. Status: 0x%04x"
@@ -720,12 +719,30 @@ msgstr "gatts value konnte nicht geschrieben werden. Status: 0x%04x"
 msgid "File exists"
 msgstr "Datei existiert"
 
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash erase failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash erase failed to start, err 0x%04x"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash write failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash write failed to start, err 0x%04x"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/bitbangio/SPI.c
-#: shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/I2C.c
+#: shared-bindings/bitbangio/SPI.c
 msgid "Function requires lock"
 msgstr "Die Funktion erwartet, dass der 'lock'-Befehl zuvor ausgeführt wurde"
 
@@ -741,7 +758,7 @@ msgstr "GPIO16 unterstützt pull up nicht"
 msgid "Group full"
 msgstr "Gruppe voll"
 
-#: extmod/vfs_posix_file.c ports/unix/file.c py/objstringio.c
+#: py/objstringio.c ports/unix/file.c extmod/vfs_posix_file.c
 msgid "I/O operation on closed file"
 msgstr "Lese/Schreibe-operation an geschlossener Datei"
 
@@ -769,8 +786,8 @@ msgstr "Eingabe-/Ausgabefehler"
 msgid "Invalid BMP file"
 msgstr "Ungültige BMP-Datei"
 
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PWMOut.c
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
 msgid "Invalid PWM frequency"
 msgstr "Ungültige PWM Frequenz"
 
@@ -815,17 +832,17 @@ msgstr "Ungültige Datei"
 msgid "Invalid format chunk size"
 msgstr "Ungültige format chunk size"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid number of bits"
 msgstr "Ungültige Anzahl von Bits"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid phase"
 msgstr "Ungültige Phase"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
 #: shared-bindings/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/touchio/TouchIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Invalid pin"
 msgstr "Ungültiger Pin"
 
@@ -837,15 +854,14 @@ msgstr "Ungültiger Pin für linken Kanal"
 msgid "Invalid pin for right channel"
 msgstr "Ungültiger Pin für rechten Kanal"
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/nrf/common-hal/busio/I2C.c ports/atmel-samd/common-hal/busio/I2C.c
 #: ports/atmel-samd/common-hal/busio/SPI.c
 #: ports/atmel-samd/common-hal/busio/UART.c
 #: ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
-#: ports/nrf/common-hal/busio/I2C.c
 msgid "Invalid pins"
 msgstr "Ungültige Pins"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid polarity"
 msgstr "Ungültige Polarität"
 
@@ -949,11 +965,11 @@ msgstr "Kein DMA Kanal gefunden"
 msgid "No PulseIn support for %q"
 msgstr "Keine PulseIn Unterstützung für %q"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No RX pin"
 msgstr "Kein RX Pin"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No TX pin"
 msgstr "Kein TX Pin"
 
@@ -985,8 +1001,8 @@ msgstr "Kein hardware random verfügbar"
 msgid "No hardware support for analog out."
 msgstr "Keine Hardwareunterstützung für analog out"
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No hardware support on pin"
 msgstr "Keine Hardwareunterstützung an diesem Pin"
 
@@ -1065,7 +1081,7 @@ msgid ""
 "PWM frequency not writable when variable_frequency is False on construction."
 msgstr "Die PWM-Frequenz ist nicht schreibbar wenn variable_Frequenz = False."
 
-#: ports/esp8266/common-hal/pulseio/PWMOut.c ports/esp8266/machine_pwm.c
+#: ports/esp8266/machine_pwm.c ports/esp8266/common-hal/pulseio/PWMOut.c
 #, c-format
 msgid "PWM not supported on pin %d"
 msgstr "PWM nicht unterstützt an Pin %d"
@@ -1078,8 +1094,8 @@ msgstr "Zugang verweigert"
 msgid "Pin %q does not have ADC capabilities"
 msgstr "Pin %q hat keine ADC Funktion"
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 #: ports/nrf/common-hal/analogio/AnalogIn.c
+#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 msgid "Pin does not have ADC capabilities"
 msgstr "Pin hat keine ADC Funktionalität"
 
@@ -1113,7 +1129,7 @@ msgstr "Pull wird nicht verwendet, wenn die Richtung output ist."
 msgid "RTC calibration is not supported on this board"
 msgstr "Die RTC-Kalibrierung wird auf diesem Board nicht unterstützt"
 
-#: shared-bindings/rtc/RTC.c shared-bindings/time/__init__.c
+#: shared-bindings/time/__init__.c shared-bindings/rtc/RTC.c
 msgid "RTC is not supported on this board"
 msgstr "Eine RTC wird auf diesem Board nicht unterstützt"
 
@@ -1125,7 +1141,7 @@ msgstr ""
 msgid "Read-only"
 msgstr "Nur lesen möglich, da Schreibgeschützt"
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: py/moduerrno.c extmod/vfs_fat.c
 msgid "Read-only filesystem"
 msgstr "Schreibgeschützte Dateisystem"
 
@@ -1179,8 +1195,8 @@ msgstr "Serializer wird benutzt"
 msgid "Slice and value different lengths."
 msgstr "Slice und Wert (value) haben unterschiedliche Längen."
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/displayio/Group.c
 msgid "Slices not supported"
 msgstr "Slices werden nicht unterstützt"
 
@@ -1272,7 +1288,7 @@ msgstr "Zum beenden, resette bitte das board ohne "
 msgid "Too many channels in sample."
 msgstr "Zu viele Kanäle im sample"
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Too many display busses"
 msgstr ""
 
@@ -1449,7 +1465,7 @@ msgstr "ein Byte-ähnliches Objekt ist erforderlich"
 msgid "abort() called"
 msgstr "abort() wurde aufgerufen"
 
-#: extmod/machine_mem.c ports/unix/modmachine.c
+#: ports/unix/modmachine.c extmod/machine_mem.c
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr "Addresse %08x ist nicht an %d bytes ausgerichtet"
@@ -1478,7 +1494,7 @@ msgstr "Anzahl/Type der Argumente passen nicht"
 msgid "argument should be a '%q' not a '%q'"
 msgstr "Argument sollte '%q' sein, nicht '%q'"
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objarray.c
 msgid "array/bytes required on right side"
 msgstr "Array/Bytes auf der rechten Seite erforderlich"
 
@@ -1539,7 +1555,7 @@ msgstr "Puffer muss ein bytes-artiges Objekt sein"
 msgid "buffer size must match format"
 msgstr "Die Puffergröße muss zum Format passen"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "buffer slices must be of equal length"
 msgstr "Puffersegmente müssen gleich lang sein"
 
@@ -1547,7 +1563,7 @@ msgstr "Puffersegmente müssen gleich lang sein"
 msgid "buffer too long"
 msgstr "Buffer zu lang"
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
+#: shared-bindings/struct/__init__.c py/modstruct.c
 #: shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr "Der Puffer ist zu klein"
@@ -1847,8 +1863,8 @@ msgstr ""
 msgid "dict update sequence has wrong length"
 msgstr ""
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/objfloat.c py/runtime.c py/modmath.c
+#: py/objint_longlong.c py/objint_mpz.c
 msgid "division by zero"
 msgstr "Division durch Null"
 
@@ -1860,7 +1876,7 @@ msgstr ""
 msgid "empty"
 msgstr "leer"
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/modutimeq.c extmod/moduheapq.c
 msgid "empty heap"
 msgstr "leerer heap"
 
@@ -1933,7 +1949,7 @@ msgstr "Es wurden zusätzliche Argumente ohne Keyword angegeben"
 msgid "ffi_prep_closure_loc"
 msgstr "ffi_prep_closure_loc"
 
-#: shared-bindings/audioio/WaveFile.c shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/audioio/WaveFile.c
 msgid "file must be a file opened in byte mode"
 msgstr "Die Datei muss eine im Byte-Modus geöffnete Datei sein"
 
@@ -2054,9 +2070,9 @@ msgstr "unvollständiger Formatschlüssel"
 msgid "incorrect padding"
 msgstr "padding ist inkorrekt"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: py/obj.c ports/nrf/common-hal/pulseio/PulseIn.c
 #: ports/esp8266/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c py/obj.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "index out of range"
 msgstr "index außerhalb der Reichweite"
 
@@ -2104,7 +2120,7 @@ msgstr "ungültige Pufferlänge"
 msgid "invalid cert"
 msgstr "ungültiges cert"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid data bits"
 msgstr "ungültige Datenbits"
 
@@ -2136,11 +2152,11 @@ msgstr "ungültiger Pin"
 msgid "invalid step"
 msgstr "ungültiger Schritt (step)"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid stop bits"
 msgstr "ungültige Stopbits"
 
-#: py/compile.c py/parse.c
+#: py/parse.c py/compile.c
 msgid "invalid syntax"
 msgstr "ungültige Syntax"
 
@@ -2181,7 +2197,7 @@ msgstr ""
 msgid "keywords must be strings"
 msgstr "Schlüsselwörter müssen Zeichenfolgen sein"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 msgid "label '%q' not defined"
 msgstr "Label '%q' nicht definiert"
 
@@ -2223,7 +2239,7 @@ msgstr "long int wird in diesem Build nicht unterstützt"
 msgid "map buffer too small"
 msgstr "map buffer zu klein"
 
-#: py/modmath.c shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/modmath.c
 msgid "math domain error"
 msgstr ""
 
@@ -2299,11 +2315,11 @@ msgstr ""
 msgid "need more than %d values to unpack"
 msgstr ""
 
-#: py/objint_longlong.c py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_longlong.c py/objint_mpz.c
 msgid "negative power with no float support"
 msgstr ""
 
-#: py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_mpz.c
 msgid "negative shift count"
 msgstr ""
 
@@ -2323,7 +2339,7 @@ msgstr ""
 msgid "no module named '%q'"
 msgstr "Kein Modul mit dem Namen '%q'"
 
-#: py/runtime.c shared-bindings/_pixelbuf/__init__.c
+#: shared-bindings/_pixelbuf/__init__.c py/runtime.c
 msgid "no such attribute"
 msgstr ""
 
@@ -2414,8 +2430,8 @@ msgstr "String mit ungerader Länge"
 msgid "offset out of bounds"
 msgstr "offset außerhalb der Grenzen"
 
-#: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objstr.c py/objarray.c py/objstrunicode.c
+#: py/objtuple.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr ""
 
@@ -2470,9 +2486,9 @@ msgstr ""
 msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr "pixel_shader muss displayio.Palette oder displayio.ColorConverter sein"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "pop from an empty PulseIn"
 msgstr "pop von einem leeren PulseIn"
 
@@ -2553,7 +2569,7 @@ msgstr "Scan fehlgeschlagen"
 msgid "schedule stack full"
 msgstr "Der schedule stack ist voll"
 
-#: lib/utils/pyexec.c py/builtinimport.c
+#: py/builtinimport.c lib/utils/pyexec.c
 msgid "script compilation not supported"
 msgstr "kompilieren von Skripten ist nicht unterstützt"
 
@@ -2581,7 +2597,7 @@ msgstr ""
 msgid "slice step cannot be zero"
 msgstr ""
 
-#: py/objint.c py/sequence.c
+#: py/sequence.c py/objint.c
 msgid "small int overflow"
 msgstr "small int Überlauf"
 
@@ -2708,7 +2724,7 @@ msgstr "tupel/list hat falsche Länge"
 msgid "tuple/list required on RHS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "tx and rx cannot both be None"
 msgstr "tx und rx können nicht beide None sein"
 

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-12 11:17-0700\n"
+"POT-Creation-Date: 2019-03-18 09:56-0400\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -52,8 +52,8 @@ msgstr ""
 msgid "%q indices must be integers, not %s"
 msgstr ""
 
+#: shared-bindings/displayio/Shape.c shared-bindings/displayio/Group.c
 #: shared-bindings/bleio/CharacteristicBuffer.c
-#: shared-bindings/displayio/Group.c shared-bindings/displayio/Shape.c
 msgid "%q must be >= 1"
 msgstr ""
 
@@ -69,12 +69,12 @@ msgstr ""
 msgid "'%q' argument required"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a label"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a register"
 msgstr ""
@@ -94,7 +94,7 @@ msgstr ""
 msgid "'%s' expects an address of the form [a, b]"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects an integer"
 msgstr ""
@@ -255,11 +255,10 @@ msgstr ""
 msgid "All timers for this pin are in use"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PulseOut.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
-#: ports/nrf/common-hal/pulseio/PulseOut.c shared-bindings/pulseio/PWMOut.c
-#: shared-module/_pew/PewPew.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c shared-module/_pew/PewPew.c
 msgid "All timers in use"
 msgstr ""
 
@@ -326,12 +325,12 @@ msgstr ""
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
+#: shared-bindings/busio/I2C.c shared-bindings/bitbangio/I2C.c
 msgid "Buffer must be at least length 1"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, c-format
 msgid "Bus pin %d is already in use"
 msgstr ""
@@ -373,7 +372,7 @@ msgstr ""
 msgid "Cannot connect to AP"
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
 msgid "Cannot delete values"
 msgstr ""
 
@@ -381,8 +380,8 @@ msgstr ""
 msgid "Cannot disconnect from AP"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -406,8 +405,8 @@ msgstr ""
 msgid "Cannot remount '/' when USB is active."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/esp8266/common-hal/microcontroller/__init__.c
+#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 
@@ -467,7 +466,7 @@ msgstr ""
 msgid "Column entry must be digitalio.DigitalInOut"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Command must be an int between 0 and 255"
 msgstr ""
 
@@ -496,8 +495,8 @@ msgstr ""
 msgid "DAC already in use"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 msgid "Data 0 pin must be byte aligned"
 msgstr ""
 
@@ -505,8 +504,8 @@ msgstr ""
 msgid "Data chunk must follow fmt chunk"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 msgid "Data too large for advertisement packet"
 msgstr ""
 
@@ -538,8 +537,8 @@ msgstr ""
 msgid "ESP8266 does not support pull down."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "EXTINT channel already in use"
 msgstr ""
 
@@ -551,8 +550,8 @@ msgstr ""
 msgid "Error in regex"
 msgstr ""
 
-#: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/microcontroller/Pin.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/neopixel_write/__init__.c
 #: shared-bindings/terminalio/Terminal.c
 msgid "Expected a %q"
 msgstr ""
@@ -561,8 +560,8 @@ msgstr ""
 msgid "Expected a Characteristic"
 msgstr ""
 
-#: shared-bindings/bleio/Characteristic.c shared-bindings/bleio/Descriptor.c
-#: shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Descriptor.c shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Characteristic.c
 msgid "Expected a UUID"
 msgstr ""
 
@@ -594,13 +593,13 @@ msgstr ""
 msgid "Failed to add service, err 0x%04x"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "Failed to allocate RX buffer"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr ""
@@ -676,8 +675,8 @@ msgstr ""
 msgid "Failed to start advertising"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, c-format
 msgid "Failed to start advertising, err 0x%04x"
 msgstr ""
@@ -695,8 +694,8 @@ msgstr ""
 msgid "Failed to stop advertising"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, c-format
 msgid "Failed to stop advertising, err 0x%04x"
 msgstr ""
@@ -715,12 +714,30 @@ msgstr ""
 msgid "File exists"
 msgstr ""
 
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash erase failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash erase failed to start, err 0x%04x"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash write failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash write failed to start, err 0x%04x"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/bitbangio/SPI.c
-#: shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/I2C.c
+#: shared-bindings/bitbangio/SPI.c
 msgid "Function requires lock"
 msgstr ""
 
@@ -736,7 +753,7 @@ msgstr ""
 msgid "Group full"
 msgstr ""
 
-#: extmod/vfs_posix_file.c ports/unix/file.c py/objstringio.c
+#: py/objstringio.c ports/unix/file.c extmod/vfs_posix_file.c
 msgid "I/O operation on closed file"
 msgstr ""
 
@@ -762,8 +779,8 @@ msgstr ""
 msgid "Invalid BMP file"
 msgstr ""
 
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PWMOut.c
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
 msgid "Invalid PWM frequency"
 msgstr ""
 
@@ -808,17 +825,17 @@ msgstr ""
 msgid "Invalid format chunk size"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid number of bits"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid phase"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
 #: shared-bindings/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/touchio/TouchIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Invalid pin"
 msgstr ""
 
@@ -830,15 +847,14 @@ msgstr ""
 msgid "Invalid pin for right channel"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/nrf/common-hal/busio/I2C.c ports/atmel-samd/common-hal/busio/I2C.c
 #: ports/atmel-samd/common-hal/busio/SPI.c
 #: ports/atmel-samd/common-hal/busio/UART.c
 #: ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
-#: ports/nrf/common-hal/busio/I2C.c
 msgid "Invalid pins"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid polarity"
 msgstr ""
 
@@ -933,11 +949,11 @@ msgstr ""
 msgid "No PulseIn support for %q"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No RX pin"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No TX pin"
 msgstr ""
 
@@ -969,8 +985,8 @@ msgstr ""
 msgid "No hardware support for analog out."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No hardware support on pin"
 msgstr ""
 
@@ -1046,7 +1062,7 @@ msgid ""
 "PWM frequency not writable when variable_frequency is False on construction."
 msgstr ""
 
-#: ports/esp8266/common-hal/pulseio/PWMOut.c ports/esp8266/machine_pwm.c
+#: ports/esp8266/machine_pwm.c ports/esp8266/common-hal/pulseio/PWMOut.c
 #, c-format
 msgid "PWM not supported on pin %d"
 msgstr ""
@@ -1059,8 +1075,8 @@ msgstr ""
 msgid "Pin %q does not have ADC capabilities"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 #: ports/nrf/common-hal/analogio/AnalogIn.c
+#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 msgid "Pin does not have ADC capabilities"
 msgstr ""
 
@@ -1092,7 +1108,7 @@ msgstr ""
 msgid "RTC calibration is not supported on this board"
 msgstr ""
 
-#: shared-bindings/rtc/RTC.c shared-bindings/time/__init__.c
+#: shared-bindings/time/__init__.c shared-bindings/rtc/RTC.c
 msgid "RTC is not supported on this board"
 msgstr ""
 
@@ -1104,7 +1120,7 @@ msgstr ""
 msgid "Read-only"
 msgstr ""
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: py/moduerrno.c extmod/vfs_fat.c
 msgid "Read-only filesystem"
 msgstr ""
 
@@ -1158,8 +1174,8 @@ msgstr ""
 msgid "Slice and value different lengths."
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/displayio/Group.c
 msgid "Slices not supported"
 msgstr ""
 
@@ -1239,7 +1255,7 @@ msgstr ""
 msgid "Too many channels in sample."
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Too many display busses"
 msgstr ""
 
@@ -1404,7 +1420,7 @@ msgstr ""
 msgid "abort() called"
 msgstr ""
 
-#: extmod/machine_mem.c ports/unix/modmachine.c
+#: ports/unix/modmachine.c extmod/machine_mem.c
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr ""
@@ -1433,7 +1449,7 @@ msgstr ""
 msgid "argument should be a '%q' not a '%q'"
 msgstr ""
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objarray.c
 msgid "array/bytes required on right side"
 msgstr ""
 
@@ -1494,7 +1510,7 @@ msgstr ""
 msgid "buffer size must match format"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "buffer slices must be of equal length"
 msgstr ""
 
@@ -1502,7 +1518,7 @@ msgstr ""
 msgid "buffer too long"
 msgstr ""
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
+#: shared-bindings/struct/__init__.c py/modstruct.c
 #: shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr ""
@@ -1802,8 +1818,8 @@ msgstr ""
 msgid "dict update sequence has wrong length"
 msgstr ""
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/objfloat.c py/runtime.c py/modmath.c
+#: py/objint_longlong.c py/objint_mpz.c
 msgid "division by zero"
 msgstr ""
 
@@ -1815,7 +1831,7 @@ msgstr ""
 msgid "empty"
 msgstr ""
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/modutimeq.c extmod/moduheapq.c
 msgid "empty heap"
 msgstr ""
 
@@ -1888,7 +1904,7 @@ msgstr ""
 msgid "ffi_prep_closure_loc"
 msgstr ""
 
-#: shared-bindings/audioio/WaveFile.c shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/audioio/WaveFile.c
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
@@ -2008,9 +2024,9 @@ msgstr ""
 msgid "incorrect padding"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: py/obj.c ports/nrf/common-hal/pulseio/PulseIn.c
 #: ports/esp8266/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c py/obj.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "index out of range"
 msgstr ""
 
@@ -2058,7 +2074,7 @@ msgstr ""
 msgid "invalid cert"
 msgstr ""
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid data bits"
 msgstr ""
 
@@ -2090,11 +2106,11 @@ msgstr ""
 msgid "invalid step"
 msgstr ""
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid stop bits"
 msgstr ""
 
-#: py/compile.c py/parse.c
+#: py/parse.c py/compile.c
 msgid "invalid syntax"
 msgstr ""
 
@@ -2131,7 +2147,7 @@ msgstr ""
 msgid "keywords must be strings"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 msgid "label '%q' not defined"
 msgstr ""
 
@@ -2171,7 +2187,7 @@ msgstr ""
 msgid "map buffer too small"
 msgstr ""
 
-#: py/modmath.c shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/modmath.c
 msgid "math domain error"
 msgstr ""
 
@@ -2246,11 +2262,11 @@ msgstr ""
 msgid "need more than %d values to unpack"
 msgstr ""
 
-#: py/objint_longlong.c py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_longlong.c py/objint_mpz.c
 msgid "negative power with no float support"
 msgstr ""
 
-#: py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_mpz.c
 msgid "negative shift count"
 msgstr ""
 
@@ -2270,7 +2286,7 @@ msgstr ""
 msgid "no module named '%q'"
 msgstr ""
 
-#: py/runtime.c shared-bindings/_pixelbuf/__init__.c
+#: shared-bindings/_pixelbuf/__init__.c py/runtime.c
 msgid "no such attribute"
 msgstr ""
 
@@ -2361,8 +2377,8 @@ msgstr ""
 msgid "offset out of bounds"
 msgstr ""
 
-#: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objstr.c py/objarray.c py/objstrunicode.c
+#: py/objtuple.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr ""
 
@@ -2415,9 +2431,9 @@ msgstr ""
 msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "pop from an empty PulseIn"
 msgstr ""
 
@@ -2496,7 +2512,7 @@ msgstr ""
 msgid "schedule stack full"
 msgstr ""
 
-#: lib/utils/pyexec.c py/builtinimport.c
+#: py/builtinimport.c lib/utils/pyexec.c
 msgid "script compilation not supported"
 msgstr ""
 
@@ -2524,7 +2540,7 @@ msgstr ""
 msgid "slice step cannot be zero"
 msgstr ""
 
-#: py/objint.c py/sequence.c
+#: py/sequence.c py/objint.c
 msgid "small int overflow"
 msgstr ""
 
@@ -2650,7 +2666,7 @@ msgstr ""
 msgid "tuple/list required on RHS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "tx and rx cannot both be None"
 msgstr ""
 

--- a/locale/en_x_pirate.po
+++ b/locale/en_x_pirate.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-12 11:17-0700\n"
+"POT-Creation-Date: 2019-03-18 09:56-0400\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: @sommersoft, @MrCertainly\n"
@@ -54,8 +54,8 @@ msgstr ""
 msgid "%q indices must be integers, not %s"
 msgstr ""
 
+#: shared-bindings/displayio/Shape.c shared-bindings/displayio/Group.c
 #: shared-bindings/bleio/CharacteristicBuffer.c
-#: shared-bindings/displayio/Group.c shared-bindings/displayio/Shape.c
 msgid "%q must be >= 1"
 msgstr ""
 
@@ -71,12 +71,12 @@ msgstr ""
 msgid "'%q' argument required"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a label"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a register"
 msgstr ""
@@ -96,7 +96,7 @@ msgstr ""
 msgid "'%s' expects an address of the form [a, b]"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects an integer"
 msgstr ""
@@ -257,11 +257,10 @@ msgstr ""
 msgid "All timers for this pin are in use"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PulseOut.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
-#: ports/nrf/common-hal/pulseio/PulseOut.c shared-bindings/pulseio/PWMOut.c
-#: shared-module/_pew/PewPew.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c shared-module/_pew/PewPew.c
 msgid "All timers in use"
 msgstr ""
 
@@ -330,12 +329,12 @@ msgstr ""
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
+#: shared-bindings/busio/I2C.c shared-bindings/bitbangio/I2C.c
 msgid "Buffer must be at least length 1"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, c-format
 msgid "Bus pin %d is already in use"
 msgstr "Belay that! Bus pin %d already be in use"
@@ -377,7 +376,7 @@ msgstr ""
 msgid "Cannot connect to AP"
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
 msgid "Cannot delete values"
 msgstr ""
 
@@ -385,8 +384,8 @@ msgstr ""
 msgid "Cannot disconnect from AP"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -410,8 +409,8 @@ msgstr ""
 msgid "Cannot remount '/' when USB is active."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/esp8266/common-hal/microcontroller/__init__.c
+#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 
@@ -471,7 +470,7 @@ msgstr ""
 msgid "Column entry must be digitalio.DigitalInOut"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Command must be an int between 0 and 255"
 msgstr ""
 
@@ -500,8 +499,8 @@ msgstr ""
 msgid "DAC already in use"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 msgid "Data 0 pin must be byte aligned"
 msgstr ""
 
@@ -509,8 +508,8 @@ msgstr ""
 msgid "Data chunk must follow fmt chunk"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 msgid "Data too large for advertisement packet"
 msgstr ""
 
@@ -542,8 +541,8 @@ msgstr ""
 msgid "ESP8266 does not support pull down."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "EXTINT channel already in use"
 msgstr "Avast! EXTINT channel already in use"
 
@@ -555,8 +554,8 @@ msgstr ""
 msgid "Error in regex"
 msgstr ""
 
-#: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/microcontroller/Pin.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/neopixel_write/__init__.c
 #: shared-bindings/terminalio/Terminal.c
 msgid "Expected a %q"
 msgstr ""
@@ -565,8 +564,8 @@ msgstr ""
 msgid "Expected a Characteristic"
 msgstr ""
 
-#: shared-bindings/bleio/Characteristic.c shared-bindings/bleio/Descriptor.c
-#: shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Descriptor.c shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Characteristic.c
 msgid "Expected a UUID"
 msgstr ""
 
@@ -598,13 +597,13 @@ msgstr ""
 msgid "Failed to add service, err 0x%04x"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "Failed to allocate RX buffer"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr ""
@@ -680,8 +679,8 @@ msgstr ""
 msgid "Failed to start advertising"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, c-format
 msgid "Failed to start advertising, err 0x%04x"
 msgstr ""
@@ -699,8 +698,8 @@ msgstr ""
 msgid "Failed to stop advertising"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, c-format
 msgid "Failed to stop advertising, err 0x%04x"
 msgstr ""
@@ -719,12 +718,30 @@ msgstr ""
 msgid "File exists"
 msgstr ""
 
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash erase failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash erase failed to start, err 0x%04x"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash write failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash write failed to start, err 0x%04x"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/bitbangio/SPI.c
-#: shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/I2C.c
+#: shared-bindings/bitbangio/SPI.c
 msgid "Function requires lock"
 msgstr ""
 
@@ -740,7 +757,7 @@ msgstr ""
 msgid "Group full"
 msgstr ""
 
-#: extmod/vfs_posix_file.c ports/unix/file.c py/objstringio.c
+#: py/objstringio.c ports/unix/file.c extmod/vfs_posix_file.c
 msgid "I/O operation on closed file"
 msgstr ""
 
@@ -766,8 +783,8 @@ msgstr ""
 msgid "Invalid BMP file"
 msgstr ""
 
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PWMOut.c
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
 msgid "Invalid PWM frequency"
 msgstr ""
 
@@ -812,17 +829,17 @@ msgstr ""
 msgid "Invalid format chunk size"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid number of bits"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid phase"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
 #: shared-bindings/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/touchio/TouchIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Invalid pin"
 msgstr ""
 
@@ -834,15 +851,14 @@ msgstr "Belay that! Invalid pin for port-side channel"
 msgid "Invalid pin for right channel"
 msgstr "Belay that! Invalid pin for starboard-side channel"
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/nrf/common-hal/busio/I2C.c ports/atmel-samd/common-hal/busio/I2C.c
 #: ports/atmel-samd/common-hal/busio/SPI.c
 #: ports/atmel-samd/common-hal/busio/UART.c
 #: ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
-#: ports/nrf/common-hal/busio/I2C.c
 msgid "Invalid pins"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid polarity"
 msgstr ""
 
@@ -937,11 +953,11 @@ msgstr ""
 msgid "No PulseIn support for %q"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No RX pin"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No TX pin"
 msgstr ""
 
@@ -973,8 +989,8 @@ msgstr ""
 msgid "No hardware support for analog out."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No hardware support on pin"
 msgstr ""
 
@@ -1050,7 +1066,7 @@ msgid ""
 "PWM frequency not writable when variable_frequency is False on construction."
 msgstr ""
 
-#: ports/esp8266/common-hal/pulseio/PWMOut.c ports/esp8266/machine_pwm.c
+#: ports/esp8266/machine_pwm.c ports/esp8266/common-hal/pulseio/PWMOut.c
 #, c-format
 msgid "PWM not supported on pin %d"
 msgstr ""
@@ -1063,8 +1079,8 @@ msgstr ""
 msgid "Pin %q does not have ADC capabilities"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 #: ports/nrf/common-hal/analogio/AnalogIn.c
+#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 msgid "Pin does not have ADC capabilities"
 msgstr "Belay that! Th' Pin be not ADC capable"
 
@@ -1096,7 +1112,7 @@ msgstr ""
 msgid "RTC calibration is not supported on this board"
 msgstr ""
 
-#: shared-bindings/rtc/RTC.c shared-bindings/time/__init__.c
+#: shared-bindings/time/__init__.c shared-bindings/rtc/RTC.c
 msgid "RTC is not supported on this board"
 msgstr ""
 
@@ -1108,7 +1124,7 @@ msgstr ""
 msgid "Read-only"
 msgstr ""
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: py/moduerrno.c extmod/vfs_fat.c
 msgid "Read-only filesystem"
 msgstr ""
 
@@ -1162,8 +1178,8 @@ msgstr ""
 msgid "Slice and value different lengths."
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/displayio/Group.c
 msgid "Slices not supported"
 msgstr ""
 
@@ -1243,7 +1259,7 @@ msgstr ""
 msgid "Too many channels in sample."
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Too many display busses"
 msgstr ""
 
@@ -1408,7 +1424,7 @@ msgstr ""
 msgid "abort() called"
 msgstr ""
 
-#: extmod/machine_mem.c ports/unix/modmachine.c
+#: ports/unix/modmachine.c extmod/machine_mem.c
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr ""
@@ -1437,7 +1453,7 @@ msgstr ""
 msgid "argument should be a '%q' not a '%q'"
 msgstr ""
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objarray.c
 msgid "array/bytes required on right side"
 msgstr ""
 
@@ -1498,7 +1514,7 @@ msgstr ""
 msgid "buffer size must match format"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "buffer slices must be of equal length"
 msgstr ""
 
@@ -1506,7 +1522,7 @@ msgstr ""
 msgid "buffer too long"
 msgstr ""
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
+#: shared-bindings/struct/__init__.c py/modstruct.c
 #: shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr ""
@@ -1806,8 +1822,8 @@ msgstr ""
 msgid "dict update sequence has wrong length"
 msgstr ""
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/objfloat.c py/runtime.c py/modmath.c
+#: py/objint_longlong.c py/objint_mpz.c
 msgid "division by zero"
 msgstr ""
 
@@ -1819,7 +1835,7 @@ msgstr ""
 msgid "empty"
 msgstr ""
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/modutimeq.c extmod/moduheapq.c
 msgid "empty heap"
 msgstr ""
 
@@ -1892,7 +1908,7 @@ msgstr ""
 msgid "ffi_prep_closure_loc"
 msgstr ""
 
-#: shared-bindings/audioio/WaveFile.c shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/audioio/WaveFile.c
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
@@ -2012,9 +2028,9 @@ msgstr ""
 msgid "incorrect padding"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: py/obj.c ports/nrf/common-hal/pulseio/PulseIn.c
 #: ports/esp8266/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c py/obj.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "index out of range"
 msgstr ""
 
@@ -2062,7 +2078,7 @@ msgstr ""
 msgid "invalid cert"
 msgstr ""
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid data bits"
 msgstr ""
 
@@ -2094,11 +2110,11 @@ msgstr ""
 msgid "invalid step"
 msgstr ""
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid stop bits"
 msgstr ""
 
-#: py/compile.c py/parse.c
+#: py/parse.c py/compile.c
 msgid "invalid syntax"
 msgstr ""
 
@@ -2135,7 +2151,7 @@ msgstr ""
 msgid "keywords must be strings"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 msgid "label '%q' not defined"
 msgstr ""
 
@@ -2175,7 +2191,7 @@ msgstr ""
 msgid "map buffer too small"
 msgstr ""
 
-#: py/modmath.c shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/modmath.c
 msgid "math domain error"
 msgstr ""
 
@@ -2250,11 +2266,11 @@ msgstr ""
 msgid "need more than %d values to unpack"
 msgstr ""
 
-#: py/objint_longlong.c py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_longlong.c py/objint_mpz.c
 msgid "negative power with no float support"
 msgstr ""
 
-#: py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_mpz.c
 msgid "negative shift count"
 msgstr ""
 
@@ -2274,7 +2290,7 @@ msgstr ""
 msgid "no module named '%q'"
 msgstr ""
 
-#: py/runtime.c shared-bindings/_pixelbuf/__init__.c
+#: shared-bindings/_pixelbuf/__init__.c py/runtime.c
 msgid "no such attribute"
 msgstr ""
 
@@ -2365,8 +2381,8 @@ msgstr ""
 msgid "offset out of bounds"
 msgstr ""
 
-#: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objstr.c py/objarray.c py/objstrunicode.c
+#: py/objtuple.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr ""
 
@@ -2419,9 +2435,9 @@ msgstr ""
 msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "pop from an empty PulseIn"
 msgstr ""
 
@@ -2500,7 +2516,7 @@ msgstr ""
 msgid "schedule stack full"
 msgstr ""
 
-#: lib/utils/pyexec.c py/builtinimport.c
+#: py/builtinimport.c lib/utils/pyexec.c
 msgid "script compilation not supported"
 msgstr ""
 
@@ -2528,7 +2544,7 @@ msgstr ""
 msgid "slice step cannot be zero"
 msgstr ""
 
-#: py/objint.c py/sequence.c
+#: py/sequence.c py/objint.c
 msgid "small int overflow"
 msgstr ""
 
@@ -2654,7 +2670,7 @@ msgstr ""
 msgid "tuple/list required on RHS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "tx and rx cannot both be None"
 msgstr ""
 

--- a/locale/es.po
+++ b/locale/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-12 11:17-0700\n"
+"POT-Creation-Date: 2019-03-18 09:56-0400\n"
 "PO-Revision-Date: 2018-08-24 22:56-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -53,8 +53,8 @@ msgstr "%w indice fuera de rango"
 msgid "%q indices must be integers, not %s"
 msgstr "%q indices deben ser enteros, no %s"
 
+#: shared-bindings/displayio/Shape.c shared-bindings/displayio/Group.c
 #: shared-bindings/bleio/CharacteristicBuffer.c
-#: shared-bindings/displayio/Group.c shared-bindings/displayio/Shape.c
 #, fuzzy
 msgid "%q must be >= 1"
 msgstr "los buffers deben de tener la misma longitud"
@@ -72,12 +72,12 @@ msgstr "%q() toma %d argumentos posicionales pero %d fueron dados"
 msgid "'%q' argument required"
 msgstr "argumento '%q' requerido"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a label"
 msgstr "'%s' espera una etiqueta"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a register"
 msgstr "'%s' espera un registro"
@@ -97,7 +97,7 @@ msgstr "'%s' espera un registro de FPU"
 msgid "'%s' expects an address of the form [a, b]"
 msgstr "'%s' espera una dirección de forma [a, b]"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects an integer"
 msgstr "'%s' espera un entero"
@@ -262,11 +262,10 @@ msgstr ""
 msgid "All timers for this pin are in use"
 msgstr "Todos los timers para este pin están siendo utilizados"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PulseOut.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
-#: ports/nrf/common-hal/pulseio/PulseOut.c shared-bindings/pulseio/PWMOut.c
-#: shared-module/_pew/PewPew.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c shared-module/_pew/PewPew.c
 msgid "All timers in use"
 msgstr "Todos los timers en uso"
 
@@ -335,12 +334,12 @@ msgstr ""
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr "Tamaño de buffer incorrecto. Debe ser de %d bytes."
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
+#: shared-bindings/busio/I2C.c shared-bindings/bitbangio/I2C.c
 msgid "Buffer must be at least length 1"
 msgstr "Buffer debe ser de longitud 1 como minimo"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, fuzzy, c-format
 msgid "Bus pin %d is already in use"
 msgstr "DAC ya está siendo utilizado"
@@ -383,7 +382,7 @@ msgstr "No se puede conectar en modo Peripheral"
 msgid "Cannot connect to AP"
 msgstr "No se puede conectar a AP"
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
 msgid "Cannot delete values"
 msgstr "No se puede eliminar valores"
 
@@ -391,8 +390,8 @@ msgstr "No se puede eliminar valores"
 msgid "Cannot disconnect from AP"
 msgstr "No se puede desconectar de AP"
 
-#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr "No puede ser pull mientras este en modo de salida"
 
@@ -417,8 +416,8 @@ msgstr "No se puede grabar en un archivo"
 msgid "Cannot remount '/' when USB is active."
 msgstr "No se puede volver a montar '/' cuando el USB esta activo."
 
-#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/esp8266/common-hal/microcontroller/__init__.c
+#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr "No se puede reiniciar a bootloader porque no hay bootloader presente."
 
@@ -478,7 +477,7 @@ msgstr "Clock unit está siendo utilizado"
 msgid "Column entry must be digitalio.DigitalInOut"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 #, fuzzy
 msgid "Command must be an int between 0 and 255"
 msgstr "Bytes debe estar entre 0 y 255."
@@ -508,8 +507,8 @@ msgstr ""
 msgid "DAC already in use"
 msgstr "DAC ya está siendo utilizado"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, fuzzy
 msgid "Data 0 pin must be byte aligned"
 msgstr "graphic debe ser 2048 bytes de largo"
@@ -518,8 +517,8 @@ msgstr "graphic debe ser 2048 bytes de largo"
 msgid "Data chunk must follow fmt chunk"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy
 msgid "Data too large for advertisement packet"
 msgstr "Los datos no caben en el paquete de anuncio."
@@ -553,8 +552,8 @@ msgstr "ESP8226 no soporta modo seguro."
 msgid "ESP8266 does not support pull down."
 msgstr "ESP8266 no soporta pull down."
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "EXTINT channel already in use"
 msgstr "El canal EXTINT ya está siendo utilizado"
 
@@ -566,8 +565,8 @@ msgstr "Error en ffi_prep_cif"
 msgid "Error in regex"
 msgstr "Error en regex"
 
-#: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/microcontroller/Pin.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/neopixel_write/__init__.c
 #: shared-bindings/terminalio/Terminal.c
 msgid "Expected a %q"
 msgstr "Se espera un %q"
@@ -577,8 +576,8 @@ msgstr "Se espera un %q"
 msgid "Expected a Characteristic"
 msgstr "No se puede agregar la Característica."
 
-#: shared-bindings/bleio/Characteristic.c shared-bindings/bleio/Descriptor.c
-#: shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Descriptor.c shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Characteristic.c
 #, fuzzy
 msgid "Expected a UUID"
 msgstr "Se espera un %q"
@@ -613,13 +612,13 @@ msgstr "No se puede detener el anuncio. status: 0x%02x"
 msgid "Failed to add service, err 0x%04x"
 msgstr "No se puede detener el anuncio. status: 0x%02x"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "Failed to allocate RX buffer"
 msgstr "Ha fallado la asignación del buffer RX"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr "Falló la asignación del buffer RX de %d bytes"
@@ -704,8 +703,8 @@ msgstr "No se puede liberar el mutex, status: 0x%08lX"
 msgid "Failed to start advertising"
 msgstr "No se puede inicar el anuncio. status: 0x%02x"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to start advertising, err 0x%04x"
 msgstr "No se puede inicar el anuncio. status: 0x%02x"
@@ -725,8 +724,8 @@ msgstr "No se puede iniciar el escaneo. status: 0x%02x"
 msgid "Failed to stop advertising"
 msgstr "No se puede detener el anuncio. status: 0x%02x"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to stop advertising, err 0x%04x"
 msgstr "No se puede detener el anuncio. status: 0x%02x"
@@ -745,12 +744,30 @@ msgstr "No se puede escribir el valor del atributo. status: 0x%02x"
 msgid "File exists"
 msgstr "El archivo ya existe"
 
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash erase failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash erase failed to start, err 0x%04x"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash write failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash write failed to start, err 0x%04x"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/bitbangio/SPI.c
-#: shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/I2C.c
+#: shared-bindings/bitbangio/SPI.c
 msgid "Function requires lock"
 msgstr "La función requiere lock"
 
@@ -766,7 +783,7 @@ msgstr "GPIO16 no soporta pull up."
 msgid "Group full"
 msgstr "Group lleno"
 
-#: extmod/vfs_posix_file.c ports/unix/file.c py/objstringio.c
+#: py/objstringio.c ports/unix/file.c extmod/vfs_posix_file.c
 msgid "I/O operation on closed file"
 msgstr "Operación I/O en archivo cerrado"
 
@@ -794,8 +811,8 @@ msgstr "error Input/output"
 msgid "Invalid BMP file"
 msgstr "Archivo BMP inválido"
 
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PWMOut.c
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
 msgid "Invalid PWM frequency"
 msgstr "Frecuencia PWM inválida"
 
@@ -840,17 +857,17 @@ msgstr "Archivo inválido"
 msgid "Invalid format chunk size"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid number of bits"
 msgstr "Numero inválido de bits"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid phase"
 msgstr "Fase inválida"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
 #: shared-bindings/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/touchio/TouchIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Invalid pin"
 msgstr "Pin inválido"
 
@@ -862,15 +879,14 @@ msgstr "Pin inválido para canal izquierdo"
 msgid "Invalid pin for right channel"
 msgstr "Pin inválido para canal derecho"
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/nrf/common-hal/busio/I2C.c ports/atmel-samd/common-hal/busio/I2C.c
 #: ports/atmel-samd/common-hal/busio/SPI.c
 #: ports/atmel-samd/common-hal/busio/UART.c
 #: ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
-#: ports/nrf/common-hal/busio/I2C.c
 msgid "Invalid pins"
 msgstr "pines inválidos"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid polarity"
 msgstr "Polaridad inválida"
 
@@ -970,11 +986,11 @@ msgstr "No se encontró el canal DMA"
 msgid "No PulseIn support for %q"
 msgstr "Sin soporte PulseIn para %q"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No RX pin"
 msgstr "Sin pin RX"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No TX pin"
 msgstr "Sin pin TX"
 
@@ -1006,8 +1022,8 @@ msgstr "No hay hardware random disponible"
 msgid "No hardware support for analog out."
 msgstr "Sin soporte de hardware para analog out"
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No hardware support on pin"
 msgstr "Sin soporte de hardware en pin"
 
@@ -1087,7 +1103,7 @@ msgid ""
 "PWM frequency not writable when variable_frequency is False on construction."
 msgstr ""
 
-#: ports/esp8266/common-hal/pulseio/PWMOut.c ports/esp8266/machine_pwm.c
+#: ports/esp8266/machine_pwm.c ports/esp8266/common-hal/pulseio/PWMOut.c
 #, c-format
 msgid "PWM not supported on pin %d"
 msgstr "El pin %d no soporta PWM"
@@ -1100,8 +1116,8 @@ msgstr "Permiso denegado"
 msgid "Pin %q does not have ADC capabilities"
 msgstr "Pin %q no tiene capacidades de ADC"
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 #: ports/nrf/common-hal/analogio/AnalogIn.c
+#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 msgid "Pin does not have ADC capabilities"
 msgstr "Pin no tiene capacidad ADC"
 
@@ -1135,7 +1151,7 @@ msgstr "Pull no se usa cuando la dirección es output."
 msgid "RTC calibration is not supported on this board"
 msgstr "Calibración de RTC no es soportada en esta placa"
 
-#: shared-bindings/rtc/RTC.c shared-bindings/time/__init__.c
+#: shared-bindings/time/__init__.c shared-bindings/rtc/RTC.c
 msgid "RTC is not supported on this board"
 msgstr "RTC no soportado en esta placa"
 
@@ -1148,7 +1164,7 @@ msgstr "address fuera de límites"
 msgid "Read-only"
 msgstr "Solo-lectura"
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: py/moduerrno.c extmod/vfs_fat.c
 msgid "Read-only filesystem"
 msgstr "Sistema de archivos de solo-Lectura"
 
@@ -1203,8 +1219,8 @@ msgstr "Serializer está siendo utilizado"
 msgid "Slice and value different lengths."
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/displayio/Group.c
 msgid "Slices not supported"
 msgstr ""
 
@@ -1291,7 +1307,7 @@ msgstr "Para salir, por favor reinicia la tarjeta sin "
 msgid "Too many channels in sample."
 msgstr "Demasiados canales en sample."
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Too many display busses"
 msgstr ""
 
@@ -1466,7 +1482,7 @@ msgstr "se requiere un objeto bytes-like"
 msgid "abort() called"
 msgstr "se llamó abort()"
 
-#: extmod/machine_mem.c ports/unix/modmachine.c
+#: ports/unix/modmachine.c extmod/machine_mem.c
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr "la dirección %08x no esta alineada a %d bytes"
@@ -1495,7 +1511,7 @@ msgstr "argumento número/tipos no coinciden"
 msgid "argument should be a '%q' not a '%q'"
 msgstr "argumento deberia ser un '%q' no un '%q'"
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objarray.c
 msgid "array/bytes required on right side"
 msgstr "array/bytes requeridos en el lado derecho"
 
@@ -1557,7 +1573,7 @@ msgstr "buffer debe de ser un objeto bytes-like"
 msgid "buffer size must match format"
 msgstr "los buffers deben de tener la misma longitud"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "buffer slices must be of equal length"
 msgstr ""
 
@@ -1565,7 +1581,7 @@ msgstr ""
 msgid "buffer too long"
 msgstr "buffer demasiado largo"
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
+#: shared-bindings/struct/__init__.c py/modstruct.c
 #: shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr "buffer demasiado pequeño"
@@ -1872,8 +1888,8 @@ msgstr "destination_length debe ser un int >= 0"
 msgid "dict update sequence has wrong length"
 msgstr "la secuencia de actualizacion del dict tiene una longitud incorrecta"
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/objfloat.c py/runtime.c py/modmath.c
+#: py/objint_longlong.c py/objint_mpz.c
 msgid "division by zero"
 msgstr "división por cero"
 
@@ -1885,7 +1901,7 @@ msgstr "ya sea pos o kw args son permitidos"
 msgid "empty"
 msgstr "vacío"
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/modutimeq.c extmod/moduheapq.c
 msgid "empty heap"
 msgstr "heap vacío"
 
@@ -1959,7 +1975,7 @@ msgstr "argumento posicional adicional dado"
 msgid "ffi_prep_closure_loc"
 msgstr "ffi_prep_closure_loc"
 
-#: shared-bindings/audioio/WaveFile.c shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/audioio/WaveFile.c
 msgid "file must be a file opened in byte mode"
 msgstr "el archivo deberia ser una archivo abierto en modo byte"
 
@@ -2079,9 +2095,9 @@ msgstr ""
 msgid "incorrect padding"
 msgstr "relleno (padding) incorrecto"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: py/obj.c ports/nrf/common-hal/pulseio/PulseIn.c
 #: ports/esp8266/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c py/obj.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "index out of range"
 msgstr "index fuera de rango"
 
@@ -2129,7 +2145,7 @@ msgstr "longitud de buffer inválida"
 msgid "invalid cert"
 msgstr "certificado inválido"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid data bits"
 msgstr "data bits inválidos"
 
@@ -2161,11 +2177,11 @@ msgstr "pin inválido"
 msgid "invalid step"
 msgstr ""
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid stop bits"
 msgstr "stop bits inválidos"
 
-#: py/compile.c py/parse.c
+#: py/parse.c py/compile.c
 msgid "invalid syntax"
 msgstr "sintaxis inválida"
 
@@ -2205,7 +2221,7 @@ msgstr ""
 msgid "keywords must be strings"
 msgstr "palabras clave deben ser strings"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 msgid "label '%q' not defined"
 msgstr "etiqueta '%q' no definida"
 
@@ -2245,7 +2261,7 @@ msgstr "long int no soportado en esta compilación"
 msgid "map buffer too small"
 msgstr "map buffer muy pequeño"
 
-#: py/modmath.c shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/modmath.c
 msgid "math domain error"
 msgstr "error de dominio matemático"
 
@@ -2321,11 +2337,11 @@ msgstr ""
 msgid "need more than %d values to unpack"
 msgstr "necesita más de %d valores para descomprimir"
 
-#: py/objint_longlong.c py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_longlong.c py/objint_mpz.c
 msgid "negative power with no float support"
 msgstr "potencia negativa sin float support"
 
-#: py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_mpz.c
 msgid "negative shift count"
 msgstr "cuenta negativa de turnos"
 
@@ -2345,7 +2361,7 @@ msgstr "no se ha encontrado ningún enlace para nonlocal"
 msgid "no module named '%q'"
 msgstr "ningún módulo se llama '%q'"
 
-#: py/runtime.c shared-bindings/_pixelbuf/__init__.c
+#: shared-bindings/_pixelbuf/__init__.c py/runtime.c
 msgid "no such attribute"
 msgstr "no hay tal atributo"
 
@@ -2440,8 +2456,8 @@ msgstr "string de longitud impar"
 msgid "offset out of bounds"
 msgstr "address fuera de límites"
 
-#: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objstr.c py/objarray.c py/objstrunicode.c
+#: py/objtuple.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr "solo se admiten segmentos con step=1 (alias None)"
 
@@ -2495,9 +2511,9 @@ msgstr ""
 msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr "pixel_shader debe ser displayio.Palette o displayio.ColorConverter"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "pop from an empty PulseIn"
 msgstr "pop de un PulseIn vacío"
 
@@ -2579,7 +2595,7 @@ msgstr "scan ha fallado"
 msgid "schedule stack full"
 msgstr ""
 
-#: lib/utils/pyexec.c py/builtinimport.c
+#: py/builtinimport.c lib/utils/pyexec.c
 msgid "script compilation not supported"
 msgstr "script de compilación no soportado"
 
@@ -2607,7 +2623,7 @@ msgstr "la longitud de sleep no puede ser negativa"
 msgid "slice step cannot be zero"
 msgstr "slice step no puede ser cero"
 
-#: py/objint.c py/sequence.c
+#: py/sequence.c py/objint.c
 msgid "small int overflow"
 msgstr "pequeño int desbordamiento"
 
@@ -2735,7 +2751,7 @@ msgstr "tupla/lista tiene una longitud incorrecta"
 msgid "tuple/list required on RHS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "tx and rx cannot both be None"
 msgstr "Ambos tx y rx no pueden ser None"
 

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-12 11:17-0700\n"
+"POT-Creation-Date: 2019-03-18 09:56-0400\n"
 "PO-Revision-Date: 2018-12-20 22:15-0800\n"
 "Last-Translator: Timothy <me@timothygarcia.ca>\n"
 "Language-Team: fil\n"
@@ -52,8 +52,8 @@ msgstr "%q indeks wala sa sakop"
 msgid "%q indices must be integers, not %s"
 msgstr "%q indeks ay dapat integers, hindi %s"
 
+#: shared-bindings/displayio/Shape.c shared-bindings/displayio/Group.c
 #: shared-bindings/bleio/CharacteristicBuffer.c
-#: shared-bindings/displayio/Group.c shared-bindings/displayio/Shape.c
 #, fuzzy
 msgid "%q must be >= 1"
 msgstr "aarehas na haba dapat ang buffer slices"
@@ -72,12 +72,12 @@ msgstr ""
 msgid "'%q' argument required"
 msgstr "'%q' argument kailangan"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a label"
 msgstr "'%s' umaasa ng label"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a register"
 msgstr "Inaasahan ng '%s' ang isang rehistro"
@@ -97,7 +97,7 @@ msgstr "Inaasahan ng '%s' ang isang FPU register"
 msgid "'%s' expects an address of the form [a, b]"
 msgstr "Inaasahan ng '%s' ang isang address sa [a, b]"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects an integer"
 msgstr "Inaasahan ng '%s' ang isang integer"
@@ -259,11 +259,10 @@ msgstr "Lahat ng sync event channels ay ginagamit"
 msgid "All timers for this pin are in use"
 msgstr "Lahat ng timers para sa pin na ito ay ginagamit"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PulseOut.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
-#: ports/nrf/common-hal/pulseio/PulseOut.c shared-bindings/pulseio/PWMOut.c
-#: shared-module/_pew/PewPew.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c shared-module/_pew/PewPew.c
 msgid "All timers in use"
 msgstr "Lahat ng timer ginagamit"
 
@@ -332,12 +331,12 @@ msgstr ""
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr "Mali ang size ng buffer. Dapat %d bytes."
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
+#: shared-bindings/busio/I2C.c shared-bindings/bitbangio/I2C.c
 msgid "Buffer must be at least length 1"
 msgstr "Buffer dapat ay hindi baba sa 1 na haba"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, fuzzy, c-format
 msgid "Bus pin %d is already in use"
 msgstr "Ginagamit na ang DAC"
@@ -380,7 +379,7 @@ msgstr "Hindi maconnect sa Peripheral mode"
 msgid "Cannot connect to AP"
 msgstr "Hindi maka connect sa AP"
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
 msgid "Cannot delete values"
 msgstr "Hindi mabura ang values"
 
@@ -388,8 +387,8 @@ msgstr "Hindi mabura ang values"
 msgid "Cannot disconnect from AP"
 msgstr "Hindi ma disconnect sa AP"
 
-#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr "Hindi makakakuha ng pull habang nasa output mode"
 
@@ -414,8 +413,8 @@ msgstr "Hindi ma-record sa isang file"
 msgid "Cannot remount '/' when USB is active."
 msgstr "Hindi ma-remount '/' kapag aktibo ang USB."
 
-#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/esp8266/common-hal/microcontroller/__init__.c
+#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr "Hindi ma-reset sa bootloader dahil walang bootloader."
 
@@ -475,7 +474,7 @@ msgstr "Clock unit ginagamit"
 msgid "Column entry must be digitalio.DigitalInOut"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 #, fuzzy
 msgid "Command must be an int between 0 and 255"
 msgstr "Sa gitna ng 0 o 255 dapat ang bytes."
@@ -505,8 +504,8 @@ msgstr "Nagcrash sa HardFault_Handler.\n"
 msgid "DAC already in use"
 msgstr "Ginagamit na ang DAC"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, fuzzy
 msgid "Data 0 pin must be byte aligned"
 msgstr "graphic ay dapat 2048 bytes ang haba"
@@ -515,8 +514,8 @@ msgstr "graphic ay dapat 2048 bytes ang haba"
 msgid "Data chunk must follow fmt chunk"
 msgstr "Dapat sunurin ng Data chunk ang fmt chunk"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy
 msgid "Data too large for advertisement packet"
 msgstr "Hindi makasya ang data sa loob ng advertisement packet"
@@ -551,8 +550,8 @@ msgstr "Walang safemode support ang ESP8266."
 msgid "ESP8266 does not support pull down."
 msgstr "Walang pull down support ang ESP8266."
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "EXTINT channel already in use"
 msgstr "Ginagamit na ang EXTINT channel"
 
@@ -564,8 +563,8 @@ msgstr "Pagkakamali sa ffi_prep_cif"
 msgid "Error in regex"
 msgstr "May pagkakamali sa REGEX"
 
-#: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/microcontroller/Pin.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/neopixel_write/__init__.c
 #: shared-bindings/terminalio/Terminal.c
 msgid "Expected a %q"
 msgstr "Umasa ng %q"
@@ -575,8 +574,8 @@ msgstr "Umasa ng %q"
 msgid "Expected a Characteristic"
 msgstr "Hindi mabasa and Characteristic."
 
-#: shared-bindings/bleio/Characteristic.c shared-bindings/bleio/Descriptor.c
-#: shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Descriptor.c shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Characteristic.c
 #, fuzzy
 msgid "Expected a UUID"
 msgstr "Umasa ng %q"
@@ -611,13 +610,13 @@ msgstr "Hindi matagumpay ang paglagay ng service, status: 0x%08lX"
 msgid "Failed to add service, err 0x%04x"
 msgstr "Hindi matagumpay ang paglagay ng service, status: 0x%08lX"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "Failed to allocate RX buffer"
 msgstr "Nabigong ilaan ang RX buffer"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr "Nabigong ilaan ang RX buffer ng %d bytes"
@@ -702,8 +701,8 @@ msgstr "Nabigo sa pagrelease ng mutex, status: 0x%08lX"
 msgid "Failed to start advertising"
 msgstr "Hindi masimulaan ang advertisement, status: 0x%08lX"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to start advertising, err 0x%04x"
 msgstr "Hindi masimulaan ang advertisement, status: 0x%08lX"
@@ -723,8 +722,8 @@ msgstr "Hindi masimulaan mag i-scan, status: 0x%0xlX"
 msgid "Failed to stop advertising"
 msgstr "Hindi mahinto ang advertisement, status: 0x%08lX"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to stop advertising, err 0x%04x"
 msgstr "Hindi mahinto ang advertisement, status: 0x%08lX"
@@ -743,12 +742,30 @@ msgstr "Hindi maisulat ang gatts value, status: 0x%08lX"
 msgid "File exists"
 msgstr "Mayroong file"
 
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash erase failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash erase failed to start, err 0x%04x"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash write failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash write failed to start, err 0x%04x"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/bitbangio/SPI.c
-#: shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/I2C.c
+#: shared-bindings/bitbangio/SPI.c
 msgid "Function requires lock"
 msgstr "Function nangangailangan ng lock"
 
@@ -764,7 +781,7 @@ msgstr "Walang pull down support ang GPI016."
 msgid "Group full"
 msgstr "Puno ang group"
 
-#: extmod/vfs_posix_file.c ports/unix/file.c py/objstringio.c
+#: py/objstringio.c ports/unix/file.c extmod/vfs_posix_file.c
 msgid "I/O operation on closed file"
 msgstr "I/O operasyon sa saradong file"
 
@@ -792,8 +809,8 @@ msgstr "May mali sa Input/Output"
 msgid "Invalid BMP file"
 msgstr "Mali ang BMP file"
 
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PWMOut.c
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
 msgid "Invalid PWM frequency"
 msgstr "Mali ang PWM frequency"
 
@@ -838,17 +855,17 @@ msgstr "Mali ang file"
 msgid "Invalid format chunk size"
 msgstr "Mali ang format ng chunk size"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid number of bits"
 msgstr "Mali ang bilang ng bits"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid phase"
 msgstr "Mali ang phase"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
 #: shared-bindings/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/touchio/TouchIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Invalid pin"
 msgstr "Mali ang pin"
 
@@ -860,15 +877,14 @@ msgstr "Mali ang pin para sa kaliwang channel"
 msgid "Invalid pin for right channel"
 msgstr "Mali ang pin para sa kanang channel"
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/nrf/common-hal/busio/I2C.c ports/atmel-samd/common-hal/busio/I2C.c
 #: ports/atmel-samd/common-hal/busio/SPI.c
 #: ports/atmel-samd/common-hal/busio/UART.c
 #: ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
-#: ports/nrf/common-hal/busio/I2C.c
 msgid "Invalid pins"
 msgstr "Mali ang pins"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid polarity"
 msgstr "Mali ang polarity"
 
@@ -968,11 +984,11 @@ msgstr "Walang DMA channel na mahanap"
 msgid "No PulseIn support for %q"
 msgstr "Walang PulseIn support sa %q"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No RX pin"
 msgstr "Walang RX pin"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No TX pin"
 msgstr "Walang TX pin"
 
@@ -1004,8 +1020,8 @@ msgstr "Walang magagamit na hardware random"
 msgid "No hardware support for analog out."
 msgstr "Hindi supportado ng hardware ang analog out."
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No hardware support on pin"
 msgstr "Walang support sa hardware ang pin"
 
@@ -1086,7 +1102,7 @@ msgid ""
 msgstr ""
 "PWM frequency hindi writable kapag variable_frequency ay False sa pag buo."
 
-#: ports/esp8266/common-hal/pulseio/PWMOut.c ports/esp8266/machine_pwm.c
+#: ports/esp8266/machine_pwm.c ports/esp8266/common-hal/pulseio/PWMOut.c
 #, c-format
 msgid "PWM not supported on pin %d"
 msgstr "Walang PWM support sa pin %d"
@@ -1099,8 +1115,8 @@ msgstr "Walang pahintulot"
 msgid "Pin %q does not have ADC capabilities"
 msgstr "Walang kakayahang ADC ang pin %q"
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 #: ports/nrf/common-hal/analogio/AnalogIn.c
+#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 msgid "Pin does not have ADC capabilities"
 msgstr "Ang pin ay walang kakayahan sa ADC"
 
@@ -1134,7 +1150,7 @@ msgstr "Pull hindi ginagamit kapag ang direksyon ay output."
 msgid "RTC calibration is not supported on this board"
 msgstr "RTC calibration ay hindi supportado ng board na ito"
 
-#: shared-bindings/rtc/RTC.c shared-bindings/time/__init__.c
+#: shared-bindings/time/__init__.c shared-bindings/rtc/RTC.c
 msgid "RTC is not supported on this board"
 msgstr "Hindi supportado ang RTC sa board na ito"
 
@@ -1147,7 +1163,7 @@ msgstr "wala sa sakop ang address"
 msgid "Read-only"
 msgstr "Basahin-lamang"
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: py/moduerrno.c extmod/vfs_fat.c
 msgid "Read-only filesystem"
 msgstr "Basahin-lamang mode"
 
@@ -1202,8 +1218,8 @@ msgstr "Serializer ginagamit"
 msgid "Slice and value different lengths."
 msgstr "Slice at value iba't ibang haba."
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/displayio/Group.c
 msgid "Slices not supported"
 msgstr "Hindi suportado ang Slices"
 
@@ -1293,7 +1309,7 @@ msgstr "Para lumabas, paki-reset ang board na wala ang "
 msgid "Too many channels in sample."
 msgstr "Sobra ang channels sa sample."
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Too many display busses"
 msgstr ""
 
@@ -1469,7 +1485,7 @@ msgstr "a bytes-like object ay kailangan"
 msgid "abort() called"
 msgstr "abort() tinawag"
 
-#: extmod/machine_mem.c ports/unix/modmachine.c
+#: ports/unix/modmachine.c extmod/machine_mem.c
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr "address %08x ay hindi pantay sa %d bytes"
@@ -1498,7 +1514,7 @@ msgstr "hindi tugma ang argument num/types"
 msgid "argument should be a '%q' not a '%q'"
 msgstr "argument ay dapat na '%q' hindi '%q'"
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objarray.c
 msgid "array/bytes required on right side"
 msgstr "array/bytes kinakailangan sa kanang bahagi"
 
@@ -1560,7 +1576,7 @@ msgstr "buffer ay dapat bytes-like object"
 msgid "buffer size must match format"
 msgstr "aarehas na haba dapat ang buffer slices"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "buffer slices must be of equal length"
 msgstr "aarehas na haba dapat ang buffer slices"
 
@@ -1568,7 +1584,7 @@ msgstr "aarehas na haba dapat ang buffer slices"
 msgid "buffer too long"
 msgstr "masyadong mahaba ng buffer"
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
+#: shared-bindings/struct/__init__.c py/modstruct.c
 #: shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr "masyadong maliit ang buffer"
@@ -1878,8 +1894,8 @@ msgstr "ang destination_length ay dapat na isang int >= 0"
 msgid "dict update sequence has wrong length"
 msgstr "may mali sa haba ng dict update sequence"
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/objfloat.c py/runtime.c py/modmath.c
+#: py/objint_longlong.c py/objint_mpz.c
 msgid "division by zero"
 msgstr "dibisyon ng zero"
 
@@ -1891,7 +1907,7 @@ msgstr "pos o kw args ang pinahihintulutan"
 msgid "empty"
 msgstr "walang laman"
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/modutimeq.c extmod/moduheapq.c
 msgid "empty heap"
 msgstr "walang laman ang heap"
 
@@ -1965,7 +1981,7 @@ msgstr "dagdag na positional argument na ibinigay"
 msgid "ffi_prep_closure_loc"
 msgstr "ffi_prep_closure_loc"
 
-#: shared-bindings/audioio/WaveFile.c shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/audioio/WaveFile.c
 msgid "file must be a file opened in byte mode"
 msgstr "file ay dapat buksan sa byte mode"
 
@@ -2086,9 +2102,9 @@ msgstr "hindi kumpleto ang format key"
 msgid "incorrect padding"
 msgstr "mali ang padding"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: py/obj.c ports/nrf/common-hal/pulseio/PulseIn.c
 #: ports/esp8266/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c py/obj.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "index out of range"
 msgstr "index wala sa sakop"
 
@@ -2136,7 +2152,7 @@ msgstr "mali ang buffer length"
 msgid "invalid cert"
 msgstr "mali ang cert"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid data bits"
 msgstr "mali ang data bits"
 
@@ -2168,11 +2184,11 @@ msgstr "mali ang pin"
 msgid "invalid step"
 msgstr "mali ang step"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid stop bits"
 msgstr "mali ang stop bits"
 
-#: py/compile.c py/parse.c
+#: py/parse.c py/compile.c
 msgid "invalid syntax"
 msgstr "mali ang sintaks"
 
@@ -2213,7 +2229,7 @@ msgstr ""
 msgid "keywords must be strings"
 msgstr "ang keywords dapat strings"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 msgid "label '%q' not defined"
 msgstr "label '%d' kailangan na i-define"
 
@@ -2253,7 +2269,7 @@ msgstr "long int hindi sinusuportahan sa build na ito"
 msgid "map buffer too small"
 msgstr "masyadong maliit ang buffer map"
 
-#: py/modmath.c shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/modmath.c
 msgid "math domain error"
 msgstr "may pagkakamali sa math domain"
 
@@ -2330,11 +2346,11 @@ msgstr "native yield"
 msgid "need more than %d values to unpack"
 msgstr "kailangan ng higit sa %d na halaga upang i-unpack"
 
-#: py/objint_longlong.c py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_longlong.c py/objint_mpz.c
 msgid "negative power with no float support"
 msgstr "negatibong power na walang float support"
 
-#: py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_mpz.c
 msgid "negative shift count"
 msgstr "negative shift count"
 
@@ -2354,7 +2370,7 @@ msgstr "no binding para sa nonlocal, nahanap"
 msgid "no module named '%q'"
 msgstr "walang module na '%q'"
 
-#: py/runtime.c shared-bindings/_pixelbuf/__init__.c
+#: shared-bindings/_pixelbuf/__init__.c py/runtime.c
 msgid "no such attribute"
 msgstr "walang ganoon na attribute"
 
@@ -2446,8 +2462,8 @@ msgstr "odd-length string"
 msgid "offset out of bounds"
 msgstr "wala sa sakop ang address"
 
-#: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objstr.c py/objarray.c py/objstrunicode.c
+#: py/objtuple.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr "ang mga slices lamang na may hakbang = 1 (aka None) ang sinusuportahan"
 
@@ -2501,9 +2517,9 @@ msgstr ""
 msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr "pixel_shader ay dapat displayio.Palette o displayio.ColorConverter"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "pop from an empty PulseIn"
 msgstr "pop mula sa walang laman na PulseIn"
 
@@ -2585,7 +2601,7 @@ msgstr "nabigo ang pag-scan"
 msgid "schedule stack full"
 msgstr "puno na ang schedule stack"
 
-#: lib/utils/pyexec.c py/builtinimport.c
+#: py/builtinimport.c lib/utils/pyexec.c
 msgid "script compilation not supported"
 msgstr "script kompilasyon hindi supportado"
 
@@ -2613,7 +2629,7 @@ msgstr "sleep length ay dapat hindi negatibo"
 msgid "slice step cannot be zero"
 msgstr "slice step ay hindi puedeng 0"
 
-#: py/objint.c py/sequence.c
+#: py/sequence.c py/objint.c
 msgid "small int overflow"
 msgstr "small int overflow"
 
@@ -2741,7 +2757,7 @@ msgstr "mali ang haba ng tuple/list"
 msgid "tuple/list required on RHS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "tx and rx cannot both be None"
 msgstr "tx at rx hindi pwedeng parehas na None"
 

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-12 11:17-0700\n"
+"POT-Creation-Date: 2019-03-18 09:56-0400\n"
 "PO-Revision-Date: 2018-12-23 20:05+0100\n"
 "Last-Translator: Pierrick Couturier <arofarn@arofarn.info>\n"
 "Language-Team: fr\n"
@@ -51,8 +51,8 @@ msgstr "index %q hors gamme"
 msgid "%q indices must be integers, not %s"
 msgstr "les indices %q doivent être des entiers, pas %s"
 
+#: shared-bindings/displayio/Shape.c shared-bindings/displayio/Group.c
 #: shared-bindings/bleio/CharacteristicBuffer.c
-#: shared-bindings/displayio/Group.c shared-bindings/displayio/Shape.c
 #, fuzzy
 msgid "%q must be >= 1"
 msgstr "les slices de tampon doivent être de longueurs égales"
@@ -70,12 +70,12 @@ msgstr "%q() prend %d arguments mais %d ont été donnés"
 msgid "'%q' argument required"
 msgstr "'%q' argument requis"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a label"
 msgstr "'%s' attend un label"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a register"
 msgstr "'%s' attend un registre"
@@ -95,7 +95,7 @@ msgstr "'%s' attend un registre FPU"
 msgid "'%s' expects an address of the form [a, b]"
 msgstr "'%s' attend une adresse de la forme [a, b]"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects an integer"
 msgstr "'%s' attend un entier"
@@ -259,11 +259,10 @@ msgstr "Tous les canaux d'événements de synchro sont utilisés"
 msgid "All timers for this pin are in use"
 msgstr "Tous les timers pour cette broche sont utilisés"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PulseOut.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
-#: ports/nrf/common-hal/pulseio/PulseOut.c shared-bindings/pulseio/PWMOut.c
-#: shared-module/_pew/PewPew.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c shared-module/_pew/PewPew.c
 msgid "All timers in use"
 msgstr "Tous les timers sont utilisés"
 
@@ -333,12 +332,12 @@ msgstr ""
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr "Tampon de taille incorrect. Devrait être de %d octets."
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
+#: shared-bindings/busio/I2C.c shared-bindings/bitbangio/I2C.c
 msgid "Buffer must be at least length 1"
 msgstr "Le tampon doit être de longueur au moins 1"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, fuzzy, c-format
 msgid "Bus pin %d is already in use"
 msgstr "DAC déjà utilisé"
@@ -381,7 +380,7 @@ msgstr "Impossible de se connecter en mode Peripheral"
 msgid "Cannot connect to AP"
 msgstr "Impossible de se connecter à 'AP'"
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
 msgid "Cannot delete values"
 msgstr "Impossible de supprimer les valeurs"
 
@@ -389,8 +388,8 @@ msgstr "Impossible de supprimer les valeurs"
 msgid "Cannot disconnect from AP"
 msgstr "Impossible de se déconnecter de 'AP'"
 
-#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr "Ne peux être tiré ('pull') en mode 'output'"
 
@@ -415,8 +414,8 @@ msgstr "Impossible d'enregistrer vers un fichier"
 msgid "Cannot remount '/' when USB is active."
 msgstr "'/' ne peut être remonté quand l'USB est actif."
 
-#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/esp8266/common-hal/microcontroller/__init__.c
+#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 "Ne peut être redémarré vers le bootloader car il n'y a pas de bootloader."
@@ -477,7 +476,7 @@ msgstr "Horloge en cours d'utilisation"
 msgid "Column entry must be digitalio.DigitalInOut"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 #, fuzzy
 msgid "Command must be an int between 0 and 255"
 msgstr "Les octets 'bytes' doivent être entre 0 et 255"
@@ -507,8 +506,8 @@ msgstr ""
 msgid "DAC already in use"
 msgstr "DAC déjà utilisé"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, fuzzy
 msgid "Data 0 pin must be byte aligned"
 msgstr "le graphic doit être long de 2048 octets"
@@ -517,8 +516,8 @@ msgstr "le graphic doit être long de 2048 octets"
 msgid "Data chunk must follow fmt chunk"
 msgstr "Un bloc de données doit suivre un bloc de format"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 msgid "Data too large for advertisement packet"
 msgstr ""
 
@@ -550,8 +549,8 @@ msgstr "l'ESP8266 ne supporte pas le mode sans-échec"
 msgid "ESP8266 does not support pull down."
 msgstr "L'ESP8266 ne supporte pas le rappel (pull-down)"
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "EXTINT channel already in use"
 msgstr "Canal EXTINT déjà utilisé"
 
@@ -563,8 +562,8 @@ msgstr "Erreur dans ffi_prep_cif"
 msgid "Error in regex"
 msgstr "Erreur dans l'expression régulière"
 
-#: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/microcontroller/Pin.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/neopixel_write/__init__.c
 #: shared-bindings/terminalio/Terminal.c
 msgid "Expected a %q"
 msgstr "Attendu : %q"
@@ -574,8 +573,8 @@ msgstr "Attendu : %q"
 msgid "Expected a Characteristic"
 msgstr "Impossible d'ajouter la Characteristic."
 
-#: shared-bindings/bleio/Characteristic.c shared-bindings/bleio/Descriptor.c
-#: shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Descriptor.c shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Characteristic.c
 #, fuzzy
 msgid "Expected a UUID"
 msgstr "Attendu : %q"
@@ -610,13 +609,13 @@ msgstr "Echec de l'ajout de service, statut: 0x%08lX"
 msgid "Failed to add service, err 0x%04x"
 msgstr "Echec de l'ajout de service, statut: 0x%08lX"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "Failed to allocate RX buffer"
 msgstr "Echec de l'allocation du tampon RX"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr "Echec de l'allocation de %d octets du tampon RX"
@@ -701,8 +700,8 @@ msgstr "Impossible de libérer mutex, status: 0x%08lX"
 msgid "Failed to start advertising"
 msgstr "Echec de l'ajout de service, statut: 0x%08lX"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to start advertising, err 0x%04x"
 msgstr "Impossible de commencer à scanner, statut: 0x%0xlX"
@@ -722,8 +721,8 @@ msgstr "Impossible de commencer à scanner, statut: 0x%0xlX"
 msgid "Failed to stop advertising"
 msgstr "Echec de l'ajout de service, statut: 0x%08lX"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to stop advertising, err 0x%04x"
 msgstr "Echec de l'ajout de service, statut: 0x%08lX"
@@ -742,12 +741,30 @@ msgstr "Impossible d'écrire la valeur de gatts. status: 0x%08lX"
 msgid "File exists"
 msgstr "Le fichier existe"
 
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash erase failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash erase failed to start, err 0x%04x"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash write failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash write failed to start, err 0x%04x"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/bitbangio/SPI.c
-#: shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/I2C.c
+#: shared-bindings/bitbangio/SPI.c
 msgid "Function requires lock"
 msgstr "La fonction nécessite un verrou"
 
@@ -763,7 +780,7 @@ msgstr "le GPIO16 ne supporte pas le tirage (pull-up)"
 msgid "Group full"
 msgstr "Groupe plein"
 
-#: extmod/vfs_posix_file.c ports/unix/file.c py/objstringio.c
+#: py/objstringio.c ports/unix/file.c extmod/vfs_posix_file.c
 msgid "I/O operation on closed file"
 msgstr "opération d'E/S sur un fichier fermé"
 
@@ -792,8 +809,8 @@ msgstr "Erreur d'entrée/sortie"
 msgid "Invalid BMP file"
 msgstr "Fichier invalide"
 
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PWMOut.c
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
 msgid "Invalid PWM frequency"
 msgstr "Fréquence de PWM invalide"
 
@@ -840,17 +857,17 @@ msgstr "Fichier invalide"
 msgid "Invalid format chunk size"
 msgstr "Taille de bloc de formatage invalide"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid number of bits"
 msgstr "Nombre de bits invalide"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid phase"
 msgstr "Phase invalide"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
 #: shared-bindings/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/touchio/TouchIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Invalid pin"
 msgstr "Broche invalide"
 
@@ -862,15 +879,14 @@ msgstr "Broche invalide pour le canal gauche"
 msgid "Invalid pin for right channel"
 msgstr "Broche invalide pour le canal droit"
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/nrf/common-hal/busio/I2C.c ports/atmel-samd/common-hal/busio/I2C.c
 #: ports/atmel-samd/common-hal/busio/SPI.c
 #: ports/atmel-samd/common-hal/busio/UART.c
 #: ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
-#: ports/nrf/common-hal/busio/I2C.c
 msgid "Invalid pins"
 msgstr "Broches invalides"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid polarity"
 msgstr "Polarité invalide"
 
@@ -971,11 +987,11 @@ msgstr "Aucun canal DMA trouvé"
 msgid "No PulseIn support for %q"
 msgstr "Pas de support de PulseIn pour %q"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No RX pin"
 msgstr "Pas de broche RX"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No TX pin"
 msgstr "Pas de broche TX"
 
@@ -1007,8 +1023,8 @@ msgstr "Pas de source matérielle d'aléa disponible"
 msgid "No hardware support for analog out."
 msgstr "Pas de support matériel pour une sortie analogique"
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No hardware support on pin"
 msgstr "Pas de support matériel pour cette broche"
 
@@ -1094,7 +1110,7 @@ msgstr ""
 "La fréquence de PWM n'est pas modifiable quand variable_frequency est False "
 "à la construction."
 
-#: ports/esp8266/common-hal/pulseio/PWMOut.c ports/esp8266/machine_pwm.c
+#: ports/esp8266/machine_pwm.c ports/esp8266/common-hal/pulseio/PWMOut.c
 #, c-format
 msgid "PWM not supported on pin %d"
 msgstr "La broche %d ne supporte pas le PWM"
@@ -1107,8 +1123,8 @@ msgstr "Permission refusée"
 msgid "Pin %q does not have ADC capabilities"
 msgstr "La broche %q n'a pas de convertisseur analogique-digital"
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 #: ports/nrf/common-hal/analogio/AnalogIn.c
+#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 msgid "Pin does not have ADC capabilities"
 msgstr "la broche ne peut être utilisé pour l'ADC"
 
@@ -1141,7 +1157,7 @@ msgstr "Le tirage 'pull' n'est pas utilisé quand la direction est 'output'."
 msgid "RTC calibration is not supported on this board"
 msgstr "calibration de la RTC non supportée sur cette carte"
 
-#: shared-bindings/rtc/RTC.c shared-bindings/time/__init__.c
+#: shared-bindings/time/__init__.c shared-bindings/rtc/RTC.c
 msgid "RTC is not supported on this board"
 msgstr "RTC non supportée sur cette carte"
 
@@ -1154,7 +1170,7 @@ msgstr "adresse hors limites"
 msgid "Read-only"
 msgstr "Lecture seule"
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: py/moduerrno.c extmod/vfs_fat.c
 msgid "Read-only filesystem"
 msgstr "Système de fichier en lecture seule"
 
@@ -1210,8 +1226,8 @@ msgstr "Sérialiseur en cours d'utilisation"
 msgid "Slice and value different lengths."
 msgstr "Slice et valeur de tailles différentes"
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/displayio/Group.c
 msgid "Slices not supported"
 msgstr "Slices non supportées"
 
@@ -1304,7 +1320,7 @@ msgstr "Pour quitter, redémarrez la carte SVP sans "
 msgid "Too many channels in sample."
 msgstr "Trop de canaux dans l'échantillon."
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Too many display busses"
 msgstr ""
 
@@ -1479,7 +1495,7 @@ msgstr "un objet 'bytes-like' est requis"
 msgid "abort() called"
 msgstr "abort() appelé"
 
-#: extmod/machine_mem.c ports/unix/modmachine.c
+#: ports/unix/modmachine.c extmod/machine_mem.c
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr "l'adresse %08x n'est pas alignée sur %d octets"
@@ -1508,7 +1524,7 @@ msgstr "argument num/types ne correspond pas"
 msgid "argument should be a '%q' not a '%q'"
 msgstr "l'argument devrait être un(e) '%q', pas '%q'"
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objarray.c
 msgid "array/bytes required on right side"
 msgstr "tableau/octets requis à droite"
 
@@ -1572,7 +1588,7 @@ msgstr "le tampon doit être un objet bytes-like"
 msgid "buffer size must match format"
 msgstr "les slices de tampon doivent être de longueurs égales"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "buffer slices must be of equal length"
 msgstr "les slices de tampon doivent être de longueurs égales"
 
@@ -1580,7 +1596,7 @@ msgstr "les slices de tampon doivent être de longueurs égales"
 msgid "buffer too long"
 msgstr "tampon trop long"
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
+#: shared-bindings/struct/__init__.c py/modstruct.c
 #: shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr "tampon trop petit"
@@ -1895,8 +1911,8 @@ msgstr "destination_length doit être un entier >= 0"
 msgid "dict update sequence has wrong length"
 msgstr "la séquence de mise à jour de dict a une mauvaise longueur"
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/objfloat.c py/runtime.c py/modmath.c
+#: py/objint_longlong.c py/objint_mpz.c
 msgid "division by zero"
 msgstr "division par zéro"
 
@@ -1908,7 +1924,7 @@ msgstr "soit 'pos', soit 'kw' est permis en argument"
 msgid "empty"
 msgstr "vide"
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/modutimeq.c extmod/moduheapq.c
 msgid "empty heap"
 msgstr "'heap' vide"
 
@@ -1982,7 +1998,7 @@ msgstr "argument positionnel donné en plus"
 msgid "ffi_prep_closure_loc"
 msgstr ""
 
-#: shared-bindings/audioio/WaveFile.c shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/audioio/WaveFile.c
 msgid "file must be a file opened in byte mode"
 msgstr "le fichier doit être un fichier ouvert en mode 'byte'"
 
@@ -2102,9 +2118,9 @@ msgstr "clé de format incomplète"
 msgid "incorrect padding"
 msgstr "espacement incorrect"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: py/obj.c ports/nrf/common-hal/pulseio/PulseIn.c
 #: ports/esp8266/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c py/obj.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "index out of range"
 msgstr "index hors gamme"
 
@@ -2152,7 +2168,7 @@ msgstr "longueur de tampon invalide"
 msgid "invalid cert"
 msgstr "certificat invalide"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid data bits"
 msgstr "bits de données invalides"
 
@@ -2184,11 +2200,11 @@ msgstr "broche invalide"
 msgid "invalid step"
 msgstr "pas invalide"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid stop bits"
 msgstr "bits d'arrêt invalides"
 
-#: py/compile.c py/parse.c
+#: py/parse.c py/compile.c
 msgid "invalid syntax"
 msgstr "syntaxe invalide"
 
@@ -2227,7 +2243,7 @@ msgstr ""
 msgid "keywords must be strings"
 msgstr "les noms doivent être des chaînes de caractère"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 msgid "label '%q' not defined"
 msgstr "label '%q' non supporté"
 
@@ -2267,7 +2283,7 @@ msgstr "entiers longs non supportés dans cette build"
 msgid "map buffer too small"
 msgstr "tampon trop petit"
 
-#: py/modmath.c shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/modmath.c
 msgid "math domain error"
 msgstr "erreur de domaine math"
 
@@ -2344,11 +2360,11 @@ msgstr ""
 msgid "need more than %d values to unpack"
 msgstr "nécessite plus de %d valeur à dégrouper"
 
-#: py/objint_longlong.c py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_longlong.c py/objint_mpz.c
 msgid "negative power with no float support"
 msgstr "puissance négative sans support des nombres flottants"
 
-#: py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_mpz.c
 msgid "negative shift count"
 msgstr "compte de décalage négatif"
 
@@ -2369,7 +2385,7 @@ msgstr "pas de lien trouvé pour nonlocal"
 msgid "no module named '%q'"
 msgstr "pas de module '%q'"
 
-#: py/runtime.c shared-bindings/_pixelbuf/__init__.c
+#: shared-bindings/_pixelbuf/__init__.c py/runtime.c
 msgid "no such attribute"
 msgstr "pas de tel attribut"
 
@@ -2463,8 +2479,8 @@ msgstr "chaîne de longueur impaire"
 msgid "offset out of bounds"
 msgstr "adresse hors limites"
 
-#: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objstr.c py/objarray.c py/objstrunicode.c
+#: py/objtuple.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr "seuls les slices avec 'step=1' (cad None) sont supportées"
 
@@ -2521,9 +2537,9 @@ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr ""
 "pixel_shader doit être un objet displayio.Palette ou displayio.ColorConverter"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "pop from an empty PulseIn"
 msgstr "'pop' d'une entrée PulseIn vide"
 
@@ -2605,7 +2621,7 @@ msgstr "échec du scan"
 msgid "schedule stack full"
 msgstr "pile de plannification pleine"
 
-#: lib/utils/pyexec.c py/builtinimport.c
+#: py/builtinimport.c lib/utils/pyexec.c
 msgid "script compilation not supported"
 msgstr "compilation de script non supporté"
 
@@ -2633,7 +2649,7 @@ msgstr "la longueur de sleep ne doit pas être négative"
 msgid "slice step cannot be zero"
 msgstr "le pas 'step' de slice ne peut être zéro"
 
-#: py/objint.c py/sequence.c
+#: py/sequence.c py/objint.c
 msgid "small int overflow"
 msgstr "dépassement de capacité d'un entier court"
 
@@ -2762,7 +2778,7 @@ msgstr "tuple/liste a une mauvaise longueur"
 msgid "tuple/list required on RHS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "tx and rx cannot both be None"
 msgstr "tx et rx ne peuvent être None tous les deux"
 

--- a/locale/it_IT.po
+++ b/locale/it_IT.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-12 11:17-0700\n"
+"POT-Creation-Date: 2019-03-18 09:56-0400\n"
 "PO-Revision-Date: 2018-10-02 16:27+0200\n"
 "Last-Translator: Enrico Paganin <enrico.paganin@mail.com>\n"
 "Language-Team: \n"
@@ -52,8 +52,8 @@ msgstr "indice %q fuori intervallo"
 msgid "%q indices must be integers, not %s"
 msgstr "gli indici %q devono essere interi, non %s"
 
+#: shared-bindings/displayio/Shape.c shared-bindings/displayio/Group.c
 #: shared-bindings/bleio/CharacteristicBuffer.c
-#: shared-bindings/displayio/Group.c shared-bindings/displayio/Shape.c
 #, fuzzy
 msgid "%q must be >= 1"
 msgstr "slice del buffer devono essere della stessa lunghezza"
@@ -71,12 +71,12 @@ msgstr "%q() prende %d argomenti posizionali ma ne sono stati forniti %d"
 msgid "'%q' argument required"
 msgstr "'%q' argomento richiesto"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a label"
 msgstr "'%s' aspetta una etichetta"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a register"
 msgstr "'%s' aspetta un registro"
@@ -96,7 +96,7 @@ msgstr "'%s' aspetta un registro"
 msgid "'%s' expects an address of the form [a, b]"
 msgstr "'%s' aspetta un registro"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects an integer"
 msgstr "'%s' aspetta un intero"
@@ -258,11 +258,10 @@ msgstr "Tutti i canali di eventi sincronizzati in uso"
 msgid "All timers for this pin are in use"
 msgstr "Tutti i timer per questo pin sono in uso"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PulseOut.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
-#: ports/nrf/common-hal/pulseio/PulseOut.c shared-bindings/pulseio/PWMOut.c
-#: shared-module/_pew/PewPew.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c shared-module/_pew/PewPew.c
 msgid "All timers in use"
 msgstr "Tutti i timer utilizzati"
 
@@ -332,12 +331,12 @@ msgstr ""
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr "Buffer di lunghezza non valida. Dovrebbe essere di %d bytes."
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
+#: shared-bindings/busio/I2C.c shared-bindings/bitbangio/I2C.c
 msgid "Buffer must be at least length 1"
 msgstr "Il buffer deve essere lungo almeno 1"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, fuzzy, c-format
 msgid "Bus pin %d is already in use"
 msgstr "DAC già in uso"
@@ -380,7 +379,7 @@ msgstr ""
 msgid "Cannot connect to AP"
 msgstr "Impossible connettersi all'AP"
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
 msgid "Cannot delete values"
 msgstr "Impossibile cancellare valori"
 
@@ -388,8 +387,8 @@ msgstr "Impossibile cancellare valori"
 msgid "Cannot disconnect from AP"
 msgstr "Impossible disconnettersi all'AP"
 
-#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -414,8 +413,8 @@ msgstr "Impossibile registrare in un file"
 msgid "Cannot remount '/' when USB is active."
 msgstr "Non è possibile rimontare '/' mentre l'USB è attiva."
 
-#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/esp8266/common-hal/microcontroller/__init__.c
+#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 "Impossibile resettare nel bootloader poiché nessun bootloader è presente."
@@ -476,7 +475,7 @@ msgstr "Unità di clock in uso"
 msgid "Column entry must be digitalio.DigitalInOut"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 #, fuzzy
 msgid "Command must be an int between 0 and 255"
 msgstr "I byte devono essere compresi tra 0 e 255"
@@ -506,8 +505,8 @@ msgstr ""
 msgid "DAC already in use"
 msgstr "DAC già in uso"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, fuzzy
 msgid "Data 0 pin must be byte aligned"
 msgstr "graphic deve essere lunga 2048 byte"
@@ -516,8 +515,8 @@ msgstr "graphic deve essere lunga 2048 byte"
 msgid "Data chunk must follow fmt chunk"
 msgstr ""
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy
 msgid "Data too large for advertisement packet"
 msgstr "Impossibile inserire dati nel pacchetto di advertisement."
@@ -551,8 +550,8 @@ msgstr "ESP8266 non supporta la modalità sicura."
 msgid "ESP8266 does not support pull down."
 msgstr "ESP8266 non supporta pull-down"
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "EXTINT channel already in use"
 msgstr "Canale EXTINT già in uso"
 
@@ -564,8 +563,8 @@ msgstr "Errore in ffi_prep_cif"
 msgid "Error in regex"
 msgstr "Errore nella regex"
 
-#: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/microcontroller/Pin.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/neopixel_write/__init__.c
 #: shared-bindings/terminalio/Terminal.c
 msgid "Expected a %q"
 msgstr "Atteso un %q"
@@ -575,8 +574,8 @@ msgstr "Atteso un %q"
 msgid "Expected a Characteristic"
 msgstr "Non è possibile aggiungere Characteristic."
 
-#: shared-bindings/bleio/Characteristic.c shared-bindings/bleio/Descriptor.c
-#: shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Descriptor.c shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Characteristic.c
 #, fuzzy
 msgid "Expected a UUID"
 msgstr "Atteso un %q"
@@ -611,13 +610,13 @@ msgstr "Impossibile fermare advertisement. status: 0x%02x"
 msgid "Failed to add service, err 0x%04x"
 msgstr "Impossibile fermare advertisement. status: 0x%02x"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "Failed to allocate RX buffer"
 msgstr "Impossibile allocare buffer RX"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr "Fallita allocazione del buffer RX di %d byte"
@@ -701,8 +700,8 @@ msgstr "Impossibile leggere valore dell'attributo. status: 0x%02x"
 msgid "Failed to start advertising"
 msgstr "Impossibile avviare advertisement. status: 0x%02x"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to start advertising, err 0x%04x"
 msgstr "Impossibile avviare advertisement. status: 0x%02x"
@@ -722,8 +721,8 @@ msgstr "Impossible iniziare la scansione. status: 0x%02x"
 msgid "Failed to stop advertising"
 msgstr "Impossibile fermare advertisement. status: 0x%02x"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to stop advertising, err 0x%04x"
 msgstr "Impossibile fermare advertisement. status: 0x%02x"
@@ -742,12 +741,30 @@ msgstr "Impossibile scrivere valore dell'attributo. status: 0x%02x"
 msgid "File exists"
 msgstr "File esistente"
 
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash erase failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash erase failed to start, err 0x%04x"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash write failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash write failed to start, err 0x%04x"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/bitbangio/SPI.c
-#: shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/I2C.c
+#: shared-bindings/bitbangio/SPI.c
 msgid "Function requires lock"
 msgstr ""
 
@@ -763,7 +780,7 @@ msgstr "GPIO16 non supporta pull-up"
 msgid "Group full"
 msgstr "Gruppo pieno"
 
-#: extmod/vfs_posix_file.c ports/unix/file.c py/objstringio.c
+#: py/objstringio.c ports/unix/file.c extmod/vfs_posix_file.c
 msgid "I/O operation on closed file"
 msgstr "operazione I/O su file chiuso"
 
@@ -791,8 +808,8 @@ msgstr "Errore input/output"
 msgid "Invalid BMP file"
 msgstr "File BMP non valido"
 
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PWMOut.c
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
 msgid "Invalid PWM frequency"
 msgstr "Frequenza PWM non valida"
 
@@ -839,17 +856,17 @@ msgstr "File non valido"
 msgid "Invalid format chunk size"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid number of bits"
 msgstr "Numero di bit non valido"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid phase"
 msgstr "Fase non valida"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
 #: shared-bindings/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/touchio/TouchIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Invalid pin"
 msgstr "Pin non valido"
 
@@ -861,15 +878,14 @@ msgstr "Pin non valido per il canale sinistro"
 msgid "Invalid pin for right channel"
 msgstr "Pin non valido per il canale destro"
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/nrf/common-hal/busio/I2C.c ports/atmel-samd/common-hal/busio/I2C.c
 #: ports/atmel-samd/common-hal/busio/SPI.c
 #: ports/atmel-samd/common-hal/busio/UART.c
 #: ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
-#: ports/nrf/common-hal/busio/I2C.c
 msgid "Invalid pins"
 msgstr "Pin non validi"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid polarity"
 msgstr "Polarità non valida"
 
@@ -966,11 +982,11 @@ msgstr "Nessun canale DMA trovato"
 msgid "No PulseIn support for %q"
 msgstr "Nessun supporto per PulseIn per %q"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No RX pin"
 msgstr "Nessun pin RX"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No TX pin"
 msgstr "Nessun pin TX"
 
@@ -1002,8 +1018,8 @@ msgstr "Nessun generatore hardware di numeri casuali disponibile"
 msgid "No hardware support for analog out."
 msgstr "Nessun supporto hardware per l'uscita analogica."
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No hardware support on pin"
 msgstr "Nessun supporto hardware sul pin"
 
@@ -1089,7 +1105,7 @@ msgstr ""
 "frequenza PWM frequency non è scrivibile quando variable_frequency è "
 "impostato nel costruttore a False."
 
-#: ports/esp8266/common-hal/pulseio/PWMOut.c ports/esp8266/machine_pwm.c
+#: ports/esp8266/machine_pwm.c ports/esp8266/common-hal/pulseio/PWMOut.c
 #, c-format
 msgid "PWM not supported on pin %d"
 msgstr "PWM non è supportato sul pin %d"
@@ -1102,8 +1118,8 @@ msgstr "Permesso negato"
 msgid "Pin %q does not have ADC capabilities"
 msgstr "Il pin %q non ha capacità ADC"
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 #: ports/nrf/common-hal/analogio/AnalogIn.c
+#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 msgid "Pin does not have ADC capabilities"
 msgstr "Il pin non ha capacità di ADC"
 
@@ -1137,7 +1153,7 @@ msgstr ""
 msgid "RTC calibration is not supported on this board"
 msgstr "calibrazione RTC non supportata su questa scheda"
 
-#: shared-bindings/rtc/RTC.c shared-bindings/time/__init__.c
+#: shared-bindings/time/__init__.c shared-bindings/rtc/RTC.c
 msgid "RTC is not supported on this board"
 msgstr "RTC non supportato su questa scheda"
 
@@ -1150,7 +1166,7 @@ msgstr "indirizzo fuori limite"
 msgid "Read-only"
 msgstr "Sola lettura"
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: py/moduerrno.c extmod/vfs_fat.c
 msgid "Read-only filesystem"
 msgstr "Filesystem in sola lettura"
 
@@ -1207,8 +1223,8 @@ msgstr "Serializer in uso"
 msgid "Slice and value different lengths."
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/displayio/Group.c
 msgid "Slices not supported"
 msgstr "Slice non supportate"
 
@@ -1291,7 +1307,7 @@ msgstr "Per uscire resettare la scheda senza "
 msgid "Too many channels in sample."
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Too many display busses"
 msgstr ""
 
@@ -1461,7 +1477,7 @@ msgstr "un oggetto byte-like è richiesto"
 msgid "abort() called"
 msgstr "abort() chiamato"
 
-#: extmod/machine_mem.c ports/unix/modmachine.c
+#: ports/unix/modmachine.c extmod/machine_mem.c
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr "l'indirizzo %08x non è allineato a %d bytes"
@@ -1490,7 +1506,7 @@ msgstr "discrepanza di numero/tipo di argomenti"
 msgid "argument should be a '%q' not a '%q'"
 msgstr "l'argomento dovrebbe essere un '%q' e non un '%q'"
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objarray.c
 msgid "array/bytes required on right side"
 msgstr ""
 
@@ -1554,7 +1570,7 @@ msgstr ""
 msgid "buffer size must match format"
 msgstr "slice del buffer devono essere della stessa lunghezza"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "buffer slices must be of equal length"
 msgstr "slice del buffer devono essere della stessa lunghezza"
 
@@ -1562,7 +1578,7 @@ msgstr "slice del buffer devono essere della stessa lunghezza"
 msgid "buffer too long"
 msgstr "buffer troppo lungo"
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
+#: shared-bindings/struct/__init__.c py/modstruct.c
 #: shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr "buffer troppo piccolo"
@@ -1868,8 +1884,8 @@ msgstr "destination_length deve essere un int >= 0"
 msgid "dict update sequence has wrong length"
 msgstr "sequanza di aggiornamento del dizionario ha la lunghezza errata"
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/objfloat.c py/runtime.c py/modmath.c
+#: py/objint_longlong.c py/objint_mpz.c
 msgid "division by zero"
 msgstr "divisione per zero"
 
@@ -1881,7 +1897,7 @@ msgstr "sono permesse solo gli argomenti pos o kw"
 msgid "empty"
 msgstr "vuoto"
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/modutimeq.c extmod/moduheapq.c
 msgid "empty heap"
 msgstr "heap vuoto"
 
@@ -1955,7 +1971,7 @@ msgstr "argomenti posizonali extra dati"
 msgid "ffi_prep_closure_loc"
 msgstr "ffi_prep_closure_loc"
 
-#: shared-bindings/audioio/WaveFile.c shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/audioio/WaveFile.c
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
@@ -2076,9 +2092,9 @@ msgstr ""
 msgid "incorrect padding"
 msgstr "padding incorretto"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: py/obj.c ports/nrf/common-hal/pulseio/PulseIn.c
 #: ports/esp8266/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c py/obj.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "index out of range"
 msgstr "indice fuori intervallo"
 
@@ -2126,7 +2142,7 @@ msgstr "lunghezza del buffer non valida"
 msgid "invalid cert"
 msgstr "certificato non valido"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid data bits"
 msgstr "bit dati invalidi"
 
@@ -2158,11 +2174,11 @@ msgstr "pin non valido"
 msgid "invalid step"
 msgstr "step non valida"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid stop bits"
 msgstr "bit di stop invalidi"
 
-#: py/compile.c py/parse.c
+#: py/parse.c py/compile.c
 msgid "invalid syntax"
 msgstr "sintassi non valida"
 
@@ -2204,7 +2220,7 @@ msgstr ""
 msgid "keywords must be strings"
 msgstr "argomenti nominati devono essere stringhe"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 msgid "label '%q' not defined"
 msgstr "etichetta '%q' non definita"
 
@@ -2244,7 +2260,7 @@ msgstr "long int non supportata in questa build"
 msgid "map buffer too small"
 msgstr "map buffer troppo piccolo"
 
-#: py/modmath.c shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/modmath.c
 msgid "math domain error"
 msgstr "errore di dominio matematico"
 
@@ -2321,11 +2337,11 @@ msgstr "yield nativo"
 msgid "need more than %d values to unpack"
 msgstr "necessari più di %d valori da scompattare"
 
-#: py/objint_longlong.c py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_longlong.c py/objint_mpz.c
 msgid "negative power with no float support"
 msgstr "potenza negativa senza supporto per float"
 
-#: py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_mpz.c
 msgid "negative shift count"
 msgstr ""
 
@@ -2346,7 +2362,7 @@ msgstr "nessun binding per nonlocal trovato"
 msgid "no module named '%q'"
 msgstr "nessun modulo chiamato '%q'"
 
-#: py/runtime.c shared-bindings/_pixelbuf/__init__.c
+#: shared-bindings/_pixelbuf/__init__.c py/runtime.c
 msgid "no such attribute"
 msgstr "attributo inesistente"
 
@@ -2440,8 +2456,8 @@ msgstr "stringa di lunghezza dispari"
 msgid "offset out of bounds"
 msgstr "indirizzo fuori limite"
 
-#: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objstr.c py/objarray.c py/objstrunicode.c
+#: py/objtuple.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr "solo slice con step=1 (aka None) sono supportate"
 
@@ -2497,9 +2513,9 @@ msgstr ""
 msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr "pixel_shader deve essere displayio.Palette o displayio.ColorConverter"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "pop from an empty PulseIn"
 msgstr "pop sun un PulseIn vuoto"
 
@@ -2581,7 +2597,7 @@ msgstr "scansione fallita"
 msgid "schedule stack full"
 msgstr ""
 
-#: lib/utils/pyexec.c py/builtinimport.c
+#: py/builtinimport.c lib/utils/pyexec.c
 msgid "script compilation not supported"
 msgstr "compilazione dello scrip non suportata"
 
@@ -2609,7 +2625,7 @@ msgstr "la lunghezza di sleed deve essere non negativa"
 msgid "slice step cannot be zero"
 msgstr "la step della slice non può essere zero"
 
-#: py/objint.c py/sequence.c
+#: py/sequence.c py/objint.c
 msgid "small int overflow"
 msgstr "small int overflow"
 
@@ -2737,7 +2753,7 @@ msgstr "tupla/lista ha la lunghezza sbagliata"
 msgid "tuple/list required on RHS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "tx and rx cannot both be None"
 msgstr "tx e rx non possono essere entrambi None"
 

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-12 11:17-0700\n"
+"POT-Creation-Date: 2019-03-18 09:56-0400\n"
 "PO-Revision-Date: 2018-10-02 21:14-0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -52,8 +52,8 @@ msgstr ""
 msgid "%q indices must be integers, not %s"
 msgstr ""
 
+#: shared-bindings/displayio/Shape.c shared-bindings/displayio/Group.c
 #: shared-bindings/bleio/CharacteristicBuffer.c
-#: shared-bindings/displayio/Group.c shared-bindings/displayio/Shape.c
 #, fuzzy
 msgid "%q must be >= 1"
 msgstr "buffers devem ser o mesmo tamanho"
@@ -71,12 +71,12 @@ msgstr ""
 msgid "'%q' argument required"
 msgstr "'%q' argumento(s) requerido(s)"
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a label"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects a register"
 msgstr ""
@@ -96,7 +96,7 @@ msgstr ""
 msgid "'%s' expects an address of the form [a, b]"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 #, c-format
 msgid "'%s' expects an integer"
 msgstr ""
@@ -258,11 +258,10 @@ msgstr ""
 msgid "All timers for this pin are in use"
 msgstr "Todos os temporizadores para este pino estão em uso"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PulseOut.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
-#: ports/nrf/common-hal/pulseio/PulseOut.c shared-bindings/pulseio/PWMOut.c
-#: shared-module/_pew/PewPew.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c shared-module/_pew/PewPew.c
 msgid "All timers in use"
 msgstr "Todos os temporizadores em uso"
 
@@ -329,12 +328,12 @@ msgstr ""
 msgid "Buffer incorrect size. Should be %d bytes."
 msgstr "Buffer de tamanho incorreto. Deve ser %d bytes."
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
+#: shared-bindings/busio/I2C.c shared-bindings/bitbangio/I2C.c
 msgid "Buffer must be at least length 1"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #, fuzzy, c-format
 msgid "Bus pin %d is already in use"
 msgstr "DAC em uso"
@@ -377,7 +376,7 @@ msgstr ""
 msgid "Cannot connect to AP"
 msgstr "Não é possível conectar-se ao AP"
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
 msgid "Cannot delete values"
 msgstr "Não é possível excluir valores"
 
@@ -385,8 +384,8 @@ msgstr "Não é possível excluir valores"
 msgid "Cannot disconnect from AP"
 msgstr "Não é possível desconectar do AP"
 
-#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -411,8 +410,8 @@ msgstr "Não é possível gravar em um arquivo"
 msgid "Cannot remount '/' when USB is active."
 msgstr "Não é possível remontar '/' enquanto o USB estiver ativo."
 
-#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/esp8266/common-hal/microcontroller/__init__.c
+#: ports/atmel-samd/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present."
 msgstr ""
 
@@ -472,7 +471,7 @@ msgstr "Unidade de Clock em uso"
 msgid "Column entry must be digitalio.DigitalInOut"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 #, fuzzy
 msgid "Command must be an int between 0 and 255"
 msgstr "Os bytes devem estar entre 0 e 255."
@@ -502,8 +501,8 @@ msgstr ""
 msgid "DAC already in use"
 msgstr "DAC em uso"
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 msgid "Data 0 pin must be byte aligned"
 msgstr ""
 
@@ -511,8 +510,8 @@ msgstr ""
 msgid "Data chunk must follow fmt chunk"
 msgstr "Pedaço de dados deve seguir o pedaço de cortes"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy
 msgid "Data too large for advertisement packet"
 msgstr "Não é possível ajustar dados no pacote de anúncios."
@@ -546,8 +545,8 @@ msgstr "O ESP8226 não suporta o modo de segurança."
 msgid "ESP8266 does not support pull down."
 msgstr "ESP8266 não suporta pull down."
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "EXTINT channel already in use"
 msgstr "Canal EXTINT em uso"
 
@@ -559,8 +558,8 @@ msgstr "Erro no ffi_prep_cif"
 msgid "Error in regex"
 msgstr "Erro no regex"
 
-#: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/microcontroller/Pin.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/neopixel_write/__init__.c
 #: shared-bindings/terminalio/Terminal.c
 msgid "Expected a %q"
 msgstr "Esperado um"
@@ -570,8 +569,8 @@ msgstr "Esperado um"
 msgid "Expected a Characteristic"
 msgstr "Não é possível adicionar Característica."
 
-#: shared-bindings/bleio/Characteristic.c shared-bindings/bleio/Descriptor.c
-#: shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Descriptor.c shared-bindings/bleio/Service.c
+#: shared-bindings/bleio/Characteristic.c
 #, fuzzy
 msgid "Expected a UUID"
 msgstr "Esperado um"
@@ -606,13 +605,13 @@ msgstr "Não pode parar propaganda. status: 0x%02x"
 msgid "Failed to add service, err 0x%04x"
 msgstr "Não pode parar propaganda. status: 0x%02x"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "Failed to allocate RX buffer"
 msgstr "Falha ao alocar buffer RX"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #, c-format
 msgid "Failed to allocate RX buffer of %d bytes"
 msgstr "Falha ao alocar buffer RX de %d bytes"
@@ -694,8 +693,8 @@ msgstr "Não é possível ler o valor do atributo. status: 0x%02x"
 msgid "Failed to start advertising"
 msgstr "Não é possível iniciar o anúncio. status: 0x%02x"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to start advertising, err 0x%04x"
 msgstr "Não é possível iniciar o anúncio. status: 0x%02x"
@@ -715,8 +714,8 @@ msgstr "Não é possível iniciar o anúncio. status: 0x%02x"
 msgid "Failed to stop advertising"
 msgstr "Não pode parar propaganda. status: 0x%02x"
 
-#: ports/nrf/common-hal/bleio/Broadcaster.c
 #: ports/nrf/common-hal/bleio/Peripheral.c
+#: ports/nrf/common-hal/bleio/Broadcaster.c
 #, fuzzy, c-format
 msgid "Failed to stop advertising, err 0x%04x"
 msgstr "Não pode parar propaganda. status: 0x%02x"
@@ -735,12 +734,30 @@ msgstr "Não é possível gravar o valor do atributo. status: 0x%02x"
 msgid "File exists"
 msgstr "Arquivo já existe"
 
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash erase failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash erase failed to start, err 0x%04x"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+msgid "Flash write failed"
+msgstr ""
+
+#: ports/nrf/supervisor/internal_flash.c
+#, c-format
+msgid "Flash write failed to start, err 0x%04x"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/bitbangio/SPI.c
-#: shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/I2C.c
+#: shared-bindings/bitbangio/SPI.c
 msgid "Function requires lock"
 msgstr ""
 
@@ -756,7 +773,7 @@ msgstr "GPIO16 não suporta pull up."
 msgid "Group full"
 msgstr "Grupo cheio"
 
-#: extmod/vfs_posix_file.c ports/unix/file.c py/objstringio.c
+#: py/objstringio.c ports/unix/file.c extmod/vfs_posix_file.c
 msgid "I/O operation on closed file"
 msgstr "Operação I/O no arquivo fechado"
 
@@ -782,8 +799,8 @@ msgstr ""
 msgid "Invalid BMP file"
 msgstr "Arquivo BMP inválido"
 
+#: shared-bindings/pulseio/PWMOut.c ports/nrf/common-hal/pulseio/PWMOut.c
 #: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
 msgid "Invalid PWM frequency"
 msgstr "Frequência PWM inválida"
 
@@ -830,17 +847,17 @@ msgstr "Arquivo inválido"
 msgid "Invalid format chunk size"
 msgstr "Tamanho do pedaço de formato inválido"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid number of bits"
 msgstr "Número inválido de bits"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid phase"
 msgstr "Fase Inválida"
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
 #: shared-bindings/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/touchio/TouchIn.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Invalid pin"
 msgstr "Pino inválido"
 
@@ -852,15 +869,14 @@ msgstr "Pino inválido para canal esquerdo"
 msgid "Invalid pin for right channel"
 msgstr "Pino inválido para canal direito"
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/nrf/common-hal/busio/I2C.c ports/atmel-samd/common-hal/busio/I2C.c
 #: ports/atmel-samd/common-hal/busio/SPI.c
 #: ports/atmel-samd/common-hal/busio/UART.c
 #: ports/atmel-samd/common-hal/i2cslave/I2CSlave.c
-#: ports/nrf/common-hal/busio/I2C.c
 msgid "Invalid pins"
 msgstr "Pinos inválidos"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "Invalid polarity"
 msgstr ""
 
@@ -956,11 +972,11 @@ msgstr "Nenhum canal DMA encontrado"
 msgid "No PulseIn support for %q"
 msgstr "Não há suporte para PulseIn no pino %q"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No RX pin"
 msgstr "Nenhum pino RX"
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "No TX pin"
 msgstr "Nenhum pino TX"
 
@@ -992,8 +1008,8 @@ msgstr ""
 msgid "No hardware support for analog out."
 msgstr "Nenhum suporte de hardware para saída analógica."
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No hardware support on pin"
 msgstr "Nenhum suporte de hardware no pino"
 
@@ -1072,7 +1088,7 @@ msgid ""
 "PWM frequency not writable when variable_frequency is False on construction."
 msgstr ""
 
-#: ports/esp8266/common-hal/pulseio/PWMOut.c ports/esp8266/machine_pwm.c
+#: ports/esp8266/machine_pwm.c ports/esp8266/common-hal/pulseio/PWMOut.c
 #, c-format
 msgid "PWM not supported on pin %d"
 msgstr "PWM não suportado no pino %d"
@@ -1085,8 +1101,8 @@ msgstr "Permissão negada"
 msgid "Pin %q does not have ADC capabilities"
 msgstr "Pino %q não tem recursos de ADC"
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 #: ports/nrf/common-hal/analogio/AnalogIn.c
+#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
 msgid "Pin does not have ADC capabilities"
 msgstr "O pino não tem recursos de ADC"
 
@@ -1119,7 +1135,7 @@ msgstr ""
 msgid "RTC calibration is not supported on this board"
 msgstr "A calibração RTC não é suportada nesta placa"
 
-#: shared-bindings/rtc/RTC.c shared-bindings/time/__init__.c
+#: shared-bindings/time/__init__.c shared-bindings/rtc/RTC.c
 msgid "RTC is not supported on this board"
 msgstr "O RTC não é suportado nesta placa"
 
@@ -1131,7 +1147,7 @@ msgstr ""
 msgid "Read-only"
 msgstr "Somente leitura"
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: py/moduerrno.c extmod/vfs_fat.c
 msgid "Read-only filesystem"
 msgstr "Sistema de arquivos somente leitura"
 
@@ -1186,8 +1202,8 @@ msgstr "Serializer em uso"
 msgid "Slice and value different lengths."
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/pulseio/PulseIn.c shared-bindings/displayio/Bitmap.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/displayio/Group.c
 msgid "Slices not supported"
 msgstr ""
 
@@ -1267,7 +1283,7 @@ msgstr "Para sair, por favor, reinicie a placa sem "
 msgid "Too many channels in sample."
 msgstr "Muitos canais na amostra."
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/ParallelBus.c
+#: shared-bindings/displayio/ParallelBus.c shared-bindings/displayio/FourWire.c
 msgid "Too many display busses"
 msgstr ""
 
@@ -1433,7 +1449,7 @@ msgstr ""
 msgid "abort() called"
 msgstr "abort() chamado"
 
-#: extmod/machine_mem.c ports/unix/modmachine.c
+#: ports/unix/modmachine.c extmod/machine_mem.c
 #, c-format
 msgid "address %08x is not aligned to %d bytes"
 msgstr "endereço %08x não está alinhado com %d bytes"
@@ -1462,7 +1478,7 @@ msgstr ""
 msgid "argument should be a '%q' not a '%q'"
 msgstr ""
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objarray.c
 msgid "array/bytes required on right side"
 msgstr ""
 
@@ -1526,7 +1542,7 @@ msgstr ""
 msgid "buffer size must match format"
 msgstr "buffers devem ser o mesmo tamanho"
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/SPI.c shared-bindings/bitbangio/SPI.c
 msgid "buffer slices must be of equal length"
 msgstr ""
 
@@ -1534,7 +1550,7 @@ msgstr ""
 msgid "buffer too long"
 msgstr "buffer muito longo"
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
+#: shared-bindings/struct/__init__.c py/modstruct.c
 #: shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr ""
@@ -1834,8 +1850,8 @@ msgstr "destination_length deve ser um int >= 0"
 msgid "dict update sequence has wrong length"
 msgstr ""
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/objfloat.c py/runtime.c py/modmath.c
+#: py/objint_longlong.c py/objint_mpz.c
 msgid "division by zero"
 msgstr "divisão por zero"
 
@@ -1847,7 +1863,7 @@ msgstr "pos ou kw args são permitidos"
 msgid "empty"
 msgstr "vazio"
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/modutimeq.c extmod/moduheapq.c
 msgid "empty heap"
 msgstr "heap vazia"
 
@@ -1921,7 +1937,7 @@ msgstr "argumentos extra posicionais passados"
 msgid "ffi_prep_closure_loc"
 msgstr "ffi_prep_closure_loc"
 
-#: shared-bindings/audioio/WaveFile.c shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/audioio/WaveFile.c
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
@@ -2041,9 +2057,9 @@ msgstr ""
 msgid "incorrect padding"
 msgstr "preenchimento incorreto"
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: py/obj.c ports/nrf/common-hal/pulseio/PulseIn.c
 #: ports/esp8266/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c py/obj.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "index out of range"
 msgstr "Índice fora do intervalo"
 
@@ -2091,7 +2107,7 @@ msgstr "comprimento de buffer inválido"
 msgid "invalid cert"
 msgstr "certificado inválido"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid data bits"
 msgstr "Bits de dados inválidos"
 
@@ -2123,11 +2139,11 @@ msgstr "Pino inválido"
 msgid "invalid step"
 msgstr "passo inválido"
 
-#: ports/esp8266/common-hal/busio/UART.c ports/esp8266/machine_uart.c
+#: ports/esp8266/machine_uart.c ports/esp8266/common-hal/busio/UART.c
 msgid "invalid stop bits"
 msgstr "Bits de parada inválidos"
 
-#: py/compile.c py/parse.c
+#: py/parse.c py/compile.c
 msgid "invalid syntax"
 msgstr ""
 
@@ -2164,7 +2180,7 @@ msgstr ""
 msgid "keywords must be strings"
 msgstr ""
 
-#: py/emitinlinethumb.c py/emitinlinextensa.c
+#: py/emitinlinextensa.c py/emitinlinethumb.c
 msgid "label '%q' not defined"
 msgstr ""
 
@@ -2204,7 +2220,7 @@ msgstr ""
 msgid "map buffer too small"
 msgstr ""
 
-#: py/modmath.c shared-bindings/math/__init__.c
+#: shared-bindings/math/__init__.c py/modmath.c
 msgid "math domain error"
 msgstr ""
 
@@ -2280,11 +2296,11 @@ msgstr ""
 msgid "need more than %d values to unpack"
 msgstr "precisa de mais de %d valores para desempacotar"
 
-#: py/objint_longlong.c py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_longlong.c py/objint_mpz.c
 msgid "negative power with no float support"
 msgstr ""
 
-#: py/objint_mpz.c py/runtime.c
+#: py/runtime.c py/objint_mpz.c
 msgid "negative shift count"
 msgstr ""
 
@@ -2304,7 +2320,7 @@ msgstr ""
 msgid "no module named '%q'"
 msgstr ""
 
-#: py/runtime.c shared-bindings/_pixelbuf/__init__.c
+#: shared-bindings/_pixelbuf/__init__.c py/runtime.c
 msgid "no such attribute"
 msgstr ""
 
@@ -2395,8 +2411,8 @@ msgstr ""
 msgid "offset out of bounds"
 msgstr ""
 
-#: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c py/objstr.c py/objarray.c py/objstrunicode.c
+#: py/objtuple.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr ""
 
@@ -2449,9 +2465,9 @@ msgstr ""
 msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/esp8266/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/esp8266/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 msgid "pop from an empty PulseIn"
 msgstr ""
 
@@ -2531,7 +2547,7 @@ msgstr "varredura falhou"
 msgid "schedule stack full"
 msgstr ""
 
-#: lib/utils/pyexec.c py/builtinimport.c
+#: py/builtinimport.c lib/utils/pyexec.c
 msgid "script compilation not supported"
 msgstr "compilação de script não suportada"
 
@@ -2559,7 +2575,7 @@ msgstr ""
 msgid "slice step cannot be zero"
 msgstr ""
 
-#: py/objint.c py/sequence.c
+#: py/sequence.c py/objint.c
 msgid "small int overflow"
 msgstr ""
 
@@ -2687,7 +2703,7 @@ msgstr ""
 msgid "tuple/list required on RHS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/atmel-samd/common-hal/busio/UART.c
 msgid "tx and rx cannot both be None"
 msgstr "TX e RX não podem ser ambos"
 

--- a/ports/nrf/bluetooth/ble_drv.h
+++ b/ports/nrf/bluetooth/ble_drv.h
@@ -50,6 +50,15 @@
 
 typedef void (*ble_drv_evt_handler_t)(ble_evt_t*, void*);
 
+typedef enum {
+    SD_FLASH_OPERATION_DONE,
+    SD_FLASH_OPERATION_IN_PROGRESS,
+    SD_FLASH_OPERATION_ERROR,
+} sd_flash_operation_status_t;
+
+// Flag indicating progress of internal flash operation.
+extern sd_flash_operation_status_t sd_flash_operation_status;
+
 typedef struct ble_drv_evt_handler_entry {
     struct ble_drv_evt_handler_entry *next;
     void *param;

--- a/ports/nrf/supervisor/internal_flash.c
+++ b/ports/nrf/supervisor/internal_flash.c
@@ -38,6 +38,7 @@
 #include "nrf_nvmc.h"
 
 #ifdef BLUETOOTH_SD
+#include "ble_drv.h"
 #include "nrf_sdm.h"
 #endif
 
@@ -71,26 +72,15 @@ uint32_t supervisor_flash_get_block_count(void) {
 }
 
 #ifdef BLUETOOTH_SD
-STATIC bool wait_for_flash_operation(void) {
-    do {
+STATIC void sd_flash_operation_start(void) {
+    sd_flash_operation_status = SD_FLASH_OPERATION_IN_PROGRESS;
+}
+
+STATIC sd_flash_operation_status_t sd_flash_operation_wait_until_done(void) {
+    while (sd_flash_operation_status == SD_FLASH_OPERATION_IN_PROGRESS) {
         sd_app_evt_wait();
-        uint32_t evt_id;
-        uint32_t result = sd_evt_get(&evt_id);
-        if (result == NRF_SUCCESS) {
-            switch (evt_id) {
-            case NRF_EVT_FLASH_OPERATION_SUCCESS:
-                return true;
-
-            case NRF_EVT_FLASH_OPERATION_ERROR:
-                return false;
-
-            default:
-                // Some other event. Wait for a flash event.
-                continue;
-            }
-        }
-        return false;
-    } while (true);
+    }
+    return sd_flash_operation_status;
 }
 #endif
 
@@ -101,27 +91,55 @@ void supervisor_flash_flush(void) {
     if (memcmp(_flash_cache, (void *)_flash_page_addr, FL_PAGE_SZ) != 0) {
 
 #ifdef BLUETOOTH_SD
-    uint8_t sd_en = 0;
-    (void) sd_softdevice_is_enabled(&sd_en);
+        uint8_t sd_en = 0;
+        (void) sd_softdevice_is_enabled(&sd_en);
 
-    if (sd_en) {
-        sd_flash_page_erase(_flash_page_addr / FL_PAGE_SZ);
-        wait_for_flash_operation();    // TODO: handle error return.
-        sd_flash_write((uint32_t *)_flash_page_addr, (uint32_t *)_flash_cache, FL_PAGE_SZ / sizeof(uint32_t));
-        wait_for_flash_operation();
-    } else {
+        if (sd_en) {
+            uint32_t err_code;
+            sd_flash_operation_status_t status;
+
+            sd_flash_operation_start();
+            err_code = sd_flash_page_erase(_flash_page_addr / FL_PAGE_SZ);
+            if (err_code != NRF_SUCCESS) {
+                mp_raise_OSError_msg_varg(translate("Flash erase failed to start, err 0x%04x"), err_code);
+            }
+            status = sd_flash_operation_wait_until_done();
+            if (status == SD_FLASH_OPERATION_ERROR) {
+                mp_raise_OSError_msg(translate("Flash erase failed"));
+            }
+
+            // Divide a full page into parts, because writing a full page causes an assertion failure.
+            // See https://devzone.nordicsemi.com/f/nordic-q-a/40088/sd_flash_write-cause-nrf_fault_id_sd_assert/
+            const size_t BLOCK_PARTS = 2;
+            size_t words_to_write = FL_PAGE_SZ / sizeof(uint32_t) / BLOCK_PARTS;
+            for (size_t i = 0; i < BLOCK_PARTS; i++) {
+                sd_flash_operation_start();
+                err_code = sd_flash_write(((uint32_t *)_flash_page_addr) + i * words_to_write,
+                                          (uint32_t *)_flash_cache + i * words_to_write,
+                                          words_to_write);
+                if (err_code != NRF_SUCCESS) {
+                    mp_raise_OSError_msg_varg(translate("Flash write failed to start, err 0x%04x"), err_code);
+                }
+                status = sd_flash_operation_wait_until_done();
+                if (status == SD_FLASH_OPERATION_ERROR) {
+                    mp_raise_OSError_msg(translate("Flash write failed"));
+                }
+            }
+        } else {
 #endif
-        nrf_nvmc_page_erase(_flash_page_addr);
-        nrf_nvmc_write_words(_flash_page_addr, (uint32_t *)_flash_cache, FL_PAGE_SZ / sizeof(uint32_t));
+            nrf_nvmc_page_erase(_flash_page_addr);
+            nrf_nvmc_write_words(_flash_page_addr, (uint32_t *)_flash_cache, FL_PAGE_SZ / sizeof(uint32_t));
 #ifdef BLUETOOTH_SD
-    }
+        }
 #endif
 
-    _flash_page_addr = NO_CACHE;
     }
+    _flash_page_addr = NO_CACHE;
 }
 
 mp_uint_t supervisor_flash_read_blocks(uint8_t *dest, uint32_t block, uint32_t num_blocks) {
+    // Must write out anything in cache before trying to read.
+    supervisor_flash_flush();
     uint32_t src = lba2addr(block);
     memcpy(dest, (uint8_t*) src, FILESYSTEM_BLOCK_SIZE*num_blocks);
     return 0; // success
@@ -139,9 +157,11 @@ mp_uint_t supervisor_flash_write_blocks(const uint8_t *src, uint32_t lba, uint32
             supervisor_flash_flush();
 
             _flash_page_addr = page_addr;
+            // Copy the current contents of the entire page into the cache.
             memcpy(_flash_cache, (void *)page_addr, FL_PAGE_SZ);
         }
 
+        // Overwrite part or all of the page cache with the src data.
         memcpy(_flash_cache + (addr & (FL_PAGE_SZ - 1)), src, count * FILESYSTEM_BLOCK_SIZE);
 
         // adjust for next run


### PR DESCRIPTION
- Logic to wait for softdevice flash operation events was wrong.
- Trying to write a full 4096-byte flash page causes BLE timeouts in the softdevice. This was discovered several months ago by @hathach while doing bootloader work. See https://devzone.nordicsemi.com/f/nordic-q-a/40088/sd_flash_write-cause-nrf_fault_id_sd_assert/. To fix, we write only half a page at a time.
- Reads from flash did not flush the write cache first.

Still thinking a bit about when else to flush the cache, maybe using auto-reload timer (even if we are not running a code.py). PR for now is for testing -- don't merge quite yet.
 