### PR TITLE
spresense: Fix USB CDC and MSC

### DIFF
--- a/ports/cxd56/mpconfigport.h
+++ b/ports/cxd56/mpconfigport.h
@@ -37,7 +37,7 @@
 // so define these before #include'ing that file.
 #define USB_CDC_EP_NUM_NOTIFICATION (3)
 #define USB_CDC_EP_NUM_DATA_OUT (2)
-#define USB_CDC_EP_NUM_DATA_IN (2)
+#define USB_CDC_EP_NUM_DATA_IN (1)
 #define USB_MSC_EP_NUM_OUT (5)
 #define USB_MSC_EP_NUM_IN (4)
 

--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -63,11 +63,11 @@ static const uint8_t usb_msc_descriptor_template[] = {
     0xFF,        // 11 bEndpointAddress (IN/D2H) [SET AT RUNTIME: 0x80 | number]
 #define MSC_IN_ENDPOINT_INDEX (11)
     0x02,        // 12 bmAttributes (Bulk)
-#if USB_HIGHSPEED
+    #if USB_HIGHSPEED
     0x00, 0x02,  // 13,14 wMaxPacketSize 512
-#else
+    #else
     0x40, 0x00,  // 13,14 wMaxPacketSize 64
-#endif
+    #endif
     0x00,        // 15 bInterval 0 (unit depends on device speed)
 
     // MSC Endpoint OUT Descriptor
@@ -76,11 +76,11 @@ static const uint8_t usb_msc_descriptor_template[] = {
     0xFF,        // 18 bEndpointAddress (OUT/H2D) [SET AT RUNTIME]
 #define MSC_OUT_ENDPOINT_INDEX (18)
     0x02,        // 19 bmAttributes (Bulk)
-#if USB_HIGHSPEED
+    #if USB_HIGHSPEED
     0x00, 0x02,  // 20,21 wMaxPacketSize 512
-#else
+    #else
     0x40, 0x00,  // 20,21 wMaxPacketSize 64
-#endif
+    #endif
     0x00,        // 22 bInterval 0 (unit depends on device speed)
 };
 

--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -63,7 +63,11 @@ static const uint8_t usb_msc_descriptor_template[] = {
     0xFF,        // 11 bEndpointAddress (IN/D2H) [SET AT RUNTIME: 0x80 | number]
 #define MSC_IN_ENDPOINT_INDEX (11)
     0x02,        // 12 bmAttributes (Bulk)
+#if USB_HIGHSPEED
+    0x00, 0x02,  // 13,14 wMaxPacketSize 512
+#else
     0x40, 0x00,  // 13,14 wMaxPacketSize 64
+#endif
     0x00,        // 15 bInterval 0 (unit depends on device speed)
 
     // MSC Endpoint OUT Descriptor
@@ -72,7 +76,11 @@ static const uint8_t usb_msc_descriptor_template[] = {
     0xFF,        // 18 bEndpointAddress (OUT/H2D) [SET AT RUNTIME]
 #define MSC_OUT_ENDPOINT_INDEX (18)
     0x02,        // 19 bmAttributes (Bulk)
+#if USB_HIGHSPEED
+    0x00, 0x02,  // 20,21 wMaxPacketSize 512
+#else
     0x40, 0x00,  // 20,21 wMaxPacketSize 64
+#endif
     0x00,        // 22 bInterval 0 (unit depends on device speed)
 };
 

--- a/shared-module/usb_cdc/__init__.c
+++ b/shared-module/usb_cdc/__init__.c
@@ -121,11 +121,11 @@ static const uint8_t usb_cdc_descriptor_template[] = {
     0xFF,        // 54 bEndpointAddress (OUT/H2D) [SET AT RUNTIME]
 #define CDC_DATA_OUT_ENDPOINT_INDEX 54
     0x02,        // 55 bmAttributes (Bulk)
-#if USB_HIGHSPEED
+    #if USB_HIGHSPEED
     0x00, 0x02,  // 56,57  wMaxPacketSize 512
-#else
+    #else
     0x40, 0x00,  // 56,57  wMaxPacketSize 64
-#endif
+    #endif
     0x00,        // 58 bInterval 0 (unit depends on device speed)
 
     // CDC Data IN Endpoint Descriptor
@@ -134,11 +134,11 @@ static const uint8_t usb_cdc_descriptor_template[] = {
     0xFF,        // 61 bEndpointAddress (IN/D2H) [SET AT RUNTIME: 0x80 | number]
 #define CDC_DATA_IN_ENDPOINT_INDEX 61
     0x02,        // 62 bmAttributes (Bulk)
-#if USB_HIGHSPEED
+    #if USB_HIGHSPEED
     0x00, 0x02,  // 63,64 wMaxPacketSize 512
-#else
+    #else
     0x40, 0x00,  // 63,64 wMaxPacketSize 64
-#endif
+    #endif
     0x00,        // 65 bInterval 0 (unit depends on device speed)
 };
 

--- a/shared-module/usb_cdc/__init__.c
+++ b/shared-module/usb_cdc/__init__.c
@@ -121,7 +121,11 @@ static const uint8_t usb_cdc_descriptor_template[] = {
     0xFF,        // 54 bEndpointAddress (OUT/H2D) [SET AT RUNTIME]
 #define CDC_DATA_OUT_ENDPOINT_INDEX 54
     0x02,        // 55 bmAttributes (Bulk)
+#if USB_HIGHSPEED
+    0x00, 0x02,  // 56,57  wMaxPacketSize 512
+#else
     0x40, 0x00,  // 56,57  wMaxPacketSize 64
+#endif
     0x00,        // 58 bInterval 0 (unit depends on device speed)
 
     // CDC Data IN Endpoint Descriptor
@@ -130,7 +134,11 @@ static const uint8_t usb_cdc_descriptor_template[] = {
     0xFF,        // 61 bEndpointAddress (IN/D2H) [SET AT RUNTIME: 0x80 | number]
 #define CDC_DATA_IN_ENDPOINT_INDEX 61
     0x02,        // 62 bmAttributes (Bulk)
+#if USB_HIGHSPEED
+    0x00, 0x02,  // 63,64 wMaxPacketSize 512
+#else
     0x40, 0x00,  // 63,64 wMaxPacketSize 64
+#endif
     0x00,        // 65 bInterval 0 (unit depends on device speed)
 };
 

--- a/shared-module/usb_midi/__init__.c
+++ b/shared-module/usb_midi/__init__.c
@@ -127,7 +127,11 @@ static const uint8_t usb_midi_descriptor_template[] = {
     0xFF,        // 66 bEndpointAddress (OUT/H2D) [SET AT RUNTIME]
 #define MIDI_STREAMING_OUT_ENDPOINT_INDEX (66)
     0x02,        // 67 bmAttributes (Bulk)
+    #if USB_HIGHSPEED
+    0x00, 0x02,  // 68,69 wMaxPacketSize (512)
+    #else
     0x40, 0x00,  // 68,69 wMaxPacketSize (64)
+    #endif
     0x00,        // 70 bInterval 0 (unit depends on device speed)
 
     // MIDI Data Endpoint Descriptor
@@ -143,7 +147,11 @@ static const uint8_t usb_midi_descriptor_template[] = {
     0xFF,        // 78 bEndpointAddress (IN/D2H) [SET AT RUNTIME: 0x80 | number]
 #define MIDI_STREAMING_IN_ENDPOINT_INDEX (78)
     0x02,        // 79 bmAttributes (Bulk)
-    0x40, 0x00,  // 8081 wMaxPacketSize 64
+    #if USB_HIGHSPEED
+    0x00, 0x02,  // 80, 81 wMaxPacketSize (512)
+    #else
+    0x40, 0x00,  // 80, 81 wMaxPacketSize (64)
+    #endif
     0x00,        // 82 bInterval 0 (unit depends on device speed)
 
     // MIDI Data Endpoint Descriptor


### PR DESCRIPTION
After the #4689, the Spresense port stopped working. EP descriptor for CDC and MSC set max packet size to 64. For `USB_HIGHSPEED` this should be 512.