### PR TITLE
nrf: track vm_used_ble better

### DIFF
--- a/ports/nrf/bluetooth/ble_drv.c
+++ b/ports/nrf/bluetooth/ble_drv.c
@@ -145,6 +145,9 @@ void SD_EVT_IRQHandler(void) {
         ble_drv_evt_handler_entry_t *it = MP_STATE_VM(ble_drv_evt_handler_entries);
         bool done = false;
         while (it != NULL) {
+            #if CIRCUITPY_VERBOSE_BLE
+            // mp_printf(&mp_plat_print, "  calling handler: 0x%08lx, param: 0x%08lx\n", it->func-1, it->param);
+            #endif
             done = it->func(event, it->param) || done;
             it = it->next;
         }

--- a/ports/nrf/common-hal/_bleio/__init__.c
+++ b/ports/nrf/common-hal/_bleio/__init__.c
@@ -91,13 +91,14 @@ void check_sec_status(uint8_t sec_status) {
 void bleio_reset() {
     bleio_adapter_reset(&common_hal_bleio_adapter_obj);
     if (!vm_used_ble) {
+        // No user-code BLE operations were done, so we can maintain the supervisor state.
         return;
     }
     if (common_hal_bleio_adapter_get_enabled(&common_hal_bleio_adapter_obj)) {
         common_hal_bleio_adapter_set_enabled(&common_hal_bleio_adapter_obj, false);
     }
-    supervisor_start_bluetooth();
     bonding_reset();
+    supervisor_start_bluetooth();
 }
 
 // The singleton _bleio.Adapter object, bound to _bleio.adapter
@@ -195,14 +196,17 @@ size_t common_hal_bleio_gattc_read(uint16_t handle, uint16_t conn_handle, uint8_
     while (nrf_error == NRF_ERROR_BUSY) {
         nrf_error = sd_ble_gattc_read(conn_handle, handle, 0);
     }
-    check_nrf_error(nrf_error);
+    if (nrf_error != NRF_SUCCESS) {
+        ble_drv_remove_event_handler(_on_gattc_read_rsp_evt, &read_info);
+        check_nrf_error(nrf_error);
+    }
 
     while (!read_info.done) {
         RUN_BACKGROUND_TASKS;
     }
-    check_gatt_status(read_info.status);
 
     ble_drv_remove_event_handler(_on_gattc_read_rsp_evt, &read_info);
+    check_gatt_status(read_info.status);
     return read_info.final_len;
 }
 

--- a/ports/nrf/common-hal/_bleio/bonding.c
+++ b/ports/nrf/common-hal/_bleio/bonding.c
@@ -267,14 +267,15 @@ void bonding_background(void) {
     for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
         bleio_connection_internal_t *connection = &bleio_connections[i];
 
-        uint64_t current_ticks_ms = supervisor_ticks_ms64();
         // Wait at least one second before saving CCCD, to consolidate
         // writes that involve multiple CCCDs. For instance, for HID,
         // three CCCD's are set in short succession by the HID client.
-        if (connection->do_bond_cccds &&
-            current_ticks_ms - connection->do_bond_cccds_request_time >= 1000) {
-            write_sys_attr_block(connection);
-            connection->do_bond_cccds = false;
+        if (connection->do_bond_cccds) {
+            uint64_t current_ticks_ms = supervisor_ticks_ms64();
+            if (current_ticks_ms - connection->do_bond_cccds_request_time >= 1000) {
+                write_sys_attr_block(connection);
+                connection->do_bond_cccds = false;
+            }
         }
 
         if (connection->do_bond_keys) {


### PR DESCRIPTION
This fixes some apparent hangs when using `adafruit_ble_heart_rate` as a central. The problem was that on a soft reload, the old event handlers were still in effect (with stale pointers) and the connection was not reset. Tested with the sample HRM program.

- `vm_used_ble`, which tracks whether any Python code (as opposed to supervisor) has done BLE operations, was not being set in a sufficient number of places. In particular, central-only BLE wasn't being detected.
- Call `bonding_reset()` in a better order.
- Disconnect user-initiated BLE connections cleanly when shutting down vm.
- Make sure BLE event handlers are removed even when there are errors. Don't throw before removing the handler.
- When bonding, don't get current ticks if not necessary.
- Implement `common_hal_mcu_disable_interrupts()` and `common_hal_mcu_enable_interrupts()`, which were completely unimplemented in nrf port (!). If SD is enabled use the SD critical section functions to avoid blocking BLE-critical interrupts. If SD is disabled really do block all interrupts.

NOTE: Some functionality depends on completely blocking interrupts. In particular, the timing for `OneWire` depends on specific timeouts that are accomplished by blocking for up to a few hundred microseconds. This would completely break BLE. So `OneWire` when using BLE may not work, and perhaps some other time-critical `bitbangio`. I'll open an issue about this.
