### PR TITLE
Tweak I2C and TFT power pin defaults

### DIFF
--- a/ports/espressif/boards/adafruit_feather_esp32s2/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2/board.c
@@ -32,10 +32,7 @@
 #include "common-hal/microcontroller/Pin.h"
 
 void board_init(void) {
-    // Turn on I2C
-    common_hal_never_reset_pin(&pin_GPIO7);
-    gpio_set_direction(7, GPIO_MODE_DEF_OUTPUT);
-    gpio_set_level(7, false);
+    reset_board();
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
@@ -71,12 +71,13 @@ uint8_t display_init_sequence[] = {
 
 
 void board_init(void) {
-    // I2C/TFT power pin
+    // Never reset the I2C/TFT power pin because doing so will reset the display.
+    // Instead, on reset set the default value and free the pin for user use.
+    // Relying on the normal pin reset would briefly float/pull the pin that
+    // could lead to a power brownout.
     common_hal_never_reset_pin(&pin_GPIO21);
 
-    // Turn on TFT and I2C
-    gpio_set_direction(21, GPIO_MODE_DEF_OUTPUT);
-    gpio_set_level(21, true);
+    reset_board();
 
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
     displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
@@ -138,8 +139,13 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
+    // Turn on TFT and I2C
+    gpio_set_direction(21, GPIO_MODE_DEF_OUTPUT);
+    gpio_set_level(21, true);
 
+    free_pin_number(21);
 }
 
 void board_deinit(void) {
+    // TODO: Should we turn off the display when asleep?
 }

--- a/ports/espressif/common-hal/microcontroller/Pin.c
+++ b/ports/espressif/common-hal/microcontroller/Pin.c
@@ -133,6 +133,10 @@ void claim_pin(const mcu_pin_obj_t *pin) {
     in_use[pin->number / 32] |= (1 << (pin->number % 32));
 }
 
+void free_pin_number(gpio_num_t pin_number) {
+    in_use[pin_number / 32] &= ~(1 << (pin_number % 32));
+}
+
 void common_hal_mcu_pin_claim(const mcu_pin_obj_t *pin) {
     claim_pin(pin);
 }

--- a/ports/espressif/common-hal/microcontroller/Pin.h
+++ b/ports/espressif/common-hal/microcontroller/Pin.h
@@ -39,6 +39,8 @@ void common_hal_reset_pin(const mcu_pin_obj_t *pin);
 void common_hal_never_reset_pin(const mcu_pin_obj_t *pin);
 void claim_pin(const mcu_pin_obj_t *pin);
 void claim_pin_number(gpio_num_t pin_number);
+// Free the pin without resetting it.
+void free_pin_number(gpio_num_t pin_number);
 bool pin_number_is_free(gpio_num_t pin_number);
 void never_reset_pin_number(gpio_num_t pin_number);
 


### PR DESCRIPTION
This should set the power to on by default without preventing the
user code from repeatedly using it.

Fixes #5903