### PR TITLE
remove duplicate RX/TX pin lines

### DIFF
--- a/ports/mimxrt10xx/boards/metro_m7_1011/pins.c
+++ b/ports/mimxrt10xx/boards/metro_m7_1011/pins.c
@@ -42,10 +42,6 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_GPIO_AD_03) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_GPIO_AD_04) },
 
-    // UART
-    { MP_OBJ_NEW_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO_10) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO_09) },
-
     // I2C
     { MP_OBJ_NEW_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO_01) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO_02) },


### PR DESCRIPTION
These are duplicated above, next to the D0/D1 version of the pins; check out the full file to see it, it's outside the normal diff context.