### PR TITLE
Update Simmel board definition to reflect DVT hardware

### DIFF
--- a/ports/nrf/boards/simmel/mpconfigboard.h
+++ b/ports/nrf/boards/simmel/mpconfigboard.h
@@ -45,6 +45,9 @@
 #define BOOTLOADER_SIZE                 (0x4000)  // 12 kiB
 #define CIRCUITPY_BLE_CONFIG_SIZE       (12*1024)
 
+#define DEFAULT_I2C_BUS_SCL         (&pin_P0_08)
+#define DEFAULT_I2C_BUS_SDA         (&pin_P1_09)
+
 // Reduce nRF SoftRadio memory usage
 #define BLEIO_VS_UUID_COUNT 10
 #define BLEIO_HVN_TX_QUEUE_SIZE 2

--- a/ports/nrf/boards/simmel/pins.c
+++ b/ports/nrf/boards/simmel/pins.c
@@ -13,7 +13,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_P0_08) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_P1_09) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },

--- a/ports/nrf/boards/simmel/pins.c
+++ b/ports/nrf/boards/simmel/pins.c
@@ -9,19 +9,15 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_NFC1), MP_ROM_PTR(&pin_P0_09) },
     { MP_ROM_QSTR(MP_QSTR_NFC2), MP_ROM_PTR(&pin_P0_10) },
 
-    { MP_ROM_QSTR(MP_QSTR_I2S_LRCK), MP_ROM_PTR(&pin_P0_08) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_SDIN), MP_ROM_PTR(&pin_P1_09) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_SCK), MP_ROM_PTR(&pin_P0_12) },
-
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_P0_06) },
-    { MP_ROM_QSTR(MP_QSTR_CHG), MP_ROM_PTR(&pin_P0_04) },
 
-    { MP_ROM_QSTR(MP_QSTR_PWM), MP_ROM_PTR(&pin_P0_02) },
-    { MP_ROM_QSTR(MP_QSTR_PWM_N), MP_ROM_PTR(&pin_P0_19) },
-
+    { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_P0_08) },
+    { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_P1_09) },
+    
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+
 };
 
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
Stripping out NUS, adding I2C support for the hardware RTC element. 

thanks!