### PR TITLE
Quiet build messages

### DIFF
--- a/mpy-cross/Makefile.static-raspbian
+++ b/mpy-cross/Makefile.static-raspbian
@@ -6,7 +6,7 @@ PROG=mpy-cross.static-raspbian
 BUILD=build-static-raspbian
 STATIC_BUILD=1
 
+$(shell if ! [ -d pitools ]; then echo 1>&2 "Fetching pi build tools.  This may take awhile."; git clone -q https://github.com/raspberrypi/tools.git --depth=1 pitools; fi)
 CROSS_COMPILE = pitools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/arm-linux-gnueabihf-
 include mpy-cross.mk
 
-$(shell [ -d pitools ] || git clone --progress --verbose https://github.com/raspberrypi/tools.git --depth=1 pitools)

--- a/mpy-cross/Makefile.static-raspbian
+++ b/mpy-cross/Makefile.static-raspbian
@@ -9,4 +9,3 @@ STATIC_BUILD=1
 $(shell if ! [ -d pitools ]; then echo 1>&2 "Fetching pi build tools.  This may take awhile."; git clone -q https://github.com/raspberrypi/tools.git --depth=1 pitools; fi)
 CROSS_COMPILE = pitools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/arm-linux-gnueabihf-
 include mpy-cross.mk
-

--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -259,8 +259,6 @@ def compress(encoding_table, decompressed, encoded_length_bits, len_translation_
                 current_bit -= 1
     if current_bit != 7:
         current_byte += 1
-    if current_byte > len(decompressed):
-        print("Note: compression increased length", repr(decompressed), len(decompressed), current_byte, file=sys.stderr)
     return enc[:current_byte]
 
 def qstr_escape(qst):

--- a/tools/gen_display_resources.py
+++ b/tools/gen_display_resources.py
@@ -61,7 +61,6 @@ f.load_glyphs(set(ord(c) for c in all_characters))
 # Get each glyph.
 for c in set(all_characters):
     if ord(c) not in f._glyphs:
-        print("Font missing character:", c, ord(c))
         filtered_characters = filtered_characters.replace(c, "")
         continue
     g = f.get_glyph(ord(c))


### PR DESCRIPTION
This gets rid of two classes of message that we know exist and do not represent a problem to be dealt with at this point:
```
Note: compression increased length 'USB Busy' 8 9
Font missing character: 見 35211
```
This removes a lot of noise from the logs and helps contributors find the relevant messages when builds fail.