### PR TITLE
MP3Decoder: allow passing in a filename instead of a file

### DIFF
--- a/shared-bindings/audiomp3/MP3Decoder.c
+++ b/shared-bindings/audiomp3/MP3Decoder.c
@@ -37,11 +37,11 @@
 //| class MP3Decoder:
 //|     """Load a mp3 file for audio playback"""
 //|
-//|     def __init__(self, file: typing.BinaryIO, buffer: WriteableBuffer) -> None:
+//|     def __init__(self, file: Union[typing.BinaryIO, str], buffer: WriteableBuffer) -> None:
 //|
 //|         """Load a .mp3 file for playback with `audioio.AudioOut` or `audiobusio.I2SOut`.
 //|
-//|         :param typing.BinaryIO file: Already opened mp3 file
+//|         :param file: Either a file open in bytes mode, or the name of a file to open
 //|         :param ~_typing.WriteableBuffer buffer: Optional pre-allocated buffer, that will be split in half and used for double-buffering of the data. If not provided, two buffers are allocated internally.  The specific buffer size required depends on the mp3 file.
 //|
 //|
@@ -56,8 +56,7 @@
 //|           speaker_enable = digitalio.DigitalInOut(board.SPEAKER_ENABLE)
 //|           speaker_enable.switch_to_output(value=True)
 //|
-//|           data = open("cplay-16bit-16khz-64kbps.mp3", "rb")
-//|           mp3 = audiomp3.MP3Decoder(data)
+//|           mp3 = audiomp3.MP3Decoder("cplay-16bit-16khz-64kbps.mp3")
 //|           a = audioio.AudioOut(board.A0)
 //|
 //|           print("playing")
@@ -72,9 +71,10 @@ STATIC mp_obj_t audiomp3_mp3file_make_new(const mp_obj_type_t *type, size_t n_ar
 
     audiomp3_mp3file_obj_t *self = m_new_obj(audiomp3_mp3file_obj_t);
     self->base.type = &audiomp3_mp3file_type;
-    if (!mp_obj_is_type(args[0], &mp_type_fileio)) {
-        mp_raise_TypeError(translate("file must be a file opened in byte mode"));
+    if (mp_obj_is_str(args[0])) {
+        args[0] = mp_call_function_2(MP_OBJ_FROM_PTR(&mp_builtin_open_obj), file, MP_OBJ_NEW_QSTR(MP_QSTR_rb));
     }
+    mp_arg_validate_type(args[0], &mp_type_fileio, MP_QSTR_file);
     uint8_t *buffer = NULL;
     size_t buffer_size = 0;
     if (n_args >= 2) {

--- a/shared-bindings/audiomp3/MP3Decoder.c
+++ b/shared-bindings/audiomp3/MP3Decoder.c
@@ -71,10 +71,11 @@ STATIC mp_obj_t audiomp3_mp3file_make_new(const mp_obj_type_t *type, size_t n_ar
 
     audiomp3_mp3file_obj_t *self = m_new_obj(audiomp3_mp3file_obj_t);
     self->base.type = &audiomp3_mp3file_type;
-    if (mp_obj_is_str(args[0])) {
-        args[0] = mp_call_function_2(MP_OBJ_FROM_PTR(&mp_builtin_open_obj), file, MP_OBJ_NEW_QSTR(MP_QSTR_rb));
+    mp_obj_t *file = args[0];
+    if (mp_obj_is_str(file)) {
+        file = mp_call_function_2(MP_OBJ_FROM_PTR(&mp_builtin_open_obj), file, MP_OBJ_NEW_QSTR(MP_QSTR_rb));
     }
-    mp_arg_validate_type(args[0], &mp_type_fileio, MP_QSTR_file);
+    mp_arg_validate_type(file, &mp_type_fileio, MP_QSTR_file);
     uint8_t *buffer = NULL;
     size_t buffer_size = 0;
     if (n_args >= 2) {
@@ -83,7 +84,7 @@ STATIC mp_obj_t audiomp3_mp3file_make_new(const mp_obj_type_t *type, size_t n_ar
         buffer = bufinfo.buf;
         buffer_size = bufinfo.len;
     }
-    common_hal_audiomp3_mp3file_construct(self, MP_OBJ_TO_PTR(args[0]),
+    common_hal_audiomp3_mp3file_construct(self, MP_OBJ_TO_PTR(file),
         buffer, buffer_size);
 
     return MP_OBJ_FROM_PTR(self);
@@ -127,14 +128,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiomp3_mp3file___exit___obj, 4, 4, 
 //|     file: typing.BinaryIO
 //|     """File to play back."""
 //|
-STATIC mp_obj_t audiomp3_mp3file_obj_get_file(mp_obj_t self_in) {
+STATIC mp_obj_t audiomp3_mp3file_get_file(mp_obj_t self_in) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
     return self->file;
 }
-MP_DEFINE_CONST_FUN_OBJ_1(audiomp3_mp3file_get_file_obj, audiomp3_mp3file_obj_get_file);
+MP_DEFINE_CONST_FUN_OBJ_1(audiomp3_mp3file_get_file_obj, audiomp3_mp3file_get_file);
 
-STATIC mp_obj_t audiomp3_mp3file_obj_set_file(mp_obj_t self_in, mp_obj_t file) {
+STATIC mp_obj_t audiomp3_mp3file_set_file(mp_obj_t self_in, mp_obj_t file) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
     if (!mp_obj_is_type(file, &mp_type_fileio)) {
@@ -143,7 +144,7 @@ STATIC mp_obj_t audiomp3_mp3file_obj_set_file(mp_obj_t self_in, mp_obj_t file) {
     common_hal_audiomp3_mp3file_set_file(self, file);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_2(audiomp3_mp3file_set_file_obj, audiomp3_mp3file_obj_set_file);
+MP_DEFINE_CONST_FUN_OBJ_2(audiomp3_mp3file_set_file_obj, audiomp3_mp3file_set_file);
 
 const mp_obj_property_t audiomp3_mp3file_file_obj = {
     .base.type = &mp_type_property,
@@ -152,6 +153,18 @@ const mp_obj_property_t audiomp3_mp3file_file_obj = {
               MP_ROM_NONE},
 };
 
+
+//|     def open(filename: str) -> None:
+//|         """Open a new file in place of the current one
+//|
+//|         :param filename: The name of an mp3 file to open"""
+//|
+STATIC mp_obj_t audiomp3_mp3file_open(mp_obj_t self, mp_obj_t filename) {
+    mp_obj_t file = mp_call_function_2(MP_OBJ_FROM_PTR(&mp_builtin_open_obj), filename, MP_OBJ_NEW_QSTR(MP_QSTR_rb));
+    audiomp3_mp3file_set_file(self, file);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(audiomp3_mp3file_open_obj, audiomp3_mp3file_open);
 
 
 //|     sample_rate: int
@@ -241,6 +254,7 @@ STATIC const mp_rom_map_elem_t audiomp3_mp3file_locals_dict_table[] = {
 
     // Properties
     { MP_ROM_QSTR(MP_QSTR_file), MP_ROM_PTR(&audiomp3_mp3file_file_obj) },
+    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&audiomp3_mp3file_open_obj) },
     { MP_ROM_QSTR(MP_QSTR_sample_rate), MP_ROM_PTR(&audiomp3_mp3file_sample_rate_obj) },
     { MP_ROM_QSTR(MP_QSTR_bits_per_sample), MP_ROM_PTR(&audiomp3_mp3file_bits_per_sample_obj) },
     { MP_ROM_QSTR(MP_QSTR_channel_count), MP_ROM_PTR(&audiomp3_mp3file_channel_count_obj) },


### PR DESCRIPTION
.. this simplifies the code, and removes a cause for pylint to suggest using `with`.