### PR TITLE
check vid/pid: find topdir relative to this script

### DIFF
--- a/tools/ci_check_duplicate_usb_vid_pid.py
+++ b/tools/ci_check_duplicate_usb_vid_pid.py
@@ -72,13 +72,7 @@ def configboard_files():
 
     :returns: A ``pathlib.Path.glob()`` generator object
     """
-    working_dir = pathlib.Path().resolve()
-    if not working_dir.name.startswith("circuitpython") and not working_dir.name.startswith(
-        "micropython"
-    ):
-        raise RuntimeError(
-            "Please run USB VID/PID duplicate verification at the " "top-level directory."
-        )
+    working_dir = pathlib.Path(__file__).resolve().parent.parent
     return working_dir.glob("ports/**/boards/**/mpconfigboard.mk")
 
 


### PR DESCRIPTION
@dhalbert noticed that if a fork was called `micropython`, theexisting check could fail during CI because it will be cloned into adirectory also called `micropython`.

Instead of hardcoding a range of strings that are OK as top directories, find the location of the top directory relative to the script.

This will be conflicty after #5069 is merged, but it should be easy to fix.