### PR TITLE
Software DFU mode implementation for STM32F4 MCU.

### DIFF
--- a/ports/stm/common-hal/microcontroller/__init__.c
+++ b/ports/stm/common-hal/microcontroller/__init__.c
@@ -36,7 +36,7 @@
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/Processor.h"
-
+#include "supervisor/port.h"
 #include "supervisor/filesystem.h"
 #include "supervisor/shared/safe_mode.h"
 
@@ -73,15 +73,25 @@ void common_hal_mcu_enable_interrupts(void) {
     __enable_irq();
 }
 
+static bool next_reset_to_bootloader = false;
+
 void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
     if (runmode == RUNMODE_SAFE_MODE) {
         safe_mode_on_next_reset(PROGRAMMATIC_SAFE_MODE);
+    }
+    if (runmode == RUNMODE_BOOTLOADER) {
+        next_reset_to_bootloader = true;
     }
 }
 
 void common_hal_mcu_reset(void) {
     filesystem_flush(); // TODO: implement as part of flash improvements
-    NVIC_SystemReset();
+
+    if (next_reset_to_bootloader) {
+        reset_to_bootloader();
+    } else {
+        NVIC_SystemReset();
+    }
 }
 
 // The singleton microcontroller.Processor object, bound to microcontroller.cpu


### PR DESCRIPTION
Hello all

I have tried to add support for entering DFU mode from software  as explained in the following issue: #https://github.com/adafruit/circuitpython/issues/3444

The implementation particularly supports STM32F4 family since I have only one MCU from ST :)

The code follows the recommended steps from the application notes: AN2606 Rev 55. Link here: https://www.st.com/resource/en/application_note/cd00167594-stm32-microcontroller-system-memory-boot-mode-stmicroelectronics.pdf

To test, add the lines bellow in your `code.py`, run the program, then connect to the device with an  ##utility as explained here: https://learn.adafruit.com/adafruit-stm32f405-feather-express/dfu-bootloader-details.

```
import microcontroller

microcontroller.on_next_reset(microcontroller.RunMode.BOOTLOADER)

microcontroller.reset()
```