### PR TITLE
Add `make fetch-submodules` to update submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -198,3 +198,4 @@
 	path = ports/broadcom/firmware
 	url = https://github.com/raspberrypi/rpi-firmware.git
 	branch = master
+	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -109,7 +109,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Register.git
 [submodule "extmod/ulab"]
 	path = extmod/ulab
-	url = https://github.com/adafruit/circuitpython-ulab
+	url = https://github.com/v923z/micropython-ulab
 [submodule "frozen/Adafruit_CircuitPython_ESP32SPI"]
 	path = frozen/Adafruit_CircuitPython_ESP32SPI
 	url = https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI

--- a/Makefile
+++ b/Makefile
@@ -321,3 +321,8 @@ clean-nrf:
 
 clean-stm:
 	$(MAKE) -C ports/stm BOARD=feather_stm32f405_express clean
+
+.PHONY: fetch-submodules
+fetch-submodules:
+	git submodule update --init -N --depth 1
+	git submodule foreach 'git fetch --tags --depth 1 origin $$sha1 && git checkout -q $$sha1'

--- a/Makefile
+++ b/Makefile
@@ -324,5 +324,8 @@ clean-stm:
 
 .PHONY: fetch-submodules
 fetch-submodules:
-	git submodule update --init -N --depth 1
+	# This update will fail because the commits we need aren't the latest on the
+	# branch. We can ignore that though because we fix it with the second command.
+	# (Only works for git servers that allow sha fetches.)
+	git submodule update --init -N --depth 1 || true
 	git submodule foreach 'git fetch --tags --depth 1 origin $$sha1 && git checkout -q $$sha1'


### PR DESCRIPTION
This also sets rpi-firmware as shallow in case submodules are updated manually.

Fixes #5619
