### PR TITLE
nRF: PWMAudioOut: handle non-looping rawsamples

### DIFF
--- a/ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
@@ -255,16 +255,18 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t* self, 
     self->pwm->LOOP = 1;
     audiosample_reset_buffer(self->sample, false, 0);
     activate_audiopwmout_obj(self);
+    self->stopping = false;
+    self->pwm->SHORTS = NRF_PWM_SHORT_LOOPSDONE_SEQSTART0_MASK;
     fill_buffers(self, 0);
     self->pwm->SEQ[1].PTR = self->pwm->SEQ[0].PTR;
     self->pwm->SEQ[1].CNT = self->pwm->SEQ[0].CNT;
     self->pwm->EVENTS_SEQSTARTED[0] = 0;
     self->pwm->EVENTS_SEQSTARTED[1] = 0;
+    self->pwm->EVENTS_SEQEND[0] = 0;
+    self->pwm->EVENTS_SEQEND[1] = 0;
     self->pwm->EVENTS_STOPPED = 0;
-    self->pwm->SHORTS = NRF_PWM_SHORT_LOOPSDONE_SEQSTART0_MASK;
     self->pwm->TASKS_SEQSTART[0] = 1;
     self->playing = true;
-    self->stopping = false;
     self->paused = false;
 }
 


### PR DESCRIPTION
By managing flags in a different order -- and by clearing out some potential left-over events from earlier use of the PWM instance -- we can stop rawsamples, rather than looping them forever

Testing performed:  On a feather_nrf52840_express, ran a test with looped and non-looped RawSamples and WaveFiles