### PR TITLE
Docs: Wrap Text In Tables

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -369,3 +369,6 @@ texinfo_documents = [
 intersphinx_mapping = {"cpython": ('https://docs.python.org/3/', None),
                        "bus_device": ('https://circuitpython.readthedocs.io/projects/busdevice/en/latest/', None),
                        "register": ('https://circuitpython.readthedocs.io/projects/register/en/latest/', None)}
+
+def setup(app):
+    app.add_stylesheet("customstyle.css")


### PR DESCRIPTION
Had some cycles, so dug a little deeper into item one of #2021.

In looking at the html source, the `docs/static/customstyle.css` wasn't being used, which explains why the override workaround wasn't working. Verified this with a local build.

This change produces an inclusion of the custom CSS in the html head:
![rtd_css_comparison](https://user-images.githubusercontent.com/21211479/64135864-c2590f00-cdb2-11e9-8ce7-fbc27cf55854.png)
