### PR TITLE
Fix testsuite for compatibility with Python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - name: Set up Python 3.5
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.8
     - name: Install deps
       run: |
         sudo apt-get install -y eatmydata
@@ -42,7 +42,7 @@ jobs:
         make -C ports/unix -j2
         make -C ports/unix coverage -j2
     - name: Test all
-      run: MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1
+      run: MICROPY_CPYTHON3=python3.8 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1
       working-directory: tests
     - name: Print failure info
       run: |
@@ -54,10 +54,10 @@ jobs:
       working-directory: tests
       if: failure()
     - name: Native Tests
-      run: MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --emit native
+      run: MICROPY_CPYTHON3=python3.8 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --emit native
       working-directory: tests
     - name: mpy Tests
-      run: MICROPY_CPYTHON3=python3.5 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --via-mpy -d basics float
+      run: MICROPY_CPYTHON3=python3.8 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --via-mpy -d basics float
       working-directory: tests
     - name: Docs
       run: sphinx-build -E -W -b html . _build/html
@@ -244,10 +244,10 @@ jobs:
         - "xinabox_cs11"
 
     steps:
-    - name: Set up Python 3.5
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.8
     - name: Install deps
       run: |
         sudo apt-get install -y gettext
@@ -290,10 +290,10 @@ jobs:
         - "fomu"
 
     steps:
-    - name: Set up Python 3.5
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.8
     - name: Install deps
       run: |
         sudo apt-get install -y gettext

--- a/.github/workflows/create_website_pr.yml
+++ b/.github/workflows/create_website_pr.yml
@@ -12,10 +12,10 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - name: Set up Python 3.5
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.8
     - name: Install deps
       run: |
         pip install requests sh click 

--- a/tests/basics/dict1.py
+++ b/tests/basics/dict1.py
@@ -27,7 +27,7 @@ print({1:1} == {2:1})
 try:
     {}[0]
 except KeyError as er:
-    print('KeyError', er, repr(er), er.args)
+    print('KeyError', er, er.args)
 
 # unsupported unary op
 try:

--- a/tests/basics/exception1.py
+++ b/tests/basics/exception1.py
@@ -1,7 +1,6 @@
 print(repr(IndexError()))
 print(str(IndexError()))
 
-print(repr(IndexError("foo")))
 print(str(IndexError("foo")))
 
 a = IndexError(1, "test", [100, 200])

--- a/tests/basics/gen_yield_from.py.exp
+++ b/tests/basics/gen_yield_from.py.exp
@@ -1,0 +1,14 @@
+here1
+3
+here2
+[1, 2]
+here1
+None
+here2
+[1, 2]
+here1
+123
+here2
+[1, 2]
+444
+[0, 1, 2]

--- a/tests/basics/gen_yield_from_close.py.exp
+++ b/tests/basics/gen_yield_from_close.py.exp
@@ -1,0 +1,20 @@
+-1
+1
+StopIteration
+-1
+1
+2
+leaf caught GeneratorExit and swallowed it
+delegating caught GeneratorExit
+StopIteration
+-1
+1
+2
+leaf caught GeneratorExit and raised StopIteration instead
+delegating caught GeneratorExit
+StopIteration
+123
+RuntimeError
+0
+1
+close

--- a/tests/basics/gen_yield_from_throw.py.exp
+++ b/tests/basics/gen_yield_from_throw.py.exp
@@ -1,0 +1,6 @@
+1
+got ValueError from upstream!
+str1
+got TypeError from downstream!
+123
+got StopIteration from downstream!

--- a/tests/basics/generator_close.py.exp
+++ b/tests/basics/generator_close.py.exp
@@ -1,0 +1,10 @@
+None
+StopIteration
+1
+None
+StopIteration
+[1, 2]
+None
+StopIteration
+None
+ValueError

--- a/tests/basics/generator_return.py
+++ b/tests/basics/generator_return.py
@@ -7,4 +7,4 @@ print(next(g))
 try:
     print(next(g))
 except StopIteration as e:
-    print(repr(e))
+    print(type(e), e.args)

--- a/tests/basics/int_big_error.py
+++ b/tests/basics/int_big_error.py
@@ -17,9 +17,9 @@ try:
 except TypeError:
     print("TypeError")
 
-# overflow because rhs of >> is being converted to machine int
+# overflow because arg of bytearray is being converted to machine int
 try:
-    1 >> i
+    bytearray(i)
 except OverflowError:
     print('OverflowError')
 

--- a/tests/basics/parser.py.exp
+++ b/tests/basics/parser.py.exp
@@ -1,0 +1,3 @@
+SyntaxError
+SyntaxError
+SyntaxError

--- a/tests/basics/python34.py
+++ b/tests/basics/python34.py
@@ -1,4 +1,4 @@
-# tests that differ when running under Python 3.4 vs 3.5/3.6
+# tests that differ when running under Python 3.4 vs 3.5/3.6/3.7
 
 try:
     exec
@@ -36,3 +36,7 @@ test_syntax("del ()") # can't delete empty tuple (in 3.6 we can)
 import sys
 print(sys.version[:3])
 print(sys.version_info[0], sys.version_info[1])
+
+# from basics/exception1.py
+# in 3.7 no comma is printed if there is only 1 arg (in 3.4-3.6 one is printed)
+print(repr(IndexError("foo")))

--- a/tests/basics/python34.py.exp
+++ b/tests/basics/python34.py.exp
@@ -11,3 +11,4 @@ SyntaxError
 SyntaxError
 3.4
 3 4
+IndexError('foo',)

--- a/tests/basics/set_pop.py
+++ b/tests/basics/set_pop.py
@@ -15,4 +15,4 @@ while s:
     print(s.pop()) # last pop() should trigger the optimisation
 for i in range(N):
     s.add(i) # check that we can add the numbers back to the set
-print(list(s))
+print(sorted(s))

--- a/tests/basics/subclass_native3.py
+++ b/tests/basics/subclass_native3.py
@@ -7,12 +7,12 @@ print(repr(e))
 print(e.args)
 
 try:
-    raise MyExc("Some error")
+    raise MyExc("Some error", 1)
 except MyExc as e:
     print("Caught exception:", repr(e))
 
 try:
-    raise MyExc("Some error2")
+    raise MyExc("Some error2", 2)
 except Exception as e:
     print("Caught exception:", repr(e))
 

--- a/tests/basics/try_as_var.py
+++ b/tests/basics/try_as_var.py
@@ -1,7 +1,7 @@
 try:
     raise ValueError(534)
 except ValueError as e:
-    print(repr(e))
+    print(type(e), e.args)
 
 # Var bound in except block is automatically deleted
 try:

--- a/tests/import/import_override.py.exp
+++ b/tests/import/import_override.py.exp
@@ -1,0 +1,2 @@
+import import1b None 0
+456

--- a/tests/misc/sys_exc_info.py
+++ b/tests/misc/sys_exc_info.py
@@ -9,7 +9,7 @@ def f():
     print(sys.exc_info()[0:2])
 
 try:
-    1/0
+    raise ValueError('value', 123)
 except:
     print(sys.exc_info()[0:2])
     f()


### PR DESCRIPTION
There were a couple of tests that succeed with Python 3.5 and fail with 3.8.  See https://github.com/micropython/micropython/issues/4000 -- I've cherry-picked them, and upgraded the Python version used by github actions.

@tannewt remarked on #2706 that he expected these changes to be included by merging micropython.  Unless we did this recently, these commits are not in our history.  They appear to first be in micropython v1.10 and our release notes say we are based on MicroPython 1.9.4.