### PR TITLE
prevents going into safe mode for watchdog resets

### DIFF
--- a/ports/esp32s2/supervisor/port.c
+++ b/ports/esp32s2/supervisor/port.c
@@ -143,9 +143,9 @@ safe_mode_t port_init(void) {
         case ESP_RST_BROWNOUT:
             return BROWNOUT;
         case ESP_RST_PANIC:
+            return HARD_CRASH;
         case ESP_RST_INT_WDT:
         case ESP_RST_WDT:
-            return HARD_CRASH;
         default:
             break;
     }


### PR DESCRIPTION
Resolves bug I reported here: https://github.com/adafruit/circuitpython/issues/3988

Prevents device from going into safe mode for watchdog resets. (Watchdog resets are normally used to re-run code and not drop into a REPL.)