### PR TITLE
nrf: Makefile: sensible flags for debugging

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -90,9 +90,7 @@ INC += -I../../supervisor/shared/usb
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)
-  CFLAGS += -ggdb
-  # You may want to enable these flags to make setting breakpoints easier.
-  CFLAGS += -fno-inline -fno-ipa-sra
+  CFLAGS += -ggdb3 -Og
 else
   CFLAGS += -Os -DNDEBUG
   CFLAGS += -flto -flto-partition=none


### PR DESCRIPTION
This enables the highest level of debug symbols, and all optimizations except lto that do NOT interfere with debugging, in the view of the gcc maintainers.

I find this mode to be useful when debugging with a J-Link and gdb.