### PR TITLE
Add build_memory_info for esp32s2

### DIFF
--- a/ports/esp32s2/.gitignore
+++ b/ports/esp32s2/.gitignore
@@ -1,2 +1,2 @@
-build*
+build*/
 sdkconfig.old

--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -316,11 +316,11 @@ esp-idf-stamp: $(BUILD)/esp-idf/config/sdkconfig.h
 $(BUILD)/firmware.elf: $(OBJ) | esp-idf-stamp
 	$(STEPECHO) "LINK $@"
 	$(Q)$(CC) -o $@ $(LDFLAGS) $^ -Wl,--start-group $(ESP_IDF_COMPONENTS_EXPANDED) $(BINARY_BLOBS) $(MBEDTLS_COMPONENTS_LINK_EXPANDED) build-$(BOARD)/esp-idf/esp-idf/newlib/libnewlib.a  -Wl,--end-group -u newlib_include_pthread_impl -Wl,--start-group $(LIBS) -Wl,--end-group build-$(BOARD)/esp-idf/esp-idf/pthread/libpthread.a  -u __cxx_fatal_exception
-	$(Q)$(SIZE) $@ | $(PYTHON3) tools/build_memory_info.py $(BUILD)/esp-idf/sdkconfig
 
-$(BUILD)/circuitpython-firmware.bin: $(BUILD)/firmware.elf
+$(BUILD)/circuitpython-firmware.bin: $(BUILD)/firmware.elf | tools/build_memory_info.py
 	$(STEPECHO) "Create $@"
 	$(Q)esptool.py --chip esp32s2 elf2image $(FLASH_FLAGS) --elf-sha256-offset 0xb0 -o $@ $^
+	$(Q)$(PYTHON3) tools/build_memory_info.py $< $(BUILD)/esp-idf/sdkconfig $@
 
 $(BUILD)/firmware.bin: $(BUILD)/circuitpython-firmware.bin | esp-idf-stamp
 	$(Q)$(PYTHON) ../../tools/join_bins.py $@ 0x1000 $(BUILD)/esp-idf/bootloader/bootloader.bin 0x8000 $(BUILD)/esp-idf/partition_table/partition-table.bin 0x10000 $(BUILD)/circuitpython-firmware.bin

--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -316,7 +316,7 @@ esp-idf-stamp: $(BUILD)/esp-idf/config/sdkconfig.h
 $(BUILD)/firmware.elf: $(OBJ) | esp-idf-stamp
 	$(STEPECHO) "LINK $@"
 	$(Q)$(CC) -o $@ $(LDFLAGS) $^ -Wl,--start-group $(ESP_IDF_COMPONENTS_EXPANDED) $(BINARY_BLOBS) $(MBEDTLS_COMPONENTS_LINK_EXPANDED) build-$(BOARD)/esp-idf/esp-idf/newlib/libnewlib.a  -Wl,--end-group -u newlib_include_pthread_impl -Wl,--start-group $(LIBS) -Wl,--end-group build-$(BOARD)/esp-idf/esp-idf/pthread/libpthread.a  -u __cxx_fatal_exception
-	# $(Q)$(SIZE) $@ | $(PYTHON3) $(TOP)/tools/build_memory_info.py $(BUILD)/esp-idf/esp-idf/esp32s2/esp32s2_out.ld
+	$(Q)$(SIZE) $@ | $(PYTHON3) tools/build_memory_info.py $(BUILD)/esp-idf/sdkconfig
 
 $(BUILD)/circuitpython-firmware.bin: $(BUILD)/firmware.elf
 	$(STEPECHO) "Create $@"

--- a/ports/esp32s2/tools/build_memory_info.py
+++ b/ports/esp32s2/tools/build_memory_info.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+# SPDX-FileCopyrightText: 2014 MicroPython & CircuitPython contributors (https://github.com/adafruit/circuitpython/graphs/contributors)
+#
+# SPDX-License-Identifier: MIT
+
+import re
+import sys
+
+# Handle size constants with K or M suffixes (allowed in .ld but not in Python).
+K_PATTERN = re.compile(r"([0-9]+)[kK]")
+K_REPLACE = r"(\1*1024)"
+
+M_PATTERN = re.compile(r"([0-9]+)[mM]")
+M_REPLACE = r"(\1*1024*1024)"
+
+print()
+
+text = 0
+data = 0
+bss = 0
+# stdin is the linker output.
+for line in sys.stdin:
+    # Uncomment to see linker output.
+    # print(line)
+    line = line.strip()
+    if not line.startswith("text"):
+        text, data, bss = map(int, line.split()[:3])
+
+
+def partition_size(arg):
+    if "4MB" in arg:
+        return "1408K"
+    else:
+        return "2048K"
+
+
+regions = {}
+# This file is the linker script.
+with open(sys.argv[1], "r") as f:
+    for line in f:
+        line = line.strip()
+        if line.startswith("CONFIG_SPIRAM_SIZE"):
+            regions["RAM"] = line.split("=")[-1]
+        if line.startswith("CONFIG_PARTITION_TABLE_FILENAME"):
+            regions["FLASH_FIRMWARE"] = partition_size(line.split("=")[-1])
+
+for region in regions:
+    space = regions[region]
+    if "/*" in space:
+        space = space.split("/*")[0]
+    space = K_PATTERN.sub(K_REPLACE, space)
+    space = M_PATTERN.sub(M_REPLACE, space)
+    regions[region] = int(eval(space))
+
+firmware_region = regions["FLASH_FIRMWARE"]
+ram_region = regions["RAM"]
+
+used_flash = data + text
+free_flash = firmware_region - used_flash
+used_ram = data + bss
+free_ram = ram_region - used_ram
+print(
+    "{} bytes used, {} bytes free in flash firmware space out of {} bytes ({}kB).".format(
+        used_flash, free_flash, firmware_region, firmware_region / 1024
+    )
+)
+print(
+    "{} bytes used, {} bytes free in ram for stack and heap out of {} bytes ({}kB).".format(
+        used_ram, free_ram, ram_region, ram_region / 1024
+    )
+)
+print()
+
+# Check that we have free flash space. GCC doesn't fail when the text + data
+# sections don't fit in FLASH. It only counts data in RAM.
+if free_flash < 0:
+    print("Too little flash!!!")
+    print()
+    sys.exit(-1)


### PR DESCRIPTION
This detects an overflowed flash partition, such as
```
1452105 bytes used, -10313 bytes free in flash firmware space out of 1441792 bytes (1408.0kB).
444428 bytes used, 1652724 bytes free in ram for stack and heap out of 2097152 bytes (2048.0kB).
```
on a metro esp32-s2 built with debugging.

Fixes #3970.