### PR TITLE
Added STAGE support for my TinyS2 board

### DIFF
--- a/ports/esp32s2/boards/unexpectedmaker_tinys2/mpconfigboard.mk
+++ b/ports/esp32s2/boards/unexpectedmaker_tinys2/mpconfigboard.mk
@@ -16,5 +16,7 @@ CIRCUITPY_ESP_FLASH_SIZE=4MB
 
 CIRCUITPY_BITBANG_NEOPIXEL = 1
 
+CIRCUITPY_STAGE = 1
+
 # Include these Python libraries in firmware.
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel


### PR DESCRIPTION
Adding Radomir's STAGE (C side) on my TinyS2 so it can be using on my new Explorer Shield without seeing custom firmware.