### PR TITLE
fetch RTC count more atomically

### DIFF
--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -498,21 +498,31 @@ uint32_t port_get_saved_word(void) {
 static volatile uint64_t overflowed_ticks = 0;
 
 static uint32_t _get_count(uint64_t *overflow_count) {
-    #ifdef SAM_D5X_E5X
-    while ((RTC->MODE0.SYNCBUSY.reg & (RTC_MODE0_SYNCBUSY_COUNTSYNC | RTC_MODE0_SYNCBUSY_COUNT)) != 0) {
-    }
-    #endif
-    // SAMD21 does continuous sync so we don't need to wait here.
+    while(1) {
+        // Disable interrupts so we can grab the count and the overflow atomically.
+        common_hal_mcu_disable_interrupts();
 
-    // Disable interrupts so we can grab the count and the overflow.
-    common_hal_mcu_disable_interrupts();
-    uint32_t count = RTC->MODE0.COUNT.reg;
-    if (overflow_count != NULL) {
-        *overflow_count = overflowed_ticks;
-    }
-    common_hal_mcu_enable_interrupts();
+        #ifdef SAM_D5X_E5X
+        while ((RTC->MODE0.SYNCBUSY.reg & (RTC_MODE0_SYNCBUSY_COUNTSYNC | RTC_MODE0_SYNCBUSY_COUNT)) != 0) {
+        }
+        #endif
+        // SAMD21 does continuous sync so we don't need to wait here.
 
-    return count;
+        uint32_t count = RTC->MODE0.COUNT.reg;
+        if (overflow_count != NULL) {
+            *overflow_count = overflowed_ticks;
+        }
+
+        bool overflow_pending = RTC->MODE0.INTFLAG.bit.OVF;
+
+        common_hal_mcu_enable_interrupts();
+
+        if (!overflow_pending) {
+            return count;
+        }
+
+    // Try again if overflow hasn't been processed yet.
+    }
 }
 
 volatile bool _woken_up;


### PR DESCRIPTION
- Fixes #5985.

- Fetch RTC counter inside critical section.
- Handle case where counter has rolled over but overflow interrupt has not yet occurred.

Thanks to:
https://github.com/tinygo-org/tinygo/blob/release/src/runtime/runtime_atsamd51.go
https://github.com/tinygo-org/tinygo/pull/1870
https://www.eevblog.com/forum/microcontrollers/correct-timing-by-timer-overflow-count/