### PR TITLE
Fix press any key responding slowly on espressif

### DIFF
--- a/ports/espressif/supervisor/usb.c
+++ b/ports/espressif/supervisor/usb.c
@@ -138,3 +138,10 @@ void tud_cdc_rx_wanted_cb(uint8_t itf, char wanted_char) {
         mp_sched_keyboard_interrupt();
     }
 }
+
+void tud_cdc_rx_cb(uint8_t itf) {
+    (void)itf;
+    // Workaround for "press any key to enter REPL" response being delayed on espressif.
+    // Wake main task when any key is pressed.
+    port_wake_main_task();
+}


### PR DESCRIPTION
On espressif, responding to `Press any key to enter the REPL. Use CTRL-D to reload` is delayed (for any key other than ctrl+c).

The cause is `port_idle_until_interrupt` not waking up on any keys pressed. On other ports, a usb interrupt will wake the loop up, but on espressif, [this a FreeRTOS task that is awoken upon ctrl+c being received by tinyusb](https://github.com/adafruit/circuitpython/blob/main/ports/espressif/supervisor/usb.c#L133).

My workaround is a little hacky, but shouldn't cause any issues as far as I can tell.