### PR TITLE
Analog in scaling fix for #4794

### DIFF
--- a/ports/atmel-samd/common-hal/analogio/AnalogIn.c
+++ b/ports/atmel-samd/common-hal/analogio/AnalogIn.c
@@ -123,8 +123,8 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     adc_sync_read_channel(&adc, self->channel, ((uint8_t *)&value), 2);
 
     adc_sync_deinit(&adc);
-    // Shift the value to be 16 bit.
-    return value << 4;
+    // Stretch 12-bit ADC reading to 16-bit range
+    return (value << 4) | (value >> 8);
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {

--- a/ports/mimxrt10xx/common-hal/analogio/AnalogIn.c
+++ b/ports/mimxrt10xx/common-hal/analogio/AnalogIn.c
@@ -81,8 +81,10 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
 
     }
 
-    // Stretch 12-bit ADC reading to 16 bits via 24-bit interim result
-    return (ADC_GetChannelConversionValue(self->pin->adc, ADC_CHANNEL_GROUP) * 0x1001) >> 8;
+    uint16_t value = ADC_GetChannelConversionValue(self->pin->adc, ADC_CHANNEL_GROUP);
+
+    // Stretch 12-bit ADC reading to 16-bit range
+    return (value << 4) | (value >> 8);
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {

--- a/ports/mimxrt10xx/common-hal/analogio/AnalogIn.c
+++ b/ports/mimxrt10xx/common-hal/analogio/AnalogIn.c
@@ -81,8 +81,8 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
 
     }
 
-    // Shift the value to be 16 bit
-    return ADC_GetChannelConversionValue(self->pin->adc, ADC_CHANNEL_GROUP) << 4;
+    // Stretch 12-bit ADC reading to 16 bits via 24-bit interim result
+    return (ADC_GetChannelConversionValue(self->pin->adc, ADC_CHANNEL_GROUP) * 0x1001) >> 8;
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {

--- a/ports/nrf/common-hal/analogio/AnalogIn.c
+++ b/ports/nrf/common-hal/analogio/AnalogIn.c
@@ -125,8 +125,8 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
         value = 0;
     }
 
-    // Map value to from 14 to 16 bits
-    return value << 2;
+    // Stretch 14-bit ADC reading to 16-bit range
+    return (value << 2) | (value >> 12);
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {

--- a/ports/raspberrypi/common-hal/analogio/AnalogIn.c
+++ b/ports/raspberrypi/common-hal/analogio/AnalogIn.c
@@ -65,8 +65,8 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     adc_select_input(self->pin->number - ADC_FIRST_PIN_NUMBER);
     uint16_t value = adc_read();
 
-    // Map value to from 12 to 16 bits
-    return value << 4;
+    // Stretch 12-bit ADC reading to 16-bit range
+    return (value << 4) | (value >> 8);
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {

--- a/ports/stm/common-hal/analogio/AnalogIn.c
+++ b/ports/stm/common-hal/analogio/AnalogIn.c
@@ -204,8 +204,8 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     uint16_t value = (uint16_t)HAL_ADC_GetValue(&AdcHandle);
     HAL_ADC_Stop(&AdcHandle);
 
-    // // Shift the value to be 16 bit.
-    return value << 4;
+    // Stretch 12-bit ADC reading to 16-bit range
+    return (value << 4) | (value >> 8);
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {


### PR DESCRIPTION
This was discussed for possible inclusion in 7.0 but didn’t happen there. See #4794. Breaking change. Heard an 8.0 might begin soon, so here’s code.

Summary: subtly changes behavior of analog reading on most ports so the result spans the full range from 0 to 65535. As of 7.X, it appears that cxd56 and espressif already do this, but all other ports return a max of 65520 due to a simplified left-shift operation.