### PR TITLE
PacketBuffer ringbuf size

### DIFF
--- a/ports/nrf/common-hal/_bleio/PacketBuffer.c
+++ b/ports/nrf/common-hal/_bleio/PacketBuffer.c
@@ -300,7 +300,8 @@ void common_hal_bleio_packet_buffer_construct(
     size_t incoming_buffer_size = 0;
     uint32_t *incoming_buffer = NULL;
     if (incoming) {
-        incoming_buffer_size = buffer_size * (sizeof(uint16_t) + max_packet_size);
+        // + 1 needed by ringbuf for empty/full detection.
+        incoming_buffer_size = buffer_size * (sizeof(uint16_t) + max_packet_size) + 1;
         incoming_buffer = m_malloc(incoming_buffer_size, false);
     }
 


### PR DESCRIPTION
- Fixes #6786.

Ringbuf for a fixed-size `PacketBuffer` was one byte too small.

I have a better cleanup for `ringbuf` which will also fix this problem in #6214, but it was a big change which I deferred to `main` and then forgot to add after doing #6238 instead for 7.x.x. I will make another PR for `main` that incorporates the fixes from #6214.

