### PR TITLE
build a CIRCUITPY_ERASER variant

### DIFF
--- a/main.c
+++ b/main.c
@@ -554,6 +554,15 @@ int __attribute__((used)) main(void) {
 
     stack_init();
 
+    // If this is a CIRCUITPY eraser build, just erase and reformat the filesystem,
+    // and that's it. Don't print anything, etc. Just erase and wait.
+    #if CIRCUITPY_ERASER
+    new_status_color(RED);
+    filesystem_init(true, true);
+    new_status_color(BLUE);
+    while(1) { }
+    #endif
+
     // Create a new filesystem only if we're not in a safe mode.
     // A power brownout here could make it appear as if there's
     // no SPI flash filesystem, and we might erase the existing one.

--- a/py/circuitpy_mpconfig.mk
+++ b/py/circuitpy_mpconfig.mk
@@ -26,6 +26,11 @@
 # Boards default to all modules enabled (with exceptions)
 # Manually disable by overriding in #mpconfigboard.mk
 
+# True if this is a special build that does nothing but erase and
+# reformat CIRCUITPY.
+CIRCUITPY_ERASER ?= 0
+CFLAGS += -DCIRCUITPY_ERASER=$(CIRCUITPY_ERASER)
+
 # Smaller builds can be forced for resource constrained chips (typically SAMD21s
 # without external flash) by setting CIRCUITPY_FULL_BUILD=0. Avoid using this
 # for merely incomplete ports, as it changes settings in other files.

--- a/tools/build_release_files.py
+++ b/tools/build_release_files.py
@@ -59,7 +59,9 @@ for board in build_boards:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
-        clean_build = clean_build_check_result.returncode == 0
+
+        # If settings is non-empty, assume we need a clean build.
+        clean_build = clean_build_check_result.returncode == 0 or settings
 
         build_dir = f"build-{board}"
         if clean_build:

--- a/tools/build_release_files.py
+++ b/tools/build_release_files.py
@@ -13,7 +13,7 @@ import build_board_info as build_info
 import time
 
 for port in build_info.SUPPORTED_PORTS:
-    result = subprocess.run("rm -rf ../ports/{port}/build*".format(port=port), shell=True)
+    result = subprocess.run(f"rm -rf ../ports/{port}/build*", shell=True)
 
 PARALLEL = "-j 5"
 if "GITHUB_ACTION" in os.environ:
@@ -34,42 +34,39 @@ print("Note: Not building languages", set(all_languages) - set(languages))
 
 exit_status = 0
 cores = multiprocessing.cpu_count()
-print("building boards with parallelism {}".format(cores))
+print(f"building boards with parallelism {cores}")
 for board in build_boards:
-    bin_directory = "../bin/{}/".format(board)
+    bin_directory = f"../bin/{board}/"
     os.makedirs(bin_directory, exist_ok=True)
     board_info = all_boards[board]
+    port = board_info["port"]
 
-    for language in languages:
-        bin_directory = "../bin/{board}/{language}".format(board=board, language=language)
+    variants = [(language, language, "") for language in languages]
+    # Add non-language variant builds.
+    variants.append(("CIRCUITPY_ERASER", "en_US", "CIRCUITPY_ERASER=1"))
+
+    for (variant_name, language, settings) in variants:
+        bin_directory = f"../bin/{board}/{variant_name}"
         os.makedirs(bin_directory, exist_ok=True)
         start_time = time.monotonic()
 
-        # Normally different language builds are all done based on the same set of compiled sources.
+        # Normally different language/variant builds are all done based on the same set of compiled sources.
         # But sometimes a particular language needs to be built from scratch, if, for instance,
         # CFLAGS_INLINE_LIMIT is set for a particular language to make it fit.
         clean_build_check_result = subprocess.run(
-            "make -C ../ports/{port} TRANSLATION={language} BOARD={board} check-release-needs-clean-build -j {cores} | fgrep 'RELEASE_NEEDS_CLEAN_BUILD = 1'".format(
-                port=board_info["port"], language=language, board=board, cores=cores
-            ),
+            f"make -C ../ports/{port} TRANSLATION={language} BOARD={board} {settings} check-release-needs-clean-build -j {cores} | fgrep 'RELEASE_NEEDS_CLEAN_BUILD = 1'",
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
         clean_build = clean_build_check_result.returncode == 0
 
-        build_dir = "build-{board}".format(board=board)
+        build_dir = f"build-{board}"
         if clean_build:
-            build_dir += "-{language}".format(language=language)
+            build_dir += f"-{variant_name}"
 
         make_result = subprocess.run(
-            "make -C ../ports/{port} TRANSLATION={language} BOARD={board} BUILD={build} -j {cores}".format(
-                port=board_info["port"],
-                language=language,
-                board=board,
-                build=build_dir,
-                cores=cores,
-            ),
+            f"make -C ../ports/{port} TRANSLATION={language} BOARD={board} {settings} BUILD={build_dir} -j {cores}",
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -84,33 +81,24 @@ for board in build_boards:
         other_output = ""
 
         for extension in board_info["extensions"]:
-            temp_filename = "../ports/{port}/{build}/firmware.{extension}".format(
-                port=board_info["port"], build=build_dir, extension=extension
-            )
+            temp_filename = f"../ports/{port}/{build_dir}/firmware.{extension}"
             for alias in board_info["aliases"] + [board]:
-                bin_directory = "../bin/{alias}/{language}".format(alias=alias, language=language)
+                bin_directory = f"../bin/{alias}/{variant_name}"
                 os.makedirs(bin_directory, exist_ok=True)
                 final_filename = (
-                    "adafruit-circuitpython-{alias}-{language}-{version}.{extension}".format(
-                        alias=alias, language=language, version=version, extension=extension
-                    )
+                    f"adafruit-circuitpython-{alias}-{variant_name}-{version}.{extension}"
                 )
                 final_filename = os.path.join(bin_directory, final_filename)
                 try:
                     shutil.copyfile(temp_filename, final_filename)
                 except FileNotFoundError:
-                    other_output = "Cannot find file {}".format(temp_filename)
+                    other_output = f"Cannot find file {temp_filename}"
                     if exit_status == 0:
                         exit_status = 1
 
+        clean_build_str = " (clean_build)" if clean_build else ""
         print(
-            "Build {board} for {language}{clean_build} took {build_duration:.2f}s and {success}".format(
-                board=board,
-                language=language,
-                clean_build=(" (clean_build)" if clean_build else ""),
-                build_duration=build_duration,
-                success=success,
-            )
+            f"Build {board} for {variant_name}{clean_build_str} took {build_duration:.2f}s and {success}"
         )
 
         print(make_result.stdout.decode("utf-8"))


### PR DESCRIPTION
For each board, this builds one special build that erases CIRCUITPY when loaded. The status LED starts at red and goes to blue when done. The build does nothing after erasing: no USB mounting, etc. So it's language-independent.

The GitHub Actions build will create a new `CIRCUITPY_ERASER` directory in S3 for each board, alongside the language directories.

Basically, this is a simple way of making per-board flash erasers without involving Arduino, etc.

Tested on a Trinket M0, but I need to see GitHub Actions working properly too.