### PR TITLE
Fetch tools/adabot submodule for website build

### DIFF
--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -73,8 +73,7 @@ elif target == "windows":
     # This builds one board from a number of ports so fill out a bunch of submodules
     submodules = ["extmod/", "lib/", "tools/", "ports/", "data/nvm.toml/"]
 elif target == "website":
-    # No submodules needed.
-    pass
+    submodules = ["tools/adabot/"]
 else:
     p = list(pathlib.Path(".").glob(f"ports/*/boards/{target}/mpconfigboard.mk"))
     if not p:


### PR DESCRIPTION
It's used by build_board_info.py

This should fix: https://github.com/adafruit/circuitpython/runs/4486482634?check_suite_focus=true