### PR TITLE
Fix to allow remount when usb enabled but not msc

### DIFF
--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -149,9 +149,7 @@ void common_hal_storage_remount(const char *mount_path, bool readonly, bool disa
     }
 
     #ifdef USB_AVAILABLE
-    // TODO(dhalbert): is this is a good enough check? It checks for
-    // CDC enabled. There is no "MSC enabled" check.
-    if (usb_enabled()) {
+    if (!usb_msc_ejected()) {
         mp_raise_RuntimeError(translate("Cannot remount '/' when USB is active."));
     }
     #endif

--- a/supervisor/shared/usb/usb_msc_flash.c
+++ b/supervisor/shared/usb/usb_msc_flash.c
@@ -39,7 +39,7 @@
 
 #define MSC_FLASH_BLOCK_SIZE    512
 
-static bool ejected[1];
+static bool ejected[1] = {true};
 
 void usb_msc_mount(void) {
     // Reset the ejection tracking every time we're plugged into USB. This allows for us to battery
@@ -51,6 +51,14 @@ void usb_msc_mount(void) {
 
 void usb_msc_umount(void) {
 
+}
+
+bool usb_msc_ejected(void) {
+    bool all_ejected = true;
+    for (uint8_t i = 0; i < sizeof(ejected); i++) {
+        all_ejected &= ejected[i];
+    }
+    return all_ejected;
 }
 
 // The root FS is always at the end of the list.

--- a/supervisor/usb.h
+++ b/supervisor/usb.h
@@ -44,5 +44,6 @@ void usb_init(void);
 // Propagate plug/unplug events to the MSC logic.
 void usb_msc_mount(void);
 void usb_msc_umount(void);
+bool usb_msc_ejected(void);
 
 #endif // MICROPY_INCLUDED_SUPERVISOR_USB_H


### PR DESCRIPTION
Addresses #2509.
storage remount now checks if USB MSC is mounted.
Would appreciate more testing before merging.