### PR TITLE
Fixed incorrect IO naming for ProS3 and FeatherS3

### DIFF
--- a/ports/espressif/boards/unexpectedmaker_feathers3/pins.c
+++ b/ports/espressif/boards/unexpectedmaker_feathers3/pins.c
@@ -110,7 +110,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_AMB), MP_ROM_PTR(&pin_GPIO4) }, // Ambient Light Sensor
 
     { MP_ROM_QSTR(MP_QSTR_LDO2), MP_ROM_PTR(&pin_GPIO39) }, // Second LDO Enable control
-    { MP_ROM_QSTR(MP_QSTR_I39), MP_ROM_PTR(&pin_GPIO39) }, // Second LDO Enable control
+    { MP_ROM_QSTR(MP_QSTR_IO39), MP_ROM_PTR(&pin_GPIO39) }, // Second LDO Enable control
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_STEMMA_I2C), MP_ROM_PTR(&board_i2c_obj) },

--- a/ports/espressif/boards/unexpectedmaker_pros3/pins.c
+++ b/ports/espressif/boards/unexpectedmaker_pros3/pins.c
@@ -130,7 +130,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO18) },
 
     { MP_ROM_QSTR(MP_QSTR_LDO2), MP_ROM_PTR(&pin_GPIO17) }, // Second LDO Enable control
-    { MP_ROM_QSTR(MP_QSTR_I17), MP_ROM_PTR(&pin_GPIO17) }, // Second LDO Enable control
+    { MP_ROM_QSTR(MP_QSTR_IO17), MP_ROM_PTR(&pin_GPIO17) }, // Second LDO Enable control
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_STEMMA_I2C), MP_ROM_PTR(&board_i2c_obj) },


### PR DESCRIPTION
As reported in issue https://github.com/adafruit/circuitpython/issues/6862#issuecomment-1237606671