### PR TITLE
gen_display_resources: speed it up

### DIFF
--- a/tools/gen_display_resources.py
+++ b/tools/gen_display_resources.py
@@ -48,18 +48,19 @@ for c in sample_characters:
         all_characters += c
 if args.extra_characters:
     all_characters.extend(args.extra_characters)
+all_characters = "".join(sorted(set(all_characters)))
 filtered_characters = all_characters
 
 # Try to pre-load all of the glyphs. Misses will still be slow later.
-f.load_glyphs(set(all_characters))
+f.load_glyphs(set(ord(c) for c in all_characters))
 
 # Get each glyph.
-for c in all_characters:
-    g = f.get_glyph(ord(c))
-    if not g:
+for c in set(all_characters):
+    if ord(c) not in f._glyphs:
         print("Font missing character:", c, ord(c))
         filtered_characters = filtered_characters.replace(c, "")
         continue
+    g = f.get_glyph(ord(c))
     if g["shift"][1] != 0:
         raise RuntimeError("y shift")
 


### PR DESCRIPTION
It was intended that the `f.load_glyphs` line was fast and did most of the work.  However, it actually didn't, because it's necessary to pass in a code point by number, not by string.

Additionally, a little light layer violation is needed to make the check for missing characters fast.  This used to be less important, as no fonts had missing characters.  However, it would take an appreciable length of time on the Korean translation when failing to find hundreds of different code points.

Testing performed: built build-circuitplayground_express_displayio/autogen_display_resources.c with ko translation before and after change.  verified the file content was identical. Time went from about 7s on my machine to way under 1 second.