### PR TITLE
Add MagTag accelo IRQ pin

### DIFF
--- a/ports/esp32s2/boards/adafruit_magtag_2.9_grayscale/pins.c
+++ b/ports/esp32s2/boards/adafruit_magtag_2.9_grayscale/pins.c
@@ -49,6 +49,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
 
-    { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].epaper_display)}
+    { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].epaper_display)},
+
+    { MP_ROM_QSTR(MP_QSTR_ACCELEROMETER_INTERRUPT), MP_ROM_PTR(&pin_GPIO9) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);


### PR DESCRIPTION
Adds the ESP32S2 pin connected to the LIS3DH INT1 pin.

![schem](https://user-images.githubusercontent.com/8755041/103799737-59b22000-5000-11eb-8872-ff35cf6f7219.png)

Crude test (still learning details on all the interrupt config), but note that IRQ pin state tracks bit 7 in the LIS3DH's IRQ status register.
```python
import time
import board
import digitalio
import adafruit_lis3dh

irq_pin = digitalio.DigitalInOut(board.ACCELEROMETER_INTERRUPT)
irq_pin.direction = digitalio.Direction.INPUT

lis = adafruit_lis3dh.LIS3DH_I2C(board.I2C(), address=0x19)

lis._write_register_byte(0x22, 0x40) # CTRL_REG3
lis._write_register_byte(0x24, 0x08) # CTRL_REG5
lis._write_register_byte(0x32, 0x20) # INT1_THS
lis._write_register_byte(0x33, 0x0A) # INT1_DURATION
lis._write_register_byte(0x30, 0x4C) # INT1_CFG

while True:
    print("IRQ PIN = {}   INT_SRC = 0b{:08b}".format(1 if irq_pin.value else 0, lis._read_register_byte(0x31)))
    time.sleep(0.5)
```

Output:
```
IRQ PIN = 0   INT_SRC = 0b00000100
IRQ PIN = 1   INT_SRC = 0b01000100
IRQ PIN = 1   INT_SRC = 0b01000100
IRQ PIN = 0   INT_SRC = 0b00010000
IRQ PIN = 1   INT_SRC = 0b01001000
IRQ PIN = 1   INT_SRC = 0b01001000
IRQ PIN = 0   INT_SRC = 0b00001000
IRQ PIN = 1   INT_SRC = 0b01001000
IRQ PIN = 0   INT_SRC = 0b00010000
```