### PR TITLE
preprocess_frozen_modules: exclude subdirs of examples, docs, tests

### DIFF
--- a/tools/preprocess_frozen_modules.py
+++ b/tools/preprocess_frozen_modules.py
@@ -34,6 +34,7 @@ def copy_and_process(in_dir, out_dir):
 
         # Skip library examples directories.
         if Path(root).name in ['examples', 'docs', 'tests']:
+            del subdirs[:]
             continue
 
         for file in files:


### PR DESCRIPTION
.. this reclaims several kB on CPX, where we really need it.