### PR TITLE
RP2040: set initial SPI frequency

### DIFF
--- a/ports/raspberrypi/common-hal/busio/SPI.c
+++ b/ports/raspberrypi/common-hal/busio/SPI.c
@@ -90,7 +90,8 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         mp_raise_ValueError(translate("SPI peripheral in use"));
     }
 
-    spi_init(self->peripheral, 250000);
+    self->target_frequency = 250000;
+    self->real_frequency = spi_init(self->peripheral, self->target_frequency);
 
     gpio_set_function(clock->number, GPIO_FUNC_SPI);
     claim_pin(clock);


### PR DESCRIPTION
- Fixes #5836.

Tested on QT Py RP2040:
```py
>>> import busio,board
>>> spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
>>> print(spi.frequency)
250000
>>> spi.try_lock()
True
>>> spi.configure(baudrate=200000)
>>> print(spi.frequency)
244140
>>> spi.configure(baudrate=250000)
>>> print(spi.frequency)
250000
>>> spi.configure(baudrate=25000)
>>> print(spi.frequency)
27126
```
