### PR TITLE
When reading data from a file into a str, check if it's utf-8

### DIFF
--- a/tests/extmod/qrio.py
+++ b/tests/extmod/qrio.py
@@ -5,7 +5,7 @@ except:
     raise SystemExit
 
 loc = __file__.rsplit("/", 1)[0]
-with open(f"{loc}/data/qr.pgm") as f:
+with open(f"{loc}/data/qr.pgm", "rb") as f:
     content = f.read()[-320 * 240 :]
 
 decoder = qrio.QRDecoder(320, 240)


### PR DESCRIPTION
Otherwise, weird stuff can happen down the line when it is print()ed, especially as it can break the webrepl of circuitpython. Closes #6752.

This needs formal tests, not just the manual testing I did.