### PR TITLE
A display fix and file system flush tweak

### DIFF
--- a/ports/atmel-samd/supervisor/internal_flash.c
+++ b/ports/atmel-samd/supervisor/internal_flash.c
@@ -76,6 +76,9 @@ uint32_t supervisor_flash_get_block_count(void) {
 void supervisor_flash_flush(void) {
 }
 
+void supervisor_flash_release_cache(void) {
+}
+
 void flash_flush(void) {
     supervisor_flash_flush();
 }

--- a/ports/nrf/supervisor/internal_flash.c
+++ b/ports/nrf/supervisor/internal_flash.c
@@ -137,6 +137,9 @@ void supervisor_flash_flush(void) {
     _flash_page_addr = NO_CACHE;
 }
 
+void supervisor_flash_release_cache(void) {
+}
+
 mp_uint_t supervisor_flash_read_blocks(uint8_t *dest, uint32_t block, uint32_t num_blocks) {
     // Must write out anything in cache before trying to read.
     supervisor_flash_flush();

--- a/supervisor/flash.h
+++ b/supervisor/flash.h
@@ -40,7 +40,6 @@
 void supervisor_flash_init(void);
 uint32_t supervisor_flash_get_block_size(void);
 uint32_t supervisor_flash_get_block_count(void);
-void supervisor_flash_flush(void);
 
 // these return 0 on success, non-zero on error
 mp_uint_t supervisor_flash_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t num_blocks);
@@ -49,5 +48,6 @@ mp_uint_t supervisor_flash_write_blocks(const uint8_t *src, uint32_t block_num, 
 struct _fs_user_mount_t;
 void supervisor_flash_init_vfs(struct _fs_user_mount_t *vfs);
 void supervisor_flash_flush(void);
+void supervisor_flash_release_cache(void);
 
 #endif  // MICROPY_INCLUDED_SUPERVISOR_FLASH_H

--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -81,6 +81,7 @@ void supervisor_start_terminal(uint16_t width_px, uint16_t height_px) {
 void supervisor_stop_terminal(void) {
     if (tilegrid_tiles != NULL) {
         free_memory(tilegrid_tiles);
+        tilegrid_tiles = NULL;
         supervisor_terminal_text_grid.inline_tiles = false;
         supervisor_terminal_text_grid.tiles = NULL;
     }

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -42,7 +42,9 @@ volatile bool filesystem_flush_requested = false;
 
 void filesystem_background(void) {
     if (filesystem_flush_requested) {
-        filesystem_flush();
+        filesystem_flush_interval_ms = CIRCUITPY_FILESYSTEM_FLUSH_INTERVAL_MS;
+        // Flush but keep caches
+        supervisor_flash_flush();
         filesystem_flush_requested = false;
     }
 }
@@ -118,6 +120,8 @@ void filesystem_flush(void) {
     // Reset interval before next flush.
     filesystem_flush_interval_ms = CIRCUITPY_FILESYSTEM_FLUSH_INTERVAL_MS;
     supervisor_flash_flush();
+    // Don't keep caches because this is called when starting or stopping the VM.
+    supervisor_flash_release_cache();
 }
 
 void filesystem_set_internal_writable_by_usb(bool writable) {


### PR DESCRIPTION
There are two pieces to this because I found the file system issue and thought it might be the issue.

First, a double free of the terminal's TileGrid was freeing the heap from the supervisor. The flash cache could then allocate over the heap and corrupt it.

Second, the flush is tweaked so that the cache is maintained while a VM is running. This also ensures the cache is released even when no current sector is loaded into it.