### PR TITLE
Fix transactions in _stage after displayio changes

### DIFF
--- a/shared-bindings/_stage/__init__.c
+++ b/shared-bindings/_stage/__init__.c
@@ -96,21 +96,8 @@ STATIC mp_obj_t stage_render(size_t n_args, const mp_obj_t *args) {
         scale = mp_obj_get_int(args[7]);
     }
 
-    // TODO: Everything below should be in shared-module because it's not argument parsing.
-    while (!displayio_display_core_begin_transaction(&display->core)) {
-        RUN_BACKGROUND_TASKS;
-    }
-    displayio_area_t area;
-    area.x1 = x0;
-    area.y1 = y0;
-    area.x2 = x1;
-    area.y2 = y1;
-    displayio_display_core_set_region_to_update(&display->core, display->set_column_command, display->set_row_command, NO_COMMAND, NO_COMMAND, display->data_as_commands, false, &area);
-
-    display->core.send(display->core.bus, DISPLAY_COMMAND, CHIP_SELECT_TOGGLE_EVERY_BYTE, &display->write_ram_command, 1);
     render_stage(x0, y0, x1, y1, layers, layers_size, buffer, buffer_size,
                  display, scale);
-    displayio_display_core_end_transaction(&display->core);
 
     return mp_const_none;
 }

--- a/shared-module/_stage/__init__.c
+++ b/shared-module/_stage/__init__.c
@@ -36,6 +36,22 @@ void render_stage(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1,
         uint16_t *buffer, size_t buffer_size,
         displayio_display_obj_t *display, uint8_t scale) {
 
+
+    displayio_area_t area;
+    area.x1 = x0;
+    area.y1 = y0;
+    area.x2 = x1;
+    area.y2 = y1;
+    displayio_display_core_set_region_to_update(
+        &display->core, display->set_column_command, display->set_row_command,
+        NO_COMMAND, NO_COMMAND, display->data_as_commands, false, &area);
+
+    while (!displayio_display_core_begin_transaction(&display->core)) {
+        RUN_BACKGROUND_TASKS;
+    }
+    display->core.send(display->core.bus, DISPLAY_COMMAND,
+                      CHIP_SELECT_TOGGLE_EVERY_BYTE,
+                      &display->write_ram_command, 1);
     size_t index = 0;
     for (uint16_t y = y0; y < y1; ++y) {
         for (uint8_t yscale = 0; yscale < scale; ++yscale) {
@@ -57,8 +73,9 @@ void render_stage(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1,
                     index += 1;
                     // The buffer is full, send it.
                     if (index >= buffer_size) {
-                        display->core.send(display->core.bus, DISPLAY_DATA, CHIP_SELECT_UNTOUCHED, ((uint8_t*)buffer),
-                                      buffer_size * 2);
+                        display->core.send(display->core.bus, DISPLAY_DATA,
+                                           CHIP_SELECT_UNTOUCHED,
+                                           ((uint8_t*)buffer), buffer_size * 2);
                         index = 0;
                     }
                 }
@@ -67,6 +84,10 @@ void render_stage(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1,
     }
     // Send the remaining data.
     if (index) {
-        display->core.send(display->core.bus, DISPLAY_DATA, CHIP_SELECT_UNTOUCHED, ((uint8_t*)buffer), index * 2);
+        display->core.send(display->core.bus, DISPLAY_DATA,
+                           CHIP_SELECT_UNTOUCHED,
+                           ((uint8_t*)buffer), index * 2);
     }
+
+    displayio_display_core_end_transaction(&display->core);
 }


### PR DESCRIPTION
Also, move the rendering setup code to shared-module from
shared-bindings.

In CP 5.0, displayio_display_core_set_region_to_update now starts
its own transaction, so it has to be moved outside of the transaction
started by the render call.