### PR TITLE
Feather ESP32-S2: turn on I2C power after reset

### DIFF
--- a/ports/espressif/boards/adafruit_feather_esp32s2/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2/board.c
@@ -33,11 +33,6 @@ void board_init(void) {
     // USB
     common_hal_never_reset_pin(&pin_GPIO19);
     common_hal_never_reset_pin(&pin_GPIO20);
-
-    // Turn on I2C
-    common_hal_never_reset_pin(&pin_GPIO7);
-    gpio_set_direction(7, GPIO_MODE_DEF_OUTPUT);
-    gpio_set_level(7, false);
 }
 
 bool board_requests_safe_mode(void) {
@@ -45,7 +40,9 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
-
+    // Turn on I2C power by default.
+    gpio_set_direction(7, GPIO_MODE_DEF_OUTPUT);
+    gpio_set_level(7, false);
 }
 
 void board_deinit(void) {

--- a/ports/espressif/boards/adafruit_feather_esp32s2/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2/board.c
@@ -27,11 +27,17 @@
 #include "supervisor/board.h"
 #include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
+#include "components/driver/include/driver/gpio.h"
 
 void board_init(void) {
     // USB
     common_hal_never_reset_pin(&pin_GPIO19);
     common_hal_never_reset_pin(&pin_GPIO20);
+
+    // Turn on I2C
+    common_hal_never_reset_pin(&pin_GPIO7);
+    gpio_set_direction(7, GPIO_MODE_DEF_OUTPUT);
+    gpio_set_level(7, false);
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/espressif/boards/adafruit_feather_esp32s2/pins.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2/pins.c
@@ -14,8 +14,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D5), MP_ROM_PTR(&pin_GPIO5) },
     { MP_ROM_QSTR(MP_QSTR_D6), MP_ROM_PTR(&pin_GPIO6) },
 
-    { MP_ROM_QSTR(MP_QSTR_D7), MP_ROM_PTR(&pin_GPIO7) },
     { MP_ROM_QSTR(MP_QSTR_I2C_POWER_INVERTED), MP_ROM_PTR(&pin_GPIO7) },
+    { MP_ROM_QSTR(MP_QSTR_D7), MP_ROM_PTR(&pin_GPIO7) },
 
     { MP_ROM_QSTR(MP_QSTR_A5), MP_ROM_PTR(&pin_GPIO8) },
     { MP_ROM_QSTR(MP_QSTR_D8), MP_ROM_PTR(&pin_GPIO8) },


### PR DESCRIPTION
This is the pretty much the same as #5776, but is a PR against 7.1.x instead of main. I read the code and could not understand why it didn't work, and after trying it myself, I was unable to repoduce the `D7 in use` message.

@ladyada, could you test, in your own way? I was using this, with the `DigitalInOut` commented out and not.

```py
import time
import board
import digitalio
import adafruit_bme280.basic

# Test with and without this.
# power = digitalio.DigitalInOut(board.I2C_POWER_INVERTED)
# power.switch_to_output(False)

i2c = board.I2C()  # uses board.SCL and board.SDA
bme280 = adafruit_bme280.basic.Adafruit_BME280_I2C(i2c)

while True:
    print("\nTemperature: %0.1f C" % bme280.temperature)
    print("Humidity: %0.1f %%" % bme280.relative_humidity)
    print("Pressure: %0.1f hPa" % bme280.pressure)
    print("Altitude = %0.2f meters" % bme280.altitude)
    time.sleep(2)
```