### PR TITLE
don't check length for remote characteristic or descriptor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -464,7 +464,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20200801
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210114
     - name: Clone IDF submodules
       run: |
         (cd $IDF_PATH && git submodule update --init)

--- a/ports/nrf/common-hal/_bleio/Connection.c
+++ b/ports/nrf/common-hal/_bleio/Connection.c
@@ -522,7 +522,7 @@ STATIC void on_char_discovery_rsp(ble_gattc_evt_char_disc_rsp_t *response, bleio
         common_hal_bleio_characteristic_construct(
             characteristic, m_char_discovery_service, gattc_char->handle_value, uuid,
             props, SECURITY_MODE_OPEN, SECURITY_MODE_OPEN,
-            GATT_MAX_DATA_LENGTH, false,   // max_length, fixed_length: values may not matter for gattc
+            GATT_MAX_DATA_LENGTH, false,   // max_length, fixed_length: values don't matter for gattc
             mp_const_empty_bytes);
 
         mp_obj_list_append(MP_OBJ_FROM_PTR(m_char_discovery_service->characteristic_list),


### PR DESCRIPTION
Fixes #3975. Fix tested by @jlopez, who file the original issue.

`_bleio`: When doing a remote a remote characteristic or descriptor write, the size of the remote attribute is not known. The code was mistakenly checking against the default values in the characteristic or descriptor proxy object. This was a actually a regression: the original code had the check in the right place. Moved the checks so they only happens when writing a local value.