### PR TITLE
protomatter: Update to version that supports tiling

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -58,7 +58,8 @@ msgstr ""
 
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
-msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+msgid ""
+"%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/sdioio/SDCard.c
@@ -516,7 +517,6 @@ msgstr ""
 msgid "Buffer must be a multiple of 512 bytes"
 msgstr ""
 
-#: shared-bindings/adafruit_bus_device/I2CDevice.c
 #: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
 msgid "Buffer must be at least length 1"
 msgstr ""

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -3711,7 +3711,7 @@ msgid "threshold must be in the range 0-65536"
 msgstr ""
 
 #: shared-bindings/rgbmatrix/RGBMatrix.c
-msgid "tile must be greater than or equal to zero"
+msgid "tile must be greater than zero"
 msgstr ""
 
 #: shared-bindings/time/__init__.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -3710,6 +3710,10 @@ msgstr ""
 msgid "threshold must be in the range 0-65536"
 msgstr ""
 
+#: shared-bindings/rgbmatrix/RGBMatrix.c
+msgid "tile must be greater than or equal to zero"
+msgstr ""
+
 #: shared-bindings/time/__init__.c
 msgid "time.struct_time() takes a 9-sequence"
 msgstr ""

--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -219,8 +219,8 @@ STATIC mp_obj_t rgbmatrix_rgbmatrix_make_new(const mp_obj_type_t *type, size_t n
             translate("tile must be greater than or equal to zero"));
     }
 
+    int computed_height = (rgb_count / 3) * (1 << (addr_count)) * tile;
     if (args[ARG_height].u_int != 0) {
-        int computed_height = (rgb_count / 3) * (1 << (addr_count)) * tile;
         if (computed_height != args[ARG_height].u_int) {
             mp_raise_ValueError_varg(
                 translate("%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"), addr_count, rgb_count, tile, computed_height, args[ARG_height].u_int);
@@ -236,7 +236,7 @@ STATIC mp_obj_t rgbmatrix_rgbmatrix_make_new(const mp_obj_type_t *type, size_t n
     mp_obj_t framebuffer = args[ARG_framebuffer].u_obj;
     if (framebuffer == mp_const_none) {
         int width = args[ARG_width].u_int;
-        int bufsize = 2 * width * rgb_count / 3 * (1 << addr_count) * tile;
+        int bufsize = 2 * width * computed_height;
         framebuffer = mp_obj_new_bytearray_of_zeros(bufsize);
     }
 

--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -214,9 +214,9 @@ STATIC mp_obj_t rgbmatrix_rgbmatrix_make_new(const mp_obj_type_t *type, size_t n
 
     int tile = args[ARG_tile].u_int;
 
-    if (tile < 0) {
+    if (tile <= 0) {
         mp_raise_ValueError_varg(
-            translate("tile must be greater than or equal to zero"));
+            translate("tile must be greater than zero"));
     }
 
     int computed_height = (rgb_count / 3) * (1 << (addr_count)) * tile;

--- a/shared-bindings/rgbmatrix/RGBMatrix.h
+++ b/shared-bindings/rgbmatrix/RGBMatrix.h
@@ -31,7 +31,7 @@
 
 extern const mp_obj_type_t rgbmatrix_RGBMatrix_type;
 
-void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t* self, int width, int bit_depth, uint8_t rgb_count, uint8_t* rgb_pins, uint8_t addr_count, uint8_t* addr_pins, uint8_t clock_pin, uint8_t latch_pin, uint8_t oe_pin, bool doublebuffer, mp_obj_t framebuffer, int8_t tile, void* timer);
+void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t* self, int width, int bit_depth, uint8_t rgb_count, uint8_t* rgb_pins, uint8_t addr_count, uint8_t* addr_pins, uint8_t clock_pin, uint8_t latch_pin, uint8_t oe_pin, bool doublebuffer, mp_obj_t framebuffer, int8_t tile, bool serpentine, void* timer);
 void common_hal_rgbmatrix_rgbmatrix_deinit(rgbmatrix_rgbmatrix_obj_t*);
 void rgbmatrix_rgbmatrix_collect_ptrs(rgbmatrix_rgbmatrix_obj_t*);
 void common_hal_rgbmatrix_rgbmatrix_reconstruct(rgbmatrix_rgbmatrix_obj_t* self, mp_obj_t framebuffer);

--- a/shared-bindings/rgbmatrix/RGBMatrix.h
+++ b/shared-bindings/rgbmatrix/RGBMatrix.h
@@ -31,7 +31,7 @@
 
 extern const mp_obj_type_t rgbmatrix_RGBMatrix_type;
 
-void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t* self, int width, int bit_depth, uint8_t rgb_count, uint8_t* rgb_pins, uint8_t addr_count, uint8_t* addr_pins, uint8_t clock_pin, uint8_t latch_pin, uint8_t oe_pin, bool doublebuffer, mp_obj_t framebuffer, void* timer);
+void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t* self, int width, int bit_depth, uint8_t rgb_count, uint8_t* rgb_pins, uint8_t addr_count, uint8_t* addr_pins, uint8_t clock_pin, uint8_t latch_pin, uint8_t oe_pin, bool doublebuffer, mp_obj_t framebuffer, int8_t tile, void* timer);
 void common_hal_rgbmatrix_rgbmatrix_deinit(rgbmatrix_rgbmatrix_obj_t*);
 void rgbmatrix_rgbmatrix_collect_ptrs(rgbmatrix_rgbmatrix_obj_t*);
 void common_hal_rgbmatrix_rgbmatrix_reconstruct(rgbmatrix_rgbmatrix_obj_t* self, mp_obj_t framebuffer);

--- a/shared-module/rgbmatrix/RGBMatrix.c
+++ b/shared-module/rgbmatrix/RGBMatrix.c
@@ -62,7 +62,7 @@ void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t *self, i
     }
 
     self->width = width;
-    self->bufsize = 2 * width * rgb_count / 3 * (1 << addr_count) * tile;
+    self->bufsize = 2 * width * common_hal_rgbmatrix_rgbmatrix_get_height(self);
 
     common_hal_rgbmatrix_rgbmatrix_reconstruct(self, framebuffer);
 }

--- a/shared-module/rgbmatrix/RGBMatrix.c
+++ b/shared-module/rgbmatrix/RGBMatrix.c
@@ -42,7 +42,7 @@
 
 extern Protomatter_core *_PM_protoPtr;
 
-void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t *self, int width, int bit_depth, uint8_t rgb_count, uint8_t *rgb_pins, uint8_t addr_count, uint8_t *addr_pins, uint8_t clock_pin, uint8_t latch_pin, uint8_t oe_pin, bool doublebuffer, mp_obj_t framebuffer, int8_t tile, void *timer) {
+void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t *self, int width, int bit_depth, uint8_t rgb_count, uint8_t *rgb_pins, uint8_t addr_count, uint8_t *addr_pins, uint8_t clock_pin, uint8_t latch_pin, uint8_t oe_pin, bool doublebuffer, mp_obj_t framebuffer, int8_t tile, bool serpentine, void *timer) {
     self->width = width;
     self->bit_depth = bit_depth;
     self->rgb_count = rgb_count;
@@ -54,6 +54,7 @@ void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t *self, i
     self->latch_pin = latch_pin;
     self->doublebuffer = doublebuffer;
     self->tile = tile;
+    self->serpentine = serpentine;
 
     self->timer = timer ? timer : common_hal_rgbmatrix_timer_allocate();
     if (self->timer == NULL) {
@@ -61,7 +62,7 @@ void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t *self, i
     }
 
     self->width = width;
-    self->bufsize = 2 * width * rgb_count / 3 * (1 << addr_count);
+    self->bufsize = 2 * width * rgb_count / 3 * (1 << addr_count) * tile;
 
     common_hal_rgbmatrix_rgbmatrix_reconstruct(self, framebuffer);
 }
@@ -96,7 +97,8 @@ void common_hal_rgbmatrix_rgbmatrix_reconstruct(rgbmatrix_rgbmatrix_obj_t* self,
         self->rgb_count/6, self->rgb_pins,
         self->addr_count, self->addr_pins,
         self->clock_pin, self->latch_pin, self->oe_pin,
-        self->doublebuffer, self->tile, self->timer);
+        self->doublebuffer, self->serpentine ? -self->tile : self->tile,
+        self->timer);
 
     if (stat == PROTOMATTER_OK) {
         _PM_protoPtr = &self->protomatter;
@@ -210,7 +212,7 @@ int common_hal_rgbmatrix_rgbmatrix_get_width(rgbmatrix_rgbmatrix_obj_t* self) {
 }
 
 int common_hal_rgbmatrix_rgbmatrix_get_height(rgbmatrix_rgbmatrix_obj_t* self) {
-    int computed_height = (self->rgb_count / 3) << (self->addr_count);
+    int computed_height = (self->rgb_count / 3) * (1 << (self->addr_count)) * self->tile;
     return computed_height;
 }
 

--- a/shared-module/rgbmatrix/RGBMatrix.c
+++ b/shared-module/rgbmatrix/RGBMatrix.c
@@ -42,7 +42,7 @@
 
 extern Protomatter_core *_PM_protoPtr;
 
-void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t *self, int width, int bit_depth, uint8_t rgb_count, uint8_t *rgb_pins, uint8_t addr_count, uint8_t *addr_pins, uint8_t clock_pin, uint8_t latch_pin, uint8_t oe_pin, bool doublebuffer, mp_obj_t framebuffer, void *timer) {
+void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t *self, int width, int bit_depth, uint8_t rgb_count, uint8_t *rgb_pins, uint8_t addr_count, uint8_t *addr_pins, uint8_t clock_pin, uint8_t latch_pin, uint8_t oe_pin, bool doublebuffer, mp_obj_t framebuffer, int8_t tile, void *timer) {
     self->width = width;
     self->bit_depth = bit_depth;
     self->rgb_count = rgb_count;
@@ -53,6 +53,7 @@ void common_hal_rgbmatrix_rgbmatrix_construct(rgbmatrix_rgbmatrix_obj_t *self, i
     self->oe_pin = oe_pin;
     self->latch_pin = latch_pin;
     self->doublebuffer = doublebuffer;
+    self->tile = tile;
 
     self->timer = timer ? timer : common_hal_rgbmatrix_timer_allocate();
     if (self->timer == NULL) {
@@ -95,7 +96,7 @@ void common_hal_rgbmatrix_rgbmatrix_reconstruct(rgbmatrix_rgbmatrix_obj_t* self,
         self->rgb_count/6, self->rgb_pins,
         self->addr_count, self->addr_pins,
         self->clock_pin, self->latch_pin, self->oe_pin,
-        self->doublebuffer, self->timer);
+        self->doublebuffer, self->tile, self->timer);
 
     if (stat == PROTOMATTER_OK) {
         _PM_protoPtr = &self->protomatter;

--- a/shared-module/rgbmatrix/RGBMatrix.h
+++ b/shared-module/rgbmatrix/RGBMatrix.h
@@ -44,5 +44,6 @@ typedef struct {
     bool core_is_initialized;
     bool paused;
     bool doublebuffer;
+    bool serpentine;
     int8_t tile;
 } rgbmatrix_rgbmatrix_obj_t;

--- a/shared-module/rgbmatrix/RGBMatrix.h
+++ b/shared-module/rgbmatrix/RGBMatrix.h
@@ -44,4 +44,5 @@ typedef struct {
     bool core_is_initialized;
     bool paused;
     bool doublebuffer;
+    int8_t tile;
 } rgbmatrix_rgbmatrix_obj_t;


### PR DESCRIPTION
Update to a version of Protomatter that supports tiling.  This requires https://github.com/adafruit/Adafruit_Protomatter/pull/32 be merged upstream.

Testing performed: None yet, just that the matrixfeather firmware builds.