### PR TITLE
Fix SAMD I2C frequency check

### DIFF
--- a/ports/atmel-samd/common-hal/busio/I2C.c
+++ b/ports/atmel-samd/common-hal/busio/I2C.c
@@ -123,7 +123,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     // The maximum frequency divisor gives a clock rate of around 48MHz/2/255
     // but set_baudrate does not diagnose this problem. (This is not the
     // exact cutoff, but no frequency well under 100kHz is available)
-    if (frequency < 95000 &&
+    if (frequency < 95000 ||
         i2c_m_sync_set_baudrate(&self->i2c_desc, 0, frequency / 1000) != ERR_NONE) {
         reset_pin_number(sda->number);
         reset_pin_number(scl->number);

--- a/ports/atmel-samd/common-hal/busio/I2C.c
+++ b/ports/atmel-samd/common-hal/busio/I2C.c
@@ -123,8 +123,8 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     // The maximum frequency divisor gives a clock rate of around 48MHz/2/255
     // but set_baudrate does not diagnose this problem. (This is not the
     // exact cutoff, but no frequency well under 100kHz is available)
-    if (frequency < 95000 ||
-        i2c_m_sync_set_baudrate(&self->i2c_desc, 0, frequency / 1000) != ERR_NONE) {
+    if ((frequency < 95000) ||
+        (i2c_m_sync_set_baudrate(&self->i2c_desc, 0, frequency / 1000) != ERR_NONE)) {
         reset_pin_number(sda->number);
         reset_pin_number(scl->number);
         common_hal_busio_i2c_deinit(self);


### PR DESCRIPTION
Fixes #6669.

Incorrect boolean operator introduced when consolidating error messages and checks.

Tested on a Metro M4.