### PR TITLE
Include sphinx and recommonmark in docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
-recommonmark
-sphinxcontrib-svg2pdfconverter
+sphinx==1.8.5
+recommonmark==0.5.0
+sphinxcontrib-svg2pdfconverter==0.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
+sphinx
+recommonmark
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
These packages seem necessary for building docs via `make html`.
This also pins the dependency versions to ensure a compatible version of sphinx is used.