### PR TITLE
STM32: Add never_reset reservation to RGBMatrix init

### DIFF
--- a/ports/stm/common-hal/rgbmatrix/RGBMatrix.c
+++ b/ports/stm/common-hal/rgbmatrix/RGBMatrix.c
@@ -36,6 +36,7 @@ extern void _PM_IRQ_HANDLER(void);
 void *common_hal_rgbmatrix_timer_allocate() {
     TIM_TypeDef * timer = stm_peripherals_find_timer();
     stm_peripherals_timer_reserve(timer);
+    stm_peripherals_timer_never_reset(timer);
     return timer;
 }
 

--- a/ports/stm/peripherals/timers.c
+++ b/ports/stm/peripherals/timers.c
@@ -195,9 +195,7 @@ TIM_TypeDef * stm_peripherals_find_timer(void) {
         // If no results are found, no unclaimed pins with this timer are in this package,
         // and it is safe to pick
         if (timer_in_package == false && mcu_tim_banks[i] != NULL) {
-            // DEBUG: print the timer
             return mcu_tim_banks[i];
-            mp_printf(&mp_plat_print, "Timer: %d\n",i);
         }
     }
     //TODO: secondary search for timers outside the pins in the board profile
@@ -205,8 +203,6 @@ TIM_TypeDef * stm_peripherals_find_timer(void) {
     // Work backwards - higher index timers have fewer pin allocations
     for (size_t i = (MP_ARRAY_SIZE(mcu_tim_banks) - 1); i >= 0; i--) {
         if ((!stm_timer_reserved[i]) && (mcu_tim_banks[i] != NULL)) {
-            // DEBUG: print the timer
-            mp_printf(&mp_plat_print, "Timer: %d\n",i);
             return mcu_tim_banks[i];
         }
     }


### PR DESCRIPTION
When soft-reset on STM32, RGBMatrix currently gets stuck in `_PM_swapbuffer_maybe`, as the timer IRQ it relies on to exit an infinite loop is disabled by the reset process. This PR adds timers used by the RGBMatrix constructor to the never_reset array so this does not happen. Tested on STM32F405 Feather Express.

Also removes some timer debug messages that were accidentally left in from a previous PR.

Resolves #3440. Mentioned in #3051 but ultimately unrelated to the issue there, which seems to have just been a documentation mixup.