### PR TITLE
[shared-module/audioio/WaveFile.h] Change sample_rate from uint16_t t…

### DIFF
--- a/shared-module/audioio/WaveFile.h
+++ b/shared-module/audioio/WaveFile.h
@@ -44,7 +44,7 @@ typedef struct {
     uint32_t bytes_remaining;
 
     uint8_t channel_count;
-    uint16_t sample_rate;
+    uint32_t sample_rate;
 
     uint32_t len;
     pyb_file_obj_t* file;


### PR DESCRIPTION
…o uint32_t so it matches the sample rate type parsed from the WAV header format, fix #1922