### PR TITLE
correct clock stretch timeout for board.I2C()

### DIFF
--- a/shared-module/board/__init__.c
+++ b/shared-module/board/__init__.c
@@ -60,7 +60,7 @@ mp_obj_t common_hal_board_create_i2c(void) {
     busio_i2c_obj_t *self = &i2c_obj;
     self->base.type = &busio_i2c_type;
 
-    common_hal_busio_i2c_construct(self, DEFAULT_I2C_BUS_SCL, DEFAULT_I2C_BUS_SDA, 100000, 0);
+    common_hal_busio_i2c_construct(self, DEFAULT_I2C_BUS_SCL, DEFAULT_I2C_BUS_SDA, 100000, 255);
     i2c_singleton = (mp_obj_t)self;
     return i2c_singleton;
 }


### PR DESCRIPTION
Fixes #4372.

The clock stretch timeout for `board.I2C()` was given as zero, but the default is 255. This timeout is only used by `bitbangio.I2C()`, and didn't matter up to now for other ports. But the RP2040 port uses bitbangio for zero-byte writes, so it used the zero clock stretch timeout.

Anyone can review. This is simple. Tested.