### PR TITLE
Restore automatic gc_collect() after an import

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1022,6 +1022,10 @@ msgstr ""
 msgid "Failed to acquire mutex, err 0x%04x"
 msgstr ""
 
+#: shared-module/rgbmatrix/RGBMatrix.c
+msgid "Failed to allocate %q buffer"
+msgstr ""
+
 #: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
 #: ports/raspberrypi/common-hal/busio/UART.c
 msgid "Failed to allocate RX buffer"

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -455,6 +455,10 @@ STATIC mp_obj_t process_import_at_level(qstr full_mod_name, qstr level_mod_name,
             // not a package.  This will be caught on the next iteration
             // because the file will not exist.
         }
+
+        // Loading a module thrashes the heap significantly so we explicitly clean up
+        // afterwards.
+        gc_collect();
     }
 
     if (outer_module_obj != MP_OBJ_NULL && VERIFY_PTR(MP_OBJ_TO_PTR(outer_module_obj))) {

--- a/shared-module/rgbmatrix/RGBMatrix.c
+++ b/shared-module/rgbmatrix/RGBMatrix.c
@@ -123,7 +123,7 @@ void common_hal_rgbmatrix_rgbmatrix_reconstruct(rgbmatrix_rgbmatrix_obj_t *self,
                 mp_raise_ValueError(translate("Invalid argument"));
                 break;
             case PROTOMATTER_ERR_MALLOC:
-                mp_raise_msg(&mp_type_MemoryError, NULL);
+                mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate %q buffer"), MP_QSTR_RGBMatrix);
                 break;
             default:
                 mp_raise_msg_varg(&mp_type_RuntimeError,


### PR DESCRIPTION
- Fixes #6402.

- The automatic garbage collection done after an `import` got lost in the MicroPython v1.18 merge, which rewrote the import code extensively. Restore it. This reduces heap fragmentation, which can make prevent allocating big buffers after significant imports.
- Improved error message for `RGBMatrix` being unable to allocate buffers. Previously, it just threw a blank `MemoryError`.