### PR TITLE
Re-enable BLE on MatrixPortal. Remove PortalBase

### DIFF
--- a/ports/atmel-samd/boards/matrixportal_m4/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/matrixportal_m4/mpconfigboard.mk
@@ -10,15 +10,12 @@ QSPI_FLASH_FILESYSTEM = 1
 EXTERNAL_FLASH_DEVICES = "S25FL116K, S25FL216K, GD25Q16C"
 LONGINT_IMPL = MPZ
 
-CIRCUITPY_BLEIO = 0
-CIRCUITPY_BLEIO_HCI = 0
 CIRCUITPY_ONEWIREIO = 0
 CIRCUITPY_PARALLELDISPLAY = 0
 CIRCUITPY_SDCARDIO = 0
 CIRCUITPY_SHARPDISPLAY = 0
 
 # Include these Python libraries in firmware.
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_PortalBase
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Requests
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_ESP32SPI
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel


### PR DESCRIPTION
We have a guide that uses it. It was removed in #6043 without
realizing that.

Fixes #6152