### PR TITLE
Shared bindings matrix ulab

### DIFF
--- a/docs/shared_bindings_matrix.py
+++ b/docs/shared_bindings_matrix.py
@@ -43,7 +43,7 @@ def get_circuitpython_root_dir():
 def get_shared_bindings():
     """ Get a list of modules in shared-bindings based on folder names
     """
-    shared_bindings_dir = get_circuitpython_root_dir() / "shared-bindings"
+    shared_bindings_dir = get_circuitpython_root_dir() / "circuitpython-stubs"
     return [item.name for item in shared_bindings_dir.iterdir()]
 
 

--- a/docs/shared_bindings_matrix.py
+++ b/docs/shared_bindings_matrix.py
@@ -28,6 +28,7 @@ import re
 import subprocess
 import sys
 
+from concurrent.futures import ThreadPoolExecutor
 
 SUPPORTED_PORTS = ['atmel-samd', 'esp32s2', 'litex', 'mimxrt10xx', 'nrf', 'stm']
 
@@ -131,38 +132,44 @@ def lookup_setting(settings, key, default=''):
         key = value[2:-1]
     return value
 
+def all_ports_all_boards(ports=SUPPORTED_PORTS):
+    for port in ports:
+
+        port_dir = get_circuitpython_root_dir() / "ports" / port
+        for entry in (port_dir / "boards").iterdir():
+            if not entry.is_dir():
+                continue
+            yield (port, entry)
+
 def support_matrix_by_board(use_branded_name=True):
     """ Compiles a list of the available core modules available for each
         board.
     """
     base = build_module_map()
 
-    boards = dict()
-    for port in SUPPORTED_PORTS:
-
+    def support_matrix(arg):
+        port, entry = arg
         port_dir = get_circuitpython_root_dir() / "ports" / port
-        for entry in (port_dir / "boards").iterdir():
-            if not entry.is_dir():
-                continue
-            board_modules = []
-            board_name = entry.name
+        settings = get_settings_from_makefile(str(port_dir), entry.name)
 
-            settings = get_settings_from_makefile(str(port_dir), entry.name)
+        if use_branded_name:
+            with open(entry / "mpconfigboard.h") as get_name:
+                board_contents = get_name.read()
+            board_name_re = re.search(r"(?<=MICROPY_HW_BOARD_NAME)\s+(.+)",
+                                      board_contents)
+            if board_name_re:
+                board_name = board_name_re.group(1).strip('"')
 
-            if use_branded_name:
-                with open(entry / "mpconfigboard.h") as get_name:
-                    board_contents = get_name.read()
-                board_name_re = re.search(r"(?<=MICROPY_HW_BOARD_NAME)\s+(.+)",
-                                          board_contents)
-                if board_name_re:
-                    board_name = board_name_re.group(1).strip('"')
+        board_modules = []
+        for module in base:
+            key = f'CIRCUITPY_{module.upper()}'
+            if int(lookup_setting(settings, key, '0')):
+                board_modules.append(base[module]['name'])
 
-            board_modules = []
-            for module in base:
-                key = f'CIRCUITPY_{module.upper()}'
-                if int(lookup_setting(settings, key, '0')):
-                    board_modules.append(base[module]['name'])
-            boards[board_name] = sorted(board_modules)
+        return (board_name, sorted(board_modules))
+
+    executor = ThreadPoolExecutor(max_workers=os.cpu_count())
+    boards = dict(sorted(executor.map(support_matrix, all_ports_all_boards())))
 
     #print(json.dumps(boards, indent=2))
     return boards


### PR DESCRIPTION
Closes: #3331 

Also adds code to speed up shared-bindings-matrix on multi-core systems, reducing it from ~1minute to ~30seconds on my laptop (2.6GHz 2C/4T) and from ~25 seconds to ~4 seconds on my desktop (3.6GHz 8C/16T)

The order of the files is different now (it is ordered by name, not by port-then-name), but I did my best effort to compare them and determine that only "ulab" was added to the matrix.