### PR TITLE
Add random dithering to ColorConverter

### DIFF
--- a/shared-bindings/displayio/ColorConverter.c
+++ b/shared-bindings/displayio/ColorConverter.c
@@ -51,11 +51,18 @@
 // TODO(tannewt): Add support for other color formats.
 //|
 STATIC mp_obj_t displayio_colorconverter_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    mp_arg_check_num(n_args, kw_args, 0, 0, false);
+    mp_arg_check_num(n_args, kw_args, 0, 1, false);
 
     displayio_colorconverter_t *self = m_new_obj(displayio_colorconverter_t);
     self->base.type = &displayio_colorconverter_type;
-    common_hal_displayio_colorconverter_construct(self);
+    
+    bool dither = false;
+
+    if (n_args > 0) {
+        dither = mp_obj_is_true(pos_args[0]);
+    }
+
+    common_hal_displayio_colorconverter_construct(self, dither);
 
     return MP_OBJ_FROM_PTR(self);
 }
@@ -79,8 +86,35 @@ STATIC mp_obj_t displayio_colorconverter_obj_convert(mp_obj_t self_in, mp_obj_t 
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_colorconverter_convert_obj, displayio_colorconverter_obj_convert);
 
+//|   .. attribute:: dither
+//|
+//|     True when the display is dithered
+//|
+STATIC mp_obj_t displayio_colorconverter_obj_get_dither(mp_obj_t self_in) {
+    displayio_colorconverter_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_bool(common_hal_displayio_colorconverter_get_dither(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(displayio_colorconverter_get_dither_obj, displayio_colorconverter_obj_get_dither);
+
+STATIC mp_obj_t displayio_colorconverter_obj_set_dither(mp_obj_t self_in, mp_obj_t dither) {
+    displayio_colorconverter_t *self = MP_OBJ_TO_PTR(self_in);
+
+    common_hal_displayio_colorconverter_set_dither(self, mp_obj_is_true(dither));
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(displayio_colorconverter_set_dither_obj, displayio_colorconverter_obj_set_dither);
+
+const mp_obj_property_t displayio_colorconverter_dither_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&displayio_colorconverter_get_dither_obj,
+              (mp_obj_t)&displayio_colorconverter_set_dither_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
+
 STATIC const mp_rom_map_elem_t displayio_colorconverter_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_convert), MP_ROM_PTR(&displayio_colorconverter_convert_obj) },
+    { MP_ROM_QSTR(MP_QSTR_dither), MP_ROM_PTR(&displayio_colorconverter_dither_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(displayio_colorconverter_locals_dict, displayio_colorconverter_locals_dict_table);
 
@@ -90,3 +124,4 @@ const mp_obj_type_t displayio_colorconverter_type = {
     .make_new = displayio_colorconverter_make_new,
     .locals_dict = (mp_obj_dict_t*)&displayio_colorconverter_locals_dict,
 };
+

--- a/shared-bindings/displayio/ColorConverter.c
+++ b/shared-bindings/displayio/ColorConverter.c
@@ -43,7 +43,7 @@
 //|
 //| Converts one color format to another.
 //|
-//| .. class:: ColorConverter()
+//| .. class:: ColorConverter(*, dither=False)
 //|
 //|   Create a ColorConverter object to convert color formats. Only supports RGB888 to RGB565
 //|   currently.
@@ -55,7 +55,7 @@ STATIC mp_obj_t displayio_colorconverter_make_new(const mp_obj_type_t *type, siz
     enum { ARG_dither};
 
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_dither, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = true} },
+        { MP_QSTR_dither, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);

--- a/shared-bindings/displayio/ColorConverter.c
+++ b/shared-bindings/displayio/ColorConverter.c
@@ -47,22 +47,23 @@
 //|
 //|   Create a ColorConverter object to convert color formats. Only supports RGB888 to RGB565
 //|   currently.
-//|
+//|   :param bool dither: Adds random noise to dither the output image
+
 // TODO(tannewt): Add support for other color formats.
 //|
 STATIC mp_obj_t displayio_colorconverter_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    mp_arg_check_num(n_args, kw_args, 0, 1, false);
+    enum { ARG_dither};
+
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_dither, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = true} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     displayio_colorconverter_t *self = m_new_obj(displayio_colorconverter_t);
     self->base.type = &displayio_colorconverter_type;
-    
-    bool dither = false;
 
-    if (n_args > 0) {
-        dither = mp_obj_is_true(pos_args[0]);
-    }
-
-    common_hal_displayio_colorconverter_construct(self, dither);
+    common_hal_displayio_colorconverter_construct(self, args[ARG_dither].u_bool);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/displayio/ColorConverter.c
+++ b/shared-bindings/displayio/ColorConverter.c
@@ -88,7 +88,8 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_colorconverter_convert_obj, displayio_colorc
 
 //|   .. attribute:: dither
 //|
-//|     True when the display is dithered
+//|     When true the color converter dithers the output by adding random noise when
+//|     truncating to display bitdepth
 //|
 STATIC mp_obj_t displayio_colorconverter_obj_get_dither(mp_obj_t self_in) {
     displayio_colorconverter_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/displayio/ColorConverter.h
+++ b/shared-bindings/displayio/ColorConverter.h
@@ -33,7 +33,10 @@
 
 extern const mp_obj_type_t displayio_colorconverter_type;
 
-void common_hal_displayio_colorconverter_construct(displayio_colorconverter_t* self);
+void common_hal_displayio_colorconverter_construct(displayio_colorconverter_t* self, bool dither);
 void common_hal_displayio_colorconverter_convert(displayio_colorconverter_t *colorconverter, const _displayio_colorspace_t* colorspace, uint32_t input_color, uint32_t* output_color);
+
+void common_hal_displayio_colorconverter_set_dither(displayio_colorconverter_t* self, bool dither);
+bool common_hal_displayio_colorconverter_get_dither(displayio_colorconverter_t* self);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_COLORCONVERTER_H

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -346,31 +346,7 @@ const mp_obj_property_t displayio_display_auto_brightness_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
-//|   .. attribute:: dither
-//|
-//|     True when the display is dithered
-//|
-STATIC mp_obj_t displayio_display_obj_get_dither(mp_obj_t self_in) {
-    displayio_display_obj_t *self = native_display(self_in);
-    return mp_obj_new_bool(common_hal_displayio_display_get_dither(self));
-}
-MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_get_dither_obj, displayio_display_obj_get_dither);
 
-STATIC mp_obj_t displayio_display_obj_set_dither(mp_obj_t self_in, mp_obj_t dither) {
-    displayio_display_obj_t *self = native_display(self_in);
-
-    common_hal_displayio_display_set_dither(self, mp_obj_is_true(dither));
-
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_2(displayio_display_set_dither_obj, displayio_display_obj_set_dither);
-
-const mp_obj_property_t displayio_display_dither_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&displayio_display_get_dither_obj,
-              (mp_obj_t)&displayio_display_set_dither_obj,
-              (mp_obj_t)&mp_const_none_obj},
-};
 
 
 //|   .. attribute:: width
@@ -514,7 +490,6 @@ STATIC const mp_rom_map_elem_t displayio_display_locals_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_brightness), MP_ROM_PTR(&displayio_display_brightness_obj) },
     { MP_ROM_QSTR(MP_QSTR_auto_brightness), MP_ROM_PTR(&displayio_display_auto_brightness_obj) },
-    { MP_ROM_QSTR(MP_QSTR_dither), MP_ROM_PTR(&displayio_display_dither_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&displayio_display_width_obj) },
     { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&displayio_display_height_obj) },

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -346,6 +346,33 @@ const mp_obj_property_t displayio_display_auto_brightness_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
+//|   .. attribute:: dither
+//|
+//|     True when the display is dithered
+//|
+STATIC mp_obj_t displayio_display_obj_get_dither(mp_obj_t self_in) {
+    displayio_display_obj_t *self = native_display(self_in);
+    return mp_obj_new_bool(common_hal_displayio_display_get_dither(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_get_dither_obj, displayio_display_obj_get_dither);
+
+STATIC mp_obj_t displayio_display_obj_set_dither(mp_obj_t self_in, mp_obj_t dither) {
+    displayio_display_obj_t *self = native_display(self_in);
+
+    common_hal_displayio_display_set_dither(self, mp_obj_is_true(dither));
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(displayio_display_set_dither_obj, displayio_display_obj_set_dither);
+
+const mp_obj_property_t displayio_display_dither_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&displayio_display_get_dither_obj,
+              (mp_obj_t)&displayio_display_set_dither_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
+
+
 //|   .. attribute:: width
 //|
 //|	Gets the width of the board
@@ -487,6 +514,7 @@ STATIC const mp_rom_map_elem_t displayio_display_locals_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_brightness), MP_ROM_PTR(&displayio_display_brightness_obj) },
     { MP_ROM_QSTR(MP_QSTR_auto_brightness), MP_ROM_PTR(&displayio_display_auto_brightness_obj) },
+    { MP_ROM_QSTR(MP_QSTR_dither), MP_ROM_PTR(&displayio_display_dither_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&displayio_display_width_obj) },
     { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&displayio_display_height_obj) },

--- a/shared-bindings/displayio/Display.h
+++ b/shared-bindings/displayio/Display.h
@@ -62,6 +62,9 @@ uint16_t common_hal_displayio_display_get_rotation(displayio_display_obj_t* self
 bool common_hal_displayio_display_get_auto_brightness(displayio_display_obj_t* self);
 void common_hal_displayio_display_set_auto_brightness(displayio_display_obj_t* self, bool auto_brightness);
 
+bool common_hal_displayio_display_get_dither(displayio_display_obj_t* self);
+void common_hal_displayio_display_set_dither(displayio_display_obj_t* self, bool dither);
+
 mp_float_t common_hal_displayio_display_get_brightness(displayio_display_obj_t* self);
 bool common_hal_displayio_display_set_brightness(displayio_display_obj_t* self, mp_float_t brightness);
 

--- a/shared-module/displayio/ColorConverter.c
+++ b/shared-module/displayio/ColorConverter.c
@@ -121,7 +121,7 @@ void common_hal_displayio_colorconverter_convert(displayio_colorconverter_t *sel
     (*output_color) = output_pixel.pixel;
 }
 
-bool displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, const displayio_input_pixel_t *input_pixel, displayio_output_pixel_t *output_color) {
+void displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, const displayio_input_pixel_t *input_pixel, displayio_output_pixel_t *output_color) {
     uint32_t pixel = input_pixel->pixel;
     
     if (colorspace->dither){
@@ -149,7 +149,7 @@ bool displayio_colorconverter_convert(displayio_colorconverter_t *self, const _d
     if (colorspace->depth == 16) {
         output_color->pixel = displayio_colorconverter_compute_rgb565(pixel);
         output_color->opaque = true;
-        return true;
+        return;
     } else if (colorspace->tricolor) {
         uint8_t luma = displayio_colorconverter_compute_luma(pixel);
         output_color->pixel = luma >> (8 - colorspace->depth);
@@ -158,19 +158,18 @@ bool displayio_colorconverter_convert(displayio_colorconverter_t *self, const _d
                 output_color->pixel = 0;
             }
             output_color->opaque = true;
-            return true;
+            return;
         }
         uint8_t pixel_hue = displayio_colorconverter_compute_hue(pixel);
         displayio_colorconverter_compute_tricolor(colorspace, pixel_hue, luma, &output_color->pixel);
-        return true;
+        return;
     }  else if (colorspace->grayscale && colorspace->depth <= 8) {
         uint8_t luma = displayio_colorconverter_compute_luma(pixel);
         output_color->pixel = luma >> (8 - colorspace->depth);
         output_color->opaque = true;
-        return true;
+        return;
     }
     output_color->opaque = false;
-    return false;
 }
 
 // Currently no refresh logic is needed for a ColorConverter.

--- a/shared-module/displayio/ColorConverter.c
+++ b/shared-module/displayio/ColorConverter.c
@@ -39,7 +39,8 @@ uint32_t displayio_colorconverter_dither_noise_2(uint32_t x, uint32_t y) {
     return displayio_colorconverter_dither_noise_1(x + y * 0xFFFF);
 }
 
-void common_hal_displayio_colorconverter_construct(displayio_colorconverter_t* self) {
+void common_hal_displayio_colorconverter_construct(displayio_colorconverter_t* self, bool dither) {
+    self->dither = dither;
 }
 
 uint16_t displayio_colorconverter_compute_rgb565(uint32_t color_rgb888) {
@@ -121,10 +122,18 @@ void common_hal_displayio_colorconverter_convert(displayio_colorconverter_t *sel
     (*output_color) = output_pixel.pixel;
 }
 
+void common_hal_displayio_colorconverter_set_dither(displayio_colorconverter_t* self, bool dither) {
+    self->dither = dither;
+}
+
+bool common_hal_displayio_colorconverter_get_dither(displayio_colorconverter_t* self) {
+    return self->dither;
+}
+
 void displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, const displayio_input_pixel_t *input_pixel, displayio_output_pixel_t *output_color) {
     uint32_t pixel = input_pixel->pixel;
     
-    if (colorspace->dither){
+    if (self->dither){
         uint8_t randr = (displayio_colorconverter_dither_noise_2(input_pixel->tile_x,input_pixel->tile_y));
         uint8_t randg = (displayio_colorconverter_dither_noise_2(input_pixel->tile_x+33,input_pixel->tile_y));
         uint8_t randb = (displayio_colorconverter_dither_noise_2(input_pixel->tile_x,input_pixel->tile_y+33));
@@ -172,6 +181,8 @@ void displayio_colorconverter_convert(displayio_colorconverter_t *self, const _d
     output_color->opaque = false;
 }
 
+
+
 // Currently no refresh logic is needed for a ColorConverter.
 bool displayio_colorconverter_needs_refresh(displayio_colorconverter_t *self) {
     return false;
@@ -179,3 +190,4 @@ bool displayio_colorconverter_needs_refresh(displayio_colorconverter_t *self) {
 
 void displayio_colorconverter_finish_refresh(displayio_colorconverter_t *self) {
 }
+

--- a/shared-module/displayio/ColorConverter.c
+++ b/shared-module/displayio/ColorConverter.c
@@ -28,6 +28,17 @@
 
 #include "py/misc.h"
 
+uint32_t displayio_colorconverter_dither_noise_1 (uint32_t n)
+{
+  n = (n >> 13) ^ n;
+  int nn = (n * (n * n * 60493 + 19990303) + 1376312589) & 0x7fffffff;
+  return (uint32_t) (((float)nn / (1073741824.0f*2)) * 255);
+}
+
+uint32_t displayio_colorconverter_dither_noise_2(uint32_t x, uint32_t y) {
+    return displayio_colorconverter_dither_noise_1(x + y * 0xFFFF);
+}
+
 void common_hal_displayio_colorconverter_construct(displayio_colorconverter_t* self) {
 }
 
@@ -96,32 +107,70 @@ void displayio_colorconverter_compute_tricolor(const _displayio_colorspace_t* co
     }
 }
 
-bool displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, uint32_t input_color, uint32_t* output_color) {
-    if (colorspace->depth == 16) {
-        *output_color = displayio_colorconverter_compute_rgb565(input_color);
-        return true;
-    } else if (colorspace->tricolor) {
-        uint8_t luma = displayio_colorconverter_compute_luma(input_color);
-        *output_color = luma >> (8 - colorspace->depth);
-        if (displayio_colorconverter_compute_chroma(input_color) <= 16) {
-            if (!colorspace->grayscale) {
-                *output_color = 0;
-            }
-            return true;
-        }
-        uint8_t pixel_hue = displayio_colorconverter_compute_hue(input_color);
-        displayio_colorconverter_compute_tricolor(colorspace, pixel_hue, luma, output_color);
-        return true;
-    } else if (colorspace->grayscale && colorspace->depth <= 8) {
-        uint8_t luma = displayio_colorconverter_compute_luma(input_color);
-        *output_color = luma >> (8 - colorspace->depth);
-        return true;
-    }
-    return false;
+void common_hal_displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, uint32_t input_color, uint32_t* output_color) {
+    displayio_input_pixel_t input_pixel;
+    input_pixel.pixel = input_color;
+    input_pixel.x = input_pixel.y = input_pixel.tile = input_pixel.tile_x = input_pixel.tile_y = 0;
+    
+    displayio_output_pixel_t output_pixel;
+    output_pixel.pixel = 0;
+    output_pixel.opaque = false;
+
+    displayio_colorconverter_convert(self, colorspace, &input_pixel, &output_pixel);
+
+    (*output_color) = output_pixel.pixel;
 }
 
-void common_hal_displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, uint32_t input_color, uint32_t* output_color) {
-    displayio_colorconverter_convert(self, colorspace, input_color, output_color);
+bool displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, const displayio_input_pixel_t *input_pixel, displayio_output_pixel_t *output_color) {
+    uint32_t pixel = input_pixel->pixel;
+    
+    if (colorspace->dither){
+        uint8_t randr = (displayio_colorconverter_dither_noise_2(input_pixel->tile_x,input_pixel->tile_y));
+        uint8_t randg = (displayio_colorconverter_dither_noise_2(input_pixel->tile_x+33,input_pixel->tile_y));
+        uint8_t randb = (displayio_colorconverter_dither_noise_2(input_pixel->tile_x,input_pixel->tile_y+33));
+
+        uint32_t r8 = (pixel >> 16);
+        uint32_t g8 = (pixel >> 8) & 0xff;
+        uint32_t b8 = pixel & 0xff;
+
+        if (colorspace->depth == 16) {
+            b8 = MIN(255,b8 + (randb&0x07));
+            r8 = MIN(255,r8 + (randr&0x07));
+            g8 = MIN(255,g8 + (randg&0x03));
+        } else {
+            int bitmask = 0xFF >> colorspace->depth;
+            b8 = MIN(255,b8 + (randb&bitmask));
+            r8 = MIN(255,r8 + (randr&bitmask));
+            g8 = MIN(255,g8 + (randg&bitmask));
+        }
+        pixel = r8 << 16 | g8 << 8 | b8;
+    }
+
+    if (colorspace->depth == 16) {
+        output_color->pixel = displayio_colorconverter_compute_rgb565(pixel);
+        output_color->opaque = true;
+        return true;
+    } else if (colorspace->tricolor) {
+        uint8_t luma = displayio_colorconverter_compute_luma(pixel);
+        output_color->pixel = luma >> (8 - colorspace->depth);
+        if (displayio_colorconverter_compute_chroma(pixel) <= 16) {
+            if (!colorspace->grayscale) {
+                output_color->pixel = 0;
+            }
+            output_color->opaque = true;
+            return true;
+        }
+        uint8_t pixel_hue = displayio_colorconverter_compute_hue(pixel);
+        displayio_colorconverter_compute_tricolor(colorspace, pixel_hue, luma, &output_color->pixel);
+        return true;
+    }  else if (colorspace->grayscale && colorspace->depth <= 8) {
+        uint8_t luma = displayio_colorconverter_compute_luma(pixel);
+        output_color->pixel = luma >> (8 - colorspace->depth);
+        output_color->opaque = true;
+        return true;
+    }
+    output_color->opaque = false;
+    return false;
 }
 
 // Currently no refresh logic is needed for a ColorConverter.

--- a/shared-module/displayio/ColorConverter.h
+++ b/shared-module/displayio/ColorConverter.h
@@ -39,7 +39,11 @@ typedef struct {
 
 bool displayio_colorconverter_needs_refresh(displayio_colorconverter_t *self);
 void displayio_colorconverter_finish_refresh(displayio_colorconverter_t *self);
-bool displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, uint32_t input_color, uint32_t* output_color);
+bool displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, const displayio_input_pixel_t *input_pixel, displayio_output_pixel_t *output_color);
+
+uint32_t displayio_colorconverter_dither_noise_1 (uint32_t n);
+uint32_t displayio_colorconverter_dither_noise_2(uint32_t x, uint32_t y);
+
 uint16_t displayio_colorconverter_compute_rgb565(uint32_t color_rgb888);
 uint8_t displayio_colorconverter_compute_luma(uint32_t color_rgb888);
 uint8_t displayio_colorconverter_compute_chroma(uint32_t color_rgb888);

--- a/shared-module/displayio/ColorConverter.h
+++ b/shared-module/displayio/ColorConverter.h
@@ -35,6 +35,7 @@
 
 typedef struct {
     mp_obj_base_t base;
+    bool dither;
 } displayio_colorconverter_t;
 
 bool displayio_colorconverter_needs_refresh(displayio_colorconverter_t *self);

--- a/shared-module/displayio/ColorConverter.h
+++ b/shared-module/displayio/ColorConverter.h
@@ -39,7 +39,7 @@ typedef struct {
 
 bool displayio_colorconverter_needs_refresh(displayio_colorconverter_t *self);
 void displayio_colorconverter_finish_refresh(displayio_colorconverter_t *self);
-bool displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, const displayio_input_pixel_t *input_pixel, displayio_output_pixel_t *output_color);
+void displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, const displayio_input_pixel_t *input_pixel, displayio_output_pixel_t *output_color);
 
 uint32_t displayio_colorconverter_dither_noise_1 (uint32_t n);
 uint32_t displayio_colorconverter_dither_noise_2(uint32_t x, uint32_t y);

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -150,6 +150,14 @@ void common_hal_displayio_display_set_auto_brightness(displayio_display_obj_t* s
     self->auto_brightness = auto_brightness;
 }
 
+void common_hal_displayio_display_set_dither(displayio_display_obj_t* self, bool dither) {
+    displayio_display_core_set_dither(&self->core, dither);
+}
+
+bool common_hal_displayio_display_get_dither(displayio_display_obj_t* self) {
+    return displayio_display_core_get_dither(&self->core);
+}
+
 mp_float_t common_hal_displayio_display_get_brightness(displayio_display_obj_t* self) {
     return self->current_brightness;
 }

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -150,14 +150,6 @@ void common_hal_displayio_display_set_auto_brightness(displayio_display_obj_t* s
     self->auto_brightness = auto_brightness;
 }
 
-void common_hal_displayio_display_set_dither(displayio_display_obj_t* self, bool dither) {
-    displayio_display_core_set_dither(&self->core, dither);
-}
-
-bool common_hal_displayio_display_get_dither(displayio_display_obj_t* self) {
-    return displayio_display_core_get_dither(&self->core);
-}
-
 mp_float_t common_hal_displayio_display_get_brightness(displayio_display_obj_t* self) {
     return self->current_brightness;
 }

--- a/shared-module/displayio/Palette.h
+++ b/shared-module/displayio/Palette.h
@@ -41,6 +41,7 @@ typedef struct {
     bool tricolor;
     bool pixels_in_byte_share_row;
     bool reverse_pixels_in_byte;
+    bool dither;
 } _displayio_colorspace_t;
 
 typedef struct {
@@ -51,6 +52,20 @@ typedef struct {
     uint8_t chroma;
     bool transparent; // This may have additional bits added later for blending.
 } _displayio_color_t;
+
+typedef struct {
+    uint32_t pixel;
+    uint16_t x;
+    uint16_t y;
+    uint8_t tile;
+    uint16_t tile_x;
+    uint16_t tile_y;
+} displayio_input_pixel_t;
+
+typedef struct {
+    uint32_t pixel;
+    bool opaque;
+} displayio_output_pixel_t;
 
 typedef struct {
     mp_obj_base_t base;

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -377,12 +377,16 @@ bool displayio_tilegrid_fill_area(displayio_tilegrid_t *self, const _displayio_c
     }
 
     uint8_t pixels_per_byte = 8 / colorspace->depth;
-    for (int16_t y = start_y; y < end_y; y++) {
-        int16_t row_start = start + (y - start_y + y_shift) * y_stride; // in pixels
-        int16_t local_y = y / self->absolute_transform->scale;
-        for (int16_t x = start_x; x < end_x; x++) {
+
+    displayio_input_pixel_t input_pixel;
+    displayio_output_pixel_t output_pixel;
+
+    for (input_pixel.y = start_y; input_pixel.y < end_y; ++input_pixel.y) {
+        int16_t row_start = start + (input_pixel.y - start_y + y_shift) * y_stride; // in pixels
+        int16_t local_y = input_pixel.y / self->absolute_transform->scale;
+        for (input_pixel.x = start_x; input_pixel.x < end_x; ++input_pixel.x) {
             // Compute the destination pixel in the buffer and mask based on the transformations.
-            int16_t offset = row_start + (x - start_x + x_shift) * x_stride; // in pixels
+            int16_t offset = row_start + (input_pixel.x - start_x + x_shift) * x_stride; // in pixels
 
             // This is super useful for debugging out of range accesses. Uncomment to use.
             // if (offset < 0 || offset >= (int32_t) displayio_area_size(area)) {
@@ -393,41 +397,43 @@ bool displayio_tilegrid_fill_area(displayio_tilegrid_t *self, const _displayio_c
             if ((mask[offset / 32] & (1 << (offset % 32))) != 0) {
                 continue;
             }
-            int16_t local_x = x / self->absolute_transform->scale;
+            int16_t local_x = input_pixel.x / self->absolute_transform->scale;
             uint16_t tile_location = ((local_y / self->tile_height + self->top_left_y) % self->height_in_tiles) * self->width_in_tiles + (local_x / self->tile_width + self->top_left_x) % self->width_in_tiles;
-            uint8_t tile = tiles[tile_location];
-            uint16_t tile_x = (tile % self->bitmap_width_in_tiles) * self->tile_width + local_x % self->tile_width;
-            uint16_t tile_y = (tile / self->bitmap_width_in_tiles) * self->tile_height + local_y % self->tile_height;
+            input_pixel.tile = tiles[tile_location];
+            input_pixel.tile_x = (input_pixel.tile % self->bitmap_width_in_tiles) * self->tile_width + local_x % self->tile_width;
+            input_pixel.tile_y = (input_pixel.tile / self->bitmap_width_in_tiles) * self->tile_height + local_y % self->tile_height;
 
-            uint32_t value = 0;
+            //uint32_t value = 0;
+            output_pixel.pixel = 0;
+            input_pixel.pixel = 0;
+
             // We always want to read bitmap pixels by row first and then transpose into the destination
             // buffer because most bitmaps are row associated.
             if (MP_OBJ_IS_TYPE(self->bitmap, &displayio_bitmap_type)) {
-                value = common_hal_displayio_bitmap_get_pixel(self->bitmap, tile_x, tile_y);
+                input_pixel.pixel = common_hal_displayio_bitmap_get_pixel(self->bitmap, input_pixel.tile_x, input_pixel.tile_y);
             } else if (MP_OBJ_IS_TYPE(self->bitmap, &displayio_shape_type)) {
-                value = common_hal_displayio_shape_get_pixel(self->bitmap, tile_x, tile_y);
+                input_pixel.pixel = common_hal_displayio_shape_get_pixel(self->bitmap, input_pixel.tile_x, input_pixel.tile_y);
             } else if (MP_OBJ_IS_TYPE(self->bitmap, &displayio_ondiskbitmap_type)) {
-                value = common_hal_displayio_ondiskbitmap_get_pixel(self->bitmap, tile_x, tile_y);
+                input_pixel.pixel = common_hal_displayio_ondiskbitmap_get_pixel(self->bitmap, input_pixel.tile_x, input_pixel.tile_y);
             }
-
-            uint32_t pixel;
-            bool opaque = true;
+            
+            output_pixel.opaque = true;
             if (self->pixel_shader == mp_const_none) {
-                pixel = value;
+                output_pixel.pixel = input_pixel.pixel;
             } else if (MP_OBJ_IS_TYPE(self->pixel_shader, &displayio_palette_type)) {
-                opaque = displayio_palette_get_color(self->pixel_shader, colorspace, value, &pixel);
+                output_pixel.opaque = displayio_palette_get_color(self->pixel_shader, colorspace, input_pixel.pixel, &output_pixel.pixel);
             } else if (MP_OBJ_IS_TYPE(self->pixel_shader, &displayio_colorconverter_type)) {
-                opaque = displayio_colorconverter_convert(self->pixel_shader, colorspace, value, &pixel);
+                displayio_colorconverter_convert(self->pixel_shader, colorspace, &input_pixel, &output_pixel);
             }
-            if (!opaque) {
+            if (!output_pixel.opaque) {
                 // A pixel is transparent so we haven't fully covered the area ourselves.
                 full_coverage = false;
             } else {
                 mask[offset / 32] |= 1 << (offset % 32);
                 if (colorspace->depth == 16) {
-                    *(((uint16_t*) buffer) + offset) = pixel;
+                    *(((uint16_t*) buffer) + offset) = output_pixel.pixel;
                 } else if (colorspace->depth == 8) {
-                    *(((uint8_t*) buffer) + offset) = pixel;
+                    *(((uint8_t*) buffer) + offset) = output_pixel.pixel;
                 } else if (colorspace->depth < 8) {
                     // Reorder the offsets to pack multiple rows into a byte (meaning they share a column).
                     if (!colorspace->pixels_in_byte_share_row) {
@@ -446,7 +452,7 @@ bool displayio_tilegrid_fill_area(displayio_tilegrid_t *self, const _displayio_c
                         // Reverse the shift by subtracting it from the leftmost shift.
                         shift = (pixels_per_byte - 1) * colorspace->depth - shift;
                     }
-                    ((uint8_t*)buffer)[offset / pixels_per_byte] |= pixel << shift;
+                    ((uint8_t*)buffer)[offset / pixels_per_byte] |= output_pixel.pixel << shift;
                 }
             }
         }

--- a/shared-module/displayio/display_core.c
+++ b/shared-module/displayio/display_core.c
@@ -49,6 +49,7 @@ void displayio_display_core_construct(displayio_display_core_t* self,
     self->colorspace.pixels_in_byte_share_row = pixels_in_byte_share_row;
     self->colorspace.bytes_per_cell = bytes_per_cell;
     self->colorspace.reverse_pixels_in_byte = reverse_pixels_in_byte;
+    self->colorspace.dither = false;
     self->current_group = NULL;
     self->colstart = colstart;
     self->rowstart = rowstart;
@@ -169,6 +170,14 @@ uint16_t displayio_display_core_get_width(displayio_display_core_t* self){
 
 uint16_t displayio_display_core_get_height(displayio_display_core_t* self){
     return self->height;
+}
+
+void displayio_display_core_set_dither(displayio_display_core_t* self, bool dither){
+    self->colorspace.dither = dither;
+}
+
+bool displayio_display_core_get_dither(displayio_display_core_t* self){
+    return self->colorspace.dither;
 }
 
 bool displayio_display_core_bus_free(displayio_display_core_t *self) {

--- a/shared-module/displayio/display_core.h
+++ b/shared-module/displayio/display_core.h
@@ -65,6 +65,9 @@ bool displayio_display_core_show(displayio_display_core_t* self, displayio_group
 uint16_t displayio_display_core_get_width(displayio_display_core_t* self);
 uint16_t displayio_display_core_get_height(displayio_display_core_t* self);
 
+void displayio_display_core_set_dither(displayio_display_core_t* self, bool dither);
+bool displayio_display_core_get_dither(displayio_display_core_t* self);
+
 bool displayio_display_core_bus_free(displayio_display_core_t *self);
 bool displayio_display_core_begin_transaction(displayio_display_core_t* self);
 void displayio_display_core_end_transaction(displayio_display_core_t* self);


### PR DESCRIPTION
Moved the dithering logic as suggested in previous PR to the ColorConverter. This will allow dithering to be done on any 24 bit source bitmap. It can easily be turned on by using the python code board.DISPLAY.dither = True, and uses the ColorConverters bitdepth to correctly add the dithering. 