### PR TITLE
fix edit URL for files inside of directories

### DIFF
--- a/supervisor/shared/web_workflow/static/directory.js
+++ b/supervisor/shared/web_workflow/static/directory.js
@@ -63,6 +63,7 @@ async function refresh_list() {
         var icon = "⬇";
         var file_path = current_path + f.name;
         let api_url = new URL("/fs" + file_path, url_base);
+        let edit_url = "/edit/#" + file_path;
         if (f.directory) {
             file_path = "#" + file_path + "/";
             api_url += "/";
@@ -91,7 +92,7 @@ async function refresh_list() {
         delete_button.disabled = !editable;
         delete_button.onclick = del;
 
-        let edit_url = new URL("/edit/#" + f.name, url_base);
+        edit_url = new URL(edit_url, url_base);
         let edit_link = clone.querySelector(".edit_link");
         edit_link.href = edit_url
 


### PR DESCRIPTION
Fixes the URL for the edit link on directory pages in the web workflow to include the directory in the hash portion of the URL.

Resolves: #6671 

Under current version the file `/lib/adafruit_logging.py` will end up with a url containing only `#adafruit_logging.py`

With this branch it will include the directory so it will be `#/lib/adafruit_logging.py`