### PR TITLE
Add AuthMode class

### DIFF
--- a/ports/esp32s2/common-hal/wifi/Network.c
+++ b/ports/esp32s2/common-hal/wifi/Network.c
@@ -24,11 +24,11 @@
  * THE SOFTWARE.
  */
 
-#include "shared-bindings/wifi/Network.h"
-
 #include <string.h>
 
-#include "py/obj.h"
+#include "py/enum.h"
+#include "shared-bindings/wifi/Network.h"
+#include "shared-bindings/wifi/AuthMode.h"
 
 mp_obj_t common_hal_wifi_network_get_ssid(wifi_network_obj_t *self) {
     const char *cstr = (const char *)self->record.ssid;
@@ -56,35 +56,42 @@ mp_obj_t common_hal_wifi_network_get_country(wifi_network_obj_t *self) {
 }
 
 mp_obj_t common_hal_wifi_network_get_authmode(wifi_network_obj_t *self) {
-    const char *authmode = "";
+    uint8_t authmode_mask = 0;
     switch (self->record.authmode) {
         case WIFI_AUTH_OPEN:
-            authmode = "OPEN";
+            authmode_mask = (1 << AUTHMODE_OPEN);
             break;
         case WIFI_AUTH_WEP:
-            authmode = "WEP";
+            authmode_mask = (1 << AUTHMODE_WEP);
             break;
         case WIFI_AUTH_WPA_PSK:
-            authmode = "WPA_PSK";
+            authmode_mask = (1 << AUTHMODE_WPA) | (1 << AUTHMODE_PSK);
             break;
         case WIFI_AUTH_WPA2_PSK:
-            authmode = "WPA2_PSK";
+            authmode_mask = (1 << AUTHMODE_WPA2) | (1 << AUTHMODE_PSK);
             break;
         case WIFI_AUTH_WPA_WPA2_PSK:
-            authmode = "WPA_WPA2_PSK";
+            authmode_mask = (1 << AUTHMODE_WPA) | (1 << AUTHMODE_WPA2) | (1 << AUTHMODE_PSK);
             break;
         case WIFI_AUTH_WPA2_ENTERPRISE:
-            authmode = "WPA2_ENTERPRISE";
+            authmode_mask = (1 << AUTHMODE_WPA2) | (1 << AUTHMODE_ENTERPRISE);
             break;
         case WIFI_AUTH_WPA3_PSK:
-            authmode = "WPA3_PSK";
+            authmode_mask = (1 << AUTHMODE_WPA3) | (1 << AUTHMODE_PSK);
             break;
         case WIFI_AUTH_WPA2_WPA3_PSK:
-            authmode = "WPA2_WPA3_PSK";
+            authmode_mask = (1 << AUTHMODE_WPA2) | (1 << AUTHMODE_WPA3) | (1 << AUTHMODE_PSK);
             break;
         default:
-            authmode = "UNKNOWN";
             break;
     }
-    return mp_obj_new_str(authmode, strlen(authmode));
+    mp_obj_t authmode_list = mp_obj_new_list(0, NULL);
+    if (authmode_mask != 0) {
+        for (uint8_t i = 0; i < 8; i++) {
+            if ((authmode_mask >> i) & 1) {
+                mp_obj_list_append(authmode_list, cp_enum_find(&wifi_authmode_type, i));
+            }
+        }
+    }
+    return authmode_list;
 }

--- a/py/circuitpy_defns.mk
+++ b/py/circuitpy_defns.mk
@@ -451,6 +451,7 @@ $(filter $(SRC_PATTERNS), \
 	msgpack/__init__.c \
 	msgpack/ExtType.c \
 	supervisor/RunReason.c \
+	wifi/AuthMode.c \
 )
 
 SRC_BINDINGS_ENUMS += \

--- a/shared-bindings/wifi/AuthMode.c
+++ b/shared-bindings/wifi/AuthMode.c
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 microDev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/enum.h"
+
+#include "shared-bindings/wifi/AuthMode.h"
+
+MAKE_ENUM_VALUE(wifi_authmode_type, authmode, OPEN, AUTHMODE_OPEN);
+MAKE_ENUM_VALUE(wifi_authmode_type, authmode, WEP, AUTHMODE_WEP);
+MAKE_ENUM_VALUE(wifi_authmode_type, authmode, WPA, AUTHMODE_WPA);
+MAKE_ENUM_VALUE(wifi_authmode_type, authmode, WPA2, AUTHMODE_WPA2);
+MAKE_ENUM_VALUE(wifi_authmode_type, authmode, WPA3, AUTHMODE_WPA3);
+MAKE_ENUM_VALUE(wifi_authmode_type, authmode, PSK, AUTHMODE_PSK);
+MAKE_ENUM_VALUE(wifi_authmode_type, authmode, ENTERPRISE, AUTHMODE_ENTERPRISE);
+
+//| class AuthMode:
+//|     """The authentication protocols used by WiFi."""
+//|
+//|     OPEN: object
+//|     """Open network. No authentication required."""
+//|
+//|     WEP: object
+//|     """Wired Equivalent Privacy."""
+//|
+//|     WPA: object
+//|     """Wireless Protected Access."""
+//|
+//|     WPA2: object
+//|     """Wireless Protected Access 2."""
+//|
+//|     WPA3: object
+//|     """Wireless Protected Access 3."""
+//|
+//|     PSK: object
+//|     """Pre-shared Key. (password)"""
+//|
+//|     ENTERPRISE: object
+//|     """Each user has a unique credential."""
+//|
+MAKE_ENUM_MAP(wifi_authmode) {
+    MAKE_ENUM_MAP_ENTRY(authmode, OPEN),
+    MAKE_ENUM_MAP_ENTRY(authmode, WEP),
+    MAKE_ENUM_MAP_ENTRY(authmode, WPA),
+    MAKE_ENUM_MAP_ENTRY(authmode, WPA2),
+    MAKE_ENUM_MAP_ENTRY(authmode, WPA3),
+    MAKE_ENUM_MAP_ENTRY(authmode, PSK),
+    MAKE_ENUM_MAP_ENTRY(authmode, ENTERPRISE),
+};
+STATIC MP_DEFINE_CONST_DICT(wifi_authmode_locals_dict, wifi_authmode_locals_table);
+
+MAKE_PRINTER(wifi, wifi_authmode);
+
+MAKE_ENUM_TYPE(wifi, AuthMode, wifi_authmode);

--- a/shared-bindings/wifi/AuthMode.h
+++ b/shared-bindings/wifi/AuthMode.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 microDev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_WIFI_AUTHMODE_H
+#define MICROPY_INCLUDED_SHARED_BINDINGS_WIFI_AUTHMODE_H
+
+typedef enum {
+    AUTHMODE_OPEN,
+    AUTHMODE_WEP,
+    AUTHMODE_WPA,
+    AUTHMODE_WPA2,
+    AUTHMODE_WPA3,
+    AUTHMODE_PSK,
+    AUTHMODE_ENTERPRISE
+} wifi_authmode_t;
+
+extern const mp_obj_type_t wifi_authmode_type;
+
+#endif // MICROPY_INCLUDED_SHARED_BINDINGS_WIFI_AUTHMODE_H


### PR DESCRIPTION
Adds `AuthMode` class. Instead of using combined enum filed like `WPA_WPA2_PSK`, uses a list separating the fields `[WPA,WPA2,PSK]`.

**Code:**
```python
import wifi
for network in wifi.radio.start_scanning_networks():
    print(network.authmode)
wifi.radio.stop_scanning_networks()
```
**Output:**
```python
[wifi.AuthMode.WPA, wifi.AuthMode.WPA2, wifi.AuthMode.PSK]
```
