### PR TITLE
Enter safe mode after panic or brownout

### DIFF
--- a/ports/esp32s2/supervisor/port.c
+++ b/ports/esp32s2/supervisor/port.c
@@ -102,6 +102,14 @@ safe_mode_t port_init(void) {
         return NO_HEAP;
     }
 
+    esp_reset_reason_t reason = esp_reset_reason();
+    if (reason == ESP_RST_BROWNOUT) {
+        return BROWNOUT;
+    }
+    if (reason == ESP_RST_PANIC) {
+        return HARD_CRASH;
+    }
+
     return NO_SAFE_MODE;
 }
 


### PR DESCRIPTION
Uses the IDF's reset reason. Does nothing before reset.

Fixes #3389