### PR TITLE
proxlight: Freeze adafruit_apds9960 instead of adafruit_hid; enable usb_midi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -191,3 +191,6 @@
 [submodule "lib/quirc"]
 	path = lib/quirc
 	url = https://github.com/adafruit/quirc.git
+[submodule "frozen/Adafruit_CircuitPython_APDS9960"]
+	path = frozen/Adafruit_CircuitPython_APDS9960
+	url = https://github.com/adafruit/Adafruit_CircuitPython_APDS9960

--- a/ports/atmel-samd/boards/adafruit_proxlight_trinkey_m0/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/adafruit_proxlight_trinkey_m0/mpconfigboard.mk
@@ -19,7 +19,6 @@ CIRCUITPY_PULSEIO = 0
 CIRCUITPY_PWMIO = 0
 CIRCUITPY_ROTARYIO = 0
 CIRCUITPY_RTC = 0
-CIRCUITPY_USB_MIDI = 0
 
 CIRCUITPY_GETPASS = 0
 CIRCUITPY_TRACEBACK = 0
@@ -28,5 +27,5 @@ CIRCUITPY_PIXELBUF = 1
 CIRCUITPY_BUSDEVICE = 1
 
 # Include these Python libraries in firmware.
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_HID
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_APDS9960
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel


### PR DESCRIPTION
The proxlight trinkey is tight on space, but we'd like it to work for both HID and MIDI. It appears that if we freeze the APDS9960 library instead of HID, then sample programs will fit.

Done:
- Enable `usb_midi`, which was previously disabled.
- Do not freeze `adafruit_hid`.
- Freeze `adafruit_adps9960`.

The APDS9960 library itself could be reduced by about 500 bytes by shortening and underscoring the command constants, but that doesn't help make anything else fit, so it's not high priority to fix right now.