### PR TITLE
new CIRCUITPY_DEBUG flag passes DEBUG into C preprocessor

### DIFF
--- a/py/circuitpy_defns.mk
+++ b/py/circuitpy_defns.mk
@@ -58,6 +58,14 @@ BASE_CFLAGS = \
 #        -H
 
 
+# Set a global CIRCUITPY_DEBUG flag.
+# Don't just call it "DEBUG": too many libraries use plain DEBUG.
+ifneq ($(DEBUG),)
+CFLAGS += -DCIRCUITPY_DEBUG=$(DEBUG)
+else
+CFLAGS += -DCIRCUITPY_DEBUG=0
+endif
+
 ###
 # Handle frozen modules.
 

--- a/supervisor/shared/translate.c
+++ b/supervisor/shared/translate.c
@@ -122,7 +122,12 @@ char* decompress(const compressed_string_t* compressed, char* decompressed) {
     return decompressed;
 }
 
-inline __attribute__((always_inline)) const compressed_string_t* translate(const char* original) {
+inline
+// gcc10 -flto has issues with this being always_inline for debug builds.
+#if CIRCUITPY_DEBUG < 1
+ __attribute__((always_inline))
+#endif
+const compressed_string_t* translate(const char* original) {
     #ifndef NO_QSTR
     #define QDEF(id, str)
     #define TRANSLATION(id, firstbyte, ...) if (strcmp(original, id) == 0) { static const compressed_string_t v = { .data = firstbyte, .tail = { __VA_ARGS__ } }; return &v; } else


### PR DESCRIPTION
Fixes #3857, and provides a general mechanism to know what the make `DEBUG=` flag is in the C preprocessor.