### PR TITLE
Statemachine improvements

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1540,6 +1540,10 @@ msgstr ""
 msgid "Mismatched data size"
 msgstr ""
 
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Mismatched swap flag"
+msgstr ""
+
 #: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
 msgid "Missing MISO or MOSI Pin"
 msgstr ""
@@ -2033,7 +2037,7 @@ msgstr ""
 msgid "RNG Init Error"
 msgstr ""
 
-#: ports/nrf/common-hal/busio/UART.c ports/raspberrypi/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c
 msgid "RS485 Not yet supported on this device"
 msgstr ""
 

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -378,7 +378,7 @@ STATIC mp_obj_t rp2pio_statemachine_stop(mp_obj_t self_obj) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_stop_obj, rp2pio_statemachine_stop);
 
-//|     def write(self, buffer: ReadableBuffer, *, start: int = 0, end: Optional[int] = None, swap bool = False) -> None:
+//|     def write(self, buffer: ReadableBuffer, *, start: int = 0, end: Optional[int] = None, swap: bool = False) -> None:
 //|         """Write the data contained in ``buffer`` to the state machine. If the buffer is empty, nothing happens.
 //|
 //|         Writes to the FIFO will match the input buffer's element size. For example, bytearray elements
@@ -390,7 +390,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_stop_obj, rp2pio_statemachine_stop
 //|
 //|         :param ~circuitpython_typing.ReadableBuffer buffer: Write out the data in this buffer
 //|         :param int start: Start of the slice of ``buffer`` to write out: ``buffer[start:end]``
-//|         :param int end: End of the slice; this index is not included. Defaults to ``len(buffer)``"""
+//|         :param int end: End of the slice; this index is not included. Defaults to ``len(buffer)``
 //|         :param bool swap: For 2- and 4-byte elements, swap (reverse) the byte order"""
 //|         ...
 //|
@@ -463,7 +463,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_obj, 2, rp2pio_statemachine
 //|
 //|         Having neither ``once`` nor ``loop`` terminates an existing
 //|         background looping write after exactly a whole loop. This is in contrast to
-//|         `stop_background_write, which interrupts an ongoing DMA operation.
+//|         `stop_background_write`, which interrupts an ongoing DMA operation.
 //|
 //|         :param ~Optional[circuitpython_typing.ReadableBuffer] once: Data to be written once
 //|         :param ~Optional[circuitpython_typing.ReadableBuffer] loop: Data to be written repeatedly
@@ -577,7 +577,7 @@ const mp_obj_property_t rp2pio_statemachine_pending_obj = {
               MP_ROM_NONE},
 };
 
-//|     def readinto(self, buffer: WriteableBuffer, *, start: int = 0, end: Optional[int] = None, bool swap) -> None:
+//|     def readinto(self, buffer: WriteableBuffer, *, start: int = 0, end: Optional[int] = None, swap: bool=False) -> None:
 //|         """Read into ``buffer``. If the number of bytes to read is 0, nothing happens. The buffer
 //|         includes any data added to the fifo even if it was added before this was called.
 //|
@@ -650,8 +650,8 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_readinto_obj, 2, rp2pio_statemach
 //|         :param int out_start: Start of the slice of buffer_out to write out: ``buffer_out[out_start:out_end]``
 //|         :param int out_end: End of the slice; this index is not included. Defaults to ``len(buffer_out)``
 //|         :param int in_start: Start of the slice of ``buffer_in`` to read into: ``buffer_in[in_start:in_end]``
-//|         :param int in_end: End of the slice; this index is not included. Defaults to ``len(buffer_in)``"""
-//|         :param bool swap_out: For 2- and 4-byte elements, swap (reverse) the byte order for the buffer being transmitted (written)"""
+//|         :param int in_end: End of the slice; this index is not included. Defaults to ``len(buffer_in)``
+//|         :param bool swap_out: For 2- and 4-byte elements, swap (reverse) the byte order for the buffer being transmitted (written)
 //|         :param bool swap_in: For 2- and 4-rx elements, swap (reverse) the byte order for the buffer being received (read)"""
 //|         ...
 //|

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -708,6 +708,18 @@ STATIC mp_obj_t rp2pio_statemachine_obj_clear_rxfifo(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_clear_rxfifo_obj, rp2pio_statemachine_obj_clear_rxfifo);
 
+//|     def clear_txstall(self) -> None:
+//|         """Clears the txstall flag."""
+//|         ...
+//|
+STATIC mp_obj_t rp2pio_statemachine_obj_clear_txstall(mp_obj_t self_in) {
+    rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_rp2pio_statemachine_clear_txstall(self);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_clear_txstall_obj, rp2pio_statemachine_obj_clear_txstall);
+
+
 //|     frequency: int
 //|     """The actual state machine frequency. This may not match the frequency requested
 //|     due to internal limitations."""
@@ -735,6 +747,26 @@ const mp_obj_property_t rp2pio_statemachine_frequency_obj = {
               (mp_obj_t)&rp2pio_statemachine_set_frequency_obj,
               MP_ROM_NONE},
 };
+
+//|     txstall: bool
+//|     """True when the state machine has stalled due to a full TX FIFO since the last
+//|        `clear_txstall` call."""
+//|
+
+STATIC mp_obj_t rp2pio_statemachine_obj_get_txstall(mp_obj_t self_in) {
+    rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    check_for_deinit(self);
+    return MP_OBJ_NEW_SMALL_INT(common_hal_rp2pio_statemachine_get_txstall(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_get_txstall_obj, rp2pio_statemachine_obj_get_txstall);
+
+const mp_obj_property_t rp2pio_statemachine_txstall_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&rp2pio_statemachine_get_txstall_obj,
+              MP_ROM_NONE,
+              MP_ROM_NONE},
+};
+
 
 //|     rxstall: bool
 //|     """True when the state machine has stalled due to a full RX FIFO since the last
@@ -782,6 +814,7 @@ STATIC const mp_rom_map_elem_t rp2pio_statemachine_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_restart), MP_ROM_PTR(&rp2pio_statemachine_restart_obj) },
     { MP_ROM_QSTR(MP_QSTR_run), MP_ROM_PTR(&rp2pio_statemachine_run_obj) },
     { MP_ROM_QSTR(MP_QSTR_clear_rxfifo), MP_ROM_PTR(&rp2pio_statemachine_clear_rxfifo_obj) },
+    { MP_ROM_QSTR(MP_QSTR_clear_txstall), MP_ROM_PTR(&rp2pio_statemachine_clear_txstall_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&rp2pio_statemachine_readinto_obj) },
     { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&rp2pio_statemachine_write_obj) },
@@ -793,6 +826,7 @@ STATIC const mp_rom_map_elem_t rp2pio_statemachine_locals_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_frequency), MP_ROM_PTR(&rp2pio_statemachine_frequency_obj) },
     { MP_ROM_QSTR(MP_QSTR_rxstall), MP_ROM_PTR(&rp2pio_statemachine_rxstall_obj) },
+    { MP_ROM_QSTR(MP_QSTR_txstall), MP_ROM_PTR(&rp2pio_statemachine_txstall_obj) },
     { MP_ROM_QSTR(MP_QSTR_in_waiting), MP_ROM_PTR(&rp2pio_statemachine_in_waiting_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(rp2pio_statemachine_locals_dict, rp2pio_statemachine_locals_dict_table);

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -391,7 +391,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_stop_obj, rp2pio_statemachine_stop
 //|         :param ~circuitpython_typing.ReadableBuffer buffer: Write out the data in this buffer
 //|         :param int start: Start of the slice of ``buffer`` to write out: ``buffer[start:end]``
 //|         :param int end: End of the slice; this index is not included. Defaults to ``len(buffer)``"""
-//|         :param bool swap: For 2- and 4-byte elements, swap the byte order"""
+//|         :param bool swap: For 2- and 4-byte elements, swap (reverse) the byte order"""
 //|         ...
 //|
 STATIC mp_obj_t rp2pio_statemachine_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -467,7 +467,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_obj, 2, rp2pio_statemachine
 //|
 //|         :param ~Optional[circuitpython_typing.ReadableBuffer] once: Data to be written once
 //|         :param ~Optional[circuitpython_typing.ReadableBuffer] loop: Data to be written repeatedly
-//|         :param bool swap: For 2- and 4-byte elements, swap the byte order"""
+//|         :param bool swap: For 2- and 4-byte elements, swap (reverse) the byte order
 //|         """
 //|         ...
 //|
@@ -592,7 +592,7 @@ const mp_obj_property_t rp2pio_statemachine_pending_obj = {
 //|         :param ~circuitpython_typing.WriteableBuffer buffer: Read data into this buffer
 //|         :param int start: Start of the slice of ``buffer`` to read into: ``buffer[start:end]``
 //|         :param int end: End of the slice; this index is not included. Defaults to ``len(buffer)``
-//|         :param bool swap: For 2- and 4-byte elements, swap the byte order"""
+//|         :param bool swap: For 2- and 4-byte elements, swap (reverse) the byte order"""
 //|         ...
 //|
 
@@ -651,8 +651,8 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_readinto_obj, 2, rp2pio_statemach
 //|         :param int out_end: End of the slice; this index is not included. Defaults to ``len(buffer_out)``
 //|         :param int in_start: Start of the slice of ``buffer_in`` to read into: ``buffer_in[in_start:in_end]``
 //|         :param int in_end: End of the slice; this index is not included. Defaults to ``len(buffer_in)``"""
-//|         :param bool swap_out: For 2- and 4-byte elements, swap the byte order for the buffer being transmitted (written)"""
-//|         :param bool swap_in: For 2- and 4-rx elements, swap the byte order for the buffer being received (read)"""
+//|         :param bool swap_out: For 2- and 4-byte elements, swap (reverse) the byte order for the buffer being transmitted (written)"""
+//|         :param bool swap_in: For 2- and 4-rx elements, swap (reverse) the byte order for the buffer being received (read)"""
 //|         ...
 //|
 

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.h
@@ -65,15 +65,15 @@ void common_hal_rp2pio_statemachine_stop(rp2pio_statemachine_obj_t *self);
 void common_hal_rp2pio_statemachine_run(rp2pio_statemachine_obj_t *self, const uint16_t *instructions, size_t len);
 
 // Writes out the given data.
-bool common_hal_rp2pio_statemachine_write(rp2pio_statemachine_obj_t *self, const uint8_t *data, size_t len, uint8_t stride_in_bytes);
-bool common_hal_rp2pio_statemachine_background_write(rp2pio_statemachine_obj_t *self, const sm_buf_info *once_obj, const sm_buf_info *loop_obj, uint8_t stride_in_bytes);
+bool common_hal_rp2pio_statemachine_write(rp2pio_statemachine_obj_t *self, const uint8_t *data, size_t len, uint8_t stride_in_bytes, bool swap);
+bool common_hal_rp2pio_statemachine_background_write(rp2pio_statemachine_obj_t *self, const sm_buf_info *once_obj, const sm_buf_info *loop_obj, uint8_t stride_in_bytes, bool swap);
 bool common_hal_rp2pio_statemachine_stop_background_write(rp2pio_statemachine_obj_t *self);
 mp_int_t common_hal_rp2pio_statemachine_get_pending(rp2pio_statemachine_obj_t *self);
 bool common_hal_rp2pio_statemachine_get_writing(rp2pio_statemachine_obj_t *self);
-bool common_hal_rp2pio_statemachine_readinto(rp2pio_statemachine_obj_t *self, uint8_t *data, size_t len, uint8_t stride_in_bytes);
+bool common_hal_rp2pio_statemachine_readinto(rp2pio_statemachine_obj_t *self, uint8_t *data, size_t len, uint8_t stride_in_bytes, bool swap);
 bool common_hal_rp2pio_statemachine_write_readinto(rp2pio_statemachine_obj_t *self,
     const uint8_t *data_out, size_t out_len, uint8_t out_stride_in_bytes,
-    uint8_t *data_in, size_t in_len, uint8_t in_stride_in_bytes);
+    uint8_t *data_in, size_t in_len, uint8_t in_stride_in_bytes, bool swap_out, bool swap_in);
 
 // Return actual state machine frequency.
 uint32_t common_hal_rp2pio_statemachine_get_frequency(rp2pio_statemachine_obj_t *self);

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.h
@@ -81,6 +81,8 @@ void common_hal_rp2pio_statemachine_set_frequency(rp2pio_statemachine_obj_t *sel
 
 bool common_hal_rp2pio_statemachine_get_rxstall(rp2pio_statemachine_obj_t *self);
 void common_hal_rp2pio_statemachine_clear_rxfifo(rp2pio_statemachine_obj_t *self);
+bool common_hal_rp2pio_statemachine_get_txstall(rp2pio_statemachine_obj_t *self);
+void common_hal_rp2pio_statemachine_clear_txstall(rp2pio_statemachine_obj_t *self);
 size_t common_hal_rp2pio_statemachine_get_in_waiting(rp2pio_statemachine_obj_t *self);
 
 void common_hal_rp2pio_statemachine_set_interrupt_handler(rp2pio_statemachine_obj_t *self, void (*handler)(void *), void *arg, int mask);

--- a/ports/raspberrypi/common-hal/audiobusio/PDMIn.c
+++ b/ports/raspberrypi/common-hal/audiobusio/PDMIn.c
@@ -157,9 +157,9 @@ uint32_t common_hal_audiobusio_pdmin_record_to_buffer(audiobusio_pdmin_obj_t *se
     size_t output_count = 0;
     common_hal_rp2pio_statemachine_clear_rxfifo(&self->state_machine);
     // Do one read to get the mic going and throw it away.
-    common_hal_rp2pio_statemachine_readinto(&self->state_machine, (uint8_t *)samples, 2 * sizeof(uint32_t), sizeof(uint32_t));
+    common_hal_rp2pio_statemachine_readinto(&self->state_machine, (uint8_t *)samples, 2 * sizeof(uint32_t), sizeof(uint32_t), false);
     while (output_count < output_buffer_length && !common_hal_rp2pio_statemachine_get_rxstall(&self->state_machine)) {
-        common_hal_rp2pio_statemachine_readinto(&self->state_machine, (uint8_t *)samples, 2 * sizeof(uint32_t), sizeof(uint32_t));
+        common_hal_rp2pio_statemachine_readinto(&self->state_machine, (uint8_t *)samples, 2 * sizeof(uint32_t), sizeof(uint32_t), false);
         // Call filter_sample just one place so it can be inlined.
         uint16_t value = filter_sample(samples);
         if (self->bit_depth == 8) {

--- a/ports/raspberrypi/common-hal/imagecapture/ParallelImageCapture.c
+++ b/ports/raspberrypi/common-hal/imagecapture/ParallelImageCapture.c
@@ -153,7 +153,7 @@ void common_hal_imagecapture_parallelimagecapture_singleshot_capture(imagecaptur
     pio_sm_exec(pio, sm, pio_encode_jmp(offset));
     pio_sm_set_enabled(pio, sm, true);
 
-    common_hal_rp2pio_statemachine_readinto(&self->state_machine, bufinfo.buf, bufinfo.len, 4);
+    common_hal_rp2pio_statemachine_readinto(&self->state_machine, bufinfo.buf, bufinfo.len, 4, false);
 
     pio_sm_set_enabled(pio, sm, false);
 }

--- a/ports/raspberrypi/common-hal/neopixel_write/__init__.c
+++ b/ports/raspberrypi/common-hal/neopixel_write/__init__.c
@@ -63,7 +63,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t *digitalinout,
     uint32_t pins_we_use = 1 << digitalinout->pin->number;
     bool ok = rp2pio_statemachine_construct(&state_machine,
         neopixel_program, sizeof(neopixel_program) / sizeof(neopixel_program[0]),
-        12800000, // MHz, to get about appropriate sub-bit times in PIO program.
+        12800000, // 12.8MHz, to get appropriate sub-bit times in PIO program.
         NULL, 0, // init program
         NULL, 1, // out
         NULL, 1, // in

--- a/ports/raspberrypi/common-hal/neopixel_write/__init__.c
+++ b/ports/raspberrypi/common-hal/neopixel_write/__init__.c
@@ -90,7 +90,7 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t *digitalinout,
     while (port_get_raw_ticks(NULL) < next_start_raw_ticks) {
     }
 
-    common_hal_rp2pio_statemachine_write(&state_machine, pixels, num_bytes, 1 /* stride in bytes */);
+    common_hal_rp2pio_statemachine_write(&state_machine, pixels, num_bytes, 1 /* stride in bytes */, false);
 
     // Use a private deinit of the state machine that doesn't reset the pin.
     rp2pio_statemachine_deinit(&state_machine, true);

--- a/ports/raspberrypi/common-hal/paralleldisplay/ParallelBus.c
+++ b/ports/raspberrypi/common-hal/paralleldisplay/ParallelBus.c
@@ -161,7 +161,7 @@ void common_hal_paralleldisplay_parallelbus_send(mp_obj_t obj, display_byte_type
     paralleldisplay_parallelbus_obj_t *self = MP_OBJ_TO_PTR(obj);
 
     common_hal_digitalio_digitalinout_set_value(&self->command, byte_type == DISPLAY_DATA);
-    common_hal_rp2pio_statemachine_write(&self->state_machine, data, data_length, 1);
+    common_hal_rp2pio_statemachine_write(&self->state_machine, data, data_length, 1, false);
 }
 
 void common_hal_paralleldisplay_parallelbus_end_transaction(mp_obj_t obj) {

--- a/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
@@ -98,7 +98,7 @@ void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencode
 
     // We're guaranteed by the init code that some output will be available promptly
     uint8_t quiescent_state;
-    common_hal_rp2pio_statemachine_readinto(&self->state_machine, &quiescent_state, 1, 1);
+    common_hal_rp2pio_statemachine_readinto(&self->state_machine, &quiescent_state, 1, 1, false);
 
     shared_module_softencoder_state_init(self, quiescent_state & 3);
     common_hal_rp2pio_statemachine_set_interrupt_handler(&self->state_machine, incrementalencoder_interrupt_handler, self, PIO_IRQ0_INTF_SM0_RXNEMPTY_BITS);

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -848,6 +848,18 @@ void common_hal_rp2pio_statemachine_clear_rxfifo(rp2pio_statemachine_obj_t *self
     self->pio->fdebug = stall_mask;
 }
 
+bool common_hal_rp2pio_statemachine_get_txstall(rp2pio_statemachine_obj_t *self) {
+    uint32_t stall_mask = 1 << (PIO_FDEBUG_TXSTALL_LSB + self->state_machine);
+    return (self->pio->fdebug & stall_mask) != 0;
+}
+
+void common_hal_rp2pio_statemachine_clear_txstall(rp2pio_statemachine_obj_t *self) {
+    uint8_t level = pio_sm_get_rx_fifo_level(self->pio, self->state_machine);
+    uint32_t stall_mask = 1 << (PIO_FDEBUG_TXSTALL_LSB + self->state_machine);
+    self->pio->fdebug = stall_mask;
+}
+
+
 size_t common_hal_rp2pio_statemachine_get_in_waiting(rp2pio_statemachine_obj_t *self) {
     uint8_t level = pio_sm_get_rx_fifo_level(self->pio, self->state_machine);
     return level;

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -917,7 +917,7 @@ bool common_hal_rp2pio_statemachine_background_write(rp2pio_statemachine_obj_t *
         self->loop = *loop;
         self->pending_buffers = pending_buffers;
 
-        if (self->dma_completed) {
+        if (self->dma_completed && self->once.info.len) {
             rp2pio_statemachine_dma_complete(self, SM_DMA_GET_CHANNEL(pio_index, sm));
             self->dma_completed = false;
         }

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -894,8 +894,8 @@ bool common_hal_rp2pio_statemachine_background_write(rp2pio_statemachine_obj_t *
     uint8_t pio_index = pio_get_index(self->pio);
     uint8_t sm = self->state_machine;
 
-    int pending_buffers = (once->info.buf != NULL) + (loop->info.buf != NULL);
-    if (!once->info.buf) {
+    int pending_buffers = (once->info.len != 0) + (loop->info.len != 0);
+    if (!once->info.len) {
         once = loop;
     }
 

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
@@ -64,7 +64,7 @@ typedef struct {
     volatile int pending_buffers;
     sm_buf_info current, once, loop;
     int background_stride_in_bytes;
-    bool dma_completed;
+    bool dma_completed, byteswap;
 } rp2pio_statemachine_obj_t;
 
 void reset_rp2pio_statemachine(void);


### PR DESCRIPTION
 * Fix a problem when once=None and loop=None in background_write
 * Fix a problem where a zero-length buffer is passed in
 * Add support for byteswapping via the DMA peripheral
 * add ability to get, clear the txstall flag

This makes it possible to
 * actually wait for the transfer to FULLY complete (not just trickery like in the morse code example)
 * stop a background transfer after a full loop exactly
 * background write neopixels that 'act like' a pypixelbuf without manually swapping. It's soooo fast the rainbow looks white.

Closes: #6359, closes #6357