### PR TITLE
 restore analogio to feather_m0_rfm9x/rfm69 builds

### DIFF
--- a/ports/atmel-samd/boards/feather_m0_rfm69/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/feather_m0_rfm69/mpconfigboard.mk
@@ -12,7 +12,7 @@ CIRCUITPY_FULL_BUILD = 0
 
 # A number of modules are removed for RFM69 to make room for frozen libraries.
 # Many I/O functions are not available.
-CIRCUITPY_ANALOGIO = 0
+CIRCUITPY_ANALOGIO = 1
 CIRCUITPY_PULSEIO = 0
 CIRCUITPY_NEOPIXEL_WRITE = 1
 CIRCUITPY_ROTARYIO = 0

--- a/ports/atmel-samd/boards/feather_m0_rfm9x/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/feather_m0_rfm9x/mpconfigboard.mk
@@ -13,7 +13,7 @@ CIRCUITPY_FULL_BUILD = 0
 
 # A number of modules are removed for RFM9x to make room for frozen libraries.
 # Many I/O functions are not available.
-CIRCUITPY_ANALOGIO = 0
+CIRCUITPY_ANALOGIO = 1
 CIRCUITPY_PULSEIO = 0
 CIRCUITPY_NEOPIXEL_WRITE = 1
 CIRCUITPY_ROTARYIO = 0


### PR DESCRIPTION
analogio now fits in these builds

generated in response to this Forum post https://forums.adafruit.com/viewtopic.php?f=57&t=171254