### PR TITLE
Configure the TFT spi to 24MHz by default

### DIFF
--- a/ports/atmel-samd/boards/pybadge/board.c
+++ b/ports/atmel-samd/boards/pybadge/board.c
@@ -73,6 +73,7 @@ void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, NULL);
     common_hal_busio_spi_never_reset(spi);
+    common_hal_busio_spi_configure(spi, 24000000, 0, 0, 8);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;


### PR DESCRIPTION
That is (slightly) out of spec for the display, but it works reliably.