### PR TITLE
Add a flag for removing the Blinka logo from the REPL

### DIFF
--- a/ports/atmel-samd/boards/pewpew_m4/mpconfigboard.h
+++ b/ports/atmel-samd/boards/pewpew_m4/mpconfigboard.h
@@ -36,3 +36,4 @@
 #define IGNORE_PIN_PB11     1
 
 #define SAMD5x_E5x_BOD33_LEVEL (100)
+#define CIRCUITPY_REPL_LOGO 0

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -480,6 +480,11 @@ void supervisor_run_background_tasks_if_tick(void);
 #define CIRCUITPY_PRECOMPUTE_QSTR_ATTR (1)
 #endif
 
+// Display the Blinka logo in the REPL on displayio displays.
+#ifndef CIRCUITPY_REPL_LOGO
+#define CIRCUITPY_REPL_LOGO (1)
+#endif
+
 // USB settings
 
 // If the port requires certain USB endpoint numbers, define these in mpconfigport.h.


### PR DESCRIPTION
There may be several reasons why we might want to remove the logo form
the REPL: a fork of CircuitPython that doesn't have the right to use the
logo, an especially small display that needs all the room it has to be
useful, displays that are especially vulnerable to burn-in, maybe even
the smaller chips where we want to save as much flash memory as
possible.