### PR TITLE
Add i2c singleton for Lolin S2 Mini

### DIFF
--- a/ports/espressif/boards/lolin_s2_mini/pins.c
+++ b/ports/espressif/boards/lolin_s2_mini/pins.c
@@ -86,5 +86,6 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IO45), MP_ROM_PTR(&pin_GPIO45) },// GPIO45
     { MP_ROM_QSTR(MP_QSTR_IO46), MP_ROM_PTR(&pin_GPIO46) },// GPIO46
     */
+    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) }, // board singleton implicit from schematic/shield standard
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
Originally when the S2 Mini board was brought up, there was some discussion as to whether or not to include an I2C singleton for it, as there was no explicit marking for such on the silkscreen for the board.

However, the S2 Mini is designed to be pinheader compatible with the ecosystem of shields for the Lolin/Wemos D1 Mini, and that does have a standard for I2C (they produce at least 6 shield boards using this standard as well as a board that provides a qwiic-like connector for several display boards, all using the same pin assignments).

The tipping point for me was when jepler pointed out to me on discord the designation of SCL/SDA pins directly from the schematic.

So therefore I'm submitting this PR to add a board.I2C singleton.

Tested with the Lolin TFT I2C Connector Shield and a 128x64 OLED board using the qwiic-like interface from this shield as well as a 64x48 oled shield.