### PR TITLE
Firmware size savings

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -520,7 +520,7 @@ STATIC mp_obj_t uctypes_struct_subscr(mp_obj_t base_in, mp_obj_t index_in, mp_ob
             uint val_type = GET_TYPE(arr_sz, VAL_TYPE_BITS);
             arr_sz &= VALUE_MASK(VAL_TYPE_BITS);
             if (index >= arr_sz) {
-                nlr_raise(mp_obj_new_exception_msg(&mp_type_IndexError, translate("struct: index out of range")));
+                mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_struct);
             }
 
             if (t->len == 2) {

--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -42,7 +42,7 @@ const byte fresult_to_errno_table[20] = {
 
 STATIC void file_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
-    mp_printf(print, "<io.%s %p>", mp_obj_get_type_str(self_in), MP_OBJ_TO_PTR(self_in));
+    mp_printf(print, "<io.%q %p>", mp_obj_get_type_qstr(self_in), MP_OBJ_TO_PTR(self_in));
 }
 
 STATIC mp_uint_t file_obj_read(mp_obj_t self_in, void *buf, mp_uint_t size, int *errcode) {

--- a/extmod/vfs_posix_file.c
+++ b/extmod/vfs_posix_file.c
@@ -34,7 +34,7 @@ STATIC void check_fd_is_open(const mp_obj_vfs_posix_file_t *o) {
 STATIC void vfs_posix_file_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_vfs_posix_file_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<io.%s %d>", mp_obj_get_type_str(self_in), self->fd);
+    mp_printf(print, "<io.%q %d>", mp_obj_get_type_qstr(self_in), self->fd);
 }
 
 mp_obj_t mp_vfs_posix_file_open(const mp_obj_type_t *type, mp_obj_t file_in, mp_obj_t mode_in) {

--- a/lib/libm/ef_rem_pio2.c
+++ b/lib/libm/ef_rem_pio2.c
@@ -35,9 +35,9 @@
  * Table of constants for 2/pi, 396 Hex digits (476 decimal) of 2/pi
  */
 #ifdef __STDC__
-static const __int32_t two_over_pi[] = {
+static const __uint8_t two_over_pi[] = {
 #else
-static __int32_t two_over_pi[] = {
+static __uint8_t two_over_pi[] = {
 #endif
 0xA2, 0xF9, 0x83, 0x6E, 0x4E, 0x44, 0x15, 0x29, 0xFC,
 0x27, 0x57, 0xD1, 0xF5, 0x34, 0xDD, 0xC0, 0xDB, 0x62,

--- a/lib/libm/ef_rem_pio2.c
+++ b/lib/libm/ef_rem_pio2.c
@@ -145,6 +145,7 @@ pio2_3t =  6.1232342629e-17; /* 0x248d3132 */
 		return -1;
 	    }
 	}
+#if CIRCUITPY_FULL_BUILD
 	if(ix<=0x43490f80) { /* |x| ~<= 2^7*(pi/2), medium size */
 	    t  = fabsf(x);
 	    n  = (__int32_t) (t*invpio2+half);
@@ -180,6 +181,11 @@ pio2_3t =  6.1232342629e-17; /* 0x248d3132 */
 	    if(hx<0) 	{y[0] = -y[0]; y[1] = -y[1]; return -n;}
 	    else	 return n;
 	}
+#else
+        // Suppress "defined but not used" diagnostics
+        (void) j; (void) fn; (void) r; (void) t; (void) w; (void) pio2_3t;
+        (void) pio2_3; (void) invpio2; (void)half; (void)npio2_hw;
+#endif
     /*
      * all other (large) arguments
      */

--- a/lib/libm/fdlibm.h
+++ b/lib/libm/fdlibm.h
@@ -188,7 +188,7 @@ extern float __ieee754_scalbf __P((float,float));
 extern float __kernel_sinf __P((float,float,int));
 extern float __kernel_cosf __P((float,float));
 extern float __kernel_tanf __P((float,float,int));
-extern int   __kernel_rem_pio2f __P((float*,float*,int,int,int,const __int32_t*));
+extern int   __kernel_rem_pio2f __P((float*,float*,int,int,int,const __uint8_t*));
 
 /* A union which permits us to convert between a float and a 32 bit
    int.  */

--- a/lib/libm/kf_rem_pio2.c
+++ b/lib/libm/kf_rem_pio2.c
@@ -62,10 +62,10 @@ two8   =  2.5600000000e+02, /* 0x43800000 */
 twon8  =  3.9062500000e-03; /* 0x3b800000 */
 
 #ifdef __STDC__
-	int __kernel_rem_pio2f(float *x, float *y, int e0, int nx, int prec, const __int32_t *ipio2)
+	int __kernel_rem_pio2f(float *x, float *y, int e0, int nx, int prec, const __uint8_t *ipio2)
 #else
 	int __kernel_rem_pio2f(x,y,e0,nx,prec,ipio2)
-	float x[], y[]; int e0,nx,prec; __int32_t ipio2[];
+	float x[], y[]; int e0,nx,prec; __uint8_t ipio2[];
 #endif
 {
 	__int32_t jz,jx,jv,jp,jk,carry,n,iq[20],i,j,k,m,q0,ih;

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 13:58-0500\n"
+"POT-Creation-Date: 2020-08-04 18:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2894,8 +2894,7 @@ msgstr ""
 #: ports/nrf/common-hal/pulseio/PulseIn.c
 #: ports/stm/common-hal/pulseio/PulseIn.c py/objdict.c py/objlist.c py/objset.c
 #: shared-bindings/ps2io/Ps2.c
-#, c-format
-msgid "pop from empty %s"
+msgid "pop from empty %q"
 msgstr ""
 
 #: py/objint_mpz.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-30 07:23-0500\n"
+"POT-Creation-Date: 2020-08-04 13:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -66,12 +66,16 @@ msgstr ""
 msgid "%q in use"
 msgstr ""
 
-#: py/obj.c
+#: extmod/moductypes.c ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/cxd56/common-hal/pulseio/PulseIn.c
+#: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/stm/common-hal/pulseio/PulseIn.c py/obj.c py/objstr.c
+#: py/objstrunicode.c
 msgid "%q index out of range"
 msgstr ""
 
 #: py/obj.c
-msgid "%q indices must be integers, not %s"
+msgid "%q indices must be integers, not %q"
 msgstr ""
 
 #: shared-bindings/vectorio/Polygon.c
@@ -108,6 +112,42 @@ msgstr ""
 
 #: py/argcheck.c
 msgid "'%q' argument required"
+msgstr ""
+
+#: py/runtime.c
+msgid "'%q' object cannot assign attribute '%q'"
+msgstr ""
+
+#: py/proto.c
+msgid "'%q' object does not support '%q'"
+msgstr ""
+
+#: py/obj.c
+msgid "'%q' object does not support item assignment"
+msgstr ""
+
+#: py/obj.c
+msgid "'%q' object does not support item deletion"
+msgstr ""
+
+#: py/runtime.c
+msgid "'%q' object has no attribute '%q'"
+msgstr ""
+
+#: py/runtime.c
+msgid "'%q' object is not an iterator"
+msgstr ""
+
+#: py/objtype.c py/runtime.c
+msgid "'%q' object is not callable"
+msgstr ""
+
+#: py/runtime.c
+msgid "'%q' object is not iterable"
+msgstr ""
+
+#: py/obj.c
+msgid "'%q' object is not subscriptable"
 msgstr ""
 
 #: py/emitinlinethumb.c py/emitinlinextensa.c
@@ -158,48 +198,6 @@ msgstr ""
 #: py/emitinlinethumb.c
 #, c-format
 msgid "'%s' integer 0x%x does not fit in mask 0x%x"
-msgstr ""
-
-#: py/runtime.c
-msgid "'%s' object cannot assign attribute '%q'"
-msgstr ""
-
-#: py/proto.c
-msgid "'%s' object does not support '%q'"
-msgstr ""
-
-#: py/obj.c
-#, c-format
-msgid "'%s' object does not support item assignment"
-msgstr ""
-
-#: py/obj.c
-#, c-format
-msgid "'%s' object does not support item deletion"
-msgstr ""
-
-#: py/runtime.c
-msgid "'%s' object has no attribute '%q'"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "'%s' object is not an iterator"
-msgstr ""
-
-#: py/objtype.c py/runtime.c
-#, c-format
-msgid "'%s' object is not callable"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "'%s' object is not iterable"
-msgstr ""
-
-#: py/obj.c
-#, c-format
-msgid "'%s' object is not subscriptable"
 msgstr ""
 
 #: py/objstr.c
@@ -1235,6 +1233,10 @@ msgstr ""
 msgid "Not playing"
 msgstr ""
 
+#: main.c
+msgid "Not running saved code.\n"
+msgstr ""
+
 #: shared-bindings/util.c
 msgid ""
 "Object has been deinitialized and can no longer be used. Create a new object."
@@ -1320,10 +1322,6 @@ msgstr ""
 msgid "Polygon needs at least 3 points"
 msgstr ""
 
-#: shared-bindings/ps2io/Ps2.c
-msgid "Pop from an empty Ps2 buffer"
-msgstr ""
-
 #: shared-bindings/_bleio/Adapter.c
 msgid "Prefix buffer must be on the heap"
 msgstr ""
@@ -1396,11 +1394,7 @@ msgid "Row entry must be digitalio.DigitalInOut"
 msgstr ""
 
 #: main.c
-msgid "Running in safe mode! Auto-reload is off.\n"
-msgstr ""
-
-#: main.c
-msgid "Running in safe mode! Not running saved code.\n"
+msgid "Running in safe mode! "
 msgstr ""
 
 #: shared-module/sdcardio/SDCard.c
@@ -1761,8 +1755,7 @@ msgid "__init__() should return None"
 msgstr ""
 
 #: py/objtype.c
-#, c-format
-msgid "__init__() should return None, not '%s'"
+msgid "__init__() should return None, not '%q'"
 msgstr ""
 
 #: py/objobject.c
@@ -1916,7 +1909,7 @@ msgstr ""
 msgid "bytes value out of range"
 msgstr ""
 
-#: ports/atmel-samd/bindings/samd/Clock.c
+#: ports/atmel-samd/bindings/samd/Clock.c ports/atmel-samd/common-hal/rtc/RTC.c
 msgid "calibration is out of range"
 msgstr ""
 
@@ -1948,47 +1941,16 @@ msgstr ""
 msgid "can't assign to expression"
 msgstr ""
 
-#: py/obj.c
-#, c-format
-msgid "can't convert %s to complex"
-msgstr ""
-
-#: py/obj.c
-#, c-format
-msgid "can't convert %s to float"
-msgstr ""
-
-#: py/obj.c
-#, c-format
-msgid "can't convert %s to int"
+#: py/obj.c py/objint.c shared-bindings/i2cperipheral/I2CPeripheral.c
+msgid "can't convert %q to %q"
 msgstr ""
 
 #: py/objstr.c
 msgid "can't convert '%q' object to %q implicitly"
 msgstr ""
 
-#: py/objint.c
-msgid "can't convert NaN to int"
-msgstr ""
-
-#: shared-bindings/i2cperipheral/I2CPeripheral.c
-msgid "can't convert address to int"
-msgstr ""
-
-#: py/objint.c
-msgid "can't convert inf to int"
-msgstr ""
-
 #: py/obj.c
-msgid "can't convert to complex"
-msgstr ""
-
-#: py/obj.c
-msgid "can't convert to float"
-msgstr ""
-
-#: py/obj.c
-msgid "can't convert to int"
+msgid "can't convert to %q"
 msgstr ""
 
 #: py/objstr.c
@@ -2396,7 +2358,7 @@ msgstr ""
 msgid "function missing required positional argument #%d"
 msgstr ""
 
-#: py/argcheck.c py/bc.c py/objnamedtuple.c
+#: py/argcheck.c py/bc.c py/objnamedtuple.c shared-bindings/time/__init__.c
 #, c-format
 msgid "function takes %d positional arguments but %d were given"
 msgstr ""
@@ -2445,10 +2407,7 @@ msgstr ""
 msgid "index is out of bounds"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/cxd56/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c
-#: ports/stm/common-hal/pulseio/PulseIn.c py/obj.c
+#: py/obj.c
 msgid "index out of range"
 msgstr ""
 
@@ -2804,8 +2763,7 @@ msgid "number of points must be at least 2"
 msgstr ""
 
 #: py/obj.c
-#, c-format
-msgid "object '%s' is not a tuple or list"
+msgid "object '%q' is not a tuple or list"
 msgstr ""
 
 #: py/obj.c
@@ -2841,8 +2799,7 @@ msgid "object not iterable"
 msgstr ""
 
 #: py/obj.c
-#, c-format
-msgid "object of type '%s' has no len()"
+msgid "object of type '%q' has no len()"
 msgstr ""
 
 #: py/obj.c
@@ -2935,20 +2892,10 @@ msgstr ""
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #: ports/cxd56/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
-#: ports/stm/common-hal/pulseio/PulseIn.c
-msgid "pop from an empty PulseIn"
-msgstr ""
-
-#: py/objset.c
-msgid "pop from an empty set"
-msgstr ""
-
-#: py/objlist.c
-msgid "pop from empty list"
-msgstr ""
-
-#: py/objdict.c
-msgid "popitem(): dictionary is empty"
+#: ports/stm/common-hal/pulseio/PulseIn.c py/objdict.c py/objlist.c py/objset.c
+#: shared-bindings/ps2io/Ps2.c
+#, c-format
+msgid "pop from empty %s"
 msgstr ""
 
 #: py/objint_mpz.c
@@ -3105,12 +3052,7 @@ msgid "stream operation not supported"
 msgstr ""
 
 #: py/objstrunicode.c
-msgid "string index out of range"
-msgstr ""
-
-#: py/objstrunicode.c
-#, c-format
-msgid "string indices must be integers, not %s"
+msgid "string indices must be integers, not %q"
 msgstr ""
 
 #: py/stream.c
@@ -3119,10 +3061,6 @@ msgstr ""
 
 #: extmod/moductypes.c
 msgid "struct: cannot index"
-msgstr ""
-
-#: extmod/moductypes.c
-msgid "struct: index out of range"
 msgstr ""
 
 #: extmod/moductypes.c
@@ -3194,7 +3132,7 @@ msgstr ""
 msgid "trapz is defined for 1D arrays of equal length"
 msgstr ""
 
-#: extmod/ulab/code/linalg/linalg.c py/objstr.c
+#: extmod/ulab/code/linalg/linalg.c
 msgid "tuple index out of range"
 msgstr ""
 
@@ -3261,8 +3199,7 @@ msgid "unknown conversion specifier %c"
 msgstr ""
 
 #: py/objstr.c
-#, c-format
-msgid "unknown format code '%c' for object of type '%s'"
+msgid "unknown format code '%c' for object of type '%q'"
 msgstr ""
 
 #: py/compile.c
@@ -3302,7 +3239,7 @@ msgid "unsupported format character '%c' (0x%x) at index %d"
 msgstr ""
 
 #: py/runtime.c
-msgid "unsupported type for %q: '%s'"
+msgid "unsupported type for %q: '%q'"
 msgstr ""
 
 #: py/runtime.c
@@ -3310,7 +3247,7 @@ msgid "unsupported type for operator"
 msgstr ""
 
 #: py/runtime.c
-msgid "unsupported types for %q: '%s', '%s'"
+msgid "unsupported types for %q: '%q', '%q'"
 msgstr ""
 
 #: py/objint.c

--- a/main.c
+++ b/main.c
@@ -257,20 +257,24 @@ bool run_code_py(safe_mode_t safe_mode) {
         new_status_color(MAIN_RUNNING);
 
         static const char *supported_filenames[] = STRING_LIST("code.txt", "code.py", "main.py", "main.txt");
+        #if CIRCUITPY_FULL_BUILD
         static const char *double_extension_filenames[] = STRING_LIST("code.txt.py", "code.py.txt", "code.txt.txt","code.py.py",
                                                     "main.txt.py", "main.py.txt", "main.txt.txt","main.py.py");
+        #endif
 
         stack_resize();
         filesystem_flush();
         supervisor_allocation* heap = allocate_remaining_memory();
         start_mp(heap);
         found_main = maybe_run_list(supported_filenames, &result);
+        #if CIRCUITPY_FULL_BUILD
         if (!found_main){
             found_main = maybe_run_list(double_extension_filenames, &result);
             if (found_main) {
                 serial_write_compressed(translate("WARNING: Your code filename has two extensions\n"));
             }
         }
+        #endif
         cleanup_after_vm(heap);
 
         if (result.return_code & PYEXEC_FORCED_EXIT) {

--- a/main.c
+++ b/main.c
@@ -234,7 +234,8 @@ bool run_code_py(safe_mode_t safe_mode) {
         if (autoreload_is_enabled()) {
             serial_write_compressed(translate("Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.\n"));
         } else if (safe_mode != NO_SAFE_MODE) {
-            serial_write_compressed(translate("Running in safe mode! Auto-reload is off.\n"));
+            serial_write_compressed(translate("Running in safe mode! "));
+            serial_write_compressed(translate("Auto-reload is off.\n"));
         } else if (!autoreload_is_enabled()) {
             serial_write_compressed(translate("Auto-reload is off.\n"));
         }
@@ -250,7 +251,8 @@ bool run_code_py(safe_mode_t safe_mode) {
     bool found_main = false;
 
     if (safe_mode != NO_SAFE_MODE) {
-        serial_write_compressed(translate("Running in safe mode! Not running saved code.\n"));
+        serial_write_compressed(translate("Running in safe mode! "));
+        serial_write_compressed(translate("Not running saved code.\n"));
     } else {
         new_status_color(MAIN_RUNNING);
 

--- a/main.c
+++ b/main.c
@@ -181,7 +181,7 @@ void stop_mp(void) {
 
 // Look for the first file that exists in the list of filenames, using mp_import_stat().
 // Return its index. If no file found, return -1.
-const char* first_existing_file_in_list(const char ** filenames) {
+const char* first_existing_file_in_list(const char * const * filenames) {
     for (int i = 0; filenames[i] != (char*)""; i++) {
         mp_import_stat_t stat = mp_import_stat(filenames[i]);
         if (stat == MP_IMPORT_STAT_FILE) {
@@ -191,7 +191,7 @@ const char* first_existing_file_in_list(const char ** filenames) {
     return NULL;
 }
 
-bool maybe_run_list(const char ** filenames, pyexec_result_t* exec_result) {
+bool maybe_run_list(const char * const * filenames, pyexec_result_t* exec_result) {
     const char* filename = first_existing_file_in_list(filenames);
     if (filename == NULL) {
         return false;
@@ -256,9 +256,9 @@ bool run_code_py(safe_mode_t safe_mode) {
     } else {
         new_status_color(MAIN_RUNNING);
 
-        static const char *supported_filenames[] = STRING_LIST("code.txt", "code.py", "main.py", "main.txt");
+        static const char * const supported_filenames[] = STRING_LIST("code.txt", "code.py", "main.py", "main.txt");
         #if CIRCUITPY_FULL_BUILD
-        static const char *double_extension_filenames[] = STRING_LIST("code.txt.py", "code.py.txt", "code.txt.txt","code.py.py",
+        static const char * const double_extension_filenames[] = STRING_LIST("code.txt.py", "code.py.txt", "code.txt.txt","code.py.py",
                                                     "main.txt.py", "main.py.txt", "main.txt.txt","main.py.py");
         #endif
 
@@ -343,7 +343,7 @@ void __attribute__ ((noinline)) run_boot_py(safe_mode_t safe_mode) {
     // If not in safe mode, run boot before initing USB and capture output in a
     // file.
     if (filesystem_present() && safe_mode == NO_SAFE_MODE && MP_STATE_VM(vfs_mount_table) != NULL) {
-        static const char *boot_py_filenames[] = STRING_LIST("settings.txt", "settings.py", "boot.py", "boot.txt");
+        static const char * const boot_py_filenames[] = STRING_LIST("settings.txt", "settings.py", "boot.py", "boot.txt");
 
         new_status_color(BOOT_RUNNING);
 

--- a/ports/atmel-samd/common-hal/pulseio/PulseIn.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseIn.c
@@ -330,7 +330,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t* self,
     }
     if (index < 0 || index >= self->len) {
         common_hal_mcu_enable_interrupts();
-        mp_raise_IndexError(translate("index out of range"));
+        mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_PulseIn);
     }
     uint16_t value = self->buffer[(self->start + index) % self->maxlen];
     common_hal_mcu_enable_interrupts();

--- a/ports/atmel-samd/common-hal/pulseio/PulseIn.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseIn.c
@@ -298,7 +298,7 @@ void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t* self) {
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
     if (self->len == 0) {
-        mp_raise_IndexError_varg(translate("pop from empty %s"), "PulseIn");
+        mp_raise_IndexError_varg(translate("pop from empty %q"), MP_QSTR_PulseIn);
     }
     common_hal_mcu_disable_interrupts();
     uint16_t value = self->buffer[self->start];

--- a/ports/atmel-samd/common-hal/pulseio/PulseIn.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseIn.c
@@ -298,7 +298,7 @@ void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t* self) {
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
     if (self->len == 0) {
-        mp_raise_IndexError(translate("pop from an empty PulseIn"));
+        mp_raise_IndexError_varg(translate("pop from empty %s"), "PulseIn");
     }
     common_hal_mcu_disable_interrupts();
     uint16_t value = self->buffer[self->start];

--- a/ports/atmel-samd/common-hal/rtc/RTC.c
+++ b/ports/atmel-samd/common-hal/rtc/RTC.c
@@ -68,7 +68,11 @@ int common_hal_rtc_get_calibration(void) {
 
 void common_hal_rtc_set_calibration(int calibration) {
     if (calibration > 127 || calibration < -127) {
+#if CIRCUITPY_FULL_BUILD
         mp_raise_ValueError(translate("calibration value out of range +/-127"));
+#else
+        mp_raise_ValueError(translate("calibration is out of range"));
+#endif
     }
 
     hri_rtcmode0_write_FREQCORR_SIGN_bit(RTC, calibration < 0 ? 0 : 1);

--- a/ports/cxd56/common-hal/pulseio/PulseIn.c
+++ b/ports/cxd56/common-hal/pulseio/PulseIn.c
@@ -190,7 +190,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t *self, int16_
     }
     if (index < 0 || index >= self->len) {
         common_hal_mcu_enable_interrupts();
-        mp_raise_IndexError(translate("index out of range"));
+        mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_PulseIn);
     }
     uint16_t value = self->buffer[(self->start + index) % self->maxlen];
     common_hal_mcu_enable_interrupts();

--- a/ports/cxd56/common-hal/pulseio/PulseIn.c
+++ b/ports/cxd56/common-hal/pulseio/PulseIn.c
@@ -160,7 +160,7 @@ void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t *self) {
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t *self) {
     if (self->len == 0) {
-        mp_raise_IndexError_varg(translate("pop from empty %s"), "PulseIn");
+        mp_raise_IndexError_varg(translate("pop from empty %q"), MP_QSTR_PulseIn);
     }
     common_hal_mcu_disable_interrupts();
     uint16_t value = self->buffer[self->start];

--- a/ports/cxd56/common-hal/pulseio/PulseIn.c
+++ b/ports/cxd56/common-hal/pulseio/PulseIn.c
@@ -160,7 +160,7 @@ void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t *self) {
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t *self) {
     if (self->len == 0) {
-        mp_raise_IndexError(translate("pop from an empty PulseIn"));
+        mp_raise_IndexError_varg(translate("pop from empty %s"), "PulseIn");
     }
     common_hal_mcu_disable_interrupts();
     uint16_t value = self->buffer[self->start];

--- a/ports/mimxrt10xx/common-hal/pulseio/PulseIn.c
+++ b/ports/mimxrt10xx/common-hal/pulseio/PulseIn.c
@@ -201,7 +201,7 @@ void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t* self) {
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
 //    if (self->len == 0) {
-//        mp_raise_IndexError_varg(translate("pop from empty %s"), "PulseIn");
+//        mp_raise_IndexError_varg(translate("pop from empty %q"), MP_QSTR_PulseIn);
 //    }
 //    common_hal_mcu_disable_interrupts();
 //    uint16_t value = self->buffer[self->start];

--- a/ports/mimxrt10xx/common-hal/pulseio/PulseIn.c
+++ b/ports/mimxrt10xx/common-hal/pulseio/PulseIn.c
@@ -237,7 +237,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t* self,
 //    }
 //    if (index < 0 || index >= self->len) {
 //        common_hal_mcu_enable_interrupts();
-//        mp_raise_IndexError(translate("index out of range"));
+//        mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_PulseIn);
 //    }
 //    uint16_t value = self->buffer[(self->start + index) % self->maxlen];
 //    common_hal_mcu_enable_interrupts();

--- a/ports/mimxrt10xx/common-hal/pulseio/PulseIn.c
+++ b/ports/mimxrt10xx/common-hal/pulseio/PulseIn.c
@@ -201,7 +201,7 @@ void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t* self) {
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
 //    if (self->len == 0) {
-//        mp_raise_IndexError(translate("pop from an empty PulseIn"));
+//        mp_raise_IndexError_varg(translate("pop from empty %s"), "PulseIn");
 //    }
 //    common_hal_mcu_disable_interrupts();
 //    uint16_t value = self->buffer[self->start];

--- a/ports/nrf/common-hal/pulseio/PulseIn.c
+++ b/ports/nrf/common-hal/pulseio/PulseIn.c
@@ -271,7 +271,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t* self, int16_
         if ( !self->paused ) {
             nrfx_gpiote_in_event_enable(self->pin, true);
         }
-        mp_raise_IndexError(translate("index out of range"));
+        mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_PulseIn);
     }
     uint16_t value = self->buffer[(self->start + index) % self->maxlen];
 

--- a/ports/nrf/common-hal/pulseio/PulseIn.c
+++ b/ports/nrf/common-hal/pulseio/PulseIn.c
@@ -284,7 +284,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t* self, int16_
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
     if (self->len == 0) {
-        mp_raise_IndexError(translate("pop from an empty PulseIn"));
+        mp_raise_IndexError_varg(translate("pop from empty %s"), "PulseIn");
     }
 
     if ( !self->paused ) {

--- a/ports/nrf/common-hal/pulseio/PulseIn.c
+++ b/ports/nrf/common-hal/pulseio/PulseIn.c
@@ -284,7 +284,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t* self, int16_
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
     if (self->len == 0) {
-        mp_raise_IndexError_varg(translate("pop from empty %s"), "PulseIn");
+        mp_raise_IndexError_varg(translate("pop from empty %q"), MP_QSTR_PulseIn);
     }
 
     if ( !self->paused ) {

--- a/ports/stm/common-hal/pulseio/PulseIn.c
+++ b/ports/stm/common-hal/pulseio/PulseIn.c
@@ -249,7 +249,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t* self, int16_
     }
     if (index < 0 || index >= self->len) {
         HAL_NVIC_EnableIRQ(self->irq);
-        mp_raise_IndexError(translate("index out of range"));
+        mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_PulseIn);
     }
     uint16_t value = self->buffer[(self->start + index) % self->maxlen];
     HAL_NVIC_EnableIRQ(self->irq);

--- a/ports/stm/common-hal/pulseio/PulseIn.c
+++ b/ports/stm/common-hal/pulseio/PulseIn.c
@@ -258,7 +258,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t* self, int16_
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
     if (self->len == 0) {
-        mp_raise_IndexError_varg(translate("pop from empty %s"), "PulseIn");
+        mp_raise_IndexError_varg(translate("pop from empty %q"), MP_QSTR_PulseIn);
     }
     HAL_NVIC_DisableIRQ(self->irq);
     uint16_t value = self->buffer[self->start];

--- a/ports/stm/common-hal/pulseio/PulseIn.c
+++ b/ports/stm/common-hal/pulseio/PulseIn.c
@@ -258,7 +258,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t* self, int16_
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
     if (self->len == 0) {
-        mp_raise_IndexError(translate("pop from an empty PulseIn"));
+        mp_raise_IndexError_varg(translate("pop from empty %s"), "PulseIn");
     }
     HAL_NVIC_DisableIRQ(self->irq);
     uint16_t value = self->buffer[self->start];

--- a/ports/unix/file.c
+++ b/ports/unix/file.c
@@ -60,7 +60,7 @@ extern const mp_obj_type_t mp_type_textio;
 STATIC void fdfile_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_fdfile_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<io.%s %d>", mp_obj_get_type_str(self_in), self->fd);
+    mp_printf(print, "<io.%q %d>", mp_obj_get_type_qstr(self_in), self->fd);
 }
 
 STATIC mp_uint_t fdfile_read(mp_obj_t o_in, void *buf, mp_uint_t size, int *errcode) {

--- a/py/obj.c
+++ b/py/obj.c
@@ -57,8 +57,12 @@ mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in) {
     }
 }
 
+qstr mp_obj_get_type_qstr(mp_const_obj_t o_in) {
+    return mp_obj_get_type(o_in)->name;
+}
+
 const char *mp_obj_get_type_str(mp_const_obj_t o_in) {
-    return qstr_str(mp_obj_get_type(o_in)->name);
+    return qstr_str(mp_obj_get_type_qstr(o_in));
 }
 
 void mp_obj_print_helper(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
@@ -263,7 +267,7 @@ mp_int_t mp_obj_get_int(mp_const_obj_t arg) {
             mp_raise_TypeError(translate("can't convert to int"));
         } else {
             mp_raise_TypeError_varg(
-                translate("can't convert %s to %s"), mp_obj_get_type_str(arg), "int");
+                translate("can't convert %q to %q"), mp_obj_get_type_qstr(arg), MP_QSTR_int);
         }
     }
 }
@@ -326,7 +330,7 @@ mp_float_t mp_obj_get_float(mp_obj_t arg) {
             mp_raise_TypeError(translate("can't convert to float"));
         } else {
             mp_raise_TypeError_varg(
-                translate("can't convert %s to %s"), mp_obj_get_type_str(arg), "float");
+                translate("can't convert %q to %q"), mp_obj_get_type_qstr(arg), MP_QSTR_float);
         }
     }
 
@@ -359,7 +363,7 @@ void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
             mp_raise_TypeError(translate("can't convert to complex"));
         } else {
             mp_raise_TypeError_varg(
-                translate("can't convert %s to %s"), mp_obj_get_type_str(arg), "complex");
+                translate("can't convert %q to %q"), mp_obj_get_type_qstr(arg), MP_QSTR_complex);
         }
     }
 }

--- a/py/obj.c
+++ b/py/obj.c
@@ -263,7 +263,7 @@ mp_int_t mp_obj_get_int(mp_const_obj_t arg) {
             mp_raise_TypeError(translate("can't convert to int"));
         } else {
             mp_raise_TypeError_varg(
-                translate("can't convert %s to int"), mp_obj_get_type_str(arg));
+                translate("can't convert %s to %s"), mp_obj_get_type_str(arg), "int");
         }
     }
 }
@@ -326,7 +326,7 @@ mp_float_t mp_obj_get_float(mp_obj_t arg) {
             mp_raise_TypeError(translate("can't convert to float"));
         } else {
             mp_raise_TypeError_varg(
-                translate("can't convert %s to float"), mp_obj_get_type_str(arg));
+                translate("can't convert %s to %s"), mp_obj_get_type_str(arg), "float");
         }
     }
 
@@ -359,7 +359,7 @@ void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
             mp_raise_TypeError(translate("can't convert to complex"));
         } else {
             mp_raise_TypeError_varg(
-                translate("can't convert %s to complex"), mp_obj_get_type_str(arg));
+                translate("can't convert %s to %s"), mp_obj_get_type_str(arg), "complex");
         }
     }
 }

--- a/py/obj.c
+++ b/py/obj.c
@@ -381,7 +381,7 @@ void mp_obj_get_array(mp_obj_t o, size_t *len, mp_obj_t **items) {
             mp_raise_TypeError(translate("expected tuple/list"));
         } else {
             mp_raise_TypeError_varg(
-                translate("object '%s' is not a tuple or list"), mp_obj_get_type_str(o));
+                translate("object '%q' is not a tuple or list"), mp_obj_get_type_qstr(o));
         }
     }
 }
@@ -410,8 +410,8 @@ size_t mp_get_index(const mp_obj_type_t *type, size_t len, mp_obj_t index, bool 
             mp_raise_TypeError(translate("indices must be integers"));
         } else {
             mp_raise_TypeError_varg(
-                translate("%q indices must be integers, not %s"),
-                type->name, mp_obj_get_type_str(index));
+                translate("%q indices must be integers, not %q"),
+                type->name, mp_obj_get_type_qstr(index));
         }
     }
 
@@ -465,7 +465,7 @@ mp_obj_t mp_obj_len(mp_obj_t o_in) {
             mp_raise_TypeError(translate("object has no len"));
         } else {
             mp_raise_TypeError_varg(
-                translate("object of type '%s' has no len()"), mp_obj_get_type_str(o_in));
+                translate("object of type '%q' has no len()"), mp_obj_get_type_qstr(o_in));
         }
     } else {
         return len;
@@ -508,21 +508,21 @@ mp_obj_t mp_obj_subscr(mp_obj_t base, mp_obj_t index, mp_obj_t value) {
             mp_raise_TypeError(translate("object does not support item deletion"));
         } else {
             mp_raise_TypeError_varg(
-                translate("'%s' object does not support item deletion"), mp_obj_get_type_str(base));
+                translate("'%q' object does not support item deletion"), mp_obj_get_type_qstr(base));
         }
     } else if (value == MP_OBJ_SENTINEL) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError(translate("object is not subscriptable"));
         } else {
             mp_raise_TypeError_varg(
-                translate("'%s' object is not subscriptable"), mp_obj_get_type_str(base));
+                translate("'%q' object is not subscriptable"), mp_obj_get_type_qstr(base));
         }
     } else {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError(translate("object does not support item assignment"));
         } else {
             mp_raise_TypeError_varg(
-                translate("'%s' object does not support item assignment"), mp_obj_get_type_str(base));
+                translate("'%q' object does not support item assignment"), mp_obj_get_type_qstr(base));
         }
     }
 }

--- a/py/obj.c
+++ b/py/obj.c
@@ -264,7 +264,7 @@ mp_int_t mp_obj_get_int(mp_const_obj_t arg) {
         return mp_obj_int_get_checked(arg);
     } else {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
-            mp_raise_TypeError(translate("can't convert to int"));
+            mp_raise_TypeError_varg(translate("can't convert to %q"), MP_QSTR_int);
         } else {
             mp_raise_TypeError_varg(
                 translate("can't convert %q to %q"), mp_obj_get_type_qstr(arg), MP_QSTR_int);
@@ -327,7 +327,7 @@ mp_float_t mp_obj_get_float(mp_obj_t arg) {
 
     if (!mp_obj_get_float_maybe(arg, &val)) {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
-            mp_raise_TypeError(translate("can't convert to float"));
+            mp_raise_TypeError_varg(translate("can't convert to %q"), MP_QSTR_float);
         } else {
             mp_raise_TypeError_varg(
                 translate("can't convert %q to %q"), mp_obj_get_type_qstr(arg), MP_QSTR_float);
@@ -360,7 +360,7 @@ void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
         mp_obj_complex_get(arg, real, imag);
     } else {
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
-            mp_raise_TypeError(translate("can't convert to complex"));
+            mp_raise_TypeError_varg(translate("can't convert to %q"), MP_QSTR_complex);
         } else {
             mp_raise_TypeError_varg(
                 translate("can't convert %q to %q"), mp_obj_get_type_qstr(arg), MP_QSTR_complex);

--- a/py/obj.c
+++ b/py/obj.c
@@ -57,10 +57,6 @@ mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in) {
     }
 }
 
-qstr mp_obj_get_type_qstr(mp_const_obj_t o_in) {
-    return mp_obj_get_type(o_in)->name;
-}
-
 const char *mp_obj_get_type_str(mp_const_obj_t o_in) {
     return qstr_str(mp_obj_get_type_qstr(o_in));
 }

--- a/py/obj.h
+++ b/py/obj.h
@@ -680,6 +680,7 @@ mp_obj_t mp_obj_new_memoryview(byte typecode, size_t nitems, void *items);
 
 mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in);
 const char *mp_obj_get_type_str(mp_const_obj_t o_in);
+qstr mp_obj_get_type_qstr(mp_const_obj_t o_in);
 bool mp_obj_is_subclass_fast(mp_const_obj_t object, mp_const_obj_t classinfo); // arguments should be type objects
 mp_obj_t mp_instance_cast_to_native_base(mp_obj_t self_in, mp_const_obj_t native_type);
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -680,7 +680,7 @@ mp_obj_t mp_obj_new_memoryview(byte typecode, size_t nitems, void *items);
 
 mp_obj_type_t *mp_obj_get_type(mp_const_obj_t o_in);
 const char *mp_obj_get_type_str(mp_const_obj_t o_in);
-qstr mp_obj_get_type_qstr(mp_const_obj_t o_in);
+#define mp_obj_get_type_qstr(o_in) (mp_obj_get_type((o_in))->name)
 bool mp_obj_is_subclass_fast(mp_const_obj_t object, mp_const_obj_t classinfo); // arguments should be type objects
 mp_obj_t mp_instance_cast_to_native_base(mp_obj_t self_in, mp_const_obj_t native_type);
 

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -313,7 +313,7 @@ STATIC mp_obj_t dict_popitem(mp_obj_t self_in) {
     size_t cur = 0;
     mp_map_elem_t *next = dict_iter_next(self, &cur);
     if (next == NULL) {
-        mp_raise_msg_varg(&mp_type_KeyError, translate("pop from empty %s"), "dict");
+        mp_raise_msg_varg(&mp_type_KeyError, translate("pop from empty %q"), MP_QSTR_dict);
     }
     self->map.used--;
     mp_obj_t items[] = {next->key, next->value};

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -313,7 +313,7 @@ STATIC mp_obj_t dict_popitem(mp_obj_t self_in) {
     size_t cur = 0;
     mp_map_elem_t *next = dict_iter_next(self, &cur);
     if (next == NULL) {
-        mp_raise_msg(&mp_type_KeyError, translate("popitem(): dictionary is empty"));
+        mp_raise_msg_varg(&mp_type_KeyError, translate("pop from empty %s"), "dict");
     }
     self->map.used--;
     mp_obj_t items[] = {next->key, next->value};

--- a/py/objint.c
+++ b/py/objint.c
@@ -141,9 +141,9 @@ STATIC mp_fp_as_int_class_t mp_classify_fp_as_int(mp_float_t val) {
 mp_obj_t mp_obj_new_int_from_float(mp_float_t val) {
     int cl = fpclassify(val);
     if (cl == FP_INFINITE) {
-        nlr_raise(mp_obj_new_exception_msg(&mp_type_OverflowError, translate("can't convert inf to int")));
+        mp_raise_OverflowError_varg(translate("can't convert %s to %s"), "inf", "int");
     } else if (cl == FP_NAN) {
-        mp_raise_ValueError(translate("can't convert NaN to int"));
+        mp_raise_ValueError_varg(translate("can't convert %s to %s"), "NaN", "int");
     } else {
         mp_fp_as_int_class_t icl = mp_classify_fp_as_int(val);
         if (icl == MP_FP_CLASS_FIT_SMALLINT) {

--- a/py/objint.c
+++ b/py/objint.c
@@ -141,9 +141,9 @@ STATIC mp_fp_as_int_class_t mp_classify_fp_as_int(mp_float_t val) {
 mp_obj_t mp_obj_new_int_from_float(mp_float_t val) {
     int cl = fpclassify(val);
     if (cl == FP_INFINITE) {
-        mp_raise_OverflowError_varg(translate("can't convert %s to %s"), "inf", "int");
+        mp_raise_OverflowError_varg(translate("can't convert %q to %q"), MP_QSTR_inf, MP_QSTR_int);
     } else if (cl == FP_NAN) {
-        mp_raise_ValueError_varg(translate("can't convert %s to %s"), "NaN", "int");
+        mp_raise_ValueError_varg(translate("can't convert %q to %q"), MP_QSTR_NaN, MP_QSTR_int);
     } else {
         mp_fp_as_int_class_t icl = mp_classify_fp_as_int(val);
         if (icl == MP_FP_CLASS_FIT_SMALLINT) {

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -274,7 +274,7 @@ STATIC mp_obj_t list_pop(size_t n_args, const mp_obj_t *args) {
     mp_check_self(MP_OBJ_IS_TYPE(args[0], &mp_type_list));
     mp_obj_list_t *self = mp_instance_cast_to_native_base(args[0], &mp_type_list);
     if (self->len == 0) {
-        mp_raise_IndexError(translate("pop from empty list"));
+        mp_raise_IndexError_varg(translate("pop from empty %s"), "list");
     }
     size_t index = mp_get_index(self->base.type, self->len, n_args == 1 ? MP_OBJ_NEW_SMALL_INT(-1) : args[1], false);
     mp_obj_t ret = self->items[index];

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -274,7 +274,7 @@ STATIC mp_obj_t list_pop(size_t n_args, const mp_obj_t *args) {
     mp_check_self(MP_OBJ_IS_TYPE(args[0], &mp_type_list));
     mp_obj_list_t *self = mp_instance_cast_to_native_base(args[0], &mp_type_list);
     if (self->len == 0) {
-        mp_raise_IndexError_varg(translate("pop from empty %s"), "list");
+        mp_raise_IndexError_varg(translate("pop from empty %q"), MP_QSTR_list);
     }
     size_t index = mp_get_index(self->base.type, self->len, n_args == 1 ? MP_OBJ_NEW_SMALL_INT(-1) : args[1], false);
     mp_obj_t ret = self->items[index];

--- a/py/objset.c
+++ b/py/objset.c
@@ -368,7 +368,7 @@ STATIC mp_obj_t set_pop(mp_obj_t self_in) {
     mp_obj_set_t *self = MP_OBJ_TO_PTR(self_in);
     mp_obj_t obj = mp_set_remove_first(&self->set);
     if (obj == MP_OBJ_NULL) {
-        mp_raise_msg_varg(&mp_type_KeyError, translate("pop from empty %s"), "set");
+        mp_raise_msg_varg(&mp_type_KeyError, translate("pop from empty %q"), MP_QSTR_set);
     }
     return obj;
 }

--- a/py/objset.c
+++ b/py/objset.c
@@ -368,7 +368,7 @@ STATIC mp_obj_t set_pop(mp_obj_t self_in) {
     mp_obj_set_t *self = MP_OBJ_TO_PTR(self_in);
     mp_obj_t obj = mp_set_remove_first(&self->set);
     if (obj == MP_OBJ_NULL) {
-        mp_raise_IndexError_varg(translate("pop from empty %s"), "set");
+        mp_raise_msg_varg(&mp_type_KeyError, translate("pop from empty %s"), "set");
     }
     return obj;
 }

--- a/py/objset.c
+++ b/py/objset.c
@@ -368,7 +368,7 @@ STATIC mp_obj_t set_pop(mp_obj_t self_in) {
     mp_obj_set_t *self = MP_OBJ_TO_PTR(self_in);
     mp_obj_t obj = mp_set_remove_first(&self->set);
     if (obj == MP_OBJ_NULL) {
-        mp_raise_msg(&mp_type_KeyError, translate("pop from an empty set"));
+        mp_raise_IndexError_varg(translate("pop from empty %s"), "set");
     }
     return obj;
 }

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1076,7 +1076,7 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                 }
                 field_name = str_to_int(field_name, field_name_top, &index);
                 if ((uint)index >= n_args - 1) {
-                    mp_raise_IndexError(translate("tuple index out of range"));
+                    mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_tuple);
                 }
                 arg = args[index + 1];
                 *arg_i = -1;
@@ -1104,7 +1104,7 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                 }
             }
             if ((uint)*arg_i >= n_args - 1) {
-                mp_raise_IndexError(translate("tuple index out of range"));
+                mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_tuple);
             }
             arg = args[(*arg_i) + 1];
             (*arg_i)++;

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1280,8 +1280,8 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                         terse_str_format_value_error();
                     } else {
                         mp_raise_ValueError_varg(
-                            translate("unknown format code '%c' for object of type '%s'"),
-                            type, mp_obj_get_type_str(arg));
+                            translate("unknown format code '%c' for object of type '%q'"),
+                            type, mp_obj_get_type_qstr(arg));
                     }
             }
         }
@@ -1352,8 +1352,8 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                         terse_str_format_value_error();
                     } else {
                         mp_raise_ValueError_varg(
-                            translate("unknown format code '%c' for object of type '%s'"),
-                            type, mp_obj_get_type_str(arg));
+                            translate("unknown format code '%c' for object of type '%q'"),
+                            type, mp_obj_get_type_qstr(arg));
                     }
             }
         } else {
@@ -1388,8 +1388,8 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                         terse_str_format_value_error();
                     } else {
                         mp_raise_ValueError_varg(
-                            translate("unknown format code '%c' for object of type '%s'"),
-                            type, mp_obj_get_type_str(arg));
+                            translate("unknown format code '%c' for object of type '%q'"),
+                            type, mp_obj_get_type_qstr(arg));
                     }
             }
         }
@@ -2133,7 +2133,7 @@ STATIC NORETURN void bad_implicit_conversion(mp_obj_t self_in) {
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_TypeError(translate("can't convert to str implicitly"));
     } else {
-        const qstr src_name = mp_obj_get_type(self_in)->name;
+        const qstr src_name = mp_obj_get_type_qstr(self_in);
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
             translate("can't convert '%q' object to %q implicitly"),
             src_name, src_name == MP_QSTR_str ? MP_QSTR_bytes : MP_QSTR_str));

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -151,7 +151,7 @@ const byte *str_index_to_ptr(const mp_obj_type_t *type, const byte *self_data, s
     if (MP_OBJ_IS_SMALL_INT(index)) {
         i = MP_OBJ_SMALL_INT_VALUE(index);
     } else if (!mp_obj_get_int_maybe(index, &i)) {
-        mp_raise_TypeError_varg(translate("string indices must be integers, not %s"), mp_obj_get_type_str(index));
+        mp_raise_TypeError_varg(translate("string indices must be integers, not %q"), mp_obj_get_type_qstr(index));
     }
     const byte *s, *top = self_data + self_len;
     if (i < 0)

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -162,7 +162,7 @@ const byte *str_index_to_ptr(const mp_obj_type_t *type, const byte *self_data, s
                 if (is_slice) {
                     return self_data;
                 }
-                mp_raise_IndexError(translate("string index out of range"));
+                mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_str);
             }
             if (!UTF8_IS_CONT(*s)) {
                 ++i;
@@ -181,7 +181,7 @@ const byte *str_index_to_ptr(const mp_obj_type_t *type, const byte *self_data, s
                 if (is_slice) {
                     return top;
                 }
-                mp_raise_IndexError(translate("string index out of range"));
+                mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_str);
             }
             // Then check completion
             if (i-- == 0) {

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -193,7 +193,7 @@ STATIC void mp_obj_class_lookup(struct class_lookup_data  *lookup, const mp_obj_
                 printf("mp_obj_class_lookup: Returning: ");
                 mp_obj_print(lookup->dest[0], PRINT_REPR); printf(" ");
                 // Don't try to repr() lookup->dest[1], as we can be called recursively
-                printf("<%s @%p>\n", mp_obj_get_type_str(lookup->dest[1]), lookup->dest[1]);
+                printf("<%q @%p>\n", mp_obj_get_type_qstr(lookup->dest[1]), lookup->dest[1]);
 #endif
                 return;
             }
@@ -285,7 +285,7 @@ STATIC void instance_print(const mp_print_t *print, mp_obj_t self_in, mp_print_k
     }
 
     // TODO: CPython prints fully-qualified type name
-    mp_printf(print, "<%s object at %p>", mp_obj_get_type_str(self_in), self);
+    mp_printf(print, "<%q object at %p>", mp_obj_get_type_qstr(self_in), self);
 }
 
 mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
@@ -376,8 +376,8 @@ mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_args, cons
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_raise_TypeError(translate("__init__() should return None"));
             } else {
-                mp_raise_TypeError_varg(translate("__init__() should return None, not '%s'"),
-                    mp_obj_get_type_str(init_ret));
+                mp_raise_TypeError_varg(translate("__init__() should return None, not '%q'"),
+                    mp_obj_get_type_qstr(init_ret));
             }
         }
 
@@ -891,8 +891,8 @@ mp_obj_t mp_obj_instance_call(mp_obj_t self_in, size_t n_args, size_t n_kw, cons
         if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
             mp_raise_TypeError(translate("object not callable"));
         } else {
-            mp_raise_TypeError_varg(translate("'%s' object is not callable"),
-                mp_obj_get_type_str(self_in));
+            mp_raise_TypeError_varg(translate("'%q' object is not callable"),
+                mp_obj_get_type_qstr(self_in));
         }
     }
     mp_obj_instance_t *self = MP_OBJ_TO_PTR(self_in);

--- a/py/proto.c
+++ b/py/proto.c
@@ -45,6 +45,6 @@ const void *mp_proto_get_or_throw(uint16_t name, mp_const_obj_t obj) {
     if (proto) {
         return proto;
     }
-    mp_raise_TypeError_varg(translate("'%s' object does not support '%q'"),
-        mp_obj_get_type_str(obj), name);
+    mp_raise_TypeError_varg(translate("'%q' object does not support '%q'"),
+        mp_obj_get_type_qstr(obj), name);
 }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1522,12 +1522,16 @@ NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const compressed_strin
     }
 }
 
+NORETURN void mp_raise_msg_vlist(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, va_list argptr) {
+    mp_obj_t exception = mp_obj_new_exception_msg_vlist(exc_type, fmt, argptr);
+    nlr_raise(exception);
+}
+
 NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, ...) {
     va_list argptr;
     va_start(argptr,fmt);
-    mp_obj_t exception = mp_obj_new_exception_msg_vlist(exc_type, fmt, argptr);
+    mp_raise_msg_vlist(exc_type, fmt, argptr);
     va_end(argptr);
-    nlr_raise(exception);
 }
 
 NORETURN void mp_raise_AttributeError(const compressed_string_t *msg) {
@@ -1549,9 +1553,8 @@ NORETURN void mp_raise_IndexError(const compressed_string_t *msg) {
 NORETURN void mp_raise_IndexError_varg(const compressed_string_t *fmt, ...) {
     va_list argptr;
     va_start(argptr,fmt);
-    mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_IndexError, fmt, argptr);
+    mp_raise_msg_vlist(&mp_type_IndexError, fmt, argptr);
     va_end(argptr);
-    nlr_raise(exception);
 }
 
 NORETURN void mp_raise_ValueError(const compressed_string_t *msg) {
@@ -1561,9 +1564,8 @@ NORETURN void mp_raise_ValueError(const compressed_string_t *msg) {
 NORETURN void mp_raise_ValueError_varg(const compressed_string_t *fmt, ...) {
     va_list argptr;
     va_start(argptr,fmt);
-    mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_ValueError, fmt, argptr);
+    mp_raise_msg_vlist(&mp_type_ValueError, fmt, argptr);
     va_end(argptr);
-    nlr_raise(exception);
 }
 
 NORETURN void mp_raise_TypeError(const compressed_string_t *msg) {
@@ -1573,9 +1575,8 @@ NORETURN void mp_raise_TypeError(const compressed_string_t *msg) {
 NORETURN void mp_raise_TypeError_varg(const compressed_string_t *fmt, ...) {
     va_list argptr;
     va_start(argptr,fmt);
-    mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_TypeError, fmt, argptr);
+    mp_raise_msg_vlist(&mp_type_TypeError, fmt, argptr);
     va_end(argptr);
-    nlr_raise(exception);
 }
 
 NORETURN void mp_raise_OSError(int errno_) {
@@ -1597,9 +1598,8 @@ NORETURN void mp_raise_OSError_errno_str(int errno_, mp_obj_t str) {
 NORETURN void mp_raise_OSError_msg_varg(const compressed_string_t *fmt, ...) {
     va_list argptr;
     va_start(argptr,fmt);
-    mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_OSError, fmt, argptr);
+    mp_raise_msg_vlist(&mp_type_OSError, fmt, argptr);
     va_end(argptr);
-    nlr_raise(exception);
 }
 
 NORETURN void mp_raise_NotImplementedError(const compressed_string_t *msg) {
@@ -1609,17 +1609,15 @@ NORETURN void mp_raise_NotImplementedError(const compressed_string_t *msg) {
 NORETURN void mp_raise_NotImplementedError_varg(const compressed_string_t *fmt, ...) {
     va_list argptr;
     va_start(argptr,fmt);
-    mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_NotImplementedError, fmt, argptr);
+    mp_raise_msg_vlist(&mp_type_NotImplementedError, fmt, argptr);
     va_end(argptr);
-    nlr_raise(exception);
 }
 
 NORETURN void mp_raise_OverflowError_varg(const compressed_string_t *fmt, ...) {
     va_list argptr;
     va_start(argptr,fmt);
-    mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_OverflowError, fmt, argptr);
+    mp_raise_msg_vlist(&mp_type_OverflowError, fmt, argptr);
     va_end(argptr);
-    nlr_raise(exception);
 }
 
 NORETURN void mp_raise_MpyError(const compressed_string_t *msg) {

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -279,8 +279,8 @@ mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
             mp_raise_TypeError(translate("unsupported type for operator"));
         } else {
             mp_raise_TypeError_varg(
-                translate("unsupported type for %q: '%s'"),
-                mp_unary_op_method_name[op], mp_obj_get_type_str(arg));
+                translate("unsupported type for %q: '%q'"),
+                mp_unary_op_method_name[op], mp_obj_get_type_qstr(arg));
         }
     }
 }
@@ -586,8 +586,8 @@ unsupported_op:
         mp_raise_TypeError(translate("unsupported type for operator"));
     } else {
         mp_raise_TypeError_varg(
-            translate("unsupported types for %q: '%s', '%s'"),
-            mp_binary_op_method_name[op], mp_obj_get_type_str(lhs), mp_obj_get_type_str(rhs));
+            translate("unsupported types for %q: '%q', '%q'"),
+            mp_binary_op_method_name[op], mp_obj_get_type_qstr(lhs), mp_obj_get_type_qstr(rhs));
     }
 
 zero_division:
@@ -627,7 +627,7 @@ mp_obj_t mp_call_function_n_kw(mp_obj_t fun_in, size_t n_args, size_t n_kw, cons
     if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
         mp_raise_TypeError(translate("object not callable"));
     } else {
-        mp_raise_TypeError_varg(translate("'%s' object is not callable"), mp_obj_get_type_str(fun_in));
+        mp_raise_TypeError_varg(translate("'%q' object is not callable"), mp_obj_get_type_qstr(fun_in));
     }
 }
 
@@ -1104,8 +1104,8 @@ void mp_load_method(mp_obj_t base, qstr attr, mp_obj_t *dest) {
                     ((mp_obj_type_t*)MP_OBJ_TO_PTR(base))->name, attr));
             } else {
                 nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError,
-                    translate("'%s' object has no attribute '%q'"),
-                    mp_obj_get_type_str(base), attr));
+                    translate("'%q' object has no attribute '%q'"),
+                    mp_obj_get_type_qstr(base), attr));
             }
         }
     }
@@ -1172,8 +1172,8 @@ void mp_store_attr(mp_obj_t base, qstr attr, mp_obj_t value) {
         mp_raise_AttributeError(translate("no such attribute"));
     } else {
         nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_AttributeError,
-            translate("'%s' object cannot assign attribute '%q'"),
-            mp_obj_get_type_str(base), attr));
+            translate("'%q' object cannot assign attribute '%q'"),
+            mp_obj_get_type_qstr(base), attr));
     }
 }
 
@@ -1213,7 +1213,7 @@ mp_obj_t mp_getiter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
         mp_raise_TypeError(translate("object not iterable"));
     } else {
         mp_raise_TypeError_varg(
-            translate("'%s' object is not iterable"), mp_obj_get_type_str(o_in));
+            translate("'%q' object is not iterable"), mp_obj_get_type_qstr(o_in));
     }
 }
 
@@ -1234,8 +1234,8 @@ mp_obj_t mp_iternext_allow_raise(mp_obj_t o_in) {
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_raise_TypeError(translate("object not an iterator"));
             } else {
-                mp_raise_TypeError_varg(translate("'%s' object is not an iterator"),
-                    mp_obj_get_type_str(o_in));
+                mp_raise_TypeError_varg(translate("'%q' object is not an iterator"),
+                    mp_obj_get_type_qstr(o_in));
             }
         }
     }
@@ -1270,8 +1270,8 @@ mp_obj_t mp_iternext(mp_obj_t o_in) {
             if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
                 mp_raise_TypeError(translate("object not an iterator"));
             } else {
-                mp_raise_TypeError_varg(translate("'%s' object is not an iterator"),
-                    mp_obj_get_type_str(o_in));
+                mp_raise_TypeError_varg(translate("'%q' object is not an iterator"),
+                    mp_obj_get_type_qstr(o_in));
             }
         }
     }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1546,6 +1546,14 @@ NORETURN void mp_raise_IndexError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_IndexError, msg);
 }
 
+NORETURN void mp_raise_IndexError_varg(const compressed_string_t *fmt, ...) {
+    va_list argptr;
+    va_start(argptr,fmt);
+    mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_IndexError, fmt, argptr);
+    va_end(argptr);
+    nlr_raise(exception);
+}
+
 NORETURN void mp_raise_ValueError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_ValueError, msg);
 }

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -152,6 +152,7 @@ void mp_import_all(mp_obj_t module);
 
 NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const compressed_string_t *msg);
 NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, ...);
+NORETURN void mp_raise_msg_vlist(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, va_list argptr);
 NORETURN void mp_raise_ValueError(const compressed_string_t *msg);
 NORETURN void mp_raise_ValueError_varg(const compressed_string_t *fmt, ...);
 NORETURN void mp_raise_TypeError(const compressed_string_t *msg);

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -160,6 +160,7 @@ NORETURN void mp_raise_AttributeError(const compressed_string_t *msg);
 NORETURN void mp_raise_RuntimeError(const compressed_string_t *msg);
 NORETURN void mp_raise_ImportError(const compressed_string_t *msg);
 NORETURN void mp_raise_IndexError(const compressed_string_t *msg);
+NORETURN void mp_raise_IndexError_varg(const compressed_string_t *msg, ...);
 NORETURN void mp_raise_OSError(int errno_);
 NORETURN void mp_raise_OSError_errno_str(int errno_, mp_obj_t str);
 NORETURN void mp_raise_OSError_msg(const compressed_string_t *msg);

--- a/shared-bindings/i2cperipheral/I2CPeripheral.c
+++ b/shared-bindings/i2cperipheral/I2CPeripheral.c
@@ -86,7 +86,7 @@ STATIC mp_obj_t i2cperipheral_i2c_peripheral_make_new(const mp_obj_type_t *type,
     while ((item = mp_iternext(iterable)) != MP_OBJ_STOP_ITERATION) {
         mp_int_t value;
         if (!mp_obj_get_int_maybe(item, &value)) {
-            mp_raise_TypeError(translate("can't convert address to int"));
+            mp_raise_TypeError_varg(translate("can't convert %s to %s"), "address", "int");
         }
         if (value < 0x00 || value > 0x7f) {
             mp_raise_ValueError(translate("address out of bounds"));

--- a/shared-bindings/i2cperipheral/I2CPeripheral.c
+++ b/shared-bindings/i2cperipheral/I2CPeripheral.c
@@ -86,7 +86,7 @@ STATIC mp_obj_t i2cperipheral_i2c_peripheral_make_new(const mp_obj_type_t *type,
     while ((item = mp_iternext(iterable)) != MP_OBJ_STOP_ITERATION) {
         mp_int_t value;
         if (!mp_obj_get_int_maybe(item, &value)) {
-            mp_raise_TypeError_varg(translate("can't convert %s to %s"), "address", "int");
+            mp_raise_TypeError_varg(translate("can't convert %q to %q"), MP_QSTR_address, MP_QSTR_int);
         }
         if (value < 0x00 || value > 0x7f) {
             mp_raise_ValueError(translate("address out of bounds"));

--- a/shared-bindings/ps2io/Ps2.c
+++ b/shared-bindings/ps2io/Ps2.c
@@ -133,7 +133,7 @@ STATIC mp_obj_t ps2io_ps2_obj_popleft(mp_obj_t self_in) {
 
     int b = common_hal_ps2io_ps2_popleft(self);
     if (b < 0) {
-        mp_raise_IndexError(translate("Pop from an empty Ps2 buffer"));
+        mp_raise_IndexError_varg(translate("pop from empty %s"), "Ps2 buffer");
     }
     return MP_OBJ_NEW_SMALL_INT(b);
 }

--- a/shared-bindings/ps2io/Ps2.c
+++ b/shared-bindings/ps2io/Ps2.c
@@ -133,7 +133,7 @@ STATIC mp_obj_t ps2io_ps2_obj_popleft(mp_obj_t self_in) {
 
     int b = common_hal_ps2io_ps2_popleft(self);
     if (b < 0) {
-        mp_raise_IndexError_varg(translate("pop from empty %s"), "Ps2 buffer");
+        mp_raise_IndexError_varg(translate("pop from empty %q"), MP_QSTR_Ps2_space_buffer);
     }
     return MP_OBJ_NEW_SMALL_INT(b);
 }

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -280,7 +280,7 @@ STATIC mp_obj_t time_mktime(mp_obj_t t) {
 
     mp_obj_tuple_get(t, &len, &elem);
     if (len != 9) {
-        mp_raise_TypeError(translate("function takes exactly 9 arguments"));
+        mp_raise_TypeError_varg(translate("function takes %d positional arguments but %d were given"), 9);
     }
 
     if (mp_obj_get_int(elem[0]) < 2000) {

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -151,9 +151,13 @@ void print_safe_mode_message(safe_mode_t reason) {
             case GC_ALLOC_OUTSIDE_VM:
                 serial_write_compressed(translate("Attempted heap allocation when MicroPython VM not running."));
                 break;
+#ifdef SOFTDEVICE_PRESENT
+            // defined in ports/nrf/bluetooth/bluetooth_common.mk
+            // will print "Unknown reason" if somehow encountered on other ports
             case NORDIC_SOFT_DEVICE_ASSERT:
                 serial_write_compressed(translate("Nordic Soft Device failure assertion."));
                 break;
+#endif
             case FLASH_WRITE_FAIL:
                 serial_write_compressed(translate("Failed to write internal flash."));
                 break;


### PR DESCRIPTION
I ended up finding a range of firmware size (flash utilization) improvements.  One item is a performance trade-off, and one item is a feature removal for the most constrainted boards.

A small amount of RAM is also saved.

Baseline: c394af412 (origin/main) Merge pull request #3241 from jepler/translation-percent-space-fixes

Binary: trinket_m0 en_US

Flash free: +1404 bytes
RAM free: +76 bytes
Total translation strings: -17
