### PR TITLE
Enable qrio to work with rgb565 data, including byte-swapped data

### DIFF
--- a/ports/espressif/bindings/esp32_camera/Camera.c
+++ b/ports/espressif/bindings/esp32_camera/Camera.c
@@ -57,7 +57,7 @@
 //|         pixel_format: PixelFormat=PixelFormat.RGB565,
 //|         frame_size: FrameSize=FrameSize.QQVGA,
 //|         jpeg_quality: int=15,
-//|         double_buffered: bool = True,
+//|         framebuffer_count: int = 1,
 //|         grab_mode: GrabMode = GrabMode.WHEN_EMPTY,
 //|     ) -> None:
 //|         """

--- a/shared-bindings/qrio/PixelPolicy.c
+++ b/shared-bindings/qrio/PixelPolicy.c
@@ -39,13 +39,23 @@
 //|     ODD_BYTES: PixelPolicy
 //|     """The input buffer to `QRDecoder.decode` consists of greyscale values in positions 1, 3, …, and ignored bytes in positions 0, 2, ….  This can decode directly from YUV images where the odd bytes hold the Y (luminance) data"""
 //|
+//|     RGB565_SWAPPED: PixelPolicy
+//|     """The input buffer to `QRDecoder.decode` consists of RGB565 values in byte-swapped order.  The green component is used."""
+//|
+//|     RGB565: PixelPolicy
+//|     """The input buffer to `QRDecoder.decode` consists of RGB565 values.  The green component is used."""
+//|
 
 MAKE_ENUM_VALUE(qrio_pixel_policy_type, qrio_pixel_policy, EVERY_BYTE, QRIO_EVERY_BYTE);
+MAKE_ENUM_VALUE(qrio_pixel_policy_type, qrio_pixel_policy, RGB565, QRIO_RGB565);
+MAKE_ENUM_VALUE(qrio_pixel_policy_type, qrio_pixel_policy, RGB565_SWAPPED, QRIO_RGB565_SWAPPED);
 MAKE_ENUM_VALUE(qrio_pixel_policy_type, qrio_pixel_policy, EVEN_BYTES, QRIO_EVEN_BYTES);
 MAKE_ENUM_VALUE(qrio_pixel_policy_type, qrio_pixel_policy, ODD_BYTES, QRIO_EVEN_BYTES);
 
 MAKE_ENUM_MAP(qrio_pixel_policy) {
     MAKE_ENUM_MAP_ENTRY(qrio_pixel_policy, EVERY_BYTE),
+    MAKE_ENUM_MAP_ENTRY(qrio_pixel_policy, RGB565),
+    MAKE_ENUM_MAP_ENTRY(qrio_pixel_policy, RGB565_SWAPPED),
     MAKE_ENUM_MAP_ENTRY(qrio_pixel_policy, EVEN_BYTES),
     MAKE_ENUM_MAP_ENTRY(qrio_pixel_policy, ODD_BYTES),
 };

--- a/shared-bindings/qrio/PixelPolicy.c
+++ b/shared-bindings/qrio/PixelPolicy.c
@@ -34,16 +34,16 @@
 //|     """The input buffer to `QRDecoder.decode` consists of greyscale values in every byte"""
 //|
 //|     EVEN_BYTES: PixelPolicy
-//|     """The input buffer to `QRDecoder.decode` consists of greyscale values in positions 0, 2, …, and ignored bytes in positions 1, 3, ….  This can decode directly from YUV images where the even bytes hold the Y (luminance) data."""
+//|     """The input buffer to `QRDecoder.decode` consists of greyscale values in positions 0, 2, …, and ignored bytes in positions 1, 3, …. This can decode directly from YUV images where the even bytes hold the Y (luminance) data."""
 //|
 //|     ODD_BYTES: PixelPolicy
-//|     """The input buffer to `QRDecoder.decode` consists of greyscale values in positions 1, 3, …, and ignored bytes in positions 0, 2, ….  This can decode directly from YUV images where the odd bytes hold the Y (luminance) data"""
+//|     """The input buffer to `QRDecoder.decode` consists of greyscale values in positions 1, 3, …, and ignored bytes in positions 0, 2, …. This can decode directly from YUV images where the odd bytes hold the Y (luminance) data"""
 //|
 //|     RGB565_SWAPPED: PixelPolicy
-//|     """The input buffer to `QRDecoder.decode` consists of RGB565 values in byte-swapped order.  The green component is used."""
+//|     """The input buffer to `QRDecoder.decode` consists of RGB565 values in byte-swapped order. Most cameras produce data in byte-swapped order. The green component is used."""
 //|
 //|     RGB565: PixelPolicy
-//|     """The input buffer to `QRDecoder.decode` consists of RGB565 values.  The green component is used."""
+//|     """The input buffer to `QRDecoder.decode` consists of RGB565 values in native order. The green component is used."""
 //|
 
 MAKE_ENUM_VALUE(qrio_pixel_policy_type, qrio_pixel_policy, EVERY_BYTE, QRIO_EVERY_BYTE);

--- a/shared-bindings/qrio/PixelPolicy.h
+++ b/shared-bindings/qrio/PixelPolicy.h
@@ -33,7 +33,7 @@
 extern const mp_obj_type_t qrio_pixel_policy_type;
 
 typedef enum {
-    QRIO_EVERY_BYTE, QRIO_EVEN_BYTES, QRIO_ODD_BYTES
+    QRIO_EVERY_BYTE, QRIO_EVEN_BYTES, QRIO_ODD_BYTES, QRIO_RGB565, QRIO_RGB565_SWAPPED
 } qrio_pixel_policy_t;
 
 extern const cp_enum_obj_t qrio_pixel_policy_EVERY_BYTE_obj;

--- a/shared-module/qrio/QRDecoder.c
+++ b/shared-module/qrio/QRDecoder.c
@@ -104,6 +104,20 @@ mp_obj_t shared_module_qrio_qrdecoder_decode(qrdecoder_qrdecoder_obj_t *self, co
     uint8_t *src = bufinfo->buf;
 
     switch (policy) {
+        case QRIO_RGB565: {
+            uint16_t *src16 = bufinfo->buf;
+            for (int i = 0; i < width * height; i++) {
+                framebuffer[i] = (src16[i] >> 3) & 0xfc;
+            }
+            break;
+        }
+        case QRIO_RGB565_SWAPPED: {
+            uint16_t *src16 = bufinfo->buf;
+            for (int i = 0; i < width * height; i++) {
+                framebuffer[i] = (__builtin_bswap16(src16[i]) >> 3) & 0xfc;
+            }
+            break;
+        }
         case QRIO_EVERY_BYTE:
             memcpy(framebuffer, src, width * height);
             break;
@@ -116,6 +130,7 @@ mp_obj_t shared_module_qrio_qrdecoder_decode(qrdecoder_qrdecoder_obj_t *self, co
             for (int i = 0; i < width * height; i++) {
                 framebuffer[i] = src[2 * i];
             }
+            break;
     }
     quirc_end(self->quirc);
 


### PR DESCRIPTION
.. and fix a docstring for camera.

With this, the qrio demo can be adapted to esp32-s3-eye and with better performance than the previous variant because it doesn't have to multiply process pixels for display & internal use by qrio.