### PR TITLE
espressif: check properly for pull values

### DIFF
--- a/ports/espressif/common-hal/digitalio/DigitalInOut.c
+++ b/ports/espressif/common-hal/digitalio/DigitalInOut.c
@@ -142,9 +142,9 @@ void common_hal_digitalio_digitalinout_set_pull(
 digitalio_pull_t common_hal_digitalio_digitalinout_get_pull(
     digitalio_digitalinout_obj_t *self) {
     gpio_num_t gpio_num = self->pin->number;
-    if (REG_GET_BIT(GPIO_PIN_MUX_REG[gpio_num], FUN_PU) == 1) {
+    if (REG_GET_BIT(GPIO_PIN_MUX_REG[gpio_num], FUN_PU)) {
         return PULL_UP;
-    } else if (REG_GET_BIT(GPIO_PIN_MUX_REG[gpio_num], FUN_PD) == 1) {
+    } else if (REG_GET_BIT(GPIO_PIN_MUX_REG[gpio_num], FUN_PD)) {
         return PULL_DOWN;
     }
     return PULL_NONE;


### PR DESCRIPTION
`DigitalInOut.pull` on Espressif boards was always returning `None`. The bit extraction to find out which pull was in use mistakenly assume the bit was shifted down to the low-order bit. It just does a masking, but not a shift.