### PR TITLE
Hide the traceback for the ReloadException.

### DIFF
--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -131,7 +131,9 @@ STATIC int parse_compile_execute(const void *source, mp_parse_input_kind_t input
             // at the moment, the value of SystemExit is unused
             ret = pyexec_system_exit;
         } else {
-            mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
+            if ((mp_obj_t) nlr.ret_val != MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_reload_exception))) {
+                mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
+            }
             ret = PYEXEC_EXCEPTION;
         }
     }


### PR DESCRIPTION
Many users think it's an error when it's us simply stopping the code.