### PR TITLE
split up serial writes

### DIFF
--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -56,10 +56,15 @@ void serial_write_substring(const char* text, uint32_t length) {
     int errcode;
     common_hal_terminalio_terminal_write(&supervisor_terminal, (const uint8_t*) text, length, &errcode);
 #endif
-
+// split into chunks to avoid buffer overflows
     uint32_t count = 0;
+    uint32_t chunk = 0;
     while (count < length && tud_cdc_connected()) {
-        count += tud_cdc_write(text + count, length - count);
+         if ((length - count) > CFG_TUD_CDC_EPSIZE)
+           chunk = CFG_TUD_CDC_EPSIZE;
+         else
+           chunk = length - count;
+        count += tud_cdc_write(text + count, chunk);
         usb_background();
     }
 }


### PR DESCRIPTION
Issue #1639 Application exception output to serial (over USB) appears truncated due to buffering issue

Added code in serial_write_substring() to split large writes into chunks to help avoid buffer overflows.
A limit of CFG_TUD_CDC_EPSIZE was used, since that is  the limit used in tud_cdc_n_write_flush() from lib/tinyusb/src/class/cdc/cdc_device.c.
Prior to the fix there was a reproduction of the issue about 80% of the time using
`>>> raise AttributeError('abcdefghij' * 12)`
After the fix 50 cycles were run with no truncated outputs.