### PR TITLE
init status LED in supervisor.set_rgb_brightness()

### DIFF
--- a/supervisor/shared/status_leds.c
+++ b/supervisor/shared/status_leds.c
@@ -329,7 +329,9 @@ void set_status_brightness(uint8_t level) {
     // LED. Usually duplicate calls of the same color are ignored without regard to brightness
     // changes.
     current_status_color = 0;
+    status_led_init();
     new_status_color(current_color);
+    status_led_deinit();
     #endif
 }
 


### PR DESCRIPTION
- Fixes #5872.

`supervisor.set_rgb_brightness()` was not making sure the status LED was inited before changing its color.

Tested on FunHouse.