### PR TITLE
Re-add pairing support

### DIFF
--- a/locale/ID.po
+++ b/locale/ID.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -680,6 +680,10 @@ msgstr ""
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1237,6 +1241,12 @@ msgstr ""
 #: shared-bindings/_pixelbuf/PixelBuf.c
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -669,6 +669,10 @@ msgstr ""
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1218,6 +1222,12 @@ msgstr ""
 #: shared-bindings/_pixelbuf/PixelBuf.c
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: Pascal Deneaux\n"
 "Language-Team: Sebastian Plamauer, Pascal Deneaux\n"
@@ -677,6 +677,10 @@ msgstr "Eingabe-/Ausgabefehler"
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1258,6 +1262,12 @@ msgid "Unmatched number of items on RHS (expected %d, got %d)."
 msgstr ""
 "Nicht übereinstimmende Anzahl von Elementen auf der rechten Seite (erwartet "
 "%d, %d erhalten)."
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
+msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c
 msgid "Unsupported baudrate"

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -669,6 +669,10 @@ msgstr ""
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1218,6 +1222,12 @@ msgstr ""
 #: shared-bindings/_pixelbuf/PixelBuf.c
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c

--- a/locale/en_x_pirate.po
+++ b/locale/en_x_pirate.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: @sommersoft, @MrCertainly\n"
@@ -673,6 +673,10 @@ msgstr ""
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1222,6 +1226,12 @@ msgstr ""
 #: shared-bindings/_pixelbuf/PixelBuf.c
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: 2018-08-24 22:56-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -679,6 +679,10 @@ msgstr "error Input/output"
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1256,6 +1260,12 @@ msgstr ""
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
 msgstr "Número incomparable de elementos en RHS (%d esperado,%d obtenido)"
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
+msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c
 msgid "Unsupported baudrate"

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: 2018-12-20 22:15-0800\n"
 "Last-Translator: Timothy <me@timothygarcia.ca>\n"
 "Language-Team: fil\n"
@@ -685,6 +685,10 @@ msgstr "May mali sa Input/Output"
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1258,6 +1262,12 @@ msgstr ""
 #: shared-bindings/_pixelbuf/PixelBuf.c
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: 2019-04-14 20:05+0100\n"
 "Last-Translator: Pierrick Couturier <arofarn@arofarn.info>\n"
 "Language-Team: fr\n"
@@ -689,6 +689,10 @@ msgstr "Erreur d'entrée/sortie"
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1282,6 +1286,12 @@ msgstr ""
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
 msgstr ""
 "Pas de correspondance du nombres d'éléments à droite (attendu %d, obtenu %d)"
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
+msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c
 msgid "Unsupported baudrate"

--- a/locale/it_IT.po
+++ b/locale/it_IT.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: 2018-10-02 16:27+0200\n"
 "Last-Translator: Enrico Paganin <enrico.paganin@mail.com>\n"
 "Language-Team: \n"
@@ -685,6 +685,10 @@ msgstr "Errore input/output"
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1258,6 +1262,12 @@ msgstr ""
 #: shared-bindings/_pixelbuf/PixelBuf.c
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: 2019-05-06 14:22-0700\n"
 "Last-Translator: \n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -673,6 +673,10 @@ msgstr ""
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1223,6 +1227,12 @@ msgstr ""
 #: shared-bindings/_pixelbuf/PixelBuf.c
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: 2019-03-19 18:37-0700\n"
 "Last-Translator: Radomir Dopieralski <circuitpython@sheep.art.pl>\n"
 "Language-Team: pl\n"
@@ -674,6 +674,10 @@ msgstr "Błąd I/O"
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1239,6 +1243,12 @@ msgstr ""
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
 msgstr "Zła liczba obiektów po prawej stronie (oczekiwano %d, jest %d)."
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
+msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c
 msgid "Unsupported baudrate"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: 2018-10-02 21:14-0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -678,6 +678,10 @@ msgstr ""
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1235,6 +1239,12 @@ msgstr ""
 #: shared-bindings/_pixelbuf/PixelBuf.c
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c

--- a/locale/zh_Latn_pinyin.po
+++ b/locale/zh_Latn_pinyin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: circuitpython-cn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-20 14:01-0800\n"
+"POT-Creation-Date: 2019-11-21 16:50-0800\n"
 "PO-Revision-Date: 2019-04-13 10:10-0700\n"
 "Last-Translator: hexthat\n"
 "Language-Team: Chinese Hanyu Pinyin\n"
@@ -675,6 +675,10 @@ msgstr "Shūrù/shūchū cuòwù"
 msgid "Insufficient authentication"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Insufficient encryption"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 msgid "Invalid %q pin"
@@ -1245,6 +1249,12 @@ msgstr ""
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
 msgstr "RHS (yùqí %d, huòdé %d) shàng wèi pǐpèi de xiàngmù."
+
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid ""
+"Unspecified issue. Can be that the pairing prompt on the other device was "
+"declined or ignored."
+msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/I2C.c
 msgid "Unsupported baudrate"

--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -178,6 +178,7 @@ STATIC bool adapter_on_ble_evt(ble_evt_t *ble_evt, void *self_in) {
 
             connection->conn_handle = ble_evt->evt.gap_evt.conn_handle;
             connection->connection_obj = mp_const_none;
+            connection->pair_status = PAIR_NOT_PAIRED;
             ble_drv_add_event_handler_entry(&connection->handler_entry, connection_on_ble_evt, connection);
             self->connection_objs = NULL;
 
@@ -436,7 +437,7 @@ STATIC bool connect_on_ble_evt(ble_evt_t *ble_evt, void *info_in) {
     return true;
 }
 
-mp_obj_t common_hal_bleio_adapter_connect(bleio_adapter_obj_t *self, bleio_address_obj_t *address, mp_float_t timeout, bool pair) {
+mp_obj_t common_hal_bleio_adapter_connect(bleio_adapter_obj_t *self, bleio_address_obj_t *address, mp_float_t timeout) {
 
     ble_gap_addr_t addr;
 

--- a/ports/nrf/common-hal/_bleio/Connection.c
+++ b/ports/nrf/common-hal/_bleio/Connection.c
@@ -290,7 +290,6 @@ STATIC bool discover_next_characteristics(bleio_connection_internal_t* connectio
 
     uint32_t err_code = sd_ble_gattc_characteristics_discover(connection->conn_handle, &handle_range);
     if (err_code != NRF_SUCCESS) {
-        asm("bkpt");
         return false;
     }
 

--- a/ports/nrf/common-hal/_bleio/Connection.c
+++ b/ports/nrf/common-hal/_bleio/Connection.c
@@ -34,6 +34,7 @@
 #include "ble_drv.h"
 #include "ble_hci.h"
 #include "nrf_soc.h"
+#include "lib/utils/interrupt_char.h"
 #include "py/gc.h"
 #include "py/objlist.h"
 #include "py/objstr.h"
@@ -51,7 +52,7 @@
 #define BLE_AD_TYPE_FLAGS_DATA_SIZE 1
 
 static const ble_gap_sec_params_t pairing_sec_params = {
-    .bond = 1,
+    .bond = 0,
     .mitm = 0,
     .lesc = 0,
     .keypress = 0,
@@ -109,7 +110,7 @@ bool connection_on_ble_evt(ble_evt_t *ble_evt, void *self_in) {
             // SoftDevice will respond to a length update request.
             sd_ble_gap_data_length_update(self->conn_handle, NULL, NULL);
             break;
-        
+
         case BLE_GAP_EVT_DATA_LENGTH_UPDATE: // 0x24
             break;
 
@@ -214,7 +215,7 @@ bool connection_on_ble_evt(ble_evt_t *ble_evt, void *self_in) {
             if (dump_events) {
                 mp_printf(&mp_plat_print, "Unhandled connection event: 0x%04x\n", ble_evt->header.evt_id);
             }
-            
+
             return false;
     }
     return true;
@@ -229,6 +230,13 @@ void bleio_connection_clear(bleio_connection_internal_t *self) {
     memset(&self->bonding_keys, 0, sizeof(self->bonding_keys));
 }
 
+bool common_hal_bleio_connection_get_paired(bleio_connection_obj_t *self) {
+    if (self->connection == NULL) {
+        return false;
+    }
+    return self->connection->pair_status == PAIR_PAIRED;
+}
+
 bool common_hal_bleio_connection_get_connected(bleio_connection_obj_t *self) {
     if (self->connection == NULL) {
         return false;
@@ -240,15 +248,17 @@ void common_hal_bleio_connection_disconnect(bleio_connection_internal_t *self) {
     sd_ble_gap_disconnect(self->conn_handle, BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
 }
 
-void common_hal_bleio_connection_pair(bleio_connection_internal_t *self) {
+void common_hal_bleio_connection_pair(bleio_connection_internal_t *self, bool bond) {
     self->pair_status = PAIR_WAITING;
 
     check_nrf_error(sd_ble_gap_authenticate(self->conn_handle, &pairing_sec_params));
 
-    while (self->pair_status == PAIR_WAITING) {
+    while (self->pair_status == PAIR_WAITING && !mp_hal_is_interrupted()) {
         RUN_BACKGROUND_TASKS;
     }
-
+    if (mp_hal_is_interrupted()) {
+        return;
+    }
     check_sec_status(self->sec_status);
 }
 
@@ -280,6 +290,7 @@ STATIC bool discover_next_characteristics(bleio_connection_internal_t* connectio
 
     uint32_t err_code = sd_ble_gattc_characteristics_discover(connection->conn_handle, &handle_range);
     if (err_code != NRF_SUCCESS) {
+        asm("bkpt");
         return false;
     }
 
@@ -574,10 +585,9 @@ STATIC void discover_remote_services(bleio_connection_internal_t *self, mp_obj_t
             // discovery call returns nothing.
             // discover_next_descriptors() appends to the descriptor_list.
             while (next_desc_start_handle <= service->end_handle &&
-                   next_desc_start_handle < next_desc_end_handle &&
+                   next_desc_start_handle <= next_desc_end_handle &&
                    discover_next_descriptors(self, characteristic,
                                              next_desc_start_handle, next_desc_end_handle)) {
-
                 // Get the most recently discovered descriptor, and then ask for descriptors
                 // whose handles start after that descriptor's handle.
                 const bleio_descriptor_obj_t *descriptor = characteristic->descriptor_list;

--- a/ports/nrf/common-hal/_bleio/__init__.c
+++ b/ports/nrf/common-hal/_bleio/__init__.c
@@ -74,7 +74,14 @@ void check_sec_status(uint8_t sec_status) {
     if (sec_status == BLE_GAP_SEC_STATUS_SUCCESS) {
         return;
     }
-    mp_raise_bleio_SecurityError(translate("Unknown security error: 0x%04x"), sec_status);
+
+    switch (sec_status) {
+        case BLE_GAP_SEC_STATUS_UNSPECIFIED:
+            mp_raise_bleio_SecurityError(translate("Unspecified issue. Can be that the pairing prompt on the other device was declined or ignored."));
+            return;
+        default:
+            mp_raise_bleio_SecurityError(translate("Unknown security error: 0x%04x"), sec_status);
+    }
 }
 
 // Turn off BLE on a reset or reload.

--- a/ports/nrf/common-hal/_bleio/__init__.c
+++ b/ports/nrf/common-hal/_bleio/__init__.c
@@ -62,6 +62,9 @@ void check_gatt_status(uint16_t gatt_status) {
         case BLE_GATT_STATUS_ATTERR_INSUF_AUTHENTICATION:
             mp_raise_bleio_SecurityError(translate("Insufficient authentication"));
             return;
+        case BLE_GATT_STATUS_ATTERR_INSUF_ENCRYPTION:
+            mp_raise_bleio_SecurityError(translate("Insufficient encryption"));
+            return;
         default:
             mp_raise_bleio_BluetoothError(translate("Unknown gatt error: 0x%04x"), gatt_status);
     }

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -321,7 +321,7 @@ const mp_obj_property_t bleio_adapter_connections_obj = {
                (mp_obj_t)&mp_const_none_obj },
 };
 
-//|   .. method:: connect(address, *, timeout, pair=False)
+//|   .. method:: connect(address, *, timeout)
 //|
 //|     Attempts a connection to the device with the given address.
 //|
@@ -331,11 +331,10 @@ const mp_obj_property_t bleio_adapter_connections_obj = {
 STATIC mp_obj_t bleio_adapter_connect(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_adapter_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
-    enum { ARG_address, ARG_timeout, ARG_pair };
+    enum { ARG_address, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_pair, MP_ARG_KW_ONLY | MP_ARG_BOOL, { .u_bool = false } },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -348,7 +347,7 @@ STATIC mp_obj_t bleio_adapter_connect(mp_uint_t n_args, const mp_obj_t *pos_args
     bleio_address_obj_t *address = MP_OBJ_TO_PTR(args[ARG_address].u_obj);
     mp_float_t timeout = mp_obj_get_float(args[ARG_timeout].u_obj);
 
-    return common_hal_bleio_adapter_connect(self, address, timeout, args[ARG_pair].u_bool);
+    return common_hal_bleio_adapter_connect(self, address, timeout);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_adapter_connect_obj, 2, bleio_adapter_connect);
 

--- a/shared-bindings/_bleio/Adapter.h
+++ b/shared-bindings/_bleio/Adapter.h
@@ -55,6 +55,6 @@ void common_hal_bleio_adapter_stop_scan(bleio_adapter_obj_t *self);
 
 bool common_hal_bleio_adapter_get_connected(bleio_adapter_obj_t *self);
 mp_obj_t common_hal_bleio_adapter_get_connections(bleio_adapter_obj_t *self);
-mp_obj_t common_hal_bleio_adapter_connect(bleio_adapter_obj_t *self, bleio_address_obj_t *address, mp_float_t timeout, bool pair);
+mp_obj_t common_hal_bleio_adapter_connect(bleio_adapter_obj_t *self, bleio_address_obj_t *address, mp_float_t timeout);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_BLEIO_ADAPTER_H

--- a/shared-bindings/_bleio/Characteristic.c
+++ b/shared-bindings/_bleio/Characteristic.c
@@ -338,7 +338,7 @@ STATIC MP_DEFINE_CONST_DICT(bleio_characteristic_locals_dict, bleio_characterist
 STATIC void bleio_characteristic_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     bleio_characteristic_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->uuid) {
-        mp_printf(print, "0x%08x Characteristic(", (uint32_t) self_in);
+        mp_printf(print, "Characteristic(");
         bleio_uuid_print(print, MP_OBJ_FROM_PTR(self->uuid), kind);
         mp_printf(print, ")");
     } else {

--- a/shared-bindings/_bleio/Characteristic.c
+++ b/shared-bindings/_bleio/Characteristic.c
@@ -168,7 +168,7 @@ const mp_obj_property_t bleio_characteristic_properties_obj = {
 //|   .. attribute:: uuid
 //|
 //|     The UUID of this characteristic. (read-only)
-//|     
+//|
 //|     Will be ``None`` if the 128-bit UUID for this characteristic is not known.
 //|
 STATIC mp_obj_t bleio_characteristic_get_uuid(mp_obj_t self_in) {
@@ -338,7 +338,7 @@ STATIC MP_DEFINE_CONST_DICT(bleio_characteristic_locals_dict, bleio_characterist
 STATIC void bleio_characteristic_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     bleio_characteristic_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->uuid) {
-        mp_printf(print, "Characteristic(");
+        mp_printf(print, "0x%08x Characteristic(", (uint32_t) self_in);
         bleio_uuid_print(print, MP_OBJ_FROM_PTR(self->uuid), kind);
         mp_printf(print, ")");
     } else {

--- a/shared-bindings/_bleio/Connection.c
+++ b/shared-bindings/_bleio/Connection.c
@@ -92,6 +92,29 @@ STATIC mp_obj_t bleio_connection_disconnect(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_connection_disconnect_obj, bleio_connection_disconnect);
 
+
+//|   .. method:: pair(*, bond=True)
+//|
+//|      Pair to the peer to improve security.
+//|
+STATIC mp_obj_t bleio_connection_pair(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    bleio_connection_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+
+    enum { ARG_bond };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_bond, MP_ARG_BOOL, {.u_bool = true} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    ensure_connected(self);
+
+    common_hal_bleio_connection_pair(self->connection, args[ARG_bond].u_bool);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_connection_pair_obj, 1, bleio_connection_pair);
+
 //|   .. method:: discover_remote_services(service_uuids_whitelist=None)
 //|
 //|      Do BLE discovery for all services or for the given service UUIDS,
@@ -99,19 +122,19 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_connection_disconnect_obj, bleio_connecti
 //|      `Connection.connected` must be True.
 //|
 //|     :param iterable service_uuids_whitelist:
-//|       
+//|
 //|       an iterable of :py:class:~`UUID` objects for the services provided by the peripheral
 //|       that you want to use.
 //|
 //|       The peripheral may provide more services, but services not listed are ignored
 //|       and will not be returned.
 //|
-//|       If service_uuids_whitelist is None, then all services will undergo discovery, which can be 
+//|       If service_uuids_whitelist is None, then all services will undergo discovery, which can be
 //|       slow.
 //|
 //|       If the service UUID is 128-bit, or its characteristic UUID's are 128-bit, you
 //|       you must have already created a :py:class:~`UUID` object for that UUID in order for the
-//|       service or characteristic to be discovered. Creating the UUID causes the UUID to be 
+//|       service or characteristic to be discovered. Creating the UUID causes the UUID to be
 //|       registered for use. (This restriction may be lifted in the future.)
 //|
 //|     :return: A tuple of `_bleio.Service` objects provided by the remote peripheral.
@@ -137,7 +160,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_connection_discover_remote_services_obj,
 
 //|   .. attribute:: connected
 //|
-//|     True if connected to a remote peer.
+//|     True if connected to the remote peer.
 //|
 STATIC mp_obj_t bleio_connection_get_connected(mp_obj_t self_in) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -153,13 +176,34 @@ const mp_obj_property_t bleio_connection_connected_obj = {
                (mp_obj_t)&mp_const_none_obj },
 };
 
+
+//|   .. attribute:: paired
+//|
+//|     True if paired to the remote peer.
+//|
+STATIC mp_obj_t bleio_connection_get_paired(mp_obj_t self_in) {
+    bleio_connection_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    return mp_obj_new_bool(common_hal_bleio_connection_get_paired(self));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_connection_get_paired_obj, bleio_connection_get_paired);
+
+const mp_obj_property_t bleio_connection_paired_obj = {
+    .base.type = &mp_type_property,
+    .proxy = { (mp_obj_t)&bleio_connection_get_paired_obj,
+               (mp_obj_t)&mp_const_none_obj,
+               (mp_obj_t)&mp_const_none_obj },
+};
+
 STATIC const mp_rom_map_elem_t bleio_connection_locals_dict_table[] = {
     // Methods
+    { MP_ROM_QSTR(MP_QSTR_pair),                     MP_ROM_PTR(&bleio_connection_pair_obj) },
     { MP_ROM_QSTR(MP_QSTR_disconnect),               MP_ROM_PTR(&bleio_connection_disconnect_obj) },
     { MP_ROM_QSTR(MP_QSTR_discover_remote_services), MP_ROM_PTR(&bleio_connection_discover_remote_services_obj) },
 
     // Properties
     { MP_ROM_QSTR(MP_QSTR_connected),       MP_ROM_PTR(&bleio_connection_connected_obj) },
+    { MP_ROM_QSTR(MP_QSTR_paired),          MP_ROM_PTR(&bleio_connection_paired_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(bleio_connection_locals_dict, bleio_connection_locals_dict_table);

--- a/shared-bindings/_bleio/Connection.h
+++ b/shared-bindings/_bleio/Connection.h
@@ -34,8 +34,10 @@
 
 extern const mp_obj_type_t bleio_connection_type;
 
+extern void common_hal_bleio_connection_pair(bleio_connection_internal_t *self, bool bond);
 extern void common_hal_bleio_connection_disconnect(bleio_connection_internal_t *self);
 extern bool common_hal_bleio_connection_get_connected(bleio_connection_obj_t *self);
+extern bool common_hal_bleio_connection_get_paired(bleio_connection_obj_t *self);
 extern mp_obj_tuple_t *common_hal_bleio_connection_discover_remote_services(bleio_connection_obj_t *self, mp_obj_t service_uuids_whitelist);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_BLEIO_CONNECTION_H


### PR DESCRIPTION
This adds a `pair` method to a connection to initiate pairing and a `paired` attribute to fetch current paired state.

This has only been tested on remotely initiated connections (aka as a peripheral.)