### PR TITLE
CI: Bump esp-idf cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -348,7 +348,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/espressif/esp-idf/HEAD') }}-20210716
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/espressif/esp-idf/HEAD') }}-20210923
     - name: Clone IDF submodules
       run: |
         (cd $IDF_PATH && git submodule update --init)


### PR DESCRIPTION
Espressif builds are failing with the current cache key.