### PR TITLE
Add Analog Support for STM32F746ZG

### DIFF
--- a/ports/stm/common-hal/analogio/AnalogIn.c
+++ b/ports/stm/common-hal/analogio/AnalogIn.c
@@ -31,10 +31,49 @@
 
 #include "shared-bindings/microcontroller/Pin.h"
 
+#ifdef STM32F405xx 
 #include "stm32f4xx_hal.h"
 #include "stm32f4xx_ll_gpio.h"
 #include "stm32f4xx_ll_adc.h"
 #include "stm32f4xx_ll_bus.h"
+#endif 
+
+#ifdef STM32F407xx
+#include "stm32f4xx_hal.h"
+#include "stm32f4xx_ll_gpio.h"
+#include "stm32f4xx_ll_adc.h"
+#include "stm32f4xx_ll_bus.h"
+#endif 
+
+#ifdef STM32F401xE 
+#include "stm32f4xx_hal.h"
+#include "stm32f4xx_ll_gpio.h"
+#include "stm32f4xx_ll_adc.h"
+#include "stm32f4xx_ll_bus.h"
+#endif 
+
+#ifdef STM32F411xE 
+#include "stm32f4xx_hal.h"
+#include "stm32f4xx_ll_gpio.h"
+#include "stm32f4xx_ll_adc.h"
+#include "stm32f4xx_ll_bus.h"
+#endif 
+
+
+#ifdef STM32F412Zx
+#include "stm32f4xx_hal.h"
+#include "stm32f4xx_ll_gpio.h"
+#include "stm32f4xx_ll_adc.h"
+#include "stm32f4xx_ll_bus.h"
+#endif 
+
+
+#ifdef STM32F746xx
+#include "stm32f7xx_hal.h"
+#include "stm32f7xx_ll_gpio.h"
+#include "stm32f7xx_ll_adc.h"
+#include "stm32f7xx_ll_bus.h"
+#endif
 
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self,
     const mcu_pin_obj_t *pin) {

--- a/ports/stm/common-hal/analogio/AnalogOut.c
+++ b/ports/stm/common-hal/analogio/AnalogOut.c
@@ -37,7 +37,32 @@
 
 #include "common-hal/microcontroller/Pin.h"
 
+
+#ifdef STM32F405xx 
 #include "stm32f4xx_hal.h"
+#endif 
+
+#ifdef STM32F407xx
+#include "stm32f4xx_hal.h"
+#endif 
+
+#ifdef STM32F401xE 
+#include "stm32f4xx_hal.h"
+#endif 
+
+#ifdef STM32F411xE 
+#include "stm32f4xx_hal.h"
+#endif 
+
+
+#ifdef STM32F412Zx
+#include "stm32f4xx_hal.h"
+#endif 
+
+
+#ifdef STM32F746xx
+#include "stm32f7xx_hal.h"
+#endif
 
 // DAC is shared between both channels.
 #if HAS_DAC

--- a/ports/stm/common-hal/analogio/AnalogOut.h
+++ b/ports/stm/common-hal/analogio/AnalogOut.h
@@ -31,7 +31,32 @@
 #include "common-hal/microcontroller/Pin.h"
 
 #include "py/obj.h"
+
+#ifdef STM32F405xx 
 #include "stm32f4xx_hal.h"
+#endif 
+
+#ifdef STM32F407xx
+#include "stm32f4xx_hal.h"
+#endif 
+
+#ifdef STM32F401xE 
+#include "stm32f4xx_hal.h"
+#endif 
+
+#ifdef STM32F411xE 
+#include "stm32f4xx_hal.h"
+#endif 
+
+
+#ifdef STM32F412Zx
+#include "stm32f4xx_hal.h"
+#endif 
+
+#ifdef STM32F746xx
+#include "stm32f7xx_hal.h"
+#endif
+
 #include "peripherals/periph.h"
 
 typedef struct {

--- a/ports/stm/mpconfigport.mk
+++ b/ports/stm/mpconfigport.mk
@@ -48,7 +48,7 @@ endif
 
 ifeq ($(MCU_SERIES),F7)
         # Not yet implemented common-hal modules:
-        CIRCUITPY_ANALOGIO ?= 0
+        CIRCUITPY_ANALOGIO ?= 1
         CIRCUITPY_AUDIOBUSIO ?= 0
         CIRCUITPY_AUDIOIO ?= 0
         CIRCUITPY_COUNTIO ?= 0

--- a/ports/stm/peripherals/periph.h
+++ b/ports/stm/peripherals/periph.h
@@ -108,7 +108,7 @@ typedef struct {
 // F7 Series
 
 #ifdef STM32F746xx
-#define HAS_DAC 0
+#define HAS_DAC 1
 #define HAS_TRNG 0
 #define HAS_BASIC_TIM 0
 #include "stm32f7/stm32f746xx/periph.h"

--- a/ports/stm/peripherals/stm32f7/stm32f746xx/pins.c
+++ b/ports/stm/peripherals/stm32f7/stm32f746xx/pins.c
@@ -28,12 +28,14 @@
 #include "py/mphal.h"
 #include "peripherals/pins.h"
 
-// Todo: some pins do have ADCs, but the module isn't set up yet.
+// Todo: Add ADC on all pins, ADC only added on A0-A5 for STM32F746ZG nucleo
+
+
 
 const mcu_pin_obj_t pin_PA00 = PIN(0, 0, NO_ADC);
 const mcu_pin_obj_t pin_PA01 = PIN(0, 1, NO_ADC);
 const mcu_pin_obj_t pin_PA02 = PIN(0, 2, NO_ADC);
-const mcu_pin_obj_t pin_PA03 = PIN(0, 3, NO_ADC);
+const mcu_pin_obj_t pin_PA03 = PIN(0, 3, ADC_INPUT(ADC_123, 3)); // A0
 const mcu_pin_obj_t pin_PA04 = PIN(0, 4, NO_ADC);
 const mcu_pin_obj_t pin_PA05 = PIN(0, 5, NO_ADC);
 const mcu_pin_obj_t pin_PA06 = PIN(0, 6, NO_ADC);
@@ -62,10 +64,10 @@ const mcu_pin_obj_t pin_PB12 = PIN(1, 12, NO_ADC);
 const mcu_pin_obj_t pin_PB13 = PIN(1, 13, NO_ADC);
 const mcu_pin_obj_t pin_PB14 = PIN(1, 14, NO_ADC);
 const mcu_pin_obj_t pin_PB15 = PIN(1, 15, NO_ADC);
-const mcu_pin_obj_t pin_PC00 = PIN(2, 0, NO_ADC);
+const mcu_pin_obj_t pin_PC00 = PIN(2, 0, ADC_INPUT(ADC_123, 10)); // A1
 const mcu_pin_obj_t pin_PC01 = PIN(2, 1, NO_ADC);
 const mcu_pin_obj_t pin_PC02 = PIN(2, 2, NO_ADC);
-const mcu_pin_obj_t pin_PC03 = PIN(2, 3, NO_ADC);
+const mcu_pin_obj_t pin_PC03 = PIN(2, 3, ADC_INPUT(ADC_123, 13)); // A2
 const mcu_pin_obj_t pin_PC04 = PIN(2, 4, NO_ADC);
 const mcu_pin_obj_t pin_PC05 = PIN(2, 5, NO_ADC);
 const mcu_pin_obj_t pin_PC06 = PIN(2, 6, NO_ADC);
@@ -113,14 +115,14 @@ const mcu_pin_obj_t pin_PE15 = PIN(4, 15, NO_ADC);
 const mcu_pin_obj_t pin_PF00 = PIN(5, 0, NO_ADC);
 const mcu_pin_obj_t pin_PF01 = PIN(5, 1, NO_ADC);
 const mcu_pin_obj_t pin_PF02 = PIN(5, 2, NO_ADC);
-const mcu_pin_obj_t pin_PF03 = PIN(5, 3, NO_ADC);
+const mcu_pin_obj_t pin_PF03 = PIN(5, 3, ADC_INPUT(ADC_3, 9)); // A3
 const mcu_pin_obj_t pin_PF04 = PIN(5, 4, NO_ADC);
-const mcu_pin_obj_t pin_PF05 = PIN(5, 5, NO_ADC);
+const mcu_pin_obj_t pin_PF05 = PIN(5, 5, ADC_INPUT(ADC_3, 15)); // A4
 const mcu_pin_obj_t pin_PF06 = PIN(5, 6, NO_ADC);
 const mcu_pin_obj_t pin_PF07 = PIN(5, 7, NO_ADC);
 const mcu_pin_obj_t pin_PF08 = PIN(5, 8, NO_ADC);
 const mcu_pin_obj_t pin_PF09 = PIN(5, 9, NO_ADC);
-const mcu_pin_obj_t pin_PF10 = PIN(5, 10, NO_ADC);
+const mcu_pin_obj_t pin_PF10 = PIN(5, 10, ADC_INPUT(ADC_3, 8)); // A5
 const mcu_pin_obj_t pin_PF11 = PIN(5, 11, NO_ADC);
 const mcu_pin_obj_t pin_PF12 = PIN(5, 12, NO_ADC);
 const mcu_pin_obj_t pin_PF13 = PIN(5, 13, NO_ADC);


### PR DESCRIPTION
Added ADC and DAC support for STM32F746ZG. Tested on STM32F746ZG Nucleo. ADC supported on pins A0 to A5 and DAC on default pins.