### PR TITLE
nrf: sd_flash_operation_status should be volatile

### DIFF
--- a/ports/nrf/bluetooth/ble_drv.c
+++ b/ports/nrf/bluetooth/ble_drv.c
@@ -43,7 +43,7 @@
 nrf_nvic_state_t nrf_nvic_state = { 0 };
 
 // Flag indicating progress of internal flash operation.
-sd_flash_operation_status_t sd_flash_operation_status;
+volatile sd_flash_operation_status_t sd_flash_operation_status;
 
 __attribute__((aligned(4)))
 static uint8_t m_ble_evt_buf[sizeof(ble_evt_t) + (BLE_GATT_ATT_MTU_DEFAULT)];

--- a/ports/nrf/bluetooth/ble_drv.h
+++ b/ports/nrf/bluetooth/ble_drv.h
@@ -59,7 +59,7 @@ typedef enum {
 } sd_flash_operation_status_t;
 
 // Flag indicating progress of internal flash operation.
-extern sd_flash_operation_status_t sd_flash_operation_status;
+extern volatile sd_flash_operation_status_t sd_flash_operation_status;
 
 typedef struct ble_drv_evt_handler_entry {
     struct ble_drv_evt_handler_entry *next;


### PR DESCRIPTION
A flag variable, `sd_flash_operation_status`, used to check when an internal flash operation was done was not `volatile`, so it could not reliably be checked.
```
STATIC sd_flash_operation_status_t sd_flash_operation_wait_until_done(void) {
    while (sd_flash_operation_status == SD_FLASH_OPERATION_IN_PROGRESS) {
        sd_app_evt_wait();
    }
    return sd_flash_operation_status;
}
```
Fixes #2339, I believe.

I think maybe this broke with better inlining and inter-routine optimization after the switch to gcc9. I looked at the assembly code and the loop above doesn't even bother to check to flag variable in the optimized code. Also, it worked fine when compiled without optimization.