### PR TITLE
atmel-samd: parallelize lto linking

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -121,7 +121,7 @@ $(echo PERIPHERALS_CHIP_FAMILY=$(PERIPHERALS_CHIP_FAMILY))
 ifeq ($(DEBUG), 1)
   CFLAGS += -ggdb3 -Og
   # You may want to disable -flto if it interferes with debugging.
-  CFLAGS += -flto -flto-partition=none
+  CFLAGS += -flto
   # You may want to enable these flags to make setting breakpoints easier.
   # CFLAGS += -fno-inline -fno-ipa-sra
   ifeq ($(CHIP_FAMILY), samd21)
@@ -144,7 +144,7 @@ else
     CFLAGS += -finline-limit=$(CFLAGS_INLINE_LIMIT)
   endif
 
-  CFLAGS += -flto -flto-partition=none
+  CFLAGS += -flto
 
   ifeq ($(CIRCUITPY_FULL_BUILD),0)
     CFLAGS += --param inline-unit-growth=15 --param max-inline-insns-auto=20
@@ -197,6 +197,7 @@ endif
 
 
 LDFLAGS = $(CFLAGS) -nostartfiles -Wl,-nostdlib -Wl,-T,$(GENERATED_LD_FILE) -Wl,-Map=$@.map -Wl,-cref -Wl,-gc-sections -specs=nano.specs
+LDFLAGS += -flto=$(shell nproc)
 LIBS := -lgcc -lc
 
 # Use toolchain libm if we're not using our own.

--- a/ports/atmel-samd/boards/sparkfun_lumidrive/mpconfigboard.h
+++ b/ports/atmel-samd/boards/sparkfun_lumidrive/mpconfigboard.h
@@ -35,9 +35,6 @@
 #define IGNORE_PIN_PA12     1
 #define IGNORE_PIN_PA15     1
 #define IGNORE_PIN_PA16     1
-#define IGNORE_PIN_PA21     1
-#define IGNORE_PIN_PA22     1
-#define IGNORE_PIN_PA23     1
 #define IGNORE_PIN_PA27     1
 #define IGNORE_PIN_PA28     1
 

--- a/ports/atmel-samd/common-hal/microcontroller/Pin.c
+++ b/ports/atmel-samd/common-hal/microcontroller/Pin.c
@@ -223,9 +223,11 @@ bool common_hal_mcu_pin_is_free(const mcu_pin_obj_t* pin) {
     #ifdef MICROPY_HW_NEOPIXEL
     if (pin == MICROPY_HW_NEOPIXEL) {
         // Special case for Metro M0 where the NeoPixel is also SWCLK
+#ifndef IGNORE_PIN_PA30
         if (MICROPY_HW_NEOPIXEL == &pin_PA30 && DSU->STATUSB.bit.DBGPRES == 1) {
             return false;
         }
+#endif
         return !neopixel_in_use;
     }
     #endif

--- a/ports/atmel-samd/common-hal/microcontroller/__init__.c
+++ b/ports/atmel-samd/common-hal/microcontroller/__init__.c
@@ -275,120 +275,119 @@ STATIC const mp_rom_map_elem_t mcu_pin_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_PB31), MP_ROM_PTR(&pin_PB31) },
 #endif
 
-// These are SAMD51 specific so we assume we want them in RAM
-#if defined(PIN_PC00)
+#if defined(PIN_PC00) && !defined(IGNORE_PIN_PC00)
     { MP_ROM_QSTR(MP_QSTR_PC00), MP_ROM_PTR(&pin_PC00) },
 #endif
-#if defined(PIN_PC01)
+#if defined(PIN_PC01) && !defined(IGNORE_PIN_PC01)
     { MP_ROM_QSTR(MP_QSTR_PC01), MP_ROM_PTR(&pin_PC01) },
 #endif
-#if defined(PIN_PC02)
+#if defined(PIN_PC02) && !defined(IGNORE_PIN_PC02)
     { MP_ROM_QSTR(MP_QSTR_PC02), MP_ROM_PTR(&pin_PC02) },
 #endif
-#if defined(PIN_PC03)
+#if defined(PIN_PC03) && !defined(IGNORE_PIN_PC03)
     { MP_ROM_QSTR(MP_QSTR_PC03), MP_ROM_PTR(&pin_PC03) },
 #endif
-#if defined(PIN_PC04)
+#if defined(PIN_PC04) && !defined(IGNORE_PIN_PC04)
     { MP_ROM_QSTR(MP_QSTR_PC04), MP_ROM_PTR(&pin_PC04) },
 #endif
-#if defined(PIN_PC05)
+#if defined(PIN_PC05) && !defined(IGNORE_PIN_PC05)
     { MP_ROM_QSTR(MP_QSTR_PC05), MP_ROM_PTR(&pin_PC05) },
 #endif
-#if defined(PIN_PC06)
+#if defined(PIN_PC06) && !defined(IGNORE_PIN_PC06)
     { MP_ROM_QSTR(MP_QSTR_PC06), MP_ROM_PTR(&pin_PC06) },
 #endif
-#if defined(PIN_PC07)
+#if defined(PIN_PC07) && !defined(IGNORE_PIN_PC07)
     { MP_ROM_QSTR(MP_QSTR_PC07), MP_ROM_PTR(&pin_PC07) },
 #endif
-#if defined(PIN_PC10)
+#if defined(PIN_PC10) && !defined(IGNORE_PIN_PC10)
     { MP_ROM_QSTR(MP_QSTR_PC10), MP_ROM_PTR(&pin_PC10) },
 #endif
-#if defined(PIN_PC11)
+#if defined(PIN_PC11) && !defined(IGNORE_PIN_PC11)
     { MP_ROM_QSTR(MP_QSTR_PC11), MP_ROM_PTR(&pin_PC11) },
 #endif
-#if defined(PIN_PC12)
+#if defined(PIN_PC12) && !defined(IGNORE_PIN_PC12)
     { MP_ROM_QSTR(MP_QSTR_PC12), MP_ROM_PTR(&pin_PC12) },
 #endif
-#if defined(PIN_PC13)
+#if defined(PIN_PC13) && !defined(IGNORE_PIN_PC13)
     { MP_ROM_QSTR(MP_QSTR_PC13), MP_ROM_PTR(&pin_PC13) },
 #endif
-#if defined(PIN_PC14)
+#if defined(PIN_PC14) && !defined(IGNORE_PIN_PC14)
     { MP_ROM_QSTR(MP_QSTR_PC14), MP_ROM_PTR(&pin_PC14) },
 #endif
-#if defined(PIN_PC15)
+#if defined(PIN_PC15) && !defined(IGNORE_PIN_PC15)
     { MP_ROM_QSTR(MP_QSTR_PC15), MP_ROM_PTR(&pin_PC15) },
 #endif
-#if defined(PIN_PC16)
+#if defined(PIN_PC16) && !defined(IGNORE_PIN_PC16)
     { MP_ROM_QSTR(MP_QSTR_PC16), MP_ROM_PTR(&pin_PC16) },
 #endif
-#if defined(PIN_PC17)
+#if defined(PIN_PC17) && !defined(IGNORE_PIN_PC17)
     { MP_ROM_QSTR(MP_QSTR_PC17), MP_ROM_PTR(&pin_PC17) },
 #endif
-#if defined(PIN_PC18)
+#if defined(PIN_PC18) && !defined(IGNORE_PIN_PC18)
     { MP_ROM_QSTR(MP_QSTR_PC18), MP_ROM_PTR(&pin_PC18) },
 #endif
-#if defined(PIN_PC19)
+#if defined(PIN_PC19) && !defined(IGNORE_PIN_PC19)
     { MP_ROM_QSTR(MP_QSTR_PC19), MP_ROM_PTR(&pin_PC19) },
 #endif
-#if defined(PIN_PC20)
+#if defined(PIN_PC20) && !defined(IGNORE_PIN_PC20)
     { MP_ROM_QSTR(MP_QSTR_PC20), MP_ROM_PTR(&pin_PC20) },
 #endif
-#if defined(PIN_PC21)
+#if defined(PIN_PC21) && !defined(IGNORE_PIN_PC21)
     { MP_ROM_QSTR(MP_QSTR_PC21), MP_ROM_PTR(&pin_PC21) },
 #endif
-#if defined(PIN_PC22)
+#if defined(PIN_PC22) && !defined(IGNORE_PIN_PC22)
     { MP_ROM_QSTR(MP_QSTR_PC22), MP_ROM_PTR(&pin_PC22) },
 #endif
-#if defined(PIN_PC23)
+#if defined(PIN_PC23) && !defined(IGNORE_PIN_PC23)
     { MP_ROM_QSTR(MP_QSTR_PC23), MP_ROM_PTR(&pin_PC23) },
 #endif
-#if defined(PIN_PC24)
+#if defined(PIN_PC24) && !defined(IGNORE_PIN_PC24)
     { MP_ROM_QSTR(MP_QSTR_PC24), MP_ROM_PTR(&pin_PC24) },
 #endif
-#if defined(PIN_PC25)
+#if defined(PIN_PC25) && !defined(IGNORE_PIN_PC25)
     { MP_ROM_QSTR(MP_QSTR_PC25), MP_ROM_PTR(&pin_PC25) },
 #endif
-#if defined(PIN_PC26)
+#if defined(PIN_PC26) && !defined(IGNORE_PIN_PC26)
     { MP_ROM_QSTR(MP_QSTR_PC26), MP_ROM_PTR(&pin_PC26) },
 #endif
-#if defined(PIN_PC27)
+#if defined(PIN_PC27) && !defined(IGNORE_PIN_PC27)
     { MP_ROM_QSTR(MP_QSTR_PC27), MP_ROM_PTR(&pin_PC27) },
 #endif
-#if defined(PIN_PC28)
+#if defined(PIN_PC28) && !defined(IGNORE_PIN_PC28)
     { MP_ROM_QSTR(MP_QSTR_PC28), MP_ROM_PTR(&pin_PC28) },
 #endif
-#if defined(PIN_PC30)
+#if defined(PIN_PC30) && !defined(IGNORE_PIN_PC30)
     { MP_ROM_QSTR(MP_QSTR_PC30), MP_ROM_PTR(&pin_PC30) },
 #endif
-#if defined(PIN_PC31)
+#if defined(PIN_PC31) && !defined(IGNORE_PIN_PC31)
     { MP_ROM_QSTR(MP_QSTR_PC31), MP_ROM_PTR(&pin_PC31) },
 #endif
 
-#if defined(PIN_PD00)
+#if defined(PIN_PD00) && !defined(IGNORE_PIN_PD00)
     { MP_ROM_QSTR(MP_QSTR_PD00), MP_ROM_PTR(&pin_PD00) },
 #endif
-#if defined(PIN_PD01)
+#if defined(PIN_PD01) && !defined(IGNORE_PIN_PD01)
     { MP_ROM_QSTR(MP_QSTR_PD01), MP_ROM_PTR(&pin_PD01) },
 #endif
-#if defined(PIN_PD08)
+#if defined(PIN_PD08) && !defined(IGNORE_PIN_PD08)
     { MP_ROM_QSTR(MP_QSTR_PD08), MP_ROM_PTR(&pin_PD08) },
 #endif
-#if defined(PIN_PD09)
+#if defined(PIN_PD09) && !defined(IGNORE_PIN_PD09)
     { MP_ROM_QSTR(MP_QSTR_PD09), MP_ROM_PTR(&pin_PD09) },
 #endif
-#if defined(PIN_PD10)
+#if defined(PIN_PD10) && !defined(IGNORE_PIN_PD10)
     { MP_ROM_QSTR(MP_QSTR_PD10), MP_ROM_PTR(&pin_PD10) },
 #endif
-#if defined(PIN_PD11)
+#if defined(PIN_PD11) && !defined(IGNORE_PIN_PD11)
     { MP_ROM_QSTR(MP_QSTR_PD11), MP_ROM_PTR(&pin_PD11) },
 #endif
-#if defined(PIN_PD12)
+#if defined(PIN_PD12) && !defined(IGNORE_PIN_PD12)
     { MP_ROM_QSTR(MP_QSTR_PD12), MP_ROM_PTR(&pin_PD12) },
 #endif
-#if defined(PIN_PD20)
+#if defined(PIN_PD20) && !defined(IGNORE_PIN_PD20)
     { MP_ROM_QSTR(MP_QSTR_PD20), MP_ROM_PTR(&pin_PD20) },
 #endif
-#if defined(PIN_PD21)
+#if defined(PIN_PD21) && !defined(IGNORE_PIN_PD21)
     { MP_ROM_QSTR(MP_QSTR_PD21), MP_ROM_PTR(&pin_PD21) },
 #endif
 };


### PR DESCRIPTION
This decreases the link time, especially on desktop machines with many CPU
cores.  However, it does come at a slight cost in binary size, making the flash
section about 200 bytes bigger for circuitplayground_express.

Before, linking build-circuitplayground_express/firmware.elf takes
8.8s elapsed time, leaving 3128 bytes free in flash.

After, linking build-circuitplayground_express/firmware.elf takes 2.8s elapsed
time, leaving 2924 bytes free in flash. (-6 seconds, -204 bytes free)

If necessary, we can make this per-board or even per-translation to squeeze full
builds.