### PR TITLE
esp32s2: Fix 'make flash'

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -3455,6 +3455,8 @@ msgstr ""
 msgid "pow() with 3 arguments requires integers"
 msgstr ""
 
+#: ports/esp32s2/boards/adafruit_feather_esp32s2_nopsram/mpconfigboard.h
+#: ports/esp32s2/boards/adafruit_feather_esp32s2_tftback_nopsram/mpconfigboard.h
 #: ports/esp32s2/boards/adafruit_magtag_2.9_grayscale/mpconfigboard.h
 #: ports/esp32s2/boards/adafruit_metro_esp32s2/mpconfigboard.h
 #: ports/esp32s2/boards/electroniccats_bastwifi/mpconfigboard.h

--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -299,7 +299,7 @@ ESP_AUTOGEN_LD = $(BUILD)/esp-idf/esp-idf/esp32s2/esp32s2_out.ld $(BUILD)/esp-id
 
 FLASH_FLAGS = --flash_mode $(CIRCUITPY_ESP_FLASH_MODE) --flash_freq $(CIRCUITPY_ESP_FLASH_FREQ) --flash_size $(CIRCUITPY_ESP_FLASH_SIZE)
 
-ESPTOOL_FLAGS ?= -b 460800 --before=default_reset --after=no_reset write_flash
+ESPTOOL_FLAGS ?= -b 460800 --before=default_reset --after=no_reset
 
 all: $(BUILD)/firmware.bin $(BUILD)/firmware.uf2
 


### PR DESCRIPTION
As reported by @jerryneedell, this change was incorrect; the given ESPTOOL_FLAGS caused `write_flash` to be repeated twice, which doesn't work.

Closes #3981.