### PR TITLE
fix mypy requirement at 0.910, for compatibility

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,5 +1,5 @@
 # For docs
-mypy
+mypy==0.910
 black
 isort
 twine


### PR DESCRIPTION
This should fix the doc build, which currently fails
```
ulab/numpy/__init__.pyi:51: error: Cannot assign multiple types to name "_float" without an explicit "Type[...]" annotation
ulab/numpy/__init__.pyi:54: error: Cannot assign multiple types to name "_bool" without an explicit "Type[...]" annotation
```
since mypy 0.920 was released.

After https://github.com/v923z/micropython-ulab/pull/461 or another fix is merged and our submodule ref is updated, we can un-pin mypy.  However, as we may not want to change the version of ulab in 7.1.x right now, this workaround may be preferable.