### PR TITLE
Fix shift right in displayio.Group

### DIFF
--- a/shared-module/displayio/Group.c
+++ b/shared-module/displayio/Group.c
@@ -73,8 +73,8 @@ void common_hal_displayio_group_insert(displayio_group_t* self, size_t index, mp
         mp_raise_ValueError(translate("Layer must be a Group or TileGrid subclass."));
     }
     // Shift everything right.
-    for (size_t i = index; i < self->size; i++) {
-        self->children[i + 1] = self->children[i];
+    for (size_t i = self->size; i > index; i--) {
+        self->children[i] = self->children[i - 1];
     }
     self->children[index].native = native_layer;
     self->children[index].original = layer;


### PR DESCRIPTION
Fix for #1739. Just a change of direction. Checks out:
```python
Adafruit CircuitPython 4.0.0-beta.6-22-g19278e028-dirty on 2019-04-03; Adafruit PyPortal with samd51j20
>>> import board, displayio
>>> from adafruit_display_shapes.circle import Circle
>>> group = displayio.Group(max_size=10)
>>> board.DISPLAY.show(group)
>>> circle1 = Circle(30, 30, 5, outline=0xFFFFFF) ; group.append(circle1)
>>> circle2 = Circle(50, 30, 10, outline=0xFFFFFF) ; group.append(circle2)
>>> circle3 = Circle(100, 100, 20, outline=0xFFFFFF) ; group.append(circle3)
>>> circle4 = Circle(200, 100, 30, outline=0xFFFFFF) ; group.append(circle4)
>>> group[0]
<Circle object at 20003390>
>>> group[1]
<Circle object at 200035d0>
>>> group[2]
<Circle object at 200035b0>
>>> group[3]
<Circle object at 200038a0>
>>> circle_foo = Circle(100, 150, 10, outline=0xFFFFFF)
>>> group.insert(1, circle_foo)
>>> group[0]
<Circle object at 20003390>
>>> group[1]
<Circle object at 20005ea0>
>>> group[2]
<Circle object at 200035d0>
>>> group[3]
<Circle object at 200035b0>
>>> group[4]
<Circle object at 200038a0>
>>> 
```