### PR TITLE
spresense: minor i2c and spi fixes

### DIFF
--- a/ports/cxd56/common-hal/busio/I2C.c
+++ b/ports/cxd56/common-hal/busio/I2C.c
@@ -103,7 +103,7 @@ uint8_t common_hal_busio_i2c_write(busio_i2c_obj_t *self, uint16_t address, cons
     msg.flags = (stop ? 0 : I2C_M_NOSTOP);
     msg.buffer = (uint8_t *) data;
     msg.length = len;
-    return I2C_TRANSFER(self->i2c_dev, &msg, 1);
+    return -I2C_TRANSFER(self->i2c_dev, &msg, 1);
 }
 
 uint8_t common_hal_busio_i2c_read(busio_i2c_obj_t *self, uint16_t address, uint8_t *data, size_t len) {
@@ -114,7 +114,7 @@ uint8_t common_hal_busio_i2c_read(busio_i2c_obj_t *self, uint16_t address, uint8
     msg.flags = I2C_M_READ;
     msg.buffer = data;
     msg.length = len;
-    return I2C_TRANSFER(self->i2c_dev, &msg, 1);
+    return -I2C_TRANSFER(self->i2c_dev, &msg, 1);
 }
 
 void common_hal_busio_i2c_never_reset(busio_i2c_obj_t *self) {

--- a/ports/cxd56/common-hal/busio/SPI.c
+++ b/ports/cxd56/common-hal/busio/SPI.c
@@ -35,9 +35,13 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self, const mcu_pin_obj_t *
     const mcu_pin_obj_t *mosi, const mcu_pin_obj_t *miso) {
     int port = -1;
 
-    if (clock->number == PIN_SPI4_SCK && mosi->number == PIN_SPI4_MOSI && miso->number == PIN_SPI4_MISO) {
+    if (clock->number == PIN_SPI4_SCK &&
+        (mosi == NULL || mosi->number == PIN_SPI4_MOSI) &&
+        (miso == NULL || miso->number == PIN_SPI4_MISO)) {
         port = 4;
-    } else if (clock->number == PIN_EMMC_CLK && mosi->number == PIN_EMMC_DATA0 && miso->number == PIN_EMMC_DATA1) {
+    } else if (clock->number == PIN_EMMC_CLK &&
+               (mosi == NULL || mosi->number == PIN_EMMC_DATA0) &&
+               (miso == NULL || miso->number == PIN_EMMC_DATA1)) {
         port = 5;
     }
 


### PR DESCRIPTION
For the `busio.SPI()` class only one pin (`MISO` or `MOSI`) needs to be defined now. There is no need to pass both of them.

`I2C_TRANSFER` returns a negative value when an error occurs. `busio.I2C` class expects error values to be positive. Adding a minus changes the error values from negative to positive.