### PR TITLE
Add support for 9-bit mode to displayio.FourWire

### DIFF
--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -43,7 +43,7 @@
 //|     """Manage updating a display over SPI four wire protocol in the background while Python code runs.
 //|     It doesn't handle display initialization."""
 //|
-//|     def __init__(self, spi_bus: busio.SPI, *, command: microcontroller.Pin, chip_select: microcontroller.Pin, reset: Optional[microcontroller.Pin] = None, baudrate: int = 24000000, polarity: int = 0, phase: int = 0) -> None:
+//|     def __init__(self, spi_bus: busio.SPI, *, command: Optional[microcontroller.Pin], chip_select: microcontroller.Pin, reset: Optional[microcontroller.Pin] = None, baudrate: int = 24000000, polarity: int = 0, phase: int = 0) -> None:
 //|         """Create a FourWire object associated with the given pins.
 //|
 //|         The SPI bus and pins are then in use by the display until `displayio.release_displays()` is
@@ -51,8 +51,13 @@
 //|         is done.) So, the first time you initialize a display bus in code.py you should call
 //|         :py:func:`displayio.release_displays` first, otherwise it will error after the first code.py run.
 //|
+//|         If the ``command`` pin is not specified, a 9-bit SPI mode will be simulated by adding a
+//|         data/command bit to every bit being transmitted, and splitting the resulting data back
+//|         into 8-bit bytes for transmission. The extra bits that this creates at the end are ignored
+//|         by the receiving device.
+//|
 //|         :param busio.SPI spi_bus: The SPI bus that make up the clock and data lines
-//|         :param microcontroller.Pin command: Data or command pin
+//|         :param microcontroller.Pin command: Data or command pin. When None, 9-bit SPI is simulated.
 //|         :param microcontroller.Pin chip_select: Chip select pin
 //|         :param microcontroller.Pin reset: Reset pin. When None only software reset can be used
 //|         :param int baudrate: Maximum baudrate in Hz for the display on the bus
@@ -65,7 +70,7 @@ STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_
     enum { ARG_spi_bus, ARG_command, ARG_chip_select, ARG_reset, ARG_baudrate, ARG_polarity, ARG_phase };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_spi_bus, MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_command, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
+        { MP_QSTR_command, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = mp_const_none} },
         { MP_QSTR_chip_select, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_reset, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = mp_const_none} },
         { MP_QSTR_baudrate, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 24000000} },
@@ -75,7 +80,7 @@ STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *command = validate_obj_is_free_pin(args[ARG_command].u_obj);
+    const mcu_pin_obj_t *command = validate_obj_is_free_pin_or_none(args[ARG_command].u_obj);
     const mcu_pin_obj_t *chip_select = validate_obj_is_free_pin(args[ARG_chip_select].u_obj);
     const mcu_pin_obj_t *reset = validate_obj_is_free_pin_or_none(args[ARG_reset].u_obj);
 


### PR DESCRIPTION
If the ``command`` pin is None, that information will instead be
sent as a ninth bit in the SPI transactions.

Fix #6109 

Note: I verified the code produces correct output, however, I can't test it with a real display until #6113 is fixed.