### PR TITLE
decompress: Fix decompression when length takes 7 bits

### DIFF
--- a/supervisor/shared/translate.c
+++ b/supervisor/shared/translate.c
@@ -86,7 +86,7 @@ uint16_t decompress_length(const compressed_string_t *compressed) {
 char *decompress(const compressed_string_t *compressed, char *decompressed) {
     uint8_t this_byte = compress_max_length_bits / 8;
     uint8_t this_bit = 7 - compress_max_length_bits % 8;
-    uint8_t b = (&compressed->data)[this_byte];
+    uint8_t b = (&compressed->data)[this_byte] << (compress_max_length_bits % 8);
     uint16_t length = decompress_length(compressed);
 
     // Stop one early because the last byte is always NULL.


### PR DESCRIPTION
This manifested as incorrect error messages from mpy-cross, like
```
$ mpy-cross doesnotexist.py
OSError: [Errno 2] cno such file/director
```

The remaining bits in `b` must be shifted to the correct position before entering the loop.

For most (all?) actual builds, compress_max_length_bits was 8 and the problem went unnoticed.