### PR TITLE
Set version and release in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
         fetch-depth: 0
     - run: git fetch --recurse-submodules=no https://github.com/adafruit/circuitpython refs/tags/*:refs/tags/*
     - name: CircuitPython version
-      run: git describe --dirty --tags
+      run: |
+        git describe --dirty --tags
+        echo "::set-env name=CP_VERSION::$(git describe --dirty --tags)"
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
@@ -68,7 +70,7 @@ jobs:
         name: stubs
         path: circuitpython-stubs*
     - name: Docs
-      run: sphinx-build -E -W -b html . _build/html
+      run: sphinx-build -E -W -b html -D version=${{ env.CP_VERSION }} -D release=${{ env.CP_VERSION }} . _build/html
     - uses: actions/upload-artifact@v2
       with:
         name: docs


### PR DESCRIPTION
This aims to fix #3134.

It sets the `version` and `release` values to the output of `git describe --dirty --tags` when `sphinx-build` is run in the build workflow. This overrides the value that is set in `conf.py` of 0.0.0.

I've tested building the docs using the `-D` flag and manually setting the `version` and `release` values and that seems to work just fine. But I do not know if this approach of using the output from `git describe --dirty --tags` will give the value needed. Either way I figured this is hopefully a good start!