### PR TITLE
conf.py (docs): Reorder the steps of the doc build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -42,6 +42,9 @@ master_doc = 'docs/index'
 # Grab the JSON values to use while building the module support matrix
 # in 'shared-bindings/index.rst'
 
+# The stubs must be built before we calculate the shared bindings matrix
+subprocess.check_output(["make", "stubs"])
+
 #modules_support_matrix = shared_bindings_matrix.support_matrix_excluded_boards()
 modules_support_matrix = shared_bindings_matrix.support_matrix_by_board()
 
@@ -77,7 +80,6 @@ source_suffix = {
     '.md': 'markdown',
 }
 
-subprocess.check_output(["make", "stubs"])
 extensions.append('autoapi.extension')
 
 autoapi_type = 'python'


### PR DESCRIPTION
Since e121e267adacf6 (#3332), the shared bindings matrix uses the stubs. Therefore, we must build them!  This should fix the failure to build the docs on readthedocs.org.

Neither @sommersoft nor I saw this locally since we had previously built the stubs.  github CI didn't see it, because it manually builds the stubs in an earlier step of the build process, and does not clean the tree in between.