### PR TITLE
Clear SAMD TAMPER interrupt in pinalarm properly

### DIFF
--- a/ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
@@ -164,7 +164,7 @@ void alarm_pin_pinalarm_reset(void) {
     woke_up = false;
     SAMD_ALARM_FLAG &= ~SAMD_ALARM_FLAG_PIN; // clear flag
     // Disable TAMPER interrupt
-    RTC->MODE0.INTENCLR.bit.TAMPER = 1;
+    RTC->MODE0.INTENCLR.reg = RTC_MODE0_INTENCLR_TAMPER;
     // Disable TAMPER control
     common_hal_mcu_disable_interrupts();
     RTC->MODE0.CTRLA.bit.ENABLE = 0;            // Disable the RTC

--- a/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+++ b/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -185,13 +185,13 @@ static void frequencyin_reference_tc_init(void) {
 
     #ifdef SAMD21
     tc->COUNT16.CTRLA.reg = TC_CTRLA_MODE_COUNT16 | TC_CTRLA_PRESCALER_DIV1;
-    tc->COUNT16.INTENSET.bit.OVF = 1;
+    tc->COUNT16.INTENSET.reg = TC_INTENSET_OVF;
     NVIC_EnableIRQ(TC3_IRQn + reference_tc);
     #endif
     #ifdef SAM_D5X_E5X
     tc->COUNT16.CTRLA.reg = TC_CTRLA_MODE_COUNT16 |
                             TC_CTRLA_PRESCALER_DIV1;
-    tc->COUNT16.INTENSET.bit.OVF = 1;
+    tc->COUNT16.INTENSET.reg = TC_INTENSET_OVF;
     NVIC_EnableIRQ(TC0_IRQn + reference_tc);
     #endif
 }

--- a/ports/atmel-samd/common-hal/watchdog/WatchDogTimer.c
+++ b/ports/atmel-samd/common-hal/watchdog/WatchDogTimer.c
@@ -58,7 +58,7 @@ STATIC void setup_wdt(watchdog_watchdogtimer_obj_t *self, int setting) {
     while (WDT->SYNCBUSY.reg) { // Sync CTRL write
     }
 
-    WDT->INTENCLR.bit.EW = 1;   // Disable early warning interrupt
+    WDT->INTENCLR.reg = WDT_INTENCLR_EW;   // Disable early warning interrupt
     WDT->CONFIG.bit.PER = setting; // Set period for chip reset
     WDT->CTRLA.bit.WEN = 0;     // Disable window mode
     while (WDT->SYNCBUSY.reg) { // Sync CTRL write

--- a/shared-bindings/keypad/__init__.c
+++ b/shared-bindings/keypad/__init__.c
@@ -42,7 +42,7 @@
 //| """
 //|
 
-STATIC mp_map_elem_t keypad_module_globals_table[] = {
+STATIC mp_rom_map_elem_t keypad_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),          MP_OBJ_NEW_QSTR(MP_QSTR_keypad) },
     { MP_ROM_QSTR(MP_QSTR_Event),             MP_OBJ_FROM_PTR(&keypad_event_type) },
     { MP_ROM_QSTR(MP_QSTR_EventQueue),        MP_OBJ_FROM_PTR(&keypad_eventqueue_type) },
@@ -51,7 +51,7 @@ STATIC mp_map_elem_t keypad_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ShiftRegisterKeys), MP_OBJ_FROM_PTR(&keypad_shiftregisterkeys_type) },
 };
 
-STATIC MP_DEFINE_MUTABLE_DICT(keypad_module_globals, keypad_module_globals_table);
+STATIC MP_DEFINE_CONST_DICT(keypad_module_globals, keypad_module_globals_table);
 
 const mp_obj_module_t keypad_module = {
     .base = { &mp_type_module },


### PR DESCRIPTION
- Fixes #5705.

- In SAMD, `alarm_pin_pinalarm_reset()` was clearing the TAMPER interrupt flag with a bitwise operation, instead of just writing a 1 to the right bit, with the rest zeros, using a full register write. The bitwise operation apparently caused the other RTC interrupts to be messed up in some way, and then caused problems with other timing-based operations (probably background task handling), and showed up as `displayio` problems.

- Based on the error above, looked for and fixed a few other `INTENCLR.bit` and `INTENSET.bit` assignments that should ahve been full-width register writes instead, and found a few. Tested `frequencyio` to make sure it still works. Did not test `watchdog`; there is only 1 active bit in that register anyway.

- Unrelated improvement found when seeing if this was a `gc`-related bug (which it was not): `keypad` module dict was mutable, but it could be constant. This was probably a leftover of an earlier version of `keypad`.