### PR TITLE
Litex: fix microcontroller common-hal interface

### DIFF
--- a/ports/litex/common-hal/microcontroller/Pin.c
+++ b/ports/litex/common-hal/microcontroller/Pin.c
@@ -41,10 +41,17 @@ void reset_pin_number(uint8_t pin_port, uint8_t pin_number) {
     claimed_pins[pin_port] &= ~(1<<pin_number);
 }
 
+void common_hal_reset_pin(const mcu_pin_obj_t* pin) {
+    reset_pin_number(0, pin->number);
+}
 
 void claim_pin(const mcu_pin_obj_t* pin) {
     // Set bit in claimed_pins bitmask.
     claimed_pins[0] |= 1<<pin->number;
+}
+
+void common_hal_mcu_pin_claim(const mcu_pin_obj_t* pin) {
+    claim_pin(pin);
 }
 
 bool pin_number_is_free(uint8_t pin_port, uint8_t pin_number) {


### PR DESCRIPTION
The shared-module TouchIO was recently modified to remove all instances of `claim_pin` in favor of `common_hal_mcu_pin_claim`, as part of a general effort to remove internal port functions being used in shared-bindings or shared-module. Litex needs a `common_hal_mcu_pin_claim` function to account for this change. I've also added `common_hal_reset_pin` to future-proof against a potential DisplayIO implementation which will need this function. 