### PR TITLE
.../external_flash.c: Don't attempt to issue CMD_READ_STATUS2 for devices with only a single_status_byte.

### DIFF
--- a/supervisor/shared/external_flash/external_flash.c
+++ b/supervisor/shared/external_flash/external_flash.c
@@ -218,11 +218,12 @@ void supervisor_flash_init(void) {
     do {
         spi_flash_read_command(CMD_READ_STATUS, read_status_response, 1);
     } while ((read_status_response[0] & 0x1) != 0);
-    // The suspended write/erase bit should be low.
-    do {
+    if (!flash_device->single_status_byte) {
+      // The suspended write/erase bit should be low.
+      do {
         spi_flash_read_command(CMD_READ_STATUS2, read_status_response, 1);
-    } while ((read_status_response[0] & 0x80) != 0);
-
+      } while ((read_status_response[0] & 0x80) != 0);
+    }
 
     spi_flash_command(CMD_ENABLE_RESET);
     spi_flash_command(CMD_RESET);


### PR DESCRIPTION
supervisor_flash_init() erroneously attempts to send CMD_READ_STATUS2 for devices with only a single status byte.

For my case with the MX25L51245G flash memory chip wired for QSPI and QSPI enabled in mpconfigboard.h, the boot up process hangs in supervisor_flash_init() at the point where the CMD_READ_STATUS2 command is issued because the command is not supported by the device and the subsequent check in the enclosing while loop is always true.

I corrected this for my case by simply not issuing the command - following the example in qspi_flash.c . I've tested on my own board and everything is working. Note - this is an M4 based board with the atsamd51n20.

I have tested on the board bdmicro_vina_m0 which uses the same MX25L51245G flash chip, but in standard SPI_FLASH mode (not QSPI), and everything seems to still work without issues. (BTW, not sure how this worked on that board without this fix in the first place.)

I'm not sure if this needs more testing or not on a wider range of boards and flash chips before merging. However, if a flash chip only has a single status byte, it seems reasonable that the command to read status2 should not be attempted.