### PR TITLE
Turn off remote wakeup in USB configuration descriptor

### DIFF
--- a/tools/gen_usb_descriptor.py
+++ b/tools/gen_usb_descriptor.py
@@ -612,6 +612,11 @@ configuration = standard.ConfigurationDescriptor(
         standard.ConfigurationDescriptor.bLength + sum([len(bytes(x)) for x in descriptor_list])
     ),
     bNumInterfaces=len(interfaces),
+    # bus powered (bit 6), remote wakeup (bit 5),
+    # bit 7 is always 1 and 0-4 are always 0
+    # Turn off remote wakeup until we handle it in CircuitPython.
+    bmAttributes=0x80,
+
 )
 descriptor_list.insert(0, configuration)
 


### PR DESCRIPTION
We had the "Remote Wakeup" bit turned on in the USB configuration descriptor we send to the host. This is problematic for two reasons:
1. We don't handle remote wakeup; we should be calling `tud_remote_wakeup()` at appropriate times, per @hathach.
2. Some chips don't fully support USB suspend/resume, notably RP2040 and STM. TinyUSB has workarounds for some but not all of these. See https://github.com/hathach/tinyusb/pull/700 for some discussion. It is on TinyUSB's agenda to work on this further.

Some MicroPython folks noted problems due to Remote Wakeup being on for the RP2040, and turned it off: https://github.com/micropython/micropython/pull/7085. See also https://github.com/raspberrypi/pico-sdk/pull/289. We should do the same.

@hathach remarked to me in a side conversation that this is less of a problem in CircuitPython because of constant USB activity due to MSC. However, the host can still go to sleep after a while, and if MSC is disabled (e.g. for an HID appliance), then it would be more of an issue.

This _may_ solve #4164 and #4190.