### PR TITLE
Revert #5341. Does not work on power-cycle.

### DIFF
--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -238,8 +238,9 @@ void port_interrupt_after_ticks(uint32_t ticks) {
 void port_idle_until_interrupt(void) {
     common_hal_mcu_disable_interrupts();
     if (!background_callback_pending()) {
-        asm volatile ("dsb 0xF" ::: "memory");
-        __wfi();
+        // TODO: Does not work when board is power-cycled.
+        // asm volatile ("dsb 0xF" ::: "memory");
+        // __wfi();
     }
     common_hal_mcu_enable_interrupts();
 }


### PR DESCRIPTION
Reverts #5341 to fix #5354 for now. We'll do a more detailed diagnosis after 7.0.0 final.

Discussed in terms of scheduling with @tannewt.