### PR TITLE
Expose display’s root_group, add function to resize REPL terminal

### DIFF
--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -444,7 +444,7 @@ const mp_obj_property_t displayio_display_bus_obj = {
               MP_ROM_NONE},
 };
 
-//|     root_group: _Group
+//|     root_group: Group
 //|     """The root group on the display."""
 //|
 //|

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -444,6 +444,23 @@ const mp_obj_property_t displayio_display_bus_obj = {
               MP_ROM_NONE},
 };
 
+//|     root_group: _Group
+//|     """The root group on the display."""
+//|
+//|
+STATIC mp_obj_t displayio_display_obj_get_root_group(mp_obj_t self_in) {
+    displayio_display_obj_t *self = native_display(self_in);
+    return common_hal_displayio_display_get_root_group(self);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(displayio_display_get_root_group_obj, displayio_display_obj_get_root_group);
+
+const mp_obj_property_t displayio_display_root_group_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&displayio_display_get_root_group_obj,
+              MP_ROM_NONE,
+              MP_ROM_NONE},
+};
+
 
 //|     def fill_row(self, y: int, buffer: WriteableBuffer) -> WriteableBuffer:
 //|         """Extract the pixels from a single row
@@ -517,6 +534,7 @@ STATIC const mp_rom_map_elem_t displayio_display_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&displayio_display_height_obj) },
     { MP_ROM_QSTR(MP_QSTR_rotation), MP_ROM_PTR(&displayio_display_rotation_obj) },
     { MP_ROM_QSTR(MP_QSTR_bus), MP_ROM_PTR(&displayio_display_bus_obj) },
+    { MP_ROM_QSTR(MP_QSTR_root_group), MP_ROM_PTR(&displayio_display_root_group_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(displayio_display_locals_dict, displayio_display_locals_dict_table);
 

--- a/shared-bindings/displayio/Display.h
+++ b/shared-bindings/displayio/Display.h
@@ -69,6 +69,6 @@ mp_float_t common_hal_displayio_display_get_brightness(displayio_display_obj_t *
 bool common_hal_displayio_display_set_brightness(displayio_display_obj_t *self, mp_float_t brightness);
 
 mp_obj_t common_hal_displayio_display_get_bus(displayio_display_obj_t *self);
-
+mp_obj_t common_hal_displayio_display_get_root_group(displayio_display_obj_t *self);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_DISPLAYIO_DISPLAY_H

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -305,8 +305,12 @@ MP_DEFINE_CONST_FUN_OBJ_0(supervisor_disable_ble_workflow_obj, supervisor_disabl
 //|     ...
 //|
 STATIC mp_obj_t supervisor_reset_terminal(mp_obj_t x_pixels, mp_obj_t y_pixels) {
+    #if CIRCUITPY_DISPLAYIO
     supervisor_stop_terminal();
     supervisor_start_terminal(mp_obj_get_int(x_pixels), mp_obj_get_int(y_pixels));
+    #else
+    mp_raise_NotImplementedError(NULL);
+    #endif
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_2(supervisor_reset_terminal_obj, supervisor_reset_terminal);

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -33,6 +33,7 @@
 #include "shared/runtime/interrupt_char.h"
 #include "supervisor/shared/autoreload.h"
 #include "supervisor/shared/bluetooth/bluetooth.h"
+#include "supervisor/shared/display.h"
 #include "supervisor/shared/status_leds.h"
 #include "supervisor/shared/stack.h"
 #include "supervisor/shared/traceback.h"
@@ -299,6 +300,17 @@ STATIC mp_obj_t supervisor_disable_ble_workflow(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(supervisor_disable_ble_workflow_obj, supervisor_disable_ble_workflow);
 
+//| def reset_terminal(x_pixels: int, y_pixels: int) -> None:
+//|     """Adjust the pixel dimensions of the REPL console."""
+//|     ...
+//|
+STATIC mp_obj_t supervisor_reset_terminal(mp_obj_t x_pixels, mp_obj_t y_pixels) {
+    supervisor_stop_terminal();
+    supervisor_start_terminal(mp_obj_get_int(x_pixels), mp_obj_get_int(y_pixels));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(supervisor_reset_terminal_obj, supervisor_reset_terminal);
+
 STATIC const mp_rom_map_elem_t supervisor_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_supervisor) },
     { MP_ROM_QSTR(MP_QSTR_enable_autoreload),  MP_ROM_PTR(&supervisor_enable_autoreload_obj) },
@@ -312,6 +324,8 @@ STATIC const mp_rom_map_elem_t supervisor_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ticks_ms),  MP_ROM_PTR(&supervisor_ticks_ms_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_previous_traceback),  MP_ROM_PTR(&supervisor_get_previous_traceback_obj) },
     { MP_ROM_QSTR(MP_QSTR_disable_ble_workflow),  MP_ROM_PTR(&supervisor_disable_ble_workflow_obj) },
+    { MP_ROM_QSTR(MP_QSTR_splash),  MP_ROM_PTR(&circuitpython_splash) },
+    { MP_ROM_QSTR(MP_QSTR_reset_terminal),  MP_ROM_PTR(&supervisor_reset_terminal_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(supervisor_module_globals, supervisor_module_globals_table);

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -324,7 +324,6 @@ STATIC const mp_rom_map_elem_t supervisor_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ticks_ms),  MP_ROM_PTR(&supervisor_ticks_ms_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_previous_traceback),  MP_ROM_PTR(&supervisor_get_previous_traceback_obj) },
     { MP_ROM_QSTR(MP_QSTR_disable_ble_workflow),  MP_ROM_PTR(&supervisor_disable_ble_workflow_obj) },
-    { MP_ROM_QSTR(MP_QSTR_splash),  MP_ROM_PTR(&circuitpython_splash) },
     { MP_ROM_QSTR(MP_QSTR_reset_terminal),  MP_ROM_PTR(&supervisor_reset_terminal_obj) },
 };
 

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -301,7 +301,7 @@ STATIC mp_obj_t supervisor_disable_ble_workflow(void) {
 MP_DEFINE_CONST_FUN_OBJ_0(supervisor_disable_ble_workflow_obj, supervisor_disable_ble_workflow);
 
 //| def reset_terminal(x_pixels: int, y_pixels: int) -> None:
-//|     """Adjust the pixel dimensions of the REPL console."""
+//|     """Reset the CircuitPython serial terminal with new dimensions."""
 //|     ...
 //|
 STATIC mp_obj_t supervisor_reset_terminal(mp_obj_t x_pixels, mp_obj_t y_pixels) {

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -220,6 +220,10 @@ mp_obj_t common_hal_displayio_display_get_bus(displayio_display_obj_t *self) {
     return self->core.bus;
 }
 
+mp_obj_t common_hal_displayio_display_get_root_group(displayio_display_obj_t *self) {
+    return self->core.current_group;
+}
+
 STATIC const displayio_area_t *_get_refresh_areas(displayio_display_obj_t *self) {
     if (self->core.full_refresh) {
         self->core.area.next = NULL;

--- a/shared-module/displayio/display_core.c
+++ b/shared-module/displayio/display_core.c
@@ -163,12 +163,15 @@ void displayio_display_core_set_rotation(displayio_display_core_t *self,
 }
 
 bool displayio_display_core_show(displayio_display_core_t *self, displayio_group_t *root_group) {
-    if (root_group == NULL) {
-        if (!circuitpython_splash.in_group) {
-            root_group = &circuitpython_splash;
-        } else if (self->current_group == &circuitpython_splash) {
-            return true;
-        }
+
+    if (root_group == NULL) { // set the display to the REPL, reset REPL position and size
+        circuitpython_splash.in_group = false;
+        // force the circuit_python_splash out of any group (Note: could cause problems with the parent group)
+        circuitpython_splash.x = 0; // reset position in case someone moved it.
+        circuitpython_splash.y = 0;
+        supervisor_stop_terminal();
+        supervisor_start_terminal(self->width, self->height);
+        root_group = &circuitpython_splash;
     }
     if (root_group == self->current_group) {
         return true;

--- a/supervisor/shared/display.h
+++ b/supervisor/shared/display.h
@@ -32,7 +32,6 @@
 #if CIRCUITPY_TERMINALIO
 
 #include "shared-bindings/displayio/Bitmap.h"
-#include "shared-bindings/displayio/Group.h"
 #include "shared-bindings/displayio/TileGrid.h"
 #include "shared-bindings/fontio/BuiltinFont.h"
 #include "shared-bindings/terminalio/Terminal.h"
@@ -46,7 +45,6 @@ extern const fontio_builtinfont_t supervisor_terminal_font;
 extern displayio_bitmap_t supervisor_terminal_font_bitmap;
 extern displayio_tilegrid_t supervisor_terminal_text_grid;
 extern terminalio_terminal_obj_t supervisor_terminal;
-extern displayio_group_t circuitpython_splash;
 
 #endif
 

--- a/supervisor/shared/display.h
+++ b/supervisor/shared/display.h
@@ -32,6 +32,7 @@
 #if CIRCUITPY_TERMINALIO
 
 #include "shared-bindings/displayio/Bitmap.h"
+#include "shared-bindings/displayio/Group.h"
 #include "shared-bindings/displayio/TileGrid.h"
 #include "shared-bindings/fontio/BuiltinFont.h"
 #include "shared-bindings/terminalio/Terminal.h"
@@ -45,6 +46,7 @@ extern const fontio_builtinfont_t supervisor_terminal_font;
 extern displayio_bitmap_t supervisor_terminal_font_bitmap;
 extern displayio_tilegrid_t supervisor_terminal_text_grid;
 extern terminalio_terminal_obj_t supervisor_terminal;
+extern displayio_group_t circuitpython_splash;
 
 #endif
 


### PR DESCRIPTION
This exposes the REPL's display group elements as `supervisor.splash`.  Also, this adds a function to resize the dimensions of the REPL terminal window.  This allows the user to view the REPL and console `print()` output as well as view any display elements at the same time.

**Warning**: This is somewhat dangerous since exposing the REPL display elements allows the the REPL to be relocated where it is no longer visible.  

Here is an example creating a split screen with the REPL at the bottom of the display and displayio elements at the top of the screen.

https://user-images.githubusercontent.com/33587466/151874447-ea85c1cc-e0d5-43df-b2c7-e8fbaccb3a1f.MOV

``` python
import board
import displayio
import supervisor
import time


display=board.DISPLAY

# Create a bitmap with two colors
bitmap1 = displayio.Bitmap(display.width//4, display.height//4 - 10, 2)

# Create a two color palette
palette1 = displayio.Palette(2)
palette1[0] = 0xff00ff
palette1[1] = 0xffffff

# Create a TileGrid using the Bitmap and Palette
tile_grid1 = displayio.TileGrid(bitmap1, pixel_shader=palette1)


# Create a bitmap with two colors
bitmap2 = displayio.Bitmap(display.width//4, display.height//4 - 10, 2)

# Create a two color palette
palette2 = displayio.Palette(2)
palette2[0] = 0x00ffff
palette2[1] = 0xffffff

# Create a TileGrid using the Bitmap and Palette
tile_grid2 = displayio.TileGrid(bitmap2, pixel_shader=palette2)
tile_grid2.x=display.width//4

# Create a bitmap with two colors
bitmap3 = displayio.Bitmap(display.width//4, display.height//4 - 10, 2)

# Create a two color palette
palette3 = displayio.Palette(2)
palette3[0] = 0xffff00
palette3[1] = 0xffffff

# Create a TileGrid using the Bitmap and Palette
tile_grid3 = displayio.TileGrid(bitmap3, pixel_shader=palette3)
tile_grid3.x=2*display.width//4

# Create a Group
mygroup = displayio.Group()

print()
print()
print()
print("REPL control test: Taking control of REPL group")
time.sleep(3)

# Note: You must "display.show" your own group before adding the supervisor.splash to your own group.
# Reason: When displaying the normal REPL (for example with display.show(None), the supervisor.splash
# group is already in a group that is displayed.  To remove the supervisor.splash from the displayed group,
# you first have to display.show some other group, doing that will remove the supervisor.splash from its group
# and allow you to append it to your own group.

display.show(mygroup)
# add the supervisor.splash group to the displayed group.
mygroup.append(supervisor.splash)

# resize the supervisor.splash group pixel dimensions, make it half the display height.
supervisor.reset_terminal(display.width, display.height//2)

# relocate the supervisor.splash group on the display, moving it half-way down the display
supervisor.splash.y=display.height//2
print("Resize and move the splash screen")
time.sleep(2)

# demonstrate how print statements scroll on the REPL/console display
print("Add some prints to show terminal scrolling:")
time.sleep(0.3)
for i in range(6):
	print("Line: {}".format(i))
	time.sleep(0.3)
time.sleep(1.5)

# Add bitmap rectangles to the display group
print("Add some displayio bitmap rectangles:")
time.sleep(1)

# Add the TileGrid to the Group
print("Add a pink rect.")
mygroup.append(tile_grid1)
time.sleep(1)
print("Add a cyan rect.")
mygroup.append(tile_grid2)
time.sleep(1)
print("Add a yellow rect.")
mygroup.append(tile_grid3)
time.sleep(1)

# print some more lines to show the console text scrolling, with 
# the bitmaps still up on the upper half of the display
for i in range(6):
	print("Another line feed: {}!".format(i))
	time.sleep(0.3)
time.sleep(3)
print("Resetting the REPL and ending the code")
time.sleep(1)

# Before finishing this code, set the terminal size to the full display pixel dimensions
supervisor.reset_terminal(display.width, display.height)
```


