### PR TITLE
Fix for issue 3663 by returning early if no scan was started before s…

### DIFF
--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -105,6 +105,10 @@ mp_obj_t common_hal_wifi_radio_start_scanning_networks(wifi_radio_obj_t *self) {
 }
 
 void common_hal_wifi_radio_stop_scanning_networks(wifi_radio_obj_t *self) {
+    // Return early if self->current_scan is NULL to avoid hang
+    if (self->current_scan == NULL) {
+        return;
+    }
     // Free the memory used to store the found aps.
     wifi_scannednetworks_deinit(self->current_scan);
     self->current_scan = NULL;


### PR DESCRIPTION
This fixes issue #3663 

I started by reproducing the issue with some additional debug logs:
![grafik](https://user-images.githubusercontent.com/5174414/101965313-84cd6d80-3c14-11eb-8a12-4f3dcd476660.png)

.. followed by a build with the fix and debug logs still enabled:
![grafik](https://user-images.githubusercontent.com/5174414/101965345-a29ad280-3c14-11eb-8ae5-c6273718497a.png)

and here is the fix of the PR that just carries the fix, minus the extra debug logs:
![grafik](https://user-images.githubusercontent.com/5174414/101965391-c65e1880-3c14-11eb-97ac-418a85f78bc0.png)

The following code no longer gives me any issues now:
```python
import wifi
wifi.radio.stop_scanning_networks()
```