### PR TITLE
spresense: Fix time.time()

### DIFF
--- a/ports/cxd56/supervisor/port.c
+++ b/ports/cxd56/supervisor/port.c
@@ -33,8 +33,9 @@
 
 #include "sched/sched.h"
 
-#include "supervisor/board.h"
+#include "shared-bindings/rtc/__init__.h"
 
+#include "supervisor/board.h"
 #include "supervisor/port.h"
 #include "supervisor/background_callback.h"
 #include "supervisor/usb.h"
@@ -89,6 +90,9 @@ void reset_port(void) {
     #endif
     #if CIRCUITPY_BUSIO
     busio_uart_reset();
+    #endif
+    #if CIRCUITPY_RTC
+    rtc_reset();
     #endif
 
     reset_all_pins();

--- a/shared-bindings/rtc/__init__.h
+++ b/shared-bindings/rtc/__init__.h
@@ -27,6 +27,8 @@
 #ifndef MICROPY_INCLUDED_SHARED_BINDINGS_RTC___INIT___H
 #define MICROPY_INCLUDED_SHARED_BINDINGS_RTC___INIT___H
 
+#include "py/obj.h"
+
 extern void rtc_reset(void);
 extern mp_obj_t rtc_get_time_source_time(void);
 


### PR DESCRIPTION
The `time.time()` function was calling a `rtc_get_time_source_time()` function that was using `MP_STATE_VM(rtc_time_source)`. Unfortunately the `MP_STATE_VM(rtc_time_source)` was `NULL` because it was never set. This caused Spresense to crash after calling `time.time()`. `MP_STATE_VM(rtc_time_source)`  is set in the `rtc_reset()` function, so adding it fixed the issue.

This PR fixes https://github.com/adafruit/circuitpython/issues/5625