### PR TITLE
Enable WFI for raspberrypi port

### DIFF
--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -238,7 +238,7 @@ void port_interrupt_after_ticks(uint32_t ticks) {
 void port_idle_until_interrupt(void) {
     common_hal_mcu_disable_interrupts();
     if (!background_callback_pending()) {
-        asm volatile ("dsb 0xF":::"memory");
+        asm volatile ("dsb 0xF" ::: "memory");
         __wfi();
     }
     common_hal_mcu_enable_interrupts();

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -238,8 +238,8 @@ void port_interrupt_after_ticks(uint32_t ticks) {
 void port_idle_until_interrupt(void) {
     common_hal_mcu_disable_interrupts();
     if (!background_callback_pending()) {
-//	asm volatile ("dsb 0xF":::"memory");
-//        __wfi();
+        asm volatile ("dsb 0xF":::"memory");
+        __wfi();
     }
     common_hal_mcu_enable_interrupts();
 }


### PR DESCRIPTION
Following #5331. Tested this change on a physical Raspberry Pi Pico board:

1. I can see the CP drive in my PC
2. I have a serial console (over USB)
3. I can copy my code to the CP drive, it runs
4. The code blinks the LED successfully and prints to the Serial console
5. I can get into the REPL and type commands successfully

If you want me to do any additional testing, just let me know what else to test. Thanks!
