### PR TITLE
Fix retries after successful connection.

### DIFF
--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -336,6 +336,9 @@ wifi_radio_error_t common_hal_wifi_radio_connect(wifi_radio_obj_t *self, uint8_t
             return WIFI_RADIO_ERROR_NO_AP_FOUND;
         }
         return self->last_disconnect_reason;
+    } else {
+        // We're connected, allow us to retry if we get disconnected.
+        self->retries_left = self->starting_retries;
     }
     return WIFI_RADIO_ERROR_NONE;
 }

--- a/supervisor/shared/web_workflow/websocket.c
+++ b/supervisor/shared/web_workflow/websocket.c
@@ -248,9 +248,6 @@ static void _websocket_send(_websocket *ws, const char *text, size_t len) {
         _send_raw(&ws->socket, extended_len, 4);
     }
     _send_raw(&ws->socket, (const uint8_t *)text, len);
-    char copy[len];
-    memcpy(copy, text, len);
-    copy[len] = '\0';
 }
 
 void websocket_write(const char *text, size_t len) {


### PR DESCRIPTION
We may have set retries to 0 to enforce a timeout but the connect
succeeded. When it succeeds, we want to allow retries later in
case we lose signal briefly. (The callback will do this too but
the connect function will override it after.)

Also, remove extra code from websocket that is leftover from
debugging.