### PR TITLE
Add missing BOARD_DICT_STANDARD_ITEMS to two boards

### DIFF
--- a/ports/nrf/boards/Seeed_XIAO_nRF52840_Sense/mpconfigboard.h
+++ b/ports/nrf/boards/Seeed_XIAO_nRF52840_Sense/mpconfigboard.h
@@ -30,8 +30,6 @@
 #define MICROPY_HW_BOARD_NAME       "Seeed XIAO nRF52840 Sense"
 #define MICROPY_HW_MCU_NAME         "nRF52840"
 
-#define MICROPY_HW_LED_STATUS       (&pin_P0_26)
-
 #if QSPI_FLASH_FILESYSTEM
 #define MICROPY_QSPI_DATA0                NRF_GPIO_PIN_MAP(0, 20)
 #define MICROPY_QSPI_DATA1                NRF_GPIO_PIN_MAP(0, 24)

--- a/ports/nrf/boards/Seeed_XIAO_nRF52840_Sense/pins.c
+++ b/ports/nrf/boards/Seeed_XIAO_nRF52840_Sense/pins.c
@@ -1,6 +1,8 @@
 #include "shared-bindings/board/__init__.h"
 
 STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
+    CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
+
     { MP_ROM_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_P0_02) },
     { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_P0_03) },
     { MP_ROM_QSTR(MP_QSTR_A2), MP_ROM_PTR(&pin_P0_28) },

--- a/ports/stm/boards/swan_r5/pins.c
+++ b/ports/stm/boards/swan_r5/pins.c
@@ -3,6 +3,8 @@
 
 // Core Feather Pins
 STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
+    CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
+
     { MP_ROM_QSTR(MP_QSTR_ENABLE_3V3), MP_ROM_PTR(&pin_PE04) },
     { MP_ROM_QSTR(MP_QSTR_DISCHARGE_3V3), MP_ROM_PTR(&pin_PE06) },
     { MP_ROM_QSTR(MP_QSTR_DISABLE_DISCHARGING), MP_ROM_TRUE },


### PR DESCRIPTION
Seeed_XIAO_nRF52840_Sense and swan_r5 were missing `CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS`. Tested on the seeed xiao board.