### PR TITLE
add a frequencyin_reset() for VM restart

### DIFF
--- a/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+++ b/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -263,10 +263,12 @@ static void frequencyin_samd51_stop_dpll(void) {
         dpll_gclk = 0xff;
     }
 
+    #if !BOARD_HAS_CRYSTAL
     if (osculp32k_gclk != 0xff) {
         disable_clock_generator(osculp32k_gclk);
         osculp32k_gclk = 0xff;
     }
+    #endif
 
     GCLK->PCHCTRL[OSCCTRL_GCLK_ID_FDPLL1].reg = 0;
     OSCCTRL->Dpll[1].DPLLCTRLA.reg = 0;

--- a/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.h
+++ b/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.h
@@ -46,14 +46,7 @@ typedef struct {
 } frequencyio_frequencyin_obj_t;
 
 void frequencyin_interrupt_handler(uint8_t index);
-void frequencyin_emergency_cancel_capture(uint8_t index);
-void frequencyin_reference_tc_init(void);
-void frequencyin_reference_tc_enable(bool enable);
-bool frequencyin_reference_tc_enabled(void);
-#ifdef SAM_D5X_E5X
-void frequencyin_samd51_start_dpll(void);
-void frequencyin_samd51_stop_dpll(void);
-#endif
+void frequencyin_reset(void);
 
 
 #endif // MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_FREQUENCYIO_FREQUENCYIN_H

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -71,6 +71,10 @@
 #include "common-hal/busio/__init__.h"
 #endif
 
+#if CIRCUITPY_FREQUENCYIO
+#include "common-hal/frequencyio/FrequencyIn.h"
+#endif
+
 #include "common-hal/microcontroller/Pin.h"
 
 #if CIRCUITPY_PULSEIO
@@ -388,6 +392,10 @@ void reset_port(void) {
     i2sout_reset();
     #endif
 
+    #if CIRCUITPY_FREQUENCYIO
+    frequencyin_reset();
+    #endif
+
     #if CIRCUITPY_TOUCHIO && CIRCUITPY_TOUCHIO_USE_NATIVE
     touchin_reset();
     #endif
@@ -399,7 +407,7 @@ void reset_port(void) {
     #if CIRCUITPY_PWMIO
     pwmout_reset();
     #endif
-    #if CIRCUITPY_PWMIO || CIRCUITPY_AUDIOIO
+    #if CIRCUITPY_PWMIO || CIRCUITPY_AUDIOIO || CIRCUITPY_FREQUENCYIO
     reset_timers();
     #endif
 


### PR DESCRIPTION
Fixes #5643.

`FrequencyIn` was assuming it was started cleanly. But in the case of a VM restart (e.g. soft boot), some resetting needed to be done.