### PR TITLE
Fixing remaining stub mypy issues + run check-stubs to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         sudo apt-get install -y eatmydata
         sudo eatmydata apt-get install -y gettext librsvg2-bin mingw-w64 latexmk texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra
-        pip install requests sh click setuptools cpp-coveralls "Sphinx<4" sphinx-rtd-theme recommonmark sphinx-autoapi sphinxcontrib-svg2pdfconverter polib pyyaml astroid isort black awscli
+        pip install requests sh click setuptools cpp-coveralls "Sphinx<4" sphinx-rtd-theme recommonmark sphinx-autoapi sphinxcontrib-svg2pdfconverter polib pyyaml astroid isort black awscli mypy
     - name: Versions
       run: |
         gcc --version
@@ -67,7 +67,7 @@ jobs:
     - name: mpy Tests
       run: MICROPY_CPYTHON3=python3.8 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --via-mpy -d basics float
       working-directory: tests
-    - name: Stubs
+    - name: Build and Validate Stubs
       run: make check-stubs -j2
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       run: MICROPY_CPYTHON3=python3.8 MICROPY_MICROPYTHON=../ports/unix/micropython_coverage ./run-tests -j1 --via-mpy -d basics float
       working-directory: tests
     - name: Stubs
-      run: make stubs -j2
+      run: make check-stubs -j2
     - uses: actions/upload-artifact@v2
       with:
         name: stubs

--- a/shared-bindings/ipaddress/IPv4Address.c
+++ b/shared-bindings/ipaddress/IPv4Address.c
@@ -126,7 +126,7 @@ const mp_obj_property_t ipaddress_ipv4address_version_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
-//|     def __eq__(self, other: IPv4Address) -> bool:
+//|     def __eq__(self, other: object) -> bool:
 //|         """Two Address objects are equal if their addresses and address types are equal."""
 //|         ...
 //|

--- a/shared-bindings/socket/__init__.c
+++ b/shared-bindings/socket/__init__.c
@@ -49,19 +49,20 @@ STATIC const mp_obj_type_t socket_type;
 
 //| class socket:
 //|
-//|     def __init__(self, family: int, type: int, proto: int) -> None:
+//|     AF_INET = 2
+//|     AF_INET6 = 10
+//|     SOCK_STREAM = 1
+//|     SOCK_DGRAM = 2
+//|     SOCK_RAW = 3
+//|     IPPROTO_TCP = 6
+//|
+//|     def __init__(self, family: int = AF_INET, type: int = SOCK_STREAM, proto: int = IPPROTO_TCP) -> None:
 //|         """Create a new socket
 //|
 //|         :param int family: AF_INET or AF_INET6
 //|         :param int type: SOCK_STREAM, SOCK_DGRAM or SOCK_RAW
 //|         :param int proto: IPPROTO_TCP, IPPROTO_UDP or IPPROTO_RAW (ignored)"""
 //|         ...
-//|
-//|     AF_INET: int
-//|     AF_INET6: int
-//|     SOCK_STREAM: int
-//|     SOCK_DGRAM: int
-//|     SOCK_RAW: int
 //|
 
 STATIC mp_obj_t socket_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {

--- a/shared-bindings/socket/__init__.c
+++ b/shared-bindings/socket/__init__.c
@@ -49,12 +49,12 @@ STATIC const mp_obj_type_t socket_type;
 
 //| class socket:
 //|
-//|     AF_INET = 2
-//|     AF_INET6 = 10
-//|     SOCK_STREAM = 1
-//|     SOCK_DGRAM = 2
-//|     SOCK_RAW = 3
-//|     IPPROTO_TCP = 6
+//|     AF_INET: int
+//|     AF_INET6: int
+//|     SOCK_STREAM: int
+//|     SOCK_DGRAM: int
+//|     SOCK_RAW: int
+//|     IPPROTO_TCP: int
 //|
 //|     def __init__(self, family: int = AF_INET, type: int = SOCK_STREAM, proto: int = IPPROTO_TCP) -> None:
 //|         """Create a new socket

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -57,12 +57,12 @@ STATIC mp_obj_t socketpool_socketpool_make_new(const mp_obj_type_t *type, size_t
     return MP_OBJ_FROM_PTR(s);
 }
 
-//|     AF_INET = 0
-//|     AF_INET6 = 1
-//|     SOCK_STREAM = 0
-//|     SOCK_DGRAM = 1
-//|     SOCK_RAW = 2
-//|     IPPROTO_TCP = 6
+//|     AF_INET: int
+//|     AF_INET6: int
+//|     SOCK_STREAM: int
+//|     SOCK_DGRAM: int
+//|     SOCK_RAW: int
+//|     IPPROTO_TCP: int
 //|
 //|     def socket(self, family: int = AF_INET, type: int = SOCK_STREAM, proto: int = IPPROTO_TCP) -> socketpool.Socket:
 //|         """Create a new socket

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -58,7 +58,7 @@ STATIC mp_obj_t socketpool_socketpool_make_new(const mp_obj_type_t *type, size_t
 }
 
 
-//|     def socket(self, family: int = AF_INET, type: int = SOCK_STREAM, proto: int = IPPROTO_TCP) -> None:
+//|     def socket(self, family: int, type: int, proto: int) -> socketpool.Socket:
 //|         """Create a new socket
 //|
 //|         :param ~int family: AF_INET or AF_INET6

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -57,8 +57,14 @@ STATIC mp_obj_t socketpool_socketpool_make_new(const mp_obj_type_t *type, size_t
     return MP_OBJ_FROM_PTR(s);
 }
 
-
-//|     def socket(self, family: int, type: int, proto: int) -> socketpool.Socket:
+//|     AF_INET = 0
+//|     AF_INET6 = 1
+//|     SOCK_STREAM = 0
+//|     SOCK_DGRAM = 1
+//|     SOCK_RAW = 2
+//|     IPPROTO_TCP = 6
+//|
+//|     def socket(self, family: int = AF_INET, type: int = SOCK_STREAM, proto: int = IPPROTO_TCP) -> socketpool.Socket:
 //|         """Create a new socket
 //|
 //|         :param ~int family: AF_INET or AF_INET6
@@ -66,6 +72,7 @@ STATIC mp_obj_t socketpool_socketpool_make_new(const mp_obj_type_t *type, size_t
 //|         :param ~int proto: IPPROTO_TCP, IPPROTO_UDP or IPPROTO_RAW (ignored)"""
 //|         ...
 //|
+
 STATIC mp_obj_t socketpool_socketpool_socket(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mp_arg_check_num(n_args, kw_args, 0, 5, false);
 


### PR DESCRIPTION
- Fixing a few remaining mypy complaints so that `make check-stubs` now passes
- Calling `make check-stubs` instead of `make stubs` in CI actions.
  - `make check-stubs` builds the stubs + runs mypy against them (returning a non-zero error code if errors pop up)

This is a follow-on PR from: #3621

I worked on this as part of #hacktoberfest (https://hacktoberfest.digitalocean.com/), so if the PR looks OK would you mind adding the label hacktoberfest-accepted?