### PR TITLE
Makefile: "make translate" will only update circuitpython.pot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,12 +202,25 @@ pseudoxml:
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
 # phony target so we always run
+.PHONY: all-source
 all-source:
 
 locale/circuitpython.pot: all-source
 	find $(TRANSLATE_SOURCES) -iname "*.c" -print | (LC_ALL=C sort) | xgettext -f- -L C -s --add-location=file --keyword=translate -o circuitpython.pot -p locale
 
+# Historically, `make translate` updated the .pot file and ran msgmerge.
+# However, this was a frequent source of merge conflicts.  Weblate can perform
+# msgmerge, so make translate merely update the translation template file.
+.PHONY: translate
 translate: locale/circuitpython.pot
+
+# Note that normally we rely on weblate to perform msgmerge.  This reduces the
+# chance of a merge conflict between developer changes (that only add and
+# remove source strings) and weblate changes (that only add and remove
+# translated strings from po files).  However, in case this is legitimately
+# needed we preserve a rule to do it.
+.PHONY: msgmerge
+msgmerge:
 	for po in $(shell ls locale/*.po); do msgmerge -U $$po -s --no-fuzzy-matching --add-location=file locale/circuitpython.pot; done
 
 merge-translate:
@@ -216,8 +229,10 @@ merge-translate:
 	git checkout --theirs -- locale/*
 	make translate
 
-check-translate: locale/circuitpython.pot $(wildcard locale/*.po)
-	$(PYTHON) tools/check_translations.py $^
+.PHONY: check-translate
+check-translate:
+	find $(TRANSLATE_SOURCES) -iname "*.c" -print | (LC_ALL=C sort) | xgettext -f- -L C -s --add-location=file --keyword=translate -o circuitpython.pot.tmp -p locale
+	$(PYTHON) tools/check_translations.py locale/circuitpython.pot.tmp locale/circuitpython.pot; status=$$?; rm -f locale/circuitpython.pot.tmp; exit $$status
 
 stubs:
 	@mkdir -p circuitpython-stubs


### PR DESCRIPTION
We can now rely on weblate to regularly update the individual language files from the template, so "make translate" only needs to update the template file circuitpython.pot.

This is advantageous because updating the other files in locale/ was a frequent source of merge conflicts; resolving the conflict incorrectly was something that could easily occur (and did).

Testing performed: that "make check-translate" finds missing translations in the template file, that "make translate" only updates circuitpython.pot, and that "make msgmerge" updates (only) the po files.