### PR TITLE
STM32: add debug flags, fix hang in simplex SPI

### DIFF
--- a/ports/stm/Makefile
+++ b/ports/stm/Makefile
@@ -81,12 +81,12 @@ INC += -I../../supervisor/shared/usb
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)
-	CFLAGS += -ggdb
+	CFLAGS += -ggdb3
 	# You may want to enable these flags to make setting breakpoints easier.
 	CFLAGS += -fno-inline -fno-ipa-sra
 else
 	CFLAGS += -Os -DNDEBUG
-	CFLAGS += -ggdb
+	CFLAGS += -ggdb3
 	# TODO: Test with -flto
 	# CFLAGS += -flto
 endif

--- a/ports/stm/common-hal/busio/SPI.c
+++ b/ports/stm/common-hal/busio/SPI.c
@@ -238,11 +238,8 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
 
     self->handle.Instance = SPIx;
     self->handle.Init.Mode = SPI_MODE_MASTER;
-    // Implementing one-directional recieve-only SPI as per [RefMan RM0090:884]
-    // results in BSY bit related hangs. Using MOSI as an IO works fine without it,
-    // so it's unclear why this mode is present in the first place.
-    //self->handle.Init.Direction =  (self->mosi == NULL) ? SPI_DIRECTION_2LINES_RXONLY : SPI_DIRECTION_2LINES;
-    self->handle.Init.Direction = SPI_DIRECTION_2LINES;
+    // Direction change only required for RX-only, see RefMan RM0090:884
+    self->handle.Init.Direction = (self->mosi == NULL) ? SPI_DIRECTION_2LINES_RXONLY : SPI_DIRECTION_2LINES;
     self->handle.Init.DataSize = SPI_DATASIZE_8BIT;
     self->handle.Init.CLKPolarity = SPI_POLARITY_LOW;
     self->handle.Init.CLKPhase = SPI_PHASE_1EDGE;

--- a/ports/stm/common-hal/busio/SPI.c
+++ b/ports/stm/common-hal/busio/SPI.c
@@ -238,8 +238,11 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
 
     self->handle.Instance = SPIx;
     self->handle.Init.Mode = SPI_MODE_MASTER;
-    // Direction change only required for RX-only, see RefMan RM0090:884
-    self->handle.Init.Direction = (self->mosi == NULL) ? SPI_DIRECTION_2LINES_RXONLY : SPI_DIRECTION_2LINES;
+    // Implementing one-directional recieve-only SPI as per [RefMan RM0090:884]
+    // results in BSY bit related hangs. Using MOSI as an IO works fine without it,
+    // so it's unclear why this mode is present in the first place.
+    //self->handle.Init.Direction =  (self->mosi == NULL) ? SPI_DIRECTION_2LINES_RXONLY : SPI_DIRECTION_2LINES;
+    self->handle.Init.Direction = SPI_DIRECTION_2LINES;
     self->handle.Init.DataSize = SPI_DATASIZE_8BIT;
     self->handle.Init.CLKPolarity = SPI_POLARITY_LOW;
     self->handle.Init.CLKPhase = SPI_PHASE_1EDGE;


### PR DESCRIPTION
Resolves #3097. Simplex SPI was suffering an issue where when in the "SPI_DIRECTION_2LINES_RXONLY" mode, it would hang when the frequency was lowered, and would deliver delayed data. ~~It's still not 100% clear why this was happening, but testing shows no issues with using MOSI as an IO pin without this mode enabled, so it's been removed.~~

Examining the ST Hal shows that this is due to a timeout bug that was fixed in HAL version 1.24.1. Updating the st_driver submodule to the latest version resolves this issue. 

Also adds -ggdb3 to both debug and optimized builds, which assisted with debugging this issue, and there's no real reason to remove it as per #2790