### PR TITLE
nrf: reset rtc as part of port_reset()

### DIFF
--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -161,6 +161,10 @@ void reset_port(void) {
     pulsein_reset();
 #endif
 
+#if CIRCUITPY_RTC
+    rtc_reset();
+#endif
+
     timers_reset();
 
 #if CIRCUITPY_BLEIO


### PR DESCRIPTION
On NRF, the `rtc_reset()` function is never called.  As a result,
calls to `time.time()` return a cryptic error>

```
>>> import time
>>> time.time()
'' object has no attribute 'datetime'
>>>
```

This is because `MP_STATE_VM(rtc_time_source)` is not initialized
due to `rtc_reset()` never being called.

If `CIRCUITPY_RTC` is enabled, call `rtc_reset()` as part of the
`reset_port()` call. This ensures that `time.time()` works as expected.