### PR TITLE
Xiao led pins

### DIFF
--- a/ports/atmel-samd/boards/seeeduino_xiao/pins.c
+++ b/ports/atmel-samd/boards/seeeduino_xiao/pins.c
@@ -44,7 +44,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_PA09) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_PA08) },
 
-    // LED pins
+    // LED pins  ... note XIAO is wired so high/1/True turns LED OFF
+    //                                     low/0/False turns LED ON
     //    duplicate names for test LED ... see D13
     { MP_ROM_QSTR(MP_QSTR_LED),   MP_ROM_PTR(&pin_PA17) }, // 
     { MP_ROM_QSTR(MP_QSTR_YELLOW_LED),   MP_ROM_PTR(&pin_PA17) }, 

--- a/ports/atmel-samd/boards/seeeduino_xiao/pins.c
+++ b/ports/atmel-samd/boards/seeeduino_xiao/pins.c
@@ -29,7 +29,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D8), MP_ROM_PTR(&pin_PA07) },
     { MP_ROM_QSTR(MP_QSTR_D9), MP_ROM_PTR(&pin_PA05) },
     { MP_ROM_QSTR(MP_QSTR_D10), MP_ROM_PTR(&pin_PA06) },
-    { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_PA17) },
+    { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_PA17) },  // yellow_led
 
     // UART pins
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_PB08) },
@@ -45,8 +45,16 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_PA08) },
 
     // LED pins
-    { MP_ROM_QSTR(MP_QSTR_LED),   MP_ROM_PTR(&pin_PA17) }, // status
-    { MP_ROM_QSTR(MP_QSTR_BLUE_LED),   MP_ROM_PTR(&pin_PA17) },
+    //    duplicate names for test LED ... see D13
+    { MP_ROM_QSTR(MP_QSTR_LED),   MP_ROM_PTR(&pin_PA17) }, // 
+    { MP_ROM_QSTR(MP_QSTR_YELLOW_LED),   MP_ROM_PTR(&pin_PA17) }, 
+    //    2 blue LEDs ... uart rx/tx indicator is default use
+    { MP_ROM_QSTR(MP_QSTR_RX_LED),   MP_ROM_PTR(&pin_PA18) },
+    { MP_ROM_QSTR(MP_QSTR_TX_LED),   MP_ROM_PTR(&pin_PA19) },
+    //    create duplicate mappings with BLUE in name
+    { MP_ROM_QSTR(MP_QSTR_BLUE1_LED),   MP_ROM_PTR(&pin_PA18) },
+    { MP_ROM_QSTR(MP_QSTR_BLUE2_LED),   MP_ROM_PTR(&pin_PA19) },
+    
 
     // Comm objects
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },

--- a/ports/atmel-samd/boards/seeeduino_xiao/pins.c
+++ b/ports/atmel-samd/boards/seeeduino_xiao/pins.c
@@ -47,15 +47,14 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     // LED pins  ... note XIAO is wired so high/1/True turns LED OFF
     //                                     low/0/False turns LED ON
     //    duplicate names for test LED ... see D13
-    { MP_ROM_QSTR(MP_QSTR_LED),   MP_ROM_PTR(&pin_PA17) }, // 
-    { MP_ROM_QSTR(MP_QSTR_YELLOW_LED),   MP_ROM_PTR(&pin_PA17) }, 
+    { MP_ROM_QSTR(MP_QSTR_LED),   MP_ROM_PTR(&pin_PA17) },
+    { MP_ROM_QSTR(MP_QSTR_YELLOW_LED),   MP_ROM_PTR(&pin_PA17) },
     //    2 blue LEDs ... uart rx/tx indicator is default use
     { MP_ROM_QSTR(MP_QSTR_RX_LED),   MP_ROM_PTR(&pin_PA18) },
     { MP_ROM_QSTR(MP_QSTR_TX_LED),   MP_ROM_PTR(&pin_PA19) },
     //    create duplicate mappings with BLUE in name
     { MP_ROM_QSTR(MP_QSTR_BLUE1_LED),   MP_ROM_PTR(&pin_PA18) },
     { MP_ROM_QSTR(MP_QSTR_BLUE2_LED),   MP_ROM_PTR(&pin_PA19) },
-    
 
     // Comm objects
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },

--- a/ports/atmel-samd/boards/seeeduino_xiao/pins.c
+++ b/ports/atmel-samd/boards/seeeduino_xiao/pins.c
@@ -45,7 +45,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_LED_INVERTED),   MP_ROM_PTR(&pin_PA17) },
     { MP_ROM_QSTR(MP_QSTR_YELLOW_LED_INVERTED),   MP_ROM_PTR(&pin_PA17) },
-    
+
     { MP_ROM_QSTR(MP_QSTR_RX_LED_INVERTED),   MP_ROM_PTR(&pin_PA18) },
     { MP_ROM_QSTR(MP_QSTR_BLUE_LED1_INVERTED),   MP_ROM_PTR(&pin_PA18) },
 

--- a/ports/atmel-samd/boards/seeeduino_xiao/pins.c
+++ b/ports/atmel-samd/boards/seeeduino_xiao/pins.c
@@ -43,17 +43,14 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_PA09) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_PA08) },
 
-    // LED pins  ... note XIAO is wired so high/1/True turns LED OFF
-    //                                     low/0/False turns LED ON
-    //    duplicate names for test LED ... see D13
-    { MP_ROM_QSTR(MP_QSTR_LED),   MP_ROM_PTR(&pin_PA17) },
-    { MP_ROM_QSTR(MP_QSTR_YELLOW_LED),   MP_ROM_PTR(&pin_PA17) },
-    //    2 blue LEDs ... uart rx/tx indicator is default use
-    { MP_ROM_QSTR(MP_QSTR_RX_LED),   MP_ROM_PTR(&pin_PA18) },
-    { MP_ROM_QSTR(MP_QSTR_TX_LED),   MP_ROM_PTR(&pin_PA19) },
-    //    create duplicate mappings with BLUE in name
-    { MP_ROM_QSTR(MP_QSTR_BLUE1_LED),   MP_ROM_PTR(&pin_PA18) },
-    { MP_ROM_QSTR(MP_QSTR_BLUE2_LED),   MP_ROM_PTR(&pin_PA19) },
+    { MP_ROM_QSTR(MP_QSTR_LED_INVERTED),   MP_ROM_PTR(&pin_PA17) },
+    { MP_ROM_QSTR(MP_QSTR_YELLOW_LED_INVERTED),   MP_ROM_PTR(&pin_PA17) },
+    
+    { MP_ROM_QSTR(MP_QSTR_RX_LED_INVERTED),   MP_ROM_PTR(&pin_PA18) },
+    { MP_ROM_QSTR(MP_QSTR_BLUE_LED1_INVERTED),   MP_ROM_PTR(&pin_PA18) },
+
+    { MP_ROM_QSTR(MP_QSTR_TX_LED_INVERTED),   MP_ROM_PTR(&pin_PA19) },
+    { MP_ROM_QSTR(MP_QSTR_BLUE_LED2_INVERTED),   MP_ROM_PTR(&pin_PA19) },
 
     // Comm objects
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },

--- a/ports/atmel-samd/boards/seeeduino_xiao/pins.c
+++ b/ports/atmel-samd/boards/seeeduino_xiao/pins.c
@@ -29,7 +29,6 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D8), MP_ROM_PTR(&pin_PA07) },
     { MP_ROM_QSTR(MP_QSTR_D9), MP_ROM_PTR(&pin_PA05) },
     { MP_ROM_QSTR(MP_QSTR_D10), MP_ROM_PTR(&pin_PA06) },
-    { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_PA17) },  // yellow_led
 
     // UART pins
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_PB08) },


### PR DESCRIPTION
 Fixes #6120.

Modify and correct LED pin mappings and names for Seeduino SAMD21 Xiao
    Added YELLOW_LED=LED=D13,
          BLUE1_LED=RX_LED,
          BLUE2_LED=TX_LED
     Added clarifying comments about duplicate names for pins, and reverse wiring for LEDs on XIAO
