### PR TITLE
Add A0 as alias to potentiometer pin.

### DIFF
--- a/ports/atmel-samd/boards/adafruit_slide_trinkey_m0/pins.c
+++ b/ports/atmel-samd/boards/adafruit_slide_trinkey_m0/pins.c
@@ -3,6 +3,7 @@
 STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_PA04) },
     { MP_ROM_QSTR(MP_QSTR_POTENTIOMETER), MP_ROM_PTR(&pin_PA02) },
+    { MP_ROM_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_PA02) },
     { MP_ROM_QSTR(MP_QSTR_TOUCH), MP_ROM_PTR(&pin_PA07) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);

--- a/ports/atmel-samd/boards/adafruit_slide_trinkey_m0/pins.c
+++ b/ports/atmel-samd/boards/adafruit_slide_trinkey_m0/pins.c
@@ -2,8 +2,10 @@
 
 STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_PA04) },
+
     { MP_ROM_QSTR(MP_QSTR_POTENTIOMETER), MP_ROM_PTR(&pin_PA02) },
     { MP_ROM_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_PA02) },
+
     { MP_ROM_QSTR(MP_QSTR_TOUCH), MP_ROM_PTR(&pin_PA07) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);


### PR DESCRIPTION
Per discussion with Limor. Tested successfully.