### PR TITLE
adjust CLUE madctl so rotation 0 is 'right'

### DIFF
--- a/ports/nrf/boards/clue_nrf52840_express/board.c
+++ b/ports/nrf/boards/clue_nrf52840_express/board.c
@@ -40,7 +40,7 @@ displayio_fourwire_obj_t board_display_obj;
 uint8_t display_init_sequence[] = {
     0x01, 0 | DELAY, 150, // SWRESET
     0x11, 0 | DELAY, 255, // SLPOUT
-    0x36, 1, 0x00,        // _MADCTL bottom to top refresh in vsync aligned order.
+    0x36, 1, 0b10100000,  // _MADCTL for rotation 0
     0x3a, 1, 0x55, // COLMOD - 16bit color
     0x21, 0 | DELAY, 10,                 // _INVON
     0x13, 0 | DELAY, 10,                 // _NORON
@@ -67,9 +67,9 @@ void board_init(void) {
         bus,
         240, // Width (after rotation)
         240, // Height (after rotation)
-        0, // column start
+        80, // column start
         0, // row start
-        270, // rotation
+        0, // rotation
         16, // Color depth
         false, // Grayscale
         false, // Pixels in a byte share a row. Only used for depth < 8


### PR DESCRIPTION
should be faster to draw