### PR TITLE
bump pico-sdk to 1.3.0

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -187,7 +187,7 @@ SRC_SDK := \
 	src/rp2_common/pico_unique_id/unique_id.c \
 
 SRC_SDK := $(addprefix sdk/, $(SRC_SDK))
-$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK)): CFLAGS += -Wno-missing-prototypes
+$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK)): CFLAGS += -Wno-missing-prototypes -Wno-undef
 
 SRC_C += \
 	boards/$(BOARD)/board.c \

--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -44,8 +44,6 @@
 #include "src/rp2040/hardware_structs/include/hardware/structs/dma.h"
 #include "src/rp2_common/hardware_pwm/include/hardware/pwm.h"
 
-#define NUM_DMA_TIMERS 4
-
 // The PWM clock frequency is base_clock_rate / PWM_TOP, typically 125_000_000 / PWM_TOP.
 // We pick BITS_PER_SAMPLE so we get a clock frequency that is above what would cause aliasing.
 #define BITS_PER_SAMPLE 10


### PR DESCRIPTION
Only tested that CIRCUITPY comes up.