### PR TITLE
mpy-cross: fix dependency analysis

### DIFF
--- a/mpy-cross/mpy-cross.mk
+++ b/mpy-cross/mpy-cross.mk
@@ -82,4 +82,6 @@ endif
 OBJ = $(PY_O)
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
 
+$(BUILD)/supervisor/shared/translate.o: $(HEADER_BUILD)/qstrdefs.generated.h
+
 include $(TOP)/py/mkrules.mk


### PR DESCRIPTION
I ran into this again in a CI run.  May still be superseded by #2902 someday, but it'd be nice to eliminate spurious build failures to the extent we can with the current Makefiles.

Closes: #3074