### PR TITLE
Fix a minor namespace issue in the countio example

### DIFF
--- a/shared-bindings/countio/Counter.c
+++ b/shared-bindings/countio/Counter.c
@@ -30,7 +30,7 @@
 //|             import countio
 //|
 //|             # Count rising edges only.
-//|             pin_counter = countio.Counter(board.D1, edge=Edge.RISE)
+//|             pin_counter = countio.Counter(board.D1, edge=countio.Edge.RISE)
 //|             # Reset the count after 100 counts.
 //|             while True:
 //|                 if pin_counter.count >= 100:


### PR DESCRIPTION
I noticed a tiny error in the example code for using the `countio` module where the `RISE` constant wasn't be referenced properly, based on the way `countio` was being imported.