### PR TITLE
[resolves #4771] DEBUG UART supported on ATMSAME5x

### DIFF
--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -255,21 +255,18 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
 }
 
 void common_hal_busio_uart_never_reset(busio_uart_obj_t *self) {
-#if (1)
-    never_reset_sercom(self->usart_desc.device.hw);
-    never_reset_pin_number(self->rx_pin);
-    never_reset_pin_number(self->tx_pin);
-    return;
-#else
-    for (size_t i = 0; i < MP_ARRAY_SIZE(mcu_uart_banks); i++) {
-        if (mcu_uart_banks[i] == self->handle.Instance) {
-            never_reset_uart[i] = true;
-            never_reset_pin_number(self->tx->pin->port, self->tx->pin->number);
-            never_reset_pin_number(self->rx->pin->port, self->rx->pin->number);
-            break;
+    for (size_t i = 0; i < MP_ARRAY_SIZE(sercom_insts); i++) {
+        const Sercom *sercom = sercom_insts[i];
+        Sercom *hw = (Sercom *)(self->usart_desc.device.hw);
+
+        // Reserve pins for active UART only
+        if (sercom == hw) {
+            never_reset_sercom(hw);
+            never_reset_pin_number(self->rx_pin);
+            never_reset_pin_number(self->tx_pin);
         }
     }
-#endif
+    return;
 }
 
 bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {

--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -45,6 +45,8 @@
 
 #include "samd/sercom.h"
 
+#include "common-hal/busio/SPI.h" // for never_reset_sercom
+
 #define UART_DEBUG(...) (void)0
 // #define UART_DEBUG(...) mp_printf(&mp_plat_print __VA_OPT__(,) __VA_ARGS__)
 
@@ -152,16 +154,22 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
 
     if (rx && receiver_buffer_size > 0) {
         self->buffer_length = receiver_buffer_size;
-        // Initially allocate the UART's buffer in the long-lived part of the
-        // heap.  UARTs are generally long-lived objects, but the "make long-
-        // lived" machinery is incapable of moving internal pointers like
-        // self->buffer, so do it manually.  (However, as long as internal
-        // pointers like this are NOT moved, allocating the buffer
-        // in the long-lived pool is not strictly necessary)
-        self->buffer = (uint8_t *)gc_alloc(self->buffer_length * sizeof(uint8_t), false, true);
-        if (self->buffer == NULL) {
-            common_hal_busio_uart_deinit(self);
-            mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"), self->buffer_length * sizeof(uint8_t));
+        if (NULL != receiver_buffer) {
+            self->buffer = receiver_buffer;
+        }
+        else {
+            // Initially allocate the UART's buffer in the long-lived part of the
+            // heap.  UARTs are generally long-lived objects, but the "make long-
+            // lived" machinery is incapable of moving internal pointers like
+            // self->buffer, so do it manually.  (However, as long as internal
+            // pointers like this are NOT moved, allocating the buffer
+            // in the long-lived pool is not strictly necessary)
+
+            self->buffer = (uint8_t *)gc_alloc(self->buffer_length * sizeof(uint8_t), false, true);
+            if (self->buffer == NULL) {
+                common_hal_busio_uart_deinit(self);
+                mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"), self->buffer_length * sizeof(uint8_t));
+            }
         }
     } else {
         self->buffer_length = 0;
@@ -244,6 +252,24 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     }
 
     usart_async_enable(usart_desc_p);
+}
+
+void common_hal_busio_uart_never_reset(busio_uart_obj_t *self) {
+#if (1)
+    never_reset_sercom(self->usart_desc.device.hw);
+    never_reset_pin_number(self->rx_pin);
+    never_reset_pin_number(self->tx_pin);
+    return;
+#else
+    for (size_t i = 0; i < MP_ARRAY_SIZE(mcu_uart_banks); i++) {
+        if (mcu_uart_banks[i] == self->handle.Instance) {
+            never_reset_uart[i] = true;
+            never_reset_pin_number(self->tx->pin->port, self->tx->pin->number);
+            never_reset_pin_number(self->rx->pin->port, self->rx->pin->number);
+            break;
+        }
+    }
+#endif
 }
 
 bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -67,7 +67,7 @@ void serial_early_init(void) {
     const mcu_pin_obj_t *tx = MP_OBJ_TO_PTR(DEBUG_UART_TX);
 
     common_hal_busio_uart_construct(&debug_uart, tx, rx, NULL, NULL, NULL,
-        false, 115200, 8, UART_PARITY_NONE, 1, 1.0f, 64,
+        false, 115200, 8, BUSIO_UART_PARITY_NONE, 1, 1.0f, 64,
         buf_array, true);
     common_hal_busio_uart_never_reset(&debug_uart);
     #endif


### PR DESCRIPTION
Works on ATSAME51J20A custom board. This pull request does not include asf4 configuration, which is board specific.