### PR TITLE
Seeed_XIAO_nRF52840_Sense: Enable rgb status LED

### DIFF
--- a/ports/nrf/boards/Seeed_XIAO_nRF52840_Sense/mpconfigboard.h
+++ b/ports/nrf/boards/Seeed_XIAO_nRF52840_Sense/mpconfigboard.h
@@ -52,3 +52,8 @@
 
 #define DEFAULT_UART_BUS_RX         (&pin_P1_12)
 #define DEFAULT_UART_BUS_TX         (&pin_P1_11)
+
+#define CIRCUITPY_RGB_STATUS_INVERTED_PWM
+#define CIRCUITPY_RGB_STATUS_R      (&pin_P0_26)
+#define CIRCUITPY_RGB_STATUS_G      (&pin_P0_30)
+#define CIRCUITPY_RGB_STATUS_B      (&pin_P0_06)


### PR DESCRIPTION
Enable rgb status led with inverted pwm on Seeed_XIAO_nRF52840_Sense. Tested on hardware, it makes it much easier to get into bluetooth discovery mode!