### PR TITLE
Enable link-time optimization for nrf targets

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -95,8 +95,7 @@ ifeq ($(DEBUG), 1)
   CFLAGS += -fno-inline -fno-ipa-sra
 else
   CFLAGS += -Os -DNDEBUG
-  # TODO: Test with -flto
-  ### CFLAGS += -flto
+  CFLAGS += -flto -flto-partition=none
 endif
 
 

--- a/ports/nrf/device/nrf52/startup_nrf52840.c
+++ b/ports/nrf/device/nrf52/startup_nrf52840.c
@@ -116,7 +116,7 @@ void CRYPTOCELL_IRQHandler       (void) __attribute__ ((weak, alias("Default_Han
 void SPIM3_IRQHandler            (void) __attribute__ ((weak, alias("Default_Handler")));
 void PWM3_IRQHandler             (void) __attribute__ ((weak, alias("Default_Handler")));
 
-const func __Vectors[] __attribute__ ((section(".isr_vector"))) = {
+const func __Vectors[] __attribute__ ((used, section(".isr_vector"))) = {
     (func)&_estack,
     Reset_Handler,
     NMI_Handler,


### PR DESCRIPTION
The good: It gets back about 60kB of flash space and increases performance (pystone) by about +14%

The bad: It adds about 12-16 seconds to each target built

The ugly: This is exactly the same thing tried for #1396 by others, and it's not clear why it seems to be working for me today.

See the commit message for further info.