### PR TITLE
Increase max LWIP sockets on ESP32-S3

### DIFF
--- a/ports/espressif/esp-idf-config/sdkconfig-esp32s3.defaults
+++ b/ports/espressif/esp-idf-config/sdkconfig-esp32s3.defaults
@@ -7,6 +7,12 @@ CONFIG_IDF_TARGET_ESP32S3=y
 CONFIG_IDF_FIRMWARE_CHIP_ID=0x0009
 # end of Espressif IoT Development Framework (ESP-IDF) Project Configuration
 
+#
+# LWIP sdkconfig.defaults override
+#
+CONFIG_LWIP_MAX_SOCKETS=8
+# end of LWIP sdkconfig.defaults override
+
 CONFIG_SDK_TOOLPREFIX="xtensa-esp32s3-elf-"
 #
 # Bootloader config


### PR DESCRIPTION
This PR changes the max socket limit from 4 to 8, implementing one of the improvements enabled by the 192KB increase in internal SRAM in the ESP32-S3 compared to the ESP32-S2, as discussed in issue #5915.

Sockets are memory-intensive, and memory use appears to be somewhat non-linear, and somewhat variable based on the socket use.

### ESP32-S2

On ESP32-S2 (`Adafruit CircuitPython 7.2.0-alpha.2 on 2022-02-11; ESP32-S2-DevKitC-1-N4R2 with ESP32S2`), fresh memory stats on reset are:
```
         espidf.heap_caps_get_*:

         largest_free_block()  free_size()  total_size()  gc.mem_free()
ESP32-S2               118784       133472        158404        2046880
```
Launching code.py and connecting to wifi brings IDF memory down to:
```
         largest_free_block()  free_size()  total_size()  gc.mem_free()
ESP32-S2                63488        78296        158404        2008080
```
With a max socket limit of 4 on ESP32-S2 (TLS connections each use two sockets), a first TLS connection brings the memory down to:
```
         largest_free_block()  free_size()  total_size()  gc.mem_free()
ESP32-S2                21504        42508        158404        1999376
```
and adding a second simultaneous TLS connection bring the memory down to:
```
         largest_free_block()  free_size()  total_size()  gc.mem_free()
ESP32-S2                 4608         9872        158404        1990832
```
Pretty slim margim, but it works. It is possible to run out of IDF memory with two TLS connections, resulting in memory exception (or sometimes an `OSError: Failed SSL handshake`, which can arise when there's not enough memory to complete the certificate transaction).

### ESP32-S3 baseline

On ESP32-S3 (`Adafruit CircuitPython 7.2.0-alpha.2 on 2022-02-11; ESP32-S3-DevKitC-1-N8R2 with ESP32S3`), fresh memory stats on reset are:
```
         espidf.heap_caps_get_*:

         largest_free_block()  free_size()  total_size()  gc.mem_free()
ESP32-S3               225280       299836        333708        2046880
```
Launching code.py and connecting to wifi brings IDF memory down to:
```
         largest_free_block()  free_size()  total_size()  gc.mem_free()
ESP32-S3               225280       242012        333708        2007440
```
Sequential stats after running one, then two, simultaneous TLS sockets, as above:
```
         largest_free_block()  free_size()  total_size()  gc.mem_free()
ESP32-S3               196608       206272        333708        1998736
ESP32-S3               163840       173492        333708        1990192
```
Plenty of headroom.

### ESP32-S3 with PR

On ESP32-S3 with PR (`Adafruit CircuitPython 7.2.0-alpha.2-8-gddac37add-dirty on 2022-02-11; ESP32-S3-DevKitC-1-N8R2 with ESP32S3`), fresh memory stats on reset are:
```
         espidf.heap_caps_get_*:

         largest_free_block()  free_size()  total_size()  gc.mem_free()
ESP32-S3               221184       292232        326460        2046896
```

Launching code.py and connecting to wifi brings IDF memory down to:
```
         largest_free_block()  free_size()  total_size()  gc.mem_free()
ESP32-S3               221184       234412        326460        2015968
```
Now, on the _modified_ ESP32-S3 ,

Allowing up to 8 sockets (or 4 TLS connections), sequential stats after each TLS connection is running are as follows:
```
         largest_free_block()  free_size()  total_size()  gc.mem_free()
ESP32-S3               192512       200396        326460        2007120
ESP32-S3               159744       167636        326460        1998768
ESP32-S3               131072       136760        326460        1989312
ESP32-S3                96256       102528        326460        1980880
```
Still an order of magnitude more headroom than in the ESP32-S2 case, and uses only about half of the 192KB increase in internal SRAM, leaving room for other features such as increasing the `CIRCUITPY_PYSTACK_SIZE`.

Much like with CircuitPython heap memory, users will need to balance the use of IDF memory between any aggressive uses such as these increased socket connections, larger numbers of wifi AP connections, and perhaps some memory-intensive BLE features in the future.