### PR TITLE
Remove `displayio_copy_coords` from shared-module displayio

### DIFF
--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -296,13 +296,6 @@ bool displayio_area_compute_overlap(const displayio_area_t *a,
     return true;
 }
 
-void displayio_copy_coords(const displayio_area_t *src, displayio_area_t *dest) {
-    dest->x1 = src->x1;
-    dest->y1 = src->y1;
-    dest->x2 = src->x2;
-    dest->y2 = src->y2;
-}
-
 bool displayio_area_empty(const displayio_area_t *a) {
     return (a->x1 == a->x2) || (a->y1 == a->y2);
 }
@@ -325,11 +318,11 @@ void displayio_area_union(const displayio_area_t *a,
     displayio_area_t *u) {
 
     if (displayio_area_empty(a)) {
-        displayio_copy_coords(b, u);
+        displayio_area_copy(b, u);
         return;
     }
     if (displayio_area_empty(b)) {
-        displayio_copy_coords(a, u);
+        displayio_area_copy(a, u);
         return;
     }
     u->x1 = MIN(a->x1, b->x1);


### PR DESCRIPTION
The method `displayio_copy_coords` is identical to `displayio_area_copy`. Remove `displayio_copy_coords` as it is the lesser used and replace with `displayio_area_copy`

```c
void displayio_copy_coords(const displayio_area_t *src, displayio_area_t *dest) {
    dest->x1 = src->x1;
    dest->y1 = src->y1;
    dest->x2 = src->x2;
    dest->y2 = src->y2;
}
```
```c
void displayio_area_copy(const displayio_area_t *src, displayio_area_t *dst) {
    dst->x1 = src->x1;
    dst->y1 = src->y1;
    dst->x2 = src->x2;
    dst->y2 = src->y2;
}
```

Built and tested on PyPortal.