### PR TITLE
Fix audacity mp3 (erroneous EOF detected)

### DIFF
--- a/shared-module/audiomp3/MP3Decoder.c
+++ b/shared-module/audiomp3/MP3Decoder.c
@@ -356,6 +356,11 @@ audioio_get_buffer_result_t audiomp3_mp3file_get_buffer(audiomp3_mp3file_obj_t *
         return GET_BUFFER_DONE;
     }
 
+    self->samples_decoded += *buffer_length / sizeof(int16_t);
+
+    mp3file_skip_id3v2(self);
+    int result = mp3file_find_sync_word(self) ? GET_BUFFER_MORE_DATA : GET_BUFFER_DONE;
+
     if (self->inbuf_offset >= 512) {
         background_callback_add(
             &self->inbuf_fill_cb,
@@ -363,8 +368,7 @@ audioio_get_buffer_result_t audiomp3_mp3file_get_buffer(audiomp3_mp3file_obj_t *
             self);
     }
 
-    self->samples_decoded += *buffer_length / sizeof(int16_t);
-    return mp3file_find_sync_word(self) ? GET_BUFFER_MORE_DATA : GET_BUFFER_DONE;
+    return result;
 }
 
 void audiomp3_mp3file_get_buffer_structure(audiomp3_mp3file_obj_t *self, bool single_channel_output,

--- a/shared-module/audiomp3/MP3Decoder.c
+++ b/shared-module/audiomp3/MP3Decoder.c
@@ -53,7 +53,7 @@
  */
 STATIC bool mp3file_update_inbuf_always(audiomp3_mp3file_obj_t *self) {
     // If we didn't previously reach the end of file, we can try reading now
-    if (!self->eof) {
+    if (!self->eof && self->inbuf_offset != 0) {
 
         // Move the unconsumed portion of the buffer to the start
         uint8_t *end_of_buffer = self->inbuf + self->inbuf_length;


### PR DESCRIPTION
The old formulation
 * could cause an erroneous EOF and stop playing
 * wouldn't work if there were ID3 tags at the end
 * would choose whether to background-refill the inbuf
   based on a check before skipping to the next sync word, which
   could be incorrect.

I think point 3 triggered point 1, leading to the EOF
problem fixed in the first commit. This would depend on specific data
sizes and offsets occuring in the file such that a read would be
scheduled but then the buffer would be filled and left 100% full by
find_sync_word(). It's just lucky(?) that a particular person produced
such a file, and/or many files produced by Audacity have those
characteristics.
