### PR TITLE
D3 pin should be GPIO26

### DIFF
--- a/ports/raspberrypi/boards/adafruit_qtpy_rp2040/pins.c
+++ b/ports/raspberrypi/boards/adafruit_qtpy_rp2040/pins.c
@@ -11,7 +11,7 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D2), MP_ROM_PTR(&pin_GPIO27) },
 
     { MP_ROM_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_GPIO26) },
-    { MP_ROM_QSTR(MP_QSTR_D3), MP_ROM_PTR(&pin_GPIO27) },
+    { MP_ROM_QSTR(MP_QSTR_D3), MP_ROM_PTR(&pin_GPIO26) },
 
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO24) },
     { MP_ROM_QSTR(MP_QSTR_D4), MP_ROM_PTR(&pin_GPIO24) },


### PR DESCRIPTION
Thanks KevinT in discord who noticed this discrepancy.

@ladyada The silk is `A3`, so normally someone wouldn't use `D3`. I can backport this to the `6.2.x` branch so in case we do a 6.2.1 it will be in the stable release. But I'm not sure this is worth a release on its own.