### PR TITLE
displayio: Add lightweight Rectangle

### DIFF
--- a/py/circuitpy_defns.mk
+++ b/py/circuitpy_defns.mk
@@ -350,6 +350,7 @@ SRC_SHARED_MODULE_ALL = \
 	displayio/I2CDisplay.c \
 	displayio/OnDiskBitmap.c \
 	displayio/Palette.c \
+	displayio/Rectangle.c\
 	displayio/Shape.c \
 	displayio/TileGrid.c \
 	displayio/__init__.c \

--- a/shared-bindings/board/__init__.c
+++ b/shared-bindings/board/__init__.c
@@ -113,7 +113,7 @@ mp_obj_t board_uart(void) {
 }
 #else
 mp_obj_t board_uart(void) {
-    mp_raise_NotImplementedError_varg(translate("No default %q bus"), MP_QSTR_SPI);
+    mp_raise_NotImplementedError_varg(translate("No default %q bus"), MP_QSTR_UART);
     return NULL;
 }
 #endif

--- a/shared-bindings/displayio/Rectangle.c
+++ b/shared-bindings/displayio/Rectangle.c
@@ -1,0 +1,60 @@
+
+#include "shared-bindings/displayio/Rectangle.h"
+
+#include <stdint.h>
+#include <float.h>
+
+#include "py/binary.h"
+#include "py/objproperty.h"
+#include "py/objtype.h"
+#include "py/runtime.h"
+#include "shared-bindings/util.h"
+#include "supervisor/shared/translate.h"
+
+
+//| .. currentmodule:: displayio
+//|
+//| :class:`Rectangle` -- Represents a rectangle by defining its bounds
+//| ==========================================================================
+//|
+//| .. class:: Rectangle(width, height)
+//|
+//|   :param int width: The number of pixels wide
+//|   :param int height: The number of pixels high
+//|
+static mp_obj_t displayio_rectangle_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_width, ARG_height, ARG_rotation_radians };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_width, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_height, MP_ARG_REQUIRED | MP_ARG_INT },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    mp_int_t width = args[ARG_width].u_int;
+    if (width < 1) {
+        mp_raise_ValueError_varg(translate("%q must be >= 1"), MP_QSTR_width);
+    }
+    mp_int_t height = args[ARG_height].u_int;
+    if (height < 1) {
+        mp_raise_ValueError_varg(translate("%q must be >= 1"), MP_QSTR_height);
+    }
+
+    displayio_rectangle_t *self = m_new_obj(displayio_rectangle_t);
+    self->base.type = &displayio_rectangle_type;
+    common_hal_displayio_rectangle_construct(self, width, height);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+
+STATIC const mp_rom_map_elem_t displayio_rectangle_locals_dict_table[] = {
+};
+STATIC MP_DEFINE_CONST_DICT(displayio_rectangle_locals_dict, displayio_rectangle_locals_dict_table);
+
+const mp_obj_type_t displayio_rectangle_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_Rectangle,
+    .make_new = displayio_rectangle_make_new,
+    .locals_dict = (mp_obj_dict_t*)&displayio_rectangle_locals_dict,
+};

--- a/shared-bindings/displayio/Rectangle.c
+++ b/shared-bindings/displayio/Rectangle.c
@@ -2,13 +2,9 @@
 #include "shared-bindings/displayio/Rectangle.h"
 
 #include <stdint.h>
-#include <float.h>
 
-#include "py/binary.h"
-#include "py/objproperty.h"
 #include "py/objtype.h"
 #include "py/runtime.h"
-#include "shared-bindings/util.h"
 #include "supervisor/shared/translate.h"
 
 

--- a/shared-bindings/displayio/Rectangle.h
+++ b/shared-bindings/displayio/Rectangle.h
@@ -1,0 +1,12 @@
+#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_RECTANGLE_H
+#define MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_RECTANGLE_H
+
+#include "shared-module/displayio/Rectangle.h"
+
+extern const mp_obj_type_t displayio_rectangle_type;
+
+void common_hal_displayio_rectangle_construct(displayio_rectangle_t *self, uint32_t width, uint32_t height);
+
+uint32_t common_hal_displayio_rectangle_get_pixel(void *shape, int16_t x, int16_t y);
+
+#endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_RECTANGLE_H

--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -37,6 +37,7 @@
 #include "shared-bindings/displayio/ColorConverter.h"
 #include "shared-bindings/displayio/OnDiskBitmap.h"
 #include "shared-bindings/displayio/Palette.h"
+#include "shared-bindings/displayio/Rectangle.h"
 #include "shared-bindings/displayio/Shape.h"
 #include "supervisor/shared/translate.h"
 
@@ -93,6 +94,10 @@ STATIC mp_obj_t displayio_tilegrid_make_new(const mp_obj_type_t *type, size_t n_
         displayio_shape_t* bmp = MP_OBJ_TO_PTR(native);
         bitmap_width = bmp->width;
         bitmap_height = bmp->height;
+    } else if (MP_OBJ_IS_TYPE(bitmap, &displayio_rectangle_type)) {
+        displayio_rectangle_t* rectangle = MP_OBJ_TO_PTR(bitmap);
+        bitmap_width = rectangle->width;
+	bitmap_height = rectangle->height;
     } else if (MP_OBJ_IS_TYPE(bitmap, &displayio_bitmap_type)) {
         displayio_bitmap_t* bmp = MP_OBJ_TO_PTR(bitmap);
         native = bitmap;

--- a/shared-bindings/displayio/__init__.c
+++ b/shared-bindings/displayio/__init__.c
@@ -40,6 +40,7 @@
 #include "shared-bindings/displayio/OnDiskBitmap.h"
 #include "shared-bindings/displayio/Palette.h"
 #include "shared-bindings/displayio/ParallelBus.h"
+#include "shared-bindings/displayio/Rectangle.h"
 #include "shared-bindings/displayio/Shape.h"
 #include "shared-bindings/displayio/TileGrid.h"
 
@@ -69,6 +70,7 @@
 //|     Palette
 //|     ParallelBus
 //|     Shape
+//|     Rectangle
 //|     TileGrid
 //|
 
@@ -97,6 +99,7 @@ STATIC const mp_rom_map_elem_t displayio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_Group), MP_ROM_PTR(&displayio_group_type) },
     { MP_ROM_QSTR(MP_QSTR_OnDiskBitmap), MP_ROM_PTR(&displayio_ondiskbitmap_type) },
     { MP_ROM_QSTR(MP_QSTR_Palette), MP_ROM_PTR(&displayio_palette_type) },
+    { MP_ROM_QSTR(MP_QSTR_Rectangle), MP_ROM_PTR(&displayio_rectangle_type) },
     { MP_ROM_QSTR(MP_QSTR_Shape), MP_ROM_PTR(&displayio_shape_type) },
     { MP_ROM_QSTR(MP_QSTR_TileGrid), MP_ROM_PTR(&displayio_tilegrid_type) },
 

--- a/shared-module/displayio/Rectangle.c
+++ b/shared-module/displayio/Rectangle.c
@@ -1,0 +1,18 @@
+#include "shared-bindings/displayio/Rectangle.h"
+
+#include <string.h>
+
+#include "py/runtime.h"
+
+void common_hal_displayio_rectangle_construct(displayio_rectangle_t *self, uint32_t width, uint32_t height) {
+    self->width = width;
+    self->height = height;
+}
+
+uint32_t common_hal_displayio_rectangle_get_pixel(void *obj, int16_t x, int16_t y) {
+    displayio_rectangle_t *self = obj;
+    if (x < 0 || x >= self->width || y >= self->height || y < 0) {
+        return 0;
+    }
+    return 1;
+}

--- a/shared-module/displayio/Rectangle.c
+++ b/shared-module/displayio/Rectangle.c
@@ -1,7 +1,5 @@
 #include "shared-bindings/displayio/Rectangle.h"
 
-#include <string.h>
-
 #include "py/runtime.h"
 
 void common_hal_displayio_rectangle_construct(displayio_rectangle_t *self, uint32_t width, uint32_t height) {

--- a/shared-module/displayio/Rectangle.h
+++ b/shared-module/displayio/Rectangle.h
@@ -1,0 +1,15 @@
+#ifndef MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_RECTANGLE_H
+#define MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_RECTANGLE_H
+
+#include <stdint.h>
+#include <float.h>
+
+#include "py/obj.h"
+
+typedef struct {
+    mp_obj_base_t base;
+    uint16_t width;
+    uint16_t height;
+} displayio_rectangle_t;
+
+#endif // MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_RECTANGLE_H

--- a/shared-module/displayio/Rectangle.h
+++ b/shared-module/displayio/Rectangle.h
@@ -2,7 +2,6 @@
 #define MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_RECTANGLE_H
 
 #include <stdint.h>
-#include <float.h>
 
 #include "py/obj.h"
 


### PR DESCRIPTION
Shape uses a bitmap to represent blocked regions.  This is fine
  for some shapes, but others may be more compactly represented.

This lets users make large, possibly overlapping areas of their screen be colored without running out of memory due to bitmap arrays in adafruit_display_shapes.Rect.

![image](https://user-images.githubusercontent.com/3454741/80860347-ef004780-8c1b-11ea-9808-4e7c3406e0fa.png)

Used like:
```
palette = displayio.Palette(1)
palette[0] = 0x001100
bitmap_grid = displayio.TileGrid(
    displayio.Rectangle(320, 220),
    pixel_shader=palette,
    x=0,
    y=20,
)
display_group.append(bitmap_grid)
```
