### PR TITLE
Only make objects long lived if they are on the GC heap

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -53,9 +53,6 @@
 // detect untraced object still in use
 #define CLEAR_ON_SWEEP (0)
 
-#define WORDS_PER_BLOCK ((MICROPY_BYTES_PER_GC_BLOCK) / BYTES_PER_WORD)
-#define BYTES_PER_BLOCK (MICROPY_BYTES_PER_GC_BLOCK)
-
 // ATB = allocation table byte
 // 0b00 = FREE -- free block
 // 0b01 = HEAD -- head of a chain of blocks
@@ -208,13 +205,6 @@ void gc_unlock(void) {
 bool gc_is_locked(void) {
     return MP_STATE_MEM(gc_lock_depth) != 0;
 }
-
-// ptr should be of type void*
-#define VERIFY_PTR(ptr) ( \
-        ((uintptr_t)(ptr) & (BYTES_PER_BLOCK - 1)) == 0      /* must be aligned on a block */ \
-        && ptr >= (void*)MP_STATE_MEM(gc_pool_start)     /* must be above start of pool */ \
-        && ptr < (void*)MP_STATE_MEM(gc_pool_end)        /* must be below end of pool */ \
-    )
 
 #ifndef TRACE_MARK
 #if DEBUG_PRINT

--- a/py/gc.h
+++ b/py/gc.h
@@ -29,7 +29,18 @@
 #include <stdint.h>
 
 #include "py/mpconfig.h"
+#include "py/mpstate.h"
 #include "py/misc.h"
+
+#define WORDS_PER_BLOCK ((MICROPY_BYTES_PER_GC_BLOCK) / BYTES_PER_WORD)
+#define BYTES_PER_BLOCK (MICROPY_BYTES_PER_GC_BLOCK)
+
+// ptr should be of type void*
+#define VERIFY_PTR(ptr) ( \
+        ((uintptr_t)(ptr) & (BYTES_PER_BLOCK - 1)) == 0      /* must be aligned on a block */ \
+        && ptr >= (void*)MP_STATE_MEM(gc_pool_start)     /* must be above start of pool */ \
+        && ptr < (void*)MP_STATE_MEM(gc_pool_end)        /* must be below end of pool */ \
+    )
 
 void gc_init(void *start, void *end);
 void gc_deinit(void);

--- a/py/gc_long_lived.c
+++ b/py/gc_long_lived.c
@@ -126,6 +126,11 @@ mp_obj_t make_obj_long_lived(mp_obj_t obj, uint8_t max_depth){
     if (obj == NULL) {
         return obj;
     }
+    // If not in the GC pool, do nothing. This can happen (at least) when
+    // there are frozen mp_type_bytes objects in ROM.
+    if (!VERIFY_PTR((void *)obj)) {
+        return obj;
+    }
     if (MP_OBJ_IS_TYPE(obj, &mp_type_fun_bc)) {
         mp_obj_fun_bc_t *fun_bc = MP_OBJ_TO_PTR(obj);
         return MP_OBJ_FROM_PTR(make_fun_bc_long_lived(fun_bc, max_depth));


### PR DESCRIPTION
When using frozen bytecode compiled into the "firmware" (obviously not quite true in the Unix port), and said frozen bytecode has mp_type_bytes object(s) defined, and said object(s) are used as default arguments to functions generated SIGSEGV. After researching, I found this is due to the behavior of making certain things "long_lived". My specific failure occurred in make_str_long_lived, specifically trying to assign str->data, but in my case, "str" is a "ROM" pointer. In other words it is not a heap address, so the concept of making that long lived doesn't seem to apply.

This fix uses VERIFY_PTR (moved from gc.c to gc.h) to check the argument passed to make_obj_long_lived and do nothing if the pointer is not verified as a GC heap block pointer.

I don't have a debugging capability on my actual microcontrollers, but in concept this patch seems safe since the concept of a "long live" GC pointer doesn't seem to apply if the pointer can't be verified to begin with.