### PR TITLE
add adafruit-circuitpython-typing to requirements-doc.txt

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -15,3 +15,6 @@ sphinx-rtd-theme
 sphinxcontrib-svg2pdfconverter
 readthedocs-sphinx-search
 myst-parser
+
+# For stubs and annotations
+adafruit-circuitpython-typing


### PR DESCRIPTION
I thought the requirements changes in #6041 were sufficient to fix the doc build failures, but that was not the case: https://github.com/adafruit/circuitpython/actions/runs/1900267735 (merge build)

Adding `adafruit-circuitpython-typing` to `requirements-doc.txt` as well.