### PR TITLE
Include wifi.radio singleton in gc

### DIFF
--- a/main.c
+++ b/main.c
@@ -95,6 +95,10 @@
 #include "common-hal/canio/CAN.h"
 #endif
 
+#if CIRCUITPY_WIFI
+#include "shared-bindings/wifi/__init__.h"
+#endif
+
 #if MICROPY_ENABLE_PYSTACK
 static size_t PLACE_IN_DTCM_BSS(_pystack[CIRCUITPY_PYSTACK_SIZE / sizeof(size_t)]);
 #endif
@@ -558,6 +562,10 @@ void gc_collect(void) {
 
     #if CIRCUITPY_BLEIO
     common_hal_bleio_gc_collect();
+    #endif
+
+    #if CIRCUITPY_WIFI
+    common_hal_wifi_gc_collect();
     #endif
 
     // This naively collects all object references from an approximate stack

--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -31,6 +31,7 @@
 
 #include "common-hal/wifi/__init__.h"
 #include "lib/utils/interrupt_char.h"
+#include "py/gc.h"
 #include "py/runtime.h"
 #include "shared-bindings/ipaddress/IPv4Address.h"
 #include "shared-bindings/wifi/ScannedNetworks.h"
@@ -261,4 +262,9 @@ mp_int_t common_hal_wifi_radio_ping(wifi_radio_obj_t *self, mp_obj_t ip_address,
     esp_ping_delete_session(ping);
 
     return elapsed_time;
+}
+
+void common_hal_wifi_radio_gc_collect(wifi_radio_obj_t *self) {
+    // Only bother to scan the actual object references.
+    gc_collect_ptr(self->current_scan);
 }

--- a/ports/esp32s2/common-hal/wifi/Radio.h
+++ b/ports/esp32s2/common-hal/wifi/Radio.h
@@ -59,4 +59,6 @@ typedef struct {
     uint8_t last_disconnect_reason;
 } wifi_radio_obj_t;
 
+extern void common_hal_wifi_radio_gc_collect(wifi_radio_obj_t *self);
+
 #endif // MICROPY_INCLUDED_ESP32S2_COMMON_HAL_WIFI_RADIO_H

--- a/ports/esp32s2/common-hal/wifi/__init__.c
+++ b/ports/esp32s2/common-hal/wifi/__init__.c
@@ -160,3 +160,7 @@ void ipaddress_ipaddress_to_esp_idf(mp_obj_t ip_address, ip_addr_t* esp_ip_addre
 
     IP_ADDR4(esp_ip_address, bytes[0], bytes[1], bytes[2], bytes[3]);
 }
+
+void common_hal_wifi_gc_collect(void) {
+    common_hal_wifi_radio_gc_collect(&common_hal_wifi_radio_obj);
+}

--- a/shared-bindings/wifi/__init__.h
+++ b/shared-bindings/wifi/__init__.h
@@ -34,5 +34,6 @@
 extern wifi_radio_obj_t common_hal_wifi_radio_obj;
 
 void common_hal_wifi_init(void);
+void common_hal_wifi_gc_collect(void);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_WIFI___INIT___H


### PR DESCRIPTION
The `wifi.radio` singleton object, which is in static storage, was not included in GC scanning. It does include one Python object.

It could have been added to `ROOT_POINTERS`, but instead I added a module-specific GC routine, as has been done in, for example, `displayio` and `_bleio` for similar static objects.

I hoped this might fix the ESP32-S2 I2C/WiFi hang. It didn't, sadly. But I think this is still necessary, unless my understanding about what needs to be scanned for GC is confused. (I keep having to re-derive this in my head.)