### PR TITLE
add board.LED to Metro M4 AirLift LIte and PyRuler

### DIFF
--- a/ports/atmel-samd/boards/metro_m4_airlift_lite/pins.c
+++ b/ports/atmel-samd/boards/metro_m4_airlift_lite/pins.c
@@ -28,6 +28,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_D10), MP_ROM_PTR(&pin_PA18) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D11), MP_ROM_PTR(&pin_PA19) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_PA17) },
+
+    { MP_OBJ_NEW_QSTR(MP_QSTR_LED),MP_ROM_PTR(&pin_PA16) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_D13),MP_ROM_PTR(&pin_PA16) },
 
     // ESP control

--- a/ports/atmel-samd/boards/pyruler/pins.c
+++ b/ports/atmel-samd/boards/pyruler/pins.c
@@ -41,6 +41,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_PA07) },
     { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_PA07) },
 
+    { MP_ROM_QSTR(MP_QSTR_LED),MP_ROM_PTR(&pin_PA10) },
     { MP_ROM_QSTR(MP_QSTR_D13),MP_ROM_PTR(&pin_PA10) },
 
     { MP_ROM_QSTR(MP_QSTR_APA102_MOSI), MP_ROM_PTR(&pin_PA00) },


### PR DESCRIPTION
Fixes #6268, and also adds `board.LED` to PyRuler.
