### PR TITLE
py: mp_obj_tuple_get: accept any item which can use tuple_getiter

### DIFF
--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -251,7 +251,8 @@ mp_obj_t mp_obj_new_tuple(size_t n, const mp_obj_t *items) {
 }
 
 void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items) {
-    assert(MP_OBJ_IS_TYPE(self_in, &mp_type_tuple));
+    // type check is done on getiter method to allow tuple, namedtuple, attrtuple
+    mp_check_self(mp_obj_get_type(self_in)->getiter == mp_obj_tuple_getiter);
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
     *len = self->len;
     *items = &self->items[0];


### PR DESCRIPTION
.. such as namedtuple and attrtuple objects.  This is the same predicate used elsewhere in the file to check for adequate compatibility between the types.

This was discovered due to crashing `time.time()` on the nrf port.

Closes: #2052