### PR TITLE
Neopixel rp2040 fix

### DIFF
--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -545,6 +545,7 @@ static bool _transfer(rp2pio_statemachine_obj_t *self,
         size_t rx_remaining = in_len;
         size_t tx_remaining = out_len;
 
+        RUN_BACKGROUND_TASKS; // clear any pending tasks before writing the small number of bytes
         while (rx_remaining || tx_remaining) {
             if (tx_remaining && !pio_sm_is_tx_fifo_full(self->pio, self->state_machine)) {
                 *tx_destination = *data_out;


### PR DESCRIPTION
Partial fix for #4135 to run background tasks before starting a non-dma transfer of data. Non-dma transfers are used when writing less then 32 bytes (which equates to 10 RGB neopixles). The fact a background task may not need to run explains why it was also further unpredictable. 

Running background tasks at all during a loop writing the 32 or less bytes could cause a timing issue so discussion should take place on if that should even take place.