### PR TITLE
Fix ipaddress.IPv4Address from returning invalid values

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1694,7 +1694,7 @@ msgid "Only one color can be transparent at a time"
 msgstr ""
 
 #: shared-bindings/ipaddress/__init__.c
-msgid "Only raw int supported for ip"
+msgid "Only raw int or string supported for ip"
 msgstr ""
 
 #: ports/esp32s2/bindings/espidf/__init__.c ports/esp32s2/esp_error.c

--- a/shared-bindings/ipaddress/IPv4Address.c
+++ b/shared-bindings/ipaddress/IPv4Address.c
@@ -60,12 +60,13 @@ STATIC mp_obj_t ipaddress_ipv4address_make_new(const mp_obj_type_t *type, size_t
     uint8_t *buf = NULL;
     if (mp_obj_get_int_maybe(address, (mp_int_t *)&value)) {
         // We're done.
-        buf = (uint8_t *)value;
+        buf = (uint8_t *)&value;
     } else if (mp_obj_is_str(address)) {
         GET_STR_DATA_LEN(address, str_data, str_len);
         if (!ipaddress_parse_ipv4address((const char *)str_data, str_len, &value)) {
             mp_raise_ValueError(translate("Not a valid IP string"));
         }
+        buf = (uint8_t *)&value;
     } else {
         mp_buffer_info_t buf_info;
         if (mp_get_buffer(address, &buf_info, MP_BUFFER_READ)) {

--- a/shared-bindings/ipaddress/__init__.c
+++ b/shared-bindings/ipaddress/__init__.c
@@ -76,7 +76,7 @@ bool ipaddress_parse_ipv4address(const char *str_data, size_t str_len, uint32_t 
     return true;
 }
 
-//| def ip_address(obj: Union[int]) -> IPv4Address:
+//| def ip_address(obj: Union[int, str]) -> IPv4Address:
 //|     """Return a corresponding IP address object or raise ValueError if not possible."""
 //|     ...
 //|
@@ -91,7 +91,7 @@ STATIC mp_obj_t ipaddress_ip_address(mp_obj_t ip_in) {
             mp_raise_ValueError(translate("Not a valid IP string"));
         }
     } else {
-        mp_raise_ValueError(translate("Only raw int supported for ip"));
+        mp_raise_ValueError(translate("Only raw int or string supported for ip"));
     }
 
     return common_hal_ipaddress_new_ipv4address(value);


### PR DESCRIPTION
Before, these would cause a board reset:
```py
>>> import ipaddress
>>> ipaddress.IPv4Address(0x08080808)
```
```py
>>> import ipaddress
>>> ipaddress.IPv4Address("8.8.8.8")
```
After:
```py
>>> import ipaddress
>>> ipaddress.IPv4Address(0x08080808)
8.8.8.8
>>> ipaddress.IPv4Address("8.8.8.8")
8.8.8.8
```
Also a fix in the error message for `ipaddress.ip_address`, since this works:
```py
>>> import ipaddress
>>> ipaddress.ip_address("8.8.8.8")
8.8.8.8
```
Note: `ipaddress.ip_address` duplicates some of the code from `IPv4Address` but without the error.