### PR TITLE
Don't let a background task call run_background_tasks()

### DIFF
--- a/main.c
+++ b/main.c
@@ -43,6 +43,7 @@
 #include "lib/mp-readline/readline.h"
 #include "lib/utils/pyexec.h"
 
+#include "background.h"
 #include "mpconfigboard.h"
 #include "shared-module/displayio/__init__.h"
 #include "supervisor/cpu.h"
@@ -85,6 +86,8 @@ void do_str(const char *src, mp_parse_input_kind_t input_kind) {
 void start_mp(supervisor_allocation* heap) {
     reset_status_led();
     autoreload_stop();
+
+    background_tasks_reset();
 
     // Stack limit should be less than real stack size, so we have a chance
     // to recover from limit hit.  (Limit is measured in bytes.)

--- a/ports/atmel-samd/background.c
+++ b/ports/atmel-samd/background.c
@@ -42,8 +42,20 @@ volatile uint64_t last_finished_tick = 0;
 
 bool stack_ok_so_far = true;
 
+static bool running_background_tasks = false;
+
+void background_tasks_reset(void) {
+    running_background_tasks = false;
+}
+
 void run_background_tasks(void) {
+    // Don't call ourselves recursively.
+    if (running_background_tasks) {
+        return;
+    }
     assert_heap_ok();
+    running_background_tasks = true;
+
     #if (defined(SAMD21) && defined(PIN_PA02)) || defined(SAMD51)
     audio_dma_background();
     #endif
@@ -56,6 +68,7 @@ void run_background_tasks(void) {
     #endif
     filesystem_background();
     usb_background();
+    running_background_tasks = false;
     assert_heap_ok();
 
     last_finished_tick = ticks_ms;

--- a/ports/atmel-samd/background.h
+++ b/ports/atmel-samd/background.h
@@ -29,6 +29,7 @@
 
 #include <stdbool.h>
 
+void background_tasks_reset(void);
 void run_background_tasks(void);
 void run_background_vm_tasks(void);
 bool background_tasks_ok(void);

--- a/ports/nrf/background.h
+++ b/ports/nrf/background.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2019 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,34 +24,12 @@
  * THE SOFTWARE.
  */
 
-#include "py/runtime.h"
-#include "supervisor/filesystem.h"
-#include "supervisor/usb.h"
-#include "supervisor/shared/stack.h"
+#ifndef MICROPY_INCLUDED_NRF_BACKGROUND_H
+#define MICROPY_INCLUDED_NRF_BACKGROUND_H
 
-#ifdef CIRCUITPY_DISPLAYIO
-#include "shared-module/displayio/__init__.h"
-#endif
+#include <stdbool.h>
 
-static bool running_background_tasks = false;
+void background_tasks_reset(void);
+void run_background_tasks(void);
 
-void background_tasks_reset(void) {
-    running_background_tasks = false;
-}
-
-void run_background_tasks(void) {
-    // Don't call ourselves recursively.
-    if (running_background_tasks) {
-        return;
-    }
-    running_background_tasks = true;
-    filesystem_background();
-    usb_background();
-
-    #ifdef CIRCUITPY_DISPLAYIO
-    displayio_refresh_displays();
-    #endif
-    running_background_tasks = false;
-
-    assert_heap_ok();
-}
+#endif  // MICROPY_INCLUDED_NRF_BACKGROUND_H

--- a/ports/nrf/supervisor/qspi_flash.c
+++ b/ports/nrf/supervisor/qspi_flash.c
@@ -47,8 +47,7 @@ bool spi_flash_command(uint8_t command) {
         .wipwait = false,
         .wren = false
     };
-    nrfx_qspi_cinstr_xfer(&cinstr_cfg, NULL, NULL);
-    return true;
+    return nrfx_qspi_cinstr_xfer(&cinstr_cfg, NULL, NULL) == NRFX_SUCCESS;
 }
 
 bool spi_flash_read_command(uint8_t command, uint8_t* response, uint32_t length) {


### PR DESCRIPTION
This PR prevents recursive calls to `run_background_tasks()`.

In the nrf port, the filesystem flush code was setting the on-board NeoPixel. This code is often called from the background. The NeoPixel code has a long wait in it, and it runs background code while waiting. So background code was calling background code on the nrf port. This caused a debug build to hang up or run very slowly, and possibly had performance impacts on the regular build as well.

