### PR TITLE
Update requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,6 +17,7 @@ polib
 # For pre-commit
 pyyaml
 black
+pre-commit
 
 # for combining the Nordic SoftDevice with CircuitPython
 intelhex


### PR DESCRIPTION
added pre-commit as it wasn't installed resulting in error when following learn guide: https://learn.adafruit.com/building-circuitpython/build-circuitpython