### PR TITLE
disable default usb_cdc

### DIFF
--- a/py/circuitpy_mpconfig.mk
+++ b/py/circuitpy_mpconfig.mk
@@ -322,8 +322,10 @@ CFLAGS += -DCIRCUITPY_TOUCHIO=$(CIRCUITPY_TOUCHIO)
 CIRCUITPY_UHEAP ?= 0
 CFLAGS += -DCIRCUITPY_UHEAP=$(CIRCUITPY_UHEAP)
 
+# Disable by default for now, until we have dynamic enabling.
+CIRCUITPY_USB_CDC ?= 0
 # Secondary CDC is usually available if there are at least 8 endpoints.
-CIRCUITPY_USB_CDC ?= $(shell expr $(USB_NUM_EP) '>=' 8)
+#CIRCUITPY_USB_CDC ?= $(shell expr $(USB_NUM_EP) '>=' 8)
 CFLAGS += -DCIRCUITPY_USB_CDC=$(CIRCUITPY_USB_CDC)
 
 CIRCUITPY_USB_HID ?= 1


### PR DESCRIPTION
After some internal discussion, we have decided to disable `usb_cdc` by default for now. It will still be available to be turned on in a custom build. Several users found it interfered with their existing workflow because there were now two devices to choose from for the REPL. Normally the devices are assigned REPL first, but on Windows, a lower-numbered COMnn device may be reused for the second CDC if it is free.

In 7.x, we hope to be able to allow this feature to be turned on and off in `boot.py`.