### PR TITLE
Fixes to keypad docs

### DIFF
--- a/shared-bindings/keypad/Event.c
+++ b/shared-bindings/keypad/Event.c
@@ -36,7 +36,7 @@
 //|     def __init__(self, key_number: int=0, pressed: bool=True, timestamp:Optional[int]=None) -> None:
 //|         """Create a key transition event, which reports a key-pressed or key-released transition.
 //|
-//|         :param int key_number: the key number
+//|         :param int key_number: The key number.
 //|         :param bool pressed: ``True`` if the key was pressed; ``False`` if it was released.
 //|         :param int timestamp: The time in milliseconds that the keypress occurred in the `supervisor.ticks_ms` time system.  If specified as None, the current value of `supervisor.ticks_ms` is used.
 //|         """
@@ -120,7 +120,7 @@ const mp_obj_property_t keypad_event_released_obj = {
 };
 
 //|     timestamp: int
-//|     """The timestamp"""
+//|     """The timestamp."""
 //|
 STATIC mp_obj_t keypad_event_get_timestamp(mp_obj_t self_in) {
     keypad_event_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/keypad/EventQueue.c
+++ b/shared-bindings/keypad/EventQueue.c
@@ -45,7 +45,7 @@
 //|         If a new event arrives when the queue is full, the event is discarded, and
 //|         `overflowed` is set to ``True``.
 //|
-//|         :return: the next queued key transition `Event`
+//|         :return: The next queued key transition `Event`.
 //|         :rtype: Optional[Event]
 //|         """
 //|         ...

--- a/shared-bindings/keypad/KeyMatrix.c
+++ b/shared-bindings/keypad/KeyMatrix.c
@@ -157,7 +157,7 @@ STATIC void check_for_deinit(keypad_keymatrix_obj_t *self) {
 //|     """
 //|
 
-//|     def key_number_to_row_column(self, row: int, column: int) -> Tuple[int]:
+//|     def key_number_to_row_column(self, key_number: int) -> Tuple[int]:
 //|         """Return the row and column for the given key number.
 //|         The row is ``key_number // len(column_pins)``.
 //|         The column is ``key_number % len(column_pins)``.


### PR DESCRIPTION
- fix arguments in `key_number_to_row_column`.
- ~~add `on the next scan` to the description of `reset`.~~