### PR TITLE
MP3Decoder: When assigning the "file", close the old one

### DIFF
--- a/shared-module/audiomp3/MP3Decoder.c
+++ b/shared-module/audiomp3/MP3Decoder.c
@@ -209,6 +209,11 @@ void common_hal_audiomp3_mp3file_construct(audiomp3_mp3file_obj_t* self,
 }
 
 void common_hal_audiomp3_mp3file_set_file(audiomp3_mp3file_obj_t* self, pyb_file_obj_t* file) {
+    if (self->file) {
+        mp_obj_t args[2];
+        mp_load_method(self->file, MP_QSTR_close, args);
+        mp_call_method_n_kw(0, 0, args);
+    }
     self->file = file;
     f_lseek(&self->file->fp, 0);
     self->inbuf_offset = self->inbuf_length;


### PR DESCRIPTION
JP ran into problems with playing multiple MP3 files within the same program.  One stumbling point was around the MP3Decoder.file property.

Before this, it was the responsibility of the user to close the old file, which led to inconvenient and non-obvious code such as
```
    old_file = decoder.file
    decoder.file = open("example.mp3", "rb")
    old_file.close()
```

Compatibility with this idiom is preserved, as it's permitted to close() a file as many times as desired; the second and subsequent close()s do nothing.