### PR TITLE
Fix several trivial problems found by clang 7's scan-build

### DIFF
--- a/py/binary.c
+++ b/py/binary.c
@@ -184,7 +184,7 @@ long long mp_binary_get_int(mp_uint_t size, bool is_signed, bool big_endian, con
         val = -1;
     }
     for (uint i = 0; i < size; i++) {
-        val <<= 8;
+        val *= 256;
         val |= *src;
         src += delta;
     }

--- a/py/gc.c
+++ b/py/gc.c
@@ -509,7 +509,6 @@ void *gc_alloc(size_t n_bytes, bool has_finaliser, bool long_lived) {
         gc_collect();
         collected = 1;
         GC_ENTER();
-        collected = true;
     }
     #endif
 

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -336,7 +336,7 @@ mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_args, cons
             mp_obj_t *args2 = m_new(mp_obj_t, 1 + n_args + 2 * n_kw);
             args2[0] = MP_OBJ_FROM_PTR(self);
             memcpy(args2 + 1, args, n_args * sizeof(mp_obj_t));
-            if (n_kw) {
+            if (kw_args) {
                 // copy in kwargs
                 memcpy(args2 + 1 + n_args, kw_args->table, 2 * n_kw * sizeof(mp_obj_t));
             }

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -336,8 +336,10 @@ mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_args, cons
             mp_obj_t *args2 = m_new(mp_obj_t, 1 + n_args + 2 * n_kw);
             args2[0] = MP_OBJ_FROM_PTR(self);
             memcpy(args2 + 1, args, n_args * sizeof(mp_obj_t));
-            // copy in kwargs
-            memcpy(args2 + 1 + n_args, kw_args->table, 2 * n_kw * sizeof(mp_obj_t));
+            if (n_kw) {
+                // copy in kwargs
+                memcpy(args2 + 1 + n_args, kw_args->table, 2 * n_kw * sizeof(mp_obj_t));
+            }
             new_ret = mp_call_function_n_kw(init_fn[0], n_args + 1, n_kw, args2);
             m_del(mp_obj_t, args2, 1 + n_args + 2 * n_kw);
         }

--- a/py/showbc.c
+++ b/py/showbc.c
@@ -185,7 +185,7 @@ const byte *mp_bytecode_print_str(const byte *ip) {
                 num--;
             }
             do {
-                num = (num << 7) | (*ip & 0x7f);
+                num = (num * 128) | (*ip & 0x7f);
             } while ((*ip++ & 0x80) != 0);
             printf("LOAD_CONST_SMALL_INT " INT_FMT, num);
             break;


### PR DESCRIPTION
By invoking `scan-build make` in `ports/unix`, a number of diagnostics are found.  This fixes several of the trivial ones.