### PR TITLE
MicroMod SAMD51: Correct default MISO

### DIFF
--- a/ports/atmel-samd/boards/sparkfun_samd51_micromod/mpconfigboard.h
+++ b/ports/atmel-samd/boards/sparkfun_samd51_micromod/mpconfigboard.h
@@ -19,7 +19,7 @@
 
 #define DEFAULT_SPI_BUS_SCK (&pin_PA05)
 #define DEFAULT_SPI_BUS_MOSI (&pin_PA04)
-#define DEFAULT_SPI_BUS_MISO (&pin_PB06)
+#define DEFAULT_SPI_BUS_MISO (&pin_PA06)
 
 #define DEFAULT_UART_BUS_RX (&pin_PB30)
 #define DEFAULT_UART_BUS_TX (&pin_PB31)


### PR DESCRIPTION
While looking into the external flash issues with this board, I noticed the `board.SPI()` was not working correctly. The reason was the wrong port pin being assigned for the default CIPO on the board.