### PR TITLE
I2C Timeout "Fix" for Espressif devices.

### DIFF
--- a/ports/espressif/peripherals/i2c.c
+++ b/ports/espressif/peripherals/i2c.c
@@ -63,8 +63,8 @@ esp_err_t peripherals_i2c_init(i2c_port_t num, const i2c_config_t *i2c_conf) {
         return err;
     }
     #if ESPRESSIF_I2C_SET_TIMEOUT_PERCENT_OF_MAX
-        int max_timeout = (ESP32_I2C_TIMEOUT_MAX + 1) * ESPRESSIF_I2C_SET_TIMEOUT_PERCENT_OF_MAX / 100;
-        err = i2c_set_timeout(num, max_timeout);
+    int max_timeout = (ESP32_I2C_TIMEOUT_MAX + 1) * ESPRESSIF_I2C_SET_TIMEOUT_PERCENT_OF_MAX / 100;
+    err = i2c_set_timeout(num, max_timeout);
     #endif
 
     return err;

--- a/ports/espressif/peripherals/i2c.c
+++ b/ports/espressif/peripherals/i2c.c
@@ -58,7 +58,16 @@ esp_err_t peripherals_i2c_init(i2c_port_t num, const i2c_config_t *i2c_conf) {
         rx_buf_len = 256;
         tx_buf_len = 256;
     }
-    return i2c_driver_install(num, i2c_conf->mode, rx_buf_len, tx_buf_len, 0);
+    err = i2c_driver_install(num, i2c_conf->mode, rx_buf_len, tx_buf_len, 0);
+    if (err != ESP_OK) {
+        return err;
+    }
+    #if ESPRESSIF_I2C_SET_TIMEOUT_PERCENT_OF_MAX
+        int max_timeout = (ESP32_I2C_TIMEOUT_MAX + 1) * ESPRESSIF_I2C_SET_TIMEOUT_PERCENT_OF_MAX / 100;
+        err = i2c_set_timeout(num, max_timeout);
+    #endif
+
+    return err;
 }
 
 void peripherals_i2c_deinit(i2c_port_t num) {

--- a/ports/espressif/peripherals/i2c.h
+++ b/ports/espressif/peripherals/i2c.h
@@ -29,6 +29,22 @@
 
 #include "driver/i2c.h"
 
+#ifndef ESPRESSIF_I2C_SET_TIMEOUT_PERCENT_OF_MAX
+#define ESPRESSIF_I2C_SET_TIMEOUT_PERCENT_OF_MAX 66
+#endif
+
+#if ESPRESSIF_I2C_SET_TIMEOUT_PERCENT_OF_MAX
+#include "soc/i2c_reg.h"
+// Determine size of memory location used to store timeout.
+#if defined(I2C_TIME_OUT_REG_M)  // Standard on ESP32
+    #define ESP32_I2C_TIMEOUT_MAX I2C_TIME_OUT_REG_M
+#elif defined(I2C_TIME_OUT_VALUE_M)  // ESP32 S3, possibly others.
+    #define ESP32_I2C_TIMEOUT_MAX I2C_TIME_OUT_VALUE_M
+#else
+    #define ESP32_I2C_TIMEOUT_MAX 1048576;  // Assume same values as basic ESP32.
+#endif // defined(I2C_TIME_OUT_REG_M)
+#endif // ESPRESSIF_I2C_SET_TIMEOUT_PERCENT_OF_MAX
+
 extern void i2c_reset(void);
 extern void never_reset_i2c(i2c_port_t num);
 extern esp_err_t peripherals_i2c_init(i2c_port_t num, const i2c_config_t *i2c_conf);


### PR DESCRIPTION
- Similar code has been tested in ESP-IDF on another project of mine with great success https://github.com/litui/esp32_bbq10kbd/blob/a3804a3436f964e52af432ee632b72a2b3149ff2/src/BBQ10Keyboard.cpp#L97
- The reason this code is important is that A. the default timeouts on I2C on ESP32 are too short for most applications, resulting in frustration trying to use CircuitPython with ESP32 chips, and B. different numbers of bits are used to store the timeout value in the I2C register depending on which chip revision, hence the need to abstract the value to a "percentage of max."
- It is better to control the timeout value at build/initialization time than accept whatever defaults Espressif happens to assume for us.
- I haven't yet inventoried the libraries for every ESP32-based chip so my i2c.h conditional load of defined values from `soc/i2c_reg.h` may need expansion.
- May not be applicable to all use cases or hardware configurations, but is working under my own use cases on the Unexpected Maker FeatherS3 boards. I've tested my similar ESP-IDF code on Adafruit "Huzzah32" Feather and Sparkfun Thing Plus C boards, though neither of these, to my knowledge, supports CircuitPython easily.