### PR TITLE
cp_sapling_m0_revb: board.UART not board.uart

### DIFF
--- a/ports/atmel-samd/boards/cp_sapling_m0_revb/pins.c
+++ b/ports/atmel-samd/boards/cp_sapling_m0_revb/pins.c
@@ -49,6 +49,6 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
-    { MP_ROM_QSTR(MP_QSTR_uart), MP_ROM_PTR(&board_uart_obj) },
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);


### PR DESCRIPTION
This is the only board that didn't match the all-uppercase convention for these UART (and more generally, these bus) entries. I'm not sure what the policy is regarding these kinds of changes, but figured I'd throw it out there for consideration.

Found when working on stubs for vscode-circuitpython (see https://github.com/joedevivo/vscode-circuitpython/pull/56 ), this needed a special casing (or rather, lower-casing) to handle as nicely as other boards.