### PR TITLE
update tools/adabot submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -462,7 +462,7 @@ jobs:
     - name: Install deps
       run: |
         sudo apt-get install -y gettext
-        pip install requests sh click setuptools awscli
+        pip install -r requirements-dev.txt
         wget https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-centos6.tar.gz
         sudo tar -C /usr --strip-components=1 -xaf riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-centos6.tar.gz
     - name: Versions

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ jinja2
 typer
 
 requests
+requests-cache
 sh
 click
 setuptools


### PR DESCRIPTION
The `tools/adabot` submodule commit was from November 2018, and was terribly out of date. It was using an outdated authentication method in `github_requests`, for instance. This broke creating the circuitpython.org PR for 7.0.0-alpha.6, for example.

Let's see if other build things break when this is updated. Not sure if I can do PR generation manually, but I can try in a local clone. [EDIT: success; I had to do this once before, and it was a lot easier this time]