### PR TITLE
ESP32-S2: Add PulseOut and PulseIn

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-14 09:36-0400\n"
+"POT-Creation-Date: 2020-08-17 10:10-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -744,7 +744,7 @@ msgstr ""
 
 #: shared-bindings/aesio/aes.c shared-bindings/busio/SPI.c
 #: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
+#: shared-bindings/neopixel_write/__init__.c
 #: shared-bindings/terminalio/Terminal.c
 msgid "Expected a %q"
 msgstr ""
@@ -1328,6 +1328,15 @@ msgstr ""
 msgid "Polygon needs at least 3 points"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/pulseio/PulseOut.c
+#: ports/cxd56/common-hal/pulseio/PulseOut.c
+#: ports/nrf/common-hal/pulseio/PulseOut.c
+#: ports/stm/common-hal/pulseio/PulseOut.c
+msgid ""
+"Port does not accept pins or frequency.                                     "
+"Construct and pass a PWM Carrier instead"
+msgstr ""
+
 #: shared-bindings/_bleio/Adapter.c
 msgid "Prefix buffer must be on the heap"
 msgstr ""
@@ -1338,6 +1347,10 @@ msgstr ""
 
 #: shared-bindings/digitalio/DigitalInOut.c
 msgid "Pull not used when direction is output."
+msgstr ""
+
+#: ports/stm/ref/pulseout-pre-timeralloc.c
+msgid "PulseOut not supported on this chip"
 msgstr ""
 
 #: ports/stm/common-hal/os/__init__.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-17 10:10-0400\n"
+"POT-Creation-Date: 2020-08-18 11:19-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1334,7 +1334,7 @@ msgstr ""
 #: ports/stm/common-hal/pulseio/PulseOut.c
 msgid ""
 "Port does not accept pins or frequency.                                     "
-"Construct and pass a PWM Carrier instead"
+"Construct and pass a PWMOut Carrier instead"
 msgstr ""
 
 #: shared-bindings/_bleio/Adapter.c

--- a/ports/atmel-samd/common-hal/pulseio/PulseOut.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseOut.c
@@ -96,7 +96,15 @@ void pulseout_reset() {
 }
 
 void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
-                                            const pulseio_pwmout_obj_t* carrier) {
+                                            const pulseio_pwmout_obj_t* carrier,
+                                            const mcu_pin_obj_t* pin,
+                                            uint32_t frequency,
+                                            uint16_t duty_cycle) {
+    if (!carrier || pin || frequency) {
+        mp_raise_NotImplementedError(translate("Port does not accept pins or frequency. \
+                                    Construct and pass a PWM Carrier instead"));
+    }
+
     if (refcount == 0) {
         // Find a spare timer.
         Tc *tc = NULL;

--- a/ports/atmel-samd/common-hal/pulseio/PulseOut.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseOut.c
@@ -102,7 +102,7 @@ void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
                                             uint16_t duty_cycle) {
     if (!carrier || pin || frequency) {
         mp_raise_NotImplementedError(translate("Port does not accept pins or frequency. \
-                                    Construct and pass a PWM Carrier instead"));
+                                    Construct and pass a PWMOut Carrier instead"));
     }
 
     if (refcount == 0) {

--- a/ports/cxd56/common-hal/pulseio/PulseOut.c
+++ b/ports/cxd56/common-hal/pulseio/PulseOut.c
@@ -58,8 +58,16 @@ static bool pulseout_timer_handler(unsigned int *next_interval_us, void *arg)
     return true;
 }
 
-void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t *self,
-    const pulseio_pwmout_obj_t *carrier) {
+void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
+                                            const pulseio_pwmout_obj_t* carrier,
+                                            const mcu_pin_obj_t* pin,
+                                            uint32_t frequency,
+                                            uint16_t duty_cycle) {
+    if (!carrier || pin || frequency) {
+        mp_raise_NotImplementedError(translate("Port does not accept pins or frequency. \
+                                    Construct and pass a PWM Carrier instead"));
+    }
+
     if (pulse_fd < 0) {
         pulse_fd = open("/dev/timer0", O_RDONLY);
     }

--- a/ports/cxd56/common-hal/pulseio/PulseOut.c
+++ b/ports/cxd56/common-hal/pulseio/PulseOut.c
@@ -65,7 +65,7 @@ void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
                                             uint16_t duty_cycle) {
     if (!carrier || pin || frequency) {
         mp_raise_NotImplementedError(translate("Port does not accept pins or frequency. \
-                                    Construct and pass a PWM Carrier instead"));
+                                    Construct and pass a PWMOut Carrier instead"));
     }
 
     if (pulse_fd < 0) {

--- a/ports/esp32s2/background.c
+++ b/ports/esp32s2/background.c
@@ -35,10 +35,17 @@
 #include "shared-module/displayio/__init__.h"
 #endif
 
+#if CIRCUITPY_PULSEIO
+#include "common-hal/pulseio/PulseIn.h"
+#endif
+
 
 void port_background_task(void) {
     // Zero delay in case FreeRTOS wants to switch to something else.
     vTaskDelay(0);
+    #if CIRCUITPY_PULSEIO
+    pulsein_background();
+    #endif
 }
 
 void port_start_background_task(void) {}

--- a/ports/esp32s2/common-hal/neopixel_write/__init__.c
+++ b/ports/esp32s2/common-hal/neopixel_write/__init__.c
@@ -93,6 +93,9 @@ void common_hal_neopixel_write (const digitalio_digitalinout_obj_t* digitalinout
     // Reserve channel
     uint8_t number = digitalinout->pin->number;
     rmt_channel_t channel = esp32s2_peripherals_find_and_reserve_rmt();
+    if (channel == RMT_CHANNEL_MAX) {
+        mp_raise_RuntimeError(translate("All timers in use"));
+    }
 
     // Configure Channel
     rmt_config_t config = RMT_DEFAULT_CONFIG_TX(number, channel);

--- a/ports/esp32s2/common-hal/pulseio/PulseIn.c
+++ b/ports/esp32s2/common-hal/pulseio/PulseIn.c
@@ -27,49 +27,208 @@
 #include "common-hal/pulseio/PulseIn.h"
 #include "py/runtime.h"
 
-// STATIC void pulsein_handler(uint8_t num) {
-// }
+STATIC uint8_t refcount = 0;
+STATIC pulseio_pulsein_obj_t * handles[RMT_CHANNEL_MAX];
+
+// Requires rmt.c void esp32s2_peripherals_reset_all(void) to reset
+
+STATIC void update_internal_buffer(pulseio_pulsein_obj_t* self) {
+    //mp_printf(&mp_plat_print, "Update internal Buffer\n");
+    uint32_t length = 0;
+    rmt_item32_t *items = (rmt_item32_t *) xRingbufferReceive(self->buf_handle, &length, 0);
+    if (items) {
+        length /= 4;
+        //mp_printf(&mp_plat_print, "Length%d\n",length);
+        // TODO: If the size of the recieve is larger than the buffer, reset it?
+
+        for (size_t i=0; i < length; i++) {
+            //mp_printf(&mp_plat_print, "Item d0:%d, l0:%d, d1:%d, l1:%d\n",(items[i].duration0 * 3),
+            //          items[i].level0,(items[i].duration1 * 3),items[i].level1);
+            uint16_t pos = (self->start + self->len) % self->maxlen;
+            self->buffer[pos] = items[i].duration0 * 3;
+            // Check if second item exists before incrementing
+            if (items[i].duration1) {
+                self->buffer[pos+1] = items[i].duration1 * 3;
+                if (self->len < (self->maxlen - 1)) {
+                    self->len += 2;
+                } else {
+                    self->start += 2;
+                }
+            } else {
+                if (self->len < self->maxlen) {
+                    self->len++;
+                } else {
+                    self->start++;
+                }
+            }
+        }
+        vRingbufferReturnItem(self->buf_handle, (void *) items);
+    }
+}
+
+// We can't access the RMT interrupt, so we need a global service to prevent
+// the ringbuffer from overflowing and crashing the peripheral
+void pulsein_background(void) {
+    //mp_printf(&mp_plat_print, "BG Task!\n");
+    for (size_t i = 0; i < RMT_CHANNEL_MAX; i++) {
+        if (handles[i]) {
+            //mp_printf(&mp_plat_print, "Located viable handle:%d\n",i);
+            update_internal_buffer(handles[i]);
+            UBaseType_t items_waiting;
+            vRingbufferGetInfo(handles[i]->buf_handle, NULL, NULL, NULL, NULL, &items_waiting);
+            //mp_printf(&mp_plat_print, "items waiting:%d\n",items_waiting);
+            // if (items_waiting > handles[i]->maxlen) {
+            //     mp_printf(&mp_plat_print, "Overage!\n");
+            //     mp_printf(&mp_plat_print, "Items waiting detected:%d\n", items_waiting);
+            //     update_internal_buffer(handles[i]);
+            // }
+        }
+    }
+}
 
 void pulsein_reset(void) {
+    mp_printf(&mp_plat_print, "Pulsein Reset called\n");
+    for (size_t i = 0; i < RMT_CHANNEL_MAX; i++) {
+        handles[i] = NULL;
+    }
+    supervisor_disable_tick();
+    refcount = 0;
 }
 
 void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self, const mcu_pin_obj_t* pin,
                                              uint16_t maxlen, bool idle_state) {
-    mp_raise_NotImplementedError(translate("PulseIn not supported on this chip"));
+    self->buffer = (uint16_t *) m_malloc(maxlen * sizeof(uint16_t), false);
+    if (self->buffer == NULL) {
+        mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"), maxlen * sizeof(uint16_t));
+    }
+    self->pin = pin;
+    self->maxlen = maxlen;
+    // self->idle_state = idle_state;
+    self->start = 0;
+    self->len = 0;
+    // self->first_edge = true;
+    self->paused = false;
+    // self->last_overflow = 0;
+    // self->last_count = 0;
+
+    rmt_channel_t channel = esp32s2_peripherals_find_and_reserve_rmt();
+    mp_printf(&mp_plat_print, "Selected Channel:%d!\n",channel);
+
+    // Configure Channel
+    rmt_config_t config = RMT_DEFAULT_CONFIG_RX(pin->number, channel);
+    config.rx_config.filter_en = true;
+    config.rx_config.idle_threshold = 30000;
+    config.clk_div = 240;
+
+    rmt_config(&config);
+    size_t len = 1000; //TODO: pick a reasonable number for this?
+    // size_t len = maxlen * 4;
+    rmt_driver_install(channel, len, 0);
+
+    self->channel = channel;
+
+    // Store handle for background updates
+    handles[channel] = self;
+
+    rmt_get_ringbuf_handle(channel, &(self->buf_handle));
+    rmt_rx_start(channel, true);
+
+    supervisor_enable_tick();
+    refcount++;
 }
 
 bool common_hal_pulseio_pulsein_deinited(pulseio_pulsein_obj_t* self) {
-    return false;
+    return handles[self->channel] ? true : false;
 }
 
 void common_hal_pulseio_pulsein_deinit(pulseio_pulsein_obj_t* self) {
+    handles[self->channel] = NULL;
+    esp32s2_peripherals_free_rmt(self->channel);
+    reset_pin_number(self->pin);
+    refcount--;
+    if (refcount == 0) {
+        supervisor_disable_tick();
+    }
 }
 
 void common_hal_pulseio_pulsein_pause(pulseio_pulsein_obj_t* self) {
+    self->paused = true;
+    rmt_rx_stop();
 }
 
 void common_hal_pulseio_pulsein_resume(pulseio_pulsein_obj_t* self, uint16_t trigger_duration) {
+    // Make sure we're paused.
+    if ( !self->paused ) {
+        common_hal_pulseio_pulsein_pause(self);
+    }
+
+    self->paused = false;
+    rmt_rx_start();
 }
 
 void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t* self) {
+    self->start = 0;
+    self->len = 0;
 }
 
 uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t* self, int16_t index) {
-    return false;
+    //mp_printf(&mp_plat_print, "Call GetItem\n");
+    update_internal_buffer(self);
+    if (index < 0) {
+        index += self->len;
+    }
+    if (index < 0 || index >= self->len) {
+        mp_raise_IndexError(translate("index out of range"));
+    }
+    uint16_t value = self->buffer[(self->start + index) % self->maxlen];
+    return value;
 }
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
-    return false;
+    mp_printf(&mp_plat_print, "Call PopLeft\n");
+    update_internal_buffer(self);
+
+    if (self->len == 0) {
+        mp_raise_IndexError(translate("pop from an empty PulseIn"));
+    }
+
+    uint16_t value = self->buffer[self->start];
+    self->start = (self->start + 1) % self->maxlen;
+    self->len--;
+
+    return value;
+
+
+    // uint32_t length = 0;
+    // rmt_item32_t *items = (rmt_item32_t *) xRingbufferReceive(self->buf_handle, &length, 10);
+    // mp_printf(&mp_plat_print, "Length%d\n",length);
+    // if (items) {
+    //     length /= 4;
+    //     mp_printf(&mp_plat_print, "Length%d\n",length);
+    //     for (size_t i=0; i < length; i++) {
+    //         mp_printf(&mp_plat_print, "Item d0:%d, l0:%d, d1:%d, l1:%d\n",(items[i].duration0 * 3),
+    //                   items[i].level0,(items[i].duration1 * 3),items[i].level1);
+    //     }
+    //     vRingbufferReturnItem(self->buf_handle, (void *) items);
+    // }
+    // // while(items) {
+    // //     mp_printf(&mp_plat_print, "Length%d",length);
+    // //     mp_printf(&mp_plat_print, "Item val0:%d, val1:%d, val:%d",items->duration0,
+    // //                     items->duration1,items->val);
+    // //     vRingbufferReturnItem(self->buf_handle, (void *) items);
+    // //     items = (rmt_item32_t *) xRingbufferReceive(self->buf_handle, &length, 1);
+    // // }
+    // return items ? items[0].duration0 : false;
 }
 
 uint16_t common_hal_pulseio_pulsein_get_maxlen(pulseio_pulsein_obj_t* self) {
-    return false;
+    return self->maxlen;
 }
 
 bool common_hal_pulseio_pulsein_get_paused(pulseio_pulsein_obj_t* self) {
-    return false;
+    return self->paused;
 }
 
 uint16_t common_hal_pulseio_pulsein_get_len(pulseio_pulsein_obj_t* self) {
-    return false;
+    return self->len;
 }

--- a/ports/esp32s2/common-hal/pulseio/PulseIn.c
+++ b/ports/esp32s2/common-hal/pulseio/PulseIn.c
@@ -105,6 +105,9 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self, const mcu
 
     // Find a free RMT Channel and configure it
     rmt_channel_t channel = esp32s2_peripherals_find_and_reserve_rmt();
+    if (channel == RMT_CHANNEL_MAX) {
+        mp_raise_RuntimeError(translate("All timers in use"));
+    }
     rmt_config_t config = RMT_DEFAULT_CONFIG_RX(pin->number, channel);
     config.rx_config.filter_en = true;
     config.rx_config.idle_threshold = 30000; // 30*3=90ms idle required to register a sequence

--- a/ports/esp32s2/common-hal/pulseio/PulseIn.h
+++ b/ports/esp32s2/common-hal/pulseio/PulseIn.h
@@ -42,15 +42,12 @@ typedef struct {
     bool paused;
 
     RingbufHandle_t buf_handle;
-    volatile bool first_edge;
 
     uint16_t* buffer;
     uint16_t maxlen;
 
     volatile uint16_t start;
     volatile uint16_t len;
-    volatile uint32_t last_overflow;
-    volatile uint16_t last_count;
 } pulseio_pulsein_obj_t;
 
 void pulsein_reset(void);

--- a/ports/esp32s2/common-hal/pulseio/PulseIn.h
+++ b/ports/esp32s2/common-hal/pulseio/PulseIn.h
@@ -30,13 +30,18 @@
 #include "common-hal/microcontroller/Pin.h"
 
 #include "py/obj.h"
+#include "driver/rmt.h"
+#include "rmt.h"
 
 typedef struct {
     mp_obj_base_t base;
 
     const mcu_pin_obj_t* pin;
+    rmt_channel_t channel;
     bool idle_state;
     bool paused;
+
+    RingbufHandle_t buf_handle;
     volatile bool first_edge;
 
     uint16_t* buffer;
@@ -49,5 +54,6 @@ typedef struct {
 } pulseio_pulsein_obj_t;
 
 void pulsein_reset(void);
+void pulsein_background(void);
 
 #endif // MICROPY_INCLUDED_ESP32S2_COMMON_HAL_PULSEIO_PULSEIN_H

--- a/ports/esp32s2/common-hal/pulseio/PulseOut.c
+++ b/ports/esp32s2/common-hal/pulseio/PulseOut.c
@@ -86,6 +86,6 @@ void common_hal_pulseio_pulseout_send(pulseio_pulseout_obj_t* self, uint16_t* pu
 
     rmt_write_items(self->channel, items, length, true);
     while (rmt_wait_tx_done(self->channel, 0) != ESP_OK) {
-        RUN_BACKGROUND_TASKS();
+        RUN_BACKGROUND_TASKS;
     }
 }

--- a/ports/esp32s2/common-hal/pulseio/PulseOut.c
+++ b/ports/esp32s2/common-hal/pulseio/PulseOut.c
@@ -32,15 +32,21 @@
 // Requires rmt.c void esp32s2_peripherals_reset_all(void) to reset
 
 void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
-                                           const mcu_pin_obj_t* pin,
-                                           uint32_t frequency) {
+                                            const pulseio_pwmout_obj_t* carrier,
+                                            const mcu_pin_obj_t* pin,
+                                            uint32_t frequency,
+                                            uint16_t duty_cycle) {
+    if (carrier || !pin || !frequency) {
+        mp_raise_NotImplementedError(translate("Port does not accept PWM carrier. \
+                                    Pass a pin, frequency and duty cycle instead"));
+    }
 
     rmt_channel_t channel = esp32s2_peripherals_find_and_reserve_rmt();
 
     // Configure Channel
     rmt_config_t config = RMT_DEFAULT_CONFIG_TX(pin->number, channel);
     config.tx_config.carrier_en = true;
-    config.tx_config.carrier_duty_percent = 50;
+    config.tx_config.carrier_duty_percent = (duty_cycle * 100) / (1<<16);
     config.tx_config.carrier_freq_hz = frequency;
     config.clk_div = 80;
 

--- a/ports/esp32s2/common-hal/pulseio/PulseOut.c
+++ b/ports/esp32s2/common-hal/pulseio/PulseOut.c
@@ -29,32 +29,52 @@
 #include "shared-bindings/pulseio/PWMOut.h"
 #include "py/runtime.h"
 
-// STATIC void turn_on(pulseio_pulseout_obj_t *pulseout) {
-// }
-
-// STATIC void turn_off(pulseio_pulseout_obj_t *pulseout) {
-// }
-
-// STATIC void start_timer(void) {
-// }
-
-// STATIC void pulseout_event_handler(void) {
-// }
-
-void pulseout_reset() {
-}
+// Requires rmt.c void esp32s2_peripherals_reset_all(void) to reset
 
 void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
-                                           const pulseio_pwmout_obj_t* carrier) {
-    mp_raise_NotImplementedError(translate("PulseOut not supported on this chip"));
+                                           const mcu_pin_obj_t* pin,
+                                           uint32_t frequency) {
+
+    rmt_channel_t channel = esp32s2_peripherals_find_and_reserve_rmt();
+
+    // Configure Channel
+    rmt_config_t config = RMT_DEFAULT_CONFIG_TX(pin->number, channel);
+    config.tx_config.carrier_en = true;
+    config.tx_config.carrier_duty_percent = 50;
+    config.tx_config.carrier_freq_hz = frequency;
+    config.clk_div = 80;
+
+    rmt_config(&config);
+    rmt_driver_install(channel, 0, 0);
+
+    self->channel = channel;
 }
 
 bool common_hal_pulseio_pulseout_deinited(pulseio_pulseout_obj_t* self) {
-    return false;
+    return (self->channel == RMT_CHANNEL_MAX);
 }
 
 void common_hal_pulseio_pulseout_deinit(pulseio_pulseout_obj_t* self) {
+    esp32s2_peripherals_free_rmt(self->channel);
+    self->channel = RMT_CHANNEL_MAX;
+
 }
 
 void common_hal_pulseio_pulseout_send(pulseio_pulseout_obj_t* self, uint16_t* pulses, uint16_t length) {
+    rmt_item32_t items[length];
+
+    // Circuitpython allows 16 bit pulse values, while ESP32 only allows 15 bits
+    // Thus, we use entire items for one pulse, rather than switching inside each item
+    for (size_t i = 0; i < length; i++) {
+        // Setting the RMT duration to 0 has undefined behavior, so avoid that pre-emptively.
+        if (pulses[i] == 0) {
+            pulses[i] = 1;
+        }
+        uint32_t level = (i % 2) ? 0 : 1;
+        const rmt_item32_t item = {{{ (pulses[i] & 0x8000 ? 0x7FFF : 1), level, (pulses[i] & 0x7FFF), level}}};
+        items[i] = item;
+    }
+
+    rmt_write_items(self->channel, items, length, true);
+    rmt_wait_tx_done(self->channel, pdMS_TO_TICKS(100));
 }

--- a/ports/esp32s2/common-hal/pulseio/PulseOut.h
+++ b/ports/esp32s2/common-hal/pulseio/PulseOut.h
@@ -29,14 +29,14 @@
 
 #include "common-hal/microcontroller/Pin.h"
 #include "common-hal/pulseio/PWMOut.h"
+#include "driver/rmt.h"
+#include "rmt.h"
 
 #include "py/obj.h"
 
 typedef struct {
     mp_obj_base_t base;
-    pulseio_pwmout_obj_t *pwmout;
+    rmt_channel_t channel;
 } pulseio_pulseout_obj_t;
-
-void pulseout_reset(void);
 
 #endif // MICROPY_INCLUDED_ESP32S2_COMMON_HAL_PULSEIO_PULSEOUT_H

--- a/ports/esp32s2/mpconfigport.h
+++ b/ports/esp32s2/mpconfigport.h
@@ -36,8 +36,6 @@
 
 #include "py/circuitpy_mpconfig.h"
 
-#define CPY_PULSEOUT_USES_DIGITALIO     (1)
-
 #define MICROPY_PORT_ROOT_POINTERS \
 	CIRCUITPY_COMMON_ROOT_POINTERS
 #define MICROPY_NLR_SETJMP              (1)

--- a/ports/esp32s2/mpconfigport.h
+++ b/ports/esp32s2/mpconfigport.h
@@ -28,19 +28,20 @@
 #ifndef ESP32S2_MPCONFIGPORT_H__
 #define ESP32S2_MPCONFIGPORT_H__
 
-#define CIRCUITPY_INTERNAL_NVM_SIZE         (0)
-#define MICROPY_NLR_THUMB                   (0)
+#define CIRCUITPY_INTERNAL_NVM_SIZE     (0)
+#define MICROPY_NLR_THUMB               (0)
 
-#define MICROPY_PY_UJSON            (0)
-#define MICROPY_USE_INTERNAL_PRINTF      (0)
+#define MICROPY_PY_UJSON                (0)
+#define MICROPY_USE_INTERNAL_PRINTF     (0)
 
 #include "py/circuitpy_mpconfig.h"
 
+#define CPY_PULSEOUT_USES_DIGITALIO     (1)
 
 #define MICROPY_PORT_ROOT_POINTERS \
 	CIRCUITPY_COMMON_ROOT_POINTERS
-#define MICROPY_NLR_SETJMP                  (1)
-#define CIRCUITPY_DEFAULT_STACK_SIZE        0x6000
+#define MICROPY_NLR_SETJMP              (1)
+#define CIRCUITPY_DEFAULT_STACK_SIZE    (0x6000)
 
 
 #endif  // __INCLUDED_ESP32S2_MPCONFIGPORT_H

--- a/ports/esp32s2/peripherals/rmt.c
+++ b/ports/esp32s2/peripherals/rmt.c
@@ -44,8 +44,8 @@ rmt_channel_t esp32s2_peripherals_find_and_reserve_rmt(void) {
             return i;
         }
     }
-    mp_raise_RuntimeError(translate("All timers in use"));
-    return false;
+    // Returning the max indicates a reservation failure.
+    return RMT_CHANNEL_MAX;
 }
 
 void esp32s2_peripherals_free_rmt(rmt_channel_t chan) {

--- a/ports/esp32s2/peripherals/rmt.c
+++ b/ports/esp32s2/peripherals/rmt.c
@@ -29,6 +29,14 @@
 
 bool rmt_reserved_channels[RMT_CHANNEL_MAX];
 
+void esp32s2_peripherals_rmt_reset(void) {
+    for (size_t i = 0; i < RMT_CHANNEL_MAX; i++) {
+        if (rmt_reserved_channels[i]) {
+            esp32s2_peripherals_free_rmt(i);
+        }
+    }
+}
+
 rmt_channel_t esp32s2_peripherals_find_and_reserve_rmt(void) {
     for (size_t i = 0; i < RMT_CHANNEL_MAX; i++) {
         if (!rmt_reserved_channels[i]) {

--- a/ports/esp32s2/peripherals/rmt.c
+++ b/ports/esp32s2/peripherals/rmt.c
@@ -30,6 +30,7 @@
 bool rmt_reserved_channels[RMT_CHANNEL_MAX];
 
 void esp32s2_peripherals_rmt_reset(void) {
+    mp_printf(&mp_plat_print, "RMT Reset called\n");
     for (size_t i = 0; i < RMT_CHANNEL_MAX; i++) {
         if (rmt_reserved_channels[i]) {
             esp32s2_peripherals_free_rmt(i);

--- a/ports/esp32s2/peripherals/rmt.c
+++ b/ports/esp32s2/peripherals/rmt.c
@@ -30,7 +30,6 @@
 bool rmt_reserved_channels[RMT_CHANNEL_MAX];
 
 void esp32s2_peripherals_rmt_reset(void) {
-    mp_printf(&mp_plat_print, "RMT Reset called\n");
     for (size_t i = 0; i < RMT_CHANNEL_MAX; i++) {
         if (rmt_reserved_channels[i]) {
             esp32s2_peripherals_free_rmt(i);

--- a/ports/esp32s2/peripherals/rmt.h
+++ b/ports/esp32s2/peripherals/rmt.h
@@ -31,6 +31,7 @@
 #include "driver/rmt.h"
 #include <stdint.h>
 
+void esp32s2_peripherals_rmt_reset(void);
 rmt_channel_t esp32s2_peripherals_find_and_reserve_rmt(void);
 void esp32s2_peripherals_free_rmt(rmt_channel_t chan);
 

--- a/ports/esp32s2/supervisor/port.c
+++ b/ports/esp32s2/supervisor/port.c
@@ -39,6 +39,7 @@
 #include "common-hal/busio/SPI.h"
 #include "common-hal/busio/UART.h"
 #include "common-hal/pulseio/PWMOut.h"
+#include "common-hal/pulseio/PulseIn.h"
 #include "supervisor/memory.h"
 #include "supervisor/shared/tick.h"
 
@@ -70,6 +71,7 @@ void reset_port(void) {
 #if CIRCUITPY_PULSEIO
     esp32s2_peripherals_rmt_reset();
     pwmout_reset();
+    pulsein_reset();
 #endif
 #if CIRCUITPY_BUSIO
     i2c_reset();

--- a/ports/esp32s2/supervisor/port.c
+++ b/ports/esp32s2/supervisor/port.c
@@ -42,6 +42,8 @@
 #include "supervisor/memory.h"
 #include "supervisor/shared/tick.h"
 
+#include "rmt.h"
+
 STATIC esp_timer_handle_t _tick_timer;
 
 void tick_timer_cb(void* arg) {
@@ -66,6 +68,7 @@ void reset_port(void) {
     vTaskDelay(4);
 
 #if CIRCUITPY_PULSEIO
+    esp32s2_peripherals_rmt_reset();
     pwmout_reset();
 #endif
 #if CIRCUITPY_BUSIO

--- a/ports/mimxrt10xx/common-hal/pulseio/PulseOut.c
+++ b/ports/mimxrt10xx/common-hal/pulseio/PulseOut.c
@@ -94,7 +94,10 @@ void pulseout_reset() {
 }
 
 void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
-                                            const pulseio_pwmout_obj_t* carrier) {
+                                            const pulseio_pwmout_obj_t* carrier,
+                                            const mcu_pin_obj_t* pin,
+                                            uint32_t frequency,
+                                            uint16_t duty_cycle) {
 //    if (refcount == 0) {
 //        // Find a spare timer.
 //        Tc *tc = NULL;

--- a/ports/nrf/common-hal/pulseio/PulseOut.c
+++ b/ports/nrf/common-hal/pulseio/PulseOut.c
@@ -106,7 +106,7 @@ void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
                                             uint16_t duty_cycle) {
     if (!carrier || pin || frequency) {
         mp_raise_NotImplementedError(translate("Port does not accept pins or frequency. \
-                                    Construct and pass a PWM Carrier instead"));
+                                    Construct and pass a PWMOut Carrier instead"));
     }
 
     if (refcount == 0) {

--- a/ports/nrf/common-hal/pulseio/PulseOut.c
+++ b/ports/nrf/common-hal/pulseio/PulseOut.c
@@ -100,7 +100,15 @@ void pulseout_reset() {
 }
 
 void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
-                                           const pulseio_pwmout_obj_t* carrier) {
+                                            const pulseio_pwmout_obj_t* carrier,
+                                            const mcu_pin_obj_t* pin,
+                                            uint32_t frequency,
+                                            uint16_t duty_cycle) {
+    if (!carrier || pin || frequency) {
+        mp_raise_NotImplementedError(translate("Port does not accept pins or frequency. \
+                                    Construct and pass a PWM Carrier instead"));
+    }
+
     if (refcount == 0) {
         timer = nrf_peripherals_allocate_timer_or_throw();
     }

--- a/ports/stm/common-hal/pulseio/PulseOut.c
+++ b/ports/stm/common-hal/pulseio/PulseOut.c
@@ -113,7 +113,15 @@ void pulseout_reset() {
 }
 
 void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
-                                           const pulseio_pwmout_obj_t* carrier) {
+                                            const pulseio_pwmout_obj_t* carrier,
+                                            const mcu_pin_obj_t* pin,
+                                            uint32_t frequency,
+                                            uint16_t duty_cycle) {
+    if (!carrier || pin || frequency) {
+        mp_raise_NotImplementedError(translate("Port does not accept pins or frequency. \
+                                    Construct and pass a PWM Carrier instead"));
+    }
+
     // Add to active PulseOuts
     refcount++;
     TIM_TypeDef * tim_instance = stm_peripherals_find_timer();

--- a/ports/stm/common-hal/pulseio/PulseOut.c
+++ b/ports/stm/common-hal/pulseio/PulseOut.c
@@ -119,7 +119,7 @@ void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
                                             uint16_t duty_cycle) {
     if (!carrier || pin || frequency) {
         mp_raise_NotImplementedError(translate("Port does not accept pins or frequency. \
-                                    Construct and pass a PWM Carrier instead"));
+                                    Construct and pass a PWMOut Carrier instead"));
     }
 
     // Add to active PulseOuts

--- a/shared-bindings/pulseio/PulseOut.c
+++ b/shared-bindings/pulseio/PulseOut.c
@@ -71,11 +71,11 @@ STATIC mp_obj_t pulseio_pulseout_make_new(const mp_obj_type_t *type, size_t n_ar
 
     mp_obj_t carrier_obj = pos_args[0];
     if (MP_OBJ_IS_TYPE(carrier_obj, &pulseio_pwmout_type)) {
-        // PWM Carrier
+        // Use a PWMOut Carrier
         mp_arg_check_num(n_args, kw_args, 1, 1, false);
         common_hal_pulseio_pulseout_construct(self, (pulseio_pwmout_obj_t *)MP_OBJ_TO_PTR(carrier_obj), NULL, 0, 0);
     } else {
-        // Pin and Frequency
+        // Use a Pin, frequency, and duty cycle
         enum { ARG_pin, ARG_frequency};
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_pin, MP_ARG_REQUIRED | MP_ARG_OBJ },

--- a/shared-bindings/pulseio/PulseOut.c
+++ b/shared-bindings/pulseio/PulseOut.c
@@ -69,29 +69,24 @@ STATIC mp_obj_t pulseio_pulseout_make_new(const mp_obj_type_t *type, size_t n_ar
     pulseio_pulseout_obj_t *self = m_new_obj(pulseio_pulseout_obj_t);
     self->base.type = &pulseio_pulseout_type;
 
-    #ifndef CPY_PULSEOUT_USES_DIGITALIO
-    // Most ports pass a PWMOut
-    mp_arg_check_num(n_args, kw_args, 1, 1, false);
-    mp_obj_t carrier_obj = args[0];
-    if (!MP_OBJ_IS_TYPE(carrier_obj, &pulseio_pwmout_type)) {
-        mp_raise_TypeError_varg(translate("Expected a %q"), pulseio_pwmout_type.name);
+    mp_obj_t carrier_obj = pos_args[0];
+    if (MP_OBJ_IS_TYPE(carrier_obj, &pulseio_pwmout_type)) {
+        // PWM Carrier
+        mp_arg_check_num(n_args, kw_args, 1, 1, false);
+        common_hal_pulseio_pulseout_construct(self, (pulseio_pwmout_obj_t *)MP_OBJ_TO_PTR(carrier_obj), NULL, 0, 0);
+    } else {
+        // Pin and Frequency
+        enum { ARG_pin, ARG_frequency};
+        static const mp_arg_t allowed_args[] = {
+            { MP_QSTR_pin, MP_ARG_REQUIRED | MP_ARG_OBJ },
+            { MP_QSTR_frequency, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 38000} },
+            { MP_QSTR_duty_cycle, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1<<15} },
+        };
+        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+        mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+        const mcu_pin_obj_t* pin = validate_obj_is_free_pin(args[ARG_pin].u_obj);
+        common_hal_pulseio_pulseout_construct(self, NULL, pin, args[ARG_frequency].u_int, args[ARG_frequency].u_int);
     }
-    common_hal_pulseio_pulseout_construct(self, (pulseio_pwmout_obj_t *)MP_OBJ_TO_PTR(carrier_obj));
-    #else
-    // ESP32-S2 Special Case
-    enum { ARG_pin, ARG_frequency};
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_pin, MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_frequency, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 38000} },
-    };
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-    const mcu_pin_obj_t* pin = validate_obj_is_free_pin(args[ARG_pin].u_obj);
-
-    common_hal_pulseio_pulseout_construct(self, pin, args[ARG_frequency].u_int);
-    #endif
-
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/pulseio/PulseOut.h
+++ b/shared-bindings/pulseio/PulseOut.h
@@ -33,13 +33,11 @@
 
 extern const mp_obj_type_t pulseio_pulseout_type;
 
-#ifndef CPY_PULSEOUT_USES_DIGITALIO
 extern void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
-    const pulseio_pwmout_obj_t* carrier);
-#else
-extern void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
-    const mcu_pin_obj_t* pin, uint32_t frequency); 
-#endif
+                                            const pulseio_pwmout_obj_t* carrier,
+                                            const mcu_pin_obj_t* pin,
+                                            uint32_t frequency,
+                                            uint16_t duty_cycle);
 
 extern void common_hal_pulseio_pulseout_deinit(pulseio_pulseout_obj_t* self);
 extern bool common_hal_pulseio_pulseout_deinited(pulseio_pulseout_obj_t* self);

--- a/shared-bindings/pulseio/PulseOut.h
+++ b/shared-bindings/pulseio/PulseOut.h
@@ -33,8 +33,14 @@
 
 extern const mp_obj_type_t pulseio_pulseout_type;
 
+#ifndef CPY_PULSEOUT_USES_DIGITALIO
 extern void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
     const pulseio_pwmout_obj_t* carrier);
+#else
+extern void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t* self,
+    const mcu_pin_obj_t* pin, uint32_t frequency); 
+#endif
+
 extern void common_hal_pulseio_pulseout_deinit(pulseio_pulseout_obj_t* self);
 extern bool common_hal_pulseio_pulseout_deinited(pulseio_pulseout_obj_t* self);
 extern void common_hal_pulseio_pulseout_send(pulseio_pulseout_obj_t* self,


### PR DESCRIPTION
This PR adds the PulseOut and PulseIn IR transmission and reception modules to the ESP32-S2 port. Unlike other ports, which transmit pulse trains using timers and PWMOut carrier objects, the ESP32-S2 has a dedicated pulse train peripheral, the "RMT", which is capable of both sending and receiving pulses with and without carrier modulation.

Because of this, PulseOut does not require a PWMOut object, which uses an entirely different peripheral, the LEDC PWM controller. Thus, the API for PulseOut has been expanded to allow the ESP32 to receive a pin object, frequency and duty cycle in place of a PWMOut object. Other ports have been correspondingly internally updated for the change, but should see no difference in their python calls for the time being. 

PulseIn has a couple of quirks that should be noted when reviewing.
- The RMT does not acknowledge or store any detected pulses until a certain "idle period" of no activity is met. I've set this to 90ms, which seemed like a practical value, but it does mean that long pulse trains with no breaks at all will not be acknowledged by the ESP32 - I'm not sure if this is an issue. 
- The internal timing and storage of the RMT required that I slow the clock down by 3x in order to accommodate pulses of 65ms, which are common in the module's examples on ReadTheDocs and Learn. Pulses are thus delivered as smaller numbers from the RMT internally, and then multiplied by 3x before being returned.
- The RMT has no real sense of "idle state", using the idle period threshold to detect the start of a pulse train. I've set this by using pullups so the trigger pulse is meaningful, but I'm not sure if more work needs to be done there.

The RMT is shared by the Neopixel Write system. A mediator system in Peripherals reserves RMT channels individually. Up to 4 channels are available on any pin, so you can have a combination of 4 total PulseOut, PulseIn, and Neopixel lines active at any given time. 

Tested on the ESP32-S2 Saola1 Wrover. Resolves #3264