### PR TITLE
Document that binascii.hexlify's sep is a single char.

### DIFF
--- a/docs/library/binascii.rst
+++ b/docs/library/binascii.rst
@@ -19,8 +19,8 @@ Functions
    .. admonition:: Difference to CPython
       :class: attention
 
-      If additional argument, *sep* is supplied, it is used as a separator
-      between hexadecimal values.
+      If additional argument, *sep* is supplied, its first byte is used as
+      a separator between hexadecimal values.
 
 .. function:: unhexlify(data)
 


### PR DESCRIPTION
micropython's actual behavior is to use the first character of sep if supplied (or... bug to be filed... a null b`\x00` character if sep is empty).