### PR TITLE
ESP32S2: pin_number_is_free should not check never_reset tables

### DIFF
--- a/ports/esp32s2/common-hal/microcontroller/Pin.c
+++ b/ports/esp32s2/common-hal/microcontroller/Pin.c
@@ -134,7 +134,7 @@ bool pin_number_is_free(gpio_num_t pin_number) {
 
     uint8_t offset = pin_number / 32;
     uint32_t mask = 1 << (pin_number % 32);
-    return (never_reset_pins[offset] & mask) == 0 && (in_use[offset] & mask) == 0;
+    return (in_use[offset] & mask) == 0;
 }
 
 bool common_hal_mcu_pin_is_free(const mcu_pin_obj_t *pin) {


### PR DESCRIPTION
Originally implemented in #3930
Reverted in #4012 without separating out this bugfix
May be responsible for #4142