### PR TITLE
fix rp2040 use of tud_disconnect

### DIFF
--- a/ports/raspberrypi/supervisor/usb.c
+++ b/ports/raspberrypi/supervisor/usb.c
@@ -31,23 +31,17 @@
 #include "src/rp2_common/pico_platform/include/pico/platform.h"
 #include "src/rp2040/hardware_regs/include/hardware/regs/intctrl.h"
 
-static background_callback_t usb_callback;
-static void usb_background_do(void* unused) {
-    usb_background();
-}
-
-static void queue_background(void) {
-    background_callback_add(&usb_callback, usb_background_do, NULL);
-}
-
 void init_usb_hardware(void) {
 }
 
 void post_usb_init(void) {
+    irq_set_enabled(USBCTRL_IRQ, false);
+
     irq_handler_t usb_handler = irq_get_exclusive_handler(USBCTRL_IRQ);
     if (usb_handler) {
         irq_remove_handler(USBCTRL_IRQ, usb_handler);
-        irq_add_shared_handler(USBCTRL_IRQ, usb_handler, PICO_DEFAULT_IRQ_PRIORITY);
     }
-    irq_add_shared_handler(USBCTRL_IRQ, queue_background, PICO_LOWEST_IRQ_PRIORITY);
+    irq_set_exclusive_handler(USBCTRL_IRQ, usb_irq_handler);
+
+    irq_set_enabled(USBCTRL_IRQ, true);
 }


### PR DESCRIPTION
- fix #4066, need https://github.com/hathach/tinyusb/pull/700 to merged [EDIT: now merged-@dhalbert] ~~first to be able to bump up tinyusb (draft for now)~~ and ready for review
- also use the normal usb_irq_handler() as well with dcd_int_hanlder() wrapper added with tinyusb recently.