### PR TITLE
Fixes incorrect pin definitions for Challenger RP2040 WiFi board.

### DIFF
--- a/ports/raspberrypi/boards/challenger_rp2040_wifi/mpconfigboard.h
+++ b/ports/raspberrypi/boards/challenger_rp2040_wifi/mpconfigboard.h
@@ -2,7 +2,7 @@
 #define MICROPY_HW_MCU_NAME "rp2040"
 
 #define DEFAULT_UART_BUS_TX   (&pin_GPIO16)
-#define DEFAULT_UART_BUS_RX   (&pin_GPIO16)
+#define DEFAULT_UART_BUS_RX   (&pin_GPIO17)
 #define DEFAULT_I2C_BUS_SDA   (&pin_GPIO0)
 #define DEFAULT_I2C_BUS_SCL   (&pin_GPIO1)
 #define DEFAULT_SPI_BUS_SCK   (&pin_GPIO22)

--- a/ports/raspberrypi/boards/challenger_rp2040_wifi/pins.c
+++ b/ports/raspberrypi/boards/challenger_rp2040_wifi/pins.c
@@ -42,8 +42,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO16) },
     { MP_ROM_QSTR(MP_QSTR_GP16), MP_ROM_PTR(&pin_GPIO16) },
 
-    { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_GPIO17) },
-    { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO17) },
+    { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_GPIO17) },
+    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO17) },
     { MP_ROM_QSTR(MP_QSTR_GP17), MP_ROM_PTR(&pin_GPIO17) },
 
     { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_GPIO22) },


### PR DESCRIPTION
As described in the title. The first commit had an error connected to the UART pins. This fixes it.