### PR TITLE
WebWorkFlow CSS Tweaks for edit.html

### DIFF
--- a/supervisor/shared/web_workflow/static/edit.html
+++ b/supervisor/shared/web_workflow/static/edit.html
@@ -3,18 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Code Edit</title>
-    <style>
-        #code_textarea {
-            width: 90%;
-            height: 600px;
-        }
-
-        #output_text {
-            margin: 0;
-            font-size: 0.7em;
-        }
-    </style>
-
+    <link rel="stylesheet" href="http://circuitpython.org/assets/css/webworkflow-8.css">
+    <link rel="stylesheet" href="/style.css">
 </head>
 <body>
 <button id="save_btn">Save</button>

--- a/supervisor/shared/web_workflow/static/style.css
+++ b/supervisor/shared/web_workflow/static/style.css
@@ -5,3 +5,15 @@ body {
   font-family: "Proxima Nova", Verdana, sans-serif;
   line-height: 20.7px;
 }
+
+
+/* for edit.html */
+#code_textarea {
+    width: 90%;
+    height: 600px;
+}
+
+#output_text {
+    margin: 0;
+    font-size: 0.7em;
+}


### PR DESCRIPTION
updated the edit.html to use the onboard stylesheet and remote css. Moved the css inside the <style> tags into the stylesheet