### PR TITLE
Try CI'ing iwth 3.11 beta!  Let's see what breaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: "3.x"
+        python-version: "3.11.0-beta.1 - 3.11"
     - name: Get CP deps
       run: python tools/ci_fetch_deps.py test ${{ github.sha }}
     - name: CircuitPython version
@@ -156,7 +156,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: "3.x"
+        python-version: "3.11.0-beta.1 - 3.11"
     - name: Get CP deps
       run: python tools/ci_fetch_deps.py mpy-cross-mac ${{ github.sha }}
     - name: CircuitPython version
@@ -220,7 +220,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: "3.x"
+        python-version: "3.11.0-beta.1 - 3.11"
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -278,7 +278,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: "3.x"
+        python-version: "3.11.0-beta.1 - 3.11"
     - uses: actions/checkout@v2.2.0
       with:
         submodules: false
@@ -331,7 +331,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: "3.x"
+        python-version: "3.11.0-beta.1 - 3.11"
     - uses: actions/checkout@v2.2.0
       with:
         submodules: false
@@ -384,7 +384,7 @@ jobs:
       id: py3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.11.0-beta.1 - 3.11"
     - uses: actions/checkout@v2.2.0
       with:
         submodules: false
@@ -473,7 +473,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: "3.x"
+        python-version: "3.11.0-beta.1 - 3.11"
     - uses: actions/checkout@v2.2.0
       with:
         submodules: false

--- a/.github/workflows/create_website_pr.yml
+++ b/.github/workflows/create_website_pr.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: "3.x"
+        python-version: "3.11.0-beta.1 - 3.11"
     - name: Get CP deps
       run: python tools/ci_fetch_deps.py website ${{ github.sha }}
     - name: Install deps

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: "3.x"
+        python-version: "3.11.0-beta.1 - 3.11"
     - name: Install deps
       run: |
         sudo apt-add-repository -y -u ppa:pybricks/ppa


### PR DESCRIPTION
@latkinso42 reported on discord that they ran into problems using Python 3.11 from a PPA. Let's see what happens when we try to CI based on 3.11.  Note that these are probably two different Python versions and could fail in different ways, since the Python installed by setup-python is built by github and is different from _any_ distribution, package, or ppa version.