### PR TITLE
Espressif pwmout reset fixes

### DIFF
--- a/main.c
+++ b/main.c
@@ -967,14 +967,14 @@ int __attribute__((used)) main(void) {
         safe_mode = NO_CIRCUITPY;
     }
 
-    // displays init after filesystem, since they could share the flash SPI
-    board_init();
-
     // Reset everything and prep MicroPython to run boot.py.
     reset_port();
     // Port-independent devices, like CIRCUITPY_BLEIO_HCI.
     reset_devices();
     reset_board();
+
+    // displays init after filesystem, since they could share the flash SPI
+    board_init();
 
     // This is first time we are running CircuitPython after a reset or power-up.
     supervisor_set_run_reason(RUN_REASON_STARTUP);

--- a/ports/espressif/boards/adafruit_esp32s2_camera/board.c
+++ b/ports/espressif/boards/adafruit_esp32s2_camera/board.c
@@ -63,9 +63,6 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    // workaround as board_init() is called before reset_port() in main.c
-    pwmout_reset();
-
     displayio_display_obj_t *display = &displays[0].display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
@@ -71,12 +71,6 @@ uint8_t display_init_sequence[] = {
 
 
 void board_init(void) {
-    // THIS SHOULD BE HANDLED BY espressif_board_reset_pin_number(), but it is not working.
-    // TEMPORARY FIX UNTIL IT'S DIAGNOSED.
-    common_hal_never_reset_pin(&pin_GPIO21);
-    gpio_set_direction(21, GPIO_MODE_DEF_OUTPUT);
-    gpio_set_level(21, true);
-
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
     displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
@@ -95,7 +89,9 @@ void board_init(void) {
     display->base.type = &displayio_display_type;
 
     // workaround as board_init() is called before reset_port() in main.c
+    #if CIRCUITPY_PWMIO
     pwmout_reset();
+    #endif
 
     common_hal_displayio_display_construct(
         display,

--- a/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
@@ -88,11 +88,6 @@ void board_init(void) {
     displayio_display_obj_t *display = &displays[0].display;
     display->base.type = &displayio_display_type;
 
-    // workaround as board_init() is called before reset_port() in main.c
-    #if CIRCUITPY_PWMIO
-    pwmout_reset();
-    #endif
-
     common_hal_displayio_display_construct(
         display,
         bus,
@@ -123,8 +118,6 @@ void board_init(void) {
         false,          // SH1107_addressing
         50000           // backlight pwm frequency
         );
-
-    common_hal_never_reset_pin(&pin_GPIO45); // backlight pin
 }
 
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {

--- a/ports/espressif/boards/adafruit_funhouse/board.c
+++ b/ports/espressif/boards/adafruit_funhouse/board.c
@@ -71,9 +71,6 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    // workaround as board_init() is called before reset_port() in main.c
-    pwmout_reset();
-
     displayio_display_obj_t *display = &displays[0].display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/espressif_esp32s3_eye/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_eye/board.c
@@ -87,9 +87,6 @@ void board_init(void) {
     displayio_display_obj_t *display = &displays[0].display;
     display->base.type = &displayio_display_type;
 
-    // workaround as board_init() is called before reset_port() in main.c
-    pwmout_reset();
-
     common_hal_displayio_display_construct(
         display,
         bus,
@@ -120,9 +117,6 @@ void board_init(void) {
         false,          // SH1107_addressing
         50000           // backlight pwm frequency
         );
-
-    common_hal_never_reset_pin(&pin_GPIO48); // backlight pin
-    // Debug UART
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/hexky_s2/board.c
+++ b/ports/espressif/boards/hexky_s2/board.c
@@ -88,9 +88,6 @@ void board_init(void) {
     displayio_display_obj_t *display = &displays[0].display;
     display->base.type = &displayio_display_type;
 
-    // workaround as board_init() is called before reset_port() in main.c
-    pwmout_reset();
-
     common_hal_displayio_display_construct(
         display,
         bus,
@@ -121,8 +118,6 @@ void board_init(void) {
         false,          // SH1107_addressing
         50000           // backlight pwm frequency
         );
-
-    common_hal_never_reset_pin(&pin_GPIO45); // backlight pin
 }
 
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {

--- a/ports/espressif/boards/hiibot_iots2/board.c
+++ b/ports/espressif/boards/hiibot_iots2/board.c
@@ -93,9 +93,6 @@ static void display_init(void) {
     displayio_display_obj_t *display = &displays[0].display;
     display->base.type = &displayio_display_type;
 
-    // workaround as board_init() is called before reset_port() in main.c
-    pwmout_reset();
-
     common_hal_displayio_display_construct(
         display,
         bus,
@@ -126,8 +123,6 @@ static void display_init(void) {
         false,          // SH1107_addressing
         50000           // backlight pwm frequency
         );
-
-    common_hal_never_reset_pin(&pin_GPIO38); // backlight pin
 }
 
 void board_init(void) {

--- a/ports/espressif/boards/lilygo_ttgo_t8_s2_st7789/board.c
+++ b/ports/espressif/boards/lilygo_ttgo_t8_s2_st7789/board.c
@@ -93,9 +93,6 @@ static void display_init(void) {
     displayio_display_obj_t *display = &displays[0].display;
     display->base.type = &displayio_display_type;
 
-    // workaround as board_init() is called before reset_port() in main.c
-    pwmout_reset();
-
     common_hal_displayio_display_construct(
         display,
         bus,
@@ -126,8 +123,6 @@ static void display_init(void) {
         false,          // SH1107_addressing
         50000           // backlight pwm frequency
         );
-
-    common_hal_never_reset_pin(&pin_GPIO33); // backlight pin
 }
 
 void board_init(void) {

--- a/ports/espressif/boards/morpheans_morphesp-240/board.c
+++ b/ports/espressif/boards/morpheans_morphesp-240/board.c
@@ -172,9 +172,6 @@ void board_init(void) {
         0               // phase
         );
 
-    // workaround as board_init() is called before reset_port() in main.c
-    pwmout_reset();
-
     displayio_display_obj_t *display = &displays[0].display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.c
+++ b/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.c
@@ -92,9 +92,6 @@ static void display_init(void) {
     displayio_display_obj_t *display = &displays[0].display;
     display->base.type = &displayio_display_type;
 
-    // workaround as board_init() is called before reset_port() in main.c
-    pwmout_reset();
-
     common_hal_displayio_display_construct(
         display,
         bus,
@@ -125,8 +122,6 @@ static void display_init(void) {
         false,          // SH1107_addressing
         50000           // backlight pwm frequency
         );
-
-    common_hal_never_reset_pin(&pin_GPIO45); // backlight pin
 }
 
 

--- a/ports/espressif/common-hal/pwmio/PWMOut.c
+++ b/ports/espressif/common-hal/pwmio/PWMOut.c
@@ -55,18 +55,14 @@ STATIC uint32_t calculate_duty_cycle(uint32_t frequency) {
 
 void pwmout_reset(void) {
     for (size_t i = 0; i < LEDC_CHANNEL_MAX; i++) {
-        if (reserved_channels[i] != INDEX_EMPTY) {
+        if (reserved_channels[i] != INDEX_EMPTY && !never_reset_chan[i]) {
             ledc_stop(LEDC_LOW_SPEED_MODE, i, 0);
-        }
-        if (!never_reset_chan[i]) {
             reserved_channels[i] = INDEX_EMPTY;
         }
     }
     for (size_t i = 0; i < LEDC_TIMER_MAX; i++) {
-        if (reserved_timer_freq[i]) {
+        if (reserved_timer_freq[i] && !never_reset_tim[i]) {
             ledc_timer_rst(LEDC_LOW_SPEED_MODE, i);
-        }
-        if (!never_reset_tim[i]) {
             reserved_timer_freq[i] = 0;
             varfreq_timers[i] = false;
         }


### PR DESCRIPTION
- Fixes #6896.

- The logic in `pwmout_reset()` was not checking the "never reset" flags for PWMOut correctly. It was partly the inverse of what it should have been. Fix this. The display brightness PWMOut was being reset multiple times due to this.
- `esp32-camera` code was resetting LEDC channel 0 clock by mistake, causing dark display on ESP32-S2 TFT.
- Removed some power-pin-reset bug workaround code which may or may not have been necessary due to this bug.
- Reordered display initialization in `main()` to avoid `pwmout_reset()` calls in `board.c` files.
- Removed unnecessary "never reset pin" calls in `board.c` files. The display constructor does this already.

@jepler I have a PR into `esp32-camera`, and this refers to that tenative commit, but you may want to fix this a different way. 

