### PR TITLE
Filter private methods from tab completion

### DIFF
--- a/py/repl.c
+++ b/py/repl.c
@@ -187,6 +187,11 @@ size_t mp_repl_autocomplete(const char *str, size_t len, const mp_print_t *print
                 if (s_len <= d_len && strncmp(s_start, d_str, s_len) == 0) {
                     mp_load_method_protected(obj, q, dest, true);
                     if (dest[0] != MP_OBJ_NULL) {
+                        // special case; filter out words that begin with underscore
+                        // unless there's already a partial match
+                        if (s_len == 0 && *d_str == '_') {
+                            continue;
+                        }
                         if (match_str == NULL) {
                             match_str = d_str;
                             match_len = d_len;

--- a/py/repl.c
+++ b/py/repl.c
@@ -189,7 +189,7 @@ size_t mp_repl_autocomplete(const char *str, size_t len, const mp_print_t *print
                     if (dest[0] != MP_OBJ_NULL) {
                         // special case; filter out words that begin with underscore
                         // unless there's already a partial match
-                        if (s_len == 0 && *d_str == '_') {
+                        if (s_len == 0 && d_str[0] == '_') {
                             continue;
                         }
                         if (match_str == NULL) {

--- a/tests/cmdline/repl_autocomplete.py
+++ b/tests/cmdline/repl_autocomplete.py
@@ -6,4 +6,7 @@ x = '123'
 1, x.isdi	()
 i = str
 i.lowe	('ABC')
+x = 5
+x.	
+x._	
 None.	

--- a/tests/cmdline/repl_autocomplete.py
+++ b/tests/cmdline/repl_autocomplete.py
@@ -7,6 +7,6 @@ x = '123'
 i = str
 i.lowe	('ABC')
 x = 5
-x.	
+x.	
 x._	
 None.	

--- a/tests/cmdline/repl_autocomplete.py.exp
+++ b/tests/cmdline/repl_autocomplete.py.exp
@@ -12,7 +12,7 @@ Use \.\+
 'abc'
 >>> x = 5
 >>> x.
-from_bytes      to_bytes
+from_bytes      to_bytes[K[K
 >>> x.__class__
 <class 'int'>
 >>> None.[K[K[K[K[K

--- a/tests/cmdline/repl_autocomplete.py.exp
+++ b/tests/cmdline/repl_autocomplete.py.exp
@@ -10,5 +10,10 @@ Use \.\+
 >>> i = str
 >>> i.lower('ABC')
 'abc'
+>>> x = 5
+>>> x.
+from_bytes      to_bytes
+>>> x.__class__
+<class 'int'>
 >>> None.[K[K[K[K[K
 >>> 

--- a/tests/cmdline/repl_autocomplete.py.exp
+++ b/tests/cmdline/repl_autocomplete.py.exp
@@ -12,7 +12,8 @@ Use \.\+
 'abc'
 >>> x = 5
 >>> x.
-from_bytes      to_bytes[K[K
+from_bytes      to_bytes
+>>> x.[K[K
 >>> x.__class__
 <class 'int'>
 >>> None.[K[K[K[K[K

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -27,11 +27,11 @@ RuntimeError:
 # repl
 ame__
 
-__class__       __name__        argv            byteorder
-exc_info        exit            getsizeof       implementation
-maxsize         modules         path            platform
-print_exception                 stderr          stdin
-stdout          version         version_info
+argv            byteorder       exc_info        exit
+getsizeof       implementation  maxsize         modules
+path            platform        print_exception
+stderr          stdin           stdout          version
+version_info
 ementation
 # attrtuple
 (start=1, stop=2, step=3)


### PR DESCRIPTION
Issue #1636 

I built and installed this on my CPX and it works the way I expected:

```
Adafruit CircuitPython 4.0.0-rc.1-23-g54aa1ce6d on 2019-05-06; Adafruit CircuitPlayground Express with samd21g18
>>> class Test:
...     def _internal(self):
...         return 1
...     
...     def external(self):
...         return 2
...     
...     def external_foo(self):
...         return 3
...     
...     def foo(self):
...         return 4
...         
...         
... 
>>> Test.
external        external_foo    foo
>>> Test.external
external        external_foo
>>> Test._
__class__       __module__      __name__        __qualname__
_internal
>>> Test.__
__class__       __module__      __name__        __qualname__
```