### PR TITLE
PicoSystem: Add DisplayIO to board config

### DIFF
--- a/ports/raspberrypi/boards/pimoroni_picosystem/board.c
+++ b/ports/raspberrypi/boards/pimoroni_picosystem/board.c
@@ -25,8 +25,93 @@
  */
 
 #include "supervisor/board.h"
+#include "mpconfigboard.h"
+#include "shared-bindings/busio/SPI.h"
+#include "shared-bindings/displayio/FourWire.h"
+#include "shared-module/displayio/__init__.h"
+#include "shared-module/displayio/mipi_constants.h"
+#include "supervisor/shared/board.h"
+
+displayio_fourwire_obj_t board_display_obj;
+
+#define DELAY 0x80
+
+uint8_t display_init_sequence[] = {
+    0x01, 0 | DELAY, 150, // SWRESET
+
+    0x36, 1, 0x04, // MADCTL
+    0x35, 1, 0x00, // TEON
+    0xB2, 5, 0x0c, 0x0c, 0x00, 0x33, 0x33, // FRMCTR2
+    0x3A, 1, 0x05, // COLMOD
+    0xB7, 1, 0x14, // GCTRL
+    0xBB, 1, 0x37, // VCOMS
+    0xC0, 1, 0x2c, // LCMCTRL
+    0xC2, 1, 0x01, // VDVVRHEN
+    0xC3, 1, 0x12, // VRHS
+    0xC4, 1, 0x20, // VDVS
+    0xD0, 2, 0xa4, 0xa1, // PWRCTRL1
+    0xC6, 1, 0x0f, // FRCTRL2
+    0xE0, 14, 0xd0, 0x04, 0x0d, 0x11, 0x13, 0x2b, 0x3f, 0x54, 0x4c, 0x18, 0x0d, 0x0b, 0x1f, 0x23, // GMCTRP1
+    0xE1, 14, 0xd0, 0x04, 0x0c, 0x11, 0x13, 0x2c, 0x3f, 0x44, 0x51, 0x2f, 0x1f, 0x1f, 0x20, 0x23, // GMCTRN1
+    0x21, 0, // INVON
+
+    0x11, 0 | DELAY, 255, // SLPOUT
+    0x29, 0 | DELAY, 100, // DISPON
+
+    0x2a, 4, 0x00, 0, 0x00, 0xfe, // CASET
+    0x2b, 4, 0x00, 0, 0x00, 0xfe, // RASET
+    0x2c, 0, // RAMWR
+};
 
 void board_init(void) {
+    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    common_hal_busio_spi_construct(spi, &pin_GPIO6, &pin_GPIO7, NULL);
+    common_hal_busio_spi_never_reset(spi);
+
+    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    bus->base.type = &displayio_fourwire_type;
+    common_hal_displayio_fourwire_construct(bus,
+        spi,
+        &pin_GPIO9, // TFT_DC Command or data
+        &pin_GPIO5, // TFT_CS Chip select
+        &pin_GPIO4, // TFT_RST Reset
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
+
+    displayio_display_obj_t *display = &displays[0].display;
+    display->base.type = &displayio_display_type;
+    common_hal_displayio_display_construct(display,
+        bus,
+        240, // Width
+        240, // Height
+        0, // column start
+        0, // row start
+        0, // rotation
+        16, // Color depth
+        false, // Grayscale
+        false, // pixels in a byte share a row. Only valid for depths < 8
+        1, // bytes per cell. Only valid for depths < 8
+        false, // reverse_pixels_in_byte. Only valid for depths < 8
+        true, // reverse_bytes_in_word
+        MIPI_COMMAND_SET_COLUMN_ADDRESS, // Set column command
+        MIPI_COMMAND_SET_PAGE_ADDRESS, // Set row command
+        MIPI_COMMAND_WRITE_MEMORY_START, // Write memory command
+        display_init_sequence,
+        sizeof(display_init_sequence),
+        &pin_GPIO12,  // backlight pin
+        NO_BRIGHTNESS_COMMAND,
+        1.0f, // brightness (ignored)
+        true, // auto_brightness
+        false, // single_byte_bounds
+        false, // data_as_commands
+        true, // auto_refresh
+        60, // native_frames_per_second
+        true, // backlight_on_high
+        false); // SH1107_addressing
+}
+
+void board_deinit(void) {
 }
 
 bool board_requests_safe_mode(void) {
@@ -34,7 +119,4 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
-}
-
-void board_deinit(void) {
 }

--- a/ports/raspberrypi/boards/pimoroni_picosystem/mpconfigboard.mk
+++ b/ports/raspberrypi/boards/pimoroni_picosystem/mpconfigboard.mk
@@ -9,3 +9,11 @@ CHIP_FAMILY = rp2
 EXTERNAL_FLASH_DEVICES = "W25Q128JVxQ"
 
 CIRCUITPY__EVE = 1
+
+CIRCUITPY_KEYPAD = 1
+CIRCUITPY_STAGE = 1
+
+CIRCUITPY_AUDIOIO = 1
+
+# TODO: how do we get stage.py and ugame.py on PicoSystem?
+# FROZEN_MPY_DIRS += $(TOP)/frozen/circuitpython-stage/picosystem

--- a/ports/raspberrypi/boards/pimoroni_picosystem/pins.c
+++ b/ports/raspberrypi/boards/pimoroni_picosystem/pins.c
@@ -1,4 +1,5 @@
 #include "shared-bindings/board/__init__.h"
+#include "shared-module/displayio/__init__.h"
 
 STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
@@ -41,5 +42,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display)}
 };
+
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
This PR adds DisplayIO bringup to the Pimoroni PicoSystem.

This is raised as a draft with a line in mpconfigboard stubbed out (so checks will hopefully pass), pending the addition of a PicoSystem "stage" and "ugame" to https://github.com/python-ugame/circuitpython-stage/ and a bump to the submodule.

Looks like circuitpython-stage submodule is currently tracking master, so there shouldn't be any implications in bumping it?