### PR TITLE
Initial support for RGB led as Status indicator, fixes #1382

### DIFF
--- a/ports/nrf/boards/particle_xenon/mpconfigboard.h
+++ b/ports/nrf/boards/particle_xenon/mpconfigboard.h
@@ -35,9 +35,9 @@
 
 #define MICROPY_HW_LED_STATUS          (&pin_P1_12)
 
-#define MICROPY_HW_RGB_LED_RED         (&pin_P0_13)
-#define MICROPY_HW_RGB_LED_GREEN       (&pin_P0_14)
-#define MICROPY_HW_RGB_LED_BLUE        (&pin_P0_15)
+#define CP_RGB_STATUS_R        (&pin_P0_13)
+#define CP_RGB_STATUS_G        (&pin_P0_14)
+#define CP_RGB_STATUS_B        (&pin_P0_15)
 
 #if QSPI_FLASH_FILESYSTEM
 #define MICROPY_QSPI_DATA0                NRF_GPIO_PIN_MAP(0, 20)

--- a/supervisor/shared/rgb_led_status.c
+++ b/supervisor/shared/rgb_led_status.c
@@ -155,9 +155,7 @@ void reset_status_led() {
         reset_pin_number(MICROPY_HW_APA102_SCK->number);
     #endif
     #if defined(CP_RGB_STATUS_LED)
-        reset_pin_number(CP_RGB_STATUS_R->number);
-        reset_pin_number(CP_RGB_STATUS_G->number);
-        reset_pin_number(CP_RGB_STATUS_B->number);
+        // TODO: Support sharing status LED with user.
     #endif
 }
 
@@ -199,9 +197,9 @@ void new_status_color(uint32_t rgb) {
         uint8_t green_u8 = (rgb_adjusted >> 8) & 0xFF;
         uint8_t blue_u8 = rgb_adjusted & 0xFF;
  
-        status_rgb_color[0] = (uint16_t) (red_u8 << 8) + red_u8;
-        status_rgb_color[1] = (uint16_t) (green_u8 << 8) + green_u8;
-        status_rgb_color[2] = (uint16_t) (blue_u8 << 8) + blue_u8;
+        status_rgb_color[0] = (1<<16) - 1 - ((uint16_t) (red_u8 << 8) + red_u8);
+        status_rgb_color[1] = (1<<16) - 1 - ((uint16_t) (green_u8 << 8) + green_u8);
+        status_rgb_color[2] = (1<<16) - 1 - ((uint16_t) (blue_u8 << 8) + blue_u8);
         
         common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_r, status_rgb_color[0]);
         common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_g, status_rgb_color[1]);
@@ -237,13 +235,14 @@ void temp_status_color(uint32_t rgb) {
         uint8_t green_u8 = (rgb_adjusted >> 8) & 0xFF;
         uint8_t blue_u8 = rgb_adjusted & 0xFF;
  
-        status_rgb_color[0] = (uint16_t) (red_u8 << 8) + red_u8;
-        status_rgb_color[1] = (uint16_t) (green_u8 << 8) + green_u8;
-        status_rgb_color[2] = (uint16_t) (blue_u8 << 8) + blue_u8;
+        uint16_t temp_status_color_rgb[3];
+        temp_status_color_rgb[0] = (uint16_t) (red_u8 << 8) + red_u8;
+        temp_status_color_rgb[1] = (uint16_t) (green_u8 << 8) + green_u8;
+        temp_status_color_rgb[2] = (uint16_t) (blue_u8 << 8) + blue_u8;
         
-        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_r, status_rgb_color[0]);
-        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_g, status_rgb_color[1]);
-        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_b, status_rgb_color[2]);
+        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_r, temp_status_color_rgb[0]);
+        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_g, temp_status_color_rgb[1]);
+        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_b, temp_status_color_rgb[2]);
     #endif
 }
 

--- a/supervisor/shared/rgb_led_status.c
+++ b/supervisor/shared/rgb_led_status.c
@@ -293,7 +293,7 @@ void clear_temp_status() {
 }
 
 uint32_t color_brightness(uint32_t color, uint8_t brightness) {
-    #if defined(MICROPY_HW_NEOPIXEL) || (defined(MICROPY_HW_APA102_MOSI) && defined(MICROPY_HW_APA102_SCK))
+    #if defined(MICROPY_HW_NEOPIXEL) || (defined(MICROPY_HW_APA102_MOSI) && defined(MICROPY_HW_APA102_SCK)) || (defined(CP_RGB_STATUS_LED))
     uint32_t result = ((color & 0xff0000) * brightness / 255) & 0xff0000;
     result += ((color & 0xff00) * brightness / 255) & 0xff00;
     result += ((color & 0xff) * brightness / 255) & 0xff;
@@ -304,7 +304,7 @@ uint32_t color_brightness(uint32_t color, uint8_t brightness) {
 }
 
 void set_rgb_status_brightness(uint8_t level){
-    #if defined(MICROPY_HW_NEOPIXEL) || (defined(MICROPY_HW_APA102_MOSI) && defined(MICROPY_HW_APA102_SCK))
+    #if defined(MICROPY_HW_NEOPIXEL) || (defined(MICROPY_HW_APA102_MOSI) && defined(MICROPY_HW_APA102_SCK)) || (defined(CP_RGB_STATUS_LED))
     rgb_status_brightness = level;
     uint32_t current_color = current_status_color;
     // Temporarily change the current color global to force the new_status_color call to update the

--- a/supervisor/shared/rgb_led_status.c
+++ b/supervisor/shared/rgb_led_status.c
@@ -196,11 +196,17 @@ void new_status_color(uint32_t rgb) {
         uint8_t red_u8 = (rgb_adjusted >> 16) & 0xFF;
         uint8_t green_u8 = (rgb_adjusted >> 8) & 0xFF;
         uint8_t blue_u8 = rgb_adjusted & 0xFF;
- 
-        status_rgb_color[0] = (1<<16) - 1 - ((uint16_t) (red_u8 << 8) + red_u8);
-        status_rgb_color[1] = (1<<16) - 1 - ((uint16_t) (green_u8 << 8) + green_u8);
-        status_rgb_color[2] = (1<<16) - 1 - ((uint16_t) (blue_u8 << 8) + blue_u8);
-        
+
+	#if defined(CP_RGB_STATUS_INVERTED_PWM)
+        status_rgb_color[0] = (1 << 16) - 1 - ((uint16_t) (red_u8 << 8) + red_u8);
+        status_rgb_color[1] = (1 << 16) - 1 - ((uint16_t) (green_u8 << 8) + green_u8);
+        status_rgb_color[2] = (1 << 16) - 1 - ((uint16_t) (blue_u8 << 8) + blue_u8);
+    #else
+        status_rgb_color[0] = (uint16_t) (red_u8 << 8) + red_u8;
+        status_rgb_color[1] = (uint16_t) (green_u8 << 8) + green_u8;
+        status_rgb_color[2] = (uint16_t) (blue_u8 << 8) + blue_u8;
+	#endif
+
         common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_r, status_rgb_color[0]);
         common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_g, status_rgb_color[1]);
         common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_b, status_rgb_color[2]);
@@ -235,11 +241,18 @@ void temp_status_color(uint32_t rgb) {
         uint8_t green_u8 = (rgb_adjusted >> 8) & 0xFF;
         uint8_t blue_u8 = rgb_adjusted & 0xFF;
  
-        uint16_t temp_status_color_rgb[3];
+        uint16_t temp_status_color_rgb[3] = {0};
+		
+	#if defined(CP_RGB_STATUS_INVERTED_PWM)
+        temp_status_color_rgb[0] = (1 << 16) - 1 - ((uint16_t) (red_u8 << 8) + red_u8);
+        temp_status_color_rgb[1] = (1 << 16) - 1 - ((uint16_t) (green_u8 << 8) + green_u8);
+        temp_status_color_rgb[2] = (1 << 16) - 1 - ((uint16_t) (blue_u8 << 8) + blue_u8);
+	#else
         temp_status_color_rgb[0] = (uint16_t) (red_u8 << 8) + red_u8;
         temp_status_color_rgb[1] = (uint16_t) (green_u8 << 8) + green_u8;
         temp_status_color_rgb[2] = (uint16_t) (blue_u8 << 8) + blue_u8;
-        
+    #endif
+
         common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_r, temp_status_color_rgb[0]);
         common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_g, temp_status_color_rgb[1]);
         common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_b, temp_status_color_rgb[2]);

--- a/supervisor/shared/rgb_led_status.c
+++ b/supervisor/shared/rgb_led_status.c
@@ -271,9 +271,24 @@ void clear_temp_status() {
         #endif
     #endif
     #if defined(CP_RGB_STATUS_LED)
-        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_r, status_rgb_color[0]);
-        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_g, status_rgb_color[1]);
-        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_b, status_rgb_color[2]);
+
+	uint16_t red = 0;
+	uint16_t green = 0;
+	uint16_t blue = 0;
+
+	#if defined(CP_RGB_STATUS_INVERTED_PWM)
+		red = (1 << 16) - 1 - status_rgb_color[0];
+		green = (1 << 16) - 1 - status_rgb_color[1];
+		blue = (1 << 16) - 1 - status_rgb_color[2];
+	#else
+		red = status_rgb_color[0];
+		green = status_rgb_color[1];
+		blue = status_rgb_color[2];
+	#endif
+
+        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_r, red);
+        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_g, green);
+        common_hal_pulseio_pwmout_set_duty_cycle(&rgb_status_b, blue);
     #endif
 }
 


### PR DESCRIPTION
Fixes #1382 

Tested with  custom board definition based on the Bast Pro Mini M0 (SAMD21).

Below is the mpconfigboard.h file, notice the CP_RGB_STATUS_R, CP_RGB_STATUS_G and CP_RGB_STATUS_B symbols, i connected there my RGB led, those pins were used because those have PWM capability on my board:
```c
#define MICROPY_HW_BOARD_NAME "Electronic Cats Bast Pro Mini RGB M0"
#define MICROPY_HW_MCU_NAME "samd21e18"

#define MICROPY_PORT_A        (0)
#define MICROPY_PORT_B        (0)
#define MICROPY_PORT_C        (0)

#define CIRCUITPY_INTERNAL_NVM_SIZE 0

#define CP_RGB_STATUS_R	(&pin_PA15)
#define CP_RGB_STATUS_G (&pin_PA23)
#define CP_RGB_STATUS_B (&pin_PA06)

#define DEFAULT_I2C_BUS_SCL (&pin_PA08)
#define DEFAULT_I2C_BUS_SDA (&pin_PA09)

#define DEFAULT_SPI_BUS_SCK (&pin_PA17)
#define DEFAULT_SPI_BUS_MOSI (&pin_PA16)
#define DEFAULT_SPI_BUS_MISO (&pin_PA19)

#define DEFAULT_UART_BUS_RX (&pin_PA01)
#define DEFAULT_UART_BUS_TX (&pin_PA00)

#define BOARD_FLASH_SIZE (0x00040000 - 0x2000 - 0x010000)

#define IGNORE_PIN_PA03     1
#define IGNORE_PIN_PA12     1
#define IGNORE_PIN_PA13     1
#define IGNORE_PIN_PA20     1
#define IGNORE_PIN_PA21     1
// USB is always used.
#define IGNORE_PIN_PA24     1
#define IGNORE_PIN_PA25     1
#define IGNORE_PIN_PA30     1
#define IGNORE_PIN_PA31     1
#define IGNORE_PIN_PB01     1
#define IGNORE_PIN_PB02     1
#define IGNORE_PIN_PB03     1
#define IGNORE_PIN_PB04     1
#define IGNORE_PIN_PB05     1
#define IGNORE_PIN_PB06     1
#define IGNORE_PIN_PB07     1
#define IGNORE_PIN_PB08     1
#define IGNORE_PIN_PB09     1
#define IGNORE_PIN_PB10     1
#define IGNORE_PIN_PB11     1
#define IGNORE_PIN_PB12     1
#define IGNORE_PIN_PB13     1
#define IGNORE_PIN_PB14     1
#define IGNORE_PIN_PB15     1
#define IGNORE_PIN_PB16     1
#define IGNORE_PIN_PB17     1
#define IGNORE_PIN_PB22     1
#define IGNORE_PIN_PB23     1
#define IGNORE_PIN_PB30     1
#define IGNORE_PIN_PB31     1
#define IGNORE_PIN_PB00     1
```

So far i check if those pins are free, if so i construct the pwmout object on three static `pulseio_pwmout_obj_t` variables and set the duty cycle to 0 and freq to 50000.

What i think i haven't been able to do is make the `new_status_color` function work properly, i'm taking the `rgb` (uint32_t) parameter and get the corresponding `r`, `g` and `b` values from it, then i calculate the equivalent porcentage on a uint16_t variable to i can then use it to set the duty cycle with `common_hal_pulseio_pwmout_set_duty_cycle`. I'm checking the behaviour with gdb but most of the times the rgb parameter is being optimized, so i have to check it seeing the value on the `r0` register of the cpu.

I can only see the RGB LED turn on green at startup, after that it remains off.