### PR TITLE
Backport #6659 (macOS CI updates)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
 
 
   mpy-cross-mac:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
     - name: Dump GitHub context
       env:
@@ -176,7 +176,7 @@ jobs:
       run: make -C mpy-cross -j2
     - uses: actions/upload-artifact@v2
       with:
-        name: mpy-cross-macos-catalina
+        name: mpy-cross-macos-11-x64
         path: mpy-cross/mpy-cross
     - name: Select SDK for M1 build
       run: sudo xcode-select -switch /Applications/Xcode_12.3.app
@@ -184,19 +184,19 @@ jobs:
       run: make -C mpy-cross -j2 -f Makefile.m1 V=2
     - uses: actions/upload-artifact@v2
       with:
-        name: mpy-cross-macos-bigsur-arm64
+        name: mpy-cross-macos-11-arm64
         path: mpy-cross/mpy-cross-arm64
     - name: Make universal binary
-      run: lipo -create -output mpy-cross-macos-universal mpy-cross/mpy-cross mpy-cross/mpy-cross-arm64
+      run: lipo -create -output mpy-cross-macos-11-universal mpy-cross/mpy-cross mpy-cross/mpy-cross-arm64
     - uses: actions/upload-artifact@v2
       with:
-        name: mpy-cross-macos-universal
-        path: mpy-cross-macos-universal
+        name: mpy-cross-macos-11-universal
+        path: mpy-cross-macos-11-universal
     - name: Upload mpy-cross build to S3
       run: |
-        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross-macos-universal s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross-macos-universal-${{ env.CP_VERSION }} --no-progress --region us-east-1
-        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross/mpy-cross-arm64 s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross-macos-bigsur-${{ env.CP_VERSION }}-arm64 --no-progress --region us-east-1
-        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross/mpy-cross s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross-macos-catalina-${{ env.CP_VERSION }} --no-progress --region us-east-1
+        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross-macos-universal s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross-macos-11-${{ env.CP_VERSION }}-universal --no-progress --region us-east-1
+        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross/mpy-cross-arm64 s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross-macos-11-${{ env.CP_VERSION }}-arm64 --no-progress --region us-east-1
+        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross/mpy-cross s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross-macos-11-${{ env.CP_VERSION }}-x64 --no-progress --region us-east-1
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,8 +178,6 @@ jobs:
       with:
         name: mpy-cross-macos-11-x64
         path: mpy-cross/mpy-cross
-    - name: Select SDK for M1 build
-      run: sudo xcode-select -switch /Applications/Xcode_12.3.app
     - name: Build mpy-cross (arm64)
       run: make -C mpy-cross -j2 -f Makefile.m1 V=2
     - uses: actions/upload-artifact@v2

--- a/mpy-cross/Makefile.m1
+++ b/mpy-cross/Makefile.m1
@@ -7,4 +7,4 @@ BUILD=build-arm64
 
 include mpy-cross.mk
 # Because mpy-cross.mk unconditionally overwrites CC for Darwin, we must set it BELOW the inclusion
-CC := $(shell xcrun --sdk macosx11.1 --find clang) -isysroot $(shell xcrun --sdk macosx11.1 --show-sdk-path) -target arm64-apple-macos11
+CC := $(shell xcrun --find clang) -isysroot $(shell xcrun --show-sdk-path) -target arm64-apple-macos11


### PR DESCRIPTION
- Backport #6659 to 7.3.x, particularly because macOS 10 will no longer be supported by GitHub Actions after August 30, 2022.