### PR TITLE
Fix for Issue #4266 - second PWMAudioOut interferes with the first one

### DIFF
--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -352,6 +352,8 @@ bool audio_dma_get_paused(audio_dma_t *dma) {
 void audio_dma_init(audio_dma_t *dma) {
     dma->first_buffer = NULL;
     dma->second_buffer = NULL;
+    dma->channel[0] = NUM_DMA_CHANNELS;
+    dma->channel[1] = NUM_DMA_CHANNELS;
 }
 
 void audio_dma_deinit(audio_dma_t *dma) {

--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -368,7 +368,6 @@ bool audio_dma_get_playing(audio_dma_t *dma) {
     }
     if (!dma_channel_is_busy(dma->channel[0]) &&
         !dma_channel_is_busy(dma->channel[1])) {
-        audio_dma_stop(dma);
         return false;
     }
 

--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -130,7 +130,7 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, 
     if (self->dma.channel[0] < NUM_DMA_CHANNELS) {
         if (common_hal_audiopwmio_pwmaudioout_get_playing(self)) {
             common_hal_audiopwmio_pwmaudioout_stop(self);
-	}
+        }
     }
 
     // TODO: Share pacing timers based on frequency.

--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -102,6 +102,7 @@ void common_hal_audiopwmio_pwmaudioout_construct(audiopwmio_pwmaudioout_obj_t *s
     }
 
     audio_dma_init(&self->dma);
+    self->pacing_timer = NUM_DMA_TIMERS;
 
     self->quiescent_value = quiescent_value;
 }
@@ -127,10 +128,8 @@ void common_hal_audiopwmio_pwmaudioout_deinit(audiopwmio_pwmaudioout_obj_t *self
 
 void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, mp_obj_t sample, bool loop) {
 
-    if (self->dma.channel[0] < NUM_DMA_CHANNELS) {
-        if (common_hal_audiopwmio_pwmaudioout_get_playing(self)) {
-            common_hal_audiopwmio_pwmaudioout_stop(self);
-        }
+    if (common_hal_audiopwmio_pwmaudioout_get_playing(self)) {
+        common_hal_audiopwmio_pwmaudioout_stop(self);
     }
 
     // TODO: Share pacing timers based on frequency.

--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -126,17 +126,14 @@ void common_hal_audiopwmio_pwmaudioout_deinit(audiopwmio_pwmaudioout_obj_t *self
 }
 
 void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, mp_obj_t sample, bool loop) {
-    if (common_hal_audiopwmio_pwmaudioout_get_playing(self)) {
-        common_hal_audiopwmio_pwmaudioout_stop(self);
-    }
 
     // TODO: Share pacing timers based on frequency.
     size_t pacing_timer = NUM_DMA_TIMERS;
     for (size_t i = 0; i < NUM_DMA_TIMERS; i++) {
         if (dma_hw->timer[i] == 0) {
             pacing_timer = i;
+            break;
         }
-        break;
     }
     if (pacing_timer == NUM_DMA_TIMERS) {
         mp_raise_RuntimeError(translate("No DMA pacing timer found"));

--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -127,6 +127,12 @@ void common_hal_audiopwmio_pwmaudioout_deinit(audiopwmio_pwmaudioout_obj_t *self
 
 void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, mp_obj_t sample, bool loop) {
 
+    if (self->dma.channel[0] < NUM_DMA_CHANNELS) {
+        if (common_hal_audiopwmio_pwmaudioout_get_playing(self)) {
+            common_hal_audiopwmio_pwmaudioout_stop(self);
+	}
+    }
+
     // TODO: Share pacing timers based on frequency.
     size_t pacing_timer = NUM_DMA_TIMERS;
     for (size_t i = 0; i < NUM_DMA_TIMERS; i++) {


### PR DESCRIPTION
For the RP2040 chips; in common_hal_audiopwmio_pwmaudioout_play() we were calling common_hal_audiopwmio_pwmaudioout_get_playing() and common_hal_audiopwmio_pwmaudioout_stop() early on;  which means we were accessing the DMA channels before we had set them up by calling audio_dma_setup_playback(). The impact was to stop the DMA for the first PWMAudioOut when setting up the second. In addition, a break statement while checking for a pacing timer was outside the proper braces. Also (perhaps unrelated), a call to audio_dma_stop() in audio_dma_get_playing() was being made even when the channels were not busy.

Closes: #4266 