### PR TITLE
string compession: Error if compressed string length exceeds 255

### DIFF
--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -423,6 +423,8 @@ def compute_huffman_coding(translations, compression_filename):
     max_translation_encoded_length = max(
         len(translation.encode("utf-8")) for (original, translation) in translations
     )
+    if max_translation_encoded_length > 255:
+        raise ValueError("Maximum encoded length too long")
 
     wends = list(len(w) - 2 for w in words)
     for i in range(1, len(wends)):


### PR DESCRIPTION
I have an idea about how to handle MP_ERROR_TEXT in native code .mpy files, but the simplest version depends on all the encoded string lengths fitting in 8 bits (so than an 8-bit sentinel length value of b'\x00' can be used to indicate that it's a "not-actually-compressed string")

If this passes CI, I can use it as a basis for work on that idea.