### PR TITLE
ESP32S2: move to official IDF submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -144,12 +144,12 @@
 [submodule "frozen/Adafruit_CircuitPython_BLE_Apple_Notification_Center"]
 	path = frozen/Adafruit_CircuitPython_BLE_Apple_Notification_Center
 	url = https://github.com/adafruit/Adafruit_CircuitPython_BLE_Apple_Notification_Center
-[submodule "ports/esp32s2/esp-idf"]
-	path = ports/esp32s2/esp-idf
-	url = https://github.com/tannewt/esp-idf.git
 [submodule "frozen/Adafruit_CircuitPython_RFM9x"]
 	path = frozen/Adafruit_CircuitPython_RFM9x
 	url = https://github.com/adafruit/Adafruit_CircuitPython_RFM9x.git
 [submodule "frozen/Adafruit_CircuitPython_RFM69"]
 	path = frozen/Adafruit_CircuitPython_RFM69
 	url = https://github.com/adafruit/Adafruit_CircuitPython_RFM69.git
+[submodule "ports/esp32s2/esp-idf"]
+	path = ports/esp32s2/esp-idf
+	url = https://github.com/espressif/esp-idf.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -152,4 +152,4 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_RFM69.git
 [submodule "ports/esp32s2/esp-idf"]
 	path = ports/esp32s2/esp-idf
-	url = https://github.com/espressif/esp-idf.git
+	url = https://github.com/hierophect/esp-idf.git

--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -263,7 +263,7 @@ menuconfig: $(BUILD)/esp-idf/config
 $(HEADER_BUILD)/qstr.i.last: | $(BUILD)/esp-idf/config/sdkconfig.h
 
 # Order here matters
-ESP_IDF_COMPONENTS_LINK = freertos log hal esp_system esp32s2 bootloader_support pthread esp_timer vfs spi_flash app_update esp_common esp32s2 heap newlib driver xtensa soc esp_ringbuf esp_wifi esp_event wpa_supplicant mbedtls efuse nvs_flash esp_netif lwip esp_rom esp-tls
+ESP_IDF_COMPONENTS_LINK = freertos log esp_system esp32s2 bootloader_support pthread esp_timer vfs spi_flash app_update esp_common esp32s2 heap newlib driver xtensa soc esp_ringbuf esp_wifi esp_event wpa_supplicant mbedtls efuse nvs_flash esp_netif lwip esp_rom esp-tls
 
 ESP_IDF_COMPONENTS_INCLUDE = driver freertos log soc
 
@@ -275,11 +275,11 @@ ESP_IDF_WIFI_COMPONENTS_EXPANDED = $(foreach component, $(ESP_IDF_WIFI_COMPONENT
 MBEDTLS_COMPONENTS_LINK = crypto tls x509
 MBEDTLS_COMPONENTS_LINK_EXPANDED = $(foreach component, $(MBEDTLS_COMPONENTS_LINK), $(BUILD)/esp-idf/esp-idf/mbedtls/mbedtls/library/libmbed$(component).a)
 
-BINARY_BLOBS = esp-idf/components/xtensa/esp32s2/libxt_hal.a
+BINARY_BLOBS = esp-idf/components/xtensa/esp32s2/libhal.a
 BINARY_WIFI_BLOBS = libcoexist.a libcore.a libespnow.a libmesh.a libnet80211.a libpp.a librtc.a libsmartconfig.a libphy.a
 BINARY_BLOBS += $(addprefix esp-idf/components/esp_wifi/lib/esp32s2/, $(BINARY_WIFI_BLOBS))
 
-ESP_IDF_COMPONENTS_EXPANDED += $(BUILD)/esp-idf/esp-idf/soc/soc/esp32s2/libsoc_esp32s2.a esp-idf/components/xtensa/esp32s2/libxt_hal.a
+ESP_IDF_COMPONENTS_EXPANDED += $(BUILD)/esp-idf/esp-idf/soc/soc/esp32s2/libsoc_esp32s2.a esp-idf/components/xtensa/esp32s2/libhal.a
 ESP_AUTOGEN_LD = $(BUILD)/esp-idf/esp-idf/esp32s2/esp32s2_out.ld $(BUILD)/esp-idf/esp-idf/esp32s2/ld/esp32s2.project.ld
 
 FLASH_FLAGS = --flash_mode $(CIRCUITPY_ESP_FLASH_MODE) --flash_freq $(CIRCUITPY_ESP_FLASH_FREQ) --flash_size $(CIRCUITPY_ESP_FLASH_SIZE)

--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -76,9 +76,6 @@ INC += -I../../supervisor/shared/usb
 
 INC += -isystem esp-idf
 INC += -isystem esp-idf/components/driver/include
-INC += -isystem esp-idf/components/hal/esp32s2/include
-INC += -isystem esp-idf/components/hal/include
-
 INC += -isystem esp-idf/components/freertos/include/freertos
 INC += -isystem esp-idf/components/freertos/xtensa/include
 INC += -isystem esp-idf/components/esp32s2/include
@@ -98,6 +95,8 @@ INC += -isystem esp-idf/components/lwip/lwip/src/include
 INC += -isystem esp-idf/components/lwip/port/esp32/include
 INC += -isystem esp-idf/components/lwip/include/apps/sntp
 INC += -isystem esp-idf/components/hal/include
+INC += -isystem esp-idf/components/hal/esp32s2/include
+INC += -isystem esp-idf/components/log/include/
 INC += -isystem esp-idf/components/soc/include
 INC += -isystem esp-idf/components/soc/src/esp32s2/include
 INC += -isystem esp-idf/components/soc/soc/include

--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -73,30 +73,37 @@ INC += -I./peripherals
 INC += -I../../lib/mp-readline
 INC += -I../../lib/tinyusb/src
 INC += -I../../supervisor/shared/usb
-INC += -Iesp-idf/components/freertos/include/freertos
-INC += -Iesp-idf/components/freertos/xtensa/include
-INC += -Iesp-idf/components/esp32s2/include
-INC += -Iesp-idf/components/xtensa/esp32s2/include
-INC += -Iesp-idf/components/esp_common/include
-INC += -Iesp-idf/components/esp_event/include
-INC += -Iesp-idf/components/esp_netif/include
-INC += -Iesp-idf/components/esp_ringbuf/include
-INC += -Iesp-idf/components/esp_rom/include
-INC += -Iesp-idf/components/esp_wifi/include
-INC += -Iesp-idf/components/xtensa/include
-INC += -Iesp-idf/components/esp_timer/include
-INC += -Iesp-idf/components/mbedtls/mbedtls/include
-INC += -Iesp-idf/components/mbedtls/port/include/
-INC += -Iesp-idf/components/newlib/platform_include
-INC += -Iesp-idf/components/lwip/lwip/src/include
-INC += -Iesp-idf/components/lwip/port/esp32/include
-INC += -Iesp-idf/components/lwip/include/apps/sntp
-INC += -Iesp-idf/components/soc/include
-INC += -Iesp-idf/components/soc/src/esp32s2/include
-INC += -Iesp-idf/components/soc/soc/include
-INC += -Iesp-idf/components/soc/soc/esp32s2/include
-INC += -Iesp-idf/components/heap/include
-INC += -Iesp-idf/components/esp_system/include
+
+INC += -isystem esp-idf
+INC += -isystem esp-idf/components/driver/include
+INC += -isystem esp-idf/components/hal/esp32s2/include
+INC += -isystem esp-idf/components/hal/include
+
+INC += -isystem esp-idf/components/freertos/include/freertos
+INC += -isystem esp-idf/components/freertos/xtensa/include
+INC += -isystem esp-idf/components/esp32s2/include
+INC += -isystem esp-idf/components/xtensa/esp32s2/include
+INC += -isystem esp-idf/components/esp_common/include
+INC += -isystem esp-idf/components/esp_event/include
+INC += -isystem esp-idf/components/esp_netif/include
+INC += -isystem esp-idf/components/esp_ringbuf/include
+INC += -isystem esp-idf/components/esp_rom/include
+INC += -isystem esp-idf/components/esp_wifi/include
+INC += -isystem esp-idf/components/xtensa/include
+INC += -isystem esp-idf/components/esp_timer/include
+INC += -isystem esp-idf/components/mbedtls/mbedtls/include
+INC += -isystem esp-idf/components/mbedtls/port/include/
+INC += -isystem esp-idf/components/newlib/platform_include
+INC += -isystem esp-idf/components/lwip/lwip/src/include
+INC += -isystem esp-idf/components/lwip/port/esp32/include
+INC += -isystem esp-idf/components/lwip/include/apps/sntp
+INC += -isystem esp-idf/components/hal/include
+INC += -isystem esp-idf/components/soc/include
+INC += -isystem esp-idf/components/soc/src/esp32s2/include
+INC += -isystem esp-idf/components/soc/soc/include
+INC += -isystem esp-idf/components/soc/soc/esp32s2/include
+INC += -isystem esp-idf/components/heap/include
+INC += -isystem esp-idf/components/esp_system/include
 INC += -I$(BUILD)/esp-idf/config
 
 CFLAGS += -DHAVE_CONFIG_H \
@@ -256,7 +263,7 @@ menuconfig: $(BUILD)/esp-idf/config
 $(HEADER_BUILD)/qstr.i.last: | $(BUILD)/esp-idf/config/sdkconfig.h
 
 # Order here matters
-ESP_IDF_COMPONENTS_LINK = freertos log esp_system esp32s2 bootloader_support pthread esp_timer vfs spi_flash app_update esp_common esp32s2 heap newlib driver xtensa soc esp_ringbuf esp_wifi esp_event wpa_supplicant mbedtls efuse nvs_flash esp_netif lwip esp_rom esp-tls
+ESP_IDF_COMPONENTS_LINK = freertos log hal esp_system esp32s2 bootloader_support pthread esp_timer vfs spi_flash app_update esp_common esp32s2 heap newlib driver xtensa soc esp_ringbuf esp_wifi esp_event wpa_supplicant mbedtls efuse nvs_flash esp_netif lwip esp_rom esp-tls
 
 ESP_IDF_COMPONENTS_INCLUDE = driver freertos log soc
 
@@ -268,11 +275,11 @@ ESP_IDF_WIFI_COMPONENTS_EXPANDED = $(foreach component, $(ESP_IDF_WIFI_COMPONENT
 MBEDTLS_COMPONENTS_LINK = crypto tls x509
 MBEDTLS_COMPONENTS_LINK_EXPANDED = $(foreach component, $(MBEDTLS_COMPONENTS_LINK), $(BUILD)/esp-idf/esp-idf/mbedtls/mbedtls/library/libmbed$(component).a)
 
-BINARY_BLOBS = esp-idf/components/xtensa/esp32s2/libhal.a
+BINARY_BLOBS = esp-idf/components/xtensa/esp32s2/libxt_hal.a
 BINARY_WIFI_BLOBS = libcoexist.a libcore.a libespnow.a libmesh.a libnet80211.a libpp.a librtc.a libsmartconfig.a libphy.a
 BINARY_BLOBS += $(addprefix esp-idf/components/esp_wifi/lib/esp32s2/, $(BINARY_WIFI_BLOBS))
 
-ESP_IDF_COMPONENTS_EXPANDED += $(BUILD)/esp-idf/esp-idf/soc/soc/esp32s2/libsoc_esp32s2.a esp-idf/components/xtensa/esp32s2/libhal.a
+ESP_IDF_COMPONENTS_EXPANDED += $(BUILD)/esp-idf/esp-idf/soc/soc/esp32s2/libsoc_esp32s2.a esp-idf/components/xtensa/esp32s2/libxt_hal.a
 ESP_AUTOGEN_LD = $(BUILD)/esp-idf/esp-idf/esp32s2/esp32s2_out.ld $(BUILD)/esp-idf/esp-idf/esp32s2/ld/esp32s2.project.ld
 
 FLASH_FLAGS = --flash_mode $(CIRCUITPY_ESP_FLASH_MODE) --flash_freq $(CIRCUITPY_ESP_FLASH_FREQ) --flash_size $(CIRCUITPY_ESP_FLASH_SIZE)

--- a/ports/esp32s2/bindings/espidf/__init__.c
+++ b/ports/esp32s2/bindings/espidf/__init__.c
@@ -29,7 +29,7 @@
 
 #include "bindings/espidf/__init__.h"
 
-#include "esp-idf/components/heap/include/esp_heap_caps.h"
+#include "components/heap/include/esp_heap_caps.h"
 
 //| """Direct access to a few ESP-IDF details. This module *should not* include any functionality
 //|    that could be implemented by other frameworks. It should only include ESP-IDF specific

--- a/ports/esp32s2/common-hal/busio/I2C.c
+++ b/ports/esp32s2/common-hal/busio/I2C.c
@@ -28,7 +28,7 @@
 #include "py/mperrno.h"
 #include "py/runtime.h"
 
-#include "driver/i2c.h"
+#include "components/driver/include/driver/i2c.h"
 
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/Pin.h"

--- a/ports/esp32s2/common-hal/busio/I2C.h
+++ b/ports/esp32s2/common-hal/busio/I2C.h
@@ -29,7 +29,7 @@
 
 #include "common-hal/microcontroller/Pin.h"
 
-#include "components/hal/include/hal/i2c_types.h"
+#include "components/soc/include/hal/i2c_types.h"
 #include "FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "py/obj.h"

--- a/ports/esp32s2/common-hal/busio/I2C.h
+++ b/ports/esp32s2/common-hal/busio/I2C.h
@@ -29,7 +29,7 @@
 
 #include "common-hal/microcontroller/Pin.h"
 
-#include "esp-idf/components/soc/include/hal/i2c_types.h"
+#include "components/hal/include/hal/i2c_types.h"
 #include "FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "py/obj.h"

--- a/ports/esp32s2/common-hal/busio/SPI.c
+++ b/ports/esp32s2/common-hal/busio/SPI.c
@@ -266,7 +266,7 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
     self->bits = bits;
     self->target_frequency = baudrate;
     self->hal_context.timing_conf = &self->timing_conf;
-    esp_err_t result =  spi_hal_get_clock_conf(&self->hal_context,
+    esp_err_t result =  spi_hal_cal_clock_conf(&self->hal_context,
                                                self->target_frequency,
                                                128 /* duty_cycle */,
                                                self->connected_through_gpio,

--- a/ports/esp32s2/common-hal/busio/SPI.h
+++ b/ports/esp32s2/common-hal/busio/SPI.h
@@ -29,9 +29,9 @@
 
 #include "common-hal/microcontroller/Pin.h"
 
-#include "esp-idf/components/driver/include/driver/spi_common_internal.h"
-#include "esp-idf/components/soc/include/hal/spi_hal.h"
-#include "esp-idf/components/soc/include/hal/spi_types.h"
+#include "components/driver/include/driver/spi_common_internal.h"
+#include "components/hal/include/hal/spi_hal.h"
+#include "components/hal/include/hal/spi_types.h"
 #include "py/obj.h"
 
 typedef struct {

--- a/ports/esp32s2/common-hal/busio/SPI.h
+++ b/ports/esp32s2/common-hal/busio/SPI.h
@@ -30,8 +30,8 @@
 #include "common-hal/microcontroller/Pin.h"
 
 #include "components/driver/include/driver/spi_common_internal.h"
-#include "components/hal/include/hal/spi_hal.h"
-#include "components/hal/include/hal/spi_types.h"
+#include "components/soc/include/hal/spi_hal.h"
+#include "components/soc/include/hal/spi_types.h"
 #include "py/obj.h"
 
 typedef struct {

--- a/ports/esp32s2/common-hal/busio/UART.c
+++ b/ports/esp32s2/common-hal/busio/UART.c
@@ -27,7 +27,7 @@
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/busio/UART.h"
 
-#include "driver/uart.h"
+#include "components/driver/include/driver/uart.h"
 
 #include "mpconfigport.h"
 #include "lib/utils/interrupt_char.h"

--- a/ports/esp32s2/common-hal/busio/UART.h
+++ b/ports/esp32s2/common-hal/busio/UART.h
@@ -29,7 +29,7 @@
 
 #include "common-hal/microcontroller/Pin.h"
 
-#include "components/hal/include/hal/uart_types.h"
+#include "components/soc/include/hal/uart_types.h"
 #include "py/obj.h"
 
 typedef struct {

--- a/ports/esp32s2/common-hal/busio/UART.h
+++ b/ports/esp32s2/common-hal/busio/UART.h
@@ -29,7 +29,7 @@
 
 #include "common-hal/microcontroller/Pin.h"
 
-#include "esp-idf/components/soc/include/hal/uart_types.h"
+#include "components/hal/include/hal/uart_types.h"
 #include "py/obj.h"
 
 typedef struct {

--- a/ports/esp32s2/common-hal/digitalio/DigitalInOut.c
+++ b/ports/esp32s2/common-hal/digitalio/DigitalInOut.c
@@ -28,9 +28,9 @@
 #include "py/runtime.h"
 #include "supervisor/shared/translate.h"
 
-#include "driver/gpio.h"
+#include "components/driver/include/driver/gpio.h"
 
-#include "esp-idf/components/soc/include/hal/gpio_hal.h"
+#include "components/hal/include/hal/gpio_hal.h"
 
 void common_hal_digitalio_digitalinout_never_reset(
         digitalio_digitalinout_obj_t *self) {

--- a/ports/esp32s2/common-hal/digitalio/DigitalInOut.c
+++ b/ports/esp32s2/common-hal/digitalio/DigitalInOut.c
@@ -30,7 +30,7 @@
 
 #include "components/driver/include/driver/gpio.h"
 
-#include "components/hal/include/hal/gpio_hal.h"
+#include "components/soc/include/hal/gpio_hal.h"
 
 void common_hal_digitalio_digitalinout_never_reset(
         digitalio_digitalinout_obj_t *self) {

--- a/ports/esp32s2/common-hal/microcontroller/Pin.c
+++ b/ports/esp32s2/common-hal/microcontroller/Pin.c
@@ -31,8 +31,8 @@
 
 #include "py/mphal.h"
 
-#include "esp-idf/components/driver/include/driver/gpio.h"
-#include "esp-idf/components/soc/include/hal/gpio_hal.h"
+#include "components/driver/include/driver/gpio.h"
+#include "components/hal/include/hal/gpio_hal.h"
 
 #ifdef MICROPY_HW_NEOPIXEL
 bool neopixel_in_use;

--- a/ports/esp32s2/common-hal/microcontroller/Pin.c
+++ b/ports/esp32s2/common-hal/microcontroller/Pin.c
@@ -32,7 +32,7 @@
 #include "py/mphal.h"
 
 #include "components/driver/include/driver/gpio.h"
-#include "components/hal/include/hal/gpio_hal.h"
+#include "components/soc/include/hal/gpio_hal.h"
 
 #ifdef MICROPY_HW_NEOPIXEL
 bool neopixel_in_use;

--- a/ports/esp32s2/common-hal/microcontroller/Processor.c
+++ b/ports/esp32s2/common-hal/microcontroller/Processor.c
@@ -34,7 +34,7 @@
 
 #include "soc/efuse_reg.h"
 
-#include "esp-idf/components/driver/esp32s2/include/driver/temp_sensor.h"
+#include "components/driver/esp32s2/include/driver/temp_sensor.h"
 
 float common_hal_mcu_processor_get_temperature(void) {
     float tsens_out;

--- a/ports/esp32s2/common-hal/neopixel_write/__init__.c
+++ b/ports/esp32s2/common-hal/neopixel_write/__init__.c
@@ -43,8 +43,8 @@
 #include "py/mphal.h"
 #include "py/runtime.h"
 #include "shared-bindings/neopixel_write/__init__.h"
-#include "driver/rmt.h"
-#include "rmt.h"
+#include "components/driver/include/driver/rmt.h"
+#include "peripherals/rmt.h"
 
 #define WS2812_T0H_NS (350)
 #define WS2812_T0L_NS (1000)

--- a/ports/esp32s2/common-hal/pulseio/PulseIn.h
+++ b/ports/esp32s2/common-hal/pulseio/PulseIn.h
@@ -30,8 +30,8 @@
 #include "common-hal/microcontroller/Pin.h"
 
 #include "py/obj.h"
-#include "driver/rmt.h"
-#include "rmt.h"
+#include "components/driver/include/driver/rmt.h"
+#include "peripherals/rmt.h"
 
 typedef struct {
     mp_obj_base_t base;

--- a/ports/esp32s2/common-hal/pulseio/PulseOut.h
+++ b/ports/esp32s2/common-hal/pulseio/PulseOut.h
@@ -28,8 +28,8 @@
 #define MICROPY_INCLUDED_ESP32S2_COMMON_HAL_PULSEIO_PULSEOUT_H
 
 #include "common-hal/microcontroller/Pin.h"
-#include "driver/rmt.h"
-#include "rmt.h"
+#include "components/driver/include/driver/rmt.h"
+#include "peripherals/rmt.h"
 
 #include "py/obj.h"
 

--- a/ports/esp32s2/common-hal/pwmio/PWMOut.c
+++ b/ports/esp32s2/common-hal/pwmio/PWMOut.c
@@ -28,7 +28,7 @@
 #include "common-hal/pwmio/PWMOut.h"
 #include "shared-bindings/pwmio/PWMOut.h"
 #include "py/runtime.h"
-#include "driver/ledc.h"
+#include "components/driver/include/driver/ledc.h"
 
 #define INDEX_EMPTY 0xFF
 

--- a/ports/esp32s2/common-hal/pwmio/PWMOut.h
+++ b/ports/esp32s2/common-hal/pwmio/PWMOut.h
@@ -28,7 +28,7 @@
 #define MICROPY_INCLUDED_ESP32S2_COMMON_HAL_PWMIO_PWMOUT_H
 
 #include "common-hal/microcontroller/Pin.h"
-#include "driver/ledc.h"
+#include "components/driver/include/driver/ledc.h"
 
 typedef struct {
     mp_obj_base_t base;

--- a/ports/esp32s2/common-hal/rtc/RTC.c
+++ b/ports/esp32s2/common-hal/rtc/RTC.c
@@ -28,7 +28,7 @@
 
 #include "py/obj.h"
 #include "py/runtime.h"
-#include "soc/rtc_periph.h"
+#include "components/soc/soc/include/soc/rtc_periph.h"
 #include "shared-bindings/rtc/RTC.h"
 
 void common_hal_rtc_get_time(timeutils_struct_time_t *tm) {

--- a/ports/esp32s2/common-hal/socketpool/Socket.h
+++ b/ports/esp32s2/common-hal/socketpool/Socket.h
@@ -32,7 +32,8 @@
 #include "common-hal/socketpool/SocketPool.h"
 #include "common-hal/ssl/SSLContext.h"
 
-#include "esp-idf/components/esp-tls/esp_tls.h"
+#include "components/esp-tls/esp_tls.h"
+#include "components/log/include/esp_log.h"
 
 typedef struct {
     mp_obj_base_t base;

--- a/ports/esp32s2/common-hal/socketpool/SocketPool.c
+++ b/ports/esp32s2/common-hal/socketpool/SocketPool.c
@@ -29,7 +29,7 @@
 #include "py/runtime.h"
 #include "shared-bindings/wifi/__init__.h"
 
-#include "esp-idf/components/lwip/lwip/src/include/lwip/netdb.h"
+#include "components/lwip/lwip/src/include/lwip/netdb.h"
 
 #include "bindings/espidf/__init__.h"
 

--- a/ports/esp32s2/common-hal/ssl/SSLContext.h
+++ b/ports/esp32s2/common-hal/ssl/SSLContext.h
@@ -29,7 +29,7 @@
 
 #include "py/obj.h"
 
-#include "esp-idf/components/esp-tls/esp_tls.h"
+#include "components/esp-tls/esp_tls.h"
 
 typedef struct {
     mp_obj_base_t base;

--- a/ports/esp32s2/common-hal/ssl/__init__.c
+++ b/ports/esp32s2/common-hal/ssl/__init__.c
@@ -26,7 +26,7 @@
 
 #include "shared-bindings/ssl/SSLContext.h"
 
-#include "esp-idf/components/mbedtls/esp_crt_bundle/include/esp_crt_bundle.h"
+#include "components/mbedtls/esp_crt_bundle/include/esp_crt_bundle.h"
 
 void common_hal_ssl_create_default_context(ssl_sslcontext_obj_t* self) {
     memset(&self->ssl_config, 0, sizeof(esp_tls_cfg_t));

--- a/ports/esp32s2/common-hal/wifi/Network.h
+++ b/ports/esp32s2/common-hal/wifi/Network.h
@@ -29,7 +29,7 @@
 
 #include "py/obj.h"
 
-#include "esp-idf/components/esp_wifi/include/esp_wifi_types.h"
+#include "components/esp_wifi/include/esp_wifi_types.h"
 
 typedef struct {
     mp_obj_base_t base;

--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -35,8 +35,8 @@
 #include "shared-bindings/wifi/ScannedNetworks.h"
 #include "shared-module/ipaddress/__init__.h"
 
-#include "esp-idf/components/esp_wifi/include/esp_wifi.h"
-#include "esp-idf/components/lwip/include/apps/ping/ping_sock.h"
+#include "components/esp_wifi/include/esp_wifi.h"
+#include "components/lwip/include/apps/ping/ping_sock.h"
 
 static void start_station(wifi_radio_obj_t *self) {
     if (self->sta_mode) {

--- a/ports/esp32s2/common-hal/wifi/Radio.h
+++ b/ports/esp32s2/common-hal/wifi/Radio.h
@@ -29,7 +29,7 @@
 
 #include "py/obj.h"
 
-#include "esp-idf/components/esp_event/include/esp_event.h"
+#include "components/esp_event/include/esp_event.h"
 
 #include "shared-bindings/wifi/ScannedNetworks.h"
 

--- a/ports/esp32s2/common-hal/wifi/ScannedNetworks.c
+++ b/ports/esp32s2/common-hal/wifi/ScannedNetworks.c
@@ -37,7 +37,7 @@
 #include "shared-bindings/wifi/Radio.h"
 #include "shared-bindings/wifi/ScannedNetworks.h"
 
-#include "esp-idf/components/esp_wifi/include/esp_wifi.h"
+#include "components/esp_wifi/include/esp_wifi.h"
 
 static void wifi_scannednetworks_done(wifi_scannednetworks_obj_t *self) {
     self->done = true;

--- a/ports/esp32s2/common-hal/wifi/ScannedNetworks.h
+++ b/ports/esp32s2/common-hal/wifi/ScannedNetworks.h
@@ -35,7 +35,8 @@
 #include "FreeRTOS.h"
 #include "freertos/event_groups.h"
 
-#include "esp-idf/components/esp_wifi/include/esp_wifi_types.h"
+#include "components/esp_wifi/include/esp_wifi_types.h"
+#include "components/log/include/esp_log.h"
 
 typedef struct {
     mp_obj_base_t base;

--- a/ports/esp32s2/common-hal/wifi/__init__.c
+++ b/ports/esp32s2/common-hal/wifi/__init__.c
@@ -31,13 +31,14 @@
 
 #include "py/runtime.h"
 
-#include "esp-idf/components/esp_wifi/include/esp_wifi.h"
+#include "components/esp_wifi/include/esp_wifi.h"
 
-#include "esp-idf/components/heap/include/esp_heap_caps.h"
+#include "components/heap/include/esp_heap_caps.h"
 
 wifi_radio_obj_t common_hal_wifi_radio_obj;
 
-#include "esp_log.h"
+#include "components/log/include/esp_log.h"
+
 static const char* TAG = "wifi";
 
 static void event_handler(void* arg, esp_event_base_t event_base,

--- a/ports/esp32s2/mphalport.c
+++ b/ports/esp32s2/mphalport.c
@@ -31,8 +31,8 @@
 #include "py/mpstate.h"
 #include "py/gc.h"
 
-#include "esp-idf/components/xtensa/include/esp_debug_helpers.h"
-#include "esp-idf/components/esp_rom/include/esp32s2/rom/ets_sys.h"
+#include "components/xtensa/include/esp_debug_helpers.h"
+#include "components/esp_rom/include/esp32s2/rom/ets_sys.h"
 
 void mp_hal_delay_us(mp_uint_t delay) {
     ets_delay_us(delay);

--- a/ports/esp32s2/peripherals/pins.h
+++ b/ports/esp32s2/peripherals/pins.h
@@ -34,7 +34,7 @@
 
 #include "esp32s2_peripherals_config.h"
 #include "esp-idf/config/sdkconfig.h"
-#include "components/hal/include/hal/gpio_types.h"
+#include "components/soc/include/hal/gpio_types.h"
 
 typedef struct {
     PIN_PREFIX_FIELDS

--- a/ports/esp32s2/peripherals/pins.h
+++ b/ports/esp32s2/peripherals/pins.h
@@ -34,7 +34,7 @@
 
 #include "esp32s2_peripherals_config.h"
 #include "esp-idf/config/sdkconfig.h"
-#include "esp-idf/components/soc/include/hal/gpio_types.h"
+#include "components/hal/include/hal/gpio_types.h"
 
 typedef struct {
     PIN_PREFIX_FIELDS

--- a/ports/esp32s2/peripherals/rmt.c
+++ b/ports/esp32s2/peripherals/rmt.c
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-#include "rmt.h"
+#include "peripherals/rmt.h"
 #include "py/runtime.h"
 
 bool rmt_reserved_channels[RMT_CHANNEL_MAX];

--- a/ports/esp32s2/peripherals/rmt.h
+++ b/ports/esp32s2/peripherals/rmt.h
@@ -28,7 +28,7 @@
 #define MICROPY_INCLUDED_ESP32S2_PERIPHERALS_RMT_H
 
 #include "py/mphal.h"
-#include "driver/rmt.h"
+#include "components/driver/include/driver/rmt.h"
 #include <stdint.h>
 
 void esp32s2_peripherals_rmt_reset(void);

--- a/ports/esp32s2/supervisor/internal_flash.c
+++ b/ports/esp32s2/supervisor/internal_flash.c
@@ -37,7 +37,7 @@
 #include "py/runtime.h"
 #include "lib/oofatfs/ff.h"
 
-#include "esp-idf/components/spi_flash/include/esp_partition.h"
+#include "components/spi_flash/include/esp_partition.h"
 
 #include "supervisor/usb.h"
 

--- a/ports/esp32s2/supervisor/port.c
+++ b/ports/esp32s2/supervisor/port.c
@@ -46,8 +46,8 @@
 #include "shared-bindings/rtc/__init__.h"
 
 #include "peripherals/rmt.h"
-#include "esp-idf/components/heap/include/esp_heap_caps.h"
-#include "esp-idf/components/soc/soc/esp32s2/include/soc/cache_memory.h"
+#include "components/heap/include/esp_heap_caps.h"
+#include "components/soc/soc/esp32s2/include/soc/cache_memory.h"
 
 #define HEAP_SIZE (48 * 1024)
 

--- a/ports/esp32s2/supervisor/usb.c
+++ b/ports/esp32s2/supervisor/usb.c
@@ -29,10 +29,10 @@
 #include "lib/utils/interrupt_char.h"
 #include "lib/mp-readline/readline.h"
 
-#include "esp-idf/components/soc/soc/esp32s2/include/soc/usb_periph.h"
-#include "esp-idf/components/driver/include/driver/periph_ctrl.h"
-#include "esp-idf/components/driver/include/driver/gpio.h"
-#include "esp-idf/components/esp_rom/include/esp32s2/rom/gpio.h"
+#include "components/soc/soc/esp32s2/include/soc/usb_periph.h"
+#include "components/driver/include/driver/periph_ctrl.h"
+#include "components/driver/include/driver/gpio.h"
+#include "components/esp_rom/include/esp32s2/rom/gpio.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/shared-bindings/socketpool/Socket.c
+++ b/shared-bindings/socketpool/Socket.c
@@ -36,7 +36,6 @@
 #include "py/runtime.h"
 #include "py/mperrno.h"
 
-#include "esp_log.h"
 static const char* TAG = "socket binding";
 
 //| class Socket:

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -37,7 +37,6 @@
 #include "shared-bindings/socketpool/Socket.h"
 #include "shared-bindings/socketpool/SocketPool.h"
 
-#include "esp_log.h"
 static const char* TAG = "socketpool binding";
 
 //| class SocketPool:

--- a/shared-bindings/wifi/ScannedNetworks.c
+++ b/shared-bindings/wifi/ScannedNetworks.c
@@ -32,7 +32,6 @@
 #include "py/runtime.h"
 #include "shared-bindings/wifi/ScannedNetworks.h"
 
-#include "esp_log.h"
 static const char *TAG = "cp iternext";
 
 //| class ScannedNetworks:


### PR DESCRIPTION
Up to now, the ESP32S2 port has been using a modified version of the ESP32-IDF (IoT Development Framework, the core framework for developing on the ESP32-S2 with all HAL APIs, drivers, FreeRTOS components, etc) forked by @tannewt. This was because the IDF itself contains a lot of `undef` type preprocessor errors that conflict with our use of `-Werror`, which Scott manually fixed in his fork.

We recently discovered a workaround for this, which involves using the "-isystem" directory option to mark all IDF files as system files, ignoring their warnings. This lets use use the official IDF, though it does require a lot of changes, both to make sure all preprocessor includes use an `-isystem` derived path, and to represent a bunch of other changes to the IDF since we forked (lots of files were moved refactored from "soc" locations to "hal" locations, and a critical system binary was renamed).

With @hathach and @julianrendell's help, the USB issue with this has been fixed. Tested successfully on a Saola 1 Wrover. 