### PR TITLE
Samd51: Allow setting dac (and ADC) reference voltage

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -221,6 +221,7 @@ SRC_C = \
 	audio_dma.c \
 	background.c \
 	bindings/samd/Clock.c \
+	bindings/samd/Reference.c \
 	bindings/samd/__init__.c \
 	boards/$(BOARD)/board.c \
 	boards/$(BOARD)/pins.c \

--- a/ports/atmel-samd/bindings/samd/Reference.c
+++ b/ports/atmel-samd/bindings/samd/Reference.c
@@ -1,0 +1,171 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Jeff Epler for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/obj.h"
+#include "py/runtime.h"
+
+#include "bindings/samd/Reference.h"
+
+typedef struct {
+    mp_obj_base_t base;
+    int16_t value;
+    int16_t name;
+} cp_enum_obj_t;
+
+#define MAKE_ENUM_VALUE(type, prefix, name, value) \
+const cp_enum_obj_t prefix ## name ## _obj = { \
+    { &type }, value, MP_QSTR_ ## name, \
+}
+
+#define MAKE_ENUM_MAP_ENTRY(prefix, name) \
+    { MP_ROM_QSTR(MP_QSTR_ ## name), MP_ROM_PTR(&prefix ## name ## _obj) }
+
+mp_obj_t cp_enum_find(const mp_obj_dict_t *dict, int value) {
+    for (int i=0; i<dict->map.used; i++) {
+        const cp_enum_obj_t *v = dict->map.table[i].value;
+        if (v->value == value) {
+            return (mp_obj_t)v;
+        }
+    }
+    return mp_const_none;
+}
+
+int cp_enum_value(const mp_obj_type_t *type, mp_obj_t *obj) {
+    if (!MP_OBJ_IS_TYPE(obj, type)) {
+        mp_raise_TypeError_varg(translate("Expected a %q"), type->name);
+    }
+    return ((cp_enum_obj_t*)MP_OBJ_TO_PTR(obj))->value;
+}
+
+void cp_enum_obj_print_helper(uint16_t module, const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    cp_enum_obj_t *self = self_in;
+    mp_printf(print, "%q.%q.%q", module, self->base.type->name, self->name);
+}
+
+const mp_obj_type_t reference_voltage_type;
+
+MAKE_ENUM_VALUE(reference_voltage_type, reference_voltage_, V1_0, 0);
+MAKE_ENUM_VALUE(reference_voltage_type, reference_voltage_, V1_1, 1);
+MAKE_ENUM_VALUE(reference_voltage_type, reference_voltage_, V1_2, 2);
+MAKE_ENUM_VALUE(reference_voltage_type, reference_voltage_, V1_25, 3);
+MAKE_ENUM_VALUE(reference_voltage_type, reference_voltage_, V2_0, 4);
+MAKE_ENUM_VALUE(reference_voltage_type, reference_voltage_, V2_2, 5);
+MAKE_ENUM_VALUE(reference_voltage_type, reference_voltage_, V2_4, 6);
+MAKE_ENUM_VALUE(reference_voltage_type, reference_voltage_, V2_5, 7);
+
+STATIC const mp_rom_map_elem_t reference_voltage_locals_table[] = {
+    MAKE_ENUM_MAP_ENTRY(reference_voltage_, V1_0),
+    MAKE_ENUM_MAP_ENTRY(reference_voltage_, V1_1),
+    MAKE_ENUM_MAP_ENTRY(reference_voltage_, V1_2),
+    MAKE_ENUM_MAP_ENTRY(reference_voltage_, V1_25),
+    MAKE_ENUM_MAP_ENTRY(reference_voltage_, V2_0),
+    MAKE_ENUM_MAP_ENTRY(reference_voltage_, V2_2),
+    MAKE_ENUM_MAP_ENTRY(reference_voltage_, V2_4),
+    MAKE_ENUM_MAP_ENTRY(reference_voltage_, V2_5),
+};
+STATIC MP_DEFINE_CONST_DICT(reference_voltage_locals_dict, reference_voltage_locals_table);
+
+STATIC void reference_voltage_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    cp_enum_obj_print_helper(MP_QSTR_samd, print, self_in, kind);
+}
+
+const mp_obj_type_t reference_voltage_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_ReferenceVoltage,
+    .print = reference_voltage_print,
+    .locals_dict = (mp_obj_t)&reference_voltage_locals_dict,
+};
+
+STATIC mp_obj_t reference_voltage_get(void) {
+    return cp_enum_find(&reference_voltage_locals_dict, SUPC->VREF.bit.SEL);
+}
+MP_DEFINE_CONST_FUN_OBJ_0(reference_voltage_get_obj, reference_voltage_get);
+
+STATIC mp_obj_t reference_voltage_set(mp_obj_t arg) {
+    int i = cp_enum_value(&reference_voltage_type, arg);
+    SUPC->VREF.bit.SEL = i;
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(reference_voltage_set_obj, reference_voltage_set);
+
+const mp_obj_property_t reference_voltage_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&reference_voltage_get_obj,
+              (mp_obj_t)&reference_voltage_set_obj,
+              (mp_obj_t)&mp_const_none_obj}
+};
+
+const mp_obj_type_t dac_reference_type;
+
+MAKE_ENUM_VALUE(dac_reference_type, dac_reference_, VREFAU, 0);
+MAKE_ENUM_VALUE(dac_reference_type, dac_reference_, VDDANA, 1);
+MAKE_ENUM_VALUE(dac_reference_type, dac_reference_, VREFAB, 2);
+MAKE_ENUM_VALUE(dac_reference_type, dac_reference_, INTREF, 3);
+
+STATIC const mp_rom_map_elem_t dac_reference_locals_table[] = {
+    MAKE_ENUM_MAP_ENTRY(dac_reference_, VREFAU),
+    MAKE_ENUM_MAP_ENTRY(dac_reference_, VDDANA),
+    MAKE_ENUM_MAP_ENTRY(dac_reference_, VREFAB),
+    MAKE_ENUM_MAP_ENTRY(dac_reference_, INTREF),
+};
+STATIC MP_DEFINE_CONST_DICT(dac_reference_locals_dict, dac_reference_locals_table);
+
+STATIC void dac_reference_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    cp_enum_obj_print_helper(MP_QSTR_samd, print, self_in, kind);
+}
+
+const mp_obj_type_t dac_reference_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_DacReference,
+    .print = dac_reference_print,
+    .locals_dict = (mp_obj_t)&dac_reference_locals_dict,
+};
+
+STATIC int dac_reference_value_default;
+
+int dac_reference_get_default_value(void) {
+    return dac_reference_value_default;
+}
+
+STATIC mp_obj_t dac_reference_get(void) {
+    return cp_enum_find(&dac_reference_locals_dict, dac_reference_value_default);
+}
+MP_DEFINE_CONST_FUN_OBJ_0(dac_reference_get_obj, dac_reference_get);
+
+STATIC mp_obj_t dac_reference_set(mp_obj_t arg) {
+    int i = cp_enum_value(&dac_reference_type, arg);
+    dac_reference_value_default = i;
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(dac_reference_set_obj, dac_reference_set);
+
+
+const mp_obj_property_t dac_reference_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&dac_reference_get_obj,
+              (mp_obj_t)&dac_reference_set_obj,
+              (mp_obj_t)&mp_const_none_obj}
+};

--- a/ports/atmel-samd/bindings/samd/Reference.h
+++ b/ports/atmel-samd/bindings/samd/Reference.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Jeff Epler for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+#ifndef MICROPY_INCLUDED_ATMEL_SAMD_BINDINGS_SAMD_REFERENCE_H
+#define MICROPY_INCLUDED_ATMEL_SAMD_BINDINGS_SAMD_REFERENCE_H
+
+#include "py/obj.h"
+#include "py/objproperty.h"
+
+MP_DECLARE_CONST_FUN_OBJ_0(reference_voltage_get_obj);
+MP_DECLARE_CONST_FUN_OBJ_1(reference_voltage_set_obj);
+MP_DECLARE_CONST_FUN_OBJ_0(dac_reference_get_obj);
+MP_DECLARE_CONST_FUN_OBJ_1(dac_reference_set_obj);
+
+extern const mp_obj_property_t reference_voltage_obj;
+extern const mp_obj_type_t reference_voltage_type;
+
+extern const mp_obj_property_t dac_reference_obj;
+extern const mp_obj_type_t dac_reference_type;
+
+extern int dac_reference_get_default_value(void);
+#endif

--- a/ports/atmel-samd/bindings/samd/__init__.c
+++ b/ports/atmel-samd/bindings/samd/__init__.c
@@ -29,6 +29,9 @@
 #include "py/runtime.h"
 
 #include "bindings/samd/Clock.h"
+#ifdef SAMD51
+#include "bindings/samd/Reference.h"
+#endif
 
 //| :mod:`samd` --- SAMD implementation settings
 //| =================================================
@@ -61,7 +64,15 @@ const mp_obj_module_t samd_clock_module = {
 
 STATIC const mp_rom_map_elem_t samd_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_samd) },
-    { MP_ROM_QSTR(MP_QSTR_clock),  MP_ROM_PTR(&samd_clock_module) },
+    { MP_ROM_QSTR(MP_QSTR_clock), MP_ROM_PTR(&samd_clock_module) },
+#ifdef SAMD51
+    { MP_ROM_QSTR(MP_QSTR_ReferenceVoltage), MP_ROM_PTR(&reference_voltage_type) },
+    { MP_ROM_QSTR(MP_QSTR_DacReference), MP_ROM_PTR(&dac_reference_type) },
+    { MP_ROM_QSTR(MP_QSTR_dac_default_reference_get), MP_ROM_PTR(&dac_reference_get_obj) },
+    { MP_ROM_QSTR(MP_QSTR_dac_default_reference_set), MP_ROM_PTR(&dac_reference_set_obj) },
+    { MP_ROM_QSTR(MP_QSTR_reference_voltage_get), MP_ROM_PTR(&reference_voltage_get_obj) },
+    { MP_ROM_QSTR(MP_QSTR_reference_voltage_set), MP_ROM_PTR(&reference_voltage_set_obj) },
+#endif
 };
 
 STATIC MP_DEFINE_CONST_DICT(samd_module_globals, samd_module_globals_table);

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -54,6 +54,8 @@
 #include "samd/pins.h"
 #include "samd/timers.h"
 
+#include "bindings/samd/Reference.h"
+
 #ifdef SAMD21
 static void ramp_value(uint16_t start, uint16_t end) {
     start = DAC->DATA.reg;
@@ -200,7 +202,6 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t* self,
         DAC->DACCTRL[0].reg = DAC_DACCTRL_CCTRL_CC100K |
                               DAC_DACCTRL_ENABLE |
                               DAC_DACCTRL_LEFTADJ;
-        DAC->CTRLB.reg = DAC_CTRLB_REFSEL_VREFPU;
         #endif
     }
     #ifdef SAMD51
@@ -209,7 +210,13 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t* self,
         DAC->DACCTRL[1].reg = DAC_DACCTRL_CCTRL_CC100K |
                               DAC_DACCTRL_ENABLE |
                               DAC_DACCTRL_LEFTADJ;
-        DAC->CTRLB.reg = DAC_CTRLB_REFSEL_VREFPU;
+    }
+    #endif
+    #ifdef SAMD51
+    DAC->CTRLB.bit.REFSEL = dac_reference_get_default_value();
+    if(dac_reference_get_default_value() == ADC_REFCTRL_REFSEL_INTREF_Val) {
+        SUPC->VREF.bit.ONDEMAND = 0;
+        SUPC->VREF.bit.RUNSTDBY = 1;
     }
     #endif
 

--- a/ports/stm/Makefile
+++ b/ports/stm/Makefile
@@ -154,43 +154,43 @@ CFLAGS += \
 	-DCFG_TUD_MIDI_TX_BUFSIZE=128
 
 SRC_STM32 = $(addprefix $(HAL_DIR)/Src/stm32$(MCU_SERIES_LOWER)xx_,\
+	hal.c \
 	hal_adc.c \
 	hal_adc_ex.c \
+	hal_cortex.c \
 	hal_dac.c \
 	hal_dac_ex.c \
+	hal_dma.c \
+	hal_dma_ex.c \
+	hal_exti.c \
+	hal_flash.c \
+	hal_flash_ex.c \
+	hal_gpio.c \
 	hal_i2c.c \
 	hal_i2c_ex.c \
+	hal_pwr.c \
+	hal_pwr_ex.c \
 	hal_qspi.c \
+	hal_rcc.c \
+	hal_rcc_ex.c \
 	hal_rng.c \
 	hal_rtc.c \
 	hal_rtc_ex.c \
+	hal_sd.c \
 	hal_spi.c \
 	hal_tim.c \
 	hal_tim_ex.c \
 	hal_uart.c \
 	hal_usart.c \
-	hal_rcc.c \
-	hal_rcc_ex.c \
-	hal_flash.c \
-	hal_flash_ex.c \
-	hal_gpio.c \
-	hal_dma_ex.c \
-	hal_dma.c \
-	hal_pwr.c \
-	hal_pwr_ex.c \
-	hal_cortex.c \
-	hal.c \
-	hal_exti.c \
-	hal_sd.c \
-	ll_gpio.c \
 	ll_adc.c \
-	ll_i2c.c \
 	ll_dma.c \
+	ll_exti.c \
+	ll_gpio.c \
+	ll_i2c.c \
+	ll_rcc.c \
 	ll_sdmmc.c \
 	ll_usart.c \
-	ll_rcc.c \
 	ll_utils.c \
-	ll_exti.c \
 )
 
 # Need this to avoid UART linker problems. TODO: rewrite to use registered callbacks.


### PR DESCRIPTION
For instance, the following makes the audio output be 1V p-p at the output pins:
```
import samd
samd.reference_voltage_set(samd.ReferenceVoltage.V1_0)
samd.dac_reference_set(samd.DacReference.INTREF)
audio = AudioOut(...)
```

If this functionality is desired, I can continue to work on this PR.

This PR also includes the start of a (not properly divided out) API for enumerated types in Python that could reduce code size.  A "cp_enum_obj_t"  with convenience routines for finding a Python object for a given internal value, finding the internal value from a Python object, and for printing a value.  It could be used for pin direction, pull modes, etc. where each one has rolled its own code before now.  Probably the code savings is in the double-digit bytes, though, there's not a _LOT_ of code there.