### PR TITLE
rgbmatrix: update protomatter to 1.0.5 tag

### DIFF
--- a/py/circuitpy_defns.mk
+++ b/py/circuitpy_defns.mk
@@ -528,10 +528,10 @@ SRC_MOD += $(addprefix lib/mp3/src/, \
 $(BUILD)/lib/mp3/src/buffers.o: CFLAGS += -include "py/misc.h" -D'MPDEC_ALLOCATOR(x)=m_malloc(x,0)' -D'MPDEC_FREE(x)=m_free(x)'
 endif
 ifeq ($(CIRCUITPY_RGBMATRIX),1)
-SRC_MOD += $(addprefix lib/protomatter/, \
+SRC_MOD += $(addprefix lib/protomatter/src/, \
 	core.c \
 )
-$(BUILD)/lib/protomatter/core.o: CFLAGS += -include "shared-module/rgbmatrix/allocator.h" -DCIRCUITPY -Wno-missing-braces
+$(BUILD)/lib/protomatter/src/core.o: CFLAGS += -include "shared-module/rgbmatrix/allocator.h" -DCIRCUITPY -Wno-missing-braces
 endif
 
 # All possible sources are listed here, and are filtered by SRC_PATTERNS.

--- a/shared-bindings/rgbmatrix/RGBMatrix.h
+++ b/shared-bindings/rgbmatrix/RGBMatrix.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include "shared-module/rgbmatrix/RGBMatrix.h"
-#include "lib/protomatter/core.h"
+#include "lib/protomatter/src/core.h"
 
 extern const mp_obj_type_t rgbmatrix_RGBMatrix_type;
 

--- a/shared-module/rgbmatrix/RGBMatrix.c
+++ b/shared-module/rgbmatrix/RGBMatrix.c
@@ -78,10 +78,10 @@ void common_hal_rgbmatrix_rgbmatrix_reconstruct(rgbmatrix_rgbmatrix_obj_t* self,
         // verify that the matrix is big enough
         mp_get_index(mp_obj_get_type(self->framebuffer), self->bufinfo.len, MP_OBJ_NEW_SMALL_INT(self->bufsize-1), false);
     } else {
-        _PM_FREE(self->bufinfo.buf);
-        _PM_FREE(self->protomatter.rgbPins);
-        _PM_FREE(self->protomatter.addr);
-        _PM_FREE(self->protomatter.screenData);
+        _PM_free(self->bufinfo.buf);
+        _PM_free(self->protomatter.rgbPins);
+        _PM_free(self->protomatter.addr);
+        _PM_free(self->protomatter.screenData);
 
         self->framebuffer = NULL;
         self->bufinfo.buf = common_hal_rgbmatrix_allocator_impl(self->bufsize);
@@ -164,13 +164,13 @@ void common_hal_rgbmatrix_rgbmatrix_deinit(rgbmatrix_rgbmatrix_obj_t* self) {
     free_pin(&self->oe_pin);
 
     if (self->protomatter.rgbPins) {
-        _PM_free(&self->protomatter);
+        _PM_deallocate(&self->protomatter);
     }
     memset(&self->protomatter, 0, sizeof(self->protomatter));
 
     // If it was supervisor-allocated, it is supervisor-freed and the pointer
     // is zeroed, otherwise the pointer is just zeroed
-    _PM_FREE(self->bufinfo.buf);
+    _PM_free(self->bufinfo.buf);
     self->base.type = NULL;
 
     // If a framebuffer was passed in to the constructor, NULL the reference

--- a/shared-module/rgbmatrix/RGBMatrix.h
+++ b/shared-module/rgbmatrix/RGBMatrix.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "lib/protomatter/core.h"
+#include "lib/protomatter/src/core.h"
 
 extern const mp_obj_type_t rgbmatrix_RGBMatrix_type;
 typedef struct {

--- a/shared-module/rgbmatrix/allocator.h
+++ b/shared-module/rgbmatrix/allocator.h
@@ -31,7 +31,7 @@
 #include "py/misc.h"
 #include "supervisor/memory.h"
 
-#define _PM_ALLOCATOR common_hal_rgbmatrix_allocator_impl
-#define _PM_FREE(x) (common_hal_rgbmatrix_free_impl((x)), (x)=NULL, (void)0)
+#define _PM_allocate common_hal_rgbmatrix_allocator_impl
+#define _PM_free(x) (common_hal_rgbmatrix_free_impl((x)), (x)=NULL, (void)0)
 extern void *common_hal_rgbmatrix_allocator_impl(size_t sz);
 extern void common_hal_rgbmatrix_free_impl(void *);


### PR DESCRIPTION
this is tested on
 * stm32f405 feather
 * matrixportal
 * nrf52840 feather
which covers all of the supported microcontroller families.