### PR TITLE
Unpin sphinx-autoapi as the bug is resolved

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ cpp-coveralls
 Sphinx<4
 sphinx-rtd-theme
 myst-parser
-sphinx-autoapi<=1.8.1
+sphinx-autoapi
 sphinxcontrib-svg2pdfconverter
 readthedocs-sphinx-search
 


### PR DESCRIPTION
I noticed that https://github.com/readthedocs/sphinx-autoapi/issues/299 was marked as resolved.  Let's see if 1.8.3 fixes the problem, as expected.