### PR TITLE
esp32-s2: Adding authmode keyword

### DIFF
--- a/ports/esp32s2/common-hal/wifi/Network.c
+++ b/ports/esp32s2/common-hal/wifi/Network.c
@@ -54,3 +54,38 @@ mp_obj_t common_hal_wifi_network_get_country(wifi_network_obj_t *self) {
         // 2 instead of strlen(cstr) as this gives us only the country-code
         return mp_obj_new_str(cstr, 2);
 }
+
+mp_obj_t common_hal_wifi_network_get_authmode(wifi_network_obj_t *self) {
+    char authmode[16];
+    switch (self->record.authmode) {
+        case WIFI_AUTH_OPEN:
+            strcpy(authmode, "OPEN");
+            break;
+        case WIFI_AUTH_WEP:
+            strcpy(authmode, "WEP");
+            break;
+        case WIFI_AUTH_WPA_PSK:
+            strcpy(authmode, "WPA_PSK");
+            break;
+        case WIFI_AUTH_WPA2_PSK:
+            strcpy(authmode, "WPA2_PSK");
+            break;
+        case WIFI_AUTH_WPA_WPA2_PSK:
+            strcpy(authmode, "WPA_WPA2_PSK");
+            break;
+        case WIFI_AUTH_WPA2_ENTERPRISE:
+            strcpy(authmode, "WPA2_ENTERPRISE");
+            break;
+        case WIFI_AUTH_WPA3_PSK:
+            strcpy(authmode, "WPA3_PSK");
+            break;
+        case WIFI_AUTH_WPA2_WPA3_PSK:
+            strcpy(authmode, "WPA2_WPA3_PSK");
+            break;
+        default:
+            strcpy(authmode, "UNKNOWN");
+            break;
+    }
+        const char* cstr = (const char*) authmode;
+        return mp_obj_new_str(cstr, strlen(cstr));
+}

--- a/ports/esp32s2/common-hal/wifi/Network.c
+++ b/ports/esp32s2/common-hal/wifi/Network.c
@@ -56,34 +56,34 @@ mp_obj_t common_hal_wifi_network_get_country(wifi_network_obj_t *self) {
 }
 
 mp_obj_t common_hal_wifi_network_get_authmode(wifi_network_obj_t *self) {
-    char authmode[16];
+    const char* authmode = "";
     switch (self->record.authmode) {
         case WIFI_AUTH_OPEN:
-            strcpy(authmode, "OPEN");
+            authmode = "OPEN";
             break;
         case WIFI_AUTH_WEP:
-            strcpy(authmode, "WEP");
+            authmode = "WEP";
             break;
         case WIFI_AUTH_WPA_PSK:
-            strcpy(authmode, "WPA_PSK");
+            authmode = "WPA_PSK";
             break;
         case WIFI_AUTH_WPA2_PSK:
-            strcpy(authmode, "WPA2_PSK");
+            authmode = "WPA2_PSK";
             break;
         case WIFI_AUTH_WPA_WPA2_PSK:
-            strcpy(authmode, "WPA_WPA2_PSK");
+            authmode = "WPA_WPA2_PSK";
             break;
         case WIFI_AUTH_WPA2_ENTERPRISE:
-            strcpy(authmode, "WPA2_ENTERPRISE");
+            authmode = "WPA2_ENTERPRISE";
             break;
         case WIFI_AUTH_WPA3_PSK:
-            strcpy(authmode, "WPA3_PSK");
+            authmode = "WPA3_PSK";
             break;
         case WIFI_AUTH_WPA2_WPA3_PSK:
-            strcpy(authmode, "WPA2_WPA3_PSK");
+            authmode = "WPA2_WPA3_PSK";
             break;
         default:
-            strcpy(authmode, "UNKNOWN");
+            authmode = "UNKNOWN";
             break;
     }
         const char* cstr = (const char*) authmode;

--- a/ports/esp32s2/common-hal/wifi/Network.c
+++ b/ports/esp32s2/common-hal/wifi/Network.c
@@ -86,6 +86,5 @@ mp_obj_t common_hal_wifi_network_get_authmode(wifi_network_obj_t *self) {
             authmode = "UNKNOWN";
             break;
     }
-        const char* cstr = (const char*) authmode;
-        return mp_obj_new_str(cstr, strlen(cstr));
+        return mp_obj_new_str(authmode, strlen(authmode));
 }

--- a/shared-bindings/wifi/Network.c
+++ b/shared-bindings/wifi/Network.c
@@ -124,6 +124,21 @@ const mp_obj_property_t wifi_network_country_obj = {
                (mp_obj_t)&mp_const_none_obj },
 };
 
+//|     authmode: str
+//|     """String id of the authmode"""
+//|
+STATIC mp_obj_t wifi_network_get_authmode(mp_obj_t self) {
+    return common_hal_wifi_network_get_authmode(self);
+
+}
+MP_DEFINE_CONST_FUN_OBJ_1(wifi_network_get_authmode_obj, wifi_network_get_authmode);
+
+const mp_obj_property_t wifi_network_authmode_obj = {
+    .base.type = &mp_type_property,
+    .proxy = { (mp_obj_t)&wifi_network_get_authmode_obj,
+               (mp_obj_t)&mp_const_none_obj,
+               (mp_obj_t)&mp_const_none_obj },
+};
 
 STATIC const mp_rom_map_elem_t wifi_network_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ssid), MP_ROM_PTR(&wifi_network_ssid_obj) },
@@ -131,6 +146,7 @@ STATIC const mp_rom_map_elem_t wifi_network_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_rssi), MP_ROM_PTR(&wifi_network_rssi_obj) },
     { MP_ROM_QSTR(MP_QSTR_channel), MP_ROM_PTR(&wifi_network_channel_obj) },
     { MP_ROM_QSTR(MP_QSTR_country), MP_ROM_PTR(&wifi_network_country_obj) },
+    { MP_ROM_QSTR(MP_QSTR_authmode), MP_ROM_PTR(&wifi_network_authmode_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(wifi_network_locals_dict, wifi_network_locals_dict_table);

--- a/shared-bindings/wifi/Network.h
+++ b/shared-bindings/wifi/Network.h
@@ -40,5 +40,6 @@ extern mp_obj_t common_hal_wifi_network_get_bssid(wifi_network_obj_t *self);
 extern mp_obj_t common_hal_wifi_network_get_rssi(wifi_network_obj_t *self);
 extern mp_obj_t common_hal_wifi_network_get_channel(wifi_network_obj_t *self);
 extern mp_obj_t common_hal_wifi_network_get_country(wifi_network_obj_t *self);
+extern mp_obj_t common_hal_wifi_network_get_authmode(wifi_network_obj_t *self);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_WIFI_NETWORK_H

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -295,7 +295,7 @@ const mp_obj_property_t wifi_radio_ipv4_dns_obj = {
 };
 
 //|     ap_info: Optional[Network]
-//|     """Network object containing BSSID, SSID, channel, country and RSSI when connected to an access point. None otherwise."""
+//|     """Network object containing BSSID, SSID, authmode, channel, country and RSSI when connected to an access point. None otherwise."""
 //|
 STATIC mp_obj_t wifi_radio_get_ap_info(mp_obj_t self) {
     return common_hal_wifi_radio_get_ap_info(self);


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/5174414/103828072-99b5e900-507a-11eb-883a-c52cc5f8e317.png)

While this works fine, I'm not entirely confident with my change around the following, as I need an additional variable.
e.g.
```c
strcpy(authmode, "OPEN");
```
Can I get around this? I've tried/attempted to directly strcpy into cstr, but this resulted in an unhappy compiler.

I'm planning to add pairwise_cipher & group_cipher, unless you'd prefer to be a separate PR (thus this is a draft).