### PR TITLE
update logic for displayio.TileGrid's transform_xy

### DIFF
--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -583,7 +583,7 @@ displayio_area_t *displayio_tilegrid_get_refresh_areas(displayio_tilegrid_t *sel
     }
 
     if (self->partial_change) {
-        if (self->absolute_transform->transpose_xy) {
+        if (self->transpose_xy != self->absolute_transform->transpose_xy) {
             int16_t x1 = self->dirty_area.x1;
             self->dirty_area.x1 = self->absolute_transform->x + self->absolute_transform->dx * (self->y + self->dirty_area.y1);
             self->dirty_area.y1 = self->absolute_transform->y + self->absolute_transform->dy * (self->x + x1);


### PR DESCRIPTION
This resolves an error in redrawing when using `transform_xy` with `displayio.TileGrid`, referenced in issue https://github.com/adafruit/circuitpython/issues/4450.

The logic for `displayio_tilegrid_get_refresh_areas` did not consider the TileGrid's `transform_xy` value and the transform of dirty rectangles was not being performed. 

Here is the result with version `Adafruit CircuitPython 6.2.0-beta.4 on 2021-03-18; Adafruit PyPortal with samd51j20`:
![IMG_7566](https://user-images.githubusercontent.com/33587466/112062451-f7ac8580-8b2d-11eb-8966-b88dacc971cb.jpg)

Here is the result with the updated code in this PR:
![IMG_7567](https://user-images.githubusercontent.com/33587466/112062454-f8ddb280-8b2d-11eb-8713-5b95aeb91615.jpg)


Here is my test code:
```python

import displayio
import board
import time
import math
import gc
from bitmaptools import rotozoom, fill_region
import adafruit_imageload
from _pixelbuf import colorwheel

delay_time=1

display=board.DISPLAY

bmap1 = displayio.Bitmap(150,200, 4)
palette1=displayio.Palette(4)
#palette1.make_transparent(3)
palette1[0]=0xFF0000
palette1[1]=0x00FF00
palette1[2]=0x0000FF
palette1[3]=0x00FFFF

tilegrid1=displayio.TileGrid(bmap1, pixel_shader=palette1)

group1=displayio.Group(max_size=1)
group1.x=20
group1.y=20

#group1.append(tilegrid0)
group1.append(tilegrid1)
display.show(group1)
time.sleep(delay_time)

print('1 change fill color of bitmap to blue')
bmap1.fill(2)
time.sleep(delay_time)

tilegrid1.transpose_xy=True
#tilegrid1.flip_x=True
#tilegrid1.flip_y=True

print('2 write red and light blue into two corners')

for i in range(bmap1.width//2):
    for j in range(bmap1.height//2):
        #print("i,j: {},{}".format(i,j))
        #time.sleep(0.001)
        bmap1[i,j]=0
        bmap1[bmap1.width-i-1, bmap1.height-j-1]=3

print('3 just finished')

time.sleep(10000)
```