### PR TITLE
Remove overwrite of run_reason in main

### DIFF
--- a/main.c
+++ b/main.c
@@ -340,7 +340,6 @@ STATIC bool run_code_py(safe_mode_t safe_mode) {
                 board_init();
             }
             #endif
-            supervisor_set_run_reason(RUN_REASON_AUTO_RELOAD);
             reload_requested = false;
             return true;
         }

--- a/main.c
+++ b/main.c
@@ -334,6 +334,8 @@ STATIC bool run_code_py(safe_mode_t safe_mode) {
     bool fake_sleeping = false;
     while (true) {
         RUN_BACKGROUND_TASKS;
+
+        // If a reload was requested by the supervisor or autoreload, return
         if (reload_requested) {
             #if CIRCUITPY_ALARM
             if (fake_sleeping) {
@@ -344,6 +346,7 @@ STATIC bool run_code_py(safe_mode_t safe_mode) {
             return true;
         }
 
+        // If interrupted by keyboard, return
         if (serial_connected() && serial_bytes_available()) {
             #if CIRCUITPY_ALARM
             if (fake_sleeping) {
@@ -370,6 +373,7 @@ STATIC bool run_code_py(safe_mode_t safe_mode) {
         }
         #endif
 
+        // If messages haven't been printed yet, print them
         if (!printed_press_any_key && serial_connected()) {
             if (!serial_connected_at_start) {
                 print_code_py_status_message(safe_mode);
@@ -596,6 +600,7 @@ int __attribute__((used)) main(void) {
     for (;;) {
         if (!skip_repl) {
             exit_code = run_repl();
+            supervisor_set_run_reason(RUN_REASON_REPL_RELOAD);
         }
         if (exit_code == PYEXEC_FORCED_EXIT) {
             if (!first_run) {

--- a/supervisor/shared/autoreload.c
+++ b/supervisor/shared/autoreload.c
@@ -30,6 +30,8 @@
 #include "py/reload.h"
 #include "supervisor/shared/tick.h"
 
+#include "shared-bindings/supervisor/Runtime.h"
+
 static volatile uint32_t autoreload_delay_ms = 0;
 static bool autoreload_enabled = false;
 static bool autoreload_suspended = false;
@@ -44,6 +46,7 @@ inline void autoreload_tick() {
         !autoreload_suspended && !reload_requested) {
         mp_raise_reload_exception();
         reload_requested = true;
+        supervisor_set_run_reason(RUN_REASON_AUTO_RELOAD);
         supervisor_disable_tick();
     }
     autoreload_delay_ms--;
@@ -91,4 +94,5 @@ void autoreload_now() {
     }
     mp_raise_reload_exception();
     reload_requested = true;
+    supervisor_set_run_reason(RUN_REASON_AUTO_RELOAD);
 }


### PR DESCRIPTION
This PR fixes an issue in main that would cause any pre-existing run reason, such as SUPERVISOR_RELOAD set in `supervisor.reload()`, to be overwritten after the `reload_requested` trigger. `autoreload.c` now sets the run reason as AUTO_RELOAD itself.

Resolves #4510
Resolves #3858