### PR TITLE
SAMD21: one endpoint pair for MSC now instead of two

### DIFF
--- a/ports/atmel-samd/mpconfigport.mk
+++ b/ports/atmel-samd/mpconfigport.mk
@@ -48,10 +48,8 @@ CIRCUITPY_SDCARDIO ?= 0
 # Not enough RAM for framebuffers
 CIRCUITPY_FRAMEBUFFERIO ?= 0
 
-# SAMD21 needs separate endpoint pairs for MSC BULK IN and BULK OUT, otherwise it's erratic.
-# Because of that, there aren't enough endpoints for a secondary CDC serial connection.
-USB_MSC_EP_NUM_OUT = 1
-CIRCUITPY_USB_CDC = 0
+# Not enough room in 192kB or 256kB builds for secondary CDC.
+CIRCUITPY_USB_CDC ?= 0
 
 CIRCUITPY_ULAB = 0
 


### PR DESCRIPTION
A long time ago when I was working on HID, I [found that MSC on the SAMD21 needed to use separate endpoint pairs](https://github.com/adafruit/circuitpython/pull/738#issuecomment-379552122) for IN and OUT. I discovered this only empirically. There is no erratum that would dictate needing two endpoints. At the time we were using the ASF4 USB stack. I was suspicious it was due to ASF4, but could not be sure.

Now that we are using TinyUSB, I tried this again, and, after some mild testing, I didn't see any problem with using just one endpoint pair with MSC on SAMD21. Neither do the [TinyUSB MSC examples](https://github.com/hathach/tinyusb/blob/master/examples/device/cdc_msc/src/usb_descriptors.c).

This PR undoes the special treatment for SAMD21. Theoretically, now, secondary CDC is available on SAMD21. Practically speaking, there is no room on many builds. When turned on, it does not fit on non-Express boards, and only barely fits on smaller translations on SAMD21 Express boards. So I have left it turned off. However, custom builds with secondary CDC should now be possible on SAMD21.

@hathach Just tagging you for interest.