### PR TITLE
random: replace generator with 'pcg32'

### DIFF
--- a/shared-module/random/__init__.c
+++ b/shared-module/random/__init__.c
@@ -32,58 +32,17 @@
 #include "shared-bindings/os/__init__.h"
 #include "shared-bindings/random/__init__.h"
 #include "shared-bindings/time/__init__.h"
-
-// Yasmarang random number generator
-// by Ilya Levin
-// http://www.literatecode.com/yasmarang
-// Public Domain
-
-STATIC uint32_t yasmarang_pad = 0xeda4baba, yasmarang_n = 69, yasmarang_d = 233;
-STATIC uint8_t yasmarang_dat = 0;
-
-STATIC uint32_t yasmarang(void) {
-    if (yasmarang_pad == 0xeda4baba) {
-        if (!common_hal_os_urandom((uint8_t *)&yasmarang_pad, sizeof(uint32_t))) {
-            yasmarang_pad = common_hal_time_monotonic_ms() & 0xffffffff;
-        }
-    }
-    yasmarang_pad += yasmarang_dat + yasmarang_d * yasmarang_n;
-    yasmarang_pad = (yasmarang_pad << 3) + (yasmarang_pad >> 29);
-    yasmarang_n = yasmarang_pad | 2;
-    yasmarang_d ^= (yasmarang_pad << 31) + (yasmarang_pad >> 1);
-    yasmarang_dat ^= (char)yasmarang_pad ^ (yasmarang_d >> 8) ^ 1;
-
-    return yasmarang_pad ^ (yasmarang_d << 5) ^ (yasmarang_pad >> 18) ^ (yasmarang_dat << 1);
-}  /* yasmarang */
-
-// End of Yasmarang
-
-// returns an unsigned integer below the given argument
-// n must not be zero
-STATIC uint32_t yasmarang_randbelow(uint32_t n) {
-    uint32_t mask = 1;
-    while ((n & mask) < n) {
-        mask = (mask << 1) | 1;
-    }
-    uint32_t r;
-    do {
-        r = yasmarang() & mask;
-    } while (r >= n);
-    return r;
-}
+#include "shared-module/random/pcg_basic.c"
 
 void shared_modules_random_seed(mp_uint_t seed) {
-    yasmarang_pad = seed;
-    yasmarang_n = 69;
-    yasmarang_d = 233;
-    yasmarang_dat = 0;
+    pcg32_srandom(seed, 0);
 }
 
 mp_uint_t shared_modules_random_getrandbits(uint8_t n) {
     uint32_t mask = ~0;
     // Beware of C undefined behavior when shifting by >= than bit size
     mask >>= (32 - n);
-    return yasmarang() & mask;
+    return pcg32_random() & mask;
 }
 
 mp_int_t shared_modules_random_randrange(mp_int_t start, mp_int_t stop, mp_int_t step) {
@@ -93,11 +52,11 @@ mp_int_t shared_modules_random_randrange(mp_int_t start, mp_int_t stop, mp_int_t
     } else {
         n = (stop - start + step + 1) / step;
     }
-    return start + step * yasmarang_randbelow(n);
+    return start + step * pcg32_boundedrand(n);
 }
 
 // returns a number in the range [0..1) using Yasmarang to fill in the fraction bits
-STATIC mp_float_t yasmarang_float(void) {
+STATIC mp_float_t random_float(void) {
     #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
     typedef uint64_t mp_float_int_t;
     #elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
@@ -116,17 +75,17 @@ STATIC mp_float_t yasmarang_float(void) {
     u.p.sgn = 0;
     u.p.exp = (1 << (MP_FLOAT_EXP_BITS - 1)) - 1;
     if (MP_FLOAT_FRAC_BITS <= 32) {
-        u.p.frc = yasmarang();
+        u.p.frc = pcg32_random();
     } else {
-        u.p.frc = ((uint64_t)yasmarang() << 32) | (uint64_t)yasmarang();
+        u.p.frc = ((uint64_t)pcg32_random() << 32) | (uint64_t)pcg32_random();
     }
     return u.f - 1;
 }
 
 mp_float_t shared_modules_random_random(void) {
-    return yasmarang_float();
+    return random_float();
 }
 
 mp_float_t shared_modules_random_uniform(mp_float_t a, mp_float_t b) {
-    return a + (b - a) * yasmarang_float();
+    return a + (b - a) * random_float();
 }

--- a/shared-module/random/pcg_basic.c
+++ b/shared-module/random/pcg_basic.c
@@ -1,0 +1,110 @@
+/*
+ * PCG Random Number Generation for C.
+ *
+ * Copyright 2014 Melissa O'Neill <oneill@pcg-random.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For additional information about the PCG random number generation scheme,
+ * including its license and other licensing options, visit
+ *
+ *       http://www.pcg-random.org
+ */
+
+/*
+ * This code is derived from the full C implementation, which is in turn
+ * derived from the canonical C++ PCG implementation. The C++ version
+ * has many additional features and is preferable if you can use C++ in
+ * your project.
+ */
+
+#include "pcg_basic.h"
+
+// state for global RNGs
+
+static pcg32_random_t pcg32_global = PCG32_INITIALIZER;
+
+// pcg32_srandom(initstate, initseq)
+// pcg32_srandom_r(rng, initstate, initseq):
+//     Seed the rng.  Specified in two parts, state initializer and a
+//     sequence selection constant (a.k.a. stream id)
+
+void pcg32_srandom_r(pcg32_random_t *rng, uint64_t initstate, uint64_t initseq) {
+    rng->state = 0U;
+    rng->inc = (initseq << 1u) | 1u;
+    pcg32_random_r(rng);
+    rng->state += initstate;
+    pcg32_random_r(rng);
+}
+
+void pcg32_srandom(uint64_t seed, uint64_t seq) {
+    pcg32_srandom_r(&pcg32_global, seed, seq);
+}
+
+// pcg32_random()
+// pcg32_random_r(rng)
+//     Generate a uniformly distributed 32-bit random number
+
+uint32_t pcg32_random_r(pcg32_random_t *rng) {
+    uint64_t oldstate = rng->state;
+    rng->state = oldstate * 6364136223846793005ULL + rng->inc;
+    uint32_t xorshifted = ((oldstate >> 18u) ^ oldstate) >> 27u;
+    uint32_t rot = oldstate >> 59u;
+    return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
+}
+
+uint32_t pcg32_random() {
+    return pcg32_random_r(&pcg32_global);
+}
+
+
+// pcg32_boundedrand(bound):
+// pcg32_boundedrand_r(rng, bound):
+//     Generate a uniformly distributed number, r, where 0 <= r < bound
+
+uint32_t pcg32_boundedrand_r(pcg32_random_t *rng, uint32_t bound) {
+    // To avoid bias, we need to make the range of the RNG a multiple of
+    // bound, which we do by dropping output less than a threshold.
+    // A naive scheme to calculate the threshold would be to do
+    //
+    //     uint32_t threshold = 0x100000000ull % bound;
+    //
+    // but 64-bit div/mod is slower than 32-bit div/mod (especially on
+    // 32-bit platforms).  In essence, we do
+    //
+    //     uint32_t threshold = (0x100000000ull-bound) % bound;
+    //
+    // because this version will calculate the same modulus, but the LHS
+    // value is less than 2^32.
+
+    uint32_t threshold = -bound % bound;
+
+    // Uniformity guarantees that this loop will terminate.  In practice, it
+    // should usually terminate quickly; on average (assuming all bounds are
+    // equally likely), 82.25% of the time, we can expect it to require just
+    // one iteration.  In the worst case, someone passes a bound of 2^31 + 1
+    // (i.e., 2147483649), which invalidates almost 50% of the range.  In
+    // practice, bounds are typically small and only a tiny amount of the range
+    // is eliminated.
+    for (;;) {
+        uint32_t r = pcg32_random_r(rng);
+        if (r >= threshold) {
+            return r % bound;
+        }
+    }
+}
+
+
+uint32_t pcg32_boundedrand(uint32_t bound) {
+    return pcg32_boundedrand_r(&pcg32_global, bound);
+}

--- a/shared-module/random/pcg_basic.h
+++ b/shared-module/random/pcg_basic.h
@@ -1,0 +1,70 @@
+/*
+ * PCG Random Number Generation for C.
+ *
+ * Copyright 2014 Melissa O'Neill <oneill@pcg-random.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For additional information about the PCG random number generation scheme,
+ * including its license and other licensing options, visit
+ *
+ *     http://www.pcg-random.org
+ */
+
+/*
+ * This code is derived from the full C implementation, which is in turn
+ * derived from the canonical C++ PCG implementation. The C++ version
+ * has many additional features and is preferable if you can use C++ in
+ * your project.
+ */
+
+#ifndef PCG_BASIC_H_INCLUDED
+#define PCG_BASIC_H_INCLUDED 1
+
+#include <inttypes.h>
+
+struct pcg_state_setseq_64 {    // Internals are *Private*.
+    uint64_t state;             // RNG state.  All values are possible.
+    uint64_t inc;               // Controls which RNG sequence (stream) is
+                                // selected. Must *always* be odd.
+};
+typedef struct pcg_state_setseq_64 pcg32_random_t;
+
+// If you *must* statically initialize it, here's one.
+
+#define PCG32_INITIALIZER   { 0x853c49e6748fea9bULL, 0xda3e39cb94b95bdbULL }
+
+// pcg32_srandom(initstate, initseq)
+// pcg32_srandom_r(rng, initstate, initseq):
+//     Seed the rng.  Specified in two parts, state initializer and a
+//     sequence selection constant (a.k.a. stream id)
+
+void pcg32_srandom(uint64_t initstate, uint64_t initseq);
+void pcg32_srandom_r(pcg32_random_t *rng, uint64_t initstate,
+    uint64_t initseq);
+
+// pcg32_random()
+// pcg32_random_r(rng)
+//     Generate a uniformly distributed 32-bit random number
+
+uint32_t pcg32_random(void);
+uint32_t pcg32_random_r(pcg32_random_t *rng);
+
+// pcg32_boundedrand(bound):
+// pcg32_boundedrand_r(rng, bound):
+//     Generate a uniformly distributed number, r, where 0 <= r < bound
+
+uint32_t pcg32_boundedrand(uint32_t bound);
+uint32_t pcg32_boundedrand_r(pcg32_random_t *rng, uint32_t bound);
+
+#endif // PCG_BASIC_H_INCLUDED


### PR DESCRIPTION
yasmarang is a cute little rng, but it doesn't have the best properties. pcg32 is a much more modern design though it does depend on 64-bit multiplication being 'fast enough' relative to the need for random numbers.

Surprisingly, this also gives back 44 bytes of flash on trinket_m0. (on raspberrypi, without lto, it takes 396 more)

pcg32 is taken from https://github.com/imneme/pcg-c-basic and is Apache-licensed.

Not yet tested on hardware, and as the unix build uses modurandom instead of shared-bindings/random, it's not testable on a host computer.