### PR TITLE
RTC and Touchin docs changes

### DIFF
--- a/shared-bindings/rtc/RTC.c
+++ b/shared-bindings/rtc/RTC.c
@@ -98,7 +98,13 @@ const mp_obj_property_t rtc_rtc_datetime_obj = {
 //|     """The RTC calibration value as an `int`.
 //|
 //|     A positive value speeds up the clock and a negative value slows it down.
-//|     Range and value is hardware specific, but one step is often approximately 1 ppm."""
+//|     Range and value is hardware specific, but one step is often approximately 1 ppm::
+//|
+//|       import rtc
+//|       import time
+//|
+//|       r = rtc.RTC()
+//|       r.calibration = 1"""
 //|
 STATIC mp_obj_t rtc_rtc_obj_get_calibration(mp_obj_t self_in) {
     int calibration = common_hal_rtc_get_calibration();

--- a/shared-bindings/touchio/TouchIn.c
+++ b/shared-bindings/touchio/TouchIn.c
@@ -153,7 +153,13 @@ const mp_obj_property_t touchio_touchin_raw_value_obj = {
 //|     When the **TouchIn** object is created, an initial `raw_value` is read from the pin,
 //|     and then `threshold` is set to be 100 + that value.
 //|
-//|     You can adjust `threshold` to make the pin more or less sensitive."""
+//|     You can adjust `threshold` to make the pin more or less sensitive::
+//|
+//|       import board
+//|       import touchio
+//|
+//|       touch = touchio.TouchIn(board.A1)
+//|       touch.threshold = 7300"""
 //|
 STATIC mp_obj_t touchio_touchin_obj_get_threshold(mp_obj_t self_in) {
     touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);


### PR DESCRIPTION
This PR includes two changes in documentation in the C files to display in the readthedocs. Adding to examples of usage::
1. RTC: add usage of the calibration setting
2. Touchin: add usage example of the threshold setting
This changes were tested doing a local built of the documentation. See pictures

![image](https://user-images.githubusercontent.com/34255413/111088800-5b67fa80-84ff-11eb-845f-ac872e5d5520.png)
![image](https://user-images.githubusercontent.com/34255413/111088864-a3871d00-84ff-11eb-943b-3ef11d0cfa6d.png)
