### PR TITLE
Set SPI CLK pin pull up/down in SPI Configure based on SPI polarity config

### DIFF
--- a/ports/stm/common-hal/busio/SPI.c
+++ b/ports/stm/common-hal/busio/SPI.c
@@ -293,6 +293,15 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
     self->handle.Init.CLKPolarity = (polarity) ? SPI_POLARITY_HIGH : SPI_POLARITY_LOW;
     self->handle.Init.CLKPhase = (phase) ? SPI_PHASE_2EDGE : SPI_PHASE_1EDGE;
 
+    // Set SCK pull up or down based on SPI CLK Polarity
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = pin_mask(self->sck->pin->number);
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = (polarity) ? GPIO_PULLUP : GPIO_PULLDOWN;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+    GPIO_InitStruct.Alternate = self->sck->altfn_index;
+    HAL_GPIO_Init(pin_port(self->sck->pin->port), &GPIO_InitStruct);
+
     self->handle.Init.BaudRatePrescaler = stm32_baud_to_spi_div(baudrate, &self->prescaler,
         get_busclock(self->handle.Instance));
 


### PR DESCRIPTION
If the SPI CLK polarity is set to 1, then a pull up resistor is required to keep the CLK signal high when the CLK goes to tri-state during idle periods. The pull up resistor could be external, but if your board is hard to modify, then setting the internal pull up resistor on the SPI CLK pin is useful. As the SPI CLK pin gets set up as a busio it becomes marked as "in use" and you can't manually set it to a pull up/down using digitalio, so the pull up/down should be set on spi configure.