### PR TITLE
Fixed internal flash filesystem stub build issue

### DIFF
--- a/supervisor/stub/filesystem.c
+++ b/supervisor/stub/filesystem.c
@@ -31,6 +31,11 @@ void filesystem_background(void) {
     return;
 }
 
+void filesystem_tick(void)
+{
+    return;
+}
+
 bool filesystem_init(bool create_allowed, bool force_create) {
     (void)create_allowed;
     (void)force_create;

--- a/supervisor/stub/filesystem.c
+++ b/supervisor/stub/filesystem.c
@@ -31,8 +31,7 @@ void filesystem_background(void) {
     return;
 }
 
-void filesystem_tick(void)
-{
+void filesystem_tick(void) {
     return;
 }
 

--- a/supervisor/stub/internal_flash.c
+++ b/supervisor/stub/internal_flash.c
@@ -55,8 +55,7 @@ mp_uint_t supervisor_flash_write_blocks(const uint8_t *src, uint32_t block_num, 
 }
 
 #if (0)
-void supervisor_flash_init_vfs(struct _fs_user_mount_t *vfs)
-{
+void supervisor_flash_init_vfs(struct _fs_user_mount_t *vfs) {
     return;
 }
 #endif

--- a/supervisor/stub/internal_flash.c
+++ b/supervisor/stub/internal_flash.c
@@ -55,14 +55,20 @@ mp_uint_t supervisor_flash_write_blocks(const uint8_t *src, uint32_t block_num, 
 }
 
 #if (0)
+// See definition in supervisor/flash.c
 void supervisor_flash_init_vfs(struct _fs_user_mount_t *vfs) {
+    return;
+}
+
+// See definition in supervisor/flash.c
+void supervisor_flash_flush(void) {
     return;
 }
 #endif
 
-void port_internal_flash_flush(void) {
-    return;
+void supervisor_flash_release_cache(void) {
 }
 
-void supervisor_flash_release_cache(void) {
+void port_internal_flash_flush(void) {
+    return;
 }

--- a/supervisor/stub/internal_flash.c
+++ b/supervisor/stub/internal_flash.c
@@ -23,7 +23,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include "supervisor/internal_flash.h"
+#include "supervisor/flash.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -46,20 +46,23 @@ uint32_t supervisor_flash_get_block_count(void) {
     return 0;
 }
 
-void port_internal_flash_flush(void) {
-    return;
-}
-
 mp_uint_t supervisor_flash_read_blocks(uint8_t *dest, uint32_t block, uint32_t num_blocks) {
     return 0; // success
 }
 
-bool supervisor_flash_write_block(const uint8_t *src, uint32_t block) {
-    return true;
-}
-
 mp_uint_t supervisor_flash_write_blocks(const uint8_t *src, uint32_t block_num, uint32_t num_blocks) {
     return 0; // success
+}
+
+#if (0)
+void supervisor_flash_init_vfs(struct _fs_user_mount_t *vfs)
+{
+    return;
+}
+#endif
+
+void port_internal_flash_flush(void) {
+    return;
 }
 
 void supervisor_flash_release_cache(void) {


### PR DESCRIPTION
Internal filesystem stubs is used when both INTERNAL_FLASH_FILESYSTEM, DISABLE_FILESYSTEM are set.