### PR TITLE
msgpack.unpack requires a readable stream

### DIFF
--- a/shared-module/msgpack/__init__.c
+++ b/shared-module/msgpack/__init__.c
@@ -497,6 +497,6 @@ void common_hal_msgpack_pack(mp_obj_t obj, mp_obj_t stream_obj, mp_obj_t default
 }
 
 mp_obj_t common_hal_msgpack_unpack(mp_obj_t stream_obj, mp_obj_t ext_hook, bool use_list) {
-    msgpack_stream_t stream = get_stream(stream_obj, MP_STREAM_OP_WRITE);
+    msgpack_stream_t stream = get_stream(stream_obj, MP_STREAM_OP_READ);
     return unpack(&stream, ext_hook, use_list);
 }


### PR DESCRIPTION
msgpack.unpack should require read, not write.
This crashes circuitpy if a write-only stream is passed to unpack:

```py
import msgpack
import usb_midi
 # get a write only stream
_, port_out = usb_midi.ports
# before fix: faults
# after fix: OSError: stream operation not supported
msgpack.unpack(port_out)
```