### PR TITLE
Add fill method to displayio.Bitmap

### DIFF
--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -178,9 +178,28 @@ STATIC mp_obj_t bitmap_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t val
     return mp_const_none;
 }
 
+//|   .. method:: fill()
+//|
+//|      Fills the bitmap.
+//|
+STATIC mp_obj_t displayio_bitmap_obj_fill(mp_obj_t self_in, mp_obj_t value_obj) {
+    displayio_bitmap_t *self = MP_OBJ_TO_PTR(self_in);
+
+    mp_int_t value = mp_obj_get_int(value_obj);
+    if (value >= 1 << common_hal_displayio_bitmap_get_bits_per_value(self)) {
+            mp_raise_ValueError(translate("pixel value requires too many bits"));
+    }
+    common_hal_displayio_bitmap_fill(self, value);
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(displayio_bitmap_fill_obj, displayio_bitmap_obj_fill);
+
 STATIC const mp_rom_map_elem_t displayio_bitmap_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&displayio_bitmap_height_obj) },
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&displayio_bitmap_width_obj) },
+    { MP_ROM_QSTR(MP_QSTR_fill), MP_ROM_PTR(&displayio_bitmap_fill_obj) },
+
 };
 STATIC MP_DEFINE_CONST_DICT(displayio_bitmap_locals_dict, displayio_bitmap_locals_dict_table);
 

--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -178,9 +178,9 @@ STATIC mp_obj_t bitmap_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t val
     return mp_const_none;
 }
 
-//|   .. method:: fill()
+//|   .. method:: fill(value)
 //|
-//|      Fills the bitmap.
+//|      Fills the bitmap with the supplied palette index value.
 //|
 STATIC mp_obj_t displayio_bitmap_obj_fill(mp_obj_t self_in, mp_obj_t value_obj) {
     displayio_bitmap_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/displayio/Bitmap.h
+++ b/shared-bindings/displayio/Bitmap.h
@@ -41,5 +41,6 @@ uint16_t common_hal_displayio_bitmap_get_width(displayio_bitmap_t *self);
 uint32_t common_hal_displayio_bitmap_get_bits_per_value(displayio_bitmap_t *self);
 void common_hal_displayio_bitmap_set_pixel(displayio_bitmap_t *bitmap, int16_t x, int16_t y, uint32_t value);
 uint32_t common_hal_displayio_bitmap_get_pixel(displayio_bitmap_t *bitmap, int16_t x, int16_t y);
+void common_hal_displayio_bitmap_fill(displayio_bitmap_t *bitmap, uint32_t value);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_BITMAP_H

--- a/shared-module/displayio/Bitmap.c
+++ b/shared-module/displayio/Bitmap.c
@@ -173,29 +173,13 @@ void common_hal_displayio_bitmap_fill(displayio_bitmap_t *self, uint32_t value) 
     self->dirty_area.y1 = 0;
     self->dirty_area.y2 = self->height;
 
-    // Update our data
-    int32_t row_start;
-    uint32_t bytes_per_value = self->bits_per_value / 8;
-    for (uint32_t x=0; x<self->width; x++) {
-        for (uint32_t y=0; y<self->height; y++) {
-            row_start = y * self->stride;
-            if (bytes_per_value < 1) {
-                uint32_t bit_position = (sizeof(size_t) * 8 - ((x & self->x_mask) + 1) * self->bits_per_value);
-                uint32_t index = row_start + (x >> self->x_shift);
-                uint32_t word = self->data[index];
-                word &= ~(self->bitmask << bit_position);
-                word |= (value & self->bitmask) << bit_position;
-                self->data[index] = word;
-            } else {
-                size_t* row = self->data + row_start;
-                if (bytes_per_value == 1) {
-                    ((uint8_t*) row)[x] = value;
-                } else if (bytes_per_value == 2) {
-                    ((uint16_t*) row)[x] = value;
-                } else if (bytes_per_value == 4) {
-                    ((uint32_t*) row)[x] = value;
-                }
-            }
-        }
+    // build the packed word
+    uint32_t word = 0;
+    for (uint8_t i=0; i<32 / self->bits_per_value; i++) {
+        word |= (value & self->bitmask) << (32 - ((i+1)*self->bits_per_value));
+    }
+    // copy it in
+    for (uint32_t i=0; i<self->stride * self->height; i++) {
+        self->data[i] = word;
     }
 }


### PR DESCRIPTION
This is functional at least. I basically just stole from the pixel set code and loopified it.

**Test program:**
```python
import time
import board
import displayio

WIDTH = board.DISPLAY.width
HEIGHT = board.DISPLAY.height

COLORS = (0xFF0000, 0x00FF00, 0x0000FF)

bitmap = displayio.Bitmap(WIDTH, HEIGHT, len(COLORS))

palette = displayio.Palette(len(COLORS))
for i, color in enumerate(COLORS):
    palette[i] = color

tile_grid = displayio.TileGrid(bitmap, pixel_shader=palette)

splash = displayio.Group()
splash.append(tile_grid)

board.DISPLAY.show(splash)

print("Fill 1")
board.DISPLAY.auto_refresh = False
start = time.monotonic()
for i in range(WIDTH*HEIGHT):
    bitmap[i] = 1
print(time.monotonic() - start)
board.DISPLAY.auto_refresh = True

time.sleep(1)

print("Fill 2")
start = time.monotonic()
bitmap.fill(2)
print(time.monotonic() - start)
```

**Results:**
```python
Adafruit CircuitPython 5.1.0-91-g49fff2d9b-dirty on 2020-04-09; Adafruit CLUE nRF52840 Express with nRF52840
>>> import fill_test
Fill 1
1.32599
Fill 2
0.0269775
>>> 
```


