### PR TITLE
eespressif: ParallelImageCapture: keep peripheral running

### DIFF
--- a/ports/espressif/common-hal/imagecapture/ParallelImageCapture.c
+++ b/ports/espressif/common-hal/imagecapture/ParallelImageCapture.c
@@ -110,10 +110,10 @@ void common_hal_imagecapture_parallelimagecapture_capture(imagecapture_paralleli
         self->config.frame1_buffer = buffer;
 
         cam_init(&self->config);
+        cam_start();
     } else {
         cam_give(buffer);
     }
-    cam_start();
 
     while (!cam_ready()) {
         RUN_BACKGROUND_TASKS;
@@ -126,6 +126,4 @@ void common_hal_imagecapture_parallelimagecapture_capture(imagecapture_paralleli
 
     uint8_t *unused;
     cam_take(&unused); // this just "returns" buffer
-
-    cam_stop();
 }


### PR DESCRIPTION
Otherwise, a lot of frames were being dropped, leading to a low framerate in the "directio" demo for OV5640 cameras

Before:
![image (3)](https://user-images.githubusercontent.com/1517291/136852976-a1bd0558-8dcb-4953-9526-4594b58e07a5.png)

After:
![image (4)](https://user-images.githubusercontent.com/1517291/136852974-8adf4556-4baf-4cde-8a5c-51ac3e92d655.png)

Note that as we're not doing anything to overlap the display write with the capture of the _next_ frame, it's expected that 2 vsync pulses are needed for one display refresh.
