### PR TITLE
Fix for CIRCUITPY_USB_MSC=0

### DIFF
--- a/supervisor/shared/usb/tusb_config.h
+++ b/supervisor/shared/usb/tusb_config.h
@@ -70,7 +70,7 @@
 #define CFG_TUD_CDC                 1
 #endif
 
-#define CFG_TUD_MSC                 1
+#define CFG_TUD_MSC                 CIRCUITPY_USB_MSC
 #define CFG_TUD_HID                 CIRCUITPY_USB_HID
 #define CFG_TUD_MIDI                CIRCUITPY_USB_MIDI
 #define CFG_TUD_VENDOR              CIRCUITPY_USB_VENDOR

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -131,12 +131,16 @@ void usb_irq_handler(void) {
 
 // Invoked when device is mounted
 void tud_mount_cb(void) {
+#if CIRCUITPY_USB_MSC
     usb_msc_mount();
+#endif
 }
 
 // Invoked when device is unmounted
 void tud_umount_cb(void) {
+#if CIRCUITPY_USB_MSC
     usb_msc_umount();
+#endif
 }
 
 // Invoked when usb bus is suspended


### PR DESCRIPTION
Avoid undefined functions when MSC is disabled.