### PR TITLE
Make _bleio.Connection.disconnect() idempotent

### DIFF
--- a/shared-bindings/_bleio/Connection.c
+++ b/shared-bindings/_bleio/Connection.c
@@ -80,14 +80,12 @@ STATIC void ensure_connected(bleio_connection_obj_t *self) {
 //|
 //|   .. method:: disconnect()
 //|
-//|     Disconnects from the remote peripheral.
+//|     Disconnects from the remote peripheral. Does nothing if already disconnected.
 //|
 STATIC mp_obj_t bleio_connection_disconnect(mp_obj_t self_in) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    ensure_connected(self);
-
+    // common_hal_bleio_connection_disconnect() does nothing if already disconnected.
     common_hal_bleio_connection_disconnect(self->connection);
-
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_connection_disconnect_obj, bleio_connection_disconnect);


### PR DESCRIPTION
Currently `_bleio.Connection.disconnect()` throws an exception if the connection is already disconnected. That makes
```python
if conn.connected:
    conn.disconnect()
```
have a potential race condition, if a disconnect happens between checking and disconnecting. So you'd have to guard the `disconnect()` with a try-except. This removes that necessity.