### PR TITLE
Add polarity and phase to FourWire.

### DIFF
--- a/ports/atmel-samd/boards/hallowing_m0_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m0_express/board.c
@@ -79,7 +79,9 @@ void board_init(void) {
         &pin_PA28, // Command or data
         &pin_PA01, // Chip select
         &pin_PA27, // Reset
-        12000000);
+        12000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/atmel-samd/boards/hallowing_m4_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m4_express/board.c
@@ -59,7 +59,9 @@ void board_init(void) {
         &pin_PB31, // TFT_DC Command or data
         &pin_PA27, // TFT_CS Chip select
         &pin_PB30, // TFT_RST Reset
-        60000000);
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/atmel-samd/boards/monster_m4sk/board.c
+++ b/ports/atmel-samd/boards/monster_m4sk/board.c
@@ -60,7 +60,9 @@ void board_init(void) {
         &pin_PA07, // TFT_DC Command or data
         &pin_PA06, // TFT_CS Chip select
         &pin_PA04, // TFT_RST Reset
-        60000000);
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/atmel-samd/boards/openbook_m4/board.c
+++ b/ports/atmel-samd/boards/openbook_m4/board.c
@@ -65,7 +65,9 @@ void board_init(void) {
         &pin_PB05, // EPD_DC Command or data
         &pin_PB07, // EPD_CS Chip select
         &pin_PA00, // EPD_RST Reset
-        1000000);
+        1000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_epaperdisplay_obj_t* display = &displays[0].epaper_display;
     display->base.type = &displayio_epaperdisplay_type;

--- a/ports/atmel-samd/boards/pewpew_m4/board.c
+++ b/ports/atmel-samd/boards/pewpew_m4/board.c
@@ -107,7 +107,9 @@ void board_init(void) {
         &pin_PA16, // TFT_DC Command or data
         &pin_PA11, // TFT_CS Chip select
         &pin_PA17, // TFT_RST Reset
-        60000000);
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     uint32_t cfg0 = lookupCfg(CFG_DISPLAY_CFG0, 0x000000);
     uint32_t offX = (cfg0 >> 8) & 0xff;

--- a/ports/atmel-samd/boards/pybadge/board.c
+++ b/ports/atmel-samd/boards/pybadge/board.c
@@ -82,7 +82,9 @@ void board_init(void) {
         &pin_PB05, // TFT_DC Command or data
         &pin_PB07, // TFT_CS Chip select
         &pin_PA00, // TFT_RST Reset
-        60000000);
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/atmel-samd/boards/pybadge_airlift/board.c
+++ b/ports/atmel-samd/boards/pybadge_airlift/board.c
@@ -60,7 +60,9 @@ void board_init(void) {
         &pin_PB05, // TFT_DC Command or data
         &pin_PB06, // TFT_CS Chip select
         &pin_PB07, // TFT_RST Reset
-        60000000);
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/atmel-samd/boards/pygamer/board.c
+++ b/ports/atmel-samd/boards/pygamer/board.c
@@ -82,7 +82,9 @@ void board_init(void) {
         &pin_PB05, // TFT_DC Command or data
         &pin_PB12, // TFT_CS Chip select
         &pin_PA00, // TFT_RST Reset
-        60000000);
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/atmel-samd/boards/pygamer_advance/board.c
+++ b/ports/atmel-samd/boards/pygamer_advance/board.c
@@ -60,7 +60,9 @@ void board_init(void) {
         &pin_PA00, // TFT_DC Command or data
         &pin_PB15, // TFT_CS Chip select
         &pin_PB05, // TFT_RST Reset
-        60000000);
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/atmel-samd/boards/ugame10/board.c
+++ b/ports/atmel-samd/boards/ugame10/board.c
@@ -79,7 +79,9 @@ void board_init(void) {
         &pin_PA09, // Command or data
         &pin_PA08, // Chip select
         NULL, // Reset
-        24000000);
+        24000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/nrf/boards/clue_nrf52840_express/board.c
+++ b/ports/nrf/boards/clue_nrf52840_express/board.c
@@ -59,7 +59,9 @@ void board_init(void) {
         &pin_P0_13, // TFT_DC Command or data
         &pin_P0_12, // TFT_CS Chip select
         &pin_P1_03, // TFT_RST Reset
-        60000000);
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/nrf/boards/ohs2020_badge/board.c
+++ b/ports/nrf/boards/ohs2020_badge/board.c
@@ -59,7 +59,9 @@ void board_init(void) {
         &pin_P0_08, // TFT_DC Command or data
         &pin_P0_14, // TFT_CS Chip select
         &pin_P0_13, // TFT_RST Reset
-        60000000);
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/ports/stm/boards/meowbit_v121/board.c
+++ b/ports/stm/boards/meowbit_v121/board.c
@@ -61,7 +61,7 @@ uint8_t display_init_sequence[] = {
 	0x3a, 1, 0x05, // COLMOD - 16bit color
 	0xe0, 0x10, 0x02, 0x1c, 0x07, 0x12,
 				0x37, 0x32, 0x29, 0x2d,
-				0x29, 0x25, 0x2B, 0x39, 
+				0x29, 0x25, 0x2B, 0x39,
 				0x00, 0x01, 0x03, 0x10, // _GMCTRP1 Gamma
 	0xe1, 0x10, 0x03, 0x1d, 0x07, 0x06,
 				0x2E, 0x2C, 0x29, 0x2D,
@@ -80,7 +80,9 @@ void board_init(void) {
         &pin_PA08, // Command or data
         &pin_PB12, // Chip select
         &pin_PB10, // Reset
-        24000000);
+        24000000, // Baudrate
+        0, // Polarity
+        0); // Phase
 
     displayio_display_obj_t* display = &displays[0].display;
     display->base.type = &displayio_display_type;

--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -46,8 +46,7 @@
 //| Manage updating a display over SPI four wire protocol in the background while Python code runs.
 //| It doesn't handle display initialization.
 //|
-//| .. class:: FourWire(spi_bus, *, command, chip_select, reset=None, baudrate=24000000, polarity=0,
-//|                     phase=0)
+//| .. class:: FourWire(spi_bus, *, command, chip_select, reset=None, baudrate=24000000, polarity=0, phase=0)
 //|
 //|   Create a FourWire object associated with the given pins.
 //|

--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -46,7 +46,8 @@
 //| Manage updating a display over SPI four wire protocol in the background while Python code runs.
 //| It doesn't handle display initialization.
 //|
-//| .. class:: FourWire(spi_bus, *, command, chip_select, reset=None, baudrate=24000000)
+//| .. class:: FourWire(spi_bus, *, command, chip_select, reset=None, baudrate=24000000, polarity=0,
+//|                     phase=0)
 //|
 //|   Create a FourWire object associated with the given pins.
 //|
@@ -60,15 +61,20 @@
 //|   :param microcontroller.Pin chip_select: Chip select pin
 //|   :param microcontroller.Pin reset: Reset pin. When None only software reset can be used
 //|   :param int baudrate: Maximum baudrate in Hz for the display on the bus
+//|   :param int polarity: the base state of the clock line (0 or 1)
+//|   :param int phase: the edge of the clock that data is captured. First (0)
+//|       or second (1). Rising or falling depends on clock polarity.
 //|
 STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_spi_bus, ARG_command, ARG_chip_select, ARG_reset, ARG_baudrate };
+    enum { ARG_spi_bus, ARG_command, ARG_chip_select, ARG_reset, ARG_baudrate, ARG_polarity, ARG_phase };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_spi_bus, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_command, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_chip_select, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_reset, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = mp_const_none} },
         { MP_QSTR_baudrate, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 24000000} },
+        { MP_QSTR_polarity, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_phase, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -91,8 +97,17 @@ STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_
         mp_raise_RuntimeError(translate("Too many display busses"));
     }
 
+    uint8_t polarity = args[ARG_polarity].u_int;
+    if (polarity != 0 && polarity != 1) {
+        mp_raise_ValueError(translate("Invalid polarity"));
+    }
+    uint8_t phase = args[ARG_phase].u_int;
+    if (phase != 0 && phase != 1) {
+        mp_raise_ValueError(translate("Invalid phase"));
+    }
+
     common_hal_displayio_fourwire_construct(self,
-        MP_OBJ_TO_PTR(spi), command, chip_select, reset, args[ARG_baudrate].u_int);
+        MP_OBJ_TO_PTR(spi), command, chip_select, reset, args[ARG_baudrate].u_int, polarity, phase);
     return self;
 }
 

--- a/shared-bindings/displayio/FourWire.h
+++ b/shared-bindings/displayio/FourWire.h
@@ -38,7 +38,8 @@ extern const mp_obj_type_t displayio_fourwire_type;
 
 void common_hal_displayio_fourwire_construct(displayio_fourwire_obj_t* self,
     busio_spi_obj_t* spi, const mcu_pin_obj_t* command,
-    const mcu_pin_obj_t* chip_select, const mcu_pin_obj_t* reset, uint32_t baudrate);
+    const mcu_pin_obj_t* chip_select, const mcu_pin_obj_t* reset, uint32_t baudrate,
+    uint8_t polarity, uint8_t phase);
 
 void common_hal_displayio_fourwire_deinit(displayio_fourwire_obj_t* self);
 

--- a/shared-module/displayio/FourWire.c
+++ b/shared-module/displayio/FourWire.c
@@ -40,7 +40,8 @@
 
 void common_hal_displayio_fourwire_construct(displayio_fourwire_obj_t* self,
     busio_spi_obj_t* spi, const mcu_pin_obj_t* command,
-    const mcu_pin_obj_t* chip_select, const mcu_pin_obj_t* reset, uint32_t baudrate) {
+    const mcu_pin_obj_t* chip_select, const mcu_pin_obj_t* reset, uint32_t baudrate,
+    uint8_t polarity, uint8_t phase) {
 
     self->bus = spi;
     common_hal_busio_spi_never_reset(self->bus);
@@ -49,8 +50,8 @@ void common_hal_displayio_fourwire_construct(displayio_fourwire_obj_t* self,
     gc_never_free(self->bus);
 
     self->frequency = baudrate;
-    self->polarity = 0;
-    self->phase = 0;
+    self->polarity = polarity;
+    self->phase = phase;
 
     common_hal_digitalio_digitalinout_construct(&self->command, command);
     common_hal_digitalio_digitalinout_switch_to_output(&self->command, true, DRIVE_MODE_PUSH_PULL);


### PR DESCRIPTION
It was fixed as 0/0 even though it used to get it from the current
SPI state. This makes it more explicit with kwargs.

Thanks to magpie_lark and kmatocha on the Adafruit Support forum
for finding the issue: https://forums.adafruit.com/viewtopic.php?f=60&t=162515