### PR TITLE
fluff_m0: add pin aliases

### DIFF
--- a/ports/atmel-samd/boards/fluff_m0/mpconfigboard.h
+++ b/ports/atmel-samd/boards/fluff_m0/mpconfigboard.h
@@ -18,27 +18,3 @@
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1
-
-// There is no port B
-#define IGNORE_PIN_PB00     1
-#define IGNORE_PIN_PB01     1
-#define IGNORE_PIN_PB02     1
-#define IGNORE_PIN_PB03     1
-#define IGNORE_PIN_PB04     1
-#define IGNORE_PIN_PB05     1
-#define IGNORE_PIN_PB06     1
-#define IGNORE_PIN_PB07     1
-#define IGNORE_PIN_PB08     1
-#define IGNORE_PIN_PB09     1
-#define IGNORE_PIN_PB10     1
-#define IGNORE_PIN_PB11     1
-#define IGNORE_PIN_PB12     1
-#define IGNORE_PIN_PB13     1
-#define IGNORE_PIN_PB14     1
-#define IGNORE_PIN_PB15     1
-#define IGNORE_PIN_PB16     1
-#define IGNORE_PIN_PB17     1
-#define IGNORE_PIN_PB22     1
-#define IGNORE_PIN_PB23     1
-#define IGNORE_PIN_PB30     1
-#define IGNORE_PIN_PB31     1

--- a/ports/atmel-samd/boards/fluff_m0/mpconfigboard.h
+++ b/ports/atmel-samd/boards/fluff_m0/mpconfigboard.h
@@ -18,3 +18,27 @@
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1
+
+// There is no port B
+#define IGNORE_PIN_PB00     1
+#define IGNORE_PIN_PB01     1
+#define IGNORE_PIN_PB02     1
+#define IGNORE_PIN_PB03     1
+#define IGNORE_PIN_PB04     1
+#define IGNORE_PIN_PB05     1
+#define IGNORE_PIN_PB06     1
+#define IGNORE_PIN_PB07     1
+#define IGNORE_PIN_PB08     1
+#define IGNORE_PIN_PB09     1
+#define IGNORE_PIN_PB10     1
+#define IGNORE_PIN_PB11     1
+#define IGNORE_PIN_PB12     1
+#define IGNORE_PIN_PB13     1
+#define IGNORE_PIN_PB14     1
+#define IGNORE_PIN_PB15     1
+#define IGNORE_PIN_PB16     1
+#define IGNORE_PIN_PB17     1
+#define IGNORE_PIN_PB22     1
+#define IGNORE_PIN_PB23     1
+#define IGNORE_PIN_PB30     1
+#define IGNORE_PIN_PB31     1

--- a/ports/atmel-samd/boards/fluff_m0/pins.c
+++ b/ports/atmel-samd/boards/fluff_m0/pins.c
@@ -13,7 +13,9 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_PA31) },
     { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_PA00) },
+    { MP_ROM_QSTR(MP_QSTR_SDO), MP_ROM_PTR(&pin_PA00) },
     { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_PA30) },
+    { MP_ROM_QSTR(MP_QSTR_SDI), MP_ROM_PTR(&pin_PA30) },
 
     { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_PA11) },
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_PA11) },
@@ -31,6 +33,7 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_PA19) },
     { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_PA17) },
     { MP_ROM_QSTR(MP_QSTR_D14), MP_ROM_PTR(&pin_PA27) },
+    { MP_ROM_QSTR(MP_QSTR_EN), MP_ROM_PTR(&pin_PA27) },
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_PA28) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },


### PR DESCRIPTION
Add aliases for SDI, SDO and EN, so that pin names match the text on the
PCB to avoid confusion.

Also disable all pins from port B, because that package of SAMD21
doesn't have port B.