### PR TITLE
metro m7: another place to fix flash capacity

### DIFF
--- a/ports/mimxrt10xx/boards/metro_m7_1011/flash_config.c
+++ b/ports/mimxrt10xx/boards/metro_m7_1011/flash_config.c
@@ -36,7 +36,7 @@ const BOOT_DATA_T boot_data = {
     0xFFFFFFFF                /* empty - extra data word */
 };
 
-// Config for W25Q16JV with QSPI routed.
+// Config for W25Q32JV with QSPI routed. (compatible with GD25Q32)
 __attribute__((section(".boot_hdr.conf")))
 const flexspi_nor_config_t qspiflash_config = {
     .pageSize = 256u,

--- a/ports/mimxrt10xx/boards/metro_m7_1011/mpconfigboard.h
+++ b/ports/mimxrt10xx/boards/metro_m7_1011/mpconfigboard.h
@@ -7,7 +7,7 @@
 // make sure you don't overwrite code
 #define CIRCUITPY_INTERNAL_NVM_SIZE 0
 
-#define BOARD_FLASH_SIZE (2 * 1024 * 1024)
+#define BOARD_FLASH_SIZE (4 * 1024 * 1024)
 
 #define DEFAULT_I2C_BUS_SCL (&pin_GPIO_02)
 #define DEFAULT_I2C_BUS_SDA (&pin_GPIO_01)


### PR DESCRIPTION
@ladyada this is one of the possible causes of being unable to write more than 1MB to the Metro M7 with GD25Q32 flash fitted