### PR TITLE
feather_m4_express: Use quad data mode on flash

### DIFF
--- a/ports/atmel-samd/boards/feather_m4_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/feather_m4_express/mpconfigboard.h
@@ -16,8 +16,6 @@
 #define MICROPY_PORT_C (0)
 #define MICROPY_PORT_D (0)
 
-#define EXTERNAL_FLASH_QSPI_DUAL
-
 #define BOARD_HAS_CRYSTAL 1
 
 #define DEFAULT_I2C_BUS_SCL (&pin_PA13)


### PR DESCRIPTION
Limor confirmed that the all shipping revisions starting with Rev D had QSPI flash chips installed.

Note that when neither EXTERNAL_FLASH_QSPI_SINGLE nor EXTERNAL_FLASH_QSPI_DUAL is specified quad mode is assumed, so this is addressed by removing the setting altogether.

I only compile-tested this.