### PR TITLE
Update formatting of `LICENSE` and clean-up

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2013-2022 Damien P. George
+Copyright (c) 2013-2022 Damien P. George and others
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,77 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
---------------------------------------------------------------------------------
-
-Unless specified otherwise (see below), the above license and copyright applies
-to all files in this repository.
-
-Individual files may include additional copyright holders.
-
-The various ports of MicroPython may include third-party software that is
-licensed under different terms. These licenses are summarised in the tree
-below, please refer to these files and directories for further license and
-copyright information. Note that (L)GPL-licensed code listed below is only
-used during the build process and is not part of the compiled source code.
-
-/ (MIT)
-    /drivers
-        /cc3000 (BSD-3-clause)
-        /cc3100 (BSD-3-clause)
-        /wiznet5k (BSD-3-clause)
-    /lib
-        /asf4 (Apache-2.0)
-        /axtls (BSD-3-clause)
-            /config
-                /scripts
-                    /config (GPL-2.0-or-later)
-                /Rules.mak (GPL-2.0)
-        /berkeley-db-1xx (BSD-4-clause)
-        /btstack (See btstack/LICENSE)
-        /cmsis (BSD-3-clause)
-        /crypto-algorithms (NONE)
-        /libhydrogen (ISC)
-        /littlefs (BSD-3-clause)
-        /lwip (BSD-3-clause)
-        /mynewt-nimble (Apache-2.0)
-        /nrfx (BSD-3-clause)
-        /nxp_driver (BSD-3-Clause)
-        /oofatfs (BSD-1-clause)
-        /pico-sdk (BSD-3-clause)
-        /re15 (BSD-3-clause)
-        /stm32lib (BSD-3-clause)
-        /tinytest (BSD-3-clause)
-        /tinyusb (MIT)
-        /uzlib (Zlib)
-    /logo (uses OFL-1.1)
-    /ports
-        /cc3200
-            /hal (BSD-3-clause)
-            /simplelink (BSD-3-clause)
-            /FreeRTOS (GPL-2.0 with FreeRTOS exception)
-        /stm32
-            /usbd*.c (MCD-ST Liberty SW License Agreement V2)
-            /stm32_it.* (MIT + BSD-3-clause)
-            /system_stm32*.c (MIT + BSD-3-clause)
-            /boards
-                /startup_stm32*.s (BSD-3-clause)
-                /*/stm32*.h (BSD-3-clause)
-            /usbdev (MCD-ST Liberty SW License Agreement V2)
-            /usbhost (MCD-ST Liberty SW License Agreement V2)
-        /teensy
-            /core (PJRC.COM)
-        /zephyr
-            /src (Apache-2.0)
-    /tools
-        /dfu.py (LGPL-3.0-only)
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE_MicroPython
+++ b/LICENSE_MicroPython
@@ -1,0 +1,85 @@
+The MIT License (MIT)
+
+Copyright (c) 2013-2022 Damien P. George
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+Unless specified otherwise (see below), the above license and copyright applies
+to all files in this repository.
+
+Individual files may include additional copyright holders.
+
+The various ports of MicroPython may include third-party software that is
+licensed under different terms. These licenses are summarised in the tree
+below, please refer to these files and directories for further license and
+copyright information. Note that (L)GPL-licensed code listed below is only
+used during the build process and is not part of the compiled source code.
+
+/ (MIT)
+    /drivers
+        /cc3000 (BSD-3-clause)
+        /cc3100 (BSD-3-clause)
+        /wiznet5k (BSD-3-clause)
+    /lib
+        /asf4 (Apache-2.0)
+        /axtls (BSD-3-clause)
+            /config
+                /scripts
+                    /config (GPL-2.0-or-later)
+                /Rules.mak (GPL-2.0)
+        /berkeley-db-1xx (BSD-4-clause)
+        /btstack (See btstack/LICENSE)
+        /cmsis (BSD-3-clause)
+        /crypto-algorithms (NONE)
+        /libhydrogen (ISC)
+        /littlefs (BSD-3-clause)
+        /lwip (BSD-3-clause)
+        /mynewt-nimble (Apache-2.0)
+        /nrfx (BSD-3-clause)
+        /nxp_driver (BSD-3-Clause)
+        /oofatfs (BSD-1-clause)
+        /pico-sdk (BSD-3-clause)
+        /re15 (BSD-3-clause)
+        /stm32lib (BSD-3-clause)
+        /tinytest (BSD-3-clause)
+        /tinyusb (MIT)
+        /uzlib (Zlib)
+    /logo (uses OFL-1.1)
+    /ports
+        /cc3200
+            /hal (BSD-3-clause)
+            /simplelink (BSD-3-clause)
+            /FreeRTOS (GPL-2.0 with FreeRTOS exception)
+        /stm32
+            /usbd*.c (MCD-ST Liberty SW License Agreement V2)
+            /stm32_it.* (MIT + BSD-3-clause)
+            /system_stm32*.c (MIT + BSD-3-clause)
+            /boards
+                /startup_stm32*.s (BSD-3-clause)
+                /*/stm32*.h (BSD-3-clause)
+            /usbdev (MCD-ST Liberty SW License Agreement V2)
+            /usbhost (MCD-ST Liberty SW License Agreement V2)
+        /teensy
+            /core (PJRC.COM)
+        /zephyr
+            /src (Apache-2.0)
+    /tools
+        /dfu.py (LGPL-3.0-only)

--- a/docs/LICENSE.md
+++ b/docs/LICENSE.md
@@ -1,9 +1,8 @@
-MicroPython & CircuitPython license information
-===============================================
+# MicroPython & CircuitPython License
 
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2013-2017 Damien P. George, and others
+Copyright (c) 2013-2022 Damien P. George and others
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -12,13 +11,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,7 +48,7 @@ Full Table of Contents
    ../CONTRIBUTING
    ../BUILDING
    ../CODE_OF_CONDUCT
-   ../license.rst
+   ../docs/LICENSE
    ../WEBUSB_README
 
 Indices and tables


### PR DESCRIPTION
Update `LICENSE` to better comply with GitHub's formatting. Also, rename MicroPython's license to `LICENSE_MicroPython`.

**After:**

![mit_license](https://user-images.githubusercontent.com/70126934/187021250-238ee813-991c-4f96-9199-749c22ba120b.png)

**Before:**

![unknown_license](https://user-images.githubusercontent.com/70126934/187021215-6747efaa-02c2-4d85-830b-4507cfd7f1d8.png)