### PR TITLE
Provide filesystem stubs to fit in with changes from 41d494df0b35bb845a9

### DIFF
--- a/supervisor/stub/filesystem.c
+++ b/supervisor/stub/filesystem.c
@@ -26,6 +26,11 @@
 
 #include "supervisor/filesystem.h"
 
+
+void filesystem_background(void) {
+    return;
+}
+
 bool filesystem_init(bool create_allowed, bool force_create) {
     (void)create_allowed;
     (void)force_create;
@@ -35,9 +40,35 @@ bool filesystem_init(bool create_allowed, bool force_create) {
 void filesystem_flush(void) {
 }
 
+void filesystem_set_internal_writable_by_usb(bool writable) {
+    (void)writable;
+    return;
+}
+
+void filesystem_set_writable_by_usb(fs_user_mount_t *vfs, bool usb_writable) {
+    (void)vfs;
+    (void)usb_writable;
+    return;
+}
+
 bool filesystem_is_writable_by_python(fs_user_mount_t *vfs) {
     (void)vfs;
     return true;
+}
+
+bool filesystem_is_writable_by_usb(fs_user_mount_t *vfs) {
+    return true;
+}
+
+void filesystem_set_internal_concurrent_write_protection(bool concurrent_write_protection) {
+    (void)concurrent_write_protection;
+    return;
+}
+
+void filesystem_set_concurrent_write_protection(fs_user_mount_t *vfs, bool concurrent_write_protection) {
+    (void)vfs;
+    (void)concurrent_write_protection;
+    return;
 }
 
 bool filesystem_present(void) {

--- a/supervisor/supervisor.mk
+++ b/supervisor/supervisor.mk
@@ -5,7 +5,6 @@ SRC_SUPERVISOR = \
 	supervisor/shared/background_callback.c \
 	supervisor/shared/board.c \
 	supervisor/shared/cpu.c \
-	supervisor/shared/filesystem.c \
 	supervisor/shared/flash.c \
 	supervisor/shared/lock.c \
 	supervisor/shared/memory.c \
@@ -16,6 +15,12 @@ SRC_SUPERVISOR = \
 	supervisor/shared/tick.c \
 	supervisor/shared/traceback.c \
 	supervisor/shared/translate.c
+
+ifeq ($(DISABLE_FILESYSTEM),1)
+SRC_SUPERVISOR += supervisor/stub/filesystem.c
+else
+SRC_SUPERVISOR += supervisor/shared/filesystem.c
+endif
 
 NO_USB ?= $(wildcard supervisor/usb.c)
 


### PR DESCRIPTION
filesystem stub implementation is used when DISABLE_FILESYSTEM is set.