### PR TITLE
Issue #5012 - RP2040 moved globals to PulseIn object to fix multiple instances

### DIFF
--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.c
@@ -39,7 +39,6 @@
 #define NO_PIN 0xff
 #define MAX_PULSE 65535
 #define MIN_PULSE 10
-volatile uint32_t result = 0;
 
 uint16_t pulsein_program[] = {
     0x4001, //  1: in     pins, 1
@@ -82,7 +81,6 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
     pio_sm_clear_fifos(self->state_machine.pio,self->state_machine.state_machine);
     self->last_level = self->idle_state;
     self->level_count = 0;
-    result = 0;
     self->buf_index = 0;
 
     pio_sm_set_in_pins(self->state_machine.pio,self->state_machine.state_machine,pin->number);
@@ -119,7 +117,6 @@ void common_hal_pulseio_pulsein_pause(pulseio_pulsein_obj_t *self) {
     pio_sm_set_enabled(self->state_machine.pio, self->state_machine.state_machine, false);
     self->last_level = self->idle_state;
     self->level_count = 0;
-    result = 0;
     self->buf_index = 0;
 }
 void common_hal_pulseio_pulsein_interrupt(pulseio_pulsein_obj_t *self) {
@@ -136,7 +133,7 @@ void common_hal_pulseio_pulsein_interrupt(pulseio_pulsein_obj_t *self) {
             if (level == self->last_level) {
                 self->level_count++;
             } else {
-                result = self->level_count;
+                uint32_t result = self->level_count;
                 self->last_level = level;
                 self->level_count = 0;
                 // Pulses that are longer than MAX_PULSE will return MAX_PULSE

--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.c
@@ -129,36 +129,36 @@ void common_hal_pulseio_pulsein_interrupt(pulseio_pulsein_obj_t *self) {
     rxfifo = pio_sm_get_blocking(self->state_machine.pio, self->state_machine.state_machine);
     // translate from fifo to buffer
     if ((rxfifo == 0 && self->last_level == false) || (rxfifo == 0xffffffff && self->last_level == true)) {
-	    self->level_count = self->level_count + 32;
+        self->level_count = self->level_count + 32;
     } else {
-    for (uint i = 0; i < 32; i++) {
-        bool level = (rxfifo & (1 << i)) >> i;
-        if (level == self->last_level) {
-            self->level_count++;
-        } else {
-            result = self->level_count;
-            self->last_level = level;
-            self->level_count = 0;
-            // Pulses that are longer than MAX_PULSE will return MAX_PULSE
-            if (result > MAX_PULSE) {
-                result = MAX_PULSE;
-            }
-            // return  pulses that are not too short
-            if (result > MIN_PULSE) {
-                self->buffer[self->buf_index] = (uint16_t)result;
-                if (self->len < self->maxlen) {
-                    self->len++;
+        for (uint i = 0; i < 32; i++) {
+            bool level = (rxfifo & (1 << i)) >> i;
+            if (level == self->last_level) {
+                self->level_count++;
+            } else {
+                result = self->level_count;
+                self->last_level = level;
+                self->level_count = 0;
+                // Pulses that are longer than MAX_PULSE will return MAX_PULSE
+                if (result > MAX_PULSE) {
+                    result = MAX_PULSE;
                 }
-                if (self->buf_index < self->maxlen) {
-                    self->buf_index++;
-                } else {
-                    self->start = 0;
-                    self->buf_index = 0;
+                // return  pulses that are not too short
+                if (result > MIN_PULSE) {
+                    self->buffer[self->buf_index] = (uint16_t)result;
+                    if (self->len < self->maxlen) {
+                        self->len++;
+                    }
+                    if (self->buf_index < self->maxlen) {
+                        self->buf_index++;
+                    } else {
+                        self->start = 0;
+                        self->buf_index = 0;
+                    }
                 }
             }
         }
     }
-   }
 
 // check for a pulse thats too long (MAX_PULSE us) or maxlen reached,  and reset
     if ((self->level_count > MAX_PULSE) || (self->buf_index >= self->maxlen)) {

--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.c
@@ -39,10 +39,7 @@
 #define NO_PIN 0xff
 #define MAX_PULSE 65535
 #define MIN_PULSE 10
-volatile bool last_level;
-volatile uint32_t level_count = 0;
 volatile uint32_t result = 0;
-volatile uint16_t buf_index = 0;
 
 uint16_t pulsein_program[] = {
     0x4001, //  1: in     pins, 1
@@ -77,12 +74,16 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
             true, 32, true, // RX auto-push every 32 bits
             false); // claim pins
 
+    if (!ok) {
+        mp_raise_RuntimeError(translate("All state machines in use"));
+    }
+
     pio_sm_set_enabled(self->state_machine.pio,self->state_machine.state_machine, false);
     pio_sm_clear_fifos(self->state_machine.pio,self->state_machine.state_machine);
-    last_level = self->idle_state;
-    level_count = 0;
+    self->last_level = self->idle_state;
+    self->level_count = 0;
     result = 0;
-    buf_index = 0;
+    self->buf_index = 0;
 
     pio_sm_set_in_pins(self->state_machine.pio,self->state_machine.state_machine,pin->number);
     common_hal_rp2pio_statemachine_set_interrupt_handler(&(self->state_machine),&common_hal_pulseio_pulsein_interrupt,self,PIO_IRQ0_INTE_SM0_RXNEMPTY_BITS);
@@ -116,10 +117,10 @@ void common_hal_pulseio_pulsein_deinit(pulseio_pulsein_obj_t *self) {
 void common_hal_pulseio_pulsein_pause(pulseio_pulsein_obj_t *self) {
     pio_sm_restart(self->state_machine.pio, self->state_machine.state_machine);
     pio_sm_set_enabled(self->state_machine.pio, self->state_machine.state_machine, false);
-    last_level = self->idle_state;
-    level_count = 0;
+    self->last_level = self->idle_state;
+    self->level_count = 0;
     result = 0;
-    buf_index = 0;
+    self->buf_index = 0;
 }
 void common_hal_pulseio_pulsein_interrupt(pulseio_pulsein_obj_t *self) {
 
@@ -127,36 +128,40 @@ void common_hal_pulseio_pulsein_interrupt(pulseio_pulsein_obj_t *self) {
 
     rxfifo = pio_sm_get_blocking(self->state_machine.pio, self->state_machine.state_machine);
     // translate from fifo to buffer
+    if ((rxfifo == 0 && self->last_level == false) || (rxfifo == 0xffffffff && self->last_level == true)) {
+	    self->level_count = self->level_count + 32;
+    } else {
     for (uint i = 0; i < 32; i++) {
         bool level = (rxfifo & (1 << i)) >> i;
-        if (level == last_level) {
-            level_count++;
+        if (level == self->last_level) {
+            self->level_count++;
         } else {
-            result = level_count;
-            last_level = level;
-            level_count = 0;
+            result = self->level_count;
+            self->last_level = level;
+            self->level_count = 0;
             // Pulses that are longer than MAX_PULSE will return MAX_PULSE
             if (result > MAX_PULSE) {
                 result = MAX_PULSE;
             }
             // return  pulses that are not too short
             if (result > MIN_PULSE) {
-                self->buffer[buf_index] = (uint16_t)result;
+                self->buffer[self->buf_index] = (uint16_t)result;
                 if (self->len < self->maxlen) {
                     self->len++;
                 }
-                if (buf_index < self->maxlen) {
-                    buf_index++;
+                if (self->buf_index < self->maxlen) {
+                    self->buf_index++;
                 } else {
                     self->start = 0;
-                    buf_index = 0;
+                    self->buf_index = 0;
                 }
             }
         }
     }
+   }
 
 // check for a pulse thats too long (MAX_PULSE us) or maxlen reached,  and reset
-    if ((level_count > MAX_PULSE) || (buf_index >= self->maxlen)) {
+    if ((self->level_count > MAX_PULSE) || (self->buf_index >= self->maxlen)) {
         pio_sm_set_enabled(self->state_machine.pio, self->state_machine.state_machine, false);
         pio_sm_init(self->state_machine.pio, self->state_machine.state_machine, self->state_machine.offset, &self->state_machine.sm_config);
         pio_sm_restart(self->state_machine.pio,self->state_machine.state_machine);
@@ -189,7 +194,7 @@ void common_hal_pulseio_pulsein_resume(pulseio_pulsein_obj_t *self,
 void common_hal_pulseio_pulsein_clear(pulseio_pulsein_obj_t *self) {
     self->start = 0;
     self->len = 0;
-    buf_index = 0;
+    self->buf_index = 0;
 }
 
 uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t *self) {
@@ -202,8 +207,8 @@ uint16_t common_hal_pulseio_pulsein_popleft(pulseio_pulsein_obj_t *self) {
     // if we are empty reset buffer pointer and counters
     if (self->len == 0) {
         self->start = 0;
-        buf_index = 0;
-        level_count = 0;
+        self->buf_index = 0;
+        self->level_count = 0;
     }
     return value;
 }

--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.h
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.h
@@ -36,14 +36,14 @@
 typedef struct {
     mp_obj_base_t base;
     uint8_t pin;
-    uint16_t *buffer;
-    uint16_t maxlen;
     bool idle_state;
-    bool last_level;
-    uint32_t level_count;
-    volatile uint16_t buf_index;
-    volatile uint16_t start;
+    uint16_t maxlen;
+    uint16_t *buffer;
+    volatile bool last_level;
+    volatile uint32_t level_count;
     volatile uint16_t len;
+    volatile uint16_t start;
+    volatile uint16_t buf_index;
     rp2pio_statemachine_obj_t state_machine;
 } pulseio_pulsein_obj_t;
 

--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.h
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.h
@@ -39,6 +39,9 @@ typedef struct {
     uint16_t *buffer;
     uint16_t maxlen;
     bool idle_state;
+    bool last_level;
+    uint32_t level_count;
+    volatile uint16_t buf_index;
     volatile uint16_t start;
     volatile uint16_t len;
     rp2pio_statemachine_obj_t state_machine;


### PR DESCRIPTION
There were issues with conflicting values in global variables when more than one PulseIn object was active at the same time.  Those variables were moved to the pulseio pulsein object to keep them separate. This also corrects the problem noted in issue #4945 where the script would hang if more than 4 pulseins were active at once. The limit is now enforced at 8 (2 PIOs with 4 State Machines each). Note that if some other module is already using state machine(s) the limit will be less than 8. 