### PR TITLE
Use current ubuntu for pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2.2.0
     - name: Set up Python 3
@@ -23,7 +23,6 @@ jobs:
         python-version: "3.x"
     - name: Install deps
       run: |
-        sudo apt-add-repository -y -u ppa:pybricks/ppa
         sudo apt-get install -y gettext uncrustify
         pip3 install black polib pyyaml
     - name: Populate selected submodules


### PR DESCRIPTION
This means that the OS version of uncrustify can be used, rather than the pybricks one.

For now this is a test to see whether it comes up green.