### PR TITLE
nrf: return None when UART.read() reads nothing

### DIFF
--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -337,6 +337,11 @@ size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t 
 
     NVIC_EnableIRQ(nrfx_get_irq_number(self->uarte->p_reg));
 
+    if (rx_bytes == 0) {
+        *errcode = EAGAIN;
+        return MP_STREAM_ERROR;
+    }
+
     return rx_bytes;
 }
 

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -200,10 +200,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_uart___exit___obj, 4, 4, busio_
 // These are standard stream methods. Code is in py/stream.c.
 //
 //|     def read(self, nbytes: Optional[int] = None) -> Optional[bytes]:
-//|         """Read characters.  If ``nbytes`` is specified then read at most that many
+//|         """Read bytes.  If ``nbytes`` is specified then read at most that many
 //|         bytes. Otherwise, read everything that arrives until the connection
 //|         times out. Providing the number of bytes expected is highly recommended
-//|         because it will be faster.
+//|         because it will be faster. If no bytes are read, return ``None``.
+//|
+//|         .. note:: When no bytes are read due to a timeout, this function returns ``None``.
+//|           This matches the behavior of `io.RawIOBase.read` in Python 3, but
+//|           differs from pyserial which returns ``b''`` in that situation.
 //|
 //|         :return: Data read
 //|         :rtype: bytes or None"""


### PR DESCRIPTION
- Fixes #6903.
- Subsumes draft PR #6349.

nRF port returned `b''` instead of `None` when `UART.read()` returned nothing. Now it returns `None`, which is consistent with all the other ports.

Made this clear in the `busio.UART.read()` documentation, taking a note that was in #6349.