### PR TITLE
Link to CPython docs for subset modules

### DIFF
--- a/shared-bindings/atexit/__init__.c
+++ b/shared-bindings/atexit/__init__.c
@@ -34,6 +34,7 @@
 //| These functions are run in the reverse order in which they were registered;
 //| if you register ``A``, ``B``, and ``C``, they will be run in the order ``C``, ``B``, ``A``.
 //|
+//| |see_cpython_module| :mod:`cpython:atexit`.
 //| """
 //| ...
 //|

--- a/shared-bindings/math/__init__.c
+++ b/shared-bindings/math/__init__.c
@@ -43,12 +43,7 @@
 //| The `math` module provides some basic mathematical functions for
 //| working with floating-point numbers.
 //|
-//| This library is a subset of the CPython library.  All code using this
-//| library should function in CPython, but not necessarily the other way
-//| around.  For more information about the `math` module, see the
-//| CPython documentation:
-//|
-//| https://docs.python.org/3/library/math.html
+//| |see_cpython_module| :mod:`cpython:math`.
 //| """
 //|
 

--- a/shared-bindings/math/__init__.c
+++ b/shared-bindings/math/__init__.c
@@ -41,7 +41,15 @@
 //| """mathematical functions
 //|
 //| The `math` module provides some basic mathematical functions for
-//| working with floating-point numbers."""
+//| working with floating-point numbers.
+//|
+//| This library is a subset of the CPython library.  All code using this
+//| library should function in CPython, but not necessarily the other way
+//| around.  For more information about the `math` module, see the
+//| CPython documentation:
+//|
+//| https://docs.python.org/3/library/math.html
+//| """
 //|
 
 STATIC NORETURN void math_error(void) {

--- a/shared-bindings/os/__init__.c
+++ b/shared-bindings/os/__init__.c
@@ -41,7 +41,11 @@
 //|
 //| The `os` module is a strict subset of the CPython `cpython:os` module. So,
 //| code written in CircuitPython will work in CPython but not necessarily the
-//| other way around."""
+//| other way around.
+//|
+//| For more information about the `os` module, see the CPython documentation:
+//| https://docs.python.org/3/library/os.html
+//| """
 //|
 //| import typing
 

--- a/shared-bindings/os/__init__.c
+++ b/shared-bindings/os/__init__.c
@@ -39,12 +39,7 @@
 
 //| """functions that an OS normally provides
 //|
-//| The `os` module is a strict subset of the CPython `cpython:os` module. So,
-//| code written in CircuitPython will work in CPython but not necessarily the
-//| other way around.
-//|
-//| For more information about the `os` module, see the CPython documentation:
-//| https://docs.python.org/3/library/os.html
+//| |see_cpython_module| :mod:`cpython:os`.
 //| """
 //|
 //| import typing

--- a/shared-bindings/random/__init__.c
+++ b/shared-bindings/random/__init__.c
@@ -35,20 +35,14 @@
 
 //| """pseudo-random numbers and choices
 //|
-//| The `random` module is a strict subset of the CPython `cpython:random`
-//| module. So, code written in CircuitPython will work in CPython but not
-//| necessarily the other way around.
+//| |see_cpython_module| :mod:`cpython:random`.
 //|
 //| Like its CPython cousin, CircuitPython's random seeds itself on first use
 //| with a true random from os.urandom() when available or the uptime otherwise.
 //| Once seeded, it will be deterministic, which is why its bad for cryptography.
 //|
 //| .. warning:: Numbers from this module are not cryptographically strong! Use
-//|   bytes from `os.urandom` directly for true randomness.
-//|
-//| For more information about the `random` module, see the CPython documentation:
-//| https://docs.python.org/3/library/random.html
-//| """
+//|   bytes from `os.urandom` directly for true randomness."""
 //|
 //| from typing import TypeVar
 //| _T = TypeVar('_T')

--- a/shared-bindings/random/__init__.c
+++ b/shared-bindings/random/__init__.c
@@ -44,7 +44,11 @@
 //| Once seeded, it will be deterministic, which is why its bad for cryptography.
 //|
 //| .. warning:: Numbers from this module are not cryptographically strong! Use
-//|   bytes from `os.urandom` directly for true randomness."""
+//|   bytes from `os.urandom` directly for true randomness.
+//|
+//| For more information about the `random` module, see the CPython documentation:
+//| https://docs.python.org/3/library/random.html
+//| """
 //|
 //| from typing import TypeVar
 //| _T = TypeVar('_T')

--- a/shared-bindings/socketpool/__init__.c
+++ b/shared-bindings/socketpool/__init__.c
@@ -35,6 +35,9 @@
 //| """
 //| The `socketpool` module provides sockets through a pool. The pools themselves
 //| act like CPython's `socket` module.
+//|
+//| For more infomration about the `socket` module, see the CPython documentation:
+//| https://docs.python.org/3/library/socket.html
 //| """
 //|
 

--- a/shared-bindings/socketpool/__init__.c
+++ b/shared-bindings/socketpool/__init__.c
@@ -36,7 +36,7 @@
 //| The `socketpool` module provides sockets through a pool. The pools themselves
 //| act like CPython's `socket` module.
 //|
-//| For more infomration about the `socket` module, see the CPython documentation:
+//| For more information about the `socket` module, see the CPython documentation:
 //| https://docs.python.org/3/library/socket.html
 //| """
 //|

--- a/shared-bindings/ssl/__init__.c
+++ b/shared-bindings/ssl/__init__.c
@@ -34,12 +34,7 @@
 //| """
 //| The `ssl` module provides SSL contexts to wrap sockets in.
 //|
-//| This module is a strict subset of the CPython `ssl` module.
-//| So, code written in CircuitPython will work in CPython but not
-//| necessarily the other way around.
-//|
-//| For more information about the `ssl` module see the CPython documentation
-//| https://docs.python.org/3/library/ssl.html
+//| |see_cpython_module| :mod:`cpython:ssl`.
 //| """
 //|
 

--- a/shared-bindings/ssl/__init__.c
+++ b/shared-bindings/ssl/__init__.c
@@ -33,6 +33,13 @@
 
 //| """
 //| The `ssl` module provides SSL contexts to wrap sockets in.
+//|
+//| This module is a strict subset of the CPython `ssl` module.
+//| So, code written in CircuitPython will work in CPython but not
+//| necessarily the other way around.
+//|
+//| For more information about the `ssl` module see the CPython documentation
+//| https://docs.python.org/3/library/ssl.html
 //| """
 //|
 

--- a/shared-bindings/struct/__init__.c
+++ b/shared-bindings/struct/__init__.c
@@ -40,9 +40,7 @@
 
 //| """Manipulation of c-style data
 //|
-//| This module implements a subset of the corresponding CPython module,
-//| as described below. For more information, refer to the original CPython
-//| documentation: struct.
+//| |see_cpython_module| :mod:`cpython:struct`.
 //|
 //| Supported size/byte order prefixes: *@*, *<*, *>*, *!*.
 //|

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -40,7 +40,11 @@
 //|
 //| The `time` module is a strict subset of the CPython `cpython:time` module. So, code
 //| using `time` written in CircuitPython will work in CPython but not necessarily the other
-//| way around."""
+//| way around.
+//|
+//| For more information about the `time` module, see the CPython documentation:
+//| https://docs.python.org/3/library/time.html
+//| """
 //|
 //| def monotonic() -> float:
 //|     """Returns an always increasing value of time with an unknown reference

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -38,12 +38,7 @@
 
 //| """time and timing related functions
 //|
-//| The `time` module is a strict subset of the CPython `cpython:time` module. So, code
-//| using `time` written in CircuitPython will work in CPython but not necessarily the other
-//| way around.
-//|
-//| For more information about the `time` module, see the CPython documentation:
-//| https://docs.python.org/3/library/time.html
+//| |see_cpython_module| :mod:`cpython:time`.
 //| """
 //|
 //| def monotonic() -> float:

--- a/shared-bindings/traceback/__init__.c
+++ b/shared-bindings/traceback/__init__.c
@@ -34,6 +34,7 @@
 //| This module provides a standard interface to print stack traces of programs.
 //| This is useful when you want to print stack traces under program control.
 //|
+//| |see_cpython_module| :mod:`cpython:traceback`.
 //| """
 //| ...
 //|


### PR DESCRIPTION
Working towards #6326, adds links to CPython documentation for the following modules:

- `time`
- `math`
- `random`
- `os`
- `ssl`
- "`socket`" - really its `socketpool`
- `atexit`
- `struct`
- `traceback`