### PR TITLE
spresense: call usb_background function

### DIFF
--- a/ports/cxd56/supervisor/port.c
+++ b/ports/cxd56/supervisor/port.c
@@ -36,6 +36,8 @@
 #include "boards/board.h"
 
 #include "supervisor/port.h"
+#include "supervisor/background_callback.h"
+#include "supervisor/usb.h"
 #include "supervisor/shared/tick.h"
 
 #include "common-hal/microcontroller/Pin.h"
@@ -114,6 +116,11 @@ uint32_t port_get_saved_word(void) {
     return _ebss;
 }
 
+static background_callback_t callback;
+static void usb_background_do(void* unused) {
+    usb_background();
+}
+
 volatile bool _tick_enabled;
 void board_timerhook(void)
 {
@@ -121,6 +128,8 @@ void board_timerhook(void)
     if (_tick_enabled) {
         supervisor_tick();
     }
+
+    background_callback_add(&callback, usb_background_do, NULL);
 }
 
 uint64_t port_get_raw_ticks(uint8_t* subticks) {


### PR DESCRIPTION
After #2879, Spresense did not work because `usb_background` function was not called.

This PR fixes this issue.