### PR TITLE
reset NeoPixels on soft reload on CPB, pybadge, and pygamer boards 

### DIFF
--- a/ports/atmel-samd/boards/circuitplayground_express/board.c
+++ b/ports/atmel-samd/boards/circuitplayground_express/board.c
@@ -28,9 +28,8 @@
 
 #include "boards/board.h"
 #include "common-hal/microcontroller/Pin.h"
+#include "supervisor/shared/board.h"
 #include "hal/include/hal_gpio.h"
-#include "shared-bindings/digitalio/DigitalInOut.h"
-#include "shared-bindings/neopixel_write/__init__.h"
 
 void board_init(void)
 {
@@ -54,12 +53,5 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
-    uint8_t empty[30];
-    memset(empty, 0, 30);
-    digitalio_digitalinout_obj_t neopixel_pin;
-    common_hal_digitalio_digitalinout_construct(&neopixel_pin, &pin_PB23);
-    common_hal_digitalio_digitalinout_switch_to_output(&neopixel_pin, false,
-        DRIVE_MODE_PUSH_PULL);
-    common_hal_neopixel_write(&neopixel_pin, empty, 30);
-    common_hal_digitalio_digitalinout_deinit(&neopixel_pin);
+    board_reset_user_neopixels();
 }

--- a/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
@@ -30,6 +30,8 @@
 // Increase stack size slightly due to CPX library import nesting
 #define CIRCUITPY_DEFAULT_STACK_SIZE  (4760) //divisible by 8
 
+#define USER_NEOPIXELS_PIN      (&pin_PB23)
+
 #define DEFAULT_I2C_BUS_SCL (&pin_PB03)
 #define DEFAULT_I2C_BUS_SDA (&pin_PB02)
 

--- a/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
@@ -24,6 +24,8 @@
 
 #define CALIBRATE_CRYSTALLESS 1
 
+#define USER_NEOPIXELS_PIN      (&pin_PB23)
+
 // Explanation of how a user got into safe mode.
 #define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
 

--- a/ports/atmel-samd/boards/circuitplayground_express_displayio/board.c
+++ b/ports/atmel-samd/boards/circuitplayground_express_displayio/board.c
@@ -29,8 +29,7 @@
 #include "boards/board.h"
 #include "common-hal/microcontroller/Pin.h"
 #include "hal/include/hal_gpio.h"
-#include "shared-bindings/digitalio/DigitalInOut.h"
-#include "shared-bindings/neopixel_write/__init__.h"
+#include "supervisor/shared/board.h"
 
 void board_init(void)
 {
@@ -54,12 +53,5 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
-    uint8_t empty[30];
-    memset(empty, 0, 30);
-    digitalio_digitalinout_obj_t neopixel_pin;
-    common_hal_digitalio_digitalinout_construct(&neopixel_pin, &pin_PB23);
-    common_hal_digitalio_digitalinout_switch_to_output(&neopixel_pin, false,
-        DRIVE_MODE_PUSH_PULL);
-    common_hal_neopixel_write(&neopixel_pin, empty, 30);
-    common_hal_digitalio_digitalinout_deinit(&neopixel_pin);
+    board_reset_user_neopixels();
 }

--- a/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
@@ -30,6 +30,8 @@
 // Increase stack size slightly due to CPX library import nesting.
 #define CIRCUITPY_DEFAULT_STACK_SIZE  (4760)  // divisible by 8
 
+#define USER_NEOPIXELS_PIN      (&pin_PB23)
+
 #define DEFAULT_I2C_BUS_SCL (&pin_PB03)
 #define DEFAULT_I2C_BUS_SDA (&pin_PB02)
 

--- a/ports/atmel-samd/boards/pybadge/board.c
+++ b/ports/atmel-samd/boards/pybadge/board.c
@@ -31,6 +31,7 @@
 #include "shared-bindings/displayio/FourWire.h"
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
+#include "supervisor/shared/board.h"
 #include "tick.h"
 
 displayio_fourwire_obj_t board_display_obj;
@@ -118,4 +119,5 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
+    board_reset_user_neopixels();
 }

--- a/ports/atmel-samd/boards/pybadge/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pybadge/mpconfigboard.h
@@ -14,6 +14,8 @@
 #define MICROPY_PORT_C (0)
 #define MICROPY_PORT_D (0)
 
+#define USER_NEOPIXELS_PIN      (&pin_PA15)
+
 #define DEFAULT_I2C_BUS_SCL (&pin_PA13)
 #define DEFAULT_I2C_BUS_SDA (&pin_PA12)
 

--- a/ports/atmel-samd/boards/pybadge_airlift/board.c
+++ b/ports/atmel-samd/boards/pybadge_airlift/board.c
@@ -31,6 +31,7 @@
 #include "shared-bindings/displayio/FourWire.h"
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
+#include "supervisor/shared/board.h"
 #include "tick.h"
 
 displayio_fourwire_obj_t board_display_obj;
@@ -96,4 +97,5 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
+    board_reset_user_neopixels();
 }

--- a/ports/atmel-samd/boards/pybadge_airlift/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pybadge_airlift/mpconfigboard.h
@@ -14,6 +14,8 @@
 #define MICROPY_PORT_C (0)
 #define MICROPY_PORT_D (0)
 
+#define USER_NEOPIXELS_PIN      (&pin_PA15)
+
 #define DEFAULT_I2C_BUS_SCL (&pin_PA13)
 #define DEFAULT_I2C_BUS_SDA (&pin_PA12)
 

--- a/ports/atmel-samd/boards/pygamer/board.c
+++ b/ports/atmel-samd/boards/pygamer/board.c
@@ -31,6 +31,7 @@
 #include "shared-bindings/displayio/FourWire.h"
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
+#include "supervisor/shared/board.h"
 #include "tick.h"
 
 displayio_fourwire_obj_t board_display_obj;
@@ -118,4 +119,5 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
+    board_reset_user_neopixels();
 }

--- a/ports/atmel-samd/boards/pygamer/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pygamer/mpconfigboard.h
@@ -13,6 +13,8 @@
 #define MICROPY_PORT_C (0)
 #define MICROPY_PORT_D (0)
 
+#define USER_NEOPIXELS_PIN      (&pin_PA15)
+
 #define DEFAULT_I2C_BUS_SCL (&pin_PA13)
 #define DEFAULT_I2C_BUS_SDA (&pin_PA12)
 

--- a/ports/atmel-samd/boards/pygamer_advance/board.c
+++ b/ports/atmel-samd/boards/pygamer_advance/board.c
@@ -31,6 +31,7 @@
 #include "shared-bindings/displayio/FourWire.h"
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
+#include "supervisor/shared/board.h"
 #include "tick.h"
 
 displayio_fourwire_obj_t board_display_obj;
@@ -96,4 +97,5 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
+    board_reset_user_neopixels();
 }

--- a/ports/atmel-samd/boards/pygamer_advance/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pygamer_advance/mpconfigboard.h
@@ -13,6 +13,8 @@
 #define MICROPY_PORT_C (0)
 #define MICROPY_PORT_D (0)
 
+#define USER_NEOPIXELS_PIN      (&pin_PA15)
+
 #define DEFAULT_I2C_BUS_SCL (&pin_PA13)
 #define DEFAULT_I2C_BUS_SDA (&pin_PA12)
 

--- a/ports/nrf/boards/circuitplayground_bluefruit/board.c
+++ b/ports/nrf/boards/circuitplayground_bluefruit/board.c
@@ -28,6 +28,7 @@
 #include "mpconfigboard.h"
 #include "py/obj.h"
 #include "peripherals/nrf/pins.h"
+#include "supervisor/shared/board.h"
 
 #include "nrf_gpio.h"
 
@@ -47,4 +48,6 @@ void reset_board(void) {
                  NRF_GPIO_PIN_S0S1,
                  NRF_GPIO_PIN_NOSENSE);
     nrf_gpio_pin_write(POWER_SWITCH_PIN->number, false);
+
+    board_reset_user_neopixels();
 }

--- a/ports/nrf/boards/circuitplayground_bluefruit/mpconfigboard.h
+++ b/ports/nrf/boards/circuitplayground_bluefruit/mpconfigboard.h
@@ -54,6 +54,8 @@
 // Disables onboard peripherals and neopixels to save power.
 #define POWER_SWITCH_PIN            (&pin_P0_06)
 
+#define USER_NEOPIXELS_PIN          (&pin_P0_13)
+
 #define DEFAULT_I2C_BUS_SCL         (&pin_P0_04)
 #define DEFAULT_I2C_BUS_SDA         (&pin_P0_05)
 

--- a/supervisor/shared/board.c
+++ b/supervisor/shared/board.c
@@ -31,14 +31,18 @@
 
 #ifdef USER_NEOPIXELS_PIN
 
+// The maximum number of user neopixels right now is 10, on Circuit Playgrounds.
+// PyBadge and PyGamer have max 5
+#define USER_NEOPIXELS_MAX_COUNT 10
+
 void board_reset_user_neopixels(void) {
     // Turn off on-board NeoPixel string
-    uint8_t empty[30] = { 0 };
+    uint8_t empty[USER_NEOPIXELS_MAX_COUNT * 3] = { 0 };
     digitalio_digitalinout_obj_t neopixel_pin;
     common_hal_digitalio_digitalinout_construct(&neopixel_pin, USER_NEOPIXELS_PIN);
     common_hal_digitalio_digitalinout_switch_to_output(&neopixel_pin, false,
         DRIVE_MODE_PUSH_PULL);
-    common_hal_neopixel_write(&neopixel_pin, empty, 30);
+    common_hal_neopixel_write(&neopixel_pin, empty, USER_NEOPIXELS_MAX_COUNT * 3);
     common_hal_digitalio_digitalinout_deinit(&neopixel_pin);
 }
 

--- a/supervisor/shared/board.c
+++ b/supervisor/shared/board.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2020 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,34 +24,22 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
-
-#include "boards/board.h"
-#include "common-hal/microcontroller/Pin.h"
-#include "hal/include/hal_gpio.h"
 #include "supervisor/shared/board.h"
 
-void board_init(void)
-{
+#include "shared-bindings/digitalio/DigitalInOut.h"
+#include "shared-bindings/neopixel_write/__init__.h"
+
+#ifdef USER_NEOPIXELS_PIN
+
+void board_reset_user_neopixels(void) {
+    // Turn off on-board NeoPixel string
+    uint8_t empty[30] = { 0 };
+    digitalio_digitalinout_obj_t neopixel_pin;
+    common_hal_digitalio_digitalinout_construct(&neopixel_pin, USER_NEOPIXELS_PIN);
+    common_hal_digitalio_digitalinout_switch_to_output(&neopixel_pin, false,
+        DRIVE_MODE_PUSH_PULL);
+    common_hal_neopixel_write(&neopixel_pin, empty, 30);
+    common_hal_digitalio_digitalinout_deinit(&neopixel_pin);
 }
 
-// Check the status of the two buttons on CircuitPlayground Express. If both are
-// pressed, then boot into user safe mode.
-bool board_requests_safe_mode(void) {
-    gpio_set_pin_function(PIN_PA14, GPIO_PIN_FUNCTION_OFF);
-    gpio_set_pin_direction(PIN_PA14, GPIO_DIRECTION_IN);
-    gpio_set_pin_pull_mode(PIN_PA14, GPIO_PULL_DOWN);
-
-    gpio_set_pin_function(PIN_PA28, GPIO_PIN_FUNCTION_OFF);
-    gpio_set_pin_direction(PIN_PA28, GPIO_DIRECTION_IN);
-    gpio_set_pin_pull_mode(PIN_PA28, GPIO_PULL_DOWN);
-    bool safe_mode = gpio_get_pin_level(PIN_PA14) &&
-        gpio_get_pin_level(PIN_PA28);
-    reset_pin_number(PIN_PA14);
-    reset_pin_number(PIN_PA28);
-    return safe_mode;
-}
-
-void reset_board(void) {
-    board_reset_user_neopixels();
-}
+#endif

--- a/supervisor/shared/board.h
+++ b/supervisor/shared/board.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2020 Dan Halbert for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,34 +24,15 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
+#ifndef MICROPY_INCLUDED_SUPERVISOR_BOARD_H
+#define MICROPY_INCLUDED_SUPERVISOR_BOARD_H
 
-#include "boards/board.h"
-#include "common-hal/microcontroller/Pin.h"
-#include "hal/include/hal_gpio.h"
-#include "supervisor/shared/board.h"
+#include "py/mpconfig.h"
 
-void board_init(void)
-{
-}
+#ifdef USER_NEOPIXELS_PIN
 
-// Check the status of the two buttons on CircuitPlayground Express. If both are
-// pressed, then boot into user safe mode.
-bool board_requests_safe_mode(void) {
-    gpio_set_pin_function(PIN_PA14, GPIO_PIN_FUNCTION_OFF);
-    gpio_set_pin_direction(PIN_PA14, GPIO_DIRECTION_IN);
-    gpio_set_pin_pull_mode(PIN_PA14, GPIO_PULL_DOWN);
+void board_reset_user_neopixels(void);
 
-    gpio_set_pin_function(PIN_PA28, GPIO_PIN_FUNCTION_OFF);
-    gpio_set_pin_direction(PIN_PA28, GPIO_DIRECTION_IN);
-    gpio_set_pin_pull_mode(PIN_PA28, GPIO_PULL_DOWN);
-    bool safe_mode = gpio_get_pin_level(PIN_PA14) &&
-        gpio_get_pin_level(PIN_PA28);
-    reset_pin_number(PIN_PA14);
-    reset_pin_number(PIN_PA28);
-    return safe_mode;
-}
+#endif
 
-void reset_board(void) {
-    board_reset_user_neopixels();
-}
+#endif  // MICROPY_INCLUDED_SUPERVISOR_BOARD_H

--- a/supervisor/supervisor.mk
+++ b/supervisor/supervisor.mk
@@ -2,6 +2,7 @@ SRC_SUPERVISOR = \
 	main.c \
 	supervisor/port.c \
 	supervisor/shared/autoreload.c \
+	supervisor/shared/board.c \
 	supervisor/shared/display.c \
 	supervisor/shared/filesystem.c \
 	supervisor/shared/flash.c \


### PR DESCRIPTION
Fixes #2341. Soft-reload was not turning off NeoPixels on Circuit Playground Bluefruit.

- Add code to CPB, pygamer boards, and pybadge boards `board.c` to turn off NeoPixels.
- Refactor the port-independent NeoPixel reset code to avoid code duplication. Add `supervisor/shared/board.c` for such common code.
- Allocate space on the stack for up to 24 NeoPixels in nrf `neopixel_write/__init__.c` to enable PWM-based NeoPixel writes without a VM but with the SoftDevice enabled. I chose 24 because it's less than 400 bytes on the stack, and will save a small amount of time for writes for up to 24 NeoPixels.