### PR TITLE
Include display objects in gc

### DIFF
--- a/main.c
+++ b/main.c
@@ -455,6 +455,11 @@ void gc_collect(void) {
     // This collects root pointers from the VFS mount table. Some of them may
     // have lost their references in the VM even though they are mounted.
     gc_collect_root((void**)&MP_STATE_VM(vfs_mount_table), sizeof(mp_vfs_mount_t) / sizeof(mp_uint_t));
+
+    #if CIRCUITPY_DISPLAYIO
+    displayio_gc_collect();
+    #endif
+
     // This naively collects all object references from an approximate stack
     // range.
     gc_collect_root((void**)sp, ((uint32_t)&_estack - sp) / sizeof(uint32_t));

--- a/ports/nrf/background.c
+++ b/ports/nrf/background.c
@@ -29,7 +29,7 @@
 #include "supervisor/usb.h"
 #include "supervisor/shared/stack.h"
 
-#ifdef CIRCUITPY_DISPLAYIO
+#if CIRCUITPY_DISPLAYIO
 #include "shared-module/displayio/__init__.h"
 #endif
 
@@ -48,7 +48,7 @@ void run_background_tasks(void) {
     filesystem_background();
     usb_background();
 
-    #ifdef CIRCUITPY_DISPLAYIO
+    #if CIRCUITPY_DISPLAYIO
     displayio_refresh_displays();
     #endif
     running_background_tasks = false;

--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -93,16 +93,22 @@ void reset_port(void) {
     i2c_reset();
     spi_reset();
     uart_reset();
+
+#if CIRCUITPY_PULSEIO
     pwmout_reset();
     pulseout_reset();
     pulsein_reset();
+#endif
+
     timers_reset();
 
-    #if CIRCUITPY_RTC
+#if CIRCUITPY_RTC
     rtc_reset();
-    #endif
+#endif
 
+#if CIRCUITPY_BLEIO
     bleio_reset();
+#endif
 
     reset_all_pins();
 }

--- a/py/gc.c
+++ b/py/gc.c
@@ -383,6 +383,10 @@ void gc_collect_start(void) {
     #endif
 }
 
+void gc_collect_ptr(void *ptr) {
+    gc_mark(ptr);
+}
+
 void gc_collect_root(void **ptrs, size_t len) {
     for (size_t i = 0; i < len; i++) {
         void *ptr = ptrs[i];

--- a/py/gc.h
+++ b/py/gc.h
@@ -43,6 +43,7 @@ bool gc_is_locked(void);
 // A given port must implement gc_collect by using the other collect functions.
 void gc_collect(void);
 void gc_collect_start(void);
+void gc_collect_ptr(void *ptr);
 void gc_collect_root(void **ptrs, size_t len);
 void gc_collect_end(void);
 

--- a/shared-bindings/board/__init__.c
+++ b/shared-bindings/board/__init__.c
@@ -34,7 +34,6 @@
 //|
 //| .. module:: board
 //|   :synopsis: Board specific pin names
-//|   :platform: SAMD21
 //|
 //| Common container for board base pin names. These will vary from board to
 //| board so don't expect portability when using this module.

--- a/shared-module/board/__init__.c
+++ b/shared-module/board/__init__.c
@@ -103,7 +103,7 @@ void reset_board_busses(void) {
 #endif
 #if BOARD_SPI
     bool display_using_spi = false;
-    #ifdef CIRCUITPY_DISPLAYIO
+    #if CIRCUITPY_DISPLAYIO
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
         if (displays[i].fourwire_bus.bus == spi_singleton) {
             display_using_spi = true;

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -3,6 +3,7 @@
 #include "shared-module/displayio/__init__.h"
 
 #include "lib/utils/interrupt_char.h"
+#include "py/gc.h"
 #include "py/reload.h"
 #include "py/runtime.h"
 #include "shared-bindings/board/__init__.h"
@@ -181,7 +182,6 @@ void common_hal_displayio_release_displays(void) {
 }
 
 void reset_displays(void) {
-    #if CIRCUITPY_DISPLAYIO
     // The SPI buses used by FourWires may be allocated on the heap so we need to move them inline.
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
         if (displays[i].fourwire_bus.base.type != &displayio_fourwire_type) {
@@ -218,5 +218,17 @@ void reset_displays(void) {
         display->auto_brightness = true;
         common_hal_displayio_display_show(display, &circuitpython_splash);
     }
-    #endif
+}
+
+void displayio_gc_collect(void) {
+    for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
+        if (displays[i].display.base.type == NULL) {
+            continue;
+        }
+
+        // Alternatively, we could use gc_collect_root over the whole object,
+        // but this is more precise, and is the only field that needs marking.
+        gc_collect_ptr(displays[i].display.current_group);
+
+    }
 }

--- a/shared-module/displayio/__init__.h
+++ b/shared-module/displayio/__init__.h
@@ -46,5 +46,6 @@ extern displayio_group_t circuitpython_splash;
 
 void displayio_refresh_displays(void);
 void reset_displays(void);
+void displayio_gc_collect(void);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO___INIT___H


### PR DESCRIPTION
The `Group` object in `Display` was not being marked during gc. Because the `display` objects are not on the heap, they can't be added to the root pointer list. So gc them explicitly.

Also:
- Added a `gc_collect_ptr()` routine to gc a single pointer, for convenience.
- Fixed some `#ifdef`s that should have been `#if`s.
- Added some missing `#if`s in `nrf` port.
- Removed redundant `#if` guard in `reset_displays()`.
- Removed a `SAMD21` platform setting from some doc.

In the long run we could use a more general mechanism, or at least perhaps factor this code into `supervisor` to hide the details from `main.c`.  (As discussed with @tannewt.)