### PR TITLE
don't wait for USB or BLE workflow after true deep sleep

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -447,9 +447,9 @@ void supervisor_run_background_tasks_if_tick(void);
 #define CIRCUITPY_PYSTACK_SIZE 1536
 #endif
 
-// Wait this long imediately after startup to see if we are connected to USB.
-#ifndef CIRCUITPY_USB_CONNECTED_SLEEP_DELAY
-#define CIRCUITPY_USB_CONNECTED_SLEEP_DELAY 5
+// Wait this long before sleeping immediately after startup, to see if we are connected via USB or BLE.
+#ifndef CIRCUITPY_WORKFLOW_CONNECTION_SLEEP_DELAY
+#define CIRCUITPY_WORKFLOW_CONNECTION_SLEEP_DELAY 5
 #endif
 
 #ifndef CIRCUITPY_PROCESSOR_COUNT

--- a/shared-bindings/alarm/__init__.c
+++ b/shared-bindings/alarm/__init__.c
@@ -125,11 +125,15 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(alarm_light_sleep_until_alarms_obj, 1, MP_OB
 //|
 //|     If no alarms are specified, the microcontroller will deep sleep until reset.
 //|
-//|     **If CircuitPython is connected to a host computer, the connection will be maintained,
-//|     and the system will not go into deep sleep.**
+//|     **If CircuitPython is connected to a host computer via USB or BLE
+//|     the first time a deep sleep is requested,
+//|     the connection will be maintained and the system will not go into deep sleep.**
 //|     This allows the user to interrupt an existing program with ctrl-C,
 //|     and to edit the files in CIRCUITPY, which would not be possible in true deep sleep.
-//|     Thus, to use deep sleep and save significant power, you will need to disconnect from the host.
+//|
+//|     If CircuitPython goes into a true deep sleep, and USB or BLE is reconnected,
+//|     the next deep sleep will still be a true deep sleep. You must do a hard reset
+//|     or power-cycle to exit a true deep sleep loop.
 //|
 //|     Here is skeletal example that deep-sleeps and restarts every 60 seconds:
 //|


### PR DESCRIPTION
- Fixes #5935.

Check whether CPy awoke from true deep sleep. If so, don't bother to wait 5 seconds for USB or BLE workflow connected, even if there is already a workflow connection. When asked to sleep again, enter true deep sleep even if USB has been connected in the meantime. A hard reset s needed to get out of a true deep sleep loop.