### PR TITLE
Reset buffer index in PulseIn clear

### DIFF
--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.c
@@ -180,6 +180,7 @@ void common_hal_pulseio_pulsein_resume(pulseio_pulsein_obj_t *self,
 void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t *self) {
     self->start = 0;
     self->len = 0;
+    buf_index = 0;
 }
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t *self) {


### PR DESCRIPTION
In common_hal_pulseio_pulsein_clear() added a reset of buf_index. Fix for issue #4660.