### PR TITLE
Swap mis-labelled D0/D1 pins on SparkFun Pro Micro RP2040

### DIFF
--- a/ports/raspberrypi/boards/sparkfun_pro_micro_rp2040/pins.c
+++ b/ports/raspberrypi/boards/sparkfun_pro_micro_rp2040/pins.c
@@ -20,9 +20,9 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SDA),  MP_ROM_PTR(&pin_GPIO16) },
     { MP_ROM_QSTR(MP_QSTR_SCL),  MP_ROM_PTR(&pin_GPIO17) },
 
-    { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_GPIO1) },
+    { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_GPIO1) },
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO1) },
-    { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_GPIO0) },
+    { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_GPIO0) },
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO0) },
 
     { MP_ROM_QSTR(MP_QSTR_D2), MP_ROM_PTR(&pin_GPIO2) },


### PR DESCRIPTION
This swaps pins D0 and D1 to correlate with GPIO0 and GPIO1, respectively; they were previously swapped so when I asked for D0 in the software I had to interface with D1 on the board (second pin down on the left instead of first).

This now matches the board schematic ([via](https://github.com/sparkfun/SparkFun_Pro_Micro-RP2040/tree/ad320adf28a23a6a8c737677f93919c821471bb7), see snipped image of the schematic below), and I also confirmed that all the other pins correctly match the board too (for 'v11' schematic and 'v11' board).

![image](https://user-images.githubusercontent.com/2113065/117557906-00a5d780-b046-11eb-8be6-57fc84d788f6.png)
