### PR TITLE
Add hiibot_bluefi board definitions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,7 @@ jobs:
         - "grandcentral_m4_express"
         - "hallowing_m0_express"
         - "hallowing_m4_express"
+        - "hiibot_bluefi"
         - "imxrt1010_evk"
         - "imxrt1020_evk"
         - "imxrt1060_evk"

--- a/ports/nrf/boards/hiibot_bluefi/board.c
+++ b/ports/nrf/boards/hiibot_bluefi/board.c
@@ -1,0 +1,103 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "boards/board.h"
+#include "mpconfigboard.h"
+
+#include "shared-bindings/busio/SPI.h"
+#include "shared-bindings/displayio/FourWire.h"
+#include "shared-module/displayio/__init__.h"
+#include "shared-module/displayio/mipi_constants.h"
+
+displayio_fourwire_obj_t board_display_obj;
+
+#define DELAY 0x80
+
+uint8_t display_init_sequence[] = {
+    0x01, 0 | DELAY, 150, // SWRESET
+    0x11, 0 | DELAY, 255, // SLPOUT
+    0x36, 1, 0b10100000,  // _MADCTL for rotation 0
+    0x3a, 1, 0x55, // COLMOD - 16bit color
+    0x21, 0 | DELAY, 10,  // _INVON
+    0x13, 0 | DELAY, 10,  // _NORON
+    0x29, 0 | DELAY, 255, // _DISPON
+};
+
+void board_init(void) {
+    busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
+    common_hal_busio_spi_construct(spi, &pin_P0_07, &pin_P1_08, NULL); // SCK, MOSI, MISO
+    common_hal_busio_spi_never_reset(spi);
+
+    displayio_fourwire_obj_t* bus = &displays[0].fourwire_bus;
+    bus->base.type = &displayio_fourwire_type;
+    common_hal_displayio_fourwire_construct(bus,
+        spi,
+        &pin_P0_27, // TFT_DC Command or data
+        &pin_P0_05, // TFT_CS Chip select
+	NULL, // no  TFT_RST Reset
+        //&pin_P1_14, // TFT_RST Reset
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
+
+    displayio_display_obj_t* display = &displays[0].display;
+    display->base.type = &displayio_display_type;
+    common_hal_displayio_display_construct(display,
+        bus,
+        240, // Width (after rotation)
+        240, // Height (after rotation)
+        80, // column start
+        0, // row start
+        180, // rotation
+        16, // Color depth
+        false, // Grayscale
+        false, // Pixels in a byte share a row. Only used for depth < 8
+        1, // bytes per cell. Only valid for depths < 8
+        false, // reverse_pixels_in_byte. Only valid for depths < 8
+        true, // reverse_pixels_in_word
+        MIPI_COMMAND_SET_COLUMN_ADDRESS, // Set column command
+        MIPI_COMMAND_SET_PAGE_ADDRESS, // Set row command
+        MIPI_COMMAND_WRITE_MEMORY_START, // Write memory command
+        0x37, // set vertical scroll command
+        display_init_sequence,
+        sizeof(display_init_sequence),
+        &pin_P1_13,  // backlight pin
+        NO_BRIGHTNESS_COMMAND,
+        1.0f, // brightness (ignored)
+        true, // auto_brightness
+        false, // single_byte_bounds
+        false, // data_as_commands
+        true, // auto_refresh
+        60, // native_frames_per_second
+        true); // backlight_on_high
+}
+
+bool board_requests_safe_mode(void) {
+    return false;
+}
+
+void reset_board(void) {
+}

--- a/ports/nrf/boards/hiibot_bluefi/mpconfigboard.h
+++ b/ports/nrf/boards/hiibot_bluefi/mpconfigboard.h
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Glenn Ruben Bakke
+ * Copyright (c) 2018 Dan Halbert for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "nrfx/hal/nrf_gpio.h"
+
+#define MICROPY_HW_BOARD_NAME       "HiiBot BlueFi"
+#define MICROPY_HW_MCU_NAME         "nRF52840"
+
+#define MICROPY_HW_NEOPIXEL	(&pin_P1_10)  // P18 / D18
+
+#define MICROPY_HW_LED_STATUS	(&pin_P1_12)  // P17 / D17
+
+#if QSPI_FLASH_FILESYSTEM
+#define MICROPY_QSPI_DATA0 	NRF_GPIO_PIN_MAP(1, 1)
+#define MICROPY_QSPI_DATA1	NRF_GPIO_PIN_MAP(1, 4)
+#define MICROPY_QSPI_DATA2	NRF_GPIO_PIN_MAP(1, 6)
+#define MICROPY_QSPI_DATA3	NRF_GPIO_PIN_MAP(1, 5)
+#define MICROPY_QSPI_SCK	NRF_GPIO_PIN_MAP(1, 3)
+#define MICROPY_QSPI_CS 	NRF_GPIO_PIN_MAP(1, 2)
+#endif
+
+#if SPI_FLASH_FILESYSTEM
+#define SPI_FLASH_MOSI_PIN  	&pin_P1_01
+#define SPI_FLASH_MISO_PIN	&pin_P1_04
+#define SPI_FLASH_SCK_PIN	&pin_P1_03
+#define SPI_FLASH_CS_PIN	&pin_P1_02
+#endif
+
+// No 32kHz crystal. THere's a 32MHz crystal in the nRF module.
+#define BOARD_HAS_32KHZ_XTAL	(0)
+
+#define DEFAULT_I2C_BUS_SCL 	(&pin_P0_00)
+#define DEFAULT_I2C_BUS_SDA	(&pin_P0_31)
+
+#define DEFAULT_SPI_BUS_SCK	(&pin_P0_06)
+#define DEFAULT_SPI_BUS_MOSI	(&pin_P0_26)
+#define DEFAULT_SPI_BUS_MISO	(&pin_P0_04)
+
+#define DEFAULT_UART_BUS_RX	(&pin_P0_28)
+#define DEFAULT_UART_BUS_TX	(&pin_P0_02)
+
+
+

--- a/ports/nrf/boards/hiibot_bluefi/mpconfigboard.mk
+++ b/ports/nrf/boards/hiibot_bluefi/mpconfigboard.mk
@@ -1,0 +1,18 @@
+USB_VID = 0x239A
+USB_PID = 0x0016
+USB_PRODUCT = "HiiBot BlueFi"
+USB_MANUFACTURER = "HiiBot"
+
+MCU_CHIP = nrf52840
+
+QSPI_FLASH_FILESYSTEM = 1
+EXTERNAL_FLASH_DEVICE_COUNT = 1
+EXTERNAL_FLASH_DEVICES = "W25Q16JV_IQ"
+
+# Allocate two, not just one I2C peripheral for Bluefi, so that we have both
+# on-board and off-board I2C available.
+# When SPIM3 becomes available we'll be able to have two I2C and two SPI peripherals.
+# We use a CFLAGS define here because there are include order issues
+# if we try to include "mpconfigport.h" into nrfx_config.h .
+CFLAGS += -DCIRCUITPY_NRF_NUM_I2C=2
+

--- a/ports/nrf/boards/hiibot_bluefi/pins.c
+++ b/ports/nrf/boards/hiibot_bluefi/pins.c
@@ -1,0 +1,180 @@
+#include "shared-bindings/board/__init__.h"
+
+#include "boards/board.h"
+#include "shared-module/displayio/__init__.h"
+
+STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_P0), MP_ROM_PTR(&pin_P0_28) },
+    { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_P0_28) },
+    { MP_ROM_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_P0_28) },
+    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_P0_28) },
+
+    { MP_ROM_QSTR(MP_QSTR_P1), MP_ROM_PTR(&pin_P0_02) },
+    { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_P0_02) },
+    { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_P0_02) },
+    { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_P0_02) },
+
+    { MP_ROM_QSTR(MP_QSTR_P2), MP_ROM_PTR(&pin_P0_29) },
+    { MP_ROM_QSTR(MP_QSTR_D2), MP_ROM_PTR(&pin_P0_29) },
+    { MP_ROM_QSTR(MP_QSTR_A2), MP_ROM_PTR(&pin_P0_29) },
+
+    { MP_ROM_QSTR(MP_QSTR_P3), MP_ROM_PTR(&pin_P0_30) },
+    { MP_ROM_QSTR(MP_QSTR_D3), MP_ROM_PTR(&pin_P0_30) },
+    { MP_ROM_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_P0_30) },
+
+    { MP_ROM_QSTR(MP_QSTR_P4), MP_ROM_PTR(&pin_P0_03) },
+    { MP_ROM_QSTR(MP_QSTR_D4), MP_ROM_PTR(&pin_P0_03) },
+    { MP_ROM_QSTR(MP_QSTR_A4), MP_ROM_PTR(&pin_P0_03) },
+
+    { MP_ROM_QSTR(MP_QSTR_P5), MP_ROM_PTR(&pin_P1_07) },
+    { MP_ROM_QSTR(MP_QSTR_D5), MP_ROM_PTR(&pin_P1_07) },
+    { MP_ROM_QSTR(MP_QSTR_BUTTON_A), MP_ROM_PTR(&pin_P1_07) },
+
+    { MP_ROM_QSTR(MP_QSTR_P6), MP_ROM_PTR(&pin_P0_08) },
+    { MP_ROM_QSTR(MP_QSTR_D6), MP_ROM_PTR(&pin_P0_08) },
+
+    { MP_ROM_QSTR(MP_QSTR_P7), MP_ROM_PTR(&pin_P0_25) },
+    { MP_ROM_QSTR(MP_QSTR_D7), MP_ROM_PTR(&pin_P0_25) },
+
+    { MP_ROM_QSTR(MP_QSTR_P8), MP_ROM_PTR(&pin_P0_23) },
+    { MP_ROM_QSTR(MP_QSTR_D8), MP_ROM_PTR(&pin_P0_23) },
+
+    { MP_ROM_QSTR(MP_QSTR_P9), MP_ROM_PTR(&pin_P0_21) },
+    { MP_ROM_QSTR(MP_QSTR_D9), MP_ROM_PTR(&pin_P0_21) },
+
+    { MP_ROM_QSTR(MP_QSTR_P10), MP_ROM_PTR(&pin_P0_19) },
+    { MP_ROM_QSTR(MP_QSTR_D10), MP_ROM_PTR(&pin_P0_19) },
+
+    { MP_ROM_QSTR(MP_QSTR_P11), MP_ROM_PTR(&pin_P1_09) },
+    { MP_ROM_QSTR(MP_QSTR_D11), MP_ROM_PTR(&pin_P1_09) },
+    { MP_ROM_QSTR(MP_QSTR_BUTTON_B), MP_ROM_PTR(&pin_P1_09) },
+
+    { MP_ROM_QSTR(MP_QSTR_P12), MP_ROM_PTR(&pin_P0_16) },
+    { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_P0_16) },
+
+    { MP_ROM_QSTR(MP_QSTR_P13), MP_ROM_PTR(&pin_P0_06) },
+    { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_P0_06) },
+    { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_P0_06) },
+
+    { MP_ROM_QSTR(MP_QSTR_P14), MP_ROM_PTR(&pin_P0_04) },
+    { MP_ROM_QSTR(MP_QSTR_D14), MP_ROM_PTR(&pin_P0_04) },
+    { MP_ROM_QSTR(MP_QSTR_A5), MP_ROM_PTR(&pin_P0_04) },
+    { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_P0_04) },
+
+    { MP_ROM_QSTR(MP_QSTR_P15), MP_ROM_PTR(&pin_P0_26) },
+    { MP_ROM_QSTR(MP_QSTR_D15), MP_ROM_PTR(&pin_P0_26) },
+    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_P0_26) },
+
+    { MP_ROM_QSTR(MP_QSTR_P16), MP_ROM_PTR(&pin_P0_01) },
+    { MP_ROM_QSTR(MP_QSTR_D16), MP_ROM_PTR(&pin_P0_01) },
+
+    { MP_ROM_QSTR(MP_QSTR_P17), MP_ROM_PTR(&pin_P1_12) },
+    { MP_ROM_QSTR(MP_QSTR_D17), MP_ROM_PTR(&pin_P1_12) },
+    { MP_ROM_QSTR(MP_QSTR_REDLED), MP_ROM_PTR(&pin_P1_12) },
+
+    { MP_ROM_QSTR(MP_QSTR_P18), MP_ROM_PTR(&pin_P1_10) },
+    { MP_ROM_QSTR(MP_QSTR_D18), MP_ROM_PTR(&pin_P1_10) },
+    { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_P1_10) },
+
+    { MP_ROM_QSTR(MP_QSTR_P19), MP_ROM_PTR(&pin_P0_00) },
+    { MP_ROM_QSTR(MP_QSTR_D19), MP_ROM_PTR(&pin_P0_00) },
+    { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_P0_00) },
+
+    { MP_ROM_QSTR(MP_QSTR_P20), MP_ROM_PTR(&pin_P0_31) },
+    { MP_ROM_QSTR(MP_QSTR_D20), MP_ROM_PTR(&pin_P0_31) },
+    { MP_ROM_QSTR(MP_QSTR_A6), MP_ROM_PTR(&pin_P0_31) },
+    { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_P0_31) },
+
+    { MP_ROM_QSTR(MP_QSTR_P21), MP_ROM_PTR(&pin_P0_09) },
+    { MP_ROM_QSTR(MP_QSTR_D21), MP_ROM_PTR(&pin_P0_09) },
+    { MP_ROM_QSTR(MP_QSTR_MICROPHONE_CLOCK), MP_ROM_PTR(&pin_P0_09) },
+
+    { MP_ROM_QSTR(MP_QSTR_P22), MP_ROM_PTR(&pin_P0_10) },
+    { MP_ROM_QSTR(MP_QSTR_D22), MP_ROM_PTR(&pin_P0_10) },
+    { MP_ROM_QSTR(MP_QSTR_MICROPHONE_DATA), MP_ROM_PTR(&pin_P0_10) },
+
+    { MP_ROM_QSTR(MP_QSTR_P23), MP_ROM_PTR(&pin_P0_07) },
+    { MP_ROM_QSTR(MP_QSTR_D23), MP_ROM_PTR(&pin_P0_07) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_SCK), MP_ROM_PTR(&pin_P0_07) },
+
+    { MP_ROM_QSTR(MP_QSTR_P24), MP_ROM_PTR(&pin_P1_08) },
+    { MP_ROM_QSTR(MP_QSTR_D24), MP_ROM_PTR(&pin_P1_08) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_MOSI), MP_ROM_PTR(&pin_P1_08) },
+
+    { MP_ROM_QSTR(MP_QSTR_P25), MP_ROM_PTR(&pin_P0_05) },
+    { MP_ROM_QSTR(MP_QSTR_D25), MP_ROM_PTR(&pin_P0_05) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_CS), MP_ROM_PTR(&pin_P0_05) },
+
+    { MP_ROM_QSTR(MP_QSTR_P26), MP_ROM_PTR(&pin_P0_27) },
+    { MP_ROM_QSTR(MP_QSTR_D26), MP_ROM_PTR(&pin_P0_27) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_DC), MP_ROM_PTR(&pin_P0_27) },
+
+    { MP_ROM_QSTR(MP_QSTR_P27), MP_ROM_PTR(&pin_P1_14) },
+    { MP_ROM_QSTR(MP_QSTR_D27), MP_ROM_PTR(&pin_P1_14) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_RESET), MP_ROM_PTR(&pin_P1_14) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_BACKLIGHT), MP_ROM_PTR(&pin_P1_14) },
+
+    // P28~P33/D28~D33 connecte into QSPI FlashROM (W25Q16JV_IQ)
+
+    { MP_ROM_QSTR(MP_QSTR_P34), MP_ROM_PTR(&pin_P0_22) },
+    { MP_ROM_QSTR(MP_QSTR_D34), MP_ROM_PTR(&pin_P0_22) },
+    { MP_ROM_QSTR(MP_QSTR_WIFI_SCK), MP_ROM_PTR(&pin_P0_22) },
+
+    { MP_ROM_QSTR(MP_QSTR_P35), MP_ROM_PTR(&pin_P0_17) },
+    { MP_ROM_QSTR(MP_QSTR_D35), MP_ROM_PTR(&pin_P0_17) },
+    { MP_ROM_QSTR(MP_QSTR_WIFI_MISO), MP_ROM_PTR(&pin_P0_17) },
+
+    { MP_ROM_QSTR(MP_QSTR_P36), MP_ROM_PTR(&pin_P0_20) },
+    { MP_ROM_QSTR(MP_QSTR_D36), MP_ROM_PTR(&pin_P0_20) },
+    { MP_ROM_QSTR(MP_QSTR_WIFI_MOSI), MP_ROM_PTR(&pin_P0_20) },
+
+    { MP_ROM_QSTR(MP_QSTR_P37), MP_ROM_PTR(&pin_P0_15) },
+    { MP_ROM_QSTR(MP_QSTR_D37), MP_ROM_PTR(&pin_P0_15) },
+    { MP_ROM_QSTR(MP_QSTR_WIFI_BUSY), MP_ROM_PTR(&pin_P0_15) },
+
+    { MP_ROM_QSTR(MP_QSTR_P38), MP_ROM_PTR(&pin_P0_24) },
+    { MP_ROM_QSTR(MP_QSTR_D38), MP_ROM_PTR(&pin_P0_24) },
+    { MP_ROM_QSTR(MP_QSTR_WIFI_CS), MP_ROM_PTR(&pin_P0_24) },
+
+    { MP_ROM_QSTR(MP_QSTR_P39), MP_ROM_PTR(&pin_P1_00) },
+    { MP_ROM_QSTR(MP_QSTR_D39), MP_ROM_PTR(&pin_P1_00) },
+    { MP_ROM_QSTR(MP_QSTR_WIFI_RESET), MP_ROM_PTR(&pin_P1_00) },
+
+    { MP_ROM_QSTR(MP_QSTR_P40), MP_ROM_PTR(&pin_P0_13) },
+    { MP_ROM_QSTR(MP_QSTR_D40), MP_ROM_PTR(&pin_P0_13) },
+    { MP_ROM_QSTR(MP_QSTR_WIFI_PWR), MP_ROM_PTR(&pin_P0_13) },
+
+    { MP_ROM_QSTR(MP_QSTR_P41), MP_ROM_PTR(&pin_P0_11) },
+    { MP_ROM_QSTR(MP_QSTR_D41), MP_ROM_PTR(&pin_P0_11) },
+    { MP_ROM_QSTR(MP_QSTR_SENSORS_SCL), MP_ROM_PTR(&pin_P0_11) },
+
+    { MP_ROM_QSTR(MP_QSTR_P42), MP_ROM_PTR(&pin_P0_12) },
+    { MP_ROM_QSTR(MP_QSTR_D42), MP_ROM_PTR(&pin_P0_12) },
+    { MP_ROM_QSTR(MP_QSTR_SENSORS_SDA), MP_ROM_PTR(&pin_P0_12) },
+
+    { MP_ROM_QSTR(MP_QSTR_P43), MP_ROM_PTR(&pin_P0_14) },
+    { MP_ROM_QSTR(MP_QSTR_D43), MP_ROM_PTR(&pin_P0_14) },
+    { MP_ROM_QSTR(MP_QSTR_IMU_IRQ), MP_ROM_PTR(&pin_P0_14) },
+    { MP_ROM_QSTR(MP_QSTR_ACCELEROMETER_INTERRUPT), MP_ROM_PTR(&pin_P0_14) },
+
+    { MP_ROM_QSTR(MP_QSTR_P44), MP_ROM_PTR(&pin_P1_14) },
+    { MP_ROM_QSTR(MP_QSTR_D44), MP_ROM_PTR(&pin_P1_14) },
+    { MP_ROM_QSTR(MP_QSTR_WHITELED), MP_ROM_PTR(&pin_P1_14) },
+
+    { MP_ROM_QSTR(MP_QSTR_P45), MP_ROM_PTR(&pin_P1_11) },
+    { MP_ROM_QSTR(MP_QSTR_D45), MP_ROM_PTR(&pin_P1_11) },
+    { MP_ROM_QSTR(MP_QSTR_SPEAKER_ENABLE), MP_ROM_PTR(&pin_P1_11) },
+
+    { MP_ROM_QSTR(MP_QSTR_P46), MP_ROM_PTR(&pin_P1_15) },
+    { MP_ROM_QSTR(MP_QSTR_D46), MP_ROM_PTR(&pin_P1_15) },
+    { MP_ROM_QSTR(MP_QSTR_SPEAKER), MP_ROM_PTR(&pin_P1_15) },
+    { MP_ROM_QSTR(MP_QSTR_AUDIO), MP_ROM_PTR(&pin_P1_15) },
+
+    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display)}
+};
+
+MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
The HiiBot BlueFi is a microbit-compatible single board computer, but has enhanced computing ability, and connectivity. BlueFi uses Nordic nRF52840 (64MHz Cortex M4F, 1MB Flash and 256KB SRAM) as main processor, ESP32 (160MHz dual CPU, 4MB Flash and 520KB SRAM) as a co-processor.

https://circuitpython.org/board/hiibot_bluefi/.