### PR TITLE
ports/unix: Fix parallel build problem

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -318,3 +318,5 @@ $(BUILD)/libaxtls.a: $(TOP)/lib/axtls/README | $(OBJ_DIRS)
 $(TOP)/lib/axtls/README:
 	@echo "You cloned without --recursive, fetching submodules for you."
 	(cd $(TOP); git submodule update --init --recursive)
+
+$(BUILD)/supervisor/shared/translate.o: $(HEADER_BUILD)/qstrdefs.generated.h


### PR DESCRIPTION
This is the same as I added to mpy-cross at e666e86035d5, see #3074

This version is cherry-picked from 6.0.x for main, as an alternative to merging 6.0.x _into_ main.  That alternative is at #4003, and at most one should be taken.