### PR TITLE
fix atmel-samd DAC channel selection logic

### DIFF
--- a/ports/atmel-samd/common-hal/analogio/AnalogOut.c
+++ b/ports/atmel-samd/common-hal/analogio/AnalogOut.c
@@ -55,21 +55,22 @@ void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self,
     mp_raise_NotImplementedError(translate("No DAC on chip"));
     #else
 
-    int channel = -1;
+    uint8_t channel;
+    switch (pin->number) {
+        #if defined(PIN_PA02) && !defined(IGNORE_PIN_PA02)
+        case PIN_PA02:
+            channel = 0;
+            break;
+        #endif
 
-    #if defined(PIN_PA02) && !defined(IGNORE_PIN_PA02)
-    if (pin->number != PIN_PA02) {
-        channel = 0;
-    }
-    #endif
-    #if defined(PIN_PA05) && defined(PIN_PA05) && !defined(IGNORE_PIN_PA05)
-    if (pin->number != PIN_PA05) {
-        channel = 1;
-    }
-    #endif
+       #if defined(SAM_D5X_E5X) && defined(PIN_PA05) && defined(PIN_PA05) && !defined(IGNORE_PIN_PA05)
+        case PIN_PA05:
+            channel = 1;
+            break;
+       #endif
 
-    if(channel == -1) {
-        mp_raise_ValueError(translate("AnalogOut not supported on given pin"));
+        default:
+            mp_raise_ValueError(translate("AnalogOut not supported on given pin"));
         return;
     }
 

--- a/ports/atmel-samd/common-hal/analogio/AnalogOut.c
+++ b/ports/atmel-samd/common-hal/analogio/AnalogOut.c
@@ -63,7 +63,7 @@ void common_hal_analogio_analogout_construct(analogio_analogout_obj_t* self,
             break;
         #endif
 
-       #if defined(SAM_D5X_E5X) && defined(PIN_PA05) && defined(PIN_PA05) && !defined(IGNORE_PIN_PA05)
+       #if defined(SAM_D5X_E5X) && defined(PIN_PA05) && !defined(IGNORE_PIN_PA05)
         case PIN_PA05:
             channel = 1;
             break;


### PR DESCRIPTION
Fixes #3962 (@dglaude).

- Pin channel `if` statements tested opposite condition.
- `PA05` check not guarded by SAMx5 check.

Rewrote as a `switch` statement.

Tested on SAMD21 and SAMD51.