### PR TITLE
modbuiltins: Catch most exceptions during dir()

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -190,8 +190,8 @@ STATIC mp_obj_t mp_builtin_dir(size_t n_args, const mp_obj_t *args) {
         // Implemented by probing all possible qstrs with mp_load_method_maybe
         size_t nqstr = QSTR_TOTAL();
         for (size_t i = MP_QSTR_ + 1; i < nqstr; ++i) {
-            mp_obj_t dest[2];
-            mp_load_method_protected(args[0], i, dest, false);
+            mp_obj_t dest[2] = {};
+            mp_load_method_protected(args[0], i, dest, true);
             if (dest[0] != MP_OBJ_NULL) {
                 #if MICROPY_PY_ALL_SPECIAL_METHODS
                 // Support for __dir__: see if we can dispatch to this special method


### PR DESCRIPTION
This helps with Python-compatibility (see issue #4171) but doesn't completely resolve it.

Now, `dir()` still computes any properties of the underlying object, HOWEVER, if the property raises an exception this exception is captured.

This ability to capture exceptions always existed in `mp_load_method_protected`, we just need to turn it on via the `catch_all_exc` boolean parameter.