### PR TITLE
Make two error messages in USB sentence case

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2182,11 +2182,7 @@ msgid "UART write error"
 msgstr ""
 
 #: shared-module/usb_hid/Device.c
-msgid "USB Busy"
-msgstr ""
-
-#: shared-module/usb_hid/Device.c
-msgid "USB Error"
+msgid "USB busy"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -2195,6 +2191,10 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid "USB devices specify too many interface names."
+msgstr ""
+
+#: shared-module/usb_hid/Device.c
+msgid "USB error"
 msgstr ""
 
 #: shared-bindings/_bleio/UUID.c

--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -204,13 +204,13 @@ void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t *
     }
 
     if (!tud_hid_ready()) {
-        mp_raise_msg(&mp_type_OSError,  translate("USB Busy"));
+        mp_raise_msg(&mp_type_OSError,  translate("USB busy"));
     }
 
     memcpy(self->in_report_buffer, report, len);
 
     if (!tud_hid_report(self->report_id, self->in_report_buffer, len)) {
-        mp_raise_msg(&mp_type_OSError, translate("USB Error"));
+        mp_raise_msg(&mp_type_OSError, translate("USB brror"));
     }
 }
 

--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -210,7 +210,7 @@ void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t *
     memcpy(self->in_report_buffer, report, len);
 
     if (!tud_hid_report(self->report_id, self->in_report_buffer, len)) {
-        mp_raise_msg(&mp_type_OSError, translate("USB brror"));
+        mp_raise_msg(&mp_type_OSError, translate("USB error"));
     }
 }
 


### PR DESCRIPTION
I made a few error messages in the `usb_hid` code `Sentence case`, where they were previously `Title Case`.

Sorry for the confusing original PR message, but `gh` did something weird with the submodule commits. 