### PR TITLE
Merge 6.0.x

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -318,3 +318,5 @@ $(BUILD)/libaxtls.a: $(TOP)/lib/axtls/README | $(OBJ_DIRS)
 $(TOP)/lib/axtls/README:
 	@echo "You cloned without --recursive, fetching submodules for you."
 	(cd $(TOP); git submodule update --init --recursive)
+
+$(BUILD)/supervisor/shared/translate.o: $(HEADER_BUILD)/qstrdefs.generated.h


### PR DESCRIPTION
There were conflicts in ports/nrf/common-hal/_bleio/Adapter.c and shared-bindings/_bleio/Adapter.c that I resolved by taking the "main" branch side.  "BLE fixes" was applied via cherry pick to both branches, but "Round BLE timing values; fix timeout check" was applied only on the main, which git couldn't resolve on its own.
    
There were conflicts in circuitpython.pot that I resolved by regenerating the file with `make translate`.
