### PR TITLE
Update README in docs/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,12 +13,9 @@ Building the documentation locally
 If you're making changes to the documentation, you should build the
 documentation locally so that you can preview your changes.
 
-Install Sphinx, recommonmark, and optionally (for the RTD-styling), sphinx_rtd_theme,
-preferably in a virtualenv:
+Install the necessary packages, preferably in a virtualenv, in `circuitpython/`:
 
-     pip install sphinx
-     pip install recommonmark
-     pip install sphinx_rtd_theme
+    pip install -r requirements-doc.txt
 
 In `circuitpython/`, build the docs:
 


### PR DESCRIPTION
Update README in `docs/` to reflect changes in package requirements. `recommonmark` is no longer used and has been replaced with `myst-parser`. Additionally there are other packages required, like `isort` and `black`. This change to the documentation covers all that and is future-proof for other changes to requirements that may happen.