### PR TITLE
[#4701] Correct DAC clock speed comments for SAMD21 and SAMD51

### DIFF
--- a/ports/atmel-samd/common-hal/analogio/AnalogOut.c
+++ b/ports/atmel-samd/common-hal/analogio/AnalogOut.c
@@ -85,8 +85,8 @@ void common_hal_analogio_analogout_construct(analogio_analogout_obj_t *self,
     _pm_enable_bus_clock(PM_BUS_APBC, DAC);
     #endif
 
-    // SAMD21: This clock should be <= 12 MHz, per datasheet section 47.6.3.
-    // SAMD51: This clock should be <= 350kHz, per datasheet table 37-6.
+    // SAMD21: This clock should be <= 350 kHz, per datasheet table 36-7.
+    // SAMD51: This clock should be <= 12 MHz, per datasheet section 47.6.3.
     _gclk_enable_channel(DAC_GCLK_ID, CONF_GCLK_DAC_SRC);
 
     // Don't double init the DAC on the SAMD51 when both outputs are in use. We use the free state


### PR DESCRIPTION
I fixed the DAC clock speed comment typos. In addition to SAMD21 and SAMD51 being reversed, the datasheet reference for the SAMD21 table was incorrect.

I verified the clock speeds and datasheet references with the current datasheets:
SAMD21: https://cdn-shop.adafruit.com/product-files/2772/atmel-42181-sam-d21_datasheet.pdf
SAMD51: https://www.microchip.com/content/dam/mchp/documents/MCU32/ProductDocuments/DataSheets/SAM_D5x_E5x_Family_Data_Sheet_DS60001507G.pdf