### PR TITLE
fix removing past releases from circuitpython.org

### DIFF
--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -266,7 +266,7 @@ def generate_download_info():
     # Delete the release we are replacing
     for board in current_info:
         info = current_info[board]
-        for version in info["versions"]:
+        for version in list(info["versions"]):
             previous_releases.add(version["version"])
             previous_languages.update(version["languages"])
             if version["stable"] == new_stable or (


### PR DESCRIPTION
Loop on a copy when removing past releases.
Fixes leaving `6.2.0-rc.0` when releasing `6.2.0`.