### PR TITLE
py/vm.c: Restore lost bits of MICROPY_OPT_COMPUTED_GOTO_SAVE_SPACE

### DIFF
--- a/py/vm.c
+++ b/py/vm.c
@@ -127,11 +127,21 @@ mp_vm_return_kind_t PLACE_IN_ITCM(mp_execute_bytecode)(mp_code_state_t * code_st
     #endif
     #if MICROPY_OPT_COMPUTED_GOTO
     #include "py/vmentrytable.h"
+    #if MICROPY_OPT_COMPUTED_GOTO_SAVE_SPACE
+    #define ONE_TRUE_DISPATCH() one_true_dispatch : do { \
+        TRACE(ip); \
+        MARK_EXC_IP_GLOBAL(); \
+        goto *(void *)((char *) && entry_MP_BC_LOAD_CONST_FALSE + entry_table[*ip++]); \
+    } while (0)
+    #define DISPATCH() do { goto one_true_dispatch; } while (0)
+    #else
+    #define ONE_TRUE_DISPATCH() DISPATCH()
     #define DISPATCH() do { \
         TRACE(ip); \
         MARK_EXC_IP_GLOBAL(); \
         goto *entry_table[*ip++]; \
-} while (0)
+    } while (0)
+    #endif
     #define DISPATCH_WITH_PEND_EXC_CHECK() goto pending_exception_check
     #define ENTRY(op) entry_##op
     #define ENTRY_DEFAULT entry_default
@@ -197,7 +207,7 @@ mp_vm_return_kind_t PLACE_IN_ITCM(mp_execute_bytecode)(mp_code_state_t * code_st
             for (;;) {
             dispatch_loop:
                 #if MICROPY_OPT_COMPUTED_GOTO
-                DISPATCH();
+                ONE_TRUE_DISPATCH();
                 #else
                 TRACE(ip);
                 MARK_EXC_IP_GLOBAL();


### PR DESCRIPTION
This fixes a problem where boards that enabled this (most SAM D21s) would crash on the first bytecode instruction.

Closes: #4686