### PR TITLE
canio: Run background tasks while waiting for message reception

### DIFF
--- a/ports/atmel-samd/common-hal/canio/Listener.c
+++ b/ports/atmel-samd/common-hal/canio/Listener.c
@@ -30,6 +30,8 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 
+#include "lib/utils/interrupt_char.h"
+
 #include "common-hal/canio/__init__.h"
 #include "common-hal/canio/Listener.h"
 #include "shared-bindings/canio/Listener.h"
@@ -354,6 +356,11 @@ mp_obj_t common_hal_canio_listener_receive(canio_listener_obj_t *self) {
         uint64_t deadline = supervisor_ticks_ms64() + self->timeout_ms;
         do {
             if (supervisor_ticks_ms64() > deadline) {
+                return NULL;
+            }
+            RUN_BACKGROUND_TASKS;
+            // Allow user to break out of a timeout with a KeyboardInterrupt.
+            if (mp_hal_is_interrupted()) {
                 return NULL;
             }
         } while (!common_hal_canio_listener_in_waiting(self));

--- a/ports/esp32s2/common-hal/canio/Listener.c
+++ b/ports/esp32s2/common-hal/canio/Listener.c
@@ -151,6 +151,11 @@ mp_obj_t common_hal_canio_listener_receive(canio_listener_obj_t *self) {
             if (supervisor_ticks_ms64() > deadline) {
                 return NULL;
             }
+            RUN_BACKGROUND_TASKS;
+            // Allow user to break out of a timeout with a KeyboardInterrupt.
+            if (mp_hal_is_interrupted()) {
+                return NULL;
+            }
         } while (!common_hal_canio_listener_in_waiting(self));
     }
 

--- a/ports/stm/common-hal/canio/Listener.c
+++ b/ports/stm/common-hal/canio/Listener.c
@@ -30,6 +30,8 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 
+#include "lib/utils/interrupt_char.h"
+
 #include "common-hal/canio/__init__.h"
 #include "common-hal/canio/Listener.h"
 #include "shared-bindings/canio/Listener.h"
@@ -270,6 +272,11 @@ mp_obj_t common_hal_canio_listener_receive(canio_listener_obj_t *self) {
         uint64_t deadline = supervisor_ticks_ms64() + self->timeout_ms;
         do {
             if (supervisor_ticks_ms64() > deadline) {
+                return NULL;
+            }
+            RUN_BACKGROUND_TASKS;
+            // Allow user to break out of a timeout with a KeyboardInterrupt.
+            if ( mp_hal_is_interrupted() ) {
                 return NULL;
             }
         } while (!common_hal_canio_listener_in_waiting(self));

--- a/ports/stm/common-hal/canio/Listener.c
+++ b/ports/stm/common-hal/canio/Listener.c
@@ -276,7 +276,7 @@ mp_obj_t common_hal_canio_listener_receive(canio_listener_obj_t *self) {
             }
             RUN_BACKGROUND_TASKS;
             // Allow user to break out of a timeout with a KeyboardInterrupt.
-            if ( mp_hal_is_interrupted() ) {
+            if (mp_hal_is_interrupted()) {
                 return NULL;
             }
         } while (!common_hal_canio_listener_in_waiting(self));


### PR DESCRIPTION
While I don't have enough information to determine if this is what affected the original reporter, I had an stm32f405 feather that readily reproduced the problem. I eventually discovered that the problem affected me only when I had a program that used canio and was spending all its time waiting in `common_hal_canio_listener_receive` for a packet that never arrived. This was due to missing background task & interrupt key checking in the blocking loop in `common_hal_canio_listener_receive`.

I added the extra code to both esp32-s2, samd and st code, but only tested stm32f405 feather.

Closes: #5004