### PR TITLE
Remove unneeded workaround for Feather ESP32-S2 TFT

### DIFF
--- a/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
@@ -71,12 +71,6 @@ uint8_t display_init_sequence[] = {
 
 
 void board_init(void) {
-    // THIS SHOULD BE HANDLED BY espressif_board_reset_pin_number(), but it is not working.
-    // TEMPORARY FIX UNTIL IT'S DIAGNOSED.
-    common_hal_never_reset_pin(&pin_GPIO21);
-    gpio_set_direction(21, GPIO_MODE_DEF_OUTPUT);
-    gpio_set_level(21, true);
-
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
     displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;


### PR DESCRIPTION
- Fixes #6369. Really finishes the fix, by removing the now unneeded workaround. The actual fix was due to #6898.

Tested on a Feather ESP32-S2 TFT. It no longer blanks the display on restart.