### PR TITLE
samd: SPI: improve conditional code

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -286,8 +286,6 @@ SRC_ASF += \
 $(BUILD)/asf4/$(CHIP_FAMILY)/hpl/sdhc/hpl_sdhc.o: CFLAGS += -Wno-cast-align -Wno-implicit-fallthrough
 endif
 
-$(BUILD)/asf4/$(CHIP_FAMILY)/hpl/sercom/hpl_sercom.o: CFLAGS += -Wno-maybe-uninitialized
-
 SRC_ASF := $(addprefix asf4/$(CHIP_FAMILY)/, $(SRC_ASF))
 
 SRC_C += \


### PR DESCRIPTION
I recently misdiagnosed a "maybe-uninitialized" diagnostic as a bug in asf4.  However, the problem was in our SPI code.

A special case for samr21 MCUs was being applied to same54p20a and possibly other D5x/E5x MCUs, since the check was simply for pin PC19 existing at all.

Change the check to use the macro PIN_PC19F_SERCOM4_PAD0 which is only defined if special function F of pin PC19 is SERCOM4 PAD0.

Reorganize the code a little bit so that brace-matching in editors is not confused by the conditionalized code, including an unrelated change for APA102_SCK's condition. (diff may look better viewed locally with `git show --patch -b`)

Revert the change to the Makefile that incorrectly attempted to silence the diagnostic.