### PR TITLE
Allow to tailor tinyusb configuration for port specific needs

### DIFF
--- a/py/circuitpy_mpconfig.mk
+++ b/py/circuitpy_mpconfig.mk
@@ -463,6 +463,13 @@ CFLAGS += -DCIRCUITPY_WATCHDOG=$(CIRCUITPY_WATCHDOG)
 CIRCUITPY_WIFI ?= 0
 CFLAGS += -DCIRCUITPY_WIFI=$(CIRCUITPY_WIFI)
 
+# tinyusb port tailored configuration
+CIRCUITPY_TUSB_MEM_ALIGN ?= 4
+CFLAGS += -DCIRCUITPY_TUSB_MEM_ALIGN=$(CIRCUITPY_TUSB_MEM_ALIGN)
+
+CIRCUITPY_TUSB_ATTR_USBRAM ?= ".bss.usbram"
+CFLAGS += -DCIRCUITPY_TUSB_ATTR_USBRAM=$(CIRCUITPY_TUSB_ATTR_USBRAM)
+
 # Define an equivalent for MICROPY_LONGINT_IMPL, to pass to $(MPY-TOOL) in py/mkrules.mk
 # $(MPY-TOOL) needs to know what kind of longint to use (if any) to freeze long integers.
 # This should correspond to the MICROPY_LONGINT_IMPL definition in mpconfigport.h.

--- a/supervisor/shared/usb/tusb_config.h
+++ b/supervisor/shared/usb/tusb_config.h
@@ -96,8 +96,18 @@ extern "C" {
 // --------------------------------------------------------------------+
 // USB RAM PLACEMENT
 // --------------------------------------------------------------------+
-#define CFG_TUSB_ATTR_USBRAM
-#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
+#if !defined(CIRCUITPY_TUSB_ATTR_USBRAM)
+#define CIRCUITPY_TUSB_ATTR_USBRAM        ".bss.usbram"
+#endif
+
+#define CFG_TUSB_ATTR_USBRAM        __attribute__((section(CIRCUITPY_TUSB_ATTR_USBRAM)))
+
+
+#if !defined(CIRCUITPY_TUSB_MEM_ALIGN)
+#define CIRCUITPY_TUSB_MEM_ALIGN 4
+#endif
+
+#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(CIRCUITPY_TUSB_MEM_ALIGN)))
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Some MCUs have specific requirements to USB buffer location and alignment. For example USB core ip3511 found in NXP LPC55S28, LPC55S69.