### PR TITLE
fix UICR check; do not use NULL for no MISO

### DIFF
--- a/ports/atmel-samd/boards/hallowing_m4_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m4_express/board.c
@@ -49,7 +49,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
-    common_hal_busio_spi_construct(spi, &pin_PA01, &pin_PA00, NULL);
+    common_hal_busio_spi_construct(spi, &pin_PA01, &pin_PA00, mp_const_none);
     common_hal_busio_spi_never_reset(spi);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;

--- a/ports/atmel-samd/boards/monster_m4sk/board.c
+++ b/ports/atmel-samd/boards/monster_m4sk/board.c
@@ -50,7 +50,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
-    common_hal_busio_spi_construct(spi, &pin_PA13, &pin_PA12, NULL);
+    common_hal_busio_spi_construct(spi, &pin_PA13, &pin_PA12, mp_const_none);
     common_hal_busio_spi_never_reset(spi);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;

--- a/ports/atmel-samd/boards/openbook_m4/board.c
+++ b/ports/atmel-samd/boards/openbook_m4/board.c
@@ -55,7 +55,7 @@ uint8_t stop_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
-    common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, NULL);
+    common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, mp_const_none);
     common_hal_busio_spi_never_reset(spi);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;

--- a/ports/atmel-samd/boards/pewpew_m4/board.c
+++ b/ports/atmel-samd/boards/pewpew_m4/board.c
@@ -97,7 +97,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
-    common_hal_busio_spi_construct(spi, &pin_PA13, &pin_PA15, NULL);
+    common_hal_busio_spi_construct(spi, &pin_PA13, &pin_PA15, mp_const_none);
     common_hal_busio_spi_never_reset(spi);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;

--- a/ports/atmel-samd/boards/pybadge/board.c
+++ b/ports/atmel-samd/boards/pybadge/board.c
@@ -72,7 +72,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
-    common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, NULL);
+    common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, mp_const_none);
     common_hal_busio_spi_never_reset(spi);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;

--- a/ports/atmel-samd/boards/pybadge_airlift/board.c
+++ b/ports/atmel-samd/boards/pybadge_airlift/board.c
@@ -50,7 +50,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
-    common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, NULL);
+    common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, mp_const_none);
     common_hal_busio_spi_never_reset(spi);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;

--- a/ports/atmel-samd/boards/pygamer/board.c
+++ b/ports/atmel-samd/boards/pygamer/board.c
@@ -72,7 +72,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
-    common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, NULL);
+    common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, mp_const_none);
     common_hal_busio_spi_never_reset(spi);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;

--- a/ports/atmel-samd/boards/pygamer_advance/board.c
+++ b/ports/atmel-samd/boards/pygamer_advance/board.c
@@ -50,7 +50,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
-    common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB12, NULL);
+    common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB12, mp_const_none);
     common_hal_busio_spi_never_reset(spi);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;

--- a/ports/nrf/boards/clue_nrf52840_express/board.c
+++ b/ports/nrf/boards/clue_nrf52840_express/board.c
@@ -49,7 +49,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
-    common_hal_busio_spi_construct(spi, &pin_P0_14, &pin_P0_15, NULL);
+    common_hal_busio_spi_construct(spi, &pin_P0_14, &pin_P0_15, mp_const_none);
     common_hal_busio_spi_never_reset(spi);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;

--- a/ports/nrf/boards/ohs2020_badge/board.c
+++ b/ports/nrf/boards/ohs2020_badge/board.c
@@ -49,7 +49,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
-    common_hal_busio_spi_construct(spi, &pin_P0_14, &pin_P0_15, NULL);
+    common_hal_busio_spi_construct(spi, &pin_P0_14, &pin_P0_15, mp_const_none);
     common_hal_busio_spi_never_reset(spi);
 
     displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;

--- a/ports/nrf/common-hal/busio/SPI.c
+++ b/ports/nrf/common-hal/busio/SPI.c
@@ -143,7 +143,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self, const mcu_pin_obj_t *
     self->clock_pin_number = clock->number;
     claim_pin(clock);
 
-    if (mosi != (mcu_pin_obj_t*)&mp_const_none_obj) {
+    if (mosi != mp_const_none) {
         config.mosi_pin = mosi->number;
         self->MOSI_pin_number = mosi->number;
         claim_pin(mosi);
@@ -151,7 +151,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self, const mcu_pin_obj_t *
         self->MOSI_pin_number = NO_PIN;
     }
 
-    if (miso != (mcu_pin_obj_t*)&mp_const_none_obj) {
+    if (miso != mp_const_none) {
         config.miso_pin = miso->number;
         self->MISO_pin_number = mosi->number;
         claim_pin(miso);

--- a/ports/nrf/peripherals/nrf/nrf52840/power.c
+++ b/ports/nrf/peripherals/nrf/nrf52840/power.c
@@ -25,16 +25,26 @@
  */
 
 #include "nrfx.h"
-#include "nrfx_nvmc.h"
+#include "hal/nrf_nvmc.h"
 
 void nrf_peripherals_power_init(void) {
     // Set GPIO reference voltage to 3.3V if it isn't already. REGOUT0 will get reset to 0xfffffff
     // if flash is erased, which sets the default to 1.8V
     // This matters only when "high voltage mode" is enabled, which is true on the PCA10059,
     // and might be true on other boards.
-    if (NRF_UICR->REGOUT0 == 0xffffffff) {
-        nrfx_nvmc_word_write((uint32_t) &NRF_UICR->REGOUT0, UICR_REGOUT0_VOUT_3V3 << UICR_REGOUT0_VOUT_Pos);
-        // Must reset to make enable change.
+    if (NRF_UICR->REGOUT0 == 0xffffffff && NRF_POWER->MAINREGSTATUS & 1) {
+        // Expand what nrf_nvmc_word_write() did.
+        // It's missing from nrfx V2.0.0, and nrfx_nvmc_word_write() does bounds
+        // checking which prevents writes to UICR.
+        // Reported: https://devzone.nordicsemi.com/f/nordic-q-a/57243/nrfx_nvmc-h-api-cannot-write-to-uicr
+        NRF_NVMC->CONFIG = NRF_NVMC_MODE_WRITE;
+        while (!(NRF_NVMC->READY & NVMC_READY_READY_Msk)) {}
+        NRF_UICR->REGOUT0 = UICR_REGOUT0_VOUT_3V3 << UICR_REGOUT0_VOUT_Pos;
+        __DMB();
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {}
+        NRF_NVMC->CONFIG = NRF_NVMC_MODE_READONLY;
+
+        // Must reset to enable change.
         NVIC_SystemReset();
     }
 }


### PR DESCRIPTION
#### UICR fix
At least some CLUE's have `NRF_UICR->REGOUT0` set to all 1's, which when the chip is in "high voltage mode" will make the outputs be 1.8V instead of 3.3V. However the nRF module on the CLUE is not in high voltage mode, so this register is ignored.

Nevertheless, we had code to fix this to rewrite `REGOUT0`, but it wasn't working because the update to nrfx v2.0.0 forced us to use a new nvm writing API, which doesn't let you write to UICR because it out of bounds of regular flash memory. I opened a ticket with Nordic about this: https://devzone.nordicsemi.com/f/nordic-q-a/57243/nrfx_nvmc-h-api-cannot-write-to-uicr.

I fixed the writing code (but it's not tested), and more importantly, didn't bother to do the UICR write if the module is not in high voltage mode. The voltage is fine as is.

### `board.c` display initialization
The `common_hal_busio_spi_construct()` calls in all the `board.c` files with on-board displays were using `NULL` for the unused MISO pin. This worked for atmel-samd because it accepted both `NULL` and `mp_const_none`, but it didn't work on nrf, which only expected `mp_const_none`. (And other ports don't accept `NULL` either). If it worked it was by accident (some builds worked), probably assigning a random pin to MISO. I fixed all the those  calls on all boards to pass `mp_const_none` instead of `NULL`.