### PR TITLE
Fix _bleio.start_advertising arg check; add doc to SocketPool.socket()

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/Adapter.c
+++ b/devices/ble_hci/common-hal/_bleio/Adapter.c
@@ -666,8 +666,17 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self,
         }
     }
 
-    // Peer address, which we don't use (no directed advertising).
-    bt_addr_le_t empty_addr = { 0 };
+    // Peer address, for directed advertising
+    bt_addr_le_t peer_addr = { 0 };
+
+    // Copy peer address, if supplied.
+    if (directed_to) {
+        mp_buffer_info_t bufinfo;
+        if (mp_get_buffer(directed_to->bytes, &bufinfo, MP_BUFFER_READ)) {
+            peer_addr.type = directed_to->type;
+            memcpy(&peer_addr.a.val, bufinfo.buf, sizeof(peer_addr.a.val));
+        }
+    }
 
     bool extended =
         advertising_data_len > self->max_adv_data_len || scan_response_data_len > self->max_adv_data_len;
@@ -696,7 +705,7 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self,
                 interval_units, // max interval
                 0b111,          // channel map: channels 37, 38, 39
                 anonymous ? BT_ADDR_LE_RANDOM : BT_ADDR_LE_PUBLIC,
-                &empty_addr,    // peer_addr,
+                &peer_addr,    // peer_addr,
                 0x00,           // filter policy: no filter
                 DEFAULT_TX_POWER,
                 BT_HCI_LE_EXT_SCAN_PHY_1M, // Secondary PHY to use
@@ -746,7 +755,7 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self,
                 interval_units, // max interval
                 adv_type,
                 anonymous ? BT_ADDR_LE_RANDOM : BT_ADDR_LE_PUBLIC,
-                &empty_addr,
+                &peer_addr,
                 0b111,          // channel map: channels 37, 38, 39
                 0x00            // filter policy: no filter
                 ));

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -218,7 +218,7 @@ STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t
         { MP_QSTR_timeout, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_interval, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_tx_power, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
-        { MP_QSTR_directed_to, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_directed_to, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -250,9 +250,12 @@ STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t
         mp_raise_bleio_BluetoothError(translate("Cannot have scan responses for extended, connectable advertisements."));
     }
 
-    const bleio_address_obj_t *address = mp_arg_validate_type(args[ARG_directed_to].u_obj, &bleio_address_type, MP_QSTR_directed_to);
-    if (address != NULL && !connectable) {
-        mp_raise_bleio_BluetoothError(translate("Only connectable advertisements can be directed"));
+    const bleio_address_obj_t *address = NULL;
+    if (args[ARG_directed_to].u_obj != mp_const_none) {
+        if (!connectable) {
+            mp_raise_bleio_BluetoothError(translate("Only connectable advertisements can be directed"));
+        }
+        address = mp_arg_validate_type(args[ARG_directed_to].u_obj, &bleio_address_type, MP_QSTR_directed_to);
     }
 
     common_hal_bleio_adapter_start_advertising(self, connectable, anonymous, timeout, interval,

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -66,7 +66,11 @@ STATIC mp_obj_t socketpool_socketpool_make_new(const mp_obj_type_t *type, size_t
 //|         """Create a new socket
 //|
 //|         :param ~int family: AF_INET or AF_INET6
-//|         :param ~int type: SOCK_STREAM, SOCK_DGRAM or SOCK_RAW"""
+//|         :param ~int type: SOCK_STREAM, SOCK_DGRAM or SOCK_RAW
+//|
+//|         The ``proto`` (protocol) and ``fileno`` arguments available in ``socket.socket()``
+//|         in CPython are not supported.
+//|         """
 //|         ...
 //|
 STATIC mp_obj_t socketpool_socketpool_socket(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {


### PR DESCRIPTION
- Fixes #5503.
- Fixes #5460, same as #5502.

Changes:
- Improve documentation noting that `SocketPool.socket()` does not take all the arguments that CPython `socket.socket()` takes.
- Fix arg checking for `Adapter.start_advertising(..., directed_to=...)`.
- Implement passing `directed_to` arg via HCI in BLE HCI device support. Not tested.

@Neradoc I tested the `start_advertising()` fix in the REPL, but if you could try too, that would be great.