### PR TITLE
Add binascii crc32 to documentation

### DIFF
--- a/docs/library/binascii.rst
+++ b/docs/library/binascii.rst
@@ -36,3 +36,9 @@ Functions
    Encode binary data in base64 format, as in `RFC 3548
    <https://tools.ietf.org/html/rfc3548.html>`_. Returns the encoded data
    followed by a newline character, as a bytes object.
+
+.. function:: crc32(data, value=0, /)
+
+   Compute CRC-32, the 32-bit checksum of the bytes in *data* starting with an
+   initial CRC of *value*. The default initial CRC is 0. The algorithm is
+   consistent with the ZIP file checksum.


### PR DESCRIPTION
Document `binascii.crc32()` (added in #5969).