### PR TITLE
improve SAMx5x NeoPixel timings

### DIFF
--- a/ports/atmel-samd/common-hal/neopixel_write/__init__.c
+++ b/ports/atmel-samd/common-hal/neopixel_write/__init__.c
@@ -60,17 +60,17 @@ static void neopixel_send_buffer_core(volatile uint32_t *clraddr, uint32_t pinMa
         "        movs r6, #3; d2: sub r6, #1; bne d2;"          // delay 3
         #endif
         #ifdef SAM_D5X_E5X
-        "        movs r6, #16; d2: subs r6, #1; bne d2;"          // delay 3
+        "        movs r6, #15; d2: subs r6, #1; bne d2;"          // short low or high
         #endif
         "        tst r4, r5;"                                   // mask&r5
         "        bne skipclr;"
         "        str r1, [r0, #0];"          // clr
         "skipclr:"
         #ifdef SAMD21
-        "        movs r6, #6; d0: sub r6, #1; bne d0;"          // delay 6
+        "        movs r6, #6; d0: sub r6, #1; bne d0;"          // long low or high
         #endif
         #ifdef SAM_D5X_E5X
-        "        movs r6, #16; d0: subs r6, #1; bne d0;"          // delay 6
+        "        movs r6, #17; d0: subs r6, #1; bne d0;"          // 834 ns
         #endif
         "        str r1, [r0, #0];"            // clr (possibly again, doesn't matter)
         #ifdef SAMD21
@@ -85,12 +85,12 @@ static void neopixel_send_buffer_core(volatile uint32_t *clraddr, uint32_t pinMa
         "        movs r6, #2; d1: sub r6, #1; bne d1;"          // delay 2
         #endif
         #ifdef SAM_D5X_E5X
-        "        movs r6, #15; d1: subs r6, #1; bne d1;"          // delay 2
+        "        movs r6, #14; d1: subs r6, #1; bne d1;"          // finish low
         #endif
         "        b       loopBit;"
         "nextbyte:"
         #ifdef SAM_D5X_E5X
-        "        movs r6, #12; d3: subs r6, #1; bne d3;"          // delay 2
+        "        movs r6, #14; d3: subs r6, #1; bne d3;"          // finish low
         #endif
         "        cmp r2, r3;"
         "        bcs neopixel_stop;"


### PR DESCRIPTION
Fixes #4102.

This seems to prevent incorrect colors on the first NeoPixel in a string on SAMx5x processors. This is especially noticeable on 5v-level-shifted pins, such as D5 on ItsBitsy M4.

Timings were revamped by empirically changing the delay counts and observing the waveforms. The current timings in ns are below, and can vary by a couple of ns:

zero: 402 high / 834 low
one: 836 high / 402 low

This is close to the RP2040 timings, which uses PIO for precise timings
input zero: 416 high / 832 low
input one: 832 low / 416 high

Note that the far-end Neopixel, which regenerates the timings, is not like this. These far-end timings was observed when driving with an RP2040
output zero: 268 high / 978 low (varies slightly by a few ns)
output one: 698 high / 550 low (varies slightly)