### PR TITLE
Fix Circuit Playground Bluefruit pin errors

### DIFF
--- a/ports/nrf/boards/circuitplayground_bluefruit/pins.c
+++ b/ports/nrf/boards/circuitplayground_bluefruit/pins.c
@@ -5,9 +5,9 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_P0_26) },
     { MP_ROM_QSTR(MP_QSTR_SPEAKER), MP_ROM_PTR(&pin_P0_26) },
 
-    { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_P0_05) },
-    { MP_ROM_QSTR(MP_QSTR_D6), MP_ROM_PTR(&pin_P0_05) },
-    { MP_ROM_QSTR(MP_QSTR_SCK),  MP_ROM_PTR(&pin_P0_05) },
+    { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_P0_02) },
+    { MP_ROM_QSTR(MP_QSTR_D6), MP_ROM_PTR(&pin_P0_02) },
+    { MP_ROM_QSTR(MP_QSTR_SCK),  MP_ROM_PTR(&pin_P0_02) },
 
     { MP_ROM_QSTR(MP_QSTR_A2), MP_ROM_PTR(&pin_P0_29) },
     { MP_ROM_QSTR(MP_QSTR_D9), MP_ROM_PTR(&pin_P0_29) },
@@ -29,7 +29,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_P0_30) },
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_P0_30) },
 
-    { MP_ROM_QSTR(MP_QSTR_A7), MP_ROM_PTR(&pin_P0_14) },
+    // This cannot be A7, as it is on CPX. We don't have enough analog inputs.
     { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_P0_14) },
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_P0_14) },
 


### PR DESCRIPTION
- A1 was mistakenly mapped to the same pin as A5
- A7 shouldn't exist: we don't have enough analog-capable pins.