### PR TITLE
fix racing issue for SAMD when executing WFI

### DIFF
--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -69,6 +69,7 @@
 #include "samd/events.h"
 #include "samd/external_interrupts.h"
 #include "samd/dma.h"
+#include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/rtc/__init__.h"
 #include "reset.h"
 
@@ -496,7 +497,12 @@ void port_sleep_until_interrupt(void) {
         (void) __get_FPSCR();
     }
     #endif
-    __WFI();
+    common_hal_mcu_disable_interrupts();
+    if (!tud_task_event_ready()) {
+        __DSB();
+        __WFI();
+    }
+    common_hal_mcu_enable_interrupts();
 }
 
 /**


### PR DESCRIPTION
fix #2912 and/or other "slow responses" with USB after low power PR. It is basically the same as #2868 for nRF. There is lots of discussion there, I will sum it up here. Following is the racing.

1. USB Interrupt handler  is complete and submitted to the event queue of TinyUSB task
2. WFI happens
3. Since `tud_task()` isn't called yet to response, there is no more USB event. CPU has a good full sleep of `N` seconds.
4. WFI end, tud_task() is called to handle usb events

It is the racing between usb isr -> event queue -> tud_task() handling and WFI.
Note: this is **NOT** what we want to do, we don't want to sleep while there are USB events in the queue and host is waiting --> therefore we must make sure all the usb events in the queue task are processed before executing WFI. That's way when there is a new request (IN/OUT) from host, we could wake up and handle.

Following is reference to other platform implementation of WFI, disabling interrupt and DSB is mostly required.

Yeah, I did a bit of research it is advisable prat to disable the interrupt before WFI() to avoid race condition. WFI() doesn't require interrupt enabled to wake CPU. It is best practice to also all DSB() before WFI() as well according to ARM docs. Here is the implementation of zephyr

https://github.com/zephyrproject-rtos/zephyr/blob/master/arch/arm/core/aarch32/cpu_idle.S#L75

another reference from freeRTOS tickless mode, which do the same as this function
https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/master/portable/GCC/ARM_CM4F/port.c#L510

There is a other useful doc from mbed as well.
https://os.mbed.com/media/uploads/pateshian/wfi_wake_up_from_sleep_11_17_2016_.pdf (D_SLEEP_VERSION == 2)

_Originally posted by @hathach in https://github.com/_render_node/MDIzOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFkMjY2MTQxNzg4OnYy/pull_request_review_threads/discussion_
