### PR TITLE
build.yml: Fix 'Print failure info' to not error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
       working-directory: tests
     - name: Print failure info
       run: |
+        shopt -s nullglob;
         for exp in *.exp;
         do testbase=$(basename $exp .exp);
         echo -e "\nFAILURE $testbase";


### PR DESCRIPTION
Print Failure Info is for printing differences detected by 'Test all'.  When some other step fails, then "*.exp" doesn't match any files at all, and _this_ step fails too.

We will assume that the shell is bash and use the easy "shopt" way of fixing the problem, so that "*.exp" expands to nothing (instead of "*.exp") if there are no matches.

This is an alternative to #4334, which would remove the step entirely. It is undesirable to do that, as we wouldn't be able to see the information about the failures that occurred anymore.