### PR TITLE
Add extern declarations for gcc10 compat

### DIFF
--- a/ports/cxd56/common-hal/microcontroller/Processor.h
+++ b/ports/cxd56/common-hal/microcontroller/Processor.h
@@ -35,6 +35,6 @@ typedef struct {
     mp_obj_base_t base;
 } mcu_processor_obj_t;
 
-const mp_obj_type_t mcu_processor_type;
+extern const mp_obj_type_t mcu_processor_type;
 
 #endif // MICROPY_INCLUDED_CXD56_COMMON_HAL_MICROCONTROLLER_PROCESSOR_H

--- a/ports/mimxrt10xx/mphalport.h
+++ b/ports/mimxrt10xx/mphalport.h
@@ -39,8 +39,8 @@ static inline mp_uint_t mp_hal_ticks_ms(void) {
   return supervisor_ticks_ms32();
 }
 // Number of bytes in receive buffer
-volatile uint8_t usb_rx_count;
-volatile bool mp_cdc_enabled;
+extern volatile uint8_t usb_rx_count;
+extern volatile bool mp_cdc_enabled;
 
 int receive_usb(void);
 

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1011/periph.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1011/periph.h
@@ -27,18 +27,18 @@
 #ifndef MICROPY_INCLUDED_MIMXRT10XX_PERIPHERALS_MIMXRT1011_PERIPH_H
 #define MICROPY_INCLUDED_MIMXRT10XX_PERIPHERALS_MIMXRT1011_PERIPH_H
 
-LPI2C_Type *mcu_i2c_banks[2];
+extern LPI2C_Type *mcu_i2c_banks[2];
 
 extern const mcu_periph_obj_t mcu_i2c_sda_list[8];
 extern const mcu_periph_obj_t mcu_i2c_scl_list[8];
 
-LPSPI_Type *mcu_spi_banks[2];
+extern LPSPI_Type *mcu_spi_banks[2];
 
 extern const mcu_periph_obj_t mcu_spi_sck_list[4];
 extern const mcu_periph_obj_t mcu_spi_mosi_list[4];
 extern const mcu_periph_obj_t mcu_spi_miso_list[4];
 
-LPUART_Type *mcu_uart_banks[4];
+extern LPUART_Type *mcu_uart_banks[4];
 
 extern const mcu_periph_obj_t mcu_uart_rx_list[9];
 extern const mcu_periph_obj_t mcu_uart_tx_list[9];

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1021/periph.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1021/periph.h
@@ -28,18 +28,18 @@
 #ifndef MICROPY_INCLUDED_MIMXRT10XX_PERIPHERALS_MIMXRT1021_PERIPH_H
 #define MICROPY_INCLUDED_MIMXRT10XX_PERIPHERALS_MIMXRT1021_PERIPH_H
 
-LPI2C_Type *mcu_i2c_banks[4];
+extern LPI2C_Type *mcu_i2c_banks[4];
 
 extern const mcu_periph_obj_t mcu_i2c_sda_list[8];
 extern const mcu_periph_obj_t mcu_i2c_scl_list[8];
 
-LPSPI_Type *mcu_spi_banks[4];
+extern LPSPI_Type *mcu_spi_banks[4];
 
 extern const mcu_periph_obj_t mcu_spi_sck_list[8];
 extern const mcu_periph_obj_t mcu_spi_mosi_list[8];
 extern const mcu_periph_obj_t mcu_spi_miso_list[8];
 
-LPUART_Type *mcu_uart_banks[8];
+extern LPUART_Type *mcu_uart_banks[8];
 
 extern const mcu_periph_obj_t mcu_uart_rx_list[16];
 extern const mcu_periph_obj_t mcu_uart_tx_list[16];

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1062/periph.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1062/periph.h
@@ -27,18 +27,18 @@
 #ifndef MICROPY_INCLUDED_MIMXRT10XX_PERIPHERALS_MIMXRT1011_PERIPH_H
 #define MICROPY_INCLUDED_MIMXRT10XX_PERIPHERALS_MIMXRT1011_PERIPH_H
 
-LPI2C_Type *mcu_i2c_banks[4];
+extern LPI2C_Type *mcu_i2c_banks[4];
 
 extern const mcu_periph_obj_t mcu_i2c_sda_list[9];
 extern const mcu_periph_obj_t mcu_i2c_scl_list[9];
 
-LPSPI_Type *mcu_spi_banks[4];
+extern LPSPI_Type *mcu_spi_banks[4];
 
 extern const mcu_periph_obj_t mcu_spi_sck_list[8];
 extern const mcu_periph_obj_t mcu_spi_mosi_list[8];
 extern const mcu_periph_obj_t mcu_spi_miso_list[8];
 
-LPUART_Type *mcu_uart_banks[8];
+extern LPUART_Type *mcu_uart_banks[8];
 
 extern const mcu_periph_obj_t mcu_uart_rx_list[18];
 extern const mcu_periph_obj_t mcu_uart_tx_list[18];

--- a/ports/nrf/common-hal/_bleio/__init__.c
+++ b/ports/nrf/common-hal/_bleio/__init__.c
@@ -87,6 +87,8 @@ void check_sec_status(uint8_t sec_status) {
     }
 }
 
+bool vm_used_ble;
+
 // Turn off BLE on a reset or reload.
 void bleio_reset() {
     if (!common_hal_bleio_adapter_get_enabled(&common_hal_bleio_adapter_obj)) {

--- a/ports/nrf/common-hal/_bleio/__init__.h
+++ b/ports/nrf/common-hal/_bleio/__init__.h
@@ -45,6 +45,6 @@ void check_gatt_status(uint16_t gatt_status);
 void check_sec_status(uint8_t sec_status);
 
 // Track if the user code modified the BLE state to know if we need to undo it on reload.
-bool vm_used_ble;
+extern bool vm_used_ble;
 
 #endif // MICROPY_INCLUDED_NRF_COMMON_HAL_BLEIO_INIT_H

--- a/ports/stm/common-hal/pulseio/PWMOut.c
+++ b/ports/stm/common-hal/pulseio/PWMOut.c
@@ -96,7 +96,7 @@ pwmout_result_t common_hal_pulseio_pwmout_construct(pulseio_pwmout_obj_t* self,
         //if pin is same
         if (l_tim->pin == pin) {
             //check if the timer has a channel active, or is reserved by main timer system
-            if (reserved_tim[l_tim_index] != 0) {
+            if (l_tim_index < TIM_BANK_ARRAY_LEN && reserved_tim[l_tim_index] != 0) {
                 // Timer has already been reserved by an internal module
                 if (stm_peripherals_timer_is_reserved(mcu_tim_banks[l_tim_index])) {
                     tim_taken_internal = true;

--- a/ports/stm/mphalport.h
+++ b/ports/stm/mphalport.h
@@ -38,8 +38,8 @@ static inline mp_uint_t mp_hal_ticks_ms(void) {
   return supervisor_ticks_ms32();
 }
 // Number of bytes in receive buffer
-volatile uint8_t usb_rx_count;
-volatile bool mp_cdc_enabled;
+extern volatile uint8_t usb_rx_count;
+extern volatile bool mp_cdc_enabled;
 
 int receive_usb(void);
 

--- a/ports/stm/peripherals/stm32f4/stm32f401xe/periph.h
+++ b/ports/stm/peripherals/stm32f4/stm32f401xe/periph.h
@@ -51,7 +51,7 @@ extern const mcu_periph_obj_t mcu_uart_rx_list[6];
 //Timers
 #define TIM_BANK_ARRAY_LEN 14
 #define TIM_PIN_ARRAY_LEN 44
-TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
-const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
+extern TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
+extern const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
 
 #endif // MICROPY_INCLUDED_STM32_PERIPHERALS_STM32F401XE_PERIPH_H

--- a/ports/stm/peripherals/stm32f4/stm32f405xx/periph.h
+++ b/ports/stm/peripherals/stm32f4/stm32f405xx/periph.h
@@ -58,8 +58,8 @@ extern const mcu_periph_obj_t mcu_uart_rx_list[UART_RX_ARRAY_LEN];
 //Timers
 #define TIM_BANK_ARRAY_LEN 14
 #define TIM_PIN_ARRAY_LEN 67
-TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
-const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
+extern TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
+extern const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
 
 //SDIO
 extern SDIO_TypeDef * mcu_sdio_banks[1];

--- a/ports/stm/peripherals/stm32f4/stm32f407xx/periph.h
+++ b/ports/stm/peripherals/stm32f4/stm32f407xx/periph.h
@@ -51,7 +51,7 @@ extern const mcu_periph_obj_t mcu_uart_rx_list[12];
 //Timers
 #define TIM_BANK_ARRAY_LEN 14
 #define TIM_PIN_ARRAY_LEN 56
-TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
-const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
+extern TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
+extern const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
 
 #endif // MICROPY_INCLUDED_STM32_PERIPHERALS_STM32F407XX_PERIPH_H

--- a/ports/stm/peripherals/stm32f4/stm32f411xe/periph.h
+++ b/ports/stm/peripherals/stm32f4/stm32f411xe/periph.h
@@ -51,7 +51,7 @@ extern const mcu_periph_obj_t mcu_uart_rx_list[7];
 //Timers
 #define TIM_BANK_ARRAY_LEN 14
 #define TIM_PIN_ARRAY_LEN 44
-TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
-const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
+extern TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
+extern const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
 
 #endif // MICROPY_INCLUDED_STM32_PERIPHERALS_STM32F411XE_PERIPH_H

--- a/ports/stm/peripherals/stm32f4/stm32f412zx/periph.h
+++ b/ports/stm/peripherals/stm32f4/stm32f412zx/periph.h
@@ -52,7 +52,7 @@ extern const mcu_periph_obj_t mcu_uart_rx_list[12];
 //Timers
 #define TIM_BANK_ARRAY_LEN 14
 #define TIM_PIN_ARRAY_LEN 60
-TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
-const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
+extern TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
+extern const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
 
 #endif // MICROPY_INCLUDED_STM32_PERIPHERALS_STM32F412ZX_PERIPH_H

--- a/ports/stm/peripherals/stm32f7/stm32f746xx/periph.h
+++ b/ports/stm/peripherals/stm32f7/stm32f746xx/periph.h
@@ -31,28 +31,28 @@
 //I2C
 extern I2C_TypeDef * mcu_i2c_banks[4];
 
-const mcu_periph_obj_t mcu_i2c_sda_list[10];
-const mcu_periph_obj_t mcu_i2c_scl_list[10];
+extern const mcu_periph_obj_t mcu_i2c_sda_list[10];
+extern const mcu_periph_obj_t mcu_i2c_scl_list[10];
 
 //SPI
 extern SPI_TypeDef * mcu_spi_banks[6];
 
-const mcu_periph_obj_t mcu_spi_sck_list[14];
-const mcu_periph_obj_t mcu_spi_mosi_list[15];
-const mcu_periph_obj_t mcu_spi_miso_list[12];
+extern const mcu_periph_obj_t mcu_spi_sck_list[14];
+extern const mcu_periph_obj_t mcu_spi_mosi_list[15];
+extern const mcu_periph_obj_t mcu_spi_miso_list[12];
 
 //UART
 extern USART_TypeDef * mcu_uart_banks[MAX_UART];
 extern bool mcu_uart_has_usart[MAX_UART];
 
-const mcu_periph_obj_t mcu_uart_tx_list[15];
-const mcu_periph_obj_t mcu_uart_rx_list[15];
+extern const mcu_periph_obj_t mcu_uart_tx_list[15];
+extern const mcu_periph_obj_t mcu_uart_rx_list[15];
 
 //Timers
 #define TIM_BANK_ARRAY_LEN 14
 #define TIM_PIN_ARRAY_LEN 55
 extern TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
 
-const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
+extern const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
 
 #endif // MICROPY_INCLUDED_STM32_PERIPHERALS_STM32F746XX_PERIPH_H

--- a/ports/stm/peripherals/stm32f7/stm32f767xx/periph.h
+++ b/ports/stm/peripherals/stm32f7/stm32f767xx/periph.h
@@ -30,28 +30,28 @@
 //I2C
 extern I2C_TypeDef * mcu_i2c_banks[4];
 
-const mcu_periph_obj_t mcu_i2c_sda_list[12];
-const mcu_periph_obj_t mcu_i2c_scl_list[12];
+extern const mcu_periph_obj_t mcu_i2c_sda_list[12];
+extern const mcu_periph_obj_t mcu_i2c_scl_list[12];
 
 //SPI
 extern SPI_TypeDef * mcu_spi_banks[6];
 
-const mcu_periph_obj_t mcu_spi_sck_list[18];
-const mcu_periph_obj_t mcu_spi_mosi_list[18];
-const mcu_periph_obj_t mcu_spi_miso_list[15];
+extern const mcu_periph_obj_t mcu_spi_sck_list[18];
+extern const mcu_periph_obj_t mcu_spi_mosi_list[18];
+extern const mcu_periph_obj_t mcu_spi_miso_list[15];
 
 //UART
 extern USART_TypeDef * mcu_uart_banks[MAX_UART];
 extern bool mcu_uart_has_usart[MAX_UART];
 
-const mcu_periph_obj_t mcu_uart_tx_list[24];
-const mcu_periph_obj_t mcu_uart_rx_list[25];
+extern const mcu_periph_obj_t mcu_uart_tx_list[24];
+extern const mcu_periph_obj_t mcu_uart_rx_list[25];
 
 //Timers
 #define TIM_BANK_ARRAY_LEN 14
 #define TIM_PIN_ARRAY_LEN 55
-TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
+extern TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
 
-const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
+extern const mcu_tim_pin_obj_t mcu_tim_pin_list[TIM_PIN_ARRAY_LEN];
 
 #endif // MICROPY_INCLUDED_STM32_PERIPHERALS_STM32F767XX_PERIPH_H

--- a/ports/stm/peripherals/stm32h7/stm32h743xx/periph.h
+++ b/ports/stm/peripherals/stm32h7/stm32h743xx/periph.h
@@ -30,26 +30,26 @@
 //I2C
 extern I2C_TypeDef * mcu_i2c_banks[4];
 
-const mcu_periph_obj_t mcu_i2c_sda_list[12];
-const mcu_periph_obj_t mcu_i2c_scl_list[12];
+extern const mcu_periph_obj_t mcu_i2c_sda_list[12];
+extern const mcu_periph_obj_t mcu_i2c_scl_list[12];
 
 //SPI
 extern SPI_TypeDef * mcu_spi_banks[6];
 
-const mcu_periph_obj_t mcu_spi_sck_list[19];
-const mcu_periph_obj_t mcu_spi_mosi_list[19];
-const mcu_periph_obj_t mcu_spi_miso_list[16];
+extern const mcu_periph_obj_t mcu_spi_sck_list[19];
+extern const mcu_periph_obj_t mcu_spi_mosi_list[19];
+extern const mcu_periph_obj_t mcu_spi_miso_list[16];
 
 //UART
 extern USART_TypeDef * mcu_uart_banks[MAX_UART];
 extern bool mcu_uart_has_usart[MAX_UART];
 
-const mcu_periph_obj_t mcu_uart_tx_list[25];
-const mcu_periph_obj_t mcu_uart_rx_list[26];
+extern const mcu_periph_obj_t mcu_uart_tx_list[25];
+extern const mcu_periph_obj_t mcu_uart_rx_list[26];
 
 //Timers
 #define TIM_BANK_ARRAY_LEN 14
 #define TIM_PIN_ARRAY_LEN 58
-TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
+extern TIM_TypeDef * mcu_tim_banks[TIM_BANK_ARRAY_LEN];
 
 #endif // MICROPY_INCLUDED_STM32_PERIPHERALS_STM32H743XX_PERIPH_H

--- a/ports/stm/supervisor/internal_flash.c
+++ b/ports/stm/supervisor/internal_flash.c
@@ -177,13 +177,13 @@ void port_internal_flash_flush(void) {
     EraseInitStruct.VoltageRange = VOLTAGE_RANGE_3; // voltage range needs to be 2.7V to 3.6V
     // get the sector information
     uint32_t sector_size;
-    uint32_t sector_start_addr;
+    uint32_t sector_start_addr = 0xffffffff;
     #if defined(STM32H7)
     EraseInitStruct.Banks = get_bank(_cache_flash_addr);
     #endif
     EraseInitStruct.Sector = flash_get_sector_info(_cache_flash_addr, &sector_start_addr, &sector_size);
     EraseInitStruct.NbSectors = 1;
-    if (sector_size > sizeof(_flash_cache)) {
+    if (sector_size > sizeof(_flash_cache) || sector_start_addr == 0xffffffff) {
         reset_into_safe_mode(FLASH_WRITE_FAIL);
     }
 

--- a/shared-bindings/_bleio/Adapter.h
+++ b/shared-bindings/_bleio/Adapter.h
@@ -35,7 +35,7 @@
 #include "py/objstr.h"
 #include "shared-module/_bleio/Address.h"
 
-const mp_obj_type_t bleio_adapter_type;
+extern const mp_obj_type_t bleio_adapter_type;
 
 extern bool common_hal_bleio_adapter_get_advertising(bleio_adapter_obj_t *self);
 extern bool common_hal_bleio_adapter_get_enabled(bleio_adapter_obj_t *self);

--- a/shared-bindings/_bleio/Service.h
+++ b/shared-bindings/_bleio/Service.h
@@ -34,7 +34,7 @@
 
 #include "py/objtuple.h"
 
-const mp_obj_type_t bleio_service_type;
+extern const mp_obj_type_t bleio_service_type;
 
 // Private version that doesn't allocate on the heap
 extern uint32_t _common_hal_bleio_service_construct(bleio_service_obj_t *self, bleio_uuid_obj_t *uuid, bool is_secondary, mp_obj_list_t * characteristic_list);

--- a/shared-bindings/gnss/PositionFix.h
+++ b/shared-bindings/gnss/PositionFix.h
@@ -13,7 +13,7 @@ typedef enum {
     POSITIONFIX_3D,
 } gnss_positionfix_t;
 
-const mp_obj_type_t gnss_positionfix_type;
+extern const mp_obj_type_t gnss_positionfix_type;
 
 gnss_positionfix_t gnss_positionfix_obj_to_type(mp_obj_t obj);
 mp_obj_t gnss_positionfix_type_to_obj(gnss_positionfix_t mode);

--- a/shared-bindings/gnss/SatelliteSystem.h
+++ b/shared-bindings/gnss/SatelliteSystem.h
@@ -16,7 +16,7 @@ typedef enum {
     SATELLITESYSTEM_QZSS_L1S   = (1U << 4),
 } gnss_satellitesystem_t;
 
-const mp_obj_type_t gnss_satellitesystem_type;
+extern const mp_obj_type_t gnss_satellitesystem_type;
 
 gnss_satellitesystem_t gnss_satellitesystem_obj_to_type(mp_obj_t obj);
 mp_obj_t gnss_satellitesystem_type_to_obj(gnss_satellitesystem_t mode);

--- a/shared-bindings/watchdog/WatchDogMode.h
+++ b/shared-bindings/watchdog/WatchDogMode.h
@@ -35,7 +35,7 @@ typedef enum {
     WATCHDOGMODE_RESET,
 } watchdog_watchdogmode_t;
 
-const mp_obj_type_t watchdog_watchdogmode_type;
+extern const mp_obj_type_t watchdog_watchdogmode_type;
 
 watchdog_watchdogmode_t watchdog_watchdogmode_obj_to_type(mp_obj_t obj);
 mp_obj_t watchdog_watchdogmode_type_to_obj(watchdog_watchdogmode_t mode);


### PR DESCRIPTION
While this PR originally switched to gcc10, it wasn't working out right now.  However, we can safely add these extern declarations to help next time we take a bite at it.

```
-        wget https://adafruit-circuit-python.s3.amazonaws.com/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2
-        sudo tar -C /usr --strip-components=1 -xaf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2
+        wget https://adafruit-circuit-python.s3.amazonaws.com/gcc-arm-none-eabi-10-2020-q2-preview-x86_64-linux.tar.bz2
+        sudo tar -C /usr --strip-components=1 -xaf gcc-arm-none-eabi-10-2020-q2-preview-x86_64-linux.tar.bz2
```