### PR TITLE
mpy-cross: Remove bug workaround, debug print

### DIFF
--- a/mpy-cross/Makefile.m1
+++ b/mpy-cross/Makefile.m1
@@ -7,5 +7,4 @@ BUILD=build-arm64
 
 include mpy-cross.mk
 # Because mpy-cross.mk unconditionally overwrites CC for Darwin, we must set it BELOW the inclusion
-CC := $(shell xcrun --sdk macosx11.1 --find clang) -isysroot $(shell xcrun --sdk macosx11.1 --show-sdk-path) -target arm64-apple-macos11 -DMICROPY_NLR_SETJMP=1
-$(info pt2 CC=$(CC))
+CC := $(shell xcrun --sdk macosx11.1 --find clang) -isysroot $(shell xcrun --sdk macosx11.1 --show-sdk-path) -target arm64-apple-macos11


### PR DESCRIPTION
Thanks to #4835 we no longer need to specify the setjmp implementation of nlr manually, because the assembly version works now.