### PR TITLE
circuitpy_mpconfig: Disable flash multi-partition

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -132,7 +132,7 @@
 #define MICROPY_FATFS_LFN_CODE_PAGE   (437)
 #define MICROPY_FATFS_USE_LABEL       (1)
 #define MICROPY_FATFS_RPATH           (2)
-#define MICROPY_FATFS_MULTI_PARTITION (1)
+#define MICROPY_FATFS_MULTI_PARTITION (0)
 
 // Only enable this if you really need it. It allocates a byte cache of this size.
 // #define MICROPY_FATFS_MAX_SS           (4096)

--- a/supervisor/shared/flash.c
+++ b/supervisor/shared/flash.c
@@ -213,7 +213,9 @@ void supervisor_flash_init_vfs(fs_user_mount_t *vfs) {
     vfs->base.type = &mp_fat_vfs_type;
     vfs->flags |= FSUSER_NATIVE | FSUSER_HAVE_IOCTL;
     vfs->fatfs.drv = vfs;
+#if MICROPY_FATFS_MULTI_PARTITION
     vfs->fatfs.part = 1; // flash filesystem lives on first partition
+#endif
     vfs->readblocks[0] = (mp_obj_t)&supervisor_flash_obj_readblocks_obj;
     vfs->readblocks[1] = (mp_obj_t)&supervisor_flash_obj;
     vfs->readblocks[2] = (mp_obj_t)flash_read_blocks; // native version


### PR DESCRIPTION
This adds some additional code in mkfs which doesn't seem necessary, and disabling it saves ~172 bytes flash.

Testing performed: Using a Feather M0 Adalogger, checked that
 * an sdcard could still be mounted (using adafruit_sdcard)
 * os.listdir() of "/" and "/sd" worked
 * CIRCUITPY still mounted on the host computer