### PR TITLE
Fixing make stub warnings and mypy issues

### DIFF
--- a/shared-bindings/canio/CAN.c
+++ b/shared-bindings/canio/CAN.c
@@ -49,7 +49,7 @@
 //|             loopback: bool = False,
 //|             silent: bool = False,
 //|             auto_restart: bool = False,
-//|         ):
+//|         ) -> None:
 //|         """A common shared-bus protocol.  The rx and tx pins are generally
 //|         connected to a transceiver which controls the H and L pins on a
 //|         shared bus.
@@ -171,7 +171,7 @@ STATIC const mp_obj_property_t canio_can_receive_error_count_obj = {
               (mp_obj_t)mp_const_none},
 };
 
-//|     state: State
+//|     state: BusState
 //|     """The current state of the bus. (read-only)"""
 STATIC mp_obj_t canio_can_state_get(mp_obj_t self_in) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -291,7 +291,7 @@ STATIC const mp_obj_property_t canio_can_loopback_obj = {
 };
 
 
-//|     def send(message: Union[RemoteTransmissionRequest, Message]) -> None:
+//|     def send(self, message: Union[RemoteTransmissionRequest, Message]) -> None:
 //|         """Send a message on the bus with the given data and id.
 //|         If the message could not be sent due to a full fifo or a bus error condition, RuntimeError is raised.
 //|         """
@@ -352,7 +352,7 @@ STATIC mp_obj_t canio_can_enter(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_can_enter_obj, canio_can_enter);
 
-//|     def __exit__(self, unused1, unused2, unused3) -> None:
+//|     def __exit__(self, unused1: Optional[Type[BaseException]], unused2: Optional[BaseException], unused3: Optional[TracebackType]) -> None:
 //|         """Calls deinit()"""
 //|         ...
 STATIC mp_obj_t canio_can_exit(size_t num_args, const mp_obj_t args[]) {

--- a/shared-bindings/canio/Listener.c
+++ b/shared-bindings/canio/Listener.c
@@ -123,7 +123,7 @@ STATIC mp_obj_t canio_listener_enter(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_listener_enter_obj, canio_listener_enter);
 
-//|     def __exit__(self, unused1, unused2, unused3) -> None:
+//|     def __exit__(self, unused1: Optional[Type[BaseException]], unused2: Optional[BaseException], unused3: Optional[TracebackType]) -> None:
 //|         """Calls deinit()"""
 //|         ...
 STATIC mp_obj_t canio_listener_exit(size_t num_args, const mp_obj_t args[]) {

--- a/shared-bindings/canio/Match.c
+++ b/shared-bindings/canio/Match.c
@@ -33,7 +33,7 @@
 //|     """Describe CAN bus messages to match"""
 //|
 //|
-//|     def __init__(self, id: int, *, mask: Optional[int] = None, extended: bool = False):
+//|     def __init__(self, id: int, *, mask: Optional[int] = None, extended: bool = False) -> None:
 //|         """Construct a Match with the given properties.
 //|
 //|         If mask is not None, then the filter is for any id which matches all

--- a/shared-bindings/canio/Message.c
+++ b/shared-bindings/canio/Message.c
@@ -31,7 +31,7 @@
 #include "py/runtime.h"
 
 //| class Message:
-//|     def __init__(self, id: int, data: bytes, *, extended: bool = False):
+//|     def __init__(self, id: int, data: bytes, *, extended: bool = False) -> None:
 //|         """Construct a Message to send on a CAN bus.
 //|
 //|         :param int id: The numeric ID of the message

--- a/shared-bindings/canio/RemoteTransmissionRequest.c
+++ b/shared-bindings/canio/RemoteTransmissionRequest.c
@@ -31,7 +31,7 @@
 #include "py/runtime.h"
 
 //| class RemoteTransmissionRequest:
-//|     def __init__(self, id: int, length: int, *, extended: bool = False):
+//|     def __init__(self, id: int, length: int, *, extended: bool = False) -> None:
 //|         """Construct a RemoteTransmissionRequest to send on a CAN bus.
 //|
 //|         :param int id: The numeric ID of the requested message

--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -172,7 +172,7 @@ STATIC mp_obj_t bitmap_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t val
     return mp_const_none;
 }
 
-//|     def blit(self, x: int, y: int, source_bitmap: bitmap, *, x1: int, y1: int, x2: int, y2: int, skip_index: int) -> None:
+//|     def blit(self, x: int, y: int, source_bitmap: Bitmap, *, x1: int, y1: int, x2: int, y2: int, skip_index: int) -> None:
 //|         """Inserts the source_bitmap region defined by rectangular boundaries
 //|                     (x1,y1) and (x2,y2) into the bitmap at the specified (x,y) location.
 //|
@@ -274,7 +274,7 @@ STATIC mp_obj_t displayio_bitmap_obj_blit(size_t n_args, const mp_obj_t *pos_arg
 MP_DEFINE_CONST_FUN_OBJ_KW(displayio_bitmap_blit_obj, 4, displayio_bitmap_obj_blit);
 // `displayio_bitmap_obj_blit` requires at least 4 arguments
 
-//|     def fill(self, value: Any) -> None:
+//|     def fill(self, value: int) -> None:
 //|         """Fills the bitmap with the supplied palette index value."""
 //|         ...
 //|

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -39,7 +39,7 @@
 #include "shared-module/displayio/__init__.h"
 #include "supervisor/shared/translate.h"
 
-//| _DisplayBus = Union[FourWire, ParallelBus, I2CDisplay]
+//| _DisplayBus = Union['FourWire', 'ParallelBus', 'I2CDisplay']
 //| """:py:class:`FourWire`, :py:class:`ParallelBus` or :py:class:`I2CDisplay`"""
 //|
 

--- a/shared-bindings/socketpool/Socket.c
+++ b/shared-bindings/socketpool/Socket.c
@@ -161,7 +161,7 @@ STATIC mp_obj_t socketpool_socket_close(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(socketpool_socket_close_obj, socketpool_socket_close);
 
-//|     def connect(self, address: tuple) -> None:
+//|     def connect(self, address: Tuple[str, int]) -> None:
 //|         """Connect a socket to a remote address
 //|
 //|         :param ~tuple address: tuple of (remote_address, remote_port)"""

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -82,7 +82,7 @@ STATIC mp_obj_t socketpool_socketpool_socket(size_t n_args, const mp_obj_t *pos_
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(socketpool_socketpool_socket_obj, 1, socketpool_socketpool_socket);
 
-//| def getaddrinfo(host: str, port: int, family: int = 0, type: int = 0, proto: int = 0, flags: int = 0) -> tuple:
+//| def getaddrinfo(host: str, port: int, family: int = 0, type: int = 0, proto: int = 0, flags: int = 0) -> Tuple[int, int, int, str, Tuple[str, int]]:
 //|     """Gets the address information for a hostname and port
 //|
 //|     Returns the appropriate family, socket type, socket protocol and

--- a/shared-bindings/ssl/SSLContext.c
+++ b/shared-bindings/ssl/SSLContext.c
@@ -51,7 +51,7 @@ STATIC mp_obj_t ssl_sslcontext_make_new(const mp_obj_type_t *type, size_t n_args
     return MP_OBJ_FROM_PTR(s);
 }
 
-//| def wrap_socket(sock: socketpool.Socket, *, server_side: bool = False, server_hostname: str = None) -> socketpool.Socket:
+//| def wrap_socket(sock: socketpool.Socket, *, server_side: bool = False, server_hostname: Optional[str] = None) -> socketpool.Socket:
 //|     """Wraps the socket into a socket-compatible class that handles SSL negotiation.
 //|        The socket must be of type SOCK_STREAM."""
 //|     ...

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -283,7 +283,7 @@ const mp_obj_property_t wifi_radio_ap_info_obj = {
                (mp_obj_t)&mp_const_none_obj },
 };
 
-//|     def ping(self, ip: wifi.Radio, *, timeout: float = 0.5) -> float:
+//|     def ping(self, ip: ipaddress.IPv4Address, *, timeout: Optional[float] = 0.5) -> float:
 //|         """Ping an IP to test connectivity. Returns echo time in seconds.
 //|            Returns None when it times out."""
 //|         ...

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -79,7 +79,7 @@ const mp_obj_property_t wifi_radio_mac_address_obj = {
 };
 
 
-//|     def start_scanning_networks(self, *, start_channel=1, stop_channel=11) -> Iterable[Network]:
+//|     def start_scanning_networks(self, *, start_channel: int = 1, stop_channel: int = 11) -> Iterable[Network]:
 //|         """Scans for available wifi networks over the given channel range. Make sure the channels are allowed in your country."""
 //|         ...
 //|
@@ -283,7 +283,7 @@ const mp_obj_property_t wifi_radio_ap_info_obj = {
                (mp_obj_t)&mp_const_none_obj },
 };
 
-//|     def ping(self, ip, *, timeout: float = 0.5) -> float:
+//|     def ping(self, ip: wifi.Radio, *, timeout: float = 0.5) -> float:
 //|         """Ping an IP to test connectivity. Returns echo time in seconds.
 //|            Returns None when it times out."""
 //|         ...

--- a/tools/extract_pyi.py
+++ b/tools/extract_pyi.py
@@ -17,7 +17,8 @@ import black
 
 
 IMPORTS_IGNORE = frozenset({'int', 'float', 'bool', 'str', 'bytes', 'tuple', 'list', 'set', 'dict', 'bytearray', 'slice', 'file', 'buffer', 'range', 'array', 'struct_time'})
-IMPORTS_TYPING = frozenset({'Any', 'Optional', 'Union', 'Tuple', 'List', 'Sequence', 'NamedTuple', 'Iterable', 'Iterator', 'Callable', 'AnyStr', 'overload'})
+IMPORTS_TYPING = frozenset({'Any', 'Optional', 'Union', 'Tuple', 'List', 'Sequence', 'NamedTuple', 'Iterable', 'Iterator', 'Callable', 'AnyStr', 'overload', 'Type'})
+IMPORTS_TYPES = frozenset({'TracebackType'})
 CPY_TYPING = frozenset({'ReadableBuffer', 'WriteableBuffer', 'AudioSample', 'FrameBuffer'})
 
 
@@ -63,6 +64,7 @@ def find_stub_issues(tree):
 def extract_imports(tree):
     modules = set()
     typing = set()
+    types = set()
     cpy_typing = set()
 
     def collect_annotations(anno_tree):
@@ -74,6 +76,8 @@ def extract_imports(tree):
                     continue
                 elif node.id in IMPORTS_TYPING:
                     typing.add(node.id)
+                elif node.id in IMPORTS_TYPES:
+                    types.add(node.id)
                 elif node.id in CPY_TYPING:
                     cpy_typing.add(node.id)
             elif isinstance(node, ast.Attribute):
@@ -94,6 +98,7 @@ def extract_imports(tree):
     return {
         "modules": sorted(modules),
         "typing": sorted(typing),
+        "types": sorted(types),
         "cpy_typing": sorted(cpy_typing),
     }
 
@@ -181,6 +186,8 @@ def convert_folder(top_level, stub_directory):
     # Add import statements
     imports = extract_imports(tree)
     import_lines = ["from __future__ import annotations"]
+    if imports["types"]:
+        import_lines.append("from types import " + ", ".join(imports["types"]))
     if imports["typing"]:
         import_lines.append("from typing import " + ", ".join(imports["typing"]))
     if imports["cpy_typing"]:


### PR DESCRIPTION
This cleanup is part of #2041 - cleaning up warnings from `make stubs` and `make check-stubs`.  Adding more detailed type information and fixing a few types.

I worked on this as part of #hacktoberfest (https://hacktoberfest.digitalocean.com/), so if the PR looks OK would you mind adding the label `hacktoberfest-accepted`?

Note that several of the warnings/errors are coming from the ulab package, so I'll try and make a PR there as well.
[Update] Looks like most of the ulab errors have been fixed now