### PR TITLE
Added Edgebadge alias build for Pybadge

### DIFF
--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -48,6 +48,7 @@ extension_by_board = {
 
 aliases_by_board = {
     "circuitplayground_express": ["circuitplayground_express_4h", "circuitplayground_express_digikey_pycon2019"],
+    "pybadge": ["edgebadge"],
     "gemma_m0": ["gemma_m0_pycon2018"],
     "pewpew10": ["pewpew13"]
 }


### PR DESCRIPTION
This is so we can add a board to circuitpython.org that uses the PyBadge files.