### PR TITLE
Sparkfun micromod samd51

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -347,6 +347,7 @@ jobs:
         - "sparkfun_redboard_turbo"
         - "sparkfun_samd21_dev"
         - "sparkfun_samd21_mini"
+        - "sparkfun_samd51_micromod"
         - "sparkfun_samd51_thing_plus"
         - "sparkfun_thing_plus_rp2040"
         - "spresense"

--- a/ports/atmel-samd/boards/sparkfun_samd51_micromod/board.c
+++ b/ports/atmel-samd/boards/sparkfun_samd51_micromod/board.c
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "supervisor/board.h"
+#include "mpconfigboard.h"
+
+void board_init(void) {
+}
+
+bool board_requests_safe_mode(void) {
+    return false;
+}
+
+void reset_board(void) {
+}

--- a/ports/atmel-samd/boards/sparkfun_samd51_micromod/mpconfigboard.h
+++ b/ports/atmel-samd/boards/sparkfun_samd51_micromod/mpconfigboard.h
@@ -1,0 +1,33 @@
+#define MICROPY_HW_BOARD_NAME "SparkFun Thing Plus - SAMD51"
+#define MICROPY_HW_MCU_NAME "samd51j20"
+
+#define CIRCUITPY_MCU_FAMILY samd51
+
+// On-board flash
+#define SPI_FLASH_MOSI_PIN &pin_PA09
+#define SPI_FLASH_MISO_PIN &pin_PA10
+#define SPI_FLASH_SCK_PIN  &pin_PA08
+#define SPI_FLASH_CS_PIN   &pin_PA11
+
+// These are pins not to reset.
+// SPI Data pins
+#define MICROPY_PORT_A (PORT_PA08 | PORT_PA09 | PORT_PA10 | PORT_PA11)
+#define MICROPY_PORT_B (0)
+#define MICROPY_PORT_C (0)
+#define MICROPY_PORT_D (0)
+
+#define BOARD_HAS_CRYSTAL 1
+
+#define DEFAULT_I2C_BUS_SCL (&pin_PA16)
+#define DEFAULT_I2C_BUS_SDA (&pin_PA17)
+
+#define DEFAULT_SPI_BUS_SCK (&pin_PA05)
+#define DEFAULT_SPI_BUS_MOSI (&pin_PA04)
+#define DEFAULT_SPI_BUS_MISO (&pin_PB06)
+
+#define DEFAULT_UART_BUS_RX (&pin_PB30)
+#define DEFAULT_UART_BUS_TX (&pin_PB31)
+
+// USB is always used internally so skip the pin objects for it.
+#define IGNORE_PIN_PA24     1
+#define IGNORE_PIN_PA25     1

--- a/ports/atmel-samd/boards/sparkfun_samd51_micromod/mpconfigboard.h
+++ b/ports/atmel-samd/boards/sparkfun_samd51_micromod/mpconfigboard.h
@@ -1,4 +1,4 @@
-#define MICROPY_HW_BOARD_NAME "SparkFun Thing Plus - SAMD51"
+#define MICROPY_HW_BOARD_NAME "SparkFun MicroMod SAMD51"
 #define MICROPY_HW_MCU_NAME "samd51j20"
 
 #define CIRCUITPY_MCU_FAMILY samd51

--- a/ports/atmel-samd/boards/sparkfun_samd51_micromod/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/sparkfun_samd51_micromod/mpconfigboard.mk
@@ -1,0 +1,14 @@
+LD_FILE = boards/samd51x20-bootloader-external-flash.ld
+USB_VID = 0x1b4f
+USB_PID = 0x0020 # Used by uf2 bootloader
+USB_PRODUCT = "SparkFun MicroMod SAMD51"
+USB_MANUFACTURER = "SparkFun Electronics"
+
+CHIP_VARIANT = SAMD51J20A
+CHIP_FAMILY = samd51
+
+SPI_FLASH_FILESYSTEM = 1
+EXTERNAL_FLASH_DEVICES = W25Q128JVxM
+LONGINT_IMPL = MPZ
+
+CIRCUITPY_PS2IO = 1

--- a/ports/atmel-samd/boards/sparkfun_samd51_micromod/pins.c
+++ b/ports/atmel-samd/boards/sparkfun_samd51_micromod/pins.c
@@ -64,7 +64,7 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     // I2C2
     { MP_ROM_QSTR(MP_QSTR_SDA2), MP_ROM_PTR(&pin_PA13) },
-    { MP_ROM_QSTR(MP_QSTR_SCL1), MP_ROM_PTR(&pin_PA12) },
+    { MP_ROM_QSTR(MP_QSTR_SCL2), MP_ROM_PTR(&pin_PA12) },
 
     // SPI
     { MP_ROM_QSTR(MP_QSTR_CIPO), MP_ROM_PTR(&pin_PA06) },

--- a/ports/atmel-samd/boards/sparkfun_samd51_micromod/pins.c
+++ b/ports/atmel-samd/boards/sparkfun_samd51_micromod/pins.c
@@ -1,0 +1,99 @@
+#include "shared-bindings/board/__init__.h"
+
+STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
+    // D (digital only) pins (D0,D1)
+    { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_PB04) }
+    { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_PB05) },
+
+    // A (ADC) pins (A0-A4)
+    { MP_ROM_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_PA02) },
+    { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_PB00) },
+    { MP_ROM_QSTR(MP_QSTR_A2), MP_ROM_PTR(&pin_PB01) },
+    { MP_ROM_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_PA02) },
+    { MP_ROM_QSTR(MP_QSTR_A4), MP_ROM_PTR(&pin_PA03) },
+
+    // DAC
+    { MP_ROM_QSTR(MP_QSTR_DAC), MP_ROM_PTR(&pin_PA02) },
+
+    // G (General/BUS) pins (G0-G9)
+    { MP_ROM_QSTR(MP_QSTR_D2), MP_ROM_PTR(&pin_PA06) },
+    { MP_ROM_QSTR(MP_QSTR_G0), MP_ROM_PTR(&pin_PA06) },
+    { MP_ROM_QSTR(MP_QSTR_D3), MP_ROM_PTR(&pin_PA15) },
+    { MP_ROM_QSTR(MP_QSTR_G1), MP_ROM_PTR(&pin_PA06) },
+    { MP_ROM_QSTR(MP_QSTR_D4), MP_ROM_PTR(&pin_PB08) },
+    { MP_ROM_QSTR(MP_QSTR_G2), MP_ROM_PTR(&pin_PB08) },
+    { MP_ROM_QSTR(MP_QSTR_D5), MP_ROM_PTR(&pin_PB09) },
+    { MP_ROM_QSTR(MP_QSTR_G3), MP_ROM_PTR(&pin_PB09) },
+    { MP_ROM_QSTR(MP_QSTR_D6), MP_ROM_PTR(&pin_PB10) },
+    { MP_ROM_QSTR(MP_QSTR_G4), MP_ROM_PTR(&pin_PB10) },
+    { MP_ROM_QSTR(MP_QSTR_D7), MP_ROM_PTR(&pin_PB11) },
+    { MP_ROM_QSTR(MP_QSTR_G5), MP_ROM_PTR(&pin_PB11) },
+    { MP_ROM_QSTR(MP_QSTR_D8), MP_ROM_PTR(&pin_PB12) },
+    { MP_ROM_QSTR(MP_QSTR_G6), MP_ROM_PTR(&pin_PB12) },
+    { MP_ROM_QSTR(MP_QSTR_D9), MP_ROM_PTR(&pin_PB13) },
+    { MP_ROM_QSTR(MP_QSTR_G7), MP_ROM_PTR(&pin_PB13) },
+    { MP_ROM_QSTR(MP_QSTR_D10), MP_ROM_PTR(&pin_PA14) },
+    { MP_ROM_QSTR(MP_QSTR_G8), MP_ROM_PTR(&pin_PA14) },
+    { MP_ROM_QSTR(MP_QSTR_D11), MP_ROM_PTR(&pin_PA15) },
+    { MP_ROM_QSTR(MP_QSTR_G9), MP_ROM_PTR(&pin_PA15) },
+    { MP_ROM_QSTR(MP_QSTR_D32), MP_ROM_PTR(&pin_PB31) },
+    { MP_ROM_QSTR(MP_QSTR_D33), MP_ROM_PTR(&pin_PB30) },
+    { MP_ROM_QSTR(MP_QSTR_D38), MP_ROM_PTR(&pin_PB14) },
+    { MP_ROM_QSTR(MP_QSTR_G10), MP_ROM_PTR(&pin_PB14) },
+    { MP_ROM_QSTR(MP_QSTR_D39), MP_ROM_PTR(&pin_PB15) },
+    { MP_ROM_QSTR(MP_QSTR_G11), MP_ROM_PTR(&pin_PB15) },
+
+    // PWM pins (PWM0, PWM1)
+    { MP_ROM_QSTR(MP_QSTR_PWM0), MP_ROM_PTR(&pin_PB01) },
+    { MP_ROM_QSTR(MP_QSTR_PWM1), MP_ROM_PTR(&pin_PA02) },
+
+    // AUD (audio)
+    { MP_ROM_QSTR(MP_QSTR_AUD_MCLK), MP_ROM_PTR(&pin_PB17) },
+    { MP_ROM_QSTR(MP_QSTR_AUD_OUT), MP_ROM_PTR(&pin_PA21) },
+    { MP_ROM_QSTR(MP_QSTR_AUD_IN), MP_ROM_PTR(&pin_PA22) },
+    { MP_ROM_QSTR(MP_QSTR_AUD_LRCLK), MP_ROM_PTR(&pin_PA20) },
+    { MP_ROM_QSTR(MP_QSTR_AUD_BCLK), MP_ROM_PTR(&pin_GPA16) },
+
+    // I2C
+    { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_PA17) },
+    { MP_ROM_QSTR(MP_QSTR_SDA1), MP_ROM_PTR(&pin_PA17) },
+    { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_PA16) },
+    { MP_ROM_QSTR(MP_QSTR_SCL1), MP_ROM_PTR(&pin_PA16) },
+
+    { MP_ROM_QSTR(MP_QSTR_I2C_INT), MP_ROM_PTR(&pin_PB18) },
+
+    // I2C2
+    { MP_ROM_QSTR(MP_QSTR_SDA2), MP_ROM_PTR(&pin_PA13) },
+    { MP_ROM_QSTR(MP_QSTR_SCL1), MP_ROM_PTR(&pin_PA12) },
+
+    // SPI
+    { MP_ROM_QSTR(MP_QSTR_CIPO), MP_ROM_PTR(&pin_PA06) },
+    { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_PA06) },
+    { MP_ROM_QSTR(MP_QSTR_COPI), MP_ROM_PTR(&pin_PA04) },
+    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_PA04) },
+    { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_PA05) },
+    { MP_ROM_QSTR(MP_QSTR_CS), MP_ROM_PTR(&pin_PA07) },
+
+    // Status LED
+    { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_PA23) },
+
+    // UART
+    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_PB30) },
+    { MP_ROM_QSTR(MP_QSTR_RX1), MP_ROM_PTR(&pin_PB30) },
+    { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_PB31) },
+    { MP_ROM_QSTR(MP_QSTR_TX1), MP_ROM_PTR(&pin_PB31) },
+
+    // UART2
+    { MP_ROM_QSTR(MP_QSTR_RX2), MP_ROM_PTR(&pin_PA13) },
+    { MP_ROM_QSTR(MP_QSTR_TX2), MP_ROM_PTR(&pin_PA12) },
+
+
+    // Board objects
+    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
+
+};
+MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);
+
+

--- a/ports/atmel-samd/boards/sparkfun_samd51_micromod/pins.c
+++ b/ports/atmel-samd/boards/sparkfun_samd51_micromod/pins.c
@@ -2,7 +2,7 @@
 
 STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     // D (digital only) pins (D0,D1)
-    { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_PB04) }
+    { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_PB04) },
     { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_PB05) },
 
     // A (ADC) pins (A0-A4)

--- a/ports/atmel-samd/boards/sparkfun_samd51_micromod/pins.c
+++ b/ports/atmel-samd/boards/sparkfun_samd51_micromod/pins.c
@@ -60,7 +60,7 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_PA16) },
     { MP_ROM_QSTR(MP_QSTR_SCL1), MP_ROM_PTR(&pin_PA16) },
 
-    { MP_ROM_QSTR(MP_QSTR_I2C_INT), MP_ROM_PTR(&pin_PB18) },
+    { MP_ROM_QSTR(MP_QSTR_I2C_INT), MP_ROM_PTR(&pin_PA18) },
 
     // I2C2
     { MP_ROM_QSTR(MP_QSTR_SDA2), MP_ROM_PTR(&pin_PA13) },


### PR DESCRIPTION
Added support for the [Sparkfun MicroMod SAMD51](https://www.sparkfun.com/products/16791) board. Board follows a pin layout similar to other MicroMod boards, like the MM RP2040 and MM nRF52840 boards already supported by CircuitPython.  This board definition was derived from the Sparkfun SAMD51 Thing+ support, with pin mapping and external flash changes.

I have confirmed the vendor USB PID with Sparkfun.

I’d love a code review. :)