### PR TITLE
Added pin for SD CS

### DIFF
--- a/ports/atmel-samd/boards/pygamer/pins.c
+++ b/ports/atmel-samd/boards/pygamer/pins.c
@@ -43,6 +43,9 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_MISO),  MP_ROM_PTR(&pin_PB22) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_MOSI),  MP_ROM_PTR(&pin_PB23) },
 
+    // SDCS, dup of D4
+    { MP_OBJ_NEW_QSTR(MP_QSTR_SD_CS),  MP_ROM_PTR(&pin_PA14) },    
+
     // Special named pins
     { MP_OBJ_NEW_QSTR(MP_QSTR_NEOPIXEL),  MP_ROM_PTR(&pin_PA15) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_LIGHT),  MP_ROM_PTR(&pin_PB04) },


### PR DESCRIPTION
Add pygamer's pin to support SD card

Ref: [forums post](https://forums.adafruit.com/viewtopic.php?f=60&t=152481)

Code used to test:

````python
import sys
import os
import adafruit_sdcard
import board
import busio
import digitalio
import storage

# Connect to the card and mount the filesystem.
spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
cs = digitalio.DigitalInOut(board.SD_CS)
sdcard = adafruit_sdcard.SDCard(spi, cs)
vfs = storage.VfsFat(sdcard)
storage.mount(vfs, "/sd")
sys.path.append("/sd")
os.chdir("/sd")
````