### PR TITLE
Add exception filename to title bar

### DIFF
--- a/main.c
+++ b/main.c
@@ -213,8 +213,9 @@ void supervisor_execution_status(void) {
     if (_current_executing_filename != NULL) {
         serial_write(_current_executing_filename);
     } else if ((_exec_result.return_code & PYEXEC_EXCEPTION) != 0 &&
+               _exec_result.exception_line > 0 &&
                exception != NULL) {
-        mp_printf(&mp_plat_print, "@%d %q", _exec_result.exception_line, exception->base.type->name);
+        mp_printf(&mp_plat_print, "@%d %s %q", _exec_result.exception_line, _exec_result.exception_filename, exception->base.type->name);
     } else {
         serial_write_compressed(translate("Done"));
     }

--- a/main.c
+++ b/main.c
@@ -215,7 +215,7 @@ void supervisor_execution_status(void) {
     } else if ((_exec_result.return_code & PYEXEC_EXCEPTION) != 0 &&
                _exec_result.exception_line > 0 &&
                exception != NULL) {
-        mp_printf(&mp_plat_print, "@%d %s %q", _exec_result.exception_line, _exec_result.exception_filename, exception->base.type->name);
+        mp_printf(&mp_plat_print, "%d@%s %q", _exec_result.exception_line, _exec_result.exception_filename, exception->base.type->name);
     } else {
         serial_write_compressed(translate("Done"));
     }

--- a/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
@@ -144,6 +144,18 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
         gpio_set_level(21, true);
         return true;
     }
+    // Pull LED down on reset rather than the default up
+    if (pin_number == 13) {
+        gpio_config_t cfg = {
+            .pin_bit_mask = BIT64(pin_number),
+            .mode = GPIO_MODE_DISABLE,
+            .pull_up_en = false,
+            .pull_down_en = true,
+            .intr_type = GPIO_INTR_DISABLE,
+        };
+        gpio_config(&cfg);
+        return true;
+    }
     return false;
 }
 

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -199,7 +199,9 @@ STATIC int parse_compile_execute(const void *source, mp_parse_input_kind_t input
                 size_t n, *values;
                 mp_obj_exception_get_traceback(return_value, &n, &values);
                 if (values != NULL) {
-                    result->exception_line = values[n - 2];
+                    result->exception_line = values[1];
+                    result->exception_filename[sizeof(result->exception_filename) - 1] = '\0';
+                    strncpy(result->exception_filename, qstr_str(values[0]), sizeof(result->exception_filename) - 1);
                 }
             }
         }

--- a/shared/runtime/pyexec.h
+++ b/shared/runtime/pyexec.h
@@ -37,6 +37,9 @@ typedef struct {
     int return_code;
     mp_obj_t exception;
     int exception_line;
+    // Only store the first 32 characters of the filename. It is very unlikely that they can all be
+    // seen.
+    char exception_filename[33];
 } pyexec_result_t;
 
 extern pyexec_mode_kind_t pyexec_mode_kind;


### PR DESCRIPTION
Add the exception filename after the line number and change the
line number so it is in that file. It used to always be code.py.

Fixes #6702