### PR TITLE
Don't send escape codes during raw REPL

### DIFF
--- a/supervisor/shared/workflow.c
+++ b/supervisor/shared/workflow.c
@@ -48,6 +48,9 @@ static background_callback_t workflow_background_cb;
 
 #if CIRCUITPY_STATUS_BAR
 static void supervisor_workflow_update_status_bar(void) {
+    if (pyexec_mode_kind == PYEXEC_MODE_RAW_REPL) {
+        return;
+    }
     // Neighboring "" "" are concatenated by the compiler. Without this separation, the hex code
     // doesn't get terminated after two following characters and the value is invalid.
     // This is the OSC command to set the title and the icon text. It can be up to 255 characters


### PR DESCRIPTION
In the raw REPL, all usual output (such as echoing back characters) is stopped. This should probably include the status bar, since otherwise there's no way for a GUI like Thonny to differentiate between output from the code it executes remotely, vs the status bar changing.

(This is separate from whether the regular friendly repl's status bar updates will confuse Thonny; in that case, it'll be up to Thonny to show or suppress the status bar updates as appropriate)

Note: I only compile-tested this so far