### PR TITLE
Add baudrate to FourWire and shorten delay.

### DIFF
--- a/ports/atmel-samd/boards/hallowing_m0_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m0_express/board.c
@@ -74,12 +74,12 @@ void board_init(void) {
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     busio_spi_obj_t *spi = common_hal_board_create_spi();
-    common_hal_busio_spi_configure(spi, 12000000, 0, 0, 8);
     common_hal_displayio_fourwire_construct(bus,
         spi,
         &pin_PA28, // Command or data
         &pin_PA01, // Chip select
-        &pin_PA27); // Reset
+        &pin_PA27, // Reset
+        12000000);
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/atmel-samd/boards/pybadge/board.c
+++ b/ports/atmel-samd/boards/pybadge/board.c
@@ -73,7 +73,6 @@ void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, NULL);
     common_hal_busio_spi_never_reset(spi);
-    common_hal_busio_spi_configure(spi, 24000000, 0, 0, 8);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
@@ -81,7 +80,8 @@ void board_init(void) {
         spi,
         &pin_PB05, // TFT_DC Command or data
         &pin_PB07, // TFT_CS Chip select
-        &pin_PA00); // TFT_RST Reset
+        &pin_PA00, // TFT_RST Reset
+        60000000);
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/atmel-samd/boards/pybadge_airlift/board.c
+++ b/ports/atmel-samd/boards/pybadge_airlift/board.c
@@ -51,7 +51,6 @@ void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, NULL);
     common_hal_busio_spi_never_reset(spi);
-    common_hal_busio_spi_configure(spi, 24000000, 0, 0, 8);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
@@ -59,7 +58,8 @@ void board_init(void) {
         spi,
         &pin_PB05, // TFT_DC Command or data
         &pin_PB06, // TFT_CS Chip select
-        &pin_PB07); // TFT_RST Reset
+        &pin_PB07, // TFT_RST Reset
+        60000000);
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/atmel-samd/boards/pygamer/board.c
+++ b/ports/atmel-samd/boards/pygamer/board.c
@@ -73,7 +73,6 @@ void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, NULL);
     common_hal_busio_spi_never_reset(spi);
-    common_hal_busio_spi_configure(spi, 24000000, 0, 0, 8);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
@@ -81,7 +80,8 @@ void board_init(void) {
         spi,
         &pin_PB05, // TFT_DC Command or data
         &pin_PB12, // TFT_CS Chip select
-        &pin_PA00); // TFT_RST Reset
+        &pin_PA00, // TFT_RST Reset
+        60000000);
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/atmel-samd/boards/ugame10/board.c
+++ b/ports/atmel-samd/boards/ugame10/board.c
@@ -74,12 +74,12 @@ void board_init(void) {
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     busio_spi_obj_t *spi = common_hal_board_create_spi();
-    common_hal_busio_spi_configure(spi, 24000000, 0, 0, 8);
     common_hal_displayio_fourwire_construct(bus,
         spi,
         &pin_PA09, // Command or data
         &pin_PA08, // Chip select
-        NULL); // Reset
+        NULL, // Reset
+        24000000);
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -46,7 +46,7 @@
 //| Manage updating a display over SPI four wire protocol in the background while Python code runs.
 //| It doesn't handle display initialization.
 //|
-//| .. class:: FourWire(spi_bus, *, command, chip_select, reset=None)
+//| .. class:: FourWire(spi_bus, *, command, chip_select, reset=None, baudrate=24000000)
 //|
 //|   Create a FourWire object associated with the given pins.
 //|
@@ -59,14 +59,16 @@
 //|   :param microcontroller.Pin command: Data or command pin
 //|   :param microcontroller.Pin chip_select: Chip select pin
 //|   :param microcontroller.Pin reset: Reset pin. When None only software reset can be used
+//|   :param int baudrate: Maximum baudrate in Hz for the display on the bus
 //|
 STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_spi_bus, ARG_command, ARG_chip_select, ARG_reset };
+    enum { ARG_spi_bus, ARG_command, ARG_chip_select, ARG_reset, ARG_baudrate };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_spi_bus, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_command, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_chip_select, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_reset, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = mp_const_none} },
+        { MP_QSTR_baudrate, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 24000000} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -97,7 +99,7 @@ STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_
     }
 
     common_hal_displayio_fourwire_construct(self,
-        MP_OBJ_TO_PTR(spi), command, chip_select, reset);
+        MP_OBJ_TO_PTR(spi), command, chip_select, reset, args[ARG_baudrate].u_int);
     return self;
 }
 

--- a/shared-bindings/displayio/FourWire.h
+++ b/shared-bindings/displayio/FourWire.h
@@ -36,7 +36,7 @@ extern const mp_obj_type_t displayio_fourwire_type;
 
 void common_hal_displayio_fourwire_construct(displayio_fourwire_obj_t* self,
     busio_spi_obj_t* spi, const mcu_pin_obj_t* command,
-    const mcu_pin_obj_t* chip_select, const mcu_pin_obj_t* reset);
+    const mcu_pin_obj_t* chip_select, const mcu_pin_obj_t* reset, uint32_t baudrate);
 
 void common_hal_displayio_fourwire_deinit(displayio_fourwire_obj_t* self);
 

--- a/shared-module/displayio/FourWire.c
+++ b/shared-module/displayio/FourWire.c
@@ -31,13 +31,14 @@
 #include "py/gc.h"
 #include "shared-bindings/busio/SPI.h"
 #include "shared-bindings/digitalio/DigitalInOut.h"
+#include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/time/__init__.h"
 
 #include "tick.h"
 
 void common_hal_displayio_fourwire_construct(displayio_fourwire_obj_t* self,
     busio_spi_obj_t* spi, const mcu_pin_obj_t* command,
-    const mcu_pin_obj_t* chip_select, const mcu_pin_obj_t* reset) {
+    const mcu_pin_obj_t* chip_select, const mcu_pin_obj_t* reset, uint32_t baudrate) {
 
     self->bus = spi;
     common_hal_busio_spi_never_reset(self->bus);
@@ -45,7 +46,7 @@ void common_hal_displayio_fourwire_construct(displayio_fourwire_obj_t* self,
     // of the heap as well.
     gc_never_free(self->bus);
 
-    self->frequency = common_hal_busio_spi_get_frequency(spi);
+    self->frequency = baudrate;
     self->polarity = common_hal_busio_spi_get_polarity(spi);
     self->phase = common_hal_busio_spi_get_phase(spi);
 
@@ -89,7 +90,7 @@ void common_hal_displayio_fourwire_send(mp_obj_t obj, bool command, uint8_t *dat
     displayio_fourwire_obj_t* self = MP_OBJ_TO_PTR(obj);
     if (command) {
         common_hal_digitalio_digitalinout_set_value(&self->chip_select, true);
-        common_hal_time_delay_ms(1);
+        common_hal_mcu_delay_us(1);
         common_hal_digitalio_digitalinout_set_value(&self->chip_select, false);
     }
     common_hal_digitalio_digitalinout_set_value(&self->command, !command);


### PR DESCRIPTION
Speeds up FourWire and makes it easy to set the baudrate of it.