### PR TITLE
`displayio` and `vectorio`: move to displayio_area_union and away from _expand

### DIFF
--- a/shared-module/displayio/Group.c
+++ b/shared-module/displayio/Group.c
@@ -123,7 +123,7 @@ bool displayio_group_get_previous_area(displayio_group_t *self, displayio_area_t
             displayio_area_copy(&layer_area, area);
             first = false;
         } else {
-            displayio_area_expand(area, &layer_area);
+            displayio_area_union(area, &layer_area, area);
         }
     }
     if (self->item_removed) {
@@ -131,7 +131,7 @@ bool displayio_group_get_previous_area(displayio_group_t *self, displayio_area_t
             displayio_area_copy(&self->dirty_area, area);
             first = false;
         } else {
-            displayio_area_expand(area, &self->dirty_area);
+            displayio_area_union(area, &self->dirty_area, area);
         }
     }
     return !first;
@@ -307,7 +307,7 @@ static void _remove_layer(displayio_group_t *self, size_t index) {
     if (!self->item_removed) {
         displayio_area_copy(&layer_area, &self->dirty_area);
     } else {
-        displayio_area_expand(&self->dirty_area, &layer_area);
+        displayio_area_union(&self->dirty_area, &layer_area, &self->dirty_area);
     }
     self->item_removed = true;
 }

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -273,7 +273,7 @@ void common_hal_displayio_tilegrid_set_tile(displayio_tilegrid_t *self, uint16_t
     tile_area->y2 = tile_area->y1 + self->tile_height;
 
     if (self->partial_change) {
-        displayio_area_expand(&self->dirty_area, &temp_area);
+        displayio_area_union(&self->dirty_area, &temp_area, &self->dirty_area);
     }
 
     self->partial_change = true;

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -245,21 +245,6 @@ void displayio_gc_collect(void) {
     }
 }
 
-void displayio_area_expand(displayio_area_t *original, const displayio_area_t *addition) {
-    if (addition->x1 < original->x1) {
-        original->x1 = addition->x1;
-    }
-    if (addition->y1 < original->y1) {
-        original->y1 = addition->y1;
-    }
-    if (addition->x2 > original->x2) {
-        original->x2 = addition->x2;
-    }
-    if (addition->y2 > original->y2) {
-        original->y2 = addition->y2;
-    }
-}
-
 void displayio_area_copy(const displayio_area_t *src, displayio_area_t *dst) {
     dst->x1 = src->x1;
     dst->y1 = src->y1;

--- a/shared-module/displayio/area.h
+++ b/shared-module/displayio/area.h
@@ -59,7 +59,6 @@ void displayio_area_canon(displayio_area_t *a);
 void displayio_area_union(const displayio_area_t *a,
     const displayio_area_t *b,
     displayio_area_t *u);
-void displayio_area_expand(displayio_area_t *original, const displayio_area_t *addition);
 void displayio_area_copy(const displayio_area_t *src, displayio_area_t *dst);
 void displayio_area_scale(displayio_area_t *area, uint16_t scale);
 void displayio_area_shift(displayio_area_t *area, int16_t dx, int16_t dy);

--- a/shared-module/vectorio/VectorShape.c
+++ b/shared-module/vectorio/VectorShape.c
@@ -55,16 +55,7 @@ static void _get_screen_area(vectorio_vector_shape_t *self, displayio_area_t *ou
         out_area->y2 = (out_area->y2 + self->y) * self->absolute_transform->dy + self->absolute_transform->y;
     }
     // We might have mirrored due to dx
-    if (out_area->x2 < out_area->x1) {
-        int16_t swap = out_area->x1;
-        out_area->x1 = out_area->x2;
-        out_area->x2 = swap;
-    }
-    if (out_area->y2 < out_area->y1) {
-        int16_t swap = out_area->y1;
-        out_area->y1 = out_area->y2;
-        out_area->y2 = swap;
-    }
+    displayio_area_canon(out_area);
     VECTORIO_SHAPE_DEBUG(" out:{(%5d,%5d), (%5d,%5d)}\n", out_area->x1, out_area->y1, out_area->x2, out_area->y2);
 }
 

--- a/shared-module/vectorio/VectorShape.c
+++ b/shared-module/vectorio/VectorShape.c
@@ -88,7 +88,7 @@ void common_hal_vectorio_vector_shape_set_dirty(void *vector_shape) {
         self->ephemeral_dirty_area.x1, self->ephemeral_dirty_area.y1, self->ephemeral_dirty_area.x2, self->ephemeral_dirty_area.y2);
     self->dirty = true;
     // Dirty area tracks the shape's footprint between draws.  It's reset on refresh finish,
-    displayio_area_expand(&self->ephemeral_dirty_area, &current_area);
+    displayio_area_union(&self->ephemeral_dirty_area, &current_area, &self->ephemeral_dirty_area);
     VECTORIO_SHAPE_DEBUG(" -> expanded:{(%3d,%3d), (%3d,%3d)}\n", self->ephemeral_dirty_area.x1, self->ephemeral_dirty_area.y1, self->ephemeral_dirty_area.x2, self->ephemeral_dirty_area.y2);
 }
 


### PR DESCRIPTION
Following up on: https://github.com/adafruit/circuitpython/pull/4432

This change removes `display_area_expand` since it didn't check for empty areas and moves to `display_area_union` which properly checks for empty areas.

Also adds one use of `display_area_canon` to vectorio to reduce duplicated code.

