### PR TITLE
Spi enhancements

### DIFF
--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -260,7 +260,7 @@ STATIC mp_obj_t bitbangio_spi_readinto(size_t n_args, const mp_obj_t *pos_args, 
         return mp_const_none;
     }
 
-    bool ok = shared_module_bitbangio_spi_read(self, ((uint8_t*)bufinfo.buf) + start, length, args[ARG_write_value].u_int);
+    bool ok = shared_module_bitbangio_spi_read(self, ((uint8_t *)bufinfo.buf) + start, length, args[ARG_write_value].u_int);
     if (!ok) {
         mp_raise_OSError(MP_EIO);
     }

--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -224,32 +224,53 @@ STATIC mp_obj_t bitbangio_spi_write(mp_obj_t self_in, mp_obj_t wr_buf) {
 MP_DEFINE_CONST_FUN_OBJ_2(bitbangio_spi_write_obj, bitbangio_spi_write);
 
 
-//|     def readinto(self, buf: WriteableBuffer) -> None:
-//|         """Read into the buffer specified by ``buf`` while writing zeroes.
-//|         Requires the SPI being locked.
-//|         If the number of bytes to read is 0, nothing happens."""
+//|     def readinto(self, buffer: WriteableBuffer, *, start: int = 0, end: Optional[int] = None, write_value: int = 0) -> None:
+//|         """Read into ``buffer`` while writing ``write_value`` for each byte read.
+//|         The SPI object must be locked.
+//|         If the number of bytes to read is 0, nothing happens.
+//|
+//|         :param bytearray buffer: Read data into this buffer
+//|         :param int start: Start of the slice of ``buffer`` to read into: ``buffer[start:end]``
+//|         :param int end: End of the slice; this index is not included. Defaults to ``len(buffer)``
+//|         :param int write_value: Value to write while reading."""
 //|         ...
 //|
-// TODO(tannewt): Add support for start and end kwargs.
-STATIC mp_obj_t bitbangio_spi_readinto(size_t n_args, const mp_obj_t *args) {
-    bitbangio_spi_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+
+STATIC mp_obj_t bitbangio_spi_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_buffer, ARG_start, ARG_end, ARG_write_value };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_buffer,     MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_start,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_end,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = INT_MAX} },
+        { MP_QSTR_write_value,MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+    };
+    bitbangio_spi_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     check_for_deinit(self);
+    check_lock(self);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_WRITE);
-    if (bufinfo.len == 0) {
+    mp_get_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_WRITE);
+    int32_t start = args[ARG_start].u_int;
+    size_t length = bufinfo.len;
+    normalize_buffer_bounds(&start, args[ARG_end].u_int, &length);
+
+    if (length == 0) {
         return mp_const_none;
     }
-    check_lock(args[0]);
-    bool ok = shared_module_bitbangio_spi_read(self, bufinfo.buf, bufinfo.len);
+
+    bool ok = shared_module_bitbangio_spi_read(self, ((uint8_t*)bufinfo.buf) + start, length, args[ARG_write_value].u_int);
     if (!ok) {
         mp_raise_OSError(MP_EIO);
     }
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitbangio_spi_readinto_obj, 2, 2, bitbangio_spi_readinto);
+MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_spi_readinto_obj, 2, bitbangio_spi_readinto);
 
-//|     def write_readinto(self, buffer_out: ReadableBuffer, buffer_in: WriteableBuffer, *, out_start: int = 0, out_end: Optional[int] = None, in_start: int = 0, in_end: Optional[int] = None) -> None:
+//|     def write_readinto(self, buffer_out: ReadableBuffer, buffer_in: ReadableBuffer, *, out_start: int = 0, out_end: Optional[int] = None, in_start: int = 0, in_end: Optional[int] = None) -> None:
 //|         """Write out the data in ``buffer_out`` while simultaneously reading data into ``buffer_in``.
+//|         The SPI object must be locked.
 //|         The lengths of the slices defined by ``buffer_out[out_start:out_end]`` and ``buffer_in[in_start:in_end]``
 //|         must be equal.
 //|         If buffer slice lengths are both 0, nothing happens.
@@ -274,6 +295,7 @@ STATIC mp_obj_t bitbangio_spi_write_readinto(size_t n_args, const mp_obj_t *pos_
     };
     bitbangio_spi_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     check_for_deinit(self);
+    check_lock(self);
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);

--- a/shared-bindings/bitbangio/SPI.h
+++ b/shared-bindings/bitbangio/SPI.h
@@ -54,7 +54,7 @@ extern void shared_module_bitbangio_spi_unlock(bitbangio_spi_obj_t *self);
 extern bool shared_module_bitbangio_spi_write(bitbangio_spi_obj_t *self, const uint8_t *data, size_t len);
 
 // Reads in len bytes while outputting zeroes.
-extern bool shared_module_bitbangio_spi_read(bitbangio_spi_obj_t *self, uint8_t *data, size_t len);
+extern bool shared_module_bitbangio_spi_read(bitbangio_spi_obj_t *self, uint8_t *data, size_t len, uint8_t write_value);
 
 // Transfer out len bytes while reading len bytes
 extern bool shared_module_bitbangio_spi_transfer(bitbangio_spi_obj_t *self, const uint8_t *dout, uint8_t *din, size_t len);

--- a/shared-module/adafruit_bus_device/SPIDevice.c
+++ b/shared-module/adafruit_bus_device/SPIDevice.c
@@ -42,14 +42,28 @@ void common_hal_adafruit_bus_device_spidevice_construct(adafruit_bus_device_spid
 }
 
 mp_obj_t common_hal_adafruit_bus_device_spidevice_enter(adafruit_bus_device_spidevice_obj_t *self) {
-    bool success = false;
-    while (!success) {
-        success = common_hal_busio_spi_try_lock(self->spi);
-        RUN_BACKGROUND_TASKS;
-        mp_handle_pending();
+    {
+        mp_obj_t dest[2];
+        mp_load_method(self->spi, MP_QSTR_try_lock, dest);
+
+        while (!mp_obj_is_true(mp_call_method_n_kw(0, 0, dest))) {
+            mp_handle_pending();
+        }
     }
 
-    common_hal_busio_spi_configure(self->spi, self->baudrate, self->polarity, self->phase, 8);
+    {
+        mp_obj_t dest[10];
+        mp_load_method(self->spi, MP_QSTR_configure, dest);
+        dest[2] = MP_OBJ_NEW_QSTR(MP_QSTR_baudrate);
+        dest[3] = MP_OBJ_NEW_SMALL_INT(self->baudrate);
+        dest[4] = MP_OBJ_NEW_QSTR(MP_QSTR_polarity);
+        dest[5] = MP_OBJ_NEW_SMALL_INT(self->polarity);
+        dest[6] = MP_OBJ_NEW_QSTR(MP_QSTR_phase);
+        dest[7] = MP_OBJ_NEW_SMALL_INT(self->phase);
+        dest[8] = MP_OBJ_NEW_QSTR(MP_QSTR_bits);
+        dest[9] = MP_OBJ_NEW_SMALL_INT(8);
+        mp_call_method_n_kw(0, 4, dest);
+    }
 
     if (self->chip_select != MP_OBJ_NULL) {
         common_hal_digitalio_digitalinout_set_value(MP_OBJ_TO_PTR(self->chip_select), false);
@@ -67,21 +81,21 @@ void common_hal_adafruit_bus_device_spidevice_exit(adafruit_bus_device_spidevice
         mp_buffer_info_t bufinfo;
         mp_obj_t buffer = mp_obj_new_bytearray_of_zeros(1);
 
-        mp_get_buffer_raise(buffer, &bufinfo, MP_BUFFER_READ);
+        mp_get_buffer_raise(buffer, &bufinfo, MP_BUFFER_WRITE);
         ((uint8_t *)bufinfo.buf)[0] = 0xFF;
 
-        uint8_t clocks = self->extra_clocks / 8;
-        if ((self->extra_clocks % 8) != 0) {
-            clocks += 1;
-        }
+        uint8_t clocks = (self->extra_clocks + 7) / 8;
 
+        mp_obj_t dest[3];
+        mp_load_method(self->spi, MP_QSTR_write, dest);
+        dest[2] = buffer;
         while (clocks > 0) {
-            if (!common_hal_busio_spi_write(self->spi, ((uint8_t *)bufinfo.buf), 1)) {
-                mp_raise_OSError(MP_EIO);
-            }
+            mp_call_method_n_kw(1, 0, dest);
             clocks--;
         }
     }
 
-    common_hal_busio_spi_unlock(self->spi);
+    mp_obj_t dest[2];
+    mp_load_method(self->spi, MP_QSTR_unlock, dest);
+    mp_call_method_n_kw(0, 0, dest);
 }


### PR DESCRIPTION
This required both adding support for the "default write value" in bitbangio.SPI, and also supporting duck-typing in adafruit_bus_device's SPIDevice which, surprisingly, was overlooked when we fixed I2C.

Now, the following code works, tested on RT1010-EVK:

```python
import os
import board
import bitbangio
import adafruit_sdcard
import storage
import digitalio

spi = bitbangio.SPI(board.SCK, MISO=board.MISO, MOSI=board.MOSI)
cs = board.D10
sdcard = adafruit_sdcard.SDCard(spi, digitalio.DigitalInOut(cs))
vfs = storage.VfsFat(sdcard)
storage.mount(vfs, "/sd")
print(os.listdir("/sd"))
```

Closes #4494.