### PR TITLE
Fix Read the Docs bulid failing

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,10 @@
 
 version: 2
 
+submodules:
+    include:
+        - extmod/ulab
+
 python:
     version: 3
     install:

--- a/tools/extract_pyi.py
+++ b/tools/extract_pyi.py
@@ -45,7 +45,10 @@ def find_stub_issues(tree):
             if isinstance(node.value, ast.Constant) and node.value.value == Ellipsis:
                 yield ("WARN", f"Unnecessary Ellipsis assignment (= ...) on line {node.lineno}.")
         elif isinstance(node, ast.arguments):
-            for arg_node in (node.args + node.posonlyargs + node.kwonlyargs):
+            allargs = list(node.args + node.kwonlyargs)
+            if sys.version_info >= (3, 8):
+                allargs.extend(node.posonlyargs)
+            for arg_node in allargs:
                 if not is_typed(arg_node.annotation) and (arg_node.arg != "self" and arg_node.arg != "cls"):
                     yield ("WARN", f"Missing argument type: {arg_node.arg} on line {arg_node.lineno}")
             if node.vararg and not is_typed(node.vararg.annotation, allow_any=True):


### PR DESCRIPTION
This PR will fix the following errors:

- https://readthedocs.org/projects/circuitpython/builds/11605442/
  ```
    File "tools/extract_pyi.py", line 91, in convert_folder
      filenames = sorted(os.listdir(top_level))
  FileNotFoundError: [Errno 2] No such file or directory: 'extmod/ulab/code'
  ```

- https://readthedocs.org/projects/circuitpython/builds/11616854/
  ```
    File "tools/extract_pyi.py", line 48, in find_stub_issues
      for arg_node in (node.args + node.posonlyargs + node.kwonlyargs):
  AttributeError: 'arguments' object has no attribute 'posonlyargs'
  ```
