### PR TITLE
nrf: assign channel width and count correctly

### DIFF
--- a/ports/nrf/common-hal/audiobusio/I2SOut.c
+++ b/ports/nrf/common-hal/audiobusio/I2SOut.c
@@ -240,7 +240,7 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t* self,
 
     uint32_t max_buffer_length;
     bool single_buffer, samples_signed;
-    audiosample_get_buffer_structure(sample, /* single channel */ false,
+    audiosample_get_buffer_structure(sample, /* single channel */ true,
         &single_buffer, &samples_signed, &max_buffer_length,
         &self->channel_count);
     self->single_buffer = single_buffer;

--- a/ports/nrf/common-hal/audiobusio/I2SOut.c
+++ b/ports/nrf/common-hal/audiobusio/I2SOut.c
@@ -250,6 +250,10 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t* self,
     NRF_I2S->CONFIG.SWIDTH = self->bytes_per_sample == 1
         ? I2S_CONFIG_SWIDTH_SWIDTH_8Bit
         : I2S_CONFIG_SWIDTH_SWIDTH_16Bit;
+    NRF_I2S->CONFIG.CHANNELS = self->channel_count == 1
+        ? I2S_CONFIG_CHANNELS_CHANNELS_Left
+        : I2S_CONFIG_CHANNELS_CHANNELS_Stereo;
+
     choose_i2s_clocking(self, sample_rate);
     /* Allocate buffers based on a maximum duration
      * This duration was chosen empirically based on what would
@@ -272,9 +276,6 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t* self,
     self->paused = false;
     self->stopping = false;
     i2s_buffer_fill(self);
-
-    NRF_I2S->CONFIG.CHANNELS = self->channel_count == 1 ? I2S_CONFIG_CHANNELS_CHANNELS_Left : I2S_CONFIG_CHANNELS_CHANNELS_Stereo;
-
 
     NRF_I2S->RXTXD.MAXCNT = self->buffer_length / 4;
     NRF_I2S->ENABLE = I2S_ENABLE_ENABLE_Enabled;

--- a/ports/nrf/common-hal/audiobusio/I2SOut.c
+++ b/ports/nrf/common-hal/audiobusio/I2SOut.c
@@ -246,6 +246,10 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t* self,
     self->single_buffer = single_buffer;
     self->samples_signed = samples_signed;
 
+
+    NRF_I2S->CONFIG.SWIDTH = self->bytes_per_sample == 1
+        ? I2S_CONFIG_SWIDTH_SWIDTH_8Bit
+        : I2S_CONFIG_SWIDTH_SWIDTH_16Bit;
     choose_i2s_clocking(self, sample_rate);
     /* Allocate buffers based on a maximum duration
      * This duration was chosen empirically based on what would


### PR DESCRIPTION
Here's a last round of nrf i2s bugfixes.  I think that together these address everything reported in #2255, except for the MAXIM I2S DAC's 8-bit hardware limitation recorded in #2323 for future action