### PR TITLE
usb_hid: Allow USB work to progress while waiting for tud_hid_ready

### DIFF
--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -47,7 +47,11 @@ void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t* 
 
     // Wait until interface is ready, timeout = 2 seconds
     uint64_t end_ticks = ticks_ms + 2000;
-    while ( (ticks_ms < end_ticks) && !tud_hid_ready() ) { }
+    while ( (ticks_ms < end_ticks) && !tud_hid_ready() ) {
+#ifdef MICROPY_VM_HOOK_LOOP
+        MICROPY_VM_HOOK_LOOP;
+#endif
+    }
 
     if ( !tud_hid_ready() ) {
         mp_raise_msg(&mp_type_OSError,  translate("USB Busy"));


### PR DESCRIPTION
Otherwise, examples like the one attached to the related issue fail
because tud_hid_ready never returns true.

Testing performed: Adapted the example to nrf particle xenon (it was
handy), removed dependency on IR, verified that the problem occurred
before this change, and that it was fixed after this change.

Closes: #2048

My reproducing program:
```
from adafruit_hid.keyboard import Keyboard
from adafruit_hid.keycode import Keycode
from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS

import time
time.sleep(1)

keyboard = Keyboard()
time.sleep(1)
try:
    print("about to press", time.monotonic())
    keyboard.press( Keycode.ZERO )
    print("about to release immediately", time.monotonic())
    keyboard.release_all()
    print("released all", time.monotonic())
finally:
    print("reached finally-handler", time.monotonic())
    time.sleep(1)
    print("about to release in finally-handler", time.monotonic())
    keyboard.release_all()
```
Note that a side-effect of the problem is that messages printed over usb-serial don't appear in a timely fashion either, so pay attention to the time.monotonic() timestamps to understand how long various steps took.