### PR TITLE
Don't update status LED color on brightness change

### DIFF
--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -76,16 +76,15 @@ STATIC mp_obj_t supervisor_disable_autoreload(void) {
 MP_DEFINE_CONST_FUN_OBJ_0(supervisor_disable_autoreload_obj, supervisor_disable_autoreload);
 
 //| def set_rgb_status_brightness(brightness: int) -> None:
-//|     """Set brightness of status neopixel from 0-255
-//|     `set_rgb_status_brightness` is called."""
+//|     """Set brightness of status RGB LED from 0-255. This will take effect
+//|        after the current code finishes and the status LED is used to show
+//|        the finish state."""
 //|     ...
 //|
 STATIC mp_obj_t supervisor_set_rgb_status_brightness(mp_obj_t lvl) {
     // This must be int. If cast to uint8_t first, will never raise a ValueError.
     int brightness_int = mp_obj_get_int(lvl);
-    if (brightness_int < 0 || brightness_int > 255) {
-        mp_raise_ValueError(translate("Brightness must be between 0 and 255"));
-    }
+    mp_arg_validate_int_range(brightness_int, 0, 255, MP_QSTR_brightness);
     set_status_brightness((uint8_t)brightness_int);
     return mp_const_none;
 }

--- a/supervisor/shared/status_leds.c
+++ b/supervisor/shared/status_leds.c
@@ -324,12 +324,9 @@ uint32_t color_brightness(uint32_t color, uint8_t brightness) {
 void set_status_brightness(uint8_t level) {
     #if CIRCUITPY_STATUS_LED
     rgb_status_brightness = level;
-    uint32_t current_color = current_status_color;
-    // Temporarily change the current color global to force the new_status_color call to update the
-    // LED. Usually duplicate calls of the same color are ignored without regard to brightness
-    // changes.
-    current_status_color = 0;
-    new_status_color(current_color);
+    // This is only called by user code and we're never controlling the status
+    // LED when user code is running. So, we don't need to update the current
+    // state (there is none.)
     #endif
 }
 


### PR DESCRIPTION
Brightness changes now happen when the LED isn't active or
initialized. When not init, CP may crash.

Fixes #5872