### PR TITLE
RFC: Use Sphinx 3 To Build Docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         sudo apt-get install -y eatmydata
         sudo eatmydata apt-get install -y gettext librsvg2-bin mingw-w64
-        pip install requests sh click setuptools cpp-coveralls "Sphinx<3" sphinx-rtd-theme recommonmark sphinxcontrib-svg2pdfconverter polib pyyaml
+        pip install requests sh click setuptools cpp-coveralls Sphinx sphinx-rtd-theme recommonmark sphinxcontrib-svg2pdfconverter polib pyyaml
     - name: Versions
       run: |
         gcc --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         sudo apt-get install -y eatmydata
         sudo eatmydata apt-get install -y gettext librsvg2-bin mingw-w64
-        pip install requests sh click setuptools cpp-coveralls Sphinx sphinx-rtd-theme recommonmark sphinxcontrib-svg2pdfconverter polib pyyaml
+        pip install requests sh click setuptools cpp-coveralls "Sphinx<4" sphinx-rtd-theme recommonmark sphinxcontrib-svg2pdfconverter polib pyyaml
     - name: Versions
       run: |
         gcc --version

--- a/conf.py
+++ b/conf.py
@@ -357,4 +357,4 @@ intersphinx_mapping = {"cpython": ('https://docs.python.org/3/', None),
                        "register": ('https://circuitpython.readthedocs.io/projects/register/en/latest/', None)}
 
 def setup(app):
-    app.add_stylesheet("customstyle.css")
+    app.add_css_file("customstyle.css")

--- a/conf.py
+++ b/conf.py
@@ -17,7 +17,7 @@ import json
 import sys
 import os
 
-from recommonmark.parser import CommonMarkParser
+import recommonmark
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -55,16 +55,20 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'rstjinja',
-    'c2rst'
+    'c2rst',
+    'recommonmark',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['templates']
 
 # The suffix of source filenames.
-source_suffix = ['.rst', '.md', '.c', '.h']
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+    '.c': ''
+}
 
-source_parsers = {'.md': CommonMarkParser}
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'

--- a/docs/library/network.rst
+++ b/docs/library/network.rst
@@ -247,7 +247,7 @@ Methods
     nic.ifconfig(('192.168.0.4', '255.255.255.0', '192.168.0.1', '8.8.8.8'))
 
 .. method:: wlan.config('param')
-.. method:: wlan.config(param=value, ...)
+            wlan.config(param=value, ...)
 
    Get or set general network interface parameters. These methods allow to work
    with additional parameters beyond standard IP configuration (as dealt with by

--- a/shared-bindings/ulab/__init__.rst
+++ b/shared-bindings/ulab/__init__.rst
@@ -126,7 +126,7 @@ Array type codes
 
    Type code for unsigned integers in the range 0 .. 255 inclusive, like the 'H' typecode of `array.array`
 
-.. attribute:: uint8
+.. attribute:: uint16
 
    Type code for unsigned integers in the range 0 .. 65535 inclusive, like the 'h' typecode of `array.array`
 


### PR DESCRIPTION
From https://github.com/adafruit/circuitpython/pull/2749#issue-400441027:
> We can move to 3 when we move the inline docs to Python stubs.

If you want to move now, this builds the docs for me. I didn't notice any disparity with the results from my local builds.