### PR TITLE
Force pin 21 high; patch; need to diagnose further

### DIFF
--- a/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
@@ -71,6 +71,12 @@ uint8_t display_init_sequence[] = {
 
 
 void board_init(void) {
+    // THIS SHOULD BE HANDLED BY espressif_board_reset_pin_number(), but it is not working.
+    // TEMPORARY FIX UNTIL IT'S DIAGNOSED.
+    common_hal_never_reset_pin(&pin_GPIO21);
+    gpio_set_direction(21, GPIO_MODE_DEF_OUTPUT);
+    gpio_set_level(21, true);
+
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
     displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;


### PR DESCRIPTION
See #6264. Will not close, as it needs to be diagnosed further.

On a few samples of Feather ESP32-S2 TFT, the display does not come on. Forcing pin 21 high in `board_init()` fixes the problem. This is already done in `espressif_board_reset_pin_number()`, but for some reason it is not working, though only on some boards.

Thanks @ladyada for the patch and testing.
