### PR TITLE
ESP32S2: common_hal_mcu_delay_us() now calls mp_hal_delay_us()

### DIFF
--- a/ports/esp32s2/common-hal/microcontroller/__init__.c
+++ b/ports/esp32s2/common-hal/microcontroller/__init__.c
@@ -42,7 +42,7 @@
 #include "freertos/FreeRTOS.h"
 
 void common_hal_mcu_delay_us(uint32_t delay) {
-
+    mp_hal_delay_us(delay);
 }
 
 volatile uint32_t nesting_count = 0;


### PR DESCRIPTION
Fixes #3739 