### PR TITLE
Fixing microcontroller.cpu on multi-core cpus and adding microcontroller.cpus

### DIFF
--- a/ports/raspberrypi/common-hal/microcontroller/__init__.c
+++ b/ports/raspberrypi/common-hal/microcontroller/__init__.c
@@ -80,6 +80,7 @@ void common_hal_mcu_reset(void) {
 
 // The singleton microcontroller.Processor object, bound to microcontroller.cpu
 // It currently only has properties, and no state.
+#if CIRCUITPY_PROCESSOR_COUNT > 1
 static const mcu_processor_obj_t processor0 = {
     .base = {
         .type = &mcu_processor_type,
@@ -92,13 +93,20 @@ static const mcu_processor_obj_t processor1 = {
     },
 };
 
-const mp_rom_obj_tuple_t common_hal_mcu_processor_obj = {
+const mp_rom_obj_tuple_t common_hal_multi_processor_obj = {
     {&mp_type_tuple},
     CIRCUITPY_PROCESSOR_COUNT,
     {
         MP_ROM_PTR(&processor0),
         MP_ROM_PTR(&processor1)
     }
+};
+#endif
+
+const mcu_processor_obj_t common_hal_mcu_processor_obj = {
+    .base = {
+        .type = &mcu_processor_type,
+    },
 };
 
 #if CIRCUITPY_NVM && CIRCUITPY_INTERNAL_NVM_SIZE > 0

--- a/shared-bindings/microcontroller/Processor.c
+++ b/shared-bindings/microcontroller/Processor.c
@@ -41,7 +41,14 @@
 //|
 //|        import microcontroller
 //|        print(microcontroller.cpu.frequency)
-//|        print(microcontroller.cpu.temperature)"""
+//|        print(microcontroller.cpu.temperature)
+//|
+//|        Note that on chips with more than one cpu (such as the RP2040)
+//|        you will need to index the cpu to select which one to get the
+//|        readings from. i.e.
+//|
+//|        print(microcontroller.cpu[0].temperature)
+//|        print(microcontroller.cpu[1].frequency)"""
 //|
 
 //|     def __init__(self) -> None:

--- a/shared-bindings/microcontroller/Processor.c
+++ b/shared-bindings/microcontroller/Processor.c
@@ -44,11 +44,12 @@
 //|        print(microcontroller.cpu.temperature)
 //|
 //|        Note that on chips with more than one cpu (such as the RP2040)
-//|        you will need to index the cpu to select which one to get the
-//|        readings from. i.e.
+//|        microcontroller.cpu will return the value for CPU 0.
+//|        To get values from other CPUs use microcontroller.cpus indexed by
+//|        the number of the desired cpu. i.e.
 //|
-//|        print(microcontroller.cpu[0].temperature)
-//|        print(microcontroller.cpu[1].frequency)"""
+//|        print(microcontroller.cpus[0].temperature)
+//|        print(microcontroller.cpus[1].frequency)"""
 //|
 
 //|     def __init__(self) -> None:

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -53,7 +53,13 @@
 //| cpu: Processor
 //| """CPU information and control, such as ``cpu.temperature`` and ``cpu.frequency``
 //| (clock frequency).
-//| This object is the sole instance of `microcontroller.Processor`."""
+//| This object is an instance of `microcontroller.Processor`."""
+//|
+
+//| cpus: Processor
+//| """CPU information and control, such as ``cpus[0].temperature`` and ``cpus[1].frequency``
+//| (clock frequency) on chips with more than 1 cpu.  the index selects which cpu.
+//| This object is an instance of `microcontroller.Processor`."""
 //|
 
 //| def delay_us(delay: int) -> None:
@@ -155,6 +161,9 @@ const mp_obj_module_t mcu_pin_module = {
 STATIC const mp_rom_map_elem_t mcu_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_microcontroller) },
     { MP_ROM_QSTR(MP_QSTR_cpu),  MP_ROM_PTR(&common_hal_mcu_processor_obj) },
+#if CIRCUITPY_PROCESSOR_COUNT > 1
+    { MP_ROM_QSTR(MP_QSTR_cpus),  MP_ROM_PTR(&common_hal_multi_processor_obj) },
+#endif
     { MP_ROM_QSTR(MP_QSTR_delay_us), MP_ROM_PTR(&mcu_delay_us_obj) },
     { MP_ROM_QSTR(MP_QSTR_disable_interrupts), MP_ROM_PTR(&mcu_disable_interrupts_obj) },
     { MP_ROM_QSTR(MP_QSTR_enable_interrupts), MP_ROM_PTR(&mcu_enable_interrupts_obj) },

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -58,7 +58,7 @@
 
 //| cpus: Processor
 //| """CPU information and control, such as ``cpus[0].temperature`` and ``cpus[1].frequency``
-//| (clock frequency) on chips with more than 1 cpu.  the index selects which cpu.
+//| (clock frequency) on chips with more than 1 cpu. The index selects which cpu.
 //| This object is an instance of `microcontroller.Processor`."""
 //|
 

--- a/shared-bindings/microcontroller/__init__.h
+++ b/shared-bindings/microcontroller/__init__.h
@@ -48,7 +48,8 @@ extern const mp_obj_dict_t mcu_pin_globals;
 #if CIRCUITPY_PROCESSOR_COUNT == 1
 extern const mcu_processor_obj_t common_hal_mcu_processor_obj;
 #elif CIRCUITPY_PROCESSOR_COUNT > 1
-extern const mp_rom_obj_tuple_t common_hal_mcu_processor_obj;
+extern const mcu_processor_obj_t common_hal_mcu_processor_obj;
+extern const mp_rom_obj_tuple_t common_hal_multi_processor_obj;
 #else
 #error "Invalid processor count"
 #endif


### PR DESCRIPTION
This will allow microcontroller.cpu.temperature, etc. to work properly on an RP2040 or other multi-cpu chip. It will default to the values for cpu 0. In addition, it adds  microcontroller.cpus, indexed by cpu number, to allow access to the values for other cpus (for example, microcontroller.cpus[1].voltage)  Note that microcontroller.cpus is only added for chips where CIRCUITPY_PROCESSOR_COUNT is defined to be > 1.