### PR TITLE
Some improvements to the core module docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,10 @@ stubs:
 	@$(PYTHON) tools/extract_pyi.py ports/atmel-samd/bindings $(STUBDIR)
 	@$(PYTHON) setup.py -q sdist
 
+.PHONY: check-stubs
+check-stubs: stubs
+	MYPYPATH=$(STUBDIR) mypy --strict $(STUBDIR)
+
 update-frozen-libraries:
 	@echo "Updating all frozen libraries to latest tagged version."
 	cd frozen; for library in *; do cd $$library; ../../tools/git-checkout-latest-tag.sh; cd ..; done

--- a/docs/autoapi/templates/python/module.rst
+++ b/docs/autoapi/templates/python/module.rst
@@ -18,8 +18,7 @@
 {% set visible_subpackages = obj.subpackages|selectattr("display")|list %}
 {% if visible_subpackages %}
 .. toctree::
-   :titlesonly:
-   :maxdepth: 3
+   :maxdepth: 2
 
 {% for subpackage in visible_subpackages %}
    {{ subpackage.short_name }}/index.rst

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx<3
+sphinx<4
 recommonmark==0.6.0
 sphinxcontrib-svg2pdfconverter==0.1.0
 astroid

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -145,8 +145,8 @@ const mp_obj_property_t bleio_adapter_name_obj = {
 //|         .. note: If you set ``anonymous=True``, then a timeout must be specified. If no timeout is
 //|            specified, then the maximum allowed timeout will be selected automatically.
 //|
-//|         :param buf data: advertising data packet bytes
-//|         :param buf scan_response: scan response data packet bytes. ``None`` if no scan response is needed.
+//|         :param ~_typing.ReadableBuffer data: advertising data packet bytes
+//|         :param ~_typing.ReadableBuffer scan_response: scan response data packet bytes. ``None`` if no scan response is needed.
 //|         :param bool connectable:  If `True` then other devices are allowed to connect to this peripheral.
 //|         :param bool anonymous:  If `True` then this device's MAC address is randomized before advertising.
 //|         :param int timeout:  If set, we will only advertise for this many seconds.
@@ -219,7 +219,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_stop_advertising_obj, bleio_adapt
 //|         """Starts a BLE scan and returns an iterator of results. Advertisements and scan responses are
 //|         filtered and returned separately.
 //|
-//|         :param sequence prefixes: Sequence of byte string prefixes to filter advertising packets
+//|         :param ~_typing.ReadableBuffer prefixes: Sequence of byte string prefixes to filter advertising packets
 //|             with. A packet without an advertising structure that matches one of the prefixes is
 //|             ignored. Format is one byte for length (n) and n bytes of prefix and can be repeated.
 //|         :param int buffer_size: the maximum number of advertising bytes to buffer.
@@ -334,7 +334,7 @@ const mp_obj_property_t bleio_adapter_connected_obj = {
                (mp_obj_t)&mp_const_none_obj },
 };
 
-//|     connections: tuple
+//|     connections: Tuple[Connection]
 //|     """Tuple of active connections including those initiated through
 //|     :py:meth:`_bleio.Adapter.connect`. (read-only)"""
 //|

--- a/shared-bindings/_bleio/Address.c
+++ b/shared-bindings/_bleio/Address.c
@@ -42,7 +42,7 @@
 //|         """Create a new Address object encapsulating the address value.
 //|         The value itself can be one of:
 //|
-//|         :param buf address: The address value to encapsulate. A buffer object (bytearray, bytes) of 6 bytes.
+//|         :param ~_typing.ReadableBuffer address: The address value to encapsulate. A buffer object (bytearray, bytes) of 6 bytes.
 //|         :param int address_type: one of the integer values: `PUBLIC`, `RANDOM_STATIC`,
 //|           `RANDOM_PRIVATE_RESOLVABLE`, or `RANDOM_PRIVATE_NON_RESOLVABLE`."""
 //|         ...
@@ -128,7 +128,7 @@ const mp_obj_property_t bleio_address_type_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
-//|     def __eq__(self, other: Address) -> bool:
+//|     def __eq__(self, other: object) -> bool:
 //|         """Two Address objects are equal if their addresses and address types are equal."""
 //|         ...
 //|

--- a/shared-bindings/_bleio/Characteristic.c
+++ b/shared-bindings/_bleio/Characteristic.c
@@ -63,7 +63,7 @@
 //|          is 512, or possibly 510 if ``fixed_length`` is False. The default, 20, is the maximum
 //|          number of data bytes that fit in a single BLE 4.x ATT packet.
 //|         :param bool fixed_length: True if the characteristic value is of fixed length.
-//|         :param buf initial_value: The initial value for this characteristic. If not given, will be
+//|         :param ~_typing.ReadableBuffer initial_value: The initial value for this characteristic. If not given, will be
 //|          filled with zeros.
 //|
 //|         :return: the new Characteristic."""

--- a/shared-bindings/_bleio/Connection.c
+++ b/shared-bindings/_bleio/Connection.c
@@ -111,12 +111,12 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_connection_pair_obj, 1, bleio_connection
 
 //|     def discover_remote_services(self, service_uuids_whitelist: Optional[Iterable[UUID]] = None) -> Tuple[Service, ...]:
 //|         """Do BLE discovery for all services or for the given service UUIDS,
-//|          to find their handles and characteristics, and return the discovered services.
-//|          `Connection.connected` must be True.
+//|         to find their handles and characteristics, and return the discovered services.
+//|         `Connection.connected` must be True.
 //|
 //|         :param iterable service_uuids_whitelist:
 //|
-//|           an iterable of :py:class:~`UUID` objects for the services provided by the peripheral
+//|           an iterable of :py:class:`UUID` objects for the services provided by the peripheral
 //|           that you want to use.
 //|
 //|           The peripheral may provide more services, but services not listed are ignored
@@ -126,7 +126,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_connection_pair_obj, 1, bleio_connection
 //|           slow.
 //|
 //|           If the service UUID is 128-bit, or its characteristic UUID's are 128-bit, you
-//|           you must have already created a :py:class:~`UUID` object for that UUID in order for the
+//|           you must have already created a :py:class:`UUID` object for that UUID in order for the
 //|           service or characteristic to be discovered. Creating the UUID causes the UUID to be
 //|           registered for use. (This restriction may be lifted in the future.)
 //|

--- a/shared-bindings/_bleio/Descriptor.c
+++ b/shared-bindings/_bleio/Descriptor.c
@@ -46,7 +46,7 @@
 //|         as part of remote Characteristics in the remote Services that are discovered."""
 //|
 //|     @classmethod
-//|     def add_to_characteristic(characteristic: Characteristic, uuid: UUID, *, read_perm: int = Attribute.OPEN, write_perm: int = Attribute.OPEN, max_length = 20, fixed_length: bool = False, initial_value: ReadableBuffer = b'') -> Descriptor:
+//|     def add_to_characteristic(cls, characteristic: Characteristic, uuid: UUID, *, read_perm: int = Attribute.OPEN, write_perm: int = Attribute.OPEN, max_length: int = 20, fixed_length: bool = False, initial_value: ReadableBuffer = b'') -> Descriptor:
 //|         """Create a new Descriptor object, and add it to this Service.
 //|
 //|         :param Characteristic characteristic: The characteristic that will hold this descriptor
@@ -61,7 +61,7 @@
 //|            is 512, or possibly 510 if ``fixed_length`` is False. The default, 20, is the maximum
 //|            number of data bytes that fit in a single BLE 4.x ATT packet.
 //|         :param bool fixed_length: True if the descriptor value is of fixed length.
-//|         :param buf initial_value: The initial value for this descriptor.
+//|         :param ~_typing.ReadableBuffer initial_value: The initial value for this descriptor.
 //|
 //|         :return: the new Descriptor."""
 //|         ...

--- a/shared-bindings/_bleio/UUID.c
+++ b/shared-bindings/_bleio/UUID.c
@@ -48,7 +48,7 @@
 //|         temporary 16-bit UUID that can be used in place of the full 128-bit UUID.
 //|
 //|         :param value: The uuid value to encapsulate
-//|         :type value: int or typing.ByteString"""
+//|         :type value: int, ~_typing.ReadableBuffer or str"""
 //|         ...
 //|
 STATIC mp_obj_t bleio_uuid_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -248,7 +248,7 @@ STATIC mp_obj_t bleio_uuid_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     }
 }
 
-//|     def __eq__(self, other: UUID) -> bool:
+//|     def __eq__(self, other: object) -> bool:
 //|         """Two UUID objects are equal if their values match and they are both 128-bit or both 16-bit."""
 //|         ...
 //|

--- a/shared-bindings/_bleio/__init__.c
+++ b/shared-bindings/_bleio/__init__.c
@@ -41,7 +41,8 @@
 #include "shared-bindings/_bleio/Service.h"
 #include "shared-bindings/_bleio/UUID.h"
 
-//| """
+//| """Bluetooth Low Energy (BLE) communication
+//|
 //| The `_bleio` module provides necessary low-level functionality for communicating
 //| using Bluetooth Low Energy (BLE). The '_' prefix indicates this module is meant
 //| for internal use by libraries but not by the end user. Its API may change incompatibly
@@ -50,12 +51,12 @@
 //| `adafruit_ble <https://circuitpython.readthedocs.io/projects/ble/en/latest/>`_
 //| CircuitPython library instead, which builds on `_bleio`, and
 //| provides higher-level convenience functionality, including predefined beacons, clients,
-//| servers.
+//| servers."""
 //|
-//| .. attribute:: adapter
-//|
-//|   BLE Adapter used to manage device discovery and connections.
-//|   This object is the sole instance of `_bleio.Adapter`."""
+
+//| adapter: Adapter
+//| """BLE Adapter used to manage device discovery and connections.
+//| This object is the sole instance of `_bleio.Adapter`."""
 //|
 
 //| class BluetoothError(Exception):

--- a/shared-bindings/_eve/__init__.c
+++ b/shared-bindings/_eve/__init__.c
@@ -41,6 +41,9 @@
 //| buffers and appending basic graphics commands."""
 //|
 
+//| class _EVE:
+//|
+
 typedef struct _mp_obj__EVE_t {
     mp_obj_base_t base;
     common_hal__eve_t _eve;
@@ -51,6 +54,9 @@ STATIC const mp_obj_type_t _EVE_type;
 #define EVEHAL(s) \
   (&((mp_obj__EVE_t*)mp_instance_cast_to_native_base((s), &_EVE_type))->_eve)
 
+//|     def register(self, o: object) -> None:
+//|         ...
+//|
 STATIC mp_obj_t _register(mp_obj_t self, mp_obj_t o) {
     common_hal__eve_t *eve = EVEHAL(self);
     mp_load_method(o, MP_QSTR_write, eve->dest);
@@ -58,11 +64,11 @@ STATIC mp_obj_t _register(mp_obj_t self, mp_obj_t o) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(register_obj, _register);
 
-//| def flush(self) -> None:
-//|     """Send any queued drawing commands directly to the hardware.
+//|     def flush(self) -> None:
+//|         """Send any queued drawing commands directly to the hardware.
 //|
-//|     :param int width: The width of the grid in tiles, or 1 for sprites."""
-//|     ...
+//|         :param int width: The width of the grid in tiles, or 1 for sprites."""
+//|         ...
 //|
 STATIC mp_obj_t _flush(mp_obj_t self) {
     common_hal__eve_flush(EVEHAL(self));
@@ -70,11 +76,11 @@ STATIC mp_obj_t _flush(mp_obj_t self) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(flush_obj, _flush);
 
-//| def cc(self, b: ReadableBuffer) -> None:
-//|     """Append bytes to the command FIFO.
+//|     def cc(self, b: ReadableBuffer) -> None:
+//|         """Append bytes to the command FIFO.
 //|
-//|     :param bytes b: The bytes to add"""
-//|     ...
+//|         :param ~_typing.ReadableBuffer b: The bytes to add"""
+//|         ...
 //|
 STATIC mp_obj_t _cc(mp_obj_t self, mp_obj_t b) {
     mp_buffer_info_t buffer_info;
@@ -86,14 +92,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(cc_obj, _cc);
 
 //{
 
-//| def AlphaFunc(self, func: int, ref: int) -> None:
-//|     """Set the alpha test function
+//|     def AlphaFunc(self, func: int, ref: int) -> None:
+//|         """Set the alpha test function
 //|
-//|     :param int func: specifies the test function, one of ``NEVER``, ``LESS``, ``LEQUAL``, ``GREATER``, ``GEQUAL``, ``EQUAL``, ``NOTEQUAL``, or ``ALWAYS``. Range 0-7. The initial value is ALWAYS(7)
-//|     :param int ref: specifies the reference value for the alpha test. Range 0-255. The initial value is 0
+//|         :param int func: specifies the test function, one of ``NEVER``, ``LESS``, ``LEQUAL``, ``GREATER``, ``GEQUAL``, ``EQUAL``, ``NOTEQUAL``, or ``ALWAYS``. Range 0-7. The initial value is ALWAYS(7)
+//|         :param int ref: specifies the reference value for the alpha test. Range 0-255. The initial value is 0
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _alphafunc(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
@@ -104,13 +110,13 @@ STATIC mp_obj_t _alphafunc(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(alphafunc_obj, _alphafunc);
 
-//| def Begin(self, prim: int) -> None:
-//|     """Begin drawing a graphics primitive
+//|     def Begin(self, prim: int) -> None:
+//|         """Begin drawing a graphics primitive
 //|
-//|     :param int prim: graphics primitive.
+//|         :param int prim: graphics primitive.
 //|
-//|     Valid primitives are ``BITMAPS``, ``POINTS``, ``LINES``, ``LINE_STRIP``, ``EDGE_STRIP_R``, ``EDGE_STRIP_L``, ``EDGE_STRIP_A``, ``EDGE_STRIP_B`` and ``RECTS``."""
-//|     ...
+//|         Valid primitives are ``BITMAPS``, ``POINTS``, ``LINES``, ``LINE_STRIP``, ``EDGE_STRIP_R``, ``EDGE_STRIP_L``, ``EDGE_STRIP_A``, ``EDGE_STRIP_B`` and ``RECTS``."""
+//|         ...
 //|
 
 STATIC mp_obj_t _begin(mp_obj_t self, mp_obj_t a0) {
@@ -120,11 +126,11 @@ STATIC mp_obj_t _begin(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(begin_obj, _begin);
 
-//| def BitmapExtFormat(self, format: int) -> None:
-//|     """Set the bitmap format
+//|     def BitmapExtFormat(self, format: int) -> None:
+//|         """Set the bitmap format
 //|
-//|     :param int format: bitmap pixel format."""
-//|     ...
+//|         :param int format: bitmap pixel format."""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmapextformat(mp_obj_t self, mp_obj_t a0) {
@@ -134,13 +140,13 @@ STATIC mp_obj_t _bitmapextformat(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(bitmapextformat_obj, _bitmapextformat);
 
-//| def BitmapHandle(self, handle: int) -> None:
-//|     """Set the bitmap handle
+//|     def BitmapHandle(self, handle: int) -> None:
+//|         """Set the bitmap handle
 //|
-//|     :param int handle: bitmap handle. Range 0-31. The initial value is 0
+//|         :param int handle: bitmap handle. Range 0-31. The initial value is 0
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmaphandle(mp_obj_t self, mp_obj_t a0) {
@@ -150,12 +156,12 @@ STATIC mp_obj_t _bitmaphandle(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(bitmaphandle_obj, _bitmaphandle);
 
-//| def BitmapLayoutH(self, linestride: int, height: int) -> None:
-//|     """Set the source bitmap memory format and layout for the current handle. high bits for large bitmaps
+//|     def BitmapLayoutH(self, linestride: int, height: int) -> None:
+//|         """Set the source bitmap memory format and layout for the current handle. high bits for large bitmaps
 //|
-//|     :param int linestride: high part of bitmap line stride, in bytes. Range 0-7
-//|     :param int height: high part of bitmap height, in lines. Range 0-3"""
-//|     ...
+//|         :param int linestride: high part of bitmap line stride, in bytes. Range 0-7
+//|         :param int height: high part of bitmap height, in lines. Range 0-3"""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmaplayouth(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
@@ -166,13 +172,13 @@ STATIC mp_obj_t _bitmaplayouth(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmaplayouth_obj, _bitmaplayouth);
 
-//| def BitmapLayout(self, format: int, linestride: int, height: int) -> None:
-//|     """Set the source bitmap memory format and layout for the current handle
+//|     def BitmapLayout(self, format: int, linestride: int, height: int) -> None:
+//|         """Set the source bitmap memory format and layout for the current handle
 //|
-//|     :param int format: bitmap pixel format, or GLFORMAT to use BITMAP_EXT_FORMAT instead. Range 0-31
-//|     :param int linestride: bitmap line stride, in bytes. Range 0-1023
-//|     :param int height: bitmap height, in lines. Range 0-511"""
-//|     ...
+//|         :param int format: bitmap pixel format, or GLFORMAT to use BITMAP_EXT_FORMAT instead. Range 0-31
+//|         :param int linestride: bitmap line stride, in bytes. Range 0-1023
+//|         :param int height: bitmap height, in lines. Range 0-511"""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmaplayout(size_t n_args, const mp_obj_t *args) {
@@ -184,12 +190,12 @@ STATIC mp_obj_t _bitmaplayout(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitmaplayout_obj, 4, 4, _bitmaplayout);
 
-//| def BitmapSizeH(self, width: int, height: int) -> None:
-//|     """Set the screen drawing of bitmaps for the current handle. high bits for large bitmaps
+//|     def BitmapSizeH(self, width: int, height: int) -> None:
+//|         """Set the screen drawing of bitmaps for the current handle. high bits for large bitmaps
 //|
-//|     :param int width: high part of drawn bitmap width, in pixels. Range 0-3
-//|     :param int height: high part of drawn bitmap height, in pixels. Range 0-3"""
-//|     ...
+//|         :param int width: high part of drawn bitmap width, in pixels. Range 0-3
+//|         :param int height: high part of drawn bitmap height, in pixels. Range 0-3"""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmapsizeh(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
@@ -200,15 +206,15 @@ STATIC mp_obj_t _bitmapsizeh(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmapsizeh_obj, _bitmapsizeh);
 
-//| def BitmapSize(self, filter: int, wrapx: int, wrapy: int, width: int, height: int) -> None:
-//|     """Set the screen drawing of bitmaps for the current handle
+//|     def BitmapSize(self, filter: int, wrapx: int, wrapy: int, width: int, height: int) -> None:
+//|         """Set the screen drawing of bitmaps for the current handle
 //|
-//|     :param int filter: bitmap filtering mode, one of ``NEAREST`` or ``BILINEAR``. Range 0-1
-//|     :param int wrapx: bitmap :math:`x` wrap mode, one of ``REPEAT`` or ``BORDER``. Range 0-1
-//|     :param int wrapy: bitmap :math:`y` wrap mode, one of ``REPEAT`` or ``BORDER``. Range 0-1
-//|     :param int width: drawn bitmap width, in pixels. Range 0-511
-//|     :param int height: drawn bitmap height, in pixels. Range 0-511"""
-//|     ...
+//|         :param int filter: bitmap filtering mode, one of ``NEAREST`` or ``BILINEAR``. Range 0-1
+//|         :param int wrapx: bitmap :math:`x` wrap mode, one of ``REPEAT`` or ``BORDER``. Range 0-1
+//|         :param int wrapy: bitmap :math:`y` wrap mode, one of ``REPEAT`` or ``BORDER``. Range 0-1
+//|         :param int width: drawn bitmap width, in pixels. Range 0-511
+//|         :param int height: drawn bitmap height, in pixels. Range 0-511"""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmapsize(size_t n_args, const mp_obj_t *args) {
@@ -222,11 +228,11 @@ STATIC mp_obj_t _bitmapsize(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitmapsize_obj, 6, 6, _bitmapsize);
 
-//| def BitmapSource(self, addr: int) -> None:
-//|     """Set the source address for bitmap graphics
+//|     def BitmapSource(self, addr: int) -> None:
+//|         """Set the source address for bitmap graphics
 //|
-//|     :param int addr: Bitmap start address, pixel-aligned. May be in SRAM or flash. Range 0-16777215"""
-//|     ...
+//|         :param int addr: Bitmap start address, pixel-aligned. May be in SRAM or flash. Range 0-16777215"""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmapsource(mp_obj_t self, mp_obj_t a0) {
@@ -236,14 +242,14 @@ STATIC mp_obj_t _bitmapsource(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(bitmapsource_obj, _bitmapsource);
 
-//| def BitmapSwizzle(self, r: int, g: int, b: int, a: int) -> None:
-//|     """Set the source for the r,g,b and a channels of a bitmap
+//|     def BitmapSwizzle(self, r: int, g: int, b: int, a: int) -> None:
+//|         """Set the source for the r,g,b and a channels of a bitmap
 //|
-//|     :param int r: red component source channel. Range 0-7
-//|     :param int g: green component source channel. Range 0-7
-//|     :param int b: blue component source channel. Range 0-7
-//|     :param int a: alpha component source channel. Range 0-7"""
-//|     ...
+//|         :param int r: red component source channel. Range 0-7
+//|         :param int g: green component source channel. Range 0-7
+//|         :param int b: blue component source channel. Range 0-7
+//|         :param int a: alpha component source channel. Range 0-7"""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmapswizzle(size_t n_args, const mp_obj_t *args) {
@@ -256,16 +262,16 @@ STATIC mp_obj_t _bitmapswizzle(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitmapswizzle_obj, 5, 5, _bitmapswizzle);
 
-//| def BitmapTransformA(self, p: int, v: int) -> None:
-//|     """Set the :math:`a` component of the bitmap transform matrix
+//|     def BitmapTransformA(self, p: int, v: int) -> None:
+//|         """Set the :math:`a` component of the bitmap transform matrix
 //|
-//|     :param int p: precision control: 0 is 8.8, 1 is 1.15. Range 0-1. The initial value is 0
-//|     :param int v: The :math:`a` component of the bitmap transform matrix, in signed 8.8 or 1.15 bit fixed-point form. Range 0-131071. The initial value is 256
+//|         :param int p: precision control: 0 is 8.8, 1 is 1.15. Range 0-1. The initial value is 0
+//|         :param int v: The :math:`a` component of the bitmap transform matrix, in signed 8.8 or 1.15 bit fixed-point form. Range 0-131071. The initial value is 256
 //|
-//|     The initial value is **p** = 0, **v** = 256. This represents the value 1.0.
+//|         The initial value is **p** = 0, **v** = 256. This represents the value 1.0.
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmaptransforma(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
@@ -276,16 +282,16 @@ STATIC mp_obj_t _bitmaptransforma(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmaptransforma_obj, _bitmaptransforma);
 
-//| def BitmapTransformB(self, p: int, v: int) -> None:
-//|     """Set the :math:`b` component of the bitmap transform matrix
+//|     def BitmapTransformB(self, p: int, v: int) -> None:
+//|         """Set the :math:`b` component of the bitmap transform matrix
 //|
-//|     :param int p: precision control: 0 is 8.8, 1 is 1.15. Range 0-1. The initial value is 0
-//|     :param int v: The :math:`b` component of the bitmap transform matrix, in signed 8.8 or 1.15 bit fixed-point form. Range 0-131071. The initial value is 0
+//|         :param int p: precision control: 0 is 8.8, 1 is 1.15. Range 0-1. The initial value is 0
+//|         :param int v: The :math:`b` component of the bitmap transform matrix, in signed 8.8 or 1.15 bit fixed-point form. Range 0-131071. The initial value is 0
 //|
-//|     The initial value is **p** = 0, **v** = 0. This represents the value 0.0.
+//|         The initial value is **p** = 0, **v** = 0. This represents the value 0.0.
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmaptransformb(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
@@ -296,13 +302,13 @@ STATIC mp_obj_t _bitmaptransformb(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmaptransformb_obj, _bitmaptransformb);
 
-//| def BitmapTransformC(self, v: int) -> None:
-//|     """Set the :math:`c` component of the bitmap transform matrix
+//|     def BitmapTransformC(self, v: int) -> None:
+//|         """Set the :math:`c` component of the bitmap transform matrix
 //|
-//|     :param int v: The :math:`c` component of the bitmap transform matrix, in signed 15.8 bit fixed-point form. Range 0-16777215. The initial value is 0
+//|         :param int v: The :math:`c` component of the bitmap transform matrix, in signed 15.8 bit fixed-point form. Range 0-16777215. The initial value is 0
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmaptransformc(mp_obj_t self, mp_obj_t a0) {
@@ -312,16 +318,16 @@ STATIC mp_obj_t _bitmaptransformc(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(bitmaptransformc_obj, _bitmaptransformc);
 
-//| def BitmapTransformD(self, p: int, v: int) -> None:
-//|     """Set the :math:`d` component of the bitmap transform matrix
+//|     def BitmapTransformD(self, p: int, v: int) -> None:
+//|         """Set the :math:`d` component of the bitmap transform matrix
 //|
-//|     :param int p: precision control: 0 is 8.8, 1 is 1.15. Range 0-1. The initial value is 0
-//|     :param int v: The :math:`d` component of the bitmap transform matrix, in signed 8.8 or 1.15 bit fixed-point form. Range 0-131071. The initial value is 0
+//|         :param int p: precision control: 0 is 8.8, 1 is 1.15. Range 0-1. The initial value is 0
+//|         :param int v: The :math:`d` component of the bitmap transform matrix, in signed 8.8 or 1.15 bit fixed-point form. Range 0-131071. The initial value is 0
 //|
-//|     The initial value is **p** = 0, **v** = 0. This represents the value 0.0.
+//|         The initial value is **p** = 0, **v** = 0. This represents the value 0.0.
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmaptransformd(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
@@ -332,16 +338,16 @@ STATIC mp_obj_t _bitmaptransformd(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmaptransformd_obj, _bitmaptransformd);
 
-//| def BitmapTransformE(self, p: int, v: int) -> None:
-//|     """Set the :math:`e` component of the bitmap transform matrix
+//|     def BitmapTransformE(self, p: int, v: int) -> None:
+//|         """Set the :math:`e` component of the bitmap transform matrix
 //|
-//|     :param int p: precision control: 0 is 8.8, 1 is 1.15. Range 0-1. The initial value is 0
-//|     :param int v: The :math:`e` component of the bitmap transform matrix, in signed 8.8 or 1.15 bit fixed-point form. Range 0-131071. The initial value is 256
+//|         :param int p: precision control: 0 is 8.8, 1 is 1.15. Range 0-1. The initial value is 0
+//|         :param int v: The :math:`e` component of the bitmap transform matrix, in signed 8.8 or 1.15 bit fixed-point form. Range 0-131071. The initial value is 256
 //|
-//|     The initial value is **p** = 0, **v** = 256. This represents the value 1.0.
+//|         The initial value is **p** = 0, **v** = 256. This represents the value 1.0.
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmaptransforme(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
@@ -352,13 +358,13 @@ STATIC mp_obj_t _bitmaptransforme(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmaptransforme_obj, _bitmaptransforme);
 
-//| def BitmapTransformF(self, v: int) -> None:
-//|     """Set the :math:`f` component of the bitmap transform matrix
+//|     def BitmapTransformF(self, v: int) -> None:
+//|         """Set the :math:`f` component of the bitmap transform matrix
 //|
-//|     :param int v: The :math:`f` component of the bitmap transform matrix, in signed 15.8 bit fixed-point form. Range 0-16777215. The initial value is 0
+//|         :param int v: The :math:`f` component of the bitmap transform matrix, in signed 15.8 bit fixed-point form. Range 0-16777215. The initial value is 0
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _bitmaptransformf(mp_obj_t self, mp_obj_t a0) {
@@ -368,14 +374,14 @@ STATIC mp_obj_t _bitmaptransformf(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(bitmaptransformf_obj, _bitmaptransformf);
 
-//| def BlendFunc(self, src: int, dst: int) -> None:
-//|     """Set pixel arithmetic
+//|     def BlendFunc(self, src: int, dst: int) -> None:
+//|         """Set pixel arithmetic
 //|
-//|     :param int src: specifies how the source blending factor is computed.  One of ``ZERO``, ``ONE``, ``SRC_ALPHA``, ``DST_ALPHA``, ``ONE_MINUS_SRC_ALPHA`` or ``ONE_MINUS_DST_ALPHA``. Range 0-7. The initial value is SRC_ALPHA(2)
-//|     :param int dst: specifies how the destination blending factor is computed, one of the same constants as **src**. Range 0-7. The initial value is ONE_MINUS_SRC_ALPHA(4)
+//|         :param int src: specifies how the source blending factor is computed.  One of ``ZERO``, ``ONE``, ``SRC_ALPHA``, ``DST_ALPHA``, ``ONE_MINUS_SRC_ALPHA`` or ``ONE_MINUS_DST_ALPHA``. Range 0-7. The initial value is SRC_ALPHA(2)
+//|         :param int dst: specifies how the destination blending factor is computed, one of the same constants as **src**. Range 0-7. The initial value is ONE_MINUS_SRC_ALPHA(4)
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _blendfunc(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
@@ -386,11 +392,11 @@ STATIC mp_obj_t _blendfunc(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(blendfunc_obj, _blendfunc);
 
-//| def Call(self, dest: int) -> None:
-//|     """Execute a sequence of commands at another location in the display list
+//|     def Call(self, dest: int) -> None:
+//|         """Execute a sequence of commands at another location in the display list
 //|
-//|     :param int dest: display list address. Range 0-65535"""
-//|     ...
+//|         :param int dest: display list address. Range 0-65535"""
+//|         ...
 //|
 
 STATIC mp_obj_t _call(mp_obj_t self, mp_obj_t a0) {
@@ -400,13 +406,13 @@ STATIC mp_obj_t _call(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(call_obj, _call);
 
-//| def Cell(self, cell: int) -> None:
-//|     """Set the bitmap cell number for the vertex2f command
+//|     def Cell(self, cell: int) -> None:
+//|         """Set the bitmap cell number for the vertex2f command
 //|
-//|     :param int cell: bitmap cell number. Range 0-127. The initial value is 0
+//|         :param int cell: bitmap cell number. Range 0-127. The initial value is 0
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _cell(mp_obj_t self, mp_obj_t a0) {
@@ -416,13 +422,13 @@ STATIC mp_obj_t _cell(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(cell_obj, _cell);
 
-//| def ClearColorA(self, alpha: int) -> None:
-//|     """Set clear value for the alpha channel
+//|     def ClearColorA(self, alpha: int) -> None:
+//|         """Set clear value for the alpha channel
 //|
-//|     :param int alpha: alpha value used when the color buffer is cleared. Range 0-255. The initial value is 0
+//|         :param int alpha: alpha value used when the color buffer is cleared. Range 0-255. The initial value is 0
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _clearcolora(mp_obj_t self, mp_obj_t a0) {
@@ -432,15 +438,15 @@ STATIC mp_obj_t _clearcolora(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(clearcolora_obj, _clearcolora);
 
-//| def ClearColorRGB(self, red: int, green: int, blue: int) -> None:
-//|     """Set clear values for red, green and blue channels
+//|     def ClearColorRGB(self, red: int, green: int, blue: int) -> None:
+//|         """Set clear values for red, green and blue channels
 //|
-//|     :param int red: red value used when the color buffer is cleared. Range 0-255. The initial value is 0
-//|     :param int green: green value used when the color buffer is cleared. Range 0-255. The initial value is 0
-//|     :param int blue: blue value used when the color buffer is cleared. Range 0-255. The initial value is 0
+//|         :param int red: red value used when the color buffer is cleared. Range 0-255. The initial value is 0
+//|         :param int green: green value used when the color buffer is cleared. Range 0-255. The initial value is 0
+//|         :param int blue: blue value used when the color buffer is cleared. Range 0-255. The initial value is 0
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _clearcolorrgb(size_t n_args, const mp_obj_t *args) {
@@ -452,13 +458,13 @@ STATIC mp_obj_t _clearcolorrgb(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(clearcolorrgb_obj, 4, 4, _clearcolorrgb);
 
-//| def Clear(self, c: int, s: int, t: int) -> None:
-//|     """Clear buffers to preset values
+//|     def Clear(self, c: int, s: int, t: int) -> None:
+//|         """Clear buffers to preset values
 //|
-//|     :param int c: clear color buffer. Range 0-1
-//|     :param int s: clear stencil buffer. Range 0-1
-//|     :param int t: clear tag buffer. Range 0-1"""
-//|     ...
+//|         :param int c: clear color buffer. Range 0-1
+//|         :param int s: clear stencil buffer. Range 0-1
+//|         :param int t: clear tag buffer. Range 0-1"""
+//|         ...
 //|
 
 STATIC mp_obj_t _clear(size_t n_args, const mp_obj_t *args) {
@@ -470,13 +476,13 @@ STATIC mp_obj_t _clear(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(clear_obj, 1, 4, _clear);
 
-//| def ClearStencil(self, s: int) -> None:
-//|     """Set clear value for the stencil buffer
+//|     def ClearStencil(self, s: int) -> None:
+//|         """Set clear value for the stencil buffer
 //|
-//|     :param int s: value used when the stencil buffer is cleared. Range 0-255. The initial value is 0
+//|         :param int s: value used when the stencil buffer is cleared. Range 0-255. The initial value is 0
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _clearstencil(mp_obj_t self, mp_obj_t a0) {
@@ -486,12 +492,12 @@ STATIC mp_obj_t _clearstencil(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(clearstencil_obj, _clearstencil);
 
-//| def ClearTag(self, s: int) -> None:
-//|     """Set clear value for the tag buffer
+//|     def ClearTag(self, s: int) -> None:
+//|         """Set clear value for the tag buffer
 //|
-//|     :param int s: value used when the tag buffer is cleared. Range 0-255. The initial value is 0
+//|         :param int s: value used when the tag buffer is cleared. Range 0-255. The initial value is 0
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|
 
 STATIC mp_obj_t _cleartag(mp_obj_t self, mp_obj_t a0) {
@@ -501,13 +507,13 @@ STATIC mp_obj_t _cleartag(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(cleartag_obj, _cleartag);
 
-//| def ColorA(self, alpha: int) -> None:
-//|     """Set the current color alpha
+//|     def ColorA(self, alpha: int) -> None:
+//|         """Set the current color alpha
 //|
-//|     :param int alpha: alpha for the current color. Range 0-255. The initial value is 255
+//|         :param int alpha: alpha for the current color. Range 0-255. The initial value is 255
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _colora(mp_obj_t self, mp_obj_t a0) {
@@ -517,16 +523,16 @@ STATIC mp_obj_t _colora(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(colora_obj, _colora);
 
-//| def ColorMask(self, r: int, g: int, b: int, a: int) -> None:
-//|     """Enable and disable writing of frame buffer color components
+//|     def ColorMask(self, r: int, g: int, b: int, a: int) -> None:
+//|         """Enable and disable writing of frame buffer color components
 //|
-//|     :param int r: allow updates to the frame buffer red component. Range 0-1. The initial value is 1
-//|     :param int g: allow updates to the frame buffer green component. Range 0-1. The initial value is 1
-//|     :param int b: allow updates to the frame buffer blue component. Range 0-1. The initial value is 1
-//|     :param int a: allow updates to the frame buffer alpha component. Range 0-1. The initial value is 1
+//|         :param int r: allow updates to the frame buffer red component. Range 0-1. The initial value is 1
+//|         :param int g: allow updates to the frame buffer green component. Range 0-1. The initial value is 1
+//|         :param int b: allow updates to the frame buffer blue component. Range 0-1. The initial value is 1
+//|         :param int a: allow updates to the frame buffer alpha component. Range 0-1. The initial value is 1
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _colormask(size_t n_args, const mp_obj_t *args) {
@@ -539,15 +545,15 @@ STATIC mp_obj_t _colormask(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(colormask_obj, 5, 5, _colormask);
 
-//| def ColorRGB(self, red: int, green: int, blue: int) -> None:
-//|     """Set the drawing color
+//|     def ColorRGB(self, red: int, green: int, blue: int) -> None:
+//|         """Set the drawing color
 //|
-//|     :param int red: red value for the current color. Range 0-255. The initial value is 255
-//|     :param int green: green for the current color. Range 0-255. The initial value is 255
-//|     :param int blue: blue for the current color. Range 0-255. The initial value is 255
+//|         :param int red: red value for the current color. Range 0-255. The initial value is 255
+//|         :param int green: green for the current color. Range 0-255. The initial value is 255
+//|         :param int blue: blue for the current color. Range 0-255. The initial value is 255
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _colorrgb(size_t n_args, const mp_obj_t *args) {
@@ -559,9 +565,9 @@ STATIC mp_obj_t _colorrgb(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(colorrgb_obj, 4, 4, _colorrgb);
 
-//| def Display(self) -> None:
-//|     """End the display list"""
-//|     ...
+//|     def Display(self) -> None:
+//|         """End the display list"""
+//|         ...
 
 STATIC mp_obj_t _display(mp_obj_t self) {
 
@@ -570,11 +576,11 @@ STATIC mp_obj_t _display(mp_obj_t self) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(display_obj, _display);
 
-//| def End(self) -> None:
-//|     """End drawing a graphics primitive
+//|     def End(self) -> None:
+//|         """End drawing a graphics primitive
 //|
-//|     :meth:`Vertex2ii` and :meth:`Vertex2f` calls are ignored until the next :meth:`Begin`."""
-//|     ...
+//|         :meth:`Vertex2ii` and :meth:`Vertex2f` calls are ignored until the next :meth:`Begin`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _end(mp_obj_t self) {
@@ -584,11 +590,11 @@ STATIC mp_obj_t _end(mp_obj_t self) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(end_obj, _end);
 
-//| def Jump(self, dest: int) -> None:
-//|     """Execute commands at another location in the display list
+//|     def Jump(self, dest: int) -> None:
+//|         """Execute commands at another location in the display list
 //|
-//|     :param int dest: display list address. Range 0-65535"""
-//|     ...
+//|         :param int dest: display list address. Range 0-65535"""
+//|         ...
 //|
 
 STATIC mp_obj_t _jump(mp_obj_t self, mp_obj_t a0) {
@@ -598,13 +604,13 @@ STATIC mp_obj_t _jump(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(jump_obj, _jump);
 
-//| def LineWidth(self, width: int) -> None:
-//|     """Set the width of rasterized lines
+//|     def LineWidth(self, width: int) -> None:
+//|         """Set the width of rasterized lines
 //|
-//|     :param int width: line width in :math:`1/16` pixel. Range 0-4095. The initial value is 16
+//|         :param int width: line width in :math:`1/16` pixel. Range 0-4095. The initial value is 16
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _linewidth(mp_obj_t self, mp_obj_t a0) {
@@ -614,11 +620,11 @@ STATIC mp_obj_t _linewidth(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(linewidth_obj, _linewidth);
 
-//| def Macro(self, m: int) -> None:
-//|     """Execute a single command from a macro register
+//|     def Macro(self, m: int) -> None:
+//|         """Execute a single command from a macro register
 //|
-//|     :param int m: macro register to read. Range 0-1"""
-//|     ...
+//|         :param int m: macro register to read. Range 0-1"""
+//|         ...
 //|
 
 STATIC mp_obj_t _macro(mp_obj_t self, mp_obj_t a0) {
@@ -628,9 +634,9 @@ STATIC mp_obj_t _macro(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(macro_obj, _macro);
 
-//| def Nop(self) -> None:
-//|     """No operation"""
-//|     ...
+//|     def Nop(self) -> None:
+//|         """No operation"""
+//|         ...
 //|
 
 STATIC mp_obj_t _nop(mp_obj_t self) {
@@ -640,13 +646,13 @@ STATIC mp_obj_t _nop(mp_obj_t self) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(nop_obj, _nop);
 
-//| def PaletteSource(self, addr: int) -> None:
-//|     """Set the base address of the palette
+//|     def PaletteSource(self, addr: int) -> None:
+//|         """Set the base address of the palette
 //|
-//|     :param int addr: Address in graphics SRAM, 2-byte aligned. Range 0-4194303. The initial value is 0
+//|         :param int addr: Address in graphics SRAM, 2-byte aligned. Range 0-4194303. The initial value is 0
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _palettesource(mp_obj_t self, mp_obj_t a0) {
@@ -656,13 +662,13 @@ STATIC mp_obj_t _palettesource(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(palettesource_obj, _palettesource);
 
-//| def PointSize(self, size: int) -> None:
-//|     """Set the radius of rasterized points
+//|     def PointSize(self, size: int) -> None:
+//|         """Set the radius of rasterized points
 //|
-//|     :param int size: point radius in :math:`1/16` pixel. Range 0-8191. The initial value is 16
+//|         :param int size: point radius in :math:`1/16` pixel. Range 0-8191. The initial value is 16
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _pointsize(mp_obj_t self, mp_obj_t a0) {
@@ -672,9 +678,9 @@ STATIC mp_obj_t _pointsize(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(pointsize_obj, _pointsize);
 
-//| def RestoreContext(self) -> None:
-//|     """Restore the current graphics context from the context stack"""
-//|     ...
+//|     def RestoreContext(self) -> None:
+//|         """Restore the current graphics context from the context stack"""
+//|         ...
 //|
 
 STATIC mp_obj_t _restorecontext(mp_obj_t self) {
@@ -684,9 +690,9 @@ STATIC mp_obj_t _restorecontext(mp_obj_t self) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(restorecontext_obj, _restorecontext);
 
-//| def Return(self) -> None:
-//|     """Return from a previous call command"""
-//|     ...
+//|     def Return(self) -> None:
+//|         """Return from a previous call command"""
+//|         ...
 //|
 
 STATIC mp_obj_t _return(mp_obj_t self) {
@@ -696,9 +702,9 @@ STATIC mp_obj_t _return(mp_obj_t self) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(return_obj, _return);
 
-//| def SaveContext(self) -> None:
-//|     """Push the current graphics context on the context stack"""
-//|     ...
+//|     def SaveContext(self) -> None:
+//|         """Push the current graphics context on the context stack"""
+//|         ...
 //|
 
 STATIC mp_obj_t _savecontext(mp_obj_t self) {
@@ -708,14 +714,14 @@ STATIC mp_obj_t _savecontext(mp_obj_t self) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(savecontext_obj, _savecontext);
 
-//| def ScissorSize(self, width: int, height: int) -> None:
-//|     """Set the size of the scissor clip rectangle
+//|     def ScissorSize(self, width: int, height: int) -> None:
+//|         """Set the size of the scissor clip rectangle
 //|
-//|     :param int width: The width of the scissor clip rectangle, in pixels. Range 0-4095. The initial value is hsize
-//|     :param int height: The height of the scissor clip rectangle, in pixels. Range 0-4095. The initial value is 2048
+//|         :param int width: The width of the scissor clip rectangle, in pixels. Range 0-4095. The initial value is hsize
+//|         :param int height: The height of the scissor clip rectangle, in pixels. Range 0-4095. The initial value is 2048
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _scissorsize(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
@@ -726,14 +732,14 @@ STATIC mp_obj_t _scissorsize(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(scissorsize_obj, _scissorsize);
 
-//| def ScissorXY(self, x: int, y: int) -> None:
-//|     """Set the top left corner of the scissor clip rectangle
+//|     def ScissorXY(self, x: int, y: int) -> None:
+//|         """Set the top left corner of the scissor clip rectangle
 //|
-//|     :param int x: The :math:`x` coordinate of the scissor clip rectangle, in pixels. Range 0-2047. The initial value is 0
-//|     :param int y: The :math:`y` coordinate of the scissor clip rectangle, in pixels. Range 0-2047. The initial value is 0
+//|         :param int x: The :math:`x` coordinate of the scissor clip rectangle, in pixels. Range 0-2047. The initial value is 0
+//|         :param int y: The :math:`y` coordinate of the scissor clip rectangle, in pixels. Range 0-2047. The initial value is 0
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _scissorxy(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
@@ -744,15 +750,15 @@ STATIC mp_obj_t _scissorxy(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(scissorxy_obj, _scissorxy);
 
-//| def StencilFunc(self, func: int, ref: int, mask: int) -> None:
-//|     """Set function and reference value for stencil testing
+//|     def StencilFunc(self, func: int, ref: int, mask: int) -> None:
+//|         """Set function and reference value for stencil testing
 //|
-//|     :param int func: specifies the test function, one of ``NEVER``, ``LESS``, ``LEQUAL``, ``GREATER``, ``GEQUAL``, ``EQUAL``, ``NOTEQUAL``, or ``ALWAYS``. Range 0-7. The initial value is ALWAYS(7)
-//|     :param int ref: specifies the reference value for the stencil test. Range 0-255. The initial value is 0
-//|     :param int mask: specifies a mask that is ANDed with the reference value and the stored stencil value. Range 0-255. The initial value is 255
+//|         :param int func: specifies the test function, one of ``NEVER``, ``LESS``, ``LEQUAL``, ``GREATER``, ``GEQUAL``, ``EQUAL``, ``NOTEQUAL``, or ``ALWAYS``. Range 0-7. The initial value is ALWAYS(7)
+//|         :param int ref: specifies the reference value for the stencil test. Range 0-255. The initial value is 0
+//|         :param int mask: specifies a mask that is ANDed with the reference value and the stored stencil value. Range 0-255. The initial value is 255
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _stencilfunc(size_t n_args, const mp_obj_t *args) {
@@ -764,13 +770,13 @@ STATIC mp_obj_t _stencilfunc(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(stencilfunc_obj, 4, 4, _stencilfunc);
 
-//| def StencilMask(self, mask: int) -> None:
-//|     """Control the writing of individual bits in the stencil planes
+//|     def StencilMask(self, mask: int) -> None:
+//|         """Control the writing of individual bits in the stencil planes
 //|
-//|     :param int mask: the mask used to enable writing stencil bits. Range 0-255. The initial value is 255
+//|         :param int mask: the mask used to enable writing stencil bits. Range 0-255. The initial value is 255
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _stencilmask(mp_obj_t self, mp_obj_t a0) {
@@ -780,14 +786,14 @@ STATIC mp_obj_t _stencilmask(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(stencilmask_obj, _stencilmask);
 
-//| def StencilOp(self, sfail: int, spass: int) -> None:
-//|     """Set stencil test actions
+//|     def StencilOp(self, sfail: int, spass: int) -> None:
+//|         """Set stencil test actions
 //|
-//|     :param int sfail: specifies the action to take when the stencil test fails, one of ``KEEP``, ``ZERO``, ``REPLACE``, ``INCR``, ``INCR_WRAP``, ``DECR``, ``DECR_WRAP``, and ``INVERT``. Range 0-7. The initial value is KEEP(1)
-//|     :param int spass: specifies the action to take when the stencil test passes, one of the same constants as **sfail**. Range 0-7. The initial value is KEEP(1)
+//|         :param int sfail: specifies the action to take when the stencil test fails, one of ``KEEP``, ``ZERO``, ``REPLACE``, ``INCR``, ``INCR_WRAP``, ``DECR``, ``DECR_WRAP``, and ``INVERT``. Range 0-7. The initial value is KEEP(1)
+//|         :param int spass: specifies the action to take when the stencil test passes, one of the same constants as **sfail**. Range 0-7. The initial value is KEEP(1)
 //|
-//|     These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _stencilop(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
@@ -798,13 +804,13 @@ STATIC mp_obj_t _stencilop(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(stencilop_obj, _stencilop);
 
-//| def TagMask(self, mask: int) -> None:
-//|     """Control the writing of the tag buffer
+//|     def TagMask(self, mask: int) -> None:
+//|         """Control the writing of the tag buffer
 //|
-//|     :param int mask: allow updates to the tag buffer. Range 0-1. The initial value is 1
+//|         :param int mask: allow updates to the tag buffer. Range 0-1. The initial value is 1
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _tagmask(mp_obj_t self, mp_obj_t a0) {
@@ -814,13 +820,13 @@ STATIC mp_obj_t _tagmask(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(tagmask_obj, _tagmask);
 
-//| def Tag(self, s: int) -> None:
-//|     """Set the current tag value
+//|     def Tag(self, s: int) -> None:
+//|         """Set the current tag value
 //|
-//|     :param int s: tag value. Range 0-255. The initial value is 255
+//|         :param int s: tag value. Range 0-255. The initial value is 255
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _tag(mp_obj_t self, mp_obj_t a0) {
@@ -830,13 +836,13 @@ STATIC mp_obj_t _tag(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(tag_obj, _tag);
 
-//| def VertexTranslateX(self, x: int) -> None:
-//|     """Set the vertex transformation's x translation component
+//|     def VertexTranslateX(self, x: int) -> None:
+//|         """Set the vertex transformation's x translation component
 //|
-//|     :param int x: signed x-coordinate in :math:`1/16` pixel. Range 0-131071. The initial value is 0
+//|         :param int x: signed x-coordinate in :math:`1/16` pixel. Range 0-131071. The initial value is 0
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _vertextranslatex(mp_obj_t self, mp_obj_t a0) {
@@ -846,13 +852,13 @@ STATIC mp_obj_t _vertextranslatex(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(vertextranslatex_obj, _vertextranslatex);
 
-//| def VertexTranslateY(self, y: int) -> None:
-//|     """Set the vertex transformation's y translation component
+//|     def VertexTranslateY(self, y: int) -> None:
+//|         """Set the vertex transformation's y translation component
 //|
-//|     :param int y: signed y-coordinate in :math:`1/16` pixel. Range 0-131071. The initial value is 0
+//|         :param int y: signed y-coordinate in :math:`1/16` pixel. Range 0-131071. The initial value is 0
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 
@@ -863,13 +869,13 @@ STATIC mp_obj_t _vertextranslatey(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(vertextranslatey_obj, _vertextranslatey);
 
-//| def VertexFormat(self, frac: int) -> None:
-//|     """Set the precision of vertex2f coordinates
+//|     def VertexFormat(self, frac: int) -> None:
+//|         """Set the precision of vertex2f coordinates
 //|
-//|     :param int frac: Number of fractional bits in X,Y coordinates, 0-4. Range 0-7. The initial value is 4
+//|         :param int frac: Number of fractional bits in X,Y coordinates, 0-4. Range 0-7. The initial value is 4
 //|
-//|     This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|     ...
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _vertexformat(mp_obj_t self, mp_obj_t a0) {
@@ -879,14 +885,14 @@ STATIC mp_obj_t _vertexformat(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(vertexformat_obj, _vertexformat);
 
-//| def Vertex2ii(self, x: int, y: int, handle: int, cell: int) -> None:
-//|     """:param int x: x-coordinate in pixels. Range 0-511
-//|     :param int y: y-coordinate in pixels. Range 0-511
-//|     :param int handle: bitmap handle. Range 0-31
-//|     :param int cell: cell number. Range 0-127
+//|     def Vertex2ii(self, x: int, y: int, handle: int, cell: int) -> None:
+//|         """:param int x: x-coordinate in pixels. Range 0-511
+//|         :param int y: y-coordinate in pixels. Range 0-511
+//|         :param int handle: bitmap handle. Range 0-31
+//|         :param int cell: cell number. Range 0-127
 //|
-//|     This method is an alternative to :meth:`Vertex2f`."""
-//|     ...
+//|         This method is an alternative to :meth:`Vertex2f`."""
+//|         ...
 //|
 
 STATIC mp_obj_t _vertex2ii(size_t n_args, const mp_obj_t *args) {
@@ -954,12 +960,12 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(vertex2ii_obj, 3, 5, _vertex2ii);
 
 // Hand-written functions {
 
-//| def Vertex2f(self, b: float) -> None:
-//|     """Draw a point.
+//|     def Vertex2f(self, b: float) -> None:
+//|         """Draw a point.
 //|
-//|     :param float x: pixel x-coordinate
-//|     :param float y: pixel y-coordinate"""
-//|     ...
+//|         :param float x: pixel x-coordinate
+//|         :param float y: pixel y-coordinate"""
+//|         ...
 //|
 STATIC mp_obj_t _vertex2f(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     mp_float_t x = mp_obj_get_float(a0);
@@ -973,14 +979,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(vertex2f_obj, _vertex2f);
 #define ADD_X(self, x) \
     common_hal__eve_add(EVEHAL(self), sizeof(x), &(x));
 
-//| def cmd0(self, n: int) -> None:
-//|     """Append the command word n to the FIFO
+//|     def cmd0(self, n: int) -> None:
+//|         """Append the command word n to the FIFO
 //|
-//|     :param int n: The command code
+//|         :param int n: The command code
 //|
-//|     This method is used by the ``eve`` module to efficiently add
-//|     commands to the FIFO."""
-//|     ...
+//|         This method is used by the ``eve`` module to efficiently add
+//|         commands to the FIFO."""
+//|         ...
 //|
 
 STATIC mp_obj_t _cmd0(mp_obj_t self, mp_obj_t n) {
@@ -990,18 +996,19 @@ STATIC mp_obj_t _cmd0(mp_obj_t self, mp_obj_t n) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(cmd0_obj, _cmd0);
 
-//| def cmd(self, n: int, fmt: str, args: tuple) -> None:
-//|     """Append a command packet to the FIFO.
+//|     def cmd(self, n: int, fmt: str, args: Tuple[str, ...]) -> None:
+//|         """Append a command packet to the FIFO.
 //|
-//|     :param int n: The command code
-//|     :param str fmt: The command format `struct` layout
-//|     :param tuple args: The command's arguments
+//|         :param int n: The command code
+//|         :param str fmt: The command format `struct` layout
+//|         :param args: The command's arguments
+//|         :type args: tuple(str, ...)
 //|
-//|     Supported format codes: h, H, i, I.
+//|         Supported format codes: h, H, i, I.
 //|
-//|     This method is used by the ``eve`` module to efficiently add
-//|     commands to the FIFO."""
-//|     ...
+//|         This method is used by the ``eve`` module to efficiently add
+//|         commands to the FIFO."""
+//|         ...
 //|
 STATIC mp_obj_t _cmd(size_t n_args, const mp_obj_t *args) {
     mp_obj_t self = args[0];

--- a/shared-bindings/_pew/PewPew.c
+++ b/shared-bindings/_pew/PewPew.c
@@ -48,26 +48,8 @@
 //|     def __init__(
 //|         self,
 //|         buffer: ReadableBuffer,
-//|         rows: List[
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|         ],
-//|         cols: List[
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|             digitalio.DigitalInOut,
-//|         ],
+//|         rows: List[digitalio.DigitalInOut],
+//|         cols: List[digitalio.DigitalInOut],
 //|         buttons: digitalio.DigitalInOut,
 //|     ) -> None:
 //|         """Initializes matrix scanning routines.

--- a/shared-bindings/_pixelbuf/PixelBuf.c
+++ b/shared-bindings/_pixelbuf/PixelBuf.c
@@ -58,12 +58,12 @@ static void parse_byteorder(mp_obj_t byteorder_obj, pixelbuf_byteorder_details_t
 //|         brightness (0.0-1.0) and will enable a Dotstar compatible 1st byte for each
 //|         pixel.
 //|
-//|         :param ~int size: Number of pixels
-//|         :param ~str byteorder: Byte order string (such as "RGB", "RGBW" or "PBGR")
-//|         :param ~float brightness: Brightness (0 to 1.0, default 1.0)
-//|         :param ~bool auto_write: Whether to automatically write pixels (Default False)
-//|         :param bytes header: Sequence of bytes to always send before pixel values.
-//|         :param bytes trailer: Sequence of bytes to always send after pixel values."""
+//|         :param int size: Number of pixels
+//|         :param str byteorder: Byte order string (such as "RGB", "RGBW" or "PBGR")
+//|         :param float brightness: Brightness (0 to 1.0, default 1.0)
+//|         :param bool auto_write: Whether to automatically write pixels (Default False)
+//|         :param ~_typing.ReadableBuffer header: Sequence of bytes to always send before pixel values.
+//|         :param ~_typing.ReadableBuffer trailer: Sequence of bytes to always send after pixel values."""
 //|         ...
 //|
 STATIC mp_obj_t pixelbuf_pixelbuf_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -257,7 +257,7 @@ STATIC mp_obj_t pixelbuf_pixelbuf_show(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(pixelbuf_pixelbuf_show_obj, pixelbuf_pixelbuf_show);
 
-//|     def fill(self, color: Union[int, Tuple[int, int, int]]) -> None:
+//|     def fill(self, color: Union[int, Tuple[int, int, int], Tuple[int, int, int, float]]) -> None:
 //|         """Fills the given pixelbuf with the given color."""
 //|         ...
 //|
@@ -270,18 +270,20 @@ STATIC mp_obj_t pixelbuf_pixelbuf_fill(mp_obj_t self_in, mp_obj_t value) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(pixelbuf_pixelbuf_fill_obj, pixelbuf_pixelbuf_fill);
 
 //|     @overload
-//|     def __getitem__(self, index: slice) -> Tuple[Tuple, ...]: ...
-//|     def __getitem__(self, index: int) -> Tuple:
+//|     def __getitem__(self, index: slice) -> Union[Tuple[Tuple[int, int, int], ...], Tuple[Tuple[int, int, int, float], ...]]: ...
+//|     @overload
+//|     def __getitem__(self, index: int) -> Union[Tuple[int, int, int], Tuple[int, int, int, float]]:
 //|         """Returns the pixel value at the given index as a tuple of (Red, Green, Blue[, White]) values
 //|         between 0 and 255.  When in PWM (DotStar) mode, the 4th tuple value is a float of the pixel
 //|         intensity from 0-1.0."""
 //|         ...
 //|
 //|     @overload
-//|     def __setitem__(self, index: slice, value: Tuple[Union[int, Tuple, List], ...]) -> None: ...
+//|     def __setitem__(self, index: slice, value: Tuple[Union[int, Tuple[float, ...], List[float]], ...]) -> None: ...
 //|     @overload
-//|     def __setitem__(self, index: slice, value: List[Union[int, Tuple, List]]) -> None: ...
-//|     def __setitem__(self, index: int, value: Union[int, Tuple, List]) -> None:
+//|     def __setitem__(self, index: slice, value: List[Union[int, Tuple[float, ...], List[float]]]) -> None: ...
+//|     @overload
+//|     def __setitem__(self, index: int, value: Union[int, Tuple[float, ...], List[float]]) -> None:
 //|         """Sets the pixel value at the given index.  Value can either be a tuple or integer.  Tuples are
 //|         The individual (Red, Green, Blue[, White]) values between 0 and 255.  If given an integer, the
 //|         red, green and blue values are packed into the lower three bytes (0xRRGGBB).

--- a/shared-bindings/_pixelbuf/__init__.c
+++ b/shared-bindings/_pixelbuf/__init__.c
@@ -33,7 +33,7 @@
 #include "shared-bindings/_pixelbuf/PixelBuf.h"
 
 
-//| """A fast RGB(W) pixel buffer library for like NeoPixel and DotStar.
+//| """A fast RGB(W) pixel buffer library for like NeoPixel and DotStar
 //|
 //| The `_pixelbuf` module provides the :py:class:`PixelBuf` class to accelerate
 //| RGB(W) strip/matrix manipulation, such as DotStar and Neopixel.

--- a/shared-bindings/_stage/Layer.c
+++ b/shared-bindings/_stage/Layer.c
@@ -40,9 +40,9 @@
 //|
 //|         :param int width: The width of the grid in tiles, or 1 for sprites.
 //|         :param int height: The height of the grid in tiles, or 1 for sprites.
-//|         :param bytearray graphic: The graphic data of the tiles.
-//|         :param bytearray palette: The color palette to be used.
-//|         :param bytearray grid: The contents of the grid map.
+//|         :param ~_typing.ReadableBuffer graphic: The graphic data of the tiles.
+//|         :param ~_typing.ReadableBuffer palette: The color palette to be used.
+//|         :param ~_typing.ReadableBuffer grid: The contents of the grid map.
 //|
 //|         This class is intended for internal use in the ``stage`` library and
 //|         it shouldn't be used on its own."""

--- a/shared-bindings/_stage/Text.c
+++ b/shared-bindings/_stage/Text.c
@@ -40,9 +40,9 @@
 //|
 //|         :param int width: The width of the grid in tiles, or 1 for sprites.
 //|         :param int height: The height of the grid in tiles, or 1 for sprites.
-//|         :param bytearray font: The font data of the characters.
-//|         :param bytearray palette: The color palette to be used.
-//|         :param bytearray chars: The contents of the character grid.
+//|         :param ~_typing.ReadableBuffer font: The font data of the characters.
+//|         :param ~_typing.ReadableBuffer palette: The color palette to be used.
+//|         :param ~_typing.ReadableBuffer chars: The contents of the character grid.
 //|
 //|         This class is intended for internal use in the ``stage`` library and
 //|         it shouldn't be used on its own."""

--- a/shared-bindings/_stage/__init__.c
+++ b/shared-bindings/_stage/__init__.c
@@ -39,15 +39,16 @@
 //| The `_stage` module contains native code to speed-up the ```stage`` Library
 //| <https://github.com/python-ugame/circuitpython-stage>`_."""
 //|
-//| def render(x0: int, y0: int, x1: int, y1: int, layers: list, buffer: WriteableBuffer, display: displayio.Display, scale: int, background: int) -> None:
+//| def render(x0: int, y0: int, x1: int, y1: int, layers: List[Layer], buffer: WriteableBuffer, display: displayio.Display, scale: int, background: int) -> None:
 //|     """Render and send to the display a fragment of the screen.
 //|
 //|     :param int x0: Left edge of the fragment.
 //|     :param int y0: Top edge of the fragment.
 //|     :param int x1: Right edge of the fragment.
 //|     :param int y1: Bottom edge of the fragment.
-//|     :param list layers: A list of the :py:class:`~_stage.Layer` objects.
-//|     :param bytearray buffer: A buffer to use for rendering.
+//|     :param layers: A list of the :py:class:`~_stage.Layer` objects.
+//|     :type layers: list[Layer]
+//|     :param ~_typing.WriteableBuffer buffer: A buffer to use for rendering.
 //|     :param ~displayio.Display display: The display to use.
 //|     :param int scale: How many times should the image be scaled up.
 //|     :param int background: What color to display when nothing is there.

--- a/shared-bindings/_typing/__init__.pyi
+++ b/shared-bindings/_typing/__init__.pyi
@@ -1,0 +1,54 @@
+"""Types for the C-level protocols"""
+
+from typing import Union
+
+import array
+import audiocore
+import audiomixer
+import audiomp3
+import rgbmatrix
+import ulab
+
+ReadableBuffer = Union[
+    bytes, bytearray, memoryview, array.array, ulab.array, rgbmatrix.RGBMatrix
+]
+"""Classes that implement the readable buffer protocol
+
+  - `bytes`
+  - `bytearray`
+  - `memoryview`
+  - `array.array`
+  - `ulab.array`
+  - `rgbmatrix.RGBMatrix`
+"""
+
+WriteableBuffer = Union[
+    bytearray, memoryview, array.array, ulab.array, rgbmatrix.RGBMatrix
+]
+"""Classes that implement the writeable buffer protocol
+
+  - `bytearray`
+  - `memoryview`
+  - `array.array`
+  - `ulab.array`
+  - `rgbmatrix.RGBMatrix`
+"""
+
+AudioSample = Union[
+    audiocore.WaveFile, audiocore.RawSample, audiomixer.Mixer, audiomp3.MP3Decoder
+]
+"""Classes that implement the audiosample protocol
+
+  - `audiocore.WaveFile`
+  - `audiocore.RawSample`
+  - `audiomixer.Mixer`
+  - `audiomp3.MP3Decoder`
+
+  You can play these back with `audioio.AudioOut`, `audiobusio.I2SOut` or `audiopwmio.PWMAudioOut`.
+"""
+
+FrameBuffer = Union[rgbmatrix.RGBMatrix]
+"""Classes that implement the framebuffer protocol
+
+  - `rgbmatrix.RGBMatrix`
+"""

--- a/shared-bindings/aesio/aes.c
+++ b/shared-bindings/aesio/aes.c
@@ -15,10 +15,10 @@
 //|     def __init__(self, key: ReadableBuffer, mode: int = 0, iv: Optional[ReadableBuffer] = None, segment_size: int = 8) -> None:
 //|         """Create a new AES state with the given key.
 //|
-//|            :param bytearray key: A 16-, 24-, or 32-byte key
+//|            :param ~_typing.ReadableBuffer key: A 16-, 24-, or 32-byte key
 //|            :param int mode: AES mode to use.  One of: AES.MODE_ECB, AES.MODE_CBC, or
 //|                             AES.MODE_CTR
-//|            :param bytearray iv: Initialization vector to use for CBC or CTR mode
+//|            :param ~_typing.ReadableBuffer iv: Initialization vector to use for CBC or CTR mode
 //|
 //|            Additional arguments are supported for legacy reasons.
 //|

--- a/shared-bindings/audiobusio/I2SOut.c
+++ b/shared-bindings/audiobusio/I2SOut.c
@@ -155,11 +155,11 @@ STATIC mp_obj_t audiobusio_i2sout_obj___exit__(size_t n_args, const mp_obj_t *ar
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiobusio_i2sout___exit___obj, 4, 4, audiobusio_i2sout_obj___exit__);
 
 
-//|     def play(self, sample: audiocore._AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: _typing.AudioSample, *, loop: bool = False) -> None:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         Sample must be an `audiocore.WaveFile`, `audiocore.RawSample`, or `audiomixer.Mixer`.
+//|         Sample must be an `audiocore.WaveFile`, `audiocore.RawSample`, `audiomixer.Mixer` or `audiomp3.MP3Decoder`.
 //|
 //|         The sample itself should consist of 8 bit or 16 bit samples."""
 //|         ...

--- a/shared-bindings/audiocore/RawSample.c
+++ b/shared-bindings/audiocore/RawSample.c
@@ -44,7 +44,7 @@
 //|         first sample will be for channel 1, the second sample will be for channel two, the third for
 //|         channel 1 and so on.
 //|
-//|         :param ReadableBuffer buffer: A buffer with samples
+//|         :param ~_typing.ReadableBuffer buffer: A buffer with samples
 //|         :param int channel_count: The number of channels in the buffer
 //|         :param int sample_rate: The desired playback sample rate
 //|

--- a/shared-bindings/audiocore/WaveFile.c
+++ b/shared-bindings/audiocore/WaveFile.c
@@ -40,11 +40,11 @@
 //|     be 8 bit unsigned or 16 bit signed. If a buffer is provided, it will be used instead of allocating
 //|     an internal buffer."""
 //|
-//|     def __init__(self, file: typing.BinaryIO, buffer: ReadableBuffer) -> None:
+//|     def __init__(self, file: typing.BinaryIO, buffer: WriteableBuffer) -> None:
 //|         """Load a .wav file for playback with `audioio.AudioOut` or `audiobusio.I2SOut`.
 //|
 //|         :param typing.BinaryIO file: Already opened wave file
-//|         :param bytearray buffer: Optional pre-allocated buffer, that will be split in half and used for double-buffering of the data. If not provided, two 512 byte buffers are allocated internally.
+//|         :param ~_typing.WriteableBuffer buffer: Optional pre-allocated buffer, that will be split in half and used for double-buffering of the data. If not provided, two 512 byte buffers are allocated internally.
 //|
 //|
 //|         Playing a wave file from flash::

--- a/shared-bindings/audiocore/__init__.c
+++ b/shared-bindings/audiocore/__init__.c
@@ -38,13 +38,6 @@
 //| """Support for audio samples"""
 //|
 
-//| _AudioSample = Union[audiocore.WaveFile, audiocore.RawSample, audiomixer.Mixer, audiomp3.MP3Decoder]
-//| """An audio sample for playback with `audioio.AudioOut`, `audiobusio.I2SOut` or `audiopwmio.PWMAudioOut`.
-//|
-//| Supported sources are :py:class:`audiocore.WaveFile`, :py:class:`audiocore.RawSample`,
-//| :py:class:`audiomixer.Mixer` and :py:class:`audiomp3.MP3Decoder`."""
-//|
-
 STATIC const mp_rom_map_elem_t audiocore_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audiocore) },
     { MP_ROM_QSTR(MP_QSTR_RawSample), MP_ROM_PTR(&audioio_rawsample_type) },

--- a/shared-bindings/audioio/AudioOut.c
+++ b/shared-bindings/audioio/AudioOut.c
@@ -146,11 +146,11 @@ STATIC mp_obj_t audioio_audioout_obj___exit__(size_t n_args, const mp_obj_t *arg
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audioio_audioout___exit___obj, 4, 4, audioio_audioout_obj___exit__);
 
 
-//|     def play(self, sample: audiocore._AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: _typing.AudioSample, *, loop: bool = False) -> None:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         Sample must be an `audiocore.WaveFile`, `audiocore.RawSample`, or `audiomixer.Mixer`.
+//|         Sample must be an `audiocore.WaveFile`, `audiocore.RawSample`, `audiomixer.Mixer` or `audiomp3.MP3Decoder`.
 //|
 //|         The sample itself should consist of 16 bit samples. Microcontrollers with a lower output
 //|         resolution will use the highest order bits to output. For example, the SAMD21 has a 10 bit

--- a/shared-bindings/audiomixer/Mixer.c
+++ b/shared-bindings/audiomixer/Mixer.c
@@ -211,11 +211,11 @@ const mp_obj_property_t audiomixer_mixer_voice_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
-//|     def play(self, sample: audiocore._AudioSample, *, voice: int = 0, loop: bool = False) -> None:
+//|     def play(self, sample: _typing.AudioSample, *, voice: int = 0, loop: bool = False) -> None:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         Sample must be an `audiocore.WaveFile`, `audiocore.RawSample`, or `audiomixer.Mixer`.
+//|         Sample must be an `audiocore.WaveFile`, `audiocore.RawSample`, `audiomixer.Mixer` or `audiomp3.MP3Decoder`.
 //|
 //|         The sample must match the Mixer's encoding settings given in the constructor."""
 //|         ...

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -56,11 +56,11 @@ STATIC mp_obj_t audiomixer_mixervoice_make_new(const mp_obj_type_t *type, size_t
     return MP_OBJ_FROM_PTR(self);
 }
 
-//|     def play(self, sample: audiocore._AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: _typing.AudioSample, *, loop: bool = False) -> None:
 //|         """Plays the sample once when ``loop=False``, and continuously when ``loop=True``.
 //|         Does not block. Use `playing` to block.
 //|
-//|         Sample must be an `audiocore.WaveFile`, `audiomixer.Mixer` or `audiocore.RawSample`.
+//|         Sample must be an `audiocore.WaveFile`, `audiocore.RawSample`, `audiomixer.Mixer` or `audiomp3.MP3Decoder`.
 //|
 //|         The sample must match the `audiomixer.Mixer`'s encoding settings given in the constructor."""
 //|         ...

--- a/shared-bindings/audiomp3/MP3Decoder.c
+++ b/shared-bindings/audiomp3/MP3Decoder.c
@@ -42,7 +42,7 @@
 //|         """Load a .mp3 file for playback with `audioio.AudioOut` or `audiobusio.I2SOut`.
 //|
 //|         :param typing.BinaryIO file: Already opened mp3 file
-//|         :param bytearray buffer: Optional pre-allocated buffer, that will be split in half and used for double-buffering of the data. If not provided, two buffers are allocated internally.  The specific buffer size required depends on the mp3 file.
+//|         :param ~_typing.WriteableBuffer buffer: Optional pre-allocated buffer, that will be split in half and used for double-buffering of the data. If not provided, two buffers are allocated internally.  The specific buffer size required depends on the mp3 file.
 //|
 //|
 //|         Playing a mp3 file from flash::
@@ -106,7 +106,7 @@ STATIC void check_for_deinit(audiomp3_mp3file_obj_t *self) {
     }
 }
 
-//|     def __enter__(self) -> MP3:
+//|     def __enter__(self) -> MP3Decoder:
 //|         """No-op used by Context Managers."""
 //|         ...
 //|
@@ -124,7 +124,7 @@ STATIC mp_obj_t audiomp3_mp3file_obj___exit__(size_t n_args, const mp_obj_t *arg
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiomp3_mp3file___exit___obj, 4, 4, audiomp3_mp3file_obj___exit__);
 
-//|     file: file
+//|     file: typing.BinaryIO
 //|     """File to play back."""
 //|
 STATIC mp_obj_t audiomp3_mp3file_obj_get_file(mp_obj_t self_in) {

--- a/shared-bindings/audiopwmio/PWMAudioOut.c
+++ b/shared-bindings/audiopwmio/PWMAudioOut.c
@@ -148,11 +148,11 @@ STATIC mp_obj_t audiopwmio_pwmaudioout_obj___exit__(size_t n_args, const mp_obj_
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiopwmio_pwmaudioout___exit___obj, 4, 4, audiopwmio_pwmaudioout_obj___exit__);
 
 
-//|     def play(self, sample: audiocore._AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: _typing.AudioSample, *, loop: bool = False) -> None:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         Sample must be an `audiocore.WaveFile`, `audiocore.RawSample`, or `audiomixer.Mixer`.
+//|         Sample must be an `audiocore.WaveFile`, `audiocore.RawSample`, `audiomixer.Mixer` or `audiomp3.MP3Decoder`.
 //|
 //|         The sample itself should consist of 16 bit samples. Microcontrollers with a lower output
 //|         resolution will use the highest order bits to output. For example, the SAMD21 has a 10 bit

--- a/shared-bindings/bitbangio/I2C.c
+++ b/shared-bindings/bitbangio/I2C.c
@@ -120,7 +120,7 @@ static void check_lock(bitbangio_i2c_obj_t *self) {
     }
 }
 
-//|     def scan(self) -> list:
+//|     def scan(self) -> List[int]:
 //|         """Scan all I2C addresses between 0x08 and 0x77 inclusive and return a list of
 //|         those that respond.  A device responds if it pulls the SDA line low after
 //|         its address (including a read bit) is sent on the bus."""
@@ -175,7 +175,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_i2c_unlock_obj, bitbangio_i2c_obj_unlock);
 //|         ``buf[start:end]`` will so it saves memory.
 //|
 //|         :param int address: 7-bit device address
-//|         :param bytearray buffer: buffer to write into
+//|         :param ~_typing.WriteableBuffer buffer: buffer to write into
 //|         :param int start: Index to start writing at
 //|         :param int end: Index to write up to but not include"""
 //|         ...
@@ -230,7 +230,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_i2c_readfrom_into_obj, 3, bitbangio_i2c_rea
 //|         to poll for the existence of a device.
 //|
 //|         :param int address: 7-bit device address
-//|         :param bytearray buffer: buffer containing the bytes to write
+//|         :param ~_typing.ReadableBuffer buffer: buffer containing the bytes to write
 //|         :param int start: Index to start writing from
 //|         :param int end: Index to read up to but not include"""
 //|         ...
@@ -274,7 +274,7 @@ STATIC mp_obj_t bitbangio_i2c_writeto(size_t n_args, const mp_obj_t *pos_args, m
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_i2c_writeto_obj, 1, bitbangio_i2c_writeto);
 
 
-//|     def writeto_then_readfrom(self, address: int, out_buffer: WriteableBuffer, in_buffer: ReadableBuffer, *, out_start: int = 0, out_end: Optional[int] = None, in_start: int = 0, in_end: Optional[int] = None) -> None:
+//|     def writeto_then_readfrom(self, address: int, out_buffer: ReadableBuffer, in_buffer: ReadableBuffer, *, out_start: int = 0, out_end: Optional[int] = None, in_start: int = 0, in_end: Optional[int] = None) -> None:
 //|         """Write the bytes from ``out_buffer`` to the device selected by ``address``, generate no stop
 //|         bit, generate a repeated start and read into ``in_buffer``. ``out_buffer`` and
 //|         ``in_buffer`` can be the same buffer because they are used sequentially.
@@ -284,8 +284,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_i2c_writeto_obj, 1, bitbangio_i2c_wr
 //|         will so it saves memory.
 //|
 //|         :param int address: 7-bit device address
-//|         :param bytearray out_buffer: buffer containing the bytes to write
-//|         :param bytearray in_buffer: buffer to write into
+//|         :param ~_typing.ReadableBuffer out_buffer: buffer containing the bytes to write
+//|         :param ~_typing.WriteableBuffer in_buffer: buffer to write into
 //|         :param int out_start: Index to start writing from
 //|         :param int out_end: Index to read up to but not include. Defaults to ``len(buffer)``
 //|         :param int in_start: Index to start writing at

--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -254,8 +254,8 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitbangio_spi_readinto_obj, 2, 2, bitbangio_
 //|         must be equal.
 //|         If buffer slice lengths are both 0, nothing happens.
 //|
-//|         :param bytearray buffer_out: Write out the data in this buffer
-//|         :param bytearray buffer_in: Read data into this buffer
+//|         :param ~_typing.ReadableBuffer buffer_out: Write out the data in this buffer
+//|         :param ~_typing.WriteableBuffer buffer_in: Read data into this buffer
 //|         :param int out_start: Start of the slice of buffer_out to write out: ``buffer_out[out_start:out_end]``
 //|         :param int out_end: End of the slice; this index is not included. Defaults to ``len(buffer_out)``
 //|         :param int in_start: Start of the slice of ``buffer_in`` to read into: ``buffer_in[in_start:in_end]``

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -125,7 +125,7 @@ static void check_lock(busio_i2c_obj_t *self) {
     }
 }
 
-//|     def scan(self) -> list:
+//|     def scan(self) -> List[int]:
 //|         """Scan all I2C addresses between 0x08 and 0x77 inclusive and return a
 //|         list of those that respond.
 //|
@@ -185,7 +185,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_i2c_unlock_obj, busio_i2c_obj_unlock);
 //|         ``buf[start:end]`` will so it saves memory.
 //|
 //|         :param int address: 7-bit device address
-//|         :param bytearray buffer: buffer to write into
+//|         :param ~_typing.WriteableBuffer buffer: buffer to write into
 //|         :param int start: Index to start writing at
 //|         :param int end: Index to write up to but not include. Defaults to ``len(buffer)``"""
 //|         ...
@@ -239,7 +239,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_i2c_readfrom_into_obj, 3, busio_i2c_readfrom_in
 //|         to poll for the existence of a device.
 //|
 //|         :param int address: 7-bit device address
-//|         :param bytearray buffer: buffer containing the bytes to write
+//|         :param ~_typing.ReadbleBuffer buffer: buffer containing the bytes to write
 //|         :param int start: Index to start writing from
 //|         :param int end: Index to read up to but not include. Defaults to ``len(buffer)``"""
 //|         ...
@@ -291,8 +291,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(busio_i2c_writeto_obj, 1, busio_i2c_writeto);
 //|         will so it saves memory.
 //|
 //|         :param int address: 7-bit device address
-//|         :param bytearray out_buffer: buffer containing the bytes to write
-//|         :param bytearray in_buffer: buffer to write into
+//|         :param ~_typing.ReadbleBuffer out_buffer: buffer containing the bytes to write
+//|         :param ~_typing.WriteableBuffer in_buffer: buffer to write into
 //|         :param int out_start: Index to start writing from
 //|         :param int out_end: Index to read up to but not include. Defaults to ``len(buffer)``
 //|         :param int in_start: Index to start writing at

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -232,7 +232,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_spi_unlock_obj, busio_spi_obj_unlock);
 //|         """Write the data contained in ``buffer``. The SPI object must be locked.
 //|         If the buffer is empty, nothing happens.
 //|
-//|         :param bytearray buffer: Write out the data in this buffer
+//|         :param ~_typing.ReadableBuffer buffer: Write out the data in this buffer
 //|         :param int start: Start of the slice of ``buffer`` to write out: ``buffer[start:end]``
 //|         :param int end: End of the slice; this index is not included. Defaults to ``len(buffer)``"""
 //|         ...
@@ -275,7 +275,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_write_obj, 2, busio_spi_write);
 //|         The SPI object must be locked.
 //|         If the number of bytes to read is 0, nothing happens.
 //|
-//|         :param bytearray buffer: Read data into this buffer
+//|         :param ~_typing.WriteableBuffer buffer: Read data into this buffer
 //|         :param int start: Start of the slice of ``buffer`` to read into: ``buffer[start:end]``
 //|         :param int end: End of the slice; this index is not included. Defaults to ``len(buffer)``
 //|         :param int write_value: Value to write while reading. (Usually ignored.)"""
@@ -314,15 +314,15 @@ STATIC mp_obj_t busio_spi_readinto(size_t n_args, const mp_obj_t *pos_args, mp_m
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_readinto_obj, 2, busio_spi_readinto);
 
-//|     def write_readinto(self, buffer_out: ReadableBuffer, buffer_in: ReadableBuffer, *, out_start: int = 0, out_end: Optional[int] = None, in_start: int = 0, in_end: Optional[int] = None) -> None:
+//|     def write_readinto(self, buffer_out: ReadableBuffer, buffer_in: WriteableBuffer, *, out_start: int = 0, out_end: Optional[int] = None, in_start: int = 0, in_end: Optional[int] = None) -> None:
 //|         """Write out the data in ``buffer_out`` while simultaneously reading data into ``buffer_in``.
 //|         The SPI object must be locked.
 //|         The lengths of the slices defined by ``buffer_out[out_start:out_end]`` and ``buffer_in[in_start:in_end]``
 //|         must be equal.
 //|         If buffer slice lengths are both 0, nothing happens.
 //|
-//|         :param bytearray buffer_out: Write out the data in this buffer
-//|         :param bytearray buffer_in: Read data into this buffer
+//|         :param ~_typing.ReadableBuffer buffer_out: Write out the data in this buffer
+//|         :param ~_typing.WriteableBuffer buffer_in: Read data into this buffer
 //|         :param int out_start: Start of the slice of buffer_out to write out: ``buffer_out[out_start:out_end]``
 //|         :param int out_end: End of the slice; this index is not included. Defaults to ``len(buffer_out)``
 //|         :param int in_start: Start of the slice of ``buffer_in`` to read into: ``buffer_in[in_start:in_end]``

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -81,8 +81,8 @@
 //|         of the display to minimize tearing artifacts.
 //|
 //|         :param display_bus: The bus that the display is connected to
-//|         :type display_bus: FourWire, ParallelBus or I2CDisplay
-//|         :param buffer init_sequence: Byte-packed initialization sequence.
+//|         :type _DisplayBus: FourWire, ParallelBus or I2CDisplay
+//|         :param ~_typing.ReadableBuffer init_sequence: Byte-packed initialization sequence.
 //|         :param int width: Width in pixels
 //|         :param int height: Height in pixels
 //|         :param int colstart: The index if the first visible column
@@ -344,7 +344,7 @@ const mp_obj_property_t displayio_display_auto_brightness_obj = {
 
 
 //|     width: int
-//|	    Gets the width of the board
+//|     """Gets the width of the board"""
 //|
 STATIC mp_obj_t displayio_display_obj_get_width(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);
@@ -360,7 +360,7 @@ const mp_obj_property_t displayio_display_width_obj = {
 };
 
 //|     height: int
-//|	    """Gets the height of the board"""
+//|     """Gets the height of the board"""
 //|
 STATIC mp_obj_t displayio_display_obj_get_height(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);
@@ -399,7 +399,7 @@ const mp_obj_property_t displayio_display_rotation_obj = {
 };
 
 //|     bus: _DisplayBus
-//|	    """The bus being used by the display"""
+//|     """The bus being used by the display"""
 //|
 //|
 STATIC mp_obj_t displayio_display_obj_get_bus(mp_obj_t self_in) {
@@ -420,7 +420,7 @@ const mp_obj_property_t displayio_display_bus_obj = {
 //|         """Extract the pixels from a single row
 //|
 //|         :param int y: The top edge of the area
-//|         :param bytearray buffer: The buffer in which to place the pixel data"""
+//|         :param ~_typing.WriteableBuffer buffer: The buffer in which to place the pixel data"""
 //|         ...
 //|
 STATIC mp_obj_t displayio_display_obj_fill_row(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/displayio/EPaperDisplay.c
+++ b/shared-bindings/displayio/EPaperDisplay.c
@@ -60,9 +60,9 @@
 //|         begin a new command definition.
 //|
 //|         :param display_bus: The bus that the display is connected to
-//|         :type display_bus: displayio.FourWire or displayio.ParallelBus
-//|         :param buffer start_sequence: Byte-packed initialization sequence.
-//|         :param buffer stop_sequence: Byte-packed initialization sequence.
+//|         :type _DisplayBus: displayio.FourWire or displayio.ParallelBus
+//|         :param ~_typing.ReadableBuffer start_sequence: Byte-packed initialization sequence.
+//|         :param ~_typing.ReadableBuffer stop_sequence: Byte-packed initialization sequence.
 //|         :param int width: Width in pixels
 //|         :param int height: Height in pixels
 //|         :param int ram_width: RAM width in pixels
@@ -238,7 +238,7 @@ const mp_obj_property_t displayio_epaperdisplay_width_obj = {
 };
 
 //|     height: int
-//|	    """Gets the height of the display in pixels"""
+//|     """Gets the height of the display in pixels"""
 //|
 STATIC mp_obj_t displayio_epaperdisplay_obj_get_height(mp_obj_t self_in) {
     displayio_epaperdisplay_obj_t *self = native_display(self_in);
@@ -254,7 +254,7 @@ const mp_obj_property_t displayio_epaperdisplay_height_obj = {
 };
 
 //|     bus: _DisplayBus
-//|	    """The bus being used by the display"""
+//|     """The bus being used by the display"""
 //|
 STATIC mp_obj_t displayio_epaperdisplay_obj_get_bus(mp_obj_t self_in) {
     displayio_epaperdisplay_obj_t *self = native_display(self_in);

--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -190,7 +190,7 @@ const mp_obj_property_t displayio_group_y_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
-//|     def append(self, layer: Union[vectorio.Shape, Group, TileGrid]) -> None:
+//|     def append(self, layer: Union[vectorio.VectorShape, Group, TileGrid]) -> None:
 //|         """Append a layer to the group. It will be drawn above other layers."""
 //|         ...
 //|
@@ -201,7 +201,7 @@ STATIC mp_obj_t displayio_group_obj_append(mp_obj_t self_in, mp_obj_t layer) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_group_append_obj, displayio_group_obj_append);
 
-//|     def insert(self, index: int, layer: Union[vectorio.Shape, Group, TileGrid]) -> None:
+//|     def insert(self, index: int, layer: Union[vectorio.VectorShape, Group, TileGrid]) -> None:
 //|         """Insert a layer into the group."""
 //|         ...
 //|
@@ -217,7 +217,7 @@ STATIC mp_obj_t displayio_group_obj_insert(mp_obj_t self_in, mp_obj_t index_obj,
 MP_DEFINE_CONST_FUN_OBJ_3(displayio_group_insert_obj, displayio_group_obj_insert);
 
 
-//|     def index(self, layer: Union[vectorio.Shape, Group, TileGrid]) -> int:
+//|     def index(self, layer: Union[vectorio.VectorShape, Group, TileGrid]) -> int:
 //|         """Returns the index of the first copy of layer. Raises ValueError if not found."""
 //|         ...
 //|
@@ -231,7 +231,7 @@ STATIC mp_obj_t displayio_group_obj_index(mp_obj_t self_in, mp_obj_t layer) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_group_index_obj, displayio_group_obj_index);
 
-//|     def pop(self, i: int = -1) -> Union[vectorio.Shape, Group, TileGrid]:
+//|     def pop(self, i: int = -1) -> Union[vectorio.VectorShape, Group, TileGrid]:
 //|         """Remove the ith item and return it."""
 //|         ...
 //|
@@ -254,7 +254,7 @@ STATIC mp_obj_t displayio_group_obj_pop(size_t n_args, const mp_obj_t *pos_args,
 MP_DEFINE_CONST_FUN_OBJ_KW(displayio_group_pop_obj, 1, displayio_group_obj_pop);
 
 
-//|     def remove(self, layer: Union[vectorio.Shape, Group, TileGrid]) -> None:
+//|     def remove(self, layer: Union[vectorio.VectorShape, Group, TileGrid]) -> None:
 //|         """Remove the first copy of layer. Raises ValueError if it is not present."""
 //|         ...
 //|
@@ -284,7 +284,7 @@ STATIC mp_obj_t group_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     }
 }
 
-//|     def __getitem__(self, index: int) -> Union[vectorio.Shape, Group, TileGrid]:
+//|     def __getitem__(self, index: int) -> Union[vectorio.VectorShape, Group, TileGrid]:
 //|         """Returns the value at the given index.
 //|
 //|         This allows you to::
@@ -292,7 +292,7 @@ STATIC mp_obj_t group_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 //|           print(group[0])"""
 //|         ...
 //|
-//|     def __setitem__(self, index: int, value: Union[vectorio.Shape, Group, TileGrid]) -> None:
+//|     def __setitem__(self, index: int, value: Union[vectorio.VectorShape, Group, TileGrid]) -> None:
 //|         """Sets the value at the given index.
 //|
 //|         This allows you to::

--- a/shared-bindings/fontio/Glyph.c
+++ b/shared-bindings/fontio/Glyph.c
@@ -39,7 +39,7 @@
 //|                  dx: int,
 //|                  dy: int,
 //|                  shift_x: int,
-//|                  shift_y: int):
+//|                  shift_y: int) -> None:
 //|         """Named tuple used to capture a single glyph and its attributes.
 //|
 //|         :param bitmap: the bitmap including the glyph

--- a/shared-bindings/framebufferio/FramebufferDisplay.c
+++ b/shared-bindings/framebufferio/FramebufferDisplay.c
@@ -47,11 +47,10 @@
 //|     objects in CircuitPython, Display objects live until `displayio.release_displays()`
 //|     is called. This is done so that CircuitPython can use the display itself."""
 //|
-//|     def __init__(self, framebuffer: rgbmatrix.RGBMatrix, *, rotation: int = 0, auto_refresh: bool = True) -> None:
+//|     def __init__(self, framebuffer: _typing.FrameBuffer, *, rotation: int = 0, auto_refresh: bool = True) -> None:
 //|         """Create a Display object with the given framebuffer (a buffer, array, ulab.array, etc)
 //|
-//|         :param framebuffer: The framebuffer that the display is connected to
-//|         :type framebuffer: any core object implementing the framebuffer protocol
+//|         :param ~_typing.FrameBuffer framebuffer: The framebuffer that the display is connected to
 //|         :param bool auto_refresh: Automatically refresh the screen
 //|         :param int rotation: The rotation of the display in degrees clockwise. Must be in 90 degree increments (0, 90, 180, 270)"""
 //|         ...
@@ -245,7 +244,7 @@ const mp_obj_property_t framebufferio_framebufferdisplay_auto_brightness_obj = {
 };
 
 //|     width: int
-//|	    """Gets the width of the framebuffer"""
+//|     """Gets the width of the framebuffer"""
 //|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_width(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
@@ -261,7 +260,7 @@ const mp_obj_property_t framebufferio_framebufferdisplay_width_obj = {
 };
 
 //|     height: int
-//|	    """Gets the height of the framebuffer"""
+//|     """Gets the height of the framebuffer"""
 //|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_height(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
@@ -299,8 +298,8 @@ const mp_obj_property_t framebufferio_framebufferdisplay_rotation_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
-//|     framebuffer: rgbmatrix.RGBMatrix
-//|	    """The framebuffer being used by the display"""
+//|     framebuffer: _typing.FrameBuffer
+//|     """The framebuffer being used by the display"""
 //|
 //|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_framebuffer(mp_obj_t self_in) {
@@ -317,11 +316,11 @@ const mp_obj_property_t framebufferio_framebufferframebuffer_obj = {
 };
 
 
-//|     def fill_row(self, y: int, buffer: WriteableBuffer) -> displayio:
+//|     def fill_row(self, y: int, buffer: WriteableBuffer) -> WriteableBuffer:
 //|         """Extract the pixels from a single row
 //|
 //|         :param int y: The top edge of the area
-//|         :param bytearray buffer: The buffer in which to place the pixel data"""
+//|         :param ~_typing.WriteableBuffer buffer: The buffer in which to place the pixel data"""
 //|         ...
 //|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_fill_row(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/help.rst
+++ b/shared-bindings/help.rst
@@ -22,7 +22,7 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
    THE SOFTWARE.
 
-:func:`help` - Built-in method to provide helpful information
+:func:`help` -- Built-in method to provide helpful information
 ==============================================================
 
 .. function:: help(object=None)

--- a/shared-bindings/i2cperipheral/I2CPeripheral.c
+++ b/shared-bindings/i2cperipheral/I2CPeripheral.c
@@ -52,13 +52,14 @@ STATIC mp_obj_t mp_obj_new_i2cperipheral_i2c_peripheral_request(i2cperipheral_i2
 //| class I2CPeripheral:
 //|     """Two wire serial protocol peripheral"""
 //|
-//|     def __init__(self, scl: microcontroller.Pin, sda: microcontroller.Pin, addresses: tuple, smbus: bool = False) -> None:
+//|     def __init__(self, scl: microcontroller.Pin, sda: microcontroller.Pin, addresses: Sequence[int], smbus: bool = False) -> None:
 //|         """I2C is a two-wire protocol for communicating between devices.
 //|         This implements the peripheral (sensor, secondary) side.
 //|
 //|         :param ~microcontroller.Pin scl: The clock pin
 //|         :param ~microcontroller.Pin sda: The data pin
-//|         :param tuple addresses: The I2C addresses to respond to (how many is hw dependent).
+//|         :param addresses: The I2C addresses to respond to (how many is hw dependent).
+//|         :type addresses: list[int]
 //|         :param bool smbus: Use SMBUS timings if the hardware supports it"""
 //|         ...
 //|
@@ -352,7 +353,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(i2cperipheral_i2c_peripheral_request_read_obj, 1, i2c
 //|     def write(self, buffer: ReadableBuffer) -> int:
 //|         """Write the data contained in buffer.
 //|
-//|         :param buffer: Write out the data in this buffer
+//|         :param ~_typing.ReadableBuffer buffer: Write out the data in this buffer
 //|         :return: Number of bytes written"""
 //|         ...
 //|

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -47,6 +47,9 @@
 //| The `microcontroller` module defines the pins from the perspective of the
 //| microcontroller. See `board` for board-specific pin mappings."""
 //|
+//| from nvm import ByteArray
+//| from watchdog import WatchDogTimer
+//|
 
 //| cpu: Processor
 //| """CPU information and control, such as ``cpu.temperature`` and ``cpu.frequency``
@@ -133,14 +136,14 @@ STATIC mp_obj_t mcu_reset(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mcu_reset_obj, mcu_reset);
 
-//| nvm: Optional[nvm.ByteArray]
+//| nvm: Optional[ByteArray]
 //| """Available non-volatile memory.
 //| This object is the sole instance of `nvm.ByteArray` when available or ``None`` otherwise.
 //|
 //| :type: nvm.ByteArray or None"""
 //|
 
-//| watchdog: Optional[watchdog.WatchDogTimer]
+//| watchdog: Optional[WatchDogTimer]
 //| """Available watchdog timer.
 //| This object is the sole instance of `watchdog.WatchDogTimer` when available or ``None`` otherwise."""
 //|

--- a/shared-bindings/multiterminal/__init__.c
+++ b/shared-bindings/multiterminal/__init__.c
@@ -78,7 +78,7 @@ STATIC mp_obj_t multiterminal_obj_clear_secondary_terminal() {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(multiterminal_clear_secondary_terminal_obj, multiterminal_obj_clear_secondary_terminal);
 
-//| def schedule_secondary_terminal_read(socket: secondary_terminal) -> None:
+//| def schedule_secondary_terminal_read(socket: socket.socket) -> None:
 //|     """In cases where the underlying OS is doing task scheduling, this notifies
 //|     the OS when more data is available on the socket to read. This is useful
 //|     as a callback for lwip sockets."""

--- a/shared-bindings/neopixel_write/__init__.c
+++ b/shared-bindings/neopixel_write/__init__.c
@@ -53,8 +53,8 @@
 //| def neopixel_write(digitalinout: digitalio.DigitalInOut, buf: ReadableBuffer) -> None:
 //|     """Write buf out on the given DigitalInOut.
 //|
-//|     :param digitalinout: the DigitalInOut to output with
-//|     :param buf: The bytes to clock out. No assumption is made about color order"""
+//|     :param ~digitalio.DigitalInOut digitalinout: the DigitalInOut to output with
+//|     :param ~_typing.ReadableBuffer buf: The bytes to clock out. No assumption is made about color order"""
 //|     ...
 STATIC mp_obj_t neopixel_write_neopixel_write_(mp_obj_t digitalinout_obj, mp_obj_t buf) {
     if (!MP_OBJ_IS_TYPE(digitalinout_obj, &digitalio_digitalinout_type)) {

--- a/shared-bindings/network/__init__.c
+++ b/shared-bindings/network/__init__.c
@@ -47,7 +47,7 @@
 //| It is used by the 'socket' module to look up a suitable
 //| NIC when a socket is created."""
 //|
-//| def route() -> list:
+//| def route() -> List[object]:
 //|     """Returns a list of all configured NICs."""
 //|     ...
 //|

--- a/shared-bindings/nvm/ByteArray.c
+++ b/shared-bindings/nvm/ByteArray.c
@@ -73,12 +73,14 @@ STATIC MP_DEFINE_CONST_DICT(nvm_bytearray_locals_dict, nvm_bytearray_locals_dict
 
 //|     @overload
 //|     def __getitem__(self, index: slice) -> bytearray: ...
+//|     @overload
 //|     def __getitem__(self, index: int) -> int:
 //|         """Returns the value at the given index."""
 //|         ...
 //|
 //|     @overload
 //|     def __setitem__(self, index: slice, value: ReadableBuffer) -> None: ...
+//|     @overload
 //|     def __setitem__(self, index: int, value: int) -> None:
 //|         """Set the value at the given index."""
 //|         ...

--- a/shared-bindings/os/__init__.c
+++ b/shared-bindings/os/__init__.c
@@ -43,11 +43,21 @@
 //| code written in CircuitPython will work in CPython but not necessarily the
 //| other way around."""
 //|
+//| import typing
 
-//| def uname() -> tuple:
+//| def uname() -> _Uname:
 //|     """Returns a named tuple of operating specific and CircuitPython port
 //|     specific information."""
 //|     ...
+//|
+//| class _Uname(typing.NamedTuple):
+//|     """The type of values that :py:func:`.uname()` returns"""
+//|
+//|     sysname: str
+//|     nodename: str
+//|     release: str
+//|     version: str
+//|     machine: str
 //|
 STATIC mp_obj_t os_uname(void) {
     return common_hal_os_uname();
@@ -134,7 +144,7 @@ mp_obj_t os_rmdir(mp_obj_t path_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(os_rmdir_obj, os_rmdir);
 
-//| def stat(path: str) -> str:
+//| def stat(path: str) -> Tuple[int, int, int, int, int, int, int, int, int, int]:
 //|     """Get the status of a file or directory.
 //|
 //|     .. note:: On builds without long integers, the number of seconds

--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -128,7 +128,7 @@ STATIC void preflight_pins_or_throw(uint8_t clock_pin, uint8_t *rgb_pins, uint8_
     }
 }
 
-//|     def __init__(self, *, width: int, bit_depth: int, rgb_pins: Sequence[digitalio.DigitalInOut], addr_pins: List[digitalio.DigitalInOut], clock_pin: digitalio.DigitalInOut, latch_pin: digitalio.DigitalInOut, output_enable_pin: digitalio.DigitalInOut, doublebuffer: bool = True, framebuffer: Optional[WriteableBuffer] = None, height: int = 0) -> None:
+//|     def __init__(self, *, width: int, bit_depth: int, rgb_pins: Sequence[digitalio.DigitalInOut], addr_pins: Sequence[digitalio.DigitalInOut], clock_pin: digitalio.DigitalInOut, latch_pin: digitalio.DigitalInOut, output_enable_pin: digitalio.DigitalInOut, doublebuffer: bool = True, framebuffer: Optional[WriteableBuffer] = None, height: int = 0) -> None:
 //|         """Create a RGBMatrix object with the given attributes.  The height of
 //|         the display is determined by the number of rgb and address pins:
 //|         len(rgb_pins) // 3 * 2 ** len(address_pins).  With 6 RGB pins and 4

--- a/shared-bindings/rotaryio/__init__.c
+++ b/shared-bindings/rotaryio/__init__.c
@@ -38,10 +38,9 @@
 //| The `rotaryio` module contains classes to read different rotation encoding schemes. See
 //| `Wikipedia's Rotary Encoder page <https://en.wikipedia.org/wiki/Rotary_encoder>`_ for more
 //| background.
-
+//|
 //| .. warning:: This module is not available in some SAMD21 (aka M0) builds. See the :ref:`module-support-matrix` for more info.
 //|
-
 //| All classes change hardware state and should be deinitialized when they
 //| are no longer needed if the program continues after use. To do so, either
 //| call :py:meth:`!deinit` or use a context manager. See

--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -125,7 +125,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(sdcardio_sdcard_deinit_obj, sdcardio_sdcard_deinit);
 //|         """Read one or more blocks from the card
 //|
 //|         :param int start_block: The block to start reading from
-//|         :param bytearray buf: The buffer to write into.  Length must be multiple of 512.
+//|         :param ~_typing.WriteableBuffer buf: The buffer to write into.  Length must be multiple of 512.
 //|
 //|         :return: None"""
 //|
@@ -149,7 +149,7 @@ MP_DEFINE_CONST_FUN_OBJ_3(sdcardio_sdcard_readblocks_obj, sdcardio_sdcard_readbl
 //|         """Write one or more blocks to the card
 //|
 //|         :param int start_block: The block to start writing from
-//|         :param bytearray buf: The buffer to read from.  Length must be multiple of 512.
+//|         :param ~_typing.ReadableBuffer buf: The buffer to read from.  Length must be multiple of 512.
 //|
 //|         :return: None"""
 //|

--- a/shared-bindings/sdioio/SDCard.c
+++ b/shared-bindings/sdioio/SDCard.c
@@ -165,7 +165,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(sdioio_sdcard_count_obj, sdioio_sdcard_count);
 //|         """Read one or more blocks from the card
 //|
 //|         :param int start_block: The block to start reading from
-//|         :param bytearray buf: The buffer to write into.  Length must be multiple of 512.
+//|         :param ~_typing.WriteableBuffer buf: The buffer to write into.  Length must be multiple of 512.
 //|
 //|         :return: None"""
 mp_obj_t sdioio_sdcard_readblocks(mp_obj_t self_in, mp_obj_t start_block_in, mp_obj_t buf_in) {
@@ -182,12 +182,12 @@ mp_obj_t sdioio_sdcard_readblocks(mp_obj_t self_in, mp_obj_t start_block_in, mp_
 
 MP_DEFINE_CONST_FUN_OBJ_3(sdioio_sdcard_readblocks_obj, sdioio_sdcard_readblocks);
 
-//|     def writeblocks(self, start_block: int, buf: WriteableBuffer) -> None:
+//|     def writeblocks(self, start_block: int, buf: ReadableBuffer) -> None:
 //|
 //|         """Write one or more blocks to the card
 //|
 //|         :param int start_block: The block to start writing from
-//|         :param bytearray buf: The buffer to read from.  Length must be multiple of 512.
+//|         :param ~_typing.ReadableBuffer buf: The buffer to read from.  Length must be multiple of 512.
 //|
 //|         :return: None"""
 //|

--- a/shared-bindings/socket/__init__.c
+++ b/shared-bindings/socket/__init__.c
@@ -52,10 +52,16 @@ STATIC const mp_obj_type_t socket_type;
 //|     def __init__(self, family: int, type: int, proto: int) -> None:
 //|         """Create a new socket
 //|
-//|         :param ~int family: AF_INET or AF_INET6
-//|         :param ~int type: SOCK_STREAM, SOCK_DGRAM or SOCK_RAW
-//|         :param ~int proto: IPPROTO_TCP, IPPROTO_UDP or IPPROTO_RAW (ignored)"""
+//|         :param int family: AF_INET or AF_INET6
+//|         :param int type: SOCK_STREAM, SOCK_DGRAM or SOCK_RAW
+//|         :param int proto: IPPROTO_TCP, IPPROTO_UDP or IPPROTO_RAW (ignored)"""
 //|         ...
+//|
+//|     AF_INET: int
+//|     AF_INET6: int
+//|     SOCK_STREAM: int
+//|     SOCK_DGRAM: int
+//|     SOCK_RAW: int
 //|
 
 STATIC mp_obj_t socket_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
@@ -96,10 +102,11 @@ STATIC void socket_select_nic(mod_network_socket_obj_t *self, const byte *ip) {
     }
 }
 
-//|     def bind(self, address: tuple) -> None:
+//|     def bind(self, address: Tuple[str, int]) -> None:
 //|         """Bind a socket to an address
 //|
-//|         :param ~tuple address: tuple of (remote_address, remote_port)"""
+//|         :param address: tuple of (remote_address, remote_port)
+//|         :type address: tuple(str, int)"""
 //|         ...
 //|
 
@@ -126,7 +133,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_bind_obj, socket_bind);
 //|     def listen(self, backlog: int) -> None:
 //|         """Set socket to listen for incoming connections
 //|
-//|         :param ~int backlog: length of backlog queue for waiting connetions"""
+//|         :param int backlog: length of backlog queue for waiting connetions"""
 //|         ...
 //|
 
@@ -148,7 +155,7 @@ STATIC mp_obj_t socket_listen(mp_obj_t self_in, mp_obj_t backlog) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_listen_obj, socket_listen);
 
-//|     def accept(self) -> tuple:
+//|     def accept(self) -> Tuple[socket, str]:
 //|         """Accept a connection on a listening socket of type SOCK_STREAM,
 //|         creating a new socket of type SOCK_STREAM.
 //|         Returns a tuple of (new_socket, remote_address)"""
@@ -185,10 +192,11 @@ STATIC mp_obj_t socket_accept(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(socket_accept_obj, socket_accept);
 
-//|     def connect(self, address: tuple) -> None:
+//|     def connect(self, address: Tuple[str, int]) -> None:
 //|         """Connect a socket to a remote address
 //|
-//|         :param ~tuple address: tuple of (remote_address, remote_port)"""
+//|         :param address: tuple of (remote_address, remote_port)
+//|         :type address: tuple(str, int)"""
 //|         ...
 //|
 
@@ -216,7 +224,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_connect_obj, socket_connect);
 //|         """Send some bytes to the connected remote address.
 //|         Suits sockets of type SOCK_STREAM
 //|
-//|         :param ~bytes bytes: some bytes to send"""
+//|         :param ~_typing.ReadableBuffer bytes: some bytes to send"""
 //|         ...
 //|
 
@@ -259,7 +267,7 @@ STATIC mp_int_t _socket_recv_into(mod_network_socket_obj_t *sock, byte *buf, mp_
 //|         Suits sockets of type SOCK_STREAM
 //|         Returns an int of number of bytes read.
 //|
-//|         :param bytearray buffer: buffer to receive into
+//|         :param ~_typing.WriteableBuffer buffer: buffer to receive into
 //|         :param int bufsize: optionally, a maximum number of bytes to read."""
 //|         ...
 //|
@@ -290,7 +298,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socket_recv_into_obj, 2, 3, socket_re
 //|         Suits sockets of type SOCK_STREAM
 //|         Returns a bytes() of length <= bufsize
 //|
-//|         :param ~int bufsize: maximum number of bytes to receive"""
+//|         :param int bufsize: maximum number of bytes to receive"""
 //|         ...
 //|
 
@@ -312,12 +320,13 @@ STATIC mp_obj_t socket_recv(mp_obj_t self_in, mp_obj_t len_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_recv_obj, socket_recv);
 
-//|     def sendto(self, bytes: ReadableBuffer, address: tuple) -> int:
+//|     def sendto(self, bytes: ReadableBuffer, address: Tuple[str, int]) -> int:
 //|         """Send some bytes to a specific address.
 //|         Suits sockets of type SOCK_DGRAM
 //|
-//|         :param ~bytes bytes: some bytes to send
-//|         :param ~tuple address: tuple of (remote_address, remote_port)"""
+//|         :param ~_typing.ReadableBuffer bytes: some bytes to send
+//|         :param address: tuple of (remote_address, remote_port)
+//|         :type address: tuple(str, int)"""
 //|         ...
 //|
 
@@ -346,7 +355,7 @@ STATIC mp_obj_t socket_sendto(mp_obj_t self_in, mp_obj_t data_in, mp_obj_t addr_
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(socket_sendto_obj, socket_sendto);
 
-//|     def recvfrom(self, bufsize: int) -> Tuple[bytes, tuple]:
+//|     def recvfrom(self, bufsize: int) -> Tuple[bytes, Tuple[str, int]]:
 //|         """Reads some bytes from the connected remote address.
 //|         Suits sockets of type SOCK_STREAM
 //|
@@ -354,7 +363,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(socket_sendto_obj, socket_sendto);
 //|         * a bytes() of length <= bufsize
 //|         * a remote_address, which is a tuple of ip address and port number
 //|
-//|         :param ~int bufsize: maximum number of bytes to receive"""
+//|         :param int bufsize: maximum number of bytes to receive"""
 //|         ...
 //|
 
@@ -422,7 +431,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socket_setsockopt_obj, 4, 4, socket_s
 //|     def settimeout(self, value: int) -> None:
 //|         """Set the timeout value for this socket.
 //|
-//|         :param ~int value: timeout in seconds.  0 means non-blocking.  None means block indefinitely."""
+//|         :param int value: timeout in seconds.  0 means non-blocking.  None means block indefinitely."""
 //|         ...
 //|
 
@@ -453,7 +462,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socket_settimeout_obj, socket_settimeout);
 //|     def setblocking(self, flag: bool) -> Optional[int]:
 //|         """Set the blocking behaviour of this socket.
 //|
-//|         :param ~bool flag: False means non-blocking, True means block indefinitely."""
+//|         :param bool flag: False means non-blocking, True means block indefinitely."""
 //|         ...
 //|
 
@@ -512,7 +521,7 @@ STATIC const mp_obj_type_t socket_type = {
     .locals_dict = (mp_obj_dict_t*)&socket_locals_dict,
 };
 
-//| def getaddrinfo(host: str, port: int) -> tuple:
+//| def getaddrinfo(host: str, port: int) -> Tuple[int, int, int, str, str]:
 //|     """Gets the address information for a hostname and port
 //|
 //|     Returns the appropriate family, socket type, socket protocol and

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -187,7 +187,7 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
 //|         """Like builtin ``open()``"""
 //|         ...
 //|
-//|     def ilistdir(self, path: str) -> Iterator[Tuple[AnyStr, int, int, int]]:
+//|     def ilistdir(self, path: str) -> Iterator[Union[Tuple[AnyStr, int, int, int], Tuple[AnyStr, int, int]]]:
 //|         """Return an iterator whose values describe files and folders within
 //|         ``path``"""
 //|         ...
@@ -200,11 +200,11 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
 //|         """Like `os.rmdir`"""
 //|         ...
 //|
-//|     def stat(self, path: str) -> str:
+//|     def stat(self, path: str) -> Tuple[int, int, int, int, int, int, int, int, int, int]:
 //|         """Like `os.stat`"""
 //|         ...
 //|
-//|     def statvfs(self, path: str) -> Tuple[str, str, str, str, str, str, str, str, str, str]:
+//|     def statvfs(self, path: int) -> Tuple[int, int, int, int, int, int, int, int, int, int]:
 //|         """Like `os.statvfs`"""
 //|         ...
 //|

--- a/shared-bindings/struct/__init__.c
+++ b/shared-bindings/struct/__init__.c
@@ -62,7 +62,7 @@ STATIC mp_obj_t struct_calcsize(mp_obj_t fmt_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(struct_calcsize_obj, struct_calcsize);
 
-//| def pack(fmt: str, *values: ReadableBuffer) -> bytes:
+//| def pack(fmt: str, *values: Any) -> bytes:
 //|     """Pack the values according to the format string fmt.
 //|     The return value is a bytes object encoding the values."""
 //|     ...
@@ -80,7 +80,7 @@ STATIC mp_obj_t struct_pack(size_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(struct_pack_obj, 1, MP_OBJ_FUN_ARGS_MAX, struct_pack);
 
-//| def pack_into(fmt: str, buffer: WriteableBuffer, offset: int, *values: ReadableBuffer) -> None:
+//| def pack_into(fmt: str, buffer: WriteableBuffer, offset: int, *values: Any) -> None:
 //|     """Pack the values according to the format string fmt into a buffer
 //|     starting at offset. offset may be negative to count from the end of buffer."""
 //|     ...
@@ -106,7 +106,7 @@ STATIC mp_obj_t struct_pack_into(size_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(struct_pack_into_obj, 3, MP_OBJ_FUN_ARGS_MAX, struct_pack_into);
 
-//| def unpack(fmt: str, data: ReadableBuffer) -> tuple:
+//| def unpack(fmt: str, data: ReadableBuffer) -> Tuple[Any, ...]:
 //|     """Unpack from the data according to the format string fmt. The return value
 //|     is a tuple of the unpacked values. The buffer size must match the size
 //|     required by the format."""
@@ -124,7 +124,7 @@ STATIC mp_obj_t struct_unpack(size_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(struct_unpack_obj, 2, 3, struct_unpack);
 
-//| def unpack_from(fmt: str, data: ReadableBuffer, offset: int = 0) -> tuple:
+//| def unpack_from(fmt: str, data: ReadableBuffer, offset: int = 0) -> Tuple[Any, ...]:
 //|     """Unpack from the data starting at offset according to the format string fmt.
 //|     offset may be negative to count from the end of buffer. The return value is
 //|     a tuple of the unpacked values. The buffer size must be at least as big

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -45,7 +45,7 @@
 //| This object is the sole instance of `supervisor.Runtime`."""
 //|
 
-//| def enable_autoreload(self) -> None:
+//| def enable_autoreload() -> None:
 //|     """Enable autoreload based on USB file write activity."""
 //|     ...
 //|
@@ -55,7 +55,7 @@ STATIC mp_obj_t supervisor_enable_autoreload(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(supervisor_enable_autoreload_obj, supervisor_enable_autoreload);
 
-//| def disable_autoreload(self) -> None:
+//| def disable_autoreload() -> None:
 //|     """Disable autoreload based on USB file write activity until
 //|     `enable_autoreload` is called."""
 //|     ...
@@ -66,7 +66,7 @@ STATIC mp_obj_t supervisor_disable_autoreload(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(supervisor_disable_autoreload_obj, supervisor_disable_autoreload);
 
-//| def set_rgb_status_brightness(self, brightness: int) -> None:
+//| def set_rgb_status_brightness(brightness: int) -> None:
 //|     """Set brightness of status neopixel from 0-255
 //|     `set_rgb_status_brightness` is called."""
 //|     ...
@@ -82,7 +82,7 @@ STATIC mp_obj_t supervisor_set_rgb_status_brightness(mp_obj_t lvl){
 }
 MP_DEFINE_CONST_FUN_OBJ_1(supervisor_set_rgb_status_brightness_obj, supervisor_set_rgb_status_brightness);
 
-//| def reload(self) -> None:
+//| def reload() -> None:
 //|     """Reload the main Python code and run it (equivalent to hitting Ctrl-D at the REPL)."""
 //|     ...
 //|
@@ -93,7 +93,7 @@ STATIC mp_obj_t supervisor_reload(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(supervisor_reload_obj, supervisor_reload);
 
-//| def set_next_stack_limit(self, size: int) -> None:
+//| def set_next_stack_limit(size: int) -> None:
 //|     """Set the size of the stack for the next vm run. If its too large, the default will be used."""
 //|     ...
 //|

--- a/shared-bindings/terminalio/__init__.c
+++ b/shared-bindings/terminalio/__init__.c
@@ -40,6 +40,9 @@
 //| The `terminalio` module contains classes to display a character stream on a display. The built
 //| in font is available as ``terminalio.FONT``."""
 //|
+//| FONT: fontio.BuiltinFont
+//| """The built in font"""
+//|
 STATIC const mp_rom_map_elem_t  terminalio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_terminalio) },
     { MP_ROM_QSTR(MP_QSTR_Terminal),   MP_OBJ_FROM_PTR(&terminalio_terminal_type) },

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -93,7 +93,7 @@ mp_obj_t struct_time_make_new(const mp_obj_type_t *type, size_t n_args, const mp
 }
 
 //| class struct_time:
-//|     def __init__(self, time_tuple: tuple) -> None:
+//|     def __init__(self, time_tuple: Tuple[int, int, int, int, int, int, int, int, int]) -> None:
 //|         """Structure used to capture a date and time. Note that it takes a tuple!
 //|
 //|         :param tuple time_tuple: Tuple of time info: ``(tm_year, tm_mon, tm_mday, tm_hour, tm_min, tm_sec, tm_wday, tm_yday, tm_isdst)``

--- a/shared-bindings/usb_midi/__init__.c
+++ b/shared-bindings/usb_midi/__init__.c
@@ -35,8 +35,14 @@
 
 #include "py/runtime.h"
 
-//| """Classes to transmit and receive MIDI messages over USB"""
+//| """MIDI over USB
 //|
+//| The `usb_midi` module contains classes to transmit and receive MIDI messages over USB."""
+//|
+//| ports: Tuple[Union[PortIn, PortOut], ...]
+//| """Tuple of all MIDI ports. Each item is ether `PortIn` or `PortOut`."""
+//|
+
 mp_map_elem_t usb_midi_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_usb_midi) },
     { MP_ROM_QSTR(MP_QSTR_ports), mp_const_empty_tuple },

--- a/shared-bindings/vectorio/VectorShape.c
+++ b/shared-bindings/vectorio/VectorShape.c
@@ -20,7 +20,7 @@
 
 
 //| class VectorShape:
-//|     def __init__(self, shape: Polygon, pixel_shader: displayio.Palette, x: int=0, y: int=0) -> None:
+//|     def __init__(self, shape: Union[Polygon, Rectangle, Circle], pixel_shader: Union[displayio.ColorConverter, displayio.Palette], x: int=0, y: int=0) -> None:
 //|         """Binds a vector shape to a location and pixel color
 //|
 //|            :param shape: The shape to draw.
@@ -145,7 +145,7 @@ const mp_obj_property_t vectorio_vector_shape_y_obj = {
 };
 
 
-//|     pixel_shader: displayio.Palette
+//|     pixel_shader: Union[displayio.ColorConverter, displayio.Palette]
 //|     """The pixel shader of the shape."""
 //|
 STATIC mp_obj_t vectorio_vector_shape_obj_get_pixel_shader(mp_obj_t self_in) {

--- a/shared-bindings/wiznet/wiznet5k.c
+++ b/shared-bindings/wiznet/wiznet5k.c
@@ -134,7 +134,7 @@ const mp_obj_property_t wiznet5k_dhcp_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
-//|     def ifconfig(self, params: Optional[Tuple] = None) -> Optional[Tuple]:
+//|     def ifconfig(self, params: Optional[Tuple[str, str, str, str]] = None) -> Optional[Tuple[str, str, str, str]]:
 //|         """Called without parameters, returns a tuple of
 //|         (ip_address, subnet_mask, gateway_address, dns_server)
 //|

--- a/tools/extract_pyi.py
+++ b/tools/extract_pyi.py
@@ -17,79 +17,99 @@ import black
 
 
 IMPORTS_IGNORE = frozenset({'int', 'float', 'bool', 'str', 'bytes', 'tuple', 'list', 'set', 'dict', 'bytearray', 'slice', 'file', 'buffer', 'range', 'array', 'struct_time'})
-IMPORTS_TYPING = frozenset({'Any', 'Optional', 'Union', 'Tuple', 'List', 'Sequence', 'Iterable', 'Iterator', 'overload'})
-IMPORTS_TYPESHED = frozenset({'ReadableBuffer', 'WriteableBuffer'})
+IMPORTS_TYPING = frozenset({'Any', 'Optional', 'Union', 'Tuple', 'List', 'Sequence', 'NamedTuple', 'Iterable', 'Iterator', 'Callable', 'AnyStr', 'overload'})
+CPY_TYPING = frozenset({'ReadableBuffer', 'WriteableBuffer', 'AudioSample', 'FrameBuffer'})
 
 
-def is_any(node):
-    node_type = type(node)
+def is_typed(node, allow_any=False):
     if node is None:
+        return False
+    if allow_any:
         return True
-    if node_type == ast.Name and node.id == "Any":
-        return True
-    if (node_type == ast.Attribute and type(node.value) == ast.Name
-            and node.value.id == "typing" and node.attr == "Any"):
-        return True
-    return False
+    elif isinstance(node, ast.Name) and node.id == "Any":
+        return False
+    elif isinstance(node, ast.Attribute) and type(node.value) == ast.Name \
+            and node.value.id == "typing" and node.attr == "Any":
+        return False
+    return True
 
 
-def report_missing_annotations(tree):
+def find_stub_issues(tree):
     for node in ast.walk(tree):
-        node_type = type(node)
-        if node_type == ast.AnnAssign:
-            if is_any(node.annotation):
-                print(f"Missing attribute type on line {node.lineno}")
-        elif node_type == ast.arg:
-            if is_any(node.annotation) and node.arg != "self":
-                print(f"Missing argument type: {node.arg} on line {node.lineno}")
-        elif node_type == ast.FunctionDef:
-            if is_any(node.returns) and node.name != "__init__":
-                print(f"Missing return type: {node.name} on line {node.lineno}")
+        if isinstance(node, ast.AnnAssign):
+            if not is_typed(node.annotation):
+                yield ("WARN", f"Missing attribute type on line {node.lineno}")
+            if isinstance(node.value, ast.Constant) and node.value.value == Ellipsis:
+                yield ("WARN", f"Unnecessary Ellipsis assignment (= ...) on line {node.lineno}.")
+        elif isinstance(node, ast.Assign):
+            if isinstance(node.value, ast.Constant) and node.value.value == Ellipsis:
+                yield ("WARN", f"Unnecessary Ellipsis assignment (= ...) on line {node.lineno}.")
+        elif isinstance(node, ast.arguments):
+            for arg_node in (node.args + node.posonlyargs + node.kwonlyargs):
+                if not is_typed(arg_node.annotation) and (arg_node.arg != "self" and arg_node.arg != "cls"):
+                    yield ("WARN", f"Missing argument type: {arg_node.arg} on line {arg_node.lineno}")
+            if node.vararg and not is_typed(node.vararg.annotation, allow_any=True):
+                yield ("WARN", f"Missing argument type: *{node.vararg.arg} on line {node.vararg.lineno}")
+            if node.kwarg and not is_typed(node.kwarg.annotation, allow_any=True):
+                yield ("WARN", f"Missing argument type: **{node.kwarg.arg} on line {node.kwarg.lineno}")
+        elif isinstance(node, ast.FunctionDef):
+            if not is_typed(node.returns):
+                yield ("WARN", f"Missing return type: {node.name} on line {node.lineno}")
 
 
 def extract_imports(tree):
     modules = set()
     typing = set()
-    typeshed = set()
+    cpy_typing = set()
 
     def collect_annotations(anno_tree):
         if anno_tree is None:
             return
         for node in ast.walk(anno_tree):
-            node_type = type(node)
-            if node_type == ast.Name:
+            if isinstance(node, ast.Name):
                 if node.id in IMPORTS_IGNORE:
                     continue
                 elif node.id in IMPORTS_TYPING:
                     typing.add(node.id)
-                elif node.id in IMPORTS_TYPESHED:
-                    typeshed.add(node.id)
-            if node_type == ast.Attribute:
-                if type(node.value) == ast.Name:
+                elif node.id in CPY_TYPING:
+                    cpy_typing.add(node.id)
+            elif isinstance(node, ast.Attribute):
+                if isinstance(node.value, ast.Name):
                     modules.add(node.value.id)
 
     for node in ast.walk(tree):
-        node_type = type(node)
-        if (node_type == ast.AnnAssign) or (node_type == ast.arg):
+        if isinstance(node, (ast.AnnAssign, ast.arg)):
             collect_annotations(node.annotation)
-        elif node_type == ast.FunctionDef:
+        elif isinstance(node, ast.Assign):
+            collect_annotations(node.value)
+        elif isinstance(node, ast.FunctionDef):
             collect_annotations(node.returns)
             for deco in node.decorator_list:
-                if deco.id in IMPORTS_TYPING:
+                if isinstance(deco, ast.Name) and (deco.id in IMPORTS_TYPING):
                     typing.add(deco.id)
 
     return {
         "modules": sorted(modules),
         "typing": sorted(typing),
-        "typeshed": sorted(typeshed),
+        "cpy_typing": sorted(cpy_typing),
     }
+
+
+def find_references(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.arguments):
+            for node in ast.walk(node):
+                if isinstance(node, ast.Attribute):
+                    if isinstance(node.value, ast.Name) and node.value.id[0].isupper():
+                        yield node.value.id
 
 
 def convert_folder(top_level, stub_directory):
     ok = 0
     total = 0
     filenames = sorted(os.listdir(top_level))
-    pyi_lines = []
+    stub_fragments = []
+    references = set()
 
     for filename in filenames:
         full_path = os.path.join(top_level, filename)
@@ -99,50 +119,69 @@ def convert_folder(top_level, stub_directory):
             ok += mok
             total += mtotal
         elif filename.endswith(".c"):
-            with open(full_path, "r") as f:
+            with open(full_path, "r", encoding="utf-8") as f:
                 for line in f:
+                    line = line.rstrip()
                     if line.startswith("//|"):
-                        if line[3] == " ":
+                        if len(line) == 3:
+                            line = ""
+                        elif line[3] == " ":
                             line = line[4:]
-                        elif line[3] == "\n":
-                            line = line[3:]
                         else:
-                            continue
+                            line = line[3:]
+                            print("[WARN] There must be at least one space after '//|'")
                         file_lines.append(line)
         elif filename.endswith(".pyi"):
             with open(full_path, "r") as f:
-                file_lines.extend(f.readlines())
+                file_lines.extend(line.rstrip() for line in f)
 
-        # Always put the contents from an __init__ first.
-        if filename.startswith("__init__."):
-            pyi_lines = file_lines + pyi_lines
-        else:
-            pyi_lines.extend(file_lines)
+        fragment = "\n".join(file_lines).strip()
+        try:
+            tree = ast.parse(fragment)
+        except SyntaxError as e:
+            print(f"[ERROR] Failed to parse a Python stub from {full_path}")
+            traceback.print_exception(type(e), e, e.__traceback__)
+            return (ok, total + 1)
+        references.update(find_references(tree))
 
-    if not pyi_lines:
+        if fragment:
+            name = os.path.splitext(os.path.basename(filename))[0]
+            if name == "__init__" or (name in references):
+                stub_fragments.insert(0, fragment)
+            else:
+                stub_fragments.append(fragment)
+
+    if not stub_fragments:
         return (ok, total)
 
     stub_filename = os.path.join(stub_directory, "__init__.pyi")
     print(stub_filename)
-    stub_contents = "".join(pyi_lines)
+    stub_contents = "\n\n".join(stub_fragments)
 
-    # Validate that the module is a parseable stub.
-    total += 1
+    # Validate the stub code.
     try:
         tree = ast.parse(stub_contents)
-        imports = extract_imports(tree)
-        report_missing_annotations(tree)
-        ok += 1
     except SyntaxError as e:
         traceback.print_exception(type(e), e, e.__traceback__)
         return (ok, total)
 
+    error = False
+    for (level, msg) in find_stub_issues(tree):
+        if level == "ERROR":
+            error = True
+        print(f"[{level}] {msg}")
+
+    total += 1
+    if not error:
+        ok += 1
+
     # Add import statements
+    imports = extract_imports(tree)
     import_lines = ["from __future__ import annotations"]
     if imports["typing"]:
         import_lines.append("from typing import " + ", ".join(imports["typing"]))
-    if imports["typeshed"]:
-        import_lines.append("from _typeshed import " + ", ".join(imports["typeshed"]))
+    if imports["cpy_typing"]:
+        import_lines.append("from _typing import " + ", ".join(imports["cpy_typing"]))
     import_lines.extend(f"import {m}" for m in imports["modules"])
     import_body = "\n".join(import_lines)
     m = re.match(r'(\s*""".*?""")', stub_contents, flags=re.DOTALL)
@@ -159,7 +198,6 @@ def convert_folder(top_level, stub_directory):
     with open(stub_filename, "w") as f:
         f.write(stub_contents)
 
-    print()
     return (ok, total)
 
 


### PR DESCRIPTION
- [Sphinx] Add a Sphinx transform to conf.py to convert the first paragraphs into the module titles. (See FIg. 1 & 2)
    - The titles will look similar to that of v5.3.x docs.
    - It also removes `refspecific=True` from xref nodes so that Sphinx can resolve references to data attributes such as  `_typing.ReadableBuffer`. (See Fig. 1)
- [stubs] Make `shared-bindings/_typing/__init__.pyi` for the types related to the C-level protocols. We shouldn't use `_typeshed` as it is typeshed's internal utility.
- [stubs] Add `make check-stubs` command to validate stubs with mypy.
- [stubs] Fix some type hints.

Fig. 1:
<img width="400" alt="Screen Shot 2020-08-04 at 18 08 26" src="https://user-images.githubusercontent.com/5351911/89550258-601b5080-d844-11ea-97f1-6bb776145e60.png">

FIg. 2:
<img width="400" alt="sc" src="https://user-images.githubusercontent.com/5351911/89550210-4da11700-d844-11ea-9bcf-952ff9db767f.png">
