### PR TITLE
QTPY RP2040 - add USBBOOT switch, move RX pin, re-enable UART (tested)

### DIFF
--- a/ports/raspberrypi/boards/qtpy_rp2040/mpconfigboard.h
+++ b/ports/raspberrypi/boards/qtpy_rp2040/mpconfigboard.h
@@ -10,8 +10,8 @@
 #define DEFAULT_SPI_BUS_MOSI (&pin_GPIO3)
 #define DEFAULT_SPI_BUS_MISO (&pin_GPIO4)
 
-// #define DEFAULT_UART_BUS_RX (&pin_PA11)
-// #define DEFAULT_UART_BUS_TX (&pin_PA10)
+#define DEFAULT_UART_BUS_RX (&pin_GPIO5)
+#define DEFAULT_UART_BUS_TX (&pin_GPIO20)
 
 // Flash chip is GD25Q64 connected over QSPI
 #define TOTAL_FLASH_SIZE (8 * 1024 * 1024)

--- a/ports/raspberrypi/boards/qtpy_rp2040/pins.c
+++ b/ports/raspberrypi/boards/qtpy_rp2040/pins.c
@@ -22,8 +22,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO20) },
     { MP_ROM_QSTR(MP_QSTR_D6), MP_ROM_PTR(&pin_GPIO20) },
 
-    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO9) },
-    { MP_ROM_QSTR(MP_QSTR_D7), MP_ROM_PTR(&pin_GPIO9) },
+    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO5) },
+    { MP_ROM_QSTR(MP_QSTR_D7), MP_ROM_PTR(&pin_GPIO5) },
 
     { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_GPIO6) },
     { MP_ROM_QSTR(MP_QSTR_D8), MP_ROM_PTR(&pin_GPIO6) },
@@ -37,13 +37,13 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO12) },
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL_POWER), MP_ROM_PTR(&pin_GPIO11) },
 
+    { MP_ROM_QSTR(MP_QSTR_SWITCH), MP_ROM_PTR(&pin_GPIO21) },
 
     { MP_ROM_QSTR(MP_QSTR_SDA1), MP_ROM_PTR(&pin_GPIO22) },
     { MP_ROM_QSTR(MP_QSTR_SCL1), MP_ROM_PTR(&pin_GPIO23) },
 
-
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
-    // { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);


### PR DESCRIPTION
final hardware , hurrah!