### PR TITLE
Add two stage reset for BLE

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/__init__.c
+++ b/devices/ble_hci/common-hal/_bleio/__init__.c
@@ -57,6 +57,11 @@ bool vm_used_ble;
 //     }
 // }
 
+void bleio_user_reset() {
+    // HCI doesn't support the BLE workflow so just do a full reset.
+    bleio_reset();
+}
+
 // Turn off BLE on a reset or reload.
 void bleio_reset() {
     // Create a UUID object for all CCCD's.

--- a/ports/espressif/common-hal/_bleio/Adapter.c
+++ b/ports/espressif/common-hal/_bleio/Adapter.c
@@ -574,6 +574,9 @@ void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self, bool 
 }
 
 void common_hal_bleio_adapter_stop_advertising(bleio_adapter_obj_t *self) {
+    if (!common_hal_bleio_adapter_get_advertising(self)) {
+        return;
+    }
     int err_code = ble_gap_ext_adv_stop(0);
     self->user_advertising = false;
 

--- a/ports/espressif/common-hal/_bleio/__init__.c
+++ b/ports/espressif/common-hal/_bleio/__init__.c
@@ -42,6 +42,17 @@
 // #include "common-hal/_bleio/bonding.h"
 #include "common-hal/_bleio/ble_events.h"
 
+void bleio_user_reset() {
+    // Stop any user scanning or advertising.
+    common_hal_bleio_adapter_stop_scan(&common_hal_bleio_adapter_obj);
+    common_hal_bleio_adapter_stop_advertising(&common_hal_bleio_adapter_obj);
+
+    ble_event_remove_heap_handlers();
+
+    // Maybe start advertising the BLE workflow.
+    supervisor_bluetooth_background();
+}
+
 // Turn off BLE on a reset or reload.
 void bleio_reset() {
     // Set this explicitly to save data.

--- a/ports/espressif/common-hal/_bleio/ble_events.c
+++ b/ports/espressif/common-hal/_bleio/ble_events.c
@@ -31,6 +31,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#include "py/gc.h"
 #include "py/misc.h"
 #include "py/mpstate.h"
 #include "py/runtime.h"
@@ -42,6 +43,17 @@
 void ble_event_reset(void) {
     // Linked list items will be gc'd.
     MP_STATE_VM(ble_event_handler_entries) = NULL;
+}
+
+void ble_event_remove_heap_handlers(void) {
+    ble_event_handler_entry_t *it = MP_STATE_VM(ble_event_handler_entries);
+    while (it != NULL) {
+        // If the param is on the heap, then delete the handler.
+        if (HEAP_PTR(it->param)) {
+            ble_event_remove_handler(it->func, it->param);
+        }
+        it = it->next;
+    }
 }
 
 void ble_event_add_handler_entry(ble_event_handler_entry_t *entry,

--- a/ports/espressif/common-hal/_bleio/ble_events.h
+++ b/ports/espressif/common-hal/_bleio/ble_events.h
@@ -40,6 +40,7 @@ typedef struct ble_event_handler_entry {
 } ble_event_handler_entry_t;
 
 void ble_event_reset(void);
+void ble_event_remove_heap_handlers(void);
 void ble_event_add_handler(ble_gap_event_fn *func, void *param);
 void ble_event_remove_handler(ble_gap_event_fn *func, void *param);
 

--- a/ports/espressif/supervisor/port.c
+++ b/ports/espressif/supervisor/port.c
@@ -283,10 +283,6 @@ void reset_port(void) {
     watchdog_reset();
     #endif
 
-    #if CIRCUITPY_BLEIO
-    bleio_reset();
-    #endif
-
     #if CIRCUITPY_WIFI
     wifi_reset();
     #endif

--- a/ports/nrf/bluetooth/ble_drv.h
+++ b/ports/nrf/bluetooth/ble_drv.h
@@ -67,6 +67,7 @@ typedef struct ble_drv_evt_handler_entry {
 } ble_drv_evt_handler_entry_t;
 
 void ble_drv_reset(void);
+void ble_drv_remove_heap_handlers(void);
 void ble_drv_add_event_handler(ble_drv_evt_handler_t func, void *param);
 void ble_drv_remove_event_handler(ble_drv_evt_handler_t func, void *param);
 

--- a/ports/nrf/common-hal/_bleio/PacketBuffer.c
+++ b/ports/nrf/common-hal/_bleio/PacketBuffer.c
@@ -380,9 +380,11 @@ mp_int_t common_hal_bleio_packet_buffer_write(bleio_packet_buffer_obj_t *self, c
                !mp_hal_is_interrupted()) {
             RUN_BACKGROUND_TASKS;
         }
+        if (mp_hal_is_interrupted()) {
+            return -1;
+        }
     }
-    if (self->conn_handle == BLE_CONN_HANDLE_INVALID ||
-        mp_hal_is_interrupted()) {
+    if (self->conn_handle == BLE_CONN_HANDLE_INVALID) {
         return -1;
     }
 

--- a/ports/nrf/common-hal/_bleio/__init__.c
+++ b/ports/nrf/common-hal/_bleio/__init__.c
@@ -94,6 +94,17 @@ void check_sec_status(uint8_t sec_status) {
     }
 }
 
+void bleio_user_reset() {
+    // Stop any user scanning or advertising.
+    common_hal_bleio_adapter_stop_scan(&common_hal_bleio_adapter_obj);
+    common_hal_bleio_adapter_stop_advertising(&common_hal_bleio_adapter_obj);
+
+    ble_drv_remove_heap_handlers();
+
+    // Maybe start advertising the BLE workflow.
+    supervisor_bluetooth_background();
+}
+
 // Turn off BLE on a reset or reload.
 void bleio_reset() {
     // Set this explicitly to save data.

--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -246,10 +246,6 @@ void reset_port(void) {
 
     timers_reset();
 
-    #if CIRCUITPY_BLEIO
-    bleio_reset();
-    #endif
-
     #if CIRCUITPY_WATCHDOG
     watchdog_reset();
     #endif

--- a/py/gc.h
+++ b/py/gc.h
@@ -35,11 +35,16 @@
 #define WORDS_PER_BLOCK ((MICROPY_BYTES_PER_GC_BLOCK) / MP_BYTES_PER_OBJ_WORD)
 #define BYTES_PER_BLOCK (MICROPY_BYTES_PER_GC_BLOCK)
 
+#define HEAP_PTR(ptr) ( \
+    MP_STATE_MEM(gc_pool_start) != 0                     /* Not on the heap if it isn't inited */ \
+    && ptr >= (void *)MP_STATE_MEM(gc_pool_start)        /* must be above start of pool */ \
+    && ptr < (void *)MP_STATE_MEM(gc_pool_end)           /* must be below end of pool */ \
+    )
+
 // ptr should be of type void*
 #define VERIFY_PTR(ptr) ( \
     ((uintptr_t)(ptr) & (BYTES_PER_BLOCK - 1)) == 0          /* must be aligned on a block */ \
-    && ptr >= (void *)MP_STATE_MEM(gc_pool_start)        /* must be above start of pool */ \
-    && ptr < (void *)MP_STATE_MEM(gc_pool_end)           /* must be below end of pool */ \
+    && HEAP_PTR(ptr) \
     )
 
 void gc_init(void *start, void *end);

--- a/shared-bindings/_bleio/__init__.h
+++ b/shared-bindings/_bleio/__init__.h
@@ -54,6 +54,11 @@ extern const mp_obj_type_t mp_type_bleio_BluetoothError;
 extern const mp_obj_type_t mp_type_bleio_RoleError;
 extern const mp_obj_type_t mp_type_bleio_SecurityError;
 
+// Resets all user created BLE state in preparation for the heap disappearing.
+// It will maintain BLE workflow and connections.
+void bleio_user_reset(void);
+
+// Completely resets the BLE stack including BLE connections.
 void bleio_reset(void);
 
 extern mp_obj_t bleio_set_adapter(mp_obj_t adapter_obj);


### PR DESCRIPTION
This lets the BLE stack run through the wait period after a VM run
when it may be waiting for more writes due to an auto-reload.

User BLE functionality will have their events stopped. Scanning and
advertising is also stopped.