### PR TITLE
bitmap.blit type checking and raise error

### DIFF
--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -222,7 +222,8 @@ STATIC mp_obj_t displayio_bitmap_obj_blit(size_t n_args, const mp_obj_t *pos_arg
     int16_t x = args[ARG_x].u_int;
     int16_t y = args[ARG_y].u_int;
 
-    displayio_bitmap_t *source = MP_OBJ_TO_PTR(args[ARG_source].u_obj);
+    displayio_bitmap_t *source = mp_arg_validate_type(args[ARG_source].u_obj, &displayio_bitmap_type, MP_QSTR_source_bitmap);
+
 
     // ensure that the target bitmap (self) has at least as many `bits_per_value` as the source
     if (self->bits_per_value < source->bits_per_value) {


### PR DESCRIPTION
resolves #5916 I confirmed the hard crash as described in the issue.

Tested on Feather TFT ESP32-S2 using this example code (mostly the same as posted in the issue):
```py
import time
import displayio

print("waiting 8...7...6..5...4...3...2...1...")
time.sleep(8)

with open("/allblue.bmp", "rb") as bits:
    source = displayio.OnDiskBitmap(bits)
    dest = displayio.Bitmap(source.width, source.height, 64)
    dest.blit(0, 0, source)

```

output after this change:
```
code.py output:
waiting 8...7...6..5...4...3...2...1...
Traceback (most recent call last):
  File "code.py", line 12, in <module>
TypeError: source_bitmap must be of type Bitmap

```