### PR TITLE
Echo control characters used for REPL modes

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -101,7 +101,7 @@ endif
 # option to override compiler optimization level, set in boards/$(BOARD)/mpconfigboard.mk
 CFLAGS += $(OPTIMIZATION_FLAGS)
 
-CFLAGS += $(INC) -Wall -Werror -std=gnu11 -nostdlib -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT)
+CFLAGS += $(INC) -Wall -Werror -std=gnu11 -nostdlib -fshort-enums -fno-ipa-modref $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT)
 
 # Undo some warnings.
 # nrfx does casts that increase alignment requirements.


### PR DESCRIPTION
This allows tools to look for invisible characters rather than
human readable phrases that may be translated.

This includes a GCC flag fix for nRF with GCC 11.2. See
https://github.com/adafruit/Adafruit_nRF52_Bootloader/pull/221
for background on the flag.

Fixes #5307