### PR TITLE
Removed 'raw' from error message 'raw int'

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1672,6 +1672,10 @@ msgstr ""
 msgid "Only edge detection is available on this hardware"
 msgstr ""
 
+#: shared-bindings/ipaddress/__init__.c
+msgid "Only int or string supported for ip"
+msgstr ""
+
 #: shared-module/displayio/OnDiskBitmap.c
 #, c-format
 msgid ""
@@ -1691,10 +1695,6 @@ msgstr ""
 
 #: shared-module/displayio/ColorConverter.c
 msgid "Only one color can be transparent at a time"
-msgstr ""
-
-#: shared-bindings/ipaddress/__init__.c
-msgid "Only raw int or string supported for ip"
 msgstr ""
 
 #: ports/esp32s2/bindings/espidf/__init__.c ports/esp32s2/esp_error.c

--- a/shared-bindings/ipaddress/__init__.c
+++ b/shared-bindings/ipaddress/__init__.c
@@ -91,7 +91,7 @@ STATIC mp_obj_t ipaddress_ip_address(mp_obj_t ip_in) {
             mp_raise_ValueError(translate("Not a valid IP string"));
         }
     } else {
-        mp_raise_ValueError(translate("Only raw int or string supported for ip"));
+        mp_raise_ValueError(translate("Only int or string supported for ip"));
     }
 
     return common_hal_ipaddress_new_ipv4address(value);


### PR DESCRIPTION
Removed the word 'raw' from error message 'raw int' for shared/ipaddress.