### PR TITLE
shared-module/usb_hid: Fix behavior of Device.get_last_received_report()

### DIFF
--- a/shared-module/usb_hid/Device.h
+++ b/shared-module/usb_hid/Device.h
@@ -38,6 +38,7 @@ typedef struct  {
     const uint8_t *report_descriptor;
     uint8_t *in_report_buffers[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];
     uint8_t *out_report_buffers[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];
+    uint8_t out_report_buffers_updated[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];
     uint16_t report_descriptor_length;
     uint8_t report_ids[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];
     uint8_t in_report_lengths[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];


### PR DESCRIPTION
Documentation states that get_last_received_report() function should
return None if there was no report received previously, otherwise it
should return report. Moreover, same report should be returned only
once. That makes it possible to reliably process incoming OUT/Feature
reports.

This patch adds an array that stores flags if report with particular
ID was received and updates get_last_received_report() to match its
documentation.

Fixes #6764