### PR TITLE
[DRAFT] nrf: enable "reboot to bootloader" functionality

### DIFF
--- a/ports/nrf/common-hal/microcontroller/__init__.c
+++ b/ports/nrf/common-hal/microcontroller/__init__.c
@@ -37,6 +37,7 @@
 #include "shared-bindings/microcontroller/Processor.h"
 
 #include "supervisor/filesystem.h"
+#include "supervisor/shared/safe_mode.h"
 #include "nrfx_glue.h"
 
 // This routine should work even when interrupts are disabled. Used by OneWire
@@ -52,7 +53,13 @@ void common_hal_mcu_enable_interrupts() {
 }
 
 void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
-    // TODO: see atmel-samd for functionality
+    enum { DFU_MAGIC_UF2_RESET = 0x57 };
+    if(runmode == RUNMODE_BOOTLOADER)
+        NRF_POWER->GPREGRET = DFU_MAGIC_UF2_RESET;
+    else
+        NRF_POWER->GPREGRET = 0;
+    if(runmode == RUNMODE_SAFE_MODE)
+        safe_mode_on_next_reset(PROGRAMMATIC_SAFE_MODE);
 }
 
 void common_hal_mcu_reset(void) {


### PR DESCRIPTION
This makes `microcontroller.on_next_reset(RunMode.BOOTLOADER)` work as documented.

Testing performed: flashed on a Particle Xenon with the Feather nRF52840 express bootloader installed, the sequence
```
import microcontroller
microcontroller.on_next_reset(microcontroller.RunMode.BOOTLOADER)
microcontroller.reset()
```
causes the CIRCUITPYTHON device to disappear and be replaced by the NRF840BOOT device.  Just doing `microcontroller.reset()` works as before, as does double-reset.

additionally, the sequence
```
import microcontroller
microcontroller.on_next_reset(microcontroller.RunMode.SAFE_MODE)
microcontroller.reset()
```
causes the serial connection to show
```
The `microcontroller` module was used to boot into safe mode. Press reset to exit safe mode.
```

Finally, calling .reset() without .on_next_reset() leads to a normal restart.

Due to technical limitations, there seems to be no way to undo the effect of requesting SAFE_MODE (though BOOTLOADER takes precedence).