### PR TITLE
free up PA00 and PA01 on BHB

### DIFF
--- a/ports/atmel-samd/boards/winterbloom_big_honking_button/mpconfigboard.h
+++ b/ports/atmel-samd/boards/winterbloom_big_honking_button/mpconfigboard.h
@@ -9,7 +9,7 @@
 #define SPI_FLASH_CS_PIN            &pin_PA27
 
 // These are pins not to reset.
-#define MICROPY_PORT_A        (PORT_PA00 | PORT_PA01)
+#define MICROPY_PORT_A        (0)
 #define MICROPY_PORT_B        (0)
 #define MICROPY_PORT_C        (0)
 


### PR DESCRIPTION
BHB's definition assigns `PA00` and `PA01` to `MICROPYTHON_PORT_A`:

https://github.com/adafruit/circuitpython/blob/af6d97f67fd8e35f60119af332d5a2178d89dc50/ports/atmel-samd/boards/winterbloom_big_honking_button/mpconfigboard.h#L12

If you try to use one of those ports from user code, for example via the neopixel library, you'll get an error saying the pin is in use. However, in the current production design those pins are not connected and so should be made available for hax. This change frees them up for use.

I tested this by checking out the `6.2.0` tag, applying the change in this PR, recompiling, and installing on my BHB. After applying this fix I'm able to use `PA00` as expected and the rest of the features of the default firmware seem to work as expected. I did not test against current head. Let me know if you need more testing.

/cc @theacodes for review