### PR TITLE
tools: Allow specific boards to be built "monolingual"

### DIFF
--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -67,12 +67,23 @@ aliases_by_board = {
     "pewpew10": ["pewpew13"]
 }
 
+monolingual_boards = set((
+    'escornabot_makech',
+    'meowmeow',
+    'pyruler',
+    'trinket_m0_haxpress',
+))
+
 def get_languages():
     languages = []
     for f in os.scandir("../locale"):
         if f.name.endswith(".po"):
             languages.append(f.name[:-3])
     return languages
+
+def get_board_languages(board, all_languages):
+    if board in monolingual_boards: return ['en_US']
+    return all_languages
 
 def get_board_mapping():
     boards = {}

--- a/tools/build_release_files.py
+++ b/tools/build_release_files.py
@@ -21,12 +21,14 @@ if "BOARDS" in os.environ:
 
 sha, version = build_info.get_version_info()
 
-languages = build_info.get_languages()
+all_languages = build_info.get_languages()
 exit_status = 0
 for board in build_boards:
     bin_directory = "../bin/{}/".format(board)
     os.makedirs(bin_directory, exist_ok=True)
     board_info = all_boards[board]
+
+    languages = build_info.get_board_languages(board, all_languages)
 
     for language in languages:
         bin_directory = "../bin/{board}/{language}".format(board=board, language=language)


### PR DESCRIPTION
We have several translations which only fit on resource-constrained boards due to being incomplete.  With contributions on weblate, some builds no longer fit.

Rather than rendering ourselves unable to accept updated weblate translations, this change allows specific boards to be switched to monolingual.  It also adds the boards which are failing in the latest
weblate PR due to space to the list. (#2942)
