### PR TITLE
Pixelbuf: Add support for 2D pixelbufs

### DIFF
--- a/shared-bindings/_pixelbuf/PixelBuf.c
+++ b/shared-bindings/_pixelbuf/PixelBuf.c
@@ -136,6 +136,17 @@ static void parse_byteorder(mp_obj_t byteorder_obj, pixelbuf_byteorder_details_t
     }
     parsed->order_string = byteorder_obj;
 
+    if (bo_len == 3 && !strcmp(byteorder, "565")) {
+        parsed->is_dotstar = false;
+        parsed->has_white = false;
+        parsed->bpp = 2;
+        parsed->byteorder.r = 0;
+        parsed->byteorder.g = 1;
+        parsed->byteorder.b = 2;
+        parsed->byteorder.w = 0;
+        return;
+    }
+
     parsed->bpp = bo_len;
     char *dotstar = strchr(byteorder, 'P');
     char *r = strchr(byteorder, 'R');

--- a/shared-bindings/_pixelbuf/PixelBuf.h
+++ b/shared-bindings/_pixelbuf/PixelBuf.h
@@ -33,7 +33,7 @@ const mp_obj_type_t pixelbuf_pixelbuf_type;
 
 void common_hal__pixelbuf_pixelbuf_construct(pixelbuf_pixelbuf_obj_t *self, size_t n,
     pixelbuf_byteorder_details_t* byteorder, mp_float_t brightness, bool auto_write, uint8_t* header,
-    size_t header_len, uint8_t* trailer, size_t trailer_len);
+    size_t header_len, uint8_t* trailer, size_t trailer_len, int width);
 
 // These take mp_obj_t because they are called on subclasses of PixelBuf.
 uint8_t common_hal__pixelbuf_pixelbuf_get_bpp(mp_obj_t self);
@@ -42,6 +42,8 @@ void common_hal__pixelbuf_pixelbuf_set_brightness(mp_obj_t self, mp_float_t brig
 bool common_hal__pixelbuf_pixelbuf_get_auto_write(mp_obj_t self);
 void common_hal__pixelbuf_pixelbuf_set_auto_write(mp_obj_t self, bool auto_write);
 size_t common_hal__pixelbuf_pixelbuf_get_len(mp_obj_t self_in);
+int common_hal__pixelbuf_pixelbuf_get_width(mp_obj_t self_in);
+int common_hal__pixelbuf_pixelbuf_get_height(mp_obj_t self_in);
 mp_obj_t common_hal__pixelbuf_pixelbuf_get_byteorder_string(mp_obj_t self);
 void common_hal__pixelbuf_pixelbuf_fill(mp_obj_t self, mp_obj_t item);
 void common_hal__pixelbuf_pixelbuf_show(mp_obj_t self);

--- a/shared-module/_pixelbuf/PixelBuf.c
+++ b/shared-module/_pixelbuf/PixelBuf.c
@@ -41,12 +41,13 @@ static pixelbuf_pixelbuf_obj_t* native_pixelbuf(mp_obj_t pixelbuf_obj) {
 
 void common_hal__pixelbuf_pixelbuf_construct(pixelbuf_pixelbuf_obj_t *self, size_t n,
         pixelbuf_byteorder_details_t* byteorder, mp_float_t brightness, bool auto_write,
-        uint8_t* header, size_t header_len, uint8_t* trailer, size_t trailer_len) {
+        uint8_t* header, size_t header_len, uint8_t* trailer, size_t trailer_len, int width) {
 
     self->pixel_count = n;
     self->byteorder = *byteorder;  // Copied because we modify for dotstar
     self->bytes_per_pixel = byteorder->is_dotstar ? 4 : byteorder->bpp;
     self->auto_write = false;
+    self->width = width;
 
     size_t pixel_len = self->pixel_count * self->bytes_per_pixel;
     self->transmit_buffer_obj = mp_obj_new_bytes_of_zeros(header_len + pixel_len + trailer_len);
@@ -78,6 +79,16 @@ void common_hal__pixelbuf_pixelbuf_construct(pixelbuf_pixelbuf_obj_t *self, size
 size_t common_hal__pixelbuf_pixelbuf_get_len(mp_obj_t self_in) {
     pixelbuf_pixelbuf_obj_t* self = native_pixelbuf(self_in);
     return self->pixel_count;
+}
+
+int common_hal__pixelbuf_pixelbuf_get_width(mp_obj_t self_in) {
+    pixelbuf_pixelbuf_obj_t* self = native_pixelbuf(self_in);
+    return self->width;
+}
+
+int common_hal__pixelbuf_pixelbuf_get_height(mp_obj_t self_in) {
+    pixelbuf_pixelbuf_obj_t* self = native_pixelbuf(self_in);
+    return self->width == -1 ? -1 : (int)self->pixel_count / self->width;
 }
 
 uint8_t common_hal__pixelbuf_pixelbuf_get_bpp(mp_obj_t self_in) {

--- a/shared-module/_pixelbuf/PixelBuf.c
+++ b/shared-module/_pixelbuf/PixelBuf.c
@@ -254,6 +254,7 @@ mp_obj_t common_hal__pixelbuf_pixelbuf_get_pixel(mp_obj_t self_in, size_t index)
     if (self->pre_brightness_buffer != NULL) {
         pixel_buffer = self->pre_brightness_buffer;
     }
+    pixel_buffer += self->byteorder.bpp * index;
 
     pixelbuf_rgbw_t *rgbw_order = &self->byteorder.byteorder;
     elems[0] = MP_OBJ_NEW_SMALL_INT(pixel_buffer[rgbw_order->r]);

--- a/shared-module/_pixelbuf/PixelBuf.h
+++ b/shared-module/_pixelbuf/PixelBuf.h
@@ -50,6 +50,7 @@ typedef struct {
     mp_obj_base_t base;
     size_t pixel_count;
     size_t bytes_per_pixel;
+    int16_t width;
     pixelbuf_byteorder_details_t byteorder;
     mp_float_t brightness;
     mp_obj_t transmit_buffer_obj;


### PR DESCRIPTION
I'm not sure we necessarily want to take this code, I wrote it while prototyping protomatter, using pixelbuf to hold the framebuffer.

It was useful to be able to index the pixels with (row,column) pairs.  However, this is probably not the direction we're going to go with protomatter as we'd like to run it with displayio instead.