### PR TITLE
Fix UART documentation

### DIFF
--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -231,7 +231,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_uart___exit___obj, 4, 4, busio_
 //|         ...
 //|
 
-//|     def write(self, buf: WriteableBuffer) -> Optional[int]:
+//|     def write(self, buf: ReadableBuffer) -> Optional[int]:
 //|         """Write the buffer of bytes to the bus.
 //|
 //|       *New in CircuitPython 4.0:* ``buf`` must be bytes, not a string.

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -222,8 +222,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_uart___exit___obj, 4, 4, busio_
 
 //|     def readline(self) -> bytes:
 //|         """Read a line, ending in a newline character, or
-//|            return None if a timeout occurs sooner, or
-//|            return everything readable if no newline is found and timeout=0
+//|         return ``None`` if a timeout occurs sooner, or
+//|         return everything readable if no newline is found and
+//|         ``timeout=0``
 //|
 //|         :return: the line read
 //|         :rtype: bytes or None"""


### PR DESCRIPTION
Formatting errors I noticed while I was looking at the docs

- `UART.readline()` has properly formatted docstring now
- `UART.write()` now says it takes `ReadableBuffer`