### PR TITLE
stm: Make family IDs consistent with TinyUF2

### DIFF
--- a/ports/stm/mpconfigport.mk
+++ b/ports/stm/mpconfigport.mk
@@ -8,6 +8,9 @@ ifeq ($(MCU_VARIANT),$(filter $(MCU_VARIANT),STM32F405xx STM32F407xx))
         CIRCUITPY_SDIOIO ?= 1
         # Number of USB endpoint pairs.
         USB_NUM_ENDPOINT_PAIRS = 4
+endif
+
+ifeq ($(MCU_VARIANT),STM32F407xx)
         UF2_FAMILY_ID ?= 0x6d0922fa
 endif
 


### PR DESCRIPTION
This should allow UF2 images for STM32F405 boards to be flashed by TinyUF2.