### PR TITLE
Exit faster on recv when TLS connection closed

### DIFF
--- a/ports/esp32s2/common-hal/socketpool/Socket.c
+++ b/ports/esp32s2/common-hal/socketpool/Socket.c
@@ -103,6 +103,11 @@ mp_uint_t common_hal_socketpool_socket_recv_into(socketpool_socket_obj_t* self, 
         }
         if (available > 0) {
             status = esp_tls_conn_read(self->tcp, (void*) buf + received, available);
+            if (status == 0) {
+                // Reading zero when something is available indicates a closed
+                // connection. (The available bytes could have been TLS internal.)
+                break;
+            }
             if (status > 0) {
                 received += status;
             }


### PR DESCRIPTION
When a TLS connection is closed by the server it usually sends a
notice. We see this incoming byte with lwip_ioctl and try to read
it. The read returns 0 but we keep trying anyway. Now, we quit
trying when we get zero back. If the connection was still alive
it'd either read a byte or delay until a byte could be read.