### PR TITLE
Fixed empty characteristic issue with bleio+nimble.

### DIFF
--- a/ports/espressif/common-hal/_bleio/Connection.c
+++ b/ports/espressif/common-hal/_bleio/Connection.c
@@ -394,6 +394,11 @@ STATIC void discover_remote_services(bleio_connection_internal_t *self, mp_obj_t
                 ? service->end_handle
                 : next_characteristic->def_handle - 1;
 
+            // Pre-check if characteristic is empty so descriptor discovery doesn't fail
+            if (end_handle <= characteristic->handle) {
+                continue;
+            }
+
             _last_discovery_status = BLE_ERR_SUCCESS;
             CHECK_NIMBLE_ERROR(ble_gattc_disc_all_dscs(self->conn_handle, characteristic->handle,
                 end_handle,


### PR DESCRIPTION
- Based on espressif/nimble's blecent example code. Confirms that the characteristic is not empty before trying to catalogue its descriptors.
- Running ble_gattc_disc_all_dscs on empty (no length) characteristics fails with the (not-very-informative) BLE_HS_EINVAL error if this check is not performed.