### PR TITLE
stubs package with data_files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 # SPDX-FileCopyrightText: 2014 MicroPython & CircuitPython contributors (https://github.com/adafruit/circuitpython/graphs/contributors)
 #
 # SPDX-License-Identifier: MIT
-
+import os
+import site
 from datetime import datetime
+from typing import List
+
 from setuptools import setup
 from pathlib import Path
 import subprocess
@@ -25,6 +28,13 @@ if len(pieces) > 2:
     pieces.pop()
 version = "-".join(pieces)
 
+def build_data_files_list() -> List[tuple]:
+    result = []
+    for package in os.listdir("circuitpython-stubs"):
+        result.append((site.getsitepackages()[0] + "/" + package + "/",
+                       ["circuitpython-stubs/{}/__init__.pyi".format(package)]))
+    return result
+
 setup(
     name="circuitpython-stubs",
     description="PEP 561 type stubs for CircuitPython",
@@ -34,7 +44,6 @@ setup(
     author_email="circuitpython@adafruit.com",
     version=version,
     license="MIT",
-    package_data={"circuitpython-stubs": stubs},
-    packages=["circuitpython-stubs"],
+    data_files=build_data_files_list(),
     setup_requires=["setuptools>=38.6.0"],
 )


### PR DESCRIPTION
With `package_data` and `packages` the installed files end up like:

```
/[Python]/lib/site-packages/circuitpython-stubs/digitalio
/[Python]/lib/site-packages/circuitpython-stubs/displayio
/[Python]/lib/site-packages/circuitpython-stubs/...
```
when it is like this the IDE will not recognize the stubs unless they are imported like this:

```
from circuitpython import digitalio
```

To fix we can use `data_files` to install all of the circuitpython stubs into the root of `../site-packages/` 

This allows the IDE to recognize the stubs when used as normal in circuitpython code i.e.

```
import digitalio
```

I tried some other ways of installing multiple packages instead of using `data_files` but never found a working solution, perhaps there are some though.

I tested the stubs from this technique successfully with PyCharm, but not with this repo specifically. I was able to get local pip install and pip install from a test pypi listing to work correctly.