### PR TITLE
Fix recording of wake_alarm

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -574,7 +574,7 @@ msgstr ""
 
 #: shared-bindings/displayio/Display.c
 #: shared-bindings/framebufferio/FramebufferDisplay.c
-#: shared-bindings/is31fl3741/is31fl3741.c
+#: shared-bindings/is31fl3741/IS31FL3741.c
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 msgid "Brightness must be 0-1.0"
 msgstr ""
@@ -1462,7 +1462,7 @@ msgstr ""
 msgid "Key must be 16, 24, or 32 bytes long"
 msgstr ""
 
-#: shared-module/is31fl3741/is31fl3741.c
+#: shared-module/is31fl3741/IS31FL3741.c
 msgid "LED mappings must match display size"
 msgstr ""
 
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid "Sample rate too high. It must be less than %d"
 msgstr ""
 
-#: shared-bindings/is31fl3741/is31fl3741.c
+#: shared-bindings/is31fl3741/IS31FL3741.c
 msgid "Scale dimensions must divide by 3"
 msgstr ""
 
@@ -2351,7 +2351,7 @@ msgstr ""
 msgid "Unable to create lock"
 msgstr ""
 
-#: shared-module/displayio/I2CDisplay.c shared-module/is31fl3741/is31fl3741.c
+#: shared-module/displayio/I2CDisplay.c shared-module/is31fl3741/IS31FL3741.c
 #, c-format
 msgid "Unable to find I2C Display at %x"
 msgstr ""
@@ -3950,6 +3950,7 @@ msgstr ""
 #: ports/espressif/boards/adafruit_funhouse/mpconfigboard.h
 #: ports/espressif/boards/adafruit_magtag_2.9_grayscale/mpconfigboard.h
 #: ports/espressif/boards/adafruit_metro_esp32s2/mpconfigboard.h
+#: ports/espressif/boards/adafruit_qtpy_esp32s2/mpconfigboard.h
 #: ports/espressif/boards/ai_thinker_esp32-c3s/mpconfigboard.h
 #: ports/espressif/boards/ai_thinker_esp_12k_nodemcu/mpconfigboard.h
 #: ports/espressif/boards/artisense_rd00/mpconfigboard.h
@@ -4462,7 +4463,7 @@ msgstr ""
 msgid "width must be from 2 to 8 (inclusive), not %d"
 msgstr ""
 
-#: shared-bindings/is31fl3741/is31fl3741.c
+#: shared-bindings/is31fl3741/IS31FL3741.c
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 msgid "width must be greater than zero"
 msgstr ""

--- a/ports/espressif/common-hal/alarm/__init__.c
+++ b/ports/espressif/common-hal/alarm/__init__.c
@@ -62,11 +62,6 @@ void alarm_reset(void) {
     esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
 }
 
-// This will be reset to false by full resets when bss is cleared. Otherwise, the
-// reload is due to CircuitPython and the ESP wakeup cause will be stale. This
-// can happen if USB is connected after a deep sleep.
-STATIC bool soft_wakeup = false;
-
 STATIC esp_sleep_wakeup_cause_t _get_wakeup_cause(void) {
     // First check if the modules remember what last woke up
     if (alarm_pin_pinalarm_woke_this_cycle()) {
@@ -80,11 +75,7 @@ STATIC esp_sleep_wakeup_cause_t _get_wakeup_cause(void) {
     }
     // If waking from true deep sleep, modules will have lost their state,
     // so check the deep wakeup cause manually
-    if (!soft_wakeup) {
-        soft_wakeup = true;
-        return esp_sleep_get_wakeup_cause();
-    }
-    return ESP_SLEEP_WAKEUP_UNDEFINED;
+    return esp_sleep_get_wakeup_cause();
 }
 
 bool common_hal_alarm_woken_from_sleep(void) {

--- a/shared-bindings/alarm/__init__.c
+++ b/shared-bindings/alarm/__init__.c
@@ -64,8 +64,10 @@
 //| This object is the sole instance of `alarm.SleepMemory`."""
 //|
 
-//| wake_alarm: Alarm
-//| """The most recently triggered alarm. If CircuitPython was sleeping, the alarm the woke it from sleep."""
+//| wake_alarm: Optional[Alarm]
+//| """The most recently triggered alarm. If CircuitPython was sleeping, the alarm that woke it from sleep.
+//| If no alarm occured since the last hard reset or soft restart, value is ``None``.
+//| """
 //|
 
 // wake_alarm is implemented as a dictionary entry, so there's no code here.
@@ -103,7 +105,9 @@ STATIC mp_obj_t alarm_light_sleep_until_alarms(size_t n_args, const mp_obj_t *ar
 
     validate_objs_are_alarms(n_args, args);
 
-    return common_hal_alarm_light_sleep_until_alarms(n_args, args);
+    mp_obj_t alarm = common_hal_alarm_light_sleep_until_alarms(n_args, args);
+    shared_alarm_save_wake_alarm(alarm);
+    return alarm;
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(alarm_light_sleep_until_alarms_obj, 1, MP_OBJ_FUN_ARGS_MAX, alarm_light_sleep_until_alarms);
 


### PR DESCRIPTION
- Fixes #5343.

`alarm.wake_alarm` was not being set properly after a real or fake deep sleep. I moved the responsibility for keeping track of whether the board had just hard-restarted to `main.c`, instead of having it in `common-hal`. The most recent wake alarm is now recorded in `alarm.wake_alarm` either after a hard-reset, or after a simulated (fake) deep sleep.

Light sleep was not setting `alarm.wake_alarm`. I did this in a port-independent way.

Also did a minor doc fix in `alarm`.

It looks like `circuitpython.pot` got out of sync with the code base at some previous point. It was using the older lowercase filename `is31fl3741.c` instead of `IS31FL3741.c`. Hence the merge to `circuitpython.pot`