### PR TITLE
Add support for external flash device Winbond W25Q80DV

### DIFF
--- a/supervisor/shared/external_flash/devices.h
+++ b/supervisor/shared/external_flash/devices.h
@@ -371,6 +371,23 @@ typedef struct {
     .single_status_byte = false, \
 }
 
+// Settings for the Winbond W25Q80DV 1MiB SPI flash.. Note that W25Q80DL has a different memory type (0x60)
+// Datasheet: https://www.winbond.com/resource-files/w25q80dv%20dl_revh_10022015.pdf
+#define W25Q80DV {\
+    .total_size = (1 << 20), /* 1 MiB */ \
+    .start_up_time_us = 5000, \
+    .manufacturer_id = 0xef, \
+    .memory_type = 0x40, \
+    .capacity = 0x14, \
+    .max_clock_speed_mhz = 104, \
+    .quad_enable_bit_mask = 0x02, \
+    .has_sector_protection = false, \
+    .supports_fast_read = true, \
+    .supports_qspi = true, \
+    .supports_qspi_writes = false, \
+    .write_status_register_split = false, \
+    .single_status_byte = false, \
+}
 
 // Settings for the Winbond W25Q128JV-SQ 16MiB SPI flash. Note that JV-IM has a different .memory_type (0x70)
 // Datasheet: https://www.winbond.com/resource-files/w25q128jv%20revf%2003272018%20plus.pdf


### PR DESCRIPTION
Currently, we only support external flash device W25Q80DL. This adds support for the W25Q80DL. They are very similar, but they are not interoperable because of a different memory type. 

See #2593

This is my first PR in this repo, so let me know if I need to make any changes!