### PR TITLE
Supervisor: create code.py file with sample code

### DIFF
--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -72,12 +72,12 @@ static void make_empty_file(FATFS *fatfs, const char *path) {
 
 static void make_sample_code_file(FATFS *fatfs) {
     FIL fs;
-    UINT *char_written = 0;
+    UINT char_written = 0;
     const byte buffer[] = "print('Hello World!')\n";
 
     //Create or modify existing code.py file 
     f_open(fatfs, &fs, "/code.py", FA_WRITE | FA_CREATE_ALWAYS);
-    f_write(&fs, buffer, sizeof(buffer) - 1, char_written);
+    f_write(&fs, buffer, sizeof(buffer) - 1, &char_written);
     f_close(&fs);
 }
 

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -73,11 +73,11 @@ static void make_empty_file(FATFS *fatfs, const char *path) {
 static void make_sample_code_file(FATFS *fatfs) {
     FIL fs;
     UINT *char_written = 0;
-    const byte buffer[] = "print('Hello World!')";
+    const byte buffer[] = "print('Hello World!')\n";
 
     //Create or modify existing code.py file 
     f_open(fatfs, &fs, "/code.py", FA_WRITE | FA_CREATE_ALWAYS);
-    f_write(&fs, buffer, sizeof(buffer), char_written);
+    f_write(&fs, buffer, sizeof(buffer) - 1, char_written);
     f_close(&fs);
 }
 

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -75,10 +75,15 @@ static void make_sample_code_file(FATFS *fatfs) {
     UINT char_written = 0;
     const byte buffer[] = "print('Hello World!')\n";
 
+    #if CIRCUITPY_FULL_BUILD == 0
+    make_empty_file(&vfs_fat->fatfs, "/code.py");
+
+    #else
     //Create or modify existing code.py file 
     f_open(fatfs, &fs, "/code.py", FA_WRITE | FA_CREATE_ALWAYS);
     f_write(&fs, buffer, sizeof(buffer) - 1, &char_written);
     f_close(&fs);
+    #endif
 }
 
 // we don't make this function static because it needs a lot of stack and we

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -71,14 +71,13 @@ static void make_empty_file(FATFS *fatfs, const char *path) {
 
 
 static void make_sample_code_file(FATFS *fatfs) {
+    #if CIRCUITPY_FULL_BUILD == 0
+    make_empty_file(fatfs, "/code.py");
+
+    #else
     FIL fs;
     UINT char_written = 0;
     const byte buffer[] = "print('Hello World!')\n";
-
-    #if CIRCUITPY_FULL_BUILD == 0
-    make_empty_file(&vfs_fat->fatfs, "/code.py");
-
-    #else
     //Create or modify existing code.py file 
     f_open(fatfs, &fs, "/code.py", FA_WRITE | FA_CREATE_ALWAYS);
     f_write(&fs, buffer, sizeof(buffer) - 1, &char_written);

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -71,10 +71,7 @@ static void make_empty_file(FATFS *fatfs, const char *path) {
 
 
 static void make_sample_code_file(FATFS *fatfs) {
-    #if CIRCUITPY_FULL_BUILD == 0
-    make_empty_file(fatfs, "/code.py");
-
-    #else
+    #if CIRCUITPY_FULL_BUILD == 1
     FIL fs;
     UINT char_written = 0;
     const byte buffer[] = "print('Hello World!')\n";

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -69,6 +69,18 @@ static void make_empty_file(FATFS *fatfs, const char *path) {
     f_close(&fp);
 }
 
+
+static void make_sample_code_file(FATFS *fatfs) {
+    FIL fs;
+    UINT *char_written = 0;
+    const byte buffer[] = "print('Hello World!')";
+
+    //Create or modify existing code.py file 
+    f_open(fatfs, &fs, "/code.py", FA_WRITE | FA_CREATE_ALWAYS);
+    f_write(&fs, buffer, sizeof(buffer), char_written);
+    f_close(&fs);
+}
+
 // we don't make this function static because it needs a lot of stack and we
 // want it to be executed without using stack within main() function
 void filesystem_init(bool create_allowed, bool force_create) {
@@ -98,6 +110,8 @@ void filesystem_init(bool create_allowed, bool force_create) {
         make_empty_file(&vfs_fat->fatfs, "/.metadata_never_index");
         make_empty_file(&vfs_fat->fatfs, "/.Trashes");
         make_empty_file(&vfs_fat->fatfs, "/.fseventsd/no_log");
+        // make a sample code.py file
+        make_sample_code_file(&vfs_fat->fatfs);
 
         // create empty lib directory
         f_mkdir(&vfs_fat->fatfs, "/lib");

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -71,7 +71,7 @@ static void make_empty_file(FATFS *fatfs, const char *path) {
 
 
 static void make_sample_code_file(FATFS *fatfs) {
-    #if CIRCUITPY_FULL_BUILD == 1
+    #if CIRCUITPY_FULL_BUILD
     FIL fs;
     UINT char_written = 0;
     const byte buffer[] = "print('Hello World!')\n";


### PR DESCRIPTION
Addresses Issue #2149

Create a sample code.py file during board flashing with a print hello world program. Tested on CircuitPlayground Express Board.

To-Do's:

1- Add compiler flags to disable this feature on non-express / limited memory boards
2- Error handling when fail to write the file for any reason
