### PR TITLE
Fix RGBMatrix, FrameBufferDisplay bugs

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -258,6 +258,8 @@ SRC_ASF += \
 $(BUILD)/asf4/$(CHIP_FAMILY)/hpl/sdhc/hpl_sdhc.o: CFLAGS += -Wno-cast-align
 endif
 
+$(BUILD)/asf4/$(CHIP_FAMILY)/hpl/sercom/hpl_sercom.o: CFLAGS += -Wno-maybe-uninitialized
+
 SRC_ASF := $(addprefix asf4/$(CHIP_FAMILY)/, $(SRC_ASF))
 
 SRC_C = \

--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -107,7 +107,7 @@ CFLAGS += -DCFG_TUSB_MCU=OPT_MCU_SAME5X -DCFG_TUD_MIDI_RX_BUFSIZE=128 -DCFG_TUD_
 endif
 
 # option to override default optimization level, set in boards/$(BOARD)/mpconfigboard.mk
-CFLAGS += $(OPTIMIZATION_FLAGS) -DNDEBUG
+CFLAGS += $(OPTIMIZATION_FLAGS)
 
 $(echo PERIPHERALS_CHIP_FAMILY=$(PERIPHERALS_CHIP_FAMILY))
 #Debugging/Optimization
@@ -121,6 +121,7 @@ ifeq ($(DEBUG), 1)
     CFLAGS += -DENABLE_MICRO_TRACE_BUFFER
   endif
 else
+  CFLAGS += -DNDEBUG
   # -finline-limit can shrink the image size.
   # -finline-limit=80 or so is similar to not having it on.
   # There is no simple default value, though.

--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -252,7 +252,7 @@ STATIC mp_obj_t rgbmatrix_rgbmatrix_deinit(mp_obj_t self_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(rgbmatrix_rgbmatrix_deinit_obj, rgbmatrix_rgbmatrix_deinit);
 
 static void check_for_deinit(rgbmatrix_rgbmatrix_obj_t *self) {
-    if (!self->core.rgbPins) {
+    if (!self->protomatter.rgbPins) {
         raise_deinited_error();
     }
 }

--- a/shared-bindings/rgbmatrix/RGBMatrix.h
+++ b/shared-bindings/rgbmatrix/RGBMatrix.h
@@ -24,29 +24,12 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_RGBMATRIX_RGBMATRIX_H
-#define MICROPY_INCLUDED_SHARED_BINDINGS_RGBMATRIX_RGBMATRIX_H
+#pragma once
 
 #include "shared-module/rgbmatrix/RGBMatrix.h"
 #include "lib/protomatter/core.h"
 
 extern const mp_obj_type_t rgbmatrix_RGBMatrix_type;
-typedef struct {
-    mp_obj_base_t base;
-    mp_obj_t framebuffer;
-    mp_buffer_info_t bufinfo;
-    Protomatter_core core;
-    void *timer;
-    uint16_t bufsize, width;
-    uint8_t rgb_pins[30];
-    uint8_t addr_pins[10];
-    uint8_t clock_pin, latch_pin, oe_pin;
-    uint8_t rgb_count, addr_count;
-    uint8_t bit_depth;
-    bool core_is_initialized;
-    bool paused;
-    bool doublebuffer;
-} rgbmatrix_rgbmatrix_obj_t;
 
 void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t* self, int width, int bit_depth, uint8_t rgb_count, uint8_t* rgb_pins, uint8_t addr_count, uint8_t* addr_pins, uint8_t clock_pin, uint8_t latch_pin, uint8_t oe_pin, bool doublebuffer, mp_obj_t framebuffer, void* timer);
 void common_hal_rgbmatrix_rgbmatrix_deinit(rgbmatrix_rgbmatrix_obj_t*);
@@ -57,5 +40,3 @@ bool common_hal_rgbmatrix_rgbmatrix_get_paused(rgbmatrix_rgbmatrix_obj_t* self);
 void common_hal_rgbmatrix_rgbmatrix_refresh(rgbmatrix_rgbmatrix_obj_t* self);
 int common_hal_rgbmatrix_rgbmatrix_get_width(rgbmatrix_rgbmatrix_obj_t* self);
 int common_hal_rgbmatrix_rgbmatrix_get_height(rgbmatrix_rgbmatrix_obj_t* self);
-
-#endif

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -66,7 +66,7 @@ void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebu
         ram_height,
         0,
         0,
-        rotation,
+        0, // rotation
         depth,
         fb_getter_default(get_grayscale, (depth < 8)),
         fb_getter_default(get_pixels_in_byte_share_row, false),
@@ -91,6 +91,10 @@ void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebu
 
     self->native_frames_per_second = fb_getter_default(get_native_frames_per_second, 60);
     self->native_ms_per_frame = 1000 / self->native_frames_per_second;
+
+    if (rotation != 0) {
+        common_hal_framebufferio_framebufferdisplay_set_rotation(self, rotation);
+    }
 
     supervisor_start_terminal(self->core.width, self->core.height);
 

--- a/shared-module/rgbmatrix/RGBMatrix.c
+++ b/shared-module/rgbmatrix/RGBMatrix.c
@@ -66,6 +66,7 @@ void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t *self, i
 }
 
 void common_hal_rgbmatrix_rgbmatrix_reconstruct(rgbmatrix_rgbmatrix_obj_t* self, mp_obj_t framebuffer) {
+    common_hal_rgbmatrix_timer_disable(self->timer);
     if (framebuffer) {
         self->framebuffer = framebuffer;
         framebuffer = mp_obj_new_bytearray_of_zeros(self->bufsize);

--- a/shared-module/rgbmatrix/RGBMatrix.c
+++ b/shared-module/rgbmatrix/RGBMatrix.c
@@ -69,7 +69,6 @@ void common_hal_rgbmatrix_rgbmatrix_reconstruct(rgbmatrix_rgbmatrix_obj_t* self,
     common_hal_rgbmatrix_timer_disable(self->timer);
     if (framebuffer) {
         self->framebuffer = framebuffer;
-        framebuffer = mp_obj_new_bytearray_of_zeros(self->bufsize);
         mp_get_buffer_raise(self->framebuffer, &self->bufinfo, MP_BUFFER_READ);
         if (mp_get_buffer(self->framebuffer, &self->bufinfo, MP_BUFFER_RW)) {
             self->bufinfo.typecode = 'H' | MP_OBJ_ARRAY_TYPECODE_FLAG_RW;

--- a/shared-module/rgbmatrix/RGBMatrix.h
+++ b/shared-module/rgbmatrix/RGBMatrix.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Jeff Epler for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include "lib/protomatter/core.h"
+
+extern const mp_obj_type_t rgbmatrix_RGBMatrix_type;
+typedef struct {
+    mp_obj_base_t base;
+    mp_obj_t framebuffer;
+    mp_buffer_info_t bufinfo;
+    Protomatter_core protomatter;
+    void *timer;
+    uint16_t bufsize, width;
+    uint8_t rgb_pins[30];
+    uint8_t addr_pins[10];
+    uint8_t clock_pin, latch_pin, oe_pin;
+    uint8_t rgb_count, addr_count;
+    uint8_t bit_depth;
+    bool core_is_initialized;
+    bool paused;
+    bool doublebuffer;
+} rgbmatrix_rgbmatrix_obj_t;

--- a/shared-module/rgbmatrix/allocator.h
+++ b/shared-module/rgbmatrix/allocator.h
@@ -1,29 +1,11 @@
-#ifndef MICROPY_INCLUDED_SHARED_MODULE_RGBMATRIX_ALLOCATOR_H
-#define MICROPY_INCLUDED_SHARED_MODULE_RGBMATRIX_ALLOCATOR_H
+#pragma once
 
 #include <stdbool.h>
 #include "py/gc.h"
 #include "py/misc.h"
 #include "supervisor/memory.h"
 
-#define _PM_ALLOCATOR _PM_allocator_impl
-#define _PM_FREE(x) (_PM_free_impl((x)), (x)=NULL, (void)0)
-
-static inline void *_PM_allocator_impl(size_t sz) {
-    if (gc_alloc_possible()) {
-        return m_malloc_maybe(sz + sizeof(void*), true);
-    } else {
-        supervisor_allocation *allocation = allocate_memory(align32_size(sz), false);
-        return allocation ? allocation->ptr : NULL;
-    }
-}
-
-static inline void _PM_free_impl(void *ptr_in) {
-    supervisor_allocation *allocation = allocation_from_ptr(ptr_in);
-
-    if (allocation) {
-        free_memory(allocation);
-    }
-}
-
-#endif
+#define _PM_ALLOCATOR common_hal_rgbmatrix_allocator_impl
+#define _PM_FREE(x) (common_hal_rgbmatrix_free_impl((x)), (x)=NULL, (void)0)
+extern void *common_hal_rgbmatrix_allocator_impl(size_t sz);
+extern void common_hal_rgbmatrix_free_impl(void *);

--- a/shared-module/rgbmatrix/allocator.h
+++ b/shared-module/rgbmatrix/allocator.h
@@ -1,3 +1,29 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Jeff Epler for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #pragma once
 
 #include <stdbool.h>

--- a/shared-module/rgbmatrix/allocator.h
+++ b/shared-module/rgbmatrix/allocator.h
@@ -11,7 +11,7 @@
 
 static inline void *_PM_allocator_impl(size_t sz) {
     if (gc_alloc_possible()) {
-        return m_malloc(sz + sizeof(void*), true);
+        return m_malloc_maybe(sz + sizeof(void*), true);
     } else {
         supervisor_allocation *allocation = allocate_memory(align32_size(sz), false);
         return allocation ? allocation->ptr : NULL;

--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -65,10 +65,14 @@ void supervisor_start_terminal(uint16_t width_px, uint16_t height_px) {
     if (width_in_tiles < 80) {
         scale = 1;
     }
+
     width_in_tiles = (width_px - blinka_bitmap.width * scale) / (grid->tile_width * scale);
+    if (width_in_tiles < 1) {
+        width_in_tiles = 1;
+    }
     uint16_t height_in_tiles = height_px / (grid->tile_height * scale);
     uint16_t remaining_pixels = height_px % (grid->tile_height * scale);
-    if (remaining_pixels > 0) {
+    if (height_in_tiles < 1 || remaining_pixels > 0) {
         height_in_tiles += 1;
     }
 
@@ -94,6 +98,8 @@ void supervisor_start_terminal(uint16_t width_px, uint16_t height_px) {
     }
     grid->width_in_tiles = width_in_tiles;
     grid->height_in_tiles = height_in_tiles;
+    assert(width_in_tiles > 0);
+    assert(height_in_tiles > 0);
     grid->pixel_width = width_in_tiles * grid->tile_width;
     grid->pixel_height = height_in_tiles * grid->tile_height;
     grid->tiles = tiles;


### PR DESCRIPTION
There were a number of problems.  First, when allocation failed during _PM_begin, a crash would occur if you tried to _PM_free the object.  Second, there were problems with how allocation errors were signaled that presented additional problems for recovery. (it was doing longjmps out of the protomatter code, and it erroneously disabled interrupts, both of which made post- or mid-crash behavior extremely hard to fathom until noticing those things)

This does not fix 'the other' problem, which is that calling "release_displays()" can't actually release all the rgbmatrix-related storage back into the CircuitPython heap.  This is because of the folllowing:
 * when a display is initially allocated, it is while circuitpython is running.  It places all allocations on the CircuitPython heap
 * when the program reloads, the allocations are moved from the CP heap to the supervisor heap
 * so when CP starts again, the CP heap is smaller by that amount
 * but it is not possible to re-use the supervisor allocations from step 2, because of the current structure of heap allocations
This can lead to an allocation failure on the second run that does not occur on a first run, part of why this crash seemed so spoopy.

Most of my testing was done with a setting where the _FIRST_ allocation would fail, e.g., by allocating a 192x32 RGBMatrix.  So it's possible I still haven't covered the problem with the original program.  However, the original program never reproduced the problem reliably for me, it was more like 2-5% of the time.

Additional bugs acknowledged and fixed:
 * Setting a nonzero rotation led to a garbled display or hard crashes
 * Small displays (e.g., 16 pixels wide) caused safe mode resets
 * Unneeded memory allocations
 * Low-probability memory splatting during soft reset
