### PR TITLE
 restructure nlr.h for undefined archtectures

### DIFF
--- a/py/nlr.h
+++ b/py/nlr.h
@@ -36,33 +36,38 @@
 
 // If MICROPY_NLR_SETJMP is not enabled then auto-detect the machine arch
 #if !defined(MICROPY_NLR_SETJMP) || !MICROPY_NLR_SETJMP
-#define MICROPY_NLR_SETJMP (0)
 // A lot of nlr-related things need different treatment on Windows
-#if defined(_WIN32) || defined(__CYGWIN__)
-#define MICROPY_NLR_OS_WINDOWS 1
-#else
-#define MICROPY_NLR_OS_WINDOWS 0
-#endif
-#if defined(__i386__)
-    #define MICROPY_NLR_X86 (1)
-    #define MICROPY_NLR_NUM_REGS (6)
-#elif defined(__x86_64__)
-    #define MICROPY_NLR_X64 (1)
-    #if MICROPY_NLR_OS_WINDOWS
+    #if defined(_WIN32) || defined(__CYGWIN__)
+        #define MICROPY_NLR_OS_WINDOWS 1
+    #else
+        #define MICROPY_NLR_OS_WINDOWS 0
+    #endif
+    #if defined(__i386__)
+        #define MICROPY_NLR_X86 (1)
+        #define MICROPY_NLR_NUM_REGS (6)
+    #elif defined(__x86_64__)
+        #define MICROPY_NLR_X64 (1)
+        #if MICROPY_NLR_OS_WINDOWS
+            #define MICROPY_NLR_NUM_REGS (10)
+        #else
+            #define MICROPY_NLR_NUM_REGS (8)
+        #endif
+    #elif defined(__thumb2__) || defined(__thumb__) || defined(__arm__)
+        #define MICROPY_NLR_THUMB (1)
+        #define MICROPY_NLR_NUM_REGS (10)
+    #elif defined(__xtensa__)
+        #define MICROPY_NLR_XTENSA (1)
         #define MICROPY_NLR_NUM_REGS (10)
     #else
-        #define MICROPY_NLR_NUM_REGS (8)
-    #endif
-#elif defined(__thumb2__) || defined(__thumb__) || defined(__arm__)
-    #define MICROPY_NLR_THUMB (1)
-    #define MICROPY_NLR_NUM_REGS (10)
-#elif defined(__xtensa__)
-    #define MICROPY_NLR_XTENSA (1)
-    #define MICROPY_NLR_NUM_REGS (10)
-#else
-    #define MICROPY_NLR_SETJMP (1)
+        #define MICROPY_NLR_SETJMP (1)
     //#warning "No native NLR support for this arch, using setjmp implementation"
+    #endif
 #endif
+
+// If MICROPY_NLR_SETJMP is not defined above -  define/disable it here
+
+#if !defined(MICROPY_NLR_SETJMP)
+    #define MICROPY_NLR_SETJMP (0)
 #endif
 
 #if MICROPY_NLR_SETJMP


### PR DESCRIPTION
This PR is by no means critical - there may be better ways to do this
Background
I was attempting to build CP on a Raspberry Pi with Ubuntu 19.04 installed - just to see if it worked...
When I tried to build mpy-cross - it failed with several instances of this error

```
make: Entering directory '/home/ubuntu/circuitpython/mpy-cross'
Use make V=1, make V=2 or set BUILD_VERBOSE similarly in your environment to increase build verbosity.
GEN build/genhdr/moduledefs.h
In file included from ../py/mpstate.h:34,
                 from ../py/runtime.h:29,
                 from ../py/gc.c:32:
../py/nlr.h:63: error: "MICROPY_NLR_SETJMP" redefined [-Werror]
     #define MICROPY_NLR_SETJMP (1)
 
../py/nlr.h:39: note: this is the location of the previous definition
 #define MICROPY_NLR_SETJMP (0)
```

The Ubuntu distribution on RPi uses the architecture "aarch64" which is not recognized by nlr.h. This should not necessarily be a problem, but as written nlr.h attempts to redefine MICROPY_NLR_SETJMP if the architecture is not recognized.
This PR just restructures the tests so it is only defined once.

With this change, the build of mpy-cross succeeds.
This change has no impact on the BSP builds other than providing a working mpy-cross.

After all taht, it is not clear there is a real need to be able to build under Ubuntu on an RPi since the build tools work fine under Raspian Buster. 

The main reason for this change is to fix a potential error when unrecognized architectures are used. nlr.h should not try to redefine MICROPY_NLR_SETJMP.

I think this is a "harmless" change to avoid that.

Note: I also did a little "clean up" of the indentation to make the section more readable.