### PR TITLE
Improve USB eject by resetting on replug

### DIFF
--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -87,10 +87,12 @@ void usb_background(void) {
 
 // Invoked when device is mounted
 void tud_mount_cb(void) {
+    usb_msc_mount();
 }
 
 // Invoked when device is unmounted
 void tud_umount_cb(void) {
+    usb_msc_umount();
 }
 
 // Invoked when usb bus is suspended

--- a/supervisor/usb.h
+++ b/supervisor/usb.h
@@ -41,4 +41,8 @@ void init_usb_hardware(void);
 bool usb_enabled(void);
 void usb_init(void);
 
+// Propagate plug/unplug events to the MSC logic.
+void usb_msc_mount(void);
+void usb_msc_umount(void);
+
 #endif // MICROPY_INCLUDED_SUPERVISOR_USB_H


### PR DESCRIPTION
This seems to fix the issue where leaving a CIRCUITPY drive plugged in leads to a crash.