### PR TITLE
nrf: i2sout: Fix double-increment when copying samples

### DIFF
--- a/ports/nrf/common-hal/audiobusio/I2SOut.c
+++ b/ports/nrf/common-hal/audiobusio/I2SOut.c
@@ -139,14 +139,14 @@ static void i2s_buffer_fill(audiobusio_i2sout_obj_t* self) {
             uint16_t *bp = (uint16_t*)buffer;
             uint16_t *be = (uint16_t*)(buffer + bytecount);
             uint16_t *sp = (uint16_t*)self->sample_data;
-            for (; bp != be; bp++) {
+            for (; bp != be;) {
                 *bp++ = *sp++ + 0x8000;
             }
         } else {
             uint8_t *bp = (uint8_t*)buffer;
             uint8_t *be = (uint8_t*)(buffer + bytecount);
             uint8_t *sp = (uint8_t*)self->sample_data;
-            for (; bp != be; bp++) {
+            for (; bp != be;) {
                 *bp++ = *sp++ + 0x80;
             }
         }


### PR DESCRIPTION
This caused two problems when playing unsigned samples:
 * When an even number of samples were present, it "worked" but only every other sample was copied into the output, changing the waveform
 * When an odd number of samples were present, the copy continued beyond the end of the buffers and caused a hard fault

This addresses only part of #2255