### PR TITLE
displayio: Fix several bugs (transparency and palettes of OnDiskBitmaps)

### DIFF
--- a/shared-module/displayio/ColorConverter.c
+++ b/shared-module/displayio/ColorConverter.c
@@ -29,6 +29,8 @@
 #include "py/misc.h"
 #include "py/runtime.h"
 
+#define NO_TRANSPARENT_COLOR (0x1000000)
+
 uint32_t displayio_colorconverter_dither_noise_1 (uint32_t n)
 {
   n = (n >> 13) ^ n;
@@ -42,6 +44,7 @@ uint32_t displayio_colorconverter_dither_noise_2(uint32_t x, uint32_t y) {
 
 void common_hal_displayio_colorconverter_construct(displayio_colorconverter_t* self, bool dither) {
     self->dither = dither;
+    self->transparent_color = NO_TRANSPARENT_COLOR;
 }
 
 uint16_t displayio_colorconverter_compute_rgb565(uint32_t color_rgb888) {
@@ -130,7 +133,7 @@ bool common_hal_displayio_colorconverter_get_dither(displayio_colorconverter_t* 
 }
 
 void common_hal_displayio_colorconverter_make_transparent(displayio_colorconverter_t* self, uint32_t transparent_color) {
-    if (self->transparent_color >= 0x1000000) {
+    if (self->transparent_color != NO_TRANSPARENT_COLOR) {
         mp_raise_RuntimeError(translate("Only one color can be transparent at a time"));
     }
     self->transparent_color = transparent_color;
@@ -138,8 +141,8 @@ void common_hal_displayio_colorconverter_make_transparent(displayio_colorconvert
 
 void common_hal_displayio_colorconverter_make_opaque(displayio_colorconverter_t* self, uint32_t transparent_color) {
     (void) transparent_color;
-    // 0x1000000 will never equal a valid color
-    self->transparent_color = 0x1000000;
+    // NO_TRANSPARENT_COLOR will never equal a valid color
+    self->transparent_color = NO_TRANSPARENT_COLOR;
 }
 
 void displayio_colorconverter_convert(displayio_colorconverter_t *self, const _displayio_colorspace_t* colorspace, const displayio_input_pixel_t *input_pixel, displayio_output_pixel_t *output_color) {

--- a/shared-module/displayio/OnDiskBitmap.c
+++ b/shared-module/displayio/OnDiskBitmap.c
@@ -57,7 +57,7 @@ void common_hal_displayio_ondiskbitmap_construct(displayio_ondiskbitmap_t *self,
     uint32_t compression = read_word(bmp_header, 15);
     uint32_t number_of_colors = read_word(bmp_header, 23);
 
-    bool indexed = ((bits_per_pixel <= 8) && (number_of_colors != 0));
+    bool indexed = bits_per_pixel <= 8;
     self->bitfield_compressed  = (compression == 3);
     self->bits_per_pixel = bits_per_pixel;
     self->width = read_word(bmp_header, 9);
@@ -75,6 +75,9 @@ void common_hal_displayio_ondiskbitmap_construct(displayio_ondiskbitmap_t *self,
             self->b_bitmask = 0x1f;
         }
     } else if (indexed && self->bits_per_pixel != 1) {
+        if (number_of_colors == 0) {
+            number_of_colors = 1 << bits_per_pixel;
+        }
         uint16_t palette_size = number_of_colors * sizeof(uint32_t);
         uint16_t palette_offset = 0xe + header_size;
 


### PR DESCRIPTION
The transparent_color field was never initialized.  I _think_ this means its value was always set to 0, or the blackest of blacks.  Instead, initialize it to the sentinel value, newly given the name NO_TRANSPARENT_COLOR.

This exposed a second problem: The test for whether there was an existing transparent color was wrong (backwards).  I am guessing that this was not found due to the first bug; since the converter had a transparent color, the correct test would have led to always getting the error "Only one color can be transparent at a time".

Closes #3723