### PR TITLE
avoid double float arithmetic in FrequencyIn

### DIFF
--- a/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+++ b/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -103,7 +103,10 @@ void frequencyin_interrupt_handler(uint8_t index) {
                 // record a new event count.
                 if (current_ms - self->last_ms >= self->capture_period) {
                     float new_factor = self->last_us + (1000 - current_us);
-                    self->factor = (current_ms - self->last_ms) + (new_factor / 1000);
+                    // ms difference will not need 64 bits. If we use 64 bits,
+                    // double-precision float routines are required, and we don't
+                    // want to include them because they're very large.
+                    self->factor = (uint32_t) (current_ms - self->last_ms) + (new_factor / 1000);
                     self->last_ms = current_ms;
                     self->last_us = current_us;
 

--- a/ports/atmel-samd/timer_handler.c
+++ b/ports/atmel-samd/timer_handler.c
@@ -48,7 +48,9 @@ void shared_timer_handler(bool is_tc, uint8_t index) {
         uint8_t handler = tc_handler[index];
         switch(handler) {
             case TC_HANDLER_PULSEOUT:
+            #if CIRCUITPY_PULSEIO
                 pulseout_interrupt_handler(index);
+            #endif
                 break;
             case TC_HANDLER_PEW:
             #if CIRCUITPY_PEW


### PR DESCRIPTION
`FrequencyIn` was computing a `float` in an expression that included a `uint64_t` value. This causes software double precision floating arithmetic to be used, which brings a lot of extra code. The difference being calculated is between two closely spaced millisecond time values, so casting to 32 bits should be no problem.

Changing the arithmetic to used `uint32_t` only saves about 3000 bytes, which should improve the space squeeze we are seeing on M0 Express builds a lot.

Also fixed a minor issue that prevented disabling `puleseio`, discovered while I was turning features on and off to find the root cause of the issue.