### PR TITLE
Add supervisor.get_previous_traceback()

### DIFF
--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -147,7 +147,7 @@ STATIC int parse_compile_execute(const void *source, mp_parse_input_kind_t input
         result->return_code = ret;
         if (ret != 0) {
             mp_obj_t return_value = (mp_obj_t)nlr.ret_val;
-            result->exception_type = mp_obj_get_type(return_value);
+            result->exception = return_value;
             result->exception_line = -1;
 
             if (mp_obj_is_exception_instance(return_value)) {

--- a/lib/utils/pyexec.h
+++ b/lib/utils/pyexec.h
@@ -35,7 +35,7 @@ typedef enum {
 
 typedef struct {
     int return_code;
-    const mp_obj_type_t * exception_type;
+    mp_obj_t exception;
     int exception_line;
 } pyexec_result_t;
 

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -48,6 +48,10 @@ msgid " is of type %q\n"
 msgstr ""
 
 #: main.c
+msgid " not found.\n"
+msgstr ""
+
+#: main.c
 msgid " output:\n"
 msgstr ""
 
@@ -2213,7 +2217,7 @@ msgstr ""
 msgid "argsort is not implemented for flattened arrays"
 msgstr ""
 
-#: py/runtime.c
+#: py/runtime.c shared-bindings/supervisor/__init__.c
 msgid "argument has wrong type"
 msgstr ""
 

--- a/main.c
+++ b/main.c
@@ -272,7 +272,11 @@ STATIC bool run_code_py(safe_mode_t safe_mode) {
     result.exception_type = NULL;
     result.exception_line = 0;
 
+    bool skip_repl;
     bool found_main = false;
+    uint8_t next_code_options = 0;
+    // Collects stickiness bits that apply in the current situation.
+    uint8_t next_code_stickiness_situation = SUPERVISOR_NEXT_CODE_OPT_NEWLY_SET;
 
     if (safe_mode == NO_SAFE_MODE) {
         new_status_color(MAIN_RUNNING);
@@ -290,22 +294,62 @@ STATIC bool run_code_py(safe_mode_t safe_mode) {
         supervisor_allocation* heap = allocate_remaining_memory();
         start_mp(heap);
 
-        found_main = maybe_run_list(supported_filenames, &result);
-        #if CIRCUITPY_FULL_BUILD
-        if (!found_main){
-            found_main = maybe_run_list(double_extension_filenames, &result);
-            if (found_main) {
-                serial_write_compressed(translate("WARNING: Your code filename has two extensions\n"));
+        if (next_code_allocation) {
+            ((next_code_info_t*)next_code_allocation->ptr)->options &= ~SUPERVISOR_NEXT_CODE_OPT_NEWLY_SET;
+            next_code_options = ((next_code_info_t*)next_code_allocation->ptr)->options;
+            if (((next_code_info_t*)next_code_allocation->ptr)->filename[0] != '\0') {
+                const char* next_list[] = {((next_code_info_t*)next_code_allocation->ptr)->filename, ""};
+                found_main = maybe_run_list(next_list, &result);
+                if (!found_main) {
+                    serial_write(((next_code_info_t*)next_code_allocation->ptr)->filename);
+                    serial_write_compressed(translate(" not found.\n"));
+                }
             }
         }
-        #endif
+        if (!found_main) {
+            found_main = maybe_run_list(supported_filenames, &result);
+            #if CIRCUITPY_FULL_BUILD
+            if (!found_main){
+                found_main = maybe_run_list(double_extension_filenames, &result);
+                if (found_main) {
+                    serial_write_compressed(translate("WARNING: Your code filename has two extensions\n"));
+                }
+            }
+            #endif
+        }
 
         // TODO: on deep sleep, make sure display is refreshed before sleeping (for e-ink).
 
         cleanup_after_vm(heap);
 
+        // If a new next code file was set, that is a reason to keep it (obviously). Stuff this into
+        // the options because it can be treated like any other reason-for-stickiness bit. The
+        // source is different though: it comes from the options that will apply to the next run,
+        // while the rest of next_code_options is what applied to this run.
+        if (next_code_allocation != NULL && (((next_code_info_t*)next_code_allocation->ptr)->options & SUPERVISOR_NEXT_CODE_OPT_NEWLY_SET)) {
+            next_code_options |= SUPERVISOR_NEXT_CODE_OPT_NEWLY_SET;
+        }
+
+        if (reload_requested) {
+            next_code_stickiness_situation |= SUPERVISOR_NEXT_CODE_OPT_STICKY_ON_RELOAD;
+        }
+        else if (result.return_code == 0) { //TODO mask out PYEXEC_DEEP_SLEEP?
+            next_code_stickiness_situation |= SUPERVISOR_NEXT_CODE_OPT_STICKY_ON_SUCCESS;
+            if (next_code_options & SUPERVISOR_NEXT_CODE_OPT_RELOAD_ON_SUCCESS) {
+                skip_repl = true;
+                goto done;
+            }
+        }
+        else {
+            next_code_stickiness_situation |= SUPERVISOR_NEXT_CODE_OPT_STICKY_ON_ERROR;
+            if (next_code_options & SUPERVISOR_NEXT_CODE_OPT_RELOAD_ON_ERROR) {
+                skip_repl = true;
+                goto done;
+            }
+        }
         if (result.return_code & PYEXEC_FORCED_EXIT) {
-            return reload_requested;
+            skip_repl = reload_requested;
+            goto done;
         }
 
         if (reload_requested && result.return_code == PYEXEC_EXCEPTION) {
@@ -333,9 +377,16 @@ STATIC bool run_code_py(safe_mode_t safe_mode) {
                 board_init();
             }
             #endif
+            next_code_stickiness_situation |= SUPERVISOR_NEXT_CODE_OPT_STICKY_ON_RELOAD;
+            // Should the STICKY_ON_SUCCESS and STICKY_ON_ERROR bits be cleared in
+            // next_code_stickiness_situation? I can see arguments either way, but I'm deciding
+            // "no" for now, mainly because it's a bit less code. At this point, we have both a
+            // success or error and a reload, so let's have both of the respective options take
+            // effect (in OR combination).
             supervisor_set_run_reason(RUN_REASON_AUTO_RELOAD);
             reload_requested = false;
-            return true;
+            skip_repl = true;
+            goto done;
         }
 
         if (serial_connected() && serial_bytes_available()) {
@@ -345,11 +396,11 @@ STATIC bool run_code_py(safe_mode_t safe_mode) {
             }
             #endif
             // Skip REPL if reload was requested.
-            bool ctrl_d = serial_read() == CHAR_CTRL_D;
-            if (ctrl_d) {
+            skip_repl = serial_read() == CHAR_CTRL_D;
+            if (skip_repl) {
                 supervisor_set_run_reason(RUN_REASON_REPL_RELOAD);
             }
-            return ctrl_d;
+            goto done;
         }
 
         // Check for a deep sleep alarm and restart the VM. This can happen if
@@ -428,6 +479,13 @@ STATIC bool run_code_py(safe_mode_t safe_mode) {
             port_idle_until_interrupt();
         }
     }
+
+done:
+    if ((next_code_options & next_code_stickiness_situation) == 0) {
+        free_memory(next_code_allocation);
+        next_code_allocation = NULL;
+    }
+    return skip_repl;
 }
 
 FIL* boot_output_file;

--- a/main.c
+++ b/main.c
@@ -57,6 +57,7 @@
 #include "supervisor/shared/safe_mode.h"
 #include "supervisor/shared/stack.h"
 #include "supervisor/shared/status_leds.h"
+#include "supervisor/shared/traceback.h"
 #include "supervisor/shared/translate.h"
 #include "supervisor/shared/workflow.h"
 #include "supervisor/usb.h"
@@ -216,7 +217,41 @@ STATIC bool maybe_run_list(const char * const * filenames, pyexec_result_t* exec
     return true;
 }
 
-STATIC void cleanup_after_vm(supervisor_allocation* heap) {
+STATIC void count_strn(void *data, const char *str, size_t len) {
+    *(size_t*)data += len;
+}
+
+STATIC void cleanup_after_vm(supervisor_allocation* heap, mp_obj_t exception) {
+    // Get the traceback of any exception from this run off the heap.
+    // MP_OBJ_SENTINEL means "this run does not contribute to traceback storage, don't touch it"
+    // MP_OBJ_NULL (=0) means "this run completed successfully, clear any stored traceback"
+    if (exception != MP_OBJ_SENTINEL) {
+        free_memory(prev_traceback_allocation);
+        // ReloadException is exempt from traceback printing in pyexec_file(), so treat it as "no
+        // traceback" here too.
+        if (exception && exception != MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_reload_exception))) {
+            size_t traceback_len = 0;
+            mp_print_t print_count = {&traceback_len, count_strn};
+            mp_obj_print_exception(&print_count, exception);
+            prev_traceback_allocation = allocate_memory(align32_size(traceback_len + 1), false, true);
+            // Empirically, this never fails in practice - even when the heap is totally filled up
+            // with single-block-sized objects referenced by a root pointer, exiting the VM frees
+            // up several hundred bytes, sufficient for the traceback (which tends to be shortened
+            // because there wasn't memory for the full one). There may be convoluted ways of
+            // making it fail, but at this point I believe they are not worth spending code on.
+            if (prev_traceback_allocation != NULL) {
+                vstr_t vstr;
+                vstr_init_fixed_buf(&vstr, traceback_len, (char*)prev_traceback_allocation->ptr);
+                mp_print_t print = {&vstr, (mp_print_strn_t)vstr_add_strn};
+                mp_obj_print_exception(&print, exception);
+                ((char*)prev_traceback_allocation->ptr)[traceback_len] = '\0';
+            }
+        }
+        else {
+            prev_traceback_allocation = NULL;
+        }
+    }
+
     // Reset port-independent devices, like CIRCUITPY_BLEIO_HCI.
     reset_devices();
     // Turn off the display and flush the filesystem before the heap disappears.
@@ -269,7 +304,7 @@ STATIC bool run_code_py(safe_mode_t safe_mode) {
     pyexec_result_t result;
 
     result.return_code = 0;
-    result.exception_type = NULL;
+    result.exception = MP_OBJ_NULL;
     result.exception_line = 0;
 
     bool skip_repl;
@@ -320,7 +355,7 @@ STATIC bool run_code_py(safe_mode_t safe_mode) {
 
         // TODO: on deep sleep, make sure display is refreshed before sleeping (for e-ink).
 
-        cleanup_after_vm(heap);
+        cleanup_after_vm(heap, result.exception);
 
         // If a new next code file was set, that is a reason to keep it (obviously). Stuff this into
         // the options because it can be treated like any other reason-for-stickiness bit. The
@@ -554,7 +589,8 @@ STATIC void __attribute__ ((noinline)) run_boot_py(safe_mode_t safe_mode) {
         start_mp(heap);
 
         // TODO(tannewt): Re-add support for flashing boot error output.
-        bool found_boot = maybe_run_list(boot_py_filenames, NULL);
+        pyexec_result_t result = {0, MP_OBJ_NULL, 0};
+        bool found_boot = maybe_run_list(boot_py_filenames, &result);
         (void) found_boot;
 
         #ifdef CIRCUITPY_BOOT_OUTPUT_FILE
@@ -565,7 +601,7 @@ STATIC void __attribute__ ((noinline)) run_boot_py(safe_mode_t safe_mode) {
         boot_output_file = NULL;
         #endif
 
-        cleanup_after_vm(heap);
+        cleanup_after_vm(heap, result.exception);
     }
 }
 
@@ -582,7 +618,7 @@ STATIC int run_repl(void) {
     } else {
         exit_code = pyexec_friendly_repl();
     }
-    cleanup_after_vm(heap);
+    cleanup_after_vm(heap, MP_OBJ_SENTINEL);
     autoreload_resume();
     return exit_code;
 }

--- a/supervisor/shared/autoreload.c
+++ b/supervisor/shared/autoreload.c
@@ -30,6 +30,8 @@
 #include "py/reload.h"
 #include "supervisor/shared/tick.h"
 
+supervisor_allocation* next_code_allocation;
+
 static volatile uint32_t autoreload_delay_ms = 0;
 static bool autoreload_enabled = false;
 static bool autoreload_suspended = false;

--- a/supervisor/shared/autoreload.h
+++ b/supervisor/shared/autoreload.h
@@ -29,6 +29,24 @@
 
 #include <stdbool.h>
 
+#include "supervisor/memory.h"
+
+enum {
+	SUPERVISOR_NEXT_CODE_OPT_RELOAD_ON_SUCCESS = 0x1,
+	SUPERVISOR_NEXT_CODE_OPT_RELOAD_ON_ERROR = 0x2,
+	SUPERVISOR_NEXT_CODE_OPT_STICKY_ON_SUCCESS = 0x4,
+	SUPERVISOR_NEXT_CODE_OPT_STICKY_ON_ERROR = 0x8,
+	SUPERVISOR_NEXT_CODE_OPT_STICKY_ON_RELOAD = 0x10,
+	SUPERVISOR_NEXT_CODE_OPT_NEWLY_SET = 0x20,
+};
+
+typedef struct {
+    uint8_t options;
+    char filename[];
+} next_code_info_t;
+
+extern supervisor_allocation* next_code_allocation;
+
 extern volatile bool reload_requested;
 
 void autoreload_tick(void);

--- a/supervisor/shared/memory.c
+++ b/supervisor/shared/memory.c
@@ -36,6 +36,8 @@ enum {
     CIRCUITPY_SUPERVISOR_IMMOVABLE_ALLOC_COUNT =
     // stack + heap
     2
+    // next_code_allocation
+    + 1
 #ifdef EXTERNAL_FLASH_DEVICES
     + 1
 #endif

--- a/supervisor/shared/memory.c
+++ b/supervisor/shared/memory.c
@@ -38,6 +38,8 @@ enum {
     2
     // next_code_allocation
     + 1
+    // prev_traceback_allocation
+    + 1
 #ifdef EXTERNAL_FLASH_DEVICES
     + 1
 #endif

--- a/supervisor/shared/rgb_led_status.c
+++ b/supervisor/shared/rgb_led_status.c
@@ -391,22 +391,25 @@ void prep_rgb_status_animation(const pyexec_result_t* result,
     if (!status->ok) {
         status->total_exception_cycle = EXCEPTION_TYPE_LENGTH_MS * 3 + LINE_NUMBER_TOGGLE_LENGTH * status->digit_sum + LINE_NUMBER_TOGGLE_LENGTH * num_places;
     }
-    if (!result->exception_type) {
+    if (!result->exception) {
         status->exception_color = OTHER_ERROR;
-    } else if (mp_obj_is_subclass_fast(result->exception_type, &mp_type_IndentationError)) {
-        status->exception_color = INDENTATION_ERROR;
-    } else if (mp_obj_is_subclass_fast(result->exception_type, &mp_type_SyntaxError)) {
-        status->exception_color = SYNTAX_ERROR;
-    } else if (mp_obj_is_subclass_fast(result->exception_type, &mp_type_NameError)) {
-        status->exception_color = NAME_ERROR;
-    } else if (mp_obj_is_subclass_fast(result->exception_type, &mp_type_OSError)) {
-        status->exception_color = OS_ERROR;
-    } else if (mp_obj_is_subclass_fast(result->exception_type, &mp_type_ValueError)) {
-        status->exception_color = VALUE_ERROR;
-    } else if (mp_obj_is_subclass_fast(result->exception_type, &mp_type_MpyError)) {
-        status->exception_color = MPY_ERROR;
     } else {
-        status->exception_color = OTHER_ERROR;
+        mp_obj_type_t* exception_type = mp_obj_get_type(result->exception);
+        if (mp_obj_is_subclass_fast(exception_type, &mp_type_IndentationError)) {
+            status->exception_color = INDENTATION_ERROR;
+        } else if (mp_obj_is_subclass_fast(exception_type, &mp_type_SyntaxError)) {
+            status->exception_color = SYNTAX_ERROR;
+        } else if (mp_obj_is_subclass_fast(exception_type, &mp_type_NameError)) {
+            status->exception_color = NAME_ERROR;
+        } else if (mp_obj_is_subclass_fast(exception_type, &mp_type_OSError)) {
+            status->exception_color = OS_ERROR;
+        } else if (mp_obj_is_subclass_fast(exception_type, &mp_type_ValueError)) {
+            status->exception_color = VALUE_ERROR;
+        } else if (mp_obj_is_subclass_fast(exception_type, &mp_type_MpyError)) {
+            status->exception_color = MPY_ERROR;
+        } else {
+            status->exception_color = OTHER_ERROR;
+        }
     }
     #endif
 }

--- a/supervisor/shared/traceback.c
+++ b/supervisor/shared/traceback.c
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Christian Walther
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "traceback.h"
+
+supervisor_allocation* prev_traceback_allocation;

--- a/supervisor/shared/traceback.h
+++ b/supervisor/shared/traceback.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Christian Walther
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SUPERVISOR_TRACEBACK_H
+#define MICROPY_INCLUDED_SUPERVISOR_TRACEBACK_H
+
+#include "supervisor/memory.h"
+
+extern supervisor_allocation* prev_traceback_allocation;
+
+#endif  // MICROPY_INCLUDED_SUPERVISOR_TRACEBACK_H

--- a/supervisor/supervisor.mk
+++ b/supervisor/supervisor.mk
@@ -12,6 +12,7 @@ SRC_SUPERVISOR = \
 	supervisor/shared/stack.c \
 	supervisor/shared/status_leds.c \
 	supervisor/shared/tick.c \
+	supervisor/shared/traceback.c \
 	supervisor/shared/translate.c
 
 ifndef $(NO_USB)


### PR DESCRIPTION
As discussed in #1084, when a VM run ends with an exception, this uses the movable allocation system to preserve the traceback across a soft reload and lets the next VM run retrieve it using `supervisor.get_previous_traceback()`.

Only the last commit is relevant, the next to last is #3454 (which it is not dependent on and could be rebased off if desired) and the rest is #3695 (which is required).

Open questions from my point of view:

* Should this be optional, or is the added weight in code size and RAM usage considered worth it for all ports?
* Should a REPL run clear the stored traceback? (It can’t end with an exception itself.) This implementation ignores REPL runs because that seemed to make sense on paper, but once implemented I found that behavior surprising myself at one point, so I’m now inclined toward changing it (which would also be a simplification, removing a special case). Or can anyone think of a use for it?
* Please take a close look at what I’m doing in `supervisor_get_previous_traceback()`. As far as I understand, it works correctly, but my understanding of how the garbage collector works and how strings work may be incomplete. Also, am I inappropriately using non-API (implementation details) of the string class by assembling an `mp_obj_str_t` object by hand? There doesn’t seem to be a macro/function for what I want.
* Adding a new C file for a single variable feels like overkill, but it didn’t seem to fit in any of the existing ones. Any opinions?