### PR TITLE
STM32: Fix restriction on GPIO clock enables for F407 Discovery board

### DIFF
--- a/ports/stm32f4/peripherals/stm32f4/stm32f405xx/gpio.c
+++ b/ports/stm32f4/peripherals/stm32f4/stm32f405xx/gpio.c
@@ -30,9 +30,13 @@
 
 void stm32f4_peripherals_gpio_init(void) {
     //Enable all GPIO for now
-    __HAL_RCC_GPIOC_CLK_ENABLE();
     __HAL_RCC_GPIOA_CLK_ENABLE();
     __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOD_CLK_ENABLE();
+    __HAL_RCC_GPIOE_CLK_ENABLE();
+    __HAL_RCC_GPIOF_CLK_ENABLE();
+    __HAL_RCC_GPIOG_CLK_ENABLE();
 
     //Never reset pins
     never_reset_pin_number(2,13); //PC13 anti tamp

--- a/ports/stm32f4/peripherals/stm32f4/stm32f407xx/gpio.c
+++ b/ports/stm32f4/peripherals/stm32f4/stm32f407xx/gpio.c
@@ -30,9 +30,13 @@
 
 void stm32f4_peripherals_gpio_init(void) {
     //Enable all GPIO for now
-    __HAL_RCC_GPIOC_CLK_ENABLE();
     __HAL_RCC_GPIOA_CLK_ENABLE();
     __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOD_CLK_ENABLE();
+    __HAL_RCC_GPIOE_CLK_ENABLE();
+    __HAL_RCC_GPIOF_CLK_ENABLE();
+    __HAL_RCC_GPIOG_CLK_ENABLE();
 
     //Never reset pins
     never_reset_pin_number(2,13); //PC13 anti tamp


### PR DESCRIPTION
Also expanded for F405 SoC definition, for the possible future case a F405 board with the expanded pins is added. Resolves #2679. 