### PR TITLE
Put mouse before gamepad due to MacOS being finicky

### DIFF
--- a/tools/gen_usb_descriptor.py
+++ b/tools/gen_usb_descriptor.py
@@ -17,9 +17,11 @@ ALL_DEVICES = "CDC CDC2 MSC AUDIO HID VENDOR"
 ALL_DEVICES_SET = frozenset(ALL_DEVICES.split())
 DEFAULT_DEVICES = "CDC MSC AUDIO HID"
 
+# This list is in preferred order. MacOS does not like GAMEPAD coming before MOUSE.
 ALL_HID_DEVICES = (
     "KEYBOARD MOUSE CONSUMER SYS_CONTROL GAMEPAD DIGITIZER XAC_COMPATIBLE_GAMEPAD RAW"
 )
+ALL_HID_DEVICES_ORDER = dict((name, idx) for (idx, name) in enumerate(ALL_HID_DEVICES.split()))
 ALL_HID_DEVICES_SET = frozenset(ALL_HID_DEVICES.split())
 # Digitizer works on Linux but conflicts with mouse, so omit it.
 DEFAULT_HID_DEVICES = "KEYBOARD MOUSE CONSUMER GAMEPAD"
@@ -352,7 +354,8 @@ if include_hid:
     else:
         report_id = 1
         concatenated_descriptors = bytearray()
-        for name in args.hid_devices:
+        # Sort HID devices by preferred order.
+        for name in sorted(args.hid_devices, key=ALL_HID_DEVICES_ORDER.get):
             concatenated_descriptors.extend(
                 bytes(hid_report_descriptors.REPORT_DESCRIPTOR_FUNCTIONS[name](report_id))
             )


### PR DESCRIPTION
Fixes #4479.

The HID devices were reordered after 6.2.0-beta.2 or so, and ended up being alphabetical. This put MOUSE last, which MacOS did not like. Reordering to KEYBOARD MOUSE ... GAMEPAD ... fixed the problem.

Tested on CPX because it was convenient:
```py
import time

import usb_hid
from adafruit_hid.keyboard import Keyboard
from adafruit_hid.keycode import Keycode
from adafruit_hid.mouse import Mouse

from adafruit_circuitplayground import cp

keyboard = Keyboard(usb_hid.devices)
mouse = Mouse(usb_hid.devices)

while True:
    if cp.button_a:
        keyboard.send(Keycode.A)
    if cp.button_b:
        mouse.move(50, 50)
    time.sleep(1)
```

