### PR TITLE
makeqstrdata: Work with older Python

### DIFF
--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -17,8 +17,9 @@ import collections
 import gettext
 import os.path
 
-sys.stdout.reconfigure(encoding='utf-8')
-sys.stderr.reconfigure(errors='backslashreplace')
+if hasattr(sys.stdout, 'reconfigure'):
+    sys.stdout.reconfigure(encoding='utf-8')
+    sys.stderr.reconfigure(errors='backslashreplace')
 
 py = os.path.dirname(sys.argv[0])
 top = os.path.dirname(py)


### PR DESCRIPTION
This construct (which I added without sufficient testing, apparently) is only supported in Python 3.7 and newer.  Make it
optional so that this script works on other Python versions.  This means that if you have a system with non-UTF-8 encoding you will need to use Python 3.7.

In particular, this affects a problem building circuitpython in github's ubuntu-18.04 virtual environment when Python 3.7 is not
explicitly installed.  cookie-cuttered libraries call for Python 3.6:
```
    - name: Set up Python 3.6
      uses: actions/setup-python@v1
      with:
        python-version: 3.6
```
Since CircuitPython's own build calls for 3.8, this problem was not detected.

This problem was also encountered by discord user mdroberts1243.

The failure I encountered was here:
https://github.com/jepler/Jepler_CircuitPython_udecimal/runs/1138045020?check_suite_focus=true
.. while my step of "clone and build circuitpython unix port" is unusual, I think the same problem would have affected "build assets" if that step had been reached.