### PR TITLE
docs: usb_cdc.Serial.readinto has no nbytes parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: "3.x"
+        python-version: "3.10.6"
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -521,9 +521,8 @@ STATIC mp_obj_t rp2pio_statemachine_obj_stop_background_write(mp_obj_t self_in) 
 }
 MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_stop_background_write_obj, rp2pio_statemachine_obj_stop_background_write);
 
-//|     @property
-//|     def writing(self) -> bool:
-//|         """Returns True if a background write is in progress"""
+//|     writing: bool
+//|     """Returns True if a background write is in progress"""
 //|
 STATIC mp_obj_t rp2pio_statemachine_obj_get_writing(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -539,11 +538,10 @@ const mp_obj_property_t rp2pio_statemachine_writing_obj = {
 };
 
 
-//|     @property
-//|     def pending(self) -> int:
-//|         """Returns the number of pending buffers for background writing.
+//|     pending: int
+//|     """Returns the number of pending buffers for background writing.
 //|
-//|         If the number is 0, then a `StateMachine.background_write` call will not block."""
+//|     If the number is 0, then a `StateMachine.background_write` call will not block."""
 //|
 STATIC mp_obj_t rp2pio_statemachine_obj_get_pending(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -9,7 +9,7 @@ setuptools>=45
 setuptools_scm
 
 # For sphinx
-sphinx>=4.0.0
+sphinx!=5.2.0.post0
 sphinx-autoapi
 sphinx-rtd-theme
 sphinxcontrib-svg2pdfconverter

--- a/shared-bindings/sdioio/SDCard.c
+++ b/shared-bindings/sdioio/SDCard.c
@@ -201,11 +201,9 @@ STATIC mp_obj_t sdioio_sdcard_writeblocks(mp_obj_t self_in, mp_obj_t start_block
 
 MP_DEFINE_CONST_FUN_OBJ_3(sdioio_sdcard_writeblocks_obj, sdioio_sdcard_writeblocks);
 
-//|     @property
-//|     def frequency(self) -> int:
-//|         """The actual SDIO bus frequency. This may not match the frequency
-//|         requested due to internal limitations."""
-//|         ...
+//|     frequency: int
+//|     """The actual SDIO bus frequency. This may not match the frequency
+//|     requested due to internal limitations."""
 //|
 STATIC mp_obj_t sdioio_sdcard_obj_get_frequency(mp_obj_t self_in) {
     sdioio_sdcard_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -217,10 +215,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(sdioio_sdcard_get_frequency_obj, sdioio_sdcard_obj_get
 MP_PROPERTY_GETTER(sdioio_sdcard_frequency_obj,
     (mp_obj_t)&sdioio_sdcard_get_frequency_obj);
 
-//|     @property
-//|     def width(self) -> int:
-//|         """The actual SDIO bus width, in bits"""
-//|         ...
+//|     width:int
+//|     """The actual SDIO bus width, in bits"""
 //|
 STATIC mp_obj_t sdioio_sdcard_obj_get_width(mp_obj_t self_in) {
     sdioio_sdcard_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/usb_cdc/Serial.c
+++ b/shared-bindings/usb_cdc/Serial.c
@@ -54,11 +54,12 @@
 //|         ...
 //|
 //|     def readinto(self, buf: WriteableBuffer) -> int:
-//|         """Read bytes into the ``buf``.  If ``nbytes`` is specified then read at most
-//|         that many bytes, subject to `timeout`.  Otherwise, read at most ``len(buf)`` bytes.
+//|         """Read bytes into the ``buf``. Read at most ``len(buf)`` bytes. If `timeout`
+//|         is > 0 or ``None``, keep waiting until the timeout expires or ``len(buf)``
+//|         bytes are available.
 //|
 //|         :return: number of bytes read and stored into ``buf``
-//|         :rtype: bytes"""
+//|         :rtype: int"""
 //|         ...
 //|
 //|     def readline(self, size: int = -1) -> Optional[bytes]:


### PR DESCRIPTION
And returns int.