### PR TITLE
revert pins of click and typer

### DIFF
--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -66,8 +66,7 @@ jobs:
         pip install wheel
         # requirements_dev.txt doesn't install on windows. (with msys2 python)
         # instead, pick a subset for what we want to do
-        # Undo the pin of typer & click when undoing it in requirements-dev.txt
-        pip install cascadetoml jinja2 typer==0.4.0 click==8.0.4 intelhex
+        pip install cascadetoml jinja2 typer click intelhex
         # check that installed packages work....?
         which python; python --version; python -c "import cascadetoml"
         which python3; python3 --version; python3 -c "import cascadetoml"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,12 +4,10 @@ huffman
 # For nvm.toml
 cascadetoml
 jinja2
-# Undo this pin when click and typer are again compatible.
-typer==0.4.0
+typer
 
 sh
-# Undo this pin when click and typer are again compatible.
-click==8.0.4
+click
 cpp-coveralls
 requests
 requests-cache


### PR DESCRIPTION
Revert most of #6210, because `typer` is compatible with click `8.1.x` again, but keep `pull_request: paths:` changes in windows workflow.

Note that `click` is up to 8.1.2 now.