### PR TITLE
locale: Fix percent-space in several translations

### DIFF
--- a/locale/cs.po
+++ b/locale/cs.po
@@ -44,11 +44,11 @@ msgstr ""
 
 #: py/obj.c
 msgid "  File \"%q\""
-msgstr "  Soubor \"% q\""
+msgstr "  Soubor \"%q\""
 
 #: py/obj.c
 msgid "  File \"%q\", line %d"
-msgstr "  Soubor \"% q\", řádek% d"
+msgstr "  Soubor \"%q\", řádek %d"
 
 #: main.c
 msgid " output:\n"
@@ -57,7 +57,7 @@ msgstr " výstup:\n"
 #: py/objstr.c
 #, c-format
 msgid "%%c requires int or char"
-msgstr "%% c vyžaduje int nebo char"
+msgstr "%%c vyžaduje int nebo char"
 
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
@@ -78,11 +78,11 @@ msgstr "%q index je mimo rozsah"
 
 #: py/obj.c
 msgid "%q indices must be integers, not %s"
-msgstr "Indexy% q musí být celá čísla, nikoli% s"
+msgstr "Indexy %q musí být celá čísla, nikoli %s"
 
 #: shared-bindings/vectorio/Polygon.c
 msgid "%q list must be a list"
-msgstr "Seznam% q musí být seznam"
+msgstr "Seznam %q musí být seznam"
 
 #: shared-bindings/memorymonitor/AllocationAlarm.c
 msgid "%q must be >= 0"
@@ -94,11 +94,11 @@ msgstr ""
 #: shared-bindings/memorymonitor/AllocationAlarm.c
 #: shared-bindings/vectorio/Circle.c shared-bindings/vectorio/Rectangle.c
 msgid "%q must be >= 1"
-msgstr "% q musí být > = 1"
+msgstr " %q musí být > = 1"
 
 #: shared-module/vectorio/Polygon.c
 msgid "%q must be a tuple of length 2"
-msgstr "% q musí být n-tice délky 2"
+msgstr " %q musí být n-tice délky 2"
 
 #: ports/atmel-samd/common-hal/sdioio/SDCard.c
 msgid "%q pin invalid"
@@ -106,7 +106,7 @@ msgstr ""
 
 #: shared-bindings/fontio/BuiltinFont.c
 msgid "%q should be an int"
-msgstr "% q by měl být int"
+msgstr " %q by měl být int"
 
 #: py/bc.c py/objnamedtuple.c
 msgid "%q() takes %d positional arguments but %d were given"

--- a/locale/es.po
+++ b/locale/es.po
@@ -3719,8 +3719,8 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ "Only monochrome, indexed 8bpp, and 16bpp or greater BMPs supported: %d "
 #~ "bpp given"
 #~ msgstr ""
-#~ "Solo se admiten BMP monocromos, indexados de 8bpp y 16bpp o superiores:% "
-#~ "d bppdado"
+#~ "Solo se admiten BMP monocromos, indexados de 8bpp y 16bpp o superiores:%d "
+#~ "bppdado"
 
 #, fuzzy
 #~ msgid "Only slices with step=1 (aka None) are supported"

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -2055,7 +2055,7 @@ msgstr "hindi puede ang maraming *x"
 
 #: py/emitnative.c
 msgid "can't implicitly convert '%q' to 'bool'"
-msgstr "hindi maaaring ma-convert ang '% qt' sa 'bool'"
+msgstr "hindi maaaring ma-convert ang ' %q' sa 'bool'"
 
 #: py/emitnative.c
 msgid "can't load from '%q'"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -3074,7 +3074,7 @@ msgstr "a anotação do retorno deve ser um identificador"
 
 #: py/emitnative.c
 msgid "return expected '%q' but got '%q'"
-msgstr "o retorno esperado era '%q', porém obteve '% q'"
+msgstr "o retorno esperado era '%q', porém obteve '%q'"
 
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -2117,7 +2117,7 @@ msgstr ""
 
 #: py/objtype.c
 msgid "cannot create '%q' instances"
-msgstr "kan inte skapa instanser av '% q'"
+msgstr "kan inte skapa instanser av '%q'"
 
 #: py/objtype.c
 msgid "cannot create instance"


### PR DESCRIPTION
These creep in when translators on weblate don't notice a problem with an automatically-generated translation.  Generated translations often transform "%q" into "% q".  Fix the latest crop.