### PR TITLE
[RP2040] Allow any GPIO pin for RS485 direction pin

### DIFF
--- a/ports/raspberrypi/common-hal/busio/UART.h
+++ b/ports/raspberrypi/common-hal/busio/UART.h
@@ -37,6 +37,8 @@ typedef struct {
     uint8_t tx_pin;
     uint8_t rx_pin;
     uint8_t cts_pin;
+    uint8_t rs485_dir_pin;
+    bool rs485_invert;
     uint8_t rts_pin;
     uint8_t uart_id;
     uint8_t uart_irq_id;


### PR DESCRIPTION
As I mentioned in issue #6310 while investigating that the Teensy port
did not support RS485_dir pin on normal GPIO pins, I found that it
was not implemented either as well on some other ports.

So was curious to implement it for RP2040 using same approach as I did
for the MIMXRT in the Pull Request #6328

That is I setup the specified pin as a normal GPIO pin in output mode
and then when you do a write operation it sets the GPIO pin logically
high, and when the write completes I set it logically low.

Note: knowing when I can set it low can be tricky, as you need to make
sure the full output has completed otherwise the data will be corrupted.

I am using:         uart_tx_wait_blocking(self->uart);
Which looks like it is supposed to wait until the busy status is no
longer set, which the Reference manual mentioned, but this is leaving
the line logically set longer than I would like.

however I have tried running it with my hacked up version of the
Python Robotis DynamixelSDK and was able to talk to some AX servos.

I did have to change the library slightly for the RP2040, as the
library was erroring out when you did something like uart.read(5)
and it timed out without receiving anything.  The RP2040 returned
None whereas I think the Teensy returned an empty set, which is what
it looks like the PySerial original code expects.

Not sure if anyone is interested in this, but thought i would
put it out as PR and see.