### PR TITLE
message consolidation and more use of validators

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/Characteristic.c
+++ b/devices/ble_hci/common-hal/_bleio/Characteristic.c
@@ -57,9 +57,9 @@ void common_hal_bleio_characteristic_construct(bleio_characteristic_obj_t *self,
     self->value = mp_obj_new_bytes(initial_value_bufinfo->buf, initial_value_bufinfo->len);
 
     const mp_int_t max_length_max = 512;
-    if (max_length < 0 || max_length > max_length_max) {
-        mp_raise_ValueError(translate("max_length must be <= 512"));
-    }
+
+    mp_arg_validate_int_range(max_length, 0, max_length_max, MP_QSTR_max_length);
+
     self->max_length = max_length;
     self->fixed_length = fixed_length;
 

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -30,6 +30,11 @@
 
 #define mp_obj_fat_vfs_t fs_user_mount_t
 
+// Factoring this common call saves about 90 bytes.
+STATIC NORETURN void mp_raise_OSError_fresult(FRESULT res) {
+    mp_raise_OSError(fresult_to_errno_table[res]);
+}
+
 STATIC mp_import_stat_t fat_vfs_import_stat(void *vfs_in, const char *path) {
     fs_user_mount_t *vfs = vfs_in;
     FILINFO fno;
@@ -64,7 +69,7 @@ STATIC mp_obj_t fat_vfs_make_new(const mp_obj_type_t *type, size_t n_args, size_
         // don't error out if no filesystem, to let mkfs()/mount() create one if wanted
         vfs->blockdev.flags |= MP_BLOCKDEV_FLAG_NO_FILESYSTEM;
     } else if (res != FR_OK) {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
 
     return MP_OBJ_FROM_PTR(vfs);
@@ -97,7 +102,7 @@ STATIC mp_obj_t fat_vfs_mkfs(mp_obj_t bdev_in) {
         res = f_mkfs(&vfs->fatfs, FM_FAT32, 0, working_buf, sizeof(working_buf));
     }
     if (res != FR_OK) {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
 
     return mp_const_none;
@@ -172,7 +177,7 @@ STATIC mp_obj_t fat_vfs_ilistdir_func(size_t n_args, const mp_obj_t *args) {
     iter->is_str = is_str_type;
     FRESULT res = f_opendir(&self->fatfs, &iter->dir, path);
     if (res != FR_OK) {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
 
     return MP_OBJ_FROM_PTR(iter);
@@ -188,7 +193,7 @@ STATIC mp_obj_t fat_vfs_remove_internal(mp_obj_t vfs_in, mp_obj_t path_in, mp_in
     FRESULT res = f_stat(&self->fatfs, path, &fno);
 
     if (res != FR_OK) {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
 
     // check if path is a file or directory
@@ -196,7 +201,7 @@ STATIC mp_obj_t fat_vfs_remove_internal(mp_obj_t vfs_in, mp_obj_t path_in, mp_in
         res = f_unlink(&self->fatfs, path);
 
         if (res != FR_OK) {
-            mp_raise_OSError(fresult_to_errno_table[res]);
+            mp_raise_OSError_fresult(res);
         }
         return mp_const_none;
     } else {
@@ -226,7 +231,7 @@ STATIC mp_obj_t fat_vfs_rename(mp_obj_t vfs_in, mp_obj_t path_in, mp_obj_t path_
     FILINFO fno;
     FRESULT res = f_stat(&self->fatfs, old_path, &fno);
     if (res != FR_OK) {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
     if ((fno.fattrib & AM_DIR) != 0 &&
         strlen(new_path) > strlen(old_path) &&
@@ -245,7 +250,7 @@ STATIC mp_obj_t fat_vfs_rename(mp_obj_t vfs_in, mp_obj_t path_in, mp_obj_t path_
     if (res == FR_OK) {
         return mp_const_none;
     } else {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
 
 }
@@ -259,7 +264,7 @@ STATIC mp_obj_t fat_vfs_mkdir(mp_obj_t vfs_in, mp_obj_t path_o) {
     if (res == FR_OK) {
         return mp_const_none;
     } else {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_mkdir_obj, fat_vfs_mkdir);
@@ -273,7 +278,7 @@ STATIC mp_obj_t fat_vfs_chdir(mp_obj_t vfs_in, mp_obj_t path_in) {
     FRESULT res = f_chdir(&self->fatfs, path);
 
     if (res != FR_OK) {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
 
     return mp_const_none;
@@ -286,7 +291,7 @@ STATIC mp_obj_t fat_vfs_getcwd(mp_obj_t vfs_in) {
     char buf[MICROPY_ALLOC_PATH_MAX + 1];
     FRESULT res = f_getcwd(&self->fatfs, buf, sizeof(buf));
     if (res != FR_OK) {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
     return mp_obj_new_str(buf, strlen(buf));
 }
@@ -307,7 +312,7 @@ STATIC mp_obj_t fat_vfs_stat(mp_obj_t vfs_in, mp_obj_t path_in) {
     } else {
         FRESULT res = f_stat(&self->fatfs, path, &fno);
         if (res != FR_OK) {
-            mp_raise_OSError(fresult_to_errno_table[res]);
+            mp_raise_OSError_fresult(res);
         }
     }
 
@@ -357,7 +362,7 @@ STATIC mp_obj_t fat_vfs_statvfs(mp_obj_t vfs_in, mp_obj_t path_in) {
     FATFS *fatfs = &self->fatfs;
     FRESULT res = f_getfree(fatfs, &nclst);
     if (FR_OK != res) {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
 
     mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(10, NULL));
@@ -395,7 +400,7 @@ STATIC mp_obj_t vfs_fat_mount(mp_obj_t self_in, mp_obj_t readonly, mp_obj_t mkfs
         res = f_mkfs(&self->fatfs, FM_FAT | FM_SFD, 0, working_buf, sizeof(working_buf));
     }
     if (res != FR_OK) {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
     self->blockdev.flags &= ~MP_BLOCKDEV_FLAG_NO_FILESYSTEM;
 
@@ -416,7 +421,7 @@ STATIC mp_obj_t vfs_fat_getlabel(mp_obj_t self_in) {
     char working_buf[12];
     FRESULT res = f_getlabel(&self->fatfs, working_buf, NULL);
     if (res != FR_OK) {
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
     return mp_obj_new_str(working_buf, strlen(working_buf));
 }
@@ -431,7 +436,7 @@ STATIC mp_obj_t vfs_fat_setlabel(mp_obj_t self_in, mp_obj_t label_in) {
         if (res == FR_WRITE_PROTECTED) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Read-only filesystem"));
         }
-        mp_raise_OSError(fresult_to_errno_table[res]);
+        mp_raise_OSError_fresult(res);
     }
     return mp_const_none;
 }

--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -182,7 +182,7 @@ STATIC mp_obj_t file_open(fs_user_mount_t *vfs, const mp_obj_type_t *type, mp_ar
     }
 
     if (rwxa_count != 1 || plus_count > 1 || bt_count > 1 || bad_mode) {
-        mp_raise_ValueError(translate("Invalid mode"));
+        mp_arg_error_invalid(MP_QSTR_mode);
     }
 
     assert(vfs != NULL);

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -66,6 +66,16 @@ msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr ""
 
+#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
+#: ports/espressif/common-hal/rtc/RTC.c
+#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
+#: ports/mimxrt10xx/common-hal/rtc/RTC.c
+#: ports/nrf/common-hal/analogio/AnalogOut.c ports/nrf/common-hal/rtc/RTC.c
+#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
+#: ports/raspberrypi/common-hal/rtc/RTC.c
+msgid "%q"
+msgstr ""
+
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
 msgstr ""
@@ -82,12 +92,7 @@ msgstr ""
 msgid "%q in use"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/cxd56/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c
-#: ports/raspberrypi/common-hal/pulseio/PulseIn.c
-#: ports/stm/common-hal/pulseio/PulseIn.c py/obj.c py/objstr.c
-#: py/objstrunicode.c
+#: py/obj.c py/objstr.c py/objstrunicode.c
 msgid "%q index out of range"
 msgstr ""
 
@@ -95,12 +100,32 @@ msgstr ""
 msgid "%q indices must be integers, not %s"
 msgstr ""
 
+#: shared-module/bitbangio/SPI.c
+msgid "%q init failed"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q length must be %d"
+msgstr ""
+
 #: py/argcheck.c
 msgid "%q length must be %d-%d"
 msgstr ""
 
-#: shared-bindings/busio/I2C.c shared-bindings/usb_hid/Device.c
+#: py/argcheck.c
+msgid "%q length must be <= %d"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q length must be >= %d"
+msgstr ""
+
+#: shared-bindings/busio/I2C.c
 msgid "%q length must be >= 1"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q must be %d"
 msgstr ""
 
 #: py/argcheck.c
@@ -119,14 +144,10 @@ msgstr ""
 msgid "%q must be >= %d"
 msgstr ""
 
-#: py/argcheck.c shared-bindings/memorymonitor/AllocationAlarm.c
+#: py/argcheck.c
 msgid "%q must be >= 0"
 msgstr ""
 
-#: shared-bindings/_bleio/CharacteristicBuffer.c
-#: shared-bindings/_bleio/PacketBuffer.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/Shape.c
-#: shared-bindings/memorymonitor/AllocationAlarm.c
 #: shared-bindings/vectorio/Circle.c shared-bindings/vectorio/Rectangle.c
 msgid "%q must be >= 1"
 msgstr ""
@@ -135,13 +156,8 @@ msgstr ""
 msgid "%q must be a string"
 msgstr ""
 
-#: shared-module/vectorio/Polygon.c
-msgid "%q must be a tuple of length 2"
-msgstr ""
-
-#: ports/espressif/common-hal/imagecapture/ParallelImageCapture.c
-#: shared-module/vectorio/VectorShape.c
-msgid "%q must be between %d and %d"
+#: py/argcheck.c
+msgid "%q must be an int"
 msgstr ""
 
 #: py/argcheck.c
@@ -160,17 +176,17 @@ msgstr ""
 msgid "%q out of bounds"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/cxd56/common-hal/pulseio/PulseIn.c
+#: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/raspberrypi/common-hal/pulseio/PulseIn.c
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#: shared-bindings/canio/Match.c
+#: ports/stm/common-hal/pulseio/PulseIn.c shared-bindings/canio/Match.c
 msgid "%q out of range"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/microcontroller/Pin.c
 msgid "%q pin invalid"
-msgstr ""
-
-#: shared-bindings/fontio/BuiltinFont.c
-msgid "%q should be an int"
 msgstr ""
 
 #: shared-bindings/usb_hid/Device.c
@@ -335,10 +351,6 @@ msgstr ""
 msgid "'yield' outside function"
 msgstr ""
 
-#: shared-module/vectorio/VectorShape.c
-msgid "(x,y) integers required"
-msgstr ""
-
 #: py/compile.c
 msgid "*x must be assignment target"
 msgstr ""
@@ -372,10 +384,6 @@ msgstr ""
 #: shared-bindings/_bleio/Address.c shared-bindings/ipaddress/IPv4Address.c
 #, c-format
 msgid "Address must be %d bytes long"
-msgstr ""
-
-#: shared-bindings/_bleio/Address.c
-msgid "Address type out of range"
 msgstr ""
 
 #: ports/espressif/common-hal/canio/CAN.c
@@ -468,25 +476,6 @@ msgstr ""
 msgid "Already scanning for wifi networks"
 msgstr ""
 
-#: ports/cxd56/common-hal/analogio/AnalogIn.c
-msgid "AnalogIn not supported on given pin"
-msgstr ""
-
-#: ports/cxd56/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-msgid "AnalogOut functionality not supported"
-msgstr ""
-
-#: shared-bindings/analogio/AnalogOut.c
-msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-msgstr ""
-
-#: ports/atmel-samd/common-hal/analogio/AnalogOut.c
-msgid "AnalogOut not supported on given pin"
-msgstr ""
-
 #: ports/stm/common-hal/audiopwmio/PWMAudioOut.c
 msgid "Another PWMAudioOut is already active"
 msgstr ""
@@ -556,11 +545,6 @@ msgstr ""
 msgid "Bit clock and word select must share a clock unit"
 msgstr ""
 
-#: shared-bindings/rgbmatrix/RGBMatrix.c
-#, c-format
-msgid "Bit depth must be from 1 to 6 inclusive, not %d"
-msgstr ""
-
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Bit depth must be multiple of 8."
 msgstr ""
@@ -602,11 +586,6 @@ msgstr ""
 msgid "Buffer elements must be 4 bytes long or less"
 msgstr ""
 
-#: shared-module/usb_hid/Device.c
-#, c-format
-msgid "Buffer incorrect size. Should be %d bytes."
-msgstr ""
-
 #: shared-bindings/framebufferio/FramebufferDisplay.c
 msgid "Buffer is not a bytearray."
 msgstr ""
@@ -616,7 +595,6 @@ msgstr ""
 msgid "Buffer is too small"
 msgstr ""
 
-#: ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
 #: ports/stm/common-hal/audiopwmio/PWMAudioOut.c
 #, c-format
 msgid "Buffer length %d too big. It must be less than %d"
@@ -629,10 +607,6 @@ msgstr ""
 
 #: ports/stm/common-hal/sdioio/SDCard.c shared-bindings/floppyio/__init__.c
 msgid "Buffer must be a multiple of 512 bytes"
-msgstr ""
-
-#: shared-bindings/bitbangio/I2C.c
-msgid "Buffer must be at least length 1"
 msgstr ""
 
 #: shared-bindings/_bleio/PacketBuffer.c
@@ -654,10 +628,6 @@ msgstr ""
 
 #: shared-bindings/_bleio/UUID.c
 msgid "Byte buffer must be 16 bytes."
-msgstr ""
-
-#: shared-bindings/alarm/SleepMemory.c shared-bindings/nvm/ByteArray.c
-msgid "Bytes must be between 0 and 255."
 msgstr ""
 
 #: shared-bindings/aesio/aes.c
@@ -732,7 +702,7 @@ msgid "Cannot pull on input-only pin."
 msgstr ""
 
 #: shared-module/bitbangio/SPI.c
-msgid "Cannot read without MISO pin."
+msgid "Cannot read without MISO pin"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -746,7 +716,7 @@ msgstr ""
 #: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/cxd56/common-hal/microcontroller/__init__.c
 #: ports/mimxrt10xx/common-hal/microcontroller/__init__.c
-msgid "Cannot reset into bootloader because no bootloader is present."
+msgid "Cannot reset into bootloader because no bootloader is present"
 msgstr ""
 
 #: ports/espressif/common-hal/socketpool/Socket.c
@@ -767,20 +737,23 @@ msgid "Cannot subclass slice"
 msgstr ""
 
 #: shared-module/bitbangio/SPI.c
-msgid "Cannot transfer without MOSI and MISO pins."
+msgid "Cannot transfer without MOSI and MISO pins"
 msgstr ""
 
 #: shared-bindings/pwmio/PWMOut.c
 msgid "Cannot vary frequency on a timer that is already in use"
 msgstr ""
 
-#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
 #: ports/nrf/common-hal/alarm/pin/PinAlarm.c
+msgid "Cannot wake on pin edge, only level"
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
 msgid "Cannot wake on pin edge. Only level."
 msgstr ""
 
 #: shared-module/bitbangio/SPI.c
-msgid "Cannot write without MOSI pin."
+msgid "Cannot write without MOSI pin"
 msgstr ""
 
 #: shared-bindings/_bleio/CharacteristicBuffer.c
@@ -795,21 +768,12 @@ msgstr ""
 msgid "CircuitPython was unable to allocate the heap."
 msgstr ""
 
-#: shared-module/bitbangio/SPI.c
-msgid "Clock pin init failed."
-msgstr ""
-
 #: shared-module/bitbangio/I2C.c
 msgid "Clock stretch too long"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Clock unit in use"
-msgstr ""
-
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/I2CDisplay.c
-#: shared-bindings/paralleldisplay/ParallelBus.c
-msgid "Command must be an int between 0 and 255"
 msgstr ""
 
 #: shared-bindings/_bleio/Connection.c
@@ -822,16 +786,9 @@ msgstr ""
 msgid "Corrupt .mpy file"
 msgstr ""
 
-#: ports/cxd56/common-hal/camera/Camera.c
-msgid "Could not initialize Camera"
-msgstr ""
-
-#: ports/cxd56/common-hal/gnss/GNSS.c
-msgid "Could not initialize GNSS"
-msgstr ""
-
+#: ports/cxd56/common-hal/camera/Camera.c ports/cxd56/common-hal/gnss/GNSS.c
 #: ports/cxd56/common-hal/sdioio/SDCard.c
-msgid "Could not initialize SDCard"
+msgid "Could not initialize %q"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
@@ -869,20 +826,6 @@ msgstr ""
 
 #: shared-module/audiomp3/MP3Decoder.c
 msgid "Couldn't allocate decoder"
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c shared-module/audiomixer/Mixer.c
-#: shared-module/audiomp3/MP3Decoder.c
-msgid "Couldn't allocate first buffer"
-msgstr ""
-
-#: shared-module/audiomp3/MP3Decoder.c
-msgid "Couldn't allocate input buffer"
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c shared-module/audiomixer/Mixer.c
-#: shared-module/audiomp3/MP3Decoder.c
-msgid "Couldn't allocate second buffer"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -930,10 +873,6 @@ msgstr ""
 
 #: ports/nrf/common-hal/audiobusio/I2SOut.c
 msgid "Device in use"
-msgstr ""
-
-#: ports/cxd56/common-hal/digitalio/DigitalInOut.c
-msgid "DigitalInOut not supported on given pin"
 msgstr ""
 
 #: shared-bindings/displayio/Display.c
@@ -991,11 +930,6 @@ msgstr ""
 msgid "Expected an alarm"
 msgstr ""
 
-#: shared-module/adafruit_pixelbuf/PixelBuf.c
-#, c-format
-msgid "Expected tuple of length %d, got %d"
-msgstr ""
-
 #: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "Extended advertisements with scan response not supported."
@@ -1020,22 +954,6 @@ msgstr ""
 #: ports/nrf/sd_mutex.c
 #, c-format
 msgid "Failed to acquire mutex, err 0x%04x"
-msgstr ""
-
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
-#: ports/raspberrypi/common-hal/busio/UART.c
-msgid "Failed to allocate RX buffer"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/cxd56/common-hal/pulseio/PulseIn.c
-#: ports/espressif/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c
-#: ports/raspberrypi/common-hal/pulseio/PulseIn.c
-#: ports/stm/common-hal/pulseio/PulseIn.c
-#, c-format
-msgid "Failed to allocate RX buffer of %d bytes"
 msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
@@ -1106,11 +1024,6 @@ msgstr ""
 msgid "Format not supported"
 msgstr ""
 
-#: shared-module/framebufferio/FramebufferDisplay.c
-#, c-format
-msgid "Framebuffer requires %d bytes"
-msgstr ""
-
 #: ports/mimxrt10xx/common-hal/microcontroller/Processor.c
 msgid ""
 "Frequency must be 24, 150, 396, 450, 528, 600, 720, 816, 912, 960 or 1008 Mhz"
@@ -1152,16 +1065,12 @@ msgstr ""
 msgid "Hardware in use, try alternative pins"
 msgstr ""
 
-#: shared-bindings/wifi/Radio.c
-msgid "Hostname must be between 1 and 253 characters"
-msgstr ""
-
 #: extmod/vfs_posix_file.c py/objstringio.c
 msgid "I/O operation on closed file"
 msgstr ""
 
 #: ports/stm/common-hal/busio/I2C.c
-msgid "I2C Init Error"
+msgid "I2C init error"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/busio/I2C.c
@@ -1269,29 +1178,21 @@ msgstr ""
 msgid "Internal error #%d"
 msgstr ""
 
-#: shared-bindings/sdioio/SDCard.c shared-module/usb_hid/Device.c
+#: py/argcheck.c
 msgid "Invalid %q"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
-#: ports/mimxrt10xx/common-hal/busio/UART.c
+#: ports/mimxrt10xx/common-hal/busio/UART.c ports/stm/common-hal/busio/I2C.c
+#: ports/stm/common-hal/busio/SPI.c ports/stm/common-hal/busio/UART.c
+#: ports/stm/common-hal/canio/CAN.c ports/stm/common-hal/sdioio/SDCard.c
 msgid "Invalid %q pin"
-msgstr ""
-
-#: ports/stm/common-hal/busio/I2C.c ports/stm/common-hal/busio/SPI.c
-#: ports/stm/common-hal/busio/UART.c ports/stm/common-hal/canio/CAN.c
-#: ports/stm/common-hal/sdioio/SDCard.c
-msgid "Invalid %q pin selection"
 msgstr ""
 
 #: ports/stm/common-hal/analogio/AnalogIn.c
 msgid "Invalid ADC Unit value"
-msgstr ""
-
-#: ports/espressif/common-hal/wifi/Radio.c
-msgid "Invalid AuthMode"
 msgstr ""
 
 #: ports/espressif/common-hal/_bleio/__init__.c
@@ -1299,45 +1200,17 @@ msgstr ""
 msgid "Invalid BLE parameter"
 msgstr ""
 
-#: shared-module/displayio/OnDiskBitmap.c
-msgid "Invalid BMP file"
-msgstr ""
-
 #: shared-bindings/wifi/Radio.c
 msgid "Invalid BSSID"
-msgstr ""
-
-#: ports/espressif/common-hal/analogio/AnalogOut.c
-#: ports/stm/common-hal/analogio/AnalogOut.c
-msgid "Invalid DAC pin supplied"
 msgstr ""
 
 #: shared-bindings/wifi/Radio.c
 msgid "Invalid MAC address"
 msgstr ""
 
-#: shared-bindings/synthio/__init__.c
-msgid "Invalid MIDI file"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/pwmio/PWMOut.c
-#: ports/cxd56/common-hal/pwmio/PWMOut.c
-#: ports/espressif/common-hal/pwmio/PWMOut.c
-#: ports/mimxrt10xx/common-hal/pwmio/PWMOut.c
-#: ports/nrf/common-hal/pwmio/PWMOut.c
-#: ports/raspberrypi/common-hal/pwmio/PWMOut.c shared-bindings/pwmio/PWMOut.c
-msgid "Invalid PWM frequency"
-msgstr ""
-
-#: ports/espressif/common-hal/analogio/AnalogIn.c
-msgid "Invalid Pin"
-msgstr ""
-
 #: ports/espressif/bindings/espidf/__init__.c
-#: ports/espressif/common-hal/busio/I2C.c
-#: ports/espressif/common-hal/i2cperipheral/I2CPeripheral.c
-#: ports/espressif/esp_error.c py/moduerrno.c
-#: shared-module/rgbmatrix/RGBMatrix.c
+#: ports/espressif/common-hal/busio/I2C.c ports/espressif/esp_error.c
+#: py/moduerrno.c
 msgid "Invalid argument"
 msgstr ""
 
@@ -1345,40 +1218,9 @@ msgstr ""
 msgid "Invalid bits per value"
 msgstr ""
 
-#: ports/nrf/common-hal/busio/UART.c ports/raspberrypi/common-hal/busio/UART.c
-#: ports/stm/common-hal/busio/UART.c
-msgid "Invalid buffer size"
-msgstr ""
-
-#: shared-bindings/adafruit_pixelbuf/PixelBuf.c
-msgid "Invalid byteorder string"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
-#: ports/espressif/common-hal/frequencyio/FrequencyIn.c
-msgid "Invalid capture period. Valid range: 1 - 500"
-msgstr ""
-
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Invalid channel count"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
-#, c-format
-msgid "Invalid data_count %d"
-msgstr ""
-
 #: ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
 #, c-format
 msgid "Invalid data_pins[%d]"
-msgstr ""
-
-#: shared-bindings/digitalio/DigitalInOut.c
-msgid "Invalid direction."
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c
-msgid "Invalid file"
 msgstr ""
 
 #: shared-module/audiocore/WaveFile.c
@@ -1389,30 +1231,8 @@ msgstr ""
 msgid "Invalid memory access."
 msgstr ""
 
-#: extmod/vfs_fat_file.c
-msgid "Invalid mode"
-msgstr ""
-
 #: ports/espressif/common-hal/wifi/Radio.c
 msgid "Invalid multicast MAC address"
-msgstr ""
-
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
-msgid "Invalid number of bits"
-msgstr ""
-
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
-#: shared-bindings/displayio/FourWire.c
-msgid "Invalid phase"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
-#: ports/espressif/common-hal/alarm/touch/TouchAlarm.c
-#: ports/espressif/common-hal/touchio/TouchIn.c
-#: ports/nrf/common-hal/alarm/pin/PinAlarm.c shared-bindings/pwmio/PWMOut.c
-#: shared-module/rgbmatrix/RGBMatrix.c
-msgid "Invalid pin"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -1423,42 +1243,8 @@ msgstr ""
 msgid "Invalid pin for right channel"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
-#: ports/atmel-samd/common-hal/busio/SPI.c
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/atmel-samd/common-hal/i2cperipheral/I2CPeripheral.c
-#: ports/cxd56/common-hal/busio/I2C.c ports/cxd56/common-hal/busio/SPI.c
-#: ports/cxd56/common-hal/busio/UART.c ports/cxd56/common-hal/sdioio/SDCard.c
-#: ports/espressif/common-hal/busio/I2C.c
-#: ports/espressif/common-hal/busio/SPI.c
-#: ports/espressif/common-hal/busio/UART.c
-#: ports/espressif/common-hal/canio/CAN.c
-#: ports/espressif/common-hal/i2cperipheral/I2CPeripheral.c
-#: ports/mimxrt10xx/common-hal/busio/I2C.c
-#: ports/mimxrt10xx/common-hal/busio/SPI.c
-#: ports/mimxrt10xx/common-hal/usb_host/Port.c ports/nrf/common-hal/busio/I2C.c
-#: ports/raspberrypi/common-hal/busio/I2C.c
-#: ports/raspberrypi/common-hal/busio/SPI.c
-#: ports/raspberrypi/common-hal/busio/UART.c shared-bindings/busio/SPI.c
-#: shared-bindings/busio/UART.c
+#: ports/espressif/common-hal/busio/UART.c shared-bindings/busio/UART.c
 msgid "Invalid pins"
-msgstr ""
-
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
-#: shared-bindings/displayio/FourWire.c
-msgid "Invalid polarity"
-msgstr ""
-
-#: shared-bindings/_bleio/Characteristic.c
-msgid "Invalid properties"
-msgstr ""
-
-#: shared-bindings/microcontroller/__init__.c
-msgid "Invalid run mode."
-msgstr ""
-
-#: shared-module/_bleio/Attribute.c
-msgid "Invalid security_mode"
 msgstr ""
 
 #: ports/espressif/bindings/espidf/__init__.c ports/espressif/esp_error.c
@@ -1471,23 +1257,6 @@ msgstr ""
 
 #: ports/espressif/bindings/espidf/__init__.c ports/espressif/esp_error.c
 msgid "Invalid state"
-msgstr ""
-
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Invalid voice"
-msgstr ""
-
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Invalid voice count"
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c
-msgid "Invalid wave file"
-msgstr ""
-
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
-#: ports/raspberrypi/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
-msgid "Invalid word/bit length"
 msgstr ""
 
 #: shared-bindings/aesio/aes.c
@@ -1503,23 +1272,15 @@ msgid "LHS of keyword arg must be an id"
 msgstr ""
 
 #: shared-module/displayio/Group.c
-msgid "Layer already in a group."
+msgid "Layer already in a group"
 msgstr ""
 
 #: shared-module/displayio/Group.c
-msgid "Layer must be a Group or TileGrid subclass."
+msgid "Layer must be a Group or TileGrid subclass"
 msgstr ""
 
 #: ports/espressif/bindings/espidf/__init__.c ports/espressif/esp_error.c
 msgid "MAC address was invalid"
-msgstr ""
-
-#: shared-module/bitbangio/SPI.c
-msgid "MISO pin init failed."
-msgstr ""
-
-#: shared-module/bitbangio/SPI.c
-msgid "MOSI pin init failed."
 msgstr ""
 
 #: shared-bindings/is31fl3741/IS31FL3741.c
@@ -1529,10 +1290,6 @@ msgstr ""
 #: shared-module/displayio/Shape.c
 #, c-format
 msgid "Maximum x value when mirrored is %d"
-msgstr ""
-
-#: shared-bindings/canio/Message.c
-msgid "Messages limited to 8 bytes"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -1548,8 +1305,12 @@ msgstr ""
 msgid "Mismatched swap flag"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
+#: ports/mimxrt10xx/common-hal/busio/SPI.c
 msgid "Missing MISO or MOSI Pin"
+msgstr ""
+
+#: ports/stm/common-hal/busio/SPI.c
+msgid "Missing MISO or MOSI pin"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -1585,11 +1346,6 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #, c-format
 msgid "Missing jmp_pin. Instruction %d jumps on pin"
-msgstr ""
-
-#: shared-module/usb_hid/Device.c
-#, c-format
-msgid "More than %d report ids not supported"
 msgstr ""
 
 #: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
@@ -1652,13 +1408,21 @@ msgid "No I2C device at address: 0x%x"
 msgstr ""
 
 #: ports/espressif/common-hal/busio/SPI.c
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
+#: ports/mimxrt10xx/common-hal/busio/SPI.c
 msgid "No MISO Pin"
 msgstr ""
 
+#: ports/stm/common-hal/busio/SPI.c
+msgid "No MISO pin"
+msgstr ""
+
 #: ports/espressif/common-hal/busio/SPI.c
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
+#: ports/mimxrt10xx/common-hal/busio/SPI.c
 msgid "No MOSI Pin"
+msgstr ""
+
+#: ports/stm/common-hal/busio/SPI.c
+msgid "No MOSI pin"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/UART.c
@@ -1697,16 +1461,6 @@ msgstr ""
 
 #: shared-bindings/os/__init__.c
 msgid "No hardware random available"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/ps2io/Ps2.c
-msgid "No hardware support on clk pin"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-msgid "No hardware support on pin"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -1853,10 +1607,13 @@ msgid "Only one address is allowed"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/alarm/time/TimeAlarm.c
-#: ports/espressif/common-hal/alarm/time/TimeAlarm.c
 #: ports/nrf/common-hal/alarm/time/TimeAlarm.c
-#: ports/raspberrypi/common-hal/alarm/time/TimeAlarm.c
 #: ports/stm/common-hal/alarm/time/TimeAlarm.c
+msgid "Only one alarm.time alarm can be set"
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/time/TimeAlarm.c
+#: ports/raspberrypi/common-hal/alarm/time/TimeAlarm.c
 msgid "Only one alarm.time alarm can be set."
 msgstr ""
 
@@ -1888,22 +1645,12 @@ msgstr ""
 msgid "Out-buffer elements must be <= 4 bytes long"
 msgstr ""
 
-#: shared-bindings/bitops/__init__.c
-#, c-format
-msgid "Output buffer must be at least %d bytes"
-msgstr ""
-
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Oversample must be multiple of 8."
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "PDMIn not available"
-msgstr ""
-
-#: shared-bindings/pwmio/PWMOut.c
-msgid ""
-"PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
 msgstr ""
 
 #: shared-bindings/pwmio/PWMOut.c
@@ -1927,27 +1674,16 @@ msgstr ""
 msgid "Permission denied"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
 #: ports/stm/common-hal/alarm/pin/PinAlarm.c
 msgid "Pin cannot wake from Deep Sleep"
 msgstr ""
 
-#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
-msgid "Pin count must be at least 1"
+#: ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
+msgid "Pin cannot wake from deep sleep"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "Pin count too large"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
-#: ports/cxd56/common-hal/analogio/AnalogIn.c
-#: ports/espressif/common-hal/analogio/AnalogIn.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogIn.c
-#: ports/nrf/common-hal/analogio/AnalogIn.c
-#: ports/raspberrypi/common-hal/analogio/AnalogIn.c
-#: ports/stm/common-hal/analogio/AnalogIn.c
-msgid "Pin does not have ADC capabilities"
 msgstr ""
 
 #: ports/stm/common-hal/alarm/pin/PinAlarm.c
@@ -2017,15 +1753,7 @@ msgid "Program does OUT without loading OSR"
 msgstr ""
 
 #: ports/raspberrypi/bindings/rp2pio/StateMachine.c
-msgid "Program must contain at least one 16-bit instruction."
-msgstr ""
-
-#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
 msgid "Program size invalid"
-msgstr ""
-
-#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
-msgid "Program too large"
 msgstr ""
 
 #: shared-bindings/digitalio/DigitalInOut.c
@@ -2050,18 +1778,12 @@ msgid "RNG Init Error"
 msgstr ""
 
 #: ports/nrf/common-hal/busio/UART.c
-msgid "RS485 Not yet supported on this device"
+msgid "RS485"
 msgstr ""
 
 #: ports/espressif/common-hal/busio/UART.c
 #: ports/mimxrt10xx/common-hal/busio/UART.c
 msgid "RS485 inversion specified when not in RS485 mode"
-msgstr ""
-
-#: ports/cxd56/common-hal/rtc/RTC.c ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c
-msgid "RTC calibration is not supported on this board"
 msgstr ""
 
 #: shared-bindings/alarm/time/TimeAlarm.c shared-bindings/time/__init__.c
@@ -2132,29 +1854,20 @@ msgstr ""
 msgid "SDIO Init Error %d"
 msgstr ""
 
-#: ports/stm/common-hal/busio/SPI.c
-msgid "SPI Init Error"
-msgstr ""
-
-#: ports/stm/common-hal/busio/SPI.c
-msgid "SPI Re-initialization error"
-msgstr ""
-
 #: ports/espressif/common-hal/busio/SPI.c
 msgid "SPI configuration failed"
+msgstr ""
+
+#: ports/stm/common-hal/busio/SPI.c
+msgid "SPI init error"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/busio/SPI.c
 msgid "SPI peripheral in use"
 msgstr ""
 
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Sample rate must be positive"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#, c-format
-msgid "Sample rate too high. It must be less than %d"
+#: ports/stm/common-hal/busio/SPI.c
+msgid "SPI re-initialization error"
 msgstr ""
 
 #: shared-bindings/is31fl3741/FrameBuffer.c
@@ -2173,14 +1886,6 @@ msgstr ""
 
 #: shared-bindings/ssl/SSLContext.c
 msgid "Server side context cannot have hostname"
-msgstr ""
-
-#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
-msgid "Set pin count must be between 1 and 5"
-msgstr ""
-
-#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
-msgid "Side set pin count must be between 1 and 5"
 msgstr ""
 
 #: ports/cxd56/common-hal/camera/Camera.c
@@ -2216,10 +1921,6 @@ msgstr ""
 
 #: extmod/modure.c
 msgid "Splitting with sub-captures"
-msgstr ""
-
-#: shared-bindings/supervisor/__init__.c
-msgid "Stack size must be at least 256"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -2308,10 +2009,6 @@ msgid "Tile index out of bounds"
 msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
-msgid "Tile value out of bounds"
-msgstr ""
-
-#: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr ""
 
@@ -2330,6 +2027,9 @@ msgid "To exit, please reset the board without "
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
+msgid "Too many channels in sample"
+msgstr ""
+
 #: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
 msgstr ""
@@ -2362,19 +2062,15 @@ msgid "Tuple or struct_time argument required"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART Buffer allocation error"
+msgid "UART de-init error"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART De-init error"
+msgid "UART init error"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART Init Error"
-msgstr ""
-
-#: ports/stm/common-hal/busio/UART.c
-msgid "UART Re-init error"
+msgid "UART re-init error"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
@@ -2515,9 +2211,7 @@ msgid ""
 "declined or ignored."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/I2C.c ports/cxd56/common-hal/busio/I2C.c
-#: ports/espressif/common-hal/busio/UART.c
-#: ports/raspberrypi/common-hal/busio/I2C.c ports/stm/common-hal/busio/I2C.c
+#: ports/cxd56/common-hal/busio/I2C.c ports/espressif/common-hal/busio/UART.c
 msgid "Unsupported baudrate"
 msgstr ""
 
@@ -2531,6 +2225,10 @@ msgstr ""
 
 #: shared-module/audiocore/WaveFile.c
 msgid "Unsupported format"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/busio/I2C.c ports/stm/common-hal/busio/I2C.c
+msgid "Unsupported frequency"
 msgstr ""
 
 #: ports/espressif/common-hal/dualbank/__init__.c
@@ -2593,10 +2291,6 @@ msgid ""
 "Visit circuitpython.org for more information.\n"
 "\n"
 "To list built-in modules type `help(\"modules\")`.\n"
-msgstr ""
-
-#: shared-bindings/wifi/Radio.c
-msgid "WiFi password must be between 8 and 63 characters"
 msgstr ""
 
 #: main.c
@@ -2751,10 +2445,6 @@ msgstr ""
 msgid "bits must be 32 or less"
 msgstr ""
 
-#: shared-bindings/busio/UART.c
-msgid "bits must be in range 5 to 9"
-msgstr ""
-
 #: shared-bindings/audiomixer/Mixer.c
 msgid "bits_per_sample must be 8 or 16"
 msgstr ""
@@ -2792,11 +2482,6 @@ msgstr ""
 msgid "byteorder is not a string"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/espressif/common-hal/busio/UART.c
-msgid "bytes > 8 bits not supported"
-msgstr ""
-
 #: py/objarray.c
 msgid "bytes length not a multiple of item size"
 msgstr ""
@@ -2805,7 +2490,7 @@ msgstr ""
 msgid "bytes value out of range"
 msgstr ""
 
-#: ports/atmel-samd/bindings/samd/Clock.c ports/atmel-samd/common-hal/rtc/RTC.c
+#: ports/atmel-samd/bindings/samd/Clock.c
 msgid "calibration is out of range"
 msgstr ""
 
@@ -2813,12 +2498,9 @@ msgstr ""
 msgid "calibration is read only"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/rtc/RTC.c
-msgid "calibration value out of range +/-127"
-msgstr ""
-
+#: shared-module/vectorio/Circle.c shared-module/vectorio/Polygon.c
 #: shared-module/vectorio/Rectangle.c
-msgid "can only be registered in one parent"
+msgid "can only have one parent"
 msgstr ""
 
 #: py/emitinlinethumb.c
@@ -2999,10 +2681,6 @@ msgstr ""
 
 #: py/modbuiltins.c
 msgid "chr() arg not in range(256)"
-msgstr ""
-
-#: shared-module/vectorio/Circle.c
-msgid "circle can only be registered in one parent"
 msgstr ""
 
 #: shared-bindings/bitmaptools/__init__.c
@@ -3679,19 +3357,11 @@ msgstr ""
 msgid "matrix is not positive definite"
 msgstr ""
 
-#: ports/espressif/common-hal/wifi/Radio.c
-msgid "max_connections must be between 0 and 10"
-msgstr ""
-
 #: ports/espressif/common-hal/_bleio/Descriptor.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Descriptor.c
 #, c-format
 msgid "max_length must be 0-%d when fixed_length is %s"
-msgstr ""
-
-#: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
-msgid "max_length must be >= 0"
 msgstr ""
 
 #: extmod/ulab/code/ndarray.c
@@ -4064,10 +3734,6 @@ msgstr ""
 msgid "poll on file not available on win32"
 msgstr ""
 
-#: shared-module/vectorio/Polygon.c
-msgid "polygon can only be registered in one parent"
-msgstr ""
-
 #: ports/espressif/common-hal/pulseio/PulseIn.c
 msgid "pop from an empty PulseIn"
 msgstr ""
@@ -4112,14 +3778,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "pull masks conflict with direction masks"
-msgstr ""
-
-#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
-msgid "pull_threshold must be between 1 and 32"
-msgstr ""
-
-#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
-msgid "push_threshold must be between 1 and 32"
 msgstr ""
 
 #: extmod/modutimeq.c
@@ -4292,10 +3950,6 @@ msgstr ""
 msgid "step must be non-zero"
 msgstr ""
 
-#: shared-bindings/busio/UART.c
-msgid "stop must be 1 or 2"
-msgstr ""
-
 #: shared-bindings/random/__init__.c
 msgid "stop not reachable from start"
 msgstr ""
@@ -4344,10 +3998,6 @@ msgstr ""
 msgid "threshold must be in the range 0-65536"
 msgstr ""
 
-#: shared-bindings/rgbmatrix/RGBMatrix.c
-msgid "tile must be greater than zero"
-msgstr ""
-
 #: shared-bindings/time/__init__.c
 msgid "time.struct_time() takes a 9-sequence"
 msgstr ""
@@ -4365,10 +4015,6 @@ msgstr ""
 
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "timeout must be < 655.35 secs"
-msgstr ""
-
-#: shared-bindings/_bleio/CharacteristicBuffer.c
-msgid "timeout must be >= 0.0"
 msgstr ""
 
 #: shared-module/sdcardio/SDCard.c
@@ -4570,13 +4216,7 @@ msgstr ""
 msgid "watchdog timeout must be greater than 0"
 msgstr ""
 
-#: shared-bindings/bitops/__init__.c
-#, c-format
-msgid "width must be from 2 to 8 (inclusive), not %d"
-msgstr ""
-
 #: shared-bindings/is31fl3741/FrameBuffer.c
-#: shared-bindings/rgbmatrix/RGBMatrix.c
 msgid "width must be greater than zero"
 msgstr ""
 

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -80,6 +80,10 @@ msgstr ""
 msgid "%q and %q contain duplicate pins"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
+msgid "%q and %q must be different"
+msgstr ""
+
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q contains duplicate pins"
 msgstr ""
@@ -179,9 +183,9 @@ msgstr ""
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #: ports/cxd56/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
-#: ports/raspberrypi/common-hal/pulseio/PulseIn.c
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
-#: ports/stm/common-hal/pulseio/PulseIn.c shared-bindings/canio/Match.c
+#: ports/stm/common-hal/pulseio/PulseIn.c py/argcheck.c
+#: shared-bindings/canio/Match.c
 msgid "%q out of range"
 msgstr ""
 
@@ -646,6 +650,10 @@ msgstr ""
 msgid "Call super().__init__() before accessing native object."
 msgstr ""
 
+#: ports/cxd56/common-hal/camera/Camera.c
+msgid "Camera init"
+msgstr ""
+
 #: ports/espressif/common-hal/alarm/pin/PinAlarm.c
 msgid "Can only alarm on RTC IO from deep sleep."
 msgstr ""
@@ -693,16 +701,8 @@ msgstr ""
 msgid "Cannot have scan responses for extended, connectable advertisements."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-msgid "Cannot output both channels on the same pin"
-msgstr ""
-
 #: ports/espressif/common-hal/alarm/pin/PinAlarm.c
 msgid "Cannot pull on input-only pin."
-msgstr ""
-
-#: shared-module/bitbangio/SPI.c
-msgid "Cannot read without MISO pin"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -752,10 +752,6 @@ msgstr ""
 msgid "Cannot wake on pin edge. Only level."
 msgstr ""
 
-#: shared-module/bitbangio/SPI.c
-msgid "Cannot write without MOSI pin"
-msgstr ""
-
 #: shared-bindings/_bleio/CharacteristicBuffer.c
 msgid "CharacteristicBuffer writing not provided"
 msgstr ""
@@ -784,28 +780,6 @@ msgstr ""
 
 #: py/persistentcode.c
 msgid "Corrupt .mpy file"
-msgstr ""
-
-#: ports/cxd56/common-hal/camera/Camera.c ports/cxd56/common-hal/gnss/GNSS.c
-#: ports/cxd56/common-hal/sdioio/SDCard.c
-msgid "Could not initialize %q"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
-#: ports/espressif/common-hal/busio/UART.c
-msgid "Could not initialize UART"
-msgstr ""
-
-#: ports/stm/common-hal/pwmio/PWMOut.c
-msgid "Could not re-init channel"
-msgstr ""
-
-#: ports/stm/common-hal/pwmio/PWMOut.c
-msgid "Could not re-init timer"
-msgstr ""
-
-#: ports/stm/common-hal/pwmio/PWMOut.c
-msgid "Could not restart PWM"
 msgstr ""
 
 #: ports/espressif/common-hal/neopixel_write/__init__.c
@@ -1038,6 +1012,10 @@ msgstr ""
 msgid "Function requires lock"
 msgstr ""
 
+#: ports/cxd56/common-hal/gnss/GNSS.c
+msgid "GNSS init"
+msgstr ""
+
 #: ports/espressif/bindings/espidf/__init__.c ports/espressif/esp_error.c
 msgid "Generic Failure"
 msgstr ""
@@ -1182,12 +1160,7 @@ msgstr ""
 msgid "Invalid %q"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
-#: ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/stm/common-hal/busio/I2C.c
-#: ports/stm/common-hal/busio/SPI.c ports/stm/common-hal/busio/UART.c
-#: ports/stm/common-hal/canio/CAN.c ports/stm/common-hal/sdioio/SDCard.c
+#: shared-bindings/microcontroller/Pin.c
 msgid "Invalid %q pin"
 msgstr ""
 
@@ -1208,8 +1181,7 @@ msgstr ""
 msgid "Invalid MAC address"
 msgstr ""
 
-#: ports/espressif/bindings/espidf/__init__.c
-#: ports/espressif/common-hal/busio/I2C.c ports/espressif/esp_error.c
+#: ports/espressif/bindings/espidf/__init__.c ports/espressif/esp_error.c
 #: py/moduerrno.c
 msgid "Invalid argument"
 msgstr ""
@@ -1235,15 +1207,7 @@ msgstr ""
 msgid "Invalid multicast MAC address"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-msgid "Invalid pin for left channel"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-msgid "Invalid pin for right channel"
-msgstr ""
-
-#: ports/espressif/common-hal/busio/UART.c shared-bindings/busio/UART.c
+#: shared-bindings/busio/UART.c
 msgid "Invalid pins"
 msgstr ""
 
@@ -1412,7 +1376,7 @@ msgstr ""
 msgid "No MISO Pin"
 msgstr ""
 
-#: ports/stm/common-hal/busio/SPI.c
+#: ports/stm/common-hal/busio/SPI.c shared-module/bitbangio/SPI.c
 msgid "No MISO pin"
 msgstr ""
 
@@ -1421,7 +1385,7 @@ msgstr ""
 msgid "No MOSI Pin"
 msgstr ""
 
-#: ports/stm/common-hal/busio/SPI.c
+#: ports/stm/common-hal/busio/SPI.c shared-module/bitbangio/SPI.c
 msgid "No MOSI pin"
 msgstr ""
 
@@ -1658,6 +1622,10 @@ msgid ""
 "PWM frequency not writable when variable_frequency is False on construction."
 msgstr ""
 
+#: ports/stm/common-hal/pwmio/PWMOut.c
+msgid "PWM restart"
+msgstr ""
+
 #: ports/raspberrypi/common-hal/countio/Counter.c
 msgid "PWM slice already in use"
 msgstr ""
@@ -1676,10 +1644,6 @@ msgstr ""
 
 #: ports/stm/common-hal/alarm/pin/PinAlarm.c
 msgid "Pin cannot wake from Deep Sleep"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
-msgid "Pin cannot wake from deep sleep"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -1777,7 +1741,8 @@ msgstr ""
 msgid "RNG Init Error"
 msgstr ""
 
-#: ports/nrf/common-hal/busio/UART.c
+#: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
 msgid "RS485"
 msgstr ""
 
@@ -1788,11 +1753,6 @@ msgstr ""
 
 #: shared-bindings/alarm/time/TimeAlarm.c shared-bindings/time/__init__.c
 msgid "RTC is not supported on this board"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
-#: ports/stm/common-hal/busio/UART.c
-msgid "RTS/CTS/RS485 Not yet supported on this device"
 msgstr ""
 
 #: ports/stm/common-hal/os/__init__.c
@@ -1844,6 +1804,10 @@ msgstr ""
 msgid "SD card CSD format not supported"
 msgstr ""
 
+#: ports/cxd56/common-hal/sdioio/SDCard.c
+msgid "SDCard init"
+msgstr ""
+
 #: ports/stm/common-hal/sdioio/SDCard.c
 #, c-format
 msgid "SDIO GetCardInfo Error %d"
@@ -1867,7 +1831,7 @@ msgid "SPI peripheral in use"
 msgstr ""
 
 #: ports/stm/common-hal/busio/SPI.c
-msgid "SPI re-initialization error"
+msgid "SPI re-init"
 msgstr ""
 
 #: shared-bindings/is31fl3741/FrameBuffer.c
@@ -2062,19 +2026,20 @@ msgid "Tuple or struct_time argument required"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART de-init error"
+msgid "UART de-init"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
+#: ports/espressif/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
+msgid "UART init"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART init error"
+msgid "UART re-init"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART re-init error"
-msgstr ""
-
-#: ports/stm/common-hal/busio/UART.c
-msgid "UART write error"
+msgid "UART write"
 msgstr ""
 
 #: shared-module/usb_hid/Device.c
@@ -2211,10 +2176,6 @@ msgid ""
 "declined or ignored."
 msgstr ""
 
-#: ports/cxd56/common-hal/busio/I2C.c ports/espressif/common-hal/busio/UART.c
-msgid "Unsupported baudrate"
-msgstr ""
-
 #: shared-bindings/bitmaptools/__init__.c
 msgid "Unsupported colorspace"
 msgstr ""
@@ -2225,10 +2186,6 @@ msgstr ""
 
 #: shared-module/audiocore/WaveFile.c
 msgid "Unsupported format"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/I2C.c ports/stm/common-hal/busio/I2C.c
-msgid "Unsupported frequency"
 msgstr ""
 
 #: ports/espressif/common-hal/dualbank/__init__.c
@@ -2671,6 +2628,10 @@ msgstr ""
 msgid "casting"
 msgstr ""
 
+#: ports/stm/common-hal/pwmio/PWMOut.c
+msgid "channel re-init"
+msgstr ""
+
 #: shared-bindings/_stage/Text.c
 msgid "chars buffer too small"
 msgstr ""
@@ -3105,6 +3066,10 @@ msgstr ""
 
 #: extmod/ulab/code/ndarray.c
 msgid "indices must be integers, slices, or Boolean lists"
+msgstr ""
+
+#: ports/espressif/common-hal/busio/I2C.c
+msgid "init I2C"
 msgstr ""
 
 #: extmod/ulab/code/scipy/optimize/optimize.c
@@ -4023,6 +3988,10 @@ msgstr ""
 
 #: shared-module/sdcardio/SDCard.c
 msgid "timeout waiting for v2 card"
+msgstr ""
+
+#: ports/stm/common-hal/pwmio/PWMOut.c
+msgid "timer re-init"
 msgstr ""
 
 #: shared-bindings/time/__init__.c

--- a/ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
@@ -261,7 +261,7 @@ static void pinalarm_set_alarms_deep(size_t n_alarms, const mp_obj_t *alarms) {
             }
         }
         if (t->n < 0) {
-            mp_raise_ValueError(translate("Pin cannot wake from deep sleep"));
+            raise_ValueError_invalid_pin();
         }
 
         // It is strange, but to my experiment, interrupt during sleep

--- a/ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
@@ -234,7 +234,7 @@ static void pinalarm_set_alarms_light(size_t n_alarms, const mp_obj_t *alarms) {
             // raise ValueError here
             MP_FALLTHROUGH
         case PINALARM_ERR_NOEXTINT:
-            mp_raise_RuntimeError(translate("No hardware support on pin"));
+            raise_ValueError_invalid_pin();
         case PINALARM_ERR_NOCHANNEL:
             mp_raise_RuntimeError(translate("A hardware interrupt channel is already in use"));
         default:
@@ -261,7 +261,7 @@ static void pinalarm_set_alarms_deep(size_t n_alarms, const mp_obj_t *alarms) {
             }
         }
         if (t->n < 0) {
-            mp_raise_ValueError(translate("Pin cannot wake from Deep Sleep"));
+            mp_raise_ValueError(translate("Pin cannot wake from deep sleep"));
         }
 
         // It is strange, but to my experiment, interrupt during sleep

--- a/ports/atmel-samd/common-hal/alarm/time/TimeAlarm.c
+++ b/ports/atmel-samd/common-hal/alarm/time/TimeAlarm.c
@@ -100,7 +100,7 @@ void alarm_time_timealarm_set_alarms(bool deep_sleep, size_t n_alarms, const mp_
             continue;
         }
         if (timealarm_set) {
-            mp_raise_ValueError(translate("Only one alarm.time alarm can be set."));
+            mp_raise_ValueError(translate("Only one alarm.time alarm can be set"));
         }
         timealarm = MP_OBJ_TO_PTR(alarms[i]);
         timealarm_set = true;

--- a/ports/atmel-samd/common-hal/analogio/AnalogIn.c
+++ b/ports/atmel-samd/common-hal/analogio/AnalogIn.c
@@ -36,6 +36,7 @@
 
 #include "samd/adc.h"
 #include "shared-bindings/analogio/AnalogIn.h"
+#include "shared-bindings/microcontroller/Pin.h"
 #include "supervisor/shared/translate.h"
 
 #include "atmel_start_pins.h"
@@ -60,7 +61,7 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self,
     }
     if (adc_channel == 0xff) {
         // No ADC function on that pin
-        mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
+        raise_ValueError_invalid_pin();
     }
     claim_pin(pin);
 

--- a/ports/atmel-samd/common-hal/analogio/AnalogOut.c
+++ b/ports/atmel-samd/common-hal/analogio/AnalogOut.c
@@ -70,7 +70,7 @@ void common_hal_analogio_analogout_construct(analogio_analogout_obj_t *self,
         #endif
 
         default:
-            mp_raise_ValueError(translate("AnalogOut not supported on given pin"));
+            raise_ValueError_invalid_pin();
             return;
     }
 

--- a/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
+++ b/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -151,16 +151,16 @@ void common_hal_audiobusio_i2sout_construct(audiobusio_i2sout_obj_t *self,
     }
     #endif
     if (bc_clock_unit == 0xff) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_bit_clock);
+        raise_ValueError_invalid_pin_name(MP_QSTR_clock);
     }
     if (ws_clock_unit == 0xff) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_word_select);
+        raise_ValueError_invalid_pin_name(MP_QSTR_word_select);
     }
     if (bc_clock_unit != ws_clock_unit) {
         mp_raise_ValueError(translate("Bit clock and word select must share a clock unit"));
     }
     if (serializer == 0xff) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_data);
+        raise_ValueError_invalid_pin_name(MP_QSTR_data);
     }
     self->clock_unit = ws_clock_unit;
     self->serializer = serializer;

--- a/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
+++ b/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -255,7 +255,7 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t *self,
     }
     uint8_t channel_count = audiosample_channel_count(sample);
     if (channel_count > 2) {
-        mp_raise_ValueError(translate("Too many channels in sample."));
+        mp_raise_ValueError(translate("Too many channels in sample"));
     }
     #ifdef SAMD21
     uint32_t serctrl = (self->clock_unit << I2S_SERCTRL_CLKSEL_Pos) | SERCTRL(SERMODE_TX) | I2S_SERCTRL_TXSAME_SAME | I2S_SERCTRL_EXTEND_MSBIT | I2S_SERCTRL_TXDEFAULT_ONE | I2S_SERCTRL_SLOTADJ_LEFT;

--- a/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+++ b/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
@@ -121,7 +121,7 @@ void common_hal_audiobusio_pdmin_construct(audiobusio_pdmin_obj_t* self,
             self->clock_unit = 1;
     #endif
     } else {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_clock);
+        raise_ValueError_invalid_pin_name(MP_QSTR_clock);
     }
 
     self->data_pin = data_pin; // PA07, PA19 -> SD0, PA08, PB16 -> SD1
@@ -152,7 +152,7 @@ void common_hal_audiobusio_pdmin_construct(audiobusio_pdmin_obj_t* self,
         self->serializer = 1;
     #endif
     } else {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_data);
+        raise_ValueError_invalid_pin_name(MP_QSTR_data);
     }
 
     if (!(bit_depth == 16 || bit_depth == 8) || !mono || oversample != OVERSAMPLING) {

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -143,13 +143,14 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t *self,
     #ifdef SAM_D5X_E5X
     self->right_channel = NULL;
     if (left_channel != &pin_PA02 && left_channel != &pin_PA05) {
-        mp_raise_ValueError(translate("Invalid pin for left channel"));
+        raise_ValueError_invalid_pin_name(MP_QSTR_left_channel);
     }
     if (right_channel != NULL && right_channel != &pin_PA02 && right_channel != &pin_PA05) {
-        mp_raise_ValueError(translate("Invalid pin for right channel"));
+        raise_ValueError_invalid_pin_name(MP_QSTR_right_channel);
     }
     if (right_channel == left_channel) {
-        mp_raise_ValueError(translate("Cannot output both channels on the same pin"));
+        mp_raise_ValueError_varg(translate("%q and %q must be different"),
+            MP_QSTR_left_channel, MP_QSTR_right_channel);
     }
     claim_pin(left_channel);
     if (right_channel != NULL) {

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -136,7 +136,7 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t *self,
         mp_raise_ValueError(translate("Right channel unsupported"));
     }
     if (left_channel != &pin_PA02) {
-        mp_raise_ValueError(translate("Invalid pin"));
+        raise_ValueError_invalid_pin();
     }
     claim_pin(left_channel);
     #endif
@@ -376,14 +376,13 @@ void common_hal_audioio_audioout_play(audioio_audioout_obj_t *self,
     audio_dma_result result = AUDIO_DMA_OK;
     uint32_t sample_rate = audiosample_sample_rate(sample);
     #ifdef SAMD21
-    uint32_t max_sample_rate = 350000;
+    const uint32_t max_sample_rate = 350000;
     #endif
     #ifdef SAM_D5X_E5X
-    uint32_t max_sample_rate = 1000000;
+    const uint32_t max_sample_rate = 1000000;
     #endif
-    if (sample_rate > max_sample_rate) {
-        mp_raise_ValueError_varg(translate("Sample rate too high. It must be less than %d"), max_sample_rate);
-    }
+    mp_arg_validate_int_max(sample_rate, max_sample_rate, MP_QSTR_sample_rate);
+
     #ifdef SAMD21
     result = audio_dma_setup_playback(&self->left_dma, sample, loop, true, 0,
         false /* output unsigned */,

--- a/ports/atmel-samd/common-hal/busio/I2C.c
+++ b/ports/atmel-samd/common-hal/busio/I2C.c
@@ -34,6 +34,7 @@
 
 #include "samd/sercom.h"
 #include "shared-bindings/microcontroller/__init__.h"
+#include "shared-bindings/microcontroller/Pin.h"
 #include "supervisor/shared/translate.h"
 
 #include "common-hal/busio/__init__.h"
@@ -76,7 +77,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     self->sda_pin = NO_PIN;
     Sercom *sercom = samd_i2c_get_sercom(scl, sda, &sercom_index, &sda_pinmux, &scl_pinmux);
     if (sercom == NULL) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     #if CIRCUITPY_REQUIRE_I2C_PULLUPS
@@ -122,15 +123,12 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     // The maximum frequency divisor gives a clock rate of around 48MHz/2/255
     // but set_baudrate does not diagnose this problem. (This is not the
     // exact cutoff, but no frequency well under 100kHz is available)
-    if (frequency < 95000) {
-        mp_raise_ValueError(translate("Unsupported baudrate"));
-    }
-
-    if (i2c_m_sync_set_baudrate(&self->i2c_desc, 0, frequency / 1000) != ERR_NONE) {
+    if (frequency < 95000 &&
+        i2c_m_sync_set_baudrate(&self->i2c_desc, 0, frequency / 1000) != ERR_NONE) {
         reset_pin_number(sda->number);
         reset_pin_number(scl->number);
         common_hal_busio_i2c_deinit(self);
-        mp_raise_ValueError(translate("Unsupported baudrate"));
+        mp_raise_ValueError(translate("Unsupported frequency"));
     }
 
     self->sda_pin = sda->number;

--- a/ports/atmel-samd/common-hal/busio/I2C.c
+++ b/ports/atmel-samd/common-hal/busio/I2C.c
@@ -128,7 +128,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
         reset_pin_number(sda->number);
         reset_pin_number(scl->number);
         common_hal_busio_i2c_deinit(self);
-        mp_raise_ValueError(translate("Unsupported frequency"));
+        mp_arg_error_invalid(MP_QSTR_frequency);
     }
 
     self->sda_pin = sda->number;

--- a/ports/atmel-samd/common-hal/busio/SPI.c
+++ b/ports/atmel-samd/common-hal/busio/SPI.c
@@ -25,6 +25,7 @@
  */
 
 #include "shared-bindings/busio/SPI.h"
+#include "shared-bindings/microcontroller/Pin.h"
 #include "py/mperrno.h"
 #include "py/runtime.h"
 
@@ -33,7 +34,6 @@
 
 #include "supervisor/board.h"
 #include "common-hal/busio/__init__.h"
-#include "common-hal/microcontroller/Pin.h"
 
 #include "hal/include/hal_gpio.h"
 #include "hal/include/hal_spi_m_sync.h"
@@ -133,7 +133,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         }
     }
     if (sercom == NULL) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     // Set up SPI clocks on SERCOM.

--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -25,6 +25,7 @@
  */
 
 #include "shared-bindings/microcontroller/__init__.h"
+#include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/busio/UART.h"
 
 #include "mpconfigport.h"
@@ -79,9 +80,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         mp_raise_ValueError(translate("RTS/CTS/RS485 Not yet supported on this device"));
     }
 
-    if (bits > 8) {
-        mp_raise_NotImplementedError(translate("bytes > 8 bits not supported"));
-    }
+    mp_arg_validate_int_max(bits, 8, MP_QSTR_bits);
 
     bool have_tx = tx != NULL;
     bool have_rx = rx != NULL;
@@ -145,7 +144,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         }
     }
     if (sercom == NULL) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
     if (!have_tx) {
         tx_pad = 0;
@@ -175,7 +174,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             self->buffer = (uint8_t *)gc_alloc(self->buffer_length * sizeof(uint8_t), false, true);
             if (self->buffer == NULL) {
                 common_hal_busio_uart_deinit(self);
-                mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"), self->buffer_length * sizeof(uint8_t));
+                m_malloc_fail(self->buffer_length * sizeof(uint8_t));
             }
         }
     } else {

--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -77,7 +77,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     self->tx_pin = NO_PIN;
 
     if ((rts != NULL) || (cts != NULL) || (rs485_dir != NULL) || (rs485_invert)) {
-        mp_raise_ValueError(translate("RTS/CTS/RS485 Not yet supported on this device"));
+        mp_raise_NotImplementedError(translate("RS485"));
     }
 
     mp_arg_validate_int_max(bits, 8, MP_QSTR_bits);
@@ -183,7 +183,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     }
 
     if (usart_async_init(usart_desc_p, sercom, self->buffer, self->buffer_length, NULL) != ERR_NONE) {
-        mp_raise_ValueError(translate("Could not initialize UART"));
+        mp_raise_RuntimeError(translate("UART init"));
     }
 
     // usart_async_init() sets a number of defaults based on a prototypical SERCOM

--- a/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+++ b/ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -45,6 +45,7 @@
 #include "peripheral_clk_config.h"
 #include "hpl_gclk_config.h"
 
+#include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/time/__init__.h"
 #include "supervisor/shared/tick.h"
 #include "supervisor/shared/translate.h"
@@ -282,11 +283,11 @@ static void frequencyin_samd51_stop_dpll(void) {
 void common_hal_frequencyio_frequencyin_construct(frequencyio_frequencyin_obj_t* self, const mcu_pin_obj_t* pin, const uint16_t capture_period) {
 
     if (!pin->has_extint) {
-        mp_raise_RuntimeError(translate("No hardware support on pin"));
+        raise_ValueError_invalid_pin();
     }
-    if ((capture_period == 0) || (capture_period > 500)) {
-        mp_raise_ValueError(translate("Invalid capture period. Valid range: 1 - 500"));
-    }
+
+    mp_arg_validate_int_range(capture_period, 0, 500, MP_QSTR_capture_period);
+
     uint32_t mask = 1 << pin->extint_channel;
     if (eic_get_enable() == 1 &&
     #ifdef SAMD21
@@ -569,9 +570,7 @@ uint16_t common_hal_frequencyio_frequencyin_get_capture_period(frequencyio_frequ
 }
 
 void common_hal_frequencyio_frequencyin_set_capture_period(frequencyio_frequencyin_obj_t *self, uint16_t capture_period) {
-    if ((capture_period == 0) || (capture_period > 500)) {
-        mp_raise_ValueError(translate("Invalid capture period. Valid range: 1 - 500"));
-    }
+    mp_arg_validate_int_range(capture_period, 1, 500, MP_QSTR_capture_period);
 
     self->capture_period = capture_period;
 

--- a/ports/atmel-samd/common-hal/i2cperipheral/I2CPeripheral.c
+++ b/ports/atmel-samd/common-hal/i2cperipheral/I2CPeripheral.c
@@ -25,6 +25,7 @@
  */
 
 #include "shared-bindings/i2cperipheral/I2CPeripheral.h"
+#include "shared-bindings/microcontroller/Pin.h"
 #include "common-hal/busio/I2C.h"
 
 #include "shared/runtime/interrupt_char.h"
@@ -42,7 +43,7 @@ void common_hal_i2cperipheral_i2c_peripheral_construct(i2cperipheral_i2c_periphe
     uint32_t sda_pinmux, scl_pinmux;
     Sercom *sercom = samd_i2c_get_sercom(scl, sda, &sercom_index, &sda_pinmux, &scl_pinmux);
     if (sercom == NULL) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
     self->sercom = sercom;
 

--- a/ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
+++ b/ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
@@ -63,7 +63,7 @@ void common_hal_imagecapture_parallelimagecapture_construct(imagecapture_paralle
     }
     // The peripheral supports 8, 10, 12, or 14 data bits, but the code only supports 8 at present
     if (data_count != 8) {
-        mp_raise_ValueError_varg(translate("Invalid data_count %d"), data_count);
+        mp_arg_error_invalid(MP_QSTR_datacount);
     }
     if (vertical_sync && vertical_sync->number != PIN_PCC_DEN1) {
         mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_vsync);

--- a/ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
+++ b/ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
@@ -66,13 +66,13 @@ void common_hal_imagecapture_parallelimagecapture_construct(imagecapture_paralle
         mp_arg_error_invalid(MP_QSTR_datacount);
     }
     if (vertical_sync && vertical_sync->number != PIN_PCC_DEN1) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_vsync);
+        raise_ValueError_invalid_pin_name(MP_QSTR_vsync);
     }
     if (horizontal_reference && horizontal_reference->number != PIN_PCC_DEN2) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_href);
+        raise_ValueError_invalid_pin_name(MP_QSTR_href);
     }
     if (data_clock->number != PIN_PCC_CLK) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_data_clock);
+        raise_ValueError_invalid_pin_name(MP_QSTR_data_clock);
     }
     // technically, 0 was validated as free already but check again
     for (int i = 0; i < data_count; i++) {

--- a/ports/atmel-samd/common-hal/microcontroller/__init__.c
+++ b/ports/atmel-samd/common-hal/microcontroller/__init__.c
@@ -66,7 +66,7 @@ void common_hal_mcu_enable_interrupts(void) {
 void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
     if (runmode == RUNMODE_BOOTLOADER) {
         if (!bootloader_available()) {
-            mp_raise_ValueError(translate("Cannot reset into bootloader because no bootloader is present."));
+            mp_raise_ValueError(translate("Cannot reset into bootloader because no bootloader is present"));
         }
         // Pretend to be the first of the two reset presses needed to enter the
         // bootloader. That way one reset will end in the bootloader.

--- a/ports/atmel-samd/common-hal/ps2io/Ps2.h
+++ b/ports/atmel-samd/common-hal/ps2io/Ps2.h
@@ -35,7 +35,7 @@
 typedef struct {
     mp_obj_base_t base;
     uint8_t channel;
-    uint8_t clk_pin;
+    uint8_t clock_pin;
     uint8_t data_pin;
 
     uint8_t state;

--- a/ports/atmel-samd/common-hal/pulseio/PulseIn.c
+++ b/ports/atmel-samd/common-hal/pulseio/PulseIn.c
@@ -352,6 +352,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t *self, int16_
     }
     if (index < 0 || index >= self->len) {
         common_hal_mcu_enable_interrupts();
+        // Can't use mp_arg_validate_index_range() here due to the critical section.
         mp_raise_IndexError_varg(translate("%q out of range"), MP_QSTR_index);
     }
     uint16_t value = self->buffer[(self->start + index) % self->maxlen];

--- a/ports/atmel-samd/common-hal/pwmio/PWMOut.c
+++ b/ports/atmel-samd/common-hal/pwmio/PWMOut.c
@@ -377,7 +377,7 @@ void common_hal_pwmio_pwmout_set_frequency(pwmio_pwmout_obj_t *self,
     uint32_t frequency) {
     uint32_t system_clock = common_hal_mcu_processor_get_frequency();
     if (frequency == 0 || frequency > system_clock / 2) {
-        mp_raise_ValueError(translate("Invalid PWM frequency"));
+        mp_arg_error_invalid(MP_QSTR_frequency);
     }
     const pin_timer_t *t = self->timer;
     uint8_t resolution;

--- a/ports/atmel-samd/common-hal/rtc/RTC.c
+++ b/ports/atmel-samd/common-hal/rtc/RTC.c
@@ -68,13 +68,7 @@ int common_hal_rtc_get_calibration(void) {
 }
 
 void common_hal_rtc_set_calibration(int calibration) {
-    if (calibration > 127 || calibration < -127) {
-        #if CIRCUITPY_FULL_BUILD
-        mp_raise_ValueError(translate("calibration value out of range +/-127"));
-        #else
-        mp_raise_ValueError(translate("calibration is out of range"));
-        #endif
-    }
+    mp_arg_validate_int_range(calibration, -127, 127, MP_QSTR_calibration);
 
     hri_rtcmode0_write_FREQCORR_SIGN_bit(RTC, calibration < 0 ? 0 : 1);
     hri_rtcmode0_write_FREQCORR_VALUE_bf(RTC, abs(calibration));

--- a/ports/atmel-samd/common-hal/touchio/TouchIn.c
+++ b/ports/atmel-samd/common-hal/touchio/TouchIn.c
@@ -31,6 +31,7 @@
 #include "py/runtime.h"
 #include "py/binary.h"
 #include "py/mphal.h"
+#include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/touchio/TouchIn.h"
 #include "supervisor/shared/translate.h"
 
@@ -60,7 +61,7 @@ static uint16_t get_raw_reading(touchio_touchin_obj_t *self) {
 void common_hal_touchio_touchin_construct(touchio_touchin_obj_t *self,
     const mcu_pin_obj_t *pin) {
     if (!pin->has_touch) {
-        mp_raise_ValueError(translate("Invalid pin"));
+        raise_ValueError_invalid_pin();
     }
     claim_pin(pin);
 

--- a/ports/broadcom/common-hal/busio/I2C.c
+++ b/ports/broadcom/common-hal/busio/I2C.c
@@ -90,7 +90,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
         }
     }
     if (instance_index == NUM_I2C) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
     i2c_in_use[instance_index] = true;
     self->index = instance_index;

--- a/ports/broadcom/common-hal/busio/SPI.c
+++ b/ports/broadcom/common-hal/busio/SPI.c
@@ -104,7 +104,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         break;
     }
     if (instance_index == NUM_SPI) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     self->clock = clock;

--- a/ports/broadcom/common-hal/busio/UART.c
+++ b/ports/broadcom/common-hal/busio/UART.c
@@ -162,13 +162,8 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     mp_float_t timeout, uint16_t receiver_buffer_size, byte *receiver_buffer,
     bool sigint_enabled) {
 
-    if (bits > 8) {
-        mp_raise_ValueError(translate("Invalid word/bit length"));
-    }
-
-    if (receiver_buffer_size == 0) {
-        mp_raise_ValueError(translate("Invalid buffer size"));
-    }
+    mp_arg_validate_int_max(bits, 8, MP_QSTR_bits);
+    mp_arg_validate_int_min(receiver_buffer_size, 1, MP_QSTR_receiver_buffer_size);
 
     if ((rs485_dir != NULL) || (rs485_invert)) {
         mp_raise_NotImplementedError(translate("RS485 Not yet supported on this device"));
@@ -203,7 +198,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         break;
     }
     if (instance_index == NUM_UART) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     self->rx_pin = rx;
@@ -224,7 +219,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             // in the long-lived pool is not strictly necessary)
             // (This is a macro.)
             if (!ringbuf_alloc(&self->ringbuf, receiver_buffer_size, true)) {
-                mp_raise_msg(&mp_type_MemoryError, translate("Failed to allocate RX buffer"));
+                m_malloc_fail(receiver_buffer_size);
             }
         }
     }

--- a/ports/cxd56/common-hal/analogio/AnalogIn.c
+++ b/ports/cxd56/common-hal/analogio/AnalogIn.c
@@ -34,6 +34,7 @@
 #include "py/runtime.h"
 
 #include "shared-bindings/analogio/AnalogIn.h"
+#include "shared-bindings/microcontroller/Pin.h"
 
 typedef struct {
     const char *devpath;
@@ -52,7 +53,7 @@ STATIC analogin_dev_t analogin_dev[] = {
 
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self, const mcu_pin_obj_t *pin) {
     if (!pin->analog) {
-        mp_raise_ValueError(translate("AnalogIn not supported on given pin"));
+        raise_ValueError_invalid_pin();
     }
 
     self->number = -1;
@@ -65,13 +66,13 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self, const
     }
 
     if (self->number < 0) {
-        mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
+        raise_ValueError_invalid_pin();
     }
 
     if (analogin_dev[self->number].fd < 0) {
         analogin_dev[self->number].fd = open(analogin_dev[self->number].devpath, O_RDONLY);
         if (analogin_dev[self->number].fd < 0) {
-            mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
+            raise_ValueError_invalid_pin();
         }
     }
 

--- a/ports/cxd56/common-hal/analogio/AnalogOut.c
+++ b/ports/cxd56/common-hal/analogio/AnalogOut.c
@@ -29,7 +29,7 @@
 #include "shared-bindings/analogio/AnalogOut.h"
 
 void common_hal_analogio_analogout_construct(analogio_analogout_obj_t *self, const mcu_pin_obj_t *pin) {
-    mp_raise_RuntimeError(translate("AnalogOut functionality not supported"));
+    mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_AnalogOut);
 }
 
 void common_hal_analogio_analogout_deinit(analogio_analogout_obj_t *self) {

--- a/ports/cxd56/common-hal/busio/I2C.c
+++ b/ports/cxd56/common-hal/busio/I2C.c
@@ -37,7 +37,7 @@
 void common_hal_busio_i2c_construct(busio_i2c_obj_t *self, const mcu_pin_obj_t *scl,
     const mcu_pin_obj_t *sda, uint32_t frequency, uint32_t timeout) {
     if (frequency != I2C_SPEED_STANDARD && frequency != I2C_SPEED_FAST) {
-        mp_raise_ValueError(translate("Unsupported baudrate"));
+        mp_arg_error_invalid(MP_QSTR_frequency);
     }
 
     if (scl->number != PIN_I2C0_BCK || sda->number != PIN_I2C0_BDT) {

--- a/ports/cxd56/common-hal/busio/I2C.c
+++ b/ports/cxd56/common-hal/busio/I2C.c
@@ -32,6 +32,7 @@
 #include "py/runtime.h"
 
 #include "shared-bindings/busio/I2C.h"
+#include "shared-bindings/microcontroller/Pin.h"
 
 void common_hal_busio_i2c_construct(busio_i2c_obj_t *self, const mcu_pin_obj_t *scl,
     const mcu_pin_obj_t *sda, uint32_t frequency, uint32_t timeout) {
@@ -40,7 +41,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self, const mcu_pin_obj_t *
     }
 
     if (scl->number != PIN_I2C0_BCK || sda->number != PIN_I2C0_BDT) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     claim_pin(scl);

--- a/ports/cxd56/common-hal/busio/SPI.c
+++ b/ports/cxd56/common-hal/busio/SPI.c
@@ -33,6 +33,7 @@
 #include "py/runtime.h"
 
 #include "shared-bindings/busio/SPI.h"
+#include "shared-bindings/microcontroller/Pin.h"
 
 void common_hal_busio_spi_construct(busio_spi_obj_t *self, const mcu_pin_obj_t *clock,
     const mcu_pin_obj_t *mosi, const mcu_pin_obj_t *miso, bool half_duplex) {
@@ -55,7 +56,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self, const mcu_pin_obj_t *
     }
 
     if (port < 0) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     claim_pin(clock);

--- a/ports/cxd56/common-hal/busio/UART.c
+++ b/ports/cxd56/common-hal/busio/UART.c
@@ -66,7 +66,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     struct termios tio;
 
     if ((rts != NULL) || (cts != NULL) || (rs485_dir != NULL) || (rs485_invert)) {
-        mp_raise_ValueError(translate("RTS/CTS/RS485 Not yet supported on this device"));
+        mp_raise_NotImplementedError(translate("RS485"));
     }
 
     mp_arg_validate_int(bits, 8, MP_QSTR_bits);
@@ -90,7 +90,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     if (busio_uart_dev[self->number].fd < 0) {
         busio_uart_dev[self->number].fd = open(busio_uart_dev[self->number].devpath, O_RDWR);
         if (busio_uart_dev[self->number].fd < 0) {
-            mp_raise_ValueError(translate("Could not initialize UART"));
+            mp_raise_RuntimeError(translate("UART init"));
         }
 
         // Wait to make sure the UART is ready

--- a/ports/cxd56/common-hal/busio/UART.c
+++ b/ports/cxd56/common-hal/busio/UART.c
@@ -40,6 +40,7 @@
 #include "py/runtime.h"
 
 #include "shared-bindings/busio/UART.h"
+#include "shared-bindings/microcontroller/Pin.h"
 
 typedef struct {
     const char *devpath;
@@ -68,17 +69,9 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         mp_raise_ValueError(translate("RTS/CTS/RS485 Not yet supported on this device"));
     }
 
-    if (bits != 8) {
-        mp_raise_ValueError(translate("Could not initialize UART"));
-    }
-
-    if (parity != BUSIO_UART_PARITY_NONE) {
-        mp_raise_ValueError(translate("Could not initialize UART"));
-    }
-
-    if (stop != 1) {
-        mp_raise_ValueError(translate("Could not initialize UART"));
-    }
+    mp_arg_validate_int(bits, 8, MP_QSTR_bits);
+    mp_arg_validate_int(parity, BUSIO_UART_PARITY_NONE, MP_QSTR_parity);
+    mp_arg_validate_int(stop, 1, MP_QSTR_stop);
 
     self->number = -1;
 
@@ -91,7 +84,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     }
 
     if (self->number < 0) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     if (busio_uart_dev[self->number].fd < 0) {

--- a/ports/cxd56/common-hal/camera/Camera.c
+++ b/ports/cxd56/common-hal/camera/Camera.c
@@ -121,11 +121,11 @@ static void camera_start_preview() {
 void common_hal_camera_construct(camera_obj_t *self) {
     if (camera_dev.fd < 0) {
         if (video_initialize(camera_dev.devpath) < 0) {
-            mp_raise_ValueError_varg(translate("Could not initialize %q"), MP_QSTR_Camera);
+            mp_raise_RuntimeError(translate("Camera init"));
         }
         camera_dev.fd = open(camera_dev.devpath, 0);
         if (camera_dev.fd < 0) {
-            mp_raise_ValueError_varg(translate("Could not initialize %q"), MP_QSTR_Camera);
+            mp_raise_RuntimeError(translate("Camera init"));
         }
     }
 

--- a/ports/cxd56/common-hal/camera/Camera.c
+++ b/ports/cxd56/common-hal/camera/Camera.c
@@ -121,11 +121,11 @@ static void camera_start_preview() {
 void common_hal_camera_construct(camera_obj_t *self) {
     if (camera_dev.fd < 0) {
         if (video_initialize(camera_dev.devpath) < 0) {
-            mp_raise_ValueError(translate("Could not initialize Camera"));
+            mp_raise_ValueError_varg(translate("Could not initialize %q"), MP_QSTR_Camera);
         }
         camera_dev.fd = open(camera_dev.devpath, 0);
         if (camera_dev.fd < 0) {
-            mp_raise_ValueError(translate("Could not initialize Camera"));
+            mp_raise_ValueError_varg(translate("Could not initialize %q"), MP_QSTR_Camera);
         }
     }
 

--- a/ports/cxd56/common-hal/digitalio/DigitalInOut.c
+++ b/ports/cxd56/common-hal/digitalio/DigitalInOut.c
@@ -29,10 +29,11 @@
 #include "py/runtime.h"
 
 #include "shared-bindings/digitalio/DigitalInOut.h"
+#include "shared-bindings/microcontroller/Pin.h"
 
 digitalinout_result_t common_hal_digitalio_digitalinout_construct(digitalio_digitalinout_obj_t *self, const mcu_pin_obj_t *pin) {
     if (pin->analog) {
-        mp_raise_ValueError(translate("DigitalInOut not supported on given pin"));
+        raise_ValueError_invalid_pin();
     }
 
     claim_pin(pin);

--- a/ports/cxd56/common-hal/gnss/GNSS.c
+++ b/ports/cxd56/common-hal/gnss/GNSS.c
@@ -56,7 +56,7 @@ void common_hal_gnss_construct(gnss_obj_t *self, unsigned long selection) {
     if (gnss_dev.fd < 0) {
         gnss_dev.fd = open(gnss_dev.devpath, O_RDONLY);
         if (gnss_dev.fd < 0) {
-            mp_raise_ValueError_varg(translate("Could not initialize %q"), MP_QSTR_GNSS);
+            mp_raise_RuntimeError(translate("GNSS init"));
         }
     }
 

--- a/ports/cxd56/common-hal/gnss/GNSS.c
+++ b/ports/cxd56/common-hal/gnss/GNSS.c
@@ -56,7 +56,7 @@ void common_hal_gnss_construct(gnss_obj_t *self, unsigned long selection) {
     if (gnss_dev.fd < 0) {
         gnss_dev.fd = open(gnss_dev.devpath, O_RDONLY);
         if (gnss_dev.fd < 0) {
-            mp_raise_ValueError(translate("Could not initialize GNSS"));
+            mp_raise_ValueError_varg(translate("Could not initialize %q"), MP_QSTR_GNSS);
         }
     }
 

--- a/ports/cxd56/common-hal/microcontroller/__init__.c
+++ b/ports/cxd56/common-hal/microcontroller/__init__.c
@@ -72,7 +72,7 @@ void common_hal_mcu_enable_interrupts(void) {
 
 void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
     if (runmode == RUNMODE_BOOTLOADER) {
-        mp_raise_ValueError(translate("Cannot reset into bootloader because no bootloader is present."));
+        mp_raise_ValueError(translate("Cannot reset into bootloader because no bootloader is present"));
     } else if (runmode == RUNMODE_SAFE_MODE) {
         safe_mode_on_next_reset(PROGRAMMATIC_SAFE_MODE);
     }

--- a/ports/cxd56/common-hal/pulseio/PulseIn.c
+++ b/ports/cxd56/common-hal/pulseio/PulseIn.c
@@ -87,7 +87,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
     const mcu_pin_obj_t *pin, uint16_t maxlen, bool idle_state) {
     self->buffer = (uint16_t *)m_malloc(maxlen * sizeof(uint16_t), false);
     if (self->buffer == NULL) {
-        mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"), maxlen * sizeof(uint16_t));
+        m_malloc_fail(maxlen * sizeof(uint16_t));
     }
 
     self->pin = pin;
@@ -190,7 +190,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t *self, int16_
     }
     if (index < 0 || index >= self->len) {
         common_hal_mcu_enable_interrupts();
-        mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_PulseIn);
+        mp_raise_IndexError_varg(translate("%q out of range"), MP_QSTR_index);
     }
     uint16_t value = self->buffer[(self->start + index) % self->maxlen];
     common_hal_mcu_enable_interrupts();

--- a/ports/cxd56/common-hal/pwmio/PWMOut.c
+++ b/ports/cxd56/common-hal/pwmio/PWMOut.c
@@ -74,7 +74,7 @@ pwmout_result_t common_hal_pwmio_pwmout_construct(pwmio_pwmout_obj_t *self,
     self->variable_frequency = variable_frequency;
 
     if (ioctl(pwmout_dev[self->number].fd, PWMIOC_SETCHARACTERISTICS, (unsigned long)((uintptr_t)&self->info)) < 0) {
-        mp_raise_ValueError(translate("Invalid PWM frequency"));
+        mp_arg_error_invalid(MP_QSTR_frequency);
     }
     ioctl(pwmout_dev[self->number].fd, PWMIOC_START, 0);
 
@@ -116,7 +116,7 @@ void common_hal_pwmio_pwmout_set_frequency(pwmio_pwmout_obj_t *self, uint32_t fr
     self->info.frequency = frequency;
 
     if (ioctl(pwmout_dev[self->number].fd, PWMIOC_SETCHARACTERISTICS, (unsigned long)((uintptr_t)&self->info)) < 0) {
-        mp_raise_ValueError(translate("Invalid PWM frequency"));
+        mp_arg_error_invalid(MP_QSTR_frequency);
     }
 }
 

--- a/ports/cxd56/common-hal/rtc/RTC.c
+++ b/ports/cxd56/common-hal/rtc/RTC.c
@@ -50,5 +50,5 @@ int common_hal_rtc_get_calibration(void) {
 }
 
 void common_hal_rtc_set_calibration(int calibration) {
-    mp_raise_NotImplementedError(translate("RTC calibration is not supported on this board"));
+    mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_calibration);
 }

--- a/ports/cxd56/common-hal/sdioio/SDCard.c
+++ b/ports/cxd56/common-hal/sdioio/SDCard.c
@@ -59,7 +59,7 @@ void common_hal_sdioio_sdcard_construct(sdioio_sdcard_obj_t *self,
     }
 
     if (open_blockdriver("/dev/mmcsd0", 0, &self->inode) < 0) {
-        mp_raise_ValueError_varg(translate("Could not initialize %q"), MP_QSTR_SDCard);
+        mp_raise_RuntimeError(translate("SDCard init"));
     }
 
     self->inode->u.i_bops->geometry(self->inode, &geo);

--- a/ports/cxd56/common-hal/sdioio/SDCard.c
+++ b/ports/cxd56/common-hal/sdioio/SDCard.c
@@ -31,6 +31,7 @@
 #include "py/mperrno.h"
 #include "py/runtime.h"
 
+#include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/sdioio/SDCard.h"
 #include "shared-bindings/util.h"
 
@@ -42,7 +43,7 @@ void common_hal_sdioio_sdcard_construct(sdioio_sdcard_obj_t *self,
     struct geometry geo;
 
     if (clock->number != PIN_SDIO_CLK || command->number != PIN_SDIO_CMD) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     uint8_t data_pins_num = 0;
@@ -54,11 +55,11 @@ void common_hal_sdioio_sdcard_construct(sdioio_sdcard_obj_t *self,
     }
 
     if (data_pins_num != DATA_PINS_NUM) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     if (open_blockdriver("/dev/mmcsd0", 0, &self->inode) < 0) {
-        mp_raise_ValueError(translate("Could not initialize SDCard"));
+        mp_raise_ValueError_varg(translate("Could not initialize %q"), MP_QSTR_SDCard);
     }
 
     self->inode->u.i_bops->geometry(self->inode, &geo);

--- a/ports/espressif/common-hal/alarm/touch/TouchAlarm.c
+++ b/ports/espressif/common-hal/alarm/touch/TouchAlarm.c
@@ -26,6 +26,7 @@
 
 #include "shared-bindings/alarm/touch/TouchAlarm.h"
 #include "shared-bindings/microcontroller/__init__.h"
+#include "shared-bindings/microcontroller/Pin.h"
 
 #include "esp_sleep.h"
 #include "peripherals/touch.h"
@@ -36,7 +37,7 @@ static volatile bool woke_up = false;
 
 void common_hal_alarm_touch_touchalarm_construct(alarm_touch_touchalarm_obj_t *self, const mcu_pin_obj_t *pin) {
     if (pin->touch_channel == TOUCH_PAD_MAX) {
-        mp_raise_ValueError(translate("Invalid pin"));
+        raise_ValueError_invalid_pin();
     }
     claim_pin(pin);
     self->pin = pin;

--- a/ports/espressif/common-hal/analogio/AnalogIn.c
+++ b/ports/espressif/common-hal/analogio/AnalogIn.c
@@ -51,7 +51,7 @@
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self,
     const mcu_pin_obj_t *pin) {
     if (pin->adc_index == 0 || pin->adc_channel == ADC_CHANNEL_MAX) {
-        mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
+        raise_ValueError_invalid_pin();
     }
     common_hal_mcu_pin_claim(pin);
     self->pin = pin;
@@ -80,7 +80,7 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     } else if (self->pin->adc_index == ADC_UNIT_2) {
         adc2_config_channel_atten((adc2_channel_t)self->pin->adc_channel, ATTENUATION);
     } else {
-        mp_raise_ValueError(translate("Invalid Pin"));
+        raise_ValueError_invalid_pin();
     }
 
     // Automatically select calibration process depending on status of efuse

--- a/ports/espressif/common-hal/analogio/AnalogOut.c
+++ b/ports/espressif/common-hal/analogio/AnalogOut.c
@@ -49,7 +49,7 @@ void common_hal_analogio_analogout_construct(analogio_analogout_obj_t *self,
     } else if (pin == &pin_GPIO18) {
         self->channel = DAC_CHANNEL_2;
     } else {
-        mp_raise_ValueError(translate("Invalid DAC pin supplied"));
+        raise_ValueError_invalid_pin();
     }
     dac_output_enable(self->channel);
     #else

--- a/ports/espressif/common-hal/busio/I2C.c
+++ b/ports/espressif/common-hal/busio/I2C.c
@@ -42,7 +42,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     //
     // 46 is also input-only so it'll never work.
     if (scl->number == 45 || scl->number == 46 || sda->number == 45 || sda->number == 46) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     #if CIRCUITPY_REQUIRE_I2C_PULLUPS

--- a/ports/espressif/common-hal/busio/I2C.c
+++ b/ports/espressif/common-hal/busio/I2C.c
@@ -113,7 +113,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
         if (err == ESP_FAIL) {
             mp_raise_OSError(MP_EIO);
         } else {
-            mp_raise_ValueError(translate("Invalid argument"));
+            mp_raise_RuntimeError(translate("init I2C"));
         }
     }
 

--- a/ports/espressif/common-hal/busio/SPI.c
+++ b/ports/espressif/common-hal/busio/SPI.c
@@ -28,6 +28,7 @@
 
 #include "py/runtime.h"
 #include "shared-bindings/busio/SPI.h"
+#include "shared-bindings/microcontroller/Pin.h"
 
 #include "driver/spi_common_internal.h"
 
@@ -101,7 +102,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     if (result == ESP_ERR_NO_MEM) {
         mp_raise_msg(&mp_type_MemoryError, translate("ESP-IDF memory allocation failed"));
     } else if (result == ESP_ERR_INVALID_ARG) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     set_spi_config(self, 250000, 0, 0, 8);

--- a/ports/espressif/common-hal/busio/UART.c
+++ b/ports/espressif/common-hal/busio/UART.c
@@ -101,9 +101,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     mp_float_t timeout, uint16_t receiver_buffer_size, byte *receiver_buffer,
     bool sigint_enabled) {
 
-    if (bits > 8) {
-        mp_raise_NotImplementedError(translate("bytes > 8 bits not supported"));
-    }
+    mp_arg_validate_int_max(bits, 8, MP_QSTR_bytes);
 
     bool have_tx = tx != NULL;
     bool have_rx = rx != NULL;

--- a/ports/espressif/common-hal/busio/UART.c
+++ b/ports/espressif/common-hal/busio/UART.c
@@ -25,6 +25,7 @@
  */
 
 #include "shared-bindings/microcontroller/__init__.h"
+#include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/busio/UART.h"
 
 #include "components/driver/include/driver/uart.h"
@@ -156,7 +157,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     // Install the driver before we change the settings.
     if (uart_driver_install(self->uart_num, receiver_buffer_size, 0, 20, &self->event_queue, 0) != ESP_OK ||
         uart_set_mode(self->uart_num, mode) != ESP_OK) {
-        mp_raise_ValueError(translate("Could not initialize UART"));
+        mp_raise_RuntimeError(translate("UART init"));
     }
     // On the debug uart, enable pattern detection to look for CTRL+C
     #ifdef CIRCUITPY_DEBUG_UART_RX
@@ -263,7 +264,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         rts_num = rs485_dir->number;
     }
     if (uart_set_pin(self->uart_num, tx_num, rx_num, rts_num, cts_num) != ESP_OK) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 }
 
@@ -374,7 +375,7 @@ uint32_t common_hal_busio_uart_get_baudrate(busio_uart_obj_t *self) {
 void common_hal_busio_uart_set_baudrate(busio_uart_obj_t *self, uint32_t baudrate) {
     if (baudrate > UART_BITRATE_MAX ||
         uart_set_baudrate(self->uart_num, baudrate) != ESP_OK) {
-        mp_raise_ValueError(translate("Unsupported baudrate"));
+        mp_arg_error_invalid(MP_QSTR_baudrate);
     }
 }
 

--- a/ports/espressif/common-hal/canio/CAN.c
+++ b/ports/espressif/common-hal/canio/CAN.c
@@ -133,7 +133,7 @@ void common_hal_canio_can_construct(canio_can_obj_t *self, const mcu_pin_obj_t *
     if (result == ESP_ERR_NO_MEM) {
         mp_raise_msg(&mp_type_MemoryError, translate("ESP-IDF memory allocation failed"));
     } else if (result == ESP_ERR_INVALID_ARG) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     } else if (result != ESP_OK) {
         mp_raise_OSError_msg_varg(translate("twai_driver_install returned esp-idf error #%d"), (int)result);
     }

--- a/ports/espressif/common-hal/frequencyio/FrequencyIn.c
+++ b/ports/espressif/common-hal/frequencyio/FrequencyIn.c
@@ -130,9 +130,7 @@ static void init_timer(frequencyio_frequencyin_obj_t *self) {
 
 void common_hal_frequencyio_frequencyin_construct(frequencyio_frequencyin_obj_t *self,
     const mcu_pin_obj_t *pin, const uint16_t capture_period) {
-    if ((capture_period == 0) || (capture_period > 500)) {
-        mp_raise_ValueError(translate("Invalid capture period. Valid range: 1 - 500"));
-    }
+    mp_arg_validate_int_range(capture_period, 1, 500, MP_QSTR_capture_period);
 
     self->pin = pin->number;
     self->handle = NULL;
@@ -188,9 +186,8 @@ uint16_t common_hal_frequencyio_frequencyin_get_capture_period(frequencyio_frequ
 }
 
 void common_hal_frequencyio_frequencyin_set_capture_period(frequencyio_frequencyin_obj_t *self, uint16_t capture_period) {
-    if ((capture_period == 0) || (capture_period > 500)) {
-        mp_raise_ValueError(translate("Invalid capture period. Valid range: 1 - 500"));
-    }
+    mp_arg_validate_int_range(capture_period, 1, 500, MP_QSTR_capture_period);
+
     self->capture_period = capture_period;
     common_hal_frequencyio_frequencyin_clear(self);
     timer_set_alarm_value(self->timer.group, self->timer.idx, capture_period * 1000000);

--- a/ports/espressif/common-hal/i2cperipheral/I2CPeripheral.c
+++ b/ports/espressif/common-hal/i2cperipheral/I2CPeripheral.c
@@ -30,6 +30,7 @@
 #include "py/runtime.h"
 
 #include "common-hal/i2cperipheral/I2CPeripheral.h"
+#include "shared-bindings/microcontroller/Pin.h"
 
 void common_hal_i2cperipheral_i2c_peripheral_construct(i2cperipheral_i2c_peripheral_obj_t *self,
     const mcu_pin_obj_t *scl, const mcu_pin_obj_t *sda,
@@ -39,7 +40,7 @@ void common_hal_i2cperipheral_i2c_peripheral_construct(i2cperipheral_i2c_periphe
     // support I2C on these pins.
     // Also 46 is input-only so it'll never work.
     if (scl->number == 45 || scl->number == 46 || sda->number == 45 || sda->number == 46) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     if (num_addresses > 1) {
@@ -72,7 +73,7 @@ void common_hal_i2cperipheral_i2c_peripheral_construct(i2cperipheral_i2c_periphe
         if (err == ESP_FAIL) {
             mp_raise_OSError(MP_EIO);
         } else {
-            mp_raise_ValueError(translate("Invalid argument"));
+            mp_arg_error_invalid(MP_QSTR_I2CPeripheral);
         }
     }
 

--- a/ports/espressif/common-hal/imagecapture/ParallelImageCapture.c
+++ b/ports/espressif/common-hal/imagecapture/ParallelImageCapture.c
@@ -41,9 +41,7 @@ void common_hal_imagecapture_parallelimagecapture_construct(imagecapture_paralle
     const mcu_pin_obj_t *horizontal_reference) {
 
     // only 8 bits is supported at present
-    if (data_count < 8 || data_count > 16) {
-        mp_raise_ValueError_varg(translate("%q must be between %d and %d"), MP_QSTR_data_count, 8, 16);
-    }
+    mp_arg_validate_int_range(data_count, 8, 16, MP_QSTR_data_count);
 
     // This will throw if unsuccessful.  Everything following is guaranteed to succeed.
     port_i2s_allocate_i2s0();

--- a/ports/espressif/common-hal/pulseio/PulseIn.c
+++ b/ports/espressif/common-hal/pulseio/PulseIn.c
@@ -88,7 +88,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
     uint16_t maxlen, bool idle_state) {
     self->buffer = (uint16_t *)m_malloc(maxlen * sizeof(uint16_t), false);
     if (self->buffer == NULL) {
-        mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"), maxlen * sizeof(uint16_t));
+        m_malloc_fail(maxlen * sizeof(uint16_t));
     }
     self->pin = pin;
     self->maxlen = maxlen;

--- a/ports/espressif/common-hal/pwmio/PWMOut.c
+++ b/ports/espressif/common-hal/pwmio/PWMOut.c
@@ -217,7 +217,7 @@ void common_hal_pwmio_pwmout_set_frequency(pwmio_pwmout_obj_t *self, uint32_t fr
     // Calculate duty cycle
     uint32_t duty_bits = calculate_duty_cycle(frequency);
     if (duty_bits == 0) {
-        mp_raise_ValueError(translate("Invalid PWM frequency"));
+        mp_arg_error_invalid(MP_QSTR_frequency);
     }
     self->duty_resolution = duty_bits;
     ledc_set_freq(LEDC_LOW_SPEED_MODE, self->tim_handle.timer_num, frequency);

--- a/ports/espressif/common-hal/rtc/RTC.c
+++ b/ports/espressif/common-hal/rtc/RTC.c
@@ -48,5 +48,5 @@ int common_hal_rtc_get_calibration(void) {
 }
 
 void common_hal_rtc_set_calibration(int calibration) {
-    mp_raise_NotImplementedError(translate("RTC calibration is not supported on this board"));
+    mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_calibration);
 }

--- a/ports/espressif/common-hal/touchio/TouchIn.c
+++ b/ports/espressif/common-hal/touchio/TouchIn.c
@@ -28,6 +28,7 @@
 
 #include "py/runtime.h"
 #include "peripherals/touch.h"
+#include "shared-bindings/microcontroller/Pin.h"
 
 static uint16_t get_raw_reading(touchio_touchin_obj_t *self) {
     uint32_t touch_value;
@@ -41,7 +42,7 @@ static uint16_t get_raw_reading(touchio_touchin_obj_t *self) {
 void common_hal_touchio_touchin_construct(touchio_touchin_obj_t *self,
     const mcu_pin_obj_t *pin) {
     if (pin->touch_channel == TOUCH_PAD_MAX) {
-        mp_raise_ValueError(translate("Invalid pin"));
+        raise_ValueError_invalid_pin();
     }
     claim_pin(pin);
 

--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -209,7 +209,7 @@ void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_
             authmode = WIFI_AUTH_WPA_WPA2_PSK;
             break;
         default:
-            mp_raise_ValueError(translate("Invalid AuthMode"));
+            mp_arg_error_invalid(MP_QSTR_authmode);
             break;
     }
 
@@ -221,9 +221,8 @@ void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_
     config->ap.channel = channel;
     config->ap.authmode = authmode;
 
-    if (max_connections < 0 || max_connections > 10) {
-        mp_raise_ValueError(translate("max_connections must be between 0 and 10"));
-    }
+    mp_arg_validate_int_range(max_connections, 0, 10, MP_QSTR_max_connections);
+
     config->ap.max_connection = max_connections;
 
     esp_wifi_set_config(WIFI_IF_AP, config);

--- a/ports/mimxrt10xx/common-hal/analogio/AnalogIn.c
+++ b/ports/mimxrt10xx/common-hal/analogio/AnalogIn.c
@@ -42,7 +42,7 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self,
     adc_config_t config = {0};
 
     if (pin->adc == NULL) {
-        mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
+        raise_ValueError_invalid_pin();
     }
 
     ADC_GetDefaultConfig(&config);

--- a/ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
+++ b/ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
@@ -32,7 +32,7 @@
 #include "supervisor/shared/translate.h"
 
 void common_hal_analogio_analogout_construct(analogio_analogout_obj_t *self, const mcu_pin_obj_t *pin) {
-    mp_raise_NotImplementedError(translate("AnalogOut functionality not supported"));
+    mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_AnalogOut);
 }
 
 bool common_hal_analogio_analogout_deinited(analogio_analogout_obj_t *self) {

--- a/ports/mimxrt10xx/common-hal/busio/I2C.c
+++ b/ports/mimxrt10xx/common-hal/busio/I2C.c
@@ -138,7 +138,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     }
 
     if (self->sda == NULL || self->scl == NULL) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     } else {
         self->i2c = mcu_i2c_banks[self->sda->bank_idx - 1];
     }

--- a/ports/mimxrt10xx/common-hal/busio/SPI.c
+++ b/ports/mimxrt10xx/common-hal/busio/SPI.c
@@ -168,7 +168,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         if (spi_taken) {
             mp_raise_ValueError(translate("Hardware busy, try alternative pins"));
         } else {
-            mp_raise_ValueError(translate("Invalid pins"));
+            raise_ValueError_invalid_pins();
         }
     }
 

--- a/ports/mimxrt10xx/common-hal/busio/UART.c
+++ b/ports/mimxrt10xx/common-hal/busio/UART.c
@@ -117,7 +117,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     self->timeout_ms = timeout * 1000;
 
     if (self->character_bits != 7 && self->character_bits != 8) {
-        mp_raise_ValueError(translate("Invalid word/bit length"));
+        mp_arg_validate_int_range(self->character_bits, 7, 8, MP_QSTR_bits);
     }
 
     DBGPrintf(&mp_plat_print, "uart_construct: tx:%p rx:%p rts:%p cts:%p rs485:%p\n", tx, rx, rts, cts, rs485_dir);
@@ -350,7 +350,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
 
         if (!self->ringbuf) {
             LPUART_Deinit(self->uart);
-            mp_raise_msg(&mp_type_MemoryError, translate("Failed to allocate RX buffer"));
+            m_malloc_fail(receiver_buffer_size);
         }
 
         LPUART_TransferCreateHandle(self->uart, &self->handle, LPUART_UserCallback, self);

--- a/ports/mimxrt10xx/common-hal/busio/UART.c
+++ b/ports/mimxrt10xx/common-hal/busio/UART.c
@@ -113,12 +113,9 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     bool sigint_enabled) {
 
     self->baudrate = baudrate;
-    self->character_bits = bits;
+    self->character_bits = (uint8_t)mp_arg_validate_int_range(self->character_bits, 7, 8, MP_QSTR_bits);
     self->timeout_ms = timeout * 1000;
 
-    if (self->character_bits != 7 && self->character_bits != 8) {
-        mp_arg_validate_int_range(self->character_bits, 7, 8, MP_QSTR_bits);
-    }
 
     DBGPrintf(&mp_plat_print, "uart_construct: tx:%p rx:%p rts:%p cts:%p rs485:%p\n", tx, rx, rts, cts, rs485_dir);
 

--- a/ports/mimxrt10xx/common-hal/busio/UART.c
+++ b/ports/mimxrt10xx/common-hal/busio/UART.c
@@ -183,10 +183,10 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     }
 
     if (rx && !rx_config) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_RX);
+        raise_ValueError_invalid_pin_name(MP_QSTR_rx);
     }
     if (tx && !tx_config) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_TX);
+        raise_ValueError_invalid_pin_name(MP_QSTR_tx);
     }
 
     if (uart_taken) {
@@ -233,7 +233,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             }
         }
         if ((rts != NULL) && (rts_config == NULL)) {
-            mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_RTS);
+            raise_ValueError_invalid_pin_name(MP_QSTR_rts);
         }
     }
 
@@ -247,7 +247,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             }
         }
         if (cts_config == NULL) {
-            mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_CTS);
+            raise_ValueError_invalid_pin_name(MP_QSTR_cts);
         }
     }
 

--- a/ports/mimxrt10xx/common-hal/microcontroller/__init__.c
+++ b/ports/mimxrt10xx/common-hal/microcontroller/__init__.c
@@ -70,7 +70,7 @@ void common_hal_mcu_enable_interrupts(void) {
 void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
     if (runmode == RUNMODE_BOOTLOADER) {
         if (!bootloader_available()) {
-            mp_raise_ValueError(translate("Cannot reset into bootloader because no bootloader is present."));
+            mp_raise_ValueError(translate("Cannot reset into bootloader because no bootloader is present"));
         }
         // Pretend to be the first of the two reset presses needed to enter the
         // bootloader. That way one reset will end in the bootloader.

--- a/ports/mimxrt10xx/common-hal/pwmio/PWMOut.c
+++ b/ports/mimxrt10xx/common-hal/pwmio/PWMOut.c
@@ -301,7 +301,7 @@ void common_hal_pwmio_pwmout_set_frequency(pwmio_pwmout_obj_t *self,
 
     int pulse_count = calculate_pulse_count(frequency, &self->prescaler);
     if (pulse_count == 0) {
-        mp_raise_ValueError(translate("Invalid PWM frequency"));
+        mp_arg_error_invalid(MP_QSTR_frequency);
     }
 
     self->pulse_count = pulse_count;

--- a/ports/mimxrt10xx/common-hal/rtc/RTC.c
+++ b/ports/mimxrt10xx/common-hal/rtc/RTC.c
@@ -75,5 +75,5 @@ int common_hal_rtc_get_calibration(void) {
 
 void common_hal_rtc_set_calibration(int calibration) {
     // SNVS has HPCALB_VAL bits for calibration.
-    mp_raise_NotImplementedError(translate("RTC calibration is not supported on this board"));
+    mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_calibration);
 }

--- a/ports/mimxrt10xx/common-hal/usb_host/Port.c
+++ b/ports/mimxrt10xx/common-hal/usb_host/Port.c
@@ -24,9 +24,8 @@
  * THE SOFTWARE.
  */
 
-#include "shared-bindings/usb_host/Port.h"
-
 #include "shared-bindings/microcontroller/Pin.h"
+#include "shared-bindings/usb_host/Port.h"
 
 #include "py/runtime.h"
 
@@ -43,7 +42,7 @@ void common_hal_usb_host_port_construct(usb_host_port_obj_t *self, const mcu_pin
         supported_dm = &pin_USB_OTG2_DN;
     }
     if (dp != supported_dp || dm != supported_dm) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
     self->init = true;
     usb_host_init = true;

--- a/ports/nrf/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/nrf/common-hal/alarm/pin/PinAlarm.c
@@ -49,10 +49,10 @@ extern uint32_t reset_reason_saved;
 
 void common_hal_alarm_pin_pinalarm_construct(alarm_pin_pinalarm_obj_t *self, const mcu_pin_obj_t *pin, bool value, bool edge, bool pull) {
     if (edge) {
-        mp_raise_ValueError(translate("Cannot wake on pin edge. Only level."));
+        mp_raise_ValueError(translate("Cannot wake on pin edge, only level"));
     }
     if (pin->number >= NUMBER_OF_PINS) {
-        mp_raise_ValueError(translate("Invalid pin"));
+        raise_ValueError_invalid_pin();
     }
     self->pin = pin;
     self->value = value;

--- a/ports/nrf/common-hal/alarm/time/TimeAlarm.c
+++ b/ports/nrf/common-hal/alarm/time/TimeAlarm.c
@@ -85,7 +85,7 @@ void alarm_time_timealarm_set_alarms(bool deep_sleep, size_t n_alarms, const mp_
             continue;
         }
         if (timealarm_set) {
-            mp_raise_ValueError(translate("Only one alarm.time alarm can be set."));
+            mp_raise_ValueError(translate("Only one alarm.time alarm can be set"));
         }
         timealarm = MP_OBJ_TO_PTR(alarms[i]);
         timealarm_set = true;

--- a/ports/nrf/common-hal/analogio/AnalogIn.c
+++ b/ports/nrf/common-hal/analogio/AnalogIn.c
@@ -27,6 +27,7 @@
 
 #include "common-hal/analogio/AnalogIn.h"
 #include "shared-bindings/analogio/AnalogIn.h"
+#include "shared-bindings/microcontroller/Pin.h"
 #include "py/runtime.h"
 #include "supervisor/shared/translate.h"
 
@@ -48,7 +49,7 @@ void analogin_init(void) {
 
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self, const mcu_pin_obj_t *pin) {
     if (pin->adc_channel == 0) {
-        mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
+        raise_ValueError_invalid_pin();
     }
 
     nrf_gpio_cfg_default(pin->number);

--- a/ports/nrf/common-hal/analogio/AnalogOut.c
+++ b/ports/nrf/common-hal/analogio/AnalogOut.c
@@ -34,7 +34,7 @@
 #include "supervisor/shared/translate.h"
 
 void common_hal_analogio_analogout_construct(analogio_analogout_obj_t *self, const mcu_pin_obj_t *pin) {
-    mp_raise_RuntimeError(translate("AnalogOut functionality not supported"));
+    mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_AnalogOut);
 }
 
 bool common_hal_analogio_analogout_deinited(analogio_analogout_obj_t *self) {

--- a/ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
@@ -263,9 +263,8 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, 
         &spacing);
     self->sample_channel_count = audiosample_channel_count(sample);
 
-    if (max_buffer_length > UINT16_MAX) {
-        mp_raise_ValueError_varg(translate("Buffer length %d too big. It must be less than %d"), max_buffer_length, UINT16_MAX);
-    }
+    mp_arg_validate_length_max(max_buffer_length, UINT16_MAX, MP_QSTR_buffer);
+
     uint16_t buffer_length = (uint16_t)max_buffer_length;
     self->buffers[0] = m_malloc(buffer_length * 2 * sizeof(uint16_t), false);
     if (!self->single_buffer) {

--- a/ports/nrf/common-hal/busio/I2C.c
+++ b/ports/nrf/common-hal/busio/I2C.c
@@ -29,6 +29,7 @@
 
 #include "shared-bindings/busio/I2C.h"
 #include "shared-bindings/microcontroller/__init__.h"
+#include "shared-bindings/microcontroller/Pin.h"
 #include "py/mperrno.h"
 #include "py/runtime.h"
 #include "supervisor/shared/translate.h"
@@ -96,7 +97,7 @@ static uint8_t twi_error_to_mp(const nrfx_err_t err) {
 
 void common_hal_busio_i2c_construct(busio_i2c_obj_t *self, const mcu_pin_obj_t *scl, const mcu_pin_obj_t *sda, uint32_t frequency, uint32_t timeout) {
     if (scl->number == sda->number) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     // Find a free instance.

--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -164,12 +164,10 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     mp_float_t timeout, uint16_t receiver_buffer_size, byte *receiver_buffer,
     bool sigint_enabled) {
 
-    if (bits != 8) {
-        mp_raise_ValueError(translate("Invalid word/bit length"));
-    }
+    mp_arg_validate_int(bits, 8, MP_QSTR_bits);
 
     if ((rs485_dir != NULL) || (rs485_invert)) {
-        mp_raise_ValueError(translate("RS485 Not yet supported on this device"));
+        mp_raise_NotImplementedError(translate("RS485"));
     }
 
     // Find a free UART peripheral.
@@ -189,9 +187,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         mp_raise_ValueError(translate("tx and rx cannot both be None"));
     }
 
-    if (receiver_buffer_size == 0) {
-        mp_raise_ValueError(translate("Invalid buffer size"));
-    }
+    mp_arg_validate_int_min(receiver_buffer_size, 1, MP_QSTR_receiver_buffer_size);
 
     if (parity == BUSIO_UART_PARITY_ODD) {
         mp_raise_ValueError(translate("Odd parity is not supported"));
@@ -234,7 +230,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             // (This is a macro.)
         } else if (!ringbuf_alloc(&self->ringbuf, receiver_buffer_size, true)) {
             nrfx_uarte_uninit(self->uarte);
-            mp_raise_msg(&mp_type_MemoryError, translate("Failed to allocate RX buffer"));
+            m_malloc_fail(receiver_buffer_size);
         }
 
         self->rx_pin_number = rx->number;

--- a/ports/nrf/common-hal/pulseio/PulseIn.c
+++ b/ports/nrf/common-hal/pulseio/PulseIn.c
@@ -129,7 +129,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
 
     self->buffer = (uint16_t *)m_malloc(maxlen * sizeof(uint16_t), false);
     if (self->buffer == NULL) {
-        mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"), maxlen * sizeof(uint16_t));
+        m_malloc_fail(maxlen * sizeof(uint16_t));
     }
 
     if (refcount == 0) {
@@ -271,7 +271,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t *self, int16_
         if (!self->paused) {
             nrfx_gpiote_in_event_enable(self->pin, true);
         }
-        mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_PulseIn);
+        mp_raise_IndexError_varg(translate("%q out of range"), MP_QSTR_index);
     }
     uint16_t value = self->buffer[(self->start + index) % self->maxlen];
 

--- a/ports/nrf/common-hal/pwmio/PWMOut.c
+++ b/ports/nrf/common-hal/pwmio/PWMOut.c
@@ -297,7 +297,7 @@ void common_hal_pwmio_pwmout_set_frequency(pwmio_pwmout_obj_t *self, uint32_t fr
     uint16_t countertop;
     nrf_pwm_clk_t base_clock;
     if (frequency == 0 || !convert_frequency(frequency, &countertop, &base_clock)) {
-        mp_raise_ValueError(translate("Invalid PWM frequency"));
+        mp_arg_error_invalid(MP_QSTR_frequency);
     }
     self->frequency = frequency;
 

--- a/ports/nrf/common-hal/rtc/RTC.c
+++ b/ports/nrf/common-hal/rtc/RTC.c
@@ -80,5 +80,5 @@ int common_hal_rtc_get_calibration(void) {
 }
 
 void common_hal_rtc_set_calibration(int calibration) {
-    mp_raise_NotImplementedError(translate("RTC calibration is not supported on this board"));
+    mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_calibration);
 }

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -223,50 +223,31 @@ STATIC mp_obj_t rp2pio_statemachine_make_new(const mp_obj_type_t *type, size_t n
 
     // We don't validate pin in use here because we may be ok sharing them within a PIO.
     const mcu_pin_obj_t *first_out_pin = validate_obj_is_pin_or_none(args[ARG_first_out_pin].u_obj);
-    if (args[ARG_out_pin_count].u_int < 1) {
-        mp_raise_ValueError(translate("Pin count must be at least 1"));
-    }
+    mp_int_t out_pin_count = mp_arg_validate_int_min(args[ARG_out_pin_count].u_int, 1, MP_QSTR_out_pin_count);
+
     const mcu_pin_obj_t *first_in_pin = validate_obj_is_pin_or_none(args[ARG_first_in_pin].u_obj);
-    if (args[ARG_in_pin_count].u_int < 1) {
-        mp_raise_ValueError(translate("Pin count must be at least 1"));
-    }
+    mp_int_t in_pin_count = mp_arg_validate_int_min(args[ARG_in_pin_count].u_int, 1, MP_QSTR_in_pin_count);
+
     const mcu_pin_obj_t *first_set_pin = validate_obj_is_pin_or_none(args[ARG_first_set_pin].u_obj);
-    if (args[ARG_set_pin_count].u_int < 1) {
-        mp_raise_ValueError(translate("Pin count must be at least 1"));
-    }
-    if (args[ARG_set_pin_count].u_int > 5) {
-        mp_raise_ValueError(translate("Set pin count must be between 1 and 5"));
-    }
+    mp_int_t set_pin_count = mp_arg_validate_int_range(args[ARG_set_pin_count].u_int, 1, 5, MP_QSTR_set_pin_count);
+
     const mcu_pin_obj_t *first_sideset_pin = validate_obj_is_pin_or_none(args[ARG_first_sideset_pin].u_obj);
-    if (args[ARG_sideset_pin_count].u_int < 1) {
-        mp_raise_ValueError(translate("Pin count must be at least 1"));
-    }
-    if (args[ARG_sideset_pin_count].u_int > 5) {
-        mp_raise_ValueError(translate("Side set pin count must be between 1 and 5"));
-    }
+    mp_int_t sideset_pin_count = mp_arg_validate_int_range(args[ARG_sideset_pin_count].u_int, 1, 5, MP_QSTR_set_pin_count);
 
     const mcu_pin_obj_t *jmp_pin = validate_obj_is_pin_or_none(args[ARG_jmp_pin].u_obj);
     digitalio_pull_t jmp_pin_pull = validate_pull(args[ARG_jmp_pin_pull].u_rom_obj, MP_QSTR_jmp_pull);
 
-    mp_int_t pull_threshold = args[ARG_pull_threshold].u_int;
-    mp_int_t push_threshold = args[ARG_push_threshold].u_int;
-    if (pull_threshold < 1 || pull_threshold > 32) {
-        mp_raise_ValueError(translate("pull_threshold must be between 1 and 32"));
-    }
-    if (push_threshold < 1 || push_threshold > 32) {
-        mp_raise_ValueError(translate("push_threshold must be between 1 and 32"));
-    }
+    mp_int_t pull_threshold =
+        mp_arg_validate_int_range(args[ARG_pull_threshold].u_int, 1, 32, MP_QSTR_pull_threshold);
+    mp_int_t push_threshold =
+        mp_arg_validate_int_range(args[ARG_push_threshold].u_int, 1, 32, MP_QSTR_push_threshold);
 
-    if (bufinfo.len < 2) {
-        mp_raise_ValueError(translate("Program must contain at least one 16-bit instruction."));
-    }
+    mp_arg_validate_length_range(bufinfo.len, 2, 64, MP_QSTR_program);
     if (bufinfo.len % 2 != 0) {
         mp_raise_ValueError(translate("Program size invalid"));
     }
-    if (bufinfo.len > 64) {
-        mp_raise_ValueError(translate("Program too large"));
-    }
 
+    mp_arg_validate_length_range(init_bufinfo.len, 2, 64, MP_QSTR_init);
     if (init_bufinfo.len % 2 != 0) {
         mp_raise_ValueError(translate("Init program size invalid"));
     }

--- a/ports/raspberrypi/common-hal/analogio/AnalogIn.c
+++ b/ports/raspberrypi/common-hal/analogio/AnalogIn.c
@@ -26,6 +26,7 @@
 
 #include "common-hal/analogio/AnalogIn.h"
 #include "shared-bindings/analogio/AnalogIn.h"
+#include "shared-bindings/microcontroller/Pin.h"
 #include "py/runtime.h"
 #include "supervisor/shared/translate.h"
 
@@ -36,7 +37,7 @@
 
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self, const mcu_pin_obj_t *pin) {
     if (pin->number < ADC_FIRST_PIN_NUMBER || pin->number > ADC_FIRST_PIN_NUMBER + ADC_PIN_COUNT) {
-        mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
+        raise_ValueError_invalid_pin();
     }
 
     adc_init();

--- a/ports/raspberrypi/common-hal/analogio/AnalogOut.c
+++ b/ports/raspberrypi/common-hal/analogio/AnalogOut.c
@@ -34,7 +34,7 @@
 #include "supervisor/shared/translate.h"
 
 void common_hal_analogio_analogout_construct(analogio_analogout_obj_t *self, const mcu_pin_obj_t *pin) {
-    mp_raise_RuntimeError(translate("AnalogOut functionality not supported"));
+    mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_AnalogOut);
 }
 
 bool common_hal_analogio_analogout_deinited(analogio_analogout_obj_t *self) {

--- a/ports/raspberrypi/common-hal/busio/I2C.c
+++ b/ports/raspberrypi/common-hal/busio/I2C.c
@@ -30,6 +30,7 @@
 #include "py/runtime.h"
 
 #include "shared-bindings/microcontroller/__init__.h"
+#include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/bitbangio/I2C.h"
 
 #include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
@@ -65,14 +66,14 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
         self->peripheral = i2c[sda_instance];
     }
     if (self->peripheral == NULL) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
     if ((i2c_get_hw(self->peripheral)->enable & I2C_IC_ENABLE_ENABLE_BITS) != 0) {
         mp_raise_ValueError(translate("I2C peripheral in use"));
     }
-    if (frequency > 1000000) {
-        mp_raise_ValueError(translate("Unsupported baudrate"));
-    }
+
+    mp_arg_validate_int_max(frequency, 1000000, MP_QSTR_frequency);
+
 
     #if CIRCUITPY_REQUIRE_I2C_PULLUPS
     // Test that the pins are in a high state. (Hopefully indicating they are pulled up.)

--- a/ports/raspberrypi/common-hal/busio/SPI.c
+++ b/ports/raspberrypi/common-hal/busio/SPI.c
@@ -82,7 +82,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     // TODO: Check to see if we're sharing the SPI with a native APA102.
 
     if (instance_index > 1) {
-        mp_raise_ValueError(translate("Invalid pins"));
+        raise_ValueError_invalid_pins();
     }
 
     if (instance_index == 0) {

--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.c
@@ -49,7 +49,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
 
     self->buffer = (uint16_t *)m_malloc(maxlen * sizeof(uint16_t), false);
     if (self->buffer == NULL) {
-        mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"), maxlen * sizeof(uint16_t));
+        m_malloc_fail(maxlen * sizeof(uint16_t));
     }
     self->pin = pin->number;
     self->maxlen = maxlen;
@@ -237,7 +237,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t *self,
         index += self->len;
     }
     if (index < 0 || index >= self->len) {
-        mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_PulseIn);
+        mp_raise_IndexError_varg(translate("%q out of range"), MP_QSTR_index);
     }
     uint16_t value = self->buffer[(self->start + index) % self->maxlen];
     return value;

--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.c
@@ -237,7 +237,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t *self,
         index += self->len;
     }
     if (index < 0 || index >= self->len) {
-        mp_raise_IndexError_varg(translate("%q out of range"), MP_QSTR_index);
+        mp_arg_validate_index_range(index, 0, self->len, MP_QSTR_index);
     }
     uint16_t value = self->buffer[(self->start + index) % self->maxlen];
     return value;

--- a/ports/raspberrypi/common-hal/pwmio/PWMOut.c
+++ b/ports/raspberrypi/common-hal/pwmio/PWMOut.c
@@ -259,7 +259,7 @@ void pwmio_pwmout_set_top(pwmio_pwmout_obj_t *self, uint16_t top) {
 
 void common_hal_pwmio_pwmout_set_frequency(pwmio_pwmout_obj_t *self, uint32_t frequency) {
     if (frequency == 0 || frequency > (common_hal_mcu_processor_get_frequency() / 2)) {
-        mp_raise_ValueError(translate("Invalid PWM frequency"));
+        mp_arg_error_invalid(MP_QSTR_frequency);
     }
 
     target_slice_frequencies[self->slice] = frequency;

--- a/ports/raspberrypi/common-hal/rtc/RTC.c
+++ b/ports/raspberrypi/common-hal/rtc/RTC.c
@@ -92,5 +92,5 @@ int common_hal_rtc_get_calibration(void) {
 }
 
 void common_hal_rtc_set_calibration(int calibration) {
-    mp_raise_NotImplementedError(translate("RTC calibration is not supported on this board"));
+    mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_calibration);
 }

--- a/ports/stm/common-hal/alarm/time/TimeAlarm.c
+++ b/ports/stm/common-hal/alarm/time/TimeAlarm.c
@@ -84,7 +84,7 @@ void alarm_time_timealarm_set_alarms(bool deep_sleep, size_t n_alarms, const mp_
             continue;
         }
         if (timealarm_set) {
-            mp_raise_ValueError(translate("Only one alarm.time alarm can be set."));
+            mp_raise_ValueError(translate("Only one alarm.time alarm can be set"));
         }
         timealarm = MP_OBJ_TO_PTR(alarms[i]);
         timealarm_set = true;

--- a/ports/stm/common-hal/analogio/AnalogIn.c
+++ b/ports/stm/common-hal/analogio/AnalogIn.c
@@ -65,7 +65,7 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self,
         LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_ADC3);
         #endif
     } else {
-        mp_raise_ValueError(translate("Invalid ADC Unit value"));
+        mp_raise_RuntimeError(translate("Invalid ADC Unit value"));
     }
     common_hal_mcu_pin_claim(pin);
     self->pin = pin;
@@ -147,7 +147,7 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
         ADCx = ADC3;
         #endif
     } else {
-        mp_raise_ValueError(translate("Invalid ADC Unit value"));
+        mp_raise_RuntimeError(translate("Invalid ADC Unit value"));
     }
 
     LL_GPIO_SetPinMode(pin_port(self->pin->port), (uint32_t)pin_mask(self->pin->number), LL_GPIO_MODE_ANALOG);

--- a/ports/stm/common-hal/analogio/AnalogIn.c
+++ b/ports/stm/common-hal/analogio/AnalogIn.c
@@ -51,7 +51,7 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self,
 
     // No ADC function on pin
     if (pin->adc_unit == 0x00) {
-        mp_raise_ValueError(translate("Pin does not have ADC capabilities"));
+        raise_ValueError_invalid_pin();
     }
     // TODO: add ADC traits to structure?
 

--- a/ports/stm/common-hal/analogio/AnalogOut.c
+++ b/ports/stm/common-hal/analogio/AnalogOut.c
@@ -65,7 +65,7 @@ void common_hal_analogio_analogout_construct(analogio_analogout_obj_t *self,
         self->channel = DAC_CHANNEL_2;
         self->dac_index = 1;
     } else {
-        mp_raise_ValueError(translate("Invalid DAC pin supplied"));
+        raise_ValueError_invalid_pin();
     }
 
     // Only init if the shared DAC is empty or reset

--- a/ports/stm/common-hal/busio/I2C.c
+++ b/ports/stm/common-hal/busio/I2C.c
@@ -120,7 +120,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
         if (i2c_taken) {
             mp_raise_ValueError(translate("Hardware busy, try alternative pins"));
         } else {
-            mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_I2C);
+            raise_ValueError_invalid_pins();
         }
     }
 
@@ -155,7 +155,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     } else if (frequency == 100000) {
         self->handle.Init.Timing = CPY_I2CSTANDARD_TIMINGR;
     } else {
-        mp_raise_ValueError(translate("Unsupported frequency"));
+        mp_arg_error_invalid(MP_QSTR_frequency);
     }
     #else
     self->handle.Init.ClockSpeed = frequency;

--- a/ports/stm/common-hal/busio/I2C.c
+++ b/ports/stm/common-hal/busio/I2C.c
@@ -120,7 +120,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
         if (i2c_taken) {
             mp_raise_ValueError(translate("Hardware busy, try alternative pins"));
         } else {
-            mp_raise_ValueError_varg(translate("Invalid %q pin selection"), MP_QSTR_I2C);
+            mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_I2C);
         }
     }
 
@@ -155,7 +155,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     } else if (frequency == 100000) {
         self->handle.Init.Timing = CPY_I2CSTANDARD_TIMINGR;
     } else {
-        mp_raise_ValueError(translate("Unsupported baudrate"));
+        mp_raise_ValueError(translate("Unsupported frequency"));
     }
     #else
     self->handle.Init.ClockSpeed = frequency;
@@ -171,7 +171,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     self->handle.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
     self->handle.State = HAL_I2C_STATE_RESET;
     if (HAL_I2C_Init(&(self->handle)) != HAL_OK) {
-        mp_raise_RuntimeError(translate("I2C Init Error"));
+        mp_raise_RuntimeError(translate("I2C init error"));
     }
     common_hal_mcu_pin_claim(sda);
     common_hal_mcu_pin_claim(scl);

--- a/ports/stm/common-hal/busio/SPI.c
+++ b/ports/stm/common-hal/busio/SPI.c
@@ -165,7 +165,7 @@ STATIC int check_pins(busio_spi_obj_t *self,
     if (spi_taken) {
         mp_raise_ValueError(translate("Hardware busy, try alternative pins"));
     } else {
-        mp_raise_ValueError_varg(translate("Invalid %q pin selection"), MP_QSTR_SPI);
+        raise_ValueError_invalid_pin();
     }
 }
 
@@ -224,7 +224,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     self->handle.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
     self->handle.Init.CRCPolynomial = 10;
     if (HAL_SPI_Init(&self->handle) != HAL_OK) {
-        mp_raise_ValueError(translate("SPI Init Error"));
+        mp_raise_ValueError(translate("SPI init error"));
     }
     self->baudrate = (get_busclock(SPIx) / 16);
     self->prescaler = 16;
@@ -306,7 +306,7 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
         get_busclock(self->handle.Instance));
 
     if (HAL_SPI_Init(&self->handle) != HAL_OK) {
-        mp_raise_ValueError(translate("SPI Re-initialization error"));
+        mp_raise_ValueError(translate("SPI re-initialization error"));
     }
 
     self->baudrate = baudrate;
@@ -346,7 +346,7 @@ void common_hal_busio_spi_unlock(busio_spi_obj_t *self) {
 bool common_hal_busio_spi_write(busio_spi_obj_t *self,
     const uint8_t *data, size_t len) {
     if (self->mosi == NULL) {
-        mp_raise_ValueError(translate("No MOSI Pin"));
+        mp_raise_ValueError(translate("No MOSI pin"));
     }
     HAL_StatusTypeDef result = HAL_SPI_Transmit(&self->handle, (uint8_t *)data, (uint16_t)len, HAL_MAX_DELAY);
     return result == HAL_OK;
@@ -355,9 +355,9 @@ bool common_hal_busio_spi_write(busio_spi_obj_t *self,
 bool common_hal_busio_spi_read(busio_spi_obj_t *self,
     uint8_t *data, size_t len, uint8_t write_value) {
     if (self->miso == NULL && !self->half_duplex) {
-        mp_raise_ValueError(translate("No MISO Pin"));
+        mp_raise_ValueError(translate("No MISO pin"));
     } else if (self->half_duplex && self->mosi == NULL) {
-        mp_raise_ValueError(translate("No MOSI Pin"));
+        mp_raise_ValueError(translate("No MOSI pin"));
     }
     HAL_StatusTypeDef result = HAL_OK;
     if ((!self->half_duplex && self->mosi == NULL) || (self->half_duplex && self->mosi != NULL && self->miso == NULL)) {
@@ -372,7 +372,7 @@ bool common_hal_busio_spi_read(busio_spi_obj_t *self,
 bool common_hal_busio_spi_transfer(busio_spi_obj_t *self,
     const uint8_t *data_out, uint8_t *data_in, size_t len) {
     if (self->miso == NULL || self->mosi == NULL) {
-        mp_raise_ValueError(translate("Missing MISO or MOSI Pin"));
+        mp_raise_ValueError(translate("Missing MISO or MOSI pin"));
     }
     HAL_StatusTypeDef result = HAL_SPI_TransmitReceive(&self->handle,
         (uint8_t *)data_out, data_in, (uint16_t)len,HAL_MAX_DELAY);

--- a/ports/stm/common-hal/busio/SPI.c
+++ b/ports/stm/common-hal/busio/SPI.c
@@ -306,7 +306,7 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
         get_busclock(self->handle.Instance));
 
     if (HAL_SPI_Init(&self->handle) != HAL_OK) {
-        mp_raise_ValueError(translate("SPI re-initialization error"));
+        mp_raise_RuntimeError(translate("SPI re-init"));
     }
 
     self->baudrate = baudrate;

--- a/ports/stm/common-hal/busio/UART.c
+++ b/ports/stm/common-hal/busio/UART.c
@@ -93,7 +93,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     uint8_t periph_index = 0; // origin 0 corrected
 
     if ((rts != NULL) || (cts != NULL) || (rs485_dir != NULL) || (rs485_invert == true)) {
-        mp_raise_ValueError(translate("RTS/CTS/RS485 Not yet supported on this device"));
+        mp_raise_NotImplementedError(translate("RS485"));
     }
 
     // Can have both pins, or either
@@ -168,7 +168,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     mp_arg_validate_int_range(bits, 8, 9, MP_QSTR_bits);
 
     if (USARTx == NULL) {  // this can only be hit if the periph file is wrong
-        mp_raise_ValueError(translate("Internal define error"));
+        mp_raise_RuntimeError(translate("Internal define error"));
     }
 
     // GPIO Init
@@ -208,7 +208,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     self->handle.Init.HwFlowCtl = UART_HWCONTROL_NONE;
     self->handle.Init.OverSampling = UART_OVERSAMPLING_16;
     if (HAL_UART_Init(&self->handle) != HAL_OK) {
-        mp_raise_ValueError(translate("UART init error"));
+        mp_raise_RuntimeError(translate("UART init"));
 
     }
 
@@ -232,7 +232,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
 
     // start the interrupt series
     if ((HAL_UART_GetState(&self->handle) & HAL_UART_STATE_BUSY_RX) == HAL_UART_STATE_BUSY_RX) {
-        mp_raise_ValueError(translate("Could not start interrupt, RX busy"));
+        mp_raise_RuntimeError(translate("Could not start interrupt, RX busy"));
     }
 
     // start the receive interrupt chain
@@ -335,7 +335,7 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, 
             Status = HAL_UART_GetState(&self->handle);
         }
     } else {
-        mp_raise_ValueError(translate("UART write error"));
+        mp_raise_RuntimeError(translate("UART write"));
     }
 
     return len;
@@ -405,11 +405,11 @@ void common_hal_busio_uart_set_baudrate(busio_uart_obj_t *self, uint32_t baudrat
 
     // Otherwise de-init and set new rate
     if (HAL_UART_DeInit(&self->handle) != HAL_OK) {
-        mp_raise_ValueError(translate("UART de-init error"));
+        mp_raise_RuntimeError(translate("UART de-init"));
     }
     self->handle.Init.BaudRate = baudrate;
     if (HAL_UART_Init(&self->handle) != HAL_OK) {
-        mp_raise_ValueError(translate("UART re-init error"));
+        mp_raise_RuntimeError(translate("UART re-init"));
     }
 
     self->baudrate = baudrate;

--- a/ports/stm/common-hal/busio/UART.c
+++ b/ports/stm/common-hal/busio/UART.c
@@ -58,7 +58,7 @@ STATIC USART_TypeDef *assign_uart_or_throw(busio_uart_obj_t *self, bool pin_eval
         if (uart_taken) {
             mp_raise_ValueError(translate("Hardware in use, try alternative pins"));
         } else {
-            mp_raise_ValueError_varg(translate("Invalid %q pin selection"), MP_QSTR_UART);
+            raise_ValueError_invalid_pin();
         }
     }
 }
@@ -164,12 +164,9 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     }
 
     // Other errors
-    if (receiver_buffer_size == 0) {
-        mp_raise_ValueError(translate("Invalid buffer size"));
-    }
-    if (bits != 8 && bits != 9) {
-        mp_raise_ValueError(translate("Invalid word/bit length"));
-    }
+    mp_arg_validate_length_min(receiver_buffer_size, 1, MP_QSTR_receiver_buffer_size);
+    mp_arg_validate_int_range(bits, 8, 9, MP_QSTR_bits);
+
     if (USARTx == NULL) {  // this can only be hit if the periph file is wrong
         mp_raise_ValueError(translate("Internal define error"));
     }
@@ -211,7 +208,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     self->handle.Init.HwFlowCtl = UART_HWCONTROL_NONE;
     self->handle.Init.OverSampling = UART_OVERSAMPLING_16;
     if (HAL_UART_Init(&self->handle) != HAL_OK) {
-        mp_raise_ValueError(translate("UART Init Error"));
+        mp_raise_ValueError(translate("UART init error"));
 
     }
 
@@ -221,7 +218,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             self->ringbuf = (ringbuf_t) { receiver_buffer, receiver_buffer_size };
         } else {
             if (!ringbuf_alloc(&self->ringbuf, receiver_buffer_size, true)) {
-                mp_raise_ValueError(translate("UART Buffer allocation error"));
+                m_malloc_fail(receiver_buffer_size);
             }
         }
         common_hal_mcu_pin_claim(rx);
@@ -408,11 +405,11 @@ void common_hal_busio_uart_set_baudrate(busio_uart_obj_t *self, uint32_t baudrat
 
     // Otherwise de-init and set new rate
     if (HAL_UART_DeInit(&self->handle) != HAL_OK) {
-        mp_raise_ValueError(translate("UART De-init error"));
+        mp_raise_ValueError(translate("UART de-init error"));
     }
     self->handle.Init.BaudRate = baudrate;
     if (HAL_UART_Init(&self->handle) != HAL_OK) {
-        mp_raise_ValueError(translate("UART Re-init error"));
+        mp_raise_ValueError(translate("UART re-init error"));
     }
 
     self->baudrate = baudrate;

--- a/ports/stm/common-hal/canio/CAN.c
+++ b/ports/stm/common-hal/canio/CAN.c
@@ -59,13 +59,13 @@ void common_hal_canio_can_construct(canio_can_obj_t *self, const mcu_pin_obj_t *
 
     const mcu_periph_obj_t *mcu_tx = find_pin_function(mcu_can_tx_list, can_tx_len, tx, -1);
     if (!mcu_tx) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_tx);
+        raise_ValueError_invalid_pin_name(MP_QSTR_tx);
     }
     int periph_index = mcu_tx->periph_index;
 
     const mcu_periph_obj_t *mcu_rx = find_pin_function(mcu_can_rx_list, can_rx_len, rx, periph_index);
     if (!mcu_rx) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_rx);
+        raise_ValueError_invalid_pin_name(MP_QSTR_rx);
     }
 
     if (reserved_can[periph_index]) {

--- a/ports/stm/common-hal/canio/CAN.c
+++ b/ports/stm/common-hal/canio/CAN.c
@@ -59,13 +59,13 @@ void common_hal_canio_can_construct(canio_can_obj_t *self, const mcu_pin_obj_t *
 
     const mcu_periph_obj_t *mcu_tx = find_pin_function(mcu_can_tx_list, can_tx_len, tx, -1);
     if (!mcu_tx) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin selection"), MP_QSTR_tx);
+        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_tx);
     }
     int periph_index = mcu_tx->periph_index;
 
     const mcu_periph_obj_t *mcu_rx = find_pin_function(mcu_can_rx_list, can_rx_len, rx, periph_index);
     if (!mcu_rx) {
-        mp_raise_ValueError_varg(translate("Invalid %q pin selection"), MP_QSTR_rx);
+        mp_raise_ValueError_varg(translate("Invalid %q pin"), MP_QSTR_rx);
     }
 
     if (reserved_can[periph_index]) {

--- a/ports/stm/common-hal/pulseio/PulseIn.c
+++ b/ports/stm/common-hal/pulseio/PulseIn.c
@@ -123,8 +123,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
     self->buffer = (uint16_t *)m_malloc(maxlen * sizeof(uint16_t), false);
     if (self->buffer == NULL) {
         // TODO: free the EXTI here?
-        mp_raise_msg_varg(&mp_type_MemoryError, translate("Failed to allocate RX buffer of %d bytes"),
-            maxlen * sizeof(uint16_t));
+        m_malloc_fail(maxlen * sizeof(uint16_t));
     }
 
     // Set internal variables
@@ -257,7 +256,7 @@ uint16_t common_hal_pulseio_pulsein_get_item(pulseio_pulsein_obj_t *self, int16_
     }
     if (index < 0 || index >= self->len) {
         stm_peripherals_exti_enable(self->pin->number);
-        mp_raise_IndexError_varg(translate("%q index out of range"), MP_QSTR_PulseIn);
+        mp_raise_IndexError_varg(translate("%q out of range"), MP_QSTR_index);
     }
     uint16_t value = self->buffer[(self->start + index) % self->maxlen];
     stm_peripherals_exti_enable(self->pin->number);

--- a/ports/stm/common-hal/pwmio/PWMOut.c
+++ b/ports/stm/common-hal/pwmio/PWMOut.c
@@ -279,16 +279,16 @@ void common_hal_pwmio_pwmout_set_frequency(pwmio_pwmout_obj_t *self, uint32_t fr
 
     // restart everything, adjusting for new speed
     if (HAL_TIM_PWM_Init(&self->handle) != HAL_OK) {
-        mp_raise_ValueError(translate("Could not re-init timer"));
+        mp_raise_RuntimeError(translate("timer re-init"));
     }
 
     self->chan_handle.Pulse = timer_get_internal_duty(self->duty_cycle, period);
 
     if (HAL_TIM_PWM_ConfigChannel(&self->handle, &self->chan_handle, self->channel) != HAL_OK) {
-        mp_raise_ValueError(translate("Could not re-init channel"));
+        mp_raise_RuntimeError(translate("channel re-init"));
     }
     if (HAL_TIM_PWM_Start(&self->handle, self->channel) != HAL_OK) {
-        mp_raise_ValueError(translate("Could not restart PWM"));
+        mp_raise_RuntimeError(translate("PWM restart"));
     }
 
     tim_frequencies[self->tim->tim_index] = frequency;

--- a/ports/stm/common-hal/sdioio/SDCard.c
+++ b/ports/stm/common-hal/sdioio/SDCard.c
@@ -115,7 +115,7 @@ STATIC int check_pins(sdioio_sdcard_obj_t *self,
     if (sdio_taken) {
         mp_raise_ValueError(translate("Hardware busy, try alternative pins"));
     } else {
-        mp_raise_ValueError_varg(translate("Invalid %q pin selection"), MP_QSTR_SDIO);
+        raise_ValueError_invalid_pin();
     }
 }
 

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -222,6 +222,14 @@ mp_uint_t mp_arg_validate_length(mp_uint_t length, mp_uint_t required_length, qs
     return length;
 }
 
+// int instead of uint because an index can be negative in some cases.
+mp_int_t mp_arg_validate_index_range(mp_int_t index, mp_int_t min, mp_int_t max, qstr arg_name) {
+    if (index < min || index > max) {
+        mp_raise_IndexError_varg(translate("%q out of range"), arg_name, min, max);
+    }
+    return index;
+}
+
 mp_obj_t mp_arg_validate_type(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name) {
     if (!mp_obj_is_type(obj, type)) {
         mp_raise_TypeError_varg(translate("%q must be of type %q"), arg_name, type->name);

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -156,6 +156,13 @@ NORETURN void mp_arg_error_unimpl_kw(void) {
 #endif
 
 
+mp_int_t mp_arg_validate_int(mp_int_t i, mp_int_t required_i, qstr arg_name) {
+    if (i != required_i) {
+        mp_raise_ValueError_varg(translate("%q must be %d"), arg_name, required_i);
+    }
+    return i;
+}
+
 mp_int_t mp_arg_validate_int_min(mp_int_t i, mp_int_t min, qstr arg_name) {
     if (i < min) {
         mp_raise_ValueError_varg(translate("%q must be >= %d"), arg_name, min);
@@ -194,6 +201,27 @@ mp_uint_t mp_arg_validate_length_range(mp_uint_t length, mp_uint_t min, mp_uint_
     return length;
 }
 
+mp_uint_t mp_arg_validate_length_min(mp_uint_t length, mp_uint_t min, qstr arg_name) {
+    if (length < min) {
+        mp_raise_ValueError_varg(translate("%q length must be >= %d"), arg_name, min);
+    }
+    return length;
+}
+
+mp_uint_t mp_arg_validate_length_max(mp_uint_t length, mp_uint_t max, qstr arg_name) {
+    if (length > max) {
+        mp_raise_ValueError_varg(translate("%q length must be <= %d"), arg_name, max);
+    }
+    return length;
+}
+
+mp_uint_t mp_arg_validate_length(mp_uint_t length, mp_uint_t required_length, qstr arg_name) {
+    if (length != required_length) {
+        mp_raise_ValueError_varg(translate("%q length must be %d"), arg_name, required_length);
+    }
+    return length;
+}
+
 mp_obj_t mp_arg_validate_type(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name) {
     if (!mp_obj_is_type(obj, type)) {
         mp_raise_TypeError_varg(translate("%q must be of type %q"), arg_name, type->name);
@@ -201,9 +229,21 @@ mp_obj_t mp_arg_validate_type(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_
     return obj;
 }
 
-mp_obj_t mp_arg_validate_string(mp_obj_t obj, qstr arg_name) {
+mp_obj_t mp_arg_validate_type_string(mp_obj_t obj, qstr arg_name) {
     if (!mp_obj_is_str(obj)) {
         mp_raise_TypeError_varg(translate("%q must be a string"), arg_name);
     }
     return obj;
+}
+
+mp_int_t mp_arg_validate_type_int(mp_obj_t obj, qstr arg_name) {
+    mp_int_t an_int;
+    if (!mp_obj_get_int_maybe(obj, &an_int)) {
+        mp_raise_TypeError_varg(translate("%q must be an int"), arg_name);
+    }
+    return an_int;
+}
+
+NORETURN void mp_arg_error_invalid(qstr arg_name) {
+    mp_raise_ValueError_varg(translate("Invalid %q"), arg_name);
 }

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -282,7 +282,7 @@ STATIC void evaluate_relative_import(mp_int_t level, const char **module_name, s
     #endif
 
     // If we have a __path__ in the globals dict, then we're a package.
-    bool is_pkg = mp_map_lookup(&mp_globals_get()->map, MP_OBJ_NEW_QSTR(MP_QSTR___path__), MP_MAP_LOOKUP);
+    bool is_pkg = mp_map_lookup(&mp_globals_get()->map, MP_OBJ_NEW_QSTR(MP_QSTR___path__), MP_MAP_LOOKUP) != NULL;
 
     #if DEBUG_PRINT
     DEBUG_printf("Current module/package: ");

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -104,6 +104,7 @@ mp_uint_t mp_arg_validate_length_min(mp_uint_t length, mp_uint_t min, qstr arg_n
 mp_uint_t mp_arg_validate_length_max(mp_uint_t length, mp_uint_t max, qstr arg_name);
 mp_uint_t mp_arg_validate_length_range(mp_uint_t length, mp_uint_t min, mp_uint_t max, qstr arg_name);
 mp_uint_t mp_arg_validate_length(mp_uint_t length, mp_uint_t required_length, qstr arg_name);
+mp_int_t mp_arg_validate_index_range(mp_int_t index, mp_int_t min, mp_int_t max, qstr arg_name);
 mp_obj_t mp_arg_validate_type(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name);
 mp_int_t mp_arg_validate_type_int(mp_obj_t obj, qstr arg_name);
 mp_obj_t mp_arg_validate_type_string(mp_obj_t obj, qstr arg_name);

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -92,15 +92,21 @@ void mp_arg_parse_all_kw_array(size_t n_pos, size_t n_kw, const mp_obj_t *args, 
 NORETURN void mp_arg_error_terse_mismatch(void);
 NORETURN void mp_arg_error_unimpl_kw(void);
 
+NORETURN void mp_arg_error_invalid(qstr arg_name);
+mp_int_t mp_arg_validate_int(mp_int_t i, mp_int_t required_i, qstr arg_name);
 mp_int_t mp_arg_validate_int_min(mp_int_t i, mp_int_t min, qstr arg_name);
 mp_int_t mp_arg_validate_int_max(mp_int_t i, mp_int_t j, qstr arg_name);
 mp_int_t mp_arg_validate_int_range(mp_int_t i, mp_int_t min, mp_int_t max, qstr arg_name);
 #if MICROPY_PY_BUILTINS_FLOAT
 mp_float_t mp_arg_validate_obj_float_non_negative(mp_obj_t float_in, mp_float_t default_for_null, qstr arg_name);
 #endif
+mp_uint_t mp_arg_validate_length_min(mp_uint_t length, mp_uint_t min, qstr arg_name);
+mp_uint_t mp_arg_validate_length_max(mp_uint_t length, mp_uint_t max, qstr arg_name);
 mp_uint_t mp_arg_validate_length_range(mp_uint_t length, mp_uint_t min, mp_uint_t max, qstr arg_name);
+mp_uint_t mp_arg_validate_length(mp_uint_t length, mp_uint_t required_length, qstr arg_name);
 mp_obj_t mp_arg_validate_type(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name);
-mp_obj_t mp_arg_validate_string(mp_obj_t obj, qstr arg_name);
+mp_int_t mp_arg_validate_type_int(mp_obj_t obj, qstr arg_name);
+mp_obj_t mp_arg_validate_type_string(mp_obj_t obj, qstr arg_name);
 
 static inline mp_obj_dict_t *PLACE_IN_ITCM(mp_locals_get)(void) {
     return MP_STATE_THREAD(dict_locals);

--- a/shared-bindings/_bleio/Address.c
+++ b/shared-bindings/_bleio/Address.c
@@ -69,7 +69,7 @@ STATIC mp_obj_t bleio_address_make_new(const mp_obj_type_t *type, size_t n_args,
 
     const mp_int_t address_type = args[ARG_address_type].u_int;
     if (address_type < BLEIO_ADDRESS_TYPE_MIN || address_type > BLEIO_ADDRESS_TYPE_MAX) {
-        mp_raise_ValueError(translate("Address type out of range"));
+        mp_arg_error_invalid(MP_QSTR_address_type);
     }
 
     common_hal_bleio_address_construct(self, buf_info.buf, address_type);

--- a/shared-bindings/_bleio/Characteristic.c
+++ b/shared-bindings/_bleio/Characteristic.c
@@ -100,7 +100,7 @@ STATIC mp_obj_t bleio_characteristic_add_to_service(size_t n_args, const mp_obj_
 
     const bleio_characteristic_properties_t properties = args[ARG_properties].u_int;
     if (properties & ~CHAR_PROP_ALL) {
-        mp_raise_ValueError(translate("Invalid properties"));
+        mp_arg_error_invalid(MP_QSTR_properties);
     }
 
     const bleio_attribute_security_mode_t read_perm = args[ARG_read_perm].u_int;
@@ -109,10 +109,8 @@ STATIC mp_obj_t bleio_characteristic_add_to_service(size_t n_args, const mp_obj_
     const bleio_attribute_security_mode_t write_perm = args[ARG_write_perm].u_int;
     common_hal_bleio_attribute_security_mode_check_valid(write_perm);
 
-    const mp_int_t max_length_int = args[ARG_max_length].u_int;
-    if (max_length_int < 0) {
-        mp_raise_ValueError(translate("max_length must be >= 0"));
-    }
+    const mp_int_t max_length_int = mp_arg_validate_int_min(args[ARG_max_length].u_int, 0, MP_QSTR_max_length);
+
     const size_t max_length = (size_t)max_length_int;
     const bool fixed_length = args[ARG_fixed_length].u_bool;
     mp_obj_t initial_value = args[ARG_initial_value].u_obj;

--- a/shared-bindings/_bleio/CharacteristicBuffer.c
+++ b/shared-bindings/_bleio/CharacteristicBuffer.c
@@ -70,15 +70,9 @@ STATIC mp_obj_t bleio_characteristic_buffer_make_new(const mp_obj_type_t *type, 
 
     bleio_characteristic_obj_t *characteristic = mp_arg_validate_type(args[ARG_characteristic].u_obj, &bleio_characteristic_type, MP_QSTR_characteristic);
 
-    mp_float_t timeout = mp_obj_get_float(args[ARG_timeout].u_obj);
-    if (timeout < 0.0f) {
-        mp_raise_ValueError(translate("timeout must be >= 0.0"));
-    }
+    mp_float_t timeout = mp_arg_validate_obj_float_non_negative(args[ARG_timeout].u_obj, 1.0f, MP_QSTR_timeout);
 
-    const int buffer_size = args[ARG_buffer_size].u_int;
-    if (buffer_size < 1) {
-        mp_raise_ValueError_varg(translate("%q must be >= 1"), MP_QSTR_buffer_size);
-    }
+    const mp_int_t buffer_size = mp_arg_validate_int_min(args[ARG_buffer_size].u_int, 1, MP_QSTR_buffer_size);
 
     bleio_characteristic_buffer_obj_t *self = m_new_obj(bleio_characteristic_buffer_obj_t);
     self->base.type = &bleio_characteristic_buffer_type;

--- a/shared-bindings/_bleio/Descriptor.c
+++ b/shared-bindings/_bleio/Descriptor.c
@@ -94,10 +94,8 @@ STATIC mp_obj_t bleio_descriptor_add_to_characteristic(size_t n_args, const mp_o
     const bleio_attribute_security_mode_t write_perm = args[ARG_write_perm].u_int;
     common_hal_bleio_attribute_security_mode_check_valid(write_perm);
 
-    const mp_int_t max_length_int = args[ARG_max_length].u_int;
-    if (max_length_int < 0) {
-        mp_raise_ValueError(translate("max_length must be >= 0"));
-    }
+    const mp_int_t max_length_int = mp_arg_validate_int_min(args[ARG_max_length].u_int, 0, MP_QSTR_max_length);
+
     const size_t max_length = (size_t)max_length_int;
     const bool fixed_length = args[ARG_fixed_length].u_bool;
     mp_obj_t initial_value = args[ARG_initial_value].u_obj;

--- a/shared-bindings/_bleio/PacketBuffer.c
+++ b/shared-bindings/_bleio/PacketBuffer.c
@@ -73,10 +73,7 @@ STATIC mp_obj_t bleio_packet_buffer_make_new(const mp_obj_type_t *type, size_t n
 
     bleio_characteristic_obj_t *characteristic = mp_arg_validate_type(args[ARG_characteristic].u_obj, &bleio_characteristic_type, MP_QSTR_characteristic);
 
-    const mp_int_t buffer_size = args[ARG_buffer_size].u_int;
-    if (buffer_size < 1) {
-        mp_raise_ValueError_varg(translate("%q must be >= 1"), MP_QSTR_buffer_size);
-    }
+    const mp_int_t buffer_size = mp_arg_validate_int_min(args[ARG_buffer_size].u_int, 1, MP_QSTR_buffer_size);
 
     size_t max_packet_size = common_hal_bleio_characteristic_get_max_length(characteristic);
     if (args[ARG_max_packet_size].u_obj != mp_const_none) {

--- a/shared-bindings/adafruit_pixelbuf/PixelBuf.c
+++ b/shared-bindings/adafruit_pixelbuf/PixelBuf.c
@@ -44,6 +44,10 @@
 #include "extmod/ulab/code/ndarray.h"
 #endif
 
+static NORETURN void invalid_byteorder(void) {
+    mp_arg_error_invalid(MP_QSTR_byteorder);
+}
+
 static void parse_byteorder(mp_obj_t byteorder_obj, pixelbuf_byteorder_details_t *parsed);
 
 //| class PixelBuf:
@@ -124,7 +128,7 @@ static void parse_byteorder(mp_obj_t byteorder_obj, pixelbuf_byteorder_details_t
     size_t bo_len;
     const char *byteorder = mp_obj_str_get_data(byteorder_obj, &bo_len);
     if (bo_len < 3 || bo_len > 4) {
-        mp_raise_ValueError(translate("Invalid byteorder string"));
+        invalid_byteorder();
     }
     parsed->order_string = byteorder_obj;
 
@@ -136,7 +140,7 @@ static void parse_byteorder(mp_obj_t byteorder_obj, pixelbuf_byteorder_details_t
     char *w = strchr(byteorder, 'W');
     int num_chars = (dotstar ? 1 : 0) + (w ? 1 : 0) + (r ? 1 : 0) + (g ? 1 : 0) + (b ? 1 : 0);
     if ((num_chars < parsed->bpp) || !(r && b && g)) {
-        mp_raise_ValueError(translate("Invalid byteorder string"));
+        invalid_byteorder();
     }
     parsed->is_dotstar = dotstar ? true : false;
     parsed->has_white = w ? true : false;
@@ -146,10 +150,10 @@ static void parse_byteorder(mp_obj_t byteorder_obj, pixelbuf_byteorder_details_t
     parsed->byteorder.w = w ? w - byteorder : 0;
     // The dotstar brightness byte is always first (as it goes with the pixel start bits)
     if (dotstar && byteorder[0] != 'P') {
-        mp_raise_ValueError(translate("Invalid byteorder string"));
+        invalid_byteorder();
     }
     if (parsed->has_white && parsed->is_dotstar) {
-        mp_raise_ValueError(translate("Invalid byteorder string"));
+        invalid_byteorder();
     }
 }
 

--- a/shared-bindings/aesio/aes.c
+++ b/shared-bindings/aesio/aes.c
@@ -63,15 +63,12 @@ STATIC mp_obj_t aesio_aes_make_new(const mp_obj_type_t *type, size_t n_args,
 
     const uint8_t *key = NULL;
     uint32_t key_length = 0;
-    if (mp_get_buffer(args[ARG_key].u_obj, &bufinfo, MP_BUFFER_READ)) {
-        if ((bufinfo.len != 16) && (bufinfo.len != 24) && (bufinfo.len != 32)) {
-            mp_raise_TypeError(translate("Key must be 16, 24, or 32 bytes long"));
-        }
-        key = bufinfo.buf;
-        key_length = bufinfo.len;
-    } else {
-        mp_raise_TypeError(translate("No key was specified"));
+    mp_get_buffer_raise(args[ARG_key].u_obj, &bufinfo, MP_BUFFER_READ);
+    if ((bufinfo.len != 16) && (bufinfo.len != 24) && (bufinfo.len != 32)) {
+        mp_raise_TypeError(translate("Key must be 16, 24, or 32 bytes long"));
     }
+    key = bufinfo.buf;
+    key_length = bufinfo.len;
 
     int mode = args[ARG_mode].u_int;
     switch (args[ARG_mode].u_int) {

--- a/shared-bindings/alarm/SleepMemory.c
+++ b/shared-bindings/alarm/SleepMemory.c
@@ -159,9 +159,8 @@ STATIC mp_obj_t alarm_sleep_memory_subscr(mp_obj_t self_in, mp_obj_t index_in, m
             } else {
                 // store
                 mp_int_t byte_value = mp_obj_get_int(value);
-                if (byte_value > 0xff || byte_value < 0) {
-                    mp_raise_ValueError(translate("Bytes must be between 0 and 255."));
-                }
+                mp_arg_validate_int_range(byte_value, 0, 255, MP_QSTR_bytes);
+
                 uint8_t short_value = byte_value;
                 if (!common_hal_alarm_sleep_memory_set_bytes(self, index, &short_value, 1)) {
                     mp_raise_RuntimeError(translate("Unable to write to sleep_memory."));

--- a/shared-bindings/analogio/AnalogOut.c
+++ b/shared-bindings/analogio/AnalogOut.c
@@ -108,10 +108,8 @@ STATIC mp_obj_t analogio_analogout_obj_set_value(mp_obj_t self_in, mp_obj_t valu
     if (common_hal_analogio_analogout_deinited(self)) {
         raise_deinited_error();
     }
-    uint32_t v = mp_obj_get_int(value);
-    if (v >= (1 << 16)) {
-        mp_raise_ValueError(translate("AnalogOut is only 16 bits. Value must be less than 65536."));
-    }
+    uint16_t v = mp_arg_validate_int_range(mp_obj_get_int(value), 0, 65535, MP_QSTR_value);
+
     common_hal_analogio_analogout_set_value(self, v);
     return mp_const_none;
 }

--- a/shared-bindings/audiomixer/Mixer.c
+++ b/shared-bindings/audiomixer/Mixer.c
@@ -91,19 +91,9 @@ STATIC mp_obj_t audiomixer_mixer_make_new(const mp_obj_type_t *type, size_t n_ar
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_int_t voice_count = args[ARG_voice_count].u_int;
-    if (voice_count < 1 || voice_count > 255) {
-        mp_raise_ValueError(translate("Invalid voice count"));
-    }
-
-    mp_int_t channel_count = args[ARG_channel_count].u_int;
-    if (channel_count < 1 || channel_count > 2) {
-        mp_raise_ValueError(translate("Invalid channel count"));
-    }
-    mp_int_t sample_rate = args[ARG_sample_rate].u_int;
-    if (sample_rate < 1) {
-        mp_raise_ValueError(translate("Sample rate must be positive"));
-    }
+    mp_int_t voice_count = mp_arg_validate_int_range(args[ARG_voice_count].u_int, 1, 255, MP_QSTR_voice_count);
+    mp_int_t channel_count = mp_arg_validate_int_range(args[ARG_channel_count].u_int, 1, 2, MP_QSTR_channel_count);
+    mp_int_t sample_rate = mp_arg_validate_int_min(args[ARG_sample_rate].u_int, 1, MP_QSTR_sample_rate);
     mp_int_t bits_per_sample = args[ARG_bits_per_sample].u_int;
     if (bits_per_sample != 8 && bits_per_sample != 16) {
         mp_raise_ValueError(translate("bits_per_sample must be 8 or 16"));
@@ -222,7 +212,7 @@ STATIC mp_obj_t audiomixer_mixer_obj_play(size_t n_args, const mp_obj_t *pos_arg
 
     uint8_t v = args[ARG_voice].u_int;
     if (v > (self->voice_count - 1)) {
-        mp_raise_ValueError(translate("Invalid voice"));
+        mp_arg_error_invalid(MP_QSTR_voice);
     }
     audiomixer_mixervoice_obj_t *voice = MP_OBJ_TO_PTR(self->voice[v]);
     mp_obj_t sample = args[ARG_sample].u_obj;
@@ -248,7 +238,7 @@ STATIC mp_obj_t audiomixer_mixer_obj_stop_voice(size_t n_args, const mp_obj_t *p
 
     uint8_t v = args[ARG_voice].u_int;
     if (v > (self->voice_count - 1)) {
-        mp_raise_ValueError(translate("Invalid voice"));
+        mp_arg_error_invalid(MP_QSTR_voice);
     }
     audiomixer_mixervoice_obj_t *voice = MP_OBJ_TO_PTR(self->voice[v]);
     common_hal_audiomixer_mixervoice_stop(voice);

--- a/shared-bindings/bitbangio/I2C.c
+++ b/shared-bindings/bitbangio/I2C.c
@@ -188,9 +188,7 @@ STATIC void readfrom(bitbangio_i2c_obj_t *self, mp_int_t address, mp_obj_t buffe
 
     size_t length = bufinfo.len;
     normalize_buffer_bounds(&start, end, &length);
-    if (length == 0) {
-        mp_raise_ValueError(translate("Buffer must be at least length 1"));
-    }
+    mp_arg_validate_length_min(length, 1, MP_QSTR_buffer);
 
     uint8_t status = shared_module_bitbangio_i2c_read(self, address, ((uint8_t *)bufinfo.buf) + start, length);
     if (status != 0) {

--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -156,18 +156,10 @@ STATIC mp_obj_t bitbangio_spi_configure(size_t n_args, const mp_obj_t *pos_args,
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    uint8_t polarity = args[ARG_polarity].u_int;
-    if (polarity != 0 && polarity != 1) {
-        mp_raise_ValueError(translate("Invalid polarity"));
-    }
-    uint8_t phase = args[ARG_phase].u_int;
-    if (phase != 0 && phase != 1) {
-        mp_raise_ValueError(translate("Invalid phase"));
-    }
-    uint8_t bits = args[ARG_bits].u_int;
-    if (bits != 8 && bits != 9) {
-        mp_raise_ValueError(translate("Invalid number of bits"));
-    }
+    uint8_t polarity = (uint8_t)mp_arg_validate_int_range(args[ARG_polarity].u_int, 0, 1, MP_QSTR_polarity);
+    uint8_t phase = (uint8_t)mp_arg_validate_int_range(args[ARG_phase].u_int, 0, 1, MP_QSTR_phase);
+    uint8_t bits = (uint8_t)mp_arg_validate_int_range(args[ARG_bits].u_int, 8, 9, MP_QSTR_bits);
+
 
     shared_module_bitbangio_spi_configure(self, args[ARG_baudrate].u_int, polarity, phase, bits);
     return mp_const_none;

--- a/shared-bindings/bitops/__init__.c
+++ b/shared-bindings/bitops/__init__.c
@@ -64,10 +64,7 @@ STATIC mp_obj_t bit_transpose(size_t n_args, const mp_obj_t *pos_args, mp_map_t 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    int width = args[ARG_width].u_int;
-    if (width < 2 || width > 8) {
-        mp_raise_ValueError_varg(translate("width must be from 2 to 8 (inclusive), not %d"), width);
-    }
+    mp_int_t width = mp_arg_validate_int_range(args[ARG_width].u_int, 2, 8, MP_QSTR_width);
 
     mp_buffer_info_t input_bufinfo;
     mp_get_buffer_raise(args[ARG_input].u_obj, &input_bufinfo, MP_BUFFER_READ);
@@ -80,9 +77,9 @@ STATIC mp_obj_t bit_transpose(size_t n_args, const mp_obj_t *pos_args, mp_map_t 
     mp_get_buffer_raise(args[ARG_output].u_obj, &output_bufinfo, MP_BUFFER_WRITE);
     int avail = output_bufinfo.len;
     int outlen = 8 * (inlen / width);
-    if (avail < outlen) {
-        mp_raise_ValueError_varg(translate("Output buffer must be at least %d bytes"), outlen);
-    }
+
+    mp_arg_validate_length_min(avail, outlen, MP_QSTR_output);
+
     common_hal_bitops_bit_transpose(output_bufinfo.buf, input_bufinfo.buf, inlen, width);
     return args[ARG_output].u_obj;
 }

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -210,9 +210,7 @@ STATIC mp_obj_t busio_i2c_readfrom_into(size_t n_args, const mp_obj_t *pos_args,
     int32_t start = args[ARG_start].u_int;
     const int32_t end = args[ARG_end].u_int;
     normalize_buffer_bounds(&start, end, &length);
-    if (length == 0) {
-        mp_raise_ValueError_varg(translate("%q length must be >= 1"), MP_QSTR_buffer);
-    }
+    mp_arg_validate_length_min(length, 1, MP_QSTR_buffer);
 
     uint8_t status =
         common_hal_busio_i2c_read(self, args[ARG_address].u_int, ((uint8_t *)bufinfo.buf) + start, length);

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -106,7 +106,7 @@ STATIC mp_obj_t busio_spi_make_new(const mp_obj_type_t *type, size_t n_args, siz
     common_hal_busio_spi_construct(self, clock, mosi, miso, args[ARG_half_duplex].u_bool);
     return MP_OBJ_FROM_PTR(self);
     #else
-    mp_raise_ValueError(translate("Invalid pins"));
+    raise_ValueError_invalid_pins();
     #endif // CIRCUITPY_BUSIO_SPI
 }
 
@@ -191,18 +191,9 @@ STATIC mp_obj_t busio_spi_configure(size_t n_args, const mp_obj_t *pos_args, mp_
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    uint8_t polarity = args[ARG_polarity].u_int;
-    if (polarity != 0 && polarity != 1) {
-        mp_raise_ValueError(translate("Invalid polarity"));
-    }
-    uint8_t phase = args[ARG_phase].u_int;
-    if (phase != 0 && phase != 1) {
-        mp_raise_ValueError(translate("Invalid phase"));
-    }
-    uint8_t bits = args[ARG_bits].u_int;
-    if (bits != 8 && bits != 9) {
-        mp_raise_ValueError(translate("Invalid number of bits"));
-    }
+    uint8_t polarity = (uint8_t)mp_arg_validate_int_range(args[ARG_polarity].u_int, 0, 1, MP_QSTR_polarity);
+    uint8_t phase = (uint8_t)mp_arg_validate_int_range(args[ARG_phase].u_int, 0, 1, MP_QSTR_phase);
+    uint8_t bits = (uint8_t)mp_arg_validate_int_range(args[ARG_bits].u_int, 8, 9, MP_QSTR_bits);
 
     if (!common_hal_busio_spi_configure(self, args[ARG_baudrate].u_int,
         polarity, phase, bits)) {

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -113,10 +113,7 @@ STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, si
         mp_raise_ValueError(translate("tx and rx cannot both be None"));
     }
 
-    if (args[ARG_bits].u_int < 5 || args[ARG_bits].u_int > 9) {
-        mp_raise_ValueError(translate("bits must be in range 5 to 9"));
-    }
-    uint8_t bits = args[ARG_bits].u_int;
+    uint8_t bits = (uint8_t)mp_arg_validate_int_range(args[ARG_bits].u_int, 5, 9, MP_QSTR_bits);
 
     busio_uart_parity_t parity = BUSIO_UART_PARITY_NONE;
     if (args[ARG_parity].u_obj == MP_OBJ_FROM_PTR(&busio_uart_parity_even_obj)) {
@@ -125,10 +122,7 @@ STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, si
         parity = BUSIO_UART_PARITY_ODD;
     }
 
-    uint8_t stop = args[ARG_stop].u_int;
-    if (stop != 1 && stop != 2) {
-        mp_raise_ValueError(translate("stop must be 1 or 2"));
-    }
+    uint8_t stop = (uint8_t)mp_arg_validate_int_range(args[ARG_stop].u_int, 1, 2, MP_QSTR_stop);
 
     mp_float_t timeout = mp_obj_get_float(args[ARG_timeout].u_obj);
     validate_timeout(timeout);

--- a/shared-bindings/canio/Message.c
+++ b/shared-bindings/canio/Message.c
@@ -57,9 +57,7 @@ STATIC mp_obj_t canio_message_make_new(const mp_obj_type_t *type, size_t n_args,
     mp_buffer_info_t data;
     mp_get_buffer_raise(args[ARG_data].u_obj, &data, MP_BUFFER_READ);
 
-    if (data.len > 8) {
-        mp_raise_ValueError(translate("Messages limited to 8 bytes"));
-    }
+    mp_arg_validate_length_range(data.len, 0, 8, MP_QSTR_data);
 
     canio_message_obj_t *self = m_new_obj(canio_message_obj_t);
     self->base.type = &canio_message_type;
@@ -100,9 +98,9 @@ STATIC mp_obj_t canio_message_data_set(const mp_obj_t self_in, const mp_obj_t da
     canio_message_obj_t *self = self_in;
     mp_buffer_info_t data;
     mp_get_buffer_raise(data_in, &data, MP_BUFFER_READ);
-    if (data.len > 8) {
-        mp_raise_ValueError(translate("Messages limited to 8 bytes"));
-    }
+
+    mp_arg_validate_length_range(data.len, 0, 8, MP_QSTR_data);
+
     common_hal_canio_message_set_data(self, data.buf, data.len);
     return mp_const_none;
 }

--- a/shared-bindings/digitalio/DigitalInOut.c
+++ b/shared-bindings/digitalio/DigitalInOut.c
@@ -207,7 +207,7 @@ STATIC mp_obj_t digitalio_digitalinout_obj_set_direction(mp_obj_t self_in, mp_ob
             mp_raise_NotImplementedError(translate("Pin is input only"));
         }
     } else {
-        mp_raise_ValueError(translate("Invalid direction."));
+        mp_arg_error_invalid(MP_QSTR_direction);
     }
     return mp_const_none;
 }

--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -89,14 +89,8 @@ STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_
     displayio_fourwire_obj_t *self = &allocate_display_bus_or_raise()->fourwire_bus;
     self->base.type = &displayio_fourwire_type;
 
-    uint8_t polarity = args[ARG_polarity].u_int;
-    if (polarity != 0 && polarity != 1) {
-        mp_raise_ValueError(translate("Invalid polarity"));
-    }
-    uint8_t phase = args[ARG_phase].u_int;
-    if (phase != 0 && phase != 1) {
-        mp_raise_ValueError(translate("Invalid phase"));
-    }
+    uint8_t polarity = (uint8_t)mp_arg_validate_int_range(args[ARG_polarity].u_int, 0, 1, MP_QSTR_polarity);
+    uint8_t phase = (uint8_t)mp_arg_validate_int_range(args[ARG_phase].u_int, 0, 1, MP_QSTR_phase);
 
     common_hal_displayio_fourwire_construct(self,
         MP_OBJ_TO_PTR(spi), command, chip_select, reset, args[ARG_baudrate].u_int, polarity, phase);
@@ -133,10 +127,8 @@ STATIC mp_obj_t displayio_fourwire_obj_send(size_t n_args, const mp_obj_t *pos_a
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_int_t command_int = args[ARG_command].u_int;
-    if (command_int > 255 || command_int < 0) {
-        mp_raise_ValueError(translate("Command must be an int between 0 and 255"));
-    }
+    mp_int_t command_int = mp_arg_validate_int_range(args[ARG_command].u_int, 0, 255, MP_QSTR_command);
+
     displayio_fourwire_obj_t *self = pos_args[0];
     uint8_t command = command_int;
     mp_buffer_info_t bufinfo;

--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -57,10 +57,7 @@ STATIC mp_obj_t displayio_group_make_new(const mp_obj_type_t *type, size_t n_arg
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_int_t scale = args[ARG_scale].u_int;
-    if (scale < 1) {
-        mp_raise_ValueError_varg(translate("%q must be >= 1"), MP_QSTR_scale);
-    }
+    mp_int_t scale = mp_arg_validate_int_min(args[ARG_scale].u_int, 1, MP_QSTR_scale);
 
     displayio_group_t *self = m_new_obj(displayio_group_t);
     self->base.type = &displayio_group_type;
@@ -114,10 +111,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(displayio_group_get_scale_obj, displayio_group_obj_get
 STATIC mp_obj_t displayio_group_obj_set_scale(mp_obj_t self_in, mp_obj_t scale_obj) {
     displayio_group_t *self = native_group(self_in);
 
-    mp_int_t scale = mp_obj_get_int(scale_obj);
-    if (scale < 1) {
-        mp_raise_ValueError_varg(translate("%q must be >= 1"), MP_QSTR_scale);
-    }
+    mp_int_t scale = mp_arg_validate_int_min(mp_obj_get_int(scale_obj), 1, MP_QSTR_scale);
+
     common_hal_displayio_group_set_scale(self, scale);
     return mp_const_none;
 }

--- a/shared-bindings/displayio/I2CDisplay.c
+++ b/shared-bindings/displayio/I2CDisplay.c
@@ -98,10 +98,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(displayio_i2cdisplay_reset_obj, displayio_i2cdisplay_o
 //|         ...
 //|
 STATIC mp_obj_t displayio_i2cdisplay_obj_send(mp_obj_t self, mp_obj_t command_obj, mp_obj_t data_obj) {
-    mp_int_t command_int = MP_OBJ_SMALL_INT_VALUE(command_obj);
-    if (!mp_obj_is_small_int(command_obj) || command_int > 255 || command_int < 0) {
-        mp_raise_ValueError(translate("Command must be an int between 0 and 255"));
-    }
+    mp_int_t command_int = mp_obj_get_int(command_obj);
+    mp_arg_validate_int_range(command_int, 0, 255, MP_QSTR_command);
+
     uint8_t command = command_int;
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(data_obj, &bufinfo, MP_BUFFER_READ);

--- a/shared-bindings/displayio/Shape.c
+++ b/shared-bindings/displayio/Shape.c
@@ -58,14 +58,8 @@ STATIC mp_obj_t displayio_shape_make_new(const mp_obj_type_t *type, size_t n_arg
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_int_t width = args[ARG_width].u_int;
-    if (width < 1) {
-        mp_raise_ValueError_varg(translate("%q must be >= 1"), MP_QSTR_width);
-    }
-    mp_int_t height = args[ARG_height].u_int;
-    if (height < 1) {
-        mp_raise_ValueError_varg(translate("%q must be >= 1"), MP_QSTR_height);
-    }
+    mp_int_t width = mp_arg_validate_int_min(args[ARG_width].u_int, 1, MP_QSTR_width);
+    mp_int_t height = mp_arg_validate_int_min(args[ARG_height].u_int, 1, MP_QSTR_height);
 
     displayio_shape_t *self = m_new_obj(displayio_shape_t);
     self->base.type = &displayio_shape_type;

--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -464,9 +464,8 @@ STATIC mp_obj_t tilegrid_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t v
             return MP_OBJ_NULL; // op not supported
         } else {
             mp_int_t value = mp_obj_get_int(value_obj);
-            if (value < 0 || value > 255) {
-                mp_raise_ValueError(translate("Tile value out of bounds"));
-            }
+            mp_arg_validate_int_range(value, 0, 255, MP_QSTR_tile);
+
             common_hal_displayio_tilegrid_set_tile(self, x, y, value);
         }
     }

--- a/shared-bindings/fontio/BuiltinFont.c
+++ b/shared-bindings/fontio/BuiltinFont.c
@@ -98,10 +98,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(fontio_builtinfont_get_bounding_box_obj, fontio_builti
 STATIC mp_obj_t fontio_builtinfont_obj_get_glyph(mp_obj_t self_in, mp_obj_t codepoint_obj) {
     fontio_builtinfont_t *self = MP_OBJ_TO_PTR(self_in);
 
-    mp_int_t codepoint;
-    if (!mp_obj_get_int_maybe(codepoint_obj, &codepoint)) {
-        mp_raise_ValueError_varg(translate("%q should be an int"), MP_QSTR_codepoint);
-    }
+    mp_int_t codepoint = mp_arg_validate_type_int(codepoint_obj, MP_QSTR_codepoint);
     return common_hal_fontio_builtinfont_get_glyph(self, codepoint);
 }
 MP_DEFINE_CONST_FUN_OBJ_2(fontio_builtinfont_get_glyph_obj, fontio_builtinfont_obj_get_glyph);

--- a/shared-bindings/memorymonitor/AllocationAlarm.c
+++ b/shared-bindings/memorymonitor/AllocationAlarm.c
@@ -63,10 +63,10 @@ STATIC mp_obj_t memorymonitor_allocationalarm_make_new(const mp_obj_type_t *type
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    mp_int_t minimum_block_count = args[ARG_minimum_block_count].u_int;
-    if (minimum_block_count < 1) {
-        mp_raise_ValueError_varg(translate("%q must be >= 1"), MP_QSTR_minimum_block_count);
-    }
+
+    mp_int_t minimum_block_count =
+        mp_arg_validate_int_min(args[ARG_minimum_block_count].u_int, 1, MP_QSTR_minimum_block_count);
+
 
     memorymonitor_allocationalarm_obj_t *self = m_new_obj(memorymonitor_allocationalarm_obj_t);
     self->base.type = &memorymonitor_allocationalarm_type;
@@ -90,9 +90,8 @@ STATIC mp_obj_t memorymonitor_allocationalarm_make_new(const mp_obj_type_t *type
 //|
 STATIC mp_obj_t memorymonitor_allocationalarm_obj_ignore(mp_obj_t self_in, mp_obj_t count_obj) {
     mp_int_t count = mp_obj_get_int(count_obj);
-    if (count < 0) {
-        mp_raise_ValueError_varg(translate("%q must be >= 0"), MP_QSTR_count);
-    }
+    mp_arg_validate_int_min(count, 0, MP_QSTR_count);
+
     common_hal_memorymonitor_allocationalarm_set_ignore(self_in, count);
     return self_in;
 }

--- a/shared-bindings/microcontroller/Pin.c
+++ b/shared-bindings/microcontroller/Pin.c
@@ -194,3 +194,11 @@ void validate_pins(qstr what, uint8_t *pin_nos, mp_int_t max_pins, mp_obj_t seq,
         pin_nos[i] = common_hal_mcu_pin_number(pins[i]);
     }
 }
+
+NORETURN void raise_ValueError_invalid_pin(void) {
+    mp_arg_error_invalid(MP_QSTR_pin);
+}
+
+NORETURN void raise_ValueError_invalid_pins(void) {
+    mp_arg_error_invalid(MP_QSTR_pins);
+}

--- a/shared-bindings/microcontroller/Pin.c
+++ b/shared-bindings/microcontroller/Pin.c
@@ -202,3 +202,7 @@ NORETURN void raise_ValueError_invalid_pin(void) {
 NORETURN void raise_ValueError_invalid_pins(void) {
     mp_arg_error_invalid(MP_QSTR_pins);
 }
+
+NORETURN void raise_ValueError_invalid_pin_name(qstr pin_name) {
+    mp_raise_ValueError_varg(translate("Invalid %q pin"), pin_name);
+}

--- a/shared-bindings/microcontroller/Pin.h
+++ b/shared-bindings/microcontroller/Pin.h
@@ -41,6 +41,8 @@ void validate_no_duplicate_pins(mp_obj_t seq, qstr arg_name);
 void validate_no_duplicate_pins_2(mp_obj_t seq1, mp_obj_t seq2, qstr arg_name1, qstr arg_name2);
 void validate_list_is_free_pins(qstr what, const mcu_pin_obj_t **pins_out, mp_int_t max_pins, mp_obj_t seq, uint8_t *count_out);
 void validate_pins(qstr what, uint8_t *pin_nos, mp_int_t max_pins, mp_obj_t seq, uint8_t *count_out);
+NORETURN void raise_ValueError_invalid_pin(void);
+NORETURN void raise_ValueError_invalid_pins(void);
 
 void assert_pin_free(const mcu_pin_obj_t *pin);
 

--- a/shared-bindings/microcontroller/Pin.h
+++ b/shared-bindings/microcontroller/Pin.h
@@ -43,6 +43,7 @@ void validate_list_is_free_pins(qstr what, const mcu_pin_obj_t **pins_out, mp_in
 void validate_pins(qstr what, uint8_t *pin_nos, mp_int_t max_pins, mp_obj_t seq, uint8_t *count_out);
 NORETURN void raise_ValueError_invalid_pin(void);
 NORETURN void raise_ValueError_invalid_pins(void);
+NORETURN void raise_ValueError_invalid_pin_name(qstr pin_name);
 
 void assert_pin_free(const mcu_pin_obj_t *pin);
 

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -119,7 +119,7 @@ STATIC mp_obj_t mcu_on_next_reset(mp_obj_t run_mode_obj) {
     } else if (run_mode_obj == MP_OBJ_FROM_PTR(&mcu_runmode_bootloader_obj)) {
         run_mode = RUNMODE_BOOTLOADER;
     } else {
-        mp_raise_ValueError(translate("Invalid run mode."));
+        mp_arg_error_invalid(MP_QSTR_run_mode);
     }
     common_hal_mcu_on_next_reset(run_mode);
     return mp_const_none;

--- a/shared-bindings/msgpack/ExtType.c
+++ b/shared-bindings/msgpack/ExtType.c
@@ -47,10 +47,8 @@ STATIC mp_obj_t mod_msgpack_exttype_make_new(const mp_obj_type_t *type, size_t n
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    int code = args[ARG_code].u_int;
-    if (code < 0 || code > 127) {
-        mp_raise_AttributeError(translate("code outside range 0~127"));
-    }
+    int code = mp_arg_validate_int_range(args[ARG_code].u_int, 0, 127, MP_QSTR_code);
+
     self->code = code;
 
     mp_obj_t data = args[ARG_data].u_obj;

--- a/shared-bindings/nvm/ByteArray.c
+++ b/shared-bindings/nvm/ByteArray.c
@@ -153,9 +153,8 @@ STATIC mp_obj_t nvm_bytearray_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj
             } else {
                 // store
                 mp_int_t byte_value = mp_obj_get_int(value);
-                if (byte_value > 0xff || byte_value < 0) {
-                    mp_raise_ValueError(translate("Bytes must be between 0 and 255."));
-                }
+                mp_arg_validate_int_range(byte_value, 0, 255, MP_QSTR_bytes);
+
                 uint8_t short_value = byte_value;
                 if (!common_hal_nvm_bytearray_set_bytes(self, index, &short_value, 1)) {
                     mp_raise_RuntimeError(translate("Unable to write to nvm."));

--- a/shared-bindings/paralleldisplay/ParallelBus.c
+++ b/shared-bindings/paralleldisplay/ParallelBus.c
@@ -126,10 +126,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(paralleldisplay_parallelbus_reset_obj, paralleldisplay
 //|         ...
 //|
 STATIC mp_obj_t paralleldisplay_parallelbus_obj_send(mp_obj_t self, mp_obj_t command_obj, mp_obj_t data_obj) {
-    mp_int_t command_int = MP_OBJ_SMALL_INT_VALUE(command_obj);
-    if (!mp_obj_is_small_int(command_obj) || command_int > 255 || command_int < 0) {
-        mp_raise_ValueError(translate("Command must be an int between 0 and 255"));
-    }
+    mp_int_t command_int = mp_arg_validate_int_range(mp_obj_get_int(command_obj), 0, 255, MP_QSTR_command);
+
     uint8_t command = command_int;
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(data_obj, &bufinfo, MP_BUFFER_READ);

--- a/shared-bindings/ps2io/Ps2.c
+++ b/shared-bindings/ps2io/Ps2.c
@@ -68,21 +68,21 @@
 //|         ...
 //|
 STATIC mp_obj_t ps2io_ps2_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    enum { ARG_datapin, ARG_clkpin };
+    enum { ARG_data_pin, ARG_clock_pin };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_datapin, MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_clkpin, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_data_pin, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_clock_pin, MP_ARG_REQUIRED | MP_ARG_OBJ },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *clkpin = validate_obj_is_free_pin(args[ARG_clkpin].u_obj);
-    const mcu_pin_obj_t *datapin = validate_obj_is_free_pin(args[ARG_datapin].u_obj);
+    const mcu_pin_obj_t *clock_pin = validate_obj_is_free_pin(args[ARG_clock_pin].u_obj);
+    const mcu_pin_obj_t *data_pin = validate_obj_is_free_pin(args[ARG_data_pin].u_obj);
 
     ps2io_ps2_obj_t *self = m_new_obj(ps2io_ps2_obj_t);
     self->base.type = &ps2io_ps2_type;
 
-    common_hal_ps2io_ps2_construct(self, datapin, clkpin);
+    common_hal_ps2io_ps2_construct(self, data_pin, clock_pin);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/ps2io/Ps2.h
+++ b/shared-bindings/ps2io/Ps2.h
@@ -34,7 +34,7 @@
 extern const mp_obj_type_t ps2io_ps2_type;
 
 extern void common_hal_ps2io_ps2_construct(ps2io_ps2_obj_t *self,
-    const mcu_pin_obj_t *data_pin, const mcu_pin_obj_t *clk_pin);
+    const mcu_pin_obj_t *data_pin, const mcu_pin_obj_t *clock_pin);
 extern void common_hal_ps2io_ps2_deinit(ps2io_ps2_obj_t *self);
 extern bool common_hal_ps2io_ps2_deinited(ps2io_ps2_obj_t *self);
 extern uint16_t common_hal_ps2io_ps2_get_len(ps2io_ps2_obj_t *self);

--- a/shared-bindings/pwmio/PWMOut.c
+++ b/shared-bindings/pwmio/PWMOut.c
@@ -41,10 +41,10 @@ void common_hal_pwmio_pwmout_raise_error(pwmout_result_t result) {
         case PWMOUT_OK:
             break;
         case PWMOUT_INVALID_PIN:
-            mp_raise_ValueError(translate("Invalid pin"));
+            raise_ValueError_invalid_pin();
             break;
         case PWMOUT_INVALID_FREQUENCY:
-            mp_raise_ValueError(translate("Invalid PWM frequency"));
+            mp_arg_error_invalid(MP_QSTR_frequency);
             break;
         case PWMOUT_INVALID_FREQUENCY_ON_PIN:
             mp_raise_ValueError(translate("Frequency must match existing PWMOut using this timer"));
@@ -212,9 +212,9 @@ STATIC mp_obj_t pwmio_pwmout_obj_set_duty_cycle(mp_obj_t self_in, mp_obj_t duty_
     pwmio_pwmout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
     mp_int_t duty = mp_obj_get_int(duty_cycle);
-    if (duty < 0 || duty > 0xffff) {
-        mp_raise_ValueError(translate("PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"));
-    }
+
+    mp_arg_validate_int_range(duty, 0, 0xffff, MP_QSTR_duty_cycle);
+
     common_hal_pwmio_pwmout_set_duty_cycle(self, duty);
     return mp_const_none;
 }
@@ -251,7 +251,7 @@ STATIC mp_obj_t pwmio_pwmout_obj_set_frequency(mp_obj_t self_in, mp_obj_t freque
     }
     mp_int_t freq = mp_obj_get_int(frequency);
     if (freq == 0) {
-        mp_raise_ValueError(translate("Invalid PWM frequency"));
+        mp_arg_error_invalid(MP_QSTR_frequency);
     }
     common_hal_pwmio_pwmout_set_frequency(self, freq);
     return mp_const_none;

--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -207,11 +207,7 @@ STATIC mp_obj_t rgbmatrix_rgbmatrix_make_new(const mp_obj_type_t *type, size_t n
     uint8_t clock_pin = validate_pin(args[ARG_clock_pin].u_obj);
     uint8_t latch_pin = validate_pin(args[ARG_latch_pin].u_obj);
     uint8_t output_enable_pin = validate_pin(args[ARG_output_enable_pin].u_obj);
-    int bit_depth = args[ARG_bit_depth].u_int;
-
-    if (bit_depth <= 0 || bit_depth > 6) {
-        mp_raise_ValueError_varg(translate("Bit depth must be from 1 to 6 inclusive, not %d"), bit_depth);
-    }
+    mp_int_t bit_depth = mp_arg_validate_int_range(args[ARG_bit_depth].u_int, 1, 6, MP_QSTR_bit_depth);
 
     validate_pins(MP_QSTR_rgb_pins, rgb_pins, MP_ARRAY_SIZE(self->rgb_pins), args[ARG_rgb_list].u_obj, &rgb_count);
     validate_pins(MP_QSTR_addr_pins, addr_pins, MP_ARRAY_SIZE(self->addr_pins), args[ARG_addr_list].u_obj, &addr_count);
@@ -220,12 +216,7 @@ STATIC mp_obj_t rgbmatrix_rgbmatrix_make_new(const mp_obj_type_t *type, size_t n
         mp_raise_ValueError_varg(translate("Must use a multiple of 6 rgb pins, not %d"), rgb_count);
     }
 
-    int tile = args[ARG_tile].u_int;
-
-    if (tile <= 0) {
-        mp_raise_ValueError_varg(
-            translate("tile must be greater than zero"));
-    }
+    int tile = mp_arg_validate_int_min(args[ARG_tile].u_int, 1, MP_QSTR_tile);
 
     int computed_height = (rgb_count / 3) * (1 << (addr_count)) * tile;
     if (args[ARG_height].u_int != 0) {
@@ -235,21 +226,18 @@ STATIC mp_obj_t rgbmatrix_rgbmatrix_make_new(const mp_obj_type_t *type, size_t n
         }
     }
 
-    if (args[ARG_width].u_int <= 0) {
-        mp_raise_ValueError(translate("width must be greater than zero"));
-    }
+    mp_int_t width = mp_arg_validate_int_min(args[ARG_width].u_int, 1, MP_QSTR_width);
 
     preflight_pins_or_throw(clock_pin, rgb_pins, rgb_count, true);
 
     mp_obj_t framebuffer = args[ARG_framebuffer].u_obj;
     if (framebuffer == mp_const_none) {
-        int width = args[ARG_width].u_int;
         int bufsize = 2 * width * computed_height;
         framebuffer = mp_obj_new_bytearray_of_zeros(bufsize);
     }
 
     common_hal_rgbmatrix_rgbmatrix_construct(self,
-        args[ARG_width].u_int,
+        width,
         bit_depth,
         rgb_count, rgb_pins,
         addr_count, addr_pins,

--- a/shared-bindings/sdioio/SDCard.c
+++ b/shared-bindings/sdioio/SDCard.c
@@ -129,14 +129,10 @@ STATIC mp_obj_t sdioio_sdcard_configure(size_t n_args, const mp_obj_t *pos_args,
     MP_STATIC_ASSERT(MP_ARRAY_SIZE(allowed_args) == NUM_ARGS);
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_int_t frequency = args[ARG_frequency].u_int;
-    if (frequency < 0) {
-        mp_raise_ValueError_varg(translate("Invalid %q"), MP_QSTR_baudrate);
-    }
-
+    mp_int_t frequency = mp_arg_validate_int_min(args[ARG_frequency].u_int, 0, MP_QSTR_frequency);
     uint8_t width = args[ARG_width].u_int;
     if (width != 0 && width != 1 && width != 4) {
-        mp_raise_ValueError_varg(translate("Invalid %q"), MP_QSTR_width);
+        mp_arg_error_invalid(MP_QSTR_width);
     }
 
     if (!common_hal_sdioio_sdcard_configure(self, frequency, width)) {

--- a/shared-bindings/sdioio/SDCard.c
+++ b/shared-bindings/sdioio/SDCard.c
@@ -129,7 +129,7 @@ STATIC mp_obj_t sdioio_sdcard_configure(size_t n_args, const mp_obj_t *pos_args,
     MP_STATIC_ASSERT(MP_ARRAY_SIZE(allowed_args) == NUM_ARGS);
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_int_t frequency = mp_arg_validate_int_min(args[ARG_frequency].u_int, 0, MP_QSTR_frequency);
+    mp_int_t frequency = mp_arg_validate_int_min(args[ARG_frequency].u_int, 1, MP_QSTR_frequency);
     uint8_t width = args[ARG_width].u_int;
     if (width != 0 && width != 1 && width != 4) {
         mp_arg_error_invalid(MP_QSTR_width);

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -106,9 +106,8 @@ MP_DEFINE_CONST_FUN_OBJ_0(supervisor_reload_obj, supervisor_reload);
 STATIC mp_obj_t supervisor_set_next_stack_limit(mp_obj_t size_obj) {
     mp_int_t size = mp_obj_get_int(size_obj);
 
-    if (size < 256) {
-        mp_raise_ValueError(translate("Stack size must be at least 256"));
-    }
+    mp_arg_validate_int_min(size, 256, MP_QSTR_size);
+
     set_next_stack_size(size);
 
     return mp_const_none;

--- a/shared-bindings/synthio/__init__.c
+++ b/shared-bindings/synthio/__init__.c
@@ -82,7 +82,7 @@ STATIC mp_obj_t synthio_from_file(size_t n_args, const mp_obj_t *pos_args, mp_ma
     }
     if (bytes_read != sizeof(chunk_header) ||
         memcmp(chunk_header, "MThd\0\0\0\6\0\0\0\1", 12)) {
-        mp_raise_ValueError(translate("Invalid MIDI file"));
+        mp_arg_error_invalid(MP_QSTR_file);
         // TODO: for a multi-track MIDI (type 1), return an AudioMixer
     }
 
@@ -97,7 +97,7 @@ STATIC mp_obj_t synthio_from_file(size_t n_args, const mp_obj_t *pos_args, mp_ma
         mp_raise_OSError(MP_EIO);
     }
     if (bytes_read != 8 || memcmp(chunk_header, "MTrk", 4)) {
-        mp_raise_ValueError(translate("Invalid MIDI file"));
+        mp_arg_error_invalid(MP_QSTR_file);
     }
     uint32_t track_size = (chunk_header[4] << 24) |
         (chunk_header[5] << 16) | (chunk_header[6] << 8) | chunk_header[7];
@@ -106,7 +106,7 @@ STATIC mp_obj_t synthio_from_file(size_t n_args, const mp_obj_t *pos_args, mp_ma
         mp_raise_OSError(MP_EIO);
     }
     if (bytes_read != track_size) {
-        mp_raise_ValueError(translate("Invalid MIDI file"));
+        mp_arg_error_invalid(MP_QSTR_file);
     }
 
     synthio_miditrack_obj_t *result = m_new_obj(synthio_miditrack_obj_t);

--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -114,10 +114,8 @@ STATIC mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type, size_t n_args
     mp_obj_t in_report_lengths = args[ARG_in_report_lengths].u_obj;
     mp_obj_t out_report_lengths = args[ARG_out_report_lengths].u_obj;
 
-    size_t report_ids_count = (size_t)MP_OBJ_SMALL_INT_VALUE(mp_obj_len(report_ids));
-    if (report_ids_count < 1) {
-        mp_raise_ValueError_varg(translate("%q length must be >= 1"), MP_QSTR_report_ids);
-    }
+    size_t report_ids_count =
+        mp_arg_validate_length_min((size_t)MP_OBJ_SMALL_INT_VALUE(mp_obj_len(report_ids)), 1, MP_QSTR_report_ids);
 
     if ((size_t)MP_OBJ_SMALL_INT_VALUE(mp_obj_len(in_report_lengths)) != report_ids_count ||
         (size_t)MP_OBJ_SMALL_INT_VALUE(mp_obj_len(out_report_lengths)) != report_ids_count) {
@@ -158,7 +156,7 @@ STATIC mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type, size_t n_args
 }
 
 
-//|     def send_report(self, buf: ReadableBuffer, report_id: Optional[int] = None) -> None:
+//|     def send_report(self, report: ReadableBuffer, report_id: Optional[int] = None) -> None:
 //|         """Send an HID report. If the device descriptor specifies zero or one report id's,
 //|         you can supply `None` (the default) as the value of ``report_id``.
 //|         Otherwise you must specify which report id to use when sending the report.
@@ -168,9 +166,9 @@ STATIC mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type, size_t n_args
 STATIC mp_obj_t usb_hid_device_send_report(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     usb_hid_device_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
-    enum { ARG_buf, ARG_report_id };
+    enum { ARG_report, ARG_report_id };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_buf, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_report, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_report_id, MP_ARG_OBJ, {.u_obj = mp_const_none} },
     };
 
@@ -178,7 +176,7 @@ STATIC mp_obj_t usb_hid_device_send_report(size_t n_args, const mp_obj_t *pos_ar
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args[ARG_buf].u_obj, &bufinfo, MP_BUFFER_READ);
+    mp_get_buffer_raise(args[ARG_report].u_obj, &bufinfo, MP_BUFFER_READ);
 
     // -1 asks common_hal to determine the report id if possible.
     mp_int_t report_id_arg = -1;

--- a/shared-bindings/wifi/Monitor.c
+++ b/shared-bindings/wifi/Monitor.c
@@ -55,19 +55,14 @@ STATIC mp_obj_t wifi_monitor_make_new(const mp_obj_type_t *type, size_t n_args, 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    if (args[ARG_channel].u_int < 1 || args[ARG_channel].u_int > 13) {
-        mp_raise_ValueError_varg(translate("%q out of bounds"), MP_QSTR_channel);
-    }
-
-    if (args[ARG_queue].u_int < 0) {
-        mp_raise_ValueError_varg(translate("%q out of bounds"), MP_QSTR_channel);
-    }
+    mp_int_t channel = mp_arg_validate_int_range(args[ARG_channel].u_int, 1, 13, MP_QSTR_channel);
+    mp_int_t queue = mp_arg_validate_int_min(args[ARG_queue].u_int, 0, MP_QSTR_queue);
 
     wifi_monitor_obj_t *self = MP_STATE_VM(wifi_monitor_singleton);
     if (common_hal_wifi_monitor_deinited()) {
         self = m_new_obj(wifi_monitor_obj_t);
         self->base.type = &wifi_monitor_type;
-        common_hal_wifi_monitor_construct(self, args[ARG_channel].u_int, args[ARG_queue].u_int);
+        common_hal_wifi_monitor_construct(self, channel, queue);
         MP_STATE_VM(wifi_monitor_singleton) = self;
     }
 

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -87,9 +87,7 @@ STATIC mp_obj_t wifi_radio_set_hostname(mp_obj_t self_in, mp_obj_t hostname_in) 
     mp_buffer_info_t hostname;
     mp_get_buffer_raise(hostname_in, &hostname, MP_BUFFER_READ);
 
-    if (hostname.len < 1 || hostname.len > 253) {
-        mp_raise_ValueError(translate("Hostname must be between 1 and 253 characters"));
-    }
+    mp_arg_validate_length_range(hostname.len, 1, 253, MP_QSTR_hostname);
 
     #ifndef CONFIG_IDF_TARGET_ESP32C3
     regex_t regex; // validate hostname according to RFC 1123
@@ -269,9 +267,7 @@ STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_
             authmode = (1 << AUTHMODE_WPA) | (1 << AUTHMODE_WPA2) | (1 << AUTHMODE_PSK);
         }
         mp_get_buffer_raise(args[ARG_password].u_obj, &password, MP_BUFFER_READ);
-        if (password.len > 0 && (password.len < 8 || password.len > 63)) {
-            mp_raise_ValueError(translate("WiFi password must be between 8 and 63 characters"));
-        }
+        mp_arg_validate_length_range(password.len, 8, 63, MP_QSTR_password);
     } else {
         authmode = 1;
     }
@@ -342,9 +338,7 @@ STATIC mp_obj_t wifi_radio_connect(size_t n_args, const mp_obj_t *pos_args, mp_m
     password.len = 0;
     if (args[ARG_password].u_obj != MP_OBJ_NULL) {
         mp_get_buffer_raise(args[ARG_password].u_obj, &password, MP_BUFFER_READ);
-        if (password.len > 0 && (password.len < 8 || password.len > 63)) {
-            mp_raise_ValueError(translate("WiFi password must be between 8 and 63 characters"));
-        }
+        mp_arg_validate_length_range(password.len, 8, 63, MP_QSTR_password);
     }
 
     #define MAC_ADDRESS_LENGTH 6

--- a/shared-module/_bleio/Attribute.c
+++ b/shared-module/_bleio/Attribute.c
@@ -40,7 +40,7 @@ void common_hal_bleio_attribute_security_mode_check_valid(bleio_attribute_securi
         case SECURITY_MODE_SIGNED_WITH_MITM:
             break;
         default:
-            mp_raise_ValueError(translate("Invalid security_mode"));
+            mp_arg_error_invalid(MP_QSTR_security_mode);
             break;
     }
 }

--- a/shared-module/adafruit_pixelbuf/PixelBuf.c
+++ b/shared-module/adafruit_pixelbuf/PixelBuf.c
@@ -171,9 +171,7 @@ STATIC void _pixelbuf_parse_color(pixelbuf_pixelbuf_obj_t *self, mp_obj_t color,
         mp_obj_t *items;
         size_t len;
         mp_obj_get_array(color, &len, &items);
-        if (len < 3 || len > 4) {
-            mp_raise_ValueError_varg(translate("Expected tuple of length %d, got %d"), byteorder->bpp, len);
-        }
+        mp_arg_validate_length_range(len, 3, 4, MP_QSTR_color);
 
         *r = _pixelbuf_get_as_uint8(items[PIXEL_R]);
         *g = _pixelbuf_get_as_uint8(items[PIXEL_G]);

--- a/shared-module/audiocore/WaveFile.c
+++ b/shared-module/audiocore/WaveFile.c
@@ -60,7 +60,7 @@ void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t *self,
     if (bytes_read != 16 ||
         memcmp(chunk_header, "RIFF", 4) != 0 ||
         memcmp(chunk_header + 8, "WAVEfmt ", 8) != 0) {
-        mp_raise_ValueError(translate("Invalid wave file"));
+        mp_arg_error_invalid(MP_QSTR_file);
     }
     uint32_t format_size;
     if (f_read(&self->file->fp, &format_size, 4, &bytes_read) != FR_OK) {
@@ -105,7 +105,7 @@ void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t *self,
         mp_raise_OSError(MP_EIO);
     }
     if (bytes_read != 4) {
-        mp_raise_ValueError(translate("Invalid file"));
+        mp_arg_error_invalid(MP_QSTR_file);
     }
     self->file_length = data_length;
     self->data_start = self->file->fp.fptr;
@@ -121,15 +121,13 @@ void common_hal_audioio_wavefile_construct(audioio_wavefile_obj_t *self,
         self->buffer = m_malloc(self->len, false);
         if (self->buffer == NULL) {
             common_hal_audioio_wavefile_deinit(self);
-            mp_raise_msg(&mp_type_MemoryError,
-                translate("Couldn't allocate first buffer"));
+            m_malloc_fail(self->len);
         }
 
         self->second_buffer = m_malloc(self->len, false);
         if (self->second_buffer == NULL) {
             common_hal_audioio_wavefile_deinit(self);
-            mp_raise_msg(&mp_type_MemoryError,
-                translate("Couldn't allocate second buffer"));
+            m_malloc_fail(self->len);
         }
     }
 }

--- a/shared-module/audiomixer/Mixer.c
+++ b/shared-module/audiomixer/Mixer.c
@@ -47,13 +47,13 @@ void common_hal_audiomixer_mixer_construct(audiomixer_mixer_obj_t *self,
     self->first_buffer = m_malloc(self->len, false);
     if (self->first_buffer == NULL) {
         common_hal_audiomixer_mixer_deinit(self);
-        mp_raise_msg(&mp_type_MemoryError, translate("Couldn't allocate first buffer"));
+        m_malloc_fail(self->len);
     }
 
     self->second_buffer = m_malloc(self->len, false);
     if (self->second_buffer == NULL) {
         common_hal_audiomixer_mixer_deinit(self);
-        mp_raise_msg(&mp_type_MemoryError, translate("Couldn't allocate second buffer"));
+        m_malloc_fail(self->len);
     }
 
     self->bits_per_sample = bits_per_sample;

--- a/shared-module/audiomp3/MP3Decoder.c
+++ b/shared-module/audiomp3/MP3Decoder.c
@@ -193,8 +193,7 @@ void common_hal_audiomp3_mp3file_construct(audiomp3_mp3file_obj_t *self,
     self->inbuf = m_malloc(self->inbuf_length, false);
     if (self->inbuf == NULL) {
         common_hal_audiomp3_mp3file_deinit(self);
-        mp_raise_msg(&mp_type_MemoryError,
-            translate("Couldn't allocate input buffer"));
+        m_malloc_fail(self->inbuf_length);
     }
     self->decoder = MP3InitDecoder();
     if (self->decoder == NULL) {
@@ -214,15 +213,13 @@ void common_hal_audiomp3_mp3file_construct(audiomp3_mp3file_obj_t *self,
         self->buffers[0] = m_malloc(MAX_BUFFER_LEN, false);
         if (self->buffers[0] == NULL) {
             common_hal_audiomp3_mp3file_deinit(self);
-            mp_raise_msg(&mp_type_MemoryError,
-                translate("Couldn't allocate first buffer"));
+            m_malloc_fail(MAX_BUFFER_LEN);
         }
 
         self->buffers[1] = m_malloc(MAX_BUFFER_LEN, false);
         if (self->buffers[1] == NULL) {
             common_hal_audiomp3_mp3file_deinit(self);
-            mp_raise_msg(&mp_type_MemoryError,
-                translate("Couldn't allocate second buffer"));
+            m_malloc_fail(MAX_BUFFER_LEN);
         }
     }
 

--- a/shared-module/bitbangio/SPI.c
+++ b/shared-module/bitbangio/SPI.c
@@ -123,7 +123,7 @@ void shared_module_bitbangio_spi_unlock(bitbangio_spi_obj_t *self) {
 // Writes out the given data.
 bool shared_module_bitbangio_spi_write(bitbangio_spi_obj_t *self, const uint8_t *data, size_t len) {
     if (len > 0 && !self->has_mosi) {
-        mp_raise_ValueError(translate("Cannot write without MOSI pin"));
+        mp_raise_ValueError(translate("No MOSI pin"));
     }
     uint32_t delay_half = self->delay_half;
 
@@ -178,7 +178,7 @@ bool shared_module_bitbangio_spi_write(bitbangio_spi_obj_t *self, const uint8_t 
 // Reads in len bytes while outputting zeroes.
 bool shared_module_bitbangio_spi_read(bitbangio_spi_obj_t *self, uint8_t *data, size_t len, uint8_t write_data) {
     if (len > 0 && !self->has_miso) {
-        mp_raise_ValueError(translate("Cannot read without MISO pin"));
+        mp_raise_ValueError(translate("No MISO pin"));
     }
 
     uint32_t delay_half = self->delay_half;

--- a/shared-module/bitbangio/SPI.c
+++ b/shared-module/bitbangio/SPI.c
@@ -41,7 +41,7 @@ void shared_module_bitbangio_spi_construct(bitbangio_spi_obj_t *self,
     const mcu_pin_obj_t *miso) {
     digitalinout_result_t result = common_hal_digitalio_digitalinout_construct(&self->clock, clock);
     if (result != DIGITALINOUT_OK) {
-        mp_raise_ValueError(translate("Clock pin init failed."));
+        mp_raise_ValueError_varg(translate("%q init failed"), MP_QSTR_clock);
     }
     common_hal_digitalio_digitalinout_switch_to_output(&self->clock, self->polarity == 1, DRIVE_MODE_PUSH_PULL);
 
@@ -49,7 +49,7 @@ void shared_module_bitbangio_spi_construct(bitbangio_spi_obj_t *self,
         result = common_hal_digitalio_digitalinout_construct(&self->mosi, mosi);
         if (result != DIGITALINOUT_OK) {
             common_hal_digitalio_digitalinout_deinit(&self->clock);
-            mp_raise_ValueError(translate("MOSI pin init failed."));
+            mp_raise_ValueError_varg(translate("%q init failed"), MP_QSTR_mosi);
         }
         self->has_mosi = true;
         common_hal_digitalio_digitalinout_switch_to_output(&self->mosi, false, DRIVE_MODE_PUSH_PULL);
@@ -63,7 +63,7 @@ void shared_module_bitbangio_spi_construct(bitbangio_spi_obj_t *self,
             if (mosi != NULL) {
                 common_hal_digitalio_digitalinout_deinit(&self->mosi);
             }
-            mp_raise_ValueError(translate("MISO pin init failed."));
+            mp_raise_ValueError_varg(translate("%q init failed"), MP_QSTR_miso);
         }
         self->has_miso = true;
     }
@@ -123,7 +123,7 @@ void shared_module_bitbangio_spi_unlock(bitbangio_spi_obj_t *self) {
 // Writes out the given data.
 bool shared_module_bitbangio_spi_write(bitbangio_spi_obj_t *self, const uint8_t *data, size_t len) {
     if (len > 0 && !self->has_mosi) {
-        mp_raise_ValueError(translate("Cannot write without MOSI pin."));
+        mp_raise_ValueError(translate("Cannot write without MOSI pin"));
     }
     uint32_t delay_half = self->delay_half;
 
@@ -178,7 +178,7 @@ bool shared_module_bitbangio_spi_write(bitbangio_spi_obj_t *self, const uint8_t 
 // Reads in len bytes while outputting zeroes.
 bool shared_module_bitbangio_spi_read(bitbangio_spi_obj_t *self, uint8_t *data, size_t len, uint8_t write_data) {
     if (len > 0 && !self->has_miso) {
-        mp_raise_ValueError(translate("Cannot read without MISO pin."));
+        mp_raise_ValueError(translate("Cannot read without MISO pin"));
     }
 
     uint32_t delay_half = self->delay_half;
@@ -246,7 +246,7 @@ bool shared_module_bitbangio_spi_read(bitbangio_spi_obj_t *self, uint8_t *data, 
 // transfer
 bool shared_module_bitbangio_spi_transfer(bitbangio_spi_obj_t *self, const uint8_t *dout, uint8_t *din, size_t len) {
     if (len > 0 && (!self->has_mosi || !self->has_miso)) {
-        mp_raise_ValueError(translate("Cannot transfer without MOSI and MISO pins."));
+        mp_raise_ValueError(translate("Cannot transfer without MOSI and MISO pins"));
     }
     uint32_t delay_half = self->delay_half;
 

--- a/shared-module/displayio/Group.c
+++ b/shared-module/displayio/Group.c
@@ -268,7 +268,7 @@ static void _add_layer(displayio_group_t *self, mp_obj_t layer) {
     if (native_layer != MP_OBJ_NULL) {
         displayio_tilegrid_t *tilegrid = native_layer;
         if (tilegrid->in_group) {
-            mp_raise_ValueError(translate("Layer already in a group."));
+            mp_raise_ValueError(translate("Layer already in a group"));
         } else {
             tilegrid->in_group = true;
         }
@@ -281,7 +281,7 @@ static void _add_layer(displayio_group_t *self, mp_obj_t layer) {
     if (native_layer != MP_OBJ_NULL) {
         displayio_group_t *group = native_layer;
         if (group->in_group) {
-            mp_raise_ValueError(translate("Layer already in a group."));
+            mp_raise_ValueError(translate("Layer already in a group"));
         } else {
             group->in_group = true;
         }
@@ -290,7 +290,7 @@ static void _add_layer(displayio_group_t *self, mp_obj_t layer) {
             group, self->hidden || self->hidden_by_parent);
         return;
     }
-    mp_raise_ValueError(translate("Layer must be a Group or TileGrid subclass."));
+    mp_raise_ValueError(translate("Layer must be a Group or TileGrid subclass"));
 }
 
 static void _remove_layer(displayio_group_t *self, size_t index) {

--- a/shared-module/displayio/OnDiskBitmap.c
+++ b/shared-module/displayio/OnDiskBitmap.c
@@ -50,7 +50,7 @@ void common_hal_displayio_ondiskbitmap_construct(displayio_ondiskbitmap_t *self,
     }
     if (bytes_read != 138 ||
         memcmp(bmp_header, "BM", 2) != 0) {
-        mp_raise_ValueError(translate("Invalid BMP file"));
+        mp_arg_error_invalid(MP_QSTR_file);
     }
 
     // We can't cast because we're not aligned.

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -83,9 +83,8 @@ void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebu
 
     self->framebuffer_protocol->get_bufinfo(self->framebuffer, &self->bufinfo);
     size_t framebuffer_size = self->first_pixel_offset + self->row_stride * self->core.height;
-    if (self->bufinfo.len < framebuffer_size) {
-        mp_raise_IndexError_varg(translate("Framebuffer requires %d bytes"), framebuffer_size);
-    }
+
+    mp_arg_validate_length_min(self->bufinfo.len, framebuffer_size, MP_QSTR_framebuffer);
 
     self->first_manual_refresh = !auto_refresh;
 

--- a/shared-module/rgbmatrix/RGBMatrix.c
+++ b/shared-module/rgbmatrix/RGBMatrix.c
@@ -117,10 +117,10 @@ void common_hal_rgbmatrix_rgbmatrix_reconstruct(rgbmatrix_rgbmatrix_obj_t *self,
         common_hal_rgbmatrix_rgbmatrix_deinit(self);
         switch (stat) {
             case PROTOMATTER_ERR_PINS:
-                mp_raise_ValueError(translate("Invalid pin"));
+                raise_ValueError_invalid_pin();
                 break;
             case PROTOMATTER_ERR_ARG:
-                mp_raise_ValueError(translate("Invalid argument"));
+                mp_arg_error_invalid(MP_QSTR_args);
                 break;
             case PROTOMATTER_ERR_MALLOC:
                 mp_raise_msg(&mp_type_MemoryError, NULL);

--- a/shared-module/vectorio/Circle.c
+++ b/shared-module/vectorio/Circle.c
@@ -15,7 +15,7 @@ void common_hal_vectorio_circle_construct(vectorio_circle_t *self, uint16_t radi
 
 void common_hal_vectorio_circle_set_on_dirty(vectorio_circle_t *self, vectorio_event_t on_dirty) {
     if (self->on_dirty.obj != NULL) {
-        mp_raise_TypeError(translate("circle can only be registered in one parent"));
+        mp_raise_TypeError(translate("can only have one parent"));
     }
     self->on_dirty = on_dirty;
 }

--- a/shared-module/vectorio/Polygon.c
+++ b/shared-module/vectorio/Polygon.c
@@ -40,9 +40,8 @@ static void _clobber_points_list(vectorio_polygon_t *self, mp_obj_t points_tuple
         mp_obj_t *tuple_items;
         mp_obj_tuple_get(items[i], &tuple_len, &tuple_items);
 
-        if (tuple_len != 2) {
-            mp_raise_ValueError_varg(translate("%q must be a tuple of length 2"), MP_QSTR_point);
-        }
+        mp_arg_validate_length(tuple_len, 2, MP_QSTR_point);
+
         mp_int_t x;
         mp_int_t y;
         if (!mp_obj_get_int_maybe(tuple_items[ 0 ], &x)
@@ -103,7 +102,7 @@ void common_hal_vectorio_polygon_set_points(vectorio_polygon_t *self, mp_obj_t p
 
 void common_hal_vectorio_polygon_set_on_dirty(vectorio_polygon_t *self, vectorio_event_t notification) {
     if (self->on_dirty.obj != NULL) {
-        mp_raise_TypeError(translate("polygon can only be registered in one parent"));
+        mp_raise_TypeError(translate("can only have one parent"));
     }
     self->on_dirty = notification;
 }

--- a/shared-module/vectorio/Rectangle.c
+++ b/shared-module/vectorio/Rectangle.c
@@ -14,7 +14,7 @@ void common_hal_vectorio_rectangle_construct(vectorio_rectangle_t *self, uint32_
 
 void common_hal_vectorio_rectangle_set_on_dirty(vectorio_rectangle_t *self, vectorio_event_t on_dirty) {
     if (self->on_dirty.obj != NULL) {
-        mp_raise_TypeError(translate("can only be registered in one parent"));
+        mp_raise_TypeError(translate("can only have one parent"));
     }
     self->on_dirty = on_dirty;
 }

--- a/shared-module/vectorio/VectorShape.c
+++ b/shared-module/vectorio/VectorShape.c
@@ -63,9 +63,7 @@
     (u32 & 0x1        ? '1' : '0')
 
 static void short_bound_check(mp_int_t i, qstr name) {
-    if (i < SHRT_MIN || i > SHRT_MAX) {
-        mp_raise_ValueError_varg(translate("%q must be between %d and %d"), name, SHRT_MIN, SHRT_MAX);
-    }
+    mp_arg_validate_int_range(i, SHRT_MIN, SHRT_MAX, name);
 }
 
 inline __attribute__((always_inline))
@@ -277,9 +275,7 @@ void common_hal_vectorio_vector_shape_set_location(vectorio_vector_shape_t *self
     size_t tuple_len = 0;
     mp_obj_t *tuple_items;
     mp_obj_tuple_get(xy, &tuple_len, &tuple_items);
-    if (tuple_len != 2) {
-        mp_raise_TypeError(translate("(x,y) integers required"));
-    }
+    mp_arg_validate_length(tuple_len, 2, MP_QSTR_location);
 
     mp_int_t x;
     mp_int_t y;


### PR DESCRIPTION
Closes #6392.

To reduce firmware size, this PR uses argument validators where possible and consolidates and simplifies various error messages.

- I went through all the `mp_raise` calls, and used validators from `argcheck.c` to simplify the validation. A few new validators were added, building on #4891.
- Added `mp_arg_error_invalid(qstr)`, which raises `ValueError` with the message `"Invalid %q"`. This is useful many places, where there were previously more specialized but not necessarily more informative messages. Then also added `raise_ValueError_invalid_pin()` and `raise_ValueError_invalid_pins()`, which refactor `mp_arg_error_invalid(MP_QSTR_pin)` and `mp_arg_error_invalid(MP_QSTR_pins)`, both of which are very common (a couple dozen uses each).
- `extmod/vfs_fat.c`: refactor multiple identical calls to `mp_raise_OSError()`
- `ps2io`: regularize using `clock*` instead of `clk*`, to make argument names and internal names more consistent.
- Shorten some `mp_raise_NotImplementedError()`
- Used `%q` args to refactor and share some messages.
- Use `m_malloc_fail()` instead of more chatty specialized messages which were not necessarily more helpful. Thanks @tannewt for pointing this routine out.
- `PixelBuf.c`: refactor some identical error messages to reduce code size.

I did not try to squeeze the last drop out of various `_bleio` messages, since we are not short on code space in those builds, and the savings would be minimal.

Some initially measured byte savings (current savings are a few bytes more than this due to further changes):

| Board | Savings in bytes |
| --- | --- |
| Trinket M0 | 316 |
| Metro M0 | 424 |
| CPX | 420 |
| Metro M4 | 1420 |
| Feather nRF52840 | 924 |
| Feather RP2040 | 4524 |
| Feather STM32F405 | 3948 |
| Metro ESP32-S2 | 4176 |
| Feather i.MX 1062 | 5632 |

I think some of the larger differences here are because some builds are not using LTO.

The number of distinct messages in `circuitpython.pot` went from 1061 to 989.
