### PR TITLE
List frozen modules in the support matrix

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -53,9 +53,13 @@ subprocess.check_output(["make", "stubs"])
 modules_support_matrix = shared_bindings_matrix.support_matrix_by_board()
 modules_support_matrix_reverse = defaultdict(list)
 for board, modules in modules_support_matrix.items():
-    for module in modules:
+    for module in modules[0]:
         modules_support_matrix_reverse[module].append(board)
-modules_support_matrix_reverse = dict((module, sorted(boards)) for module, boards in modules_support_matrix_reverse.items())
+
+modules_support_matrix_reverse = dict(
+    (module, sorted(boards))
+    for module, boards in modules_support_matrix_reverse.items()
+)
 
 html_context = {
     'support_matrix': modules_support_matrix,

--- a/docs/static/filter.css
+++ b/docs/static/filter.css
@@ -7,8 +7,21 @@
 	right: 10px;
 	top: 4px;
 }
-.support-matrix-table .this_module code,
-.support-matrix-table .this_module span {
+
+.support-matrix-table .reference.external {
+	box-sizing: border-box;
+	font-weight: 700;
+	color: #404050;
+	font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
+	padding: 2px 5px;
+	background: white;
+	border: 1px solid #e1e4e5;
+	font-size: 75%;
+}
+
+.support-matrix-table .this_module,
+.support-matrix-table .this_module.reference.external,
+.support-matrix-table .this_module * {
 	background: black;
 	color: white;
 }

--- a/docs/static/filter.css
+++ b/docs/static/filter.css
@@ -11,7 +11,7 @@
 .support-matrix-table .reference.external {
 	box-sizing: border-box;
 	font-weight: 700;
-	color: #404050;
+	color: #404040;
 	font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
 	padding: 2px 5px;
 	background: white;

--- a/docs/static/filter.js
+++ b/docs/static/filter.js
@@ -44,14 +44,14 @@ $(() => {
 		var nvisible = 0;
 		$(".support-matrix-table tbody tr").each( (index,item) => {
 			var name = $(item).find("td:first-child p").html();
-			var modules = $(item).find("a.reference.internal");
+			var modules = $(item).find("code, a.reference.external");
 			var matching_all = true;
 			//
 			list_search.forEach((sstring) => {
 				var matching = (sstring[0] == "-");
 				for(var modi = 0; modi < modules.length; ++modi) {
 					module = modules[modi];
-					var mod_name = module.firstChild.firstChild.textContent;
+					var mod_name = module.firstChild.textContent;
 					if(sstring[0] == "-") {
 						if(mod_name.match(sstring.substr(1))) {
 							matching = false;

--- a/shared-bindings/support_matrix.rst
+++ b/shared-bindings/support_matrix.rst
@@ -4,7 +4,7 @@ Module Support Matrix - Which Modules Are Available on Which Boards
 ===================================================================
 
 The following table lists the available built-in modules for each CircuitPython
-capable board.
+capable board, as well as each :term:`frozen module` included on it.
 
 .. raw:: html
 
@@ -21,6 +21,14 @@ capable board.
    {% for key, value in support_matrix|dictsort %}
        {{ '.. _' ~ key|replace(" ", "-") ~ ':' }}
    * - {{ key }}
-     - {{ ':py:mod:`' ~ value|join("`, :py:mod:`") ~ '`' }}
+     - {{ ':py:mod:`' ~ value[0]|join("`, :py:mod:`") ~ '`' }}
+
+       {% for module in value[1] %}\
+       {% if loop.index == 1 %}**Frozen Modules:** {% endif %}\
+       {% if loop.index > 1 %}, {% endif %}\
+       {% if module[1] %}{{ '`' ~ module[0] ~ ' <' ~ module[1] ~ '>`__' }}\
+       {% else %}{{ '`' ~ module[0] ~ ' <#>`__' }}\
+       {% endif %}\
+       {% endfor %}
 
    {% endfor %}

--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -13,14 +13,15 @@ import base64
 from datetime import date
 from sh.contrib import git
 
-sys.path.append("../docs")
-import shared_bindings_matrix
-
 sys.path.append("adabot")
 import adabot.github_requests as github
 
-from shared_bindings_matrix import SUPPORTED_PORTS
-from shared_bindings_matrix import aliases_by_board
+sys.path.append("../docs")
+from shared_bindings_matrix import (
+    SUPPORTED_PORTS,
+    aliases_by_board,
+    support_matrix_by_board,
+)
 
 BIN = ("bin",)
 UF2 = ("uf2",)
@@ -124,20 +125,11 @@ def get_board_mapping():
                 extensions = extension_by_port[port]
                 extensions = extension_by_board.get(board_path.name, extensions)
                 aliases = aliases_by_board.get(board_path.name, [])
-                frozen_libraries = []
-                with open(os.path.join(board_path, "mpconfigboard.mk")) as mpconfig:
-                    frozen_lines = [
-                        line for line in mpconfig if line.startswith("FROZEN_MPY_DIRS")
-                    ]
-                    frozen_libraries.extend(
-                        [line[line.rfind("/") + 1 :].strip() for line in frozen_lines]
-                    )
                 boards[board_id] = {
                     "port": port,
                     "extensions": extensions,
                     "download_count": 0,
                     "aliases": aliases,
-                    "frozen_libraries": frozen_libraries,
                 }
                 for alias in aliases:
                     boards[alias] = {
@@ -284,7 +276,7 @@ def generate_download_info():
 
     languages = get_languages()
 
-    support_matrix = shared_bindings_matrix.support_matrix_by_board(use_branded_name=False)
+    support_matrix = support_matrix_by_board(use_branded_name=False)
 
     new_stable = "-" not in new_tag
 
@@ -321,10 +313,10 @@ def generate_download_info():
                     new_version = {
                         "stable": new_stable,
                         "version": new_tag,
-                        "modules": support_matrix[alias],
+                        "modules": support_matrix[alias][0],
                         "languages": languages,
                         "extensions": board_info["extensions"],
-                        "frozen_libraries": board_info["frozen_libraries"],
+                        "frozen_libraries": [frozen[0] for frozen in support_matrix[alias][1]],
                     }
                     current_info[alias]["downloads"] = alias_info["download_count"]
                     current_info[alias]["versions"].append(new_version)

--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -66,14 +66,14 @@ submodules = []
 if target == "test":
     submodules = ["extmod/", "lib/", "tools/", "extmod/ulab", "lib/berkeley-db-1.xx"]
 elif target == "docs":
-    submodules = ["extmod/ulab/"]
+    submodules = ["extmod/ulab/", "frozen/"]
 elif target == "mpy-cross-mac":
     submodules = ["tools/"]  # for huffman
 elif target == "windows":
     # This builds one board from a number of ports so fill out a bunch of submodules
     submodules = ["extmod/", "lib/", "tools/", "ports/", "data/nvm.toml/"]
 elif target == "website":
-    submodules = ["tools/adabot/"]
+    submodules = ["tools/adabot/", "frozen/"]
 else:
     p = list(pathlib.Path(".").glob(f"ports/*/boards/{target}/mpconfigboard.mk"))
     if not p:


### PR DESCRIPTION
This adds the frozen modules to the support matrix.
- each module is designated by its import name. eg: `neopixel` not `Adafruit_Circuitpython_Neopixel`
- frozen modules appear without a link, since those links are generated by sphinx as internal links
- the `usb` module is fixed to only show on boards with `CIRCUITPY_USB_HOST` (Closes: #6364)

Questions:
- Any idea how to make Sphinx link to the libraries RTD pages ?
- Should the frozen libraries be listed separately from the built-in ones or visually differentiated in some way ?

<img width="697" alt="Capture d’écran 2022-04-17 à 04 16 22" src="https://user-images.githubusercontent.com/6160205/163697409-37b6bbe7-d89f-410d-9279-843ba269d9dd.png">
