### PR TITLE
Fix flash write error handling; clean up safe mode message printing

### DIFF
--- a/locale/ID.po
+++ b/locale/ID.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,6 +21,19 @@ msgstr ""
 msgid ""
 "\n"
 "Code done running. Waiting for reload.\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
 msgstr ""
 
 #: py/obj.c
@@ -294,7 +307,7 @@ msgid "Array values should be single bytes."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
 msgstr ""
 
 #: main.c
@@ -454,6 +467,16 @@ msgstr ""
 msgid "CharacteristicBuffer writing not provided"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr ""
@@ -515,7 +538,7 @@ msgid "Couldn't allocate second buffer"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -632,26 +655,16 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr "Gagal untuk melepaskan mutex, status: 0x%08lX"
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr ""
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -826,13 +839,6 @@ msgstr ""
 msgid "Length must be non-negative"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr ""
@@ -847,11 +853,11 @@ msgid "Maximum x value when mirrored is %d"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
+msgid "MicroPython fatal error."
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -918,6 +924,10 @@ msgstr ""
 
 #: py/moduerrno.c
 msgid "No such file/directory"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
@@ -1103,10 +1113,7 @@ msgstr ""
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -1116,20 +1123,10 @@ msgid ""
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-#, fuzzy
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
-msgstr ""
-"Tegangan dari mikrokontroler turun atau mati. Pastikan sumber tegangan "
-"memberikan daya\n"
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
 msgstr ""
 
 #: shared-module/audiomixer/MixerVoice.c
@@ -1163,10 +1160,6 @@ msgstr ""
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
-msgstr "Untuk keluar, silahkan reset board tanpa "
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
@@ -1246,6 +1239,10 @@ msgstr ""
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown security error: 0x%04x"
@@ -1323,12 +1320,8 @@ msgstr ""
 "Untuk menampilkan modul built-in silahkan ketik `help(\"modules\")`.\n"
 
 #: supervisor/shared/safe_mode.c
-#, fuzzy
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
-"Anda sedang menjalankan mode aman (safe mode) yang berarti sesuatu yang "
-"sangat buruk telah terjadi.\n"
 
 #: supervisor/shared/safe_mode.c
 msgid "You requested starting safe mode by "
@@ -2853,6 +2846,19 @@ msgstr ""
 #~ msgid "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 #~ msgstr "Dukungan soft device, id: 0x%08lX, pc: 0x%08l"
 
+#, fuzzy
+#~ msgid ""
+#~ "The microcontroller's power dipped. Please make sure your power supply "
+#~ "provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "Tegangan dari mikrokontroler turun atau mati. Pastikan sumber tegangan "
+#~ "memberikan daya\n"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Untuk keluar, silahkan reset board tanpa "
+
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) tidak ada"
 
@@ -2869,6 +2875,14 @@ msgstr ""
 #~ msgstr ""
 #~ "Gunakan esptool untuk menghapus flash dan upload ulang Python sebagai "
 #~ "gantinya"
+
+#, fuzzy
+#~ msgid ""
+#~ "You are running in safe mode which means something unanticipated "
+#~ "happened.\n"
+#~ msgstr ""
+#~ "Anda sedang menjalankan mode aman (safe mode) yang berarti sesuatu yang "
+#~ "sangat buruk telah terjadi.\n"
 
 #~ msgid "[addrinfo error %d]"
 #~ msgstr "[addrinfo error %d]"

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,6 +21,19 @@ msgstr ""
 msgid ""
 "\n"
 "Code done running. Waiting for reload.\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
 msgstr ""
 
 #: py/obj.c
@@ -292,7 +305,7 @@ msgid "Array values should be single bytes."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
 msgstr ""
 
 #: main.c
@@ -444,6 +457,16 @@ msgstr ""
 msgid "CharacteristicBuffer writing not provided"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr ""
@@ -505,7 +528,7 @@ msgid "Couldn't allocate second buffer"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -621,26 +644,16 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr ""
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -815,13 +828,6 @@ msgstr ""
 msgid "Length must be non-negative"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr ""
@@ -836,11 +842,11 @@ msgid "Maximum x value when mirrored is %d"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
+msgid "MicroPython fatal error."
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -907,6 +913,10 @@ msgstr ""
 
 #: py/moduerrno.c
 msgid "No such file/directory"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
@@ -1087,10 +1097,7 @@ msgstr ""
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -1101,16 +1108,9 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
 msgstr ""
 
 #: shared-module/audiomixer/MixerVoice.c
@@ -1143,10 +1143,6 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -1227,6 +1223,10 @@ msgstr ""
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown security error: 0x%04x"
@@ -1297,8 +1297,7 @@ msgid ""
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: Pascal Deneaux\n"
 "Language-Team: Sebastian Plamauer, Pascal Deneaux\n"
@@ -24,6 +24,19 @@ msgid ""
 msgstr ""
 "\n"
 "Der Code wurde ausgeführt. Warte auf reload.\n"
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
+msgstr ""
 
 #: py/obj.c
 msgid "  File \"%q\""
@@ -294,7 +307,7 @@ msgid "Array values should be single bytes."
 msgstr "Array-Werte sollten aus Einzelbytes bestehen."
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
 msgstr ""
 
 #: main.c
@@ -448,6 +461,16 @@ msgstr "Kann nicht ohne MOSI-Pin schreiben."
 msgid "CharacteristicBuffer writing not provided"
 msgstr "Schreiben von CharacteristicBuffer ist nicht vorgesehen"
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr "Clock pin init fehlgeschlagen."
@@ -509,8 +532,8 @@ msgid "Couldn't allocate second buffer"
 msgstr "Konnte second buffer nicht zuteilen"
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
-msgstr "Absturz in HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
+msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "DAC already in use"
@@ -625,26 +648,16 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr "Mutex konnte nicht freigegeben werden. Status: 0x%04x"
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr "Datei existiert"
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -823,17 +836,6 @@ msgstr "Länge muss ein int sein"
 msgid "Length must be non-negative"
 msgstr "Länge darf nicht negativ sein"
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-"Sieht aus, als wäre der CircuitPython-Kernel-Code abgestürzt. Uups!\n"
-"Bitte melde das Problem unter https://github.com/adafruit/circuitpython/"
-"issues\n"
-"mit dem Inhalt deines CIRCUITPY-Laufwerks und dieser Nachricht:\n"
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr "MISO pin Initialisierung fehlgeschlagen"
@@ -848,14 +850,12 @@ msgid "Maximum x value when mirrored is %d"
 msgstr "Maximaler x-Wert beim Spiegeln ist %d"
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
 msgstr ""
-"MicroPython-NLR-Sprung ist fehlgeschlagen. Wahrscheinlich "
-"Speicherbeschädigung.\n"
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
-msgstr "Schwerwiegender MicroPython-Fehler\n"
+msgid "MicroPython fatal error."
+msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
@@ -923,6 +923,10 @@ msgstr "Kein Speicherplatz mehr verfügbar auf dem Gerät"
 #: py/moduerrno.c
 msgid "No such file/directory"
 msgstr "Keine solche Datei/Verzeichnis"
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
+msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
 #: shared-bindings/_bleio/CharacteristicBuffer.c
@@ -1110,17 +1114,8 @@ msgstr "Stream fehlt readinto() oder write() Methode."
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
-"Der CircuitPython-Heap war beschädigt, weil der Stack zu klein war.\n"
-"Bitte erhöhe die stack size limits und drücke die Reset-Taste (nach Auswurf "
-"des CIRCUITPY-Laufwerks)\n"
-"Wenn du den Stack nicht geändert hast, melde bitte das Problem unter https://"
-"github.com/adafruit/circuitpython/issues\n"
-"mit dem Inhalt deines CIRCUITPY-Laufwerks.\n"
 
 #: supervisor/shared/safe_mode.c
 msgid ""
@@ -1132,23 +1127,10 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
-"Die Stromversorgung des Mikrocontrollers ist eingebrochen. Stelle sicher, "
-"dass deine Stromversorgung genug Leistung für die gesamte Schaltung zur "
-"Verfügung stellt und drücke die Reset-Taste (nach Auswurf des CIRCUITPY-"
-"Laufwerks)\n"
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
-msgstr ""
-"Die Reset-Taste wurde beim Booten von CircuitPython gedrückt. Drücke sie "
-"erneut um den abgesicherten Modus zu verlassen. \n"
 
 #: shared-module/audiomixer/MixerVoice.c
 msgid "The sample's bits_per_sample does not match the mixer's"
@@ -1181,10 +1163,6 @@ msgstr ""
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
-msgstr "Zum beenden, resette bitte das board ohne "
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
@@ -1262,6 +1240,10 @@ msgstr "Unerwarteter nrfx uuid-Typ"
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown gatt error: 0x%04x"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
@@ -1343,11 +1325,8 @@ msgstr ""
 "aus.\n"
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
-"Sie laufen im abgesicherten Modus, was bedeutet, dass etwas Unerwartetes "
-"passiert ist.\n"
 
 #: supervisor/shared/safe_mode.c
 msgid "You requested starting safe mode by "
@@ -2737,6 +2716,9 @@ msgstr ""
 #~ msgid "Could not decode ble_uuid, err 0x%04x"
 #~ msgstr "Konnte ble_uuid nicht decodieren. Status: 0x%04x"
 
+#~ msgid "Crash into the HardFault_Handler.\n"
+#~ msgstr "Absturz in HardFault_Handler.\n"
+
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Daten sind zu groß für das advertisement packet"
 
@@ -2871,8 +2853,26 @@ msgstr ""
 #~ msgid "Invalid data pin"
 #~ msgstr "Ungültiger data pin"
 
+#~ msgid ""
+#~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
+#~ "Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
+#~ " with the contents of your CIRCUITPY drive and this message:\n"
+#~ msgstr ""
+#~ "Sieht aus, als wäre der CircuitPython-Kernel-Code abgestürzt. Uups!\n"
+#~ "Bitte melde das Problem unter https://github.com/adafruit/circuitpython/"
+#~ "issues\n"
+#~ "mit dem Inhalt deines CIRCUITPY-Laufwerks und dieser Nachricht:\n"
+
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "Maximale PWM Frequenz ist %dHz"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+#~ msgstr ""
+#~ "MicroPython-NLR-Sprung ist fehlgeschlagen. Wahrscheinlich "
+#~ "Speicherbeschädigung.\n"
+
+#~ msgid "MicroPython fatal error.\n"
+#~ msgstr "Schwerwiegender MicroPython-Fehler\n"
 
 #~ msgid "Minimum PWM frequency is 1hz."
 #~ msgstr "Minimale PWM Frequenz ist %dHz"
@@ -2920,6 +2920,41 @@ msgstr ""
 #~ msgid "STA required"
 #~ msgstr "STA erforderlich"
 
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase stack size limits and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ "If you didn't change the stack, then file an issue here with the contents "
+#~ "of your CIRCUITPY drive:\n"
+#~ msgstr ""
+#~ "Der CircuitPython-Heap war beschädigt, weil der Stack zu klein war.\n"
+#~ "Bitte erhöhe die stack size limits und drücke die Reset-Taste (nach "
+#~ "Auswurf des CIRCUITPY-Laufwerks)\n"
+#~ "Wenn du den Stack nicht geändert hast, melde bitte das Problem unter "
+#~ "https://github.com/adafruit/circuitpython/issues\n"
+#~ "mit dem Inhalt deines CIRCUITPY-Laufwerks.\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Please make sure your power supply "
+#~ "provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "Die Stromversorgung des Mikrocontrollers ist eingebrochen. Stelle sicher, "
+#~ "dass deine Stromversorgung genug Leistung für die gesamte Schaltung zur "
+#~ "Verfügung stellt und drücke die Reset-Taste (nach Auswurf des CIRCUITPY-"
+#~ "Laufwerks)\n"
+
+#~ msgid ""
+#~ "The reset button was pressed while booting CircuitPython. Press again to "
+#~ "exit safe mode.\n"
+#~ msgstr ""
+#~ "Die Reset-Taste wurde beim Booten von CircuitPython gedrückt. Drücke sie "
+#~ "erneut um den abgesicherten Modus zu verlassen. \n"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Zum beenden, resette bitte das board ohne "
+
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) existiert nicht"
 
@@ -2941,6 +2976,13 @@ msgstr ""
 
 #~ msgid "Voice index too high"
 #~ msgstr "Voice index zu hoch"
+
+#~ msgid ""
+#~ "You are running in safe mode which means something unanticipated "
+#~ "happened.\n"
+#~ msgstr ""
+#~ "Sie laufen im abgesicherten Modus, was bedeutet, dass etwas Unerwartetes "
+#~ "passiert ist.\n"
 
 #~ msgid "buffer too long"
 #~ msgstr "Buffer zu lang"

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -21,6 +21,19 @@ msgstr ""
 msgid ""
 "\n"
 "Code done running. Waiting for reload.\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
 msgstr ""
 
 #: py/obj.c
@@ -292,7 +305,7 @@ msgid "Array values should be single bytes."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
 msgstr ""
 
 #: main.c
@@ -444,6 +457,16 @@ msgstr ""
 msgid "CharacteristicBuffer writing not provided"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr ""
@@ -505,7 +528,7 @@ msgid "Couldn't allocate second buffer"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -621,26 +644,16 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr ""
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -815,13 +828,6 @@ msgstr ""
 msgid "Length must be non-negative"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr ""
@@ -836,11 +842,11 @@ msgid "Maximum x value when mirrored is %d"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
+msgid "MicroPython fatal error."
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -907,6 +913,10 @@ msgstr ""
 
 #: py/moduerrno.c
 msgid "No such file/directory"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
@@ -1087,10 +1097,7 @@ msgstr ""
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -1101,16 +1108,9 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
 msgstr ""
 
 #: shared-module/audiomixer/MixerVoice.c
@@ -1143,10 +1143,6 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -1227,6 +1223,10 @@ msgstr ""
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown security error: 0x%04x"
@@ -1297,8 +1297,7 @@ msgid ""
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c

--- a/locale/en_x_pirate.po
+++ b/locale/en_x_pirate.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: @sommersoft, @MrCertainly\n"
@@ -24,6 +24,19 @@ msgid ""
 msgstr ""
 "\n"
 "Captin's orders are complete. Holdin' fast fer reload.\n"
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
+msgstr ""
 
 #: py/obj.c
 msgid "  File \"%q\""
@@ -294,7 +307,7 @@ msgid "Array values should be single bytes."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
 msgstr ""
 
 #: main.c
@@ -448,6 +461,16 @@ msgstr ""
 msgid "CharacteristicBuffer writing not provided"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr ""
@@ -509,7 +532,7 @@ msgid "Couldn't allocate second buffer"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -625,26 +648,16 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr ""
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -819,13 +832,6 @@ msgstr ""
 msgid "Length must be non-negative"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr ""
@@ -840,11 +846,11 @@ msgid "Maximum x value when mirrored is %d"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
+msgid "MicroPython fatal error."
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -911,6 +917,10 @@ msgstr ""
 
 #: py/moduerrno.c
 msgid "No such file/directory"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
@@ -1091,10 +1101,7 @@ msgstr ""
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -1105,16 +1112,9 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
 msgstr ""
 
 #: shared-module/audiomixer/MixerVoice.c
@@ -1147,10 +1147,6 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -1231,6 +1227,10 @@ msgstr ""
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown security error: 0x%04x"
@@ -1301,8 +1301,7 @@ msgid ""
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: 2018-08-24 22:56-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -24,6 +24,19 @@ msgid ""
 msgstr ""
 "\n"
 "El código terminó su ejecución. Esperando para recargar.\n"
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
+msgstr ""
 
 #: py/obj.c
 msgid "  File \"%q\""
@@ -296,10 +309,8 @@ msgid "Array values should be single bytes."
 msgstr "Valores del array deben ser bytes individuales."
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
 msgstr ""
-"Intento de allocation de heap cuando la VM de MicroPython no estaba "
-"corriendo.\n"
 
 #: main.c
 msgid "Auto-reload is off.\n"
@@ -452,6 +463,16 @@ msgstr "No se puede escribir sin pin MOSI."
 msgid "CharacteristicBuffer writing not provided"
 msgstr "CharateristicBuffer escritura no proporcionada"
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr "Clock pin init fallido"
@@ -513,8 +534,8 @@ msgid "Couldn't allocate second buffer"
 msgstr "No se pudo asignar el segundo buffer"
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
-msgstr "Choque en el HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
+msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "DAC already in use"
@@ -629,27 +650,17 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr "No se puede liberar el mutex, err 0x%04x"
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr "El archivo ya existe"
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr "Falló borrado de flash"
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr "Falló el iniciar borrado de flash, err 0x%04x"
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
 msgstr "Falló la escritura"
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
-msgstr "Falló el iniciar la escritura de flash, err 0x%04x"
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
@@ -825,17 +836,6 @@ msgstr "Length debe ser un int"
 msgid "Length must be non-negative"
 msgstr "Longitud no deberia ser negativa"
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-"Parece que nuestro código de CircuitPython ha fallado con fuerza. Whoops!\n"
-"Por favor, crea un issue en https://github.com/adafruit/circuitpython/"
-"issues\n"
-" con el contenido de su unidad CIRCUITPY y este mensaje:\n"
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr "MISO pin init fallido."
@@ -850,12 +850,12 @@ msgid "Maximum x value when mirrored is %d"
 msgstr "Valor máximo de x cuando se refleja es %d"
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
-msgstr "MicroPython NLR salto fallido. Probable corrupción de memoria.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
+msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
-msgstr "Error fatal de MicroPython.\n"
+msgid "MicroPython fatal error."
+msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
@@ -922,6 +922,10 @@ msgstr "No queda espacio en el dispositivo"
 #: py/moduerrno.c
 msgid "No such file/directory"
 msgstr "No existe el archivo/directorio"
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
+msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
 #: shared-bindings/_bleio/CharacteristicBuffer.c
@@ -1112,17 +1116,8 @@ msgstr "A Stream le falta el método readinto() o write()."
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
-"El heap de CircuitPython estaba corrupto porque el stack era demasiado "
-"pequeño.\n"
-"Aumente los límites del tamaño del stacj y presione reset (después de "
-"expulsarCIRCUITPY).\n"
-"Si no cambió el stack, entonces reporte un issue aquí con el contenido desu "
-"unidad CIRCUITPY:\n"
 
 #: supervisor/shared/safe_mode.c
 msgid ""
@@ -1132,23 +1127,10 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
-"La alimentación del microcontrolador cayó. Por favor asegurate de que tu "
-"fuente de alimentación provee\n"
-"suficiente energia para todo el circuito y presiona el botón de reset "
-"(despuesde expulsar CIRCUITPY).\n"
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
-msgstr ""
-"El botón reset fue presionado mientras arrancaba CircuitPython. Presiona "
-"otra vez para salir del modo seguro.\n"
 
 #: shared-module/audiomixer/MixerVoice.c
 msgid "The sample's bits_per_sample does not match the mixer's"
@@ -1181,10 +1163,6 @@ msgstr ""
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr "Ancho del Tile debe dividir exactamente el ancho de mapa de bits"
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
-msgstr "Para salir, por favor reinicia la tarjeta sin "
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
@@ -1264,6 +1242,10 @@ msgstr "Tipo de uuid nrfx inesperado"
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown security error: 0x%04x"
@@ -1341,11 +1323,8 @@ msgstr ""
 "Para listar los módulos incorporados por favor haga `help(\"modules\")`.\n"
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
-"Estás ejecutando en modo seguro, lo cual significa que algo realmente malo "
-"ha sucedido.\n"
 
 #: supervisor/shared/safe_mode.c
 msgid "You requested starting safe mode by "
@@ -2702,6 +2681,11 @@ msgstr "paso cero"
 #~ msgid "Address is not %d bytes long or is in wrong format"
 #~ msgstr "Direción no es %d bytes largo o esta en el formato incorrecto"
 
+#~ msgid "Attempted heap allocation when MicroPython VM not running.\n"
+#~ msgstr ""
+#~ "Intento de allocation de heap cuando la VM de MicroPython no estaba "
+#~ "corriendo.\n"
+
 #~ msgid "Can't add services in Central mode"
 #~ msgstr "No se pueden agregar servicio en modo Central"
 
@@ -2734,6 +2718,9 @@ msgstr "paso cero"
 
 #~ msgid "Could not decode ble_uuid, err 0x%04x"
 #~ msgstr "No se puede descodificar ble_uuid, err 0x%04x"
+
+#~ msgid "Crash into the HardFault_Handler.\n"
+#~ msgstr "Choque en el HardFault_Handler.\n"
 
 #, fuzzy
 #~ msgid "Data too large for the advertisement packet"
@@ -2849,6 +2836,15 @@ msgstr "paso cero"
 #~ msgid "Failed to write gatts value, err 0x%04x"
 #~ msgstr "No se puede escribir el valor del atributo. err: 0x%04x"
 
+#~ msgid "Flash erase failed"
+#~ msgstr "Falló borrado de flash"
+
+#~ msgid "Flash erase failed to start, err 0x%04x"
+#~ msgstr "Falló el iniciar borrado de flash, err 0x%04x"
+
+#~ msgid "Flash write failed to start, err 0x%04x"
+#~ msgstr "Falló el iniciar la escritura de flash, err 0x%04x"
+
 #~ msgid "Function requires lock."
 #~ msgstr "La función requiere lock"
 
@@ -2864,8 +2860,25 @@ msgstr "paso cero"
 #~ msgid "Invalid data pin"
 #~ msgstr "Pin de datos inválido"
 
+#~ msgid ""
+#~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
+#~ "Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
+#~ " with the contents of your CIRCUITPY drive and this message:\n"
+#~ msgstr ""
+#~ "Parece que nuestro código de CircuitPython ha fallado con fuerza. "
+#~ "Whoops!\n"
+#~ "Por favor, crea un issue en https://github.com/adafruit/circuitpython/"
+#~ "issues\n"
+#~ " con el contenido de su unidad CIRCUITPY y este mensaje:\n"
+
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "La frecuencia máxima del PWM es %dhz."
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+#~ msgstr "MicroPython NLR salto fallido. Probable corrupción de memoria.\n"
+
+#~ msgid "MicroPython fatal error.\n"
+#~ msgstr "Error fatal de MicroPython.\n"
 
 #~ msgid "Minimum PWM frequency is 1hz."
 #~ msgstr "La frecuencia mínima del PWM es 1hz"
@@ -2926,8 +2939,43 @@ msgstr "paso cero"
 #~ msgid "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 #~ msgstr "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase stack size limits and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ "If you didn't change the stack, then file an issue here with the contents "
+#~ "of your CIRCUITPY drive:\n"
+#~ msgstr ""
+#~ "El heap de CircuitPython estaba corrupto porque el stack era demasiado "
+#~ "pequeño.\n"
+#~ "Aumente los límites del tamaño del stacj y presione reset (después de "
+#~ "expulsarCIRCUITPY).\n"
+#~ "Si no cambió el stack, entonces reporte un issue aquí con el contenido "
+#~ "desu unidad CIRCUITPY:\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Please make sure your power supply "
+#~ "provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "La alimentación del microcontrolador cayó. Por favor asegurate de que tu "
+#~ "fuente de alimentación provee\n"
+#~ "suficiente energia para todo el circuito y presiona el botón de reset "
+#~ "(despuesde expulsar CIRCUITPY).\n"
+
+#~ msgid ""
+#~ "The reset button was pressed while booting CircuitPython. Press again to "
+#~ "exit safe mode.\n"
+#~ msgstr ""
+#~ "El botón reset fue presionado mientras arrancaba CircuitPython. Presiona "
+#~ "otra vez para salir del modo seguro.\n"
+
 #~ msgid "Tile indices must be 0 - 255"
 #~ msgstr "Los índices de Tile deben ser 0 - 255"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Para salir, por favor reinicia la tarjeta sin "
 
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) no existe"
@@ -2950,6 +2998,13 @@ msgstr "paso cero"
 
 #~ msgid "Voice index too high"
 #~ msgstr "Index de voz demasiado alto"
+
+#~ msgid ""
+#~ "You are running in safe mode which means something unanticipated "
+#~ "happened.\n"
+#~ msgstr ""
+#~ "Estás ejecutando en modo seguro, lo cual significa que algo realmente "
+#~ "malo ha sucedido.\n"
 
 #~ msgid "bad GATT role"
 #~ msgstr "mal GATT role"

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: 2018-12-20 22:15-0800\n"
 "Last-Translator: Timothy <me@timothygarcia.ca>\n"
 "Language-Team: fil\n"
@@ -21,6 +21,19 @@ msgstr ""
 msgid ""
 "\n"
 "Code done running. Waiting for reload.\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
 msgstr ""
 
 #: py/obj.c
@@ -296,7 +309,7 @@ msgid "Array values should be single bytes."
 msgstr "Array values ay dapat single bytes."
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
 msgstr ""
 
 #: main.c
@@ -452,6 +465,16 @@ msgstr "Hindi maaring isulat kapag walang MOSI pin."
 msgid "CharacteristicBuffer writing not provided"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr "Nabigo sa pag init ng Clock pin."
@@ -514,8 +537,8 @@ msgid "Couldn't allocate second buffer"
 msgstr "Hindi ma-iallocate ang second buffer"
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
-msgstr "Nagcrash sa HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
+msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "DAC already in use"
@@ -635,26 +658,16 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr "Nabigo sa pagrelease ng mutex, status: 0x%08lX"
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr "Mayroong file"
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -831,17 +844,6 @@ msgstr "Haba ay dapat int"
 msgid "Length must be non-negative"
 msgstr "Haba ay dapat hindi negatibo"
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-"Mukhang ang core CircuitPython code nag crash. Ay!\n"
-"Maaring mag file ng issue sa https://github.com/adafruit/circuitpython/"
-"issues\n"
-"kasama ng laman ng iyong CIRCUITPY drive at ang message na ito:\n"
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr "Hindi ma-initialize ang MISO pin."
@@ -856,12 +858,12 @@ msgid "Maximum x value when mirrored is %d"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
-msgstr "CircuitPython NLR jump nabigo. Maaring memory corruption.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
+msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
-msgstr "CircuitPython fatal na pagkakamali.\n"
+msgid "MicroPython fatal error."
+msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
@@ -928,6 +930,10 @@ msgstr ""
 #: py/moduerrno.c
 msgid "No such file/directory"
 msgstr "Walang file/directory"
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
+msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
 #: shared-bindings/_bleio/CharacteristicBuffer.c
@@ -1116,16 +1122,8 @@ msgstr "Stream kulang ng readinto() o write() method."
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
-"Ang CircuitPython heap ay na corrupt dahil ang stack ay maliit.\n"
-"Maaring i-increase ang stack size limit at i-press ang reset (pagkatapos i-"
-"eject ang CIRCUITPY.\n"
-"Kung hindi mo pinalitan ang stack, mag file ng issue dito kasama ng laman ng "
-"CIRCUITPY drive:\n"
 
 #: supervisor/shared/safe_mode.c
 msgid ""
@@ -1135,22 +1133,10 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
-"Ang kapangyarihan ng mikrokontroller ay bumaba. Mangyaring suriin ang power "
-"supply \n"
-"pindutin ang reset (pagkatapos i-eject ang CIRCUITPY).\n"
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
-msgstr ""
-"Ang reset button ay pinindot habang nag boot ang CircuitPython. Pindutin "
-"ulit para lumabas sa safe mode.\n"
 
 #: shared-module/audiomixer/MixerVoice.c
 msgid "The sample's bits_per_sample does not match the mixer's"
@@ -1183,10 +1169,6 @@ msgstr ""
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
-msgstr "Para lumabas, paki-reset ang board na wala ang "
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
@@ -1265,6 +1247,10 @@ msgstr "hindi inaasahang indent"
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown gatt error: 0x%04x"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
@@ -1346,9 +1332,8 @@ msgstr ""
 "Para makita ang listahan ng modules, `help(“modules”)`.\n"
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
-msgstr "Ikaw ay tumatakbo sa safe mode dahil may masamang nangyari.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
+msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid "You requested starting safe mode by "
@@ -2735,6 +2720,9 @@ msgstr "zero step"
 #~ msgid "Cannot update i/f status"
 #~ msgstr "Hindi ma-update i/f status"
 
+#~ msgid "Crash into the HardFault_Handler.\n"
+#~ msgstr "Nagcrash sa HardFault_Handler.\n"
+
 #, fuzzy
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Hindi makasya ang data sa loob ng advertisement packet"
@@ -2871,8 +2859,24 @@ msgstr "zero step"
 #~ msgid "Invalid data pin"
 #~ msgstr "Mali ang data pin"
 
+#~ msgid ""
+#~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
+#~ "Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
+#~ " with the contents of your CIRCUITPY drive and this message:\n"
+#~ msgstr ""
+#~ "Mukhang ang core CircuitPython code nag crash. Ay!\n"
+#~ "Maaring mag file ng issue sa https://github.com/adafruit/circuitpython/"
+#~ "issues\n"
+#~ "kasama ng laman ng iyong CIRCUITPY drive at ang message na ito:\n"
+
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "Pinakamataas na PWM frequency ay %dhz."
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+#~ msgstr "CircuitPython NLR jump nabigo. Maaring memory corruption.\n"
+
+#~ msgid "MicroPython fatal error.\n"
+#~ msgstr "CircuitPython fatal na pagkakamali.\n"
 
 #~ msgid "Minimum PWM frequency is 1hz."
 #~ msgstr "Pinakamababang PWM frequency ay 1hz."
@@ -2918,6 +2922,39 @@ msgstr "zero step"
 #~ msgid "STA required"
 #~ msgstr "STA kailangan"
 
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase stack size limits and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ "If you didn't change the stack, then file an issue here with the contents "
+#~ "of your CIRCUITPY drive:\n"
+#~ msgstr ""
+#~ "Ang CircuitPython heap ay na corrupt dahil ang stack ay maliit.\n"
+#~ "Maaring i-increase ang stack size limit at i-press ang reset (pagkatapos "
+#~ "i-eject ang CIRCUITPY.\n"
+#~ "Kung hindi mo pinalitan ang stack, mag file ng issue dito kasama ng laman "
+#~ "ng CIRCUITPY drive:\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Please make sure your power supply "
+#~ "provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "Ang kapangyarihan ng mikrokontroller ay bumaba. Mangyaring suriin ang "
+#~ "power supply \n"
+#~ "pindutin ang reset (pagkatapos i-eject ang CIRCUITPY).\n"
+
+#~ msgid ""
+#~ "The reset button was pressed while booting CircuitPython. Press again to "
+#~ "exit safe mode.\n"
+#~ msgstr ""
+#~ "Ang reset button ay pinindot habang nag boot ang CircuitPython. Pindutin "
+#~ "ulit para lumabas sa safe mode.\n"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Para lumabas, paki-reset ang board na wala ang "
+
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "Walang UART(%d)"
 
@@ -2936,6 +2973,11 @@ msgstr "zero step"
 
 #~ msgid "Voice index too high"
 #~ msgstr "Index ng Voice ay masyadong mataas"
+
+#~ msgid ""
+#~ "You are running in safe mode which means something unanticipated "
+#~ "happened.\n"
+#~ msgstr "Ikaw ay tumatakbo sa safe mode dahil may masamang nangyari.\n"
 
 #~ msgid "[addrinfo error %d]"
 #~ msgstr "[addrinfo error %d]"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: 2019-04-14 20:05+0100\n"
 "Last-Translator: Pierrick Couturier <arofarn@arofarn.info>\n"
 "Language-Team: fr\n"
@@ -24,6 +24,19 @@ msgid ""
 msgstr ""
 "\n"
 "Fin d'éxecution du code. En attente de recharge.\n"
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
+msgstr ""
 
 #: py/obj.c
 msgid "  File \"%q\""
@@ -300,9 +313,8 @@ msgid "Array values should be single bytes."
 msgstr "Les valeurs du tableau doivent être des octets simples 'bytes'."
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
 msgstr ""
-"Tentative d'allocation de tas alors que la VM MicroPython ne tourne pas.\n"
 
 #: main.c
 msgid "Auto-reload is off.\n"
@@ -458,6 +470,16 @@ msgstr "Impossible d'écrire sans broche MOSI."
 msgid "CharacteristicBuffer writing not provided"
 msgstr "Ecriture sur 'CharacteristicBuffer' non fournie"
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr "Echec de l'init. de la broche d'horloge"
@@ -520,8 +542,8 @@ msgid "Couldn't allocate second buffer"
 msgstr "Impossible d'allouer le 2e tampon"
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
-msgstr "Plantage vers le 'HardFault_Handler'.\n"
+msgid "Crash into the HardFault_Handler."
+msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "DAC already in use"
@@ -639,27 +661,17 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr "Impossible de libérer mutex, err 0x%04x"
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr "Le fichier existe"
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr "L'effacement de la flash a échoué"
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr "Echec du démarrage de l'effacement de la flash, err 0x%04x"
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
 msgstr "L'écriture de la flash échoué"
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
-msgstr "Echec du démarrage de l'écriture de la flash, err 0x%04x"
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
@@ -839,17 +851,6 @@ msgstr "La longueur doit être un nombre entier"
 msgid "Length must be non-negative"
 msgstr "La longueur ne doit pas être négative"
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-"On dirait que notre code CircuitPython a durement planté. Oups !\n"
-"Merci de remplir un ticket sur https://github.com/adafruit/circuitpython/"
-"issues\n"
-"avec le contenu de votre lecteur CIRCUITPY et ce message:\n"
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr "Echec de l'init. de la broche MISO"
@@ -864,12 +865,12 @@ msgid "Maximum x value when mirrored is %d"
 msgstr "La valeur max. de x est %d lors d'une opération miroir"
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
-msgstr "Saut MicroPython NLR a échoué. Corruption de mémoire possible.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
+msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
-msgstr "Erreur fatale de MicroPython.\n"
+msgid "MicroPython fatal error."
+msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
@@ -936,6 +937,10 @@ msgstr "Il n'y a plus d'espace libre sur le périphérique"
 #: py/moduerrno.c
 msgid "No such file/directory"
 msgstr "Fichier/dossier introuvable"
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
+msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
 #: shared-bindings/_bleio/CharacteristicBuffer.c
@@ -1131,17 +1136,8 @@ msgstr "Il manque une méthode readinto() ou write() au flux."
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
-"Le tas (heap) de CircuitPython a été corrompu parce que la pile était trop "
-"petite.\n"
-"Augmentez la limite de taille de la pile et appuyez sur 'reset' (après avoir "
-"éjecté CIRCUITPY).\n"
-"Si vous n'avez pas modifié la pile, merci de remplir un ticket avec le "
-"contenu  de votre lecteur CIRCUITPY :\n"
 
 #: supervisor/shared/safe_mode.c
 msgid ""
@@ -1150,25 +1146,11 @@ msgid ""
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-#, fuzzy
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
-"L'alimentation du microcontroleur a chuté. Merci de vérifier que votre "
-"alimentation fournit\n"
-"suffisamment de puissance pour l'ensemble du circuit et appuyez sur "
-"'reset' (après avoir éjecté CIRCUITPY).\n"
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
-msgstr ""
-"Le bouton 'reset' a été appuyé pendant le démarrage de CircuitPython. "
-"Appuyer de nouveau pour quitter de le mode sans-échec.\n"
 
 #: shared-module/audiomixer/MixerVoice.c
 msgid "The sample's bits_per_sample does not match the mixer's"
@@ -1202,10 +1184,6 @@ msgstr ""
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr "La largeur de la tuile doit diviser exactement la largeur de l'image"
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
-msgstr "Pour quitter, redémarrez la carte SVP sans "
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
@@ -1289,6 +1267,10 @@ msgstr "Type inattendu pour l'uuid nrfx"
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown security error: 0x%04x"
@@ -1367,11 +1349,8 @@ msgstr ""
 "Pour lister les modules inclus, tapez `help(\"modules\")`.\n"
 
 #: supervisor/shared/safe_mode.c
-#, fuzzy
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
-"Vous êtes en mode sans-échec ce qui signifie qu'un imprévu est survenu.\n"
 
 #: supervisor/shared/safe_mode.c
 msgid "You requested starting safe mode by "
@@ -2753,6 +2732,10 @@ msgstr "'step' nul"
 #~ msgid "Address is not %d bytes long or is in wrong format"
 #~ msgstr "L'adresse n'est pas longue de %d octets ou est d'un format erroné"
 
+#~ msgid "Attempted heap allocation when MicroPython VM not running.\n"
+#~ msgstr ""
+#~ "Tentative d'allocation de tas alors que la VM MicroPython ne tourne pas.\n"
+
 #~ msgid "Can't add services in Central mode"
 #~ msgstr "Impossible d'ajouter des services en mode Central"
 
@@ -2785,6 +2768,9 @@ msgstr "'step' nul"
 
 #~ msgid "Could not decode ble_uuid, err 0x%04x"
 #~ msgstr "Impossible de décoder le 'ble_uuid', err 0x%04x"
+
+#~ msgid "Crash into the HardFault_Handler.\n"
+#~ msgstr "Plantage vers le 'HardFault_Handler'.\n"
 
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Données trop volumineuses pour le paquet de diffusion"
@@ -2912,6 +2898,15 @@ msgstr "'step' nul"
 #~ msgid "Failed to write gatts value, err 0x%04x"
 #~ msgstr "Impossible d'écrire la valeur de 'gatts', err 0x%04x"
 
+#~ msgid "Flash erase failed"
+#~ msgstr "L'effacement de la flash a échoué"
+
+#~ msgid "Flash erase failed to start, err 0x%04x"
+#~ msgstr "Echec du démarrage de l'effacement de la flash, err 0x%04x"
+
+#~ msgid "Flash write failed to start, err 0x%04x"
+#~ msgstr "Echec du démarrage de l'écriture de la flash, err 0x%04x"
+
 #~ msgid "Function requires lock."
 #~ msgstr "La fonction nécessite un verrou."
 
@@ -2927,8 +2922,24 @@ msgstr "'step' nul"
 #~ msgid "Invalid data pin"
 #~ msgstr "Broche de données invalide"
 
+#~ msgid ""
+#~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
+#~ "Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
+#~ " with the contents of your CIRCUITPY drive and this message:\n"
+#~ msgstr ""
+#~ "On dirait que notre code CircuitPython a durement planté. Oups !\n"
+#~ "Merci de remplir un ticket sur https://github.com/adafruit/circuitpython/"
+#~ "issues\n"
+#~ "avec le contenu de votre lecteur CIRCUITPY et ce message:\n"
+
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "La fréquence de PWM maximale est %dHz"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+#~ msgstr "Saut MicroPython NLR a échoué. Corruption de mémoire possible.\n"
+
+#~ msgid "MicroPython fatal error.\n"
+#~ msgstr "Erreur fatale de MicroPython.\n"
 
 #~ msgid "Minimum PWM frequency is 1hz."
 #~ msgstr "La fréquence de PWM minimale est 1Hz"
@@ -2986,8 +2997,44 @@ msgstr "'step' nul"
 #~ msgid "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 #~ msgstr "Assertion en mode 'soft-device', id: 0x%08lX, pc: 0x%08lX"
 
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase stack size limits and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ "If you didn't change the stack, then file an issue here with the contents "
+#~ "of your CIRCUITPY drive:\n"
+#~ msgstr ""
+#~ "Le tas (heap) de CircuitPython a été corrompu parce que la pile était "
+#~ "trop petite.\n"
+#~ "Augmentez la limite de taille de la pile et appuyez sur 'reset' (après "
+#~ "avoir éjecté CIRCUITPY).\n"
+#~ "Si vous n'avez pas modifié la pile, merci de remplir un ticket avec le "
+#~ "contenu  de votre lecteur CIRCUITPY :\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "The microcontroller's power dipped. Please make sure your power supply "
+#~ "provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "L'alimentation du microcontroleur a chuté. Merci de vérifier que votre "
+#~ "alimentation fournit\n"
+#~ "suffisamment de puissance pour l'ensemble du circuit et appuyez sur "
+#~ "'reset' (après avoir éjecté CIRCUITPY).\n"
+
+#~ msgid ""
+#~ "The reset button was pressed while booting CircuitPython. Press again to "
+#~ "exit safe mode.\n"
+#~ msgstr ""
+#~ "Le bouton 'reset' a été appuyé pendant le démarrage de CircuitPython. "
+#~ "Appuyer de nouveau pour quitter de le mode sans-échec.\n"
+
 #~ msgid "Tile indices must be 0 - 255"
 #~ msgstr "Les indices des tuiles doivent être compris entre 0 et 255 "
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Pour quitter, redémarrez la carte SVP sans "
 
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) n'existe pas"
@@ -3010,6 +3057,13 @@ msgstr "'step' nul"
 
 #~ msgid "Voice index too high"
 #~ msgstr "Index de la voix trop grand"
+
+#, fuzzy
+#~ msgid ""
+#~ "You are running in safe mode which means something unanticipated "
+#~ "happened.\n"
+#~ msgstr ""
+#~ "Vous êtes en mode sans-échec ce qui signifie qu'un imprévu est survenu.\n"
 
 #~ msgid "bad GATT role"
 #~ msgstr "mauvais rôle GATT"

--- a/locale/it_IT.po
+++ b/locale/it_IT.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: 2018-10-02 16:27+0200\n"
 "Last-Translator: Enrico Paganin <enrico.paganin@mail.com>\n"
 "Language-Team: \n"
@@ -21,6 +21,19 @@ msgstr ""
 msgid ""
 "\n"
 "Code done running. Waiting for reload.\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
 msgstr ""
 
 #: py/obj.c
@@ -295,7 +308,7 @@ msgid "Array values should be single bytes."
 msgstr "Valori di Array dovrebbero essere bytes singulari"
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
 msgstr ""
 
 #: main.c
@@ -453,6 +466,16 @@ msgstr "Impossibile scrivere senza pin MOSI."
 msgid "CharacteristicBuffer writing not provided"
 msgstr "CharacteristicBuffer scritura non dato"
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr "Inizializzazione del pin di clock fallita."
@@ -515,7 +538,7 @@ msgid "Couldn't allocate second buffer"
 msgstr "Impossibile allocare il secondo buffer"
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -635,27 +658,17 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr "Impossibile leggere valore dell'attributo. status: 0x%02x"
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr "File esistente"
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr "Cancellamento di Flash fallito"
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr "Iniziamento di Cancellamento di Flash fallito, err 0x%04x"
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
 msgstr "Impostazione di Flash fallito"
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
-msgstr "Iniziamento di Impostazione di Flash dallito, err 0x%04x"
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
@@ -834,13 +847,6 @@ msgstr "Length deve essere un intero"
 msgid "Length must be non-negative"
 msgstr "Length deve essere non negativo"
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr "inizializzazione del pin MISO fallita."
@@ -855,12 +861,12 @@ msgid "Maximum x value when mirrored is %d"
 msgstr "Valore massimo di x quando rispachiato è %d"
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
-msgstr "Errore fatale in MicroPython.\n"
+msgid "MicroPython fatal error."
+msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
@@ -928,6 +934,10 @@ msgstr "Non che spazio sul dispositivo"
 #: py/moduerrno.c
 msgid "No such file/directory"
 msgstr "Nessun file/directory esistente"
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
+msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
 #: shared-bindings/_bleio/CharacteristicBuffer.c
@@ -1123,10 +1133,7 @@ msgstr "Metodi mancanti readinto() o write() allo stream."
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -1136,20 +1143,10 @@ msgid ""
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-#, fuzzy
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
-msgstr ""
-"La potenza del microcontrollore è calata. Assicurati che l'alimentazione sia "
-"attaccata correttamente\n"
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
 msgstr ""
 
 #: shared-module/audiomixer/MixerVoice.c
@@ -1183,10 +1180,6 @@ msgstr ""
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
-msgstr "Per uscire resettare la scheda senza "
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
@@ -1267,6 +1260,10 @@ msgstr "indentazione inaspettata"
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown security error: 0x%04x"
@@ -1338,12 +1335,8 @@ msgid ""
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-#, fuzzy
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
-"Sei nella modalità sicura che significa che qualcosa di molto brutto è "
-"successo.\n"
 
 #: supervisor/shared/safe_mode.c
 msgid "You requested starting safe mode by "
@@ -2862,6 +2855,15 @@ msgstr "zero step"
 #~ msgid "Failed to write gatts value, err 0x%04x"
 #~ msgstr "Impossibile scrivere valore dell'attributo. status: 0x%02x"
 
+#~ msgid "Flash erase failed"
+#~ msgstr "Cancellamento di Flash fallito"
+
+#~ msgid "Flash erase failed to start, err 0x%04x"
+#~ msgstr "Iniziamento di Cancellamento di Flash fallito, err 0x%04x"
+
+#~ msgid "Flash write failed to start, err 0x%04x"
+#~ msgstr "Iniziamento di Impostazione di Flash dallito, err 0x%04x"
+
 #~ msgid "GPIO16 does not support pull up."
 #~ msgstr "GPIO16 non supporta pull-up"
 
@@ -2876,6 +2878,9 @@ msgstr "zero step"
 
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "Frequenza massima su PWM è %dhz"
+
+#~ msgid "MicroPython fatal error.\n"
+#~ msgstr "Errore fatale in MicroPython.\n"
 
 #~ msgid "Minimum PWM frequency is 1hz."
 #~ msgstr "Frequenza minima su PWM è 1hz"
@@ -2922,6 +2927,19 @@ msgstr "zero step"
 #~ msgid "STA required"
 #~ msgstr "STA richiesta"
 
+#, fuzzy
+#~ msgid ""
+#~ "The microcontroller's power dipped. Please make sure your power supply "
+#~ "provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "La potenza del microcontrollore è calata. Assicurati che l'alimentazione "
+#~ "sia attaccata correttamente\n"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Per uscire resettare la scheda senza "
+
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) non esistente"
 
@@ -2936,6 +2954,14 @@ msgstr "zero step"
 
 #~ msgid "Use esptool to erase flash and re-upload Python instead"
 #~ msgstr "Usa esptool per cancellare la flash e ricaricare Python invece"
+
+#, fuzzy
+#~ msgid ""
+#~ "You are running in safe mode which means something unanticipated "
+#~ "happened.\n"
+#~ msgstr ""
+#~ "Sei nella modalità sicura che significa che qualcosa di molto brutto è "
+#~ "successo.\n"
 
 #~ msgid "[addrinfo error %d]"
 #~ msgstr "[errore addrinfo %d]"

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: 2019-05-06 14:22-0700\n"
 "Last-Translator: \n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,6 +24,19 @@ msgid ""
 msgstr ""
 "\n"
 "실행 완료 코드. 재장전 을 기다리는 중입니다\n"
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
+msgstr ""
 
 #: py/obj.c
 msgid "  File \"%q\""
@@ -294,7 +307,7 @@ msgid "Array values should be single bytes."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
 msgstr ""
 
 #: main.c
@@ -448,6 +461,16 @@ msgstr ""
 msgid "CharacteristicBuffer writing not provided"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr ""
@@ -509,7 +532,7 @@ msgid "Couldn't allocate second buffer"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -625,26 +648,16 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr ""
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -819,13 +832,6 @@ msgstr "길이는 정수(int) 여야합니다"
 msgid "Length must be non-negative"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr ""
@@ -840,11 +846,11 @@ msgid "Maximum x value when mirrored is %d"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
+msgid "MicroPython fatal error."
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -911,6 +917,10 @@ msgstr ""
 
 #: py/moduerrno.c
 msgid "No such file/directory"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
@@ -1091,10 +1101,7 @@ msgstr ""
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -1105,16 +1112,9 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
 msgstr ""
 
 #: shared-module/audiomixer/MixerVoice.c
@@ -1147,10 +1147,6 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -1232,6 +1228,10 @@ msgstr ""
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown security error: 0x%04x"
@@ -1302,8 +1302,7 @@ msgid ""
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: 2019-03-19 18:37-0700\n"
 "Last-Translator: Radomir Dopieralski <circuitpython@sheep.art.pl>\n"
 "Language-Team: pl\n"
@@ -23,6 +23,19 @@ msgid ""
 msgstr ""
 "\n"
 "Kod wykonany. Czekam na przeładowanie.\n"
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
+msgstr ""
 
 #: py/obj.c
 msgid "  File \"%q\""
@@ -293,8 +306,8 @@ msgid "Array values should be single bytes."
 msgstr "Wartości powinny być bajtami."
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
-msgstr "Próba alokacji pamięci na stercie gdy VM nie działa.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
+msgstr ""
 
 #: main.c
 msgid "Auto-reload is off.\n"
@@ -447,6 +460,16 @@ msgstr "Nie można pisać bez nóżki MOSI."
 msgid "CharacteristicBuffer writing not provided"
 msgstr "Pisanie do CharacteristicBuffer niewspierane"
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr "Nie powiodło się ustawienie nóżki zegara"
@@ -508,8 +531,8 @@ msgid "Couldn't allocate second buffer"
 msgstr "Nie udała się alokacja drugiego bufora"
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
-msgstr "Katastrofa w HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
+msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "DAC already in use"
@@ -624,27 +647,17 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr "Nie udało się zwolnić blokady, błąd 0x%04x"
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr "Plik istnieje"
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr "Nie udało się skasować flash"
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr "Nie udało się rozpocząć kasowania flash, błąd 0x%04x"
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
 msgstr "Zapis do flash nie powiódł się"
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
-msgstr "Nie udało się rozpocząć zapisu do flash, błąd 0x%04x"
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
@@ -820,17 +833,6 @@ msgstr "Długość musi być całkowita"
 msgid "Length must be non-negative"
 msgstr "Długość musi być nieujemna"
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-"Ojej, wygląda na to, że CircuitPython natrafił na poważny problem!\n"
-"Prosimy o zgłoszenie błędu pod adresem https://github.com/adafruit/"
-"circuitpython/issues\n"
-" z zawartością dysku CIRCUITPY oraz tym komunikatem:\n"
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr "Nie powiodło się ustawienie nóżki MISO."
@@ -845,13 +847,12 @@ msgid "Maximum x value when mirrored is %d"
 msgstr "Największa wartość x przy odwróceniu to %d"
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
 msgstr ""
-"Skok NLR MicroPythona nie powiódł się. Prawdopodobne skażenie pamięci.\n"
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
-msgstr "Krytyczny błąd MicroPythona.\n"
+msgid "MicroPython fatal error."
+msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
@@ -918,6 +919,10 @@ msgstr "Brak miejsca"
 #: py/moduerrno.c
 msgid "No such file/directory"
 msgstr "Brak pliku/katalogu"
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
+msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
 #: shared-bindings/_bleio/CharacteristicBuffer.c
@@ -1097,16 +1102,8 @@ msgstr "Strumień nie ma metod readinto() lub write()."
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
-"Sterta CircuitPythona jest skażona z powodu zbyt małego stosu.\n"
-"Proszę zwiększyć limity wielkości stosu i nazisnąć reset (po odmontowaniu "
-"CIRCUITPY).\n"
-"Jeśli wielkość stosu nie była zmieniana, proszę zgłosić błąd zawierający "
-"zawartość CIRCUITPY tutaj:\n"
 
 #: supervisor/shared/safe_mode.c
 msgid ""
@@ -1116,22 +1113,10 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
-"Zasilanie mikrokontrolera gwałtownie spadło. Proszę upewnić się,\n"
-"że zasilanie jest wystarczające dla całego obwodu in nacisnąć reset (po "
-"odmontowaniu CIRCUITPY).\n"
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
-msgstr ""
-"Przycisk reset został wciśnięty podczas startu CircuitPythona. Wciśnij go "
-"ponownie aby wyjść z trybu bezpieczeństwa.\n"
 
 #: shared-module/audiomixer/MixerVoice.c
 msgid "The sample's bits_per_sample does not match the mixer's"
@@ -1164,10 +1149,6 @@ msgstr ""
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr "Szerokość bitmapy musi być wielokrotnością szerokości kafelka"
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
-msgstr "By wyjść, proszę zresetować płytkę bez "
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
@@ -1247,6 +1228,10 @@ msgstr "Nieoczekiwany typ nrfx uuid."
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown security error: 0x%04x"
@@ -1320,10 +1305,8 @@ msgstr ""
 "Aby zobaczyć wbudowane moduły, wpisz `help(\"modules\")`.\n"
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
-"Uruchomiono w trybie bezpieczeństwa, gdyż nastąpiło coś nieoczekiwanego.\n"
 
 #: supervisor/shared/safe_mode.c
 msgid "You requested starting safe mode by "
@@ -2660,6 +2643,9 @@ msgstr "zerowy krok"
 #~ msgid "Address is not %d bytes long or is in wrong format"
 #~ msgstr "Adres nie ma długości %d bajtów lub zły format"
 
+#~ msgid "Attempted heap allocation when MicroPython VM not running.\n"
+#~ msgstr "Próba alokacji pamięci na stercie gdy VM nie działa.\n"
+
 #~ msgid "Can't add services in Central mode"
 #~ msgstr "Nie można dodać serwisów w trybie Central"
 
@@ -2680,6 +2666,9 @@ msgstr "zerowy krok"
 
 #~ msgid "Could not decode ble_uuid, err 0x%04x"
 #~ msgstr "Nie można zdekodować ble_uuid, błąd 0x%04x"
+
+#~ msgid "Crash into the HardFault_Handler.\n"
+#~ msgstr "Katastrofa w HardFault_Handler.\n"
 
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Zbyt dużo danych pakietu rozgłoszeniowego"
@@ -2763,6 +2752,15 @@ msgstr "zerowy krok"
 #~ msgid "Failed to write gatts value, err 0x%04x"
 #~ msgstr "Nie udało się zapisać gatts, błąd 0x%04x"
 
+#~ msgid "Flash erase failed"
+#~ msgstr "Nie udało się skasować flash"
+
+#~ msgid "Flash erase failed to start, err 0x%04x"
+#~ msgstr "Nie udało się rozpocząć kasowania flash, błąd 0x%04x"
+
+#~ msgid "Flash write failed to start, err 0x%04x"
+#~ msgstr "Nie udało się rozpocząć zapisu do flash, błąd 0x%04x"
+
 #~ msgid "Invalid bit clock pin"
 #~ msgstr "Zła nóżka zegara"
 
@@ -2771,6 +2769,23 @@ msgstr "zerowy krok"
 
 #~ msgid "Invalid data pin"
 #~ msgstr "Zła nóżka danych"
+
+#~ msgid ""
+#~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
+#~ "Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
+#~ " with the contents of your CIRCUITPY drive and this message:\n"
+#~ msgstr ""
+#~ "Ojej, wygląda na to, że CircuitPython natrafił na poważny problem!\n"
+#~ "Prosimy o zgłoszenie błędu pod adresem https://github.com/adafruit/"
+#~ "circuitpython/issues\n"
+#~ " z zawartością dysku CIRCUITPY oraz tym komunikatem:\n"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+#~ msgstr ""
+#~ "Skok NLR MicroPythona nie powiódł się. Prawdopodobne skażenie pamięci.\n"
+
+#~ msgid "MicroPython fatal error.\n"
+#~ msgstr "Krytyczny błąd MicroPythona.\n"
 
 #~ msgid "Must be a Group subclass."
 #~ msgstr "Musi dziedziczyć z Group."
@@ -2783,14 +2798,53 @@ msgstr "zerowy krok"
 #~ msgid "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 #~ msgstr "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase stack size limits and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ "If you didn't change the stack, then file an issue here with the contents "
+#~ "of your CIRCUITPY drive:\n"
+#~ msgstr ""
+#~ "Sterta CircuitPythona jest skażona z powodu zbyt małego stosu.\n"
+#~ "Proszę zwiększyć limity wielkości stosu i nazisnąć reset (po odmontowaniu "
+#~ "CIRCUITPY).\n"
+#~ "Jeśli wielkość stosu nie była zmieniana, proszę zgłosić błąd zawierający "
+#~ "zawartość CIRCUITPY tutaj:\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Please make sure your power supply "
+#~ "provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "Zasilanie mikrokontrolera gwałtownie spadło. Proszę upewnić się,\n"
+#~ "że zasilanie jest wystarczające dla całego obwodu in nacisnąć reset (po "
+#~ "odmontowaniu CIRCUITPY).\n"
+
+#~ msgid ""
+#~ "The reset button was pressed while booting CircuitPython. Press again to "
+#~ "exit safe mode.\n"
+#~ msgstr ""
+#~ "Przycisk reset został wciśnięty podczas startu CircuitPythona. Wciśnij go "
+#~ "ponownie aby wyjść z trybu bezpieczeństwa.\n"
+
 #~ msgid "Tile indices must be 0 - 255"
 #~ msgstr "Indeks kafelka musi być pomiędzy 0 a 255 włącznie"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "By wyjść, proszę zresetować płytkę bez "
 
 #~ msgid "UUID integer value not in range 0 to 0xffff"
 #~ msgstr "Wartość UUID poza zakresem 0 do 0xffff"
 
 #~ msgid "Voice index too high"
 #~ msgstr "Zbyt wysoki indeks głosu"
+
+#~ msgid ""
+#~ "You are running in safe mode which means something unanticipated "
+#~ "happened.\n"
+#~ msgstr ""
+#~ "Uruchomiono w trybie bezpieczeństwa, gdyż nastąpiło coś nieoczekiwanego.\n"
 
 #~ msgid "bad GATT role"
 #~ msgstr "zła rola GATT"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: 2018-10-02 21:14-0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -21,6 +21,19 @@ msgstr ""
 msgid ""
 "\n"
 "Code done running. Waiting for reload.\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
 msgstr ""
 
 #: py/obj.c
@@ -295,7 +308,7 @@ msgid "Array values should be single bytes."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
 msgstr ""
 
 #: main.c
@@ -449,6 +462,16 @@ msgstr "Não é possível ler sem um pino MOSI"
 msgid "CharacteristicBuffer writing not provided"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr "Inicialização do pino de Clock falhou."
@@ -511,7 +534,7 @@ msgid "Couldn't allocate second buffer"
 msgstr "Não pôde alocar segundo buffer"
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -630,26 +653,16 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr "Não é possível ler o valor do atributo. status: 0x%02x"
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr "Arquivo já existe"
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
-msgstr ""
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -827,13 +840,6 @@ msgstr "Tamanho deve ser um int"
 msgid "Length must be non-negative"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr "Inicialização do pino MISO falhou"
@@ -848,11 +854,11 @@ msgid "Maximum x value when mirrored is %d"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
+msgid "MicroPython fatal error."
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -919,6 +925,10 @@ msgstr ""
 
 #: py/moduerrno.c
 msgid "No such file/directory"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
@@ -1104,10 +1114,7 @@ msgstr ""
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -1118,16 +1125,9 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
 msgstr ""
 
 #: shared-module/audiomixer/MixerVoice.c
@@ -1161,10 +1161,6 @@ msgstr ""
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
-msgstr "Para sair, por favor, reinicie a placa sem "
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
@@ -1244,6 +1240,10 @@ msgstr ""
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown security error: 0x%04x"
@@ -1315,8 +1315,7 @@ msgid ""
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -2836,6 +2835,9 @@ msgstr "passo zero"
 
 #~ msgid "STA required"
 #~ msgstr "STA requerido"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Para sair, por favor, reinicie a placa sem "
 
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) não existe"

--- a/locale/zh_Latn_pinyin.po
+++ b/locale/zh_Latn_pinyin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: circuitpython-cn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-10 13:55-0600\n"
+"POT-Creation-Date: 2019-12-12 14:51-0500\n"
 "PO-Revision-Date: 2019-04-13 10:10-0700\n"
 "Last-Translator: hexthat\n"
 "Language-Team: Chinese Hanyu Pinyin\n"
@@ -24,6 +24,19 @@ msgid ""
 msgstr ""
 "\n"
 "Dàimǎ yǐ wánchéng yùnxíng. Zhèngzài děngdài chóngxīn jiāzài.\n"
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"Please file an issue with the contents of your CIRCUITPY drive at \n"
+"https://github.com/adafruit/circuitpython/issues\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"To exit, please reset the board without "
+msgstr ""
 
 #: py/obj.c
 msgid "  File \"%q\""
@@ -294,8 +307,8 @@ msgid "Array values should be single bytes."
 msgstr "Shùzǔ zhí yīnggāi shì dāngè zì jié."
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running.\n"
-msgstr "MicroPython VM wèi yùnxíng shí chángshì duī fēnpèi.\n"
+msgid "Attempted heap allocation when MicroPython VM not running."
+msgstr ""
 
 #: main.c
 msgid "Auto-reload is off.\n"
@@ -448,6 +461,16 @@ msgstr "Wúfǎ xiě rù MOSI de yǐn jiǎo."
 msgid "CharacteristicBuffer writing not provided"
 msgstr "Wèi tígōng zìfú huǎncún xiě rù"
 
+#: supervisor/shared/safe_mode.c
+msgid "CircuitPython core code crashed hard. Whoops!\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode because you pressed the reset button during "
+"boot. Press again to exit safe mode.\n"
+msgstr ""
+
 #: shared-module/bitbangio/SPI.c
 msgid "Clock pin init failed."
 msgstr "Shízhōng de yǐn jiǎo chūshǐhuà shībài."
@@ -509,8 +532,8 @@ msgid "Couldn't allocate second buffer"
 msgstr "Wúfǎ fēnpèi dì èr gè huǎnchōng qū"
 
 #: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler.\n"
-msgstr "Bēngkuì dào HardFault_Handler.\n"
+msgid "Crash into the HardFault_Handler."
+msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "DAC already in use"
@@ -625,27 +648,17 @@ msgstr ""
 msgid "Failed to release mutex, err 0x%04x"
 msgstr "Wúfǎ shìfàng mutex, err 0x%04x"
 
+#: supervisor/shared/safe_mode.c
+msgid "Failed to write internal flash."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr "Wénjiàn cúnzài"
 
-#: ports/nrf/peripherals/nrf/nvm.c
-msgid "Flash erase failed"
-msgstr "Flash cā chú shībài"
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash erase failed to start, err 0x%04x"
-msgstr "Flash cā chú shībài, err 0x%04x"
-
-#: ports/nrf/peripherals/nrf/nvm.c
+#: ports/nrf/common-hal/nvm/ByteArray.c
 msgid "Flash write failed"
 msgstr "Flash xiě rù shībài"
-
-#: ports/nrf/peripherals/nrf/nvm.c
-#, c-format
-msgid "Flash write failed to start, err 0x%04x"
-msgstr "Flash xiě rù shībài, err 0x%04x"
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "Frequency captured is above capability. Capture Paused."
@@ -821,17 +834,6 @@ msgstr "Chángdù bìxū shì yīgè zhěngshù"
 msgid "Length must be non-negative"
 msgstr "Chángdù bìxū shìfēi fùshù"
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"Looks like our core CircuitPython code crashed hard. Whoops!\n"
-"Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
-" with the contents of your CIRCUITPY drive and this message:\n"
-msgstr ""
-"Kàn lái wǒmen de héxīn CircuitPython dàimǎ bēngkuì dé hěn lìhài. Āi yōu!\n"
-"Qǐng zài https://Github.Com/adafruit/circuitpython/issues\n"
-"shàng tíjiāo yīgè wèntí, qízhōng bāohán nín de CIRCUITPY qūdòngqì de nèiróng "
-"hé cǐ xiāoxī:\n"
-
 #: shared-module/bitbangio/SPI.c
 msgid "MISO pin init failed."
 msgstr "MISO yǐn jiǎo chūshǐhuà shībài."
@@ -846,12 +848,12 @@ msgid "Maximum x value when mirrored is %d"
 msgstr "Jìngxiàng shí de zuìdà X zhí wèi%d"
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
-msgstr "MicroPython NLR tiàoyuè shībài. Kěnéng nèicún fǔbài.\n"
+msgid "MicroPython NLR jump failed. Likely memory corruption."
+msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error.\n"
-msgstr "MicroPython zhìmìng cuòwù.\n"
+msgid "MicroPython fatal error."
+msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
@@ -918,6 +920,10 @@ msgstr "Shèbèi shàng méiyǒu kònggé"
 #: py/moduerrno.c
 msgid "No such file/directory"
 msgstr "Méiyǒu cǐ lèi wénjiàn/mùlù"
+
+#: supervisor/shared/safe_mode.c
+msgid "Nordic Soft Device failure assertion."
+msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
 #: shared-bindings/_bleio/CharacteristicBuffer.c
@@ -1101,16 +1107,8 @@ msgstr "Liú quēshǎo readinto() huò write() fāngfǎ."
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase stack size limits and press reset (after ejecting "
-"CIRCUITPY).\n"
-"If you didn't change the stack, then file an issue here with the contents of "
-"your CIRCUITPY drive:\n"
+"Please increase the stack size if you know how, or if not:"
 msgstr ""
-"Yóuyú duīzhàn tài xiǎo, huánliú Python rè sǔnhuài.\n"
-"Qǐng zēngjiā duīzhàn chǐcùn xiànzhì, ránhòu chóngxīn shèzhì (zài dànchū "
-"CIRCUITPY).\n"
-"Rúguǒ nín méiyǒu gǎibiàn duīzhàn, qǐng zài cǐ chù tíchū yīgè wèntí, bìng zài "
-"rù nín de CIRCUITPY qūdòngqì:\n"
 
 #: supervisor/shared/safe_mode.c
 msgid ""
@@ -1122,22 +1120,10 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
-"The microcontroller's power dipped. Please make sure your power supply "
-"provides\n"
+"The microcontroller's power dipped. Make sure your power supply provides\n"
 "enough power for the whole circuit and press reset (after ejecting "
 "CIRCUITPY).\n"
 msgstr ""
-"Wēi kòngzhì qì de diànliàng bèi chōng chū. Qǐng quèbǎo nín de diànyuán wèi\n"
-"zhěnggè diànlù tígōng zúgòu de diànyuán bìng àn xià fùwèi (zài dànchū "
-"CIRCUITPY hòu).\n"
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The reset button was pressed while booting CircuitPython. Press again to "
-"exit safe mode.\n"
-msgstr ""
-"Qǐdòng CircuitPython shí, chóng zhì ànniǔ bèi àn xià. Zàicì àn xià yǐ tuìchū "
-"ānquán móshì\n"
 
 #: shared-module/audiomixer/MixerVoice.c
 msgid "The sample's bits_per_sample does not match the mixer's"
@@ -1170,10 +1156,6 @@ msgstr "Píng pū zhí chāochū fànwéi"
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr "Píng pū kuāndù bìxū huàfēn wèi tú kuāndù"
-
-#: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
-msgstr "Yào tuìchū, qǐng chóng zhì bǎnkuài ér bùyòng "
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
@@ -1253,6 +1235,10 @@ msgstr "Yìwài de nrfx uuid lèixíng"
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Unknown reason."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
 msgid "Unknown security error: 0x%04x"
@@ -1328,11 +1314,8 @@ msgstr ""
 "Ruò yào liè chū nèizài de mókuài, qǐng qǐng zuò yǐxià `help(\"modules\")`.\n"
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"You are running in safe mode which means something unanticipated happened.\n"
+msgid "You are in safe mode: something unanticipated happened.\n"
 msgstr ""
-"Nǐ zhèngzài ānquán móshì xià yùnxíng, zhè yì wèi zhuó yìwài fāshēng de "
-"shìqíng.\n"
 
 #: supervisor/shared/safe_mode.c
 msgid "You requested starting safe mode by "
@@ -2673,6 +2656,9 @@ msgstr "líng bù"
 #~ msgid "Address is not %d bytes long or is in wrong format"
 #~ msgstr "Dìzhǐ bùshì %d zì jié zhǎng, huòzhě géshì cuòwù"
 
+#~ msgid "Attempted heap allocation when MicroPython VM not running.\n"
+#~ msgstr "MicroPython VM wèi yùnxíng shí chángshì duī fēnpèi.\n"
+
 #~ msgid "Can't add services in Central mode"
 #~ msgstr "Wúfǎ zài zhōngyāng móshì xià tiānjiā fúwù"
 
@@ -2696,6 +2682,9 @@ msgstr "líng bù"
 
 #~ msgid "Could not decode ble_uuid, err 0x%04x"
 #~ msgstr "Wúfǎ jiěmǎ kě dú_uuid, err 0x%04x"
+
+#~ msgid "Crash into the HardFault_Handler.\n"
+#~ msgstr "Bēngkuì dào HardFault_Handler.\n"
 
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Guǎnggào bāo de shùjù tài dà"
@@ -2802,6 +2791,15 @@ msgstr "líng bù"
 #~ msgid "Failed to write gatts value, err 0x%04x"
 #~ msgstr "Xiě rù gatts zhí,err 0x%04x shībài"
 
+#~ msgid "Flash erase failed"
+#~ msgstr "Flash cā chú shībài"
+
+#~ msgid "Flash erase failed to start, err 0x%04x"
+#~ msgstr "Flash cā chú shībài, err 0x%04x"
+
+#~ msgid "Flash write failed to start, err 0x%04x"
+#~ msgstr "Flash xiě rù shībài, err 0x%04x"
+
 #~ msgid "Invalid bit clock pin"
 #~ msgstr "Wúxiào de wèi shízhōng yǐn jiǎo"
 
@@ -2810,6 +2808,22 @@ msgstr "líng bù"
 
 #~ msgid "Invalid data pin"
 #~ msgstr "Wúxiào de shùjù yǐn jiǎo"
+
+#~ msgid ""
+#~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
+#~ "Please file an issue at https://github.com/adafruit/circuitpython/issues\n"
+#~ " with the contents of your CIRCUITPY drive and this message:\n"
+#~ msgstr ""
+#~ "Kàn lái wǒmen de héxīn CircuitPython dàimǎ bēngkuì dé hěn lìhài. Āi yōu!\n"
+#~ "Qǐng zài https://Github.Com/adafruit/circuitpython/issues\n"
+#~ "shàng tíjiāo yīgè wèntí, qízhōng bāohán nín de CIRCUITPY qūdòngqì de "
+#~ "nèiróng hé cǐ xiāoxī:\n"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
+#~ msgstr "MicroPython NLR tiàoyuè shībài. Kěnéng nèicún fǔbài.\n"
+
+#~ msgid "MicroPython fatal error.\n"
+#~ msgstr "MicroPython zhìmìng cuòwù.\n"
 
 #~ msgid "Must be a Group subclass."
 #~ msgstr "Bìxū shì fēnzǔ zi lèi."
@@ -2835,14 +2849,55 @@ msgstr "líng bù"
 #~ msgid "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 #~ msgstr "Ruǎn shèbèi wéihù, id: 0X%08lX, pc: 0X%08lX"
 
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase stack size limits and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ "If you didn't change the stack, then file an issue here with the contents "
+#~ "of your CIRCUITPY drive:\n"
+#~ msgstr ""
+#~ "Yóuyú duīzhàn tài xiǎo, huánliú Python rè sǔnhuài.\n"
+#~ "Qǐng zēngjiā duīzhàn chǐcùn xiànzhì, ránhòu chóngxīn shèzhì (zài dànchū "
+#~ "CIRCUITPY).\n"
+#~ "Rúguǒ nín méiyǒu gǎibiàn duīzhàn, qǐng zài cǐ chù tíchū yīgè wèntí, bìng "
+#~ "zài rù nín de CIRCUITPY qūdòngqì:\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Please make sure your power supply "
+#~ "provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "Wēi kòngzhì qì de diànliàng bèi chōng chū. Qǐng quèbǎo nín de diànyuán "
+#~ "wèi\n"
+#~ "zhěnggè diànlù tígōng zúgòu de diànyuán bìng àn xià fùwèi (zài dànchū "
+#~ "CIRCUITPY hòu).\n"
+
+#~ msgid ""
+#~ "The reset button was pressed while booting CircuitPython. Press again to "
+#~ "exit safe mode.\n"
+#~ msgstr ""
+#~ "Qǐdòng CircuitPython shí, chóng zhì ànniǔ bèi àn xià. Zàicì àn xià yǐ "
+#~ "tuìchū ānquán móshì\n"
+
 #~ msgid "Tile indices must be 0 - 255"
 #~ msgstr "Píng pū zhǐshù bìxū wèi 0 - 255"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Yào tuìchū, qǐng chóng zhì bǎnkuài ér bùyòng "
 
 #~ msgid "UUID integer value not in range 0 to 0xffff"
 #~ msgstr "UUID zhěngshù zhí bùzài fànwéi 0 zhì 0xffff"
 
 #~ msgid "Voice index too high"
 #~ msgstr "Yǔyīn suǒyǐn tài gāo"
+
+#~ msgid ""
+#~ "You are running in safe mode which means something unanticipated "
+#~ "happened.\n"
+#~ msgstr ""
+#~ "Nǐ zhèngzài ānquán móshì xià yùnxíng, zhè yì wèi zhuó yìwài fāshēng de "
+#~ "shìqíng.\n"
 
 #~ msgid "bad GATT role"
 #~ msgstr "zǒng xiédìng de bùliáng juésè"

--- a/main.c
+++ b/main.c
@@ -264,9 +264,7 @@ bool run_code_py(safe_mode_t safe_mode) {
     rgb_status_animation_t animation;
     prep_rgb_status_animation(&result, found_main, safe_mode, &animation);
     while (true) {
-        #ifdef MICROPY_VM_HOOK_LOOP
-            MICROPY_VM_HOOK_LOOP
-        #endif
+        RUN_BACKGROUND_TASKS;
         if (reload_requested) {
             reload_requested = false;
             return true;

--- a/ports/nrf/common-hal/nvm/ByteArray.c
+++ b/ports/nrf/common-hal/nvm/ByteArray.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "py/runtime.h"
 #include "common-hal/nvm/ByteArray.h"
 
 #include <stdio.h>
@@ -43,16 +44,20 @@ uint32_t common_hal_nvm_bytearray_get_length(nvm_bytearray_obj_t *self) {
 }
 
 static void write_page(uint32_t page_addr, uint32_t offset, uint32_t len, uint8_t *bytes) {
-    // Write a whole page to flash, buffering it first and then erasing and rewriting 
+    // Write a whole page to flash, buffering it first and then erasing and rewriting
     // it since we can only clear a whole page at a time.
 
+    bool status;
     if (offset == 0 && len == FLASH_PAGE_SIZE) {
-        nrf_nvm_safe_flash_page_write(page_addr, bytes);
+        status = nrf_nvm_safe_flash_page_write(page_addr, bytes);
     } else {
         uint8_t buffer[FLASH_PAGE_SIZE];
         memcpy(buffer, (uint8_t *)page_addr, FLASH_PAGE_SIZE);
         memcpy(buffer + offset, bytes, len);
-        nrf_nvm_safe_flash_page_write(page_addr, buffer);
+        status = nrf_nvm_safe_flash_page_write(page_addr, buffer);
+    }
+    if (!status) {
+        mp_raise_OSError_msg(translate("Flash write failed"));
     }
 }
 

--- a/ports/nrf/peripherals/nrf/nvm.c
+++ b/ports/nrf/peripherals/nrf/nvm.c
@@ -50,7 +50,7 @@ STATIC sd_flash_operation_status_t sd_flash_operation_wait_until_done(void) {
 }
 #endif
 
-void nrf_nvm_safe_flash_page_write(uint32_t page_addr, uint8_t *data) {
+bool nrf_nvm_safe_flash_page_write(uint32_t page_addr, uint8_t *data) {
     #ifdef BLUETOOTH_SD
         uint8_t sd_en = 0;
         (void) sd_softdevice_is_enabled(&sd_en);
@@ -61,11 +61,11 @@ void nrf_nvm_safe_flash_page_write(uint32_t page_addr, uint8_t *data) {
             sd_flash_operation_start();
             err_code = sd_flash_page_erase(page_addr / FLASH_PAGE_SIZE);
             if (err_code != NRF_SUCCESS) {
-                mp_raise_OSError_msg_varg(translate("Flash erase failed to start, err 0x%04x"), err_code);
+                return false;
             }
             status = sd_flash_operation_wait_until_done();
             if (status == SD_FLASH_OPERATION_ERROR) {
-                mp_raise_OSError_msg(translate("Flash erase failed"));
+                return false;
             }
 
             // Divide a full page into parts, because writing a full page causes an assertion failure.
@@ -78,18 +78,19 @@ void nrf_nvm_safe_flash_page_write(uint32_t page_addr, uint8_t *data) {
                                           (uint32_t *)data + i * words_to_write,
                                           words_to_write);
                 if (err_code != NRF_SUCCESS) {
-                    mp_raise_OSError_msg_varg(translate("Flash write failed to start, err 0x%04x"), err_code);
+                    return false;
                 }
                 status = sd_flash_operation_wait_until_done();
                 if (status == SD_FLASH_OPERATION_ERROR) {
-                    mp_raise_OSError_msg(translate("Flash write failed"));
+                    return false;
                 }
             }
 
-            return;
+            return true;
         }
     #endif
 
     nrf_nvmc_page_erase(page_addr);
     nrf_nvmc_write_bytes(page_addr, data, FLASH_PAGE_SIZE);
-}    
+    return true;
+}

--- a/ports/nrf/peripherals/nrf/nvm.h
+++ b/ports/nrf/peripherals/nrf/nvm.h
@@ -31,4 +31,4 @@
 #define CIRCUITPY_INTERNAL_NVM_SIZE (0)
 #endif
 
-void nrf_nvm_safe_flash_page_write(uint32_t page_addr, uint8_t *data);
+bool nrf_nvm_safe_flash_page_write(uint32_t page_addr, uint8_t *data);

--- a/ports/nrf/supervisor/internal_flash.c
+++ b/ports/nrf/supervisor/internal_flash.c
@@ -34,6 +34,7 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "lib/oofatfs/ff.h"
+#include "supervisor/shared/safe_mode.h"
 
 #include "peripherals/nrf/nvm.h"
 
@@ -75,7 +76,9 @@ void supervisor_flash_flush(void) {
 
     // Skip if data is the same
     if (memcmp(_flash_cache, (void *)_flash_page_addr, FLASH_PAGE_SIZE) != 0) {
-        nrf_nvm_safe_flash_page_write(_flash_page_addr, _flash_cache);
+        if (!nrf_nvm_safe_flash_page_write(_flash_page_addr, _flash_cache)) {
+            reset_into_safe_mode(FLASH_WRITE_FAIL);
+        }
     }
 }
 
@@ -120,4 +123,3 @@ mp_uint_t supervisor_flash_write_blocks(const uint8_t *src, uint32_t lba, uint32
 
 void supervisor_flash_release_cache(void) {
 }
-

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -94,44 +94,72 @@ void __attribute__((noinline,)) reset_into_safe_mode(safe_mode_t reason) {
     reset_cpu();
 }
 
+
+
+#define FILE_AN_ISSUE translate("\r\nPlease file an issue with the contents of your CIRCUITPY drive at \nhttps://github.com/adafruit/circuitpython/issues\r\n")
+
 void print_safe_mode_message(safe_mode_t reason) {
     if (reason == NO_SAFE_MODE) {
         return;
     }
     serial_write("\r\n");
-    // Output a user safe mode string if its set.
+    // Output a user safe mode string if it's set.
     #ifdef BOARD_USER_SAFE_MODE
     if (reason == USER_SAFE_MODE) {
         serial_write_compressed(translate("You requested starting safe mode by "));
         serial_write(BOARD_USER_SAFE_MODE_ACTION);
-        serial_write("\r\n");
-        serial_write_compressed(translate("To exit, please reset the board without "));
+        serial_write_compressed(translate("\r\nTo exit, please reset the board without "));
         serial_write(BOARD_USER_SAFE_MODE_ACTION);
         serial_write("\r\n");
     } else
     #endif
-    if (reason == MANUAL_SAFE_MODE) {
-        serial_write_compressed(translate("The reset button was pressed while booting CircuitPython. Press again to exit safe mode.\n"));
-    } else if (reason == PROGRAMMATIC_SAFE_MODE) {
-        serial_write_compressed(translate("The `microcontroller` module was used to boot into safe mode. Press reset to exit safe mode.\n"));
-    } else {
-        serial_write_compressed(translate("You are running in safe mode which means something unanticipated happened.\n"));
-        if (reason == HARD_CRASH || reason == MICROPY_NLR_JUMP_FAIL || reason == MICROPY_FATAL_ERROR || reason == GC_ALLOC_OUTSIDE_VM) {
-            serial_write_compressed(translate("Looks like our core CircuitPython code crashed hard. Whoops!\nPlease file an issue at https://github.com/adafruit/circuitpython/issues\n with the contents of your CIRCUITPY drive and this message:\n"));
-            if (reason == HARD_CRASH) {
-                serial_write_compressed(translate("Crash into the HardFault_Handler.\n"));
-            } else if (reason == MICROPY_NLR_JUMP_FAIL) {
-                serial_write_compressed(translate("MicroPython NLR jump failed. Likely memory corruption.\n"));
-            } else if (reason == MICROPY_FATAL_ERROR) {
-                serial_write_compressed(translate("MicroPython fatal error.\n"));
-            } else if (reason == GC_ALLOC_OUTSIDE_VM) {
-                serial_write_compressed(translate("Attempted heap allocation when MicroPython VM not running.\n"));
-            }
-        } else if (reason == BROWNOUT) {
-            serial_write_compressed(translate("The microcontroller's power dipped. Please make sure your power supply provides\nenough power for the whole circuit and press reset (after ejecting CIRCUITPY).\n"));
-        } else if (reason == HEAP_OVERWRITTEN) {
-            serial_write_compressed(translate("The CircuitPython heap was corrupted because the stack was too small.\nPlease increase stack size limits and press reset (after ejecting CIRCUITPY).\nIf you didn't change the stack, then file an issue here with the contents of your CIRCUITPY drive:\n"));
-            serial_write("https://github.com/adafruit/circuitpython/issues\r\n");
+        switch (reason) {
+            case MANUAL_SAFE_MODE:
+                serial_write_compressed(translate("CircuitPython is in safe mode because you pressed the reset button during boot. Press again to exit safe mode.\r\n"));
+                return;
+            case PROGRAMMATIC_SAFE_MODE:
+                serial_write_compressed(translate("The `microcontroller` module was used to boot into safe mode. Press reset to exit safe mode.\r\n"));
+                return;
+            default:
+                break;
         }
-    }
+
+        serial_write_compressed(translate("You are in safe mode: something unanticipated happened.\r\n"));
+        switch (reason) {
+            case BROWNOUT:
+                serial_write_compressed(translate("The microcontroller's power dipped. Make sure your power supply provides\r\nenough power for the whole circuit and press reset (after ejecting CIRCUITPY).\r\n"));
+                return;
+            case HEAP_OVERWRITTEN:
+                serial_write_compressed(translate("The CircuitPython heap was corrupted because the stack was too small.\r\nPlease increase the stack size if you know how, or if not:"));
+                serial_write_compressed(FILE_AN_ISSUE);
+                return;
+            default:
+                break;
+        }
+
+        serial_write_compressed(translate("CircuitPython core code crashed hard. Whoops!\r\n"));
+        switch (reason) {
+            case HARD_CRASH:
+                serial_write_compressed(translate("Crash into the HardFault_Handler."));
+                return;
+            case MICROPY_NLR_JUMP_FAIL:
+                serial_write_compressed(translate("MicroPython NLR jump failed. Likely memory corruption."));
+                return;
+            case MICROPY_FATAL_ERROR:
+                serial_write_compressed(translate("MicroPython fatal error."));
+                break;
+            case GC_ALLOC_OUTSIDE_VM:
+                serial_write_compressed(translate("Attempted heap allocation when MicroPython VM not running."));
+                break;
+            case NORDIC_SOFT_DEVICE_ASSERT:
+                serial_write_compressed(translate("Nordic Soft Device failure assertion."));
+                break;
+            case FLASH_WRITE_FAIL:
+                serial_write_compressed(translate("Failed to write internal flash."));
+                break;
+            default:
+                serial_write_compressed(translate("Unknown reason."));
+                break;
+        }
+        serial_write_compressed(FILE_AN_ISSUE);
 }

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -96,48 +96,48 @@ void __attribute__((noinline,)) reset_into_safe_mode(safe_mode_t reason) {
 
 
 
-#define FILE_AN_ISSUE translate("\r\nPlease file an issue with the contents of your CIRCUITPY drive at \nhttps://github.com/adafruit/circuitpython/issues\r\n")
+#define FILE_AN_ISSUE translate("\nPlease file an issue with the contents of your CIRCUITPY drive at \nhttps://github.com/adafruit/circuitpython/issues\n")
 
 void print_safe_mode_message(safe_mode_t reason) {
     if (reason == NO_SAFE_MODE) {
         return;
     }
-    serial_write("\r\n");
+    serial_write("\n");
     // Output a user safe mode string if it's set.
     #ifdef BOARD_USER_SAFE_MODE
     if (reason == USER_SAFE_MODE) {
         serial_write_compressed(translate("You requested starting safe mode by "));
         serial_write(BOARD_USER_SAFE_MODE_ACTION);
-        serial_write_compressed(translate("\r\nTo exit, please reset the board without "));
+        serial_write_compressed(translate("\nTo exit, please reset the board without "));
         serial_write(BOARD_USER_SAFE_MODE_ACTION);
-        serial_write("\r\n");
+        serial_write("\n");
     } else
     #endif
         switch (reason) {
             case MANUAL_SAFE_MODE:
-                serial_write_compressed(translate("CircuitPython is in safe mode because you pressed the reset button during boot. Press again to exit safe mode.\r\n"));
+                serial_write_compressed(translate("CircuitPython is in safe mode because you pressed the reset button during boot. Press again to exit safe mode.\n"));
                 return;
             case PROGRAMMATIC_SAFE_MODE:
-                serial_write_compressed(translate("The `microcontroller` module was used to boot into safe mode. Press reset to exit safe mode.\r\n"));
+                serial_write_compressed(translate("The `microcontroller` module was used to boot into safe mode. Press reset to exit safe mode.\n"));
                 return;
             default:
                 break;
         }
 
-        serial_write_compressed(translate("You are in safe mode: something unanticipated happened.\r\n"));
+        serial_write_compressed(translate("You are in safe mode: something unanticipated happened.\n"));
         switch (reason) {
             case BROWNOUT:
-                serial_write_compressed(translate("The microcontroller's power dipped. Make sure your power supply provides\r\nenough power for the whole circuit and press reset (after ejecting CIRCUITPY).\r\n"));
+                serial_write_compressed(translate("The microcontroller's power dipped. Make sure your power supply provides\nenough power for the whole circuit and press reset (after ejecting CIRCUITPY).\n"));
                 return;
             case HEAP_OVERWRITTEN:
-                serial_write_compressed(translate("The CircuitPython heap was corrupted because the stack was too small.\r\nPlease increase the stack size if you know how, or if not:"));
+                serial_write_compressed(translate("The CircuitPython heap was corrupted because the stack was too small.\nPlease increase the stack size if you know how, or if not:"));
                 serial_write_compressed(FILE_AN_ISSUE);
                 return;
             default:
                 break;
         }
 
-        serial_write_compressed(translate("CircuitPython core code crashed hard. Whoops!\r\n"));
+        serial_write_compressed(translate("CircuitPython core code crashed hard. Whoops!\n"));
         switch (reason) {
             case HARD_CRASH:
                 serial_write_compressed(translate("Crash into the HardFault_Handler."));

--- a/supervisor/shared/safe_mode.h
+++ b/supervisor/shared/safe_mode.h
@@ -38,7 +38,8 @@ typedef enum {
   MICROPY_FATAL_ERROR,
   GC_ALLOC_OUTSIDE_VM,
   PROGRAMMATIC_SAFE_MODE,
-  NORDIC_SOFT_DEVICE_ASSERT
+  NORDIC_SOFT_DEVICE_ASSERT,
+  FLASH_WRITE_FAIL,
 } safe_mode_t;
 
 safe_mode_t wait_for_safe_mode_reset(void);


### PR DESCRIPTION
- `nrf_nvm_safe_flash_page_write()` was throwing Python exceptions, though it could be called from a non-Python context. Have it return success/failure and have the callers handle the error.
- Add `FLASH_WRITE_FAIL` to possible reasons to go into safe mode.
- Whiled adding `FLASH_WRITE_FAIL`, redid `print_safe_mode_message()` so it uses case statements and reduces the length of the messages.

This is a clean-up follow-on to #2376.