### PR TITLE
Changed to follow standard that Pad 0 is always TX

### DIFF
--- a/ports/atmel-samd/boards/robohatmm1_m4/pins.c
+++ b/ports/atmel-samd/boards/robohatmm1_m4/pins.c
@@ -28,8 +28,7 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
 	{ MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_PB23) },
 	{ MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_PB22) },
-	{ MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_PB02) },
-	{ MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_PB03) },
+
 
 	// GROVE on SERCOM0
 	{ MP_ROM_QSTR(MP_QSTR_GROVE_SCL), MP_ROM_PTR(&pin_PA09) },
@@ -50,8 +49,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 	// UART on SERCOM1 (Raspberry Pi)
 	{ MP_ROM_QSTR(MP_QSTR_TX1), MP_ROM_PTR(&pin_PA16) },
 	{ MP_ROM_QSTR(MP_QSTR_RX1), MP_ROM_PTR(&pin_PA17) },
-	{ MP_ROM_QSTR(MP_QSTR_PI_RX), MP_ROM_PTR(&pin_PA16) },
-	{ MP_ROM_QSTR(MP_QSTR_PI_TX), MP_ROM_PTR(&pin_PA17) },
+	{ MP_ROM_QSTR(MP_QSTR_PI_TX), MP_ROM_PTR(&pin_PA16) },
+	{ MP_ROM_QSTR(MP_QSTR_PI_RX), MP_ROM_PTR(&pin_PA17) },
 
 	// I2C on SERCOM1 (External Connector)
 	{ MP_ROM_QSTR(MP_QSTR_SDA1), MP_ROM_PTR(&pin_PA00) },


### PR DESCRIPTION
Minor changes to Robo HAT MM1 pins.

- All Pins Names are from the perspective of SAMD51
- All TX pins are Pad 0.
- All RX pins are Pad 1.

