### PR TITLE
ROTARYIO_MODULE mistakenly omitted from module list

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -212,6 +212,7 @@ SRC_C = \
 	bindings/samd/__init__.c \
 	boards/$(BOARD)/board.c \
 	boards/$(BOARD)/pins.c \
+	eic_handler.c \
 	fatfs_port.c \
 	freetouch/adafruit_ptc.c \
 	lib/libc/string0.c \

--- a/ports/atmel-samd/common-hal/pulseio/PulseIn.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseIn.c
@@ -32,6 +32,7 @@
 #include "hal/include/hal_gpio.h"
 
 #include "background.h"
+#include "eic_handler.h"
 #include "mpconfigport.h"
 #include "py/gc.h"
 #include "py/runtime.h"
@@ -54,7 +55,8 @@ static void pulsein_set_config(pulseio_pulsein_obj_t* self, bool first_edge) {
     } else {
         sense_setting = EIC_CONFIG_SENSE0_RISE_Val;
     }
-    turn_on_eic_channel(self->channel, sense_setting, EIC_HANDLER_PULSEIN);
+    set_eic_handler(self->channel, EIC_HANDLER_PULSEIN);
+    turn_on_eic_channel(self->channel, sense_setting);
 }
 
 void pulsein_interrupt_handler(uint8_t channel) {
@@ -153,6 +155,7 @@ void common_hal_pulseio_pulsein_deinit(pulseio_pulsein_obj_t* self) {
     if (common_hal_pulseio_pulsein_deinited(self)) {
         return;
     }
+    set_eic_handler(self->channel, EIC_HANDLER_NO_INTERRUPT);
     turn_off_eic_channel(self->channel);
     reset_pin_number(self->pin);
     self->pin = NO_PIN;

--- a/ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
@@ -28,6 +28,7 @@
 
 #include "atmel_start_pins.h"
 
+#include "eic_handler.h"
 #include "samd/external_interrupts.h"
 #include "py/runtime.h"
 #include "supervisor/shared/translate.h"
@@ -76,8 +77,11 @@ void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencode
     claim_pin(pin_a);
     claim_pin(pin_b);
 
-    turn_on_eic_channel(self->eic_channel_a, EIC_CONFIG_SENSE0_BOTH_Val, EIC_HANDLER_INCREMENTAL_ENCODER);
-    turn_on_eic_channel(self->eic_channel_b, EIC_CONFIG_SENSE0_BOTH_Val, EIC_HANDLER_INCREMENTAL_ENCODER);
+    set_eic_handler(self->eic_channel_a, EIC_HANDLER_INCREMENTAL_ENCODER);
+    turn_on_eic_channel(self->eic_channel_a, EIC_CONFIG_SENSE0_BOTH_Val);
+
+    set_eic_handler(self->eic_channel_b, EIC_HANDLER_INCREMENTAL_ENCODER);
+    turn_on_eic_channel(self->eic_channel_b, EIC_CONFIG_SENSE0_BOTH_Val);
 }
 
 bool common_hal_rotaryio_incrementalencoder_deinited(rotaryio_incrementalencoder_obj_t* self) {
@@ -88,10 +92,16 @@ void common_hal_rotaryio_incrementalencoder_deinit(rotaryio_incrementalencoder_o
     if (common_hal_rotaryio_incrementalencoder_deinited(self)) {
         return;
     }
+
+    set_eic_handler(self->eic_channel_a, EIC_HANDLER_NO_INTERRUPT);
     turn_off_eic_channel(self->eic_channel_a);
+
+    set_eic_handler(self->eic_channel_b, EIC_HANDLER_NO_INTERRUPT);
     turn_off_eic_channel(self->eic_channel_b);
+
     reset_pin_number(self->pin_a);
     self->pin_a = NO_PIN;
+
     reset_pin_number(self->pin_b);
     self->pin_b = NO_PIN;
 }

--- a/ports/atmel-samd/eic_handler.c
+++ b/ports/atmel-samd/eic_handler.c
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Dan Halbert for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "common-hal/pulseio/PulseIn.h"
+#include "common-hal/rotaryio/IncrementalEncoder.h"
+#include "shared-bindings/microcontroller/__init__.h"
+//#include "samd/external_interrupts.h"
+#include "eic_handler.h"
+
+// Which handler should be called for a particular channel?
+static uint8_t eic_channel_handler[EIC_EXTINT_NUM];
+
+void set_eic_handler(uint8_t channel, uint8_t eic_handler) {
+    eic_channel_handler[channel] = eic_handler;
+}
+
+void shared_eic_handler(uint8_t channel) {
+    uint8_t handler = eic_channel_handler[channel];
+    switch (handler) {
+    case EIC_HANDLER_PULSEIN:
+        pulsein_interrupt_handler(channel);
+        break;
+
+    case EIC_HANDLER_INCREMENTAL_ENCODER:
+        incrementalencoder_interrupt_handler(channel);
+        break;
+
+    default:
+        break;
+    }
+}

--- a/ports/atmel-samd/eic_handler.h
+++ b/ports/atmel-samd/eic_handler.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Dan Halbert for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_ATMEL_SAMD_EIC_HANDLER_H
+#define MICROPY_INCLUDED_ATMEL_SAMD_EIC_HANDLER_H
+
+#define EIC_HANDLER_NO_INTERRUPT 0x0
+#define EIC_HANDLER_PULSEIN 0x1
+#define EIC_HANDLER_INCREMENTAL_ENCODER 0x2
+
+void set_eic_handler(uint8_t channel, uint8_t eic_handler);
+void shared_eic_handler(uint8_t channel);
+
+#endif  // MICROPY_INCLUDED_ATMEL_SAMD_EIC_HANDLER_H

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -360,6 +360,13 @@ extern const struct _mp_obj_module_t os_module;
 #define OS_MODULE_ALT_NAME
 #endif
 
+#if CIRCUITPY_PEW
+extern const struct _mp_obj_module_t pew_module;
+#define PEW_MODULE          { MP_OBJ_NEW_QSTR(MP_QSTR__pew),(mp_obj_t)&pew_module },
+#else
+#define PEW_MODULE
+#endif
+
 #if CIRCUITPY_PIXELBUF
 extern const struct _mp_obj_module_t pixelbuf_module;
 #define PIXELBUF_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR__pixelbuf),(mp_obj_t)&pixelbuf_module },
@@ -474,13 +481,6 @@ extern const struct _mp_obj_module_t ustack_module;
 #define USTACK_MODULE
 #endif
 
-#if CIRCUITPY_PEW
-extern const struct _mp_obj_module_t pew_module;
-#define PEW_MODULE          { MP_OBJ_NEW_QSTR(MP_QSTR__pew),(mp_obj_t)&pew_module },
-#else
-#define PEW_MODULE
-#endif
-
 // These modules are not yet in shared-bindings, but we prefer the non-uxxx names.
 #if MICROPY_PY_UERRNO
 #define ERRNO_MODULE           { MP_ROM_QSTR(MP_QSTR_errno), MP_ROM_PTR(&mp_module_uerrno) },
@@ -546,6 +546,7 @@ extern const struct _mp_obj_module_t pew_module;
     PULSEIO_MODULE \
     RANDOM_MODULE \
     RE_MODULE \
+    ROTARYIO_MODULE \
     RTC_MODULE \
     SAMD_MODULE \
     STAGE_MODULE \


### PR DESCRIPTION
`ROTARYIO_MODULE` mistakenly omitted from `MICROPY_PORT_BUILTIN_MODULES_STRONG_LINKS`. This caused `rotaryio` to be unimportable.

Also, alphabetized `PEW_MODULE` in `#ifndef checks`.