### PR TITLE
use top-left heuristic for vectorio.Polygon

### DIFF
--- a/shared-module/vectorio/Polygon.c
+++ b/shared-module/vectorio/Polygon.c
@@ -143,13 +143,13 @@ uint32_t common_hal_vectorio_polygon_get_pixel(void *obj, int16_t x, int16_t y) 
         int y2 = self->points_list[i % self->len];
         VECTORIO_POLYGON_DEBUG(" (%3d, %3d)}\n", x2, y2);
         if ( y1 <= y ) {
-            if ( y2 > y && line_side(x1, y1, x2, y2, x, y) > 0 ) {
-                // Wind up, point is to the right of the edge vector
+            if ( y2 > y && line_side(x1, y1, x2, y2, x, y) < 0 ) {
+                // Wind up, point is to the left of the edge vector
                 ++winding_number;
                 VECTORIO_POLYGON_DEBUG("    wind:%2d winding_number:%2d\n", 1, winding_number);
             }
-        } else if ( y2 <= y && line_side(x1, y1, x2, y2, x, y) < 0 ) {
-            // Wind down, point is to the left of the edge vector
+        } else if ( y2 <= y && line_side(x1, y1, x2, y2, x, y) > 0 ) {
+            // Wind down, point is to the right of the edge vector
             --winding_number;
             VECTORIO_POLYGON_DEBUG("    wind:%2d winding_number:%2d\n", -1, winding_number);
         }


### PR DESCRIPTION
this flips the bottom-right style to top-left which is at least
kind of normal.  A 2x2 square at (0,0) would be defined like
(0,0), (3,0), (3,3), (0,3)
Which seems kind of surprising but at least less bonkers than
that square being defined at (1,1), which is the current behavior.

```
[
  (0,0),
  (5,0),
  (5,10),
  (0,10)
]
```
points as above create the interior pixels below
![image](https://user-images.githubusercontent.com/3454741/88763266-b4794e80-d127-11ea-899d-4639ec321853.png)
