### PR TITLE
sharpdisplay: Prevent 'ValueError: <pin> in use' exception

### DIFF
--- a/shared-module/board/__init__.c
+++ b/shared-module/board/__init__.c
@@ -164,8 +164,8 @@ void reset_board_busses(void) {
             break;
         }
         #endif
-    #endif
     }
+    #endif
     if (!display_using_spi) {
         spi_singleton = NULL;
     }

--- a/shared-module/board/__init__.c
+++ b/shared-module/board/__init__.c
@@ -39,6 +39,11 @@
 #include "shared-module/displayio/__init__.h"
 #endif
 
+#if CIRCUITPY_SHARPDISPLAY
+#include "shared-bindings/sharpdisplay/SharpMemoryFramebuffer.h"
+#include "shared-module/sharpdisplay/SharpMemoryFramebuffer.h"
+#endif
+
 #if BOARD_I2C
 // Statically allocate the I2C object so it can live past the end of the heap and into the next VM.
 // That way it can be used by built-in I2CDisplay displays and be accessible through board.I2C().
@@ -148,12 +153,19 @@ void reset_board_busses(void) {
     bool display_using_spi = false;
     #if CIRCUITPY_DISPLAYIO
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
-        if (displays[i].fourwire_bus.bus == spi_singleton) {
+        mp_const_obj_t bus_type = displays[i].bus_base.type;
+        if (bus_type == &displayio_fourwire_type && displays[i].fourwire_bus.bus == spi_singleton) {
             display_using_spi = true;
             break;
         }
-    }
+        #if CIRCUITPY_SHARPDISPLAY
+        if (displays[i].bus_base.type == &sharpdisplay_framebuffer_type && displays[i].sharpdisplay.bus == spi_singleton) {
+            display_using_spi = true;
+            break;
+        }
+        #endif
     #endif
+    }
     if (!display_using_spi) {
         spi_singleton = NULL;
     }

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -26,7 +26,7 @@
 
 primary_display_t displays[CIRCUITPY_DISPLAY_LIMIT];
 
-#if CIRCUITPY_RGBMATRIX || CIRCUITPY_SHARPDISPLAY
+#if CIRCUITPY_RGBMATRIX
 STATIC bool any_display_uses_this_framebuffer(mp_obj_base_t *obj) {
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
         if (displays[i].display_base.type == &framebufferio_framebufferdisplay_type) {

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -186,11 +186,7 @@ void reset_displays(void) {
 #if CIRCUITPY_SHARPDISPLAY
         } else if (displays[i].bus_base.type == &sharpdisplay_framebuffer_type) {
             sharpdisplay_framebuffer_obj_t * sharp = &displays[i].sharpdisplay;
-            if(any_display_uses_this_framebuffer(&sharp->base)) {
-                common_hal_sharpdisplay_framebuffer_reset(sharp);
-            } else {
-                common_hal_sharpdisplay_framebuffer_deinit(sharp);
-            }
+            common_hal_sharpdisplay_framebuffer_reset(sharp);
 #endif
         } else {
             // Not an active display bus.


### PR DESCRIPTION
.. when constructing the SPI bus again after reset.

Testing performed: on nRF52840, that these sequences would work repeatedly when soft-resetting in between invocations:
```
import displayio, board, sharpdisplay
displayio.release_displays()
bus = board.SPI()
framebuffer = sharpdisplay.SharpMemoryFramebuffer(bus, board.D2, 400, 240)
```
and
```
import displayio, board, sharpdisplay, busio
displayio.release_displays()
bus = busio.SPI(board.SCK, MOSI=board.MOSI)
framebuffer = sharpdisplay.SharpMemoryFramebuffer(bus, board.D2, 400, 240)
```
.. and that an actual demo would work across soft resets as well.

This feels a bit ad-hoc.  Better would be to make "never reset bus" be a counted thing and add some "un-never-resets" in the right spots.  An area for future improvement.