### PR TITLE
ESP32-S2: Enable ulab

### DIFF
--- a/ports/esp32s2/mpconfigport.mk
+++ b/ports/esp32s2/mpconfigport.mk
@@ -27,6 +27,6 @@ CIRCUITPY_COUNTIO = 0
 # any port once their prerequisites in common-hal are complete.
 CIRCUITPY_RANDOM = 0          # Requires OS
 CIRCUITPY_USB_MIDI = 0        # Requires USB
-CIRCUITPY_ULAB = 0            # No requirements, but takes extra flash
+CIRCUITPY_ULAB = 1            # No requirements, but takes extra flash
 
 CIRCUITPY_MODULE ?= none


### PR DESCRIPTION
This PR enables ulab for the ESP32-S2, since there's no reason not to.