### PR TITLE
PulseIn: add frequency selection

### DIFF
--- a/ports/atmel-samd/common-hal/pulseio/PulseIn.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseIn.c
@@ -145,7 +145,7 @@ void pulsein_reset() {
 }
 
 void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
-        const mcu_pin_obj_t* pin, uint16_t maxlen, bool idle_state) {
+        const mcu_pin_obj_t* pin, uint32_t frequency, uint16_t maxlen, bool idle_state) {
     if (!pin->has_extint) {
         mp_raise_RuntimeError(translate("No hardware support on pin"));
     }
@@ -322,6 +322,10 @@ uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t* self) {
 
 uint16_t common_hal_pulseio_pulsein_get_maxlen(pulseio_pulsein_obj_t* self) {
     return self->maxlen;
+}
+
+uint32_t common_hal_pulseio_pulsein_get_frequency(pulseio_pulsein_obj_t* self) {
+    return 1000000;
 }
 
 uint16_t common_hal_pulseio_pulsein_get_len(pulseio_pulsein_obj_t* self) {

--- a/ports/cxd56/common-hal/pulseio/PulseIn.c
+++ b/ports/cxd56/common-hal/pulseio/PulseIn.c
@@ -83,8 +83,8 @@ static int pulsein_interrupt_handler(int irq, FAR void *context, FAR void *arg) 
     return 0;
 }
 
-void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
-    const mcu_pin_obj_t *pin, uint16_t maxlen, bool idle_state) {
+void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
+        const mcu_pin_obj_t* pin, uint32_t frequency, uint16_t maxlen, bool idle_state) {
     self->buffer = (uint16_t *)m_malloc(maxlen * sizeof(uint16_t), false);
     if (self->buffer == NULL) {
         mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"), maxlen * sizeof(uint16_t));
@@ -173,6 +173,10 @@ uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t *self) {
 
 uint16_t common_hal_pulseio_pulsein_get_maxlen(pulseio_pulsein_obj_t *self) {
     return self->maxlen;
+}
+
+uint32_t common_hal_pulseio_pulsein_get_frequency(pulseio_pulsein_obj_t* self) {
+    return 1000000;
 }
 
 bool common_hal_pulseio_pulsein_get_paused(pulseio_pulsein_obj_t *self) {

--- a/ports/esp32s2/common-hal/pulseio/PulseIn.c
+++ b/ports/esp32s2/common-hal/pulseio/PulseIn.c
@@ -83,8 +83,8 @@ void pulsein_reset(void) {
     refcount = 0;
 }
 
-void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu_pin_obj_t *pin,
-    uint16_t maxlen, bool idle_state) {
+void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
+        const mcu_pin_obj_t* pin, uint32_t frequency, uint16_t maxlen, bool idle_state) {
     self->buffer = (uint16_t *)m_malloc(maxlen * sizeof(uint16_t), false);
     if (self->buffer == NULL) {
         mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"), maxlen * sizeof(uint16_t));
@@ -201,6 +201,10 @@ uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t *self) {
 
 uint16_t common_hal_pulseio_pulsein_get_maxlen(pulseio_pulsein_obj_t *self) {
     return self->maxlen;
+}
+
+uint32_t common_hal_pulseio_pulsein_get_frequency(pulseio_pulsein_obj_t* self) {
+    return 1000000;
 }
 
 bool common_hal_pulseio_pulsein_get_paused(pulseio_pulsein_obj_t *self) {

--- a/ports/mimxrt10xx/common-hal/pulseio/PulseIn.c
+++ b/ports/mimxrt10xx/common-hal/pulseio/PulseIn.c
@@ -101,8 +101,8 @@
 //    self->last_us = current_us;
 // }
 
-void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
-    const mcu_pin_obj_t *pin, uint16_t maxlen, bool idle_state) {
+void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
+        const mcu_pin_obj_t* pin, uint32_t frequency, uint16_t maxlen, bool idle_state) {
 //    if (!pin->has_extint) {
 //        mp_raise_RuntimeError(translate("No hardware support on pin"));
 //    }
@@ -216,6 +216,10 @@ uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t *self) {
 uint16_t common_hal_pulseio_pulsein_get_maxlen(pulseio_pulsein_obj_t *self) {
 //    return self->maxlen;
     return 0;
+}
+
+uint32_t common_hal_pulseio_pulsein_get_frequency(pulseio_pulsein_obj_t* self) {
+    return 1000000;
 }
 
 uint16_t common_hal_pulseio_pulsein_get_len(pulseio_pulsein_obj_t *self) {

--- a/ports/nrf/common-hal/pulseio/PulseIn.c
+++ b/ports/nrf/common-hal/pulseio/PulseIn.c
@@ -125,7 +125,8 @@ void pulsein_reset(void) {
     memset(_objs, 0, sizeof(_objs));
 }
 
-void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu_pin_obj_t *pin, uint16_t maxlen, bool idle_state) {
+void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
+        const mcu_pin_obj_t* pin, uint32_t frequency, uint16_t maxlen, bool idle_state) {
     int idx = _find_pulsein_obj(NULL);
     if (idx < 0) {
         mp_raise_NotImplementedError(NULL);
@@ -306,6 +307,10 @@ uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t *self) {
 
 uint16_t common_hal_pulseio_pulsein_get_maxlen(pulseio_pulsein_obj_t *self) {
     return self->maxlen;
+}
+
+uint32_t common_hal_pulseio_pulsein_get_frequency(pulseio_pulsein_obj_t* self) {
+    return 1000000;
 }
 
 bool common_hal_pulseio_pulsein_get_paused(pulseio_pulsein_obj_t *self) {

--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.c
@@ -49,7 +49,7 @@ uint16_t pulsein_program[] = {
 };
 
 void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
-    const mcu_pin_obj_t *pin, uint16_t maxlen, bool idle_state) {
+    const mcu_pin_obj_t *pin, uint32_t frequency, uint16_t maxlen, bool idle_state) {
 
     self->buffer = (uint16_t *)m_malloc(maxlen * sizeof(uint16_t), false);
     if (self->buffer == NULL) {
@@ -67,7 +67,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
 
     bool ok = rp2pio_statemachine_construct(&state_machine,
         pulsein_program, sizeof(pulsein_program) / sizeof(pulsein_program[0]),
-        1000000,
+        frequency,
         NULL, 0,
         NULL, 0,
         pin, 1,
@@ -204,6 +204,10 @@ uint16_t common_hal_pulseio_pulsein_get_maxlen(pulseio_pulsein_obj_t *self) {
 
 uint16_t common_hal_pulseio_pulsein_get_len(pulseio_pulsein_obj_t *self) {
     return self->len;
+}
+
+uint32_t common_hal_pulseio_pulsein_get_frequency(pulseio_pulsein_obj_t *self) {
+    return common_hal_rp2pio_statemachine_get_frequency(&self->state_machine);
 }
 
 bool common_hal_pulseio_pulsein_get_paused(pulseio_pulsein_obj_t *self) {

--- a/ports/stm/common-hal/pulseio/PulseIn.c
+++ b/ports/stm/common-hal/pulseio/PulseIn.c
@@ -108,8 +108,8 @@ void pulsein_reset(void) {
     refcount = 0;
 }
 
-void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu_pin_obj_t *pin,
-    uint16_t maxlen, bool idle_state) {
+void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t* self,
+        const mcu_pin_obj_t* pin, uint32_t frequency, uint16_t maxlen, bool idle_state) {
     // STM32 has one shared EXTI for each pin number, 0-15
     uint8_t p_num = pin->number;
     if (_objs[p_num]) {
@@ -270,6 +270,10 @@ uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t *self) {
 
 uint16_t common_hal_pulseio_pulsein_get_maxlen(pulseio_pulsein_obj_t *self) {
     return self->maxlen;
+}
+
+uint32_t common_hal_pulseio_pulsein_get_frequency(pulseio_pulsein_obj_t* self) {
+    return 1000000;
 }
 
 bool common_hal_pulseio_pulsein_get_paused(pulseio_pulsein_obj_t *self) {

--- a/shared-bindings/pulseio/PulseIn.h
+++ b/shared-bindings/pulseio/PulseIn.h
@@ -33,13 +33,14 @@
 extern const mp_obj_type_t pulseio_pulsein_type;
 
 extern void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
-    const mcu_pin_obj_t *pin, uint16_t maxlen, bool idle_state);
+    const mcu_pin_obj_t *pin, uint32_t frequency, uint16_t maxlen, bool idle_state);
 extern void common_hal_pulseio_pulsein_deinit(pulseio_pulsein_obj_t *self);
 extern bool common_hal_pulseio_pulsein_deinited(pulseio_pulsein_obj_t *self);
 extern void common_hal_pulseio_pulsein_pause(pulseio_pulsein_obj_t *self);
 extern void common_hal_pulseio_pulsein_resume(pulseio_pulsein_obj_t *self, uint16_t trigger_duration);
 extern void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t *self);
 extern uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t *self);
+extern uint32_t common_hal_pulseio_pulsein_get_frequency(pulseio_pulsein_obj_t *self);
 extern uint16_t common_hal_pulseio_pulsein_get_maxlen(pulseio_pulsein_obj_t *self);
 extern bool common_hal_pulseio_pulsein_get_paused(pulseio_pulsein_obj_t *self);
 extern uint16_t common_hal_pulseio_pulsein_get_len(pulseio_pulsein_obj_t *self);


### PR DESCRIPTION
.. implemented only on raspberrypi, where it's easiest.  If this is considered useful enough, we can potentially implement it on at least SOME other ports.  However, each port is a bit different so for now I just made them ignore the frequency= constructor parameter and return 1_000_000 for the frequency property.

This is useful to me because using a frequency of 1000 lets me track the length of WWWB symbols, which are from 200ms to 800ms long.