### PR TITLE
Fix #3504: Don't use time module in pew.tick()

### DIFF
--- a/ports/atmel-samd/common-hal/_pew/PewPew.c
+++ b/ports/atmel-samd/common-hal/_pew/PewPew.c
@@ -40,6 +40,7 @@
 
 
 static uint8_t pewpew_tc_index = 0xff;
+static volatile uint16_t pewpew_ticks = 0;
 
 
 void pewpew_interrupt_handler(uint8_t index) {
@@ -52,6 +53,7 @@ void pewpew_interrupt_handler(uint8_t index) {
     }
 
     pew_tick();
+    ++pewpew_ticks;
 
     // Clear the interrupt bit.
     tc->COUNT16.INTFLAG.reg = TC_INTFLAG_MC0;
@@ -123,3 +125,8 @@ void pew_reset(void) {
     }
     MP_STATE_VM(pew_singleton) = NULL;
 }
+
+uint16_t pew_get_ticks() {
+    return pewpew_ticks;
+}
+

--- a/ports/atmel-samd/common-hal/_pew/PewPew.c
+++ b/ports/atmel-samd/common-hal/_pew/PewPew.c
@@ -129,4 +129,3 @@ void pew_reset(void) {
 uint16_t pew_get_ticks() {
     return pewpew_ticks;
 }
-

--- a/ports/atmel-samd/common-hal/_pew/PewPew.h
+++ b/ports/atmel-samd/common-hal/_pew/PewPew.h
@@ -44,5 +44,6 @@ typedef struct {
 void pew_init(void);
 void pewpew_interrupt_handler(uint8_t index);
 void pew_reset(void);
+uint16_t pew_get_ticks(void);
 
 #endif  // MICROPY_INCLUDED_PEW_PEWPEW_H

--- a/shared-bindings/_pew/__init__.c
+++ b/shared-bindings/_pew/__init__.c
@@ -29,6 +29,7 @@
 #include "PewPew.h"
 #include "common-hal/_pew/PewPew.h"
 
+
 STATIC mp_obj_t get_pressed(void) {
     pew_obj_t *pew = MP_STATE_VM(pew_singleton);
     if (!pew) {
@@ -41,12 +42,19 @@ STATIC mp_obj_t get_pressed(void) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(get_pressed_obj, get_pressed);
 
 
+STATIC mp_obj_t get_ticks(void) {
+    return mp_obj_new_int(pew_get_ticks());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(get_ticks_obj, get_ticks);
+
+
 //| """LED matrix driver"""
 //|
 STATIC const mp_rom_map_elem_t pew_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR__pew) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_PewPew),  MP_ROM_PTR(&pewpew_type)},
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_pressed),  MP_ROM_PTR(&get_pressed_obj)},
+    { MP_OBJ_NEW_QSTR(MP_QSTR_get_ticks),  MP_ROM_PTR(&get_ticks_obj)},
 };
 STATIC MP_DEFINE_CONST_DICT(pew_module_globals,
         pew_module_globals_table);


### PR DESCRIPTION
The time.sleep() and time.monotonic() functions break the timer
interrupt on which PewPew10 display relies, so we can't use them
anymore. Instead I'm adding a time-keeping function to the display
code itself, which then can be used in pew.tick() internally.