### PR TITLE
Correcting order of sideset parameters in function call

### DIFF
--- a/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+++ b/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
@@ -127,14 +127,14 @@ void common_hal_audiobusio_i2sout_construct(audiobusio_i2sout_obj_t *self,
         0, 0, // in pulls
         NULL, 0, 0, 0x1f, // set pins
         bit_clock, 2, 0, 0x1f, // sideset pins
+        false, // No sideset enable
         NULL, // jump pin
         0, // wait gpio pins
         true, // exclusive pin use
         false, 32, false, // shift out left to start with MSB
         false, // Wait for txstall
         false, 32, false, // in settings
-        false, // Not user-interruptible.
-        false); // No sideset enable
+        false); // Not user-interruptible.
 
     self->playing = false;
     audio_dma_init(&self->dma);

--- a/ports/raspberrypi/common-hal/audiobusio/PDMIn.c
+++ b/ports/raspberrypi/common-hal/audiobusio/PDMIn.c
@@ -71,14 +71,14 @@ void common_hal_audiobusio_pdmin_construct(audiobusio_pdmin_obj_t *self,
         0, 0, // in pulls
         NULL, 0, 0, 0x1f, // set pins
         clock_pin, 1, 0, 0x1f, // sideset pins
+        false, // No sideset enable
         NULL, // jump pin
         0, // wait gpio pins
         true, // exclusive pin use
         false, 32, false, // out settings
         false, // Wait for txstall
         false, 32, true, // in settings
-        false, // Not user-interruptible.
-        false); // No sideset enable
+        false); // Not user-interruptible.
 
     uint32_t actual_frequency = common_hal_rp2pio_statemachine_get_frequency(&self->state_machine);
     if (actual_frequency < MIN_MIC_CLOCK) {


### PR DESCRIPTION
Issue #5967 - PDMIn (and I2SOut) had the sideset enable parameter to common_hal_rp2pio_statemachine_construct() incorrectly positioned at the end of the parameter list. This would be where it goes if calling rp2pio_statemachine_construct(), but for common_hal_rp2pio_statemachine_construct() it needs to be just above the jmp_pin parameter. Tested the fix with a PDM mic using the script provided, and now correctly getting values.