### PR TITLE
modmath: Remove stray "pragma GCC diagnostic pop"

### DIFF
--- a/py/modmath.c
+++ b/py/modmath.c
@@ -244,7 +244,6 @@ STATIC mp_obj_t mp_math_log(size_t n_args, const mp_obj_t *args) {
         if (base <= (mp_float_t)0.0) {
             math_error();
         } else if (base == (mp_float_t)1.0) {
-            #pragma GCC diagnostic pop
             mp_raise_msg(&mp_type_ZeroDivisionError, MP_ERROR_TEXT("division by zero"));
         }
         return mp_obj_new_float(l / MICROPY_FLOAT_C_FUN(log)(base));


### PR DESCRIPTION
This caused an error when building on macos:

```
../../py/modmath.c:247:36: error: pragma diagnostic pop could not pop, no matching push [-Werror,-Wunknown-pragmas]
            #pragma GCC diagnostic pop
                                   ^
1 error generated.
```

The pragma was half-removed during the merge of micropython.