### PR TITLE
flush flash filesystem once a second

### DIFF
--- a/ports/atmel-samd/background.c
+++ b/ports/atmel-samd/background.c
@@ -27,6 +27,7 @@
 
 #include "audio_dma.h"
 #include "tick.h"
+#include "supervisor/filesystem.h"
 #include "supervisor/usb.h"
 
 #include "py/runtime.h"
@@ -53,6 +54,7 @@ void run_background_tasks(void) {
     #if CIRCUITPY_NETWORK
     network_module_background();
     #endif
+    filesystem_background();
     usb_background();
     assert_heap_ok();
 

--- a/ports/nrf/background.c
+++ b/ports/nrf/background.c
@@ -25,6 +25,7 @@
  */
 
 #include "py/runtime.h"
+#include "supervisor/filesystem.h"
 #include "supervisor/usb.h"
 #include "supervisor/shared/stack.h"
 
@@ -33,6 +34,7 @@
 #endif
 
 void run_background_tasks(void) {
+    filesystem_background();
     usb_background();
 
     #ifdef CIRCUITPY_DISPLAYIO

--- a/ports/nrf/tick.c
+++ b/ports/nrf/tick.c
@@ -27,6 +27,7 @@
 #include "tick.h"
 
 #include "supervisor/shared/autoreload.h"
+#include "supervisor/filesystem.h"
 #include "shared-module/gamepad/__init__.h"
 #include "shared-bindings/microcontroller/Processor.h"
 #include "nrf.h"
@@ -39,14 +40,17 @@ void SysTick_Handler(void) {
     // (every millisecond).
     ticks_ms += 1;
 
-    #ifdef CIRCUITPY_AUTORELOAD_DELAY_MS
-        autoreload_tick();
-    #endif
-    #ifdef CIRCUITPY_GAMEPAD_TICKS
+#if CIRCUITPY_FILESYSTEM_FLUSH_INTERVAL_MS > 0
+    filesystem_tick();
+#endif
+#ifdef CIRCUITPY_AUTORELOAD_DELAY_MS
+    autoreload_tick();
+#endif
+#ifdef CIRCUITPY_GAMEPAD_TICKS
     if (!(ticks_ms & CIRCUITPY_GAMEPAD_TICKS)) {
         gamepad_tick();
     }
-    #endif
+#endif
 }
 
 void tick_init() {

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -592,6 +592,7 @@ void run_background_tasks(void);
 #define MICROPY_VM_HOOK_RETURN run_background_tasks();
 
 #define CIRCUITPY_AUTORELOAD_DELAY_MS 500
+#define CIRCUITPY_FILESYSTEM_FLUSH_INTERVAL_MS 1000
 #define CIRCUITPY_BOOT_OUTPUT_FILE "/boot_out.txt"
 
 #endif  // __INCLUDED_MPCONFIG_CIRCUITPY_H

--- a/supervisor/filesystem.h
+++ b/supervisor/filesystem.h
@@ -31,6 +31,10 @@
 
 #include "extmod/vfs_fat.h"
 
+extern volatile bool filesystem_flush_requested;
+
+void filesystem_background(void);
+void filesystem_tick(void);
 void filesystem_init(bool create_allowed, bool force_create);
 void filesystem_flush(void);
 bool filesystem_present(void);

--- a/supervisor/shared/autoreload.c
+++ b/supervisor/shared/autoreload.c
@@ -29,9 +29,10 @@
 #include "py/mphal.h"
 #include "py/reload.h"
 
-volatile uint32_t autoreload_delay_ms = 0;
-bool autoreload_enabled = false;
+static volatile uint32_t autoreload_delay_ms = 0;
+static bool autoreload_enabled = false;
 static bool autoreload_suspended = false;
+
 volatile bool reload_requested = false;
 
 inline void autoreload_tick() {

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -115,6 +115,8 @@ void filesystem_init(bool create_allowed, bool force_create) {
 }
 
 void filesystem_flush(void) {
+    // Reset interval before next flush.
+    filesystem_flush_interval_ms = CIRCUITPY_FILESYSTEM_FLUSH_INTERVAL_MS;
     supervisor_flash_flush();
 }
 


### PR DESCRIPTION
This PR adds timing code to flush the flash filesystem once a second (if needed). The interval can be varied by a compile constant.

I think this would solve any remaining file-flushing issues. But there may be other issues causing a hard crash that will corrupt the filesystem if they occur during a write, and this won't fix those.

I have done limited testing. I saw one safe-mode reboot on PyPortal that may have been unrelated to the filesystem.

Tagging @makermelissa and @uhrheber on this.