### PR TITLE
Changed confusing error messages.

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1199,7 +1199,9 @@ msgid "Invalid DAC pin supplied"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pwmio/PWMOut.c
-#: ports/cxd56/common-hal/pwmio/PWMOut.c ports/nrf/common-hal/pwmio/PWMOut.c
+#: ports/cxd56/common-hal/pwmio/PWMOut.c
+#: ports/mimxrt10xx/common-hal/pwmio/PWMOut.c
+#: ports/nrf/common-hal/pwmio/PWMOut.c
 #: ports/raspberrypi/common-hal/pwmio/PWMOut.c shared-bindings/pwmio/PWMOut.c
 msgid "Invalid PWM frequency"
 msgstr ""
@@ -1579,11 +1581,11 @@ msgid "No timer available"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Nordic Soft Device failure assertion."
+msgid "Nordic system firmware failure assertion."
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
-msgid "Nordic soft device out of memory"
+msgid "Nordic system firmware out of memory"
 msgstr ""
 
 #: shared-bindings/ipaddress/IPv4Address.c shared-bindings/ipaddress/__init__.c
@@ -2233,7 +2235,7 @@ msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
 #, c-format
-msgid "Unknown soft device error: %04x"
+msgid "Unknown system firmware error: %04x"
 msgstr ""
 
 #: shared-bindings/_pixelbuf/PixelBuf.c

--- a/ports/nrf/common-hal/_bleio/__init__.c
+++ b/ports/nrf/common-hal/_bleio/__init__.c
@@ -47,7 +47,7 @@ void check_nrf_error(uint32_t err_code) {
     }
     switch (err_code) {
         case NRF_ERROR_NO_MEM:
-            mp_raise_msg(&mp_type_MemoryError, translate("Nordic soft device out of memory"));
+            mp_raise_msg(&mp_type_MemoryError, translate("Nordic system firmware out of memory"));
             return;
         case NRF_ERROR_TIMEOUT:
             mp_raise_msg(&mp_type_TimeoutError, NULL);
@@ -56,7 +56,7 @@ void check_nrf_error(uint32_t err_code) {
             mp_raise_ConnectionError(translate("Not connected"));
             return;
         default:
-            mp_raise_bleio_BluetoothError(translate("Unknown soft device error: %04x"), err_code);
+            mp_raise_bleio_BluetoothError(translate("Unknown system firmware error: %04x"), err_code);
             break;
     }
 }

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -182,7 +182,7 @@ void print_safe_mode_message(safe_mode_t reason) {
         // defined in ports/nrf/bluetooth/bluetooth_common.mk
         // will print "Unknown reason" if somehow encountered on other ports
         case NORDIC_SOFT_DEVICE_ASSERT:
-            serial_write_compressed(translate("Nordic Soft Device failure assertion."));
+            serial_write_compressed(translate("Nordic system firmware failure assertion."));
             break;
             #endif
         case FLASH_WRITE_FAIL:


### PR DESCRIPTION
Changed error message to display the generic term 'system firmware' instead of the Nordic specific term 'soft device' as suggested by @dhalbert.