### PR TITLE
Add a font protocol

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -6,6 +6,7 @@ twine
 wheel
 astroid
 setuptools
+setuptools_scm
 
 # For sphinx
 Sphinx<4

--- a/shared-bindings/fontio/BuiltinFont.c
+++ b/shared-bindings/fontio/BuiltinFont.c
@@ -36,6 +36,25 @@
 #include "shared-bindings/util.h"
 #include "supervisor/shared/translate.h"
 
+//| from typing_extensions import Protocol # for compat with python < 3.8
+//|
+//| class FontProtocol(Protocol):
+//|     """A protocol shared by `BuiltinFont` and classes in ``adafruit_bitmap_font``"""
+//|     def get_bounding_box(self) -> Union[Tuple[int, int], Tuple[int, int, int, int]]:
+//|         """Retrieve the maximum bounding box of any glyph in the font.
+//|
+//|         The four element version is ``(width, height, x_offset, y_offset)``.
+//|         The two element version is ``(width, height)``, in which
+//|         ``x_offset`` and ``y_offset`` are assumed to be zero."""
+//|         pass
+//|
+//|     def get_glyph(self, codepoint: int) -> Optional[Glyph]:
+//|         """Retrieve the Glyph for a given code point
+//|
+//|         If the code point is not present in the font, `None` is returned."""
+//|         pass
+//|
+
 //| class BuiltinFont:
 //|     """A font built into CircuitPython"""
 //|


### PR DESCRIPTION
@tekktrik noticed that there was no convenient way to specify that a function takes "any kind of Font", including the built in one and the ones from the `adafruit_bitmap_font` package. By defining this _protocol_ in our stubs, it's hoped that `fontio.FontProtocol` can be used instead of an ad-hoc `Union[]` of several known font types.

![image](https://user-images.githubusercontent.com/1517291/147002455-6a924f61-09be-4e1a-8b7d-934362fd48ac.png)
