### PR TITLE
Added D17/Battery Pin definition to melopero shake rp2040 

### DIFF
--- a/ports/raspberrypi/boards/melopero_shake_rp2040/pins.c
+++ b/ports/raspberrypi/boards/melopero_shake_rp2040/pins.c
@@ -26,6 +26,9 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_GPIO12) },
     { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_GPIO13) },
     { MP_ROM_QSTR(MP_QSTR_D17), MP_ROM_PTR(&pin_GPIO17) },
+
+    { MP_ROM_QSTR(MP_QSTR_BATTERY), MP_ROM_PTR(&pin_GPIO17) },
+
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO13) },
 
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO16) },


### PR DESCRIPTION
Hi, 
We added the D17/Battery pin definition to the pins.c file.
Let me know if there are any problems with the pr, thanks in advance.  