### PR TITLE
Fix spi gaps

### DIFF
--- a/ports/mimxrt10xx/boards/imxrt1010_evk/mpconfigboard.mk
+++ b/ports/mimxrt10xx/boards/imxrt1010_evk/mpconfigboard.mk
@@ -6,3 +6,7 @@ USB_MANUFACTURER = "NXP"
 CHIP_VARIANT = MIMXRT1011DAE5A
 CHIP_FAMILY = MIMXRT1011
 FLASH = AT25SF128A
+
+# Include these Python libraries in the firmware
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_ESP32SPI
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Requests

--- a/ports/mimxrt10xx/common-hal/busio/SPI.c
+++ b/ports/mimxrt10xx/common-hal/busio/SPI.c
@@ -234,6 +234,10 @@ void common_hal_busio_spi_deinit(busio_spi_obj_t *self) {
 bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
     uint32_t baudrate, uint8_t polarity, uint8_t phase, uint8_t bits) {
 
+    if (baudrate > 30000000) {
+        baudrate = 30000000; // "Absolute maximum frequency of operation (fop) is 30 MHz" -- IMXRT1010CEC.pdf
+    }
+
     LPSPI_Enable(self->spi, false);
     uint32_t tcrPrescaleValue;
     self->baudrate = LPSPI_MasterSetBaudRate(self->spi, baudrate, LPSPI_MASTER_CLK_FREQ, &tcrPrescaleValue);

--- a/ports/mimxrt10xx/common-hal/busio/SPI.c
+++ b/ports/mimxrt10xx/common-hal/busio/SPI.c
@@ -255,7 +255,7 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
     // The between-transfer-delay must be equal to the SCK low-time.
     // Setting it lower introduces runt pulses, while setting it higher
     // wastes time.
-    config.betweenTransferDelayInNanoSec = 1000000000 / config.baudRate / 2;
+    config.betweenTransferDelayInNanoSec = (1000000000 / config.baudRate) / 2;
 
     LPSPI_Deinit(self->spi);
     LPSPI_MasterInit(self->spi, &config, LPSPI_MASTER_CLK_FREQ);


### PR DESCRIPTION
It's possible to configure very large gaps between transfers (bytes), and indeed this is what we ended up with by using LPSPI_MasterGetDefaultConfig.

Set all the delays to zero, enable a bit for "continuous transfers", and cap the speed at 30MHz per the datasheet's restrictions.

After this change, here is a view of a transfer at 30MHz:
![image](https://user-images.githubusercontent.com/1517291/112526558-15692d00-8d70-11eb-8a51-2416338c5328.png)

I tested on the MIMXRT1010-EVK both with a logic analyzer on the SCK and MOSI pins, and with a loopback wire from MOSI to MISO. (comment out the equality-assertion when scoping, put it back when looping back)

```python
import sys
import time
import board
import digitalio

b = board.SPI()
l = digitalio.DigitalInOut(board.USER_LED)
l.switch_to_output()

while not b.try_lock():
    pass
data = bytes([0x55, 0xaa, 0, 0xff]) * 8
data_in = bytearray(len(data))

baudrates = [1_000_000 << rs for rs in range(6)]
while True:
    l.value = True
    for baudrate in baudrates:
        b.configure(baudrate=baudrate)
        print(baudrate, b.frequency)
        b.write_readinto(data, data_in)
        #b.write(data)
        print(data_in)
        assert data == data_in
    l.value = False
    time.sleep(1)

b.unlock()
```

![image](https://user-images.githubusercontent.com/1517291/112527097-a9d38f80-8d70-11eb-866d-d5286e835fd2.png)


Closes: #3062 