### PR TITLE
MP3Decoder: Accurately inform when no more data

### DIFF
--- a/shared-module/audiomp3/MP3Decoder.c
+++ b/shared-module/audiomp3/MP3Decoder.c
@@ -364,7 +364,7 @@ audioio_get_buffer_result_t audiomp3_mp3file_get_buffer(audiomp3_mp3file_obj_t *
     }
 
     self->samples_decoded += *buffer_length / sizeof(int16_t);
-    return GET_BUFFER_MORE_DATA;
+    return mp3file_find_sync_word(self) ? GET_BUFFER_MORE_DATA : GET_BUFFER_DONE;
 }
 
 void audiomp3_mp3file_get_buffer_structure(audiomp3_mp3file_obj_t *self, bool single_channel_output,


### PR DESCRIPTION
Some audio implementations, notably samd, really don't like it when you return 0 samples of data. This was the case when reaching the end of an MP3 file.

Now, we read forward in an MP3 file to the next sync word during "get_buffer", so that we can accurately return GET_BUFFER_DONE when the NEXT call WOULD HAVE resulted in 0 samples.

Tested with @gamblor21's "laugh.mp3" file on a Trellis M4 Express.

Closes: #5415.