### PR TITLE
Allow boards to change the "CircuitPython" text in their USB interface description.

### DIFF
--- a/supervisor/supervisor.mk
+++ b/supervisor/supervisor.mk
@@ -91,6 +91,10 @@ else
 	CFLAGS += -DUSB_AVAILABLE
 endif
 
+ifndef USB_INTERFACE_NAME
+USB_INTERFACE_NAME = "CircuitPython"
+endif
+
 ifndef USB_DEVICES
 USB_DEVICES = "CDC,MSC,AUDIO,HID"
 endif
@@ -145,6 +149,7 @@ USB_DESCRIPTOR_ARGS = \
 	--vid $(USB_VID)\
 	--pid $(USB_PID)\
 	--serial_number_length $(USB_SERIAL_NUMBER_LENGTH)\
+	--interface_name $(USB_INTERFACE_NAME)\
 	--devices $(USB_DEVICES)\
 	--hid_devices $(USB_HID_DEVICES)\
   --msc_max_packet_size $(USB_MSC_MAX_PACKET_SIZE)\


### PR DESCRIPTION
In cases where more than one board is connected to a single computer it can become pretty hard to figure out which board you're actually talking to. For example, if you have several MIDI-compatible boards they all show up as "CircuitPython MIDI". This change allows boards to replace the "CircuitPython" part of their USB descriptors with more specific text, for example, "CircuitPython Feather" or just "Feather". This will let folks more easily tell boards apart.

The new option is named `USB_INTERFACE_NAME` and is available in `mkconfigboard.mk`. For example:

```
USB_INTERFACE_NAME = "Feather"
```