### PR TITLE
Add movable supervisor allocations

### DIFF
--- a/main.c
+++ b/main.c
@@ -123,15 +123,15 @@ void start_mp(supervisor_allocation* heap) {
     // to recover from limit hit.  (Limit is measured in bytes.)
     mp_stack_ctrl_init();
 
-    if (stack_alloc != NULL) {
-        mp_stack_set_limit(stack_alloc->length - 1024);
+    if (stack_get_bottom() != NULL) {
+        mp_stack_set_limit(stack_get_length() - 1024);
     }
 
 
 #if MICROPY_MAX_STACK_USAGE
     // _ezero (same as _ebss) is an int, so start 4 bytes above it.
-    if (stack_alloc != NULL) {
-        mp_stack_set_bottom(stack_alloc->ptr);
+    if (stack_get_bottom() != NULL) {
+        mp_stack_set_bottom(stack_get_bottom());
         mp_stack_fill_with_sentinel();
     }
 #endif
@@ -148,7 +148,7 @@ void start_mp(supervisor_allocation* heap) {
     #endif
 
     #if MICROPY_ENABLE_GC
-    gc_init(heap->ptr, heap->ptr + heap->length / 4);
+    gc_init(heap->ptr, heap->ptr + get_allocation_length(heap) / 4);
     #endif
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);
@@ -450,9 +450,6 @@ int run_repl(void) {
 int __attribute__((used)) main(void) {
     // initialise the cpu and peripherals
     safe_mode_t safe_mode = port_init();
-
-    // Init memory after the port in case the port needs to set aside memory.
-    memory_init();
 
     // Turn on LEDs
     init_status_leds();

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -390,8 +390,8 @@ void reset_cpu(void) {
     reset();
 }
 
-supervisor_allocation* port_fixed_stack(void) {
-    return NULL;
+bool port_has_fixed_stack(void) {
+    return false;
 }
 
 uint32_t *port_stack_get_limit(void) {

--- a/ports/cxd56/supervisor/port.c
+++ b/ports/cxd56/supervisor/port.c
@@ -98,12 +98,8 @@ void reset_to_bootloader(void) {
     }
 }
 
-supervisor_allocation _fixed_stack;
-
-supervisor_allocation* port_fixed_stack(void) {
-    _fixed_stack.ptr = port_stack_get_limit();
-    _fixed_stack.length = (port_stack_get_top() - port_stack_get_limit()) * sizeof(uint32_t);
-    return &_fixed_stack;
+bool port_has_fixed_stack(void) {
+    return true;
 }
 
 uint32_t *port_stack_get_limit(void) {

--- a/ports/esp32s2/supervisor/port.c
+++ b/ports/esp32s2/supervisor/port.c
@@ -193,12 +193,8 @@ uint32_t *port_stack_get_top(void) {
     return port_stack_get_limit() + ESP_TASK_MAIN_STACK / (sizeof(uint32_t) / sizeof(StackType_t));
 }
 
-supervisor_allocation _fixed_stack;
-
-supervisor_allocation* port_fixed_stack(void) {
-    _fixed_stack.ptr = port_stack_get_limit();
-    _fixed_stack.length = (port_stack_get_top() - port_stack_get_limit()) * sizeof(uint32_t);
-    return &_fixed_stack;
+bool port_has_fixed_stack(void) {
+    return true;
 }
 
 // Place the word to save just after our BSS section that gets blanked.

--- a/ports/litex/supervisor/port.c
+++ b/ports/litex/supervisor/port.c
@@ -98,8 +98,8 @@ void reset_cpu(void) {
     for(;;) {}
 }
 
-supervisor_allocation* port_fixed_stack(void) {
-    return NULL;
+bool port_has_fixed_stack(void) {
+    return false;
 }
 
 uint32_t *port_heap_get_bottom(void) {

--- a/ports/mimxrt10xx/supervisor/port.c
+++ b/ports/mimxrt10xx/supervisor/port.c
@@ -334,11 +334,8 @@ uint32_t *port_stack_get_top(void) {
     return &_ld_stack_top;
 }
 
-supervisor_allocation _fixed_stack;
-supervisor_allocation* port_fixed_stack(void) {
-    _fixed_stack.ptr = port_stack_get_limit();
-    _fixed_stack.length = (port_stack_get_top() - port_stack_get_limit()) * sizeof(uint32_t);
-    return &_fixed_stack;
+bool port_has_fixed_stack(void) {
+    return true;
 }
 
 uint32_t *port_heap_get_bottom(void) {

--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -251,8 +251,8 @@ uint32_t *port_heap_get_top(void) {
     return port_stack_get_top();
 }
 
-supervisor_allocation* port_fixed_stack(void) {
-    return NULL;
+bool port_has_fixed_stack(void) {
+    return false;
 }
 
 uint32_t *port_stack_get_limit(void) {

--- a/ports/stm/supervisor/port.c
+++ b/ports/stm/supervisor/port.c
@@ -267,8 +267,8 @@ uint32_t *port_heap_get_top(void) {
     return &_ld_heap_end;
 }
 
-supervisor_allocation* port_fixed_stack(void) {
-    return NULL;
+bool port_has_fixed_stack(void) {
+    return false;
 }
 
 uint32_t *port_stack_get_limit(void) {

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -858,6 +858,9 @@ extern const struct _mp_obj_module_t wifi_module;
 
 #include "supervisor/flash_root_pointers.h"
 
+// From supervisor/memory.c
+struct _supervisor_allocation_node;
+
 #define CIRCUITPY_COMMON_ROOT_POINTERS \
     const char *readline_hist[8]; \
     vstr_t *repl_line; \
@@ -869,6 +872,7 @@ extern const struct _mp_obj_module_t wifi_module;
     FLASH_ROOT_POINTERS \
     MEMORYMONITOR_ROOT_POINTERS \
     NETWORK_ROOT_POINTERS \
+    struct _supervisor_allocation_node* first_embedded_allocation; \
 
 void supervisor_run_background_tasks_if_tick(void);
 #define RUN_BACKGROUND_TASKS (supervisor_run_background_tasks_if_tick())

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -867,7 +867,6 @@ struct _supervisor_allocation_node;
     mp_obj_t rtc_time_source; \
     GAMEPAD_ROOT_POINTERS \
     mp_obj_t pew_singleton; \
-    mp_obj_t terminal_tilegrid_tiles; \
     BOARD_UART_ROOT_POINTER \
     FLASH_ROOT_POINTERS \
     MEMORYMONITOR_ROOT_POINTERS \

--- a/shared-module/rgbmatrix/RGBMatrix.c
+++ b/shared-module/rgbmatrix/RGBMatrix.c
@@ -220,7 +220,7 @@ void *common_hal_rgbmatrix_allocator_impl(size_t sz) {
     if (gc_alloc_possible()) {
         return m_malloc_maybe(sz + sizeof(void*), true);
     } else {
-        supervisor_allocation *allocation = allocate_memory(align32_size(sz), false);
+        supervisor_allocation *allocation = allocate_memory(align32_size(sz), false, false);
         return allocation ? allocation->ptr : NULL;
     }
 }

--- a/shared-module/sharpdisplay/SharpMemoryFramebuffer.c
+++ b/shared-module/sharpdisplay/SharpMemoryFramebuffer.c
@@ -40,7 +40,7 @@
 #define SHARPMEM_BIT_VCOM_LSB (0x40)
 
 static void *hybrid_alloc(size_t sz) {
-    supervisor_allocation *allocation = allocate_memory(align32_size(sz), false);
+    supervisor_allocation *allocation = allocate_memory(align32_size(sz), false, false);
     if (allocation) {
         memset(allocation->ptr, 0, sz);
         return allocation->ptr;

--- a/shared-module/sharpdisplay/SharpMemoryFramebuffer.c
+++ b/shared-module/sharpdisplay/SharpMemoryFramebuffer.c
@@ -34,31 +34,9 @@
 #include "shared-module/sharpdisplay/SharpMemoryFramebuffer.h"
 
 #include "supervisor/memory.h"
-#include "supervisor/shared/safe_mode.h"
 
 #define SHARPMEM_BIT_WRITECMD_LSB (0x80)
 #define SHARPMEM_BIT_VCOM_LSB (0x40)
-
-static void *hybrid_alloc(size_t sz) {
-    supervisor_allocation *allocation = allocate_memory(align32_size(sz), false, false);
-    if (allocation) {
-        memset(allocation->ptr, 0, sz);
-        return allocation->ptr;
-    }
-    if (gc_alloc_possible()) {
-        return m_malloc(sz, true);
-    }
-    reset_into_safe_mode(MEM_MANAGE);
-    return NULL; // unreached
-}
-
-static inline void hybrid_free(void *ptr_in) {
-    supervisor_allocation *allocation = allocation_from_ptr(ptr_in);
-
-    if (allocation) {
-        free_memory(allocation);
-    }
-}
 
 STATIC uint8_t bitrev(uint8_t n) {
     uint8_t r = 0;
@@ -102,9 +80,9 @@ void common_hal_sharpdisplay_framebuffer_reset(sharpdisplay_framebuffer_obj_t *s
 }
 
 void common_hal_sharpdisplay_framebuffer_reconstruct(sharpdisplay_framebuffer_obj_t *self) {
-    if (!allocation_from_ptr(self->bufinfo.buf)) {
-        self->bufinfo.buf = NULL;
-    }
+    // Look up the allocation by the old pointer and get the new pointer from it.
+    supervisor_allocation* alloc = allocation_from_ptr(self->bufinfo.buf);
+    self->bufinfo.buf = alloc ? alloc->ptr : NULL;
 }
 
 void common_hal_sharpdisplay_framebuffer_get_bufinfo(sharpdisplay_framebuffer_obj_t *self, mp_buffer_info_t *bufinfo) {
@@ -112,7 +90,12 @@ void common_hal_sharpdisplay_framebuffer_get_bufinfo(sharpdisplay_framebuffer_ob
         int row_stride = common_hal_sharpdisplay_framebuffer_get_row_stride(self);
         int height = common_hal_sharpdisplay_framebuffer_get_height(self);
         self->bufinfo.len = row_stride * height + 2;
-        self->bufinfo.buf = hybrid_alloc(self->bufinfo.len);
+        supervisor_allocation* alloc = allocate_memory(align32_size(self->bufinfo.len), false, true);
+        if (alloc == NULL) {
+            m_malloc_fail(self->bufinfo.len);
+        }
+        self->bufinfo.buf = alloc->ptr;
+        memset(alloc->ptr, 0, self->bufinfo.len);
 
         uint8_t *data = self->bufinfo.buf;
         *data++ = SHARPMEM_BIT_WRITECMD_LSB;
@@ -123,7 +106,9 @@ void common_hal_sharpdisplay_framebuffer_get_bufinfo(sharpdisplay_framebuffer_ob
         }
         self->full_refresh = true;
     }
-    *bufinfo = self->bufinfo;
+    if (bufinfo) {
+        *bufinfo = self->bufinfo;
+    }
 }
 
 void common_hal_sharpdisplay_framebuffer_deinit(sharpdisplay_framebuffer_obj_t *self) {
@@ -137,7 +122,7 @@ void common_hal_sharpdisplay_framebuffer_deinit(sharpdisplay_framebuffer_obj_t *
 
     common_hal_reset_pin(self->chip_select.pin);
 
-    hybrid_free(self->bufinfo.buf);
+    free_memory(allocation_from_ptr(self->bufinfo.buf));
 
     memset(self, 0, sizeof(*self));
 }
@@ -154,19 +139,7 @@ void common_hal_sharpdisplay_framebuffer_construct(sharpdisplay_framebuffer_obj_
     self->height = height;
     self->baudrate = baudrate;
 
-    int row_stride = common_hal_sharpdisplay_framebuffer_get_row_stride(self);
-    self->bufinfo.len = row_stride * height + 2;
-    // re-use a supervisor allocation if possible
-    self->bufinfo.buf = hybrid_alloc(self->bufinfo.len);
-
-    uint8_t *data = self->bufinfo.buf;
-    *data++ = SHARPMEM_BIT_WRITECMD_LSB;
-
-    for(int y=0; y<self->height; y++) {
-        *data = bitrev(y+1);
-        data += row_stride;
-    }
-    self->full_refresh = true;
+    common_hal_sharpdisplay_framebuffer_get_bufinfo(self, NULL);
 }
 
 void common_hal_sharpdisplay_framebuffer_swapbuffers(sharpdisplay_framebuffer_obj_t *self, uint8_t *dirty_row_bitmask) {
@@ -271,7 +244,5 @@ const framebuffer_p_t sharpdisplay_framebuffer_proto = {
 };
 
 void common_hal_sharpdisplay_framebuffer_collect_ptrs(sharpdisplay_framebuffer_obj_t *self) {
-    gc_collect_ptr(self->framebuffer);
     gc_collect_ptr(self->bus);
-    gc_collect_ptr(self->bufinfo.buf);
 }

--- a/shared-module/sharpdisplay/SharpMemoryFramebuffer.h
+++ b/shared-module/sharpdisplay/SharpMemoryFramebuffer.h
@@ -33,7 +33,6 @@
 
 typedef struct {
     mp_obj_base_t base;
-    mp_obj_t framebuffer;
     busio_spi_obj_t* bus;
     busio_spi_obj_t inline_bus;
     digitalio_digitalinout_obj_t chip_select;

--- a/shared-module/usb_midi/__init__.c
+++ b/shared-module/usb_midi/__init__.c
@@ -40,9 +40,9 @@ supervisor_allocation* usb_midi_allocation;
 
 void usb_midi_init(void) {
     // TODO(tannewt): Make this dynamic.
-    uint16_t tuple_size = align32_size(sizeof(mp_obj_tuple_t) + sizeof(mp_obj_t*) * 2);
-    uint16_t portin_size = align32_size(sizeof(usb_midi_portin_obj_t));
-    uint16_t portout_size = align32_size(sizeof(usb_midi_portout_obj_t));
+    size_t tuple_size = align32_size(sizeof(mp_obj_tuple_t) + sizeof(mp_obj_t*) * 2);
+    size_t portin_size = align32_size(sizeof(usb_midi_portin_obj_t));
+    size_t portout_size = align32_size(sizeof(usb_midi_portout_obj_t));
 
     // For each embedded MIDI Jack in the descriptor we create a Port
     usb_midi_allocation = allocate_memory(tuple_size + portin_size + portout_size, false, false);

--- a/shared-module/usb_midi/__init__.c
+++ b/shared-module/usb_midi/__init__.c
@@ -45,7 +45,7 @@ void usb_midi_init(void) {
     uint16_t portout_size = align32_size(sizeof(usb_midi_portout_obj_t));
 
     // For each embedded MIDI Jack in the descriptor we create a Port
-    usb_midi_allocation = allocate_memory(tuple_size + portin_size + portout_size, false);
+    usb_midi_allocation = allocate_memory(tuple_size + portin_size + portout_size, false, false);
 
     mp_obj_tuple_t *ports = (mp_obj_tuple_t *) usb_midi_allocation->ptr;
     ports->base.type = &mp_type_tuple;

--- a/supervisor/memory.h
+++ b/supervisor/memory.h
@@ -64,11 +64,8 @@ supervisor_allocation* allocate_remaining_memory(void);
 // supervisor_move_memory().
 supervisor_allocation* allocate_memory(uint32_t length, bool high_address, bool movable);
 
-static inline uint16_t align32_size(uint16_t size) {
-    if (size % 4 != 0) {
-        return (size & 0xfffc) + 0x4;
-    }
-    return size;
+static inline size_t align32_size(size_t size) {
+    return (size + 3) & ~3;
 }
 
 size_t get_allocation_length(supervisor_allocation* allocation);

--- a/supervisor/port.h
+++ b/supervisor/port.h
@@ -61,15 +61,14 @@ uint32_t *port_stack_get_limit(void);
 // Get stack top address
 uint32_t *port_stack_get_top(void);
 
-supervisor_allocation* port_fixed_stack(void);
+// True if stack is not located inside heap (at the top)
+bool port_has_fixed_stack(void);
 
 // Get heap bottom address
 uint32_t *port_heap_get_bottom(void);
 
 // Get heap top address
 uint32_t *port_heap_get_top(void);
-
-supervisor_allocation* port_fixed_heap(void);
 
 // Save and retrieve a word from memory that is preserved over reset. Used for safe mode.
 void port_set_saved_word(uint32_t);

--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -82,7 +82,7 @@ void supervisor_start_terminal(uint16_t width_px, uint16_t height_px) {
     uint16_t total_tiles = width_in_tiles * height_in_tiles;
 
     // First try to allocate outside the heap. This will fail when the VM is running.
-    tilegrid_tiles = allocate_memory(align32_size(total_tiles), false);
+    tilegrid_tiles = allocate_memory(align32_size(total_tiles), false, false);
     uint8_t* tiles;
     if (tilegrid_tiles == NULL) {
         tiles = m_malloc(total_tiles, true);
@@ -133,7 +133,7 @@ void supervisor_display_move_memory(void) {
         grid->tiles == MP_STATE_VM(terminal_tilegrid_tiles)) {
         uint16_t total_tiles = grid->width_in_tiles * grid->height_in_tiles;
 
-        tilegrid_tiles = allocate_memory(align32_size(total_tiles), false);
+        tilegrid_tiles = allocate_memory(align32_size(total_tiles), false, false);
         if (tilegrid_tiles != NULL) {
             memcpy(tilegrid_tiles->ptr, grid->tiles, total_tiles);
             grid->tiles = (uint8_t*) tilegrid_tiles->ptr;

--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -81,19 +81,21 @@ void supervisor_start_terminal(uint16_t width_px, uint16_t height_px) {
 
     uint16_t total_tiles = width_in_tiles * height_in_tiles;
 
-    // First try to allocate outside the heap. This will fail when the VM is running.
-    tilegrid_tiles = allocate_memory(align32_size(total_tiles), false, false);
-    uint8_t* tiles;
-    if (tilegrid_tiles == NULL) {
-        tiles = m_malloc(total_tiles, true);
-        MP_STATE_VM(terminal_tilegrid_tiles) = tiles;
-    } else {
-        tiles = (uint8_t*) tilegrid_tiles->ptr;
+    // Reuse the previous allocation if possible
+    if (tilegrid_tiles) {
+        if (get_allocation_length(tilegrid_tiles) != align32_size(total_tiles)) {
+            free_memory(tilegrid_tiles);
+            tilegrid_tiles = NULL;
+        }
     }
+    if (!tilegrid_tiles) {
+        tilegrid_tiles = allocate_memory(align32_size(total_tiles), false, true);
+        if (!tilegrid_tiles) {
+            return;
+        }
+    }
+    uint8_t* tiles = (uint8_t*) tilegrid_tiles->ptr;
 
-    if (tiles == NULL) {
-        return;
-    }
     grid->y = tall ? blinka_bitmap.height : 0;
     grid->x = tall ? 0 : blinka_bitmap.width;
     grid->top_left_y = 0;
@@ -120,7 +122,6 @@ void supervisor_stop_terminal(void) {
     if (tilegrid_tiles != NULL) {
         free_memory(tilegrid_tiles);
         tilegrid_tiles = NULL;
-        supervisor_terminal_text_grid.inline_tiles = false;
         supervisor_terminal_text_grid.tiles = NULL;
     }
     #endif
@@ -128,20 +129,10 @@ void supervisor_stop_terminal(void) {
 
 void supervisor_display_move_memory(void) {
     #if CIRCUITPY_TERMINALIO
-    displayio_tilegrid_t* grid = &supervisor_terminal_text_grid;
-    if (MP_STATE_VM(terminal_tilegrid_tiles) != NULL &&
-        grid->tiles == MP_STATE_VM(terminal_tilegrid_tiles)) {
-        uint16_t total_tiles = grid->width_in_tiles * grid->height_in_tiles;
-
-        tilegrid_tiles = allocate_memory(align32_size(total_tiles), false, false);
-        if (tilegrid_tiles != NULL) {
-            memcpy(tilegrid_tiles->ptr, grid->tiles, total_tiles);
-            grid->tiles = (uint8_t*) tilegrid_tiles->ptr;
-        } else {
-            grid->tiles = NULL;
-            grid->inline_tiles = false;
-        }
-        MP_STATE_VM(terminal_tilegrid_tiles) = NULL;
+    if (tilegrid_tiles != NULL) {
+        supervisor_terminal_text_grid.tiles = (uint8_t*) tilegrid_tiles->ptr;
+    } else {
+        supervisor_terminal_text_grid.tiles = NULL;
     }
     #endif
 

--- a/supervisor/shared/external_flash/external_flash.c
+++ b/supervisor/shared/external_flash/external_flash.c
@@ -338,7 +338,7 @@ static bool allocate_ram_cache(void) {
 
     uint32_t table_size = blocks_per_sector * pages_per_block * sizeof(uint32_t);
     // Attempt to allocate outside the heap first.
-    supervisor_cache = allocate_memory(table_size + SPI_FLASH_ERASE_SIZE, false);
+    supervisor_cache = allocate_memory(table_size + SPI_FLASH_ERASE_SIZE, false, false);
     if (supervisor_cache != NULL) {
         MP_STATE_VM(flash_ram_cache) = (uint8_t **) supervisor_cache->ptr;
         uint8_t* page_start = (uint8_t *) supervisor_cache->ptr + table_size;

--- a/supervisor/shared/memory.c
+++ b/supervisor/shared/memory.c
@@ -32,7 +32,32 @@
 #include "py/gc.h"
 #include "supervisor/shared/display.h"
 
-#define CIRCUITPY_SUPERVISOR_ALLOC_COUNT (12)
+enum {
+    CIRCUITPY_SUPERVISOR_ALLOC_COUNT =
+    // stack + heap
+    2
+#ifdef EXTERNAL_FLASH_DEVICES
+    + 1
+#endif
+#if CIRCUITPY_USB_MIDI
+    + 1
+#endif
+#if CIRCUITPY_DISPLAYIO
+    #if CIRCUITPY_TERMINALIO
+        + 1
+    #endif
+    + CIRCUITPY_DISPLAY_LIMIT * (
+        // Maximum needs of one display: max(4 if RGBMATRIX, 1 if SHARPDISPLAY, 0)
+        #if CIRCUITPY_RGBMATRIX
+            4
+        #elif CIRCUITPY_SHARPDISPLAY
+            1
+        #else
+            0
+        #endif
+    )
+#endif
+};
 
 // The lowest two bits of a valid length are always zero, so we can use them to mark an allocation
 // as a hole (freed by the client but not yet reclaimed into the free middle) and as movable.

--- a/supervisor/shared/stack.c
+++ b/supervisor/shared/stack.c
@@ -34,36 +34,42 @@
 
 extern uint32_t _estack;
 
+// Requested size.
 static uint32_t next_stack_size = CIRCUITPY_DEFAULT_STACK_SIZE;
 static uint32_t current_stack_size = 0;
-supervisor_allocation* stack_alloc = NULL;
+// Actual location and size, may be larger than requested.
+static uint32_t* stack_limit = NULL;
+static size_t stack_length = 0;
 
 #define EXCEPTION_STACK_SIZE 1024
 
 void allocate_stack(void) {
 
-    if (port_fixed_stack() != NULL) {
-        stack_alloc = port_fixed_stack();
-        current_stack_size = stack_alloc->length;
+    if (port_has_fixed_stack()) {
+        stack_limit = port_stack_get_limit();
+        stack_length = (port_stack_get_top() - stack_limit)*sizeof(uint32_t);
+        current_stack_size = stack_length;
     } else {
         mp_uint_t regs[10];
         mp_uint_t sp = cpu_get_regs_and_sp(regs);
 
         mp_uint_t c_size = (uint32_t) port_stack_get_top() - sp;
-        stack_alloc = allocate_memory(c_size + next_stack_size + EXCEPTION_STACK_SIZE, true);
+        supervisor_allocation* stack_alloc = allocate_memory(c_size + next_stack_size + EXCEPTION_STACK_SIZE, true, false);
         if (stack_alloc == NULL) {
-            stack_alloc = allocate_memory(c_size + CIRCUITPY_DEFAULT_STACK_SIZE + EXCEPTION_STACK_SIZE, true);
+            stack_alloc = allocate_memory(c_size + CIRCUITPY_DEFAULT_STACK_SIZE + EXCEPTION_STACK_SIZE, true, false);
             current_stack_size = CIRCUITPY_DEFAULT_STACK_SIZE;
         } else {
             current_stack_size = next_stack_size;
         }
+        stack_limit = stack_alloc->ptr;
+        stack_length = get_allocation_length(stack_alloc);
     }
 
-    *stack_alloc->ptr = STACK_CANARY_VALUE;
+    *stack_limit = STACK_CANARY_VALUE;
 }
 
 inline bool stack_ok(void) {
-    return stack_alloc == NULL || *stack_alloc->ptr == STACK_CANARY_VALUE;
+    return stack_limit == NULL || *stack_limit == STACK_CANARY_VALUE;
 }
 
 inline void assert_heap_ok(void) {
@@ -77,16 +83,24 @@ void stack_init(void) {
 }
 
 void stack_resize(void) {
-    if (stack_alloc == NULL) {
+    if (stack_limit == NULL) {
         return;
     }
     if (next_stack_size == current_stack_size) {
-        *stack_alloc->ptr = STACK_CANARY_VALUE;
+        *stack_limit = STACK_CANARY_VALUE;
         return;
     }
-    free_memory(stack_alloc);
-    stack_alloc = NULL;
+    free_memory(allocation_from_ptr(stack_limit));
+    stack_limit = NULL;
     allocate_stack();
+}
+
+uint32_t* stack_get_bottom(void) {
+    return stack_limit;
+}
+
+size_t stack_get_length(void) {
+    return stack_length;
 }
 
 void set_next_stack_size(uint32_t size) {

--- a/supervisor/shared/stack.h
+++ b/supervisor/shared/stack.h
@@ -31,10 +31,12 @@
 
 #include "supervisor/memory.h"
 
-extern supervisor_allocation* stack_alloc;
-
 void stack_init(void);
 void stack_resize(void);
+// Actual stack location and size, may be larger than requested.
+uint32_t* stack_get_bottom(void);
+size_t stack_get_length(void);
+// Next/current requested stack size.
 void set_next_stack_size(uint32_t size);
 uint32_t get_current_stack_size(void);
 bool stack_ok(void);


### PR DESCRIPTION
This allows calls to `allocate_memory()` while the VM is running, it will then allocate from the GC heap (unless there is a suitable hole among the supervisor allocations), and when the VM exits and the GC heap is freed, the allocation will be moved to the bottom of the former GC heap and transformed into a proper supervisor allocation. Existing movable allocations will also be moved to defragment the supervisor heap and ensure that the next VM run gets as much memory as possible for the GC heap.

Allocations embedded in the GC heap are tracked using the same `supervisor_allocation` struct as proper supervisor allocations, transparently to clients. Clients can deal with moving memory either by holding onto their `supervisor_allocation` (which stays valid across the move) and getting its `ptr` (which changes) every time they need to dereference it, or if they held onto the `ptr` directly, get notified using a callback when it changes. The only time moves happen is at the end of a VM run.

This unifies a couple of existing ad-hoc mechanisms doing similar things with the terminal tilegrid, Sharp display framebuffer, and RGBMatrix, and provides the infrastructure for future applications of saving information from one VM run into the next, such as which file to run next (#1084 + #3454), exception traceback from the previous run (#1084, PR forthcoming), and USB descriptors (#1015).

Rationale for the internal design:

* When also tracking embedded GC allocations, the order in the array of `supervisor_allocation`s can no longer match the order in memory, as GC allocations can come in any order. The order, still needed by the regular supervisor heap administration, therefore needs to be tracked in some other way. Let’s use a linked list (or two, one for the low and one for the high side – that also allows treating them the same in some places).
* GC allocations need to be covered by some root pointer to keep them from being collected. The linked list also comes in handy there, because it allows getting by with a single statically allocated root pointer rather than one per allocation: It points to the first block, and each block points to the next. For this to work, the `next` pointers need to be part of the allocated blocks themselves so that the GC can find them, rather than some external structure like `supervisor_allocation`. This introduces the `supervisor_allocation_node` struct, of which the `data` block given to the client is only a part.
* At this point, we may just as well move the `length` from `supervisor_allocation` to `supervisor_allocation_node` too, so that it only takes up memory when actually used. To avoid putting the `supervisor_allocation_node` definition and the `ALLOCATION_NODE` macro in the public header, client access to the length is mediated by a function, `get_allocation_length()`.
* This also allows storing the `MOVABLE` flag (which unlike the existing `HOLE` flag can also be set on allocations that are in use by clients) in the `length` field without confusing clients.
* The only remaining purpose of `supervisor_allocation` is for `supervisor_allocation*` to act as a “handle” or “pointer-to-pointer” to enable clients to deal with moving memory. Keeping it a single-field struct rather than changing it to `typedef uint32_t* supervisor_allocation` improves type safety somewhat.
* For clients that expect a `malloc`-like API and want to hold onto block pointers directly instead of through a “handle”, such as Protomatter in the RGBMatrix case, there needs to be a way of mapping from old to new pointer during a move notification. This is achieved by making `allocation_from_ptr()` expect the old pointer during that time, with the old pointers set aside higher up in the stack.