### PR TITLE
Include Frozen Libraries In build_board_info.py

### DIFF
--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -109,11 +109,20 @@ def get_board_mapping():
                 extensions = extension_by_port[port]
                 extensions = extension_by_board.get(board_path.name, extensions)
                 aliases = aliases_by_board.get(board_path.name, [])
+                frozen_libraries = []
+                with open(os.path.join(board_path, "mpconfigboard.mk")) as mpconfig:
+                    frozen_lines = [
+                        line for line in mpconfig if line.startswith("FROZEN_MPY_DIRS")
+                    ]
+                    frozen_libraries.extend(
+                        [line[line.rfind("/") + 1 :].strip() for line in frozen_lines]
+                    )
                 boards[board_id] = {
                     "port": port,
                     "extensions": extensions,
                     "download_count": 0,
                     "aliases": aliases,
+                    "frozen_libraries": frozen_libraries,
                 }
                 for alias in aliases:
                     boards[alias] = {
@@ -300,6 +309,7 @@ def generate_download_info():
                         "modules": support_matrix[alias],
                         "languages": languages,
                         "extensions": board_info["extensions"],
+                        "frozen_libraries": board_info["frozen_libraries"],
                     }
                     current_info[alias]["downloads"] = alias_info["download_count"]
                     current_info[alias]["versions"].append(new_version)

--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -220,7 +220,8 @@ def create_pr(changes, updated, git_info, user):
     }
 
     response = github.put(
-        "/repos/{}/circuitpython-org/contents/_data/files.json".format(user), json=update_file
+        "/repos/{}/circuitpython-org/contents/_data/files.json".format(user),
+        json=update_file,
     )
     if not response.ok:
         print("unable to post new file")


### PR DESCRIPTION
Fixes #4672

Tested with the following:
```shell
(.venv) ~/Dev/circuitpython/tools:$> python
Python 3.8.2 (default, May 20 2020, 16:07:42) 
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import json
>>> import pathlib
>>> from build_board_info import get_board_mapping
>>> fpath = pathlib.Path().home()
>>> with open(fpath / "Dev" / "frozen_board_mapping.txt", "w") as f:
...     json.dump(get_board_mapping(), f, indent=2)
... 
>>>
```
Result:
[frozen_board_mapping.txt](https://github.com/adafruit/circuitpython/files/7115848/frozen_board_mapping.txt)

_Note: without a manual update, this will only update the newest version in `circuitpython-org/_data/files.json`._

