### PR TITLE
Free ringbuf buffer by relying on gc, not gc_free()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,7 +400,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/espressif/esp-idf/HEAD') }}-20210923
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/espressif/esp-idf/HEAD') }}-20220404
     - name: Clone IDF submodules
       run: |
         (cd $IDF_PATH && git submodule update --init)

--- a/py/ringbuf.c
+++ b/py/ringbuf.c
@@ -28,7 +28,6 @@
 #include "ringbuf.h"
 
 bool ringbuf_init(ringbuf_t *r, uint8_t *buf, size_t capacity) {
-    r->heap = false;
     r->buf = buf;
     r->size = capacity;
     r->iget = r->iput = 0;
@@ -40,7 +39,6 @@ bool ringbuf_init(ringbuf_t *r, uint8_t *buf, size_t capacity) {
 // size of the buffer is one greater than that, due to how the buffer
 // handles empty and full statuses.
 bool ringbuf_alloc(ringbuf_t *r, size_t capacity, bool long_lived) {
-    r->heap = true;
     r->buf = gc_alloc(capacity + 1, false, long_lived);
     r->size = capacity + 1;
     r->iget = r->iput = 0;
@@ -48,9 +46,8 @@ bool ringbuf_alloc(ringbuf_t *r, size_t capacity, bool long_lived) {
 }
 
 void ringbuf_free(ringbuf_t *r) {
-    if (r->heap) {
-        gc_free(r->buf);
-    }
+    // Free buf by letting gc take care of it. If the VM has finished already,
+    // this will be safe.
     r->buf = (uint8_t *)NULL;
     r->size = 0;
     ringbuf_clear(r);

--- a/py/ringbuf.h
+++ b/py/ringbuf.h
@@ -37,7 +37,6 @@ typedef struct _ringbuf_t {
     uint32_t size;
     uint32_t iget;
     uint32_t iput;
-    bool heap;
 } ringbuf_t;
 
 // Note that the capacity of the buffer is N-1!


### PR DESCRIPTION
Fixes #6213 by not calling gc_free() on the ringbuf buffer, since `ringbuf_free()` may be called after the VM has stopped running. Instead, just rely on gc to free the buffer, if the VM is running.

Removes the `heap` struct field, since it's no longer needed.

This is not related to #6237, even though it seemed that way for a while.