### PR TITLE
Add a flag to skip waiting for safe mode

### DIFF
--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -66,6 +66,9 @@ safe_mode_t wait_for_safe_mode_reset(void) {
         reset_reason != RESET_REASON_SOFTWARE) {
         return NO_SAFE_MODE;
     }
+    #ifdef CIRCUITPY_SKIP_SAFE_MODE_WAIT
+    return NO_SAFE_MODE;
+    #endif
     port_set_saved_word(SAFE_MODE_DATA_GUARD | (MANUAL_SAFE_MODE << 8));
     // Wait for a while to allow for reset.
 


### PR DESCRIPTION
Sometimes we don't want the delay in the device's startup.

I used a simple flag, but now it also occurs to me that we could
instead make the wait time a define, and set it to 0 to disable it.