### PR TITLE
fix pins for trellis_m4 board.I2C()

### DIFF
--- a/ports/atmel-samd/boards/trellis_m4_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/trellis_m4_express/mpconfigboard.h
@@ -16,8 +16,8 @@
 #define MICROPY_PORT_C (0)
 #define MICROPY_PORT_D (0)
 
-#define DEFAULT_I2C_BUS_SCL (&pin_PB08)
-#define DEFAULT_I2C_BUS_SDA (&pin_PB09)
+#define DEFAULT_I2C_BUS_SCL (&pin_PB09)
+#define DEFAULT_I2C_BUS_SDA (&pin_PB08)
 
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1


### PR DESCRIPTION
SCL and SDA pins were reversed for `board.I2C()`.

Tested on a real board. Before this fix, got "Invalid pins" error.

I discovered this accidentally while trying to debug a NeoTrellis problem, and confusing a NeoTrellis M4 with a regular NeoTrellis. :smiley: 