### PR TITLE
STM32: SPI clock rate fix and cleanup

### DIFF
--- a/ports/stm32f4/common-hal/busio/SPI.c
+++ b/ports/stm32f4/common-hal/busio/SPI.c
@@ -38,6 +38,8 @@
 
 #define MAX_SPI 6 //TODO; replace this as part of periph cleanup
 #define ALL_CLOCKS 0xFF
+
+//arrays use 0 based numbering: SPI1 is stored at index 0
 STATIC bool reserved_spi[MAX_SPI];
 STATIC bool never_reset_spi[MAX_SPI];
 

--- a/ports/stm32f4/common-hal/busio/SPI.c
+++ b/ports/stm32f4/common-hal/busio/SPI.c
@@ -50,7 +50,7 @@ STATIC uint32_t get_busclock(SPI_TypeDef * instance) {
         if(instance == SPI2) return HAL_RCC_GetPCLK1Freq();
     #endif
     #ifdef SPI3
-        if(instance == SPI2) return HAL_RCC_GetPCLK1Freq();
+        if(instance == SPI3) return HAL_RCC_GetPCLK1Freq();
     #endif
     return HAL_RCC_GetPCLK2Freq();
 }


### PR DESCRIPTION
This PR corrects an issue in the STM32 port where an incorrect bus clock was used to calculate frequency on several instances of the SPI peripheral, halving the clock rate. The module now correctly selects a bus clock based on SPI instance. Thanks @dhalbert for finding this!

Since SPI was one of the first modules created for the port, I've also taken the opportunity to clean it up a bit to bring it more in line with the other modules. 

resolves #2304 