### PR TITLE
Add board.STEMMA_I2C on ESP QTPYs

### DIFF
--- a/ports/espressif/boards/adafruit_qtpy_esp32s2/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s2/mpconfigboard.h
@@ -38,17 +38,17 @@
 
 #define AUTORESET_DELAY_MS 500
 
-#define DEFAULT_I2C_BUS_SCL (&pin_GPIO6)
-#define DEFAULT_I2C_BUS_SDA (&pin_GPIO7)
+#define CIRCUITPY_BOARD_I2C         (2)
+#define CIRCUITPY_BOARD_I2C_PIN     {{.scl = &pin_GPIO6, .sda = &pin_GPIO7}, \
+                                     {.scl = &pin_GPIO40, .sda = &pin_GPIO41}}
 
-#define DEFAULT_SPI_BUS_SCK (&pin_GPIO36)
-#define DEFAULT_SPI_BUS_MOSI (&pin_GPIO35)
-#define DEFAULT_SPI_BUS_MISO (&pin_GPIO37)
+#define CIRCUITPY_BOARD_SPI         (1)
+#define CIRCUITPY_BOARD_SPI_PIN     {{.clock = &pin_GPIO36, .mosi = &pin_GPIO35, .miso = &pin_GPIO37}}
 
-#define DEFAULT_UART_BUS_RX (&pin_GPIO16)
-#define DEFAULT_UART_BUS_TX (&pin_GPIO5)
+#define CIRCUITPY_BOARD_UART        (1)
+#define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO5, .rx = &pin_GPIO16}}
 
 #define DOUBLE_TAP_PIN (&pin_GPIO10)
 
-#define DEBUG_UART_RX               DEFAULT_UART_BUS_RX
-#define DEBUG_UART_TX               DEFAULT_UART_BUS_TX
+#define DEBUG_UART_RX               (&pin_GPIO16)
+#define DEBUG_UART_TX               (&pin_GPIO5)

--- a/ports/espressif/boards/adafruit_qtpy_esp32s2/pins.c
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s2/pins.c
@@ -1,5 +1,7 @@
 #include "shared-bindings/board/__init__.h"
 
+CIRCUITPY_BOARD_BUS_SINGLETON(stemma_i2c, i2c, 1)
+
 STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
 
@@ -54,7 +56,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D41), MP_ROM_PTR(&pin_GPIO41) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_STEMMA_I2C), MP_ROM_PTR(&board_stemma_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
-    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) }
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/mpconfigboard.h
@@ -38,14 +38,14 @@
 
 #define AUTORESET_DELAY_MS 500
 
-#define DEFAULT_I2C_BUS_SCL (&pin_GPIO6)
-#define DEFAULT_I2C_BUS_SDA (&pin_GPIO7)
+#define CIRCUITPY_BOARD_I2C         (2)
+#define CIRCUITPY_BOARD_I2C_PIN     {{.scl = &pin_GPIO6, .sda = &pin_GPIO7}, \
+                                     {.scl = &pin_GPIO40, .sda = &pin_GPIO41}}
 
-#define DEFAULT_SPI_BUS_SCK (&pin_GPIO35)
-#define DEFAULT_SPI_BUS_MOSI (&pin_GPIO34)
-#define DEFAULT_SPI_BUS_MISO (&pin_GPIO36)
+#define CIRCUITPY_BOARD_SPI         (1)
+#define CIRCUITPY_BOARD_SPI_PIN     {{.clock = &pin_GPIO35, .mosi = &pin_GPIO34, .miso = &pin_GPIO36}}
 
-#define DEFAULT_UART_BUS_RX (&pin_GPIO16)
-#define DEFAULT_UART_BUS_TX (&pin_GPIO5)
+#define CIRCUITPY_BOARD_UART        (1)
+#define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO5, .rx = &pin_GPIO16}}
 
 #define DOUBLE_TAP_PIN (&pin_GPIO10)

--- a/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/pins.c
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/pins.c
@@ -1,5 +1,7 @@
 #include "shared-bindings/board/__init__.h"
 
+CIRCUITPY_BOARD_BUS_SINGLETON(stemma_i2c, i2c, 1)
+
 STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
 
@@ -53,7 +55,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D41), MP_ROM_PTR(&pin_GPIO41) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_STEMMA_I2C), MP_ROM_PTR(&board_stemma_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
-    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) }
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
Adds STEMMA_I2C on the other QTPY boards that have separate pins for the stemma QT connector.
Also changes the other busses to using the new format.
Part of #4638