### PR TITLE
Top and limit stack addresses

### DIFF
--- a/main.c
+++ b/main.c
@@ -477,7 +477,7 @@ void gc_collect(void) {
 
     // This naively collects all object references from an approximate stack
     // range.
-    gc_collect_root((void**)sp, ((uint32_t)&_estack - sp) / sizeof(uint32_t));
+    gc_collect_root((void**)sp, ((uint32_t)port_stack_get_top() - sp) / sizeof(uint32_t));
     gc_collect_end();
 }
 

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -271,6 +271,14 @@ void reset_cpu(void) {
     reset();
 }
 
+uint32_t *port_stack_get_limit(void) {
+    return &_ebss;
+}
+
+uint32_t *port_stack_get_top(void) {
+    return &_estack;
+}
+
 // Place the word to save 8k from the end of RAM so we and the bootloader don't clobber it.
 #ifdef SAMD21
 uint32_t* safe_word = (uint32_t*) (HMCRAMC0_ADDR + HMCRAMC0_SIZE - 0x2000);

--- a/ports/cxd56/Makefile
+++ b/ports/cxd56/Makefile
@@ -90,6 +90,7 @@ INC += \
 	-I$(SPRESENSE_SDK)/nuttx/include \
 	-I$(SPRESENSE_SDK)/nuttx/arch \
 	-I$(SPRESENSE_SDK)/nuttx/arch/chip \
+	-I$(SPRESENSE_SDK)/nuttx/arch/os \
 	-I$(SPRESENSE_SDK)/sdk/bsp/include \
 	-I$(SPRESENSE_SDK)/sdk/bsp/include/sdk \
 
@@ -124,7 +125,6 @@ LDFLAGS = \
 	--entry=__start \
 	-nostartfiles \
 	-nodefaultlibs \
-	--defsym __stack=_vectors+786432 \
 	-T$(SPRESENSE_SDK)/nuttx/build/ramconfig.ld \
 	--gc-sections \
 	-Map=$(BUILD)/output.map \

--- a/ports/cxd56/mpconfigport.h
+++ b/ports/cxd56/mpconfigport.h
@@ -27,8 +27,8 @@
 #ifndef __INCLUDED_MPCONFIGPORT_H
 #define __INCLUDED_MPCONFIGPORT_H
 
-// 24kiB stack
-#define CIRCUITPY_DEFAULT_STACK_SIZE            0x6000
+// 64kiB stack
+#define CIRCUITPY_DEFAULT_STACK_SIZE            0x10000
 
 #include "py/circuitpy_mpconfig.h"
 

--- a/ports/cxd56/supervisor/port.c
+++ b/ports/cxd56/supervisor/port.c
@@ -67,6 +67,14 @@ void reset_port(void) {
 void reset_to_bootloader(void) {
 }
 
+uint32_t *port_stack_get_limit(void) {
+    return &_ebss;
+}
+
+uint32_t *port_stack_get_top(void) {
+    return &_estack;
+}
+
 extern uint32_t _ebss;
 
 // Place the word to save just after our BSS section that gets blanked.

--- a/ports/cxd56/supervisor/port.c
+++ b/ports/cxd56/supervisor/port.c
@@ -27,6 +27,8 @@
 #include <stdint.h>
 #include <sys/boardctl.h>
 
+#include "sched/sched.h"
+
 #include "boards/board.h"
 
 #include "supervisor/port.h"
@@ -68,11 +70,15 @@ void reset_to_bootloader(void) {
 }
 
 uint32_t *port_stack_get_limit(void) {
-    return &_ebss;
+    struct tcb_s *rtcb = this_task();
+
+    return rtcb->adj_stack_ptr - (uint32_t)rtcb->adj_stack_size;
 }
 
 uint32_t *port_stack_get_top(void) {
-    return &_estack;
+    struct tcb_s *rtcb = this_task();
+
+    return rtcb->adj_stack_ptr;
 }
 
 extern uint32_t _ebss;

--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -146,6 +146,14 @@ void reset_cpu(void) {
     NVIC_SystemReset();
 }
 
+uint32_t *port_stack_get_limit(void) {
+    return &_ebss;
+}
+
+uint32_t *port_stack_get_top(void) {
+    return &_estack;
+}
+
 extern uint32_t _ebss;
 // Place the word to save just after our BSS section that gets blanked.
 void port_set_saved_word(uint32_t value) {

--- a/ports/stm32f4/supervisor/port.c
+++ b/ports/stm32f4/supervisor/port.c
@@ -67,6 +67,14 @@ void reset_cpu(void) {
 	NVIC_SystemReset();
 }
 
+uint32_t *port_stack_get_limit(void) {
+    return &_ebss;
+}
+
+uint32_t *port_stack_get_top(void) {
+    return &_estack;
+}
+
 extern uint32_t _ebss;
 // Place the word to save just after our BSS section that gets blanked.
 void port_set_saved_word(uint32_t value) {

--- a/supervisor/port.h
+++ b/supervisor/port.h
@@ -54,6 +54,12 @@ void reset_board(void);
 // Reset to the bootloader
 void reset_to_bootloader(void);
 
+// Get stack limit address
+uint32_t *port_stack_get_limit(void);
+
+// Get stack top address
+uint32_t *port_stack_get_top(void);
+
 // Save and retrieve a word from memory that is preserved over reset. Used for safe mode.
 void port_set_saved_word(uint32_t);
 uint32_t port_get_saved_word(void);

--- a/supervisor/shared/memory.c
+++ b/supervisor/shared/memory.c
@@ -25,6 +25,7 @@
  */
 
 #include "supervisor/memory.h"
+#include "supervisor/port.h"
 
 #include <stddef.h>
 
@@ -36,12 +37,10 @@ static supervisor_allocation allocations[CIRCUITPY_SUPERVISOR_ALLOC_COUNT];
 // We use uint32_t* to ensure word (4 byte) alignment.
 uint32_t* low_address;
 uint32_t* high_address;
-extern uint32_t _ebss;
-extern uint32_t _estack;
 
 void memory_init(void) {
-    low_address = &_ebss;
-    high_address = &_estack;
+    low_address = port_stack_get_limit();
+    high_address = port_stack_get_top();
 }
 
 void free_memory(supervisor_allocation* allocation) {

--- a/supervisor/shared/stack.c
+++ b/supervisor/shared/stack.c
@@ -29,6 +29,7 @@
 #include "py/mpconfig.h"
 #include "py/runtime.h"
 #include "supervisor/cpu.h"
+#include "supervisor/port.h"
 #include "supervisor/shared/safe_mode.h"
 
 extern uint32_t _estack;
@@ -43,7 +44,7 @@ void allocate_stack(void) {
     mp_uint_t regs[10];
     mp_uint_t sp = cpu_get_regs_and_sp(regs);
 
-    mp_uint_t c_size = (uint32_t) &_estack - sp;
+    mp_uint_t c_size = (uint32_t) port_stack_get_top() - sp;
 
     stack_alloc = allocate_memory(c_size + next_stack_size + EXCEPTION_STACK_SIZE, true);
     if (stack_alloc == NULL) {


### PR DESCRIPTION
This PR changes the way to get stack addresses. Now instead of using only values from the linker file, you can define the top and limit address of the stack in the code.

Two new functions have been added: `port_stack_get_limit` and` port_stack_get_top`.

For `atmel-samd`, `nrf` and `stm32f4` stack addresses are returned using values from the linker file. For `cxd56` the stack addresses have been taken from the task where CircuitPython is running.