### PR TITLE
Add LED and GP25 for Cytron Maker Pi Pico

### DIFF
--- a/ports/raspberrypi/boards/cytron_maker_pi_rp2040/pins.c
+++ b/ports/raspberrypi/boards/cytron_maker_pi_rp2040/pins.c
@@ -40,6 +40,9 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_BUZZER), MP_ROM_PTR(&pin_GPIO22) },
     { MP_ROM_QSTR(MP_QSTR_GP22), MP_ROM_PTR(&pin_GPIO22) },
 
+    { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO25) },
+    { MP_ROM_QSTR(MP_QSTR_GP25), MP_ROM_PTR(&pin_GPIO25) },
+
     { MP_ROM_QSTR(MP_QSTR_GP26_A0), MP_ROM_PTR(&pin_GPIO26) },
     { MP_ROM_QSTR(MP_QSTR_GP26), MP_ROM_PTR(&pin_GPIO26) },
     { MP_ROM_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_GPIO26) },


### PR DESCRIPTION
Pin definitions for LED and GP25 were missing. Tested that GP25 does exist on the board and does run the on-board LED.