### PR TITLE
handle clearing both RXIC and RTIC interrupts

### DIFF
--- a/ports/raspberrypi/common-hal/busio/UART.c
+++ b/ports/raspberrypi/common-hal/busio/UART.c
@@ -85,7 +85,7 @@ static void shared_callback(busio_uart_obj_t *self) {
     _copy_into_ringbuf(&self->ringbuf, self->uart);
     // We always clear the interrupt so it doesn't continue to fire because we
     // may not have read everything available.
-    uart_get_hw(self->uart)->icr = UART_UARTICR_RXIC_BITS;
+    uart_get_hw(self->uart)->icr = UART_UARTICR_RXIC_BITS | UART_UARTICR_RTIC_BITS;
 }
 
 static void uart0_callback(void) {


### PR DESCRIPTION
Fixes #6237.

Between pico-sdk 1.2.0 and 1.3.0, the `RP2040 RT` UART timeout interrupt was enabled as part of `uart_set_irq_enables()`.  See https://github.com/raspberrypi/pico-sdk/issues/500 and https://github.com/raspberrypi/pico-sdk/pull/504. Our code did not know this interrupt was now enabled, and did not clear it in the interrupt service routine. Random noise on the RX line could cause this interrupt to be triggered, and once triggered, it was not cleared if the data was not read, and I believe it ended up in a tight constantly firing interrupt loop.

Added code to clear the interrupt. Tested with two RP2040's, one sending data to the other.

@ATMakersBill This sounds like it may be the cause the odd behavior you saw on your USB host board. This means causes other than noise could also trigger the original bug.