### PR TITLE
OnDiskBitmap palette getter/setters

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -550,6 +550,7 @@ msgstr ""
 #: ports/atmel-samd/common-hal/displayio/ParallelBus.c
 #: ports/esp32s2/common-hal/displayio/ParallelBus.c
 #: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/raspberrypi/common-hal/displayio/ParallelBus.c
 #, c-format
 msgid "Bus pin %d is already in use"
 msgstr ""
@@ -1635,6 +1636,10 @@ msgstr ""
 msgid "Odd parity is not supported"
 msgstr ""
 
+#: shared-module/displayio/OnDiskBitmap.c
+msgid "OnDiskBitmap is raw color, not indexed"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
 msgid "Only 8 or 16 bit mono with "
@@ -1729,7 +1734,6 @@ msgid "PWM slice channel A already in use"
 msgstr ""
 
 #: ports/mimxrt10xx/common-hal/displayio/ParallelBus.c
-#: ports/raspberrypi/common-hal/displayio/ParallelBus.c
 #: ports/stm/common-hal/displayio/ParallelBus.c
 msgid "ParallelBus not yet supported"
 msgstr ""
@@ -3106,6 +3110,14 @@ msgstr ""
 msgid "index is out of bounds"
 msgstr ""
 
+#: shared-module/displayio/OnDiskBitmap.c
+msgid "index is outside OnDiskBitmap palette size"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c
+msgid "index is outside of palette size"
+msgstr ""
+
 #: extmod/ulab/code/numerical/numerical.c
 #: ports/esp32s2/common-hal/pulseio/PulseIn.c py/obj.c
 msgid "index out of range"
@@ -3662,8 +3674,12 @@ msgstr ""
 msgid "palette must be 32 bytes long"
 msgstr ""
 
-#: shared-bindings/displayio/Palette.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/displayio/Palette.c
 msgid "palette_index should be an int"
+msgstr ""
+
+#: shared-bindings/displayio/OnDiskBitmap.c
+msgid "palette_index, palette_value should be an int"
 msgstr ""
 
 #: py/compile.c
@@ -3948,6 +3964,10 @@ msgstr ""
 
 #: extmod/moductypes.c
 msgid "syntax error in uctypes descriptor"
+msgstr ""
+
+#: shared-module/displayio/OnDiskBitmap.c
+msgid "this OnDiskBitmap is raw color, not indexed"
 msgstr ""
 
 #: shared-bindings/touchio/TouchIn.c

--- a/shared-bindings/displayio/OnDiskBitmap.c
+++ b/shared-bindings/displayio/OnDiskBitmap.c
@@ -127,9 +127,56 @@ const mp_obj_property_t displayio_ondiskbitmap_height_obj = {
 
 };
 
+//|     palette_size(self) -> int
+//|     """Returns the OnDiskBitmap's palette size."""
+//|
+STATIC mp_obj_t displayio_ondiskbitmap_obj_palette_size(mp_obj_t self_in) {
+    displayio_ondiskbitmap_t *self = MP_OBJ_TO_PTR(self_in);
+
+    return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_ondiskbitmap_palette_size(self));
+}
+
+MP_DEFINE_CONST_FUN_OBJ_1(displayio_ondiskbitmap_palette_size_obj, displayio_ondiskbitmap_obj_palette_size);
+
+//|     get_palette: (self, palette_index: int) -> int
+//|     """Get the value of the palette value at the specified index.
+//|     Usage: ondiskbitmap.get_palette(palette_index)"""
+//|
+STATIC mp_obj_t displayio_ondiskbitmap_obj_get_palette(mp_obj_t self_in, mp_obj_t palette_index_obj) {
+    displayio_ondiskbitmap_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_int_t palette_index;
+    if (!mp_obj_get_int_maybe(palette_index_obj, &palette_index)) {
+        mp_raise_ValueError(translate("palette_index should be an int"));
+    }
+    return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_ondiskbitmap_get_palette(self, palette_index));
+}
+
+MP_DEFINE_CONST_FUN_OBJ_2(displayio_ondiskbitmap_get_palette_obj, displayio_ondiskbitmap_obj_get_palette);
+
+//|     set_palette: (self, palette_index: int, palette_value: int) -> None
+//|     """Get the value of the palette value at the specified index.
+//|     Usage: ondiskbitmap.set_palette(palette_index, palette_value)"""
+//|
+STATIC mp_obj_t displayio_ondiskbitmap_obj_set_palette(mp_obj_t self_in, mp_obj_t palette_index_obj, mp_obj_t palette_value_obj) {
+    displayio_ondiskbitmap_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_int_t palette_index, palette_value;
+    if ((!mp_obj_get_int_maybe(palette_index_obj, &palette_index)) ||
+        (!mp_obj_get_int_maybe(palette_value_obj, &palette_value))) {
+        mp_raise_ValueError(translate("palette_index, palette_value should be an int"));
+    }
+    common_hal_displayio_ondiskbitmap_set_palette(self, palette_index, palette_value);
+    return mp_const_none;
+}
+
+MP_DEFINE_CONST_FUN_OBJ_3(displayio_ondiskbitmap_set_palette_obj, displayio_ondiskbitmap_obj_set_palette);
+
+
 STATIC const mp_rom_map_elem_t displayio_ondiskbitmap_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&displayio_ondiskbitmap_height_obj) },
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&displayio_ondiskbitmap_width_obj) },
+    { MP_ROM_QSTR(MP_QSTR_palette_size), MP_ROM_PTR(&displayio_ondiskbitmap_palette_size_obj) },
+    { MP_ROM_QSTR(MP_QSTR_get_palette), MP_ROM_PTR(&displayio_ondiskbitmap_get_palette_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_palette), MP_ROM_PTR(&displayio_ondiskbitmap_set_palette_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(displayio_ondiskbitmap_locals_dict, displayio_ondiskbitmap_locals_dict_table);
 

--- a/shared-bindings/displayio/OnDiskBitmap.c
+++ b/shared-bindings/displayio/OnDiskBitmap.c
@@ -127,8 +127,9 @@ const mp_obj_property_t displayio_ondiskbitmap_height_obj = {
 
 };
 
-//|     palette_size(self) -> int
-//|     """Returns the OnDiskBitmap's palette size."""
+//|     def palette_size(self) -> int:
+//|         """Returns the OnDiskBitmap palette size."""
+//|         ...
 //|
 STATIC mp_obj_t displayio_ondiskbitmap_obj_palette_size(mp_obj_t self_in) {
     displayio_ondiskbitmap_t *self = MP_OBJ_TO_PTR(self_in);
@@ -138,9 +139,9 @@ STATIC mp_obj_t displayio_ondiskbitmap_obj_palette_size(mp_obj_t self_in) {
 
 MP_DEFINE_CONST_FUN_OBJ_1(displayio_ondiskbitmap_palette_size_obj, displayio_ondiskbitmap_obj_palette_size);
 
-//|     get_palette: (self, palette_index: int) -> int
-//|     """Get the value of the palette value at the specified index.
-//|     Usage: ondiskbitmap.get_palette(palette_index)"""
+//|     def get_palette(self, palette_index: int) -> int:
+//|         """Get the color value of the palette value at the specified index."""
+//|         ...
 //|
 STATIC mp_obj_t displayio_ondiskbitmap_obj_get_palette(mp_obj_t self_in, mp_obj_t palette_index_obj) {
     displayio_ondiskbitmap_t *self = MP_OBJ_TO_PTR(self_in);
@@ -153,9 +154,9 @@ STATIC mp_obj_t displayio_ondiskbitmap_obj_get_palette(mp_obj_t self_in, mp_obj_
 
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_ondiskbitmap_get_palette_obj, displayio_ondiskbitmap_obj_get_palette);
 
-//|     set_palette: (self, palette_index: int, palette_value: int) -> None
-//|     """Get the value of the palette value at the specified index.
-//|     Usage: ondiskbitmap.set_palette(palette_index, palette_value)"""
+//|     def set_palette(self, palette_index: int, palette_value: int) -> None:
+//|         """Set the color value of the palette at the specified index."""
+//|         ...
 //|
 STATIC mp_obj_t displayio_ondiskbitmap_obj_set_palette(mp_obj_t self_in, mp_obj_t palette_index_obj, mp_obj_t palette_value_obj) {
     displayio_ondiskbitmap_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/displayio/OnDiskBitmap.h
+++ b/shared-bindings/displayio/OnDiskBitmap.h
@@ -40,4 +40,14 @@ uint32_t common_hal_displayio_ondiskbitmap_get_pixel(displayio_ondiskbitmap_t *b
 uint16_t common_hal_displayio_ondiskbitmap_get_height(displayio_ondiskbitmap_t *self);
 
 uint16_t common_hal_displayio_ondiskbitmap_get_width(displayio_ondiskbitmap_t *self);
+
+uint16_t common_hal_displayio_ondiskbitmap_palette_size(displayio_ondiskbitmap_t *self);
+
+uint32_t common_hal_displayio_ondiskbitmap_get_palette(displayio_ondiskbitmap_t *self, uint32_t palette_index);
+
+void common_hal_displayio_ondiskbitmap_set_palette(displayio_ondiskbitmap_t *self, uint32_t palette_index, uint32_t palette_value);
+
+bool displayio_ondiskbitmap_needs_refresh(displayio_ondiskbitmap_t *self);
+
+void displayio_ondiskbitmap_finish_refresh(displayio_ondiskbitmap_t *self);
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_ONDISKBITMAP_H

--- a/shared-module/displayio/OnDiskBitmap.h
+++ b/shared-module/displayio/OnDiskBitmap.h
@@ -46,7 +46,9 @@ typedef struct {
     bool bitfield_compressed;
     pyb_file_obj_t *file;
     uint8_t bits_per_pixel;
+    uint16_t palette_size;
     uint32_t *palette_data;
+    bool full_refresh;
 } displayio_ondiskbitmap_t;
 
 #endif // MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_ONDISKBITMAP_H

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -522,8 +522,9 @@ void displayio_tilegrid_finish_refresh(displayio_tilegrid_t *self) {
     } else if (MP_OBJ_IS_TYPE(self->bitmap, &displayio_shape_type)) {
         displayio_shape_finish_refresh(self->bitmap);
     } else if (MP_OBJ_IS_TYPE(self->bitmap, &displayio_ondiskbitmap_type)) {
-        // OnDiskBitmap changes will trigger a complete reload so no need to
-        // track changes.
+        displayio_ondiskbitmap_finish_refresh(self->bitmap);
+        //
+        // OnDiskBitmap palette changes will need a complete reload.
     }
     // TODO(tannewt): We could double buffer changes to position and move them over here.
     // That way they won't change during a refresh and tear.
@@ -576,7 +577,9 @@ displayio_area_t *displayio_tilegrid_get_refresh_areas(displayio_tilegrid_t *sel
         (MP_OBJ_IS_TYPE(self->pixel_shader, &displayio_palette_type) &&
             displayio_palette_needs_refresh(self->pixel_shader)) ||
         (MP_OBJ_IS_TYPE(self->pixel_shader, &displayio_colorconverter_type) &&
-            displayio_colorconverter_needs_refresh(self->pixel_shader));
+            displayio_colorconverter_needs_refresh(self->pixel_shader)) ||
+        (MP_OBJ_IS_TYPE(self->bitmap, &displayio_ondiskbitmap_type) &&
+            displayio_ondiskbitmap_needs_refresh(self->bitmap));
     if (self->full_change || first_draw) {
         self->current_area.next = tail;
         return &self->current_area;


### PR DESCRIPTION

This is an addition to add color palette getters/setters for the OnDiskBitmap.  This will allow for palete animations/color cycling for bitmaps without having to load them into RAM.

Also, this adds a flag that provides an option to force refresh of an OnDiskBitmap whenever the palette is modified.

-------------
This work was spurred out of an exploration of animated icons.  @FoamyGuy demonstrated that using OnDiskBitmap allowed loading of significantly more images for the "TouchDeck" project, however currently there is no way of adjusting the color palette.  This addition allows modifications of an OnDiskBitmap's color palette to achieve these types of color cycling animations.

This capability probably has a relative small set of use cases, so if feedback is that this should be put on hold, I'm perfectly fine to park this one, and it will reside here for posterity.

-------
This allows OnDiskBitmap to do these kinds of palette animations:
![Adafruit_logo  - OnDiskBitmap palette cycling](https://user-images.githubusercontent.com/33587466/111730616-cbe48380-883f-11eb-9c72-1898b903a36d.gif)