### PR TITLE
Add additional documentation for modules, builtin exceptions

### DIFF
--- a/docs/library/builtins.rst
+++ b/docs/library/builtins.rst
@@ -214,7 +214,7 @@ Exceptions
 .. exception:: ReloadException
 
    `ReloadException` is used internally to deal with soft restarts.
-   
+
    Not a part of the CPython standard library
 
 .. exception:: StopAsyncIteration

--- a/docs/library/builtins.rst
+++ b/docs/library/builtins.rst
@@ -4,10 +4,17 @@
 All builtin functions and exceptions are described here. They are also
 available via ``builtins`` module.
 
+For more information about built-ins, see the following CPython documentation:
+
+* `Builtin CPython Functions <https://docs.python.org/3/library/functions.html>`_
+* `Builtin CPython Exceptions <https://docs.python.org/3/library/exceptions.html>`_
+* `Builtin CPython Constants <https://docs.python.org/3/library/constants.html>`_
+
+.. note:: Not all of these functions, types, exceptions, and constants are turned
+    on in all CircuitPython ports, for space reasons.
+
 Functions and types
 -------------------
-
-Not all of these functions and types are turned on in all CircuitPython ports, for space reasons.
 
 .. function:: abs()
 
@@ -160,13 +167,25 @@ Not all of these functions and types are turned on in all CircuitPython ports, f
 Exceptions
 ----------
 
+.. exception:: ArithmeticError
+
 .. exception:: AssertionError
 
 .. exception:: AttributeError
 
+.. exception:: BaseException
+
+.. exception:: BrokenPipeError
+
+.. exception:: ConnectionError
+
+.. exception:: EOFError
+
 .. exception:: Exception
 
 .. exception:: ImportError
+
+.. exception:: IndentationError
 
 .. exception:: IndexError
 
@@ -174,7 +193,13 @@ Exceptions
 
 .. exception:: KeyError
 
+.. exception:: LookupError
+
 .. exception:: MemoryError
+
+.. exception:: MpyError
+
+    Not a part of the CPython standard library
 
 .. exception:: NameError
 
@@ -182,11 +207,17 @@ Exceptions
 
 .. exception:: OSError
 
+.. exception:: OverflowError
+
 .. exception:: RuntimeError
 
 .. exception:: ReloadException
 
    `ReloadException` is used internally to deal with soft restarts.
+   
+   Not a part of the CPython standard library
+
+.. exception:: StopAsyncIteration
 
 .. exception:: StopIteration
 
@@ -194,12 +225,19 @@ Exceptions
 
 .. exception:: SystemExit
 
-    |see_cpython| :py:class:`cpython:SystemExit`.
+.. exception:: TimeoutError
 
 .. exception:: TypeError
 
-    |see_cpython| :py:class:`cpython:TypeError`.
+.. exception:: UnicodeError
 
 .. exception:: ValueError
 
 .. exception:: ZeroDivisionError
+
+Constants
+---------
+
+.. data:: Ellipsis
+
+.. data:: NotImplemented

--- a/ports/raspberrypi/bindings/rp2pio/__init__.c
+++ b/ports/raspberrypi/bindings/rp2pio/__init__.c
@@ -30,7 +30,14 @@
 #include "bindings/rp2pio/StateMachine.h"
 #include "bindings/rp2pio/__init__.h"
 
-//| """Hardware interface to RP2 series' programmable IO (PIO) peripheral."""
+//| """Hardware interface to RP2 series' programmable IO (PIO) peripheral.
+//|
+//| .. note:: This module is intended to be used with the `adafruit_pioasm library
+//|     <https://github.com/adafruit/Adafruit_CircuitPython_PIOASM>`_.  For an
+//|     introduction and guide to working with PIO in CircuitPython, see `this
+//|     Learn guide <https://learn.adafruit.com/intro-to-rp2040-pio-with-circuitpython>`_.
+//|
+//| """
 //|
 
 //| def pins_are_sequential(pins: List[microcontroller.Pin]) -> bool:

--- a/shared-bindings/alarm/__init__.c
+++ b/shared-bindings/alarm/__init__.c
@@ -55,6 +55,9 @@
 //|
 //| For both light sleep and deep sleep, if CircuitPython is connected to a host computer,
 //| maintaining the connection takes priority and power consumption may not be reduced.
+//|
+//| For more information about working with alarms and light/deep sleep in CircuitPython,
+//| see `this Learn guide <https://learn.adafruit.com/deep-sleep-with-circuitpython>`_.
 //| """
 
 //| sleep_memory: SleepMemory

--- a/shared-bindings/analogio/__init__.c
+++ b/shared-bindings/analogio/__init__.c
@@ -59,12 +59,11 @@
 //| :py:meth:`~analogio.AnalogIn.deinit` the hardware. The last step is optional
 //| because CircuitPython will do it automatically after the program finishes.
 //|
-//| For the essentials of `analogio`, see the CircuitPython Essentials
-//| Learn guide:
-//| https://learn.adafruit.com/circuitpython-essentials/circuitpython-analog-in
+//| For the essentials of `analogio`, see the `CircuitPython Essentials
+//| Learn guide <https://learn.adafruit.com/circuitpython-essentials/circuitpython-analog-in>`_
 //|
-//| For more information on using `analogio`, see this additional Learn guide:
-//| https://learn.adafruit.com/circuitpython-basics-analog-inputs-and-outputs
+//| For more information on using `analogio`, see `this additional Learn guide
+//| <https://learn.adafruit.com/circuitpython-basics-analog-inputs-and-outputs>`_
 //| """
 //|
 

--- a/shared-bindings/audiomp3/__init__.c
+++ b/shared-bindings/audiomp3/__init__.c
@@ -31,7 +31,12 @@
 
 #include "shared-bindings/audiomp3/MP3Decoder.h"
 
-//| """Support for MP3-compressed audio files"""
+//| """Support for MP3-compressed audio files
+//|
+//| For more infomration about working with MP3 files in CircuitPython,
+//| see `this CircuitPython Essentials Learn guide page
+//| <https://learn.adafruit.com/circuitpython-essentials/circuitpython-mp3-audio>`_.
+//| """
 //|
 
 STATIC const mp_rom_map_elem_t audiomp3_module_globals_table[] = {

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -43,7 +43,13 @@
 #include "extmod/vfs_posix.h"
 #endif
 
-//| """Collection of bitmap manipulation tools"""
+//| """Collection of bitmap manipulation tools
+//|
+//| .. note:: If you're looking for information about displaying bitmaps on
+//|     screens in CircuitPython, see `this Learn guide
+//|     <https://learn.adafruit.com/circuitpython-display-support-using-displayio>`_
+//|     for information about using the :py:mod:`displayio` module.
+//| """
 //|
 
 STATIC int16_t validate_point(mp_obj_t point, int16_t default_value) {

--- a/shared-bindings/board/__init__.c
+++ b/shared-bindings/board/__init__.c
@@ -47,9 +47,9 @@
 //| the default pins and settings.  For more information about serial communcication
 //| in CircuitPython, see the :mod:`busio`.
 //|
-//| For more information regarding the typical usage of :py:mod:`board`, refer to the CircuitPython
-//| Essentials Learn guide:
-//| https://learn.adafruit.com/circuitpython-essentials/circuitpython-pins-and-modules
+//| For more information regarding the typical usage of :py:mod:`board`, refer to the `CircuitPython
+//| Essentials Learn guide
+//| <https://learn.adafruit.com/circuitpython-essentials/circuitpython-pins-and-modules>`_
 //|
 //| .. warning:: The board module varies by board. The APIs documented here may or may not be
 //|              available on a specific board."""

--- a/shared-bindings/digitalio/__init__.c
+++ b/shared-bindings/digitalio/__init__.c
@@ -73,12 +73,11 @@
 //|       led.value = False
 //|       time.sleep(0.1)
 //|
-//| For the essentials of `digitalio`, see the CircuitPython Essentials
-//| Learn guide:
-//| https://learn.adafruit.com/circuitpython-essentials/circuitpython-digital-in-out
+//| For the essentials of `digitalio`, see the `CircuitPython Essentials
+//| Learn guide <https://learn.adafruit.com/circuitpython-essentials/circuitpython-digital-in-out>`_
 //|
-//| For more information on using `digitalio`, see this additional Learn guide:
-//| https://learn.adafruit.com/circuitpython-digital-inputs-and-outputs
+//| For more information on using `digitalio`, see `this additional Learn guide
+//| <https://learn.adafruit.com/circuitpython-digital-inputs-and-outputs>`_
 //| """
 
 STATIC const mp_rom_map_elem_t digitalio_module_globals_table[] = {

--- a/shared-bindings/displayio/__init__.c
+++ b/shared-bindings/displayio/__init__.c
@@ -51,9 +51,9 @@
 //| The `displayio` module contains classes to manage display output
 //| including synchronizing with refresh rates and partial updating.
 //|
-//| For more a more thorugh explanation and guide for using `displayio`, please
-//| refer to this Learn guide:
-//| https://learn.adafruit.com/circuitpython-display-support-using-displayio
+//| For more a more thorough explanation and guide for using `displayio`, please
+//| refer to `this Learn guide
+//| <https://learn.adafruit.com/circuitpython-display-support-using-displayio>`_.
 //| """
 //|
 

--- a/shared-bindings/fontio/__init__.c
+++ b/shared-bindings/fontio/__init__.c
@@ -35,6 +35,12 @@
 
 //| """Core font related data structures"""
 //|
+//| .. note:: This library is intended only for low-level usage.  For working with
+//|     fonts in CircuitPython see the
+//|     `adafruit_bitmap_font library <https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font>`_.
+//|     For infromation on creating custom fonts for use in CircuitPython, see
+//|     `this Learn guide <https://learn.adafruit.com/custom-fonts-for-pyportal-circuitpython-display>`_
+//|
 
 STATIC const mp_rom_map_elem_t fontio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_fontio) },

--- a/shared-bindings/fontio/__init__.c
+++ b/shared-bindings/fontio/__init__.c
@@ -33,13 +33,15 @@
 #include "shared-bindings/fontio/BuiltinFont.h"
 #include "shared-bindings/fontio/Glyph.h"
 
-//| """Core font related data structures"""
+//| """Core font related data structures
 //|
 //| .. note:: This library is intended only for low-level usage.  For working with
-//|     fonts in CircuitPython see the
-//|     `adafruit_bitmap_font library <https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font>`_.
-//|     For infromation on creating custom fonts for use in CircuitPython, see
+//|     fonts in CircuitPython see the `adafruit_bitmap_font library
+//|     <https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font>`_.
+//|     For information on creating custom fonts for use in CircuitPython, see
 //|     `this Learn guide <https://learn.adafruit.com/custom-fonts-for-pyportal-circuitpython-display>`_
+//|
+//| """
 //|
 
 STATIC const mp_rom_map_elem_t fontio_module_globals_table[] = {

--- a/shared-bindings/fontio/__init__.c
+++ b/shared-bindings/fontio/__init__.c
@@ -35,7 +35,7 @@
 
 //| """Core font related data structures
 //|
-//| .. note:: This library is intended only for low-level usage.  For working with
+//| .. note:: This module is intended only for low-level usage.  For working with
 //|     fonts in CircuitPython see the `adafruit_bitmap_font library
 //|     <https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font>`_.
 //|     For information on creating custom fonts for use in CircuitPython, see

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -43,8 +43,9 @@
 
 //| """Pin references and cpu functionality
 //|
-//| The `microcontroller` module defines the pins from the perspective of the
-//| microcontroller. See :py:mod:`board` for board-specific pin mappings."""
+//| The `microcontroller` module defines the pins and other bare-metal hardware
+//| from the perspective of the microcontroller. See :py:mod:`board` for
+//| board-specific pin mappings."""
 //|
 //| from nvm import ByteArray
 //| from watchdog import WatchDogTimer

--- a/shared-bindings/neopixel_write/__init__.c
+++ b/shared-bindings/neopixel_write/__init__.c
@@ -97,11 +97,11 @@ STATIC void check_for_deinit(digitalio_digitalinout_obj_t *self) {
 //|
 //|     This library is typically not used by user level code.
 //|
-//|     For more information on actually using NeoPixels, refer to the CircuitPython
-//|     Essentials Learn guide: https://learn.adafruit.com/circuitpython-essentials/circuitpython-neopixel
+//|     For more information on actually using NeoPixels, refer to the `CircuitPython
+//|     Essentials Learn guide <https://learn.adafruit.com/circuitpython-essentials/circuitpython-neopixel>`_
 //|
-//|     For a much more thorough guide about using NeoPixels, refer to the Adadfruit NeoPixel Überguide:
-//|     https://learn.adafruit.com/adafruit-neopixel-uberguide
+//|     For a much more thorough guide about using NeoPixels, refer to the `Adafruit NeoPixel Überguide
+//|     <https://learn.adafruit.com/adafruit-neopixel-uberguide>`_.
 //|
 //| """
 //|

--- a/shared-bindings/neopixel_write/__init__.c
+++ b/shared-bindings/neopixel_write/__init__.c
@@ -95,7 +95,7 @@ STATIC void check_for_deinit(digitalio_digitalinout_obj_t *self) {
 //|
 //| .. note::
 //|
-//|     This library is typically not used by user level code.
+//|     This module is typically not used by user level code.
 //|
 //|     For more information on actually using NeoPixels, refer to the `CircuitPython
 //|     Essentials Learn guide <https://learn.adafruit.com/circuitpython-essentials/circuitpython-neopixel>`_

--- a/shared-bindings/pwmio/__init__.c
+++ b/shared-bindings/pwmio/__init__.c
@@ -59,9 +59,8 @@
 //| hardware after program completion. Use ``deinit()`` or a ``with`` statement
 //| to do it yourself.
 //|
-//| For the essentials of `pwmio`, see the CircuitPython Essentials
-//| Learn guide:
-//| https://learn.adafruit.com/circuitpython-essentials/circuitpython-pwm
+//| For the essentials of `pwmio`, see the `CircuitPython Essentials
+//| Learn guide <https://learn.adafruit.com/circuitpython-essentials/circuitpython-pwm>`_.
 //| """
 //|
 

--- a/shared-bindings/qrio/__init__.c
+++ b/shared-bindings/qrio/__init__.c
@@ -31,9 +31,15 @@
 #include "py/obj.h"
 #include "py/enum.h"
 
-//| """`qrio` module.
+//| """Low-level QR code decoding
 //|
-//| Provides the `QRDecoder` object."""
+//| Provides the `QRDecoder` object used for decoding QR codes.  For more
+//| information about working with QR codes, see
+//| `this Learn guide <https://learn.adafruit.com/scan-qr-codes-with-circuitpython>`_.
+//|
+//| .. note:: This library only handles decoding QR codes.  If you are looking
+//|     to generate a QR code, use the
+//|     `adafruit_miniqr library <https://github.com/adafruit/Adafruit_CircuitPython_miniQR>`_"""
 //|
 
 STATIC const mp_rom_map_elem_t qrio_module_globals_table[] = {

--- a/shared-bindings/qrio/__init__.c
+++ b/shared-bindings/qrio/__init__.c
@@ -37,7 +37,7 @@
 //| information about working with QR codes, see
 //| `this Learn guide <https://learn.adafruit.com/scan-qr-codes-with-circuitpython>`_.
 //|
-//| .. note:: This library only handles decoding QR codes.  If you are looking
+//| .. note:: This module only handles decoding QR codes.  If you are looking
 //|     to generate a QR code, use the
 //|     `adafruit_miniqr library <https://github.com/adafruit/Adafruit_CircuitPython_miniQR>`_"""
 //|

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -42,9 +42,9 @@
 //| CircuitPython does not have an OS, so this module provides this functionality
 //| directly.
 
-//| For more information regarding using the `storage` module, refer to the CircuitPython
-//| Essentials Learn guide:
-//| https://learn.adafruit.com/circuitpython-essentials/circuitpython-storage
+//| For more information regarding using the `storage` module, refer to the `CircuitPython
+//| Essentials Learn guide
+//| <https://learn.adafruit.com/circuitpython-essentials/circuitpython-storage>`_.
 //| """
 //|
 

--- a/shared-bindings/terminalio/__init__.c
+++ b/shared-bindings/terminalio/__init__.c
@@ -38,7 +38,12 @@
 //| """Displays text in a TileGrid
 //|
 //| The `terminalio` module contains classes to display a character stream on a display. The built
-//| in font is available as ``terminalio.FONT``."""
+//| in font is available as ``terminalio.FONT``.
+//|
+//| .. note:: This module does not give access to the
+//|     `REPL <https://learn.adafruit.com/welcome-to-circuitpython/interacting-with-the-serial-console>`_.
+//|
+//| """
 //|
 //| FONT: fontio.BuiltinFont
 //| """The built in font"""


### PR DESCRIPTION
Another day, another documentation PR!  Resolves #6381, and works towards #6326:

- Adds additional exceptions to `builtins`

Adds links to guides/libraries for:

- `qrio`
- `fontio`
- `terminalio` (really just a note additional that it doesn't give REPL access with link to REPL guide page)
- `microcontroller` (actually just a touchup, no linking)
- `audiomp3`
- `rp2pio`
- `alarm`
- `bitmaptools`

Also makes additions from #6353 prettier.

Documentation builds locally!