### PR TITLE
Fix for Issue #4983 - stop state machine before restarting

### DIFF
--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -497,12 +497,12 @@ void common_hal_rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
 }
 
 void common_hal_rp2pio_statemachine_restart(rp2pio_statemachine_obj_t *self) {
-    pio_sm_restart(self->pio, self->state_machine);
+    common_hal_rp2pio_statemachine_stop(self);
     // Reset program counter to the original offset. A JMP is 0x0000 plus
     // the desired offset, so we can just use self->offset.
     pio_sm_exec(self->pio, self->state_machine,self->offset);
+    pio_sm_restart(self->pio, self->state_machine);
     uint8_t pio_index = pio_get_index(self->pio);
-    common_hal_rp2pio_statemachine_stop(self);
     uint32_t pins_we_use = _current_sm_pins[pio_index][self->state_machine];
     pio_sm_set_pins_with_mask(self->pio, self->state_machine, self->initial_pin_state, pins_we_use);
     pio_sm_set_pindirs_with_mask(self->pio, self->state_machine, self->initial_pin_direction, pins_we_use);

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -500,6 +500,7 @@ void common_hal_rp2pio_statemachine_restart(rp2pio_statemachine_obj_t *self) {
     pio_sm_restart(self->pio, self->state_machine);
 
     uint8_t pio_index = pio_get_index(self->pio);
+    common_hal_rp2pio_statemachine_stop(self);
     uint32_t pins_we_use = _current_sm_pins[pio_index][self->state_machine];
     pio_sm_set_pins_with_mask(self->pio, self->state_machine, self->initial_pin_state, pins_we_use);
     pio_sm_set_pindirs_with_mask(self->pio, self->state_machine, self->initial_pin_direction, pins_we_use);

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -498,7 +498,9 @@ void common_hal_rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
 
 void common_hal_rp2pio_statemachine_restart(rp2pio_statemachine_obj_t *self) {
     pio_sm_restart(self->pio, self->state_machine);
-
+    // Reset program counter to the original offset. A JMP is 0x0000 plus
+    // the desired offset, so we can just use self->offset.
+    pio_sm_exec(self->pio, self->state_machine,self->offset);
     uint8_t pio_index = pio_get_index(self->pio);
     common_hal_rp2pio_statemachine_stop(self);
     uint32_t pins_we_use = _current_sm_pins[pio_index][self->state_machine];


### PR DESCRIPTION
Correct state machine restart code by adding a stop before re-starting. Tested OK with the sample Python code provided.