### PR TITLE
Turn off auto_brightness if brightness is set

### DIFF
--- a/ports/atmel-samd/boards/hallowing_m0_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m0_express/board.c
@@ -98,9 +98,10 @@ void board_init(void) {
         display_init_sequence,
         sizeof(display_init_sequence),
         &pin_PA00,
+        1.0f, // brightness (ignored)
+        true, // auto_brightness
         false, // single_byte_bounds
         false); // data_as_commands
-    common_hal_displayio_display_set_auto_brightness(display, true);
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/pybadge/board.c
+++ b/ports/atmel-samd/boards/pybadge/board.c
@@ -100,9 +100,10 @@ void board_init(void) {
         display_init_sequence,
         sizeof(display_init_sequence),
         &pin_PA00,
+        1.0f, // brightness (ignored)
+        true, // auto_brightness
         false, // single_byte_bounds
         false); // data_as_commands
-    common_hal_displayio_display_set_auto_brightness(display, true);
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/pyportal/board.c
+++ b/ports/atmel-samd/boards/pyportal/board.c
@@ -90,10 +90,10 @@ void board_init(void) {
         display_init_sequence,
         sizeof(display_init_sequence),
         &pin_PB31,
+        1.0f, // brightness (ignored)
+        true, // auto_brightness
         false, // single_byte_bounds
         false); // data_as_commands
-
-    common_hal_displayio_display_set_auto_brightness(display, true);
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/ugame10/board.c
+++ b/ports/atmel-samd/boards/ugame10/board.c
@@ -98,6 +98,8 @@ void board_init(void) {
         display_init_sequence,
         sizeof(display_init_sequence),
         NULL,
+        1.0f, // brightness
+        false, // auto_brightness
         false, // single_byte_bounds
         false); // data as commands
 }

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -50,7 +50,7 @@
 //| Most people should not use this class directly. Use a specific display driver instead that will
 //| contain the initialization sequence at minimum.
 //|
-//| .. class:: Display(display_bus, init_sequence, *, width, height, colstart=0, rowstart=0, rotation=0, color_depth=16, set_column_command=0x2a, set_row_command=0x2b, write_ram_command=0x2c, set_vertical_scroll=0, backlight_pin=None, single_byte_bounds=False, data_as_commands=False)
+//| .. class:: Display(display_bus, init_sequence, *, width, height, colstart=0, rowstart=0, rotation=0, color_depth=16, set_column_command=0x2a, set_row_command=0x2b, write_ram_command=0x2c, set_vertical_scroll=0, backlight_pin=None, brightness=1.0, auto_brightness=False, single_byte_bounds=False, data_as_commands=False)
 //|
 //|   Create a Display object on the given display bus (`displayio.FourWire` or `displayio.ParallelBus`).
 //|
@@ -91,11 +91,13 @@
 //|   :param int write_ram_command: Command used to write pixels values into the update region
 //|   :param int set_vertical_scroll: Command used to set the first row to show
 //|   :param microcontroller.Pin backlight_pin: Pin connected to the display's backlight
+//|   :param bool brightness: Initial display brightness. This value is ignored if auto_brightness is True.
+//|   :param bool auto_brightness: If True, brightness is controlled via an ambient light sensor or other mechanism.
 //|   :param bool single_byte_bounds: Display column and row commands use single bytes
 //|   :param bool data_as_commands: Treat all init and boundary data as SPI commands. Certain displays require this.
 //|
 STATIC mp_obj_t displayio_display_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_display_bus, ARG_init_sequence, ARG_width, ARG_height, ARG_colstart, ARG_rowstart, ARG_rotation, ARG_color_depth, ARG_set_column_command, ARG_set_row_command, ARG_write_ram_command, ARG_set_vertical_scroll, ARG_backlight_pin, ARG_single_byte_bounds, ARG_data_as_commands };
+    enum { ARG_display_bus, ARG_init_sequence, ARG_width, ARG_height, ARG_colstart, ARG_rowstart, ARG_rotation, ARG_color_depth, ARG_set_column_command, ARG_set_row_command, ARG_write_ram_command, ARG_set_vertical_scroll, ARG_backlight_pin, ARG_brightness, ARG_auto_brightness, ARG_single_byte_bounds, ARG_data_as_commands };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_display_bus, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_init_sequence, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -110,6 +112,8 @@ STATIC mp_obj_t displayio_display_make_new(const mp_obj_type_t *type, size_t n_a
         { MP_QSTR_write_ram_command, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0x2c} },
         { MP_QSTR_set_vertical_scroll, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0x0} },
         { MP_QSTR_backlight_pin, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = mp_const_none} },
+        { MP_QSTR_brightness, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = MP_OBJ_NEW_SMALL_INT(1)} },
+        { MP_QSTR_auto_brightness, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
         { MP_QSTR_single_byte_bounds, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
         { MP_QSTR_data_as_commands, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
     };
@@ -128,6 +132,9 @@ STATIC mp_obj_t displayio_display_make_new(const mp_obj_type_t *type, size_t n_a
         backlight_pin = MP_OBJ_TO_PTR(backlight_pin_obj);
         assert_pin_free(backlight_pin);
     }
+
+    mp_float_t brightness = mp_obj_get_float(args[ARG_brightness].u_obj);
+
     mp_int_t rotation = args[ARG_rotation].u_int;
     if (rotation % 90 != 0) {
         mp_raise_ValueError(translate("Display rotation must be in 90 degree increments"));
@@ -145,14 +152,19 @@ STATIC mp_obj_t displayio_display_make_new(const mp_obj_type_t *type, size_t n_a
         mp_raise_RuntimeError(translate("Too many displays"));
     }
     self->base.type = &displayio_display_type;
-    common_hal_displayio_display_construct(self,
-            display_bus, args[ARG_width].u_int, args[ARG_height].u_int, args[ARG_colstart].u_int, args[ARG_rowstart].u_int, rotation,
-            args[ARG_color_depth].u_int, args[ARG_set_column_command].u_int, args[ARG_set_row_command].u_int,
-            args[ARG_write_ram_command].u_int,
-            args[ARG_set_vertical_scroll].u_int,
-            bufinfo.buf, bufinfo.len, MP_OBJ_TO_PTR(backlight_pin),
-            args[ARG_single_byte_bounds].u_bool,
-            args[ARG_data_as_commands].u_bool);
+    common_hal_displayio_display_construct(
+        self,
+        display_bus, args[ARG_width].u_int, args[ARG_height].u_int, args[ARG_colstart].u_int, args[ARG_rowstart].u_int, rotation,
+        args[ARG_color_depth].u_int, args[ARG_set_column_command].u_int, args[ARG_set_row_command].u_int,
+        args[ARG_write_ram_command].u_int,
+        args[ARG_set_vertical_scroll].u_int,
+        bufinfo.buf, bufinfo.len,
+        MP_OBJ_TO_PTR(backlight_pin),
+        brightness,
+        args[ARG_auto_brightness].u_bool,
+        args[ARG_single_byte_bounds].u_bool,
+        args[ARG_data_as_commands].u_bool
+        );
 
     return self;
 }

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -209,8 +209,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_wait_for_frame_obj, displayio_displa
 //|   .. attribute:: brightness
 //|
 //|     The brightness of the display as a float. 0.0 is off and 1.0 is full brightness. When
-//|     `auto_brightness` is True this value will change automatically and setting it will have no
-//|     effect. To control the brightness, auto_brightness must be false.
+//|     `auto_brightness` is True, the value of `brightness` will change automatically.
+//|     If `brightness` is set, `auto_brightness` will be disabled and will be set to False.
 //|
 STATIC mp_obj_t displayio_display_obj_get_brightness(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);
@@ -224,6 +224,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_get_brightness_obj, displayio_displa
 
 STATIC mp_obj_t displayio_display_obj_set_brightness(mp_obj_t self_in, mp_obj_t brightness) {
     displayio_display_obj_t *self = native_display(self_in);
+    common_hal_displayio_display_set_auto_brightness(self, false);
     bool ok = common_hal_displayio_display_set_brightness(self, mp_obj_get_float(brightness));
     if (!ok) {
         mp_raise_RuntimeError(translate("Brightness not adjustable"));
@@ -241,7 +242,10 @@ const mp_obj_property_t displayio_display_brightness_obj = {
 
 //|   .. attribute:: auto_brightness
 //|
-//|     True when the display brightness is auto adjusted.
+//|     True when the display brightness is adjusted automatically, based on an ambient
+//|     light sensor or other method. Note that some displays may have this set to True by default,
+//|     but not actually implement automatic brightness adjustment. `auto_brightness` is set to False
+//|     if `brightness` is set manually.
 //|
 STATIC mp_obj_t displayio_display_obj_get_auto_brightness(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);

--- a/shared-bindings/displayio/Display.h
+++ b/shared-bindings/displayio/Display.h
@@ -40,8 +40,9 @@ void common_hal_displayio_display_construct(displayio_display_obj_t* self,
     mp_obj_t bus, uint16_t width, uint16_t height,
     int16_t colstart, int16_t rowstart, uint16_t rotation, uint16_t color_depth,
     uint8_t set_column_command, uint8_t set_row_command, uint8_t write_ram_command, uint8_t set_vertical_scroll,
-    uint8_t* init_sequence, uint16_t init_sequence_len, const mcu_pin_obj_t* backlight_pin, bool single_byte_bounds,
-    bool data_as_commands);
+    uint8_t* init_sequence, uint16_t init_sequence_len, const mcu_pin_obj_t* backlight_pin,
+    mp_float_t brightness, bool auto_brightness,
+    bool single_byte_bounds, bool data_as_commands);
 
 int32_t common_hal_displayio_display_wait_for_frame(displayio_display_obj_t* self);
 

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -44,7 +44,8 @@ void common_hal_displayio_display_construct(displayio_display_obj_t* self,
         mp_obj_t bus, uint16_t width, uint16_t height, int16_t colstart, int16_t rowstart, uint16_t rotation,
         uint16_t color_depth, uint8_t set_column_command, uint8_t set_row_command,
         uint8_t write_ram_command, uint8_t set_vertical_scroll, uint8_t* init_sequence, uint16_t init_sequence_len,
-        const mcu_pin_obj_t* backlight_pin, bool single_byte_bounds, bool data_as_commands) {
+        const mcu_pin_obj_t* backlight_pin, mp_float_t brightness, bool auto_brightness,
+        bool single_byte_bounds, bool data_as_commands) {
     self->color_depth = color_depth;
     self->set_column_command = set_column_command;
     self->set_row_command = set_row_command;
@@ -53,7 +54,7 @@ void common_hal_displayio_display_construct(displayio_display_obj_t* self,
     self->current_group = NULL;
     self->colstart = colstart;
     self->rowstart = rowstart;
-    self->auto_brightness = false;
+    self->auto_brightness = auto_brightness;
     self->data_as_commands = data_as_commands;
     self->single_byte_bounds = single_byte_bounds;
 
@@ -142,6 +143,9 @@ void common_hal_displayio_display_construct(displayio_display_obj_t* self,
         } else {
             self->backlight_pwm.base.type = &pulseio_pwmout_type;
             common_hal_pulseio_pwmout_never_reset(&self->backlight_pwm);
+            if (!self->auto_brightness) {
+                common_hal_displayio_display_set_brightness(self, brightness);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1796.

`auto_brightness` was interfering with setting `brightness` manually. Changed the semantics per @makermelissa's suggestion to disable `auto_brightness` if `brightness` is set.