### PR TITLE
palette_index validation in Palette functions

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -3688,10 +3688,6 @@ msgid "palette must be 32 bytes long"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c
-msgid "palette_index out of bounds"
-msgstr ""
-
-#: shared-bindings/displayio/Palette.c
 msgid "palette_index should be an int"
 msgstr ""
 

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -72,7 +72,7 @@ msgstr ""
 #: ports/mimxrt10xx/common-hal/rtc/RTC.c
 #: ports/nrf/common-hal/analogio/AnalogOut.c ports/nrf/common-hal/rtc/RTC.c
 #: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c
+#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/rtc/RTC.c
 msgid "%q"
 msgstr ""
 
@@ -432,7 +432,6 @@ msgstr ""
 msgid "All event channels in use"
 msgstr ""
 
-#: ports/raspberrypi/common-hal/pulseio/PulseIn.c
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "All state machines in use"
 msgstr ""
@@ -518,7 +517,7 @@ msgstr ""
 msgid "AuthMode.OPEN is not used with password"
 msgstr ""
 
-#: shared-bindings/wifi/Radio.c
+#: shared-bindings/wifi/Radio.c supervisor/shared/web_workflow/web_workflow.c
 msgid "Authentication failure"
 msgstr ""
 
@@ -3688,6 +3687,10 @@ msgid "palette must be 32 bytes long"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c
+msgid "palette_index out of bounds"
+msgstr ""
+
+#: shared-bindings/displayio/Palette.c
 msgid "palette_index should be an int"
 msgstr ""
 
@@ -3913,10 +3916,6 @@ msgstr ""
 
 #: shared-bindings/bitmaptools/__init__.c
 msgid "source_bitmap must have value_count of 8"
-msgstr ""
-
-#: shared-bindings/wifi/Radio.c
-msgid "ssid can't be more than 32 bytes"
 msgstr ""
 
 #: py/objstr.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -72,7 +72,7 @@ msgstr ""
 #: ports/mimxrt10xx/common-hal/rtc/RTC.c
 #: ports/nrf/common-hal/analogio/AnalogOut.c ports/nrf/common-hal/rtc/RTC.c
 #: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/rtc/RTC.c
+#: ports/raspberrypi/common-hal/rtc/RTC.c
 msgid "%q"
 msgstr ""
 
@@ -432,6 +432,7 @@ msgstr ""
 msgid "All event channels in use"
 msgstr ""
 
+#: ports/raspberrypi/common-hal/pulseio/PulseIn.c
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "All state machines in use"
 msgstr ""
@@ -517,7 +518,7 @@ msgstr ""
 msgid "AuthMode.OPEN is not used with password"
 msgstr ""
 
-#: shared-bindings/wifi/Radio.c supervisor/shared/web_workflow/web_workflow.c
+#: shared-bindings/wifi/Radio.c
 msgid "Authentication failure"
 msgstr ""
 
@@ -3916,6 +3917,10 @@ msgstr ""
 
 #: shared-bindings/bitmaptools/__init__.c
 msgid "source_bitmap must have value_count of 8"
+msgstr ""
+
+#: shared-bindings/wifi/Radio.c
+msgid "ssid can't be more than 32 bytes"
 msgstr ""
 
 #: py/objstr.c

--- a/shared-bindings/displayio/Palette.c
+++ b/shared-bindings/displayio/Palette.c
@@ -160,6 +160,10 @@ STATIC mp_obj_t displayio_palette_obj_make_transparent(mp_obj_t self_in, mp_obj_
     if (!mp_obj_get_int_maybe(palette_index_obj, &palette_index)) {
         mp_raise_ValueError(translate("palette_index should be an int"));
     }
+    if (palette_index < 0 || (unsigned)palette_index >= common_hal_displayio_palette_get_len(self)) {
+        mp_raise_IndexError(translate("palette_index out of bounds"));
+    }
+
     common_hal_displayio_palette_make_transparent(self, palette_index);
     return mp_const_none;
 }

--- a/shared-bindings/displayio/Palette.c
+++ b/shared-bindings/displayio/Palette.c
@@ -179,6 +179,10 @@ STATIC mp_obj_t displayio_palette_obj_make_opaque(mp_obj_t self_in, mp_obj_t pal
     if (!mp_obj_get_int_maybe(palette_index_obj, &palette_index)) {
         mp_raise_ValueError(translate("palette_index should be an int"));
     }
+    if (palette_index < 0 || (unsigned)palette_index >= common_hal_displayio_palette_get_len(self)) {
+        mp_raise_IndexError(translate("palette_index out of bounds"));
+    }
+
     common_hal_displayio_palette_make_opaque(self, palette_index);
     return mp_const_none;
 }
@@ -195,6 +199,10 @@ STATIC mp_obj_t displayio_palette_obj_is_transparent(mp_obj_t self_in, mp_obj_t 
     if (!mp_obj_get_int_maybe(palette_index_obj, &palette_index)) {
         mp_raise_ValueError(translate("palette_index should be an int"));
     }
+    if (palette_index < 0 || (unsigned)palette_index >= common_hal_displayio_palette_get_len(self)) {
+        mp_raise_IndexError(translate("palette_index out of bounds"));
+    }
+
     return mp_obj_new_bool(common_hal_displayio_palette_is_transparent(self, palette_index));
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_palette_is_transparent_obj, displayio_palette_obj_is_transparent);

--- a/shared-bindings/displayio/Palette.c
+++ b/shared-bindings/displayio/Palette.c
@@ -160,9 +160,7 @@ STATIC mp_obj_t displayio_palette_obj_make_transparent(mp_obj_t self_in, mp_obj_
     if (!mp_obj_get_int_maybe(palette_index_obj, &palette_index)) {
         mp_raise_ValueError(translate("palette_index should be an int"));
     }
-    if (palette_index < 0 || (unsigned)palette_index >= common_hal_displayio_palette_get_len(self)) {
-        mp_raise_IndexError(translate("palette_index out of bounds"));
-    }
+    palette_index = mp_arg_validate_int_range(palette_index, 0, common_hal_displayio_palette_get_len(self) - 1, MP_QSTR_palette_index);
 
     common_hal_displayio_palette_make_transparent(self, palette_index);
     return mp_const_none;
@@ -179,9 +177,7 @@ STATIC mp_obj_t displayio_palette_obj_make_opaque(mp_obj_t self_in, mp_obj_t pal
     if (!mp_obj_get_int_maybe(palette_index_obj, &palette_index)) {
         mp_raise_ValueError(translate("palette_index should be an int"));
     }
-    if (palette_index < 0 || (unsigned)palette_index >= common_hal_displayio_palette_get_len(self)) {
-        mp_raise_IndexError(translate("palette_index out of bounds"));
-    }
+    palette_index = mp_arg_validate_int_range(palette_index, 0, common_hal_displayio_palette_get_len(self) - 1, MP_QSTR_palette_index);
 
     common_hal_displayio_palette_make_opaque(self, palette_index);
     return mp_const_none;
@@ -199,9 +195,7 @@ STATIC mp_obj_t displayio_palette_obj_is_transparent(mp_obj_t self_in, mp_obj_t 
     if (!mp_obj_get_int_maybe(palette_index_obj, &palette_index)) {
         mp_raise_ValueError(translate("palette_index should be an int"));
     }
-    if (palette_index < 0 || (unsigned)palette_index >= common_hal_displayio_palette_get_len(self)) {
-        mp_raise_IndexError(translate("palette_index out of bounds"));
-    }
+    palette_index = mp_arg_validate_int_range(palette_index, 0, common_hal_displayio_palette_get_len(self) - 1, MP_QSTR_palette_index);
 
     return mp_obj_new_bool(common_hal_displayio_palette_is_transparent(self, palette_index));
 }


### PR DESCRIPTION
This adds bounds validation for the `palette_index` argument for `make_transparent()`, `make_opaque()` and `is_transparent()` functions on the Palette object.

Resolves: #6507 