### PR TITLE
Socket: fix inconsistencies in argument types

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -3622,6 +3622,10 @@ msgstr ""
 msgid "pop from empty %q"
 msgstr ""
 
+#: shared-bindings/socketpool/Socket.c shared-bindings/ssl/SSLSocket.c
+msgid "port must be >= 0"
+msgstr ""
+
 #: py/objint_mpz.c
 msgid "pow() 3rd argument cannot be 0"
 msgstr ""

--- a/ports/esp32s2/common-hal/socketpool/Socket.c
+++ b/ports/esp32s2/common-hal/socketpool/Socket.c
@@ -63,7 +63,7 @@ bool register_open_socket(socketpool_socket_obj_t* self) {
 }
 
 socketpool_socket_obj_t* common_hal_socketpool_socket_accept(socketpool_socket_obj_t* self,
-                                        uint8_t* ip, uint *port) {
+                                        uint8_t* ip, uint32_t *port) {
     struct sockaddr_in accept_addr;
     socklen_t socklen = sizeof(accept_addr);
     int newsoc = -1;
@@ -113,7 +113,7 @@ socketpool_socket_obj_t* common_hal_socketpool_socket_accept(socketpool_socket_o
 }
 
 bool common_hal_socketpool_socket_bind(socketpool_socket_obj_t* self,
-                                        const char* host, size_t hostlen, uint8_t port) {
+                                        const char* host, size_t hostlen, uint32_t port) {
     struct sockaddr_in bind_addr;
     bind_addr.sin_addr.s_addr = inet_addr(host);
     bind_addr.sin_family = AF_INET;
@@ -144,7 +144,7 @@ void common_hal_socketpool_socket_close(socketpool_socket_obj_t* self) {
 }
 
 bool common_hal_socketpool_socket_connect(socketpool_socket_obj_t* self,
-                                            const char* host, mp_uint_t hostlen, mp_int_t port) {
+                                            const char* host, size_t hostlen, uint32_t port) {
     const struct addrinfo hints = {
         .ai_family = AF_INET,
         .ai_socktype = SOCK_STREAM,
@@ -202,7 +202,7 @@ bool common_hal_socketpool_socket_listen(socketpool_socket_obj_t* self, int back
 }
 
 mp_uint_t common_hal_socketpool_socket_recvfrom_into(socketpool_socket_obj_t* self,
-    uint8_t* buf, mp_uint_t len, uint8_t* ip, uint *port) {
+    uint8_t* buf, uint32_t len, uint8_t* ip, uint *port) {
 
     struct sockaddr_in source_addr;
     socklen_t socklen = sizeof(source_addr);
@@ -241,7 +241,7 @@ mp_uint_t common_hal_socketpool_socket_recvfrom_into(socketpool_socket_obj_t* se
     return received;
 }
 
-mp_uint_t common_hal_socketpool_socket_recv_into(socketpool_socket_obj_t* self, const uint8_t* buf, mp_uint_t len) {
+mp_uint_t common_hal_socketpool_socket_recv_into(socketpool_socket_obj_t* self, const uint8_t* buf, uint32_t len) {
     int received = 0;
     bool timed_out = false;
 
@@ -273,7 +273,7 @@ mp_uint_t common_hal_socketpool_socket_recv_into(socketpool_socket_obj_t* self, 
     return received;
 }
 
-mp_uint_t common_hal_socketpool_socket_send(socketpool_socket_obj_t* self, const uint8_t* buf, mp_uint_t len) {
+mp_uint_t common_hal_socketpool_socket_send(socketpool_socket_obj_t* self, const uint8_t* buf, uint32_t len) {
     int sent = -1;
     if (self->num != -1) {
         // LWIP Socket
@@ -290,7 +290,7 @@ mp_uint_t common_hal_socketpool_socket_send(socketpool_socket_obj_t* self, const
 }
 
 mp_uint_t common_hal_socketpool_socket_sendto(socketpool_socket_obj_t* self,
-    const char* host, size_t hostlen, uint8_t port, const uint8_t* buf, mp_uint_t len) {
+    const char* host, size_t hostlen, uint32_t port, const uint8_t* buf, uint32_t len) {
 
     // Set parameters
     const struct addrinfo hints = {
@@ -322,6 +322,6 @@ mp_uint_t common_hal_socketpool_socket_sendto(socketpool_socket_obj_t* self,
     return bytes_sent;
 }
 
-void common_hal_socketpool_socket_settimeout(socketpool_socket_obj_t* self, mp_uint_t timeout_ms) {
+void common_hal_socketpool_socket_settimeout(socketpool_socket_obj_t* self, uint32_t timeout_ms) {
     self->timeout_ms = timeout_ms;
 }

--- a/ports/esp32s2/common-hal/ssl/SSLSocket.c
+++ b/ports/esp32s2/common-hal/ssl/SSLSocket.c
@@ -35,19 +35,15 @@
 #include "py/runtime.h"
 #include "supervisor/shared/tick.h"
 
-void common_hal_ssl_sslsocket_settimeout(ssl_sslsocket_obj_t* self, mp_uint_t timeout_ms) {
-    self->sock->timeout_ms = timeout_ms;
-}
-
 ssl_sslsocket_obj_t* common_hal_ssl_sslsocket_accept(ssl_sslsocket_obj_t* self,
-                                        uint8_t* ip, uint *port) {
+                                        uint8_t* ip, uint32_t *port) {
     socketpool_socket_obj_t * sock = common_hal_socketpool_socket_accept(self->sock, ip, port);
     ssl_sslsocket_obj_t * sslsock = common_hal_ssl_sslcontext_wrap_socket(self->ssl_context, sock, false, NULL);
     return sslsock;
 }
 
 bool common_hal_ssl_sslsocket_bind(ssl_sslsocket_obj_t* self,
-                                        const char* host, size_t hostlen, uint8_t port) {
+                                        const char* host, size_t hostlen, uint32_t port) {
     return common_hal_socketpool_socket_bind(self->sock, host, hostlen, port);
 }
 
@@ -58,7 +54,7 @@ void common_hal_ssl_sslsocket_close(ssl_sslsocket_obj_t* self) {
 }
 
 bool common_hal_ssl_sslsocket_connect(ssl_sslsocket_obj_t* self,
-                                            const char* host, mp_uint_t hostlen, mp_int_t port) {
+                                            const char* host, size_t hostlen, uint32_t port) {
     esp_tls_cfg_t* tls_config = NULL;
     tls_config = &self->ssl_context->ssl_config;
     int result = esp_tls_conn_new_sync(host, hostlen, port, tls_config, self->tls);
@@ -104,7 +100,7 @@ bool common_hal_ssl_sslsocket_listen(ssl_sslsocket_obj_t* self, int backlog) {
     return common_hal_socketpool_socket_listen(self->sock, backlog);
 }
 
-mp_uint_t common_hal_ssl_sslsocket_recv_into(ssl_sslsocket_obj_t* self, const uint8_t* buf, mp_uint_t len) {
+mp_uint_t common_hal_ssl_sslsocket_recv_into(ssl_sslsocket_obj_t* self, const uint8_t* buf, uint32_t len) {
     int received = 0;
     bool timed_out = false;
     int status = 0;
@@ -155,7 +151,7 @@ mp_uint_t common_hal_ssl_sslsocket_recv_into(ssl_sslsocket_obj_t* self, const ui
     return received;
 }
 
-mp_uint_t common_hal_ssl_sslsocket_send(ssl_sslsocket_obj_t* self, const uint8_t* buf, mp_uint_t len) {
+mp_uint_t common_hal_ssl_sslsocket_send(ssl_sslsocket_obj_t* self, const uint8_t* buf, uint32_t len) {
     int sent = -1;
     sent = esp_tls_conn_write(self->tls, buf, len);
 
@@ -173,4 +169,8 @@ mp_uint_t common_hal_ssl_sslsocket_send(ssl_sslsocket_obj_t* self, const uint8_t
         }
     }
     return sent;
+}
+
+void common_hal_ssl_sslsocket_settimeout(ssl_sslsocket_obj_t* self, uint32_t timeout_ms) {
+    self->sock->timeout_ms = timeout_ms;
 }

--- a/shared-bindings/socketpool/Socket.c
+++ b/shared-bindings/socketpool/Socket.c
@@ -72,7 +72,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socketpool_socket___exit___obj, 4, 4,
 STATIC mp_obj_t socketpool_socket_accept(mp_obj_t self_in) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint8_t ip[4];
-    uint port;
+    uint32_t port;
 
     socketpool_socket_obj_t * sock = common_hal_socketpool_socket_accept(self, ip, &port);
 
@@ -98,8 +98,11 @@ STATIC mp_obj_t socketpool_socket_bind(mp_obj_t self_in, mp_obj_t addr_in) {
     size_t hostlen;
     const char* host = mp_obj_str_get_data(addr_items[0], &hostlen);
     mp_int_t port = mp_obj_get_int(addr_items[1]);
+    if (port < 0) {
+        mp_raise_ValueError(translate("port must be >= 0"));
+    }
 
-    bool ok = common_hal_socketpool_socket_bind(self, host, hostlen, port);
+    bool ok = common_hal_socketpool_socket_bind(self, host, hostlen, (uint32_t)port);
     if (!ok) {
         mp_raise_ValueError(translate("Error: Failure to bind"));
     }
@@ -133,8 +136,11 @@ STATIC mp_obj_t socketpool_socket_connect(mp_obj_t self_in, mp_obj_t addr_in) {
     size_t hostlen;
     const char* host = mp_obj_str_get_data(addr_items[0], &hostlen);
     mp_int_t port = mp_obj_get_int(addr_items[1]);
+    if (port < 0) {
+        mp_raise_ValueError(translate("port must be >= 0"));
+    }
 
-    bool ok = common_hal_socketpool_socket_connect(self, host, hostlen, port);
+    bool ok = common_hal_socketpool_socket_connect(self, host, hostlen, (uint32_t)port);
     if (!ok) {
         mp_raise_OSError(0);
     }
@@ -278,8 +284,11 @@ STATIC mp_obj_t socketpool_socket_sendto(mp_obj_t self_in, mp_obj_t data_in, mp_
     size_t hostlen;
     const char* host = mp_obj_str_get_data(addr_items[0], &hostlen);
     mp_int_t port = mp_obj_get_int(addr_items[1]);
+    if (port < 0) {
+        mp_raise_ValueError(translate("port must be >= 0"));
+    }
 
-    mp_int_t ret = common_hal_socketpool_socket_sendto(self, host, hostlen, port, bufinfo.buf, bufinfo.len);
+    mp_int_t ret = common_hal_socketpool_socket_sendto(self, host, hostlen, (uint32_t)port, bufinfo.buf, bufinfo.len);
     if (!ret) {
         mp_raise_OSError(0);
     }

--- a/shared-bindings/socketpool/Socket.h
+++ b/shared-bindings/socketpool/Socket.h
@@ -31,20 +31,20 @@
 
 extern const mp_obj_type_t socketpool_socket_type;
 
-socketpool_socket_obj_t * common_hal_socketpool_socket_accept(socketpool_socket_obj_t* self, uint8_t* ip, uint *port);
-bool common_hal_socketpool_socket_bind(socketpool_socket_obj_t* self, const char* host, size_t hostlen, uint8_t port);
+socketpool_socket_obj_t * common_hal_socketpool_socket_accept(socketpool_socket_obj_t* self, uint8_t* ip, uint32_t *port);
+bool common_hal_socketpool_socket_bind(socketpool_socket_obj_t* self, const char* host, size_t hostlen, uint32_t port);
 void common_hal_socketpool_socket_close(socketpool_socket_obj_t* self);
-bool common_hal_socketpool_socket_connect(socketpool_socket_obj_t* self, const char* host, size_t hostlen, mp_int_t port);
+bool common_hal_socketpool_socket_connect(socketpool_socket_obj_t* self, const char* host, size_t hostlen, uint32_t port);
 bool common_hal_socketpool_socket_get_closed(socketpool_socket_obj_t* self);
 bool common_hal_socketpool_socket_get_connected(socketpool_socket_obj_t* self);
 mp_uint_t common_hal_socketpool_socket_get_timeout(socketpool_socket_obj_t* self);
 bool common_hal_socketpool_socket_listen(socketpool_socket_obj_t* self, int backlog);
 mp_uint_t common_hal_socketpool_socket_recvfrom_into(socketpool_socket_obj_t* self,
-    uint8_t* buf, mp_uint_t len, uint8_t* ip, uint *port);
-mp_uint_t common_hal_socketpool_socket_recv_into(socketpool_socket_obj_t* self, const uint8_t* buf, mp_uint_t len);
-mp_uint_t common_hal_socketpool_socket_send(socketpool_socket_obj_t* self, const uint8_t* buf, mp_uint_t len);
+    uint8_t* buf, uint32_t len, uint8_t* ip, uint32_t *port);
+mp_uint_t common_hal_socketpool_socket_recv_into(socketpool_socket_obj_t* self, const uint8_t* buf, uint32_t len);
+mp_uint_t common_hal_socketpool_socket_send(socketpool_socket_obj_t* self, const uint8_t* buf, uint32_t len);
 mp_uint_t common_hal_socketpool_socket_sendto(socketpool_socket_obj_t* self,
-    const char* host, size_t hostlen, uint8_t port, const uint8_t* buf, mp_uint_t len);
-void common_hal_socketpool_socket_settimeout(socketpool_socket_obj_t* self, mp_uint_t timeout_ms);
+    const char* host, size_t hostlen, uint32_t port, const uint8_t* buf, uint32_t len);
+void common_hal_socketpool_socket_settimeout(socketpool_socket_obj_t* self, uint32_t timeout_ms);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_SOCKETPOOL_SOCKET_H

--- a/shared-bindings/ssl/SSLSocket.c
+++ b/shared-bindings/ssl/SSLSocket.c
@@ -71,7 +71,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ssl_sslsocket___exit___obj, 4, 4, ssl
 STATIC mp_obj_t ssl_sslsocket_accept(mp_obj_t self_in) {
     ssl_sslsocket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint8_t ip[4];
-    uint port;
+    uint32_t port;
 
     ssl_sslsocket_obj_t * sslsock = common_hal_ssl_sslsocket_accept(self, ip, &port);
 
@@ -97,8 +97,11 @@ STATIC mp_obj_t ssl_sslsocket_bind(mp_obj_t self_in, mp_obj_t addr_in) {
     size_t hostlen;
     const char* host = mp_obj_str_get_data(addr_items[0], &hostlen);
     mp_int_t port = mp_obj_get_int(addr_items[1]);
+    if (port < 0) {
+        mp_raise_ValueError(translate("port must be >= 0"));
+    }
 
-    bool ok = common_hal_ssl_sslsocket_bind(self, host, hostlen, port);
+    bool ok = common_hal_ssl_sslsocket_bind(self, host, hostlen, (uint32_t)port);
     if (!ok) {
         mp_raise_ValueError(translate("Error: Failure to bind"));
     }
@@ -132,8 +135,11 @@ STATIC mp_obj_t ssl_sslsocket_connect(mp_obj_t self_in, mp_obj_t addr_in) {
     size_t hostlen;
     const char* host = mp_obj_str_get_data(addr_items[0], &hostlen);
     mp_int_t port = mp_obj_get_int(addr_items[1]);
+    if (port < 0) {
+        mp_raise_ValueError(translate("port must be >= 0"));
+    }
 
-    bool ok = common_hal_ssl_sslsocket_connect(self, host, hostlen, port);
+    bool ok = common_hal_ssl_sslsocket_connect(self, host, hostlen, (uint32_t)port);
     if (!ok) {
         mp_raise_OSError(0);
     }

--- a/shared-bindings/ssl/SSLSocket.h
+++ b/shared-bindings/ssl/SSLSocket.h
@@ -31,15 +31,15 @@
 
 extern const mp_obj_type_t ssl_sslsocket_type;
 
-ssl_sslsocket_obj_t * common_hal_ssl_sslsocket_accept(ssl_sslsocket_obj_t* self, uint8_t* ip, uint *port);
-bool common_hal_ssl_sslsocket_bind(ssl_sslsocket_obj_t* self, const char* host, size_t hostlen, uint8_t port);
+ssl_sslsocket_obj_t * common_hal_ssl_sslsocket_accept(ssl_sslsocket_obj_t* self, uint8_t* ip, uint32_t *port);
+bool common_hal_ssl_sslsocket_bind(ssl_sslsocket_obj_t* self, const char* host, size_t hostlen, uint32_t port);
 void common_hal_ssl_sslsocket_close(ssl_sslsocket_obj_t* self);
-bool common_hal_ssl_sslsocket_connect(ssl_sslsocket_obj_t* self, const char* host, size_t hostlen, mp_int_t port);
+bool common_hal_ssl_sslsocket_connect(ssl_sslsocket_obj_t* self, const char* host, size_t hostlen, uint32_t port);
 bool common_hal_ssl_sslsocket_get_closed(ssl_sslsocket_obj_t* self);
 bool common_hal_ssl_sslsocket_get_connected(ssl_sslsocket_obj_t* self);
 bool common_hal_ssl_sslsocket_listen(ssl_sslsocket_obj_t* self, int backlog);
-mp_uint_t common_hal_ssl_sslsocket_recv_into(ssl_sslsocket_obj_t* self, const uint8_t* buf, mp_uint_t len);
-mp_uint_t common_hal_ssl_sslsocket_send(ssl_sslsocket_obj_t* self, const uint8_t* buf, mp_uint_t len);
-void common_hal_ssl_sslsocket_settimeout(ssl_sslsocket_obj_t* self, mp_uint_t timeout_ms);
+mp_uint_t common_hal_ssl_sslsocket_recv_into(ssl_sslsocket_obj_t* self, const uint8_t* buf, uint32_t len);
+mp_uint_t common_hal_ssl_sslsocket_send(ssl_sslsocket_obj_t* self, const uint8_t* buf, uint32_t len);
+void common_hal_ssl_sslsocket_settimeout(ssl_sslsocket_obj_t* self, uint32_t timeout_ms);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_SSL_SSLSOCKET_H


### PR DESCRIPTION
The Common-Hal API for Socket had some inconsistencies argument size and type between functions, such as the "port" argument. Some of these were even using uint8_t, which is far too small for many common port values. This PR converts all arguments to uint32_t and adds some sign checking since Python always passes them in as signed ints. 

Further down the line, it may be appropriate to add more comprehensive input sanitation to this and other shared-bindings implementations.

Resolves #4127