### PR TITLE
Implement hardware flow control on SAMD busio.UART

### DIFF
--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -203,10 +203,10 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     // which don't necessarily match what we need. After calling it, set the values
     // specific to this instantiation of UART.
 
-    // Set pads computed for this SERCOM.
+    // Set pads computed for this SERCOM. Refer to the datasheet for details on pads.
     // TXPO:
     // 0x0: TX pad 0; no RTS/CTS
-    // 0x1: resevered
+    // 0x1: reserved
     // 0x2: TX pad 0; RTS: pad 2, CTS: pad 3
     // 0x3: TX pad 0; RTS: pad 2; no CTS
     // RXPO:

--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -129,8 +129,8 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             #endif
             tx_pinmux = PINMUX(tx->number, (i == 0) ? MUX_C : MUX_D);
             tx_pad = tx->sercom[i].pad;
-            if (have_cts) {
-                cts_pinmux = PINMUX(cts->number, (i == 0) ? MUX_C : MUX_D);
+            if (have_rts) {
+                rts_pinmux = PINMUX(rts->number, (i == 0) ? MUX_C : MUX_D);
             }
             if (rx == NULL) {
                 sercom = potential_sercom;
@@ -144,8 +144,8 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
                 rx->sercom[j].pad != tx_pad) {
                 rx_pinmux = PINMUX(rx->number, (j == 0) ? MUX_C : MUX_D);
                 rx_pad = rx->sercom[j].pad;
-                if (have_rts) {
-                    rts_pinmux = PINMUX(rts->number, (j == 0) ? MUX_C : MUX_D);
+                if (have_cts) {
+                    cts_pinmux = PINMUX(cts->number, (j == 0) ? MUX_C : MUX_D);
                 }
                 sercom = sercom_insts[rx->sercom[j].index];
                 sercom_index = rx->sercom[j].index;

--- a/ports/atmel-samd/common-hal/busio/UART.h
+++ b/ports/atmel-samd/common-hal/busio/UART.h
@@ -38,6 +38,8 @@ typedef struct {
     struct usart_async_descriptor usart_desc;
     uint8_t rx_pin;
     uint8_t tx_pin;
+    int8_t rts_pin;
+    int8_t cts_pin;
     uint8_t character_bits;
     bool rx_error;
     uint32_t baudrate;


### PR DESCRIPTION
The current atmel-samd port does not support RTS/CTS for hardware flow control, even though the underlying SAMx2x/SAMx5x chips are capable of using this mode on async UARTs. This change enables hardware flow control by allowing assignment of pins to RTS/CTS, and enabling selection of the correction pad configuration for the pinout via the CTRLA.TXPO register.

An example of working code looks like this (using the pin configs on the Sparkfun SAMD51 MicroMod):

```
import board
import busio

# On the SAMD51 MicroMod, SERCOM5 is used for UART1, and the pins that would be assigned to RTS/CTS are PB00/PB001
uart = busio.UART(board.UART_TX1, board.UART_RX1, cts=board.PWM0, rts=board.A1)
uart.write(bytearray("hello")) # Write 'hello' to the UART
uart.readline() # gets whatever is being written from the other side
```

I have tested this with on the MicroMod, and it works as expected when the other side is set up for hardware flow control. To fully confirm it, I disabled hardware flow control in picocom attached to an FTDI USB-to-serial board wired to the UART RX/TX/RTS/CTS lines on the MicroMod, then used picocomd's toggle features to assert RTS and CTS to prevent reads or writes as desired. I also confirmed that normal operation of the UART when hardware flow control is not specified works as it did prior to this change.

A note re confirming this PR: while RTS/CTS flow control is available on the SAMx2x/SAMx5x chips, it's only happenstance that a given dev board exposes the correct pins used for the given SERCOM underlying the UART(s) exposed via hardware. I found that several boards did not have the pins I need even connected. The MicroMod was one where I was able to find the right pads connected to pins.