### PR TITLE
Increase CPX stack size slightly

### DIFF
--- a/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
@@ -27,6 +27,9 @@
 // Explanation of how a user got into safe mode.
 #define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
 
+// Increase stack size slightly due to CPX library import nesting
+#define CIRCUITPY_DEFAULT_STACK_SIZE  (4504)
+
 #define DEFAULT_I2C_BUS_SCL (&pin_PB03)
 #define DEFAULT_I2C_BUS_SDA (&pin_PB02)
 

--- a/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
@@ -27,6 +27,9 @@
 // Explanation of how a user got into safe mode.
 #define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
 
+// Increase stack size slightly due to CPX library import nesting
+#define CIRCUITPY_DEFAULT_STACK_SIZE  (4504)
+
 #define DEFAULT_I2C_BUS_SCL (&pin_PB03)
 #define DEFAULT_I2C_BUS_SDA (&pin_PB02)
 

--- a/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
@@ -27,6 +27,9 @@
 // Explanation of how a user got into safe mode.
 #define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
 
+// Increase stack size slightly due to CPX library import nesting.
+#define CIRCUITPY_DEFAULT_STACK_SIZE  (4504)  // divisible by 8
+
 #define DEFAULT_I2C_BUS_SCL (&pin_PB03)
 #define DEFAULT_I2C_BUS_SDA (&pin_PB02)
 

--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -42,7 +42,6 @@
 #define CIRCUITPY_MCU_FAMILY                        samd21
 #define MICROPY_PY_SYS_PLATFORM                     "Atmel SAMD21"
 #define SPI_FLASH_MAX_BAUDRATE 8000000
-#define CIRCUITPY_DEFAULT_STACK_SIZE                4096
 #define MICROPY_PY_BUILTINS_NOTIMPLEMENTED          (0)
 #define MICROPY_PY_COLLECTIONS_ORDEREDDICT          (0)
 #define MICROPY_PY_FUNCTION_ATTRS                   (0)
@@ -74,8 +73,6 @@
 #define CIRCUITPY_MCU_FAMILY                        samd51
 #define MICROPY_PY_SYS_PLATFORM                     "MicroChip SAMD51"
 #define SPI_FLASH_MAX_BAUDRATE 24000000
-// 24kiB stack
-#define CIRCUITPY_DEFAULT_STACK_SIZE                0x6000
 #define MICROPY_PY_BUILTINS_NOTIMPLEMENTED          (1)
 #define MICROPY_PY_COLLECTIONS_ORDEREDDICT          (1)
 #define MICROPY_PY_FUNCTION_ATTRS                   (1)
@@ -108,6 +105,10 @@
 #define CIRCUITPY_INTERNAL_NVM_SIZE (256)
 #endif
 
+#ifndef CIRCUITPY_DEFAULT_STACK_SIZE
+#define CIRCUITPY_DEFAULT_STACK_SIZE                4096
+#endif
+
 #endif // SAMD21
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -116,6 +117,10 @@
 
 #ifndef CIRCUITPY_INTERNAL_NVM_SIZE
 #define CIRCUITPY_INTERNAL_NVM_SIZE (8192)
+#endif
+
+#ifndef CIRCUITPY_DEFAULT_STACK_SIZE
+#define CIRCUITPY_DEFAULT_STACK_SIZE                (24*1024)
 #endif
 
 // If CIRCUITPY is internal, use half of flash for it.

--- a/tools/build_memory_info.py
+++ b/tools/build_memory_info.py
@@ -73,7 +73,7 @@ ram_region = regions["RAM"]
 free_flash = firmware_region - text - data
 free_ram = ram_region - data - bss
 print("{} bytes free in flash firmware space out of {} bytes ({}kB).".format(free_flash, firmware_region, firmware_region / 1024))
-print("{} bytes free in ram for heap out of {} bytes ({}kB).".format(free_ram, ram_region, ram_region / 1024))
+print("{} bytes free in ram for stack and heap out of {} bytes ({}kB).".format(free_ram, ram_region, ram_region / 1024))
 print()
 
 # Check that we have free flash space. GCC doesn't fail when the text + data


### PR DESCRIPTION
The restructured CP library with code in `__init__.py` and a subclass structure overflows the stack on import. Increase CPX stack size slightly (4096 -> 4504).

This change may also be needed on 4.x.