### PR TITLE
free RX and TX on QTPY-ESP32S2 in non debug builds

### DIFF
--- a/ports/espressif/boards/adafruit_qtpy_esp32s2/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s2/mpconfigboard.h
@@ -50,5 +50,7 @@
 
 #define DOUBLE_TAP_PIN (&pin_GPIO10)
 
+#ifdef DEBUG
 #define DEBUG_UART_RX               (&pin_GPIO16)
 #define DEBUG_UART_TX               (&pin_GPIO5)
+#endif


### PR DESCRIPTION
Fix #5904 