### PR TITLE
shared runtime: Improve buffer handling

### DIFF
--- a/shared-bindings/bitbangio/I2C.c
+++ b/shared-bindings/bitbangio/I2C.c
@@ -184,15 +184,13 @@ MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_i2c_unlock_obj, bitbangio_i2c_obj_unlock);
 // Shared arg parsing for readfrom_into and writeto_then_readfrom.
 STATIC void readfrom(bitbangio_i2c_obj_t *self, mp_int_t address, mp_obj_t buffer, int32_t start, mp_int_t end) {
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(buffer, &bufinfo, MP_BUFFER_WRITE);
+    get_normalized_buffer_raise(buffer, &bufinfo, MP_BUFFER_WRITE, start, end);
 
-    size_t length = bufinfo.len;
-    normalize_buffer_bounds(&start, end, &length);
-    if (length == 0) {
+    if (bufinfo.len == 0) {
         mp_raise_ValueError(translate("Buffer must be at least length 1"));
     }
 
-    uint8_t status = shared_module_bitbangio_i2c_read(self, address, ((uint8_t *)bufinfo.buf) + start, length);
+    uint8_t status = shared_module_bitbangio_i2c_read(self, address, bufinfo.buf, bufinfo.len);
     if (status != 0) {
         mp_raise_OSError(status);
     }
@@ -242,15 +240,11 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_i2c_readfrom_into_obj, 1, bitbangio_i2c_rea
 STATIC void writeto(bitbangio_i2c_obj_t *self, mp_int_t address, mp_obj_t buffer, int32_t start, mp_int_t end, bool stop) {
     // get the buffer to write the data from
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(buffer, &bufinfo, MP_BUFFER_READ);
-
-    size_t length = bufinfo.len;
-    normalize_buffer_bounds(&start, end, &length);
+    get_normalized_buffer_raise(buffer, &bufinfo, MP_BUFFER_READ, start, end);
 
     // do the transfer
     uint8_t status = shared_module_bitbangio_i2c_write(self, address,
-        ((uint8_t *)bufinfo.buf) + start, length,
-        stop);
+        bufinfo.buf, bufinfo.len, stop);
     if (status != 0) {
         mp_raise_OSError(status);
     }

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -194,15 +194,12 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_i2c_unlock_obj, busio_i2c_obj_unlock);
 // Shared arg parsing for readfrom_into and writeto_then_readfrom.
 STATIC void readfrom(busio_i2c_obj_t *self, mp_int_t address, mp_obj_t buffer, int32_t start, mp_int_t end) {
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(buffer, &bufinfo, MP_BUFFER_WRITE);
-
-    size_t length = bufinfo.len;
-    normalize_buffer_bounds(&start, end, &length);
-    if (length == 0) {
+    get_normalized_buffer_raise(buffer, &bufinfo, MP_BUFFER_WRITE, start, end);
+    if (bufinfo.len == 0) {
         mp_raise_ValueError(translate("Buffer must be at least length 1"));
     }
 
-    uint8_t status = common_hal_busio_i2c_read(self, address, ((uint8_t *)bufinfo.buf) + start, length);
+    uint8_t status = common_hal_busio_i2c_read(self, address, bufinfo.buf, bufinfo.len);
     if (status != 0) {
         mp_raise_OSError(status);
     }
@@ -251,14 +248,10 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_i2c_readfrom_into_obj, 1, busio_i2c_readfrom_in
 STATIC void writeto(busio_i2c_obj_t *self, mp_int_t address, mp_obj_t buffer, int32_t start, mp_int_t end, bool stop) {
     // get the buffer to write the data from
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(buffer, &bufinfo, MP_BUFFER_READ);
-
-    size_t length = bufinfo.len;
-    normalize_buffer_bounds(&start, end, &length);
+    get_normalized_buffer_raise(buffer, &bufinfo, MP_BUFFER_READ, start, end);
 
     // do the transfer
-    uint8_t status = common_hal_busio_i2c_write(self, address, ((uint8_t *)bufinfo.buf) + start,
-        length, stop);
+    uint8_t status = common_hal_busio_i2c_write(self, address, bufinfo.buf, bufinfo.len, stop);
     if (status != 0) {
         mp_raise_OSError(status);
     }

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -267,16 +267,13 @@ STATIC mp_obj_t busio_spi_write(size_t n_args, const mp_obj_t *pos_args, mp_map_
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_READ);
-    int32_t start = args[ARG_start].u_int;
-    size_t length = bufinfo.len;
-    normalize_buffer_bounds(&start, args[ARG_end].u_int, &length);
+    get_normalized_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_READ, args[ARG_start].u_int, args[ARG_end].u_int);
 
-    if (length == 0) {
+    if (bufinfo.len == 0) {
         return mp_const_none;
     }
 
-    bool ok = common_hal_busio_spi_write(self, ((uint8_t *)bufinfo.buf) + start, length);
+    bool ok = common_hal_busio_spi_write(self, bufinfo.buf, bufinfo.len);
     if (!ok) {
         mp_raise_OSError(MP_EIO);
     }
@@ -318,16 +315,13 @@ STATIC mp_obj_t busio_spi_readinto(size_t n_args, const mp_obj_t *pos_args, mp_m
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_WRITE);
-    int32_t start = args[ARG_start].u_int;
-    size_t length = bufinfo.len;
-    normalize_buffer_bounds(&start, args[ARG_end].u_int, &length);
+    get_normalized_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_WRITE, args[ARG_start].u_int, args[ARG_end].u_int);
 
-    if (length == 0) {
+    if (bufinfo.len == 0) {
         return mp_const_none;
     }
 
-    bool ok = common_hal_busio_spi_read(self, ((uint8_t *)bufinfo.buf) + start, length, args[ARG_write_value].u_int);
+    bool ok = common_hal_busio_spi_read(self, bufinfo.buf, bufinfo.len, args[ARG_write_value].u_int);
     if (!ok) {
         mp_raise_OSError(MP_EIO);
     }
@@ -379,29 +373,23 @@ STATIC mp_obj_t busio_spi_write_readinto(size_t n_args, const mp_obj_t *pos_args
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_buffer_info_t buf_out_info;
-    mp_get_buffer_raise(args[ARG_out_buffer].u_obj, &buf_out_info, MP_BUFFER_READ);
-    int32_t out_start = args[ARG_out_start].u_int;
-    size_t out_length = buf_out_info.len;
-    normalize_buffer_bounds(&out_start, args[ARG_out_end].u_int, &out_length);
+    get_normalized_buffer_raise(args[ARG_out_buffer].u_obj, &buf_out_info, MP_BUFFER_READ, args[ARG_out_start].u_int, args[ARG_out_end].u_int);
 
     mp_buffer_info_t buf_in_info;
-    mp_get_buffer_raise(args[ARG_in_buffer].u_obj, &buf_in_info, MP_BUFFER_WRITE);
-    int32_t in_start = args[ARG_in_start].u_int;
-    size_t in_length = buf_in_info.len;
-    normalize_buffer_bounds(&in_start, args[ARG_in_end].u_int, &in_length);
+    get_normalized_buffer_raise(args[ARG_in_buffer].u_obj, &buf_in_info, MP_BUFFER_WRITE, args[ARG_in_start].u_int, args[ARG_in_end].u_int);
 
-    if (out_length != in_length) {
+    if (buf_out_info.len != buf_in_info.len) {
         mp_raise_ValueError(translate("buffer slices must be of equal length"));
     }
 
-    if (out_length == 0) {
+    if (buf_out_info.len == 0) {
         return mp_const_none;
     }
 
     bool ok = common_hal_busio_spi_transfer(self,
-        ((uint8_t *)buf_out_info.buf) + out_start,
-        ((uint8_t *)buf_in_info.buf) + in_start,
-        out_length);
+        buf_out_info.buf,
+        buf_in_info.buf,
+        buf_out_info.len);
     if (!ok) {
         mp_raise_OSError(MP_EIO);
     }

--- a/shared/runtime/buffer_helper.h
+++ b/shared/runtime/buffer_helper.h
@@ -29,7 +29,8 @@
 
 #include <stdint.h>
 #include <string.h>
+#include "py/obj.h"
 
-void normalize_buffer_bounds(int32_t *start, int32_t end, size_t *length);
+void get_normalized_buffer_raise(mp_obj_t obj, mp_buffer_info_t *bufinfo, mp_uint_t flags, int32_t start, int32_t end);
 
 #endif  // MICROPY_INCLUDED_LIB_UTILS_BUFFER_HELPER_H


### PR DESCRIPTION
This simplifies the pair of calls mp_get_buffer_raise + normalize_buffer_bounds into a single call. It also lays the groundwork for the element size to be used in normalization, so that e.g., if you work with an array of 16-bit values, `write(buf, start=3, end=9)`
will work in 2 byte chunks, just like `write(buf[3:9])`.

However, the latter part of the change is not enabled yet, it's just that the place it would need to be done is centralized by this change.

This change also saves 104 bytes on trinket m0, which is nice.

As of the time the PR was opened, it's only tested to compile (for feather rp2040 and trinket m0), I didn't run it.