### PR TITLE
Improve web workflow responsiveness

### DIFF
--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -1265,6 +1265,9 @@ void supervisor_web_workflow_background(void) {
     // If we have a request in progress, continue working on it.
     if (common_hal_socketpool_socket_get_connected(&active)) {
         _process_request(&active, &active_request);
+    } else {
+        // Close the active socket if it is no longer connected.
+        common_hal_socketpool_socket_close(&active);
     }
 }
 


### PR DESCRIPTION
1. Run the socket select task at the same priority as CP. This is needed because it queues up the background work. Without it, CP needed to sleep to let the lower priority task go.
2. Close the active socket on disconnect. This prevents looping over a disconnected but not closed socket.

This also improve CI builds by using board compute settings for some changed file paths.