### PR TITLE
Compress word offset table

### DIFF
--- a/locale/ID.po
+++ b/locale/ID.po
@@ -42,11 +42,11 @@ msgstr ""
 "Harap ajukan masalah dengan konten drive CIRCUITPY Anda di\n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  File \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  File \"%q\", baris %d"
 
@@ -329,7 +329,7 @@ msgstr "'yield' diluar fungsi"
 msgid "*x must be assignment target"
 msgstr "*x harus menjadi target assignment"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", dalam %q\n"
 
@@ -1207,11 +1207,6 @@ msgstr "Kesalahan input/output"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 
@@ -1524,6 +1519,11 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
 msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
@@ -2097,7 +2097,6 @@ msgid "Size not supported"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2246,7 +2245,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Traceback (bagian terakhir dari panggilan terkini):\n"
 
@@ -2552,7 +2551,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "argumen num/types tidak cocok"
 
@@ -3116,6 +3115,10 @@ msgstr ""
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr ""
@@ -3403,6 +3406,10 @@ msgstr ""
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "format tidak valid"
@@ -3438,6 +3445,10 @@ msgstr ""
 
 #: py/parsenum.c
 msgid "invalid syntax for number"
+msgstr ""
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
 msgstr ""
 
 #: py/objtype.c
@@ -3482,6 +3493,10 @@ msgstr ""
 
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
+msgstr ""
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
 msgstr ""
 
 #: py/emitnative.c
@@ -3634,10 +3649,6 @@ msgstr ""
 
 #: py/vm.c
 msgid "no active exception to reraise"
-msgstr ""
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
 msgstr ""
 
 #: py/compile.c

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -38,11 +38,11 @@ msgstr ""
 "Založte prosím problém s obsahem vaší jednotky CIRCUITPY na adrese\n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  Soubor \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  Soubor \"%q\", řádek %d"
 
@@ -325,7 +325,7 @@ msgstr ""
 msgid "*x must be assignment target"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ""
 
@@ -1190,11 +1190,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 
@@ -1507,6 +1502,11 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
 msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
@@ -2066,7 +2066,6 @@ msgid "Size not supported"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2215,7 +2214,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr ""
 
@@ -2513,7 +2512,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr ""
 
@@ -3077,6 +3076,10 @@ msgstr ""
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr ""
@@ -3364,6 +3367,10 @@ msgstr ""
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr ""
@@ -3399,6 +3406,10 @@ msgstr ""
 
 #: py/parsenum.c
 msgid "invalid syntax for number"
+msgstr ""
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
 msgstr ""
 
 #: py/objtype.c
@@ -3443,6 +3454,10 @@ msgstr ""
 
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
+msgstr ""
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
 msgstr ""
 
 #: py/emitnative.c
@@ -3595,10 +3610,6 @@ msgstr ""
 
 #: py/vm.c
 msgid "no active exception to reraise"
-msgstr ""
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
 msgstr ""
 
 #: py/compile.c

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -41,11 +41,11 @@ msgstr ""
 "Bitte melden Sie ein Problem mit dem Inhalt Ihres CIRCUITPY-Laufwerks unter\n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  Datei \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  Datei \"%q\", Zeile %d"
 
@@ -331,7 +331,7 @@ msgstr "'yield' außerhalb einer Funktion"
 msgid "*x must be assignment target"
 msgstr "*x muss Zuordnungsziel sein"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", in %q\n"
 
@@ -1207,11 +1207,6 @@ msgstr "Eingabe-/Ausgabefehler"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 
@@ -1526,6 +1521,11 @@ msgstr "Fehlender first_out_pin. Instruktion %d schreibt Pin(s)"
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
 msgstr "Fehlender first_set_pin. Instruktion %d setzt Pin(s)"
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
+msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
 msgid "Must be a %q subclass."
@@ -2095,7 +2095,6 @@ msgid "Size not supported"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2247,7 +2246,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Zurückverfolgung (jüngste Aufforderung zuletzt):\n"
 
@@ -2558,7 +2557,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "Anzahl/Typen der Argumente passen nicht"
 
@@ -3134,6 +3133,10 @@ msgstr "f-string: einzelne '}' nicht erlaubt"
 msgid "file must be a file opened in byte mode"
 msgstr "Die Datei muss eine im Byte-Modus geöffnete Datei sein"
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "Das Dateisystem muss eine Mount-Methode bereitstellen"
@@ -3423,6 +3426,10 @@ msgstr ""
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "ungültiges Format"
@@ -3459,6 +3466,10 @@ msgstr "ungültige Syntax für integer mit Basis %d"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "ungültige Syntax für number"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3507,6 +3518,10 @@ msgstr "Der Pegel muss zwischen 0 und 1 liegen"
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "lhs und rhs sollten kompatibel sein"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr ""
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3661,10 +3676,6 @@ msgstr ""
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr "Keine aktive Ausnahme zu verusachen (raise)"
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
-msgstr "kein verfügbares Netzwerkadapter (NIC)"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4498,6 +4509,9 @@ msgstr ""
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
+
+#~ msgid "no available NIC"
+#~ msgstr "kein verfügbares Netzwerkadapter (NIC)"
 
 #~ msgid "Instruction %d jumps on pin"
 #~ msgstr "Instruktion %d springt auf Pin"

--- a/locale/el.po
+++ b/locale/el.po
@@ -35,11 +35,11 @@ msgid ""
 "https://github.com/adafruit/circuitpython/issues\n"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "*x must be assignment target"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ""
 
@@ -1187,11 +1187,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 
@@ -1504,6 +1499,11 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
 msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
@@ -2063,7 +2063,6 @@ msgid "Size not supported"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2212,7 +2211,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr ""
 
@@ -2510,7 +2509,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr ""
 
@@ -3074,6 +3073,10 @@ msgstr ""
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr ""
@@ -3361,6 +3364,10 @@ msgstr ""
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr ""
@@ -3396,6 +3403,10 @@ msgstr ""
 
 #: py/parsenum.c
 msgid "invalid syntax for number"
+msgstr ""
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
 msgstr ""
 
 #: py/objtype.c
@@ -3440,6 +3451,10 @@ msgstr ""
 
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
+msgstr ""
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
 msgstr ""
 
 #: py/emitnative.c
@@ -3592,10 +3607,6 @@ msgstr ""
 
 #: py/vm.c
 msgid "no active exception to reraise"
-msgstr ""
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
 msgstr ""
 
 #: py/compile.c

--- a/locale/en_GB.po
+++ b/locale/en_GB.po
@@ -43,11 +43,11 @@ msgstr ""
 "Please file an issue with the contents of your CIRCUITPY drive at \n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  File \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  File \"%q\", line %d"
 
@@ -331,7 +331,7 @@ msgstr "'yield' outside function"
 msgid "*x must be assignment target"
 msgstr "*x must be assignment target"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", in %q\n"
 
@@ -1202,11 +1202,6 @@ msgstr "Input/output error"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr "Instruction %d shifts in more bits than pin count"
 
@@ -1520,6 +1515,11 @@ msgstr "Missing first_out_pin. Instruction %d writes pin(s)"
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
 msgstr "Missing first_set_pin. Instruction %d sets pin(s)"
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
+msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
 msgid "Must be a %q subclass."
@@ -2087,7 +2087,6 @@ msgid "Size not supported"
 msgstr "Size not supported"
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2236,7 +2235,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Traceback (most recent call last):\n"
 
@@ -2541,7 +2540,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "argument num/types mismatch"
 
@@ -3108,6 +3107,10 @@ msgstr "f-string: single '}' is not allowed"
 msgid "file must be a file opened in byte mode"
 msgstr "file must be a file opened in byte mode"
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "filesystem must provide mount method"
@@ -3395,6 +3398,10 @@ msgstr "invalid element size %d for bits_per_pixel %d\n"
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr "invalid element_size %d, must be, 1, 2, or 4"
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "invalid format"
@@ -3432,6 +3439,10 @@ msgstr "invalid syntax for integer with base %d"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "invalid syntax for number"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3476,6 +3487,10 @@ msgstr "level must be between 0 and 1"
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "lhs and rhs should be compatible"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr ""
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3628,10 +3643,6 @@ msgstr "no SD card"
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr "no active exception to reraise"
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
-msgstr "no available NIC"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4456,6 +4467,9 @@ msgstr "zi must be of float type"
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi must be of shape (n_section, 2)"
+
+#~ msgid "no available NIC"
+#~ msgstr "no available NIC"
 
 #~ msgid ""
 #~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "

--- a/locale/es.po
+++ b/locale/es.po
@@ -44,11 +44,11 @@ msgstr ""
 "Presente un problema con el contenido de su unidad CIRCUITPY en\n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  Archivo \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  Archivo \"%q\", línea %d"
 
@@ -333,7 +333,7 @@ msgstr "'yield' fuera de una función"
 msgid "*x must be assignment target"
 msgstr "*x debe ser objetivo de la tarea"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", en %q\n"
 
@@ -1220,11 +1220,6 @@ msgstr "error Input/output"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr "La instruccion %d mueve mas bits que la cuenta del pin"
 
@@ -1542,6 +1537,11 @@ msgstr "first_in_pin no encontrado. La instrucción %d escribe pin(es)"
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
 msgstr ""
 "first_set_pin no encontrado. La instrucción %d configura el/los pin(es)"
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
+msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
 msgid "Must be a %q subclass."
@@ -2115,7 +2115,6 @@ msgid "Size not supported"
 msgstr "Sin capacidades para el tamaño"
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr "Memoria de sueño no disponible"
 
@@ -2274,7 +2273,7 @@ msgstr "La cantidad total de datos es mas grande que %q"
 msgid "Touch alarms not available"
 msgstr "Alarmas táctiles no disponibles"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Traceback (ultima llamada reciente):\n"
 
@@ -2585,7 +2584,7 @@ msgid "argument name reused"
 msgstr "nombre de argumento reutilizado"
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "argumento número/tipos no coinciden"
 
@@ -3156,6 +3155,10 @@ msgstr "cadena-f: solo '}' no está permitido"
 msgid "file must be a file opened in byte mode"
 msgstr "el archivo deberia ser una archivo abierto en modo byte"
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "sistema de archivos debe proporcionar método de montaje"
@@ -3443,6 +3446,10 @@ msgstr "el tamaño del elemento no es valido%d por bits_per_pixel %d\n"
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr "el element_size %d,no es valido, debe ser 1,2 ó 4"
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "formato inválido"
@@ -3479,6 +3486,10 @@ msgstr "sintaxis inválida para entero con base %d"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "sintaxis inválida para número"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3526,6 +3537,10 @@ msgstr "el nivel debe ser entre 0 y 1"
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "lhs y rhs deben ser compatibles"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr ""
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3679,10 +3694,6 @@ msgstr "no hay tarjeta SD"
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr "exception no activa para reraise"
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
-msgstr "NIC no disponible"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4511,6 +4522,9 @@ msgstr "zi debe ser de tipo flotante"
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi debe ser una forma (n_section,2)"
+
+#~ msgid "no available NIC"
+#~ msgstr "NIC no disponible"
 
 #~ msgid ""
 #~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -34,11 +34,11 @@ msgid ""
 "https://github.com/adafruit/circuitpython/issues\n"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  File \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  File \"%q\", line %d"
 
@@ -324,7 +324,7 @@ msgstr "'yield' sa labas ng function"
 msgid "*x must be assignment target"
 msgstr "*x ay dapat na assignment target"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", sa %q\n"
 
@@ -1202,11 +1202,6 @@ msgstr "May mali sa Input/Output"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 
@@ -1519,6 +1514,11 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
 msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
@@ -2083,7 +2083,6 @@ msgid "Size not supported"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2232,7 +2231,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Traceback (pinakahuling huling tawag): \n"
 
@@ -2538,7 +2537,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "hindi tugma ang argument num/types"
 
@@ -3114,6 +3113,10 @@ msgstr ""
 msgid "file must be a file opened in byte mode"
 msgstr "file ay dapat buksan sa byte mode"
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "ang filesystem dapat mag bigay ng mount method"
@@ -3402,6 +3405,10 @@ msgstr ""
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "hindi wastong pag-format"
@@ -3438,6 +3445,10 @@ msgstr "maling sintaks sa integer na may base %d"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "maling sintaks sa number"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3486,6 +3497,10 @@ msgstr ""
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "lhs at rhs ay dapat magkasundo"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr ""
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3638,10 +3653,6 @@ msgstr ""
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr "walang aktibong exception para i-reraise"
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
-msgstr "walang magagamit na NIC"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4472,6 +4483,9 @@ msgstr ""
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
+
+#~ msgid "no available NIC"
+#~ msgstr "walang magagamit na NIC"
 
 #~ msgid "USB Busy"
 #~ msgstr "Busy ang USB"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -44,11 +44,11 @@ msgstr ""
 "l'adresse\n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  Fichier \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  Fichier \"%q\", ligne %d"
 
@@ -333,7 +333,7 @@ msgstr "'yield' dehors d'une fonction"
 msgid "*x must be assignment target"
 msgstr "*x doit être la cible de l'assignement"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", dans %q\n"
 
@@ -1226,11 +1226,6 @@ msgstr "Erreur d'entrée/sortie"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 "Instruction %d décale vers l'intérieur de plus de bits que le nombre de "
@@ -1550,6 +1545,11 @@ msgstr "first_out_pin manquant. Instruction %d écrit un/des broche(s)"
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
 msgstr "first_set_pin manquant. L'instruction %d règle la/les broche(s)"
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
+msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
 msgid "Must be a %q subclass."
@@ -2124,7 +2124,6 @@ msgid "Size not supported"
 msgstr "Taille n'est pas supportée"
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2274,7 +2273,7 @@ msgstr "Quantité de données à écrire est plus que %q"
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Traceback (appels les plus récents en dernier) :\n"
 
@@ -2587,7 +2586,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "Nombre/types de paramètres ne correspondent pas"
 
@@ -3164,6 +3163,10 @@ msgstr "f-string : single '}' n'est pas autorisé"
 msgid "file must be a file opened in byte mode"
 msgstr "le fichier doit être un fichier ouvert en mode 'byte'"
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "le system de fichier doit fournir une méthode 'mount'"
@@ -3452,6 +3455,10 @@ msgstr "taille d'élément %d est invalide pour bits_per_pixel %d\n"
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr "element_size %d est invalide, doit être 1, 2 ou 4"
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "format invalide"
@@ -3488,6 +3495,10 @@ msgstr "syntaxe invalide pour un entier de base %d"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "syntaxe invalide pour un nombre"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3536,6 +3547,10 @@ msgstr "le niveau doit être compris entre 0 et 1"
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "Les parties gauches et droites doivent être compatibles"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr ""
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3688,10 +3703,6 @@ msgstr "pas de carte SD"
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr "aucune exception active à relever"
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
-msgstr "adapteur réseau non disponible"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4522,6 +4533,9 @@ msgstr "zi doit être de type float"
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi doit être de forme (n_section, 2)"
+
+#~ msgid "no available NIC"
+#~ msgstr "adapteur réseau non disponible"
 
 #~ msgid ""
 #~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "

--- a/locale/hi.po
+++ b/locale/hi.po
@@ -35,11 +35,11 @@ msgid ""
 "https://github.com/adafruit/circuitpython/issues\n"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "*x must be assignment target"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ""
 
@@ -1187,11 +1187,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 
@@ -1504,6 +1499,11 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
 msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
@@ -2063,7 +2063,6 @@ msgid "Size not supported"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2212,7 +2211,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr ""
 
@@ -2510,7 +2509,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr ""
 
@@ -3074,6 +3073,10 @@ msgstr ""
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr ""
@@ -3361,6 +3364,10 @@ msgstr ""
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr ""
@@ -3396,6 +3403,10 @@ msgstr ""
 
 #: py/parsenum.c
 msgid "invalid syntax for number"
+msgstr ""
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
 msgstr ""
 
 #: py/objtype.c
@@ -3440,6 +3451,10 @@ msgstr ""
 
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
+msgstr ""
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
 msgstr ""
 
 #: py/emitnative.c
@@ -3592,10 +3607,6 @@ msgstr ""
 
 #: py/vm.c
 msgid "no active exception to reraise"
-msgstr ""
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
 msgstr ""
 
 #: py/compile.c

--- a/locale/it_IT.po
+++ b/locale/it_IT.po
@@ -43,11 +43,11 @@ msgstr ""
 "Per favore, segnala il problema con il contenuto del tuo CIRCUITPY a\n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  File \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  File \"%q\", riga %d"
 
@@ -333,7 +333,7 @@ msgstr "'yield' al di fuori della funzione"
 msgid "*x must be assignment target"
 msgstr "*x deve essere il bersaglio del assegnamento"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", in %q\n"
 
@@ -1211,11 +1211,6 @@ msgstr "Errore input/output"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 
@@ -1532,6 +1527,11 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
 msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
@@ -2104,7 +2104,6 @@ msgid "Size not supported"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2253,7 +2252,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Traceback (chiamata più recente per ultima):\n"
 
@@ -2553,7 +2552,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "discrepanza di numero/tipo di argomenti"
 
@@ -3127,6 +3126,10 @@ msgstr ""
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "il filesystem deve fornire un metodo di mount"
@@ -3415,6 +3418,10 @@ msgstr ""
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "formato non valido"
@@ -3451,6 +3458,10 @@ msgstr "sintassi invalida per l'intero con base %d"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "sintassi invalida per il numero"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3500,6 +3511,10 @@ msgstr ""
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "lhs e rhs devono essere compatibili"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr ""
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3652,11 +3667,6 @@ msgstr ""
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr "nessuna eccezione attiva da rilanciare"
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-#, fuzzy
-msgid "no available NIC"
-msgstr "busio.UART non ancora implementato"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4491,6 +4501,10 @@ msgstr ""
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
+
+#, fuzzy
+#~ msgid "no available NIC"
+#~ msgstr "busio.UART non ancora implementato"
 
 #~ msgid "Buffer too large and unable to allocate"
 #~ msgstr "Buffer troppo grande ed impossibile allocare"

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -40,11 +40,11 @@ msgstr ""
 "CIRCUITPYドライブの内容を添えて問題を以下で報告してください：\n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  ファイル \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  ファイル \"%q\", 行 %d"
 
@@ -327,7 +327,7 @@ msgstr "関数外でのyield"
 msgid "*x must be assignment target"
 msgstr "*xは代入先でなければなりません"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ""
 
@@ -1198,11 +1198,6 @@ msgstr "入力/出力エラー"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 
@@ -1515,6 +1510,11 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
 msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
@@ -2077,7 +2077,6 @@ msgid "Size not supported"
 msgstr "サイズは対応していません"
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2226,7 +2225,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "トレースバック（最新の呼び出しが末尾）:\n"
 
@@ -2525,7 +2524,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr ""
 
@@ -3093,6 +3092,10 @@ msgstr "f-string: 1つだけの'}'は許されません"
 msgid "file must be a file opened in byte mode"
 msgstr "fileはバイトモードで開かれたファイルでなければなりません"
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "filesystemはmountメソッドを提供しなければなりません"
@@ -3381,6 +3384,10 @@ msgstr ""
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr ""
@@ -3417,6 +3424,10 @@ msgstr ""
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "数字として不正な構文"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3461,6 +3472,10 @@ msgstr "levelは0から1の間でなければなりません"
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "左辺と右辺が互換でなければなりません"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr ""
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3613,10 +3628,6 @@ msgstr "SDカードがありません"
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr ""
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
-msgstr "利用可能なNICがありません"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4442,6 +4453,9 @@ msgstr "ziはfloat値でなければなりません"
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
+
+#~ msgid "no available NIC"
+#~ msgstr "利用可能なNICがありません"
 
 #~ msgid "Buffer too large and unable to allocate"
 #~ msgstr "バッファが大きすぎて確保できません"

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -36,11 +36,11 @@ msgid ""
 "https://github.com/adafruit/circuitpython/issues\n"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr " 파일 \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  파일 \"%q\", 라인 %d"
 
@@ -323,7 +323,7 @@ msgstr "'yield' 는 함수 외부에 존재합니다"
 msgid "*x must be assignment target"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", 에서 %q\n"
 
@@ -1190,11 +1190,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 
@@ -1507,6 +1502,11 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
 msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
@@ -2066,7 +2066,6 @@ msgid "Size not supported"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2215,7 +2214,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr ""
 
@@ -2514,7 +2513,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr ""
 
@@ -3078,6 +3077,10 @@ msgstr ""
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr ""
@@ -3365,6 +3368,10 @@ msgstr ""
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "형식가 유효하지 않습니다"
@@ -3401,6 +3408,10 @@ msgstr "구문(syntax)가 정수가 유효하지 않습니다"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "숫자에 대한 구문(syntax)가 유효하지 않습니다"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3444,6 +3455,10 @@ msgstr ""
 
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
+msgstr ""
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
 msgstr ""
 
 #: py/emitnative.c
@@ -3596,10 +3611,6 @@ msgstr ""
 
 #: py/vm.c
 msgid "no active exception to reraise"
-msgstr ""
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
 msgstr ""
 
 #: py/compile.c

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -38,11 +38,11 @@ msgstr ""
 "Meld een probleem met de inhoud van de CIRCUITPY drive op:\n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  Bestand"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  Bestand \"%q\", regel %d"
 
@@ -325,7 +325,7 @@ msgstr "'yield' buiten de functie"
 msgid "*x must be assignment target"
 msgstr "*x moet een assignment target zijn"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", in %q\n"
 
@@ -1199,11 +1199,6 @@ msgstr "Input/Output fout"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 
@@ -1516,6 +1511,11 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
 msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
@@ -2089,7 +2089,6 @@ msgid "Size not supported"
 msgstr "Afmeting niet ondersteund"
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2238,7 +2237,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Traceback (meest recente call laatst):\n"
 
@@ -2547,7 +2546,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "argument num/typen komen niet overeen"
 
@@ -3115,6 +3114,10 @@ msgstr "f-string: enkele '}' is niet toegestaan"
 msgid "file must be a file opened in byte mode"
 msgstr "bestand moet een bestand zijn geopend in byte modus"
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "bestandssysteem moet een mount methode bieden"
@@ -3403,6 +3406,10 @@ msgstr ""
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "ongeldig formaat"
@@ -3439,6 +3446,10 @@ msgstr "ongeldige syntax voor integer met grondtal %d"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "ongeldige syntax voor nummer"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3486,6 +3497,10 @@ msgstr "level moet tussen 0 en 1 liggen"
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "lhs en rhs moeten compatibel zijn"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr ""
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3638,10 +3653,6 @@ msgstr "geen SD kaart"
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr "geen actieve uitzondering om opnieuw op te werpen (raise)"
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
-msgstr "geen netwerkadapter (NIC) beschikbaar"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4467,6 +4478,9 @@ msgstr "zi moet van type float zijn"
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi moet vorm (n_section, 2) hebben"
+
+#~ msgid "no available NIC"
+#~ msgstr "geen netwerkadapter (NIC) beschikbaar"
 
 #~ msgid ""
 #~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -40,11 +40,11 @@ msgstr ""
 "Zgłoś problem z zawartością dysku CIRCUITPY pod adresem\n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  Plik \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  Plik \"%q\", linia %d"
 
@@ -327,7 +327,7 @@ msgstr "'yield' poza funkcją"
 msgid "*x must be assignment target"
 msgstr "*x musi być obiektem przypisania"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", w %q\n"
 
@@ -1198,11 +1198,6 @@ msgstr "Błąd I/O"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr ""
 
@@ -1515,6 +1510,11 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
 msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
@@ -2074,7 +2074,6 @@ msgid "Size not supported"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr ""
 
@@ -2223,7 +2222,7 @@ msgstr ""
 msgid "Touch alarms not available"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Ślad wyjątku (najnowsze wywołanie na końcu):\n"
 
@@ -2527,7 +2526,7 @@ msgid "argument name reused"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "zła liczba lub typ argumentów"
 
@@ -3092,6 +3091,10 @@ msgstr ""
 msgid "file must be a file opened in byte mode"
 msgstr "file musi być otwarte w trybie bajtowym"
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "system plików musi mieć metodę mount"
@@ -3379,6 +3382,10 @@ msgstr ""
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr ""
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "zły format"
@@ -3415,6 +3422,10 @@ msgstr "zła składnia dla liczby całkowitej w bazie %d"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "zła składnia dla liczby"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3459,6 +3470,10 @@ msgstr ""
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "lewa i prawa strona powinny być kompatybilne"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr ""
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3611,10 +3626,6 @@ msgstr ""
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr "brak wyjątku do ponownego rzucenia"
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
-msgstr "brak wolnego NIC"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4439,6 +4450,9 @@ msgstr ""
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
+
+#~ msgid "no available NIC"
+#~ msgstr "brak wolnego NIC"
 
 #~ msgid "Buffer too large and unable to allocate"
 #~ msgstr "Bufor jest zbyt duży i nie można go przydzielić"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -42,11 +42,11 @@ msgstr ""
 "Registre um problema com o conteúdo do seu controlador no CIRCUITPY\n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  Arquivo \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  Arquivo \"%q\", linha %d"
 
@@ -335,7 +335,7 @@ msgstr "função externa 'yield'"
 msgid "*x must be assignment target"
 msgstr "*x deve ser o destino da atribuição"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", em %q\n"
 
@@ -1221,11 +1221,6 @@ msgstr "Erro de entrada/saída"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr "Falta o jmp_pin. A instrução %d salta no pino"
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr "A instrução %d muda com mais bits do que a quantidade dos pinos"
 
@@ -1539,6 +1534,11 @@ msgstr "Faltando first_out_pin. A instrução %d escreve nos pinos(s)"
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
 msgstr "Faltando first_set_pin. A instrução %d define os pinos(s)"
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
+msgstr "Falta o jmp_pin. A instrução %d salta no pino"
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
 msgid "Must be a %q subclass."
@@ -2117,7 +2117,6 @@ msgid "Size not supported"
 msgstr "O tamanho não é suportado"
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr "Sleep memory não está disponível"
 
@@ -2277,7 +2276,7 @@ msgstr "O total dos dados que serão escritos é maior do que %q"
 msgid "Touch alarms not available"
 msgstr "Alarmes de toque não estão disponíveis"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Traceback (a última chamada mais recente):\n"
 
@@ -2590,7 +2589,7 @@ msgid "argument name reused"
 msgstr "nome do argumento reutilizado"
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "o argumento num/tipos não combinam"
 
@@ -3163,6 +3162,10 @@ msgstr "f-string: um único '}' não é permitido"
 msgid "file must be a file opened in byte mode"
 msgstr "o arquivo deve ser um arquivo aberto no modo byte"
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "sistema de arquivos deve fornecer método de montagem"
@@ -3451,6 +3454,10 @@ msgstr "tamanho do elemento %d é inválido para bits_per_pixel %d\n"
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr "element_size %d é inválido, deve ser, 1, 2, ou 4"
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "formato inválido"
@@ -3487,6 +3494,10 @@ msgstr "sintaxe inválida para o número inteiro com base %d"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "sintaxe inválida para o número"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3534,6 +3545,10 @@ msgstr "o nível deve estar entre 0 e 1"
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "o lhs e rhs devem ser compatíveis"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr ""
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3688,10 +3703,6 @@ msgstr "nenhum cartão SD"
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr "nenhuma exceção ativa para reraise"
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
-msgstr "não há uma Placa de Rede disponível"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4521,6 +4532,9 @@ msgstr "zi deve ser de um tipo float"
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi deve estar na forma (n_section, 2)"
+
+#~ msgid "no available NIC"
+#~ msgstr "não há uma Placa de Rede disponível"
 
 #~ msgid ""
 #~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-01-04 12:55-0600\n"
-"PO-Revision-Date: 2021-07-24 15:35+0000\n"
+"PO-Revision-Date: 2021-08-07 04:00+0000\n"
 "Last-Translator: Jonny Bergdahl <jonny@bergdahl.it>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: sv\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.7.2-dev\n"
+"X-Generator: Weblate 4.8-dev\n"
 
 #: main.c
 msgid ""
@@ -42,11 +42,11 @@ msgstr ""
 "Vänligen skapa ett ärende med innehållet i din CIRCUITPY-enhet på\n"
 "https://github.com/adafruit/circuitpython/issues\n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  Filen \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  Fil \"%q\", rad %d"
 
@@ -330,7 +330,7 @@ msgstr "'yield' utanför funktion"
 msgid "*x must be assignment target"
 msgstr "*x måste vara mål för tilldelning"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", i %q\n"
 
@@ -1206,11 +1206,6 @@ msgstr "Indata-/utdatafel"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr "Saknar jmp_pin. Instruktion %d hoppar på pin"
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr "Instruktion %d skiftar fler bitar än antalet pinnar"
 
@@ -1525,6 +1520,11 @@ msgstr "Saknad first_out_pin. Instruktion %d skriver till pinnar"
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
 msgstr "Saknad first_set_pin. Instruktion %d sätter pinnar"
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
+msgstr "Saknar jmp_pin. Instruktion %d hoppar på pin"
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
 msgid "Must be a %q subclass."
@@ -2095,7 +2095,6 @@ msgid "Size not supported"
 msgstr "Storleken stöds inte"
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr "Sömnminne inte tillgängligt"
 
@@ -2252,7 +2251,7 @@ msgstr "Totala data att skriva är större än %q"
 msgid "Touch alarms not available"
 msgstr "Touchalarm är inte tillgängligt"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Traceback (senaste anrop):\n"
 
@@ -2560,7 +2559,7 @@ msgid "argument name reused"
 msgstr "argumentnamn återanvänt"
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "argument antal/typ matchar inte"
 
@@ -3129,6 +3128,10 @@ msgstr "f-string: singel '}' är inte tillåten"
 msgid "file must be a file opened in byte mode"
 msgstr "filen måste vara en fil som öppnats i byte-läge"
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr "Filskrivning är inte tillgängligt"
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "filsystemet måste tillhandahålla mount-metod"
@@ -3416,6 +3419,10 @@ msgstr "ogiltig elementstorlek %d för bits_per_pixel %d\n"
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr "ogiltig element_size %d, måste vara, 1, 2 eller 4"
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr "Ogiltig exception"
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "ogiltigt format"
@@ -3452,6 +3459,10 @@ msgstr "ogiltig syntax för heltal med bas %d"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "ogiltig syntax för tal"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr "Ogilitig källspårning"
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3499,6 +3510,10 @@ msgstr "level ska ligga mellan 0 och 1"
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "lhs och rhs måste vara kompatibla"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr "limit måste vara en int"
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3651,10 +3666,6 @@ msgstr "inget SD-kort"
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr "ingen aktiv exception för reraise"
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
-msgstr "ingen tillgänglig NIC"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4480,6 +4491,9 @@ msgstr "zi måste vara av typ float"
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi måste vara i formen (n_section, 2)"
+
+#~ msgid "no available NIC"
+#~ msgstr "ingen tillgänglig NIC"
 
 #~ msgid ""
 #~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "

--- a/locale/zh_Latn_pinyin.po
+++ b/locale/zh_Latn_pinyin.po
@@ -43,11 +43,11 @@ msgstr ""
 "Qǐng tōngguò https://github.com/adafruit/circuitpython/issues\n"
 "tíjiāo yǒuguān nín de CIRCUITPY qūdòngqì nèiróng de wèntí \n"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\""
 msgstr "  Wénjiàn \"%q\""
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "  File \"%q\", line %d"
 msgstr "  Wénjiàn \"%q\", dì %d xíng"
 
@@ -332,7 +332,7 @@ msgstr "'yield' wàibù gōngnéng"
 msgid "*x must be assignment target"
 msgstr "*x bìxū shì rènwù mùbiāo"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid ", in %q\n"
 msgstr ", zài %q\n"
 
@@ -1209,11 +1209,6 @@ msgstr "Shūrù/shūchū cuòwù"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
-msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#, c-format
 msgid "Instruction %d shifts in more bits than pin count"
 msgstr "zhǐ lìng %d yí wèi chāo guò yǐn jiǎo jì shù"
 
@@ -1528,6 +1523,11 @@ msgstr "xiān lòu chū yǐn jiǎo. zhǐ lìng %d xiě rù yǐn jiǎo"
 #, c-format
 msgid "Missing first_set_pin. Instruction %d sets pin(s)"
 msgstr "quē shǎo dì yī zǔ yǐn jiǎo. zhǐ lìng %d shè zhì yǐn jiǎo"
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#, c-format
+msgid "Missing jmp_pin. Instruction %d jumps on pin"
+msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
 msgid "Must be a %q subclass."
@@ -2097,7 +2097,6 @@ msgid "Size not supported"
 msgstr "bù zhī chí dà xiǎo"
 
 #: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-#: ports/stm/common-hal/alarm/SleepMemory.c
 msgid "Sleep Memory not available"
 msgstr "shuì mián jì yì bù kě yòng"
 
@@ -2253,7 +2252,7 @@ msgstr "yào biān xiě de zǒng shù jù dà yú %q"
 msgid "Touch alarms not available"
 msgstr "bù kě yòng chù mō bào jǐng qì"
 
-#: py/obj.c
+#: py/obj.c shared-bindings/traceback/__init__.c
 msgid "Traceback (most recent call last):\n"
 msgstr "Traceback (Zuìjìn yīcì dǎ diànhuà):\n"
 
@@ -2562,7 +2561,7 @@ msgid "argument name reused"
 msgstr "chóng fù shǐ yòng de cān shù míng chēng"
 
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr "cānshù biānhào/lèixíng bù pǐpèi"
 
@@ -3132,6 +3131,10 @@ msgstr "f-string: bù yǔnxǔ shǐyòng dāngè '}'"
 msgid "file must be a file opened in byte mode"
 msgstr "wénjiàn bìxū shì zài zì jié móshì xià dǎkāi de wénjiàn"
 
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
+msgstr ""
+
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr "wénjiàn xìtǒng bìxū tígōng guà zài fāngfǎ"
@@ -3419,6 +3422,10 @@ msgstr "wú xiào yuán jiàn dà xiǎo %d wéi bits_per_pixel %d\n"
 msgid "invalid element_size %d, must be, 1, 2, or 4"
 msgstr "wú xiào element_size %d, bì xū shì, 1, 2, huò 4"
 
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
+msgstr ""
+
 #: extmod/modframebuf.c
 msgid "invalid format"
 msgstr "wúxiào géshì"
@@ -3455,6 +3462,10 @@ msgstr "jīshù wèi %d de zhěng shǔ de yǔfǎ wúxiào"
 #: py/parsenum.c
 msgid "invalid syntax for number"
 msgstr "wúxiào de hàomǎ yǔfǎ"
+
+#: py/objexcept.c shared-bindings/traceback/__init__.c
+msgid "invalid traceback"
+msgstr ""
 
 #: py/objtype.c
 msgid "issubclass() arg 1 must be a class"
@@ -3500,6 +3511,10 @@ msgstr "Level bìxū jiè yú 0 hé 1 zhī jiān"
 #: py/objarray.c
 msgid "lhs and rhs should be compatible"
 msgstr "lhs hé rhs yīnggāi jiānróng"
+
+#: shared-bindings/traceback/__init__.c
+msgid "limit should be an int"
+msgstr ""
 
 #: py/emitnative.c
 msgid "local '%q' has type '%q' but source is '%q'"
@@ -3652,10 +3667,6 @@ msgstr "méiyǒu SD kǎ"
 #: py/vm.c
 msgid "no active exception to reraise"
 msgstr "méiyǒu jīhuó de yìcháng lái chóngxīn píngjià"
-
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
-msgstr "méiyǒu kěyòng de NIC"
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
@@ -4480,6 +4491,9 @@ msgstr "zi bìxū wèi fú diǎn xíng"
 #: extmod/ulab/code/scipy/signal/signal.c
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
+
+#~ msgid "no available NIC"
+#~ msgstr "méiyǒu kěyòng de NIC"
 
 #~ msgid ""
 #~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "

--- a/supervisor/shared/translate.c
+++ b/supervisor/shared/translate.c
@@ -43,22 +43,34 @@ void serial_write_compressed(const compressed_string_t *compressed) {
     serial_write(decompressed);
 }
 
+STATIC void get_word(int n, const mchar_t **pos, const mchar_t **end) {
+    int len = minlen;
+    int i = 0;
+    *pos = words;
+    while (wlencount[i] <= n) {
+        n -= wlencount[i];
+        *pos += len * wlencount[i];
+        i++;
+        len++;
+    }
+    *pos += len * n;
+    *end = *pos + len;
+}
+
 STATIC int put_utf8(char *buf, int u) {
     if (u <= 0x7f) {
         *buf = u;
         return 1;
     } else if (word_start <= u && u <= word_end) {
         uint n = (u - word_start);
-        size_t pos = 0;
-        if (n > 0) {
-            pos = wends[n - 1] + (n * 2);
-        }
+        const mchar_t *pos, *end;
+        get_word(n, &pos, &end);
         int ret = 0;
         // note that at present, entries in the words table are
         // guaranteed not to represent words themselves, so this adds
         // at most 1 level of recursive call
-        for (; pos < wends[n] + (n + 1) * 2; pos++) {
-            int len = put_utf8(buf, words[pos]);
+        for (; pos < end; pos++) {
+            int len = put_utf8(buf, *pos);
             buf += len;
             ret += len;
         }

--- a/supervisor/shared/translate.h
+++ b/supervisor/shared/translate.h
@@ -50,11 +50,14 @@
 //   are computed with a heuristic based on frequent substrings of 2 to
 //   9 code points.  These are called "words" but are not, grammatically
 //   speaking, words.  They're just spans of code points that frequently
-//   occur together.
+//   occur together.  They are ordered shortest to longest.
 //
 // - dictionary entries are non-overlapping, and the _ending_ index of each
-//   entry is stored in an array.  Since the index given is the ending
-//   index, the array is called "wends".
+//   entry is stored in an array.  A count of words of each length, from
+//   minlen to maxlen, is given in the array called wlencount.  From
+//   this small array, the start and end of the N'th word can be
+//   calculated by an efficient, small loop.  (A bit of time is traded
+//   to reduce the size of this table indicating lengths)
 //
 // The "data" / "tail" construct is so that the struct's last member is a
 // "flexible array".  However, the _only_ member is not permitted to be


### PR DESCRIPTION
By storing "count of words by length", the long `wends` table can be replaced with a short `wlencount` table.  This saves flash storage space.

Extend the range of string lengths that can be in the dictionary. Originally it was to 2 to 9; at one point it was changed to 3 to 9.
Putting the lower bound back at 2 has a positive impact on the French translation (a bunch of them, such as "ch", "\r\n", "%q", are used). Increasing the maximum length gets 'mpossible', ' doit être ', and 'CircuitPyth' at the long end.  This adds a bit of processing time to makeqstrdata. The specific 2/11 values are again empirical based on the French translation on the adafruit_proxlight_trinkey_m0.

This also pulls in #5104 which apparently made the French-language adafruit_proxlight_trinkey_m0 build overflow. This build now has 108 bytes free when I make it locally.