### PR TITLE
Minor docs fix in TileGrid.c

### DIFF
--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -56,7 +56,7 @@
 //|         tile_width and tile_height match the height of the bitmap by default.
 //|
 //|         :param Bitmap bitmap: The bitmap storing one or more tiles.
-//|         :param ColorConverter or Palette pixel_shader: The pixel shader that produces colors from values
+//|         :param ColorConverter,Palette pixel_shader: The pixel shader that produces colors from values
 //|         :param int width: Width of the grid in tiles.
 //|         :param int height: Height of the grid in tiles.
 //|         :param int tile_width: Width of a single tile in pixels. Defaults to the full Bitmap and must evenly divide into the Bitmap's dimensions.


### PR DESCRIPTION
Tested locally with `make html`

Before:
![before](https://user-images.githubusercontent.com/70200140/124831362-013dea00-df73-11eb-9da6-65ce3723687c.png)

After:
![After](https://user-images.githubusercontent.com/70200140/124831372-04d17100-df73-11eb-8043-09def4e38ea9.png)
