### PR TITLE
Don't reset GPIO4 on the MagTag (used for voltage monitoring)

### DIFF
--- a/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
+++ b/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
@@ -188,6 +188,10 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
         gpio_config(&cfg);
         return true;
     }
+    // Pin 4 is used for voltage monitoring, so don't reset
+    if (pin_number == 4) {
+        return true;
+    }
     return false;
 }
 

--- a/ports/espressif/common-hal/analogio/AnalogIn.c
+++ b/ports/espressif/common-hal/analogio/AnalogIn.c
@@ -55,6 +55,10 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self,
     }
     common_hal_mcu_pin_claim(pin);
     self->pin = pin;
+    // Pull-ups are enabled by default for power-saving reasons on quiescent pins.
+    // Turn off the pull-up as soon as we know the pin will be used for analog reads,
+    // since it may take a while for the voltage to stabilize if the input is high-impedance.
+    gpio_pullup_dis(pin->number);
 }
 
 bool common_hal_analogio_analogin_deinited(analogio_analogin_obj_t *self) {


### PR DESCRIPTION
Fixes #6148. Since the re-doing of Espressif GPIO resets done as part of PR #5892 the voltage monitoring done on the MagTag by pin GPIO4 has been always returning high values. This fix avoids resetting that pin on the MagTag and allows correct readings of the voltage.