### PR TITLE
Fix inconsistent supervisor heap

### DIFF
--- a/supervisor/shared/memory.c
+++ b/supervisor/shared/memory.c
@@ -125,7 +125,7 @@ supervisor_allocation* allocate_memory(uint32_t length, bool high) {
     supervisor_allocation* alloc;
     for (; index < CIRCUITPY_SUPERVISOR_ALLOC_COUNT; index += direction) {
         alloc = &allocations[index];
-        if (alloc->length == FREE) {
+        if (alloc->length == FREE && (high_address - low_address) * 4 >= (int32_t) length) {
             break;
         }
         // If a hole matches in length exactly, we can reuse it.
@@ -134,7 +134,7 @@ supervisor_allocation* allocate_memory(uint32_t length, bool high) {
             return alloc;
         }
     }
-    if (index >= CIRCUITPY_SUPERVISOR_ALLOC_COUNT || (high_address - low_address) * 4 < (int32_t) length) {
+    if (index >= CIRCUITPY_SUPERVISOR_ALLOC_COUNT) {
         return NULL;
     }
     if (high) {

--- a/supervisor/shared/memory.c
+++ b/supervisor/shared/memory.c
@@ -37,6 +37,10 @@
 // impossible to support zero-length allocations).
 #define FREE 0
 
+// The lowest two bits of a valid length are always zero, so we can use them to mark an allocation
+// as freed by the client but not yet reclaimed into the FREE middle.
+#define HOLE 1
+
 static supervisor_allocation allocations[CIRCUITPY_SUPERVISOR_ALLOC_COUNT];
 // We use uint32_t* to ensure word (4 byte) alignment.
 uint32_t* low_address;
@@ -67,9 +71,10 @@ void free_memory(supervisor_allocation* allocation) {
         high_address += allocation->length / 4;
         allocation->length = FREE;
         for (index++; index < CIRCUITPY_SUPERVISOR_ALLOC_COUNT; index++) {
-            if (allocations[index].ptr != NULL) {
+            if (!(allocations[index].length & HOLE)) {
                 break;
             }
+            // Division automatically shifts out the HOLE bit.
             high_address += allocations[index].length / 4;
             allocations[index].length = FREE;
         }
@@ -77,7 +82,7 @@ void free_memory(supervisor_allocation* allocation) {
         low_address = allocation->ptr;
         allocation->length = FREE;
         for (index--; index >= 0; index--) {
-            if (allocations[index].ptr != NULL) {
+            if (!(allocations[index].length & HOLE)) {
                 break;
             }
             low_address -= allocations[index].length / 4;
@@ -85,9 +90,10 @@ void free_memory(supervisor_allocation* allocation) {
         }
     } else {
         // Freed memory isn't in the middle so skip updating bounds. The memory will be added to the
-        // middle when the memory to the inside is freed.
+        // middle when the memory to the inside is freed. We still need its length, but setting
+        // only the lowest bit is nondestructive.
+        allocation->length |= HOLE;
     }
-    allocation->ptr = NULL;
 }
 
 supervisor_allocation* allocation_from_ptr(void *ptr) {
@@ -107,7 +113,7 @@ supervisor_allocation* allocate_remaining_memory(void) {
 }
 
 supervisor_allocation* allocate_memory(uint32_t length, bool high) {
-    if (length == 0 || (high_address - low_address) * 4 < (int32_t) length || length % 4 != 0) {
+    if (length == 0 || length % 4 != 0) {
         return NULL;
     }
     uint8_t index = 0;
@@ -116,15 +122,21 @@ supervisor_allocation* allocate_memory(uint32_t length, bool high) {
         index = CIRCUITPY_SUPERVISOR_ALLOC_COUNT - 1;
         direction = -1;
     }
+    supervisor_allocation* alloc;
     for (; index < CIRCUITPY_SUPERVISOR_ALLOC_COUNT; index += direction) {
-        if (allocations[index].length == FREE) {
+        alloc = &allocations[index];
+        if (alloc->length == FREE) {
             break;
         }
+        // If a hole matches in length exactly, we can reuse it.
+        if (alloc->length == (length | HOLE)) {
+            alloc->length = length;
+            return alloc;
+        }
     }
-    if (index >= CIRCUITPY_SUPERVISOR_ALLOC_COUNT) {
+    if (index >= CIRCUITPY_SUPERVISOR_ALLOC_COUNT || (high_address - low_address) * 4 < (int32_t) length) {
         return NULL;
     }
-    supervisor_allocation* alloc = &allocations[index];
     if (high) {
         high_address -= length / 4;
         alloc->ptr = high_address;


### PR DESCRIPTION
There is a logic error in the supervisor memory allocation functions that causes the supervisor heap to get into an inconsistent state, eventually resulting in crashes, when allocations are freed in a different order from the reverse of how they were allocated (leaving holes). Apparently nobody has been doing that so far, but now my recent experiments on #1084 at one point did.

`free_memory()` relies on having allocations in order, but `allocate_memory()` does not guarantee that: It reuses the first allocation with a NULL `ptr` without ensuring that it is between `low_address` and `high_address`. When it belongs to a hole in the allocated memory, such an allocation is not really free for reuse, because `free_memory()` still needs its `length`.

Here’s a sketch that hopefully explains better than words what goes wrong in a specific sequence of calls: `c = allocate(8)` reuses an out-of-order slot, then `free(b)` moves `low_address` outside of the heap, and the next allocation after that will probably crash when the caller tries to use it.

![image](https://user-images.githubusercontent.com/234094/94485981-08afb600-01df-11eb-803e-276325733886.png)

The simplest way of fixing that I found is to explicitly mark allocations available for reuse with a special (invalid) value in the `length` field. Only allocations that lie between `low_address` and `high_address` are marked that way.

There is an open question on what value to use for that special marker. Using zero saves a couple of bytes of code for initialization (and possibly the comparisons use fewer instructions too), 28 bytes shorter code on a SAMD51 in my tests. The drawback is that it makes it impossible to support zero-length allocations (`allocate_memory()` needs to check for that and return NULL). Such allocations are mostly useless, because while you get a valid pointer, you can’t write to it, but clients that don’t try to do that might have gotten away with it. I have identified one possible zero-length caller, `rgbmatrix_rgbmatrix_make_new()`, but there may be other sloppily programmed ones in the future. Do we want to be safe against sloppy code, or do we want it to crash?