### PR TITLE
objtype: Restore our customized behavior of instance_subscr

### DIFF
--- a/ports/atmel-samd/boards/feather_m0_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/feather_m0_express/mpconfigboard.h
@@ -27,6 +27,17 @@
 #define DEFAULT_UART_BUS_RX (&pin_PA11)
 #define DEFAULT_UART_BUS_TX (&pin_PA10)
 
+// Other some pins that do not appear in the pinout & are not used internally
+// this list is not (yet) exhaustive
+#define IGNORE_PIN_PA03     1
+#define IGNORE_PIN_PB01     1
+#define IGNORE_PIN_PB03     1
+#define IGNORE_PIN_PB04     1
+#define IGNORE_PIN_PB05     1
+#define IGNORE_PIN_PB06     1
+#define IGNORE_PIN_PB07     1
+#define IGNORE_PIN_PB12     1
+
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1

--- a/ports/atmel-samd/boards/snekboard/mpconfigboard.h
+++ b/ports/atmel-samd/boards/snekboard/mpconfigboard.h
@@ -23,6 +23,21 @@
 #define DEFAULT_UART_BUS_RX (&pin_PB08) /* ANALOG 1 */
 #define DEFAULT_UART_BUS_TX (&pin_PB09) /* ANALOG 2 */
 
+// Other some pins that do not appear in the pinout & are not used internally
+// this list is not (yet) exhaustive
+#define IGNORE_PIN_PA01     1
+#define IGNORE_PIN_PA03     1
+#define IGNORE_PIN_PB04     1
+#define IGNORE_PIN_PB05     1
+#define IGNORE_PIN_PB00     1
+#define IGNORE_PIN_PB01     1
+#define IGNORE_PIN_PB02     1
+#define IGNORE_PIN_PB04     1
+#define IGNORE_PIN_PB05     1
+#define IGNORE_PIN_PB06     1
+#define IGNORE_PIN_PB07     1
+#define IGNORE_PIN_PB12     1
+
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -854,7 +854,8 @@ STATIC mp_obj_t instance_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value
     }
     mp_obj_class_lookup(&lookup, self->base.type);
     if (member[0] == MP_OBJ_SENTINEL) {
-        mp_obj_t ret = mp_obj_subscr(self->subobj[0], index, value);
+        mp_obj_type_t *subobj_type = mp_obj_get_type(self->subobj[0]);
+        mp_obj_t ret = subobj_type->subscr(self_in, index, value);
         // May have called port specific C code. Make sure it didn't mess up the heap.
         assert_heap_ok();
         return ret;


### PR DESCRIPTION
For pixelbuf's [] to be able to call _transmit on the Python subclass, we need to do the subscripting operation specially.