### PR TITLE
fix espressif latest idf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -152,4 +152,4 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_RFM69.git
 [submodule "ports/esp32s2/esp-idf"]
 	path = ports/esp32s2/esp-idf
-	url = https://github.com/hierophect/esp-idf.git
+	url = https://github.com/espressif/esp-idf.git

--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -271,7 +271,7 @@ menuconfig: $(BUILD)/esp-idf/config
 $(HEADER_BUILD)/qstr.i.last: | $(BUILD)/esp-idf/config/sdkconfig.h
 
 # Order here matters
-ESP_IDF_COMPONENTS_LINK = freertos log esp_system esp32s2 bootloader_support pthread esp_timer vfs spi_flash app_update esp_common esp32s2 heap newlib driver xtensa soc esp_ringbuf esp_wifi esp_event wpa_supplicant mbedtls efuse nvs_flash esp_netif lwip esp_rom esp-tls
+ESP_IDF_COMPONENTS_LINK = freertos log hal esp_system esp32s2 bootloader_support pthread esp_timer vfs spi_flash app_update esp_common esp32s2 heap newlib driver xtensa soc esp_ringbuf esp_wifi esp_event wpa_supplicant mbedtls efuse nvs_flash esp_netif lwip esp_rom esp-tls
 
 ESP_IDF_COMPONENTS_INCLUDE = driver freertos log soc
 
@@ -283,11 +283,11 @@ ESP_IDF_WIFI_COMPONENTS_EXPANDED = $(foreach component, $(ESP_IDF_WIFI_COMPONENT
 MBEDTLS_COMPONENTS_LINK = crypto tls x509
 MBEDTLS_COMPONENTS_LINK_EXPANDED = $(foreach component, $(MBEDTLS_COMPONENTS_LINK), $(BUILD)/esp-idf/esp-idf/mbedtls/mbedtls/library/libmbed$(component).a)
 
-BINARY_BLOBS = esp-idf/components/xtensa/esp32s2/libhal.a
+BINARY_BLOBS = esp-idf/components/xtensa/esp32s2/libxt_hal.a
 BINARY_WIFI_BLOBS = libcoexist.a libcore.a libespnow.a libmesh.a libnet80211.a libpp.a librtc.a libsmartconfig.a libphy.a
 BINARY_BLOBS += $(addprefix esp-idf/components/esp_wifi/lib/esp32s2/, $(BINARY_WIFI_BLOBS))
 
-ESP_IDF_COMPONENTS_EXPANDED += $(BUILD)/esp-idf/esp-idf/soc/soc/esp32s2/libsoc_esp32s2.a esp-idf/components/xtensa/esp32s2/libhal.a
+ESP_IDF_COMPONENTS_EXPANDED += $(BUILD)/esp-idf/esp-idf/soc/soc/esp32s2/libsoc_esp32s2.a esp-idf/components/xtensa/esp32s2/libxt_hal.a
 ESP_AUTOGEN_LD = $(BUILD)/esp-idf/esp-idf/esp32s2/esp32s2_out.ld $(BUILD)/esp-idf/esp-idf/esp32s2/ld/esp32s2.project.ld
 
 FLASH_FLAGS = --flash_mode $(CIRCUITPY_ESP_FLASH_MODE) --flash_freq $(CIRCUITPY_ESP_FLASH_FREQ) --flash_size $(CIRCUITPY_ESP_FLASH_SIZE)

--- a/ports/esp32s2/common-hal/busio/I2C.h
+++ b/ports/esp32s2/common-hal/busio/I2C.h
@@ -29,7 +29,7 @@
 
 #include "common-hal/microcontroller/Pin.h"
 
-#include "components/soc/include/hal/i2c_types.h"
+#include "components/hal/include/hal/i2c_types.h"
 #include "FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "py/obj.h"

--- a/ports/esp32s2/common-hal/busio/SPI.h
+++ b/ports/esp32s2/common-hal/busio/SPI.h
@@ -30,8 +30,8 @@
 #include "common-hal/microcontroller/Pin.h"
 
 #include "components/driver/include/driver/spi_common_internal.h"
-#include "components/soc/include/hal/spi_hal.h"
-#include "components/soc/include/hal/spi_types.h"
+#include "components/hal/include/hal/spi_hal.h"
+#include "components/hal/include/hal/spi_types.h"
 #include "py/obj.h"
 
 typedef struct {

--- a/ports/esp32s2/common-hal/busio/UART.h
+++ b/ports/esp32s2/common-hal/busio/UART.h
@@ -29,7 +29,7 @@
 
 #include "common-hal/microcontroller/Pin.h"
 
-#include "components/soc/include/hal/uart_types.h"
+#include "components/hal/include/hal/uart_types.h"
 #include "py/obj.h"
 
 typedef struct {

--- a/ports/esp32s2/common-hal/digitalio/DigitalInOut.c
+++ b/ports/esp32s2/common-hal/digitalio/DigitalInOut.c
@@ -30,7 +30,7 @@
 
 #include "components/driver/include/driver/gpio.h"
 
-#include "components/soc/include/hal/gpio_hal.h"
+#include "components/hal/include/hal/gpio_hal.h"
 
 void common_hal_digitalio_digitalinout_never_reset(
         digitalio_digitalinout_obj_t *self) {

--- a/ports/esp32s2/common-hal/microcontroller/Pin.c
+++ b/ports/esp32s2/common-hal/microcontroller/Pin.c
@@ -32,7 +32,7 @@
 #include "py/mphal.h"
 
 #include "components/driver/include/driver/gpio.h"
-#include "components/soc/include/hal/gpio_hal.h"
+#include "components/hal/include/hal/gpio_hal.h"
 
 #ifdef MICROPY_HW_NEOPIXEL
 bool neopixel_in_use;

--- a/ports/esp32s2/peripherals/pins.h
+++ b/ports/esp32s2/peripherals/pins.h
@@ -34,7 +34,7 @@
 
 #include "esp32s2_peripherals_config.h"
 #include "esp-idf/config/sdkconfig.h"
-#include "components/soc/include/hal/gpio_types.h"
+#include "components/hal/include/hal/gpio_types.h"
 
 typedef struct {
     PIN_PREFIX_FIELDS


### PR DESCRIPTION
[Not working yet]
I am trying to fix #3516 , I have  fixed the build issue with hal file got move around with latest IDF. However, I got an linking issue. @hierophect  Would you mind help me to fix this, then I will try to test out the usb patch.

```
xtensa-esp32s2-elf-gcc: error: esp-idf/components/xtensa/esp32s2/libhal.a: No such file or directory
xtensa-esp32s2-elf-gcc: error: esp-idf/components/xtensa/esp32s2/libhal.a: No such file or directory
make: *** [Makefile:319: build-espressif_saola_1_wrover/firmware.elf] Error 1
```