### PR TITLE
Implement default busses to IOTS2

### DIFF
--- a/ports/espressif/boards/hiibot_iots2/mpconfigboard.h
+++ b/ports/espressif/boards/hiibot_iots2/mpconfigboard.h
@@ -34,3 +34,12 @@
 
 #define MICROPY_HW_BUTTON (&pin_GPIO21)
 #define CIRCUITPY_BOOT_BUTTON (&pin_GPIO21)
+
+#define CIRCUITPY_BOARD_I2C         (1)
+#define CIRCUITPY_BOARD_I2C_PIN     {{.scl = &pin_GPIO1, .sda = &pin_GPIO2}}
+
+#define CIRCUITPY_BOARD_SPI         (1)
+#define CIRCUITPY_BOARD_SPI_PIN     {{.clock = &pin_GPIO40, .mosi = &pin_GPIO42, .miso = &pin_GPIO41}}
+
+#define CIRCUITPY_BOARD_UART        (1)
+#define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO43, .rx = &pin_GPIO44}}

--- a/ports/espressif/boards/hiibot_iots2/pins.c
+++ b/ports/espressif/boards/hiibot_iots2/pins.c
@@ -71,6 +71,7 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO44) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_STEMMA_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };


### PR DESCRIPTION
Add pin definitions for busses:
- board.I2C and board.STEMMA_I2C go to the stemma QT port.
- board.UART goes to the RX and TX pins.
- board.SPI goes to the SCK, MISO and MOSI pins, which despite not being on the silkscreen were already defined with those names and are on the pinout card.