### PR TITLE
Move frozen adafruit_circuitplayground to CPX subdirectory

### DIFF
--- a/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.mk
@@ -19,7 +19,7 @@ CIRCUITPY_COUNTIO = 1
 CIRCUITPY_BUSDEVICE = 1
 
 # Include these Python libraries in firmware.
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_CircuitPlayground
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_CircuitPlayground/frozen_cpx
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_HID
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_LIS3DH
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel

--- a/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.mk
@@ -18,7 +18,7 @@ CIRCUITPY_KEYPAD = 0
 CIRCUITPY_ONEWIREIO = 0
 
 # Include these Python libraries in firmware.
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_CircuitPlayground
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_CircuitPlayground/frozen_cpx
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Crickit
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_LIS3DH
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Motor

--- a/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.mk
@@ -24,7 +24,7 @@ CIRCUITPY_BITMAPTOOLS = 0
 CIRCUITPY_PARALLELDISPLAY = 0
 
 # Include these Python libraries in firmware.
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_CircuitPlayground
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_CircuitPlayground/frozen_cpx
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_LIS3DH
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Thermistor


### PR DESCRIPTION
This PR requires [an update and release of the adafruit_circuitplayground library](https://github.com/adafruit/Adafruit_CircuitPython_CircuitPlayground/pull/117) (followed by updating frozen modules in this PR) before it can be merged.

It changes the frozen directory of the circuitplayground library to a subdirectory with a copy of the library made using symbolic links excluding the CPB specific file. Reduces the size of the CPX build by 1148 bytes.

Note: it's important now to NOT freeze in the parent directory or it will include double files. If we ever want to freeze in the library on the CPB, a `frozen_cpb` sub directory will have to be made.