### PR TITLE
setup.py: Improve installation of stubs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,14 @@
 import os
 import site
 from datetime import datetime
-from typing import List
+from typing import Dict, List
 
 from setuptools import setup
 from pathlib import Path
 import subprocess
 import re
+
+STD_PACKAGES = set(('array', 'math', 'os', 'random', 'struct', 'sys', 'ssl', 'time'))
 
 stub_root = Path("circuitpython-stubs")
 stubs = [p.relative_to(stub_root).as_posix() for p in stub_root.glob("*.pyi")]
@@ -28,13 +30,18 @@ if len(pieces) > 2:
     pieces.pop()
 version = "-".join(pieces)
 
-def build_data_files_list() -> List[tuple]:
-    result = []
-    for package in os.listdir("circuitpython-stubs"):
-        result.append((site.getsitepackages()[0] + "/" + package + "/",
-                       ["circuitpython-stubs/{}/__init__.pyi".format(package)]))
+packages = set(os.listdir("circuitpython-stubs")) - STD_PACKAGES
+package_dir = dict((f"{package}-stubs", f"circuitpython-stubs/{package}")
+    for package in packages)
+print("package dir is", package_dir)
+
+def build_package_data() -> Dict[str, List[str]]:
+    result = {}
+    for package in packages:
+        result[f"{package}-stubs"] = ["*.pyi", "*/*.pyi"]
     return result
 
+package_data=build_package_data()
 setup(
     name="circuitpython-stubs",
     description="PEP 561 type stubs for CircuitPython",
@@ -44,6 +51,9 @@ setup(
     author_email="circuitpython@adafruit.com",
     version=version,
     license="MIT",
-    data_files=build_data_files_list(),
+    packages=list(package_data.keys()),
+    package_data=package_data,
+    package_dir = package_dir,
     setup_requires=["setuptools>=38.6.0"],
+    zip_safe=False,
 )


### PR DESCRIPTION
 * Don't include a full path from the build system
 * Rename all packages to "foo-stubs"
 * Don't install stubs for standard packages like "os"

After this, I can `python setup.py install --user` to install the stubs
to my local environment, and successfully check code against the stubs,
such as
```
/$ mypy -c 'import busio; b: busio.I2C; b.readfrom_into(0x30, b"")'
<string>:1: error: Argument 2 to "readfrom_into" of "I2C" has incompatible type "bytes"; expected "Union[bytearray, memoryview, array[Any], ndarray, RGBMatrix]"
Found 1 error in 1 file (checked 1 source file)
```

The structure of a wheel built with `python setup.py bdist_wheel` looks
more like lxml-stubs, as well.
```
Archive:  dist/circuitpython_stubs-7.0.0a3.dev28+g124c7b785-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
    30705  2021-06-10 13:50   _bleio-stubs/__init__.pyi…
```

Finally, by eliminating `site.getsitepackages()`, this **may** fix
the doc building problem on readthedocs.

Closes: #4879 