### PR TITLE
Removed warning box regarding SAMD21 builds

### DIFF
--- a/shared-bindings/pulseio/__init__.c
+++ b/shared-bindings/pulseio/__init__.c
@@ -54,10 +54,6 @@
 //|     PWMOut
 //|
 
-//| .. warning:: This module is not available in some SAMD21 builds. See the
-//|   :ref:`module-support-matrix` for more info.
-//|
-
 //| All classes change hardware state and should be deinitialized when they
 //| are no longer needed if the program continues after use. To do so, either
 //| call :py:meth:`!deinit` or use a context manager. See


### PR DESCRIPTION
The support matrix shows that pulseio is supported for all SAMD21/SAMD51 variants. Removing warning to avoid confusion.