### PR TITLE
Treat an empty sep on binascii.hexlify as no sep.

### DIFF
--- a/extmod/modubinascii.c
+++ b/extmod/modubinascii.c
@@ -29,6 +29,7 @@
 #include <string.h>
 
 #include "py/runtime.h"
+#include "py/objstr.h"
 #include "py/binary.h"
 #include "extmod/modubinascii.h"
 
@@ -43,7 +44,7 @@ static void check_not_unicode(const mp_obj_t arg) {
 mp_obj_t mod_binascii_hexlify(size_t n_args, const mp_obj_t *args) {
     // Second argument is for an extension to allow a separator to be used
     // between values.
-    const char *sep = NULL;
+    const byte *sep = NULL;
     mp_buffer_info_t bufinfo;
     check_not_unicode(args[0]);
     mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);
@@ -58,8 +59,11 @@ mp_obj_t mod_binascii_hexlify(size_t n_args, const mp_obj_t *args) {
     size_t out_len = bufinfo.len * 2;
     if (n_args > 1) {
         // 1-char separator between hex numbers
-        out_len += bufinfo.len - 1;
-        sep = mp_obj_str_get_str(args[1]);
+        GET_STR_DATA_LEN(args[1], sep_data, sep_len);
+        if (sep_len > 0) {
+            sep = sep_data;
+            out_len += bufinfo.len - 1;
+        }
     }
     vstr_init_len(&vstr, out_len);
     byte *in = bufinfo.buf, *out = (byte*)vstr.buf;

--- a/tests/extmod/ubinascii_micropython.py
+++ b/tests/extmod/ubinascii_micropython.py
@@ -10,6 +10,7 @@ except ImportError:
 # two arguments supported in uPy but not CPython
 a = binascii.hexlify(b'123', ':')
 print(a)
+
 # Ensure that the second argument changes the output but still contains.
 # the hex values.
 assert binascii.hexlify(b'spam', b'-') != binascii.hexlify(b'spam')
@@ -19,6 +20,6 @@ assert binascii.hexlify(b'spam', b'-')[-2:] == binascii.hexlify(b'm')
 # zero length buffer
 print(binascii.hexlify(b'', b':'))
 
-# A zero length sep should acts like no sep.
-# https://github.com/micropython/micropython/issues/2287
+# A zero length sep should act like no sep.
+#  https://github.com/micropython/micropython/issues/2287
 assert binascii.hexlify(b'spam', b'') == binascii.hexlify(b'spam')

--- a/tests/extmod/ubinascii_micropython.py
+++ b/tests/extmod/ubinascii_micropython.py
@@ -12,13 +12,13 @@ a = binascii.hexlify(b'123', ':')
 print(a)
 # Ensure that the second argument changes the output but still contains.
 # the hex values.
-assert binascii.hexlify(b'spam', b'-')) != binascii.hexlify(b'spam'))
-assert binascii.hexlify(b'spam', b'-'))[:2] == binascii.hexlify(b's'))
-assert binascii.hexlify(b'spam', b'-'))[-2:] == binascii.hexlify(b'm'))
+assert binascii.hexlify(b'spam', b'-') != binascii.hexlify(b'spam')
+assert binascii.hexlify(b'spam', b'-')[:2] == binascii.hexlify(b's'))
+assert binascii.hexlify(b'spam', b'-')[-2:] == binascii.hexlify(b'm'))
 
 # zero length buffer
 print(binascii.hexlify(b'', b':'))
 
 # A zero length sep should acts like no sep.
 # https://github.com/micropython/micropython/issues/2287
-assert binascii.hexlify(b'spam', b'')) == binascii.hexlify(b'spam'))
+assert binascii.hexlify(b'spam', b'') == binascii.hexlify(b'spam')

--- a/tests/extmod/ubinascii_micropython.py
+++ b/tests/extmod/ubinascii_micropython.py
@@ -13,8 +13,8 @@ print(a)
 # Ensure that the second argument changes the output but still contains.
 # the hex values.
 assert binascii.hexlify(b'spam', b'-') != binascii.hexlify(b'spam')
-assert binascii.hexlify(b'spam', b'-')[:2] == binascii.hexlify(b's'))
-assert binascii.hexlify(b'spam', b'-')[-2:] == binascii.hexlify(b'm'))
+assert binascii.hexlify(b'spam', b'-')[:2] == binascii.hexlify(b's')
+assert binascii.hexlify(b'spam', b'-')[-2:] == binascii.hexlify(b'm')
 
 # zero length buffer
 print(binascii.hexlify(b'', b':'))

--- a/tests/extmod/ubinascii_micropython.py
+++ b/tests/extmod/ubinascii_micropython.py
@@ -10,6 +10,15 @@ except ImportError:
 # two arguments supported in uPy but not CPython
 a = binascii.hexlify(b'123', ':')
 print(a)
+# Ensure that the second argument changes the output but still contains.
+# the hex values.
+assert binascii.hexlify(b'spam', b'-')) != binascii.hexlify(b'spam'))
+assert binascii.hexlify(b'spam', b'-'))[:2] == binascii.hexlify(b's'))
+assert binascii.hexlify(b'spam', b'-'))[-2:] == binascii.hexlify(b'm'))
 
 # zero length buffer
 print(binascii.hexlify(b'', b':'))
+
+# A zero length sep should acts like no sep.
+# https://github.com/micropython/micropython/issues/2287
+assert binascii.hexlify(b'spam', b'')) == binascii.hexlify(b'spam'))


### PR DESCRIPTION
This fixes https://github.com/micropython/micropython/issues/2287.