### PR TITLE
arm builds: request gcc 10.2.1 by default

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -54,6 +54,7 @@ include $(TOP)/supervisor/supervisor.mk
 include $(TOP)/py/circuitpy_defns.mk
 
 CROSS_COMPILE = arm-none-eabi-
+CCSUFFIX = -10.2.1
 
 HAL_DIR=hal/$(MCU_SERIES)
 

--- a/ports/cxd56/Makefile
+++ b/ports/cxd56/Makefile
@@ -57,6 +57,7 @@ include $(TOP)/supervisor/supervisor.mk
 include $(TOP)/py/circuitpy_defns.mk
 
 CROSS_COMPILE = arm-none-eabi-
+CCSUFFIX = -10.2.1
 
 SPRESENSE_SDK = spresense-exported-sdk
 

--- a/ports/mimxrt10xx/Makefile
+++ b/ports/mimxrt10xx/Makefile
@@ -55,6 +55,7 @@ include $(TOP)/supervisor/supervisor.mk
 include $(TOP)/py/circuitpy_defns.mk
 
 CROSS_COMPILE = arm-none-eabi-
+CCSUFFIX = -10.2.1
 
 INC += \
 	-I. \

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -64,6 +64,7 @@ ifneq ($(SD), )
 endif
 
 CROSS_COMPILE = arm-none-eabi-
+CCSUFFIX = -10.2.1
 
 FATFS_DIR = lib/oofatfs
 

--- a/ports/stm/Makefile
+++ b/ports/stm/Makefile
@@ -56,6 +56,7 @@ include $(TOP)/supervisor/supervisor.mk
 include $(TOP)/py/circuitpy_defns.mk
 
 CROSS_COMPILE = arm-none-eabi-
+CCSUFFIX = -10.2.1
 
 MCU_SERIES_LOWER = $(shell echo $(MCU_SERIES) | tr '[:upper:]' '[:lower:]')
 MCU_VARIANT_LOWER = $(shell echo $(MCU_VARIANT) | tr '[:upper:]' '[:lower:]')

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -59,7 +59,8 @@ SED = sed
 NPROC = $(PYTHON3) -c 'import multiprocessing as mp; print(mp.cpu_count())'
 
 AS = $(CROSS_COMPILE)as
-CC = $(CROSS_COMPILE)gcc
+CCSUFFIX ?=
+CC = $(CROSS_COMPILE)gcc$(CCSUFFIX)
 CXX = $(CROSS_COMPILE)g++
 LD = $(CROSS_COMPILE)ld
 OBJCOPY = $(CROSS_COMPILE)objcopy


### PR DESCRIPTION
This means that you can build 6.0 and main with the same PATH, as long as the unsuffixed compiler is 9.

You can `make CCSUFFIX=` to use the unsuffixed compiler at any time, or `make CCSUFFIX=-12.3.4` to select a particular suffix.