### PR TITLE
test sizes when async/await on everywhere

### DIFF
--- a/ports/atmel-samd/mpconfigport.mk
+++ b/ports/atmel-samd/mpconfigport.mk
@@ -58,7 +58,7 @@ CIRCUITPY_TOUCHIO_USE_NATIVE ?= 1
 CIRCUITPY_ULAB = 0
 CIRCUITPY_VECTORIO = 0
 
-MICROPY_PY_ASYNC_AWAIT = 0
+MICROPY_PY_ASYNC_AWAIT = 1
 
 # We don't have room for the fonts for terminalio for ja and ko
 # so turn off terminalio, and if it's off and displayio is on,


### PR DESCRIPTION
async/await takes about 1600 bytes; where does it overflow?

This is not completely everywhere: a few no-flash-chip nRF's still have it off.