### PR TITLE
Fix the nRF builds with GCC 11.2

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -103,6 +103,18 @@ CFLAGS += $(OPTIMIZATION_FLAGS)
 
 CFLAGS += $(INC) -Wall -Werror -std=gnu11 -nostdlib -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT)
 
+# Nordic Softdevice SDK header files contains inline assembler that has
+# broken constraints. As a result the IPA-modref pass, introduced in gcc-11,
+# is able to "prove" that arguments to wrapper functions generated with
+# the SVCALL() macro are unused and, as a result, the optimizer will remove
+# code within the callers that sets up these arguments (which results in
+# a broken bootloader). The broken headers come from Nordic-supplied zip
+# files and are not trivial to patch so, for now, we'll simply disable the
+# new gcc-11 inter-procedural optimizations.
+ifeq (,$(findstring unrecognized,$(shell $(CC) $(CFLAGS) -fno-ipa-modref 2>&1)))
+CFLAGS += -fno-ipa-modref
+endif
+
 # Undo some warnings.
 # nrfx does casts that increase alignment requirements.
 CFLAGS += -Wno-cast-align


### PR DESCRIPTION
See adafruit/Adafruit_nRF52_Bootloader#221
for background on the flag.