### PR TITLE
mimxrt10xx: Fix neopixel_write

### DIFF
--- a/ports/mimxrt10xx/common-hal/neopixel_write/__init__.c
+++ b/ports/mimxrt10xx/common-hal/neopixel_write/__init__.c
@@ -32,7 +32,6 @@
 #include "py/mperrno.h"
 #include "py/runtime.h"
 #include "common-hal/microcontroller/Pin.h"
-#include "fsl_gpio.h"
 
 uint64_t next_start_tick_ms = 0;
 uint32_t next_start_tick_us = 1000;
@@ -45,7 +44,7 @@ uint32_t next_start_tick_us = 1000;
 #pragma GCC push_options
 #pragma GCC optimize ("Os")
 
-void common_hal_neopixel_write (const digitalio_digitalinout_obj_t* digitalinout, uint8_t *pixels,
+void PLACE_IN_ITCM(common_hal_neopixel_write)(const digitalio_digitalinout_obj_t* digitalinout, uint8_t *pixels,
                                 uint32_t numBytes) {
     uint8_t *p = pixels, *end = p + numBytes, pix = *p++, mask = 0x80;
     uint32_t start = 0;
@@ -54,14 +53,10 @@ void common_hal_neopixel_write (const digitalio_digitalinout_obj_t* digitalinout
     //assumes 800_000Hz frequency
     //Theoretical values here are 800_000 -> 1.25us, 2500000->0.4us, 1250000->0.8us
     //TODO: try to get dynamic weighting working again
-#ifdef MIMXRT1011_SERIES
-    uint32_t sys_freq = CLOCK_GetCoreFreq();
-#else
-    uint32_t sys_freq = CLOCK_GetAhbFreq();
-#endif
-    uint32_t interval = sys_freq/MAGIC_800_INT;
-    uint32_t t0 = (sys_freq/MAGIC_800_T0H);
-    uint32_t t1 = (sys_freq/MAGIC_800_T1H);
+    const uint32_t sys_freq = SystemCoreClock;
+    const uint32_t interval = (sys_freq / MAGIC_800_INT);
+    const uint32_t t0 = (sys_freq / MAGIC_800_T0H);
+    const uint32_t t1 = (sys_freq / MAGIC_800_T1H);
 
     // This must be called while interrupts are on in case we're waiting for a
     // future ms tick.
@@ -79,9 +74,9 @@ void common_hal_neopixel_write (const digitalio_digitalinout_obj_t* digitalinout
     for(;;) {
         cyc = (pix & mask) ? t1 : t0;
         start = DWT->CYCCNT;
-        GPIO_PinWrite(gpio, pin, 1);
+        gpio->DR |= (1U << pin);
         while((DWT->CYCCNT - start) < cyc);
-        GPIO_PinWrite(gpio, pin, 0);
+        gpio->DR &= ~(1U << pin);
         while((DWT->CYCCNT - start) < interval);
         if(!(mask >>= 1)) {
             if(p >= end) break;


### PR DESCRIPTION
Looks like the timing issues were caused by the code being in flash, moving it to ITCM and making sure no flash functions are called in the timing-critical section fixed the issue :)

Closes #2476

![](https://allg.one/OA4e)