### PR TITLE
change extensa github actions cache key to avoid bad cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -464,7 +464,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20200801
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210114
     - name: Clone IDF submodules
       run: |
         (cd $IDF_PATH && git submodule update --init)


### PR DESCRIPTION
Breaking this out from #3993 so other PR's will succeed.