### PR TITLE
Allow drive name to be set per target

### DIFF
--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -104,7 +104,11 @@ void filesystem_init(bool create_allowed, bool force_create) {
         }
 
         // set label
+#ifdef CIRCUITPY_DRIVE_LABEL
+        f_setlabel(&vfs_fat->fatfs, CIRCUITPY_DRIVE_LABEL);
+#else
         f_setlabel(&vfs_fat->fatfs, "CIRCUITPY");
+#endif
 
         // inhibit file indexing on MacOS
         f_mkdir(&vfs_fat->fatfs, "/.fseventsd");


### PR DESCRIPTION
Allows the drive name to be set in the mpconfigboard.h file, with a fallback to pre-existing behaviour. The name can already be changed from the default by the host of course, but this new define is useful when you've got multiple circuitpython boards on your system and you want to be able to differentiate between the drives when in a compile/upload/test frenzy...and it costs nothing to add in code size or execution time.