### PR TITLE
ujson: work with mp stream protocol for fast & easy read

### DIFF
--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -45,6 +45,9 @@
 
 #include "samd/sercom.h"
 
+#define UART_DEBUG(...) (void)0
+// #define UART_DEBUG(...) mp_printf(&mp_plat_print __VA_OPT__(,) __VA_ARGS__)
+
 // Do-nothing callback needed so that usart_async code will enable rx interrupts.
 // See comment below re usart_async_register_callback()
 static void usart_async_rxc_callback(const struct usart_async_descriptor *const descr) {

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -39,6 +39,9 @@
 #include "py/stream.h"
 #include "supervisor/shared/translate.h"
 
+#define STREAM_DEBUG(...) (void)0
+// #define STREAM_DEBUG(...) mp_printf(&mp_plat_print __VA_OPT__(,) __VA_ARGS__)
+
 
 //| .. currentmodule:: busio
 //|
@@ -219,6 +222,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_uart___exit___obj, 4, 4, busio_
 
 // These three methods are used by the shared stream methods.
 STATIC mp_uint_t busio_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
+    STREAM_DEBUG("busio_uart_read stream %d\n", size);
     busio_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
     byte *buf = buf_in;


### PR DESCRIPTION
Ujson should be able to read directly from device input buffers that support MP stream protocol.

When you attempt to read(1) on a UART (and possibly other protocols) you have to wait for either the byte or the timeout.

Fixes:
- Waiting for a timeout after you have completed reading a correct and complete JSON off the input.
- Raising an OSError after reading a correct and complete JSON off the input.
- Eating more data than semantically owned off the input buffer.
- Blocking to start parsing JSON until the entire JSON body has been loaded into a potentially large, contiguous Python object.

Code you would write before:
```
line = board_busio_uart_port.read_line()
json_dict = json.loads(line)
```
or reaching for fixed buffers and swapping them around in Python.

Code that did not work before that does now:
```
json_dict = json.load(board_busio_uart_port)
```

- This removes the need for intermediate copies of data when reading JSON from micropython stream protocol inputs.
- It also increases total application speed by parsing JSON concurrently with receiving on boards that read from UART via DMA.
- It simplifies code that users write while improving their apps.