### PR TITLE
Fix empty boot_out.txt (#5062)

### DIFF
--- a/main.c
+++ b/main.c
@@ -633,11 +633,13 @@ STATIC void __attribute__ ((noinline)) run_boot_py(safe_mode_t safe_mode) {
 
     static const char * const boot_py_filenames[] = STRING_LIST("boot.py", "boot.txt");
     bool skip_boot_output = false;
+    #ifdef CIRCUITPY_BOOT_OUTPUT_FILE
+    FIL file_pointer;
+    #endif
 
     if (ok_to_run) {
 
         #ifdef CIRCUITPY_BOOT_OUTPUT_FILE
-        FIL file_pointer;
         boot_output_file = &file_pointer;
 
         // Get the base filesystem.


### PR DESCRIPTION
A pointer to the FIL structure was kept after it went out of scope. Apparently this happened to work until cf97793 added the `result` variable that clobbered it.

Tested on ItsyBitsy nRF52840 Express.

Fixes #5062.