### PR TITLE
[mimxrt (teensy) Allow Any GPIO pin for RS485 pin

### DIFF
--- a/ports/mimxrt10xx/common-hal/busio/UART.h
+++ b/ports/mimxrt10xx/common-hal/busio/UART.h
@@ -50,6 +50,9 @@ typedef struct {
     const mcu_pin_obj_t *tx;
     const mcu_pin_obj_t *cts;
     const mcu_pin_obj_t *rts;
+    const mcu_pin_obj_t *rs485_dir;
+    bool rs485_invert;
+
 } busio_uart_obj_t;
 
 void uart_reset(void);


### PR DESCRIPTION
The existing code was setup that allowed you to specify an RTS
pin to be used as an RS485 direction pin, however there are no
RTS pins that are exposed on any of the Teensy 4.x boards.

Instead Arduino code base allowed you to specify any GPIO pin to
work instead.  So I added the code in to facilitate this.

In addition the alternative code to wrap your own GPIO pin set high and low
around call(s) to uart.write() will not currently work, unless maybe you
fudge it and add your own delays as the write will return after the last
byte was pushed onto the UART’s hardware FIFO queue and as such if you
then immediately set the IO pin low, it will corrupt your output stream.

The code I added detects that you are setup to use the RS485 pin and
before it returns will wait for the UART’s Transfer complete status flag
to be set.

We (@mjs513 and myself) have done a little playing with Dynamixel Servos connected up to a Teensy 4.1

I have hacked up the Python version of the DynamixelSDK to run on CPY.  

Will continue to play some more, with it... 
