### PR TITLE
Fix SD_DET pin assignment of seeduino_wio_terminal.

### DIFF
--- a/ports/atmel-samd/boards/seeeduino_wio_terminal/pins.c
+++ b/ports/atmel-samd/boards/seeeduino_wio_terminal/pins.c
@@ -60,7 +60,7 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_SD_MOSI),  MP_ROM_PTR(&pin_PC16) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_SD_SCK),  MP_ROM_PTR(&pin_PC17) },
     { MP_ROM_QSTR(MP_QSTR_SD_CS),  MP_ROM_PTR(&pin_PC19) },
-    { MP_ROM_QSTR(MP_QSTR_SD_DET),  MP_ROM_PTR(&pin_PC21) },
+    { MP_ROM_QSTR(MP_QSTR_SD_DET),  MP_ROM_PTR(&pin_PD21) },
 
     // Switch
     { MP_OBJ_NEW_QSTR(MP_QSTR_SWITCH_UP),  MP_ROM_PTR(&pin_PD20) },


### PR DESCRIPTION
In the Wio Terminal pin definition, the original SD_DET assignment (=PC21) collides with GYROSCOPE_INT.  According to the schmematics, SD_DET is connected to PD21.