### PR TITLE
fix #6015

### DIFF
--- a/shared-module/rainbowio/__init__.c
+++ b/shared-module/rainbowio/__init__.c
@@ -42,5 +42,6 @@ int32_t colorwheel(mp_float_t pos) {
         shift2 = 0;
     }
     int p = (int)(pos * 3);
+    p = (p<256) ? p : 255;
     return (p << shift1) | ((255 - p) << shift2);
 }


### PR DESCRIPTION
Of the two fix options described in https://github.com/adafruit/circuitpython/issues/6015, this seems like the more-compatible fix.  It guards against the overflow that was happening but doesn't change the method signature.  (Which would break all existing code that is sending a float, something I do a lot with stuff like `colorwheel( time.monotonic() * 20 )`