### PR TITLE
Pin rename on Servo2040 to match schematic and C++/MP board defs

### DIFF
--- a/ports/raspberrypi/boards/pimoroni_servo2040/pins.c
+++ b/ports/raspberrypi/boards/pimoroni_servo2040/pins.c
@@ -23,7 +23,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SERVO_18), MP_ROM_PTR(&pin_GPIO17) },
     { MP_ROM_QSTR(MP_QSTR_NUM_SERVOS), MP_ROM_INT(18) },
 
-    { MP_ROM_QSTR(MP_QSTR_LED_DAT), MP_ROM_PTR(&pin_GPIO18) },
+    { MP_ROM_QSTR(MP_QSTR_LED_DATA), MP_ROM_PTR(&pin_GPIO18) },
     { MP_ROM_QSTR(MP_QSTR_NUM_LEDS), MP_ROM_INT(6) },
 
     { MP_ROM_QSTR(MP_QSTR_INT), MP_ROM_PTR(&pin_GPIO19) },


### PR DESCRIPTION
I had not spotted that in the schematic `LED_DAT` was called `LED_DATA` prior to my previous PR being approved 😓 