### PR TITLE
ESP32-S2 update docs to match code usage of IPPROTO_* 

### DIFF
--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -62,14 +62,12 @@ STATIC mp_obj_t socketpool_socketpool_make_new(const mp_obj_type_t *type, size_t
 //|     SOCK_STREAM: int
 //|     SOCK_DGRAM: int
 //|     SOCK_RAW: int
-//|     IPPROTO_TCP: int
 //|
-//|     def socket(self, family: int = AF_INET, type: int = SOCK_STREAM, proto: int = IPPROTO_TCP) -> socketpool.Socket:
+//|     def socket(self, family: int = AF_INET, type: int = SOCK_STREAM) -> socketpool.Socket:
 //|         """Create a new socket
 //|
 //|         :param ~int family: AF_INET or AF_INET6
 //|         :param ~int type: SOCK_STREAM, SOCK_DGRAM or SOCK_RAW
-//|         :param ~int proto: IPPROTO_TCP, IPPROTO_UDP or IPPROTO_RAW (ignored)"""
 //|         ...
 //|
 

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -67,7 +67,7 @@ STATIC mp_obj_t socketpool_socketpool_make_new(const mp_obj_type_t *type, size_t
 //|         """Create a new socket
 //|
 //|         :param ~int family: AF_INET or AF_INET6
-//|         :param ~int type: SOCK_STREAM, SOCK_DGRAM or SOCK_RAW
+//|         :param ~int type: SOCK_STREAM, SOCK_DGRAM or SOCK_RAW"""
 //|         ...
 //|
 


### PR DESCRIPTION
`IPPROTO_IP` vs. `IPPROTO_IPV6` is currently [determined](https://github.com/adafruit/circuitpython/blob/f9c762256fed05c1beaa122de960310b36df3002/ports/esp32s2/common-hal/socketpool/SocketPool.c#L42) based on `family`, rather than passed in as a parameter.
```
Adafruit CircuitPython 6.1.0-rc.0-12-gf07dd487a-dirty on 2021-01-12; Saola 1 w/Wrover with ESP32S2
>>> import socketpool
>>> dir(socketpool)
['__class__', '__name__', 'Socket', 'SocketPool']
>>> dir(socketpool.SocketPool)
['__class__', '__name__', 'AF_INET', 'AF_INET6', 'SOCK_DGRAM', 'SOCK_RAW', 'SOCK_STREAM', 'getaddrinfo', 'socket']
```