### PR TITLE
Stop hard-coding SPI frequency in FourWire

### DIFF
--- a/ports/atmel-samd/boards/hallowing_m0_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m0_express/board.c
@@ -29,6 +29,7 @@
 #include "shared-bindings/displayio/FourWire.h"
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
+#include "shared-bindings/busio/SPI.h"
 
 #include "tick.h"
 
@@ -71,8 +72,10 @@ uint8_t display_init_sequence[] = {
 void board_init(void) {
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
+    busio_spi_obj_t *spi = board_spi();
+    common_hal_busio_spi_configure(spi, 12000000, 0, 0, 8);
     common_hal_displayio_fourwire_construct(bus,
-        board_spi(),
+        spi,
         &pin_PA28, // Command or data
         &pin_PA01, // Chip select
         &pin_PA27); // Reset

--- a/ports/atmel-samd/common-hal/busio/SPI.c
+++ b/ports/atmel-samd/common-hal/busio/SPI.c
@@ -361,3 +361,13 @@ bool common_hal_busio_spi_transfer(busio_spi_obj_t *self, uint8_t *data_out, uin
 uint32_t common_hal_busio_spi_get_frequency(busio_spi_obj_t* self) {
     return samd_peripherals_spi_baud_reg_value_to_baudrate(hri_sercomspi_read_BAUD_reg(self->spi_desc.dev.prvt));
 }
+
+uint8_t common_hal_busio_spi_get_phase(busio_spi_obj_t* self) {
+    void * hw = self->spi_desc.dev.prvt;
+    return hri_sercomspi_get_CTRLA_CPHA_bit(hw);
+}
+
+uint8_t common_hal_busio_spi_get_polarity(busio_spi_obj_t* self) {
+    void * hw = self->spi_desc.dev.prvt;
+    return hri_sercomspi_get_CTRLA_CPOL_bit(hw);
+}

--- a/ports/nrf/common-hal/busio/SPI.c
+++ b/ports/nrf/common-hal/busio/SPI.c
@@ -327,3 +327,13 @@ uint32_t common_hal_busio_spi_get_frequency(busio_spi_obj_t* self) {
         return 0;
     }
 }
+
+uint8_t common_hal_busio_spi_get_phase(busio_spi_obj_t* self) {
+    // XXX(deshipu) implement
+    return 0;
+}
+
+uint8_t common_hal_busio_spi_get_polarity(busio_spi_obj_t* self) {
+    // XXX(deshipu) implement
+    return 0;
+}

--- a/ports/nrf/common-hal/busio/SPI.c
+++ b/ports/nrf/common-hal/busio/SPI.c
@@ -329,11 +329,9 @@ uint32_t common_hal_busio_spi_get_frequency(busio_spi_obj_t* self) {
 }
 
 uint8_t common_hal_busio_spi_get_phase(busio_spi_obj_t* self) {
-    // XXX(deshipu) implement
     return 0;
 }
 
 uint8_t common_hal_busio_spi_get_polarity(busio_spi_obj_t* self) {
-    // XXX(deshipu) implement
     return 0;
 }

--- a/shared-bindings/busio/SPI.h
+++ b/shared-bindings/busio/SPI.h
@@ -61,6 +61,12 @@ extern bool common_hal_busio_spi_transfer(busio_spi_obj_t *self, uint8_t *data_o
 // Return actual SPI bus frequency.
 uint32_t common_hal_busio_spi_get_frequency(busio_spi_obj_t* self);
 
+// Return SPI bus phase.
+uint8_t common_hal_busio_spi_get_phase(busio_spi_obj_t* self);
+
+// Return SPI bus polarity.
+uint8_t common_hal_busio_spi_get_polarity(busio_spi_obj_t* self);
+
 // This is used by the supervisor to claim SPI devices indefinitely.
 extern void common_hal_busio_spi_never_reset(busio_spi_obj_t *self);
 

--- a/shared-module/displayio/FourWire.c
+++ b/shared-module/displayio/FourWire.c
@@ -40,6 +40,9 @@ void common_hal_displayio_fourwire_construct(displayio_fourwire_obj_t* self,
 
     self->bus = spi;
     common_hal_busio_spi_never_reset(self->bus);
+    self->frequency = common_hal_busio_spi_get_frequency(spi);
+    self->polarity = common_hal_busio_spi_get_polarity(spi);
+    self->phase = common_hal_busio_spi_get_phase(spi);
 
     common_hal_digitalio_digitalinout_construct(&self->command, command);
     common_hal_digitalio_digitalinout_switch_to_output(&self->command, true, DRIVE_MODE_PUSH_PULL);
@@ -71,8 +74,8 @@ bool common_hal_displayio_fourwire_begin_transaction(mp_obj_t obj) {
     if (!common_hal_busio_spi_try_lock(self->bus)) {
         return false;
     }
-    // TODO(tannewt): Stop hardcoding SPI frequency, polarity and phase.
-    common_hal_busio_spi_configure(self->bus, 12000000, 0, 0, 8);
+    common_hal_busio_spi_configure(self->bus, self->frequency, self->polarity,
+                                   self->phase, 8);
     common_hal_digitalio_digitalinout_set_value(&self->chip_select, false);
     return true;
 }

--- a/shared-module/displayio/FourWire.h
+++ b/shared-module/displayio/FourWire.h
@@ -38,6 +38,9 @@ typedef struct {
     digitalio_digitalinout_obj_t command;
     digitalio_digitalinout_obj_t chip_select;
     digitalio_digitalinout_obj_t reset;
+    uint32_t frequency;
+    uint8_t polarity;
+    uint8_t phase;
 } displayio_fourwire_obj_t;
 
 #endif // MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_DISPLAYIO_FOURWIRE_H


### PR DESCRIPTION
Instead remember and use the frequency, polarity and phase that was
set when the bus was first created.