### PR TITLE
[3.x] Custom CSS For "Viewing Outdated Docs" Message

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -345,3 +345,6 @@ texinfo_documents = [
 intersphinx_mapping = {"cpython": ('https://docs.python.org/3/', None),
                        "bus_device": ('https://circuitpython.readthedocs.io/projects/busdevice/en/latest/', None),
                        "register": ('https://circuitpython.readthedocs.io/projects/register/en/latest/', None)}
+
+def setup(app):
+    app.add_stylesheet("customstyle.css")

--- a/docs/static/customstyle.css
+++ b/docs/static/customstyle.css
@@ -10,6 +10,19 @@
 }
 
 
+/* custom CSS to sticky the ' viewing outdated version'
+   warning
+*/
+.document > .admonition {
+    position: sticky;
+    top: 0px;
+    background-color: salmon;
+    z-index: 2;
+}
+
+body {
+    overflow-x: unset!important;
+}
 
 /* override table width restrictions */
 @media screen and (min-width: 767px) {


### PR DESCRIPTION
First step, and initial RTD test, of #3022. Obviously, will need to be accomplished with `2.x`, `4.x`, `5.x`, and `main` after this one is ironed out.

I didn't include the JavaScript to close the message. I can try to work out how to do that with the RTD builds, but its hard to test local builds (the message doesn't pop up locally).

Will this require a 3.x release to kick RTD?