### PR TITLE
wifi.radio.start_ap() new kwarg: max_connections

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -3630,6 +3630,10 @@ msgstr ""
 msgid "matrix is not positive definite"
 msgstr ""
 
+#: shared-bindings/wifi/Radio.c
+msgid "max_connections must be between 0 and 10"
+msgstr ""
+
 #: ports/espressif/common-hal/_bleio/Descriptor.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Descriptor.c

--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -213,7 +213,12 @@ void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_
     config->ap.password[password_len] = 0;
     config->ap.channel = channel;
     config->ap.authmode = authmode;
+
+    if (max_connections < 0 || max_connections > 10) {
+        mp_raise_ValueError(translate("max_connections must be between 0 and 10"));
+    }
     config->ap.max_connection = max_connections;
+
     esp_wifi_set_config(WIFI_IF_AP, config);
 }
 

--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -185,7 +185,7 @@ void common_hal_wifi_radio_stop_station(wifi_radio_obj_t *self) {
     set_mode_station(self, false);
 }
 
-void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, uint8_t authmode) {
+void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, uint8_t authmode, uint8_t max_connections) {
     set_mode_ap(self, true);
 
     switch (authmode) {
@@ -213,7 +213,7 @@ void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_
     config->ap.password[password_len] = 0;
     config->ap.channel = channel;
     config->ap.authmode = authmode;
-    config->ap.max_connection = 4; // kwarg?
+    config->ap.max_connection = max_connections;
     esp_wifi_set_config(WIFI_IF_AP, config);
 }
 

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -240,10 +240,10 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_station_obj, wifi_radio_stop_station);
 //|            If ``authmode`` is given, the access point will use that Authentication
 //|            mode. If a password is given, ``authmode`` must not be ``OPEN``.
 //|            If ``authmode`` isn't given, ``OPEN`` will be used when password isn't provided,
-//|            otherwise ``WPA_WPA2_PSK``."""
+//|            otherwise ``WPA_WPA2_PSK``.
 //|
 //|            If ``max_connections`` is given, the access point will allow up to
-//|            that number of stations to connect. Default is 4. Maximum is 10.
+//|            that number of stations to connect. Default is 4. Maximum is 10."""
 //|         ...
 //|
 STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -243,7 +243,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_station_obj, wifi_radio_stop_station);
 //|            otherwise ``WPA_WPA2_PSK``.
 //|
 //|            If ``max_connections`` is given, the access point will allow up to
-//|            that number of stations to connect. Default is 4. Maximum is 10."""
+//|            that number of stations to connect."""
 //|         ...
 //|
 STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -286,10 +286,6 @@ STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_
         }
     } else {
         authmode = 1;
-    }
-
-    if (args[ARG_max_connections].u_int < 0 || args[ARG_max_connections].u_int > 10) {
-        mp_raise_ValueError(translate("max_connections must be between 0 and 10"));
     }
 
     common_hal_wifi_radio_start_ap(self, ssid.buf, ssid.len, password.buf, password.len, args[ARG_channel].u_int, authmode, args[ARG_max_connections].u_int);

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -230,7 +230,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_station_obj, wifi_radio_stop_station);
 //|                  password: ReadableBuffer = b"",
 //|                  *,
 //|                  channel: Optional[int] = 1,
-//|                  authmode: Optional[AuthMode]) -> None:
+//|                  authmode: Optional[AuthMode],
+//|                  max_connections: Optional[int] = 4) -> None:
 //|         """Starts an Access Point with the specified ssid and password.
 //|
 //|            If ``channel`` is given, the access point will use that channel unless
@@ -240,15 +241,19 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_station_obj, wifi_radio_stop_station);
 //|            mode. If a password is given, ``authmode`` must not be ``OPEN``.
 //|            If ``authmode`` isn't given, ``OPEN`` will be used when password isn't provided,
 //|            otherwise ``WPA_WPA2_PSK``."""
+//|
+//|            If ``max_connections`` is given, the access point will allow up to
+//|            that number of stations to connect. Default is 4. Maximum is 10.
 //|         ...
 //|
 STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_ssid, ARG_password, ARG_channel, ARG_authmode };
+    enum { ARG_ssid, ARG_password, ARG_channel, ARG_authmode, ARG_max_connections };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_ssid, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_password,  MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_channel, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
         { MP_QSTR_authmode, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_max_connections, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 4} },
     };
 
     wifi_radio_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
@@ -283,7 +288,11 @@ STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_
         authmode = 1;
     }
 
-    common_hal_wifi_radio_start_ap(self, ssid.buf, ssid.len, password.buf, password.len, args[ARG_channel].u_int, authmode);
+    if (args[ARG_max_connections].u_int < 0 || args[ARG_max_connections].u_int > 10) {
+        mp_raise_ValueError(translate("max_connections must be between 0 and 10"));
+    }
+
+    common_hal_wifi_radio_start_ap(self, ssid.buf, ssid.len, password.buf, password.len, args[ARG_channel].u_int, authmode, args[ARG_max_connections].u_int);
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_start_ap_obj, 1, wifi_radio_start_ap);

--- a/shared-bindings/wifi/Radio.h
+++ b/shared-bindings/wifi/Radio.h
@@ -88,7 +88,7 @@ extern void common_hal_wifi_radio_stop_scanning_networks(wifi_radio_obj_t *self)
 extern void common_hal_wifi_radio_start_station(wifi_radio_obj_t *self);
 extern void common_hal_wifi_radio_stop_station(wifi_radio_obj_t *self);
 
-extern void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, uint8_t authmode);
+extern void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, uint8_t authmode, uint8_t max_connections);
 extern void common_hal_wifi_radio_stop_ap(wifi_radio_obj_t *self);
 
 extern wifi_radio_error_t common_hal_wifi_radio_connect(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, mp_float_t timeout, uint8_t *bssid, size_t bssid_len);


### PR DESCRIPTION
This PR is somewhat independent of #5915, though extra internal RAM never hurts. Each Station connection to the Access Point uses an additional ~1.5KB. Even on an ESP32-S2-DevKitC-1-N4R2, A simple AP running with 10 connections should have about 50KB of free espidf memory (a simple AP with no connections has about 65KB free).

This max_connections value was hard-coded to 4 in the released code, which was Espressif's default setting. Now it can go from 0 to 10 (Espressif's full supported range), with default (without the kwarg) remaining at 4. There are use cases for 0; creating an AP to which no connections can be made. An exception is raised for values outside the range.

Although we can't have this many simultaneous sockets (with or without #6021), more Station devices could stay connected to the AP and use UDP or  sometimes-connected TCP, assuming they had appropriate exception-handling for when the AP refused the connection.

Tested the 0 case using a phone as Station and got an unable to connect dialog as expected. A CircuitPython device connecting to an AP with `max_connections=0` will get a `ConnectionError: Unknown failure 205`, which is a general Espressif wifi error code. Progressively tested 8 simultaneous connections on an esp32s3_devkitc_1_n8r2, with 8 separate ESP32-S2 and ESP32-S3 Stations.