### PR TITLE
Use FONTBOUNDINGBOX for font metrics

### DIFF
--- a/tools/gen_display_resources.py
+++ b/tools/gen_display_resources.py
@@ -29,7 +29,6 @@ class BitmapStub:
         self.rows[y] = bytes(row)
 
 f = bitmap_font.load_font(args.font, BitmapStub)
-real_bb = [0, 0]
 
 # Load extra characters from the sample file.
 sample_characters = set()
@@ -61,13 +60,11 @@ for c in all_characters:
         print("Font missing character:", c, ord(c))
         filtered_characters = filtered_characters.replace(c, "")
         continue
-    x, y, dx, dy = g["bounds"]
     if g["shift"][1] != 0:
         raise RuntimeError("y shift")
-    real_bb[0] = max(real_bb[0], x - dx)
-    real_bb[1] = max(real_bb[1], y - dy)
 
-tile_x, tile_y = real_bb
+x, y, dx, dy = f.get_bounding_box()
+tile_x, tile_y = x - dx, y - dy
 total_bits = tile_x * len(all_characters)
 total_bits += 32 - total_bits % 32
 bytes_per_row = total_bits // 8


### PR DESCRIPTION
Instead of iterating over all the glyphs and calculating the maximum
width and height, use the FONTBOUNDINGBOX to determine the size of a
tile for terminalio.

This works better with fonts such as generated by FontForge, that don't
include the empty space in the glyph bitmap itself. It also lets the
font author specify vertical spacing they want.

I only tested this with the default font and with one I generated with
FontForge.