### PR TITLE
enter four spaces when there are no matches

### DIFF
--- a/py/repl.c
+++ b/py/repl.c
@@ -210,6 +210,10 @@ size_t mp_repl_autocomplete(const char *str, size_t len, const mp_print_t *print
 
             // nothing found
             if (q_first == 0) {
+                if (s_len == 0) {
+                    *compl_str = "    ";
+                    return 4;
+                }
                 // If there're no better alternatives, and if it's first word
                 // in the line, try to complete "import".
                 if (s_start == org_str) {


### PR DESCRIPTION
After https://github.com/adafruit/circuitpython/pull/1850 is merged, if you are on a blank line and press `TAB` it will autofill `import `. Also, if you are in a continuation block like the following:

```
>>> import 
>>> while True:
...     if True:
...     
```

Then currently using `TAB` won't do anything, but it seems like it would be handy if this moved forward by four spaces.

I'm not sure how to run the tests or which should be updated, so please let me know what I can do there.