### PR TITLE
Replace _bleio.ConnectionError with the native version

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/__init__.c
+++ b/devices/ble_hci/common-hal/_bleio/__init__.c
@@ -98,7 +98,7 @@ bleio_adapter_obj_t *common_hal_bleio_allocate_adapter_or_raise(void) {
 
 void common_hal_bleio_check_connected(uint16_t conn_handle) {
     if (conn_handle == BLE_CONN_HANDLE_INVALID) {
-        mp_raise_bleio_ConnectionError(translate("Not connected"));
+        mp_raise_ConnectionError(translate("Not connected"));
     }
 }
 

--- a/ports/nrf/common-hal/_bleio/__init__.c
+++ b/ports/nrf/common-hal/_bleio/__init__.c
@@ -50,7 +50,7 @@ void check_nrf_error(uint32_t err_code) {
             mp_raise_msg(&mp_type_TimeoutError, NULL);
             return;
         case BLE_ERROR_INVALID_CONN_HANDLE:
-            mp_raise_bleio_ConnectionError(translate("Not connected"));
+            mp_raise_ConnectionError(translate("Not connected"));
             return;
         default:
             mp_raise_bleio_BluetoothError(translate("Unknown soft device error: %04x"), err_code);
@@ -115,7 +115,7 @@ bleio_adapter_obj_t common_hal_bleio_adapter_obj = {
 
 void common_hal_bleio_check_connected(uint16_t conn_handle) {
     if (conn_handle == BLE_CONN_HANDLE_INVALID) {
-        mp_raise_bleio_ConnectionError(translate("Not connected"));
+        mp_raise_ConnectionError(translate("Not connected"));
     }
 }
 

--- a/shared-bindings/_bleio/CharacteristicBuffer.c
+++ b/shared-bindings/_bleio/CharacteristicBuffer.c
@@ -37,7 +37,7 @@
 
 STATIC void raise_error_if_not_connected(bleio_characteristic_buffer_obj_t *self) {
     if (!common_hal_bleio_characteristic_buffer_connected(self)) {
-        mp_raise_bleio_ConnectionError(translate("Not connected"));
+        mp_raise_ConnectionError(translate("Not connected"));
     }
 }
 

--- a/shared-bindings/_bleio/Connection.c
+++ b/shared-bindings/_bleio/Connection.c
@@ -63,7 +63,7 @@
 
 void bleio_connection_ensure_connected(bleio_connection_obj_t *self) {
     if (!common_hal_bleio_connection_get_connected(self)) {
-        mp_raise_bleio_ConnectionError(translate("Connection has been disconnected and can no longer be used. Create a new connection."));
+        mp_raise_ConnectionError(translate("Connection has been disconnected and can no longer be used. Create a new connection."));
     }
 }
 

--- a/shared-bindings/_bleio/PacketBuffer.c
+++ b/shared-bindings/_bleio/PacketBuffer.c
@@ -161,7 +161,7 @@ STATIC mp_obj_t bleio_packet_buffer_write(mp_uint_t n_args, const mp_obj_t *pos_
         // gatts write events, which may not have been sent yet.
         //
         // IDEAL:
-        // mp_raise_bleio_ConnectionError(translate("Not connected"));
+        // mp_raise_ConnectionError(translate("Not connected"));
         // TEMPORARY:
         num_bytes_written = 0;
     }

--- a/shared-bindings/_bleio/__init__.c
+++ b/shared-bindings/_bleio/__init__.c
@@ -63,23 +63,10 @@
 //|     """Catchall exception for Bluetooth related errors."""
 //|     ...
 MP_DEFINE_BLEIO_EXCEPTION(BluetoothError, Exception)
-
 NORETURN void mp_raise_bleio_BluetoothError(const compressed_string_t* fmt, ...) {
     va_list argptr;
     va_start(argptr,fmt);
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_bleio_BluetoothError, fmt, argptr);
-    va_end(argptr);
-    nlr_raise(exception);
-}
-//| class ConnectionError(BluetoothError):
-//|     """Raised when a connection is unavailable."""
-//|     ...
-//|
-MP_DEFINE_BLEIO_EXCEPTION(ConnectionError, bleio_BluetoothError)
-NORETURN void mp_raise_bleio_ConnectionError(const compressed_string_t* fmt, ...) {
-    va_list argptr;
-    va_start(argptr,fmt);
-    mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_bleio_ConnectionError, fmt, argptr);
     va_end(argptr);
     nlr_raise(exception);
 }
@@ -93,6 +80,7 @@ MP_DEFINE_BLEIO_EXCEPTION(RoleError, bleio_BluetoothError)
 NORETURN void mp_raise_bleio_RoleError(const compressed_string_t* msg) {
     mp_raise_msg(&mp_type_bleio_RoleError, msg);
 }
+
 //| class SecurityError(BluetoothError):
 //|     """Raised when a security related error occurs."""
 //|     ...
@@ -183,7 +171,6 @@ STATIC const mp_rom_map_elem_t bleio_module_globals_table[] = {
 
     // Errors
     { MP_ROM_QSTR(MP_QSTR_BluetoothError),       OBJ_FROM_PTR(&mp_type_bleio_BluetoothError) },
-    { MP_ROM_QSTR(MP_QSTR_ConnectionError),      OBJ_FROM_PTR(&mp_type_bleio_ConnectionError) },
     { MP_ROM_QSTR(MP_QSTR_RoleError),            OBJ_FROM_PTR(&mp_type_bleio_RoleError) },
     { MP_ROM_QSTR(MP_QSTR_SecurityError),        OBJ_FROM_PTR(&mp_type_bleio_SecurityError) },
 

--- a/shared-bindings/_bleio/__init__.h
+++ b/shared-bindings/_bleio/__init__.h
@@ -51,14 +51,12 @@ const mp_obj_type_t mp_type_bleio_ ## exc_name = { \
 };
 
 extern const mp_obj_type_t mp_type_bleio_BluetoothError;
-extern const mp_obj_type_t mp_type_bleio_ConnectionError;
 extern const mp_obj_type_t mp_type_bleio_RoleError;
 extern const mp_obj_type_t mp_type_bleio_SecurityError;
 
 extern mp_obj_t bleio_set_adapter(mp_obj_t adapter_obj);
 
 NORETURN void mp_raise_bleio_BluetoothError(const compressed_string_t* msg, ...);
-NORETURN void mp_raise_bleio_ConnectionError(const compressed_string_t* msg, ...);
 NORETURN void mp_raise_bleio_RoleError(const compressed_string_t* msg);
 NORETURN void mp_raise_bleio_SecurityError(const compressed_string_t* msg, ...);
 


### PR DESCRIPTION
Replace uses of _bleio.ConnectionError with regular ConnectionError

Fixes #3008