### PR TITLE
arrayblit: mark bitmap area as dirty

### DIFF
--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -401,6 +401,7 @@ void common_hal_bitmaptools_arrayblit(displayio_bitmap_t *self, void *data, int 
             }
         }
     }
+    displayio_bitmap_set_dirty_area(self, x1, y1, x2, y2);
 }
 
 void common_hal_bitmaptools_readinto(displayio_bitmap_t *self, pyb_file_obj_t *file, int element_size, int bits_per_pixel, bool reverse_pixels_in_element, bool swap_bytes) {


### PR DESCRIPTION
In https://github.com/adafruit/circuitpython/pull/4403#issuecomment-801546317, @dglaude reported that the screen wasn't updating.  This is due to forgetting to mark the target of the arrayblit operation as "dirty".