### PR TITLE
Add IO9 / VBAT_SENSE to lilygo-t8-s2-st7789

### DIFF
--- a/ports/esp32s2/boards/lilygo_ttgo_t8_s2_st7789/pins.c
+++ b/ports/esp32s2/boards/lilygo_ttgo_t8_s2_st7789/pins.c
@@ -57,6 +57,6 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_PE_POWER), MP_ROM_PTR(&pin_GPIO14) },
 
     // Battery Sense
-    { MP_ROM_QSTR(MP_QSTR_VBAT_SENSE), MP_ROM_PTR(&pin_GPIO9) },
+    { MP_ROM_QSTR(MP_QSTR_BATTERY), MP_ROM_PTR(&pin_GPIO9) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);

--- a/ports/esp32s2/boards/lilygo_ttgo_t8_s2_st7789/pins.c
+++ b/ports/esp32s2/boards/lilygo_ttgo_t8_s2_st7789/pins.c
@@ -13,6 +13,7 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IO6), MP_ROM_PTR(&pin_GPIO6) },
     { MP_ROM_QSTR(MP_QSTR_IO7), MP_ROM_PTR(&pin_GPIO7) },
     { MP_ROM_QSTR(MP_QSTR_IO8), MP_ROM_PTR(&pin_GPIO8) },
+    { MP_ROM_QSTR(MP_QSTR_IO9), MP_ROM_PTR(&pin_GPIO9) },
 
     { MP_ROM_QSTR(MP_QSTR_IO11), MP_ROM_PTR(&pin_GPIO11) },
     { MP_ROM_QSTR(MP_QSTR_IO12), MP_ROM_PTR(&pin_GPIO12) },
@@ -54,5 +55,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
 
     // Peripheral Power control
     { MP_ROM_QSTR(MP_QSTR_PE_POWER), MP_ROM_PTR(&pin_GPIO14) },
+
+    // Battery Sense
+    { MP_ROM_QSTR(MP_QSTR_VBAT_SENSE), MP_ROM_PTR(&pin_GPIO9) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_global_dict_table);


### PR DESCRIPTION
Added IO9 / VBAT_SENSE pin to  lilygo_t8_s2_st7789 board
Tested with
`````import time
import board
import analogio

vbat_voltage = analogio.AnalogIn(board.VBAT_SENSE)


def get_voltage(pin):
    return (pin.value * 3.3) / 65536 * 2


while True:
    battery_voltage = get_voltage(vbat_voltage)
    print("VBat voltage: {:.2f}".format(battery_voltage))
    time.sleep(1)
````