### PR TITLE
Explicitly ignore unused variables (fixes #6158)

### DIFF
--- a/py/bc.h
+++ b/py/bc.h
@@ -124,6 +124,11 @@
             D |= (z & 0x1) << n;                                    \
         }                                                           \
         S += 1;                                                     \
+        (void)E;                                                    \
+        (void)F;                                                    \
+        (void)A;                                                    \
+        (void)K;                                                    \
+        (void)D;                                                    \
     } while (0)
 
 #define MP_BC_PRELUDE_SIG_DECODE(ip) \


### PR DESCRIPTION
A macro in `py/bc.h` declares five variables that are used to hold data temporarily, without their values being used after the assignments. This causes "unused-but-set-variable" warnings in clang 13. We mark these variables as explicitly ignored to avoid this new warning.

Initially reported in #6158; the fix with `(void) var_name;` was suggested there and I was asked to open a PR with this fix.