### PR TITLE
fix qtpy_esp32s3_nopsram neopixel pins

### DIFF
--- a/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/mpconfigboard.h
@@ -29,8 +29,8 @@
 #define MICROPY_HW_BOARD_NAME       "Adafruit QT Py ESP32-S3 no psram"
 #define MICROPY_HW_MCU_NAME         "ESP32S3"
 
-#define MICROPY_HW_NEOPIXEL (&pin_GPIO38)
-#define CIRCUITPY_STATUS_LED_POWER (&pin_GPIO37)
+#define MICROPY_HW_NEOPIXEL (&pin_GPIO39)
+#define CIRCUITPY_STATUS_LED_POWER (&pin_GPIO38)
 
 #define CIRCUITPY_BOARD_I2C         (2)
 #define CIRCUITPY_BOARD_I2C_PIN     {{.scl = &pin_GPIO6, .sda = &pin_GPIO7}, \

--- a/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/pins.c
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/pins.c
@@ -45,8 +45,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_GPIO36) },
     { MP_ROM_QSTR(MP_QSTR_D36), MP_ROM_PTR(&pin_GPIO36) },
 
-    { MP_ROM_QSTR(MP_QSTR_NEOPIXEL_POWER), MP_ROM_PTR(&pin_GPIO37) },
-    { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO38) },
+    { MP_ROM_QSTR(MP_QSTR_NEOPIXEL_POWER), MP_ROM_PTR(&pin_GPIO38) },
+    { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO39) },
 
     { MP_ROM_QSTR(MP_QSTR_SCL1), MP_ROM_PTR(&pin_GPIO40) },
     { MP_ROM_QSTR(MP_QSTR_D40), MP_ROM_PTR(&pin_GPIO40) },


### PR DESCRIPTION
This PR adjusts the values for `NEOPIXEL` and `NEOPIXEL_POWER` in `board.c` and `mpconfigboard.h` to match those in tinyuf2's [adafruit_qtpy_esp32s3/board.h](https://github.com/adafruit/tinyuf2/blob/master/ports/espressif/boards/adafruit_qtpy_esp32s3/board.h#L46)

Currently this code does not light the built-in NeoPixel LED:

```py
import board, digitalio
ledpower = digitalio.DigitalInOut(board.NEOPIXEL_POWER)
ledpower.switch_to_output(value=True)
leds = neopixel.NeoPixel(board.NEOXPIXEL, 1, brightness=0.1)
leds.fill(0xff00ff)
```

but this code does:

```py
import microcontroller, digitalio
ledpower = digitalio.DigitalInOut(microcontroller.pin.GPIO38)
ledpower.switch_to_output(value=True)
leds = neopixel.NeoPixel(microcontroller.pin.GPIO39, 1, brightness=0.1)
leds.fill(0xff00ff)
```
