### PR TITLE
Add some minimum versions to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ typer
 
 requests
 sh
-click
+click>=7.1.2
 setuptools
 cpp-coveralls
 
@@ -20,14 +20,14 @@ sphinx-autoapi
 sphinxcontrib-svg2pdfconverter
 
 # For translate check
-polib
+polib>=1.1.0
 
 # For pre-commit
 pyyaml
-astroid
-isort
-black
-mypy
+astroid>=2.5.1
+isort>=5.7.0
+black>=20.8b1
+mypy>=0.812
 
 # For uploading artifacts
 awscli


### PR DESCRIPTION
@tannewt We've seen at least two people get bitten by too-old versions of `click`. I added a few minimum versions to `requirements-dev.txt` but am quite unsure about what to include here. And should we pin `black`? It would take some research to find the minimums for some of these on older versions of Python, perhaps.