### PR TITLE
Fix website action dependencies; don't build everything on CI changes - 7.1.x backport

### DIFF
--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -73,8 +73,7 @@ elif target == "windows":
     # This builds one board from a number of ports so fill out a bunch of submodules
     submodules = ["extmod/", "lib/", "tools/", "ports/", "data/nvm.toml/"]
 elif target == "website":
-    # No submodules needed.
-    pass
+    submodules = ["tools/adabot/"]
 else:
     p = list(pathlib.Path(".").glob(f"ports/*/boards/{target}/mpconfigboard.mk"))
     if not p:

--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -34,6 +34,11 @@ PORT_TO_ARCH = {
     "stm": "arm",
 }
 
+IGNORE = [
+    "tools/ci_set_matrix.py",
+    "tools/ci_check_duplicate_usb_vid_pid.py",
+]
+
 changed_files = {}
 try:
     changed_files = json.loads(os.environ["CHANGED_FILES"])
@@ -79,6 +84,14 @@ def set_boards_to_build(build_all):
                 port = port_matches.group(1)
                 if port != "unix":
                     boards_to_build.update(port_to_boards[port])
+                continue
+            
+            # Check the ignore list to see if the file isn't used on board builds.
+            if p in IGNORE:
+                continue
+                
+            # Boards don't run tests so ignore those as well.
+            if p.startswith("tests"):
                 continue
 
             # Otherwise build it all

--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -85,11 +85,11 @@ def set_boards_to_build(build_all):
                 if port != "unix":
                     boards_to_build.update(port_to_boards[port])
                 continue
-            
+
             # Check the ignore list to see if the file isn't used on board builds.
             if p in IGNORE:
                 continue
-                
+
             # Boards don't run tests so ignore those as well.
             if p.startswith("tests"):
                 continue


### PR DESCRIPTION
Backport to 7.1.x from `main`, using `git cherry-pick`:
- #5701
- #5702

(7.1.x `circuitpython-org` action was still failing)