### PR TITLE
doc fix: remove the text about the non-existing clock specification

### DIFF
--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -215,7 +215,7 @@ STATIC mp_obj_t time_time(void) {
 MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 
 //| def monotonic_ns() -> Any:
-//|     """Return the time of the specified clock clk_id in nanoseconds.
+//|     """Return the time of the monotonic clock, cannot go backward, in nanoseconds.
 //|
 //|     :return: the current time
 //|     :rtype: int"""


### PR DESCRIPTION
Jeff E.Today at 11:16 AM
@CarlFK that's almost certainly my fault.  there's only one clock :slight_smile:   that's documentation taken from desktop unix python3's time.clock_gettime_ns which actually does have multiple clocks it can refer to.  A PR to remove the text about the non-existing clock specification would be very welcome. 