### PR TITLE
Backport fix for building ports/unix with gcc9 from micropython

### DIFF
--- a/lib/utils/printf.c
+++ b/lib/utils/printf.c
@@ -103,9 +103,11 @@ STATIC void strn_print_strn(void *data, const char *str, size_t len) {
     strn_print_env->remain -= len;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
 // uClibc requires this alias to be defined, or there may be link errors
 // when linkings against it statically.
+// GCC 9 gives a warning about missing attributes so it's excluded until
+// uClibc+GCC9 support is needed.
 int __GI_vsnprintf(char *str, size_t size, const char *fmt, va_list ap) __attribute__((weak, alias ("vsnprintf")));
 #endif
 


### PR DESCRIPTION
This pulls in a single commit from micropython to allow the unix port to build with gcc 9 (the default on Fedora 30)

I cherry-picked the commit from micropython to make a future merge simpler.
