### PR TITLE
Ignore "makefile", which can be used to customize the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,7 @@ TAGS
 ####################
 .venv
 .env
+
+# Local customizations to the build
+####################
+**/makefile


### PR DESCRIPTION
e.g., I put content in ports/_portname_/makefile like
```
BOARD=boardname
DEBUG=1
include Makefile
```
so that when I `make` it picks up these flags automatically.

This change means that these files won't be picked up by `git status` or removed by `git clean` (unless -x is specified).