### PR TITLE
actions: Try checkout v2.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,11 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.2.0
       with:
         submodules: true
         fetch-depth: 0
     - run: git fetch --recurse-submodules=no https://github.com/adafruit/circuitpython refs/tags/*:refs/tags/*
-    - run: git submodule sync
-    - run: git submodule foreach git remote -v
-    - run: git submodule foreach git fetch --recurse-submodules=no origin +refs/tags/*:refs/tags/*
     - name: CircuitPython version
       run: git describe --dirty --tags
     - name: Set up Python 3.8
@@ -110,14 +107,11 @@ jobs:
         gcc --version
         python3 --version
         msgfmt --version
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.2.0
       with:
         submodules: true
         fetch-depth: 0
     - run: git fetch --recurse-submodules=no https://github.com/adafruit/circuitpython refs/tags/*:refs/tags/*
-    - run: git submodule sync
-    - run: git submodule foreach git remote -v
-    - run: git submodule foreach git fetch --recurse-submodules=no origin +refs/tags/*:refs/tags/*
     - name: CircuitPython version
       run: git describe --dirty --tags
     - name: Build mpy-cross
@@ -286,14 +280,11 @@ jobs:
         gcc --version
         arm-none-eabi-gcc --version
         python3 --version
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.2.0
       with:
         submodules: true
         fetch-depth: 0
     - run: git fetch --recurse-submodules=no https://github.com/adafruit/circuitpython refs/tags/*:refs/tags/*
-    - run: git submodule sync
-    - run: git submodule foreach git remote -v
-    - run: git submodule foreach git fetch --recurse-submodules=no origin +refs/tags/*:refs/tags/*
     - name: mpy-cross
       run: make -C mpy-cross -j2
     - name: build
@@ -337,14 +328,11 @@ jobs:
         gcc --version
         riscv64-unknown-elf-gcc --version
         python3 --version
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.2.0
       with:
         submodules: true
         fetch-depth: 0
     - run: git fetch --recurse-submodules=no https://github.com/adafruit/circuitpython refs/tags/*:refs/tags/*
-    - run: git submodule sync
-    - run: git submodule foreach git remote -v
-    - run: git submodule foreach git fetch --recurse-submodules=no origin +refs/tags/*:refs/tags/*
     - name: mpy-cross
       run: make -C mpy-cross -j2
     - name: build
@@ -377,14 +365,11 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.2.0
       with:
         submodules: true
         fetch-depth: 0
     - run: git fetch --recurse-submodules=no https://github.com/adafruit/circuitpython refs/tags/*:refs/tags/*
-    - run: git submodule sync
-    - run: git submodule foreach git remote -v
-    - run: git submodule foreach git fetch --recurse-submodules=no origin +refs/tags/*:refs/tags/*
     - name: CircuitPython version
       run: git describe --dirty --tags
     - uses: actions/cache@v1

--- a/.github/workflows/create_website_pr.yml
+++ b/.github/workflows/create_website_pr.yml
@@ -23,12 +23,11 @@ jobs:
       run: |
         gcc --version
         python3 --version
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.2.0
       with:
         submodules: true
         fetch-depth: 0
     - run: git fetch --recurse-submodules=no https://github.com/adafruit/circuitpython refs/tags/*:refs/tags/*
-    - run: git submodule foreach git fetch --recurse-submodules=no origin +refs/tags/*:refs/tags/*
     - name: CircuitPython version
       run: git describe --dirty --tags
     - name: Website


### PR DESCRIPTION
This version of actions/checkout will
> Fetch all history for all tags and branches when fetch-depth=0

We leave the tags fetch in place so that actions _in cloned repos_ work.  Cloned repos' tags do not necessarily match adafruit/circuitpython, but we want version reporting to be able to use adafruit/circuitpython tags when they are most relevant according to "git describe"'s heuristics.

Submodules are different, as they always point to the repo specified in .gitmodules, so they don't need special handling to get the most relevant tags.