### PR TITLE
Off-by-one error for usage of MAX_TX_IN_PROGRESS

### DIFF
--- a/ports/nrf/common-hal/bleio/Characteristic.c
+++ b/ports/nrf/common-hal/bleio/Characteristic.c
@@ -118,7 +118,7 @@ STATIC void gatts_notify_indicate(bleio_characteristic_obj_t *characteristic, mp
         .p_data = bufinfo->buf,
     };
 
-    while (m_tx_in_progress > MAX_TX_IN_PROGRESS) {
+    while (m_tx_in_progress >= MAX_TX_IN_PROGRESS) {
 #ifdef MICROPY_VM_HOOK_LOOP
     MICROPY_VM_HOOK_LOOP
 #endif


### PR DESCRIPTION
There is a maximum number of BLE notify messages that can be queued. We should wait when this queue is full. The check for queue full was off by one.

This is a minor issue: usually this queue does not fill up unless the central receiving the notifications falls behind, or the data is being sent too fast.