### PR TITLE
restrict WaveFile buffer size to 8-1024

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -103,7 +103,7 @@ msgid "%q indices must be integers, not %s"
 msgstr ""
 
 #: py/argcheck.c
-msgid "%q length must be %q"
+msgid "%q length must be %d-%d"
 msgstr ""
 
 #: shared-bindings/usb_hid/Device.c

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -195,11 +195,11 @@ mp_float_t mp_arg_validate_obj_float_non_negative(mp_obj_t float_in, mp_float_t 
     return f;
 }
 
-size_t mp_arg_validate_length_with_name(mp_int_t i, size_t length, qstr arg_name, qstr length_name) {
-    if (i != (mp_int_t)length) {
-        mp_raise_ValueError_varg(translate("%q length must be %q"), arg_name, length_name);
+mp_uint_t mp_arg_validate_length_range(mp_uint_t length, mp_uint_t min, mp_uint_t max, qstr arg_name) {
+    if (length < min || length > max) {
+        mp_raise_ValueError_varg(translate("%q length must be %d-%d"), arg_name, min, max);
     }
-    return (size_t)i;
+    return length;
 }
 
 mp_obj_t mp_arg_validate_type(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name) {

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -95,7 +95,7 @@ mp_int_t mp_arg_validate_int_min(mp_int_t i, mp_int_t min, qstr arg_name);
 mp_int_t mp_arg_validate_int_max(mp_int_t i, mp_int_t j, qstr arg_name);
 mp_int_t mp_arg_validate_int_range(mp_int_t i, mp_int_t min, mp_int_t max, qstr arg_name);
 mp_float_t mp_arg_validate_obj_float_non_negative(mp_obj_t float_in, mp_float_t default_for_null, qstr arg_name);
-size_t mp_arg_validate_length_with_name(mp_int_t i, size_t length, qstr arg_name, qstr length_name);
+mp_uint_t mp_arg_validate_length_range(mp_uint_t length, mp_uint_t min, mp_uint_t max, qstr arg_name);
 mp_obj_t mp_arg_validate_type(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name);
 mp_obj_t mp_arg_validate_string(mp_obj_t obj, qstr arg_name);
 

--- a/shared-bindings/audiocore/WaveFile.c
+++ b/shared-bindings/audiocore/WaveFile.c
@@ -38,13 +38,16 @@
 //|
 //|     A .wav file prepped for audio playback. Only mono and stereo files are supported. Samples must
 //|     be 8 bit unsigned or 16 bit signed. If a buffer is provided, it will be used instead of allocating
-//|     an internal buffer."""
+//|     an internal buffer, which can prevent memory fragmentation."""
 //|
 //|     def __init__(self, file: typing.BinaryIO, buffer: WriteableBuffer) -> None:
 //|         """Load a .wav file for playback with `audioio.AudioOut` or `audiobusio.I2SOut`.
 //|
 //|         :param typing.BinaryIO file: Already opened wave file
-//|         :param ~_typing.WriteableBuffer buffer: Optional pre-allocated buffer, that will be split in half and used for double-buffering of the data. If not provided, two 256 byte buffers are allocated internally.
+//|         :param ~_typing.WriteableBuffer buffer: Optional pre-allocated buffer,
+//|           that will be split in half and used for double-buffering of the data.
+//|           The buffer must be 8 to 1024 bytes long.
+//|           If not provided, two 256 byte buffers are initially allocated internally.
 //|
 //|
 //|         Playing a wave file from flash::
@@ -83,7 +86,7 @@ STATIC mp_obj_t audioio_wavefile_make_new(const mp_obj_type_t *type, size_t n_ar
         mp_buffer_info_t bufinfo;
         mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_WRITE);
         buffer = bufinfo.buf;
-        buffer_size = bufinfo.len;
+        buffer_size = mp_arg_validate_length_range(bufinfo.len, 8, 1024, MP_QSTR_buffer);
     }
     common_hal_audioio_wavefile_construct(self, MP_OBJ_TO_PTR(args[0]),
         buffer, buffer_size);


### PR DESCRIPTION
- Fixes #5167

Validate that the optional `WaveFile` constructor `buffer` argument is 8-1024 bytes long. Larger than 1024 does not work and will not improve performance anyway. 8 was empirically determined to be the lowest usable bound for a MacroPad.

As part of this, I added a new `argcheck.c` arg validator, and removed an unused one. The new validator could be used a few other places, but I'll defer doing that now since we are working on more general arg validation schemes. I didn't see any small builds that might benefit from the new validator.

I tested the range checking in the REPL.