### PR TITLE
Update import statement in design guide code snippet.

### DIFF
--- a/docs/design_guide.rst
+++ b/docs/design_guide.rst
@@ -60,6 +60,7 @@ For example, a user can then use ``deinit()```::
 
     import digitalio
     import board
+    import time
 
     led = digitalio.DigitalInOut(board.D13)
     led.direction = digitalio.Direction.OUTPUT
@@ -79,6 +80,7 @@ Alternatively, using a ``with`` statement ensures that the hardware is deinitial
 
     import digitalio
     import board
+    import time
 
     with digitalio.DigitalInOut(board.D13) as led:
         led.direction = digitalio.Direction.OUTPUT


### PR DESCRIPTION
The code snippets in the [Design Guide](https://circuitpython.readthedocs.io/en/4.x/docs/design_guide.html) article reference `time`  without the `import time` statement.