### PR TITLE
actions: Don't skip trying to (re)install idf tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,9 +389,8 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20200523
     - name: Install IDF tools
-      if: steps.idf-cache.outputs.cache-hit != 'true'
       run: |
         $IDF_PATH/tools/idf_tools.py --non-interactive install required
         $IDF_PATH/tools/idf_tools.py --non-interactive install cmake


### PR DESCRIPTION
We were seeing actions failures where the cache would be restored
"successfully" but then "Install CircuitPython deps" would fail:

    # Step "Fetch IDF tool cache"
    Cache Size: ~247 MB (259277989 B)
    /bin/tar -xz -f /home/runner/work/_temp/a990f24d-c365-4685-b739-10e052812c81/cache.tgz -C /home/runner/work/circuitpython/circuitpython/.idf_tools
    Cache restored from key: Linux-idf-tools-731ed12bcdfbfa8b5dd37e03703992271b3ce85dd629e45130f80f43b84ce3a8
    ...
    # Step "Install CircuitPython deps"
    Adding ESP-IDF tools to PATH...
    Not using an unsupported version of tool cmake found in PATH: 3.17.0.

I checked locally, and (even when dist/* is removed) it is very quick to
run each of the `idf_tools install` steps, about 2s total.

Try doing this to see whether it fixes the CI problems.