### PR TITLE
Fix uctypes.sizeof(struct)  in NATIVE mode

### DIFF
--- a/tests/extmod/uctypes_sizeof_layout.py
+++ b/tests/extmod/uctypes_sizeof_layout.py
@@ -13,10 +13,9 @@ desc = {
 # uctypes.NATIVE is default
 print(uctypes.sizeof(desc) == uctypes.sizeof(desc, uctypes.NATIVE))
 
-# Here we assume that that we run on a platform with convential ABI
-# (which rounds up structure size based on max alignment). For platforms
-# where that doesn't hold, this tests should be just disabled in the runner.
-print(uctypes.sizeof(desc, uctypes.NATIVE) > uctypes.sizeof(desc, uctypes.LITTLE_ENDIAN))
+# To accord with convential ABI (which rounds up structure size based
+# on max alignment), users should add padding bytes explicitly.
+print(uctypes.sizeof(desc, uctypes.NATIVE) == uctypes.sizeof(desc, uctypes.LITTLE_ENDIAN))
 
 # When taking sizeof of instantiated structure, layout type param
 # is prohibited (because structure already has its layout type).

--- a/tests/extmod/uctypes_sizeof_native.py
+++ b/tests/extmod/uctypes_sizeof_native.py
@@ -60,6 +60,10 @@ S8 = {
 assert uctypes.sizeof(S8) == 15
 
 S9 = {
-    "arr": (uctypes.ARRAY | 0, 3, {"a": uctypes.UINT32 | 0, "b": uctypes.UINT8 | 4, "dummy": uctypes.UINT8 | 7}),
+    "arr": (
+        uctypes.ARRAY | 0,
+        3,
+        {"a": uctypes.UINT32 | 0, "b": uctypes.UINT8 | 4, "dummy": uctypes.UINT8 | 7},
+    ),
 }
 assert uctypes.sizeof(S9) == 24

--- a/tests/extmod/uctypes_sizeof_native.py
+++ b/tests/extmod/uctypes_sizeof_native.py
@@ -21,7 +21,7 @@ S4 = {
     "b": uctypes.UINT32 | 4,
     "c": uctypes.UINT8 | 8,
 }
-assert uctypes.sizeof(S4) == 12
+assert uctypes.sizeof(S4) == 9
 
 S5 = {
     "a": uctypes.UINT8 | 0,
@@ -37,10 +37,10 @@ S5 = {
     ),
 }
 
-assert uctypes.sizeof(S5) == 12
+assert uctypes.sizeof(S5) == 9
 
 s5 = uctypes.struct(0, S5)
-assert uctypes.sizeof(s5) == 12
+assert uctypes.sizeof(s5) == 9
 assert uctypes.sizeof(s5.sub) == 2
 
 S6 = {
@@ -57,4 +57,9 @@ assert uctypes.sizeof(S7) == 5
 S8 = {
     "arr": (uctypes.ARRAY | 0, 3, {"a": uctypes.UINT32 | 0, "b": uctypes.UINT8 | 4}),
 }
-assert uctypes.sizeof(S8) == 24
+assert uctypes.sizeof(S8) == 15
+
+S9 = {
+    "arr": (uctypes.ARRAY | 0, 3, {"a": uctypes.UINT32 | 0, "b": uctypes.UINT8 | 4, "dummy": uctypes.UINT8 | 7}),
+}
+assert uctypes.sizeof(S9) == 24


### PR DESCRIPTION
This PR fixes the size calculation of struct in NATIVE mode of uctypes.  In NATIVE mode, uctypes try to add padding bytes automatically to align struct in 2/4 byte boarder if necessary.  Different from ctypes of CPython, however, the memory layout of struct is defined explicitly by users in uctypes, so that the automatic padding is not necessary.  The padding action is especially harmful when using an array of struct: the stride is determined by sizeof(struct), which depends on the order of dict.keys() (see the following example on CircuitPython 7.0).  This PR removes the padding codes from moductypes.c.  

```
import uctypes as ct
buf = bytearray( [ 0x12, 0x34, 0x56, 0x78 ] + list(range(16)) )
bad = ct.addressof(buf)
d0 = { "v1" : 0x00 | ct.UINT32,
       "v2" : ( 0x04 | ct.ARRAY, 2 | ct.UINT8 ) }
s0 = ct.struct(bad, d0)
print(ct.sizeof(s0))
↓
8
```

When we define bit-field for UINT8, it is considered as struct, and padding bytes are added:
```
d1BF = { "lo" : 0x00 | ct.BFUINT8 | 0 << ct.BF_POS | 4 << ct.BF_LEN }
d1 = { "v1" :  0x00 | ct.UINT32,
       "v2" : ( 0x04 | ct.ARRAY, 2, d1BF) }
s1 = ct.struct(bad, d1)
print(ct.sizeof(s1))
print([ hex(ct.addressof(x)) for x in (s1, s1.v2[0], s1.v2[1]) ])
↓
12
['0x20004180', '0x20004184', '0x20004185']
```
Each element of d1BF is assumed to be aligned on UINT32 boundary, so that sizeof(struct) becomes 12.  However, the actual layout is different, as shown in addressof(element).
If we modify the keys of the definition, the sizeof(struct) changes:
```
d2 = { "v0" :  0x00 | ct.UINT32,
       "v1" : ( 0x04 | ct.ARRAY, 2, d1BF) }
s2 = ct.struct(bad, d2)
print( ct.sizeof(s2) )
print( list(d2.keys()) )
↓
8
['v1', 'v0']
```
It is because the boundary size is determined in the order of dict.keys().  In this case, the initial UINT8 boundary is applied for `v1` because it comes earlier.

**Why NATIVE is necessary?**
The padding is avoided by using LITTLE_ENDIAN/BIG_ENDIAN modes.  Under these modes, however, multi-byte writing (UINT16/UINT32) is not atomic.  This causes problem when manipulating some registers of peripherals.