### PR TITLE
Quiet stubs warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ stubs:
 	@mkdir -p circuitpython-stubs
 	@$(PYTHON) tools/extract_pyi.py shared-bindings/ $(STUBDIR)
 	@$(PYTHON) tools/extract_pyi.py ports/atmel-samd/bindings $(STUBDIR)
+	@touch $(STUBDIR)/__init__.py
 	@$(PYTHON) setup.py -q sdist
 
 update-frozen-libraries:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from setuptools import setup
+from setuptools import setup, sic
 from pathlib import Path
 import subprocess
 import re
@@ -19,7 +19,7 @@ if len(pieces) > 2:
     # Merge the commit count and build to the pre-release identifier.
     pieces[-2] += ".dev." + pieces[-1]
     pieces.pop()
-version = "-".join(pieces)
+version = sic("-".join(pieces))
 
 setup(
     name="circuitpython-stubs",


### PR DESCRIPTION
This quiets two diagnostics I got when running `make stubs`:
```
.../setuptools/dist.py:454: UserWarning: Normalizing '5.4.0-beta.0.dev.407+g47efd595f' to '5.4.0b0.dev407+g47efd595f'
package init file 'circuitpython-stubs/__init__.py' not found (or not a regular file)
```