### PR TITLE
Fix usb sleep for NRF

### DIFF
--- a/ports/nrf/peripherals/nrf/nvm.c
+++ b/ports/nrf/peripherals/nrf/nvm.c
@@ -40,6 +40,8 @@
 
 STATIC bool sd_is_enabled(void) {
     uint8_t sd_en = 0;
+    if (__get_PRIMASK())
+        return false;
     (void) sd_softdevice_is_enabled(&sd_en);
     return sd_en;
 }

--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -273,8 +273,10 @@ void port_sleep_until_interrupt(void) {
         // available, even though the actual handler won't fire until
         // we re-enable interrupts.
         common_hal_mcu_disable_interrupts();
-        if (!tud_task_event_ready())
+        if (!tud_task_event_ready()) {
+            __DSB();
             __WFI();
+        }
         common_hal_mcu_enable_interrupts();
     }
 }

--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -51,7 +51,10 @@
 #include "common-hal/rtc/RTC.h"
 #include "common-hal/neopixel_write/__init__.h"
 
+#include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/rtc/__init__.h"
+
+#include "lib/tinyusb/src/device/usbd.h"
 
 #ifdef CIRCUITPY_AUDIOBUSIO
 #include "common-hal/audiobusio/I2SOut.h"
@@ -264,7 +267,15 @@ void port_sleep_until_interrupt(void) {
         sd_app_evt_wait();
     } else {
         // Call wait for interrupt ourselves if the SD isn't enabled.
-        __WFI();
+        // Note that `wfi` should be called with interrupts disabled,
+        // to ensure that the queue is properly drained.  The `wfi`
+        // instruction will returned as long as an interrupt is
+        // available, even though the actual handler won't fire until
+        // we re-enable interrupts.
+        common_hal_mcu_disable_interrupts();
+        if (!tud_task_event_ready())
+            __WFI();
+        common_hal_mcu_enable_interrupts();
     }
 }
 

--- a/supervisor/shared/usb/tusb_config.h
+++ b/supervisor/shared/usb/tusb_config.h
@@ -49,7 +49,9 @@
 //--------------------------------------------------------------------+
 #define CFG_TUSB_RHPORT0_MODE       OPT_MODE_DEVICE
 
+#ifndef CFG_TUSB_DEBUG
 #define CFG_TUSB_DEBUG              0
+#endif
 
 /*------------- RTOS -------------*/
 #ifndef CFG_TUSB_OS


### PR DESCRIPTION
This fixes connecting and disconnecting USB while executing `time.sleep()` on NRF.  This issue may be present on other ports, so similar fixes should be implemented on other platforms as well.