### PR TITLE
patch esp-idf for i2c crash

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -148,7 +148,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_RFM69.git
 [submodule "ports/espressif/esp-idf"]
 	path = ports/espressif/esp-idf
-	url = https://github.com/espressif/esp-idf.git
+	url = https://github.com/adafruit/esp-idf.git
 	branch = release/v4.4
 [submodule "ports/espressif/certificates/nina-fw"]
 	path = ports/espressif/certificates/nina-fw


### PR DESCRIPTION
In theory, this Closes: #5680 -- I didn't test it on HW yet.