### PR TITLE
Fix with PWM for brightness slowing devices down

### DIFF
--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -399,7 +399,6 @@ void common_hal_displayio_display_set_auto_refresh(displayio_display_obj_t *self
 }
 
 void displayio_display_background(displayio_display_obj_t *self) {
-    common_hal_displayio_display_set_brightness(self, 1.0);
     if (self->auto_refresh && (supervisor_ticks_ms64() - self->core.last_refresh) > self->native_ms_per_frame) {
         _refresh_display(self);
     }


### PR DESCRIPTION
Fix for [CircuitPython v8.0.0-beta.2: display_shapes.polygon color fill is rendering very slowly](https://github.com/adafruit/Adafruit_CircuitPython_Display_Shapes/issues/57)

#6734 removed support for auto brightness left a call in `displayio_display_background` to set the brightness to a 1.0f fixed value. In the previous code another function call checked that auto-brightness was set to True and skipped any work if it was not true and limited to how often the brightness was set.

With the previous PR always calling `common_hal_displayio_display_set_brightness` to 1.0f it was both preventing the brightness from being set (using the same auto-brightness behavior that no longer exists) and having to change the PWMOut object was slow the lower the frequency of the PWM timer. Most boards with built in displays were set to 50KHz so it was barely noticeable. The Titano was set to 500Hz so the problem became apparent. But there is a measurable speed-up even when the frequency was set to the higher value.

This PR does not fix the brightness from not being set properly. This would be one source of error but apparently others exist still.

But this PR does fix a slowdown with any board using PWM to control the display brightness.
