### PR TITLE
build: parallelize the qstr build steps

### DIFF
--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -269,7 +269,7 @@ menuconfig: $(BUILD)/esp-idf/config
 	$(Q)grep -Fvxf $(DEBUG_SDKCONFIG) -f $(FLASH_SDKCONFIG) $(BUILD)/sdkconfig.diff > boards/$(BOARD)/sdkconfig
 
 # qstr builds include headers so we need to make sure they are up to date
-$(HEADER_BUILD)/qstr.i.last: | $(BUILD)/esp-idf/config/sdkconfig.h
+$(HEADER_BUILD)/qstr.split: | $(BUILD)/esp-idf/config/sdkconfig.h
 
 ESP_IDF_COMPONENTS_LINK = freertos log hal esp_system esp_adc_cal esp32s2 bootloader_support pthread esp_timer vfs spi_flash app_update esp_common esp32s2 heap newlib driver xtensa soc esp_ringbuf esp_wifi esp_event wpa_supplicant mbedtls efuse nvs_flash esp_netif lwip esp_rom esp-tls
 

--- a/py/genlast.py
+++ b/py/genlast.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import sys
+from concurrent.futures import ThreadPoolExecutor
+import multiprocessing
+import threading
+import subprocess
+
+
+def checkoutput1(args):
+    info = subprocess.run(args, check=True, stdout=subprocess.PIPE, input='')
+    return info.stdout
+
+idx1 = sys.argv.index('--')
+idx2 = sys.argv.index('--', idx1+1)
+check = sys.argv[1:idx1]
+always = sys.argv[idx1+1:idx2]
+command = sys.argv[idx2+1:]
+
+output_lock = threading.Lock()
+def preprocess(fn):
+    output = checkoutput1(command + [fn])
+    # Ensure our output doesn't interleave with others
+    # a threading.Lock is not a context manager object :(
+    try:
+        output_lock.acquire()
+        sys.stdout.buffer.write(output)
+    finally:
+        output_lock.release()
+
+def maybe_preprocess(fn):
+    if subprocess.call(["grep", "-lqE", "(MP_QSTR|translate)", fn]) == 0:
+        preprocess(fn)
+
+executor = ThreadPoolExecutor(max_workers=multiprocessing.cpu_count() + 1)
+executor.map(maybe_preprocess, check)
+executor.map(preprocess, always)
+executor.shutdown()

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -76,18 +76,14 @@ $(OBJ): | $(HEADER_BUILD)/qstrdefs.enum.h $(HEADER_BUILD)/mpversion.h
 # - if anything in QSTR_GLOBAL_DEPENDENCIES is newer, then process all source files ($^)
 # - else, if list of newer prerequisites ($?) is not empty, then process just these ($?)
 # - else, process all source files ($^) [this covers "make -B" which can set $? to empty]
-$(HEADER_BUILD)/qstr.i.last: $(SRC_QSTR) $(SRC_QSTR_PREPROCESSOR) $(QSTR_GLOBAL_DEPENDENCIES) | $(HEADER_BUILD)/mpversion.h
+$(HEADER_BUILD)/qstr.split: $(SRC_QSTR) $(SRC_QSTR_PREPROCESSOR) $(QSTR_GLOBAL_DEPENDENCIES) | $(HEADER_BUILD)/mpversion.h $(PY_SRC)/genlast.py
 	$(STEPECHO) "GEN $@"
-	$(Q)$(PYTHON3) $(PY_SRC)/genlast.py $(if $(filter $?,$(QSTR_GLOBAL_DEPENDENCIES)),$^,$(if $?,$?,$^)) --  $(SRC_QSTR_PREPROCESSOR) -- $(CPP) $(QSTR_GEN_EXTRA_CFLAGS) $(CFLAGS) >$(HEADER_BUILD)/qstr.i.last;
-
-$(HEADER_BUILD)/qstr.split: $(HEADER_BUILD)/qstr.i.last $(PY_SRC)/makeqstrdefs.py
-	$(STEPECHO) "GEN $@"
-	$(Q)$(PYTHON3) $(PY_SRC)/makeqstrdefs.py split $(HEADER_BUILD)/qstr.i.last $(HEADER_BUILD)/qstr $(QSTR_DEFS_COLLECTED)
+	$(Q)$(PYTHON3) $(PY_SRC)/genlast.py $(HEADER_BUILD)/qstr $(if $(filter $?,$(QSTR_GLOBAL_DEPENDENCIES)),$^,$(if $?,$?,$^)) --  $(SRC_QSTR_PREPROCESSOR) -- $(CPP) $(QSTR_GEN_EXTRA_CFLAGS) $(CFLAGS)
 	$(Q)touch $@
 
 $(QSTR_DEFS_COLLECTED): $(HEADER_BUILD)/qstr.split $(PY_SRC)/makeqstrdefs.py
 	$(STEPECHO) "GEN $@"
-	$(Q)$(PYTHON3) $(PY_SRC)/makeqstrdefs.py cat $(HEADER_BUILD)/qstr.i.last $(HEADER_BUILD)/qstr $(QSTR_DEFS_COLLECTED)
+	$(Q)$(PYTHON3) $(PY_SRC)/makeqstrdefs.py cat - $(HEADER_BUILD)/qstr $(QSTR_DEFS_COLLECTED)
 
 # $(sort $(var)) removes duplicates
 #

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -78,7 +78,7 @@ $(OBJ): | $(HEADER_BUILD)/qstrdefs.enum.h $(HEADER_BUILD)/mpversion.h
 # - else, process all source files ($^) [this covers "make -B" which can set $? to empty]
 $(HEADER_BUILD)/qstr.i.last: $(SRC_QSTR) $(SRC_QSTR_PREPROCESSOR) $(QSTR_GLOBAL_DEPENDENCIES) | $(HEADER_BUILD)/mpversion.h
 	$(STEPECHO) "GEN $@"
-	$(Q)grep -lE "(MP_QSTR|translate)" $(if $(filter $?,$(QSTR_GLOBAL_DEPENDENCIES)),$^,$(if $?,$?,$^)) | xargs $(CPP) $(QSTR_GEN_EXTRA_CFLAGS) $(CFLAGS) $(SRC_QSTR_PREPROCESSOR) >$(HEADER_BUILD)/qstr.i.last;
+	$(Q)$(PYTHON3) $(PY_SRC)/genlast.py $(if $(filter $?,$(QSTR_GLOBAL_DEPENDENCIES)),$^,$(if $?,$?,$^)) --  $(SRC_QSTR_PREPROCESSOR) -- $(CPP) $(QSTR_GEN_EXTRA_CFLAGS) $(CFLAGS) >$(HEADER_BUILD)/qstr.i.last;
 
 $(HEADER_BUILD)/qstr.split: $(HEADER_BUILD)/qstr.i.last $(PY_SRC)/makeqstrdefs.py
 	$(STEPECHO) "GEN $@"


### PR DESCRIPTION
The generation of "qstr defs" involves running the C preprocessor on a selection of source files, extracting pattern matches from them, and writing them out into a single output file.  Then, a second sequential step reads all that output to produce individual "qstr" files.  Especially with a non-lto build on a powerful desktop computer, these sequential steps actually have a pretty large effect on the overall build time.

The improvements came in two discrete steps; refer to the individual commit messages for a clearer view.
 * The first commit parallelizes the generation of qstr.i.last.  It is the larger timesaver.
 * The second commit eliminates qstr.i.last, and pulls the steps of "makeqstrdefs.py split" into "genlast.py", also parallelizing the regular expression search.  It is a smaller timesaver, but still important.

I tested by repeatedly building the feather stm32f405 on my 8 core / 16-thread Ryzen.  Before, a build took about 16s.  After, a build took about 9.5s.  This is elapsed time; CPU time was about 1m12s before and 1m13s after.