### PR TITLE
Fix bug with socket.recv_into size == 0.

### DIFF
--- a/shared-bindings/socketpool/Socket.c
+++ b/shared-bindings/socketpool/Socket.c
@@ -261,7 +261,7 @@ STATIC mp_obj_t socketpool_socket_recv_into(size_t n_args, const mp_obj_t *args)
     mp_int_t len = bufinfo.len;
     if (n_args == 3) {
         mp_int_t given_len = mp_obj_get_int(args[2]);
-        if (given_len < len) {
+        if (given_len > 0 && given_len < len) {
             len = given_len;
         }
     }


### PR DESCRIPTION
It returned 0 when it should have filled the buffer.

Python reference: https://docs.python.org/3/library/socket.html#socket.socket.recv_into