### PR TITLE
Fix lost board.SPI and board.I2C

### DIFF
--- a/main.c
+++ b/main.c
@@ -234,10 +234,12 @@ void cleanup_after_vm(supervisor_allocation* heap) {
     common_hal_canio_reset();
     #endif
 
-    reset_port();
+    // reset_board_busses() first because it may release pins from the never_reset state, so that
+    // reset_port() can reset them.
     #if CIRCUITPY_BOARD
     reset_board_busses();
     #endif
+    reset_port();
     reset_board();
     reset_status_led();
 }

--- a/shared-bindings/board/__init__.c
+++ b/shared-bindings/board/__init__.c
@@ -28,6 +28,12 @@
 #include "py/runtime.h"
 
 #include "shared-bindings/board/__init__.h"
+#if BOARD_I2C
+#include "shared-bindings/busio/I2C.h"
+#endif
+#if BOARD_SPI
+#include "shared-bindings/busio/SPI.h"
+#endif
 
 //| """Board specific pin names
 //|
@@ -45,7 +51,7 @@
 #if BOARD_I2C
 mp_obj_t board_i2c(void) {
     mp_obj_t singleton = common_hal_board_get_i2c();
-    if (singleton != NULL) {
+    if (singleton != NULL && !common_hal_busio_i2c_deinited(singleton)) {
         return singleton;
     }
     assert_pin_free(DEFAULT_I2C_BUS_SDA);
@@ -69,7 +75,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(board_i2c_obj, board_i2c);
 #if BOARD_SPI
 mp_obj_t board_spi(void) {
     mp_obj_t singleton = common_hal_board_get_spi();
-    if (singleton != NULL) {
+    if (singleton != NULL && !common_hal_busio_spi_deinited(singleton)) {
         return singleton;
     }
     assert_pin_free(DEFAULT_SPI_BUS_SCK);

--- a/shared-module/board/__init__.c
+++ b/shared-module/board/__init__.c
@@ -139,7 +139,7 @@ void reset_board_busses(void) {
     bool display_using_i2c = false;
     #if CIRCUITPY_DISPLAYIO
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
-        if (displays[i].i2cdisplay_bus.bus == i2c_singleton) {
+        if (displays[i].bus_base.type == &displayio_i2cdisplay_type && displays[i].i2cdisplay_bus.bus == i2c_singleton) {
             display_using_i2c = true;
             break;
         }

--- a/shared-module/board/__init__.c
+++ b/shared-module/board/__init__.c
@@ -145,8 +145,11 @@ void reset_board_busses(void) {
         }
     }
     #endif
-    if (!display_using_i2c) {
-        i2c_singleton = NULL;
+    if (i2c_singleton != NULL) {
+        if (!display_using_i2c) {
+            common_hal_busio_i2c_deinit(i2c_singleton);
+            i2c_singleton = NULL;
+        }
     }
 #endif
 #if BOARD_SPI
@@ -169,9 +172,10 @@ void reset_board_busses(void) {
     // make sure SPI lock is not held over a soft reset
     if (spi_singleton != NULL) {
         common_hal_busio_spi_unlock(spi_singleton);
-    }
-    if (!display_using_spi) {
-        spi_singleton = NULL;
+        if (!display_using_spi) {
+            common_hal_busio_spi_deinit(spi_singleton);
+            spi_singleton = NULL;
+        }
     }
 #endif
 #if BOARD_UART

--- a/shared-module/board/__init__.c
+++ b/shared-module/board/__init__.c
@@ -55,9 +55,8 @@ mp_obj_t common_hal_board_get_i2c(void) {
 }
 
 mp_obj_t common_hal_board_create_i2c(void) {
-    if (i2c_singleton != NULL) {
-        return i2c_singleton;
-    }
+    // All callers have either already verified this or come so early that it can't be otherwise.
+    assert(i2c_singleton == NULL || common_hal_busio_i2c_deinited(i2c_singleton));
     busio_i2c_obj_t *self = &i2c_obj;
     self->base.type = &busio_i2c_type;
 
@@ -79,9 +78,8 @@ mp_obj_t common_hal_board_get_spi(void) {
 }
 
 mp_obj_t common_hal_board_create_spi(void) {
-    if (spi_singleton != NULL) {
-        return spi_singleton;
-    }
+    // All callers have either already verified this or come so early that it can't be otherwise.
+    assert(spi_singleton == NULL || common_hal_busio_spi_deinited(spi_singleton));
     busio_spi_obj_t *self = &spi_obj;
     self->base.type = &busio_spi_type;
 


### PR DESCRIPTION
The **first commit** brings `board.I2C` into the same state as `board.SPI` by fixing something that was clearly wrong, but by itself caused no severe problems. It thereby _introduces_ the problem described in #3581 for `board.SPI` also for `board.I2C`. See commit message for details.

The **second commit** fixes #3581 for both SPI and I2C.

I found no reason in the code or in the Git history for `reset_port()` to come before `reset_board_busses()` in `cleanup_after_vm()`, so I reversed them.

For symmetry, since setting `spi_singleton` to non-NULL occurs together with `common_hal_busio_spi_construct()`, setting it to NULL should also occur together with `common_hal_busio_spi_deinit()` (and likewise for I2C). This makes the pins resettable and allows the swapped `reset_port()` to do its job. (The symmetry is not complete because `common_hal_busio_spi_deinit()` can also occur without setting `spi_singleton` to NULL, i.e. `spi_singleton` can end up pointing at a non-NULL deinited object. This is dealt with in the third commit, see below.)

Another desirable symmetry would be that since `common_hal_displayio_fourwire_construct()` calls `common_hal_busio_spi_never_reset()`, `common_hal_displayio_fourwire_deinit()` should also call `common_hal_busio_spi_reset()` (which doesn’t exist, but would do the reverse of `…_never_reset()`) (and likewise for `i2cdisplay`). However, this is not necessary, since the `never_reset` flags only take effect at the end of the session, and at that time everything is already handled correctly by the changes made here. There is effectively a redundancy between the `never_reset` flags and `reset_board_busses()` checking for things still in use by displays. Therefore I avoided adding that symmetry, which would just add more code.

Critical review appreciated.

The **third commit** fixes a tangentially related issue: After one had explicitly deinited the `board.SPI` or `board.I2C` busses (maybe to temporarily use their pins for other purposes), there was no way to get them back in the same session. Calling the function again would just return the unusable deinited object. Reproducible as follows:

```
Adafruit CircuitPython 6.0.0-rc.0-99-g32c2e9354-dirty on 2020-10-25; PewPew M4 CW with samd51G19
>>> import board
>>> bus = board.SPI()
>>> bus.try_lock()
True
>>> bus.write(b'X')
>>> bus.unlock()
>>> bus.deinit()
>>> 
>>> bus = board.SPI()
>>> bus.try_lock()
True
>>> bus.write(b'X')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Object has been deinitialized and can no longer be used. Create a new object.
>>> 
```

or

```
# with an SSD1306 display connected to the I2C pins
Adafruit CircuitPython 6.0.0-rc.0-99-g32c2e9354-dirty on 2020-10-25; PewPew M4 CW with samd51G19
>>> import board
>>> bus = board.I2C()
>>> bus.try_lock()
True
>>> bus.writeto(60, b'X')
>>> bus.unlock()
>>> bus.deinit()
>>> 
>>> bus = board.I2C()
>>> bus.try_lock()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Object has been deinitialized and can no longer be used. Create a new object.
>>> 
```

Testing on non-SAMD ports would be appreciated.