### PR TITLE
nrf: Enable the adafruit_hid modules on nrf boards

### DIFF
--- a/ports/nrf/mpconfigport.mk
+++ b/ports/nrf/mpconfigport.mk
@@ -34,3 +34,5 @@ CIRCUITPY_FREQUENCYIO = 0
 # See https://github.com/adafruit/circuitpython/issues/1300
 # Defined here because system_nrf52840.c doesn't #include any of our own include files.
 CFLAGS += -DCONFIG_NFCT_PINS_AS_GPIOS
+
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_HID


### PR DESCRIPTION
Cross-platform bugs aside (#2048) this seems to work, and there's plenty of room available.