### PR TITLE
PDMIn fix for SAMD: backport of #5842

### DIFF
--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -386,7 +386,7 @@ void reset_port(void) {
     audioout_reset();
     #endif
     #if CIRCUITPY_AUDIOBUSIO
-    // pdmin_reset();
+    pdmin_reset();
     #endif
     #if CIRCUITPY_AUDIOBUSIO_I2SOUT
     i2sout_reset();


### PR DESCRIPTION
Backport of #5842 to 7.1.x.

This build tested on 7.1.x branch on CPX and Metro M4, both running a sound-level-meter program.

My plan is to release 7.1.1 that will include (only) this fix, because the microphone not working on CPX is a significant regression.