### PR TITLE
ESP32-S2: Initialize touch in proper order

### DIFF
--- a/ports/esp32s2/peripherals/touch.c
+++ b/ports/esp32s2/peripherals/touch.c
@@ -46,8 +46,13 @@ void peripherals_touch_init(const touch_pad_t touchpad) {
     if (!touch_inited) {
         touch_pad_init();
         touch_pad_set_fsm_mode(TOUCH_FSM_MODE_TIMER);
+    }
+    // touch_pad_config() must be done before touch_pad_fsm_start() the first time.
+    // Otherwise the calibration is wrong and we get maximum raw values if there is
+    // a trace of any significant length on the pin.
+    touch_pad_config(touchpad);
+    if (!touch_inited) {
         touch_pad_fsm_start();
         touch_inited = true;
     }
-    touch_pad_config(touchpad);
 }


### PR DESCRIPTION
Rework order of touch peripheral initialization code. 048ca2a5 changed it around slightly. This apparently made the calibration be wrong on pins with any length of trace or wire connected to them, causing the `TouchIn.raw_value` to be its max 65535, all the time.. Thanks to @microdev for help in debugging: the microS2 did not show this problem, which was a clue, because it's a very small board with short traces. When @microdev connected a wire to one pin, the problem did appear on that pin.

Tested with `TouchIn` and also `TouchAlarm`. Both work now.

Note that `TouchAlarm` does not work on the MagTag `D10` pin, probably because it has a protection Zener and resistor permanently attached.