### PR TITLE
Further refine autoreload

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -25,7 +25,7 @@ msgstr ""
 #: main.c
 msgid ""
 "\n"
-"Code stopped by auto-reload.\n"
+"Code stopped by auto-reload. Reloading soon.\n"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -584,10 +584,6 @@ msgstr ""
 msgid "Brightness must be 0-1.0"
 msgstr ""
 
-#: shared-bindings/supervisor/__init__.c
-msgid "Brightness must be between 0 and 255"
-msgstr ""
-
 #: shared-bindings/displayio/Display.c
 #: shared-bindings/framebufferio/FramebufferDisplay.c
 msgid "Brightness not adjustable"
@@ -688,6 +684,7 @@ msgstr ""
 msgid "Can only alarm on two low pins from deep sleep."
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 msgid "Can't set CCCD on local Characteristic"
 msgstr ""
@@ -1605,6 +1602,7 @@ msgstr ""
 msgid "Nimble out of memory"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 msgid "No CCCD for this Characteristic"
 msgstr ""
@@ -3642,7 +3640,7 @@ msgstr ""
 msgid "matrix is not positive definite"
 msgstr ""
 
-#: shared-bindings/wifi/Radio.c
+#: ports/espressif/common-hal/wifi/Radio.c
 msgid "max_connections must be between 0 and 10"
 msgstr ""
 
@@ -4061,6 +4059,7 @@ msgstr ""
 #: ports/espressif/boards/adafruit_metro_esp32s2/mpconfigboard.h
 #: ports/espressif/boards/adafruit_qtpy_esp32s2/mpconfigboard.h
 #: ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/mpconfigboard.h
+#: ports/espressif/boards/ai_thinker_esp32-c3s-2m/mpconfigboard.h
 #: ports/espressif/boards/ai_thinker_esp32-c3s/mpconfigboard.h
 #: ports/espressif/boards/ai_thinker_esp_12k_nodemcu/mpconfigboard.h
 #: ports/espressif/boards/artisense_rd00/mpconfigboard.h
@@ -4068,6 +4067,7 @@ msgstr ""
 #: ports/espressif/boards/crumpspace_crumps2/mpconfigboard.h
 #: ports/espressif/boards/electroniccats_bastwifi/mpconfigboard.h
 #: ports/espressif/boards/espressif_esp32c3_devkitm_1_n4/mpconfigboard.h
+#: ports/espressif/boards/espressif_esp32s2_devkitc_1_n4r2/mpconfigboard.h
 #: ports/espressif/boards/espressif_esp32s3_box/mpconfigboard.h
 #: ports/espressif/boards/espressif_esp32s3_devkitc_1_n8/mpconfigboard.h
 #: ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r2/mpconfigboard.h
@@ -4083,6 +4083,7 @@ msgstr ""
 #: ports/espressif/boards/gravitech_cucumber_ms/mpconfigboard.h
 #: ports/espressif/boards/gravitech_cucumber_r/mpconfigboard.h
 #: ports/espressif/boards/gravitech_cucumber_rs/mpconfigboard.h
+#: ports/espressif/boards/hiibot_iots2/mpconfigboard.h
 #: ports/espressif/boards/lilygo_ttgo_t8_s2_st7789/mpconfigboard.h
 #: ports/espressif/boards/lolin_s2_mini/mpconfigboard.h
 #: ports/espressif/boards/lolin_s2_pico/mpconfigboard.h

--- a/ports/stm/supervisor/port.c
+++ b/ports/stm/supervisor/port.c
@@ -346,8 +346,6 @@ void port_enable_tick(void) {
     stm32_peripherals_rtc_assign_wkup_callback(supervisor_tick);
     stm32_peripherals_rtc_enable_wakeup_timer();
 }
-// TODO: what is this? can I get rid of it?
-extern volatile uint32_t autoreload_delay_ms;
 
 // Disable 1/1024 second tick.
 void port_disable_tick(void) {

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -82,7 +82,7 @@ void displayio_background(void) {
     if (mp_hal_is_interrupted()) {
         return;
     }
-    if (reload_requested) {
+    if (autoreload_ready()) {
         // Reload is about to happen, so don't redisplay.
         return;
     }

--- a/supervisor/shared/bluetooth/file_transfer.c
+++ b/supervisor/shared/bluetooth/file_transfer.c
@@ -325,8 +325,7 @@ STATIC uint8_t _process_write(const uint8_t *raw_buf, size_t command_len) {
     if (chunk_size == 0) {
         // Don't reload until everything is written out of the packet buffer.
         common_hal_bleio_packet_buffer_flush(&_transfer_packet_buffer);
-        // Trigger an autoreload
-        autoreload_start();
+        autoreload_trigger();
         return ANY_COMMAND;
     }
 
@@ -383,8 +382,7 @@ STATIC uint8_t _process_write_data(const uint8_t *raw_buf, size_t command_len) {
         #endif
         // Don't reload until everything is written out of the packet buffer.
         common_hal_bleio_packet_buffer_flush(&_transfer_packet_buffer);
-        // Trigger an autoreload
-        autoreload_start();
+        autoreload_trigger();
         return ANY_COMMAND;
     }
     return WRITE_DATA;
@@ -465,8 +463,7 @@ STATIC uint8_t _process_delete(const uint8_t *raw_buf, size_t command_len) {
     if (result == FR_OK) {
         // Don't reload until everything is written out of the packet buffer.
         common_hal_bleio_packet_buffer_flush(&_transfer_packet_buffer);
-        // Trigger an autoreload
-        autoreload_start();
+        autoreload_trigger();
     }
     return ANY_COMMAND;
 }
@@ -520,8 +517,7 @@ STATIC uint8_t _process_mkdir(const uint8_t *raw_buf, size_t command_len) {
     if (result == FR_OK) {
         // Don't reload until everything is written out of the packet buffer.
         common_hal_bleio_packet_buffer_flush(&_transfer_packet_buffer);
-        // Trigger an autoreload
-        autoreload_start();
+        autoreload_trigger();
     }
     return ANY_COMMAND;
 }
@@ -668,8 +664,7 @@ STATIC uint8_t _process_move(const uint8_t *raw_buf, size_t command_len) {
     if (result == FR_OK) {
         // Don't reload until everything is written out of the packet buffer.
         common_hal_bleio_packet_buffer_flush(&_transfer_packet_buffer);
-        // Trigger an autoreload
-        autoreload_start();
+        autoreload_trigger();
     }
     return ANY_COMMAND;
 }

--- a/supervisor/shared/reload.h
+++ b/supervisor/shared/reload.h
@@ -42,7 +42,8 @@ enum {
 
 enum {
     AUTORELOAD_SUSPEND_REPL = 0x1,
-    AUTORELOAD_SUSPEND_BLE = 0x2
+    AUTORELOAD_SUSPEND_BLE = 0x2,
+    AUTORELOAD_SUSPEND_USB = 0x4
 };
 
 typedef struct {
@@ -52,17 +53,29 @@ typedef struct {
 
 extern supervisor_allocation *next_code_allocation;
 
-extern volatile bool reload_requested;
-
+// Helper for exiting the VM and reloading immediately.
 void reload_initiate(supervisor_run_reason_t run_reason);
 
-void autoreload_start(void);
-void autoreload_reset(void);
+// Enabled state is user controllable and very sticky. We don't reset it.
 void autoreload_enable(void);
 void autoreload_disable(void);
 bool autoreload_is_enabled(void);
 
-// Temporarily turn autoreload off, for the given reason(s).
+// Start the autoreload process.
+void autoreload_trigger(void);
+// True when the autoreload should occur. (A trigger happened and the delay has
+// passed.)
+bool autoreload_ready(void);
+// Reset the autoreload timer in preparation for another trigger. Call when the
+// last trigger starts being executed.
+void autoreload_reset(void);
+// True when a trigger has occurred but we're still delaying in case another
+// trigger occurs.
+bool autoreload_pending(void);
+
+// Temporarily turn autoreload off, for the given reason(s). Autoreload triggers
+// will still be tracked so resuming with autoreload ready with cause an
+// immediate reload.
 // Used during the REPL or during parts of BLE workflow.
 void autoreload_suspend(uint32_t suspend_reason_mask);
 // Allow autoreloads again, for the given reason(s).

--- a/supervisor/shared/usb/usb_msc_flash.c
+++ b/supervisor/shared/usb/usb_msc_flash.c
@@ -185,6 +185,7 @@ int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void *buff
 int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t *buffer, uint32_t bufsize) {
     (void)lun;
     (void)offset;
+    autoreload_suspend(AUTORELOAD_SUSPEND_USB);
 
     const uint32_t block_count = bufsize / MSC_FLASH_BLOCK_SIZE;
 
@@ -215,7 +216,8 @@ void tud_msc_write10_complete_cb(uint8_t lun) {
     (void)lun;
 
     // This write is complete; initiate an autoreload.
-    autoreload_start();
+    autoreload_trigger();
+    autoreload_resume(AUTORELOAD_SUSPEND_USB);
 }
 
 // Invoked when received SCSI_CMD_INQUIRY


### PR DESCRIPTION
This unifies the delay into the post-run delay that also waits
for user input and fake sleep. This ensures we always delay.
Previous code would only delay if the code.py was running when
autoreload was triggered. Now it will always delay.

We also now suspend autoreload when a USB write starts and then
resume on completion. This should prevent reloading in between
sectors of a single write.