### PR TITLE
Espressif: fix allocation of multiple Incremental Encoders

### DIFF
--- a/ports/espressif/common-hal/countio/Counter.c
+++ b/ports/espressif/common-hal/countio/Counter.c
@@ -36,7 +36,7 @@ void common_hal_countio_counter_construct(countio_counter_obj_t *self,
     claim_pin(pin);
 
     // Prepare configuration for the PCNT unit
-    const pcnt_config_t pcnt_config = {
+    pcnt_config_t pcnt_config = {
         // Set PCNT input signal and control GPIOs
         .pulse_gpio_num = pin->number,
         .ctrl_gpio_num = PCNT_PIN_NOT_USED,
@@ -48,7 +48,7 @@ void common_hal_countio_counter_construct(countio_counter_obj_t *self,
     };
 
     // Initialize PCNT unit
-    const int8_t unit = peripherals_pcnt_init(pcnt_config);
+    const int8_t unit = peripherals_pcnt_init(&pcnt_config);
     if (unit == -1) {
         mp_raise_RuntimeError(translate("All PCNT units in use"));
     }

--- a/ports/espressif/common-hal/frequencyio/FrequencyIn.c
+++ b/ports/espressif/common-hal/frequencyio/FrequencyIn.c
@@ -69,7 +69,7 @@ static void IRAM_ATTR timer_interrupt_handler(void *self_in) {
 
 static void init_pcnt(frequencyio_frequencyin_obj_t *self) {
     // Prepare configuration for the PCNT unit
-    const pcnt_config_t pcnt_config = {
+    pcnt_config_t pcnt_config = {
         // Set PCNT input signal and control GPIOs
         .pulse_gpio_num = self->pin,
         .ctrl_gpio_num = PCNT_PIN_NOT_USED,
@@ -83,7 +83,7 @@ static void init_pcnt(frequencyio_frequencyin_obj_t *self) {
     };
 
     // initialize PCNT
-    const int8_t unit = peripherals_pcnt_init(pcnt_config);
+    const int8_t unit = peripherals_pcnt_init(&pcnt_config);
     if (unit == -1) {
         mp_raise_RuntimeError(translate("All PCNT units in use"));
     }

--- a/ports/espressif/peripherals/pcnt.h
+++ b/ports/espressif/peripherals/pcnt.h
@@ -30,8 +30,8 @@
 #include "driver/pcnt.h"
 #include "soc/pcnt_struct.h"
 
-extern int peripherals_pcnt_init(pcnt_config_t pcnt_config);
-extern int peripherals_pcnt_get_unit(pcnt_config_t pcnt_config);
+extern int peripherals_pcnt_init(pcnt_config_t *pcnt_config);
+extern void peripherals_pcnt_reinit(pcnt_config_t *pcnt_config);
 extern void peripherals_pcnt_deinit(pcnt_unit_t *unit);
 extern void peripherals_pcnt_reset(void);
 


### PR DESCRIPTION
Fixes #6429.

- Fixes allocation of PCNT units by some code restructuring.
- No longer passes pcnt init structs by value.

Tested on QT PY ESP32-S2, using a test program similar to what's in #6429. I didn't have two encoders to try it at once, but I moved jumpers back and forth, and the encoder worked on both pairs of pins.