### PR TITLE
FrequencyIn: do not raise in interrupt handler

### DIFF
--- a/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+++ b/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -82,7 +82,8 @@ void frequencyin_emergency_cancel_capture(uint8_t index) {
     #ifdef SAM_D5X_E5X
     NVIC_EnableIRQ(EIC_0_IRQn + self->channel);
     #endif
-    mp_raise_RuntimeError(translate("Frequency captured is above capability. Capture Paused."));
+    // Frequency captured is above capability. Capture paused.
+    // We can't raise an error here; we're in an interrupt handler.
 }
 
 void frequencyin_interrupt_handler(uint8_t index) {


### PR DESCRIPTION
Fixes #3788.

More info in https://github.com/adafruit/circuitpython/issues/3788#issuecomment-749839525:

Remove this `mp_raise`:
https://github.com/adafruit/circuitpython/blob/8b03951fee166b1eea06d114fc347982b7b186bf/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c#L85.
This is inside `frequencyin_emergency_cancel_capture()`, which is called from `frequencyin_interrupt_handler()`. Interrupt handlers should not raise exceptions.

Simply commenting out the `mp_raise_RuntimeError()` prevents the crash. The `FrequencyIn` object is still functional: I tested it with a `PWMOut()` running at 500Hz and got the expected value.

This is a quick fix to remove the 6.0.0 regression and fatal error; #3788 did not occur in 5.3.1. A more complete solution can be worked out for later. `FrequencyIn` is still functional with this change.