### PR TITLE
test and adjust NeoPixel timings on multiple ports

### DIFF
--- a/ports/espressif/common-hal/neopixel_write/__init__.c
+++ b/ports/espressif/common-hal/neopixel_write/__init__.c
@@ -47,11 +47,11 @@
 #include "components/driver/include/driver/rmt.h"
 #include "peripherals/rmt.h"
 
-// 416 ns is 1/3 of the 1250ns period of a 800khz signal.
-#define WS2812_T0H_NS (416)
-#define WS2812_T0L_NS (416 * 2)
-#define WS2812_T1H_NS (416 * 2)
-#define WS2812_T1L_NS (416)
+// Use closer to WS2812-style timings instead of WS2812B, to accommodate more varieties.
+#define WS2812_T0H_NS (316)
+#define WS2812_T0L_NS (316 * 3)
+#define WS2812_T1H_NS (700)
+#define WS2812_T1L_NS (564)
 
 static uint32_t ws2812_t0h_ticks = 0;
 static uint32_t ws2812_t1h_ticks = 0;

--- a/ports/nrf/common-hal/neopixel_write/__init__.c
+++ b/ports/nrf/common-hal/neopixel_write/__init__.c
@@ -53,13 +53,16 @@
 // The PWM starts the duty cycle in LOW. To start with HIGH we
 // need to set the 15th bit on each register.
 
+// *** CircuitPython: Use WS2812 for all, works with https://adafru.it/5225 and everything else
+// ***
+
 // WS2812 (rev A) timing is 0.35 and 0.7us
-// #define MAGIC_T0H               5UL | (0x8000) // 0.3125us
-// #define MAGIC_T1H              12UL | (0x8000) // 0.75us
+#define MAGIC_T0H               5UL | (0x8000) // 0.3125us
+#define MAGIC_T1H              12UL | (0x8000) // 0.75us
 
 // WS2812B (rev B) timing is 0.4 and 0.8 us
-#define MAGIC_T0H               6UL | (0x8000) // 0.375us
-#define MAGIC_T1H              13UL | (0x8000) // 0.8125us
+// #define MAGIC_T0H               6UL | (0x8000) // 0.375us
+// #define MAGIC_T1H              13UL | (0x8000) // 0.8125us
 #define CTOPVAL                20UL            // 1.25us
 
 // ---------- END Constants for the EasyDMA implementation -------------

--- a/ports/stm/common-hal/neopixel_write/__init__.c
+++ b/ports/stm/common-hal/neopixel_write/__init__.c
@@ -38,8 +38,8 @@ uint64_t next_start_raw_ticks = 0;
 
 // sysclock divisors
 #define MAGIC_800_INT  900000  // ~1.11 us  -> 1.2  field
-#define MAGIC_800_T0H  2800000  // ~0.36 us -> 0.44 field
-#define MAGIC_800_T1H  1350000  // ~0.74 us -> 0.84 field
+#define MAGIC_800_T0H  3500000  // 300ns actual; 880 low
+#define MAGIC_800_T1H  1350000  // 768ns actual; 412 low
 
 #pragma GCC push_options
 #pragma GCC optimize ("Os")

--- a/shared-bindings/neopixel_write/__init__.c
+++ b/shared-bindings/neopixel_write/__init__.c
@@ -32,6 +32,42 @@
 #include "shared-bindings/util.h"
 #include "supervisor/shared/translate.h"
 
+// RGB LED timing information:
+
+// From the WS2811 datasheet: high speed mode
+// - T0H 0 code,high voltage time 0.25 us +-150ns
+// - T1H 1 code,high voltage time 0.6  us +-150ns
+// - T0L 0 code,low voltage time 1.0 us +-150ns
+// - T1L 1 code,low voltage time 0.65 us +-150ns
+// - RES low voltage time Above 50us
+
+// From the SK6812 datasheet:
+// - T0H 0 code, high level time 0.3us +-0.15us
+// - T1H 1 code, high level time 0.6us +-0.15us
+// - T0L 0 code, low level time 0.9us +-0.15us
+// - T1L 1 code, low level time 0.6us +-0.15us
+// - Trst Reset code，low level time 80us
+
+// From the WS2812 datasheet:
+// - T0H 0 code, high voltage time 0.35us +-150ns
+// - T1H 1 code, high voltage time 0.7us +-150ns
+// - T0L 0 code, low voltage time 0.8us +-150ns
+// - T1L 1 code, low voltage time 0.6us +-150ns
+// - RES low voltage time Above 50us
+
+// From the WS28212B datasheet:
+// - T0H 0 code, high voltage time 0.4us +-150ns
+// - T1H 1 code, high voltage time 0.8us +-150ns
+// - T0L 0 code, low voltage time 0.85us +-150ns
+// - T1L 1 code, low voltage time 0.45us +-150ns
+// - RES low voltage time Above 50us
+
+// The timings used in various ports do not always follow the guidelines above.
+// In general, a zero bit is about 300ns high, 900ns low.
+// A one bit is about 700ns high, 500ns low.
+// But the ports vary based on implementation considerations; the proof is in the testing.
+// https://adafru.it/5225 is more sensitive to timing and should be included in testing.
+
 STATIC void check_for_deinit(digitalio_digitalinout_obj_t *self) {
     if (common_hal_digitalio_digitalinout_deinited(self)) {
         raise_deinited_error();


### PR DESCRIPTION
Reworked NeoPixel timings for a number of ports.
Fixes #5505.
Fixes #4102.

Tested with:
- https://www.adafruit.com/product/1426 - Stick of 8 NeoPixels
- https://www.adafruit.com/product/3919 - strip of 20
- https://www.adafruit.com/product/5225 - "Fairylight" slim strand of 20; WS2811-ish, according to mfr
- https://www.adafruit.com/product/1260 - Float RGB Smart NeoPixel Version 2; 6 pin WS2812
- https://www.adafruit.com/product/4560 - Soft Flexible Wire strand
- SeeedStudio WS2813B 104990303 - 60 strip WS2813B

No work done on Spresense, i.MX, fomu, or broadcom ports.

The main issue was getting https://www.adafruit.com/product/5225 to work properly. It did not work on several ports previously. SAMD51 timings were also off enough that the first pixel was sometimes wrong.

The timings have been adjusted to:
about 300 ns high, 900 ns low, for a zero
about 700 ns high, 500 ns low, for a one
These vary per implementation, based on implementation constraints.

For reference, I added a datasheet summary to `shared-bindings/neopixel_write/__init__.c`.
.



