### PR TITLE
Fix espressif serial over uart

### DIFF
--- a/ports/espressif/common-hal/microcontroller/Pin.c
+++ b/ports/espressif/common-hal/microcontroller/Pin.c
@@ -58,6 +58,9 @@ void never_reset_pin_number(gpio_num_t pin_number) {
 }
 
 void common_hal_never_reset_pin(const mcu_pin_obj_t *pin) {
+    if (pin == NULL) {
+        return;
+    }
     never_reset_pin_number(pin->number);
 }
 

--- a/ports/espressif/common-hal/microcontroller/Pin.h
+++ b/ports/espressif/common-hal/microcontroller/Pin.h
@@ -36,6 +36,7 @@ void reset_all_pins(void);
 // need to store a full pointer.
 void reset_pin_number(gpio_num_t pin_number);
 void common_hal_reset_pin(const mcu_pin_obj_t *pin);
+void common_hal_never_reset_pin(const mcu_pin_obj_t *pin);
 void claim_pin(const mcu_pin_obj_t *pin);
 void claim_pin_number(gpio_num_t pin_number);
 bool pin_number_is_free(gpio_num_t pin_number);


### PR DESCRIPTION
The `common_hal_busio_uart_never_reset()` function wasn't implemented in espressif port. 
This caused serial over uart to not function properly as `busio` is reset at multiple occasions after `serial_early_init()`.