### PR TITLE
ports/atmel-samd/boards/bdmicro_vina_d51/pins.c: Add LED_AUX pin.

### DIFF
--- a/ports/atmel-samd/boards/bdmicro_vina_d51/pins.c
+++ b/ports/atmel-samd/boards/bdmicro_vina_d51/pins.c
@@ -85,6 +85,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_PA12) },
     { MP_ROM_QSTR(MP_QSTR_I2C1_SDA), MP_ROM_PTR(&pin_PA13) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_PA13) },
+    { MP_ROM_QSTR(MP_QSTR_LED_AUX), MP_ROM_PTR(&pin_PC26) },
     { MP_ROM_QSTR(MP_QSTR_LED_B), MP_ROM_PTR(&pin_PA23) },
     { MP_ROM_QSTR(MP_QSTR_LED_STATUS), MP_ROM_PTR(&pin_PA23) },
     { MP_ROM_QSTR(MP_QSTR_LED_G), MP_ROM_PTR(&pin_PB15) },


### PR DESCRIPTION
This just adds a new QSTR name for an LED added to the latest board revision. No other changes, and updates only the bdmicro_vina_d51 board pins.c definitions. Built and tested using the latest from main:

boot_out.txt:
Adafruit CircuitPython 7.2.0-alpha.1-40-g1fb4f02de-dirty on 2022-01-06; BDMICRO VINA-D51 with samd51n20
Board ID:bdmicro_vina_d51
