### PR TITLE
#3875 fix for rotary reverse direction dead spot

### DIFF
--- a/ports/nrf/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/nrf/common-hal/rotaryio/IncrementalEncoder.c
@@ -51,10 +51,10 @@ static void _intr_handler(nrfx_gpiote_pin_t pin, nrf_gpiote_polarity_t action) {
 
     // logic from the atmel-samd port: provides some damping and scales movement
     // down by 4:1.
-    if (self->quarter >= 4) {
+    if (self->quarter > 0 && new_state == 2) {
         self->position++;
         self->quarter = 0;
-    } else if (self->quarter <= -4) {
+    } else if (self->quarter < 0 && new_state == 2) {
         self->position--;
         self->quarter = 0;
     }


### PR DESCRIPTION
It is possible that the `quarter` counter can get out of sync with the quadrature pins. By checking the new_state, instead of just the quarter counter, it stays in sync with the rotary encoding.

During testing I was able to recreate the bug and saw that the `quarter` count would sometimes count (from a settled click position to next encoder position)  2, 3, 4, 1 and back to 2. In this mode it does a position increment mid way through the quadrature cycle and it works fine if it is always increasing or always decreasing. When the encoder reverses it does not pass 4, instead it counts down 2, 1, 0, -1, -2 (which will not decrement the position).

This PR changes the conditions for a `position` increment or decrement, to only fire when the encoder is at the settled state.