### PR TITLE
Update data argument in displayio.FourWire.send()

### DIFF
--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -118,7 +118,7 @@ STATIC mp_obj_t displayio_fourwire_obj_reset(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(displayio_fourwire_reset_obj, displayio_fourwire_obj_reset);
 
-//|     def send(self, command: int, data: ReadableBuffer, *, toggle_every_byte: bool = False) -> None:
+//|     def send(self, command: int, data: Union[ReadableBuffer, str], *, toggle_every_byte: bool = False) -> None:
 //|         """Sends the given command value followed by the full set of data. Display state, such as
 //|         vertical scroll, set via ``send`` may or may not be reset once the code is done."""
 //|         ...


### PR DESCRIPTION
Resolves #6150 by adding `str` as a valid type for `data` in the type annotation for `displayio.FourWire.send()`