### PR TITLE
Return fixed stack on Spresense

### DIFF
--- a/ports/cxd56/supervisor/port.c
+++ b/ports/cxd56/supervisor/port.c
@@ -98,8 +98,12 @@ void reset_to_bootloader(void) {
     }
 }
 
+supervisor_allocation _fixed_stack;
+
 supervisor_allocation* port_fixed_stack(void) {
-    return NULL;
+    _fixed_stack.ptr = port_stack_get_limit();
+    _fixed_stack.length = (port_stack_get_top() - port_stack_get_limit()) * sizeof(uint32_t);
+    return &_fixed_stack;
 }
 
 uint32_t *port_stack_get_limit(void) {


### PR DESCRIPTION
Spresense also has a fixed stack, so `port_fixed_stack()` should not return `NULL`.

It was pointed here: https://github.com/adafruit/circuitpython/pull/3695