### PR TITLE
force a new idf-cache id to fix build issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -475,7 +475,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210128
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210303
     - name: Clone IDF submodules
       run: |
         (cd $IDF_PATH && git submodule update --init)


### PR DESCRIPTION
We're getting bad cache builds again, it looks like.