### PR TITLE
improve SAMD audio DMA

### DIFF
--- a/ports/atmel-samd/audio_dma.h
+++ b/ports/atmel-samd/audio_dma.h
@@ -35,22 +35,24 @@
 
 typedef struct {
     mp_obj_t sample;
+    uint8_t *buffer[2];
+    size_t buffer_length[2];
+    DmacDescriptor *descriptor[2];
+    DmacDescriptor second_descriptor;
+    background_callback_t callback;
     uint8_t dma_channel;
     uint8_t event_channel;
     uint8_t audio_channel;
     uint8_t bytes_per_sample;
     uint8_t beat_size;
     uint8_t spacing;
+    uint8_t buffer_to_load; // Index
     bool loop;
+    bool single_buffer;
     bool single_channel_output;
     bool signed_to_unsigned;
     bool unsigned_to_signed;
-    bool first_buffer_free;
-    uint8_t *first_buffer;
-    uint8_t *second_buffer;
-    bool first_descriptor_free;
-    DmacDescriptor *second_descriptor;
-    background_callback_t callback;
+    bool playing_in_progress;
 } audio_dma_t;
 
 typedef enum {

--- a/ports/atmel-samd/boards/dynossat_edu_obc/mpconfigboard.h
+++ b/ports/atmel-samd/boards/dynossat_edu_obc/mpconfigboard.h
@@ -23,16 +23,11 @@
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1
-#define IGNORE_PIN_PA02     1
 #define IGNORE_PIN_PA13     1
 #define IGNORE_PIN_PA14     1
-#define IGNORE_PIN_PA20     1
-#define IGNORE_PIN_PA21     1
 #define IGNORE_PIN_PA27     1
-#define IGNORE_PIN_PB00     1
 #define IGNORE_PIN_PB04     1
 #define IGNORE_PIN_PB05     1
-#define IGNORE_PIN_PB16     1
 #define IGNORE_PIN_PB17     1
 #define IGNORE_PIN_PB23     1
 #define IGNORE_PIN_PB31     1

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -248,7 +248,7 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t *self,
     }
     self->tc_index = tc_index;
 
-    // Use the 48mhz clocks on both the SAMD21 and 51 because we will be going much slower.
+    // Use the 48MHz clocks on both the SAMD21 and 51 because we will be going much slower.
     uint8_t tc_gclk = 0;
     #ifdef SAM_D5X_E5X
     tc_gclk = 1;
@@ -469,8 +469,8 @@ bool common_hal_audioio_audioout_get_paused(audioio_audioout_obj_t *self) {
 }
 
 void common_hal_audioio_audioout_stop(audioio_audioout_obj_t *self) {
-    Tc *timer = tc_insts[self->tc_index];
-    timer->COUNT16.CTRLBSET.reg = TC_CTRLBSET_CMD_STOP;
+    // Do not stop the timer here. There are occasional audible artifacts if the DMA-triggering timer
+    // is stopped between audio plays. (Heard this only on PyPortal with one particular 32kHz sample.)
     audio_dma_stop(&self->left_dma);
     #ifdef SAM_D5X_E5X
     audio_dma_stop(&self->right_dma);

--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -137,7 +137,7 @@ STATIC void audio_dma_convert_samples(
     #pragma GCC diagnostic pop
 }
 
-// channel_idx is 0 or 1.
+// buffer_idx is 0 or 1.
 STATIC void audio_dma_load_next_block(audio_dma_t *dma, size_t buffer_idx) {
     size_t dma_channel = dma->channel[buffer_idx];
 

--- a/ports/raspberrypi/audio_dma.h
+++ b/ports/raspberrypi/audio_dma.h
@@ -34,23 +34,23 @@
 
 typedef struct {
     mp_obj_t sample;
+    uint8_t *buffer[2];
+    size_t buffer_length[2];
+    uint32_t channels_to_load_mask;
+    uint32_t output_register_address;
+    background_callback_t callback;
     uint8_t channel[2];
     uint8_t audio_channel;
     uint8_t output_size;
     uint8_t sample_spacing;
+    uint8_t output_resolution; // in bits
+    uint8_t sample_resolution; // in bits
     bool loop;
     bool single_channel_output;
     bool signed_to_unsigned;
     bool unsigned_to_signed;
     bool output_signed;
     bool playing_in_progress;
-    uint8_t output_resolution; // in bits
-    uint8_t sample_resolution; // in bits
-    uint8_t *buffer[2];
-    size_t buffer_length[2];
-    uint32_t channels_to_load_mask;
-    uint32_t output_register_address;
-    background_callback_t callback;
 } audio_dma_t;
 
 typedef enum {


### PR DESCRIPTION
These are changes to audio DMA on SAMD to reduce scratchiness and other artifacts. The changes are similar to #5079: determining which buffer to fill is no longer done with a flip-flipping boolean, but instead by figuring out the buffer that finished playing in the DMA ISR. The code has also been restructured somewhat as with #5079. Also some extremely minor changes were made in a couple of RP2040 files.

On my PyPortal, I heard an uncommon trailing artifact when playing a A440 16-bit 32-kHz 1 second tone after playing another non-32kHz file. The fix was to not turn off the DAC-trigger timer between plays. I think this may be the DAC output picking up noise or acting oddly when no longer triggered.

I also heard other noise artifacts after playing sample, when using an analog amplifier with `AudioOut`. However, these seem to be solely electrical, not software. Putting a 0.1uF cap across the output cured these. A large resistor might have worked also. I think these are noise from a floating PWM or DAC output. They can last for seconds, and can be cured with, say, the cap, or by simply unplugging and replugging the analog input line. There was also noise leakage from an adjacent I2S amp when it was powered.

It is still the case that display activity and other SPI activity can cause output glitches. On the PyPortal, these show up due to the REPL echoing at the beginning of a play, using the sample program below. Turning off the display eliminates the artifacts.

Tested with `AudioOut` and `I2SOut` on a PyPortal and a Metro M4.
Tested with `AudioOut` on a CPX (SAMD21).
Tested with `I2SOut` on Metro M4.

Fixes #5047, to the extent that the glitches are not caused by SPI contention, such as by displays.

Typical test program, modified slightly for different boards and for `I2SOut`.
```py
import array
import board
import digitalio
import displayio
import os
import time

from audiocore import WaveFile
from audioio import AudioOut

# If uncommented on PyPortal, artifacts can be heard at the beginning of a play, due to display activity
#displayio.release_displays()

speaker_shutdown = digitalio.DigitalInOut(board.SPEAKER_ENABLE)
speaker_shutdown.switch_to_output(True);

def print_filenames(filenames):
    for num, filename in enumerate(filenames):
        print(f"{num:2d} {filename}")

a = AudioOut(board.SPEAKER)

wavs = []
for filename in (os.listdir()):
    if filename.endswith(".wav"):
        wavs.append(filename)
        wavs.sort()

print_filenames(wavs)

while True:
    inp = input("play: ")
    try:
        filenum = int(inp)
    except (IndexError, ValueError):
        print_filenames(wavs)
        continue

    if filenum >= len(wavs):
        print_filenames(wavs)
        continue

    filename = wavs[filenum]
    wav = WaveFile(open(filename, "rb"))

    print(f"  playing {filename}")
    a.play(wav)
    while a.playing:
        pass
    time.sleep(0.1)
```




