### PR TITLE
NRF: Fix MP type checking macros

### DIFF
--- a/ports/nrf/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/nrf/common-hal/alarm/pin/PinAlarm.c
@@ -93,7 +93,7 @@ bool alarm_pin_pinalarm_woke_us_up(void) {
 mp_obj_t alarm_pin_pinalarm_get_wakeup_alarm(size_t n_alarms, const mp_obj_t *alarms) {
     // First, check to see if we match any given alarms.
     for (size_t i = 0; i < n_alarms; i++) {
-        if (!MP_OBJ_IS_TYPE(alarms[i], &alarm_pin_pinalarm_type)) {
+        if (!mp_obj_is_type(alarms[i], &alarm_pin_pinalarm_type)) {
             continue;
         }
         alarm_pin_pinalarm_obj_t *alarm  = MP_OBJ_TO_PTR(alarms[i]);
@@ -197,7 +197,7 @@ void alarm_pin_pinalarm_set_alarms(bool deep_sleep, size_t n_alarms, const mp_ob
     int pin_number = -1;
 
     for (size_t i = 0; i < n_alarms; i++) {
-        if (!MP_OBJ_IS_TYPE(alarms[i], &alarm_pin_pinalarm_type)) {
+        if (!mp_obj_is_type(alarms[i], &alarm_pin_pinalarm_type)) {
             continue;
         }
         alarm_pin_pinalarm_obj_t *alarm  = MP_OBJ_TO_PTR(alarms[i]);

--- a/ports/nrf/common-hal/alarm/time/TimeAlarm.c
+++ b/ports/nrf/common-hal/alarm/time/TimeAlarm.c
@@ -43,7 +43,7 @@ mp_float_t common_hal_alarm_time_timealarm_get_monotonic_time(alarm_time_timeala
 mp_obj_t alarm_time_timealarm_get_wakeup_alarm(size_t n_alarms, const mp_obj_t *alarms) {
     // First, check to see if we match
     for (size_t i = 0; i < n_alarms; i++) {
-        if (MP_OBJ_IS_TYPE(alarms[i], &alarm_time_timealarm_type)) {
+        if (mp_obj_is_type(alarms[i], &alarm_time_timealarm_type)) {
             return alarms[i];
         }
     }
@@ -82,7 +82,7 @@ void alarm_time_timealarm_set_alarms(bool deep_sleep, size_t n_alarms, const mp_
     wakeup_time_saved = 0;
 
     for (size_t i = 0; i < n_alarms; i++) {
-        if (!MP_OBJ_IS_TYPE(alarms[i], &alarm_time_timealarm_type)) {
+        if (!mp_obj_is_type(alarms[i], &alarm_time_timealarm_type)) {
             continue;
         }
         if (timealarm_set) {


### PR DESCRIPTION
A change to the macros introduced in MP 1.11 snuck past CI on #4236. Fix should un-break the NRF builds.