### PR TITLE
vectorio: speed up polygon

### DIFF
--- a/locale/ID.po
+++ b/locale/ID.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr "buffers harus mempunyai panjang yang sama"
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1269,6 +1269,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr "Tambahkan module apapun pada filesystem\n"
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr ""
@@ -2135,10 +2139,6 @@ msgstr ""
 
 #: py/objdeque.c
 msgid "empty"
-msgstr ""
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
 msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
@@ -3158,8 +3158,8 @@ msgstr ""
 msgid "unreadable attribute"
 msgstr ""
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr ""
 

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,7 +81,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr ""
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1257,6 +1257,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr ""
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr ""
@@ -2111,10 +2115,6 @@ msgstr ""
 
 #: py/objdeque.c
 msgid "empty"
-msgstr ""
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
 msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
@@ -3132,8 +3132,8 @@ msgstr ""
 msgid "unreadable attribute"
 msgstr ""
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr ""
 

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,7 +81,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr ""
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1257,6 +1257,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr ""
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr ""
@@ -2111,10 +2115,6 @@ msgstr ""
 
 #: py/objdeque.c
 msgid "empty"
-msgstr ""
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
 msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
@@ -3132,8 +3132,8 @@ msgstr ""
 msgid "unreadable attribute"
 msgstr ""
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr ""
 

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2020-05-18 02:48+0000\n"
 "Last-Translator: Jeff Epler <jepler@gmail.com>\n"
 "Language-Team: German <https://later.unpythonic.net/projects/circuitpython/"
@@ -90,7 +90,7 @@ msgstr "%q Liste muss eine Liste sein"
 msgid "%q must be >= 1"
 msgstr "%q muss >= 1 sein"
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr "%q muss ein Tupel der Länge 2 sein"
 
@@ -1279,6 +1279,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr "und alle Module im Dateisystem \n"
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr ""
@@ -2148,10 +2152,6 @@ msgstr "Division durch Null"
 #: py/objdeque.c
 msgid "empty"
 msgstr "leer"
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
-msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
 msgid "empty heap"
@@ -3184,8 +3184,8 @@ msgstr ""
 msgid "unreadable attribute"
 msgstr "nicht lesbares Attribut"
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr "Nicht unterstützter %q-Typ"
 

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -81,7 +81,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr ""
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1257,6 +1257,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr ""
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr ""
@@ -2111,10 +2115,6 @@ msgstr ""
 
 #: py/objdeque.c
 msgid "empty"
-msgstr ""
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
 msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
@@ -3132,8 +3132,8 @@ msgstr ""
 msgid "unreadable attribute"
 msgstr ""
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr ""
 

--- a/locale/en_x_pirate.po
+++ b/locale/en_x_pirate.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2020-03-30 22:11+0000\n"
 "Last-Translator: Tannewt <devnull@unpythonic.net>\n"
 "Language-Team: English <https://later.unpythonic.net/projects/circuitpython/"
@@ -88,7 +88,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr ""
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1266,6 +1266,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr ""
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr ""
@@ -2120,10 +2124,6 @@ msgstr ""
 
 #: py/objdeque.c
 msgid "empty"
-msgstr ""
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
 msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
@@ -3141,8 +3141,8 @@ msgstr ""
 msgid "unreadable attribute"
 msgstr ""
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr ""
 

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2020-05-17 20:56+0000\n"
 "Last-Translator: Jeff Epler <jepler@gmail.com>\n"
 "Language-Team: \n"
@@ -84,7 +84,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr "%q debe ser >= 1"
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1273,6 +1273,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr "Incapaz de montar de nuevo el sistema de archivos"
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr "Pop de un buffer Ps2 vacio"
@@ -2145,10 +2149,6 @@ msgstr "división por cero"
 #: py/objdeque.c
 msgid "empty"
 msgstr "vacío"
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
-msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
 msgid "empty heap"
@@ -3175,8 +3175,8 @@ msgstr "No coinciden '{' en format"
 msgid "unreadable attribute"
 msgstr "atributo no legible"
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr "tipo de %q no soportado"
 

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2018-12-20 22:15-0800\n"
 "Last-Translator: Timothy <me@timothygarcia.ca>\n"
 "Language-Team: fil\n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr "aarehas na haba dapat ang buffer slices"
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1277,6 +1277,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr "Kasama ang kung ano pang modules na sa filesystem\n"
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr ""
@@ -2156,10 +2160,6 @@ msgstr "dibisyon ng zero"
 #: py/objdeque.c
 msgid "empty"
 msgstr "walang laman"
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
-msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
 msgid "empty heap"
@@ -3188,8 +3188,8 @@ msgstr "hindi tugma ang '{' sa format"
 msgid "unreadable attribute"
 msgstr "hindi mabasa ang attribute"
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr "Hindi supportadong tipo ng %q"
 

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2020-05-17 20:56+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: French <https://later.unpythonic.net/projects/circuitpython/"
@@ -94,7 +94,7 @@ msgstr "La liste %q doit être une liste"
 msgid "%q must be >= 1"
 msgstr "%q doit être >=1"
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr "%q doit être un tuple de longueur 2"
 
@@ -534,7 +534,8 @@ msgstr "Impossible d'obtenir la taille du scalaire sans ambigüité"
 
 #: ports/stm/common-hal/pulseio/PWMOut.c
 msgid "Cannot vary frequency on a timer that is already in use"
-msgstr "Impossible de faire varier la fréquence sur une minuterie déjà utilisée"
+msgstr ""
+"Impossible de faire varier la fréquence sur une minuterie déjà utilisée"
 
 #: shared-module/bitbangio/SPI.c
 msgid "Cannot write without MOSI pin."
@@ -1293,12 +1294,16 @@ msgid ""
 "constructor"
 msgstr ""
 "Le brochage utilise %d octets par élément, ce qui consomme plus que le %d "
-"octets idéal. Si cela ne peut pas être évité, transmettez allow_inefficient ="
-" True au constructeur"
+"octets idéal. Si cela ne peut pas être évité, transmettez allow_inefficient "
+"= True au constructeur"
 
 #: py/builtinhelp.c
 msgid "Plus any modules on the filesystem\n"
 msgstr "Ainsi que tout autre module présent sur le système de fichiers\n"
+
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
 
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
@@ -2063,7 +2068,8 @@ msgstr "ne peut pas réaliser un import relatif"
 
 #: extmod/ulab/code/ndarray.c
 msgid "cannot reshape array (incompatible input/output shape)"
-msgstr "ne peut pas remodeler le tableau (forme d'entrée / sortie incompatible)"
+msgstr ""
+"ne peut pas remodeler le tableau (forme d'entrée / sortie incompatible)"
 
 #: py/emitnative.c
 msgid "casting"
@@ -2190,10 +2196,6 @@ msgstr "division par zéro"
 #: py/objdeque.c
 msgid "empty"
 msgstr "vide"
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
-msgstr "liste %q vide"
 
 #: extmod/moduheapq.c extmod/modutimeq.c
 msgid "empty heap"
@@ -3226,8 +3228,8 @@ msgstr "'{' sans correspondance dans le format"
 msgid "unreadable attribute"
 msgstr "attribut illisible"
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr "type %q non pris on charge"
 
@@ -3700,6 +3702,9 @@ msgstr "'step' nul"
 
 #~ msgid "either pos or kw args are allowed"
 #~ msgstr "soit 'pos', soit 'kw' est permis en argument"
+
+#~ msgid "empty %q list"
+#~ msgstr "liste %q vide"
 
 #~ msgid "expected a DigitalInOut"
 #~ msgstr "objet DigitalInOut attendu"

--- a/locale/it_IT.po
+++ b/locale/it_IT.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2018-10-02 16:27+0200\n"
 "Last-Translator: Enrico Paganin <enrico.paganin@mail.com>\n"
 "Language-Team: \n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr "slice del buffer devono essere della stessa lunghezza"
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1287,6 +1287,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr "Imposssibile rimontare il filesystem"
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr ""
@@ -2157,10 +2161,6 @@ msgstr "divisione per zero"
 #: py/objdeque.c
 msgid "empty"
 msgstr "vuoto"
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
-msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
 msgid "empty heap"
@@ -3195,8 +3195,8 @@ msgstr "'{' spaiato nella stringa di formattazione"
 msgid "unreadable attribute"
 msgstr "attributo non leggibile"
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr "tipo di %q non supportato"
 

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2019-05-06 14:22-0700\n"
 "Last-Translator: \n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -83,7 +83,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr "%q 는 >=1이어야합니다"
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1261,6 +1261,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr ""
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr ""
@@ -2116,10 +2120,6 @@ msgstr ""
 
 #: py/objdeque.c
 msgid "empty"
-msgstr ""
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
 msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
@@ -3137,8 +3137,8 @@ msgstr ""
 msgid "unreadable attribute"
 msgstr ""
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr ""
 

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2019-03-19 18:37-0700\n"
 "Last-Translator: Radomir Dopieralski <circuitpython@sheep.art.pl>\n"
 "Language-Team: pl\n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr "%q musi być >= 1"
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1262,6 +1262,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr "Oraz moduły w systemie plików\n"
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr ""
@@ -2121,10 +2125,6 @@ msgstr "dzielenie przez zero"
 #: py/objdeque.c
 msgid "empty"
 msgstr "puste"
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
-msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
 msgid "empty heap"
@@ -3143,8 +3143,8 @@ msgstr "niepasujące '{' for formacie"
 msgid "unreadable attribute"
 msgstr "nieczytelny atrybut"
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr "zły typ %q"
 

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2018-10-02 21:14-0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr "buffers devem ser o mesmo tamanho"
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1273,6 +1273,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr "Não é possível remontar o sistema de arquivos"
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr "Buffer Ps2 vazio"
@@ -2133,10 +2137,6 @@ msgstr "divisão por zero"
 #: py/objdeque.c
 msgid "empty"
 msgstr "vazio"
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
-msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
 msgid "empty heap"
@@ -3156,8 +3156,8 @@ msgstr ""
 msgid "unreadable attribute"
 msgstr "atributo ilegível"
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr ""
 

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2020-05-17 20:56+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -89,7 +89,7 @@ msgstr "%q-listan måste vara en lista"
 msgid "%q must be >= 1"
 msgstr "%q måste vara >= 1"
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr "%q måste vara en tuple av längd 2"
 
@@ -1067,7 +1067,8 @@ msgstr "MicroPython fatalt fel."
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
-msgstr "Startfördröjningen för mikrofonen måste vara i intervallet 0,0 till 1,0"
+msgstr ""
+"Startfördröjningen för mikrofonen måste vara i intervallet 0,0 till 1,0"
 
 #: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
 msgid "Missing MISO or MOSI Pin"
@@ -1278,13 +1279,17 @@ msgid ""
 "bytes.  If this cannot be avoided, pass allow_inefficient=True to the "
 "constructor"
 msgstr ""
-"Pinout använder %d byte per element, vilket förbrukar mer än det idealiska %"
-"d byte.  Om detta inte kan undvikas, skicka allow_inefficient=True till "
+"Pinout använder %d byte per element, vilket förbrukar mer än det idealiska "
+"%d byte.  Om detta inte kan undvikas, skicka allow_inefficient=True till "
 "konstruktorn"
 
 #: py/builtinhelp.c
 msgid "Plus any modules on the filesystem\n"
 msgstr "Plus eventuella moduler i filsystemet\n"
+
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
 
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
@@ -2162,10 +2167,6 @@ msgstr "division med noll"
 #: py/objdeque.c
 msgid "empty"
 msgstr "tom"
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
-msgstr "tom %q-lista"
 
 #: extmod/moduheapq.c extmod/modutimeq.c
 msgid "empty heap"
@@ -3188,8 +3189,8 @@ msgstr "omatchad '{' i format"
 msgid "unreadable attribute"
 msgstr "attribut kan inte läsas"
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr "typ %q stöds inte"
 
@@ -3268,3 +3269,6 @@ msgstr "y-värde utanför intervall"
 #: py/objrange.c
 msgid "zero step"
 msgstr "noll steg"
+
+#~ msgid "empty %q list"
+#~ msgstr "tom %q-lista"

--- a/locale/zh_Latn_pinyin.po
+++ b/locale/zh_Latn_pinyin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: circuitpython-cn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-12 14:37+1000\n"
+"POT-Creation-Date: 2020-05-18 13:32-0700\n"
 "PO-Revision-Date: 2019-04-13 10:10-0700\n"
 "Last-Translator: hexthat\n"
 "Language-Team: Chinese Hanyu Pinyin\n"
@@ -88,7 +88,7 @@ msgstr ""
 msgid "%q must be >= 1"
 msgstr "%q bìxū dàyú huò děngyú 1"
 
-#: shared-bindings/vectorio/Polygon.c
+#: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
 msgstr ""
 
@@ -1276,6 +1276,10 @@ msgstr ""
 msgid "Plus any modules on the filesystem\n"
 msgstr "Zài wénjiàn xìtǒng shàng tiānjiā rènhé mókuài\n"
 
+#: shared-module/vectorio/Polygon.c
+msgid "Polygon needs at least 3 points"
+msgstr ""
+
 #: shared-bindings/ps2io/Ps2.c
 msgid "Pop from an empty Ps2 buffer"
 msgstr "Cóng kōng de Ps2 huǎnchōng qū dànchū"
@@ -2149,10 +2153,6 @@ msgstr "bèi líng chú"
 #: py/objdeque.c
 msgid "empty"
 msgstr "kòngxián"
-
-#: shared-bindings/vectorio/Polygon.c
-msgid "empty %q list"
-msgstr ""
 
 #: extmod/moduheapq.c extmod/modutimeq.c
 msgid "empty heap"
@@ -3173,8 +3173,8 @@ msgstr "géshì wèi pǐpèi '{'"
 msgid "unreadable attribute"
 msgstr "bùkě dú shǔxìng"
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/Polygon.c
-#: shared-bindings/vectorio/VectorShape.c
+#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
+#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr "bù zhīchí %q lèixíng"
 

--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -15,6 +15,7 @@
 // #define VECTORIO_POLYGON_DEBUG(...) mp_printf(&mp_plat_print __VA_OPT__(,) __VA_ARGS__)
 
 
+//| from typing import List, Tuple
 //|
 //| class Polygon:
 //|     def __init__(self, points: List[ Tuple[ x, y ], ... ] ):

--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -15,41 +15,6 @@
 // #define VECTORIO_POLYGON_DEBUG(...) mp_printf(&mp_plat_print __VA_OPT__(,) __VA_ARGS__)
 
 
-// Converts a list of points tuples to a flat list of ints for speedier internal use.
-// Also validates the points.
-static mp_obj_t _to_points_list(mp_obj_t points_tuple_list) {
-    size_t len = 0;
-    mp_obj_t *items;
-    mp_obj_list_get(points_tuple_list, &len, &items);
-    VECTORIO_POLYGON_DEBUG("polygon_points_list len: %d\n", len);
-
-    if ( len == 0 ) {
-        mp_raise_TypeError_varg(translate("empty %q list"), MP_QSTR_point);
-    }
-
-    mp_obj_t points_list = mp_obj_new_list(0, NULL);
-
-    for ( size_t i = 0; i < len; ++i) {
-        size_t tuple_len = 0;
-        mp_obj_t *tuple_items;
-        mp_obj_tuple_get(items[i], &tuple_len, &tuple_items);
-
-        if (tuple_len != 2) {
-            mp_raise_ValueError_varg(translate("%q must be a tuple of length 2"), MP_QSTR_point);
-        }
-        int value;
-        if (!mp_obj_get_int_maybe(tuple_items[0], &value)) {
-            mp_raise_ValueError_varg(translate("unsupported %q type"), MP_QSTR_point);
-        }
-        mp_obj_list_append(points_list, MP_OBJ_NEW_SMALL_INT(value));
-        if (!mp_obj_get_int_maybe(tuple_items[1], &value)) {
-            mp_raise_ValueError_varg(translate("unsupported %q type"), MP_QSTR_point);
-        }
-        mp_obj_list_append(points_list, MP_OBJ_NEW_SMALL_INT(value));
-    }
-    return points_list;
-}
-//| from typing import List, Tuple
 //|
 //| class Polygon:
 //|     def __init__(self, points: List[ Tuple[ x, y ], ... ] ):
@@ -68,12 +33,11 @@ static mp_obj_t vectorio_polygon_make_new(const mp_obj_type_t *type, size_t n_ar
     if (!MP_OBJ_IS_TYPE(args[ARG_points_list].u_obj, &mp_type_list)) {
         mp_raise_TypeError_varg(translate("%q list must be a list"), MP_QSTR_point);
     }
-    mp_obj_t points_list = _to_points_list(args[ARG_points_list].u_obj);
 
     vectorio_polygon_t *self = m_new_obj(vectorio_polygon_t);
     self->base.type = &vectorio_polygon_type;
 
-    common_hal_vectorio_polygon_construct(self, points_list);
+    common_hal_vectorio_polygon_construct(self, args[ARG_points_list].u_obj);
 
     return MP_OBJ_FROM_PTR(self);
 }
@@ -104,9 +68,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(vectorio_polygon_get_points_obj, vectorio_polygon_obj_
 STATIC mp_obj_t vectorio_polygon_obj_set_points(mp_obj_t self_in, mp_obj_t points) {
     vectorio_polygon_t *self = MP_OBJ_TO_PTR(self_in);
 
-    mp_obj_t points_list = _to_points_list(points);
-
-    common_hal_vectorio_polygon_set_points(self, points_list);
+    common_hal_vectorio_polygon_set_points(self, points);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_2(vectorio_polygon_set_points_obj, vectorio_polygon_obj_set_points);

--- a/shared-module/vectorio/Polygon.c
+++ b/shared-module/vectorio/Polygon.c
@@ -4,6 +4,8 @@
 #include "shared-module/displayio/area.h"
 
 #include "py/runtime.h"
+#include "py/gc.h"
+
 #include "stdlib.h"
 #include <stdio.h>
 
@@ -12,10 +14,57 @@
 // #define VECTORIO_POLYGON_DEBUG(...) mp_printf(&mp_plat_print __VA_OPT__(,) __VA_ARGS__)
 
 
+// Converts a list of points tuples to a flat list of ints for speedier internal use.
+// Also validates the points.
+static void _clobber_points_list(vectorio_polygon_t *self, mp_obj_t points_tuple_list) {
+    size_t len = 0;
+    mp_obj_t *items;
+    mp_obj_list_get(points_tuple_list, &len, &items);
+    VECTORIO_POLYGON_DEBUG("polygon_points_list len: %d\n", len);
+
+    if ( len < 3 ) {
+        mp_raise_TypeError_varg(translate("Polygon needs at least 3 points"));
+    }
+
+    if ( self->len < 2*len ) {
+        if ( self->points_list != NULL ) {
+            gc_free( self->points_list );
+        }
+        self->points_list = gc_alloc( 2 * len * sizeof(int), false, false );
+    }
+    self->len = 2*len;
+
+    for ( size_t i = 0; i < len; ++i) {
+        size_t tuple_len = 0;
+        mp_obj_t *tuple_items;
+        mp_obj_tuple_get(items[i], &tuple_len, &tuple_items);
+
+        if (tuple_len != 2) {
+            mp_raise_ValueError_varg(translate("%q must be a tuple of length 2"), MP_QSTR_point);
+        }
+        if (!mp_obj_get_int_maybe(tuple_items[0], &self->points_list[2*i])) {
+            self->len = 0;
+            gc_free( self->points_list );
+            self->points_list = NULL;
+            mp_raise_ValueError_varg(translate("unsupported %q type"), MP_QSTR_point);
+        }
+        if (!mp_obj_get_int_maybe(tuple_items[1], &self->points_list[2*i + 1])) {
+            self->len = 0;
+            gc_free( self->points_list );
+            self->points_list = NULL;
+            mp_raise_ValueError_varg(translate("unsupported %q type"), MP_QSTR_point);
+        }
+    }
+}
+
+
+
 void common_hal_vectorio_polygon_construct(vectorio_polygon_t *self, mp_obj_t points_list) {
     VECTORIO_POLYGON_DEBUG("%p polygon_construct\n", self);
-    self->points_list = points_list;
+    self->points_list = NULL;
+    self->len = 0;
     self->on_dirty.obj = NULL;
+    _clobber_points_list( self, points_list );
 }
 
 
@@ -23,7 +72,7 @@ mp_obj_t common_hal_vectorio_polygon_get_points(vectorio_polygon_t *self) {
     return self->points_list;
 }
 void common_hal_vectorio_polygon_set_points(vectorio_polygon_t *self, mp_obj_t points_list) {
-    self->points_list = points_list;
+    _clobber_points_list( self, points_list );
     if (self->on_dirty.obj != NULL) {
         self->on_dirty.event(self->on_dirty.obj);
     }
@@ -38,21 +87,16 @@ void common_hal_vectorio_polygon_set_on_dirty(vectorio_polygon_t *self, vectorio
 
 
 void common_hal_vectorio_polygon_get_area(void *polygon, displayio_area_t *area) {
-    VECTORIO_POLYGON_DEBUG("%p polygon get_area", polygon);
     vectorio_polygon_t *self = polygon;
-    size_t len;
-    mp_obj_t *points;
-    mp_obj_list_get(self->points_list, &len, &points);
-    VECTORIO_POLYGON_DEBUG(" len: %2d, points: %d\n", len, len/2);
 
     area->x1 = SHRT_MAX;
     area->y1 = SHRT_MAX;
     area->x2 = SHRT_MIN;
     area->y2 = SHRT_MIN;
-    for (size_t i=0; i < len; ++i) {
-        mp_int_t x = mp_obj_get_int(points[i]);
+    for (size_t i=0; i < self->len; ++i) {
+        int x = self->points_list[i];
         ++i;
-        mp_int_t y = mp_obj_get_int(points[i]);
+        int y = self->points_list[i];
         if (x <= area->x1) area->x1 = x-1;
         if (y <= area->y1) area->y1 = y-1;
         if (x >= area->x2) area->x2 = x+1;
@@ -73,22 +117,19 @@ __attribute__((always_inline)) static inline int line_side( mp_int_t x1, mp_int_
 uint32_t common_hal_vectorio_polygon_get_pixel(void *obj, int16_t x, int16_t y) {
     VECTORIO_POLYGON_DEBUG("%p polygon get_pixel %d, %d\n", obj, x, y);
     vectorio_polygon_t *self = obj;
-    size_t len;
-    mp_obj_t *points;
-    mp_obj_list_get(self->points_list, &len, &points);
 
-    if (len == 0) {
+    if (self->len == 0) {
         return 0;
     }
 
     int winding_number = 0;
-    mp_int_t x1 = mp_obj_get_int(points[0]);
-    mp_int_t y1 = mp_obj_get_int(points[1]);
-    for (size_t i=2; i <= len + 1; ++i) {
+    int x1 = self->points_list[0];
+    int y1 = self->points_list[1];
+    for (size_t i=2; i <= self->len + 1; ++i) {
         VECTORIO_POLYGON_DEBUG("  {(%3d, %3d),", x1, y1);
-        mp_int_t x2 = mp_obj_get_int(points[i % len]);
+        int x2 = self->points_list[i % self->len];
         ++i;
-        mp_int_t y2 = mp_obj_get_int(points[i % len]);
+        int y2 = self->points_list[i % self->len];
         VECTORIO_POLYGON_DEBUG(" (%3d, %3d)}\n", x2, y2);
         if ( y1 <= y ) {
             if ( y2 > y && line_side(x1, y1, x2, y2, x, y) > 0 ) {

--- a/shared-module/vectorio/Polygon.c
+++ b/shared-module/vectorio/Polygon.c
@@ -42,13 +42,9 @@ static void _clobber_points_list(vectorio_polygon_t *self, mp_obj_t points_tuple
         if (tuple_len != 2) {
             mp_raise_ValueError_varg(translate("%q must be a tuple of length 2"), MP_QSTR_point);
         }
-        if (!mp_obj_get_int_maybe(tuple_items[0], &self->points_list[2*i])) {
-            self->len = 0;
-            gc_free( self->points_list );
-            self->points_list = NULL;
-            mp_raise_ValueError_varg(translate("unsupported %q type"), MP_QSTR_point);
-        }
-        if (!mp_obj_get_int_maybe(tuple_items[1], &self->points_list[2*i + 1])) {
+        if (   !mp_obj_get_int_maybe(tuple_items[ 0 ], &self->points_list[2*i    ])
+            || !mp_obj_get_int_maybe(tuple_items[ 1 ], &self->points_list[2*i + 1])
+        ) {
             self->len = 0;
             gc_free( self->points_list );
             self->points_list = NULL;

--- a/shared-module/vectorio/Polygon.h
+++ b/shared-module/vectorio/Polygon.h
@@ -8,8 +8,9 @@
 
 typedef struct {
     mp_obj_base_t base;
-    // A micropython List[ x, y, ... ]
-    mp_obj_t points_list;
+    // An int array[ x, y, ... ]
+    int *points_list;
+    size_t len;
     vectorio_event_t on_dirty;
 } vectorio_polygon_t;
 


### PR DESCRIPTION
Takes polygon from 126k pixels per second fill to 240k pps fill
  on a reference 5 point star 50x66px polygon, updating both location and shape
  at 10hz.  Tested on an m4 express feather.

As a curiosity, the flat-out fill rate of a shape whose get_pixel is `return 0;`
  fills just shy of 375k pixels per second.

Baseline:
```
Polygon -> shape:{1020px,  8.1ms, 126603.0pps fill}  shape_pixels:{5859.4us total,  5.7us/px}
Polygon -> shape:{ 510px,  4.0ms, 126603.0pps fill}  shape_pixels:{2929.7us total,  5.7us/px}
```

This change:
```
Polygon -> shape:{1020px,  4.3ms, 238738.0pps fill}  shape_pixels:{2807.6us total,  2.8us/px}
Polygon -> shape:{ 510px,  2.1ms, 245759.0pps fill}  shape_pixels:{ 976.6us total,  1.9us/px}
```