### PR TITLE
STM32: rename vbus flag

### DIFF
--- a/ports/stm32f4/boards/stm32f411ce_blackpill/mpconfigboard.h
+++ b/ports/stm32f4/boards/stm32f411ce_blackpill/mpconfigboard.h
@@ -33,7 +33,7 @@
 #define FLASH_PAGE_SIZE             (0x4000)
 
 #define BOARD_OSC_DIV 25
-#define BOARD_NO_VBUS
+#define BOARD_NO_VBUS_SENSE
 
 // On-board flash
 // #define SPI_FLASH_MOSI_PIN          (&pin_PA07)

--- a/ports/stm32f4/supervisor/usb.c
+++ b/ports/stm32f4/supervisor/usb.c
@@ -38,7 +38,7 @@
 
 STATIC void init_usb_vbus_sense(void) {
 
-#ifdef BOARD_NO_VBUS
+#ifdef BOARD_NO_VBUS_SENSE
     // Disable VBUS sensing
     #ifdef USB_OTG_GCCFG_VBDEN
         USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_VBDEN;


### PR DESCRIPTION
A tiny PR to get it out of the way. Catchup for https://github.com/adafruit/circuitpython/pull/2379 since I was traveling and didn't get the change in on time. 