### PR TITLE
rp2040: add a background write with looping to StateMachines

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1530,6 +1530,11 @@ msgstr ""
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
 msgstr ""
 
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Mismatched data size"
+msgstr ""
+
 #: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
 msgid "Missing MISO or MOSI Pin"
 msgstr ""
@@ -3019,7 +3024,7 @@ msgstr ""
 msgid "complex values not supported"
 msgstr ""
 
-#: extmod/moduzlib.c shared-module/zlib/DecompIO.c
+#: extmod/moduzlib.c
 msgid "compression header"
 msgstr ""
 

--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -459,8 +459,8 @@ void isr_dma_0(void) {
             dma->channels_to_load_mask |= mask;
             background_callback_add(&dma->callback, dma_callback_fun, (void *)dma);
         }
-        if (MP_STATE_PORT(continuous_pio)[i] != NULL) {
-            rp2pio_statemachine_obj_t *pio = MP_STATE_PORT(continuous_pio)[i];
+        if (MP_STATE_PORT(background_pio)[i] != NULL) {
+            rp2pio_statemachine_obj_t *pio = MP_STATE_PORT(background_pio)[i];
             rp2pio_statemachine_dma_complete(pio, i);
         }
     }

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -426,7 +426,7 @@ STATIC mp_obj_t rp2pio_statemachine_write(size_t n_args, const mp_obj_t *pos_arg
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_obj, 2, rp2pio_statemachine_write);
 
-//|     def continuous_write(self, buffer: Optional[ReadableBuffer], *, start: int = 0, end: Optional[int] = None) -> None:
+//|     def start_continuous_write(self, buffer: Optional[ReadableBuffer], *, start: int = 0, end: Optional[int] = None) -> None:
 //|         """Write the data contained in ``buffer`` to the state machine repeatedly until stopped. If the buffer is empty or None, an existing continuous_write is canceled.
 //|
 //|         Writes to the FIFO will match the input buffer's element size. For example, bytearray elements
@@ -434,11 +434,12 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_obj, 2, rp2pio_statemachine
 //|         the other byte positions. So, pulling more data in the PIO assembly will read the duplicated values.
 //|
 //|         To perform 16 or 32 bits writes into the FIFO use an `array.array` with a type code of the desired
-//|         size.
+//|         size, or use `memoryview.cast` to change the interpretation of an existing buffer.
 //|
 //|         To atomically change from one buffer to another, simply call
-//|         `StateMachine.continuous_write` again with a different buffer.
-//|         The call will only return once outputting the new buffer has started.
+//|         `StateMachine.continuous_write` again with a different buffer with the same element size.
+//|         The call will only return once DMA has started putting the previous
+//|         buffer's data into the PIO FIFO.
 //|
 //|         If the buffer is modified while it is being written out, the updated
 //|         values will be used. However, because of interactions between CPU

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -482,6 +482,9 @@ STATIC mp_obj_t rp2pio_statemachine_start_continuous_write(size_t n_args, const 
 
         ok = common_hal_rp2pio_statemachine_start_continuous_write(self, args[ARG_buffer].u_obj, ((uint8_t *)bufinfo.buf) + start, length, stride_in_bytes);
     }
+    if (mp_hal_is_interrupted()) {
+        return mp_const_none;
+    }
     if (!ok) {
         mp_raise_OSError(MP_EIO);
     }
@@ -495,6 +498,9 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_start_continuous_write_obj, 2, rp
 STATIC mp_obj_t rp2pio_statemachine_obj_end_continuous_write(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
     bool ok = common_hal_rp2pio_statemachine_end_continuous_write(self);
+    if (mp_hal_is_interrupted()) {
+        return mp_const_none;
+    }
     if (!ok) {
         mp_raise_OSError(MP_EIO);
     }

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -480,7 +480,7 @@ STATIC mp_obj_t rp2pio_statemachine_start_continuous_write(size_t n_args, const 
             mp_raise_ValueError(translate("Buffer elements must be 4 bytes long or less"));
         }
 
-        ok = common_hal_rp2pio_statemachine_start_continuous_write(self, ((uint8_t *)bufinfo.buf) + start, length, stride_in_bytes);
+        ok = common_hal_rp2pio_statemachine_start_continuous_write(self, args[ARG_buffer].u_obj, ((uint8_t *)bufinfo.buf) + start, length, stride_in_bytes);
     }
     if (!ok) {
         mp_raise_OSError(MP_EIO);

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -426,7 +426,7 @@ STATIC mp_obj_t rp2pio_statemachine_write(size_t n_args, const mp_obj_t *pos_arg
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_obj, 2, rp2pio_statemachine_write);
 
-//|     def background_write(self, once: Optional[ReadableBuffer]=None, *, loop=Optional[ReadableBuffer]=None) -> None:
+//|     def background_write(self, once: Optional[ReadableBuffer]=None, *, loop: Optional[ReadableBuffer]=None) -> None:
 //|         """Write data to the TX fifo in the background, with optional looping.
 //|
 //|         First, if any previous ``once`` or ``loop`` buffer has not been started, this function blocks until they have.

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -437,7 +437,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_obj, 2, rp2pio_statemachine
 //|         size, or use `memoryview.cast` to change the interpretation of an existing buffer.
 //|
 //|         To atomically change from one buffer to another, simply call
-//|         `StateMachine.continuous_write` again with a different buffer with the same element size.
+//|         `StateMachine.start_continuous_write` again with a different buffer with the same element size.
 //|         The call will only return once DMA has started putting the previous
 //|         buffer's data into the PIO FIFO.
 //|

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.h
@@ -65,6 +65,8 @@ void common_hal_rp2pio_statemachine_run(rp2pio_statemachine_obj_t *self, const u
 
 // Writes out the given data.
 bool common_hal_rp2pio_statemachine_write(rp2pio_statemachine_obj_t *self, const uint8_t *data, size_t len, uint8_t stride_in_bytes);
+bool common_hal_rp2pio_statemachine_start_continuous_write(rp2pio_statemachine_obj_t *self, const uint8_t *data, size_t len, uint8_t stride_in_bytes);
+bool common_hal_rp2pio_statemachine_end_continuous_write(rp2pio_statemachine_obj_t *self);
 bool common_hal_rp2pio_statemachine_readinto(rp2pio_statemachine_obj_t *self, uint8_t *data, size_t len, uint8_t stride_in_bytes);
 bool common_hal_rp2pio_statemachine_write_readinto(rp2pio_statemachine_obj_t *self,
     const uint8_t *data_out, size_t out_len, uint8_t out_stride_in_bytes,

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.h
@@ -65,8 +65,10 @@ void common_hal_rp2pio_statemachine_run(rp2pio_statemachine_obj_t *self, const u
 
 // Writes out the given data.
 bool common_hal_rp2pio_statemachine_write(rp2pio_statemachine_obj_t *self, const uint8_t *data, size_t len, uint8_t stride_in_bytes);
-bool common_hal_rp2pio_statemachine_start_continuous_write(rp2pio_statemachine_obj_t *self, mp_obj_t buf_obj, const uint8_t *data, size_t len, uint8_t stride_in_bytes);
-bool common_hal_rp2pio_statemachine_end_continuous_write(rp2pio_statemachine_obj_t *self);
+bool common_hal_rp2pio_statemachine_background_write(rp2pio_statemachine_obj_t *self, const sm_buf_info *once_obj, const sm_buf_info *loop_obj, uint8_t stride_in_bytes);
+bool common_hal_rp2pio_statemachine_stop_background_write(rp2pio_statemachine_obj_t *self);
+mp_int_t common_hal_rp2pio_statemachine_get_pending(rp2pio_statemachine_obj_t *self);
+bool common_hal_rp2pio_statemachine_get_writing(rp2pio_statemachine_obj_t *self);
 bool common_hal_rp2pio_statemachine_readinto(rp2pio_statemachine_obj_t *self, uint8_t *data, size_t len, uint8_t stride_in_bytes);
 bool common_hal_rp2pio_statemachine_write_readinto(rp2pio_statemachine_obj_t *self,
     const uint8_t *data_out, size_t out_len, uint8_t out_stride_in_bytes,

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.h
@@ -65,7 +65,7 @@ void common_hal_rp2pio_statemachine_run(rp2pio_statemachine_obj_t *self, const u
 
 // Writes out the given data.
 bool common_hal_rp2pio_statemachine_write(rp2pio_statemachine_obj_t *self, const uint8_t *data, size_t len, uint8_t stride_in_bytes);
-bool common_hal_rp2pio_statemachine_start_continuous_write(rp2pio_statemachine_obj_t *self, const uint8_t *data, size_t len, uint8_t stride_in_bytes);
+bool common_hal_rp2pio_statemachine_start_continuous_write(rp2pio_statemachine_obj_t *self, mp_obj_t buf_obj, const uint8_t *data, size_t len, uint8_t stride_in_bytes);
 bool common_hal_rp2pio_statemachine_end_continuous_write(rp2pio_statemachine_obj_t *self);
 bool common_hal_rp2pio_statemachine_readinto(rp2pio_statemachine_obj_t *self, uint8_t *data, size_t len, uint8_t stride_in_bytes);
 bool common_hal_rp2pio_statemachine_write_readinto(rp2pio_statemachine_obj_t *self,

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -848,3 +848,11 @@ uint8_t rp2pio_statemachine_program_offset(rp2pio_statemachine_obj_t *self) {
     uint8_t sm = self->state_machine;
     return _current_program_offset[pio_index][sm];
 }
+
+bool common_hal_rp2pio_statemachine_start_continuous_write(rp2pio_statemachine_obj_t *self, const uint8_t *data, size_t len, uint8_t stride_in_bytes) {
+    return false;
+}
+
+bool common_hal_rp2pio_statemachine_end_continuous_write(rp2pio_statemachine_obj_t *self) {
+    return false;
+}

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -24,6 +24,8 @@
  * THE SOFTWARE.
  */
 
+#include <string.h>
+
 #include "bindings/rp2pio/StateMachine.h"
 
 #include "common-hal/microcontroller/__init__.h"
@@ -86,7 +88,7 @@ STATIC void rp2pio_statemachine_clear_dma(int pio_index, int sm) {
         if (!dma_hw->inte0) {
             irq_set_mask_enabled(1 << DMA_IRQ_0, false);
         }
-        MP_STATE_PORT(continuous_pio)[channel] = NULL;
+        MP_STATE_PORT(background_pio)[channel] = NULL;
         dma_channel_abort(channel);
         dma_channel_unclaim(channel);
     }
@@ -608,7 +610,7 @@ void common_hal_rp2pio_statemachine_set_frequency(rp2pio_statemachine_obj_t *sel
 
 void rp2pio_statemachine_deinit(rp2pio_statemachine_obj_t *self, bool leave_pins) {
     common_hal_rp2pio_statemachine_stop(self);
-    (void)common_hal_rp2pio_statemachine_end_continuous_write(self);
+    (void)common_hal_rp2pio_statemachine_stop_background_write(self);
 
     uint8_t sm = self->state_machine;
     uint8_t pio_index = pio_get_index(self->pio);
@@ -877,31 +879,42 @@ uint8_t rp2pio_statemachine_program_offset(rp2pio_statemachine_obj_t *self) {
     return _current_program_offset[pio_index][sm];
 }
 
-bool common_hal_rp2pio_statemachine_start_continuous_write(rp2pio_statemachine_obj_t *self, mp_obj_t buf_obj, const uint8_t *data, size_t len, uint8_t stride_in_bytes) {
+bool common_hal_rp2pio_statemachine_background_write(rp2pio_statemachine_obj_t *self, const sm_buf_info *once, const sm_buf_info *loop, uint8_t stride_in_bytes) {
     uint8_t pio_index = pio_get_index(self->pio);
     uint8_t sm = self->state_machine;
 
-    if (SM_DMA_ALLOCATED(pio_index, sm) && stride_in_bytes == self->continuous_stride_in_bytes) {
-        while (self->pending_set_data) {
+    int pending_buffers = (once->info.buf != NULL) + (loop->info.buf != NULL);
+    if (!once->info.buf) {
+        once = loop;
+    }
+
+
+    if (SM_DMA_ALLOCATED(pio_index, sm)) {
+        if (stride_in_bytes != self->background_stride_in_bytes) {
+            mp_raise_ValueError(translate("Mismatched data size"));
+        }
+
+        while (self->pending_buffers) {
             RUN_BACKGROUND_TASKS;
             if (self->user_interruptible && mp_hal_is_interrupted()) {
-                (void)common_hal_rp2pio_statemachine_end_continuous_write(self);
                 return false;
             }
         }
 
         common_hal_mcu_disable_interrupts();
-        self->next_buffer = data;
-        self->next_size = len / stride_in_bytes;
-        self->pending_set_data = true;
+        self->once = *once;
+        self->loop = *loop;
+        self->pending_buffers = pending_buffers;
+
+        if (self->dma_completed) {
+            rp2pio_statemachine_dma_complete(self, SM_DMA_GET_CHANNEL(pio_index, sm));
+            self->dma_completed = false;
+        }
+
         common_hal_mcu_enable_interrupts();
 
-        // need to keep a reference alive to the buffer, lest the GC collect it while its lone remaining pointer is in the DMA peripheral register
-        self->buf_objs[++self->buf_obj_idx % 2] = buf_obj;
         return true;
     }
-
-    common_hal_rp2pio_statemachine_end_continuous_write(self);
 
     int channel = dma_claim_unused_channel(false);
     if (channel == -1) {
@@ -916,13 +929,12 @@ bool common_hal_rp2pio_statemachine_start_continuous_write(rp2pio_statemachine_o
 
     dma_channel_config c;
 
-    self->pending_set_data = false;
-    self->continuous_stride_in_bytes = stride_in_bytes;
-    self->buf_objs[0] = buf_obj;
-    self->buf_objs[1] = NULL;
-
-    self->next_buffer = data;
-    self->next_size = len / stride_in_bytes;
+    self->current = *once;
+    self->once = *loop;
+    self->loop = *loop;
+    self->pending_buffers = pending_buffers;
+    self->dma_completed = false;
+    self->background_stride_in_bytes = stride_in_bytes;
 
     c = dma_channel_get_default_config(channel);
     channel_config_set_transfer_data_size(&c, _stride_to_dma_size(stride_in_bytes));
@@ -931,12 +943,12 @@ bool common_hal_rp2pio_statemachine_start_continuous_write(rp2pio_statemachine_o
     channel_config_set_write_increment(&c, false);
     dma_channel_configure(channel, &c,
         tx_destination,
-        data,
-        len / stride_in_bytes,
+        once->info.buf,
+        once->info.len / stride_in_bytes,
         false);
 
     common_hal_mcu_disable_interrupts();
-    MP_STATE_PORT(continuous_pio)[channel] = self;
+    MP_STATE_PORT(background_pio)[channel] = self;
     dma_hw->inte0 |= 1u << channel;
     irq_set_mask_enabled(1 << DMA_IRQ_0, true);
     dma_start_channel_mask(1u << channel);
@@ -946,15 +958,36 @@ bool common_hal_rp2pio_statemachine_start_continuous_write(rp2pio_statemachine_o
 }
 
 void rp2pio_statemachine_dma_complete(rp2pio_statemachine_obj_t *self, int channel) {
-    dma_channel_set_read_addr(channel, self->next_buffer, false);
-    dma_channel_set_trans_count(channel, self->next_size, true);
+    self->current = self->once;
+    self->once = self->loop;
 
-    self->pending_set_data = false;
+    if (self->current.info.buf) {
+        if (self->pending_buffers > 0) {
+            self->pending_buffers--;
+        }
+        dma_channel_set_read_addr(channel, self->current.info.buf, false);
+        dma_channel_set_trans_count(channel, self->current.info.len / self->background_stride_in_bytes, true);
+    } else {
+        self->dma_completed = true;
+        self->pending_buffers = 0; // should be a no-op
+    }
 }
 
-bool common_hal_rp2pio_statemachine_end_continuous_write(rp2pio_statemachine_obj_t *self) {
+bool common_hal_rp2pio_statemachine_stop_background_write(rp2pio_statemachine_obj_t *self) {
     uint8_t pio_index = pio_get_index(self->pio);
     uint8_t sm = self->state_machine;
     rp2pio_statemachine_clear_dma(pio_index, sm);
+    memset(&self->current, 0, sizeof(self->current));
+    memset(&self->once, 0, sizeof(self->once));
+    memset(&self->loop, 0, sizeof(self->loop));
+    self->pending_buffers = 0;
     return true;
+}
+
+bool common_hal_rp2pio_statemachine_get_writing(rp2pio_statemachine_obj_t *self) {
+    return !self->dma_completed;
+}
+
+int common_hal_rp2pio_statemachine_get_pending(rp2pio_statemachine_obj_t *self) {
+    return self->pending_buffers;
 }

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
@@ -59,7 +59,6 @@ typedef struct {
     uint8_t buf_obj_idx;
     const uint8_t *next_buffer;
     size_t next_size;
-    int dma_channel[2];
     mp_obj_t buf_objs[2];
     int continuous_stride_in_bytes;
     volatile int pending_set_data;

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
@@ -54,6 +54,15 @@ typedef struct {
     bool in_shift_right;
     bool user_interruptible;
     uint8_t offset;
+
+    // dma-related items
+    uint8_t buf_obj_idx;
+    const uint8_t *next_buffer;
+    size_t next_size;
+    int dma_channel[2];
+    mp_obj_t buf_objs[2];
+    int continuous_stride_in_bytes;
+    volatile int pending_set_data;
 } rp2pio_statemachine_obj_t;
 
 void reset_rp2pio_statemachine(void);
@@ -82,6 +91,7 @@ bool rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
 uint8_t rp2pio_statemachine_program_offset(rp2pio_statemachine_obj_t *self);
 
 void rp2pio_statemachine_deinit(rp2pio_statemachine_obj_t *self, bool leave_pins);
+void rp2pio_statemachine_dma_complete(rp2pio_statemachine_obj_t *self, int channel);
 
 extern const mp_obj_type_t rp2pio_statemachine_type;
 

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
@@ -32,6 +32,11 @@
 #include "common-hal/microcontroller/Pin.h"
 #include "src/rp2_common/hardware_pio/include/hardware/pio.h"
 
+typedef struct sm_buf_info {
+    mp_obj_t obj;
+    mp_buffer_info_t info;
+} sm_buf_info;
+
 typedef struct {
     mp_obj_base_t base;
     uint32_t pins; // Bitmask of what pins this state machine uses.
@@ -56,12 +61,10 @@ typedef struct {
     uint8_t offset;
 
     // dma-related items
-    uint8_t buf_obj_idx;
-    const uint8_t *next_buffer;
-    size_t next_size;
-    mp_obj_t buf_objs[2];
-    int continuous_stride_in_bytes;
-    volatile int pending_set_data;
+    volatile int pending_buffers;
+    sm_buf_info current, once, loop;
+    int background_stride_in_bytes;
+    bool dma_completed;
 } rp2pio_statemachine_obj_t;
 
 void reset_rp2pio_statemachine(void);

--- a/ports/raspberrypi/mpconfigport.h
+++ b/ports/raspberrypi/mpconfigport.h
@@ -46,7 +46,7 @@
 #define MICROPY_PORT_ROOT_POINTERS \
     mp_obj_t counting[NUM_PWM_SLICES]; \
     mp_obj_t playing_audio[NUM_DMA_CHANNELS]; \
-    mp_obj_t continuous_pio[NUM_DMA_CHANNELS]; \
+    mp_obj_t background_pio[NUM_DMA_CHANNELS]; \
     CIRCUITPY_COMMON_ROOT_POINTERS;
 
 #endif  // __INCLUDED_MPCONFIGPORT_H

--- a/ports/raspberrypi/mpconfigport.h
+++ b/ports/raspberrypi/mpconfigport.h
@@ -46,6 +46,7 @@
 #define MICROPY_PORT_ROOT_POINTERS \
     mp_obj_t counting[NUM_PWM_SLICES]; \
     mp_obj_t playing_audio[NUM_DMA_CHANNELS]; \
+    mp_obj_t continuous_pio[NUM_DMA_CHANNELS]; \
     CIRCUITPY_COMMON_ROOT_POINTERS;
 
 #endif  // __INCLUDED_MPCONFIGPORT_H


### PR DESCRIPTION
This adds the ability to background-write to a StateMachine, either once or in a loop (or both). It can be seen in action driving servos in the parallel pull request https://github.com/adafruit/Adafruit_CircuitPython_PIOASM/pull/41

- [x] buffers less than 8 entries long don't work right
- [x] exiting without deinit runs out of buffers
- [x] it seems to take "a long time" to switch buffers, but that may be because of how I have artificially long sequences
- [x] debug statements
- [x] traces of using 2 dma channels, can use just 1
- [x] update the pulsegroup example to the current API

The examples below worked with an older version of the PR:
<details>

"Servo Cluster" / "PWM Cluster" works: https://gist.github.com/jepler/5043843c9c196ad9d513e9f89e48ba79 as does this simpler test program:
```python
import supervisor
import array
import board
import rp2pio
import adafruit_pioasm
import sys

# Two different blinks: long & short
a = array.array('H', [0xc0c0])
b = array.array('H', [0x6060])

delay = 1
text_program = f"""
    set pins 0 [{delay}]
    out x 8 [{delay}]
wait_hi:
    jmp x--, wait_hi  [{delay}]

    set pins 1 [{delay}]
    out x 8 [{delay}]
wait_lo:
    jmp x--, wait_lo  [{delay}]
"""

program = adafruit_pioasm.Program(text_program, build_debuginfo=True)

def cycle(*args):
    while True:
        yield from args

sm = rp2pio.StateMachine(program.assembled, frequency=2000, first_set_pin=board.D13, auto_pull=True, pull_threshold=16)

print("""
Press a key to change blink patterns. Note the delay of 8-9 blinks before
change, due to the 8-element depth of the PIO TX FIFO
"""
)
for signal in cycle(a, b):
    sm.start_continuous_write(signal)
    sys.stdin.read(1)

```
</details>

Closes: #6295 