### PR TITLE
displayio.Bitmap: Make memoryview()able

### DIFF
--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -37,7 +37,15 @@
 #include "supervisor/shared/translate.h"
 
 //| class Bitmap:
-//|     """Stores values of a certain size in a 2D array"""
+//|     """Stores values of a certain size in a 2D array
+//|
+//| Bitmaps can be treated as read-only buffers. If the number of bits in a pixel is 8, 16, or 32; and the number of bytes
+//| per row is a multiple of 4, then the resulting memoryview will correspond directly with the bitmap's contents. Otherwise,
+//| the bitmap data is packed into the memoryview with unspecified padding.
+//|
+//| A read-only buffer can be used e.g., with `ulab.fromarray` to efficiently create an array with the same content as a Bitmap;
+//| to move data efficiently from ulab back into a Bitmap, use `bitmaptools.arrayblit`.
+//| """
 //|
 //|     def __init__(self, width: int, height: int, value_count: int) -> None:
 //|         """Create a Bitmap object with the given fixed size. Each pixel stores a value that is used to
@@ -300,10 +308,17 @@ STATIC const mp_rom_map_elem_t displayio_bitmap_locals_dict_table[] = {
 };
 STATIC MP_DEFINE_CONST_DICT(displayio_bitmap_locals_dict, displayio_bitmap_locals_dict_table);
 
+// (the get_buffer protocol returns 0 for success, 1 for failure)
+STATIC mp_int_t bitmap_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_uint_t flags) {
+    displayio_bitmap_t *self = MP_OBJ_TO_PTR(self_in);
+    return common_hal_displayio_bitmap_get_buffer(self, bufinfo, flags);
+}
+
 const mp_obj_type_t displayio_bitmap_type = {
     { &mp_type_type },
     .name = MP_QSTR_Bitmap,
     .make_new = displayio_bitmap_make_new,
     .subscr = bitmap_subscr,
     .locals_dict = (mp_obj_dict_t *)&displayio_bitmap_locals_dict,
+    .buffer_p = { .get_buffer = bitmap_get_buffer },
 };

--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -43,7 +43,7 @@
 //| per row is a multiple of 4, then the resulting memoryview will correspond directly with the bitmap's contents. Otherwise,
 //| the bitmap data is packed into the memoryview with unspecified padding.
 //|
-//| A read-only buffer can be used e.g., with `ulab.fromarray` to efficiently create an array with the same content as a Bitmap;
+//| A read-only buffer can be used e.g., with `ulab.frombuffer` to efficiently create an array with the same content as a Bitmap;
 //| to move data efficiently from ulab back into a Bitmap, use `bitmaptools.arrayblit`.
 //| """
 //|

--- a/shared-bindings/displayio/Bitmap.h
+++ b/shared-bindings/displayio/Bitmap.h
@@ -45,5 +45,6 @@ void common_hal_displayio_bitmap_blit(displayio_bitmap_t *self, int16_t x, int16
     uint32_t skip_index, bool skip_index_none);
 uint32_t common_hal_displayio_bitmap_get_pixel(displayio_bitmap_t *bitmap, int16_t x, int16_t y);
 void common_hal_displayio_bitmap_fill(displayio_bitmap_t *bitmap, uint32_t value);
+int common_hal_displayio_bitmap_get_buffer(displayio_bitmap_t *self, mp_buffer_info_t *bufinfo, mp_uint_t flags);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_BITMAP_H

--- a/shared-module/displayio/Bitmap.c
+++ b/shared-module/displayio/Bitmap.c
@@ -271,3 +271,23 @@ void common_hal_displayio_bitmap_fill(displayio_bitmap_t *self, uint32_t value) 
         self->data[i] = word;
     }
 }
+
+int common_hal_displayio_bitmap_get_buffer(displayio_bitmap_t *self, mp_buffer_info_t *bufinfo, mp_uint_t flags) {
+    if (flags & MP_BUFFER_WRITE) {
+        return 1;
+    }
+    bufinfo->len = self->stride * self->height * sizeof(size_t);
+    bufinfo->buf = self->data;
+    switch (self->bits_per_value) {
+        case 32:
+            bufinfo->typecode = 'I';
+            break;
+        case 16:
+            bufinfo->typecode = 'H';
+            break;
+        default:
+            bufinfo->typecode = 'B';
+            break;
+    }
+    return 0;
+}


### PR DESCRIPTION
This makes a displayio.Bitmap usable as a read-only buffer.
It enables this to work:
```>>> b=displayio.Bitmap(8,8,65536)
>>> b[0] = 32
>>> b[1] = 64
>>> b[8] = 64
>>> ulab.frombuffer(b, dtype=ulab.uint16).reshape((8,8))
array([[32, 64, 0, 0, 0, 0, 0, 0],
       [64, 0, 0, 0, 0, 0, 0, 0],
       [0, 0, 0, 0, 0, 0, 0, 0],
       [0, 0, 0, 0, 0, 0, 0, 0],
       [0, 0, 0, 0, 0, 0, 0, 0],
       [0, 0, 0, 0, 0, 0, 0, 0],
       [0, 0, 0, 0, 0, 0, 0, 0],
       [0, 0, 0, 0, 0, 0, 0, 0]], dtype=uint16)
```

By having a buffer-like Bitmap we can now get bitmap data INTO ulab efficiently, just as we recently became able to get it OUT efficiently by addng `bitmaptools.arrayblit`.

The docs explain that this is really only "defined" for 8/16/32-bit bitmaps where a row is a multiple of 4 bytes. For other cases, we pack bits in odd ways, and/or add padding bytes to the end of a row. I could throw an error in these cases instead, or we could fully document the in-memory format of the bitmap.  I'm open to thoughts.