### PR TITLE
Fix usb_cdc.enable(console=False, data=True)

### DIFF
--- a/ports/atmel-samd/boards/metro_m4_express/pins.c
+++ b/ports/atmel-samd/boards/metro_m4_express/pins.c
@@ -26,6 +26,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_D10), MP_ROM_PTR(&pin_PA18) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D11), MP_ROM_PTR(&pin_PA19) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_PA17) },
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_LED),MP_ROM_PTR(&pin_PA16) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D13),MP_ROM_PTR(&pin_PA16) },
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_SDA),MP_ROM_PTR(&pin_PB02) },

--- a/shared-module/usb_cdc/__init__.c
+++ b/shared-module/usb_cdc/__init__.c
@@ -147,26 +147,26 @@ static const char data_cdc_comm_interface_name[] = USB_INTERFACE_NAME " CDC2 con
 static const char console_cdc_data_interface_name[] = USB_INTERFACE_NAME " CDC data";
 static const char data_cdc_data_interface_name[] = USB_INTERFACE_NAME " CDC2 data";
 
+// .idx is set later.
+
 static usb_cdc_serial_obj_t usb_cdc_console_obj = {
     .base.type = &usb_cdc_serial_type,
     .timeout = -1.0f,
     .write_timeout = -1.0f,
-    .idx = 0,
 };
 
 static usb_cdc_serial_obj_t usb_cdc_data_obj = {
     .base.type = &usb_cdc_serial_type,
     .timeout = -1.0f,
     .write_timeout = -1.0f,
-    .idx = 1,
 };
 
 static bool usb_cdc_console_is_enabled;
 static bool usb_cdc_data_is_enabled;
 
 void usb_cdc_set_defaults(void) {
-    usb_cdc_console_is_enabled = CIRCUITPY_USB_CDC_CONSOLE_ENABLED_DEFAULT;
-    usb_cdc_data_is_enabled = CIRCUITPY_USB_CDC_DATA_ENABLED_DEFAULT;
+    common_hal_usb_cdc_enable(CIRCUITPY_USB_CDC_CONSOLE_ENABLED_DEFAULT,
+        CIRCUITPY_USB_CDC_DATA_ENABLED_DEFAULT);
 }
 
 bool usb_cdc_console_enabled(void) {
@@ -241,11 +241,21 @@ bool common_hal_usb_cdc_enable(bool console, bool data) {
     // Right now these objects contain no heap objects, but if that changes,
     // they will need to be protected against gc.
 
+    // Assign only as many idx values as necessary. They must start at 0.
+    uint8_t idx = 0;
     usb_cdc_console_is_enabled = console;
     usb_cdc_set_console(console ? MP_OBJ_FROM_PTR(&usb_cdc_console_obj) : mp_const_none);
+    if (console) {
+        usb_cdc_console_obj.idx = idx;
+        idx++;
+    }
 
     usb_cdc_data_is_enabled = data;
     usb_cdc_set_data(data ? MP_OBJ_FROM_PTR(&usb_cdc_data_obj) : mp_const_none);
+    if (data) {
+        usb_cdc_data_obj.idx = idx;
+    }
+
 
     return true;
 }

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -83,6 +83,7 @@ void usb_init(void) {
 
     // Don't watch for ctrl-C if there is no REPL.
     if (usb_cdc_console_enabled()) {
+        // Console will always be itf 0.
         tud_cdc_set_wanted_char(CHAR_CTRL_C);
     }
     #endif
@@ -156,9 +157,12 @@ void usb_background(void) {
         tud_task();
         #endif
         // No need to flush if there's no REPL.
+        #if CIRCUITPY_USB_CDC
         if (usb_cdc_console_enabled()) {
+            // Console will always be itf 0.
             tud_cdc_write_flush();
         }
+        #endif
     }
 }
 
@@ -212,6 +216,7 @@ void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts) {
     // DTR = false is counted as disconnected
     if (!dtr) {
         cdc_line_coding_t coding;
+        // Use whichever CDC is itf 0.
         tud_cdc_get_line_coding(&coding);
 
         if (coding.bit_rate == 1200) {


### PR DESCRIPTION
`usb_cdc.enable(console=False, data=True)` was not working.

- Set `usb_cdc` defaults correctly
- Use correct TinyUSB `itf` values when only one CDC is used. Number them from zero. This was the main bug.
- Don't watch for ctrl-c if console is not enabled.
- add `board.LED` to Metro M4. (Discovered it was missing by accident when i was trying to blink the led for debugging purposes).'

Tested on Feather STM32F405 and on Metro M4.

Thanks to discord user osten (@pdecherf) who found the problem and tested the fix on an STM32F405.