### PR TITLE
shared-module/usb_hid: Fix behavior of Device.get_last_received_report()

### DIFF
--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include <stdbool.h>
 #include <string.h>
 
 #include "py/gc.h"
@@ -246,6 +247,10 @@ void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t *
 mp_obj_t common_hal_usb_hid_device_get_last_received_report(usb_hid_device_obj_t *self, uint8_t report_id) {
     // report_id has already been validated for this device.
     size_t id_idx = get_report_id_idx(self, report_id);
+    if (!self->out_report_buffers_updated[id_idx]) {
+        return mp_const_none;
+    }
+    self->out_report_buffers_updated[id_idx] = false;
     return mp_obj_new_bytes(self->out_report_buffers[id_idx], self->out_report_lengths[id_idx]);
 }
 
@@ -263,6 +268,7 @@ void usb_hid_device_create_report_buffers(usb_hid_device_obj_t *self) {
             ? gc_alloc(self->out_report_lengths[i], false, true /*long-lived*/)
             : NULL;
     }
+    memset(self->out_report_buffers_updated, 0, sizeof(self->out_report_buffers_updated));
 }
 
 
@@ -309,6 +315,7 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
             hid_device->out_report_buffers[id_idx] &&
             hid_device->out_report_lengths[id_idx] >= bufsize) {
             memcpy(hid_device->out_report_buffers[id_idx], buffer, bufsize);
+            hid_device->out_report_buffers_updated[id_idx] = true;
         }
     }
 }

--- a/shared-module/usb_hid/Device.h
+++ b/shared-module/usb_hid/Device.h
@@ -38,6 +38,7 @@ typedef struct  {
     const uint8_t *report_descriptor;
     uint8_t *in_report_buffers[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];
     uint8_t *out_report_buffers[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];
+    uint8_t out_report_buffers_updated[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];
     uint16_t report_descriptor_length;
     uint8_t report_ids[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];
     uint8_t in_report_lengths[CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR];


### PR DESCRIPTION
 Documentation states that get_last_received_report() function should
 return None if there was no report received previously, otherwise it
 should return report. Moreover, same report should be returned only
 once. That makes it possible to reliably process incoming OUT/Feature
 reports.
    
 This patch adds an array that stores flags if report with particular
 ID was received and updates get_last_received_report() to match its
 documentation.

Backport from main to 7.3.x (see original PR #6767)