### PR TITLE
Retains REPL contents when display.show(None) is called or code.py finishes and REPL is not resized

### DIFF
--- a/shared-bindings/terminalio/Terminal.c
+++ b/shared-bindings/terminalio/Terminal.c
@@ -62,7 +62,7 @@ STATIC mp_obj_t terminalio_terminal_make_new(const mp_obj_type_t *type, size_t n
     terminalio_terminal_obj_t *self = m_new_obj(terminalio_terminal_obj_t);
     self->base.type = &terminalio_terminal_type;
 
-    common_hal_terminalio_terminal_construct(self, tilegrid, font);
+    common_hal_terminalio_terminal_construct(self, tilegrid, font, true);
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/terminalio/Terminal.h
+++ b/shared-bindings/terminalio/Terminal.h
@@ -34,7 +34,7 @@
 extern const mp_obj_type_t terminalio_terminal_type;
 
 extern void common_hal_terminalio_terminal_construct(terminalio_terminal_obj_t *self,
-    displayio_tilegrid_t *tilegrid, const fontio_builtinfont_t *font);
+    displayio_tilegrid_t *tilegrid, const fontio_builtinfont_t *font, const bool reset_tiles);
 
 // Write characters. len is in characters NOT bytes!
 extern size_t common_hal_terminalio_terminal_write(terminalio_terminal_obj_t *self,

--- a/shared-module/displayio/display_core.c
+++ b/shared-module/displayio/display_core.c
@@ -169,8 +169,9 @@ bool displayio_display_core_show(displayio_display_core_t *self, displayio_group
         // force the circuit_python_splash out of any group (Note: could cause problems with the parent group)
         circuitpython_splash.x = 0; // reset position in case someone moved it.
         circuitpython_splash.y = 0;
-        supervisor_stop_terminal();
+
         supervisor_start_terminal(self->width, self->height);
+
         root_group = &circuitpython_splash;
     }
     if (root_group == self->current_group) {

--- a/shared-module/terminalio/Terminal.c
+++ b/shared-module/terminalio/Terminal.c
@@ -30,16 +30,18 @@
 #include "shared-bindings/displayio/TileGrid.h"
 #include "shared-bindings/terminalio/Terminal.h"
 
-void common_hal_terminalio_terminal_construct(terminalio_terminal_obj_t *self, displayio_tilegrid_t *tilegrid, const fontio_builtinfont_t *font) {
+void common_hal_terminalio_terminal_construct(terminalio_terminal_obj_t *self, displayio_tilegrid_t *tilegrid, const fontio_builtinfont_t *font, const bool reset_tiles) {
     self->cursor_x = 0;
     self->cursor_y = 0;
     self->font = font;
     self->tilegrid = tilegrid;
     self->first_row = 0;
 
-    for (uint16_t x = 0; x < self->tilegrid->width_in_tiles; x++) {
-        for (uint16_t y = 0; y < self->tilegrid->height_in_tiles; y++) {
-            common_hal_displayio_tilegrid_set_tile(self->tilegrid, x, y, 0);
+    if (reset_tiles) {
+        for (uint16_t x = 0; x < self->tilegrid->width_in_tiles; x++) {
+            for (uint16_t y = 0; y < self->tilegrid->height_in_tiles; y++) {
+                common_hal_displayio_tilegrid_set_tile(self->tilegrid, x, y, 0);
+            }
         }
     }
 

--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -61,6 +61,7 @@ void supervisor_start_terminal(uint16_t width_px, uint16_t height_px) {
     #if CIRCUITPY_TERMINALIO
     displayio_tilegrid_t *grid = &supervisor_terminal_text_grid;
     bool tall = height_px > width_px;
+    bool reset_tiles = false;
     uint16_t terminal_width_px = tall ? width_px : width_px - blinka_bitmap.width;
     uint16_t terminal_height_px = tall ? height_px - blinka_bitmap.height : height_px;
     uint16_t width_in_tiles = terminal_width_px / grid->tile_width;
@@ -86,10 +87,12 @@ void supervisor_start_terminal(uint16_t width_px, uint16_t height_px) {
         if (get_allocation_length(tilegrid_tiles) != align32_size(total_tiles)) {
             free_memory(tilegrid_tiles);
             tilegrid_tiles = NULL;
+            reset_tiles = true;
         }
     }
     if (!tilegrid_tiles) {
         tilegrid_tiles = allocate_memory(align32_size(total_tiles), false, true);
+        reset_tiles = true;
         if (!tilegrid_tiles) {
             return;
         }
@@ -111,7 +114,7 @@ void supervisor_start_terminal(uint16_t width_px, uint16_t height_px) {
     grid->tiles = tiles;
     grid->full_change = true;
 
-    common_hal_terminalio_terminal_construct(&supervisor_terminal, grid, &supervisor_terminal_font);
+    common_hal_terminalio_terminal_construct(&supervisor_terminal, grid, &supervisor_terminal_font, reset_tiles);
     #endif
 
     circuitpython_splash.scale = scale;


### PR DESCRIPTION
This PR improves upon a [previous PR](https://github.com/adafruit/circuitpython/pull/5954) to make the behavior of the REPL more predictable in 99.9% of uses, yet still provide user access to the REPL group.

This resolves https://github.com/adafruit/circuitpython/issues/6071



