### PR TITLE
Vectorio color index

### DIFF
--- a/shared-bindings/vectorio/Circle.c
+++ b/shared-bindings/vectorio/Circle.c
@@ -18,7 +18,8 @@
 //|            :param Union[~displayio.ColorConverter,~displayio.Palette] pixel_shader: The pixel shader that produces colors from values
 //|            :param int radius: The radius of the circle in pixels
 //|            :param int x: Initial x position of the axis.
-//|            :param int y: Initial y position of the axis."""
+//|            :param int y: Initial y position of the axis.
+//|            :param int color_index: Initial color_index to use when selecting color from the palette."""
 //|
 static mp_obj_t vectorio_circle_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pixel_shader, ARG_radius, ARG_x, ARG_y, ARG_color_index };

--- a/shared-bindings/vectorio/Circle.c
+++ b/shared-bindings/vectorio/Circle.c
@@ -21,12 +21,13 @@
 //|            :param int y: Initial y position of the axis."""
 //|
 static mp_obj_t vectorio_circle_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    enum { ARG_pixel_shader, ARG_radius, ARG_x, ARG_y };
+    enum { ARG_pixel_shader, ARG_radius, ARG_x, ARG_y, ARG_color_index };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pixel_shader, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_radius, MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_x, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
         { MP_QSTR_y, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
+        { MP_QSTR_color_index, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -38,7 +39,8 @@ static mp_obj_t vectorio_circle_make_new(const mp_obj_type_t *type, size_t n_arg
 
     vectorio_circle_t *self = m_new_obj(vectorio_circle_t);
     self->base.type = &vectorio_circle_type;
-    common_hal_vectorio_circle_construct(self, radius);
+    uint16_t color_index = args[ARG_color_index].u_int;
+    common_hal_vectorio_circle_construct(self, radius, color_index);
 
     // VectorShape parts
     mp_obj_t pixel_shader = args[ARG_pixel_shader].u_obj;
@@ -80,6 +82,29 @@ const mp_obj_property_t vectorio_circle_radius_obj = {
               MP_ROM_NONE},
 };
 
+//|     color_index : int
+//|     """The color_index of the circle as 0 based index of the palette."""
+//|
+STATIC mp_obj_t vectorio_circle_obj_get_color_index(mp_obj_t self_in) {
+    vectorio_circle_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_int(common_hal_vectorio_circle_get_color_index(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(vectorio_circle_get_color_index_obj, vectorio_circle_obj_get_color_index);
+
+STATIC mp_obj_t vectorio_circle_obj_set_color_index(mp_obj_t self_in, mp_obj_t color_index) {
+    vectorio_circle_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_vectorio_circle_set_color_index(self, mp_obj_get_int(color_index));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(vectorio_circle_set_color_index_obj, vectorio_circle_obj_set_color_index);
+
+const mp_obj_property_t vectorio_circle_color_index_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&vectorio_circle_get_color_index_obj,
+              (mp_obj_t)&vectorio_circle_set_color_index_obj,
+              MP_ROM_NONE},
+};
+
 
 // Documentation for properties inherited from VectorShape.
 
@@ -103,6 +128,7 @@ STATIC const mp_rom_map_elem_t vectorio_circle_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_radius), MP_ROM_PTR(&vectorio_circle_radius_obj) },
     { MP_ROM_QSTR(MP_QSTR_x), MP_ROM_PTR(&vectorio_vector_shape_x_obj) },
     { MP_ROM_QSTR(MP_QSTR_y), MP_ROM_PTR(&vectorio_vector_shape_y_obj) },
+    { MP_ROM_QSTR(MP_QSTR_color_index), MP_ROM_PTR(&vectorio_circle_color_index_obj) },
     { MP_ROM_QSTR(MP_QSTR_location), MP_ROM_PTR(&vectorio_vector_shape_location_obj) },
     { MP_ROM_QSTR(MP_QSTR_pixel_shader), MP_ROM_PTR(&vectorio_vector_shape_pixel_shader_obj) },
 };

--- a/shared-bindings/vectorio/Circle.h
+++ b/shared-bindings/vectorio/Circle.h
@@ -7,7 +7,7 @@
 
 extern const mp_obj_type_t vectorio_circle_type;
 
-void common_hal_vectorio_circle_construct(vectorio_circle_t *self, uint16_t radius);
+void common_hal_vectorio_circle_construct(vectorio_circle_t *self, uint16_t radius, uint16_t color_index);
 
 void common_hal_vectorio_circle_set_on_dirty(vectorio_circle_t *self, vectorio_event_t notification);
 
@@ -18,6 +18,9 @@ void common_hal_vectorio_circle_get_area(void *circle, displayio_area_t *out_are
 
 int16_t common_hal_vectorio_circle_get_radius(void *circle);
 void common_hal_vectorio_circle_set_radius(void *circle, int16_t radius);
+
+uint16_t common_hal_vectorio_circle_get_color_index(void *obj);
+void common_hal_vectorio_circle_set_color_index(void *obj, uint16_t color_index);
 
 mp_obj_t common_hal_vectorio_circle_get_draw_protocol(void *circle);
 

--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -25,7 +25,8 @@
 //|             shader that produces colors from values
 //|         :param List[Tuple[int,int]] points: Vertices for the polygon
 //|         :param int x: Initial screen x position of the 0,0 origin in the points list.
-//|         :param int y: Initial screen y position of the 0,0 origin in the points list."""
+//|         :param int y: Initial screen y position of the 0,0 origin in the points list.
+//|         :param int color_index: Initial color_index to use when selecting color from the palette."""
 //|
 static mp_obj_t vectorio_polygon_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pixel_shader, ARG_points_list, ARG_x, ARG_y, ARG_color_index };

--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -28,12 +28,13 @@
 //|         :param int y: Initial screen y position of the 0,0 origin in the points list."""
 //|
 static mp_obj_t vectorio_polygon_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    enum { ARG_pixel_shader, ARG_points_list, ARG_x, ARG_y };
+    enum { ARG_pixel_shader, ARG_points_list, ARG_x, ARG_y, ARG_color_index };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pixel_shader, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_points, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_x, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
         { MP_QSTR_y, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
+        { MP_QSTR_color_index, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -43,7 +44,8 @@ static mp_obj_t vectorio_polygon_make_new(const mp_obj_type_t *type, size_t n_ar
     vectorio_polygon_t *self = m_new_obj(vectorio_polygon_t);
     self->base.type = &vectorio_polygon_type;
 
-    common_hal_vectorio_polygon_construct(self, points_list);
+    uint16_t color_index = args[ARG_color_index].u_int;
+    common_hal_vectorio_polygon_construct(self, points_list, color_index);
 
     // VectorShape parts
     mp_obj_t pixel_shader = args[ARG_pixel_shader].u_obj;
@@ -86,6 +88,29 @@ const mp_obj_property_t vectorio_polygon_points_obj = {
               MP_ROM_NONE},
 };
 
+//|     color_index : int
+//|     """The color_index of the polygon as 0 based index of the palette."""
+//|
+STATIC mp_obj_t vectorio_polygon_obj_get_color_index(mp_obj_t self_in) {
+    vectorio_polygon_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_int(common_hal_vectorio_polygon_get_color_index(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(vectorio_polygon_get_color_index_obj, vectorio_polygon_obj_get_color_index);
+
+STATIC mp_obj_t vectorio_polygon_obj_set_color_index(mp_obj_t self_in, mp_obj_t color_index) {
+    vectorio_polygon_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_vectorio_polygon_set_color_index(self, mp_obj_get_int(color_index));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(vectorio_polygon_set_color_index_obj, vectorio_polygon_obj_set_color_index);
+
+const mp_obj_property_t vectorio_polygon_color_index_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&vectorio_polygon_get_color_index_obj,
+              (mp_obj_t)&vectorio_polygon_set_color_index_obj,
+              MP_ROM_NONE},
+};
+
 
 // Documentation for properties inherited from VectorShape.
 
@@ -109,6 +134,7 @@ STATIC const mp_rom_map_elem_t vectorio_polygon_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_points), MP_ROM_PTR(&vectorio_polygon_points_obj) },
     { MP_ROM_QSTR(MP_QSTR_x), MP_ROM_PTR(&vectorio_vector_shape_x_obj) },
     { MP_ROM_QSTR(MP_QSTR_y), MP_ROM_PTR(&vectorio_vector_shape_y_obj) },
+    { MP_ROM_QSTR(MP_QSTR_color_index), MP_ROM_PTR(&vectorio_polygon_color_index_obj) },
     { MP_ROM_QSTR(MP_QSTR_location), MP_ROM_PTR(&vectorio_vector_shape_location_obj) },
     { MP_ROM_QSTR(MP_QSTR_pixel_shader), MP_ROM_PTR(&vectorio_vector_shape_pixel_shader_obj) },
 };

--- a/shared-bindings/vectorio/Polygon.h
+++ b/shared-bindings/vectorio/Polygon.h
@@ -7,7 +7,7 @@
 
 extern const mp_obj_type_t vectorio_polygon_type;
 
-void common_hal_vectorio_polygon_construct(vectorio_polygon_t *self, mp_obj_t points_list);
+void common_hal_vectorio_polygon_construct(vectorio_polygon_t *self, mp_obj_t points_list, uint16_t color_index);
 void common_hal_vectorio_polygon_set_on_dirty(vectorio_polygon_t *self, vectorio_event_t notification);
 
 
@@ -19,6 +19,9 @@ void common_hal_vectorio_polygon_get_area(void *polygon, displayio_area_t *out_a
 
 mp_obj_t common_hal_vectorio_polygon_get_points(vectorio_polygon_t *self);
 void common_hal_vectorio_polygon_set_points(vectorio_polygon_t *self, mp_obj_t points_list);
+
+uint16_t common_hal_vectorio_polygon_get_color_index(void *obj);
+void common_hal_vectorio_polygon_set_color_index(void *obj, uint16_t color_index);
 
 mp_obj_t common_hal_vectorio_polygon_get_draw_protocol(void *polygon);
 

--- a/shared-bindings/vectorio/Rectangle.c
+++ b/shared-bindings/vectorio/Rectangle.c
@@ -18,17 +18,17 @@
 //|            :param int height: The number of pixels high
 //|            :param int x: Initial x position of the top left corner.
 //|            :param int y: Initial y position of the top left corner.
-//|            :param int color_number: Initial color_number to use when selecting color from the palette."""
+//|            :param int color_index: Initial color_index to use when selecting color from the palette."""
 //|
 static mp_obj_t vectorio_rectangle_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    enum { ARG_pixel_shader, ARG_width, ARG_height, ARG_x, ARG_y, ARG_color_number };
+    enum { ARG_pixel_shader, ARG_width, ARG_height, ARG_x, ARG_y, ARG_color_index };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pixel_shader, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_width, MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_height, MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_x, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
         { MP_QSTR_y, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
-        { MP_QSTR_color_number, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 1} },
+        { MP_QSTR_color_index, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -44,8 +44,8 @@ static mp_obj_t vectorio_rectangle_make_new(const mp_obj_type_t *type, size_t n_
 
     vectorio_rectangle_t *self = m_new_obj(vectorio_rectangle_t);
     self->base.type = &vectorio_rectangle_type;
-    int32_t color_number = args[ARG_color_number].u_int;
-    common_hal_vectorio_rectangle_construct(self, width, height, color_number);
+    uint16_t color_index = args[ARG_color_index].u_int;
+    common_hal_vectorio_rectangle_construct(self, width, height, color_index);
 
     // VectorShape parts
     mp_obj_t pixel_shader = args[ARG_pixel_shader].u_obj;
@@ -109,26 +109,26 @@ const mp_obj_property_t vectorio_rectangle_height_obj = {
               MP_ROM_NONE},
 };
 
-//|     color_number : int
-//|     """The color_number of the rectangle in 1 based index of the palette."""
+//|     color_index : int
+//|     """The color_index of the rectangle in 1 based index of the palette."""
 //|
-STATIC mp_obj_t vectorio_rectangle_obj_get_color_number(mp_obj_t self_in) {
+STATIC mp_obj_t vectorio_rectangle_obj_get_color_index(mp_obj_t self_in) {
     vectorio_rectangle_t *self = MP_OBJ_TO_PTR(self_in);
-    return mp_obj_new_int(common_hal_vectorio_rectangle_get_color_number(self));
+    return mp_obj_new_int(common_hal_vectorio_rectangle_get_color_index(self));
 }
-MP_DEFINE_CONST_FUN_OBJ_1(vectorio_rectangle_get_color_number_obj, vectorio_rectangle_obj_get_color_number);
+MP_DEFINE_CONST_FUN_OBJ_1(vectorio_rectangle_get_color_index_obj, vectorio_rectangle_obj_get_color_index);
 
-STATIC mp_obj_t vectorio_rectangle_obj_set_color_number(mp_obj_t self_in, mp_obj_t color_number) {
+STATIC mp_obj_t vectorio_rectangle_obj_set_color_index(mp_obj_t self_in, mp_obj_t color_index) {
     vectorio_rectangle_t *self = MP_OBJ_TO_PTR(self_in);
-    common_hal_vectorio_rectangle_set_color_number(self, mp_obj_get_int(color_number));
+    common_hal_vectorio_rectangle_set_color_index(self, mp_obj_get_int(color_index));
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_2(vectorio_rectangle_set_color_number_obj, vectorio_rectangle_obj_set_color_number);
+MP_DEFINE_CONST_FUN_OBJ_2(vectorio_rectangle_set_color_index_obj, vectorio_rectangle_obj_set_color_index);
 
-const mp_obj_property_t vectorio_rectangle_color_number_obj = {
+const mp_obj_property_t vectorio_rectangle_color_index_obj = {
     .base.type = &mp_type_property,
-    .proxy = {(mp_obj_t)&vectorio_rectangle_get_color_number_obj,
-              (mp_obj_t)&vectorio_rectangle_set_color_number_obj,
+    .proxy = {(mp_obj_t)&vectorio_rectangle_get_color_index_obj,
+              (mp_obj_t)&vectorio_rectangle_set_color_index_obj,
               MP_ROM_NONE},
 };
 
@@ -153,7 +153,7 @@ STATIC const mp_rom_map_elem_t vectorio_rectangle_locals_dict_table[] = {
     // Properties
     { MP_ROM_QSTR(MP_QSTR_x), MP_ROM_PTR(&vectorio_vector_shape_x_obj) },
     { MP_ROM_QSTR(MP_QSTR_y), MP_ROM_PTR(&vectorio_vector_shape_y_obj) },
-    { MP_ROM_QSTR(MP_QSTR_color_number), MP_ROM_PTR(&vectorio_rectangle_color_number_obj) },
+    { MP_ROM_QSTR(MP_QSTR_color_index), MP_ROM_PTR(&vectorio_rectangle_color_index_obj) },
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&vectorio_rectangle_width_obj) },
     { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&vectorio_rectangle_height_obj) },
     { MP_ROM_QSTR(MP_QSTR_location), MP_ROM_PTR(&vectorio_vector_shape_location_obj) },

--- a/shared-bindings/vectorio/Rectangle.c
+++ b/shared-bindings/vectorio/Rectangle.c
@@ -17,16 +17,18 @@
 //|            :param int width: The number of pixels wide
 //|            :param int height: The number of pixels high
 //|            :param int x: Initial x position of the top left corner.
-//|            :param int y: Initial y position of the top left corner."""
+//|            :param int y: Initial y position of the top left corner.
+//|            :param int color_number: Initial color_number to use when selecting color from the palette."""
 //|
 static mp_obj_t vectorio_rectangle_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    enum { ARG_pixel_shader, ARG_width, ARG_height, ARG_x, ARG_y };
+    enum { ARG_pixel_shader, ARG_width, ARG_height, ARG_x, ARG_y, ARG_color_number };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pixel_shader, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_width, MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_height, MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_x, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
         { MP_QSTR_y, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
+        { MP_QSTR_color_number, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 1} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -42,7 +44,8 @@ static mp_obj_t vectorio_rectangle_make_new(const mp_obj_type_t *type, size_t n_
 
     vectorio_rectangle_t *self = m_new_obj(vectorio_rectangle_t);
     self->base.type = &vectorio_rectangle_type;
-    common_hal_vectorio_rectangle_construct(self, width, height);
+    int32_t color_number = args[ARG_color_number].u_int;
+    common_hal_vectorio_rectangle_construct(self, width, height, color_number);
 
     // VectorShape parts
     mp_obj_t pixel_shader = args[ARG_pixel_shader].u_obj;
@@ -106,6 +109,29 @@ const mp_obj_property_t vectorio_rectangle_height_obj = {
               MP_ROM_NONE},
 };
 
+//|     color_number : int
+//|     """The color_number of the rectangle in 1 based index of the palette."""
+//|
+STATIC mp_obj_t vectorio_rectangle_obj_get_color_number(mp_obj_t self_in) {
+    vectorio_rectangle_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_int(common_hal_vectorio_rectangle_get_color_number(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(vectorio_rectangle_get_color_number_obj, vectorio_rectangle_obj_get_color_number);
+
+STATIC mp_obj_t vectorio_rectangle_obj_set_color_number(mp_obj_t self_in, mp_obj_t color_number) {
+    vectorio_rectangle_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_vectorio_rectangle_set_color_number(self, mp_obj_get_int(color_number));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(vectorio_rectangle_set_color_number_obj, vectorio_rectangle_obj_set_color_number);
+
+const mp_obj_property_t vectorio_rectangle_color_number_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&vectorio_rectangle_get_color_number_obj,
+              (mp_obj_t)&vectorio_rectangle_set_color_number_obj,
+              MP_ROM_NONE},
+};
+
 // Documentation for properties inherited from VectorShape.
 
 //|     x : int
@@ -127,6 +153,7 @@ STATIC const mp_rom_map_elem_t vectorio_rectangle_locals_dict_table[] = {
     // Properties
     { MP_ROM_QSTR(MP_QSTR_x), MP_ROM_PTR(&vectorio_vector_shape_x_obj) },
     { MP_ROM_QSTR(MP_QSTR_y), MP_ROM_PTR(&vectorio_vector_shape_y_obj) },
+    { MP_ROM_QSTR(MP_QSTR_color_number), MP_ROM_PTR(&vectorio_rectangle_color_number_obj) },
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&vectorio_rectangle_width_obj) },
     { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&vectorio_rectangle_height_obj) },
     { MP_ROM_QSTR(MP_QSTR_location), MP_ROM_PTR(&vectorio_vector_shape_location_obj) },

--- a/shared-bindings/vectorio/Rectangle.h
+++ b/shared-bindings/vectorio/Rectangle.h
@@ -7,7 +7,7 @@
 
 extern const mp_obj_type_t vectorio_rectangle_type;
 
-void common_hal_vectorio_rectangle_construct(vectorio_rectangle_t *self, uint32_t width, uint32_t height, uint32_t color_index);
+void common_hal_vectorio_rectangle_construct(vectorio_rectangle_t *self, uint32_t width, uint32_t height, uint16_t color_index);
 void common_hal_vectorio_rectangle_set_on_dirty(vectorio_rectangle_t *self, vectorio_event_t on_dirty);
 
 uint32_t common_hal_vectorio_rectangle_get_pixel(void *rectangle, int16_t x, int16_t y);
@@ -18,8 +18,9 @@ mp_obj_t common_hal_vectorio_rectangle_get_draw_protocol(void *rectangle);
 
 int16_t common_hal_vectorio_rectangle_get_width(void *obj);
 void common_hal_vectorio_rectangle_set_width(void *obj, int16_t width);
-int16_t common_hal_vectorio_rectangle_get_color_number(void *obj);
-void common_hal_vectorio_rectangle_set_color_number(void *obj, int16_t color_number);
+
+uint16_t common_hal_vectorio_rectangle_get_color_index(void *obj);
+void common_hal_vectorio_rectangle_set_color_index(void *obj, uint16_t color_index);
 
 int16_t common_hal_vectorio_rectangle_get_height(void *obj);
 void common_hal_vectorio_rectangle_set_height(void *obj, int16_t height);

--- a/shared-bindings/vectorio/Rectangle.h
+++ b/shared-bindings/vectorio/Rectangle.h
@@ -7,7 +7,7 @@
 
 extern const mp_obj_type_t vectorio_rectangle_type;
 
-void common_hal_vectorio_rectangle_construct(vectorio_rectangle_t *self, uint32_t width, uint32_t height);
+void common_hal_vectorio_rectangle_construct(vectorio_rectangle_t *self, uint32_t width, uint32_t height, uint32_t color_index);
 void common_hal_vectorio_rectangle_set_on_dirty(vectorio_rectangle_t *self, vectorio_event_t on_dirty);
 
 uint32_t common_hal_vectorio_rectangle_get_pixel(void *rectangle, int16_t x, int16_t y);
@@ -18,6 +18,8 @@ mp_obj_t common_hal_vectorio_rectangle_get_draw_protocol(void *rectangle);
 
 int16_t common_hal_vectorio_rectangle_get_width(void *obj);
 void common_hal_vectorio_rectangle_set_width(void *obj, int16_t width);
+int16_t common_hal_vectorio_rectangle_get_color_number(void *obj);
+void common_hal_vectorio_rectangle_set_color_number(void *obj, int16_t color_number);
 
 int16_t common_hal_vectorio_rectangle_get_height(void *obj);
 void common_hal_vectorio_rectangle_set_height(void *obj, int16_t height);

--- a/shared-module/vectorio/Circle.c
+++ b/shared-module/vectorio/Circle.c
@@ -7,9 +7,10 @@
 #include "stdlib.h"
 
 
-void common_hal_vectorio_circle_construct(vectorio_circle_t *self, uint16_t radius) {
+void common_hal_vectorio_circle_construct(vectorio_circle_t *self, uint16_t radius, uint16_t color_index) {
     self->radius = radius;
     self->on_dirty.obj = NULL;
+    self->color_index = color_index + 1;
 }
 
 void common_hal_vectorio_circle_set_on_dirty(vectorio_circle_t *self, vectorio_event_t on_dirty) {
@@ -26,7 +27,7 @@ uint32_t common_hal_vectorio_circle_get_pixel(void *obj, int16_t x, int16_t y) {
     x = abs(x);
     y = abs(y);
     if (x + y <= radius) {
-        return 1;
+        return self->color_index;
     }
     if (x > radius) {
         return 0;
@@ -35,7 +36,7 @@ uint32_t common_hal_vectorio_circle_get_pixel(void *obj, int16_t x, int16_t y) {
         return 0;
     }
     const bool pythagorasSmallerThanRadius = (int32_t)x * x + (int32_t)y * y <= (int32_t)radius * radius;
-    return pythagorasSmallerThanRadius ? 1 : 0;
+    return pythagorasSmallerThanRadius ? self->color_index : 0;
 }
 
 
@@ -55,6 +56,19 @@ int16_t common_hal_vectorio_circle_get_radius(void *obj) {
 void common_hal_vectorio_circle_set_radius(void *obj, int16_t radius) {
     vectorio_circle_t *self = obj;
     self->radius = abs(radius);
+    if (self->on_dirty.obj != NULL) {
+        self->on_dirty.event(self->on_dirty.obj);
+    }
+}
+
+uint16_t common_hal_vectorio_circle_get_color_index(void *obj) {
+    vectorio_circle_t *self = obj;
+    return self->color_index - 1;
+}
+
+void common_hal_vectorio_circle_set_color_index(void *obj, uint16_t color_index) {
+    vectorio_circle_t *self = obj;
+    self->color_index = abs(color_index + 1);
     if (self->on_dirty.obj != NULL) {
         self->on_dirty.event(self->on_dirty.obj);
     }

--- a/shared-module/vectorio/Circle.h
+++ b/shared-module/vectorio/Circle.h
@@ -10,6 +10,7 @@
 typedef struct {
     mp_obj_base_t base;
     uint16_t radius;
+    uint16_t color_index;
     vectorio_event_t on_dirty;
     mp_obj_t draw_protocol_instance;
 } vectorio_circle_t;

--- a/shared-module/vectorio/Polygon.c
+++ b/shared-module/vectorio/Polygon.c
@@ -61,11 +61,12 @@ static void _clobber_points_list(vectorio_polygon_t *self, mp_obj_t points_tuple
 
 
 
-void common_hal_vectorio_polygon_construct(vectorio_polygon_t *self, mp_obj_t points_list) {
+void common_hal_vectorio_polygon_construct(vectorio_polygon_t *self, mp_obj_t points_list, uint16_t color_index) {
     VECTORIO_POLYGON_DEBUG("%p polygon_construct: ", self);
     self->points_list = NULL;
     self->len = 0;
     self->on_dirty.obj = NULL;
+    self->color_index = color_index + 1;
     _clobber_points_list(self, points_list);
     VECTORIO_POLYGON_DEBUG("\n");
 }
@@ -181,10 +182,23 @@ uint32_t common_hal_vectorio_polygon_get_pixel(void *obj, int16_t x, int16_t y) 
         x1 = x2;
         y1 = y2;
     }
-    return winding_number == 0 ? 0 : 1;
+    return winding_number == 0 ? 0 : self->color_index;
 }
 
 mp_obj_t common_hal_vectorio_polygon_get_draw_protocol(void *polygon) {
     vectorio_polygon_t *self = polygon;
     return self->draw_protocol_instance;
+}
+
+uint16_t common_hal_vectorio_polygon_get_color_index(void *obj) {
+    vectorio_polygon_t *self = obj;
+    return self->color_index - 1;
+}
+
+void common_hal_vectorio_polygon_set_color_index(void *obj, uint16_t color_index) {
+    vectorio_polygon_t *self = obj;
+    self->color_index = abs(color_index + 1);
+    if (self->on_dirty.obj != NULL) {
+        self->on_dirty.event(self->on_dirty.obj);
+    }
 }

--- a/shared-module/vectorio/Polygon.h
+++ b/shared-module/vectorio/Polygon.h
@@ -11,6 +11,7 @@ typedef struct {
     // An int array[ x, y, ... ]
     int16_t *points_list;
     uint16_t len;
+    uint16_t color_index;
     vectorio_event_t on_dirty;
     mp_obj_t draw_protocol_instance;
 } vectorio_polygon_t;

--- a/shared-module/vectorio/Rectangle.c
+++ b/shared-module/vectorio/Rectangle.c
@@ -6,9 +6,10 @@
 #include "stdlib.h"
 
 
-void common_hal_vectorio_rectangle_construct(vectorio_rectangle_t *self, uint32_t width, uint32_t height) {
+void common_hal_vectorio_rectangle_construct(vectorio_rectangle_t *self, uint32_t width, uint32_t height, uint32_t color_number) {
     self->width = width;
     self->height = height;
+    self->color_number = color_number;
 }
 
 void common_hal_vectorio_rectangle_set_on_dirty(vectorio_rectangle_t *self, vectorio_event_t on_dirty) {
@@ -21,7 +22,7 @@ void common_hal_vectorio_rectangle_set_on_dirty(vectorio_rectangle_t *self, vect
 uint32_t common_hal_vectorio_rectangle_get_pixel(void *obj, int16_t x, int16_t y) {
     vectorio_rectangle_t *self = obj;
     if (x >= 0 && y >= 0 && x < self->width && y < self->height) {
-        return 1;
+        return self->color_number;
     }
     return 0;
 }
@@ -62,6 +63,19 @@ int16_t common_hal_vectorio_rectangle_get_height(void *obj) {
 void common_hal_vectorio_rectangle_set_height(void *obj, int16_t height) {
     vectorio_rectangle_t *self = obj;
     self->height = abs(height);
+    if (self->on_dirty.obj != NULL) {
+        self->on_dirty.event(self->on_dirty.obj);
+    }
+}
+
+int16_t common_hal_vectorio_rectangle_get_color_number(void *obj) {
+    vectorio_rectangle_t *self = obj;
+    return self->color_number;
+}
+
+void common_hal_vectorio_rectangle_set_color_number(void *obj, int16_t color_number) {
+    vectorio_rectangle_t *self = obj;
+    self->color_number = abs(color_number);
     if (self->on_dirty.obj != NULL) {
         self->on_dirty.event(self->on_dirty.obj);
     }

--- a/shared-module/vectorio/Rectangle.c
+++ b/shared-module/vectorio/Rectangle.c
@@ -6,10 +6,10 @@
 #include "stdlib.h"
 
 
-void common_hal_vectorio_rectangle_construct(vectorio_rectangle_t *self, uint32_t width, uint32_t height, uint32_t color_number) {
+void common_hal_vectorio_rectangle_construct(vectorio_rectangle_t *self, uint32_t width, uint32_t height, uint16_t color_index) {
     self->width = width;
     self->height = height;
-    self->color_number = color_number;
+    self->color_index = color_index + 1;
 }
 
 void common_hal_vectorio_rectangle_set_on_dirty(vectorio_rectangle_t *self, vectorio_event_t on_dirty) {
@@ -22,7 +22,7 @@ void common_hal_vectorio_rectangle_set_on_dirty(vectorio_rectangle_t *self, vect
 uint32_t common_hal_vectorio_rectangle_get_pixel(void *obj, int16_t x, int16_t y) {
     vectorio_rectangle_t *self = obj;
     if (x >= 0 && y >= 0 && x < self->width && y < self->height) {
-        return self->color_number;
+        return self->color_index;
     }
     return 0;
 }
@@ -68,14 +68,14 @@ void common_hal_vectorio_rectangle_set_height(void *obj, int16_t height) {
     }
 }
 
-int16_t common_hal_vectorio_rectangle_get_color_number(void *obj) {
+uint16_t common_hal_vectorio_rectangle_get_color_index(void *obj) {
     vectorio_rectangle_t *self = obj;
-    return self->color_number;
+    return self->color_index - 1;
 }
 
-void common_hal_vectorio_rectangle_set_color_number(void *obj, int16_t color_number) {
+void common_hal_vectorio_rectangle_set_color_index(void *obj, uint16_t color_index) {
     vectorio_rectangle_t *self = obj;
-    self->color_number = abs(color_number);
+    self->color_index = abs(color_index + 1);
     if (self->on_dirty.obj != NULL) {
         self->on_dirty.event(self->on_dirty.obj);
     }

--- a/shared-module/vectorio/Rectangle.h
+++ b/shared-module/vectorio/Rectangle.h
@@ -10,6 +10,7 @@ typedef struct {
     mp_obj_base_t base;
     uint16_t width;
     uint16_t height;
+    uint16_t color_number;
     vectorio_event_t on_dirty;
     mp_obj_t draw_protocol_instance;
 } vectorio_rectangle_t;

--- a/shared-module/vectorio/Rectangle.h
+++ b/shared-module/vectorio/Rectangle.h
@@ -10,7 +10,7 @@ typedef struct {
     mp_obj_base_t base;
     uint16_t width;
     uint16_t height;
-    uint16_t color_number;
+    uint16_t color_index;
     vectorio_event_t on_dirty;
     mp_obj_t draw_protocol_instance;
 } vectorio_rectangle_t;

--- a/tests/vectorio/color_index.py
+++ b/tests/vectorio/color_index.py
@@ -1,8 +1,6 @@
 import time
-
 import board
 import displayio
-import rainbowio
 import vectorio
 
 

--- a/tests/vectorio/color_index.py
+++ b/tests/vectorio/color_index.py
@@ -1,0 +1,52 @@
+import time
+
+import board
+import displayio
+import rainbowio
+import vectorio
+
+
+def increment_color(shape):
+    if shape.color_index + 1 < len(shape.pixel_shader):
+        shape.color_index += 1
+    else:
+        shape.color_index = 0
+
+
+display = board.DISPLAY
+main_group = displayio.Group()
+
+palette = displayio.Palette(4)
+palette[0] = 0x125690
+palette[1] = 0x34BB90
+palette[2] = 0xAA1220
+palette[3] = 0xAA04BA
+
+circle = vectorio.Circle(pixel_shader=palette, radius=25, x=25, y=25)
+main_group.append(circle)
+
+rectangle = vectorio.Rectangle(pixel_shader=palette, width=50, height=50, x=25, y=75)
+main_group.append(rectangle)
+
+points = [(5, 5), (70, 20), (35, 35), (20, 70)]
+polygon = vectorio.Polygon(pixel_shader=palette, points=points, x=145, y=55)
+main_group.append(polygon)
+
+display.show(main_group)
+
+while True:
+    for x in range(25, display.width - 25):
+        circle.x = x
+        time.sleep(0.01)
+
+    increment_color(circle)
+    increment_color(rectangle)
+    increment_color(polygon)
+
+    for x in range(display.width - 25, 25, -1):
+        circle.x = x
+        time.sleep(0.01)
+
+    increment_color(circle)
+    increment_color(rectangle)
+    increment_color(polygon)


### PR DESCRIPTION
Implementing `color_index` argument and property for all of the vectorio shapes. This allows user to specify which color index to fill the shape from the given palette. Previous behavior was always defaulting to the `0` index within the palette.

There is a script illustrating it's usage in this PR inside of `tests/vecotrio/color_index.py`

If the argument is omitted the previous behavior is the default.