### PR TITLE
Documentation fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ pseudoxml:
 all-source:
 
 locale/circuitpython.pot: all-source
-	find $(TRANSLATE_SOURCES) -iname "*.c" -print0 | sort -z | xargs -0 xgettext -L C -s --add-location=file --keyword=translate -o circuitpython.pot -p locale
+	find $(TRANSLATE_SOURCES) -iname "*.c" -print0 | (LC_ALL=C sort -z) | xargs -0 xgettext -L C -s --add-location=file --keyword=translate -o circuitpython.pot -p locale
 
 translate: locale/circuitpython.pot
 	for po in $(shell ls locale/*.po); do msgmerge -U $$po -s --no-fuzzy-matching --add-location=file locale/circuitpython.pot; done

--- a/docs/library/builtins.rst
+++ b/docs/library/builtins.rst
@@ -182,7 +182,7 @@ Exceptions
 
 .. exception:: OSError
 
-    |see_cpython| `OSError`. CircuitPython doesn't implement the ``errno``
+    |see_cpython| :py:class:`cpython:OSError`. CircuitPython doesn't implement the ``errno``
     attribute, instead use the standard way to access exception arguments:
     ``exc.args[0]``.
 
@@ -198,11 +198,11 @@ Exceptions
 
 .. exception:: SystemExit
 
-    |see_cpython| :py:class:`python:SystemExit`.
+    |see_cpython| :py:class:`cpython:SystemExit`.
 
 .. exception:: TypeError
 
-    |see_cpython| :py:class:`python:TypeError`.
+    |see_cpython| :py:class:`cpython:TypeError`.
 
 .. exception:: ValueError
 

--- a/shared-bindings/digitalio/DigitalInOut.c
+++ b/shared-bindings/digitalio/DigitalInOut.c
@@ -49,8 +49,8 @@
 //| =========================================================
 //|
 //| A DigitalInOut is used to digitally control I/O pins. For analog control of
-//| a pin, see the :py:class:`~digitalio.AnalogIn` and
-//| :py:class:`~digitalio.AnalogOut` classes.
+//| a pin, see the :py:class:`analogio.AnalogIn` and
+//| :py:class:`analogio.AnalogOut` classes.
 //|
 
 //| .. class:: DigitalInOut(pin)

--- a/shared-bindings/digitalio/Direction.c
+++ b/shared-bindings/digitalio/Direction.c
@@ -43,7 +43,7 @@
 //| :class:`Direction` -- defines the direction of a digital pin
 //| =============================================================
 //|
-//| .. class:: digitalio.DigitalInOut.Direction
+//| .. class:: Direction
 //|
 //|     Enum-like class to define which direction the digital values are
 //|     going.

--- a/shared-bindings/digitalio/DriveMode.c
+++ b/shared-bindings/digitalio/DriveMode.c
@@ -31,7 +31,7 @@
 //| :class:`DriveMode` -- defines the drive mode of a digital pin
 //| =============================================================
 //|
-//| .. class:: digitalio.DriveMode
+//| .. class:: DriveMode
 //|
 //|     Enum-like class to define the drive mode used when outputting
 //|     digital values.

--- a/shared-bindings/digitalio/Pull.c
+++ b/shared-bindings/digitalio/Pull.c
@@ -31,7 +31,7 @@
 //| :class:`Pull` -- defines the pull of a digital input pin
 //| =============================================================
 //|
-//| .. class:: digitalio.Pull
+//| .. class:: Pull
 //|
 //|     Enum-like class to define the pull value, if any, used while reading
 //|     digital values in.

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -78,7 +78,8 @@
 //|   The initialization sequence should always leave the display memory access inline with the scan
 //|   of the display to minimize tearing artifacts.
 //|
-//|   :param displayio.FourWire or displayio.ParallelBus display_bus: The bus that the display is connected to
+//|   :param display_bus: The bus that the display is connected to
+//|   :type display_bus: displayio.FourWire or displayio.ParallelBus
 //|   :param buffer init_sequence: Byte-packed initialization sequence.
 //|   :param int width: Width in pixels
 //|   :param int height: Height in pixels
@@ -182,6 +183,7 @@ static displayio_display_obj_t* native_display(mp_obj_t display_obj) {
 //|     Switches to displaying the given group of layers. When group is None, the default
 //|     CircuitPython terminal will be shown.
 //|
+//|     :param Group group: The group to show.
 STATIC mp_obj_t displayio_display_obj_show(mp_obj_t self_in, mp_obj_t group_in) {
     displayio_display_obj_t *self = native_display(self_in);
     displayio_group_t* group = NULL;

--- a/shared-bindings/fontio/Glyph.c
+++ b/shared-bindings/fontio/Glyph.c
@@ -37,7 +37,7 @@
 //|
 //|   Named tuple used to capture a single glyph and its attributes.
 //|
-//|   :param fontio.Bitmap bitmap: the bitmap including the glyph
+//|   :param displayio.Bitmap bitmap: the bitmap including the glyph
 //|   :param int tile_index: the tile index within the bitmap
 //|   :param int width: the width of the glyph's bitmap
 //|   :param int height: the height of the glyph's bitmap


### PR DESCRIPTION
Fixes #1921 and other documentation errors.
Also forced the locale when sorting the translations to ensure consistent sort order.