### PR TITLE
MP3: skip id3v2 tags, make "bartlebeats" tracks playable

### DIFF
--- a/shared-module/audiocore/__init__.c
+++ b/shared-module/audiocore/__init__.c
@@ -52,7 +52,7 @@ uint8_t audiosample_channel_count(mp_obj_t sample_obj) {
 
 void audiosample_reset_buffer(mp_obj_t sample_obj, bool single_channel, uint8_t audio_channel) {
     const audiosample_p_t *proto = mp_proto_get_or_throw(MP_QSTR_protocol_audiosample, sample_obj);
-    proto->reset_buffer(MP_OBJ_TO_PTR(sample_obj));
+    proto->reset_buffer(MP_OBJ_TO_PTR(sample_obj), single_channel, audio_channel);
 }
 
 audioio_get_buffer_result_t audiosample_get_buffer(mp_obj_t sample_obj,

--- a/shared-module/audiocore/__init__.h
+++ b/shared-module/audiocore/__init__.h
@@ -42,7 +42,8 @@ typedef enum {
 typedef uint32_t (*audiosample_sample_rate_fun)(mp_obj_t);
 typedef uint8_t (*audiosample_bits_per_sample_fun)(mp_obj_t);
 typedef uint8_t (*audiosample_channel_count_fun)(mp_obj_t);
-typedef void (*audiosample_reset_buffer_fun)(mp_obj_t);
+typedef void (*audiosample_reset_buffer_fun)(mp_obj_t,
+        bool single_channel, uint8_t audio_channel);
 typedef audioio_get_buffer_result_t (*audiosample_get_buffer_fun)(mp_obj_t,
         bool single_channel, uint8_t channel, uint8_t** buffer,
         uint32_t* buffer_length);

--- a/shared-module/audiomp3/MP3File.c
+++ b/shared-module/audiomp3/MP3File.c
@@ -139,7 +139,15 @@ STATIC bool mp3file_find_sync_word(audiomp3_mp3file_obj_t* self) {
 }
 
 STATIC bool mp3file_get_next_frame_info(audiomp3_mp3file_obj_t* self, MP3FrameInfo* fi) {
-    int err = MP3GetNextFrameInfo(self->decoder, fi, READ_PTR(self));
+    int err;
+    do {
+        err = MP3GetNextFrameInfo(self->decoder, fi, READ_PTR(self));
+        if (err == ERR_MP3_NONE) {
+           break;
+        }
+        CONSUME(self, 1);
+        mp3file_find_sync_word(self);
+    } while (!self->eof);
     return err == ERR_MP3_NONE;
 }
 


### PR DESCRIPTION
This set of fixes makes  "[bartlebeats - Frequency](https://bartlebeats.bandcamp.com/releases)" in "MP3 v0" format play on my pygamer.

It also fixes a problem with the sample "reset" method that went unnoticed when converted to protocols.