### PR TITLE
Fix `FourWire` and `I2CDisplay` argument validation

### DIFF
--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -32,6 +32,7 @@
 #include "py/binary.h"
 #include "py/objproperty.h"
 #include "py/runtime.h"
+#include "shared-bindings/busio/SPI.h"
 #include "shared-bindings/displayio/Group.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/util.h"

--- a/shared-bindings/displayio/I2CDisplay.c
+++ b/shared-bindings/displayio/I2CDisplay.c
@@ -34,6 +34,7 @@
 #include "py/objproperty.h"
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/Pin.h"
+#include "shared-bindings/busio/I2C.h"
 #include "shared-bindings/util.h"
 #include "shared-module/displayio/__init__.h"
 #include "supervisor/shared/translate.h"
@@ -67,7 +68,7 @@ STATIC mp_obj_t displayio_i2cdisplay_make_new(const mp_obj_type_t *type, size_t 
 
     mcu_pin_obj_t *reset = validate_obj_is_free_pin_or_none(args[ARG_reset].u_obj);
 
-    mp_obj_t i2c = args[ARG_i2c_bus].u_obj;
+    mp_obj_t i2c = mp_arg_validate_type(args[ARG_i2c_bus].u_obj, &busio_i2c_type, MP_QSTR_i2c_bus);
     displayio_i2cdisplay_obj_t *self = &allocate_display_bus_or_raise()->i2cdisplay_bus;
     self->base.type = &displayio_i2cdisplay_type;
 


### PR DESCRIPTION
resolves #5449 

Check spi argument for `None` and raise a ValueError instead of crashing.

Tested successfully with code from the issue. on:
```
Adafruit CircuitPython 7.0.0-176-gf13db0d0e-dirty on 2021-10-09; Raspberry Pi Pico with rp2040
Board ID:raspberry_pi_pico
```
With the build from the PR it does successfully raise the ValueError instead of crashing into the broken state.