### PR TITLE
extend visibility of nibble_to_hex_upper and nibble_to_hex_lower

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -25,6 +25,8 @@
  * THE SOFTWARE.
  */
 
+#define MICROPY_INSIDE_PY_OBJSTR_C
+
 #include <string.h>
 #include <assert.h>
 

--- a/py/objstr.h
+++ b/py/objstr.h
@@ -77,8 +77,14 @@ const byte *str_index_to_ptr(const mp_obj_type_t *type, const byte *self_data, s
                              mp_obj_t index, bool is_slice);
 const byte *find_subbytes(const byte *haystack, size_t hlen, const byte *needle, size_t nlen, int direction);
 
-const char nibble_to_hex_upper[16];
-const char nibble_to_hex_lower[16];
+#ifdef MICROPY_INSIDE_PY_OBJSTR_C
+#define EXTERN
+#else
+#define EXTERN extern
+#endif
+
+EXTERN const char nibble_to_hex_upper[16];
+EXTERN const char nibble_to_hex_lower[16];
 
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(str_encode_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(str_find_obj);


### PR DESCRIPTION
This fixes the error of multiple definition that I've been finding during linking process.