### PR TITLE
Convert more modules to use MP_REGISTER_MODULE

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -244,54 +244,12 @@ typedef long mp_off_t;
 // These CIRCUITPY_xxx values should all be defined in the *.mk files as being on or off.
 // So if any are not defined in *.mk, they'll throw an error here.
 
-#if CIRCUITPY_AESIO
-extern const struct _mp_obj_module_t aesio_module;
-#define AESIO_MODULE       { MP_OBJ_NEW_QSTR(MP_QSTR_aesio), (mp_obj_t)&aesio_module },
-#else
-#define AESIO_MODULE
-#endif
-
-#if CIRCUITPY_ALARM
-extern const struct _mp_obj_module_t alarm_module;
-#define ALARM_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_alarm), (mp_obj_t)&alarm_module },
-#else
-#define ALARM_MODULE
-#endif
-
-// CIRCUITPY_ANALOGIO uses MP_REGISTER_MODULE
-// CIRCUITPY_ATEXIT uses MP_REGISTER_MODULE
-// CIRCUITPY_AUDIOBUSIO uses MP_REGISTER_MODULE
-// CIRCUITPY_AUDIOCORE uses MP_REGISTER_MODULE
-// CIRCUITPY_AUDIOIO uses MP_REGISTER_MODULE
-// CIRCUITPY_AUDIOMIXER uses MP_REGISTER_MODULE
-// CIRCUITPY_AUDIOMP3 uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_AUDIOPWMIO
-#define AUDIOPWMIO_MODULE         { MP_OBJ_NEW_QSTR(MP_QSTR_audiopwmio), (mp_obj_t)&audiopwmio_module },
-extern const struct _mp_obj_module_t audiopwmio_module;
-#else
-#define AUDIOPWMIO_MODULE
-#endif
-
 #if CIRCUITPY_BINASCII
 #define MICROPY_PY_UBINASCII CIRCUITPY_BINASCII
 #define BINASCII_MODULE        { MP_ROM_QSTR(MP_QSTR_binascii), MP_ROM_PTR(&mp_module_ubinascii) },
 #else
 #define BINASCII_MODULE
 #endif
-
-// CIRCUITPY_BITBANGIO uses MP_REGISTER_MODULE
-// CIRCUITPY_BITMAPTOOLS uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_BITOPS
-extern const struct _mp_obj_module_t bitops_module;
-#define BITOPS_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR_bitops),(mp_obj_t)&bitops_module },
-#else
-#define BITOPS_MODULE
-#endif
-
-// CIRCUITPY_BLEIO uses MP_REGISTER_MODULE
-// CIRCUITPY_BOARD uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_BOARD
 #define BOARD_I2C (defined(DEFAULT_I2C_BUS_SDA) && defined(DEFAULT_I2C_BUS_SCL))
@@ -310,43 +268,12 @@ extern const struct _mp_obj_module_t bitops_module;
 #define BOARD_UART_ROOT_POINTER
 #endif
 
-// CIRCUITPY_BUSDEVICE (adafruit_bus_device_module) uses MP_REGISTER_MODULE
-// CIRCUITPY_BUSIO uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_CAMERA
-extern const struct _mp_obj_module_t camera_module;
-#define CAMERA_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR_camera), (mp_obj_t)&camera_module },
-#else
-#define CAMERA_MODULE
-#endif
-
-#if CIRCUITPY_CANIO
-extern const struct _mp_obj_module_t canio_module;
-#define CANIO_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_canio), (mp_obj_t)&canio_module },
-#else
-#define CANIO_MODULE
-#endif
-
-// CIRCUITPY_COUNTIO uses MP_REGISTER_MODULE
-// CIRCUITPY_DIGITALIO uses MP_REGISTER_MODULE
-// CIRCUITPY_DISPLAYIO uses MP_REGISTER_MODULE
-// CIRCUITPY_PARALLELDISPLAY uses MP_REGISTER_MODULE
-// CIRCUITPY_TERMINALIO uses MP_REGISTER_MODULE
-// CIRCUITPY_FONTIO uses MP_REGISTER_MODULE
-
 #if CIRCUITPY_DISPLAYIO
 #ifndef CIRCUITPY_DISPLAY_LIMIT
 #define CIRCUITPY_DISPLAY_LIMIT (1)
 #endif
 #else
 #define CIRCUITPY_DISPLAY_LIMIT (0)
-#endif
-
-#if CIRCUITPY_DUALBANK
-extern const struct _mp_obj_module_t dualbank_module;
-#define DUALBANK_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_dualbank), (mp_obj_t)&dualbank_module },
-#else
-#define DUALBANK_MODULE
 #endif
 
 #if CIRCUITPY_ERRNO
@@ -366,55 +293,12 @@ extern const struct _mp_obj_module_t espidf_module;
 #define ESPIDF_MODULE
 #endif
 
-#if CIRCUITPY__EVE
-extern const struct _mp_obj_module_t _eve_module;
-#define _EVE_MODULE            { MP_OBJ_NEW_QSTR(MP_QSTR__eve), (mp_obj_t)&_eve_module },
-#else
-#define _EVE_MODULE
-#endif
-
-// CIRCUITPY_FRAMEBUFFERIO uses MP_REGISTER_MODULE
-// CIRCUITPY_VECTORIO uses MP_REGISTER_MODULE
-
-// CIRCUITPY_FREQUENCYIO uses MP_REGISTER_MODULE
-// CIRCUITPY_GAMEPADSHIFT uses MP_REGISTER_MODULE
-
 #if CIRCUITPY_GAMEPADSHIFT
 // Scan gamepad every 32ms
 #define CIRCUITPY_GAMEPAD_TICKS 0x1f
 #define GAMEPAD_ROOT_POINTERS mp_obj_t gamepad_singleton;
 #else
 #define GAMEPAD_ROOT_POINTERS
-#endif
-
-// CIRCUITPY_GETPASS uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_GNSS
-extern const struct _mp_obj_module_t gnss_module;
-#define GNSS_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR_gnss), (mp_obj_t)&gnss_module },
-#else
-#define GNSS_MODULE
-#endif
-
-#if CIRCUITPY_I2CPERIPHERAL
-extern const struct _mp_obj_module_t i2cperipheral_module;
-#define I2CPERIPHERAL_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR_i2cperipheral), (mp_obj_t)&i2cperipheral_module },
-#else
-#define I2CPERIPHERAL_MODULE
-#endif
-
-#if CIRCUITPY_IMAGECAPTURE
-extern const struct _mp_obj_module_t imagecapture_module;
-#define IMAGECAPTURE_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_imagecapture), (mp_obj_t)&imagecapture_module },
-#else
-#define IMAGECAPTURE_MODULE
-#endif
-
-#if CIRCUITPY_IPADDRESS
-extern const struct _mp_obj_module_t ipaddress_module;
-#define IPADDRESS_MODULE        { MP_OBJ_NEW_QSTR(MP_QSTR_ipaddress), (mp_obj_t)&ipaddress_module },
-#else
-#define IPADDRESS_MODULE
 #endif
 
 #if CIRCUITPY_JSON
@@ -429,35 +313,23 @@ extern const struct _mp_obj_module_t ipaddress_module;
 #define JSON_MODULE
 #endif
 
-// CIRCUITPY_KEYPAD uses MP_REGISTER_MODULE
-
 #if CIRCUITPY_KEYPAD
 #define KEYPAD_ROOT_POINTERS mp_obj_t keypad_scanners_linked_list;
 #else
 #define KEYPAD_ROOT_POINTERS
 #endif
 
-// CIRCUITPY_MATH uses MP_REGISTER_MODULE
-
 #if CIRCUITPY_MEMORYMONITOR
-extern const struct _mp_obj_module_t memorymonitor_module;
-#define MEMORYMONITOR_MODULE { MP_OBJ_NEW_QSTR(MP_QSTR_memorymonitor), (mp_obj_t)&memorymonitor_module },
 #define MEMORYMONITOR_ROOT_POINTERS mp_obj_t active_allocationsizes; \
     mp_obj_t active_allocationalarms;
 #else
-#define MEMORYMONITOR_MODULE
 #define MEMORYMONITOR_ROOT_POINTERS
 #endif
-
-// CIRCUITPY_MICROCONTROLLER uses MP_REGISTER_MODULE
-// CIRCUITPY_NEOPIXEL_WRITE uses MP_REGISTER_MODULE
 
 // This is not a top-level module; it's microcontroller.nvm.
 #if CIRCUITPY_NVM
 extern const struct _mp_obj_module_t nvm_module;
 #endif
-
-// CIRCUITPY_ONEWIREIO_WRITE uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_OS
 extern const struct _mp_obj_module_t os_module;
@@ -468,30 +340,12 @@ extern const struct _mp_obj_module_t os_module;
 #define OS_MODULE_ALT_NAME
 #endif
 
-#if CIRCUITPY_PEW
-extern const struct _mp_obj_module_t pew_module;
-#define PEW_MODULE          { MP_OBJ_NEW_QSTR(MP_QSTR__pew),(mp_obj_t)&pew_module },
-#else
-#define PEW_MODULE
-#endif
-
-// CIRCUITPY_PIXELBUF (pixelbuf_module) uses MP_REGISTER_MODULE
-// CIRCUITPY_PS2IO uses MP_REGISTER_MODULE
-// CIRCUITPY_PULSEIO uses MP_REGISTER_MODULE
-// CIRCUITPY_PWMIO uses MP_REGISTER_MODULE
-// CIRCUITPY_QRIO uses MP_REGISTER_MODULE
-// CIRCUITPY_RAINBOWIO uses MP_REGISTER_MODULE
-// CIRCUITPY_RANDOM uses MP_REGISTER_MODULE
-
 #if CIRCUITPY_RE
 #define MICROPY_PY_URE (1)
 #define RE_MODULE            { MP_ROM_QSTR(MP_QSTR_re), MP_ROM_PTR(&mp_module_ure) },
 #else
 #define RE_MODULE
 #endif
-
-// CIRCUITPY_RGBMATRIX uses MP_REGISTER_MODULE
-// CIRCUITPY_ROTARYIO uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_RP2PIO
 extern const struct _mp_obj_module_t rp2pio_module;
@@ -500,45 +354,12 @@ extern const struct _mp_obj_module_t rp2pio_module;
 #define RP2PIO_MODULE
 #endif
 
-// CIRCUITPY_RTC uses MP_REGISTER_MODULE
-
 #if CIRCUITPY_SAMD
 extern const struct _mp_obj_module_t samd_module;
 #define SAMD_MODULE            { MP_OBJ_NEW_QSTR(MP_QSTR_samd),(mp_obj_t)&samd_module },
 #else
 #define SAMD_MODULE
 #endif
-
-// CIRCUITPY_SDCARDIO uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_SDIOIO
-extern const struct _mp_obj_module_t sdioio_module;
-#define SDIOIO_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_sdioio), (mp_obj_t)&sdioio_module },
-#else
-#define SDIOIO_MODULE
-#endif
-
-// CIRCUITPY_SHARPDISPLAY uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_SOCKETPOOL
-extern const struct _mp_obj_module_t socketpool_module;
-#define SOCKETPOOL_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_socketpool), (mp_obj_t)&socketpool_module },
-#else
-#define SOCKETPOOL_MODULE
-#endif
-
-#if CIRCUITPY_SSL
-extern const struct _mp_obj_module_t ssl_module;
-#define SSL_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_ssl), (mp_obj_t)&ssl_module },
-#else
-#define SSL_MODULE
-#endif
-
-// CIRCUITPY_STAGE uses MP_REGISTER_MODULE
-// CIRCUITPY_STORAGE uses MP_REGISTER_MODULE
-// CIRCUITPY_STRUCT uses MP_REGISTER_MODULE
-// CIRCUITPY_SUPERVISOR uses MP_REGISTER_MODULE
-// CIRCUITPY_SYNTHIO uses MP_REGISTER_MODULE
 
 #if CIRCUITPY_TIME
 extern const struct _mp_obj_module_t time_module;
@@ -547,27 +368,6 @@ extern const struct _mp_obj_module_t time_module;
 #else
 #define TIME_MODULE
 #define TIME_MODULE_ALT_NAME
-#endif
-
-// CIRCUITPY_TOUCHIO uses MP_REGISTER_MODULE
-// CIRCUITPY_TRACEBACK uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_UHEAP
-extern const struct _mp_obj_module_t uheap_module;
-#define UHEAP_MODULE           { MP_OBJ_NEW_QSTR(MP_QSTR_uheap),(mp_obj_t)&uheap_module },
-#else
-#define UHEAP_MODULE
-#endif
-
-// CIRCUITPY_USB_CDC uses MP_REGISTER_MODULE
-// CIRCUITPY_USB_HID uses MP_REGISTER_MODULE
-// CIRCUITPY_USB_MIDI uses MP_REGISTER_MODULE
-
-#if CIRCUITPY_USTACK
-extern const struct _mp_obj_module_t ustack_module;
-#define USTACK_MODULE          { MP_OBJ_NEW_QSTR(MP_QSTR_ustack),(mp_obj_t)&ustack_module },
-#else
-#define USTACK_MODULE
 #endif
 
 #if defined(CIRCUITPY_ULAB) && CIRCUITPY_ULAB
@@ -580,23 +380,6 @@ extern const struct _mp_obj_module_t ustack_module;
 #else
 #define ULAB_MODULE
 #endif
-
-// This is not a top-level module; it's microcontroller.watchdog.
-#if CIRCUITPY_WATCHDOG
-extern const struct _mp_obj_module_t watchdog_module;
-#define WATCHDOG_MODULE { MP_ROM_QSTR(MP_QSTR_watchdog), MP_ROM_PTR(&watchdog_module) },
-#else
-#define WATCHDOG_MODULE
-#endif
-
-#if CIRCUITPY_WIFI
-extern const struct _mp_obj_module_t wifi_module;
-#define WIFI_MODULE { MP_ROM_QSTR(MP_QSTR_wifi), MP_ROM_PTR(&wifi_module) },
-#else
-#define WIFI_MODULE
-#endif
-
-// CIRCUITPY_MSGPACK uses MP_REGISTER_MODULE
 
 // Define certain native modules with weak links so they can be replaced with Python
 // implementations. This list may grow over time.
@@ -616,35 +399,91 @@ extern const struct _mp_obj_module_t wifi_module;
 // including dependencies.
 // Some of these definitions will be blank depending on what is turned on and off.
 // Some are omitted because they're in MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS above.
+
 #define MICROPY_PORT_BUILTIN_MODULES_STRONG_LINKS \
-    AESIO_MODULE \
-    ALARM_MODULE \
-    AUDIOPWMIO_MODULE \
     BINASCII_MODULE \
-    BITOPS_MODULE \
-    CAMERA_MODULE \
-    CANIO_MODULE \
-    DUALBANK_MODULE \
     ERRNO_MODULE \
     ESPIDF_MODULE \
-    _EVE_MODULE \
-    GNSS_MODULE \
-    I2CPERIPHERAL_MODULE \
-    IPADDRESS_MODULE \
-    IMAGECAPTURE_MODULE \
     JSON_MODULE \
-    MEMORYMONITOR_MODULE \
-    PEW_MODULE \
     RE_MODULE \
     RP2PIO_MODULE \
     SAMD_MODULE \
-    SDIOIO_MODULE \
-    SOCKETPOOL_MODULE \
-    SSL_MODULE \
-    UHEAP_MODULE \
-    USTACK_MODULE \
-    WATCHDOG_MODULE \
-    WIFI_MODULE \
+
+// The following modules are defined in their respective __init__.c file in the
+// shared-bindings directory using MP_REGISTER_MODULE.
+//
+// CIRCUITPY_AESIO
+// CIRCUITPY_ANALOGIO
+// CIRCUITPY_ATEXIT
+// CIRCUITPY_AUDIOBUSIO
+// CIRCUITPY_AUDIOCORE
+// CIRCUITPY_AUDIOIO
+// CIRCUITPY_AUDIOMIXER
+// CIRCUITPY_AUDIOMP3
+// CIRCUITPY_AUDIOPWMIO
+// CIRCUITPY_BITBANGIO
+// CIRCUITPY_BITMAPTOOLS
+// CIRCUITPY_BITOPS
+// CIRCUITPY_BLEIO
+// CIRCUITPY_BOARD
+// CIRCUITPY_BUSDEVICE
+// CIRCUITPY_BUSIO
+// CIRCUITPY_CAMERA
+// CIRCUITPY_CANIO
+// CIRCUITPY_COUNTIO
+// CIRCUITPY_DIGITALIO
+// CIRCUITPY_DISPLAYIO
+// CIRCUITPY_DUALBANK
+// CIRCUITPY__EVE
+// CIRCUITPY_FONTIO
+// CIRCUITPY_FRAMEBUFFERIO
+// CIRCUITPY_FREQUENCYIO
+// CIRCUITPY_GAMEPADSHIFT
+// CIRCUITPY_GETPASS
+// CIRCUITPY_GNSS
+// CIRCUITPY_I2CPERIPHERAL
+// CIRCUITPY_IMAGECAPTURE
+// CIRCUITPY_IPADDRESS
+// CIRCUITPY_KEYPAD
+// CIRCUITPY_MATH
+// CIRCUITPY_MEMORYMONITOR
+// CIRCUITPY_MICROCONTROLLER
+// CIRCUITPY_MSGPACK
+// CIRCUITPY_NEOPIXEL_WRITE
+// CIRCUITPY_ONEWIREIO_WRITE
+// CIRCUITPY_PARALLELDISPLAY
+// CIRCUITPY_PEW
+// CIRCUITPY_PIXELBUF
+// CIRCUITPY_PS2IO
+// CIRCUITPY_PULSEIO
+// CIRCUITPY_PWMIO
+// CIRCUITPY_QRIO
+// CIRCUITPY_RAINBOWIO
+// CIRCUITPY_RANDOM
+// CIRCUITPY_RGBMATRIX
+// CIRCUITPY_ROTARYIO
+// CIRCUITPY_RTC
+// CIRCUITPY_SDCARDIO
+// CIRCUITPY_SDIOIO
+// CIRCUITPY_SHARPDISPLAY
+// CIRCUITPY_SOCKETPOOL
+// CIRCUITPY_SSL
+// CIRCUITPY_STAGE
+// CIRCUITPY_STORAGE
+// CIRCUITPY_STRUCT
+// CIRCUITPY_SUPERVISOR
+// CIRCUITPY_SYNTHIO
+// CIRCUITPY_TERMINALIO
+// CIRCUITPY_TOUCHIO
+// CIRCUITPY_TRACEBACK
+// CIRCUITPY_UHEAP
+// CIRCUITPY_USB_CDC
+// CIRCUITPY_USB_HID
+// CIRCUITPY_USB_MIDI
+// CIRCUITPY_USTACK
+// CIRCUITPY_VECTORIO
+// CIRCUITPY_WATCHDOG
+// CIRCUITPY_WIFI
 
 // If weak links are enabled, just include strong links in the main list of modules,
 // and also include the underscore alternate names.

--- a/shared-bindings/_eve/__init__.c
+++ b/shared-bindings/_eve/__init__.c
@@ -1105,3 +1105,5 @@ const mp_obj_module_t _eve_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&mp_module__eve_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR__eve, _eve_module, CIRCUITPY__EVE);

--- a/shared-bindings/_pew/__init__.c
+++ b/shared-bindings/_pew/__init__.c
@@ -63,3 +63,5 @@ const mp_obj_module_t pew_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&pew_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR__pew, pew_module, CIRCUITPY_PEW);

--- a/shared-bindings/aesio/__init__.c
+++ b/shared-bindings/aesio/__init__.c
@@ -63,3 +63,5 @@ const mp_obj_module_t aesio_module = {
     .base = {&mp_type_module},
     .globals = (mp_obj_dict_t *)&aesio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_aesio, aesio_module, CIRCUITPY_AESIO);

--- a/shared-bindings/alarm/__init__.c
+++ b/shared-bindings/alarm/__init__.c
@@ -248,3 +248,5 @@ extern void port_idle_until_interrupt(void);
 MP_WEAK void common_hal_alarm_pretending_deep_sleep(void) {
     port_idle_until_interrupt();
 }
+
+MP_REGISTER_MODULE(MP_QSTR_alarm, alarm_module, CIRCUITPY_ALARM);

--- a/shared-bindings/audiopwmio/__init__.c
+++ b/shared-bindings/audiopwmio/__init__.c
@@ -57,3 +57,5 @@ const mp_obj_module_t audiopwmio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&audiopwmio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_audiopwmio, audiopwmio_module, CIRCUITPY_AUDIOPWMIO);

--- a/shared-bindings/bitops/__init__.c
+++ b/shared-bindings/bitops/__init__.c
@@ -99,3 +99,5 @@ const mp_obj_module_t bitops_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&bitops_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_bitops, bitops_module, CIRCUITPY_BITOPS);

--- a/shared-bindings/camera/__init__.c
+++ b/shared-bindings/camera/__init__.c
@@ -48,3 +48,5 @@ const mp_obj_module_t camera_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&camera_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_camera, camera_module, CIRCUITPY_CAMERA);

--- a/shared-bindings/canio/__init__.c
+++ b/shared-bindings/canio/__init__.c
@@ -108,6 +108,7 @@ MAKE_PRINTER(canio, canio_bus_state);
 MAKE_ENUM_TYPE(canio, BusState, canio_bus_state);
 
 STATIC const mp_rom_map_elem_t canio_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_canio) },
     { MP_ROM_QSTR(MP_QSTR_BusState), MP_ROM_PTR(&canio_bus_state_type) },
     { MP_ROM_QSTR(MP_QSTR_CAN), MP_ROM_PTR(&canio_can_type) },
     { MP_ROM_QSTR(MP_QSTR_Listener), MP_ROM_PTR(&canio_listener_type) },
@@ -123,3 +124,5 @@ const mp_obj_module_t canio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&canio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_canio, canio_module, CIRCUITPY_CANIO);

--- a/shared-bindings/dualbank/__init__.c
+++ b/shared-bindings/dualbank/__init__.c
@@ -113,3 +113,5 @@ const mp_obj_module_t dualbank_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&dualbank_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_dualbank, dualbank_module, CIRCUITPY_DUALBANK);

--- a/shared-bindings/gnss/__init__.c
+++ b/shared-bindings/gnss/__init__.c
@@ -29,3 +29,5 @@ const mp_obj_module_t gnss_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&gnss_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_gnss, gnss_module, CIRCUITPY_GNSS);

--- a/shared-bindings/i2cperipheral/__init__.c
+++ b/shared-bindings/i2cperipheral/__init__.c
@@ -104,3 +104,5 @@ const mp_obj_module_t i2cperipheral_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&i2cperipheral_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_i2cperipheral, i2cperipheral_module, CIRCUITPY_I2CPERIPHERAL);

--- a/shared-bindings/imagecapture/__init__.c
+++ b/shared-bindings/imagecapture/__init__.c
@@ -45,3 +45,5 @@ const mp_obj_module_t imagecapture_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&imagecapture_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_imagecapture, imagecapture_module, CIRCUITPY_IMAGECAPTURE);

--- a/shared-bindings/ipaddress/__init__.c
+++ b/shared-bindings/ipaddress/__init__.c
@@ -111,3 +111,5 @@ const mp_obj_module_t ipaddress_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&ipaddress_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_ipaddress, ipaddress_module, CIRCUITPY_IPADDRESS);

--- a/shared-bindings/memorymonitor/__init__.c
+++ b/shared-bindings/memorymonitor/__init__.c
@@ -74,3 +74,5 @@ const mp_obj_module_t memorymonitor_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&memorymonitor_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_memorymonitor, memorymonitor_module, CIRCUITPY_MEMORYMONITOR);

--- a/shared-bindings/sdioio/__init__.c
+++ b/shared-bindings/sdioio/__init__.c
@@ -45,3 +45,5 @@ const mp_obj_module_t sdioio_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&sdioio_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_sdio, sdioio_module, CIRCUITPY_SDIOIO);

--- a/shared-bindings/socketpool/__init__.c
+++ b/shared-bindings/socketpool/__init__.c
@@ -51,3 +51,5 @@ const mp_obj_module_t socketpool_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&socketpool_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_socketpool, socketpool_module, CIRCUITPY_SOCKETPOOL);

--- a/shared-bindings/ssl/__init__.c
+++ b/shared-bindings/ssl/__init__.c
@@ -64,3 +64,5 @@ const mp_obj_module_t ssl_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&ssl_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_ssl, ssl_module, CIRCUITPY_SSL);

--- a/shared-bindings/uheap/__init__.c
+++ b/shared-bindings/uheap/__init__.c
@@ -57,3 +57,5 @@ const mp_obj_module_t uheap_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&uheap_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_uheap, uheap_module, CIRCUITPY_UHEAP);

--- a/shared-bindings/ustack/__init__.c
+++ b/shared-bindings/ustack/__init__.c
@@ -85,3 +85,5 @@ const mp_obj_module_t ustack_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&ustack_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_ustack, ustack_module, CIRCUITPY_USTACK);

--- a/shared-bindings/watchdog/__init__.c
+++ b/shared-bindings/watchdog/__init__.c
@@ -77,3 +77,5 @@ const mp_obj_module_t watchdog_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&watchdog_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_watchdog, watchdog_module, CIRCUITPY_WATCHDOG);

--- a/shared-bindings/wifi/__init__.c
+++ b/shared-bindings/wifi/__init__.c
@@ -70,3 +70,5 @@ const mp_obj_module_t wifi_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&wifi_module_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_wifi, wifi_module, CIRCUITPY_WIFI);


### PR DESCRIPTION
Convert _eve, _pew, aesio, alarm, audiopwmio, bitops, camera, canio, dualbank, gnss, i2cperipheral, imagecapture, ipaddress, memorymonitor, sdioio, socketpool, ssl, uheap, ustack, watchdog, and wifi modules to use MP_REGISTER_MODULE.

Related to #5183.