### PR TITLE
compression: Implement @ciscorn's dictionary approach

### DIFF
--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -16,6 +16,9 @@ import collections
 import gettext
 import os.path
 
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(errors='backslashreplace')
+
 py = os.path.dirname(sys.argv[0])
 top = os.path.dirname(py)
 

--- a/supervisor/shared/translate.c
+++ b/supervisor/shared/translate.c
@@ -47,13 +47,22 @@ STATIC int put_utf8(char *buf, int u) {
     if(u <= 0x7f) {
         *buf = u;
         return 1;
-    } else if(bigram_start <= u && u <= bigram_end) {
-        int n = (u - 0x80) * 2;
-        // (note that at present, entries in the bigrams table are
-        // guaranteed not to represent bigrams themselves, so this adds
+    } else if(word_start <= u && u <= word_end) {
+        int n = (u - 0x80);
+        size_t off = 0;
+        for(int i=0; i<n; i++) {
+            off += wlen[i];
+        }
+        int ret = 0;
+        // note that at present, entries in the words table are
+        // guaranteed not to represent words themselves, so this adds
         // at most 1 level of recursive call
-        int ret = put_utf8(buf, bigrams[n]);
-        return ret + put_utf8(buf + ret, bigrams[n+1]);
+        for(int i=0; i<wlen[n]; i++) {
+            int len = put_utf8(buf, words[off+i]);
+            buf += len;
+            ret += len;
+        }
+        return ret;
     } else if(u <= 0x07ff) {
         *buf++ = 0b11000000 | (u >> 6);
         *buf   = 0b10000000 | (u & 0b00111111);

--- a/supervisor/shared/translate.h
+++ b/supervisor/shared/translate.h
@@ -43,6 +43,19 @@
 //   (building the huffman encoding on UTF-16 code points gave better
 //   compression than building it on UTF-8 bytes)
 //
+// - code points starting at 128 (word_start) and potentially extending
+//   to 255 (word_end) (but never interfering with the target
+//   language's used code points) stand for dictionary entries in a
+//   dictionary with size up to 256 code points.  The dictionary entries
+//   are computed with a heuristic based on frequent substrings of 2 to
+//   9 code points.  These are called "words" but are not, grammatically
+//   speaking, words.  They're just spans of code points that frequently
+//   occur together.
+//
+// - dictionary entries are non-overlapping, and the _ending_ index of each
+//   entry is stored in an array.  Since the index given is the ending
+//   index, the array is called "wends".
+//
 // The "data" / "tail" construct is so that the struct's last member is a
 // "flexible array".  However, the _only_ member is not permitted to be
 // a flexible member, so we have to declare the first byte as a separte


### PR DESCRIPTION
Massive savings.  Thanks so much @ciscorn for providing the initial code for choosing the dictionary at https://github.com/adafruit/circuitpython/pull/3370#issuecomment-691486409

Now, a "dictionary" is chosen based on the frequency of strings of various lengths within the input corpus, according to a somewhat magic weight function.  Some huffman codes, starting at 128, are set aside to indicate indices into this dictionary.  The dictionary itself is up to 256 code points.  The big advance (compared to bigrams) is that the dictionary items are arbitrary length.    For instance, on Trinket M0 in English, here are some of the dictionary items: `[' must be ', ' argument', ' specifi', 'attribut', 'support', ...]`.  " must be " occurs 21 times and gets a Huffman coding of 11001101 which is very economical (fewer bits than the single code point "%", for instance).

This adds a bit of time to the build, in order to compute the dictionary.

I also deleted a line to produce the "estimated total memory size" -- at least on the unix build with TRANSLATION=ja, this led to a build time KeyError trying to compute the codebook size for all the strings. I think this occurs because some single unicode code point ('ァ') is no longer present as itself in the compressed strings, due to always being replaced by a word.  Because this line was not accounting for ngrams before or words now, it was inaccurate anyway.

As promised, this seems to save hundreds of bytes in the German translation on the trinket m0.

Testing performed:
 - built trinket_m0 (en, de_DE)
 - built and ran unix port in several languages (en, de_DE, ja) and ran simple error-producing codes like ./micropython -c '1/0', verifying there were no display errors