### PR TITLE
Safe mode when ESP interrupt watchdog fires

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -72,7 +72,7 @@ msgstr ""
 #: ports/mimxrt10xx/common-hal/rtc/RTC.c
 #: ports/nrf/common-hal/analogio/AnalogOut.c ports/nrf/common-hal/rtc/RTC.c
 #: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c
+#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/rtc/RTC.c
 msgid "%q"
 msgstr ""
 
@@ -432,7 +432,6 @@ msgstr ""
 msgid "All event channels in use"
 msgstr ""
 
-#: ports/raspberrypi/common-hal/pulseio/PulseIn.c
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "All state machines in use"
 msgstr ""
@@ -518,7 +517,7 @@ msgstr ""
 msgid "AuthMode.OPEN is not used with password"
 msgstr ""
 
-#: shared-bindings/wifi/Radio.c
+#: shared-bindings/wifi/Radio.c supervisor/shared/web_workflow/web_workflow.c
 msgid "Authentication failure"
 msgstr ""
 
@@ -1158,6 +1157,10 @@ msgstr ""
 #: shared-module/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid "Internal error #%d"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Internal watchdog timer expired."
 msgstr ""
 
 #: py/argcheck.c
@@ -2242,10 +2245,6 @@ msgstr ""
 
 #: shared-bindings/watchdog/WatchDogTimer.c
 msgid "WatchDogTimer.timeout must be greater than 0"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "Watchdog timer expired."
 msgstr ""
 
 #: py/builtinhelp.c
@@ -3913,10 +3912,6 @@ msgstr ""
 
 #: shared-bindings/bitmaptools/__init__.c
 msgid "source_bitmap must have value_count of 8"
-msgstr ""
-
-#: shared-bindings/wifi/Radio.c
-msgid "ssid can't be more than 32 bytes"
 msgstr ""
 
 #: py/objstr.c

--- a/ports/espressif/supervisor/port.c
+++ b/ports/espressif/supervisor/port.c
@@ -214,6 +214,9 @@ safe_mode_t port_init(void) {
         case ESP_RST_PANIC:
             return HARD_CRASH;
         case ESP_RST_INT_WDT:
+            // The interrupt watchdog is used internally to make sure that latency sensitive
+            // interrupt code isn't blocked. User watchdog resets come through ESP_RST_WDT.
+            return WATCHDOG_RESET;
         case ESP_RST_WDT:
         default:
             break;

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -178,7 +178,7 @@ void print_safe_mode_message(safe_mode_t reason) {
             message = translate("Boot device must be first device (interface #0).");
             break;
         case WATCHDOG_RESET:
-            message = translate("Watchdog timer expired.");
+            message = translate("Internal watchdog timer expired.");
             break;
         case NO_CIRCUITPY:
             message = translate("CIRCUITPY drive could not be found or created.");


### PR DESCRIPTION
This makes us enter safe mode when sleep on the S3 fails. The
task watchdog is used for the user watchdog.