### PR TITLE
Fix PulseIn buffer overread in popleft #6318

### DIFF
--- a/ports/atmel-samd/common-hal/pulseio/PulseIn.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseIn.c
@@ -132,7 +132,7 @@ void pulsein_interrupt_handler(uint8_t channel) {
         if (self->len < self->maxlen) {
             self->len++;
         } else {
-            self->start++;
+            self->start = (self->start + 1) % self->maxlen;
         }
     }
     self->last_overflow = current_overflow;

--- a/ports/cxd56/common-hal/pulseio/PulseIn.c
+++ b/ports/cxd56/common-hal/pulseio/PulseIn.c
@@ -75,7 +75,7 @@ static int pulsein_interrupt_handler(int irq, FAR void *context, FAR void *arg) 
         if (self->len < self->maxlen) {
             self->len++;
         } else {
-            self->start++;
+            self->start = (self->start + 1) % self->maxlen;
         }
     }
     self->last_us = current_us;

--- a/ports/espressif/common-hal/pulseio/PulseIn.c
+++ b/ports/espressif/common-hal/pulseio/PulseIn.c
@@ -42,19 +42,19 @@ STATIC void update_internal_buffer(pulseio_pulsein_obj_t *self) {
         for (size_t i = 0; i < length; i++) {
             uint16_t pos = (self->start + self->len) % self->maxlen;
             self->buffer[pos] = items[i].duration0 * 3;
-            // Check if second item exists before incrementing
-            if (items[i].duration1) {
-                self->buffer[pos + 1] = items[i].duration1 * 3;
-                if (self->len < (self->maxlen - 1)) {
-                    self->len += 2;
-                } else {
-                    self->start += 2;
-                }
+            if (self->len < self->maxlen) {
+                self->len++;
             } else {
+                self->start = (self->start + 1) % self->maxlen;
+            }
+            // Check if second item exists
+            if (items[i].duration1) {
+                pos = (self->start + self->len) % self->maxlen;
+                self->buffer[pos] = items[i].duration1 * 3;
                 if (self->len < self->maxlen) {
                     self->len++;
                 } else {
-                    self->start++;
+                    self->start = (self->start + 1) % self->maxlen;
                 }
             }
         }

--- a/ports/nrf/common-hal/pulseio/PulseIn.c
+++ b/ports/nrf/common-hal/pulseio/PulseIn.c
@@ -103,7 +103,7 @@ static void _pulsein_handler(nrfx_gpiote_pin_t pin, nrf_gpiote_polarity_t action
         if (self->len < self->maxlen) {
             self->len++;
         } else {
-            self->start++;
+            self->start = (self->start + 1) % self->maxlen;
         }
     }
 

--- a/ports/stm/common-hal/pulseio/PulseIn.c
+++ b/ports/stm/common-hal/pulseio/PulseIn.c
@@ -89,7 +89,7 @@ STATIC void pulsein_exti_event_handler(uint8_t num) {
         if (self->len < self->maxlen) {
             self->len++;
         } else {
-            self->start++;
+            self->start = (self->start + 1) % self->maxlen;
         }
     }
 


### PR DESCRIPTION
Tested and working correctly on an esp32-s2. I went ahead and made the change for all ports that have the bug but I don't currently have boards for testing.