### PR TITLE
vectorio: palettes don't color dirty rectangles

### DIFF
--- a/shared-bindings/vectorio/VectorShape.c
+++ b/shared-bindings/vectorio/VectorShape.c
@@ -21,7 +21,7 @@
 
 //| class VectorShape:
 //|     def __init__(self, shape: Union[Polygon, Rectangle, Circle], pixel_shader: Union[displayio.ColorConverter, displayio.Palette], x: int=0, y: int=0) -> None:
-//|         """Binds a vector shape to a location and pixel color
+//|         """Binds a vector shape to a location and pixel shader. The shader can be a displayio.Palette(1); it will be asked to color pixel value 0.
 //|
 //|            :param shape: The shape to draw.
 //|            :param pixel_shader: The pixel shader that produces colors from values

--- a/shared-module/vectorio/VectorShape.c
+++ b/shared-module/vectorio/VectorShape.c
@@ -233,7 +233,7 @@ bool vectorio_vector_shape_fill_area(vectorio_vector_shape_t *self, const _displ
                 }
 
                 // We double-check this to fast-path the case when a pixel is not covered by the shape & not call the color converter unnecessarily.
-                if (output_pixel.opaque) {
+                if (!output_pixel.opaque) {
                     VECTORIO_SHAPE_PIXEL_DEBUG(" (encountered transparent pixel from colorconverter; input area is not fully covered)\n");
                     full_coverage = false;
                 }


### PR DESCRIPTION
This is a breaking change with previous palette semantic with respect to python code that uses vectorio.
Displayio has breaking changes in cpy 7 for Group's removal of max_size parameter so this is as good a
time as any to break everything.

**Currently:**
To color vectorio shapes correctly you have to pass in a palette with length 2. Palette[0] must be set transparent and palette[1] must be the color you want.

**New:**
To color vectorio shapes correctly you pass in a palette with length >= 1. Palette[0] will be the color of the shape.

Also improves pixels per second when skipping areas that aren't covered by the shape.

Related to and motivated by https://github.com/adafruit/circuitpython/issues/5084