### PR TITLE
Fix cascadetoml more

### DIFF
--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -60,7 +60,7 @@ jobs:
         pip install wheel
         # requirements_dev.txt doesn't install on windows. (with msys2 python)
         # instead, pick a subset for what we want to do
-        pip install cascadetoml jinja2 typer intelhex
+        pip install jinja2 typer intelhex cascadetoml==0.3.1 tomlkit==0.7.2
         # check that installed packages work....?
         which python; python --version; python -c "import cascadetoml"
         which python3; python3 --version; python3 -c "import cascadetoml"


### PR DESCRIPTION
Only when I created 
 * #5754

did CI run the windows build, which didn't use the requirements file to install the python dependencies, get run. It fails too, due to the cascadetoml/tomlkit incompatibility.  Pin it here, too.