### PR TITLE
Fix pin assignments I2S_SDIN/SDOUT of Wio Terminal

### DIFF
--- a/ports/atmel-samd/boards/seeeduino_wio_terminal/pins.c
+++ b/ports/atmel-samd/boards/seeeduino_wio_terminal/pins.c
@@ -89,8 +89,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     // I2S
     { MP_OBJ_NEW_QSTR(MP_QSTR_I2S_LRCLK),  MP_ROM_PTR(&pin_PA20) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_I2S_SDIN),  MP_ROM_PTR(&pin_PA21) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_I2S_SDOUT),  MP_ROM_PTR(&pin_PA22) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_I2S_SDOUT),  MP_ROM_PTR(&pin_PA21) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_I2S_SDIN),  MP_ROM_PTR(&pin_PA22) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_I2S_BCLK),  MP_ROM_PTR(&pin_PB16) },
 
     // RTL8720D


### PR DESCRIPTION
This PR fixes pin assignments of I2S_SDIN/SDOUT of Wio Terminal, added at #4679.  The initial implementation followed the schematics (https://files.seeedstudio.com/wiki/Wio-Terminal/res/Wio-Terminal-SCH-v1.2.pdf), where I2S_SDIN and I2S_SDOUT are defined as PA21(SDO) and PA22(SDI), respectively.  This PR swaps the definitions to be consistent with other boards.