### PR TITLE
mp_hal_delay_ms: avoid overflow when scaling ticks

### DIFF
--- a/supervisor/shared/tick.c
+++ b/supervisor/shared/tick.c
@@ -127,12 +127,12 @@ void PLACE_IN_ITCM(supervisor_run_background_tasks_if_tick)() {
     background_callback_run_all();
 }
 
-void mp_hal_delay_ms(mp_uint_t delay) {
+void mp_hal_delay_ms(mp_uint_t delay_ms) {
     uint64_t start_tick = port_get_raw_ticks(NULL);
     // Adjust the delay to ticks vs ms.
-    delay = delay * 1024 / 1000;
-    uint64_t end_tick = start_tick + delay;
-    int64_t remaining = delay;
+    uint64_t delay_ticks = (delay_ms * (uint64_t)1024) / 1000;
+    uint64_t end_tick = start_tick + delay_ticks;
+    int64_t remaining = delay_ticks;
 
     // Loop until we've waited long enough or we've been CTRL-Ced by autoreload
     // or the user.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3068843/133827940-970c653e-7dcc-4262-89dc-3d47fe03ce69.png)

This patch casts the `delay` argument to `mp_hal_delay_ms()` from `mp_uint_t` to `uint64_t` when scaling from milliseconds to ticks to avoid 32-bit integer overflow when `time.sleep()` is called with a duration of greater than 70 minutes.

[for those who may rely on assistive technology, the image reads:
> The implementation of time.sleep() in CircuitPython for the RP2040 is sus.  Seemst o have consistent issues with sleep times measured in hours
> A sleep of 2 hours seems to take about 2 hours and 15 mins while a sleep of 22 hours takes less than an hour :/

-- @jepler]