### PR TITLE
Update devices.h

### DIFF
--- a/supervisor/shared/external_flash/devices.h
+++ b/supervisor/shared/external_flash/devices.h
@@ -537,7 +537,7 @@ typedef struct {
     .start_up_time_us = 800, \
     .manufacturer_id = 0xc2, \
     .memory_type = 0x28, \
-    .capacity = 0x18, \
+    .capacity = 0x15, \
     .max_clock_speed_mhz = 33, /* 8 mhz for dual/quad */ \
     .quad_enable_bit_mask = 0x80, \
     .has_sector_protection = false, \


### PR DESCRIPTION
Correct capacity value for the MX25R1635F from 0x18 to 0x15 (tested and working)
refer to 
https://github.com/adafruit/circuitpython/issues/3558