### PR TITLE
samd: audio_dma: Shift responsibility for two-dma-channel audio

### DIFF
--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -232,6 +232,7 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t* dma,
     uint32_t max_buffer_length;
     audiosample_get_buffer_structure(sample, &single_buffer, &samples_signed,
                                      &max_buffer_length, &dma->spacing);
+    dma->spacing = single_channel ? audiosample_channel_count(sample) : 1;
     uint8_t output_spacing = dma->spacing;
     if (output_signed != samples_signed) {
         output_spacing = 1;

--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -231,7 +231,7 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t* dma,
     bool samples_signed;
     uint32_t max_buffer_length;
     audiosample_get_buffer_structure(sample, &single_buffer, &samples_signed,
-                                     &max_buffer_length, &dma->spacing);
+                                     &max_buffer_length);
     dma->spacing = single_channel ? audiosample_channel_count(sample) : 1;
     uint8_t output_spacing = dma->spacing;
     if (output_signed != samples_signed) {

--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -123,8 +123,7 @@ void audio_dma_load_next_block(audio_dma_t* dma) {
     uint8_t* buffer;
     uint32_t buffer_length;
     audioio_get_buffer_result_t get_buffer_result =
-        audiosample_get_buffer(dma->sample, false, dma->audio_channel,
-                               &buffer, &buffer_length);
+        audiosample_get_buffer(dma->sample, &buffer, &buffer_length);
 
     DmacDescriptor* descriptor = dma->second_descriptor;
     if (dma->first_descriptor_free) {
@@ -231,7 +230,7 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t* dma,
     bool single_buffer;
     bool samples_signed;
     uint32_t max_buffer_length;
-    audiosample_get_buffer_structure(sample, single_channel, &single_buffer, &samples_signed,
+    audiosample_get_buffer_structure(sample, &single_buffer, &samples_signed,
                                      &max_buffer_length, &dma->spacing);
     uint8_t output_spacing = dma->spacing;
     if (output_signed != samples_signed) {

--- a/ports/atmel-samd/audio_dma.h
+++ b/ports/atmel-samd/audio_dma.h
@@ -35,6 +35,7 @@
 typedef struct {
     mp_obj_t sample;
     uint8_t dma_channel;
+    uint8_t sibling_channel;
     uint8_t event_channel;
     uint8_t audio_channel;
     uint8_t bytes_per_sample;
@@ -84,6 +85,11 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t* dma,
                                           bool output_signed,
                                           uint32_t output_register_address,
                                           uint8_t dma_trigger_source);
+
+#ifdef SAMD51
+audio_dma_result audio_dma_link_channels(audio_dma_t* first, audio_dma_t* second);
+#endif
+audio_dma_result audio_dma_preload(audio_dma_t* dma, uint8_t dma_trigger_source);
 
 void audio_dma_disable_channel(uint8_t channel);
 void audio_dma_enable_channel(uint8_t channel);

--- a/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
+++ b/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -299,7 +299,9 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t* self,
     #endif
     audio_dma_result result = audio_dma_setup_playback(&self->dma, sample, loop, false, 0,
         true /* output signed */, tx_register, dmac_id);
-
+    if (result == AUDIO_DMA_OK) {
+        result = audio_dma_preload(&self->dma, dmac_id);
+    }
     if (result == AUDIO_DMA_DMA_BUSY) {
         common_hal_audiobusio_i2sout_stop(self);
         mp_raise_RuntimeError(translate("No DMA channel found"));

--- a/ports/nrf/common-hal/audiobusio/I2SOut.c
+++ b/ports/nrf/common-hal/audiobusio/I2SOut.c
@@ -246,8 +246,8 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t* self,
     uint32_t max_buffer_length;
     bool single_buffer, samples_signed;
     audiosample_get_buffer_structure(sample,
-        &single_buffer, &samples_signed, &max_buffer_length,
-        &self->channel_count);
+        &single_buffer, &samples_signed, &max_buffer_length);
+    self->channel_count = audiosample_channel_count(sample);
     self->single_buffer = single_buffer;
     self->samples_signed = samples_signed;
 

--- a/ports/nrf/common-hal/audiobusio/I2SOut.c
+++ b/ports/nrf/common-hal/audiobusio/I2SOut.c
@@ -117,7 +117,7 @@ static void i2s_buffer_fill(audiobusio_i2sout_obj_t* self) {
         if (self->sample_data == self->sample_end) {
             uint32_t sample_buffer_length;
             audioio_get_buffer_result_t get_buffer_result =
-                audiosample_get_buffer(self->sample, false, 0,
+                audiosample_get_buffer(self->sample,
                                        &self->sample_data, &sample_buffer_length);
             self->sample_end = self->sample_data + sample_buffer_length;
             if (get_buffer_result == GET_BUFFER_DONE) {
@@ -245,7 +245,7 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t* self,
 
     uint32_t max_buffer_length;
     bool single_buffer, samples_signed;
-    audiosample_get_buffer_structure(sample, /* single channel */ true,
+    audiosample_get_buffer_structure(sample,
         &single_buffer, &samples_signed, &max_buffer_length,
         &self->channel_count);
     self->single_buffer = single_buffer;

--- a/ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
@@ -91,7 +91,7 @@ STATIC void fill_buffers(audiopwmio_pwmaudioout_obj_t *self, int buf) {
     uint8_t *buffer;
     uint32_t buffer_length;
     audioio_get_buffer_result_t get_buffer_result =
-        audiosample_get_buffer(self->sample, false, 0,
+        audiosample_get_buffer(self->sample,
                                &buffer, &buffer_length);
     if (get_buffer_result == GET_BUFFER_ERROR) {
         common_hal_audiopwmio_pwmaudioout_stop(self);
@@ -229,7 +229,7 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t* self, 
 
     uint32_t max_buffer_length;
     uint8_t spacing;
-    audiosample_get_buffer_structure(sample, /* single channel */ false,
+    audiosample_get_buffer_structure(sample,
         &self->single_buffer, &self->signed_to_unsigned, &max_buffer_length,
         &spacing);
     self->sample_channel_count = audiosample_channel_count(sample);

--- a/ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
@@ -228,10 +228,8 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t* self, 
     self->bytes_per_sample = audiosample_bits_per_sample(sample) / 8;
 
     uint32_t max_buffer_length;
-    uint8_t spacing;
     audiosample_get_buffer_structure(sample,
-        &self->single_buffer, &self->signed_to_unsigned, &max_buffer_length,
-        &spacing);
+        &self->single_buffer, &self->signed_to_unsigned, &max_buffer_length);
     self->sample_channel_count = audiosample_channel_count(sample);
 
     if (max_buffer_length > UINT16_MAX) {

--- a/shared-bindings/audiocore/RawSample.c
+++ b/shared-bindings/audiocore/RawSample.c
@@ -109,7 +109,7 @@ STATIC mp_obj_t audioio_rawsample_make_new(const mp_obj_type_t *type, size_t n_a
 //|
 //|      Deinitialises the AudioOut and releases any hardware resources for reuse.
 //|
-STATIC mp_obj_t audioio_rawsample_deinit(mp_obj_t self_in) {
+STATIC mp_obj_t audioio_rawsample_deinit(void* self_in) {
     audioio_rawsample_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_audioio_rawsample_deinit(self);
     return mp_const_none;
@@ -147,14 +147,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audioio_rawsample___exit___obj, 4, 4,
 //|     sample. This will not change the sample rate of any active playback. Call ``play`` again to
 //|     change it.
 //|
-STATIC mp_obj_t audioio_rawsample_obj_get_sample_rate(mp_obj_t self_in) {
+STATIC mp_obj_t audioio_rawsample_obj_get_sample_rate(void* self_in) {
     audioio_rawsample_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
     return MP_OBJ_NEW_SMALL_INT(common_hal_audioio_rawsample_get_sample_rate(self));
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audioio_rawsample_get_sample_rate_obj, audioio_rawsample_obj_get_sample_rate);
 
-STATIC mp_obj_t audioio_rawsample_obj_set_sample_rate(mp_obj_t self_in, mp_obj_t sample_rate) {
+STATIC mp_obj_t audioio_rawsample_obj_set_sample_rate(void* self_in, mp_obj_t sample_rate) {
     audioio_rawsample_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
     common_hal_audioio_rawsample_set_sample_rate(self, mp_obj_get_int(sample_rate));
@@ -182,12 +182,12 @@ STATIC MP_DEFINE_CONST_DICT(audioio_rawsample_locals_dict, audioio_rawsample_loc
 
 STATIC const audiosample_p_t audioio_rawsample_proto = {
     MP_PROTO_IMPLEMENT(MP_QSTR_protocol_audiosample)
-    .sample_rate = (audiosample_sample_rate_fun)common_hal_audioio_rawsample_get_sample_rate,
-    .bits_per_sample = (audiosample_bits_per_sample_fun)common_hal_audioio_rawsample_get_bits_per_sample,
-    .channel_count = (audiosample_channel_count_fun)common_hal_audioio_rawsample_get_channel_count,
-    .reset_buffer = (audiosample_reset_buffer_fun)audioio_rawsample_reset_buffer,
-    .get_buffer = (audiosample_get_buffer_fun)audioio_rawsample_get_buffer,
-    .get_buffer_structure = (audiosample_get_buffer_structure_fun)audioio_rawsample_get_buffer_structure,
+    .sample_rate = common_hal_audioio_rawsample_get_sample_rate,
+    .bits_per_sample = common_hal_audioio_rawsample_get_bits_per_sample,
+    .channel_count = common_hal_audioio_rawsample_get_channel_count,
+    .reset_buffer = audioio_rawsample_reset_buffer,
+    .get_buffer = audioio_rawsample_get_buffer,
+    .get_buffer_structure = audioio_rawsample_get_buffer_structure,
 };
 
 const mp_obj_type_t audioio_rawsample_type = {

--- a/shared-bindings/audiocore/RawSample.h
+++ b/shared-bindings/audiocore/RawSample.h
@@ -38,9 +38,9 @@ void common_hal_audioio_rawsample_construct(audioio_rawsample_obj_t* self,
 
 void common_hal_audioio_rawsample_deinit(audioio_rawsample_obj_t* self);
 bool common_hal_audioio_rawsample_deinited(audioio_rawsample_obj_t* self);
-uint32_t common_hal_audioio_rawsample_get_sample_rate(audioio_rawsample_obj_t* self);
-uint8_t common_hal_audioio_rawsample_get_bits_per_sample(audioio_rawsample_obj_t* self);
-uint8_t common_hal_audioio_rawsample_get_channel_count(audioio_rawsample_obj_t* self);
+uint32_t common_hal_audioio_rawsample_get_sample_rate(void* self_in);
+uint8_t common_hal_audioio_rawsample_get_bits_per_sample(void* self_in);
+uint8_t common_hal_audioio_rawsample_get_channel_count(void* self_in);
 void common_hal_audioio_rawsample_set_sample_rate(audioio_rawsample_obj_t* self, uint32_t sample_rate);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_AUDIOIO_RAWSAMPLE_H

--- a/shared-bindings/audiocore/WaveFile.c
+++ b/shared-bindings/audiocore/WaveFile.c
@@ -208,12 +208,12 @@ STATIC MP_DEFINE_CONST_DICT(audioio_wavefile_locals_dict, audioio_wavefile_local
 
 STATIC const audiosample_p_t audioio_wavefile_proto = {
     MP_PROTO_IMPLEMENT(MP_QSTR_protocol_audiosample)
-    .sample_rate = (audiosample_sample_rate_fun)common_hal_audioio_wavefile_get_sample_rate,
-    .bits_per_sample = (audiosample_bits_per_sample_fun)common_hal_audioio_wavefile_get_bits_per_sample,
-    .channel_count = (audiosample_channel_count_fun)common_hal_audioio_wavefile_get_channel_count,
-    .reset_buffer = (audiosample_reset_buffer_fun)audioio_wavefile_reset_buffer,
-    .get_buffer = (audiosample_get_buffer_fun)audioio_wavefile_get_buffer,
-    .get_buffer_structure = (audiosample_get_buffer_structure_fun)audioio_wavefile_get_buffer_structure,
+    .sample_rate = common_hal_audioio_wavefile_get_sample_rate,
+    .bits_per_sample = common_hal_audioio_wavefile_get_bits_per_sample,
+    .channel_count = common_hal_audioio_wavefile_get_channel_count,
+    .reset_buffer = audioio_wavefile_reset_buffer,
+    .get_buffer = audioio_wavefile_get_buffer,
+    .get_buffer_structure = audioio_wavefile_get_buffer_structure,
 };
 
 

--- a/shared-bindings/audiocore/WaveFile.h
+++ b/shared-bindings/audiocore/WaveFile.h
@@ -39,9 +39,9 @@ void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t* self,
 
 void common_hal_audioio_wavefile_deinit(audioio_wavefile_obj_t* self);
 bool common_hal_audioio_wavefile_deinited(audioio_wavefile_obj_t* self);
-uint32_t common_hal_audioio_wavefile_get_sample_rate(audioio_wavefile_obj_t* self);
+uint32_t common_hal_audioio_wavefile_get_sample_rate(void* self);
 void common_hal_audioio_wavefile_set_sample_rate(audioio_wavefile_obj_t* self, uint32_t sample_rate);
-uint8_t common_hal_audioio_wavefile_get_bits_per_sample(audioio_wavefile_obj_t* self);
-uint8_t common_hal_audioio_wavefile_get_channel_count(audioio_wavefile_obj_t* self);
+uint8_t common_hal_audioio_wavefile_get_bits_per_sample(void* self);
+uint8_t common_hal_audioio_wavefile_get_channel_count(void* self);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_AUDIOIO_WAVEFILE_H

--- a/shared-bindings/audiomixer/Mixer.c
+++ b/shared-bindings/audiomixer/Mixer.c
@@ -293,12 +293,12 @@ STATIC MP_DEFINE_CONST_DICT(audiomixer_mixer_locals_dict, audiomixer_mixer_local
 
 STATIC const audiosample_p_t audiomixer_mixer_proto = {
     MP_PROTO_IMPLEMENT(MP_QSTR_protocol_audiosample)
-    .sample_rate = (audiosample_sample_rate_fun)common_hal_audiomixer_mixer_get_sample_rate,
-    .bits_per_sample = (audiosample_bits_per_sample_fun)common_hal_audiomixer_mixer_get_bits_per_sample,
-    .channel_count = (audiosample_channel_count_fun)common_hal_audiomixer_mixer_get_channel_count,
-    .reset_buffer = (audiosample_reset_buffer_fun)audiomixer_mixer_reset_buffer,
-    .get_buffer = (audiosample_get_buffer_fun)audiomixer_mixer_get_buffer,
-    .get_buffer_structure = (audiosample_get_buffer_structure_fun)audiomixer_mixer_get_buffer_structure,
+    .sample_rate = common_hal_audiomixer_mixer_get_sample_rate,
+    .bits_per_sample = common_hal_audiomixer_mixer_get_bits_per_sample,
+    .channel_count = common_hal_audiomixer_mixer_get_channel_count,
+    .reset_buffer = audiomixer_mixer_reset_buffer,
+    .get_buffer = audiomixer_mixer_get_buffer,
+    .get_buffer_structure = audiomixer_mixer_get_buffer_structure,
 };
 
 const mp_obj_type_t audiomixer_mixer_type = {

--- a/shared-bindings/audiomixer/Mixer.h
+++ b/shared-bindings/audiomixer/Mixer.h
@@ -46,8 +46,8 @@ void common_hal_audiomixer_mixer_deinit(audiomixer_mixer_obj_t* self);
 bool common_hal_audiomixer_mixer_deinited(audiomixer_mixer_obj_t* self);
 
 bool common_hal_audiomixer_mixer_get_playing(audiomixer_mixer_obj_t* self);
-uint32_t common_hal_audiomixer_mixer_get_sample_rate(audiomixer_mixer_obj_t* self);
-uint8_t common_hal_audiomixer_mixer_get_channel_count(audiomixer_mixer_obj_t* self);
-uint8_t common_hal_audiomixer_mixer_get_bits_per_sample(audiomixer_mixer_obj_t* self);
+uint32_t common_hal_audiomixer_mixer_get_sample_rate(void* self);
+uint8_t common_hal_audiomixer_mixer_get_channel_count(void* self);
+uint8_t common_hal_audiomixer_mixer_get_bits_per_sample(void* self);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_AUDIOMIXER_MIXER_H

--- a/shared-module/audiocore/RawSample.c
+++ b/shared-module/audiocore/RawSample.c
@@ -86,10 +86,9 @@ audioio_get_buffer_result_t audioio_rawsample_get_buffer(void* self_in,
 
 void audioio_rawsample_get_buffer_structure(void* self_in,
                                             bool* single_buffer, bool* samples_signed,
-                                            uint32_t* max_buffer_length, uint8_t* spacing) {
+                                            uint32_t* max_buffer_length) {
     audioio_rawsample_obj_t* self = self_in;
     *single_buffer = true;
     *samples_signed = self->samples_signed;
     *max_buffer_length = self->len;
-    *spacing = 1;
 }

--- a/shared-module/audiocore/RawSample.c
+++ b/shared-module/audiocore/RawSample.c
@@ -73,28 +73,18 @@ void audioio_rawsample_reset_buffer(audioio_rawsample_obj_t* self,
 }
 
 audioio_get_buffer_result_t audioio_rawsample_get_buffer(audioio_rawsample_obj_t* self,
-                                                         bool single_channel,
-                                                         uint8_t channel,
                                                          uint8_t** buffer,
                                                          uint32_t* buffer_length) {
     *buffer_length = self->len;
-    if (single_channel) {
-        *buffer = self->buffer + (channel % self->channel_count) * (self->bits_per_sample / 8);
-    } else {
-        *buffer = self->buffer;
-    }
+    *buffer = self->buffer;
     return GET_BUFFER_DONE;
 }
 
-void audioio_rawsample_get_buffer_structure(audioio_rawsample_obj_t* self, bool single_channel,
+void audioio_rawsample_get_buffer_structure(audioio_rawsample_obj_t* self,
                                             bool* single_buffer, bool* samples_signed,
                                             uint32_t* max_buffer_length, uint8_t* spacing) {
     *single_buffer = true;
     *samples_signed = self->samples_signed;
     *max_buffer_length = self->len;
-    if (single_channel) {
-        *spacing = self->channel_count;
-    } else {
-        *spacing = 1;
-    }
+    *spacing = 1;
 }

--- a/shared-module/audiocore/RawSample.c
+++ b/shared-module/audiocore/RawSample.c
@@ -53,36 +53,41 @@ bool common_hal_audioio_rawsample_deinited(audioio_rawsample_obj_t* self) {
     return self->buffer == NULL;
 }
 
-uint32_t common_hal_audioio_rawsample_get_sample_rate(audioio_rawsample_obj_t* self) {
+uint32_t common_hal_audioio_rawsample_get_sample_rate(void* self_in) {
+    audioio_rawsample_obj_t* self = self_in;
     return self->sample_rate;
 }
 void common_hal_audioio_rawsample_set_sample_rate(audioio_rawsample_obj_t* self,
                                                   uint32_t sample_rate) {
     self->sample_rate = sample_rate;
 }
-uint8_t common_hal_audioio_rawsample_get_bits_per_sample(audioio_rawsample_obj_t* self) {
+uint8_t common_hal_audioio_rawsample_get_bits_per_sample(void* self_in) {
+    audioio_rawsample_obj_t* self = self_in;
     return self->bits_per_sample;
 }
-uint8_t common_hal_audioio_rawsample_get_channel_count(audioio_rawsample_obj_t* self) {
+uint8_t common_hal_audioio_rawsample_get_channel_count(void* self_in) {
+    audioio_rawsample_obj_t* self = self_in;
     return self->channel_count;
 }
 
-void audioio_rawsample_reset_buffer(audioio_rawsample_obj_t* self,
+void audioio_rawsample_reset_buffer(void* self_in,
                                     bool single_channel,
                                     uint8_t channel) {
 }
 
-audioio_get_buffer_result_t audioio_rawsample_get_buffer(audioio_rawsample_obj_t* self,
+audioio_get_buffer_result_t audioio_rawsample_get_buffer(void* self_in,
                                                          uint8_t** buffer,
                                                          uint32_t* buffer_length) {
+    audioio_rawsample_obj_t* self = self_in;
     *buffer_length = self->len;
     *buffer = self->buffer;
     return GET_BUFFER_DONE;
 }
 
-void audioio_rawsample_get_buffer_structure(audioio_rawsample_obj_t* self,
+void audioio_rawsample_get_buffer_structure(void* self_in,
                                             bool* single_buffer, bool* samples_signed,
                                             uint32_t* max_buffer_length, uint8_t* spacing) {
+    audioio_rawsample_obj_t* self = self_in;
     *single_buffer = true;
     *samples_signed = self->samples_signed;
     *max_buffer_length = self->len;

--- a/shared-module/audiocore/RawSample.h
+++ b/shared-module/audiocore/RawSample.h
@@ -52,6 +52,6 @@ audioio_get_buffer_result_t audioio_rawsample_get_buffer(void* self_in,
                                                          uint32_t* buffer_length); // length in bytes
 void audioio_rawsample_get_buffer_structure(void* self_in,
                                             bool* single_buffer, bool* samples_signed,
-                                            uint32_t* max_buffer_length, uint8_t* spacing);
+                                            uint32_t* max_buffer_length);
 
 #endif // MICROPY_INCLUDED_SHARED_MODULE_AUDIOIO_RAWSAMPLE_H

--- a/shared-module/audiocore/RawSample.h
+++ b/shared-module/audiocore/RawSample.h
@@ -48,11 +48,9 @@ void audioio_rawsample_reset_buffer(audioio_rawsample_obj_t* self,
                                     bool single_channel,
                                     uint8_t channel);
 audioio_get_buffer_result_t audioio_rawsample_get_buffer(audioio_rawsample_obj_t* self,
-                                                         bool single_channel,
-                                                         uint8_t channel,
                                                          uint8_t** buffer,
                                                          uint32_t* buffer_length); // length in bytes
-void audioio_rawsample_get_buffer_structure(audioio_rawsample_obj_t* self, bool single_channel,
+void audioio_rawsample_get_buffer_structure(audioio_rawsample_obj_t* self,
                                             bool* single_buffer, bool* samples_signed,
                                             uint32_t* max_buffer_length, uint8_t* spacing);
 

--- a/shared-module/audiocore/RawSample.h
+++ b/shared-module/audiocore/RawSample.h
@@ -44,13 +44,13 @@ typedef struct {
 
 
 // These are not available from Python because it may be called in an interrupt.
-void audioio_rawsample_reset_buffer(audioio_rawsample_obj_t* self,
+void audioio_rawsample_reset_buffer(void* self_in,
                                     bool single_channel,
                                     uint8_t channel);
-audioio_get_buffer_result_t audioio_rawsample_get_buffer(audioio_rawsample_obj_t* self,
+audioio_get_buffer_result_t audioio_rawsample_get_buffer(void* self_in,
                                                          uint8_t** buffer,
                                                          uint32_t* buffer_length); // length in bytes
-void audioio_rawsample_get_buffer_structure(audioio_rawsample_obj_t* self,
+void audioio_rawsample_get_buffer_structure(void* self_in,
                                             bool* single_buffer, bool* samples_signed,
                                             uint32_t* max_buffer_length, uint8_t* spacing);
 

--- a/shared-module/audiocore/WaveFile.c
+++ b/shared-module/audiocore/WaveFile.c
@@ -143,7 +143,8 @@ bool common_hal_audioio_wavefile_deinited(audioio_wavefile_obj_t* self) {
     return self->buffer == NULL;
 }
 
-uint32_t common_hal_audioio_wavefile_get_sample_rate(audioio_wavefile_obj_t* self) {
+uint32_t common_hal_audioio_wavefile_get_sample_rate(void* self_in) {
+    audioio_wavefile_obj_t* self = self_in;
     return self->sample_rate;
 }
 
@@ -152,25 +153,29 @@ void common_hal_audioio_wavefile_set_sample_rate(audioio_wavefile_obj_t* self,
     self->sample_rate = sample_rate;
 }
 
-uint8_t common_hal_audioio_wavefile_get_bits_per_sample(audioio_wavefile_obj_t* self) {
+uint8_t common_hal_audioio_wavefile_get_bits_per_sample(void* self_in) {
+    audioio_wavefile_obj_t* self = self_in;
     return self->bits_per_sample;
 }
 
-uint8_t common_hal_audioio_wavefile_get_channel_count(audioio_wavefile_obj_t* self) {
+uint8_t common_hal_audioio_wavefile_get_channel_count(void* self_in) {
+    audioio_wavefile_obj_t* self = self_in;
     return self->channel_count;
 }
 
-bool audioio_wavefile_samples_signed(audioio_wavefile_obj_t* self) {
+bool audioio_wavefile_samples_signed(void* self_in) {
+    audioio_wavefile_obj_t* self = self_in;
     return self->bits_per_sample > 8;
 }
 
-uint32_t audioio_wavefile_max_buffer_length(audioio_wavefile_obj_t* self) {
+uint32_t audioio_wavefile_max_buffer_length(void* self_in) {
     return 512;
 }
 
-void audioio_wavefile_reset_buffer(audioio_wavefile_obj_t* self,
+void audioio_wavefile_reset_buffer(void* self_in,
                                    bool single_channel,
                                    uint8_t channel) {
+    audioio_wavefile_obj_t* self = self_in;
     if (single_channel && channel == 1) {
         return;
     }
@@ -180,9 +185,10 @@ void audioio_wavefile_reset_buffer(audioio_wavefile_obj_t* self,
     f_lseek(&self->file->fp, self->data_start);
 }
 
-audioio_get_buffer_result_t audioio_wavefile_get_buffer(audioio_wavefile_obj_t* self,
+audioio_get_buffer_result_t audioio_wavefile_get_buffer(void* self_in,
                                                         uint8_t** buffer,
                                                         uint32_t* buffer_length) {
+    audioio_wavefile_obj_t* self = self_in;
     if (self->bytes_remaining == 0) {
         *buffer = NULL;
         *buffer_length = 0;
@@ -230,9 +236,10 @@ audioio_get_buffer_result_t audioio_wavefile_get_buffer(audioio_wavefile_obj_t* 
     return self->bytes_remaining == 0 ? GET_BUFFER_DONE : GET_BUFFER_MORE_DATA;
 }
 
-void audioio_wavefile_get_buffer_structure(audioio_wavefile_obj_t* self,
+void audioio_wavefile_get_buffer_structure(void* self_in,
                                            bool* single_buffer, bool* samples_signed,
                                            uint32_t* max_buffer_length, uint8_t* spacing) {
+    audioio_wavefile_obj_t* self = self_in;
     *single_buffer = false;
     *samples_signed = self->bits_per_sample > 8;
     *max_buffer_length = 512;

--- a/shared-module/audiocore/WaveFile.c
+++ b/shared-module/audiocore/WaveFile.c
@@ -178,102 +178,63 @@ void audioio_wavefile_reset_buffer(audioio_wavefile_obj_t* self,
     // loads
     self->bytes_remaining = self->file_length;
     f_lseek(&self->file->fp, self->data_start);
-    self->read_count = 0;
-    self->left_read_count = 0;
-    self->right_read_count = 0;
 }
 
 audioio_get_buffer_result_t audioio_wavefile_get_buffer(audioio_wavefile_obj_t* self,
-                                                        bool single_channel,
-                                                        uint8_t channel,
                                                         uint8_t** buffer,
                                                         uint32_t* buffer_length) {
-    if (!single_channel) {
-        channel = 0;
-    }
-
-    uint32_t channel_read_count = self->left_read_count;
-    if (channel == 1) {
-        channel_read_count = self->right_read_count;
-    }
-
-    bool need_more_data = self->read_count == channel_read_count;
-
-    if (self->bytes_remaining == 0 && need_more_data) {
+    if (self->bytes_remaining == 0) {
         *buffer = NULL;
         *buffer_length = 0;
         return GET_BUFFER_DONE;
     }
 
-    if (need_more_data) {
-        uint16_t num_bytes_to_load = self->len;
-        if (num_bytes_to_load > self->bytes_remaining) {
-            num_bytes_to_load = self->bytes_remaining;
-        }
-        UINT length_read;
-        if (self->buffer_index % 2 == 1) {
-            *buffer = self->second_buffer;
-        } else {
-            *buffer = self->buffer;
-        }
-        if (f_read(&self->file->fp, *buffer, num_bytes_to_load, &length_read) != FR_OK || length_read != num_bytes_to_load) {
-            return GET_BUFFER_ERROR;
-        }
-        self->bytes_remaining -= length_read;
-        // Pad the last buffer to word align it.
-        if (self->bytes_remaining == 0 && length_read % sizeof(uint32_t) != 0) {
-            uint32_t pad = length_read % sizeof(uint32_t);
-            length_read += pad;
-            if (self->bits_per_sample == 8) {
-                for (uint32_t i = 0; i < pad; i++) {
-                    ((uint8_t*) (*buffer))[length_read / sizeof(uint8_t) - i - 1] = 0x80;
-                }
-            } else if (self->bits_per_sample == 16) {
-                // We know the buffer is aligned because we allocated it onto the heap ourselves.
-                #pragma GCC diagnostic push
-                #pragma GCC diagnostic ignored "-Wcast-align"
-                ((int16_t*) (*buffer))[length_read / sizeof(int16_t) - 1] = 0;
-                #pragma GCC diagnostic pop
-            }
-        }
-        *buffer_length = length_read;
-        if (self->buffer_index % 2 == 1) {
-            self->second_buffer_length = length_read;
-        } else {
-            self->buffer_length = length_read;
-        }
-        self->buffer_index += 1;
-        self->read_count += 1;
+    uint16_t num_bytes_to_load = self->len;
+    if (num_bytes_to_load > self->bytes_remaining) {
+        num_bytes_to_load = self->bytes_remaining;
     }
-
-    uint32_t buffers_back = self->read_count - 1 - channel_read_count;
-    if ((self->buffer_index - buffers_back) % 2 == 0) {
+    UINT length_read;
+    if (self->buffer_index % 2 == 1) {
         *buffer = self->second_buffer;
-        *buffer_length = self->second_buffer_length;
     } else {
         *buffer = self->buffer;
-        *buffer_length = self->buffer_length;
     }
-
-    if (channel == 0) {
-        self->left_read_count += 1;
-    } else if (channel == 1) {
-        self->right_read_count += 1;
-        *buffer = *buffer + self->bits_per_sample / 8;
+    if (f_read(&self->file->fp, *buffer, num_bytes_to_load, &length_read) != FR_OK || length_read != num_bytes_to_load) {
+        return GET_BUFFER_ERROR;
     }
+    self->bytes_remaining -= length_read;
+    // Pad the last buffer to word align it.
+    if (self->bytes_remaining == 0 && length_read % sizeof(uint32_t) != 0) {
+        uint32_t pad = length_read % sizeof(uint32_t);
+        length_read += pad;
+        if (self->bits_per_sample == 8) {
+            for (uint32_t i = 0; i < pad; i++) {
+                ((uint8_t*) (*buffer))[length_read / sizeof(uint8_t) - i - 1] = 0x80;
+            }
+        } else if (self->bits_per_sample == 16) {
+            // We know the buffer is aligned because we allocated it onto the heap ourselves.
+            #pragma GCC diagnostic push
+            #pragma GCC diagnostic ignored "-Wcast-align"
+            ((int16_t*) (*buffer))[length_read / sizeof(int16_t) - 1] = 0;
+            #pragma GCC diagnostic pop
+        }
+    }
+    *buffer_length = length_read;
+    if (self->buffer_index % 2 == 1) {
+        self->second_buffer_length = length_read;
+    } else {
+        self->buffer_length = length_read;
+    }
+    self->buffer_index += 1;
 
     return self->bytes_remaining == 0 ? GET_BUFFER_DONE : GET_BUFFER_MORE_DATA;
 }
 
-void audioio_wavefile_get_buffer_structure(audioio_wavefile_obj_t* self, bool single_channel,
+void audioio_wavefile_get_buffer_structure(audioio_wavefile_obj_t* self,
                                            bool* single_buffer, bool* samples_signed,
                                            uint32_t* max_buffer_length, uint8_t* spacing) {
     *single_buffer = false;
     *samples_signed = self->bits_per_sample > 8;
     *max_buffer_length = 512;
-    if (single_channel) {
-        *spacing = self->channel_count;
-    } else {
-        *spacing = 1;
-    }
+    *spacing = 1;
 }

--- a/shared-module/audiocore/WaveFile.c
+++ b/shared-module/audiocore/WaveFile.c
@@ -238,10 +238,9 @@ audioio_get_buffer_result_t audioio_wavefile_get_buffer(void* self_in,
 
 void audioio_wavefile_get_buffer_structure(void* self_in,
                                            bool* single_buffer, bool* samples_signed,
-                                           uint32_t* max_buffer_length, uint8_t* spacing) {
+                                           uint32_t* max_buffer_length) {
     audioio_wavefile_obj_t* self = self_in;
     *single_buffer = false;
     *samples_signed = self->bits_per_sample > 8;
     *max_buffer_length = 512;
-    *spacing = 1;
 }

--- a/shared-module/audiocore/WaveFile.h
+++ b/shared-module/audiocore/WaveFile.h
@@ -52,13 +52,13 @@ typedef struct {
 } audioio_wavefile_obj_t;
 
 // These are not available from Python because it may be called in an interrupt.
-void audioio_wavefile_reset_buffer(audioio_wavefile_obj_t* self,
+void audioio_wavefile_reset_buffer(void* self_in,
                                    bool single_channel,
                                    uint8_t channel);
-audioio_get_buffer_result_t audioio_wavefile_get_buffer(audioio_wavefile_obj_t* self,
+audioio_get_buffer_result_t audioio_wavefile_get_buffer(void* self_in,
                                                         uint8_t** buffer,
                                                         uint32_t* buffer_length); // length in bytes
-void audioio_wavefile_get_buffer_structure(audioio_wavefile_obj_t* self,
+void audioio_wavefile_get_buffer_structure(void* self_in,
                                            bool* single_buffer, bool* samples_signed,
                                            uint32_t* max_buffer_length, uint8_t* spacing);
 

--- a/shared-module/audiocore/WaveFile.h
+++ b/shared-module/audiocore/WaveFile.h
@@ -60,6 +60,6 @@ audioio_get_buffer_result_t audioio_wavefile_get_buffer(void* self_in,
                                                         uint32_t* buffer_length); // length in bytes
 void audioio_wavefile_get_buffer_structure(void* self_in,
                                            bool* single_buffer, bool* samples_signed,
-                                           uint32_t* max_buffer_length, uint8_t* spacing);
+                                           uint32_t* max_buffer_length);
 
 #endif // MICROPY_INCLUDED_SHARED_MODULE_AUDIOIO_WAVEFILE_H

--- a/shared-module/audiocore/WaveFile.h
+++ b/shared-module/audiocore/WaveFile.h
@@ -49,10 +49,6 @@ typedef struct {
 
     uint32_t len;
     pyb_file_obj_t* file;
-
-    uint32_t read_count;
-    uint32_t left_read_count;
-    uint32_t right_read_count;
 } audioio_wavefile_obj_t;
 
 // These are not available from Python because it may be called in an interrupt.
@@ -60,11 +56,9 @@ void audioio_wavefile_reset_buffer(audioio_wavefile_obj_t* self,
                                    bool single_channel,
                                    uint8_t channel);
 audioio_get_buffer_result_t audioio_wavefile_get_buffer(audioio_wavefile_obj_t* self,
-                                                        bool single_channel,
-                                                        uint8_t channel,
                                                         uint8_t** buffer,
                                                         uint32_t* buffer_length); // length in bytes
-void audioio_wavefile_get_buffer_structure(audioio_wavefile_obj_t* self, bool single_channel,
+void audioio_wavefile_get_buffer_structure(audioio_wavefile_obj_t* self,
                                            bool* single_buffer, bool* samples_signed,
                                            uint32_t* max_buffer_length, uint8_t* spacing);
 

--- a/shared-module/audiocore/__init__.c
+++ b/shared-module/audiocore/__init__.c
@@ -63,8 +63,8 @@ audioio_get_buffer_result_t audiosample_get_buffer(mp_obj_t sample_obj,
 
 void audiosample_get_buffer_structure(mp_obj_t sample_obj,
                                       bool* single_buffer, bool* samples_signed,
-                                      uint32_t* max_buffer_length, uint8_t* spacing) {
+                                      uint32_t* max_buffer_length) {
     const audiosample_p_t *proto = mp_proto_get_or_throw(MP_QSTR_protocol_audiosample, sample_obj);
     proto->get_buffer_structure(MP_OBJ_TO_PTR(sample_obj), single_buffer,
-        samples_signed, max_buffer_length, spacing);
+        samples_signed, max_buffer_length);
 }

--- a/shared-module/audiocore/__init__.c
+++ b/shared-module/audiocore/__init__.c
@@ -56,17 +56,15 @@ void audiosample_reset_buffer(mp_obj_t sample_obj, bool single_channel, uint8_t 
 }
 
 audioio_get_buffer_result_t audiosample_get_buffer(mp_obj_t sample_obj,
-                                                   bool single_channel,
-                                                   uint8_t channel,
                                                    uint8_t** buffer, uint32_t* buffer_length) {
     const audiosample_p_t *proto = mp_proto_get_or_throw(MP_QSTR_protocol_audiosample, sample_obj);
-    return proto->get_buffer(MP_OBJ_TO_PTR(sample_obj), single_channel, channel, buffer, buffer_length);
+    return proto->get_buffer(MP_OBJ_TO_PTR(sample_obj), buffer, buffer_length);
 }
 
-void audiosample_get_buffer_structure(mp_obj_t sample_obj, bool single_channel,
+void audiosample_get_buffer_structure(mp_obj_t sample_obj,
                                       bool* single_buffer, bool* samples_signed,
                                       uint32_t* max_buffer_length, uint8_t* spacing) {
     const audiosample_p_t *proto = mp_proto_get_or_throw(MP_QSTR_protocol_audiosample, sample_obj);
-    proto->get_buffer_structure(MP_OBJ_TO_PTR(sample_obj), single_channel, single_buffer,
+    proto->get_buffer_structure(MP_OBJ_TO_PTR(sample_obj), single_buffer,
         samples_signed, max_buffer_length, spacing);
 }

--- a/shared-module/audiocore/__init__.h
+++ b/shared-module/audiocore/__init__.h
@@ -45,12 +45,10 @@ typedef uint8_t (*audiosample_channel_count_fun)(mp_obj_t);
 typedef void (*audiosample_reset_buffer_fun)(mp_obj_t,
         bool single_channel, uint8_t audio_channel);
 typedef audioio_get_buffer_result_t (*audiosample_get_buffer_fun)(mp_obj_t,
-        bool single_channel, uint8_t channel, uint8_t** buffer,
-        uint32_t* buffer_length);
+        uint8_t** buffer, uint32_t* buffer_length);
 typedef void (*audiosample_get_buffer_structure_fun)(mp_obj_t,
-        bool single_channel, bool* single_buffer,
-        bool* samples_signed, uint32_t *max_buffer_length,
-        uint8_t* spacing);
+        bool* single_buffer, bool* samples_signed,
+        uint32_t *max_buffer_length, uint8_t* spacing);
 
 typedef struct _audiosample_p_t {
     MP_PROTOCOL_HEAD // MP_QSTR_protocol_audiosample
@@ -67,10 +65,8 @@ uint8_t audiosample_bits_per_sample(mp_obj_t sample_obj);
 uint8_t audiosample_channel_count(mp_obj_t sample_obj);
 void audiosample_reset_buffer(mp_obj_t sample_obj, bool single_channel, uint8_t audio_channel);
 audioio_get_buffer_result_t audiosample_get_buffer(mp_obj_t sample_obj,
-                                                   bool single_channel,
-                                                   uint8_t channel,
                                                    uint8_t** buffer, uint32_t* buffer_length);
-void audiosample_get_buffer_structure(mp_obj_t sample_obj, bool single_channel,
+void audiosample_get_buffer_structure(mp_obj_t sample_obj,
                                       bool* single_buffer, bool* samples_signed,
                                       uint32_t* max_buffer_length, uint8_t* spacing);
 

--- a/shared-module/audiocore/__init__.h
+++ b/shared-module/audiocore/__init__.h
@@ -39,14 +39,14 @@ typedef enum {
     GET_BUFFER_ERROR,           // Error while reading data.
 } audioio_get_buffer_result_t;
 
-typedef uint32_t (*audiosample_sample_rate_fun)(mp_obj_t);
-typedef uint8_t (*audiosample_bits_per_sample_fun)(mp_obj_t);
-typedef uint8_t (*audiosample_channel_count_fun)(mp_obj_t);
-typedef void (*audiosample_reset_buffer_fun)(mp_obj_t,
+typedef uint32_t (*audiosample_sample_rate_fun)(void*);
+typedef uint8_t (*audiosample_bits_per_sample_fun)(void*);
+typedef uint8_t (*audiosample_channel_count_fun)(void*);
+typedef void (*audiosample_reset_buffer_fun)(void*,
         bool single_channel, uint8_t audio_channel);
-typedef audioio_get_buffer_result_t (*audiosample_get_buffer_fun)(mp_obj_t,
+typedef audioio_get_buffer_result_t (*audiosample_get_buffer_fun)(void*,
         uint8_t** buffer, uint32_t* buffer_length);
-typedef void (*audiosample_get_buffer_structure_fun)(mp_obj_t,
+typedef void (*audiosample_get_buffer_structure_fun)(void*,
         bool* single_buffer, bool* samples_signed,
         uint32_t *max_buffer_length, uint8_t* spacing);
 

--- a/shared-module/audiocore/__init__.h
+++ b/shared-module/audiocore/__init__.h
@@ -48,7 +48,7 @@ typedef audioio_get_buffer_result_t (*audiosample_get_buffer_fun)(void*,
         uint8_t** buffer, uint32_t* buffer_length);
 typedef void (*audiosample_get_buffer_structure_fun)(void*,
         bool* single_buffer, bool* samples_signed,
-        uint32_t *max_buffer_length, uint8_t* spacing);
+        uint32_t *max_buffer_length);
 
 typedef struct _audiosample_p_t {
     MP_PROTOCOL_HEAD // MP_QSTR_protocol_audiosample
@@ -68,6 +68,6 @@ audioio_get_buffer_result_t audiosample_get_buffer(mp_obj_t sample_obj,
                                                    uint8_t** buffer, uint32_t* buffer_length);
 void audiosample_get_buffer_structure(mp_obj_t sample_obj,
                                       bool* single_buffer, bool* samples_signed,
-                                      uint32_t* max_buffer_length, uint8_t* spacing);
+                                      uint32_t* max_buffer_length);
 
 #endif  // MICROPY_INCLUDED_SHARED_MODULE_AUDIOCORE__INIT__H

--- a/shared-module/audiomixer/Mixer.c
+++ b/shared-module/audiomixer/Mixer.c
@@ -72,15 +72,18 @@ bool common_hal_audiomixer_mixer_deinited(audiomixer_mixer_obj_t* self) {
     return self->first_buffer == NULL;
 }
 
-uint32_t common_hal_audiomixer_mixer_get_sample_rate(audiomixer_mixer_obj_t* self) {
+uint32_t common_hal_audiomixer_mixer_get_sample_rate(void* self_in) {
+    audiomixer_mixer_obj_t* self = self_in;
     return self->sample_rate;
 }
 
-uint8_t common_hal_audiomixer_mixer_get_channel_count(audiomixer_mixer_obj_t* self) {
+uint8_t common_hal_audiomixer_mixer_get_channel_count(void* self_in) {
+    audiomixer_mixer_obj_t* self = self_in;
     return self->channel_count;
 }
 
-uint8_t common_hal_audiomixer_mixer_get_bits_per_sample(audiomixer_mixer_obj_t* self) {
+uint8_t common_hal_audiomixer_mixer_get_bits_per_sample(void* self_in) {
+    audiomixer_mixer_obj_t* self = self_in;
     return self->bits_per_sample;
 }
 
@@ -93,9 +96,10 @@ bool common_hal_audiomixer_mixer_get_playing(audiomixer_mixer_obj_t* self) {
     return false;
 }
 
-void audiomixer_mixer_reset_buffer(audiomixer_mixer_obj_t* self,
+void audiomixer_mixer_reset_buffer(void* self_in,
                                    bool single_channel,
                                    uint8_t channel) {
+    audiomixer_mixer_obj_t* self = self_in;
     for (uint8_t i = 0; i < self->voice_count; i++) {
         common_hal_audiomixer_mixervoice_stop(self->voice[i]);
     }
@@ -240,9 +244,10 @@ static void mix_one_voice(audiomixer_mixer_obj_t* self,
     }
 }
 
-audioio_get_buffer_result_t audiomixer_mixer_get_buffer(audiomixer_mixer_obj_t* self,
+audioio_get_buffer_result_t audiomixer_mixer_get_buffer(void *self_in,
                                                         uint8_t** buffer,
                                                         uint32_t* buffer_length) {
+    audiomixer_mixer_obj_t* self = self_in;
     *buffer_length = self->len;
 
     uint32_t* word_buffer;
@@ -279,9 +284,10 @@ audioio_get_buffer_result_t audiomixer_mixer_get_buffer(audiomixer_mixer_obj_t* 
     return GET_BUFFER_MORE_DATA;
 }
 
-void audiomixer_mixer_get_buffer_structure(audiomixer_mixer_obj_t* self,
+void audiomixer_mixer_get_buffer_structure(void* self_in,
                                         bool* single_buffer, bool* samples_signed,
                                         uint32_t* max_buffer_length, uint8_t* spacing) {
+    audiomixer_mixer_obj_t* self = self_in;
     *single_buffer = false;
     *samples_signed = self->samples_signed;
     *max_buffer_length = self->len;

--- a/shared-module/audiomixer/Mixer.c
+++ b/shared-module/audiomixer/Mixer.c
@@ -286,10 +286,9 @@ audioio_get_buffer_result_t audiomixer_mixer_get_buffer(void *self_in,
 
 void audiomixer_mixer_get_buffer_structure(void* self_in,
                                         bool* single_buffer, bool* samples_signed,
-                                        uint32_t* max_buffer_length, uint8_t* spacing) {
+                                        uint32_t* max_buffer_length) {
     audiomixer_mixer_obj_t* self = self_in;
     *single_buffer = false;
     *samples_signed = self->samples_signed;
     *max_buffer_length = self->len;
-    *spacing = 1;
 }

--- a/shared-module/audiomixer/Mixer.c
+++ b/shared-module/audiomixer/Mixer.c
@@ -101,213 +101,60 @@ void audiomixer_mixer_reset_buffer(audiomixer_mixer_obj_t* self,
     }
 }
 
-uint32_t add8signed(uint32_t a, uint32_t b) {
-    #if (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1)) //Cortex-M4 w/FPU
-    return __SHADD8(a, b);
-    #else
-    uint32_t result = 0;
-    for (int8_t i = 0; i < 4; i++) {
-        int8_t ai = a >> (sizeof(int8_t) * 8 * i);
-        int8_t bi = b >> (sizeof(int8_t) * 8 * i);
-        int32_t intermediate = (int32_t) ai + bi / 2;
-        if (intermediate > CHAR_MAX) {
-            intermediate = CHAR_MAX;
-        } else if (intermediate < CHAR_MIN) {
-            intermediate = CHAR_MIN;
-        }
-        result |= ((uint32_t) intermediate & 0xff) << (sizeof(int8_t) * 8 * i);
-    }
-    return result;
-    #endif
+__attribute__((always_inline))
+static inline uint32_t add16signed(uint32_t a, uint32_t b) {
+    return __QADD16(a, b);
 }
 
-uint32_t add8unsigned(uint32_t a, uint32_t b) {
-    #if (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1)) //Cortex-M4 w/FPU
-    return __UHADD8(a, b);
-    #else
-    uint32_t result = 0;
-    for (int8_t i = 0; i < 4; i++) {
-        uint8_t ai = (a >> (sizeof(uint8_t) * 8 * i));
-        uint8_t bi = (b >> (sizeof(uint8_t) * 8 * i));
-        int32_t intermediate = (int32_t) (ai + bi) / 2;
-        if (intermediate > UCHAR_MAX) {
-            intermediate = UCHAR_MAX;
-        }
-        result |= ((uint32_t) intermediate & 0xff) << (sizeof(uint8_t) * 8 * i);
-    }
-    return result;
-    #endif
-}
-
-uint32_t add16signed(uint32_t a, uint32_t b) {
-    #if (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1)) //Cortex-M4 w/FPU
-    return __SHADD16(a, b);
-    #else
-    uint32_t result = 0;
-    for (int8_t i = 0; i < 2; i++) {
-        int16_t ai = a >> (sizeof(int16_t) * 8 * i);
-        int16_t bi = b >> (sizeof(int16_t) * 8 * i);
-        int32_t intermediate = (int32_t) ai + bi / 2;
-        if (intermediate > SHRT_MAX) {
-            intermediate = SHRT_MAX;
-        } else if (intermediate < SHRT_MIN) {
-            intermediate = SHRT_MIN;
-        }
-        result |= (((uint32_t) intermediate) & 0xffff) << (sizeof(int16_t) * 8 * i);
-    }
-    return result;
-    #endif
-}
-
-uint32_t add16unsigned(uint32_t a, uint32_t b) {
-    #if (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1)) //Cortex-M4 w/FPU
-    return __UHADD16(a, b);
-    #else
-    uint32_t result = 0;
-    for (int8_t i = 0; i < 2; i++) {
-        int16_t ai = (a >> (sizeof(uint16_t) * 8 * i)) - 0x8000;
-        int16_t bi = (b >> (sizeof(uint16_t) * 8 * i)) - 0x8000;
-        int32_t intermediate = (int32_t) ai + bi / 2;
-        if (intermediate > USHRT_MAX) {
-            intermediate = USHRT_MAX;
-        }
-        result |= ((uint32_t) intermediate & 0xffff) << (sizeof(int16_t) * 8 * i);
-    }
-    return result;
-    #endif
-}
-
-static inline uint32_t mult8unsigned(uint32_t val, int32_t mul) {
-    // if mul == 0, no need in wasting cycles
-    if (mul == 0) {
-        return 0;
-    }
-    /* TODO: workout ARMv7 instructions
-    #if (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1)) //Cortex-M4 w/FPU
-    return val;
-    #else*/
-    uint32_t result = 0;
-    float mod_mul = (float) mul / (float) ((1<<15)-1);
-    for (int8_t i = 0; i < 4; i++) {
-        uint8_t ai = val >> (sizeof(uint8_t) * 8 * i);
-        int32_t intermediate = ai * mod_mul;
-        if (intermediate > SHRT_MAX) {
-            intermediate = SHRT_MAX;
-        }
-        result |= ((uint32_t) intermediate & 0xff) << (sizeof(uint8_t) * 8 * i);
-    }
-
-    return result;
-    //#endif
-}
-
-static inline uint32_t mult8signed(uint32_t val, int32_t mul) {
-    // if mul == 0, no need in wasting cycles
-    if (mul == 0) {
-        return 0;
-    }
-    /* TODO: workout ARMv7 instructions
-    #if (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1)) //Cortex-M4 w/FPU
-    return val;
-    #else
-    */
-    uint32_t result = 0;
-    float mod_mul = (float)mul / (float)((1<<15)-1);
-    for (int8_t i = 0; i < 4; i++) {
-        int16_t ai = val >> (sizeof(int8_t) * 8 * i);
-        int32_t intermediate = ai * mod_mul;
-        if (intermediate > CHAR_MAX) {
-            intermediate = CHAR_MAX;
-        } else if (intermediate < CHAR_MIN) {
-            intermediate = CHAR_MIN;
-        }
-        result |= (((uint32_t) intermediate) & 0xff) << (sizeof(int16_t) * 8 * i);
-    }
-    return result;
-    //#endif
-}
-
-//TODO:
-static inline uint32_t mult16unsigned(uint32_t val, int32_t mul) {
-    // if mul == 0, no need in wasting cycles
-    if (mul == 0) {
-        return 0;
-    }
-    /* TODO: the below ARMv7m instructions "work", but the amplitude is much higher/louder
-    #if (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1)) //Cortex-M4 w/FPU
-    // there is no unsigned equivalent to the 'SMULWx' ARMv7 Thumb function,
-    // so we have to do it by hand.
-    uint32_t lo = val & 0xffff;
-    uint32_t hi = val >> 16;
-    //mp_printf(&mp_plat_print, "pre-asm: (mul: %d)\n\tval: %x\tlo: %x\thi: %x\n", mul, val, lo, hi);
-    uint32_t val_lo;
-    asm volatile("mul %0, %1, %2" : "=r" (val_lo) : "r" (mul), "r" (lo));
-    asm volatile("mla %0, %1, %2, %3" : "=r" (val) : "r" (mul), "r" (hi), "r" (val_lo));
-    //mp_printf(&mp_plat_print, "post-asm:\n\tval: %x\tlo: %x\n\n", val, val_lo);
-    return val;
-    #else
-    */
-    uint32_t result = 0;
-    float mod_mul = (float)mul / (float)((1<<15)-1);
-    for (int8_t i = 0; i < 2; i++) {
-        int16_t ai = (val >> (sizeof(uint16_t) * 8 * i)) - 0x8000;
-        int32_t intermediate = ai * mod_mul;
-        if (intermediate > SHRT_MAX) {
-            intermediate = SHRT_MAX;
-        } else if (intermediate < SHRT_MIN) {
-            intermediate = SHRT_MIN;
-        }
-        result |= (((uint32_t) intermediate) + 0x8000) << (sizeof(int16_t) * 8 * i);
-    }
-    return result;
-    //#endif
-}
-
+__attribute__((always_inline))
 static inline uint32_t mult16signed(uint32_t val, int32_t mul) {
-    // if mul == 0, no need in wasting cycles
-    if (mul == 0) {
-        return 0;
-    }
-    #if (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1)) //Cortex-M4 w/FPU
+    mul <<= 16;
     int32_t hi, lo;
     enum { bits = 16 }; // saturate to 16 bits
-    enum { shift = 0 }; // shift is done automatically
+    enum { shift = 15 }; // shift is done automatically
     asm volatile("smulwb %0, %1, %2" : "=r" (lo) : "r" (mul), "r" (val));
     asm volatile("smulwt %0, %1, %2" : "=r" (hi) : "r" (mul), "r" (val));
     asm volatile("ssat %0, %1, %2, asr %3" : "=r" (lo) : "I" (bits), "r" (lo), "I" (shift));
     asm volatile("ssat %0, %1, %2, asr %3" : "=r" (hi) : "I" (bits), "r" (hi), "I" (shift));
     asm volatile("pkhbt %0, %1, %2, lsl #16" : "=r" (val) : "r" (lo), "r" (hi)); // pack
     return val;
-    #else
-    uint32_t result = 0;
-    float mod_mul = (float)mul / (float)((1<<15)-1);
-    for (int8_t i = 0; i < 2; i++) {
-        int16_t ai = val >> (sizeof(int16_t) * 8 * i);
-        int32_t intermediate = ai * mod_mul;
-        if (intermediate > SHRT_MAX) {
-            intermediate = SHRT_MAX;
-        } else if (intermediate < SHRT_MIN) {
-            intermediate = SHRT_MIN;
-        }
-        result |= (((uint32_t) intermediate) & 0xffff) << (sizeof(int16_t) * 8 * i);
-    }
-    return result;
-    #endif
 }
 
+static inline uint32_t tounsigned8(uint32_t val) {
+    return __UADD8(val, 0x80808080);
+}
+
+static inline uint32_t tounsigned16(uint32_t val) {
+    return __UADD16(val, 0x80008000);
+}
+
+static inline uint32_t tosigned16(uint32_t val) {
+    return __UADD16(val, 0x80008000);
+}
+
+static inline uint32_t unpack8(uint16_t val) {
+    return ((val & 0xff00) << 16) | ((val & 0x00ff) << 8);
+}
+
+static inline uint32_t pack8(uint32_t val) {
+    return ((val & 0xff000000) >> 16) | ((val & 0xff00) >> 8);
+}
+
+#define LIKELY(x) (__builtin_expect(!!(x), 1))
+#define UNLIKELY(x) (__builtin_expect(!!(x), 0))
 static void mix_one_voice(audiomixer_mixer_obj_t* self,
         audiomixer_mixervoice_obj_t* voice, bool voices_active,
         uint32_t* word_buffer, uint32_t length) {
-    uint32_t j = 0;
     bool voice_done = voice->sample == NULL;
-    for (uint32_t i = 0; i < length; i++) {
-        if (!voice_done && j >= voice->buffer_length) {
+    while (!voice_done && length != 0) {
+        if (voice->buffer_length == 0) {
             if (!voice->more_data) {
                 if (voice->loop) {
                     audiosample_reset_buffer(voice->sample, false, 0);
                 } else {
                     voice->sample = NULL;
                     voice_done = true;
+                    break;
                 }
             }
             if (!voice_done) {
@@ -316,64 +163,81 @@ static void mix_one_voice(audiomixer_mixer_obj_t* self,
                 // Track length in terms of words.
                 voice->buffer_length /= sizeof(uint32_t);
                 voice->more_data = result == GET_BUFFER_MORE_DATA;
-                j = 0;
             }
         }
+
+        uint32_t n = MIN(voice->buffer_length, length);
+        uint32_t *src = voice->remaining_buffer;
+        uint16_t level = voice->level;
+
         // First active voice gets copied over verbatim.
-        uint32_t sample_value;
-        if (voice_done) {
-            // Exit early if another voice already set all samples once.
-            if (voices_active) {
-                continue;
-            }
-            sample_value = 0;
-            if (!self->samples_signed) {
-                if (self->bits_per_sample == 8) {
-                    sample_value = 0x7f7f7f7f;
-                } else {
-                    sample_value = 0x7fff7fff;
-                }
-            }
-        } else {
-            sample_value = voice->remaining_buffer[j];
-        }
-
-        // apply the mixer level
-        if (!self->samples_signed) {
-            if (self->bits_per_sample == 8) {
-                sample_value = mult8unsigned(sample_value, voice->level);
-            } else {
-                sample_value = mult16unsigned(sample_value, voice->level);
-            }
-        } else {
-            if (self->bits_per_sample == 8) {
-                sample_value = mult8signed(sample_value, voice->level);
-            } else {
-                sample_value = mult16signed(sample_value, voice->level);
-            }
-        }
-
         if (!voices_active) {
-            word_buffer[i] = sample_value;
-        } else {
-            if (self->bits_per_sample == 8) {
-                if (self->samples_signed) {
-                    word_buffer[i] = add8signed(word_buffer[i], sample_value);
+            if (LIKELY(self->bits_per_sample == 16)) {
+                if (LIKELY(self->samples_signed)) {
+                    for (uint32_t i = 0; i<n; i++) {
+                        uint32_t v = src[i];
+                        word_buffer[i] = mult16signed(v, level);
+                    }
                 } else {
-                    word_buffer[i] = add8unsigned(word_buffer[i], sample_value);
+                    for (uint32_t i = 0; i<n; i++) {
+                        uint32_t v = src[i];
+                        v = tosigned16(v);
+                        word_buffer[i] = mult16signed(v, level);
+                    }
                 }
             } else {
-                if (self->samples_signed) {
-                    word_buffer[i] = add16signed(word_buffer[i], sample_value);
+                uint16_t *hword_buffer = (uint16_t*)word_buffer;
+                uint16_t *hsrc = (uint16_t*)src;
+                for (uint32_t i = 0; i<n*2; i++) {
+                    uint32_t word = unpack8(hsrc[i]);
+                    if (LIKELY(!self->samples_signed)) {
+                        word = tosigned16(word);
+                    }
+                    word = mult16signed(word, level);
+                    hword_buffer[i] = pack8(word);
+                }
+            }
+        } else {
+            if (LIKELY(self->bits_per_sample == 16)) {
+                if (LIKELY(self->samples_signed)) {
+                    for (uint32_t i = 0; i<n; i++) {
+                        uint32_t word = src[i];
+                        word_buffer[i] = add16signed(mult16signed(word, level), word_buffer[i]);
+                    }
                 } else {
-                    word_buffer[i] = add16unsigned(word_buffer[i], sample_value);
+                    for (uint32_t i = 0; i<n; i++) {
+                        uint32_t word = src[i];
+                        word = tosigned16(word);
+                        word_buffer[i] = add16signed(mult16signed(word, level), word_buffer[i]);
+                        }
+                }
+            } else {
+                uint16_t *hword_buffer = (uint16_t*)word_buffer;
+                uint16_t *hsrc = (uint16_t*)src;
+                for (uint32_t i = 0; i<n*2; i++) {
+                    uint32_t word = unpack8(hsrc[i]);
+                    if (LIKELY(!self->samples_signed)) {
+                        word = tosigned16(word);
+                    }
+                    word = mult16signed(word, level);
+                    word = add16signed(word, unpack8(hword_buffer[i]));
+                    hword_buffer[i] = pack8(word);
                 }
             }
         }
-        j++;
+        length -= n;
+        word_buffer += n;
+        voice->remaining_buffer += n;
+        voice->buffer_length -= n;
     }
-    voice->buffer_length -= j;
-    voice->remaining_buffer += j;
+
+    if (length && !voices_active) {
+        uint32_t sample_value = self->bits_per_sample == 8
+            ?  0x80808080 : 0x80008000;
+        for (uint32_t i = 0; i<length; i++) {
+            word_buffer[i] = sample_value;
+        }
+    }
 }
 
 audioio_get_buffer_result_t audiomixer_mixer_get_buffer(audiomixer_mixer_obj_t* self,
@@ -403,11 +267,25 @@ audioio_get_buffer_result_t audiomixer_mixer_get_buffer(audiomixer_mixer_obj_t* 
         }
         self->use_first_buffer = !self->use_first_buffer;
         bool voices_active = false;
+        uint32_t length = self->len / sizeof(uint32_t);
+
         for (int32_t v = 0; v < self->voice_count; v++) {
             audiomixer_mixervoice_obj_t* voice = MP_OBJ_TO_PTR(self->voice[v]);
 
-            mix_one_voice(self, voice, voices_active, word_buffer, self->len / sizeof(uint32_t));
+            mix_one_voice(self, voice, voices_active, word_buffer, length);
             voices_active = true;
+        }
+
+        if (!self->samples_signed) {
+            if (self->bits_per_sample == 16) {
+                for (uint32_t i = 0; i < length; i++) {
+                    word_buffer[i] = tounsigned16(word_buffer[i]);
+                }
+            } else {
+                for (uint32_t i = 0; i < length; i++) {
+                    word_buffer[i] = tounsigned8(word_buffer[i]);
+                }
+            }
         }
 
         self->read_count += 1;

--- a/shared-module/audiomixer/Mixer.h
+++ b/shared-module/audiomixer/Mixer.h
@@ -43,10 +43,6 @@ typedef struct {
     uint8_t channel_count;
     uint32_t sample_rate;
 
-    uint32_t read_count;
-    uint32_t left_read_count;
-    uint32_t right_read_count;
-
     uint8_t voice_count;
     mp_obj_tuple_t *voice_tuple;
     mp_obj_t voice[];
@@ -58,11 +54,9 @@ void audiomixer_mixer_reset_buffer(audiomixer_mixer_obj_t* self,
                                     bool single_channel,
                                     uint8_t channel);
 audioio_get_buffer_result_t audiomixer_mixer_get_buffer(audiomixer_mixer_obj_t* self,
-                                                         bool single_channel,
-                                                         uint8_t channel,
                                                          uint8_t** buffer,
                                                          uint32_t* buffer_length); // length in bytes
-void audiomixer_mixer_get_buffer_structure(audiomixer_mixer_obj_t* self, bool single_channel,
+void audiomixer_mixer_get_buffer_structure(audiomixer_mixer_obj_t* self,
                                             bool* single_buffer, bool* samples_signed,
                                             uint32_t* max_buffer_length, uint8_t* spacing);
 

--- a/shared-module/audiomixer/Mixer.h
+++ b/shared-module/audiomixer/Mixer.h
@@ -50,13 +50,13 @@ typedef struct {
 
 
 // These are not available from Python because it may be called in an interrupt.
-void audiomixer_mixer_reset_buffer(audiomixer_mixer_obj_t* self,
+void audiomixer_mixer_reset_buffer(void* self_in,
                                     bool single_channel,
                                     uint8_t channel);
-audioio_get_buffer_result_t audiomixer_mixer_get_buffer(audiomixer_mixer_obj_t* self,
+audioio_get_buffer_result_t audiomixer_mixer_get_buffer(void* self_in,
                                                          uint8_t** buffer,
                                                          uint32_t* buffer_length); // length in bytes
-void audiomixer_mixer_get_buffer_structure(audiomixer_mixer_obj_t* self,
+void audiomixer_mixer_get_buffer_structure(void* self_in,
                                             bool* single_buffer, bool* samples_signed,
                                             uint32_t* max_buffer_length, uint8_t* spacing);
 

--- a/shared-module/audiomixer/Mixer.h
+++ b/shared-module/audiomixer/Mixer.h
@@ -58,6 +58,6 @@ audioio_get_buffer_result_t audiomixer_mixer_get_buffer(void* self_in,
                                                          uint32_t* buffer_length); // length in bytes
 void audiomixer_mixer_get_buffer_structure(void* self_in,
                                             bool* single_buffer, bool* samples_signed,
-                                            uint32_t* max_buffer_length, uint8_t* spacing);
+                                            uint32_t* max_buffer_length);
 
 #endif // MICROPY_INCLUDED_SHARED_MODULE_AUDIOMIXER_MIXER_H

--- a/shared-module/audiomixer/MixerVoice.c
+++ b/shared-module/audiomixer/MixerVoice.c
@@ -63,7 +63,7 @@ void common_hal_audiomixer_mixervoice_play(audiomixer_mixervoice_obj_t* self, mp
     bool samples_signed;
     uint32_t max_buffer_length;
     uint8_t spacing;
-    audiosample_get_buffer_structure(sample, false, &single_buffer, &samples_signed,
+    audiosample_get_buffer_structure(sample, &single_buffer, &samples_signed,
                                      &max_buffer_length, &spacing);
     if (samples_signed != self->parent->samples_signed) {
         mp_raise_ValueError(translate("The sample's signedness does not match the mixer's"));
@@ -72,7 +72,7 @@ void common_hal_audiomixer_mixervoice_play(audiomixer_mixervoice_obj_t* self, mp
     self->loop = loop;
 
     audiosample_reset_buffer(sample, false, 0);
-    audioio_get_buffer_result_t result = audiosample_get_buffer(sample, false, 0, (uint8_t**) &self->remaining_buffer, &self->buffer_length);
+    audioio_get_buffer_result_t result = audiosample_get_buffer(sample, (uint8_t**) &self->remaining_buffer, &self->buffer_length);
     // Track length in terms of words.
     self->buffer_length /= sizeof(uint32_t);
     self->more_data = result == GET_BUFFER_MORE_DATA;

--- a/shared-module/audiomixer/MixerVoice.c
+++ b/shared-module/audiomixer/MixerVoice.c
@@ -62,9 +62,8 @@ void common_hal_audiomixer_mixervoice_play(audiomixer_mixervoice_obj_t* self, mp
     bool single_buffer;
     bool samples_signed;
     uint32_t max_buffer_length;
-    uint8_t spacing;
     audiosample_get_buffer_structure(sample, &single_buffer, &samples_signed,
-                                     &max_buffer_length, &spacing);
+                                     &max_buffer_length);
     if (samples_signed != self->parent->samples_signed) {
         mp_raise_ValueError(translate("The sample's signedness does not match the mixer's"));
     }

--- a/shared-module/audiomixer/MixerVoice.c
+++ b/shared-module/audiomixer/MixerVoice.c
@@ -34,7 +34,7 @@
 
 void common_hal_audiomixer_mixervoice_construct(audiomixer_mixervoice_obj_t *self) {
     self->sample = NULL;
-    self->level = ((1 << 15) - 1);
+    self->level = 1 << 15;
 }
 
 void common_hal_audiomixer_mixervoice_set_parent(audiomixer_mixervoice_obj_t* self, audiomixer_mixer_obj_t *parent) {
@@ -42,11 +42,11 @@ void common_hal_audiomixer_mixervoice_set_parent(audiomixer_mixervoice_obj_t* se
 }
 
 float common_hal_audiomixer_mixervoice_get_level(audiomixer_mixervoice_obj_t* self) {
-	return ((float) self->level / ((1 << 15) - 1));
+	return ((float) self->level / (1 << 15));
 }
 
 void common_hal_audiomixer_mixervoice_set_level(audiomixer_mixervoice_obj_t* self, float level) {
-	self->level = level * ((1 << 15)-1);
+	self->level = level * (1 << 15);
 }
 
 void common_hal_audiomixer_mixervoice_play(audiomixer_mixervoice_obj_t* self, mp_obj_t sample, bool loop) {

--- a/shared-module/audiomixer/MixerVoice.h
+++ b/shared-module/audiomixer/MixerVoice.h
@@ -39,7 +39,7 @@ typedef struct {
     bool more_data;
     uint32_t* remaining_buffer;
     uint32_t buffer_length;
-    int16_t level;
+    uint16_t level;
 } audiomixer_mixervoice_obj_t;
 
 

--- a/shared-module/audiomp3/MP3Decoder.c
+++ b/shared-module/audiomp3/MP3Decoder.c
@@ -51,8 +51,8 @@
  * Sets self->eof if any read of the file returns 0 bytes
  */
 STATIC bool mp3file_update_inbuf(audiomp3_mp3file_obj_t* self) {
-    // If buffer is over half full, do nothing
-    if (self->inbuf_offset < self->inbuf_length/2) return true;
+    // If there's not even a full block to read, do nothing
+    if (self->inbuf_offset < 512) return true;
 
     // If we didn't previously reach the end of file, we can try reading now
     if (!self->eof) {
@@ -213,7 +213,7 @@ void common_hal_audiomp3_mp3file_set_file(audiomp3_mp3file_obj_t* self, pyb_file
     f_lseek(&self->file->fp, 0);
     self->inbuf_offset = self->inbuf_length;
     self->eof = 0;
-    self->other_channel = -1;
+    self->read_count = self->channel_read_count[0] = self->channel_read_count[1] = 0;
     mp3file_update_inbuf(self);
     mp3file_find_sync_word(self);
     // It **SHOULD** not be necessary to do this; the buffer should be filled
@@ -280,7 +280,7 @@ void audiomp3_mp3file_reset_buffer(audiomp3_mp3file_obj_t* self,
     f_lseek(&self->file->fp, 0);
     self->inbuf_offset = self->inbuf_length;
     self->eof = 0;
-    self->other_channel = -1;
+    self->read_count = self->channel_read_count[0] = self->channel_read_count[1] = 0;
     mp3file_update_inbuf(self);
     mp3file_skip_id3v2(self);
     mp3file_find_sync_word(self);
@@ -300,29 +300,32 @@ audioio_get_buffer_result_t audiomp3_mp3file_get_buffer(audiomp3_mp3file_obj_t* 
 
     *buffer_length = self->frame_buffer_size;
 
-    if (channel == self->other_channel) {
-        *bufptr = (uint8_t*)(self->buffers[self->other_buffer_index] + channel);
-        self->other_channel = -1;
-        return GET_BUFFER_MORE_DATA;
-    }
+    uint32_t channel_read_count = self->channel_read_count[channel] ++;
+    bool need_more_data = self->read_count == channel_read_count;
 
+    uint32_t channel_offset = channel;
+    if(need_more_data) {
+        self->read_count ++;
+        int16_t *buffer = (int16_t *)(void *)self->buffers[self->buffer_index];
+        self->buffer_index = !self->buffer_index;
+        *bufptr = (uint8_t*)(buffer + channel_offset);
 
-    self->buffer_index = !self->buffer_index;
-    self->other_channel = 1-channel;
-    self->other_buffer_index = self->buffer_index;
-    int16_t *buffer = (int16_t *)(void *)self->buffers[self->buffer_index];
-    *bufptr = (uint8_t*)buffer;
-
-    mp3file_skip_id3v2(self);
-    if (!mp3file_find_sync_word(self)) {
-        return self->eof ? GET_BUFFER_DONE : GET_BUFFER_ERROR;
-    }
-    int bytes_left = BYTES_LEFT(self);
-    uint8_t *inbuf = READ_PTR(self);
-    int err = MP3Decode(self->decoder, &inbuf, &bytes_left, buffer, 0);
-    CONSUME(self, BYTES_LEFT(self) - bytes_left);
-    if (err) {
-        return GET_BUFFER_DONE;
+        mp3file_skip_id3v2(self);
+        if (!mp3file_find_sync_word(self)) {
+            return self->eof ? GET_BUFFER_DONE : GET_BUFFER_ERROR;
+        }
+        int bytes_left = BYTES_LEFT(self);
+        uint8_t *inbuf = READ_PTR(self);
+        int err = MP3Decode(self->decoder, &inbuf, &bytes_left, buffer, 0);
+        CONSUME(self, BYTES_LEFT(self) - bytes_left);
+        if (err) {
+            return GET_BUFFER_DONE;
+        }
+    } else {
+        uint32_t buffers_back = self->read_count - channel_read_count;
+        uint32_t buffer_index = (self->buffer_index - buffers_back) & 1;
+        int16_t *buffer = (int16_t *)(void *)self->buffers[buffer_index];
+        *bufptr = (uint8_t*)(buffer + channel_offset);
     }
 
     return GET_BUFFER_MORE_DATA;

--- a/shared-module/audiomp3/MP3Decoder.c
+++ b/shared-module/audiomp3/MP3Decoder.c
@@ -313,11 +313,10 @@ audioio_get_buffer_result_t audiomp3_mp3file_get_buffer(audiomp3_mp3file_obj_t* 
 
 void audiomp3_mp3file_get_buffer_structure(audiomp3_mp3file_obj_t* self,
                                            bool* single_buffer, bool* samples_signed,
-                                           uint32_t* max_buffer_length, uint8_t* spacing) {
+                                           uint32_t* max_buffer_length) {
     *single_buffer = false;
     *samples_signed = true;
     *max_buffer_length = self->frame_buffer_size;
-    *spacing = 1;
 }
 
 float common_hal_audiomp3_mp3file_get_rms_level(audiomp3_mp3file_obj_t* self) {

--- a/shared-module/audiomp3/MP3Decoder.h
+++ b/shared-module/audiomp3/MP3Decoder.h
@@ -49,9 +49,6 @@ typedef struct {
     uint8_t buffer_index;
     uint8_t channel_count;
     bool eof;
-
-    uint32_t read_count;
-    uint32_t channel_read_count[2];
 } audiomp3_mp3file_obj_t;
 
 // These are not available from Python because it may be called in an interrupt.
@@ -59,11 +56,9 @@ void audiomp3_mp3file_reset_buffer(audiomp3_mp3file_obj_t* self,
                                    bool single_channel,
                                    uint8_t channel);
 audioio_get_buffer_result_t audiomp3_mp3file_get_buffer(audiomp3_mp3file_obj_t* self,
-                                                        bool single_channel,
-                                                        uint8_t channel,
                                                         uint8_t** buffer,
                                                         uint32_t* buffer_length); // length in bytes
-void audiomp3_mp3file_get_buffer_structure(audiomp3_mp3file_obj_t* self, bool single_channel,
+void audiomp3_mp3file_get_buffer_structure(audiomp3_mp3file_obj_t* self,
                                            bool* single_buffer, bool* samples_signed,
                                            uint32_t* max_buffer_length, uint8_t* spacing);
 

--- a/shared-module/audiomp3/MP3Decoder.h
+++ b/shared-module/audiomp3/MP3Decoder.h
@@ -60,7 +60,7 @@ audioio_get_buffer_result_t audiomp3_mp3file_get_buffer(audiomp3_mp3file_obj_t* 
                                                         uint32_t* buffer_length); // length in bytes
 void audiomp3_mp3file_get_buffer_structure(audiomp3_mp3file_obj_t* self,
                                            bool* single_buffer, bool* samples_signed,
-                                           uint32_t* max_buffer_length, uint8_t* spacing);
+                                           uint32_t* max_buffer_length);
 
 float audiomp3_mp3file_get_rms_level(audiomp3_mp3file_obj_t* self);
 

--- a/shared-module/audiomp3/MP3Decoder.h
+++ b/shared-module/audiomp3/MP3Decoder.h
@@ -50,8 +50,8 @@ typedef struct {
     uint8_t channel_count;
     bool eof;
 
-    int8_t other_channel;
-    int8_t other_buffer_index;
+    uint32_t read_count;
+    uint32_t channel_read_count[2];
 } audiomp3_mp3file_obj_t;
 
 // These are not available from Python because it may be called in an interrupt.


### PR DESCRIPTION
While working on audio playback, I noticed that there were problems affecting only the right channel, and only on samd dac; not on i2s or on nrf.

These problems affected both the mp3 and mixer audio sources, and stem from the necessary handling of the "single_channel" flag to the "get_buffer" method being complicated and not (as far as I could see) documented.

Rather than fix the similar bug at least twice, I think it is preferable to shift the responsibility to the port that requires it, so that it can be gotten right once.

(Furthermore, I *suspect* that after a DMA overrun, there's simply no way to get the right data back in each channel, because in this case they may have been advanced independently and the series of "almost exactly alternating" calls to get_buffer per channel was broken)

So:
 * For samd51, add the concept of a "sibling" DMA channel.  When playing stereo on DAC, the left channel is made the "first" sibling (so its sibling channel number is the right channel number) and the right channel is made the second channel.
 * To facilitate this, the step of preloading audio blocks has to be split out, so that the channels can be linked at the right moment
 * Some details around stopping channels together

This touches a lot of stuff, so I'm leaving it in draft state until I get through this self-made testing checklist.  Also, I ended up writing it cumulative with #2526 because otherwise there would be conflicts between the two PRs; After that PR is merged this one should be rebased before its own merge.

Testing checklist (pygamer, DAC):
 * [X] Listen to the whole bartlebeats album in JEplayer without an audio glitch
 * [ ] Run through the RawSample test cases
 * [ ] Run through the WaveFile + AudioMixer test cases

Testing checlist (Metro M4 Express + I2S):
 * [ ] Run through the RawSample test cases
 * [ ] Run through the WaveFile + AudioMixer test cases

Testing checklist (Trinket M0 / Pyruler):
 * [ ] Run through the mono RawSample test cases