### PR TITLE
Consistently validate location on VectorShape

### DIFF
--- a/shared-bindings/vectorio/Circle.c
+++ b/shared-bindings/vectorio/Circle.c
@@ -42,8 +42,8 @@ static mp_obj_t vectorio_circle_make_new(const mp_obj_type_t *type, size_t n_arg
 
     // VectorShape parts
     mp_obj_t pixel_shader = args[ARG_pixel_shader].u_obj;
-    int16_t x = args[ARG_x].u_int;
-    int16_t y = args[ARG_y].u_int;
+    int32_t x = args[ARG_x].u_int;
+    int32_t y = args[ARG_y].u_int;
     mp_obj_t vector_shape = vectorio_vector_shape_make_new(self, pixel_shader, x, y);
     self->draw_protocol_instance = vector_shape;
 

--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -47,8 +47,8 @@ static mp_obj_t vectorio_polygon_make_new(const mp_obj_type_t *type, size_t n_ar
 
     // VectorShape parts
     mp_obj_t pixel_shader = args[ARG_pixel_shader].u_obj;
-    int16_t x = args[ARG_x].u_int;
-    int16_t y = args[ARG_y].u_int;
+    int32_t x = args[ARG_x].u_int;
+    int32_t y = args[ARG_y].u_int;
     mp_obj_t vector_shape = vectorio_vector_shape_make_new(self, pixel_shader, x, y);
     self->draw_protocol_instance = vector_shape;
 

--- a/shared-bindings/vectorio/Rectangle.c
+++ b/shared-bindings/vectorio/Rectangle.c
@@ -46,8 +46,8 @@ static mp_obj_t vectorio_rectangle_make_new(const mp_obj_type_t *type, size_t n_
 
     // VectorShape parts
     mp_obj_t pixel_shader = args[ARG_pixel_shader].u_obj;
-    int16_t x = args[ARG_x].u_int;
-    int16_t y = args[ARG_y].u_int;
+    int32_t x = args[ARG_x].u_int;
+    int32_t y = args[ARG_y].u_int;
     mp_obj_t vector_shape = vectorio_vector_shape_make_new(self, pixel_shader, x, y);
     self->draw_protocol_instance = vector_shape;
 

--- a/shared-bindings/vectorio/VectorShape.c
+++ b/shared-bindings/vectorio/VectorShape.c
@@ -23,7 +23,7 @@
 // pixel_shader: The pixel shader that produces colors from values. The shader can be a displayio.Palette(1); it will be asked to color pixel value 0.
 // x: Initial x position of the center axis of the shape within the parent.
 // y: Initial y position of the center axis of the shape within the parent."""
-mp_obj_t vectorio_vector_shape_make_new(const mp_obj_t shape, const mp_obj_t pixel_shader, int16_t x, int16_t y) {
+mp_obj_t vectorio_vector_shape_make_new(const mp_obj_t shape, const mp_obj_t pixel_shader, int32_t x, int32_t y) {
     if (!mp_obj_is_type(pixel_shader, &displayio_colorconverter_type) &&
         !mp_obj_is_type(pixel_shader, &displayio_palette_type)) {
         mp_raise_TypeError_varg(translate("unsupported %q type"), MP_QSTR_pixel_shader);
@@ -99,7 +99,10 @@ STATIC mp_obj_t vectorio_vector_shape_obj_set_x(mp_obj_t wrapper_shape, mp_obj_t
     vectorio_vector_shape_t *self = MP_OBJ_TO_PTR(draw_protocol->draw_get_protocol_self(wrapper_shape));
 
     mp_int_t x = mp_obj_get_int(x_obj);
-    common_hal_vectorio_vector_shape_set_x(self, x);
+    bool dirty = common_hal_vectorio_vector_shape_set_x(self, x);
+    if (dirty) {
+        common_hal_vectorio_vector_shape_set_dirty(self);
+    }
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_2(vectorio_vector_shape_set_x_obj, vectorio_vector_shape_obj_set_x);
@@ -130,7 +133,10 @@ STATIC mp_obj_t vectorio_vector_shape_obj_set_y(mp_obj_t wrapper_shape, mp_obj_t
     vectorio_vector_shape_t *self = MP_OBJ_TO_PTR(draw_protocol->draw_get_protocol_self(wrapper_shape));
 
     mp_int_t y = mp_obj_get_int(y_obj);
-    common_hal_vectorio_vector_shape_set_y(self, y);
+    bool dirty = common_hal_vectorio_vector_shape_set_y(self, y);
+    if (dirty) {
+        common_hal_vectorio_vector_shape_set_dirty(self);
+    }
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_2(vectorio_vector_shape_set_y_obj, vectorio_vector_shape_obj_set_y);

--- a/shared-bindings/vectorio/VectorShape.c
+++ b/shared-bindings/vectorio/VectorShape.c
@@ -99,10 +99,7 @@ STATIC mp_obj_t vectorio_vector_shape_obj_set_x(mp_obj_t wrapper_shape, mp_obj_t
     vectorio_vector_shape_t *self = MP_OBJ_TO_PTR(draw_protocol->draw_get_protocol_self(wrapper_shape));
 
     mp_int_t x = mp_obj_get_int(x_obj);
-    bool dirty = common_hal_vectorio_vector_shape_set_x(self, x);
-    if (dirty) {
-        common_hal_vectorio_vector_shape_set_dirty(self);
-    }
+    common_hal_vectorio_vector_shape_set_x(self, x);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_2(vectorio_vector_shape_set_x_obj, vectorio_vector_shape_obj_set_x);
@@ -133,10 +130,7 @@ STATIC mp_obj_t vectorio_vector_shape_obj_set_y(mp_obj_t wrapper_shape, mp_obj_t
     vectorio_vector_shape_t *self = MP_OBJ_TO_PTR(draw_protocol->draw_get_protocol_self(wrapper_shape));
 
     mp_int_t y = mp_obj_get_int(y_obj);
-    bool dirty = common_hal_vectorio_vector_shape_set_y(self, y);
-    if (dirty) {
-        common_hal_vectorio_vector_shape_set_dirty(self);
-    }
+    common_hal_vectorio_vector_shape_set_y(self, y);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_2(vectorio_vector_shape_set_y_obj, vectorio_vector_shape_obj_set_y);

--- a/shared-bindings/vectorio/VectorShape.h
+++ b/shared-bindings/vectorio/VectorShape.h
@@ -11,23 +11,23 @@
 extern const mp_obj_type_t vectorio_vector_shape_type;
 
 // Python shared bindings constructor
-mp_obj_t vectorio_vector_shape_make_new(const mp_obj_t shape, const mp_obj_t pixel_shader, int16_t x, int16_t y);
+mp_obj_t vectorio_vector_shape_make_new(const mp_obj_t shape, const mp_obj_t pixel_shader, int32_t x, int32_t y);
 
 // C data constructor
 void common_hal_vectorio_vector_shape_construct(vectorio_vector_shape_t *self,
     vectorio_ishape_t ishape,
-    mp_obj_t pixel_shader, uint16_t x, uint16_t y);
+    mp_obj_t pixel_shader, int32_t x, int32_t y);
 
 void common_hal_vectorio_vector_shape_set_dirty(void *self);
 
 mp_int_t common_hal_vectorio_vector_shape_get_x(vectorio_vector_shape_t *self);
-void common_hal_vectorio_vector_shape_set_x(vectorio_vector_shape_t *self, mp_int_t x);
+bool common_hal_vectorio_vector_shape_set_x(vectorio_vector_shape_t *self, mp_int_t x);
 
 mp_obj_tuple_t *common_hal_vectorio_vector_shape_get_location(vectorio_vector_shape_t *self);
 void common_hal_vectorio_vector_shape_set_location(vectorio_vector_shape_t *self, mp_obj_t xy);
 
 mp_int_t common_hal_vectorio_vector_shape_get_y(vectorio_vector_shape_t *self);
-void common_hal_vectorio_vector_shape_set_y(vectorio_vector_shape_t *self, mp_int_t y);
+bool common_hal_vectorio_vector_shape_set_y(vectorio_vector_shape_t *self, mp_int_t y);
 
 mp_obj_t common_hal_vectorio_vector_shape_get_pixel_shader(vectorio_vector_shape_t *self);
 void common_hal_vectorio_vector_shape_set_pixel_shader(vectorio_vector_shape_t *self, mp_obj_t pixel_shader);

--- a/shared-bindings/vectorio/VectorShape.h
+++ b/shared-bindings/vectorio/VectorShape.h
@@ -21,13 +21,13 @@ void common_hal_vectorio_vector_shape_construct(vectorio_vector_shape_t *self,
 void common_hal_vectorio_vector_shape_set_dirty(void *self);
 
 mp_int_t common_hal_vectorio_vector_shape_get_x(vectorio_vector_shape_t *self);
-bool common_hal_vectorio_vector_shape_set_x(vectorio_vector_shape_t *self, mp_int_t x);
+void common_hal_vectorio_vector_shape_set_x(vectorio_vector_shape_t *self, mp_int_t x);
 
 mp_obj_tuple_t *common_hal_vectorio_vector_shape_get_location(vectorio_vector_shape_t *self);
 void common_hal_vectorio_vector_shape_set_location(vectorio_vector_shape_t *self, mp_obj_t xy);
 
 mp_int_t common_hal_vectorio_vector_shape_get_y(vectorio_vector_shape_t *self);
-bool common_hal_vectorio_vector_shape_set_y(vectorio_vector_shape_t *self, mp_int_t y);
+void common_hal_vectorio_vector_shape_set_y(vectorio_vector_shape_t *self, mp_int_t y);
 
 mp_obj_t common_hal_vectorio_vector_shape_get_pixel_shader(vectorio_vector_shape_t *self);
 void common_hal_vectorio_vector_shape_set_pixel_shader(vectorio_vector_shape_t *self, mp_obj_t pixel_shader);

--- a/shared-module/vectorio/Polygon.c
+++ b/shared-module/vectorio/Polygon.c
@@ -22,7 +22,7 @@ static void _clobber_points_list(vectorio_polygon_t *self, mp_obj_t points_tuple
     VECTORIO_POLYGON_DEBUG(" self.len: %d, len: %d, ", self->len, len);
 
     if (len < 3) {
-        mp_raise_TypeError_varg(translate("Polygon needs at least 3 points"));
+        mp_raise_TypeError(translate("Polygon needs at least 3 points"));
     }
 
     if (self->len < 2 * len) {

--- a/shared-module/vectorio/VectorShape.c
+++ b/shared-module/vectorio/VectorShape.c
@@ -230,7 +230,7 @@ void common_hal_vectorio_vector_shape_set_location(vectorio_vector_shape_t *self
     mp_obj_t *tuple_items;
     mp_obj_tuple_get(xy, &tuple_len, &tuple_items);
     if (tuple_len != 2) {
-        mp_raise_TypeError_varg(translate("(x,y) integers required"));
+        mp_raise_TypeError(translate("(x,y) integers required"));
     }
 
     mp_int_t x;

--- a/shared-module/vectorio/VectorShape.c
+++ b/shared-module/vectorio/VectorShape.c
@@ -125,6 +125,24 @@ static void _get_screen_area(vectorio_vector_shape_t *self, displayio_area_t *ou
 }
 
 
+STATIC
+void check_bounds_and_set_x(vectorio_vector_shape_t *self, mp_int_t x) {
+    if (x < SHRT_MIN || x > SHRT_MAX) {
+        mp_raise_ValueError_varg(translate("%q must be between %d and %d"), MP_QSTR_x, SHRT_MIN, SHRT_MAX);
+    }
+    self->x = x;
+}
+
+
+STATIC
+void check_bounds_and_set_y(vectorio_vector_shape_t *self, mp_int_t y) {
+    if (y < SHRT_MIN || y > SHRT_MAX) {
+        mp_raise_ValueError_varg(translate("%q must be between %d and %d"), MP_QSTR_y, SHRT_MIN, SHRT_MAX);
+    }
+    self->y = y;
+}
+
+
 // For use by Group to know where it needs to redraw on layer removal.
 bool vectorio_vector_shape_get_dirty_area(vectorio_vector_shape_t *self, displayio_area_t *out_area) {
     out_area->x1 = out_area->x2;
@@ -166,10 +184,8 @@ void common_hal_vectorio_vector_shape_construct(vectorio_vector_shape_t *self,
     vectorio_ishape_t ishape,
     mp_obj_t pixel_shader, int32_t x, int32_t y) {
     VECTORIO_SHAPE_DEBUG("%p vector_shape_construct x:%3d, y:%3d\n", self, x, y);
-    vectorio_vector_shape_validate_x_bounds(x);
-    self->x = x;
-    vectorio_vector_shape_validate_y_bounds(y);
-    self->y = y;
+    check_bounds_and_set_x(self, x);
+    check_bounds_and_set_y(self, y);
     self->pixel_shader = pixel_shader;
     self->ishape = ishape;
     self->absolute_transform = &null_transform; // Critical to have a valid transform before getting screen area.
@@ -191,8 +207,7 @@ void common_hal_vectorio_vector_shape_set_x(vectorio_vector_shape_t *self, mp_in
     if (self->x == x) {
         return;
     }
-    vectorio_vector_shape_validate_x_bounds(x);
-    self->x = x;
+    check_bounds_and_set_x(self, x);
     common_hal_vectorio_vector_shape_set_dirty(self);
 }
 
@@ -208,8 +223,7 @@ void common_hal_vectorio_vector_shape_set_y(vectorio_vector_shape_t *self, mp_in
     if (self->y == y) {
         return;
     }
-    vectorio_vector_shape_validate_y_bounds(y);
-    self->y = y;
+    check_bounds_and_set_y(self, y);
     common_hal_vectorio_vector_shape_set_dirty(self);
 }
 
@@ -239,31 +253,15 @@ void common_hal_vectorio_vector_shape_set_location(vectorio_vector_shape_t *self
     }
     bool dirty = false;
     if (self->x != x) {
-        vectorio_vector_shape_validate_x_bounds(x);
-        self->x = x;
+        check_bounds_and_set_x(self, x);
         dirty = true;
     }
     if (self->y != y) {
-        vectorio_vector_shape_validate_y_bounds(y);
-        self->y = y;
+        check_bounds_and_set_y(self, y);
         dirty = true;
     }
     if (dirty) {
         common_hal_vectorio_vector_shape_set_dirty(self);
-    }
-}
-
-
-void vectorio_vector_shape_validate_x_bounds(mp_int_t x) {
-    if (x < SHRT_MIN || x > SHRT_MAX) {
-        mp_raise_ValueError_varg(translate("%q must be between %d and %d"), MP_QSTR_x, SHRT_MIN, SHRT_MAX);
-    }
-}
-
-
-void vectorio_vector_shape_validate_y_bounds(mp_int_t y) {
-    if (y < SHRT_MIN || y > SHRT_MAX) {
-        mp_raise_ValueError_varg(translate("%q must be between %d and %d"), MP_QSTR_y, SHRT_MIN, SHRT_MAX);
     }
 }
 

--- a/shared-module/vectorio/VectorShape.h
+++ b/shared-module/vectorio/VectorShape.h
@@ -51,7 +51,4 @@ bool vectorio_vector_shape_fill_area(vectorio_vector_shape_t *self, const _displ
 bool vectorio_vector_shape_get_previous_area(vectorio_vector_shape_t *self, displayio_area_t *out_area);
 void vectorio_vector_shape_finish_refresh(vectorio_vector_shape_t *self);
 
-void vectorio_vector_shape_validate_x_bounds(mp_int_t x);
-void vectorio_vector_shape_validate_y_bounds(mp_int_t y);
-
 #endif // MICROPY_INCLUDED_SHARED_MODULE_VECTORIO_SHAPE_H

--- a/shared-module/vectorio/VectorShape.h
+++ b/shared-module/vectorio/VectorShape.h
@@ -51,4 +51,7 @@ bool vectorio_vector_shape_fill_area(vectorio_vector_shape_t *self, const _displ
 bool vectorio_vector_shape_get_previous_area(vectorio_vector_shape_t *self, displayio_area_t *out_area);
 void vectorio_vector_shape_finish_refresh(vectorio_vector_shape_t *self);
 
+void vectorio_vector_shape_validate_x_bounds(mp_int_t x);
+void vectorio_vector_shape_validate_y_bounds(mp_int_t y);
+
 #endif // MICROPY_INCLUDED_SHARED_MODULE_VECTORIO_SHAPE_H


### PR DESCRIPTION
Closes #5325

The x, y or location properties now use the same bounds validation whether set via the constructor or setters.
Tested with the code in #5325 which now raises Errors consistently when out of range.

@WarriorOfWire can you check if these changes are consistent with the rewrite and pass any test code you have?