### PR TITLE
Gamepad, GamepadShift: Fix after lower-power by enabling supervisor tick

### DIFF
--- a/shared-bindings/gamepad/GamePad.c
+++ b/shared-bindings/gamepad/GamePad.c
@@ -106,9 +106,8 @@ STATIC mp_obj_t gamepad_make_new(const mp_obj_type_t *type, size_t n_args,
     gamepad_obj_t* gamepad_singleton = MP_STATE_VM(gamepad_singleton);
     if (!gamepad_singleton ||
         !MP_OBJ_IS_TYPE(MP_OBJ_FROM_PTR(gamepad_singleton), &gamepad_type)) {
-        gamepad_singleton = m_new_obj(gamepad_obj_t);
+        gamepad_singleton = m_new_ll_obj(gamepad_obj_t);
         gamepad_singleton->base.type = &gamepad_type;
-        gamepad_singleton = gc_make_long_lived(gamepad_singleton);
         if (!MP_STATE_VM(gamepad_singleton)) {
             supervisor_enable_tick();
         }

--- a/shared-bindings/gamepad/GamePad.c
+++ b/shared-bindings/gamepad/GamePad.c
@@ -33,6 +33,7 @@
 #include "shared-bindings/gamepad/__init__.h"
 #include "shared-bindings/digitalio/DigitalInOut.h"
 #include "supervisor/shared/translate.h"
+#include "supervisor/shared/tick.h"
 
 
 //| .. currentmodule:: gamepad
@@ -108,6 +109,9 @@ STATIC mp_obj_t gamepad_make_new(const mp_obj_type_t *type, size_t n_args,
         gamepad_singleton = m_new_obj(gamepad_obj_t);
         gamepad_singleton->base.type = &gamepad_type;
         gamepad_singleton = gc_make_long_lived(gamepad_singleton);
+        if (!MP_STATE_VM(gamepad_singleton)) {
+            supervisor_enable_tick();
+        }
         MP_STATE_VM(gamepad_singleton) = gamepad_singleton;
     }
     common_hal_gamepad_gamepad_init(gamepad_singleton, args, n_args);

--- a/shared-bindings/gamepadshift/GamePadShift.c
+++ b/shared-bindings/gamepadshift/GamePadShift.c
@@ -73,9 +73,8 @@ STATIC mp_obj_t gamepadshift_make_new(const mp_obj_type_t *type, size_t n_args,
     if (!gamepad_singleton ||
         !MP_OBJ_IS_TYPE(MP_OBJ_FROM_PTR(gamepad_singleton),
                         &gamepadshift_type)) {
-        gamepad_singleton = m_new_obj(gamepadshift_obj_t);
+        gamepad_singleton = m_new_ll_obj(gamepadshift_obj_t);
         gamepad_singleton->base.type = &gamepadshift_type;
-        gamepad_singleton = gc_make_long_lived(gamepad_singleton);
         if (!MP_STATE_VM(gamepad_singleton)) {
             supervisor_enable_tick();
         }

--- a/shared-bindings/gamepadshift/GamePadShift.c
+++ b/shared-bindings/gamepadshift/GamePadShift.c
@@ -31,6 +31,7 @@
 #include "shared-bindings/gamepadshift/GamePadShift.h"
 #include "shared-bindings/gamepadshift/__init__.h"
 #include "supervisor/shared/translate.h"
+#include "supervisor/shared/tick.h"
 
 //| .. currentmodule:: gamepadshift
 //|
@@ -75,6 +76,9 @@ STATIC mp_obj_t gamepadshift_make_new(const mp_obj_type_t *type, size_t n_args,
         gamepad_singleton = m_new_obj(gamepadshift_obj_t);
         gamepad_singleton->base.type = &gamepadshift_type;
         gamepad_singleton = gc_make_long_lived(gamepad_singleton);
+        if (!MP_STATE_VM(gamepad_singleton)) {
+            supervisor_enable_tick();
+        }
         MP_STATE_VM(gamepad_singleton) = gamepad_singleton;
     }
     common_hal_gamepadshift_gamepadshift_init(gamepad_singleton, clock_pin, data_pin, latch_pin);

--- a/shared-module/gamepad/GamePad.c
+++ b/shared-module/gamepad/GamePad.c
@@ -27,6 +27,7 @@
 #include "py/mpstate.h"
 #include "shared-bindings/digitalio/DigitalInOut.h"
 #include "shared-bindings/gamepad/GamePad.h"
+#include "supervisor/shared/tick.h"
 
 void common_hal_gamepad_gamepad_init(gamepad_obj_t *gamepad,
                   const mp_obj_t pins[], size_t n_pins) {
@@ -54,4 +55,5 @@ void common_hal_gamepad_gamepad_init(gamepad_obj_t *gamepad,
 
 void common_hal_gamepad_gamepad_deinit(gamepad_obj_t *self) {
     MP_STATE_VM(gamepad_singleton) = NULL;
+    supervisor_disable_tick();
 }

--- a/shared-module/gamepad/__init__.c
+++ b/shared-module/gamepad/__init__.c
@@ -29,6 +29,7 @@
 #include "py/mpstate.h"
 #include "shared-bindings/gamepad/__init__.h"
 #include "shared-bindings/gamepad/GamePad.h"
+#include "supervisor/shared/tick.h"
 
 #include "shared-bindings/digitalio/DigitalInOut.h"
 
@@ -59,5 +60,8 @@ void gamepad_tick(void) {
 }
 
 void gamepad_reset(void) {
+    if (MP_STATE_VM(gamepad_singleton)) {
+        supervisor_disable_tick();
+    }
     MP_STATE_VM(gamepad_singleton) = NULL;
 }

--- a/shared-module/gamepadshift/GamePadShift.c
+++ b/shared-module/gamepadshift/GamePadShift.c
@@ -27,6 +27,7 @@
 #include "py/mpstate.h"
 #include "shared-bindings/digitalio/DigitalInOut.h"
 #include "shared-module/gamepadshift/GamePadShift.h"
+#include "supervisor/shared/tick.h"
 
 void common_hal_gamepadshift_gamepadshift_init(gamepadshift_obj_t *gamepadshift,
                                                 digitalio_digitalinout_obj_t *clock_pin,
@@ -46,4 +47,5 @@ void common_hal_gamepadshift_gamepadshift_init(gamepadshift_obj_t *gamepadshift,
 
 void common_hal_gamepadshift_gamepadshift_deinit(gamepadshift_obj_t *gamepadshift) {
     MP_STATE_VM(gamepad_singleton) = NULL;
+    supervisor_disable_tick();
 }


### PR DESCRIPTION
@tannewt your advice was right on, thanks.

Closes: #2880 