### PR TITLE
account for deleted boards

### DIFF
--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -88,7 +88,12 @@ def set_boards_to_build(build_all):
     arch_to_boards = {"arm": [], "riscv": [], "espressif": []}
     for board in boards_to_build:
         print(" ", board)
-        arch = PORT_TO_ARCH[board_to_port[board]]
+        port = board_to_port.get(board)
+        # A board can appear due to its _deletion_ (rare)
+        # if this happens it's not in `board_to_port`.
+        if not port:
+            continue
+        arch = PORT_TO_ARCH[port]
         arch_to_boards[arch].append(board)
 
     # Set the step outputs for each architecture


### PR DESCRIPTION
Over in #5516 there was a build error about the removed board:
```
Adding docs/boards to build based on changed files
Building docs: False
Building boards:
Traceback (most recent call last):
  File "ci_set_matrix.py", line 131, in <module>
    main()
  adafruit_feather_esp32s2
  File "ci_set_matrix.py", line 127, in main
  adafruit_feather_esp32s2_nopsram
    set_boards_to_build(build_all)
  File "ci_set_matrix.py", line 91, in set_boards_to_build
    arch = PORT_TO_ARCH[board_to_port[board]]
KeyError: 'adafruit_feather_esp32s2_nopsram'
```

deleted files cause the related code to build (this is sensible! don't change it) but if what's deleted is a whole board you get an error like that.