### PR TITLE
correct some status LED pin defns per #5161

### DIFF
--- a/ports/esp32s2/boards/adafruit_funhouse/mpconfigboard.h
+++ b/ports/esp32s2/boards/adafruit_funhouse/mpconfigboard.h
@@ -29,8 +29,8 @@
 #define MICROPY_HW_BOARD_NAME       "Adafruit FunHouse"
 #define MICROPY_HW_MCU_NAME         "ESP32S2"
 
-#define MICROPY_HW_APA_MOSI (&pin_GPIO14)
-#define MICROPY_HW_APA_SCK (&pin_GPIO15)
+#define MICROPY_HW_APA102_MOSI (&pin_GPIO14)
+#define MICROPY_HW_APA102_SCK (&pin_GPIO15)
 
 #define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
 

--- a/ports/esp32s2/boards/microdev_micro_s2/mpconfigboard.h
+++ b/ports/esp32s2/boards/microdev_micro_s2/mpconfigboard.h
@@ -28,7 +28,7 @@
 #define MICROPY_HW_BOARD_NAME       "microS2"
 #define MICROPY_HW_MCU_NAME         "ESP32S2"
 
-#define MICROPY_HW_LED (&pin_GPIO21)
+#define MICROPY_HW_LED_STATUS (&pin_GPIO21)
 #define MICROPY_HW_BUTTON (&pin_GPIO0)
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO33)
 

--- a/ports/esp32s2/boards/microdev_micro_s2/mpconfigboard.h
+++ b/ports/esp32s2/boards/microdev_micro_s2/mpconfigboard.h
@@ -28,8 +28,6 @@
 #define MICROPY_HW_BOARD_NAME       "microS2"
 #define MICROPY_HW_MCU_NAME         "ESP32S2"
 
-#define MICROPY_HW_LED_STATUS (&pin_GPIO21)
-#define MICROPY_HW_BUTTON (&pin_GPIO0)
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO33)
 
 // Default bus pins

--- a/ports/nrf/boards/particle_argon/mpconfigboard.h
+++ b/ports/nrf/boards/particle_argon/mpconfigboard.h
@@ -30,11 +30,9 @@
 #define MICROPY_HW_BOARD_NAME       "Particle Argon"
 #define MICROPY_HW_MCU_NAME         "nRF52840"
 
-#define MICROPY_HW_LED_STATUS          (&pin_P1_12)
-
-#define MICROPY_HW_RGB_LED_RED         (&pin_P0_13)
-#define MICROPY_HW_RGB_LED_GREEN       (&pin_P0_14)
-#define MICROPY_HW_RGB_LED_BLUE        (&pin_P0_15)
+#define CIRCUITPY_RGB_STATUS_R       (&pin_P0_13)
+#define CIRCUITPY_RGB_STATUS_G       (&pin_P0_14)
+#define CIRCUITPY_RGB_STATUS_B       (&pin_P0_15)
 
 #if QSPI_FLASH_FILESYSTEM
 #define MICROPY_QSPI_DATA0                NRF_GPIO_PIN_MAP(0, 20)

--- a/ports/nrf/boards/particle_boron/mpconfigboard.h
+++ b/ports/nrf/boards/particle_boron/mpconfigboard.h
@@ -30,11 +30,9 @@
 #define MICROPY_HW_BOARD_NAME       "Particle Boron"
 #define MICROPY_HW_MCU_NAME         "nRF52840"
 
-#define MICROPY_HW_LED_STATUS          (&pin_P1_12)
-
-#define MICROPY_HW_RGB_LED_RED         (&pin_P0_13)
-#define MICROPY_HW_RGB_LED_GREEN       (&pin_P0_14)
-#define MICROPY_HW_RGB_LED_BLUE        (&pin_P0_15)
+#define CIRCUITPY_RGB_STATUS_R       (&pin_P0_13)
+#define CIRCUITPY_RGB_STATUS_G       (&pin_P0_14)
+#define CIRCUITPY_RGB_STATUS_B       (&pin_P0_15)
 
 #if QSPI_FLASH_FILESYSTEM
 #define MICROPY_QSPI_DATA0                NRF_GPIO_PIN_MAP(0, 20)


### PR DESCRIPTION
Thanks to @ZodiusInfuser for cataloging in #5161 some other boards that had incorrect status LED pin names.

Fixes:
- Correct Status APA102 names for Funhouse
- Correct LED status name for microS2
- Use the RGB LED instead of the single-color LED for status on Particle Argon and Boron