### PR TITLE
PacketBuffer.packet_size was returning bool instead of int

### DIFF
--- a/shared-bindings/_bleio/Characteristic.c
+++ b/shared-bindings/_bleio/Characteristic.c
@@ -49,7 +49,7 @@
 //|   as part of remote Services.
 //|
 
-//|   .. method:: add_to_service(service, uuid, *, properties=0, read_perm=`Attribute.OPEN`, write_perm=`Attribute.OPEN`, max_length=20, fixed_length=False, initial_value=None)
+//|   .. method:: add_to_service(service, uuid, *, properties=0, read_perm=Attribute.OPEN, write_perm=Attribute.OPEN, max_length=20, fixed_length=False, initial_value=None)
 //|
 //|     Create a new Characteristic object, and add it to this Service.
 //|

--- a/shared-bindings/_bleio/PacketBuffer.c
+++ b/shared-bindings/_bleio/PacketBuffer.c
@@ -163,13 +163,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_packet_buffer_deinit_obj, bleio_packet_bu
 
 //|   .. attribute:: packet_size
 //|
-//|     Maximum size of each packet in bytes. This is the minimum of the Characterstic length and
+//|     Maximum size of each packet in bytes. This is the minimum of the Characteristic length and
 //|     the negotiated Maximum Transfer Unit (MTU).
 //|
 STATIC mp_obj_t bleio_packet_buffer_get_packet_size(mp_obj_t self_in) {
     bleio_packet_buffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    return mp_obj_new_bool(common_hal_bleio_packet_buffer_get_packet_size(self));
+    return MP_OBJ_NEW_SMALL_INT(common_hal_bleio_packet_buffer_get_packet_size(self));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_packet_buffer_get_packet_size_obj, bleio_packet_buffer_get_packet_size);
 


### PR DESCRIPTION
- Fix return value for `PacketBuffer.packet_size`
- Fix some documentation issues. It doesn't seem possible to use backticks in function signatures: they get included literally in the signature. If you know how to fix this let me know.