### PR TITLE
Check connection validity after service discovery.

### DIFF
--- a/ports/nrf/bluetooth/ble_drv.c
+++ b/ports/nrf/bluetooth/ble_drv.c
@@ -153,10 +153,6 @@ void SD_EVT_IRQHandler(void) {
             ble_gatts_evt_write_t* write_evt = &event->evt.gatts_evt.params.write;
             mp_printf(&mp_plat_print, "Write to: UUID(0x%04x) handle %x of length %d auth %x\n", write_evt->uuid.uuid, write_evt->handle, write_evt->len, write_evt->auth_required);
         }
-        if (!done) {
-            mp_printf(&mp_plat_print, "Unhandled ble event: 0x%04x\n", event->header.evt_id);
-
-        }
         #endif
     }
 }

--- a/ports/nrf/common-hal/_bleio/Connection.c
+++ b/ports/nrf/common-hal/_bleio/Connection.c
@@ -248,11 +248,6 @@ bool connection_on_ble_evt(ble_evt_t *ble_evt, void *self_in) {
 
 
         default:
-            // For debugging.
-            #if CIRCUITPY_VERBOSE_BLE
-                mp_printf(&mp_plat_print, "Unhandled connection event: 0x%04x\n", ble_evt->header.evt_id);
-            #endif
-
             return false;
     }
     return true;
@@ -659,6 +654,7 @@ STATIC void discover_remote_services(bleio_connection_internal_t *self, mp_obj_t
 
 mp_obj_tuple_t *common_hal_bleio_connection_discover_remote_services(bleio_connection_obj_t *self, mp_obj_t service_uuids_whitelist) {
     discover_remote_services(self->connection, service_uuids_whitelist);
+    bleio_connection_ensure_connected(self);
     // Convert to a tuple and then clear the list so the callee will take ownership.
     mp_obj_tuple_t *services_tuple = service_linked_list_to_tuple(self->connection->remote_service_list);
     self->connection->remote_service_list = NULL;

--- a/shared-bindings/_bleio/Connection.c
+++ b/shared-bindings/_bleio/Connection.c
@@ -66,7 +66,7 @@
 //|    connection = _bleio.adapter.connect(my_entry.address, timeout=10)
 //|
 
-STATIC void ensure_connected(bleio_connection_obj_t *self) {
+void bleio_connection_ensure_connected(bleio_connection_obj_t *self) {
     if (!common_hal_bleio_connection_get_connected(self)) {
         mp_raise_bleio_ConnectionError(translate("Connection has been disconnected and can no longer be used. Create a new connection."));
     }
@@ -106,7 +106,7 @@ STATIC mp_obj_t bleio_connection_pair(mp_uint_t n_args, const mp_obj_t *pos_args
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    ensure_connected(self);
+    bleio_connection_ensure_connected(self);
 
     common_hal_bleio_connection_pair(self->connection, args[ARG_bond].u_bool);
     return mp_const_none;
@@ -148,7 +148,7 @@ STATIC mp_obj_t bleio_connection_discover_remote_services(mp_uint_t n_args, cons
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    ensure_connected(self);
+    bleio_connection_ensure_connected(self);
 
     return MP_OBJ_FROM_PTR(common_hal_bleio_connection_discover_remote_services(
                                self,
@@ -209,7 +209,7 @@ const mp_obj_property_t bleio_connection_paired_obj = {
 STATIC mp_obj_t bleio_connection_get_connection_interval(mp_obj_t self_in) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    ensure_connected(self);
+    bleio_connection_ensure_connected(self);
     return mp_obj_new_float(common_hal_bleio_connection_get_connection_interval(self->connection));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_connection_get_connection_interval_obj, bleio_connection_get_connection_interval);
@@ -219,7 +219,7 @@ STATIC mp_obj_t bleio_connection_set_connection_interval(mp_obj_t self_in, mp_ob
 
     mp_float_t interval = mp_obj_get_float(interval_in);
 
-    ensure_connected(self);
+    bleio_connection_ensure_connected(self);
     common_hal_bleio_connection_set_connection_interval(self->connection, interval);
 
     return mp_const_none;

--- a/shared-bindings/_bleio/Connection.h
+++ b/shared-bindings/_bleio/Connection.h
@@ -43,4 +43,6 @@ extern mp_obj_tuple_t *common_hal_bleio_connection_discover_remote_services(blei
 mp_float_t common_hal_bleio_connection_get_connection_interval(bleio_connection_internal_t *self);
 void common_hal_bleio_connection_set_connection_interval(bleio_connection_internal_t *self, mp_float_t new_interval);
 
+void bleio_connection_ensure_connected(bleio_connection_obj_t *self);
+
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_BLEIO_CONNECTION_H

--- a/shared-bindings/_bleio/Service.c
+++ b/shared-bindings/_bleio/Service.c
@@ -136,7 +136,7 @@ const mp_obj_property_t bleio_service_secondary_obj = {
 //|   .. attribute:: uuid
 //|
 //|     The UUID of this service. (read-only)
-//|     
+//|
 //|     Will be ``None`` if the 128-bit UUID for this service is not known.
 //|
 STATIC mp_obj_t bleio_service_get_uuid(mp_obj_t self_in) {


### PR DESCRIPTION
Instead of HardFaulting it will now raise a ConnectionError when a disconnect happens while discovering services.

Fixes #2347