### PR TITLE
Use a longer clock stretching timeout for RP2040 zero-byte I2C writes

### DIFF
--- a/ports/raspberrypi/common-hal/busio/I2C.c
+++ b/ports/raspberrypi/common-hal/busio/I2C.c
@@ -109,8 +109,11 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     // set up as GPIO by the bitbangio.I2C object.
     //
     // Sets pins to open drain, high, and input.
+    //
+    // Do not use the default supplied clock stretching timeout here.
+    // It is too short for some devices. Use the busio timeout instead.
     shared_module_bitbangio_i2c_construct(&self->bitbangio_i2c, scl, sda,
-        frequency, timeout);
+        frequency, BUS_TIMEOUT_US);
 
     self->baudrate = i2c_init(self->peripheral, frequency);
 


### PR DESCRIPTION
ATTiny-based seesaw devices were not working well with RP2040 I2C. RP2040 I2C uses `bitbangio.I2C` internally for zero-byte I2C writes, because the RP2040 peripheral does not allow zero-byte writes. The clock stretch timeout was slightly too short (255us, need at least 278 or so).

This lengthens the the hidden `bitbangio` clock stretching timeout to the same timeout used for RP2040 `busio.I2C()`, which right now is 1 second (excessively long, but that is a separate thing to fix).

Tested with a NeoSlider and a QT Py 2040.