### PR TITLE
Tweak RTD to install svg2pdfconverter

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,2 +1,10 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
 python:
     version: 3
+    install:
+        - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Just need to merge this to test. I used to have a private circuitpython RTD build but Google found it and confused people.