### PR TITLE
 allow PORT specification for esp32s2 flashing

### DIFF
--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -31,6 +31,9 @@ else
   endif
 endif
 
+# If the flash PORT is not given, use the default /dev/tty.SLAB_USBtoUART.
+PORT ?= /dev/tty.SLAB_USBtoUART
+
 # If the build directory is not given, make it reflect the board name.
 BUILD ?= build-$(BOARD)
 
@@ -270,7 +273,7 @@ $(BUILD)/firmware.bin: $(BUILD)/esp-idf/partition_table/partition-table.bin $(BU
 	$(Q)$(PYTHON) ../../tools/join_bins.py $@ 0x1000 $(BUILD)/esp-idf/bootloader/bootloader.bin 0x8000 $(BUILD)/esp-idf/partition_table/partition-table.bin 0x10000 $(BUILD)/circuitpython-firmware.bin
 
 flash: $(BUILD)/firmware.bin
-	esptool.py --chip esp32s2 -p /dev/tty.SLAB_USBtoUART -b 460800 --before=default_reset --after=hard_reset write_flash $(FLASH_FLAGS) 0x0000 $^
+	esptool.py --chip esp32s2 -p $(PORT) -b 460800 --before=default_reset --after=hard_reset write_flash $(FLASH_FLAGS) 0x0000 $^
 
 include $(TOP)/py/mkrules.mk
 


### PR DESCRIPTION
minor change to allow setting PORT when using make flash if
left default as /dev/tty.SLAB_USBtuUART
but others can use
make BOARD=espressif_saola_1_wrover PORT=/dev/ttyUSB1 flash


feel free to close if you don't want this at this time.