### PR TITLE
Fix CAN pin assignment on Feather STM32F405 Express board.

### DIFF
--- a/ports/stm/boards/feather_stm32f405_express/pins.c
+++ b/ports/stm/boards/feather_stm32f405_express/pins.c
@@ -50,7 +50,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SDIO_COMMAND), MP_ROM_PTR(&pin_PD02) },
     { MP_ROM_QSTR(MP_QSTR_SDIO_DATA), MP_ROM_PTR(&sdio_data_tuple) },
 
-    { MP_OBJ_NEW_QSTR(MP_QSTR_CAN_RX),  MP_ROM_PTR(&pin_PB09) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_CAN_TX),  MP_ROM_PTR(&pin_PB08) },
+    { MP_ROM_QSTR(MP_QSTR_CAN_RX),  MP_ROM_PTR(&pin_PB08) },
+    { MP_ROM_QSTR(MP_QSTR_CAN_TX),  MP_ROM_PTR(&pin_PB09) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/stm/peripherals/stm32f4/stm32f405xx/periph.c
+++ b/ports/stm/peripherals/stm32f4/stm32f405xx/periph.c
@@ -220,7 +220,7 @@ const mcu_periph_obj_t mcu_sdio_data3_list[1] = {
 // CAN
 CAN_TypeDef *mcu_can_banks[2] = {CAN1, CAN2};
 
-const mcu_periph_obj_t mcu_can_tx_list[6] = {
+const mcu_periph_obj_t mcu_can_rx_list[6] = {
     PERIPH(1, 9, &pin_PA11),
     PERIPH(1, 9, &pin_PB08),
     PERIPH(1, 9, &pin_PD00),
@@ -230,7 +230,7 @@ const mcu_periph_obj_t mcu_can_tx_list[6] = {
     PERIPH(2, 9, &pin_PB05),
 };
 
-const mcu_periph_obj_t mcu_can_rx_list[6] = {
+const mcu_periph_obj_t mcu_can_tx_list[6] = {
     PERIPH(1, 9, &pin_PA12),
     PERIPH(1, 9, &pin_PB09),
     PERIPH(1, 9, &pin_PD01),


### PR DESCRIPTION
I think the pin assignment for the CAN pins in the Feather STM32F405 Express board are swapped.

![image](https://user-images.githubusercontent.com/14631/126887722-493824ae-5f3a-494e-90b8-a308f5f14d39.png)
