### PR TITLE
supervisor/shared/external_flash/devices.h: Add MX25L51245G support.

### DIFF
--- a/supervisor/shared/external_flash/devices.h
+++ b/supervisor/shared/external_flash/devices.h
@@ -481,6 +481,24 @@ typedef struct {
     .single_status_byte = true, \
 }
 
+// Settings for the Macronix MX25L51245G 64MiB SPI flash.
+// Datasheet: https://www.macronix.com/Lists/Datasheet/Attachments/7437/MX25L51245G,%203V,%20512Mb,%20v1.6.pdf
+#define MX25L51245G  {\
+    .total_size = (1 << 26), /* 64 MiB */ \
+    .start_up_time_us = 5000, \
+    .manufacturer_id = 0xc2, \
+    .memory_type = 0x20, \
+    .capacity = 0x1a, \
+    .max_clock_speed_mhz = 133, \
+    .quad_enable_bit_mask = 0x40, \
+    .has_sector_protection = false, \
+    .supports_fast_read = true, \
+    .supports_qspi = true, \
+    .supports_qspi_writes = true, \
+    .write_status_register_split = false, \
+    .single_status_byte = true, \
+}
+
 // Settings for the Winbond W25Q128JV-PM 16MiB SPI flash. Note that JV-IM has a different .memory_type (0x70)
 // Datasheet: https://www.winbond.com/resource-files/w25q128jv%20revf%2003272018%20plus.pdf
 #define W25Q128JV_PM {\


### PR DESCRIPTION
Add external flash support for Macronix MX25L51245G 64MiB SPI flash.

This flash chip provides 64MB of flash for the CircuitPython filesystem and exported USB mass storage device. I have tested it extensively with no issues. The data sheet for the chip is listed in the patch directly for reference within in the devices.h file.

I checked the data sheet very carefully when specifying the values for the device parameters. If anyone wants to double check me on those, I welcome any feedback. However, I believe they are correct, and it is well tested.

I am asking for this chip to be included as a supported device because in the near future I plan to make another pull request for a new board I am developing that utilizes this flash chip. The 64MB of space will be very useful for remote data logging where access to the device is infrequent. And the hard-wired chip is generally more reliable than an SD-card in harsh environments.

So if this pull request is accepted, I will make another pull request for the new board that utilizes it. And other people can utilize it more easily on other new boards also.

Note: I decided to make this pull request separate from the new board files request, because they are really independent of each other. So in case anything needs to be backed out or reverted, they can be dealt with separately.

Thank you for reviewing, and if you have any questions or feedback, please don't hesitate to let me know.

-Brian Dean