### PR TITLE
Update to newer 4.4 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -145,8 +145,8 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_RFM69.git
 [submodule "ports/espressif/esp-idf"]
 	path = ports/espressif/esp-idf
-	url = https://github.com/espressif/esp-idf.git
-	branch = release/v4.4
+	url = https://github.com/adafruit/esp-idf.git
+	branch = circuitpython8
 [submodule "ports/espressif/certificates/nina-fw"]
 	path = ports/espressif/certificates/nina-fw
 	url = https://github.com/adafruit/nina-fw.git


### PR DESCRIPTION
This uses a new `circuitpython8` branch on our IDF fork. It has the I2C fix and a revert that fixes an issue with running the main task on the APP CPU: https://github.com/espressif/esp-idf/issues/9247