### PR TITLE
Round BLE timing values; fix timeout check

### DIFF
--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -469,7 +469,7 @@ mp_obj_t common_hal_bleio_adapter_start_scan(bleio_adapter_obj_t *self, uint8_t*
 
     ble_drv_add_event_handler(scan_on_ble_evt, self->scan_results);
 
-    uint32_t nrf_timeout = SEC_TO_UNITS(timeout, UNIT_10_MS);
+    uint32_t nrf_timeout = SEC_TO_UNITS(timeout, UNIT_10_MS) + 0.5f;
     if (nrf_timeout > UINT16_MAX) {
         // 0xffff / 100
         mp_raise_ValueError(translate("timeout must be < 655.35 secs"));
@@ -479,15 +479,15 @@ mp_obj_t common_hal_bleio_adapter_start_scan(bleio_adapter_obj_t *self, uint8_t*
         mp_raise_ValueError(translate("non-zero timeout must be > 0.01"));
     }
 
-    if (nrf_timeout) {
+    if (nrf_timeout == 0) {
         nrf_timeout = BLE_GAP_SCAN_TIMEOUT_UNLIMITED;
     }
 
     ble_gap_scan_params_t scan_params = {
         .extended = extended,
-        .interval = SEC_TO_UNITS(interval, UNIT_0_625_MS),
+        .interval = SEC_TO_UNITS(interval, UNIT_0_625_MS) + 0.5f,
         .timeout = nrf_timeout,
-        .window = SEC_TO_UNITS(window, UNIT_0_625_MS),
+        .window = SEC_TO_UNITS(window, UNIT_0_625_MS) + 0.5f,
         .scan_phys = BLE_GAP_PHY_1MBPS,
         .active = active
     };
@@ -553,7 +553,7 @@ mp_obj_t common_hal_bleio_adapter_connect(bleio_adapter_obj_t *self, bleio_addre
         .window = MSEC_TO_UNITS(100, UNIT_0_625_MS),
         .scan_phys = BLE_GAP_PHY_1MBPS,
         // timeout of 0 means no timeout
-        .timeout = SEC_TO_UNITS(timeout, UNIT_10_MS),
+        .timeout = SEC_TO_UNITS(timeout, UNIT_10_MS) + 0.5f,
     };
 
     ble_gap_conn_params_t conn_params = {
@@ -696,7 +696,7 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, 
     }
 
     ble_gap_adv_params_t adv_params = {
-        .interval = SEC_TO_UNITS(interval, UNIT_0_625_MS),
+        .interval = SEC_TO_UNITS(interval, UNIT_0_625_MS) + 0.5f,
         .properties.type = adv_type,
         .duration = SEC_TO_UNITS(timeout, UNIT_10_MS),
         .filter_policy = BLE_GAP_ADV_FP_ANY,

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -33,8 +33,8 @@
 #include "shared-bindings/_bleio/Address.h"
 #include "shared-bindings/_bleio/Adapter.h"
 
-#define ADV_INTERVAL_MIN (0.02001f)
-#define ADV_INTERVAL_MIN_STRING "0.02001"
+#define ADV_INTERVAL_MIN (0.02f)
+#define ADV_INTERVAL_MIN_STRING "0.02"
 #define ADV_INTERVAL_MAX (10.24f)
 #define ADV_INTERVAL_MAX_STRING "10.24"
 // 20ms is recommended by Apple
@@ -204,7 +204,7 @@ const mp_obj_property_t bleio_adapter_name_obj = {
 //|         :param ~_typing.ReadableBuffer scan_response: scan response data packet bytes. ``None`` if no scan response is needed.
 //|         :param bool connectable:  If `True` then other devices are allowed to connect to this peripheral.
 //|         :param bool anonymous:  If `True` then this device's MAC address is randomized before advertising.
-//|         :param int timeout:  If set, we will only advertise for this many seconds.
+//|         :param int timeout:  If set, we will only advertise for this many seconds. Zero means no timeout.
 //|         :param float interval:  advertising interval, in seconds"""
 //|         ...
 //|
@@ -237,7 +237,7 @@ STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t
         args[ARG_interval].u_obj = mp_obj_new_float(ADV_INTERVAL_DEFAULT);
     }
 
-    const mp_float_t interval = mp_obj_float_get(args[ARG_interval].u_obj);
+    const mp_float_t interval = mp_obj_get_float(args[ARG_interval].u_obj);
     if (interval < ADV_INTERVAL_MIN || interval > ADV_INTERVAL_MAX) {
         mp_raise_ValueError_varg(translate("interval must be in range %s-%s"),
                                  ADV_INTERVAL_MIN_STRING, ADV_INTERVAL_MAX_STRING);
@@ -279,7 +279,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_stop_advertising_obj, bleio_adapt
 //|             ignored. Format is one byte for length (n) and n bytes of prefix and can be repeated.
 //|         :param int buffer_size: the maximum number of advertising bytes to buffer.
 //|         :param bool extended: When True, support extended advertising packets. Increasing buffer_size is recommended when this is set.
-//|         :param float timeout: the scan timeout in seconds. If None, will scan until `stop_scan` is called.
+//|         :param float timeout: the scan timeout in seconds. If None or zero, will scan until `stop_scan` is called.
 //|         :param float interval: the interval (in seconds) between the start of two consecutive scan windows
 //|            Must be in the range 0.0025 - 40.959375 seconds.
 //|         :param float window: the duration (in seconds) to scan a single BLE channel.
@@ -320,7 +320,7 @@ STATIC mp_obj_t bleio_adapter_start_scan(size_t n_args, const mp_obj_t *pos_args
         args[ARG_window].u_obj = mp_obj_new_float(WINDOW_DEFAULT);
     }
 
-    const mp_float_t interval = mp_obj_float_get(args[ARG_interval].u_obj);
+    const mp_float_t interval = mp_obj_get_float(args[ARG_interval].u_obj);
     if (interval < INTERVAL_MIN || interval > INTERVAL_MAX) {
         mp_raise_ValueError_varg(translate("interval must be in range %s-%s"), INTERVAL_MIN_STRING, INTERVAL_MAX_STRING);
     }
@@ -332,7 +332,7 @@ STATIC mp_obj_t bleio_adapter_start_scan(size_t n_args, const mp_obj_t *pos_args
     }
 #pragma GCC diagnostic pop
 
-    const mp_float_t window = mp_obj_float_get(args[ARG_window].u_obj);
+    const mp_float_t window = mp_obj_get_float(args[ARG_window].u_obj);
     if (window > interval) {
         mp_raise_ValueError(translate("window must be <= interval"));
     }

--- a/shared-bindings/_pixelbuf/__init__.c
+++ b/shared-bindings/_pixelbuf/__init__.c
@@ -51,7 +51,7 @@
 //|
 
 STATIC mp_obj_t pixelbuf_colorwheel(mp_obj_t n) {
-    return MP_OBJ_NEW_SMALL_INT(colorwheel(MP_OBJ_IS_SMALL_INT(n) ? MP_OBJ_SMALL_INT_VALUE(n) : mp_obj_float_get(n)));
+    return MP_OBJ_NEW_SMALL_INT(colorwheel(MP_OBJ_IS_SMALL_INT(n) ? MP_OBJ_SMALL_INT_VALUE(n) : mp_obj_get_float(n)));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(pixelbuf_colorwheel_obj, pixelbuf_colorwheel);
 


### PR DESCRIPTION
Fixes #3942.
Fixes #2930.

- Fix reversed logic for `_bleio.start_scan()` no timeout check in `nrf`.
- Use error-checking float conversion in `_bleio` float argument validation.
- Round _bleio float timeout values to nearest integer quantum, instead of truncating. This solves the problem of `0.02` being not quite big enough due to float representation issues.
- Fix one float conversion in `_pixelbuf` that was not using the error-checking object-to-float conversion routine.