### PR TITLE
use setup-python v4 for python-path support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -383,7 +383,7 @@ jobs:
     steps:
     - name: Set up Python 3
       id: py3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
     - uses: actions/checkout@v2.2.0


### PR DESCRIPTION
When reviewing, please check actions to make sure the cache key includes the path of python.

Closes: #6496 