### PR TITLE
include uf2 firmware for nrf52840 mdk usb dongle

### DIFF
--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -53,7 +53,7 @@ extension_by_board = {
 
     # nRF52840 dev kits that may not have UF2 bootloaders,
     "makerdiary_nrf52840_mdk": HEX,
-    "makerdiary_nrf52840_mdk_usb_dongle": HEX,
+    "makerdiary_nrf52840_mdk_usb_dongle": HEX_UF2,
     "pca10056": BIN_UF2,
     "pca10059": BIN_UF2,
     "electronut_labs_blip": HEX


### PR DESCRIPTION
The nRF52840 MDK USB Dongle has a new UF2 bootloader. Provide both Hex firmware and  UF2 firmware for it.

#2982 