### PR TITLE
turn off power pins during deep sleep

### DIFF
--- a/ports/espressif/boards/adafruit_feather_esp32_v2/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32_v2/board.c
@@ -46,8 +46,13 @@ void reset_board(void) {
 }
 
 void board_deinit(void) {
-}
-
-bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
-    return false;
+    // Disable NEOPIXEL_I2C_POWER with a pull-down to reduce power during deep sleep.
+    gpio_config_t cfg = {
+        .pin_bit_mask = BIT64(2),
+        .mode = GPIO_MODE_DISABLE,
+        .pull_up_en = false,
+        .pull_down_en = true,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&cfg);
 }

--- a/ports/espressif/boards/adafruit_feather_esp32s2/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2/board.c
@@ -54,4 +54,13 @@ void reset_board(void) {
 }
 
 void board_deinit(void) {
+    // Disable NEOPIXEL_POWER and I2C_POWER with a pull-down to reduce power during deep sleep.
+    gpio_config_t cfg = {
+        .pin_bit_mask = BIT64(7) | BIT64(21),
+        .mode = GPIO_MODE_DISABLE,
+        .pull_up_en = false,
+        .pull_down_en = true,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&cfg);
 }

--- a/ports/espressif/boards/adafruit_feather_esp32s3_4mbflash_2mbpsram/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_4mbflash_2mbpsram/board.c
@@ -40,11 +40,23 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
-    // Turn on I2C power by default.
+    // Turn on I2C and NeoPixel power by default.
+
+    gpio_set_direction(2, GPIO_MODE_DEF_OUTPUT);
+    gpio_set_level(2, true);
 
     gpio_set_direction(7, GPIO_MODE_DEF_OUTPUT);
     gpio_set_level(7, true);
 }
 
 void board_deinit(void) {
+    // Disable I2C_POWER and NEOPIXEL_POWER with a pull-down to reduce power during deep sleep.
+    gpio_config_t cfg = {
+        .pin_bit_mask = BIT64(7) | BIT64(21),
+        .mode = GPIO_MODE_DISABLE,
+        .pull_up_en = false,
+        .pull_down_en = true,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&cfg);
 }

--- a/ports/espressif/boards/adafruit_feather_esp32s3_nopsram/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_nopsram/board.c
@@ -40,11 +40,23 @@ bool board_requests_safe_mode(void) {
 }
 
 void reset_board(void) {
-    // Turn on I2C power by default.
+    // Turn on I2C and NeoPixel power by default.
+
+    gpio_set_direction(2, GPIO_MODE_DEF_OUTPUT);
+    gpio_set_level(2, true);
 
     gpio_set_direction(7, GPIO_MODE_DEF_OUTPUT);
     gpio_set_level(7, true);
 }
 
 void board_deinit(void) {
+    // Disable I2C_POWER and NEOPIXEL_POWER with a pull-down to reduce power during deep sleep.
+    gpio_config_t cfg = {
+        .pin_bit_mask = BIT64(7) | BIT64(21),
+        .mode = GPIO_MODE_DISABLE,
+        .pull_up_en = false,
+        .pull_down_en = true,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&cfg);
 }


### PR DESCRIPTION
For some Espressif Feather boards, reduce power during rel deep sleep by disabling NeoPixel and/or I2C power pins with a pull-down instead of a pull-up. This reduces deep sleep consumption from about 480 uA to about 75 uA.

More could be done on TFT boards, which don't have this. I think maybe we need to pass a `deep_sleep` boolean to `board_deinit()` for these boards so we don't disable the display during fake deep sleep.