### PR TITLE
Fix a critical "typo"

### DIFF
--- a/ports/nrf/boards/makerdiary_nrf52840_mdk/mpconfigboard.h
+++ b/ports/nrf/boards/makerdiary_nrf52840_mdk/mpconfigboard.h
@@ -37,7 +37,7 @@
 #define MICROPY_QSPI_DATA2                NRF_GPIO_PIN_MAP(1, 2)
 #define MICROPY_QSPI_DATA3                NRF_GPIO_PIN_MAP(1, 1)
 #define MICROPY_QSPI_SCK                  NRF_GPIO_PIN_MAP(1, 3)
-#define MICROPY_QSPI_CS                   NRF_GPIO_PIN_MAP(1, 8)
+#define MICROPY_QSPI_CS                   NRF_GPIO_PIN_MAP(1, 6)
 
 #define BOARD_HAS_CRYSTAL 0
 


### PR DESCRIPTION
Current compiled downloads are unusable because MICROPY_QSPI_CS is defined as the wrong pin