### PR TITLE
makeversionhdr should be unforgiving

### DIFF
--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -59,29 +59,25 @@ def get_version_info_from_git():
     return git_tag, git_hash, ver
 
 
-def get_version_info_from_docs_conf():
-    with open(os.path.join(os.path.dirname(sys.argv[0]), "..", "conf.py")) as f:
-        for line in f:
-            if line.startswith("version = release = '"):
-                ver = line.strip().split(" = ")[2].strip("'")
-                git_tag = "v" + ver
-                ver = ver.split(".")
-                if len(ver) == 2:
-                    ver.append("0")
-                return git_tag, "<no hash>", ver
-    return None
+def cannot_determine_version():
+    raise SystemExit(
+        """Cannot determine version.
+
+CircuitPython must be built from a git clone with tags.
+If you cloned from a fork, fetch the tags from adafruit/circuitpython as follows:
+
+    git fetch --tags --recurse-submodules=no --shallow-since="2021-07-01" https://github.com/adafruit/circuitpython HEAD"""
+    )
 
 
 def make_version_header(filename):
-    # Get version info using git, with fallback to docs/conf.py
+    # Get version info using git (required)
     info = get_version_info_from_git()
     if info is None:
-        info = get_version_info_from_docs_conf()
-
+        cannot_determine_version()
     git_tag, git_hash, ver = info
     if len(ver) < 3:
-        ver = ("0", "0", "0")
-        version_string = git_hash
+        cannot_determine_version()
     else:
         version_string = ".".join(ver)
 


### PR DESCRIPTION
Recently(?) github started making it the default to only copy a single branch (e.g., main) and NO TAGS into new forks.

This makes the step of the build process that determines the CircuitPython version not work, because tags are expected to be present. When tags are not present, the version number is only a git hash. The version number ends up being 0.0.0.

This causes problems with libraries that check for CircuitPython version to determine compatibility, among other things.

We'll do other things to improve the situation, such as document it. But it'd also be good if the build stopped when this detectable condition occurs.

Other stuff I considered was whether the `make fetch-submodules` should be updated (and possibly renamed) to perform this step.

Finally, it's worth noting that we need some way to get these tags into users' clones after the initial time. Otherwise, unless you `git fetch --tags origin` you won't get the new 8.0.0 tag when it's made and your version numbers are still wrong, possibly subtly so.