### PR TITLE
Palette: accept tuples of RGB values

### DIFF
--- a/locale/ID.po
+++ b/locale/ID.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1845,7 +1845,7 @@ msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
+msgid "color buffer must be a buffer, tuple or int"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1821,7 +1821,7 @@ msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
+msgid "color buffer must be a buffer, tuple or int"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: Pascal Deneaux\n"
 "Language-Team: Sebastian Plamauer, Pascal Deneaux\n"
@@ -1849,8 +1849,8 @@ msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
 msgstr "Farbpuffer muss 3 Bytes (RGB) oder 4 Bytes (RGB + pad byte) sein"
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
-msgstr "Farbpuffer muss ein Puffer oder ein int sein"
+msgid "color buffer must be a buffer, tuple or int"
+msgstr ""
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a bytearray or array of type 'b' or 'B'"
@@ -2853,7 +2853,6 @@ msgstr ""
 #~ msgid "C-level assert"
 #~ msgstr "C-Level Assert"
 
-#, c-format
 #~ msgid "Can not use dotstar with %s"
 #~ msgstr "Kann dotstar nicht mit %s verwenden"
 
@@ -3167,16 +3166,17 @@ msgstr ""
 #~ "Sie laufen im abgesicherten Modus, was bedeutet, dass etwas Unerwartetes "
 #~ "passiert ist.\n"
 
-#, c-format
 #~ msgid "buf is too small. need %d bytes"
 #~ msgstr "buf ist zu klein. brauche %d Bytes"
 
 #~ msgid "buffer too long"
 #~ msgstr "Buffer zu lang"
 
-#, c-format
 #~ msgid "byteorder is not an instance of ByteOrder (got a %s)"
 #~ msgstr "byteorder ist keine Instanz von ByteOrder (%s erhalten)"
+
+#~ msgid "color buffer must be a buffer or int"
+#~ msgstr "Farbpuffer muss ein Puffer oder ein int sein"
 
 #~ msgid "expected a DigitalInOut"
 #~ msgstr "erwarte DigitalInOut"

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -1821,7 +1821,7 @@ msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
+msgid "color buffer must be a buffer, tuple or int"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c

--- a/locale/en_x_pirate.po
+++ b/locale/en_x_pirate.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: @sommersoft, @MrCertainly\n"
@@ -1825,7 +1825,7 @@ msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
+msgid "color buffer must be a buffer, tuple or int"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: 2018-08-24 22:56-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -1850,8 +1850,8 @@ msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
 msgstr "color buffer debe ser 3 bytes (RGB) ó 4 bytes (RGB + pad byte)"
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
-msgstr "color buffer deber ser un buffer o un int"
+msgid "color buffer must be a buffer, tuple or int"
+msgstr ""
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a bytearray or array of type 'b' or 'B'"
@@ -2853,7 +2853,6 @@ msgstr "paso cero"
 #~ "Intento de allocation de heap cuando la VM de MicroPython no estaba "
 #~ "corriendo.\n"
 
-#, c-format
 #~ msgid "Can not use dotstar with %s"
 #~ msgstr "No se puede usar dotstar con %s"
 
@@ -3194,14 +3193,12 @@ msgstr "paso cero"
 #~ msgid "bad GATT role"
 #~ msgstr "mal GATT role"
 
-#, c-format
 #~ msgid "buf is too small. need %d bytes"
 #~ msgstr "buf es demasiado pequeño. necesita %d bytes"
 
 #~ msgid "buffer too long"
 #~ msgstr "buffer demasiado largo"
 
-#, c-format
 #~ msgid "byteorder is not an instance of ByteOrder (got a %s)"
 #~ msgstr "byteorder no es instancia de ByteOrder (encontarmos un %s)"
 
@@ -3222,6 +3219,9 @@ msgstr "paso cero"
 
 #~ msgid "characteristics includes an object that is not a Characteristic"
 #~ msgstr "characteristics incluye un objeto que no es una Characteristica"
+
+#~ msgid "color buffer must be a buffer or int"
+#~ msgstr "color buffer deber ser un buffer o un int"
 
 #~ msgid "either pos or kw args are allowed"
 #~ msgstr "ya sea pos o kw args son permitidos"
@@ -3312,11 +3312,9 @@ msgstr "paso cero"
 #~ msgid "unknown config param"
 #~ msgstr "parámetro config desconocido"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr "codigo format desconocido '%c' para el typo de objeto 'float'"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'str'"
 #~ msgstr "codigo format desconocido '%c' para objeto de tipo 'str'"
 

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: 2018-12-20 22:15-0800\n"
 "Last-Translator: Timothy <me@timothygarcia.ca>\n"
 "Language-Team: fil\n"
@@ -1861,8 +1861,8 @@ msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
 msgstr "color buffer ay dapat na 3 bytes (RGB) o 4 bytes (RGB + pad byte)"
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
-msgstr "color buffer ay dapat buffer or int"
+msgid "color buffer must be a buffer, tuple or int"
+msgstr ""
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a bytearray or array of type 'b' or 'B'"
@@ -3176,6 +3176,9 @@ msgstr "zero step"
 #~ msgid "can't set STA config"
 #~ msgstr "hindi makuha ang STA config"
 
+#~ msgid "color buffer must be a buffer or int"
+#~ msgstr "color buffer ay dapat buffer or int"
+
 #~ msgid "either pos or kw args are allowed"
 #~ msgstr "pos o kw args ang pinahihintulutan"
 
@@ -3254,11 +3257,9 @@ msgstr "zero step"
 #~ msgid "unknown config param"
 #~ msgstr "hindi alam na config param"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr "hindi alam ang format code '%c' sa object na ang type ay 'float'"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'str'"
 #~ msgstr ""
 #~ "hindi alam ang format ng code na '%c' para sa object ng type ay 'str'"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: 2019-04-14 20:05+0100\n"
 "Last-Translator: Pierrick Couturier <arofarn@arofarn.info>\n"
 "Language-Team: fr\n"
@@ -1884,9 +1884,8 @@ msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
 msgstr "le tampon de couleur doit faire 3 octets (RVB) ou 4 (RVB + pad byte)"
 
 #: shared-bindings/displayio/Palette.c
-#, fuzzy
-msgid "color buffer must be a buffer or int"
-msgstr "le tampon de couleur doit être un tampon ou un entier 'int'"
+msgid "color buffer must be a buffer, tuple or int"
+msgstr ""
 
 #: shared-bindings/displayio/Palette.c
 #, fuzzy
@@ -2903,7 +2902,6 @@ msgstr "'step' nul"
 #~ msgstr ""
 #~ "Tentative d'allocation de tas alors que la VM MicroPython ne tourne pas.\n"
 
-#, c-format
 #~ msgid "Can not use dotstar with %s"
 #~ msgstr "Impossible d'utiliser 'dotstar' avec %s"
 
@@ -3253,14 +3251,12 @@ msgstr "'step' nul"
 #~ msgid "bad GATT role"
 #~ msgstr "mauvais rôle GATT"
 
-#, c-format
 #~ msgid "buf is too small. need %d bytes"
 #~ msgstr "'buf' est trop petit. Besoin de %d octets"
 
 #~ msgid "buffer too long"
 #~ msgstr "tampon trop long"
 
-#, c-format
 #~ msgid "byteorder is not an instance of ByteOrder (got a %s)"
 #~ msgstr "'byteorder' n'est pas une instance de ByteOrder (reçu un %s)"
 
@@ -3282,6 +3278,10 @@ msgstr "'step' nul"
 #~ msgid "characteristics includes an object that is not a Characteristic"
 #~ msgstr ""
 #~ "'characteristics' inclut un objet qui n'est pas une 'Characteristic'"
+
+#, fuzzy
+#~ msgid "color buffer must be a buffer or int"
+#~ msgstr "le tampon de couleur doit être un tampon ou un entier 'int'"
 
 #~ msgid "either pos or kw args are allowed"
 #~ msgstr "soit 'pos', soit 'kw' est permis en argument"
@@ -3368,11 +3368,9 @@ msgstr "'step' nul"
 #~ msgid "unknown config param"
 #~ msgstr "paramètre de config. inconnu"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr "code de format '%c' inconnu pour un objet de type 'float'"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'str'"
 #~ msgstr "code de format '%c' inconnu pour un objet de type 'str'"
 

--- a/locale/it_IT.po
+++ b/locale/it_IT.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: 2018-10-02 16:27+0200\n"
 "Last-Translator: Enrico Paganin <enrico.paganin@mail.com>\n"
 "Language-Team: \n"
@@ -1862,8 +1862,8 @@ msgstr ""
 "il buffer del colore deve esseer di 3 byte (RGB) o 4 byte (RGB + pad byte)"
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
-msgstr "il buffer del colore deve essere un buffer o un int"
+msgid "color buffer must be a buffer, tuple or int"
+msgstr ""
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a bytearray or array of type 'b' or 'B'"
@@ -2870,7 +2870,6 @@ msgstr "zero step"
 #~ msgid "C-level assert"
 #~ msgstr "assert a livello C"
 
-#, c-format
 #~ msgid "Can not use dotstar with %s"
 #~ msgstr "dotstar non può essere usato con %s"
 
@@ -3166,6 +3165,9 @@ msgstr "zero step"
 #~ msgid "can't set STA config"
 #~ msgstr "impossibile impostare le configurazioni della STA"
 
+#~ msgid "color buffer must be a buffer or int"
+#~ msgstr "il buffer del colore deve essere un buffer o un int"
+
 #~ msgid "either pos or kw args are allowed"
 #~ msgstr "sono permesse solo gli argomenti pos o kw"
 
@@ -3241,12 +3243,10 @@ msgstr "zero step"
 #~ msgid "unknown config param"
 #~ msgstr "parametro di configurazione sconosciuto"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr ""
 #~ "codice di formattazione '%c' sconosciuto per oggetto di tipo 'float'"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'str'"
 #~ msgstr "codice di formattazione '%c' sconosciuto per oggetto di tipo 'str'"
 

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: 2019-05-06 14:22-0700\n"
 "Last-Translator: \n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1826,7 +1826,7 @@ msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
+msgid "color buffer must be a buffer, tuple or int"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: 2019-03-19 18:37-0700\n"
 "Last-Translator: Radomir Dopieralski <circuitpython@sheep.art.pl>\n"
 "Language-Team: pl\n"
@@ -1829,8 +1829,8 @@ msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
 msgstr "bufor kolorów musi nieć 3 bajty (RGB) lub 4 bajty (RGB + wypełnienie)"
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
-msgstr "bufor kolorów musi być typu buffer lub int"
+msgid "color buffer must be a buffer, tuple or int"
+msgstr ""
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a bytearray or array of type 'b' or 'B'"
@@ -2816,7 +2816,6 @@ msgstr "zerowy krok"
 #~ msgid "Attempted heap allocation when MicroPython VM not running.\n"
 #~ msgstr "Próba alokacji pamięci na stercie gdy VM nie działa.\n"
 
-#, c-format
 #~ msgid "Can not use dotstar with %s"
 #~ msgstr "Nie można używać dotstar z %s"
 
@@ -3035,17 +3034,18 @@ msgstr "zerowy krok"
 #~ msgid "bad GATT role"
 #~ msgstr "zła rola GATT"
 
-#, c-format
 #~ msgid "buf is too small. need %d bytes"
 #~ msgstr "buf zbyt mały. Wymagane %d bajtów"
 
-#, c-format
 #~ msgid "byteorder is not an instance of ByteOrder (got a %s)"
 #~ msgstr "byteorder musi być typu ByteOrder (jest %s)"
 
 #~ msgid "characteristics includes an object that is not a Characteristic"
 #~ msgstr ""
 #~ "charakterystyki zawierają obiekt, który nie jest typu Characteristic"
+
+#~ msgid "color buffer must be a buffer or int"
+#~ msgstr "bufor kolorów musi być typu buffer lub int"
 
 #~ msgid "interval not in range 0.0020 to 10.24"
 #~ msgstr "przedział poza zakresem 0.0020 do 10.24"
@@ -3068,11 +3068,9 @@ msgstr "zerowy krok"
 #~ msgid "timeout >100 (units are now seconds, not msecs)"
 #~ msgstr "timeout > 100 (jednostkami są sekundy)"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr "zły kod foratowania '%c' dla obiektu typu 'float'"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'str'"
 #~ msgstr "zły kod formatowania '%c' dla obiektu typu 'str'"
 

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: 2018-10-02 21:14-0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -1842,7 +1842,7 @@ msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
+msgid "color buffer must be a buffer, tuple or int"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c

--- a/locale/zh_Latn_pinyin.po
+++ b/locale/zh_Latn_pinyin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: circuitpython-cn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-29 17:27-0800\n"
+"POT-Creation-Date: 2020-02-03 10:12-0600\n"
 "PO-Revision-Date: 2019-04-13 10:10-0700\n"
 "Last-Translator: hexthat\n"
 "Language-Team: Chinese Hanyu Pinyin\n"
@@ -1839,8 +1839,8 @@ msgstr ""
 "yánsè huǎnchōng qū bìxū wèi 3 zì jié (RGB) huò 4 zì jié (RGB + pad zì jié)"
 
 #: shared-bindings/displayio/Palette.c
-msgid "color buffer must be a buffer or int"
-msgstr "yánsè huǎnchōng qū bìxū shì huǎnchōng qū huò zhěngshù"
+msgid "color buffer must be a buffer, tuple or int"
+msgstr ""
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a bytearray or array of type 'b' or 'B'"
@@ -2829,7 +2829,6 @@ msgstr "líng bù"
 #~ msgid "Attempted heap allocation when MicroPython VM not running.\n"
 #~ msgstr "MicroPython VM wèi yùnxíng shí chángshì duī fēnpèi.\n"
 
-#, c-format
 #~ msgid "Can not use dotstar with %s"
 #~ msgstr "Wúfǎ yǔ dotstar yīqǐ shǐyòng %s"
 
@@ -3091,16 +3090,17 @@ msgstr "líng bù"
 #~ msgid "bad GATT role"
 #~ msgstr "zǒng xiédìng de bùliáng juésè"
 
-#, c-format
 #~ msgid "buf is too small. need %d bytes"
 #~ msgstr "huǎnchōng tài xiǎo. Xūyào%d zì jié"
 
-#, c-format
 #~ msgid "byteorder is not an instance of ByteOrder (got a %s)"
 #~ msgstr "zì jié bùshì zì jié xù shílì (yǒu %s)"
 
 #~ msgid "characteristics includes an object that is not a Characteristic"
 #~ msgstr "tèxìng bāokuò bùshì zìfú de wùtǐ"
+
+#~ msgid "color buffer must be a buffer or int"
+#~ msgstr "yánsè huǎnchōng qū bìxū shì huǎnchōng qū huò zhěngshù"
 
 #~ msgid "expected a DigitalInOut"
 #~ msgstr "qídài de DigitalInOut"
@@ -3132,11 +3132,9 @@ msgstr "líng bù"
 #~ msgid "too many arguments"
 #~ msgstr "tài duō cānshù"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr "lèixíng 'float' duìxiàng wèizhī de géshì dàimǎ '%c'"
 
-#, c-format
 #~ msgid "unknown format code '%c' for object of type 'str'"
 #~ msgstr "lèixíng 'str' duìxiàng wèizhī de géshì dàimǎ '%c'"
 

--- a/ports/atmel-samd/boards/pewpew_m4/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/pewpew_m4/mpconfigboard.mk
@@ -46,7 +46,13 @@ USB_DEVICES = "CDC,MSC"
 
 # Tweak inlining depending on language.
 ifeq ($(TRANSLATION), zh_Latn_pinyin)
-CFLAGS_INLINE_LIMIT = 45
+CFLAGS_INLINE_LIMIT = 15
+CFLAGS_BOARD = --param inline-unit-growth=12 --param max-inline-insns-auto=15
+else
+ifeq ($(TRANSLATION), de_DE)
+CFLAGS_INLINE_LIMIT = 15
+CFLAGS_BOARD = --param inline-unit-growth=12 --param max-inline-insns-auto=15
 else
 CFLAGS_INLINE_LIMIT = 70
+endif
 endif

--- a/shared-bindings/displayio/Palette.c
+++ b/shared-bindings/displayio/Palette.c
@@ -111,6 +111,11 @@ STATIC mp_obj_t palette_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t val
         return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_palette_get_color(self, index));
     }
 
+    // Convert a tuple to a bytearray
+    if (mp_obj_get_type(value)->getiter == mp_obj_tuple_getiter) {
+        value = mp_type_bytes.make_new(&mp_type_bytes, 1, &value, NULL);
+    }
+
     uint32_t color;
     mp_int_t int_value;
     mp_buffer_info_t bufinfo;
@@ -130,7 +135,7 @@ STATIC mp_obj_t palette_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t val
         }
         color = int_value;
     } else {
-        mp_raise_TypeError(translate("color buffer must be a buffer or int"));
+        mp_raise_TypeError(translate("color buffer must be a buffer, tuple or int"));
     }
     common_hal_displayio_palette_set_color(self, index, color);
     return mp_const_none;


### PR DESCRIPTION
This makes Palette more similar to pixelbuf, and lets e.g., the unmodified "wheel" function be used to set pixel values.

Testing performed: I adapted an existing demo (pygamer) of mine to directly use wheel() tuples instead of converting them to 24-bit integers, and it worked.