### PR TITLE
spresense: minor changes for i2c, spi and uart

### DIFF
--- a/ports/cxd56/common-hal/busio/I2C.c
+++ b/ports/cxd56/common-hal/busio/I2C.c
@@ -27,6 +27,7 @@
 #include <arch/chip/pin.h>
 #include <nuttx/i2c/i2c_master.h>
 #include <cxd56_i2c.h>
+#include <cxd56_pinconfig.h>
 
 #include "py/runtime.h"
 
@@ -49,6 +50,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self, const mcu_pin_obj_t *
     self->sda_pin = sda;
     self->frequency = frequency;
     self->i2c_dev = cxd56_i2cbus_initialize(0);
+    CXD56_PIN_CONFIGS(PINCONFS_I2C0);
 }
 
 void common_hal_busio_i2c_deinit(busio_i2c_obj_t *self) {

--- a/ports/cxd56/common-hal/busio/SPI.c
+++ b/ports/cxd56/common-hal/busio/SPI.c
@@ -26,6 +26,7 @@
 
 #include <arch/chip/pin.h>
 #include <cxd56_spi.h>
+#include <cxd56_pinconfig.h>
 
 #include "py/runtime.h"
 
@@ -39,10 +40,12 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self, const mcu_pin_obj_t *
         (mosi == NULL || mosi->number == PIN_SPI4_MOSI) &&
         (miso == NULL || miso->number == PIN_SPI4_MISO)) {
         port = 4;
+        CXD56_PIN_CONFIGS(PINCONFS_SPI4);
     } else if (clock->number == PIN_EMMC_CLK &&
                (mosi == NULL || mosi->number == PIN_EMMC_DATA0) &&
                (miso == NULL || miso->number == PIN_EMMC_DATA1)) {
         port = 5;
+        CXD56_PIN_CONFIGS(PINCONFS_EMMCA_SPI5);
     }
 
     if (port < 0) {

--- a/ports/cxd56/common-hal/busio/UART.c
+++ b/ports/cxd56/common-hal/busio/UART.c
@@ -59,6 +59,9 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     uint32_t baudrate, uint8_t bits, busio_uart_parity_t parity, uint8_t stop,
     mp_float_t timeout, uint16_t receiver_buffer_size, byte* receiver_buffer,
     bool sigint_enabled) {
+    int i;
+    int count;
+    char tmp;
     struct termios tio;
 
     if ((rts != NULL) || (cts != NULL) || (rs485_dir != NULL) || (rs485_invert)) {
@@ -95,6 +98,14 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         busio_uart_dev[self->number].fd = open(busio_uart_dev[self->number].devpath, O_RDWR);
         if (busio_uart_dev[self->number].fd < 0) {
             mp_raise_ValueError(translate("Could not initialize UART"));
+        }
+
+        // Wait to make sure the UART is ready
+        usleep(1000);
+        // Clear RX FIFO
+        ioctl(busio_uart_dev[self->number].fd, FIONREAD, (long unsigned int)&count);
+        for (i = 0; i < count; i++) {
+            read(busio_uart_dev[self->number].fd, &tmp, 1);
         }
     }
 


### PR DESCRIPTION
After a soft restart, the pins change to gpio mode. After re-initialization, change the pin mode to spi or i2c.

Empty rx uart fifo to remove characters that were received during initialization.

