### PR TITLE
Remove busio.OneWire and bitbangio.OneWire in favor of onewireio.OneWire

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -45,12 +45,10 @@ shared-bindings/audiomp3/__init__.rst shared-bindings/audiomp3/
 shared-bindings/audiopwmio/PWMAudioOut.rst shared-bindings/audiopwmio/#audiopwmio.PWMAudioOut
 shared-bindings/audiopwmio/__init__.rst shared-bindings/audiopwmio/
 shared-bindings/bitbangio/I2C.rst shared-bindings/bitbangio/#bitbangio.I2C
-shared-bindings/bitbangio/OneWire.rst shared-bindings/bitbangio/#bitbangio.OneWire
 shared-bindings/bitbangio/SPI.rst shared-bindings/bitbangio/#bitbangio.SPI
 shared-bindings/bitbangio/__init__.rst shared-bindings/bitbangio/
 shared-bindings/board/__init__.rst shared-bindings/board/
 shared-bindings/busio/I2C.rst shared-bindings/busio/#busio.I2C
-shared-bindings/busio/OneWire.rst shared-bindings/busio/#busio.OneWire
 shared-bindings/busio/Parity.rst shared-bindings/busio/#busio.Parity
 shared-bindings/busio/SPI.rst shared-bindings/busio/#busio.SPI
 shared-bindings/busio/UART.rst shared-bindings/busio/#busio.UART
@@ -101,6 +99,7 @@ shared-bindings/neopixel_write/__init__.rst shared-bindings/neopixel_write/
 shared-bindings/network/__init__.rst shared-bindings/network/
 shared-bindings/nvm/ByteArray.rst shared-bindings/nvm/#nvm.ByteArray
 shared-bindings/nvm/__init__.rst shared-bindings/nvm/
+shared-bindings/onewireio/OneWire.rst shared-bindings/onewireio/#onewireio.OneWire
 shared-bindings/os/__init__.rst shared-bindings/os/
 shared-bindings/protomatter/__init__.rst shared-bindings/protomatter/
 shared-bindings/ps2io/Ps2.rst shared-bindings/ps2io/#ps2io.Ps2

--- a/ports/atmel-samd/tools/gen_pin_name_table.py
+++ b/ports/atmel-samd/tools/gen_pin_name_table.py
@@ -164,11 +164,10 @@ capabilities = {
         "AnalogOut": ["PA02"],
     },
     "audioio": {"AudioOut": ["PA02"]},
-    "bitbangio": {"I2C": ALL_BUT_USB, "OneWire": ALL_BUT_USB, "SPI": ALL_BUT_USB},
+    "bitbangio": {"I2C": ALL_BUT_USB, "SPI": ALL_BUT_USB},
     "busio": {
         "I2C - SDA": ["PA00", "PB08", "PA08", "PA12", "PA16", "PA22", "PB02"],  # SERCOM pad 0
         "I2C - SCL": ["PA01", "PB09", "PA09", "PA13", "PA17", "PA23", "PB03"],  # SERCOM pad 1
-        "OneWire": ALL_BUT_USB,
         "SPI - MISO": [
             "PA00",
             "PA01",
@@ -299,6 +298,7 @@ capabilities = {
         ],  # pad 0 or 2
     },
     "digitalio": {"DigitalInOut": ALL_BUT_USB},
+    "onewireio": {"OneWire": ALL_BUT_USB},
     "pulseio": {
         "PulseIn": ALL_BUT_USB,
         "PWMOut": [

--- a/shared-bindings/bitbangio/__init__.c
+++ b/shared-bindings/bitbangio/__init__.c
@@ -34,7 +34,6 @@
 
 #include "shared-bindings/bitbangio/__init__.h"
 #include "shared-bindings/bitbangio/I2C.h"
-#include "shared-bindings/onewireio/OneWire.h"
 #include "shared-bindings/bitbangio/SPI.h"
 
 #include "py/runtime.h"
@@ -72,9 +71,6 @@
 STATIC const mp_rom_map_elem_t bitbangio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_bitbangio) },
     { MP_ROM_QSTR(MP_QSTR_I2C),   MP_ROM_PTR(&bitbangio_i2c_type) },
-    #if CIRCUITPY_ONEWIREIO
-    { MP_ROM_QSTR(MP_QSTR_OneWire),   MP_ROM_PTR(&onewireio_onewire_type) },
-    #endif
     { MP_ROM_QSTR(MP_QSTR_SPI),   MP_ROM_PTR(&bitbangio_spi_type) },
 };
 

--- a/shared-bindings/busio/__init__.c
+++ b/shared-bindings/busio/__init__.c
@@ -34,9 +34,6 @@
 #include "shared-bindings/busio/I2C.h"
 #include "shared-bindings/busio/SPI.h"
 #include "shared-bindings/busio/UART.h"
-#if CIRCUITPY_ONEWIREIO
-#include "shared-bindings/onewireio/OneWire.h"
-#endif
 
 #include "py/runtime.h"
 
@@ -87,9 +84,6 @@ STATIC const mp_rom_map_elem_t busio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_busio) },
     { MP_ROM_QSTR(MP_QSTR_I2C),   MP_ROM_PTR(&busio_i2c_type) },
     { MP_ROM_QSTR(MP_QSTR_SPI),   MP_ROM_PTR(&busio_spi_type) },
-    #if CIRCUITPY_ONEWIREIO
-    { MP_ROM_QSTR(MP_QSTR_OneWire),   MP_ROM_PTR(&onewireio_onewire_type) },
-    #endif
     { MP_ROM_QSTR(MP_QSTR_UART),   MP_ROM_PTR(&busio_uart_type) },
 };
 


### PR DESCRIPTION
Complete incompatible change of moving `OneWire` to its own `onewireio` module, so it's no longer a part of `bitbangio` and `busio`.
