### PR TITLE
issue adafruit#6538 loose bounds checking on WAIT PIO instruction

### DIFF
--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -436,7 +436,7 @@ void common_hal_rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
                 if (first_in_pin == NULL) {
                     mp_raise_ValueError_varg(translate("Missing first_in_pin. Instruction %d waits based on pin"), i);
                 }
-                if (wait_index > in_pin_count) {
+                if (wait_index >= in_pin_count) {
                     mp_raise_ValueError_varg(translate("Instruction %d waits on input outside of count"), i);
                 }
             }


### PR DESCRIPTION
The check on `wait x pin y` was allowing the use of one more pin than had been claimed as 'in' pins