### PR TITLE
Request RTD to use python3.9 for building

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,11 @@
 
 version: 2
 
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
 submodules:
     include:
         - extmod/ulab
@@ -16,6 +21,5 @@ formats:
   - pdf
 
 python:
-    version: 3
     install:
         - requirements: docs/requirements.txt


### PR DESCRIPTION
~~.. this isn't handled when the stubs extraction procedure runs on RTD, due to the python version they use.  It did not seem to be possible to select to run on a newer 3.x version.~~



Closes: #5543 