### PR TITLE
condition for release version of stubs upload to pypi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,7 +242,7 @@ jobs:
         zip -9r circuitpython-stubs.zip circuitpython-stubs
         [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp circuitpython-stubs/dist/*.tar.gz s3://adafruit-circuit-python/bin/stubs/circuitpython-stubs-${{ env.CP_VERSION }}.zip --no-progress --region us-east-1
     - name: Upload stubs to PyPi
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit'
+      if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
       env:
         TWINE_USERNAME: ${{ secrets.pypi_username }}
         TWINE_PASSWORD: ${{ secrets.pypi_password }}


### PR DESCRIPTION
The `7.0.0` [release actions](https://github.com/adafruit/circuitpython/runs/3651069692?check_suite_focus=true) skipped the step to upload the stubs to PyPi so we've ended up with only `pre-release` versions that are on PyPi.

This changes the condition for PyPi stubs upload to match the ones used for the S3 stubs upload so that it will upload a stable version when the next release is made.

I tested these conditions in a branch on my fork. The actions run that did complete the upload successfully can be found here:
https://github.com/FoamyGuy/circuitpython/runs/3681958468?check_suite_focus=true

and the stable version now appears in the PyPi release history for my test copy of the stubs here:
https://pypi.org/project/circuitpython-stubs-foamyguy-1/7.0.3/#history