### PR TITLE
mpy-cross: Build an arm64 (M1) bin and a universal bin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,8 +154,24 @@ jobs:
       with:
         name: mpy-cross-macos-catalina
         path: mpy-cross/mpy-cross
+    - name: Select SDK for M1 build
+      run: sudo xcode-select -switch /Applications/Xcode_12.3.app
+    - name: Build mpy-cross (arm64)
+      run: make -C mpy-cross -j2 -f Makefile.m1 V=2
+    - uses: actions/upload-artifact@v2
+      with:
+        name: mpy-cross-macos-bigsur-arm64
+        path: mpy-cross/mpy-cross-arm64
+    - name: Make universal binary
+      run: lipo -create -output mpy-cross-macos-universal mpy-cross/mpy-cross mpy-cross/mpy-cross-arm64
+    - uses: actions/upload-artifact@v2
+      with:
+        name: mpy-cross-macos-universal
+        path: mpy-cross-macos-universal
     - name: Upload mpy-cross build to S3
       run: |
+        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross-macos-universal s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross-macos-universal-${{ env.CP_VERSION }} --no-progress --region us-east-1
+        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross/mpy-cross-arm64 s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross-macos-bigsur-${{ env.CP_VERSION }}-arm64 --no-progress --region us-east-1
         [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross/mpy-cross s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross-macos-catalina-${{ env.CP_VERSION }} --no-progress --region us-east-1
       env:
         AWS_PAGER: ''

--- a/mpy-cross/Makefile.m1
+++ b/mpy-cross/Makefile.m1
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2014 MicroPython & CircuitPython contributors (https://github.com/adafruit/circuitpython/graphs/contributors)
+#
+# SPDX-License-Identifier: MIT
+
+PROG=mpy-cross-arm64
+BUILD=build-arm64
+
+include mpy-cross.mk
+# Because mpy-cross.mk unconditionally overwrites CC for Darwin, we must set it BELOW the inclusion
+CC := $(shell xcrun --sdk macosx11.1 --find clang) -isysroot $(shell xcrun --sdk macosx11.1 --show-sdk-path) -target arm64-apple-macos11 -DMICROPY_NLR_SETJMP=1
+$(info pt2 CC=$(CC))


### PR DESCRIPTION
Untested, as I don't have mac hardware.  However, Linux identifies the resulting files as expected:
```
mpy-cross:                 Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
mpy-cross-arm64:           Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>
mpy-cross-macos-universal: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>] [arm64:Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE>]
```

In theory, the x86_64 versions still work with catalina (and up, presumably), but the arm64 version (and maybe the universal version?) would be big sur only.

We should probably only merge this after positive testing from both x86_64 and m1 users.