### PR TITLE
Implement reset_reason for raspberrypi port

### DIFF
--- a/shared-bindings/microcontroller/ResetReason.c
+++ b/shared-bindings/microcontroller/ResetReason.c
@@ -36,6 +36,7 @@ MAKE_ENUM_VALUE(mcu_reset_reason_type, reset_reason, DEEP_SLEEP_ALARM, RESET_REA
 MAKE_ENUM_VALUE(mcu_reset_reason_type, reset_reason, RESET_PIN, RESET_REASON_RESET_PIN);
 MAKE_ENUM_VALUE(mcu_reset_reason_type, reset_reason, WATCHDOG, RESET_REASON_WATCHDOG);
 MAKE_ENUM_VALUE(mcu_reset_reason_type, reset_reason, UNKNOWN, RESET_REASON_UNKNOWN);
+MAKE_ENUM_VALUE(mcu_reset_reason_type, reset_reason, RESCUE_DEBUG, RESET_REASON_RESCUE_DEBUG);
 
 //| class ResetReason:
 //|     """The reason the microntroller was last reset"""
@@ -61,6 +62,9 @@ MAKE_ENUM_VALUE(mcu_reset_reason_type, reset_reason, UNKNOWN, RESET_REASON_UNKNO
 //|     UNKNOWN: object
 //|     """The microntroller restarted for an unknown reason."""
 //|
+//|     RESCUE_DEBUG: object
+//|     """The microntroller was reset by the rescue debug port."""
+//|
 MAKE_ENUM_MAP(mcu_reset_reason) {
     MAKE_ENUM_MAP_ENTRY(reset_reason, POWER_ON),
     MAKE_ENUM_MAP_ENTRY(reset_reason, BROWNOUT),
@@ -69,6 +73,7 @@ MAKE_ENUM_MAP(mcu_reset_reason) {
     MAKE_ENUM_MAP_ENTRY(reset_reason, RESET_PIN),
     MAKE_ENUM_MAP_ENTRY(reset_reason, WATCHDOG),
     MAKE_ENUM_MAP_ENTRY(reset_reason, UNKNOWN),
+    MAKE_ENUM_MAP_ENTRY(reset_reason, RESCUE_DEBUG),
 };
 STATIC MP_DEFINE_CONST_DICT(mcu_reset_reason_locals_dict, mcu_reset_reason_locals_table);
 

--- a/shared-bindings/microcontroller/ResetReason.h
+++ b/shared-bindings/microcontroller/ResetReason.h
@@ -38,6 +38,7 @@ typedef enum {
     RESET_REASON_RESET_PIN,
     RESET_REASON_WATCHDOG,
     RESET_REASON_UNKNOWN,
+    RESET_REASON_RESCUE_DEBUG,
 } mcu_reset_reason_t;
 
 extern const mp_obj_type_t mcu_reset_reason_type;


### PR DESCRIPTION
This implements the reset_reason for the microcontroller.Processor class on the raspberrypi port. It also adds a ResetReason.RESCUE_DEBUG enum for if the RP2040 is reset via the Rescue Debug Port. One thing to note is that resetting the microcontroller in software will report a watchdog reset, due to the implementation of the watchdog_reset in the pico_sdk setting a low watchdog timeout rather than triggering a reset directly in the watchdog.