### PR TITLE
makeqstrdefs: don't make _and_, _or_ poisoned substrings for QSTRs

### DIFF
--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -57,6 +57,10 @@ name2codepoint['caret'] = ord('^')
 name2codepoint['pipe'] = ord('|')
 name2codepoint['tilde'] = ord('~')
 
+# These are just vexing!
+del name2codepoint['and']
+del name2codepoint['or']
+
 def write_out(fname, output):
     if output:
         for m, r in [("/", "__"), ("\\", "__"), (":", "@"), ("..", "@@")]:


### PR DESCRIPTION
New contributor @mdroberts1243 encountered an interesting problem in which the argument they had named "column_underscore_and_page_addressing" simply couldn't be used; I discovered that internally this had been transformed into "column_underscore∧page_addressing", because QSTR makes _ENTITY_ stand for the same thing as &ENTITY; does in HTML.
    
This might be nice for some things, but we don't want it here!  I was unable to find a sensible way to "escape" and prevent this entity coding, so instead I ripped out support for the _and_ and _or_ escapes. 
