### PR TITLE
Implement issue #4470

### DIFF
--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -109,7 +109,7 @@ def get_languages(list_all = False):
             languages.add(f.name[:-3])
     if not list_all:
         languages = languages & language_allow_list
-    return sorted(list(languages))
+    return sorted(list(languages), key = lambda s: s.casefold())
 
 
 def get_board_mapping():

--- a/tools/build_release_files.py
+++ b/tools/build_release_files.py
@@ -27,23 +27,10 @@ if "BOARDS" in os.environ:
 sha, version = build_info.get_version_info()
 
 languages = build_info.get_languages()
-language_allow_list = [
-    "ID",
-    "de_DE",
-    "en_US",
-    "en_x_pirate",
-    "es",
-    "fil",
-    "fr",
-    "it_IT",
-    "ja",
-    "nl",
-    "pl",
-    "pt_BR",
-    "sv",
-    "zh_Latn_pinyin",
-]
-print("Note: Not building languages", set(languages) - set(language_allow_list))
+
+all_languages = build_info.get_languages(list_all=True)
+
+print("Note: Not building languages", set(all_languages) - set(languages))
 
 exit_status = 0
 cores = multiprocessing.cpu_count()
@@ -53,7 +40,7 @@ for board in build_boards:
     os.makedirs(bin_directory, exist_ok=True)
     board_info = all_boards[board]
 
-    for language in language_allow_list:
+    for language in languages:
         bin_directory = "../bin/{board}/{language}".format(board=board, language=language)
         os.makedirs(bin_directory, exist_ok=True)
         start_time = time.monotonic()


### PR DESCRIPTION
Moves the *language allow list* to `build_board_info.py` and use it with `generate_download_info()`.
This syncs the list of languages on circuitpython.org with the builds.

I did some tests by adding a print of the generated json and using a test script digging into the data structure to compare it with the file generated from main (adding the same print to main), using beta and stable tags, checking that only the languages vary by what is expected.