### PR TITLE
Fluff M0: additional pins on version 1.3 of the board

### DIFF
--- a/ports/atmel-samd/boards/fluff_m0/pins.c
+++ b/ports/atmel-samd/boards/fluff_m0/pins.c
@@ -30,6 +30,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D11), MP_ROM_PTR(&pin_PA16) },
     { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_PA19) },
     { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_PA17) },
+    { MP_ROM_QSTR(MP_QSTR_D14), MP_ROM_PTR(&pin_PA27) },
+    { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_PA28) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },


### PR DESCRIPTION
Version 1.3 of the board has an additional digital pin exposed and a LED on the board.