### PR TITLE
Tilegrid transpose fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -475,7 +475,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210303
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210304
     - name: Clone IDF submodules
       run: |
         (cd $IDF_PATH && git submodule update --init)

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -26,6 +26,20 @@
 
 primary_display_t displays[CIRCUITPY_DISPLAY_LIMIT];
 
+displayio_buffer_transform_t null_transform = {
+    .x = 0,
+    .y = 0,
+    .dx = 1,
+    .dy = 1,
+    .scale = 1,
+    .width = 0,
+    .height = 0,
+    .mirror_x = false,
+    .mirror_y = false,
+    .transpose_xy = false
+};
+
+
 #if CIRCUITPY_RGBMATRIX
 STATIC bool any_display_uses_this_framebuffer(mp_obj_base_t *obj) {
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {

--- a/shared-module/displayio/area.h
+++ b/shared-module/displayio/area.h
@@ -51,6 +51,8 @@ typedef struct {
     bool transpose_xy;
 } displayio_buffer_transform_t;
 
+extern displayio_buffer_transform_t null_transform;
+
 void displayio_area_union(const displayio_area_t* a,
                           const displayio_area_t* b,
                           displayio_area_t* u);

--- a/shared-module/vectorio/VectorShape.c
+++ b/shared-module/vectorio/VectorShape.c
@@ -93,20 +93,6 @@ void common_hal_vectorio_vector_shape_set_dirty(void *vector_shape) {
 }
 
 
-static displayio_buffer_transform_t null_transform = {
-    .x = 0,
-    .y = 0,
-    .dx = 1,
-    .dy = 1,
-    .scale = 1,
-    .width = 0,
-    .height = 0,
-    .mirror_x = false,
-    .mirror_y = false,
-    .transpose_xy = false
-};
-
-
 void common_hal_vectorio_vector_shape_construct(vectorio_vector_shape_t *self,
         vectorio_ishape_t ishape,
         mp_obj_t pixel_shader, uint16_t x, uint16_t y) {


### PR DESCRIPTION
Fixes #4284.

Setting `TileGrid.transpose_xy` forces the x,y, height, and width to be recalculated using `_update_current_x()` and `_update_current_y()`. Those routines did not handle the case of `absolute_transform` being `NULL`, and used NULL as a pointer to a transform, so they got random values.

This fix guards against that. It also makes `null_transform`, an identity transform defined for use in `vectorio`, be a global. I used it in the fix.

An alternative fix would be to never use a `NULL` pointer as `absolute_transform`, and use `&null_transform` to signify the identity transform. However, `absolute_transform == NULL` is overloaded as a signal the object has no parent, and so some other indicator (like a new bool) would have to be added to indicate no parent. I chose not to make that change now.

I tested this with a simple quotes example on a PyPortal Titano. @jposada202020 if you would like to test this in the context of your full program, that would be great. Thanks.