### PR TITLE
Fixes issue with memory alignment in STM32

### DIFF
--- a/ports/stm/common-hal/microcontroller/Pin.c
+++ b/ports/stm/common-hal/microcontroller/Pin.c
@@ -55,7 +55,7 @@ bool neopixel_in_use;
 
 
 STATIC uint16_t claimed_pins[GPIO_PORT_COUNT];
-STATIC uint16_t never_reset_pins[GPIO_PORT_COUNT];
+STATIC uint16_t __ALIGNED(4) never_reset_pins[GPIO_PORT_COUNT];
 
 void reset_all_pins(void) {
     // Reset claimed pins


### PR DESCRIPTION
When compiling with optimizations on, an issue occurs where the claimed_pins/never_reset_pins memory location is shared with another variable. This causes some bad memory read, so the USB pins ended up being reset. Setting these to have an alignment of 4 bytes resolves this.

Tested on nucleo_f746zg