### PR TITLE
Make PulseIn object long-lived

### DIFF
--- a/shared-bindings/pulseio/PulseIn.c
+++ b/shared-bindings/pulseio/PulseIn.c
@@ -87,7 +87,7 @@ STATIC mp_obj_t pulseio_pulsein_make_new(const mp_obj_type_t *type, size_t n_arg
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj);
 
-    pulseio_pulsein_obj_t *self = m_new_obj(pulseio_pulsein_obj_t);
+    pulseio_pulsein_obj_t *self = m_new_ll_obj(pulseio_pulsein_obj_t);
     self->base.type = &pulseio_pulsein_type;
 
     common_hal_pulseio_pulsein_construct(self, pin, args[ARG_maxlen].u_int,

--- a/shared-bindings/pulseio/PulseIn.c
+++ b/shared-bindings/pulseio/PulseIn.c
@@ -87,6 +87,7 @@ STATIC mp_obj_t pulseio_pulsein_make_new(const mp_obj_type_t *type, size_t n_arg
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj);
 
+    // Make object long-lived to avoid moving between imports
     pulseio_pulsein_obj_t *self = m_new_ll_obj(pulseio_pulsein_obj_t);
     self->base.type = &pulseio_pulsein_type;
 


### PR DESCRIPTION
Made the pulsein object long-lived so it persists across imports. I did not find any boards that used the pulsein object as input to an interrupt handler, but creating the object in one script and then importing that script will cause hangs, crashing into safe mode, etc.
Fixes #6565 