### PR TITLE
Issue #4945 - handle multiple PulseIns

### DIFF
--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.c
@@ -36,8 +36,6 @@
 #include "bindings/rp2pio/StateMachine.h"
 #include "common-hal/pulseio/PulseIn.h"
 
-pulseio_pulsein_obj_t *save_self;
-
 #define NO_PIN 0xff
 #define MAX_PULSE 65535
 #define MIN_PULSE 10
@@ -62,7 +60,6 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
     self->idle_state = idle_state;
     self->start = 0;
     self->len = 0;
-    save_self = self;
 
     bool ok = rp2pio_statemachine_construct(&self->state_machine,
         pulsein_program, sizeof(pulsein_program) / sizeof(pulsein_program[0]),
@@ -88,7 +85,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
     buf_index = 0;
 
     pio_sm_set_in_pins(self->state_machine.pio,self->state_machine.state_machine,pin->number);
-    common_hal_rp2pio_statemachine_set_interrupt_handler(&(self->state_machine),&common_hal_pulseio_pulsein_interrupt,NULL,PIO_IRQ0_INTE_SM0_RXNEMPTY_BITS);
+    common_hal_rp2pio_statemachine_set_interrupt_handler(&(self->state_machine),&common_hal_pulseio_pulsein_interrupt,self,PIO_IRQ0_INTE_SM0_RXNEMPTY_BITS);
 
     // exec a set pindirs to 0 for input
     pio_sm_exec(self->state_machine.pio,self->state_machine.state_machine,0xe080);
@@ -124,9 +121,8 @@ void common_hal_pulseio_pulsein_pause(pulseio_pulsein_obj_t *self) {
     result = 0;
     buf_index = 0;
 }
-void common_hal_pulseio_pulsein_interrupt() {
+void common_hal_pulseio_pulsein_interrupt(pulseio_pulsein_obj_t *self) {
 
-    pulseio_pulsein_obj_t *self = save_self;
     uint32_t rxfifo = 0;
 
     rxfifo = pio_sm_get_blocking(self->state_machine.pio, self->state_machine.state_machine);


### PR DESCRIPTION
Changed the logic in RP2040 PulseIn to pass the pulseio_pulsein object reference as an argument in the interrupt call. This avoids getting an incorrect pio/state machine reference when checking the input FIFO and using more that one PulseIn.