### PR TITLE
Fix 4193 - set hidden_by_parent when adding to displayio group

### DIFF
--- a/shared-module/displayio/Group.c
+++ b/shared-module/displayio/Group.c
@@ -258,6 +258,8 @@ static void _add_layer(displayio_group_t *self, mp_obj_t layer) {
             tilegrid->in_group = true;
         }
         displayio_tilegrid_update_transform(tilegrid, &self->absolute_transform);
+        displayio_tilegrid_set_hidden_by_parent(
+            tilegrid, self->hidden || self->hidden_by_parent);
         return;
     }
     native_layer = mp_obj_cast_to_native_base(layer, &displayio_group_type);
@@ -269,6 +271,8 @@ static void _add_layer(displayio_group_t *self, mp_obj_t layer) {
             group->in_group = true;
         }
         displayio_group_update_transform(group, &self->absolute_transform);
+        displayio_group_set_hidden_by_parent(
+            group, self->hidden || self->hidden_by_parent);
         return;
     }
     mp_raise_ValueError(translate("Layer must be a Group or TileGrid subclass."));


### PR DESCRIPTION
Fixes #4193 using the proposed _simple solution_.

When appending a layer (`Group` or `TileGrid`) to a `displayio` group, set the `hidden_by_parent` attribute to true if the group (the new "parent") is either `hidden` or `hidden_by_parent`. The `*_set_hidden_by_parent` functions propagate the value further down the tree as necessary.

This fixes in particular updating text labels while they are hidden, like you would with a pagination system, since it involves inserting one or more `TileGrid`s inside the label's `Group`, triggering the issue.

Tested on the Clue with the code from the issue and some test code updating text labels while hidden.