### PR TITLE
Codeformat version checking

### DIFF
--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -119,6 +119,15 @@ C_EXTS = (
 )
 PY_EXTS = (".py",)
 
+
+def check_uncrustify_version():
+    version = subprocess.check_output(
+        ["uncrustify", "--version"], encoding="utf-8", errors="replace"
+    )
+    if version < "Uncrustify-0.71":
+        raise SystemExit(f"codeformat.py requires Uncrustify 0.71 or newer, got {version}")
+
+
 # Transform a filename argument relative to the current directory into one
 # relative to the TOP directory, which is what we need when checking against
 # path_rx.
@@ -218,6 +227,7 @@ def main():
 
     # Format C files with uncrustify.
     if format_c:
+        check_uncrustify_version()
         command = ["uncrustify", "-c", UNCRUSTIFY_CFG, "-lC", "--no-backup"]
         if not args.v:
             command.append("-q")


### PR DESCRIPTION
Add a version check for uncrustify.

Checking the return code doesn't work like we'd hoped, as a nonzero exit status is used by uncrustify to signify "success, but files modified".

(Because we disagree with some things uncrustify does, and un-do them by search & replace, it is normal for uncrustify to modify many many files every time it's invoked)


Closes: #5126 