### PR TITLE
sdcardio:  add a note about sharing the SPI bus with SD cards and other devices

### DIFF
--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -55,6 +55,12 @@
 //|         Data transfers use the specified baurate (rounded down to one that is supported by
 //|         the microcontroller)
 //|
+//|         .. important::
+//|            If the same SPI bus is shared with other peripherals, it is important that
+//|            the SD card be initialized before accessing any other peripheral on the bus.
+//|            Failure to do so can prevent the SD card from being recognized until it is
+//|            powered off or re-inserted.
+//|
 //|         Example usage:
 //|
 //|         .. code-block:: python


### PR DESCRIPTION
Similar to https://github.com/adafruit/Adafruit_CircuitPython_SD/pull/44

![image](https://user-images.githubusercontent.com/1517291/107391338-362a3b80-6abe-11eb-9b91-bc1f1eee8a76.png)