### PR TITLE
Add Internal Links To Boards In The Support Matrix

### DIFF
--- a/shared-bindings/support_matrix.rst
+++ b/shared-bindings/support_matrix.rst
@@ -6,11 +6,16 @@ Support Matrix
 The following table lists the available built-in modules for each CircuitPython
 capable board.
 
-.. csv-table::
+.. list-table::
    :header-rows: 1
    :widths: 7, 50
 
-   "Board", "Modules Available"
-   {% for key, value in support_matrix|dictsort -%}
-   "{{ key }}", "{{ '`' ~ value|join("`, `") ~ '`' }}"
-   {% endfor -%}
+   * - Board
+     - Modules Available
+
+   {% for key, value in support_matrix|dictsort %}
+       {{ '.. _' ~ key ~ ':' }}
+   * - {{ key }}
+     - {{ '`' ~ value|join("`, `") ~ '`' }}
+
+   {% endfor %}

--- a/shared-bindings/support_matrix.rst
+++ b/shared-bindings/support_matrix.rst
@@ -14,7 +14,7 @@ capable board.
      - Modules Available
 
    {% for key, value in support_matrix|dictsort %}
-       {{ '.. _' ~ key ~ ':' }}
+       {{ '.. _' ~ key|replace(" ", "-") ~ ':' }}
    * - {{ key }}
      - {{ '`' ~ value|join("`, `") ~ '`' }}
 


### PR DESCRIPTION
Implements #2923. Allows the following: `https://circuitpython.readthedocs.io/en/latest/shared-bindings/support_matrix.html#<id>`

@askpatrickw was correct, rST's `csv-table` parsing just wouldn't allow the reference to be generated. I switched it to use a `list-table`, using an example in the `docutils` [reference](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#id18) of applying internal hyperlink targets.

The only tricky part is _utilizing_ the resulting hyperlink target. `docutils` [normalizes](https://docutils.sourceforge.io/docs/ref/rst/directives.html#identifier-normalization) the identifiers to conform to this regex: `[a-z](-?[a-z0-9]+)*`.  This may prove difficult to replicate in certain instances. Programmatically, something like `re.sub(r"\W+", "-")` should suffice for the special characters; the rest is just lowercase and stripping non-alpha leading characters. Manually, its just a matter of looking at the HTML source on RTD I guess.

Here is an example of the resulting HTML (truncated elements, for easier reading):
```html
<tbody id="commander">
    <tr class="row-even">
        <td><p>8086 Commander</p></td>
    </tr>
    <tr class="row-odd" id="adafruit-circuit-playground-bluefruit">
        <td><p>Adafruit Circuit Playground Bluefruit</p></td>
    </tr>
    <tr class="row-odd" id="j-j-studios-datum-light">
        <td><p>J&amp;J Studios datum-Light</p></td>
    </tr>
    <tr class="row-even" id="ndgarage-n-bit6-feathersnow-v2">
        <td><p>ndGarage[n°] Bit6: FeatherSnow-v2</p></td>
    </tr>
</tbody>
```