### PR TITLE
Socket: Fix LWIP connect error

### DIFF
--- a/ports/esp32s2/common-hal/socketpool/Socket.c
+++ b/ports/esp32s2/common-hal/socketpool/Socket.c
@@ -181,7 +181,7 @@ bool common_hal_socketpool_socket_connect(socketpool_socket_obj_t* self,
     opts = opts | O_NONBLOCK;
     lwip_fcntl(self->num, F_SETFL, opts);
 
-    if (result) {
+    if (result >= 0) {
         self->connected = true;
         return true;
     } else {


### PR DESCRIPTION
This PR fixes an issue with the TCP-only version of `socket.connect()` where it would always report an OSError even when successful. Thanks to @Neradoc for pointing this out, I don't know how it made it through my testing gauntlet.