### PR TITLE
Small updates to Open Book board

### DIFF
--- a/ports/atmel-samd/boards/openbook_m4/board.c
+++ b/ports/atmel-samd/boards/openbook_m4/board.c
@@ -76,13 +76,13 @@ void board_init(void) {
         sizeof(start_sequence),
         stop_sequence,
         sizeof(stop_sequence),
-        400, // width
-        300, // height
-        400, // RAM width
-        300, // RAM height
+        300, // width
+        400, // height
+        300, // RAM width
+        400, // RAM height
         0, // colstart
         0, // rowstart
-        0, // rotation
+        270, // rotation
         NO_COMMAND, // set_column_window_command
         NO_COMMAND, // set_row_window_command
         NO_COMMAND, // set_current_column_command

--- a/ports/atmel-samd/boards/openbook_m4/pins.c
+++ b/ports/atmel-samd/boards/openbook_m4/pins.c
@@ -53,6 +53,10 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_EBSY),  MP_ROM_PTR(&pin_PA01) },
 
     // Special named pins
+    { MP_OBJ_NEW_QSTR(MP_QSTR_BATTERY),  MP_ROM_PTR(&pin_PB01) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_USB),  MP_ROM_PTR(&pin_PB00) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_MICIN),  MP_ROM_PTR(&pin_PB04) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_MICOUT),  MP_ROM_PTR(&pin_PA07) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_NEOPIXEL),  MP_ROM_PTR(&pin_PA15) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_LOCK_BUTTON),  MP_ROM_PTR(&pin_PA27) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_BUTTON_LATCH),  MP_ROM_PTR(&pin_PB12) },


### PR DESCRIPTION
This is just a couple of minor improvements to the Open Book. The main change is that it sets the screen's orientation to portrait to match the way users hold the device. 

It also adds descriptive pin names per comments in #2520; I tried to use nomenclature that matches other Adafruit boards (MICIN and MICOUT from the NeoTrellis, BATTERY from Feather boards). USB is a voltage divider on VBUS for determining if the device is plugged in to external power.