### PR TITLE
rp2pio: allow keyboard interrupt while waiting for tx fifo to empty (& stall)

### DIFF
--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -673,6 +673,9 @@ static bool _transfer(rp2pio_statemachine_obj_t *self,
         while (!pio_sm_is_tx_fifo_empty(self->pio, self->state_machine) ||
                (self->wait_for_txstall && (self->pio->fdebug & stall_mask) == 0)) {
             RUN_BACKGROUND_TASKS;
+            if (mp_hal_is_interrupted()) {
+                break;
+            }
         }
     }
     return true;


### PR DESCRIPTION
I noticed that one of the busy-waiting loops in the pio I/O code was not allowing a keyboard interrupt to break out of it.  Fix it!