### PR TITLE
CIRCUITPY_DISPLAY_LIMIT = 2 for monster m4sk

### DIFF
--- a/ports/atmel-samd/boards/monster_m4sk/mpconfigboard.h
+++ b/ports/atmel-samd/boards/monster_m4sk/mpconfigboard.h
@@ -19,3 +19,10 @@
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1
+
+// Enable the use of 2 displays
+
+#define CIRCUITPY_DISPLAY_LIMIT (2)
+
+
+

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -328,7 +328,9 @@ extern const struct _mp_obj_module_t terminalio_module;
 #define DISPLAYIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_displayio), (mp_obj_t)&displayio_module },
 #define FONTIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_fontio), (mp_obj_t)&fontio_module },
 #define TERMINALIO_MODULE      { MP_OBJ_NEW_QSTR(MP_QSTR_terminalio), (mp_obj_t)&terminalio_module },
-#define CIRCUITPY_DISPLAY_LIMIT (2)
+#ifndef CIRCUITPY_DISPLAY_LIMIT
+#define CIRCUITPY_DISPLAY_LIMIT (1)
+#endif
 #else
 #define DISPLAYIO_MODULE
 #define FONTIO_MODULE

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -328,7 +328,7 @@ extern const struct _mp_obj_module_t terminalio_module;
 #define DISPLAYIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_displayio), (mp_obj_t)&displayio_module },
 #define FONTIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_fontio), (mp_obj_t)&fontio_module },
 #define TERMINALIO_MODULE      { MP_OBJ_NEW_QSTR(MP_QSTR_terminalio), (mp_obj_t)&terminalio_module },
-#define CIRCUITPY_DISPLAY_LIMIT (1)
+#define CIRCUITPY_DISPLAY_LIMIT (2)
 #else
 #define DISPLAYIO_MODULE
 #define FONTIO_MODULE


### PR DESCRIPTION
allow defining `CIRCUITPY_DISPLAY_LIMIT` in the mpconfigboard.h files for each board
setting it at 2 for the monster m4sk
following instructions from : https://github.com/adafruit/circuitpython/issues/1760#issuecomment-570802884