### PR TITLE
resolves #4153: Fixed build issue when CIRCUITPY_USB is off

### DIFF
--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -33,7 +33,9 @@
 #include "shared-bindings/supervisor/RunReason.h"
 #include "shared-bindings/supervisor/Runtime.h"
 
+#if (CIRCUITPY_USB)
 #include "tusb.h"
+#endif
 
 STATIC supervisor_run_reason_t _run_reason;
 


### PR DESCRIPTION
Small change to exclude tinyusb header file if CIRCUITPY_USB is set to 0