### PR TITLE
Fix scanning after a peripheral bond has been made

### DIFF
--- a/ports/nrf/common-hal/_bleio/Adapter.c
+++ b/ports/nrf/common-hal/_bleio/Adapter.c
@@ -507,6 +507,16 @@ mp_obj_t common_hal_bleio_adapter_start_scan(bleio_adapter_obj_t *self, uint8_t 
         }
         self->scan_results = NULL;
     }
+    // Check to see if advertising is going already.
+    if (self->current_advertising_data != NULL && self->current_advertising_data == self->advertising_data) {
+        check_nrf_error(NRF_ERROR_BUSY);
+    }
+
+    // If the current advertising data isn't owned by the adapter then it must be an internal
+    // advertisement that we should stop.
+    if (self->current_advertising_data != NULL) {
+        common_hal_bleio_adapter_stop_advertising(self);
+    }
     self->scan_results = shared_module_bleio_new_scanresults(buffer_size, prefixes, prefix_length, minimum_rssi);
     size_t max_packet_size = extended ? BLE_GAP_SCAN_BUFFER_EXTENDED_MAX_SUPPORTED : BLE_GAP_SCAN_BUFFER_MAX;
     uint8_t *raw_data = m_malloc(sizeof(ble_data_t) + max_packet_size, false);


### PR DESCRIPTION
The BLE workflow will be advertising and the scan's load of
identities conflicts with it. This change ensures scanning and
advertising happens exclusively.

This showed as an unknown error 3204.

Fixes https://github.com/adafruit/Adafruit_CircuitPython_BLE/issues/134