### PR TITLE
Update Display.fill_row() to accept all WriteableBuffers

### DIFF
--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -467,9 +467,6 @@ STATIC mp_obj_t displayio_display_obj_fill_row(size_t n_args, const mp_obj_t *po
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(result, &bufinfo, MP_BUFFER_WRITE);
 
-    if (bufinfo.typecode != BYTEARRAY_TYPECODE) {
-        mp_raise_ValueError(translate("Buffer is not a bytearray."));
-    }
     if (self->core.colorspace.depth != 16) {
         mp_raise_ValueError(translate("Display must have a 16 bit colorspace."));
     }


### PR DESCRIPTION
Closes #5362

Tested on PyPortal with the following code:
```python
import board
import displayio
import array
import ulab

display = board.DISPLAY
width = display.width
height = display.height
scale = max(width, height)

g = displayio.Group(scale=scale)
bitmap = displayio.Bitmap(10, 10, 1)
palette = displayio.Palette(1)
palette[0] = 0xFF7F00
tilegrid = displayio.TileGrid(bitmap, pixel_shader=palette)
g.append(tilegrid)
display.show(g)

bufsize = 2 * (width if display.rotation in (0, 180) else height)

memviewbuffer = bytearray(bufsize)
buffers = (
    bytearray(bufsize),
    memoryview(memviewbuffer),
    array.array("B", [0] * bufsize),  # Unsigned 1-byte
    array.array("L", [0] * (bufsize // 4)),  # Unsigned 2-byte
    array.array("Q", [0] * (bufsize // 8)),  # Unsigned 4-byte
    ulab.numpy.ndarray([0] * bufsize, dtype=ulab.numpy.uint8),  # Unsigned 1-byte
    ulab.numpy.ndarray([0] * (bufsize // 2), dtype=ulab.numpy.uint16),  # Unsigned 2-byte
)

outbuffers = []
for buffer in buffers:
    outbuffers.append(display.fill_row(0, buffer))

for out in outbuffers:
    buf = bytes(out[:16])
    buf = [f"{b:02X}" for b in buf[:16]]
    print(type(out))
    print("    ", "".join(buf))
```

Outputs:
```
%Run -c $EDITOR_CONTENT
<class 'bytearray'>
     FBE0FBE0FBE0FBE0FBE0FBE0FBE0FBE0
<class 'memoryview'>
     FBE0FBE0FBE0FBE0FBE0FBE0FBE0FBE0
<class 'array'>
     FBE0FBE0FBE0FBE0FBE0FBE0FBE0FBE0
<class 'array'>
     FBE0FBE0FBE0FBE0FBE0FBE0FBE0FBE0
<class 'array'>
     FBE0FBE0FBE0FBE0FBE0FBE0FBE0FBE0
<class 'ndarray'>
     FBE0FBE0FBE0FBE0FBE0FBE0FBE0FBE0
<class 'ndarray'>
     FBE0FBE0FBE0FBE0FBE0FBE0FBE0FBE0
```