### PR TITLE
Add backlight polarity flag to Display

### DIFF
--- a/ports/atmel-samd/boards/hallowing_m0_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m0_express/board.c
@@ -108,7 +108,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/hallowing_m4_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m4_express/board.c
@@ -88,7 +88,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/monster_m4sk/board.c
+++ b/ports/atmel-samd/boards/monster_m4sk/board.c
@@ -89,7 +89,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/pewpew_m4/board.c
+++ b/ports/atmel-samd/boards/pewpew_m4/board.c
@@ -139,7 +139,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         false, // auto_refresh
-        20); // native_frames_per_second
+        20, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/pybadge/board.c
+++ b/ports/atmel-samd/boards/pybadge/board.c
@@ -111,7 +111,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/pybadge_airlift/board.c
+++ b/ports/atmel-samd/boards/pybadge_airlift/board.c
@@ -89,7 +89,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/pygamer/board.c
+++ b/ports/atmel-samd/boards/pygamer/board.c
@@ -111,7 +111,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/pygamer_advance/board.c
+++ b/ports/atmel-samd/boards/pygamer_advance/board.c
@@ -89,7 +89,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/pyportal/board.c
+++ b/ports/atmel-samd/boards/pyportal/board.c
@@ -100,7 +100,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/pyportal_titano/board.c
+++ b/ports/atmel-samd/boards/pyportal_titano/board.c
@@ -117,7 +117,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/ugame10/board.c
+++ b/ports/atmel-samd/boards/ugame10/board.c
@@ -108,7 +108,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data as commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/nrf/boards/clue_nrf52840_express/board.c
+++ b/ports/nrf/boards/clue_nrf52840_express/board.c
@@ -88,7 +88,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/nrf/boards/ohs2020_badge/board.c
+++ b/ports/nrf/boards/ohs2020_badge/board.c
@@ -81,14 +81,16 @@ void board_init(void) {
         0x37, // set vertical scroll command
         display_init_sequence,
         sizeof(display_init_sequence),
-        NULL,  // backlight pin
+        //NULL,  // backlight pin
+        &pin_P0_02,   // backlight pin
         NO_BRIGHTNESS_COMMAND,
-        1.0f, // brightness (ignored)
-        true, // auto_brightness
+        0.0f, // brightness (ignored)
+        false, // auto_brightness
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
         60); // native_frames_per_second
+
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/nrf/boards/ohs2020_badge/board.c
+++ b/ports/nrf/boards/ohs2020_badge/board.c
@@ -81,16 +81,15 @@ void board_init(void) {
         0x37, // set vertical scroll command
         display_init_sequence,
         sizeof(display_init_sequence),
-        //NULL,  // backlight pin
-        &pin_P0_02,   // backlight pin
+        &pin_P0_02, // backlight pin
         NO_BRIGHTNESS_COMMAND,
-        0.0f, // brightness (ignored)
-        false, // auto_brightness
+        1.0f, // brightness (ignored)
+        true, // auto_brightness
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
-
+        60, // native_frames_per_second
+        false); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/stm/boards/meowbit_v121/board.c
+++ b/ports/stm/boards/meowbit_v121/board.c
@@ -109,7 +109,8 @@ void board_init(void) {
         false, // single_byte_bounds
         false, // data_as_commands
         true, // auto_refresh
-        60); // native_frames_per_second
+        60, // native_frames_per_second
+        true); // backlight_on_high
 }
 
 bool board_requests_safe_mode(void) {

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -104,9 +104,10 @@
 //|   :param bool data_as_commands: Treat all init and boundary data as SPI commands. Certain displays require this.
 //|   :param bool auto_refresh: Automatically refresh the screen
 //|   :param int native_frames_per_second: Number of display refreshes per second that occur with the given init_sequence.
+//|   :param bool backlight_on_high: If True, pulling the backlight pin high turns the backlight on.
 //|
 STATIC mp_obj_t displayio_display_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_display_bus, ARG_init_sequence, ARG_width, ARG_height, ARG_colstart, ARG_rowstart, ARG_rotation, ARG_color_depth, ARG_grayscale, ARG_pixels_in_byte_share_row, ARG_bytes_per_cell, ARG_reverse_pixels_in_byte, ARG_set_column_command, ARG_set_row_command, ARG_write_ram_command, ARG_set_vertical_scroll, ARG_backlight_pin, ARG_brightness_command, ARG_brightness, ARG_auto_brightness, ARG_single_byte_bounds, ARG_data_as_commands, ARG_auto_refresh, ARG_native_frames_per_second };
+    enum { ARG_display_bus, ARG_init_sequence, ARG_width, ARG_height, ARG_colstart, ARG_rowstart, ARG_rotation, ARG_color_depth, ARG_grayscale, ARG_pixels_in_byte_share_row, ARG_bytes_per_cell, ARG_reverse_pixels_in_byte, ARG_set_column_command, ARG_set_row_command, ARG_write_ram_command, ARG_set_vertical_scroll, ARG_backlight_pin, ARG_brightness_command, ARG_brightness, ARG_auto_brightness, ARG_single_byte_bounds, ARG_data_as_commands, ARG_auto_refresh, ARG_native_frames_per_second, ARG_backlight_on_high };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_display_bus, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_init_sequence, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -132,6 +133,7 @@ STATIC mp_obj_t displayio_display_make_new(const mp_obj_type_t *type, size_t n_a
         { MP_QSTR_data_as_commands, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
         { MP_QSTR_auto_refresh, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = true} },
         { MP_QSTR_native_frames_per_second, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 60} },
+        { MP_QSTR_backlight_on_high, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = true} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -178,7 +180,8 @@ STATIC mp_obj_t displayio_display_make_new(const mp_obj_type_t *type, size_t n_a
         args[ARG_single_byte_bounds].u_bool,
         args[ARG_data_as_commands].u_bool,
         args[ARG_auto_refresh].u_bool,
-        args[ARG_native_frames_per_second].u_int
+        args[ARG_native_frames_per_second].u_int,
+        args[ARG_backlight_on_high].u_bool
         );
 
     return self;

--- a/shared-bindings/displayio/Display.h
+++ b/shared-bindings/displayio/Display.h
@@ -45,7 +45,7 @@ void common_hal_displayio_display_construct(displayio_display_obj_t* self,
     uint8_t set_column_command, uint8_t set_row_command, uint8_t write_ram_command, uint8_t set_vertical_scroll,
     uint8_t* init_sequence, uint16_t init_sequence_len, const mcu_pin_obj_t* backlight_pin, uint16_t brightness_command,
     mp_float_t brightness, bool auto_brightness,
-    bool single_byte_bounds, bool data_as_commands, bool auto_refresh, uint16_t native_frames_per_second);
+    bool single_byte_bounds, bool data_as_commands, bool auto_refresh, uint16_t native_frames_per_second, bool backlight_on_high);
 
 bool common_hal_displayio_display_show(displayio_display_obj_t* self,
                                        displayio_group_t* root_group);

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -50,7 +50,7 @@ void common_hal_displayio_display_construct(displayio_display_obj_t* self,
         uint8_t set_row_command, uint8_t write_ram_command, uint8_t set_vertical_scroll,
         uint8_t* init_sequence, uint16_t init_sequence_len, const mcu_pin_obj_t* backlight_pin,
         uint16_t brightness_command, mp_float_t brightness, bool auto_brightness,
-        bool single_byte_bounds, bool data_as_commands, bool auto_refresh, uint16_t native_frames_per_second) {
+        bool single_byte_bounds, bool data_as_commands, bool auto_refresh, uint16_t native_frames_per_second, bool backlight_on_high) {
     // Turn off auto-refresh as we init.
     self->auto_refresh = false;
     uint16_t ram_width = 0x100;
@@ -159,6 +159,9 @@ mp_float_t common_hal_displayio_display_get_brightness(displayio_display_obj_t* 
 
 bool common_hal_displayio_display_set_brightness(displayio_display_obj_t* self, mp_float_t brightness) {
     self->updating_backlight = true;
+    if (!self->backlight_on_high){
+        brightness = 1.0-brightness;
+    }
     bool ok = false;
     if (self->backlight_pwm.base.type == &pulseio_pwmout_type) {
         common_hal_pulseio_pwmout_set_duty_cycle(&self->backlight_pwm, (uint16_t) (0xffff * brightness));

--- a/shared-module/displayio/Display.h
+++ b/shared-module/displayio/Display.h
@@ -55,6 +55,7 @@ typedef struct {
     bool data_as_commands;
     bool auto_brightness;
     bool updating_backlight;
+    bool backlight_on_high;
 } displayio_display_obj_t;
 
 void displayio_display_background(displayio_display_obj_t* self);


### PR DESCRIPTION
This adds a `backlight_on_high` flag to the `Display` constructor (defaulting to `True`) to allow for swapping the polarity of the backlight pin for boards where pulling the backlight pin low turns the display on.