### PR TITLE
esp32s2: Set station mode early to avoid SoftAP on startup

### DIFF
--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -72,6 +72,8 @@ void common_hal_wifi_radio_set_enabled(wifi_radio_obj_t *self, bool enabled) {
         return;
     }
     if (!self->started && enabled) {
+	// esp_wifi_start() would default to soft-AP, thus setting it to station
+        ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
         ESP_ERROR_CHECK(esp_wifi_start());
         self->started = true;
         return;


### PR DESCRIPTION
The behaviour that an Access Point is seen early during bring-up is also mentioned in #3321 by @anecdata  
@tannewt would be happy if you could review.

The below was the output before this (with DEBUG=1)
I (3996) wifi_init: WiFi RX IRAM OP enabled
I (4116) phy: phy_version: 603, 72dfd77, Jul  7 2020, 19:57:05, 0, 2
I (4116) wifi:enable tsf
**I (4116) wifi:mode : softAP (7c:df:a1:03:b7:a5)**
I (4116) wifi:Total power save buffer number: 8
I (4126) wifi:Init max length of beacon: 752/752
I (4126) wifi:Init max length of beacon: 752/752
**I (5266) wifi:mode : sta (7c:df:a1:03:b7:a4)**