### PR TITLE
swap recvfrom_into() port byte-order

### DIFF
--- a/ports/esp32s2/common-hal/socketpool/Socket.c
+++ b/ports/esp32s2/common-hal/socketpool/Socket.c
@@ -229,7 +229,7 @@ mp_uint_t common_hal_socketpool_socket_recvfrom_into(socketpool_socket_obj_t *se
 
     if (!timed_out) {
         memcpy((void *)ip, (void *)&source_addr.sin_addr.s_addr, sizeof(source_addr.sin_addr.s_addr));
-        *port = source_addr.sin_port;
+        *port = htons(source_addr.sin_port);
     } else {
         mp_raise_OSError(ETIMEDOUT);
     }


### PR DESCRIPTION
Addresses UDP server issue https://github.com/adafruit/circuitpython/issues/4445 by changing the `recvfrom_into()` port number into network byte-order, so that `sendto()` replies back to the correct port that a client initiated the transaction from.

Successful sequence:

CircuitPython `socketpool` UDP Server:
```
code.py output:
Connecting to Wifi
Self IP 192.168.6.198
Server ping 192.168.6.198 0.0 ms
Create UDP Server socket ('192.168.6.198', 5000)
```
CPython UDP Client:
```
Create UDP Client Socket
Sent 12 bytes
```
`tcpdump`:
```
20:15:52.771675 IP: (tos 0x0, ttl 64, id 63564, offset 0, flags [none], proto UDP (17), length 40, bad cksum 0 (->f541)!)
    192.168.5.32.61409 > 192.168.6.198.5000: UDP, length 12
```
CircuitPython `socketpool` UDP Server:
```
Received bytearray(b'Hello, world') 12 bytes from ('192.168.5.32', 61409)
Sent bytearray(b'Hello, world') 12 bytes to ('192.168.5.32', 61409)
```
`tcpdump`:
```
20:15:52.885491 IP: (tos 0x0, ttl 255, id 233, offset 0, flags [none], proto UDP (17), length 40)
    192.168.6.198.5000 > 192.168.5.32.61409: UDP, length 12
```
CPython UDP Client:
```
Received bytearray(b'Hello, world') 12 bytes from ('192.168.6.198', 5000)
```
