### PR TITLE
Reduced property flash

### DIFF
--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -438,10 +438,9 @@ STATIC mp_obj_t vfs_fat_setlabel(mp_obj_t self_in, mp_obj_t label_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_setlabel_obj, vfs_fat_setlabel);
 STATIC const mp_obj_property_t fat_vfs_label_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&fat_vfs_getlabel_obj,
-              (mp_obj_t)&fat_vfs_setlabel_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&fat_vfs_setlabel_obj}
 };
 #endif
 

--- a/ports/atmel-samd/bindings/samd/Clock.c
+++ b/ports/atmel-samd/bindings/samd/Clock.c
@@ -54,10 +54,8 @@ STATIC mp_obj_t samd_clock_get_enabled(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(samd_clock_get_enabled_obj, samd_clock_get_enabled);
 
 const mp_obj_property_t samd_clock_enabled_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&samd_clock_get_enabled_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE,},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&samd_clock_get_enabled_obj}
 };
 
 //|     parent: Union[Clock, None]
@@ -83,10 +81,8 @@ STATIC mp_obj_t samd_clock_get_parent(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(samd_clock_get_parent_obj, samd_clock_get_parent);
 
 const mp_obj_property_t samd_clock_parent_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&samd_clock_get_parent_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE,},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&samd_clock_get_parent_obj},
 };
 
 //|     frequency: int
@@ -100,10 +96,8 @@ STATIC mp_obj_t samd_clock_get_frequency(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(samd_clock_get_frequency_obj, samd_clock_get_frequency);
 
 const mp_obj_property_t samd_clock_frequency_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&samd_clock_get_frequency_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE,},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&samd_clock_get_frequency_obj},
 };
 
 //|     calibration: int
@@ -131,10 +125,9 @@ STATIC mp_obj_t samd_clock_set_calibration(mp_obj_t self_in, mp_obj_t calibratio
 MP_DEFINE_CONST_FUN_OBJ_2(samd_clock_set_calibration_obj, samd_clock_set_calibration);
 
 const mp_obj_property_t samd_clock_calibration_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&samd_clock_get_calibration_obj,
-              (mp_obj_t)&samd_clock_set_calibration_obj,
-              MP_ROM_NONE,},
+              (mp_obj_t)&samd_clock_set_calibration_obj,},
 };
 
 STATIC const mp_rom_map_elem_t samd_clock_locals_dict_table[] = {

--- a/py/obj.h
+++ b/py/obj.h
@@ -356,10 +356,8 @@ typedef struct _mp_rom_obj_t { mp_const_obj_t o; } mp_rom_obj_t;
 #define MP_DEFINE_CONST_PROP_GET(obj_name, fun_name) \
     const mp_obj_fun_builtin_fixed_t fun_name##_obj = {{&mp_type_fun_builtin_1}, .fun._1 = fun_name}; \
     const mp_obj_property_t obj_name = { \
-        .base.type = &mp_type_property, \
-        .proxy = {(mp_obj_t)&fun_name##_obj, \
-                  MP_ROM_NONE, \
-                  MP_ROM_NONE}, }
+        .base.type = &mp_type_ro_property, \
+        .proxy = {(mp_obj_t)&fun_name##_obj }}
 
 // These macros are used to define constant or mutable map/dict objects
 // You can put "static" in front of the definition to make it local
@@ -670,6 +668,8 @@ extern const mp_obj_type_t mp_type_module;
 extern const mp_obj_type_t mp_type_staticmethod;
 extern const mp_obj_type_t mp_type_classmethod;
 extern const mp_obj_type_t mp_type_property;
+extern const mp_obj_type_t mp_type_rw_property;
+extern const mp_obj_type_t mp_type_ro_property;
 extern const mp_obj_type_t mp_type_stringio;
 extern const mp_obj_type_t mp_type_bytesio;
 extern const mp_obj_type_t mp_type_reversed;

--- a/py/objproperty.h
+++ b/py/objproperty.h
@@ -32,8 +32,13 @@
 
 typedef struct _mp_obj_property_t {
     mp_obj_base_t base;
-    mp_obj_t proxy[3]; // getter, setter, deleter
+    mp_obj_t proxy[]; // getter, setter, deleter
 } mp_obj_property_t;
+
+// Each category includes the categories above it
+bool mp_obj_is_any_property(const mp_obj_t *obj); // Has slot allocated for at least get (mp_type_roproperty)
+bool mp_obj_is_settable_property(const mp_obj_t *obj); // Has slots allocated for at least get and set (mp_type_rwproperty)
+bool mp_obj_is_deletable_property(const mp_obj_t *obj); // Has slots allocated for get, set, and del (mp_type_property)
 
 #endif  // MICROPY_PY_BUILTINS_PROPERTY
 

--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -118,10 +118,8 @@ STATIC mp_obj_t analogio_analogin_obj_get_value(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(analogio_analogin_get_value_obj, analogio_analogin_obj_get_value);
 
 const mp_obj_property_t analogio_analogin_value_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&analogio_analogin_get_value_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&analogio_analogin_get_value_obj},
 };
 
 //|     reference_voltage: float
@@ -143,10 +141,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(analogio_analogin_get_reference_voltage_obj,
     analogio_analogin_obj_get_reference_voltage);
 
 const mp_obj_property_t analogio_analogin_reference_voltage_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&analogio_analogin_get_reference_voltage_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&analogio_analogin_get_reference_voltage_obj},
 };
 
 STATIC const mp_rom_map_elem_t analogio_analogin_locals_dict_table[] = {

--- a/shared-bindings/analogio/AnalogOut.c
+++ b/shared-bindings/analogio/AnalogOut.c
@@ -118,10 +118,9 @@ STATIC mp_obj_t analogio_analogout_obj_set_value(mp_obj_t self_in, mp_obj_t valu
 MP_DEFINE_CONST_FUN_OBJ_2(analogio_analogout_set_value_obj, analogio_analogout_obj_set_value);
 
 const mp_obj_property_t analogio_analogout_value_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {MP_ROM_NONE,
-              (mp_obj_t)&analogio_analogout_set_value_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&analogio_analogout_set_value_obj},
 };
 
 STATIC const mp_rom_map_elem_t analogio_analogout_locals_dict_table[] = {

--- a/shared-bindings/audiobusio/I2SOut.c
+++ b/shared-bindings/audiobusio/I2SOut.c
@@ -205,10 +205,8 @@ STATIC mp_obj_t audiobusio_i2sout_obj_get_playing(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(audiobusio_i2sout_get_playing_obj, audiobusio_i2sout_obj_get_playing);
 
 const mp_obj_property_t audiobusio_i2sout_playing_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audiobusio_i2sout_get_playing_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&audiobusio_i2sout_get_playing_obj},
 };
 
 //|     def pause(self) -> None:
@@ -254,10 +252,8 @@ STATIC mp_obj_t audiobusio_i2sout_obj_get_paused(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(audiobusio_i2sout_get_paused_obj, audiobusio_i2sout_obj_get_paused);
 
 const mp_obj_property_t audiobusio_i2sout_paused_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audiobusio_i2sout_get_paused_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&audiobusio_i2sout_get_paused_obj},
 };
 #endif // CIRCUITPY_AUDIOBUSIO_I2SOUT
 

--- a/shared-bindings/audiobusio/PDMIn.c
+++ b/shared-bindings/audiobusio/PDMIn.c
@@ -227,10 +227,8 @@ STATIC mp_obj_t audiobusio_pdmin_obj_get_sample_rate(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(audiobusio_pdmin_get_sample_rate_obj, audiobusio_pdmin_obj_get_sample_rate);
 
 const mp_obj_property_t audiobusio_pdmin_sample_rate_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audiobusio_pdmin_get_sample_rate_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&audiobusio_pdmin_get_sample_rate_obj},
 };
 
 STATIC const mp_rom_map_elem_t audiobusio_pdmin_locals_dict_table[] = {

--- a/shared-bindings/audiocore/RawSample.c
+++ b/shared-bindings/audiocore/RawSample.c
@@ -154,10 +154,9 @@ STATIC mp_obj_t audioio_rawsample_obj_set_sample_rate(mp_obj_t self_in, mp_obj_t
 MP_DEFINE_CONST_FUN_OBJ_2(audioio_rawsample_set_sample_rate_obj, audioio_rawsample_obj_set_sample_rate);
 
 const mp_obj_property_t audioio_rawsample_sample_rate_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&audioio_rawsample_get_sample_rate_obj,
-              (mp_obj_t)&audioio_rawsample_set_sample_rate_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&audioio_rawsample_set_sample_rate_obj},
 };
 
 STATIC const mp_rom_map_elem_t audioio_rawsample_locals_dict_table[] = {

--- a/shared-bindings/audiocore/WaveFile.c
+++ b/shared-bindings/audiocore/WaveFile.c
@@ -146,10 +146,9 @@ STATIC mp_obj_t audioio_wavefile_obj_set_sample_rate(mp_obj_t self_in, mp_obj_t 
 MP_DEFINE_CONST_FUN_OBJ_2(audioio_wavefile_set_sample_rate_obj, audioio_wavefile_obj_set_sample_rate);
 
 const mp_obj_property_t audioio_wavefile_sample_rate_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&audioio_wavefile_get_sample_rate_obj,
-              (mp_obj_t)&audioio_wavefile_set_sample_rate_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&audioio_wavefile_set_sample_rate_obj},
 };
 
 //|     bits_per_sample: int
@@ -163,10 +162,8 @@ STATIC mp_obj_t audioio_wavefile_obj_get_bits_per_sample(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(audioio_wavefile_get_bits_per_sample_obj, audioio_wavefile_obj_get_bits_per_sample);
 
 const mp_obj_property_t audioio_wavefile_bits_per_sample_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audioio_wavefile_get_bits_per_sample_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&audioio_wavefile_get_bits_per_sample_obj},
 };
 //|     channel_count: int
 //|     """Number of audio channels. (read only)"""
@@ -179,10 +176,8 @@ STATIC mp_obj_t audioio_wavefile_obj_get_channel_count(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(audioio_wavefile_get_channel_count_obj, audioio_wavefile_obj_get_channel_count);
 
 const mp_obj_property_t audioio_wavefile_channel_count_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audioio_wavefile_get_channel_count_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&audioio_wavefile_get_channel_count_obj},
 };
 
 

--- a/shared-bindings/audioio/AudioOut.c
+++ b/shared-bindings/audioio/AudioOut.c
@@ -198,10 +198,8 @@ STATIC mp_obj_t audioio_audioout_obj_get_playing(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(audioio_audioout_get_playing_obj, audioio_audioout_obj_get_playing);
 
 const mp_obj_property_t audioio_audioout_playing_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audioio_audioout_get_playing_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&audioio_audioout_get_playing_obj},
 };
 
 //|     def pause(self) -> None:
@@ -247,10 +245,8 @@ STATIC mp_obj_t audioio_audioout_obj_get_paused(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(audioio_audioout_get_paused_obj, audioio_audioout_obj_get_paused);
 
 const mp_obj_property_t audioio_audioout_paused_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audioio_audioout_get_paused_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&audioio_audioout_get_paused_obj},
 };
 
 STATIC const mp_rom_map_elem_t audioio_audioout_locals_dict_table[] = {

--- a/shared-bindings/audiomixer/Mixer.c
+++ b/shared-bindings/audiomixer/Mixer.c
@@ -167,10 +167,8 @@ STATIC mp_obj_t audiomixer_mixer_obj_get_playing(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(audiomixer_mixer_get_playing_obj, audiomixer_mixer_obj_get_playing);
 
 const mp_obj_property_t audiomixer_mixer_playing_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audiomixer_mixer_get_playing_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&audiomixer_mixer_get_playing_obj},
 };
 
 //|     sample_rate: int
@@ -184,10 +182,8 @@ STATIC mp_obj_t audiomixer_mixer_obj_get_sample_rate(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(audiomixer_mixer_get_sample_rate_obj, audiomixer_mixer_obj_get_sample_rate);
 
 const mp_obj_property_t audiomixer_mixer_sample_rate_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audiomixer_mixer_get_sample_rate_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&audiomixer_mixer_get_sample_rate_obj},
 };
 
 //|     voice: Tuple[MixerVoice, ...]
@@ -205,10 +201,8 @@ STATIC mp_obj_t audiomixer_mixer_obj_get_voice(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(audiomixer_mixer_get_voice_obj, audiomixer_mixer_obj_get_voice);
 
 const mp_obj_property_t audiomixer_mixer_voice_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audiomixer_mixer_get_voice_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&audiomixer_mixer_get_voice_obj},
 };
 
 //|     def play(self, sample: _typing.AudioSample, *, voice: int = 0, loop: bool = False) -> None:

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -130,10 +130,9 @@ STATIC mp_obj_t audiomixer_mixervoice_obj_set_level(size_t n_args, const mp_obj_
 MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_set_level_obj, 1, audiomixer_mixervoice_obj_set_level);
 
 const mp_obj_property_t audiomixer_mixervoice_level_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&audiomixer_mixervoice_get_level_obj,
-              (mp_obj_t)&audiomixer_mixervoice_set_level_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&audiomixer_mixervoice_set_level_obj},
 };
 
 //|     playing: bool
@@ -149,10 +148,8 @@ STATIC mp_obj_t audiomixer_mixervoice_obj_get_playing(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(audiomixer_mixervoice_get_playing_obj, audiomixer_mixervoice_obj_get_playing);
 
 const mp_obj_property_t audiomixer_mixervoice_playing_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&audiomixer_mixervoice_get_playing_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&audiomixer_mixervoice_get_playing_obj},
 };
 
 STATIC const mp_rom_map_elem_t audiomixer_mixervoice_locals_dict_table[] = {

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -399,10 +399,8 @@ STATIC mp_obj_t busio_spi_obj_get_frequency(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(busio_spi_get_frequency_obj, busio_spi_obj_get_frequency);
 
 const mp_obj_property_t busio_spi_frequency_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&busio_spi_get_frequency_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&busio_spi_get_frequency_obj},
 };
 #endif // CIRCUITPY_BUSIO_SPI
 

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -283,10 +283,9 @@ MP_DEFINE_CONST_FUN_OBJ_2(busio_uart_set_baudrate_obj, busio_uart_obj_set_baudra
 
 
 const mp_obj_property_t busio_uart_baudrate_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&busio_uart_get_baudrate_obj,
-              (mp_obj_t)&busio_uart_set_baudrate_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&busio_uart_set_baudrate_obj},
 };
 
 //|     in_waiting: int
@@ -300,10 +299,8 @@ STATIC mp_obj_t busio_uart_obj_get_in_waiting(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(busio_uart_get_in_waiting_obj, busio_uart_obj_get_in_waiting);
 
 const mp_obj_property_t busio_uart_in_waiting_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&busio_uart_get_in_waiting_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&busio_uart_get_in_waiting_obj},
 };
 
 //|     timeout: float
@@ -328,10 +325,9 @@ MP_DEFINE_CONST_FUN_OBJ_2(busio_uart_set_timeout_obj, busio_uart_obj_set_timeout
 
 
 const mp_obj_property_t busio_uart_timeout_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&busio_uart_get_timeout_obj,
-              (mp_obj_t)&busio_uart_set_timeout_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&busio_uart_set_timeout_obj},
 };
 
 //|     def reset_input_buffer(self) -> None:

--- a/shared-bindings/countio/Counter.c
+++ b/shared-bindings/countio/Counter.c
@@ -106,10 +106,9 @@ STATIC mp_obj_t countio_counter_obj_set_count(mp_obj_t self_in, mp_obj_t new_cou
 MP_DEFINE_CONST_FUN_OBJ_2(countio_counter_set_count_obj, countio_counter_obj_set_count);
 
 const mp_obj_property_t countio_counter_count_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&countio_counter_get_count_obj,
-              (mp_obj_t)&countio_counter_set_count_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&countio_counter_set_count_obj},
 };
 
 //|     def reset(self) -> None:

--- a/shared-bindings/digitalio/DigitalInOut.c
+++ b/shared-bindings/digitalio/DigitalInOut.c
@@ -222,10 +222,9 @@ STATIC mp_obj_t digitalio_digitalinout_obj_set_direction(mp_obj_t self_in, mp_ob
 MP_DEFINE_CONST_FUN_OBJ_2(digitalio_digitalinout_set_direction_obj, digitalio_digitalinout_obj_set_direction);
 
 const mp_obj_property_t digitalio_digitalio_direction_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&digitalio_digitalinout_get_direction_obj,
-              (mp_obj_t)&digitalio_digitalinout_set_direction_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&digitalio_digitalinout_set_direction_obj},
 };
 
 //|     value: bool
@@ -252,10 +251,9 @@ STATIC mp_obj_t digitalio_digitalinout_obj_set_value(mp_obj_t self_in, mp_obj_t 
 MP_DEFINE_CONST_FUN_OBJ_2(digitalio_digitalinout_set_value_obj, digitalio_digitalinout_obj_set_value);
 
 const mp_obj_property_t digitalio_digitalinout_value_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&digitalio_digitalinout_get_value_obj,
-              (mp_obj_t)&digitalio_digitalinout_set_value_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&digitalio_digitalinout_set_value_obj},
 };
 
 //|     drive_mode: DriveMode
@@ -296,10 +294,9 @@ STATIC mp_obj_t digitalio_digitalinout_obj_set_drive_mode(mp_obj_t self_in, mp_o
 MP_DEFINE_CONST_FUN_OBJ_2(digitalio_digitalinout_set_drive_mode_obj, digitalio_digitalinout_obj_set_drive_mode);
 
 const mp_obj_property_t digitalio_digitalio_drive_mode_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&digitalio_digitalinout_get_drive_mode_obj,
-              (mp_obj_t)&digitalio_digitalinout_set_drive_mode_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&digitalio_digitalinout_set_drive_mode_obj},
 };
 
 //|     pull: Optional[Pull]
@@ -349,10 +346,9 @@ STATIC mp_obj_t digitalio_digitalinout_obj_set_pull(mp_obj_t self_in, mp_obj_t p
 MP_DEFINE_CONST_FUN_OBJ_2(digitalio_digitalinout_set_pull_obj, digitalio_digitalinout_obj_set_pull);
 
 const mp_obj_property_t digitalio_digitalio_pull_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&digitalio_digitalinout_get_pull_obj,
-              (mp_obj_t)&digitalio_digitalinout_set_pull_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&digitalio_digitalinout_set_pull_obj},
 };
 
 STATIC const mp_rom_map_elem_t digitalio_digitalinout_locals_dict_table[] = {

--- a/shared-bindings/microcontroller/Processor.c
+++ b/shared-bindings/microcontroller/Processor.c
@@ -68,11 +68,8 @@ STATIC mp_obj_t mcu_processor_get_frequency(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(mcu_processor_get_frequency_obj, mcu_processor_get_frequency);
 
 const mp_obj_property_t mcu_processor_frequency_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&mcu_processor_get_frequency_obj,  // getter
-              MP_ROM_NONE,            // no setter
-              MP_ROM_NONE,            // no deleter
-    },
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&mcu_processor_get_frequency_obj},
 };
 
 //|     reset_reason: microcontroller.ResetReason
@@ -85,11 +82,8 @@ STATIC mp_obj_t mcu_processor_get_reset_reason(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(mcu_processor_get_reset_reason_obj, mcu_processor_get_reset_reason);
 
 const mp_obj_property_t mcu_processor_reset_reason_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&mcu_processor_get_reset_reason_obj,  // getter
-              MP_ROM_NONE,            // no setter
-              MP_ROM_NONE,            // no deleter
-    },
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&mcu_processor_get_reset_reason_obj},
 };
 
 //|     temperature: Optional[float]
@@ -105,11 +99,8 @@ STATIC mp_obj_t mcu_processor_get_temperature(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(mcu_processor_get_temperature_obj, mcu_processor_get_temperature);
 
 const mp_obj_property_t mcu_processor_temperature_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&mcu_processor_get_temperature_obj,  // getter
-              MP_ROM_NONE,            // no setter
-              MP_ROM_NONE,            // no deleter
-    },
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&mcu_processor_get_temperature_obj},
 };
 
 //|     uid: bytearray
@@ -124,11 +115,8 @@ STATIC mp_obj_t mcu_processor_get_uid(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(mcu_processor_get_uid_obj, mcu_processor_get_uid);
 
 const mp_obj_property_t mcu_processor_uid_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&mcu_processor_get_uid_obj,  // getter
-              MP_ROM_NONE,      // no setter
-              MP_ROM_NONE,      // no deleter
-    },
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&mcu_processor_get_uid_obj},
 };
 
 //|     voltage: Optional[float]
@@ -144,11 +132,8 @@ STATIC mp_obj_t mcu_processor_get_voltage(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(mcu_processor_get_voltage_obj, mcu_processor_get_voltage);
 
 const mp_obj_property_t mcu_processor_voltage_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&mcu_processor_get_voltage_obj,  // getter
-              MP_ROM_NONE,            // no setter
-              MP_ROM_NONE,            // no deleter
-    },
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&mcu_processor_get_voltage_obj},
 };
 
 STATIC const mp_rom_map_elem_t mcu_processor_locals_dict_table[] = {

--- a/shared-bindings/pwmio/PWMOut.c
+++ b/shared-bindings/pwmio/PWMOut.c
@@ -200,10 +200,9 @@ STATIC mp_obj_t pwmio_pwmout_obj_set_duty_cycle(mp_obj_t self_in, mp_obj_t duty_
 MP_DEFINE_CONST_FUN_OBJ_2(pwmio_pwmout_set_duty_cycle_obj, pwmio_pwmout_obj_set_duty_cycle);
 
 const mp_obj_property_t pwmio_pwmout_duty_cycle_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&pwmio_pwmout_get_duty_cycle_obj,
-              (mp_obj_t)&pwmio_pwmout_set_duty_cycle_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&pwmio_pwmout_set_duty_cycle_obj},
 };
 
 //|     frequency: int
@@ -237,10 +236,9 @@ STATIC mp_obj_t pwmio_pwmout_obj_set_frequency(mp_obj_t self_in, mp_obj_t freque
 MP_DEFINE_CONST_FUN_OBJ_2(pwmio_pwmout_set_frequency_obj, pwmio_pwmout_obj_set_frequency);
 
 const mp_obj_property_t pwmio_pwmout_frequency_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&pwmio_pwmout_get_frequency_obj,
-              (mp_obj_t)&pwmio_pwmout_set_frequency_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&pwmio_pwmout_set_frequency_obj},
 };
 
 STATIC const mp_rom_map_elem_t pwmio_pwmout_locals_dict_table[] = {

--- a/shared-bindings/rotaryio/IncrementalEncoder.c
+++ b/shared-bindings/rotaryio/IncrementalEncoder.c
@@ -138,10 +138,9 @@ STATIC mp_obj_t rotaryio_incrementalencoder_obj_set_position(mp_obj_t self_in, m
 MP_DEFINE_CONST_FUN_OBJ_2(rotaryio_incrementalencoder_set_position_obj, rotaryio_incrementalencoder_obj_set_position);
 
 const mp_obj_property_t rotaryio_incrementalencoder_position_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&rotaryio_incrementalencoder_get_position_obj,
-              (mp_obj_t)&rotaryio_incrementalencoder_set_position_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&rotaryio_incrementalencoder_set_position_obj},
 };
 
 STATIC const mp_rom_map_elem_t rotaryio_incrementalencoder_locals_dict_table[] = {

--- a/shared-bindings/rtc/RTC.c
+++ b/shared-bindings/rtc/RTC.c
@@ -88,10 +88,9 @@ STATIC mp_obj_t rtc_rtc_obj_set_datetime(mp_obj_t self_in, mp_obj_t datetime) {
 MP_DEFINE_CONST_FUN_OBJ_2(rtc_rtc_set_datetime_obj, rtc_rtc_obj_set_datetime);
 
 const mp_obj_property_t rtc_rtc_datetime_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&rtc_rtc_get_datetime_obj,
-              (mp_obj_t)&rtc_rtc_set_datetime_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&rtc_rtc_set_datetime_obj},
 };
 
 //|     calibration: int
@@ -119,10 +118,9 @@ STATIC mp_obj_t rtc_rtc_obj_set_calibration(mp_obj_t self_in, mp_obj_t calibrati
 MP_DEFINE_CONST_FUN_OBJ_2(rtc_rtc_set_calibration_obj, rtc_rtc_obj_set_calibration);
 
 const mp_obj_property_t rtc_rtc_calibration_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&rtc_rtc_get_calibration_obj,
-              (mp_obj_t)&rtc_rtc_set_calibration_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&rtc_rtc_set_calibration_obj},
 };
 
 STATIC const mp_rom_map_elem_t rtc_rtc_locals_dict_table[] = {

--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -70,10 +70,8 @@ STATIC mp_obj_t supervisor_runtime_get_usb_connected(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(supervisor_runtime_get_usb_connected_obj, supervisor_runtime_get_usb_connected);
 
 const mp_obj_property_t supervisor_runtime_usb_connected_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&supervisor_runtime_get_usb_connected_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&supervisor_runtime_get_usb_connected_obj},
 };
 
 //|     serial_connected: bool
@@ -85,10 +83,8 @@ STATIC mp_obj_t supervisor_runtime_get_serial_connected(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(supervisor_runtime_get_serial_connected_obj, supervisor_runtime_get_serial_connected);
 
 const mp_obj_property_t supervisor_runtime_serial_connected_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&supervisor_runtime_get_serial_connected_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&supervisor_runtime_get_serial_connected_obj},
 };
 
 //|     serial_bytes_available: int
@@ -102,10 +98,8 @@ STATIC mp_obj_t supervisor_runtime_get_serial_bytes_available(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(supervisor_runtime_get_serial_bytes_available_obj, supervisor_runtime_get_serial_bytes_available);
 
 const mp_obj_property_t supervisor_runtime_serial_bytes_available_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&supervisor_runtime_get_serial_bytes_available_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&supervisor_runtime_get_serial_bytes_available_obj},
 };
 
 //|     run_reason: RunReason
@@ -117,10 +111,8 @@ STATIC mp_obj_t supervisor_runtime_get_run_reason(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(supervisor_runtime_get_run_reason_obj, supervisor_runtime_get_run_reason);
 
 const mp_obj_property_t supervisor_runtime_run_reason_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&supervisor_runtime_get_run_reason_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&supervisor_runtime_get_run_reason_obj},
 };
 
 void supervisor_set_run_reason(supervisor_run_reason_t run_reason) {

--- a/shared-bindings/touchio/TouchIn.c
+++ b/shared-bindings/touchio/TouchIn.c
@@ -121,10 +121,8 @@ STATIC mp_obj_t touchio_touchin_obj_get_value(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(touchio_touchin_get_value_obj, touchio_touchin_obj_get_value);
 
 const mp_obj_property_t touchio_touchin_value_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&touchio_touchin_get_value_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&touchio_touchin_get_value_obj},
 };
 
 
@@ -140,10 +138,8 @@ STATIC mp_obj_t touchio_touchin_obj_get_raw_value(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(touchio_touchin_get_raw_value_obj, touchio_touchin_obj_get_raw_value);
 
 const mp_obj_property_t touchio_touchin_raw_value_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&touchio_touchin_get_raw_value_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&touchio_touchin_get_raw_value_obj},
 };
 
 
@@ -184,10 +180,9 @@ STATIC mp_obj_t touchio_touchin_obj_set_threshold(mp_obj_t self_in, mp_obj_t thr
 MP_DEFINE_CONST_FUN_OBJ_2(touchio_touchin_set_threshold_obj, touchio_touchin_obj_set_threshold);
 
 const mp_obj_property_t touchio_touchin_threshold_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&touchio_touchin_get_threshold_obj,
-              (mp_obj_t)&touchio_touchin_set_threshold_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&touchio_touchin_set_threshold_obj},
 };
 
 

--- a/shared-bindings/usb_cdc/Serial.c
+++ b/shared-bindings/usb_cdc/Serial.c
@@ -158,10 +158,8 @@ STATIC mp_obj_t usb_cdc_serial_get_connected(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(usb_cdc_serial_get_connected_obj, usb_cdc_serial_get_connected);
 
 const mp_obj_property_t usb_cdc_serial_connected_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&usb_cdc_serial_get_connected_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&usb_cdc_serial_get_connected_obj},
 };
 
 //|     in_waiting: int
@@ -174,10 +172,8 @@ STATIC mp_obj_t usb_cdc_serial_get_in_waiting(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(usb_cdc_serial_get_in_waiting_obj, usb_cdc_serial_get_in_waiting);
 
 const mp_obj_property_t usb_cdc_serial_in_waiting_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&usb_cdc_serial_get_in_waiting_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&usb_cdc_serial_get_in_waiting_obj},
 };
 
 //|     out_waiting: int
@@ -190,10 +186,8 @@ STATIC mp_obj_t usb_cdc_serial_get_out_waiting(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(usb_cdc_serial_get_out_waiting_obj, usb_cdc_serial_get_out_waiting);
 
 const mp_obj_property_t usb_cdc_serial_out_waiting_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&usb_cdc_serial_get_out_waiting_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&usb_cdc_serial_get_out_waiting_obj},
 };
 
 //|     def reset_input_buffer(self) -> None:
@@ -238,10 +232,9 @@ STATIC mp_obj_t usb_cdc_serial_set_timeout(mp_obj_t self_in, mp_obj_t timeout_in
 MP_DEFINE_CONST_FUN_OBJ_2(usb_cdc_serial_set_timeout_obj, usb_cdc_serial_set_timeout);
 
 const mp_obj_property_t usb_cdc_serial_timeout_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&usb_cdc_serial_get_timeout_obj,
-              (mp_obj_t)&usb_cdc_serial_set_timeout_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&usb_cdc_serial_set_timeout_obj},
 };
 
 //|     write_timeout: Optional[float]
@@ -265,10 +258,9 @@ STATIC mp_obj_t usb_cdc_serial_set_write_timeout(mp_obj_t self_in, mp_obj_t writ
 MP_DEFINE_CONST_FUN_OBJ_2(usb_cdc_serial_set_write_timeout_obj, usb_cdc_serial_set_write_timeout);
 
 const mp_obj_property_t usb_cdc_serial_write_timeout_obj = {
-    .base.type = &mp_type_property,
+    .base.type = &mp_type_rw_property,
     .proxy = {(mp_obj_t)&usb_cdc_serial_get_write_timeout_obj,
-              (mp_obj_t)&usb_cdc_serial_set_write_timeout_obj,
-              MP_ROM_NONE},
+              (mp_obj_t)&usb_cdc_serial_set_write_timeout_obj},
 };
 
 

--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -149,10 +149,8 @@ STATIC mp_obj_t usb_hid_device_obj_get_last_received_report(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(usb_hid_device_get_last_received_report_obj, usb_hid_device_obj_get_last_received_report);
 
 const mp_obj_property_t usb_hid_device_last_received_report_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&usb_hid_device_get_last_received_report_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&usb_hid_device_get_last_received_report_obj},
 };
 
 //|     usage_page: int
@@ -165,10 +163,8 @@ STATIC mp_obj_t usb_hid_device_obj_get_usage_page(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(usb_hid_device_get_usage_page_obj, usb_hid_device_obj_get_usage_page);
 
 const mp_obj_property_t usb_hid_device_usage_page_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&usb_hid_device_get_usage_page_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&usb_hid_device_get_usage_page_obj},
 };
 
 //|     usage: int
@@ -185,10 +181,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(usb_hid_device_get_usage_obj,
     usb_hid_device_obj_get_usage);
 
 const mp_obj_property_t usb_hid_device_usage_obj = {
-    .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&usb_hid_device_get_usage_obj,
-              MP_ROM_NONE,
-              MP_ROM_NONE},
+    .base.type = &mp_type_ro_property,
+    .proxy = {(mp_obj_t)&usb_hid_device_get_usage_obj},
 };
 
 STATIC const mp_rom_map_elem_t usb_hid_device_locals_dict_table[] = {


### PR DESCRIPTION
I saw #4899 and took a stab at implementing it.

This concentrates on (and I think hits all of) the properties that exist in libraries on the trinket_m0.

Baseline:  3760 bytes free in flash
New code:  3580 bytes free in flash  (+180 vs baseline)
Using it:  3812 bytes free in flash  (-52 vs baseline) (-232 vs core code)

I tested
 * read-only properties like `AnalogIn.value`
 * read-write properties like `VfsFat.label`
 * deletable properies like the (this example in the python documentation)[https://docs.python.org/3.8/library/functions.html#property]