### PR TITLE
Fix esp32s3 devkitc uart naming and add board.UART

### DIFF
--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8/mpconfigboard.h
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8/mpconfigboard.h
@@ -29,10 +29,13 @@
 #define MICROPY_HW_BOARD_NAME       "ESP32-S3-DevKitC-1-N8"
 #define MICROPY_HW_MCU_NAME         "ESP32S3"
 
-#define MICROPY_HW_NEOPIXEL (&pin_GPIO48)
+#define MICROPY_HW_NEOPIXEL         (&pin_GPIO48)
 
-#define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
+#define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO0)
+
+#define DEFAULT_UART_BUS_RX         (&pin_GPIO44)
+#define DEFAULT_UART_BUS_TX         (&pin_GPIO43)
 
 #define BOARD_USER_SAFE_MODE_ACTION translate("pressing boot button at start up.\n")
 
-#define AUTORESET_DELAY_MS 500
+#define AUTORESET_DELAY_MS          500

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8/pins.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8/pins.c
@@ -33,13 +33,16 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IO41), MP_ROM_PTR(&pin_GPIO41) },
     { MP_ROM_QSTR(MP_QSTR_IO42), MP_ROM_PTR(&pin_GPIO42) },
     { MP_ROM_QSTR(MP_QSTR_IO43), MP_ROM_PTR(&pin_GPIO43) },
-    { MP_ROM_QSTR(MP_QSTR_TXD0), MP_ROM_PTR(&pin_GPIO43) },
     { MP_ROM_QSTR(MP_QSTR_IO44), MP_ROM_PTR(&pin_GPIO44) },
-    { MP_ROM_QSTR(MP_QSTR_TXD1), MP_ROM_PTR(&pin_GPIO44) },
     { MP_ROM_QSTR(MP_QSTR_IO45), MP_ROM_PTR(&pin_GPIO45) },
     { MP_ROM_QSTR(MP_QSTR_IO46), MP_ROM_PTR(&pin_GPIO46) },
     { MP_ROM_QSTR(MP_QSTR_IO47), MP_ROM_PTR(&pin_GPIO47) },
     { MP_ROM_QSTR(MP_QSTR_IO48), MP_ROM_PTR(&pin_GPIO48) },
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO48) },
+
+    { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO43) },
+    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO44) },
+
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r2/mpconfigboard.h
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r2/mpconfigboard.h
@@ -29,10 +29,13 @@
 #define MICROPY_HW_BOARD_NAME       "ESP32-S3-DevKitC-1-N8R2"
 #define MICROPY_HW_MCU_NAME         "ESP32S3"
 
-#define MICROPY_HW_NEOPIXEL (&pin_GPIO48)
+#define MICROPY_HW_NEOPIXEL         (&pin_GPIO48)
 
-#define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
+#define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO0)
+
+#define DEFAULT_UART_BUS_RX         (&pin_GPIO44)
+#define DEFAULT_UART_BUS_TX         (&pin_GPIO43)
 
 #define BOARD_USER_SAFE_MODE_ACTION translate("pressing boot button at start up.\n")
 
-#define AUTORESET_DELAY_MS 500
+#define AUTORESET_DELAY_MS          500

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r2/pins.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r2/pins.c
@@ -33,13 +33,16 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IO41), MP_ROM_PTR(&pin_GPIO41) },
     { MP_ROM_QSTR(MP_QSTR_IO42), MP_ROM_PTR(&pin_GPIO42) },
     { MP_ROM_QSTR(MP_QSTR_IO43), MP_ROM_PTR(&pin_GPIO43) },
-    { MP_ROM_QSTR(MP_QSTR_TXD0), MP_ROM_PTR(&pin_GPIO43) },
     { MP_ROM_QSTR(MP_QSTR_IO44), MP_ROM_PTR(&pin_GPIO44) },
-    { MP_ROM_QSTR(MP_QSTR_TXD1), MP_ROM_PTR(&pin_GPIO44) },
     { MP_ROM_QSTR(MP_QSTR_IO45), MP_ROM_PTR(&pin_GPIO45) },
     { MP_ROM_QSTR(MP_QSTR_IO46), MP_ROM_PTR(&pin_GPIO46) },
     { MP_ROM_QSTR(MP_QSTR_IO47), MP_ROM_PTR(&pin_GPIO47) },
     { MP_ROM_QSTR(MP_QSTR_IO48), MP_ROM_PTR(&pin_GPIO48) },
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO48) },
+
+    { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO43) },
+    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO44) },
+
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8/mpconfigboard.h
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8/mpconfigboard.h
@@ -29,10 +29,13 @@
 #define MICROPY_HW_BOARD_NAME       "ESP32-S3-DevKitC-1-N8R8"
 #define MICROPY_HW_MCU_NAME         "ESP32S3"
 
-#define MICROPY_HW_NEOPIXEL (&pin_GPIO48)
+#define MICROPY_HW_NEOPIXEL         (&pin_GPIO48)
 
-#define CIRCUITPY_BOOT_BUTTON (&pin_GPIO0)
+#define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO0)
+
+#define DEFAULT_UART_BUS_RX         (&pin_GPIO44)
+#define DEFAULT_UART_BUS_TX         (&pin_GPIO43)
 
 #define BOARD_USER_SAFE_MODE_ACTION translate("pressing boot button at start up.\n")
 
-#define AUTORESET_DELAY_MS 500
+#define AUTORESET_DELAY_MS          500

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8/pins.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8/pins.c
@@ -33,13 +33,16 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IO41), MP_ROM_PTR(&pin_GPIO41) },
     { MP_ROM_QSTR(MP_QSTR_IO42), MP_ROM_PTR(&pin_GPIO42) },
     { MP_ROM_QSTR(MP_QSTR_IO43), MP_ROM_PTR(&pin_GPIO43) },
-    { MP_ROM_QSTR(MP_QSTR_TXD0), MP_ROM_PTR(&pin_GPIO43) },
     { MP_ROM_QSTR(MP_QSTR_IO44), MP_ROM_PTR(&pin_GPIO44) },
-    { MP_ROM_QSTR(MP_QSTR_TXD1), MP_ROM_PTR(&pin_GPIO44) },
     { MP_ROM_QSTR(MP_QSTR_IO45), MP_ROM_PTR(&pin_GPIO45) },
     { MP_ROM_QSTR(MP_QSTR_IO46), MP_ROM_PTR(&pin_GPIO46) },
     { MP_ROM_QSTR(MP_QSTR_IO47), MP_ROM_PTR(&pin_GPIO47) },
     { MP_ROM_QSTR(MP_QSTR_IO48), MP_ROM_PTR(&pin_GPIO48) },
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO48) },
+
+    { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO43) },
+    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO44) },
+
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
The TX/RX pins were erroneously named TXD0/TXD1. I renamed them to TX/RX, also added board.UART.

Tested on n8r8 hardware