### PR TITLE
STM32: Add port D to LQFP64

### DIFF
--- a/ports/stm/common-hal/microcontroller/Pin.c
+++ b/ports/stm/common-hal/microcontroller/Pin.c
@@ -46,8 +46,8 @@ bool neopixel_in_use;
     #define GPIO_PORT_COUNT 5
     GPIO_TypeDef * ports[GPIO_PORT_COUNT] = {GPIOA, GPIOB, GPIOC, GPIOD, GPIOE};
 #elif defined(LQFP64)
-    #define GPIO_PORT_COUNT 3
-    GPIO_TypeDef * ports[GPIO_PORT_COUNT] = {GPIOA, GPIOB, GPIOC};
+    #define GPIO_PORT_COUNT 4
+    GPIO_TypeDef * ports[GPIO_PORT_COUNT] = {GPIOA, GPIOB, GPIOC, GPIOD};
 #elif defined(UFQFPN48)
     #define GPIO_PORT_COUNT 3
     GPIO_TypeDef * ports[GPIO_PORT_COUNT] = {GPIOA, GPIOB, GPIOC};


### PR DESCRIPTION
Pin PD2, which is used in SDIO and available for DigitalInOut use, was mistakenly left out of the microcontroller/Pin.c bank array, and accessing it would cause a hardfault. This PR correctly adds this bank to the package array. 