### PR TITLE
preprocess_frozen_modules: exclude subdirs of examples, docs, tests

### DIFF
--- a/tools/preprocess_frozen_modules.py
+++ b/tools/preprocess_frozen_modules.py
@@ -35,6 +35,7 @@ def copy_and_process(in_dir, out_dir):
         # Skip library examples directory and subfolders.
         relative_path_parts = Path(root).relative_to(in_dir).parts
         if relative_path_parts and relative_path_parts[0] in ['examples', 'docs', 'tests']:
+            del subdirs[:]
             continue
 
         for file in files:


### PR DESCRIPTION
.. this reclaims several kB on CPX, where we really need it.

This is the version for master branch.