### PR TITLE
Enable bitmaptools on the 'unix' build, 'coverage' variant

### DIFF
--- a/ports/unix/displayio_min.c
+++ b/ports/unix/displayio_min.c
@@ -29,6 +29,7 @@
 #include "py/runtime.h"
 
 #include "shared-bindings/displayio/__init__.h"
+#include "shared-bindings/displayio/Bitmap.h"
 
 MAKE_ENUM_VALUE(displayio_colorspace_type, displayio_colorspace, RGB888, DISPLAYIO_COLORSPACE_RGB888);
 MAKE_ENUM_VALUE(displayio_colorspace_type, displayio_colorspace, RGB565, DISPLAYIO_COLORSPACE_RGB565);
@@ -78,6 +79,7 @@ MAKE_ENUM_TYPE(displayio, ColorSpace, displayio_colorspace);
 
 STATIC const mp_rom_map_elem_t displayio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_displayio) },
+    { MP_ROM_QSTR(MP_QSTR_Bitmap), MP_ROM_PTR(&displayio_bitmap_type) },
     { MP_ROM_QSTR(MP_QSTR_Colorspace), MP_ROM_PTR(&displayio_colorspace_type) },
 };
 STATIC MP_DEFINE_CONST_DICT(displayio_module_globals, displayio_module_globals_table);
@@ -87,4 +89,4 @@ const mp_obj_module_t displayio_module = {
     .globals = (mp_obj_dict_t *)&displayio_module_globals,
 };
 
-MP_REGISTER_MODULE(MP_QSTR_displayio, displayio_module, CIRCUITPY_DISPLAYIO_COLORSPACE_ONLY);
+MP_REGISTER_MODULE(MP_QSTR_displayio, displayio_module, CIRCUITPY_DISPLAYIO_UNIX);

--- a/ports/unix/variants/coverage/mpconfigvariant.mk
+++ b/ports/unix/variants/coverage/mpconfigvariant.mk
@@ -35,12 +35,14 @@ SRC_BITMAP := \
 	shared-module/displayio/area.c \
 	shared-module/displayio/Bitmap.c \
 	shared-module/displayio/ColorConverter.c \
+	shared-bindings/bitmaptools/__init__.c \
+	shared-module/bitmaptools/__init__.c \
 	shared-bindings/util.c \
 
 $(info $(SRC_BITMAP))
 SRC_C += $(SRC_BITMAP)
 
-CFLAGS += -DCIRCUITPY_GIFIO=1 -DCIRCUITPY_DISPLAYIO_UNIX=1
+CFLAGS += -DCIRCUITPY_GIFIO=1 -DCIRCUITPY_DISPLAYIO_UNIX=1 -DCIRCUITPY_BITMAPTOOLS=1
 
 SRC_C += coverage.c
 SRC_CXX += coveragecpp.cpp

--- a/ports/unix/variants/coverage/mpconfigvariant.mk
+++ b/ports/unix/variants/coverage/mpconfigvariant.mk
@@ -27,10 +27,20 @@ SRC_C += $(SRC_QRIO)
 CFLAGS += -DCIRCUITPY_QRIO=1
 $(BUILD)/lib/quirc/lib/%.o: CFLAGS += -Wno-shadow -Wno-sign-compare -include shared-module/qrio/quirc_alloc.h
 
-SRC_GIFIO := $(patsubst ../../%,%,$(wildcard ../../shared-bindings/gifio/*.c ../../shared-module/gifio/*.c)) shared/runtime/context_manager_helpers.c displayio_colorspace_only.c shared-module/displayio/ColorConverter.c shared-bindings/util.c
-SRC_C += $(SRC_GIFIO)
+SRC_BITMAP := \
+	$(patsubst ../../%,%,$(wildcard ../../shared-bindings/gifio/*.c ../../shared-module/gifio/*.c)) \
+	shared/runtime/context_manager_helpers.c \
+	displayio_min.c \
+	shared-bindings/displayio/Bitmap.c \
+	shared-module/displayio/area.c \
+	shared-module/displayio/Bitmap.c \
+	shared-module/displayio/ColorConverter.c \
+	shared-bindings/util.c \
 
-CFLAGS += -DCIRCUITPY_GIFIO=1 -DCIRCUITPY_DISPLAYIO_COLORSPACE_ONLY=1
+$(info $(SRC_BITMAP))
+SRC_C += $(SRC_BITMAP)
+
+CFLAGS += -DCIRCUITPY_GIFIO=1 -DCIRCUITPY_DISPLAYIO_UNIX=1
 
 SRC_C += coverage.c
 SRC_CXX += coveragecpp.cpp

--- a/py/circuitpy_defns.mk
+++ b/py/circuitpy_defns.mk
@@ -534,6 +534,7 @@ SRC_SHARED_MODULE_ALL = \
 	displayio/Palette.c \
 	displayio/Shape.c \
 	displayio/TileGrid.c \
+	displayio/area.c \
 	displayio/__init__.c \
 	fontio/BuiltinFont.c \
 	fontio/__init__.c \

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -176,6 +176,10 @@ extern void common_hal_mcu_enable_interrupts(void);
 #define INT_FMT "%d"
 typedef int mp_int_t; // must be pointer size
 typedef unsigned mp_uint_t; // must be pointer size
+#if __GNUC__ >= 10 // on recent gcc versions we can check that this is so
+_Static_assert(sizeof(mp_int_t) == sizeof(void *));
+_Static_assert(sizeof(mp_uint_t) == sizeof(void *));
+#endif
 typedef long mp_off_t;
 
 #define MP_PLAT_PRINT_STRN(str, len) mp_hal_stdout_tx_strn_cooked(str, len)

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -161,8 +161,8 @@ STATIC mp_obj_t bitmaptools_obj_rotozoom(size_t n_args, const mp_obj_t *pos_args
           ARG_angle, ARG_scale, ARG_skip_index};
 
     static const mp_arg_t allowed_args[] = {
-        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0}},
-        {MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0}},
+        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL}},
 
         {MP_QSTR_ox, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} }, // None convert to destination->width  / 2
         {MP_QSTR_oy, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} }, // None convert to destination->height / 2
@@ -353,12 +353,12 @@ STATIC mp_obj_t bitmaptools_obj_fill_region(size_t n_args, const mp_obj_t *pos_a
     enum {ARG_dest_bitmap, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_value};
 
     static const mp_arg_t allowed_args[] = {
-        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0}},
-        {MP_QSTR_x1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
-        {MP_QSTR_y1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
-        {MP_QSTR_x2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
-        {MP_QSTR_y2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
-        {MP_QSTR_value, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_x1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_y1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_x2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_y2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_value, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -405,10 +405,10 @@ STATIC mp_obj_t bitmaptools_obj_boundary_fill(size_t n_args, const mp_obj_t *pos
     enum {ARG_dest_bitmap, ARG_x, ARG_y, ARG_fill_color_value, ARG_replaced_color_value};
 
     static const mp_arg_t allowed_args[] = {
-        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0}},
-        {MP_QSTR_x, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
-        {MP_QSTR_y, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
-        {MP_QSTR_fill_color_value, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_x, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_y, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_fill_color_value, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
         {MP_QSTR_replaced_color_value, MP_ARG_INT, {.u_int = INT_MAX} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -468,12 +468,12 @@ STATIC mp_obj_t bitmaptools_obj_draw_line(size_t n_args, const mp_obj_t *pos_arg
     enum {ARG_dest_bitmap, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_value};
 
     static const mp_arg_t allowed_args[] = {
-        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0}},
-        {MP_QSTR_x1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
-        {MP_QSTR_y1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
-        {MP_QSTR_x2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
-        {MP_QSTR_y2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
-        {MP_QSTR_value, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_x1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_y1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_x2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_y2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
+        {MP_QSTR_value, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL}},
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -539,8 +539,8 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_draw_line_obj, 0, bitmaptools_obj_draw_li
 STATIC mp_obj_t bitmaptools_arrayblit(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bitmap, ARG_data, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_skip_index };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
-        { MP_QSTR_data, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
+        { MP_QSTR_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_data, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_x1, MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_y1, MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_x2, MP_ARG_INT, {.u_int = -1} },
@@ -605,9 +605,9 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_arrayblit_obj, 0, bitmaptools_arrayblit);
 STATIC mp_obj_t bitmaptools_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bitmap, ARG_file, ARG_bits_per_pixel, ARG_element_size, ARG_reverse_pixels_in_element, ARG_swap_bytes_in_element, ARG_reverse_rows };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
-        { MP_QSTR_file, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
-        { MP_QSTR_bits_per_pixel, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0} },
+        { MP_QSTR_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_file, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_bits_per_pixel, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_element_size, MP_ARG_INT, { .u_int = 1 } },
         { MP_QSTR_reverse_pixels_in_element, MP_ARG_BOOL, { .u_bool = false } },
         { MP_QSTR_swap_bytes_in_element,  MP_ARG_BOOL, { .u_bool = false } },
@@ -689,9 +689,9 @@ MAKE_ENUM_TYPE(bitmaptools, DitherAlgorithm, bitmaptools_dither_algorithm);
 STATIC mp_obj_t bitmaptools_dither(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_dest_bitmap, ARG_source_bitmap, ARG_source_colorspace, ARG_algorithm };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
-        { MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
-        { MP_QSTR_source_colorspace, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
+        { MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_source_colorspace, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_algorithm, MP_ARG_OBJ, { .u_obj = MP_ROM_PTR((void *)&dither_algorithm_Atkinson_obj) } },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -39,7 +39,7 @@
 #if MICROPY_VFS
 #include "extmod/vfs.h"
 #endif
-#if MICROPY_VFS_POSIX
+#if defined(MICROPY_VFS_POSIX) && MICROPY_VFS_POSIX
 #include "extmod/vfs_posix.h"
 #endif
 

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -36,6 +36,13 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 
+#if MICROPY_VFS
+#include "extmod/vfs.h"
+#endif
+#if MICROPY_VFS_POSIX
+#include "extmod/vfs_posix.h"
+#endif
+
 //| """Collection of bitmap manipulation tools"""
 //|
 
@@ -154,8 +161,8 @@ STATIC mp_obj_t bitmaptools_obj_rotozoom(size_t n_args, const mp_obj_t *pos_args
           ARG_angle, ARG_scale, ARG_skip_index};
 
     static const mp_arg_t allowed_args[] = {
-        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ},
-        {MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ},
+        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0}},
+        {MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0}},
 
         {MP_QSTR_ox, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} }, // None convert to destination->width  / 2
         {MP_QSTR_oy, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} }, // None convert to destination->height / 2
@@ -207,13 +214,13 @@ STATIC mp_obj_t bitmaptools_obj_rotozoom(size_t n_args, const mp_obj_t *pos_args
         args[ARG_source_clip1].u_obj, &source_clip1_x, &source_clip1_y);
 
     // Confirm the angle value
-    float angle = 0.0;
+    mp_float_t angle = 0.0;
     if (args[ARG_angle].u_obj != mp_const_none) {
         angle = mp_obj_get_float(args[ARG_angle].u_obj);
     }
 
     // Confirm the scale value
-    float scale = 1.0;
+    mp_float_t scale = 1.0;
     if (args[ARG_scale].u_obj != mp_const_none) {
         scale = mp_obj_get_float(args[ARG_scale].u_obj);
     }
@@ -269,10 +276,10 @@ STATIC mp_obj_t bitmaptools_alphablend(size_t n_args, const mp_obj_t *pos_args, 
     enum {ARG_dest_bitmap, ARG_source_bitmap_1, ARG_source_bitmap_2, ARG_colorspace, ARG_factor_1, ARG_factor_2};
 
     static const mp_arg_t allowed_args[] = {
-        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ},
-        {MP_QSTR_source_bitmap_1, MP_ARG_REQUIRED | MP_ARG_OBJ},
-        {MP_QSTR_source_bitmap_2, MP_ARG_REQUIRED | MP_ARG_OBJ},
-        {MP_QSTR_colorspace, MP_ARG_REQUIRED | MP_ARG_OBJ},
+        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = NULL}},
+        {MP_QSTR_source_bitmap_1, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = NULL}},
+        {MP_QSTR_source_bitmap_2, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = NULL}},
+        {MP_QSTR_colorspace, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = NULL}},
         {MP_QSTR_factor_1, MP_ARG_OBJ, {.u_obj = MP_ROM_NONE}},
         {MP_QSTR_factor_2, MP_ARG_OBJ, {.u_obj = MP_ROM_NONE}},
     };
@@ -283,8 +290,8 @@ STATIC mp_obj_t bitmaptools_alphablend(size_t n_args, const mp_obj_t *pos_args, 
     displayio_bitmap_t *source1 = MP_OBJ_TO_PTR(mp_arg_validate_type(args[ARG_source_bitmap_1].u_obj, &displayio_bitmap_type, MP_QSTR_source_bitmap_1)); // the first source bitmap
     displayio_bitmap_t *source2 = MP_OBJ_TO_PTR(mp_arg_validate_type(args[ARG_source_bitmap_2].u_obj, &displayio_bitmap_type, MP_QSTR_source_bitmap_2)); // the second source bitmap
 
-    float factor1 = (args[ARG_factor_1].u_obj == mp_const_none) ? .5f : mp_obj_float_get(args[ARG_factor_1].u_obj);
-    float factor2 = (args[ARG_factor_2].u_obj == mp_const_none) ? 1 - factor1 : mp_obj_float_get(args[ARG_factor_2].u_obj);
+    mp_float_t factor1 = (args[ARG_factor_1].u_obj == mp_const_none) ? MICROPY_FLOAT_CONST(.5) : mp_obj_float_get(args[ARG_factor_1].u_obj);
+    mp_float_t factor2 = (args[ARG_factor_2].u_obj == mp_const_none) ? 1 - factor1 : mp_obj_float_get(args[ARG_factor_2].u_obj);
 
     displayio_colorspace_t colorspace = (displayio_colorspace_t)cp_enum_value(&displayio_colorspace_type, args[ARG_colorspace].u_obj);
 
@@ -346,12 +353,12 @@ STATIC mp_obj_t bitmaptools_obj_fill_region(size_t n_args, const mp_obj_t *pos_a
     enum {ARG_dest_bitmap, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_value};
 
     static const mp_arg_t allowed_args[] = {
-        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ},
-        {MP_QSTR_x1, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_y1, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_x2, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_y2, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_value, MP_ARG_REQUIRED | MP_ARG_INT},
+        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0}},
+        {MP_QSTR_x1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_y1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_x2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_y2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_value, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -398,10 +405,10 @@ STATIC mp_obj_t bitmaptools_obj_boundary_fill(size_t n_args, const mp_obj_t *pos
     enum {ARG_dest_bitmap, ARG_x, ARG_y, ARG_fill_color_value, ARG_replaced_color_value};
 
     static const mp_arg_t allowed_args[] = {
-        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ},
-        {MP_QSTR_x, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_y, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_fill_color_value, MP_ARG_REQUIRED | MP_ARG_INT},
+        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0}},
+        {MP_QSTR_x, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_y, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_fill_color_value, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
         {MP_QSTR_replaced_color_value, MP_ARG_INT, {.u_int = INT_MAX} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -461,12 +468,12 @@ STATIC mp_obj_t bitmaptools_obj_draw_line(size_t n_args, const mp_obj_t *pos_arg
     enum {ARG_dest_bitmap, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_value};
 
     static const mp_arg_t allowed_args[] = {
-        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ},
-        {MP_QSTR_x1, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_y1, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_x2, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_y2, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_value, MP_ARG_REQUIRED | MP_ARG_INT},
+        {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0}},
+        {MP_QSTR_x1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_y1, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_x2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_y2, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
+        {MP_QSTR_value, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0}},
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -532,8 +539,8 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_draw_line_obj, 0, bitmaptools_obj_draw_li
 STATIC mp_obj_t bitmaptools_arrayblit(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bitmap, ARG_data, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_skip_index };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_data, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
+        { MP_QSTR_data, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
         { MP_QSTR_x1, MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_y1, MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_x2, MP_ARG_INT, {.u_int = -1} },
@@ -598,9 +605,9 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_arrayblit_obj, 0, bitmaptools_arrayblit);
 STATIC mp_obj_t bitmaptools_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bitmap, ARG_file, ARG_bits_per_pixel, ARG_element_size, ARG_reverse_pixels_in_element, ARG_swap_bytes_in_element, ARG_reverse_rows };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_file, MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_bits_per_pixel, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
+        { MP_QSTR_file, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
+        { MP_QSTR_bits_per_pixel, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0} },
         { MP_QSTR_element_size, MP_ARG_INT, { .u_int = 1 } },
         { MP_QSTR_reverse_pixels_in_element, MP_ARG_BOOL, { .u_bool = false } },
         { MP_QSTR_swap_bytes_in_element,  MP_ARG_BOOL, { .u_bool = false } },
@@ -682,9 +689,9 @@ MAKE_ENUM_TYPE(bitmaptools, DitherAlgorithm, bitmaptools_dither_algorithm);
 STATIC mp_obj_t bitmaptools_dither(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_dest_bitmap, ARG_source_bitmap, ARG_source_colorspace, ARG_algorithm };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_source_colorspace, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
+        { MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
+        { MP_QSTR_source_colorspace, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
         { MP_QSTR_algorithm, MP_ARG_OBJ, { .u_obj = MP_ROM_PTR((void *)&dither_algorithm_Atkinson_obj) } },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];

--- a/shared-bindings/bitmaptools/__init__.h
+++ b/shared-bindings/bitmaptools/__init__.h
@@ -46,8 +46,8 @@ void common_hal_bitmaptools_rotozoom(displayio_bitmap_t *self, int16_t ox, int16
     displayio_bitmap_t *source, int16_t px, int16_t py,
     int16_t source_clip0_x, int16_t source_clip0_y,
     int16_t source_clip1_x, int16_t source_clip1_y,
-    float angle,
-    float scale,
+    mp_float_t angle,
+    mp_float_t scale,
     uint32_t skip_index, bool skip_index_none);
 
 void common_hal_bitmaptools_fill_region(displayio_bitmap_t *destination,
@@ -68,6 +68,6 @@ void common_hal_bitmaptools_readinto(displayio_bitmap_t *self, pyb_file_obj_t *f
 void common_hal_bitmaptools_arrayblit(displayio_bitmap_t *self, void *data, int element_size, int x1, int y1, int x2, int y2, bool skip_specified, uint32_t skip_index);
 void common_hal_bitmaptools_dither(displayio_bitmap_t *dest_bitmap, displayio_bitmap_t *source_bitmap, displayio_colorspace_t colorspace, bitmaptools_dither_algorithm_t algorithm);
 
-void common_hal_bitmaptools_alphablend(displayio_bitmap_t *destination, displayio_bitmap_t *source1, displayio_bitmap_t *source2, displayio_colorspace_t colorspace, float factor1, float factor2);
+void common_hal_bitmaptools_alphablend(displayio_bitmap_t *destination, displayio_bitmap_t *source1, displayio_bitmap_t *source2, displayio_colorspace_t colorspace, mp_float_t factor1, mp_float_t factor2);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_BITMAPTOOLS__INIT__H

--- a/shared-bindings/canio/CAN.c
+++ b/shared-bindings/canio/CAN.c
@@ -240,8 +240,8 @@ STATIC mp_obj_t canio_can_listen(size_t n_args, const mp_obj_t *pos_args, mp_map
 
     enum { ARG_matches, ARG_timeout, NUM_ARGS };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_matches, MP_ARG_OBJ, {.u_obj = 0} },
-        { MP_QSTR_timeout, MP_ARG_OBJ, {.u_obj = 0} },
+        { MP_QSTR_matches, MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_timeout, MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     MP_STATIC_ASSERT(MP_ARRAY_SIZE(allowed_args) == NUM_ARGS);

--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -33,7 +33,6 @@
 #include "py/binary.h"
 #include "py/objproperty.h"
 #include "py/runtime.h"
-#include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/util.h"
 #include "supervisor/shared/translate.h"
 
@@ -206,9 +205,9 @@ STATIC mp_obj_t bitmap_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t val
 STATIC mp_obj_t displayio_bitmap_obj_blit(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_x, ARG_y, ARG_source, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_skip_index};
     static const mp_arg_t allowed_args[] = {
-        {MP_QSTR_x, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_y, MP_ARG_REQUIRED | MP_ARG_INT},
-        {MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ},
+        {MP_QSTR_x, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0} },
+        {MP_QSTR_y, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0} },
+        {MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
         {MP_QSTR_x1, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         {MP_QSTR_y1, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         {MP_QSTR_x2, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} }, // None convert to source->width

--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -205,9 +205,9 @@ STATIC mp_obj_t bitmap_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t val
 STATIC mp_obj_t displayio_bitmap_obj_blit(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_x, ARG_y, ARG_source, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_skip_index};
     static const mp_arg_t allowed_args[] = {
-        {MP_QSTR_x, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0} },
-        {MP_QSTR_y, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = 0} },
-        {MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = 0} },
+        {MP_QSTR_x, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL} },
+        {MP_QSTR_y, MP_ARG_REQUIRED | MP_ARG_INT, {.u_obj = MP_OBJ_NULL} },
+        {MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         {MP_QSTR_x1, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         {MP_QSTR_y1, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         {MP_QSTR_x2, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} }, // None convert to source->width

--- a/shared-module/displayio/Bitmap.c
+++ b/shared-module/displayio/Bitmap.c
@@ -113,7 +113,7 @@ void displayio_bitmap_set_dirty_area(displayio_bitmap_t *self, const displayio_a
     displayio_area_t area = *dirty_area;
     displayio_area_canon(&area);
     displayio_area_union(&area, &self->dirty_area, &area);
-    displayio_area_t bitmap_area = {0, 0, self->width, self->height};
+    displayio_area_t bitmap_area = {0, 0, self->width, self->height, NULL};
     displayio_area_compute_overlap(&area, &bitmap_area, &self->dirty_area);
 }
 
@@ -160,7 +160,7 @@ void common_hal_displayio_bitmap_blit(displayio_bitmap_t *self, int16_t x, int16
         dirty_y_max = self->height;
     }
 
-    displayio_area_t a = { x, y, dirty_x_max, dirty_y_max};
+    displayio_area_t a = { x, y, dirty_x_max, dirty_y_max, NULL};
     displayio_bitmap_set_dirty_area(self, &a);
 
     bool x_reverse = false;
@@ -199,7 +199,7 @@ void common_hal_displayio_bitmap_blit(displayio_bitmap_t *self, int16_t x, int16
 
 void common_hal_displayio_bitmap_set_pixel(displayio_bitmap_t *self, int16_t x, int16_t y, uint32_t value) {
     // update the dirty region
-    displayio_area_t a = {x, y, x + 1, y + 1};
+    displayio_area_t a = {x, y, x + 1, y + 1, NULL};
     displayio_bitmap_set_dirty_area(self, &a);
 
     // write the pixel
@@ -221,7 +221,7 @@ void displayio_bitmap_finish_refresh(displayio_bitmap_t *self) {
 }
 
 void common_hal_displayio_bitmap_fill(displayio_bitmap_t *self, uint32_t value) {
-    displayio_area_t a = {0, 0, self->width, self->height};
+    displayio_area_t a = {0, 0, self->width, self->height, NULL};
     displayio_bitmap_set_dirty_area(self, &a);
 
     // build the packed word

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -1,3 +1,29 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 
 #include <string.h>
 
@@ -246,138 +272,6 @@ void displayio_gc_collect(void) {
         } else if (displays[i].epaper_display.base.type == &displayio_epaperdisplay_type) {
             displayio_epaperdisplay_collect_ptrs(&displays[i].epaper_display);
         }
-    }
-}
-
-void displayio_area_copy(const displayio_area_t *src, displayio_area_t *dst) {
-    dst->x1 = src->x1;
-    dst->y1 = src->y1;
-    dst->x2 = src->x2;
-    dst->y2 = src->y2;
-}
-
-void displayio_area_scale(displayio_area_t *area, uint16_t scale) {
-    area->x1 *= scale;
-    area->y1 *= scale;
-    area->x2 *= scale;
-    area->y2 *= scale;
-}
-
-void displayio_area_shift(displayio_area_t *area, int16_t dx, int16_t dy) {
-    area->x1 += dx;
-    area->y1 += dy;
-    area->x2 += dx;
-    area->y2 += dy;
-}
-
-bool displayio_area_compute_overlap(const displayio_area_t *a,
-    const displayio_area_t *b,
-    displayio_area_t *overlap) {
-    overlap->x1 = a->x1;
-    if (b->x1 > overlap->x1) {
-        overlap->x1 = b->x1;
-    }
-    overlap->x2 = a->x2;
-    if (b->x2 < overlap->x2) {
-        overlap->x2 = b->x2;
-    }
-    if (overlap->x1 >= overlap->x2) {
-        return false;
-    }
-    overlap->y1 = a->y1;
-    if (b->y1 > overlap->y1) {
-        overlap->y1 = b->y1;
-    }
-    overlap->y2 = a->y2;
-    if (b->y2 < overlap->y2) {
-        overlap->y2 = b->y2;
-    }
-    if (overlap->y1 >= overlap->y2) {
-        return false;
-    }
-    return true;
-}
-
-bool displayio_area_empty(const displayio_area_t *a) {
-    return (a->x1 == a->x2) || (a->y1 == a->y2);
-}
-
-void displayio_area_canon(displayio_area_t *a) {
-    if (a->x1 > a->x2) {
-        int16_t t = a->x1;
-        a->x1 = a->x2;
-        a->x2 = t;
-    }
-    if (a->y1 > a->y2) {
-        int16_t t = a->y1;
-        a->y1 = a->y2;
-        a->y2 = t;
-    }
-}
-
-void displayio_area_union(const displayio_area_t *a,
-    const displayio_area_t *b,
-    displayio_area_t *u) {
-
-    if (displayio_area_empty(a)) {
-        displayio_area_copy(b, u);
-        return;
-    }
-    if (displayio_area_empty(b)) {
-        displayio_area_copy(a, u);
-        return;
-    }
-    u->x1 = MIN(a->x1, b->x1);
-    u->y1 = MIN(a->y1, b->y1);
-    u->x2 = MAX(a->x2, b->x2);
-    u->y2 = MAX(a->y2, b->y2);
-}
-
-uint16_t displayio_area_width(const displayio_area_t *area) {
-    return area->x2 - area->x1;
-}
-
-uint16_t displayio_area_height(const displayio_area_t *area) {
-    return area->y2 - area->y1;
-}
-
-uint32_t displayio_area_size(const displayio_area_t *area) {
-    return displayio_area_width(area) * displayio_area_height(area);
-}
-
-bool displayio_area_equal(const displayio_area_t *a, const displayio_area_t *b) {
-    return a->x1 == b->x1 &&
-           a->y1 == b->y1 &&
-           a->x2 == b->x2 &&
-           a->y2 == b->y2;
-}
-
-// Original and whole must be in the same coordinate space.
-void displayio_area_transform_within(bool mirror_x, bool mirror_y, bool transpose_xy,
-    const displayio_area_t *original,
-    const displayio_area_t *whole,
-    displayio_area_t *transformed) {
-    if (mirror_x) {
-        transformed->x1 = whole->x1 + (whole->x2 - original->x2);
-        transformed->x2 = whole->x2 - (original->x1 - whole->x1);
-    } else {
-        transformed->x1 = original->x1;
-        transformed->x2 = original->x2;
-    }
-    if (mirror_y) {
-        transformed->y1 = whole->y1 + (whole->y2 - original->y2);
-        transformed->y2 = whole->y2 - (original->y1 - whole->y1);
-    } else {
-        transformed->y1 = original->y1;
-        transformed->y2 = original->y2;
-    }
-    if (transpose_xy) {
-        int16_t y1 = transformed->y1;
-        int16_t y2 = transformed->y2;
-        transformed->y1 = whole->y1 + (transformed->x1 - whole->x1);
-        transformed->y2 = whole->y1 + (transformed->x2 - whole->x1);
-        transformed->x2 = whole->x1 + (y2 - whole->y1);
-        transformed->x1 = whole->x1 + (y1 - whole->y1);
     }
 }
 

--- a/shared-module/displayio/area.c
+++ b/shared-module/displayio/area.c
@@ -1,0 +1,161 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "shared-module/displayio/area.h"
+
+#include "py/misc.h"
+
+void displayio_area_copy(const displayio_area_t *src, displayio_area_t *dst) {
+    dst->x1 = src->x1;
+    dst->y1 = src->y1;
+    dst->x2 = src->x2;
+    dst->y2 = src->y2;
+}
+
+void displayio_area_scale(displayio_area_t *area, uint16_t scale) {
+    area->x1 *= scale;
+    area->y1 *= scale;
+    area->x2 *= scale;
+    area->y2 *= scale;
+}
+
+void displayio_area_shift(displayio_area_t *area, int16_t dx, int16_t dy) {
+    area->x1 += dx;
+    area->y1 += dy;
+    area->x2 += dx;
+    area->y2 += dy;
+}
+
+bool displayio_area_compute_overlap(const displayio_area_t *a,
+    const displayio_area_t *b,
+    displayio_area_t *overlap) {
+    overlap->x1 = a->x1;
+    if (b->x1 > overlap->x1) {
+        overlap->x1 = b->x1;
+    }
+    overlap->x2 = a->x2;
+    if (b->x2 < overlap->x2) {
+        overlap->x2 = b->x2;
+    }
+    if (overlap->x1 >= overlap->x2) {
+        return false;
+    }
+    overlap->y1 = a->y1;
+    if (b->y1 > overlap->y1) {
+        overlap->y1 = b->y1;
+    }
+    overlap->y2 = a->y2;
+    if (b->y2 < overlap->y2) {
+        overlap->y2 = b->y2;
+    }
+    if (overlap->y1 >= overlap->y2) {
+        return false;
+    }
+    return true;
+}
+
+bool displayio_area_empty(const displayio_area_t *a) {
+    return (a->x1 == a->x2) || (a->y1 == a->y2);
+}
+
+void displayio_area_canon(displayio_area_t *a) {
+    if (a->x1 > a->x2) {
+        int16_t t = a->x1;
+        a->x1 = a->x2;
+        a->x2 = t;
+    }
+    if (a->y1 > a->y2) {
+        int16_t t = a->y1;
+        a->y1 = a->y2;
+        a->y2 = t;
+    }
+}
+
+void displayio_area_union(const displayio_area_t *a,
+    const displayio_area_t *b,
+    displayio_area_t *u) {
+
+    if (displayio_area_empty(a)) {
+        displayio_area_copy(b, u);
+        return;
+    }
+    if (displayio_area_empty(b)) {
+        displayio_area_copy(a, u);
+        return;
+    }
+    u->x1 = MIN(a->x1, b->x1);
+    u->y1 = MIN(a->y1, b->y1);
+    u->x2 = MAX(a->x2, b->x2);
+    u->y2 = MAX(a->y2, b->y2);
+}
+
+uint16_t displayio_area_width(const displayio_area_t *area) {
+    return area->x2 - area->x1;
+}
+
+uint16_t displayio_area_height(const displayio_area_t *area) {
+    return area->y2 - area->y1;
+}
+
+uint32_t displayio_area_size(const displayio_area_t *area) {
+    return displayio_area_width(area) * displayio_area_height(area);
+}
+
+bool displayio_area_equal(const displayio_area_t *a, const displayio_area_t *b) {
+    return a->x1 == b->x1 &&
+           a->y1 == b->y1 &&
+           a->x2 == b->x2 &&
+           a->y2 == b->y2;
+}
+
+// Original and whole must be in the same coordinate space.
+void displayio_area_transform_within(bool mirror_x, bool mirror_y, bool transpose_xy,
+    const displayio_area_t *original,
+    const displayio_area_t *whole,
+    displayio_area_t *transformed) {
+    if (mirror_x) {
+        transformed->x1 = whole->x1 + (whole->x2 - original->x2);
+        transformed->x2 = whole->x2 - (original->x1 - whole->x1);
+    } else {
+        transformed->x1 = original->x1;
+        transformed->x2 = original->x2;
+    }
+    if (mirror_y) {
+        transformed->y1 = whole->y1 + (whole->y2 - original->y2);
+        transformed->y2 = whole->y2 - (original->y1 - whole->y1);
+    } else {
+        transformed->y1 = original->y1;
+        transformed->y2 = original->y2;
+    }
+    if (transpose_xy) {
+        int16_t y1 = transformed->y1;
+        int16_t y2 = transformed->y2;
+        transformed->y1 = whole->y1 + (transformed->x1 - whole->x1);
+        transformed->y2 = whole->y1 + (transformed->x2 - whole->x1);
+        transformed->x2 = whole->x1 + (y2 - whole->y1);
+        transformed->x1 = whole->x1 + (y1 - whole->y1);
+    }
+}

--- a/shared-module/displayio/area.h
+++ b/shared-module/displayio/area.h
@@ -27,7 +27,10 @@
 #ifndef MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_AREA_H
 #define MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO_AREA_H
 
-// Implementations are in __init__.c
+#include <stdint.h>
+#include <stdbool.h>
+
+// Implementations are in area.c
 typedef struct _displayio_area_t displayio_area_t;
 
 struct _displayio_area_t {

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -30,15 +30,15 @@ ame__
 mport 
 
 builtins        micropython     _thread         array
-binascii        btree           cexample        cmath
-collections     cppexample      displayio       errno
-ffi             framebuf        gc              gifio
-hashlib         json            math            qrio
-re              sys             termios         ubinascii
-uctypes         uerrno          uheapq          uio
-ujson           ulab            uos             urandom
-ure             uselect         ustruct         utime
-utimeq          uzlib
+binascii        bitmaptools     btree           cexample
+cmath           collections     cppexample      displayio
+errno           ffi             framebuf        gc
+gifio           hashlib         json            math
+qrio            re              sys             termios
+ubinascii       uctypes         uerrno          uheapq
+uio             ujson           ulab            uos
+urandom         ure             uselect         ustruct
+utime           utimeq          uzlib
 ime
 
 utime           utimeq

--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -76,7 +76,8 @@ def set_boards_to_build(build_all):
             port_matches = port_pattern.search(p)
             if port_matches:
                 port = port_matches.group(1)
-                boards_to_build.update(port_to_boards[port])
+                if port != "unix":
+                    boards_to_build.update(port_to_boards[port])
                 continue
 
             # Otherwise build it all


### PR DESCRIPTION
This allows testing & debugging of bitmaptools routines like alphablend & dither on host computers. It shouldn't change anything about how displayio/bitmaptools work on microcontrollers.

```python
$ ./micropython-coverage 
MicroPython 7.1.0-beta.0-3-gd55388a17 on 2021-11-12; linux version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> import displayio, bitmaptools
>>> b = displayio.Bitmap(32, 32, 65536)
>>> bitmaptools.dither(b, b, displayio.Colorspace.RGB565)
```
