### PR TITLE
update tinyusb to 00c440cb

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -184,8 +184,7 @@ SRC_C += \
 # USB source files for nrf52840
 ifeq ($(MCU_SUB_VARIANT),nrf52840)
 SRC_C += \
-	lib/tinyusb/src/portable/nordic/nrf5x/dcd_nrf5x.c \
-	lib/tinyusb/src/portable/nordic/nrf5x/hal_nrf5x.c
+	lib/tinyusb/src/portable/nordic/nrf5x/dcd_nrf5x.c
 endif
 
 SRC_COMMON_HAL_EXPANDED = $(addprefix shared-bindings/, $(SRC_COMMON_HAL)) \


### PR DESCRIPTION
Update tinyusb to current tip of master. Current version is a PR commit but not the resulting merge. @hathach recently updated tinyusb from the `develop` branch.

In the latest version, `lib/tinyusb/src/portable/nordic/nrf5x/hal_nrf5x.c` was merged with `lib/tinyusb/src/portable/nordic/nrf5x/dcd_nrf5x.c`, so a mentioned of hal_nrf5x.c was removed from `ports/nrf/Makefile`.

Tested on nRF52840, Metro M0, and Metro M4. CIRCUITPY and REPL work. HID keyboard tested on all three.