### PR TITLE
esp32: Two random changes that also fixed the I2C crash for me

### DIFF
--- a/ports/esp32s2/common-hal/pulseio/PulseIn.c
+++ b/ports/esp32s2/common-hal/pulseio/PulseIn.c
@@ -77,7 +77,9 @@ void pulsein_reset(void) {
     for (size_t i = 0; i < RMT_CHANNEL_MAX; i++) {
         handles[i] = NULL;
     }
-    supervisor_disable_tick();
+    if (refcount != 0) {
+        supervisor_disable_tick();
+    }
     refcount = 0;
 }
 
@@ -122,8 +124,10 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self, const mcu
 
     // start RMT RX, and enable ticks so the core doesn't turn off.
     rmt_rx_start(channel, true);
-    supervisor_enable_tick();
     refcount++;
+    if (refcount == 1) {
+        supervisor_enable_tick();
+    }
 }
 
 bool common_hal_pulseio_pulsein_deinited(pulseio_pulsein_obj_t* self) {

--- a/ports/esp32s2/supervisor/port.c
+++ b/ports/esp32s2/supervisor/port.c
@@ -191,14 +191,14 @@ uint32_t port_get_saved_word(void) {
 }
 
 uint64_t port_get_raw_ticks(uint8_t* subticks) {
-    struct timeval tv_now;
-    gettimeofday(&tv_now, NULL);
-    // convert usec back to ticks
-    uint64_t all_subticks = (uint64_t)(tv_now.tv_usec * 2) / 71;
+    // Convert microseconds to subticks of 1/32768 seconds
+    // 32768/1000000 = 64/15625 in lowest terms
+    // this arithmetic overflows after 570 years
+    int64_t all_subticks = esp_timer_get_time() * 512 / 15625;
     if (subticks != NULL) {
         *subticks = all_subticks % 32;
     }
-    return (uint64_t)tv_now.tv_sec * 1024L + all_subticks / 32;
+    return all_subticks / 32;
 }
 
 // Enable 1/1024 second tick.


### PR DESCRIPTION
While I didn't get anything sensible out of my debugging efforts today (I'm not getting full tracebacks in gdb so it's hard to interpret where I am) I noticed that there (A) seemed to be problems with background ticks and (B) maybe something scheduled from an interrupt was taking too long.  Beyond that, I don't have a good explanation, but since making these changes I have seen my test program on #3572 stop crashing on the Kaluga, and I also edited-and-reloaded a bunch of iterations of a temperature display program on a Magtag without any crashes or lockups.