### PR TITLE
Revert "pre-commit: Add checking of 'make translate' status"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,10 +11,3 @@ repos:
         exclude: '^(tests/.*\.exp|tests/cmdline/.*|tests/.*/data/.*|ports/esp32s2/esp-idf-config/.*|ports/esp32s2/boards/.*/sdkconfig)'
     -   id: trailing-whitespace
         exclude: '^(tests/.*\.exp|tests/cmdline/.*|tests/.*/data/.*)'
--   repo: local
-    hooks:
-    -   id: translations
-        name: Check Translations
-        entry: sh -c "make translate"
-        language: system
-        always_run: true


### PR DESCRIPTION
This reverts commit 1dda33dc418cae1a0047df0241762ebdb3d87e8a.

For reasons we don't understand, running check-translate in the pre-commit context doesn't work during ci, giving 
```
OSError: Syntax error in po file (line 1)
make: *** [Makefile:251: check-translate] Error 1
```
(see #3984)

Instead of fixing this RIGHT NOW, just revert it.  We'll do more careful testing next time.