### PR TITLE
_bleio: support anonymous advertising

### DIFF
--- a/locale/ID.po
+++ b/locale/ID.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1487,6 +1487,11 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1471,6 +1471,11 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1471,6 +1471,11 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2020-05-18 02:48+0000\n"
 "Last-Translator: Jeff Epler <jepler@gmail.com>\n"
 "Language-Team: German <https://later.unpythonic.net/projects/circuitpython/"
@@ -1497,6 +1497,11 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2018-07-27 11:55-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -1471,6 +1471,11 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/locale/en_x_pirate.po
+++ b/locale/en_x_pirate.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2020-03-30 22:11+0000\n"
 "Last-Translator: Tannewt <devnull@unpythonic.net>\n"
 "Language-Team: English <https://later.unpythonic.net/projects/circuitpython/"
@@ -1480,6 +1480,11 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2020-05-17 20:56+0000\n"
 "Last-Translator: Jeff Epler <jepler@gmail.com>\n"
 "Language-Team: \n"
@@ -1490,6 +1490,11 @@ msgstr ""
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr "Ancho del Tile debe dividir exactamente el ancho de mapa de bits"
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
+msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2018-12-20 22:15-0800\n"
 "Last-Translator: Timothy <me@timothygarcia.ca>\n"
 "Language-Team: fil\n"
@@ -1494,6 +1494,11 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2020-05-17 20:56+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: French <https://later.unpythonic.net/projects/circuitpython/"
@@ -1525,6 +1525,11 @@ msgstr "Valeur de tuile hors limites"
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr "La largeur de la tuile doit diviser exactement la largeur de l'image"
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
+msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."

--- a/locale/it_IT.po
+++ b/locale/it_IT.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2018-10-02 16:27+0200\n"
 "Last-Translator: Enrico Paganin <enrico.paganin@mail.com>\n"
 "Language-Team: \n"
@@ -1505,6 +1505,11 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2019-05-06 14:22-0700\n"
 "Last-Translator: \n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1475,6 +1475,11 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2019-03-19 18:37-0700\n"
 "Last-Translator: Radomir Dopieralski <circuitpython@sheep.art.pl>\n"
 "Language-Team: pl\n"
@@ -1477,6 +1477,11 @@ msgstr ""
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr "Szerokość bitmapy musi być wielokrotnością szerokości kafelka"
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
+msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2018-10-02 21:14-0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -1488,6 +1488,11 @@ msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2020-05-17 20:56+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1511,6 +1511,11 @@ msgstr "Tile-värde utanför intervall"
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr "Tile-bredd måste vara jämnt delbar med bredd på bitmap"
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
+msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."

--- a/locale/zh_Latn_pinyin.po
+++ b/locale/zh_Latn_pinyin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: circuitpython-cn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-18 13:32-0700\n"
+"POT-Creation-Date: 2020-05-19 15:01+0800\n"
 "PO-Revision-Date: 2019-04-13 10:10-0700\n"
 "Last-Translator: hexthat\n"
 "Language-Team: Chinese Hanyu Pinyin\n"
@@ -1498,6 +1498,11 @@ msgstr "Píng pū zhí chāochū fànwéi"
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr "Píng pū kuāndù bìxū huàfēn wèi tú kuāndù"
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+#, c-format
+msgid "Timeout is too long: Maximum timeout length is %d seconds"
+msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."

--- a/ports/nrf/bluetooth/ble_drv.h
+++ b/ports/nrf/bluetooth/ble_drv.h
@@ -41,6 +41,7 @@
 
 #define MSEC_TO_UNITS(TIME, RESOLUTION) (((TIME) * 1000) / (RESOLUTION))
 #define SEC_TO_UNITS(TIME, RESOLUTION) (((TIME) * 1000000) / (RESOLUTION))
+#define UNITS_TO_SEC(TIME, RESOLUTION) (((TIME) * (RESOLUTION)) / 1000000)
 // 0.625 msecs (625 usecs)
 #define ADV_INTERVAL_UNIT_FLOAT_SECS (0.000625)
 // Microseconds is the base unit. The macros above know that.

--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -594,7 +594,7 @@ STATIC void check_data_fit(size_t data_len, bool connectable) {
     }
 }
 
-uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len) {
+uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len) {
     if (self->current_advertising_data != NULL && self->current_advertising_data == self->advertising_data) {
         return NRF_ERROR_BUSY;
     }
@@ -605,7 +605,7 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, 
         common_hal_bleio_adapter_stop_advertising(self);
     }
 
-
+    uint32_t err_code;
     bool extended = advertising_data_len > BLE_GAP_ADV_SET_DATA_SIZE_MAX ||
                     scan_response_data_len > BLE_GAP_ADV_SET_DATA_SIZE_MAX;
 
@@ -626,7 +626,27 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, 
         adv_type = BLE_GAP_ADV_TYPE_NONCONNECTABLE_NONSCANNABLE_UNDIRECTED;
     }
 
-    uint32_t err_code;
+    if (anonymous) {
+        ble_gap_privacy_params_t privacy = {
+            .privacy_mode = BLE_GAP_PRIVACY_MODE_DEVICE_PRIVACY,
+            .private_addr_type = BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE,
+            .private_addr_cycle_s = 0,
+            .p_device_irk = NULL,
+        };
+        err_code = sd_ble_gap_privacy_set(&privacy);
+    } else {
+        ble_gap_privacy_params_t privacy = {
+            .privacy_mode = BLE_GAP_PRIVACY_MODE_OFF,
+            .private_addr_type = BLE_GAP_ADDR_TYPE_PUBLIC,
+            .private_addr_cycle_s = 0,
+            .p_device_irk = NULL,
+        };
+        err_code = sd_ble_gap_privacy_set(&privacy);
+    }
+    if (err_code != NRF_SUCCESS) {
+        return err_code;
+    }
+
     ble_gap_adv_params_t adv_params = {
         .interval = SEC_TO_UNITS(interval, UNIT_0_625_MS),
         .properties.type = adv_type,
@@ -657,7 +677,7 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, 
 }
 
 
-void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo) {
+void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo) {
     if (self->current_advertising_data != NULL && self->current_advertising_data == self->advertising_data) {
         mp_raise_bleio_BluetoothError(translate("Already advertising."));
     }
@@ -681,7 +701,7 @@ void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool 
     memcpy(self->advertising_data, advertising_data_bufinfo->buf, advertising_data_bufinfo->len);
     memcpy(self->scan_response_data, scan_response_data_bufinfo->buf, scan_response_data_bufinfo->len);
 
-    check_nrf_error(_common_hal_bleio_adapter_start_advertising(self, connectable, interval,
+    check_nrf_error(_common_hal_bleio_adapter_start_advertising(self, connectable, anonymous, interval,
                                                                 self->advertising_data,
                                                                 advertising_data_bufinfo->len,
                                                                 self->scan_response_data,

--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -600,14 +600,13 @@ STATIC bool advertising_on_ble_evt(ble_evt_t *ble_evt, void *self_in) {
 
     switch (ble_evt->header.evt_id) {
         case BLE_GAP_EVT_ADV_SET_TERMINATED:
-            mp_printf(&mp_plat_print, "Advertising set terminated - %d advertising events were completed - reason: %d\n", ble_evt->evt.gap_evt.params.adv_set_terminated.num_completed_adv_events, ble_evt->evt.gap_evt.params.adv_set_terminated.reason);
             common_hal_bleio_adapter_stop_advertising(self);
             ble_drv_remove_event_handler(advertising_on_ble_evt, self_in);
             break;
 
         default:
             // For debugging.
-            mp_printf(&mp_plat_print, "Unhandled Advertising etvent: 0x%04x\n", ble_evt->header.evt_id);
+            // mp_printf(&mp_plat_print, "Unhandled advertising event: 0x%04x\n", ble_evt->header.evt_id);
             return false;
             break;
     }
@@ -722,7 +721,7 @@ void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool 
     if (!timeout) {
         if (anonymous) {
             // The Nordic macro is in units of 10ms. Convert to seconds.
-            uint32_t adv_timeout_max_secs = BLE_GAP_ADV_TIMEOUT_LIMITED_MAX / 100;
+            uint32_t adv_timeout_max_secs = UNITS_TO_SEC(BLE_GAP_ADV_TIMEOUT_LIMITED_MAX, UNIT_10_MS);
             uint32_t rotate_timeout_max_secs = BLE_GAP_DEFAULT_PRIVATE_ADDR_CYCLE_INTERVAL_S;
             timeout = MIN(adv_timeout_max_secs, rotate_timeout_max_secs);
         }
@@ -732,7 +731,7 @@ void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool 
     } else {
         if (SEC_TO_UNITS(timeout, UNIT_10_MS) > BLE_GAP_ADV_TIMEOUT_LIMITED_MAX) {
             mp_raise_bleio_BluetoothError(translate("Timeout is too long: Maximum timeout length is %d seconds"),
-                                        BLE_GAP_ADV_TIMEOUT_LIMITED_MAX / 100);
+                                        UNITS_TO_SEC(BLE_GAP_ADV_TIMEOUT_LIMITED_MAX, UNIT_10_MS));
         }
     }
 

--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -26,6 +26,7 @@
  * THE SOFTWARE.
  */
 
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -594,7 +595,26 @@ STATIC void check_data_fit(size_t data_len, bool connectable) {
     }
 }
 
-uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len) {
+STATIC bool advertising_on_ble_evt(ble_evt_t *ble_evt, void *self_in) {
+    bleio_adapter_obj_t *self = (bleio_adapter_obj_t*)self_in;
+
+    switch (ble_evt->header.evt_id) {
+        case BLE_GAP_EVT_ADV_SET_TERMINATED:
+            mp_printf(&mp_plat_print, "Advertising set terminated - %d advertising events were completed - reason: %d\n", ble_evt->evt.gap_evt.params.adv_set_terminated.num_completed_adv_events, ble_evt->evt.gap_evt.params.adv_set_terminated.reason);
+            common_hal_bleio_adapter_stop_advertising(self);
+            ble_drv_remove_event_handler(advertising_on_ble_evt, self_in);
+            break;
+
+        default:
+            // For debugging.
+            mp_printf(&mp_plat_print, "Unhandled Advertising etvent: 0x%04x\n", ble_evt->header.evt_id);
+            return false;
+            break;
+    }
+    return true;
+}
+
+uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len) {
     if (self->current_advertising_data != NULL && self->current_advertising_data == self->advertising_data) {
         return NRF_ERROR_BUSY;
     }
@@ -630,7 +650,11 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, 
         ble_gap_privacy_params_t privacy = {
             .privacy_mode = BLE_GAP_PRIVACY_MODE_DEVICE_PRIVACY,
             .private_addr_type = BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE,
-            .private_addr_cycle_s = 0,
+            // Rotate the keys one second after we're scheduled to stop
+            // advertising. This prevents a potential race condition where we
+            // fire off a beacon with the same advertising data but a new MAC
+            // address just as we tear down the connection.
+            .private_addr_cycle_s = timeout + 1,
             .p_device_irk = NULL,
         };
         err_code = sd_ble_gap_privacy_set(&privacy);
@@ -650,7 +674,7 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, 
     ble_gap_adv_params_t adv_params = {
         .interval = SEC_TO_UNITS(interval, UNIT_0_625_MS),
         .properties.type = adv_type,
-        .duration = BLE_GAP_ADV_TIMEOUT_GENERAL_UNLIMITED,
+        .duration = SEC_TO_UNITS(timeout, UNIT_10_MS),
         .filter_policy = BLE_GAP_ADV_FP_ANY,
         .primary_phy = BLE_GAP_PHY_1MBPS,
     };
@@ -667,6 +691,8 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, 
         return err_code;
     }
 
+    ble_drv_add_event_handler(advertising_on_ble_evt, self);
+
     vm_used_ble = true;
     err_code = sd_ble_gap_adv_start(adv_handle, BLE_CONN_CFG_TAG_CUSTOM);
     if (err_code != NRF_SUCCESS) {
@@ -677,7 +703,7 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, 
 }
 
 
-void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo) {
+void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo) {
     if (self->current_advertising_data != NULL && self->current_advertising_data == self->advertising_data) {
         mp_raise_bleio_BluetoothError(translate("Already advertising."));
     }
@@ -689,6 +715,27 @@ void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool 
     if (advertising_data_bufinfo->len > 31 && scan_response_data_bufinfo->len > 0) {
         mp_raise_bleio_BluetoothError(translate("Extended advertisements with scan response not supported."));
     }
+
+    // Anonymous mode requires a timeout so that we don't continue to broadcast
+    // the same data while cycling the MAC address -- otherwise, what's the
+    // point of randomizing the MAC address?
+    if (!timeout) {
+        if (anonymous) {
+            // The Nordic macro is in units of 10ms. Convert to seconds.
+            uint32_t adv_timeout_max_secs = BLE_GAP_ADV_TIMEOUT_LIMITED_MAX / 100;
+            uint32_t rotate_timeout_max_secs = BLE_GAP_DEFAULT_PRIVATE_ADDR_CYCLE_INTERVAL_S;
+            timeout = MIN(adv_timeout_max_secs, rotate_timeout_max_secs);
+        }
+        else {
+            timeout = BLE_GAP_ADV_TIMEOUT_GENERAL_UNLIMITED;
+        }
+    } else {
+        if (SEC_TO_UNITS(timeout, UNIT_10_MS) > BLE_GAP_ADV_TIMEOUT_LIMITED_MAX) {
+            mp_raise_bleio_BluetoothError(translate("Timeout is too long: Maximum timeout length is %d seconds"),
+                                        BLE_GAP_ADV_TIMEOUT_LIMITED_MAX / 100);
+        }
+    }
+
     // The advertising data buffers must not move, because the SoftDevice depends on them.
     // So make them long-lived and reuse them onwards.
     if (self->advertising_data == NULL) {
@@ -701,7 +748,7 @@ void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool 
     memcpy(self->advertising_data, advertising_data_bufinfo->buf, advertising_data_bufinfo->len);
     memcpy(self->scan_response_data, scan_response_data_bufinfo->buf, scan_response_data_bufinfo->len);
 
-    check_nrf_error(_common_hal_bleio_adapter_start_advertising(self, connectable, anonymous, interval,
+    check_nrf_error(_common_hal_bleio_adapter_start_advertising(self, connectable, anonymous, timeout, interval,
                                                                 self->advertising_data,
                                                                 advertising_data_bufinfo->len,
                                                                 self->scan_response_data,
@@ -719,6 +766,10 @@ void common_hal_bleio_adapter_stop_advertising(bleio_adapter_obj_t *self) {
     if ((err_code != NRF_SUCCESS) && (err_code != NRF_ERROR_INVALID_STATE)) {
         check_nrf_error(err_code);
     }
+}
+
+bool common_hal_bleio_adapter_get_advertising(bleio_adapter_obj_t *self) {
+    return self->current_advertising_data != NULL;
 }
 
 bool common_hal_bleio_adapter_get_connected(bleio_adapter_obj_t *self) {

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -135,29 +135,34 @@ const mp_obj_property_t bleio_adapter_name_obj = {
                (mp_obj_t)&mp_const_none_obj },
 };
 
-//|     def start_advertising(self, data: buf, *, scan_response: buf = None, connectable: bool = True, interval: float = 0.1) -> Any:
+//|     def start_advertising(self, data: buf, *, scan_response: buf = None, connectable: bool = True, anonymous: bool = False, timeout: int = 0, interval: float = 0.1) -> Any:
 //|         """Starts advertising until `stop_advertising` is called or if connectable, another device
 //|         connects to us.
 //|
 //|         .. warning: If data is longer than 31 bytes, then this will automatically advertise as an
 //|            extended advertisement that older BLE 4.x clients won't be able to scan for.
 //|
+//|         .. note: If you set ``anonymous=True``, then a timeout must be specified. If no timeout is
+//|            specified, then the maximum allowed timeout will be selected automatically.
+//|
 //|         :param buf data: advertising data packet bytes
 //|         :param buf scan_response: scan response data packet bytes. ``None`` if no scan response is needed.
 //|         :param bool connectable:  If `True` then other devices are allowed to connect to this peripheral.
-//|         :param bool anonymous:  If `True` then this device's MAC address is randomized regularly.
+//|         :param bool anonymous:  If `True` then this device's MAC address is randomized before advertising.
+//|         :param int timeout:  If set, we will only advertise for this many seconds.
 //|         :param float interval:  advertising interval, in seconds"""
 //|         ...
 //|
 STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_adapter_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
-    enum { ARG_data, ARG_scan_response, ARG_connectable, ARG_anonymous, ARG_interval };
+    enum { ARG_data, ARG_scan_response, ARG_connectable, ARG_anonymous, ARG_timeout, ARG_interval };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_data, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_scan_response, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_connectable, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = true} },
         { MP_QSTR_anonymous, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
+        { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_interval, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
     };
 
@@ -185,11 +190,12 @@ STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t
 
     bool connectable = args[ARG_connectable].u_bool;
     bool anonymous = args[ARG_anonymous].u_bool;
+    uint32_t timeout = args[ARG_timeout].u_int;
     if (data_bufinfo.len > 31 && connectable && scan_response_bufinfo.len > 0) {
         mp_raise_bleio_BluetoothError(translate("Cannot have scan responses for extended, connectable advertisements."));
     }
 
-    common_hal_bleio_adapter_start_advertising(self, connectable, anonymous, interval,
+    common_hal_bleio_adapter_start_advertising(self, connectable, anonymous, timeout, interval,
                                                &data_bufinfo, &scan_response_bufinfo);
 
     return mp_const_none;
@@ -295,6 +301,22 @@ STATIC mp_obj_t bleio_adapter_stop_scan(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_stop_scan_obj, bleio_adapter_stop_scan);
 
+//|     advertising: Any = ...
+//|     """True when the adapter is currently advertising. (read-only)"""
+//|
+STATIC mp_obj_t bleio_adapter_get_advertising(mp_obj_t self) {
+    return mp_obj_new_bool(common_hal_bleio_adapter_get_advertising(self));
+
+}
+MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_get_advertising_obj, bleio_adapter_get_advertising);
+
+const mp_obj_property_t bleio_adapter_advertising_obj = {
+    .base.type = &mp_type_property,
+    .proxy = { (mp_obj_t)&bleio_adapter_get_advertising_obj,
+               (mp_obj_t)&mp_const_none_obj,
+               (mp_obj_t)&mp_const_none_obj },
+};
+
 //|     connected: Any = ...
 //|     """True when the adapter is connected to another device regardless of who initiated the
 //|     connection. (read-only)"""
@@ -378,6 +400,7 @@ STATIC const mp_rom_map_elem_t bleio_adapter_locals_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_start_advertising), MP_ROM_PTR(&bleio_adapter_start_advertising_obj) },
     { MP_ROM_QSTR(MP_QSTR_stop_advertising),  MP_ROM_PTR(&bleio_adapter_stop_advertising_obj) },
+    { MP_ROM_QSTR(MP_QSTR_advertising),   MP_ROM_PTR(&bleio_adapter_advertising_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_start_scan), MP_ROM_PTR(&bleio_adapter_start_scan_obj) },
     { MP_ROM_QSTR(MP_QSTR_stop_scan),  MP_ROM_PTR(&bleio_adapter_stop_scan_obj) },

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -145,17 +145,19 @@ const mp_obj_property_t bleio_adapter_name_obj = {
 //|         :param buf data: advertising data packet bytes
 //|         :param buf scan_response: scan response data packet bytes. ``None`` if no scan response is needed.
 //|         :param bool connectable:  If `True` then other devices are allowed to connect to this peripheral.
+//|         :param bool anonymous:  If `True` then this device's MAC address is randomized regularly.
 //|         :param float interval:  advertising interval, in seconds"""
 //|         ...
 //|
 STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_adapter_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
-    enum { ARG_data, ARG_scan_response, ARG_connectable, ARG_interval };
+    enum { ARG_data, ARG_scan_response, ARG_connectable, ARG_anonymous, ARG_interval };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_data, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_scan_response, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_connectable, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = true} },
+        { MP_QSTR_anonymous, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
         { MP_QSTR_interval, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
     };
 
@@ -182,11 +184,12 @@ STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t
     }
 
     bool connectable = args[ARG_connectable].u_bool;
+    bool anonymous = args[ARG_anonymous].u_bool;
     if (data_bufinfo.len > 31 && connectable && scan_response_bufinfo.len > 0) {
         mp_raise_bleio_BluetoothError(translate("Cannot have scan responses for extended, connectable advertisements."));
     }
 
-    common_hal_bleio_adapter_start_advertising(self, connectable, interval,
+    common_hal_bleio_adapter_start_advertising(self, connectable, anonymous, interval,
                                                &data_bufinfo, &scan_response_bufinfo);
 
     return mp_const_none;

--- a/shared-bindings/_bleio/Adapter.h
+++ b/shared-bindings/_bleio/Adapter.h
@@ -45,9 +45,9 @@ extern bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_o
 extern mp_obj_str_t* common_hal_bleio_adapter_get_name(bleio_adapter_obj_t *self);
 extern void common_hal_bleio_adapter_set_name(bleio_adapter_obj_t *self, const char* name);
 
-extern uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len);
+extern uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len);
 
-extern void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo);
+extern void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo);
 extern void common_hal_bleio_adapter_stop_advertising(bleio_adapter_obj_t *self);
 
 extern mp_obj_t common_hal_bleio_adapter_start_scan(bleio_adapter_obj_t *self, uint8_t* prefixes, size_t prefix_length, bool extended, mp_int_t buffer_size, mp_float_t timeout, mp_float_t interval, mp_float_t window, mp_int_t minimum_rssi, bool active);

--- a/shared-bindings/_bleio/Adapter.h
+++ b/shared-bindings/_bleio/Adapter.h
@@ -37,6 +37,7 @@
 
 const mp_obj_type_t bleio_adapter_type;
 
+extern bool common_hal_bleio_adapter_get_advertising(bleio_adapter_obj_t *self);
 extern bool common_hal_bleio_adapter_get_enabled(bleio_adapter_obj_t *self);
 extern void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enabled);
 extern bool common_hal_bleio_adapter_get_connected(bleio_adapter_obj_t *self);
@@ -45,9 +46,9 @@ extern bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_o
 extern mp_obj_str_t* common_hal_bleio_adapter_get_name(bleio_adapter_obj_t *self);
 extern void common_hal_bleio_adapter_set_name(bleio_adapter_obj_t *self, const char* name);
 
-extern uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len);
+extern uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len);
 
-extern void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo);
+extern void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo);
 extern void common_hal_bleio_adapter_stop_advertising(bleio_adapter_obj_t *self);
 
 extern mp_obj_t common_hal_bleio_adapter_start_scan(bleio_adapter_obj_t *self, uint8_t* prefixes, size_t prefix_length, bool extended, mp_int_t buffer_size, mp_float_t timeout, mp_float_t interval, mp_float_t window, mp_int_t minimum_rssi, bool active);

--- a/supervisor/shared/bluetooth.c
+++ b/supervisor/shared/bluetooth.c
@@ -74,6 +74,7 @@ void supervisor_bluetooth_start_advertising(void) {
     // TODO: switch to Adafruit short UUID for the advertisement and add manufacturing data to distinguish ourselves from arduino.
     _common_hal_bleio_adapter_start_advertising(&common_hal_bleio_adapter_obj,
                                                    true,
+                                                   false,
                                                    1.0,
                                                    circuitpython_advertising_data,
                                                    sizeof(circuitpython_advertising_data),

--- a/supervisor/shared/bluetooth.c
+++ b/supervisor/shared/bluetooth.c
@@ -74,7 +74,7 @@ void supervisor_bluetooth_start_advertising(void) {
     // TODO: switch to Adafruit short UUID for the advertisement and add manufacturing data to distinguish ourselves from arduino.
     _common_hal_bleio_adapter_start_advertising(&common_hal_bleio_adapter_obj,
                                                    true,
-                                                   false,
+                                                   false, 0,
                                                    1.0,
                                                    circuitpython_advertising_data,
                                                    sizeof(circuitpython_advertising_data),


### PR DESCRIPTION
This experimental patch adds a new parameter to `_bleio.adapter.start_advertising()`: `anonymous`.

This boolean parameter defaults to `False`. When set to `True`, it enables privacy mode by calling `sd_ble_gap_privacy_set()`.

I have tested this on my device, and I confirm that it works -- the address is randomized, and is rotated every 15 minutes.  A second device is capable of connecting to a GATT service and communicating.

Unanswered questions:

- How does this work with bonding?
- Should we expose the cycle time? It's currently set to `0` which uses the Nordic defaults
- Should the `IRK` be exposed anywhere, and does this affect bonding at all?