### PR TITLE
Add board.LED (alias of board.LED_R part of RGB)

### DIFF
--- a/ports/raspberrypi/boards/pimoroni_interstate75/pins.c
+++ b/ports/raspberrypi/boards/pimoroni_interstate75/pins.c
@@ -22,6 +22,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_SW_A), MP_ROM_PTR(&pin_GPIO14) },
 
+    { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO16) },
     { MP_ROM_QSTR(MP_QSTR_LED_R), MP_ROM_PTR(&pin_GPIO16) },
     { MP_ROM_QSTR(MP_QSTR_LED_G), MP_ROM_PTR(&pin_GPIO17) },
     { MP_ROM_QSTR(MP_QSTR_LED_B), MP_ROM_PTR(&pin_GPIO18) },


### PR DESCRIPTION
Totally untested change (will try with the artifact), but I think every board should have a board.LED if possible to be able to use the learn guide basic instruction.