### PR TITLE
build.yml: Adjust for change in 'brew'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
       run: echo "$GITHUB_CONTEXT"
     - name: Make gettext programs available
       run: |
+        brew install gettext
         echo "::set-env name=PATH::/usr/local/opt/gettext/bin:$PATH"
     - name: Versions
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,15 +94,15 @@ jobs:
         path: mpy-cross/mpy-cross.static.exe
 
   mpy-cross-mac:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - name: Dump GitHub context
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - name: Install deps
+    - name: Make gettext programs available
       run: |
-        brew link --force gettext
+        echo "::set-env name=PATH::/usr/local/opt/gettext/bin:$PATH"
     - name: Versions
       run: |
         gcc --version


### PR DESCRIPTION
'brew' apparently introduced an incompatible change, where even "--force" does not actually make the commands available in the default path.

Also switch to a numbered macos release instead of "latest", though this did not save us from breaking changes in brew or other preinstalled sw.

This was reported upstream and they may be fixing it, but for now this puts the wheels back on the bus. https://github.com/Homebrew/homebrew-core/issues/53485