### PR TITLE
Increased size of #defined CFG_TUD_CDC_EPSIZE

### DIFF
--- a/supervisor/shared/usb/tusb_config.h
+++ b/supervisor/shared/usb/tusb_config.h
@@ -88,6 +88,7 @@
  * CFG_TUD_TASK_QUEUE_SZ with large value
  */
 #define CFG_TUD_CDC_FLUSH_ON_SOF    0
+#define CFG_TUD_CDC_EPSIZE          128
 
 
 /*------------- MSC -------------*/


### PR DESCRIPTION
Issue #1639 Application exception output to serial (over USB) appears truncated due to buffering issue

Increased size of #defined CFG_TUD_CDC_EPSIZE to 128 from tinyusb default of 64.
Reproduced issue 80%+ of the time by running in REPL on CircuitPlayground Express:
`>>> raise AttributeError('abcdefghij' * 12)`

Note that there is certainly some timing/host driver issue involved, since running the same code when
connected to a Linux instance on the same system never reproduced the code.
I believe the issue is in function tud_cdc_n_write_flush() from lib/tinyusb/src/class/cdc/cdc_device.c:

uint16_t count = tu_fifo_read_n(&_cdcd_itf[itf].tx_ff, p_cdc->epin_buf, CFG_TUD_CDC_EPSIZE);

This limits the count of what is to be flushed to CFG_TUD_CDC_EPSIZE. When a buffer larger than that needs flushing it seems to not flush anything.