### PR TITLE
disable interrupts inside of ports raspberrypi common hal

### DIFF
--- a/ports/raspberrypi/common-hal/nvm/ByteArray.c
+++ b/ports/raspberrypi/common-hal/nvm/ByteArray.c
@@ -43,31 +43,32 @@ uint32_t common_hal_nvm_bytearray_get_length(const nvm_bytearray_obj_t *self) {
 }
 
 static void write_page(uint32_t page_addr, uint32_t offset, uint32_t len, uint8_t *bytes) {
-    // disable interrupts to prevent core hang on rp2040
-    common_hal_mcu_disable_interrupts();
-
     // Write a whole page to flash, buffering it first and then erasing and rewriting it
     // since we can only write a whole page at a time.
     if (offset == 0 && len == FLASH_PAGE_SIZE) {
+        // disable interrupts to prevent core hang on rp2040
+        common_hal_mcu_disable_interrupts();
         flash_range_program(RMV_OFFSET(page_addr), bytes, FLASH_PAGE_SIZE);
+        common_hal_mcu_enable_interrupts();
     } else {
         uint8_t buffer[FLASH_PAGE_SIZE];
         memcpy(buffer, (uint8_t *)page_addr, FLASH_PAGE_SIZE);
         memcpy(buffer + offset, bytes, len);
+        common_hal_mcu_disable_interrupts();
         flash_range_program(RMV_OFFSET(page_addr), buffer, FLASH_PAGE_SIZE);
+        common_hal_mcu_enable_interrupts();
     }
-    common_hal_mcu_enable_interrupts();
+
 }
 
 static void erase_and_write_sector(uint32_t address, uint32_t len, uint8_t *bytes) {
-    // disable interrupts to prevent core hang on rp2040
-    common_hal_mcu_disable_interrupts();
-
     // Write a whole sector to flash, buffering it first and then erasing and rewriting it
     // since we can only erase a whole sector at a time.
     uint8_t buffer[FLASH_SECTOR_SIZE];
     memcpy(buffer, (uint8_t *)CIRCUITPY_INTERNAL_NVM_START_ADDR, FLASH_SECTOR_SIZE);
     memcpy(buffer + address, bytes, len);
+    // disable interrupts to prevent core hang on rp2040
+    common_hal_mcu_disable_interrupts();
     flash_range_erase(RMV_OFFSET(CIRCUITPY_INTERNAL_NVM_START_ADDR), FLASH_SECTOR_SIZE);
     flash_range_program(RMV_OFFSET(CIRCUITPY_INTERNAL_NVM_START_ADDR), buffer, FLASH_SECTOR_SIZE);
     common_hal_mcu_enable_interrupts();

--- a/ports/raspberrypi/common-hal/nvm/ByteArray.c
+++ b/ports/raspberrypi/common-hal/nvm/ByteArray.c
@@ -31,6 +31,7 @@
 
 #include "py/runtime.h"
 #include "src/rp2_common/hardware_flash/include/hardware/flash.h"
+#include "shared-bindings/microcontroller/__init__.h"
 
 extern uint32_t __flash_binary_start;
 static const uint32_t flash_binary_start = (uint32_t)&__flash_binary_start;
@@ -71,6 +72,8 @@ void common_hal_nvm_bytearray_get_bytes(const nvm_bytearray_obj_t *self,
 
 bool common_hal_nvm_bytearray_set_bytes(const nvm_bytearray_obj_t *self,
     uint32_t start_index, uint8_t *values, uint32_t len) {
+    // disable interrupts to prevent core hang on rp2040
+    common_hal_mcu_disable_interrupts();
     uint8_t values_in[len];
     common_hal_nvm_bytearray_get_bytes(self, start_index, len, values_in);
 
@@ -99,5 +102,6 @@ bool common_hal_nvm_bytearray_set_bytes(const nvm_bytearray_obj_t *self,
         erase_and_write_sector(start_index, len, values);
     }
 
+    common_hal_mcu_enable_interrupts();
     return true;
 }


### PR DESCRIPTION
resolves: #4867 

This seems to resolve the issue. Since making this change I have succeeded with several NVM writes with both multi-byte array splices and single byte. I have not had the device hang at all since making this change.

Tested on Raspberry Pi Pico. But I believe fix applies to all RP2040 based devices.

When I ran pre-commit I noticed locally that it made some changes in `ports/broadcom/qstrdefsport.h` and `ports/esspresif/boards/adafruit_feather_esp32s2/board.c` which were unrelated to the NVM change as far as I can tell. I didn't include those changes in this PR. But If I should do that let me know and I can make a new commit with the changes that it made.

Thank you @tannewt for pointing me in the right direction to get this fixed!