### PR TITLE
Removed default UART, SPI and I2C from Tiny2040 config

### DIFF
--- a/ports/raspberrypi/boards/pimoroni_tiny2040/pins.c
+++ b/ports/raspberrypi/boards/pimoroni_tiny2040/pins.c
@@ -31,9 +31,5 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_GPIO29) },
     { MP_ROM_QSTR(MP_QSTR_GP29_A3), MP_ROM_PTR(&pin_GPIO29) },
     { MP_ROM_QSTR(MP_QSTR_GP29), MP_ROM_PTR(&pin_GPIO29) },
-
-    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
-    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
-    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);


### PR DESCRIPTION
Tiny2040 does not have explicitly labelled UART, SPI or I2C pins, so had no pins defined, but had the objects defined for them. This would cause a NotImplementedException as raised in https://github.com/adafruit/circuitpython/issues/5148#issuecomment-898701100. Rather than introduce default pins we have instead opted to remove these objects.