### PR TITLE
ports/unix: Fix parallel build problem

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -318,3 +318,5 @@ $(BUILD)/libaxtls.a: $(TOP)/lib/axtls/README | $(OBJ_DIRS)
 $(TOP)/lib/axtls/README:
 	@echo "You cloned without --recursive, fetching submodules for you."
 	(cd $(TOP); git submodule update --init --recursive)
+
+$(BUILD)/supervisor/shared/translate.o: $(HEADER_BUILD)/qstrdefs.generated.h


### PR DESCRIPTION
This is the same as I added to mpy-cross at e666e86035d5, see #3074

I made this pull into 6.0.x because I ran into it while working on mircopython-ulab's ci process which currently uses the 6.0.x branch.  We'll want this fix in 6.1 which I think we can get by merging 6.0.x up into main.