### PR TITLE
Fix for Issue #6478

### DIFF
--- a/ports/nrf/boards/clue_nrf52840_express/board.c
+++ b/ports/nrf/boards/clue_nrf52840_express/board.c
@@ -102,4 +102,5 @@ void reset_board(void) {
 }
 
 void board_deinit(void) {
+    common_hal_displayio_release_displays();
 }

--- a/ports/nrf/common-hal/alarm/__init__.c
+++ b/ports/nrf/common-hal/alarm/__init__.c
@@ -48,6 +48,9 @@
 #include "nrf_power.h"
 #include "nrfx.h"
 #include "nrfx_gpiote.h"
+#ifdef NRF_DEBUG_PRINT
+void print_wakeup_cause(nrf_sleep_source_t cause);
+#endif
 
 // Singleton instance of SleepMemory.
 const alarm_sleep_memory_obj_t alarm_sleep_memory_obj = {


### PR DESCRIPTION
Fix for crash into safe mode when waking up (Issue #6478). Added a call to common_hal_displayio_release_displays() in board_deinit() to release the SPI display. Also snuck in a fix into common-hal/alarm/__init__.c  that was causing a build failure if NRF_DEBUG_PRINT was defined. This may be related to Issue #6484, but I don't have hardware to test all the boards listed there.