### PR TITLE
Set AP MAC address

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2143,7 +2143,7 @@ msgid "Stack size must be at least 256"
 msgstr ""
 
 #: ports/espressif/common-hal/wifi/Radio.c
-msgid "Station must be started"
+msgid "Interface must be started"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c

--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -112,6 +112,7 @@ mp_obj_t common_hal_wifi_radio_get_hostname(wifi_radio_obj_t *self) {
 
 void common_hal_wifi_radio_set_hostname(wifi_radio_obj_t *self, const char *hostname) {
     esp_netif_set_hostname(self->netif, hostname);
+    esp_netif_set_hostname(self->ap_netif, hostname);
 }
 
 mp_obj_t common_hal_wifi_radio_get_mac_address(wifi_radio_obj_t *self) {
@@ -122,7 +123,7 @@ mp_obj_t common_hal_wifi_radio_get_mac_address(wifi_radio_obj_t *self) {
 
 void common_hal_wifi_radio_set_mac_address(wifi_radio_obj_t *self, const uint8_t *mac) {
     if (!self->sta_mode) {
-        mp_raise_RuntimeError(translate("Station must be started"));
+        mp_raise_RuntimeError(translate("Interface must be started"));
     }
     if ((mac[0] & 0b1) == 0b1) {
         mp_raise_RuntimeError(translate("Invalid multicast MAC address"));
@@ -134,6 +135,16 @@ mp_obj_t common_hal_wifi_radio_get_mac_address_ap(wifi_radio_obj_t *self) {
     uint8_t mac[MAC_ADDRESS_LENGTH];
     esp_wifi_get_mac(ESP_IF_WIFI_AP, mac);
     return mp_obj_new_bytes(mac, MAC_ADDRESS_LENGTH);
+}
+
+void common_hal_wifi_radio_set_mac_address_ap(wifi_radio_obj_t *self, const uint8_t *mac) {
+    if (!self->ap_mode) {
+        mp_raise_RuntimeError(translate("Interface must be started"));
+    }
+    if ((mac[0] & 0b1) == 0b1) {
+        mp_raise_RuntimeError(translate("Invalid multicast MAC address"));
+    }
+    esp_wifi_set_mac(ESP_IF_WIFI_AP, mac);
 }
 
 mp_obj_t common_hal_wifi_radio_start_scanning_networks(wifi_radio_obj_t *self) {

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -149,22 +149,37 @@ const mp_obj_property_t wifi_radio_mac_address_obj = {
                MP_ROM_NONE },
 };
 
-//|     mac_address_ap: bytes
-//|     """MAC address of the wifi radio access point. (read-only)"""
+//|     mac_address_ap: ReadableBuffer
+//|     """MAC address for the AP. When the address is altered after interface is started
+//|        the changes would only be reflected once the interface restarts."""
 //|
-STATIC mp_obj_t wifi_radio_get_mac_address_ap(mp_obj_t self) {
+STATIC mp_obj_t wifi_radio_get_mac_address_ap(mp_obj_t self_in) {
+    wifi_radio_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_FROM_PTR(common_hal_wifi_radio_get_mac_address_ap(self));
-
 }
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_get_mac_address_ap_obj, wifi_radio_get_mac_address_ap);
+
+STATIC mp_obj_t wifi_radio_set_mac_address_ap(mp_obj_t self_in, mp_obj_t mac_address_in) {
+    mp_buffer_info_t mac_address;
+    mp_get_buffer_raise(mac_address_in, &mac_address, MP_BUFFER_READ);
+
+    if (mac_address.len != MAC_ADDRESS_LENGTH) {
+        mp_raise_ValueError(translate("Invalid MAC address"));
+    }
+
+    wifi_radio_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_wifi_radio_set_mac_address_ap(self, mac_address.buf);
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(wifi_radio_set_mac_address_ap_obj, wifi_radio_set_mac_address_ap);
 
 const mp_obj_property_t wifi_radio_mac_address_ap_obj = {
     .base.type = &mp_type_property,
     .proxy = { (mp_obj_t)&wifi_radio_get_mac_address_ap_obj,
-               MP_ROM_NONE,
+               (mp_obj_t)&wifi_radio_set_mac_address_ap_obj,
                MP_ROM_NONE },
 };
-
 
 //|     def start_scanning_networks(self, *, start_channel: int = 1, stop_channel: int = 11) -> Iterable[Network]:
 //|         """Scans for available wifi networks over the given channel range. Make sure the channels are allowed in your country."""

--- a/shared-bindings/wifi/Radio.h
+++ b/shared-bindings/wifi/Radio.h
@@ -80,6 +80,7 @@ extern void common_hal_wifi_radio_set_hostname(wifi_radio_obj_t *self, const cha
 extern mp_obj_t common_hal_wifi_radio_get_mac_address(wifi_radio_obj_t *self);
 extern void common_hal_wifi_radio_set_mac_address(wifi_radio_obj_t *self, const uint8_t *mac);
 extern mp_obj_t common_hal_wifi_radio_get_mac_address_ap(wifi_radio_obj_t *self);
+extern void common_hal_wifi_radio_set_mac_address_ap(wifi_radio_obj_t *self, const uint8_t *mac);
 
 extern mp_obj_t common_hal_wifi_radio_start_scanning_networks(wifi_radio_obj_t *self);
 extern void common_hal_wifi_radio_stop_scanning_networks(wifi_radio_obj_t *self);


### PR DESCRIPTION
Allow setting the Access Point `mac_address`. Like #5571, but for AP. Also, when `hostname` is set, set it for AP as well as Station.


Example code to demonstrate the feature, with results in the comments:
```py
import time
import wifi
from secrets import secrets

# after init, wifi is started/enabled, wifi mode is station
# hostname is default, mac_addresses are default
print("# Defaults:")
print(wifi.radio.hostname)
print(f'{wifi.radio.mac_address[5]:02X}')
print(f'{wifi.radio.mac_address_ap[5]:02X}')

# set a new hostname
print("# New hostname:")
wifi.radio.hostname = "hostname24".encode()
print(wifi.radio.hostname)

# set new Station MAC address and connect to an external AP
print("# Station MAC address:")
wifi.radio.mac_address = bytes((0x7A, 0xDF, 0xA1, 0xFF, 0xFF, 0x24))
print(":".join("%02X" % _ for _ in wifi.radio.mac_address))
wifi.radio.connect(secrets["ssid"], secrets["password"])
if wifi.radio.ipv4_address:
    print("Connected.")
# router shows Station as:
# hostname24 7A:DF:A1:FF:FF:24

# disable / stop wifi (Station will be disconnected from its external AP)
print("# Disable / stop wifi")
wifi.radio.enabled = False

# start an on-board AP and set its MAC address
print("AP MAC address:")
wifi.radio.start_ap("ZZZ_📶", "wqiugdf23894756", authmode=[wifi.AuthMode.WPA2, wifi.AuthMode.PSK])
wifi.radio.mac_address_ap = bytes((0x7A, 0xDF, 0xA1, 0xFF, 0xFF, 0x25))  # Local MAC address
print(":".join("%02X" % _ for _ in wifi.radio.mac_address_ap))

# enable / restart wifi & re-check the AP MAC address
print("# Enable / restart wifi:")
wifi.radio.enabled = True
print("AP Gateway", wifi.radio.ipv4_gateway_ap)
print("AP Subnet ", wifi.radio.ipv4_subnet_ap)
print("AP IPv4   ", wifi.radio.ipv4_address_ap)
print(":".join("%02X" % _ for _ in wifi.radio.mac_address_ap))
print("# Check external wifi utility...")
time.sleep(15)  # allow time to check external wifi utility...
# wifi utility shows AP as:
# SSID BSSID             RSSI CHANNEL HT CC SECURITY (auth/unicast/group)
# ZZZ_📶 7a:df:a1:ff:ff:25 -23  1,+1    Y  CN WPA2(PSK/AES,TKIP/TKIP)

# stop AP and try to set MAC address
wifi.radio.stop_ap()
wifi.radio.mac_address_ap = bytes((0x7A, 0xDF, 0xA1, 0xFF, 0xFF, 0x26))  # Local MAC address
# exception, as expected:
# RuntimeError: Interface must be started
print(":".join("%02X" % _ for _ in wifi.radio.mac_address_ap))
```