### PR TITLE
Lots of web workflow, C3 and title bar fixes

### DIFF
--- a/main.c
+++ b/main.c
@@ -57,6 +57,7 @@
 #include "supervisor/shared/stack.h"
 #include "supervisor/shared/status_leds.h"
 #include "supervisor/shared/tick.h"
+#include "supervisor/shared/title_bar.h"
 #include "supervisor/shared/traceback.h"
 #include "supervisor/shared/translate/translate.h"
 #include "supervisor/shared/workflow.h"
@@ -822,7 +823,9 @@ STATIC int run_repl(bool first_run) {
     status_led_deinit();
     #endif
     if (pyexec_mode_kind == PYEXEC_MODE_RAW_REPL) {
+        supervisor_title_bar_suspend();
         exit_code = pyexec_raw_repl();
+        supervisor_title_bar_resume();
     } else {
         exit_code = pyexec_friendly_repl();
     }
@@ -914,6 +917,7 @@ int __attribute__((used)) main(void) {
     run_boot_py(safe_mode);
 
     supervisor_workflow_start();
+    supervisor_title_bar_start();
 
     // Boot script is finished, so now go into REPL or run code.py.
     int exit_code = PYEXEC_FORCED_EXIT;

--- a/ports/espressif/boards/adafruit_qtpy_esp32c3/sdkconfig
+++ b/ports/espressif/boards/adafruit_qtpy_esp32c3/sdkconfig
@@ -31,6 +31,14 @@ CONFIG_PARTITION_TABLE_FILENAME="esp-idf-config/partitions-4MB-no-uf2.csv"
 # Component config
 #
 #
+
+#
+# PHY
+#
+CONFIG_ESP_PHY_ENABLE_USB=y
+# end of PHY
+
+#
 # ESP System Settings
 #
 # CONFIG_ESP_SYSTEM_USE_EH_FRAME is not set

--- a/ports/espressif/boards/beetle-esp32-c3/sdkconfig
+++ b/ports/espressif/boards/beetle-esp32-c3/sdkconfig
@@ -1,4 +1,10 @@
 #
+# PHY
+#
+CONFIG_ESP_PHY_ENABLE_USB=y
+# end of PHY
+
+#
 # LWIP
 #
 CONFIG_LWIP_LOCAL_HOSTNAME="beetle-esp32-c3

--- a/ports/espressif/boards/lolin_c3_mini/sdkconfig
+++ b/ports/espressif/boards/lolin_c3_mini/sdkconfig
@@ -1,4 +1,10 @@
 #
+# PHY
+#
+CONFIG_ESP_PHY_ENABLE_USB=y
+# end of PHY
+
+#
 # LWIP
 #
 CONFIG_LWIP_LOCAL_HOSTNAME="lolin-c3-mini"

--- a/ports/espressif/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/espressif/common-hal/alarm/pin/PinAlarm.c
@@ -27,7 +27,7 @@
 
 #include "py/runtime.h"
 
-#include "supervisor/esp_port.h"
+#include "supervisor/port.h"
 #include "shared-bindings/alarm/pin/PinAlarm.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/__init__.h"
@@ -90,11 +90,7 @@ STATIC void gpio_interrupt(void *arg) {
             gpio_ll_intr_disable(&GPIO, 32 + i);
         }
     }
-    BaseType_t high_task_wakeup;
-    vTaskNotifyGiveFromISR(circuitpython_task, &high_task_wakeup);
-    if (high_task_wakeup) {
-        portYIELD_FROM_ISR();
-    }
+    port_wake_main_task_from_isr();
 }
 
 bool alarm_pin_pinalarm_woke_this_cycle(void) {

--- a/ports/espressif/common-hal/alarm/time/TimeAlarm.c
+++ b/ports/espressif/common-hal/alarm/time/TimeAlarm.c
@@ -27,7 +27,7 @@
 #include "esp_sleep.h"
 
 #include "py/runtime.h"
-#include "supervisor/esp_port.h"
+#include "supervisor/port.h"
 
 #include "components/esp_timer/include/esp_timer.h"
 
@@ -66,7 +66,7 @@ STATIC bool woke_up = false;
 STATIC void timer_callback(void *arg) {
     (void)arg;
     woke_up = true;
-    xTaskNotifyGive(circuitpython_task);
+    port_wake_main_task();
 }
 
 bool alarm_time_timealarm_woke_this_cycle(void) {

--- a/ports/espressif/common-hal/alarm/touch/TouchAlarm.c
+++ b/ports/espressif/common-hal/alarm/touch/TouchAlarm.c
@@ -30,7 +30,7 @@
 
 #include "esp_sleep.h"
 #include "peripherals/touch.h"
-#include "supervisor/esp_port.h"
+#include "supervisor/port.h"
 
 static uint16_t touch_channel_mask;
 static volatile bool woke_up = false;
@@ -86,11 +86,7 @@ mp_obj_t alarm_touch_touchalarm_create_wakeup_alarm(void) {
 STATIC void touch_interrupt(void *arg) {
     (void)arg;
     woke_up = true;
-    BaseType_t task_wakeup;
-    vTaskNotifyGiveFromISR(circuitpython_task, &task_wakeup);
-    if (task_wakeup) {
-        portYIELD_FROM_ISR();
-    }
+    port_wake_main_task_from_isr();
 }
 
 void alarm_touch_touchalarm_set_alarm(const bool deep_sleep, const size_t n_alarms, const mp_obj_t *alarms) {

--- a/ports/espressif/common-hal/wifi/__init__.c
+++ b/ports/espressif/common-hal/wifi/__init__.c
@@ -44,6 +44,7 @@ wifi_radio_obj_t common_hal_wifi_radio_obj;
 #include "components/log/include/esp_log.h"
 
 #include "supervisor/port.h"
+#include "supervisor/shared/title_bar.h"
 #include "supervisor/workflow.h"
 
 #include "esp_ipc.h"
@@ -55,7 +56,7 @@ wifi_radio_obj_t common_hal_wifi_radio_obj;
 static const char *TAG = "CP wifi";
 
 STATIC void schedule_background_on_cp_core(void *arg) {
-    supervisor_workflow_request_background();
+    supervisor_title_bar_request_update(false);
 
     // CircuitPython's VM is run in a separate FreeRTOS task from wifi callbacks. So, we have to
     // notify the main task every time in case it's waiting for us.

--- a/ports/espressif/supervisor/port.c
+++ b/ports/espressif/supervisor/port.c
@@ -30,7 +30,6 @@
 #include "supervisor/board.h"
 #include "supervisor/port.h"
 #include "py/runtime.h"
-#include "supervisor/esp_port.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -388,6 +387,14 @@ void port_disable_tick(void) {
 
 void port_wake_main_task() {
     xTaskNotifyGive(circuitpython_task);
+}
+
+void port_wake_main_task_from_isr() {
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    vTaskNotifyGiveFromISR(circuitpython_task, &xHigherPriorityTaskWoken);
+    if (xHigherPriorityTaskWoken == pdTRUE) {
+        portYIELD_FROM_ISR();
+    }
 }
 
 void sleep_timer_cb(void *arg) {

--- a/ports/espressif/supervisor/usb.c
+++ b/ports/espressif/supervisor/usb.c
@@ -27,7 +27,6 @@
 
 #include "py/runtime.h"
 #include "supervisor/usb.h"
-#include "supervisor/esp_port.h"
 #include "supervisor/port.h"
 #include "shared/runtime/interrupt_char.h"
 #include "shared/readline/readline.h"

--- a/supervisor/port.h
+++ b/supervisor/port.h
@@ -99,8 +99,14 @@ void port_background_task(void);
 void port_start_background_task(void);
 void port_finish_background_task(void);
 
-// Some ports need special handling to wake the main task from an interrupt
-// context or other task.  The port must implement the necessary code in this
-// function.  A default weak implementation is provided that does nothing.
+// Some ports need special handling to wake the main task from another task. The
+// port must implement the necessary code in this function.  A default weak
+// implementation is provided that does nothing.
 void port_wake_main_task(void);
+
+// Some ports need special handling to wake the main task from an interrupt
+// context.  The port must implement the necessary code in this function.  A
+// default weak implementation is provided that does nothing.
+void port_wake_main_task_from_isr(void);
+
 #endif  // MICROPY_INCLUDED_SUPERVISOR_PORT_H

--- a/supervisor/shared/port.c
+++ b/supervisor/shared/port.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Lucian Copeland for Adafruit Industries
+ * Copyright (c) 2022 Scott Shawcroft for Adafruit Industries
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,12 +24,10 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_ESPRESSIF_SUPERVISOR_PORT_H
-#define MICROPY_INCLUDED_ESPRESSIF_SUPERVISOR_PORT_H
+#include "supervisor/port.h"
 
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
+MP_WEAK void port_wake_main_task(void) {
+}
 
-extern TaskHandle_t circuitpython_task;
-
-#endif // MICROPY_INCLUDED_ESPRESSIF_SUPERVISOR_PORT_H
+MP_WEAK void port_wake_main_task_from_isr(void) {
+}

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -207,9 +207,16 @@ char serial_read(void) {
 
     #if CIRCUITPY_WEB_WORKFLOW
     if (websocket_available()) {
-        return websocket_read_char();
+        char c = websocket_read_char();
+        if (c != -1) {
+            return c;
+        }
     }
     #endif
+
+    if (port_serial_bytes_available() > 0) {
+        return port_serial_read();
+    }
 
     #if CIRCUITPY_USB_CDC
     if (!usb_cdc_console_enabled()) {
@@ -220,9 +227,6 @@ char serial_read(void) {
     return (char)tud_cdc_read_char();
     #endif
 
-    if (port_serial_bytes_available() > 0) {
-        return port_serial_read();
-    }
     return -1;
 }
 

--- a/supervisor/shared/title_bar.c
+++ b/supervisor/shared/title_bar.c
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Scott Shawcroft for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdbool.h>
+#include "genhdr/mpversion.h"
+#include "py/mpconfig.h"
+#include "supervisor/background_callback.h"
+#include "supervisor/serial.h"
+#include "supervisor/shared/title_bar.h"
+
+#if CIRCUITPY_WEB_WORKFLOW
+#include "supervisor/shared/web_workflow/web_workflow.h"
+#endif
+static background_callback_t title_bar_background_cb;
+
+static bool _forced_dirty = false;
+static bool _suspended = false;
+
+static void title_bar_background(void *data) {
+    if (_suspended) {
+        return;
+    }
+    bool dirty = _forced_dirty;
+
+    #if CIRCUITPY_WEB_WORKFLOW
+    dirty = dirty || supervisor_web_workflow_status_dirty();
+    #endif
+
+    if (!dirty) {
+        return;
+    }
+    _forced_dirty = false;
+    #if CIRCUITPY_STATUS_BAR
+    // Neighboring "" "" are concatenated by the compiler. Without this separation, the hex code
+    // doesn't get terminated after two following characters and the value is invalid.
+    // This is the OSC command to set the title and the icon text. It can be up to 255 characters
+    // but some may be cut off.
+    serial_write("\x1b" "]0;");
+    serial_write("🐍 ");
+    #if CIRCUITPY_WEB_WORKFLOW
+    supervisor_web_workflow_status();
+    #endif
+    serial_write("|");
+    serial_write(MICROPY_GIT_TAG);
+    // Send string terminator
+    serial_write("\x1b" "\\");
+    #endif
+}
+
+void supervisor_title_bar_start(void) {
+    title_bar_background_cb.fun = title_bar_background;
+    title_bar_background_cb.data = NULL;
+    supervisor_title_bar_request_update(true);
+}
+
+void supervisor_title_bar_request_update(bool force_dirty) {
+    if (force_dirty) {
+        _forced_dirty = true;
+    }
+    background_callback_add_core(&title_bar_background_cb);
+}
+
+void supervisor_title_bar_suspend(void) {
+    _suspended = true;
+}
+
+void supervisor_title_bar_resume(void) {
+    _suspended = false;
+    supervisor_title_bar_request_update(false);
+}

--- a/supervisor/shared/title_bar.c
+++ b/supervisor/shared/title_bar.c
@@ -40,6 +40,9 @@ static bool _forced_dirty = false;
 static bool _suspended = false;
 
 static void title_bar_background(void *data) {
+    #if !CIRCUITPY_STATUS_BAR
+    return;
+    #endif
     if (_suspended) {
         return;
     }
@@ -53,7 +56,6 @@ static void title_bar_background(void *data) {
         return;
     }
     _forced_dirty = false;
-    #if CIRCUITPY_STATUS_BAR
     // Neighboring "" "" are concatenated by the compiler. Without this separation, the hex code
     // doesn't get terminated after two following characters and the value is invalid.
     // This is the OSC command to set the title and the icon text. It can be up to 255 characters
@@ -67,16 +69,21 @@ static void title_bar_background(void *data) {
     serial_write(MICROPY_GIT_TAG);
     // Send string terminator
     serial_write("\x1b" "\\");
-    #endif
 }
 
 void supervisor_title_bar_start(void) {
+    #if !CIRCUITPY_STATUS_BAR
+    return;
+    #endif
     title_bar_background_cb.fun = title_bar_background;
     title_bar_background_cb.data = NULL;
     supervisor_title_bar_request_update(true);
 }
 
 void supervisor_title_bar_request_update(bool force_dirty) {
+    #if !CIRCUITPY_STATUS_BAR
+    return;
+    #endif
     if (force_dirty) {
         _forced_dirty = true;
     }
@@ -84,10 +91,16 @@ void supervisor_title_bar_request_update(bool force_dirty) {
 }
 
 void supervisor_title_bar_suspend(void) {
+    #if !CIRCUITPY_STATUS_BAR
+    return;
+    #endif
     _suspended = true;
 }
 
 void supervisor_title_bar_resume(void) {
+    #if !CIRCUITPY_STATUS_BAR
+    return;
+    #endif
     _suspended = false;
     supervisor_title_bar_request_update(false);
 }

--- a/supervisor/shared/title_bar.h
+++ b/supervisor/shared/title_bar.h
@@ -28,10 +28,7 @@
 
 #include <stdbool.h>
 
-// This background function should be called repeatedly. It cannot be done based
-// on events.
-void supervisor_web_workflow_background(void);
-bool supervisor_web_workflow_status_dirty(void);
-void supervisor_web_workflow_status(void);
-void supervisor_start_web_workflow(void);
-void supervisor_stop_web_workflow(void);
+void supervisor_title_bar_start(void);
+void supervisor_title_bar_suspend(void);
+void supervisor_title_bar_resume(void);
+void supervisor_title_bar_request_update(bool force_dirty);

--- a/supervisor/shared/web_workflow/static/serial.js
+++ b/supervisor/shared/web_workflow/static/serial.js
@@ -63,10 +63,12 @@ input.addEventListener("beforeinput", function(e) {
     input.value = "";
     input.focus();
     e.preventDefault();
-  } else if (e.inputType == "insertText") {
+  } else if (e.inputType == "insertText" || e.inputType == "insertFromPaste") {
     ws.send(e.data);
   } else if (e.inputType == "deleteContentBackward") {
     ws.send("\b");
+  } else {
+    console.log(e);
   }
 });
 

--- a/supervisor/shared/workflow.c
+++ b/supervisor/shared/workflow.c
@@ -46,27 +46,7 @@
 #endif
 static background_callback_t workflow_background_cb;
 
-#if CIRCUITPY_STATUS_BAR
-static void supervisor_workflow_update_status_bar(void) {
-    // Neighboring "" "" are concatenated by the compiler. Without this separation, the hex code
-    // doesn't get terminated after two following characters and the value is invalid.
-    // This is the OSC command to set the title and the icon text. It can be up to 255 characters
-    // but some may be cut off.
-    serial_write("\x1b" "]0;");
-    serial_write("🐍 ");
-    #if CIRCUITPY_WEB_WORKFLOW
-    supervisor_web_workflow_status();
-    #endif
-    // Send string terminator
-    serial_write("\x1b" "\\");
-}
-#endif
-
 static void workflow_background(void *data) {
-    #if CIRCUITPY_STATUS_BAR
-    supervisor_workflow_update_status_bar();
-    #endif
-
     #if CIRCUITPY_WEB_WORKFLOW
     supervisor_web_workflow_background();
     #endif

--- a/supervisor/supervisor.mk
+++ b/supervisor/supervisor.mk
@@ -8,12 +8,14 @@ SRC_SUPERVISOR = \
 	supervisor/shared/lock.c \
 	supervisor/shared/memory.c \
 	supervisor/shared/micropython.c \
+	supervisor/shared/port.c \
 	supervisor/shared/reload.c \
 	supervisor/shared/safe_mode.c \
   supervisor/shared/serial.c \
 	supervisor/shared/stack.c \
 	supervisor/shared/status_leds.c \
 	supervisor/shared/tick.c \
+	supervisor/shared/title_bar.c \
 	supervisor/shared/traceback.c \
 	supervisor/shared/translate/translate.c \
   supervisor/shared/workflow.c


### PR DESCRIPTION
* Fixes #6221 - C3 hang on `import wifi`. Enabling the WiFi PHY was
  disabling USB. Now boards that use it set CONFIG_ESP_PHY_ENABLE_USB
  explicitly.
* Fixes #6655 - Allows pasting into the web serial page. Fixes reading
  more than 0xf bytes at a time.
* Fixes #6653 - Fixes web socket encoding of payloads >125 bytes. Can
  happen when printing a long string.
* Fixes C3 responsiveness when waiting for key to enter REPL. (It
  now correctly stops sleeping.)
* Disables title bar updates when in raw REPL. Related to #6548.
* Adds version to title bar.