### PR TITLE
mimxrt: SPI: Set the TCR value returned by MasterBaudSetRate

### DIFF
--- a/ports/mimxrt10xx/common-hal/busio/SPI.c
+++ b/ports/mimxrt10xx/common-hal/busio/SPI.c
@@ -187,6 +187,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     LPSPI_Enable(self->spi, false);
     uint32_t tcrPrescaleValue;
     self->baudrate = LPSPI_MasterSetBaudRate(self->spi, config.baudRate, LPSPI_MASTER_CLK_FREQ, &tcrPrescaleValue);
+    self->spi->TCR = (self->spi->TCR & ~LPSPI_TCR_PRESCALE_MASK) | LPSPI_TCR_PRESCALE(tcrPrescaleValue);
     LPSPI_Enable(self->spi, true);
 
     claim_pin(self->clock->pin);
@@ -236,6 +237,7 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
     LPSPI_Enable(self->spi, false);
     uint32_t tcrPrescaleValue;
     self->baudrate = LPSPI_MasterSetBaudRate(self->spi, baudrate, LPSPI_MASTER_CLK_FREQ, &tcrPrescaleValue);
+    self->spi->TCR = (self->spi->TCR & ~LPSPI_TCR_PRESCALE_MASK) | LPSPI_TCR_PRESCALE(tcrPrescaleValue);
     LPSPI_Enable(self->spi, true);
 
     if ((polarity == common_hal_busio_spi_get_polarity(self)) &&


### PR DESCRIPTION
without this, the baud rate could be wrong; in my testing, it was low by a factor of 2 when requesating baudrate=1_000_000 (1MHz).

When passing the baudrate in to LPSPI_MasterInit, the setting is made automatically, but LPSPI_MAster_SetBaudRate just returns it via the out-parameter tcrPrescaleValue.

This is related to #3062 but is not a solution for it, as there remain long inter-byte gaps.

Now with correct 1MHz SCK rate, but still with multi-microsecond gaps between bytes:
![image](https://user-images.githubusercontent.com/1517291/112365510-bc34c700-8ca5-11eb-89c3-6382dd4c0a31.png)
