### PR TITLE
Correct type name for EventQueue; EventQueue.overflowed not accessible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -531,7 +531,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210506
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/esp32s2/esp-idf/HEAD') }}-20210716
     - name: Clone IDF submodules
       run: |
         (cd $IDF_PATH && git submodule update --init)

--- a/shared-bindings/keypad/EventQueue.c
+++ b/shared-bindings/keypad/EventQueue.c
@@ -137,9 +137,10 @@ const mp_obj_property_t keypad_eventqueue_overflowed_obj = {
 };
 
 STATIC const mp_rom_map_elem_t keypad_eventqueue_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_clear),       MP_ROM_PTR(&keypad_eventqueue_clear_obj) },
+    { MP_ROM_QSTR(MP_QSTR_clear),      MP_ROM_PTR(&keypad_eventqueue_clear_obj) },
     { MP_ROM_QSTR(MP_QSTR_get),        MP_ROM_PTR(&keypad_eventqueue_get_obj) },
-    { MP_ROM_QSTR(MP_QSTR_get_into),  MP_ROM_PTR(&keypad_eventqueue_get_into_obj) },
+    { MP_ROM_QSTR(MP_QSTR_get_into),   MP_ROM_PTR(&keypad_eventqueue_get_into_obj) },
+    { MP_ROM_QSTR(MP_QSTR_overflowed), MP_ROM_PTR(&keypad_eventqueue_overflowed_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(keypad_eventqueue_locals_dict, keypad_eventqueue_locals_dict_table);
@@ -147,7 +148,7 @@ STATIC MP_DEFINE_CONST_DICT(keypad_eventqueue_locals_dict, keypad_eventqueue_loc
 const mp_obj_type_t keypad_eventqueue_type = {
     { &mp_type_type },
     .flags = MP_TYPE_FLAG_EXTENDED,
-    .name = MP_QSTR_Keys,
+    .name = MP_QSTR_EventQueue,
     MP_TYPE_EXTENDED_FIELDS(
         .unary_op = keypad_eventqueue_unary_op,
         ),


### PR DESCRIPTION
- `keypad.EventQueue` had the wrong name for its type name.
- `EventQueue.overflowed` was missing from the class dict.