### PR TITLE
Turn Default power on Wio Terminal's 40 Pin

### DIFF
--- a/ports/atmel-samd/boards/seeeduino_wio_terminal/board.c
+++ b/ports/atmel-samd/boards/seeeduino_wio_terminal/board.c
@@ -31,8 +31,12 @@
 #include "shared-bindings/displayio/FourWire.h"
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
+#include "shared-bindings/digitalio/DigitalInOut.h"
 
 displayio_fourwire_obj_t board_display_obj;
+digitalio_digitalinout_obj_t CTR_5V;
+digitalio_digitalinout_obj_t CTR_3V3;
+digitalio_digitalinout_obj_t USB_HOST_ENABLE;
 
 uint8_t display_init_sequence[] = {
     0x01, 0x80, 0x80, // Software reset then delay 0x80 (128ms)
@@ -106,6 +110,25 @@ void board_init(void) {
         true, // auto_refresh
         60, // native_frames_per_second
         true); // backlight_on_high
+
+        // Enabling the Power of the 40-pin at the back
+        CTR_5V.base.type = &digitalio_digitalinout_type;
+        CTR_3V3.base.type = &digitalio_digitalinout_type;
+        USB_HOST_ENABLE.base.type = &digitalio_digitalinout_type;
+
+        common_hal_digitalio_digitalinout_construct(&CTR_5V, PIN_CTR_5V);
+        common_hal_digitalio_digitalinout_construct(&CTR_3V3, PIN_CTR_3V3);
+        common_hal_digitalio_digitalinout_construct(&USB_HOST_ENABLE, PIN_USB_HOST_ENABLE);
+
+        common_hal_digitalio_digitalinout_set_value(&CTR_5V, true);
+        common_hal_digitalio_digitalinout_set_value(&CTR_3V3, false);
+        common_hal_digitalio_digitalinout_set_value(&USB_HOST_ENABLE, false);
+
+        // Never reset
+        common_hal_digitalio_digitalinout_never_reset(&CTR_5V);
+        common_hal_digitalio_digitalinout_never_reset(&CTR_3V3);
+        common_hal_digitalio_digitalinout_never_reset(&USB_HOST_ENABLE);
+
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/atmel-samd/boards/seeeduino_wio_terminal/mpconfigboard.h
+++ b/ports/atmel-samd/boards/seeeduino_wio_terminal/mpconfigboard.h
@@ -27,6 +27,10 @@
 #define DEFAULT_UART_BUS_RX (&pin_PB27)
 #define DEFAULT_UART_BUS_TX (&pin_PB26)
 
+#define PIN_CTR_5V (&pin_PC14)
+#define PIN_CTR_3V3 (&pin_PC15)
+#define PIN_USB_HOST_ENABLE (&pin_PA27)
+
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1


### PR DESCRIPTION
Closed my previous one and opened a new PR for only files i changed.

At default, need to pull up and down few pins for enabling the power to turn on for 40-pin header.

For ArduinoCore, this is done : https://github.com/Seeed-Studio/ArduinoCore-samd/blob/ef8f3edde07a701374b7c683510e33d42f6a9627/cores/arduino/wiring.c#L218