### PR TITLE
Update I2SOut.c

### DIFF
--- a/shared-bindings/audiobusio/I2SOut.c
+++ b/shared-bindings/audiobusio/I2SOut.c
@@ -72,7 +72,6 @@
 //|         Playing a wave file from flash::
 //|
 //|           import board
-//|           import audioio
 //|           import audiocore
 //|           import audiobusio
 //|           import digitalio


### PR DESCRIPTION
Redundant import of audioio in example.
Confused MagTag user. MagTag does not come with audioio in uf2 and cannot play native WAV with buzzer hardware.