### PR TITLE
STM32: make Meowbit default to UF2 on website

### DIFF
--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -56,7 +56,10 @@ extension_by_board = {
     "makerdiary_nrf52840_mdk_usb_dongle": HEX_UF2,
     "pca10056": BIN_UF2,
     "pca10059": BIN_UF2,
-    "electronut_labs_blip": HEX
+    "electronut_labs_blip": HEX,
+
+    # stm32
+    "meowbit_v121": UF2
 }
 
 aliases_by_board = {


### PR DESCRIPTION
Resolves #2702