### PR TITLE
Fix typo UART

### DIFF
--- a/locale/es.po
+++ b/locale/es.po
@@ -1826,15 +1826,15 @@ msgstr "No se pudo encontrar el búfer para UART"
 
 #: ports/stm/common-hal/busio/UART.c
 msgid "UART De-init error"
-msgstr "Error de desinicialización de UARL"
+msgstr "Error de desinicialización de UART"
 
 #: ports/stm/common-hal/busio/UART.c
 msgid "UART Init Error"
-msgstr "Error de inicialización de UARL"
+msgstr "Error de inicialización de UART"
 
 #: ports/stm/common-hal/busio/UART.c
 msgid "UART Re-init error"
-msgstr "Error de reinicialización de UARL"
+msgstr "Error de reinicialización de UART"
 
 #: ports/stm/common-hal/busio/UART.c
 msgid "UART write error"


### PR DESCRIPTION
Hi @tannewt 

This commit fix typo in spanish

Regards from CCOSS  México

<img width="996" alt="Captura de Pantalla 2020-10-22 a la(s) 16 15 53" src="https://user-images.githubusercontent.com/2874292/96930798-ecbbcf00-1481-11eb-8316-59173d607640.png">
