### PR TITLE
displayio, framebufferio: Remove spurious call to supervisor_start_terminal

### DIFF
--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -107,8 +107,6 @@ void common_hal_displayio_display_construct(displayio_display_obj_t* self,
         i += 2 + data_size;
     }
 
-    supervisor_start_terminal(width, height);
-
     // Always set the backlight type in case we're reusing memory.
     self->backlight_inout.base.type = &mp_type_NoneType;
     if (backlight_pin != NULL && common_hal_mcu_pin_is_free(backlight_pin)) {

--- a/shared-module/displayio/EPaperDisplay.c
+++ b/shared-module/displayio/EPaperDisplay.c
@@ -90,8 +90,6 @@ void common_hal_displayio_epaperdisplay_construct(displayio_epaperdisplay_obj_t*
         // TODO: Clear
     }
 
-    supervisor_start_terminal(width, height);
-
     // Set the group after initialization otherwise we may send pixels while we delay in
     // initialization.
     common_hal_displayio_epaperdisplay_show(self, &circuitpython_splash);

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -96,8 +96,6 @@ void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebu
         common_hal_framebufferio_framebufferdisplay_set_rotation(self, rotation);
     }
 
-    supervisor_start_terminal(self->core.width, self->core.height);
-
     // Set the group after initialization otherwise we may send pixels while we delay in
     // initialization.
     common_hal_framebufferio_framebufferdisplay_show(self, &circuitpython_splash);


### PR DESCRIPTION
A call to supervisor_start_terminal remained in
common_hal_displayio_display_construct and was copied to other display
_construct functions, even though it was also being done in
displayio_display_core_construct when that was factored out.

Originally, this was harmless, except it created an extra allocation.
When investigating #3482, I found that this bug became harmful,
especially for displays that were created in Python code, because it
caused a supervisor allocation to leak.

I believe that it is safe to merge #3482 after this PR is merged.

Testing done: Sharp memory display on nRF52840 works properly after this change