### PR TITLE
[build] Allow USB to be set to 0

### DIFF
--- a/main.c
+++ b/main.c
@@ -60,6 +60,7 @@
 #include "supervisor/shared/translate.h"
 #include "supervisor/shared/workflow.h"
 #include "supervisor/usb.h"
+#include "supervisor/workflow.h"
 
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/Processor.h"
@@ -188,7 +189,10 @@ STATIC void stop_mp(void) {
     #endif
 
     background_callback_reset();
+
+    #if CIRCUITPY_USB
     usb_background();
+    #endif
 
     gc_deinit();
 }

--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -201,7 +201,7 @@ SRC_C += \
 	peripherals/rmt.c \
 	supervisor/shared/memory.c
 
-ifneq ($(USB),FALSE)
+ifneq ($(CIRCUITPY_USB),0)
 SRC_C += lib/tinyusb/src/portable/espressif/esp32s2/dcd_esp32s2.c
 endif
 

--- a/ports/litex/Makefile
+++ b/ports/litex/Makefile
@@ -136,7 +136,7 @@ SRC_C += \
 	lib/utils/sys_stdio_mphal.c \
 	supervisor/shared/memory.c
 
-ifneq ($(USB),FALSE)
+ifneq ($(CIRCUITPY_USB),0)
 SRC_C += lib/tinyusb/src/portable/valentyusb/eptri/dcd_eptri.c
 endif
 

--- a/ports/litex/supervisor/internal_flash.c
+++ b/ports/litex/supervisor/internal_flash.c
@@ -310,7 +310,7 @@ mp_uint_t supervisor_flash_read_blocks(uint8_t *dest, uint32_t block, uint32_t n
     uint32_t src = lba2addr(block);
     memcpy(dest, (uint8_t *)src, FILESYSTEM_BLOCK_SIZE * num_blocks);
 
-    #if USB_AVAILABLE
+    #if CIRCUITPY_USB
     usb_background();
     #endif
 
@@ -347,7 +347,7 @@ mp_uint_t supervisor_flash_write_blocks(const uint8_t *src, uint32_t lba, uint32
         src += count * FILESYSTEM_BLOCK_SIZE;
         num_blocks -= count;
 
-        #if USB_AVAILABLE
+        #if CIRCUITPY_USB
         usb_background();
         #endif
     }

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -177,6 +177,7 @@ SRC_C += \
 	sd_mutex.c \
 	supervisor/shared/memory.c
 
+ifneq ($(CIRCUITPY_USB),0)
 # USB source files for nrf52840
 ifeq ($(MCU_SUB_VARIANT),nrf52840)
 SRC_C += \
@@ -187,6 +188,7 @@ ifeq ($(MCU_SUB_VARIANT),nrf52833)
 SRC_C += \
 	lib/tinyusb/src/portable/nordic/nrf5x/dcd_nrf5x.c
 endif
+endif # CIRCUITPY_USB
 
 ifeq ($(CIRCUITPY_NETWORK),1)
 CFLAGS += -DMICROPY_PY_NETWORK=1

--- a/ports/nrf/bluetooth/ble_drv.c
+++ b/ports/nrf/bluetooth/ble_drv.c
@@ -98,6 +98,7 @@ void SD_EVT_IRQHandler(void) {
     uint32_t evt_id;
     while (sd_evt_get(&evt_id) != NRF_ERROR_NOT_FOUND) {
         switch (evt_id) {
+            #if CIRCUITPY_USB
             // usb power event
             case NRF_EVT_POWER_USB_DETECTED:
             case NRF_EVT_POWER_USB_POWER_READY:
@@ -109,6 +110,7 @@ void SD_EVT_IRQHandler(void) {
                 tusb_hal_nrf_power_event(usbevt);
             }
             break;
+            #endif
 
             // Set flag indicating that a flash operation has finished.
             case NRF_EVT_FLASH_OPERATION_SUCCESS:

--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -351,8 +351,11 @@ void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enable
     } else {
         err_code = sd_softdevice_disable();
     }
+
+    #if CIRCUITPY_USB
     // Re-init USB hardware
     init_usb_hardware();
+    #endif
 
     check_nrf_error(err_code);
 

--- a/ports/stm/Makefile
+++ b/ports/stm/Makefile
@@ -238,7 +238,7 @@ SRC_C += \
 	lib/utils/sys_stdio_mphal.c \
 	supervisor/shared/memory.c
 
-ifneq ($(USB),FALSE)
+ifneq ($(CIRCUITPY_USB),0)
 SRC_C += lib/tinyusb/src/portable/st/synopsys/dcd_synopsys.c
 endif
 

--- a/py/circuitpy_mpconfig.mk
+++ b/py/circuitpy_mpconfig.mk
@@ -331,6 +331,9 @@ CFLAGS += -DCIRCUITPY_TOUCHIO=$(CIRCUITPY_TOUCHIO)
 CIRCUITPY_UHEAP ?= 0
 CFLAGS += -DCIRCUITPY_UHEAP=$(CIRCUITPY_UHEAP)
 
+CIRCUITPY_USB ?= 1
+CFLAGS += -DCIRCUITPY_USB=$(CIRCUITPY_USB)
+
 # Disable by default for now, until we have dynamic enabling.
 CIRCUITPY_USB_CDC ?= 0
 # Secondary CDC is usually available if there are at least 8 endpoints.

--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -59,7 +59,11 @@ STATIC supervisor_run_reason_t _run_reason;
 //|     """Returns the USB enumeration status (read-only)."""
 //|
 STATIC mp_obj_t supervisor_runtime_get_usb_connected(mp_obj_t self) {
+    #if CIRCUITPY_USB
     return mp_obj_new_bool(tud_ready());
+    #else
+    return mp_const_false;
+    #endif
 }
 MP_DEFINE_CONST_FUN_OBJ_1(supervisor_runtime_get_usb_connected_obj, supervisor_runtime_get_usb_connected);
 

--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -160,7 +160,9 @@ void common_hal_storage_remount(const char *mount_path, bool readonly, bool disa
 }
 
 void common_hal_storage_erase_filesystem(void) {
+    #if CIRCUITPY_USB
     usb_disconnect();
+    #endif
     mp_hal_delay_ms(1000);
     filesystem_init(false, true); // Force a re-format.
     common_hal_mcu_reset();

--- a/supervisor/shared/workflow.h
+++ b/supervisor/shared/workflow.h
@@ -26,7 +26,5 @@
 
 #pragma once
 
-extern void supervisor_workflow_reset(void);
-
 extern bool supervisor_workflow_connecting(void);
 extern bool supervisor_workflow_active(void);

--- a/supervisor/stub/serial.c
+++ b/supervisor/stub/serial.c
@@ -25,6 +25,7 @@
  */
 
 #include "supervisor/serial.h"
+#include "supervisor/workflow.h"
 
 void serial_early_init(void) {
 
@@ -48,4 +49,7 @@ bool serial_bytes_available(void) {
 
 void serial_write(const char *text) {
     (void)text;
+}
+
+void supervisor_workflow_reset(void) {
 }

--- a/supervisor/supervisor.mk
+++ b/supervisor/supervisor.mk
@@ -59,7 +59,7 @@ $(BUILD)/supervisor/shared/external_flash/external_flash.o: $(HEADER_BUILD)/devi
 
 endif
 
-ifeq ($(USB),FALSE)
+ifeq ($(CIRCUITPY_USB),0)
   ifeq ($(wildcard supervisor/serial.c),)
     SRC_SUPERVISOR += supervisor/stub/serial.c
   else
@@ -122,8 +122,6 @@ else
       lib/tinyusb/src/class/vendor/vendor_device.c \
 
   endif
-
-  CFLAGS += -DUSB_AVAILABLE
 endif
 
 SUPERVISOR_O = $(addprefix $(BUILD)/, $(SRC_SUPERVISOR:.c=.o))

--- a/supervisor/workflow.h
+++ b/supervisor/workflow.h
@@ -26,5 +26,7 @@
 
 #pragma once
 
+void supervisor_workflow_reset(void);
+
 // True when the user could be actively iterating on their code.
 bool workflow_active(void);


### PR DESCRIPTION
`USB_AVAILABLE` was conditionally defined in supervisor.mk,
but never actually used to `#ifdef` USB-related code.

Loosely related to #4546