### PR TITLE
minor .py changes due to blacken update

### DIFF
--- a/tests/extmod/utimeq1.py
+++ b/tests/extmod/utimeq1.py
@@ -17,7 +17,6 @@ if DEBUG:
     def dprint(*v):
         print(*v)
 
-
 else:
 
     def dprint(*v):

--- a/tools/pydfu.py
+++ b/tools/pydfu.py
@@ -83,7 +83,6 @@ if "length" in inspect.getfullargspec(usb.util.get_string).args:
     def get_string(dev, index):
         return usb.util.get_string(dev, 255, index)
 
-
 else:
     # PyUSB 1.0.0.b2 dropped the length argument
     def get_string(dev, index):


### PR DESCRIPTION
An update to `blacken` caused some `.py` scripts to fail pre-commit due to extra blank lines.