### PR TITLE
STM32: Change SPI Read to acknowledge write_value

### DIFF
--- a/ports/stm/Makefile
+++ b/ports/stm/Makefile
@@ -102,7 +102,8 @@ CFLAGS += $(INC) -Werror -Wall -std=gnu11 -fshort-enums $(BASE_CFLAGS) $(C_DEFS)
 
 # Undo some warnings.
 # STM32 HAL uses undefined preprocessor variables, shadowed variables, casts that change alignment reqs
-CFLAGS += -Wno-undef -Wno-shadow -Wno-cast-align
+# You can add your own temporary suppression by setting ADD_CFLAGS in the make command
+CFLAGS += -Wno-undef -Wno-shadow -Wno-cast-align $(ADD_CFLAGS)
 
 CFLAGS += -mthumb -mabi=aapcs-linux
 

--- a/ports/stm/common-hal/busio/SPI.c
+++ b/ports/stm/common-hal/busio/SPI.c
@@ -25,6 +25,7 @@
  * THE SOFTWARE.
  */
 #include <stdbool.h>
+#include <string.h>
 
 #include "shared-bindings/busio/SPI.h"
 #include "py/mperrno.h"
@@ -340,7 +341,7 @@ bool common_hal_busio_spi_write(busio_spi_obj_t *self,
     if (self->mosi == NULL) {
         mp_raise_ValueError(translate("No MOSI Pin"));
     }
-    HAL_StatusTypeDef result = HAL_SPI_Transmit (&self->handle, (uint8_t *)data, (uint16_t)len, HAL_MAX_DELAY);
+    HAL_StatusTypeDef result = HAL_SPI_Transmit(&self->handle, (uint8_t *)data, (uint16_t)len, HAL_MAX_DELAY);
     return result == HAL_OK;
 }
 
@@ -349,7 +350,13 @@ bool common_hal_busio_spi_read(busio_spi_obj_t *self,
     if (self->miso == NULL) {
         mp_raise_ValueError(translate("No MISO Pin"));
     }
-    HAL_StatusTypeDef result = HAL_SPI_Receive (&self->handle, data, (uint16_t)len, HAL_MAX_DELAY);
+    HAL_StatusTypeDef result = HAL_OK;
+    if (self->mosi == NULL) {
+        result = HAL_SPI_Receive(&self->handle, data, (uint16_t)len, HAL_MAX_DELAY);
+    } else {
+        memset(data, write_value, len);
+        result = HAL_SPI_TransmitReceive(&self->handle, data, data, (uint16_t)len, HAL_MAX_DELAY);
+    }
     return result == HAL_OK;
 }
 
@@ -358,7 +365,7 @@ bool common_hal_busio_spi_transfer(busio_spi_obj_t *self,
     if (self->miso == NULL || self->mosi == NULL) {
         mp_raise_ValueError(translate("Missing MISO or MOSI Pin"));
     }
-    HAL_StatusTypeDef result = HAL_SPI_TransmitReceive (&self->handle,
+    HAL_StatusTypeDef result = HAL_SPI_TransmitReceive(&self->handle,
         (uint8_t *) data_out, data_in, (uint16_t)len,HAL_MAX_DELAY);
     return result == HAL_OK;
 }


### PR DESCRIPTION
Some SPI devices on STM32 have been having difficulty connecting, particularly SD cards and some breakouts such as the NRF24L01. This is because the STM32 HAL does not have defined behavior for its output pin (MOSI) when performing Reads - SD cards and the NRF24L01 require specific values such as 0xFF or a key value, but during a `HAL_SPI_Receive`, this line will typically just be random junk. This is supposed to be handled by setting the `write_value` parameter - however, the STM32 port previously ignored this value since it was based off NRF52, which also does not use it.

This PR switches the HAL function to HAL_SPI_TransmitReceive, which maintains both lines, so it can use `write_value`. This requires adding a memset of length `len` to prepare `write_value` to be issued as outgoing data, which may reduce performance somewhat at fast SPI speeds. 

This probably should also be done on the ESP32-S2 port, which appears to be having similar difficulties with SD cards. I'm not entirely sure why it isn't an issue on the NRF52 - that port may have a default Logic 1 level for the output while reading, and special cases like the NRF24L01 may simply never have come up.

Thanks @jerryneedell for findig and @jepler for identifying and suggesting the code for this fix. Resolves #3176. Also adds a minor makefile change (ADD_CFLAGS variable) to assist debugging.