### PR TITLE
don't gc_free() ringbuf if no heap; cleanup ringbuf

### DIFF
--- a/ports/broadcom/common-hal/busio/UART.c
+++ b/ports/broadcom/common-hal/busio/UART.c
@@ -213,8 +213,11 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     self->sigint_enabled = sigint_enabled;
 
     if (rx != NULL) {
+        self->allocated_ringbuf = true;
+        // Use the provided buffer when given.
         if (receiver_buffer != NULL) {
-            self->ringbuf = (ringbuf_t) { receiver_buffer, receiver_buffer_size };
+            ringbuf_init(&self->ringbuf, receiver_buffer, receiver_buffer_size);
+            self->allocated_ringbuf = false;
         } else {
             // Initially allocate the UART's buffer in the long-lived part of the
             // heap. UARTs are generally long-lived objects, but the "make long-
@@ -222,7 +225,6 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             // self->buffer, so do it manually.  (However, as long as internal
             // pointers like this are NOT moved, allocating the buffer
             // in the long-lived pool is not strictly necessary)
-            // (This is a macro.)
             if (!ringbuf_alloc(&self->ringbuf, receiver_buffer_size, true)) {
                 mp_raise_msg(&mp_type_MemoryError, translate("Failed to allocate RX buffer"));
             }
@@ -342,7 +344,9 @@ void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
         pl011->CR = 0;
     }
     active_uart[self->uart_id] = NULL;
-    ringbuf_free(&self->ringbuf);
+    if (self->allocated_ringbuf) {
+        ringbuf_free(&self->ringbuf);
+    }
     uart_status[self->uart_id] = STATUS_FREE;
     common_hal_reset_pin(self->tx_pin);
     common_hal_reset_pin(self->rx_pin);

--- a/ports/broadcom/common-hal/busio/UART.h
+++ b/ports/broadcom/common-hal/busio/UART.h
@@ -36,10 +36,11 @@ typedef struct {
     const mcu_pin_obj_t *rx_pin;
     const mcu_pin_obj_t *cts_pin;
     const mcu_pin_obj_t *rts_pin;
-    uint8_t uart_id;
     uint32_t baudrate;
     uint32_t timeout_ms;
+    uint8_t uart_id;
     bool sigint_enabled;
+    bool allocated_ringbuf;
     ringbuf_t ringbuf;
 } busio_uart_obj_t;
 

--- a/ports/espressif/common-hal/_bleio/CharacteristicBuffer.c
+++ b/ports/espressif/common-hal/_bleio/CharacteristicBuffer.c
@@ -73,10 +73,7 @@ void _common_hal_bleio_characteristic_buffer_construct(bleio_characteristic_buff
     self->characteristic = characteristic;
     self->timeout_ms = timeout * 1000;
 
-    self->ringbuf.buf = (uint8_t *)buffer;
-    self->ringbuf.size = buffer_size;
-    self->ringbuf.iget = 0;
-    self->ringbuf.iput = 0;
+    ringbuf_init(&self->ringbuf, buffer, buffer_size);
 
     if (static_handler_entry != NULL) {
         ble_event_add_handler_entry((ble_event_handler_entry_t *)static_handler_entry, characteristic_buffer_on_ble_evt, self);

--- a/ports/espressif/common-hal/_bleio/PacketBuffer.c
+++ b/ports/espressif/common-hal/_bleio/PacketBuffer.c
@@ -164,10 +164,7 @@ void _common_hal_bleio_packet_buffer_construct(
     }
 
     if (incoming) {
-        self->ringbuf.buf = (uint8_t *)incoming_buffer;
-        self->ringbuf.size = incoming_buffer_size;
-        self->ringbuf.iget = 0;
-        self->ringbuf.iput = 0;
+        ringbuf_init(&self->ringbuf, (uint8_t *)incoming_buffer, incoming_buffer_size);
     }
 
     self->packet_queued = false;

--- a/ports/nrf/common-hal/_bleio/CharacteristicBuffer.c
+++ b/ports/nrf/common-hal/_bleio/CharacteristicBuffer.c
@@ -90,10 +90,7 @@ void _common_hal_bleio_characteristic_buffer_construct(bleio_characteristic_buff
     self->characteristic = characteristic;
     self->timeout_ms = timeout * 1000;
 
-    self->ringbuf.buf = (uint8_t *)buffer;
-    self->ringbuf.size = buffer_size;
-    self->ringbuf.iget = 0;
-    self->ringbuf.iput = 0;
+    ringbuf_init(&self->ringbuf, buffer, buffer_size);
 
     if (static_handler_entry != NULL) {
         ble_drv_add_event_handler_entry((ble_drv_evt_handler_entry_t *)static_handler_entry, characteristic_buffer_on_ble_evt, self);

--- a/ports/nrf/common-hal/_bleio/PacketBuffer.c
+++ b/ports/nrf/common-hal/_bleio/PacketBuffer.c
@@ -233,10 +233,7 @@ void _common_hal_bleio_packet_buffer_construct(
     }
 
     if (incoming) {
-        self->ringbuf.buf = (uint8_t *)incoming_buffer;
-        self->ringbuf.size = incoming_buffer_size;
-        self->ringbuf.iget = 0;
-        self->ringbuf.iput = 0;
+        ringbuf_init(&self->ringbuf, (uint8_t *)incoming_buffer, incoming_buffer_size);
     }
 
     self->packet_queued = false;

--- a/ports/raspberrypi/common-hal/busio/UART.h
+++ b/ports/raspberrypi/common-hal/busio/UART.h
@@ -40,6 +40,7 @@ typedef struct {
     uint8_t rts_pin;
     uint8_t uart_id;
     uint8_t uart_irq_id;
+    bool allocated_ringbuf;
     uint32_t baudrate;
     uint32_t timeout_ms;
     uart_inst_t *uart;

--- a/ports/stm/common-hal/busio/UART.h
+++ b/ports/stm/common-hal/busio/UART.h
@@ -48,12 +48,12 @@ typedef struct {
     const mcu_periph_obj_t *rx;
 
     ringbuf_t ringbuf;
-    uint8_t rx_char;
-
     uint32_t baudrate;
     uint32_t timeout_ms;
 
+    uint8_t rx_char;
     bool sigint_enabled;
+    bool allocated_ringbuf;
 } busio_uart_obj_t;
 
 void uart_reset(void);

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -528,6 +528,8 @@ STATIC mp_obj_t extra_coverage(void) {
     {
         byte buf[100];
         ringbuf_t ringbuf;
+        // Capacity of ringbuf is 100, one less than actual memory size.
+        // We pass the actual size to ringbuf_init().
         ringbuf_init(&ringbuf, &buf[0], sizeof(buf));
 
         mp_printf(&mp_plat_print, "# ringbuf\n");

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -526,10 +526,10 @@ STATIC mp_obj_t extra_coverage(void) {
 
     // ringbuf
     {
-        byte buf[100];
+        #define RINGBUF_CAPACITY 99
+
+        byte buf[RINGBUF_CAPACITY];
         ringbuf_t ringbuf;
-        // Capacity of ringbuf is 100, one less than actual memory size.
-        // We pass the actual size to ringbuf_init().
         ringbuf_init(&ringbuf, &buf[0], sizeof(buf));
 
         mp_printf(&mp_plat_print, "# ringbuf\n");
@@ -548,7 +548,7 @@ STATIC mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "%d %d\n", ringbuf_num_empty(&ringbuf), ringbuf_num_filled(&ringbuf));
 
         // Two-byte put with full ringbuf.
-        for (int i = 0; i < 99; ++i) {
+        for (int i = 0; i < RINGBUF_CAPACITY; ++i) {
             ringbuf_put(&ringbuf, i);
         }
         mp_printf(&mp_plat_print, "%d %d\n", ringbuf_num_empty(&ringbuf), ringbuf_num_filled(&ringbuf));
@@ -560,16 +560,15 @@ STATIC mp_obj_t extra_coverage(void) {
         ringbuf_get(&ringbuf);
         mp_printf(&mp_plat_print, "%d %d\n", ringbuf_num_empty(&ringbuf), ringbuf_num_filled(&ringbuf));
         mp_printf(&mp_plat_print, "%d\n", ringbuf_put16(&ringbuf, 0xcc99));
-        for (int i = 0; i < 97; ++i) {
+        for (int i = 0; i < RINGBUF_CAPACITY - 2; ++i) {
             ringbuf_get(&ringbuf);
         }
         mp_printf(&mp_plat_print, "%04x\n", ringbuf_get16(&ringbuf));
         mp_printf(&mp_plat_print, "%d %d\n", ringbuf_num_empty(&ringbuf), ringbuf_num_filled(&ringbuf));
 
         // Two-byte put with wrap around on first byte:
-        ringbuf.iput = 0;
-        ringbuf.iget = 0;
-        for (int i = 0; i < 99; ++i) {
+        ringbuf_clear(&ringbuf);
+        for (int i = 0; i < RINGBUF_CAPACITY; ++i) {
             ringbuf_put(&ringbuf, i);
             ringbuf_get(&ringbuf);
         }
@@ -577,9 +576,8 @@ STATIC mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "%04x\n", ringbuf_get16(&ringbuf));
 
         // Two-byte put with wrap around on second byte:
-        ringbuf.iput = 0;
-        ringbuf.iget = 0;
-        for (int i = 0; i < 98; ++i) {
+        ringbuf_clear(&ringbuf);
+        for (int i = 0; i < RINGBUF_CAPACITY - 1; ++i) {
             ringbuf_put(&ringbuf, i);
             ringbuf_get(&ringbuf);
         }
@@ -587,13 +585,11 @@ STATIC mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "%04x\n", ringbuf_get16(&ringbuf));
 
         // Two-byte get from empty ringbuf.
-        ringbuf.iput = 0;
-        ringbuf.iget = 0;
+        ringbuf_clear(&ringbuf);
         mp_printf(&mp_plat_print, "%d\n", ringbuf_get16(&ringbuf));
 
         // Two-byte get from ringbuf with one byte available.
-        ringbuf.iput = 0;
-        ringbuf.iget = 0;
+        ringbuf_clear(&ringbuf);
         ringbuf_put(&ringbuf, 0xaa);
         mp_printf(&mp_plat_print, "%d\n", ringbuf_get16(&ringbuf));
     }

--- a/py/ringbuf.c
+++ b/py/ringbuf.c
@@ -27,92 +27,91 @@
 
 #include "ringbuf.h"
 
-// Note that ringbuf_init() takes the actual buffer size, but
-// ringbuf_alloc() takes the capacity. The capacity is one less than the size.
-bool ringbuf_init(ringbuf_t *r, uint8_t *buf, size_t buf_size) {
+bool ringbuf_init(ringbuf_t *r, uint8_t *buf, size_t size) {
     r->heap = false;
     r->buf = buf;
-    r->size = buf_size;
-    r->iget = r->iput = 0;
+    r->size = size;
+    r->used = 0;
+    r->next_read = 0;
+    r->next_write = 0;
     return r->buf != NULL;
 }
 
 // Dynamic initialization. This should be accessible from a root pointer.
-// capacity is the number of bytes the ring buffer can hold. The actual
-// size of the buffer is one greater than that, due to how the buffer
-// handles empty and full statuses.
-bool ringbuf_alloc(ringbuf_t *r, size_t capacity, bool long_lived) {
+bool ringbuf_alloc(ringbuf_t *r, size_t size, bool long_lived) {
+    bool result = ringbuf_init(r, gc_alloc(size, false, long_lived), size);
     r->heap = true;
-    r->buf = gc_alloc(capacity + 1, false, long_lived);
-    r->size = capacity + 1;
-    r->iget = r->iput = 0;
-    return r->buf != NULL;
+    return result;
 }
 
 void ringbuf_free(ringbuf_t *r) {
     if (r->heap && gc_alloc_possible()) {
-        // Only free if on the heap, and there is really a heap.
+        // Only free if on the heap, and there is really a heap right now.
         gc_free(r->buf);
     }
     r->buf = (uint8_t *)NULL;
+    r->heap = false;
     r->size = 0;
+
     ringbuf_clear(r);
 }
 
 size_t ringbuf_capacity(ringbuf_t *r) {
-    return r->size - 1;
+    return r->size;
 }
 
-// Returns -1 if buffer is empty, else returns byte fetched.
+// Return -1 if buffer is empty, else return byte fetched.
 int ringbuf_get(ringbuf_t *r) {
-    if (r->iget == r->iput) {
+    if (r->used < 1) {
         return -1;
     }
-    uint8_t v = r->buf[r->iget++];
-    if (r->iget >= r->size) {
-        r->iget = 0;
+    uint8_t v = r->buf[r->next_read];
+    r->next_read++;
+    if (r->next_read >= r->size) {
+        r->next_read = 0;
     }
+    r->used--;
     return v;
 }
 
 int ringbuf_get16(ringbuf_t *r) {
-    int v = ringbuf_peek16(r);
-    if (v == -1) {
-        return v;
-    }
-    r->iget += 2;
-    if (r->iget >= r->size) {
-        r->iget -= r->size;
-    }
-    return v;
-}
-
-// Returns -1 if no room in buffer, else returns 0.
-int ringbuf_put(ringbuf_t *r, uint8_t v) {
-    uint32_t iput_new = r->iput + 1;
-    if (iput_new >= r->size) {
-        iput_new = 0;
-    }
-    if (iput_new == r->iget) {
+    if (r->used < 2) {
         return -1;
     }
-    r->buf[r->iput] = v;
-    r->iput = iput_new;
+
+    int high_byte = ringbuf_get(r);
+    int low_byte = ringbuf_get(r);
+    return (high_byte << 8) | low_byte;
+}
+
+// Return -1 if no room in buffer, else return 0.
+int ringbuf_put(ringbuf_t *r, uint8_t v) {
+    if (r->used >= r->size) {
+        return -1;
+    }
+    r->buf[r->next_write] = v;
+    r->next_write++;
+    if (r->next_write >= r->size) {
+        r->next_write = 0;
+    }
+    r->used++;
     return 0;
 }
 
 void ringbuf_clear(ringbuf_t *r) {
-    r->iput = r->iget = 0;
+    r->next_write = 0;
+    r->next_read = 0;
+    r->used = 0;
 }
 
 // Number of free slots that can be written.
 size_t ringbuf_num_empty(ringbuf_t *r) {
-    return (r->size + r->iget - r->iput - 1) % r->size;
+    return r->size - r->used;
 }
 
 // Number of bytes available to read.
 size_t ringbuf_num_filled(ringbuf_t *r) {
-    return (r->size + r->iput - r->iget) % r->size;
+    return r->used;
 }
 
 // If the ring buffer fills up, not all bytes will be written.
@@ -140,37 +139,12 @@ size_t ringbuf_get_n(ringbuf_t *r, uint8_t *buf, size_t bufsize) {
     return bufsize;
 }
 
-int ringbuf_peek16(ringbuf_t *r) {
-    if (r->iget == r->iput) {
-        return -1;
-    }
-    uint32_t iget_a = r->iget + 1;
-    if (iget_a == r->size) {
-        iget_a = 0;
-    }
-    if (iget_a == r->iput) {
-        return -1;
-    }
-    return (r->buf[r->iget] << 8) | (r->buf[iget_a]);
-}
-
 int ringbuf_put16(ringbuf_t *r, uint16_t v) {
-    uint32_t iput_a = r->iput + 1;
-    if (iput_a == r->size) {
-        iput_a = 0;
-    }
-    if (iput_a == r->iget) {
+    if (r->size - r->used < 2) {
         return -1;
     }
-    uint32_t iput_b = iput_a + 1;
-    if (iput_b == r->size) {
-        iput_b = 0;
-    }
-    if (iput_b == r->iget) {
-        return -1;
-    }
-    r->buf[r->iput] = (v >> 8) & 0xff;
-    r->buf[iput_a] = v & 0xff;
-    r->iput = iput_b;
+
+    ringbuf_put(r, (v >> 8) & 0xff);
+    ringbuf_put(r, v & 0xff);
     return 0;
 }

--- a/py/ringbuf.c
+++ b/py/ringbuf.c
@@ -48,7 +48,8 @@ bool ringbuf_alloc(ringbuf_t *r, size_t capacity, bool long_lived) {
 }
 
 void ringbuf_free(ringbuf_t *r) {
-    if (r->heap) {
+    if (r->heap && gc_alloc_possible()) {
+        // Only free if on the heap, and there is really a heap.
         gc_free(r->buf);
     }
     r->buf = (uint8_t *)NULL;

--- a/py/ringbuf.c
+++ b/py/ringbuf.c
@@ -27,10 +27,12 @@
 
 #include "ringbuf.h"
 
-bool ringbuf_init(ringbuf_t *r, uint8_t *buf, size_t capacity) {
+// Note that ringbuf_init() takes the actual buffer size, but
+// ringbuf_alloc() takes the capacity. The capacity is one less than the size.
+bool ringbuf_init(ringbuf_t *r, uint8_t *buf, size_t buf_size) {
     r->heap = false;
     r->buf = buf;
-    r->size = capacity;
+    r->size = buf_size;
     r->iget = r->iput = 0;
     return r->buf != NULL;
 }

--- a/py/ringbuf.h
+++ b/py/ringbuf.h
@@ -33,19 +33,19 @@
 
 typedef struct _ringbuf_t {
     uint8_t *buf;
-    // Allocated size; capacity is one less. Don't reference this directly.
     uint32_t size;
-    uint32_t iget;
-    uint32_t iput;
+    uint32_t used;
+    uint32_t next_read;
+    uint32_t next_write;
     bool heap;
 } ringbuf_t;
 
-// Note that the capacity of the buffer is N-1!
+// For static initialization with an existing buffer, use ringbuf_init().
+bool ringbuf_init(ringbuf_t *r, uint8_t *buf, size_t size);
 
-// For static initialization use ringbuf_init(), which takes actual size instead of capacity.
-bool ringbuf_init(ringbuf_t *r, uint8_t *buf, size_t buf_size);
-// For heap allocation, use ringbuf_alloc, which takes capacity.
-bool ringbuf_alloc(ringbuf_t *r, size_t capacity, bool long_lived);
+// For allocation of a buffer on the heap, use ringbuf_alloc().
+bool ringbuf_alloc(ringbuf_t *r, size_t size, bool long_lived);
+
 void ringbuf_free(ringbuf_t *r);
 size_t ringbuf_capacity(ringbuf_t *r);
 int ringbuf_get(ringbuf_t *r);
@@ -56,9 +56,8 @@ size_t ringbuf_num_filled(ringbuf_t *r);
 size_t ringbuf_put_n(ringbuf_t *r, const uint8_t *buf, size_t bufsize);
 size_t ringbuf_get_n(ringbuf_t *r, uint8_t *buf, size_t bufsize);
 
-// Note: big-endian. No-op if not enough room available for both bytes.
+// Note: big-endian. Return -1 if can't read or write two bytes.
 int ringbuf_get16(ringbuf_t *r);
-int ringbuf_peek16(ringbuf_t *r);
 int ringbuf_put16(ringbuf_t *r, uint16_t v);
 
 #endif // MICROPY_INCLUDED_PY_RINGBUF_H

--- a/py/ringbuf.h
+++ b/py/ringbuf.h
@@ -42,8 +42,9 @@ typedef struct _ringbuf_t {
 
 // Note that the capacity of the buffer is N-1!
 
-// For static initialization use ringbuf_init()
-bool ringbuf_init(ringbuf_t *r, uint8_t *buf, size_t capacity);
+// For static initialization use ringbuf_init(), which takes actual size instead of capacity.
+bool ringbuf_init(ringbuf_t *r, uint8_t *buf, size_t buf_size);
+// For heap allocation, use ringbuf_alloc, which takes capacity.
 bool ringbuf_alloc(ringbuf_t *r, size_t capacity, bool long_lived);
 void ringbuf_free(ringbuf_t *r);
 size_t ringbuf_capacity(ringbuf_t *r);


### PR DESCRIPTION
- Fixes #6213.

- UART deinit might happen when there is no VM, during `reset_board_buses()`, so check before trying to free a UART ringbuf that is on the heap. This UART deinit possibility was introduced in #5422.
- There was a lot of inconsistency about how and whether a buffer could be supplied as the UART ringbuf. Make the code consistent across multiple ports.
- `ringbuf_init()` should have been used several places where it was not. ~~There is a fine distinction between the ringbuf buffer size in bytes, and its capacity in bytes, which is one less. `ringbuf_init()` used to take the capacity, but I made it take the actual buffer size, because that was less confusing when passing in an existing buffer, though inconsistent with `ringbuf_alloc()`, which takes `capacity` and then allocates a buffer of one extra byte. Some discussion here about this point: https://github.com/adafruit/circuitpython/pull/5813#discussion_r779749113~~
- (EDIT) Rewrote `ringbuf` to remove `capacity == size -1` limitation. Now the size is the capacity. Code is smaller and I think more readable, at the very small expense of keeping a count of used slots.

~~I will see if this builds, and test it more tomorrow, to make sure I have the ringbuf fixes right. Draft for now.~~

