### PR TITLE
Allow NFC pins to be used for other purposes.

### DIFF
--- a/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/mpconfigboard.h
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/mpconfigboard.h
@@ -40,7 +40,3 @@
 #define BOARD_FLASH_SIZE (FLASH_SIZE - 0x4000 - CIRCUITPY_INTERNAL_NVM_SIZE)
 
 #define BOARD_HAS_CRYSTAL 1  // according to the schematic we do
-
-// See https://github.com/adafruit/circuitpython/issues/1300, circuitpython
-// doesn't yet support NFC so just force those pins to be GPIO.
-#define CONFIG_NFCT_PINS_AS_GPIOS

--- a/ports/nrf/common-hal/microcontroller/Pin.c
+++ b/ports/nrf/common-hal/microcontroller/Pin.c
@@ -168,5 +168,15 @@ bool common_hal_mcu_pin_is_free(const mcu_pin_obj_t *pin) {
     }
     #endif
 
+    #ifdef NRF52840
+    // If NFC pins are enabled for NFC, don't allow them to be used for GPIO.
+    if (((NRF_UICR->NFCPINS & UICR_NFCPINS_PROTECT_Msk) ==
+         (UICR_NFCPINS_PROTECT_NFC << UICR_NFCPINS_PROTECT_Pos)) &&
+        (pin->number == 9 || pin->number == 10)) {
+        return false;
+    }
+    #endif
+
     return pin_number_is_free(pin->number);
+
 }

--- a/ports/nrf/mpconfigport.mk
+++ b/ports/nrf/mpconfigport.mk
@@ -27,3 +27,8 @@ CIRCUITPY_RTC = 0
 
 # frequencyio not yet implemented
 CIRCUITPY_FREQUENCYIO = 0
+
+# CircuitPython doesn't yet support NFC so force the NFC antenna pins to be GPIO.
+# See https://github.com/adafruit/circuitpython/issues/1300
+# Defined here because system_nrf52840.c doesn't #include any of our own include files.
+CFLAGS += -DCONFIG_NFCT_PINS_AS_GPIOS


### PR DESCRIPTION
Fixes #1300. We don't support NFC, so the NFC pins can be used for other purposes. This sets a `#define` (in the right place) so that the nRF startup code will flip a bit that enables these pins to be used for non-NFC purposes.

Note that on the PCA10056 board, some jumpers must be moved to make the the black female headers for these pins be connected. See section "8.13 NFC antenna interface" in the nRF52840 DK PDF for more information. More info about possible pin limitations as well in in #1300.

Tagging @uhrheber.

I tested this on PCA10056.