### PR TITLE
Make time.time() return float

### DIFF
--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -224,7 +224,8 @@ STATIC mp_obj_t time_time(void) {
     struct_time_to_tm(rtc_get_time_source_time(), &tm);
     mp_uint_t secs = timeutils_seconds_since_epoch(tm.tm_year, tm.tm_mon, tm.tm_mday,
         tm.tm_hour, tm.tm_min, tm.tm_sec);
-    return mp_obj_new_int_from_uint(secs);
+    mp_float_t secs_f = (mp_float_t)secs
+    return mp_obj_new_float(secs_f);
 }
 MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -224,7 +224,7 @@ STATIC mp_obj_t time_time(void) {
     struct_time_to_tm(rtc_get_time_source_time(), &tm);
     mp_uint_t secs = timeutils_seconds_since_epoch(tm.tm_year, tm.tm_mon, tm.tm_mday,
         tm.tm_hour, tm.tm_min, tm.tm_sec);
-    mp_float_t secs_f = (mp_float_t)secs
+    mp_float_t secs_f = (mp_float_t)secs;
     return mp_obj_new_float(secs_f);
 }
 MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -216,7 +216,7 @@ mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
 //|     """Return the current time in seconds since since Jan 1, 1970.
 //|
 //|     :return: the current time
-//|     :rtype: int"""
+//|     :rtype: float"""
 //|     ...
 //|
 STATIC mp_obj_t time_time(void) {


### PR DESCRIPTION
First real contribution!  Still pretty new to C/C++ as opposed to Python, but looking around, I think this is the fix for #3125, by casting it as a `float`.  If I understand correctly, this will default to using `float` or `double` depending on the board's implementation.