### PR TITLE
fix check of usb_hid.Device out_report_length

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -88,6 +88,10 @@ msgid "%q list must be a list"
 msgstr ""
 
 #: shared-bindings/usb_hid/Device.c
+msgid "%q must be 0-255"
+msgstr ""
+
+#: shared-bindings/usb_hid/Device.c
 msgid "%q must be 1-255"
 msgstr ""
 
@@ -104,7 +108,7 @@ msgid "%q must be >= 1"
 msgstr ""
 
 #: shared-bindings/usb_hid/Device.c
-msgid "%q must be None or 1-255"
+msgid "%q must be None or between 1 and len(report_descriptor)-1"
 msgstr ""
 
 #: shared-module/vectorio/Polygon.c


### PR DESCRIPTION
- The `out_report_length` arg for the `usb_hid.Device` constructor was checked to be 1-255 instead of 0-255. There was also a bug of what type the arg was, which meant that an arg of 0 was interpreted as 1, so the check was not triggered. Fixed.
-  Check the the `report_id_index` is in range, not past the end of the report.

Tested by @ATMakersBill.