### PR TITLE
ESP32S2: Fix PWM timer leak and variable frequency conflicts

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1270,6 +1270,7 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/pwmio/PWMOut.c
 #: ports/cxd56/common-hal/pwmio/PWMOut.c
+#: ports/esp32s2/common-hal/pwmio/PWMOut.c
 #: ports/mimxrt10xx/common-hal/pwmio/PWMOut.c
 #: ports/nrf/common-hal/pwmio/PWMOut.c
 #: ports/raspberrypi/common-hal/pwmio/PWMOut.c shared-bindings/pwmio/PWMOut.c
@@ -1329,7 +1330,7 @@ msgstr ""
 msgid "Invalid format chunk size"
 msgstr ""
 
-#: ports/esp32s2/common-hal/busio/I2C.c ports/esp32s2/common-hal/pwmio/PWMOut.c
+#: ports/esp32s2/common-hal/busio/I2C.c
 msgid "Invalid frequency"
 msgstr ""
 

--- a/shared-bindings/pwmio/PWMOut.c
+++ b/shared-bindings/pwmio/PWMOut.c
@@ -231,7 +231,11 @@ STATIC mp_obj_t pwmio_pwmout_obj_set_frequency(mp_obj_t self_in, mp_obj_t freque
             "PWM frequency not writable when variable_frequency is False on "
             "construction."));
     }
-    common_hal_pwmio_pwmout_set_frequency(self, mp_obj_get_int(frequency));
+    mp_int_t freq = mp_obj_get_int(frequency);
+    if (freq == 0) {
+        mp_raise_ValueError(translate("Invalid PWM frequency"));
+    }
+    common_hal_pwmio_pwmout_set_frequency(self, freq);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_2(pwmio_pwmout_set_frequency_obj, pwmio_pwmout_obj_set_frequency);


### PR DESCRIPTION
Resolves a number of issues within the ESP32S2 PWMIO module, including issues with the deinit function not releasing system timers properly, various unchecked issues with variable frequency channel assignment, and duty cycle config recalculation when the frequency is changed.

Resolves #4259