### PR TITLE
Implemented the ability to set the transmitter power on nRF52 devices

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/Adapter.c
+++ b/devices/ble_hci/common-hal/_bleio/Adapter.c
@@ -645,7 +645,7 @@ STATIC void check_data_fit(size_t data_len, bool connectable) {
 //     return true;
 // }
 
-uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len) {
+uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len, mp_int_t tx_power) {
     check_enabled(self);
 
     if (self->now_advertising) {
@@ -769,7 +769,7 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, 
     return 0;
 }
 
-void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo) {
+void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo, mp_int_t tx_power) {
     check_enabled(self);
 
     // interval value has already been validated.
@@ -793,12 +793,17 @@ void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool 
         }
     }
 
+    if (tx_power != 0) {
+        mp_raise_NotImplementedError();
+    }
+
     const uint32_t result = _common_hal_bleio_adapter_start_advertising(
         self, connectable, anonymous, timeout, interval,
         advertising_data_bufinfo->buf,
         advertising_data_bufinfo->len,
         scan_response_data_bufinfo->buf,
-        scan_response_data_bufinfo->len);
+        scan_response_data_bufinfo->len,
+        tx_power);
 
     if (result) {
         mp_raise_bleio_BluetoothError(translate("Already advertising"));

--- a/devices/ble_hci/common-hal/_bleio/Adapter.c
+++ b/devices/ble_hci/common-hal/_bleio/Adapter.c
@@ -794,7 +794,7 @@ void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool 
     }
 
     if (tx_power != 0) {
-        mp_raise_NotImplementedError();
+        mp_raise_NotImplementedError(translate("Only tx_power=0 supported"));
     }
 
     const uint32_t result = _common_hal_bleio_adapter_start_advertising(

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1211,6 +1211,10 @@ msgstr ""
 msgid "Invalid AuthMode"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Invalid BLE parameter"
+msgstr ""
+
 #: shared-module/displayio/OnDiskBitmap.c
 msgid "Invalid BMP file"
 msgstr ""
@@ -2316,7 +2320,7 @@ msgstr ""
 msgid "Unsupported format"
 msgstr ""
 
-#: ports/raspberrypi/common-hal/pulseio/PulseOut.c py/moduerrno.c
+#: py/moduerrno.c
 msgid "Unsupported operation"
 msgstr ""
 

--- a/ports/nrf/common-hal/_bleio/Adapter.h
+++ b/ports/nrf/common-hal/_bleio/Adapter.h
@@ -48,6 +48,7 @@ typedef struct {
     uint8_t *current_advertising_data;
     bleio_scanresults_obj_t *scan_results;
     mp_obj_t name;
+    mp_int_t tx_power;
     mp_obj_tuple_t *connection_objs;
     ble_drv_evt_handler_entry_t handler_entry;
 } bleio_adapter_obj_t;

--- a/ports/nrf/common-hal/_bleio/Adapter.h
+++ b/ports/nrf/common-hal/_bleio/Adapter.h
@@ -48,7 +48,6 @@ typedef struct {
     uint8_t *current_advertising_data;
     bleio_scanresults_obj_t *scan_results;
     mp_obj_t name;
-    mp_int_t tx_power;
     mp_obj_tuple_t *connection_objs;
     ble_drv_evt_handler_entry_t handler_entry;
 } bleio_adapter_obj_t;

--- a/ports/nrf/common-hal/_bleio/__init__.c
+++ b/ports/nrf/common-hal/_bleio/__init__.c
@@ -52,6 +52,9 @@ void check_nrf_error(uint32_t err_code) {
         case NRF_ERROR_TIMEOUT:
             mp_raise_msg(&mp_type_TimeoutError, NULL);
             return;
+        case NRF_ERROR_INVALID_PARAM:
+            mp_raise_ValueError(translate("Invalid BLE parameter"));
+            return;
         case BLE_ERROR_INVALID_CONN_HANDLE:
             mp_raise_ConnectionError(translate("Not connected"));
             return;

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -142,34 +142,6 @@ const mp_obj_property_t bleio_adapter_enabled_obj = {
                MP_ROM_NONE },
 };
 
-//|
-//|     tx_power: int
-//|     """transmitter power"""
-//|
-
-STATIC mp_obj_t bleio_adapter_get_tx_power(mp_obj_t self) {
-return mp_obj_new_int(common_hal_bleio_adapter_get_tx_power(self));
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_get_tx_power_obj, bleio_adapter_get_tx_power);
-
-static mp_obj_t bleio_adapter_set_tx_power(mp_obj_t self, mp_obj_t value) {
-    const mp_int_t tx_power = mp_obj_get_int(value);
-
-    common_hal_bleio_adapter_set_tx_power(self, tx_power);
-
-    return mp_const_none;
-}
-
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(bleio_adapter_set_tx_power_obj, bleio_adapter_set_tx_power);
-
-const mp_obj_property_t bleio_adapter_tx_power_obj = {
-        .base.type = &mp_type_property,
-        .proxy = { (mp_obj_t)&bleio_adapter_get_tx_power_obj,
-                   (mp_obj_t)&bleio_adapter_set_tx_power_obj,
-                   (mp_obj_t)&mp_const_none_obj },
-};
-
-
 //|     address: Address
 //|     """MAC address of the BLE adapter."""
 //|
@@ -218,7 +190,7 @@ const mp_obj_property_t bleio_adapter_name_obj = {
                MP_ROM_NONE },
 };
 
-//|     def start_advertising(self, data: ReadableBuffer, *, scan_response: Optional[ReadableBuffer] = None, connectable: bool = True, anonymous: bool = False, timeout: int = 0, interval: float = 0.1) -> None:
+//|     def start_advertising(self, data: ReadableBuffer, *, scan_response: Optional[ReadableBuffer] = None, connectable: bool = True, anonymous: bool = False, timeout: int = 0, interval: float = 0.1, tx_power: int = 0) -> None:
 //|         """Starts advertising until `stop_advertising` is called or if connectable, another device
 //|         connects to us.
 //|
@@ -233,13 +205,14 @@ const mp_obj_property_t bleio_adapter_name_obj = {
 //|         :param bool connectable:  If `True` then other devices are allowed to connect to this peripheral.
 //|         :param bool anonymous:  If `True` then this device's MAC address is randomized before advertising.
 //|         :param int timeout:  If set, we will only advertise for this many seconds. Zero means no timeout.
-//|         :param float interval:  advertising interval, in seconds"""
+//|         :param float interval:  advertising interval, in seconds
+//|         :param tx_power int: transmitter power while advertising in dBm"""
 //|         ...
 //|
 STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_adapter_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
-    enum { ARG_data, ARG_scan_response, ARG_connectable, ARG_anonymous, ARG_timeout, ARG_interval };
+    enum { ARG_data, ARG_scan_response, ARG_connectable, ARG_anonymous, ARG_timeout, ARG_interval, ARG_tx_power };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_data, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_scan_response, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
@@ -247,6 +220,7 @@ STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t
         { MP_QSTR_anonymous, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
         { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_interval, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_tx_power, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -279,7 +253,7 @@ STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t
     }
 
     common_hal_bleio_adapter_start_advertising(self, connectable, anonymous, timeout, interval,
-        &data_bufinfo, &scan_response_bufinfo);
+        &data_bufinfo, &scan_response_bufinfo, args[ARG_tx_power].u_int);
 
     return mp_const_none;
 }
@@ -485,7 +459,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_erase_bonding_obj, bleio_adapter_
 
 STATIC const mp_rom_map_elem_t bleio_adapter_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_enabled), MP_ROM_PTR(&bleio_adapter_enabled_obj) },
-    { MP_ROM_QSTR(MP_QSTR_tx_power), MP_ROM_PTR(&bleio_adapter_tx_power_obj) },
     { MP_ROM_QSTR(MP_QSTR_address), MP_ROM_PTR(&bleio_adapter_address_obj) },
     { MP_ROM_QSTR(MP_QSTR_name),    MP_ROM_PTR(&bleio_adapter_name_obj) },
 

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -142,6 +142,34 @@ const mp_obj_property_t bleio_adapter_enabled_obj = {
                MP_ROM_NONE },
 };
 
+//|
+//|     tx_power: int
+//|     """transmitter power"""
+//|
+
+STATIC mp_obj_t bleio_adapter_get_tx_power(mp_obj_t self) {
+return mp_obj_new_int(common_hal_bleio_adapter_get_tx_power(self));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_get_tx_power_obj, bleio_adapter_get_tx_power);
+
+static mp_obj_t bleio_adapter_set_tx_power(mp_obj_t self, mp_obj_t value) {
+    const mp_int_t tx_power = mp_obj_get_int(value);
+
+    common_hal_bleio_adapter_set_tx_power(self, tx_power);
+
+    return mp_const_none;
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(bleio_adapter_set_tx_power_obj, bleio_adapter_set_tx_power);
+
+const mp_obj_property_t bleio_adapter_tx_power_obj = {
+        .base.type = &mp_type_property,
+        .proxy = { (mp_obj_t)&bleio_adapter_get_tx_power_obj,
+                   (mp_obj_t)&bleio_adapter_set_tx_power_obj,
+                   (mp_obj_t)&mp_const_none_obj },
+};
+
+
 //|     address: Address
 //|     """MAC address of the BLE adapter."""
 //|
@@ -457,6 +485,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_erase_bonding_obj, bleio_adapter_
 
 STATIC const mp_rom_map_elem_t bleio_adapter_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_enabled), MP_ROM_PTR(&bleio_adapter_enabled_obj) },
+    { MP_ROM_QSTR(MP_QSTR_tx_power), MP_ROM_PTR(&bleio_adapter_tx_power_obj) },
     { MP_ROM_QSTR(MP_QSTR_address), MP_ROM_PTR(&bleio_adapter_address_obj) },
     { MP_ROM_QSTR(MP_QSTR_name),    MP_ROM_PTR(&bleio_adapter_name_obj) },
 

--- a/shared-bindings/_bleio/Adapter.h
+++ b/shared-bindings/_bleio/Adapter.h
@@ -44,6 +44,8 @@ void common_hal_bleio_adapter_construct_hci_uart(bleio_adapter_obj_t *self, busi
 extern bool common_hal_bleio_adapter_get_advertising(bleio_adapter_obj_t *self);
 extern bool common_hal_bleio_adapter_get_enabled(bleio_adapter_obj_t *self);
 extern void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enabled);
+extern mp_int_t common_hal_bleio_adapter_get_tx_power(bleio_adapter_obj_t *self);
+extern void common_hal_bleio_adapter_set_tx_power(bleio_adapter_obj_t *self, mp_int_t tx_power);
 extern bool common_hal_bleio_adapter_get_connected(bleio_adapter_obj_t *self);
 extern bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_obj_t *self);
 extern bool common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, bleio_address_obj_t *address);

--- a/shared-bindings/_bleio/Adapter.h
+++ b/shared-bindings/_bleio/Adapter.h
@@ -53,9 +53,9 @@ extern bool common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, blei
 extern mp_obj_str_t *common_hal_bleio_adapter_get_name(bleio_adapter_obj_t *self);
 extern void common_hal_bleio_adapter_set_name(bleio_adapter_obj_t *self, const char *name);
 
-extern uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len);
+extern uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, float interval, uint8_t *advertising_data, uint16_t advertising_data_len, uint8_t *scan_response_data, uint16_t scan_response_data_len, mp_int_t tx_power);
 
-extern void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo);
+extern void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool connectable, bool anonymous, uint32_t timeout, mp_float_t interval, mp_buffer_info_t *advertising_data_bufinfo, mp_buffer_info_t *scan_response_data_bufinfo, mp_int_t tx_power);
 extern void common_hal_bleio_adapter_stop_advertising(bleio_adapter_obj_t *self);
 
 extern mp_obj_t common_hal_bleio_adapter_start_scan(bleio_adapter_obj_t *self, uint8_t *prefixes, size_t prefix_length, bool extended, mp_int_t buffer_size, mp_float_t timeout, mp_float_t interval, mp_float_t window, mp_int_t minimum_rssi, bool active);


### PR DESCRIPTION
I added the ability to set the transmitter power on the nrf52 devices. I also modified the Adafruit_CircuitPython_BLE python file and will commit those changes as well.  Other devices will need to have the hal interface added or a dummy interface created if not possible. Alternatively a compile time flag could disable this for all but this particular device. 