### PR TITLE
Use NO_PIN, not 0, for PDMIn unset pins

### DIFF
--- a/ports/nrf/boards/adafruit_led_glasses_nrf52840/pins.c
+++ b/ports/nrf/boards/adafruit_led_glasses_nrf52840/pins.c
@@ -12,6 +12,11 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_P0_31) },
 
+    { MP_ROM_QSTR(MP_QSTR_ACCELEROMETER_INTERRUPT), MP_ROM_PTR(&pin_P0_01) },
+
+    { MP_ROM_QSTR(MP_QSTR_VOLTAGE_MONITOR), MP_ROM_PTR(&pin_P0_04) },
+    { MP_ROM_QSTR(MP_QSTR_BATTERY), MP_ROM_PTR(&pin_P0_04) },
+
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_P0_08) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_P0_06) },
 

--- a/ports/nrf/common-hal/audiobusio/I2SOut.c
+++ b/ports/nrf/common-hal/audiobusio/I2SOut.c
@@ -230,7 +230,7 @@ void common_hal_audiobusio_i2sout_construct(audiobusio_i2sout_obj_t *self,
 }
 
 bool common_hal_audiobusio_i2sout_deinited(audiobusio_i2sout_obj_t *self) {
-    return self->data_pin_number == 0xff;
+    return self->data_pin_number == NO_PIN;
 }
 
 void common_hal_audiobusio_i2sout_deinit(audiobusio_i2sout_obj_t *self) {
@@ -240,11 +240,11 @@ void common_hal_audiobusio_i2sout_deinit(audiobusio_i2sout_obj_t *self) {
     NRF_I2S->TASKS_STOP = 1;
     NRF_I2S->ENABLE = I2S_ENABLE_ENABLE_Disabled;
     reset_pin_number(self->bit_clock_pin_number);
-    self->bit_clock_pin_number = 0xff;
+    self->bit_clock_pin_number = NO_PIN;
     reset_pin_number(self->word_select_pin_number);
-    self->word_select_pin_number = 0xff;
+    self->word_select_pin_number = NO_PIN;
     reset_pin_number(self->data_pin_number);
-    self->data_pin_number = 0xff;
+    self->data_pin_number = NO_PIN;
     instance = NULL;
     supervisor_disable_tick();
 }

--- a/ports/nrf/common-hal/audiobusio/PDMIn.c
+++ b/ports/nrf/common-hal/audiobusio/PDMIn.c
@@ -69,16 +69,16 @@ void common_hal_audiobusio_pdmin_construct(audiobusio_pdmin_obj_t *self,
 }
 
 bool common_hal_audiobusio_pdmin_deinited(audiobusio_pdmin_obj_t *self) {
-    return !self->clock_pin_number;
+    return self->clock_pin_number == NO_PIN;
 }
 
 void common_hal_audiobusio_pdmin_deinit(audiobusio_pdmin_obj_t *self) {
     nrf_pdm->ENABLE = 0;
 
     reset_pin_number(self->clock_pin_number);
-    self->clock_pin_number = 0;
+    self->clock_pin_number = NO_PIN;
     reset_pin_number(self->data_pin_number);
-    self->data_pin_number = 0;
+    self->data_pin_number = NO_PIN;
 }
 
 uint8_t common_hal_audiobusio_pdmin_get_bit_depth(audiobusio_pdmin_obj_t *self) {


### PR DESCRIPTION
Accidentally disallowed using pin P0_00.

Also:
- Use NO_PIN, not 0xff for I2SOut (cosmetic fix only; no actual functional change)
- Add VOLTAGE_MONITOR/BATTERY, ACCELEROMETER_INTERRUPT pins for LED Glasses Driver