### PR TITLE
Allow mpconfigboard.mk to set board extensions

### DIFF
--- a/ports/nrf/boards/microbit_v2/mpconfigboard.mk
+++ b/ports/nrf/boards/microbit_v2/mpconfigboard.mk
@@ -7,3 +7,5 @@ INTERNAL_FLASH_FILESYSTEM = 1
 
 # USB pins aren't used.
 CIRCUITPY_USB = 0
+
+EXTENSIONS = combined.hex


### PR DESCRIPTION
Looking at the PR to add Beetle esp32 c3 (#6615) I noticed that any microcontroller of this type would require modifying build_board_info, which in turn causes a build of all boards. The same would be true of esp32 boards, of which we hope a large number will be submitted soon.

Instead, create two different ways for an mpconfigboard.mk file to override the default setting by port: For espressif, use the existing IDF_TARGET variable. For the general case, allow the EXTENSIONS variable to be specified.

Note that the value cannot come from mpconfigport.mk and cannot be conditional. This condition could be lifted in the future if it is useful. Additionally, if IDF_TARGET and EXTENSIONS both exist, the one that appears FIRST in the mpconfigboard.mk file is used, which is a bit tricky.

I ran "DEBUG=x RELEASE_TAG=x build_board_info.py > foo.json" before and after to generate a copy of the release info. When diffing them, there is no difference (as expected).

I also used a new quick debug facility just for checking extensions, "build_board_info.py espressif:adafruit_feather_esp32s2", to spot check that the code was working as expected, since running the full "build_board_info" process is time consuming.

The remaining special cases in "extension_by_board" should be moved to the correct mpconfigport.mk files and the whole facility of "extension by board" should be removed from build_board_info.py.