### PR TITLE
Correct errno messages

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1750,6 +1750,10 @@ msgid "No space left on device"
 msgstr ""
 
 #: py/moduerrno.c
+msgid "No such device"
+msgstr ""
+
+#: py/moduerrno.c
 msgid "No such file/directory"
 msgstr ""
 
@@ -1854,6 +1858,10 @@ msgstr ""
 
 #: shared-module/displayio/ColorConverter.c
 msgid "Only one color can be transparent at a time"
+msgstr ""
+
+#: py/moduerrno.c
+msgid "Operation not permitted"
 msgstr ""
 
 #: ports/espressif/bindings/espidf/__init__.c ports/espressif/esp_error.c
@@ -2519,10 +2527,6 @@ msgstr ""
 
 #: shared-module/audiocore/WaveFile.c
 msgid "Unsupported format"
-msgstr ""
-
-#: py/moduerrno.c
-msgid "Unsupported operation"
 msgstr ""
 
 #: ports/espressif/common-hal/dualbank/__init__.c

--- a/py/moduerrno.c
+++ b/py/moduerrno.c
@@ -140,7 +140,7 @@ const char *mp_common_errno_to_str(mp_obj_t errno_val, char *buf, size_t len) {
     const compressed_string_t *desc = NULL;
     switch (MP_OBJ_SMALL_INT_VALUE(errno_val)) {
         case EPERM:
-            desc = MP_ERROR_TEXT("Permission denied");
+            desc = MP_ERROR_TEXT("Operation not permitted");
             break;
         case ENOENT:
             desc = MP_ERROR_TEXT("No such file/directory");
@@ -155,7 +155,7 @@ const char *mp_common_errno_to_str(mp_obj_t errno_val, char *buf, size_t len) {
             desc = MP_ERROR_TEXT("File exists");
             break;
         case ENODEV:
-            desc = MP_ERROR_TEXT("Unsupported operation");
+            desc = MP_ERROR_TEXT("No such device");
             break;
         case EINVAL:
             desc = MP_ERROR_TEXT("Invalid argument");


### PR DESCRIPTION
The `errno` messages for `EPERM` and `ENODEV` were wrong. In particular the ENODEV message was confusingly wrong.

This grows builds slightly due to a new string, and alter the errors we see in some circumstances, but I think it's better to have the correct messages. If the mesages are mentioned in any guides, they'll need to be changed, but I think the mentions may only be in issues. I'll do a learn.adafruit.com site search after this is merged.