### PR TITLE
Fix crashes while copying files to nRF via USB

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -667,6 +667,9 @@ void gc_free(void *ptr) {
     if (ptr == NULL) {
         GC_EXIT();
     } else {
+        if (MP_STATE_MEM(gc_pool_start) == 0) {
+            reset_into_safe_mode(GC_ALLOC_OUTSIDE_VM);
+        }
         // get the GC block number corresponding to this pointer
         assert(VERIFY_PTR(ptr));
         size_t block = BLOCK_FROM_PTR(ptr);

--- a/supervisor/shared/external_flash/external_flash.c
+++ b/supervisor/shared/external_flash/external_flash.c
@@ -371,7 +371,7 @@ static void release_ram_cache(void) {
     if (supervisor_cache != NULL) {
         free_memory(supervisor_cache);
         supervisor_cache = NULL;
-    } else {
+    } else if (MP_STATE_MEM(gc_pool_start)) {
         m_free(MP_STATE_VM(flash_ram_cache));
     }
     MP_STATE_VM(flash_ram_cache) = NULL;
@@ -419,7 +419,7 @@ static bool flush_ram_cache(bool keep_cache) {
             write_flash(current_sector + (i * pages_per_block + j) * SPI_FLASH_PAGE_SIZE,
                         MP_STATE_VM(flash_ram_cache)[i * pages_per_block + j],
                         SPI_FLASH_PAGE_SIZE);
-            if (!keep_cache && supervisor_cache == NULL) {
+            if (!keep_cache && supervisor_cache == NULL && MP_STATE_MEM(gc_pool_start)) {
                 m_free(MP_STATE_VM(flash_ram_cache)[i * pages_per_block + j]);
             }
         }

--- a/supervisor/shared/external_flash/external_flash.c
+++ b/supervisor/shared/external_flash/external_flash.c
@@ -324,6 +324,10 @@ static bool allocate_ram_cache(void) {
         return true;
     }
 
+    if (MP_STATE_MEM(gc_pool_start) == 0) {
+        return false;
+    }
+
     MP_STATE_VM(flash_ram_cache) = m_malloc_maybe(blocks_per_sector * pages_per_block * sizeof(uint32_t), false);
     if (MP_STATE_VM(flash_ram_cache) == NULL) {
         return false;


### PR DESCRIPTION
There are a number of tricky cases that exist when there is the possibility to enter background
tasks early in initialization.  I discovered and fixed several of them, which were due to trying operations on the GC heap while it was not initialized.  This closes #2338 according to my testing.  An assertion which clarifies problematic calls to `m_free` was added, but is not strictly necessary.