### PR TITLE
esp32s2: Reserve UART pins only if DEBUG=1 is set to address issue 3811

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
         python-version: 3.8
     - name: Install deps
       run: |
+        sudo apt-get update
         sudo apt-get install -y eatmydata
         sudo eatmydata apt-get install -y gettext librsvg2-bin mingw-w64 latexmk texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra
         pip install requests sh click setuptools cpp-coveralls "Sphinx<4" sphinx-rtd-theme recommonmark sphinx-autoapi sphinxcontrib-svg2pdfconverter polib pyyaml astroid isort black awscli mypy

--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -118,7 +118,7 @@ CFLAGS += -DSTACK_CANARY_VALUE=0xa5a5a5a5
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)
-  CFLAGS += -ggdb
+  CFLAGS += -DDEBUG -ggdb
   OPTIMIZATION_FLAGS ?= -Og
   # You may want to enable these flags to make setting breakpoints easier.
   # CFLAGS += -fno-inline -fno-ipa-sra

--- a/ports/esp32s2/boards/adafruit_magtag_2.9_grayscale/board.c
+++ b/ports/esp32s2/boards/adafruit_magtag_2.9_grayscale/board.c
@@ -115,8 +115,10 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO20);
 
     // Debug UART
+#ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
+#endif /* DEBUG */
 
     busio_spi_obj_t* spi = &displays[0].fourwire_bus.inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO36, &pin_GPIO35, NULL);

--- a/ports/esp32s2/boards/electroniccats_bastwifi/board.c
+++ b/ports/esp32s2/boards/electroniccats_bastwifi/board.c
@@ -34,8 +34,10 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO20);
 
     // Debug UART
+#ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
+#endif /* DEBUG */
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/esp32s2/boards/espressif_kaluga_1/board.c
+++ b/ports/esp32s2/boards/espressif_kaluga_1/board.c
@@ -34,8 +34,10 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO20);
 
     // Debug UART
+#ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
+#endif /* DEBUG */
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/esp32s2/boards/espressif_saola_1_wroom/board.c
+++ b/ports/esp32s2/boards/espressif_saola_1_wroom/board.c
@@ -34,8 +34,10 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO20);
 
     // Debug UART
+#ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
+#endif /* DEBUG */
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/esp32s2/boards/espressif_saola_1_wrover/board.c
+++ b/ports/esp32s2/boards/espressif_saola_1_wrover/board.c
@@ -34,8 +34,10 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO20);
 
     // Debug UART
+#ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
+#endif /* DEBUG */
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/esp32s2/boards/microdev_micro_s2/board.c
+++ b/ports/esp32s2/boards/microdev_micro_s2/board.c
@@ -34,8 +34,10 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO20);
 
     // Debug UART
+#ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
+#endif /* DEBUG */
 
     // SPI Flash and RAM
     common_hal_never_reset_pin(&pin_GPIO26);

--- a/ports/esp32s2/boards/muselab_nanoesp32_s2/board.c
+++ b/ports/esp32s2/boards/muselab_nanoesp32_s2/board.c
@@ -34,8 +34,10 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO20);
 
     // Debug UART
+#ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
+#endif /* DEBUG */
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/esp32s2/boards/targett_module_clip_wroom/board.c
+++ b/ports/esp32s2/boards/targett_module_clip_wroom/board.c
@@ -34,8 +34,10 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO20);
 
     // Debug UART
+#ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
+#endif /* DEBUG */
 
     // Crystal
     common_hal_never_reset_pin(&pin_GPIO15);

--- a/ports/esp32s2/boards/targett_module_clip_wrover/board.c
+++ b/ports/esp32s2/boards/targett_module_clip_wrover/board.c
@@ -34,8 +34,10 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO20);
 
     // Debug UART
+#ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
+#endif /* DEBUG */
 
     //Crystal
     common_hal_never_reset_pin(&pin_GPIO15);

--- a/ports/esp32s2/boards/unexpectedmaker_feathers2/board.c
+++ b/ports/esp32s2/boards/unexpectedmaker_feathers2/board.c
@@ -34,8 +34,10 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO20);
 
     // Debug UART
+#ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
+#endif /* DEBUG */
 
     // SPI Flash and RAM
     common_hal_never_reset_pin(&pin_GPIO26);

--- a/ports/esp32s2/boards/unexpectedmaker_feathers2_prerelease/board.c
+++ b/ports/esp32s2/boards/unexpectedmaker_feathers2_prerelease/board.c
@@ -34,8 +34,10 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO20);
 
     // Debug UART
+#ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
+#endif /* DEBUG */
 
     // SPI Flash and RAM
     common_hal_never_reset_pin(&pin_GPIO26);


### PR DESCRIPTION
This addresses issue #3811 

Same patch for all esp32s2 boards. Tested on featherS2 (see screenshot below).

Python code for test:

```python
import board
import busio
uart = busio.UART(board.TX, board.RX, baudrate=115200)
uart.write(bytes("Test123", "utf8"))
```

![grafik](https://user-images.githubusercontent.com/5174414/101949423-e4675100-3bf3-11eb-989e-d781951e9fbc.png)
