### PR TITLE
Update Sparkfun Thing Plus RP2040 pins to match board breakouts

### DIFF
--- a/ports/raspberrypi/boards/sparkfun_thing_plus_rp2040/mpconfigboard.h
+++ b/ports/raspberrypi/boards/sparkfun_thing_plus_rp2040/mpconfigboard.h
@@ -1,14 +1,14 @@
 #define MICROPY_HW_BOARD_NAME "SparkFun Thing Plus - RP2040"
 #define MICROPY_HW_MCU_NAME "rp2040"
 
-#define MICROPY_HW_NEOPIXEL (&pin_GPIO8)
-
-#define DEFAULT_I2C_BUS_SCL (&pin_GPIO7)
-#define DEFAULT_I2C_BUS_SDA (&pin_GPIO6)
-
-#define DEFAULT_SPI_BUS_SCK (&pin_GPIO14)
-#define DEFAULT_SPI_BUS_MOSI (&pin_GPIO15)
-#define DEFAULT_SPI_BUS_MISO (&pin_GPIO12)
-
-#define DEFAULT_UART_BUS_RX (&pin_GPIO1)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO0)
+#define DEFAULT_UART_BUS_RX (&pin_GPIO1)
+
+#define DEFAULT_SPI_BUS_SCK (&pin_GPIO2)
+#define DEFAULT_SPI_BUS_MOSI (&pin_GPIO3)
+#define DEFAULT_SPI_BUS_MISO (&pin_GPIO4)
+
+#define DEFAULT_I2C_BUS_SDA (&pin_GPIO6)
+#define DEFAULT_I2C_BUS_SCL (&pin_GPIO7)
+
+#define MICROPY_HW_NEOPIXEL (&pin_GPIO8)

--- a/ports/raspberrypi/boards/sparkfun_thing_plus_rp2040/pins.c
+++ b/ports/raspberrypi/boards/sparkfun_thing_plus_rp2040/pins.c
@@ -4,11 +4,11 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     // Left side breakouts, top-to-bottom, as labeled
     { MP_ROM_QSTR(MP_QSTR_D6),  MP_ROM_PTR(&pin_GPIO6) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO6) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_D7),  MP_ROM_PTR(&pin_GPIO7) },
     { MP_ROM_QSTR(MP_QSTR_D23), MP_ROM_PTR(&pin_GPIO7) }, // GPIO7 & GPIO23 are shorted together
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO7) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_D22), MP_ROM_PTR(&pin_GPIO22) },
     { MP_ROM_QSTR(MP_QSTR_D21), MP_ROM_PTR(&pin_GPIO21) },
     { MP_ROM_QSTR(MP_QSTR_D20), MP_ROM_PTR(&pin_GPIO20) },
@@ -16,46 +16,46 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D18), MP_ROM_PTR(&pin_GPIO18) },
     { MP_ROM_QSTR(MP_QSTR_D17), MP_ROM_PTR(&pin_GPIO17) },
     { MP_ROM_QSTR(MP_QSTR_D16), MP_ROM_PTR(&pin_GPIO16) },
-    
+
     // Right side breakouts, top-to-bottom, as labeled
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO8) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_GPIO0) },
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO0) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_GPIO1) },
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO1) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_D4),   MP_ROM_PTR(&pin_GPIO4) },
     { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_GPIO4) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_D3),   MP_ROM_PTR(&pin_GPIO3) },
     { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_GPIO3) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_D2),  MP_ROM_PTR(&pin_GPIO2) },
     { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_GPIO2) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_A3),  MP_ROM_PTR(&pin_GPIO29) },
     { MP_ROM_QSTR(MP_QSTR_D29), MP_ROM_PTR(&pin_GPIO29) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_A2),  MP_ROM_PTR(&pin_GPIO28) },
     { MP_ROM_QSTR(MP_QSTR_D28), MP_ROM_PTR(&pin_GPIO28) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_A1),  MP_ROM_PTR(&pin_GPIO27) },
     { MP_ROM_QSTR(MP_QSTR_D27), MP_ROM_PTR(&pin_GPIO27) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_A0),  MP_ROM_PTR(&pin_GPIO28) },
     { MP_ROM_QSTR(MP_QSTR_D26), MP_ROM_PTR(&pin_GPIO28) },
-    
+
     // SD Card
     { MP_ROM_QSTR(MP_QSTR_SD_SCK),  MP_ROM_PTR(&pin_GPIO14)},
     { MP_ROM_QSTR(MP_QSTR_SD_MOSI), MP_ROM_PTR(&pin_GPIO15)},
     { MP_ROM_QSTR(MP_QSTR_SD_MISO), MP_ROM_PTR(&pin_GPIO12)},
     { MP_ROM_QSTR(MP_QSTR_SD_CS),   MP_ROM_PTR(&pin_GPIO9)},
-    
+
     // Others
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO25) }, // on-board LED (separate/additional from neopixel)
-    
+
     { MP_ROM_QSTR(MP_QSTR_I2C),  MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI),  MP_ROM_PTR(&board_spi_obj) },
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },

--- a/ports/raspberrypi/boards/sparkfun_thing_plus_rp2040/pins.c
+++ b/ports/raspberrypi/boards/sparkfun_thing_plus_rp2040/pins.c
@@ -1,37 +1,63 @@
 #include "shared-bindings/board/__init__.h"
 
 STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_GPIO26) },
-    { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_GPIO27) },
-    { MP_ROM_QSTR(MP_QSTR_A2), MP_ROM_PTR(&pin_GPIO28) },
-    { MP_ROM_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_GPIO29) },
-    { MP_ROM_QSTR(MP_QSTR_D24), MP_ROM_PTR(&pin_GPIO24) },
-    { MP_ROM_QSTR(MP_QSTR_D25), MP_ROM_PTR(&pin_GPIO25) },
-    { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_GPIO14) },
-    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_GPIO15) },
-    { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_GPIO12) },
-    { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_GPIO1) },
-    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO1) },
-    { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_GPIO0) },
-    { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO0) },
-    { MP_ROM_QSTR(MP_QSTR_D4), MP_ROM_PTR(&pin_GPIO2) },
-
+    // Left side breakouts, top-to-bottom, as labeled
+    { MP_ROM_QSTR(MP_QSTR_D6),  MP_ROM_PTR(&pin_GPIO6) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO6) },
+    
+    { MP_ROM_QSTR(MP_QSTR_D7),  MP_ROM_PTR(&pin_GPIO7) },
+    { MP_ROM_QSTR(MP_QSTR_D23), MP_ROM_PTR(&pin_GPIO7) }, // GPIO7 & GPIO23 are shorted together
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO7) },
-    { MP_ROM_QSTR(MP_QSTR_D5), MP_ROM_PTR(&pin_GPIO3) },
-    { MP_ROM_QSTR(MP_QSTR_D6), MP_ROM_PTR(&pin_GPIO8) },
-    { MP_ROM_QSTR(MP_QSTR_D9), MP_ROM_PTR(&pin_GPIO9) },
-    { MP_ROM_QSTR(MP_QSTR_D10), MP_ROM_PTR(&pin_GPIO10) },
-    { MP_ROM_QSTR(MP_QSTR_D11), MP_ROM_PTR(&pin_GPIO11) },
-    { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_GPIO12) },
-    { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_GPIO13) },
-    { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO25) },
-
+    
+    { MP_ROM_QSTR(MP_QSTR_D22), MP_ROM_PTR(&pin_GPIO22) },
+    { MP_ROM_QSTR(MP_QSTR_D21), MP_ROM_PTR(&pin_GPIO21) },
+    { MP_ROM_QSTR(MP_QSTR_D20), MP_ROM_PTR(&pin_GPIO20) },
+    { MP_ROM_QSTR(MP_QSTR_D19), MP_ROM_PTR(&pin_GPIO19) },
+    { MP_ROM_QSTR(MP_QSTR_D18), MP_ROM_PTR(&pin_GPIO18) },
+    { MP_ROM_QSTR(MP_QSTR_D17), MP_ROM_PTR(&pin_GPIO17) },
+    { MP_ROM_QSTR(MP_QSTR_D16), MP_ROM_PTR(&pin_GPIO16) },
+    
+    // Right side breakouts, top-to-bottom, as labeled
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO8) },
-    { MP_ROM_QSTR(MP_QSTR_SD_CS), MP_ROM_PTR(&pin_GPIO9)},
-
-    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
-    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
+    
+    { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_GPIO0) },
+    { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO0) },
+    
+    { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_GPIO1) },
+    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO1) },
+    
+    { MP_ROM_QSTR(MP_QSTR_D4),   MP_ROM_PTR(&pin_GPIO4) },
+    { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_GPIO4) },
+    
+    { MP_ROM_QSTR(MP_QSTR_D3),   MP_ROM_PTR(&pin_GPIO3) },
+    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_GPIO3) },
+    
+    { MP_ROM_QSTR(MP_QSTR_D2),  MP_ROM_PTR(&pin_GPIO2) },
+    { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_GPIO2) },
+    
+    { MP_ROM_QSTR(MP_QSTR_A3),  MP_ROM_PTR(&pin_GPIO29) },
+    { MP_ROM_QSTR(MP_QSTR_D29), MP_ROM_PTR(&pin_GPIO29) },
+    
+    { MP_ROM_QSTR(MP_QSTR_A2),  MP_ROM_PTR(&pin_GPIO28) },
+    { MP_ROM_QSTR(MP_QSTR_D28), MP_ROM_PTR(&pin_GPIO28) },
+    
+    { MP_ROM_QSTR(MP_QSTR_A1),  MP_ROM_PTR(&pin_GPIO27) },
+    { MP_ROM_QSTR(MP_QSTR_D27), MP_ROM_PTR(&pin_GPIO27) },
+    
+    { MP_ROM_QSTR(MP_QSTR_A0),  MP_ROM_PTR(&pin_GPIO28) },
+    { MP_ROM_QSTR(MP_QSTR_D26), MP_ROM_PTR(&pin_GPIO28) },
+    
+    // SD Card
+    { MP_ROM_QSTR(MP_QSTR_SD_SCK),  MP_ROM_PTR(&pin_GPIO14)},
+    { MP_ROM_QSTR(MP_QSTR_SD_MOSI), MP_ROM_PTR(&pin_GPIO15)},
+    { MP_ROM_QSTR(MP_QSTR_SD_MISO), MP_ROM_PTR(&pin_GPIO12)},
+    { MP_ROM_QSTR(MP_QSTR_SD_CS),   MP_ROM_PTR(&pin_GPIO9)},
+    
+    // Others
+    { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO25) }, // on-board LED (separate/additional from neopixel)
+    
+    { MP_ROM_QSTR(MP_QSTR_I2C),  MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_SPI),  MP_ROM_PTR(&board_spi_obj) },
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);


### PR DESCRIPTION
This fixes some missing and incorrectly-assigned pins for the SparkFun Thing Plus RP2040 protoboard so that they match what the board has printed. This also changes the default SPI pins from the SD card to the breakout pins on the side of the board (the SD card pins can now be found via `board.SD_*`).

These pins match the EAGLE files posted by sparkfun [here](https://cdn.sparkfun.com/assets/7/f/e/c/2/RP2040_Thing_Plus_Eagle_Files.zip) (marked as 'v10' on the schematic and 'v11' on the board) and seem to be working great on the board I personally have (marked 'v11').

_edit:_  adding link to the Thing Plus RP2040 on SparkFun's website: https://www.sparkfun.com/products/17745