### PR TITLE
raspberrypi: Several rotary encoder fixes

### DIFF
--- a/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
@@ -60,17 +60,14 @@ STATIC void incrementalencoder_interrupt_handler(void *self_in);
 void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencoder_obj_t *self,
     const mcu_pin_obj_t *pin_a, const mcu_pin_obj_t *pin_b) {
     mp_obj_t pins[] = {MP_OBJ_FROM_PTR(pin_a), MP_OBJ_FROM_PTR(pin_b)};
-    bool swap = false;
     if (!common_hal_rp2pio_pins_are_sequential(2, pins)) {
         pins[0] = MP_OBJ_FROM_PTR(pin_b);
         pins[1] = MP_OBJ_FROM_PTR(pin_a);
-        swap = true;
         if (!common_hal_rp2pio_pins_are_sequential(2, pins)) {
             mp_raise_RuntimeError(translate("Pins must be sequential"));
         }
     }
 
-    self->swap = swap;
     self->position = 0;
     self->quarter_count = 0;
 
@@ -113,12 +110,12 @@ void common_hal_rotaryio_incrementalencoder_deinit(rotaryio_incrementalencoder_o
 }
 
 mp_int_t common_hal_rotaryio_incrementalencoder_get_position(rotaryio_incrementalencoder_obj_t *self) {
-    return self->swap ? -self->position : self->position;
+    return self->position;
 }
 
 void common_hal_rotaryio_incrementalencoder_set_position(rotaryio_incrementalencoder_obj_t *self,
     mp_int_t new_position) {
-    self->position = self->swap ? -new_position : new_position;
+    self->position = new_position;
 }
 
 STATIC void incrementalencoder_interrupt_handler(void *self_in) {

--- a/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
@@ -60,10 +60,17 @@ STATIC void incrementalencoder_interrupt_handler(void *self_in);
 void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencoder_obj_t *self,
     const mcu_pin_obj_t *pin_a, const mcu_pin_obj_t *pin_b) {
     mp_obj_t pins[] = {MP_OBJ_FROM_PTR(pin_a), MP_OBJ_FROM_PTR(pin_b)};
+    bool swap = false;
     if (!common_hal_rp2pio_pins_are_sequential(2, pins)) {
-        mp_raise_RuntimeError(translate("Pins must be sequential"));
+        pins[0] = MP_OBJ_FROM_PTR(pin_b);
+        pins[1] = MP_OBJ_FROM_PTR(pin_a);
+        swap = true;
+        if (!common_hal_rp2pio_pins_are_sequential(2, pins)) {
+            mp_raise_RuntimeError(translate("Pins must be sequential"));
+        }
     }
 
+    self->swap = swap;
     self->position = 0;
     self->quarter_count = 0;
 
@@ -72,7 +79,7 @@ void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencode
         1000000,
         encoder_init, MP_ARRAY_SIZE(encoder_init), // init
         NULL, 0, 0, 0, // out pin
-        pin_a, 2, // in pins
+        pins[0], 2, // in pins
         3, 0, // in pulls
         NULL, 0, 0, 0x1f, // set pins
         NULL, 0, 0, 0x1f, // sideset pins
@@ -106,12 +113,12 @@ void common_hal_rotaryio_incrementalencoder_deinit(rotaryio_incrementalencoder_o
 }
 
 mp_int_t common_hal_rotaryio_incrementalencoder_get_position(rotaryio_incrementalencoder_obj_t *self) {
-    return self->position;
+    return self->swap ? -self->position : self->position;
 }
 
 void common_hal_rotaryio_incrementalencoder_set_position(rotaryio_incrementalencoder_obj_t *self,
     mp_int_t new_position) {
-    self->position = new_position;
+    self->position = self->swap ? -new_position : new_position;
 }
 
 STATIC void incrementalencoder_interrupt_handler(void *self_in) {

--- a/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
@@ -71,7 +71,7 @@ void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencode
         encoder, MP_ARRAY_SIZE(encoder),
         1000000,
         encoder_init, MP_ARRAY_SIZE(encoder_init), // init
-        NULL, 1, 0, 0xffffffff, // out pin
+        NULL, 0, 0, 0, // out pin
         pin_a, 2, // in pins
         3, 0, // in pulls
         NULL, 0, 0, 0x1f, // set pins

--- a/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
@@ -101,6 +101,7 @@ void common_hal_rotaryio_incrementalencoder_deinit(rotaryio_incrementalencoder_o
     if (common_hal_rotaryio_incrementalencoder_deinited(self)) {
         return;
     }
+    common_hal_rp2pio_statemachine_set_interrupt_handler(&self->state_machine, NULL, NULL, 0);
     common_hal_rp2pio_statemachine_deinit(&self->state_machine);
 }
 

--- a/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.h
+++ b/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.h
@@ -37,5 +37,4 @@ typedef struct {
     uint8_t last_state : 4;   // <old A><old B><new A><new B>
     int8_t quarter_count : 4; // count intermediate transitions between detents
     mp_int_t position;
-    bool swap;
 } rotaryio_incrementalencoder_obj_t;

--- a/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.h
+++ b/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.h
@@ -37,4 +37,5 @@ typedef struct {
     uint8_t last_state : 4;   // <old A><old B><new A><new B>
     int8_t quarter_count : 4; // count intermediate transitions between detents
     mp_int_t position;
+    bool swap;
 } rotaryio_incrementalencoder_obj_t;


### PR DESCRIPTION
Support swapped pins, Closes: #4422

Turn off interrupts with deinit(), Closes: #4557

Don't say we have an output pin, Closes: #4556 