### PR TITLE
adafruit_bus_device: Don't transmit STOP condition in write_then_readinto

### DIFF
--- a/shared-bindings/adafruit_bus_device/I2CDevice.c
+++ b/shared-bindings/adafruit_bus_device/I2CDevice.c
@@ -163,7 +163,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(adafruit_bus_device_i2cdevice_readinto_obj, 2,
 //|         """
 //|         ...
 //|
-STATIC void write(adafruit_bus_device_i2cdevice_obj_t *self, mp_obj_t buffer, int32_t start, mp_int_t end) {
+STATIC void write(adafruit_bus_device_i2cdevice_obj_t *self, mp_obj_t buffer, int32_t start, mp_int_t end, bool transmit_stop_bit) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buffer, &bufinfo, MP_BUFFER_READ);
 
@@ -173,7 +173,7 @@ STATIC void write(adafruit_bus_device_i2cdevice_obj_t *self, mp_obj_t buffer, in
         mp_raise_ValueError(translate("Buffer must be at least length 1"));
     }
 
-    uint8_t status = common_hal_adafruit_bus_device_i2cdevice_write(MP_OBJ_TO_PTR(self), ((uint8_t*)bufinfo.buf) + start, length);
+    uint8_t status = common_hal_adafruit_bus_device_i2cdevice_write(MP_OBJ_TO_PTR(self), ((uint8_t*)bufinfo.buf) + start, length, transmit_stop_bit);
     if (status != 0) {
         mp_raise_OSError(status);
     }
@@ -191,7 +191,7 @@ STATIC mp_obj_t adafruit_bus_device_i2cdevice_write(size_t n_args, const mp_obj_
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    write(self, args[ARG_buffer].u_obj, args[ARG_start].u_int, args[ARG_end].u_int);
+    write(self, args[ARG_buffer].u_obj, args[ARG_start].u_int, args[ARG_end].u_int, true);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(adafruit_bus_device_i2cdevice_write_obj, 2, adafruit_bus_device_i2cdevice_write);
@@ -233,7 +233,7 @@ STATIC mp_obj_t adafruit_bus_device_i2cdevice_write_then_readinto(size_t n_args,
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    write(self, args[ARG_out_buffer].u_obj, args[ARG_out_start].u_int, args[ARG_out_end].u_int);
+    write(self, args[ARG_out_buffer].u_obj, args[ARG_out_start].u_int, args[ARG_out_end].u_int, false);
 
     readinto(self, args[ARG_in_buffer].u_obj, args[ARG_in_start].u_int, args[ARG_in_end].u_int);
 

--- a/shared-bindings/adafruit_bus_device/I2CDevice.h
+++ b/shared-bindings/adafruit_bus_device/I2CDevice.h
@@ -45,7 +45,7 @@ extern const mp_obj_type_t adafruit_bus_device_i2cdevice_type;
 // Initializes the hardware peripheral.
 extern void common_hal_adafruit_bus_device_i2cdevice_construct(adafruit_bus_device_i2cdevice_obj_t *self, busio_i2c_obj_t *i2c, uint8_t device_address);
 extern uint8_t common_hal_adafruit_bus_device_i2cdevice_readinto(adafruit_bus_device_i2cdevice_obj_t *self, mp_obj_t buffer, size_t length);
-extern uint8_t common_hal_adafruit_bus_device_i2cdevice_write(adafruit_bus_device_i2cdevice_obj_t *self, mp_obj_t buffer, size_t length);
+extern uint8_t common_hal_adafruit_bus_device_i2cdevice_write(adafruit_bus_device_i2cdevice_obj_t *self, mp_obj_t buffer, size_t length, bool transmit_stop_bit);
 extern void common_hal_adafruit_bus_device_i2cdevice_lock(adafruit_bus_device_i2cdevice_obj_t *self);
 extern void common_hal_adafruit_bus_device_i2cdevice_unlock(adafruit_bus_device_i2cdevice_obj_t *self);
 extern void common_hal_adafruit_bus_device_i2cdevice_probe_for_device(adafruit_bus_device_i2cdevice_obj_t *self);

--- a/shared-module/adafruit_bus_device/I2CDevice.c
+++ b/shared-module/adafruit_bus_device/I2CDevice.c
@@ -57,8 +57,8 @@ uint8_t common_hal_adafruit_bus_device_i2cdevice_readinto(adafruit_bus_device_i2
     return common_hal_busio_i2c_read(self->i2c, self->device_address, buffer, length);
 }
 
-uint8_t common_hal_adafruit_bus_device_i2cdevice_write(adafruit_bus_device_i2cdevice_obj_t *self, mp_obj_t buffer, size_t length) {
-    return common_hal_busio_i2c_write(self->i2c, self->device_address, buffer, length, true);
+uint8_t common_hal_adafruit_bus_device_i2cdevice_write(adafruit_bus_device_i2cdevice_obj_t *self, mp_obj_t buffer, size_t length, bool transmit_stop_bit) {
+    return common_hal_busio_i2c_write(self->i2c, self->device_address, buffer, length, transmit_stop_bit);
 }
 
 void common_hal_adafruit_bus_device_i2cdevice_probe_for_device(adafruit_bus_device_i2cdevice_obj_t *self) {


### PR DESCRIPTION
Testing performed: on esp32s2 kaluga with LC709203 sensor on the pins shown below, use the repl to check the cell voltage:
```
>>> import board, busio, adafruit_lc709203f; bus = busio.I2C(board.IO10, board.IO11); dev = adafruit_lc709203f.LC709023F(bus); print(dev.cell_voltage)
3.807
```

(this bug is not esp32s2 specific and was reported to affect other ports as well, but the LC7… sensor is sensitive to this bug in a way other sensors apparently are not)

Closes #3795