### PR TITLE
mimxrt10xx: Disable pin_reset on 1060 boards

### DIFF
--- a/ports/mimxrt10xx/boards/teensy40/board.c
+++ b/ports/mimxrt10xx/boards/teensy40/board.c
@@ -30,11 +30,6 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 void board_init(void) {
-    // SWD Pins
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_06);//SWDIO
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_07);//SWCLK
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_10);//SWO
-
     // FLEX flash
     common_hal_never_reset_pin(&pin_GPIO_SD_B1_06);
     common_hal_never_reset_pin(&pin_GPIO_SD_B1_07);
@@ -43,9 +38,16 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO_SD_B1_10);
     common_hal_never_reset_pin(&pin_GPIO_SD_B1_11);
 
-    // USB Pins
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_01);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_03);
+    // FLEX flash 2
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_04);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_06);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_07);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_08);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_09);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_10);
+    common_hal_never_reset_pin(&pin_GPIO_EMC_01);
+    common_hal_never_reset_pin(&pin_GPIO_B0_13);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_11);
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/mimxrt10xx/boards/teensy41/board.c
+++ b/ports/mimxrt10xx/boards/teensy41/board.c
@@ -29,6 +29,24 @@
 #include "mpconfigboard.h"
 
 void board_init(void) {
+    // FLEX flash
+    common_hal_never_reset_pin(&pin_GPIO_SD_B1_06);
+    common_hal_never_reset_pin(&pin_GPIO_SD_B1_07);
+    common_hal_never_reset_pin(&pin_GPIO_SD_B1_08);
+    common_hal_never_reset_pin(&pin_GPIO_SD_B1_09);
+    common_hal_never_reset_pin(&pin_GPIO_SD_B1_10);
+    common_hal_never_reset_pin(&pin_GPIO_SD_B1_11);
+
+    // FLEX flash 2
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_04);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_06);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_07);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_08);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_09);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_10);
+    common_hal_never_reset_pin(&pin_GPIO_EMC_01);
+    common_hal_never_reset_pin(&pin_GPIO_B0_13);
+    common_hal_never_reset_pin(&pin_GPIO_AD_B0_11);
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/mimxrt10xx/boards/teensy41/board.c
+++ b/ports/mimxrt10xx/boards/teensy41/board.c
@@ -27,6 +27,7 @@
 
 #include "boards/board.h"
 #include "mpconfigboard.h"
+#include "shared-bindings/microcontroller/Pin.h"
 
 void board_init(void) {
     // FLEX flash

--- a/ports/mimxrt10xx/supervisor/port.c
+++ b/ports/mimxrt10xx/supervisor/port.c
@@ -306,7 +306,9 @@ void reset_port(void) {
 
     //reset_event_system();
 
+    #if !defined (MIMXRT1062_SERIES)
     reset_all_pins();
+    #endif
 }
 
 void reset_to_bootloader(void) {

--- a/ports/mimxrt10xx/supervisor/port.c
+++ b/ports/mimxrt10xx/supervisor/port.c
@@ -306,6 +306,7 @@ void reset_port(void) {
 
     //reset_event_system();
 
+    // TODO: implement a proper fix for 1060 resets
     #if !defined (MIMXRT1062_SERIES)
     reset_all_pins();
     #endif


### PR DESCRIPTION
This PR removes reset_all_pins for the 1060 line, as a temporary fix for what appears to be a general hard crash when pins in this line are reset. Also expands the never reset pin set in board.c to appropriately cover all flash chips on the Teensy 4.0 and 4.1, but since these pins will not be called by reset_all, this change will only affect future fixed commits.

This PR should be followed up by a more general fix for reset_all_pins on the 1060.

Resolves #2998