### PR TITLE
enable aesio on all nRF52840 boards

### DIFF
--- a/ports/nrf/mpconfigport.mk
+++ b/ports/nrf/mpconfigport.mk
@@ -45,6 +45,9 @@ MCU_SERIES = m4
 MCU_VARIANT = nrf52
 MCU_SUB_VARIANT = nrf52840
 
+# Fits on nrf52840 but space is tight on nrf52833.
+CIRCUITPY_AESIO ?= 1
+
 SD ?= s140
 SOFTDEV_VERSION ?= 6.1.0
 


### PR DESCRIPTION
As requested by @ladyada. Does not fit on nrf52833 with other default choices. Appears to fit on all nRF52840 boards even with internal filesystems. Full build will confirm.