### PR TITLE
Fix incorrect use of allocate_memory()

### DIFF
--- a/main.c
+++ b/main.c
@@ -236,7 +236,7 @@ STATIC void cleanup_after_vm(supervisor_allocation* heap, mp_obj_t exception) {
             size_t traceback_len = 0;
             mp_print_t print_count = {&traceback_len, count_strn};
             mp_obj_print_exception(&print_count, exception);
-            prev_traceback_allocation = allocate_memory(align32_size(traceback_len + 1), false, true);
+            prev_traceback_allocation = allocate_memory(align32_size(traceback_len + 1), false, false);
             // Empirically, this never fails in practice - even when the heap is totally filled up
             // with single-block-sized objects referenced by a root pointer, exiting the VM frees
             // up several hundred bytes, sufficient for the traceback (which tends to be shortened

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -195,7 +195,7 @@ STATIC mp_obj_t supervisor_set_next_code_file(size_t n_args, const mp_obj_t *pos
     const char *filename = mp_obj_str_get_data(args.filename.u_obj, &len);
     free_memory(next_code_allocation);
     if (options != 0 || len != 0) {
-        next_code_allocation = allocate_memory(align32_size(sizeof(next_code_info_t) + len + 1), false, true);
+        next_code_allocation = allocate_memory(align32_size(sizeof(next_code_info_t) + len + 1), false, false);
         if (next_code_allocation == NULL) {
             m_malloc_fail(sizeof(next_code_info_t) + len + 1);
         }


### PR DESCRIPTION
`next_code_allocation` and `prev_traceback_allocation` are in the IMMOVABLE group. See: https://github.com/adafruit/circuitpython/blob/7ce3f256509ba64b63ea926922d22854f8fb8ac7/supervisor/shared/memory.c#L39. However, calls to the `allocate_memory()` function are with the argument `movable = true`. This causes an assert: https://github.com/adafruit/circuitpython/blob/7ce3f256509ba64b63ea926922d22854f8fb8ac7/supervisor/shared/memory.c#L168

