### PR TITLE
Pass ci_fetch_deps.py the sha rather than ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Get CP deps
-      run: python tools/ci_fetch_deps.py test ${{ github.ref }}
+      run: python tools/ci_fetch_deps.py test ${{ github.sha }}
     - name: CircuitPython version
       run: |
         git describe --dirty --tags || git log --parents HEAD~4..
@@ -141,7 +141,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Get CP deps
-      run: python tools/ci_fetch_deps.py mpy-cross-mac ${{ github.ref }}
+      run: python tools/ci_fetch_deps.py mpy-cross-mac ${{ github.sha }}
     - name: CircuitPython version
       run: |
         git describe --dirty --tags
@@ -197,7 +197,7 @@ jobs:
         submodules: false
         fetch-depth: 1
     - name: Get CP deps
-      run: python tools/ci_fetch_deps.py docs ${{ github.ref }}
+      run: python tools/ci_fetch_deps.py docs ${{ github.sha }}
     - name: CircuitPython version
       run: |
         git describe --dirty --tags
@@ -269,7 +269,7 @@ jobs:
         submodules: false
         fetch-depth: 1
     - name: Get CP deps
-      run: python tools/ci_fetch_deps.py ${{ matrix.board }} ${{ github.ref }}
+      run: python tools/ci_fetch_deps.py ${{ matrix.board }} ${{ github.sha }}
     - name: Install dependencies
       run: |
         sudo apt-get install -y gettext

--- a/.github/workflows/create_website_pr.yml
+++ b/.github/workflows/create_website_pr.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Get CP deps
-      run: python tools/ci_fetch_deps.py website ${{ github.ref }}
+      run: python tools/ci_fetch_deps.py website ${{ github.sha }}
     - name: Install deps
       run: |
         pip install -r requirements-dev.txt

--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -70,7 +70,7 @@ jobs:
         submodules: false
         fetch-depth: 1
     - name: Get CP deps
-      run: python tools/ci_fetch_deps.py windows ${{ github.ref }}
+      run: python tools/ci_fetch_deps.py windows ${{ github.sha }}
     - name: CircuitPython version
       run: |
         git describe --dirty --tags


### PR DESCRIPTION
The remote ref may be out of date and not get the right branch
history in some cases. actions/checkout also fetches based on sha:

https://github.com/adafruit/circuitpython/runs/4449960809?check_suite_focus=true#step:3:40