### PR TITLE
Fix hyperlink to circuitpython.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ CircuitPython
 
 |Build Status| |Doc Status| |License| |Discord|
 
-`circuitpython.org <https:/circuitpython.org>`__ \| `Get CircuitPython <#get-circuitpython>`__ \|
+`circuitpython.org <https://circuitpython.org>`__ \| `Get CircuitPython <#get-circuitpython>`__ \|
 `Documentation <#documentation>`__ \| `Contributing <#contributing>`__ \|
 `Branding <#branding>`__ \| `Differences from Micropython <#differences-from-micropython>`__ \|
 `Project Structure <#project-structure>`__


### PR DESCRIPTION
Currently the link goes to: https://github.com/circuitpython.org