### PR TITLE
fixes: busio, SPI OS error 5 for mimxrt10xx

### DIFF
--- a/ports/mimxrt10xx/common-hal/busio/SPI.c
+++ b/ports/mimxrt10xx/common-hal/busio/SPI.c
@@ -289,7 +289,11 @@ bool common_hal_busio_spi_write(busio_spi_obj_t *self,
     xfer.dataSize = len;
     xfer.configFlags = kLPSPI_MasterPcs0;
 
-    const status_t status = LPSPI_MasterTransferBlocking(self->spi, &xfer);
+    status_t status;
+    do {
+        status = LPSPI_MasterTransferBlocking(self->spi, &xfer);
+    } while (status == kStatus_LPSPI_Busy);
+
     if (status != kStatus_Success)
         printf("%s: status %ld\r\n", __func__, status);
 
@@ -311,7 +315,11 @@ bool common_hal_busio_spi_read(busio_spi_obj_t *self,
     xfer.rxData = data;
     xfer.dataSize = len;
 
-    const status_t status = LPSPI_MasterTransferBlocking(self->spi, &xfer);
+    status_t status;
+    do {
+        status = LPSPI_MasterTransferBlocking(self->spi, &xfer);
+    } while (status == kStatus_LPSPI_Busy);
+
     if (status != kStatus_Success)
         printf("%s: status %ld\r\n", __func__, status);
 
@@ -333,7 +341,11 @@ bool common_hal_busio_spi_transfer(busio_spi_obj_t *self, const uint8_t *data_ou
     xfer.rxData = data_in;
     xfer.dataSize = len;
 
-    const status_t status = LPSPI_MasterTransferBlocking(self->spi, &xfer);
+    status_t status;
+    do {
+        status = LPSPI_MasterTransferBlocking(self->spi, &xfer);
+    } while (status == kStatus_LPSPI_Busy);
+    
     if (status != kStatus_Success)
         printf("%s: status %ld\r\n", __func__, status);
 

--- a/ports/mimxrt10xx/common-hal/busio/SPI.c
+++ b/ports/mimxrt10xx/common-hal/busio/SPI.c
@@ -345,7 +345,7 @@ bool common_hal_busio_spi_transfer(busio_spi_obj_t *self, const uint8_t *data_ou
     do {
         status = LPSPI_MasterTransferBlocking(self->spi, &xfer);
     } while (status == kStatus_LPSPI_Busy);
-    
+
     if (status != kStatus_Success)
         printf("%s: status %ld\r\n", __func__, status);
 

--- a/ports/mimxrt10xx/common-hal/busio/SPI.c
+++ b/ports/mimxrt10xx/common-hal/busio/SPI.c
@@ -38,6 +38,8 @@
 
 #define LPSPI_MASTER_CLK_FREQ (CLOCK_GetFreq(kCLOCK_Usb1PllPfd0Clk) / (CLOCK_GetDiv(kCLOCK_LpspiDiv) + 1))
 
+#define MAX_SPI_BUSY_RETRIES 100
+
 //arrays use 0 based numbering: SPI1 is stored at index 0
 #define MAX_SPI 4
 STATIC bool reserved_spi[MAX_SPI];
@@ -290,9 +292,10 @@ bool common_hal_busio_spi_write(busio_spi_obj_t *self,
     xfer.configFlags = kLPSPI_MasterPcs0;
 
     status_t status;
+    int retries = MAX_SPI_BUSY_RETRIES;
     do {
         status = LPSPI_MasterTransferBlocking(self->spi, &xfer);
-    } while (status == kStatus_LPSPI_Busy);
+    } while (status == kStatus_LPSPI_Busy && --retries > 0);
 
     if (status != kStatus_Success)
         printf("%s: status %ld\r\n", __func__, status);
@@ -316,9 +319,10 @@ bool common_hal_busio_spi_read(busio_spi_obj_t *self,
     xfer.dataSize = len;
 
     status_t status;
+    int retries = MAX_SPI_BUSY_RETRIES;
     do {
         status = LPSPI_MasterTransferBlocking(self->spi, &xfer);
-    } while (status == kStatus_LPSPI_Busy);
+    } while (status == kStatus_LPSPI_Busy && --retries > 0);
 
     if (status != kStatus_Success)
         printf("%s: status %ld\r\n", __func__, status);
@@ -342,9 +346,10 @@ bool common_hal_busio_spi_transfer(busio_spi_obj_t *self, const uint8_t *data_ou
     xfer.dataSize = len;
 
     status_t status;
+    int retries = MAX_SPI_BUSY_RETRIES;
     do {
         status = LPSPI_MasterTransferBlocking(self->spi, &xfer);
-    } while (status == kStatus_LPSPI_Busy);
+    } while (status == kStatus_LPSPI_Busy && --retries > 0);
 
     if (status != kStatus_Success)
         printf("%s: status %ld\r\n", __func__, status);


### PR DESCRIPTION
I ran into an issue trying to connect an MCP2515 CAN bus controller via SPI to a Teensy 4.0 (using adafruit_mcp2515) and might have a simple solution to this and possibly related issues #3763 and #3055.  

After a few CAN messages transferred, there is an exception with the following information.
```
common_hal_busio_spi_read: status 400
Traceback (most recent call last):
  File "code.py", line 49, in <module>
  File "code.py", line 44, in <module>
  File "/lib/adafruit_mcp2515/canio/__init__.py", line 102, in receive
  File "/lib/adafruit_mcp2515/__init__.py", line 355, in unread_message_count
  File "/lib/adafruit_mcp2515/__init__.py", line 421, in _read_from_rx_buffers
  File "/lib/adafruit_mcp2515/__init__.py", line 386, in _read_rx_buffer
  File "/lib/adafruit_mcp2515/__init__.py", line 386, in _read_rx_buffer
OSError: [Errno 5] Input/output error
```

It seems that SPI might occasionally be busy. The SPI drivers (e.g. [`MIMXRT10xx_SDK/.../MIMXRT1062/drivers/fsl_lpspi.c`](https://github.com/adafruit/MIMXRT10xx_SDK/blob/8363ff7bed7533b9e7e6a6239aace3d6da14f349/devices/MIMXRT1062/drivers/fsl_lpspi.c#L792-L796) ) then return `kStatus_LPSPI_Busy`, which in busio [`mimxrt10xx/common-hal/busio/SPI.c`](https://github.com/adafruit/circuitpython/blob/0dfa9fb7c1cf4a2b93275229b699d87490ee6390/ports/mimxrt10xx/common-hal/busio/SPI.c#L292-L296) translates into `false` result, thus resulting in OS Error 5.

Attempting a simple busy waiting loop in case of `kStatus_LPSPI_Busy` instead seems to do the trick. The problem seems to be resolved and I so far did not see more than a single additional iteration of the idle loop.

However, since I do not know the details of how SPI works here, I have no idea whether this simple solution is too simple. So if someone can asses this, please comment.
