### PR TITLE
Update Arch Linux ARM compiler installation instructions

### DIFF
--- a/ports/atmel-samd/README.rst
+++ b/ports/atmel-samd/README.rst
@@ -124,15 +124,20 @@ Setup
 -----
 
 An ARM compiler is required for the build, along with the associated binary
-utilities.  On Ubuntu, these can be installed as follows:
+utilities.  They can be installed as follows:
 
-.. code-block:: shell
+- Ubuntu
 
-    sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
-    sudo apt-get install gcc-arm-embedded
+  .. code-block:: shell
 
-On Arch Linux the compiler is available for via the package
-``arm-none-eabi-gcc``.
+      sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
+      sudo apt-get install gcc-arm-embedded
+
+- Arch Linux
+
+  .. code-block:: shell
+
+      sudo pacman -S arm-none-eabi-gcc arm-none-eabi-newlib 
 
 For other systems, the `GNU Arm Embedded Toolchain <https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads>`_
 may be available in binary form.


### PR DESCRIPTION
- Add copy-pasteable Arch Linux `arm-none-eabi-gcc` install line similar to Ubuntu example
- Add `arm-none-eabi-newlib` as a required package for Arch
- Reformat Ubuntu and Arch install code-blocks to catch the eye for the impatient

Arch Linux changed their packaging for [arm-none-eabi-gcc](https://www.archlinux.org/packages/community/x86_64/arm-none-eabi-gcc/) by creating [arm-none-eabi-newlib](https://www.archlinux.org/packages/community/any/arm-none-eabi-newlib/) as an optional package. Without it users will get errors about missing header files like:

```
In file included from asf4/samd51/include/samd51j19a.h:49,
                 from asf4/samd51/include/sam.h:38,
                 from ./mpconfigport.h:31,
                 from ../../py/mpconfig.h:45,
                 from ../../py/emitnx64.c:3:
/usr/lib/gcc/arm-none-eabi/9.1.0/include/stdint.h:9:16: fatal error: stdint.h: No such file or directory
    9 | # include_next <stdint.h>
      |                ^~~~~~~~~~
compilation terminated.
```