### PR TITLE
ESP32S2 - Fix SPI's SD card issue, add pin protections

### DIFF
--- a/ports/esp32s2/common-hal/busio/SPI.c
+++ b/ports/esp32s2/common-hal/busio/SPI.c
@@ -115,6 +115,16 @@ static void spi_bus_intr_disable(void *self)
 void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         const mcu_pin_obj_t * clock, const mcu_pin_obj_t * mosi,
         const mcu_pin_obj_t * miso) {
+
+    //SCK is not optional. MOSI and MISO are
+    if (!clock) {
+        mp_raise_ValueError(translate("Must provide SCK pin"));
+    }
+
+    if (!miso && !mosi) {
+        mp_raise_ValueError(translate("Must provide MISO or MOSI pin"));
+    }
+
     spi_bus_config_t bus_config;
     bus_config.mosi_io_num = mosi != NULL ? mosi->number : -1;
     bus_config.miso_io_num = miso != NULL ? miso->number : -1;
@@ -212,8 +222,12 @@ void common_hal_busio_spi_never_reset(busio_spi_obj_t *self) {
     spi_never_reset[self->host_id] = true;
 
     common_hal_never_reset_pin(self->clock_pin);
-    common_hal_never_reset_pin(self->MOSI_pin);
-    common_hal_never_reset_pin(self->MISO_pin);
+    if (self->MOSI_pin != NULL) {
+        common_hal_never_reset_pin(self->MOSI_pin);
+    }
+    if (self->MISO_pin != NULL) {
+        common_hal_never_reset_pin(self->MISO_pin);
+    }
 }
 
 bool common_hal_busio_spi_deinited(busio_spi_obj_t *self) {
@@ -236,9 +250,15 @@ void common_hal_busio_spi_deinit(busio_spi_obj_t *self) {
     spi_bus_free(self->host_id);
 
     common_hal_reset_pin(self->clock_pin);
-    common_hal_reset_pin(self->MOSI_pin);
-    common_hal_reset_pin(self->MISO_pin);
+    if (self->MOSI_pin != NULL) {
+        common_hal_reset_pin(self->MOSI_pin);
+    }
+    if (self->MISO_pin != NULL) {
+        common_hal_reset_pin(self->MISO_pin);
+    }
     self->clock_pin = NULL;
+    self->MISO_pin = NULL;
+    self->MOSI_pin = NULL;
 }
 
 bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
@@ -293,17 +313,36 @@ void common_hal_busio_spi_unlock(busio_spi_obj_t *self) {
 
 bool common_hal_busio_spi_write(busio_spi_obj_t *self,
         const uint8_t *data, size_t len) {
+    if (self->MOSI_pin == NULL) {
+        mp_raise_ValueError(translate("No MOSI Pin"));
+    }
     return common_hal_busio_spi_transfer(self, data, NULL, len);
 }
 
 bool common_hal_busio_spi_read(busio_spi_obj_t *self,
         uint8_t *data, size_t len, uint8_t write_value) {
-    return common_hal_busio_spi_transfer(self, NULL, data, len);
+
+    if (self->MISO_pin == NULL) {
+        mp_raise_ValueError(translate("No MISO Pin"));
+    }
+    if (self->MOSI_pin == NULL) {
+        return common_hal_busio_spi_transfer(self, NULL, data, len);
+    } else {
+        memset(data, write_value, len);
+        return common_hal_busio_spi_transfer(self, data, data, len);
+    }
 }
 
 bool common_hal_busio_spi_transfer(busio_spi_obj_t *self, const uint8_t *data_out, uint8_t *data_in, size_t len) {
     if (len == 0) {
         return true;
+    }
+    // Other than the read special case, stop transfers that don't have a pin/array match
+    if (!self->MOSI_pin && (data_out != data_in)) {
+        mp_raise_ValueError(translate("No MOSI Pin"));
+    }
+    if (!self->MISO_pin && data_in) {
+        mp_raise_ValueError(translate("No MISO Pin"));
     }
 
     spi_hal_context_t* hal = &self->hal_context;


### PR DESCRIPTION
This PR implements the same fix for ESP3-S2 as was previously done for STM32 (PR: #3431, issue: #3176). Details are more or less the same as the previous fix, and while I did not test precise timings in this case we can probably assume the same small loss in transmission speed at higher SPI baudrates due to the `memset()` involved. Tested on Saola 1 Wrover compared to a control case where SD card was not working. [Test sketch](https://gist.github.com/hierophect/ef38920b27a9d0cf4770138525f7084c).

Also adds in some precautionary exceptions for cases where either MOSI and MISO are unset, which would cause IDF errors and null reference exceptions during reboots.

Resolves #3396, part one of addressing #3447