### PR TITLE
_pixelbuf: Increase performance of brightness-scaling

### DIFF
--- a/shared-module/_pixelbuf/PixelBuf.h
+++ b/shared-module/_pixelbuf/PixelBuf.h
@@ -49,7 +49,8 @@ typedef struct {
 typedef struct {
     mp_obj_base_t base;
     size_t pixel_count;
-    size_t bytes_per_pixel;
+    uint16_t bytes_per_pixel;
+    uint16_t scaled_brightness;
     pixelbuf_byteorder_details_t byteorder;
     mp_float_t brightness;
     mp_obj_t transmit_buffer_obj;


### PR DESCRIPTION
On the Pico, this increases the "fill rate" of
```python
    pixels[:] = newvalues
```
considerably.  On a strip of 240 RGB LEDs, auto_write=False, the timingsare:

<table>
<tr> <td> Brightness <td> Before <td> After <td> Improvement
<tr> <th> 1.0        <td> 117 kpix/s <td> 307 kpix/s <td> 2.62x
<tr> <th> 0.07       <td> 117 kpix/s <td> 273 kpix/s <td> 2.33x
</table>

It's worth noting that even the "before" rate is fast compared to the time to transmit a single neopixel, but any time we can gain back in the whole pipeline will let marginal animations work a little better. To set all the pixels in this way and then show() gives a pleasant bump to the framerate, from about 108Hz to 124Hz (1.15x)

The main source of speed-up is using integer math instead of floating point math for the calculation of the post-scaled pixel values.  A slight secondary gain is achieved by avoiding the scaling altogether when the scale factor is 1.0.

Because the math is not exactly the same, some scaled pixel values may change by +- 1 RGBW "step".  In practice, this is unlikely to matter.

The gains are bigger on the Pico and other M0 microcontrollers than M4 microcontrollers with floating point math in the hardware.

Happily, flash size is also improved a bit on the Pico build I did, going from
> 542552 bytes used, 506024 bytes free in flash firmware space out of 1048576 bytes (1024.0kB).
    
to
> 542376 bytes used, 506200 bytes free in flash firmware space out of 1048576 bytes (1024.0kB).
