### PR TITLE
Add POWER_SWITCH pin to CPB

### DIFF
--- a/ports/nrf/boards/circuitplayground_bluefruit/board.c
+++ b/ports/nrf/boards/circuitplayground_bluefruit/board.c
@@ -25,6 +25,11 @@
  */
 
 #include "boards/board.h"
+#include "mpconfigboard.h"
+#include "py/obj.h"
+#include "peripherals/nrf/pins.h"
+
+#include "nrf_gpio.h"
 
 void board_init(void) {
 }
@@ -34,5 +39,12 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
-
+    // Turn off board.POWER_SWITCH (power-saving switch) on each soft reload, to prevent confusion.
+    nrf_gpio_cfg(POWER_SWITCH_PIN->number,
+                 NRF_GPIO_PIN_DIR_OUTPUT,
+                 NRF_GPIO_PIN_INPUT_DISCONNECT,
+                 NRF_GPIO_PIN_NOPULL,
+                 NRF_GPIO_PIN_S0S1,
+                 NRF_GPIO_PIN_NOSENSE);
+    nrf_gpio_pin_write(POWER_SWITCH_PIN->number, false);
 }

--- a/ports/nrf/boards/circuitplayground_bluefruit/mpconfigboard.h
+++ b/ports/nrf/boards/circuitplayground_bluefruit/mpconfigboard.h
@@ -54,6 +54,9 @@
 #define SPI_FLASH_CS_PIN &pin_P0_15
 #endif
 
+// Disables onboard peripherals and neopixels to save power.
+#define POWER_SWITCH_PIN            (&pin_P0_06)
+
 #define CIRCUITPY_AUTORELOAD_DELAY_MS 500
 
 #define CIRCUITPY_INTERNAL_NVM_SIZE (4096)

--- a/ports/nrf/boards/circuitplayground_bluefruit/pins.c
+++ b/ports/nrf/boards/circuitplayground_bluefruit/pins.c
@@ -48,8 +48,12 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SLIDE_SWITCH), MP_ROM_PTR(&pin_P1_06) },
     { MP_ROM_QSTR(MP_QSTR_D7), MP_ROM_PTR(&pin_P1_06) },
 
-    { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_P1_14) },
+    // If high, turns off NeoPixels, LIS3DH, sound sensor, light sensor, temp sensor.
+    { MP_ROM_QSTR(MP_QSTR_POWER_SWITCH), MP_ROM_PTR(&pin_P0_06) },
+    { MP_ROM_QSTR(MP_QSTR_D35), MP_ROM_PTR(&pin_P0_06) },
+
     { MP_ROM_QSTR(MP_QSTR_L), MP_ROM_PTR(&pin_P1_14) },
+    { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_P1_14) },
 
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_P0_13) },
     { MP_ROM_QSTR(MP_QSTR_D8), MP_ROM_PTR(&pin_P0_13) },


### PR DESCRIPTION
- Add `board.POWER_SWITCH` pin to CPB, aka `D35`. `POWER_SWITCH` controls the power to onboard peripherals and NeoPixels. If high, it turns them off.
- Set pin to output low on each soft reload. This disables power saving until it's re-enabled. This prevents confusion ("why aren't my NeoPixels working?") at the cost of a brief power-glitch on reload.