### PR TITLE
samd: When possible, use one DMA channel for stereo AudioOut

### DIFF
--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -203,13 +203,13 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t* dma,
     if (output_signed != samples_signed) {
         output_spacing = 1;
         max_buffer_length /= dma->spacing;
-        dma->first_buffer = (uint8_t*) m_malloc(max_buffer_length, false);
+        dma->first_buffer = (uint8_t*) m_realloc(dma->first_buffer, max_buffer_length);
         if (dma->first_buffer == NULL) {
             return AUDIO_DMA_MEMORY_ERROR;
         }
         dma->first_buffer_free = true;
         if (!single_buffer) {
-            dma->second_buffer = (uint8_t*) m_malloc(max_buffer_length, false);
+            dma->second_buffer = (uint8_t*) m_realloc(dma->second_buffer, max_buffer_length);
             if (dma->second_buffer == NULL) {
                 return AUDIO_DMA_MEMORY_ERROR;
             }

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -397,15 +397,22 @@ void common_hal_audioio_audioout_play(audioio_audioout_obj_t* self,
     if (self->right_channel == &pin_PA02) {
         right_channel_reg = (uint32_t) &DAC->DATABUF[0].reg;
     }
-    result = audio_dma_setup_playback(&self->left_dma, sample, loop, true, 0,
-                                      false /* output unsigned */,
-                                      left_channel_reg,
-                                      left_channel_trigger);
-    if (right_channel_reg != 0 && result == AUDIO_DMA_OK) {
-        result = audio_dma_setup_playback(&self->right_dma, sample, loop, true, 1,
+    if(right_channel_reg == left_channel_reg + 2 && audiosample_bits_per_sample(sample) == 16) {
+        result = audio_dma_setup_playback(&self->left_dma, sample, loop, false, 0,
                                           false /* output unsigned */,
-                                          right_channel_reg,
-                                          right_channel_trigger);
+                                          left_channel_reg,
+                                          left_channel_trigger);
+    } else {
+        result = audio_dma_setup_playback(&self->left_dma, sample, loop, true, 0,
+                                          false /* output unsigned */,
+                                          left_channel_reg,
+                                          left_channel_trigger);
+        if (right_channel_reg != 0 && result == AUDIO_DMA_OK) {
+            result = audio_dma_setup_playback(&self->right_dma, sample, loop, true, 1,
+                                              false /* output unsigned */,
+                                              right_channel_reg,
+                                              right_channel_trigger);
+        }
     }
     #endif
     if (result != AUDIO_DMA_OK) {


### PR DESCRIPTION
.. the documentation doesn't make this clear, but in practice it works to write both of the DATABUF registers at the same time.  This should also reduce the amount of wear and tear DMA puts on the system, as the number of transfers is cut in half.  (the number of bytes transferred remains the same, though)

In principle, this could cover all stereo cases if audio_dma_convert_signed also learned to 16-bit extend and swap values.  However, this is the case that matters for stereo mp3 playback on PyGamer.

Testing performed: Listened to some tracks with good stereo separation.

This will end up conflicting with #2533, which should be rebased if this is accepted first.  In fact, if this is accepted, then in lieu of #2533 it is probably better to extend audio_dma_convert_signed and ditch the sibling dma channel code.  Other parts of that PR would still apply, as far as getting rid of the "single channel" flags through the audio stack.