### PR TITLE
builtinimport: Fix a crash with 'import ulab.linalg' on unix port only

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -488,7 +488,7 @@ mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
                 // afterwards.
                 gc_collect();
             }
-            if (outer_module_obj != MP_OBJ_NULL) {
+            if (outer_module_obj != MP_OBJ_NULL && VERIFY_PTR(outer_module_obj) ) {
                 qstr s = qstr_from_strn(mod_str + last, i - last);
                 mp_store_attr(outer_module_obj, s, module_obj);
                 // The above store can cause a dictionary rehash and new allocation. So,


### PR DESCRIPTION
A crash like the following occurs in the unix port:
```
Program received signal SIGSEGV, Segmentation fault.
0x00005555555a2d7a in mp_obj_module_set_globals (self_in=0x55555562c860 <ulab_user_cmodule>, globals=0x55555562c840 <mp_module_ulab_globals>) at ../../py/objmodule.c:145
145	    self->globals = globals;
(gdb) up
#1  0x00005555555b2781 in mp_builtin___import__ (n_args=5, args=0x7fffffffdbb0) at ../../py/builtinimport.c:496
496	                mp_obj_module_set_globals(outer_module_obj,
(gdb)
#2  0x00005555555940c9 in mp_import_name (name=824, fromlist=0x555555621f10 <mp_const_none_obj>, level=0x1) at ../../py/runtime.c:1392
1392	    return mp_builtin___import__(5, args);
```

I don't understand how it doesn't happen on the embedded ports, because the module object should reside in ROM and the assignment of self->globals should trigger a Hard Fault.

By checking VERIFY_PTR, we know that the pointed-to data is on the heap so we can do things like mutate it.