### PR TITLE
include python executable path in the idf key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -382,6 +382,7 @@ jobs:
     if: ${{ needs.test.outputs.boards-espressif != '[]' }}
     steps:
     - name: Set up Python 3
+      id: py3
       uses: actions/setup-python@v2
       with:
         python-version: "3.x"
@@ -400,7 +401,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/espressif/esp-idf/HEAD') }}-20220404
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/espressif/esp-idf/HEAD') }}-${{ steps.py3.outputs.python-path }}-20220404
     - name: Clone IDF submodules
       run: |
         (cd $IDF_PATH && git submodule update --init)


### PR DESCRIPTION
I noticed that the latest time we needed to switch the idf key was when the environment changed from python 3.10.4 to 3.10.5. I don't know if this is the only cause of needing to change the key, but it seems to be a good idea to make the key include it.

I think this is what's going on because when I replaced a virtualenv's "python" with a dangling symlink (same as would occur when python's version gets bumped), I got a similar error.

May be an alternative to #6493.