### PR TITLE
Fix version skew for bast_pro_mini build

### DIFF
--- a/ports/atmel-samd/boards/bast_pro_mini_m0/pins.c
+++ b/ports/atmel-samd/boards/bast_pro_mini_m0/pins.c
@@ -1,7 +1,5 @@
 #include "shared-bindings/board/__init__.h"
 
-#include "supervisor/shared/board_busses.h"
-
 STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_PA02) },
     { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_PA04) },

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -57,7 +57,7 @@
 //|   :param int bits:  the number of bits per byte, 7, 8 or 9.
 //|   :param Parity parity:  the parity used for error checking.
 //|   :param int stop:  the number of stop bits, 1 or 2.
-//|   :param int timeout:  the timeout in seconds to wait for the first character and between subsequent characters. Raises ``ValueError`` if timeout >100 seconds.
+//|   :param float timeout:  the timeout in seconds to wait for the first character and between subsequent characters. Raises ``ValueError`` if timeout >100 seconds.
 //|   :param int receiver_buffer_size: the character length of the read buffer (0 to disable). (When a character is 9 bits the buffer will be 2 * receiver_buffer_size bytes.)
 //|
 //|   *New in CircuitPython 4.0:* ``timeout`` has incompatibly changed units from milliseconds to seconds.


### PR DESCRIPTION
`#include "supervisor/shared/board_busses.h"` in `pins.c` is now obsolete.

Also fixed a doc bug in UART timeout parameter (`int` -> `float`)