### PR TITLE
urandom: Discard first number after seeding.

### DIFF
--- a/shared-module/random/__init__.c
+++ b/shared-module/random/__init__.c
@@ -77,6 +77,7 @@ void shared_modules_random_seed(mp_uint_t seed) {
     yasmarang_n = 69;
     yasmarang_d = 233;
     yasmarang_dat = 0;
+    (void)yasmarang();
 }
 
 mp_uint_t shared_modules_random_getrandbits(uint8_t n) {


### PR DESCRIPTION
This is in some sense an incompatible change, as it alters the sequence of random values for any particular given seed.

@kattni brought it to my attention that the very first number after seeding is highly non-uniform. This is exposed by a program like the following, which tries 10,000 different random seeds and records the out come of `randint(0,2)` for each seed:
```python
try:
    import random
except ImportError:
    import urandom as random

s = [0] * 3
for i in range(10000):
    random.seed(i)
    s[random.randint(0, 2)] += 1

print(s)
```

Ideally, the values of `s` would all be approximately equal. However, before this change, the outcome is
```
[5008, 0, 4992]
```
After this commit, which discards the first result after each seeding, the result is
```
[3542, 3332, 3126]
```

Only the very first value seems to be so extremely uneven in distribution.

This improvement has also been submitted upstream: https://github.com/micropython/micropython/pull/8599 as the implementing code is in a different location in our fork.

Signed-off-by: Jeff Epler <jepler@gmail.com>