### PR TITLE
Add support for nrf boards that don't have an external crystal

### DIFF
--- a/ports/nrf/peripherals/nrf/clocks.c
+++ b/ports/nrf/peripherals/nrf/clocks.c
@@ -26,11 +26,21 @@
  */
 
 #include "nrfx.h"
+#include "mpconfigboard.h" // for BOARD_HAS_CRYSTAL
+
+static inline bool board_has_crystal(void) {
+#ifdef BOARD_HAS_CRYSTAL
+    return BOARD_HAS_CRYSTAL == 1;
+#else
+    return false;
+#endif
+}
 
 void nrf_peripherals_clocks_init(void) {
-    // Set low-frequency clock source to be crystal. If there's a crystalless board, this will need to be
-    // generalized.
-    NRF_CLOCK->LFCLKSRC = (uint32_t)((CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos) & CLOCK_LFCLKSRC_SRC_Msk);
+    // Set low-frequency clock source to be either an external 32.768kHz crystal if one exists on the board
+    // or an internal 32.768 kHz RC oscillator otherwise
+    uint32_t clock_src = board_has_crystal() ? CLOCK_LFCLKSRC_SRC_Xtal : CLOCK_LFCLKSRC_SRC_RC;
+    NRF_CLOCK->LFCLKSRC = (uint32_t)((clock_src << CLOCK_LFCLKSRC_SRC_Pos) & CLOCK_LFCLKSRC_SRC_Msk);
     NRF_CLOCK->TASKS_LFCLKSTART = 1UL;
 
     // Wait for clocks to start.


### PR DESCRIPTION
This PR adds support for nrf boards that don't have an external crystal.
This was tested using a modified version of [ble_demo_periph](https://github.com/adafruit/Adafruit_CircuitPython_BLE/blob/master/examples/ble_demo_periph.py) example from [Adafruit_CircuitPython_BLE](https://github.com/adafruit/Adafruit_CircuitPython_BLE)
on a custom board without an external crystal and on a Particle Xenon (which has an external crystal).
