### PR TITLE
Fix default socket timeout

### DIFF
--- a/ports/esp32s2/common-hal/socketpool/Socket.c
+++ b/ports/esp32s2/common-hal/socketpool/Socket.c
@@ -135,7 +135,7 @@ socketpool_socket_obj_t* common_hal_socketpool_socket_accept(socketpool_socket_o
     while (newsoc == -1 &&
            !timed_out &&
            !mp_hal_is_interrupted()) {
-        if (self->timeout_ms != (uint)-1) {
+        if (self->timeout_ms != (uint)-1 && self->timeout_ms != 0) {
             timed_out = supervisor_ticks_ms64() - start_ticks >= self->timeout_ms;
         }
         RUN_BACKGROUND_TASKS;
@@ -251,7 +251,7 @@ mp_uint_t common_hal_socketpool_socket_recv_into(socketpool_socket_obj_t* self, 
         while (received == -1 &&
                 !timed_out &&
                 !mp_hal_is_interrupted()) {
-            if (self->timeout_ms != (uint)-1) {
+            if (self->timeout_ms != (uint)-1 && self->timeout_ms != 0) {
                 timed_out = supervisor_ticks_ms64() - start_ticks >= self->timeout_ms;
             }
             RUN_BACKGROUND_TASKS;
@@ -362,7 +362,7 @@ mp_uint_t common_hal_socketpool_socket_recvfrom_into(socketpool_socket_obj_t* se
     while (received == -1 &&
             !timed_out &&
             !mp_hal_is_interrupted()) {
-        if (self->timeout_ms != (uint)-1) {
+        if (self->timeout_ms != (uint)-1 && self->timeout_ms != 0) {
             timed_out = supervisor_ticks_ms64() - start_ticks >= self->timeout_ms;
         }
         RUN_BACKGROUND_TASKS;

--- a/ports/esp32s2/common-hal/socketpool/SocketPool.c
+++ b/ports/esp32s2/common-hal/socketpool/SocketPool.c
@@ -77,6 +77,7 @@ socketpool_socket_obj_t* common_hal_socketpool_socket(socketpool_socketpool_obj_
     sock->type = socket_type;
     sock->family = addr_family;
     sock->ipproto = ipproto;
+    sock->timeout_ms = (uint)-1;
 
     sock->tls = NULL;
     sock->ssl_context = NULL;


### PR DESCRIPTION
PR #3854 accidentally set the default timeout of the Socket module to 0, which does not match Cpython's default of None (as in, never time out). This was causing some user programs to throw unexpected EAGAIN errors. Additionally, when Socket was placed in non-blocking mode (with a timeout of 0), even successful calls from some functions would result in ETIMEDOUT. This PR fixes both issues.

Resolves #3836