### PR TITLE
make Pin hashable

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -623,7 +623,7 @@ msgstr ""
 msgid "Buffer length must be a multiple of 512"
 msgstr ""
 
-#: ports/stm/common-hal/sdioio/SDCard.c
+#: ports/stm/common-hal/sdioio/SDCard.c shared-bindings/floppyio/__init__.c
 msgid "Buffer must be a multiple of 512 bytes"
 msgstr ""
 

--- a/shared-bindings/microcontroller/Pin.c
+++ b/shared-bindings/microcontroller/Pin.c
@@ -78,10 +78,28 @@ STATIC void mcu_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
     }
 }
 
+//|     def __hash__(self) -> int:
+//|         """Returns a hash for the Pin."""
+//|         ...
+//|
+STATIC mp_obj_t mcu_pin_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
+    switch (op) {
+        case MP_UNARY_OP_HASH: {
+            return mp_obj_id(self_in);
+        }
+        default:
+            return MP_OBJ_NULL; // op not supported
+    }
+}
+
 const mp_obj_type_t mcu_pin_type = {
     { &mp_type_type },
+    .flags = MP_TYPE_FLAG_EXTENDED,
     .name = MP_QSTR_Pin,
-    .print = mcu_pin_print
+    .print = mcu_pin_print,
+    MP_TYPE_EXTENDED_FIELDS(
+        .unary_op = mcu_pin_unary_op,
+        )
 };
 
 const mcu_pin_obj_t *validate_obj_is_pin(mp_obj_t obj) {

--- a/shared-bindings/microcontroller/Pin.c
+++ b/shared-bindings/microcontroller/Pin.c
@@ -43,6 +43,12 @@
 //|         ...
 //|
 
+//|     def __hash__(self) -> int:
+//|         """Returns a hash for the Pin."""
+//|         ...
+//|
+// Provided by mp_generic_unary_op().
+
 static void get_pin_name(const mcu_pin_obj_t *self, qstr *package, qstr *module, qstr *name) {
     const mp_map_t *board_map = &board_module_globals.map;
     for (uint8_t i = 0; i < board_map->alloc; i++) {
@@ -78,27 +84,13 @@ STATIC void mcu_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
     }
 }
 
-//|     def __hash__(self) -> int:
-//|         """Returns a hash for the Pin."""
-//|         ...
-//|
-STATIC mp_obj_t mcu_pin_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
-    switch (op) {
-        case MP_UNARY_OP_HASH: {
-            return mp_obj_id(self_in);
-        }
-        default:
-            return MP_OBJ_NULL; // op not supported
-    }
-}
-
 const mp_obj_type_t mcu_pin_type = {
     { &mp_type_type },
     .flags = MP_TYPE_FLAG_EXTENDED,
     .name = MP_QSTR_Pin,
     .print = mcu_pin_print,
     MP_TYPE_EXTENDED_FIELDS(
-        .unary_op = mcu_pin_unary_op,
+        .unary_op = mp_generic_unary_op,
         )
 };
 

--- a/shared-bindings/socketpool/Socket.c
+++ b/shared-bindings/socketpool/Socket.c
@@ -46,6 +46,12 @@
 //|        recv that do not allocate bytes objects."""
 //|
 
+//|     def __hash__(self) -> int:
+//|         """Returns a hash for the Socket."""
+//|         ...
+//|
+// Provided by mp_generic_unary_op().
+
 //|     def __enter__(self) -> Socket:
 //|         """No-op used by Context Managers."""
 //|         ...
@@ -366,20 +372,6 @@ STATIC mp_obj_t socketpool_socket_settimeout(mp_obj_t self_in, mp_obj_t timeout_
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(socketpool_socket_settimeout_obj, socketpool_socket_settimeout);
 
-//|     def __hash__(self) -> int:
-//|         """Returns a hash for the Socket."""
-//|         ...
-//|
-STATIC mp_obj_t socketpool_socket_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
-    switch (op) {
-        case MP_UNARY_OP_HASH: {
-            return mp_obj_id(self_in);
-        }
-        default:
-            return MP_OBJ_NULL; // op not supported
-    }
-}
-
 STATIC const mp_rom_map_elem_t socketpool_socket_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&default___enter___obj) },
     { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&socketpool_socket___exit___obj) },
@@ -407,6 +399,6 @@ const mp_obj_type_t socketpool_socket_type = {
     .name = MP_QSTR_Socket,
     .locals_dict = (mp_obj_dict_t *)&socketpool_socket_locals_dict,
     MP_TYPE_EXTENDED_FIELDS(
-        .unary_op = socketpool_socket_unary_op,
+        .unary_op = mp_generic_unary_op,
         )
 };

--- a/shared-bindings/ssl/SSLSocket.c
+++ b/shared-bindings/ssl/SSLSocket.c
@@ -45,6 +45,12 @@
 //|        recv that do not allocate bytes objects."""
 //|
 
+//|     def __hash__(self) -> int:
+//|         """Returns a hash for the Socket."""
+//|         ...
+//|
+// Provided by mp_generic_unary_op().
+
 //|     def __enter__(self) -> SSLSocket:
 //|         """No-op used by Context Managers."""
 //|         ...
@@ -282,20 +288,6 @@ STATIC mp_obj_t ssl_sslsocket_setblocking(mp_obj_t self_in, mp_obj_t blocking) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(ssl_sslsocket_setblocking_obj, ssl_sslsocket_setblocking);
 
-//|     def __hash__(self) -> int:
-//|         """Returns a hash for the Socket."""
-//|         ...
-//|
-STATIC mp_obj_t ssl_sslsocket_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
-    switch (op) {
-        case MP_UNARY_OP_HASH: {
-            return mp_obj_id(self_in);
-        }
-        default:
-            return MP_OBJ_NULL; // op not supported
-    }
-}
-
 STATIC const mp_rom_map_elem_t ssl_sslsocket_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&default___enter___obj) },
     { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&ssl_sslsocket___exit___obj) },
@@ -321,6 +313,6 @@ const mp_obj_type_t ssl_sslsocket_type = {
     .name = MP_QSTR_SSLSocket,
     .locals_dict = (mp_obj_dict_t *)&ssl_sslsocket_locals_dict,
     MP_TYPE_EXTENDED_FIELDS(
-        .unary_op = ssl_sslsocket_unary_op,
+        .unary_op = mp_generic_unary_op,
         )
 };


### PR DESCRIPTION
Fixes #6179.

I keep encountering cases where I would like to `microcontroller.Pin` objects to be in a `set()` or be dictionary keys.