### PR TITLE
#3702 breaks printing an exception twice

### DIFF
--- a/py/obj.c
+++ b/py/obj.c
@@ -125,7 +125,6 @@ void mp_obj_print_exception(const mp_print_t *print, mp_obj_t exc) {
                     mp_printf(print, decompressed_block, block);
                 }
             }
-            mp_obj_exception_clear_traceback(exc);
         }
     }
     mp_obj_print_helper(print, exc, PRINT_EXC);


### PR DESCRIPTION
Just so it isn’t forgotten, since I can’t seem to reopen #3702:

I believe the fix proposed there is wrong: It prevents printing an exception twice, which I do in #3696 (once to measure the length of the traceback, once to get the text) and which people may want to do for other reasons, it’s available from Python via `sys.print_exception()`. (For some reason, it also causes the `terminalio` screen to be drawn over the `stage` screen, haven’t investigated that yet.)

The problem observed in #2056 is specific to `adafruit_midi` in that it raises the same exception instance every time, a usage that apparently wasn’t anticipated in the core. Will have to dig deeper into how exceptions work to figure out how to properly fix that. It may be nontrivial – there would need to be a way to distinguish an exception reused in the way `adafruit_midi` does it from one re-raised in an `except` block.

In fact, I’m not sure it should be fixed, since CPython appears to do the same:
```
Python 3.8.3 (default, Jul  8 2020, 14:25:02) 
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> e = ValueError('X')
>>> raise e
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    <?xml version="1.0" encoding="UTF-8"?>
ValueError: X
>>> raise e
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    <?xml version="1.0" encoding="UTF-8"?>
  File "<stdin>", line 1, in <module>
    <?xml version="1.0" encoding="UTF-8"?>
ValueError: X
>>> raise e
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    <?xml version="1.0" encoding="UTF-8"?>
  File "<stdin>", line 1, in <module>
    <?xml version="1.0" encoding="UTF-8"?>
  File "<stdin>", line 1, in <module>
    <?xml version="1.0" encoding="UTF-8"?>
ValueError: X
```

So maybe the proper fix is rather to make `adafruit_midi` stop reusing exceptions. @kevinjwalters, looks like that would be your territory? It comes from https://github.com/adafruit/Adafruit_CircuitPython_MIDI/commit/0f963573639d2acf7c73f3e8b58acae85b420db7.