### PR TITLE
Use uint16 for temporary variables in displayio.TileGrid

### DIFF
--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -104,7 +104,7 @@ bool displayio_tilegrid_get_previous_area(displayio_tilegrid_t *self, displayio_
 }
 
 void _update_current_x(displayio_tilegrid_t *self) {
-    int16_t width;
+    uint16_t width;
     if (self->transpose_xy) {
         width = self->pixel_height;
     } else {
@@ -130,7 +130,7 @@ void _update_current_x(displayio_tilegrid_t *self) {
 }
 
 void _update_current_y(displayio_tilegrid_t *self) {
-    int16_t height;
+    uint16_t height;
     if (self->transpose_xy) {
         height = self->pixel_width;
     } else {


### PR DESCRIPTION
Should fix #4284