### PR TITLE
MagTag: Add pin A1 as alias for AD1; A1 is preferred

### DIFF
--- a/ports/esp32s2/boards/adafruit_magtag_2.9_grayscale/pins.c
+++ b/ports/esp32s2/boards/adafruit_magtag_2.9_grayscale/pins.c
@@ -4,7 +4,11 @@
 
 STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D10), MP_ROM_PTR(&pin_GPIO10) },
+
+    { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_GPIO18) },
+    // Previous name from schematic.
     { MP_ROM_QSTR(MP_QSTR_AD1), MP_ROM_PTR(&pin_GPIO18) },
+
     { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_GPIO13) },
 
     { MP_ROM_QSTR(MP_QSTR_SPEAKER), MP_ROM_PTR(&pin_GPIO17) },


### PR DESCRIPTION
`A1` is on the silk and is in the Guides.