### PR TITLE
Fix bit_length() method to work with zero-valued mpz integer.

### DIFF
--- a/py/mpz.h
+++ b/py/mpz.h
@@ -142,6 +142,9 @@ static inline size_t mpz_max_num_bits(const mpz_t *z) {
     return z->len * MPZ_DIG_SIZE;
 }
 static inline size_t mpz_num_bits(const mpz_t *z) {
+    if (mpz_is_zero(z)) {
+	return 0;
+    }
     size_t last_bits = (8 * (sizeof(long) - sizeof(mpz_dig_t))) - __builtin_clzl(z->dig[z->len - 1]);
     return z->len * MPZ_DIG_SIZE + last_bits;
 }

--- a/py/mpz.h
+++ b/py/mpz.h
@@ -143,7 +143,7 @@ static inline size_t mpz_max_num_bits(const mpz_t *z) {
 }
 static inline size_t mpz_num_bits(const mpz_t *z) {
     if (mpz_is_zero(z)) {
-	return 0;
+        return 0;
     }
     size_t last_bits = (8 * (sizeof(long) - sizeof(mpz_dig_t))) - __builtin_clzl(z->dig[z->len - 1]);
     return z->len * MPZ_DIG_SIZE + last_bits;


### PR DESCRIPTION
The following code crashes CircuitPython 6.2 (tested on Wio Terminal) :
```
a = 10**10
a *= 0
a.bit_length()
```
This PR fixes the problem.
