### PR TITLE
Moved global variables to support multiple RP2040 PulseOuts

### DIFF
--- a/ports/raspberrypi/common-hal/pulseio/PulseOut.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseOut.c
@@ -39,7 +39,7 @@
 #include "src/common/pico_time/include/pico/time.h"
 
 static uint8_t refcount = 0;
-volatile  alarm_id_t cur_alarm = 0;
+volatile alarm_id_t cur_alarm = 0;
 
 void turn_off(uint8_t slice) {
     pwm_hw->slice[slice].ctr = 0;

--- a/ports/raspberrypi/common-hal/pulseio/PulseOut.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseOut.c
@@ -39,13 +39,7 @@
 #include "src/common/pico_time/include/pico/time.h"
 
 static uint8_t refcount = 0;
-static uint16_t *pulse_buffer = NULL;
-static volatile uint16_t pulse_index = 0;
-static uint16_t pulse_length;
-pwmio_pwmout_obj_t *pwmout_obj;
-volatile uint16_t current_duty_cycle;
-static uint32_t min_pulse = 0;
-static alarm_id_t cur_alarm;
+volatile  alarm_id_t cur_alarm = 0;
 
 void turn_off(uint8_t slice) {
     pwm_hw->slice[slice].ctr = 0;
@@ -56,24 +50,24 @@ void turn_off(uint8_t slice) {
     pwm_hw->slice[slice].csr = 0;
 }
 
-void pulse_finish(pwmio_pwmout_obj_t *carrier) {
-    pulse_index++;
+void pulse_finish(pulseio_pulseout_obj_t *self) {
+    self->pulse_index++;
     // Turn pwm pin off by setting duty cyle to 1.
-    common_hal_pwmio_pwmout_set_duty_cycle(carrier,1);
-    if (pulse_index >= pulse_length) {
+    common_hal_pwmio_pwmout_set_duty_cycle(self->carrier,1);
+    if (self->pulse_index >= self->pulse_length) {
         return;
     }
-    if (pulse_index % 2 == 0) {
-        common_hal_pwmio_pwmout_set_duty_cycle(carrier,current_duty_cycle);
+    if (self->pulse_index % 2 == 0) {
+        common_hal_pwmio_pwmout_set_duty_cycle(self->carrier,self->current_duty_cycle);
     }
-    uint64_t delay = pulse_buffer[pulse_index];
-    if (delay < min_pulse) {
-        delay = min_pulse;
+    uint64_t delay = self->pulse_buffer[self->pulse_index];
+    if (delay < self->min_pulse) {
+        delay = self->min_pulse;
     }
     cur_alarm = 0;
     // if the alarm cannot be set, try again with a longer delay
     while (cur_alarm == 0) {
-        cur_alarm = add_alarm_in_us(delay, pulseout_interrupt_handler, carrier, false);
+        cur_alarm = add_alarm_in_us(delay, pulseout_interrupt_handler, self, false);
         delay = delay + 1;
     }
 }
@@ -94,15 +88,14 @@ void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t *self,
     uint16_t duty_cycle) {
 
     refcount++;
-    pwmout_obj = (pwmio_pwmout_obj_t *)carrier;
-    current_duty_cycle = common_hal_pwmio_pwmout_get_duty_cycle(pwmout_obj);
-    pwm_set_enabled(carrier->slice,false);
-    turn_off(carrier->slice);
-    common_hal_pwmio_pwmout_set_duty_cycle(pwmout_obj,1);
-    self->pin = carrier->pin->number;
-    self->slice = carrier->slice;
-    self->carrier = pwmout_obj;
-    min_pulse = (1000000 / carrier->actual_frequency);
+    self->carrier = (pwmio_pwmout_obj_t *)carrier;
+    self->current_duty_cycle = common_hal_pwmio_pwmout_get_duty_cycle(self->carrier);
+    pwm_set_enabled(self->carrier->slice,false);
+    turn_off(self->carrier->slice);
+    common_hal_pwmio_pwmout_set_duty_cycle(self->carrier,1);
+    self->pin = self->carrier->pin->number;
+    self->slice = self->carrier->slice;
+    self->min_pulse = (1000000 / self->carrier->actual_frequency);
 }
 
 bool common_hal_pulseio_pulseout_deinited(pulseio_pulseout_obj_t *self) {
@@ -118,25 +111,24 @@ void common_hal_pulseio_pulseout_deinit(pulseio_pulseout_obj_t *self) {
 }
 
 void common_hal_pulseio_pulseout_send(pulseio_pulseout_obj_t *self, uint16_t *pulses, uint16_t length) {
-    pulse_buffer = pulses;
-    pulse_index = 0;
-    pulse_length = length;
+    self->pulse_buffer = pulses;
+    self->pulse_index = 0;
+    self->pulse_length = length;
 
-    common_hal_pwmio_pwmout_set_duty_cycle(self->carrier,current_duty_cycle);
+    common_hal_pwmio_pwmout_set_duty_cycle(self->carrier,self->current_duty_cycle);
     pwm_set_enabled(self->slice,true);
-    uint64_t delay = pulse_buffer[0];
-    if (delay < min_pulse) {
-        delay = min_pulse;
+    uint64_t delay = self->pulse_buffer[0];
+    if (delay < self->min_pulse) {
+        delay = self->min_pulse;
     }
-    alarm_id_t init_alarm = 0;
+    cur_alarm = 0;
     // if the alarm cannot be set, try again with a longer delay
-    while (init_alarm == 0) {
-        init_alarm = add_alarm_in_us(delay, pulseout_interrupt_handler, self->carrier, false);
+    while (cur_alarm == 0) {
+        cur_alarm = add_alarm_in_us(delay, pulseout_interrupt_handler, self, false);
         delay = delay + 1;
     }
-    cur_alarm = init_alarm;
 
-    while (pulse_index < length) {
+    while (self->pulse_index < length) {
         // Do other things while we wait. The interrupts will handle sending the
         // signal.
         RUN_BACKGROUND_TASKS;

--- a/ports/raspberrypi/common-hal/pulseio/PulseOut.h
+++ b/ports/raspberrypi/common-hal/pulseio/PulseOut.h
@@ -40,6 +40,11 @@ typedef struct {
     uint8_t pin;
     uint8_t slice;
     pwmio_pwmout_obj_t *carrier;
+    uint16_t *pulse_buffer;
+    uint16_t pulse_length;
+    uint16_t current_duty_cycle;
+    uint32_t min_pulse;
+    volatile uint16_t pulse_index;
 } pulseio_pulseout_obj_t;
 
 void pulseout_reset(void);


### PR DESCRIPTION
Not sure how much of a use case there is for this; but moved global variables to the pulseio_pulseout object to support multiple pulseout sessions. It's cleaner code in any event. Verified that pulseout now works with two IR transmitters.