### PR TITLE
Add some NORETURN attributes

### DIFF
--- a/ports/atmel-samd/reset.c
+++ b/ports/atmel-samd/reset.c
@@ -29,6 +29,8 @@
 #include "reset.h"
 #include "supervisor/filesystem.h"
 
+void NVIC_SystemReset(void) NORETURN;
+
 void reset(void) {
     filesystem_flush();
     NVIC_SystemReset();

--- a/ports/atmel-samd/reset.h
+++ b/ports/atmel-samd/reset.h
@@ -29,14 +29,16 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "py/mpconfig.h"
+
 // Copied from inc/uf2.h in https://github.com/Microsoft/uf2-samd21
 #define DBL_TAP_MAGIC 0xf01669ef // Randomly selected, adjusted to have first and last bit set
 #define DBL_TAP_MAGIC_QUICK_BOOT 0xf02669ef
 
 extern uint32_t _bootloader_dbl_tap;
 
-void reset_to_bootloader(void);
-void reset(void);
+void reset_to_bootloader(void) NORETURN;
+void reset(void) NORETURN;
 bool bootloader_available(void);
 
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_RESET_H

--- a/ports/cxd56/supervisor/port.c
+++ b/ports/cxd56/supervisor/port.c
@@ -71,6 +71,8 @@ safe_mode_t port_init(void) {
 
 void reset_cpu(void) {
     boardctl(BOARDIOC_RESET, 0);
+    for (;;) {
+    }
 }
 
 void reset_port(void) {
@@ -91,6 +93,9 @@ void reset_port(void) {
 }
 
 void reset_to_bootloader(void) {
+    boardctl(BOARDIOC_RESET, 0);
+    for (;;) {
+    }
 }
 
 supervisor_allocation* port_fixed_stack(void) {

--- a/ports/esp32s2/supervisor/port.c
+++ b/ports/esp32s2/supervisor/port.c
@@ -56,6 +56,8 @@ uint32_t heap_size;
 
 STATIC esp_timer_handle_t _tick_timer;
 
+extern void esp_restart(void) NORETURN;
+
 void tick_timer_cb(void* arg) {
     supervisor_tick();
 }
@@ -118,6 +120,7 @@ void reset_port(void) {
 }
 
 void reset_to_bootloader(void) {
+    esp_restart();
 }
 
 void reset_cpu(void) {

--- a/ports/esp32s2/supervisor/port.c
+++ b/ports/esp32s2/supervisor/port.c
@@ -121,6 +121,7 @@ void reset_to_bootloader(void) {
 }
 
 void reset_cpu(void) {
+    esp_restart();
 }
 
 uint32_t *port_heap_get_bottom(void) {

--- a/ports/litex/supervisor/port.c
+++ b/ports/litex/supervisor/port.c
@@ -85,9 +85,17 @@ void reset_port(void) {
 
 void reset_to_bootloader(void) {
     reboot_ctrl_write(0xac);
+    for(;;) {}
 }
 
 void reset_cpu(void) {
+    // "You can reset Fomu by writing a special value to the CSR_REBOOT_CTRL
+    // register at 0xe0006000L. All writes to this register must start with
+    // 0xac, to ensure random values aren’t written. We can reboot Fomu by
+    // simply writing this value" --
+    //     https://workshop.fomu.im/en/latest/riscv.html
+    reboot_ctrl_write(0xac);
+    for(;;) {}
 }
 
 supervisor_allocation* port_fixed_stack(void) {

--- a/ports/mimxrt10xx/reset.h
+++ b/ports/mimxrt10xx/reset.h
@@ -34,8 +34,8 @@
 #define DBL_TAP_MAGIC 0xf01669ef // Randomly selected, adjusted to have first and last bit set
 #define DBL_TAP_MAGIC_QUICK_BOOT 0xf02669ef
 
-void reset_to_bootloader(void);
-void reset(void);
+void reset_to_bootloader(void) NORETURN;
+void reset(void) NORETURN;
 bool bootloader_available(void);
 
 #endif  // MICROPY_INCLUDED_MIMXRT10XX_RESET_H

--- a/ports/mimxrt10xx/reset.h
+++ b/ports/mimxrt10xx/reset.h
@@ -30,6 +30,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "py/mpconfig.h"
+
 // Copied from inc/uf2.h in https://github.com/Microsoft/uf2-samd21
 #define DBL_TAP_MAGIC 0xf01669ef // Randomly selected, adjusted to have first and last bit set
 #define DBL_TAP_MAGIC_QUICK_BOOT 0xf02669ef

--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -234,6 +234,8 @@ void reset_cpu(void) {
     uint32_t ticks = nrfx_rtc_counter_get(&rtc_instance);
     overflow_tracker.overflowed_ticks += ticks / 32;
     NVIC_SystemReset();
+    for (;;) {
+    }
 }
 
 // The uninitialized data section is placed directly after BSS, under the theory

--- a/ports/stm/supervisor/port.c
+++ b/ports/stm/supervisor/port.c
@@ -56,6 +56,8 @@
 
 #include STM32_HAL_H
 
+void NVIC_SystemReset(void) NORETURN;
+
 #if (CPY_STM32H7) || (CPY_STM32F7)
 
 // Device memories must be accessed in order.
@@ -247,7 +249,7 @@ void reset_port(void) {
 }
 
 void reset_to_bootloader(void) {
-
+    NVIC_SystemReset();
 }
 
 void reset_cpu(void) {

--- a/supervisor/port.h
+++ b/supervisor/port.h
@@ -44,7 +44,7 @@ extern uint32_t _ebss;
 safe_mode_t port_init(void);
 
 // Reset the microcontroller completely.
-void reset_cpu(void);
+void reset_cpu(void) NORETURN;
 
 // Reset the microcontroller state.
 void reset_port(void);
@@ -53,7 +53,7 @@ void reset_port(void);
 void reset_board(void);
 
 // Reset to the bootloader
-void reset_to_bootloader(void);
+void reset_to_bootloader(void) NORETURN;
 
 // Get stack limit address
 uint32_t *port_stack_get_limit(void);

--- a/supervisor/shared/safe_mode.h
+++ b/supervisor/shared/safe_mode.h
@@ -27,6 +27,8 @@
 #ifndef MICROPY_INCLUDED_SUPERVISOR_SAFE_MODE_H
 #define MICROPY_INCLUDED_SUPERVISOR_SAFE_MODE_H
 
+#include "py/mpconfig.h"
+
 typedef enum {
   NO_SAFE_MODE = 0,
   BROWNOUT,
@@ -48,7 +50,7 @@ typedef enum {
 safe_mode_t wait_for_safe_mode_reset(void);
 
 void safe_mode_on_next_reset(safe_mode_t reason);
-void reset_into_safe_mode(safe_mode_t reason);
+void reset_into_safe_mode(safe_mode_t reason) NORETURN;
 
 void print_safe_mode_message(safe_mode_t reason);
 

--- a/supervisor/stub/safe_mode.c
+++ b/supervisor/stub/safe_mode.c
@@ -26,14 +26,15 @@
 
 #include "supervisor/shared/safe_mode.h"
 
+#include <stdlib.h>
+
 safe_mode_t wait_for_safe_mode_reset(void) {
     return NO_SAFE_MODE;
 }
 
 void reset_into_safe_mode(safe_mode_t reason) {
     (void) reason;
-    for (;;) {
-    }
+    abort();
 }
 
 void print_safe_mode_message(safe_mode_t reason) {


### PR DESCRIPTION
I have (or will have, in stm32 canbus) a function where it should be impossible to reach the end, so I put in a safe-mode reset at the bottom:
```
int find_unused_slot(void) {
    // precondition: you already verified that a slot was available
    assert(available_slot());
    for (int i=0; i<NUM_SLOTS; i++) {
        if (slot_free(i)) {
            return i;
        }
    }
    safe_mode_reset(MICROPY_FATAL_ERROR);
}
```
However, the compiler still gave a diagnostic, because safe_mode_reset was not declared NORETURN.

So I started by teaching the compiler that reset_into_safe_mode never returned.  This leads at least one level deeper due to reset_cpu needing to be a NORETURN function.  Each port is a little different in this area.  I also marked reset_to_bootloader as NORETURN.
Additional notes:

 * stm32's reset_to_bootloader was not implemented, but now does a bare reset.  Most stm32s are not fitted with uf2 bootloaders anyway.
 * ditto cxd56
 * esp32s2 did not implement reset_cpu at all.  I used esp_restart().  (not tested)
 * litex did not implement reset_cpu at all.  I used reboot_ctrl_write.  But notably this is what reset_to_bootloader already did, so one or the other must be incorrect (not tested).  reboot_ctrl_write cannot be declared NORETURN, as it returns unless the special value 0xac is written), so a new unreachable forever-loop is added.
 * cxd56's reset is via a boardctl() call which can't generically be declared NORETURN, so a new unreacahble "for(;;)" forever-loop is added.
 * In several places, NVIC_SystemReset is redeclared with NORETURN applied.  This is accepted just fine by gcc.  I chose this as preferable to editing the multiple copies of CMSIS headers where it is normally declared.
 * the stub safe_mode reset simply aborts.  This is used in mpy-cross.