### PR TITLE
INVERT the sense of the I2C_POWER pin (active low)

### DIFF
--- a/ports/espressif/boards/adafruit_feather_esp32s2/pins.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2/pins.c
@@ -15,7 +15,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D6), MP_ROM_PTR(&pin_GPIO6) },
 
     { MP_ROM_QSTR(MP_QSTR_D7), MP_ROM_PTR(&pin_GPIO7) },
-    { MP_ROM_QSTR(MP_QSTR_I2C_POWER), MP_ROM_PTR(&pin_GPIO7) },
+    { MP_ROM_QSTR(MP_QSTR_I2C_POWER_INVERTED), MP_ROM_PTR(&pin_GPIO7) },
 
     { MP_ROM_QSTR(MP_QSTR_D8), MP_ROM_PTR(&pin_GPIO8) },
     { MP_ROM_QSTR(MP_QSTR_A5), MP_ROM_PTR(&pin_GPIO8) },


### PR DESCRIPTION
I don't have the board to test, but this was reported and discussed on Discord. Probably only relevant for the BME280 version of the board.