### PR TITLE
Fixed comment in mpconfigboard.h

### DIFF
--- a/ports/atmel-samd/boards/itsybitsy_m4_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/itsybitsy_m4_express/mpconfigboard.h
@@ -12,7 +12,7 @@
 // These are pins not to reset.
 // QSPI Data pins
 #define MICROPY_PORT_A (PORT_PA08 | PORT_PA09 | PORT_PA10 | PORT_PA11)
-// DotStar pins, QSPI CS, and QSPI SCK
+// DotStar SCK, DotStar MOSI, QSPI SCK, and QSPI CS
 #define MICROPY_PORT_B (PORT_PB02 | PORT_PB03 | PORT_PB10 | PORT_PB11)
 #define MICROPY_PORT_C (0)
 #define MICROPY_PORT_D (0)


### PR DESCRIPTION
Fixed a comment that had QSPI SCK and CS reversed, compared to the line of code below it.
Also added further clarity on the DotStar pins in the comment.