### PR TITLE
py.mk: Fix race condition building .mo files

### DIFF
--- a/py/py.mk
+++ b/py/py.mk
@@ -317,7 +317,7 @@ SRC_QSTR += $(HEADER_BUILD)/moduledefs.h
 # overall config, so they need to be caught
 MPCONFIGPORT_MK = $(wildcard mpconfigport.mk)
 
-$(HEADER_BUILD)/$(TRANSLATION).mo: $(TOP)/locale/$(TRANSLATION).po
+$(HEADER_BUILD)/$(TRANSLATION).mo: $(TOP)/locale/$(TRANSLATION).po | $(HEADER_BUILD)
 	$(Q)msgfmt -o $@ $^
 
 $(HEADER_BUILD)/qstrdefs.preprocessed.h: $(PY_QSTR_DEFS) $(QSTR_DEFS) $(QSTR_DEFS_COLLECTED) mpconfigport.h $(MPCONFIGPORT_MK) $(PY_SRC)/mpconfig.h | $(HEADER_BUILD)


### PR DESCRIPTION
By having an order-only dependency on the directory itself, the directory
is sure to be created before the rule to create a .mo file is.

This fixes a low-freqency error on github actions such as

> msgfmt: error while opening "build/genhdr/en_US.mo" for writing: No such file or directory