### PR TITLE
Revert "add robots.txt to specify doc versions to appear in search engines"

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -284,7 +284,7 @@ html_static_path = ['docs/static']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-html_extra_path = ["docs/robots.txt"]
+#html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,6 +1,0 @@
-User-agent: *
-Allow: /*/latest/
-Allow: /en/latest/   # Fallback for bots that don't understand wildcards
-Allow: /*/6.0.x/
-Allow: /en/6.0.x/    # Fallback for bots that don't understand wildcards
-Disallow: /


### PR DESCRIPTION
Reverts adafruit/circuitpython#3291, which added our own `robots.txt`. I discovered that readthedocs will automatically generate an appropriate `robots.txt` based on which versions are activated and/or hidden. We can manage the visible versions from `readthedocs`.

The ` robots.txt` file is at https://circuitpython.readthedocs.io/en/robots.txt.

See https://docs.readthedocs.io/en/stable/versions.html#states:
>! Note
>Active versions that are hidden will be listed as Disallow: /path/to/version/ in the default robots.txt file created by Read the Docs.

To manage visible versions, we use https://readthedocs.org/projects/circuitpython/versions/, and edit the individual versions. I just added `6.2.x`, removed previous `6.x.x` versions, and marked older versions as "hidden". Click on the Edit buttons to change the Active/Hidden state:
![image](https://user-images.githubusercontent.com/2847802/114187882-7d924400-9916-11eb-816b-fa3af27d69d8.png)
Example:
![image](https://user-images.githubusercontent.com/2847802/114187925-8c78f680-9916-11eb-8bea-3d5b9755f9ed.png)
