### PR TITLE
Fix ePaper so it works after a GC.

### DIFF
--- a/shared-module/displayio/EPaperDisplay.c
+++ b/shared-module/displayio/EPaperDisplay.c
@@ -26,6 +26,7 @@
 
 #include "shared-bindings/displayio/EPaperDisplay.h"
 
+#include "py/gc.h"
 #include "py/runtime.h"
 #include "shared-bindings/displayio/ColorConverter.h"
 #include "shared-bindings/displayio/FourWire.h"
@@ -298,7 +299,7 @@ bool displayio_epaperdisplay_refresh_area(displayio_epaperdisplay_obj_t* self, c
 }
 
 bool common_hal_displayio_epaperdisplay_refresh(displayio_epaperdisplay_obj_t* self) {
-    
+
     if (self->refreshing && self->busy.base.type == &digitalio_digitalinout_type) {
         if (common_hal_digitalio_digitalinout_get_value(&self->busy) != self->busy_state) {
             self->refreshing = false;
@@ -365,6 +366,8 @@ void release_epaperdisplay(displayio_epaperdisplay_obj_t* self) {
 
 void displayio_epaperdisplay_collect_ptrs(displayio_epaperdisplay_obj_t* self) {
     displayio_display_core_collect_ptrs(&self->core);
+    gc_collect_ptr(self->start_sequence);
+    gc_collect_ptr(self->stop_sequence);
 }
 
 bool maybe_refresh_epaperdisplay(void) {


### PR DESCRIPTION
We weren't correctly collecting the start and stop sequences. As
a result, the GC would free the space and allocate other info
there.

Thanks to JacobT on Discord for the bug report!