### PR TITLE
signal errors in ci_fetch_deps subprocesses

### DIFF
--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -47,9 +47,11 @@ def run(title, command):
     print("::group::" + title, flush=True)
     print(command, flush=True)
     start = time.monotonic()
-    subprocess.run(shlex.split(command), stderr=subprocess.STDOUT)
-    print("Duration:", time.monotonic() - start, flush=True)
-    print("::endgroup::", flush=True)
+    try:
+        subprocess.run(shlex.split(command), stderr=subprocess.STDOUT, check=True)
+    finally:
+        print("Duration:", time.monotonic() - start, flush=True)
+        print("::endgroup::", flush=True)
 
 
 run(

--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -43,12 +43,12 @@ port_deps = {
 }
 
 
-def run(title, command):
+def run(title, command, check=True):
     print("::group::" + title, flush=True)
     print(command, flush=True)
     start = time.monotonic()
     try:
-        subprocess.run(shlex.split(command), stderr=subprocess.STDOUT, check=True)
+        subprocess.run(shlex.split(command), stderr=subprocess.STDOUT, check=check)
     finally:
         print("Duration:", time.monotonic() - start, flush=True)
         print("::endgroup::", flush=True)
@@ -108,7 +108,11 @@ if submodules:
     submodules = " ".join(submodules)
     # This line will fail because the submodule's need different commits than the tip of the branch. We
     # fix it later.
-    run("Init the submodules we'll need", f"git submodule update --init -N --depth 1 {submodules}")
+    run(
+        "Init the submodules we'll need",
+        f"git submodule update --init -N --depth 1 {submodules}",
+        check=False,
+    )
 
     run(
         "Fetch the submodule sha",


### PR DESCRIPTION
A recent build failed. The original error seemed to be during ci_fetch_deps where a build message said
```
  fatal: reference is not a tree: 346c936e14c6ea3a8d3d65cb1fa46202dc92999d
  fatal: Unable to checkout '346c936e14c6ea3a8d3d65cb1fa46202dc92999d' in submodule path 'extmod/ulab'
```
(along with other problems), but this step didn't signal failure to github actions.

By adding the check= parameter, a failure of the subprocess will cause a CalledProcessError to be raised, which will make `ci_fetch_deps` exit with nonzero status. In turn, this should let Actions understand that something went wrong with this step, instead of waiting for some subsequent step(s) to go wrong.