### PR TITLE
Fix struct.pack with padding bytes

### DIFF
--- a/py/binary.c
+++ b/py/binary.c
@@ -371,11 +371,7 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte **
         }
     }
 
-    if (val_type == 'x') {
-        memset(p, 0, 1);
-    } else {
-        mp_binary_set_int(MIN((size_t)size, sizeof(val)), struct_type == '>', p, val);
-    }
+    mp_binary_set_int(MIN((size_t)size, sizeof(val)), struct_type == '>', p, val);
 }
 
 void mp_binary_set_val_array(char typecode, void *p, mp_uint_t index, mp_obj_t val_in) {

--- a/shared-module/struct/__init__.c
+++ b/shared-module/struct/__init__.c
@@ -153,9 +153,11 @@ void shared_modules_struct_pack_into(mp_obj_t fmt_in, byte *p, byte *end_p, size
             p += sz;
         } else {
             while (sz--) {
-                mp_binary_set_val(fmt_type, *fmt, args[i], &p);
                 // Pad bytes don't have a corresponding argument.
-                if (*fmt != 'x') {
+                if (*fmt == 'x') {
+                    mp_binary_set_val(fmt_type, *fmt, MP_OBJ_NEW_SMALL_INT(0), &p);
+                } else {
+                    mp_binary_set_val(fmt_type, *fmt, args[i], &p);
                     i++;
                 }
             }

--- a/tests/basics/struct1.py
+++ b/tests/basics/struct1.py
@@ -121,3 +121,5 @@ except:
 
 # check padding bytes
 print(struct.pack("xb", 3))
+# Make sure pack doesn't reuse a larger value and error
+print(struct.pack("xH", 0x100))


### PR DESCRIPTION
It used to validate the following arg could fit in a single byte.
Now, it always uses zero to pad.

Previous work on padding bytes in struct was done in #3405