### PR TITLE
nRF: Change analog reference voltage

### DIFF
--- a/ports/nrf/common-hal/analogio/AnalogIn.c
+++ b/ports/nrf/common-hal/analogio/AnalogIn.c
@@ -67,8 +67,8 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     const nrf_saadc_channel_config_t config = {
         .resistor_p = NRF_SAADC_RESISTOR_DISABLED,
         .resistor_n = NRF_SAADC_RESISTOR_DISABLED,
-        .gain = NRF_SAADC_GAIN1_6,
-        .reference = NRF_SAADC_REFERENCE_INTERNAL,
+        .gain = NRF_SAADC_GAIN1_4,
+        .reference = NRF_SAADC_REFERENCE_VDD4,
         .acq_time = NRF_SAADC_ACQTIME_3US,
         .mode = NRF_SAADC_MODE_SINGLE_ENDED,
         .burst = NRF_SAADC_BURST_DISABLED,
@@ -108,9 +108,6 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {
-    // With internal reference, single ended input (grounded negative
-    // input), and a gain of 1/6 the input range will be:
-    //    Input range = (0.6 V)/(1/6) = 3.6 V
-    // The AIN0-AIN7 inputs cannot exceed VDD, or be lower than VSS. (36.8)
-    return 3.6f;
+    // The nominal VCC voltage
+    return 3.3f;
 }

--- a/ports/nrf/common-hal/analogio/AnalogIn.c
+++ b/ports/nrf/common-hal/analogio/AnalogIn.c
@@ -108,5 +108,9 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {
-    return 3.3f;
+    // With internal reference, single ended input (grounded negative
+    // input), and a gain of 1/6 the input range will be:
+    //    Input range = (0.6 V)/(1/6) = 3.6 V
+    // The AIN0-AIN7 inputs cannot exceed VDD, or be lower than VSS. (36.8)
+    return 3.6f;
 }


### PR DESCRIPTION
Datasheet reading explains one reason why readings might have been 10% low.