### PR TITLE
fix autoapi bug ourselves for now

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -33,6 +33,25 @@ from sphinx import addnodes
 
 tools_describe = str(pathlib.Path(__file__).parent / "tools/describe")
 
+# Monkeypatch autoapi
+def _format_args(args_info, include_annotations=True, ignore_self=None):
+    result = []
+
+    for i, (prefix, name, annotation, default) in enumerate(args_info):
+        if i == 0 and ignore_self is not None and name == ignore_self:
+            continue
+        formatted = "{}{}{}{}".format(
+            prefix or "",
+            name or "",
+            ": {}".format(annotation) if annotation and include_annotations else "",
+            (" = {}" if annotation else "={}").format(default) if default else "",
+        )
+        result.append(formatted)
+    return ", ".join(result)
+
+import autoapi.mappers.python.objects as objects
+objects._format_args = _format_args
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.


### PR DESCRIPTION
This applies the equivalent of https://github.com/readthedocs/sphinx-autoapi/pull/340/files by "monkey" patching, that is, using the dynamic nature of Python to replace the buggy function `_format_args` with the fixed version.
![image](https://user-images.githubusercontent.com/1517291/171194830-8d1922d8-1f84-47b9-9942-f7ad09e6e52f.png)
