### PR TITLE
storage: Correct when we check for USB mounts

### DIFF
--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -149,7 +149,7 @@ void common_hal_storage_remount(const char *mount_path, bool readonly, bool disa
         mp_raise_OSError(MP_EINVAL);
     }
 
-    #ifdef USB_AVAILABLE
+    #if CIRCUITPY_USB_MSC
     if (!usb_msc_ejected()) {
         mp_raise_RuntimeError(translate("Cannot remount '/' when USB is active."));
     }

--- a/supervisor/usb.h
+++ b/supervisor/usb.h
@@ -54,8 +54,10 @@ void usb_init(void);
 void usb_disconnect(void);
 
 // Propagate plug/unplug events to the MSC logic.
+#if CIRCUITPY_USB_MSC
 void usb_msc_mount(void);
 void usb_msc_umount(void);
 bool usb_msc_ejected(void);
+#endif
 
 #endif // MICROPY_INCLUDED_SUPERVISOR_USB_H


### PR DESCRIPTION
Closes #4417

I only compile-tested this for feather rp2040 with 
```diff
diff --git a/ports/raspberrypi/boards/adafruit_feather_rp2040/mpconfigboard.mk b/ports/raspberrypi/boards/adafruit_feather_rp2040/mpconfigboard.mk
index f4106b94a..f891c3668 100644
--- a/ports/raspberrypi/boards/adafruit_feather_rp2040/mpconfigboard.mk
+++ b/ports/raspberrypi/boards/adafruit_feather_rp2040/mpconfigboard.mk
@@ -7,3 +7,5 @@ CHIP_VARIANT = RP2040
 CHIP_FAMILY = rp2
 
 INTERNAL_FLASH_FILESYSTEM = 1
+
+CIRCUITPY_USB_MSC = 0
```

@arielwolle @miclooking please test with this change and let us know if it resolves the problem for you.