### PR TITLE
actions: Clone the esp-idf submodules ourselves

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -433,6 +433,11 @@ jobs:
       with:
         path: ${{ github.workspace }}/.idf_tools
         key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20200801
+    - name: Clone IDF submodules
+      run: |
+        (cd $IDF_PATH && git submodule update --init)
+      env:
+        IDF_PATH: ${{ github.workspace }}/ports/esp32s2/esp-idf
     - name: Install IDF tools
       run: |
         $IDF_PATH/tools/idf_tools.py --non-interactive install required


### PR DESCRIPTION
Builds of the esp32s2 targets frequently fail:
```
-- Found Git: /usr/bin/git (found version "2.28.0")
-- Initialising new submodule components/asio/asio...
warning: could not look up configuration 'remote.origin.url'. Assuming this repository is its own authoritative upstream.
Submodule 'components/asio/asio' (/home/runner/work/circuitpython/circuitpython/ports/espressif/asio.git) registered for path 'components/asio/asio'
fatal: repository '/home/runner/work/circuitpython/circuitpython/ports/espressif/asio.git' does not exist
fatal: clone of '/home/runner/work/circuitpython/circuitpython/ports/espressif/asio.git' into submodule path '/home/runner/work/circuitpython/circuitpython/ports/esp32s2/esp-idf/components/asio/asio' failed
Failed to clone 'components/asio/asio'. Retry scheduled
fatal: repository '/home/runner/work/circuitpython/circuitpython/ports/espressif/asio.git' does not exist
fatal: clone of '/home/runner/work/circuitpython/circuitpython/ports/espressif/asio.git' into submodule path '/home/runner/work/circuitpython/circuitpython/ports/esp32s2/esp-idf/components/asio/asio' failed
Failed to clone 'components/asio/asio' a second time, aborting
CMake Error at esp-idf/tools/cmake/git_submodules.cmake:48 (message):
  Git submodule init failed for components/asio/asio
Call Stack (most recent call first):
  esp-idf/tools/cmake/build.cmake:78 (git_submodule_check)
  esp-idf/tools/cmake/build.cmake:160 (__build_get_idf_git_revision)
  esp-idf/tools/cmake/idf.cmake:49 (__build_init)
  esp-idf/tools/cmake/project.cmake:7 (include)
  CMakeLists.txt:8 (include)
```

It's not clear how/why this happens--is it something to do with our multithreaded build?.  Attempt to clear it up by manually checking out these submodules ourselves.

I don't know how to judge whether this PR should be accepted.