### PR TITLE
Use MP_REGISTER_MODULE with displayio, terminalio, and fontio

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -412,25 +412,16 @@ extern const struct _mp_obj_module_t digitalio_module;
 #define DIGITALIO_MODULE
 #endif
 
+// CIRCUITPY_DISPLAYIO uses MP_REGISTER_MODULE
+// CIRCUITPY_TERMINALIO uses MP_REGISTER_MODULE
+// CIRCUITPY_FONTIO uses MP_REGISTER_MODULE
+
 #if CIRCUITPY_DISPLAYIO
-extern const struct _mp_obj_module_t displayio_module;
-extern const struct _mp_obj_module_t fontio_module;
-extern const struct _mp_obj_module_t terminalio_module;
-#define DISPLAYIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_displayio), (mp_obj_t)&displayio_module },
 #ifndef CIRCUITPY_DISPLAY_LIMIT
 #define CIRCUITPY_DISPLAY_LIMIT (1)
 #endif
 #else
-#define DISPLAYIO_MODULE
 #define CIRCUITPY_DISPLAY_LIMIT (0)
-#endif
-
-#if CIRCUITPY_DISPLAYIO && CIRCUITPY_TERMINALIO
-#define FONTIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_fontio), (mp_obj_t)&fontio_module },
-#define TERMINALIO_MODULE   { MP_OBJ_NEW_QSTR(MP_QSTR_terminalio), (mp_obj_t)&terminalio_module },
-#else
-#define FONTIO_MODULE
-#define TERMINALIO_MODULE
 #endif
 
 #if CIRCUITPY_DUALBANK
@@ -886,7 +877,7 @@ extern const struct _mp_obj_module_t msgpack_module;
     TIME_MODULE_ALT_NAME \
 
 // This is an inclusive list that should correspond to the CIRCUITPY_XXX list above,
-// including dependencies such as TERMINALIO depending on DISPLAYIO (shown by indentation).
+// including dependencies (shown by indentation).
 // Some of these definitions will be blank depending on what is turned on and off.
 // Some are omitted because they're in MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS above.
 #define MICROPY_PORT_BUILTIN_MODULES_STRONG_LINKS \
@@ -912,10 +903,7 @@ extern const struct _mp_obj_module_t msgpack_module;
     CANIO_MODULE \
     COUNTIO_MODULE \
     DIGITALIO_MODULE \
-    DISPLAYIO_MODULE \
     DUALBANK_MODULE \
-    FONTIO_MODULE \
-    TERMINALIO_MODULE \
     VECTORIO_MODULE \
     ERRNO_MODULE \
     ESPIDF_MODULE \

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -877,7 +877,7 @@ extern const struct _mp_obj_module_t msgpack_module;
     TIME_MODULE_ALT_NAME \
 
 // This is an inclusive list that should correspond to the CIRCUITPY_XXX list above,
-// including dependencies (shown by indentation).
+// including dependencies.
 // Some of these definitions will be blank depending on what is turned on and off.
 // Some are omitted because they're in MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS above.
 #define MICROPY_PORT_BUILTIN_MODULES_STRONG_LINKS \

--- a/shared-bindings/displayio/__init__.c
+++ b/shared-bindings/displayio/__init__.c
@@ -136,3 +136,5 @@ const mp_obj_module_t displayio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&displayio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_displayio, displayio_module, CIRCUITPY_DISPLAYIO);

--- a/shared-bindings/fontio/__init__.c
+++ b/shared-bindings/fontio/__init__.c
@@ -48,3 +48,5 @@ const mp_obj_module_t fontio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&fontio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_fontio, fontio_module, CIRCUITPY_DISPLAYIO && CIRCUITPY_TERMINALIO);

--- a/shared-bindings/terminalio/__init__.c
+++ b/shared-bindings/terminalio/__init__.c
@@ -56,3 +56,5 @@ const mp_obj_module_t terminalio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&terminalio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_terminalio, terminalio_module, CIRCUITPY_DISPLAYIO && CIRCUITPY_TERMINALIO);


### PR DESCRIPTION
Convert from using MICROPY_PORT_BUILTIN_MODULES_STRONG_LINKS to using MP_REGISTER_MODULE for displayio, terminalio, and fontio modules.

Related to #5183.