### PR TITLE
Fix qstr error

### DIFF
--- a/supervisor/shared/translate.c
+++ b/supervisor/shared/translate.c
@@ -87,10 +87,12 @@ STATIC int put_utf8(char *buf, int u) {
 }
 
 uint16_t decompress_length(const compressed_string_t *compressed) {
+    #ifndef NO_QSTR
     #if (compress_max_length_bits <= 8)
     return 1 + (compressed->data >> (8 - compress_max_length_bits));
     #else
     return 1 + ((compressed->data * 256 + compressed->tail[0]) >> (16 - compress_max_length_bits));
+    #endif
     #endif
 }
 


### PR DESCRIPTION
Dan noticed that builds were printing a scary message like
```
../../supervisor/shared/translate.c:90:10: error: "compress_max_length_bits" is not defined, evaluates to 0 [-Werror=undef]
   90 |     #if (compress_max_length_bits <= 8)
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
Command '['arm-none-eabi-gcc', '-E', '-DNO_QSTR', ..., '../supervisor/shared/translate.c']' returned non-zero exit status 1.
make: *** [../../py/mkrules.mk:100: build-adafruit_feather_rp2040/genhdr/qstr.split] Error 1
```
but continuing, apparently, just fine.  This two part PR:
 * makes the scary message be followed by an actual error that stops make
 * fixes the original problem, which was harmless but wouldn't have been allowed to creep in if not for the first problem