### PR TITLE
Fixes for pulsein on ESP32S3

### DIFF
--- a/ports/espressif/common-hal/neopixel_write/__init__.c
+++ b/ports/espressif/common-hal/neopixel_write/__init__.c
@@ -94,7 +94,7 @@ static void IRAM_ATTR ws2812_rmt_adapter(const void *src, rmt_item32_t *dest, si
 void common_hal_neopixel_write(const digitalio_digitalinout_obj_t *digitalinout, uint8_t *pixels, uint32_t numBytes) {
     // Reserve channel
     uint8_t number = digitalinout->pin->number;
-    rmt_channel_t channel = peripherals_find_and_reserve_rmt();
+    rmt_channel_t channel = peripherals_find_and_reserve_rmt(TRANSMIT_MODE);
     if (channel == RMT_CHANNEL_MAX) {
         mp_raise_RuntimeError(translate("All timers in use"));
     }

--- a/ports/espressif/common-hal/pulseio/PulseIn.c
+++ b/ports/espressif/common-hal/pulseio/PulseIn.c
@@ -107,7 +107,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
     }
 
     // Find a free RMT Channel and configure it
-    rmt_channel_t channel = peripherals_find_and_reserve_rmt();
+    rmt_channel_t channel = peripherals_find_and_reserve_rmt(RECEIVE_MODE);
     if (channel == RMT_CHANNEL_MAX) {
         mp_raise_RuntimeError(translate("All timers in use"));
     }

--- a/ports/espressif/common-hal/pulseio/PulseOut.c
+++ b/ports/espressif/common-hal/pulseio/PulseOut.c
@@ -37,7 +37,7 @@ void common_hal_pulseio_pulseout_construct(pulseio_pulseout_obj_t *self,
     uint32_t frequency,
     uint16_t duty_cycle) {
 
-    rmt_channel_t channel = peripherals_find_and_reserve_rmt();
+    rmt_channel_t channel = peripherals_find_and_reserve_rmt(TRANSMIT_MODE);
     if (channel == RMT_CHANNEL_MAX) {
         mp_raise_RuntimeError(translate("All timers in use"));
     }

--- a/ports/espressif/peripherals/rmt.c
+++ b/ports/espressif/peripherals/rmt.c
@@ -37,8 +37,17 @@ void peripherals_rmt_reset(void) {
     }
 }
 
-rmt_channel_t peripherals_find_and_reserve_rmt(void) {
-    for (size_t i = 0; i < RMT_CHANNEL_MAX; i++) {
+rmt_channel_t peripherals_find_and_reserve_rmt(bool mode) {
+    size_t start_channel = 0;
+    size_t end_channel = RMT_CHANNEL_MAX;
+    #if SOC_RMT_CHANNELS_PER_GROUP > 4
+    if (mode == RECEIVE_MODE) {
+        start_channel = 4;
+    } else {
+        end_channel = 4;
+    }
+    #endif
+    for (size_t i = start_channel; i < end_channel; i++) {
         if (!rmt_reserved_channels[i]) {
             rmt_reserved_channels[i] = true;
             return i;

--- a/ports/espressif/peripherals/rmt.h
+++ b/ports/espressif/peripherals/rmt.h
@@ -30,9 +30,11 @@
 #include "py/mphal.h"
 #include "components/driver/include/driver/rmt.h"
 #include <stdint.h>
+#define TRANSMIT_MODE true
+#define RECEIVE_MODE false
 
 void peripherals_rmt_reset(void);
-rmt_channel_t peripherals_find_and_reserve_rmt(void);
+rmt_channel_t peripherals_find_and_reserve_rmt(bool mode);
 void peripherals_free_rmt(rmt_channel_t chan);
 
 #endif // MICROPY_INCLUDED_ESPRESSIF_PERIPHERALS_RMT_H


### PR DESCRIPTION
Issue #5909. Corrected which RMT channels are used for receiving pulses on Espressif boards with separate transmit and receive channels. Tested that pulseout and neopixels on ESP32-S3 still worked properly, and that ESP32-S2 boards still worked properly.