### PR TITLE
huffman is a submodule and does not need to be in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,3 @@
-# For string compression
-huffman
-
 # For nvm.toml
 cascadetoml
 jinja2


### PR DESCRIPTION
Per #6313, there are two references to `huffman`, and there should be only one. The one in `tools/huffman` is https://github.com/tannewt/huffman, and is enhanced from the PyPi one.