### PR TITLE
Added conditional compilation around selection of TX pad candidates

### DIFF
--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -88,11 +88,19 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
                 continue;
             }
             potential_sercom = sercom_insts[sercom_index];
-            if (potential_sercom->USART.CTRLA.bit.ENABLE != 0 ||
+#ifdef SAMD21
+	    if (potential_sercom->USART.CTRLA.bit.ENABLE != 0 ||
                 !(tx->sercom[i].pad == 0 ||
                   tx->sercom[i].pad == 2)) {
                 continue;
             }
+#endif
+#ifdef SAMD51
+	    if (potential_sercom->USART.CTRLA.bit.ENABLE != 0 ||
+                !(tx->sercom[i].pad == 0)) {
+                continue;
+            }
+#endif
             tx_pinmux = PINMUX(tx->number, (i == 0) ? MUX_C : MUX_D);
             tx_pad = tx->sercom[i].pad;
             if (rx == mp_const_none) {


### PR DESCRIPTION
Original code was correct for SAMD21
New code for SAMD51 only permits pad-0 for TX
Minimal change of 1 code block

tested on Metro M4, now produces a list compatible with my reading of the datasheet...

`Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
TX pin: microcontroller.pin.A3   RX pin: microcontroller.pin.A1
TX pin: microcontroller.pin.A3   RX pin: microcontroller.pin.A2
TX pin: microcontroller.pin.A4   RX pin: microcontroller.pin.A5
TX pin: microcontroller.pin.A4   RX pin: microcontroller.pin.D4
TX pin: microcontroller.pin.A4   RX pin: microcontroller.pin.D5
TX pin: microcontroller.pin.A4   RX pin: microcontroller.pin.D6
TX pin: microcontroller.pin.D0   RX pin: microcontroller.pin.D1
TX pin: microcontroller.pin.D0   RX pin: microcontroller.pin.D2
TX pin: microcontroller.pin.D0   RX pin: microcontroller.pin.D8
TX pin: microcontroller.pin.D0   RX pin: microcontroller.pin.D9
TX pin: microcontroller.pin.D1   RX pin: microcontroller.pin.D0
TX pin: microcontroller.pin.D1   RX pin: microcontroller.pin.D10
TX pin: microcontroller.pin.D1   RX pin: microcontroller.pin.D11
TX pin: microcontroller.pin.D1   RX pin: microcontroller.pin.D13
TX pin: microcontroller.pin.D1   RX pin: microcontroller.pin.D8
TX pin: microcontroller.pin.D1   RX pin: microcontroller.pin.D9
TX pin: microcontroller.pin.D12          RX pin: microcontroller.pin.D0
TX pin: microcontroller.pin.D12          RX pin: microcontroller.pin.D10
TX pin: microcontroller.pin.D12          RX pin: microcontroller.pin.D11
TX pin: microcontroller.pin.D12          RX pin: microcontroller.pin.D13
TX pin: microcontroller.pin.D12          RX pin: microcontroller.pin.D8
TX pin: microcontroller.pin.D12          RX pin: microcontroller.pin.D9
TX pin: microcontroller.pin.D13          RX pin: microcontroller.pin.D10
TX pin: microcontroller.pin.D13          RX pin: microcontroller.pin.D11
TX pin: microcontroller.pin.D13          RX pin: microcontroller.pin.D12
TX pin: microcontroller.pin.D3   RX pin: microcontroller.pin.D1
TX pin: microcontroller.pin.D3   RX pin: microcontroller.pin.D2
TX pin: microcontroller.pin.D3   RX pin: microcontroller.pin.D8
TX pin: microcontroller.pin.D3   RX pin: microcontroller.pin.D9
TX pin: microcontroller.pin.D7   RX pin: microcontroller.pin.A5
TX pin: microcontroller.pin.D7   RX pin: microcontroller.pin.D4
TX pin: microcontroller.pin.D7   RX pin: microcontroller.pin.D5
TX pin: microcontroller.pin.D7   RX pin: microcontroller.pin.D6`

also confirmed that it compiles for the M0 case, but I don't have my M0 to hand to test...