### PR TITLE
Fix tuple subscr

### DIFF
--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -71,15 +71,6 @@ void namedtuple_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t ki
     mp_obj_attrtuple_print_helper(print, fields, &o->tuple);
 }
 
-mp_obj_t namedtuple_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
-    mp_obj_type_t *type = mp_obj_get_type(self_in);
-    // Check for subclasses of namedtuple and unpack if needed.
-    if (type->parent != &mp_type_tuple) {
-        self_in = ((mp_obj_instance_t*) self_in)->subobj[0];
-    }
-    return mp_obj_tuple_subscr(self_in, index, value);
-}
-
 void namedtuple_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     if (dest[0] == MP_OBJ_NULL) {
         // load attribute
@@ -177,7 +168,7 @@ STATIC mp_obj_t mp_obj_new_namedtuple_type(qstr name, size_t n_fields, mp_obj_t 
     o->base.unary_op = mp_obj_tuple_unary_op;
     o->base.binary_op = mp_obj_tuple_binary_op;
     o->base.attr = namedtuple_attr;
-    o->base.subscr = namedtuple_subscr;
+    o->base.subscr = mp_obj_tuple_subscr;
     o->base.getiter = mp_obj_tuple_getiter;
     o->base.parent = &mp_type_tuple;
     return MP_OBJ_FROM_PTR(o);

--- a/py/objnamedtuple.h
+++ b/py/objnamedtuple.h
@@ -49,7 +49,6 @@ typedef struct _mp_obj_namedtuple_t {
 
 void namedtuple_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind);
 size_t mp_obj_namedtuple_find_field(const mp_obj_namedtuple_type_t *type, qstr name);
-mp_obj_t namedtuple_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value);
 void namedtuple_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
 mp_obj_namedtuple_type_t *mp_obj_new_namedtuple_base(size_t n_fields, mp_obj_t *fields);
 mp_obj_t namedtuple_make_new(const mp_obj_type_t *type_in, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args);

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -29,6 +29,7 @@
 
 #include "py/objtuple.h"
 #include "py/runtime.h"
+#include "py/objtype.h"
 
 #include "supervisor/shared/translate.h"
 
@@ -178,10 +179,14 @@ mp_obj_t mp_obj_tuple_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
 }
 
 mp_obj_t mp_obj_tuple_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
-
     if (value == MP_OBJ_SENTINEL) {
         // load
         mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
+        // when called with a native type (eg namedtuple) using mp_obj_tuple_subscr, get the native self
+        if (self->base.type->subscr != &mp_obj_tuple_subscr) {
+            self = mp_instance_cast_to_native_base(self_in, &mp_type_tuple);
+        }
+
 #if MICROPY_PY_BUILTINS_SLICE
         if (MP_OBJ_IS_TYPE(index, &mp_type_slice)) {
             mp_bound_slice_t slice;

--- a/tests/basics/subscr_tuple.py
+++ b/tests/basics/subscr_tuple.py
@@ -1,0 +1,7 @@
+# subscripting a subclassed tuple
+class Foo(tuple):
+    pass
+
+foo = Foo((1,2))
+foo[0]
+


### PR DESCRIPTION
This fix should address #2465 by making sure that any native type using mp_obj_tuple_subscr gets the native instance it needs.  There might be more unit tests needed to verify all instances of mp_obj_tuple_subscr work properly when subclassed:

```
./shared-bindings/time/__init__.c:        .subscr = mp_obj_tuple_subscr,
./shared-bindings/fontio/Glyph.c:        .subscr = mp_obj_tuple_subscr,
./py/objattrtuple.c:    .subscr = mp_obj_tuple_subscr,
./py/objexcept.c:        .subscr = mp_obj_tuple_subscr,
./py/objexcept.c:        .subscr = mp_obj_tuple_subscr,
./py/objexcept.c:        .subscr = mp_obj_tuple_subscr,
./py/objnamedtuple.c:    o->base.subscr = mp_obj_tuple_subscr;
./py/objtuple.c:    .subscr = mp_obj_tuple_subscr,
```