### PR TITLE
ESP32S2: Reset sta_mode and ap_mode flags

### DIFF
--- a/ports/esp32s2/common-hal/wifi/__init__.c
+++ b/ports/esp32s2/common-hal/wifi/__init__.c
@@ -101,7 +101,7 @@ void common_hal_wifi_init(void) {
     self->netif = esp_netif_create_default_wifi_sta();
 
     // Even though we just called esp_netif_create_default_wifi_sta,
-    //   station mode isn't actually set until esp_wifi_set_mode()
+    //   station mode isn't actually ready for use until esp_wifi_set_mode()
     //   is called and the configuration is loaded via esp_wifi_set_config().
     // Set both convienence flags to false so it's not forgotten.
     self->sta_mode = 0;

--- a/ports/esp32s2/common-hal/wifi/__init__.c
+++ b/ports/esp32s2/common-hal/wifi/__init__.c
@@ -100,6 +100,13 @@ void common_hal_wifi_init(void) {
     wifi_radio_obj_t* self = &common_hal_wifi_radio_obj;
     self->netif = esp_netif_create_default_wifi_sta();
 
+    // Even though we just called esp_netif_create_default_wifi_sta,
+    //   station mode isn't actually set until esp_wifi_set_mode()
+    //   is called and the configuration is loaded via esp_wifi_set_config().
+    // Set both convienence flags to false so it's not forgotten.
+    self->sta_mode = 0;
+    self->ap_mode = 0;
+
     self->event_group_handle = xEventGroupCreateStatic(&self->event_group);
     ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT,
                                                         ESP_EVENT_ANY_ID,


### PR DESCRIPTION
Should close #3576.

I opted to set both ```ap_mode``` and ```sta_mode``` flags in ```common_hal_wifi_init``` to False just to start from a clean slate every time, since at that point things aren't properly configured for either mode anyways.  I think *technically* setting ```sta_mode``` to True might be legit after the call to ```esp_netif_create_default_wifi_sta``` but it's functionally not useful until after you load in the config so to me it seems debatable.  I at least added a comment to that effect as a reminder for the next brave soul mucking about in there.

These could be removed in favor of just using ```esp_wifi_get_mode``` and checking what comes back, but that requires an esp-idf call whereas it seems simple enough to just carry around the bool flags for now.  If things get more complicated in there it might be worth doing though.