### PR TITLE
storage.erase_filesystem(): disconnect from USB and wait 1 second before resetting

### DIFF
--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -30,6 +30,7 @@
 
 #include "extmod/vfs.h"
 #include "py/mperrno.h"
+#include "py/mphal.h"
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/__init__.h"
@@ -159,6 +160,8 @@ void common_hal_storage_remount(const char *mount_path, bool readonly, bool disa
 }
 
 void common_hal_storage_erase_filesystem(void) {
+    usb_disconnect();
+    mp_hal_delay_ms(1000);
     filesystem_init(false, true); // Force a re-format.
     common_hal_mcu_reset();
     // We won't actually get here, since we're resetting.

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -73,6 +73,10 @@ void usb_init(void) {
 #endif
 }
 
+void usb_disconnect(void) {
+    tud_disconnect();
+}
+
 void usb_background(void) {
     if (usb_enabled()) {
         #if CFG_TUSB_OS == OPT_OS_NONE

--- a/supervisor/usb.h
+++ b/supervisor/usb.h
@@ -40,6 +40,7 @@ void init_usb_hardware(void);
 // Shared implementation.
 bool usb_enabled(void);
 void usb_init(void);
+void usb_disconnect(void);
 
 // Propagate plug/unplug events to the MSC logic.
 void usb_msc_mount(void);


### PR DESCRIPTION
Calling `storage.erase_filesystem()` can cause an intermittent but frequent Linux crash. I considered this a Linux bug but have been informed that Linux doesn't see the need to guard against USB MSC devices acting badly.

This change disconnects from USB before reformatting the filesystem and then waits for 1 second before resetting. This appears to prevent the Linux crashes: I tested multiple times.

My original Ubuntu bug report:
https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1871143

Correspondence on the linux-usb mailing list:
https://marc.info/?l=linux-usb&m=159387610928589&w=2

@hathach This may be of interest to you.

