### PR TITLE
nrf: put supervisor enable/disable tick in place

### DIFF
--- a/ports/nrf/common-hal/audiobusio/I2SOut.c
+++ b/ports/nrf/common-hal/audiobusio/I2SOut.c
@@ -31,6 +31,7 @@
 #include "common-hal/audiobusio/I2SOut.h"
 #include "shared-bindings/audiobusio/I2SOut.h"
 #include "shared-module/audiocore/__init__.h"
+#include "supervisor/shared/tick.h"
 
 #include "py/obj.h"
 #include "py/runtime.h"
@@ -211,6 +212,8 @@ void common_hal_audiobusio_i2sout_construct(audiobusio_i2sout_obj_t* self,
     NRF_I2S->CONFIG.ALIGN = I2S_CONFIG_ALIGN_ALIGN_Left;
     NRF_I2S->CONFIG.FORMAT = left_justified ? I2S_CONFIG_FORMAT_FORMAT_Aligned
                                     : I2S_CONFIG_FORMAT_FORMAT_I2S;
+
+    supervisor_enable_tick();
 }
 
 bool common_hal_audiobusio_i2sout_deinited(audiobusio_i2sout_obj_t* self) {
@@ -230,6 +233,7 @@ void common_hal_audiobusio_i2sout_deinit(audiobusio_i2sout_obj_t* self) {
     reset_pin_number(self->data_pin_number);
     self->data_pin_number = 0xff;
     instance = NULL;
+    supervisor_disable_tick();
 }
 
 void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t* self,
@@ -340,5 +344,8 @@ void i2s_reset(void) {
     NRF_I2S->PSEL.LRCK = 0xFFFFFFFF;
     NRF_I2S->PSEL.SDOUT = 0xFFFFFFFF;
     NRF_I2S->PSEL.SDIN = 0xFFFFFFFF;
+    if (instance) {
+        supervisor_disable_tick();
+    }
     instance = NULL;
 }

--- a/ports/nrf/common-hal/audiobusio/I2SOut.c
+++ b/ports/nrf/common-hal/audiobusio/I2SOut.c
@@ -159,7 +159,7 @@ static void i2s_buffer_fill(audiobusio_i2sout_obj_t* self) {
 
     // Find the last frame of real audio data and replicate its samples until
     // you have 32 bits worth, which is the fundamental unit of nRF I2S DMA
-    if(buffer != buffer_start) {
+    if (buffer != buffer_start) {
         if (self->bytes_per_sample == 1 && self->channel_count == 1) {
             // For 8-bit mono, 4 copies of the final sample are required
             self->hold_value = 0x01010101 * *(uint8_t*)(buffer-1);

--- a/ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
@@ -36,6 +36,7 @@
 #include "shared-bindings/audiopwmio/PWMAudioOut.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/Pin.h"
+#include "supervisor/shared/tick.h"
 #include "supervisor/shared/translate.h"
 
 // TODO: This should be the same size as PWMOut.c:pwms[], but there's no trivial way to accomplish that
@@ -67,6 +68,7 @@ STATIC void activate_audiopwmout_obj(audiopwmio_pwmaudioout_obj_t *self) {
     for (size_t i=0; i < MP_ARRAY_SIZE(active_audio); i++) {
         if (!active_audio[i]) {
             active_audio[i] = self;
+            supervisor_enable_tick();
             break;
         }
     }
@@ -77,12 +79,16 @@ STATIC void deactivate_audiopwmout_obj(audiopwmio_pwmaudioout_obj_t *self) {
     for (size_t i=0; i < MP_ARRAY_SIZE(active_audio); i++) {
         if (active_audio[i] == self) {
             active_audio[i] = NULL;
+            supervisor_disable_tick();
         }
     }
 }
 
 void audiopwmout_reset() {
     for (size_t i=0; i < MP_ARRAY_SIZE(active_audio); i++) {
+        if (active_audio[i]) {
+            supervisor_disable_tick();
+        }
         active_audio[i] = NULL;
     }
 }


### PR DESCRIPTION
I assume that the "same" fix as samd is needed in order to make audio play properly after reduced power.

Testing performed: only building the software