### PR TITLE
Make error messages platform agnostic

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -434,7 +434,7 @@ msgid "Attempt to allocate %d blocks"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running."
+msgid "Attempted heap allocation when VM not running."
 msgstr ""
 
 #: shared-bindings/wifi/Radio.c
@@ -999,6 +999,10 @@ msgstr ""
 msgid "Failed to write internal flash."
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Fatal error."
+msgstr ""
+
 #: py/moduerrno.c
 msgid "File exists"
 msgstr ""
@@ -1171,6 +1175,7 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+#: ports/mimxrt10xx/common-hal/busio/UART.c
 msgid "Invalid %q pin"
 msgstr ""
 
@@ -1386,14 +1391,6 @@ msgstr ""
 msgid "Messages limited to 8 bytes"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption."
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error."
-msgstr ""
-
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
 msgstr ""
@@ -1443,6 +1440,10 @@ msgstr ""
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid "Must use a multiple of 6 rgb pins, not %d"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "NLR jump failed. Likely memory corruption."
 msgstr ""
 
 #: ports/esp32s2/common-hal/nvm/ByteArray.c
@@ -1877,7 +1878,7 @@ msgstr ""
 msgid "Read-only filesystem"
 msgstr ""
 
-#: shared-module/bitmaptools/__init__.c shared-module/displayio/Bitmap.c
+#: shared-module/displayio/Bitmap.c
 msgid "Read-only object"
 msgstr ""
 
@@ -1950,14 +1951,6 @@ msgstr ""
 
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "Scan already in progess. Stop with stop_scan."
-msgstr ""
-
-#: ports/mimxrt10xx/common-hal/busio/UART.c
-msgid "Selected CTS pin not valid"
-msgstr ""
-
-#: ports/mimxrt10xx/common-hal/busio/UART.c
-msgid "Selected RTS pin not valid"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -3191,6 +3184,10 @@ msgstr ""
 
 #: extmod/modussl_axtls.c
 msgid "invalid cert"
+msgstr ""
+
+#: py/compile.c
+msgid "invalid decorator"
 msgstr ""
 
 #: extmod/uos_dupterm.c

--- a/py/compile.c
+++ b/py/compile.c
@@ -768,7 +768,7 @@ STATIC bool compile_built_in_decorator(compiler_t *comp, int name_len, mp_parse_
     }
 
     if (name_len != 2) {
-        compile_syntax_error(comp, name_nodes[0], translate("invalid micropython decorator"));
+        compile_syntax_error(comp, name_nodes[0], translate("invalid decorator"));
         return true;
     }
 

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -170,13 +170,13 @@ void print_safe_mode_message(safe_mode_t reason) {
             serial_write_compressed(translate("Crash into the HardFault_Handler."));
             return;
         case MICROPY_NLR_JUMP_FAIL:
-            serial_write_compressed(translate("MicroPython NLR jump failed. Likely memory corruption."));
+            serial_write_compressed(translate("NLR jump failed. Likely memory corruption."));
             return;
         case MICROPY_FATAL_ERROR:
-            serial_write_compressed(translate("MicroPython fatal error."));
+            serial_write_compressed(translate("Fatal error."));
             break;
         case GC_ALLOC_OUTSIDE_VM:
-            serial_write_compressed(translate("Attempted heap allocation when MicroPython VM not running."));
+            serial_write_compressed(translate("Attempted heap allocation when VM not running."));
             break;
             #ifdef SOFTDEVICE_PRESENT
         // defined in ports/nrf/bluetooth/bluetooth_common.mk


### PR DESCRIPTION
Remove mentions of 'MicroPython' in error messages as they could lead to confusion in lesser-experienced users

This change comes as [a brief discussion on Discord](https://discord.com/channels/327254708534116352/327298996332658690/830510123276959764) with @jepler with regards to translations and references to "MicroPython" changed to "CircuitPython" being done in weblate.

Rather than updating translations to convert "MicroPython" to "CircuitPython", I inquired about making the change in the source itself, at which point Jeff mentioned the message remains as clear with neither "CircuitPython" nor "MicroPython" being mentioned.

This pull request is not only to affect the mentioned change but also spur any potential discussion or debate with regards to this type of change.