### PR TITLE
overflowed tick counter needs 64 bits everywhere

### DIFF
--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -431,7 +431,7 @@ uint32_t port_get_saved_word(void) {
 static volatile uint64_t overflowed_ticks = 0;
 static volatile bool _ticks_enabled = false;
 
-static uint32_t _get_count(uint32_t* overflow_count) {
+static uint32_t _get_count(uint64_t* overflow_count) {
     #ifdef SAM_D5X_E5X
     while ((RTC->MODE0.SYNCBUSY.reg & (RTC_MODE0_SYNCBUSY_COUNTSYNC | RTC_MODE0_SYNCBUSY_COUNT)) != 0) {}
     #endif
@@ -500,7 +500,7 @@ void RTC_Handler(void) {
 }
 
 uint64_t port_get_raw_ticks(uint8_t* subticks) {
-    uint32_t overflow_count;
+    uint64_t overflow_count;
     uint32_t current_ticks = _get_count(&overflow_count);
     if (subticks != NULL) {
         *subticks = (current_ticks % 16) * 2;

--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -276,7 +276,7 @@ uint32_t port_get_saved_word(void) {
 uint64_t port_get_raw_ticks(uint8_t* subticks) {
     common_hal_mcu_disable_interrupts();
     uint32_t rtc = nrfx_rtc_counter_get(&rtc_instance);
-    uint32_t overflow_count = overflow_tracker.overflowed_ticks;
+    uint64_t overflow_count = overflow_tracker.overflowed_ticks;
     common_hal_mcu_enable_interrupts();
 
     if (subticks != NULL) {


### PR DESCRIPTION
The 64-bit tick overflow counter was being truncated when copied, in certain cases.

This seems to fix #3919. ~~It may also xxfix #3918, and perhaps xxfix #3912~~.

I still don't understand why this problem is showing up only in MacOS.