### PR TITLE
wifi: more disconnect reasons for retries & include error code in exception

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2013,7 +2013,8 @@ msgid "Unhandled ESP TLS error %d %d %x %d"
 msgstr ""
 
 #: shared-bindings/wifi/Radio.c
-msgid "Unknown failure"
+#, c-format
+msgid "Unknown failure %d"
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c

--- a/ports/esp32s2/common-hal/wifi/Radio.c
+++ b/ports/esp32s2/common-hal/wifi/Radio.c
@@ -168,11 +168,11 @@ wifi_radio_error_t common_hal_wifi_radio_connect(wifi_radio_obj_t *self, uint8_t
     } while ((bits & (WIFI_CONNECTED_BIT | WIFI_DISCONNECTED_BIT)) == 0 && !mp_hal_is_interrupted());
     if ((bits & WIFI_DISCONNECTED_BIT) != 0) {
         if (self->last_disconnect_reason == WIFI_REASON_AUTH_FAIL) {
-            return WIFI_RADIO_ERROR_AUTH;
+            return WIFI_RADIO_ERROR_AUTH_FAIL;
         } else if (self->last_disconnect_reason == WIFI_REASON_NO_AP_FOUND) {
             return WIFI_RADIO_ERROR_NO_AP_FOUND;
         }
-        return WIFI_RADIO_ERROR_UNKNOWN;
+        return self->last_disconnect_reason;
     }
     return WIFI_RADIO_ERROR_NONE;
 }

--- a/ports/esp32s2/common-hal/wifi/__init__.c
+++ b/ports/esp32s2/common-hal/wifi/__init__.c
@@ -65,11 +65,9 @@ static void event_handler(void* arg, esp_event_base_t event_base,
                 uint8_t reason = d->reason;
                 ESP_LOGW(TAG, "reason %d 0x%02x", reason, reason);
                 if (radio->retries_left > 0 &&
-                        (reason == WIFI_REASON_AUTH_EXPIRE ||
-                         reason == WIFI_REASON_NOT_AUTHED ||
-                         reason == WIFI_REASON_ASSOC_EXPIRE ||
-                         reason == WIFI_REASON_CONNECTION_FAIL ||
-                         reason == WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT)) {
+                        reason != WIFI_REASON_AUTH_FAIL &&
+                        reason != WIFI_REASON_NO_AP_FOUND &&
+                        reason != WIFI_REASON_ASSOC_LEAVE) {
                     radio->retries_left--;
                     ESP_LOGI(TAG, "Retrying connect. %d retries remaining", radio->retries_left);
                     esp_wifi_connect();

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -218,12 +218,12 @@ STATIC mp_obj_t wifi_radio_connect(size_t n_args, const mp_obj_t *pos_args, mp_m
     }
 
     wifi_radio_error_t error = common_hal_wifi_radio_connect(self, ssid.buf, ssid.len, password.buf, password.len, args[ARG_channel].u_int, timeout, bssid.buf, bssid.len);
-    if (error == WIFI_RADIO_ERROR_AUTH) {
+    if (error == WIFI_RADIO_ERROR_AUTH_FAIL) {
         mp_raise_ConnectionError(translate("Authentication failure"));
     } else if (error == WIFI_RADIO_ERROR_NO_AP_FOUND) {
         mp_raise_ConnectionError(translate("No network with that ssid"));
     } else if (error != WIFI_RADIO_ERROR_NONE) {
-        mp_raise_ConnectionError(translate("Unknown failure"));
+        mp_raise_msg_varg(&mp_type_ConnectionError, translate("Unknown failure %d"), error);
     }
 
     return mp_const_none;

--- a/shared-bindings/wifi/Radio.h
+++ b/shared-bindings/wifi/Radio.h
@@ -36,10 +36,39 @@
 const mp_obj_type_t wifi_radio_type;
 
 typedef enum {
-    WIFI_RADIO_ERROR_NONE,
-    WIFI_RADIO_ERROR_UNKNOWN,
-    WIFI_RADIO_ERROR_AUTH,
-    WIFI_RADIO_ERROR_NO_AP_FOUND
+    // 0 is circuitpython-specific; 1-53 are IEEE; 200+ are Espressif
+    WIFI_RADIO_ERROR_NONE                     = 0,
+    WIFI_RADIO_ERROR_UNSPECIFIED              = 1,
+    WIFI_RADIO_ERROR_AUTH_EXPIRE              = 2,
+    WIFI_RADIO_ERROR_AUTH_LEAVE               = 3,
+    WIFI_RADIO_ERROR_ASSOC_EXPIRE             = 4,
+    WIFI_RADIO_ERROR_ASSOC_TOOMANY            = 5,
+    WIFI_RADIO_ERROR_NOT_AUTHED               = 6,
+    WIFI_RADIO_ERROR_NOT_ASSOCED              = 7,
+    WIFI_RADIO_ERROR_ASSOC_LEAVE              = 8,
+    WIFI_RADIO_ERROR_ASSOC_NOT_AUTHED         = 9,
+    WIFI_RADIO_ERROR_DISASSOC_PWRCAP_BAD      = 10,
+    WIFI_RADIO_ERROR_DISASSOC_SUPCHAN_BAD     = 11,
+    WIFI_RADIO_ERROR_IE_INVALID               = 13,
+    WIFI_RADIO_ERROR_MIC_FAILURE              = 14,
+    WIFI_RADIO_ERROR_4WAY_HANDSHAKE_TIMEOUT   = 15,
+    WIFI_RADIO_ERROR_GROUP_KEY_UPDATE_TIMEOUT = 16,
+    WIFI_RADIO_ERROR_IE_IN_4WAY_DIFFERS       = 17,
+    WIFI_RADIO_ERROR_GROUP_CIPHER_INVALID     = 18,
+    WIFI_RADIO_ERROR_PAIRWISE_CIPHER_INVALID  = 19,
+    WIFI_RADIO_ERROR_AKMP_INVALID             = 20,
+    WIFI_RADIO_ERROR_UNSUPP_RSN_IE_VERSION    = 21,
+    WIFI_RADIO_ERROR_INVALID_RSN_IE_CAP       = 22,
+    WIFI_RADIO_ERROR_802_1X_AUTH_FAILED       = 23,
+    WIFI_RADIO_ERROR_CIPHER_SUITE_REJECTED    = 24,
+    WIFI_RADIO_ERROR_INVALID_PMKID            = 53,
+    WIFI_RADIO_ERROR_BEACON_TIMEOUT           = 200,
+    WIFI_RADIO_ERROR_NO_AP_FOUND              = 201,
+    WIFI_RADIO_ERROR_AUTH_FAIL                = 202,
+    WIFI_RADIO_ERROR_ASSOC_FAIL               = 203,
+    WIFI_RADIO_ERROR_HANDSHAKE_TIMEOUT        = 204,
+    WIFI_RADIO_ERROR_CONNECTION_FAIL          = 205,
+    WIFI_RADIO_ERROR_AP_TSF_RESET             = 206,
 } wifi_radio_error_t;
 
 extern bool common_hal_wifi_radio_get_enabled(wifi_radio_obj_t *self);


### PR DESCRIPTION
**Changes**

Based on goals and discussion in [https://github.com/adafruit/circuitpython/issues/3837](https://github.com/adafruit/circuitpython/issues/3837):

- expand retries to all reasons for disconnection _except_ for: the two current fatal reasons that raise an exception (NO_AP_FOUND==201 and AUTH_FAIL==202); and the one reason that arises when user code manually triggers a wi-fi disconnect or stop (ASSOC_LEAVE==8)

- return the error code for exceptions that don't currently have specific error strings (used to be just "Unknown failure")

For example,
```
W (242170) wifi: reason 205 0xcd
```
will raise to user code:
```
ConnectionError: Unknown failure 205
```

**Discussion**

I've tested this in various scenarios with Peplink and Apple APs, and there is slight variation in disconnect reason codes that arise from various actions. I'd expect other equipment to potentially have other variations. So I'd like more eyes on this code, and hopefully some testing by others in different environments too. I'm open to further tweaking the disconnection reasons we raise exceptions for, and further tweaking the reason logic in the event handler.

The most questionable thing here I think is the slight muddling of the shared-bindings / common-hal interface with the `wifi_radio_error_t` `enum` and returning the reason number from common-hal. Every known disconnect reason is now in the `enum`, and `WIFI_RADIO_ERROR_UNKNOWN` is no longer needed. The alternative (especially if the error number is considered inelegant), assuming we want specific errors known to users (very useful for troubleshooting), is to itemize each of the 30+ disconnect reasons as a unique error string. Or perhaps raise the Espressif-specific exceptions in common-hal, and return the IEEE-based codes to raise in shared-bindings. Or perhaps there's another solution I'm not aware of.

The saving grace is that most of the reasons in the `enum` are IEEE 802.11 numbers, so should carry over to any future alternate wi-fi-capable ports.

There is a small risk with this code that the IDF returns an unexpected reason code not in the `enum` (not in their docs). Not sure how to handle this.