### PR TITLE
fix ReloadException when in REPL 

### DIFF
--- a/supervisor/shared/reload.c
+++ b/supervisor/shared/reload.c
@@ -80,7 +80,7 @@ inline bool autoreload_is_enabled() {
 }
 
 void autoreload_trigger() {
-    if (autoreload_enabled) {
+    if (autoreload_enabled & !autoreload_suspended) {
         last_autoreload_trigger = supervisor_ticks_ms32();
         // Guard against the rare time that ticks is 0;
         if (last_autoreload_trigger == 0) {

--- a/supervisor/shared/usb/usb_msc_flash.c
+++ b/supervisor/shared/usb/usb_msc_flash.c
@@ -216,8 +216,8 @@ void tud_msc_write10_complete_cb(uint8_t lun) {
     (void)lun;
 
     // This write is complete; initiate an autoreload.
-    autoreload_trigger();
     autoreload_resume(AUTORELOAD_SUSPEND_USB);
+    autoreload_trigger();
 }
 
 // Invoked when received SCSI_CMD_INQUIRY


### PR DESCRIPTION
Do not raise ReloadException if in the REPL.
Also undo autoreload suspend before triggering autoreload. This is not imperative, but if `autoreload_trigger()` were to check the suspend state (it does not currently), it would have the wrong value. This was originally necessary when I was testing a different fix.

- Fixes #6159
- Fixes #6165 

Please test! I tested on macOS and Linux with a Metro M4 and a Feather RP2040,
modifying a running code.py, copying a 40kB file while running, and also editing code.py and copying a file when in the REPL.