### PR TITLE
Update built-in help output for localization (Issue #3907)

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-23 23:04-0500\n"
+"POT-Creation-Date: 2020-12-30 17:42-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -42,6 +42,10 @@ msgstr ""
 
 #: py/obj.c
 msgid "  File \"%q\", line %d"
+msgstr ""
+
+#: py/builtinhelp.c
+msgid " is of type %q\n"
 msgstr ""
 
 #: main.c
@@ -3191,6 +3195,10 @@ msgstr ""
 
 #: extmod/ulab/code/ulab_create.c
 msgid "number of points must be at least 2"
+msgstr ""
+
+#: py/builtinhelp.c
+msgid "object "
 msgstr ""
 
 #: py/obj.c

--- a/ports/atmel-samd/boards/8086_commander/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/8086_commander/mpconfigboard.mk
@@ -22,6 +22,7 @@ CIRCUITPY_GAMEPAD = 1
 CIRCUITPY_BUSDEVICE = 1
 
 # Include these Python libraries in firmware.
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_HID
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_SD
 #FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_ADXL34x

--- a/ports/atmel-samd/boards/feather_m0_express_crickit/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/feather_m0_express_crickit/mpconfigboard.mk
@@ -20,6 +20,7 @@ CIRCUITPY_GAMEPAD = 0
 CFLAGS_INLINE_LIMIT = 50
 
 # Include these Python libraries in firmware.
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Crickit
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Motor
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel

--- a/ports/atmel-samd/boards/feather_m0_rfm69/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/feather_m0_rfm69/mpconfigboard.mk
@@ -28,4 +28,5 @@ CFLAGS_INLINE_LIMIT = 35
 SUPEROPT_GC = 0
 
 # Include these Python libraries in firmware.
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_RFM69

--- a/ports/atmel-samd/boards/feather_m0_rfm9x/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/feather_m0_rfm9x/mpconfigboard.mk
@@ -29,4 +29,5 @@ CFLAGS_INLINE_LIMIT = 35
 SUPEROPT_GC = 0
 
 # Include these Python libraries in firmware.
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_RFM9x

--- a/ports/atmel-samd/boards/hallowing_m0_express/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/hallowing_m0_express/mpconfigboard.mk
@@ -27,6 +27,7 @@ CFLAGS_INLINE_LIMIT = 55
 SUPEROPT_GC = 0
 
 # Include these Python libraries in firmware.
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_LIS3DH
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
 

--- a/ports/atmel-samd/boards/pycubed/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/pycubed/mpconfigboard.mk
@@ -21,6 +21,7 @@ CIRCUITPY_GAMEPAD = 0
 CIRCUITPY_RGBMATRIX = 0
 CIRCUITPY_PS2IO = 0
 
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Register
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_SD

--- a/ports/atmel-samd/boards/pycubed_mram/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/pycubed_mram/mpconfigboard.mk
@@ -21,6 +21,7 @@ CIRCUITPY_GAMEPAD = 0
 CIRCUITPY_RGBMATRIX = 0
 CIRCUITPY_PS2IO = 0
 
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Register
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_SD

--- a/ports/atmel-samd/boards/sam32/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/sam32/mpconfigboard.mk
@@ -13,4 +13,5 @@ LONGINT_IMPL = MPZ
 CIRCUITPY_AUDIOBUSIO = 0
 CIRCUITPY_USTACK = 1
 
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel

--- a/ports/atmel-samd/boards/xinabox_cc03/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/xinabox_cc03/mpconfigboard.mk
@@ -24,3 +24,4 @@ CIRCUITPY_TOUCHIO=0
 CIRCUITPY_BUSDEVICE=1
 
 # Include these Python libraries in firmware.
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice

--- a/ports/atmel-samd/boards/xinabox_cs11/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/xinabox_cs11/mpconfigboard.mk
@@ -27,4 +27,5 @@ CIRCUITPY_COUNTIO=0
 CIRCUITPY_BUSDEVICE=1
 
 # Include these Python libraries in firmware.
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_SD

--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -152,9 +152,18 @@ STATIC void mp_help_print_obj(const mp_obj_t obj) {
     mp_obj_type_t *type = mp_obj_get_type(obj);
 
     // try to print something sensible about the given object
-    mp_print_str(MP_PYTHON_PRINTER, "object ");
+    const compressed_string_t* compressed = translate("object ");
+    char decompressed_object[decompress_length(compressed)];
+    decompress(compressed, decompressed_object);
+
+    mp_print_str(MP_PYTHON_PRINTER, decompressed_object);
     mp_obj_print(obj, PRINT_STR);
-    mp_printf(MP_PYTHON_PRINTER, " is of type %q\n", type->name);
+
+    compressed = translate(" is of type %q\n");
+    char decompressed_typestring[decompress_length(compressed)];
+    decompress(compressed, decompressed_typestring);
+
+    mp_printf(MP_PYTHON_PRINTER, decompressed_typestring, type->name);
 
     mp_map_t *map = NULL;
     if (type == &mp_type_module) {


### PR DESCRIPTION
Adding localization values for the output of calls to `help(<object>)` can match the current firmware's language.

This change addresses issue #3907 