### PR TITLE
Remove WaveFile() buffer argument

### DIFF
--- a/shared-bindings/audiocore/WaveFile.c
+++ b/shared-bindings/audiocore/WaveFile.c
@@ -37,14 +37,13 @@
 //|     """Load a wave file for audio playback
 //|
 //|     A .wav file prepped for audio playback. Only mono and stereo files are supported. Samples must
-//|     be 8 bit unsigned or 16 bit signed. If a buffer is provided, it will be used instead of allocating
-//|     an internal buffer."""
+//|     be 8 bit unsigned or 16 bit signed.
+//|     """
 //|
-//|     def __init__(self, file: typing.BinaryIO, buffer: WriteableBuffer) -> None:
+//|     def __init__(self, file: typing.BinaryIO) -> None:
 //|         """Load a .wav file for playback with `audioio.AudioOut` or `audiobusio.I2SOut`.
 //|
 //|         :param typing.BinaryIO file: Already opened wave file
-//|         :param ~_typing.WriteableBuffer buffer: Optional pre-allocated buffer, that will be split in half and used for double-buffering of the data. If not provided, two 256 byte buffers are allocated internally.
 //|
 //|
 //|         Playing a wave file from flash::
@@ -70,23 +69,14 @@
 //|         ...
 //|
 STATIC mp_obj_t audioio_wavefile_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
-    mp_arg_check_num(n_args, kw_args, 1, 2, false);
+    mp_arg_check_num(n_args, kw_args, 1, 1, false);
 
     audioio_wavefile_obj_t *self = m_new_obj(audioio_wavefile_obj_t);
     self->base.type = &audioio_wavefile_type;
     if (!mp_obj_is_type(args[0], &mp_type_fileio)) {
         mp_raise_TypeError(translate("file must be a file opened in byte mode"));
     }
-    uint8_t *buffer = NULL;
-    size_t buffer_size = 0;
-    if (n_args >= 2) {
-        mp_buffer_info_t bufinfo;
-        mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_WRITE);
-        buffer = bufinfo.buf;
-        buffer_size = bufinfo.len;
-    }
-    common_hal_audioio_wavefile_construct(self, MP_OBJ_TO_PTR(args[0]),
-        buffer, buffer_size);
+    common_hal_audioio_wavefile_construct(self, MP_OBJ_TO_PTR(args[0]));
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/audiocore/WaveFile.h
+++ b/shared-bindings/audiocore/WaveFile.h
@@ -34,8 +34,7 @@
 
 extern const mp_obj_type_t audioio_wavefile_type;
 
-void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t *self,
-    pyb_file_obj_t *file, uint8_t *buffer, size_t buffer_size);
+void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t *self, pyb_file_obj_t *file);
 
 void common_hal_audioio_wavefile_deinit(audioio_wavefile_obj_t *self);
 bool common_hal_audioio_wavefile_deinited(audioio_wavefile_obj_t *self);

--- a/shared-module/audiocore/WaveFile.c
+++ b/shared-module/audiocore/WaveFile.c
@@ -45,10 +45,7 @@ struct wave_format_chunk {
     uint16_t extra_params; // Assumed to be zero below.
 };
 
-void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t *self,
-    pyb_file_obj_t *file,
-    uint8_t *buffer,
-    size_t buffer_size) {
+void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t *self, pyb_file_obj_t *file) {
     // Load the wave
     self->file = file;
     uint8_t chunk_header[16];
@@ -112,25 +109,19 @@ void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t *self,
 
     // Try to allocate two buffers, one will be loaded from file and the other
     // DMAed to DAC.
-    if (buffer_size) {
-        self->len = buffer_size / 2;
-        self->buffer = buffer;
-        self->second_buffer = buffer + self->len;
-    } else {
-        self->len = 256;
-        self->buffer = m_malloc(self->len, false);
-        if (self->buffer == NULL) {
-            common_hal_audioio_wavefile_deinit(self);
-            mp_raise_msg(&mp_type_MemoryError,
-                translate("Couldn't allocate first buffer"));
-        }
+    self->len = 256;
+    self->buffer = m_malloc(self->len, false);
+    if (self->buffer == NULL) {
+        common_hal_audioio_wavefile_deinit(self);
+        mp_raise_msg(&mp_type_MemoryError,
+            translate("Couldn't allocate first buffer"));
+    }
 
-        self->second_buffer = m_malloc(self->len, false);
-        if (self->second_buffer == NULL) {
-            common_hal_audioio_wavefile_deinit(self);
-            mp_raise_msg(&mp_type_MemoryError,
-                translate("Couldn't allocate second buffer"));
-        }
+    self->second_buffer = m_malloc(self->len, false);
+    if (self->second_buffer == NULL) {
+        common_hal_audioio_wavefile_deinit(self);
+        mp_raise_msg(&mp_type_MemoryError,
+            translate("Couldn't allocate second buffer"));
     }
 }
 


### PR DESCRIPTION
- Fixes #5167 by defining away the problem.

This error is about supplying an optional buffer that's split into two for reading WaveFiles, but those buffers is not used for playing unless no conversion is done. Propagating the buffer sizes through is not so easy, and there are some assumptions about using 512-byte buffers. Given that audio is working better, I don't really see a use case for it right now.

The `buffer` arg is not used by any Learn Guide or library examples.

In the long run, we may be revamping the audio API anyway.