### PR TITLE
Add fetch-modules to main makefile `make help` 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ TRANSLATE_SOURCES_EXC = -path "ports/*/build-*" \
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  fetch-submodules	to fetch dependencies from submodules, run this right after you clone the repo"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"


### PR DESCRIPTION
This adds the new suggested method for downloading submodules into the `make help` command.

## Rationale
After returning to (the internals of) CircuitPython, I forgot the newer command for initing the submodules. It looks like the documentation is only in the [circuitpython build guide](https://learn.adafruit.com/building-circuitpython/build-circuitpython).

### Output
```
tg-techie@ 12May2022 circuitpython % make help
Please use `make <target>' where <target> is one of
  fetch-submodules      to fetch dependencies from submodules, run this right after you clone the repo
  html       to make standalone HTML files
```

### remaining
- [ ] Should the description convey anything else? less?

#### Side Note
It's great to see all the tooling improvements😊. I look forward to more; hug report hugs all around, and thank you.