### PR TITLE
Fix crash after empty REPL session

### DIFF
--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -723,7 +723,10 @@ void bleio_adapter_gc_collect(bleio_adapter_obj_t* adapter) {
 
 void bleio_adapter_reset(bleio_adapter_obj_t* adapter) {
     common_hal_bleio_adapter_stop_scan(adapter);
-    common_hal_bleio_adapter_stop_advertising(adapter);
+    if (adapter->current_advertising_data != NULL) {
+        common_hal_bleio_adapter_stop_advertising(adapter);
+    }
+
     adapter->connection_objs = NULL;
     for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
         bleio_connection_internal_t *connection = &bleio_connections[i];

--- a/ports/nrf/common-hal/_bleio/__init__.c
+++ b/ports/nrf/common-hal/_bleio/__init__.c
@@ -89,14 +89,15 @@ void check_sec_status(uint8_t sec_status) {
 
 // Turn off BLE on a reset or reload.
 void bleio_reset() {
+    if (!common_hal_bleio_adapter_get_enabled(&common_hal_bleio_adapter_obj)) {
+        return;
+    }
     bleio_adapter_reset(&common_hal_bleio_adapter_obj);
     if (!vm_used_ble) {
         // No user-code BLE operations were done, so we can maintain the supervisor state.
         return;
     }
-    if (common_hal_bleio_adapter_get_enabled(&common_hal_bleio_adapter_obj)) {
-        common_hal_bleio_adapter_set_enabled(&common_hal_bleio_adapter_obj, false);
-    }
+    common_hal_bleio_adapter_set_enabled(&common_hal_bleio_adapter_obj, false);
     bonding_reset();
     supervisor_start_bluetooth();
 }


### PR DESCRIPTION
We were trying to reset bluetooth when it was off and then trying
to raise an exception without the heap.