### PR TITLE
Only make CIRCUITPY readonly with USB

### DIFF
--- a/main.c
+++ b/main.c
@@ -838,7 +838,7 @@ int __attribute__((used)) main(void) {
     // By default our internal flash is readonly to local python code and
     // writable over USB. Set it here so that boot.py can change it.
     filesystem_set_internal_concurrent_write_protection(true);
-    filesystem_set_internal_writable_by_usb(true);
+    filesystem_set_internal_writable_by_usb(CIRCUITPY_USB == 1);
 
     run_boot_py(safe_mode);
 


### PR DESCRIPTION
CIRCUITPY will be writable from CP on all non-USB boards now. This
includes micro:bit v2 and C3 boards. It should allow it to work
with serial file loading programs.

Fixes #5901