### PR TITLE
STM32: fix illegal option error on mac builds 

### DIFF
--- a/ports/stm32f4/Makefile
+++ b/ports/stm32f4/Makefile
@@ -222,9 +222,10 @@ SRC_SHARED_MODULE_EXPANDED = $(addprefix shared-bindings/, $(SRC_SHARED_MODULE))
                              $(addprefix shared-module/, $(SRC_SHARED_MODULE_INTERNAL))
 
 
-
+ifneq ($(FROZEN_MPY_DIR),)
 FROZEN_MPY_PY_FILES := $(shell find -L $(FROZEN_MPY_DIR) -type f -name '*.py')
 FROZEN_MPY_MPY_FILES := $(addprefix $(BUILD)/,$(FROZEN_MPY_PY_FILES:.py=.mpy))
+endif
 
 OBJ += $(PY_O) $(SUPERVISOR_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_STM32:.c=.o))


### PR DESCRIPTION
Macs would get grumpy looking for FROZEN_MPY_DIR if it didn't exist. Closes #2139, thanks for the suggestion @jepler. 