### PR TITLE
Remove workaround for autoapi bug

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -33,25 +33,6 @@ from sphinx import addnodes
 
 tools_describe = str(pathlib.Path(__file__).parent / "tools/describe")
 
-# Monkeypatch autoapi
-def _format_args(args_info, include_annotations=True, ignore_self=None):
-    result = []
-
-    for i, (prefix, name, annotation, default) in enumerate(args_info):
-        if i == 0 and ignore_self is not None and name == ignore_self:
-            continue
-        formatted = "{}{}{}{}".format(
-            prefix or "",
-            name or "",
-            ": {}".format(annotation) if annotation and include_annotations else "",
-            (" = {}" if annotation else "={}").format(default) if default else "",
-        )
-        result.append(formatted)
-    return ", ".join(result)
-
-import autoapi.mappers.python.objects as objects
-objects._format_args = _format_args
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.


### PR DESCRIPTION
https://github.com/readthedocs/sphinx-autoapi/issues/328 has been fixed and released in version 1.9.0 on pypi.  This version should automatically be picked up, as we use unversioned dependencies on the package.