### PR TITLE
stm32: Add support for Stage games to Meowbit

### DIFF
--- a/ports/stm/boards/meowbit_v121/board.c
+++ b/ports/stm/boards/meowbit_v121/board.c
@@ -53,7 +53,7 @@ uint8_t display_init_sequence[] = {
     0xc4, 2, 0x8a, 0xee,
     0xc5, 1, 0x0e,     // _VMCTR1 VCOMH = 4V, VOML = -1.1V
     0x20, 0,     // _INVOFF //MISMATCh 0x2a vs 0x20
-    0x36, 1, 0x18,     // _MADCTL bottom to top refresh
+    0x36, 1, 0x60,     // _MADCTL bottom to top refresh
     // 1 clk cycle nonoverlap, 2 cycle gate rise, 3 sycle osc equalie,
     // fix on VTL
     0x3a, 1, 0x05,     // COLMOD - 16bit color
@@ -90,7 +90,7 @@ void board_init(void) {
         128, // Height
         0, // column start
         0, // row start
-        90, // rotation
+        0, // rotation
         16, // Color depth
         false, // Grayscale
         false, // Pixels in a byte share a row. Only used for depth < 8

--- a/ports/stm/boards/meowbit_v121/mpconfigboard.mk
+++ b/ports/stm/boards/meowbit_v121/mpconfigboard.mk
@@ -22,3 +22,6 @@ LD_FILE = boards/STM32F401xe_boot.ld
 
 CIRCUITPY_BLEIO_HCI = 0
 CIRCUITPY_ULAB = 0
+CIRCUITPY_STAGE = 1
+
+FROZEN_MPY_DIRS += $(TOP)/frozen/circuitpython-stage/meowbit


### PR DESCRIPTION
This enables the _stage library and adds stage and ugame modules to the
frozen modules, so that all Stage games should work.

I had to do several hacks:

* Since displayio.release_displays doesn't release the pins, I couldn't
  re-initialize the display inside the ugame module. Instead I changed
  the default display initialization for the board to match what Stage
  expects. (see https://github.com/adafruit/circuitpython/issues/3873)

* I wanted to make the MENU key works as K_Z, but when I try to use it
  with the keypad module, I get "pin in use" error. So for now only the
  A and B buttons are used.