### PR TITLE
rp2pio: fix occasional bug when not using OUT pins

### DIFF
--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -369,6 +369,9 @@ bool rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
 }
 
 static uint32_t mask_and_rotate(const mcu_pin_obj_t *first_pin, uint32_t bit_count, uint32_t value) {
+    if (!first_pin) {
+        return 0;
+    }
     value = value & ((1 << bit_count) - 1);
     uint32_t shift = first_pin->number;
     return value << shift | value >> (32 - shift);


### PR DESCRIPTION
a NULL first pin object is used to indicate that there are zero of some kind of pin associated with the StateMachine. However, mask_and_rotate wasn't checking for zero. It actually read data from near address 0x0 and (in my case) got a nonzero mask, which then caused a program with GPIO11 and GPIO12 as input with pull-up and no out pins to erroneously encounter the error "pull masks conflict with direction masks"