### PR TITLE
Allow to specify pre-allocated buffer in audicore.WaveFile

### DIFF
--- a/shared-bindings/audiocore/WaveFile.c
+++ b/shared-bindings/audiocore/WaveFile.c
@@ -47,7 +47,8 @@
 //|   Load a .wav file for playback with `audioio.AudioOut` or `audiobusio.I2SOut`.
 //|
 //|   :param typing.BinaryIO file: Already opened wave file
-//|   :param bytearray buffer: Optional pre-allocated buffer
+//|   :param bytearray buffer: Optional pre-allocated buffer, that will be split in half and used for double-buffering of the data. If not provided, two 512 byte buffers are allocated internally.
+//|
 //|
 //|   Playing a wave file from flash::
 //|

--- a/shared-bindings/audiocore/WaveFile.h
+++ b/shared-bindings/audiocore/WaveFile.h
@@ -35,7 +35,7 @@
 extern const mp_obj_type_t audioio_wavefile_type;
 
 void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t* self,
-    pyb_file_obj_t* file);
+    pyb_file_obj_t* file, uint8_t *buffer, size_t buffer_size);
 
 void common_hal_audioio_wavefile_deinit(audioio_wavefile_obj_t* self);
 bool common_hal_audioio_wavefile_deinited(audioio_wavefile_obj_t* self);

--- a/shared-module/audiocore/WaveFile.c
+++ b/shared-module/audiocore/WaveFile.c
@@ -46,7 +46,9 @@ struct wave_format_chunk {
 };
 
 void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t* self,
-                                           pyb_file_obj_t* file) {
+                                           pyb_file_obj_t* file,
+                                           uint8_t *buffer,
+                                           size_t buffer_size) {
     // Load the wave
     self->file = file;
     uint8_t chunk_header[16];
@@ -84,7 +86,6 @@ void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t* self,
     }
     // Get the sample_rate
     self->sample_rate = format.sample_rate;
-    self->len = 256;
     self->channel_count = format.num_channels;
     self->bits_per_sample = format.bits_per_sample;
 
@@ -111,21 +112,31 @@ void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t* self,
 
     // Try to allocate two buffers, one will be loaded from file and the other
     // DMAed to DAC.
-    self->buffer = m_malloc(self->len, false);
-    if (self->buffer == NULL) {
-        common_hal_audioio_wavefile_deinit(self);
-        mp_raise_msg(&mp_type_MemoryError, translate("Couldn't allocate first buffer"));
-    }
+    if (buffer_size) {
+        self->len = buffer_size / 2;
+        self->buffer = buffer;
+        self->second_buffer = buffer + self->len;
+    } else {
+        self->len = 256;
+        self->buffer = m_malloc(self->len, false);
+        if (self->buffer == NULL) {
+            common_hal_audioio_wavefile_deinit(self);
+            mp_raise_msg(&mp_type_MemoryError,
+                         translate("Couldn't allocate first buffer"));
+        }
 
-    self->second_buffer = m_malloc(self->len, false);
-    if (self->second_buffer == NULL) {
-        common_hal_audioio_wavefile_deinit(self);
-        mp_raise_msg(&mp_type_MemoryError, translate("Couldn't allocate second buffer"));
+        self->second_buffer = m_malloc(self->len, false);
+        if (self->second_buffer == NULL) {
+            common_hal_audioio_wavefile_deinit(self);
+            mp_raise_msg(&mp_type_MemoryError,
+                         translate("Couldn't allocate second buffer"));
+        }
     }
 }
 
 void common_hal_audioio_wavefile_deinit(audioio_wavefile_obj_t* self) {
     self->buffer = NULL;
+    self->second_buffer = NULL;
 }
 
 bool common_hal_audioio_wavefile_deinited(audioio_wavefile_obj_t* self) {


### PR DESCRIPTION
This also allows us to control the size of the buffer. Half of the
buffer will be used for the fist, and half for the second internal
buffer.