### PR TITLE
Remove the max_size parameter from displayio.Group

### DIFF
--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -38,20 +38,18 @@
 //| class Group:
 //|     """Manage a group of sprites and groups and how they are inter-related."""
 //|
-//|     def __init__(self, *, max_size: int = 4, scale: int = 1, x: int = 0, y: int = 0) -> None:
+//|     def __init__(self, *, scale: int = 1, x: int = 0, y: int = 0) -> None:
 //|         """Create a Group of a given size and scale. Scale is in one dimension. For example, scale=2
 //|         leads to a layer's pixel being 2x2 pixels when in the group.
 //|
-//|         :param int max_size: Ignored. Will be removed in 7.x.
 //|         :param int scale: Scale of layer pixels in one dimension.
 //|         :param int x: Initial x position within the parent.
 //|         :param int y: Initial y position within the parent."""
 //|         ...
 //|
 STATIC mp_obj_t displayio_group_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_max_size, ARG_scale, ARG_x, ARG_y };
+    enum { ARG_scale, ARG_x, ARG_y };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_max_size, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 4} },
         { MP_QSTR_scale, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 1} },
         { MP_QSTR_x, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
         { MP_QSTR_y, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },


### PR DESCRIPTION
Remove `max_size` parameter from `displayio.Group`
Closes #4959

**This is potentially a breaking change as the constructor signature is changing.**

Status of dependents:

*Frozen modules*
```bash
> grep -r max_size frozen | wc
      0       0       0
```
All frozen modules that use `max_size` have been updated

*Adafruit_CircuitPython_Bundle libraries* - after the next release
```bash
>> Adafruit_CircuitPython_Bundle  main
> .update-submodules.sh
> grep -r max_size * | grep -v adafruit_fram
libraries/drivers/displayio_sh1106/examples/displayio_sh1106_simpletest.py:splash = displayio.Group(max_size=10)
libraries/drivers/displayio_sh1106/README.rst:    splash = displayio.Group(max_size=10)
```
All **code/examples/docs** have been updated, merged and released *except*
* https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_SH1106 - PR merged, no new release yet.

*CircuitPython_Org_Bundle*
All **code/example/docs** have been updated, merged and released.

*CircuitPython_Community_Bundle libraries*
```bash
>> CircuitPython_Community_Bundle  master
> .update-submodules.sh
> grep -r max_size *
libraries/drivers/gc9a01/examples/gc9a01_simpletest.py:splash = displayio.Group(max_size=10)
libraries/drivers/gc9a01/README.rst:    splash = displayio.Group(max_size=10)
libraries/drivers/ili9163/examples/ili9163_simpletest.py:splash = displayio.Group(max_size=10)
libraries/drivers/ili9163/README.rst:    splash = displayio.Group(max_size=10)
libraries/helpers/circuitpython_display_frame/examples/display_frame_pygame_display_simpletest.py:main_group = displayio.Group(max_size=10)
```
All **code/examples/docs** have been updated, merged and released *except*
* https://github.com/tylercrumpton/CircuitPython_GC9A01 - PR merged, no new release yet.
* https://github.com/FoamyGuy/CircuitPython_Display_Frame - PR merged, no new release yet.
* https://github.com/electronut/Electronutlabs_CircuitPython_ILI9163 - PR submitted, **NOT** merged or released yet. *This repo appears to have had no activity in over a year.*

*Learn Guides*
https://github.com/adafruit/Adafruit_Learning_System_Guides/issues/1603
Progressing slowly but steadily.

**Testing**
This has been tested successfully on a PyPortal Pynt with a selection of example code from libraries that previously used `max_size`.
`Adafruit CircuitPython 7.0.0-alpha.5-dirty on 2021-07-22; Adafruit PyPortal with samd51j20`