### PR TITLE
WIP: Circuitpython nickzoic 1800 wiznet socket

### DIFF
--- a/shared-bindings/socket/__init__.c
+++ b/shared-bindings/socket/__init__.c
@@ -248,7 +248,7 @@ STATIC mp_int_t _socket_recv_into(mod_network_socket_obj_t *sock, byte *buf, mp_
     if (ret == -1) {
         mp_raise_OSError(_errno);
     }
-    return len;
+    return ret;
 }
 
 

--- a/shared-bindings/wiznet/wiznet5k.c
+++ b/shared-bindings/wiznet/wiznet5k.c
@@ -57,8 +57,14 @@
 //|
 //|   :param ~busio.SPI spi: spi bus to use
 //|   :param ~microcontroller.Pin cs: pin to use for Chip Select
-//|   :param ~microcontroller.Pin rst: pin to use for Reset
-//|   :param bool dhcp: boolean flag, whether to start DHCP automatically (default True)
+//|   :param ~microcontroller.Pin rst: pin to use for Reset (optional)
+//|   :param bool dhcp: boolean flag, whether to start DHCP automatically (optional, keyword only, default True)
+//|
+//|   * The reset pin is optional: if supplied it is used to reset the
+//|     wiznet board before initialization.
+//|   * The SPI bus will be initialized appropriately by this library.
+//|   * At present, the WIZNET5K object is a singleton, so only one WizNet
+//|     interface is supported at a time.
 //|
 
 STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -82,7 +88,7 @@ STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, cons
 
 //| .. attribute:: connected
 //|
-//|   is this device physically connected?
+//|   (boolean, readonly) is this device physically connected?
 //|
 
 STATIC mp_obj_t wiznet5k_connected_get_value(mp_obj_t self_in) {
@@ -100,7 +106,9 @@ const mp_obj_property_t wiznet5k_connected_obj = {
 
 //| .. attribute:: dhcp
 //|
-//|   is DHCP active on this device? (set to true to activate DHCP, false to turn it off)
+//|   (boolean, readwrite) is DHCP active on this device?
+//|
+//|   * set to True to activate DHCP, False to turn it off
 //|
 
 STATIC mp_obj_t wiznet5k_dhcp_get_value(mp_obj_t self_in) {
@@ -152,6 +160,7 @@ STATIC mp_obj_t wiznet5k_ifconfig(size_t n_args, const mp_obj_t *args) {
         return mp_obj_new_tuple(4, tuple);
     } else {
         // set
+        // XXX should this automatically stop DHCP here?
         mp_obj_t *items;
         mp_obj_get_array_fixed_n(args[1], 4, &items);
         netutils_parse_ipv4_addr(items[0], netinfo.ip, NETUTILS_BIG);

--- a/shared-bindings/wiznet/wiznet5k.c
+++ b/shared-bindings/wiznet/wiznet5k.c
@@ -51,13 +51,14 @@
 //| :class:`WIZNET5K` -- wrapper for Wiznet 5500 Ethernet interface
 //| ===============================================================
 //|
-//| .. class:: WIZNET5K(spi, cs, rst)
+//| .. class:: WIZNET5K(spi, cs, rst, dhcp=True)
 //|
 //|   Create a new WIZNET5500 interface using the specified pins
 //|
-//|   :param spi: spi bus to use
-//|   :param cs: pin to use for Chip Select
-//|   :param rst: pin to use for Reset
+//|   :param ~busio.SPI spi: spi bus to use
+//|   :param ~microcontroller.Pin cs: pin to use for Chip Select
+//|   :param ~microcontroller.Pin rst: pin to use for Reset
+//|   :param bool dhcp: boolean flag, whether to start DHCP automatically (default True)
 //|
 
 STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/wiznet/wiznet5k.c
+++ b/shared-bindings/wiznet/wiznet5k.c
@@ -77,7 +77,7 @@ STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, cons
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    // XXX check type of ARG_spi?
+    // TODO check type of ARG_spi?
     assert_pin(args[ARG_cs].u_obj, false);
     assert_pin(args[ARG_rst].u_obj, true); // may be NULL
 
@@ -144,6 +144,7 @@ const mp_obj_property_t wiznet5k_dhcp_obj = {
 //|   (ip_address, subnet_mask, gateway_address, dns_server)
 //|
 //|   Or can be called with the same tuple to set those parameters.
+//|   Setting ifconfig parameters turns DHCP off, if it was on.
 //|
 
 STATIC mp_obj_t wiznet5k_ifconfig(size_t n_args, const mp_obj_t *args) {
@@ -160,7 +161,7 @@ STATIC mp_obj_t wiznet5k_ifconfig(size_t n_args, const mp_obj_t *args) {
         return mp_obj_new_tuple(4, tuple);
     } else {
         // set
-        // XXX should this automatically stop DHCP here?
+        wiznet5k_stop_dhcp();
         mp_obj_t *items;
         mp_obj_get_array_fixed_n(args[1], 4, &items);
         netutils_parse_ipv4_addr(items[0], netinfo.ip, NETUTILS_BIG);

--- a/shared-bindings/wiznet/wiznet5k.c
+++ b/shared-bindings/wiznet/wiznet5k.c
@@ -66,15 +66,14 @@ STATIC mp_obj_t wiznet5k_make_new(const mp_obj_type_t *type, size_t n_args, cons
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_spi, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_cs, MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_rst, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_rst, MP_ARG_OBJ, { .u_obj = mp_const_none } },
         { MP_QSTR_dhcp, MP_ARG_KW_ONLY | MP_ARG_BOOL, { .u_bool = true } },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     // XXX check type of ARG_spi?
-    // XXX should ARG_rst be optional?
     assert_pin(args[ARG_cs].u_obj, false);
-    assert_pin(args[ARG_rst].u_obj, false);
+    assert_pin(args[ARG_rst].u_obj, true); // may be NULL
 
     mp_obj_t ret = wiznet5k_create(args[ARG_spi].u_obj, args[ARG_cs].u_obj, args[ARG_rst].u_obj);
     if (args[ARG_dhcp].u_bool) wiznet5k_start_dhcp();

--- a/shared-bindings/wiznet/wiznet5k.c
+++ b/shared-bindings/wiznet/wiznet5k.c
@@ -204,6 +204,7 @@ const mod_network_nic_type_t mod_network_nic_type_wiznet5k = {
     .settimeout = wiznet5k_socket_settimeout,
     .ioctl = wiznet5k_socket_ioctl,
     .timer_tick = wiznet5k_socket_timer_tick,
+    .deinit = wiznet5k_socket_deinit,
 };
 
 #endif // MICROPY_PY_WIZNET5K

--- a/shared-module/network/__init__.c
+++ b/shared-module/network/__init__.c
@@ -99,3 +99,7 @@ void network_module_create_random_mac_address(uint8_t *mac) {
     mac[4] = (uint8_t)(rb2 >> 8);
     mac[5] = (uint8_t)(rb2);
 }
+
+uint16_t network_module_create_random_source_tcp_port(void) {
+    return 0xc000 | shared_modules_random_getrandbits(14);
+}

--- a/shared-module/network/__init__.c
+++ b/shared-module/network/__init__.c
@@ -43,6 +43,11 @@ void network_module_init(void) {
 }
 
 void network_module_deinit(void) {
+    for (mp_uint_t i = 0; i < MP_STATE_PORT(mod_network_nic_list).len; i++) {
+        mp_obj_t nic = MP_STATE_PORT(mod_network_nic_list).items[i];
+        mod_network_nic_type_t *nic_type = (mod_network_nic_type_t*)mp_obj_get_type(nic); 
+        if (nic_type->deinit != NULL) nic_type->deinit(nic);
+    }
     mp_obj_list_set_len(&MP_STATE_PORT(mod_network_nic_list), 0);
 }
 

--- a/shared-module/network/__init__.c
+++ b/shared-module/network/__init__.c
@@ -43,6 +43,7 @@ void network_module_init(void) {
 }
 
 void network_module_deinit(void) {
+    mp_obj_list_set_len(&MP_STATE_PORT(mod_network_nic_list), 0);
 }
 
 void network_module_background(void) {

--- a/shared-module/network/__init__.h
+++ b/shared-module/network/__init__.h
@@ -25,10 +25,11 @@
  * THE SOFTWARE.
  */
 
-void network_module_create_random_mac_address(uint8_t *mac);
-
 #ifndef MICROPY_INCLUDED_SHARED_MODULE_NETWORK___INIT___H
 #define MICROPY_INCLUDED_SHARED_MODULE_NETWORK___INIT___H
+
+void network_module_create_random_mac_address(uint8_t *mac);
+uint16_t network_module_create_random_source_tcp_port(void);
 
 #define MOD_NETWORK_IPADDR_BUF_SIZE (4)
 

--- a/shared-module/network/__init__.h
+++ b/shared-module/network/__init__.h
@@ -62,6 +62,7 @@ typedef struct _mod_network_nic_type_t {
     int (*settimeout)(struct _mod_network_socket_obj_t *socket, mp_uint_t timeout_ms, int *_errno);
     int (*ioctl)(struct _mod_network_socket_obj_t *socket, mp_uint_t request, mp_uint_t arg, int *_errno);
     void (*timer_tick)(struct _mod_network_socket_obj_t *socket);
+    void (*deinit)(struct _mod_network_socket_obj_t *socket);
 } mod_network_nic_type_t;
 
 typedef struct _mod_network_socket_obj_t {

--- a/shared-module/wiznet/wiznet5k.c
+++ b/shared-module/wiznet/wiznet5k.c
@@ -203,8 +203,12 @@ int wiznet5k_socket_accept(mod_network_socket_obj_t *socket, mod_network_socket_
 }
 
 int wiznet5k_socket_connect(mod_network_socket_obj_t *socket, byte *ip, mp_uint_t port, int *_errno) {
+    uint16_t src_port = network_module_create_random_source_tcp_port();
+    // make sure same outgoing port number can't be in use by two different sockets.
+    src_port = (src_port & ~(_WIZCHIP_SOCK_NUM_ - 1)) | socket->u_param.fileno;
+
     // use "bind" function to open the socket in client mode
-    if (wiznet5k_socket_bind(socket, ip, 0, _errno) != 0) {
+    if (wiznet5k_socket_bind(socket, NULL, src_port, _errno) != 0) {
         return -1;
     }
 

--- a/shared-module/wiznet/wiznet5k.c
+++ b/shared-module/wiznet/wiznet5k.c
@@ -106,8 +106,8 @@ int wiznet5k_socket_socket(mod_network_socket_obj_t *socket, int *_errno) {
     }
 
     if (socket->u_param.fileno == -1) {
-        // get first unused socket number
-        for (mp_uint_t sn = 0; sn < _WIZCHIP_SOCK_NUM_; sn++) {
+        // get first unused socket number ... 0 is reserved for DHCP
+        for (mp_uint_t sn = 1; sn < _WIZCHIP_SOCK_NUM_; sn++) {
             if ((wiznet5k_obj.socket_used & (1 << sn)) == 0) {
                 wiznet5k_obj.socket_used |= (1 << sn);
                 socket->u_param.fileno = sn;

--- a/shared-module/wiznet/wiznet5k.c
+++ b/shared-module/wiznet/wiznet5k.c
@@ -364,8 +364,6 @@ mp_obj_t wiznet5k_create(mp_obj_t spi_in, mp_obj_t cs_in, mp_obj_t rst_in) {
     wiznet5k_obj.base.type = (mp_obj_type_t*)&mod_network_nic_type_wiznet5k;
     wiznet5k_obj.cris_state = 0;
     wiznet5k_obj.spi = MP_OBJ_TO_PTR(spi_in);
-    common_hal_digitalio_digitalinout_construct(&wiznet5k_obj.cs, cs_in);
-    common_hal_digitalio_digitalinout_construct(&wiznet5k_obj.rst, rst_in);
     wiznet5k_obj.socket_used = 0;
     wiznet5k_obj.dhcp_socket = -1;
 
@@ -380,13 +378,17 @@ mp_obj_t wiznet5k_create(mp_obj_t spi_in, mp_obj_t cs_in, mp_obj_t rst_in) {
         8 // 8 BITS
     );
 
+    common_hal_digitalio_digitalinout_construct(&wiznet5k_obj.cs, cs_in);
     common_hal_digitalio_digitalinout_switch_to_output(&wiznet5k_obj.cs, 1, DRIVE_MODE_PUSH_PULL);
-    common_hal_digitalio_digitalinout_switch_to_output(&wiznet5k_obj.rst, 1, DRIVE_MODE_PUSH_PULL); 
 
-    common_hal_digitalio_digitalinout_set_value(&wiznet5k_obj.rst, 0);
-    mp_hal_delay_us(10); // datasheet says 2us
-    common_hal_digitalio_digitalinout_set_value(&wiznet5k_obj.rst, 1);
-    mp_hal_delay_ms(160); // datasheet says 150ms
+    if (rst_in) {
+        common_hal_digitalio_digitalinout_construct(&wiznet5k_obj.rst, rst_in);
+        common_hal_digitalio_digitalinout_switch_to_output(&wiznet5k_obj.rst, 1, DRIVE_MODE_PUSH_PULL); 
+        common_hal_digitalio_digitalinout_set_value(&wiznet5k_obj.rst, 0);
+        mp_hal_delay_us(10); // datasheet says 2us
+        common_hal_digitalio_digitalinout_set_value(&wiznet5k_obj.rst, 1);
+        mp_hal_delay_ms(160); // datasheet says 150ms
+    }
 
     reg_wizchip_cris_cbfunc(wiz_cris_enter, wiz_cris_exit);
     reg_wizchip_cs_cbfunc(wiz_cs_select, wiz_cs_deselect);

--- a/shared-module/wiznet/wiznet5k.h
+++ b/shared-module/wiznet/wiznet5k.h
@@ -39,7 +39,7 @@ typedef struct _wiznet5k_obj_t {
     digitalio_digitalinout_obj_t cs;
     digitalio_digitalinout_obj_t rst;
     uint8_t socket_used;
-    bool dhcp_active;
+    int8_t dhcp_socket;
 } wiznet5k_obj_t;
 
 int wiznet5k_gethostbyname(mp_obj_t nic, const char *name, mp_uint_t len, uint8_t *out_ip);

--- a/shared-module/wiznet/wiznet5k.h
+++ b/shared-module/wiznet/wiznet5k.h
@@ -57,6 +57,7 @@ int wiznet5k_socket_setsockopt(mod_network_socket_obj_t *socket, mp_uint_t level
 int wiznet5k_socket_settimeout(mod_network_socket_obj_t *socket, mp_uint_t timeout_ms, int *_errno);
 int wiznet5k_socket_ioctl(mod_network_socket_obj_t *socket, mp_uint_t request, mp_uint_t arg, int *_errno);
 void wiznet5k_socket_timer_tick(mod_network_socket_obj_t *socket);
+void wiznet5k_socket_deinit(mod_network_socket_obj_t *socket);
 mp_obj_t wiznet5k_socket_disconnect(mp_obj_t self_in);
 mp_obj_t wiznet5k_create(mp_obj_t spi_in, mp_obj_t cs_in, mp_obj_t rst_in);
 

--- a/shared-module/wiznet/wiznet5k.h
+++ b/shared-module/wiznet/wiznet5k.h
@@ -39,7 +39,7 @@ typedef struct _wiznet5k_obj_t {
     digitalio_digitalinout_obj_t cs;
     digitalio_digitalinout_obj_t rst;
     uint8_t socket_used;
-    int8_t dhcp_socket;
+    int8_t dhcp_socket; // -1 for DHCP not in use
 } wiznet5k_obj_t;
 
 int wiznet5k_gethostbyname(mp_obj_t nic, const char *name, mp_uint_t len, uint8_t *out_ip);
@@ -60,8 +60,8 @@ void wiznet5k_socket_timer_tick(mod_network_socket_obj_t *socket);
 mp_obj_t wiznet5k_socket_disconnect(mp_obj_t self_in);
 mp_obj_t wiznet5k_create(mp_obj_t spi_in, mp_obj_t cs_in, mp_obj_t rst_in);
 
-void wiznet5k_start_dhcp(void);
-void wiznet5k_stop_dhcp(void);
+int wiznet5k_start_dhcp(void);
+int wiznet5k_stop_dhcp(void);
 bool wiznet5k_check_dhcp(void);
 
 extern const mod_network_nic_type_t mod_network_nic_type_wiznet5k;


### PR DESCRIPTION
* Fixes problems experienced in #703 #1500 and #1800 with DHCP interfering with open sockets.

* Adds "dhcp" as a boolean argument to wiznet constructor (keyword only, default True)
   Setting "dhcp=False" will prevent DHCP from starting.  It can still be started by setting the .dhcp 
   property.