### PR TITLE
Add WeAct manufacturer for STM32F411 blackpill boards

### DIFF
--- a/ports/stm/boards/stm32f411ce_blackpill/mpconfigboard.mk
+++ b/ports/stm/boards/stm32f411ce_blackpill/mpconfigboard.mk
@@ -1,7 +1,7 @@
 USB_VID = 0x239A
 USB_PID = 0x806A
 USB_PRODUCT = "stm32f411ce blackpill"
-USB_MANUFACTURER = "Unknown"
+USB_MANUFACTURER = "WeAct"
 
 # SPI_FLASH_FILESYSTEM = 1
 # EXTERNAL_FLASH_DEVICES = xxxxxx #See supervisor/shared/external_flash/devices.h for options

--- a/ports/stm/boards/stm32f411ce_blackpill_with_flash/mpconfigboard.mk
+++ b/ports/stm/boards/stm32f411ce_blackpill_with_flash/mpconfigboard.mk
@@ -1,7 +1,7 @@
 USB_VID = 0x239A
 USB_PID = 0x006A
 USB_PRODUCT = "stm32f411ce blackpill with flash"
-USB_MANUFACTURER = "Unknown"
+USB_MANUFACTURER = "WeAct"
 
 SPI_FLASH_FILESYSTEM = 1
 #See supervisor/shared/external_flash/devices.h for options


### PR DESCRIPTION
Change the "Unknown" manufacturer to the actual maker of the board.

https://github.com/WeActTC/MiniSTM32F4x1

This should just be a cosmetic change.