### PR TITLE
sdcardio: Don't require reaching idle state during early init

### DIFF
--- a/shared-module/sdcardio/SDCard.c
+++ b/shared-module/sdcardio/SDCard.c
@@ -230,11 +230,18 @@ STATIC const compressed_string_t *init_card(sdcardio_sdcard_obj_t *self) {
 
     common_hal_digitalio_digitalinout_set_value(&self->cs, false);
 
+    assert(!self->in_cmd25);
+    self->in_cmd25 = false; // should be false already
+
     // CMD0: init card: should return _R1_IDLE_STATE (allow 5 attempts)
     {
         bool reached_idle_state = false;
         for (int i = 0; i < 5; i++) {
-            if (cmd(self, 0, 0, NULL, 0, true, true) == R1_IDLE_STATE) {
+            // do not call cmd with wait=true, because that will return
+            // prematurely if the idle state is not reached. we can't depend on
+            // this when the card is not yet in SPI mode
+            (void)wait_for_ready(self);
+            if (cmd(self, 0, 0, NULL, 0, true, false) == R1_IDLE_STATE) {
                 reached_idle_state = true;
                 break;
             }

--- a/shared-module/sdcardio/SDCard.c
+++ b/shared-module/sdcardio/SDCard.c
@@ -266,6 +266,7 @@ STATIC const compressed_string_t *init_card(sdcardio_sdcard_obj_t *self) {
                 return result;
             }
         } else {
+            DEBUG_PRINT("Reading card version, response=0x%02x\n", response);
             return translate("couldn't determine SD card version");
         }
     }


### PR DESCRIPTION
.. which is what the addition of cmd25 made happen. We still signal an error when failing to reach the idle state at any other time, which _is_ different than adafruit_sdcard but I think that it is correct.

This fixes #5600 according to Dan's testing on a GCM4 on the internal SD card slot. There are still some ambiguous results on the MM4 with external SD card slot on 6" jumper wires.