### PR TITLE
Fix nRF UART reset

### DIFF
--- a/ports/nrf/common-hal/busio/I2C.c
+++ b/ports/nrf/common-hal/busio/I2C.c
@@ -63,7 +63,7 @@ void i2c_reset(void) {
         if (never_reset[i]) {
             continue;
         }
-        nrf_twim_disable(twim_peripherals[i].twim.p_twim);
+        nrfx_twim_uninit(&twim_peripherals[i].twim);
         twim_peripherals[i].in_use = false;
     }
 }
@@ -150,13 +150,6 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self, const mcu_pin_obj_t *
     // About to init. If we fail after this point, common_hal_busio_i2c_deinit() will set in_use to false.
     self->twim_peripheral->in_use = true;
     nrfx_err_t err = nrfx_twim_init(&self->twim_peripheral->twim, &config, NULL, NULL);
-
-    // A soft reset doesn't uninit the driver so we might end up with a invalid state
-    if (err == NRFX_ERROR_INVALID_STATE) {
-        nrfx_twim_uninit(&self->twim_peripheral->twim);
-        err = nrfx_twim_init(&self->twim_peripheral->twim, &config, NULL, NULL);
-    }
-
     if (err != NRFX_SUCCESS) {
         common_hal_busio_i2c_deinit(self);
         mp_raise_OSError(MP_EIO);

--- a/ports/nrf/common-hal/busio/SPI.c
+++ b/ports/nrf/common-hal/busio/SPI.c
@@ -68,7 +68,7 @@ void spi_reset(void) {
         if (never_reset[i]) {
             continue;
         }
-        nrf_spim_disable(spim_peripherals[i].spim.p_reg);
+        nrfx_spim_uninit(&spim_peripherals[i].spim);
     }
 }
 
@@ -160,13 +160,6 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self, const mcu_pin_obj_t *
     }
 
     nrfx_err_t err = nrfx_spim_init(&self->spim_peripheral->spim, &config, NULL, NULL);
-
-    // A soft reset doesn't uninit the driver so we might end up with a invalid state
-    if (err == NRFX_ERROR_INVALID_STATE) {
-        nrfx_spim_uninit(&self->spim_peripheral->spim);
-        err = nrfx_spim_init(&self->spim_peripheral->spim, &config, NULL, NULL);
-    }
-
     if (err != NRFX_SUCCESS) {
         common_hal_busio_spi_deinit(self);
         mp_raise_OSError(MP_EIO);

--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -124,7 +124,7 @@ static void uart_callback_irq (const nrfx_uarte_event_t * event, void * context)
 
 void uart_reset(void) {
     for (size_t i = 0 ; i < MP_ARRAY_SIZE(nrfx_uartes); i++) {
-        nrf_uarte_disable(nrfx_uartes[i].p_reg);
+        nrfx_uarte_uninit(&nrfx_uartes[i]);
     }
 }
 
@@ -171,7 +171,6 @@ void common_hal_busio_uart_construct (busio_uart_obj_t *self,
         }
     };
 
-    nrfx_uarte_uninit(self->uarte);
     _VERIFY_ERR(nrfx_uarte_init(self->uarte, &config, uart_callback_irq));
 
     // Init buffer for rx

--- a/ports/nrf/common-hal/neopixel_write/__init__.c
+++ b/ports/nrf/common-hal/neopixel_write/__init__.c
@@ -130,7 +130,17 @@ void common_hal_neopixel_write (const digitalio_digitalinout_obj_t* digitalinout
         if (pattern_size <= sizeof(one_pixel)) {
             pixels_pattern = (uint16_t *) one_pixel;
         } else {
-            pixels_pattern = (uint16_t *) m_malloc_maybe(pattern_size, false);
+            uint8_t sd_en = 0;
+            (void) sd_softdevice_is_enabled(&sd_en);
+            if (sd_en) {
+                // If the soft device is enabled then we must use PWM to
+                // transmit. This takes a bunch of memory to do so raise an
+                // exception if we can't.
+                pixels_pattern = (uint16_t *) m_malloc(pattern_size, false);
+            } else {
+                pixels_pattern = (uint16_t *) m_malloc_maybe(pattern_size, false);
+            }
+
             pattern_on_heap = true;
         }
     }


### PR DESCRIPTION
disable only turns off ENABLE but doesn't set the init tracking that
nrfx uses. uninit hangs if ENABLE is off and is called because it
waits forever for TX to stop.