### PR TITLE
Update mpconfigboard.h DEFAULT_I2C_BUS_SDA & _SCL pins to match pins.c and schematic

### DIFF
--- a/ports/atmel-samd/boards/feather_m0_adalogger/mpconfigboard.h
+++ b/ports/atmel-samd/boards/feather_m0_adalogger/mpconfigboard.h
@@ -8,8 +8,8 @@
 #define MICROPY_PORT_B        (0)
 #define MICROPY_PORT_C        (0)
 
-#define DEFAULT_I2C_BUS_SCL (&pin_PA22)
-#define DEFAULT_I2C_BUS_SDA (&pin_PA23)
+#define DEFAULT_I2C_BUS_SDA (&pin_PA22)
+#define DEFAULT_I2C_BUS_SCL (&pin_PA23)
 
 #define DEFAULT_SPI_BUS_SCK (&pin_PB11)
 #define DEFAULT_SPI_BUS_MOSI (&pin_PB10)


### PR DESCRIPTION
Feather M0 Adalogger:

For #4630. I don't have a board to test, flying blind.