### PR TITLE
Corrected number of serial bytes returned

### DIFF
--- a/ports/mimxrt10xx/common-hal/busio/UART.c
+++ b/ports/mimxrt10xx/common-hal/busio/UART.c
@@ -345,7 +345,10 @@ size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t 
 
     // if we timed out, stop the transfer
     if (self->rx_ongoing) {
+        uint32_t recvd = 0;
+        LPUART_TransferGetReceiveCount(self->uart, &self->handle, &recvd);
         LPUART_TransferAbortReceive(self->uart, &self->handle);
+        return recvd;
     }
 
     // No data left, we got it all
@@ -355,7 +358,11 @@ size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t 
 
     // The only place we can reliably tell how many bytes have been received is from the current
     // wp in the handle (because the abort nukes rxDataSize, and reading it before abort is a race.)
-    return self->handle.rxData - data;
+    if (self->handle.rxData > data) {
+        return self->handle.rxData - data;
+    } else {
+        return len;
+    }
 }
 
 // Write characters.


### PR DESCRIPTION
Issue 5477. The calculation for number of UART bytes returned under some circumstances could result in a negative number. Since it was unsigned, this meant that a large value would be used and memory would get stepped on. The real issue seems to be that the SDK does not always update the handle.rxData field, but rather than trying to fix the SDK, code was added to UART.c to correct for the situation.