### PR TITLE
Fix and revise convert-release-notes.py

### DIFF
--- a/tools/convert_release_notes.py
+++ b/tools/convert_release_notes.py
@@ -16,9 +16,8 @@ html = mistune.create_markdown()
 print()
 print("HTML")
 print("=====================================")
-print('From the <a href="">GitHub release page</a>:\n<blockquote>')
+print('<p><em>From the <a href="">GitHub release page</a>:</em></p>\n')
 print(html(source))
-print("</blockquote>")
 
 
 class AdafruitBBCodeRenderer(mistune.renderers.BaseRenderer):
@@ -59,10 +58,13 @@ class AdafruitBBCodeRenderer(mistune.renderers.BaseRenderer):
         return "[b]{}[/b]".format(text)
 
     def emphasis(self, text):
-        return "[b]{}[/b]".format(text)
+        return "[i]{}[/i]".format(text)
 
     def strong(self, text):
-        return "[i]{}[/i]".format(text)
+        return "[b]{}[/b]".format(text)
+
+    def finalize(self, data):
+        return "".join(data)
 
 
 bbcode = mistune.create_markdown(renderer=AdafruitBBCodeRenderer())
@@ -70,6 +72,5 @@ bbcode = mistune.create_markdown(renderer=AdafruitBBCodeRenderer())
 print()
 print("BBCode")
 print("=====================================")
-print("From the [url=]GitHub release page[/url]:\n[quote]")
+print("[i]From the [url=]GitHub release page[/url]:[/i]\n")
 print(bbcode(source))
-print("[/quote]")


### PR DESCRIPTION
Changes to `convert-release-notes.py`, which is used to convert the markdown release notes to HTML and BBCODE when we make a new release:

- add `finalize()` to `AdafruitBBCodeRenderer` due to a library now requiring it
- fix `strong()` and `em()` to do bold and italic, respectively
- don't include the notes in a blockquote (my personal style preference)