### PR TITLE
Reduce DotStar status brightness; macros for status colors

### DIFF
--- a/supervisor/shared/rgb_led_colors.h
+++ b/supervisor/shared/rgb_led_colors.h
@@ -1,12 +1,18 @@
-#define BLACK   0x000000
-#define GREEN   0x003000
-#define BLUE    0x000030
-#define CYAN    0x003030
-#define RED     0x300000
-#define ORANGE  0x302000
-#define YELLOW  0x303000
-#define PURPLE  0x300030
-#define WHITE   0x303030
+
+#define COLOR(r, g, b) (((r) << 16) | ((g) << 8) | (b))
+// For brightness == 255 (full). This will be adjusted downward for various different RGB indicators,
+// which vary in brightness.
+#define INTENSITY (0x30)
+
+#define BLACK   COLOR(0, 0, 0)
+#define GREEN   COLOR(0, INTENSITY, 0)
+#define BLUE    COLOR(0, 0, INTENSITY)
+#define CYAN    COLOR(0, INTENSITY, INTENSITY)
+#define RED     COLOR(INTENSITY, 0, 0)
+#define ORANGE  COLOR(INTENSITY, INTENSITY*2/3, 0)
+#define YELLOW  COLOR(INTENSITY, INTENSITY, 0)
+#define PURPLE  COLOR(INTENSITY, 0, INTENSITY)
+#define WHITE   COLOR(INTENSITY, INTENSITY, INTENSITY)
 
 #define BOOT_RUNNING BLUE
 #define MAIN_RUNNING GREEN

--- a/supervisor/shared/rgb_led_status.c
+++ b/supervisor/shared/rgb_led_status.c
@@ -38,7 +38,7 @@ static digitalio_digitalinout_obj_t status_neopixel;
 
 
 #if defined(MICROPY_HW_APA102_MOSI) && defined(MICROPY_HW_APA102_SCK)
-uint8_t rgb_status_brightness = 255;
+uint8_t rgb_status_brightness = 50;
 
 #define APA102_BUFFER_LENGTH 12
 static uint8_t status_apa102_color[APA102_BUFFER_LENGTH] = {0, 0, 0, 0, 0xff, 0, 0, 0, 0xff, 0xff, 0xff, 0xff};


### PR DESCRIPTION
Fixes #2259.

Reduces status RGB LED brightness on boards with DotStars. There are various versions of DotStars that vary significantly in brightness. Also parameterizes the RGB status color definitions. It's a bit of overkill, but it doesn't add code. I did it because I originally didn't realize there were run-time brightness changes being done in `rgb_led_status.c`, and was preparing to do compile-time brightness changes based on the kind of status LED.