### PR TITLE
Convert more modules to use MP_REGISTER_MODULE

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -374,13 +374,7 @@ extern const struct _mp_obj_module_t _eve_module;
 #endif
 
 // CIRCUITPY_FRAMEBUFFERIO uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_VECTORIO
-extern const struct _mp_obj_module_t vectorio_module;
-#define VECTORIO_MODULE { MP_OBJ_NEW_QSTR(MP_QSTR_vectorio), (mp_obj_t)&vectorio_module },
-#else
-#define VECTORIO_MODULE
-#endif
+// CIRCUITPY_VECTORIO uses MP_REGISTER_MODULE
 
 // CIRCUITPY_FREQUENCYIO uses MP_REGISTER_MODULE
 // CIRCUITPY_GAMEPADSHIFT uses MP_REGISTER_MODULE
@@ -456,25 +450,14 @@ extern const struct _mp_obj_module_t memorymonitor_module;
 #endif
 
 // CIRCUITPY_MICROCONTROLLER uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_NEOPIXEL_WRITE
-extern const struct _mp_obj_module_t neopixel_write_module;
-#define NEOPIXEL_WRITE_MODULE  { MP_OBJ_NEW_QSTR(MP_QSTR_neopixel_write),(mp_obj_t)&neopixel_write_module },
-#else
-#define NEOPIXEL_WRITE_MODULE
-#endif
+// CIRCUITPY_NEOPIXEL_WRITE uses MP_REGISTER_MODULE
 
 // This is not a top-level module; it's microcontroller.nvm.
 #if CIRCUITPY_NVM
 extern const struct _mp_obj_module_t nvm_module;
 #endif
 
-#if CIRCUITPY_ONEWIREIO
-extern const struct _mp_obj_module_t onewireio_module;
-#define ONEWIREIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_onewireio), (mp_obj_t)&onewireio_module },
-#else
-#define ONEWIREIO_MODULE
-#endif
+// CIRCUITPY_ONEWIREIO_WRITE uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_OS
 extern const struct _mp_obj_module_t os_module;
@@ -493,43 +476,12 @@ extern const struct _mp_obj_module_t pew_module;
 #endif
 
 // CIRCUITPY_PIXELBUF (pixelbuf_module) uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_PS2IO
-extern const struct _mp_obj_module_t ps2io_module;
-#define PS2IO_MODULE         { MP_OBJ_NEW_QSTR(MP_QSTR_ps2io), (mp_obj_t)&ps2io_module },
-#else
-#define PS2IO_MODULE
-#endif
-
-#if CIRCUITPY_PULSEIO
-extern const struct _mp_obj_module_t pulseio_module;
-#define PULSEIO_MODULE         { MP_OBJ_NEW_QSTR(MP_QSTR_pulseio), (mp_obj_t)&pulseio_module },
-#else
-#define PULSEIO_MODULE
-#endif
-
-#if CIRCUITPY_PWMIO
-extern const struct _mp_obj_module_t pwmio_module;
-#define PWMIO_MODULE         { MP_OBJ_NEW_QSTR(MP_QSTR_pwmio), (mp_obj_t)&pwmio_module },
-#else
-#define PWMIO_MODULE
-#endif
-
+// CIRCUITPY_PS2IO uses MP_REGISTER_MODULE
+// CIRCUITPY_PULSEIO uses MP_REGISTER_MODULE
+// CIRCUITPY_PWMIO uses MP_REGISTER_MODULE
 // CIRCUITPY_QRIO uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_RAINBOWIO
-extern const struct _mp_obj_module_t rainbowio_module;
-#define RAINBOWIO_MODULE            { MP_OBJ_NEW_QSTR(MP_QSTR_rainbowio), (mp_obj_t)&rainbowio_module },
-#else
-#define RAINBOWIO_MODULE
-#endif
-
-#if CIRCUITPY_RANDOM
-extern const struct _mp_obj_module_t random_module;
-#define RANDOM_MODULE          { MP_OBJ_NEW_QSTR(MP_QSTR_random), (mp_obj_t)&random_module },
-#else
-#define RANDOM_MODULE
-#endif
+// CIRCUITPY_RAINBOWIO uses MP_REGISTER_MODULE
+// CIRCUITPY_RANDOM uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_RE
 #define MICROPY_PY_URE (1)
@@ -538,19 +490,8 @@ extern const struct _mp_obj_module_t random_module;
 #define RE_MODULE
 #endif
 
-#if CIRCUITPY_RGBMATRIX
-extern const struct _mp_obj_module_t rgbmatrix_module;
-#define RGBMATRIX_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR_rgbmatrix),(mp_obj_t)&rgbmatrix_module },
-#else
-#define RGBMATRIX_MODULE
-#endif
-
-#if CIRCUITPY_ROTARYIO
-extern const struct _mp_obj_module_t rotaryio_module;
-#define ROTARYIO_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR_rotaryio), (mp_obj_t)&rotaryio_module },
-#else
-#define ROTARYIO_MODULE
-#endif
+// CIRCUITPY_RGBMATRIX uses MP_REGISTER_MODULE
+// CIRCUITPY_ROTARYIO uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_RP2PIO
 extern const struct _mp_obj_module_t rp2pio_module;
@@ -559,12 +500,7 @@ extern const struct _mp_obj_module_t rp2pio_module;
 #define RP2PIO_MODULE
 #endif
 
-#if CIRCUITPY_RTC
-extern const struct _mp_obj_module_t rtc_module;
-#define RTC_MODULE             { MP_OBJ_NEW_QSTR(MP_QSTR_rtc), (mp_obj_t)&rtc_module },
-#else
-#define RTC_MODULE
-#endif
+// CIRCUITPY_RTC uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_SAMD
 extern const struct _mp_obj_module_t samd_module;
@@ -573,12 +509,7 @@ extern const struct _mp_obj_module_t samd_module;
 #define SAMD_MODULE
 #endif
 
-#if CIRCUITPY_SDCARDIO
-extern const struct _mp_obj_module_t sdcardio_module;
-#define SDCARDIO_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_sdcardio), (mp_obj_t)&sdcardio_module },
-#else
-#define SDCARDIO_MODULE
-#endif
+// CIRCUITPY_SDCARDIO uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_SDIOIO
 extern const struct _mp_obj_module_t sdioio_module;
@@ -587,12 +518,7 @@ extern const struct _mp_obj_module_t sdioio_module;
 #define SDIOIO_MODULE
 #endif
 
-#if CIRCUITPY_SHARPDISPLAY
-extern const struct _mp_obj_module_t sharpdisplay_module;
-#define SHARPDISPLAY_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR_sharpdisplay),(mp_obj_t)&sharpdisplay_module },
-#else
-#define SHARPDISPLAY_MODULE
-#endif
+// CIRCUITPY_SHARPDISPLAY uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_SOCKETPOOL
 extern const struct _mp_obj_module_t socketpool_module;
@@ -608,40 +534,11 @@ extern const struct _mp_obj_module_t ssl_module;
 #define SSL_MODULE
 #endif
 
-#if CIRCUITPY_STAGE
-extern const struct _mp_obj_module_t stage_module;
-#define STAGE_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR__stage), (mp_obj_t)&stage_module },
-#else
-#define STAGE_MODULE
-#endif
-
-#if CIRCUITPY_STORAGE
-extern const struct _mp_obj_module_t storage_module;
-#define STORAGE_MODULE         { MP_OBJ_NEW_QSTR(MP_QSTR_storage), (mp_obj_t)&storage_module },
-#else
-#define STORAGE_MODULE
-#endif
-
-#if CIRCUITPY_STRUCT
-extern const struct _mp_obj_module_t struct_module;
-#define STRUCT_MODULE          { MP_OBJ_NEW_QSTR(MP_QSTR_struct), (mp_obj_t)&struct_module },
-#else
-#define STRUCT_MODULE
-#endif
-
-#if CIRCUITPY_SUPERVISOR
-extern const struct _mp_obj_module_t supervisor_module;
-#define SUPERVISOR_MODULE      { MP_OBJ_NEW_QSTR(MP_QSTR_supervisor), (mp_obj_t)&supervisor_module },
-#else
-#define SUPERVISOR_MODULE
-#endif
-
-#if CIRCUITPY_SYNTHIO
-#define SYNTHIO_MODULE         { MP_OBJ_NEW_QSTR(MP_QSTR_synthio), (mp_obj_t)&synthio_module },
-extern const struct _mp_obj_module_t synthio_module;
-#else
-#define SYNTHIO_MODULE
-#endif
+// CIRCUITPY_STAGE uses MP_REGISTER_MODULE
+// CIRCUITPY_STORAGE uses MP_REGISTER_MODULE
+// CIRCUITPY_STRUCT uses MP_REGISTER_MODULE
+// CIRCUITPY_SUPERVISOR uses MP_REGISTER_MODULE
+// CIRCUITPY_SYNTHIO uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_TIME
 extern const struct _mp_obj_module_t time_module;
@@ -652,19 +549,8 @@ extern const struct _mp_obj_module_t time_module;
 #define TIME_MODULE_ALT_NAME
 #endif
 
-#if CIRCUITPY_TOUCHIO
-extern const struct _mp_obj_module_t touchio_module;
-#define TOUCHIO_MODULE         { MP_OBJ_NEW_QSTR(MP_QSTR_touchio), (mp_obj_t)&touchio_module },
-#else
-#define TOUCHIO_MODULE
-#endif
-
-#if CIRCUITPY_TRACEBACK
-extern const struct _mp_obj_module_t traceback_module;
-#define TRACEBACK_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_traceback), (mp_obj_t)&traceback_module },
-#else
-#define TRACEBACK_MODULE
-#endif
+// CIRCUITPY_TOUCHIO uses MP_REGISTER_MODULE
+// CIRCUITPY_TRACEBACK uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_UHEAP
 extern const struct _mp_obj_module_t uheap_module;
@@ -673,26 +559,9 @@ extern const struct _mp_obj_module_t uheap_module;
 #define UHEAP_MODULE
 #endif
 
-#if CIRCUITPY_USB_CDC
-extern const struct _mp_obj_module_t usb_cdc_module;
-#define USB_CDC_MODULE         { MP_OBJ_NEW_QSTR(MP_QSTR_usb_cdc),(mp_obj_t)&usb_cdc_module },
-#else
-#define USB_CDC_MODULE
-#endif
-
-#if CIRCUITPY_USB_HID
-extern const struct _mp_obj_module_t usb_hid_module;
-#define USB_HID_MODULE         { MP_OBJ_NEW_QSTR(MP_QSTR_usb_hid),(mp_obj_t)&usb_hid_module },
-#else
-#define USB_HID_MODULE
-#endif
-
-#if CIRCUITPY_USB_MIDI
-extern const struct _mp_obj_module_t usb_midi_module;
-#define USB_MIDI_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR_usb_midi),(mp_obj_t)&usb_midi_module },
-#else
-#define USB_MIDI_MODULE
-#endif
+// CIRCUITPY_USB_CDC uses MP_REGISTER_MODULE
+// CIRCUITPY_USB_HID uses MP_REGISTER_MODULE
+// CIRCUITPY_USB_MIDI uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_USTACK
 extern const struct _mp_obj_module_t ustack_module;
@@ -756,7 +625,6 @@ extern const struct _mp_obj_module_t wifi_module;
     CAMERA_MODULE \
     CANIO_MODULE \
     DUALBANK_MODULE \
-    VECTORIO_MODULE \
     ERRNO_MODULE \
     ESPIDF_MODULE \
     _EVE_MODULE \
@@ -766,36 +634,14 @@ extern const struct _mp_obj_module_t wifi_module;
     IMAGECAPTURE_MODULE \
     JSON_MODULE \
     MEMORYMONITOR_MODULE \
-    NEOPIXEL_WRITE_MODULE \
-    ONEWIREIO_MODULE \
     PEW_MODULE \
-    PS2IO_MODULE \
-    PULSEIO_MODULE \
-    PWMIO_MODULE \
-    RAINBOWIO_MODULE \
-    RANDOM_MODULE \
     RE_MODULE \
-    RGBMATRIX_MODULE \
-    ROTARYIO_MODULE \
     RP2PIO_MODULE \
-    RTC_MODULE \
     SAMD_MODULE \
-    SDCARDIO_MODULE \
     SDIOIO_MODULE \
-    SHARPDISPLAY_MODULE \
     SOCKETPOOL_MODULE \
     SSL_MODULE \
-    STAGE_MODULE \
-    STORAGE_MODULE \
-    STRUCT_MODULE \
-    SUPERVISOR_MODULE \
-    SYNTHIO_MODULE \
-    TOUCHIO_MODULE \
-    TRACEBACK_MODULE \
     UHEAP_MODULE \
-    USB_CDC_MODULE \
-    USB_HID_MODULE \
-    USB_MIDI_MODULE \
     USTACK_MODULE \
     WATCHDOG_MODULE \
     WIFI_MODULE \

--- a/shared-bindings/_stage/__init__.c
+++ b/shared-bindings/_stage/__init__.c
@@ -111,3 +111,5 @@ const mp_obj_module_t stage_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&stage_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR__stage, stage_module, CIRCUITPY_STAGE);

--- a/shared-bindings/neopixel_write/__init__.c
+++ b/shared-bindings/neopixel_write/__init__.c
@@ -81,3 +81,5 @@ const mp_obj_module_t neopixel_write_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&neopixel_write_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_neopixel_write, neopixel_write_module, CIRCUITPY_NEOPIXEL_WRITE);

--- a/shared-bindings/onewireio/__init__.c
+++ b/shared-bindings/onewireio/__init__.c
@@ -51,3 +51,5 @@ const mp_obj_module_t onewireio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&onewireio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_onewireio, onewireio_module, CIRCUITPY_ONEWIREIO);

--- a/shared-bindings/ps2io/__init__.c
+++ b/shared-bindings/ps2io/__init__.c
@@ -59,3 +59,5 @@ const mp_obj_module_t ps2io_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&ps2io_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_ps2io, ps2io_module, CIRCUITPY_PS2IO);

--- a/shared-bindings/pulseio/__init__.c
+++ b/shared-bindings/pulseio/__init__.c
@@ -58,3 +58,5 @@ const mp_obj_module_t pulseio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&pulseio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_pulseio, pulseio_module, CIRCUITPY_PULSEIO);

--- a/shared-bindings/pwmio/__init__.c
+++ b/shared-bindings/pwmio/__init__.c
@@ -71,3 +71,5 @@ const mp_obj_module_t pwmio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&pwmio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_pwmio, pwmio_module, CIRCUITPY_PWMIO);

--- a/shared-bindings/rainbowio/__init__.c
+++ b/shared-bindings/rainbowio/__init__.c
@@ -52,3 +52,5 @@ const mp_obj_module_t rainbowio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&rainbowio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_rainbowio, rainbowio_module, CIRCUITPY_RAINBOWIO);

--- a/shared-bindings/random/__init__.c
+++ b/shared-bindings/random/__init__.c
@@ -184,3 +184,5 @@ const mp_obj_module_t random_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&mp_module_random_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_random, random_module, CIRCUITPY_RANDOM);

--- a/shared-bindings/rgbmatrix/__init__.c
+++ b/shared-bindings/rgbmatrix/__init__.c
@@ -45,3 +45,5 @@ const mp_obj_module_t rgbmatrix_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&rgbmatrix_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_rgbmatrix, rgbmatrix_module, CIRCUITPY_RGBMATRIX);

--- a/shared-bindings/rotaryio/__init__.c
+++ b/shared-bindings/rotaryio/__init__.c
@@ -56,3 +56,5 @@ const mp_obj_module_t rotaryio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&rotaryio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_rotaryio, rotaryio_module, CIRCUITPY_ROTARYIO);

--- a/shared-bindings/rtc/__init__.c
+++ b/shared-bindings/rtc/__init__.c
@@ -86,3 +86,5 @@ const mp_obj_module_t rtc_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&rtc_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_rtc, rtc_module, CIRCUITPY_RTC);

--- a/shared-bindings/sdcardio/__init__.c
+++ b/shared-bindings/sdcardio/__init__.c
@@ -45,3 +45,5 @@ const mp_obj_module_t sdcardio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&sdcardio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_sdcardio, sdcardio_module, CIRCUITPY_SDCARDIO);

--- a/shared-bindings/sharpdisplay/__init__.c
+++ b/shared-bindings/sharpdisplay/__init__.c
@@ -45,3 +45,5 @@ const mp_obj_module_t sharpdisplay_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&sharpdisplay_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_sharpdisplay, sharpdisplay_module, CIRCUITPY_SHARPDISPLAY);

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -270,3 +270,5 @@ const mp_obj_module_t storage_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&storage_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_storage, storage_module, CIRCUITPY_STORAGE);

--- a/shared-bindings/struct/__init__.c
+++ b/shared-bindings/struct/__init__.c
@@ -179,3 +179,5 @@ const mp_obj_module_t struct_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&mp_module_struct_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_struct, struct_module, CIRCUITPY_STRUCT);

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -320,3 +320,5 @@ const mp_obj_module_t supervisor_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&supervisor_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_supervisor, supervisor_module, CIRCUITPY_SUPERVISOR);

--- a/shared-bindings/synthio/__init__.c
+++ b/shared-bindings/synthio/__init__.c
@@ -134,3 +134,5 @@ const mp_obj_module_t synthio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&synthio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_synthio, synthio_module, CIRCUITPY_SYNTHIO);

--- a/shared-bindings/touchio/__init__.c
+++ b/shared-bindings/touchio/__init__.c
@@ -68,3 +68,5 @@ const mp_obj_module_t touchio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&touchio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_touchio, touchio_module, CIRCUITPY_TOUCHIO);

--- a/shared-bindings/traceback/__init__.c
+++ b/shared-bindings/traceback/__init__.c
@@ -170,3 +170,5 @@ const mp_obj_module_t traceback_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&traceback_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_traceback, traceback_module, CIRCUITPY_TRACEBACK);

--- a/shared-bindings/usb_cdc/__init__.c
+++ b/shared-bindings/usb_cdc/__init__.c
@@ -139,3 +139,5 @@ void usb_cdc_set_console(mp_obj_t serial_obj) {
 void usb_cdc_set_data(mp_obj_t serial_obj) {
     set_module_dict_entry(MP_ROM_QSTR(MP_QSTR_data), serial_obj);
 }
+
+MP_REGISTER_MODULE(MP_QSTR_usb_cdc, usb_cdc_module, CIRCUITPY_USB_CDC);

--- a/shared-bindings/usb_hid/__init__.c
+++ b/shared-bindings/usb_hid/__init__.c
@@ -116,3 +116,5 @@ void usb_hid_set_devices(mp_obj_t devices) {
         elem->value = devices;
     }
 }
+
+MP_REGISTER_MODULE(MP_QSTR_usb_hid, usb_hid_module, CIRCUITPY_USB_HID);

--- a/shared-bindings/usb_midi/__init__.c
+++ b/shared-bindings/usb_midi/__init__.c
@@ -94,3 +94,5 @@ const mp_obj_module_t usb_midi_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&usb_midi_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_usb_midi, usb_midi_module, CIRCUITPY_USB_MIDI);

--- a/shared-bindings/vectorio/__init__.c
+++ b/shared-bindings/vectorio/__init__.c
@@ -23,3 +23,5 @@ const mp_obj_module_t vectorio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&vectorio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_vectorio, vectorio_module, CIRCUITPY_VECTORIO);


### PR DESCRIPTION
Convert neopixel_write, onewireio, ps2io, pulseio, pwmio, rainbowio, random, rgbmatrix, rotaryio, rtc, sdcardio, sharpdisplay, _stage, storage, struct, supervisor, synthio, touchio, traceback, usb_cdc, usb_hid, usb_midi, and vectorio modules to use MP_REGISTER_MODULE.

Related to #5183.