### PR TITLE
litex: remove call to `board_init()`

### DIFF
--- a/ports/litex/supervisor/port.c
+++ b/ports/litex/supervisor/port.c
@@ -68,7 +68,6 @@ safe_mode_t port_init(void) {
     irq_setmask(0);
     irq_setie(1);
     tick_init();
-    board_init();
     return NO_SAFE_MODE;
 }
 


### PR DESCRIPTION
These calls were all moved into `main.c`, however this call was not
removed from litex. As a result, litex was calling `board_init()` twice.

This is currently not a problem, as `fomu` is able to be initialized
twice without issue, however future boards may have issue with this.

This fixes #2991.