### PR TITLE
Make time.time_tuple constructor more CPython3 compatible

### DIFF
--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -85,7 +85,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(time_sleep_obj, time_sleep);
 #if MICROPY_PY_COLLECTIONS
 mp_obj_t struct_time_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     if (n_args != 1 || (kw_args != NULL && kw_args->used > 0)) {
-        mp_raise_TypeError(translate("time.struct_time() takes exactly 1 argument"));
+        return namedtuple_make_new(type, n_args, args, kw_args);
     }
     if (mp_obj_get_type(args[0])->getiter != mp_obj_tuple_getiter || ((mp_obj_tuple_t*) MP_OBJ_TO_PTR(args[0]))->len != 9) {
         mp_raise_TypeError(translate("time.struct_time() takes a 9-sequence"));

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -87,7 +87,7 @@ mp_obj_t struct_time_make_new(const mp_obj_type_t *type, size_t n_args, const mp
     if (n_args != 1 || (kw_args != NULL && kw_args->used > 0)) {
         mp_raise_TypeError(translate("time.struct_time() takes exactly 1 argument"));
     }
-    if (!MP_OBJ_IS_TYPE(args[0], &mp_type_tuple) || ((mp_obj_tuple_t*) MP_OBJ_TO_PTR(args[0]))->len != 9) {
+    if (mp_obj_get_type(args[0])->getiter != mp_obj_tuple_getiter || ((mp_obj_tuple_t*) MP_OBJ_TO_PTR(args[0]))->len != 9) {
         mp_raise_TypeError(translate("time.struct_time() takes a 9-sequence"));
     }
 


### PR DESCRIPTION
This covers the #2326 case, and also allows construction e.g., from positional or keyword arguments, which was not possible before.