### PR TITLE
Add board-specific pico-sdk settings; set xosc multipler for Adafruit boards

### DIFF
--- a/ports/raspberrypi/boards/adafruit_feather_rp2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/adafruit_feather_rp2040/pico-sdk-configboard.h
@@ -1,0 +1,4 @@
+// Put board-specific pico-sdk definitions here. This file must exist.
+
+// Allow extra time for xosc to start.
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64

--- a/ports/raspberrypi/boards/adafruit_itsybitsy_rp2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/adafruit_itsybitsy_rp2040/pico-sdk-configboard.h
@@ -1,0 +1,4 @@
+// Put board-specific pico-sdk definitions here. This file must exist.
+
+// Allow extra time for xosc to start.
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64

--- a/ports/raspberrypi/boards/adafruit_macropad_rp2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/adafruit_macropad_rp2040/pico-sdk-configboard.h
@@ -1,0 +1,4 @@
+// Put board-specific pico-sdk definitions here. This file must exist.
+
+// Allow extra time for xosc to start.
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64

--- a/ports/raspberrypi/boards/adafruit_qt2040_trinkey/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/adafruit_qt2040_trinkey/pico-sdk-configboard.h
@@ -1,0 +1,4 @@
+// Put board-specific pico-sdk definitions here. This file must exist.
+
+// Allow extra time for xosc to start.
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64

--- a/ports/raspberrypi/boards/adafruit_qtpy_rp2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/adafruit_qtpy_rp2040/pico-sdk-configboard.h
@@ -1,0 +1,4 @@
+// Put board-specific pico-sdk definitions here. This file must exist.
+
+// Allow extra time for xosc to start.
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64

--- a/ports/raspberrypi/boards/arduino_nano_rp2040_connect/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/arduino_nano_rp2040_connect/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/boards/cytron_maker_pi_rp2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/cytron_maker_pi_rp2040/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/boards/pimoroni_keybow2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/pimoroni_keybow2040/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/boards/pimoroni_pga2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/pimoroni_pga2040/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/boards/pimoroni_picolipo_16mb/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/pimoroni_picolipo_16mb/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/boards/pimoroni_picolipo_4mb/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/pimoroni_picolipo_4mb/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/boards/pimoroni_picosystem/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/pimoroni_picosystem/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/boards/pimoroni_tiny2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/pimoroni_tiny2040/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/boards/raspberry_pi_pico/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/raspberry_pi_pico/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/boards/sparkfun_micromod_rp2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/sparkfun_micromod_rp2040/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/boards/sparkfun_pro_micro_rp2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/sparkfun_pro_micro_rp2040/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/boards/sparkfun_thing_plus_rp2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/sparkfun_thing_plus_rp2040/pico-sdk-configboard.h
@@ -1,0 +1,1 @@
+// Put board-specific pico-sdk definitions here. This file must exist.

--- a/ports/raspberrypi/sdk_config/pico/config_autogen.h
+++ b/ports/raspberrypi/sdk_config/pico/config_autogen.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "pico-sdk-configboard.h"
+
 // alphabetized
 #define LIB_PICO_BINARY_INFO (0)
 #define LIB_PICO_PRINTF_NONE (0)


### PR DESCRIPTION
The longer xosc delay startup was inadvertently lost when we switched back to the `raspberrypi/pico-sdk` submodule. So `7.0.0-alpha.5` did not have the XOSC fix for Adafruit boards. This is a regression which can cause a few samples of boards not to work.

Add the fix back, by `#include`ing a board-specific file in the `pico-sdk` global config file `ports/raspberrypi/sdk_config/pico/config_autogen.h`.

I would do an alpha.6 very soon to get this out.