### PR TITLE
fix #1833, replace expired discord link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Contributors who follow the `Code of
 Conduct <https://github.com/adafruit/circuitpython/blob/master/CODE_OF_CONDUCT.md>`__
 are welcome to submit pull requests and they will be promptly reviewed
 by project admins. Please join the
-`Discord <https://discord.gg/nBQh6qu>`__ too.
+`Discord <http://adafru.it/discord>`__ too.
 
 Branding
 ------------

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Contributors who follow the `Code of
 Conduct <https://github.com/adafruit/circuitpython/blob/master/CODE_OF_CONDUCT.md>`__
 are welcome to submit pull requests and they will be promptly reviewed
 by project admins. Please join the
-`Discord <http://adafru.it/discord>`__ too.
+`Discord <https://adafru.it/discord>`__ too.
 
 Branding
 ------------


### PR DESCRIPTION
The footer already links directly to https://adafru.it/discord, which seems like a more permanent location. I've just replaced the expired link at the top with the same thing.