### PR TITLE
mimxrt10xx: Return proper UART read length when everything was read

### DIFF
--- a/ports/mimxrt10xx/common-hal/busio/UART.c
+++ b/ports/mimxrt10xx/common-hal/busio/UART.c
@@ -270,9 +270,14 @@ size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t 
         LPUART_TransferAbortReceive(self->uart, &self->handle);
     }
 
+    // No data left, we got it all
+    if (self->handle.rxData == NULL) {
+        return len;
+    }
+
     // The only place we can reliably tell how many bytes have been received is from the current
     // wp in the handle (because the abort nukes rxDataSize, and reading it before abort is a race.)
-    return self->handle.rxData-data;
+    return self->handle.rxData - data;
 }
 
 // Write characters.


### PR DESCRIPTION
You can imagine what happens with `return self->handle.rxData - data;` if rxData = 0.

Hint: Nothing good ;)