### PR TITLE
use --long for describe in setup.py-stubs

### DIFF
--- a/setup.py-stubs
+++ b/setup.py-stubs
@@ -43,7 +43,7 @@ setup(
         "root": "..",
         "relative_to": __file__,
         "local_scheme": local_scheme,
-        "git_describe_command": "tools/describe",
+        "git_describe_command": "tools/describe --long",
     },
     zip_safe=False,
 )

--- a/tools/describe
+++ b/tools/describe
@@ -1,2 +1,3 @@
 #!/bin/sh
-git describe --first-parent --dirty --tags --always --match "[1-9].*"
+# Add any supplied arguments.
+git describe --first-parent --dirty --tags --always --match "[1-9].*" "$@"


### PR DESCRIPTION
- Fixes #6063.

This will use `--long` so `setup()` in `setup.py` will be happy when running on a tag.