### PR TITLE
esp32s2: wifi: fix several debug-build errors

### DIFF
--- a/ports/esp32s2/common-hal/wifi/__init__.c
+++ b/ports/esp32s2/common-hal/wifi/__init__.c
@@ -143,8 +143,8 @@ void wifi_reset(void) {
                                                           radio->handler_instance_got_ip));
     ESP_ERROR_CHECK(esp_wifi_deinit());
     esp_netif_destroy(radio->netif);
+    ESP_ERROR_CHECK(esp_event_loop_delete_default());
     radio->netif = NULL;
-    ESP_ERROR_CHECK(esp_netif_deinit());
 }
 
 void ipaddress_ipaddress_to_esp_idf(mp_obj_t ip_address, ip_addr_t* esp_ip_address) {


### PR DESCRIPTION
Closes #3688

With this change, I don't get the ESP_ERROR_CHECK failed repeatedly running code that imports wifi.  (I'm not getting a successful connection but that's probably my own fault, such as a secrets problem)