### PR TITLE
esp32s3-box: enable display

### DIFF
--- a/ports/espressif/boards/espressif_esp32s3_box/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_box/board.c
@@ -28,7 +28,68 @@
 #include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
+#include "shared-bindings/busio/SPI.h"
+#include "shared-bindings/displayio/FourWire.h"
+#include "shared-module/displayio/__init__.h"
+#include "shared-module/displayio/mipi_constants.h"
+
+uint8_t display_init_sequence[] = {
+    0x01, 0x80, 0x96, //  _SWRESET and Delay 150ms
+    0x11, 0x80, 0xFF, //  _SLPOUT and Delay 500ms
+    0x3A, 0x81, 0x55, 0x0A, //  _COLMOD and Delay 10ms
+    0x36, 0x01, 0x08, //  _MADCTL
+    0x13, 0x80, 0x0A, //  _NORON and Delay 10ms
+    0x36, 0x01, 0xC0, //  _MADCTL
+    0x29, 0x80, 0xFF, //  _DISPON and Delay 500ms
+};
+
 void board_init(void) {
+    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    common_hal_busio_spi_construct(spi, &pin_GPIO7, &pin_GPIO6, NULL);
+    common_hal_busio_spi_never_reset(spi);
+
+    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    bus->base.type = &displayio_fourwire_type;
+    common_hal_displayio_fourwire_construct(bus,
+        spi,
+        &pin_GPIO4, // TFT_DC Command or data
+        &pin_GPIO5, // TFT_CS Chip select
+        &pin_GPIO48, // TFT_RST Reset
+        60000000, // Baudrate
+        0, // Polarity
+        0); // Phase
+
+    displayio_display_obj_t *display = &displays[0].display;
+    display->base.type = &displayio_display_type;
+    common_hal_displayio_display_construct(display,
+        bus,
+        320, // Width
+        240, // Height
+        0, // column start
+        0, // row start
+        0, // rotation
+        16, // Color depth
+        false, // Grayscale
+        false, // pixels in a byte share a row. Only valid for depths < 8
+        1, // bytes per cell. Only valid for depths < 8
+        false, // reverse_pixels_in_byte. Only valid for depths < 8
+        true, // reverse_pixels_in_word
+        MIPI_COMMAND_SET_COLUMN_ADDRESS, // Set column command
+        MIPI_COMMAND_SET_PAGE_ADDRESS, // Set row command
+        MIPI_COMMAND_WRITE_MEMORY_START, // Write memory command
+        display_init_sequence,
+        sizeof(display_init_sequence),
+        &pin_GPIO45,  // backlight pin
+        NO_BRIGHTNESS_COMMAND,
+        1.0f, // brightness (ignored)
+        true, // auto_brightness
+        false, // single_byte_bounds
+        false, // data_as_commands
+        true, // auto_refresh
+        60, // native_frames_per_second
+        true, // backlight_on_high
+        false); // SH1107_addressing
+
     // USB
     common_hal_never_reset_pin(&pin_GPIO19);
     common_hal_never_reset_pin(&pin_GPIO20);

--- a/ports/espressif/boards/espressif_esp32s3_box/pins.c
+++ b/ports/espressif/boards/espressif_esp32s3_box/pins.c
@@ -1,4 +1,5 @@
 #include "shared-bindings/board/__init__.h"
+#include "shared-module/displayio/__init__.h"
 
 STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
@@ -60,5 +61,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     // boot button, also usable as a software button
     { MP_ROM_QSTR(MP_QSTR_BOOT), MP_ROM_PTR(&pin_GPIO0) },
+
+    { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display)}
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/espressif/common-hal/microcontroller/Pin.c
+++ b/ports/espressif/common-hal/microcontroller/Pin.c
@@ -95,8 +95,8 @@ void reset_all_pins(void) {
         }
         floating_gpio_reset(i);
     }
-    in_use[0] = 0;
-    in_use[1] = 0;
+    in_use[0] = never_reset_pins[0];
+    in_use[1] = never_reset_pins[1];
 }
 
 void claim_pin_number(gpio_num_t pin_number) {

--- a/ports/espressif/common-hal/pwmio/PWMOut.c
+++ b/ports/espressif/common-hal/pwmio/PWMOut.c
@@ -32,10 +32,9 @@
 
 #define INDEX_EMPTY 0xFF
 
-STATIC bool not_first_reset = false;
 STATIC uint32_t reserved_timer_freq[LEDC_TIMER_MAX];
 STATIC bool varfreq_timers[LEDC_TIMER_MAX];
-STATIC uint8_t reserved_channels[LEDC_CHANNEL_MAX];
+STATIC uint8_t reserved_channels[LEDC_CHANNEL_MAX] = { [0 ... LEDC_CHANNEL_MAX - 1] = INDEX_EMPTY};
 STATIC bool never_reset_tim[LEDC_TIMER_MAX];
 STATIC bool never_reset_chan[LEDC_CHANNEL_MAX];
 
@@ -56,7 +55,7 @@ STATIC uint32_t calculate_duty_cycle(uint32_t frequency) {
 
 void pwmout_reset(void) {
     for (size_t i = 0; i < LEDC_CHANNEL_MAX; i++) {
-        if (reserved_channels[i] != INDEX_EMPTY && not_first_reset) {
+        if (reserved_channels[i] != INDEX_EMPTY) {
             ledc_stop(LEDC_LOW_SPEED_MODE, i, 0);
         }
         if (!never_reset_chan[i]) {
@@ -72,7 +71,6 @@ void pwmout_reset(void) {
             varfreq_timers[i] = false;
         }
     }
-    not_first_reset = true;
 }
 
 pwmout_result_t common_hal_pwmio_pwmout_construct(pwmio_pwmout_obj_t *self,


### PR DESCRIPTION
This involves also fixing some problems with pin & pwm busy & never-reset tracking.

Before these changes, the PWM created during `board_init()` was lost, making the display not appear (backlight turned full off).

Now, the display is initialized at boot time and all the related pins remain allocated as far as attempts to construct a `DigitalInOut` using them are concerned.

@dhalbert wondered whether this could be related to #5476 but as the fixes I found were entirely within the port, it seems less likely there is a shared cause with that other issue, affecting samd microcontrollers. (which is not to say there might not be similar bugs in two ports)