### PR TITLE
Enable support for extended HID usage page and usage. Related to Supp…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,7 +400,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/espressif/esp-idf/HEAD') }}-20210923
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/espressif/esp-idf/HEAD') }}-20220404
     - name: Clone IDF submodules
       run: |
         (cd $IDF_PATH && git submodule update --init)

--- a/mpy-cross/mpy-cross.mk
+++ b/mpy-cross/mpy-cross.mk
@@ -29,6 +29,8 @@ INC += -I$(BUILD)
 # compiler settings
 CWARN = -Wall -Werror
 CWARN += -Wpointer-arith -Wuninitialized
+# Disable errors for array-bounds warnings on "sp[-MP_OBJ_ITER_BUF_NSLOTS + 2]" access
+CWARN += -Wno-array-bounds
 CFLAGS = $(INC) $(CWARN) -std=gnu99 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
 CFLAGS += -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables
 

--- a/mpy-cross/mpy-cross.mk
+++ b/mpy-cross/mpy-cross.mk
@@ -29,8 +29,6 @@ INC += -I$(BUILD)
 # compiler settings
 CWARN = -Wall -Werror
 CWARN += -Wpointer-arith -Wuninitialized
-# Disable errors for array-bounds warnings on "sp[-MP_OBJ_ITER_BUF_NSLOTS + 2]" access
-CWARN += -Wno-array-bounds
 CFLAGS = $(INC) $(CWARN) -std=gnu99 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
 CFLAGS += -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables
 

--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -103,12 +103,12 @@ STATIC mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type, size_t n_args
     mp_obj_t descriptor = mp_obj_new_bytearray(descriptor_bufinfo.len, descriptor_bufinfo.buf);
 
     const mp_int_t usage_page_arg = args[ARG_usage_page].u_int;
-    mp_arg_validate_int_range(usage_page_arg, 1, 255, MP_QSTR_usage_page);
-    const uint8_t usage_page = usage_page_arg;
+    mp_arg_validate_int_range(usage_page_arg, 1, 0xFFFF, MP_QSTR_usage_page);
+    const uint16_t usage_page = usage_page_arg;
 
     const mp_int_t usage_arg = args[ARG_usage].u_int;
-    mp_arg_validate_int_range(usage_arg, 1, 255, MP_QSTR_usage_page);
-    const uint8_t usage = usage_arg;
+    mp_arg_validate_int_range(usage_arg, 1, 0xFFFF, MP_QSTR_usage_page);
+    const uint16_t usage = usage_arg;
 
     mp_obj_t report_ids = args[ARG_report_ids].u_obj;
     mp_obj_t in_report_lengths = args[ARG_in_report_lengths].u_obj;

--- a/shared-bindings/usb_hid/Device.h
+++ b/shared-bindings/usb_hid/Device.h
@@ -33,11 +33,11 @@
 
 extern const mp_obj_type_t usb_hid_device_type;
 
-void common_hal_usb_hid_device_construct(usb_hid_device_obj_t *self, mp_obj_t report_descriptor, uint8_t usage_page, uint8_t usage, size_t report_ids_count,uint8_t *report_ids, uint8_t *in_report_lengths, uint8_t *out_report_lengths);
+void common_hal_usb_hid_device_construct(usb_hid_device_obj_t *self, mp_obj_t report_descriptor, uint16_t usage_page, uint16_t usage, size_t report_ids_count,uint8_t *report_ids, uint8_t *in_report_lengths, uint8_t *out_report_lengths);
 void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t *report, uint8_t len, uint8_t report_id);
 mp_obj_t common_hal_usb_hid_device_get_last_received_report(usb_hid_device_obj_t *self, uint8_t report_id);
-uint8_t common_hal_usb_hid_device_get_usage_page(usb_hid_device_obj_t *self);
-uint8_t common_hal_usb_hid_device_get_usage(usb_hid_device_obj_t *self);
+uint16_t common_hal_usb_hid_device_get_usage_page(usb_hid_device_obj_t *self);
+uint16_t common_hal_usb_hid_device_get_usage(usb_hid_device_obj_t *self);
 uint8_t common_hal_usb_hid_device_validate_report_id(usb_hid_device_obj_t *self, mp_int_t report_id);
 
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_USB_HID_DEVICE_H

--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -186,7 +186,7 @@ uint8_t common_hal_usb_hid_device_validate_report_id(usb_hid_device_obj_t *self,
     return (uint8_t)report_id_arg;
 }
 
-void common_hal_usb_hid_device_construct(usb_hid_device_obj_t *self, mp_obj_t report_descriptor, uint8_t usage_page, uint8_t usage, size_t num_report_ids, uint8_t *report_ids, uint8_t *in_report_lengths, uint8_t *out_report_lengths) {
+void common_hal_usb_hid_device_construct(usb_hid_device_obj_t *self, mp_obj_t report_descriptor, uint16_t usage_page, uint16_t usage, size_t num_report_ids, uint8_t *report_ids, uint8_t *in_report_lengths, uint8_t *out_report_lengths) {
     if (num_report_ids > CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR) {
         mp_raise_ValueError_varg(translate("More than %d report ids not supported"),
             CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR);
@@ -211,11 +211,11 @@ void common_hal_usb_hid_device_construct(usb_hid_device_obj_t *self, mp_obj_t re
     memcpy(self->out_report_lengths, out_report_lengths, num_report_ids);
 }
 
-uint8_t common_hal_usb_hid_device_get_usage_page(usb_hid_device_obj_t *self) {
+uint16_t common_hal_usb_hid_device_get_usage_page(usb_hid_device_obj_t *self) {
     return self->usage_page;
 }
 
-uint8_t common_hal_usb_hid_device_get_usage(usb_hid_device_obj_t *self) {
+uint16_t common_hal_usb_hid_device_get_usage(usb_hid_device_obj_t *self) {
     return self->usage;
 }
 

--- a/shared-module/usb_hid/Device.h
+++ b/shared-module/usb_hid/Device.h
@@ -42,8 +42,8 @@ typedef struct  {
     uint8_t report_ids[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];
     uint8_t in_report_lengths[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];
     uint8_t out_report_lengths[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];
-    uint8_t usage_page;
-    uint8_t usage;
+    uint16_t usage_page;
+    uint16_t usage;
     uint8_t num_report_ids;
 } usb_hid_device_obj_t;
 


### PR DESCRIPTION
Enable support for extended HID usage page and usage. Related to Support HID Usage Pages and Usages >255 #5529.
Also added suppression for array-bounds warning to enable mpy-cross to build on Mac.

Fixes #5529 (EDIT by @dhalbert for automatic linkage to issue)