### PR TITLE
rp2pio: Enable read and read/write transactions

### DIFF
--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -296,110 +296,109 @@ STATIC mp_obj_t rp2pio_statemachine_write(size_t n_args, const mp_obj_t *pos_arg
 MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_obj, 2, rp2pio_statemachine_write);
 
 
-// // |     def readinto(self, buffer: WriteableBuffer, *, start: int = 0, end: Optional[int] = None) -> None:
-// // |         """Read into ``buffer``. If the number of bytes to read is 0, nothing happens.
-// // |
-// // |         :param ~_typing.WriteableBuffer buffer: Read data into this buffer
-// // |         :param int start: Start of the slice of ``buffer`` to read into: ``buffer[start:end]``
-// // |         :param int end: End of the slice; this index is not included. Defaults to ``len(buffer)``
-// // |         :param int write_value: Value to write while reading. (Usually ignored.)"""
-// // |         ...
-// // |
+// |     def readinto(self, buffer: WriteableBuffer, *, start: int = 0, end: Optional[int] = None) -> None:
+// |         """Read into ``buffer``. If the number of bytes to read is 0, nothing happens.
+// |
+// |         :param ~_typing.WriteableBuffer buffer: Read data into this buffer
+// |         :param int start: Start of the slice of ``buffer`` to read into: ``buffer[start:end]``
+// |         :param int end: End of the slice; this index is not included. Defaults to ``len(buffer)``
+// |         :param int write_value: Value to write while reading. (Usually ignored.)"""
+// |         ...
+// |
 
-// STATIC mp_obj_t rp2pio_statemachine_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-//     enum { ARG_buffer, ARG_start, ARG_end, ARG_write_value };
-//     static const mp_arg_t allowed_args[] = {
-//         { MP_QSTR_buffer,     MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
-//         { MP_QSTR_start,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
-//         { MP_QSTR_end,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = INT_MAX} },
-//         { MP_QSTR_write_value,MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
-//     };
-//     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-//     check_for_deinit(self);
-//     check_lock(self);
-//     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-//     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+STATIC mp_obj_t rp2pio_statemachine_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_buffer, ARG_start, ARG_end, ARG_write_value };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_buffer,     MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_start,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_end,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = INT_MAX} },
+        { MP_QSTR_write_value,MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+    };
+    rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    check_for_deinit(self);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-//     mp_buffer_info_t bufinfo;
-//     mp_get_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_WRITE);
-//     int32_t start = args[ARG_start].u_int;
-//     size_t length = bufinfo.len;
-//     normalize_buffer_bounds(&start, args[ARG_end].u_int, &length);
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_WRITE);
+    int32_t start = args[ARG_start].u_int;
+    size_t length = bufinfo.len;
+    normalize_buffer_bounds(&start, args[ARG_end].u_int, &length);
 
-//     if (length == 0) {
-//         return mp_const_none;
-//     }
+    if (length == 0) {
+        return mp_const_none;
+    }
 
-//     bool ok = common_hal_rp2pio_statemachine_read(self, ((uint8_t*)bufinfo.buf) + start, length, args[ARG_write_value].u_int);
-//     if (!ok) {
-//         mp_raise_OSError(MP_EIO);
-//     }
-//     return mp_const_none;
-// }
-// MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_readinto_obj, 2, rp2pio_statemachine_readinto);
+    bool ok = common_hal_rp2pio_statemachine_read(self, ((uint8_t*)bufinfo.buf) + start, length);
+    if (!ok) {
+        mp_raise_OSError(MP_EIO);
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_readinto_obj, 2, rp2pio_statemachine_readinto);
 
-// //|     def write_readinto(self, buffer_out: ReadableBuffer, buffer_in: WriteableBuffer, *, out_start: int = 0, out_end: Optional[int] = None, in_start: int = 0, in_end: Optional[int] = None) -> None:
-// //|         """Write out the data in ``buffer_out`` while simultaneously reading data into ``buffer_in``.
-// //|         The SPI object must be locked.
-// //|         The lengths of the slices defined by ``buffer_out[out_start:out_end]`` and ``buffer_in[in_start:in_end]``
-// //|         must be equal.
-// //|         If buffer slice lengths are both 0, nothing happens.
-// //|
-// //|         :param ~_typing.ReadableBuffer buffer_out: Write out the data in this buffer
-// //|         :param ~_typing.WriteableBuffer buffer_in: Read data into this buffer
-// //|         :param int out_start: Start of the slice of buffer_out to write out: ``buffer_out[out_start:out_end]``
-// //|         :param int out_end: End of the slice; this index is not included. Defaults to ``len(buffer_out)``
-// //|         :param int in_start: Start of the slice of ``buffer_in`` to read into: ``buffer_in[in_start:in_end]``
-// //|         :param int in_end: End of the slice; this index is not included. Defaults to ``len(buffer_in)``"""
-// //|         ...
-// //|
+//|     def write_readinto(self, buffer_out: ReadableBuffer, buffer_in: WriteableBuffer, *, out_start: int = 0, out_end: Optional[int] = None, in_start: int = 0, in_end: Optional[int] = None) -> None:
+//|         """Write out the data in ``buffer_out`` while simultaneously reading data into ``buffer_in``.
+//|         The SPI object must be locked.
+//|         The lengths of the slices defined by ``buffer_out[out_start:out_end]`` and ``buffer_in[in_start:in_end]``
+//|         must be equal.
+//|         If buffer slice lengths are both 0, nothing happens.
+//|
+//|         :param ~_typing.ReadableBuffer buffer_out: Write out the data in this buffer
+//|         :param ~_typing.WriteableBuffer buffer_in: Read data into this buffer
+//|         :param int out_start: Start of the slice of buffer_out to write out: ``buffer_out[out_start:out_end]``
+//|         :param int out_end: End of the slice; this index is not included. Defaults to ``len(buffer_out)``
+//|         :param int in_start: Start of the slice of ``buffer_in`` to read into: ``buffer_in[in_start:in_end]``
+//|         :param int in_end: End of the slice; this index is not included. Defaults to ``len(buffer_in)``"""
+//|         ...
+//|
 
-// STATIC mp_obj_t rp2pio_statemachine_write_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-//     enum { ARG_buffer_out, ARG_buffer_in, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end };
-//     static const mp_arg_t allowed_args[] = {
-//         { MP_QSTR_buffer_out,    MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
-//         { MP_QSTR_buffer_in,     MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
-//         { MP_QSTR_out_start,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
-//         { MP_QSTR_out_end,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = INT_MAX} },
-//         { MP_QSTR_in_start,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
-//         { MP_QSTR_in_end,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = INT_MAX} },
-//     };
-//     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-//     check_for_deinit(self);
-//     check_lock(self);
-//     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-//     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+STATIC mp_obj_t rp2pio_statemachine_write_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_buffer_out, ARG_buffer_in, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_buffer_out,    MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_buffer_in,     MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_out_start,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_out_end,       MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = INT_MAX} },
+        { MP_QSTR_in_start,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_in_end,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = INT_MAX} },
+    };
+    rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    check_for_deinit(self);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-//     mp_buffer_info_t buf_out_info;
-//     mp_get_buffer_raise(args[ARG_buffer_out].u_obj, &buf_out_info, MP_BUFFER_READ);
-//     int32_t out_start = args[ARG_out_start].u_int;
-//     size_t out_length = buf_out_info.len;
-//     normalize_buffer_bounds(&out_start, args[ARG_out_end].u_int, &out_length);
+    mp_buffer_info_t buf_out_info;
+    mp_get_buffer_raise(args[ARG_buffer_out].u_obj, &buf_out_info, MP_BUFFER_READ);
+    int32_t out_start = args[ARG_out_start].u_int;
+    size_t out_length = buf_out_info.len;
+    normalize_buffer_bounds(&out_start, args[ARG_out_end].u_int, &out_length);
 
-//     mp_buffer_info_t buf_in_info;
-//     mp_get_buffer_raise(args[ARG_buffer_in].u_obj, &buf_in_info, MP_BUFFER_WRITE);
-//     int32_t in_start = args[ARG_in_start].u_int;
-//     size_t in_length = buf_in_info.len;
-//     normalize_buffer_bounds(&in_start, args[ARG_in_end].u_int, &in_length);
+    mp_buffer_info_t buf_in_info;
+    mp_get_buffer_raise(args[ARG_buffer_in].u_obj, &buf_in_info, MP_BUFFER_WRITE);
+    int32_t in_start = args[ARG_in_start].u_int;
+    size_t in_length = buf_in_info.len;
+    normalize_buffer_bounds(&in_start, args[ARG_in_end].u_int, &in_length);
 
-//     if (out_length != in_length) {
-//         mp_raise_ValueError(translate("buffer slices must be of equal length"));
-//     }
+    if (out_length != in_length) {
+        mp_raise_ValueError(translate("buffer slices must be of equal length"));
+    }
 
-//     if (out_length == 0) {
-//         return mp_const_none;
-//     }
+    if (out_length == 0) {
+        return mp_const_none;
+    }
 
-//     bool ok = common_hal_rp2pio_statemachine_transfer(self,
-//                                             ((uint8_t*)buf_out_info.buf) + out_start,
-//                                             ((uint8_t*)buf_in_info.buf) + in_start,
-//                                             out_length);
-//     if (!ok) {
-//         mp_raise_OSError(MP_EIO);
-//     }
-//     return mp_const_none;
-// }
-// MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_readinto_obj, 2, rp2pio_statemachine_write_readinto);
+    bool ok = common_hal_rp2pio_statemachine_transfer(self,
+                                            ((uint8_t*)buf_out_info.buf) + out_start,
+                                            out_length,
+                                            ((uint8_t*)buf_in_info.buf) + in_start,
+                                            in_length);
+    if (!ok) {
+        mp_raise_OSError(MP_EIO);
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_readinto_obj, 2, rp2pio_statemachine_write_readinto);
 
 //|     frequency: int
 //|     """The actual state machine frequency. This may not match the frequency requested
@@ -427,9 +426,9 @@ STATIC const mp_rom_map_elem_t rp2pio_statemachine_locals_dict_table[] = {
 
 //    { MP_ROM_QSTR(MP_QSTR_restart), MP_ROM_PTR(&rp2pio_statemachine_configure_obj) },
 
-//    { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&rp2pio_statemachine_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&rp2pio_statemachine_readinto_obj) },
     { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&rp2pio_statemachine_write_obj) },
-//     { MP_ROM_QSTR(MP_QSTR_write_readinto), MP_ROM_PTR(&rp2pio_statemachine_write_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write_readinto), MP_ROM_PTR(&rp2pio_statemachine_write_readinto_obj) },
     { MP_ROM_QSTR(MP_QSTR_frequency), MP_ROM_PTR(&rp2pio_statemachine_frequency_obj) }
 };
 STATIC MP_DEFINE_CONST_DICT(rp2pio_statemachine_locals_dict, rp2pio_statemachine_locals_dict_table);

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.h
@@ -52,20 +52,20 @@ extern void common_hal_rp2pio_statemachine_deinit(rp2pio_statemachine_obj_t *sel
 extern bool common_hal_rp2pio_statemachine_deinited(rp2pio_statemachine_obj_t *self);
 
 // Writes out the given data.
-extern bool common_hal_rp2pio_statemachine_write(rp2pio_statemachine_obj_t *self, const uint8_t *data, size_t len);
+bool common_hal_rp2pio_statemachine_write(rp2pio_statemachine_obj_t *self, const uint8_t *data, size_t len);
 
-// // Reads in len bytes while outputting zeroes.
-// extern bool common_hal_rp2pio_statemachine_read(rp2pio_statemachine_obj_t *self, uint8_t *data, size_t len, uint8_t write_value);
+// Reads data into the given buffer
+bool common_hal_rp2pio_statemachine_read(rp2pio_statemachine_obj_t *self, uint8_t *data, size_t len);
 
-// // Reads and write len bytes simultaneously.
-// extern bool common_hal_rp2pio_statemachine_transfer(rp2pio_statemachine_obj_t *self,
-//                                           const uint8_t *data_out, size_t out_len,
-//                                           uint8_t *data_in, size_t in_len);
+// Performs a bidirectional transfer using both buffers
+bool common_hal_rp2pio_statemachine_transfer(rp2pio_statemachine_obj_t *self,
+    const uint8_t *data_out, size_t out_len,
+    uint8_t *data_in, size_t in_len);
 
-// Return actual SPI bus frequency.
+// Return actual PIO clock frequency.
 uint32_t common_hal_rp2pio_statemachine_get_frequency(rp2pio_statemachine_obj_t* self);
 
-// This is used by the supervisor to claim SPI devices indefinitely.
+// This is used by the supervisor to claim state machines indefinitely.
 // extern void common_hal_rp2pio_statemachine_never_reset(rp2pio_statemachine_obj_t *self);
 
 #endif // MICROPY_INCLUDED_RASPBERRYPI_BINDINGS_RP2PIO_STATEMACHINE_H

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -445,9 +445,17 @@ bool common_hal_rp2pio_statemachine_deinited(rp2pio_statemachine_obj_t *self) {
     return self->state_machine == NUM_PIO_STATE_MACHINES;
 }
 
-static bool _transfer(rp2pio_statemachine_obj_t *self,
+bool common_hal_rp2pio_statemachine_transfer(rp2pio_statemachine_obj_t *self,
     const uint8_t *data_out, size_t out_len,
     uint8_t *data_in, size_t in_len) {
+
+    if (data_out && !self->out) {
+        mp_raise_RuntimeError(translate("Program lacks output instructions"));
+    }
+    if (data_in && !self->in) {
+        mp_raise_RuntimeError(translate("Program lacks input instructions"));
+    }
+
     // This implementation is based on SPI but varies because the tx and rx buffers
     // may be different lengths and occur at different times or speeds.
 
@@ -586,8 +594,11 @@ static bool _transfer(rp2pio_statemachine_obj_t *self,
 // Writes out the given data.
 bool common_hal_rp2pio_statemachine_write(rp2pio_statemachine_obj_t *self,
     const uint8_t *data, size_t len) {
-    if (!self->out) {
-        mp_raise_RuntimeError(translate("No out in program"));
-    }
-    return _transfer(self, data, len, NULL, 0);
+    return common_hal_rp2pio_statemachine_transfer(self, data, len, NULL, 0);
+}
+
+// Reads data into the given buffer
+bool common_hal_rp2pio_statemachine_read(rp2pio_statemachine_obj_t *self,
+    uint8_t *data, size_t len) {
+    return common_hal_rp2pio_statemachine_transfer(self, NULL, 0, data, len);
 }


### PR DESCRIPTION
Here's my test program, with a workaround for https://github.com/adafruit/Adafruit_CircuitPython_PIOASM/issues/7 applied:
```
import adafruit_pioasm
import rp2pio
import board
import time

spi_cpha0_source = """
.program spi_cpha0
.side_set 1

.wrap_target
    out pins, 1 side 0 [1] ; Stall here on empty (sideset proceeds even if
    in pins,  1 side 1 [1] ; instruction stalls, so we stall with SCK low)
.wrap

"""

spi_cpha0_assembled = adafruit_pioasm.assemble(spi_cpha0_source)

pio_spi_sm = rp2pio.StateMachine(
    spi_cpha0_assembled,
    frequency=8000000,  # 2 MHz, / 4 (?) clocks per bit
    init=adafruit_pioasm.assemble("set pindirs 3"),
    first_sideset_pin=board.GP1,
    first_out_pin=board.GP0,
    first_in_pin=board.GP2,
    first_set_pin=board.GP0,
    set_pin_count=3,
    auto_pull=True,
    auto_push=True,
    out_shift_right=True,
    in_shift_right=True,
    pull_threshold=8,
    push_threshold=8,
)

print(dir(pio_spi_sm))
b = bytearray(4)
while True:
    b[0] = b[2] = 0xaa
    b[1] = b[3] = 0x55
    print(b, end=" -> ")
    pio_spi_sm.write_readinto(b, b)
    print(b)
```

I get pulses out on GP0/1 and if I connect GP0 to GP2 I read back the same value I write.