### PR TITLE
turn on ticks during USB writes

### DIFF
--- a/supervisor/shared/tick.c
+++ b/supervisor/shared/tick.c
@@ -33,6 +33,7 @@
 #include "supervisor/filesystem.h"
 #include "supervisor/background_callback.h"
 #include "supervisor/port.h"
+#include "supervisor/usb.h"
 #include "supervisor/shared/autoreload.h"
 #include "supervisor/shared/stack.h"
 
@@ -77,6 +78,8 @@ void supervisor_background_tasks(void *unused) {
 
     assert_heap_ok();
 
+    usb_background();
+
     #if CIRCUITPY_DISPLAYIO
     displayio_background();
     #endif
@@ -105,6 +108,10 @@ bool supervisor_background_tasks_ok(void) {
 }
 
 void supervisor_tick(void) {
+    // For debugging ticks.
+    // REG_PORT_DIRSET1 = (1<<2); //PB02, A5 on Metro M0 Express.
+    // REG_PORT_OUTSET1 = (1<<2);
+
 #if CIRCUITPY_FILESYSTEM_FLUSH_INTERVAL_MS > 0
     filesystem_tick();
 #endif
@@ -121,6 +128,7 @@ void supervisor_tick(void) {
         #endif
     }
 #endif
+    // REG_PORT_OUTCLR1 = (1<<2);
     background_callback_add(&tick_callback, supervisor_background_tasks, NULL);
 }
 


### PR DESCRIPTION
Fixes #3986.

Before 6.0.0, there was alway a 1ms tick mechanism that ran a background task. The task include a call to `tud_task()`. Starting in 6.0.0, we turned off 1ms ticks all the time, and now we currently call `tud_task()` only when there's an interrupt.

It appears we need to call it more often than that when USB writes happen, because some writes are not triggered by an interrupt.

So, this PR adds `usb_background()` back to the supervisor tick background task. And, when a write starts, we enable the 1ms ticks so `tud_task()` will be called on every tick. When the write completes, we turn off ticks for us. (If someone else needs ticks, they stay on, due to `tick_enable_count`.)

@hathach thinks there may be some other reason writes are not being scheduled properly, but this appears to solve the problem for now. This fix could be removed or modified when more analysis is done in TinyUSB about this issue.