### PR TITLE
workflows: Don't try to upload when running in someone's fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,7 @@ jobs:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
     - name: Upload to S3
-      run: aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1
+      run: "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -199,7 +199,7 @@ jobs:
       run: |
         pip install uritemplate
     - name: Upload to Release
-      run: python3 -u upload_release_files.py
+      run: "[ -z \"$ADABOT_GITHUB_ACCESS_TOKEN\" ] || python3 -u upload_release_files.py"
       working-directory: tools
       env:
         UPLOAD_URL: ${{ github.event.release.upload_url }}


### PR DESCRIPTION
.. which we can tell by whether the environment variable is non-empty.

This fixes a problem where, when I push to my own circuitpython fork, which has actions enabled, I eventually get a failure at the upload step.  See e.g., https://github.com/jepler/circuitpython/commit/8e9ac593963537f2504efdfeefe28782de68a53f/checks?check_suite_id=315428254 where all board builds fail at the upload step.

This may only affect users who have deliberately enabled actions within their fork, or maybe actions are still a beta/opt in thing at the user level?  For instance, checking another random fork that has recently prepared a pull request, there are no actions that ran in the past: https://github.com/sarfata/circuitpython/actions