### PR TITLE
Convert more modules to use MP_REGISTER_MODULE

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -280,19 +280,8 @@ extern const struct _mp_obj_module_t audiopwmio_module;
 #define BINASCII_MODULE
 #endif
 
-#if CIRCUITPY_BITBANGIO
-#define BITBANGIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_bitbangio), (mp_obj_t)&bitbangio_module },
-extern const struct _mp_obj_module_t bitbangio_module;
-#else
-#define BITBANGIO_MODULE
-#endif
-
-#if CIRCUITPY_BITMAPTOOLS
-#define BITMAPTOOLS_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_bitmaptools), (mp_obj_t)&bitmaptools_module },
-extern const struct _mp_obj_module_t bitmaptools_module;
-#else
-#define BITMAPTOOLS_MODULE
-#endif
+// CIRCUITPY_BITBANGIO uses MP_REGISTER_MODULE
+// CIRCUITPY_BITMAPTOOLS uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_BITOPS
 extern const struct _mp_obj_module_t bitops_module;
@@ -301,17 +290,10 @@ extern const struct _mp_obj_module_t bitops_module;
 #define BITOPS_MODULE
 #endif
 
-#if CIRCUITPY_BLEIO
-#define BLEIO_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR__bleio), (mp_obj_t)&bleio_module },
-extern const struct _mp_obj_module_t bleio_module;
-#else
-#define BLEIO_MODULE
-#endif
+// CIRCUITPY_BLEIO uses MP_REGISTER_MODULE
+// CIRCUITPY_BOARD uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_BOARD
-#define BOARD_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_board), (mp_obj_t)&board_module },
-extern const struct _mp_obj_module_t board_module;
-
 #define BOARD_I2C (defined(DEFAULT_I2C_BUS_SDA) && defined(DEFAULT_I2C_BUS_SCL))
 #define BOARD_SPI (defined(DEFAULT_SPI_BUS_SCK) && defined(DEFAULT_SPI_BUS_MISO) && defined(DEFAULT_SPI_BUS_MOSI))
 #define BOARD_UART (defined(DEFAULT_UART_BUS_RX) && defined(DEFAULT_UART_BUS_TX))
@@ -325,18 +307,11 @@ extern const struct _mp_obj_module_t board_module;
 #endif
 
 #else
-#define BOARD_MODULE
 #define BOARD_UART_ROOT_POINTER
 #endif
 
 // CIRCUITPY_BUSDEVICE (adafruit_bus_device_module) uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_BUSIO
-extern const struct _mp_obj_module_t busio_module;
-#define BUSIO_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_busio), (mp_obj_t)&busio_module },
-#else
-#define BUSIO_MODULE
-#endif
+// CIRCUITPY_BUSIO uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_CAMERA
 extern const struct _mp_obj_module_t camera_module;
@@ -352,20 +327,8 @@ extern const struct _mp_obj_module_t canio_module;
 #define CANIO_MODULE
 #endif
 
-#if CIRCUITPY_COUNTIO
-extern const struct _mp_obj_module_t countio_module;
-#define COUNTIO_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR_countio), (mp_obj_t)&countio_module },
-#else
-#define COUNTIO_MODULE
-#endif
-
-#if CIRCUITPY_DIGITALIO
-extern const struct _mp_obj_module_t digitalio_module;
-#define DIGITALIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_digitalio), (mp_obj_t)&digitalio_module },
-#else
-#define DIGITALIO_MODULE
-#endif
-
+// CIRCUITPY_COUNTIO uses MP_REGISTER_MODULE
+// CIRCUITPY_DIGITALIO uses MP_REGISTER_MODULE
 // CIRCUITPY_DISPLAYIO uses MP_REGISTER_MODULE
 // CIRCUITPY_TERMINALIO uses MP_REGISTER_MODULE
 // CIRCUITPY_FONTIO uses MP_REGISTER_MODULE
@@ -409,12 +372,7 @@ extern const struct _mp_obj_module_t _eve_module;
 #define _EVE_MODULE
 #endif
 
-#if CIRCUITPY_FRAMEBUFFERIO
-extern const struct _mp_obj_module_t framebufferio_module;
-#define FRAMEBUFFERIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_framebufferio), (mp_obj_t)&framebufferio_module },
-#else
-#define FRAMEBUFFERIO_MODULE
-#endif
+// CIRCUITPY_FRAMEBUFFERIO uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_VECTORIO
 extern const struct _mp_obj_module_t vectorio_module;
@@ -423,19 +381,8 @@ extern const struct _mp_obj_module_t vectorio_module;
 #define VECTORIO_MODULE
 #endif
 
-#if CIRCUITPY_FREQUENCYIO
-extern const struct _mp_obj_module_t frequencyio_module;
-#define FREQUENCYIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_frequencyio), (mp_obj_t)&frequencyio_module },
-#else
-#define FREQUENCYIO_MODULE
-#endif
-
-#if CIRCUITPY_GAMEPADSHIFT
-extern const struct _mp_obj_module_t gamepadshift_module;
-#define GAMEPADSHIFT_MODULE         { MP_OBJ_NEW_QSTR(MP_QSTR_gamepadshift),(mp_obj_t)&gamepadshift_module },
-#else
-#define GAMEPADSHIFT_MODULE
-#endif
+// CIRCUITPY_FREQUENCYIO uses MP_REGISTER_MODULE
+// CIRCUITPY_GAMEPADSHIFT uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_GAMEPADSHIFT
 // Scan gamepad every 32ms
@@ -445,12 +392,7 @@ extern const struct _mp_obj_module_t gamepadshift_module;
 #define GAMEPAD_ROOT_POINTERS
 #endif
 
-#if CIRCUITPY_GETPASS
-extern const struct _mp_obj_module_t getpass_module;
-#define GETPASS_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_getpass), (mp_obj_t)&getpass_module },
-#else
-#define GETPASS_MODULE
-#endif
+// CIRCUITPY_GETPASS uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_GNSS
 extern const struct _mp_obj_module_t gnss_module;
@@ -492,29 +434,15 @@ extern const struct _mp_obj_module_t ipaddress_module;
 #define JSON_MODULE
 #endif
 
+// CIRCUITPY_KEYPAD uses MP_REGISTER_MODULE
+
 #if CIRCUITPY_KEYPAD
-extern const struct _mp_obj_module_t keypad_module;
-#define KEYPAD_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR_keypad), (mp_obj_t)&keypad_module },
 #define KEYPAD_ROOT_POINTERS mp_obj_t keypad_scanners_linked_list;
 #else
-#define KEYPAD_MODULE
 #define KEYPAD_ROOT_POINTERS
 #endif
 
-#if CIRCUITPY_GAMEPADSHIFT
-// Scan gamepadshift every 32ms
-#define CIRCUITPY_GAMEPAD_TICKS 0x1f
-#define GAMEPAD_ROOT_POINTERS mp_obj_t gamepad_singleton;
-#else
-#define GAMEPAD_ROOT_POINTERS
-#endif
-
-#if CIRCUITPY_MATH
-extern const struct _mp_obj_module_t math_module;
-#define MATH_MODULE            { MP_OBJ_NEW_QSTR(MP_QSTR_math), (mp_obj_t)&math_module },
-#else
-#define MATH_MODULE
-#endif
+// CIRCUITPY_MATH uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_MEMORYMONITOR
 extern const struct _mp_obj_module_t memorymonitor_module;
@@ -526,12 +454,7 @@ extern const struct _mp_obj_module_t memorymonitor_module;
 #define MEMORYMONITOR_ROOT_POINTERS
 #endif
 
-#if CIRCUITPY_MICROCONTROLLER
-extern const struct _mp_obj_module_t microcontroller_module;
-#define MICROCONTROLLER_MODULE { MP_OBJ_NEW_QSTR(MP_QSTR_microcontroller), (mp_obj_t)&microcontroller_module },
-#else
-#define MICROCONTROLLER_MODULE
-#endif
+// CIRCUITPY_MICROCONTROLLER uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_NEOPIXEL_WRITE
 extern const struct _mp_obj_module_t neopixel_write_module;
@@ -803,12 +726,7 @@ extern const struct _mp_obj_module_t wifi_module;
 #define WIFI_MODULE
 #endif
 
-#if CIRCUITPY_MSGPACK
-extern const struct _mp_obj_module_t msgpack_module;
-#define MSGPACK_MODULE { MP_ROM_QSTR(MP_QSTR_msgpack), MP_ROM_PTR(&msgpack_module) },
-#else
-#define MSGPACK_MODULE
-#endif
+// CIRCUITPY_MSGPACK uses MP_REGISTER_MODULE
 
 // Define certain native modules with weak links so they can be replaced with Python
 // implementations. This list may grow over time.
@@ -833,35 +751,20 @@ extern const struct _mp_obj_module_t msgpack_module;
     ALARM_MODULE \
     AUDIOPWMIO_MODULE \
     BINASCII_MODULE \
-    BITBANGIO_MODULE \
-    BITMAPTOOLS_MODULE \
     BITOPS_MODULE \
-    BLEIO_MODULE \
-    BOARD_MODULE \
-    BUSIO_MODULE \
     CAMERA_MODULE \
     CANIO_MODULE \
-    COUNTIO_MODULE \
-    DIGITALIO_MODULE \
     DUALBANK_MODULE \
     VECTORIO_MODULE \
     ERRNO_MODULE \
     ESPIDF_MODULE \
     _EVE_MODULE \
-    FRAMEBUFFERIO_MODULE \
-    FREQUENCYIO_MODULE \
-    GAMEPADSHIFT_MODULE \
-    GETPASS_MODULE \
     GNSS_MODULE \
     I2CPERIPHERAL_MODULE \
     IPADDRESS_MODULE \
     IMAGECAPTURE_MODULE \
     JSON_MODULE \
-    KEYPAD_MODULE \
-    MATH_MODULE \
     MEMORYMONITOR_MODULE \
-    MICROCONTROLLER_MODULE \
-    MSGPACK_MODULE \
     NEOPIXEL_WRITE_MODULE \
     ONEWIREIO_MODULE \
     PEW_MODULE \

--- a/shared-bindings/_bleio/__init__.c
+++ b/shared-bindings/_bleio/__init__.c
@@ -201,3 +201,5 @@ const mp_obj_module_t bleio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&bleio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR__bleio, bleio_module, CIRCUITPY_BLEIO);

--- a/shared-bindings/bitbangio/__init__.c
+++ b/shared-bindings/bitbangio/__init__.c
@@ -84,3 +84,5 @@ const mp_obj_module_t bitbangio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&bitbangio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_bitbangio, bitbangio_module, CIRCUITPY_BITBANGIO);

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -578,6 +578,7 @@ STATIC mp_obj_t bitmaptools_readinto(size_t n_args, const mp_obj_t *pos_args, mp
 MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_readinto_obj, 0, bitmaptools_readinto);
 
 STATIC const mp_rom_map_elem_t bitmaptools_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_bitmaptools) },
     { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&bitmaptools_readinto_obj) },
     { MP_ROM_QSTR(MP_QSTR_rotozoom), MP_ROM_PTR(&bitmaptools_rotozoom_obj) },
     { MP_ROM_QSTR(MP_QSTR_arrayblit), MP_ROM_PTR(&bitmaptools_arrayblit_obj) },
@@ -591,3 +592,5 @@ const mp_obj_module_t bitmaptools_module = {
     .base = {&mp_type_module },
     .globals = (mp_obj_dict_t *)&bitmaptools_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_bitmaptools, bitmaptools_module, CIRCUITPY_BITMAPTOOLS);

--- a/shared-bindings/board/__init__.c
+++ b/shared-bindings/board/__init__.c
@@ -124,3 +124,5 @@ const mp_obj_module_t board_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&board_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_board, board_module, CIRCUITPY_BOARD);

--- a/shared-bindings/busio/__init__.c
+++ b/shared-bindings/busio/__init__.c
@@ -85,3 +85,5 @@ const mp_obj_module_t busio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&busio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_busio, busio_module, CIRCUITPY_BUSIO);

--- a/shared-bindings/countio/__init__.c
+++ b/shared-bindings/countio/__init__.c
@@ -34,3 +34,5 @@ const mp_obj_module_t countio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&countio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_countio, countio_module, CIRCUITPY_COUNTIO);

--- a/shared-bindings/digitalio/__init__.c
+++ b/shared-bindings/digitalio/__init__.c
@@ -90,3 +90,5 @@ const mp_obj_module_t digitalio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&digitalio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_digitalio, digitalio_module, CIRCUITPY_DIGITALIO);

--- a/shared-bindings/framebufferio/__init__.c
+++ b/shared-bindings/framebufferio/__init__.c
@@ -42,9 +42,13 @@ static const mp_rom_map_elem_t framebufferio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_framebufferio) },
     { MP_ROM_QSTR(MP_QSTR_FramebufferDisplay), MP_ROM_PTR(&framebufferio_framebufferdisplay_type) },
 };
+
 STATIC MP_DEFINE_CONST_DICT(framebufferio_module_globals, framebufferio_module_globals_table);
+
 const mp_obj_module_t framebufferio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&framebufferio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_framebufferio, framebufferio_module, CIRCUITPY_FRAMEBUFFERIO);
 #endif

--- a/shared-bindings/frequencyio/__init__.c
+++ b/shared-bindings/frequencyio/__init__.c
@@ -72,3 +72,5 @@ const mp_obj_module_t frequencyio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&frequencyio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_frequencyio, frequencyio_module, CIRCUITPY_FREQUENCYIO);

--- a/shared-bindings/gamepadshift/__init__.c
+++ b/shared-bindings/gamepadshift/__init__.c
@@ -40,9 +40,12 @@ STATIC const mp_rom_map_elem_t gamepadshift_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_gamepadshift) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_GamePadShift),  MP_ROM_PTR(&gamepadshift_type)},
 };
+
 STATIC MP_DEFINE_CONST_DICT(gamepadshift_module_globals, gamepadshift_module_globals_table);
 
 const mp_obj_module_t gamepadshift_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&gamepadshift_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_gamepadshift, gamepadshift_module, CIRCUITPY_GAMEPADSHIFT);

--- a/shared-bindings/getpass/__init__.c
+++ b/shared-bindings/getpass/__init__.c
@@ -84,3 +84,5 @@ const mp_obj_module_t getpass_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&getpass_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_getpass, getpass_module, CIRCUITPY_GETPASS);

--- a/shared-bindings/keypad/__init__.c
+++ b/shared-bindings/keypad/__init__.c
@@ -57,3 +57,5 @@ const mp_obj_module_t keypad_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&keypad_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_keypad, keypad_module, CIRCUITPY_KEYPAD);

--- a/shared-bindings/math/__init__.c
+++ b/shared-bindings/math/__init__.c
@@ -427,4 +427,6 @@ const mp_obj_module_t math_module = {
     .globals = (mp_obj_dict_t *)&mp_module_math_globals,
 };
 
-#endif // MICROPY_PY_BUILTINS_FLOAT && MICROPY_PY_MATH
+MP_REGISTER_MODULE(MP_QSTR_math, math_module, CIRCUITPY_MATH);
+
+#endif // MICROPY_PY_BUILTINS_FLOAT

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -193,3 +193,5 @@ const mp_obj_module_t microcontroller_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&mcu_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_microcontroller, microcontroller_module, CIRCUITPY_MICROCONTROLLER);

--- a/shared-bindings/msgpack/__init__.c
+++ b/shared-bindings/msgpack/__init__.c
@@ -160,3 +160,5 @@ const mp_obj_module_t msgpack_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&msgpack_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_msgpack, msgpack_module, CIRCUITPY_MSGPACK);


### PR DESCRIPTION
Convert bitbangio, bitmaptools, _bleio, board, busio, countio, digitalio, framebufferio, frequencyio, gamepadshift, getpass, keypad, math, microcontroller, and msgpack modules to use MP_REGISTER_MODULE.

Related to #5183.