### PR TITLE
cpb: Disable the onboard speaker until request

### DIFF
--- a/ports/nrf/boards/circuitplayground_bluefruit/mpconfigboard.h
+++ b/ports/nrf/boards/circuitplayground_bluefruit/mpconfigboard.h
@@ -70,3 +70,5 @@
 
 #define DEFAULT_UART_BUS_RX         (&pin_P0_30)
 #define DEFAULT_UART_BUS_TX         (&pin_P0_14)
+
+#define SPEAKER_ENABLE_PIN          (&pin_P1_04)


### PR DESCRIPTION
This allows the board to disable the onboard speaker until explicitly enabled in user code.
    
Testing performed on a CPB:
 * Touching the AUDIO pin with a fingertip no longer generates noise/buzz
 * Generating a waveform with `simpleio.tone` produces no sound by default
 * When the board.SPEAKER_ENABLE is configured as a digital output and
       set True, `simpleio.tone` does produce sound
    
Note that while guides should include information about SPEAKER_ENABLE, it's possible that some users who omitted it could view this as a breaking change.  They can fix it by simply adding code similar to
```    
speaker_enable = digitalio.DigitalInOut(board.SPEAKER_ENABLE)
speaker_enable.direction = digitalio.Direction.OUTPUT
speaker_enable.value = True
```
before using the internal speaker.
    
Closes: #2258
