### PR TITLE
increase max BLE connections from 2 to 5

### DIFF
--- a/ports/nrf/bluetooth/ble_drv.h
+++ b/ports/nrf/bluetooth/ble_drv.h
@@ -33,8 +33,6 @@
 
 #include "ble.h"
 
-#define MAX_TX_IN_PROGRESS 10
-
 #ifndef BLE_GATT_ATT_MTU_DEFAULT
     #define BLE_GATT_ATT_MTU_DEFAULT GATT_MTU_SIZE_DEFAULT
 #endif

--- a/ports/nrf/boards/common.template.ld
+++ b/ports/nrf/boards/common.template.ld
@@ -19,14 +19,13 @@ MEMORY
 
 
     /* 0x2000000 - RAM:ORIGIN is reserved for Softdevice */
-    /* SoftDevice 6.1.0 takes 0x7b78 bytes (30.86 kb) minimum with high ATT MTU. */
+    /* SoftDevice 6.1.0 with 5 connections and various increases takes just under 64kiB.
     /* To measure the minimum required amount of memory for given configuration, set this number
        high enough to work and then check the mutation of the value done by sd_ble_enable. */
-    RAM (xrw)       : ORIGIN = 0x20000000 + 32K, LENGTH = 256K - 32K
+    RAM (xrw)       : ORIGIN = 0x20000000 + 64K, LENGTH = 256K - 64K
 }
 
-/* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 40K;
+/* produce a link error if there is not this amount of RAM available */
 _minimum_heap_size = 0;
 
 /* top end of the stack */
@@ -125,7 +124,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + _minimum_stack_size;
+        . = . + ${CIRCUITPY_DEFAULT_STACK_SIZE};
         . = ALIGN(4);
     } >RAM
 

--- a/ports/nrf/common-hal/_bleio/Adapter.h
+++ b/ports/nrf/common-hal/_bleio/Adapter.h
@@ -35,7 +35,7 @@
 #include "shared-bindings/_bleio/Connection.h"
 #include "shared-bindings/_bleio/ScanResults.h"
 
-#define BLEIO_TOTAL_CONNECTION_COUNT 2
+#define BLEIO_TOTAL_CONNECTION_COUNT 5
 
 extern bleio_connection_internal_t bleio_connections[BLEIO_TOTAL_CONNECTION_COUNT];
 


### PR DESCRIPTION
Increase number of connections and other parameters for BLE.

Figuring 5 connections: 1 for workflow (not yet in use)
Connecting to 3 sensors + 1 other connection as a possible maxed-out application

- Number of connections increased from 2 to 5.
- Max number of peripheral roles increased from 2 to 4.
- Max number of central roles increased from 1 to 4.
- Increase size of attribute table by factor of 5 from default (was factor of 3).
- Support up to 75 128-bit UUIDs (was 32).
- Decreased notify/indicate tx queue size from 10 to 9 (each increment takes about 2kB, so these are expensive).
- The above changes increase RAM used by SoftDevice from 32kiB to 64kiB.

- Added experimental results of how much increasing each parameter affects RAM use
- Fixed up max stack size check in .ld file.
- Removed a `#define` for one of the values above which was defined in a different file and used only one place.

We can fine-tune this later. I thought originally the stack size was 40kiB, but it's actually 24kiB right now, which is fine.

