### PR TITLE
Rp2040 pulsein improvements

### DIFF
--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.h
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.h
@@ -37,13 +37,13 @@ typedef struct {
     mp_obj_base_t base;
     uint8_t pin;
     bool idle_state;
+    bool paused;
     uint16_t maxlen;
     uint16_t *buffer;
     volatile bool last_level;
     volatile uint32_t level_count;
     volatile uint16_t len;
     volatile uint16_t start;
-    volatile uint16_t buf_index;
     rp2pio_statemachine_obj_t state_machine;
 } pulseio_pulsein_obj_t;
 


### PR DESCRIPTION
I was working on issue #4664 but I found a few other small issues and instead of opening issues for each I hoped it would be ok if I just submitted one pull request that addressed them all. I tested these changes with a dht22, an ir remote and an rcwl-1601 and all work as expected. Below is a list of changes.

Fixes #4664
Addresses #4946 since just dropping short pulses isn't a valid way to filter out short pulses
Fixes a buffer start index reset bug on [line 160](https://github.com/adafruit/circuitpython/compare/main...mwisslead:rp2040_pulsein_common_hal_construct?expand=1#diff-d6faa070ed5811465cef0d6b1f9426a22b6a9571b7871ed898f01314564eba15L160) I missed before
Fixes lost counts when state machine is reset unnecessarily
Fixes missing initial count on pin value change  [line 143](https://github.com/adafruit/circuitpython/compare/main...mwisslead:rp2040_pulsein_common_hal_construct?expand=1#diff-d6faa070ed5811465cef0d6b1f9426a22b6a9571b7871ed898f01314564eba15L143)
Removes delay after resume pulse
Fix popleft resetting level count
Removes unneeded buf_index
Add call to pause at the beginning of resume
Adds paused attribute to fix .paused always returning true.
Remove unneeded resets of start pointer in .clear and .popleft.