### PR TITLE
fix automatic i2c enablement with rev C

### DIFF
--- a/ports/espressif/boards/adafruit_feather_esp32s2/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2/board.c
@@ -41,8 +41,16 @@ bool board_requests_safe_mode(void) {
 
 void reset_board(void) {
     // Turn on I2C power by default.
+
+    // set pin to input to find 'rest state'
+    gpio_set_direction(7, GPIO_MODE_DEF_INPUT);
+    // wait 1 millis for pull to activate
+    mp_hal_delay_ms(1);
+    // read rest state (off)
+    bool restlevel = gpio_get_level(7);
     gpio_set_direction(7, GPIO_MODE_DEF_OUTPUT);
-    gpio_set_level(7, false);
+    // flip it!
+    gpio_set_level(7, !restlevel);
 }
 
 void board_deinit(void) {

--- a/ports/espressif/boards/adafruit_feather_esp32s2/pins.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2/pins.c
@@ -17,6 +17,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D6), MP_ROM_PTR(&pin_GPIO6) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C_POWER_INVERTED), MP_ROM_PTR(&pin_GPIO7) },
+    { MP_ROM_QSTR(MP_QSTR_I2C_POWER), MP_ROM_PTR(&pin_GPIO7) },
     { MP_ROM_QSTR(MP_QSTR_D7), MP_ROM_PTR(&pin_GPIO7) },
 
     { MP_ROM_QSTR(MP_QSTR_A5), MP_ROM_PTR(&pin_GPIO8) },


### PR DESCRIPTION
rev C of the PCB has inverted-inverted polarity (e.g. now its what most would expect) this code should support both