### PR TITLE
ESP32-S2: added sys.platform

### DIFF
--- a/ports/esp32s2/mpconfigport.h
+++ b/ports/esp32s2/mpconfigport.h
@@ -32,6 +32,7 @@
 
 #define MICROPY_PY_UJSON                    (1)
 #define MICROPY_USE_INTERNAL_PRINTF         (0)
+#define MICROPY_PY_SYS_PLATFORM             "Espressif ESP32-S2"
 
 #include "py/circuitpy_mpconfig.h"
 


### PR DESCRIPTION
Addresses [https://github.com/adafruit/circuitpython/issues/3951](https://github.com/adafruit/circuitpython/issues/3951)

```
>>> Adafruit CircuitPython 6.1.0-rc.0-11-g55c80754c-dirty on 2021-01-08; Saola 1 w/Wrover with ESP32S2
>>> import sys
>>> sys.platform
'Espressif ESP32-S2'
```