### PR TITLE
Fix central pairing and crash on clear

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1171,6 +1171,7 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+#: ports/mimxrt10xx/common-hal/busio/UART.c
 msgid "Invalid %q pin"
 msgstr ""
 
@@ -1581,6 +1582,10 @@ msgstr ""
 msgid "Nordic Soft Device failure assertion."
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Nordic soft device out of memory"
+msgstr ""
+
 #: shared-bindings/ipaddress/IPv4Address.c shared-bindings/ipaddress/__init__.c
 msgid "Not a valid IP string"
 msgstr ""
@@ -1877,7 +1882,7 @@ msgstr ""
 msgid "Read-only filesystem"
 msgstr ""
 
-#: shared-module/bitmaptools/__init__.c shared-module/displayio/Bitmap.c
+#: shared-module/displayio/Bitmap.c
 msgid "Read-only object"
 msgstr ""
 
@@ -1950,14 +1955,6 @@ msgstr ""
 
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "Scan already in progess. Stop with stop_scan."
-msgstr ""
-
-#: ports/mimxrt10xx/common-hal/busio/UART.c
-msgid "Selected CTS pin not valid"
-msgstr ""
-
-#: ports/mimxrt10xx/common-hal/busio/UART.c
-msgid "Selected RTS pin not valid"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c

--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -147,6 +147,8 @@ STATIC uint32_t ble_stack_enable(void) {
     ble_conf.gap_cfg.role_count_cfg.periph_role_count = BLEIO_PERIPH_ROLE_COUNT;
     // central_role_count costs 648 bytes for 1 to 2, then ~1250 for each further increment.
     ble_conf.gap_cfg.role_count_cfg.central_role_count = BLEIO_CENTRAL_ROLE_COUNT;
+    // The number of concurrent pairing processes. Takes 392 bytes.
+    ble_conf.gap_cfg.role_count_cfg.central_sec_count = BLE_GAP_ROLE_COUNT_CENTRAL_SEC_DEFAULT;
     err_code = sd_ble_cfg_set(BLE_GAP_CFG_ROLE_COUNT, &ble_conf, sd_ram_end);
     if (err_code != NRF_SUCCESS) {
         return err_code;
@@ -283,6 +285,10 @@ STATIC bool adapter_on_ble_evt(ble_evt_t *ble_evt, void *self_in) {
             ble_drv_remove_event_handler(connection_on_ble_evt, connection);
             connection->conn_handle = BLE_CONN_HANDLE_INVALID;
             connection->pair_status = PAIR_NOT_PAIRED;
+
+            #if CIRCUITPY_VERBOSE_BLE
+            mp_printf(&mp_plat_print, "disconnected %02x\n", ble_evt->evt.gap_evt.params.disconnected.reason);
+            #endif
             if (connection->connection_obj != mp_const_none) {
                 bleio_connection_obj_t *obj = connection->connection_obj;
                 obj->connection = NULL;

--- a/ports/nrf/common-hal/_bleio/Connection.c
+++ b/ports/nrf/common-hal/_bleio/Connection.c
@@ -325,8 +325,7 @@ bool connection_on_ble_evt(ble_evt_t *ble_evt, void *self_in) {
 }
 
 void bleio_connection_clear(bleio_connection_internal_t *self) {
-    mp_obj_list_clear(MP_OBJ_FROM_PTR(self->remote_service_list));
-
+    self->remote_service_list = NULL;
     self->conn_handle = BLE_CONN_HANDLE_INVALID;
     self->pair_status = PAIR_NOT_PAIRED;
     self->is_central = false;

--- a/ports/nrf/common-hal/_bleio/__init__.c
+++ b/ports/nrf/common-hal/_bleio/__init__.c
@@ -46,6 +46,9 @@ void check_nrf_error(uint32_t err_code) {
         return;
     }
     switch (err_code) {
+        case NRF_ERROR_NO_MEM:
+            mp_raise_msg(&mp_type_MemoryError, translate("Nordic soft device out of memory"));
+            return;
         case NRF_ERROR_TIMEOUT:
             mp_raise_msg(&mp_type_TimeoutError, NULL);
             return;


### PR DESCRIPTION
The list_clear would crash if we tried to clear a NULL list. (It
can happen if we haven't tried to discover any services.)