### PR TITLE
Guard against workflow background happening early

### DIFF
--- a/supervisor/shared/web_workflow/websocket.c
+++ b/supervisor/shared/web_workflow/websocket.c
@@ -78,7 +78,7 @@ void websocket_handoff(socketpool_socket_obj_t *socket) {
 }
 
 bool websocket_connected(void) {
-    return !cp_serial.closed && common_hal_socketpool_socket_get_connected(&cp_serial.socket);
+    return _incoming_ringbuf.size > 0 && !cp_serial.closed && common_hal_socketpool_socket_get_connected(&cp_serial.socket);
 }
 
 static bool _read_byte(uint8_t *c) {

--- a/supervisor/shared/workflow.c
+++ b/supervisor/shared/workflow.c
@@ -46,6 +46,8 @@
 #endif
 static background_callback_t workflow_background_cb;
 
+static bool workflow_started = false;
+
 static void workflow_background(void *data) {
     #if CIRCUITPY_WEB_WORKFLOW
     supervisor_web_workflow_background();
@@ -68,6 +70,9 @@ void supervisor_workflow_reset(void) {
 }
 
 void supervisor_workflow_request_background(void) {
+    if (!workflow_started) {
+        return;
+    }
     background_callback_add_core(&workflow_background_cb);
 }
 
@@ -114,4 +119,6 @@ void supervisor_workflow_start(void) {
     #if CIRCUITPY_WEB_WORKFLOW
     supervisor_start_web_workflow();
     #endif
+
+    workflow_started = true;
 }


### PR DESCRIPTION
Fixes #6756 because the ringbuf size is zero and the empty check
does % which leads to division by zero error.