### PR TITLE
fix mistaken use of PWM channel for slice

### DIFF
--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -207,7 +207,7 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, 
     uint32_t tx_register = (uint32_t)&pwm_hw->slice[self->left_pwm.slice].cc;
     if (self->stereo) {
         // Shift the destination if we are outputting to both PWM channels.
-        tx_register += self->left_pwm.channel * sizeof(uint16_t);
+        tx_register += self->left_pwm.ab_channel * sizeof(uint16_t);
     }
 
     self->pacing_timer = pacing_timer;

--- a/ports/raspberrypi/common-hal/pwmio/PWMOut.h
+++ b/ports/raspberrypi/common-hal/pwmio/PWMOut.h
@@ -24,8 +24,8 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_PWMIO_PWMOUT_H
-#define MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_PWMIO_PWMOUT_H
+#ifndef MICROPY_INCLUDED_RASPBERRY_PI_COMMON_HAL_PWMIO_PWMOUT_H
+#define MICROPY_INCLUDED_RASPBERRY_PI_COMMON_HAL_PWMIO_PWMOUT_H
 
 #include "common-hal/microcontroller/Pin.h"
 
@@ -34,8 +34,8 @@
 typedef struct {
     mp_obj_base_t base;
     const mcu_pin_obj_t *pin;
-    uint8_t slice;
-    uint8_t channel;
+    uint8_t slice;        // 0-7
+    uint8_t ab_channel;   // 0-1: A or B slice channel
     bool variable_frequency;
     uint16_t duty_cycle;
     uint32_t actual_frequency;
@@ -46,13 +46,13 @@ void pwmout_reset(void);
 // Private API for AudioPWMOut.
 void pwmio_pwmout_set_top(pwmio_pwmout_obj_t *self, uint16_t top);
 // Private APIs for RGBMatrix
-enum pwmout_result_t pwmout_allocate(uint8_t slice, uint8_t channel, bool variable_frequency, uint32_t frequency);
-void pwmout_free(uint8_t slice, uint8_t channel);
-void pwmout_never_reset(uint8_t slice, uint8_t channel);
-void pwmout_reset_ok(uint8_t slice, uint8_t channel);
+enum pwmout_result_t pwmout_allocate(uint8_t slice, uint8_t ab_channel, bool variable_frequency, uint32_t frequency);
+void pwmout_free(uint8_t slice, uint8_t ab_channel);
+void pwmout_never_reset(uint8_t slice, uint8_t ab_channel);
+void pwmout_reset_ok(uint8_t slice, uint8_t ab_channel);
 
-// Private API for countio to claim both channels on a slice
-bool pwmio_claim_slice_channels(uint8_t slice);
-void pwmio_release_slice_channels(uint8_t slice);
+// Private API for countio to claim both ab_channels on a slice
+bool pwmio_claim_slice_ab_channels(uint8_t slice);
+void pwmio_release_slice_ab_channels(uint8_t slice);
 
-#endif // MICROPY_INCLUDED_ATMEL_SAMD_COMMON_HAL_PWMIO_PWMOUT_H
+#endif // MICROPY_INCLUDED_RASPBERRY_PI_COMMON_HAL_PWMIO_PWMOUT_H

--- a/tests/extmod/utimeq1.py
+++ b/tests/extmod/utimeq1.py
@@ -17,7 +17,6 @@ if DEBUG:
     def dprint(*v):
         print(*v)
 
-
 else:
 
     def dprint(*v):

--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -83,7 +83,6 @@ if "length" in inspect.getfullargspec(usb.util.get_string).args:
     def get_string(dev, index):
         return usb.util.get_string(dev, 255, index)
 
-
 else:
     # PyUSB 1.0.0.b2 dropped the length argument
     def get_string(dev, index):


### PR DESCRIPTION
- Fixes #5556. May also fix some mysterious other PWM problems.

In RP2040 PWM, the term _channel_ is overloaded. Sometimes it means one of two channels (A or B) in a slice, sometimes it means one of 16 PWM output channels, and sometimes it is another name for _slice_ (of which there are 8).

It appears we used an AB channel number when we meant to use a slice number. This caused #5556.

I renamed some uses of the word `channel`, when it meant an A or B slice channel. I renamed those channels to `ab_channel`, to make this clearer. But I'd kind of like another term for the 16-instance channels as well, maybe `pwm_channel`, or something.

I also made a doc issue for the RP2040 folks about the overloading: https://github.com/raspberrypi/pico-feedback/issues/209