### PR TITLE
fix stubs upload conditionals

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,8 +133,8 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
         # setup.py sdist was run by 'make stubs'
-        if [ -z "$TWINE_USERNAME" ] || echo "Uploading dev release to PyPi"
-        if [ -z "$TWINE_USERNAME" ] || twine upload circuitpython-stubs/dist/*
+        [ -z "$TWINE_USERNAME" ] || echo "Uploading dev release to PyPi"
+        [ -z "$TWINE_USERNAME" ] || twine upload circuitpython-stubs/dist/*
 
   mpy-cross-mac:
     runs-on: macos-10.15


### PR DESCRIPTION
Remove `if` from a couple of conditional lines: there is no following `then`.

This should fix the stub upload failures when a PR is merged, which cause the whole composite job to fail.