### PR TITLE
Sharpdisplay: reuse supervisor heap

### DIFF
--- a/shared-module/sharpdisplay/SharpMemoryFramebuffer.c
+++ b/shared-module/sharpdisplay/SharpMemoryFramebuffer.c
@@ -34,21 +34,22 @@
 #include "shared-module/sharpdisplay/SharpMemoryFramebuffer.h"
 
 #include "supervisor/memory.h"
+#include "supervisor/shared/safe_mode.h"
 
 #define SHARPMEM_BIT_WRITECMD_LSB (0x80)
 #define SHARPMEM_BIT_VCOM_LSB (0x40)
 
-static inline void *hybrid_alloc(size_t sz) {
-    if (gc_alloc_possible()) {
-        return m_malloc(sz + sizeof(void*), true);
-    } else {
-        supervisor_allocation *allocation = allocate_memory(align32_size(sz), false);
-        if (!allocation) {
-            return NULL;
-        }
+static void *hybrid_alloc(size_t sz) {
+    supervisor_allocation *allocation = allocate_memory(align32_size(sz), false);
+    if (allocation) {
         memset(allocation->ptr, 0, sz);
         return allocation->ptr;
     }
+    if (gc_alloc_possible()) {
+        return m_malloc(sz, true);
+    }
+    reset_into_safe_mode(MEM_MANAGE);
+    return NULL; // unreached
 }
 
 static inline void hybrid_free(void *ptr_in) {
@@ -155,7 +156,8 @@ void common_hal_sharpdisplay_framebuffer_construct(sharpdisplay_framebuffer_obj_
 
     int row_stride = common_hal_sharpdisplay_framebuffer_get_row_stride(self);
     self->bufinfo.len = row_stride * height + 2;
-    self->bufinfo.buf = gc_alloc(self->bufinfo.len, false, true);
+    // re-use a supervisor allocation if possible
+    self->bufinfo.buf = hybrid_alloc(self->bufinfo.len);
 
     uint8_t *data = self->bufinfo.buf;
     *data++ = SHARPMEM_BIT_WRITECMD_LSB;


### PR DESCRIPTION
Due to an existing limitation of being unable to re-allocate a freed supervisor heap entry, framebuffer displays used more memory than necessary, particularly on the second and subsequent runs: The preserved-over-soft-reset display has its framebuffer moved to the supervisor heap, but we release that display with release_displays() and then create a fresh one which places its framebuffer on the GC heap.

A newly exposed problem, where framebuffer displays would cause a leak of the terminal grid storage, was also found and fixed.

With this change, sharp displays will re-use the same supervisor allocation as long as the WxH of the display matches.

A similar change should be made for RGBMatrix, however at this moment I did not want to take the time to implement and test it.  It consists of switching the order of preference for allocation to try supervisor first and gc second, then fixing whatever breaks.

This requires #3482 + #3497 in order to be fully effective, so it should be merged only after those go in.