### PR TITLE
Enable UF2 builds for STM32 Thing Plus

### DIFF
--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -69,6 +69,7 @@ extension_by_board = {
     "microbit_v2": COMBINED_HEX,
     # stm32
     "meowbit_v121": UF2,
+    "sparkfun_stm32_thing_plus": BIN_UF2,
     # esp32c3
     "adafruit_qtpy_esp32c3": BIN,
     "ai_thinker_esp32-c3s": BIN,


### PR DESCRIPTION
This MR enables (hopefully) the UF2 builds for the SparkFun Thing Plus - STM32 board.
This board is supported by the [tinyuf2 bootloader](https://github.com/adafruit/tinyuf2/releases/tag/0.9.0).