### PR TITLE
Change TinyS2 default SPI pins

### DIFF
--- a/ports/esp32s2/boards/unexpectedmaker_tinys2/mpconfigboard.h
+++ b/ports/esp32s2/boards/unexpectedmaker_tinys2/mpconfigboard.h
@@ -39,9 +39,9 @@
 #define DEFAULT_I2C_BUS_SCL (&pin_GPIO9)
 #define DEFAULT_I2C_BUS_SDA (&pin_GPIO8)
 
-#define DEFAULT_SPI_BUS_SCK (&pin_GPIO36)
+#define DEFAULT_SPI_BUS_SCK (&pin_GPIO37)
 #define DEFAULT_SPI_BUS_MOSI (&pin_GPIO35)
-#define DEFAULT_SPI_BUS_MISO (&pin_GPIO37)
+#define DEFAULT_SPI_BUS_MISO (&pin_GPIO36)
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)


### PR DESCRIPTION
Leading on from https://github.com/adafruit/circuitpython/pull/4534
`pins.c` was previously updated, but there was also a reference in `mpconfigboard.h` that was missed.

```
SCK = 37
SDI = 36
SDO = 35
```