### PR TITLE
ESP32S2: Enter station mode before connecting

### DIFF
--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -106,6 +106,8 @@ void common_hal_wifi_radio_stop_scanning_networks(wifi_radio_obj_t *self) {
 
 wifi_radio_error_t common_hal_wifi_radio_connect(wifi_radio_obj_t *self, uint8_t* ssid, size_t ssid_len, uint8_t* password, size_t password_len, uint8_t channel, mp_float_t timeout, uint8_t* bssid, size_t bssid_len) {
     // check enabled
+    start_station(self);
+
     wifi_config_t* config = &self->sta_config;
     memcpy(&config->sta.ssid, ssid, ssid_len);
     config->sta.ssid[ssid_len] = 0;


### PR DESCRIPTION
Closes #3419 

It looks like ```wifi.radio.connect()``` is missing a call to ```esp_wifi_set_mode()``` which is probably why scanning, and then connecting works, but connecting without a scan makes the board wait indefinitely.  

Rather than copy the same logic checks to change the mode only if it's different, I just added a call to ```start_station()``` and it seems to work as expected.  I suppose another fix could be to call ```esp_wifi_set_mode()``` in ```connect()```.