### PR TITLE
Increase stack size in 4.1.x (by a hair more than in 5.0)

### DIFF
--- a/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
@@ -34,7 +34,7 @@
 #define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
 
 // Increase stack size slightly due to CPX library import nesting
-#define CIRCUITPY_DEFAULT_STACK_SIZE  (4504)
+#define CIRCUITPY_DEFAULT_STACK_SIZE  (5016)
 
 #define DEFAULT_I2C_BUS_SCL (&pin_PB03)
 #define DEFAULT_I2C_BUS_SDA (&pin_PB02)

--- a/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
@@ -33,6 +33,9 @@
 // Explanation of how a user got into safe mode.
 #define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
 
+// Increase stack size slightly due to CPX library import nesting
+#define CIRCUITPY_DEFAULT_STACK_SIZE  (4504)
+
 #define DEFAULT_I2C_BUS_SCL (&pin_PB03)
 #define DEFAULT_I2C_BUS_SDA (&pin_PB02)
 

--- a/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
@@ -34,7 +34,7 @@
 #define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
 
 // Increase stack size slightly due to CPX library import nesting
-#define CIRCUITPY_DEFAULT_STACK_SIZE  (4504)
+#define CIRCUITPY_DEFAULT_STACK_SIZE  (5016)
 
 #define DEFAULT_I2C_BUS_SCL (&pin_PB03)
 #define DEFAULT_I2C_BUS_SDA (&pin_PB02)

--- a/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
@@ -33,6 +33,9 @@
 // Explanation of how a user got into safe mode.
 #define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
 
+// Increase stack size slightly due to CPX library import nesting
+#define CIRCUITPY_DEFAULT_STACK_SIZE  (4504)
+
 #define DEFAULT_I2C_BUS_SCL (&pin_PB03)
 #define DEFAULT_I2C_BUS_SDA (&pin_PB02)
 

--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -34,7 +34,6 @@
 #define CIRCUITPY_MCU_FAMILY                        samd21
 #define MICROPY_PY_SYS_PLATFORM                     "Atmel SAMD21"
 #define SPI_FLASH_MAX_BAUDRATE 8000000
-#define CIRCUITPY_DEFAULT_STACK_SIZE                4096
 #define MICROPY_PY_BUILTINS_NOTIMPLEMENTED          (0)
 #define MICROPY_PY_COLLECTIONS_ORDEREDDICT          (0)
 #define MICROPY_PY_FUNCTION_ATTRS                   (0)
@@ -69,6 +68,7 @@
 #define MICROPY_PY_UJSON                            (1)
 #define MICROPY_PY_REVERSE_SPECIAL_METHODS          (1)
 //      MICROPY_PY_UERRNO_LIST - Use the default
+
 #endif
 
 // Turning off audioio, audiobusio, and touchio as necessary
@@ -77,6 +77,19 @@
 #include "peripherals/samd/dma.h"
 
 #include "py/circuitpy_mpconfig.h"
+
+
+#ifdef SAMD21
+#ifndef CIRCUITPY_DEFAULT_STACK_SIZE
+#define CIRCUITPY_DEFAULT_STACK_SIZE                4096
+#endif
+#endif
+
+#ifdef SAMD51
+#ifndef CIRCUITPY_DEFAULT_STACK_SIZE
+#define CIRCUITPY_DEFAULT_STACK_SIZE                (24*1024)
+#endif
+#endif
 
 #define MICROPY_PORT_ROOT_POINTERS \
     CIRCUITPY_COMMON_ROOT_POINTERS \

--- a/tools/build_memory_info.py
+++ b/tools/build_memory_info.py
@@ -61,10 +61,11 @@ for region in regions:
     space = M_PATTERN.sub(M_REPLACE, space)
     regions[region] = eval(space)
 
+ram_region = regions["RAM"]
 free_flash = regions["FLASH"] - text - data
 free_ram = regions["RAM"] - data - bss
 print(free_flash, "bytes free in flash out of", regions["FLASH"], "bytes (", regions["FLASH"] / 1024, "kb ).")
-print(free_ram, "bytes free in ram for stack out of", regions["RAM"], "bytes (", regions["RAM"] / 1024, "kb ).")
+print("{} bytes free in ram for stack and heap out of {} bytes ({}kB).".format(free_ram, ram_region, ram_region / 1024))
 print()
 
 # Check that we have free flash space. GCC doesn't fail when the text + data


### PR DESCRIPTION
This backports @dhalbert 's stack size change #2393 with a slightly larger value.  Empirically, the 4504 value didn't work; the first value (a 512 byte bump) I tried did.

This, together with #2398 are probably prerequisites for @kattni 's work on fixing up the express library with cpx/cbp/cp functionality.