### PR TITLE
Fix import of builtin submodules

### DIFF
--- a/py/py.mk
+++ b/py/py.mk
@@ -55,7 +55,7 @@ endif
 ifeq ($(CIRCUITPY_ULAB),1)
 ULAB_SRCS := $(shell find $(TOP)/extmod/ulab/code -type f -name "*.c")
 SRC_MOD += $(patsubst $(TOP)/%,%,$(ULAB_SRCS))
-CFLAGS_MOD += -DCIRCUITPY_ULAB=1 -DMODULE_ULAB_ENABLED=1 -iquote $(TOP)/extmod/ulab/code
+CFLAGS_MOD += -DCIRCUITPY_ULAB=1 -DMODULE_ULAB_ENABLED=1 -DULAB_HAS_USER_MODULE=0 -iquote $(TOP)/extmod/ulab/code
 $(BUILD)/extmod/ulab/code/%.o: CFLAGS += -Wno-missing-declarations -Wno-missing-prototypes -Wno-unused-parameter -Wno-float-equal -Wno-sign-compare -Wno-cast-align -Wno-shadow -DCIRCUITPY
 endif
 

--- a/shared-bindings/adafruit_bus_device/__init__.c
+++ b/shared-bindings/adafruit_bus_device/__init__.c
@@ -78,3 +78,5 @@ const mp_obj_module_t adafruit_bus_device_module = {
 };
 
 MP_REGISTER_MODULE(MP_QSTR_adafruit_bus_device, adafruit_bus_device_module, CIRCUITPY_BUSDEVICE);
+MP_REGISTER_MODULE(MP_QSTR_adafruit_bus_device_dot_i2c_device, adafruit_bus_device_i2c_device_module, CIRCUITPY_BUSDEVICE);
+MP_REGISTER_MODULE(MP_QSTR_adafruit_bus_device_dot_spi_device, adafruit_bus_device_spi_device_module, CIRCUITPY_BUSDEVICE);

--- a/tests/circuitpython/builtin_submodule.py
+++ b/tests/circuitpython/builtin_submodule.py
@@ -1,0 +1,9 @@
+try:
+    import ulab
+except:
+    print("SKIP")
+    raise SystemExit(0)
+
+import ulab.scipy.linalg
+
+print(ulab.scipy.linalg)

--- a/tests/circuitpython/builtin_submodule.py.exp
+++ b/tests/circuitpython/builtin_submodule.py.exp
@@ -1,0 +1,1 @@
+<module 'linalg'>

--- a/tests/unix/extra_coverage.py.exp
+++ b/tests/unix/extra_coverage.py.exp
@@ -37,9 +37,12 @@ gc              gifio           hashlib         json
 math            qrio            rainbowio       re
 sys             termios         traceback       ubinascii
 uctypes         uerrno          uheapq          uio
-ujson           ulab            uos             urandom
-ure             uselect         ustruct         utime
-utimeq          uzlib
+ujson           ulab            ulab.fft        ulab.linalg
+ulab.numpy      ulab.scipy      ulab.scipy.linalg
+ulab.scipy.optimize             ulab.scipy.signal
+ulab.scipy.special              ulab.utils      uos
+urandom         ure             uselect         ustruct
+utime           utimeq          uzlib
 ime
 
 utime           utimeq


### PR DESCRIPTION
Originally I was going to figure out where to restore our added behavior for submodule importing, but I found that as long as the submodule is registered as `foo.bar` it can be imported without other code changes.

Closes: #6066 

Note that allowing dotted submodules like this requires a CircuitPython extension: _dot_ in a QSTR name can represent a ".". This isn't possible in general in micropython, except if the string is listed in qstrdefs.h (that's how QSTR__dot_frozen works in MP)