### PR TITLE
Framebufferio: Set ground work for smart LEDs as "framebuffers"

### DIFF
--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -395,6 +395,7 @@ STATIC int rgbmatrix_rgbmatrix_get_native_frames_per_second_proto(mp_obj_t self_
 STATIC const framebuffer_p_t rgbmatrix_rgbmatrix_proto = {
     MP_PROTO_IMPLEMENT(MP_QSTR_protocol_framebuffer)
     .get_bufinfo = rgbmatrix_rgbmatrix_get_bufinfo,
+    .put_pixel_span = framebufferio_framebufferio_put_simple_pixel_span,
     .set_brightness = rgbmatrix_rgbmatrix_set_brightness_proto,
     .get_brightness = rgbmatrix_rgbmatrix_get_brightness_proto,
     .get_width = rgbmatrix_rgbmatrix_get_width_proto,

--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -394,6 +394,7 @@ STATIC int rgbmatrix_rgbmatrix_get_native_frames_per_second_proto(mp_obj_t self_
 
 STATIC const framebuffer_p_t rgbmatrix_rgbmatrix_proto = {
     MP_PROTO_IMPLEMENT(MP_QSTR_protocol_framebuffer)
+    .can_survive_reset = true,
     .get_bufinfo = rgbmatrix_rgbmatrix_get_bufinfo,
     .put_pixel_span = framebufferio_framebufferio_put_simple_pixel_span,
     .set_brightness = rgbmatrix_rgbmatrix_set_brightness_proto,

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -191,8 +191,12 @@ void reset_displays(void) {
 #if CIRCUITPY_FRAMEBUFFERIO
         } else if (displays[i].framebuffer_display.base.type == &framebufferio_framebufferdisplay_type) {
             framebufferio_framebufferdisplay_obj_t* display = &displays[i].framebuffer_display;
-            display->auto_refresh = true;
-            common_hal_framebufferio_framebufferdisplay_show(display, NULL);
+            if(display->framebuffer_protocol->can_survive_reset) {
+                display->auto_refresh = true;
+                common_hal_framebufferio_framebufferdisplay_show(display, NULL);
+            } else {
+                memset(display, 0, sizeof(*display));
+            }
 #endif
         }
     }

--- a/shared-module/framebufferio/FramebufferDisplay.h
+++ b/shared-module/framebufferio/FramebufferDisplay.h
@@ -60,7 +60,10 @@ void framebufferio_framebufferdisplay_collect_ptrs(framebufferio_framebufferdisp
 
 mp_obj_t common_hal_framebufferio_framebufferdisplay_get_framebuffer(framebufferio_framebufferdisplay_obj_t* self);
 
+void framebufferio_framebufferio_put_simple_pixel_span(mp_obj_t framebuffer, framebufferio_framebufferdisplay_obj_t *display, const displayio_area_t *subrectangle, uint32_t *buffer);
+
 typedef void (*framebuffer_get_bufinfo_fun)(mp_obj_t, mp_buffer_info_t *bufinfo);
+typedef void (*framebuffer_put_pixel_span_fun)(mp_obj_t, framebufferio_framebufferdisplay_obj_t *, const displayio_area_t *subrectangle, uint32_t *buffer);
 typedef void (*framebuffer_swapbuffers_fun)(mp_obj_t);
 typedef void (*framebuffer_deinit_fun)(mp_obj_t);
 typedef bool (*framebuffer_set_brightness_fun)(mp_obj_t, mp_float_t);
@@ -76,6 +79,7 @@ typedef int (*framebuffer_get_native_frames_per_second_fun)(mp_obj_t);
 typedef struct _framebuffer_p_t {
     MP_PROTOCOL_HEAD // MP_QSTR_protocol_framebuffer
     framebuffer_get_bufinfo_fun get_bufinfo;
+    framebuffer_put_pixel_span_fun put_pixel_span;
     framebuffer_swapbuffers_fun swapbuffers;
     framebuffer_deinit_fun deinit;
     framebuffer_get_width_fun get_width;

--- a/shared-module/framebufferio/FramebufferDisplay.h
+++ b/shared-module/framebufferio/FramebufferDisplay.h
@@ -78,6 +78,7 @@ typedef int (*framebuffer_get_native_frames_per_second_fun)(mp_obj_t);
 
 typedef struct _framebuffer_p_t {
     MP_PROTOCOL_HEAD // MP_QSTR_protocol_framebuffer
+    bool can_survive_reset;
     framebuffer_get_bufinfo_fun get_bufinfo;
     framebuffer_put_pixel_span_fun put_pixel_span;
     framebuffer_swapbuffers_fun swapbuffers;


### PR DESCRIPTION
@rhooper this starts to flesh out some of the stuff we talked about last week.  If you get a chance to take a look, let me know what you think.