### PR TITLE
Make all `PYTHON` env vars into `PYTHON3`

### DIFF
--- a/py/py.mk
+++ b/py/py.mk
@@ -304,12 +304,12 @@ FORCE:
 
 $(HEADER_BUILD)/mpversion.h: FORCE | $(HEADER_BUILD)
 	$(STEPECHO) "GEN $@"
-	$(Q)$(PYTHON) $(PY_SRC)/makeversionhdr.py $@
+	$(Q)$(PYTHON3) $(PY_SRC)/makeversionhdr.py $@
 
 # build a list of registered modules for py/objmodule.c.
 $(HEADER_BUILD)/moduledefs.h: $(SRC_QSTR) $(QSTR_GLOBAL_DEPENDENCIES) | $(HEADER_BUILD)/mpversion.h
 	@$(STEPECHO) "GEN $@"
-	$(Q)$(PYTHON) $(PY_SRC)/makemoduledefs.py --vpath="., $(TOP), $(USER_C_MODULES)" $(SRC_QSTR) > $@
+	$(Q)$(PYTHON3) $(PY_SRC)/makemoduledefs.py --vpath="., $(TOP), $(USER_C_MODULES)" $(SRC_QSTR) > $@
 
 SRC_QSTR += $(HEADER_BUILD)/moduledefs.h
 


### PR DESCRIPTION
The file `py.mk` contained a mix of references to `PYTHON` and `PYTHON3`, and did not build on a fresh install of Ubuntu (under Windows LXSS).  Converting all of these to `PYTHON3` fixed the issue