### PR TITLE
py/vm: Prevent array bound warning when using -MP_OBJ_ITER_BUF_NSLOTS.

### DIFF
--- a/py/vm.c
+++ b/py/vm.c
@@ -821,8 +821,8 @@ unwind_jump:;
                     obj = mp_getiter(obj, iter_buf);
                     if (obj != MP_OBJ_FROM_PTR(iter_buf)) {
                         // Iterator didn't use the stack so indicate that with MP_OBJ_NULL.
-                        sp[-MP_OBJ_ITER_BUF_NSLOTS + 1] = MP_OBJ_NULL;
-                        sp[-MP_OBJ_ITER_BUF_NSLOTS + 2] = obj;
+                        *(sp - MP_OBJ_ITER_BUF_NSLOTS + 1) = MP_OBJ_NULL;
+                        *(sp - MP_OBJ_ITER_BUF_NSLOTS + 2) = obj;
                     }
                     DISPATCH();
                 }
@@ -833,8 +833,8 @@ unwind_jump:;
                     DECODE_ULABEL; // the jump offset if iteration finishes; for labels are always forward
                     code_state->sp = sp;
                     mp_obj_t obj;
-                    if (sp[-MP_OBJ_ITER_BUF_NSLOTS + 1] == MP_OBJ_NULL) {
-                        obj = sp[-MP_OBJ_ITER_BUF_NSLOTS + 2];
+                    if (*(sp - MP_OBJ_ITER_BUF_NSLOTS + 1) == MP_OBJ_NULL) {
+                        obj = *(sp - MP_OBJ_ITER_BUF_NSLOTS + 2);
                     } else {
                         obj = MP_OBJ_FROM_PTR(&sp[-MP_OBJ_ITER_BUF_NSLOTS + 1]);
                     }


### PR DESCRIPTION
This warning can happen on clang 13.0.1 building mpy-cross:
```
../py/vm.c:748:25: error: array index -3 refers past the last possible
  element for an array in 64-bit address space containing 64-bit (8-byte)
  elements (max possible 2305843009213693952 elements)
  [-Werror,-Warray-bounds]
                        sp[-MP_OBJ_ITER_BUF_NSLOTS + 1] = MP_OBJ_NULL;
                        ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Using pointer access instead of array access works around this warning.

This is a cherry-pick of https://github.com/micropython/micropython/commit/bb70874111dbb246624a68c013e8f1c3245ca0d8

Closes: #6215