### PR TITLE
nrf: Correctly mark PWM unused during reset

### DIFF
--- a/ports/nrf/common-hal/pwmio/PWMOut.c
+++ b/ports/nrf/common-hal/pwmio/PWMOut.c
@@ -108,6 +108,7 @@ STATIC void reset_single_pwmout(uint8_t i) {
 
     for (int ch = 0; ch < CHANNELS_PER_PWM; ch++) {
         pwm_seq[i][ch] = (1 << 15); // polarity = 0
+        pwm->PSEL.OUT[ch] = 0xFFFFFFFF; // disconnnect from I/O
     }
 }
 


### PR DESCRIPTION
This register is ALSO used to tell if the PWM channel should be considered in use by software.

Closes #6061.