### PR TITLE
spresense: return valid reference voltage

### DIFF
--- a/ports/cxd56/common-hal/analogio/AnalogIn.c
+++ b/ports/cxd56/common-hal/analogio/AnalogIn.c
@@ -114,11 +114,18 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
 
 // Reference voltage is a fixed value which is depending on the board.
 // e.g.)
-// - Reference Voltage of A4 and A5 pins on Main Board is 0.7V.
-// - Reference Voltage of A0 ~ A5 pins on External Interface board
-//   is selected 3.3V or 5.0V by a IO Volt jumper pin.
+// - Reference Voltage of A2 and A3 pins on Main Board is 0.7V.
+// - Reference Voltage of A0 ~ A5 pins on External Interface board is 5.0V
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {
-    return 0.0f;
+    float voltage;
+
+    if (self->number == 2 || self->number == 3) {
+        voltage = 0.0f;
+    } else {
+        voltage = 5.0f;
+    }
+
+    return voltage;
 }
 
 void analogin_reset(void) {

--- a/ports/cxd56/mpconfigport.mk
+++ b/ports/cxd56/mpconfigport.mk
@@ -10,7 +10,13 @@ USB_MSC_EP_NUM_IN = 4
 # Number of USB endpoint pairs.
 USB_NUM_EP = 6
 
+# Define an equivalent for MICROPY_LONGINT_IMPL, to pass to $(MPY-TOOL) in py/mkrules.mk
+# $(MPY-TOOL) needs to know what kind of longint to use (if any) to freeze long integers.
+# This should correspond to the MICROPY_LONGINT_IMPL definition in mpconfigport.h.
 MPY_TOOL_LONGINT_IMPL = -mlongint-impl=mpz
+
+# Longints can be implemented as mpz, as longlong, or not
+LONGINT_IMPL = MPZ
 
 CIRCUITPY_AUDIOBUSIO = 0
 CIRCUITPY_AUDIOIO = 0


### PR DESCRIPTION
Return as reference voltage, **5V** for pins `A0`, `A1`, `A4` and `A5`. These pins are only available on the extension board. For pins `A2` and `A3` the reference voltage will differ depending on the board. For main board it is **0.7V** and for extension board it is **5V**. For this reason, I return 0 for these pins.