### PR TITLE
switch back one I2C message

### DIFF
--- a/ports/espressif/common-hal/i2ctarget/I2CTarget.c
+++ b/ports/espressif/common-hal/i2ctarget/I2CTarget.c
@@ -54,7 +54,7 @@ void common_hal_i2ctarget_i2c_target_construct(i2ctarget_i2c_target_obj_t *self,
     self->i2c_num = peripherals_i2c_get_free_num();
 
     if (self->i2c_num == I2C_NUM_MAX) {
-        mp_raise_ValueError(translate("All I2C targets are in use"));
+        mp_raise_ValueError(translate("All I2C peripherals are in use"));
     }
 
     const i2c_config_t i2c_conf = {


### PR DESCRIPTION
Fixes #6737.

I inadvertently changed "All I2C peripherals are in use" to "All I2C targets are in use" in `I2Ctarget.c` in #6721. This switches it back. Thanks to @bergdahl and @jepler for noticing.

In this particular message, "peripheral" means the hardware on the microcontroller chip. It does not refer to an "I2C target", formerly called an "I2C peripheral". The other changes of "I2C peripheral" to "I2C target" do reflect the updated official terminology.