### PR TITLE
fix 3169: Polygon.points property

### DIFF
--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -49,20 +49,7 @@ static mp_obj_t vectorio_polygon_make_new(const mp_obj_type_t *type, size_t n_ar
 //|
 STATIC mp_obj_t vectorio_polygon_obj_get_points(mp_obj_t self_in) {
     vectorio_polygon_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_obj_t list = mp_obj_new_list(0, NULL);
-
-    size_t len = 0;
-    mp_obj_t *items;
-    mp_obj_list_get(common_hal_vectorio_polygon_get_points(self), &len, &items);
-
-    for (size_t i = 0; i < len; i += 2) {
-        mp_obj_t tuple[] = { items[i], items[i+1] };
-        mp_obj_list_append(
-            list,
-            mp_obj_new_tuple(2, tuple)
-        );
-    }
-    return list;
+    return common_hal_vectorio_polygon_get_points(self);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(vectorio_polygon_get_points_obj, vectorio_polygon_obj_get_points);
 

--- a/shared-module/vectorio/Polygon.c
+++ b/shared-module/vectorio/Polygon.c
@@ -69,7 +69,7 @@ void common_hal_vectorio_polygon_construct(vectorio_polygon_t *self, mp_obj_t po
 
 mp_obj_t common_hal_vectorio_polygon_get_points(vectorio_polygon_t *self) {
     VECTORIO_POLYGON_DEBUG("%p common_hal_vectorio_polygon_get_points {len: %d, points_list: %p}\n", self, self->len, self->points_list);
-    mp_obj_t list = mp_obj_new_list(0, NULL);
+    mp_obj_t list = mp_obj_new_list(self->len/2, NULL);
 
     for (size_t i = 0; i < self->len; i += 2) {
         mp_obj_t tuple[] = { mp_obj_new_int(self->points_list[i]), mp_obj_new_int(self->points_list[i+1]) };


### PR DESCRIPTION
The getter for vectorio.Polygon#points was not updated with the data type change of the stored points list.

This moves the implementation to shared_module and updates the data type to reflect the actual state.