### PR TITLE
Fix bad submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -109,7 +109,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Register.git
 [submodule "extmod/ulab"]
 	path = extmod/ulab
-	url = https://github.com/v923z/micropython-ulab/
+	url = https://github.com/v923z/micropython-ulab
 [submodule "frozen/Adafruit_CircuitPython_ESP32SPI"]
 	path = frozen/Adafruit_CircuitPython_ESP32SPI
 	url = https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI


### PR DESCRIPTION
The repository URL for extmod/ulab had a trailing slash, causing
errors when trying to clone it.

Closes #2762