### PR TITLE
Fix a couple fake sleep bugs on nrf and esp

### DIFF
--- a/lib/utils/pyexec.c
+++ b/lib/utils/pyexec.c
@@ -165,7 +165,12 @@ STATIC int parse_compile_execute(const void *source, mp_parse_input_kind_t input
     }
     if (result != NULL) {
         result->return_code = ret;
+        #if CIRCUITPY_ALARM
+        // Don't set the exception object if we exited for deep sleep.
+        if (ret != 0 && ret != PYEXEC_DEEP_SLEEP) {
+        #else
         if (ret != 0) {
+            #endif
             mp_obj_t return_value = (mp_obj_t)nlr.ret_val;
             result->exception = return_value;
             result->exception_line = -1;

--- a/ports/esp32s2/common-hal/alarm/__init__.c
+++ b/ports/esp32s2/common-hal/alarm/__init__.c
@@ -62,6 +62,11 @@ void alarm_reset(void) {
     esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
 }
 
+// This will be reset to false by full resets when bss is cleared. Otherwise, the
+// reload is due to CircuitPython and the ESP wakeup cause will be stale. This
+// can happen if USB is connected after a deep sleep.
+STATIC bool soft_wakeup = false;
+
 STATIC esp_sleep_wakeup_cause_t _get_wakeup_cause(void) {
     // First check if the modules remember what last woke up
     if (alarm_pin_pinalarm_woke_this_cycle()) {
@@ -75,7 +80,11 @@ STATIC esp_sleep_wakeup_cause_t _get_wakeup_cause(void) {
     }
     // If waking from true deep sleep, modules will have lost their state,
     // so check the deep wakeup cause manually
-    return esp_sleep_get_wakeup_cause();
+    if (!soft_wakeup) {
+        soft_wakeup = true;
+        return esp_sleep_get_wakeup_cause();
+    }
+    return ESP_SLEEP_WAKEUP_UNDEFINED;
 }
 
 bool common_hal_alarm_woken_from_sleep(void) {

--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -952,8 +952,11 @@ bool common_hal_bleio_adapter_is_bonded_to_central(bleio_adapter_obj_t *self) {
 }
 
 void bleio_adapter_gc_collect(bleio_adapter_obj_t *adapter) {
-    gc_collect_root((void **)adapter, sizeof(bleio_adapter_obj_t) / sizeof(size_t));
-    gc_collect_root((void **)bleio_connections, sizeof(bleio_connections) / sizeof(size_t));
+    // We divide by size_t so that we can scan each 32-bit aligned value to see
+    // if it is a pointer. This allows us to change the structs without worrying
+    // about collecting new pointers.
+    gc_collect_root((void **)adapter, sizeof(bleio_adapter_obj_t) / (sizeof(size_t)));
+    gc_collect_root((void **)bleio_connections, sizeof(bleio_connections) / (sizeof(size_t)));
 }
 
 void bleio_adapter_reset(bleio_adapter_obj_t *adapter) {

--- a/ports/nrf/common-hal/alarm/time/TimeAlarm.c
+++ b/ports/nrf/common-hal/alarm/time/TimeAlarm.c
@@ -70,10 +70,6 @@ int64_t alarm_time_timealarm_get_wakeup_timediff_ms(void) {
     return wakeup_time_saved - common_hal_time_monotonic_ms();
 }
 
-void alarm_time_timealarm_clear_wakeup_time(void) {
-    wakeup_time_saved = 0;
-}
-
 void alarm_time_timealarm_reset(void) {
     port_disable_interrupt_after_ticks_ch(1);
     wakeup_time_saved = 0;


### PR DESCRIPTION
On ESP ctrl-c during fake sleep will now stop the sleep. A crash
on real deep sleep is now fixed as well. (Exception string saving
was crashing on reading the deep sleep exception.) Fixes #4010

This also fixes nRF fake sleep after the first time. The internal
variable wasn't being reset early enough. Fixes #4869