### PR TITLE
espressif: busio.SPI: Use SPI_DMA_CH_AUTO

### DIFF
--- a/ports/espressif/common-hal/busio/SPI.c
+++ b/ports/espressif/common-hal/busio/SPI.c
@@ -93,7 +93,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         mp_raise_ValueError(translate("All SPI peripherals are in use"));
     }
 
-    esp_err_t result = spi_bus_initialize(self->host_id, &bus_config, self->host_id /* dma channel */);
+    esp_err_t result = spi_bus_initialize(self->host_id, &bus_config, SPI_DMA_CH_AUTO);
     if (result == ESP_ERR_NO_MEM) {
         mp_raise_msg(&mp_type_MemoryError, translate("ESP-IDF memory allocation failed"));
     } else if (result == ESP_ERR_INVALID_ARG) {


### PR DESCRIPTION
All 3 micros we care about (S2, S3, C3) state in the documentation that DMA channel can be specified as SPI_DMA_CH_AUTO.

Specifying a specific DMA channel explicitly doesn't _ever_ work on ESP32-S3, so no SPI bus could be used.

Testing performed: On the ESP32-S3-DevKitC, used neopixel_spi to turn the onboard neopixel red, green, and blue.  However, I didn't test any S2 boards even though it "should just work".