### PR TITLE
Adding quick refresh support

### DIFF
--- a/shared-bindings/displayio/EPaperDisplay.c
+++ b/shared-bindings/displayio/EPaperDisplay.c
@@ -217,6 +217,30 @@ STATIC mp_obj_t displayio_epaperdisplay_obj_show(mp_obj_t self_in, mp_obj_t grou
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_epaperdisplay_show_obj, displayio_epaperdisplay_obj_show);
 
+STATIC mp_obj_t update_refresh_mode(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args)
+{
+    enum { ARG_start_sequence, ARG_seconds_per_frame };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_start_sequence, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_seconds_per_frame, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_SMALL_INT(180)} },
+    };
+    displayio_epaperdisplay_obj_t *self = native_display(pos_args[0]);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get parameters
+    mp_buffer_info_t start_sequence;
+    mp_get_buffer_raise(args[ARG_start_sequence].u_obj, &start_sequence, MP_BUFFER_READ);
+    float seconds_per_frame = mp_obj_get_float(args[ARG_seconds_per_frame].u_obj);
+
+    // Update parameters
+    self->start_sequence = (uint8_t *)start_sequence.buf;
+    self->start_sequence_len = start_sequence.len;
+    self->milliseconds_per_frame = seconds_per_frame * 1000;
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(update_refresh_mode_obj, 3, update_refresh_mode);
+
 //|     def refresh(self) -> None:
 //|         """Refreshes the display immediately or raises an exception if too soon. Use
 //|         ``time.sleep(display.time_to_refresh)`` to sleep until a refresh can occur."""
@@ -339,6 +363,7 @@ const mp_obj_property_t displayio_epaperdisplay_bus_obj = {
 
 STATIC const mp_rom_map_elem_t displayio_epaperdisplay_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_show), MP_ROM_PTR(&displayio_epaperdisplay_show_obj) },
+    { MP_ROM_QSTR(MP_QSTR_update_refresh_mode), MP_ROM_PTR(&update_refresh_mode_obj) },
     { MP_ROM_QSTR(MP_QSTR_refresh), MP_ROM_PTR(&displayio_epaperdisplay_refresh_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&displayio_epaperdisplay_width_obj) },

--- a/shared-bindings/displayio/EPaperDisplay.h
+++ b/shared-bindings/displayio/EPaperDisplay.h
@@ -39,7 +39,7 @@ extern const mp_obj_type_t displayio_epaperdisplay_type;
 #define NO_COMMAND 0x100
 
 void common_hal_displayio_epaperdisplay_construct(displayio_epaperdisplay_obj_t *self,
-    mp_obj_t bus, const uint8_t *start_sequence, uint16_t start_sequence_len, const uint8_t *stop_sequence, uint16_t stop_sequence_len,
+    mp_obj_t bus, uint8_t *start_sequence, uint16_t start_sequence_len, const uint8_t *stop_sequence, uint16_t stop_sequence_len,
     uint16_t width, uint16_t height, uint16_t ram_width, uint16_t ram_height, int16_t colstart, int16_t rowstart, uint16_t rotation,
     uint16_t set_column_window_command, uint16_t set_row_window_command,
     uint16_t set_current_column_command, uint16_t set_current_row_command,

--- a/shared-module/displayio/EPaperDisplay.c
+++ b/shared-module/displayio/EPaperDisplay.c
@@ -43,7 +43,7 @@
 #include <string.h>
 
 void common_hal_displayio_epaperdisplay_construct(displayio_epaperdisplay_obj_t *self,
-    mp_obj_t bus, const uint8_t *start_sequence, uint16_t start_sequence_len,
+    mp_obj_t bus, uint8_t *start_sequence, uint16_t start_sequence_len,
     const uint8_t *stop_sequence, uint16_t stop_sequence_len,
     uint16_t width, uint16_t height, uint16_t ram_width, uint16_t ram_height,
     int16_t colstart, int16_t rowstart, uint16_t rotation,

--- a/shared-module/displayio/EPaperDisplay.h
+++ b/shared-module/displayio/EPaperDisplay.h
@@ -38,7 +38,7 @@ typedef struct {
     displayio_display_core_t core;
     digitalio_digitalinout_obj_t busy;
     uint32_t milliseconds_per_frame;
-    const uint8_t *start_sequence;
+    uint8_t *start_sequence;
     uint32_t start_sequence_len;
     const uint8_t *stop_sequence;
     uint32_t stop_sequence_len;


### PR DESCRIPTION
During the process of creating the ARAMCON 2 Badge, we needed the E Paper Display to refresh more frequently. Therefore, we added an API function that allowed us to change the start_sequence of an EPaperDisplay object and control it's waveform data that is used to update the display.
I'm sure this is not the prettiest way to do it, but we needed a fast solution so I decided to change the core base as little as possible.
I came out with the proposed solution that doesn't change any of the "default" configurations and keeps it backwards-compatible.
After we added this API call, we changed the IL0373 driver (IL0373 is our EPaperDisplay) and were able to set our own waveform using the start sequence. Our modified driver can be found here: https://github.com/aramcon-badge/Adafruit_CircuitPython_IL0373/blob/quick-lut/adafruit_il0373.py
After (and if) this PR is merged we can open a PR to update the driver as well.
You can find a usage example of this modified driver in our badge code: https://github.com/aramcon-badge/aramcon-firmware/blob/master/lib/display.py

I know these changes to the waveform might affect the display over time, and might even result in "dead pixels". I didn't encounter such things, but it still needs to be considered when using this method. Also, these waveforms are most likely not optimized, this is what I came with after some trial and error.

We used version 6.3.0 on our badge, so the code was tested on this version. However I can't think of a reason why it shouldn't work on later versions...