### PR TITLE
Fix bindings typing

### DIFF
--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -267,7 +267,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_rotozoom_obj, 0, bitmaptools_obj_rotozoom
 // requires at least 2 arguments (destination bitmap and source bitmap)
 
 //|
-//| def alphablend(dest_bitmap: displayio.Bitmap , source_bitmap_1: displayio.Bitmap, source_bitmap_2: displayio.Bitmap, colorspace: displayio.Colorspace, factor1: float=.5, factor2: float=None) -> None:
+//| def alphablend(dest_bitmap: displayio.Bitmap , source_bitmap_1: displayio.Bitmap, source_bitmap_2: displayio.Bitmap, colorspace: displayio.Colorspace, factor1: float=.5, factor2: Optional[float]=None) -> None:
 //|     """Alpha blend the two source bitmaps into the destination.
 //|
 //|     It is permitted for the destination bitmap to be one of the two

--- a/shared-bindings/usb/core/Device.c
+++ b/shared-bindings/usb/core/Device.c
@@ -187,7 +187,7 @@ STATIC mp_obj_t usb_core_device_read(size_t n_args, const mp_obj_t *pos_args, mp
 MP_DEFINE_CONST_FUN_OBJ_KW(usb_core_device_read_obj, 2, usb_core_device_read);
 
 //|     def ctrl_transfer(self, bmRequestType, bRequest, wValue=0, wIndex=0,
-//|                       data_or_wLength: array.array = None, timeout = None) -> int:
+//|                       data_or_wLength: Optional[array.array] = None, timeout = None) -> int:
 //|         """Do a control transfer on the endpoint 0. The parameters bmRequestType,
 //|            bRequest, wValue and wIndex are the same of the USB Standard Control
 //|            Request format.


### PR DESCRIPTION
Hi, we create a Type support (typings) package for CircuitPython built-in binding packages: [types-circuitpython](https://github.com/hardfury-labs/types-circuitpython)

So fixed some typings typo throw by pyright check.