### PR TITLE
ci: don't run the "thread" tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,6 @@ jobs:
         done
       working-directory: tests
       if: failure()
-    - name: Test threads
-      run: MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 -d thread
-      working-directory: tests
     - name: Native Tests
       run: MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --emit native
       working-directory: tests


### PR DESCRIPTION
This part of the unix micropython port isn't related to any functionality used in CircuitPython, and at least one of the tests (thread_gc) fails with non-negligible frequency.

Reasons to revisit this in the future would include if/when thread support is added in CircuitPython.