### PR TITLE
More MicroPython float format fixes

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -242,10 +242,12 @@ extern mp_uint_t mp_verbose_flag;
 
 #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
 #define MP_FLOAT_EXP_BITS (11)
+#define MP_FLOAT_EXP_OFFSET (1023)
 #define MP_FLOAT_FRAC_BITS (52)
 typedef uint64_t mp_float_uint_t;
 #elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
 #define MP_FLOAT_EXP_BITS (8)
+#define MP_FLOAT_EXP_OFFSET (127)
 #define MP_FLOAT_FRAC_BITS (23)
 typedef uint32_t mp_float_uint_t;
 #endif

--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -168,37 +168,73 @@ value_error:
     }
 }
 
+enum {
+    REAL_IMAG_STATE_START = 0,
+    REAL_IMAG_STATE_HAVE_REAL = 1,
+    REAL_IMAG_STATE_HAVE_IMAG = 2,
+};
+
 typedef enum {
     PARSE_DEC_IN_INTG,
     PARSE_DEC_IN_FRAC,
     PARSE_DEC_IN_EXP,
 } parse_dec_in_t;
 
-mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool force_complex, mp_lexer_t *lex) {
-    #if MICROPY_PY_BUILTINS_FLOAT
-
+#if MICROPY_PY_BUILTINS_FLOAT
 // DEC_VAL_MAX only needs to be rough and is used to retain precision while not overflowing
 // SMALL_NORMAL_VAL is the smallest power of 10 that is still a normal float
 // EXACT_POWER_OF_10 is the largest value of x so that 10^x can be stored exactly in a float
 //   Note: EXACT_POWER_OF_10 is at least floor(log_5(2^mantissa_length)). Indeed, 10^n = 2^n * 5^n
 //   so we only have to store the 5^n part in the mantissa (the 2^n part will go into the float's
 //   exponent).
-    #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
+#if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
 #define DEC_VAL_MAX 1e20F
 #define SMALL_NORMAL_VAL (1e-37F)
 #define SMALL_NORMAL_EXP (-37)
 #define EXACT_POWER_OF_10 (9)
-    #elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
+#elif MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
 #define DEC_VAL_MAX 1e200
 #define SMALL_NORMAL_VAL (1e-307)
 #define SMALL_NORMAL_EXP (-307)
 #define EXACT_POWER_OF_10 (22)
-    #endif
+#endif
+
+// Break out inner digit accumulation routine to ease trailing zero deferral.
+static void accept_digit(mp_float_t *p_dec_val, int dig, int *p_exp_extra, int in) {
+    // Core routine to ingest an additional digit.
+    if (*p_dec_val < DEC_VAL_MAX) {
+        // dec_val won't overflow so keep accumulating
+        *p_dec_val = 10 * *p_dec_val + dig;
+        if (in == PARSE_DEC_IN_FRAC) {
+            --(*p_exp_extra);
+        }
+    } else {
+        // dec_val might overflow and we anyway can't represent more digits
+        // of precision, so ignore the digit and just adjust the exponent
+        if (in == PARSE_DEC_IN_INTG) {
+            ++(*p_exp_extra);
+        }
+    }
+}
+#endif // MICROPY_BUILTINS_FLOAT
+
+#if MICROPY_PY_BUILTINS_COMPLEX
+mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool force_complex, mp_lexer_t *lex)
+#else
+mp_obj_t mp_parse_num_float(const char *str, size_t len, bool allow_imag, mp_lexer_t *lex)
+#endif
+{
+    #if MICROPY_PY_BUILTINS_FLOAT
 
     const char *top = str + len;
     mp_float_t dec_val = 0;
     bool dec_neg = false;
-    bool imag = false;
+
+    #if MICROPY_PY_BUILTINS_COMPLEX
+    unsigned int real_imag_state = REAL_IMAG_STATE_START;
+    mp_float_t dec_real = 0;
+parse_start:
+    #endif
 
     // skip leading space
     for (; str < top && unichar_isspace(*str); str++) {
@@ -241,6 +277,7 @@ mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool
         bool exp_neg = false;
         int exp_val = 0;
         int exp_extra = 0;
+        int trailing_zeros_intg = 0, trailing_zeros_frac = 0;
         while (str < top) {
             unsigned int dig = *str++;
             if ('0' <= dig && dig <= '9') {
@@ -253,18 +290,25 @@ mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool
                         exp_val = 10 * exp_val + dig;
                     }
                 } else {
-                    if (dec_val < DEC_VAL_MAX) {
-                        // dec_val won't overflow so keep accumulating
-                        dec_val = 10 * dec_val + dig;
-                        if (in == PARSE_DEC_IN_FRAC) {
-                            --exp_extra;
+                    if (dig == 0 || dec_val >= DEC_VAL_MAX) {
+                        // Defer treatment of zeros in fractional part.  If nothing comes afterwards, ignore them.
+                        // Also, once we reach DEC_VAL_MAX, treat every additional digit as a trailing zero.
+                        if (in == PARSE_DEC_IN_INTG) {
+                            ++trailing_zeros_intg;
+                        } else {
+                            ++trailing_zeros_frac;
                         }
                     } else {
-                        // dec_val might overflow and we anyway can't represent more digits
-                        // of precision, so ignore the digit and just adjust the exponent
-                        if (in == PARSE_DEC_IN_INTG) {
-                            ++exp_extra;
+                        // Time to un-defer any trailing zeros.  Intg zeros first.
+                        while (trailing_zeros_intg) {
+                            accept_digit(&dec_val, 0, &exp_extra, PARSE_DEC_IN_INTG);
+                            --trailing_zeros_intg;
                         }
+                        while (trailing_zeros_frac) {
+                            accept_digit(&dec_val, 0, &exp_extra, PARSE_DEC_IN_FRAC);
+                            --trailing_zeros_frac;
+                        }
+                        accept_digit(&dec_val, dig, &exp_extra, in);
                     }
                 }
             } else if (in == PARSE_DEC_IN_INTG && dig == '.') {
@@ -282,9 +326,6 @@ mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool
                 if (str == top) {
                     goto value_error;
                 }
-            } else if (allow_imag && (dig | 0x20) == 'j') {
-                imag = true;
-                break;
             } else if (dig == '_') {
                 continue;
             } else {
@@ -300,7 +341,7 @@ mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool
         }
 
         // apply the exponent, making sure it's not a subnormal value
-        exp_val += exp_extra;
+        exp_val += exp_extra + trailing_zeros_intg;
         if (exp_val < SMALL_NORMAL_EXP) {
             exp_val -= SMALL_NORMAL_EXP;
             dec_val *= SMALL_NORMAL_VAL;
@@ -316,6 +357,19 @@ mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool
         } else {
             dec_val *= MICROPY_FLOAT_C_FUN(pow)(10, exp_val);
         }
+    }
+
+    if (allow_imag && str < top && (*str | 0x20) == 'j') {
+        #if MICROPY_PY_BUILTINS_COMPLEX
+        if (str == str_val_start) {
+            // Convert "j" to "1j".
+            dec_val = 1;
+        }
+        ++str;
+        real_imag_state |= REAL_IMAG_STATE_HAVE_IMAG;
+        #else
+        raise_exc(mp_obj_new_exception_msg(&mp_type_ValueError, MP_ERROR_TEXT("complex values not supported")), lex);
+        #endif
     }
 
     // negate value if needed
@@ -334,24 +388,36 @@ mp_obj_t mp_parse_num_decimal(const char *str, size_t len, bool allow_imag, bool
 
     // check we reached the end of the string
     if (str != top) {
+        #if MICROPY_PY_BUILTINS_COMPLEX
+        if (force_complex && real_imag_state == REAL_IMAG_STATE_START) {
+            // If we've only seen a real so far, keep parsing for the imaginary part.
+            dec_real = dec_val;
+            dec_val = 0;
+            real_imag_state |= REAL_IMAG_STATE_HAVE_REAL;
+            goto parse_start;
+        }
+        #endif
         goto value_error;
     }
 
-    // return the object
     #if MICROPY_PY_BUILTINS_COMPLEX
-    if (imag) {
-        return mp_obj_new_complex(0, dec_val);
+    if (real_imag_state == REAL_IMAG_STATE_HAVE_REAL) {
+        // We're on the second part, but didn't get the expected imaginary number.
+        goto value_error;
+    }
+    #endif
+
+    // return the object
+
+    #if MICROPY_PY_BUILTINS_COMPLEX
+    if (real_imag_state != REAL_IMAG_STATE_START) {
+        return mp_obj_new_complex(dec_real, dec_val);
     } else if (force_complex) {
         return mp_obj_new_complex(dec_val, 0);
     }
-    #else
-    if (imag || force_complex) {
-        raise_exc(mp_obj_new_exception_msg(&mp_type_ValueError, MP_ERROR_TEXT("complex values not supported")), lex);
-    }
     #endif
-    else {
-        return mp_obj_new_float(dec_val);
-    }
+
+    return mp_obj_new_float(dec_val);
 
 value_error:
     raise_exc(mp_obj_new_exception_msg(&mp_type_ValueError, MP_ERROR_TEXT("invalid syntax for number")), lex);

--- a/tests/float/float_format.py
+++ b/tests/float/float_format.py
@@ -17,3 +17,11 @@ print("%.2e" % float("9" * 40 + "e-21"))
 # check a case that would render negative digit values, eg ")" characters
 # the string is converted back to a float to check for no illegal characters
 float("%.23e" % 1e-80)
+
+# Check a problem with malformed "e" format numbers on the edge of 1.0e-X.
+for r in range(38):
+    s = "%.12e" % float("1e-" + str(r))
+    # It may format as 1e-r, or 9.999...e-(r+1), both are OK.
+    # But formatting as 0.999...e-r is NOT ok.
+    if s[0] == "0":
+        print("FAIL:", s)

--- a/tests/float/float_format_ints_doubleprec.py
+++ b/tests/float/float_format_ints_doubleprec.py
@@ -13,3 +13,6 @@ v1 = 0x54B249AD2594C37D  # 1e100
 v2 = 0x6974E718D7D7625A  # 1e200
 print("{:.12e}".format(array.array("d", v1.to_bytes(8, sys.byteorder))[0]))
 print("{:.12e}".format(array.array("d", v2.to_bytes(8, sys.byteorder))[0]))
+
+for i in range(300):
+    print(float("1e" + str(i)))

--- a/tests/float/string_format_modulo.py
+++ b/tests/float/string_format_modulo.py
@@ -41,7 +41,10 @@ print(("%.40f" % 1e-300)[:2])
 print(("%.40g" % 1e-1)[:2])
 print(("%.40g" % 1e-2)[:2])
 print(("%.40g" % 1e-3)[:2])
-print(("%.40g" % 1e-4)[:2])
+# Under Appveyor Release builds, 1e-4 was being formatted as 9.99999...e-5
+# instead of 0.0001.  (Interestingly, it formatted correctly for the Debug
+# build). Avoid the edge case.
+print(("%.40g" % 1.1e-4)[:2])
 
 print("%.0g" % 1)  # 0 precision 'g'
 


### PR DESCRIPTION
Fixes #6748: incorporate addition floating-point format fixes from MicroPython. Cherry-picked two commits from upstream. One required some merge fixes, maybe due to an upstream rebase. Verified that latest version now matches upstream except for a comment change.