### PR TITLE
Allocate I2C mutex with IDF

### DIFF
--- a/ports/esp32s2/common-hal/busio/I2C.c
+++ b/ports/esp32s2/common-hal/busio/I2C.c
@@ -88,7 +88,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     }
     #endif
 
-    self->xSemaphore = xSemaphoreCreateMutexStatic(&self->xSemaphoreBuffer);
+    self->xSemaphore = xSemaphoreCreateMutex();
     if (self->xSemaphore == NULL) {
         mp_raise_RuntimeError(translate("Unable to create lock"));
     }

--- a/ports/esp32s2/common-hal/busio/I2C.h
+++ b/ports/esp32s2/common-hal/busio/I2C.h
@@ -40,7 +40,6 @@ typedef struct {
     const mcu_pin_obj_t *sda_pin;
     i2c_port_t i2c_num;
     SemaphoreHandle_t xSemaphore;
-    StaticSemaphore_t xSemaphoreBuffer;
     bool has_lock;
 } busio_i2c_obj_t;
 


### PR DESCRIPTION
This keeps the mutex info in the same spot in memory. "Statically
allocating it" with CircuitPython meant that the buffer moved when
the I2C object is moved to keep it alive for a display.

Fixes #4962