### PR TITLE
 Disable board.SPI() for Challenger NB RP2040 WiFi

### DIFF
--- a/ports/raspberrypi/boards/challenger_nb_rp2040_wifi/mpconfigboard.h
+++ b/ports/raspberrypi/boards/challenger_nb_rp2040_wifi/mpconfigboard.h
@@ -5,6 +5,3 @@
 #define DEFAULT_UART_BUS_RX   (&pin_GPIO17)
 #define DEFAULT_I2C_BUS_SDA   (&pin_GPIO0)
 #define DEFAULT_I2C_BUS_SCL   (&pin_GPIO1)
-#define DEFAULT_SPI_BUS_SCK   (&pin_GPIO22)
-#define DEFAULT_SPI_BUS_MOSI  (&pin_GPIO23)
-#define DEFAULT_SPI_BUS_MISO  (&pin_GPIO24)


### PR DESCRIPTION
This was done as a result of an issue with the SPI pin mappings.
Please refer to the following for additional information: https://ilabs.se/challenger-rp2040-wifi-spi-bug

Tested by:

1. Calling `board.SPI()` - an exception is now implicitly raised: `NotImplementedError: No default SPI bus`
2. Ensuring that it is still possible to construct and use the SPI bus using by `busio.SPI(board.SCK, MOSI=board.MOSI)`

NB: This PR targets the 7.3.x branch and replaces https://github.com/adafruit/circuitpython/pull/6460
