### PR TITLE
board bdmicro_vina_d51: Add support for MX25L12833F flash chip.

### DIFF
--- a/ports/atmel-samd/boards/bdmicro_vina_d51/mpconfigboard.h
+++ b/ports/atmel-samd/boards/bdmicro_vina_d51/mpconfigboard.h
@@ -1,5 +1,5 @@
 // More than one revision of this board is available.
-// This board specifies PCB Revision 10
+// This board specifies the most up to date PCB Revision
 
 #define MICROPY_HW_BOARD_NAME "BDMICRO VINA-D51"
 #define MICROPY_HW_MCU_NAME "samd51n20"

--- a/ports/atmel-samd/boards/bdmicro_vina_d51/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/bdmicro_vina_d51/mpconfigboard.mk
@@ -1,5 +1,5 @@
 # More than one revision of this board is available.
-# This board specifies PCB Revision 10
+# This board specifies the most up to date PCB Revision
 
 USB_VID = 0x31e2
 USB_PID = 0x2021
@@ -10,5 +10,5 @@ CHIP_VARIANT = SAMD51N20A
 CHIP_FAMILY = samd51
 
 QSPI_FLASH_FILESYSTEM = 1
-EXTERNAL_FLASH_DEVICES = "MX25L51245G","GD25S512MD"
+EXTERNAL_FLASH_DEVICES = "MX25L12833F","MX25L51245G","GD25S512MD"
 LONGINT_IMPL = MPZ

--- a/ports/atmel-samd/boards/bdmicro_vina_d51/pins.c
+++ b/ports/atmel-samd/boards/bdmicro_vina_d51/pins.c
@@ -1,5 +1,5 @@
 // More than one revision of this board is available.
-// This board specifies PCB Revision 10
+// This board specifies the most up to date PCB Revision
 
 #include "shared-bindings/board/__init__.h"
 
@@ -59,6 +59,16 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_PA15) },
     { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_PB12) },
     { MP_ROM_QSTR(MP_QSTR_D14), MP_ROM_PTR(&pin_PB13) },
+    { MP_ROM_QSTR(MP_QSTR_D15), MP_ROM_PTR(&pin_PA21) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_SDO), MP_ROM_PTR(&pin_PA21) },
+    { MP_ROM_QSTR(MP_QSTR_D16), MP_ROM_PTR(&pin_PA22) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_SDI), MP_ROM_PTR(&pin_PA22) },
+    { MP_ROM_QSTR(MP_QSTR_D17), MP_ROM_PTR(&pin_PA20) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_FS_0), MP_ROM_PTR(&pin_PA20) },
+    { MP_ROM_QSTR(MP_QSTR_D18), MP_ROM_PTR(&pin_PB16) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_SCK_0), MP_ROM_PTR(&pin_PB16) },
+    { MP_ROM_QSTR(MP_QSTR_D19), MP_ROM_PTR(&pin_PB17) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_MCK_0), MP_ROM_PTR(&pin_PB17) },
     { MP_ROM_QSTR(MP_QSTR_D2), MP_ROM_PTR(&pin_PC17) },
     { MP_ROM_QSTR(MP_QSTR_D3), MP_ROM_PTR(&pin_PC18) },
     { MP_ROM_QSTR(MP_QSTR_D4), MP_ROM_PTR(&pin_PC19) },
@@ -73,14 +83,10 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_PA12) },
     { MP_ROM_QSTR(MP_QSTR_I2C1_SDA), MP_ROM_PTR(&pin_PA13) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_PA13) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_FS_0), MP_ROM_PTR(&pin_PA20) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_MCK_0), MP_ROM_PTR(&pin_PB17) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_SCK_0), MP_ROM_PTR(&pin_PB16) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_SDI), MP_ROM_PTR(&pin_PA22) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_SDO), MP_ROM_PTR(&pin_PA21) },
     { MP_ROM_QSTR(MP_QSTR_LED_B), MP_ROM_PTR(&pin_PA23) },
     { MP_ROM_QSTR(MP_QSTR_LED_STATUS), MP_ROM_PTR(&pin_PA23) },
     { MP_ROM_QSTR(MP_QSTR_LED_G), MP_ROM_PTR(&pin_PB15) },
+    { MP_ROM_QSTR(MP_QSTR_LED_QSPI), MP_ROM_PTR(&pin_PC07) },
     { MP_ROM_QSTR(MP_QSTR_LED_R), MP_ROM_PTR(&pin_PB14) },
     { MP_ROM_QSTR(MP_QSTR_LED_RX), MP_ROM_PTR(&pin_PC05) },
     { MP_ROM_QSTR(MP_QSTR_LED_TX), MP_ROM_PTR(&pin_PC06) },


### PR DESCRIPTION
Add support for MX25L12833F 16MB QSPI flash chip.
Add QSPI activity indicator LED.
Add D15-D19 as aliases for the I2S peripheral pins.

VINA-D51 originally used a 64MB flash chip, but the SAMD51 only supports 16MB in the QSPI pseudo-memory mapping area. And 16MB is really quite a lot, so let's just go with the Macronix MX25L12833F 16 MB chip and simplify. The MX25L12872F chip is actually used on the board, but it is interchangeable with the '33F and they even have the same JEDEC ids as read by the RDID instruction. The only difference I can see is that the '72F version has Quad I/O mode permanently enabled.

And another LED to the board - it is general purpose, but is intended to be used to indicate activity on the QSPI flash chip filesystem. It could be used for other purposes if desired.

Make it easier to reference the I2S peripheral pins as general purposes GPIO pins by creating D15-D19 alias for those pins. That way, if more I/O is needed and I2S is not used, those pins can be easily referenced using the expected name nomenclature.

No backward compatibility changes are made in this update as the 64MB flash chips are still in the config, and the other pin references are new, so no code existing user code should be affected. Board documentation will be updated to indicate support for the 16 MB of external flash instead of 64 MB. The new board revision will support 16 MB-only, though the 64MB chips are still in the config for anyone with an older revision.