### PR TITLE
Makefile: Fix a problem where `xargs` invoked `xgettext` 2x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ pseudoxml:
 all-source:
 
 locale/circuitpython.pot: all-source
-	find $(TRANSLATE_SOURCES) -iname "*.c" -print0 | (LC_ALL=C sort -z) | xargs -0 xgettext -L C -s --add-location=file --keyword=translate -o circuitpython.pot -p locale
+	find $(TRANSLATE_SOURCES) -iname "*.c" -print | (LC_ALL=C sort) | xgettext -f- -L C -s --add-location=file --keyword=translate -o circuitpython.pot -p locale
 
 translate: locale/circuitpython.pot
 	for po in $(shell ls locale/*.po); do msgmerge -U $$po -s --no-fuzzy-matching --add-location=file locale/circuitpython.pot; done


### PR DESCRIPTION
On a Debian 10 system, the number of arguments to xargs was such that it would not fit in a single invocation (xargs --show-limits prints "bytes: Size of command buffer we are actually using: 131072").

In this situation, the output from the second invocation of xgettext would replace the output of the first one, so messages that appeared only in files early in the list would be lost.  Strings in "extmod" were most frequently the victim, including "incorrect padding" from modubinascii.c.

Unfortunately, when the github environment was similar enough to the environment where "make translate" was invoked, the problem was not found by "check-translate", because the same (incorrect, truncated) potfile would be generated on both systems.  Apparently Ubuntu and Debian were different enough that the problem could become visible.

xgettext has a mode where it reads files from stdin ('-f-'), but this does not have a zero-delimited variant documented.  Still, we will assume that files with adversarial names are not committed to circuitpython or created by the build process, and print newline-delimited filenames from `find` to be processed by `xgettext -f-`.

I also added this change to #1858 while trying to get that branch to pass CI.  Doing the investigation of that failure led me to diagnose and fix this problem.