### PR TITLE
Fix ScanEntry prefix matching for any=False 

### DIFF
--- a/shared-module/_bleio/ScanEntry.c
+++ b/shared-module/_bleio/ScanEntry.c
@@ -56,12 +56,19 @@ bool bleio_scanentry_data_matches(const uint8_t* data, size_t len, const uint8_t
     if (prefixes_length == 0) {
         return true;
     }
+    if (len == 0) {
+        // Prefixes exist, but no data.
+        return false;
+    }
     size_t i = 0;
     while(i < prefixes_length) {
         uint8_t prefix_length = prefixes[i];
         i += 1;
         size_t j = 0;
+        bool prefix_matched = false;
+        mp_printf(&mp_plat_print,"i %d\n", i); // XXX
         while (j < len) {
+            mp_printf(&mp_plat_print,"  j %d\n", j); // XXX
             uint8_t structure_length = data[j];
             j += 1;
             if (structure_length == 0) {
@@ -71,13 +78,21 @@ bool bleio_scanentry_data_matches(const uint8_t* data, size_t len, const uint8_t
                 if (any) {
                     return true;
                 }
-            } else if (!any) {
-                return false;
+                prefix_matched = true;
+                mp_printf(&mp_plat_print,"    match\n"); // XXX
+                break;
             }
             j += structure_length;
         }
+        // If all (!any), the current prefix must have matched at least one field.
+        if (!prefix_matched && !any) {
+            mp_printf(&mp_plat_print,"<prefix not matched\n"); // XXX
+            return false;
+        }
         i += prefix_length;
     }
+    // All prefixes matched some field (if !any), or none did (if any).
+    mp_printf(&mp_plat_print,"<all matched\n"); // XXX
     return !any;
 }
 

--- a/shared-module/_bleio/ScanEntry.c
+++ b/shared-module/_bleio/ScanEntry.c
@@ -66,9 +66,7 @@ bool bleio_scanentry_data_matches(const uint8_t* data, size_t len, const uint8_t
         i += 1;
         size_t j = 0;
         bool prefix_matched = false;
-        mp_printf(&mp_plat_print,"i %d\n", i); // XXX
         while (j < len) {
-            mp_printf(&mp_plat_print,"  j %d\n", j); // XXX
             uint8_t structure_length = data[j];
             j += 1;
             if (structure_length == 0) {
@@ -79,20 +77,17 @@ bool bleio_scanentry_data_matches(const uint8_t* data, size_t len, const uint8_t
                     return true;
                 }
                 prefix_matched = true;
-                mp_printf(&mp_plat_print,"    match\n"); // XXX
                 break;
             }
             j += structure_length;
         }
         // If all (!any), the current prefix must have matched at least one field.
         if (!prefix_matched && !any) {
-            mp_printf(&mp_plat_print,"<prefix not matched\n"); // XXX
             return false;
         }
         i += prefix_length;
     }
     // All prefixes matched some field (if !any), or none did (if any).
-    mp_printf(&mp_plat_print,"<all matched\n"); // XXX
     return !any;
 }
 


### PR DESCRIPTION
Fixes #2973.

Tested with a heart rate monitor advertisement with this program:

```python

from _bleio import adapter, Address, ScanEntry

def p(x):
    print(tuple(hex(b) for b in x))

# Reverse the two prefixes to test both orders.
prefixes = b"\x07" b"\x03\x0D\x18\x0A\x18\x25\x17"       b"\x03" b"\x19\x41\x03"
p(prefixes)
HRM_ADDR = Address(bytes(reversed(b"\xEC\x5D\x34\x85\x99\x11")), Address.RANDOM_STATIC)
# active=False: skip scan responses
for se in adapter.start_scan(active=False):
    #print(se.address, se.address.type, HRM_ADDR, HRM_ADDR.type)
    if se.address == HRM_ADDR:
        print("equal")
        p(se.advertisement_bytes)
        print("all", se.matches(prefixes, all=True))
        print("any", se.matches(prefixes, all=False))
        break
```
