### PR TITLE
Removed unnecessary defines from Pimoroni board files

### DIFF
--- a/ports/raspberrypi/boards/pimoroni_keybow2040/mpconfigboard.h
+++ b/ports/raspberrypi/boards/pimoroni_keybow2040/mpconfigboard.h
@@ -1,39 +1,8 @@
 #define MICROPY_HW_BOARD_NAME "Pimoroni Keybow 2040"
 #define MICROPY_HW_MCU_NAME "rp2040"
 
-#define MICROPY_HW_SW0 (&pin_GPIO21)
-#define MICROPY_HW_SW1 (&pin_GPIO20)
-#define MICROPY_HW_SW2 (&pin_GPIO19)
-#define MICROPY_HW_SW3 (&pin_GPIO18)
-#define MICROPY_HW_SW4 (&pin_GPIO17)
-#define MICROPY_HW_SW5 (&pin_GPIO16)
-#define MICROPY_HW_SW6 (&pin_GPIO15)
-#define MICROPY_HW_SW7 (&pin_GPIO14)
-#define MICROPY_HW_SW8 (&pin_GPIO13)
-#define MICROPY_HW_SW9 (&pin_GPIO12)
-#define MICROPY_HW_SW10 (&pin_GPIO11)
-#define MICROPY_HW_SW11 (&pin_GPIO10)
-#define MICROPY_HW_SW12 (&pin_GPIO9)
-#define MICROPY_HW_SW13 (&pin_GPIO8)
-#define MICROPY_HW_SW14 (&pin_GPIO7)
-#define MICROPY_HW_SW15 (&pin_GPIO6)
-
-#define MICROPY_HW_USER_SW (&pin_GPIO23)
-
-#define MICROPY_HW_I2C_INT (&pin_GPIO3)
-
 #define DEFAULT_I2C_BUS_SCL (&pin_GPIO5)
 #define DEFAULT_I2C_BUS_SDA (&pin_GPIO4)
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO1)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO0)
-
-// These pins are unconnected
-#define IGNORE_PIN_GPIO2    1
-#define IGNORE_PIN_GPIO22   1
-#define IGNORE_PIN_GPIO24   1
-#define IGNORE_PIN_GPIO25   1
-#define IGNORE_PIN_GPIO26   1
-#define IGNORE_PIN_GPIO27   1
-#define IGNORE_PIN_GPIO28   1
-#define IGNORE_PIN_GPIO29   1

--- a/ports/raspberrypi/boards/pimoroni_picolipo_16mb/mpconfigboard.h
+++ b/ports/raspberrypi/boards/pimoroni_picolipo_16mb/mpconfigboard.h
@@ -1,10 +1,5 @@
 #define MICROPY_HW_BOARD_NAME "Pimoroni Pico LiPo (16MB)"
 #define MICROPY_HW_MCU_NAME "rp2040"
 
-#define MICROPY_HW_VBUS_DETECT (&pin_GPIO24)
-#define MICROPY_HW_BAT_SENSE (&pin_GPIO29)
-
-#define MICROPY_HW_USER_SW (&pin_GPIO23)
-
 #define DEFAULT_I2C_BUS_SCL (&pin_GPIO5)
 #define DEFAULT_I2C_BUS_SDA (&pin_GPIO4)

--- a/ports/raspberrypi/boards/pimoroni_picolipo_4mb/mpconfigboard.h
+++ b/ports/raspberrypi/boards/pimoroni_picolipo_4mb/mpconfigboard.h
@@ -1,10 +1,5 @@
 #define MICROPY_HW_BOARD_NAME "Pimoroni Pico LiPo (4MB)"
 #define MICROPY_HW_MCU_NAME "rp2040"
 
-#define MICROPY_HW_VBUS_DETECT (&pin_GPIO24)
-#define MICROPY_HW_BAT_SENSE (&pin_GPIO29)
-
-#define MICROPY_HW_USER_SW (&pin_GPIO23)
-
 #define DEFAULT_I2C_BUS_SCL (&pin_GPIO5)
 #define DEFAULT_I2C_BUS_SDA (&pin_GPIO4)

--- a/ports/raspberrypi/boards/pimoroni_picosystem/mpconfigboard.h
+++ b/ports/raspberrypi/boards/pimoroni_picosystem/mpconfigboard.h
@@ -1,48 +1,13 @@
 #define MICROPY_HW_BOARD_NAME "Pimoroni PicoSystem"
 #define MICROPY_HW_MCU_NAME "rp2040"
 
-#define MICROPY_HW_VBUS_DETECT (&pin_GPIO2)
-
-#define MICROPY_HW_LCD_RESET (&pin_GPIO4)
-#define MICROPY_HW_LCD_CS (&pin_GPIO5)
-#define MICROPY_HW_LCD_SCLK (&pin_GPIO6)
-#define MICROPY_HW_LCD_MOSI (&pin_GPIO7)
-#define MICROPY_HW_LCD_VSYNC (&pin_GPIO8)
-#define MICROPY_HW_LCD_DS (&pin_GPIO9)
-
-#define MICROPY_HW_AUDIO (&pin_GPIO11)
-#define MICROPY_HW_BACKLIGHT (&pin_GPIO12)
-#define MICROPY_HW_VBUS_DETECT (&pin_GPIO2)
-
 #define CIRCUITPY_RGB_STATUS_INVERTED_PWM
 #define CIRCUITPY_RGB_STATUS_G (&pin_GPIO13)
 #define CIRCUITPY_RGB_STATUS_R (&pin_GPIO14)
 #define CIRCUITPY_RGB_STATUS_B (&pin_GPIO15)
-
-#define MICROPY_HW_SW_Y (&pin_GPIO16)
-#define MICROPY_HW_SW_X (&pin_GPIO17)
-#define MICROPY_HW_SW_A (&pin_GPIO18)
-#define MICROPY_HW_SW_B (&pin_GPIO19)
-
-#define MICROPY_HW_SW_DOWN (&pin_GPIO20)
-#define MICROPY_HW_SW_RIGHT (&pin_GPIO21)
-#define MICROPY_HW_SW_LEFT (&pin_GPIO22)
-#define MICROPY_HW_SW_UP (&pin_GPIO23)
-
-#define MICROPY_HW_CHARGE_STAT (&pin_GPIO24)
-
-#define MICROPY_HW_BAT_SENSE (&pin_GPIO26)
 
 #define DEFAULT_SPI_BUS_SCK (&pin_GPIO6)
 #define DEFAULT_SPI_BUS_MOSI (&pin_GPIO7)
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO1)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO0)
-
-// These pins are unconnected
-#define IGNORE_PIN_GPIO3    1
-#define IGNORE_PIN_GPIO10   1
-#define IGNORE_PIN_GPIO25   1
-#define IGNORE_PIN_GPIO27   1
-#define IGNORE_PIN_GPIO28   1
-#define IGNORE_PIN_GPIO29   1

--- a/ports/raspberrypi/boards/pimoroni_tiny2040/mpconfigboard.h
+++ b/ports/raspberrypi/boards/pimoroni_tiny2040/mpconfigboard.h
@@ -5,21 +5,3 @@
 #define CIRCUITPY_RGB_STATUS_R (&pin_GPIO18)
 #define CIRCUITPY_RGB_STATUS_G (&pin_GPIO19)
 #define CIRCUITPY_RGB_STATUS_B (&pin_GPIO20)
-
-#define MICROPY_HW_USER_SW (&pin_GPIO23)
-
-// These pins are unconnected
-#define IGNORE_PIN_GPIO8    1
-#define IGNORE_PIN_GPIO9    1
-#define IGNORE_PIN_GPIO10   1
-#define IGNORE_PIN_GPIO11   1
-#define IGNORE_PIN_GPIO12   1
-#define IGNORE_PIN_GPIO13   1
-#define IGNORE_PIN_GPIO14   1
-#define IGNORE_PIN_GPIO15   1
-#define IGNORE_PIN_GPIO16   1
-#define IGNORE_PIN_GPIO17   1
-#define IGNORE_PIN_GPIO21   1
-#define IGNORE_PIN_GPIO22   1
-#define IGNORE_PIN_GPIO24   1
-#define IGNORE_PIN_GPIO25   1


### PR DESCRIPTION
As highlighted by @tannewt in https://github.com/adafruit/circuitpython/pull/5099#pullrequestreview-727859125, most of the Pimoroni board definitions had erroneous `#define MICROPY_` and `#define IGNORE_PIN_` lines that serve no purpose in CircuitPython, other than causing confusion for anyone looking into the code. These have now been removed.