### PR TITLE
esp32-s2: wifi enhancement to include countrycode

### DIFF
--- a/ports/esp32s2/common-hal/wifi/Network.c
+++ b/ports/esp32s2/common-hal/wifi/Network.c
@@ -51,7 +51,8 @@ mp_obj_t common_hal_wifi_network_get_channel(wifi_network_obj_t *self) {
 
 mp_obj_t common_hal_wifi_network_get_country(wifi_network_obj_t *self) {
     const char* cstr = (const char*) self->record.country.cc;
-        // We know that we only want the CC thus limiting to two chars
+        // To address esp_wifi_get_country() returned/set wifi_country_t structure
+        // doesn't follow the documented behaviour (IDFGH-4486) #6315
+        // 2 instead of strlen(cstr) which would be 6 and contain full element
         return mp_obj_new_str(cstr, 2);
 }
-

--- a/ports/esp32s2/common-hal/wifi/Network.c
+++ b/ports/esp32s2/common-hal/wifi/Network.c
@@ -48,3 +48,9 @@ mp_obj_t common_hal_wifi_network_get_rssi(wifi_network_obj_t *self) {
 mp_obj_t common_hal_wifi_network_get_channel(wifi_network_obj_t *self) {
     return mp_obj_new_int(self->record.primary);
 }
+
+mp_obj_t common_hal_wifi_network_get_country(wifi_network_obj_t *self) {
+    const char* cstr = (const char*) self->record.country.cc;
+        return mp_obj_new_str(cstr, strlen(cstr));
+}
+

--- a/ports/esp32s2/common-hal/wifi/Network.c
+++ b/ports/esp32s2/common-hal/wifi/Network.c
@@ -51,8 +51,6 @@ mp_obj_t common_hal_wifi_network_get_channel(wifi_network_obj_t *self) {
 
 mp_obj_t common_hal_wifi_network_get_country(wifi_network_obj_t *self) {
     const char* cstr = (const char*) self->record.country.cc;
-        // To address esp_wifi_get_country() returned/set wifi_country_t structure
-        // doesn't follow the documented behaviour (IDFGH-4486) #6315
-        // 2 instead of strlen(cstr) which would be 6 and contain full element
+        // 2 instead of strlen(cstr) as this gives us only the country-code
         return mp_obj_new_str(cstr, 2);
 }

--- a/ports/esp32s2/common-hal/wifi/Network.c
+++ b/ports/esp32s2/common-hal/wifi/Network.c
@@ -51,6 +51,7 @@ mp_obj_t common_hal_wifi_network_get_channel(wifi_network_obj_t *self) {
 
 mp_obj_t common_hal_wifi_network_get_country(wifi_network_obj_t *self) {
     const char* cstr = (const char*) self->record.country.cc;
-        return mp_obj_new_str(cstr, strlen(cstr));
+        // We know that we only want the CC thus limiting to two chars
+        return mp_obj_new_str(cstr, 2);
 }
 

--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -42,6 +42,10 @@
 
 #define MAC_ADDRESS_LENGTH 6
 
+#include "components/log/include/esp_log.h"
+
+static const char* TAG = "wifi";
+
 static void start_station(wifi_radio_obj_t *self) {
     if (self->sta_mode) {
         return;
@@ -194,6 +198,19 @@ mp_obj_t common_hal_wifi_radio_get_ap_info(wifi_radio_obj_t *self) {
     if (esp_wifi_sta_get_ap_info(&self->ap_info.record) != ESP_OK){
         return mp_const_none;
     } else {
+        ESP_EARLY_LOGW(TAG, "ssid: %s", self->ap_info.record.ssid);
+        ESP_EARLY_LOGW(TAG, "channel: %d", self->ap_info.record.primary);
+        ESP_EARLY_LOGW(TAG, "secondary: %d", self->ap_info.record.second);
+        ESP_EARLY_LOGW(TAG, "rssi: %d", self->ap_info.record.rssi);
+        ESP_EARLY_LOGW(TAG, "authmode: %d", self->ap_info.record.authmode);
+        ESP_EARLY_LOGW(TAG, "pairwise_cipher: %d", self->ap_info.record.pairwise_cipher);
+        ESP_EARLY_LOGW(TAG, "group_cipher: %d", self->ap_info.record.group_cipher);
+        ESP_EARLY_LOGW(TAG, "11b: %d", self->ap_info.record.phy_11b);
+        ESP_EARLY_LOGW(TAG, "11g: %d", self->ap_info.record.phy_11g);
+        ESP_EARLY_LOGW(TAG, "11n: %d", self->ap_info.record.phy_11n);
+        ESP_EARLY_LOGW(TAG, "phy_lr: %d", self->ap_info.record.phy_lr);
+        ESP_EARLY_LOGW(TAG, "country: %s", self->ap_info.record.country);
+        ESP_EARLY_LOGW(TAG, "countryCC: %s", self->ap_info.record.country.cc);
         memcpy(&ap_info->record, &self->ap_info.record, sizeof(wifi_ap_record_t));
         return MP_OBJ_FROM_PTR(ap_info);
     }

--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -198,6 +198,37 @@ mp_obj_t common_hal_wifi_radio_get_ap_info(wifi_radio_obj_t *self) {
     if (esp_wifi_sta_get_ap_info(&self->ap_info.record) != ESP_OK){
         return mp_const_none;
     } else {
+        ESP_EARLY_LOGW(TAG, "country before handler country: %s", (char *)&self->ap_info.record.country);
+        ESP_EARLY_LOGW(TAG, "country memory at: %p", self->ap_info.record.country);
+        ESP_EARLY_LOGW(TAG, "countryCC memory at: %p", self->ap_info.record.country.cc);
+        ESP_EARLY_LOGW(TAG, "countryCC strlen: %d", strlen(self->ap_info.record.country.cc));
+        // The struct member appears to be <null> (not NULL!), I don't know how to properly test for it.
+        // If the ESP-IDF starts working fine, this "if" wouldn't trigger.
+        // Note: It is possible that Wi-Fi APs don't have a CC set, then even after this workaround
+        //       the element would remain empty.
+        if (strlen(self->ap_info.record.country.cc) == 0) {
+            // Workaround to fill country related information in ap_info until ESP-IDF carries a fix
+            // esp_wifi_sta_get_ap_info does not appear to fill wifi_country_t (e.g. country.cc) details
+            // (IDFGH-4437) #6267
+            ESP_EARLY_LOGW(TAG, "Triggered missing country workaround");
+            if (esp_wifi_get_country(&self->ap_info.record.country) == ESP_OK) {
+                ESP_EARLY_LOGW(TAG, "Workaround worked fine!");
+                ESP_EARLY_LOGW(TAG, "country: %d", self->ap_info.record.country);
+                ESP_EARLY_LOGW(TAG, "CC: %s", self->ap_info.record.country.cc);
+            } else {
+                ESP_EARLY_LOGW(TAG, "Workaround failed!");
+            }
+        //} else {
+        //    ESP_EARLY_LOGW(TAG, "Triggered missing country workaround IN ELSE");
+        //    //memset(&self->ap_info.record.country, 0, sizeof(wifi_country_t));
+        //    if (esp_wifi_get_country(&self->ap_info.record.country) == ESP_OK) {
+        //    //if (esp_wifi_get_country(&self->ap_info.record.country) == ESP_OK) {
+        //        ESP_EARLY_LOGW(TAG, "Workaround worked fine!");
+        //        ESP_EARLY_LOGW(TAG, "CC: %s", self->ap_info.record.country.cc);
+        //    } else {
+        //        ESP_EARLY_LOGW(TAG, "Workaround failed!");
+        //    }
+        }
         ESP_EARLY_LOGW(TAG, "ssid: %s", self->ap_info.record.ssid);
         ESP_EARLY_LOGW(TAG, "channel: %d", self->ap_info.record.primary);
         ESP_EARLY_LOGW(TAG, "secondary: %d", self->ap_info.record.second);
@@ -209,8 +240,13 @@ mp_obj_t common_hal_wifi_radio_get_ap_info(wifi_radio_obj_t *self) {
         ESP_EARLY_LOGW(TAG, "11g: %d", self->ap_info.record.phy_11g);
         ESP_EARLY_LOGW(TAG, "11n: %d", self->ap_info.record.phy_11n);
         ESP_EARLY_LOGW(TAG, "phy_lr: %d", self->ap_info.record.phy_lr);
-        ESP_EARLY_LOGW(TAG, "country: %s", self->ap_info.record.country);
+        ESP_EARLY_LOGW(TAG, "ap_info.record: %s", self->ap_info.record);
+        ESP_EARLY_LOGW(TAG, "country with cast: %s", (char *)&self->ap_info.record.country);
+        //ESP_EARLY_LOGW(TAG, "country: %s", self->ap_info.record.country);
+        ESP_EARLY_LOGW(TAG, "country memory at: %p", self->ap_info.record.country);
         ESP_EARLY_LOGW(TAG, "countryCC: %s", self->ap_info.record.country.cc);
+        ESP_EARLY_LOGW(TAG, "countryCC memory at: %p", self->ap_info.record.country.cc);
+        ESP_EARLY_LOGW(TAG, "countryCC strlen: %d", strlen(self->ap_info.record.country.cc));
         memcpy(&ap_info->record, &self->ap_info.record, sizeof(wifi_ap_record_t));
         return MP_OBJ_FROM_PTR(ap_info);
     }

--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -198,55 +198,20 @@ mp_obj_t common_hal_wifi_radio_get_ap_info(wifi_radio_obj_t *self) {
     if (esp_wifi_sta_get_ap_info(&self->ap_info.record) != ESP_OK){
         return mp_const_none;
     } else {
-        ESP_EARLY_LOGW(TAG, "country before handler country: %s", (char *)&self->ap_info.record.country);
-        ESP_EARLY_LOGW(TAG, "country memory at: %p", self->ap_info.record.country);
-        ESP_EARLY_LOGW(TAG, "countryCC memory at: %p", self->ap_info.record.country.cc);
-        ESP_EARLY_LOGW(TAG, "countryCC strlen: %d", strlen(self->ap_info.record.country.cc));
         // The struct member appears to be <null> (not NULL!), I don't know how to properly test for it.
-        // If the ESP-IDF starts working fine, this "if" wouldn't trigger.
+        // When the ESP-IDF starts working fine (when their bugfix is available), this "if" wouldn't trigger.
         // Note: It is possible that Wi-Fi APs don't have a CC set, then even after this workaround
         //       the element would remain empty.
         if (strlen(self->ap_info.record.country.cc) == 0) {
             // Workaround to fill country related information in ap_info until ESP-IDF carries a fix
             // esp_wifi_sta_get_ap_info does not appear to fill wifi_country_t (e.g. country.cc) details
             // (IDFGH-4437) #6267
-            ESP_EARLY_LOGW(TAG, "Triggered missing country workaround");
             if (esp_wifi_get_country(&self->ap_info.record.country) == ESP_OK) {
-                ESP_EARLY_LOGW(TAG, "Workaround worked fine!");
-                ESP_EARLY_LOGW(TAG, "country: %d", self->ap_info.record.country);
-                ESP_EARLY_LOGW(TAG, "CC: %s", self->ap_info.record.country.cc);
+                ESP_EARLY_LOGW(TAG, "Country Code: %s", self->ap_info.record.country.cc);
             } else {
-                ESP_EARLY_LOGW(TAG, "Workaround failed!");
+                ESP_EARLY_LOGW(TAG, "Country Code - Workaround failed!");
             }
-        //} else {
-        //    ESP_EARLY_LOGW(TAG, "Triggered missing country workaround IN ELSE");
-        //    //memset(&self->ap_info.record.country, 0, sizeof(wifi_country_t));
-        //    if (esp_wifi_get_country(&self->ap_info.record.country) == ESP_OK) {
-        //    //if (esp_wifi_get_country(&self->ap_info.record.country) == ESP_OK) {
-        //        ESP_EARLY_LOGW(TAG, "Workaround worked fine!");
-        //        ESP_EARLY_LOGW(TAG, "CC: %s", self->ap_info.record.country.cc);
-        //    } else {
-        //        ESP_EARLY_LOGW(TAG, "Workaround failed!");
-        //    }
         }
-        ESP_EARLY_LOGW(TAG, "ssid: %s", self->ap_info.record.ssid);
-        ESP_EARLY_LOGW(TAG, "channel: %d", self->ap_info.record.primary);
-        ESP_EARLY_LOGW(TAG, "secondary: %d", self->ap_info.record.second);
-        ESP_EARLY_LOGW(TAG, "rssi: %d", self->ap_info.record.rssi);
-        ESP_EARLY_LOGW(TAG, "authmode: %d", self->ap_info.record.authmode);
-        ESP_EARLY_LOGW(TAG, "pairwise_cipher: %d", self->ap_info.record.pairwise_cipher);
-        ESP_EARLY_LOGW(TAG, "group_cipher: %d", self->ap_info.record.group_cipher);
-        ESP_EARLY_LOGW(TAG, "11b: %d", self->ap_info.record.phy_11b);
-        ESP_EARLY_LOGW(TAG, "11g: %d", self->ap_info.record.phy_11g);
-        ESP_EARLY_LOGW(TAG, "11n: %d", self->ap_info.record.phy_11n);
-        ESP_EARLY_LOGW(TAG, "phy_lr: %d", self->ap_info.record.phy_lr);
-        ESP_EARLY_LOGW(TAG, "ap_info.record: %s", self->ap_info.record);
-        ESP_EARLY_LOGW(TAG, "country with cast: %s", (char *)&self->ap_info.record.country);
-        //ESP_EARLY_LOGW(TAG, "country: %s", self->ap_info.record.country);
-        ESP_EARLY_LOGW(TAG, "country memory at: %p", self->ap_info.record.country);
-        ESP_EARLY_LOGW(TAG, "countryCC: %s", self->ap_info.record.country.cc);
-        ESP_EARLY_LOGW(TAG, "countryCC memory at: %p", self->ap_info.record.country.cc);
-        ESP_EARLY_LOGW(TAG, "countryCC strlen: %d", strlen(self->ap_info.record.country.cc));
         memcpy(&ap_info->record, &self->ap_info.record, sizeof(wifi_ap_record_t));
         return MP_OBJ_FROM_PTR(ap_info);
     }

--- a/ports/esp32s2/common-hal/wifi/ScannedNetworks.c
+++ b/ports/esp32s2/common-hal/wifi/ScannedNetworks.c
@@ -39,6 +39,10 @@
 
 #include "components/esp_wifi/include/esp_wifi.h"
 
+#include "components/log/include/esp_log.h"
+
+static const char* TAG = "wifi";
+
 static void wifi_scannednetworks_done(wifi_scannednetworks_obj_t *self) {
     self->done = true;
     if (self->results != NULL) {
@@ -117,6 +121,8 @@ mp_obj_t common_hal_wifi_scannednetworks_next(wifi_scannednetworks_obj_t *self) 
 
     wifi_network_obj_t *entry = m_new_obj(wifi_network_obj_t);
     entry->base.type = &wifi_network_type;
+    // benny remove again
+    ESP_EARLY_LOGW(TAG, "scan country: %s", &self->results[self->current_result].country);
     memcpy(&entry->record, &self->results[self->current_result], sizeof(wifi_ap_record_t));
     self->current_result++;
 

--- a/ports/esp32s2/common-hal/wifi/ScannedNetworks.c
+++ b/ports/esp32s2/common-hal/wifi/ScannedNetworks.c
@@ -39,10 +39,6 @@
 
 #include "components/esp_wifi/include/esp_wifi.h"
 
-#include "components/log/include/esp_log.h"
-
-static const char* TAG = "wifi";
-
 static void wifi_scannednetworks_done(wifi_scannednetworks_obj_t *self) {
     self->done = true;
     if (self->results != NULL) {
@@ -121,8 +117,6 @@ mp_obj_t common_hal_wifi_scannednetworks_next(wifi_scannednetworks_obj_t *self) 
 
     wifi_network_obj_t *entry = m_new_obj(wifi_network_obj_t);
     entry->base.type = &wifi_network_type;
-    // benny remove again
-    ESP_EARLY_LOGW(TAG, "scan country: %s", &self->results[self->current_result].country);
     memcpy(&entry->record, &self->results[self->current_result], sizeof(wifi_ap_record_t));
     self->current_result++;
 

--- a/shared-bindings/wifi/Network.c
+++ b/shared-bindings/wifi/Network.c
@@ -108,12 +108,29 @@ const mp_obj_property_t wifi_network_channel_obj = {
                (mp_obj_t)&mp_const_none_obj },
 };
 
+//|     country: str
+//|     """String id of the country code"""
+//|
+STATIC mp_obj_t wifi_network_get_country(mp_obj_t self) {
+    return common_hal_wifi_network_get_country(self);
+
+}
+MP_DEFINE_CONST_FUN_OBJ_1(wifi_network_get_country_obj, wifi_network_get_country);
+
+const mp_obj_property_t wifi_network_country_obj = {
+    .base.type = &mp_type_property,
+    .proxy = { (mp_obj_t)&wifi_network_get_country_obj,
+               (mp_obj_t)&mp_const_none_obj,
+               (mp_obj_t)&mp_const_none_obj },
+};
+
 
 STATIC const mp_rom_map_elem_t wifi_network_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ssid), MP_ROM_PTR(&wifi_network_ssid_obj) },
     { MP_ROM_QSTR(MP_QSTR_bssid), MP_ROM_PTR(&wifi_network_bssid_obj) },
     { MP_ROM_QSTR(MP_QSTR_rssi), MP_ROM_PTR(&wifi_network_rssi_obj) },
     { MP_ROM_QSTR(MP_QSTR_channel), MP_ROM_PTR(&wifi_network_channel_obj) },
+    { MP_ROM_QSTR(MP_QSTR_country), MP_ROM_PTR(&wifi_network_country_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(wifi_network_locals_dict, wifi_network_locals_dict_table);

--- a/shared-bindings/wifi/Network.h
+++ b/shared-bindings/wifi/Network.h
@@ -39,5 +39,6 @@ extern mp_obj_t common_hal_wifi_network_get_ssid(wifi_network_obj_t *self);
 extern mp_obj_t common_hal_wifi_network_get_bssid(wifi_network_obj_t *self);
 extern mp_obj_t common_hal_wifi_network_get_rssi(wifi_network_obj_t *self);
 extern mp_obj_t common_hal_wifi_network_get_channel(wifi_network_obj_t *self);
+extern mp_obj_t common_hal_wifi_network_get_country(wifi_network_obj_t *self);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_WIFI_NETWORK_H

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -295,7 +295,7 @@ const mp_obj_property_t wifi_radio_ipv4_dns_obj = {
 };
 
 //|     ap_info: Optional[Network]
-//|     """Network object containing BSSID, SSID, channel, and RSSI when connected to an access point. None otherwise."""
+//|     """Network object containing BSSID, SSID, channel, country and RSSI when connected to an access point. None otherwise."""
 //|
 STATIC mp_obj_t wifi_radio_get_ap_info(mp_obj_t self) {
     return common_hal_wifi_radio_get_ap_info(self);


### PR DESCRIPTION
This adds support to access the country code as announced by the Wi-Fi access point (*if* it announces it). 

The workaround via esp_wifi_get_country() is necessary as esp_wifi_sta_get_ap_info() returns wifi_ap_record_t where wifi_country_t is empty. Reference to ESP-IDF bug report/issue: https://github.com/espressif/esp-idf/issues/6267 

![win10-wsl-screenshot](https://user-images.githubusercontent.com/5174414/103009083-6a5d9300-4536-11eb-9ea8-e9336470f453.jpeg)

The discussion with @tannewt happened on this commit (so that there is more context, as questions are associated to line numbers):
https://github.com/BennyE/circuitpython/commit/ae3b4408350e5623ef769a2860984d2d8937be59 
(next time, I'll do this via a draft PR - Thank you! :))

As I haven't added new objects, it should not be necessary to add something to the gc - but I'd love to hear @dhalbert feedback. :)