### PR TITLE
update tinyusb to fix disconnect/suspend issue with #1681

### DIFF
--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -92,13 +92,15 @@ void tud_mount_cb(void) {
 void tud_umount_cb(void) {
 }
 
-uint32_t tusb_hal_millis(void) {
-    uint64_t ms;
-    uint32_t us;
-    current_tick(&ms, &us);
-    return (uint32_t) ms;
+// Invoked when usb bus is suspended
+// remote_wakeup_en : if host allows us to perform remote wakeup
+// USB Specs: Within 7ms, device must draw an average current less than 2.5 mA from bus
+void tud_suspend_cb(bool remote_wakeup_en) {
 }
 
+// Invoked when usb bus is resumed
+void tud_resume_cb(void) {
+}
 
 // Invoked when cdc when line state changed e.g connected/disconnected
 // Use to reset to DFU when disconnect with 1200 bps


### PR DESCRIPTION
should fix issue with pc going into suspend mode. Since SAMD doesn't distinguish between suspend and disconnect. `tud_umount_cb()` is never triggered, `tud_suspend_cb()` is instead in both case : disconnect and suspend (e.g pc sleep mode). 

If enabled by host which is most likely for HID device, `tud_remote_wakeup()` can be used to wake up PC from sleep mode. Though it require this PR for usb descriptor https://github.com/adafruit/usb_descriptor/pull/7 . 

We should wait for usb_descriptor PR to be merged, then I will push with usb descriptor submodule update.