### PR TITLE
Fix for neopixels on <100MHz STM32 boards

### DIFF
--- a/ports/stm32f4/common-hal/digitalio/DigitalInOut.c
+++ b/ports/stm32f4/common-hal/digitalio/DigitalInOut.c
@@ -47,7 +47,7 @@ digitalinout_result_t common_hal_digitalio_digitalinout_construct(
     GPIO_InitStruct.Pin = pin_mask(self->pin->number);
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
     HAL_GPIO_Init(pin_port(self->pin->port), &GPIO_InitStruct);
 
     return DIGITALINOUT_OK;
@@ -73,7 +73,7 @@ void common_hal_digitalio_digitalinout_switch_to_input(
     GPIO_InitStruct.Pin = pin_mask(self->pin->number);
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
     HAL_GPIO_Init(pin_port(self->pin->port), &GPIO_InitStruct);
 
     common_hal_digitalio_digitalinout_set_pull(self, pull);
@@ -114,7 +114,7 @@ void common_hal_digitalio_digitalinout_set_drive_mode(
     GPIO_InitStruct.Mode = (drive_mode == DRIVE_MODE_OPEN_DRAIN ? 
         GPIO_MODE_OUTPUT_OD : GPIO_MODE_OUTPUT_PP);
     GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
     HAL_GPIO_Init(pin_port(self->pin->port), &GPIO_InitStruct);
 }
 

--- a/ports/stm32f4/common-hal/neopixel_write/__init__.c
+++ b/ports/stm32f4/common-hal/neopixel_write/__init__.c
@@ -76,13 +76,9 @@ void common_hal_neopixel_write (const digitalio_digitalinout_obj_t* digitalinout
         cyc = (pix & mask) ? t1 : t0;
         start = DWT->CYCCNT;
         LL_GPIO_SetOutputPin(p_port, p_mask);
-        while((DWT->CYCCNT - start) < cyc) {
-            __asm__ __volatile__("nop");
-        }
+        while((DWT->CYCCNT - start) < cyc);
         LL_GPIO_ResetOutputPin(p_port, p_mask);
-        while((DWT->CYCCNT - start) < interval) {
-            __asm__ __volatile__("nop");
-        }
+        while((DWT->CYCCNT - start) < interval);
         if(!(mask >>= 1)) {
             if(p >= end) break;
             pix       = *p++;

--- a/ports/stm32f4/common-hal/neopixel_write/__init__.c
+++ b/ports/stm32f4/common-hal/neopixel_write/__init__.c
@@ -28,6 +28,8 @@
 #include "shared-bindings/neopixel_write/__init__.h"
 
 #include "tick.h"
+#include "py/mperrno.h"
+#include "py/runtime.h"
 #include "common-hal/microcontroller/Pin.h"
 #include "stm32f4xx_hal.h"
 #include "stm32f4xx_ll_gpio.h"
@@ -40,6 +42,9 @@ uint32_t next_start_tick_us = 1000;
 #define MAGIC_800_T0H  2800000  // ~0.36 us -> 0.44 field
 #define MAGIC_800_T1H  1350000  // ~0.74 us -> 0.84 field
 
+#pragma GCC push_options
+#pragma GCC optimize ("Os")
+
 void common_hal_neopixel_write (const digitalio_digitalinout_obj_t* digitalinout, uint8_t *pixels, 
                                 uint32_t numBytes) {
     uint8_t *p = pixels, *end = p + numBytes, pix = *p++, mask = 0x80;
@@ -48,7 +53,7 @@ void common_hal_neopixel_write (const digitalio_digitalinout_obj_t* digitalinout
 
     //assumes 800_000Hz frequency
     //Theoretical values here are 800_000 -> 1.25us, 2500000->0.4us, 1250000->0.8us
-    //But they don't work, possibly due to bad optimization? Use tested magic values instead
+    //TODO: try to get dynamic weighting working again
     uint32_t sys_freq = HAL_RCC_GetSysClockFreq();
     uint32_t interval = sys_freq/MAGIC_800_INT;
     uint32_t t0 = (sys_freq/MAGIC_800_T0H);
@@ -63,23 +68,26 @@ void common_hal_neopixel_write (const digitalio_digitalinout_obj_t* digitalinout
 
     __disable_irq();
     // Enable DWT in debug core. Useable when interrupts disabled, as opposed to Systick->VAL
-    //ITM->LAR = 0xC5ACCE55; //this should be required but isn't
     CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
     DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
     DWT->CYCCNT = 0;
 
     for(;;) {
+        cyc = (pix & mask) ? t1 : t0;
         start = DWT->CYCCNT;
         LL_GPIO_SetOutputPin(p_port, p_mask);
-        cyc = (pix & mask) ? t1 : t0;
-        while(DWT->CYCCNT - start < cyc);
+        while((DWT->CYCCNT - start) < cyc) {
+            __asm__ __volatile__("nop");
+        }
         LL_GPIO_ResetOutputPin(p_port, p_mask);
+        while((DWT->CYCCNT - start) < interval) {
+            __asm__ __volatile__("nop");
+        }
         if(!(mask >>= 1)) {
             if(p >= end) break;
             pix       = *p++;
             mask = 0x80;
         }
-        while(DWT->CYCCNT - start < interval); //wait for interval to finish
     }
 
     // Enable interrupts again
@@ -94,3 +102,5 @@ void common_hal_neopixel_write (const digitalio_digitalinout_obj_t* digitalinout
         next_start_tick_us -= 100;
     }
 }
+
+#pragma GCC pop_options


### PR DESCRIPTION
Unlike the Atmel and NRF ports, the STM32F series has many different max CPU speeds across the starter, foundation and advanced lines. At lower CPU speeds, the previous neopixel code encounters an issue where the cycle time required to change a GPIO pin begins to approach the maximum allowable logic high period for a neopixel 0 bit. This results in the neopixel outputting a strong white as every bit is evaluated as 1 rather than 0. 

I had hoped to replace the system with a weighted one, where the processor cycles needed to change the GPIO pins would be subtracted from the timing, making timing consistent across all frequencies. Unfortunately, I haven't managed to get a fully dynamic system granular enough to be workable. In lieu of writing the whole thing in assembly, I've just shuffled the timing enough to hit acceptable timing across most frequencies. It should work on any ST chip higher than 84MHz, and is protected against optimization differences. 

As a side note, if anyone's used the `ARDUINO_ARCH_ARDUINO_CORE_STM32` code [here](https://github.com/adafruit/Adafruit_NeoPixel/blob/9cf5e96e8f436cc3460f6e7a32b20aceab6e905c/Adafruit_NeoPixel.cpp#L1902), I'd be interested to know if it works, since I don't see how the theoretical timings it uses could cooperate with the 0.22us cycle time required for the functions it uses without added trickery. It might provide some insight on this issue. 

Resolves #2346. @dhalbert, maybe you could also give it a shot on your dud feather and see if it helps at all? 

Bin for Feather below, but it won't do anything other than not break - will be more relevant once #2315 passes review. Also applies to the F411 Discovery, if anyone else has one. 
[firmware.bin.zip](https://github.com/adafruit/circuitpython/files/3918641/firmware.bin.zip)