### PR TITLE
Add SPEAKER_ENABLE to MacroPad

### DIFF
--- a/ports/raspberrypi/boards/adafruit_macropad_rp2040/pins.c
+++ b/ports/raspberrypi/boards/adafruit_macropad_rp2040/pins.c
@@ -17,7 +17,9 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO13) },
 
+    // SPEAKER_SHUTDOWN is deprecated and will be removed in a future release.
     { MP_ROM_QSTR(MP_QSTR_SPEAKER_SHUTDOWN), MP_ROM_PTR(&pin_GPIO14) },
+    { MP_ROM_QSTR(MP_QSTR_SPEAKER_ENABLE), MP_ROM_PTR(&pin_GPIO14) },
     { MP_ROM_QSTR(MP_QSTR_SPEAKER), MP_ROM_PTR(&pin_GPIO16) },
 
     { MP_ROM_QSTR(MP_QSTR_ENCODER_SWITCH), MP_ROM_PTR(&pin_GPIO0) },

--- a/ports/raspberrypi/boards/adafruit_macropad_rp2040/pins.c
+++ b/ports/raspberrypi/boards/adafruit_macropad_rp2040/pins.c
@@ -17,8 +17,6 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO13) },
 
-    // SPEAKER_SHUTDOWN is deprecated and will be removed in a future release.
-    { MP_ROM_QSTR(MP_QSTR_SPEAKER_SHUTDOWN), MP_ROM_PTR(&pin_GPIO14) },
     { MP_ROM_QSTR(MP_QSTR_SPEAKER_ENABLE), MP_ROM_PTR(&pin_GPIO14) },
     { MP_ROM_QSTR(MP_QSTR_SPEAKER), MP_ROM_PTR(&pin_GPIO16) },
 


### PR DESCRIPTION
Also removes `SPEAKER_SHUTDOWN` which was confusing and inconsistent with other naming. As it is not widely used, it made more sense to remove it now than to wait.

Verified all boards with `SPEAKER_ENABLE` are named appropriately.

Will require updating MacroPad library (once the next release is completed) and Pinouts page of MacroPad guide.