### PR TITLE
framebufferdisplay: Allow implementation of framebuffers in Python

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1542,6 +1542,14 @@ NORETURN void mp_raise_ImportError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_ImportError, msg);
 }
 
+NORETURN void mp_raise_IndexError_varg(const compressed_string_t *fmt, ...) {
+    va_list argptr;
+    va_start(argptr,fmt);
+    mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_IndexError, fmt, argptr);
+    va_end(argptr);
+    nlr_raise(exception);
+}
+
 NORETURN void mp_raise_IndexError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_IndexError, msg);
 }

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -160,6 +160,7 @@ NORETURN void mp_raise_AttributeError(const compressed_string_t *msg);
 NORETURN void mp_raise_RuntimeError(const compressed_string_t *msg);
 NORETURN void mp_raise_ImportError(const compressed_string_t *msg);
 NORETURN void mp_raise_IndexError(const compressed_string_t *msg);
+NORETURN void mp_raise_IndexError_varg(const compressed_string_t *fmt, ...);
 NORETURN void mp_raise_OSError(int errno_);
 NORETURN void mp_raise_OSError_errno_str(int errno_, mp_obj_t str);
 NORETURN void mp_raise_OSError_msg(const compressed_string_t *msg);

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -253,6 +253,13 @@ void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebu
     if (self->row_stride == 0) {
         self->row_stride = self->core.width * self->core.colorspace.depth/8;
     }
+
+    self->framebuffer_protocol->get_bufinfo(self->framebuffer, &self->bufinfo);
+    size_t framebuffer_size = self->first_pixel_offset + self->row_stride * self->core.height;
+    if (self->bufinfo.len < framebuffer_size) {
+        mp_raise_IndexError_varg(translate("Framebuffer requires %d bytes"), framebuffer_size);
+    }
+
     self->first_manual_refresh = !auto_refresh;
 
     self->native_frames_per_second = self->framebuffer_protocol->get_native_frames_per_second(self->framebuffer);

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -309,6 +309,7 @@ void release_framebufferdisplay(framebufferio_framebufferdisplay_obj_t* self) {
     common_hal_framebufferio_framebufferdisplay_set_auto_refresh(self, false);
     release_display_core(&self->core);
     self->framebuffer_protocol->deinit(self->framebuffer);
+    self->base.type = &mp_type_NoneType;
 }
 
 void reset_framebufferdisplay(framebufferio_framebufferdisplay_obj_t* self) {

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -219,12 +219,14 @@ STATIC void _refresh_display(framebufferio_framebufferdisplay_obj_t* self) {
     displayio_display_core_start_refresh(&self->core);
     self->framebuffer_protocol->get_bufinfo(self->framebuffer, &self->bufinfo);
     const displayio_area_t* current_area = _get_refresh_areas(self);
-    while (current_area != NULL) {
-        _refresh_area(self, current_area);
-        current_area = current_area->next;
+    if (current_area) {
+        while (current_area != NULL) {
+            _refresh_area(self, current_area);
+            current_area = current_area->next;
+        }
+        self->framebuffer_protocol->swapbuffers(self->framebuffer);
     }
     displayio_display_core_finish_refresh(&self->core);
-    self->framebuffer_protocol->swapbuffers(self->framebuffer);
 }
 
 void common_hal_framebufferio_framebufferdisplay_set_rotation(framebufferio_framebufferdisplay_obj_t* self, int rotation){

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -299,6 +299,14 @@ STATIC bool _refresh_area(framebufferio_framebufferdisplay_obj_t* self, const di
         return true;
     }
     uint16_t subrectangles = 1;
+
+    // If pixels are packed by row then rows are on byte boundaries
+    if (self->core.colorspace.depth < 8 && self->core.colorspace.pixels_in_byte_share_row) {
+        int div = 8 / self->core.colorspace.depth;
+        clipped.x1 = (clipped.x1 / div) * div;
+        clipped.x2 = ((clipped.x2 + div - 1) / div) * div;
+    }
+
     uint16_t rows_per_buffer = displayio_area_height(&clipped);
     uint8_t pixels_per_word = (sizeof(uint32_t) * 8) / self->core.colorspace.depth;
     uint16_t pixels_per_buffer = displayio_area_size(&clipped);
@@ -339,6 +347,7 @@ STATIC bool _refresh_area(framebufferio_framebufferdisplay_obj_t* self, const di
             .x2 = clipped.x2,
             .y2 = clipped.y1 + rows_per_buffer * (j + 1)
         };
+
         if (remaining_rows < rows_per_buffer) {
             subrectangle.y2 = subrectangle.y1 + remaining_rows;
         }
@@ -349,12 +358,14 @@ STATIC bool _refresh_area(framebufferio_framebufferdisplay_obj_t* self, const di
 
         displayio_display_core_fill_area(&self->core, &subrectangle, mask, buffer);
 
-        // COULDDO: this arithmetic only supports multiple-of-8 bpp
-        uint8_t *dest = self->bufinfo.buf + (subrectangle.y1 * self->core.width + subrectangle.x1) * (self->core.colorspace.depth / 8);
+        uint8_t *buf = (uint8_t *)self->bufinfo.buf, *endbuf = buf + self->bufinfo.len;
+
+        uint8_t *dest = self->bufinfo.buf + (subrectangle.y1 * self->core.width + subrectangle.x1) * self->core.colorspace.depth / 8;
         uint8_t *src = (uint8_t*)buffer;
-        size_t rowsize = (subrectangle.x2 - subrectangle.x1) * (self->core.colorspace.depth / 8);
-        size_t rowstride = self->core.width * (self->core.colorspace.depth/8);
+        size_t rowsize = (subrectangle.x2 - subrectangle.x1) * self->core.colorspace.depth / 8;
+        size_t rowstride = self->core.width * self->core.colorspace.depth/8;
         for (uint16_t i = subrectangle.y1; i < subrectangle.y2; i++) {
+            assert(dest >= buf && dest < endbuf && dest+rowsize <= endbuf);
             memcpy(dest, src, rowsize);
             dest += rowstride;
             src += rowsize;

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -40,6 +40,152 @@
 #include <stdint.h>
 #include <string.h>
 
+typedef struct {
+    mp_obj_base_t base;
+    mp_obj_t m_deinit[2];
+    mp_obj_t m_get_brightness[2];
+    mp_obj_t m_get_auto_brightness[2];
+    mp_obj_t m_get_buffer[2];
+    mp_obj_t m_get_bytes_per_cell[2];
+    mp_obj_t m_get_color_depth[2];
+    mp_obj_t m_get_height[2];
+    mp_obj_t m_get_native_frames_per_second[2];
+    mp_obj_t m_get_width[2];
+    mp_obj_t m_set_brightness[3];
+    mp_obj_t m_set_auto_brightness[3];
+    mp_obj_t m_swapbuffers[2];
+} framebufferio_shim_obj_t;
+
+void framebufferio_shim_deinit(void *self_in) {
+    framebufferio_shim_obj_t *self = self_in;
+    if (self->m_deinit[0]) {
+        mp_call_method_n_kw(0, 0, self->m_deinit);
+    }
+}
+
+bool framebufferio_shim_get_auto_brightness(void *self_in) {
+    framebufferio_shim_obj_t *self = self_in;
+    if (self->m_get_auto_brightness[0]) {
+        return mp_obj_is_true(mp_call_method_n_kw(0, 0, self->m_get_auto_brightness));
+    }
+    return false;
+}
+
+mp_float_t framebufferio_shim_get_brightness(void *self_in) {
+    framebufferio_shim_obj_t *self = self_in;
+    if (self->m_get_brightness[0]) {
+        return mp_obj_get_float(mp_call_method_n_kw(0, 0, self->m_get_brightness));
+    }
+    return -1;
+}
+
+void framebufferio_shim_get_bufinfo(void *self_in, mp_buffer_info_t *bufinfo) {
+    framebufferio_shim_obj_t *self = self_in;
+    mp_obj_t info = mp_call_method_n_kw(0, 0, self->m_get_buffer);
+    mp_get_buffer_raise(info, bufinfo, MP_BUFFER_WRITE);
+}
+
+int framebufferio_shim_get_bytes_per_cell(void *self_in) {
+    framebufferio_shim_obj_t *self = self_in;
+    if (self->m_get_bytes_per_cell[0]) {
+        return mp_obj_get_int(mp_call_method_n_kw(0, 0, self->m_get_bytes_per_cell));
+    }
+    return 1;
+}
+
+int framebufferio_shim_get_color_depth(void *self_in) {
+    framebufferio_shim_obj_t *self = self_in;
+    if (self->m_get_color_depth[0]) {
+        return mp_obj_get_int(mp_call_method_n_kw(0, 0, self->m_get_color_depth));
+    }
+    return 16;
+}
+
+int framebufferio_shim_get_height(void *self_in) {
+    framebufferio_shim_obj_t *self = self_in;
+    return mp_obj_get_int(mp_call_method_n_kw(0, 0, self->m_get_height));
+}
+
+int framebufferio_shim_get_native_frames_per_second(void *self_in) {
+    framebufferio_shim_obj_t *self = self_in;
+    if (self->m_get_native_frames_per_second[0]) {
+        return mp_obj_get_int(mp_call_method_n_kw(0, 0, self->m_get_native_frames_per_second));
+    }
+    return 60;
+}
+
+
+int framebufferio_shim_get_width(void *self_in) {
+    framebufferio_shim_obj_t *self = self_in;
+    return mp_obj_get_int(mp_call_method_n_kw(0, 0, self->m_get_width));
+}
+
+bool framebufferio_shim_set_auto_brightness(void *self_in, bool auto_brightness) {
+    framebufferio_shim_obj_t *self = self_in;
+    if (self->m_set_auto_brightness[0]) {
+        self->m_set_auto_brightness[2] = mp_obj_new_bool(auto_brightness);
+        return mp_obj_is_true(mp_call_method_n_kw(1, 0, self->m_set_auto_brightness));
+    }
+    return false;
+}
+
+
+bool framebufferio_shim_set_brightness(void *self_in, mp_float_t brightness) {
+    framebufferio_shim_obj_t *self = self_in;
+    if (self->m_set_brightness) {
+        self->m_set_brightness[2] = mp_obj_new_float(brightness);
+        return mp_obj_is_true(mp_call_method_n_kw(0, 0, self->m_set_brightness));
+    }
+    return false;
+}
+
+
+void framebufferio_shim_swapbuffers(void *self_in) {
+    framebufferio_shim_obj_t *self = self_in;
+    mp_call_method_n_kw(0, 0, self->m_swapbuffers);
+}
+
+STATIC const framebuffer_p_t framebufferio_shim_proto = {
+    MP_PROTO_IMPLEMENT(MP_QSTR_protocol_framebuffer)
+    .deinit = framebufferio_shim_deinit,
+    .get_auto_brightness = framebufferio_shim_get_auto_brightness,
+    .get_brightness = framebufferio_shim_get_brightness,
+    .get_bufinfo = framebufferio_shim_get_bufinfo,
+    .get_bytes_per_cell = framebufferio_shim_get_bytes_per_cell,
+    .get_color_depth = framebufferio_shim_get_color_depth,
+    .get_height = framebufferio_shim_get_height,
+    .get_native_frames_per_second = framebufferio_shim_get_native_frames_per_second,
+    .get_width = framebufferio_shim_get_width,
+    .set_auto_brightness = framebufferio_shim_set_auto_brightness,
+    .set_brightness = framebufferio_shim_set_brightness,
+    .swapbuffers = framebufferio_shim_swapbuffers,
+};
+
+STATIC mp_obj_type_t framebufferio_shim_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_framebuffer_shim,
+    // .buffer_p = { .get_buffer = framebufferio_shim_get_buffer, },
+    .protocol = &framebufferio_shim_proto,
+};
+
+STATIC void framebufferio_shim_construct(framebufferio_shim_obj_t *self, mp_obj_t *obj) {
+    self->base.type = &framebufferio_shim_type;
+    // mandatory methods
+    mp_load_method(obj, MP_QSTR_get_buffer, self->m_get_buffer);
+    mp_load_method(obj, MP_QSTR_get_height, self->m_get_height);
+    mp_load_method(obj, MP_QSTR_get_width, self->m_get_width);
+    mp_load_method(obj, MP_QSTR_swapbuffers, self->m_swapbuffers);
+
+    // optional methods
+    mp_load_method_maybe(obj, MP_QSTR_deinit, self->m_deinit);
+    mp_load_method_maybe(obj, MP_QSTR_get_brightness, self->m_get_brightness);
+    mp_load_method_maybe(obj, MP_QSTR_get_bytes_per_cell, self->m_get_bytes_per_cell);
+    mp_load_method_maybe(obj, MP_QSTR_get_color_depth, self->m_get_color_depth);
+    mp_load_method_maybe(obj, MP_QSTR_get_native_frames_per_second, self->m_get_native_frames_per_second);
+    mp_load_method_maybe(obj, MP_QSTR_set_auto_brightness, self->m_set_auto_brightness);
+    mp_load_method_maybe(obj, MP_QSTR_set_brightness, self->m_set_brightness);
+}
+
 void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebufferdisplay_obj_t* self,
         mp_obj_t framebuffer,
         uint16_t rotation,
@@ -47,7 +193,13 @@ void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebu
     // Turn off auto-refresh as we init.
     self->auto_refresh = false;
     self->framebuffer = framebuffer;
-    self->framebuffer_protocol = mp_proto_get_or_throw(MP_QSTR_protocol_framebuffer, framebuffer);
+    self->framebuffer_protocol = mp_proto_get(MP_QSTR_protocol_framebuffer, framebuffer);
+    if (!self->framebuffer_protocol) {
+        framebufferio_shim_obj_t *shim = m_new_obj(framebufferio_shim_obj_t);
+        framebufferio_shim_construct(shim, framebuffer);
+        self->framebuffer = shim;
+        self->framebuffer_protocol = mp_proto_get_or_throw(MP_QSTR_protocol_framebuffer, shim);
+    }
 
     uint16_t ram_width = 0x100;
     uint16_t ram_height = 0x100;
@@ -323,6 +475,12 @@ void framebufferio_framebufferdisplay_collect_ptrs(framebufferio_framebufferdisp
 }
 
 void framebufferio_framebufferdisplay_reset(framebufferio_framebufferdisplay_obj_t* self) {
-    common_hal_framebufferio_framebufferdisplay_set_auto_refresh(self, true);
-    common_hal_framebufferio_framebufferdisplay_show(self, NULL);
+    if (self->framebuffer_protocol == &framebufferio_shim_proto) {
+        // A shim framebuffer cannot survive soft reset, because it refers to Python objects
+        // which no longer exist.  Instead, we must release it.
+        release_framebufferdisplay(self);
+    } else {
+        common_hal_framebufferio_framebufferdisplay_set_auto_refresh(self, true);
+        common_hal_framebufferio_framebufferdisplay_show(self, NULL);
+    }
 }

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -109,7 +109,7 @@ bool common_hal_framebufferio_framebufferdisplay_set_auto_brightness(framebuffer
 }
 
 mp_float_t common_hal_framebufferio_framebufferdisplay_get_brightness(framebufferio_framebufferdisplay_obj_t* self) {
-    if (self->framebuffer_protocol->set_brightness) {
+    if (self->framebuffer_protocol->get_brightness) {
         return self->framebuffer_protocol->get_brightness(self->framebuffer);
     }
     return -1;

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -203,7 +203,7 @@ void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebu
 
     uint16_t ram_width = 0x100;
     uint16_t ram_height = 0x100;
-
+    uint16_t depth = self->framebuffer_protocol->get_color_depth(self->framebuffer);
     displayio_display_core_construct(
         &self->core,
         NULL,
@@ -214,12 +214,13 @@ void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebu
         0,
         0,
         rotation,
-        self->framebuffer_protocol->get_color_depth(self->framebuffer),
-        false,
-        false,
+        depth,
+        (depth < 12), // grayscale
+        true, // pixels_in_byte_share_row
         self->framebuffer_protocol->get_bytes_per_cell(self->framebuffer),
-        false,
-        false);
+        true, // reverse_pixels_in_byte
+        false // reverse_bytes_in_word
+    );
 
     self->first_manual_refresh = !auto_refresh;
 

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -360,6 +360,7 @@ STATIC bool _refresh_area(framebufferio_framebufferdisplay_obj_t* self, const di
         displayio_display_core_fill_area(&self->core, &subrectangle, mask, buffer);
 
         uint8_t *buf = (uint8_t *)self->bufinfo.buf, *endbuf = buf + self->bufinfo.len;
+        (void)endbuf; // Hint to compiler that endbuf is "used" even if NDEBUG
 
         uint8_t *dest = self->bufinfo.buf + (subrectangle.y1 * self->core.width + subrectangle.x1) * self->core.colorspace.depth / 8;
         uint8_t *src = (uint8_t*)buffer;

--- a/shared-module/framebufferio/FramebufferDisplay.h
+++ b/shared-module/framebufferio/FramebufferDisplay.h
@@ -48,6 +48,7 @@ typedef struct {
     uint64_t last_refresh_call;
     uint16_t native_frames_per_second;
     uint16_t native_ms_per_frame;
+    uint16_t first_pixel_offset, row_stride;
     bool auto_refresh;
     bool first_manual_refresh;
 } framebufferio_framebufferdisplay_obj_t;
@@ -70,6 +71,8 @@ typedef bool (*framebuffer_set_auto_brightness_fun)(mp_obj_t, bool);
 typedef bool (*framebuffer_get_auto_brightness_fun)(mp_obj_t);
 typedef int (*framebuffer_get_width_fun)(mp_obj_t);
 typedef int (*framebuffer_get_height_fun)(mp_obj_t);
+typedef int (*framebuffer_get_row_stride_fun)(mp_obj_t);
+typedef int (*framebuffer_get_first_pixel_offset_fun)(mp_obj_t);
 typedef int (*framebuffer_get_color_depth_fun)(mp_obj_t);
 typedef int (*framebuffer_get_bytes_per_cell_fun)(mp_obj_t);
 typedef int (*framebuffer_get_native_frames_per_second_fun)(mp_obj_t);
@@ -86,6 +89,8 @@ typedef struct _framebuffer_p_t {
     framebuffer_get_native_frames_per_second_fun get_native_frames_per_second;
     framebuffer_get_brightness_fun get_brightness;
     framebuffer_set_brightness_fun set_brightness;
+    framebuffer_get_row_stride_fun get_row_stride;
+    framebuffer_get_first_pixel_offset_fun get_first_pixel_offset;
     framebuffer_get_auto_brightness_fun get_auto_brightness;
     framebuffer_set_auto_brightness_fun set_auto_brightness;
 } framebuffer_p_t;


### PR DESCRIPTION
This comes in several parts.  Everything but the hypothetical `adafruit_displayio_sharpmemory` is in this PR:

## Shim framebuffer protocol
Allows pure Python objects to implement the framebuffer protocol.  However, because these displays are Python objects, they do not survive soft-reset.

A do-nothing implementation might read as follows:
```
class UFrame:
    def __init__(self, *, width=64, height=32, color_depth=8):
        if color_depth not in (1, 8, 16):
            raise ValueError("only supports 1, 8 or 16 bit depth")
        xwidth = (7 + width) // 8 if color_depth == 1 else width
        dtype = ulab.uint16 if color_depth == 16 else ulab.uint8
        self.buffer = ulab.zeros((height, xwidth), dtype=dtype)
        self.height = height
        self.width = width
        self.color_depth = color_depth
        print(self.width)

    def get_color_depth(self):
        return self.color_depth

    def get_buffer(self):
        return self.buffer

    def get_height(self):
        return self.height

    def get_width(self):
        return self.width

    def swapbuffers(self):
        pass
```

## Supporting 1 (and probably 2 and 4) bpp displays
There was a *COULDDO* about this.  It is handled by rounding the X coordinates to be computed to byte boundaries.

## Bug fixing
I noticed or encountered bugs along the way.
```
framebufferio: Fix crash calling unimplemented get_brightness
framebufferio: Don't call swapbuffers unnecessarily
framebufferio: Set type to none when releasing
```

One I did _NOT_ fix is that an 8x8 display causes an infinite loop.  If 8x8 displays become interesting for displayio we can look at it again.

## Shortcomings
I hard-coded the fact that the Sharp Memory Display needs pixels in the "reverse_pixels_in_byte" direction.  This is subject to change, depending whether we merge the LSBfirst SPI feature branch.  Ultimately, it might not be necessary for this PR, but all the "knobs" provided by displayio_display_core_construct should be turnable from C and Python implementations of framebuffers

## `adafruit_displayio_sharpmemory.py`
This was a SUPER EASY conversion from the old framebuf version!  I don't know what other kinds of displays haven't been converted yet, but this might make them all "pretty easy".  Once we commit to this approcah, it needs to be librarified, added to bundle, etc.

```
--- adafruit_sharpmemorydisplay.py	2020-05-05 09:09:03.679323691 -0500
+++ displayio_sharpmemory.py	2020-07-31 15:34:56.000000000 -0500
@@ -67,7 +67,7 @@
     return result
 
 
-class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
+class SharpMemoryDisplay:
     """A driver for sharp memory displays, you can use any size but the
     full display must be buffered in memory!"""
 
@@ -86,12 +85,26 @@
         # even tho technically this display is LSB, we have to flip the bits
         # when writing out SPI so lets just do flipping once, in the buffer
         self.buffer = bytearray((width // 8) * height)
-        super().__init__(self.buffer, width, height, buf_format=adafruit_framebuf.MHMSB)
 
         # Set the vcom bit to a defined state
         self._vcom = True
 
-    def show(self):
+        self.width = width
+        self.height = height
+
+    def get_color_depth(self):
+        return 1
+
+    def get_buffer(self):
+        return self.buffer
+
+    def get_height(self):
+        return self.height
+
+    def get_width(self):
+        return self.width
+
+    def swapbuffers(self):
         """write out the frame buffer via SPI, we use MSB SPI only so some
         bit-swapping is rquired. The display also uses inverted CS for some
         reason so we con't use bus_device"""
```

```
# The MIT License (MIT)
#
# Copyright (c) 2018 ladyada for Adafruit Industries
#
# Permission is hereby granted, free of charge, to any person obtaining a copy
# of this software and associated documentation files (the "Software"), to deal
# in the Software without restriction, including without limitation the rights
# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
# copies of the Software, and to permit persons to whom the Software is
# furnished to do so, subject to the following conditions:
#
# The above copyright notice and this permission notice shall be included in
# all copies or substantial portions of the Software.
#
# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
# THE SOFTWARE.

# pylint: disable=line-too-long
"""
`adafruit_sharpmemorydisplay`
====================================================

A display control library for Sharp 'memory' displays

* Author(s): ladyada

Implementation Notes
--------------------

**Hardware:**

* `Adafruit SHARP Memory Display Breakout - 1.3 inch 144x168 Monochrome <https://www.adafruit.com/product/3502>`_

* `Adafruit SHARP Memory Display Breakout - 1.3 inch 96x96 Monochrome <https://www.adafruit.com/product/1393>`_

**Software and Dependencies:**

* Adafruit CircuitPython firmware for the supported boards:
  https://github.com/adafruit/circuitpython/releases

"""
# pylint: enable=line-too-long

from micropython import const

__version__ = "0.0.0-auto.0"
__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SharpMemoryDisplay.git"

_SHARPMEM_BIT_WRITECMD = const(0x80)  # in lsb
_SHARPMEM_BIT_VCOM = const(0x40)  # in lsb
_SHARPMEM_BIT_CLEAR = const(0x20)  # in lsb


def reverse_bit(num):
    """Turn an LSB byte to an MSB byte, and vice versa. Used for SPI as
    it is LSB for the SHARP, but 99% of SPI implementations are MSB only!"""
    result = 0
    for _ in range(8):
        result <<= 1
        result += num & 1
        num >>= 1
    return result


class SharpMemoryDisplay:
    """A driver for sharp memory displays, you can use any size but the
    full display must be buffered in memory!"""

    # pylint: disable=too-many-instance-attributes,abstract-method

    def __init__(self, spi, scs_pin, width, height, *, baudrate=8000000):
        self._scs_pin = scs_pin
        scs_pin.switch_to_output(value=True)
        self._baudrate = baudrate
        # The SCS pin is active HIGH so we can't use bus_device. exciting!
        self._spi = spi
        # prealloc for when we write the display
        self._buf = bytearray(1)

        # even tho technically this display is LSB, we have to flip the bits
        # when writing out SPI so lets just do flipping once, in the buffer
        self.buffer = bytearray((width // 8) * height)

        # Set the vcom bit to a defined state
        self._vcom = True

        self.width = width
        self.height = height

    def get_color_depth(self):
        return 1

    def get_buffer(self):
        return self.buffer

    def get_height(self):
        return self.height

    def get_width(self):
        return self.width

    def swapbuffers(self):
        """write out the frame buffer via SPI, we use MSB SPI only so some
        bit-swapping is rquired. The display also uses inverted CS for some
        reason so we con't use bus_device"""

        # CS pin is inverted so we have to do this all by hand
        while not self._spi.try_lock():
            pass
        self._spi.configure(baudrate=self._baudrate)
        self._scs_pin.value = True

        # toggle the VCOM bit
        self._buf[0] = _SHARPMEM_BIT_WRITECMD
        if self._vcom:
            self._buf[0] |= _SHARPMEM_BIT_VCOM
        self._vcom = not self._vcom
        self._spi.write(self._buf)

        slice_from = 0
        line_len = self.width // 8
        for line in range(self.height):
            self._buf[0] = reverse_bit(line + 1)
            self._spi.write(self._buf)
            self._spi.write(memoryview(self.buffer[slice_from : slice_from + line_len]))
            slice_from += line_len
            self._buf[0] = 0
            self._spi.write(self._buf)
        self._spi.write(self._buf)  # we send one last 0 byte
        self._scs_pin.value = False
        self._spi.unlock()
```

## `go.py`
Import this in your program or repl to get the display going.
```
import board
import digitalio
import displayio
import adafruit_displayio_sharpmemory
import framebufferio

displayio.release_displays()


buf = adafruit_displayio_sharpmemory.SharpMemoryDisplay(spi=board.SPI(), scs_pin=digitalio.DigitalInOut(board.D3), width=144, height=168)
display = framebufferio.FramebufferDisplay(buf)

```