### PR TITLE
Add non-DMA SPI support.

### DIFF
--- a/ports/esp32s2/common-hal/busio/SPI.h
+++ b/ports/esp32s2/common-hal/busio/SPI.h
@@ -44,10 +44,6 @@ typedef struct {
     spi_hal_context_t hal_context;
     spi_hal_timing_conf_t timing_conf;
     intr_handle_t interrupt;
-    // IDF allocates these in DMA accessible memory so they may need to move when
-    // we use external RAM for CircuitPython.
-    lldesc_t tx_dma;
-    lldesc_t rx_dma;
     uint32_t target_frequency;
     int32_t real_frequency;
     uint8_t polarity;


### PR DESCRIPTION
This fixes SPI with PSRAM allocated buffers. DMA with SPI2 was
attempted but produced junk output. This manual copy is less than
2x slower than DMA when not interrupted.

Fixes #3339