### PR TITLE
Add esp32s2 safe mode support & fix user_safe_mode output

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-12 18:06+0530\n"
+"POT-Creation-Date: 2020-09-13 22:53+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -574,12 +574,6 @@ msgstr ""
 msgid ""
 "CircuitPython is in safe mode because you pressed the reset button during "
 "boot. Press again to exit safe mode.\n"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"CircuitPython is in safe mode with status being USER_SAFE_MODE but no "
-"specific reason was provided.\n"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-09 14:33-0700\n"
+"POT-Creation-Date: 2020-09-12 18:06+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,12 +28,6 @@ msgid ""
 "\n"
 "Please file an issue with the contents of your CIRCUITPY drive at \n"
 "https://github.com/adafruit/circuitpython/issues\n"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid ""
-"\n"
-"To exit, please reset the board without "
 msgstr ""
 
 #: py/obj.c
@@ -580,6 +574,12 @@ msgstr ""
 msgid ""
 "CircuitPython is in safe mode because you pressed the reset button during "
 "boot. Press again to exit safe mode.\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"CircuitPython is in safe mode with status being USER_SAFE_MODE but no "
+"specific reason was provided.\n"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -1603,6 +1603,10 @@ msgstr ""
 #: ports/stm/common-hal/pwmio/PWMOut.c
 msgid ""
 "Timer was reserved for internal use - declare PWM pins earlier in the program"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "To exit, please reset the board without "
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
@@ -25,7 +25,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up\n"
+#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up.\n"
 
 // Increase stack size slightly due to CPX library import nesting
 #define CIRCUITPY_DEFAULT_STACK_SIZE  (4248) //divisible by 8

--- a/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
@@ -25,7 +25,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
+#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up\n"
 
 // Increase stack size slightly due to CPX library import nesting
 #define CIRCUITPY_DEFAULT_STACK_SIZE  (4248) //divisible by 8

--- a/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
@@ -27,7 +27,7 @@
 #define USER_NEOPIXELS_PIN      (&pin_PB23)
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
+#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up\n"
 
 // Increase stack size slightly due to CPX library import nesting
 #define CIRCUITPY_DEFAULT_STACK_SIZE  (4248) // divisible by 8

--- a/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
@@ -27,7 +27,7 @@
 #define USER_NEOPIXELS_PIN      (&pin_PB23)
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up\n"
+#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up.\n"
 
 // Increase stack size slightly due to CPX library import nesting
 #define CIRCUITPY_DEFAULT_STACK_SIZE  (4248) // divisible by 8

--- a/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
@@ -25,7 +25,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
+#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up\n"
 
 // Increase stack size slightly due to CPX library import nesting.
 #define CIRCUITPY_DEFAULT_STACK_SIZE  (4248)  // divisible by 8

--- a/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
@@ -25,7 +25,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up\n"
+#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up.\n"
 
 // Increase stack size slightly due to CPX library import nesting.
 #define CIRCUITPY_DEFAULT_STACK_SIZE  (4248)  // divisible by 8

--- a/ports/atmel-samd/boards/escornabot_makech/mpconfigboard.h
+++ b/ports/atmel-samd/boards/escornabot_makech/mpconfigboard.h
@@ -11,7 +11,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
+#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up\n"
 
 #define DEFAULT_I2C_BUS_SCL (&pin_PA08)
 #define DEFAULT_I2C_BUS_SDA (&pin_PA09)

--- a/ports/atmel-samd/boards/escornabot_makech/mpconfigboard.h
+++ b/ports/atmel-samd/boards/escornabot_makech/mpconfigboard.h
@@ -11,7 +11,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up\n"
+#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up.\n"
 
 #define DEFAULT_I2C_BUS_SCL (&pin_PA08)
 #define DEFAULT_I2C_BUS_SDA (&pin_PA09)

--- a/ports/atmel-samd/boards/meowmeow/mpconfigboard.h
+++ b/ports/atmel-samd/boards/meowmeow/mpconfigboard.h
@@ -11,7 +11,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up"
+#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up\n"
 
 #define DEFAULT_I2C_BUS_SCL (&pin_PA01)
 #define DEFAULT_I2C_BUS_SDA (&pin_PA00)

--- a/ports/atmel-samd/boards/meowmeow/mpconfigboard.h
+++ b/ports/atmel-samd/boards/meowmeow/mpconfigboard.h
@@ -11,7 +11,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up\n"
+#define BOARD_USER_SAFE_MODE_ACTION "pressing both buttons at start up.\n"
 
 #define DEFAULT_I2C_BUS_SCL (&pin_PA01)
 #define DEFAULT_I2C_BUS_SDA (&pin_PA00)

--- a/ports/esp32s2/boards/electroniccats_bastwifi/mpconfigboard.h
+++ b/ports/esp32s2/boards/electroniccats_bastwifi/mpconfigboard.h
@@ -29,4 +29,8 @@
 #define MICROPY_HW_BOARD_NAME       "BastWiFi"
 #define MICROPY_HW_MCU_NAME         "ESP32S2"
 
+#define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
+
+#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up.\n"
+
 #define AUTORESET_DELAY_MS 500

--- a/ports/esp32s2/boards/espressif_kaluga_1/mpconfigboard.h
+++ b/ports/esp32s2/boards/espressif_kaluga_1/mpconfigboard.h
@@ -31,4 +31,8 @@
 
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO45)
 
+#define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
+
+#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up.\n"
+
 #define AUTORESET_DELAY_MS 500

--- a/ports/esp32s2/boards/espressif_saola_1_wroom/mpconfigboard.h
+++ b/ports/esp32s2/boards/espressif_saola_1_wroom/mpconfigboard.h
@@ -33,6 +33,6 @@
 
 #define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
 
-#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up."
+#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up.\n"
 
 #define AUTORESET_DELAY_MS 500

--- a/ports/esp32s2/boards/espressif_saola_1_wroom/mpconfigboard.h
+++ b/ports/esp32s2/boards/espressif_saola_1_wroom/mpconfigboard.h
@@ -31,4 +31,8 @@
 
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO18)
 
+#define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
+
+#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up."
+
 #define AUTORESET_DELAY_MS 500

--- a/ports/esp32s2/boards/espressif_saola_1_wrover/mpconfigboard.h
+++ b/ports/esp32s2/boards/espressif_saola_1_wrover/mpconfigboard.h
@@ -33,6 +33,6 @@
 
 #define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
 
-#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up."
+#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up.\n"
 
 #define AUTORESET_DELAY_MS 500

--- a/ports/esp32s2/boards/espressif_saola_1_wrover/mpconfigboard.h
+++ b/ports/esp32s2/boards/espressif_saola_1_wrover/mpconfigboard.h
@@ -31,4 +31,8 @@
 
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO18)
 
+#define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
+
+#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up."
+
 #define AUTORESET_DELAY_MS 500

--- a/ports/esp32s2/boards/microdev_micro_s2/mpconfigboard.h
+++ b/ports/esp32s2/boards/microdev_micro_s2/mpconfigboard.h
@@ -32,4 +32,8 @@
 #define MICROPY_HW_LED (&pin_GPIO21)
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO33)
 
+#define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
+
+#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up."
+
 #define AUTORESET_DELAY_MS 500

--- a/ports/esp32s2/boards/microdev_micro_s2/mpconfigboard.h
+++ b/ports/esp32s2/boards/microdev_micro_s2/mpconfigboard.h
@@ -34,6 +34,6 @@
 
 #define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
 
-#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up."
+#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up.\n"
 
 #define AUTORESET_DELAY_MS 500

--- a/ports/esp32s2/boards/unexpectedmaker_feathers2/mpconfigboard.h
+++ b/ports/esp32s2/boards/unexpectedmaker_feathers2/mpconfigboard.h
@@ -29,6 +29,10 @@
 #define MICROPY_HW_BOARD_NAME       "FeatherS2"
 #define MICROPY_HW_MCU_NAME         "ESP32S2"
 
+#define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
+
+#define BOARD_USER_SAFE_MODE_ACTION "pressing boot button at start up.\n"
+
 #define AUTORESET_DELAY_MS 500
 
 // Doesn't work with this on.

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -72,7 +72,7 @@ safe_mode_t wait_for_safe_mode_reset(void) {
         // Blink on for 100, off for 100, on for 100, off for 100 and on for 200
         common_hal_digitalio_digitalinout_set_value(&status_led, diff > 100 && diff / 100 != 2 && diff / 100 != 4);
         #endif
-	    #ifdef CIRCUITPY_BOOT_BUTTON
+        #ifdef CIRCUITPY_BOOT_BUTTON
         if (!common_hal_digitalio_digitalinout_get_value(&boot_button)) {
            return USER_SAFE_MODE;
         }

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -123,8 +123,7 @@ void print_safe_mode_message(safe_mode_t reason) {
                 serial_write_compressed(translate("To exit, please reset the board without "));
                 serial_write_compressed(translate(BOARD_USER_SAFE_MODE_ACTION));
             #else
-                // fallthrough
-                serial_write_compressed(translate("CircuitPython is in safe mode with status being USER_SAFE_MODE but no specific reason was provided.\n"));
+                break;
             #endif
             return;
         case MANUAL_SAFE_MODE:

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -72,7 +72,7 @@ safe_mode_t wait_for_safe_mode_reset(void) {
         // Blink on for 100, off for 100, on for 100, off for 100 and on for 200
         common_hal_digitalio_digitalinout_set_value(&status_led, diff > 100 && diff / 100 != 2 && diff / 100 != 4);
         #endif
-	#ifdef CIRCUITPY_BOOT_BUTTON
+	    #ifdef CIRCUITPY_BOOT_BUTTON
         if (!common_hal_digitalio_digitalinout_get_value(&boot_button)) {
            return USER_SAFE_MODE;
         }
@@ -120,11 +120,11 @@ void print_safe_mode_message(safe_mode_t reason) {
                 // Output a user safe mode string if it's set.
                 serial_write_compressed(translate("You requested starting safe mode by "));
                 serial_write_compressed(translate(BOARD_USER_SAFE_MODE_ACTION));
-                serial_write_compressed(translate("\nTo exit, please reset the board without "));
+                serial_write_compressed(translate("To exit, please reset the board without "));
                 serial_write_compressed(translate(BOARD_USER_SAFE_MODE_ACTION));
-                serial_write("\n");
             #else
                 // fallthrough
+                serial_write_compressed(translate("CircuitPython is in safe mode with status being USER_SAFE_MODE but no specific reason was provided.\n"));
             #endif
             return;
         case MANUAL_SAFE_MODE:


### PR DESCRIPTION
_Please go through issue https://github.com/adafruit/circuitpython/issues/3389 for a background of this PR._

**What works:**
- On esp32s2, one can manually enter safe mode by pressing boot button during the 700ms loop on startup. This loop is indicated by:  
  - yellow color on rgb led and/or,
  - a blinking led      
_Note: If you do not have any way of guessing the loop status, power-on the board/press the reset button and after a short delay, press and hold boot button for a while_     
- This PR also fixes the output of `USER_SAFE_MODE` which provides a board specific reason for entering safe mode. 

**To-do:**

_As of now when boot button is pressed esp32s2 doesn't perform a `soft_reboot` with `safe_mode` data stored in ram, instead it continues to boot with `safe_mode` status being `USER_SAFE_MODE` and finally ends up in safe mode. This workflow is not consistent with other CPY ports where a reset is performed and safe mode is entered on next boot._

To address this the following needs to be implemented:
1. Instead of returning `USER_SAFE_MODE` in function `wait_for_safe_mode_reset()`, `soft_reboot` needs to be called.  
2. `port_set_saved_word()` function needs to edited in order to save `safe_mode` status in ram for the next boot.
