### PR TITLE
BLE fixes

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-04 21:18+0530\n"
+"POT-Creation-Date: 2020-12-21 23:48-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2861,7 +2861,7 @@ msgid "max_length must be 0-%d when fixed_length is %s"
 msgstr ""
 
 #: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
-msgid "max_length must be > 0"
+msgid "max_length must be >= 0"
 msgstr ""
 
 #: py/runtime.c
@@ -2997,6 +2997,14 @@ msgstr ""
 
 #: py/compile.c
 msgid "non-keyword arg after keyword arg"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+msgid "non-zero timeout must be > 0.01"
+msgstr ""
+
+#: shared-bindings/_bleio/Adapter.c
+msgid "non-zero timeout must be >= interval"
 msgstr ""
 
 #: shared-bindings/_bleio/UUID.c
@@ -3398,6 +3406,10 @@ msgstr ""
 
 #: shared-bindings/busio/UART.c
 msgid "timeout must be 0.0-100.0 seconds"
+msgstr ""
+
+#: ports/nrf/common-hal/_bleio/Adapter.c
+msgid "timeout must be < 655.35 secs"
 msgstr ""
 
 #: shared-bindings/_bleio/CharacteristicBuffer.c

--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -470,7 +470,16 @@ mp_obj_t common_hal_bleio_adapter_start_scan(bleio_adapter_obj_t *self, uint8_t*
     ble_drv_add_event_handler(scan_on_ble_evt, self->scan_results);
 
     uint32_t nrf_timeout = SEC_TO_UNITS(timeout, UNIT_10_MS);
-    if (timeout <= 0.0001) {
+    if (nrf_timeout > UINT16_MAX) {
+        // 0xffff / 100
+        mp_raise_ValueError(translate("timeout must be < 655.35 secs"));
+    }
+    if (nrf_timeout == 0 && timeout > 0.0f) {
+        // Make sure converted timeout is > 0 if original timeout is > 0.
+        mp_raise_ValueError(translate("non-zero timeout must be > 0.01"));
+    }
+
+    if (nrf_timeout) {
         nrf_timeout = BLE_GAP_SCAN_TIMEOUT_UNLIMITED;
     }
 

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -33,8 +33,8 @@
 #include "shared-bindings/_bleio/Address.h"
 #include "shared-bindings/_bleio/Adapter.h"
 
-#define ADV_INTERVAL_MIN (0.0020f)
-#define ADV_INTERVAL_MIN_STRING "0.0020"
+#define ADV_INTERVAL_MIN (0.02001f)
+#define ADV_INTERVAL_MIN_STRING "0.02001"
 #define ADV_INTERVAL_MAX (10.24f)
 #define ADV_INTERVAL_MAX_STRING "10.24"
 // 20ms is recommended by Apple
@@ -307,7 +307,7 @@ STATIC mp_obj_t bleio_adapter_start_scan(size_t n_args, const mp_obj_t *pos_args
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_float_t timeout = 0;
+    mp_float_t timeout = 0.0f;
     if (args[ARG_timeout].u_obj != mp_const_none) {
         timeout = mp_obj_get_float(args[ARG_timeout].u_obj);
     }
@@ -324,6 +324,13 @@ STATIC mp_obj_t bleio_adapter_start_scan(size_t n_args, const mp_obj_t *pos_args
     if (interval < INTERVAL_MIN || interval > INTERVAL_MAX) {
         mp_raise_ValueError_varg(translate("interval must be in range %s-%s"), INTERVAL_MIN_STRING, INTERVAL_MAX_STRING);
     }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+    if (timeout != 0.0f && timeout < interval) {
+        mp_raise_ValueError(translate("non-zero timeout must be >= interval"));
+    }
+#pragma GCC diagnostic pop
 
     const mp_float_t window = mp_obj_float_get(args[ARG_window].u_obj);
     if (window > interval) {

--- a/shared-bindings/_bleio/Characteristic.c
+++ b/shared-bindings/_bleio/Characteristic.c
@@ -110,8 +110,8 @@ STATIC mp_obj_t bleio_characteristic_add_to_service(size_t n_args, const mp_obj_
     common_hal_bleio_attribute_security_mode_check_valid(write_perm);
 
     const mp_int_t max_length_int = args[ARG_max_length].u_int;
-    if (max_length_int <= 0) {
-        mp_raise_ValueError(translate("max_length must be > 0"));
+    if (max_length_int < 0) {
+        mp_raise_ValueError(translate("max_length must be >= 0"));
     }
     const size_t max_length = (size_t) max_length_int;
     const bool fixed_length =  args[ARG_fixed_length].u_bool;

--- a/shared-bindings/_bleio/Descriptor.c
+++ b/shared-bindings/_bleio/Descriptor.c
@@ -101,8 +101,8 @@ STATIC mp_obj_t bleio_descriptor_add_to_characteristic(size_t n_args, const mp_o
     common_hal_bleio_attribute_security_mode_check_valid(write_perm);
 
     const mp_int_t max_length_int = args[ARG_max_length].u_int;
-    if (max_length_int <= 0) {
-        mp_raise_ValueError(translate("max_length must be > 0"));
+    if (max_length_int < 0) {
+        mp_raise_ValueError(translate("max_length must be >= 0"));
     }
     const size_t max_length = (size_t) max_length_int;
     const bool fixed_length =  args[ARG_fixed_length].u_bool;


### PR DESCRIPTION
(Same as #3848, but applied against `6.0.x` instead of `main`; MagTag name fix not included because board is not in 6.0.x)

- Characteristic and descriptor `max_length`s can be zero. Fixes #3746.
- Assure that `start_scan()` timeout is either zero or >= interval. This is a guess for this fix, but it coincides with working values reported in #3826. Fixes #3826.
- Assure that `start_scan()` max timeout is not too large for a `uint16_t` when passed to nRF SD. Fixes #3340.
- Fixes small advertising interval values. Fix check and make sure it's at least 0.02001, to allow for rounding issues, as discussed in #2930. Fixes #2930.

Tested HID, and tested advertising scans with and without a timeout.
