### PR TITLE
mimxrt10xx: Change exception type to match other ports

### DIFF
--- a/ports/mimxrt10xx/common-hal/busio/I2C.c
+++ b/ports/mimxrt10xx/common-hal/busio/I2C.c
@@ -81,7 +81,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     }
 
     if(self->sda_pin == NULL || self->scl_pin == NULL) {
-        mp_raise_RuntimeError(translate("Invalid I2C pin selection"));
+        mp_raise_ValueError(translate("Invalid I2C pin selection"));
     } else {
         self->i2c = mcu_i2c_banks[self->sda_pin->bank_idx - 1];
     }


### PR DESCRIPTION
Sync the exception type with samd https://github.com/adafruit/circuitpython/blob/master/ports/atmel-samd/common-hal/busio/I2C.c#L76 and nrf https://github.com/adafruit/circuitpython/blob/master/ports/nrf/common-hal/busio/I2C.c#L101

It's important to have it synced because of example code like this: https://learn.adafruit.com/circuitpython-essentials/circuitpython-i2c#wheres-my-i2c-2985160-17