### PR TITLE
Fixes for native module support

### DIFF
--- a/py/dynruntime.h
+++ b/py/dynruntime.h
@@ -140,9 +140,7 @@ static inline mp_obj_t mp_obj_cast_to_native_base_dyn(mp_obj_t self_in, mp_const
 
     if (MP_OBJ_FROM_PTR(self_type) == native_type) {
         return self_in;
-    }
-    mp_parent_t parent = mp_type_get_parent_slot(self_type);
-    if (parent != native_type) {
+    } else if (self_type->parent != native_type) {
         // The self_in object is not a direct descendant of native_type, so fail the cast.
         // This is a very simple version of mp_obj_is_subclass_fast that could be improved.
         return MP_OBJ_NULL;
@@ -221,7 +219,7 @@ static inline mp_obj_t mp_obj_len_dyn(mp_obj_t o) {
 
 #define nlr_raise(o)                            (mp_raise_dyn(o))
 #define mp_raise_type_arg(type, arg)            (mp_raise_dyn(mp_obj_new_exception_arg1_dyn((type), (arg))))
-#define mp_raise_msg(type, msg)                 (mp_fun_table.raise_msg_str((type), (msg)))
+#define mp_raise_msg(type, msg)                 (mp_fun_table.raise_msg((type), (msg)))
 #define mp_raise_OSError(er)                    (mp_raise_OSError_dyn(er))
 #define mp_raise_NotImplementedError(msg)       (mp_raise_msg(&mp_type_NotImplementedError, (msg)))
 #define mp_raise_TypeError(msg)                 (mp_raise_msg(&mp_type_TypeError, (msg)))
@@ -281,7 +279,7 @@ static inline void mp_obj_get_array_dyn(mp_obj_t o, size_t *len, mp_obj_t **item
         *len = l->len;
         *items = l->items;
     } else {
-        mp_raise_TypeError("expected tuple/list");
+        mp_raise_TypeError(MP_ERROR_TEXT("expected tuple/list"));
     }
 }
 

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -318,7 +318,7 @@ const mp_fun_table_t mp_fun_table = {
     gc_realloc,
     mp_printf,
     mp_vprintf,
-    mp_raise_msg_str,
+    mp_raise_msg,
     mp_obj_get_type,
     mp_obj_new_str,
     mp_obj_new_bytes,

--- a/py/nativeglue.h
+++ b/py/nativeglue.h
@@ -145,7 +145,7 @@ typedef struct _mp_fun_table_t {
     #if defined(__GNUC__)
     NORETURN // Only certain compilers support no-return attributes in function pointer declarations
     #endif
-    void (*raise_msg_str)(const mp_obj_type_t *exc_type, const char *msg);
+    void (*raise_msg)(const mp_obj_type_t *exc_type, const compressed_string_t *);
     const mp_obj_type_t *(*obj_get_type)(mp_const_obj_t o_in);
     mp_obj_t (*obj_new_str)(const char *data, size_t len);
     mp_obj_t (*obj_new_bytes)(const byte *data, size_t len);

--- a/supervisor/shared/translate.h
+++ b/supervisor/shared/translate.h
@@ -85,7 +85,7 @@ uint16_t decompress_length(const compressed_string_t *compressed);
 
 // Map MicroPython's error messages to our translations.
 #if defined(MICROPY_ENABLE_DYNRUNTIME) && MICROPY_ENABLE_DYNRUNTIME
-#define MP_ERROR_TEXT(x) (x)
+#define MP_ERROR_TEXT(x) translate(x)
 #else
 #define MP_ERROR_TEXT(x) translate(x)
 #endif


### PR DESCRIPTION
I did a proof of concept to get native modules to work in CP. There were a few changes required to get everything compiling properly and updated after all the MP merges. What is in this PR are basically bug fixes in code paths not ran during normal CP operation. They are not encountered unless the native mpy flag is enabled.

To enable the `CIRCUITPY_ENABLE_MPY_NATIVE` needs to be set to 1.

**This change does not enable native modules in any build.**