### PR TITLE
Make particle Xenon analog RGB LED available to user

### DIFF
--- a/ports/nrf/boards/particle_xenon/mpconfigboard.h
+++ b/ports/nrf/boards/particle_xenon/mpconfigboard.h
@@ -32,10 +32,6 @@
 
 #define MICROPY_HW_LED_STATUS          (&pin_P1_12)
 
-#define CP_RGB_STATUS_R        (&pin_P0_13)
-#define CP_RGB_STATUS_G        (&pin_P0_14)
-#define CP_RGB_STATUS_B        (&pin_P0_15)
-
 #if QSPI_FLASH_FILESYSTEM
 #define MICROPY_QSPI_DATA0                NRF_GPIO_PIN_MAP(0, 20)
 #define MICROPY_QSPI_DATA1                NRF_GPIO_PIN_MAP(0, 21)


### PR DESCRIPTION
Particle Xenon has an on-board analog RGB LED but .with it's current configuration in CircuitPython it is not available to user. 

`
>>> import board
import digitalio
led = digitalio.DigitalInOut(board.RGB_LED_BLUE)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: RGB_LED_BLUE in use
`

It is understandable that this RGB LED could have been used to show bootloader status but it doesn't follow the standard set by CircuitPython project, making it unusable and not to mention it stays on all the time with some weird colour (power usage) , 

So IMHO it is a good idea to rather make this LED available to user within CircuitPython.

Fix tested on top of release 5.2.0

`
>>> import board
>>> import digitalio
>>> led = digitalio.DigitalInOut(board.RGB_LED_BLUE)
>>> led.direction = digitalio.Direction.OUTPUT
>>> led.value = 1
>>> led.value = 0
`