### PR TITLE
[Makerdiary nRF52840 M.2 Devkit] Add SDA & SDL, RX & TX to pins.c

### DIFF
--- a/ports/nrf/boards/makerdiary_nrf52840_m2_devkit/pins.c
+++ b/ports/nrf/boards/makerdiary_nrf52840_m2_devkit/pins.c
@@ -59,7 +59,13 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_P1_9), MP_ROM_PTR(&pin_P1_09) },
 
   { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_P0_15) },
+  { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_P0_15) },
+  { MP_ROM_QSTR(MP_QSTR_RXD), MP_ROM_PTR(&pin_P0_15) },
+  
   { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_P0_16) },
+  { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_P0_16) },
+  { MP_ROM_QSTR(MP_QSTR_TXD), MP_ROM_PTR(&pin_P0_16) },
+  
   { MP_ROM_QSTR(MP_QSTR_D2), MP_ROM_PTR(&pin_P0_19) },
   { MP_ROM_QSTR(MP_QSTR_D3), MP_ROM_PTR(&pin_P0_20) },
   { MP_ROM_QSTR(MP_QSTR_D4), MP_ROM_PTR(&pin_P0_21) },
@@ -72,8 +78,12 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_D11), MP_ROM_PTR(&pin_P1_03) },
   { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_P1_04) },
   { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_P1_07) },
+  
   { MP_ROM_QSTR(MP_QSTR_D14), MP_ROM_PTR(&pin_P1_05) },
+  { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_P1_05) },
+  
   { MP_ROM_QSTR(MP_QSTR_D15), MP_ROM_PTR(&pin_P1_06) },
+  { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_P1_06) },
 
   { MP_ROM_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_P0_02) },
   { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_P0_03) },
@@ -81,6 +91,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_P0_27) },
   { MP_ROM_QSTR(MP_QSTR_A4), MP_ROM_PTR(&pin_P0_26) },
   { MP_ROM_QSTR(MP_QSTR_A5), MP_ROM_PTR(&pin_P0_04) },
+ 
 
   { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_P0_11) },
   { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_P0_12) },
@@ -90,9 +101,6 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_LCD_CS), MP_ROM_PTR(&pin_P0_06) },
   { MP_ROM_QSTR(MP_QSTR_LCD_BL), MP_ROM_PTR(&pin_P0_20) },
   { MP_ROM_QSTR(MP_QSTR_LCD_RST), MP_ROM_PTR(&pin_P1_09) },
-
-  { MP_ROM_QSTR(MP_QSTR_TXD), MP_ROM_PTR(&pin_P0_16) },
-  { MP_ROM_QSTR(MP_QSTR_RXD), MP_ROM_PTR(&pin_P0_15) },
 
   { MP_ROM_QSTR(MP_QSTR_LED_R), MP_ROM_PTR(&pin_P0_30) },
   { MP_ROM_QSTR(MP_QSTR_LED_G), MP_ROM_PTR(&pin_P0_29) },

--- a/ports/nrf/boards/makerdiary_nrf52840_m2_devkit/pins.c
+++ b/ports/nrf/boards/makerdiary_nrf52840_m2_devkit/pins.c
@@ -103,7 +103,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_LED_G), MP_ROM_PTR(&pin_P0_29) },
   { MP_ROM_QSTR(MP_QSTR_LED_B), MP_ROM_PTR(&pin_P0_31) },
 
-  { MP_ROM_QSTR(MP_QSTR_USR_BTN), MP_ROM_PTR(&pin_P0_19) },
+  { MP_ROM_QSTR(MP_QSTR_USR), MP_ROM_PTR(&pin_P0_19) },
+  { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_P0_19) },
 
   { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
   { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },

--- a/ports/nrf/boards/makerdiary_nrf52840_m2_devkit/pins.c
+++ b/ports/nrf/boards/makerdiary_nrf52840_m2_devkit/pins.c
@@ -103,8 +103,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_LED_G), MP_ROM_PTR(&pin_P0_29) },
   { MP_ROM_QSTR(MP_QSTR_LED_B), MP_ROM_PTR(&pin_P0_31) },
 
-  { MP_ROM_QSTR(MP_QSTR_USR), MP_ROM_PTR(&pin_P0_19) },
-  { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_P0_19) },
+  { MP_ROM_QSTR(MP_QSTR_BUTTON_USR), MP_ROM_PTR(&pin_P0_19) },
 
   { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
   { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },

--- a/ports/nrf/boards/makerdiary_nrf52840_m2_devkit/pins.c
+++ b/ports/nrf/boards/makerdiary_nrf52840_m2_devkit/pins.c
@@ -60,12 +60,10 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
   { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_P0_15) },
   { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_P0_15) },
-  { MP_ROM_QSTR(MP_QSTR_RXD), MP_ROM_PTR(&pin_P0_15) },
-  
+
   { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_P0_16) },
   { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_P0_16) },
-  { MP_ROM_QSTR(MP_QSTR_TXD), MP_ROM_PTR(&pin_P0_16) },
-  
+
   { MP_ROM_QSTR(MP_QSTR_D2), MP_ROM_PTR(&pin_P0_19) },
   { MP_ROM_QSTR(MP_QSTR_D3), MP_ROM_PTR(&pin_P0_20) },
   { MP_ROM_QSTR(MP_QSTR_D4), MP_ROM_PTR(&pin_P0_21) },
@@ -78,10 +76,10 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_D11), MP_ROM_PTR(&pin_P1_03) },
   { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_P1_04) },
   { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_P1_07) },
-  
+
   { MP_ROM_QSTR(MP_QSTR_D14), MP_ROM_PTR(&pin_P1_05) },
   { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_P1_05) },
-  
+
   { MP_ROM_QSTR(MP_QSTR_D15), MP_ROM_PTR(&pin_P1_06) },
   { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_P1_06) },
 
@@ -91,7 +89,6 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_P0_27) },
   { MP_ROM_QSTR(MP_QSTR_A4), MP_ROM_PTR(&pin_P0_26) },
   { MP_ROM_QSTR(MP_QSTR_A5), MP_ROM_PTR(&pin_P0_04) },
- 
 
   { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_P0_11) },
   { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_P0_12) },

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk/pins.c
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk/pins.c
@@ -55,7 +55,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_LED_GREEN), MP_ROM_PTR(&pin_P0_22) },
   { MP_ROM_QSTR(MP_QSTR_LED_BLUE), MP_ROM_PTR(&pin_P0_24) },
 
-  { MP_ROM_QSTR(MP_QSTR_USR_BTN), MP_ROM_PTR(&pin_P1_00) },
+  { MP_ROM_QSTR(MP_QSTR_BUTTON_USR), MP_ROM_PTR(&pin_P1_00) },
 };
 
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/pins.c
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk_usb_dongle/pins.c
@@ -9,9 +9,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_AREF), MP_ROM_PTR(&pin_P0_04) },  // User must connect manually.
   { MP_ROM_QSTR(MP_QSTR_VDIV), MP_ROM_PTR(&pin_P0_05) },  // User must connect manually.
 
-// Not defining the NFC names until CircuitPython supports NFC.
-//  { MP_ROM_QSTR(MP_QSTR_NFC1), MP_ROM_PTR(&pin_P0_09) },
-//  { MP_ROM_QSTR(MP_QSTR_NFC2), MP_ROM_PTR(&pin_P0_10) },
+  { MP_ROM_QSTR(MP_QSTR_NFC1), MP_ROM_PTR(&pin_P0_09) },
+  { MP_ROM_QSTR(MP_QSTR_NFC2), MP_ROM_PTR(&pin_P0_10) },
 
   { MP_ROM_QSTR(MP_QSTR_P2), MP_ROM_PTR(&pin_P0_02) },
   { MP_ROM_QSTR(MP_QSTR_P3), MP_ROM_PTR(&pin_P0_03) },

--- a/ports/nrf/boards/pitaya_go/pins.c
+++ b/ports/nrf/boards/pitaya_go/pins.c
@@ -58,7 +58,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
   { MP_ROM_QSTR(MP_QSTR_LED_GREEN), MP_ROM_PTR(&pin_P0_11) },
   { MP_ROM_QSTR(MP_QSTR_LED_BLUE), MP_ROM_PTR(&pin_P0_12) },
 
-  { MP_ROM_QSTR(MP_QSTR_USR_BTN), MP_ROM_PTR(&pin_P1_00) },
+  { MP_ROM_QSTR(MP_QSTR_BUTTON_USER), MP_ROM_PTR(&pin_P1_00) },
 };
 
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
Despite the [silk on the dock board](https://wiki.makerdiary.com/nrf52840-m2-devkit/resources/nrf52840_m2_devkit_hw_diagram_v1_0.pdf), the SDA/SCL pins weren't defined. Though, they were already defined in `mpconfigboard.h`.

Same for RX/TX. It looks like it declared `TXD` and `RXD`, so I didn't want to remove those, but I think it makes sense to have the "standard" pin names, but I moved ithem to illustrate they were all referencing the same pins.

I mimicked the whitespace I saw in the metro_nrf52840_express port.