### PR TITLE
esp32s2: Do a full scan when channel/BSSID are not given

### DIFF
--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -142,10 +142,10 @@ wifi_radio_error_t common_hal_wifi_radio_connect(wifi_radio_obj_t *self, uint8_t
     } else {
         config->sta.bssid_set = 0;
     }
-    // if channel and bssid both not set, do a full scan instead of fast scan
-    // this will ensure that the best AP is chosen automatically
-    if ((self->sta.bssid_set == 0) && (self->sta.channel == NULL)) {
-        config.scan_method = WIFI_ALL_CHANNEL_SCAN;
+    // If channel is 0 (default/unset) and BSSID is not given, do a full scan instead of fast scan
+    // This will ensure that the best AP in range is chosen automatically
+    if ((config->sta.bssid_set == 0) && (config->sta.channel == 0)) {
+        config->sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
     }
     esp_wifi_set_config(ESP_IF_WIFI_STA, config);
     self->starting_retries = 5;

--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -142,6 +142,11 @@ wifi_radio_error_t common_hal_wifi_radio_connect(wifi_radio_obj_t *self, uint8_t
     } else {
         config->sta.bssid_set = 0;
     }
+    // if channel and bssid both not set, do a full scan instead of fast scan
+    // this will ensure that the best AP is chosen automatically
+    if ((self->sta.bssid_set == 0) && (self->sta.channel == NULL)) {
+        config.scan_method = WIFI_ALL_CHANNEL_SCAN;
+    }
     esp_wifi_set_config(ESP_IF_WIFI_STA, config);
     self->starting_retries = 5;
     self->retries_left = 5;

--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -146,6 +146,8 @@ wifi_radio_error_t common_hal_wifi_radio_connect(wifi_radio_obj_t *self, uint8_t
     // This will ensure that the best AP in range is chosen automatically
     if ((config->sta.bssid_set == 0) && (config->sta.channel == 0)) {
         config->sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+    } else {
+        config->sta.scan_method = WIFI_FAST_SCAN;
     }
     esp_wifi_set_config(ESP_IF_WIFI_STA, config);
     self->starting_retries = 5;


### PR DESCRIPTION
Whenever you connect to your Wi-Fi network / SSID just with the following code the first AP that matches the SSID will be chosen, even if there is another AP with better signal strength (RSSI).

wifi.radio.connect(mysecrets["ssid"], mysecrets["password"])

This commit will enhance the function to do a full scan (across all channels) whenever channel/BSSID are omitted.