### PR TITLE
reduce SPI display baudrate from 60 MHz to 5 MHz to eliminate display glitch

### DIFF
--- a/ports/esp32s2/boards/adafruit_funhouse/board.c
+++ b/ports/esp32s2/boards/adafruit_funhouse/board.c
@@ -71,7 +71,7 @@ void board_init(void) {
         &pin_GPIO39, // TFT_DC Command or data
         &pin_GPIO40, // TFT_CS Chip select
         &pin_GPIO41, // TFT_RESET Reset
-        60000000, // Baudrate
+        5000000, // Baudrate
         0, // Polarity
         0); // Phase
 


### PR DESCRIPTION
This is a workaround to eliminate the display glitch reported in: https://github.com/adafruit/circuitpython/issues/4775

This PR reduces the display SPI speed from 60 MHz to 5 MHz.  

(Note: Not sure if this is a workaround or a fix, since it is currently unclear why the display glitches occur at higher SPI speeds.  The same glitches occurred on ILI9341- and ST7789- driver displays.  Perhaps this is an issue with the ESP32-S2 SPI timings at higher speeds.)

