### PR TITLE
tools: upload .bin and .uf2 for Itaca uChip boards

### DIFF
--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -48,6 +48,7 @@ extension_by_board = {
     "feather_m0_basic": BIN_UF2,
     "feather_m0_rfm69": BIN_UF2,
     "feather_m0_rfm9x": BIN_UF2,
+    "uchip": BIN_UF2,
 
     # nRF52840 dev kits that may not have UF2 bootloaders,
     "makerdiary_nrf52840_mdk": HEX,


### PR DESCRIPTION
uChip boards are shipped with an Arduino bootloader.  The .bin files can be installed without first installing a .uf2 bootloader.

Resolves #2798 
