### PR TITLE
Fix freeze on bitmaptools.dither

### DIFF
--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -691,7 +691,7 @@ static void write_pixels(displayio_bitmap_t *bitmap, int y, bool *data) {
         uint32_t *pixel_data = (uint32_t *)(bitmap->data + bitmap->stride * y);
         for (int i = 0; i < bitmap->stride; i++) {
             uint32_t p = 0;
-            for (int j = 0; j < 32; i++) {
+            for (int j = 0; j < 32; j++) {
                 p = (p << 1);
                 if (*data++) {
                     p |= 1;


### PR DESCRIPTION
This tiny PR fixes a typo in bitmaptools.

Test code:
```
import board
import displayio as dpio
import bitmaptools as bmt

disp = board.DISPLAY

# Read RGB565 bitmap
with open("test.bmp", "rb") as f :
  f.seek(0x0a)
  offset = int.from_bytes(f.read(4), "little")
  f.seek(0x12)
  width  = int.from_bytes(f.read(4), "little")
  height = int.from_bytes(f.read(4), "little")
  f.seek(offset)
  bmp = dpio.Bitmap(width, height, 65536)
  bmt.readinto(bmp, f, 16)
pal = dpio.ColorConverter(input_colorspace = dpio.Colorspace.RGB565)
tg = dpio.TileGrid(bmp, pixel_shader = pal)
g = dpio.Group()
g.append(tg)
disp.show(g)

bm2 = dpio.Bitmap(width, height, 2)
pa2 = dpio.Palette(2)
pa2[1] = 0xFFFFFF
bm2.fill(1)
tg2 = dpio.TileGrid(bm2, pixel_shader = pa2)
tg2.x = width + 10
g.append(tg2)

bmt.dither(bm2, bmp, dpio.Colorspace.RGB565)    # freeze here
```
It is tested on Wio Terminal with `test.bmp`.

[test.bmp.zip](https://github.com/adafruit/circuitpython/files/8184178/test.bmp.zip)
