### PR TITLE
esp32s2: rework nvm/nvs storage

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1225,7 +1225,7 @@ msgstr ""
 msgid "Insufficient encryption"
 msgstr ""
 
-#: ports/raspberrypi/audio_dma.c
+#: ports/atmel-samd/audio_dma.c ports/raspberrypi/audio_dma.c
 msgid "Internal audio buffer too small"
 msgstr ""
 
@@ -1392,7 +1392,8 @@ msgstr ""
 #: ports/mimxrt10xx/common-hal/busio/SPI.c ports/nrf/common-hal/busio/I2C.c
 #: ports/raspberrypi/common-hal/busio/I2C.c
 #: ports/raspberrypi/common-hal/busio/SPI.c
-#: ports/raspberrypi/common-hal/busio/UART.c
+#: ports/raspberrypi/common-hal/busio/UART.c shared-bindings/busio/SPI.c
+#: shared-bindings/busio/UART.c
 msgid "Invalid pins"
 msgstr ""
 
@@ -3915,8 +3916,10 @@ msgstr ""
 #: ports/esp32s2/boards/adafruit_funhouse/mpconfigboard.h
 #: ports/esp32s2/boards/adafruit_magtag_2.9_grayscale/mpconfigboard.h
 #: ports/esp32s2/boards/adafruit_metro_esp32s2/mpconfigboard.h
+#: ports/esp32s2/boards/ai_thinker_esp_12k_nodemcu/mpconfigboard.h
 #: ports/esp32s2/boards/artisense_rd00/mpconfigboard.h
 #: ports/esp32s2/boards/atmegazero_esp32s2/mpconfigboard.h
+#: ports/esp32s2/boards/crumpspace_crumps2/mpconfigboard.h
 #: ports/esp32s2/boards/electroniccats_bastwifi/mpconfigboard.h
 #: ports/esp32s2/boards/espressif_kaluga_1.3/mpconfigboard.h
 #: ports/esp32s2/boards/espressif_kaluga_1/mpconfigboard.h
@@ -3933,6 +3936,7 @@ msgstr ""
 #: ports/esp32s2/boards/morpheans_morphesp-240/mpconfigboard.h
 #: ports/esp32s2/boards/muselab_nanoesp32_s2_wroom/mpconfigboard.h
 #: ports/esp32s2/boards/muselab_nanoesp32_s2_wrover/mpconfigboard.h
+#: ports/esp32s2/boards/odt_pixelwing_esp32_s2/mpconfigboard.h
 #: ports/esp32s2/boards/targett_module_clip_wroom/mpconfigboard.h
 #: ports/esp32s2/boards/targett_module_clip_wrover/mpconfigboard.h
 #: ports/esp32s2/boards/unexpectedmaker_feathers2/mpconfigboard.h

--- a/ports/esp32s2/bindings/espidf/__init__.c
+++ b/ports/esp32s2/bindings/espidf/__init__.c
@@ -26,9 +26,12 @@
 
 #include "py/obj.h"
 #include "py/runtime.h"
+#include "py/mphal.h"
+
 
 #include "bindings/espidf/__init__.h"
 
+#include "nvs_flash.h"
 #include "components/heap/include/esp_heap_caps.h"
 
 //| """Direct access to a few ESP-IDF details. This module *should not* include any functionality
@@ -64,6 +67,20 @@ STATIC mp_obj_t espidf_heap_caps_get_largest_free_block(void) {
     return MP_OBJ_NEW_SMALL_INT(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
 }
 MP_DEFINE_CONST_FUN_OBJ_0(espidf_heap_caps_get_largest_free_block_obj, espidf_heap_caps_get_largest_free_block);
+
+//| def erase_nvs() -> None:
+//|     """Erase all data in the non-volatile storage (nvs), including data stored by with `microcontroller.nvm`
+//|
+//|     This is necessary when upgrading from CircuitPython 6.3.0 or earlier to CircuitPython 7.0.0, because the
+//|     layout of data in nvs has changed. The old data will be lost when you perform this operation."""
+STATIC mp_obj_t espidf_erase_nvs(void) {
+    ESP_ERROR_CHECK(nvs_flash_deinit());
+    ESP_ERROR_CHECK(nvs_flash_erase());
+    ESP_ERROR_CHECK(nvs_flash_init());
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_0(espidf_erase_nvs_obj, espidf_erase_nvs);
+
 
 //| class IDFError(OSError):
 //|     """Raised for certain generic ESP IDF errors."""
@@ -116,6 +133,8 @@ STATIC const mp_rom_map_elem_t espidf_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_heap_caps_get_total_size), MP_ROM_PTR(&espidf_heap_caps_get_total_size_obj)},
     { MP_ROM_QSTR(MP_QSTR_heap_caps_get_free_size), MP_ROM_PTR(&espidf_heap_caps_get_free_size_obj)},
     { MP_ROM_QSTR(MP_QSTR_heap_caps_get_largest_free_block), MP_ROM_PTR(&espidf_heap_caps_get_largest_free_block_obj)},
+
+    { MP_ROM_QSTR(MP_QSTR_erase_nvs), MP_ROM_PTR(&espidf_erase_nvs_obj)},
 
     { MP_ROM_QSTR(MP_QSTR_IDFError), MP_ROM_PTR(&mp_type_espidf_IDFError) },
     { MP_ROM_QSTR(MP_QSTR_MemoryError),      MP_ROM_PTR(&mp_type_espidf_MemoryError) },

--- a/ports/esp32s2/mpconfigport.h
+++ b/ports/esp32s2/mpconfigport.h
@@ -42,8 +42,12 @@
 
 #define CIRCUITPY_INTERNAL_NVM_START_ADDR (0x9000)
 
+// 20kB is statically allocated to nvs, but when overwriting an existing
+// item, it's temporarily necessary to store both the old and new copies.
+// Additionally, there is some overhad for the names and values of items
+// in nvs. So, set the size at 9/20ths of the allocated space
 #ifndef CIRCUITPY_INTERNAL_NVM_SIZE
-#define CIRCUITPY_INTERNAL_NVM_SIZE (20 * 1024)
+#define CIRCUITPY_INTERNAL_NVM_SIZE (9 * 1024)
 #endif
 
 #endif  // __INCLUDED_ESP32S2_MPCONFIGPORT_H


### PR DESCRIPTION
Note that any data stored in nvs using 6.3.0 is not readable by 7, or vice versa.

Closes: #4030