### PR TITLE
`workflow_active` was never defined or used

### DIFF
--- a/supervisor/shared/workflow.h
+++ b/supervisor/shared/workflow.h
@@ -27,4 +27,3 @@
 #pragma once
 
 extern bool supervisor_workflow_connecting(void);
-extern bool supervisor_workflow_active(void);

--- a/supervisor/stub/serial.c
+++ b/supervisor/stub/serial.c
@@ -53,3 +53,7 @@ void serial_write(const char *text) {
 
 void supervisor_workflow_reset(void) {
 }
+
+bool supervisor_workflow_active(void) {
+    return false;
+}

--- a/supervisor/workflow.h
+++ b/supervisor/workflow.h
@@ -29,4 +29,4 @@
 void supervisor_workflow_reset(void);
 
 // True when the user could be actively iterating on their code.
-bool workflow_active(void);
+bool supervisor_workflow_active(void);


### PR DESCRIPTION
`supervisor_workflow_active` needs to be stubbed for when there's no USB