### PR TITLE
Change in documentation in Analogio

### DIFF
--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -124,7 +124,7 @@ const mp_obj_property_t analogio_analogin_value_obj = {
               (mp_obj_t)&mp_const_none_obj},
 };
 
-//|     reference_voltage: Optional[float]
+//|     reference_voltage: float
 //|     """The maximum voltage measurable (also known as the reference voltage) as a
 //|     `float` in Volts."""
 //|

--- a/shared-bindings/analogio/AnalogOut.c
+++ b/shared-bindings/analogio/AnalogOut.c
@@ -42,10 +42,10 @@
 //|     Example usage::
 //|
 //|         import analogio
-//|         from microcontroller import pin
+//|         from board import *
 //|
-//|        dac = analogio.AnalogOut(pin.PA02)          # output on pin PA02
-//|         dac.value = 32768                           # makes PA02 1.65V"""
+//|         dac = analogio.AnalogOut(A2)                # output on pin A2
+//|         dac.value = 32768                           # makes A2 1.65V"""
 //|
 //|     def __init__(self, pin: microcontroller.Pin) -> None:
 //|         """Use the AnalogOut on the given pin.


### PR DESCRIPTION
Corrections to the doc_strings in the analogio docs for readthedocs generation. Two changes:

1. Erasing the [Optional] in the voltage reference
2. Standarize both usage examples. Using CircuitPython 
Verified Building docs using sphinx locally
![image](https://user-images.githubusercontent.com/34255413/111061977-7d6c6900-847c-11eb-8a28-02e00be864a7.png)
![image](https://user-images.githubusercontent.com/34255413/111061990-96751a00-847c-11eb-958e-873639cf6073.png)
