### PR TITLE
EVE: change fixed-point integer arguments to floating point 

### DIFF
--- a/shared-bindings/_eve/__init__.c
+++ b/shared-bindings/_eve/__init__.c
@@ -604,22 +604,6 @@ STATIC mp_obj_t _jump(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(jump_obj, _jump);
 
-//|     def LineWidth(self, width: int) -> None:
-//|         """Set the width of rasterized lines
-//|
-//|         :param int width: line width in :math:`1/16` pixel. Range 0-4095. The initial value is 16
-//|
-//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|         ...
-//|
-
-STATIC mp_obj_t _linewidth(mp_obj_t self, mp_obj_t a0) {
-    uint32_t width  = mp_obj_get_int_truncated(a0);
-    common_hal__eve_LineWidth(EVEHAL(self), width);
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(linewidth_obj, _linewidth);
-
 //|     def Macro(self, m: int) -> None:
 //|         """Execute a single command from a macro register
 //|
@@ -661,22 +645,6 @@ STATIC mp_obj_t _palettesource(mp_obj_t self, mp_obj_t a0) {
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(palettesource_obj, _palettesource);
-
-//|     def PointSize(self, size: int) -> None:
-//|         """Set the radius of rasterized points
-//|
-//|         :param int size: point radius in :math:`1/16` pixel. Range 0-8191. The initial value is 16
-//|
-//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|         ...
-//|
-
-STATIC mp_obj_t _pointsize(mp_obj_t self, mp_obj_t a0) {
-    uint32_t size   = mp_obj_get_int_truncated(a0);
-    common_hal__eve_PointSize(EVEHAL(self), size);
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(pointsize_obj, _pointsize);
 
 //|     def RestoreContext(self) -> None:
 //|         """Restore the current graphics context from the context stack"""
@@ -836,48 +804,6 @@ STATIC mp_obj_t _tag(mp_obj_t self, mp_obj_t a0) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(tag_obj, _tag);
 
-//|     def VertexTranslateX(self, x: int) -> None:
-//|         """Set the vertex transformation's x translation component
-//|
-//|         :param int x: signed x-coordinate in :math:`1/16` pixel. Range 0-131071. The initial value is 0
-//|
-//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|         ...
-//|
-
-STATIC mp_obj_t _vertextranslatex(mp_obj_t self, mp_obj_t a0) {
-    uint32_t x      = mp_obj_get_int_truncated(a0);
-    common_hal__eve_VertexTranslateX(EVEHAL(self), x);
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(vertextranslatex_obj, _vertextranslatex);
-
-//|     def VertexTranslateY(self, y: int) -> None:
-//|         """Set the vertex transformation's y translation component
-//|
-//|         :param int y: signed y-coordinate in :math:`1/16` pixel. Range 0-131071. The initial value is 0
-//|
-//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|         ...
-//|
-
-
-STATIC mp_obj_t _vertextranslatey(mp_obj_t self, mp_obj_t a0) {
-    uint32_t y      = mp_obj_get_int_truncated(a0);
-    common_hal__eve_VertexTranslateY(EVEHAL(self), y);
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(vertextranslatey_obj, _vertextranslatey);
-
-//|     def VertexFormat(self, frac: int) -> None:
-//|         """Set the precision of vertex2f coordinates
-//|
-//|         :param int frac: Number of fractional bits in X,Y coordinates, 0-4. Range 0-7. The initial value is 4
-//|
-//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|         ...
-//|
-
 STATIC mp_obj_t _vertexformat(mp_obj_t self, mp_obj_t a0) {
     uint32_t frac   = mp_obj_get_int_truncated(a0);
     common_hal__eve_VertexFormat(EVEHAL(self), frac);
@@ -974,6 +900,82 @@ STATIC mp_obj_t _vertex2f(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(vertex2f_obj, _vertex2f);
+
+//|     def LineWidth(self, width: float) -> None:
+//|         """Set the width of rasterized lines
+//|
+//|         :param float width: line width in pixels. Range 0-511. The initial value is 1
+//|
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
+//|
+
+STATIC mp_obj_t _linewidth(mp_obj_t self, mp_obj_t a0) {
+    mp_float_t width  = mp_obj_get_float(a0);
+    common_hal__eve_LineWidth(EVEHAL(self), width);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(linewidth_obj, _linewidth);
+
+//|     def PointSize(self, size: float) -> None:
+//|         """Set the diameter of rasterized points
+//|
+//|         :param float size: point diameter in pixels. Range 0-1023. The initial value is 1
+//|
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
+//|
+
+STATIC mp_obj_t _pointsize(mp_obj_t self, mp_obj_t a0) {
+    mp_float_t size   = mp_obj_get_float(a0);
+    common_hal__eve_PointSize(EVEHAL(self), size);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(pointsize_obj, _pointsize);
+
+//|     def VertexTranslateX(self, x: float) -> None:
+//|         """Set the vertex transformation's x translation component
+//|
+//|         :param float x: signed x-coordinate in pixels. Range ±4095. The initial value is 0
+//|
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
+//|
+
+STATIC mp_obj_t _vertextranslatex(mp_obj_t self, mp_obj_t a0) {
+    mp_float_t x      = mp_obj_get_float(a0);
+    common_hal__eve_VertexTranslateX(EVEHAL(self), x);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(vertextranslatex_obj, _vertextranslatex);
+
+//|     def VertexTranslateY(self, y: float) -> None:
+//|         """Set the vertex transformation's y translation component
+//|
+//|         :param float y: signed y-coordinate in pixels. Range ±4095. The initial value is 0
+//|
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
+//|
+
+
+STATIC mp_obj_t _vertextranslatey(mp_obj_t self, mp_obj_t a0) {
+    mp_float_t y      = mp_obj_get_float(a0);
+    common_hal__eve_VertexTranslateY(EVEHAL(self), y);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(vertextranslatey_obj, _vertextranslatey);
+
+//|     def VertexFormat(self, frac: int) -> None:
+//|         """Set the precision of vertex2f coordinates
+//|
+//|         :param int frac: Number of fractional bits in X,Y coordinates, 0-4. Range 0-7. The initial value is 4
+//|
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
+//|         ...
+//|
+
+//}
 
 // Append an object x to the FIFO
 #define ADD_X(self, x) \

--- a/shared-bindings/_eve/__init__.h
+++ b/shared-bindings/_eve/__init__.h
@@ -61,11 +61,11 @@ void common_hal__eve_ColorRGB(common_hal__eve_t *eve, uint32_t red, uint32_t gre
 void common_hal__eve_Display(common_hal__eve_t *eve);
 void common_hal__eve_End(common_hal__eve_t *eve);
 void common_hal__eve_Jump(common_hal__eve_t *eve, uint32_t dest);
-void common_hal__eve_LineWidth(common_hal__eve_t *eve, uint32_t width);
+void common_hal__eve_LineWidth(common_hal__eve_t *eve, mp_float_t width);
 void common_hal__eve_Macro(common_hal__eve_t *eve, uint32_t m);
 void common_hal__eve_Nop(common_hal__eve_t *eve);
 void common_hal__eve_PaletteSource(common_hal__eve_t *eve, uint32_t addr);
-void common_hal__eve_PointSize(common_hal__eve_t *eve, uint32_t size);
+void common_hal__eve_PointSize(common_hal__eve_t *eve, mp_float_t size);
 void common_hal__eve_RestoreContext(common_hal__eve_t *eve);
 void common_hal__eve_Return(common_hal__eve_t *eve);
 void common_hal__eve_SaveContext(common_hal__eve_t *eve);
@@ -76,8 +76,8 @@ void common_hal__eve_StencilMask(common_hal__eve_t *eve, uint32_t mask);
 void common_hal__eve_StencilOp(common_hal__eve_t *eve, uint32_t sfail, uint32_t spass);
 void common_hal__eve_TagMask(common_hal__eve_t *eve, uint32_t mask);
 void common_hal__eve_Tag(common_hal__eve_t *eve, uint32_t s);
-void common_hal__eve_VertexTranslateX(common_hal__eve_t *eve, uint32_t x);
-void common_hal__eve_VertexTranslateY(common_hal__eve_t *eve, uint32_t y);
+void common_hal__eve_VertexTranslateX(common_hal__eve_t *eve, mp_float_t x);
+void common_hal__eve_VertexTranslateY(common_hal__eve_t *eve, mp_float_t y);
 void common_hal__eve_VertexFormat(common_hal__eve_t *eve, uint32_t frac);
 void common_hal__eve_Vertex2ii(common_hal__eve_t *eve, uint32_t x, uint32_t y, uint32_t handle, uint32_t cell);
 

--- a/shared-module/_eve/__init__.c
+++ b/shared-module/_eve/__init__.c
@@ -226,8 +226,9 @@ void common_hal__eve_Jump(common_hal__eve_t *eve, uint32_t dest) {
 }
 
 
-void common_hal__eve_LineWidth(common_hal__eve_t *eve, uint32_t width) {
-    C4(eve, ((14 << 24) | ((width & 4095))));
+void common_hal__eve_LineWidth(common_hal__eve_t *eve, mp_float_t width) {
+    int16_t iw = (int)(8 * width);
+    C4(eve, ((14 << 24) | ((iw & 4095))));
 }
 
 
@@ -246,8 +247,9 @@ void common_hal__eve_PaletteSource(common_hal__eve_t *eve, uint32_t addr) {
 }
 
 
-void common_hal__eve_PointSize(common_hal__eve_t *eve, uint32_t size) {
-    C4(eve, ((13 << 24) | ((size & 8191))));
+void common_hal__eve_PointSize(common_hal__eve_t *eve, mp_float_t size) {
+    int16_t is = (int)(8 * size);
+    C4(eve, ((13 << 24) | ((is & 8191))));
 }
 
 
@@ -301,13 +303,15 @@ void common_hal__eve_Tag(common_hal__eve_t *eve, uint32_t s) {
 }
 
 
-void common_hal__eve_VertexTranslateX(common_hal__eve_t *eve, uint32_t x) {
-    C4(eve, ((43 << 24) | (((x) & 131071))));
+void common_hal__eve_VertexTranslateX(common_hal__eve_t *eve, mp_float_t x) {
+    int16_t ix = (int)(16 * x);
+    C4(eve, ((43 << 24) | (ix & 131071)));
 }
 
 
-void common_hal__eve_VertexTranslateY(common_hal__eve_t *eve, uint32_t y) {
-    C4(eve, ((44 << 24) | (((y) & 131071))));
+void common_hal__eve_VertexTranslateY(common_hal__eve_t *eve, mp_float_t y) {
+    int16_t iy = (int)(16 * y);
+    C4(eve, ((44 << 24) | (iy & 131071)));
 }
 
 


### PR DESCRIPTION
Change from fixed-point integer arguments to floating point in EVE API functions

Changed calls: PointSize(), LineWidth(), VertexTranslateX() and VertexTranslateY()
Units for all the above are now pixels, not fixed-point integers. This matches OpenGL.
Docstrings updated accordingly