### PR TITLE
RGBMatrix: fix memoryview(matrix)

### DIFF
--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -441,6 +441,7 @@ STATIC mp_int_t rgbmatrix_rgbmatrix_get_buffer(mp_obj_t self_in, mp_buffer_info_
         return 1;
     }
     *bufinfo = self->bufinfo;
+    bufinfo->typecode = 'H';
     return 0;
 }
 


### PR DESCRIPTION
Typical test:
```python
import displayio
import rgbmatrix
import board
displayio.release_displays()
matrix = rgbmatrix.RGBMatrix(
    width=128, bit_depth=4,
    rgb_pins=[board.GP0, board.GP1, board.GP2, board.GP3, board.GP4, board.GP5],
    addr_pins=[board.GP6, board.GP7, board.GP8, board.GP9],
    clock_pin=board.GP10, latch_pin=board.GP11, output_enable_pin=board.GP12)
mem = memoryview(matrix)
mem[0] = 65535 #  OK
mem[0] = 65536 #  errors (out of range)
```

Prior to this change, the line `mem = memoryview(matrix)` would raise a `ValueError: bad typecode`