### PR TITLE
Don't use reset reason to skip writing boot_out.txt

### DIFF
--- a/main.c
+++ b/main.c
@@ -678,7 +678,7 @@ STATIC void __attribute__ ((noinline)) run_boot_py(safe_mode_t safe_mode) {
         FATFS *fs = &vfs->fatfs;
 
         boot_output = NULL;
-        bool write_boot_output = (common_hal_mcu_processor_get_reset_reason() == RESET_REASON_POWER_ON);
+        bool write_boot_output = true;
         FIL boot_output_file;
         if (f_open(fs, &boot_output_file, CIRCUITPY_BOOT_OUTPUT_FILE, FA_READ) == FR_OK) {
             char *file_contents = m_new(char, boot_text.alloc);


### PR DESCRIPTION
As @neradoc and @anecdata noted, we can't depend on the reset reason.

Instead, just rely on the existing safe mode logic (the write already is skipped anytime boot.py was skipped), and otherwise potentially write boot_out.txt anytime it differs from the version on disk (or if the file doesn't exist in the first place)

Testing performed: On qtpy m0 haxpress, removed boot_out.txt, projectly ejected, then clicked reset button.  verified boot_out.txt was recreated.

Closes #5588