### PR TITLE
support to change ble mac address

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-11 15:37-0500\n"
+"POT-Creation-Date: 2020-08-14 09:36-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -639,6 +639,10 @@ msgstr ""
 
 #: ports/stm/common-hal/pulseio/PWMOut.c
 msgid "Could not restart PWM"
+msgstr ""
+
+#: shared-bindings/_bleio/Adapter.c
+msgid "Could not set address"
 msgstr ""
 
 #: ports/stm/common-hal/pulseio/PWMOut.c

--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -386,6 +386,15 @@ bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_obj_t *s
     return address;
 }
 
+uint32_t common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, bleio_address_obj_t *address)
+{
+    ble_gap_addr_t local_address;
+    local_address.addr_type = address->type;
+    const char *data = mp_obj_str_get_str(address->bytes);
+    memcpy(local_address.addr, data, NUM_BLEIO_ADDRESS_BYTES);
+    return sd_ble_gap_addr_set(&local_address);
+}
+
 mp_obj_str_t* common_hal_bleio_adapter_get_name(bleio_adapter_obj_t *self) {
     uint16_t len = 0;
     sd_ble_gap_device_name_get(NULL, &len);

--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -386,13 +386,15 @@ bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_obj_t *s
     return address;
 }
 
-uint32_t common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, bleio_address_obj_t *address)
-{
+bool common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, bleio_address_obj_t *address) {
     ble_gap_addr_t local_address;
+    mp_buffer_info_t bufinfo;
+    if (!mp_get_buffer(address->bytes, &bufinfo, MP_BUFFER_READ)) {
+        return false;
+    }
     local_address.addr_type = address->type;
-    const char *data = mp_obj_str_get_str(address->bytes);
-    memcpy(local_address.addr, data, NUM_BLEIO_ADDRESS_BYTES);
-    return sd_ble_gap_addr_set(&local_address);
+    memcpy(local_address.addr, bufinfo.buf, NUM_BLEIO_ADDRESS_BYTES);
+    return sd_ble_gap_addr_set(&local_address) == NRF_SUCCESS;
 }
 
 mp_obj_str_t* common_hal_bleio_adapter_get_name(bleio_adapter_obj_t *self) {

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -96,7 +96,7 @@ const mp_obj_property_t bleio_adapter_enabled_obj = {
 };
 
 //|     address: Address
-//|     """MAC address of the BLE adapter. (read-only)"""
+//|     """MAC address of the BLE adapter."""
 //|
 STATIC mp_obj_t bleio_adapter_get_address(mp_obj_t self) {
     return MP_OBJ_FROM_PTR(common_hal_bleio_adapter_get_address(self));
@@ -104,10 +104,16 @@ STATIC mp_obj_t bleio_adapter_get_address(mp_obj_t self) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_get_address_obj, bleio_adapter_get_address);
 
+STATIC mp_obj_t bleio_adapter_set_address(mp_obj_t self, mp_obj_t new_address) {
+    common_hal_bleio_adapter_set_address(self, new_address);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(bleio_adapter_set_address_obj, bleio_adapter_set_address);
+
 const mp_obj_property_t bleio_adapter_address_obj = {
     .base.type = &mp_type_property,
     .proxy = { (mp_obj_t)&bleio_adapter_get_address_obj,
-               (mp_obj_t)&mp_const_none_obj,
+               (mp_obj_t)&bleio_adapter_set_address_obj,
                (mp_obj_t)&mp_const_none_obj },
 };
 

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -105,7 +105,9 @@ STATIC mp_obj_t bleio_adapter_get_address(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_get_address_obj, bleio_adapter_get_address);
 
 STATIC mp_obj_t bleio_adapter_set_address(mp_obj_t self, mp_obj_t new_address) {
-    common_hal_bleio_adapter_set_address(self, new_address);
+    if (!common_hal_bleio_adapter_set_address(self, new_address)) {
+        mp_raise_bleio_BluetoothError(translate("Could not set address"));
+    }
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_2(bleio_adapter_set_address_obj, bleio_adapter_set_address);

--- a/shared-bindings/_bleio/Adapter.h
+++ b/shared-bindings/_bleio/Adapter.h
@@ -42,6 +42,7 @@ extern bool common_hal_bleio_adapter_get_enabled(bleio_adapter_obj_t *self);
 extern void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enabled);
 extern bool common_hal_bleio_adapter_get_connected(bleio_adapter_obj_t *self);
 extern bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_obj_t *self);
+extern uint32_t common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, bleio_address_obj_t *address);
 
 extern mp_obj_str_t* common_hal_bleio_adapter_get_name(bleio_adapter_obj_t *self);
 extern void common_hal_bleio_adapter_set_name(bleio_adapter_obj_t *self, const char* name);

--- a/shared-bindings/_bleio/Adapter.h
+++ b/shared-bindings/_bleio/Adapter.h
@@ -42,7 +42,7 @@ extern bool common_hal_bleio_adapter_get_enabled(bleio_adapter_obj_t *self);
 extern void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enabled);
 extern bool common_hal_bleio_adapter_get_connected(bleio_adapter_obj_t *self);
 extern bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_obj_t *self);
-extern uint32_t common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, bleio_address_obj_t *address);
+extern bool common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, bleio_address_obj_t *address);
 
 extern mp_obj_str_t* common_hal_bleio_adapter_get_name(bleio_adapter_obj_t *self);
 extern void common_hal_bleio_adapter_set_name(bleio_adapter_obj_t *self, const char* name);


### PR DESCRIPTION
In some cases, we want to change the mac address of a ble device. For a keyboard, we can change the mac address to connect to another computer or phone.