### PR TITLE
go into safe mode with a useful message if no CIRCUITPY

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -659,6 +659,10 @@ msgstr ""
 msgid "CBC blocks must be multiples of 16 bytes"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "CIRCUITPY drive could not be found or created."
+msgstr ""
+
 #: ports/espressif/bindings/espidf/__init__.c ports/espressif/esp_error.c
 msgid "CRC or checksum was invalid"
 msgstr ""

--- a/main.c
+++ b/main.c
@@ -813,7 +813,7 @@ int __attribute__((used)) main(void) {
     // no SPI flash filesystem, and we might erase the existing one.
 
     // Check whether CIRCUITPY is available. Don't check if it already hasn't been found.
-    if (safe_mode != NO_CIRCUITPY && !filesystem_init(safe_mode == NO_SAFE_MODE, false)) {
+    if ((safe_mode != NO_CIRCUITPY) && !filesystem_init(safe_mode == NO_SAFE_MODE, false)) {
         reset_into_safe_mode(NO_CIRCUITPY);
     }
 

--- a/main.c
+++ b/main.c
@@ -811,7 +811,11 @@ int __attribute__((used)) main(void) {
     // Create a new filesystem only if we're not in a safe mode.
     // A power brownout here could make it appear as if there's
     // no SPI flash filesystem, and we might erase the existing one.
-    filesystem_init(safe_mode == NO_SAFE_MODE, false);
+
+    // Check whether CIRCUITPY is available. Don't check if it already hasn't been found.
+    if (safe_mode != NO_CIRCUITPY && !filesystem_init(safe_mode == NO_SAFE_MODE, false)) {
+        reset_into_safe_mode(NO_CIRCUITPY);
+    }
 
     // displays init after filesystem, since they could share the flash SPI
     board_init();

--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -271,7 +271,7 @@ void common_hal_storage_erase_filesystem(void) {
     usb_disconnect();
     #endif
     mp_hal_delay_ms(1000);
-    filesystem_init(false, true); // Force a re-format.
+    (void)filesystem_init(false, true);  // Force a re-format. Ignore failure.
     common_hal_mcu_reset();
     // We won't actually get here, since we're resetting.
 }

--- a/supervisor/filesystem.h
+++ b/supervisor/filesystem.h
@@ -35,7 +35,7 @@ extern volatile bool filesystem_flush_requested;
 
 void filesystem_background(void);
 void filesystem_tick(void);
-void filesystem_init(bool create_allowed, bool force_create);
+bool filesystem_init(bool create_allowed, bool force_create);
 void filesystem_flush(void);
 bool filesystem_present(void);
 void filesystem_set_internal_writable_by_usb(bool usb_writable);

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -175,6 +175,8 @@ void print_safe_mode_message(safe_mode_t reason) {
         case WATCHDOG_RESET:
             message = translate("Watchdog timer expired.");
             break;
+        case NO_CIRCUITPY:
+            message = translate("CIRCUITPY drive could not be found or created.");
         default:
             break;
     }

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -177,6 +177,7 @@ void print_safe_mode_message(safe_mode_t reason) {
             break;
         case NO_CIRCUITPY:
             message = translate("CIRCUITPY drive could not be found or created.");
+            break;
         default:
             break;
     }

--- a/supervisor/shared/safe_mode.h
+++ b/supervisor/shared/safe_mode.h
@@ -48,6 +48,7 @@ typedef enum {
     USB_TOO_MANY_INTERFACE_NAMES,
     USB_BOOT_DEVICE_NOT_INTERFACE_ZERO,
     NO_HEAP,
+    NO_CIRCUITPY,
 } safe_mode_t;
 
 safe_mode_t wait_for_safe_mode_reset(void);

--- a/supervisor/stub/filesystem.c
+++ b/supervisor/stub/filesystem.c
@@ -26,9 +26,10 @@
 
 #include "supervisor/filesystem.h"
 
-void filesystem_init(bool create_allowed, bool force_create) {
+bool filesystem_init(bool create_allowed, bool force_create) {
     (void)create_allowed;
     (void)force_create;
+    return true;
 }
 
 void filesystem_flush(void) {


### PR DESCRIPTION
Check whether CIRCUITPY was mounted or created on startup. If CIRCUITPY was not available, go into safe mode with a useful error message.

Motivation: a few people have had bad external flash chips. There is no indication they are bad, except that there is nothing in CIRCUITPY.

Tested on a CPB I got from a customer that had a bad flash chip, and on a good CPB as well.