### PR TITLE
 adjust stack for SAMD21 to accommodate larger pystack

### DIFF
--- a/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
@@ -28,7 +28,7 @@
 #define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
 
 // Increase stack size slightly due to CPX library import nesting
-#define CIRCUITPY_DEFAULT_STACK_SIZE  (4760) //divisible by 8
+#define CIRCUITPY_DEFAULT_STACK_SIZE  (4248) //divisible by 8
 
 #define USER_NEOPIXELS_PIN      (&pin_PB23)
 

--- a/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
@@ -30,7 +30,7 @@
 #define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
 
 // Increase stack size slightly due to CPX library import nesting
-#define CIRCUITPY_DEFAULT_STACK_SIZE  (4760) // divisible by 8
+#define CIRCUITPY_DEFAULT_STACK_SIZE  (4248) // divisible by 8
 
 #define DEFAULT_I2C_BUS_SCL (&pin_PB03)
 #define DEFAULT_I2C_BUS_SDA (&pin_PB02)

--- a/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
@@ -28,7 +28,7 @@
 #define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
 
 // Increase stack size slightly due to CPX library import nesting.
-#define CIRCUITPY_DEFAULT_STACK_SIZE  (4760)  // divisible by 8
+#define CIRCUITPY_DEFAULT_STACK_SIZE  (4248)  // divisible by 8
 
 #define USER_NEOPIXELS_PIN      (&pin_PB23)
 

--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -109,7 +109,7 @@
 #endif
 
 #ifndef CIRCUITPY_DEFAULT_STACK_SIZE
-#define CIRCUITPY_DEFAULT_STACK_SIZE                4096
+#define CIRCUITPY_DEFAULT_STACK_SIZE                3584
 #endif
 
 #ifndef SAMD21_BOD33_LEVEL

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -799,7 +799,7 @@ void supervisor_run_background_tasks_if_tick(void);
 #endif
 
 #ifndef CIRCUITPY_PYSTACK_SIZE
-#define CIRCUITPY_PYSTACK_SIZE 1024
+#define CIRCUITPY_PYSTACK_SIZE 1536
 #endif
 
 #define CIRCUITPY_BOOT_OUTPUT_FILE "/boot_out.txt"


### PR DESCRIPTION
increase pystack by 512 bytes 
decrease SAMD21 stack by 512 bytes

fixes #3208 - this was the original impetus for the update since pystack was too small to use the airlift.

also update frozen module Adafruit_CircuitPython_BusDevice -- not sure if I did this correctly but it works...


Tested on CircuitPlayGround Express -- able to import express library
from adafruit_circuitplayground.express import cpx

Are there other tests that need to be done with he crickit or displayio variants?

also tested on metro_m4_airlift_lite to verify #3208 fixed.


Only the pystack size in py/circuitpy_mpconfigport.h and the specific setting of CIRCUITPY_DEFAULT_STACK_SIZE for the atmel-samd SAMD21 are changed since it is the most impacted. It did not seem necessary to change all the other ports with stacks sized 20K or greater for the 512 byte difference.  They can be added if desired.


also verified that several SAMD21 build seem to work normally
trinket_m0,pyruler_gemma_m0,pewpew10

the only issue I am having is with irremote(pulseio) and taht appears to be a 6.0.0-alpha2 issue in general  -- see #3216 