### PR TITLE
displayio: further ensure just one start_terminal call

### DIFF
--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -347,8 +347,10 @@ void common_hal_displayio_display_set_rotation(displayio_display_obj_t* self, in
         self->core.height = tmp;
     }
     displayio_display_core_set_rotation(&self->core, rotation);
-    supervisor_stop_terminal();
-    supervisor_start_terminal(self->core.width, self->core.height);
+    if (self == &displays[0].display) {
+        supervisor_stop_terminal();
+        supervisor_start_terminal(self->core.width, self->core.height);
+    }
     if (self->core.current_group != NULL) {
         displayio_group_update_transform(self->core.current_group, &self->core.transform);
     }

--- a/shared-module/displayio/display_core.c
+++ b/shared-module/displayio/display_core.c
@@ -85,7 +85,10 @@ void displayio_display_core_construct(displayio_display_core_t* self,
     self->bus = bus;
 
 
-    supervisor_start_terminal(width, height);
+    // (offsetof core is equal in all display types)
+    if (self == &displays[0].display.core) {
+        supervisor_start_terminal(width, height);
+    }
 
     self->width = width;
     self->height = height;

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -280,8 +280,10 @@ void common_hal_framebufferio_framebufferdisplay_set_rotation(framebufferio_fram
         self->core.height = tmp;
     }
     displayio_display_core_set_rotation(&self->core, rotation);
-    supervisor_stop_terminal();
-    supervisor_start_terminal(self->core.width, self->core.height);
+    if (self == &displays[0].framebuffer_display) {
+        supervisor_stop_terminal();
+        supervisor_start_terminal(self->core.width, self->core.height);
+    }
     if (self->core.current_group != NULL) {
         displayio_group_update_transform(self->core.current_group, &self->core.transform);
     }


### PR DESCRIPTION
@cwalther determined that for boards with 2 displays (monster m4sk), start_terminal would be called for each one, leaking supervisor heap entries.

Determine, by comparing addresses, whether the display being acted on is the first display (number zero) and do (or do not) call start_terminal.

stop_terminal can safely be called multiple times, so there's no need to guard against calling it more than once.

Slight behavioral change: The terminal size would follow the displays[0] size, not the displays[1] size

Testing performed: none