### PR TITLE
improve USB CDC disconnect/reconnect checking

### DIFF
--- a/supervisor/serial.h
+++ b/supervisor/serial.h
@@ -47,5 +47,4 @@ char serial_read(void);
 bool serial_bytes_available(void);
 bool serial_connected(void);
 
-extern volatile bool _serial_connected;
 #endif  // MICROPY_INCLUDED_SUPERVISOR_SERIAL_H

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -47,8 +47,6 @@ busio_uart_obj_t debug_uart;
 byte buf_array[64];
 #endif
 
-volatile bool _serial_connected;
-
 void serial_early_init(void) {
 #if defined(DEBUG_UART_TX) && defined(DEBUG_UART_RX)
     debug_uart.base.type = &busio_uart_type;
@@ -71,7 +69,9 @@ bool serial_connected(void) {
 #if defined(DEBUG_UART_TX) && defined(DEBUG_UART_RX)
     return true;
 #else
-    return _serial_connected;
+    // True if DTR is asserted, and the USB connection is up.
+    // tud_cdc_get_line_state(): bit 0 is DTR, bit 1 is RTS
+    return (tud_cdc_get_line_state() & 1) && tud_ready();
 #endif
 }
 

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -116,7 +116,6 @@ void tud_umount_cb(void) {
 // remote_wakeup_en : if host allows us to perform remote wakeup
 // USB Specs: Within 7ms, device must draw an average current less than 2.5 mA from bus
 void tud_suspend_cb(bool remote_wakeup_en) {
-    _serial_connected = false;
 }
 
 // Invoked when usb bus is resumed
@@ -127,8 +126,6 @@ void tud_resume_cb(void) {
 // Use to reset to DFU when disconnect with 1200 bps
 void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts) {
     (void) itf; // interface ID, not used
-
-    _serial_connected = dtr;
 
     // DTR = false is counted as disconnected
     if ( !dtr )


### PR DESCRIPTION
Fixes #3588.

Check for DTR by querying `tud_cdc_get_line_state()`, and check for `tud_usb_ready()`. One doesn't need to save state in callbacks this way.

Tested two ways:
- By putting the host computer to sleep, and then waking it up. When sleeping, `supervisor.runtime.serial_available` becomes falase. After wakeup, the serial connection is restored, and `supervisor.runtime.serial_available` is `True`. Interrupting the running program with ctrl-c works properly, and one can get to the REPL.
- Powering the board externally (AC adapter on a Metro M4), and unplugging and replugging the USB cable.

I did try the data/charge-only cable with a switch, but it gives peculiar results. It detects as disconnected and then reconnected when switched, I think because some resistors are added to the data lines to mark the cable as charge-only.