### PR TITLE
PyKey60: added startup delay multiplier to help some hardware start up...

### DIFF
--- a/ports/raspberrypi/boards/jpconstantineau_pykey60/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/jpconstantineau_pykey60/pico-sdk-configboard.h
@@ -1,1 +1,4 @@
 // Put board-specific pico-sdk definitions here. This file must exist.
+
+// Allow extra time for xosc to start.
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64


### PR DESCRIPTION
Had some random issues with startup on some boards where it could enter the boot mode but circuitpython could not start.  The issue is quite random as it's seen on identical hardware, made within a single batch.

After some discussions on discord, it was suggested that adding a clock delay would eliminate the issue. 

After testing on affected hardware, this fixes the issue observed.