### PR TITLE
Fix compression of strings >256 bytes long in UTF-8 encoding

### DIFF
--- a/supervisor/shared/translate.c
+++ b/supervisor/shared/translate.c
@@ -87,11 +87,11 @@ STATIC int put_utf8(char *buf, int u) {
 }
 
 uint16_t decompress_length(const compressed_string_t *compressed) {
-    if (compress_max_length_bits <= 8) {
-        return 1 + (compressed->data >> (8 - compress_max_length_bits));
-    } else {
-        return 1 + ((compressed->data * 256 + compressed->tail[0]) >> (16 - compress_max_length_bits));
-    }
+    #if (compress_max_length_bits <= 8)
+    return 1 + (compressed->data >> (8 - compress_max_length_bits));
+    #else
+    return 1 + ((compressed->data * 256 + compressed->tail[0]) >> (16 - compress_max_length_bits));
+    #endif
 }
 
 char *decompress(const compressed_string_t *compressed, char *decompressed) {


### PR DESCRIPTION
~~This also includes the changes from #6031 at the time I began working on the build problem first seen there.~~
The problem is only seen with changes from #6031; I had included them here but rebased the branch because some undesired commits were also present, so they're not here anymore.