### PR TITLE
Socket: Connect accepted sockets

### DIFF
--- a/ports/esp32s2/common-hal/socketpool/Socket.c
+++ b/ports/esp32s2/common-hal/socketpool/Socket.c
@@ -99,6 +99,7 @@ socketpool_socket_obj_t* common_hal_socketpool_socket_accept(socketpool_socket_o
         sock->base.type = &socketpool_socket_type;
         sock->num = newsoc;
         sock->pool = self->pool;
+        sock->connected = true;
 
         if (!register_open_socket(sock)) {
             mp_raise_OSError(MP_EBADF);


### PR DESCRIPTION
This PR fixes an issue where sockets created by `accept()` were not given the `sock->connected = true` internal parameter, and thus caused `send()` to fail when used in a server context. Found while creating a new suite of socket tests.