### PR TITLE
fix REPL terminal garbled characters upon code.py finished

### DIFF
--- a/shared-bindings/terminalio/Terminal.c
+++ b/shared-bindings/terminalio/Terminal.c
@@ -62,7 +62,7 @@ STATIC mp_obj_t terminalio_terminal_make_new(const mp_obj_type_t *type, size_t n
     terminalio_terminal_obj_t *self = m_new_obj(terminalio_terminal_obj_t);
     self->base.type = &terminalio_terminal_type;
 
-    common_hal_terminalio_terminal_construct(self, tilegrid, font, true);
+    common_hal_terminalio_terminal_construct(self, tilegrid, font);
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/terminalio/Terminal.h
+++ b/shared-bindings/terminalio/Terminal.h
@@ -34,7 +34,7 @@
 extern const mp_obj_type_t terminalio_terminal_type;
 
 extern void common_hal_terminalio_terminal_construct(terminalio_terminal_obj_t *self,
-    displayio_tilegrid_t *tilegrid, const fontio_builtinfont_t *font, const bool reset_tiles);
+    displayio_tilegrid_t *tilegrid, const fontio_builtinfont_t *font);
 
 // Write characters. len is in characters NOT bytes!
 extern size_t common_hal_terminalio_terminal_write(terminalio_terminal_obj_t *self,

--- a/shared-module/terminalio/Terminal.c
+++ b/shared-module/terminalio/Terminal.c
@@ -30,18 +30,15 @@
 #include "shared-bindings/displayio/TileGrid.h"
 #include "shared-bindings/terminalio/Terminal.h"
 
-void common_hal_terminalio_terminal_construct(terminalio_terminal_obj_t *self, displayio_tilegrid_t *tilegrid, const fontio_builtinfont_t *font, const bool reset_tiles) {
+void common_hal_terminalio_terminal_construct(terminalio_terminal_obj_t *self, displayio_tilegrid_t *tilegrid, const fontio_builtinfont_t *font) {
     self->cursor_x = 0;
     self->cursor_y = 0;
     self->font = font;
     self->tilegrid = tilegrid;
     self->first_row = 0;
-
-    if (reset_tiles) {
-        for (uint16_t x = 0; x < self->tilegrid->width_in_tiles; x++) {
-            for (uint16_t y = 0; y < self->tilegrid->height_in_tiles; y++) {
-                common_hal_displayio_tilegrid_set_tile(self->tilegrid, x, y, 0);
-            }
+    for (uint16_t x = 0; x < self->tilegrid->width_in_tiles; x++) {
+        for (uint16_t y = 0; y < self->tilegrid->height_in_tiles; y++) {
+            common_hal_displayio_tilegrid_set_tile(self->tilegrid, x, y, 0);
         }
     }
 


### PR DESCRIPTION

This PR is to resolve the garbled characters observed in: 
https://github.com/adafruit/circuitpython/pull/6076#issuecomment-1047174101


Test code for standard use of the REPL:
```python
for i in range(3):
    print("hello world!")
```


Test code for resizing the REPL.  I just see one minor weirdness when using the resized REPL and then code.py finishes running.  If there is no serial connection, whenever the code is done running and it resets back to the REPL, the "Code is done running." is not shown.  There is just a black screen with Blinka. 

 If there is a serial connection, it shows the next lines "Autoreload is on....".  To avoid this, the last line of your code you can add `display.show(None)`.  Alternately, we could rearrange the sequence of when "Code is done running." is printed so that it occurs after the REPL is reset.

```python
import board
import displayio
import supervisor
import time


display=board.DISPLAY

# Create a bitmap with two colors
bitmap1 = displayio.Bitmap(display.width//4, display.height//4 - 10, 2)

# Create a two color palette
palette1 = displayio.Palette(2)
palette1[0] = 0xff00ff
palette1[1] = 0xffffff

# Create a TileGrid using the Bitmap and Palette
tile_grid1 = displayio.TileGrid(bitmap1, pixel_shader=palette1)


# Create a bitmap with two colors
bitmap2 = displayio.Bitmap(display.width//4, display.height//4 - 10, 2)

# Create a two color palette
palette2 = displayio.Palette(2)
palette2[0] = 0x00ffff
palette2[1] = 0xffffff

# Create a TileGrid using the Bitmap and Palette
tile_grid2 = displayio.TileGrid(bitmap2, pixel_shader=palette2)
tile_grid2.x=display.width//4

# Create a bitmap with two colors
bitmap3 = displayio.Bitmap(display.width//4, display.height//4 - 10, 2)

# Create a two color palette
palette3 = displayio.Palette(2)
palette3[0] = 0xffff00
palette3[1] = 0xffffff

# Create a TileGrid using the Bitmap and Palette
tile_grid3 = displayio.TileGrid(bitmap3, pixel_shader=palette3)
tile_grid3.x=2*display.width//4

# Create a Group
mygroup = displayio.Group()

print()
print()
print()
print("REPL control test: Taking control of REPL group")
time.sleep(3)


# clear the display to the REPL 
display.show(None)
splash = board.DISPLAY.root_group # this gets the current root_group, the REPL

# Note: You must "display.show" your own group before adding the splash to your own group.
# Reason: When displaying the normal REPL (for example with display.show(None), the splash
# group is already in a group that is displayed.  To remove the splash from the displayed group,
# you first have to display.show some other group, doing that will remove the splash from its group
# and allow you to append it to your own group. 
display.show(mygroup)

# resize the supervisor.splash group pixel dimensions, make it half the display height.
supervisor.reset_terminal(display.width//2, display.height//2)

# relocate the supervisor.splash group on the display, moving it half-way down the display
splash.x=display.width//2
splash.y=display.height//2
print("Resize and move the splash screen")

# append the supervisor.splash group to the displayed group.
mygroup.append(splash)
time.sleep(2)

# demonstrate how print statements scroll on the REPL/console display
print("Add some prints to show terminal scrolling:")
time.sleep(0.3)
for i in range(6):
    print("Line: {}".format(i))
    time.sleep(0.3)
time.sleep(1.5)

# Add bitmap rectangles to the display group
print("Add some displayio bitmap rectangles:")
time.sleep(1)

# Add the TileGrid to the Group
print("Add a pink rect.")
mygroup.append(tile_grid1)
time.sleep(0.5)
print("Add a cyan rect.")
mygroup.append(tile_grid2)
time.sleep(0.5)
print("Add a yellow rect.")
mygroup.append(tile_grid3)
time.sleep(0.5)

# print some more lines to show the console text scrolling, with 
# the bitmaps shown on the upper half of the display
for i in range(6):
    print("Another line feed: {}!".format(i))
    time.sleep(0.3)
time.sleep(3)
print("Ending the code")
time.sleep(1)

### If there is no serial connection, just the Blinka remains after the code is done.

### Have to reset the display to show(None) to see the "Code done running." text.
# display.show(None)
```
