### PR TITLE
ESP UART pins misnamed on some boards

### DIFF
--- a/ports/atmel-samd/boards/pybadge_airlift/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pybadge_airlift/mpconfigboard.h
@@ -23,9 +23,6 @@
 #define DEFAULT_SPI_BUS_MOSI (&pin_PB23)
 #define DEFAULT_SPI_BUS_MISO (&pin_PB22)
 
-#define DEFAULT_UART_BUS_RX (&pin_PB17)
-#define DEFAULT_UART_BUS_TX (&pin_PB16)
-
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1

--- a/ports/atmel-samd/boards/pybadge_airlift/pins.c
+++ b/ports/atmel-samd/boards/pybadge_airlift/pins.c
@@ -30,12 +30,6 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     {MP_OBJ_NEW_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_PA22)},
     {MP_OBJ_NEW_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_PA23)},
 
-    // ESP UART
-    {MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RX), MP_ROM_PTR(&pin_PB17)},
-    {MP_OBJ_NEW_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_PB17)},
-    {MP_OBJ_NEW_QSTR(MP_QSTR_ESP_TX), MP_ROM_PTR(&pin_PB16)},
-    {MP_OBJ_NEW_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_PB16)},
-
     // I2C
     {MP_OBJ_NEW_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_PA12)},
     {MP_OBJ_NEW_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_PA13)},
@@ -60,6 +54,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     {MP_OBJ_NEW_QSTR(MP_QSTR_ESP_GPIO0), MP_ROM_PTR(&pin_PA31)},
     {MP_OBJ_NEW_QSTR(MP_QSTR_ESP_BUSY), MP_ROM_PTR(&pin_PA00)},
     {MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RESET), MP_ROM_PTR(&pin_PB12)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_ESP_TX), MP_ROM_PTR(&pin_PB16)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RX), MP_ROM_PTR(&pin_PB17)},
 
     // TFT control pins
     {MP_OBJ_NEW_QSTR(MP_QSTR_TFT_LITE), MP_ROM_PTR(&pin_PA01)},
@@ -71,7 +67,6 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     {MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj)},
     {MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj)},
-    {MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj)},
 
     {MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display)}};
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);

--- a/ports/atmel-samd/boards/pybadge_airlift/pins.c
+++ b/ports/atmel-samd/boards/pybadge_airlift/pins.c
@@ -30,8 +30,10 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     {MP_OBJ_NEW_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_PA22)},
     {MP_OBJ_NEW_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_PA23)},
 
-    // UART
+    // ESP UART
+    {MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RX), MP_ROM_PTR(&pin_PB17)},
     {MP_OBJ_NEW_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_PB17)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_ESP_TX), MP_ROM_PTR(&pin_PB16)},
     {MP_OBJ_NEW_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_PB16)},
 
     // I2C

--- a/ports/atmel-samd/boards/pyportal/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pyportal/mpconfigboard.h
@@ -24,9 +24,6 @@
 #define DEFAULT_SPI_BUS_MOSI (&pin_PA12)
 #define DEFAULT_SPI_BUS_MISO (&pin_PA14)
 
-#define DEFAULT_UART_BUS_RX (&pin_PB13)
-#define DEFAULT_UART_BUS_TX (&pin_PB12)
-
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1

--- a/ports/atmel-samd/boards/pyportal/pins.c
+++ b/ports/atmel-samd/boards/pyportal/pins.c
@@ -58,11 +58,7 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_BUSY), MP_ROM_PTR(&pin_PB16) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RESET), MP_ROM_PTR(&pin_PB17) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RTS), MP_ROM_PTR(&pin_PA15) },
-
-    // UART
-    { MP_OBJ_NEW_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_PB12) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_TX), MP_ROM_PTR(&pin_PB12) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_PB13) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RX), MP_ROM_PTR(&pin_PB13) },
 
     // SPI
@@ -80,7 +76,6 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
-    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display) },
 };

--- a/ports/atmel-samd/boards/pyportal/pins.c
+++ b/ports/atmel-samd/boards/pyportal/pins.c
@@ -61,7 +61,9 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     // UART
     { MP_OBJ_NEW_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_PB12) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_TX), MP_ROM_PTR(&pin_PB12) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_PB13) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RX), MP_ROM_PTR(&pin_PB13) },
 
     // SPI
     { MP_OBJ_NEW_QSTR(MP_QSTR_MOSI),MP_ROM_PTR(&pin_PA12) },

--- a/ports/atmel-samd/boards/pyportal_titano/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pyportal_titano/mpconfigboard.h
@@ -22,9 +22,6 @@
 #define DEFAULT_SPI_BUS_MOSI (&pin_PA12)
 #define DEFAULT_SPI_BUS_MISO (&pin_PA14)
 
-#define DEFAULT_UART_BUS_RX (&pin_PB13)
-#define DEFAULT_UART_BUS_TX (&pin_PB12)
-
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1

--- a/ports/atmel-samd/boards/pyportal_titano/pins.c
+++ b/ports/atmel-samd/boards/pyportal_titano/pins.c
@@ -59,8 +59,11 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RESET), MP_ROM_PTR(&pin_PB17) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RTS), MP_ROM_PTR(&pin_PA15) },
 
-    // UART
+    // ESP UART
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_TX), MP_ROM_PTR(&pin_PB12) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_PB12) },
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RX), MP_ROM_PTR(&pin_PB13) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_PB13) },
 
     // SPI

--- a/ports/atmel-samd/boards/pyportal_titano/pins.c
+++ b/ports/atmel-samd/boards/pyportal_titano/pins.c
@@ -58,13 +58,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_BUSY), MP_ROM_PTR(&pin_PB16) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RESET), MP_ROM_PTR(&pin_PB17) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RTS), MP_ROM_PTR(&pin_PA15) },
-
-    // ESP UART
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_TX), MP_ROM_PTR(&pin_PB12) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_PB12) },
-
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RX), MP_ROM_PTR(&pin_PB13) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_PB13) },
 
     // SPI
     { MP_OBJ_NEW_QSTR(MP_QSTR_MOSI),MP_ROM_PTR(&pin_PA12) },
@@ -81,7 +76,6 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
-    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display) },
 };


### PR DESCRIPTION
I was helping someone with a PyPortal-using-BLE issue, and it turns out the ESP TX/RX pins on a few Airlift-style boards are labeled only `RX` and `TX`, even though they are only connected to the ESP32. This makes them incompatible with the `adafruit-airlift` library right now without giving different pin names.

This PR adds `ESP_TX` and `ESP_RX` names to the existing `TX` and `RX` pins, which is upward compatible.

_However_, I think that it would actually be better to remove the `TX` and `RX` names and also `board.UART()`, since these are not externally available pins.

If you agree, let me know and I'll revise this draft PR. One or two Guides would have to be updated as well.