### PR TITLE
Respect product name: space between QT and Py

### DIFF
--- a/ports/raspberrypi/boards/adafruit_qtpy_rp2040/mpconfigboard.h
+++ b/ports/raspberrypi/boards/adafruit_qtpy_rp2040/mpconfigboard.h
@@ -1,4 +1,4 @@
-#define MICROPY_HW_BOARD_NAME "Adafruit QTPy RP2040"
+#define MICROPY_HW_BOARD_NAME "Adafruit QT Py RP2040"
 #define MICROPY_HW_MCU_NAME "rp2040"
 
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO12)


### PR DESCRIPTION
https://www.adafruit.com/product/4900 say "Adafruit QT Py RP2040"

This is also matching other "QT Py" product.