### PR TITLE
Samd dma tracking

### DIFF
--- a/ports/atmel-samd/audio_dma.h
+++ b/ports/atmel-samd/audio_dma.h
@@ -64,7 +64,8 @@ uint8_t audiosample_channel_count(mp_obj_t sample_obj);
 void audio_dma_init(audio_dma_t* dma);
 void audio_dma_reset(void);
 
-uint8_t find_free_audio_dma_channel(void);
+uint8_t audio_dma_allocate_channel(void);
+void audio_dma_free_channel(uint8_t channel);
 
 // This sets everything up but doesn't start the timer.
 // Sample is the python object for the sample to play.

--- a/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+++ b/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
@@ -355,7 +355,7 @@ static uint16_t filter_sample(uint32_t pdm_samples[4]) {
 // output_buffer_length is the number of slots, not the number of bytes.
 uint32_t common_hal_audiobusio_pdmin_record_to_buffer(audiobusio_pdmin_obj_t* self,
         uint16_t* output_buffer, uint32_t output_buffer_length) {
-    uint8_t dma_channel = find_free_audio_dma_channel();
+    uint8_t dma_channel = audio_dma_allocate_channel();
     uint8_t event_channel = find_sync_event_channel();
     if (event_channel >= EVSYS_SYNCH_NUM) {
         mp_raise_RuntimeError(translate("All sync event channels in use"));
@@ -464,7 +464,7 @@ uint32_t common_hal_audiobusio_pdmin_record_to_buffer(audiobusio_pdmin_obj_t* se
     }
 
     disable_event_channel(event_channel);
-    audio_dma_disable_channel(dma_channel);
+    audio_dma_free_channel(dma_channel);
     // Turn off serializer, but leave clock on, to avoid mic startup delay.
     i2s_set_serializer_enable(self->serializer, false);
 

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -312,6 +312,10 @@ void common_hal_audioio_audioout_deinit(audioio_audioout_obj_t* self) {
         return;
     }
 
+    if (common_hal_audioio_audioout_get_playing(self)) {
+        common_hal_audioio_audioout_stop(self);
+    }
+
     // Ramp the DAC down.
     ramp_value(self->quiescent_value, 0);
 


### PR DESCRIPTION
Previously, we depended on allocated channels to always be "dma_channel_enabled".  However, (A) sometimes, many operations would take place between find_free_audio_dma_channel and audio_dma_enable_channel, and (B) some debugging I did led me to believe that "dma_channel_enabled" would become false when the hardware ended a scheduled DMA transaction, but while a CP object would still think it owned the DMA channel.

((B) is not documented in the datasheet and I am not 100% convinced that my debugging session was not simply missing where we were disabling the channel, but in either case, it shows a need to directly track allocated separately from enabled)

Therefore,
 * Add audio_dma_{allocate,free}_channel.
   * audio_dma_free_channel implies audio_dma_disable_channel
   * track via a new array audio_dma_allocated[]
 * clear all allocated flags on soft-reboot
 * Convert find_free_audio_dma_channel to audio_dma_allocate_channel
   * use audio_dma_allocated[] instead of dma_channel_enabled() to check
     availability
 * remove find_free_audio_dma_channel
 * For each one, find a matching audio_dma_disable_channel to convert
   to audio_dma_free_channel
 * in common_hal_audioio_audioout_deinit ensure to stop audio output if it was running

Testing Performed: AudioIn and PDMIn on Metro M4 Express work as expected (playing RawSamples and computing RMS audio levels).  **Note that I2SOut is possibly affected by these changes but I do not yet have my I2S board set up and did not test with it.**

Closes: #2058