### PR TITLE
Calculate the Huffman codebook without MP_QSTRs

### DIFF
--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -102,10 +102,6 @@ def translate(translation_file, i18ns):
 
 def compute_huffman_coding(translations, qstrs, compression_filename):
     all_strings = [x[1] for x in translations]
-
-    # go through each qstr and print it out
-    for _, _, qstr in qstrs.values():
-        all_strings.append(qstr)
     all_strings_concat = "".join(all_strings)
     counts = collections.Counter(all_strings_concat)
     cb = huffman.codebook(counts.items())


### PR DESCRIPTION
The Huffman code book for the translation is currently calculated with the translated texts and MP_QSTRs. However, I don't think they are actually used for QSTRs.

We can decrease the entropy a bit by calculating the codebook based only on the translation texts.

```
BOARD=feather_m0_express TRANSLATION=ja

(before) // 9342 bytes worth of translations compressed
↓↓↓
(after)  // 9149 bytes worth of translations compressed
```

BOARD=feather_m0_express

- en: 8398 bytes → 8239 bytes
- es: 9617 bytes → 9561 bytes
- ko: 8815 bytes → 8651 bytes