### PR TITLE
Require await in async

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 18:43-0700\n"
+"POT-Creation-Date: 2020-07-24 19:58-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -108,10 +108,6 @@ msgstr ""
 
 #: py/argcheck.c
 msgid "'%q' argument required"
-msgstr ""
-
-#: py/objarray.c
-msgid "'%q' object is not bytes-like"
 msgstr ""
 
 #: py/emitinlinethumb.c py/emitinlinextensa.c
@@ -219,11 +215,11 @@ msgid "'align' requires 1 argument"
 msgstr ""
 
 #: py/compile.c
-msgid "'async for' or 'async with' outside async function"
+msgid "'await' outside function"
 msgstr ""
 
 #: py/compile.c
-msgid "'await' outside function"
+msgid "'await', 'async for' or 'async with' outside async function"
 msgstr ""
 
 #: py/compile.c
@@ -1336,10 +1332,6 @@ msgstr ""
 msgid "Pull not used when direction is output."
 msgstr ""
 
-#: ports/stm/ref/pulseout-pre-timeralloc.c
-msgid "PulseOut not supported on this chip"
-msgstr ""
-
 #: ports/stm/common-hal/os/__init__.c
 msgid "RNG DeInit Error"
 msgstr ""
@@ -1773,7 +1765,7 @@ msgstr ""
 msgid "__new__ arg must be a user-type"
 msgstr ""
 
-#: extmod/modubinascii.c extmod/moduhashlib.c
+#: extmod/modubinascii.c extmod/moduhashlib.c py/objarray.c
 msgid "a bytes-like object is required"
 msgstr ""
 

--- a/py/compile.c
+++ b/py/compile.c
@@ -1713,11 +1713,11 @@ STATIC void compile_yield_from(compiler_t *comp) {
 #if MICROPY_PY_ASYNC_AWAIT
 STATIC bool compile_require_async_context(compiler_t *comp, mp_parse_node_struct_t *pns) {
     int scope_flags = comp->scope_cur->scope_flags;
-    if(scope_flags & MP_SCOPE_FLAG_GENERATOR) {
+    if(scope_flags & MP_SCOPE_FLAG_ASYNC) {
         return true;
     }
     compile_syntax_error(comp, (mp_parse_node_t)pns,
-        translate("'async for' or 'async with' outside async function"));
+        translate("'await', 'async for' or 'async with' outside async function"));
     return false;
 }
 
@@ -2645,6 +2645,7 @@ STATIC void compile_atom_expr_await(compiler_t *comp, mp_parse_node_struct_t *pn
         compile_syntax_error(comp, (mp_parse_node_t)pns, translate("'await' outside function"));
         return;
     }
+    compile_require_async_context(comp, pns);
     compile_atom_expr_normal(comp, pns);
     compile_yield_from(comp);
 }


### PR DESCRIPTION
disallows using `await` outside of an `async def` scope

```
await ''  # syntax error, not async def (also '' is not awaitable but this does change not fix that)

def f():
  await ''  # syntax error, not async def

def f():
  async with real_async_function() as a:  # syntax error, not async def

def f():
  async for i in arange():  # syntax error, not async def
```

My branch: ![Build CI](https://github.com/WarriorOfWire/circuitpython/workflows/Build%20CI/badge.svg?branch=require_await_in_async)