### PR TITLE
Correct pins to not reset.

### DIFF
--- a/ports/atmel-samd/boards/matrixportal_m4/mpconfigboard.h
+++ b/ports/atmel-samd/boards/matrixportal_m4/mpconfigboard.h
@@ -9,7 +9,7 @@
 
 // These are pins not to reset.
 // QSPI Data pins, PA23 is NeoPixel
-#define MICROPY_PORT_A (PORT_PA08 | PORT_PA09 | PORT_PA10 | PORT_PA11 | PA23)
+#define MICROPY_PORT_A (PORT_PA08 | PORT_PA09 | PORT_PA10 | PORT_PA11 | PORT_PA23)
 // QSPI CS, QSPI SCK
 #define MICROPY_PORT_B (PORT_PB10 | PORT_PB11)
 #define MICROPY_PORT_C (0)


### PR DESCRIPTION
They must have the PORT_ prefix otherwise they mask the wrong pins.

Fixes #3552

PRing to 6.0.x and then will merge from 6.0.x into main.