### PR TITLE
restore len(alarm.sleep_memory) and bool(alarm.sleep_memory)

### DIFF
--- a/shared-bindings/alarm/SleepMemory.c
+++ b/shared-bindings/alarm/SleepMemory.c
@@ -53,6 +53,25 @@
 //|         """Not used. Access the sole instance through `alarm.sleep_memory`."""
 //|         ...
 //|
+//|     def __bool__(self) -> bool:
+//|         """``sleep_memory`` is ``True`` if its length is greater than zero.
+//|         This is an easy way to check for its existence.
+//|         """
+//|         ...
+//|
+//|     def __len__(self) -> int:
+//|         """Return the length. This is used by (`len`)"""
+//|         ...
+//|
+STATIC mp_obj_t alarm_sleep_memory_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
+    alarm_sleep_memory_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    uint16_t len = common_hal_alarm_sleep_memory_get_length(self);
+    switch (op) {
+        case MP_UNARY_OP_BOOL: return mp_obj_new_bool(len != 0);
+        case MP_UNARY_OP_LEN: return MP_OBJ_NEW_SMALL_INT(len);
+        default: return MP_OBJ_NULL; // op not supported
+    }
+}
 
 STATIC const mp_rom_map_elem_t alarm_sleep_memory_locals_dict_table[] = {
 };
@@ -154,6 +173,7 @@ const mp_obj_type_t alarm_sleep_memory_type = {
     { &mp_type_type },
     .name = MP_QSTR_SleepMemory,
     .subscr = alarm_sleep_memory_subscr,
+    .unary_op = alarm_sleep_memory_unary_op,
     .print = NULL,
     .locals_dict = (mp_obj_t)&alarm_sleep_memory_locals_dict,
 };


### PR DESCRIPTION
Fixes #3956.

This was originally copied over from `microcontroller.nvm`, and then after a discussion with @tannewt, was deleted. I didn't mean to delete `len()` . And on reflection, I think `bool()` can stay: it's small and cheap, and there's a off-chance that an implementation might provide a zero-length `alarm.sleep_memory`(say, for instance, its size was dynamically chosen) and that needs to have proper falsiness. 