### PR TITLE
ESP32-S2: Log all Wi-Fi events & remove unneeded call

### DIFF
--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -55,8 +55,6 @@ static void start_station(wifi_radio_obj_t *self) {
     esp_wifi_set_mode(next_mode);
 
     self->sta_mode = 1;
-
-    esp_wifi_set_config(WIFI_MODE_STA, &self->sta_config);
 }
 
 bool common_hal_wifi_radio_get_enabled(wifi_radio_obj_t *self) {

--- a/ports/esp32s2/common-hal/wifi/__init__.c
+++ b/ports/esp32s2/common-hal/wifi/__init__.c
@@ -47,23 +47,23 @@ static void event_handler(void* arg, esp_event_base_t event_base,
     if (event_base == WIFI_EVENT) {
         switch (event_id) {
             case WIFI_EVENT_SCAN_DONE:
-                ESP_EARLY_LOGW(TAG, "scan");
+                ESP_LOGW(TAG, "scan");
                 xEventGroupSetBits(radio->event_group_handle, WIFI_SCAN_DONE_BIT);
                 break;
             case WIFI_EVENT_STA_START:
-                ESP_EARLY_LOGW(TAG, "start");
+                ESP_LOGW(TAG, "start");
                 break;
             case WIFI_EVENT_STA_STOP:
-                ESP_EARLY_LOGW(TAG, "stop");
+                ESP_LOGW(TAG, "stop");
                 break;
             case WIFI_EVENT_STA_CONNECTED:
-                ESP_EARLY_LOGW(TAG, "connected");
+                ESP_LOGW(TAG, "connected");
                 break;
             case WIFI_EVENT_STA_DISCONNECTED: {
-                ESP_EARLY_LOGW(TAG, "disconnected");
+                ESP_LOGW(TAG, "disconnected");
                 wifi_event_sta_disconnected_t* d = (wifi_event_sta_disconnected_t*) event_data;
                 uint8_t reason = d->reason;
-                ESP_EARLY_LOGW(TAG, "reason %d 0x%02x", reason, reason);
+                ESP_LOGW(TAG, "reason %d 0x%02x", reason, reason);
                 if (radio->retries_left > 0 &&
                         (reason == WIFI_REASON_AUTH_EXPIRE ||
                          reason == WIFI_REASON_NOT_AUTHED ||
@@ -71,7 +71,7 @@ static void event_handler(void* arg, esp_event_base_t event_base,
                          reason == WIFI_REASON_CONNECTION_FAIL ||
                          reason == WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT)) {
                     radio->retries_left--;
-                    ESP_EARLY_LOGI(TAG, "Retrying connect. %d retries remaining", radio->retries_left);
+                    ESP_LOGI(TAG, "Retrying connect. %d retries remaining", radio->retries_left);
                     esp_wifi_connect();
                     return;
                 }
@@ -84,14 +84,14 @@ static void event_handler(void* arg, esp_event_base_t event_base,
             // Cases to handle later.
             // case WIFI_EVENT_STA_AUTHMODE_CHANGE:
             default: {
-                ESP_EARLY_LOGW(TAG, "event %d 0x%02x", event_id, event_id);
+                ESP_LOGW(TAG, "event %d 0x%02x", event_id, event_id);
                 break;
             }
         }
     }
 
     if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
-        ESP_EARLY_LOGW(TAG, "got ip");
+        ESP_LOGW(TAG, "got ip");
         radio->retries_left = radio->starting_retries;
         xEventGroupSetBits(radio->event_group_handle, WIFI_CONNECTED_BIT);
     }

--- a/ports/esp32s2/common-hal/wifi/__init__.c
+++ b/ports/esp32s2/common-hal/wifi/__init__.c
@@ -78,12 +78,15 @@ static void event_handler(void* arg, esp_event_base_t event_base,
 
                 radio->last_disconnect_reason = reason;
                 xEventGroupSetBits(radio->event_group_handle, WIFI_DISCONNECTED_BIT);
+                break;
             }
 
             // Cases to handle later.
             // case WIFI_EVENT_STA_AUTHMODE_CHANGE:
-            default:
+            default: {
+                ESP_EARLY_LOGW(TAG, "event %d 0x%02x", event_id, event_id);
                 break;
+            }
         }
     }
 


### PR DESCRIPTION
### __init.c__:

Add logging to the event handler default event to capture any other wi-fi events that occur, to see what else happens in the field that we may want to handle better.

### Radio.c:

This call in `start_station()`:
```
esp_wifi_set_config(WIFI_MODE_STA, &self->sta_config);
```
has the wrong parameter [type] (should be `ESP_IF_WIFI_STA` == 0; `WIFI_MODE_STA` == 1 and sets the config for AP interface type ), and is also not needed here since it's called in `connect()` anyway (and is not needed for scanning or ping).

Alternatively, we could correct the call in `start_station()`, and remove it from `connect()` (`connect()` calls `start_station()`)

All depends on the design intent... how granular we want these functions to be as features like AP, AP+STA, etc. get added. It might be nice to keep clean code demarcation between concepts of netif [de]init, wifi [de]init, wi-fi mode, wifi start/stop, and station [dis]connect.