### PR TITLE
allow writing empty color frame

### DIFF
--- a/shared-module/displayio/EPaperDisplay.c
+++ b/shared-module/displayio/EPaperDisplay.c
@@ -275,7 +275,7 @@ STATIC bool displayio_epaperdisplay_refresh_area(displayio_epaperdisplay_obj_t *
     uint32_t mask[mask_length];
 
     uint8_t passes = 1;
-    if (self->core.colorspace.tricolor || self->grayscale) {
+    if (self->write_color_ram_command != NO_COMMAND) {
         passes = 2;
     }
     for (uint8_t pass = 0; pass < passes; pass++) {
@@ -318,11 +318,14 @@ STATIC bool displayio_epaperdisplay_refresh_area(displayio_epaperdisplay_obj_t *
             if (pass == 1) {
                 if (self->grayscale) { // 4-color grayscale
                     self->core.colorspace.grayscale_bit = 6;
-                } else { // Tri-color
+                    displayio_display_core_fill_area(&self->core, &subrectangle, mask, buffer);
+                } else if (self->core.colorspace.tricolor) {
                     self->core.colorspace.grayscale = false;
+                    displayio_display_core_fill_area(&self->core, &subrectangle, mask, buffer);
                 }
+            } else {
+                displayio_display_core_fill_area(&self->core, &subrectangle, mask, buffer);
             }
-            displayio_display_core_fill_area(&self->core, &subrectangle, mask, buffer);
 
             // Invert it all.
             if ((pass == 1 && self->color_bits_inverted) ||


### PR DESCRIPTION
fixes #6870 by sending an empty second frame if `write_color_ram_command` is specified but no `highlight_color` or `grayscale` is given.

Demonstration: https://twitter.com/pepijndevos/status/1567198891887529986

FYI an actual driver for PervasiveDisplays panels lives here, feel free to adapt if you ever want to support these displays in some Adafruit product.

https://github.com/pepijndevos/mapseflaps/blob/d9c1d9ff485b7df8da765d193d6b1c99783c8e95/render_displayio.py#L26-L59