### PR TITLE
It's OK for an init program to be zero bytes long

### DIFF
--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -247,7 +247,7 @@ STATIC mp_obj_t rp2pio_statemachine_make_new(const mp_obj_type_t *type, size_t n
         mp_raise_ValueError(translate("Program size invalid"));
     }
 
-    mp_arg_validate_length_range(init_bufinfo.len, 2, 64, MP_QSTR_init);
+    mp_arg_validate_length_range(init_bufinfo.len, 0, 64, MP_QSTR_init);
     if (init_bufinfo.len % 2 != 0) {
         mp_raise_ValueError(translate("Init program size invalid"));
     }


### PR DESCRIPTION
The "2 to 64 bytes long" condition was added when the code was converted to use the common length checking functions, but actually 0 to 64 bytes is just fine for init code.

Closes #6636