### PR TITLE
Improvements to Audio DMA management

### DIFF
--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -270,10 +270,13 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t* dma,
 }
 
 void audio_dma_stop(audio_dma_t* dma) {
-    audio_dma_disable_channel(dma->dma_channel);
-    disable_event_channel(dma->event_channel);
-    MP_STATE_PORT(playing_audio)[dma->dma_channel] = NULL;
-    audio_dma_state[dma->dma_channel] = NULL;
+    uint8_t channel = dma->dma_channel;
+    if (channel < AUDIO_DMA_CHANNEL_COUNT) {
+        audio_dma_disable_channel(channel);
+        disable_event_channel(dma->event_channel);
+        MP_STATE_PORT(playing_audio)[channel] = NULL;
+        audio_dma_state[channel] = NULL;
+    }
     dma->dma_channel = AUDIO_DMA_CHANNEL_COUNT;
 }
 

--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -261,6 +261,7 @@ void audio_dma_stop(audio_dma_t* dma) {
     dma_disable_channel(dma->dma_channel);
     disable_event_channel(dma->event_channel);
     MP_STATE_PORT(playing_audio)[dma->dma_channel] = NULL;
+    audio_dma_state[dma->dma_channel] = NULL;
 
     dma->dma_channel = AUDIO_DMA_CHANNEL_COUNT;
 }

--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -35,6 +35,8 @@
 #include "py/mpstate.h"
 #include "py/runtime.h"
 
+#if CIRCUITPY_AUDIOIO || CIRCUITPY_AUDIOBUSIO
+
 static audio_dma_t* audio_dma_state[AUDIO_DMA_CHANNEL_COUNT];
 
 // This cannot be in audio_dma_state because it's volatile.
@@ -348,3 +350,4 @@ void audio_dma_background(void) {
         audio_dma_pending[i] = false;
     }
 }
+#endif

--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -52,13 +52,13 @@ uint8_t find_free_audio_dma_channel(void) {
 
 void audio_dma_disable_channel(uint8_t channel) {
     if (channel >= AUDIO_DMA_CHANNEL_COUNT)
-        mp_raise_RuntimeError(translate("Internal error: disable invalid dma channel"));
+        return;
     dma_disable_channel(channel);
 }
 
 void audio_dma_enable_channel(uint8_t channel) {
     if (channel >= AUDIO_DMA_CHANNEL_COUNT)
-        mp_raise_RuntimeError(translate("Internal error: enable invalid dma channel"));
+        return;
     dma_enable_channel(channel);
 }
 

--- a/ports/atmel-samd/audio_dma.h
+++ b/ports/atmel-samd/audio_dma.h
@@ -83,6 +83,9 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t* dma,
                                           bool output_signed,
                                           uint32_t output_register_address,
                                           uint8_t dma_trigger_source);
+
+void audio_dma_disable_channel(uint8_t channel);
+void audio_dma_enable_channel(uint8_t channel);
 void audio_dma_stop(audio_dma_t* dma);
 bool audio_dma_get_playing(audio_dma_t* dma);
 void audio_dma_pause(audio_dma_t* dma);

--- a/ports/atmel-samd/background.c
+++ b/ports/atmel-samd/background.c
@@ -56,7 +56,7 @@ void run_background_tasks(void) {
     assert_heap_ok();
     running_background_tasks = true;
 
-    #if (defined(SAMD21) && defined(PIN_PA02)) || defined(SAMD51)
+    #if CIRCUITPY_AUDIOIO || CIRCUITPY_AUDIOBUSIO
     audio_dma_background();
     #endif
     #if CIRCUITPY_DISPLAYIO

--- a/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+++ b/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
@@ -385,7 +385,7 @@ uint32_t common_hal_audiobusio_pdmin_record_to_buffer(audiobusio_pdmin_obj_t* se
     init_event_channel_interrupt(event_channel, CORE_GCLK, EVSYS_ID_GEN_DMAC_CH_0 + dma_channel);
     // Turn on serializer now to get it in sync with DMA.
     i2s_set_serializer_enable(self->serializer, true);
-    dma_enable_channel(dma_channel);
+    audio_dma_enable_channel(dma_channel);
 
     // Record
     uint32_t buffers_processed = 0;
@@ -466,7 +466,7 @@ uint32_t common_hal_audiobusio_pdmin_record_to_buffer(audiobusio_pdmin_obj_t* se
     }
 
     disable_event_channel(event_channel);
-    dma_disable_channel(dma_channel);
+    audio_dma_disable_channel(dma_channel);
     // Turn off serializer, but leave clock on, to avoid mic startup delay.
     i2s_set_serializer_enable(self->serializer, false);
 


### PR DESCRIPTION
This includes a fix which directly addresses the original problem, as well as some further fixes for other weirdness I noticed along the way. In particular, while I saw some spurious soft-resets with only the first fix, I believe the change to `audio_dma_stop` somehow has the side effect of fixing some spurious soft resets I was seeing during testing.  Or, at least, they changed from 1 per ~300s to <1 per 30,000s while running the #1908 reproducer.

Testing performed: Ran the reproducer script overnight on a CPX, no hard lockup.

@c-k-dillard said the first commit in this PR fixed things for them too.