### PR TITLE
atmel-samd: Fix converting watchdog seconds to cycles

### DIFF
--- a/ports/atmel-samd/common-hal/watchdog/WatchDogTimer.c
+++ b/ports/atmel-samd/common-hal/watchdog/WatchDogTimer.c
@@ -70,7 +70,7 @@ void setup_wdt(watchdog_watchdogtimer_obj_t *self, int setting) {
 }
 
 void common_hal_watchdog_set_timeout(watchdog_watchdogtimer_obj_t *self, mp_float_t new_timeout) {
-    int wdt_cycles = (int)(new_timeout * 1000);
+    int wdt_cycles = (int)(new_timeout * 1024);
     if (wdt_cycles < 8) {
         wdt_cycles = 8;
     }


### PR DESCRIPTION
It's intended that the actual timeout always be at least the requested timeout.  However, due to multiplying by the wrong factor to get from seconds to cycles, a timeout request of e.g., 8.1s (which is less than 8.192s) would give an actual timeout of 8, not 16 as it should.

I found this while researching #5546.