### PR TITLE
Fix Arduino RP2040 flash size

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -260,6 +260,12 @@ $(BUILD)/stage2.c: stage2.c.jinja gen_stage2.py | $(BUILD)/
 	$(STEPECHO) "GEN $<"
 	$(Q)$(PYTHON3) gen_stage2.py $< $@ $(EXTERNAL_FLASH_DEVICES)
 
+$(HEADER_BUILD)/flash_info.h: flash_info.h.jinja gen_stage2.py | $(HEADER_BUILD)/
+	$(STEPECHO) "GEN $<"
+	$(Q)$(PYTHON3) gen_stage2.py $< $@ $(EXTERNAL_FLASH_DEVICES)
+
+$(BUILD)/supervisor/internal_flash.o: $(HEADER_BUILD)/flash_info.h
+
 $(BUILD)/boot2.elf: $(BUILD)/stage2.c
 	$(STEPECHO) "BOOT $<"
 	$(Q)$(CC) $(CFLAGS) $(BOOT2_S_CFLAGS) -Os -ggdb3 -I. -fPIC --specs=nosys.specs -nostartfiles -Wl,-T,boot_stage2.ld  -Wl,-Map=$@.map -o $@ $<

--- a/ports/raspberrypi/flash_info.h.jinja
+++ b/ports/raspberrypi/flash_info.h.jinja
@@ -1,0 +1,5 @@
+// This file is auto-generated using gen_stage2.py
+
+#pragma once
+
+#define FLASH_DEFAULT_POWER_OF_TWO {{ default_power_of_two }}

--- a/ports/raspberrypi/supervisor/internal_flash.c
+++ b/ports/raspberrypi/supervisor/internal_flash.c
@@ -32,6 +32,7 @@
 
 #include "extmod/vfs.h"
 #include "extmod/vfs_fat.h"
+#include "genhdr/flash_info.h"
 #include "py/mphal.h"
 #include "py/obj.h"
 #include "py/runtime.h"
@@ -68,7 +69,7 @@ void supervisor_flash_init(void) {
     uint8_t cmd[] = {0x9f, 0, 0, 0};
     uint8_t data[4];
     flash_do_cmd(cmd, data, 4);
-    uint8_t power_of_two = 21;
+    uint8_t power_of_two = FLASH_DEFAULT_POWER_OF_TWO;
     // Flash must be at least 2MB (1 << 21) because we use the first 1MB for the
     // CircuitPython core. We validate the range because Adesto Tech flash chips
     // don't return the correct value. So, we default to 2MB which will work for


### PR DESCRIPTION
For RP2040 boards, we now change the default flash size based on
the configured flash. We will still try to read the size from the
flash first.

Fixes #4874