### PR TITLE
Support for opening a file by name in MP3Decoder

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2942,10 +2942,6 @@ msgstr ""
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
-#: shared-bindings/audiomp3/MP3Decoder.c
-msgid "file path must be provided as input"
-msgstr ""
-
 #: shared-bindings/traceback/__init__.c
 msgid "file write is not available"
 msgstr ""

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2942,6 +2942,10 @@ msgstr ""
 msgid "file must be a file opened in byte mode"
 msgstr ""
 
+#: shared-bindings/audiomp3/MP3Decoder.c
+msgid "file path must be provided as input"
+msgstr ""
+
 #: shared-bindings/traceback/__init__.c
 msgid "file write is not available"
 msgstr ""

--- a/shared-bindings/audiomp3/MP3Decoder.c
+++ b/shared-bindings/audiomp3/MP3Decoder.c
@@ -172,25 +172,20 @@ STATIC mp_obj_t audiomp3_mp3file_obj_set_file(mp_obj_t self_in, mp_obj_t file) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(audiomp3_mp3file_set_file_obj, audiomp3_mp3file_obj_set_file);
 
-//|     def open_file(self, str) -> None:
+//|     def open(self, str) -> None:
 //|         """Takes in the name of a mp3 file, opens it, and replaces the old playback file."""
 //|         ...
 //|
-STATIC mp_obj_t audiomp3_mp3file_obj_open_file(mp_obj_t self_in, mp_obj_t path) {
+STATIC mp_obj_t audiomp3_mp3file_obj_open(mp_obj_t self_in, mp_obj_t path) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_obj_t file;
     check_for_deinit(self);
-    if (!mp_obj_is_str(path)) {
-        mp_raise_TypeError(translate("file path must be provided as input"));
-    }
-    file = mp_call_function_2(MP_OBJ_FROM_PTR(&mp_builtin_open_obj), path, MP_ROM_QSTR(MP_QSTR_rb));
-    if (!mp_obj_is_type(file, &mp_type_fileio)) {
-        mp_raise_TypeError(translate("file must be a file opened in byte mode"));
-    }
+
+    mp_obj_t file = mp_call_function_2(MP_OBJ_FROM_PTR(&mp_builtin_open_obj), path, MP_ROM_QSTR(MP_QSTR_rb));
+
     common_hal_audiomp3_mp3file_set_file(self, file);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_2(audiomp3_mp3file_open_file_obj, audiomp3_mp3file_obj_open_file);
+MP_DEFINE_CONST_FUN_OBJ_2(audiomp3_mp3file_open_obj, audiomp3_mp3file_obj_open);
 
 MP_PROPERTY_GETSET(audiomp3_mp3file_file_obj,
     (mp_obj_t)&audiomp3_mp3file_get_file_obj,
@@ -276,7 +271,7 @@ MP_PROPERTY_GETTER(audiomp3_mp3file_samples_decoded_obj,
 
 STATIC const mp_rom_map_elem_t audiomp3_mp3file_locals_dict_table[] = {
     // Methods
-    { MP_ROM_QSTR(MP_QSTR_open_file), MP_ROM_PTR(&audiomp3_mp3file_open_file_obj) },
+    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&audiomp3_mp3file_open_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&audiomp3_mp3file_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&default___enter___obj) },
     { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&audiomp3_mp3file___exit___obj) },

--- a/shared-bindings/audiomp3/MP3Decoder.c
+++ b/shared-bindings/audiomp3/MP3Decoder.c
@@ -172,7 +172,7 @@ STATIC mp_obj_t audiomp3_mp3file_obj_set_file(mp_obj_t self_in, mp_obj_t file) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(audiomp3_mp3file_set_file_obj, audiomp3_mp3file_obj_set_file);
 
-//|     def open(self, str) -> None:
+//|     def open(self, filepath: str) -> None:
 //|         """Takes in the name of a mp3 file, opens it, and replaces the old playback file."""
 //|         ...
 //|

--- a/shared-bindings/audiomp3/MP3Decoder.c
+++ b/shared-bindings/audiomp3/MP3Decoder.c
@@ -172,6 +172,26 @@ STATIC mp_obj_t audiomp3_mp3file_obj_set_file(mp_obj_t self_in, mp_obj_t file) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(audiomp3_mp3file_set_file_obj, audiomp3_mp3file_obj_set_file);
 
+//|     def open_file(self, str) -> None:
+//|         """Takes in the name of a mp3 file, opens it, and replaces the old playback file."""
+//|         ...
+//|
+STATIC mp_obj_t audiomp3_mp3file_obj_open_file(mp_obj_t self_in, mp_obj_t path) {
+    audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_obj_t file;
+    check_for_deinit(self);
+    if (!mp_obj_is_str(path)) {
+        mp_raise_TypeError(translate("file path must be provided as input"));
+    }
+    file = mp_call_function_2(MP_OBJ_FROM_PTR(&mp_builtin_open_obj), path, MP_ROM_QSTR(MP_QSTR_rb));
+    if (!mp_obj_is_type(file, &mp_type_fileio)) {
+        mp_raise_TypeError(translate("file must be a file opened in byte mode"));
+    }
+    common_hal_audiomp3_mp3file_set_file(self, file);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(audiomp3_mp3file_open_file_obj, audiomp3_mp3file_obj_open_file);
+
 MP_PROPERTY_GETSET(audiomp3_mp3file_file_obj,
     (mp_obj_t)&audiomp3_mp3file_get_file_obj,
     (mp_obj_t)&audiomp3_mp3file_set_file_obj);
@@ -256,6 +276,7 @@ MP_PROPERTY_GETTER(audiomp3_mp3file_samples_decoded_obj,
 
 STATIC const mp_rom_map_elem_t audiomp3_mp3file_locals_dict_table[] = {
     // Methods
+    { MP_ROM_QSTR(MP_QSTR_open_file), MP_ROM_PTR(&audiomp3_mp3file_open_file_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&audiomp3_mp3file_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&default___enter___obj) },
     { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&audiomp3_mp3file___exit___obj) },


### PR DESCRIPTION
Hi @jepler  ! 🐈‍⬛ 🐈‍⬛ 

Based on our discussion in #6931, I added a method that takes a mp3 file name as input, opens the mp3 file, and replaces the old opened file in the current MP3Decoder object. 

Please let me know if this is what you had in mind, and it looks good. 

Thank you! 