### PR TITLE
Fix linker error when ONEWIREIO = 0

### DIFF
--- a/shared-bindings/bitbangio/__init__.c
+++ b/shared-bindings/bitbangio/__init__.c
@@ -72,7 +72,9 @@
 STATIC const mp_rom_map_elem_t bitbangio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_bitbangio) },
     { MP_ROM_QSTR(MP_QSTR_I2C),   MP_ROM_PTR(&bitbangio_i2c_type) },
+    #if CIRCUITPY_ONEWIREIO
     { MP_ROM_QSTR(MP_QSTR_OneWire),   MP_ROM_PTR(&onewireio_onewire_type) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_SPI),   MP_ROM_PTR(&bitbangio_spi_type) },
 };
 

--- a/shared-bindings/busio/__init__.c
+++ b/shared-bindings/busio/__init__.c
@@ -73,7 +73,9 @@ STATIC const mp_rom_map_elem_t busio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_busio) },
     { MP_ROM_QSTR(MP_QSTR_I2C),   MP_ROM_PTR(&busio_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI),   MP_ROM_PTR(&busio_spi_type) },
+    #if CIRCUITPY_ONEWIREIO
     { MP_ROM_QSTR(MP_QSTR_OneWire),   MP_ROM_PTR(&onewireio_onewire_type) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_UART),   MP_ROM_PTR(&busio_uart_type) },
 };
 


### PR DESCRIPTION
Addendum to #5139 to fix linker errors like

```
arm-none-eabi/bin/ld: firmware.elf.lto.o:(.rodata.busio_module_globals_table+0x1c): undefined reference to `onewireio_onewire_type'
```

when `CIRCUITPY_ONEWIREIO = 0`, allowing to actually turn off `onewireio` (no board currently does that).