### PR TITLE
Only check the savings if a word occurs at least twice

### DIFF
--- a/py/makeqstrdata.py
+++ b/py/makeqstrdata.py
@@ -400,7 +400,8 @@ def compute_huffman_coding(translations, compression_filename):
         # words[] array.
 
         scores = sorted(
-            ((s, -est_net_savings(s, occ)) for (s, occ) in counter.items()), key=lambda x: x[1]
+            ((s, -est_net_savings(s, occ)) for (s, occ) in counter.items() if occ > 1),
+            key=lambda x: x[1],
         )
 
         # Pick the one with the highest score.  The score must be negative.


### PR DESCRIPTION
Profiling shows that `est_net_savings` is one of the highest costs of the whole process. Approximately, you can save storage only if a word appears more than once, and doing this greatly reduces the number of `est_net_savings` calls (this isn't exactly true, because a 'word' could be made only of very infrequent code points, but let's ignore it). In a local build, it reduces the time for this specific build step by 50% on ports/unix VARIANT=coverage build, without affecting the size of the generated binary.