### PR TITLE
STM32: Raise clock speed of F405

### DIFF
--- a/ports/stm32f4/peripherals/stm32f4/stm32f405xx/clocks.c
+++ b/ports/stm32f4/peripherals/stm32f4/stm32f405xx/clocks.c
@@ -48,7 +48,7 @@ void stm32f4_peripherals_clocks_init(void) {
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
     RCC_OscInitStruct.PLL.PLLM = 12;
     RCC_OscInitStruct.PLL.PLLN = 336;
-    RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV4;
+    RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
     RCC_OscInitStruct.PLL.PLLQ = 7;
     HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
@@ -57,7 +57,7 @@ void stm32f4_peripherals_clocks_init(void) {
     RCC_ClkInitStruct.ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
     RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
     RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV2;
-    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
+    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;
     HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_5);
 }


### PR DESCRIPTION
This PR raises the clock speed of the F405 used in the feather_stm32f405_express and the pyboard to max value of 168MHz. Tested on a feather across a variety of modules. Resolves #2284. 

Thanks @manitou48 for bringing up and testing. 

Note to @dhalbert: us_delay dynamically calculates loop intervals for the no-interrupt case based on system frequency, so it's unaffected by this change. Double checked on the feather and we're still at ~1us accuracy. 