### PR TITLE
fix bitmap_font path in display resource gen

### DIFF
--- a/tools/gen_display_resources.py
+++ b/tools/gen_display_resources.py
@@ -8,8 +8,8 @@ import os
 import struct
 import sys
 
-sys.path.append("bitmap_font")
-sys.path.append("../../tools/bitmap_font")
+sys.path.insert(0, "bitmap_font")
+sys.path.insert(0, "../../tools/bitmap_font")
 
 from adafruit_bitmap_font import bitmap_font
 


### PR DESCRIPTION
This change allows you to successfully build circuitpython even if you have the bitmap_font library installed in your python environment.

I'm guessing that this script is involved in making `terminalio.FONT` but am not certain. I tested the resulting build on a PyPortal with a script that draws text using `terminalio.FONT` and it does appear to work normally as far as I can tell.

resolves: #4129 