### PR TITLE
Add Authorization to Allow-Headers in web workflow

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -82,6 +82,7 @@ CIRCUITPY_WIFI_SSID='scottswifi'
 CIRCUITPY_WIFI_PASSWORD='secretpassword'
 
 # To enable modifying files from the web. Change this too!
+# Leave the User field blank in the browser.
 CIRCUITPY_WEB_API_PASSWORD='passw0rd'
 
 CIRCUITPY_WEB_API_PORT=80
@@ -121,7 +122,7 @@ The web server will allow requests from `cpy-XXXXXX.local`, `127.0.0.1`, the dev
 ### File REST API
 All file system related APIs are protected by HTTP basic authentication. It is *NOT* secure but will
 hopefully prevent some griefing in shared settings. The password is sent unencrypted so do not reuse
-a password with something important.
+a password with something important. The user field is left blank.
 
 The password is taken from `/.env` with the key `CIRCUITPY_WEB_API_PASSWORD`. If this is unset, the
 server will respond with `403 Forbidden`. When a password is set, but not provided in a request, it

--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -492,7 +492,7 @@ static void _reply_access_control(socketpool_socket_obj_t *socket, _request *req
         "HTTP/1.1 204 No Content\r\n",
         "Content-Length: 0\r\n",
         "Access-Control-Expose-Headers: Access-Control-Allow-Methods\r\n",
-        "Access-Control-Allow-Headers: X-Timestamp, Content-Type\r\n",
+        "Access-Control-Allow-Headers: X-Timestamp, Content-Type, Authorization\r\n",
         "Access-Control-Allow-Methods:GET, OPTIONS", NULL);
     if (!_usb_active()) {
         _send_str(socket, ", PUT, DELETE");


### PR DESCRIPTION
Makes Safari happy with CORS.
Also added the mention that the user field should be left empty.