### PR TITLE
Define default SPI pins on kb2040

### DIFF
--- a/ports/raspberrypi/boards/adafruit_kb2040/mpconfigboard.h
+++ b/ports/raspberrypi/boards/adafruit_kb2040/mpconfigboard.h
@@ -8,3 +8,7 @@
 
 #define DEFAULT_UART_BUS_TX (&pin_GPIO0)
 #define DEFAULT_UART_BUS_RX (&pin_GPIO1)
+
+#define DEFAULT_SPI_BUS_SCK (&pin_GPIO18)
+#define DEFAULT_SPI_BUS_MOSI (&pin_GPIO19)
+#define DEFAULT_SPI_BUS_MISO (&pin_GPIO20)


### PR DESCRIPTION
Fixes #5875 