### PR TITLE
Fix RST formatting for readthedocs

### DIFF
--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -400,7 +400,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_obj, 2, rp2pio_statemachine
 
 //|     def readinto(self, buffer: WriteableBuffer, *, start: int = 0, end: Optional[int] = None) -> None:
 //|         """Read into ``buffer``. If the number of bytes to read is 0, nothing happens. The buffer
-//|            include any data added to the fifo even if it was added before this was called.
+//|         includes any data added to the fifo even if it was added before this was called.
 //|
 //|         :param ~_typing.WriteableBuffer buffer: Read data into this buffer
 //|         :param int start: Start of the slice of ``buffer`` to read into: ``buffer[start:end]``


### PR DESCRIPTION
And also a typo/grammar thing.

Note that currently, the doc shows the "Read into..." line incorrectly formatted - and looks likes the line tails off at the phrase "The buffer...". This should make the RST format correctly (matching the format of other doc sections that don't have the same render glitch).