### PR TITLE
vectorio contains(x, y)

### DIFF
--- a/shared-bindings/vectorio/Circle.c
+++ b/shared-bindings/vectorio/Circle.c
@@ -97,6 +97,8 @@ const mp_obj_property_t vectorio_circle_radius_obj = {
 //|
 
 STATIC const mp_rom_map_elem_t vectorio_circle_locals_dict_table[] = {
+    // Functions
+    { MP_ROM_QSTR(MP_QSTR_contains), MP_ROM_PTR(&vectorio_vector_shape_contains_obj) },
     // Properties
     { MP_ROM_QSTR(MP_QSTR_radius), MP_ROM_PTR(&vectorio_circle_radius_obj) },
     { MP_ROM_QSTR(MP_QSTR_x), MP_ROM_PTR(&vectorio_vector_shape_x_obj) },

--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -103,6 +103,8 @@ const mp_obj_property_t vectorio_polygon_points_obj = {
 //|
 
 STATIC const mp_rom_map_elem_t vectorio_polygon_locals_dict_table[] = {
+    // Functions
+    { MP_ROM_QSTR(MP_QSTR_contains), MP_ROM_PTR(&vectorio_vector_shape_contains_obj) },
     // Properties
     { MP_ROM_QSTR(MP_QSTR_points), MP_ROM_PTR(&vectorio_polygon_points_obj) },
     { MP_ROM_QSTR(MP_QSTR_x), MP_ROM_PTR(&vectorio_vector_shape_x_obj) },

--- a/shared-bindings/vectorio/Rectangle.c
+++ b/shared-bindings/vectorio/Rectangle.c
@@ -122,6 +122,8 @@ const mp_obj_property_t vectorio_rectangle_height_obj = {
 //|
 
 STATIC const mp_rom_map_elem_t vectorio_rectangle_locals_dict_table[] = {
+    // Functions
+    { MP_ROM_QSTR(MP_QSTR_contains), MP_ROM_PTR(&vectorio_vector_shape_contains_obj) },
     // Properties
     { MP_ROM_QSTR(MP_QSTR_x), MP_ROM_PTR(&vectorio_vector_shape_x_obj) },
     { MP_ROM_QSTR(MP_QSTR_y), MP_ROM_PTR(&vectorio_vector_shape_y_obj) },

--- a/shared-bindings/vectorio/VectorShape.c
+++ b/shared-bindings/vectorio/VectorShape.c
@@ -80,6 +80,21 @@ vectorio_draw_protocol_impl_t vectorio_vector_shape_draw_protocol_impl = {
     .draw_get_refresh_areas = (draw_get_refresh_areas_fun)vectorio_vector_shape_get_refresh_areas,
 };
 
+// Stub checker does not approve of these shared properties.
+//     x: int
+//     y: int
+//     """true if x,y lies inside the shape."""
+//
+STATIC mp_obj_t vectorio_vector_shape_obj_contains(mp_obj_t wrapper_shape, mp_obj_t x_obj, mp_obj_t y_obj) {
+    // Relies on the fact that only vector_shape impl gets matched with a VectorShape.
+    const vectorio_draw_protocol_t *draw_protocol = mp_proto_get(MP_QSTR_protocol_draw, wrapper_shape);
+    vectorio_vector_shape_t *self = MP_OBJ_TO_PTR(draw_protocol->draw_get_protocol_self(wrapper_shape));
+
+    mp_int_t x = mp_obj_get_int(x_obj);
+    mp_int_t y = mp_obj_get_int(y_obj);
+    return mp_obj_new_bool(common_hal_vectorio_vector_shape_contains(self, x, y));
+}
+MP_DEFINE_CONST_FUN_OBJ_3(vectorio_vector_shape_contains_obj, vectorio_vector_shape_obj_contains);
 
 // Stub checker does not approve of these shared properties.
 //     x: int

--- a/shared-bindings/vectorio/VectorShape.h
+++ b/shared-bindings/vectorio/VectorShape.h
@@ -18,6 +18,8 @@ void common_hal_vectorio_vector_shape_construct(vectorio_vector_shape_t *self,
     vectorio_ishape_t ishape,
     mp_obj_t pixel_shader, int32_t x, int32_t y);
 
+bool common_hal_vectorio_vector_shape_contains(vectorio_vector_shape_t *self, mp_int_t x, mp_int_t y);
+
 void common_hal_vectorio_vector_shape_set_dirty(void *self);
 
 mp_int_t common_hal_vectorio_vector_shape_get_x(vectorio_vector_shape_t *self);
@@ -40,5 +42,6 @@ extern const mp_obj_property_t vectorio_vector_shape_x_obj;
 extern const mp_obj_property_t vectorio_vector_shape_y_obj;
 extern const mp_obj_property_t vectorio_vector_shape_location_obj;
 extern const mp_obj_property_t vectorio_vector_shape_pixel_shader_obj;
+extern const mp_obj_fun_builtin_fixed_t vectorio_vector_shape_contains_obj;
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_VECTORIO_SHAPE_H


### PR DESCRIPTION
new utility function for all vectorio shape specializations for testing
whether a screen-space x,y point falls within a shape's x,y.

This respects the current orientation of the screen in the manner of
displayio and vectorio - so your x,y requests are in the same coordinate
domain as your x,y locations and your width/height etc. properties that
ou set on other shapes. I.e., if you're using this for touch points then
you will need to make sure the touch events are in the same x,y domain as
your display.
```
contains(2, 4) -> true
------------------
|                |
|                |
| --             |
| | \            |
| |. \           |
| |   \          |
| |____\         |
|                |
------------------

contains(5, 4) -> false
------------------
|                |
|                |
| --             |
| | \            |
| |  \.          |
| |   \          |
| |____\         |
|                |
------------------
```

This helps provide low overhead introspection of shape coverage on screen.
It's envisioned that this will be used for things like touch-and-drag
widget controls, touch "areas" and may help with random ornament placement
on toy Christmas trees.

I am out of state for a few more days and do not have a microcontroller with me - and I can't seem to make displayio compile into the unix port or I'd give this a try myself. It compiles but not 100% sure about it - I'll be able to try in a few days! Feel free to review & see if anything stands out as problematic.

@FoamyGuy merry Christmas and I hope your next tree can have a little more random cheer 🍻 