### PR TITLE
Make ResetReason and RunReason available

### DIFF
--- a/shared-bindings/alarm/__init__.c
+++ b/shared-bindings/alarm/__init__.c
@@ -125,8 +125,8 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(alarm_light_sleep_until_alarms_obj, 1, MP_OB
 //|
 //|     If no alarms are specified, the microcontroller will deep sleep until reset.
 //|
-//|     **If CircuitPython is connected to a host computer, `alarm.exit_and_deep_sleep_until_alarms()`
-//|     then the connection will be maintained, and the system will not go into deep sleep.**
+//|     **If CircuitPython is connected to a host computer, the connection will be maintained,
+//|     and the system will not go into deep sleep.**
 //|     This allows the user to interrupt an existing program with ctrl-C,
 //|     and to edit the files in CIRCUITPY, which would not be possible in true deep sleep.
 //|     Thus, to use deep sleep and save significant power, you will need to disconnect from the host.

--- a/shared-bindings/microcontroller/ResetReason.c
+++ b/shared-bindings/microcontroller/ResetReason.c
@@ -72,6 +72,6 @@ MAKE_ENUM_MAP(mcu_reset_reason) {
 };
 STATIC MP_DEFINE_CONST_DICT(mcu_reset_reason_locals_dict, mcu_reset_reason_locals_table);
 
-MAKE_PRINTER(alarm, mcu_reset_reason);
+MAKE_PRINTER(microcontroller, mcu_reset_reason);
 
-MAKE_ENUM_TYPE(alarm, ResetReason, mcu_reset_reason);
+MAKE_ENUM_TYPE(microcontroller, ResetReason, mcu_reset_reason);

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -170,6 +170,7 @@ STATIC const mp_rom_map_elem_t mcu_module_globals_table[] = {
     #else
     { MP_ROM_QSTR(MP_QSTR_watchdog),  MP_ROM_PTR(&mp_const_none_obj) },
     #endif
+    { MP_ROM_QSTR(MP_QSTR_ResetReason),  MP_ROM_PTR(&mcu_reset_reason_type) },
     { MP_ROM_QSTR(MP_QSTR_RunMode),  MP_ROM_PTR(&mcu_runmode_type) },
     { MP_ROM_QSTR(MP_QSTR_Pin),  MP_ROM_PTR(&mcu_pin_type) },
     { MP_ROM_QSTR(MP_QSTR_pin),  MP_ROM_PTR(&mcu_pin_module) },

--- a/shared-bindings/microcontroller/__init__.h
+++ b/shared-bindings/microcontroller/__init__.h
@@ -1,4 +1,3 @@
-
 /*
  * This file is part of the MicroPython project, http://micropython.org/
  *

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -119,6 +119,7 @@ STATIC const mp_rom_map_elem_t supervisor_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_set_rgb_status_brightness),  MP_ROM_PTR(&supervisor_set_rgb_status_brightness_obj) },
     { MP_ROM_QSTR(MP_QSTR_runtime),  MP_ROM_PTR(&common_hal_supervisor_runtime_obj) },
     { MP_ROM_QSTR(MP_QSTR_reload),  MP_ROM_PTR(&supervisor_reload_obj) },
+    { MP_ROM_QSTR(MP_QSTR_RunReason),  MP_ROM_PTR(&supervisor_run_reason_type) },
     { MP_ROM_QSTR(MP_QSTR_set_next_stack_limit),  MP_ROM_PTR(&supervisor_set_next_stack_limit_obj) },
 
 };


### PR DESCRIPTION
- `microcontroller.ResetReason` and `supervisor.RunReason` were missing from the corresponding module dictionaries, making them unavailable.
- The printer for `ResetReason` mistakenly was saying it was part of `alarm`.
- Fixed a typo in deep-sleep API documentation.
- Remove a blank line at the top of a file (found accidentally).

Testing:
```python
>>> import microcontroller
>>> microcontroller.<tab>
Pin             Processor       ResetReason     RunMode
cpu             delay_us        disable_interrupts
enable_interrupts               nvm             on_next_reset
pin             reset           watchdog
>>> microcontroller.ResetReason.<tab>
BROWNOUT        DEEP_SLEEP_ALARM                POWER_ON
RESET_PIN       SOFTWARE        UNKNOWN         WATCHDOG
>>> microcontroller.cpu.reset_reason
microcontroller.ResetReason.POWER_ON
>>> microcontroller.cpu.reset_reason == microcontroller.ResetReason.POWER_ON
True
>>> microcontroller.cpu.reset_reason == microcontroller.ResetReason.BROWNOUT
False
>>> import supervisor
>>> supervisor.runtime.run_reason
supervisor.RunReason.STARTUP
>>> supervisor.RunReason.STARTUP == supervisor.runtime.run_reason
True
```
