### PR TITLE
TileGrid: pixel_shader is not always a Palette

### DIFF
--- a/shared-module/displayio/ColorConverter.c
+++ b/shared-module/displayio/ColorConverter.c
@@ -39,3 +39,11 @@ bool common_hal_displayio_colorconverter_convert(displayio_colorconverter_t *sel
     *output_color = __builtin_bswap16(packed);
     return true;
 }
+
+// Currently no refresh logic is needed for a ColorConverter.
+bool displayio_colorconverter_needs_refresh(displayio_colorconverter_t *self) {
+    return false;
+}
+
+void displayio_colorconverter_finish_refresh(displayio_colorconverter_t *self) {
+}

--- a/shared-module/displayio/ColorConverter.h
+++ b/shared-module/displayio/ColorConverter.h
@@ -36,4 +36,7 @@ typedef struct {
     mp_obj_base_t base;
 } displayio_colorconverter_t;
 
+bool displayio_colorconverter_needs_refresh(displayio_colorconverter_t *self);
+void displayio_colorconverter_finish_refresh(displayio_colorconverter_t *self);
+
 #endif // MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_COLORCONVERTER_H


### PR DESCRIPTION
`shared-module/TileGrid.c` didn't handle some cases where the `pixel_shader` might be a `ColorConverter` instead of a `Palette`. Fixes #1695.