### PR TITLE
Do not open the same PWM device if it is already open

### DIFF
--- a/ports/cxd56/common-hal/analogio/AnalogIn.c
+++ b/ports/cxd56/common-hal/analogio/AnalogIn.c
@@ -68,9 +68,11 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self, const
         mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
     }
 
-    analogin_dev[self->number].fd = open(analogin_dev[pin->number].devpath, O_RDONLY);
     if (analogin_dev[self->number].fd < 0) {
-        mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
+        analogin_dev[self->number].fd = open(analogin_dev[self->number].devpath, O_RDONLY);
+        if (analogin_dev[self->number].fd < 0) {
+            mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
+        }
     }
 
     // SCU FIFO overwrite
@@ -99,7 +101,7 @@ void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self) {
 }
 
 bool common_hal_analogio_analogin_deinited(analogio_analogin_obj_t *self) {
-    return self->pin == mp_const_none;
+    return analogin_dev[self->number].fd < 0;
 }
 
 uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {

--- a/ports/cxd56/common-hal/analogio/AnalogIn.h
+++ b/ports/cxd56/common-hal/analogio/AnalogIn.h
@@ -34,7 +34,7 @@
 typedef struct {
     mp_obj_base_t base;
     const mcu_pin_obj_t *pin;
-    uint8_t number;
+    int8_t number;
 } analogio_analogin_obj_t;
 
 void analogin_reset(void);

--- a/ports/cxd56/common-hal/busio/UART.c
+++ b/ports/cxd56/common-hal/busio/UART.c
@@ -32,7 +32,6 @@
 #include <sys/time.h>
 #include <sys/select.h>
 #include <sys/ioctl.h>
-#include <arch/chip/pin.h>
 #include <nuttx/serial/tioctl.h>
 #include <nuttx/fs/ioctl.h>
 
@@ -42,21 +41,22 @@
 
 #include "shared-bindings/busio/UART.h"
 
+typedef struct {
+    const char* devpath;
+    const mcu_pin_obj_t *tx;
+    const mcu_pin_obj_t *rx;
+    int fd;
+} busio_uart_dev_t;
+
+STATIC busio_uart_dev_t busio_uart_dev[] = {
+    {"/dev/ttyS2", &pin_UART2_TXD, &pin_UART2_RXD, -1},
+};
+
 void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     const mcu_pin_obj_t *tx, const mcu_pin_obj_t *rx, uint32_t baudrate,
     uint8_t bits, uart_parity_t parity, uint8_t stop, mp_float_t timeout,
     uint16_t receiver_buffer_size) {
     struct termios tio;
-
-    self->uart_fd = open("/dev/ttyS2", O_RDWR);
-    if (self->uart_fd < 0) {
-        mp_raise_ValueError(translate("Could not initialize UART"));
-    }
-
-    ioctl(self->uart_fd, TCGETS, (long unsigned int)&tio);
-    tio.c_speed = baudrate;
-    ioctl(self->uart_fd, TCSETS, (long unsigned int)&tio);
-    ioctl(self->uart_fd, TCFLSH, (long unsigned int)NULL);
 
     if (bits != 8) {
         mp_raise_ValueError(translate("Could not initialize UART"));
@@ -70,9 +70,31 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         mp_raise_ValueError(translate("Could not initialize UART"));
     }
 
-    if (tx->number != PIN_UART2_TXD || rx->number != PIN_UART2_RXD) {
+    self->number = -1;
+
+    for (int i = 0; i < MP_ARRAY_SIZE(busio_uart_dev); i++) {
+        if (tx->number == busio_uart_dev[i].tx->number &&
+            rx->number == busio_uart_dev[i].rx->number) {
+            self->number = i;
+            break;
+        }
+    }
+
+    if (self->number < 0) {
         mp_raise_ValueError(translate("Invalid pins"));
     }
+
+    if (busio_uart_dev[self->number].fd < 0) {
+        busio_uart_dev[self->number].fd = open(busio_uart_dev[self->number].devpath, O_RDWR);
+        if (busio_uart_dev[self->number].fd < 0) {
+            mp_raise_ValueError(translate("Could not initialize UART"));
+        }
+    }
+
+    ioctl(busio_uart_dev[self->number].fd, TCGETS, (long unsigned int)&tio);
+    tio.c_speed = baudrate;
+    ioctl(busio_uart_dev[self->number].fd, TCSETS, (long unsigned int)&tio);
+    ioctl(busio_uart_dev[self->number].fd, TCFLSH, (long unsigned int)NULL);
 
     claim_pin(tx);
     claim_pin(rx);
@@ -88,15 +110,15 @@ void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
         return;
     }
 
-    close(self->uart_fd);
-    self->uart_fd = -1;
+    close(busio_uart_dev[self->number].fd);
+    busio_uart_dev[self->number].fd = -1;
 
     reset_pin_number(self->tx_pin->number);
     reset_pin_number(self->rx_pin->number);
 }
 
 bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {
-    return self->uart_fd < 0;
+    return busio_uart_dev[self->number].fd < 0;
 }
 
 size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t len, int *errcode) {
@@ -110,15 +132,15 @@ size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t 
     }
 
     FD_ZERO(&rfds);
-    FD_SET(self->uart_fd, &rfds);
+    FD_SET(busio_uart_dev[self->number].fd, &rfds);
 
     tv.tv_sec = 0;
     tv.tv_usec = self->timeout * 1000;
 
-    retval = select(self->uart_fd + 1, &rfds, NULL, NULL, &tv);
+    retval = select(busio_uart_dev[self->number].fd + 1, &rfds, NULL, NULL, &tv);
 
     if (retval) {
-        bytes_read = read(self->uart_fd, data, len);
+        bytes_read = read(busio_uart_dev[self->number].fd, data, len);
     } else {
         *errcode = EAGAIN;
         return MP_STREAM_ERROR;
@@ -128,8 +150,7 @@ size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t 
 }
 
 size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, size_t len, int *errcode) {
-    int bytes_written = write(self->uart_fd, data, len);
-
+    int bytes_written = write(busio_uart_dev[self->number].fd, data, len);
     if (bytes_written < 0) {
         *errcode = MP_EAGAIN;
         return MP_STREAM_ERROR;
@@ -145,16 +166,16 @@ uint32_t common_hal_busio_uart_get_baudrate(busio_uart_obj_t *self) {
 void common_hal_busio_uart_set_baudrate(busio_uart_obj_t *self, uint32_t baudrate) {
     struct termios tio;
 
-    ioctl(self->uart_fd, TCGETS, (long unsigned int)&tio);
+    ioctl(busio_uart_dev[self->number].fd, TCGETS, (long unsigned int)&tio);
     tio.c_speed = baudrate;
-    ioctl(self->uart_fd, TCSETS, (long unsigned int)&tio);
-    ioctl(self->uart_fd, TCFLSH, (long unsigned int)NULL);
+    ioctl(busio_uart_dev[self->number].fd, TCSETS, (long unsigned int)&tio);
+    ioctl(busio_uart_dev[self->number].fd, TCFLSH, (long unsigned int)NULL);
 }
 
 uint32_t common_hal_busio_uart_rx_characters_available(busio_uart_obj_t *self) {
     int count = 0;
 
-    ioctl(self->uart_fd, FIONREAD, (long unsigned int)&count);
+    ioctl(busio_uart_dev[self->number].fd, FIONREAD, (long unsigned int)&count);
 
     return count;
 }
@@ -163,6 +184,6 @@ void common_hal_busio_uart_clear_rx_buffer(busio_uart_obj_t *self) {
 }
 
 bool common_hal_busio_uart_ready_to_tx(busio_uart_obj_t *self) {
-    ioctl(self->uart_fd, TCFLSH, (long unsigned int)NULL);
+    ioctl(busio_uart_dev[self->number].fd, TCFLSH, (long unsigned int)NULL);
     return true;
 }

--- a/ports/cxd56/common-hal/busio/UART.c
+++ b/ports/cxd56/common-hal/busio/UART.c
@@ -187,3 +187,12 @@ bool common_hal_busio_uart_ready_to_tx(busio_uart_obj_t *self) {
     ioctl(busio_uart_dev[self->number].fd, TCFLSH, (long unsigned int)NULL);
     return true;
 }
+
+void busio_uart_reset(void) {
+    for (int i = 0; i < MP_ARRAY_SIZE(busio_uart_dev); i++) {
+        if (busio_uart_dev[i].fd >= 0) {
+            close(busio_uart_dev[i].fd);
+            busio_uart_dev[i].fd = -1;
+        }
+    }
+}

--- a/ports/cxd56/common-hal/busio/UART.h
+++ b/ports/cxd56/common-hal/busio/UART.h
@@ -33,7 +33,7 @@
 
 typedef struct {
     mp_obj_base_t base;
-    int uart_fd;
+    int8_t number;
     const mcu_pin_obj_t *tx_pin;
     const mcu_pin_obj_t *rx_pin;
     uint32_t baudrate;

--- a/ports/cxd56/common-hal/busio/UART.h
+++ b/ports/cxd56/common-hal/busio/UART.h
@@ -40,4 +40,6 @@ typedef struct {
     uint32_t timeout;
 } busio_uart_obj_t;
 
+void busio_uart_reset(void);
+
 #endif // MICROPY_INCLUDED_CXD56_COMMON_HAL_BUSIO_UART_H

--- a/ports/cxd56/common-hal/pulseio/PWMOut.c
+++ b/ports/cxd56/common-hal/pulseio/PWMOut.c
@@ -62,9 +62,11 @@ pwmout_result_t common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t *self,
         return PWMOUT_INVALID_PIN;
     }
 
-    pwmout_dev[self->number].fd = open(pwmout_dev[self->number].devpath, O_RDONLY);
     if (pwmout_dev[self->number].fd < 0) {
-        return PWMOUT_INVALID_PIN;
+        pwmout_dev[self->number].fd = open(pwmout_dev[self->number].devpath, O_RDONLY);
+        if (pwmout_dev[self->number].fd < 0) {
+            return PWMOUT_INVALID_PIN;
+        }
     }
 
     self->info.frequency = frequency;
@@ -97,7 +99,7 @@ void common_hal_pulseio_pwmout_deinit(pulseio_pwmout_obj_t *self) {
 }
 
 bool common_hal_pulseio_pwmout_deinited(pulseio_pwmout_obj_t *self) {
-    return self->pin == mp_const_none;
+    return pwmout_dev[self->number].fd < 0;
 }
 
 void common_hal_pulseio_pwmout_set_duty_cycle(pulseio_pwmout_obj_t *self, uint16_t duty) {

--- a/ports/cxd56/common-hal/pulseio/PWMOut.h
+++ b/ports/cxd56/common-hal/pulseio/PWMOut.h
@@ -38,7 +38,7 @@ typedef struct {
     const mcu_pin_obj_t *pin;
     struct pwm_info_s info;
     bool variable_frequency;
-    uint8_t number;
+    int8_t number;
 } pulseio_pwmout_obj_t;
 
 void pwmout_reset(void);

--- a/ports/cxd56/supervisor/port.c
+++ b/ports/cxd56/supervisor/port.c
@@ -35,6 +35,7 @@
 #include "common-hal/analogio/AnalogIn.h"
 #include "common-hal/pulseio/PulseOut.h"
 #include "common-hal/pulseio/PWMOut.h"
+#include "common-hal/busio/UART.h"
 
 safe_mode_t port_init(void) {
     boardctl(BOARDIOC_INIT, 0);
@@ -59,6 +60,9 @@ void reset_port(void) {
 #if CIRCUITPY_PULSEIO
     pulseout_reset();
     pwmout_reset();
+#endif
+#if CIRCUITPY_BUSIO
+    busio_uart_reset();
 #endif
 
     reset_all_pins();


### PR DESCRIPTION
This PR solves the problem with too many open devices. Now, instead of creating new descriptor files, those that were created when the device was first opened are used.