### PR TITLE
Adds `BOOT0` (`GPIO0`) as a named pin for MagTag.

### DIFF
--- a/ports/espressif/boards/adafruit_magtag_2.9_grayscale/pins.c
+++ b/ports/espressif/boards/adafruit_magtag_2.9_grayscale/pins.c
@@ -37,6 +37,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_BUTTON_D), MP_ROM_PTR(&pin_GPIO11) },
     { MP_ROM_QSTR(MP_QSTR_D11), MP_ROM_PTR(&pin_GPIO11) },
 
+    { MP_ROM_QSTR(MP_QSTR_BOOT0), MP_ROM_PTR(&pin_GPIO0) },
+
     { MP_ROM_QSTR(MP_QSTR_LIGHT), MP_ROM_PTR(&pin_GPIO3) },
     { MP_ROM_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_GPIO3) },
 


### PR DESCRIPTION
Hello you lovely folx.

Wasn't sure if this was an accidental or intentional omission. I needed the fifth button on my MagTag today and realized it isn't bound to a name, so I did that.

If leaving it out was intentional and I just missed the discussion to do so, feel free to close this! Otherwise, maybe there's more weirdos out there like me that wanted the extra button 🙂 