### PR TITLE
adding battery monitoring pins to M60

### DIFF
--- a/ports/nrf/boards/makerdiary_m60_keyboard/pins.c
+++ b/ports/nrf/boards/makerdiary_m60_keyboard/pins.c
@@ -39,7 +39,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_CHARGING), MP_ROM_PTR(&pin_P0_03) },
     { MP_ROM_QSTR(MP_QSTR_VOLTAGE_MONITOR), MP_ROM_PTR(&pin_P0_02) },
     { MP_ROM_QSTR(MP_QSTR_BATTERY), MP_ROM_PTR(&pin_P0_02) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_RGB_POWER), MP_ROM_PTR(&pin_P1_04) },
 
 //   { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },


### PR DESCRIPTION
The M60 Pin Configuration had missing pins to allow for Battery monitoring.
These match the documentation from [makerdairy wiki](https://wiki.makerdiary.com/m60/developer_guide/hardware/)

