### PR TITLE
Pin typer and click to have compatible versions

### DIFF
--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -5,12 +5,14 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
-      - 'py/**'
       - 'extmod/**'
       - 'lib/**'
+      - 'mpy-cross/**'
       - 'ports/unix/**'
       - 'ports/windows/**'
+      - 'py/**'
+      - 'requirements*.txt'
+      - 'tools/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -64,7 +66,8 @@ jobs:
         pip install wheel
         # requirements_dev.txt doesn't install on windows. (with msys2 python)
         # instead, pick a subset for what we want to do
-        pip install cascadetoml jinja2 typer intelhex
+        # Undo the pin of typer & click when undoing it in requirements-dev.txt
+        pip install cascadetoml jinja2 typer==0.4.0 click==8.0.4 intelhex
         # check that installed packages work....?
         which python; python --version; python -c "import cascadetoml"
         which python3; python3 --version; python3 -c "import cascadetoml"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,10 +4,12 @@ huffman
 # For nvm.toml
 cascadetoml
 jinja2
-typer
+# Undo this pin when click and typer are again compatible.
+typer==0.4.0
 
 sh
-click
+# Undo this pin when click and typer are again compatible.
+click==8.0.4
 cpp-coveralls
 requests
 requests-cache


### PR DESCRIPTION
`click` 8.1.0 made incompatible changes that broke `black` and `typer`. `black` has released a fix, but `typer` has not yet done so. Pin `click` and `typer` to compatible versions for now, while we await a fix to `typer`.