### PR TITLE
Add sub-ms resolution for time.monotonic_ns, on samd and nrf ports

### DIFF
--- a/ports/cxd56/tick.c
+++ b/ports/cxd56/tick.c
@@ -43,3 +43,7 @@ void board_timerhook(void)
     autoreload_tick();
 #endif
 }
+
+uint64_t common_hal_time_monotonic_ns(void) {
+    return ticks_ms * 1000000;
+}

--- a/ports/nrf/tick.c
+++ b/ports/nrf/tick.c
@@ -102,3 +102,23 @@ void wait_until(uint64_t ms, uint32_t us_until_ms) {
     uint32_t ticks_per_us = common_hal_mcu_processor_get_frequency() / 1000 / 1000;
     while(ticks_ms <= ms && SysTick->VAL / ticks_per_us >= us_until_ms) {}
 }
+
+uint64_t common_hal_time_monotonic_ns(void) {
+    uint32_t ticks_per_us = common_hal_mcu_processor_get_frequency() / 1000 / 1000;
+
+    // We disable interrupts to prevent ticks_ms from changing while we grab it.
+    common_hal_mcu_disable_interrupts();
+    uint32_t tick_status = SysTick->CTRL;
+    uint32_t current_us = SysTick->VAL;
+    uint32_t tick_status2 = SysTick->CTRL;
+    uint64_t current_ms = ticks_ms;
+    // The second clause ensures our value actually rolled over. Its possible it hit zero between
+    // the VAL read and CTRL read.
+    if ((tick_status & SysTick_CTRL_COUNTFLAG_Msk) != 0 ||
+        ((tick_status2 & SysTick_CTRL_COUNTFLAG_Msk) != 0 && current_us > ticks_per_us)) {
+        current_ms++;
+    }
+    common_hal_mcu_enable_interrupts();
+    return (current_ms + 1) * 1000000
+        - current_us * 1000 / ticks_per_us;
+}

--- a/ports/nrf/tick.c
+++ b/ports/nrf/tick.c
@@ -30,6 +30,7 @@
 #include "supervisor/filesystem.h"
 #include "shared-module/gamepad/__init__.h"
 #include "shared-bindings/microcontroller/Processor.h"
+#include "shared-bindings/microcontroller/__init__.h"
 #include "nrf.h"
 
 // Global millisecond tick count
@@ -38,7 +39,12 @@ volatile uint64_t ticks_ms = 0;
 void SysTick_Handler(void) {
     // SysTick interrupt handler called when the SysTick timer reaches zero
     // (every millisecond).
+    common_hal_mcu_disable_interrupts();
     ticks_ms += 1;
+
+    // Read the control register to reset the COUNTFLAG.
+    (void) SysTick->CTRL;
+    common_hal_mcu_enable_interrupts();
 
 #if CIRCUITPY_FILESYSTEM_FLUSH_INTERVAL_MS > 0
     filesystem_tick();
@@ -74,8 +80,22 @@ void tick_delay(uint32_t us) {
 // us counts down!
 void current_tick(uint64_t* ms, uint32_t* us_until_ms) {
     uint32_t ticks_per_us = common_hal_mcu_processor_get_frequency() / 1000 / 1000;
-    *ms = ticks_ms;
-    *us_until_ms = SysTick->VAL / ticks_per_us;
+
+    // We disable interrupts to prevent ticks_ms from changing while we grab it.
+    common_hal_mcu_disable_interrupts();
+    uint32_t tick_status = SysTick->CTRL;
+    uint32_t current_us = SysTick->VAL;
+    uint32_t tick_status2 = SysTick->CTRL;
+    uint64_t current_ms = ticks_ms;
+    // The second clause ensures our value actually rolled over. Its possible it hit zero between
+    // the VAL read and CTRL read.
+    if ((tick_status & SysTick_CTRL_COUNTFLAG_Msk) != 0 ||
+        ((tick_status2 & SysTick_CTRL_COUNTFLAG_Msk) != 0 && current_us > ticks_per_us)) {
+        current_ms++;
+    }
+    common_hal_mcu_enable_interrupts();
+    *ms = current_ms;
+    *us_until_ms = current_us / ticks_per_us;
 }
 
 void wait_until(uint64_t ms, uint32_t us_until_ms) {

--- a/ports/stm32f4/tick.c
+++ b/ports/stm32f4/tick.c
@@ -30,6 +30,7 @@
 #include "supervisor/filesystem.h"
 #include "shared-module/gamepad/__init__.h"
 #include "shared-bindings/microcontroller/Processor.h"
+#include "shared-bindings/time/__init__.h"
 
 #include "stm32f4xx.h"
 
@@ -92,4 +93,8 @@ void current_tick(uint64_t* ms, uint32_t* us_until_ms) {
 void wait_until(uint64_t ms, uint32_t us_until_ms) {
     uint32_t ticks_per_us = SystemCoreClock / 1000 / 1000;
     while(ticks_ms <= ms && SysTick->VAL / ticks_per_us >= us_until_ms) {}
+}
+
+uint64_t common_hal_time_monotonic_ns(void) {
+    return common_hal_time_monotonic() * 1000000;
 }

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -216,7 +216,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 //|   :rtype: int
 //|
 STATIC mp_obj_t time_monotonic_ns(void) {
-    uint64_t time64 = common_hal_time_monotonic() * 1000000llu;
+    uint64_t time64 = common_hal_time_monotonic_ns();
     return mp_obj_new_int_from_ll((long long) time64);
 }
 MP_DEFINE_CONST_FUN_OBJ_0(time_monotonic_ns_obj, time_monotonic_ns);

--- a/shared-bindings/time/__init__.h
+++ b/shared-bindings/time/__init__.h
@@ -36,6 +36,7 @@ extern mp_obj_t struct_time_from_tm(timeutils_struct_time_t *tm);
 extern void struct_time_to_tm(mp_obj_t t, timeutils_struct_time_t *tm);
 
 extern uint64_t common_hal_time_monotonic(void);
+extern uint64_t common_hal_time_monotonic_ns(void);
 extern void common_hal_time_delay_ms(uint32_t);
 
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_TIME___INIT___H


### PR DESCRIPTION
This also addresses a problem where current_tick() / wait_until() could be wrong by 1ms on nRF, by copying systick code from the samd port.

Testing performed: on pyportal and cpb, looked at `time.monotonic_ns` values.  The values always went forward, and usually by "consistent" amounts in a small loop:

```
# Sub-millisecond times on pyportal with patch
>>> l = [time.monotonic_ns() for i in range(99)]
>>> all(l[i] < l[i+1] for i in range(len(l)-1))
True
>>> [l[i] - l[i-1] for i in range(1,len(l))]
[28850, 27825, 27650, 27808, ..., 28183, 28134]

# on nRF (slower CPU speed)
[43172, 42938, 42937, 42875, ..., 42875, 42937]
```

On samd builds, this new code isn't enabled for small builds to avoid increasing code size.  So those boards will still have just 1ms resolution in monotonic_ns.  Also, the resolution of time.monotonic isn't increased, since very soon after boot even 1ms resolution is not possible in CP floating-point values.