### PR TITLE
Bitmap dirty improvements

### DIFF
--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -195,7 +195,7 @@ void common_hal_bitmaptools_rotozoom(displayio_bitmap_t *self, int16_t ox, int16
     float rowu = startu + miny * duCol;
     float rowv = startv + miny * dvCol;
 
-    displayio_area_t dirty_area = {minx, miny, maxx, maxy};
+    displayio_area_t dirty_area = {minx, miny, maxx + 1, maxy + 1};
     displayio_bitmap_set_dirty_area(self, &dirty_area);
 
     for (y = miny; y <= maxy; y++) {

--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -401,6 +401,7 @@ void common_hal_bitmaptools_arrayblit(displayio_bitmap_t *self, void *data, int 
             }
         }
     }
+    displayio_bitmap_set_dirty_area(self, x1, y1, x2, y2);
 }
 
 void common_hal_bitmaptools_readinto(displayio_bitmap_t *self, pyb_file_obj_t *file, int element_size, int bits_per_pixel, bool reverse_pixels_in_element, bool swap_bytes) {

--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -205,7 +205,7 @@ void common_hal_bitmaptools_rotozoom(displayio_bitmap_t *self, int16_t ox, int16
             if (u >= source_clip0_x && u < source_clip1_x && v >= source_clip0_y && v < source_clip1_y) {
                 uint32_t c = common_hal_displayio_bitmap_get_pixel(source, u, v);
                 if ((skip_index_none) || (c != skip_index)) {
-                    common_hal_displayio_bitmap_set_pixel(self, x, y, c);
+                    displayio_bitmap_write_pixel(self, x, y, c);
                 }
             }
             u += duRow;

--- a/shared-module/displayio/Bitmap.h
+++ b/shared-module/displayio/Bitmap.h
@@ -49,7 +49,7 @@ typedef struct {
 
 void displayio_bitmap_finish_refresh(displayio_bitmap_t *self);
 displayio_area_t *displayio_bitmap_get_refresh_areas(displayio_bitmap_t *self, displayio_area_t *tail);
-void displayio_bitmap_set_dirty_area(displayio_bitmap_t *self, int16_t x1, int16_t y1, int16_t x2, int16_t y2);
+void displayio_bitmap_set_dirty_area(displayio_bitmap_t *self, const displayio_area_t *area);
 void displayio_bitmap_write_pixel(displayio_bitmap_t *self, int16_t x, int16_t y, uint32_t value);
 
 #endif // MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_BITMAP_H

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -320,6 +320,19 @@ bool displayio_area_empty(const displayio_area_t *a) {
     return (a->x1 == a->x2) || (a->y1 == a->y2);
 }
 
+void displayio_area_canon(displayio_area_t *a) {
+    if (a->x1 < a->x2) {
+        int16_t t = a->x1;
+        a->x1 = a->x2;
+        a->x2 = t;
+    }
+    if (a->y1 < a->y2) {
+        int16_t t = a->y1;
+        a->y1 = a->y2;
+        a->y2 = t;
+    }
+}
+
 void displayio_area_union(const displayio_area_t *a,
     const displayio_area_t *b,
     displayio_area_t *u) {

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -309,26 +309,33 @@ bool displayio_area_compute_overlap(const displayio_area_t *a,
     return true;
 }
 
+void displayio_copy_coords(const displayio_area_t *src, displayio_area_t *dest) {
+    dest->x1 = src->x1;
+    dest->y1 = src->y1;
+    dest->x2 = src->x2;
+    dest->y2 = src->y2;
+}
+
+bool displayio_area_empty(const displayio_area_t *a) {
+    return (a->x1 == a->x2) || (a->y1 == a->y2);
+}
+
 void displayio_area_union(const displayio_area_t *a,
     const displayio_area_t *b,
     displayio_area_t *u) {
-    u->x1 = a->x1;
-    if (b->x1 < u->x1) {
-        u->x1 = b->x1;
-    }
-    u->x2 = a->x2;
-    if (b->x2 > u->x2) {
-        u->x2 = b->x2;
-    }
 
-    u->y1 = a->y1;
-    if (b->y1 < u->y1) {
-        u->y1 = b->y1;
+    if (displayio_area_empty(a)) {
+        displayio_copy_coords(b, u);
+        return;
     }
-    u->y2 = a->y2;
-    if (b->y2 > u->y2) {
-        u->y2 = b->y2;
+    if (displayio_area_empty(b)) {
+        displayio_copy_coords(a, u);
+        return;
     }
+    u->x1 = MIN(a->x1, b->x1);
+    u->y1 = MIN(a->y1, b->y1);
+    u->x2 = MAX(a->x2, b->x2);
+    u->y2 = MAX(a->y2, b->y2);
 }
 
 uint16_t displayio_area_width(const displayio_area_t *area) {

--- a/shared-module/displayio/area.h
+++ b/shared-module/displayio/area.h
@@ -53,6 +53,8 @@ typedef struct {
 
 extern displayio_buffer_transform_t null_transform;
 
+bool displayio_area_empty(const displayio_area_t *a);
+void displayio_area_copy_coords(const displayio_area_t *src, displayio_area_t *dest);
 void displayio_area_union(const displayio_area_t *a,
     const displayio_area_t *b,
     displayio_area_t *u);

--- a/shared-module/displayio/area.h
+++ b/shared-module/displayio/area.h
@@ -55,6 +55,7 @@ extern displayio_buffer_transform_t null_transform;
 
 bool displayio_area_empty(const displayio_area_t *a);
 void displayio_area_copy_coords(const displayio_area_t *src, displayio_area_t *dest);
+void displayio_area_canon(displayio_area_t *a);
 void displayio_area_union(const displayio_area_t *a,
     const displayio_area_t *b,
     displayio_area_t *u);


### PR DESCRIPTION
In #4430, @kmatch98 raised an issue where calling `displayio_bitmap_set_dirty_area` with an "empty area" could in fact dirty some pixels.

This made me start looking in the code for ways to make the C APIs more resistant to misuse.  To that end, I
 * Added more area helpers (`canon`, `copy_coords` and `area_empty`)
   * `canon` swaps the coordinates of an area if necessary to make it "**canon**ical"
   * `copy_coords` copies the x1/y1/x2/y2 coordinates of one area (but not its 'next' pointer) to another
   * `empty_area` is a predicate that returns true if the area is empty, false otherwise
 * Improve `displayio_area_union` so that it handles the union of empty areas properly (if one area is empty, the result is the other area's coords)
 * make `displayio_bitmap_set_dirty_area` use `displayio_area` routines
   * taking in an area structure also improves code size a bit, at the expense of requiring temporary variables in callers
 * the area computed in this way can also be used in some of the bitmap routines to remove redundant code & calculations (see `fill_region`)
 * Moved the responsibility for read-only checking to `displayio_bitmap_set_dirty_area`
 * converted rotozoom to use `set_dirty_area` + `write_pixel` instead of `bitmap_set_pixel`

The adafruit_feather_rp2040 build got 216 bytes smaller with this change.

I did not _TEST_ this beyond making sure it built, so I'm creating the PR in draft state.