### PR TITLE
Add `esp32c3` documentation in `readme`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,7 +213,7 @@ Supported         Support status
 ================  ============================================================
 atmel-samd        ``SAMD21`` stable | ``SAMD51`` stable
 cxd56             stable
-espressif         stable
+espressif         ``ESP32-C3`` beta | ``ESP32-S2`` stable
 litex             alpha
 mimxrt10xx        alpha
 nrf               stable

--- a/ports/espressif/README.rst
+++ b/ports/espressif/README.rst
@@ -1,7 +1,16 @@
-Circuitpython on ESP32-S2
+CircuitPython on Espressif SoCs
 =======================================
 
-This port adds the ESP32-S2 line of modules from Espressif to Circuitpython. ESP32-S2 modules are low power, single-core Wi-Fi microcontroller SoCs designed for IoT applications.
+This port adds the Espressif line of SoCs to CircuitPython.
+
+Support Status:
+---------------------------------------
+
+.. csv-table::
+    :header: SoC, Status
+
+    ESP32-C3, "beta"
+    ESP32-S2, "stable"
 
 How this port is organized:
 ---------------------------------------
@@ -10,17 +19,54 @@ How this port is organized:
 - **boards/** contains the configuration files for each development board and breakout available on the port.
 - **common-hal/** contains the port-specific module implementations, used by shared-module and shared-bindings.
 - **esp-idf/** contains the Espressif IoT development framework installation, including all the drivers for the port.
-- **modules/** contains information specific to certain ESP32-S2 hardware modules, such as the pins used for flash and RAM on the WROVER and WROOM.
+- **modules/** contains information specific to certain Espressif SoC based hardware modules, such as the pins used for flash and RAM on the WROVER and WROOM.
 - **peripherals/** contains peripheral setup files and peripheral mapping information, sorted by family and sub-variant. Most files in this directory can be generated with the python scripts in **tools/**.
 - **supervisor/** contains port-specific implementations of internal flash, serial and USB, as well as the **port.c** file, which initializes the port at startup.
 - **tools/** includes useful python scripts for debugging and other purposes.
 
 At the root level, refer to **mpconfigboard.h** and **mpconfigport.mk** for port specific settings and a list of enabled circuitpython modules.
 
+Connecting to the ESP32-C3
+---------------------------------------
+
+**USB Connetion:**
+
+On ESP32-C3 REV3 chips, a USB Serial/JTAG Controller is available. Note: The USB connection cannot be used for a ``CIRCUITPY`` drive.
+
+Depending on the board you have the USB port may or may not be connected to native USB, if it isn't connected to native USB then following connections need to be made to get serial console, REPL interface, flashing CircuitPython and JTAG debugging.
+
+.. csv-table::
+    :header: GPIO, USB
+
+    19, "D+ (green)"
+    18, "D- (white)"
+    GND, "GND (black)"
+    5V, "5V (red)"
+
+Connect these pins using a `USB adapter <https://www.adafruit.com/product/4090>`_ or `breakout cable <https://www.adafruit.com/product/4448>`_.
+
+**UART Connection:**
+
+A `USB to UART convertor <https://www.adafruit.com/product/3309>`_ can be used for connecting to ESP32-C3 to get serial console, REPL interface and flashing CircuitPython. Following connections need to be made in this case.
+
+.. csv-table::
+    :header: GPIO, UART
+
+    21, "RX"
+    20, "TX"
+    GND, "GND"
+    5V, "5V"
+
+**BLE Connection:**
+
+This feature is not yet available and currently under development.
+
 Connecting to the ESP32-S2
 ---------------------------------------
 
-The USB port built into ESP32-S2 boards such as the Saola is not the native USB of the board, but a debugging and programming interface. The actual ESP32-S2 native USB which exposes the Circuitpython drive and CDC connection is located on IO pins 19 and 20:
+**USB Connetion:**
+
+Depending on the board you have the USB port may or may not be connected to native USB, if it isn't connected to native USB then following connections need to be made to get CircuitPython working.
 
 .. csv-table::
     :header: GPIO, USB
@@ -28,14 +74,14 @@ The USB port built into ESP32-S2 boards such as the Saola is not the native USB 
     20, "D+ (green)"
     19, "D- (white)"
     GND, "GND (black)"
-    5V, "+5V (red)"
+    5V, "5V (red)"
 
-Connect these pins using a `USB adapter <https://www.adafruit.com/product/4090>`_ or `breakout cable <https://www.adafruit.com/product/4448>`_ to access the Circuitpython drive.
+Connect these pins using a `USB adapter <https://www.adafruit.com/product/4090>`_ or `breakout cable <https://www.adafruit.com/product/4448>`_ to access the CircuitPython drive.
 
 Building and flashing
 ---------------------------------------
 
-Before building or flashing the ESP32-S2, you must `install the esp-idf <https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/get-started/index.html>`_. This must be re-done every time the esp-idf is updated, but not every time you build. Run ``cd ports/esp32s2`` from ``circuitpython/`` to move to the esp32s2 port root, and run:
+Before building or flashing the, you must `install the esp-idf <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/index.html>`_. This must be re-done every time the esp-idf is updated, but not every time you build. Run ``cd ports/espressif`` from ``circuitpython/`` to move to the espressif port root, and run:
 
 .. code-block::
 
@@ -47,16 +93,20 @@ After this initial installation, you must add the esp-idf tools to your path. Yo
 
     . esp-idf/export.sh
 
-When Circuitpython updates the ESP-IDF to a new release, you may need to run this installation process again. The exact commands used may also vary based on your bash environment.
+When CircuitPython updates the ESP-IDF to a new release, you may need to run this installation process again. The exact commands used may also vary based on your bash environment.
 
-Building boards such as the Saola is typically done through ``make flash``. The default port is ``tty.SLAB_USBtoUART``, which will only work on certain Mac setups. On most machines, both Mac and Linux, you will need to set the port yourself by running ``ls /dev/tty.usb*`` and selecting the one that only appears when your development board is plugged in. An example make command with the port setting is as follows:
+Building boards is typically done through ``make BOARD=board_id``. The default port is ``tty.SLAB_USBtoUART``, which will only work on certain Mac setups. On most machines, both Mac and Linux, you will need to set the port yourself by running ``ls /dev/tty.usb*`` and selecting the one that only appears when your development board is plugged in. An example make command with the port setting is as follows:
 
 .. code-block::
 
-    make BOARD=espressif_saola_1_wrover flash PORT=/dev/tty.usbserial-1421120
+    make BOARD=board_id PORT=/dev/tty.usbserial-1421120 flash
+
+``board_id`` is the unique board identifier in CircuitPython. It is the same as the name of board in ``boards`` directory.
 
 Debugging
 ---------------------------------------
+
+TODO: Add documentation for ESP32-C3 JTAG feature.
 
 The ESP32-S2 supports JTAG debugging over OpenOCD using a JLink or other probe hardware. The official tutorials can be found on the Espressif website `here <https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/jtag-debugging/index.html>`_, but they are mostly for the ESP32-S2 Kaluga, which has built-in debugging.
 
@@ -64,7 +114,7 @@ OpenOCD is automatically installed and added to your bash environment during the
 
 Once the debugger is connected physically, you must run OpenOCD with attached configuration files specifying the **interface** (your debugger probe) and either a **target** or a **board** (targets are for SoCs only, and can be used when a full board configuration file doesn't exist). You can find the path location of these files by checking the ``OPENOCD_SCRIPTS`` environmental variable by running ``echo $OPENOCD_SCRIPTS`` in bash. Interfaces will be in the ``interface/`` directory, and targets and boards in the ``target/`` and ``board/`` directories, respectively.
 
-**Note:** Unfortunately, there are no board files for the esp32-s2 other than the Kaluga, and the included ``target/esp32s2.cfg`` target file will not work by default on the Jlink for boards like the Saola 1, as the default speed is incorrect. In addition, these files are covered under the GPL and cannot be included in Circuitpython. Thus, you must make a copy of the esp32s2.cfg file yourself and add the following line manually, under ``transport select jtag`` at the start of the file:
+**Note:** Unfortunately, there are no board files for the esp32-s2 other than the Kaluga, and the included ``target/esp32s2.cfg`` target file will not work by default on the Jlink for boards like the Saola 1, as the default speed is incorrect. In addition, these files are covered under the GPL and cannot be included in CircuitPython. Thus, you must make a copy of the esp32s2.cfg file yourself and add the following line manually, under ``transport select jtag`` at the start of the file:
 
 .. code-block::
 


### PR DESCRIPTION
Updates `readme` to include `esp32c3` related documentation. 