### PR TITLE
paralleldisplay: make it actually importable

### DIFF
--- a/py/circuitpy_defns.mk
+++ b/py/circuitpy_defns.mk
@@ -471,6 +471,8 @@ $(filter $(SRC_PATTERNS), \
 	microcontroller/RunMode.c \
 	msgpack/__init__.c \
 	msgpack/ExtType.c \
+	paralleldisplay/__init__.c \
+	paralleldisplay/ParallelBus.c \
 	supervisor/RunReason.c \
 	wifi/AuthMode.c \
 )

--- a/shared-bindings/paralleldisplay/__init__.c
+++ b/shared-bindings/paralleldisplay/__init__.c
@@ -24,4 +24,28 @@
  * THE SOFTWARE.
  */
 
-#pragma once
+#include <stdint.h>
+
+#include "py/enum.h"
+#include "py/obj.h"
+#include "py/runtime.h"
+
+#include "shared-bindings/paralleldisplay/__init__.h"
+#include "shared-bindings/paralleldisplay/ParallelBus.h"
+
+//| """Native helpers for driving parallel displays"""
+
+
+STATIC const mp_rom_map_elem_t paralleldisplay_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_paralleldisplay) },
+    { MP_ROM_QSTR(MP_QSTR_ParallelBus), MP_ROM_PTR(&paralleldisplay_parallelbus_type) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(paralleldisplay_module_globals, paralleldisplay_module_globals_table);
+
+const mp_obj_module_t paralleldisplay_module = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&paralleldisplay_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_paralleldisplay, paralleldisplay_module, CIRCUITPY_PARALLELDISPLAY);


### PR DESCRIPTION
Some code that should have been in a C file was in a header file instead.  It's a wonder it built at all.