### PR TITLE
change esp32s2 CMake verision requirement to >= 3.13

### DIFF
--- a/ports/esp32s2/CMakeLists.txt
+++ b/ports/esp32s2/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The following five lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.13)
 
 set(ENV{IDF_PATH} ${CMAKE_SOURCE_DIR}/esp-idf)
 set(COMPONENTS esptool_py soc driver log main)


### PR DESCRIPTION
fixes #3084 
Raspberry Pi Raspbian Buster uses CMake v 3.13.4  - this allows building esp32s2 on Raspberry Pi.

Tested on Raspberry Pi 4 B +
