### PR TITLE
traceback: fix for crash on non-native exceptions

### DIFF
--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -104,7 +104,7 @@ mp_obj_t mp_alloc_emergency_exception_buf(mp_obj_t size_in) {
 #endif
 #endif  // MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF
 
-STATIC mp_obj_exception_t *get_native_exception(mp_obj_t self_in) {
+mp_obj_exception_t *mp_obj_exception_get_native(mp_obj_t self_in) {
     assert(mp_obj_is_exception_instance(self_in));
     if (mp_obj_is_native_exception_instance(self_in)) {
         return MP_OBJ_TO_PTR(self_in);
@@ -206,7 +206,7 @@ mp_obj_t mp_obj_exception_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
 // Get exception "value" - that is, first argument, or None
 mp_obj_t mp_obj_exception_get_value(mp_obj_t self_in) {
-    mp_obj_exception_t *self = get_native_exception(self_in);
+    mp_obj_exception_t *self = mp_obj_exception_get_native(self_in);
     if (self->args->len == 0) {
         return mp_const_none;
     } else {
@@ -543,14 +543,14 @@ bool mp_obj_exception_match(mp_obj_t exc, mp_const_obj_t exc_type) {
 // traceback handling functions
 
 void mp_obj_exception_clear_traceback(mp_obj_t self_in) {
-    mp_obj_exception_t *self = get_native_exception(self_in);
+    mp_obj_exception_t *self = mp_obj_exception_get_native(self_in);
     // just set the traceback to the empty traceback object
     // we don't want to call any memory management functions here
     self->traceback = (mp_obj_traceback_t *)&mp_const_empty_traceback_obj;
 }
 
 void mp_obj_exception_add_traceback(mp_obj_t self_in, qstr file, size_t line, qstr block) {
-    mp_obj_exception_t *self = get_native_exception(self_in);
+    mp_obj_exception_t *self = mp_obj_exception_get_native(self_in);
 
     // Try to allocate memory for the traceback, with fallback to emergency traceback object
     if (self->traceback == NULL || self->traceback == (mp_obj_traceback_t *)&mp_const_empty_traceback_obj) {
@@ -612,7 +612,7 @@ void mp_obj_exception_add_traceback(mp_obj_t self_in, qstr file, size_t line, qs
 }
 
 void mp_obj_exception_get_traceback(mp_obj_t self_in, size_t *n, size_t **values) {
-    mp_obj_exception_t *self = get_native_exception(self_in);
+    mp_obj_exception_t *self = mp_obj_exception_get_native(self_in);
 
     if (self->traceback == NULL) {
         *n = 0;

--- a/py/objexcept.h
+++ b/py/objexcept.h
@@ -38,6 +38,7 @@ typedef struct _mp_obj_exception_t {
 
 void mp_obj_exception_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind);
 void mp_obj_exception_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
+mp_obj_exception_t *mp_obj_exception_get_native(mp_obj_t self_in);
 
 #define MP_DEFINE_EXCEPTION(exc_name, base_name) \
     const mp_obj_type_t mp_type_##exc_name = { \

--- a/tests/circuitpython/traceback_test.py
+++ b/tests/circuitpython/traceback_test.py
@@ -22,4 +22,15 @@ except Exception as exc:
     traceback.print_exception(None, exc, exc.__traceback__, limit=0)
     print("\nLimit=-1 Trace:")
     traceback.print_exception(None, exc, exc.__traceback__, limit=-1)
+
+
+class NonNativeException(Exception):
+    pass
+
+
+try:
+    raise NonNativeException("test")
+except Exception as e:
+    print("\nNonNative Trace:")
+    traceback.print_exception(None, e, e.__traceback__)
     print("")

--- a/tests/circuitpython/traceback_test.py.exp
+++ b/tests/circuitpython/traceback_test.py.exp
@@ -21,3 +21,8 @@ Traceback (most recent call last):
   File "circuitpython/traceback_test.py", line 9, in fun
 Exception: test
 
+NonNative Trace:
+Traceback (most recent call last):
+  File "circuitpython/traceback_test.py", line 32, in <module>
+NonNativeException: test
+


### PR DESCRIPTION
Fix for #5704 