### PR TITLE
Stop StateMachine explicitly on deinit

### DIFF
--- a/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
@@ -91,8 +91,6 @@ void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencode
         false, // Wait for txstall
         false, 32, false); // in settings
 
-    common_hal_rp2pio_statemachine_run(&self->state_machine, encoder_init, MP_ARRAY_SIZE(encoder_init));
-
     // We're guaranteed by the init code that some output will be available promptly
     uint8_t quiescent_state;
     common_hal_rp2pio_statemachine_readinto(&self->state_machine, &quiescent_state, 1, 1);

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -553,6 +553,8 @@ void common_hal_rp2pio_statemachine_set_frequency(rp2pio_statemachine_obj_t *sel
 }
 
 void rp2pio_statemachine_deinit(rp2pio_statemachine_obj_t *self, bool leave_pins) {
+    common_hal_rp2pio_statemachine_stop(self);
+
     uint8_t sm = self->state_machine;
     uint8_t pio_index = pio_get_index(self->pio);
     common_hal_mcu_disable_interrupts();


### PR DESCRIPTION
- Fixes #5150.

- Explicitly stop the PIO `StateMachine` before deiniting it.
- Also minor fix: Don't run the `encoder_init` PIO program twice.


PIO is new to me, so a few notes about this:

- The `IncrementalEncoder` `StateMachine` is created with `common_hal_rp2pio_statemachine_construct()`, while the `neopixel_write()` one uses the more basic `rp2pio_statemachine_construct()`. I don't know if `IncrementalEncoder` should use the latter or not, so I left it alone.
- The `IncrementalEncoder` runs the `encoder_init` PIO program explicitly after constructing the StateMachine, but the `StateMachine` runs `encoder_init` itself because it's supplied in the `StateMachine` constructor. So I removed the explicit run.
- In the `StateMachine` constructor, the `init` program, if any, is run before setting the frequency to the given value. I think this is OK but I am not sure it is the correct thing in general.

Tested with @Neradoc's simple test program, which reliably reproduced the #5150 issue for me:
```py
import board, neopixel, rotaryio, time

pix = neopixel.NeoPixel(board.NEOPIXEL, 12)
encoder = rotaryio.IncrementalEncoder(board.ROTA, board.ROTB)
pix.fill(0x0000FF)
time.sleep(2)
encoder.deinit()
pix.fill(0x00FF00)
time.sleep(2)
```