### PR TITLE
fix espressif DigitalInOut open-drain

### DIFF
--- a/ports/espressif/common-hal/digitalio/DigitalInOut.c
+++ b/ports/espressif/common-hal/digitalio/DigitalInOut.c
@@ -108,11 +108,9 @@ digitalinout_result_t common_hal_digitalio_digitalinout_set_drive_mode(
     digitalio_digitalinout_obj_t *self,
     digitalio_drive_mode_t drive_mode) {
     gpio_num_t number = self->pin->number;
-    gpio_mode_t mode;
+    gpio_mode_t mode = GPIO_MODE_DEF_OUTPUT;
     if (drive_mode == DRIVE_MODE_OPEN_DRAIN) {
-        mode = GPIO_MODE_DEF_OD;
-    } else {
-        mode = GPIO_MODE_DEF_OUTPUT;
+        mode |= GPIO_MODE_DEF_OD;
     }
     esp_err_t result = gpio_set_direction(number, mode);
     if (result != ESP_OK) {

--- a/ports/espressif/common-hal/digitalio/DigitalInOut.c
+++ b/ports/espressif/common-hal/digitalio/DigitalInOut.c
@@ -71,7 +71,7 @@ void common_hal_digitalio_digitalinout_deinit(digitalio_digitalinout_obj_t *self
 void common_hal_digitalio_digitalinout_switch_to_input(
     digitalio_digitalinout_obj_t *self, digitalio_pull_t pull) {
     common_hal_digitalio_digitalinout_set_pull(self, pull);
-    gpio_set_direction(self->pin->number, GPIO_MODE_DEF_INPUT);
+    gpio_set_direction(self->pin->number, GPIO_MODE_INPUT);
 }
 
 digitalinout_result_t common_hal_digitalio_digitalinout_switch_to_output(
@@ -108,9 +108,9 @@ digitalinout_result_t common_hal_digitalio_digitalinout_set_drive_mode(
     digitalio_digitalinout_obj_t *self,
     digitalio_drive_mode_t drive_mode) {
     gpio_num_t number = self->pin->number;
-    gpio_mode_t mode = GPIO_MODE_DEF_OUTPUT;
+    gpio_mode_t mode = GPIO_MODE_OUTPUT;
     if (drive_mode == DRIVE_MODE_OPEN_DRAIN) {
-        mode |= GPIO_MODE_DEF_OD;
+        mode |= GPIO_MODE_OUTPUT_OD;
     }
     esp_err_t result = gpio_set_direction(number, mode);
     if (result != ESP_OK) {


### PR DESCRIPTION
- Fixes #3845.

Open-drain and output both need to be set. Discovered while researching #5865, which is not yet fixed.

Tested with a Saleae and a QT Py ESP32-S2.