### PR TITLE
Mention a read behavior difference vs pyserial

### DIFF
--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -206,6 +206,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_uart___exit___obj, 4, 4, busio_
 //|         times out. Providing the number of bytes expected is highly recommended
 //|         because it will be faster.
 //|
+//|         .. note:: In the case of a timeout, this function returns None.
+//|         This matches the behavior of `io.RawIOBase.read` in Python3, but
+//|         differs from pyserial which returns ``b''`` in that situation.
+//|
 //|         :return: Data read
 //|         :rtype: bytes or None"""
 //|         ...


### PR DESCRIPTION
Note that this updated documentation is presently a lie, as it depends on the underlying platform to set an errno-like value before returning that 0 bytes were read. At least mimxrt was behaving in this way, I think. See #6332.