### PR TITLE
switch to checkout@v2 with submodules and fetch-depth 0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,14 @@ jobs:
       run: |
         gcc --version
         python3 --version
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: true
+        fetch-depth: 0
+    - run: git fetch origin --recurse-submodules=no +refs/tags/*:refs/tags/*
+    - run: git submodule foreach git fetch --recurse-submodules=no origin +refs/tags/*:refs/tags/*
     - name: CircuitPython version
-      run: git describe --dirty --always --tags
+      run: git describe --dirty --tags
     - name: Build mpy-cross
       run: make -C mpy-cross -j2
     - name: Build unix port
@@ -103,11 +106,14 @@ jobs:
         gcc --version
         python3 --version
         msgfmt --version
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: true
+        fetch-depth: 0
+    - run: git fetch origin --recurse-submodules=no +refs/tags/*:refs/tags/*
+    - run: git submodule foreach git fetch --recurse-submodules=no origin +refs/tags/*:refs/tags/*
     - name: CircuitPython version
-      run: git describe --dirty --always --tags
+      run: git describe --dirty --tags
     - name: Build mpy-cross
       run: make -C mpy-cross -j2
     - uses: actions/upload-artifact@v1.0.0
@@ -256,9 +262,12 @@ jobs:
         gcc --version
         arm-none-eabi-gcc --version
         python3 --version
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: true
+        fetch-depth: 0
+    - run: git fetch origin --recurse-submodules=no +refs/tags/*:refs/tags/*
+    - run: git submodule foreach git fetch --recurse-submodules=no origin +refs/tags/*:refs/tags/*
     - name: mpy-cross
       run: make -C mpy-cross -j2
     - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
         submodules: true
         fetch-depth: 0
     - run: git fetch origin --recurse-submodules=no +refs/tags/*:refs/tags/*
+    - run: git submodule foreach git remote -v
     - run: git submodule foreach git fetch --recurse-submodules=no origin +refs/tags/*:refs/tags/*
     - name: CircuitPython version
       run: git describe --dirty --tags

--- a/.github/workflows/create_website_pr.yml
+++ b/.github/workflows/create_website_pr.yml
@@ -23,11 +23,14 @@ jobs:
       run: |
         gcc --version
         python3 --version
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: true
+        fetch-depth: 0
+    - run: git fetch origin --recurse-submodules=no +refs/tags/*:refs/tags/*
+    - run: git submodule foreach git fetch --recurse-submodules=no origin +refs/tags/*:refs/tags/*
     - name: CircuitPython version
-      run: git describe --dirty --always --tags
+      run: git describe --dirty --tags
     - name: Website
       run: python3 build_board_info.py
       working-directory: tools


### PR DESCRIPTION
This switches us to the current version of checkout, which has recently added support for a feature we use (submodules).  This feature was in v1 but was not initially in v2.  It was recently added to v2.

For more background, see https://github.com/actions/checkout/issues/176 and #2718.

Things to check: that the checkout includes the needed tags that fetch-depth 0 is intended to add.

Besides just keeping modern, it appears to be the case that checkout@v2 works properly when re-running a failed actions job.