### PR TITLE
Background callback bugfixes

### DIFF
--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -190,9 +190,7 @@ void reset_displays(void) {
             common_hal_displayio_epaperdisplay_show(display, NULL);
 #if CIRCUITPY_FRAMEBUFFERIO
         } else if (displays[i].framebuffer_display.base.type == &framebufferio_framebufferdisplay_type) {
-            framebufferio_framebufferdisplay_obj_t* display = &displays[i].framebuffer_display;
-            display->auto_refresh = true;
-            common_hal_framebufferio_framebufferdisplay_show(display, NULL);
+            framebufferio_framebufferdisplay_reset(&displays[i].framebuffer_display);
 #endif
         }
     }

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -318,3 +318,8 @@ void framebufferio_framebufferdisplay_collect_ptrs(framebufferio_framebufferdisp
     gc_collect_ptr(self->framebuffer);
     displayio_display_core_collect_ptrs(&self->core);
 }
+
+void framebufferio_framebufferdisplay_reset(framebufferio_framebufferdisplay_obj_t* self) {
+    common_hal_framebufferio_framebufferdisplay_set_auto_refresh(self, true);
+    common_hal_framebufferio_framebufferdisplay_show(self, NULL);
+}

--- a/shared-module/framebufferio/FramebufferDisplay.h
+++ b/shared-module/framebufferio/FramebufferDisplay.h
@@ -55,6 +55,7 @@ typedef struct {
 void framebufferio_framebufferdisplay_background(framebufferio_framebufferdisplay_obj_t* self);
 void release_framebufferdisplay(framebufferio_framebufferdisplay_obj_t* self);
 void reset_framebufferdisplay(framebufferio_framebufferdisplay_obj_t* self);
+void framebufferio_framebufferdisplay_reset(framebufferio_framebufferdisplay_obj_t* self);
 
 void framebufferio_framebufferdisplay_collect_ptrs(framebufferio_framebufferdisplay_obj_t* self);
 

--- a/supervisor/shared/background_callback.c
+++ b/supervisor/shared/background_callback.c
@@ -24,6 +24,8 @@
  * THE SOFTWARE.
  */
 
+#include <string.h>
+
 #include "py/gc.h"
 #include "py/mpconfig.h"
 #include "supervisor/background_callback.h"
@@ -101,6 +103,12 @@ void background_callback_end_critical_section() {
 
 void background_callback_reset() {
     CALLBACK_CRITICAL_BEGIN;
+    background_callback_t *cb = (background_callback_t*)callback_head;
+    while(cb) {
+        background_callback_t *next = cb->next;
+        memset(cb, 0, sizeof(*cb));
+        cb = next;
+    }
     callback_head = NULL;
     callback_tail = NULL;
     in_background_callback = false;

--- a/supervisor/shared/tick.c
+++ b/supervisor/shared/tick.c
@@ -66,7 +66,7 @@
 
 static volatile uint64_t PLACE_IN_DTCM_BSS(background_ticks);
 
-static background_callback_t callback;
+static background_callback_t tick_callback;
 
 volatile uint64_t last_finished_tick = 0;
 
@@ -119,7 +119,7 @@ void supervisor_tick(void) {
         #endif
     }
 #endif
-    background_callback_add(&callback, supervisor_background_tasks, NULL);
+    background_callback_add(&tick_callback, supervisor_background_tasks, NULL);
 }
 
 uint64_t supervisor_ticks_ms64() {

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -64,8 +64,8 @@ void usb_init(void) {
     tusb_init();
 
 #if MICROPY_KBD_EXCEPTION
-    // Set Ctrl+C as wanted char, tud_cdc_rx_wanted_cb() callback will be invoked when Ctrl+C is received
-    // This callback always got invoked regardless of mp_interrupt_char value since we only set it once here
+    // Set Ctrl+C as wanted char, tud_cdc_rx_wanted_cb() usb_callback will be invoked when Ctrl+C is received
+    // This usb_callback always got invoked regardless of mp_interrupt_char value since we only set it once here
     tud_cdc_set_wanted_char(CHAR_CTRL_C);
 #endif
 
@@ -83,14 +83,14 @@ void usb_background(void) {
     }
 }
 
-static background_callback_t callback;
+static background_callback_t usb_callback;
 static void usb_background_do(void* unused) {
     usb_background();
 }
 
 void usb_irq_handler(void) {
     tud_int_handler(0);
-    background_callback_add(&callback, usb_background_do, NULL);
+    background_callback_add(&usb_callback, usb_background_do, NULL);
 }
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
While investigating #3173 I found that the display would usually stop auto-refreshing after soft reset.  This stemmed from not correctly clearing the state of tasks that were queued at that moment.  In theory, it could have caused #3173 as well depending on the order in which multiple background callbacks were added, and not happen consistently.

This also fixes a potential problem with framebufferio auto refresh over soft reset, by making the code match displayio.

Testing performed: soft-reset a pygamer repeatedly, both with the auto_refresh flag = True and = False via REPL.  Display continued to refresh consistently.