### PR TITLE
Added missing LDO control pin (SARA_PWR)

### DIFF
--- a/ports/raspberrypi/boards/challenger_rp2040_lte/pins.c
+++ b/ports/raspberrypi/boards/challenger_rp2040_lte/pins.c
@@ -24,6 +24,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_GP6), MP_ROM_PTR(&pin_GPIO6) },
     { MP_ROM_QSTR(MP_QSTR_SARA_RTS), MP_ROM_PTR(&pin_GPIO7) },
     { MP_ROM_QSTR(MP_QSTR_GP7), MP_ROM_PTR(&pin_GPIO7) },
+    { MP_ROM_QSTR(MP_QSTR_SARA_PWR), MP_ROM_PTR(&pin_GPIO15) },
+    { MP_ROM_QSTR(MP_QSTR_GP15), MP_ROM_PTR(&pin_GPIO15) },
 
     // GPIO
     { MP_ROM_QSTR(MP_QSTR_D9), MP_ROM_PTR(&pin_GPIO12) },


### PR DESCRIPTION
This PR adds the missing LDO control pin (SARA_PWR) to the pin list.