### PR TITLE
allocate_display_bus: fix bug where in-use bus would be returned

### DIFF
--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -398,7 +398,7 @@ primary_display_t *allocate_display_or_raise(void) {
 }
 primary_display_t *allocate_display_bus(void) {
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
-        mp_const_obj_t display_type = displays[i].display.base.type;
+        mp_const_obj_t display_type = displays[i].bus_base.type;
         if (display_type == NULL || display_type == &mp_type_NoneType) {
             return &displays[i];
         }


### PR DESCRIPTION
When I factored out "allocate_display_bus" I introduced a bug where the code checked if the _display_ was allocated, not the _bus_.  Correct the in-use check.