### PR TITLE
Enable _bleio adapter when _bleio is imported

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -72,6 +72,7 @@
 #define MICROPY_HELPER_REPL              (1)
 #define MICROPY_KBD_EXCEPTION            (1)
 #define MICROPY_MEM_STATS                (0)
+#define MICROPY_MODULE_BUILTIN_INIT      (1)
 #define MICROPY_NONSTANDARD_TYPECODES    (0)
 #define MICROPY_OPT_COMPUTED_GOTO        (1)
 #define MICROPY_PERSISTENT_CODE_LOAD     (1)

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -117,7 +117,7 @@ const mp_obj_property_t bleio_adapter_address_obj = {
 
 //|   .. attribute:: name
 //|
-//|       name of the BLE adapter used once connected. Not used in advertisements.
+//|       name of the BLE adapter used once connected.
 //|       The name is "CIRCUITPY" + the last four hex digits of ``adapter.address``,
 //|       to make it easy to distinguish multiple CircuitPython boards.
 //|

--- a/shared-bindings/_bleio/__init__.c
+++ b/shared-bindings/_bleio/__init__.c
@@ -132,6 +132,14 @@ NORETURN void mp_raise_bleio_SecurityError(const compressed_string_t* fmt, ...) 
     nlr_raise(exception);
 }
 
+// Called when _bleio is imported.
+STATIC mp_obj_t bleio___init__(void) {
+    common_hal_bleio_adapter_set_enabled(&common_hal_bleio_adapter_obj, true);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(bleio___init___obj, bleio___init__);
+
+
 STATIC const mp_rom_map_elem_t bleio_module_globals_table[] = {
     // Name must be the first entry so that the exception printing below is correct.
     { MP_ROM_QSTR(MP_QSTR___name__),             MP_ROM_QSTR(MP_QSTR__bleio) },
@@ -156,6 +164,10 @@ STATIC const mp_rom_map_elem_t bleio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ConnectionError),     MP_ROM_PTR(&mp_type_bleio_ConnectionError) },
     { MP_ROM_QSTR(MP_QSTR_RoleError),           MP_ROM_PTR(&mp_type_bleio_RoleError) },
     { MP_ROM_QSTR(MP_QSTR_SecurityError),       MP_ROM_PTR(&mp_type_bleio_SecurityError) },
+
+    // Initialization
+    { MP_ROM_QSTR(MP_QSTR___init__),            MP_ROM_PTR(&bleio___init___obj) },
+
 };
 
 STATIC MP_DEFINE_CONST_DICT(bleio_module_globals, bleio_module_globals_table);


### PR DESCRIPTION
Fixes #2646.

Uses `MICROPY_MODULE_BUILTIN_INIT` mechanism to call a native module `__init__()` function when the `_bleio` module is imported. The init function enables the `Adapter`, which enables the SD. This mechanism was disabled in all our ports before this PR, but might come in handy in other cases.

Also fixed one minor doc thing I found by accident.