### PR TITLE
Fix board_timerhook

### DIFF
--- a/ports/cxd56/Makefile
+++ b/ports/cxd56/Makefile
@@ -131,6 +131,7 @@ LDFLAGS = \
 	-o $(BUILD)/firmware.elf \
 	--start-group \
 	-u spresense_main \
+	-u board_timerhook \
 	$(BUILD)/libmpy.a \
 	$(SPRESENSE_SDK)/sdk/libs/libapps.a \
 	$(SPRESENSE_SDK)/sdk/libs/libsdk.a \


### PR DESCRIPTION
After the https://github.com/adafruit/circuitpython/commit/7f744a2369a5036cadfa05575da1704f709c98bb commit, the cxd56 port did not work. Function `board_timerhook` was not called. This PR fixes this issue.