### PR TITLE
SAMD: make the brownout detection level configurable per board

### DIFF
--- a/ports/atmel-samd/boards/pewpew10/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pewpew10/mpconfigboard.h
@@ -44,4 +44,4 @@
 #define DEFAULT_UART_BUS_RX (&pin_PA01)
 #define DEFAULT_UART_BUS_TX (&pin_PA00)
 
-#define BOARD_BROWNOUT_LEVEL (6)
+#define SAMD21_BOD33_LEVEL (6)

--- a/ports/atmel-samd/boards/pewpew10/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pewpew10/mpconfigboard.h
@@ -43,3 +43,5 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_PA01)
 #define DEFAULT_UART_BUS_TX (&pin_PA00)
+
+#define BOARD_BROWNOUT_LEVEL (6)

--- a/ports/atmel-samd/boards/pewpew_m4/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pewpew_m4/mpconfigboard.h
@@ -41,5 +41,4 @@
 #define IGNORE_PIN_PB10     1
 #define IGNORE_PIN_PB11     1
 
-#define BOARD_BROWNOUT_LEVEL (6)
-// 1.6V
+#define SAMD5x_E5x_BOD33_LEVEL (100)

--- a/ports/atmel-samd/boards/pewpew_m4/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pewpew_m4/mpconfigboard.h
@@ -40,3 +40,6 @@
 #define IGNORE_PIN_PB09     1
 #define IGNORE_PIN_PB10     1
 #define IGNORE_PIN_PB11     1
+
+#define BOARD_BROWNOUT_LEVEL (6)
+// 1.6V

--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -112,6 +112,11 @@
 #define CIRCUITPY_DEFAULT_STACK_SIZE                4096
 #endif
 
+#ifndef BOARD_BROWNOUT_LEVEL (
+#define BOARD_BROWNLOUT_LEVEL (39)
+// 2.77V with hysteresis off. Table 37.20 in datasheet.
+#endif
+
 // Smallest unit of flash that can be erased.
 #define FLASH_ERASE_SIZE NVMCTRL_ROW_SIZE
 
@@ -127,6 +132,11 @@
 
 #ifndef CIRCUITPY_DEFAULT_STACK_SIZE
 #define CIRCUITPY_DEFAULT_STACK_SIZE                (24*1024)
+#endif
+
+#ifndef BOARD_BROWNOUT_LEVEL (
+#define BOARD_BROWNLOUT_LEVEL (200)
+// 2.7V: 1.5V + LEVEL * 6mV.
 #endif
 
 // Smallest unit of flash that can be erased.

--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -112,8 +112,11 @@
 #define CIRCUITPY_DEFAULT_STACK_SIZE                4096
 #endif
 
-#ifndef BOARD_BROWNOUT_LEVEL (
-#define BOARD_BROWNLOUT_LEVEL (39)
+#ifndef SAMD21_BOD33_LEVEL
+// Set brownout detection to ~2.7V. Default from factory is 1.7V,
+// which is too low for proper operation of external SPI flash chips
+// (they are 2.7-3.6V).
+#define SAMD21_BOD33_LEVEL (39)
 // 2.77V with hysteresis off. Table 37.20 in datasheet.
 #endif
 
@@ -134,8 +137,11 @@
 #define CIRCUITPY_DEFAULT_STACK_SIZE                (24*1024)
 #endif
 
-#ifndef BOARD_BROWNOUT_LEVEL (
-#define BOARD_BROWNLOUT_LEVEL (200)
+#ifndef SAMD5x_E5x_BOD33_LEVEL
+// Set brownout detection to ~2.7V. Default from factory is 1.7V,
+// which is too low for proper operation of external SPI flash chips
+// (they are 2.7-3.6V).
+#define SAMD5x_E5x_BOD33_LEVEL (200)
 // 2.7V: 1.5V + LEVEL * 6mV.
 #endif
 

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -206,11 +206,11 @@ static void rtc_init(void) {
 safe_mode_t port_init(void) {
 #if defined(SAMD21)
 
-    // Set brownout detection to ~2.7V. Default from factory is 1.7V,
+    // Set brownout detection. Default from factory is 1.7V,
     // which is too low for proper operation of external SPI flash chips (they are 2.7-3.6V).
     // Disable while changing level.
     SYSCTRL->BOD33.bit.ENABLE = 0;
-    SYSCTRL->BOD33.bit.LEVEL = 39;  // 2.77V with hysteresis off. Table 37.20 in datasheet.
+    SYSCTRL->BOD33.bit.LEVEL = BOARD_BROWNOUT_LEVEL;
     SYSCTRL->BOD33.bit.ENABLE = 1;
 
     #ifdef ENABLE_MICRO_TRACE_BUFFER
@@ -229,7 +229,7 @@ safe_mode_t port_init(void) {
     // which is too low for proper operation of external SPI flash chips (they are 2.7-3.6V).
     // Disable while changing level.
     SUPC->BOD33.bit.ENABLE = 0;
-    SUPC->BOD33.bit.LEVEL = 200;  // 2.7V: 1.5V + LEVEL * 6mV.
+    SUPC->BOD33.bit.LEVEL = BOARD_BROWNOUT_LEVEL;
     SUPC->BOD33.bit.ENABLE = 1;
 
     // MPU (Memory Protection Unit) setup.

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -206,11 +206,10 @@ static void rtc_init(void) {
 safe_mode_t port_init(void) {
 #if defined(SAMD21)
 
-    // Set brownout detection. Default from factory is 1.7V,
-    // which is too low for proper operation of external SPI flash chips (they are 2.7-3.6V).
+    // Set brownout detection.
     // Disable while changing level.
     SYSCTRL->BOD33.bit.ENABLE = 0;
-    SYSCTRL->BOD33.bit.LEVEL = BOARD_BROWNOUT_LEVEL;
+    SYSCTRL->BOD33.bit.LEVEL = SAMD21_BOD33_LEVEL;
     SYSCTRL->BOD33.bit.ENABLE = 1;
 
     #ifdef ENABLE_MICRO_TRACE_BUFFER
@@ -225,11 +224,10 @@ safe_mode_t port_init(void) {
 #endif
 
 #if defined(SAM_D5X_E5X)
-    // Set brownout detection to ~2.7V. Default from factory is 1.7V,
-    // which is too low for proper operation of external SPI flash chips (they are 2.7-3.6V).
+    // Set brownout detection.
     // Disable while changing level.
     SUPC->BOD33.bit.ENABLE = 0;
-    SUPC->BOD33.bit.LEVEL = BOARD_BROWNOUT_LEVEL;
+    SUPC->BOD33.bit.LEVEL = SAMD5x_E5x_BOD33_LEVEL;
     SUPC->BOD33.bit.ENABLE = 1;
 
     // MPU (Memory Protection Unit) setup.


### PR DESCRIPTION
Not all boards have external flash or other components that make them
require 2.7V -- sometimes we can get considerably longer battery life
by decreasing this requirement.

In particular, pewpew10 and pewpew_m4 are powered directly from
battery, with no LDO, and should work fine down to 1.6V.