### PR TITLE
update bitmask for 4-bit colors

### DIFF
--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -441,7 +441,7 @@ void common_hal_bitmaptools_readinto(displayio_bitmap_t *self, pyb_file_obj_t *f
                     int byte_offset = x / 2;
                     int bit_offset = 4 * (reverse_pixels_in_element ? (1 - x % 2) : x % 2);
 
-                    value = (rowdata8[byte_offset] >> bit_offset) & 7;
+                    value = (rowdata8[byte_offset] >> bit_offset) & 15;
                     break;
                 }
                 case 8:


### PR DESCRIPTION
This updates the bitmask for 4-bit colors, to allow proper color loading of 4-bit bitmaps.