### PR TITLE
STM32: Displayio

### DIFF
--- a/ports/stm32f4/common-hal/busio/SPI.c
+++ b/ports/stm32f4/common-hal/busio/SPI.c
@@ -165,7 +165,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     self->baudrate = (get_busclock(SPIx)/16);
     self->prescaler = 16;
     self->polarity = 0;
-    self->phase = 1;
+    self->phase = 0;
     self->bits = 8;
 
     claim_pin(sck);

--- a/ports/stm32f4/common-hal/busio/SPI.c
+++ b/ports/stm32f4/common-hal/busio/SPI.c
@@ -191,7 +191,8 @@ bool common_hal_busio_spi_deinited(busio_spi_obj_t *self) {
 
 void common_hal_busio_spi_deinit(busio_spi_obj_t *self) {
     spi_clock_disable(1<<(self->sck->spi_index - 1));
-    reserved_spi[self->sck->spi_index - 1] = true;
+    reserved_spi[self->sck->spi_index - 1] = false;
+    never_reset_spi[self->sck->spi_index - 1] = false;
 
     reset_pin_number(self->sck->pin->port,self->sck->pin->number);
     reset_pin_number(self->mosi->pin->port,self->mosi->pin->number);

--- a/ports/stm32f4/common-hal/displayio/ParallelBus.c
+++ b/ports/stm32f4/common-hal/displayio/ParallelBus.c
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Lucian Copeland for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "shared-bindings/displayio/ParallelBus.h"
+
+#include <stdint.h>
+
+#include "common-hal/microcontroller/Pin.h"
+#include "py/runtime.h"
+#include "shared-bindings/digitalio/DigitalInOut.h"
+#include "shared-bindings/microcontroller/__init__.h"
+
+#include "tick.h"
+
+void common_hal_displayio_parallelbus_construct(displayio_parallelbus_obj_t* self,
+    const mcu_pin_obj_t* data0, const mcu_pin_obj_t* command, const mcu_pin_obj_t* chip_select,
+    const mcu_pin_obj_t* write, const mcu_pin_obj_t* read, const mcu_pin_obj_t* reset) {
+
+    mp_raise_NotImplementedError(translate("ParallelBus not yet supported"));
+}
+
+void common_hal_displayio_parallelbus_deinit(displayio_parallelbus_obj_t* self) {
+
+}
+
+bool common_hal_displayio_parallelbus_reset(mp_obj_t obj) {
+	return false;
+}
+
+bool common_hal_displayio_parallelbus_bus_free(mp_obj_t obj) {
+    return false;
+}
+
+bool common_hal_displayio_parallelbus_begin_transaction(mp_obj_t obj) {
+
+    return false;
+}
+
+void common_hal_displayio_parallelbus_send(mp_obj_t obj, display_byte_type_t byte_type, display_chip_select_behavior_t chip_select, uint8_t *data, uint32_t data_length) {
+
+}
+
+void common_hal_displayio_parallelbus_end_transaction(mp_obj_t obj) {
+
+}

--- a/ports/stm32f4/common-hal/displayio/ParallelBus.h
+++ b/ports/stm32f4/common-hal/displayio/ParallelBus.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Lucian Copeland for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_STM32F4_COMMON_HAL_DISPLAYIO_PARALLELBUS_H
+#define MICROPY_INCLUDED_STM32F4_COMMON_HAL_DISPLAYIO_PARALLELBUS_H
+
+#include "common-hal/digitalio/DigitalInOut.h"
+
+typedef struct {
+    mp_obj_base_t base;
+} displayio_parallelbus_obj_t;
+
+#endif // MICROPY_INCLUDED_STM32F4_COMMON_HAL_DISPLAYIO_PARALLELBUS_H

--- a/ports/stm32f4/mpconfigport.mk
+++ b/ports/stm32f4/mpconfigport.mk
@@ -65,6 +65,9 @@ ifndef CIRCUITPY_NEOPIXEL_WRITE
 CIRCUITPY_NEOPIXEL_WRITE = 1
 endif
 
+ifndef
+CIRCUITPY_DISPLAYIO = 1
+endif
 
 #ifeq ($(MCU_SUB_VARIANT), stm32f412zx)
 #endif

--- a/shared-module/displayio/FourWire.c
+++ b/shared-module/displayio/FourWire.c
@@ -49,8 +49,8 @@ void common_hal_displayio_fourwire_construct(displayio_fourwire_obj_t* self,
     gc_never_free(self->bus);
 
     self->frequency = baudrate;
-    self->polarity = common_hal_busio_spi_get_polarity(spi);
-    self->phase = common_hal_busio_spi_get_phase(spi);
+    self->polarity = 0;
+    self->phase = 0;
 
     common_hal_digitalio_digitalinout_construct(&self->command, command);
     common_hal_digitalio_digitalinout_switch_to_output(&self->command, true, DRIVE_MODE_PUSH_PULL);


### PR DESCRIPTION
DisplayIO is back! And... still buggy. Works for the SSD1306, but not the ILI9341 TFT as used on the TFT Featherwing. 

A control Saleae for the Atmel M4 Express Feather looks like this:
![Screen Shot 2019-12-03 at 5 24 37 PM](https://user-images.githubusercontent.com/5904176/70095359-8a03df80-15f2-11ea-900c-1433967a2624.png)
One block of data:
![Screen Shot 2019-12-03 at 5 29 38 PM](https://user-images.githubusercontent.com/5904176/70095402-a3a52700-15f2-11ea-988e-ad0ffbd24056.png)
Subblock
![Screen Shot 2019-12-03 at 5 29 07 PM](https://user-images.githubusercontent.com/5904176/70095424-af90e900-15f2-11ea-9f16-3e77923a22c2.png)

SPI on the Feather looks a bit different: 
![Screen Shot 2019-12-03 at 5 32 49 PM](https://user-images.githubusercontent.com/5904176/70095671-5e352980-15f3-11ea-9435-161837c27826.png)
Subblocks are a lot larger, and send different (wrong?) data
![Screen Shot 2019-12-03 at 5 34 46 PM](https://user-images.githubusercontent.com/5904176/70095710-71e09000-15f3-11ea-9db2-750e5ab64310.png)
![Screen Shot 2019-12-03 at 5 35 47 PM](https://user-images.githubusercontent.com/5904176/70095719-79079e00-15f3-11ea-8c9e-50c297183698.png)

~~I'm concerned it might be trying to go too fast. The Atmel version is only going at 1MHz, while the STM32 is at 4MHz. The datasheet for the ILI9341 says it should be good up to 10M on writing only, though. I presume the settings for speed are handled by the ILI9341 library, since it isn't exposed in the python code.~~ Wasn't running Saleae fast enough, I see in FourWire that the display is substantially overclocked at 25MHz on both devices. 

I'd welcome more input from anyone more familiar with the ILI9341 screen and any quirks it might have with regard to SPI operation.

This should resolve #2308 when solved.
