### PR TITLE
RP2040 and ESP32S2: Return correct count from UART.write()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -482,7 +482,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210304
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210422
     - name: Clone IDF submodules
       run: |
         (cd $IDF_PATH && git submodule update --init)

--- a/ports/esp32s2/common-hal/busio/UART.c
+++ b/ports/esp32s2/common-hal/busio/UART.c
@@ -291,13 +291,14 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, 
         mp_raise_ValueError(translate("No TX pin"));
     }
 
-    while (len > 0) {
-        int count = uart_tx_chars(self->uart_num, (const char *)data, len);
+    size_t left_to_write = len;
+    while (left_to_write > 0) {
+        int count = uart_tx_chars(self->uart_num, (const char *)data, left_to_write);
         if (count < 0) {
             *errcode = MP_EAGAIN;
             return MP_STREAM_ERROR;
         }
-        len -= count;
+        left_to_write -= count;
         data += count;
         RUN_BACKGROUND_TASKS;
     }

--- a/ports/raspberrypi/common-hal/busio/UART.c
+++ b/ports/raspberrypi/common-hal/busio/UART.c
@@ -191,12 +191,13 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, 
         mp_raise_ValueError(translate("No TX pin"));
     }
 
-    while (len > 0) {
-        while (uart_is_writable(self->uart) && len > 0) {
+    size_t left_to_write = len;
+    while (left_to_write > 0) {
+        while (uart_is_writable(self->uart) && left_to_write > 0) {
             // Write and advance.
             uart_get_hw(self->uart)->dr = *data++;
             // Decrease how many chars left to write.
-            len--;
+            left_to_write--;
         }
         RUN_BACKGROUND_TASKS;
     }


### PR DESCRIPTION
`UART.write()` was always returning zero because it used the input `len` as a countdown.

This change is on `6.2.x`, and we can merge or cherry-pick this to `main`.