### PR TITLE
Teensy Builds retain Filesystem

### DIFF
--- a/ports/mimxrt10xx/boards/sparkfun_teensy_micromod/flash_config.c
+++ b/ports/mimxrt10xx/boards/sparkfun_teensy_micromod/flash_config.c
@@ -15,7 +15,7 @@ __attribute__((section(".boot_hdr.ivt")))
  *  IVT Data
  *************************************/
 const ivt image_vector_table = {
-    IVT_HEADER,                       /* IVT Header */
+    0x432000D1,                       /* Teensy bootloader looks for this value*/
     IMAGE_ENTRY_ADDRESS,              /* Image Entry Function */
     IVT_RSVD,                         /* Reserved = 0 */
     (uint32_t)DCD_ADDRESS,            /* Address where DCD information is stored */
@@ -25,13 +25,15 @@ const ivt image_vector_table = {
     IVT_RSVD                          /* Reserved = 0 */
 };
 
+extern unsigned long _flashimagelen;
+
 __attribute__((section(".boot_hdr.boot_data")))
 /*************************************
  *  Boot Data
  *************************************/
 const BOOT_DATA_T boot_data = {
     FLASH_BASE,               /* boot start location */
-    FLASH_SIZE,               /* size */
+    (uint32_t)&_flashimagelen, /* actual size of image */
     PLUGIN_FLAG,              /* Plugin flag*/
     0xFFFFFFFF                /* empty - extra data word */
 };

--- a/ports/mimxrt10xx/boards/teensy40/flash_config.c
+++ b/ports/mimxrt10xx/boards/teensy40/flash_config.c
@@ -15,7 +15,7 @@ __attribute__((section(".boot_hdr.ivt")))
  *  IVT Data
  *************************************/
 const ivt image_vector_table = {
-    IVT_HEADER,                       /* IVT Header */
+    0x432000D1,                       /* Teensy bootloader looks for this value*/
     IMAGE_ENTRY_ADDRESS,              /* Image Entry Function */
     IVT_RSVD,                         /* Reserved = 0 */
     (uint32_t)DCD_ADDRESS,            /* Address where DCD information is stored */
@@ -25,13 +25,15 @@ const ivt image_vector_table = {
     IVT_RSVD                          /* Reserved = 0 */
 };
 
+extern unsigned long _flashimagelen;
+
 __attribute__((section(".boot_hdr.boot_data")))
 /*************************************
  *  Boot Data
  *************************************/
 const BOOT_DATA_T boot_data = {
     FLASH_BASE,               /* boot start location */
-    FLASH_SIZE,               /* size */
+    (uint32_t)&_flashimagelen, /* actual size of image */
     PLUGIN_FLAG,              /* Plugin flag*/
     0xFFFFFFFF                /* empty - extra data word */
 };

--- a/ports/mimxrt10xx/boards/teensy41/flash_config.c
+++ b/ports/mimxrt10xx/boards/teensy41/flash_config.c
@@ -15,7 +15,7 @@ __attribute__((section(".boot_hdr.ivt")))
  *  IVT Data
  *************************************/
 const ivt image_vector_table = {
-    IVT_HEADER,                       /* IVT Header */
+    0x432000D1,                       /* Teensy bootloader looks for this value*/
     IMAGE_ENTRY_ADDRESS,              /* Image Entry Function */
     IVT_RSVD,                         /* Reserved = 0 */
     (uint32_t)DCD_ADDRESS,            /* Address where DCD information is stored */
@@ -25,13 +25,15 @@ const ivt image_vector_table = {
     IVT_RSVD                          /* Reserved = 0 */
 };
 
+extern unsigned long _flashimagelen;
+
 __attribute__((section(".boot_hdr.boot_data")))
 /*************************************
  *  Boot Data
  *************************************/
 const BOOT_DATA_T boot_data = {
     FLASH_BASE,               /* boot start location */
-    FLASH_SIZE,               /* size */
+    (uint32_t)&_flashimagelen, /* actual size of image */
     PLUGIN_FLAG,              /* Plugin flag*/
     0xFFFFFFFF                /* empty - extra data word */
 };

--- a/ports/mimxrt10xx/linking/common.ld
+++ b/ports/mimxrt10xx/linking/common.ld
@@ -74,7 +74,6 @@ SECTIONS
         _etext = .;        /* define a global symbol at end of code */
         __etext = .;       /* define a global symbol at end of code */
     } > FLASH_FIRMWARE
-
     _ld_filesystem_start = ORIGIN(FLASH_FATFS);
     _ld_filesystem_end = _ld_filesystem_start + LENGTH(FLASH_FATFS);
 
@@ -126,6 +125,8 @@ SECTIONS
     _ld_dtcm_data_destination = ADDR(.dtcm_data);
     _ld_dtcm_data_flash_copy = LOADADDR(.dtcm_data);
     _ld_dtcm_data_size = SIZEOF(.dtcm_data);
+
+    _flashimagelen = _ld_dtcm_data_flash_copy + _ld_dtcm_data_size - flash_config_location;
 
     .dtcm_bss :
     {


### PR DESCRIPTION
As mentioned in the issue #6309,  The newer Teensy boot loader can retain a file system that is stored in the flash memory as long as it is not in the area that is automatically erased. 

Some of this is described on the web page: https://www.pjrc.com/teensy/td_code_security.html

But to do this, the bootloader code looks at specific things in the uploaded data to determine if it will retain any data or not and how much.

The two things I fixed was the Loader is looking for the value:  0x432000D1 at 0x60001000, it was 0x412000D1 

And the bootloader needs to know the flash size bootdata length.  And the build was simply filling in the whole flash size... like 8MB on Teensy4.1.  So it now captures that data in the .ld file and uses it to generate that section.

So far I have done some rudimentary testing of reprogramming it a couple of times and it retained the python script that was on the chip.

Resolves #6309
