### PR TITLE
raspberrypi: RTC: Ensure a time is set

### DIFF
--- a/ports/raspberrypi/common-hal/rtc/RTC.c
+++ b/ports/raspberrypi/common-hal/rtc/RTC.c
@@ -29,9 +29,23 @@
 
 #include "py/runtime.h"
 #include "src/rp2_common/hardware_rtc/include/hardware/rtc.h"
+#include "src/rp2_common/hardware_clocks/include/hardware/clocks.h"
 
 void common_hal_rtc_init(void) {
+    datetime_t t = {
+            .year  = 2020,
+            .month = 1,
+            .day   = 1,
+            .dotw  = 3, // 0 is Sunday, so 3 is Wednesday
+            .hour  = 0,
+            .min   = 0,
+            .sec   = 0
+    };
+
+    // Start the RTC
     rtc_init();
+    rtc_set_datetime(&t);
+
 }
 
 void common_hal_rtc_get_time(timeutils_struct_time_t *tm) {


### PR DESCRIPTION
Until a time is set, the RTC is not running, and rtc_get_datetime() returns false without assigning to the out-parameter.

In CircuitPython, this would manifest as arbitrary values being returned by `rtc.RTC().datetime`, since uninitialized storage on the stack was being converted into a timestamp.

After this change, the RTC starts on January 1, 2020. I think this is the same epoch as the other ports.