### PR TITLE
usb_cdc: avoid pulling in extra float-uint64 routines

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -684,6 +684,7 @@ mp_obj_t mp_obj_new_bytearray_by_ref(size_t n, void *items);
 mp_obj_t mp_obj_new_int_from_float(mp_float_t val);
 mp_obj_t mp_obj_new_complex(mp_float_t real, mp_float_t imag);
 extern mp_float_t uint64_to_float(uint64_t ui64);
+extern uint64_t float_to_uint64(float f);
 #endif
 mp_obj_t mp_obj_new_exception(const mp_obj_type_t *exc_type);
 mp_obj_t mp_obj_new_exception_arg1(const mp_obj_type_t *exc_type, mp_obj_t arg);

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -340,6 +340,15 @@ mp_float_t uint64_to_float(uint64_t ui64) {
     return (mp_float_t) ((uint32_t) (ui64 >> 32) * 4294967296.0f + (uint32_t) (ui64 & 0xffffffff));
 }
 
+// Convert a uint64_t to a 32-bit float to a uint64_t without invoking extra math routines.
+// which are large.
+// Assume f >= 0.
+uint64_t float_to_uint64(float f) {
+    // 4294967296 = 2^32
+    const uint32_t upper_half = (uint32_t) (f /  4294967296.0f);
+    const uint32_t lower_half = (uint32_t) f;
+    return (((uint64_t) upper_half) << 32) + lower_half;
+}
 #pragma GCC diagnostic pop
 
 #endif // MICROPY_PY_BUILTINS_FLOAT

--- a/shared-module/usb_cdc/Serial.c
+++ b/shared-module/usb_cdc/Serial.c
@@ -41,7 +41,8 @@ size_t common_hal_usb_cdc_serial_read(usb_cdc_serial_obj_t *self, uint8_t *data,
 
     if (wait_forever || wait_for_timeout) {
         // Read more if we have time.
-        uint64_t timeout_ms = self->timeout * 1000;  // Junk value if timeout < 0.
+        // Use special routine to avoid pulling in uint64-float-compatible math routines.
+        uint64_t timeout_ms = float_to_uint64(self->timeout * 1000);  // Junk value if timeout < 0.
         uint64_t start_ticks = supervisor_ticks_ms64();
 
         uint32_t num_read = 0;
@@ -78,7 +79,8 @@ size_t common_hal_usb_cdc_serial_write(usb_cdc_serial_obj_t *self, const uint8_t
 
     if (wait_forever || wait_for_timeout) {
         // Write more if we have time.
-        uint64_t timeout_ms = self->write_timeout * 1000;  // Junk value if write_timeout < 0.
+        // Use special routine to avoid pulling in uint64-float-compatible math routines.
+        uint64_t timeout_ms = float_to_uint64(self->write_timeout * 1000);  // Junk value if write_timeout < 0.
         uint64_t start_ticks = supervisor_ticks_ms64();
 
         uint32_t num_written = 0;


### PR DESCRIPTION
A couple of conversions from float to `uint64_t` in `usb_cdc` brought in a bunch of floating-point library routines that were otherwise not needed, adding a couple of kB to the build. Use a special-purpose conversion routine instead.

Another alternative would be to limit the conversion to `uint32_t`, but then I have to check for the timeouts being too large, so this is probably less code.

This is the inverse of a routine I wrote a long time ago to compactly convert a `uint64_t` to a `float`.

I did write a small test program to confirm the calculation was correct (it's meant to run on a 64-bit host, not on the chip).
```c

#include <stdint.h>
#include <stdio.h>

uint64_t float_to_uint64(float f) {
    // 4294967296 = 2^32
    const uint32_t upper_half = (uint32_t) (f /  4294967296.0f);
    const uint32_t lower_half = (uint32_t) f;
    return (((uint64_t) upper_half) << 32) + lower_half;
}

int main(void) {
    float f = 1.0f;
    while(1) {
        printf("%g: float_to_uint64: %lu, (uint64_t): %lu\n",
               (double) f, float_to_uint64(f), (uint64_t) f);
        f *= 1.5f;
        if (f > 4294967296.0f * (1L << 32)) {
            break;
        }
    }
}
```