### PR TITLE
Update readline.c for REPL Unicode issue 1905

### DIFF
--- a/lib/mp-readline/readline.c
+++ b/lib/mp-readline/readline.c
@@ -206,7 +206,7 @@ int readline_process_char(int c) {
                 redraw_step_forward = compl_len;
             }
         #endif
-        } else if (32 <= c && c <= 126) {
+         } else if (32 <= c ) {
             // printable character
             vstr_ins_char(rl.line, rl.cursor_pos, c);
             // set redraw parameters


### PR DESCRIPTION
The issue reported in #1905 was that UTF-8 characters were not getting echoed in REPL. This was because the code in readline.c made sure the character was 'printable', i.e. between 32 and 126 inclusive. For UTF-8 the character can go up to 255, so simply removing the upper test resolves the issue. A simple test:
```
>>> a='27° C'
>>> print (a)
27° C
```
