### PR TITLE
Cannot assign values to 32-bit Bitmap

### DIFF
--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -163,8 +163,8 @@ STATIC mp_obj_t bitmap_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t val
         // load
         return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_bitmap_get_pixel(self, x, y));
     } else {
-        mp_int_t value = mp_obj_get_int(value_obj);
-        if (value >= 1 << common_hal_displayio_bitmap_get_bits_per_value(self)) {
+        mp_uint_t value = (mp_uint_t)mp_obj_get_int(value_obj);
+        if ((value >> common_hal_displayio_bitmap_get_bits_per_value(self)) != 0) {
             mp_raise_ValueError(translate("pixel value requires too many bits"));
         }
         common_hal_displayio_bitmap_set_pixel(self, x, y, value);
@@ -179,8 +179,8 @@ STATIC mp_obj_t bitmap_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t val
 STATIC mp_obj_t displayio_bitmap_obj_fill(mp_obj_t self_in, mp_obj_t value_obj) {
     displayio_bitmap_t *self = MP_OBJ_TO_PTR(self_in);
 
-    mp_int_t value = mp_obj_get_int(value_obj);
-    if (value >= 1 << common_hal_displayio_bitmap_get_bits_per_value(self)) {
+    mp_uint_t value = (mp_uint_t)mp_obj_get_int(value_obj);
+    if ((value >> common_hal_displayio_bitmap_get_bits_per_value(self)) != 0) {
             mp_raise_ValueError(translate("pixel value requires too many bits"));
     }
     common_hal_displayio_bitmap_fill(self, value);


### PR DESCRIPTION
**Actual result:**
```python
>>> import displayio
>>> b = displayio.Bitmap(8, 8, 2**28)
>>> b[0, 0] = 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: pixel value requires too many bits
>>> b.fill(1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: pixel value requires too many bits
```

(`2**28` is used because the PewPew M4 I am testing on doesn’t have long ints enabled – the bit depth is rounded up to multiples of 8 so this results in a 32-bit bitmap.)

**Expected result:** no error in either case, `b[0, 0] == 1`.

This happens because the left-shift by 32 in the check in `bitmap_subscr()` and `displayio_bitmap_obj_fill()` overflows a 32-bit integer, ending up in zero, which is always matched by the comparison. The attached commit fixes it by right-shifting on the other side of the equation instead (using an unsigned type to avoid sign extension).