### PR TITLE
Fix all assignments affected by inline makefile comments

### DIFF
--- a/docs/porting.rst
+++ b/docs/porting.rst
@@ -51,10 +51,15 @@ as a natural "TODO" list. An example minimal build list is shown below:
 .. code-block:: makefile
 
     # These modules are implemented in ports/<port>/common-hal:
-    CIRCUITPY_MICROCONTROLLER = 0 # Typically the first module to create
-    CIRCUITPY_DIGITALIO = 0       # Typically the second module to create
+
+    # Typically the first module to create
+    CIRCUITPY_MICROCONTROLLER = 0
+    # Typically the second module to create
+    CIRCUITPY_DIGITALIO = 0
+    # Other modules:
     CIRCUITPY_ANALOGIO = 0
     CIRCUITPY_BUSIO = 0
+    CIRCUITPY_COUNTIO = 0
     CIRCUITPY_NEOPIXEL_WRITE = 0
     CIRCUITPY_PULSEIO = 0
     CIRCUITPY_OS = 0
@@ -63,22 +68,34 @@ as a natural "TODO" list. An example minimal build list is shown below:
     CIRCUITPY_AUDIOIO = 0
     CIRCUITPY_ROTARYIO = 0
     CIRCUITPY_RTC = 0
+    CIRCUITPY_SDCARDIO = 0
+    CIRCUITPY_FRAMEBUFFERIO = 0
     CIRCUITPY_FREQUENCYIO = 0
     CIRCUITPY_I2CPERIPHERAL = 0
-    CIRCUITPY_DISPLAYIO = 0       # Requires SPI, PulseIO (stub ok)
+    # Requires SPI, PulseIO (stub ok):
+    CIRCUITPY_DISPLAYIO = 0
 
     # These modules are implemented in shared-module/ - they can be included in
     # any port once their prerequisites in common-hal are complete.
-    CIRCUITPY_BITBANGIO = 0       # Requires DigitalIO
-    CIRCUITPY_GAMEPAD = 0         # Requires DigitalIO
-    CIRCUITPY_PIXELBUF = 0        # Requires neopixel_write or SPI (dotstar)
-    CIRCUITPY_RANDOM = 0          # Requires OS
-    CIRCUITPY_STORAGE = 0         # Requires OS, filesystem
-    CIRCUITPY_TOUCHIO = 0         # Requires Microcontroller
-    CIRCUITPY_USB_HID = 0         # Requires USB
-    CIRCUITPY_USB_MIDI = 0        # Requires USB
-    CIRCUITPY_REQUIRE_I2C_PULLUPS = 0 # Does nothing without I2C
-    CIRCUITPY_ULAB = 0            # No requirements, but takes extra flash
+    # Requires DigitalIO:
+    CIRCUITPY_BITBANGIO = 0
+    # Requires DigitalIO
+    CIRCUITPY_GAMEPAD = 0
+    # Requires neopixel_write or SPI (dotstar)
+    CIRCUITPY_PIXELBUF = 0
+    # Requires OS
+    CIRCUITPY_RANDOM = 0
+    # Requires OS, filesystem
+    CIRCUITPY_STORAGE = 0
+    # Requires Microcontroller
+    CIRCUITPY_TOUCHIO = 0
+    # Requires USB
+    CIRCUITPY_USB_HID = 0
+    CIRCUITPY_USB_MIDI = 0
+    # Does nothing without I2C
+    CIRCUITPY_REQUIRE_I2C_PULLUPS = 0
+    # No requirements, but takes extra flash
+    CIRCUITPY_ULAB = 0
 
 Step 2: Init
 --------------

--- a/ports/esp32s2/mpconfigport.mk
+++ b/ports/esp32s2/mpconfigport.mk
@@ -25,8 +25,9 @@ CIRCUITPY_COUNTIO = 0
 
 # These modules are implemented in shared-module/ - they can be included in
 # any port once their prerequisites in common-hal are complete.
-CIRCUITPY_RANDOM = 0          # Requires OS
-CIRCUITPY_USB_MIDI = 0        # Requires USB
-CIRCUITPY_ULAB = 1            # No requirements, but takes extra flash
+# Requires OS
+CIRCUITPY_RANDOM = 0
+# Requires USB
+CIRCUITPY_USB_MIDI = 0
 
 CIRCUITPY_MODULE ?= none

--- a/ports/esp32s2/mpconfigport.mk
+++ b/ports/esp32s2/mpconfigport.mk
@@ -29,5 +29,7 @@ CIRCUITPY_COUNTIO = 0
 CIRCUITPY_RANDOM = 0
 # Requires USB
 CIRCUITPY_USB_MIDI = 0
+# Too large for the partition table!
+CIRCUITPY_ULAB = 0
 
 CIRCUITPY_MODULE ?= none

--- a/ports/stm/boards/espruino_pico/mpconfigboard.mk
+++ b/ports/stm/boards/espruino_pico/mpconfigboard.mk
@@ -10,7 +10,8 @@ MCU_VARIANT = STM32F401xE
 MCU_PACKAGE = UFQFPN48
 
 LD_COMMON = boards/common_default.ld
-LD_FILE = boards/STM32F401xd_fs.ld # use for internal flash
+# use for internal flash
+LD_FILE = boards/STM32F401xd_fs.ld
 
 # Disable ulab as we're nearly out of space on this board due to
 # INTERNAL_FLASH_FILESYSTEM.  It can probably be reenabled if we enable

--- a/ports/stm/boards/feather_stm32f405_express/mpconfigboard.mk
+++ b/ports/stm/boards/feather_stm32f405_express/mpconfigboard.mk
@@ -13,5 +13,6 @@ MCU_PACKAGE = LQFP64
 
 LD_COMMON = boards/common_default.ld
 LD_DEFAULT = boards/STM32F405_default.ld
-LD_BOOT = boards/STM32F405_boot.ld # UF2 boot option
+# UF2 boot option
+LD_BOOT = boards/STM32F405_boot.ld
 UF2_OFFSET = 0x8010000

--- a/ports/stm/boards/meowbit_v121/mpconfigboard.mk
+++ b/ports/stm/boards/meowbit_v121/mpconfigboard.mk
@@ -18,4 +18,5 @@ OPTIMIZATION_FLAGS = -Os
 
 LD_COMMON = boards/common_default.ld
 LD_FILE = boards/STM32F401xe_boot.ld
-# LD_FILE = boards/STM32F401xe_fs.ld # use for internal flash
+# use for internal flash
+# LD_FILE = boards/STM32F401xe_fs.ld

--- a/tools/mpconfig_category_reader.py
+++ b/tools/mpconfig_category_reader.py
@@ -1,0 +1,31 @@
+filepath = '../py/circuitpy_mpconfig.mk'
+with open(filepath) as fp:
+    line = fp.readline()
+    cnt = 1
+    fullbuild = []
+    defon = []
+    defoff = []
+    while line:
+        wordlist = line.split()
+        if wordlist:
+            if wordlist[-1] == "$(CIRCUITPY_FULL_BUILD)":
+                fullbuild.append(wordlist[0])
+            elif wordlist[-1] == "0":
+                defoff.append(wordlist[0])
+            elif wordlist[-1] == "1":
+                defon.append(wordlist[0])
+        line = fp.readline()
+        cnt += 1
+
+    print(str(cnt) + " Lines Read\n")
+    print("\nFULL BUILDS ------------------------")
+    for string in fullbuild:
+        print(string)
+
+    print("\nON BUILDS ------------------------")
+    for string in defon:
+        print(string)
+
+    print("\nOFF BUILDS ------------------------")
+    for string in defoff:
+        print(string)


### PR DESCRIPTION
When making an assignment such as `CIRCUITPY_MODULENAME = 1` in a makefile, make will automatically add any trailing whitespace to the value of the assignment, which can cause evaluation failures down the line. Normally the compiler will warn you about this, but when the assignment is followed by an inline comment, `CIRCUITPY_MODULENAME = 1 #somecomment`, this warning is omitted. 

Unaware of this I mistakenly included several inline comments in the STM32 and ESP32 ports, as well as in the copy-pastable "template" for a port's mpconfigport.mk file in the documentation. This PR removes all problematic inclusions of inline comments and updates the documentation. 

Other additional minor improvements include updating the porting template to include COUNTIO, SDCARDIO and FRAMEBUFFERIO, which are now on by default, and a small python tool for quickly visualizing what modules in Circuitpython default as on, off, or are for large builds only. Note that it also turns Ulab back off for the ESP32, since including this module properly revealed that it is actually too big to fit with our current partition table!