### PR TITLE
fix atmel-samd filesystem_tick'ing; clear_temp_status() should check for status indicator in use

### DIFF
--- a/ports/atmel-samd/tick.c
+++ b/ports/atmel-samd/tick.c
@@ -29,6 +29,7 @@
 #include "peripheral_clk_config.h"
 
 #include "supervisor/shared/autoreload.h"
+#include "supervisor/filesystem.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/Processor.h"
 
@@ -52,10 +53,13 @@ void SysTick_Handler(void) {
     (void) SysTick->CTRL;
     common_hal_mcu_enable_interrupts();
 
-    #ifdef CIRCUITPY_AUTORELOAD_DELAY_MS
+#if CIRCUITPY_FILESYSTEM_FLUSH_INTERVAL_MS > 0
+    filesystem_tick();
+#endif
+#ifdef CIRCUITPY_AUTORELOAD_DELAY_MS
         autoreload_tick();
-    #endif
-    #ifdef CIRCUITPY_GAMEPAD_TICKS
+#endif
+#ifdef CIRCUITPY_GAMEPAD_TICKS
     if (!(ticks_ms & CIRCUITPY_GAMEPAD_TICKS)) {
         #if CIRCUITPY_GAMEPAD
         gamepad_tick();
@@ -64,7 +68,7 @@ void SysTick_Handler(void) {
         gamepadshift_tick();
         #endif
     }
-    #endif
+#endif
 }
 
 void tick_init() {

--- a/supervisor/shared/external_flash/external_flash.c
+++ b/supervisor/shared/external_flash/external_flash.c
@@ -428,6 +428,7 @@ static bool flush_ram_cache(bool keep_cache) {
 }
 
 // Delegates to the correct flash flush method depending on the existing cache.
+// TODO Don't blink the status indicator if we don't actually do any writing (hard to tell right now).
 static void spi_flash_flush_keep_cache(bool keep_cache) {
     #ifdef MICROPY_HW_LED_MSC
         port_pin_set_output_level(MICROPY_HW_LED_MSC, true);

--- a/supervisor/shared/rgb_led_status.c
+++ b/supervisor/shared/rgb_led_status.c
@@ -266,9 +266,15 @@ void temp_status_color(uint32_t rgb) {
 
 void clear_temp_status() {
     #ifdef MICROPY_HW_NEOPIXEL
+        if (neopixel_in_use) {
+            return;
+        }
         common_hal_neopixel_write(&status_neopixel, status_neopixel_color, 3);
     #endif
     #if defined(MICROPY_HW_APA102_MOSI) && defined(MICROPY_HW_APA102_SCK)
+        if (apa102_mosi_in_use || apa102_sck_in_use) {
+            return;
+        }
         #if CIRCUITPY_BITBANG_APA102
         shared_module_bitbangio_spi_write(&status_apa102, status_apa102_color, APA102_BUFFER_LENGTH);
         #else


### PR DESCRIPTION
Fixes #2114.

- `clear_temp_status()` now checks whether status NeoPixel or DotStar is in use.
- in `atmel_samd/tick.c`, `SysTickHandler()` ws not calling `filesystem_tick()`

There is very similar code in the different versions of `ports/*/tick.c` which should be factored out eventually into common code. That's part of why the second bug above existed. Since we should rewrite the timing code anyway for #696 (sleep and wakeup), I don't think it's worth refactoring right now.