### PR TITLE
Remove frozen bus device modules

### DIFF
--- a/ports/espressif/boards/adafruit_feather_esp32s2_tftback_nopsram/mpconfigboard.mk
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_tftback_nopsram/mpconfigboard.mk
@@ -20,5 +20,4 @@ CIRCUITPY_MODULE=wroom
 
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Requests
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Register

--- a/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/mpconfigboard.mk
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/mpconfigboard.mk
@@ -19,5 +19,4 @@ CIRCUITPY_ESP_FLASH_SIZE=8MB
 
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Requests
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Register

--- a/ports/nrf/boards/TG-Watch/mpconfigboard.mk
+++ b/ports/nrf/boards/TG-Watch/mpconfigboard.mk
@@ -8,7 +8,6 @@ MCU_CHIP = nrf52840
 QSPI_FLASH_FILESYSTEM = 1
 EXTERNAL_FLASH_DEVICES = "GD25Q16C, W25Q128JVxQ"
 
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Register
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_ST7789
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Display_Shapes

--- a/ports/raspberrypi/boards/solderparty_rp2040_stamp/mpconfigboard.mk
+++ b/ports/raspberrypi/boards/solderparty_rp2040_stamp/mpconfigboard.mk
@@ -11,7 +11,6 @@ EXTERNAL_FLASH_DEVICES = "GD25Q64C"
 CIRCUITPY__EVE = 1
 
 FROZEN_MPY_DIRS += $(TOP)/ports/raspberrypi/boards/solderparty_rp2040_stamp
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_HID
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Register


### PR DESCRIPTION
`adafruit_bus_device` is built-in now, no need to freeze it in. The other frozen modules have been put intentionally (in particular the ESP boards with no PSRAM benefit from common modules being in the flash).