### PR TITLE
Implement to_bytes(..., signed=True)

### DIFF
--- a/tests/basics/int_bytes.py
+++ b/tests/basics/int_bytes.py
@@ -1,8 +1,11 @@
 print((10).to_bytes(1, "little"))
+print((-10).to_bytes(1, "little", signed=True))
 # Test fitting in length that's not a power of two.
 print((0x10000).to_bytes(3, 'little'))
 print((111111).to_bytes(4, "little"))
+print((-111111).to_bytes(4, "little", signed=True))
 print((100).to_bytes(10, "little"))
+print((-100).to_bytes(10, "little", signed=True))
 
 # check that extra zero bytes don't change the internal int value
 print(int.from_bytes(bytes(20), "little") == 0)
@@ -10,7 +13,9 @@ print(int.from_bytes(b"\x01" + bytes(20), "little") == 1)
 
 # big-endian conversion
 print((10).to_bytes(1, "big"))
+print((-10).to_bytes(1, "big", signed=True))
 print((100).to_bytes(10, "big"))
+print((-100).to_bytes(10, "big", signed=True))
 print(int.from_bytes(b"\0\0\0\0\0\0\0\0\0\x01", "big"))
 print(int.from_bytes(b"\x01\0", "big"))
 
@@ -26,8 +31,13 @@ try:
 except OverflowError:
     print("OverflowError")
 
-# negative numbers should raise an error
+# negative numbers should raise an error if signed=False
 try:
     (-256).to_bytes(2, "little")
+except OverflowError:
+    print("OverflowError")
+
+try:
+    (-256).to_bytes(2, "little", signed=False)
 except OverflowError:
     print("OverflowError")

--- a/tests/basics/int_bytes_intbig.py
+++ b/tests/basics/int_bytes_intbig.py
@@ -2,7 +2,9 @@ import skip_if
 skip_if.no_bigint()
 
 print((2**64).to_bytes(9, "little"))
+print((-2**64).to_bytes(9, "little", signed=True))
 print((2**64).to_bytes(9, "big"))
+print((-2**64).to_bytes(9, "big", signed=True))
 
 b = bytes(range(20))
 
@@ -22,8 +24,12 @@ try:
 except OverflowError:
     print("OverflowError")
 
-# negative numbers should raise an error
+# negative numbers should raise an error if signed=False
 try:
     (-2**64).to_bytes(9, "little")
+except OverflowError:
+    print("OverflowError")
+try:
+    (-2**64).to_bytes(9, "little", signed=False)
 except OverflowError:
     print("OverflowError")

--- a/tests/basics/int_longint_bytes.py
+++ b/tests/basics/int_longint_bytes.py
@@ -3,6 +3,7 @@ import skip_if
 skip_if.no_bigint()
 
 print((2**64).to_bytes(9, "little"))
+print((-2**64).to_bytes(9, "little", signed=True))
 print(int.from_bytes(b"\x00\x01\0\0\0\0\0\0", "little"))
 print(int.from_bytes(b"\x01\0\0\0\0\0\0\0", "little"))
 print(int.from_bytes(b"\x00\x01\0\0\0\0\0\0", "little"))


### PR DESCRIPTION
Fixes #2579.

Uses existing latent support for signed conversions. It was mostly just the arg parsing. Tests added.

Implementing `from_bytes(..., signed=True)` is harder: #2624.

