### PR TITLE
esp32-s2: Don't set PWMOut frequency to 0

### DIFF
--- a/ports/esp32s2/common-hal/pwmio/PWMOut.c
+++ b/ports/esp32s2/common-hal/pwmio/PWMOut.c
@@ -128,7 +128,13 @@ pwmout_result_t common_hal_pwmio_pwmout_construct(pwmio_pwmout_obj_t *self,
     if (ledc_channel_config(&(self->chan_handle))) {
         return PWMOUT_INITIALIZATION_ERROR;
     }
-
+    
+    // check the frequency -- 0 is not valid
+    // maybe also want to reject frequency > system_clock / 2 ??
+    if (frequency == 0) {
+        return PWMOUT_INVALID_FREQUENCY;
+    }
+    
     // Make reservations
     reserved_timer_freq[timer_index] = frequency;
     reserved_channels[channel_index] = timer_index;

--- a/ports/esp32s2/common-hal/pwmio/PWMOut.c
+++ b/ports/esp32s2/common-hal/pwmio/PWMOut.c
@@ -63,6 +63,12 @@ pwmout_result_t common_hal_pwmio_pwmout_construct(pwmio_pwmout_obj_t *self,
     uint16_t duty,
     uint32_t frequency,
     bool variable_frequency) {
+
+    // check the frequency (avoid divide by zero below)
+    if (frequency == 0) {
+        return PWMOUT_INVALID_FREQUENCY;
+    }
+
     // Calculate duty cycle
     uint32_t duty_bits = 0;
     uint32_t interval = LEDC_APB_CLK_HZ / frequency;
@@ -127,12 +133,6 @@ pwmout_result_t common_hal_pwmio_pwmout_construct(pwmio_pwmout_obj_t *self,
 
     if (ledc_channel_config(&(self->chan_handle))) {
         return PWMOUT_INITIALIZATION_ERROR;
-    }
-
-    // check the frequency -- 0 is not valid
-    // maybe also want to reject frequency > system_clock / 2 ??
-    if (frequency == 0) {
-        return PWMOUT_INVALID_FREQUENCY;
     }
 
     // Make reservations

--- a/ports/esp32s2/common-hal/pwmio/PWMOut.c
+++ b/ports/esp32s2/common-hal/pwmio/PWMOut.c
@@ -128,13 +128,13 @@ pwmout_result_t common_hal_pwmio_pwmout_construct(pwmio_pwmout_obj_t *self,
     if (ledc_channel_config(&(self->chan_handle))) {
         return PWMOUT_INITIALIZATION_ERROR;
     }
-    
+
     // check the frequency -- 0 is not valid
     // maybe also want to reject frequency > system_clock / 2 ??
     if (frequency == 0) {
         return PWMOUT_INVALID_FREQUENCY;
     }
-    
+
     // Make reservations
     reserved_timer_freq[timer_index] = frequency;
     reserved_channels[channel_index] = timer_index;


### PR DESCRIPTION
FeatherS2 crashes if you set the PWMOut frequency to 0.
This change will raise `ValueError: Invalid PWM frequency` if the requested frequency is 0.
(Lifted from the atmel-samd port)