### PR TITLE
Change optimizer option so RP2040 DEBUG builds work

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -117,7 +117,7 @@ CFLAGS += $(OPTIMIZATION_FLAGS)
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)
-  CFLAGS += -ggdb3 -Og
+  CFLAGS += -ggdb3 -O3
   # No LTO because we may place some functions in RAM instead of flash.
 else
   CFLAGS += -DNDEBUG


### PR DESCRIPTION
Fix for issue #5091. Changing -Og to -O3 allows RP2040 debug builds to boot and still remain debuggable.