### PR TITLE
Removed hardware APA settings from ESP32-S2 Feather mpconfigboard.h

### DIFF
--- a/ports/esp32s2/boards/unexpectedmaker_feathers2/mpconfigboard.h
+++ b/ports/esp32s2/boards/unexpectedmaker_feathers2/mpconfigboard.h
@@ -35,5 +35,5 @@
 
 #define AUTORESET_DELAY_MS 500
 
-#define MICROPY_HW_APA102_MOSI   (&pin_GPIO40)
-#define MICROPY_HW_APA102_SCK    (&pin_GPIO45)
+// #define MICROPY_HW_APA102_MOSI   (&pin_GPIO40)
+// #define MICROPY_HW_APA102_SCK    (&pin_GPIO45)

--- a/ports/esp32s2/boards/unexpectedmaker_feathers2_prerelease/mpconfigboard.h
+++ b/ports/esp32s2/boards/unexpectedmaker_feathers2_prerelease/mpconfigboard.h
@@ -34,5 +34,5 @@
 
 #define AUTORESET_DELAY_MS 500
 
-#define MICROPY_HW_APA102_MOSI   (&pin_GPIO40)
-#define MICROPY_HW_APA102_SCK    (&pin_GPIO45)
+// #define MICROPY_HW_APA102_MOSI   (&pin_GPIO40)
+// #define MICROPY_HW_APA102_SCK    (&pin_GPIO45)


### PR DESCRIPTION
Removed hardware APA settings from mpconfigboard.h because they make the APA flicker on boot. I need to look into why, but for now I'd rather no flicker.