### PR TITLE
ESP32S2: Fix watchdog deinit

### DIFF
--- a/ports/esp32s2/common-hal/watchdog/WatchDogTimer.c
+++ b/ports/esp32s2/common-hal/watchdog/WatchDogTimer.c
@@ -49,7 +49,7 @@ void common_hal_watchdog_feed(watchdog_watchdogtimer_obj_t *self) {
 }
 
 void common_hal_watchdog_deinit(watchdog_watchdogtimer_obj_t *self) {
-    if (esp_task_wdt_deinit() == ESP_OK) {
+    if (esp_task_wdt_delete(NULL) == ESP_OK && esp_task_wdt_deinit() == ESP_OK) {
         self->mode = WATCHDOGMODE_NONE;
     }
 }


### PR DESCRIPTION
Delete subscribed task before watchdog deinit. Fixes #4324.