### PR TITLE
Fetch the submodules in readthedocs with ci_fetch_deps.py

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,17 +9,15 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
-  tools:
-    python: "3"
-
-submodules:
-    include:
-        - extmod/ulab
-        - frozen
+    os: ubuntu-20.04
+    tools:
+        python: "3"
+    jobs:
+        post_install:
+            - python tools/ci_fetch_deps.py docs HEAD
 
 formats:
-  - pdf
+    - pdf
 
 python:
     install:

--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -68,7 +68,7 @@ submodules = []
 if target == "test":
     submodules = ["extmod/", "lib/", "tools/", "extmod/ulab", "lib/berkeley-db-1.xx"]
 elif target == "docs":
-    # NOTE: must match .readthedocs.yml as this script is not run by readthedocs
+    # used in .readthedocs.yml to generate RTD
     submodules = ["extmod/ulab/", "frozen/"]
 elif target == "mpy-cross-mac":
     submodules = ["tools/"]  # for huffman


### PR DESCRIPTION
Closes #6399 
Make Readthedocs's own build process use ci_fetch_deps.py to checkout the submodules in the same way the CI does. That doesn't make github docs CI and the RTD build use the exact same steps (which they didn't already), but submodule dependencies are now in a single place.

Note: the previous version caused an error because RTD's submodule clause requires exact submodules, it doesn't do parent directories like `frozen` or patterns like `frozen/*`.