### PR TITLE
Remove sentence about a link that fixes a problem

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -52,5 +52,3 @@ TimeoutError: Clock stretch too long
 
 <!-- Optionally, add any other information like hardware connection, scope output etc.
 If you have already done some debugging, mention it here. -->
-
-Removing [this](url) line resolves the issue.


### PR DESCRIPTION
Multiple times it has occurred that people left this line in a PR by mistake.  it makes it look like they failed to include some useful information, but really is just a misunderstanding.  Delete the text to reduce the chance of misunderstanding.