### PR TITLE
Allow setting RGBW pixels with RGB tuples

### DIFF
--- a/shared-bindings/_pixelbuf/PixelBuf.c
+++ b/shared-bindings/_pixelbuf/PixelBuf.c
@@ -53,18 +53,13 @@ static void parse_byteorder(mp_obj_t byteorder_obj, pixelbuf_byteorder_details_t
 //|         When brightness is less than 1.0, a second buffer will be used to store the color values
 //|         before they are adjusted for brightness.
 //|
-//|         When ``P`` (pwm duration) is present as the 4th character of the byteorder
+//|         When ``P`` (PWM duration) is present as the 4th character of the byteorder
 //|         string, the 4th value in the tuple/list for a pixel is the individual pixel
-//|         brightness (0.0-1.0) and will enable a Dotstar compatible 1st byte in the
-//|         output buffer (``buf``).
-//|
-//|         When ``P`` (pwm duration) is present as the first character of the byteorder
-//|         string, the 4th value in the tuple/list for a pixel is the individual pixel
-//|         brightness (0.0-1.0) and will enable a Dotstar compatible 1st byte in the
-//|         output buffer (``buf``).
+//|         brightness (0.0-1.0) and will enable a Dotstar compatible 1st byte for each 
+//|         pixel.
 //|
 //|         :param ~int size: Number of pixels
-//|         :param ~str byteorder: Byte order string (such as "BGR" or "PBGR")
+//|         :param ~str byteorder: Byte order string (such as "RGB", "RGBW" or "PBGR")
 //|         :param ~float brightness: Brightness (0 to 1.0, default 1.0)
 //|         :param ~bool auto_write: Whether to automatically write pixels (Default False)
 //|         :param bytes header: Sequence of bytes to always send before pixel values.
@@ -276,13 +271,16 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(pixelbuf_pixelbuf_fill_obj, pixelbuf_pixelbuf_f
 
 //|     def __getitem__(self, index: Any) -> Any:
 //|         """Returns the pixel value at the given index as a tuple of (Red, Green, Blue[, White]) values
-//|         between 0 and 255."""
+//|         between 0 and 255.  When in PWM (DotStar) mode, the 4th tuple value is a float of the pixel
+//|         intensity from 0-1.0."""
 //|         ...
 //|
 //|     def __setitem__(self, index: Any, value: Any) -> Any:
-//|         """Sets the pixel value at the given index. Value can either be a tuple of (Red, Green, Blue
-//|         [, White]) values between 0 and 255 or an integer where the red, green and blue values are
-//|         packed into the lower three bytes (0xRRGGBB)."""
+//|         """Sets the pixel value at the given index.  Value can either be a tuple or integer.  Tuples are
+//|         The individual (Red, Green, Blue[, White]) values between 0 and 255.  If given an integer, the
+//|         red, green and blue values are packed into the lower three bytes (0xRRGGBB).
+//|         For RGBW byteorders, if given only RGB values either as an int or as a tuple, the white value
+//|         is used instead when the red, green, and blue values are the same."""
 //|         ...
 //|
 STATIC mp_obj_t pixelbuf_pixelbuf_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {

--- a/shared-module/_pixelbuf/PixelBuf.c
+++ b/shared-module/_pixelbuf/PixelBuf.c
@@ -147,18 +147,11 @@ void _pixelbuf_parse_color(pixelbuf_pixelbuf_obj_t* self, mp_obj_t color, uint8_
         *r = value >> 16 & 0xff;
         *g = (value >> 8) & 0xff;
         *b = value & 0xff;
-        // Int colors can't set white directly so convert to white when all components are equal.
-        if (!byteorder->is_dotstar && byteorder->bpp == 4 && byteorder->has_white && *r == *g && *r == *b) {
-            *w = *r;
-            *r = 0;
-            *g = 0;
-            *b = 0;
-        }
     } else {
         mp_obj_t *items;
         size_t len;
         mp_obj_get_array(color, &len, &items);
-        if (len != byteorder->bpp && !byteorder->is_dotstar) {
+        if (len < 3 || len > 4) {
             mp_raise_ValueError_varg(translate("Expected tuple of length %d, got %d"), byteorder->bpp, len);
         }
 
@@ -171,7 +164,16 @@ void _pixelbuf_parse_color(pixelbuf_pixelbuf_obj_t* self, mp_obj_t color, uint8_
             } else {
                 *w = mp_obj_get_int_truncated(items[PIXEL_W]);
             }
+            return;
         }
+    }
+    // Int colors can't set white directly so convert to white when all components are equal.
+    // Also handles RGBW values assigned an RGB tuple.
+    if (!byteorder->is_dotstar && byteorder->bpp == 4 && byteorder->has_white && *r == *g && *r == *b) {
+        *w = *r;
+        *r = 0;
+        *g = 0;
+        *b = 0;
     }
 }
 


### PR DESCRIPTION
Fixes #2953 by coercing RGB tuples to RGBW values, just like assigning an int to an RGBW value does.