### PR TITLE
WIP: Allow the REPL/console to be mirrored onto a UART

### DIFF
--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -182,6 +182,10 @@ typedef struct _mp_state_vm_t {
     mp_obj_t dupterm_arr_obj;
     #endif
 
+    #if CIRCUITPY_BUSIO
+    mp_obj_t *serial_mirror_obj;
+    #endif
+
     #if MICROPY_PY_LWIP_SLIP
     mp_obj_t lwip_slip_stream;
     #endif

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -110,7 +110,7 @@ typedef struct {
 extern const busio_uart_parity_obj_t busio_uart_parity_even_obj;
 extern const busio_uart_parity_obj_t busio_uart_parity_odd_obj;
 
-STATIC mp_obj_t busio_uart_construct_common(busio_uart_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+STATIC mp_obj_t busio_uart_construct_common(busio_uart_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args, bool never_reset) {
     self->base.type = &busio_uart_type;
     enum { ARG_tx, ARG_rx, ARG_baudrate, ARG_bits, ARG_parity, ARG_stop, ARG_timeout, ARG_receiver_buffer_size};
     static const mp_arg_t allowed_args[] = {
@@ -158,7 +158,7 @@ STATIC mp_obj_t busio_uart_construct_common(busio_uart_obj_t *self, size_t n_arg
 
     common_hal_busio_uart_construct(self, tx, rx,
                                     args[ARG_baudrate].u_int, bits, parity, stop, timeout,
-                                    args[ARG_receiver_buffer_size].u_int);
+                                    args[ARG_receiver_buffer_size].u_int, never_reset);
     return (mp_obj_t)self;
 }
 
@@ -168,7 +168,7 @@ STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, co
     // cannot accomodate being moved after creation. (See
     // https://github.com/adafruit/circuitpython/issues/1056)
     busio_uart_obj_t *self = m_new_ll_obj(busio_uart_obj_t);
-    return busio_uart_construct_common(self, n_args, pos_args, kw_args);
+    return busio_uart_construct_common(self, n_args, pos_args, kw_args, false);
 }
 
 STATIC mp_obj_t busio_uart_obj_deinit(mp_obj_t self_in) {
@@ -192,7 +192,7 @@ STATIC mp_obj_t busio_uart_make_console(size_t n_args, const mp_obj_t *pos_args,
     if (!common_hal_busio_uart_deinited(&busio_uart_console_obj)) {
         common_hal_busio_uart_deinit(&busio_uart_console_obj);
     }
-    busio_uart_construct_common(&busio_uart_console_obj, n_args-1, pos_args+1, kw_args);
+    busio_uart_construct_common(&busio_uart_console_obj, n_args-1, pos_args+1, kw_args, true);
     common_hal_busio_uart_never_reset(&busio_uart_console_obj);
     busio_uart_serial_hook.data = &busio_uart_console_obj;
     serial_hook_set(&busio_uart_serial_hook);

--- a/shared-bindings/busio/UART.h
+++ b/shared-bindings/busio/UART.h
@@ -42,7 +42,7 @@ typedef enum {
 extern void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     const mcu_pin_obj_t * tx, const mcu_pin_obj_t * rx, uint32_t baudrate,
     uint8_t bits, uart_parity_t parity, uint8_t stop, mp_float_t timeout,
-    uint16_t receiver_buffer_size);
+    uint16_t receiver_buffer_size, bool never_reset);
 
 extern void common_hal_busio_uart_deinit(busio_uart_obj_t *self);
 extern bool common_hal_busio_uart_deinited(busio_uart_obj_t *self);

--- a/shared-bindings/busio/UART.h
+++ b/shared-bindings/busio/UART.h
@@ -63,4 +63,7 @@ extern uint32_t common_hal_busio_uart_rx_characters_available(busio_uart_obj_t *
 extern void common_hal_busio_uart_clear_rx_buffer(busio_uart_obj_t *self);
 extern bool common_hal_busio_uart_ready_to_tx(busio_uart_obj_t *self);
 
+// This is used by the supervisor to claim UART devices indefinitely.
+extern void common_hal_busio_uart_never_reset(busio_uart_obj_t *self);
+
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_BUSIO_UART_H

--- a/shared-module/board/__init__.c
+++ b/shared-module/board/__init__.c
@@ -101,7 +101,7 @@ mp_obj_t common_hal_board_create_uart(void) {
     const mcu_pin_obj_t* rx = MP_OBJ_TO_PTR(DEFAULT_UART_BUS_RX);
     const mcu_pin_obj_t* tx = MP_OBJ_TO_PTR(DEFAULT_UART_BUS_TX);
 
-    common_hal_busio_uart_construct(self, tx, rx, 9600, 8, PARITY_NONE, 1, 1000, 64);
+    common_hal_busio_uart_construct(self, tx, rx, 9600, 8, PARITY_NONE, 1, 1000, 64, true);
     MP_STATE_VM(shared_uart_bus) = MP_OBJ_FROM_PTR(self);
     return MP_STATE_VM(shared_uart_bus);
 }

--- a/supervisor/serial.h
+++ b/supervisor/serial.h
@@ -46,4 +46,16 @@ char serial_read(void);
 bool serial_bytes_available(void);
 bool serial_connected(void);
 
+typedef struct {
+    void *data;
+    bool (*connected)(void *data);
+    bool (*bytes_available)(void *data);
+    void (*write)(void *data, const char* text, uint32_t length);
+    char (*read)(void *data);
+    void (*unhook)(void *data);
+} serial_hook_t;
+
+serial_hook_t *serial_hook_get(void);
+void serial_hook_set(serial_hook_t *hook);
+
 #endif  // MICROPY_INCLUDED_SUPERVISOR_SERIAL_H


### PR DESCRIPTION
This is certainly in a "hacky-hack" stage.  It
 * seems to work on nRF52840
 * almost certainly fails to build on every other platform
 * takes some liberties with existing HAL APIs and memory allocations
but it does achieve the goal of letting you write in boot.py
```
import busio, board
busio.UART.make_console(board.TX, board.RX)
```
to get the regular REPL and program output mirrored both on USB (if attached) and via UART.

The platform build problem is of course surmountable; but can the "hack factor" of the specific implementations be reduced enough that this is acceptable for core?  It will be good enough for my specific purposes, getting a CircuitPython REPL into a Commodore 64 via its serial port as a proof of concept.