### PR TITLE
tilegrid.contains() function

### DIFF
--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -322,6 +322,24 @@ MP_PROPERTY_GETSET(displayio_tilegrid_transpose_xy_obj,
     (mp_obj_t)&displayio_tilegrid_get_transpose_xy_obj,
     (mp_obj_t)&displayio_tilegrid_set_transpose_xy_obj);
 
+//|     def contains(self, touch_tuple: tuple) -> bool:
+//|         """returns true if first two values in touch_tuple represent an x,y coordinate
+//|            inside the tilegrid rectangle bounds"""
+//|
+STATIC mp_obj_t displayio_tilegrid_obj_contains(mp_obj_t self_in, mp_obj_t touch_tuple) {
+    displayio_tilegrid_t *self = MP_OBJ_TO_PTR(self_in);
+
+    mp_obj_t *touch_tuple_items;
+    mp_obj_get_array_fixed_n(touch_tuple, 3, &touch_tuple_items);
+    uint16_t x = 0;
+    uint16_t y = 0;
+    x = mp_obj_get_int(touch_tuple_items[0]);
+    y = mp_obj_get_int(touch_tuple_items[1]);
+
+    return mp_obj_new_bool(common_hal_displayio_tilegrid_contains(self, x, y));
+}
+MP_DEFINE_CONST_FUN_OBJ_2(displayio_tilegrid_contains_obj, displayio_tilegrid_obj_contains);
+
 //|     pixel_shader: Union[ColorConverter, Palette]
 //|     """The pixel shader of the tilegrid."""
 //|
@@ -484,6 +502,7 @@ STATIC const mp_rom_map_elem_t displayio_tilegrid_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_flip_x), MP_ROM_PTR(&displayio_tilegrid_flip_x_obj) },
     { MP_ROM_QSTR(MP_QSTR_flip_y), MP_ROM_PTR(&displayio_tilegrid_flip_y_obj) },
     { MP_ROM_QSTR(MP_QSTR_transpose_xy), MP_ROM_PTR(&displayio_tilegrid_transpose_xy_obj) },
+    { MP_ROM_QSTR(MP_QSTR_contains), MP_ROM_PTR(&displayio_tilegrid_contains_obj) },
     { MP_ROM_QSTR(MP_QSTR_pixel_shader), MP_ROM_PTR(&displayio_tilegrid_pixel_shader_obj) },
     { MP_ROM_QSTR(MP_QSTR_bitmap), MP_ROM_PTR(&displayio_tilegrid_bitmap_obj) },
 };

--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -323,8 +323,8 @@ MP_PROPERTY_GETSET(displayio_tilegrid_transpose_xy_obj,
     (mp_obj_t)&displayio_tilegrid_set_transpose_xy_obj);
 
 //|     def contains(self, touch_tuple: tuple) -> bool:
-//|         """returns true if first two values in touch_tuple represent an x,y coordinate
-//|            inside the tilegrid rectangle bounds"""
+//|         """Returns True if the first two values in ``touch_tuple`` represent an x,y coordinate
+//|            inside the tilegrid rectangle bounds."""
 //|
 STATIC mp_obj_t displayio_tilegrid_obj_contains(mp_obj_t self_in, mp_obj_t touch_tuple) {
     displayio_tilegrid_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/displayio/TileGrid.h
+++ b/shared-bindings/displayio/TileGrid.h
@@ -56,6 +56,8 @@ void common_hal_displayio_tilegrid_set_flip_y(displayio_tilegrid_t *self, bool f
 bool common_hal_displayio_tilegrid_get_transpose_xy(displayio_tilegrid_t *self);
 void common_hal_displayio_tilegrid_set_transpose_xy(displayio_tilegrid_t *self, bool transpose_xy);
 
+bool common_hal_displayio_tilegrid_contains(displayio_tilegrid_t *self, uint16_t x, uint16_t y);
+
 uint16_t common_hal_displayio_tilegrid_get_width(displayio_tilegrid_t *self);
 uint16_t common_hal_displayio_tilegrid_get_height(displayio_tilegrid_t *self);
 

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -342,6 +342,17 @@ void common_hal_displayio_tilegrid_set_transpose_xy(displayio_tilegrid_t *self, 
     self->moved = true;
 }
 
+bool common_hal_displayio_tilegrid_contains(displayio_tilegrid_t *self, uint16_t x, uint16_t y) {
+    uint16_t right_edge = self->x + (self->width_in_tiles * self->tile_width);
+    uint16_t bottom_edge = self->y + (self->height_in_tiles * self->tile_height);
+    if (x >= self->x && x <= right_edge &&
+        y >= self->y && y <= bottom_edge) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 void common_hal_displayio_tilegrid_set_top_left(displayio_tilegrid_t *self, uint16_t x, uint16_t y) {
     self->top_left_x = x;
     self->top_left_y = y;

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -345,8 +345,8 @@ void common_hal_displayio_tilegrid_set_transpose_xy(displayio_tilegrid_t *self, 
 bool common_hal_displayio_tilegrid_contains(displayio_tilegrid_t *self, uint16_t x, uint16_t y) {
     uint16_t right_edge = self->x + (self->width_in_tiles * self->tile_width);
     uint16_t bottom_edge = self->y + (self->height_in_tiles * self->tile_height);
-    return x >= self->x && x <= right_edge &&
-           y >= self->y && y <= bottom_edge;
+    return x >= self->x && x < right_edge &&
+           y >= self->y && y < bottom_edge;
 }
 
 void common_hal_displayio_tilegrid_set_top_left(displayio_tilegrid_t *self, uint16_t x, uint16_t y) {

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -346,7 +346,7 @@ bool common_hal_displayio_tilegrid_contains(displayio_tilegrid_t *self, uint16_t
     uint16_t right_edge = self->x + (self->width_in_tiles * self->tile_width);
     uint16_t bottom_edge = self->y + (self->height_in_tiles * self->tile_height);
     return x >= self->x && x <= right_edge &&
-        y >= self->y && y <= bottom_edge;
+           y >= self->y && y <= bottom_edge;
 }
 
 void common_hal_displayio_tilegrid_set_top_left(displayio_tilegrid_t *self, uint16_t x, uint16_t y) {

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -345,12 +345,8 @@ void common_hal_displayio_tilegrid_set_transpose_xy(displayio_tilegrid_t *self, 
 bool common_hal_displayio_tilegrid_contains(displayio_tilegrid_t *self, uint16_t x, uint16_t y) {
     uint16_t right_edge = self->x + (self->width_in_tiles * self->tile_width);
     uint16_t bottom_edge = self->y + (self->height_in_tiles * self->tile_height);
-    if (x >= self->x && x <= right_edge &&
-        y >= self->y && y <= bottom_edge) {
-        return true;
-    } else {
-        return false;
-    }
+    return x >= self->x && x <= right_edge &&
+        y >= self->y && y <= bottom_edge;
 }
 
 void common_hal_displayio_tilegrid_set_top_left(displayio_tilegrid_t *self, uint16_t x, uint16_t y) {


### PR DESCRIPTION
This adds a `tilegrid.contains()` function that accepts a touch tuple from adafruit_touchscreen library (or similar) and returns true or false based on whether the touch point is inside the rectangular bounds of this tilegrid. 

This function matches the API provided by the display button library: https://github.com/adafruit/Adafruit_CircuitPython_Display_Button

This will allow us to use arbitrary Bitmaps and OnDiskBitmaps as touch interactive objects.