### PR TITLE
Fix stm32f412zg compile warning

### DIFF
--- a/ports/stm32f4/Makefile
+++ b/ports/stm32f4/Makefile
@@ -105,8 +105,7 @@ endif
 
 C_DEFS += -DMCU_PACKAGE=$(MCU_PACKAGE)
 
-#TODO: Add ASM Flags? -Werror
-CFLAGS += $(INC) -Wall -std=gnu11 -nostdlib $(BASE_CFLAGS) $(C_DEFS) $(CFLAGS_MOD) $(COPT)
+CFLAGS += $(INC) -Werror -Wall -std=gnu11 -nostdlib $(BASE_CFLAGS) $(C_DEFS) $(CFLAGS_MOD) $(COPT)
 
 # Undo some warnings.
 # STM32 apparently also uses undefined preprocessor variables quite casually, 

--- a/supervisor/stub/internal_flash.c
+++ b/supervisor/stub/internal_flash.c
@@ -49,10 +49,6 @@ uint32_t supervisor_flash_get_block_count(void) {
 void supervisor_flash_flush(void) {
 }
 
-static int32_t convert_block_to_flash_addr(uint32_t block) {
-    return -1;
-}
-
 mp_uint_t supervisor_flash_read_blocks(uint8_t *dest, uint32_t block, uint32_t num_blocks) {
     return 0; // success
 }


### PR DESCRIPTION
Resolves #2122. Removes an unnecessary function in the new flash stub file that causes a compiler warning for boards that use it. Also re-applies warning as error, which was removed for very early stm32 port work. 