### PR TITLE
Use the modified args to sort in displayio.Group

### DIFF
--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -335,7 +335,7 @@ STATIC mp_obj_t displayio_group_obj_sort(size_t n_args, const mp_obj_t *pos_args
         args[i] = pos_args[i];
     }
     args[0] = MP_OBJ_FROM_PTR(self->members);
-    return mp_obj_list_sort(n_args, pos_args, kw_args);
+    return mp_obj_list_sort(n_args, args, kw_args);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(displayio_group_sort_obj, 1, displayio_group_obj_sort);
 


### PR DESCRIPTION
Calling `sort()` on a Group hard crashed.
The `pos_args` were modified but the unmodified ones were passed onto `mp_obj_list_sort()`

This has been tested on a PyPortal with the following code:
```python
import displayio
import board
import adafruit_display_text.label as label
from terminalio import FONT

group = displayio.Group()
for i in range(10):
    lbl = label.Label(FONT, text=f"Label {i}", x = 100 - (i * 5), y = 100 - (i * 5))
    group.append(lbl)
    
for layer in group:
    print(layer.text, "x", layer.x, "y", layer.y)

def sort_function(layer) -> int:
    return layer.x

print("About to sort")

# Test / Pass 1
group.sort(key = sort_function)

# Test / Pass 2
# group.sort()

print("Sort has happened")

for layer in group:
    print(layer.text, "x", layer.x, "y", layer.y)
```

Test/Pass 1 - Using a provided sort function - sorts by `x` as expected
```
Label 0 x 100 y 100
Label 1 x 95 y 95
Label 2 x 90 y 90
Label 3 x 85 y 85
Label 4 x 80 y 80
Label 5 x 75 y 75
Label 6 x 70 y 70
Label 7 x 65 y 65
Label 8 x 60 y 60
Label 9 x 55 y 55

Label 9 x 55 y 55
Label 8 x 60 y 60
Label 7 x 65 y 65
Label 6 x 70 y 70
Label 5 x 75 y 75
Label 4 x 80 y 80
Label 3 x 85 y 85
Label 2 x 90 y 90
Label 1 x 95 y 95
Label 0 x 100 y 100
```

Test/Pass 2 - Using the default sort order - errors as expected, there is no `__lt__` defined for Label
```
Label 0 x 100 y 100
Label 1 x 95 y 95
Label 2 x 90 y 90
Label 3 x 85 y 85
Label 4 x 80 y 80
Label 5 x 75 y 75
Label 6 x 70 y 70
Label 7 x 65 y 65
Label 8 x 60 y 60
Label 9 x 55 y 55
About to sort
Traceback (most recent call last):
  File "<stdin>", line 23, in <module>
TypeError: unsupported types for __lt__: 'Label', 'Label'
```