### PR TITLE
Makefiles: add targets to build unix port, mpy-cross for fuzzing

### DIFF
--- a/mpy-cross/.gitignore
+++ b/mpy-cross/.gitignore
@@ -3,4 +3,5 @@
 /mpy-cross.static
 /mpy-cross.static.exe
 /mpy-cross.static-raspbian
+/mpy-cross.fuzz
 /pitools

--- a/mpy-cross/Makefile.fuzz
+++ b/mpy-cross/Makefile.fuzz
@@ -1,0 +1,6 @@
+
+PROG=mpy-cross.fuzz
+BUILD=build-static
+STATIC_BUILD=1
+CC=afl-clang-fast
+include mpy-cross.mk

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -277,6 +277,18 @@ coverage_test: coverage
 coverage_clean:
 	$(MAKE) V=2 BUILD=build-coverage PROG=micropython_coverage clean
 
+# build an interpreter for fuzzing
+fuzz:
+	$(MAKE) \
+	    CC=afl-clang-fast DEBUG=1 \
+	    CFLAGS_EXTRA='$(CFLAGS_EXTRA) -ffunction-sections' \
+	    LDFLAGS_EXTRA='$(LDFLAGS_EXTRA)' \
+	    BUILD=build-fuzz PROG=micropython_fuzz
+
+fuzz_clean:
+	$(MAKE) V=2 BUILD=build-fuzz PROG=micropython_fuzz clean
+
+
 # Value of configure's --host= option (required for cross-compilation).
 # Deduce it from CROSS_COMPILE by default, but can be overridden.
 ifneq ($(CROSS_COMPILE),)


### PR DESCRIPTION
This assumes you have properly install afl-fuzz with afl-clang-fast.
Tested with AFLplusplus 2.60c-75-g2c6847b.