### PR TITLE
Fix readthedocs checking out frozen modules

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,6 +16,7 @@ build:
 submodules:
     include:
         - extmod/ulab
+        - frozen
 
 formats:
   - pdf

--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -66,6 +66,7 @@ submodules = []
 if target == "test":
     submodules = ["extmod/", "lib/", "tools/", "extmod/ulab", "lib/berkeley-db-1.xx"]
 elif target == "docs":
+    # NOTE: must match .readthedocs.yml as this script is not run by readthedocs
     submodules = ["extmod/ulab/", "frozen/"]
 elif target == "mpy-cross-mac":
     submodules = ["tools/"]  # for huffman


### PR DESCRIPTION
This is a follow up to #6288 that broke RTD because RTD was not setup to checkout the frozen modules.
https://readthedocs.org/projects/circuitpython/builds/16907973/
That should fix it, right ?