### PR TITLE
BLE fixes; magtag name fix

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-08 09:56-0800\n"
+"POT-Creation-Date: 2020-12-18 17:12-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -388,7 +388,7 @@ msgstr ""
 msgid "Array must contain halfwords (type 'H')"
 msgstr ""
 
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/alarm/SleepMemory.c shared-bindings/nvm/ByteArray.c
 msgid "Array values should be single bytes."
 msgstr ""
 
@@ -522,7 +522,7 @@ msgstr ""
 msgid "Byte buffer must be 16 bytes."
 msgstr ""
 
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/alarm/SleepMemory.c shared-bindings/nvm/ByteArray.c
 msgid "Bytes must be between 0 and 255."
 msgstr ""
 
@@ -1078,6 +1078,10 @@ msgstr ""
 #: ports/cxd56/common-hal/pwmio/PWMOut.c ports/nrf/common-hal/pwmio/PWMOut.c
 #: shared-bindings/pwmio/PWMOut.c
 msgid "Invalid PWM frequency"
+msgstr ""
+
+#: ports/esp32s2/common-hal/analogio/AnalogIn.c
+msgid "Invalid Pin"
 msgstr ""
 
 #: py/moduerrno.c shared-module/rgbmatrix/RGBMatrix.c
@@ -1696,7 +1700,7 @@ msgstr ""
 msgid "Size not supported"
 msgstr ""
 
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/alarm/SleepMemory.c shared-bindings/nvm/ByteArray.c
 msgid "Slice and value different lengths."
 msgstr ""
 
@@ -1911,6 +1915,10 @@ msgstr ""
 msgid "Unable to write to nvm."
 msgstr ""
 
+#: shared-bindings/alarm/SleepMemory.c
+msgid "Unable to write to sleep_memory."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/UUID.c
 msgid "Unexpected nrfx uuid type"
 msgstr ""
@@ -2117,7 +2125,8 @@ msgstr ""
 msgid "array and index length must be equal"
 msgstr ""
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: py/objarray.c shared-bindings/alarm/SleepMemory.c
+#: shared-bindings/nvm/ByteArray.c
 msgid "array/bytes required on right side"
 msgstr ""
 
@@ -3130,6 +3139,14 @@ msgstr ""
 msgid "non-keyword arg after keyword arg"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/Adapter.c
+msgid "non-zero timeout must be > 0.01"
+msgstr ""
+
+#: shared-bindings/_bleio/Adapter.c
+msgid "non-zero timeout must be >= interval"
+msgstr ""
+
 #: extmod/ulab/code/linalg/linalg.c
 msgid "norm is defined for 1D and 2D arrays"
 msgstr ""
@@ -3215,7 +3232,7 @@ msgid "only sample_rate=16000 is supported"
 msgstr ""
 
 #: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/nvm/ByteArray.c
+#: shared-bindings/alarm/SleepMemory.c shared-bindings/nvm/ByteArray.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr ""
 
@@ -3545,6 +3562,10 @@ msgstr ""
 
 #: shared-bindings/busio/UART.c
 msgid "timeout must be 0.0-100.0 seconds"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+msgid "timeout must be < 655.35 secs"
 msgstr ""
 
 #: shared-bindings/_bleio/CharacteristicBuffer.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-14 12:59-0500\n"
+"POT-Creation-Date: 2020-12-08 09:56-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -388,7 +388,7 @@ msgstr ""
 msgid "Array must contain halfwords (type 'H')"
 msgstr ""
 
-#: shared-bindings/alarm/SleepMemory.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c
 msgid "Array values should be single bytes."
 msgstr ""
 
@@ -522,7 +522,7 @@ msgstr ""
 msgid "Byte buffer must be 16 bytes."
 msgstr ""
 
-#: shared-bindings/alarm/SleepMemory.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c
 msgid "Bytes must be between 0 and 255."
 msgstr ""
 
@@ -1078,10 +1078,6 @@ msgstr ""
 #: ports/cxd56/common-hal/pwmio/PWMOut.c ports/nrf/common-hal/pwmio/PWMOut.c
 #: shared-bindings/pwmio/PWMOut.c
 msgid "Invalid PWM frequency"
-msgstr ""
-
-#: ports/esp32s2/common-hal/analogio/AnalogIn.c
-msgid "Invalid Pin"
 msgstr ""
 
 #: py/moduerrno.c shared-module/rgbmatrix/RGBMatrix.c
@@ -1700,7 +1696,7 @@ msgstr ""
 msgid "Size not supported"
 msgstr ""
 
-#: shared-bindings/alarm/SleepMemory.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c
 msgid "Slice and value different lengths."
 msgstr ""
 
@@ -1915,10 +1911,6 @@ msgstr ""
 msgid "Unable to write to nvm."
 msgstr ""
 
-#: shared-bindings/alarm/SleepMemory.c
-msgid "Unable to write to sleep_memory."
-msgstr ""
-
 #: ports/nrf/common-hal/_bleio/UUID.c
 msgid "Unexpected nrfx uuid type"
 msgstr ""
@@ -2125,8 +2117,7 @@ msgstr ""
 msgid "array and index length must be equal"
 msgstr ""
 
-#: py/objarray.c shared-bindings/alarm/SleepMemory.c
-#: shared-bindings/nvm/ByteArray.c
+#: py/objarray.c shared-bindings/nvm/ByteArray.c
 msgid "array/bytes required on right side"
 msgstr ""
 
@@ -3001,7 +2992,7 @@ msgid "max_length must be 0-%d when fixed_length is %s"
 msgstr ""
 
 #: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
-msgid "max_length must be > 0"
+msgid "max_length must be >= 0"
 msgstr ""
 
 #: extmod/ulab/code/ndarray.c
@@ -3224,7 +3215,7 @@ msgid "only sample_rate=16000 is supported"
 msgstr ""
 
 #: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
-#: shared-bindings/alarm/SleepMemory.c shared-bindings/nvm/ByteArray.c
+#: shared-bindings/nvm/ByteArray.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr ""
 

--- a/locale/es.po
+++ b/locale/es.po
@@ -3073,8 +3073,8 @@ msgid "max_length must be 0-%d when fixed_length is %s"
 msgstr "max_length debe ser 0-%d cuando fixed_length es %s"
 
 #: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
-msgid "max_length must be > 0"
-msgstr "max_lenght debe ser > 0"
+msgid "max_length must be >= 0"
+msgstr "max_lenght debe ser >= 0"
 
 #: extmod/ulab/code/ndarray.c
 msgid "maximum number of dimensions is 4"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -3093,8 +3093,8 @@ msgid "max_length must be 0-%d when fixed_length is %s"
 msgstr "max_length doit être 0-%d lorsque fixed_length est %s"
 
 #: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
-msgid "max_length must be > 0"
-msgstr "max_length doit être > 0"
+msgid "max_length must be >= 0"
+msgstr "max_length doit être >= 0"
 
 #: extmod/ulab/code/ndarray.c
 msgid "maximum number of dimensions is 4"

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -3063,7 +3063,7 @@ msgstr "max_length moet 0-%d zijn als fixed_length %s is"
 
 #: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
 msgid "max_length must be > 0"
-msgstr "max_length moet >0 zijn"
+msgstr "max_length moet >= 0 zijn"
 
 #: extmod/ulab/code/ndarray.c
 msgid "maximum number of dimensions is 4"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -3023,8 +3023,8 @@ msgid "max_length must be 0-%d when fixed_length is %s"
 msgstr ""
 
 #: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
-msgid "max_length must be > 0"
-msgstr "max_length musi być > 0"
+msgid "max_length must be >= 0"
+msgstr "max_length musi być >= 0"
 
 #: extmod/ulab/code/ndarray.c
 msgid "maximum number of dimensions is 4"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -3085,8 +3085,8 @@ msgid "max_length must be 0-%d when fixed_length is %s"
 msgstr "o max_length deve ser 0-%d quando Fixed_length for %s"
 
 #: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
-msgid "max_length must be > 0"
-msgstr "max_length deve ser > 0"
+msgid "max_length must be >= 0"
+msgstr "max_length deve ser >= 0"
 
 #: extmod/ulab/code/ndarray.c
 msgid "maximum number of dimensions is 4"

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -3056,8 +3056,8 @@ msgid "max_length must be 0-%d when fixed_length is %s"
 msgstr "max_length måste vara 0-%d när fixed_length är %s"
 
 #: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
-msgid "max_length must be > 0"
-msgstr "max_length måste vara > 0"
+msgid "max_length must be >= 0"
+msgstr "max_length måste vara >= 0"
 
 #: extmod/ulab/code/ndarray.c
 msgid "maximum number of dimensions is 4"

--- a/locale/zh_Latn_pinyin.po
+++ b/locale/zh_Latn_pinyin.po
@@ -3047,8 +3047,8 @@ msgid "max_length must be 0-%d when fixed_length is %s"
 msgstr "Dāng gùdìng chángdù wèi %s shí, zuìdà chángdù bìxū wèi 0-%d"
 
 #: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
-msgid "max_length must be > 0"
-msgstr "Max_length bìxū > 0"
+msgid "max_length must be >= 0"
+msgstr "Max_length bìxū >= 0"
 
 #: extmod/ulab/code/ndarray.c
 msgid "maximum number of dimensions is 4"

--- a/ports/esp32s2/boards/adafruit_magtag_2.9_grayscale/mpconfigboard.h
+++ b/ports/esp32s2/boards/adafruit_magtag_2.9_grayscale/mpconfigboard.h
@@ -26,7 +26,7 @@
 
 //Micropython setup
 
-#define MICROPY_HW_BOARD_NAME       "MagTag"
+#define MICROPY_HW_BOARD_NAME       "Adafruit MagTag"
 #define MICROPY_HW_MCU_NAME         "ESP32S2"
 
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO1)

--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -470,7 +470,16 @@ mp_obj_t common_hal_bleio_adapter_start_scan(bleio_adapter_obj_t *self, uint8_t*
     ble_drv_add_event_handler(scan_on_ble_evt, self->scan_results);
 
     uint32_t nrf_timeout = SEC_TO_UNITS(timeout, UNIT_10_MS);
-    if (timeout <= 0.0001) {
+    if (nrf_timeout > UINT16_MAX) {
+        // 0xffff / 100
+        mp_raise_ValueError(translate("timeout must be < 655.35 secs"));
+    }
+    if (nrf_timeout == 0 && timeout > 0.0f) {
+        // Make sure converted timeout is > 0 if original timeout is > 0.
+        mp_raise_ValueError(translate("non-zero timeout must be > 0.01"));
+    }
+
+    if (nrf_timeout) {
         nrf_timeout = BLE_GAP_SCAN_TIMEOUT_UNLIMITED;
     }
 

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -33,8 +33,8 @@
 #include "shared-bindings/_bleio/Address.h"
 #include "shared-bindings/_bleio/Adapter.h"
 
-#define ADV_INTERVAL_MIN (0.0020f)
-#define ADV_INTERVAL_MIN_STRING "0.0020"
+#define ADV_INTERVAL_MIN (0.02001f)
+#define ADV_INTERVAL_MIN_STRING "0.02001"
 #define ADV_INTERVAL_MAX (10.24f)
 #define ADV_INTERVAL_MAX_STRING "10.24"
 // 20ms is recommended by Apple

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -307,7 +307,7 @@ STATIC mp_obj_t bleio_adapter_start_scan(size_t n_args, const mp_obj_t *pos_args
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_float_t timeout = 0;
+    mp_float_t timeout = 0.0f;
     if (args[ARG_timeout].u_obj != mp_const_none) {
         timeout = mp_obj_get_float(args[ARG_timeout].u_obj);
     }
@@ -324,6 +324,13 @@ STATIC mp_obj_t bleio_adapter_start_scan(size_t n_args, const mp_obj_t *pos_args
     if (interval < INTERVAL_MIN || interval > INTERVAL_MAX) {
         mp_raise_ValueError_varg(translate("interval must be in range %s-%s"), INTERVAL_MIN_STRING, INTERVAL_MAX_STRING);
     }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+    if (timeout != 0.0f && timeout < interval) {
+        mp_raise_ValueError(translate("non-zero timeout must be >= interval"));
+    }
+#pragma GCC diagnostic pop
 
     const mp_float_t window = mp_obj_float_get(args[ARG_window].u_obj);
     if (window > interval) {

--- a/shared-bindings/_bleio/Characteristic.c
+++ b/shared-bindings/_bleio/Characteristic.c
@@ -110,8 +110,8 @@ STATIC mp_obj_t bleio_characteristic_add_to_service(size_t n_args, const mp_obj_
     common_hal_bleio_attribute_security_mode_check_valid(write_perm);
 
     const mp_int_t max_length_int = args[ARG_max_length].u_int;
-    if (max_length_int <= 0) {
-        mp_raise_ValueError(translate("max_length must be > 0"));
+    if (max_length_int < 0) {
+        mp_raise_ValueError(translate("max_length must be >= 0"));
     }
     const size_t max_length = (size_t) max_length_int;
     const bool fixed_length =  args[ARG_fixed_length].u_bool;

--- a/shared-bindings/_bleio/Descriptor.c
+++ b/shared-bindings/_bleio/Descriptor.c
@@ -101,8 +101,8 @@ STATIC mp_obj_t bleio_descriptor_add_to_characteristic(size_t n_args, const mp_o
     common_hal_bleio_attribute_security_mode_check_valid(write_perm);
 
     const mp_int_t max_length_int = args[ARG_max_length].u_int;
-    if (max_length_int <= 0) {
-        mp_raise_ValueError(translate("max_length must be > 0"));
+    if (max_length_int < 0) {
+        mp_raise_ValueError(translate("max_length must be >= 0"));
     }
     const size_t max_length = (size_t) max_length_int;
     const bool fixed_length =  args[ARG_fixed_length].u_bool;


### PR DESCRIPTION
- Characteristic and descriptor `max_length`s can be zero. Fixes #3746.
- Assure that `start_scan()` timeout is either zero or >= interval. This is a guess for this fix, but it coincides with working values reported in #3826. Fixes #3826.
- Assure that `start_scan()` max timeout is not too large for a `uint16_t` when passed to nRF SD. Fixes #3340.
- Fixes small advertising interval values. Fix check and make sure it's at least 0.02001, to allow for rounding issues, as discussed in #2930. Fixes #2930.

- Change MagTag board name to "Adafruit MagTag", so it appears in the support matrix in the right place. Fixes #3831.

Tested HID, and tested advertising scans with and without a timeout.

