### PR TITLE
Enhance debug log for wifi scan, sta_start, sta_stop

### DIFF
--- a/ports/esp32s2/common-hal/wifi/__init__.c
+++ b/ports/esp32s2/common-hal/wifi/__init__.c
@@ -47,7 +47,14 @@ static void event_handler(void* arg, esp_event_base_t event_base,
     if (event_base == WIFI_EVENT) {
         switch (event_id) {
             case WIFI_EVENT_SCAN_DONE:
+                ESP_EARLY_LOGW(TAG, "scan");
                 xEventGroupSetBits(radio->event_group_handle, WIFI_SCAN_DONE_BIT);
+                break;
+            case WIFI_EVENT_STA_START:
+                ESP_EARLY_LOGW(TAG, "start");
+                break;
+            case WIFI_EVENT_STA_STOP:
+                ESP_EARLY_LOGW(TAG, "stop");
                 break;
             case WIFI_EVENT_STA_CONNECTED:
                 ESP_EARLY_LOGW(TAG, "connected");
@@ -74,8 +81,6 @@ static void event_handler(void* arg, esp_event_base_t event_base,
             }
 
             // Cases to handle later.
-            // case WIFI_EVENT_STA_START:
-            // case WIFI_EVENT_STA_STOP:
             // case WIFI_EVENT_STA_AUTHMODE_CHANGE:
             default:
                 break;


### PR DESCRIPTION
I found it very helpful to have those information in the UART console, while working on the Wi-Fi / i2c related topics.
I don't believe there are any negative side-effects, but would love to hear from you.

```
I (4129) wifi_init: WiFi RX IRAM OP enabled
I (4269) phy: phy_version: 603, 72dfd77, Jul  7 2020, 19:57:05, 0, 2
I (4269) wifi:enable tsf
I (4269) wifi:mode : sta (7c:df:a1:a1:b2:c3)
W (4269) wifi: start
W (5589) wifi: scan
W (5829) wifi: scan
W (6159) wifi: scan
W (6429) wifi: scan
W (6549) wifi: scan
W (6669) wifi: scan
W (6789) wifi: scan
W (6919) wifi: scan
W (7039) wifi: scan
W (7159) wifi: scan
W (7279) wifi: scan
I (9329) wifi:new:<6,0>, old:<1,0>, ap:<255,255>, sta:<6,0>, prof:1
I (9809) wifi:state: init -> auth (b0)
I (9839) wifi:state: auth -> assoc (0)
I (9849) wifi:state: assoc -> run (10)
I (11059) wifi:connected with Stellar-DSPSK, aid = 1, channel 6, BW20, bssid = dc:08:56:aa:bb:cc
I (11059) wifi:security: WPA2-PSK, phy: bgn, rssi: -49
I (11059) wifi:pm start, type: 1

W (11069) wifi: connected
I (11109) wifi:AP's beacon interval = 102400 us, DTIM period = 2
W (11599) i2c: i2c_reset
W (11599) i2c: i2c_reset (num): 0, i2c_status: 0
W (11599) i2c: i2c_reset (num): 1, i2c_status: 0
I (11599) wifi:state: run -> init (0)
I (11599) wifi:pm stop, total sleep time: 388234 us / 535638 us

I (11609) wifi:new:<6,0>, old:<6,0>, ap:<255,255>, sta:<6,0>, prof:1
W (11609) wifi: disconnected
W (11619) wifi: reason 8 0x08
W (11619) wifi: stop
I (11649) wifi:flush txq
I (11649) wifi:stop sw txq
I (11649) wifi:lmac stop hw txq
I (11649) wifi:Deinit lldesc rx mblock:4
```