### PR TITLE
fix name for macOS mpy-cross universal build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,11 +185,11 @@ jobs:
         name: mpy-cross-macos-11-arm64
         path: mpy-cross/mpy-cross-arm64
     - name: Make universal binary
-      run: lipo -create -output mpy-cross-macos-11-universal mpy-cross/mpy-cross mpy-cross/mpy-cross-arm64
+      run: lipo -create -output mpy-cross-macos-universal mpy-cross/mpy-cross mpy-cross/mpy-cross-arm64
     - uses: actions/upload-artifact@v2
       with:
         name: mpy-cross-macos-11-universal
-        path: mpy-cross-macos-11-universal
+        path: mpy-cross-macos-universal
     - name: Upload mpy-cross build to S3
       run: |
         [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross-macos-universal s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross-macos-11-${{ env.CP_VERSION }}-universal --no-progress --region us-east-1


### PR DESCRIPTION
I got the name for the universal build wrong. Let's try again.