### PR TITLE
USB descriptors: Save flash storage for serial number

### DIFF
--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -62,6 +62,7 @@ void load_serial_number(void) {
     uint8_t raw_id[COMMON_HAL_MCU_PROCESSOR_UID_LENGTH];
     common_hal_mcu_processor_get_uid(raw_id);
 
+    usb_serial_number[0] = 0x300 | MP_ARRAY_SIZE(usb_serial_number);
     for (int i = 0; i < COMMON_HAL_MCU_PROCESSOR_UID_LENGTH; i++) {
         for (int j = 0; j < 2; j++) {
             uint8_t nibble = (raw_id[i] >> (j * 4)) & 0xf;

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -62,7 +62,7 @@ void load_serial_number(void) {
     uint8_t raw_id[COMMON_HAL_MCU_PROCESSOR_UID_LENGTH];
     common_hal_mcu_processor_get_uid(raw_id);
 
-    usb_serial_number[0] = 0x300 | MP_ARRAY_SIZE(usb_serial_number);
+    usb_serial_number[0] = 0x300 | sizeof(usb_serial_number);
     for (int i = 0; i < COMMON_HAL_MCU_PROCESSOR_UID_LENGTH; i++) {
         for (int j = 0; j < 2; j++) {
             uint8_t nibble = (raw_id[i] >> (j * 4)) & 0xf;

--- a/tools/gen_usb_descriptor.py
+++ b/tools/gen_usb_descriptor.py
@@ -778,30 +778,32 @@ for idx, descriptor in enumerate(string_descriptors):
     variable_name = StringIndex.index_to_variable[idx]
     if not variable_name:
         variable_name = "string_descriptor{}".format(idx)
+    pointers_to_strings.append("{name}".format(name=variable_name))
 
     const = "const "
     if variable_name == "usb_serial_number":
-        const = ""
-    c_file.write(
-        """\
-{const}uint16_t {NAME}[] = {{
-""".format(
-            const=const, NAME=variable_name
+        length = len(b)
+        c_file.write("    uint16_t {NAME}[{length}];\n".format(NAME=variable_name, length=length//2))
+    else:
+        c_file.write(
+            """\
+    const uint16_t {NAME}[] = {{
+    """.format(
+                const=const, NAME=variable_name
+            )
         )
-    )
-    pointers_to_strings.append("{name}".format(name=variable_name))
-    n = 0
-    while i < len(b):
-        length = b[i]
-        for j in range(length // 2):
-            c_file.write("0x{:04x}, ".format(b[i + 2 * j + 1] << 8 | b[i + 2 * j]))
-        n += 1
-        c_file.write("\n")
-        i += length
-    c_file.write(
-        """\
-};
-"""
+        n = 0
+        while i < len(b):
+            length = b[i]
+            for j in range(length // 2):
+                c_file.write("0x{:04x}, ".format(b[i + 2 * j + 1] << 8 | b[i + 2 * j]))
+            n += 1
+            c_file.write("\n")
+            i += length
+        c_file.write(
+            """\
+    };
+    """
     )
 
 c_file.write(


### PR DESCRIPTION
This saves about 60 bytes (Feather M4 went from 45040 -> 45100 bytes free) — 66 bytes of data eliminated, but 6 bytes paid back to initialize the length field.

~~I didn't test it yet, but I think the idea is solid.~~ The initial version had a problem (descriptor size is in bytes) but now it's fixed and tested.

 * Before: SerialNumber: 9A814A27E47353350202026351D3A0FF
 * After: SerialNumber: 9A814A27E47353350202026351D3A0FF
