### PR TITLE
fix mtime on file creation

### DIFF
--- a/ports/nrf/fatfs_port.c
+++ b/ports/nrf/fatfs_port.c
@@ -27,9 +27,8 @@
 #include "py/runtime.h"
 #include "lib/oofatfs/ff.h"
 #include "lib/timeutils/timeutils.h"
-
-extern void common_hal_rtc_get_time(timeutils_struct_time_t *tm);
-extern void struct_time_to_tm(mp_obj_t t, timeutils_struct_time_t *tm);
+#include "shared-bindings/rtc/RTC.h"
+#include "shared-bindings/time/__init__.h"
 
 DWORD get_fattime(void) {
 #if CIRCUITPY_RTC

--- a/ports/nrf/fatfs_port.c
+++ b/ports/nrf/fatfs_port.c
@@ -26,8 +26,18 @@
 
 #include "py/runtime.h"
 #include "lib/oofatfs/ff.h"
+#include "lib/timeutils/timeutils.h"
+
+extern void common_hal_rtc_get_time(timeutils_struct_time_t *tm);
+extern void struct_time_to_tm(mp_obj_t t, timeutils_struct_time_t *tm);
 
 DWORD get_fattime(void) {
-	// TODO: Implement this function. For now, fake it.
-    return ((2016 - 1980) << 25) | ((12) << 21) | ((4) << 16) | ((00) << 11) | ((18) << 5) | (23 / 2);
+#if CIRCUITPY_RTC
+    timeutils_struct_time_t tm;
+    common_hal_rtc_get_time(&tm);
+    return ((tm.tm_year - 1980) << 25) | (tm.tm_mon << 21) | (tm.tm_mday << 16) |
+           (tm.tm_hour << 11)          | (tm.tm_min << 5)  | (tm.tm_sec >> 1);
+#else
+    return ((2016 - 1980) << 25) | ((9) << 21) | ((1) << 16) | ((16) << 11) | ((43) << 5) | (35 / 2);
+#endif
 }


### PR DESCRIPTION
(Partial) fix for issue #2335 (nrf port).

Test:

```python
import os
import time

def current_time(lt = time.localtime()):
    return "{:2d}-{:02d}-{:02d} {:2d}:{:02d}:{:02d}".format(lt.tm_year, lt.tm_mon, lt.tm_mday, lt.tm_hour, lt.tm_min, lt.tm_sec)

print("now:  ", current_time())

file = '/test.txt'
try:
    os.remove(file)
except:
    pass

with open(file, 'w') as f:
    f.write("hi from MCU")
    
print("mtime:", current_time(time.localtime(os.stat(file)[7])))

# Output:
# now:   2019-12-10 17:34:16
# mtime: 2019-12-10 17:34:16
```
