### PR TITLE
Fixed common_hal_busio_uart_deinited incorrect pin assignment check.

### DIFF
--- a/ports/stm/common-hal/busio/SPI.c
+++ b/ports/stm/common-hal/busio/SPI.c
@@ -250,7 +250,7 @@ void common_hal_busio_spi_never_reset(busio_spi_obj_t *self) {
 }
 
 bool common_hal_busio_spi_deinited(busio_spi_obj_t *self) {
-    return self->sck->pin == NULL;
+    return self->sck == NULL;
 }
 
 void common_hal_busio_spi_deinit(busio_spi_obj_t *self) {

--- a/ports/stm/common-hal/busio/UART.c
+++ b/ports/stm/common-hal/busio/UART.c
@@ -259,7 +259,7 @@ void common_hal_busio_uart_never_reset(busio_uart_obj_t *self) {
 }
 
 bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {
-    return self->tx->pin == NULL && self->rx->pin == NULL;
+    return self->tx == NULL && self->rx == NULL;
 }
 
 void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {


### PR DESCRIPTION
The pin must be tested instead of pin->number in the same way as in STM
I2C busio layer.

```
 pytest -s -v test_busio.py --port=/dev/ttyACM2 --html-report=./report/stm32_f4ve.html
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.1, pytest-6.2.4, py-1.11.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /work/external/repos/circuitpython/tests/circuitpython-r
[report-stm32_f4ve.zip](https://github.com/adafruit/circuitpython/files/7964098/report-stm32_f4ve.zip)
egression
plugins: html-reporter-0.2.6
collected 6 items                                                                                                                                                                                                                            

test_busio.py::Test_SPI::test_SPI PASSED
test_busio.py::Test_SPI::test_configure PASSED
test_busio.py::Test_SPI::test_frequency PASSED
test_busio.py::Test_SPI::test_try_lock PASSED
test_busio.py::Test_SPI::test_unlock PASSED
test_busio.py::Test_SPI::test_write PASSED

============================================================================================================= 6 passed in 3.78s ==============================================================================================================

```