### PR TITLE
support to get HID OUT report

### DIFF
--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -115,7 +115,7 @@ const mp_obj_property_t usb_hid_device_usage_obj = {
 
 STATIC const mp_rom_map_elem_t usb_hid_device_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_send_report),          MP_ROM_PTR(&usb_hid_device_send_report_obj) },
-    { MP_ROM_QSTR(MP_QSTR_last_received_report), MP_ROM_PTR(&usb_hid_device_report_obj) },
+    { MP_ROM_QSTR(MP_QSTR_last_received_report), MP_ROM_PTR(&usb_hid_device_last_received_report_obj) },
     { MP_ROM_QSTR(MP_QSTR_usage_page),           MP_ROM_PTR(&usb_hid_device_usage_page_obj)},
     { MP_ROM_QSTR(MP_QSTR_usage),                MP_ROM_PTR(&usb_hid_device_usage_obj)},
 };

--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -58,21 +58,21 @@ STATIC mp_obj_t usb_hid_device_send_report(mp_obj_t self_in, mp_obj_t buffer) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(usb_hid_device_send_report_obj, usb_hid_device_send_report);
 
-//|     report: bytes
-//|     """The HID OUT report as a `bytes`. (read-only)"""
+//|     last_received_report: bytes
+//|     """The HID OUT report as a `bytes`. (read-only). `None` if nothing received."""
 //|
-STATIC mp_obj_t usb_hid_device_obj_get_report(mp_obj_t self_in) {
+STATIC mp_obj_t usb_hid_device_obj_get_last_received_report(mp_obj_t self_in) {
     usb_hid_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (self->out_report_buffer == 0) {
         return mp_const_none;
     }
     return mp_obj_new_bytes(self->out_report_buffer, self->out_report_length);
 }
-MP_DEFINE_CONST_FUN_OBJ_1(usb_hid_device_get_report_obj, usb_hid_device_obj_get_report);
+MP_DEFINE_CONST_FUN_OBJ_1(usb_hid_device_get_last_received_report_obj, usb_hid_device_obj_get_last_received_report);
 
-const mp_obj_property_t usb_hid_device_report_obj = {
+const mp_obj_property_t usb_hid_device_last_received_report_obj = {
     .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&usb_hid_device_get_report_obj,
+    .proxy = {(mp_obj_t)&usb_hid_device_get_last_received_report_obj,
               (mp_obj_t)&mp_const_none_obj,
               (mp_obj_t)&mp_const_none_obj},
 };
@@ -114,10 +114,10 @@ const mp_obj_property_t usb_hid_device_usage_obj = {
 };
 
 STATIC const mp_rom_map_elem_t usb_hid_device_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_send_report),    MP_ROM_PTR(&usb_hid_device_send_report_obj) },
-    { MP_ROM_QSTR(MP_QSTR_report),         MP_ROM_PTR(&usb_hid_device_report_obj) },
-    { MP_ROM_QSTR(MP_QSTR_usage_page),     MP_ROM_PTR(&usb_hid_device_usage_page_obj)},
-    { MP_ROM_QSTR(MP_QSTR_usage),          MP_ROM_PTR(&usb_hid_device_usage_obj)},
+    { MP_ROM_QSTR(MP_QSTR_send_report),          MP_ROM_PTR(&usb_hid_device_send_report_obj) },
+    { MP_ROM_QSTR(MP_QSTR_last_received_report), MP_ROM_PTR(&usb_hid_device_report_obj) },
+    { MP_ROM_QSTR(MP_QSTR_usage_page),           MP_ROM_PTR(&usb_hid_device_usage_page_obj)},
+    { MP_ROM_QSTR(MP_QSTR_usage),                MP_ROM_PTR(&usb_hid_device_usage_obj)},
 };
 
 STATIC MP_DEFINE_CONST_DICT(usb_hid_device_locals_dict, usb_hid_device_locals_dict_table);

--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -58,6 +58,25 @@ STATIC mp_obj_t usb_hid_device_send_report(mp_obj_t self_in, mp_obj_t buffer) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(usb_hid_device_send_report_obj, usb_hid_device_send_report);
 
+//|report: bytes
+//|     """The HID OUT report as a `bytes`. (read-only)"""
+//|
+STATIC mp_obj_t usb_hid_device_obj_get_report(mp_obj_t self_in) {
+    usb_hid_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (self->out_report_buffer == 0) {
+        return mp_const_none;
+    }
+    return mp_obj_new_bytes(self->out_report_buffer, self->out_report_length);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(usb_hid_device_get_report_obj, usb_hid_device_obj_get_report);
+
+const mp_obj_property_t usb_hid_device_report_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&usb_hid_device_get_report_obj,
+              (mp_obj_t)&mp_const_none_obj,
+              (mp_obj_t)&mp_const_none_obj},
+};
+
 //|     usage_page: int
 //|     """The usage page of the device as an `int`. Can be thought of a category. (read-only)"""
 //|
@@ -96,6 +115,7 @@ const mp_obj_property_t usb_hid_device_usage_obj = {
 
 STATIC const mp_rom_map_elem_t usb_hid_device_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_send_report),    MP_ROM_PTR(&usb_hid_device_send_report_obj) },
+    { MP_ROM_QSTR(MP_QSTR_report),         MP_ROM_PTR(&usb_hid_device_report_obj) },
     { MP_ROM_QSTR(MP_QSTR_usage_page),     MP_ROM_PTR(&usb_hid_device_usage_page_obj)},
     { MP_ROM_QSTR(MP_QSTR_usage),          MP_ROM_PTR(&usb_hid_device_usage_obj)},
 };

--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -58,7 +58,7 @@ STATIC mp_obj_t usb_hid_device_send_report(mp_obj_t self_in, mp_obj_t buffer) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(usb_hid_device_send_report_obj, usb_hid_device_send_report);
 
-//|report: bytes
+//|     report: bytes
 //|     """The HID OUT report as a `bytes`. (read-only)"""
 //|
 STATIC mp_obj_t usb_hid_device_obj_get_report(mp_obj_t self_in) {

--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -84,14 +84,17 @@ uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type,
 
 // Callbacks invoked when receive Set_Report request through control endpoint
 void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) {
+    if (report_type == HID_REPORT_TYPE_INVALID) {
+        report_id = buffer[0];
+        buffer++;
+        bufsize--;
+    } else if (report_type != HID_REPORT_TYPE_OUTPUT) {
+        return;
+    }
+
     usb_hid_device_obj_t* hid_device = get_hid_device(report_id);
 
-    if ( report_type == HID_REPORT_TYPE_OUTPUT ) {
-        // Check if it is Keyboard device
-        if (hid_device->usage_page == HID_USAGE_PAGE_DESKTOP &&
-                hid_device->usage == HID_USAGE_DESKTOP_KEYBOARD) {
-            // This is LED indicator (CapsLock, NumLock)
-            // TODO Light up some LED here
-        }
+    if (hid_device && hid_device->out_report_length >= bufsize) {
+        memcpy(hid_device->out_report_buffer, buffer, bufsize);
     }
 }

--- a/shared-module/usb_hid/Device.h
+++ b/shared-module/usb_hid/Device.h
@@ -43,6 +43,8 @@ typedef struct  {
     uint8_t report_length;
     uint8_t usage_page;
     uint8_t usage;
+    uint8_t* out_report_buffer;
+    uint8_t out_report_length;
 } usb_hid_device_obj_t;
 
 

--- a/tools/gen_usb_descriptor.py
+++ b/tools/gen_usb_descriptor.py
@@ -535,7 +535,7 @@ c_file.write("""
 };
 """)
 
-c_file.write("\n");
+c_file.write("\n")
 
 hid_descriptor_length = len(bytes(combined_hid_report_descriptor))
 
@@ -593,12 +593,18 @@ for name in args.hid_devices:
 static uint8_t {name}_report_buffer[{report_length}];
 """.format(name=name.lower(), report_length=hid_report_descriptors.HID_DEVICE_DATA[name].report_length))
 
+    if hid_report_descriptors.HID_DEVICE_DATA[name].out_report_length > 0:
+        c_file.write("""\
+static uint8_t {name}_out_report_buffer[{report_length}];
+""".format(name=name.lower(), report_length=hid_report_descriptors.HID_DEVICE_DATA[name].out_report_length))
+
 # Write out table of device objects.
 c_file.write("""
 usb_hid_device_obj_t usb_hid_devices[] = {
-""");
+""")
 for name in args.hid_devices:
     device_data = hid_report_descriptors.HID_DEVICE_DATA[name]
+    out_report_buffer = '{}_out_report_buffer'.format(name.lower()) if device_data.out_report_length > 0 else 'NULL'
     c_file.write("""\
     {{
         .base          = {{ .type = &usb_hid_device_type }},
@@ -607,11 +613,15 @@ for name in args.hid_devices:
         .report_length = {report_length},
         .usage_page    = {usage_page:#04x},
         .usage         = {usage:#04x},
+        .out_report_buffer = {out_report_buffer},
+        .out_report_length = {out_report_length},
     }},
 """.format(name=name.lower(), report_id=report_ids[name],
            report_length=device_data.report_length,
            usage_page=device_data.usage_page,
-           usage=device_data.usage))
+           usage=device_data.usage,
+           out_report_buffer=out_report_buffer,
+           out_report_length=device_data.out_report_length))
 c_file.write("""\
 };
 """)

--- a/tools/hid_report_descriptors.py
+++ b/tools/hid_report_descriptors.py
@@ -18,16 +18,16 @@ from adafruit_usb_descriptor import hid
 
 # Information about each kind of device
 # report_length does not include report ID in first byte, if present when sent.
-DeviceData = namedtuple('DeviceData', ('report_length', 'usage_page', 'usage'))
+DeviceData = namedtuple('DeviceData', ('report_length', 'out_report_length', 'usage_page', 'usage'))
 HID_DEVICE_DATA = {
-    "KEYBOARD" : DeviceData(report_length=8, usage_page=0x01, usage=0x06),    # Generic Desktop, Keyboard
-    "MOUSE" : DeviceData(report_length=4, usage_page=0x01, usage=0x02),       # Generic Desktop, Mouse
-    "CONSUMER" : DeviceData(report_length=2, usage_page=0x0C, usage=0x01),    # Consumer, Consumer Control
-    "SYS_CONTROL" : DeviceData(report_length=1, usage_page=0x01, usage=0x80), # Generic Desktop, Sys Control
-    "GAMEPAD" : DeviceData(report_length=6, usage_page=0x01, usage=0x05),     # Generic Desktop, Game Pad
-    "DIGITIZER" : DeviceData(report_length=5, usage_page=0x0D, usage=0x02),   # Digitizers, Pen
-    "XAC_COMPATIBLE_GAMEPAD" : DeviceData(report_length=3, usage_page=0x01, usage=0x05), # Generic Desktop, Game Pad
-    "RAW" : DeviceData(report_length=64, usage_page=0xFFAF, usage=0xAF),      # Vendor 0xFFAF "Adafruit", 0xAF
+    "KEYBOARD" : DeviceData(report_length=8, out_report_length=1, usage_page=0x01, usage=0x06),    # Generic Desktop, Keyboard
+    "MOUSE" : DeviceData(report_length=4, out_report_length=0, usage_page=0x01, usage=0x02),       # Generic Desktop, Mouse
+    "CONSUMER" : DeviceData(report_length=2, out_report_length=0, usage_page=0x0C, usage=0x01),    # Consumer, Consumer Control
+    "SYS_CONTROL" : DeviceData(report_length=1, out_report_length=0, usage_page=0x01, usage=0x80), # Generic Desktop, Sys Control
+    "GAMEPAD" : DeviceData(report_length=6, out_report_length=0, usage_page=0x01, usage=0x05),     # Generic Desktop, Game Pad
+    "DIGITIZER" : DeviceData(report_length=5, out_report_length=0, usage_page=0x0D, usage=0x02),   # Digitizers, Pen
+    "XAC_COMPATIBLE_GAMEPAD" : DeviceData(report_length=3, out_report_length=0, usage_page=0x01, usage=0x05), # Generic Desktop, Game Pad
+    "RAW" : DeviceData(report_length=64, out_report_length=0, usage_page=0xFFAF, usage=0xAF),      # Vendor 0xFFAF "Adafruit", 0xAF
     }
 
 def keyboard_hid_descriptor(report_id):


### PR DESCRIPTION
This is a draft implementation to get USB HID OUT report, which added a `report` property for `usb_hid.Device` to get HID OUT report.
With the feature. we  are able to get the keyboard leds info (capslock, numlock).

Usage:
```
indicators = usb_hid.devices[0].report[0]
```

Besides, Have added a `report` property to [BLE HID `ReportOut`](https://github.com/adafruit/Adafruit_CircuitPython_BLE/blob/master/adafruit_ble/services/standard/hid.py#L245) too.