### PR TITLE
Remove the `pixel_luma` parameter from `compute_tricolor`

### DIFF
--- a/shared-module/displayio/ColorConverter.c
+++ b/shared-module/displayio/ColorConverter.c
@@ -96,7 +96,7 @@ uint8_t displayio_colorconverter_compute_hue(uint32_t color_rgb888) {
     return hue;
 }
 
-void displayio_colorconverter_compute_tricolor(const _displayio_colorspace_t *colorspace, uint8_t pixel_hue, uint8_t pixel_luma, uint32_t *color) {
+void displayio_colorconverter_compute_tricolor(const _displayio_colorspace_t *colorspace, uint8_t pixel_hue, uint32_t *color) {
 
     int16_t hue_diff = colorspace->tricolor_hue - pixel_hue;
     if ((-10 <= hue_diff && hue_diff <= 10) || hue_diff <= -220 || hue_diff >= 220) {
@@ -244,7 +244,7 @@ void displayio_colorconverter_convert(displayio_colorconverter_t *self, const _d
             return;
         }
         uint8_t pixel_hue = displayio_colorconverter_compute_hue(pixel);
-        displayio_colorconverter_compute_tricolor(colorspace, pixel_hue, luma, &output_color->pixel);
+        displayio_colorconverter_compute_tricolor(colorspace, pixel_hue, &output_color->pixel);
         return;
     } else if (colorspace->grayscale && colorspace->depth <= 8) {
         uint8_t luma = displayio_colorconverter_compute_luma(pixel);

--- a/shared-module/displayio/ColorConverter.h
+++ b/shared-module/displayio/ColorConverter.h
@@ -51,6 +51,6 @@ uint16_t displayio_colorconverter_compute_rgb565(uint32_t color_rgb888);
 uint8_t displayio_colorconverter_compute_luma(uint32_t color_rgb888);
 uint8_t displayio_colorconverter_compute_chroma(uint32_t color_rgb888);
 uint8_t displayio_colorconverter_compute_hue(uint32_t color_rgb888);
-void displayio_colorconverter_compute_tricolor(const _displayio_colorspace_t *colorspace, uint8_t pixel_hue, uint8_t pixel_luma, uint32_t *color);
+void displayio_colorconverter_compute_tricolor(const _displayio_colorspace_t *colorspace, uint8_t pixel_hue, uint32_t *color);
 
 #endif // MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_COLORCONVERTER_H

--- a/shared-module/displayio/Palette.c
+++ b/shared-module/displayio/Palette.c
@@ -85,7 +85,7 @@ bool displayio_palette_get_color(displayio_palette_t *self, const _displayio_col
             return true;
         }
         uint8_t pixel_hue = self->colors[palette_index].hue;
-        displayio_colorconverter_compute_tricolor(colorspace, pixel_hue, luma, color);
+        displayio_colorconverter_compute_tricolor(colorspace, pixel_hue, color);
     } else if (colorspace->grayscale) {
         size_t bitmask = (1 << colorspace->depth) - 1;
         *color = (self->colors[palette_index].luma >> colorspace->grayscale_bit) & bitmask;


### PR DESCRIPTION
Remove the pixel_luma parameter from displayio_colorconverter_compute_tricolor (Closes #5194)

Not tested, I don't currently have a three colour eInk screen to test with.