### PR TITLE
 disable on mimxrt10xx (Teensy40 41) Serial port Hooks

### DIFF
--- a/ports/mimxrt10xx/supervisor/serial.c
+++ b/ports/mimxrt10xx/supervisor/serial.c
@@ -26,65 +26,65 @@
  * THE SOFTWARE.
  */
 
+#include "supervisor/serial.h"
 #include "py/mphal.h"
 #include <string.h>
-#include "supervisor/serial.h"
 
 #include "fsl_clock.h"
 #include "fsl_lpuart.h"
 
 // TODO: Switch this to using DEBUG_UART.
-
+#if defined(USE_DEBUG_PORT_CODE)
 // static LPUART_Type *uart_instance = LPUART1; // evk
 static LPUART_Type *uart_instance = LPUART4; // feather 1011
 // static LPUART_Type *uart_instance = LPUART2; // feather 1062
 
 static uint32_t UartSrcFreq(void) {
-    uint32_t freq;
+  uint32_t freq;
 
-    /* To make it simple, we assume default PLL and divider settings, and the only variable
-         from application is use PLL3 source or OSC source */
-    /* PLL3 div6 80M */
-    if (CLOCK_GetMux(kCLOCK_UartMux) == 0) {
-        freq = (CLOCK_GetPllFreq(kCLOCK_PllUsb1) / 6U) / (CLOCK_GetDiv(kCLOCK_UartDiv) + 1U);
-    } else {
-        freq = CLOCK_GetOscFreq() / (CLOCK_GetDiv(kCLOCK_UartDiv) + 1U);
-    }
+  /* To make it simple, we assume default PLL and divider settings, and the only
+     variable from application is use PLL3 source or OSC source */
+  /* PLL3 div6 80M */
+  if (CLOCK_GetMux(kCLOCK_UartMux) == 0) {
+    freq = (CLOCK_GetPllFreq(kCLOCK_PllUsb1) / 6U) /
+           (CLOCK_GetDiv(kCLOCK_UartDiv) + 1U);
+  } else {
+    freq = CLOCK_GetOscFreq() / (CLOCK_GetDiv(kCLOCK_UartDiv) + 1U);
+  }
 
-    return freq;
+  return freq;
 }
 
 void port_serial_init(void) {
-    lpuart_config_t config;
+  lpuart_config_t config;
 
-    LPUART_GetDefaultConfig(&config);
-    config.baudRate_Bps = 115200;
-    config.enableTx = true;
-    config.enableRx = true;
+  LPUART_GetDefaultConfig(&config);
+  config.baudRate_Bps = 115200;
+  config.enableTx = true;
+  config.enableRx = true;
 
-    LPUART_Init(uart_instance, &config, UartSrcFreq());
+  LPUART_Init(uart_instance, &config, UartSrcFreq());
 }
 
-bool port_serial_connected(void) {
-    return true;
-}
+bool port_serial_connected(void) { return true; }
 
 char port_serial_read(void) {
-    uint8_t data;
+  uint8_t data;
 
-    LPUART_ReadBlocking(uart_instance, &data, sizeof(data));
+  LPUART_ReadBlocking(uart_instance, &data, sizeof(data));
 
-    return data;
+  return data;
 }
 
 bool port_serial_bytes_available(void) {
-    return LPUART_GetStatusFlags(uart_instance) & kLPUART_RxDataRegFullFlag;
+  return LPUART_GetStatusFlags(uart_instance) & kLPUART_RxDataRegFullFlag;
 }
 
 void port_serial_write_substring(const char *text, uint32_t len) {
-    if (len == 0) {
-        return;
-    }
+  if (len == 0) {
+    return;
+  }
 
-    LPUART_WriteBlocking(uart_instance, (uint8_t *)text, len);
+  LPUART_WriteBlocking(uart_instance, (uint8_t *)text, len);
 }
+#endif // USE_DEBUG_PORT_CODE

--- a/ports/mimxrt10xx/supervisor/serial.c
+++ b/ports/mimxrt10xx/supervisor/serial.c
@@ -34,12 +34,11 @@
 #include "fsl_lpuart.h"
 
 // TODO: Switch this to using DEBUG_UART.
-// Need official way to turn off the port serial code when it is not needed
-#if defined(USE_DEBUG_PORT_CODE)
+// If the board defined a debug uart tx or rx pin then we enable this code
+#if defined(CIRCUITPY_DEBUG_UART_TX) || defined(CIRCUITPY_DEBUG_UART_RX)
 // static LPUART_Type *uart_instance = LPUART1; // evk
 static LPUART_Type *uart_instance = LPUART4; // feather 1011
 // static LPUART_Type *uart_instance = LPUART2; // feather 1062
-
 static uint32_t UartSrcFreq(void) {
     uint32_t freq;
 

--- a/ports/mimxrt10xx/supervisor/serial.c
+++ b/ports/mimxrt10xx/supervisor/serial.c
@@ -34,57 +34,60 @@
 #include "fsl_lpuart.h"
 
 // TODO: Switch this to using DEBUG_UART.
+// Need official way to turn off the port serial code when it is not needed
 #if defined(USE_DEBUG_PORT_CODE)
 // static LPUART_Type *uart_instance = LPUART1; // evk
 static LPUART_Type *uart_instance = LPUART4; // feather 1011
 // static LPUART_Type *uart_instance = LPUART2; // feather 1062
 
 static uint32_t UartSrcFreq(void) {
-  uint32_t freq;
+    uint32_t freq;
 
-  /* To make it simple, we assume default PLL and divider settings, and the only
-     variable from application is use PLL3 source or OSC source */
-  /* PLL3 div6 80M */
-  if (CLOCK_GetMux(kCLOCK_UartMux) == 0) {
-    freq = (CLOCK_GetPllFreq(kCLOCK_PllUsb1) / 6U) /
-           (CLOCK_GetDiv(kCLOCK_UartDiv) + 1U);
-  } else {
-    freq = CLOCK_GetOscFreq() / (CLOCK_GetDiv(kCLOCK_UartDiv) + 1U);
-  }
+    /* To make it simple, we assume default PLL and divider settings, and the only
+       variable from application is use PLL3 source or OSC source */
+    /* PLL3 div6 80M */
+    if (CLOCK_GetMux(kCLOCK_UartMux) == 0) {
+        freq = (CLOCK_GetPllFreq(kCLOCK_PllUsb1) / 6U) /
+            (CLOCK_GetDiv(kCLOCK_UartDiv) + 1U);
+    } else {
+        freq = CLOCK_GetOscFreq() / (CLOCK_GetDiv(kCLOCK_UartDiv) + 1U);
+    }
 
-  return freq;
+    return freq;
 }
 
 void port_serial_init(void) {
-  lpuart_config_t config;
+    lpuart_config_t config;
 
-  LPUART_GetDefaultConfig(&config);
-  config.baudRate_Bps = 115200;
-  config.enableTx = true;
-  config.enableRx = true;
+    LPUART_GetDefaultConfig(&config);
+    config.baudRate_Bps = 115200;
+    config.enableTx = true;
+    config.enableRx = true;
 
-  LPUART_Init(uart_instance, &config, UartSrcFreq());
+    LPUART_Init(uart_instance, &config, UartSrcFreq());
 }
 
-bool port_serial_connected(void) { return true; }
+bool port_serial_connected(void) {
+    return true;
+}
 
 char port_serial_read(void) {
-  uint8_t data;
+    uint8_t data;
 
-  LPUART_ReadBlocking(uart_instance, &data, sizeof(data));
+    LPUART_ReadBlocking(uart_instance, &data, sizeof(data));
 
-  return data;
+    return data;
 }
 
 bool port_serial_bytes_available(void) {
-  return LPUART_GetStatusFlags(uart_instance) & kLPUART_RxDataRegFullFlag;
+    return LPUART_GetStatusFlags(uart_instance) & kLPUART_RxDataRegFullFlag;
 }
 
 void port_serial_write_substring(const char *text, uint32_t len) {
-  if (len == 0) {
-    return;
-  }
+    if (len == 0) {
+        return;
+    }
 
-  LPUART_WriteBlocking(uart_instance, (uint8_t *)text, len);
+    LPUART_WriteBlocking(uart_instance, (uint8_t *)text, len);
 }
 #endif // USE_DEBUG_PORT_CODE


### PR DESCRIPTION
As mentioned in issue #6241  the commit to setup port hooks is now causing all input/output that are to go to the Mu window to also go to the LpUart that is defined the port serial.c

and in this case it goes to lpuart4, which on Teensy 4, 4.1 is used on Arduino `Serial2`.  With this new code this port no longer
works properly.

This is one way to solve it, in that there is a `#if defined()` that if not set, all of the code in this file is ignored and the higher level supervisor stub versions of these functions will be used, which don't interfere with `Serial2` and my test sketch works again.

Note: the PR for Switch to Port Serial Hooks, also changed code in other ports.  I have not tried to see how.

There are other more global fixes for this, in which maybe a higher level  #if that disables the code within the top level supervisor.  Or could be software controlled

Again this may not be the final solution, but at least it gets `Serial2` up and running again.

I went ahead and opened this up as s PR as suggested by @jepler  in my earlier issue: #6228

But I suspect we will want a more inclusive solution.