### PR TITLE
Revert "circuitpy_mpconfig: Disable flash multi-partition"

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -133,7 +133,7 @@
 #define MICROPY_FATFS_LFN_CODE_PAGE   (437)
 #define MICROPY_FATFS_USE_LABEL       (1)
 #define MICROPY_FATFS_RPATH           (2)
-#define MICROPY_FATFS_MULTI_PARTITION (0)
+#define MICROPY_FATFS_MULTI_PARTITION (1)
 
 // Only enable this if you really need it. It allocates a byte cache of this size.
 // #define MICROPY_FATFS_MAX_SS           (4096)

--- a/supervisor/shared/flash.c
+++ b/supervisor/shared/flash.c
@@ -213,9 +213,7 @@ void supervisor_flash_init_vfs(fs_user_mount_t *vfs) {
     vfs->base.type = &mp_fat_vfs_type;
     vfs->flags |= FSUSER_NATIVE | FSUSER_HAVE_IOCTL;
     vfs->fatfs.drv = vfs;
-#if MICROPY_FATFS_MULTI_PARTITION
     vfs->fatfs.part = 1; // flash filesystem lives on first partition
-#endif
     vfs->readblocks[0] = (mp_obj_t)&supervisor_flash_obj_readblocks_obj;
     vfs->readblocks[1] = (mp_obj_t)&supervisor_flash_obj;
     vfs->readblocks[2] = (mp_obj_t)flash_read_blocks; // native version


### PR DESCRIPTION
This reverts commit 156ee4833ab170d598991fd8d4d6f6d04c759744.

I found that `storage.erase_filesystem()` on the rp2040 didn't do anything.  I don't know why, but reverting this seems to fix it.

```
Adafruit CircuitPython 6.2.0-beta.3-75-g7d92f5aa5 on 2021-03-09; Adafruit Feather RP2040 with rp2040
>>> import os; os.listdir('.')
['.fseventsd', '.metadata_never_index', '.Trashes', 'code.py', 'lib', 'boot_out.txt', 'hello.txt', 'alot-128.mp3']
>>> import storage; storage.erase_filesystem()

[tio 11:07:57] Disconnected
[tio 11:08:03] Connected
Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.

Press any key to enter the REPL. Use CTRL-D to reload.

Adafruit CircuitPython 6.2.0-beta.3-75-g7d92f5aa5 on 2021-03-09; Adafruit Feather RP2040 with rp2040
>>> import os; os.listdir('.')
['.fseventsd', '.metadata_never_index', '.Trashes', 'code.py', 'lib', 'boot_out.txt', 'hello.txt', 'alot-128.mp3']
```