### PR TITLE
Release PRs To circuitpython.org: Include The Available Built-in Modules For Each Board

### DIFF
--- a/docs/shared_bindings_matrix.py
+++ b/docs/shared_bindings_matrix.py
@@ -34,22 +34,10 @@ SUPPORTED_PORTS = ['atmel-samd', 'esp32s2', 'litex', 'mimxrt10xx', 'nrf', 'stm']
 def get_circuitpython_root_dir():
     """ The path to the root './circuitpython' directory
     """
-    cwd = pathlib.Path('.').resolve()
-    cwd_parts = cwd.parts
+    file_path = pathlib.Path(__file__).resolve()
+    root_dir = file_path.parent.parent
 
-    root_idx = len(cwd_parts)
-
-    # Search the path from tail to head, so that we capture the
-    # deepest folder. This avoids overshooting in instances like:
-    # '/home/user/circuitpython_v5/circuitpython'
-    for idx, val in enumerate(cwd_parts[::-1]):
-        if val.startswith("circuitpython"):
-            root_idx = root_idx - idx
-            break
-
-    root_dir = '/'.join(cwd_parts[:root_idx])
-
-    return pathlib.Path(root_dir).resolve()
+    return root_dir
 
 def get_shared_bindings():
     """ Get a list of modules in shared-bindings based on folder names

--- a/docs/shared_bindings_matrix.py
+++ b/docs/shared_bindings_matrix.py
@@ -162,7 +162,7 @@ def support_matrix_by_board(use_branded_name=True):
             settings = get_settings_from_makefile(str(port_dir), entry.name)
 
             if use_branded_name:
-                with open(os.path.join(entry.path, "mpconfigboard.h")) as get_name:
+                with open(entry / "mpconfigboard.h") as get_name:
                     board_contents = get_name.read()
                 board_name_re = re.search(r"(?<=MICROPY_HW_BOARD_NAME)\s+(.+)",
                                           board_contents)

--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -9,6 +9,9 @@ import base64
 from datetime import date
 from sh.contrib import git
 
+sys.path.append("../docs")
+import shared_bindings_matrix
+
 sys.path.append("adabot")
 import adabot.github_requests as github
 
@@ -246,6 +249,10 @@ def generate_download_info():
 
     languages = get_languages()
 
+    support_matrix = shared_bindings_matrix.support_matrix_by_board(
+        use_branded_name=False
+    )
+
     new_stable = "-" not in new_tag
 
     previous_releases = set()
@@ -283,6 +290,7 @@ def generate_download_info():
                     new_version = {
                         "stable": new_stable,
                         "version": new_tag,
+                        "modules": support_matrix.get(alias, "[]"),
                         "files": {}
                     }
                     for language in languages:


### PR DESCRIPTION
Allows [circuitpython-org #426](https://github.com/adafruit/circuitpython-org/issues/426) to be updated with each release.

- Docs verified locally, and built correctly with changes to `shared_bindings_matrix.py`.

- Changes to `build_board_info.py` were used to generate info that was manually merged into `_data/files.json` in [circuitpython-org  #493](https://github.com/adafruit/circuitpython-org/pull/493). I'm fairly confident they will work in the CI when the release Action is run. Its just hard to test locally without mocking and turning things off. Please give it a very close look though; there's a lot going on in that section.