### PR TITLE
Set the default pin state for GPIOs to pull down (Cytron Maker Feather AIoT S3).

### DIFF
--- a/ports/espressif/boards/cytron_maker_feather_aiot_s3/board.c
+++ b/ports/espressif/boards/cytron_maker_feather_aiot_s3/board.c
@@ -38,7 +38,7 @@ void board_init(void) {
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // For GPIOs used in Maker Feather AIoT S3, set the default state to pull down
     // as most of them are connected to active high LED.
-    switch (pin_number) {
+    switch ((int8_t)pin_number) {
         case 4:
         case 5:
         case 6:

--- a/ports/espressif/boards/cytron_maker_feather_aiot_s3/board.c
+++ b/ports/espressif/boards/cytron_maker_feather_aiot_s3/board.c
@@ -64,7 +64,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
             gpio_pullup_dis(pin_number);
             gpio_pulldown_en(pin_number);
             return true;
-            
+
         // Do not pull up/down as this is the battery voltage monitoring pin.
         case 13:
             gpio_reset_pin(pin_number);
@@ -72,7 +72,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
             gpio_pulldown_dis(pin_number);
             return true;
     }
-    
+
     return false;
 }
 

--- a/ports/espressif/boards/cytron_maker_feather_aiot_s3/board.c
+++ b/ports/espressif/boards/cytron_maker_feather_aiot_s3/board.c
@@ -35,6 +35,47 @@ void board_init(void) {
     reset_board();
 }
 
+bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
+    // For GPIOs used in Maker Feather AIoT S3, set the default state to pull down
+    // as most of them are connected to active high LED.
+    switch (pin_number) {
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
+        case 10:
+        case 12:
+        case 14:
+        case 15:
+        case 16:
+        case 17:
+        case 18:
+        case 21:
+        case 38:
+        case 39:
+        case 40:
+        case 41:
+        case 42:
+        case 47:
+        case 48:
+            gpio_reset_pin(pin_number);
+            gpio_pullup_dis(pin_number);
+            gpio_pulldown_en(pin_number);
+            return true;
+            
+        // Do not pull up/down as this is the battery voltage monitoring pin.
+        case 13:
+            gpio_reset_pin(pin_number);
+            gpio_pullup_dis(pin_number);
+            gpio_pulldown_dis(pin_number);
+            return true;
+    }
+    
+    return false;
+}
+
 void reset_board(void) {
     // Turn on VP by default.
     gpio_set_direction(11, GPIO_MODE_DEF_OUTPUT);

--- a/ports/espressif/boards/cytron_maker_feather_aiot_s3/mpconfigboard.h
+++ b/ports/espressif/boards/cytron_maker_feather_aiot_s3/mpconfigboard.h
@@ -30,6 +30,7 @@
 #define MICROPY_HW_MCU_NAME         "ESP32S3"
 
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO46)
+#define CIRCUITPY_STATUS_LED_POWER (&pin_GPIO11)
 
 #define MICROPY_HW_LED_STATUS (&pin_GPIO2)
 


### PR DESCRIPTION
Most of the pins are connected to LEDs and we do not want them to turn on by default.