### PR TITLE
Remove adafruit_bus_device.SPIDevice.spi

### DIFF
--- a/shared-bindings/adafruit_bus_device/SPIDevice.c
+++ b/shared-bindings/adafruit_bus_device/SPIDevice.c
@@ -123,29 +123,9 @@ STATIC mp_obj_t adafruit_bus_device_spidevice_obj___exit__(size_t n_args, const 
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(adafruit_bus_device_spidevice___exit___obj, 4, 4, adafruit_bus_device_spidevice_obj___exit__);
 
-//|     spi: busio.SPI
-//|     """The underlying SPI bus. Useful for weird uses like clocking an SD card without chip select.
-//|
-//|        You shouldn't normally need this."""
-//|
-STATIC mp_obj_t adafruit_bus_device_spidevice_obj_get_spi(mp_obj_t self_in) {
-    adafruit_bus_device_spidevice_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    return common_hal_adafruit_bus_device_spidevice_get_spi(self);
-}
-MP_DEFINE_CONST_FUN_OBJ_1(adafruit_bus_device_spidevice_get_spi_obj, adafruit_bus_device_spidevice_obj_get_spi);
-
-const mp_obj_property_t adafruit_bus_device_spidevice_spi_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&adafruit_bus_device_spidevice_get_spi_obj,
-              (mp_obj_t)&mp_const_none_obj,
-              (mp_obj_t)&mp_const_none_obj},
-};
-
 STATIC const mp_rom_map_elem_t adafruit_bus_device_spidevice_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&adafruit_bus_device_spidevice___enter___obj) },
     { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&adafruit_bus_device_spidevice___exit___obj) },
-
-    { MP_ROM_QSTR(MP_QSTR_spi), MP_ROM_PTR(&adafruit_bus_device_spidevice_spi_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(adafruit_bus_device_spidevice_locals_dict, adafruit_bus_device_spidevice_locals_dict_table);

--- a/shared-bindings/adafruit_bus_device/SPIDevice.h
+++ b/shared-bindings/adafruit_bus_device/SPIDevice.h
@@ -46,6 +46,5 @@ extern void common_hal_adafruit_bus_device_spidevice_construct(adafruit_bus_devi
     uint32_t baudrate, uint8_t polarity, uint8_t phase, uint8_t extra_clocks);
 extern mp_obj_t common_hal_adafruit_bus_device_spidevice_enter(adafruit_bus_device_spidevice_obj_t *self);
 extern void common_hal_adafruit_bus_device_spidevice_exit(adafruit_bus_device_spidevice_obj_t *self);
-extern mp_obj_t common_hal_adafruit_bus_device_spidevice_get_spi(adafruit_bus_device_spidevice_obj_t *self);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_BUSDEVICE_SPIDEVICE_H

--- a/shared-module/adafruit_bus_device/SPIDevice.c
+++ b/shared-module/adafruit_bus_device/SPIDevice.c
@@ -84,7 +84,3 @@ void common_hal_adafruit_bus_device_spidevice_exit(adafruit_bus_device_spidevice
 
     common_hal_busio_spi_unlock(self->spi);
 }
-
-mp_obj_t common_hal_adafruit_bus_device_spidevice_get_spi(adafruit_bus_device_spidevice_obj_t *self) {
-    return self->spi;
-}


### PR DESCRIPTION
Fixes #4172.

https://github.com/adafruit/Adafruit_CircuitPython_SD/pull/43 removes the need for the `.spi` accessor. We don't want to expose this internal state unnecessarily.

@tannewt's PR that added `.spi`, #4114, also cleaned up `__enter__()` and `__exit__()`, so this revert does not undo those improvements.

I tested this on a PyPortal with the `sd` `simpletest`.