### PR TITLE
displayio: Fix "bus type" problem introduced at 8cba145c9029

### DIFF
--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -84,6 +84,7 @@ STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_
 
     mp_obj_t spi = args[ARG_spi_bus].u_obj;
     displayio_fourwire_obj_t* self = &allocate_display_bus_or_raise()->fourwire_bus;
+    self->base.type = &displayio_fourwire_type;
 
     uint8_t polarity = args[ARG_polarity].u_int;
     if (polarity != 0 && polarity != 1) {

--- a/shared-bindings/displayio/I2CDisplay.c
+++ b/shared-bindings/displayio/I2CDisplay.c
@@ -73,6 +73,7 @@ STATIC mp_obj_t displayio_i2cdisplay_make_new(const mp_obj_type_t *type, size_t 
 
     mp_obj_t i2c = args[ARG_i2c_bus].u_obj;
     displayio_i2cdisplay_obj_t* self = &allocate_display_bus_or_raise()->i2cdisplay_bus;
+    self->base.type = &displayio_i2cdisplay_type;
 
     common_hal_displayio_i2cdisplay_construct(self,
         MP_OBJ_TO_PTR(i2c), args[ARG_device_address].u_int, reset);

--- a/shared-bindings/displayio/ParallelBus.c
+++ b/shared-bindings/displayio/ParallelBus.c
@@ -84,6 +84,7 @@ STATIC mp_obj_t displayio_parallelbus_make_new(const mp_obj_type_t *type, size_t
     mcu_pin_obj_t *reset = validate_obj_is_free_pin(args[ARG_reset].u_obj);
 
     displayio_parallelbus_obj_t* self = &allocate_display_bus_or_raise()->parallel_bus;
+    self->base.type = &displayio_parallelbus_type;
 
     common_hal_displayio_parallelbus_construct(self, data0, command, chip_select, write, read, reset);
     return self;


### PR DESCRIPTION
When allocate_display_bus_or_raise was factored out, the assignment of the bus's Python type was lost.  Restore it.

This would have affected displays of any type other than RGBMatrix, when they were created dynamically.  Boards with displays configured in flash were unaffected.

Testing performed: ran the code from https://forums.adafruit.com/viewtopic.php?f=60&t=164561 on a Metro M4 Express (no display attached)

Closes: #2792