### PR TITLE
WiFi Monitor: improve channel validation

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -156,6 +156,10 @@ msgstr ""
 msgid "%q out of bounds"
 msgstr ""
 
+#: shared-bindings/wifi/Monitor.c
+msgid "%d out of bounds"
+msgstr ""
+
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #: shared-bindings/canio/Match.c
 msgid "%q out of range"

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -156,10 +156,6 @@ msgstr ""
 msgid "%q out of bounds"
 msgstr ""
 
-#: shared-bindings/wifi/Monitor.c
-msgid "%d out of bounds"
-msgstr ""
-
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #: shared-bindings/canio/Match.c
 msgid "%q out of range"

--- a/shared-bindings/wifi/Monitor.c
+++ b/shared-bindings/wifi/Monitor.c
@@ -85,7 +85,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_monitor_get_channel_obj, wifi_monitor_obj_get_cha
 STATIC mp_obj_t wifi_monitor_obj_set_channel(mp_obj_t self_in, mp_obj_t channel) {
     mp_int_t c = mp_obj_get_int(channel);
     if (c < 1 || c > 13) {
-        mp_raise_ValueError_varg(translate("%d out of bounds"), c);
+        mp_raise_ValueError_varg(translate("%q out of bounds"), MP_QSTR_channel);
     }
     common_hal_wifi_monitor_set_channel(self_in, c);
     return mp_const_none;

--- a/shared-bindings/wifi/Monitor.c
+++ b/shared-bindings/wifi/Monitor.c
@@ -55,7 +55,7 @@ STATIC mp_obj_t wifi_monitor_make_new(const mp_obj_type_t *type, size_t n_args, 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    if (args[ARG_channel].u_int < 0 || args[ARG_channel].u_int > 13) {
+    if (args[ARG_channel].u_int < 1 || args[ARG_channel].u_int > 13) {
         mp_raise_ValueError_varg(translate("%q out of bounds"), MP_QSTR_channel);
     }
 
@@ -83,7 +83,11 @@ STATIC mp_obj_t wifi_monitor_obj_get_channel(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_monitor_get_channel_obj, wifi_monitor_obj_get_channel);
 
 STATIC mp_obj_t wifi_monitor_obj_set_channel(mp_obj_t self_in, mp_obj_t channel) {
-    common_hal_wifi_monitor_set_channel(self_in, mp_obj_get_int(channel));
+    mp_int_t c = mp_obj_get_int(channel);
+    if (c < 1 || c > 13) {
+        mp_raise_ValueError_varg(translate("%d out of bounds"), c);
+    }
+    common_hal_wifi_monitor_set_channel(self_in, c);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_2(wifi_monitor_set_channel_obj, wifi_monitor_obj_set_channel);


### PR DESCRIPTION
Test code:
```py
import wifi

# new check in monitor.channel
monitor = wifi.Monitor()
for channel in range(-1, 16):
    try:
        monitor.channel = channel
        print(monitor.channel, "channel OK")
    except ValueError as e:
        print(channel, e)

print()

# corrected check in wifi.Monitor(channel=)
for channel in range(-1, 16):
    try:
        monitor = wifi.Monitor(channel=channel)
        print(monitor.channel, "channel OK")
        monitor.deinit()
    except ValueError as e:
        print(channel, e)
```
Result (same for both loops):
```
code.py output:
-1 channel out of bounds
0 channel out of bounds
1 channel OK
2 channel OK
3 channel OK
4 channel OK
5 channel OK
6 channel OK
7 channel OK
8 channel OK
9 channel OK
10 channel OK
11 channel OK
12 channel OK
13 channel OK
14 channel out of bounds
15 channel out of bounds
```