### PR TITLE
proof of concept: error if float->u64 cast used

### DIFF
--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -580,3 +580,13 @@ __attribute__((used)) void HardFault_Handler(void)
         asm("nop;");
     }
 }
+
+extern void __bad_use_of_float_to_u64_cast(void);
+void __aeabi_f2ulz(void) {
+    __bad_use_of_float_to_u64_cast();
+}
+
+extern void __bad_use_of_float_to_s64_cast(void);
+void __aeabi_f2lz(void) {
+    __bad_use_of_float_to_s64_cast();
+}


### PR DESCRIPTION
When the change to fix use of this routine via the case '(uint64_t)(float expression)' is reverted, this error occurs during the build of feather_m4_express:

```
.../firmware.elf.lto.o: in function `usb_cdc_serial_write_stream':
.../Serial.c:81: undefined reference to `__aeabi_f2ulz'
.../ld: firmware.elf.lto.o: in function `usb_cdc_serial_read_stream':
.../Serial.c:44: undefined reference to `__aeabi_f2ulz'
```

I don't exactly know why it says that __aeabi_f2ulz is the undefined symbol, since it's actually some other symbol (__bad_use_of_float_to_u64_cast) which is undefined, but I'll take it.

I don't know if we actually want this, but as I think the problem has arisen more than once it may not hurt.  Let's see what CI says.