### PR TITLE
Touchin.c - fix clean up in constructor before exception is thrown

### DIFF
--- a/shared-module/touchio/TouchIn.c
+++ b/shared-module/touchio/TouchIn.c
@@ -78,6 +78,7 @@ void common_hal_touchio_touchin_construct(touchio_touchin_obj_t *self, const mcu
 
     uint16_t raw_reading = get_raw_reading(self);
     if (raw_reading == TIMEOUT_TICKS) {
+        common_hal_touchio_touchin_deinit(self);
         mp_raise_ValueError(translate("No pulldown on pin; 1Mohm recommended"));
     }
     self->threshold = raw_reading * 1.05 + 100;


### PR DESCRIPTION
When the constructor value reading times out, an exception is thrown, but the digital pin is not de-initialised. Make sure to run the clean up, so user could catch the exception and retry using the same pin.