### PR TITLE
Enable -Wmissing-prototypes for atmel-samd

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/att.c
+++ b/devices/ble_hci/common-hal/_bleio/att.c
@@ -26,6 +26,7 @@
 // Zephyr include files to define HCI communication values and structs.
 // #include "hci_include/hci.h"
 // #include "hci_include/hci_err.h"
+#include "hci_include/att_internal.h"
 #include "hci_include/l2cap_internal.h"
 
 #include "py/obj.h"

--- a/devices/ble_hci/common-hal/_bleio/hci_include/att_internal.h
+++ b/devices/ble_hci/common-hal/_bleio/hci_include/att_internal.h
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#pragma once
 
 #include <stdbool.h>
 // for __packed

--- a/main.c
+++ b/main.c
@@ -915,13 +915,13 @@ void NORETURN nlr_jump_fail(void *val) {
     }
 }
 
-void NORETURN __fatal_error(const char *msg) {
+#ifndef NDEBUG
+static void NORETURN __fatal_error(const char *msg) {
     reset_into_safe_mode(MICROPY_FATAL_ERROR);
     while (true) {
     }
 }
 
-#ifndef NDEBUG
 void MP_WEAK __assert_func(const char *file, int line, const char *func, const char *expr) {
     mp_printf(&mp_plat_print, "Assertion '%s' failed, at file %s:%d\n", expr, file, line);
     __fatal_error("Assertion failed");

--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -158,7 +158,7 @@ else
   endif
 endif
 
-CFLAGS += $(INC) -Wall -Werror -std=gnu11 -nostdlib -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT)
+CFLAGS += $(INC) -Wall -Werror -std=gnu11 -nostdlib -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT) -Werror=missing-prototypes
 
 ifeq ($(CHIP_FAMILY), samd21)
 CFLAGS += \
@@ -291,19 +291,9 @@ $(BUILD)/asf4/$(CHIP_FAMILY)/hpl/sdhc/hpl_sdhc.o: CFLAGS += -Wno-cast-align -Wno
 endif
 
 SRC_ASF := $(addprefix asf4/$(CHIP_FAMILY)/, $(SRC_ASF))
+$(patsubst $(SRC_ASF),%.c,%.o): CFLAGS += -Wno-missing-prototypes
 
-SRC_C += \
-	audio_dma.c \
-	background.c \
-	bindings/samd/Clock.c \
-	bindings/samd/__init__.c \
-	boards/$(BOARD)/board.c \
-	boards/$(BOARD)/pins.c \
-	eic_handler.c \
-	fatfs_port.c \
-	freetouch/adafruit_ptc.c \
-	lib/tinyusb/src/portable/microchip/samd/dcd_samd.c \
-	mphalport.c \
+SRC_PERIPHERALS := \
 	peripherals/samd/$(PERIPHERALS_CHIP_FAMILY)/adc.c \
 	peripherals/samd/$(PERIPHERALS_CHIP_FAMILY)/cache.c \
 	peripherals/samd/$(PERIPHERALS_CHIP_FAMILY)/clocks.c \
@@ -319,8 +309,24 @@ SRC_C += \
 	peripherals/samd/external_interrupts.c \
 	peripherals/samd/sercom.c \
 	peripherals/samd/timers.c \
+
+$(patsubst $(SRC_PERIPHERALS),%.c,%.o): CFLAGS += -Wno-missing-prototypes
+
+SRC_C += \
+	audio_dma.c \
+	background.c \
+	bindings/samd/Clock.c \
+	bindings/samd/__init__.c \
+	boards/$(BOARD)/board.c \
+	boards/$(BOARD)/pins.c \
+	eic_handler.c \
+	fatfs_port.c \
+	freetouch/adafruit_ptc.c \
+	lib/tinyusb/src/portable/microchip/samd/dcd_samd.c \
+	mphalport.c \
 	reset.c \
 	timer_handler.c \
+	$(SRC_PERIPHERALS) \
 
 # This is an OR because it filters to any 1s and then checks to see if it is not
 # empty.

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -556,7 +556,7 @@ uint64_t port_get_raw_ticks(uint8_t *subticks) {
     return overflow_count + current_ticks / 16;
 }
 
-void evsyshandler_common(void) {
+static void evsyshandler_common(void) {
     #ifdef SAMD21
     if (_tick_event_channel < EVSYS_SYNCH_NUM && event_interrupt_active(_tick_event_channel)) {
         supervisor_tick();

--- a/shared-module/usb_cdc/Serial.c
+++ b/shared-module/usb_cdc/Serial.c
@@ -25,6 +25,7 @@
  */
 
 #include "shared/runtime/interrupt_char.h"
+#include "shared-bindings/usb_cdc/Serial.h"
 #include "shared-module/usb_cdc/Serial.h"
 #include "supervisor/shared/tick.h"
 

--- a/shared-module/usb_midi/PortIn.c
+++ b/shared-module/usb_midi/PortIn.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "shared-bindings/usb_midi/PortIn.h"
 #include "shared-module/usb_midi/PortIn.h"
 #include "supervisor/shared/translate.h"
 #include "tusb.h"

--- a/shared-module/usb_midi/PortOut.c
+++ b/shared-module/usb_midi/PortOut.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "shared-bindings/usb_midi/PortOut.h"
 #include "shared-module/usb_midi/PortOut.h"
 #include "supervisor/shared/translate.h"
 #include "tusb.h"

--- a/supervisor/shared/background_callback.c
+++ b/supervisor/shared/background_callback.c
@@ -30,6 +30,7 @@
 #include "py/mpconfig.h"
 #include "supervisor/background_callback.h"
 #include "supervisor/linker.h"
+#include "supervisor/port.h"
 #include "supervisor/shared/tick.h"
 #include "shared-bindings/microcontroller/__init__.h"
 

--- a/supervisor/shared/external_flash/external_flash.c
+++ b/supervisor/shared/external_flash/external_flash.c
@@ -495,7 +495,7 @@ static int32_t convert_block_to_flash_addr(uint32_t block) {
     return -1;
 }
 
-bool external_flash_read_block(uint8_t *dest, uint32_t block) {
+static bool external_flash_read_block(uint8_t *dest, uint32_t block) {
     int32_t address = convert_block_to_flash_addr(block);
     if (address == -1) {
         // bad block number
@@ -524,7 +524,7 @@ bool external_flash_read_block(uint8_t *dest, uint32_t block) {
     return read_flash(address, dest, FILESYSTEM_BLOCK_SIZE);
 }
 
-bool external_flash_write_block(const uint8_t *data, uint32_t block) {
+static bool external_flash_write_block(const uint8_t *data, uint32_t block) {
     // Non-MBR block, copy to cache
     int32_t address = convert_block_to_flash_addr(block);
     if (address == -1) {

--- a/supervisor/shared/external_flash/qspi_flash.c
+++ b/supervisor/shared/external_flash/qspi_flash.c
@@ -27,6 +27,7 @@
 #include "supervisor/spi_flash_api.h"
 
 #include "supervisor/shared/external_flash/common_commands.h"
+#include "supervisor/shared/external_flash/qspi_flash.h"
 
 void check_quad_enable(const external_flash_device *device) {
     if (device->quad_enable_bit_mask == 0x00) {

--- a/supervisor/shared/flash.c
+++ b/supervisor/shared/flash.c
@@ -28,6 +28,7 @@
 #include "extmod/vfs_fat.h"
 #include "py/runtime.h"
 #include "lib/oofatfs/ff.h"
+#include "supervisor/flash.h"
 #include "supervisor/shared/tick.h"
 
 #define VFS_INDEX 0
@@ -46,7 +47,7 @@ STATIC mp_obj_t supervisor_flash_obj_make_new(const mp_obj_type_t *type, size_t 
     return (mp_obj_t)&supervisor_flash_obj;
 }
 
-uint32_t flash_get_block_count(void) {
+static uint32_t flash_get_block_count(void) {
     return PART1_START_BLOCK + supervisor_flash_get_block_count();
 }
 
@@ -86,7 +87,7 @@ static void build_partition(uint8_t *buf, int boot, int type, uint32_t start_blo
     buf[15] = num_blocks >> 24;
 }
 
-mp_uint_t flash_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t num_blocks) {
+static mp_uint_t flash_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t num_blocks) {
     if (block_num == 0) {
         // fake the MBR so we can decide on our own partition table
 
@@ -114,7 +115,7 @@ mp_uint_t flash_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t num_bloc
 
 volatile bool filesystem_dirty = false;
 
-mp_uint_t flash_write_blocks(const uint8_t *src, uint32_t block_num, uint32_t num_blocks) {
+static mp_uint_t flash_write_blocks(const uint8_t *src, uint32_t block_num, uint32_t num_blocks) {
     if (block_num == 0) {
         if (num_blocks > 1) {
             return 1; // error
@@ -160,7 +161,7 @@ STATIC mp_obj_t supervisor_flash_obj_writeblocks(mp_obj_t self, mp_obj_t block_n
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(supervisor_flash_obj_writeblocks_obj, supervisor_flash_obj_writeblocks);
 
-bool flash_ioctl(size_t cmd, mp_int_t *out_value) {
+static bool flash_ioctl(size_t cmd, mp_int_t *out_value) {
     *out_value = 0;
     switch (cmd) {
         case MP_BLOCKDEV_IOCTL_INIT:

--- a/supervisor/shared/micropython.c
+++ b/supervisor/shared/micropython.c
@@ -29,6 +29,7 @@
 #include "supervisor/serial.h"
 #include "lib/oofatfs/ff.h"
 #include "py/mpconfig.h"
+#include "py/mphal.h"
 #include "py/mpstate.h"
 #include "py/runtime.h"
 #include "py/stream.h"

--- a/supervisor/shared/stack.c
+++ b/supervisor/shared/stack.c
@@ -43,7 +43,7 @@ static size_t stack_length = 0;
 
 #define EXCEPTION_STACK_SIZE 1024
 
-void allocate_stack(void) {
+static void allocate_stack(void) {
 
     if (port_has_fixed_stack()) {
         stack_limit = port_stack_get_limit();

--- a/supervisor/shared/tick.c
+++ b/supervisor/shared/tick.c
@@ -27,6 +27,7 @@
 #include "supervisor/shared/tick.h"
 
 #include "shared/runtime/interrupt_char.h"
+#include "py/mphal.h"
 #include "py/mpstate.h"
 #include "py/runtime.h"
 #include "supervisor/linker.h"
@@ -63,7 +64,7 @@ static background_callback_t tick_callback;
 
 volatile uint64_t last_finished_tick = 0;
 
-void supervisor_background_tasks(void *unused) {
+static void supervisor_background_tasks(void *unused) {
     port_start_background_task();
 
     assert_heap_ok();

--- a/supervisor/shared/workflow.c
+++ b/supervisor/shared/workflow.c
@@ -26,6 +26,8 @@
 
 #include <stdbool.h>
 #include "py/mpconfig.h"
+#include "supervisor/workflow.h"
+#include "supervisor/shared/workflow.h"
 #include "tusb.h"
 
 void supervisor_workflow_reset(void) {


### PR DESCRIPTION
When a function is defined, but its declaration isn't present, the compiler can't check that the declaration and definition match.  "-Wmissing-prototypes" enables a diagnostic in this case.

Fixes fall into several categories:
 * Include headers where needed
 * Add/fix declarations / definitions where needed
 * Mark functions as static if appropriate
 * Remove some never-used functions

This PR aims to fix all the diagnostics that occur in the atmel-samd builds, so that the -Wmissing-prototypes flag can be enabled in that whole port.