### PR TITLE
Update all implementations of spi read to honor write_value

### DIFF
--- a/ports/cxd56/common-hal/busio/SPI.c
+++ b/ports/cxd56/common-hal/busio/SPI.c
@@ -132,7 +132,8 @@ bool common_hal_busio_spi_write(busio_spi_obj_t *self, const uint8_t *data, size
 }
 
 bool common_hal_busio_spi_read(busio_spi_obj_t *self, uint8_t *data, size_t len, uint8_t write_value) {
-    SPI_EXCHANGE(self->spi_dev, NULL, data, len);
+    memset(data, write_value, len);
+    SPI_EXCHANGE(self->spi_dev, data, data, len);
 
     return true;
 }

--- a/ports/nrf/common-hal/busio/SPI.c
+++ b/ports/nrf/common-hal/busio/SPI.c
@@ -269,18 +269,8 @@ bool common_hal_busio_spi_write(busio_spi_obj_t *self, const uint8_t *data, size
 }
 
 bool common_hal_busio_spi_read(busio_spi_obj_t *self, uint8_t *data, size_t len, uint8_t write_value) {
-    uint8_t *next_chunk = data;
-
-    while (len > 0) {
-        size_t chunk_size = MIN(len, self->spim_peripheral->max_xfer_size);
-        const nrfx_spim_xfer_desc_t xfer = NRFX_SPIM_XFER_RX(next_chunk, chunk_size);
-        if (nrfx_spim_xfer(&self->spim_peripheral->spim, &xfer, 0) != NRFX_SUCCESS) {
-            return false;
-        }
-        next_chunk += chunk_size;
-        len -= chunk_size;
-    }
-    return true;
+    memset(data, write_value, len);
+    return common_hal_busio_spi_transfer(self, data, data, len);
 }
 
 bool common_hal_busio_spi_transfer(busio_spi_obj_t *self, const uint8_t *data_out, uint8_t *data_in, size_t len) {

--- a/ports/raspberrypi/common-hal/busio/SPI.c
+++ b/ports/raspberrypi/common-hal/busio/SPI.c
@@ -263,8 +263,8 @@ bool common_hal_busio_spi_write(busio_spi_obj_t *self,
 
 bool common_hal_busio_spi_read(busio_spi_obj_t *self,
     uint8_t *data, size_t len, uint8_t write_value) {
-    uint32_t data_out = write_value << 24 | write_value << 16 | write_value << 8 | write_value;
-    return _transfer(self, (const uint8_t *)&data_out, MIN(4, len), data, len);
+    memset(data, write_value, len);
+    return _transfer(self, data, len, data, len);
 }
 
 bool common_hal_busio_spi_transfer(busio_spi_obj_t *self, const uint8_t *data_out, uint8_t *data_in, size_t len) {

--- a/ports/raspberrypi/common-hal/busio/SPI.c
+++ b/ports/raspberrypi/common-hal/busio/SPI.c
@@ -263,8 +263,8 @@ bool common_hal_busio_spi_write(busio_spi_obj_t *self,
 
 bool common_hal_busio_spi_read(busio_spi_obj_t *self,
     uint8_t *data, size_t len, uint8_t write_value) {
-    memset(data, write_value, len);
-    return _transfer(self, data, len, data, len);
+    uint32_t data_out = write_value << 24 | write_value << 16 | write_value << 8 | write_value;
+    return _transfer(self, (const uint8_t *)&data_out, MIN(4, len), data, len);
 }
 
 bool common_hal_busio_spi_transfer(busio_spi_obj_t *self, const uint8_t *data_out, uint8_t *data_in, size_t len) {

--- a/shared-bindings/busio/SPI.h
+++ b/shared-bindings/busio/SPI.h
@@ -52,7 +52,7 @@ extern void common_hal_busio_spi_unlock(busio_spi_obj_t *self);
 // Writes out the given data.
 extern bool common_hal_busio_spi_write(busio_spi_obj_t *self, const uint8_t *data, size_t len);
 
-// Reads in len bytes while outputting zeroes.
+// Reads in len bytes while outputting the byte write_value.
 extern bool common_hal_busio_spi_read(busio_spi_obj_t *self, uint8_t *data, size_t len, uint8_t write_value);
 
 // Reads and write len bytes simultaneously.


### PR DESCRIPTION
(nrf, rp2040, and cxd56)

.. as well as a misleading comment that said that read always output zeros.

Closes: #3447