### PR TITLE
Don't block serial output in interrupt

### DIFF
--- a/supervisor/shared/cpu.c
+++ b/supervisor/shared/cpu.c
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+
+#include "supervisor/shared/cpu.h"
+
+bool cpu_interrupt_active(void) {
+    #if defined(__ARM_ARCH) && (__ARM_ARCH >= 6)
+    // Check VECTACTIVE in ICSR. We don't need to disable interrupts because if
+    // one occurs after we read, we won't continue until it is resolved.
+    return (*((volatile uint32_t *)0xE000ED04) & 0x1ff) != 0;
+    #else
+    // We don't know.
+    return false;
+    #endif
+}

--- a/supervisor/shared/cpu.h
+++ b/supervisor/shared/cpu.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SUPERVISOR_SHARED_CPU_H
+#define MICROPY_INCLUDED_SUPERVISOR_SHARED_CPU_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+// True when we're in an interrupt handler.
+bool cpu_interrupt_active(void);
+
+#endif  // MICROPY_INCLUDED_SUPERVISOR_SHARED_CPU_H

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -28,6 +28,7 @@
 
 #include "py/mpconfig.h"
 
+#include "supervisor/shared/cpu.h"
 #include "supervisor/shared/display.h"
 #include "shared-bindings/terminalio/Terminal.h"
 #include "supervisor/serial.h"
@@ -136,6 +137,10 @@ void serial_write_substring(const char *text, uint32_t length) {
     uint32_t count = 0;
     while (count < length && tud_cdc_connected()) {
         count += tud_cdc_write(text + count, length - count);
+        // If we're in an interrupt, then don't wait for more room. Queue up what we can.
+        if (cpu_interrupt_active()) {
+            break;
+        }
         usb_background();
     }
 

--- a/supervisor/supervisor.mk
+++ b/supervisor/supervisor.mk
@@ -4,6 +4,7 @@ SRC_SUPERVISOR = \
 	supervisor/shared/autoreload.c \
 	supervisor/shared/background_callback.c \
 	supervisor/shared/board.c \
+	supervisor/shared/cpu.c \
 	supervisor/shared/filesystem.c \
 	supervisor/shared/flash.c \
 	supervisor/shared/micropython.c \


### PR DESCRIPTION
The interrupt may have a higher priority than the serial output's
(USB) interrupt and may never make room. This makes prints from
interrupts (like the BLE event calls) best effort for what can be
queued up. The rest of the output will be dropped.