### PR TITLE
unmounted filesystems start as ejected

### DIFF
--- a/supervisor/shared/usb/usb_msc_flash.c
+++ b/supervisor/shared/usb/usb_msc_flash.c
@@ -39,7 +39,7 @@
 
 #define MSC_FLASH_BLOCK_SIZE    512
 
-static bool ejected[1] = {false};
+static bool ejected[1] = {true};
 
 void usb_msc_mount(void) {
     // Reset the ejection tracking every time we're plugged into USB. This allows for us to battery


### PR DESCRIPTION
Fixes #3709.

Undoes https://github.com/adafruit/circuitpython/commit/bda3267432aee57e704a20308b724369cceeb6ca from #3680. The problem is that a board that starts unconnected does not start with unejected drives; they should be ejected when `boot.py` is entered.

The original change saved 20 bytes. I tried reversing the sense of the `ejected[]` array, calling it `not_ejected[]`.  (`mounted` was too confusing, because it has two meanings: one for TinyUSB, and one for the filesystem.) But the code was harder to read and the change caused the addition of a little extra code elsewhere to reverse the sense of various tests. So it ended up that only 12 bytes were saved. I think that was not worth the cost of harder-to-read-code.

This fix is only needed for `main`: the original change was done after 6.0.0.

Tested via `boot.py` on a QTPy.