### PR TITLE
Add docs/templates to templates in conf.py

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -83,7 +83,7 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['templates']
+templates_path = ['templates', "docs/templates"]
 
 # The suffix of source filenames.
 source_suffix = {


### PR DESCRIPTION
Fixes #5763 with the fix suggested by @neradoc by adding `docs/templates` to `conf.py`.  Building locally, it removes the "View page source" so this should be the fix!