### PR TITLE
update wifi module doc types to str

### DIFF
--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -76,7 +76,7 @@ const mp_obj_property_t wifi_radio_enabled_obj = {
                MP_ROM_NONE },
 };
 
-//|     hostname: str
+//|     hostname: Union[str | ReadableBuffer]
 //|     """Hostname for wifi interface. When the hostname is altered after interface started/connected
 //|        the changes would only be reflected once the interface restarts/reconnects."""
 //|
@@ -117,7 +117,7 @@ const mp_obj_property_t wifi_radio_hostname_obj = {
               MP_ROM_NONE},
 };
 
-//|     mac_address: str
+//|     mac_address: ReadableBuffer
 //|     """MAC address for the station. When the address is altered after interface is connected
 //|        the changes would only be reflected once the interface reconnects."""
 //|
@@ -149,7 +149,7 @@ const mp_obj_property_t wifi_radio_mac_address_obj = {
                MP_ROM_NONE },
 };
 
-//|     mac_address_ap: str
+//|     mac_address_ap: ReadableBuffer
 //|     """MAC address for the AP. When the address is altered after interface is started
 //|        the changes would only be reflected once the interface restarts."""
 //|
@@ -226,8 +226,8 @@ STATIC mp_obj_t wifi_radio_stop_station(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_station_obj, wifi_radio_stop_station);
 
 //|     def start_ap(self,
-//|                  ssid: str,
-//|                  password: str = b"",
+//|                  ssid: Union[str | ReadableBuffer],
+//|                  password: Union[str | ReadableBuffer] = "",
 //|                  *,
 //|                  channel: Optional[int] = 1,
 //|                  authmode: Optional[AuthMode],
@@ -304,11 +304,11 @@ STATIC mp_obj_t wifi_radio_stop_ap(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_ap_obj, wifi_radio_stop_ap);
 
 //|     def connect(self,
-//|                 ssid: str,
-//|                 password: str = b"",
+//|                 ssid: Union[str | ReadableBuffer],
+//|                 password: Union[str | ReadableBuffer] = "",
 //|                 *,
 //|                 channel: Optional[int] = 0,
-//|                 bssid: Optional[str] = b"",
+//|                 bssid: Optional[Union[str | ReadableBuffer]] = "",
 //|                 timeout: Optional[float] = None) -> None:
 //|         """Connects to the given ssid and waits for an ip address. Reconnections are handled
 //|            automatically once one connection succeeds.

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -76,7 +76,7 @@ const mp_obj_property_t wifi_radio_enabled_obj = {
                MP_ROM_NONE },
 };
 
-//|     hostname: ReadableBuffer
+//|     hostname: str
 //|     """Hostname for wifi interface. When the hostname is altered after interface started/connected
 //|        the changes would only be reflected once the interface restarts/reconnects."""
 //|
@@ -117,7 +117,7 @@ const mp_obj_property_t wifi_radio_hostname_obj = {
               MP_ROM_NONE},
 };
 
-//|     mac_address: ReadableBuffer
+//|     mac_address: str
 //|     """MAC address for the station. When the address is altered after interface is connected
 //|        the changes would only be reflected once the interface reconnects."""
 //|
@@ -149,7 +149,7 @@ const mp_obj_property_t wifi_radio_mac_address_obj = {
                MP_ROM_NONE },
 };
 
-//|     mac_address_ap: ReadableBuffer
+//|     mac_address_ap: str
 //|     """MAC address for the AP. When the address is altered after interface is started
 //|        the changes would only be reflected once the interface restarts."""
 //|
@@ -226,8 +226,8 @@ STATIC mp_obj_t wifi_radio_stop_station(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_station_obj, wifi_radio_stop_station);
 
 //|     def start_ap(self,
-//|                  ssid: ReadableBuffer,
-//|                  password: ReadableBuffer = b"",
+//|                  ssid: str,
+//|                  password: str = b"",
 //|                  *,
 //|                  channel: Optional[int] = 1,
 //|                  authmode: Optional[AuthMode],
@@ -304,11 +304,11 @@ STATIC mp_obj_t wifi_radio_stop_ap(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_ap_obj, wifi_radio_stop_ap);
 
 //|     def connect(self,
-//|                 ssid: ReadableBuffer,
-//|                 password: ReadableBuffer = b"",
+//|                 ssid: str,
+//|                 password: str = b"",
 //|                 *,
 //|                 channel: Optional[int] = 0,
-//|                 bssid: Optional[ReadableBuffer] = b"",
+//|                 bssid: Optional[str] = b"",
 //|                 timeout: Optional[float] = None) -> None:
 //|         """Connects to the given ssid and waits for an ip address. Reconnections are handled
 //|            automatically once one connection succeeds.


### PR DESCRIPTION
If I understand correctly this is the resolution that was discussed here: https://github.com/adafruit/Adafruit_CircuitPython_Typing/pull/5

Changed all of the ReadableBuffer typed arguments in `wifi` to `str`