### PR TITLE
displayio: Fix matrixportal crash

### DIFF
--- a/shared-module/displayio/display_core.c
+++ b/shared-module/displayio/display_core.c
@@ -197,7 +197,7 @@ bool displayio_display_core_get_dither(displayio_display_core_t* self){
 }
 
 bool displayio_display_core_bus_free(displayio_display_core_t *self) {
-    return self->bus_free(self->bus);
+    return !self->bus || self->bus_free(self->bus);
 }
 
 bool displayio_display_core_begin_transaction(displayio_display_core_t* self) {


### PR DESCRIPTION
An RGBMatrix has no bus and no bus_free method.  It is always possible to refresh the display.

This was not a problem before, but the fix I suggested (#3449) added a call to core_bus_free when a FramebufferDisplay was being refreshed. This was not caught during testing.

This is a band-aid fix and it brings to light a second problem in which a SharpDisplay + FrameBuffer will not have a 'bus' object, and yet does operate using a shared SPI bus.  This kind of display will need a "bus-free" like function to be added, or it can have problems like #3309.

Closes: #3506 

Testing performed: Used the 1-line reproducer from #3506 on my matrixportal.