### PR TITLE
Fix partial refresh of displayio.TileGrid

### DIFF
--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -583,19 +583,36 @@ displayio_area_t *displayio_tilegrid_get_refresh_areas(displayio_tilegrid_t *sel
     }
 
     if (self->partial_change) {
-        if (self->transpose_xy != self->absolute_transform->transpose_xy) {
-            int16_t x1 = self->dirty_area.x1;
-            self->dirty_area.x1 = self->absolute_transform->x + self->absolute_transform->dx * (self->y + self->dirty_area.y1);
-            self->dirty_area.y1 = self->absolute_transform->y + self->absolute_transform->dy * (self->x + x1);
-            int16_t x2 = self->dirty_area.x2;
-            self->dirty_area.x2 = self->absolute_transform->x + self->absolute_transform->dx * (self->y + self->dirty_area.y2);
-            self->dirty_area.y2 = self->absolute_transform->y + self->absolute_transform->dy * (self->x + x2);
-        } else {
-            self->dirty_area.x1 = self->absolute_transform->x + self->absolute_transform->dx * (self->x + self->dirty_area.x1);
-            self->dirty_area.y1 = self->absolute_transform->y + self->absolute_transform->dy * (self->y + self->dirty_area.y1);
-            self->dirty_area.x2 = self->absolute_transform->x + self->absolute_transform->dx * (self->x + self->dirty_area.x2);
-            self->dirty_area.y2 = self->absolute_transform->y + self->absolute_transform->dy * (self->y + self->dirty_area.y2);
-        }
+	int16_t x = self->x;
+	int16_t y = self->y;
+	if (self->absolute_transform->transpose_xy) {
+	    int16_t temp = y;
+	    y = x;
+	    x = temp;
+	}
+	int16_t x1 = self->dirty_area.x1;
+	int16_t x2 = self->dirty_area.x2;
+	if (self->flip_x) {
+	    x1 = self->pixel_width - x1;
+	    x2 = self->pixel_width - x2;
+	}
+	int16_t y1 = self->dirty_area.y1;
+	int16_t y2 = self->dirty_area.y2;
+	if (self->flip_y) {
+	    y1 = self->pixel_height - y1;
+	    y2 = self->pixel_height - y2;
+	}
+	if (self->transpose_xy != self->absolute_transform->transpose_xy) {
+	    int16_t temp1 = y1, temp2 = y2;
+	    y1 = x1;
+	    x1 = temp1;
+	    y2 = x2;
+	    x2 = temp2;
+	}
+	self->dirty_area.x1 = self->absolute_transform->x + self->absolute_transform->dx * (x + x1);
+	self->dirty_area.y1 = self->absolute_transform->y + self->absolute_transform->dy * (y + y1);
+	self->dirty_area.x2 = self->absolute_transform->x + self->absolute_transform->dx * (x + x2);
+	self->dirty_area.y2 = self->absolute_transform->y + self->absolute_transform->dy * (y + y2);
         if (self->dirty_area.y2 < self->dirty_area.y1) {
             int16_t temp = self->dirty_area.y2;
             self->dirty_area.y2 = self->dirty_area.y1;

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -583,36 +583,36 @@ displayio_area_t *displayio_tilegrid_get_refresh_areas(displayio_tilegrid_t *sel
     }
 
     if (self->partial_change) {
-	int16_t x = self->x;
-	int16_t y = self->y;
-	if (self->absolute_transform->transpose_xy) {
-	    int16_t temp = y;
-	    y = x;
-	    x = temp;
-	}
-	int16_t x1 = self->dirty_area.x1;
-	int16_t x2 = self->dirty_area.x2;
-	if (self->flip_x) {
-	    x1 = self->pixel_width - x1;
-	    x2 = self->pixel_width - x2;
-	}
-	int16_t y1 = self->dirty_area.y1;
-	int16_t y2 = self->dirty_area.y2;
-	if (self->flip_y) {
-	    y1 = self->pixel_height - y1;
-	    y2 = self->pixel_height - y2;
-	}
-	if (self->transpose_xy != self->absolute_transform->transpose_xy) {
-	    int16_t temp1 = y1, temp2 = y2;
-	    y1 = x1;
-	    x1 = temp1;
-	    y2 = x2;
-	    x2 = temp2;
-	}
-	self->dirty_area.x1 = self->absolute_transform->x + self->absolute_transform->dx * (x + x1);
-	self->dirty_area.y1 = self->absolute_transform->y + self->absolute_transform->dy * (y + y1);
-	self->dirty_area.x2 = self->absolute_transform->x + self->absolute_transform->dx * (x + x2);
-	self->dirty_area.y2 = self->absolute_transform->y + self->absolute_transform->dy * (y + y2);
+        int16_t x = self->x;
+        int16_t y = self->y;
+        if (self->absolute_transform->transpose_xy) {
+            int16_t temp = y;
+            y = x;
+            x = temp;
+        }
+        int16_t x1 = self->dirty_area.x1;
+        int16_t x2 = self->dirty_area.x2;
+        if (self->flip_x) {
+            x1 = self->pixel_width - x1;
+            x2 = self->pixel_width - x2;
+        }
+        int16_t y1 = self->dirty_area.y1;
+        int16_t y2 = self->dirty_area.y2;
+        if (self->flip_y) {
+            y1 = self->pixel_height - y1;
+            y2 = self->pixel_height - y2;
+        }
+        if (self->transpose_xy != self->absolute_transform->transpose_xy) {
+            int16_t temp1 = y1, temp2 = y2;
+            y1 = x1;
+            x1 = temp1;
+            y2 = x2;
+            x2 = temp2;
+        }
+        self->dirty_area.x1 = self->absolute_transform->x + self->absolute_transform->dx * (x + x1);
+        self->dirty_area.y1 = self->absolute_transform->y + self->absolute_transform->dy * (y + y1);
+        self->dirty_area.x2 = self->absolute_transform->x + self->absolute_transform->dx * (x + x2);
+        self->dirty_area.y2 = self->absolute_transform->y + self->absolute_transform->dy * (y + y2);
         if (self->dirty_area.y2 < self->dirty_area.y1) {
             int16_t temp = self->dirty_area.y2;
             self->dirty_area.y2 = self->dirty_area.y1;


### PR DESCRIPTION
This PR fixes a partial refresh of displayio.TileGrid.  The original code works only for limited combinations of DISPLAY.rotation and TileGrid.{flip_x, flip_y, transpose_xy}.  The following is a test code to check the algorithm (tested on Wio Terminal).

```
import board
import time
import displayio as dpio
import bitmaptools as bmt

disp = board.DISPLAY
bmp = dpio.Bitmap(200, 150, 2)
pal = dpio.Palette(2)
pal[0] = 0xFFFFFF
pal[1] = 0x0000FF
tg = dpio.TileGrid(bmp, pixel_shader = pal)
g = dpio.Group()
g.append(tg)
disp.show(g)

tg.x = 20
tg.y = 10

def draw() :
  bmp.fill(0)
  disp.refresh()
  bmt.fill_region(bmp, 110, 10, 190, 60, 1)
  disp.refresh()
  time.sleep(1)

def do_test() :
  tg.flip_x = tg.flip_y = tg.transpose_xy = False
  draw()    # top right

  tg.flip_x = True
  draw()    # top left

  tg.flip_y = True
  draw()    # bottom left

  tg.transpose_xy = True
  draw()    # top right

  tg.flip_x = False
  draw()    # bottom right

  tg.flip_y = False
  draw()    # bottom left

  tg.transpose_xy = False
  draw()    # top right

disp.auto_refresh = False

disp.rotation = 0
do_test()

disp.rotation = 90
do_test()

disp.rotation = 180
do_test()

disp.rotation = 270
do_test()

disp.rotation = 0
disp.auto_refresh = True
```