### PR TITLE
adding bitmap property to TileGrid

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2717,6 +2717,11 @@ msgstr ""
 msgid "binary op %q not implemented"
 msgstr ""
 
+#: shared-bindings/displayio/TileGrid.c
+msgid ""
+"bitmap must be displayio.Bitmap, displayio.Shape, or displayio.OnDiskBitmap"
+msgstr ""
+
 #: shared-bindings/bitmaptools/__init__.c
 msgid "bitmap sizes must match"
 msgstr ""

--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -379,6 +379,37 @@ const mp_obj_property_t displayio_tilegrid_pixel_shader_obj = {
               MP_ROM_NONE},
 };
 
+//|     bitmap: Union[Bitmap,OnDiskBitmap,Shape]
+//|     """The bitmap of the tilegrid."""
+//|
+STATIC mp_obj_t displayio_tilegrid_obj_get_bitmap(mp_obj_t self_in) {
+    displayio_tilegrid_t *self = native_tilegrid(self_in);
+    return common_hal_displayio_tilegrid_get_bitmap(self);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(displayio_tilegrid_get_bitmap_obj, displayio_tilegrid_obj_get_bitmap);
+
+STATIC mp_obj_t displayio_tilegrid_obj_set_bitmap(mp_obj_t self_in, mp_obj_t bitmap) {
+    displayio_tilegrid_t *self = native_tilegrid(self_in);
+    if (!mp_obj_is_type(bitmap, &displayio_bitmap_type) &&
+        !mp_obj_is_type(bitmap, &displayio_ondiskbitmap_type) &&
+        !mp_obj_is_type(bitmap, &displayio_shape_type)) {
+
+        mp_raise_TypeError(translate("bitmap must be displayio.Bitmap, displayio.Shape, or displayio.OnDiskBitmap"));
+    }
+
+    common_hal_displayio_tilegrid_set_bitmap(self, bitmap);
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(displayio_tilegrid_set_bitmap_obj, displayio_tilegrid_obj_set_bitmap);
+
+const mp_obj_property_t displayio_tilegrid_bitmap_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&displayio_tilegrid_get_bitmap_obj,
+              (mp_obj_t)&displayio_tilegrid_set_bitmap_obj,
+              MP_ROM_NONE},
+};
+
 //|     def __getitem__(self, index: Union[Tuple[int, int], int]) -> int:
 //|         """Returns the tile index at the given index. The index can either be an x,y tuple or an int equal
 //|         to ``y * width + x``.
@@ -454,7 +485,8 @@ STATIC const mp_rom_map_elem_t displayio_tilegrid_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_flip_x), MP_ROM_PTR(&displayio_tilegrid_flip_x_obj) },
     { MP_ROM_QSTR(MP_QSTR_flip_y), MP_ROM_PTR(&displayio_tilegrid_flip_y_obj) },
     { MP_ROM_QSTR(MP_QSTR_transpose_xy), MP_ROM_PTR(&displayio_tilegrid_transpose_xy_obj) },
-    { MP_ROM_QSTR(MP_QSTR_pixel_shader),          MP_ROM_PTR(&displayio_tilegrid_pixel_shader_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pixel_shader), MP_ROM_PTR(&displayio_tilegrid_pixel_shader_obj) },
+    { MP_ROM_QSTR(MP_QSTR_bitmap), MP_ROM_PTR(&displayio_tilegrid_bitmap_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(displayio_tilegrid_locals_dict, displayio_tilegrid_locals_dict_table);
 

--- a/shared-bindings/displayio/TileGrid.h
+++ b/shared-bindings/displayio/TileGrid.h
@@ -45,6 +45,9 @@ void common_hal_displayio_tilegrid_set_y(displayio_tilegrid_t *self, mp_int_t y)
 mp_obj_t common_hal_displayio_tilegrid_get_pixel_shader(displayio_tilegrid_t *self);
 void common_hal_displayio_tilegrid_set_pixel_shader(displayio_tilegrid_t *self, mp_obj_t pixel_shader);
 
+mp_obj_t common_hal_displayio_tilegrid_get_bitmap(displayio_tilegrid_t *self);
+void common_hal_displayio_tilegrid_set_bitmap(displayio_tilegrid_t *self, mp_obj_t bitmap);
+
 
 bool common_hal_displayio_tilegrid_get_flip_x(displayio_tilegrid_t *self);
 void common_hal_displayio_tilegrid_set_flip_x(displayio_tilegrid_t *self, bool flip_x);

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -221,6 +221,15 @@ void common_hal_displayio_tilegrid_set_pixel_shader(displayio_tilegrid_t *self, 
     self->full_change = true;
 }
 
+mp_obj_t common_hal_displayio_tilegrid_get_bitmap(displayio_tilegrid_t *self) {
+    return self->bitmap;
+}
+
+void common_hal_displayio_tilegrid_set_bitmap(displayio_tilegrid_t *self, mp_obj_t bitmap) {
+    self->bitmap = bitmap;
+    self->full_change = true;
+}
+
 uint16_t common_hal_displayio_tilegrid_get_width(displayio_tilegrid_t *self) {
     return self->width_in_tiles;
 }


### PR DESCRIPTION
Allows the Bitmap to be changed so that you can swap a tilegrid from one source Bitmap to another. 

Tested successfully with this code:
```py
import time
import adafruit_imageload
import displayio
import board

display = board.DISPLAY
main_group = displayio.Group()

first_bitmap, first_palette = adafruit_imageload.load("bmps/test_bmp_1.bmp")
second_bitmap, second_palette = adafruit_imageload.load("bmps/test_bmp_2.bmp")

first_palette.make_transparent(0)
second_palette.make_transparent(0)

tilegrid = displayio.TileGrid(bitmap=first_bitmap, pixel_shader=first_palette,
                              width=4, height=4,
                              tile_width=16, tile_height=16, default_tile=4)
# fill the tiles
tilegrid[0] = 0
tilegrid[3] = 2
tilegrid[12] = 6
tilegrid[15] = 8
for x in range(2):
    tilegrid[x+1, 0] = 1
    tilegrid[x+1, 3] = 7
for y in range(2):
    tilegrid[0, y+1] = 3
    tilegrid[3, y+1] = 5

# show on the display
main_group.append(tilegrid)
display.show(main_group)

while True:
    tilegrid.bitmap = second_bitmap
    tilegrid.pixel_shader = second_palette
    time.sleep(2)
    tilegrid.bitmap = first_bitmap
    tilegrid.pixel_shader = first_palette
    time.sleep(2)
```
When this test code run it looks like this:

https://user-images.githubusercontent.com/2406189/162583226-7803859a-a4bb-49d9-8754-321689e57218.mp4

I used these bmp files for testing:

[test_bmps.zip](https://github.com/adafruit/circuitpython/files/8457380/test_bmps.zip)

While working on this I noticed an extra large amount of whitespace in this line:
```
{ MP_ROM_QSTR(MP_QSTR_pixel_shader), MP_ROM_PTR(&displayio_tilegrid_pixel_shader_obj) },
```
and removed it as part of the PR to make the spacing match all of the lines around it.
