### PR TITLE
Optimize out `TYPE_CHECKING` at byte-compile time

### DIFF
--- a/py/parse.c
+++ b/py/parse.c
@@ -910,6 +910,11 @@ mp_parse_tree_t mp_parse(mp_lexer_t *lex, mp_parse_input_kind_t input_kind) {
 
     #if MICROPY_COMP_CONST
     mp_map_init(&parser.consts, 0);
+    {
+        mp_map_elem_t *elem = mp_map_lookup(&parser.consts, MP_OBJ_NEW_QSTR(MP_QSTR_TYPE_CHECKING), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
+        assert(elem->value == MP_OBJ_NULL);
+        elem->value = mp_obj_new_int(0);
+    }
     #endif
 
     // work out the top-level rule to use, and push it on the stack

--- a/shared-bindings/typing/__init__.c
+++ b/shared-bindings/typing/__init__.c
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * SPDX-FileCopyrightText: Copyright (c) 2022 Dan Halbert for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+//| """Typing features module
+//|
+//| This module is intended to be a compatible subset of `Python's module
+//| of the same name <https://docs.python.org/3.10/library/typing.html>`_
+//| """
+//|
+//| TYPE_CHECKING: bool = False
+//| """
+//| indicates that expensive type checks should be skipped.
+//|
+//| In CircuitPython using the exact following sequence prevents the body
+//| of the 'if' statement (including the qstr identifiers it uses)
+//| from being included in the mpy file at all::
+//|
+//|     from typing import TYPE_CHECKING
+//|     if TYPE_CHECKING:
+//|         import module_may_not_even_exist_in_circuitpython
+//|
+//| Together with ``from __future__ import typing`` this can help
+//| reduce the memory impact of type annotations in CircuitPython
+//| programs.
+//| """
+
+STATIC const mp_rom_map_elem_t future_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR___future__) },
+
+    { MP_ROM_QSTR(MP_QSTR_TYPE_CHECKING), mp_const_false },
+};
+
+STATIC MP_DEFINE_CONST_DICT(future_module_globals, future_module_globals_table);
+
+const mp_obj_module_t future_module = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&future_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR___future__, future_module, CIRCUITPY_FUTURE);

--- a/shared-bindings/typing/__init__.h
+++ b/shared-bindings/typing/__init__.h
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Dan Halbert for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_SHARED_BINDINGS___FUTURE_____INIT___H
+#define MICROPY_INCLUDED_SHARED_BINDINGS___FUTURE_____INIT___H
+
+#endif  // MICROPY_INCLUDED_SHARED_BINDINGS___FUTURE_____INIT___H


### PR DESCRIPTION
For instance, with a change to `adafruit_requests` (an example more complex than most! and not on the most memory-constrained builds) it decreases the mpy file size from 9196 bytes to 7878 bytes.

```diff
diff --git a/adafruit_requests.py b/adafruit_requests.py
index 4c046ad..74a9a22 100644
--- a/adafruit_requests.py
+++ b/adafruit_requests.py
@@ -33,20 +33,16 @@ license='MIT'
 
 """
 
+from __future__ import annotations
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Requests.git"
 
 import errno
 import sys
+from typing import TYPE_CHECKING
 
-if sys.implementation.name == "circuitpython":
-
-    def cast(_t, value):
-        """No-op shim for the typing.cast() function which is not available in CircuitPython."""
-        return value
-
-
-else:
+if TYPE_CHECKING:
     from ssl import SSLContext
     from types import ModuleType, TracebackType
     from typing import Any, Dict, List, Optional, Protocol, Tuple, Type, Union, cast
@@ -146,6 +142,11 @@ else:
             ...
 
     SSLContextType = Union[SSLContext, "_FakeSSLContext"]
+else:
+
+    def cast(_t, value):
+        """No-op shim for the typing.cast() function which is not available in CircuitPython."""
+        return value
 
 
 # CircuitPython 6.0 does not have the bytearray.split method.
```

Of course, we could not adopt use of this until it's in all supported versions of CircuitPython (e.g., if this is added in 7.3 then not until after 7.2.x support ends)