### PR TITLE
Move release note converter to latest markdown helper lib

### DIFF
--- a/tools/convert_release_notes.py
+++ b/tools/convert_release_notes.py
@@ -4,13 +4,14 @@
 
 import sys
 import mistune
+import mistune.renderers
 
 print(sys.argv[1])
 
 with open(sys.argv[1], "r") as source_file:
     source = source_file.read()
 
-html = mistune.Markdown()
+html = mistune.create_markdown()
 
 print()
 print("HTML")
@@ -19,39 +20,39 @@ print("From the <a href=\"\">GitHub release page</a>:\n<blockquote>")
 print(html(source))
 print("</blockquote>")
 
-class AdafruitBBCodeRenderer:
-    def __init__(self, **kwargs):
-        self.options = kwargs
-
+class AdafruitBBCodeRenderer(mistune.renderers.BaseRenderer):
     def placeholder(self):
         return ''
 
     def paragraph(self, text):
         return text + "\n\n"
 
+    def block_text(self, text):
+        return text
+
     def text(self, text):
         return text
 
     def link(self, link, title, text):
-        return "[url={}]{}[/url]".format(link, text)
+        return "[url={}]{}[/url]".format(link, title)
 
     def autolink(self, link, is_email):
         if not is_email:
             return "[url={}]{}[/url]".format(link, link)
         return link
 
-    def header(self, text, level, raw):
+    def heading(self, text, level):
         return "[b][size=150]{}[/size][/b]\n".format(text)
 
     def codespan(self, text):
         return "[color=#E74C3C][size=95]{}[/size][/color]".format(text)
 
-    def list_item(self, text):
+    def list_item(self, text, level):
         return "[*]{}[/*]\n".format(text.strip())
 
-    def list(self, body, ordered=True):
+    def list(self, text, ordered, level, start=None):
         ordered_indicator = "=" if ordered else ""
-        return "[list{}]\n{}[/list]".format(ordered_indicator, body)
+        return "[list{}]\n{}[/list]".format(ordered_indicator, text)
 
     def double_emphasis(self, text):
         return "[b]{}[/b]".format(text)
@@ -59,7 +60,10 @@ class AdafruitBBCodeRenderer:
     def emphasis(self, text):
         return "[b]{}[/b]".format(text)
 
-bbcode = mistune.Markdown(renderer=AdafruitBBCodeRenderer())
+    def strong(self, text):
+        return "[i]{}[/i]".format(text)
+
+bbcode = mistune.create_markdown(renderer=AdafruitBBCodeRenderer())
 
 print()
 print("BBCode")


### PR DESCRIPTION
Update the release notes converter for the 2.x alpha release of mistune.