### PR TITLE
Standardize on FLASH_FIRMWARE section name in linker scripts

### DIFF
--- a/ports/litex/boards/fomu/fomu-spi.ld
+++ b/ports/litex/boards/fomu/fomu-spi.ld
@@ -8,6 +8,7 @@ ENTRY(_start)
 MEMORY
 {
     FLASH (rx)      : ORIGIN = 0x20040000, LENGTH = 0x100000 /* entire flash, 1 MiB */
+    FLASH_FIRMWARE (rx)      : ORIGIN = 0x20040000, LENGTH = 0x100000 /* entire flash, 1 MiB */
     RAM (xrw)       : ORIGIN = 0x10000000, LENGTH = 0x00020000 /* 128 KiB */
 }
 
@@ -19,7 +20,7 @@ SECTIONS
 {
     /* This is the initialized data section
     The program executes knowing that the data is in the RAM
-    but the loader puts the initial values in the FLASH (inidata).
+    but the loader puts the initial values in the FLASH_FIRMWARE (inidata).
     It is one task of the startup to copy the initial values from FLASH to RAM. */
     .data :  AT ( _sidata )
     {
@@ -73,7 +74,7 @@ SECTIONS
         _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
     } >RAM
 
-    /* The program code and other data goes into FLASH */
+    /* The program code and other data goes into FLASH_FIRMWARE */
     .text :
     {
         . = ALIGN(4);
@@ -88,7 +89,7 @@ SECTIONS
         . = ALIGN(4);
         _etext = .;        /* define a global symbol at end of code */
         _sidata = _etext;  /* This is used by the startup in order to initialize the .data secion */
-    } >FLASH
+    } >FLASH_FIRMWARE
 
     /* Uninitialized data section */
     .bss :

--- a/ports/litex/boards/fomu/fomu-spi.ld
+++ b/ports/litex/boards/fomu/fomu-spi.ld
@@ -7,9 +7,9 @@ ENTRY(_start)
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x20040000, LENGTH = 0x100000 /* entire flash, 1 MiB */
+    FLASH (rx)               : ORIGIN = 0x20040000, LENGTH = 0x100000 /* entire flash, 1 MiB */
     FLASH_FIRMWARE (rx)      : ORIGIN = 0x20040000, LENGTH = 0x100000 /* entire flash, 1 MiB */
-    RAM (xrw)       : ORIGIN = 0x10000000, LENGTH = 0x00020000 /* 128 KiB */
+    RAM (xrw)                : ORIGIN = 0x10000000, LENGTH = 0x00020000 /* 128 KiB */
 }
 
 /* top end of the stack */

--- a/ports/mimxrt10xx/linking/common.ld
+++ b/ports/mimxrt10xx/linking/common.ld
@@ -21,7 +21,7 @@ MEMORY
     /* This can't move because the bootrom looks at this address. */
     FLASH_IVT (rx)        : ORIGIN = 0x60001000, LENGTH = 4K
     /* Place the ISRs 48k in to leave room for the bootloader when it is available. */
-    FLASH_FIRMWARE (rx)        : ORIGIN = 0x6000C000, LENGTH = code_size - 48K
+    FLASH_FIRMWARE (rx)   : ORIGIN = 0x6000C000, LENGTH = code_size - 48K
     FLASH_FATFS (r)       : ORIGIN = 0x60100000, LENGTH = _ld_flash_size - code_size - _ld_reserved_flash_size
     /* Teensy uses the last bit of flash for recovery. */
     RESERVED_FLASH        : ORIGIN = 0x60100000 + _ld_flash_size - _ld_reserved_flash_size, LENGTH = _ld_reserved_flash_size

--- a/ports/mimxrt10xx/linking/common.ld
+++ b/ports/mimxrt10xx/linking/common.ld
@@ -21,7 +21,7 @@ MEMORY
     /* This can't move because the bootrom looks at this address. */
     FLASH_IVT (rx)        : ORIGIN = 0x60001000, LENGTH = 4K
     /* Place the ISRs 48k in to leave room for the bootloader when it is available. */
-    FLASH_TEXT (rx)        : ORIGIN = 0x6000C000, LENGTH = code_size - 48K
+    FLASH_FIRMWARE (rx)        : ORIGIN = 0x6000C000, LENGTH = code_size - 48K
     FLASH_FATFS (r)       : ORIGIN = 0x60100000, LENGTH = _ld_flash_size - code_size - _ld_reserved_flash_size
     /* Teensy uses the last bit of flash for recovery. */
     RESERVED_FLASH        : ORIGIN = 0x60100000 + _ld_flash_size - _ld_reserved_flash_size, LENGTH = _ld_reserved_flash_size
@@ -67,7 +67,7 @@ SECTIONS
     ) .text*)                /* .text* sections (code) */
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
         . = ALIGN(4);
-    } > FLASH_TEXT
+    } > FLASH_FIRMWARE
 
     .ARM.exidx :
     {
@@ -75,7 +75,7 @@ SECTIONS
         *(.gnu.linkonce.armexidx.*)
         _etext = .;        /* define a global symbol at end of code */
         __etext = .;       /* define a global symbol at end of code */
-    } > FLASH_TEXT
+    } > FLASH_FIRMWARE
 
     _ld_filesystem_start = ORIGIN(FLASH_FATFS);
     _ld_filesystem_end = _ld_filesystem_start + LENGTH(FLASH_FATFS);
@@ -87,7 +87,7 @@ SECTIONS
         *flexspi_nor_flash_ops.o(.text*)
         *fsl_flexspi.o(.text*)
         . = ALIGN(4);
-    } > OCRAM AT> FLASH_TEXT
+    } > OCRAM AT> FLASH_FIRMWARE
     _ld_ocram_data_destination = ADDR(.data);
     _ld_ocram_data_flash_copy = LOADADDR(.data);
     _ld_ocram_data_size = SIZEOF(.data);
@@ -114,7 +114,7 @@ SECTIONS
         *(.itcm.*)
 
         . = ALIGN(4);
-    } > ITCM AT> FLASH_TEXT
+    } > ITCM AT> FLASH_FIRMWARE
     _ld_itcm_destination = ADDR(.itcm);
     _ld_itcm_flash_copy = LOADADDR(.itcm);
     _ld_itcm_size = SIZEOF(.itcm);
@@ -126,7 +126,7 @@ SECTIONS
         *(.dtcm_data.*)
 
         . = ALIGN(4);
-    } > DTCM AT> FLASH_TEXT
+    } > DTCM AT> FLASH_FIRMWARE
     _ld_dtcm_data_destination = ADDR(.dtcm_data);
     _ld_dtcm_data_flash_copy = LOADADDR(.dtcm_data);
     _ld_dtcm_data_size = SIZEOF(.dtcm_data);

--- a/ports/stm/boards/STM32F401xd_fs.ld
+++ b/ports/stm/boards/STM32F401xd_fs.ld
@@ -8,7 +8,7 @@ MEMORY
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 384K /* entire flash */
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
     FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08010000, LENGTH = 320K /* sector 4 is 64K, sectors 5,6,7 are 128K */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 320K /* sector 4 is 64K, sectors 5,6,7 are 128K */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 96K
 }
 

--- a/ports/stm/boards/STM32F401xd_fs.ld
+++ b/ports/stm/boards/STM32F401xd_fs.ld
@@ -5,11 +5,11 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 384K /* entire flash */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
-    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
+    FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 384K /* entire flash */
+    FLASH_ISR (rx)      : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
+    FLASH_FS (rx)       : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 320K /* sector 4 is 64K, sectors 5,6,7 are 128K */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 96K
+    RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 96K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F401xe_boot.ld
+++ b/ports/stm/boards/STM32F401xe_boot.ld
@@ -7,7 +7,7 @@ MEMORY
 {
     FLASH (rx)      : ORIGIN = 0x08010000, LENGTH = 512K - 64K  /* entire flash, sans bootloader region */
     FLASH_ISR (rx)  : ORIGIN = 0x08010000, LENGTH = 64K         /* sector 4 */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 384K        /* sectors 5,6,7 are 128K */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08020000, LENGTH = 384K        /* sectors 5,6,7 are 128K */
     RAM (xrw)       : ORIGIN = 0x20000194, LENGTH = 96K - 0x194
 }
 

--- a/ports/stm/boards/STM32F401xe_boot.ld
+++ b/ports/stm/boards/STM32F401xe_boot.ld
@@ -5,10 +5,10 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08010000, LENGTH = 512K - 64K  /* entire flash, sans bootloader region */
-    FLASH_ISR (rx)  : ORIGIN = 0x08010000, LENGTH = 64K         /* sector 4 */
+    FLASH (rx)          : ORIGIN = 0x08010000, LENGTH = 512K - 64K  /* entire flash, sans bootloader region */
+    FLASH_ISR (rx)      : ORIGIN = 0x08010000, LENGTH = 64K         /* sector 4 */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08020000, LENGTH = 384K        /* sectors 5,6,7 are 128K */
-    RAM (xrw)       : ORIGIN = 0x20000194, LENGTH = 96K - 0x194
+    RAM (xrw)           : ORIGIN = 0x20000194, LENGTH = 96K - 0x194
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F401xe_fs.ld
+++ b/ports/stm/boards/STM32F401xe_fs.ld
@@ -8,7 +8,7 @@ MEMORY
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K /* entire flash */
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
     FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08010000, LENGTH = 448K /* sector 4 is 64K, sectors 5,6,7 are 128K */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 448K /* sector 4 is 64K, sectors 5,6,7 are 128K */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 96K
 }
 

--- a/ports/stm/boards/STM32F401xe_fs.ld
+++ b/ports/stm/boards/STM32F401xe_fs.ld
@@ -5,11 +5,11 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K /* entire flash */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
-    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
+    FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 512K /* entire flash */
+    FLASH_ISR (rx)      : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
+    FLASH_FS (rx)       : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 448K /* sector 4 is 64K, sectors 5,6,7 are 128K */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 96K
+    RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 96K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F405_boot.ld
+++ b/ports/stm/boards/STM32F405_boot.ld
@@ -5,11 +5,11 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08010000, LENGTH = 1024K - 64K         /* entire flash, sans bootloader region */
-    FLASH_ISR (rx)  : ORIGIN = 0x08010000, LENGTH = 64K                 /* sector 0 */
+    FLASH (rx)          : ORIGIN = 0x08010000, LENGTH = 1024K - 64K         /* entire flash, sans bootloader region */
+    FLASH_ISR (rx)      : ORIGIN = 0x08010000, LENGTH = 64K                 /* sector 0 */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08020000, LENGTH = 1024K - 64K - 64K   /* sectors 5+ */
-    CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 64K
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
+    CCMRAM (xrw)        : ORIGIN = 0x10000000, LENGTH = 64K
+    RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F405_boot.ld
+++ b/ports/stm/boards/STM32F405_boot.ld
@@ -7,7 +7,7 @@ MEMORY
 {
     FLASH (rx)      : ORIGIN = 0x08010000, LENGTH = 1024K - 64K         /* entire flash, sans bootloader region */
     FLASH_ISR (rx)  : ORIGIN = 0x08010000, LENGTH = 64K                 /* sector 0 */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 1024K - 64K - 64K   /* sectors 5+ */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08020000, LENGTH = 1024K - 64K - 64K   /* sectors 5+ */
     CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 64K
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
 }

--- a/ports/stm/boards/STM32F405_default.ld
+++ b/ports/stm/boards/STM32F405_default.ld
@@ -5,11 +5,11 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
+    FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
+    FLASH_ISR (rx)      : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08004000, LENGTH = 1008K /* sectors 0-7*/
-    CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 64K
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
+    CCMRAM (xrw)        : ORIGIN = 0x10000000, LENGTH = 64K
+    RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F405_default.ld
+++ b/ports/stm/boards/STM32F405_default.ld
@@ -7,7 +7,7 @@ MEMORY
 {
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
-    FLASH_TEXT (rx) : ORIGIN = 0x08004000, LENGTH = 1008K /* sectors 0-7*/
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08004000, LENGTH = 1008K /* sectors 0-7*/
     CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 64K
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
 }

--- a/ports/stm/boards/STM32F405_fs.ld
+++ b/ports/stm/boards/STM32F405_fs.ld
@@ -8,7 +8,7 @@ MEMORY
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
     FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08010000, LENGTH = 960K /* sector 4 is 64K, sectors 5,6,7 are 128K */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 960K /* sector 4 is 64K, sectors 5,6,7 are 128K */
     CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 64K
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
 }

--- a/ports/stm/boards/STM32F405_fs.ld
+++ b/ports/stm/boards/STM32F405_fs.ld
@@ -5,12 +5,12 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
-    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
+    FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
+    FLASH_ISR (rx)      : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
+    FLASH_FS (rx)       : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 960K /* sector 4 is 64K, sectors 5,6,7 are 128K */
-    CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 64K
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
+    CCMRAM (xrw)        : ORIGIN = 0x10000000, LENGTH = 64K
+    RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F407_fs.ld
+++ b/ports/stm/boards/STM32F407_fs.ld
@@ -8,7 +8,7 @@ MEMORY
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
     FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08010000, LENGTH = 960K /* sector 4 is 64K, sectors 5,6,7 are 128K */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 960K /* sector 4 is 64K, sectors 5,6,7 are 128K */
     CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 64K
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
 }

--- a/ports/stm/boards/STM32F407_fs.ld
+++ b/ports/stm/boards/STM32F407_fs.ld
@@ -5,12 +5,12 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
-    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
+    FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
+    FLASH_ISR (rx)      : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
+    FLASH_FS (rx)       : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 960K /* sector 4 is 64K, sectors 5,6,7 are 128K */
-    CCMRAM (xrw)    : ORIGIN = 0x10000000, LENGTH = 64K
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
+    CCMRAM (xrw)        : ORIGIN = 0x10000000, LENGTH = 64K
+    RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F411_fs.ld
+++ b/ports/stm/boards/STM32F411_fs.ld
@@ -8,7 +8,7 @@ MEMORY
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K /* entire flash */
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
     FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08010000, LENGTH = 448K /* sector 4 is 64K, sectors 5,6,7 are 128K */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 448K /* sector 4 is 64K, sectors 5,6,7 are 128K */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
 }
 

--- a/ports/stm/boards/STM32F411_fs.ld
+++ b/ports/stm/boards/STM32F411_fs.ld
@@ -5,11 +5,11 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K /* entire flash */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
-    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
+    FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 512K /* entire flash */
+    FLASH_ISR (rx)      : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
+    FLASH_FS (rx)       : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 448K /* sector 4 is 64K, sectors 5,6,7 are 128K */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
+    RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F411_nvm.ld
+++ b/ports/stm/boards/STM32F411_nvm.ld
@@ -9,7 +9,7 @@ MEMORY
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
     FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 32K /* sectors 1,2 are 16K */
     FLASH_NVM (rwx) : ORIGIN = 0x0800C000, LENGTH = 16K /* sector 3 is 16K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08010000, LENGTH = 448K /* sector 4 is 64K, sectors 5,6,7 are 128K */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 448K /* sector 4 is 64K, sectors 5,6,7 are 128K */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
 }
 

--- a/ports/stm/boards/STM32F411_nvm.ld
+++ b/ports/stm/boards/STM32F411_nvm.ld
@@ -5,12 +5,12 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K /* entire flash */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
-    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 32K /* sectors 1,2 are 16K */
-    FLASH_NVM (rwx) : ORIGIN = 0x0800C000, LENGTH = 16K /* sector 3 is 16K */
+    FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 512K /* entire flash */
+    FLASH_ISR (rx)      : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
+    FLASH_FS (rx)       : ORIGIN = 0x08004000, LENGTH = 32K /* sectors 1,2 are 16K */
+    FLASH_NVM (rwx)     : ORIGIN = 0x0800C000, LENGTH = 16K /* sector 3 is 16K */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 448K /* sector 4 is 64K, sectors 5,6,7 are 128K */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
+    RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F412_fs.ld
+++ b/ports/stm/boards/STM32F412_fs.ld
@@ -8,7 +8,7 @@ MEMORY
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
     FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08010000, LENGTH = 960K /* sector 4 is 64K, sectors 5,6,7 are 128K */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 960K /* sector 4 is 64K, sectors 5,6,7 are 128K */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 256K
 }
 

--- a/ports/stm/boards/STM32F412_fs.ld
+++ b/ports/stm/boards/STM32F412_fs.ld
@@ -5,11 +5,11 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
-    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
+    FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
+    FLASH_ISR (rx)      : ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
+    FLASH_FS (rx)       : ORIGIN = 0x08004000, LENGTH = 48K /* sectors 1,2,3 are 16K */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08010000, LENGTH = 960K /* sector 4 is 64K, sectors 5,6,7 are 128K */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 256K
+    RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F746xG_fs.ld
+++ b/ports/stm/boards/STM32F746xG_fs.ld
@@ -29,12 +29,12 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 32K /* sector 0 */
-    FLASH_FS (rx)   : ORIGIN = 0x08008000, LENGTH = 96K /* sectors 1,2,3 are 32K */
+    FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
+    FLASH_ISR (rx)      : ORIGIN = 0x08000000, LENGTH = 32K /* sector 0 */
+    FLASH_FS (rx)       : ORIGIN = 0x08008000, LENGTH = 96K /* sectors 1,2,3 are 32K */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08020000, LENGTH = 896K /* sector 4 is 128K, sectors 5,6,7 are 256K */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 320K
-    ITCM (xrw)      : ORIGIN = 0x00000000, LENGTH = 16K
+    RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 320K
+    ITCM (xrw)          : ORIGIN = 0x00000000, LENGTH = 16K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F746xG_fs.ld
+++ b/ports/stm/boards/STM32F746xG_fs.ld
@@ -32,7 +32,7 @@ MEMORY
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 32K /* sector 0 */
     FLASH_FS (rx)   : ORIGIN = 0x08008000, LENGTH = 96K /* sectors 1,2,3 are 32K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 896K /* sector 4 is 128K, sectors 5,6,7 are 256K */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08020000, LENGTH = 896K /* sector 4 is 128K, sectors 5,6,7 are 256K */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 320K
     ITCM (xrw)      : ORIGIN = 0x00000000, LENGTH = 16K
 }

--- a/ports/stm/boards/STM32F767_fs.ld
+++ b/ports/stm/boards/STM32F767_fs.ld
@@ -5,11 +5,11 @@
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K /* entire flash */
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 32K /* sector 0 */
-    FLASH_FS (rx)   : ORIGIN = 0x08008000, LENGTH = 96K /* sectors 1,2,3 are 32K */
+    FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 2048K /* entire flash */
+    FLASH_ISR (rx)      : ORIGIN = 0x08000000, LENGTH = 32K /* sector 0 */
+    FLASH_FS (rx)       : ORIGIN = 0x08008000, LENGTH = 96K /* sectors 1,2,3 are 32K */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08020000, LENGTH = 1920K /* sector 4 is 128K, sectors 5,6,7 are 256K */
-    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 512K
+    RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 512K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/STM32F767_fs.ld
+++ b/ports/stm/boards/STM32F767_fs.ld
@@ -8,7 +8,7 @@ MEMORY
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K /* entire flash */
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 32K /* sector 0 */
     FLASH_FS (rx)   : ORIGIN = 0x08008000, LENGTH = 96K /* sectors 1,2,3 are 32K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 1920K /* sector 4 is 128K, sectors 5,6,7 are 256K */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08020000, LENGTH = 1920K /* sector 4 is 128K, sectors 5,6,7 are 256K */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 512K
 }
 

--- a/ports/stm/boards/STM32H743_fs.ld
+++ b/ports/stm/boards/STM32H743_fs.ld
@@ -13,7 +13,7 @@ MEMORY
     FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
     FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 128K    /* sector 0, 128K */
     FLASH_FS (r)    : ORIGIN = 0x08020000, LENGTH = 128K    /* sector 1, 128K */
-    FLASH_TEXT (rx) : ORIGIN = 0x08040000, LENGTH = 1792K   /* sectors 6*128 + 8*128 */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08040000, LENGTH = 1792K   /* sectors 6*128 + 8*128 */
     DTCM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
     RAM (xrw)       : ORIGIN = 0x24000000, LENGTH = 512K    /* AXI SRAM */
     SRAM_D2 (xrw)   : ORIGIN = 0x30000000, LENGTH = 288K    /* AHB1 SRAM */

--- a/ports/stm/boards/STM32H743_fs.ld
+++ b/ports/stm/boards/STM32H743_fs.ld
@@ -10,15 +10,15 @@ _ld_default_stack_size = 24K;
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
-    FLASH_ISR (rx)  : ORIGIN = 0x08000000, LENGTH = 128K    /* sector 0, 128K */
-    FLASH_FS (r)    : ORIGIN = 0x08020000, LENGTH = 128K    /* sector 1, 128K */
+    FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 2048K
+    FLASH_ISR (rx)      : ORIGIN = 0x08000000, LENGTH = 128K    /* sector 0, 128K */
+    FLASH_FS (r)        : ORIGIN = 0x08020000, LENGTH = 128K    /* sector 1, 128K */
     FLASH_FIRMWARE (rx) : ORIGIN = 0x08040000, LENGTH = 1792K   /* sectors 6*128 + 8*128 */
-    DTCM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
-    RAM (xrw)       : ORIGIN = 0x24000000, LENGTH = 512K    /* AXI SRAM */
-    SRAM_D2 (xrw)   : ORIGIN = 0x30000000, LENGTH = 288K    /* AHB1 SRAM */
-    SRAM_D3 (xrw)   : ORIGIN = 0x30040000, LENGTH = 64K     /* AHB2 SRAM */
-    ITCM (xrw)      : ORIGIN = 0x00000000, LENGTH = 64K
+    DTCM (xrw)          : ORIGIN = 0x20000000, LENGTH = 128K
+    RAM (xrw)           : ORIGIN = 0x24000000, LENGTH = 512K    /* AXI SRAM */
+    SRAM_D2 (xrw)       : ORIGIN = 0x30000000, LENGTH = 288K    /* AHB1 SRAM */
+    SRAM_D3 (xrw)       : ORIGIN = 0x30040000, LENGTH = 64K     /* AHB2 SRAM */
+    ITCM (xrw)          : ORIGIN = 0x00000000, LENGTH = 64K
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */

--- a/ports/stm/boards/common_default.ld
+++ b/ports/stm/boards/common_default.ld
@@ -1,8 +1,8 @@
 /* Memory layout for default case. 
 
     FLASH_ISR   .isr_vector
-    FLASH_TEXT  .text
-    FLASH_TEXT  .data
+    FLASH_FIRMWARE  .text
+    FLASH_FIRMWARE  .data
     FLASH_FS    // ignored for fs use
 
     RAM         .data
@@ -42,7 +42,7 @@ SECTIONS
 
         . = ALIGN(4);
         _etext = .;        /* define a global symbol at end of code */
-    } >FLASH_TEXT
+    } >FLASH_FIRMWARE
 
     /* used by the startup to initialize data */
     _sidata = LOADADDR(.data);
@@ -59,7 +59,7 @@ SECTIONS
 
         . = ALIGN(4);
         _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
+    } >RAM AT> FLASH_FIRMWARE
 
     /* Uninitialized data section */
     .bss :

--- a/ports/stm/boards/common_default.ld
+++ b/ports/stm/boards/common_default.ld
@@ -1,14 +1,14 @@
 /* Memory layout for default case. 
 
-    FLASH_ISR   .isr_vector
+    FLASH_ISR       .isr_vector
     FLASH_FIRMWARE  .text
     FLASH_FIRMWARE  .data
-    FLASH_FS    // ignored for fs use
+    FLASH_FS        // ignored for fs use
 
-    RAM         .data
-    RAM         .bss
-    RAM         .heap
-    RAM         .stack
+    RAM             .data
+    RAM             .bss
+    RAM             .heap
+    RAM             .stack
 */
 
 ENTRY(Reset_Handler)

--- a/ports/stm/boards/common_nvm.ld
+++ b/ports/stm/boards/common_nvm.ld
@@ -1,16 +1,16 @@
 /* Memory layout for case with dedicated nvm sector (inefficient)
 TODO: rewrite nvm module, remove this file entirely
 
-    FLASH_ISR   .isr_vector
+    FLASH_ISR       .isr_vector
     FLASH_FIRMWARE  .text
     FLASH_FIRMWARE  .data
-    FLASH_NVM   .nvm_data
-    FLASH_FS    // ignored for fs use
+    FLASH_NVM       .nvm_data
+    FLASH_FS        // ignored for fs use
 
-    RAM         .data
-    RAM         .bss
-    RAM         .heap
-    RAM         .stack
+    RAM             .data
+    RAM             .bss
+    RAM             .heap
+    RAM             .stack
 */
 
 ENTRY(Reset_Handler)

--- a/ports/stm/boards/common_nvm.ld
+++ b/ports/stm/boards/common_nvm.ld
@@ -2,8 +2,8 @@
 TODO: rewrite nvm module, remove this file entirely
 
     FLASH_ISR   .isr_vector
-    FLASH_TEXT  .text
-    FLASH_TEXT  .data
+    FLASH_FIRMWARE  .text
+    FLASH_FIRMWARE  .data
     FLASH_NVM   .nvm_data
     FLASH_FS    // ignored for fs use
 
@@ -52,7 +52,7 @@ SECTIONS
 
         . = ALIGN(4);
         _etext = .;        /* define a global symbol at end of code */
-    } >FLASH_TEXT
+    } >FLASH_FIRMWARE
 
     /* used by the startup to initialize data */
     _sidata = LOADADDR(.data);
@@ -69,7 +69,7 @@ SECTIONS
 
         . = ALIGN(4);
         _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
+    } >RAM AT> FLASH_FIRMWARE
 
     /* Uninitialized data section */
     .bss :

--- a/ports/stm/boards/common_tcm.ld
+++ b/ports/stm/boards/common_tcm.ld
@@ -1,18 +1,18 @@
 /* Memory layout for cases with itcm and dtcm
 
-    FLASH_ISR   .isr_vector
+    FLASH_ISR       .isr_vector
     FLASH_FIRMWARE  .text
     FLASH_FIRMWARE  .data
-    FLASH_FS    // ignored for fs use
+    FLASH_FS        // ignored for fs use
 
-    RAM         .data
-    RAM         .bss
-    RAM         .heap
+    RAM             .data
+    RAM             .bss
+    RAM             .heap
 
-    ITCM        .itcm
-    DTCM        .dtcm_data
-    DTCM        .dtcm_bss
-    DTCM        .stack
+    ITCM            .itcm
+    DTCM            .dtcm_data
+    DTCM            .dtcm_bss
+    DTCM            .stack
 */
 
 ENTRY(Reset_Handler)

--- a/ports/stm/boards/common_tcm.ld
+++ b/ports/stm/boards/common_tcm.ld
@@ -1,8 +1,8 @@
 /* Memory layout for cases with itcm and dtcm
 
     FLASH_ISR   .isr_vector
-    FLASH_TEXT  .text
-    FLASH_TEXT  .data
+    FLASH_FIRMWARE  .text
+    FLASH_FIRMWARE  .data
     FLASH_FS    // ignored for fs use
 
     RAM         .data
@@ -44,7 +44,7 @@ SECTIONS
 
         . = ALIGN(4);
         _etext = .;        /* define a global symbol at end of code */
-    } >FLASH_TEXT
+    } >FLASH_FIRMWARE
 
     /* used by the startup to initialize data */
     _sidata = LOADADDR(.data);
@@ -61,7 +61,7 @@ SECTIONS
 
         . = ALIGN(4);
         _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM AT> FLASH_TEXT
+    } >RAM AT> FLASH_FIRMWARE
     _ld_d1_ram_data_destination = ADDR(.data);
     _ld_d1_ram_data_flash_copy = LOADADDR(.data);
     _ld_d1_ram_data_size = SIZEOF(.data);
@@ -98,7 +98,7 @@ SECTIONS
         *(.itcm.*)
 
         . = ALIGN(4);
-    } > ITCM AT> FLASH_TEXT
+    } > ITCM AT> FLASH_FIRMWARE
     _ld_itcm_destination = ADDR(.itcm);
     _ld_itcm_flash_copy = LOADADDR(.itcm);
     _ld_itcm_size = SIZEOF(.itcm);
@@ -110,7 +110,7 @@ SECTIONS
         *(.dtcm_data.*)
 
         . = ALIGN(4);
-    } > DTCM AT> FLASH_TEXT
+    } > DTCM AT> FLASH_FIRMWARE
     _ld_dtcm_data_destination = ADDR(.dtcm_data);
     _ld_dtcm_data_flash_copy = LOADADDR(.dtcm_data);
     _ld_dtcm_data_size = SIZEOF(.dtcm_data);

--- a/tools/build_memory_info.py
+++ b/tools/build_memory_info.py
@@ -52,7 +52,7 @@ regions = {}
 with open(sys.argv[1], "r") as f:
     for line in f:
         line = line.strip()
-        if line.startswith(("FLASH_FIRMWARE", "FLASH", "RAM")):
+        if line.startswith(("FLASH_FIRMWARE", "RAM")):
             regions[line.split()[0]] = line.split("=")[-1]
 
 for region in regions:
@@ -63,11 +63,7 @@ for region in regions:
     space = M_PATTERN.sub(M_REPLACE, space)
     regions[region] = int(eval(space))
 
-# TODO Remove check for both FLASH_FIRMWARE and FLASH after all ports are converted to use FLASH_FIRMWARE.
-try:
-    firmware_region = regions["FLASH_FIRMWARE"]
-except KeyError:
-    firmware_region = regions["FLASH"]
+firmware_region = regions["FLASH_FIRMWARE"]
 ram_region = regions["RAM"]
 
 free_flash = firmware_region - text - data

--- a/tools/build_memory_info.py
+++ b/tools/build_memory_info.py
@@ -66,10 +66,12 @@ for region in regions:
 firmware_region = regions["FLASH_FIRMWARE"]
 ram_region = regions["RAM"]
 
-free_flash = firmware_region - text - data
-free_ram = ram_region - data - bss
-print("{} bytes free in flash firmware space out of {} bytes ({}kB).".format(free_flash, firmware_region, firmware_region / 1024))
-print("{} bytes free in ram for stack and heap out of {} bytes ({}kB).".format(free_ram, ram_region, ram_region / 1024))
+used_flash = data + text
+free_flash = firmware_region - used_flash
+used_ram = data + bss
+free_ram = ram_region - used_ram
+print("{} bytes used, {} bytes free in flash firmware space out of {} bytes ({}kB).".format(used_flash, free_flash, firmware_region, firmware_region / 1024))
+print("{} bytes used, {} bytes free in ram for stack and heap out of {} bytes ({}kB).".format(used_ram, free_ram, ram_region, ram_region / 1024))
 print()
 
 # Check that we have free flash space. GCC doesn't fail when the text + data


### PR DESCRIPTION
Closes: #2816 

This ended up touching stm, i.mx, and litex ports.

I only built, I didn't test on HW.