### PR TITLE
Revert "UMFEATHERS2 - implement use of DotStar for status led"

### DIFF
--- a/ports/esp32s2/boards/unexpectedmaker_feathers2/board.c
+++ b/ports/esp32s2/boards/unexpectedmaker_feathers2/board.c
@@ -27,8 +27,6 @@
 #include "supervisor/board.h"
 #include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
-#include "components/driver/include/driver/gpio.h"
-#include "components/soc/include/hal/gpio_hal.h"
 
 void board_init(void) {
     // USB
@@ -49,12 +47,6 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO30);
     common_hal_never_reset_pin(&pin_GPIO31);
     common_hal_never_reset_pin(&pin_GPIO32);
-
-
-    // Add LDO2 to never reset list, set to output and enable
-    common_hal_never_reset_pin(&pin_GPIO21);
-    gpio_set_direction(pin_GPIO21.number, GPIO_MODE_DEF_OUTPUT);
-    gpio_set_level(pin_GPIO21.number, true);
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/esp32s2/boards/unexpectedmaker_feathers2/mpconfigboard.h
+++ b/ports/esp32s2/boards/unexpectedmaker_feathers2/mpconfigboard.h
@@ -34,8 +34,8 @@
 
 #define AUTORESET_DELAY_MS 500
 
-#define MICROPY_HW_APA102_MOSI   (&pin_GPIO40)
-#define MICROPY_HW_APA102_SCK    (&pin_GPIO45)
+// #define MICROPY_HW_APA102_MOSI   (&pin_GPIO40)
+// #define MICROPY_HW_APA102_SCK    (&pin_GPIO45)
 
 #define DEFAULT_I2C_BUS_SCL (&pin_GPIO9)
 #define DEFAULT_I2C_BUS_SDA (&pin_GPIO8)

--- a/ports/esp32s2/common-hal/microcontroller/Pin.c
+++ b/ports/esp32s2/common-hal/microcontroller/Pin.c
@@ -37,13 +37,12 @@
 #ifdef MICROPY_HW_NEOPIXEL
 bool neopixel_in_use;
 #endif
-#ifdef MICROPY_HW_APA102_MOSI
-bool apa102_sck_in_use;
-bool apa102_mosi_in_use;
-#endif
 
 STATIC uint32_t never_reset_pins[2];
 STATIC uint32_t in_use[2];
+
+bool apa102_mosi_in_use;
+bool apa102_sck_in_use;
 
 STATIC void floating_gpio_reset(gpio_num_t pin_number) {
     // This is the same as gpio_reset_pin(), but without the pullup.
@@ -87,20 +86,6 @@ void reset_pin_number(gpio_num_t pin_number) {
         return;
     }
     #endif
-    #ifdef MICROPY_HW_APA102_MOSI
-    if (pin_number == MICROPY_HW_APA102_MOSI->number ||
-        pin_number == MICROPY_HW_APA102_SCK->number) {
-        apa102_mosi_in_use = apa102_mosi_in_use && pin_number != MICROPY_HW_APA102_MOSI->number;
-        apa102_sck_in_use = apa102_sck_in_use && pin_number != MICROPY_HW_APA102_SCK->number;
-        if (!apa102_sck_in_use && !apa102_mosi_in_use) {
-            rgb_led_status_init();
-        }
-        return;
-    }
-    #endif
-
-
-
 }
 
 void common_hal_reset_pin(const mcu_pin_obj_t* pin) {
@@ -125,11 +110,6 @@ void reset_all_pins(void) {
     #ifdef MICROPY_HW_NEOPIXEL
     neopixel_in_use = false;
     #endif
-    #ifdef MICROPY_HW_APA102_MOSI
-    apa102_sck_in_use = false;
-    apa102_mosi_in_use = false;
-    #endif
-
 }
 
 void claim_pin(const mcu_pin_obj_t* pin) {
@@ -139,15 +119,6 @@ void claim_pin(const mcu_pin_obj_t* pin) {
         neopixel_in_use = true;
     }
     #endif
-    #ifdef MICROPY_HW_APA102_MOSI
-    if (pin == MICROPY_HW_APA102_MOSI) {
-        apa102_mosi_in_use = true;
-    }
-    if (pin == MICROPY_HW_APA102_SCK) {
-        apa102_sck_in_use = true;
-    }
-    #endif
-
 }
 
 void common_hal_mcu_pin_claim(const mcu_pin_obj_t* pin) {
@@ -160,18 +131,10 @@ bool pin_number_is_free(gpio_num_t pin_number) {
         return !neopixel_in_use;
     }
     #endif
-    #ifdef MICROPY_HW_APA102_MOSI
-    if (pin_number == MICROPY_HW_APA102_MOSI->number) {
-        return !apa102_mosi_in_use;
-    }
-    if (pin_number == MICROPY_HW_APA102_SCK->number) {
-        return !apa102_sck_in_use;
-    }
-    #endif
 
     uint8_t offset = pin_number / 32;
     uint32_t mask = 1 << (pin_number % 32);
-    return (in_use[offset] & mask) == 0;
+    return (never_reset_pins[offset] & mask) == 0 && (in_use[offset] & mask) == 0;
 }
 
 bool common_hal_mcu_pin_is_free(const mcu_pin_obj_t *pin) {

--- a/ports/esp32s2/common-hal/microcontroller/Pin.h
+++ b/ports/esp32s2/common-hal/microcontroller/Pin.h
@@ -31,10 +31,8 @@
 
 #include "peripherals/pins.h"
 
-#ifdef MICROPY_HW_APA102_MOSI
-extern bool apa102_sck_in_use;
 extern bool apa102_mosi_in_use;
-#endif
+extern bool apa102_sck_in_use;
 
 #ifdef MICROPY_HW_NEOPIXEL
 extern bool neopixel_in_use;


### PR DESCRIPTION
Reverts adafruit/circuitpython#3930
Apparently causing unexpected issues with control of LDO2. see #4012