### PR TITLE
Fixes SAMD PDMIn

### DIFF
--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -386,7 +386,7 @@ void reset_port(void) {
     audioout_reset();
     #endif
     #if CIRCUITPY_AUDIOBUSIO
-    // pdmin_reset();
+    pdmin_reset();
     #endif
     #if CIRCUITPY_AUDIOBUSIO_I2SOUT
     i2sout_reset();


### PR DESCRIPTION
- Fixes #5797 (both on SAMx5x and SAMD21). Tested with a sound level program on CPX and with a simpler program on Metro M4.

SAMD PDMIn has not worked right for a while.

- The main problem was that the needed IRQ was never actually enabled.
- Made a flag variable `volatile`, as it should have been.
- Called to `pdmin_reset()` was commented out, maybe left over from some debugging.


I will probably backport this to 7.1.x, but there is maybe one other unrelated regression that should be checked for a 7.1.1 release first.