### PR TITLE
RP2040: fix off-by-one PWM top issue

### DIFF
--- a/ports/raspberrypi/common-hal/pwmio/PWMOut.h
+++ b/ports/raspberrypi/common-hal/pwmio/PWMOut.h
@@ -39,11 +39,11 @@ typedef struct {
     bool variable_frequency;
     uint16_t duty_cycle;
     uint32_t actual_frequency;
-    uint32_t top;
+    uint16_t top;
 } pwmio_pwmout_obj_t;
 
 void pwmout_reset(void);
 // Private API for AudioPWMOut.
-void pwmio_pwmout_set_top(pwmio_pwmout_obj_t* self, uint32_t top);
+void pwmio_pwmout_set_top(pwmio_pwmout_obj_t* self, uint16_t top);
 
 #endif // MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_PWMIO_PWMOUT_H

--- a/shared-bindings/adafruit_bus_device/SPIDevice.c
+++ b/shared-bindings/adafruit_bus_device/SPIDevice.c
@@ -34,7 +34,6 @@
 
 #include "lib/utils/buffer_helper.h"
 #include "lib/utils/context_manager_helpers.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "supervisor/shared/translate.h"
 


### PR DESCRIPTION
Fixes #4189.

- The `pwmio_pwmout_obj_t` `top` was 32 bits, but it's passed to pico-sdk as 16 bits. Make it 16 bits so the compiler can catch values that are too large. Then needed to force some arithmetic to be 32 bit.
- Maintain top as a 0 to n-1 value. It was getting set to 65536 in one case. Remove `self-> top -1` computations.
- Comparison check for low vs high frequency had a boundary problem at `.frequency = 1907`. Fix by using `<=` comparison instead of `<`.
- Add some bounds checking to make sure values fit in 16 bits.

- Unrelated, missed getting into a previous PR: Remove extraneous include in `shared-bindings/adafruit_bus_device/SPIDevice.c`.

@jedgarpark Could you test this after the artifact builds? It's more complicated than the version I gave you earlier to test.