### PR TITLE
Makefile: Correct and expand translation excluded directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ TRANSLATE_SOURCES = extmod lib main.c ports/atmel-samd ports/cxd56 ports/esp32s2
 # Each must be preceded by "-path"; if any wildcards, enclose in quotes.
 # Separate by "-o" (Find's "or" operand)
 TRANSLATE_SOURCES_EXC = -path "ports/*/build-*" \
+	-o -path "ports/*/build" \
 	-o -path ports/esp32s2/esp-idf \
 	-o -path ports/cxd56/spresense-exported-sdk \
 	-o -path ports/stm/st_driver \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,17 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(BASEOPTS)
 I18NSPHINXOPTS  = $(BASEOPTS)
 
 TRANSLATE_SOURCES = extmod lib main.c ports/atmel-samd ports/cxd56 ports/esp32s2 ports/mimxrt10xx ports/nrf ports/stm py shared-bindings shared-module supervisor
-TRANSLATE_SOURCES_EXC = -path ports/*/build-* -o -path ports/esp32s2/esp-idf
+# Paths to exclude from TRANSLATE_SOURCES
+# Each must be preceded by "-path"; if any wildcards, enclose in quotes.
+# Separate by "-o" (Find's "or" operand)
+TRANSLATE_SOURCES_EXC = -path "ports/*/build-*" \
+	-o -path ports/esp32s2/esp-idf \
+	-o -path ports/cxd56/spresense-exported-sdk \
+	-o -path ports/stm/st_driver \
+	-o -path ports/atmel-samd/asf4 \
+	-o -path ports/mimxrt10xx/sdk \
+	-o -path lib/tinyusb \
+	-o -path lib/lwip \
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext stubs
 


### PR DESCRIPTION
As originally written, the TRANSLATE_SOURCES_EXC was incorrect.  If more than one build directory existed, "make translate"
(and make check-translate) would error.

I corrected the problem, commented it, and added a number of additional exclude directives.  This decreases the length of time it takes to "make translate", which is always nice.

I reviewed the PR and should have caught this, but did not.

cc @microdev
