### PR TITLE
ESP32S2: Reset PCNT on user code reload

### DIFF
--- a/ports/esp32s2/peripherals/pcnt.c
+++ b/ports/esp32s2/peripherals/pcnt.c
@@ -29,14 +29,20 @@
 #define PCNT_UNIT_ACTIVE    1
 #define PCNT_UNIT_INACTIVE  0
 
-static uint8_t pcnt_state[4];
+static uint8_t pcnt_unit_state[4];
+
+void peripherals_pcnt_reset(void) {
+    for (uint8_t i = 0; i<=3; i++) {
+        pcnt_unit_state[i] = PCNT_UNIT_INACTIVE;
+    }
+}
 
 int peripherals_pcnt_init(pcnt_config_t pcnt_config) {
     // Look for available pcnt unit
     for (uint8_t i = 0; i<=3; i++) {
-        if (pcnt_state[i] == PCNT_UNIT_INACTIVE) {
+        if (pcnt_unit_state[i] == PCNT_UNIT_INACTIVE) {
             pcnt_config.unit = (pcnt_unit_t)i;
-            pcnt_state[i] = PCNT_UNIT_ACTIVE;
+            pcnt_unit_state[i] = PCNT_UNIT_ACTIVE;
             break;
         } else if (i == 3) {
             return -1;
@@ -45,10 +51,6 @@ int peripherals_pcnt_init(pcnt_config_t pcnt_config) {
 
     // Initialize PCNT unit
     pcnt_unit_config(&pcnt_config);
-
-    // Configure and enable the input filter
-    pcnt_set_filter_value(pcnt_config.unit, 100);
-    pcnt_filter_enable(pcnt_config.unit);
 
     // Initialize PCNT's counter
     pcnt_counter_pause(pcnt_config.unit);
@@ -61,6 +63,6 @@ int peripherals_pcnt_init(pcnt_config_t pcnt_config) {
 }
 
 void peripherals_pcnt_deinit(pcnt_unit_t* unit) {
-    pcnt_state[*unit] = PCNT_UNIT_INACTIVE;
+    pcnt_unit_state[*unit] = PCNT_UNIT_INACTIVE;
     *unit = PCNT_UNIT_MAX;
 }

--- a/ports/esp32s2/peripherals/pcnt.h
+++ b/ports/esp32s2/peripherals/pcnt.h
@@ -31,5 +31,6 @@
 
 extern int peripherals_pcnt_init(pcnt_config_t pcnt_config);
 extern void peripherals_pcnt_deinit(pcnt_unit_t* unit);
+extern void peripherals_pcnt_reset(void);
 
 #endif  // MICROPY_INCLUDED_ESP32S2_PERIPHERALS_PCNT_HANDLER_H

--- a/ports/esp32s2/supervisor/port.c
+++ b/ports/esp32s2/supervisor/port.c
@@ -49,6 +49,7 @@
 #include "shared-bindings/rtc/__init__.h"
 
 #include "peripherals/rmt.h"
+#include "peripherals/pcnt.h"
 #include "components/heap/include/esp_heap_caps.h"
 #include "components/soc/soc/esp32s2/include/soc/cache_memory.h"
 
@@ -115,6 +116,10 @@ void reset_port(void) {
     i2c_reset();
     spi_reset();
     uart_reset();
+#endif
+
+#if defined(CIRCUITPY_COUNTIO) || defined(CIRCUITPY_ROTARYIO)
+    peripherals_pcnt_reset();
 #endif
 
 #if CIRCUITPY_RTC


### PR DESCRIPTION
Prior to this PR the pcnt unit would not reset on reload of user code.