### PR TITLE
Updated Group.c to correct bug with insert into displayio.Group

### DIFF
--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -218,11 +218,11 @@ STATIC mp_obj_t displayio_group_obj_insert(mp_obj_t self_in, mp_obj_t index_obj,
     if ((size_t) MP_OBJ_SMALL_INT_VALUE(index_obj) == common_hal_displayio_group_get_len(self)){
         return displayio_group_obj_append(self_in, layer);
     }
-    else {
-        size_t index = mp_get_index(&displayio_group_type, common_hal_displayio_group_get_len(self), index_obj, false);
-        common_hal_displayio_group_insert(self, index, layer);
-        return mp_const_none;
-    }
+    
+    size_t index = mp_get_index(&displayio_group_type, common_hal_displayio_group_get_len(self), index_obj, false);
+    common_hal_displayio_group_insert(self, index, layer);
+    return mp_const_none;
+    
 }
 MP_DEFINE_CONST_FUN_OBJ_3(displayio_group_insert_obj, displayio_group_obj_insert);
 

--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -215,9 +215,14 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_group_append_obj, displayio_group_obj_append
 //|
 STATIC mp_obj_t displayio_group_obj_insert(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t layer) {
     displayio_group_t *self = native_group(self_in);
-    size_t index = mp_get_index(&displayio_group_type, common_hal_displayio_group_get_len(self), index_obj, false);
-    common_hal_displayio_group_insert(self, index, layer);
-    return mp_const_none;
+    if ((size_t) MP_OBJ_SMALL_INT_VALUE(index_obj) == common_hal_displayio_group_get_len(self)){
+        return displayio_group_obj_append(self_in, layer);
+    }
+    else {
+        size_t index = mp_get_index(&displayio_group_type, common_hal_displayio_group_get_len(self), index_obj, false);
+        common_hal_displayio_group_insert(self, index, layer);
+        return mp_const_none;
+    }
 }
 MP_DEFINE_CONST_FUN_OBJ_3(displayio_group_insert_obj, displayio_group_obj_insert);
 


### PR DESCRIPTION
This is to resolve the bug when inserting an element at the end of an existing group.  See issue: https://github.com/adafruit/circuitpython/issues/3129#issuecomment-656252519

In this PR, per your suggestions I check if the requested insert index is equal to the length of the group.  If so, then call append, else call insert.

I hunted around the code for the proper type conversions, but I am unsure if I am doing the type conversion correctly.
** Please double-check since I am not familiar with any of the data types that are used here.

I built this and verified on an Itsy-Bitsy NRF52840

Here is how I verified the code:
```
>>> 
>>> import displayio
>>> group1=displayio.Group(max_size=5)
>>> group2=displayio.Group(max_size=5)
>>> group3=displayio.Group(max_size=5)
>>> group1.insert(0,group2)
>>> group1.insert(1,group3)
>>> len(group1)
2
>>> group1.pop(0)
<Group>
>>> len(group1)
1
>>> group1.insert(1,group2)
>>> len(group1)
2
>>> 
```

@foamyguy whenever this bug is corrected, you can simplify the workaround  to the label.py related where you had to double-check the length of the group to decide whether to use `group.append` or `group.insert`.