### PR TITLE
forgot tools/git-checkout-latest-tag.sh in PR #1909

### DIFF
--- a/tools/git-checkout-latest-tag.sh
+++ b/tools/git-checkout-latest-tag.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+git fetch --tags
+git checkout $(git describe --tags `git rev-list --tags --max-count=1`)


### PR DESCRIPTION
Forgot to `git add tools/git-checkout-latest-tag.sh` in #1909. I had added a `Makefile` target that used this script.