### PR TITLE
update github actions xtensa cache id; fix a typo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -506,7 +506,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210422
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210506
     - name: Clone IDF submodules
       run: |
         (cd $IDF_PATH && git submodule update --init)

--- a/shared-bindings/gamepadshift/GamePadShift.c
+++ b/shared-bindings/gamepadshift/GamePadShift.c
@@ -42,7 +42,7 @@
 //|         The ``clock``, ``data`` and ``latch`` parameters are ``DigitalInOut``
 //|         objects connected to the shift register controlling the buttons.
 //|
-//|         They button presses are accumulated, until the ``get_pressed`` method
+//|         The button presses are accumulated, until the ``get_pressed`` method
 //|         is called, at which point the button state is cleared, and the new
 //|         button presses start to be recorded.
 //|


### PR DESCRIPTION
GitHub actions cache is broken again. Also fixes #4717.