### PR TITLE
supervisor: check for interrupt during rx_chr

### DIFF
--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -113,6 +113,8 @@ STATIC int parse_compile_execute(const void *source, mp_parse_input_kind_t input
         start = mp_hal_ticks_ms();
         mp_call_function_0(module_fun);
         mp_hal_set_interrupt_char(-1); // disable interrupt
+        // Handle any ctrl-c interrupt that arrived just in time
+        mp_handle_pending();
         nlr_pop();
         ret = 0;
         if (exec_flags & EXEC_FLAG_PRINT_EOF) {

--- a/py/obj.c
+++ b/py/obj.c
@@ -67,6 +67,8 @@ void mp_obj_print_helper(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t
     #ifdef RUN_BACKGROUND_TASKS
     RUN_BACKGROUND_TASKS;
     #endif
+    mp_handle_pending();
+
 #ifndef NDEBUG
     if (o_in == MP_OBJ_NULL) {
         mp_print_str(print, "(nil)");

--- a/supervisor/shared/micropython.c
+++ b/supervisor/shared/micropython.c
@@ -30,6 +30,7 @@
 #include "lib/oofatfs/ff.h"
 #include "py/mpconfig.h"
 #include "py/mpstate.h"
+#include "py/runtime.h"
 
 #include "supervisor/shared/status_leds.h"
 
@@ -45,16 +46,7 @@ int mp_hal_stdin_rx_chr(void) {
         #ifdef MICROPY_VM_HOOK_LOOP
             MICROPY_VM_HOOK_LOOP
         #endif
-        // Check to see if we've been CTRL-Ced by autoreload or the user.
-        if (MP_STATE_VM(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception))) {
-            // clear exception and generate stacktrace
-            MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
-            nlr_raise(&MP_STATE_VM(mp_kbd_exception));
-          }
-        if (MP_STATE_VM(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_reload_exception)) || WATCHDOG_EXCEPTION_CHECK()) {
-            // stop reading immediately
-            return EOF;
-        }
+        mp_handle_pending();
         if (serial_bytes_available()) {
             toggle_rx_led();
             return serial_read();

--- a/supervisor/shared/tick.c
+++ b/supervisor/shared/tick.c
@@ -27,6 +27,7 @@
 #include "supervisor/shared/tick.h"
 
 #include "py/mpstate.h"
+#include "py/runtime.h"
 #include "supervisor/linker.h"
 #include "supervisor/filesystem.h"
 #include "supervisor/background_callback.h"
@@ -149,17 +150,7 @@ void mp_hal_delay_ms(mp_uint_t delay) {
     while (remaining > 0) {
         RUN_BACKGROUND_TASKS;
         // Check to see if we've been CTRL-Ced by autoreload or the user.
-        if(MP_STATE_VM(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception)))
-           {
-            // clear exception and generate stacktrace
-            MP_STATE_VM(mp_pending_exception) = MP_OBJ_NULL;
-            nlr_raise(&MP_STATE_VM(mp_kbd_exception));
-          }
-        if( MP_STATE_VM(mp_pending_exception) == MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_reload_exception)) ||
-           WATCHDOG_EXCEPTION_CHECK()) {
-            // stop sleeping immediately
-            break;
-        }
+        mp_handle_pending();
         remaining = end_tick - port_get_raw_ticks(NULL);
         // We break a bit early so we don't risk setting the alarm before the time when we call
         // sleep.


### PR DESCRIPTION
I noticed that during `sys.stdin.read(1)` or `input()`, hitting ctrl-c or doing something that should cause code-reload would fail to do so.  This related to #2689 and is a possible alternative fix vs #3312.