### PR TITLE
esp32: don't fully reset the wifi device

### DIFF
--- a/ports/espressif/common-hal/wifi/__init__.c
+++ b/ports/espressif/common-hal/wifi/__init__.c
@@ -214,6 +214,7 @@ void wifi_reset(void) {
     common_hal_wifi_monitor_deinit(MP_STATE_VM(wifi_monitor_singleton));
     wifi_radio_obj_t *radio = &common_hal_wifi_radio_obj;
     common_hal_wifi_radio_set_enabled(radio, false);
+    #ifndef CONFIG_IDF_TARGET_ESP32
     ESP_ERROR_CHECK(esp_event_handler_instance_unregister(WIFI_EVENT,
         ESP_EVENT_ANY_ID,
         radio->handler_instance_all_wifi));
@@ -226,6 +227,7 @@ void wifi_reset(void) {
     esp_netif_destroy(radio->ap_netif);
     radio->ap_netif = NULL;
     wifi_inited = false;
+    #endif
     supervisor_workflow_request_background();
 }
 

--- a/ports/espressif/common-hal/wifi/__init__.c
+++ b/ports/espressif/common-hal/wifi/__init__.c
@@ -141,7 +141,12 @@ static bool wifi_ever_inited;
 static bool wifi_user_initiated;
 
 void common_hal_wifi_init(bool user_initiated) {
+    wifi_radio_obj_t *self = &common_hal_wifi_radio_obj;
+
     if (wifi_inited) {
+        if (user_initiated && !wifi_user_initiated) {
+            common_hal_wifi_radio_set_enabled(self, true);
+        }
         return;
     }
     wifi_inited = true;
@@ -154,7 +159,6 @@ void common_hal_wifi_init(bool user_initiated) {
     }
     wifi_ever_inited = true;
 
-    wifi_radio_obj_t *self = &common_hal_wifi_radio_obj;
     self->netif = esp_netif_create_default_wifi_sta();
     self->ap_netif = esp_netif_create_default_wifi_ap();
     self->started = false;
@@ -204,6 +208,7 @@ void common_hal_wifi_init(bool user_initiated) {
 void wifi_user_reset(void) {
     if (wifi_user_initiated) {
         wifi_reset();
+        wifi_user_initiated = false;
     }
 }
 


### PR DESCRIPTION
.. this makes reconnecting without a full reset not work. The _user initiated wifi_ flag is now used to track whether `import wifi` needs to re-enable the wifi interface.

Because this works on other generations of the esp32 (c2, c3, etc), apply this behavior only to esp32.

After this change, it's possible to connect multiple times to wifi in different runs of code.py or the repl after soft rebooting.

Testing procedure: Connect with Thonny.  Put wifi deets in .env on device (to open this file when it exists already, use the hamburger menu to select to show hidden files on the target device).  Run the following script with F5:
```
#raise SystemExit

import wifi
import socketpool
import ssl
import os
import adafruit_requests

print(dir())
print(f"connected with address {wifi.radio.ipv4_address=}?")


def print_networks():
    print("networks:")
    for n in wifi.radio.start_scanning_networks(): print(f"{n.ssid:24} {n.rssi: 3}")
    wifi.radio.stop_scanning_networks()

def connect():
    wifi.radio.connect(os.getenv("WIFI_SSID"), os.getenv("WIFI_PASSWORD"))

    print(f"connected with address {wifi.radio.ipv4_address}")

    pool = socketpool.SocketPool(wifi.radio)
    requests = adafruit_requests.Session(pool, ssl.create_default_context())
    print(requests.get("https://httpbin.org/get").json())

def go():
    print_networks()
    connect()
    
if __name__ == '__main__':
    go()
```