### PR TITLE
Two tweaks to BLE workflow

### DIFF
--- a/main.c
+++ b/main.c
@@ -755,7 +755,7 @@ STATIC int run_repl(void) {
     usb_setup_with_vm();
     #endif
 
-    autoreload_suspend();
+    autoreload_suspend(AUTORELOAD_LOCK_REPL);
 
     // Set the status LED to the REPL color before running the REPL. For
     // NeoPixels and DotStars this will be sticky but for PWM or single LED it
@@ -785,7 +785,7 @@ STATIC int run_repl(void) {
     status_led_deinit();
     #endif
 
-    autoreload_resume();
+    autoreload_resume(AUTORELOAD_LOCK_REPL);
     return exit_code;
 }
 

--- a/supervisor/shared/autoreload.c
+++ b/supervisor/shared/autoreload.c
@@ -35,7 +35,7 @@ supervisor_allocation *next_code_allocation;
 
 static volatile uint32_t autoreload_delay_ms = 0;
 static bool autoreload_enabled = false;
-static bool autoreload_suspended = false;
+static size_t autoreload_suspended = 0;
 
 volatile bool reload_requested = false;
 
@@ -44,7 +44,7 @@ inline void autoreload_tick() {
         return;
     }
     if (autoreload_delay_ms == 1 && autoreload_enabled &&
-        !autoreload_suspended && !reload_requested) {
+        autoreload_suspended == 0 && !reload_requested) {
         mp_raise_reload_exception();
         reload_requested = true;
         supervisor_set_run_reason(RUN_REASON_AUTO_RELOAD);
@@ -62,12 +62,12 @@ void autoreload_disable() {
     autoreload_enabled = false;
 }
 
-void autoreload_suspend() {
-    autoreload_suspended = true;
+void autoreload_suspend(size_t lock_mask) {
+    autoreload_suspended |= lock_mask;
 }
 
-void autoreload_resume() {
-    autoreload_suspended = false;
+void autoreload_resume(size_t lock_mask) {
+    autoreload_suspended &= ~lock_mask;
 }
 
 inline bool autoreload_is_enabled() {

--- a/supervisor/shared/autoreload.h
+++ b/supervisor/shared/autoreload.h
@@ -40,6 +40,11 @@ enum {
     SUPERVISOR_NEXT_CODE_OPT_NEWLY_SET = 0x20,
 };
 
+enum {
+    AUTORELOAD_LOCK_REPL = 0x1,
+    AUTORELOAD_LOCK_BLE = 0x2
+};
+
 typedef struct {
     uint8_t options;
     char filename[];
@@ -58,8 +63,8 @@ void autoreload_disable(void);
 bool autoreload_is_enabled(void);
 
 // Temporarily turn it off. Used during the REPL.
-void autoreload_suspend(void);
-void autoreload_resume(void);
+void autoreload_suspend(size_t lock_mask);
+void autoreload_resume(size_t lock_mask);
 
 void autoreload_now(void);
 


### PR DESCRIPTION
1. Use autoreload for restarting after a write. This gives time for
   a follow up command before restarting BLE.
2. Switch to recursive deletion of directories. This greatly
   simplifies deleting directories with contents.

Fixes https://github.com/adafruit/Adafruit_CircuitPython_BLE_File_Transfer/issues/7