### PR TITLE
feat(swan_r5): Enable UF2 support for Swan R5 board

### DIFF
--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -70,6 +70,7 @@ extension_by_board = {
     # stm32
     "meowbit_v121": UF2,
     "sparkfun_stm32_thing_plus": BIN_UF2,
+    "swan_r5": BIN_UF2,
     # esp32c3
     "adafruit_qtpy_esp32c3": BIN,
     "ai_thinker_esp32-c3s": BIN,


### PR DESCRIPTION
Enable UF2 build artifact for Swan R5 - Swan R5 support in tinyuf2 has been merged to `main` in and will be available in the next release. 

The nightly build of the bootloader is available at https://github.com/adafruit/tinyuf2/actions/runs/2517588142


