### PR TITLE
remove duplicate line in setup py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,6 @@ from pathlib import Path
 
 STD_PACKAGES = set(('array', 'math', 'os', 'random', 'struct', 'sys', 'ssl', 'time'))
 
-STD_PACKAGES = set(('array', 'math', 'os', 'random', 'struct', 'sys', 'ssl', 'time'))
-
 stub_root = Path("circuitpython-stubs")
 stubs = [p.relative_to(stub_root).as_posix() for p in stub_root.glob("*.pyi")]
 


### PR DESCRIPTION
this removes a duplicate line that was accidentally included in the recent stubs PR.