### PR TITLE
samd51: DAC: Make clock usage more like Arduino core

### DIFF
--- a/ports/atmel-samd/asf4_conf/samd51/hpl_dac_config.h
+++ b/ports/atmel-samd/asf4_conf/samd51/hpl_dac_config.h
@@ -51,7 +51,7 @@
 // <i> This defines the current in output buffer according to conversion rate
 // <id> dac0_arch_cctrl
 #ifndef CONF_DAC0_CCTRL
-#define CONF_DAC0_CCTRL 1
+#define CONF_DAC0_CCTRL 2
 #endif
 
 // <q> Run in standby
@@ -90,7 +90,7 @@
 // <i> This defines the current in output buffer according to conversion rate
 // <id> dac1_arch_cctrl
 #ifndef CONF_DAC1_CCTRL
-#define CONF_DAC1_CCTRL 1
+#define CONF_DAC1_CCTRL 2
 #endif
 
 // <q> Run in standby

--- a/ports/atmel-samd/asf4_conf/samd51/hpl_gclk_config.h
+++ b/ports/atmel-samd/asf4_conf/samd51/hpl_gclk_config.h
@@ -1,7 +1,8 @@
 // Circuit Python SAMD51 clock tree:
-// DFLL48M (with USBCRM on to sync with external USB ref) -> GCLK1, GCLK5
+// DFLL48M (with USBCRM on to sync with external USB ref) -> GCLK1, GCLK4, GCLK5
 //   GCLK1 (48MHz) -> 48 MHz peripherals
-//   GCLK5 (48 MHz divided down to 2 MHz) -> DPLL0, DAC peripherals
+//   GCLK4 (48MHz divded down to 12MHz) -> DAC
+//   GCLK5 (48 MHz divided down to 2 MHz) -> DPLL0 peripheral
 //     DPLL0 (multiplied up to 120 MHz) -> GCLK0, GCLK4 (output for monitoring)
 
 // We'd like to use XOSC32K as a ref for DFLL48M on boards with a 32kHz crystal,
@@ -338,7 +339,7 @@
 // <i> This defines the clock source for generic clock generator 4
 // <id> gclk_gen_4_oscillator
 #ifndef CONF_GCLK_GEN_4_SOURCE
-#define CONF_GCLK_GEN_4_SOURCE GCLK_GENCTRL_SRC_DPLL0
+#define CONF_GCLK_GEN_4_SOURCE GCLK_GENCTRL_SRC_DFLL
 #endif
 
 // <q> Run in Standby
@@ -388,7 +389,7 @@
 //<o> Generic clock generator 4 division <0x0000-0xFFFF>
 // <id> gclk_gen_4_div
 #ifndef CONF_GCLK_GEN_4_DIV
-#define CONF_GCLK_GEN_4_DIV 1
+#define CONF_GCLK_GEN_4_DIV 4
 #endif
 // </h>
 // </e>

--- a/ports/atmel-samd/asf4_conf/samd51/peripheral_clk_config.h
+++ b/ports/atmel-samd/asf4_conf/samd51/peripheral_clk_config.h
@@ -73,7 +73,7 @@
 // <id> dac_gclk_selection
 // <i> Select the clock source for DAC.
 #ifndef CONF_GCLK_DAC_SRC
-#define CONF_GCLK_DAC_SRC GCLK_PCHCTRL_GEN_GCLK5_Val
+#define CONF_GCLK_DAC_SRC GCLK_PCHCTRL_GEN_GCLK4_Val
 #endif
 
 /**
@@ -81,7 +81,7 @@
  * \brief DAC's Clock frequency
  */
 #ifndef CONF_GCLK_DAC_FREQUENCY
-#define CONF_GCLK_DAC_FREQUENCY 2000000
+#define CONF_GCLK_DAC_FREQUENCY 12000000
 #endif
 
 // <y> EVSYS Channel 0 Clock Source

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -198,7 +198,7 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t* self,
         #endif
         #ifdef SAMD51
         DAC->EVCTRL.reg |= DAC_EVCTRL_STARTEI0;
-        DAC->DACCTRL[0].reg = DAC_DACCTRL_CCTRL_CC1M |
+        DAC->DACCTRL[0].reg = DAC_DACCTRL_CCTRL_CC12M |
                               DAC_DACCTRL_ENABLE |
                               DAC_DACCTRL_LEFTADJ;
         DAC->CTRLB.reg = DAC_CTRLB_REFSEL_VREFPU;
@@ -207,7 +207,7 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t* self,
     #ifdef SAMD51
     if (channel1_enabled) {
         DAC->EVCTRL.reg |= DAC_EVCTRL_STARTEI1;
-        DAC->DACCTRL[1].reg = DAC_DACCTRL_CCTRL_CC1M |
+        DAC->DACCTRL[1].reg = DAC_DACCTRL_CCTRL_CC12M |
                               DAC_DACCTRL_ENABLE |
                               DAC_DACCTRL_LEFTADJ;
         DAC->CTRLB.reg = DAC_CTRLB_REFSEL_VREFPU;


### PR DESCRIPTION
This improves the behavior around #1992.  The samples stay in sync now, though full scale changes still behave erratically.

Testing performed: On a Metro M4, with both analog channels going to a scope, I looked for synchronization and waveform shape.

Original reproducer: Stays synchronized.

https://github.com/adafruit/circuitpython/issues/1992#issuecomment-526847786 reproducer: Stays synchronized and plays at the nominal 100kHz sample rate. However, waveform peaks are "regularly irregular", with every other high peak being truncated, usually.

A difference I'm aware of between this and Arduino's M4 core is that Arduino uses CCTRL_CC100K; however, doing this makes CP worse, so I went with the more "correct" CC12M setting.

Closes: #1992