### PR TITLE
displayio: make 'rotation' property settable

### DIFF
--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -394,11 +394,18 @@ STATIC mp_obj_t displayio_display_obj_get_rotation(mp_obj_t self_in) {
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_display_get_rotation(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_get_rotation_obj, displayio_display_obj_get_rotation);
+STATIC mp_obj_t displayio_display_obj_set_rotation(mp_obj_t self_in, mp_obj_t value) {
+    displayio_display_obj_t *self = native_display(self_in);
+    common_hal_displayio_display_set_rotation(self, mp_obj_get_int(value));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(displayio_display_set_rotation_obj, displayio_display_obj_set_rotation);
+
 
 const mp_obj_property_t displayio_display_rotation_obj = {
     .base.type = &mp_type_property,
     .proxy = {(mp_obj_t)&displayio_display_get_rotation_obj,
-              (mp_obj_t)&mp_const_none_obj,
+              (mp_obj_t)&displayio_display_set_rotation_obj,
               (mp_obj_t)&mp_const_none_obj},
 };
 

--- a/shared-bindings/displayio/Display.h
+++ b/shared-bindings/displayio/Display.h
@@ -58,6 +58,7 @@ void common_hal_displayio_display_set_auto_refresh(displayio_display_obj_t* self
 uint16_t common_hal_displayio_display_get_width(displayio_display_obj_t* self);
 uint16_t common_hal_displayio_display_get_height(displayio_display_obj_t* self);
 uint16_t common_hal_displayio_display_get_rotation(displayio_display_obj_t* self);
+void common_hal_displayio_display_set_rotation(displayio_display_obj_t* self, int rotation);
 
 bool common_hal_displayio_display_get_auto_brightness(displayio_display_obj_t* self);
 void common_hal_displayio_display_set_auto_brightness(displayio_display_obj_t* self, bool auto_brightness);

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -308,9 +308,26 @@ STATIC void _refresh_display(displayio_display_obj_t* self) {
     displayio_display_core_finish_refresh(&self->core);
 }
 
+void common_hal_displayio_display_set_rotation(displayio_display_obj_t* self, int rotation){
+    bool transposed = (self->core.rotation == 90 || self->core.rotation == 270);
+    bool will_transposed = (rotation == 90 || rotation == 270);
+    if(transposed != will_transposed) {
+        int tmp = self->core.width;
+        self->core.width = self->core.height;
+        self->core.height = tmp;
+    }
+    displayio_display_core_set_rotation(&self->core, rotation);
+    supervisor_stop_terminal();
+    supervisor_start_terminal(self->core.width, self->core.height);
+    if (self->core.current_group != NULL) {
+        displayio_group_update_transform(self->core.current_group, &self->core.transform);
+    }
+}
+
 uint16_t common_hal_displayio_display_get_rotation(displayio_display_obj_t* self){
     return self->core.rotation;
 }
+
 
 bool common_hal_displayio_display_refresh(displayio_display_obj_t* self, uint32_t target_ms_per_frame, uint32_t maximum_ms_per_real_frame) {
     if (!self->auto_refresh && !self->first_manual_refresh) {

--- a/shared-module/displayio/display_core.c
+++ b/shared-module/displayio/display_core.c
@@ -86,6 +86,15 @@ void displayio_display_core_construct(displayio_display_core_t* self,
     self->height = height;
     self->ram_width = ram_width;
     self->ram_height = ram_height;
+
+    displayio_display_core_set_rotation(self, rotation);
+}
+
+void displayio_display_core_set_rotation( displayio_display_core_t* self,
+        int rotation) {
+    int height = self->height;
+    int width = self->width;
+
     rotation = rotation % 360;
     self->rotation = rotation;
     self->transform.x = 0;

--- a/shared-module/displayio/display_core.h
+++ b/shared-module/displayio/display_core.h
@@ -68,6 +68,8 @@ uint16_t displayio_display_core_get_height(displayio_display_core_t* self);
 void displayio_display_core_set_dither(displayio_display_core_t* self, bool dither);
 bool displayio_display_core_get_dither(displayio_display_core_t* self);
 
+void displayio_display_core_set_rotation(displayio_display_core_t* self, int rotation);
+
 bool displayio_display_core_bus_free(displayio_display_core_t *self);
 bool displayio_display_core_begin_transaction(displayio_display_core_t* self);
 void displayio_display_core_end_transaction(displayio_display_core_t* self);

--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -81,6 +81,7 @@ void supervisor_start_terminal(uint16_t width_px, uint16_t height_px) {
     grid->pixel_width = width_in_tiles * grid->tile_width;
     grid->pixel_height = height_in_tiles * grid->tile_height;
     grid->tiles = tiles;
+    grid->full_change = true;
 
     common_hal_terminalio_terminal_construct(&supervisor_terminal, grid, &supervisor_terminal_font);
 }


### PR DESCRIPTION
Discord's andyleer and I both recently noticed that it is not possible to set the rotation property of a 
display.  This is inconvenient if you want to change the rotation, as you have to copy the initialization from core C code into Python.  Since e.g., the Pynt's blurb on adafruit.com says

> Rotate it 90 degrees, it’s a web-connected conference badge #badgelife.

we should probably make it easy.

This lightly tested change does that, including resizing the terminal when you do.  If you've got your own Groups displaying, you may need to reinitialize them.  (I only tested it with terminal or with  resetting the displayed group immediately)

(I also want to use this as a workaround for #2386 in JEplayer, I'll just flip the display orientation to the one that is faster)