### PR TITLE
changing MICROPY_HW_BOARD_NAME from Dongle to DK

### DIFF
--- a/ports/nrf/boards/pca10100/mpconfigboard.h
+++ b/ports/nrf/boards/pca10100/mpconfigboard.h
@@ -27,7 +27,7 @@
 
 #include "nrfx/hal/nrf_gpio.h"
 
-#define MICROPY_HW_BOARD_NAME       "PCA10100 nRF52833 Dongle"
+#define MICROPY_HW_BOARD_NAME       "PCA10100 nRF52833 DK"
 #define MICROPY_HW_MCU_NAME         "nRF52833"
 
 #define MICROPY_HW_LED_STATUS          (&pin_P0_13)


### PR DESCRIPTION
As I was creating a new nRF52833 board, I saw that the nRF52833 DK (PCA10100)  MICROPY_HW_BOARD_NAME is incorrectly defined as a Dongle and not a DK.

Both the [CircuitPython Org](https://circuitpython.org/board/pca10100/) and [Nordic Semiconductor](https://www.nordicsemi.com/Products/Development-hardware/nrf52833-dk) sites indicate DK (for development kit)