### PR TITLE
raspberrypi: implement reset, reset_to_bootloader

### DIFF
--- a/ports/raspberrypi/common-hal/microcontroller/__init__.c
+++ b/ports/raspberrypi/common-hal/microcontroller/__init__.c
@@ -35,11 +35,15 @@
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/Processor.h"
+#include "supervisor/filesystem.h"
+#include "supervisor/port.h"
 #include "supervisor/shared/safe_mode.h"
 #include "supervisor/shared/translate.h"
 
 #include "src/rp2040/hardware_structs/include/hardware/structs/sio.h"
 #include "src/rp2_common/hardware_sync/include/hardware/sync.h"
+
+#include "hardware/watchdog.h"
 
 void common_hal_mcu_delay_us(uint32_t delay) {
     mp_hal_delay_us(delay);
@@ -66,8 +70,11 @@ void common_hal_mcu_enable_interrupts(void) {
     asm volatile ("cpsie i" : : : "memory");
 }
 
+static bool next_reset_to_bootloader = false;
+
 void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
     if (runmode == RUNMODE_BOOTLOADER) {
+        next_reset_to_bootloader = true;
     } else {
     }
     if (runmode == RUNMODE_SAFE_MODE) {
@@ -76,6 +83,12 @@ void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
 }
 
 void common_hal_mcu_reset(void) {
+    filesystem_flush();
+    if (next_reset_to_bootloader) {
+        reset_to_bootloader();
+    } else {
+        reset_cpu();
+    }
 }
 
 // The singleton microcontroller.Processor object, bound to microcontroller.cpu

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -52,6 +52,8 @@
 
 #include "tusb.h"
 
+#include "pico/bootrom.h"
+#include "hardware/watchdog.h"
 
 extern volatile bool mp_msc_enabled;
 
@@ -110,13 +112,17 @@ void reset_port(void) {
 }
 
 void reset_to_bootloader(void) {
-    // reset();
+    reset_usb_boot(0, 0);
     while (true) {}
 }
 
 void reset_cpu(void) {
-    // reset();
-    while (true) {}
+    watchdog_reboot(0, SRAM_END, 0);
+    watchdog_start_tick(12);
+
+    while (true) {
+        __wfi();
+    }
 }
 
 bool port_has_fixed_stack(void) {


### PR DESCRIPTION
This makes all the following work:
 * normal microcontroller.reset()
 * reset into safe mode or UF2 bootloader via microcontroller.on_next_reset()
 * reset into UF2 bootloader via the "1200 baud trick"
    
The implementation of reset_cpu is from micropython.
