### PR TITLE
Fix missing `nproc` on macOS

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -197,7 +197,7 @@ endif
 
 
 LDFLAGS = $(CFLAGS) -nostartfiles -Wl,-nostdlib -Wl,-T,$(GENERATED_LD_FILE) -Wl,-Map=$@.map -Wl,-cref -Wl,-gc-sections -specs=nano.specs
-LDFLAGS += -flto=$(shell nproc)
+LDFLAGS += -flto=$(shell $(NPROC))
 LIBS := -lgcc -lc
 
 # Use toolchain libm if we're not using our own.

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -55,6 +55,8 @@ PYTHON3 ?= python3
 RM = rm
 RSYNC = rsync
 SED = sed
+# Linux has 'nproc', macOS has 'sysctl -n hw.logicalcpu', this is cross-platform
+NPROC = $(PYTHON) -c 'import multiprocessing as mp; print(mp.cpu_count())'
 
 AS = $(CROSS_COMPILE)as
 CC = $(CROSS_COMPILE)gcc


### PR DESCRIPTION
#3541 (396979a67e538da087136ce01dbc4c7a670bf60e) breaks building on macOS, which doesn’t have an `nproc` command. That seems to be a Linux thing. The equivalent would be `sysctl -n hw.logicalcpu`, but since I can’t find any existing platform distinctions in the makefiles, I chose to call Python for a cross-platform solution. (Credits to https://stackoverflow.com/questions/1715580.)