### PR TITLE
Lower default flash speed.

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -234,7 +234,7 @@ SRC_COMMON_HAL_SHARED_MODULE_EXPANDED = $(sort $(SRC_COMMON_HAL_EXPANDED) $(SRC_
 
 SRC_S = supervisor/$(CHIP_FAMILY)_cpu.s
 BOOT2_S_UPPER ?= sdk/src/rp2_common/boot_stage2/boot2_generic_03h.S
-BOOT2_S_CFLAGS ?= -DPICO_FLASH_SPI_CLKDIV=2
+BOOT2_S_CFLAGS ?= -DPICO_FLASH_SPI_CLKDIV=6
 SRC_S_UPPER = sdk/src/rp2_common/hardware_divider/divider.S \
               sdk/src/rp2_common/hardware_irq/irq_handler_chain.S \
               sdk/src/rp2_common/pico_bit_ops/bit_ops_aeabi.S \


### PR DESCRIPTION
/ 6 leads to ~40mhz. GD25C 2M and 4M have a max 0x03 read speed of 60mhz.
If the divisor is / 4 then the speed is just over 60mhz.

Fixes #4377