### PR TITLE
Fix minor typo in MicroPython libraries page

### DIFF
--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -70,7 +70,7 @@ CircuitPython/MicroPython-specific libraries
 
 Functionality specific to the CircuitPython/MicroPython implementation is available in
 the following libraries. These libraries may change signficantly or be removed in future
-versions of CircuitPtyon.
+versions of CircuitPython.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Recreated the PR off of the `main` branch instead of the 5.3 branch, as discussed in https://github.com/adafruit/circuitpython/pull/3118#issuecomment-653884572

Thanks!