### PR TITLE
7.3.x #6798 backport (zero-length pulse Pulseout fix

### DIFF
--- a/ports/nrf/common-hal/pulseio/PulseOut.c
+++ b/ports/nrf/common-hal/pulseio/PulseOut.c
@@ -74,6 +74,11 @@ static void pulseout_event_handler(nrf_timer_event_t event_type, void *p_context
     nrfx_timer_pause(timer);
 
     pulse_array_index++;
+    // Ignore a zero-length pulse
+    while (pulse_array[pulse_array_index] == 0 &&
+           pulse_array_index < pulse_array_length) {
+        pulse_array_index++;
+    }
 
     // No more pulses. Turn off output and don't restart.
     if (pulse_array_index >= pulse_array_length) {

--- a/ports/nrf/common-hal/pulseio/PulseOut.c
+++ b/ports/nrf/common-hal/pulseio/PulseOut.c
@@ -75,8 +75,8 @@ static void pulseout_event_handler(nrf_timer_event_t event_type, void *p_context
 
     pulse_array_index++;
     // Ignore a zero-length pulse
-    while (pulse_array[pulse_array_index] == 0 &&
-           pulse_array_index < pulse_array_length) {
+    while (pulse_array_index < pulse_array_length &&
+           pulse_array[pulse_array_index] == 0) {
         pulse_array_index++;
     }
 


### PR DESCRIPTION
- Backport of #6798 to 7.3.x.