### PR TITLE
Use a linked list of background tasks to perform

### DIFF
--- a/main.c
+++ b/main.c
@@ -45,6 +45,7 @@
 
 #include "background.h"
 #include "mpconfigboard.h"
+#include "supervisor/background_callback.h"
 #include "supervisor/cpu.h"
 #include "supervisor/memory.h"
 #include "supervisor/port.h"
@@ -160,6 +161,8 @@ void stop_mp(void) {
     MP_STATE_VM(vfs_mount_table) = vfs;
     MP_STATE_VM(vfs_cur) = vfs;
     #endif
+
+    background_callback_reset();
 
     gc_deinit();
 }

--- a/main.c
+++ b/main.c
@@ -493,6 +493,8 @@ void gc_collect(void) {
     // have lost their references in the VM even though they are mounted.
     gc_collect_root((void**)&MP_STATE_VM(vfs_mount_table), sizeof(mp_vfs_mount_t) / sizeof(mp_uint_t));
 
+    background_callback_gc_collect();
+
     #if CIRCUITPY_DISPLAYIO
     displayio_gc_collect();
     #endif

--- a/main.c
+++ b/main.c
@@ -101,8 +101,6 @@ void start_mp(supervisor_allocation* heap) {
     reset_status_led();
     autoreload_stop();
 
-    background_tasks_reset();
-
     // Stack limit should be less than real stack size, so we have a chance
     // to recover from limit hit.  (Limit is measured in bytes.)
     mp_stack_ctrl_init();

--- a/ports/atmel-samd/audio_dma.h
+++ b/ports/atmel-samd/audio_dma.h
@@ -31,6 +31,7 @@
 #include "py/obj.h"
 #include "shared-module/audiocore/RawSample.h"
 #include "shared-module/audiocore/WaveFile.h"
+#include "supervisor/background_callback.h"
 
 typedef struct {
     mp_obj_t sample;
@@ -49,6 +50,7 @@ typedef struct {
     uint8_t* second_buffer;
     bool first_descriptor_free;
     DmacDescriptor* second_descriptor;
+    background_callback_t callback;
 } audio_dma_t;
 
 typedef enum {

--- a/ports/atmel-samd/background.c
+++ b/ports/atmel-samd/background.c
@@ -39,59 +39,21 @@
 #include "shared-module/displayio/__init__.h"
 #endif
 
-volatile uint64_t last_finished_tick = 0;
-
-bool stack_ok_so_far = true;
-
-static bool running_background_tasks = false;
-
 #ifdef MONITOR_BACKGROUND_TASKS
 // PB03 is physical pin "SCL" on the Metro M4 express
 // so you can't use this code AND an i2c peripheral
 // at the same time unless you change this
-STATIC void start_background_task(void) {
+void port_start_background_task(void) {
     REG_PORT_DIRSET1 = (1<<3);
     REG_PORT_OUTSET1 = (1<<3);
 }
 
-STATIC void finish_background_task(void) {
+void port_finish_background_task(void) {
     REG_PORT_OUTCLR1 = (1<<3);
 }
 #else
-STATIC void start_background_task(void) {}
-STATIC void finish_background_task(void) {}
+void port_start_background_task(void) {}
+void port_finish_background_task(void) {}
 #endif
 
-void background_tasks_reset(void) {
-    running_background_tasks = false;
-}
-
-void run_background_tasks(void) {
-    // Don't call ourselves recursively.
-    if (running_background_tasks) {
-        return;
-    }
-
-    start_background_task();
-
-    assert_heap_ok();
-    running_background_tasks = true;
-
-    #if CIRCUITPY_DISPLAYIO
-    displayio_background();
-    #endif
-
-    #if CIRCUITPY_NETWORK
-    network_module_background();
-    #endif
-    filesystem_background();
-    running_background_tasks = false;
-    assert_heap_ok();
-
-    last_finished_tick = port_get_raw_ticks(NULL);
-    finish_background_task();
-}
-
-bool background_tasks_ok(void) {
-    return port_get_raw_ticks(NULL) - last_finished_tick < 1024;
-}
+void port_background_task(void) {}

--- a/ports/atmel-samd/background.c
+++ b/ports/atmel-samd/background.c
@@ -85,7 +85,6 @@ void run_background_tasks(void) {
     network_module_background();
     #endif
     filesystem_background();
-    usb_background();
     running_background_tasks = false;
     assert_heap_ok();
 

--- a/ports/atmel-samd/background.c
+++ b/ports/atmel-samd/background.c
@@ -77,9 +77,6 @@ void run_background_tasks(void) {
     assert_heap_ok();
     running_background_tasks = true;
 
-    #if CIRCUITPY_AUDIOIO || CIRCUITPY_AUDIOBUSIO
-    audio_dma_background();
-    #endif
     #if CIRCUITPY_DISPLAYIO
     displayio_background();
     #endif

--- a/ports/atmel-samd/background.h
+++ b/ports/atmel-samd/background.h
@@ -29,9 +29,4 @@
 
 #include <stdbool.h>
 
-void background_tasks_reset(void);
-void run_background_tasks(void);
-void run_background_vm_tasks(void);
-bool background_tasks_ok(void);
-
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_BACKGROUND_H

--- a/ports/atmel-samd/boards/uchip/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/uchip/mpconfigboard.mk
@@ -9,3 +9,10 @@ CHIP_FAMILY = samd21
 INTERNAL_FLASH_FILESYSTEM = 1
 LONGINT_IMPL = NONE
 CIRCUITPY_FULL_BUILD = 0
+
+# Tweak inlining depending on language.
+ifeq ($(TRANSLATION), zh_Latn_pinyin)
+CFLAGS_INLINE_LIMIT = 45
+else
+CFLAGS_INLINE_LIMIT = 70
+endif

--- a/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+++ b/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -46,6 +46,7 @@
 #include "hpl_gclk_config.h"
 
 #include "shared-bindings/time/__init__.h"
+#include "supervisor/shared/tick.h"
 #include "supervisor/shared/translate.h"
 
 #ifdef SAMD21
@@ -132,7 +133,7 @@ void frequencyin_interrupt_handler(uint8_t index) {
             }
 
             // Check if we've reached the upper limit of detection
-            if (!background_tasks_ok() || self->errored_too_fast) {
+            if (!supervisor_background_tasks_ok() || self->errored_too_fast) {
                 self->errored_too_fast = true;
                 frequencyin_emergency_cancel_capture(i);
             }

--- a/ports/atmel-samd/common-hal/pulseio/PulseIn.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseIn.c
@@ -42,6 +42,7 @@
 #include "samd/timers.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/pulseio/PulseIn.h"
+#include "supervisor/shared/tick.h"
 #include "supervisor/shared/translate.h"
 
 // This timer is shared amongst all PulseIn objects as a higher resolution clock.
@@ -87,7 +88,7 @@ void pulsein_interrupt_handler(uint8_t channel) {
     uint32_t current_count = tc->COUNT16.COUNT.reg;
 
     pulseio_pulsein_obj_t* self = get_eic_channel_data(channel);
-    if (!background_tasks_ok() || self->errored_too_fast) {
+    if (!supervisor_background_tasks_ok() || self->errored_too_fast) {
         self->errored_too_fast = true;
         common_hal_pulseio_pulsein_pause(self);
         return;

--- a/ports/atmel-samd/supervisor/usb.c
+++ b/ports/atmel-samd/supervisor/usb.c
@@ -29,6 +29,8 @@
 #include "hpl/gclk/hpl_gclk_base.h"
 #include "hal_gpio.h"
 #include "lib/tinyusb/src/device/usbd.h"
+#include "supervisor/background_callback.h"
+#include "supervisor/usb.h"
 
 void init_usb_hardware(void) {
     #ifdef SAMD21
@@ -61,24 +63,24 @@ void init_usb_hardware(void) {
 
 #ifdef SAMD21
 void USB_Handler(void) {
-    tud_int_handler(0);
+    usb_irq_handler();
 }
 #endif
 
 #ifdef SAM_D5X_E5X
 void USB_0_Handler (void) {
-  tud_int_handler(0);
+    usb_irq_handler();
 }
 
 void USB_1_Handler (void) {
-  tud_int_handler(0);
+    usb_irq_handler();
 }
 
 void USB_2_Handler (void) {
-  tud_int_handler(0);
+    usb_irq_handler();
 }
 
 void USB_3_Handler (void) {
-  tud_int_handler(0);
+    usb_irq_handler();
 }
 #endif

--- a/ports/cxd56/background.c
+++ b/ports/cxd56/background.c
@@ -30,24 +30,6 @@
 #include "supervisor/filesystem.h"
 #include "supervisor/shared/stack.h"
 
-static bool running_background_tasks = false;
-
-void background_tasks_reset(void) {
-    running_background_tasks = false;
-}
-
-void run_background_tasks(void) {
-    // Don't call ourselves recursively.
-    if (running_background_tasks) {
-        return;
-    }
-
-    assert_heap_ok();
-    running_background_tasks = true;
-
-    usb_background();
-    filesystem_background();
-
-    running_background_tasks = false;
-    assert_heap_ok();
-}
+void port_background_task(void) {}
+void port_start_background_task(void) {}
+void port_finish_background_task(void) {}

--- a/ports/cxd56/background.h
+++ b/ports/cxd56/background.h
@@ -27,7 +27,4 @@
 #ifndef MICROPY_INCLUDED_CXD56_BACKGROUND_H
 #define MICROPY_INCLUDED_CXD56_BACKGROUND_H
 
-void background_tasks_reset(void);
-void run_background_tasks(void);
-
 #endif  // MICROPY_INCLUDED_CXD56_BACKGROUND_H

--- a/ports/esp32s2/background.c
+++ b/ports/esp32s2/background.c
@@ -35,27 +35,12 @@
 #include "shared-module/displayio/__init__.h"
 #endif
 
-static bool running_background_tasks = false;
 
-void background_tasks_reset(void) {
-    running_background_tasks = false;
-}
-
-void run_background_tasks(void) {
-    // Don't call ourselves recursively.
-    if (running_background_tasks) {
-        return;
-    }
-
+void port_background_task(void) {
     // Zero delay in case FreeRTOS wants to switch to something else.
     vTaskDelay(0);
-    running_background_tasks = true;
-    filesystem_background();
-
-    #if CIRCUITPY_DISPLAYIO
-    displayio_background();
-    #endif
-    running_background_tasks = false;
-
-    assert_heap_ok();
 }
+
+void port_start_background_task(void) {}
+
+void port_finish_background_task(void) {}

--- a/ports/esp32s2/background.h
+++ b/ports/esp32s2/background.h
@@ -29,7 +29,4 @@
 
 #include <stdbool.h>
 
-void background_tasks_reset(void);
-void run_background_tasks(void);
-
 #endif  // MICROPY_INCLUDED_ESP32S2_BACKGROUND_H

--- a/ports/litex/background.c
+++ b/ports/litex/background.c
@@ -29,32 +29,6 @@
 #include "supervisor/usb.h"
 #include "supervisor/shared/stack.h"
 
-#if CIRCUITPY_DISPLAYIO
-#include "shared-module/displayio/__init__.h"
-#endif
-
-static bool running_background_tasks = false;
-
-void background_tasks_reset(void) {
-    running_background_tasks = false;
-}
-
-void run_background_tasks(void) {
-    // Don't call ourselves recursively.
-    if (running_background_tasks) {
-        return;
-    }
-    running_background_tasks = true;
-    filesystem_background();
-
-    #if USB_AVAILABLE
-    usb_background();
-    #endif
-
-    #if CIRCUITPY_DISPLAYIO
-    displayio_background();
-    #endif
-    running_background_tasks = false;
-
-    assert_heap_ok();
-}
+void port_background_task(void) {}
+void port_start_background_task(void) {}
+void port_finish_background_task(void) {}

--- a/ports/litex/background.h
+++ b/ports/litex/background.h
@@ -27,9 +27,4 @@
 #ifndef MICROPY_INCLUDED_LITEX_BACKGROUND_H
 #define MICROPY_INCLUDED_LITEX_BACKGROUND_H
 
-#include <stdbool.h>
-
-void background_tasks_reset(void);
-void run_background_tasks(void);
-
 #endif  // MICROPY_INCLUDED_LITEX_BACKGROUND_H

--- a/ports/litex/mphalport.c
+++ b/ports/litex/mphalport.c
@@ -31,6 +31,7 @@
 #include "py/mphal.h"
 #include "py/mpstate.h"
 #include "py/gc.h"
+#include "supervisor/usb.h"
 
 #include "csr.h"
 #include "generated/soc.h"
@@ -49,7 +50,7 @@ void isr(void) {
 
 #ifdef CFG_TUSB_MCU
     if (irqs & (1 << USB_INTERRUPT))
-        tud_int_handler(0);
+        usb_irq_handler();
 #endif
     if (irqs & (1 << TIMER0_INTERRUPT))
         SysTick_Handler();

--- a/ports/mimxrt10xx/background.c
+++ b/ports/mimxrt10xx/background.c
@@ -24,58 +24,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include "background.h"
 
-//#include "audio_dma.h"
-#include "supervisor/filesystem.h"
-#include "supervisor/shared/tick.h"
-#include "supervisor/usb.h"
+#include "supervisor/port.h"
 
-#include "py/runtime.h"
-#include "shared-module/network/__init__.h"
-#include "supervisor/linker.h"
-#include "supervisor/shared/stack.h"
-
-#ifdef CIRCUITPY_DISPLAYIO
-#include "shared-module/displayio/__init__.h"
-#endif
-
-volatile uint64_t last_finished_tick = 0;
-
-bool stack_ok_so_far = true;
-
-static bool running_background_tasks = false;
-
-void background_tasks_reset(void) {
-    running_background_tasks = false;
-}
-
-void PLACE_IN_ITCM(run_background_tasks)(void) {
-    // Don't call ourselves recursively.
-    if (running_background_tasks) {
-        return;
-    }
-    assert_heap_ok();
-    running_background_tasks = true;
-
+void port_background_task(void) {
     #if CIRCUITPY_AUDIOIO || CIRCUITPY_AUDIOBUSIO
     audio_dma_background();
     #endif
-    #if CIRCUITPY_DISPLAYIO
-    displayio_background();
-    #endif
-
-    #if CIRCUITPY_NETWORK
-    network_module_background();
-    #endif
-    filesystem_background();
-    usb_background();
-    running_background_tasks = false;
-    assert_heap_ok();
-
-    last_finished_tick = supervisor_ticks_ms64();
 }
-
-bool background_tasks_ok(void) {
-    return supervisor_ticks_ms64() - last_finished_tick < 1000;
-}
+void port_start_background_task(void) {}
+void port_finish_background_task(void) {}

--- a/ports/mimxrt10xx/background.h
+++ b/ports/mimxrt10xx/background.h
@@ -28,11 +28,4 @@
 #ifndef MICROPY_INCLUDED_MIMXRT10XX_BACKGROUND_H
 #define MICROPY_INCLUDED_MIMXRT10XX_BACKGROUND_H
 
-#include <stdbool.h>
-
-void background_tasks_reset(void);
-void run_background_tasks(void);
-void run_background_vm_tasks(void);
-bool background_tasks_ok(void);
-
 #endif  // MICROPY_INCLUDED_MIMXRT10XX_BACKGROUND_H

--- a/ports/mimxrt10xx/common-hal/pulseio/PulseIn.c
+++ b/ports/mimxrt10xx/common-hal/pulseio/PulseIn.c
@@ -64,7 +64,7 @@
 //    // last ms.
 //    current_us = 1000 - current_us;
 //    pulseio_pulsein_obj_t* self = get_eic_channel_data(channel);
-//    if (!background_tasks_ok() || self->errored_too_fast) {
+//    if (!supervisor_background_tasks_ok() || self->errored_too_fast) {
 //        self->errored_too_fast = true;
 //        common_hal_pulseio_pulsein_pause(self);
 //        return;

--- a/ports/mimxrt10xx/supervisor/usb.c
+++ b/ports/mimxrt10xx/supervisor/usb.c
@@ -27,6 +27,7 @@
 
 #include "fsl_clock.h"
 #include "tusb.h"
+#include "supervisor/usb.h"
 
 void init_usb_hardware(void) {
     CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usbphy480M, 480000000U);
@@ -56,5 +57,5 @@ void init_usb_hardware(void) {
 }
 
 void USB_OTG1_IRQHandler(void) {
-    tud_int_handler(0);
+    usb_irq_handler();
 }

--- a/ports/nrf/background.c
+++ b/ports/nrf/background.c
@@ -46,35 +46,14 @@
 #include "common-hal/_bleio/bonding.h"
 #endif
 
-static bool running_background_tasks = false;
+void port_start_background_task(void) {}
+void port_finish_background_task(void) {}
 
-void background_tasks_reset(void) {
-    running_background_tasks = false;
-}
-
-void run_background_tasks(void) {
-    // Don't call ourselves recursively.
-    if (running_background_tasks) {
-        return;
-    }
-    running_background_tasks = true;
-    filesystem_background();
+void port_background_task(void) {
 #if CIRCUITPY_AUDIOPWMIO
     audiopwmout_background();
 #endif
 #if CIRCUITPY_AUDIOBUSIO
     i2s_background();
 #endif
-
-#if CIRCUITPY_BLEIO
-    supervisor_bluetooth_background();
-    bonding_background();
-#endif
-
-    #if CIRCUITPY_DISPLAYIO
-    displayio_background();
-    #endif
-    running_background_tasks = false;
-
-    assert_heap_ok();
 }

--- a/ports/nrf/background.c
+++ b/ports/nrf/background.c
@@ -59,7 +59,6 @@ void run_background_tasks(void) {
     }
     running_background_tasks = true;
     filesystem_background();
-    usb_background();
 #if CIRCUITPY_AUDIOPWMIO
     audiopwmout_background();
 #endif

--- a/ports/nrf/background.h
+++ b/ports/nrf/background.h
@@ -27,9 +27,4 @@
 #ifndef MICROPY_INCLUDED_NRF_BACKGROUND_H
 #define MICROPY_INCLUDED_NRF_BACKGROUND_H
 
-#include <stdbool.h>
-
-void background_tasks_reset(void);
-void run_background_tasks(void);
-
 #endif  // MICROPY_INCLUDED_NRF_BACKGROUND_H

--- a/ports/nrf/supervisor/usb.c
+++ b/ports/nrf/supervisor/usb.c
@@ -30,6 +30,7 @@
 #include "lib/utils/interrupt_char.h"
 #include "lib/mp-readline/readline.h"
 #include "lib/tinyusb/src/device/usbd.h"
+#include "supervisor/background_callback.h"
 
 #ifdef SOFTDEVICE_PRESENT
 #include "nrf_sdm.h"
@@ -42,7 +43,9 @@ extern void tusb_hal_nrf_power_event(uint32_t event);
 
 void init_usb_hardware(void) {
 
-    // 2 is max priority (0, 1 are reserved for SD)
+    // 2 is max priority (0, 1, and 4 are reserved for SD)
+    // 5 is max priority that still allows calling SD functions such as
+    // sd_softdevice_is_enabled
     NVIC_SetPriority(USBD_IRQn, 2);
 
     // USB power may already be ready at this time -> no event generated
@@ -89,5 +92,5 @@ void init_usb_hardware(void) {
 }
 
 void USBD_IRQHandler(void) {
-  tud_int_handler(0);
+    usb_irq_handler();
 }

--- a/ports/stm/background.c
+++ b/ports/stm/background.c
@@ -33,28 +33,6 @@
 #include "shared-module/displayio/__init__.h"
 #endif
 
-static bool running_background_tasks = false;
-
-void background_tasks_reset(void) {
-    running_background_tasks = false;
-}
-
-void run_background_tasks(void) {
-    // Don't call ourselves recursively.
-    if (running_background_tasks) {
-        return;
-    }
-    running_background_tasks = true;
-    filesystem_background();
-
-    #if USB_AVAILABLE
-    usb_background();
-    #endif
-
-    #if CIRCUITPY_DISPLAYIO
-    displayio_background();
-    #endif
-    running_background_tasks = false;
-
-    assert_heap_ok();
-}
+void port_background_task(void) {}
+void port_start_background_task(void) {}
+void port_finish_background_task(void) {}

--- a/ports/stm/background.h
+++ b/ports/stm/background.h
@@ -27,9 +27,4 @@
 #ifndef MICROPY_INCLUDED_STM32_BACKGROUND_H
 #define MICROPY_INCLUDED_STM32_BACKGROUND_H
 
-#include <stdbool.h>
-
-void background_tasks_reset(void);
-void run_background_tasks(void);
-
 #endif  // MICROPY_INCLUDED_STM32_BACKGROUND_H

--- a/ports/stm/supervisor/usb.c
+++ b/ports/stm/supervisor/usb.c
@@ -130,5 +130,5 @@ void init_usb_hardware(void) {
 }
 
 void OTG_FS_IRQHandler(void) {
-  tud_int_handler(0);
+  usb_irq_handler();
 }

--- a/shared-module/audiomp3/MP3Decoder.h
+++ b/shared-module/audiomp3/MP3Decoder.h
@@ -28,6 +28,7 @@
 #ifndef MICROPY_INCLUDED_SHARED_MODULE_AUDIOIO_MP3FILE_H
 #define MICROPY_INCLUDED_SHARED_MODULE_AUDIOIO_MP3FILE_H
 
+#include "supervisor/background_callback.h"
 #include "extmod/vfs_fat.h"
 #include "py/obj.h"
 
@@ -36,6 +37,7 @@
 typedef struct {
     mp_obj_base_t base;
     struct _MP3DecInfo *decoder;
+    background_callback_t inbuf_fill_cb;
     uint8_t* inbuf;
     uint32_t inbuf_length;
     uint32_t inbuf_offset;

--- a/supervisor/background_callback.h
+++ b/supervisor/background_callback.h
@@ -79,4 +79,9 @@ void background_callback_reset(void);
 void background_callback_begin_critical_section(void);
 void background_callback_end_critical_section(void);
 
+/*
+ * Background callbacks may stop objects from being collected
+ */
+void background_callback_gc_collect(void);
+
 #endif

--- a/supervisor/background_callback.h
+++ b/supervisor/background_callback.h
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Jeff Epler for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef CIRCUITPY_INCLUDED_SUPERVISOR_BACKGROUND_CALLBACK_H
+#define CIRCUITPY_INCLUDED_SUPERVISOR_BACKGROUND_CALLBACK_H
+
+/** Background callbacks are a linked list of tasks to call in the background.
+ *
+ * Include a member of type `background_callback_t` inside an object
+ * which needs to queue up background work, and zero-initialize it.
+ *
+ * To schedule the work, use background_callback_add, with fun as the
+ * function to call and data pointing to the object itself.
+ *
+ * Next time run_background_tasks_if_tick is called, the callback will
+ * be run and removed from the linked list.
+ *
+ * Queueing a task that is already queued does nothing.  Unconditionally
+ * re-queueing it from its own background task will cause it to run during the
+ * very next background-tasks invocation, leading to a CircuitPython freeze, so
+ * don't do that.
+ *
+ * background_callback_add can be called from interrupt context.
+ */
+typedef void (*background_callback_fun)(void *data);
+typedef struct background_callback {
+    background_callback_fun fun;
+    void *data;
+    struct background_callback *next;
+    struct background_callback *prev;
+} background_callback_t;
+
+/* Add a background callback for which 'fun' and 'data' were previously set */
+void background_callback_add_core(background_callback_t *cb);
+
+/* Add a background callback to the given function with the given data.  When
+ * the callback involves an object on the GC heap, the 'data' must be a pointer
+ * to that object itself, not an internal pointer.  Otherwise, it can be the
+ * case that no other references to the object itself survive, and the object
+ * becomes garbage collected while an outstanding background callback still
+ * exists.
+ */
+void background_callback_add(background_callback_t *cb, background_callback_fun fun, void *data);
+
+/* Run all background callbacks.  Normally, this is done by the supervisor
+ * whenever the list is non-empty */
+void background_callback_run_all(void);
+
+/* During soft reset, remove all pending callbacks and clear the critical section flag */
+void background_callback_reset(void);
+
+/* Sometimes background callbacks must be blocked.  Use these functions to
+ * bracket the section of code where this is the case.  These calls nest, and
+ * begins must be balanced with ends.
+ */
+void background_callback_begin_critical_section(void);
+void background_callback_end_critical_section(void);
+
+#endif

--- a/supervisor/port.h
+++ b/supervisor/port.h
@@ -91,4 +91,12 @@ void port_interrupt_after_ticks(uint32_t ticks);
 // Sleep the CPU until an interrupt is received.
 void port_sleep_until_interrupt(void);
 
+// Execute port specific actions during background tasks.
+void port_background_task(void);
+
+// Take port specific actions at the beginning and end of background tasks.
+// This is used e.g., to set a monitoring pin for debug purposes.  "Actual
+// work" should be done in port_background_task() instead.
+void port_start_background_task(void);
+void port_finish_background_task(void);
 #endif  // MICROPY_INCLUDED_SUPERVISOR_PORT_H

--- a/supervisor/shared/background_callback.c
+++ b/supervisor/shared/background_callback.c
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Jeff Epler for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mpconfig.h"
+#include "supervisor/background_callback.h"
+#include "supervisor/shared/tick.h"
+#include "shared-bindings/microcontroller/__init__.h"
+
+STATIC volatile background_callback_t *callback_head, *callback_tail;
+
+#define CALLBACK_CRITICAL_BEGIN (common_hal_mcu_disable_interrupts())
+#define CALLBACK_CRITICAL_END (common_hal_mcu_enable_interrupts())
+
+void background_callback_add_core(background_callback_t *cb) {
+    CALLBACK_CRITICAL_BEGIN;
+    if (cb->prev || callback_head == cb) {
+        CALLBACK_CRITICAL_END;
+        return;
+    }
+    cb->next = 0;
+    cb->prev = (background_callback_t*)callback_tail;
+    if (callback_tail) {
+        callback_tail->next = cb;
+        cb->prev = (background_callback_t*)callback_tail;
+    }
+    if (!callback_head) {
+        callback_head = cb;
+    }
+    callback_tail = cb;
+    CALLBACK_CRITICAL_END;
+}
+
+void background_callback_add(background_callback_t *cb, background_callback_fun fun, void *data) {
+    cb->fun = fun;
+    cb->data = data;
+    background_callback_add_core(cb);
+}
+
+static bool in_background_callback;
+void background_callback_run_all() {
+    CALLBACK_CRITICAL_BEGIN;
+    if(in_background_callback) {
+        CALLBACK_CRITICAL_END;
+        return;
+    }
+    in_background_callback = true;
+    background_callback_t *cb = (background_callback_t*)callback_head;
+    callback_head = NULL;
+    callback_tail = NULL;
+    while (cb) {
+        background_callback_t *next = cb->next;
+        cb->next = cb->prev = NULL;
+        background_callback_fun fun = cb->fun;
+        void *data = cb->data;
+        CALLBACK_CRITICAL_END;
+        // Leave the critical section in order to run the callback function
+        if (fun) {
+            fun(data);
+        }
+        CALLBACK_CRITICAL_BEGIN;
+        cb = next;
+    }
+    in_background_callback = false;
+    CALLBACK_CRITICAL_END;
+}
+
+void background_callback_begin_critical_section() {
+    CALLBACK_CRITICAL_BEGIN;
+}
+
+void background_callback_end_critical_section() {
+    CALLBACK_CRITICAL_END;
+}
+
+void background_callback_reset() {
+    CALLBACK_CRITICAL_BEGIN;
+    callback_head = NULL;
+    callback_tail = NULL;
+    in_background_callback = false;
+    CALLBACK_CRITICAL_END;
+}

--- a/supervisor/shared/background_callback.c
+++ b/supervisor/shared/background_callback.c
@@ -61,8 +61,11 @@ void background_callback_add(background_callback_t *cb, background_callback_fun 
 
 static bool in_background_callback;
 void background_callback_run_all() {
+    if (!callback_head) {
+        return;
+    }
     CALLBACK_CRITICAL_BEGIN;
-    if(in_background_callback) {
+    if (in_background_callback) {
         CALLBACK_CRITICAL_END;
         return;
     }

--- a/supervisor/shared/background_callback.c
+++ b/supervisor/shared/background_callback.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "py/gc.h"
 #include "py/mpconfig.h"
 #include "supervisor/background_callback.h"
 #include "supervisor/shared/tick.h"
@@ -104,4 +105,9 @@ void background_callback_reset() {
     callback_tail = NULL;
     in_background_callback = false;
     CALLBACK_CRITICAL_END;
+}
+
+void background_callback_gc_collect(void) {
+    background_callback_t *cb = (background_callback_t*)callback_head;
+    gc_collect_ptr(cb);
 }

--- a/supervisor/shared/tick.c
+++ b/supervisor/shared/tick.c
@@ -29,6 +29,7 @@
 #include "py/mpstate.h"
 #include "supervisor/linker.h"
 #include "supervisor/filesystem.h"
+#include "supervisor/background_callback.h"
 #include "supervisor/port.h"
 #include "supervisor/shared/autoreload.h"
 
@@ -86,10 +87,7 @@ uint32_t supervisor_ticks_ms32() {
 extern void run_background_tasks(void);
 
 void PLACE_IN_ITCM(supervisor_run_background_tasks_if_tick)() {
-    // TODO: Add a global that can be set by anyone to indicate we should run background tasks. That
-    // way we can short circuit the background tasks early. We used to do it based on time but it
-    // breaks cases where we wake up for a short period and then sleep. If we skipped the last
-    // background task or more before sleeping we may end up starving a task like USB.
+    background_callback_run_all();
     run_background_tasks();
 }
 

--- a/supervisor/shared/tick.c
+++ b/supervisor/shared/tick.c
@@ -52,6 +52,14 @@ static volatile uint64_t PLACE_IN_DTCM_BSS(background_ticks);
 #define WATCHDOG_EXCEPTION_CHECK() 0
 #endif
 
+static background_callback_t callback;
+
+extern void run_background_tasks(void);
+
+void background_task_tick(void *unused) {
+    run_background_tasks();
+}
+
 void supervisor_tick(void) {
 #if CIRCUITPY_FILESYSTEM_FLUSH_INTERVAL_MS > 0
     filesystem_tick();
@@ -69,6 +77,7 @@ void supervisor_tick(void) {
         #endif
     }
 #endif
+    background_callback_add(&callback, background_task_tick, NULL);
 }
 
 uint64_t supervisor_ticks_ms64() {
@@ -84,11 +93,9 @@ uint32_t supervisor_ticks_ms32() {
     return supervisor_ticks_ms64();
 }
 
-extern void run_background_tasks(void);
 
 void PLACE_IN_ITCM(supervisor_run_background_tasks_if_tick)() {
     background_callback_run_all();
-    run_background_tasks();
 }
 
 void mp_hal_delay_ms(mp_uint_t delay) {

--- a/supervisor/shared/tick.c
+++ b/supervisor/shared/tick.c
@@ -104,13 +104,13 @@ void mp_hal_delay_ms(mp_uint_t delay) {
         // Check to see if we've been CTRL-Ced by autoreload or the user.
         if(MP_STATE_VM(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception)))
            {
-           // clear exception and generate stacktrace
+            // clear exception and generate stacktrace
             MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
             nlr_raise(&MP_STATE_VM(mp_kbd_exception));
           }
         if( MP_STATE_VM(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_reload_exception)) ||
            WATCHDOG_EXCEPTION_CHECK()) {
-           // stop sleeping immediately
+            // stop sleeping immediately
             break;
         }
         remaining = end_tick - port_get_raw_ticks(NULL);

--- a/supervisor/shared/tick.h
+++ b/supervisor/shared/tick.h
@@ -28,6 +28,7 @@
 #define __INCLUDED_SUPERVISOR_TICK_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /** @brief To be called once every ms
  *
@@ -36,13 +37,6 @@
  * interrupt context.
  */
 extern void supervisor_tick(void);
-/** @brief Cause background tasks to be called soon
- *
- * Normally, background tasks are only run once per tick.  For other cases where
- * an event noticed from an interrupt context needs to be completed by a background
- * task activity, the interrupt can call supervisor_fake_tick.
- */
-extern void supervisor_fake_tick(void);
 /** @brief Get the lower 32 bits of the time in milliseconds
  *
  * This can be more efficient than supervisor_ticks_ms64, for sites where a wraparound
@@ -66,5 +60,13 @@ extern void supervisor_run_background_if_tick(void);
 
 extern void supervisor_enable_tick(void);
 extern void supervisor_disable_tick(void);
+
+/**
+ * @brief Return true if tick-based background tasks ran within the last 1s
+ *
+ * Note that when ticks are not enabled, this function can return false; this is
+ * intended.
+ */
+extern bool supervisor_background_tasks_ok(void);
 
 #endif

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -27,6 +27,7 @@
 #include "py/objstr.h"
 #include "shared-bindings/microcontroller/Processor.h"
 #include "shared-module/usb_midi/__init__.h"
+#include "supervisor/background_callback.h"
 #include "supervisor/port.h"
 #include "supervisor/usb.h"
 #include "lib/utils/interrupt_char.h"
@@ -80,6 +81,16 @@ void usb_background(void) {
         #endif
         tud_cdc_write_flush();
     }
+}
+
+static background_callback_t callback;
+static void usb_background_do(void* unused) {
+    usb_background();
+}
+
+void usb_irq_handler(void) {
+    tud_int_handler(0);
+    background_callback_add(&callback, usb_background_do, NULL);
 }
 
 //--------------------------------------------------------------------+

--- a/supervisor/supervisor.mk
+++ b/supervisor/supervisor.mk
@@ -2,6 +2,7 @@ SRC_SUPERVISOR = \
 	main.c \
 	supervisor/port.c \
 	supervisor/shared/autoreload.c \
+	supervisor/shared/background_callback.c \
 	supervisor/shared/board.c \
 	supervisor/shared/filesystem.c \
 	supervisor/shared/flash.c \

--- a/supervisor/usb.h
+++ b/supervisor/usb.h
@@ -33,6 +33,9 @@
 // alive and responsive.
 void usb_background(void);
 
+// Ports must call this from their particular USB IRQ handler
+void usb_irq_handler(void);
+
 // Only inits the USB peripheral clocks and pins. The peripheral will be initialized by
 // TinyUSB.
 void init_usb_hardware(void);

--- a/supervisor/usb.h
+++ b/supervisor/usb.h
@@ -29,8 +29,10 @@
 
 #include <stdbool.h>
 
-// Ports must call this as frequently as they can in order to keep the USB connection
-// alive and responsive.
+// Ports must call this as frequently as they can in order to keep the USB
+// connection alive and responsive.  Normally this is called from background
+// tasks after the USB IRQ handler is executed, but in specific circumstances
+// it may be necessary to call it directly.
 void usb_background(void);
 
 // Ports must call this from their particular USB IRQ handler


### PR DESCRIPTION
The "lower power" branch removed a previous optimization that allowed the background tasks to run just once every tick.  Restore this, for things that run on the basis of time; and where possible move things to happening based on interrupts.

The foundation for this is a new linked list of background callbacks.  A background callback takes a function pointer and an optional object pointer.  Usually, such callbacks are registered from interrupts.  For instance, on atmel sam, the audio DMA interrupt is used to schedule a fill of the new sample data, rather than polling a flag every 1ms.

Current state of this PR:
 * Builds on a range of boards
 * transitions all boards back to running background tasks just once per ms, though only when ticks are enabled
 * transitions sam d20/d5x/e5x to using interrupts for audio and usb

Testing performed: on pygamer and grand central m4, did general tire kicking of related code:
 * audio code
 * usb
 * filesystem
 * eink display
 * lcd display
 * gamepad

Benchmarks:  On Grand Central M4, I ran the following code
```
import time
t0 = time.monotonic_ns()
k = 0
for i in range(1000):
    for j in range(100):
        k += j
t1 = time.monotonic_ns()
print(k)
print((t1-t0) / 1e9)
```
The regression from 5.3.0 to 6.0.0.alpha.1 is almost entirely fixed.  However, the difference between the original timing of 1.02s and the new timing of 1.04s seems "real" and is not within the usual variability of execution time. (that the above loop takes about 1s on samd51 is a total coincidence, I didn't choose the numbers specially or anything!)

| version | time |
|:-------------| -----:|
| 5.3.0   |  1.02s |
| 6.0.0.a1 |  1.54s |
| this PR | 1.04s |

What's next: 
 * test & benchmark more boards
 * get a green from Actions
 * possible strategic conversion of more stuff to interrupt-driven