### PR TITLE
build.yml: Fix building mpy-cross-mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
       run: echo "$GITHUB_CONTEXT"
     - name: Install dependencies
       run: |
-        brew install gettext awscli
+        brew install gettext
         echo >>$GITHUB_PATH /usr/local/opt/gettext/bin
     - name: Versions
       run: |


### PR DESCRIPTION
Recently, the macos-10.15 image was updated with a non-brew version of awscli.  This made our CI script, which does a `brew install awscli` fail:
```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/aws
Target /usr/local/bin/aws
already exists. You may want to remove it:
  rm '/usr/local/bin/aws'
```