### PR TITLE
ESP32S2: Fix parallel strip issue with Neopixels

### DIFF
--- a/ports/esp32s2/common-hal/neopixel_write/__init__.c
+++ b/ports/esp32s2/common-hal/neopixel_write/__init__.c
@@ -125,4 +125,6 @@ void common_hal_neopixel_write (const digitalio_digitalinout_obj_t* digitalinout
 
     // Free channel again
     esp32s2_peripherals_free_rmt(config.channel);
+    // Swap pin back to GPIO mode
+    gpio_set_direction(digitalinout->pin->number, GPIO_MODE_OUTPUT);
 }


### PR DESCRIPTION
This PR adds a pin reconfiguration step at the end of Neopixel write, which should solve the issue where any previously declared Neopixel pins would receive the same pulse outputs as newly declared ones. An alternative to setting the pin to GPIO output could be using a full `gpio_reset_pin()` here instead.