### PR TITLE
Fix S2/S3 USB

### DIFF
--- a/ports/espressif/CMakeLists.txt
+++ b/ports/espressif/CMakeLists.txt
@@ -6,7 +6,7 @@ set(ENV{IDF_PATH} ${CMAKE_SOURCE_DIR}/esp-idf)
 
 # The component list here determines what options we get in menuconfig and what the ninja file
 # can build.
-set(COMPONENTS esptool_py soc driver log main esp-tls mbedtls mdns esp_event esp_adc_cal esp_netif esp_wifi lwip wpa_supplicant freertos bt)
+set(COMPONENTS esptool_py soc driver log main esp-tls mbedtls mdns esp_event esp_adc_cal esp_netif esp_wifi lwip wpa_supplicant freertos bt usb)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(circuitpython)


### PR DESCRIPTION
The new Kconfig that fixed C3 added a dependency on USB_OTG_SUPPORTED
that is only calculated if we include the usb module in cmake.

Fixes #6679