### PR TITLE
Explicitly cast float to mp_int_t

### DIFF
--- a/shared-module/adafruit_pixelbuf/PixelBuf.c
+++ b/shared-module/adafruit_pixelbuf/PixelBuf.c
@@ -163,7 +163,7 @@ STATIC void _pixelbuf_parse_color(pixelbuf_pixelbuf_obj_t *self, mp_obj_t color,
     }
 
     if (mp_obj_is_int(color) || mp_obj_is_float(color)) {
-        mp_int_t value = mp_obj_is_int(color) ? mp_obj_get_int_truncated(color) : mp_obj_get_float(color);
+        mp_int_t value = mp_obj_is_int(color) ? mp_obj_get_int_truncated(color) : (mp_int_t)mp_obj_get_float(color);
         *r = value >> 16 & 0xff;
         *g = (value >> 8) & 0xff;
         *b = value & 0xff;


### PR DESCRIPTION
Not sure why this is necessary, but it prevents an off-by-one error in some (rare?) circumstances.

Fixes the bug found in #5725:

```python
>>> import board, neopixel
>>> pixels = neopixel.NeoPixel(board.D5, 8, brightness=1.0, auto_write=False, pixel_order=neopixel.GRBW)
>>> pixels[2] = 0x400000FF
>>> pixels[2]
(0, 0, 255, 0)
```

This doesn't close #5725, since that it is also about whether or not the behavior of integer values with RGBW neopixels is appropriate.