### PR TITLE
Fix to error checking in espressif SSLSocket

### DIFF
--- a/ports/espressif/common-hal/ssl/SSLSocket.c
+++ b/ports/espressif/common-hal/ssl/SSLSocket.c
@@ -66,7 +66,7 @@ void common_hal_ssl_sslsocket_connect(ssl_sslsocket_obj_t *self,
 
         if (err == ESP_ERR_MBEDTLS_SSL_SETUP_FAILED) {
             mp_raise_espidf_MemoryError();
-        } else if (ESP_ERR_MBEDTLS_SSL_HANDSHAKE_FAILED) {
+        } else if (err == ESP_ERR_MBEDTLS_SSL_HANDSHAKE_FAILED) {
             mp_raise_OSError_msg_varg(translate("Failed SSL handshake"));
         } else {
             mp_raise_OSError_msg_varg(translate("Unhandled ESP TLS error %d %d %x %d"), esp_tls_code, flags, err, result);


### PR DESCRIPTION
A typo in an error comparison caused all TLS errors to be masked as "Failed SSL handshake" instead of returning a more detailed error code.