### PR TITLE
main: redesign boot_out.txt writing

### DIFF
--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -107,7 +107,7 @@ def make_version_header(filename):
 #define MICROPY_VERSION_MINOR (%s)
 #define MICROPY_VERSION_MICRO (%s)
 #define MICROPY_VERSION_STRING "%s"
-#define MICROPY_FULL_VERSION_INFO ("Adafruit CircuitPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME)
+#define MICROPY_FULL_VERSION_INFO "Adafruit CircuitPython " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE "; " MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME
 """ % (
         git_tag,
         git_hash,

--- a/supervisor/serial.h
+++ b/supervisor/serial.h
@@ -34,9 +34,9 @@
 #include "py/mpconfig.h"
 
 #ifdef CIRCUITPY_BOOT_OUTPUT_FILE
-#include "lib/oofatfs/ff.h"
+#include "py/misc.h"
 
-extern FIL *boot_output_file;
+extern vstr_t *boot_output;
 #endif
 
 void serial_early_init(void);

--- a/supervisor/shared/micropython.c
+++ b/supervisor/shared/micropython.c
@@ -60,7 +60,13 @@ void mp_hal_stdout_tx_strn(const char *str, size_t len) {
 
     #ifdef CIRCUITPY_BOOT_OUTPUT_FILE
     if (boot_output != NULL) {
-        vstr_add_strn(boot_output, str, len);
+        // Ensure boot_out.txt is capped at 1 filesystem block and ends with a newline
+        if (len + boot_output->len > 508) {
+            vstr_add_str(boot_output, "...\n");
+            boot_output = NULL;
+        } else {
+            vstr_add_strn(boot_output, str, len);
+        }
     }
     #endif
 

--- a/supervisor/shared/micropython.c
+++ b/supervisor/shared/micropython.c
@@ -59,9 +59,8 @@ void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     toggle_tx_led();
 
     #ifdef CIRCUITPY_BOOT_OUTPUT_FILE
-    if (boot_output_file != NULL) {
-        UINT bytes_written = 0;
-        f_write(boot_output_file, str, len, &bytes_written);
+    if (boot_output != NULL) {
+        vstr_add_strn(boot_output, str, len);
     }
     #endif
 


### PR DESCRIPTION
New design:
 * capture output to a vstr
 * compare the complete vstr to boot_out.txt
 * rewrite if not a complete match

This is resilient against future changes to the automatic text written to boot_out.txt.

This also fixes rewriting boot_out.txt in the case where boot.py prints something.

Perhaps it also saves a bit of code space. Some tricks:
 * no need to close a file in read mode
 * no need to switch on/off USB write access, going down to the   oofatfs layer doesn't check it anyway

This is  a possible alternative to 
 * #5535 .