### PR TITLE
Black bindings

### DIFF
--- a/ports/atmel-samd/bindings/samd/Clock.c
+++ b/ports/atmel-samd/bindings/samd/Clock.c
@@ -33,9 +33,8 @@
 //| class Clock:
 //|     """Identifies a clock on the microcontroller.
 //|
-//|        They are fixed by the hardware so they cannot be constructed on demand. Instead, use
-//|        ``samd.clock`` to reference the desired clock."""
-//|
+//|     They are fixed by the hardware so they cannot be constructed on demand. Instead, use
+//|     ``samd.clock`` to reference the desired clock."""
 
 STATIC void samd_clock_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     samd_clock_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -45,7 +44,6 @@ STATIC void samd_clock_print(const mp_print_t *print, mp_obj_t self_in, mp_print
 
 //|     enabled: bool
 //|     """Is the clock enabled? (read-only)"""
-//|
 STATIC mp_obj_t samd_clock_get_enabled(mp_obj_t self_in) {
     samd_clock_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(clock_get_enabled(self->type, self->index));
@@ -58,7 +56,6 @@ MP_PROPERTY_GETTER(samd_clock_enabled_obj,
 
 //|     parent: Union[Clock, None]
 //|     """Clock parent. (read-only)"""
-//|
 STATIC mp_obj_t samd_clock_get_parent(mp_obj_t self_in) {
     samd_clock_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint8_t p_type, p_index;
@@ -83,7 +80,6 @@ MP_PROPERTY_GETTER(samd_clock_parent_obj,
 
 //|     frequency: int
 //|     """Clock frequency in Herz. (read-only)"""
-//|
 STATIC mp_obj_t samd_clock_get_frequency(mp_obj_t self_in) {
     samd_clock_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int_from_uint(clock_get_frequency(self->type, self->index));
@@ -96,7 +92,6 @@ MP_PROPERTY_GETTER(samd_clock_frequency_obj,
 
 //|     calibration: int
 //|     """Clock calibration. Not all clocks can be calibrated."""
-//|
 STATIC mp_obj_t samd_clock_get_calibration(mp_obj_t self_in) {
     samd_clock_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int_from_uint(clock_get_calibration(self->type, self->index));

--- a/ports/atmel-samd/bindings/samd/__init__.c
+++ b/ports/atmel-samd/bindings/samd/__init__.c
@@ -40,7 +40,6 @@
 //|   :platform: SAMD21
 //|
 //| References to clocks as named by the microcontroller"""
-//|
 const mp_obj_module_t samd_clock_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&samd_clock_globals,

--- a/ports/broadcom/bindings/videocore/Framebuffer.c
+++ b/ports/broadcom/bindings/videocore/Framebuffer.c
@@ -46,7 +46,6 @@
 //|
 //|         A Framebuffer is often used in conjunction with a
 //|         `framebufferio.FramebufferDisplay`."""
-//|
 
 STATIC mp_obj_t videocore_framebuffer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_width, ARG_height, };
@@ -72,7 +71,6 @@ STATIC mp_obj_t videocore_framebuffer_make_new(const mp_obj_type_t *type, size_t
 //|         rgbmatrix instance.  After deinitialization, no further operations
 //|         may be performed."""
 //|         ...
-//|
 STATIC mp_obj_t videocore_framebuffer_deinit(mp_obj_t self_in) {
     videocore_framebuffer_obj_t *self = (videocore_framebuffer_obj_t *)self_in;
     common_hal_videocore_framebuffer_deinit(self);
@@ -89,7 +87,6 @@ static void check_for_deinit(videocore_framebuffer_obj_t *self) {
 
 //|     width: int
 //|     """The width of the display, in pixels"""
-//|
 STATIC mp_obj_t videocore_framebuffer_get_width(mp_obj_t self_in) {
     videocore_framebuffer_obj_t *self = (videocore_framebuffer_obj_t *)self_in;
     check_for_deinit(self);
@@ -101,7 +98,6 @@ MP_PROPERTY_GETTER(videocore_framebuffer_width_obj,
 
 //|     height: int
 //|     """The height of the display, in pixels"""
-//|
 STATIC mp_obj_t videocore_framebuffer_get_height(mp_obj_t self_in) {
     videocore_framebuffer_obj_t *self = (videocore_framebuffer_obj_t *)self_in;
     check_for_deinit(self);

--- a/ports/broadcom/bindings/videocore/__init__.c
+++ b/ports/broadcom/bindings/videocore/__init__.c
@@ -32,7 +32,6 @@
 #include "bindings/videocore/Framebuffer.h"
 
 //| """Low-level routines for interacting with the Broadcom VideoCore GPU"""
-//|
 
 STATIC const mp_rom_map_elem_t videocore_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_videocore) },

--- a/ports/espressif/bindings/esp32_camera/Camera.c
+++ b/ports/espressif/bindings/esp32_camera/Camera.c
@@ -54,9 +54,9 @@
 //|         external_clock_frequency: int,
 //|         powerdown_pin: Optional[microcontroller.Pin] = None,
 //|         reset_pin: Optional[microcontroller.Pin] = None,
-//|         pixel_format: PixelFormat=PixelFormat.RGB565,
-//|         frame_size: FrameSize=FrameSize.QQVGA,
-//|         jpeg_quality: int=15,
+//|         pixel_format: PixelFormat = PixelFormat.RGB565,
+//|         frame_size: FrameSize = FrameSize.QQVGA,
+//|         jpeg_quality: int = 15,
 //|         framebuffer_count: int = 1,
 //|         grab_mode: GrabMode = GrabMode.WHEN_EMPTY,
 //|     ) -> None:
@@ -93,7 +93,6 @@
 //|         :param framebuffer_count: The number of framebuffers (1 for single-buffered and 2 for double-buffered)
 //|         :param grab_mode: When to grab a new frame
 //|         """
-//|
 STATIC mp_obj_t esp32_camera_camera_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_data_pins, ARG_pixel_clock_pin, ARG_vsync_pin, ARG_href_pin, ARG_i2c, ARG_external_clock_pin, ARG_external_clock_frequency, ARG_powerdown_pin, ARG_reset_pin, ARG_pixel_format, ARG_frame_size, ARG_jpeg_quality, ARG_framebuffer_count, ARG_grab_mode, NUM_ARGS };
     static const mp_arg_t allowed_args[] = {
@@ -161,7 +160,6 @@ STATIC mp_obj_t esp32_camera_camera_make_new(const mp_obj_type_t *type, size_t n
 //|     def deinit(self) -> None:
 //|         """Deinitialises the camera and releases all memory resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t esp32_camera_camera_deinit(mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_esp32_camera_camera_deinit(self);
@@ -178,14 +176,12 @@ STATIC void check_for_deinit(esp32_camera_camera_obj_t *self) {
 //|     def __enter__(self) -> Camera:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t esp32_camera_camera_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     return esp32_camera_camera_deinit(args[0]);
@@ -205,14 +201,15 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp32_camera_camera_frame_available_get_obj, es
 MP_PROPERTY_GETTER(esp32_camera_camera_frame_available_obj,
     (mp_obj_t)&esp32_camera_camera_frame_available_get_obj);
 
-//|     def take(self, timeout: Optional[float]=0.25) -> Optional[displayio.Bitmap | ReadableBuffer]:
+//|     def take(
+//|         self, timeout: Optional[float] = 0.25
+//|     ) -> Optional[displayio.Bitmap | ReadableBuffer]:
 //|         """Record a frame. Wait up to 'timeout' seconds for a frame to be captured.
 //|
 //|         In the case of timeout, `None` is returned.
 //|         If `pixel_format` is `PixelFormat.JPEG`, the returned value is a read-only `memoryview`.
 //|         Otherwise, the returned value is a read-only `displayio.Bitmap`.
 //|         """
-//|
 STATIC mp_obj_t esp32_camera_camera_take(size_t n_args, const mp_obj_t *args) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     mp_float_t timeout = n_args < 2 ? MICROPY_FLOAT_CONST(0.25) : mp_obj_get_float(args[1]);
@@ -249,7 +246,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp32_camera_camera_take_obj, 1, 2, e
 //|         the other properties to set, they are set together in a single function call.
 //|
 //|         If an argument is unspecified or None, then the setting is unchanged."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_reconfigure(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
@@ -318,7 +314,6 @@ MP_PROPERTY_GETTER(esp32_camera_camera_frame_size_obj,
 
 //|     contrast: int
 //|     """The sensor contrast.  Positive values increase contrast, negative values lower it. The total range is device-specific but is often from -2 to +2 inclusive."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_contrast(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -340,7 +335,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_contrast_obj,
 
 //|     brightness: int
 //|     """The sensor brightness.  Positive values increase brightness, negative values lower it. The total range is device-specific but is often from -2 to +2 inclusive."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_brightness(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -362,7 +356,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_brightness_obj,
 
 //|     saturation: int
 //|     """The sensor saturation.  Positive values increase saturation (more vibrant colors), negative values lower it (more muted colors).  The total range is device-specific but the value is often from -2 to +2 inclusive."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_saturation(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -384,7 +377,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_saturation_obj,
 
 //|     sharpness: int
 //|     """The sensor sharpness.  Positive values increase sharpness (more defined edges), negative values lower it (softer edges).  The total range is device-specific but the value is often from -2 to +2 inclusive."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_sharpness(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -406,7 +398,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_sharpness_obj,
 
 //|     denoise: int
 //|     """The sensor 'denoise' setting.  Any camera sensor has inherent 'noise', especially in low brightness environments. Software algorithms can decrease noise at the expense of fine detail.  A larger value increases the amount of software noise removal.  The total range is device-specific but the value is often from 0 to 10."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_denoise(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -428,7 +419,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_denoise_obj,
 
 //|     gain_ceiling: GainCeiling
 //|     """The sensor 'gain ceiling' setting. "Gain" is an analog multiplier applied to the raw sensor data.  The 'ceiling' is the maximum gain value that the sensor will use. A higher gain means that the sensor has a greater response to light, but also makes sensor noise more visible."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_gain_ceiling(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -450,7 +440,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_gain_ceiling_obj,
 
 //|     quality: int
 //|     """The 'quality' setting when capturing JPEG images.  This is similar to the quality setting when exporting a jpeg image from photo editing software.  Typical values range from 5 to 40, with higher numbers leading to larger image sizes and better overall image quality. However, when the quality is set to a high number, the total size of the JPEG data can exceed the size of an internal buffer, causing image capture to fail."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_quality(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -472,7 +461,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_quality_obj,
 
 //|     colorbar: bool
 //|     """When `True`, a test pattern image is captured and the real sensor data is not used."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_colorbar(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -494,7 +482,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_colorbar_obj,
 
 //|     whitebal: bool
 //|     """When `True`, the camera attempts to automatically control white balance.  When `False`, the `wb_mode` setting is used instead."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_whitebal(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -516,7 +503,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_whitebal_obj,
 
 //|     gain_ctrl: bool
 //|     """When `True`, the camera attempts to automatically control the sensor gain, up to the value in the `gain_ceiling` property.  When `False`, the `agc_gain` setting is used instead."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_gain_ctrl(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -538,7 +524,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_gain_ctrl_obj,
 
 //|     exposure_ctrl: bool
 //|     """When `True` the camera attempts to automatically control the exposure. When `False`, the `aec_value` setting is used instead."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_exposure_ctrl(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -560,7 +545,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_exposure_ctrl_obj,
 
 //|     hmirror: bool
 //|     """When `True` the camera image is mirrored left-to-right"""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_hmirror(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -582,7 +566,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_hmirror_obj,
 
 //|     vflip: bool
 //|     """When `True` the camera image is flipped top-to-bottom"""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_vflip(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -604,7 +587,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_vflip_obj,
 
 //|     aec2: bool
 //|     """When `True` the sensor's "night mode" is enabled, extending the range of automatic gain control."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_aec2(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -626,7 +608,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_aec2_obj,
 
 //|     awb_gain: bool
 //|     """Access the awb_gain property of the camera sensor"""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_awb_gain(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -648,7 +629,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_awb_gain_obj,
 
 //|     agc_gain: int
 //|     """Access the gain level of the sensor. Higher values produce brighter images.  Typical settings range from 0 to 30. """
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_agc_gain(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -670,7 +650,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_agc_gain_obj,
 
 //|     aec_value: int
 //|     """Access the exposure value of the camera.  Higher values produce brighter images.  Typical settings range from 0 to 1200."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_aec_value(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -692,7 +671,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_aec_value_obj,
 
 //|     special_effect: int
 //|     """Enable a "special effect". Zero is no special effect.  On OV5640, special effects range from 0 to 6 inclusive and select various color modes."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_special_effect(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -714,7 +692,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_special_effect_obj,
 
 //|     wb_mode: int
 //|     """The white balance mode.  0 is automatic white balance.  Typical values range from 0 to 4 inclusive."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_wb_mode(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -736,7 +713,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_wb_mode_obj,
 
 //|     ae_level: int
 //|     """The exposure offset for automatic exposure.  Typical values range from -2 to +2."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_ae_level(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -758,7 +734,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_ae_level_obj,
 
 //|     dcw: bool
 //|     """When `True` an advanced white balance mode is selected."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_dcw(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -780,7 +755,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_dcw_obj,
 
 //|     bpc: bool
 //|     """When `True`, "black point compensation" is enabled. This can make black parts of the image darker."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_bpc(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -802,7 +776,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_bpc_obj,
 
 //|     wpc: bool
 //|     """When `True`, "white point compensation" is enabled.  This can make white parts of the image whiter."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_wpc(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -824,7 +797,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_wpc_obj,
 
 //|     raw_gma: bool
 //|     """When `True`, raw gamma mode is enabled."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_raw_gma(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -846,7 +818,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_raw_gma_obj,
 
 //|     lenc: bool
 //|     """Enable "lens correction". This can help compensate for light fall-off at the edge of the sensor area."""
-//|
 
 STATIC mp_obj_t esp32_camera_camera_get_lenc(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -868,7 +839,6 @@ MP_PROPERTY_GETSET(esp32_camera_camera_lenc_obj,
 
 //|     max_frame_size: FrameSize
 //|     """The maximum frame size that can be captured"""
-//|
 STATIC mp_obj_t esp32_camera_camera_get_max_frame_size(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -882,7 +852,6 @@ MP_PROPERTY_GETTER(esp32_camera_camera_max_frame_size_obj,
 
 //|     address: int
 //|     """The I2C (SCCB) address of the sensor"""
-//|
 STATIC mp_obj_t esp32_camera_camera_get_address(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -896,7 +865,6 @@ MP_PROPERTY_GETTER(esp32_camera_camera_address_obj,
 
 //|     sensor_name: str
 //|     """The name of the sensor"""
-//|
 STATIC mp_obj_t esp32_camera_camera_get_sensor_name(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -911,7 +879,6 @@ MP_PROPERTY_GETTER(esp32_camera_camera_sensor_name_obj,
 
 //|     supports_jpeg: bool
 //|     """True if the sensor can capture images in JPEG format"""
-//|
 STATIC mp_obj_t esp32_camera_camera_get_supports_jpeg(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -924,7 +891,6 @@ MP_PROPERTY_GETTER(esp32_camera_camera_supports_jpeg_obj,
 
 //|     height: int
 //|     """The height of the image being captured"""
-//|
 STATIC mp_obj_t esp32_camera_camera_get_height(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -937,7 +903,6 @@ MP_PROPERTY_GETTER(esp32_camera_camera_height_obj,
 
 //|     width: int
 //|     """The width of the image being captured"""
-//|
 STATIC mp_obj_t esp32_camera_camera_get_width(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -950,7 +915,6 @@ MP_PROPERTY_GETTER(esp32_camera_camera_width_obj,
 
 //|     grab_mode: GrabMode
 //|     """The grab mode of the camera"""
-//|
 STATIC mp_obj_t esp32_camera_camera_get_grab_mode(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -964,7 +928,6 @@ MP_PROPERTY_GETTER(esp32_camera_camera_grab_mode_obj,
 
 //|     framebuffer_count: int
 //|     """True if double buffering is used"""
-//|
 STATIC mp_obj_t esp32_camera_camera_get_framebuffer_count(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/ports/espressif/bindings/esp32_camera/__init__.c
+++ b/ports/espressif/bindings/esp32_camera/__init__.c
@@ -54,7 +54,6 @@
 //|
 //|     LATEST: GrabMode
 //|     """Except when 1 frame buffer is used, queue will always contain the last ``fb_count`` frames"""
-//|
 
 MAKE_ENUM_VALUE(esp32_camera_grab_mode_type, grab_mode, WHEN_EMPTY, CAMERA_GRAB_WHEN_EMPTY);
 MAKE_ENUM_VALUE(esp32_camera_grab_mode_type, grab_mode, LATEST, CAMERA_GRAB_LATEST);
@@ -83,7 +82,6 @@ camera_grab_mode_t validate_grab_mode(mp_obj_t obj, qstr arg_name) {
 //|
 //|     JPEG: PixelFormat
 //|     """A compressed format"""
-//|
 
 MAKE_ENUM_VALUE(esp32_camera_pixel_format_type, pixel_format, RGB565, PIXFORMAT_RGB565);
 MAKE_ENUM_VALUE(esp32_camera_pixel_format_type, pixel_format, GRAYSCALE, PIXFORMAT_GRAYSCALE);
@@ -171,7 +169,6 @@ pixformat_t validate_pixel_format(mp_obj_t obj, qstr arg_name) {
 //|
 //|     QSXGA: FrameSize
 //|     """2560x1920"""
-//|
 
 MAKE_ENUM_VALUE(esp32_camera_frame_size_type, frame_size, R96X96, FRAMESIZE_96X96);
 MAKE_ENUM_VALUE(esp32_camera_frame_size_type, frame_size, R240X240, FRAMESIZE_240X240);
@@ -240,7 +237,6 @@ framesize_t validate_frame_size(mp_obj_t obj, qstr arg_name) {
 //|     GAIN_32X: GainCeiling
 //|     GAIN_64X: GainCeiling
 //|     GAIN_128X: GainCeiling
-//|
 
 MAKE_ENUM_VALUE(esp32_camera_gain_ceiling_type, gain_ceiling, GAIN_2X, GAINCEILING_2X);
 MAKE_ENUM_VALUE(esp32_camera_gain_ceiling_type, gain_ceiling, GAIN_4X, GAINCEILING_4X);

--- a/ports/espressif/bindings/espidf/__init__.c
+++ b/ports/espressif/bindings/espidf/__init__.c
@@ -41,7 +41,6 @@
 //| def heap_caps_get_total_size() -> int:
 //|     """Return the total size of the ESP-IDF, which includes the CircuitPython heap."""
 //|     ...
-//|
 
 STATIC mp_obj_t espidf_heap_caps_get_total_size(void) {
     return MP_OBJ_NEW_SMALL_INT(heap_caps_get_total_size(MALLOC_CAP_8BIT));
@@ -51,7 +50,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(espidf_heap_caps_get_total_size_obj, espidf_heap_caps_
 //| def heap_caps_get_free_size() -> int:
 //|     """Return total free memory in the ESP-IDF heap."""
 //|     ...
-//|
 
 STATIC mp_obj_t espidf_heap_caps_get_free_size(void) {
     return MP_OBJ_NEW_SMALL_INT(heap_caps_get_free_size(MALLOC_CAP_8BIT));
@@ -61,7 +59,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(espidf_heap_caps_get_free_size_obj, espidf_heap_caps_g
 //| def heap_caps_get_largest_free_block() -> int:
 //|     """Return the size of largest free memory block in the ESP-IDF heap."""
 //|     ...
-//|
 
 STATIC mp_obj_t espidf_heap_caps_get_largest_free_block(void) {
     return MP_OBJ_NEW_SMALL_INT(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
@@ -103,10 +100,11 @@ const mp_obj_type_t mp_type_espidf_IDFError = {
 
 
 //| import builtins
+//|
 //| class MemoryError(builtins.MemoryError):
 //|     """Raised when an ESP IDF memory allocation fails."""
-//|     ...
 //|
+//|     ...
 NORETURN void mp_raise_espidf_MemoryError(void) {
     nlr_raise(mp_obj_new_exception(&mp_type_espidf_MemoryError));
 }

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -313,9 +313,8 @@ STATIC void check_for_deinit(rp2pio_statemachine_obj_t *self) {
 
 //|     def restart(self) -> None:
 //|         """Resets this state machine, runs any init and enables the clock."""
-// TODO: "and any others given. They must share an underlying PIO. An exception will be raised otherwise.""
 //|         ...
-//|
+// TODO: "and any others given. They must share an underlying PIO. An exception will be raised otherwise.""
 STATIC mp_obj_t rp2pio_statemachine_restart(mp_obj_t self_obj) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_obj);
     check_for_deinit(self);

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -57,42 +57,43 @@
 //|     in either PIO. State machines with the same program will be placed in the
 //|     same PIO if possible."""
 //|
-//|     def __init__(self,
-//|                  program: ReadableBuffer,
-//|                  frequency: int,
-//|                  *,
-//|                  init: Optional[ReadableBuffer] = None,
-//|                  first_out_pin: Optional[microcontroller.Pin] = None,
-//|                  out_pin_count: int = 1,
-//|                  initial_out_pin_state: int = 0,
-//|                  initial_out_pin_direction: int = 0xffffffff,
-//|                  first_in_pin: Optional[microcontroller.Pin] = None,
-//|                  in_pin_count: int = 1,
-//|                  pull_in_pin_up: int = 0,
-//|                  pull_in_pin_down: int = 0,
-//|                  first_set_pin: Optional[microcontroller.Pin] = None,
-//|                  set_pin_count: int = 1,
-//|                  initial_set_pin_state: int = 0,
-//|                  initial_set_pin_direction: int = 0x1f,
-//|                  first_sideset_pin: Optional[microcontroller.Pin] = None,
-//|                  sideset_pin_count: int = 1,
-//|                  initial_sideset_pin_state: int = 0,
-//|                  initial_sideset_pin_direction: int = 0x1f,
-//|                  sideset_enable: bool = False,
-//|                  jmp_pin: Optional[microcontroller.Pin] = None,
-//|                  jmp_pin_pull: Optional[digitalio.Pull] = None,
-//|                  exclusive_pin_use: bool = True,
-//|                  auto_pull: bool = False,
-//|                  pull_threshold: int = 32,
-//|                  out_shift_right: bool = True,
-//|                  wait_for_txstall: bool = True,
-//|                  auto_push: bool = False,
-//|                  push_threshold: int = 32,
-//|                  in_shift_right: bool = True,
-//|                  user_interruptible: bool = True,
-//|                  wrap_target: int = 0,
-//|                  wrap: int = -1,
-//|                 ) -> None:
+//|     def __init__(
+//|         self,
+//|         program: ReadableBuffer,
+//|         frequency: int,
+//|         *,
+//|         init: Optional[ReadableBuffer] = None,
+//|         first_out_pin: Optional[microcontroller.Pin] = None,
+//|         out_pin_count: int = 1,
+//|         initial_out_pin_state: int = 0,
+//|         initial_out_pin_direction: int = 0xFFFFFFFF,
+//|         first_in_pin: Optional[microcontroller.Pin] = None,
+//|         in_pin_count: int = 1,
+//|         pull_in_pin_up: int = 0,
+//|         pull_in_pin_down: int = 0,
+//|         first_set_pin: Optional[microcontroller.Pin] = None,
+//|         set_pin_count: int = 1,
+//|         initial_set_pin_state: int = 0,
+//|         initial_set_pin_direction: int = 0x1F,
+//|         first_sideset_pin: Optional[microcontroller.Pin] = None,
+//|         sideset_pin_count: int = 1,
+//|         initial_sideset_pin_state: int = 0,
+//|         initial_sideset_pin_direction: int = 0x1F,
+//|         sideset_enable: bool = False,
+//|         jmp_pin: Optional[microcontroller.Pin] = None,
+//|         jmp_pin_pull: Optional[digitalio.Pull] = None,
+//|         exclusive_pin_use: bool = True,
+//|         auto_pull: bool = False,
+//|         pull_threshold: int = 32,
+//|         out_shift_right: bool = True,
+//|         wait_for_txstall: bool = True,
+//|         auto_push: bool = False,
+//|         push_threshold: int = 32,
+//|         in_shift_right: bool = True,
+//|         user_interruptible: bool = True,
+//|         wrap_target: int = 0,
+//|         wrap: int = -1,
+//|     ) -> None:
 //|
 //|         """Construct a StateMachine object on the given pins with the given program.
 //|
@@ -148,7 +149,6 @@
 //|             last instruction of the program.
 //|         """
 //|         ...
-//|
 
 STATIC mp_obj_t rp2pio_statemachine_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     rp2pio_statemachine_obj_t *self = m_new_obj(rp2pio_statemachine_obj_t);
@@ -278,7 +278,6 @@ STATIC mp_obj_t rp2pio_statemachine_make_new(const mp_obj_type_t *type, size_t n
 //|     def deinit(self) -> None:
 //|         """Turn off the state machine and release its resources."""
 //|         ...
-//|
 STATIC mp_obj_t rp2pio_statemachine_obj_deinit(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_rp2pio_statemachine_deinit(self);
@@ -290,13 +289,11 @@ MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_deinit_obj, rp2pio_statemachine_ob
 //|         """No-op used by Context Managers.
 //|         Provided by context manager helper."""
 //|         ...
-//|
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t rp2pio_statemachine_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_rp2pio_statemachine_deinit(args[0]);
@@ -327,12 +324,11 @@ MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_restart_obj, rp2pio_statemachine_r
 
 //|     def run(self, instructions: ReadableBuffer) -> None:
 //|         """Runs all given instructions. They will likely be interleaved with
-//|            in-memory instructions. Make sure this doesn't wait for input!
+//|         in-memory instructions. Make sure this doesn't wait for input!
 //|
-//|            This can be used to output internal state to the RX FIFO and then
-//|            read with `readinto`."""
+//|         This can be used to output internal state to the RX FIFO and then
+//|         read with `readinto`."""
 //|         ...
-//|
 STATIC mp_obj_t rp2pio_statemachine_run(mp_obj_t self_obj, mp_obj_t instruction_obj) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_obj);
     check_for_deinit(self);
@@ -348,7 +344,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(rp2pio_statemachine_run_obj, rp2pio_statemachine_run);
 //|     def stop(self) -> None:
 //|         """Stops the state machine clock. Use `restart` to enable it."""
 //|         ...
-//|
 STATIC mp_obj_t rp2pio_statemachine_stop(mp_obj_t self_obj) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_obj);
     check_for_deinit(self);
@@ -358,7 +353,14 @@ STATIC mp_obj_t rp2pio_statemachine_stop(mp_obj_t self_obj) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_stop_obj, rp2pio_statemachine_stop);
 
-//|     def write(self, buffer: ReadableBuffer, *, start: int = 0, end: Optional[int] = None, swap: bool = False) -> None:
+//|     def write(
+//|         self,
+//|         buffer: ReadableBuffer,
+//|         *,
+//|         start: int = 0,
+//|         end: Optional[int] = None,
+//|         swap: bool = False
+//|     ) -> None:
 //|         """Write the data contained in ``buffer`` to the state machine. If the buffer is empty, nothing happens.
 //|
 //|         Writes to the FIFO will match the input buffer's element size. For example, bytearray elements
@@ -373,7 +375,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_stop_obj, rp2pio_statemachine_stop
 //|         :param int end: End of the slice; this index is not included. Defaults to ``len(buffer)``
 //|         :param bool swap: For 2- and 4-byte elements, swap (reverse) the byte order"""
 //|         ...
-//|
 STATIC mp_obj_t rp2pio_statemachine_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_start, ARG_end, ARG_swap };
     static const mp_arg_t allowed_args[] = {
@@ -413,7 +414,13 @@ STATIC mp_obj_t rp2pio_statemachine_write(size_t n_args, const mp_obj_t *pos_arg
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_obj, 2, rp2pio_statemachine_write);
 
-//|     def background_write(self, once: Optional[ReadableBuffer]=None, *, loop: Optional[ReadableBuffer]=None, swap: bool=False) -> None:
+//|     def background_write(
+//|         self,
+//|         once: Optional[ReadableBuffer] = None,
+//|         *,
+//|         loop: Optional[ReadableBuffer] = None,
+//|         swap: bool = False
+//|     ) -> None:
 //|         """Write data to the TX fifo in the background, with optional looping.
 //|
 //|         First, if any previous ``once`` or ``loop`` buffer has not been started, this function blocks until they have.
@@ -450,7 +457,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_obj, 2, rp2pio_statemachine
 //|         :param bool swap: For 2- and 4-byte elements, swap (reverse) the byte order
 //|         """
 //|         ...
-//|
 
 STATIC void fill_buf_info(sm_buf_info *info, mp_obj_t obj, size_t *stride_in_bytes) {
     if (obj != mp_const_none) {
@@ -506,7 +512,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_background_write_obj, 1, rp2pio_s
 //|         """Immediately stop a background write, if one is in progress.  Any
 //|         DMA in progress is halted, but items already in the TX FIFO are not
 //|         affected."""
-//|
 STATIC mp_obj_t rp2pio_statemachine_obj_stop_background_write(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
     bool ok = common_hal_rp2pio_statemachine_stop_background_write(self);
@@ -522,7 +527,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_stop_background_write_obj, rp2pio_
 
 //|     writing: bool
 //|     """Returns True if a background write is in progress"""
-//|
 STATIC mp_obj_t rp2pio_statemachine_obj_get_writing(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_rp2pio_statemachine_get_writing(self));
@@ -541,7 +545,6 @@ const mp_obj_property_t rp2pio_statemachine_writing_obj = {
 //|     """Returns the number of pending buffers for background writing.
 //|
 //|     If the number is 0, then a `StateMachine.background_write` call will not block."""
-//|
 STATIC mp_obj_t rp2pio_statemachine_obj_get_pending(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(common_hal_rp2pio_statemachine_get_pending(self));
@@ -555,7 +558,14 @@ const mp_obj_property_t rp2pio_statemachine_pending_obj = {
               MP_ROM_NONE},
 };
 
-//|     def readinto(self, buffer: WriteableBuffer, *, start: int = 0, end: Optional[int] = None, swap: bool=False) -> None:
+//|     def readinto(
+//|         self,
+//|         buffer: WriteableBuffer,
+//|         *,
+//|         start: int = 0,
+//|         end: Optional[int] = None,
+//|         swap: bool = False
+//|     ) -> None:
 //|         """Read into ``buffer``. If the number of bytes to read is 0, nothing happens. The buffer
 //|         includes any data added to the fifo even if it was added before this was called.
 //|
@@ -572,7 +582,6 @@ const mp_obj_property_t rp2pio_statemachine_pending_obj = {
 //|         :param int end: End of the slice; this index is not included. Defaults to ``len(buffer)``
 //|         :param bool swap: For 2- and 4-byte elements, swap (reverse) the byte order"""
 //|         ...
-//|
 
 STATIC mp_obj_t rp2pio_statemachine_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_start, ARG_end, ARG_swap };
@@ -611,7 +620,16 @@ STATIC mp_obj_t rp2pio_statemachine_readinto(size_t n_args, const mp_obj_t *pos_
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_readinto_obj, 2, rp2pio_statemachine_readinto);
 
-//|     def write_readinto(self, buffer_out: ReadableBuffer, buffer_in: WriteableBuffer, *, out_start: int = 0, out_end: Optional[int] = None, in_start: int = 0, in_end: Optional[int] = None) -> None:
+//|     def write_readinto(
+//|         self,
+//|         buffer_out: ReadableBuffer,
+//|         buffer_in: WriteableBuffer,
+//|         *,
+//|         out_start: int = 0,
+//|         out_end: Optional[int] = None,
+//|         in_start: int = 0,
+//|         in_end: Optional[int] = None
+//|     ) -> None:
 //|         """Write out the data in ``buffer_out`` while simultaneously reading data into ``buffer_in``.
 //|         The lengths of the slices defined by ``buffer_out[out_start:out_end]`` and ``buffer_in[in_start:in_end]``
 //|         may be different. The function will return once both are filled.
@@ -632,7 +650,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_readinto_obj, 2, rp2pio_statemach
 //|         :param bool swap_out: For 2- and 4-byte elements, swap (reverse) the byte order for the buffer being transmitted (written)
 //|         :param bool swap_in: For 2- and 4-rx elements, swap (reverse) the byte order for the buffer being received (read)"""
 //|         ...
-//|
 
 STATIC mp_obj_t rp2pio_statemachine_write_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer_out, ARG_buffer_in, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end, ARG_swap_out, ARG_swap_in };
@@ -694,7 +711,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_readinto_obj, 2, rp2pio_sta
 //|     def clear_rxfifo(self) -> None:
 //|         """Clears any unread bytes in the rxfifo."""
 //|         ...
-//|
 STATIC mp_obj_t rp2pio_statemachine_obj_clear_rxfifo(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_rp2pio_statemachine_clear_rxfifo(self);
@@ -705,7 +721,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_clear_rxfifo_obj, rp2pio_statemach
 //|     def clear_txstall(self) -> None:
 //|         """Clears the txstall flag."""
 //|         ...
-//|
 STATIC mp_obj_t rp2pio_statemachine_obj_clear_txstall(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_rp2pio_statemachine_clear_txstall(self);
@@ -717,7 +732,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_clear_txstall_obj, rp2pio_statemac
 //|     frequency: int
 //|     """The actual state machine frequency. This may not match the frequency requested
 //|     due to internal limitations."""
-//|
 
 STATIC mp_obj_t rp2pio_statemachine_obj_get_frequency(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -742,7 +756,6 @@ MP_PROPERTY_GETSET(rp2pio_statemachine_frequency_obj,
 //|     txstall: bool
 //|     """True when the state machine has stalled due to a full TX FIFO since the last
 //|        `clear_txstall` call."""
-//|
 
 STATIC mp_obj_t rp2pio_statemachine_obj_get_txstall(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -762,7 +775,6 @@ const mp_obj_property_t rp2pio_statemachine_txstall_obj = {
 //|     rxstall: bool
 //|     """True when the state machine has stalled due to a full RX FIFO since the last
 //|        `clear_rxfifo` call."""
-//|
 
 STATIC mp_obj_t rp2pio_statemachine_obj_get_rxstall(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -776,7 +788,6 @@ MP_PROPERTY_GETTER(rp2pio_statemachine_rxstall_obj,
 
 //|     in_waiting: int
 //|     """The number of words available to readinto"""
-//|
 
 STATIC mp_obj_t rp2pio_statemachine_obj_get_in_waiting(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/ports/raspberrypi/bindings/rp2pio/__init__.c
+++ b/ports/raspberrypi/bindings/rp2pio/__init__.c
@@ -38,12 +38,10 @@
 //|     Learn guide <https://learn.adafruit.com/intro-to-rp2040-pio-with-circuitpython>`_.
 //|
 //| """
-//|
 
 //| def pins_are_sequential(pins: List[microcontroller.Pin]) -> bool:
 //|     """Return True if the pins have sequential GPIO numbers, False otherwise"""
 //|     ...
-//|
 STATIC mp_obj_t rp2pio_pins_are_sequential(const mp_obj_t pins) {
     size_t len;
     mp_obj_t *items;

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -62,9 +62,10 @@
 //|     The Adapter can do both parts of this process: it can scan for other device
 //|     advertisements and it can advertise its own data. Furthermore, Adapters can accept incoming
 //|     connections and also initiate connections."""
-//|
 
-//|     def __init__(self, *, uart: busio.UART, rts: digitalio.DigitalInOut, cts: digitalio.DigitalInOut) -> None:
+//|     def __init__(
+//|         self, *, uart: busio.UART, rts: digitalio.DigitalInOut, cts: digitalio.DigitalInOut
+//|     ) -> None:
 //|         """On boards that do not have native BLE, you can use an HCI co-processor.
 //|         Pass the uart and pins used to communicate with the co-processor, such as an Adafruit AirLift.
 //|         The co-processor must have been reset and put into BLE mode beforehand
@@ -80,7 +81,6 @@
 //|         Use `_bleio.adapter` to access the sole instance already available.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t bleio_adapter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     #if CIRCUITPY_BLEIO_HCI
     bleio_adapter_obj_t *self = common_hal_bleio_allocate_adapter_or_raise();
@@ -110,10 +110,8 @@ STATIC mp_obj_t bleio_adapter_make_new(const mp_obj_type_t *type, size_t n_args,
     #endif // CIRCUITPY_BLEIO_HCI
 }
 
-//|
 //|     enabled: bool
 //|     """State of the BLE adapter."""
-//|
 STATIC mp_obj_t bleio_adapter_get_enabled(mp_obj_t self) {
     return mp_obj_new_bool(common_hal_bleio_adapter_get_enabled(self));
 }
@@ -134,7 +132,6 @@ MP_PROPERTY_GETSET(bleio_adapter_enabled_obj,
 
 //|     address: Address
 //|     """MAC address of the BLE adapter."""
-//|
 STATIC mp_obj_t bleio_adapter_get_address(mp_obj_t self) {
     return MP_OBJ_FROM_PTR(common_hal_bleio_adapter_get_address(self));
 
@@ -157,7 +154,6 @@ MP_PROPERTY_GETSET(bleio_adapter_address_obj,
 //|     """name of the BLE adapter used once connected.
 //|     The name is "CIRCUITPY" + the last four hex digits of ``adapter.address``,
 //|     to make it easy to distinguish multiple CircuitPython boards."""
-//|
 STATIC mp_obj_t _bleio_adapter_get_name(mp_obj_t self) {
     return MP_OBJ_FROM_PTR(common_hal_bleio_adapter_get_name(self));
 }
@@ -174,10 +170,18 @@ MP_PROPERTY_GETSET(bleio_adapter_name_obj,
     (mp_obj_t)&bleio_adapter_get_name_obj,
     (mp_obj_t)&bleio_adapter_set_name_obj);
 
-//|     def start_advertising(self, data: ReadableBuffer, *,
-//|                           scan_response: Optional[ReadableBuffer] = None, connectable: bool = True,
-//|                           anonymous: bool = False, timeout: int = 0, interval: float = 0.1,
-//|                           tx_power: int = 0, directed_to: Optional[Address] = None) -> None:
+//|     def start_advertising(
+//|         self,
+//|         data: ReadableBuffer,
+//|         *,
+//|         scan_response: Optional[ReadableBuffer] = None,
+//|         connectable: bool = True,
+//|         anonymous: bool = False,
+//|         timeout: int = 0,
+//|         interval: float = 0.1,
+//|         tx_power: int = 0,
+//|         directed_to: Optional[Address] = None
+//|     ) -> None:
 //|         """Starts advertising until `stop_advertising` is called or if connectable, another device
 //|         connects to us.
 //|
@@ -196,7 +200,6 @@ MP_PROPERTY_GETSET(bleio_adapter_name_obj,
 //|         :param tx_power int: transmitter power while advertising in dBm
 //|         :param directed_to Address: peer to advertise directly to"""
 //|         ...
-//|
 STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_adapter_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
@@ -259,7 +262,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_adapter_start_advertising_obj, 1, bleio_
 //|     def stop_advertising(self) -> None:
 //|         """Stop sending advertising packets."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_adapter_stop_advertising(mp_obj_t self_in) {
     bleio_adapter_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -269,7 +271,18 @@ STATIC mp_obj_t bleio_adapter_stop_advertising(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_stop_advertising_obj, bleio_adapter_stop_advertising);
 
-//|     def start_scan(self, prefixes: ReadableBuffer = b"", *, buffer_size: int = 512, extended: bool = False, timeout: Optional[float] = None, interval: float = 0.1, window: float = 0.1, minimum_rssi: int = -80, active: bool = True) -> Iterable[ScanEntry]:
+//|     def start_scan(
+//|         self,
+//|         prefixes: ReadableBuffer = b"",
+//|         *,
+//|         buffer_size: int = 512,
+//|         extended: bool = False,
+//|         timeout: Optional[float] = None,
+//|         interval: float = 0.1,
+//|         window: float = 0.1,
+//|         minimum_rssi: int = -80,
+//|         active: bool = True
+//|     ) -> Iterable[ScanEntry]:
 //|         """Starts a BLE scan and returns an iterator of results. Advertisements and scan responses are
 //|         filtered and returned separately.
 //|
@@ -288,7 +301,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_stop_advertising_obj, bleio_adapt
 //|         :returns: an iterable of `_bleio.ScanEntry` objects
 //|         :rtype: iterable"""
 //|         ...
-//|
 STATIC mp_obj_t bleio_adapter_start_scan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_prefixes, ARG_buffer_size, ARG_extended, ARG_timeout, ARG_interval, ARG_window, ARG_minimum_rssi, ARG_active };
     static const mp_arg_t allowed_args[] = {
@@ -352,7 +364,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_adapter_start_scan_obj, 1, bleio_adapter
 //|     def stop_scan(self) -> None:
 //|         """Stop the current scan."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_adapter_stop_scan(mp_obj_t self_in) {
     bleio_adapter_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -364,7 +375,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_adapter_stop_scan_obj, bleio_adapter_stop
 
 //|     advertising: bool
 //|     """True when the adapter is currently advertising. (read-only)"""
-//|
 STATIC mp_obj_t bleio_adapter_get_advertising(mp_obj_t self) {
     return mp_obj_new_bool(common_hal_bleio_adapter_get_advertising(self));
 
@@ -377,7 +387,6 @@ MP_PROPERTY_GETTER(bleio_adapter_advertising_obj,
 //|     connected: bool
 //|     """True when the adapter is connected to another device regardless of who initiated the
 //|     connection. (read-only)"""
-//|
 STATIC mp_obj_t bleio_adapter_get_connected(mp_obj_t self) {
     return mp_obj_new_bool(common_hal_bleio_adapter_get_connected(self));
 
@@ -390,7 +399,6 @@ MP_PROPERTY_GETTER(bleio_adapter_connected_obj,
 //|     connections: Tuple[Connection]
 //|     """Tuple of active connections including those initiated through
 //|     :py:meth:`_bleio.Adapter.connect`. (read-only)"""
-//|
 STATIC mp_obj_t bleio_adapter_get_connections(mp_obj_t self) {
     return common_hal_bleio_adapter_get_connections(self);
 }
@@ -405,7 +413,6 @@ MP_PROPERTY_GETTER(bleio_adapter_connections_obj,
 //|         :param Address address: The address of the peripheral to connect to
 //|         :param float/int timeout: Try to connect for timeout seconds."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_adapter_connect(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_adapter_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
@@ -428,7 +435,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_adapter_connect_obj, 1, bleio_adapter_co
 //|     def erase_bonding(self) -> None:
 //|         """Erase all bonding information stored in flash memory."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_adapter_erase_bonding(mp_obj_t self_in) {
     bleio_adapter_obj_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/_bleio/Address.c
+++ b/shared-bindings/_bleio/Address.c
@@ -36,7 +36,6 @@
 
 //| class Address:
 //|     """Encapsulates the address of a BLE device."""
-//|
 
 //|     def __init__(self, address: ReadableBuffer, address_type: int) -> None:
 //|         """Create a new Address object encapsulating the address value.
@@ -46,7 +45,6 @@
 //|         :param int address_type: one of the integer values: `PUBLIC`, `RANDOM_STATIC`,
 //|           `RANDOM_PRIVATE_RESOLVABLE`, or `RANDOM_PRIVATE_NON_RESOLVABLE`."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_address_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_address, ARG_address_type };
     static const mp_arg_t allowed_args[] = {
@@ -93,7 +91,6 @@ STATIC mp_obj_t bleio_address_make_new(const mp_obj_type_t *type, size_t n_args,
 //|       <Address c8:1d:f5:ed:a8:35>
 //|       >>> _bleio.adapter.address.address_bytes
 //|       b'5\\xa8\\xed\\xf5\\x1d\\xc8'"""
-//|
 STATIC mp_obj_t bleio_address_get_address_bytes(mp_obj_t self_in) {
     bleio_address_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -109,7 +106,6 @@ MP_PROPERTY_GETTER(bleio_address_address_bytes_obj,
 //|
 //|     One of the integer values: `PUBLIC`, `RANDOM_STATIC`, `RANDOM_PRIVATE_RESOLVABLE`,
 //|     or `RANDOM_PRIVATE_NON_RESOLVABLE`."""
-//|
 STATIC mp_obj_t bleio_address_get_type(mp_obj_t self_in) {
     bleio_address_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -123,7 +119,6 @@ MP_PROPERTY_GETTER(bleio_address_type_obj,
 //|     def __eq__(self, other: object) -> bool:
 //|         """Two Address objects are equal if their addresses and address types are equal."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_address_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
     switch (op) {
         // Two Addresses are equal if their address bytes and address_type are equal
@@ -149,7 +144,6 @@ STATIC mp_obj_t bleio_address_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_o
 //|     def __hash__(self) -> int:
 //|         """Returns a hash for the Address data."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_address_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     switch (op) {
         // Two Addresses are equal if their address bytes and address_type are equal
@@ -191,7 +185,6 @@ STATIC void bleio_address_print(const mp_print_t *print, mp_obj_t self_in, mp_pr
 //|
 //|     RANDOM_PRIVATE_NON_RESOLVABLE: int
 //|     """A randomly generated address that changes on every connection."""
-//|
 STATIC const mp_rom_map_elem_t bleio_address_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_address_bytes),                 MP_ROM_PTR(&bleio_address_address_bytes_obj) },
     { MP_ROM_QSTR(MP_QSTR_type),                          MP_ROM_PTR(&bleio_address_type_obj) },

--- a/shared-bindings/_bleio/Attribute.c
+++ b/shared-bindings/_bleio/Attribute.c
@@ -39,7 +39,6 @@
 //|     def __init__(self) -> None:
 //|         """You cannot create an instance of :py:class:`~_bleio.Attribute`."""
 //|         ...
-//|
 
 STATIC const mp_rom_map_elem_t bleio_attribute_locals_dict_table[] = {
 
@@ -63,7 +62,6 @@ STATIC const mp_rom_map_elem_t bleio_attribute_locals_dict_table[] = {
 //|
 //|     SIGNED_WITH_MITM: int
 //|     """security_mode: authenticated data signing, without man-in-the-middle protection"""
-//|
     { MP_ROM_QSTR(MP_QSTR_NO_ACCESS),              MP_ROM_INT(SECURITY_MODE_NO_ACCESS) },
     { MP_ROM_QSTR(MP_QSTR_OPEN),                   MP_ROM_INT(SECURITY_MODE_OPEN) },
     { MP_ROM_QSTR(MP_QSTR_ENCRYPT_NO_MITM),        MP_ROM_INT(SECURITY_MODE_ENC_NO_MITM) },

--- a/shared-bindings/_bleio/Characteristic.c
+++ b/shared-bindings/_bleio/Characteristic.c
@@ -35,7 +35,7 @@
 
 //| class Characteristic:
 //|     """Stores information about a BLE service characteristic and allows reading
-//|        and writing of the characteristic's value."""
+//|     and writing of the characteristic's value."""
 //|
 //|     def __init__(self) -> None:
 //|         """There is no regular constructor for a Characteristic. A new local Characteristic can be created
@@ -43,13 +43,20 @@
 //|         Remote Characteristic objects are created by `Connection.discover_remote_services()`
 //|         as part of remote Services."""
 //|         ...
-//|
 
-//|     def add_to_service(self, service: Service, uuid: UUID, *, properties: int = 0,
-//|                        read_perm: int = Attribute.OPEN, write_perm: int = Attribute.OPEN,
-//|                        max_length: int = 20, fixed_length: bool = False,
-//|                        initial_value: Optional[ReadableBuffer] = None,
-//|                        user_description: Optional[str] = None) -> Characteristic:
+//|     def add_to_service(
+//|         self,
+//|         service: Service,
+//|         uuid: UUID,
+//|         *,
+//|         properties: int = 0,
+//|         read_perm: int = Attribute.OPEN,
+//|         write_perm: int = Attribute.OPEN,
+//|         max_length: int = 20,
+//|         fixed_length: bool = False,
+//|         initial_value: Optional[ReadableBuffer] = None,
+//|         user_description: Optional[str] = None
+//|     ) -> Characteristic:
 //|         """Create a new Characteristic object, and add it to this Service.
 //|
 //|         :param Service service: The service that will provide this characteristic
@@ -73,7 +80,6 @@
 //|
 //|         :return: the new Characteristic."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_characteristic_add_to_service(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // class is arg[0], which we can ignore.
 
@@ -157,7 +163,6 @@ STATIC MP_DEFINE_CONST_CLASSMETHOD_OBJ(bleio_characteristic_add_to_service_obj, 
 //|     """An int bitmask representing which properties are set, specified as bitwise or'ing of
 //|     of these possible values.
 //|     `BROADCAST`, `INDICATE`, `NOTIFY`, `READ`, `WRITE`, `WRITE_NO_RESPONSE`."""
-//|
 STATIC mp_obj_t bleio_characteristic_get_properties(mp_obj_t self_in) {
     bleio_characteristic_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -172,7 +177,6 @@ MP_PROPERTY_GETTER(bleio_characteristic_properties_obj,
 //|     """The UUID of this characteristic. (read-only)
 //|
 //|     Will be ``None`` if the 128-bit UUID for this characteristic is not known."""
-//|
 STATIC mp_obj_t bleio_characteristic_get_uuid(mp_obj_t self_in) {
     bleio_characteristic_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -186,7 +190,6 @@ MP_PROPERTY_GETTER(bleio_characteristic_uuid_obj,
 
 //|     value: bytearray
 //|     """The value of this characteristic."""
-//|
 STATIC mp_obj_t bleio_characteristic_get_value(mp_obj_t self_in) {
     bleio_characteristic_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -214,7 +217,6 @@ MP_PROPERTY_GETSET(bleio_characteristic_value_obj,
 
 //|     max_length: int
 //|     """The max length of this characteristic."""
-//|
 STATIC mp_obj_t bleio_characteristic_get_max_length(mp_obj_t self_in) {
     bleio_characteristic_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -227,7 +229,6 @@ MP_PROPERTY_GETTER(bleio_characteristic_max_length_obj,
 
 //|     descriptors: Descriptor
 //|     """A tuple of :py:class:`Descriptor` objects related to this characteristic. (read-only)"""
-//|
 STATIC mp_obj_t bleio_characteristic_get_descriptors(mp_obj_t self_in) {
     bleio_characteristic_obj_t *self = MP_OBJ_TO_PTR(self_in);
     // Return list as a tuple so user won't be able to change it.
@@ -241,7 +242,6 @@ MP_PROPERTY_GETTER(bleio_characteristic_descriptors_obj,
 
 //|     service: Service
 //|     """The Service this Characteristic is a part of."""
-//|
 STATIC mp_obj_t bleio_characteristic_get_service(mp_obj_t self_in) {
     bleio_characteristic_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -258,7 +258,6 @@ MP_PROPERTY_GETTER(bleio_characteristic_service_obj,
 //|         :param bool notify: True if Characteristic should receive notifications of remote writes
 //|         :param float indicate: True if Characteristic should receive indications of remote writes"""
 //|         ...
-//|
 STATIC mp_obj_t bleio_characteristic_set_cccd(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_characteristic_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
@@ -302,7 +301,6 @@ STATIC const mp_rom_map_elem_t bleio_characteristic_locals_dict_table[] = {
 //|
 //|     WRITE_NO_RESPONSE: int
 //|     """property: clients may write this characteristic; no response will be sent back"""
-//|
     { MP_ROM_QSTR(MP_QSTR_BROADCAST),         MP_ROM_INT(CHAR_PROP_BROADCAST) },
     { MP_ROM_QSTR(MP_QSTR_INDICATE),          MP_ROM_INT(CHAR_PROP_INDICATE) },
     { MP_ROM_QSTR(MP_QSTR_NOTIFY),            MP_ROM_INT(CHAR_PROP_NOTIFY) },

--- a/shared-bindings/_bleio/CharacteristicBuffer.c
+++ b/shared-bindings/_bleio/CharacteristicBuffer.c
@@ -44,7 +44,9 @@ STATIC void raise_error_if_not_connected(bleio_characteristic_buffer_obj_t *self
 //| class CharacteristicBuffer:
 //|     """Accumulates a Characteristic's incoming values in a FIFO buffer."""
 //|
-//|     def __init__(self, characteristic: Characteristic, *, timeout: int = 1, buffer_size: int = 64) -> None:
+//|     def __init__(
+//|         self, characteristic: Characteristic, *, timeout: int = 1, buffer_size: int = 64
+//|     ) -> None:
 //|
 //|         """Monitor the given Characteristic. Each time a new value is written to the Characteristic
 //|         add the newly-written bytes to a FIFO buffer.
@@ -56,7 +58,6 @@ STATIC void raise_error_if_not_connected(bleio_characteristic_buffer_obj_t *self
 //|         :param int buffer_size: Size of ring buffer that stores incoming data coming from client.
 //|           Must be >= 1."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_characteristic_buffer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_characteristic, ARG_timeout, ARG_buffer_size, };
     static const mp_arg_t allowed_args[] = {
@@ -99,21 +100,18 @@ STATIC void check_for_deinit(bleio_characteristic_buffer_obj_t *self) {
 //|         :return: Data read
 //|         :rtype: bytes or None"""
 //|         ...
-//|
 //|     def readinto(self, buf: WriteableBuffer) -> Optional[int]:
 //|         """Read bytes into the ``buf``. Read at most ``len(buf)`` bytes.
 //|
 //|         :return: number of bytes read and stored into ``buf``
 //|         :rtype: int or None (on a non-blocking error)"""
 //|         ...
-//|
 //|     def readline(self) -> bytes:
 //|         """Read a line, ending in a newline character.
 //|
 //|         :return: the line read
 //|         :rtype: int or None"""
 //|         ...
-//|
 
 // These three methods are used by the shared stream methods.
 STATIC mp_uint_t bleio_characteristic_buffer_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
@@ -159,7 +157,6 @@ STATIC mp_uint_t bleio_characteristic_buffer_ioctl(mp_obj_t self_in, mp_uint_t r
 
 //|     in_waiting: int
 //|     """The number of bytes in the input buffer, available to be read"""
-//|
 STATIC mp_obj_t bleio_characteristic_buffer_obj_get_in_waiting(mp_obj_t self_in) {
     bleio_characteristic_buffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -173,7 +170,6 @@ MP_PROPERTY_GETTER(bleio_characteristic_buffer_in_waiting_obj,
 //|     def reset_input_buffer(self) -> None:
 //|         """Discard any unread characters in the input buffer."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_characteristic_buffer_obj_reset_input_buffer(mp_obj_t self_in) {
     bleio_characteristic_buffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -185,7 +181,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_characteristic_buffer_reset_input_buffer_
 //|     def deinit(self) -> None:
 //|         """Disable permanently."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_characteristic_buffer_deinit(mp_obj_t self_in) {
     bleio_characteristic_buffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_bleio_characteristic_buffer_deinit(self);

--- a/shared-bindings/_bleio/Connection.c
+++ b/shared-bindings/_bleio/Connection.c
@@ -59,7 +59,6 @@
 //|            raise Exception("'InterestingPeripheral' not found")
 //|
 //|        connection = _bleio.adapter.connect(my_entry.address, timeout=10)"""
-//|
 
 void bleio_connection_ensure_connected(bleio_connection_obj_t *self) {
     if (!common_hal_bleio_connection_get_connected(self)) {
@@ -72,11 +71,9 @@ void bleio_connection_ensure_connected(bleio_connection_obj_t *self) {
 //|         Connections may also be made when another device initiates a connection. To use a Connection
 //|         created by a peer, read the `Adapter.connections` property."""
 //|         ...
-//|
 //|     def disconnect(self) -> None:
 //|         """Disconnects from the remote peripheral. Does nothing if already disconnected."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_connection_disconnect(mp_obj_t self_in) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(self_in);
     // common_hal_bleio_connection_disconnect() does nothing if already disconnected.
@@ -89,7 +86,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_connection_disconnect_obj, bleio_connecti
 //|     def pair(self, *, bond: bool = True) -> None:
 //|         """Pair to the peer to improve security."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_connection_pair(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
@@ -108,7 +104,9 @@ STATIC mp_obj_t bleio_connection_pair(mp_uint_t n_args, const mp_obj_t *pos_args
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_connection_pair_obj, 1, bleio_connection_pair);
 
-//|     def discover_remote_services(self, service_uuids_whitelist: Optional[Iterable[UUID]] = None) -> Tuple[Service, ...]:
+//|     def discover_remote_services(
+//|         self, service_uuids_whitelist: Optional[Iterable[UUID]] = None
+//|     ) -> Tuple[Service, ...]:
 //|         """Do BLE discovery for all services or for the given service UUIDS,
 //|         to find their handles and characteristics, and return the discovered services.
 //|         `Connection.connected` must be True.
@@ -131,7 +129,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_connection_pair_obj, 1, bleio_connection
 //|
 //|         :return: A tuple of `_bleio.Service` objects provided by the remote peripheral."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_connection_discover_remote_services(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
@@ -153,7 +150,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_connection_discover_remote_services_obj,
 
 //|     connected: bool
 //|     """True if connected to the remote peer."""
-//|
 STATIC mp_obj_t bleio_connection_get_connected(mp_obj_t self_in) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -167,7 +163,6 @@ MP_PROPERTY_GETTER(bleio_connection_connected_obj,
 
 //|     paired: bool
 //|     """True if paired to the remote peer."""
-//|
 STATIC mp_obj_t bleio_connection_get_paired(mp_obj_t self_in) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -188,7 +183,6 @@ MP_PROPERTY_GETTER(bleio_connection_paired_obj,
 //|
 //|     Apple has additional guidelines that dictate should be a multiple of 15ms except if HID is
 //|     available. When HID is available Apple devices may accept 11.25ms intervals."""
-//|
 STATIC mp_obj_t bleio_connection_get_connection_interval(mp_obj_t self_in) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -205,7 +199,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_connection_get_connection_interval_obj, b
 //|     which must be sent in a single packet.
 //|     But for a regular characteristic read or write, may be sent in multiple packets,
 //|     so this limit does not apply."""
-//|
 STATIC mp_obj_t bleio_connection_get_max_packet_length(mp_obj_t self_in) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/_bleio/Descriptor.c
+++ b/shared-bindings/_bleio/Descriptor.c
@@ -44,9 +44,18 @@
 //|         and attached to a Characteristic by calling `add_to_characteristic()`.
 //|         Remote Descriptor objects are created by `Connection.discover_remote_services()`
 //|         as part of remote Characteristics in the remote Services that are discovered."""
-//|
 //|     @classmethod
-//|     def add_to_characteristic(cls, characteristic: Characteristic, uuid: UUID, *, read_perm: int = Attribute.OPEN, write_perm: int = Attribute.OPEN, max_length: int = 20, fixed_length: bool = False, initial_value: ReadableBuffer = b'') -> Descriptor:
+//|     def add_to_characteristic(
+//|         cls,
+//|         characteristic: Characteristic,
+//|         uuid: UUID,
+//|         *,
+//|         read_perm: int = Attribute.OPEN,
+//|         write_perm: int = Attribute.OPEN,
+//|         max_length: int = 20,
+//|         fixed_length: bool = False,
+//|         initial_value: ReadableBuffer = b""
+//|     ) -> Descriptor:
 //|         """Create a new Descriptor object, and add it to this Service.
 //|
 //|         :param Characteristic characteristic: The characteristic that will hold this descriptor
@@ -65,7 +74,6 @@
 //|
 //|         :return: the new Descriptor."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_descriptor_add_to_characteristic(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // class is arg[0], which we can ignore.
 
@@ -133,7 +141,6 @@ STATIC MP_DEFINE_CONST_CLASSMETHOD_OBJ(bleio_descriptor_add_to_characteristic_ob
 
 //|     uuid: UUID
 //|     """The descriptor uuid. (read-only)"""
-//|
 STATIC mp_obj_t bleio_descriptor_get_uuid(mp_obj_t self_in) {
     bleio_descriptor_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -147,7 +154,6 @@ MP_PROPERTY_GETTER(bleio_descriptor_uuid_obj,
 
 //|     characteristic: Characteristic
 //|     """The Characteristic this Descriptor is a part of."""
-//|
 STATIC mp_obj_t bleio_descriptor_get_characteristic(mp_obj_t self_in) {
     bleio_descriptor_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -160,7 +166,6 @@ MP_PROPERTY_GETTER(bleio_descriptor_characteristic_obj,
 
 //|     value: bytearray
 //|     """The value of this descriptor."""
-//|
 STATIC mp_obj_t bleio_descriptor_get_value(mp_obj_t self_in) {
     bleio_descriptor_obj_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/_bleio/PacketBuffer.c
+++ b/shared-bindings/_bleio/PacketBuffer.c
@@ -44,7 +44,13 @@
 //|     When we're the server, we ignore all connections besides the first to subscribe to
 //|     notifications."""
 //|
-//|     def __init__(self, characteristic: Characteristic, *, buffer_size: int, max_packet_size: Optional[int] = None) -> None:
+//|     def __init__(
+//|         self,
+//|         characteristic: Characteristic,
+//|         *,
+//|         buffer_size: int,
+//|         max_packet_size: Optional[int] = None
+//|     ) -> None:
 //|         """Monitor the given Characteristic. Each time a new value is written to the Characteristic
 //|         add the newly-written bytes to a FIFO buffer.
 //|
@@ -59,7 +65,6 @@
 //|         :param int max_packet_size: Maximum size of packets. Overrides value from the characteristic.
 //|           (Remote characteristics may not have the correct length.)"""
 //|         ...
-//|
 STATIC mp_obj_t bleio_packet_buffer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_characteristic, ARG_buffer_size, ARG_max_packet_size };
     static const mp_arg_t allowed_args[] = {
@@ -101,7 +106,6 @@ STATIC void check_for_deinit(bleio_packet_buffer_obj_t *self) {
 //|         :return: number of bytes read and stored into ``buf``
 //|         :rtype: int"""
 //|         ...
-//|
 STATIC mp_obj_t bleio_packet_buffer_readinto(mp_obj_t self_in, mp_obj_t buffer_obj) {
     bleio_packet_buffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -127,7 +131,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(bleio_packet_buffer_readinto_obj, bleio_packet_
 //|         :return: number of bytes written. May include header bytes when packet is empty.
 //|         :rtype: int"""
 //|         ...
-//|
 // TODO: Add a kwarg `merge=False` to dictate whether subsequent writes are merged into a pending
 // one.
 STATIC mp_obj_t bleio_packet_buffer_write(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -182,7 +185,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_packet_buffer_deinit_obj, bleio_packet_bu
 
 //|     incoming_packet_length: int
 //|     """Maximum length in bytes of a packet we are reading."""
-//|
 STATIC mp_obj_t bleio_packet_buffer_get_incoming_packet_length(mp_obj_t self_in) {
     bleio_packet_buffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -199,7 +201,6 @@ MP_PROPERTY_GETTER(bleio_packet_buffer_incoming_packet_length_obj,
 
 //|     outgoing_packet_length: int
 //|     """Maximum length in bytes of a packet we are writing."""
-//|
 STATIC mp_obj_t bleio_packet_buffer_get_outgoing_packet_length(mp_obj_t self_in) {
     bleio_packet_buffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/_bleio/ScanEntry.c
+++ b/shared-bindings/_bleio/ScanEntry.c
@@ -39,18 +39,15 @@
 //|     """Encapsulates information about a device that was received during scanning. It can be
 //|     advertisement or scan response data. This object may only be created by a `_bleio.ScanResults`:
 //|     it has no user-visible constructor."""
-//|
 
 //|     def __init__(self) -> None:
 //|         """Cannot be instantiated directly. Use `_bleio.Adapter.start_scan`."""
 //|         ...
-//|
 //|     def matches(self, prefixes: ScanEntry, *, match_all: bool = True) -> bool:
 //|         """Returns True if the ScanEntry matches all prefixes when ``match_all`` is True. This is stricter
 //|         than the scan filtering which accepts any advertisements that match any of the prefixes
 //|         where ``match_all`` is False."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_scanentry_matches(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_scanentry_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
@@ -73,7 +70,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_scanentry_matches_obj, 1, bleio_scanentr
 
 //|     address: Address
 //|     """The address of the device (read-only), of type `_bleio.Address`."""
-//|
 STATIC mp_obj_t bleio_scanentry_get_address(mp_obj_t self_in) {
     bleio_scanentry_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_bleio_scanentry_get_address(self);
@@ -85,7 +81,6 @@ MP_PROPERTY_GETTER(bleio_scanentry_address_obj,
 
 //|     advertisement_bytes: bytes
 //|     """All the advertisement data present in the packet, returned as a ``bytes`` object. (read-only)"""
-//|
 STATIC mp_obj_t scanentry_get_advertisement_bytes(mp_obj_t self_in) {
     bleio_scanentry_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_bleio_scanentry_get_advertisement_bytes(self);
@@ -97,7 +92,6 @@ MP_PROPERTY_GETTER(bleio_scanentry_advertisement_bytes_obj,
 
 //|     rssi: int
 //|     """The signal strength of the device at the time of the scan, in integer dBm. (read-only)"""
-//|
 STATIC mp_obj_t scanentry_get_rssi(mp_obj_t self_in) {
     bleio_scanentry_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(common_hal_bleio_scanentry_get_rssi(self));
@@ -109,7 +103,6 @@ MP_PROPERTY_GETTER(bleio_scanentry_rssi_obj,
 
 //|     connectable: bool
 //|     """True if the device can be connected to. (read-only)"""
-//|
 STATIC mp_obj_t scanentry_get_connectable(mp_obj_t self_in) {
     bleio_scanentry_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_bleio_scanentry_get_connectable(self));
@@ -121,7 +114,6 @@ MP_PROPERTY_GETTER(bleio_scanentry_connectable_obj,
 
 //|     scan_response: bool
 //|     """True if the entry was a scan response. (read-only)"""
-//|
 STATIC mp_obj_t scanentry_get_scan_response(mp_obj_t self_in) {
     bleio_scanentry_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_bleio_scanentry_get_scan_response(self));

--- a/shared-bindings/_bleio/ScanResults.c
+++ b/shared-bindings/_bleio/ScanResults.c
@@ -35,7 +35,6 @@
 //| class ScanResults:
 //|     """Iterates over advertising data received while scanning. This object is always created
 //|     by a `_bleio.Adapter`: it has no user-visible constructor."""
-//|
 STATIC mp_obj_t scanresults_iternext(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &bleio_scanresults_type));
     bleio_scanresults_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -49,16 +48,13 @@ STATIC mp_obj_t scanresults_iternext(mp_obj_t self_in) {
 //|     def __init__(self) -> None:
 //|         """Cannot be instantiated directly. Use `_bleio.Adapter.start_scan`."""
 //|         ...
-//|
 //|     def __iter__(self) -> Iterator[ScanEntry]:
 //|         """Returns itself since it is the iterator."""
 //|         ...
-//|
 //|     def __next__(self) -> ScanEntry:
 //|         """Returns the next `_bleio.ScanEntry`. Blocks if none have been received and scanning is still
 //|         active. Raises `StopIteration` if scanning is finished and no other results are available."""
 //|         ...
-//|
 
 const mp_obj_type_t bleio_scanresults_type = {
     { &mp_type_type },

--- a/shared-bindings/_bleio/Service.c
+++ b/shared-bindings/_bleio/Service.c
@@ -47,7 +47,6 @@
 //|
 //|         :return: the new Service"""
 //|         ...
-//|
 STATIC mp_obj_t bleio_service_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_uuid, ARG_secondary };
     static const mp_arg_t allowed_args[] = {
@@ -73,7 +72,6 @@ STATIC mp_obj_t bleio_service_make_new(const mp_obj_type_t *type, size_t n_args,
 //|     characteristics: Tuple[Characteristic, ...]
 //|     """A tuple of :py:class:`Characteristic` designating the characteristics that are offered by
 //|     this service. (read-only)"""
-//|
 STATIC mp_obj_t bleio_service_get_characteristics(mp_obj_t self_in) {
     bleio_service_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_FROM_PTR(common_hal_bleio_service_get_characteristics(self));
@@ -85,7 +83,6 @@ MP_PROPERTY_GETTER(bleio_service_characteristics_obj,
 
 //|     remote: bool
 //|     """True if this is a service provided by a remote device. (read-only)"""
-//|
 STATIC mp_obj_t bleio_service_get_remote(mp_obj_t self_in) {
     bleio_service_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -98,7 +95,6 @@ MP_PROPERTY_GETTER(bleio_service_remote_obj,
 
 //|     secondary: bool
 //|     """True if this is a secondary service. (read-only)"""
-//|
 STATIC mp_obj_t bleio_service_get_secondary(mp_obj_t self_in) {
     bleio_service_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -113,7 +109,6 @@ MP_PROPERTY_GETTER(bleio_service_secondary_obj,
 //|     """The UUID of this service. (read-only)
 //|
 //|     Will be ``None`` if the 128-bit UUID for this service is not known."""
-//|
 STATIC mp_obj_t bleio_service_get_uuid(mp_obj_t self_in) {
     bleio_service_obj_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/_bleio/UUID.c
+++ b/shared-bindings/_bleio/UUID.c
@@ -50,7 +50,6 @@
 //|         :param value: The uuid value to encapsulate
 //|         :type value: int, ~circuitpython_typing.ReadableBuffer or str"""
 //|         ...
-//|
 STATIC mp_obj_t bleio_uuid_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
 
@@ -124,7 +123,6 @@ STATIC mp_obj_t bleio_uuid_make_new(const mp_obj_type_t *type, size_t n_args, si
 //|     """The 16-bit part of the UUID. (read-only)
 //|
 //|     :type: int"""
-//|
 STATIC mp_obj_t bleio_uuid_get_uuid16(mp_obj_t self_in) {
     bleio_uuid_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_bleio_uuid_get_uuid16(self));
@@ -140,7 +138,6 @@ MP_PROPERTY_GETTER(bleio_uuid_uuid16_obj,
 //|     Raises AttributeError if this is a 16-bit UUID. (read-only)
 //|
 //|     :type: bytes"""
-//|
 STATIC mp_obj_t bleio_uuid_get_uuid128(mp_obj_t self_in) {
     bleio_uuid_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -162,7 +159,6 @@ MP_PROPERTY_GETTER(bleio_uuid_uuid128_obj,
 //|     16-bit Bluetooth SIG assigned UUID. (read-only) 32-bit UUIDs are not currently supported.
 //|
 //|     :type: int"""
-//|
 STATIC mp_obj_t bleio_uuid_get_size(mp_obj_t self_in) {
     bleio_uuid_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_bleio_uuid_get_size(self));
@@ -177,7 +173,6 @@ MP_PROPERTY_GETTER(bleio_uuid_size_obj,
 //|     def pack_into(self, buffer: WriteableBuffer, offset: int = 0) -> None:
 //|         """Packs the UUID into the given buffer at the given offset."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_uuid_pack_into(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_uuid_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
@@ -239,7 +234,6 @@ STATIC mp_obj_t bleio_uuid_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 //|     def __eq__(self, other: object) -> bool:
 //|         """Two UUID objects are equal if their values match and they are both 128-bit or both 16-bit."""
 //|         ...
-//|
 STATIC mp_obj_t bleio_uuid_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
     switch (op) {
         // Two UUID's are equal if their uuid16 values match or their uuid128 values match.

--- a/shared-bindings/_bleio/__init__.c
+++ b/shared-bindings/_bleio/__init__.c
@@ -54,15 +54,14 @@
 //| CircuitPython library instead, which builds on `_bleio`, and
 //| provides higher-level convenience functionality, including predefined beacons, clients,
 //| servers."""
-//|
 
 //| adapter: Adapter
 //| """BLE Adapter used to manage device discovery and connections.
 //| This object is the sole instance of `_bleio.Adapter`."""
-//|
 
 //| class BluetoothError(Exception):
 //|     """Catchall exception for Bluetooth related errors."""
+//|
 //|     ...
 MP_DEFINE_BLEIO_EXCEPTION(BluetoothError, Exception)
 NORETURN void mp_raise_bleio_BluetoothError(const compressed_string_t *fmt, ...) {
@@ -76,8 +75,8 @@ NORETURN void mp_raise_bleio_BluetoothError(const compressed_string_t *fmt, ...)
 //| class RoleError(BluetoothError):
 //|     """Raised when a resource is used as the mismatched role. For example, if a local CCCD is
 //|     attempted to be set but they can only be set when remote."""
-//|     ...
 //|
+//|     ...
 MP_DEFINE_BLEIO_EXCEPTION(RoleError, bleio_BluetoothError)
 NORETURN void mp_raise_bleio_RoleError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_bleio_RoleError, msg);
@@ -85,8 +84,8 @@ NORETURN void mp_raise_bleio_RoleError(const compressed_string_t *msg) {
 
 //| class SecurityError(BluetoothError):
 //|     """Raised when a security related error occurs."""
-//|     ...
 //|
+//|     ...
 MP_DEFINE_BLEIO_EXCEPTION(SecurityError, bleio_BluetoothError)
 NORETURN void mp_raise_bleio_SecurityError(const compressed_string_t *fmt, ...) {
     va_list argptr;
@@ -116,7 +115,6 @@ STATIC mp_obj_dict_t bleio_module_globals;
 //|     """Set the adapter to use for BLE, such as when using an HCI adapter.
 //|     Raises `NotImplementedError` when the adapter is a singleton and cannot be set."""
 //|     ...
-//|
 mp_obj_t bleio_set_adapter(mp_obj_t adapter_obj) {
     #if CIRCUITPY_BLEIO_HCI
     if (adapter_obj != mp_const_none && !mp_obj_is_type(adapter_obj, &bleio_adapter_type)) {

--- a/shared-bindings/_eve/__init__.c
+++ b/shared-bindings/_eve/__init__.c
@@ -40,10 +40,10 @@
 //| contains methods for constructing EVE command
 //| buffers and appending basic graphics commands."""
 //|
-
 //| class _EVE:
+//|     def __init__(self) -> None:
+//|         """Create an _EVE object"""
 //|
-
 typedef struct _mp_obj__EVE_t {
     mp_obj_base_t base;
     common_hal__eve_t _eve;

--- a/shared-bindings/_eve/__init__.c
+++ b/shared-bindings/_eve/__init__.c
@@ -43,7 +43,6 @@
 //| class _EVE:
 //|     def __init__(self) -> None:
 //|         """Create an _EVE object"""
-//|
 typedef struct _mp_obj__EVE_t {
     mp_obj_base_t base;
     common_hal__eve_t _eve;
@@ -54,9 +53,7 @@ STATIC const mp_obj_type_t _EVE_type;
 #define EVEHAL(s) \
     (&((mp_obj__EVE_t *)mp_obj_cast_to_native_base((s), &_EVE_type))->_eve)
 
-//|     def register(self, o: object) -> None:
-//|         ...
-//|
+//|     def register(self, o: object) -> None: ...
 STATIC mp_obj_t _register(mp_obj_t self, mp_obj_t o) {
     common_hal__eve_t *eve = EVEHAL(self);
     mp_load_method(o, MP_QSTR_write, eve->dest);
@@ -69,7 +66,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(register_obj, _register);
 //|
 //|         :param int width: The width of the grid in tiles, or 1 for sprites."""
 //|         ...
-//|
 STATIC mp_obj_t _flush(mp_obj_t self) {
     common_hal__eve_flush(EVEHAL(self));
     return mp_const_none;
@@ -81,7 +77,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(flush_obj, _flush);
 //|
 //|         :param ~circuitpython_typing.ReadableBuffer b: The bytes to add"""
 //|         ...
-//|
 STATIC mp_obj_t _cc(mp_obj_t self, mp_obj_t b) {
     mp_buffer_info_t buffer_info;
     mp_get_buffer_raise(b, &buffer_info, MP_BUFFER_READ);
@@ -100,7 +95,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(cc_obj, _cc);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _alphafunc(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     uint32_t func = mp_obj_get_int_truncated(a0);
@@ -117,7 +111,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(alphafunc_obj, _alphafunc);
 //|
 //|         Valid primitives are ``BITMAPS``, ``POINTS``, ``LINES``, ``LINE_STRIP``, ``EDGE_STRIP_R``, ``EDGE_STRIP_L``, ``EDGE_STRIP_A``, ``EDGE_STRIP_B`` and ``RECTS``."""
 //|         ...
-//|
 
 STATIC mp_obj_t _begin(mp_obj_t self, mp_obj_t a0) {
     uint32_t prim = mp_obj_get_int_truncated(a0);
@@ -131,7 +124,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(begin_obj, _begin);
 //|
 //|         :param int format: bitmap pixel format."""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmapextformat(mp_obj_t self, mp_obj_t a0) {
     uint32_t fmt = mp_obj_get_int_truncated(a0);
@@ -147,7 +139,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(bitmapextformat_obj, _bitmapextformat);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmaphandle(mp_obj_t self, mp_obj_t a0) {
     uint32_t handle = mp_obj_get_int_truncated(a0);
@@ -162,7 +153,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(bitmaphandle_obj, _bitmaphandle);
 //|         :param int linestride: high part of bitmap line stride, in bytes. Range 0-7
 //|         :param int height: high part of bitmap height, in lines. Range 0-3"""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmaplayouth(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     uint32_t linestride = mp_obj_get_int_truncated(a0);
@@ -179,7 +169,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmaplayouth_obj, _bitmaplayouth);
 //|         :param int linestride: bitmap line stride, in bytes. Range 0-1023
 //|         :param int height: bitmap height, in lines. Range 0-511"""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmaplayout(size_t n_args, const mp_obj_t *args) {
     uint32_t format = mp_obj_get_int_truncated(args[1]);
@@ -196,7 +185,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitmaplayout_obj, 4, 4, _bitmaplayout
 //|         :param int width: high part of drawn bitmap width, in pixels. Range 0-3
 //|         :param int height: high part of drawn bitmap height, in pixels. Range 0-3"""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmapsizeh(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     uint32_t width = mp_obj_get_int_truncated(a0);
@@ -215,7 +203,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmapsizeh_obj, _bitmapsizeh);
 //|         :param int width: drawn bitmap width, in pixels. Range 0-511
 //|         :param int height: drawn bitmap height, in pixels. Range 0-511"""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmapsize(size_t n_args, const mp_obj_t *args) {
     uint32_t filter = mp_obj_get_int_truncated(args[1]);
@@ -233,7 +220,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitmapsize_obj, 6, 6, _bitmapsize);
 //|
 //|         :param int addr: Bitmap start address, pixel-aligned. May be in SRAM or flash. Range 0-16777215"""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmapsource(mp_obj_t self, mp_obj_t a0) {
     uint32_t addr = mp_obj_get_int_truncated(a0);
@@ -250,7 +236,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(bitmapsource_obj, _bitmapsource);
 //|         :param int b: blue component source channel. Range 0-7
 //|         :param int a: alpha component source channel. Range 0-7"""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmapswizzle(size_t n_args, const mp_obj_t *args) {
     uint32_t r = mp_obj_get_int_truncated(args[1]);
@@ -272,7 +257,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitmapswizzle_obj, 5, 5, _bitmapswizz
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmaptransforma(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     uint32_t p = mp_obj_get_int_truncated(a0);
@@ -292,7 +276,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmaptransforma_obj, _bitmaptransforma);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmaptransformb(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     uint32_t p = mp_obj_get_int_truncated(a0);
@@ -309,7 +292,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmaptransformb_obj, _bitmaptransformb);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmaptransformc(mp_obj_t self, mp_obj_t a0) {
     uint32_t v = mp_obj_get_int_truncated(a0);
@@ -328,7 +310,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(bitmaptransformc_obj, _bitmaptransformc);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmaptransformd(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     uint32_t p = mp_obj_get_int_truncated(a0);
@@ -348,7 +329,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmaptransformd_obj, _bitmaptransformd);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmaptransforme(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     uint32_t p = mp_obj_get_int_truncated(a0);
@@ -365,7 +345,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(bitmaptransforme_obj, _bitmaptransforme);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _bitmaptransformf(mp_obj_t self, mp_obj_t a0) {
     uint32_t v = mp_obj_get_int_truncated(a0);
@@ -382,7 +361,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(bitmaptransformf_obj, _bitmaptransformf);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _blendfunc(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     uint32_t src = mp_obj_get_int_truncated(a0);
@@ -397,7 +375,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(blendfunc_obj, _blendfunc);
 //|
 //|         :param int dest: display list address. Range 0-65535"""
 //|         ...
-//|
 
 STATIC mp_obj_t _call(mp_obj_t self, mp_obj_t a0) {
     uint32_t dest = mp_obj_get_int_truncated(a0);
@@ -413,7 +390,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(call_obj, _call);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _cell(mp_obj_t self, mp_obj_t a0) {
     uint32_t cell = mp_obj_get_int_truncated(a0);
@@ -429,7 +405,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(cell_obj, _cell);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _clearcolora(mp_obj_t self, mp_obj_t a0) {
     uint32_t alpha = mp_obj_get_int_truncated(a0);
@@ -447,7 +422,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(clearcolora_obj, _clearcolora);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _clearcolorrgb(size_t n_args, const mp_obj_t *args) {
     uint32_t red = mp_obj_get_int_truncated(args[1]);
@@ -465,7 +439,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(clearcolorrgb_obj, 4, 4, _clearcolorr
 //|         :param int s: clear stencil buffer. Range 0-1
 //|         :param int t: clear tag buffer. Range 0-1"""
 //|         ...
-//|
 
 STATIC mp_obj_t _clear(size_t n_args, const mp_obj_t *args) {
     uint32_t c = (n_args > 1) ? mp_obj_get_int_truncated(args[1]) : 1;
@@ -483,7 +456,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(clear_obj, 1, 4, _clear);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _clearstencil(mp_obj_t self, mp_obj_t a0) {
     uint32_t s = mp_obj_get_int_truncated(a0);
@@ -498,7 +470,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(clearstencil_obj, _clearstencil);
 //|         :param int s: value used when the tag buffer is cleared. Range 0-255. The initial value is 0
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
-//|
 
 STATIC mp_obj_t _cleartag(mp_obj_t self, mp_obj_t a0) {
     uint32_t s = mp_obj_get_int_truncated(a0);
@@ -514,7 +485,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(cleartag_obj, _cleartag);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _colora(mp_obj_t self, mp_obj_t a0) {
     uint32_t alpha = mp_obj_get_int_truncated(a0);
@@ -533,7 +503,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(colora_obj, _colora);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _colormask(size_t n_args, const mp_obj_t *args) {
     uint32_t r = mp_obj_get_int_truncated(args[1]);
@@ -554,7 +523,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(colormask_obj, 5, 5, _colormask);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _colorrgb(size_t n_args, const mp_obj_t *args) {
     uint32_t red = mp_obj_get_int_truncated(args[1]);
@@ -581,7 +549,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(display_obj, _display);
 //|
 //|         :meth:`Vertex2ii` and :meth:`Vertex2f` calls are ignored until the next :meth:`Begin`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _end(mp_obj_t self) {
 
@@ -595,7 +562,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(end_obj, _end);
 //|
 //|         :param int dest: display list address. Range 0-65535"""
 //|         ...
-//|
 
 STATIC mp_obj_t _jump(mp_obj_t self, mp_obj_t a0) {
     uint32_t dest = mp_obj_get_int_truncated(a0);
@@ -609,7 +575,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(jump_obj, _jump);
 //|
 //|         :param int m: macro register to read. Range 0-1"""
 //|         ...
-//|
 
 STATIC mp_obj_t _macro(mp_obj_t self, mp_obj_t a0) {
     uint32_t m = mp_obj_get_int_truncated(a0);
@@ -621,7 +586,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(macro_obj, _macro);
 //|     def Nop(self) -> None:
 //|         """No operation"""
 //|         ...
-//|
 
 STATIC mp_obj_t _nop(mp_obj_t self) {
 
@@ -637,7 +601,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(nop_obj, _nop);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _palettesource(mp_obj_t self, mp_obj_t a0) {
     uint32_t addr = mp_obj_get_int_truncated(a0);
@@ -649,7 +612,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(palettesource_obj, _palettesource);
 //|     def RestoreContext(self) -> None:
 //|         """Restore the current graphics context from the context stack"""
 //|         ...
-//|
 
 STATIC mp_obj_t _restorecontext(mp_obj_t self) {
 
@@ -661,7 +623,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(restorecontext_obj, _restorecontext);
 //|     def Return(self) -> None:
 //|         """Return from a previous call command"""
 //|         ...
-//|
 
 STATIC mp_obj_t _return(mp_obj_t self) {
 
@@ -673,7 +634,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(return_obj, _return);
 //|     def SaveContext(self) -> None:
 //|         """Push the current graphics context on the context stack"""
 //|         ...
-//|
 
 STATIC mp_obj_t _savecontext(mp_obj_t self) {
 
@@ -690,7 +650,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(savecontext_obj, _savecontext);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _scissorsize(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     uint32_t width = mp_obj_get_int_truncated(a0);
@@ -708,7 +667,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(scissorsize_obj, _scissorsize);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _scissorxy(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     uint32_t x = mp_obj_get_int_truncated(a0);
@@ -727,7 +685,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(scissorxy_obj, _scissorxy);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _stencilfunc(size_t n_args, const mp_obj_t *args) {
     uint32_t func = mp_obj_get_int_truncated(args[1]);
@@ -745,7 +702,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(stencilfunc_obj, 4, 4, _stencilfunc);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _stencilmask(mp_obj_t self, mp_obj_t a0) {
     uint32_t mask = mp_obj_get_int_truncated(a0);
@@ -762,7 +718,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(stencilmask_obj, _stencilmask);
 //|
 //|         These values are part of the graphics context and are saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _stencilop(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     uint32_t sfail = mp_obj_get_int_truncated(a0);
@@ -779,7 +734,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(stencilop_obj, _stencilop);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _tagmask(mp_obj_t self, mp_obj_t a0) {
     uint32_t mask = mp_obj_get_int_truncated(a0);
@@ -795,7 +749,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(tagmask_obj, _tagmask);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _tag(mp_obj_t self, mp_obj_t a0) {
     uint32_t s = mp_obj_get_int_truncated(a0);
@@ -819,7 +772,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(vertexformat_obj, _vertexformat);
 //|
 //|         This method is an alternative to :meth:`Vertex2f`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _vertex2ii(size_t n_args, const mp_obj_t *args) {
     uint32_t x = mp_obj_get_int_truncated(args[1]);
@@ -892,7 +844,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(vertex2ii_obj, 3, 5, _vertex2ii);
 //|         :param float x: pixel x-coordinate
 //|         :param float y: pixel y-coordinate"""
 //|         ...
-//|
 STATIC mp_obj_t _vertex2f(mp_obj_t self, mp_obj_t a0, mp_obj_t a1) {
     mp_float_t x = mp_obj_get_float(a0);
     mp_float_t y = mp_obj_get_float(a1);
@@ -908,7 +859,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(vertex2f_obj, _vertex2f);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _linewidth(mp_obj_t self, mp_obj_t a0) {
     mp_float_t width = mp_obj_get_float(a0);
@@ -924,7 +874,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(linewidth_obj, _linewidth);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _pointsize(mp_obj_t self, mp_obj_t a0) {
     mp_float_t size = mp_obj_get_float(a0);
@@ -940,7 +889,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(pointsize_obj, _pointsize);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 STATIC mp_obj_t _vertextranslatex(mp_obj_t self, mp_obj_t a0) {
     mp_float_t x = mp_obj_get_float(a0);
@@ -956,7 +904,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(vertextranslatex_obj, _vertextranslatex);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 
 STATIC mp_obj_t _vertextranslatey(mp_obj_t self, mp_obj_t a0) {
@@ -973,7 +920,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(vertextranslatey_obj, _vertextranslatey);
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`."""
 //|         ...
-//|
 
 // }
 
@@ -989,7 +935,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(vertextranslatey_obj, _vertextranslatey);
 //|         This method is used by the ``eve`` module to efficiently add
 //|         commands to the FIFO."""
 //|         ...
-//|
 
 STATIC mp_obj_t _cmd0(mp_obj_t self, mp_obj_t n) {
     uint32_t code = 0xffffff00 | mp_obj_get_int_truncated(n);
@@ -1011,7 +956,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(cmd0_obj, _cmd0);
 //|         This method is used by the ``eve`` module to efficiently add
 //|         commands to the FIFO."""
 //|         ...
-//|
 STATIC mp_obj_t _cmd(size_t n_args, const mp_obj_t *args) {
     mp_obj_t self = args[0];
     mp_obj_t num = args[1];

--- a/shared-bindings/_pew/PewPew.c
+++ b/shared-bindings/_pew/PewPew.c
@@ -61,7 +61,6 @@
 //|         is connected to the common side of all buttons (the other sides of the
 //|         buttons are connected to rows of the matrix)."""
 //|         ...
-//|
 STATIC mp_obj_t pewpew_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_buffer, ARG_rows, ARG_cols, ARG_buttons };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/_pew/__init__.c
+++ b/shared-bindings/_pew/__init__.c
@@ -49,7 +49,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(get_ticks_obj, get_ticks);
 
 
 //| """LED matrix driver"""
-//|
 STATIC const mp_rom_map_elem_t pew_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR__pew) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_PewPew),  MP_ROM_PTR(&pewpew_type)},

--- a/shared-bindings/_stage/Layer.c
+++ b/shared-bindings/_stage/Layer.c
@@ -33,7 +33,14 @@
 //| class Layer:
 //|     """Keep information about a single layer of graphics"""
 //|
-//|     def __init__(self, width: int, height: int, graphic: ReadableBuffer, palette: ReadableBuffer, grid: ReadableBuffer) -> None:
+//|     def __init__(
+//|         self,
+//|         width: int,
+//|         height: int,
+//|         graphic: ReadableBuffer,
+//|         palette: ReadableBuffer,
+//|         grid: ReadableBuffer,
+//|     ) -> None:
 //|         """Keep internal information about a layer of graphics (either a
 //|         ``Grid`` or a ``Sprite``) in a format suitable for fast rendering
 //|         with the ``render()`` function.
@@ -47,7 +54,6 @@
 //|         This class is intended for internal use in the ``stage`` library and
 //|         it shouldn't be used on its own."""
 //|         ...
-//|
 STATIC mp_obj_t layer_make_new(const mp_obj_type_t *type, size_t n_args,
     size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 4, 5, false);
@@ -91,7 +97,6 @@ STATIC mp_obj_t layer_make_new(const mp_obj_type_t *type, size_t n_args,
 //|     def move(self, x: int, y: int) -> None:
 //|         """Set the offset of the layer to the specified values."""
 //|         ...
-//|
 STATIC mp_obj_t layer_move(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in) {
     layer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     self->x = mp_obj_get_int(x_in);
@@ -104,7 +109,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(layer_move_obj, layer_move);
 //|         """Set the animation frame of the sprite, and optionally rotation its
 //|         graphic."""
 //|         ...
-//|
 STATIC mp_obj_t layer_frame(mp_obj_t self_in, mp_obj_t frame_in,
     mp_obj_t rotation_in) {
     layer_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/_stage/Text.c
+++ b/shared-bindings/_stage/Text.c
@@ -33,7 +33,14 @@
 //| class Text:
 //|     """Keep information about a single grid of text"""
 //|
-//|     def __init__(self, width: int, height: int, font: ReadableBuffer, palette: ReadableBuffer, chars: ReadableBuffer) -> None:
+//|     def __init__(
+//|         self,
+//|         width: int,
+//|         height: int,
+//|         font: ReadableBuffer,
+//|         palette: ReadableBuffer,
+//|         chars: ReadableBuffer,
+//|     ) -> None:
 //|         """Keep internal information about a grid of text
 //|         in a format suitable for fast rendering
 //|         with the ``render()`` function.
@@ -47,7 +54,6 @@
 //|         This class is intended for internal use in the ``stage`` library and
 //|         it shouldn't be used on its own."""
 //|         ...
-//|
 STATIC mp_obj_t text_make_new(const mp_obj_type_t *type, size_t n_args,
     size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 5, 5, false);
@@ -85,7 +91,6 @@ STATIC mp_obj_t text_make_new(const mp_obj_type_t *type, size_t n_args,
 //|     def move(self, x: int, y: int) -> None:
 //|         """Set the offset of the text to the specified values."""
 //|         ...
-//|
 STATIC mp_obj_t text_move(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in) {
     text_obj_t *self = MP_OBJ_TO_PTR(self_in);
     self->x = mp_obj_get_int(x_in);

--- a/shared-bindings/_stage/__init__.c
+++ b/shared-bindings/_stage/__init__.c
@@ -39,7 +39,17 @@
 //| The `_stage` module contains native code to speed-up the ```stage`` Library
 //| <https://github.com/python-ugame/circuitpython-stage>`_."""
 //|
-//| def render(x0: int, y0: int, x1: int, y1: int, layers: List[Layer], buffer: WriteableBuffer, display: displayio.Display, scale: int, background: int) -> None:
+//| def render(
+//|     x0: int,
+//|     y0: int,
+//|     x1: int,
+//|     y1: int,
+//|     layers: List[Layer],
+//|     buffer: WriteableBuffer,
+//|     display: displayio.Display,
+//|     scale: int,
+//|     background: int,
+//| ) -> None:
 //|     """Render and send to the display a fragment of the screen.
 //|
 //|     :param int x0: Left edge of the fragment.
@@ -59,7 +69,6 @@
 //|
 //|     This function is intended for internal use in the ``stage`` library
 //|     and all the necessary checks are performed there."""
-//|
 STATIC mp_obj_t stage_render(size_t n_args, const mp_obj_t *args) {
     uint16_t x0 = mp_obj_get_int(args[0]);
     uint16_t y0 = mp_obj_get_int(args[1]);

--- a/shared-bindings/adafruit_bus_device/__init__.c
+++ b/shared-bindings/adafruit_bus_device/__init__.c
@@ -63,7 +63,6 @@ const mp_obj_module_t adafruit_bus_device_spi_device_module = {
 //| For example, they manage locking the bus to prevent other concurrent access. For SPI
 //| devices, it manages the chip select and protocol changes such as mode. For I2C, it
 //| manages the device address."""
-//|
 STATIC const mp_rom_map_elem_t adafruit_bus_device_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_adafruit_bus_device) },
     { MP_ROM_QSTR(MP_QSTR_i2c_device),   MP_ROM_PTR(&adafruit_bus_device_i2c_device_module) },

--- a/shared-bindings/adafruit_bus_device/i2c_device/I2CDevice.c
+++ b/shared-bindings/adafruit_bus_device/i2c_device/I2CDevice.c
@@ -64,9 +64,8 @@
 //|                 # A second transaction
 //|                 with device:
 //|                     device.write(bytes_read)
-//|     """
+//|         """
 //|     ...
-//|
 STATIC mp_obj_t adafruit_bus_device_i2cdevice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     adafruit_bus_device_i2cdevice_obj_t *self = m_new_obj(adafruit_bus_device_i2cdevice_obj_t);
     self->base.type = &adafruit_bus_device_i2cdevice_type;
@@ -92,7 +91,6 @@ STATIC mp_obj_t adafruit_bus_device_i2cdevice_make_new(const mp_obj_type_t *type
 //|     def __enter__(self) -> I2CDevice:
 //|         """Context manager entry to lock bus."""
 //|         ...
-//|
 STATIC mp_obj_t adafruit_bus_device_i2cdevice_obj___enter__(mp_obj_t self_in) {
     adafruit_bus_device_i2cdevice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_adafruit_bus_device_i2cdevice_lock(self);
@@ -103,7 +101,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(adafruit_bus_device_i2cdevice___enter___obj, ad
 //|     def __exit__(self) -> None:
 //|         """Automatically unlocks the bus on exit."""
 //|         ...
-//|
 STATIC mp_obj_t adafruit_bus_device_i2cdevice_obj___exit__(size_t n_args, const mp_obj_t *args) {
     common_hal_adafruit_bus_device_i2cdevice_unlock(MP_OBJ_TO_PTR(args[0]));
     return mp_const_none;
@@ -111,7 +108,9 @@ STATIC mp_obj_t adafruit_bus_device_i2cdevice_obj___exit__(size_t n_args, const 
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(adafruit_bus_device_i2cdevice___exit___obj, 4, 4, adafruit_bus_device_i2cdevice_obj___exit__);
 
 //|     import sys
-//|     def readinto(self, buffer: WriteableBuffer, *, start: int = 0, end: int = sys.maxsize) -> None:
+//|     def readinto(
+//|         self, buffer: WriteableBuffer, *, start: int = 0, end: int = sys.maxsize
+//|     ) -> None:
 //|         """Read into ``buffer`` from the device.
 //|
 //|         If ``start`` or ``end`` is provided, then the buffer will be sliced
@@ -123,7 +122,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(adafruit_bus_device_i2cdevice___exit_
 //|         :param int end: end of buffer slice; if not specified, use ``len(buffer)``
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t adafruit_bus_device_i2cdevice_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_start, ARG_end };
     static const mp_arg_t allowed_args[] = {
@@ -170,7 +168,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(adafruit_bus_device_i2cdevice_readinto_obj, 1,
 //|         :param int end: end of buffer slice; if not specified, use ``len(buffer)``
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t adafruit_bus_device_i2cdevice_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_start, ARG_end };
     static const mp_arg_t allowed_args[] = {
@@ -205,7 +202,16 @@ MP_DEFINE_CONST_FUN_OBJ_KW(adafruit_bus_device_i2cdevice_write_obj, 1, adafruit_
 
 
 //|     import sys
-//|     def write_then_readinto(self, out_buffer: ReadableBuffer, in_buffer: WriteableBuffer, *, out_start: int = 0, out_end: int = sys.maxsize, in_start: int = 0, in_end: int = sys.maxsize) -> None:
+//|     def write_then_readinto(
+//|         self,
+//|         out_buffer: ReadableBuffer,
+//|         in_buffer: WriteableBuffer,
+//|         *,
+//|         out_start: int = 0,
+//|         out_end: int = sys.maxsize,
+//|         in_start: int = 0,
+//|         in_end: int = sys.maxsize
+//|     ) -> None:
 //|         """Write the bytes from ``out_buffer`` to the device, then immediately
 //|         reads into ``in_buffer`` from the device.
 //|
@@ -225,7 +231,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(adafruit_bus_device_i2cdevice_write_obj, 1, adafruit_
 //|         :param int in_end: end of ``in_buffer slice``; if not specified, use ``len(in_buffer)``
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t adafruit_bus_device_i2cdevice_write_then_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_out_buffer, ARG_in_buffer, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/adafruit_bus_device/spi_device/SPIDevice.c
+++ b/shared-bindings/adafruit_bus_device/spi_device/SPIDevice.c
@@ -41,7 +41,16 @@
 //| class SPIDevice:
 //|     """SPI Device Manager"""
 //|
-//|     def __init__(self, spi: busio.SPI, chip_select: digitalio.DigitalInOut, *, baudrate: int = 100000, polarity: int = 0, phase: int = 0, extra_clocks : int = 0) -> None:
+//|     def __init__(
+//|         self,
+//|         spi: busio.SPI,
+//|         chip_select: digitalio.DigitalInOut,
+//|         *,
+//|         baudrate: int = 100000,
+//|         polarity: int = 0,
+//|         phase: int = 0,
+//|         extra_clocks: int = 0
+//|     ) -> None:
 //|
 //|         """
 //|         Represents a single SPI device and manages locking the bus and the device address.
@@ -70,7 +79,6 @@
 //|                 with device as spi:
 //|                     spi.write(bytes_read)"""
 //|     ...
-//|
 STATIC mp_obj_t adafruit_bus_device_spidevice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     adafruit_bus_device_spidevice_obj_t *self = m_new_obj(adafruit_bus_device_spidevice_obj_t);
     self->base.type = &adafruit_bus_device_spidevice_type;
@@ -108,7 +116,6 @@ STATIC mp_obj_t adafruit_bus_device_spidevice_make_new(const mp_obj_type_t *type
 //|     def __enter__(self) -> busio.SPI:
 //|         """Starts a SPI transaction by configuring the SPI and asserting chip select."""
 //|         ...
-//|
 STATIC mp_obj_t adafruit_bus_device_spidevice_obj___enter__(mp_obj_t self_in) {
     adafruit_bus_device_spidevice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_adafruit_bus_device_spidevice_enter(self);
@@ -120,7 +127,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(adafruit_bus_device_spidevice___enter___obj, ad
 //|         """Ends a SPI transaction by deasserting chip select. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t adafruit_bus_device_spidevice_obj___exit__(size_t n_args, const mp_obj_t *args) {
     common_hal_adafruit_bus_device_spidevice_exit(MP_OBJ_TO_PTR(args[0]));
     return mp_const_none;

--- a/shared-bindings/adafruit_pixelbuf/PixelBuf.c
+++ b/shared-bindings/adafruit_pixelbuf/PixelBuf.c
@@ -53,7 +53,16 @@ static void parse_byteorder(mp_obj_t byteorder_obj, pixelbuf_byteorder_details_t
 //| class PixelBuf:
 //|     """A fast RGB[W] pixel buffer for LED and similar devices."""
 //|
-//|     def __init__(self, size: int, *, byteorder: str = "BGR", brightness: float = 0, auto_write: bool = False, header: ReadableBuffer = b"", trailer: ReadableBuffer = b"") -> None:
+//|     def __init__(
+//|         self,
+//|         size: int,
+//|         *,
+//|         byteorder: str = "BGR",
+//|         brightness: float = 0,
+//|         auto_write: bool = False,
+//|         header: ReadableBuffer = b"",
+//|         trailer: ReadableBuffer = b""
+//|     ) -> None:
 //|         """Create a PixelBuf object of the specified size, byteorder, and bits per pixel.
 //|
 //|         When brightness is less than 1.0, a second buffer will be used to store the color values
@@ -71,7 +80,6 @@ static void parse_byteorder(mp_obj_t byteorder_obj, pixelbuf_byteorder_details_t
 //|         :param ~circuitpython_typing.ReadableBuffer header: Sequence of bytes to always send before pixel values.
 //|         :param ~circuitpython_typing.ReadableBuffer trailer: Sequence of bytes to always send after pixel values."""
 //|         ...
-//|
 STATIC mp_obj_t pixelbuf_pixelbuf_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_size, ARG_byteorder, ARG_brightness, ARG_auto_write, ARG_header, ARG_trailer };
     static const mp_arg_t allowed_args[] = {
@@ -159,7 +167,6 @@ static void parse_byteorder(mp_obj_t byteorder_obj, pixelbuf_byteorder_details_t
 
 //|     bpp: int
 //|     """The number of bytes per pixel in the buffer (read-only)"""
-//|
 STATIC mp_obj_t pixelbuf_pixelbuf_obj_get_bpp(mp_obj_t self_in) {
     return MP_OBJ_NEW_SMALL_INT(common_hal_adafruit_pixelbuf_pixelbuf_get_bpp(self_in));
 }
@@ -174,7 +181,6 @@ MP_PROPERTY_GETTER(pixelbuf_pixelbuf_bpp_obj,
 //|
 //|     When brightness is less than 1.0, a second buffer will be used to store the color values
 //|     before they are adjusted for brightness."""
-//|
 STATIC mp_obj_t pixelbuf_pixelbuf_obj_get_brightness(mp_obj_t self_in) {
     return mp_obj_new_float(common_hal_adafruit_pixelbuf_pixelbuf_get_brightness(self_in));
 }
@@ -199,7 +205,6 @@ MP_PROPERTY_GETSET(pixelbuf_pixelbuf_brightness_obj,
 
 //|     auto_write: bool
 //|     """Whether to automatically write the pixels after each update."""
-//|
 STATIC mp_obj_t pixelbuf_pixelbuf_obj_get_auto_write(mp_obj_t self_in) {
     return mp_obj_new_bool(common_hal_adafruit_pixelbuf_pixelbuf_get_auto_write(self_in));
 }
@@ -218,7 +223,6 @@ MP_PROPERTY_GETSET(pixelbuf_pixelbuf_auto_write_obj,
 
 //|     byteorder: str
 //|     """byteorder string for the buffer (read-only)"""
-//|
 STATIC mp_obj_t pixelbuf_pixelbuf_obj_get_byteorder(mp_obj_t self_in) {
     return common_hal_adafruit_pixelbuf_pixelbuf_get_byteorder_string(self_in);
 }
@@ -242,7 +246,6 @@ STATIC mp_obj_t pixelbuf_pixelbuf_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 //|         """Transmits the color data to the pixels so that they are shown. This is done automatically
 //|         when `auto_write` is True."""
 //|         ...
-//|
 
 STATIC mp_obj_t pixelbuf_pixelbuf_show(mp_obj_t self_in) {
     common_hal_adafruit_pixelbuf_pixelbuf_show(self_in);
@@ -250,10 +253,11 @@ STATIC mp_obj_t pixelbuf_pixelbuf_show(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(pixelbuf_pixelbuf_show_obj, pixelbuf_pixelbuf_show);
 
-//|     def fill(self, color: Union[int, Tuple[int, int, int], Tuple[int, int, int, float]]) -> None:
+//|     def fill(
+//|         self, color: Union[int, Tuple[int, int, int], Tuple[int, int, int, float]]
+//|     ) -> None:
 //|         """Fills the given pixelbuf with the given color."""
 //|         ...
-//|
 
 STATIC mp_obj_t pixelbuf_pixelbuf_fill(mp_obj_t self_in, mp_obj_t value) {
     common_hal_adafruit_pixelbuf_pixelbuf_fill(self_in, value);
@@ -263,27 +267,35 @@ STATIC mp_obj_t pixelbuf_pixelbuf_fill(mp_obj_t self_in, mp_obj_t value) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(pixelbuf_pixelbuf_fill_obj, pixelbuf_pixelbuf_fill);
 
 //|     @overload
-//|     def __getitem__(self, index: slice) -> Union[Tuple[Tuple[int, int, int], ...], Tuple[Tuple[int, int, int, float], ...]]: ...
+//|     def __getitem__(
+//|         self, index: slice
+//|     ) -> Union[Tuple[Tuple[int, int, int], ...], Tuple[Tuple[int, int, int, float], ...]]: ...
 //|     @overload
-//|     def __getitem__(self, index: int) -> Union[Tuple[int, int, int], Tuple[int, int, int, float]]:
+//|     def __getitem__(
+//|         self, index: int
+//|     ) -> Union[Tuple[int, int, int], Tuple[int, int, int, float]]:
 //|         """Returns the pixel value at the given index as a tuple of (Red, Green, Blue[, White]) values
 //|         between 0 and 255.  When in PWM (DotStar) mode, the 4th tuple value is a float of the pixel
 //|         intensity from 0-1.0."""
 //|         ...
-//|
 //|     @overload
-//|     def __setitem__(self, index: slice, value: Tuple[Union[int, Tuple[float, ...], List[float]], ...]) -> None: ...
+//|     def __setitem__(
+//|         self, index: slice, value: Tuple[Union[int, Tuple[float, ...], List[float]], ...]
+//|     ) -> None: ...
 //|     @overload
-//|     def __setitem__(self, index: slice, value: List[Union[int, Tuple[float, ...], List[float]]]) -> None: ...
+//|     def __setitem__(
+//|         self, index: slice, value: List[Union[int, Tuple[float, ...], List[float]]]
+//|     ) -> None: ...
 //|     @overload
-//|     def __setitem__(self, index: int, value: Union[int, Tuple[float, ...], List[float]]) -> None:
+//|     def __setitem__(
+//|         self, index: int, value: Union[int, Tuple[float, ...], List[float]]
+//|     ) -> None:
 //|         """Sets the pixel value at the given index.  Value can either be a tuple or integer.  Tuples are
 //|         The individual (Red, Green, Blue[, White]) values between 0 and 255.  If given an integer, the
 //|         red, green and blue values are packed into the lower three bytes (0xRRGGBB).
 //|         For RGBW byteorders, if given only RGB values either as an int or as a tuple, the white value
 //|         is used instead when the red, green, and blue values are the same."""
 //|         ...
-//|
 STATIC mp_obj_t pixelbuf_pixelbuf_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {
     if (value == MP_OBJ_NULL) {
         // delete item

--- a/shared-bindings/aesio/aes.c
+++ b/shared-bindings/aesio/aes.c
@@ -16,29 +16,34 @@
 //| class AES:
 //|     """Encrypt and decrypt AES streams"""
 //|
-//|     def __init__(self, key: ReadableBuffer, mode: int = 0, iv: Optional[ReadableBuffer] = None, segment_size: int = 8) -> None:
+//|     def __init__(
+//|         self,
+//|         key: ReadableBuffer,
+//|         mode: int = 0,
+//|         iv: Optional[ReadableBuffer] = None,
+//|         segment_size: int = 8,
+//|     ) -> None:
 //|         """Create a new AES state with the given key.
 //|
-//|            :param ~circuitpython_typing.ReadableBuffer key: A 16-, 24-, or 32-byte key
-//|            :param int mode: AES mode to use.  One of: `MODE_ECB`, `MODE_CBC`, or
-//|                             `MODE_CTR`
-//|            :param ~circuitpython_typing.ReadableBuffer iv: Initialization vector to use for CBC or CTR mode
+//|         :param ~circuitpython_typing.ReadableBuffer key: A 16-, 24-, or 32-byte key
+//|         :param int mode: AES mode to use.  One of: `MODE_ECB`, `MODE_CBC`, or
+//|                          `MODE_CTR`
+//|         :param ~circuitpython_typing.ReadableBuffer iv: Initialization vector to use for CBC or CTR mode
 //|
-//|            Additional arguments are supported for legacy reasons.
+//|         Additional arguments are supported for legacy reasons.
 //|
-//|            Encrypting a string::
+//|         Encrypting a string::
 //|
-//|              import aesio
-//|              from binascii import hexlify
+//|           import aesio
+//|           from binascii import hexlify
 //|
-//|              key = b'Sixteen byte key'
-//|              inp = b'CircuitPython!!!' # Note: 16-bytes long
-//|              outp = bytearray(len(inp))
-//|              cipher = aesio.AES(key, aesio.MODE_ECB)
-//|              cipher.encrypt_into(inp, outp)
-//|              hexlify(outp)"""
+//|           key = b'Sixteen byte key'
+//|           inp = b'CircuitPython!!!' # Note: 16-bytes long
+//|           outp = bytearray(len(inp))
+//|           cipher = aesio.AES(key, aesio.MODE_ECB)
+//|           cipher.encrypt_into(inp, outp)
+//|           hexlify(outp)"""
 //|         ...
-//|
 
 STATIC mp_obj_t aesio_aes_make_new(const mp_obj_type_t *type, size_t n_args,
     size_t n_kw, const mp_obj_t *all_args) {
@@ -155,11 +160,10 @@ STATIC void validate_length(aesio_aes_obj_t *self, size_t src_length,
 //|     def encrypt_into(self, src: ReadableBuffer, dest: WriteableBuffer) -> None:
 //|         """Encrypt the buffer from ``src`` into ``dest``.
 //|
-//|            For ECB mode, the buffers must be 16 bytes long.  For CBC mode, the
-//|            buffers must be a multiple of 16 bytes, and must be equal length.  For
-//|            CTX mode, there are no restrictions."""
+//|         For ECB mode, the buffers must be 16 bytes long.  For CBC mode, the
+//|         buffers must be a multiple of 16 bytes, and must be equal length.  For
+//|         CTX mode, there are no restrictions."""
 //|         ...
-//|
 STATIC mp_obj_t aesio_aes_encrypt_into(mp_obj_t aesio_obj, mp_obj_t src,
     mp_obj_t dest) {
     if (!mp_obj_is_type(aesio_obj, &aesio_aes_type)) {
@@ -185,11 +189,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(aesio_aes_encrypt_into_obj,
 
 //|     def decrypt_into(self, src: ReadableBuffer, dest: WriteableBuffer) -> None:
 //|         """Decrypt the buffer from ``src`` into ``dest``.
-//|            For ECB mode, the buffers must be 16 bytes long.  For CBC mode, the
-//|            buffers must be a multiple of 16 bytes, and must be equal length.  For
-//|            CTX mode, there are no restrictions."""
+//|         For ECB mode, the buffers must be 16 bytes long.  For CBC mode, the
+//|         buffers must be a multiple of 16 bytes, and must be equal length.  For
+//|         CTX mode, there are no restrictions."""
 //|         ...
-//|
 STATIC mp_obj_t aesio_aes_decrypt_into(mp_obj_t aesio_obj, mp_obj_t src,
     mp_obj_t dest) {
     if (!mp_obj_is_type(aesio_obj, &aesio_aes_type)) {

--- a/shared-bindings/alarm/SleepMemory.c
+++ b/shared-bindings/alarm/SleepMemory.c
@@ -52,17 +52,14 @@
 //|     def __init__(self) -> None:
 //|         """Not used. Access the sole instance through `alarm.sleep_memory`."""
 //|         ...
-//|
 //|     def __bool__(self) -> bool:
 //|         """``sleep_memory`` is ``True`` if its length is greater than zero.
 //|         This is an easy way to check for its existence.
 //|         """
 //|         ...
-//|
 //|     def __len__(self) -> int:
 //|         """Return the length. This is used by (`len`)"""
 //|         ...
-//|
 STATIC mp_obj_t alarm_sleep_memory_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     alarm_sleep_memory_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint16_t len = common_hal_alarm_sleep_memory_get_length(self);
@@ -87,14 +84,12 @@ STATIC MP_DEFINE_CONST_DICT(alarm_sleep_memory_locals_dict, alarm_sleep_memory_l
 //|     def __getitem__(self, index: int) -> int:
 //|         """Returns the value at the given index."""
 //|         ...
-//|
 //|     @overload
 //|     def __setitem__(self, index: slice, value: ReadableBuffer) -> None: ...
 //|     @overload
 //|     def __setitem__(self, index: int, value: int) -> None:
 //|         """Set the value at the given index."""
 //|         ...
-//|
 STATIC mp_obj_t alarm_sleep_memory_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {
     if (value == MP_OBJ_NULL) {
         // delete item

--- a/shared-bindings/alarm/__init__.c
+++ b/shared-bindings/alarm/__init__.c
@@ -64,13 +64,11 @@
 //| sleep_memory: SleepMemory
 //| """Memory that persists during deep sleep.
 //| This object is the sole instance of `alarm.SleepMemory`."""
-//|
 
 //| wake_alarm: Optional[circuitpython_typing.Alarm]
 //| """The most recently triggered alarm. If CircuitPython was sleeping, the alarm that woke it from sleep.
 //| If no alarm occured since the last hard reset or soft restart, value is ``None``.
 //| """
-//|
 
 // wake_alarm is implemented as a dictionary entry, so there's no code here.
 
@@ -85,7 +83,9 @@ STATIC void validate_objs_are_alarms(size_t n_args, const mp_obj_t *objs) {
     }
 }
 
-//| def light_sleep_until_alarms(*alarms: circuitpython_typing.Alarm) -> circuitpython_typing.Alarm:
+//| def light_sleep_until_alarms(
+//|     *alarms: circuitpython_typing.Alarm,
+//| ) -> circuitpython_typing.Alarm:
 //|     """Go into a light sleep until awakened one of the alarms. The alarm causing the wake-up
 //|     is returned, and is also available as `alarm.wake_alarm`.
 //|
@@ -99,7 +99,6 @@ STATIC void validate_objs_are_alarms(size_t n_args, const mp_obj_t *objs) {
 //|     it may be necessary to disconnect from the host.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t alarm_light_sleep_until_alarms(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
         return mp_const_none;
@@ -113,7 +112,9 @@ STATIC mp_obj_t alarm_light_sleep_until_alarms(size_t n_args, const mp_obj_t *ar
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(alarm_light_sleep_until_alarms_obj, 1, MP_OBJ_FUN_ARGS_MAX, alarm_light_sleep_until_alarms);
 
-//| def exit_and_deep_sleep_until_alarms(*alarms: circuitpython_typing.Alarm, preserve_dios: Sequence[digitalio.DigitalInOut] = ()) -> None:
+//| def exit_and_deep_sleep_until_alarms(
+//|     *alarms: circuitpython_typing.Alarm, preserve_dios: Sequence[digitalio.DigitalInOut] = ()
+//| ) -> None:
 //|     """Exit the program and go into a deep sleep, until awakened by one of the alarms.
 //|     This function does not return.
 //|
@@ -171,7 +172,6 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(alarm_light_sleep_until_alarms_obj, 1, MP_OB
 //|         alarm.exit_and_deep_sleep_until_alarms(time_alarm, pin_alarm)
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t alarm_exit_and_deep_sleep_until_alarms(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_preserve_dios };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/alarm/pin/PinAlarm.c
+++ b/shared-bindings/alarm/pin/PinAlarm.c
@@ -38,7 +38,9 @@
 //| class PinAlarm:
 //|     """Trigger an alarm when a pin changes state."""
 //|
-//|     def __init__(self, pin: microcontroller.Pin, value: bool, edge: bool = False, pull: bool = False) -> None:
+//|     def __init__(
+//|         self, pin: microcontroller.Pin, value: bool, edge: bool = False, pull: bool = False
+//|     ) -> None:
 //|         """Create an alarm triggered by a `microcontroller.Pin` level. The alarm is not active
 //|         until it is passed to an `alarm`-enabling function, such as `alarm.light_sleep_until_alarms()` or
 //|         `alarm.exit_and_deep_sleep_until_alarms()`.
@@ -59,7 +61,6 @@
 //|           pulls it high.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t alarm_pin_pinalarm_make_new(const mp_obj_type_t *type, mp_uint_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     alarm_pin_pinalarm_obj_t *self = m_new_obj(alarm_pin_pinalarm_obj_t);
     self->base.type = &alarm_pin_pinalarm_type;
@@ -86,7 +87,6 @@ STATIC mp_obj_t alarm_pin_pinalarm_make_new(const mp_obj_type_t *type, mp_uint_t
 
 //|     pin: microcontroller.Pin
 //|     """The trigger pin."""
-//|
 STATIC mp_obj_t alarm_pin_pinalarm_obj_get_pin(mp_obj_t self_in) {
     alarm_pin_pinalarm_obj_t *self = MP_OBJ_TO_PTR(self_in);
     const mcu_pin_obj_t *pin = common_hal_alarm_pin_pinalarm_get_pin(self);
@@ -102,7 +102,6 @@ MP_PROPERTY_GETTER(alarm_pin_pinalarm_pin_obj,
 
 //|     value: bool
 //|     """The value on which to trigger."""
-//|
 STATIC mp_obj_t alarm_pin_pinalarm_obj_get_value(mp_obj_t self_in) {
     alarm_pin_pinalarm_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_alarm_pin_pinalarm_get_value(self));

--- a/shared-bindings/alarm/time/TimeAlarm.c
+++ b/shared-bindings/alarm/time/TimeAlarm.c
@@ -44,7 +44,9 @@ mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
 //| class TimeAlarm:
 //|     """Trigger an alarm when the specified time is reached."""
 //|
-//|     def __init__(self, monotonic_time: Optional[float] = None, epoch_time: Optional[int] = None) -> None:
+//|     def __init__(
+//|         self, monotonic_time: Optional[float] = None, epoch_time: Optional[int] = None
+//|     ) -> None:
 //|         """Create an alarm that will be triggered when `time.monotonic()` would equal
 //|         ``monotonic_time``, or when `time.time()` would equal ``epoch_time``.
 //|         Only one of the two arguments can be given.
@@ -56,7 +58,6 @@ mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
 //|         immediately.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t alarm_time_timealarm_make_new(const mp_obj_type_t *type,
     size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     alarm_time_timealarm_obj_t *self = m_new_obj(alarm_time_timealarm_obj_t);
@@ -116,7 +117,6 @@ STATIC mp_obj_t alarm_time_timealarm_make_new(const mp_obj_type_t *type,
 //|        The time may be given as ``epoch_time`` in the constructor, but it is returned
 //|        by this property only as a `time.monotonic()` time.
 //|        """
-//|
 STATIC mp_obj_t alarm_time_timealarm_obj_get_monotonic_time(mp_obj_t self_in) {
     alarm_time_timealarm_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_float(common_hal_alarm_time_timealarm_get_monotonic_time(self));

--- a/shared-bindings/alarm/touch/TouchAlarm.c
+++ b/shared-bindings/alarm/touch/TouchAlarm.c
@@ -41,7 +41,6 @@
 //|           may be limited due to hardware restrictions, particularly for deep-sleep alarms.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t alarm_touch_touchalarm_make_new(const mp_obj_type_t *type,
     size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     alarm_touch_touchalarm_obj_t *self = m_new_obj(alarm_touch_touchalarm_obj_t);
@@ -64,7 +63,6 @@ STATIC mp_obj_t alarm_touch_touchalarm_make_new(const mp_obj_type_t *type,
 
 //|     pin: microcontroller.Pin
 //|     """The trigger pin."""
-//|
 STATIC mp_obj_t alarm_touch_touchalarm_obj_get_pin(mp_obj_t self_in) {
     alarm_touch_touchalarm_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_FROM_PTR(self->pin);

--- a/shared-bindings/analogbufio/BufferedIn.c
+++ b/shared-bindings/analogbufio/BufferedIn.c
@@ -58,9 +58,10 @@
 //|         (TODO) The reference voltage varies by platform so use
 //|         ``reference_voltage`` to read the configured setting.
 //|         (TODO) Provide mechanism to read CPU Temperature."""
-//|
 
-//|     def __init__(self, pin: microcontroller.Pin, buffer: WriteableBuffer, *, sample_rate: int = 500000) -> None:
+//|     def __init__(
+//|         self, pin: microcontroller.Pin, buffer: WriteableBuffer, *, sample_rate: int = 500000
+//|     ) -> None:
 //|         """Create a `BufferedIn` on the given pin. ADC values will be read
 //|            into the given buffer at the supplied sample_rate. Depending on the
 //|            buffer typecode, 'b', 'B', 'h', 'H', samples are 8-bit byte-arrays or
@@ -72,7 +73,6 @@
 //|         :param ~circuitpython_typing.WriteableBuffer buffer: buffer: A buffer for samples
 //|         :param ~int sample_rate: rate: sampling frequency, in samples per second"""
 //|         ...
-//|
 STATIC mp_obj_t analogbufio_bufferedin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pin, ARG_buffer, ARG_sample_rate };
     static const mp_arg_t allowed_args[] = {
@@ -124,7 +124,6 @@ STATIC mp_obj_t analogbufio_bufferedin_make_new(const mp_obj_type_t *type, size_
 //|     def deinit(self) -> None:
 //|         """Shut down the `BufferedIn` and release the pin for other use."""
 //|         ...
-//|
 STATIC mp_obj_t analogbufio_bufferedin_deinit(mp_obj_t self_in) {
     analogbufio_bufferedin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_analogbufio_bufferedin_deinit(self);
@@ -140,14 +139,12 @@ STATIC void check_for_deinit(analogbufio_bufferedin_obj_t *self) {
 //|     def __enter__(self) -> BufferedIn:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t analogbufio_bufferedin___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_analogbufio_bufferedin_deinit(args[0]);
@@ -158,7 +155,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(analogbufio_bufferedin___exit___obj, 
 //|     def read(self) -> None:
 //|         """Fills the provided buffer with ADC voltage values."""
 //|         ...
-//|
 STATIC mp_obj_t analogbufio_bufferedin_obj_read(mp_obj_t self_in) {
     analogbufio_bufferedin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/analogbufio/__init__.c
+++ b/shared-bindings/analogbufio/__init__.c
@@ -62,7 +62,6 @@
 //| TODO: For more information on using `analogbufio`, see `this additional Learn guide
 //| <https://learn.adafruit.com/circuitpython-advanced-analog-inputs-and-outputs>`_
 //| """
-//|
 
 STATIC const mp_rom_map_elem_t analogbufio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_analogbufio) },

--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -46,7 +46,6 @@
 //|
 //|        adc = analogio.AnalogIn(A1)
 //|        val = adc.value"""
-//|
 
 //|     def __init__(self, pin: microcontroller.Pin) -> None:
 //|         """Use the AnalogIn on the given pin. The reference voltage varies by
@@ -54,7 +53,6 @@
 //|
 //|         :param ~microcontroller.Pin pin: the pin to read from"""
 //|         ...
-//|
 STATIC mp_obj_t analogio_analogin_make_new(const mp_obj_type_t *type,
     mp_uint_t n_args, size_t n_kw, const mp_obj_t *args) {
     // check number of arguments
@@ -73,7 +71,6 @@ STATIC mp_obj_t analogio_analogin_make_new(const mp_obj_type_t *type,
 //|     def deinit(self) -> None:
 //|         """Turn off the AnalogIn and release the pin for other use."""
 //|         ...
-//|
 STATIC mp_obj_t analogio_analogin_deinit(mp_obj_t self_in) {
     analogio_analogin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_analogio_analogin_deinit(self);
@@ -89,14 +86,12 @@ STATIC void check_for_deinit(analogio_analogin_obj_t *self) {
 //|     def __enter__(self) -> AnalogIn:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t analogio_analogin___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_analogio_analogin_deinit(args[0]);
@@ -109,7 +104,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(analogio_analogin___exit___obj, 4, 4,
 //|
 //|     Even if the underlying analog to digital converter (ADC) is lower
 //|     resolution, the value is 16-bit."""
-//|
 STATIC mp_obj_t analogio_analogin_obj_get_value(mp_obj_t self_in) {
     analogio_analogin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -124,7 +118,6 @@ MP_PROPERTY_GETTER(analogio_analogin_value_obj,
 //|     """The maximum voltage measurable (also known as the reference voltage) as a
 //|     `float` in Volts.  Note the ADC value may not scale to the actual voltage linearly
 //|     at ends of the analog range."""
-//|
 STATIC mp_obj_t analogio_analogin_obj_get_reference_voltage(mp_obj_t self_in) {
     analogio_analogin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/analogio/AnalogOut.c
+++ b/shared-bindings/analogio/AnalogOut.c
@@ -52,7 +52,6 @@
 //|
 //|         :param ~microcontroller.Pin pin: the pin to output to"""
 //|         ...
-//|
 STATIC mp_obj_t analogio_analogout_make_new(const mp_obj_type_t *type, mp_uint_t n_args, size_t n_kw, const mp_obj_t *args) {
     // check arguments
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
@@ -69,7 +68,6 @@ STATIC mp_obj_t analogio_analogout_make_new(const mp_obj_type_t *type, mp_uint_t
 //|     def deinit(self) -> None:
 //|         """Turn off the AnalogOut and release the pin for other use."""
 //|         ...
-//|
 STATIC mp_obj_t analogio_analogout_deinit(mp_obj_t self_in) {
     analogio_analogout_obj_t *self = self_in;
 
@@ -82,14 +80,12 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(analogio_analogout_deinit_obj, analogio_analogo
 //|     def __enter__(self) -> AnalogOut:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t analogio_analogout___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_analogio_analogout_deinit(args[0]);
@@ -102,7 +98,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(analogio_analogout___exit___obj, 4, 4
 //|
 //|     Even if the underlying digital to analog converter (DAC) is lower
 //|     resolution, the value is 16-bit."""
-//|
 STATIC mp_obj_t analogio_analogout_obj_set_value(mp_obj_t self_in, mp_obj_t value) {
     analogio_analogout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (common_hal_analogio_analogout_deinited(self)) {

--- a/shared-bindings/analogio/__init__.c
+++ b/shared-bindings/analogio/__init__.c
@@ -65,7 +65,6 @@
 //| For more information on using `analogio`, see `this additional Learn guide
 //| <https://learn.adafruit.com/circuitpython-basics-analog-inputs-and-outputs>`_
 //| """
-//|
 
 STATIC const mp_rom_map_elem_t analogio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_analogio) },

--- a/shared-bindings/atexit/__init__.c
+++ b/shared-bindings/atexit/__init__.c
@@ -37,26 +37,26 @@
 //| |see_cpython_module| :mod:`cpython:atexit`.
 //| """
 //| ...
-//|
 
-//| def register(func: Callable[..., Any], *args: Optional[Any], **kwargs: Optional[Any]) -> Callable[..., Any]:
+//| def register(
+//|     func: Callable[..., Any], *args: Optional[Any], **kwargs: Optional[Any]
+//| ) -> Callable[..., Any]:
 //|
 //|     """Register func as a function to be executed at termination.
 //|
-//|        Any optional arguments that are to be passed to func must be passed as arguments to `register()`.
-//|        It is possible to register the same function and arguments more than once.
+//|     Any optional arguments that are to be passed to func must be passed as arguments to `register()`.
+//|     It is possible to register the same function and arguments more than once.
 //|
-//|        At normal program termination (for instance, if `sys.exit()` is called or the vm execution completes),
-//|        all functions registered are called in last in, first out order.
+//|     At normal program termination (for instance, if `sys.exit()` is called or the vm execution completes),
+//|     all functions registered are called in last in, first out order.
 //|
-//|        If an exception is raised during execution of the exit handler,
-//|        a traceback is printed (unless `SystemExit` is raised) and the execution stops.
+//|     If an exception is raised during execution of the exit handler,
+//|     a traceback is printed (unless `SystemExit` is raised) and the execution stops.
 //|
-//|        This function returns func, which makes it possible to use it as a decorator.
+//|     This function returns func, which makes it possible to use it as a decorator.
 //|
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t atexit_register(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     shared_module_atexit_register(pos_args[0], (n_args - 1), ((n_args > 1) ? &pos_args[1] : NULL), kw_args);
     return pos_args[0];
@@ -67,12 +67,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(atexit_register_obj, 1, atexit_register);
 //|
 //|     """Remove func from the list of functions to be run at termination.
 //|
-//|        `unregister()` silently does nothing if func was not previously registered. If func has been registered more than once,
-//|        every occurrence of that function in the atexit call stack will be removed.
+//|     `unregister()` silently does nothing if func was not previously registered. If func has been registered more than once,
+//|     every occurrence of that function in the atexit call stack will be removed.
 //|
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t atexit_unregister(const mp_obj_t self_in) {
     shared_module_atexit_unregister(&self_in);
     return mp_const_none;

--- a/shared-bindings/audiobusio/I2SOut.c
+++ b/shared-bindings/audiobusio/I2SOut.c
@@ -38,7 +38,14 @@
 //| class I2SOut:
 //|     """Output an I2S audio signal"""
 //|
-//|     def __init__(self, bit_clock: microcontroller.Pin, word_select: microcontroller.Pin, data: microcontroller.Pin, *, left_justified: bool) -> None:
+//|     def __init__(
+//|         self,
+//|         bit_clock: microcontroller.Pin,
+//|         word_select: microcontroller.Pin,
+//|         data: microcontroller.Pin,
+//|         *,
+//|         left_justified: bool
+//|     ) -> None:
 //|         """Create a I2SOut object associated with the given pins.
 //|
 //|         :param ~microcontroller.Pin bit_clock: The bit clock (or serial clock) pin
@@ -88,7 +95,6 @@
 //|             pass
 //|           print("stopped")"""
 //|         ...
-//|
 STATIC mp_obj_t audiobusio_i2sout_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     #if !CIRCUITPY_AUDIOBUSIO_I2SOUT
     mp_raise_NotImplementedError(translate("I2SOut not available"));
@@ -121,7 +127,6 @@ STATIC mp_obj_t audiobusio_i2sout_make_new(const mp_obj_type_t *type, size_t n_a
 //|     def deinit(self) -> None:
 //|         """Deinitialises the I2SOut and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t audiobusio_i2sout_deinit(mp_obj_t self_in) {
     audiobusio_i2sout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_audiobusio_i2sout_deinit(self);
@@ -138,14 +143,12 @@ STATIC void check_for_deinit(audiobusio_i2sout_obj_t *self) {
 //|     def __enter__(self) -> I2SOut:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t audiobusio_i2sout_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_audiobusio_i2sout_deinit(args[0]);
@@ -162,7 +165,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiobusio_i2sout___exit___obj, 4, 4,
 //|
 //|         The sample itself should consist of 8 bit or 16 bit samples."""
 //|         ...
-//|
 STATIC mp_obj_t audiobusio_i2sout_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_sample, ARG_loop };
     static const mp_arg_t allowed_args[] = {
@@ -184,7 +186,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiobusio_i2sout_play_obj, 1, audiobusio_i2sout_obj_
 //|     def stop(self) -> None:
 //|         """Stops playback."""
 //|         ...
-//|
 STATIC mp_obj_t audiobusio_i2sout_obj_stop(mp_obj_t self_in) {
     audiobusio_i2sout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -195,7 +196,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiobusio_i2sout_stop_obj, audiobusio_i2sout_obj_stop
 
 //|     playing: bool
 //|     """True when the audio sample is being output. (read-only)"""
-//|
 STATIC mp_obj_t audiobusio_i2sout_obj_get_playing(mp_obj_t self_in) {
     audiobusio_i2sout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -209,7 +209,6 @@ MP_PROPERTY_GETTER(audiobusio_i2sout_playing_obj,
 //|     def pause(self) -> None:
 //|         """Stops playback temporarily while remembering the position. Use `resume` to resume playback."""
 //|         ...
-//|
 STATIC mp_obj_t audiobusio_i2sout_obj_pause(mp_obj_t self_in) {
     audiobusio_i2sout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -225,7 +224,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiobusio_i2sout_pause_obj, audiobusio_i2sout_obj_pau
 //|     def resume(self) -> None:
 //|         """Resumes sample playback after :py:func:`pause`."""
 //|         ...
-//|
 STATIC mp_obj_t audiobusio_i2sout_obj_resume(mp_obj_t self_in) {
     audiobusio_i2sout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -240,7 +238,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiobusio_i2sout_resume_obj, audiobusio_i2sout_obj_re
 
 //|     paused: bool
 //|     """True when playback is paused. (read-only)"""
-//|
 STATIC mp_obj_t audiobusio_i2sout_obj_get_paused(mp_obj_t self_in) {
     audiobusio_i2sout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audiobusio/PDMIn.c
+++ b/shared-bindings/audiobusio/PDMIn.c
@@ -39,7 +39,17 @@
 //| class PDMIn:
 //|     """Record an input PDM audio stream"""
 //|
-//|     def __init__(self, clock_pin: microcontroller.Pin, data_pin: microcontroller.Pin, *, sample_rate: int = 16000, bit_depth: int = 8, mono: bool = True, oversample: int = 64, startup_delay: float = 0.11) -> None:
+//|     def __init__(
+//|         self,
+//|         clock_pin: microcontroller.Pin,
+//|         data_pin: microcontroller.Pin,
+//|         *,
+//|         sample_rate: int = 16000,
+//|         bit_depth: int = 8,
+//|         mono: bool = True,
+//|         oversample: int = 64,
+//|         startup_delay: float = 0.11
+//|     ) -> None:
 //|         """Create a PDMIn object associated with the given pins. This allows you to
 //|         record audio signals from the given pins. Individual ports may put further
 //|         restrictions on the recording parameters. The overall sample rate is
@@ -56,33 +66,31 @@
 //|         :param float startup_delay: seconds to wait after starting microphone clock
 //|          to allow microphone to turn on. Most require only 0.01s; some require 0.1s. Longer is safer.
 //|          Must be in range 0.0-1.0 seconds."""
-//|
 
-//|         """Record 8-bit unsigned samples to buffer::
+//|     """Record 8-bit unsigned samples to buffer::
 //|
-//|           import audiobusio
-//|           import board
+//|       import audiobusio
+//|       import board
 //|
-//|           # Prep a buffer to record into
-//|           b = bytearray(200)
-//|           with audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA, sample_rate=16000) as mic:
-//|               mic.record(b, len(b))
+//|       # Prep a buffer to record into
+//|       b = bytearray(200)
+//|       with audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA, sample_rate=16000) as mic:
+//|           mic.record(b, len(b))
 //|
-//|         Record 16-bit unsigned samples to buffer::
+//|     Record 16-bit unsigned samples to buffer::
 //|
-//|           import audiobusio
-//|           import board
+//|       import audiobusio
+//|       import board
 //|
-//|           # Prep a buffer to record into. The array interface doesn't allow for
-//|           # constructing with a set size so we append to it until we have the size
-//|           # we want.
-//|           b = array.array("H")
-//|           for i in range(200):
-//|               b.append(0)
-//|           with audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA, sample_rate=16000, bit_depth=16) as mic:
-//|               mic.record(b, len(b))"""
-//|         ...
-//|
+//|       # Prep a buffer to record into. The array interface doesn't allow for
+//|       # constructing with a set size so we append to it until we have the size
+//|       # we want.
+//|       b = array.array("H")
+//|       for i in range(200):
+//|           b.append(0)
+//|       with audiobusio.PDMIn(board.MICROPHONE_CLOCK, board.MICROPHONE_DATA, sample_rate=16000, bit_depth=16) as mic:
+//|           mic.record(b, len(b))"""
+//|     ...
 STATIC mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     #if !CIRCUITPY_AUDIOBUSIO_PDMIN
     mp_raise_NotImplementedError(translate("PDMIn not available"));
@@ -142,7 +150,6 @@ STATIC mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_ar
 //|     def deinit(self) -> None:
 //|         """Deinitialises the PDMIn and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t audiobusio_pdmin_deinit(mp_obj_t self_in) {
     audiobusio_pdmin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_audiobusio_pdmin_deinit(self);
@@ -158,13 +165,11 @@ STATIC void check_for_deinit(audiobusio_pdmin_obj_t *self) {
 //|     def __enter__(self) -> PDMIn:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context."""
 //|         ...
-//|
 STATIC mp_obj_t audiobusio_pdmin_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_audiobusio_pdmin_deinit(args[0]);
@@ -184,7 +189,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiobusio_pdmin___exit___obj, 4, 4, 
 //|         :return: The number of samples recorded. If this is less than ``destination_length``,
 //|           some samples were missed due to processing time."""
 //|         ...
-//|
 STATIC mp_obj_t audiobusio_pdmin_obj_record(mp_obj_t self_obj, mp_obj_t destination, mp_obj_t destination_length) {
     audiobusio_pdmin_obj_t *self = MP_OBJ_TO_PTR(self_obj);
     check_for_deinit(self);
@@ -216,7 +220,6 @@ MP_DEFINE_CONST_FUN_OBJ_3(audiobusio_pdmin_record_obj, audiobusio_pdmin_obj_reco
 //|     sample_rate: int
 //|     """The actual sample_rate of the recording. This may not match the constructed
 //|     sample rate due to internal clock limitations."""
-//|
 STATIC mp_obj_t audiobusio_pdmin_obj_get_sample_rate(mp_obj_t self_in) {
     audiobusio_pdmin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audiobusio/__init__.c
+++ b/shared-bindings/audiobusio/__init__.c
@@ -44,7 +44,6 @@
 //| All classes change hardware state and should be deinitialized when they
 //| are no longer needed. To do so, either call :py:meth:`!deinit` or use a
 //| context manager."""
-//|
 
 STATIC const mp_rom_map_elem_t audiobusio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audiobusio) },

--- a/shared-bindings/audiocore/RawSample.c
+++ b/shared-bindings/audiocore/RawSample.c
@@ -37,7 +37,9 @@
 //| class RawSample:
 //|     """A raw audio sample buffer in memory"""
 //|
-//|     def __init__(self, buffer: ReadableBuffer, *, channel_count: int = 1, sample_rate: int = 8000) -> None:
+//|     def __init__(
+//|         self, buffer: ReadableBuffer, *, channel_count: int = 1, sample_rate: int = 8000
+//|     ) -> None:
 //|         """Create a RawSample based on the given buffer of signed values. If channel_count is more than
 //|         1 then each channel's samples should alternate. In other words, for a two channel buffer, the
 //|         first sample will be for channel 1, the second sample will be for channel two, the third for
@@ -68,7 +70,6 @@
 //|           time.sleep(1)
 //|           dac.stop()"""
 //|         ...
-//|
 STATIC mp_obj_t audioio_rawsample_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_buffer, ARG_channel_count, ARG_sample_rate };
     static const mp_arg_t allowed_args[] = {
@@ -100,7 +101,6 @@ STATIC mp_obj_t audioio_rawsample_make_new(const mp_obj_type_t *type, size_t n_a
 //|     def deinit(self) -> None:
 //|         """Deinitialises the RawSample and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t audioio_rawsample_deinit(mp_obj_t self_in) {
     audioio_rawsample_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_audioio_rawsample_deinit(self);
@@ -117,14 +117,12 @@ STATIC void check_for_deinit(audioio_rawsample_obj_t *self) {
 //|     def __enter__(self) -> RawSample:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t audioio_rawsample_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_audioio_rawsample_deinit(args[0]);
@@ -137,7 +135,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audioio_rawsample___exit___obj, 4, 4,
 //|     When the sample is looped, this can change the pitch output without changing the underlying
 //|     sample. This will not change the sample rate of any active playback. Call ``play`` again to
 //|     change it."""
-//|
 STATIC mp_obj_t audioio_rawsample_obj_get_sample_rate(mp_obj_t self_in) {
     audioio_rawsample_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audiocore/WaveFile.c
+++ b/shared-bindings/audiocore/WaveFile.c
@@ -70,7 +70,6 @@
 //|           print("stopped")
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t audioio_wavefile_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 2, false);
     mp_obj_t arg = args[0];
@@ -117,14 +116,12 @@ STATIC void check_for_deinit(audioio_wavefile_obj_t *self) {
 //|     def __enter__(self) -> WaveFile:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t audioio_wavefile_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_audioio_wavefile_deinit(args[0]);
@@ -136,7 +133,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audioio_wavefile___exit___obj, 4, 4, 
 //|     """32 bit value that dictates how quickly samples are loaded into the DAC
 //|     in Hertz (cycles per second). When the sample is looped, this can change
 //|     the pitch output without changing the underlying sample."""
-//|
 STATIC mp_obj_t audioio_wavefile_obj_get_sample_rate(mp_obj_t self_in) {
     audioio_wavefile_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -158,7 +154,6 @@ MP_PROPERTY_GETSET(audioio_wavefile_sample_rate_obj,
 
 //|     bits_per_sample: int
 //|     """Bits per sample. (read only)"""
-//|
 STATIC mp_obj_t audioio_wavefile_obj_get_bits_per_sample(mp_obj_t self_in) {
     audioio_wavefile_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -170,7 +165,6 @@ MP_PROPERTY_GETTER(audioio_wavefile_bits_per_sample_obj,
     (mp_obj_t)&audioio_wavefile_get_bits_per_sample_obj);
 //|     channel_count: int
 //|     """Number of audio channels. (read only)"""
-//|
 STATIC mp_obj_t audioio_wavefile_obj_get_channel_count(mp_obj_t self_in) {
     audioio_wavefile_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audiocore/__init__.c
+++ b/shared-bindings/audiocore/__init__.c
@@ -36,7 +36,6 @@
 // #include "shared-bindings/audiomixer/Mixer.h"
 
 //| """Support for audio samples"""
-//|
 
 STATIC const mp_rom_map_elem_t audiocore_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audiocore) },

--- a/shared-bindings/audioio/AudioOut.c
+++ b/shared-bindings/audioio/AudioOut.c
@@ -39,7 +39,13 @@
 //| class AudioOut:
 //|     """Output an analog audio signal"""
 //|
-//|     def __init__(self, left_channel: microcontroller.Pin, *, right_channel: Optional[microcontroller.Pin] = None, quiescent_value: int = 0x8000) -> None:
+//|     def __init__(
+//|         self,
+//|         left_channel: microcontroller.Pin,
+//|         *,
+//|         right_channel: Optional[microcontroller.Pin] = None,
+//|         quiescent_value: int = 0x8000
+//|     ) -> None:
 //|         """Create a AudioOut object associated with the given pin(s). This allows you to
 //|         play audio signals out on the given pin(s).
 //|
@@ -89,7 +95,6 @@
 //|             pass
 //|           print("stopped")"""
 //|         ...
-//|
 STATIC mp_obj_t audioio_audioout_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_left_channel, ARG_right_channel, ARG_quiescent_value };
     static const mp_arg_t allowed_args[] = {
@@ -114,7 +119,6 @@ STATIC mp_obj_t audioio_audioout_make_new(const mp_obj_type_t *type, size_t n_ar
 //|     def deinit(self) -> None:
 //|         """Deinitialises the AudioOut and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t audioio_audioout_deinit(mp_obj_t self_in) {
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_audioio_audioout_deinit(self);
@@ -130,14 +134,12 @@ STATIC void check_for_deinit(audioio_audioout_obj_t *self) {
 //|     def __enter__(self) -> AudioOut:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t audioio_audioout_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_audioio_audioout_deinit(args[0]);
@@ -156,7 +158,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audioio_audioout___exit___obj, 4, 4, 
 //|         resolution will use the highest order bits to output. For example, the SAMD21 has a 10 bit
 //|         DAC that ignores the lowest 6 bits when playing 16 bit samples."""
 //|         ...
-//|
 STATIC mp_obj_t audioio_audioout_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_sample, ARG_loop };
     static const mp_arg_t allowed_args[] = {
@@ -178,7 +179,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audioio_audioout_play_obj, 1, audioio_audioout_obj_pl
 //|     def stop(self) -> None:
 //|         """Stops playback and resets to the start of the sample."""
 //|         ...
-//|
 STATIC mp_obj_t audioio_audioout_obj_stop(mp_obj_t self_in) {
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -189,7 +189,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(audioio_audioout_stop_obj, audioio_audioout_obj_stop);
 
 //|     playing: bool
 //|     """True when an audio sample is being output even if `paused`. (read-only)"""
-//|
 STATIC mp_obj_t audioio_audioout_obj_get_playing(mp_obj_t self_in) {
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -203,7 +202,6 @@ MP_PROPERTY_GETTER(audioio_audioout_playing_obj,
 //|     def pause(self) -> None:
 //|         """Stops playback temporarily while remembering the position. Use `resume` to resume playback."""
 //|         ...
-//|
 STATIC mp_obj_t audioio_audioout_obj_pause(mp_obj_t self_in) {
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -219,7 +217,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(audioio_audioout_pause_obj, audioio_audioout_obj_pause
 //|     def resume(self) -> None:
 //|         """Resumes sample playback after :py:func:`pause`."""
 //|         ...
-//|
 STATIC mp_obj_t audioio_audioout_obj_resume(mp_obj_t self_in) {
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -234,7 +231,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(audioio_audioout_resume_obj, audioio_audioout_obj_resu
 
 //|     paused: bool
 //|     """True when playback is paused. (read-only)"""
-//|
 STATIC mp_obj_t audioio_audioout_obj_get_paused(mp_obj_t self_in) {
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audioio/__init__.c
+++ b/shared-bindings/audioio/__init__.c
@@ -52,7 +52,6 @@
 //| For compatibility with CircuitPython 4.x, some builds allow the items in
 //| `audiocore` to be imported from `audioio`.  This will be removed for all
 //| boards in a future build of CircuitPython."""
-//|
 
 STATIC const mp_rom_map_elem_t audioio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audioio) },

--- a/shared-bindings/audiomixer/Mixer.c
+++ b/shared-bindings/audiomixer/Mixer.c
@@ -41,7 +41,15 @@
 //| class Mixer:
 //|     """Mixes one or more audio samples together into one sample."""
 //|
-//|     def __init__(self, voice_count: int = 2, buffer_size: int = 1024, channel_count: int = 2, bits_per_sample: int = 16, samples_signed: bool = True, sample_rate: int = 8000) -> None:
+//|     def __init__(
+//|         self,
+//|         voice_count: int = 2,
+//|         buffer_size: int = 1024,
+//|         channel_count: int = 2,
+//|         bits_per_sample: int = 16,
+//|         samples_signed: bool = True,
+//|         sample_rate: int = 8000,
+//|     ) -> None:
 //|         """Create a Mixer object that can mix multiple channels with the same sample rate.
 //|         Samples are accessed and controlled with the mixer's `audiomixer.MixerVoice` objects.
 //|
@@ -77,7 +85,6 @@
 //|             time.sleep(1)
 //|           print("stopped")"""
 //|         ...
-//|
 STATIC mp_obj_t audiomixer_mixer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_voice_count, ARG_buffer_size, ARG_channel_count, ARG_bits_per_sample, ARG_samples_signed, ARG_sample_rate };
     static const mp_arg_t allowed_args[] = {
@@ -114,7 +121,6 @@ STATIC mp_obj_t audiomixer_mixer_make_new(const mp_obj_type_t *type, size_t n_ar
 //|     def deinit(self) -> None:
 //|         """Deinitialises the Mixer and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t audiomixer_mixer_deinit(mp_obj_t self_in) {
     audiomixer_mixer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_audiomixer_mixer_deinit(self);
@@ -131,14 +137,12 @@ STATIC void check_for_deinit(audiomixer_mixer_obj_t *self) {
 //|     def __enter__(self) -> Mixer:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t audiomixer_mixer_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_audiomixer_mixer_deinit(args[0]);
@@ -148,7 +152,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiomixer_mixer___exit___obj, 4, 4, 
 
 //|     playing: bool
 //|     """True when any voice is being output. (read-only)"""
-//|
 STATIC mp_obj_t audiomixer_mixer_obj_get_playing(mp_obj_t self_in) {
     audiomixer_mixer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -161,7 +164,6 @@ MP_PROPERTY_GETTER(audiomixer_mixer_playing_obj,
 
 //|     sample_rate: int
 //|     """32 bit value that dictates how quickly samples are played in Hertz (cycles per second)."""
-//|
 STATIC mp_obj_t audiomixer_mixer_obj_get_sample_rate(mp_obj_t self_in) {
     audiomixer_mixer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -189,7 +191,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiomixer_mixer_get_voice_obj, audiomixer_mixer_obj_g
 MP_PROPERTY_GETTER(audiomixer_mixer_voice_obj,
     (mp_obj_t)&audiomixer_mixer_get_voice_obj);
 
-//|     def play(self, sample: circuitpython_typing.AudioSample, *, voice: int = 0, loop: bool = False) -> None:
+//|     def play(
+//|         self, sample: circuitpython_typing.AudioSample, *, voice: int = 0, loop: bool = False
+//|     ) -> None:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
@@ -197,7 +201,6 @@ MP_PROPERTY_GETTER(audiomixer_mixer_voice_obj,
 //|
 //|         The sample must match the Mixer's encoding settings given in the constructor."""
 //|         ...
-//|
 STATIC mp_obj_t audiomixer_mixer_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_sample, ARG_voice, ARG_loop };
     static const mp_arg_t allowed_args[] = {
@@ -225,7 +228,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixer_play_obj, 1, audiomixer_mixer_obj_pl
 //|     def stop_voice(self, voice: int = 0) -> None:
 //|         """Stops playback of the sample on the given voice."""
 //|         ...
-//|
 STATIC mp_obj_t audiomixer_mixer_obj_stop_voice(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_voice };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -45,7 +45,6 @@
 //|     def __init__(self) -> None:
 //|         """MixerVoice instance object(s) created by `audiomixer.Mixer`."""
 //|         ...
-//|
 // TODO: support mono or stereo voices
 STATIC mp_obj_t audiomixer_mixervoice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
@@ -65,7 +64,6 @@ STATIC mp_obj_t audiomixer_mixervoice_make_new(const mp_obj_type_t *type, size_t
 //|
 //|         The sample must match the `audiomixer.Mixer`'s encoding settings given in the constructor."""
 //|         ...
-//|
 STATIC mp_obj_t audiomixer_mixervoice_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_sample, ARG_loop };
     static const mp_arg_t allowed_args[] = {
@@ -85,7 +83,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_play_obj, 1, audiomixer_mixervo
 //|     def stop(self) -> None:
 //|         """Stops playback of the sample on this voice."""
 //|         ...
-//|
 STATIC mp_obj_t audiomixer_mixervoice_obj_stop(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_voice };
     static const mp_arg_t allowed_args[] = {
@@ -103,7 +100,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_stop_obj, 1, audiomixer_mixervo
 
 //|     level: float
 //|     """The volume level of a voice, as a floating point number between 0 and 1."""
-//|
 STATIC mp_obj_t audiomixer_mixervoice_obj_get_level(mp_obj_t self_in) {
     return mp_obj_new_float(common_hal_audiomixer_mixervoice_get_level(self_in));
 }
@@ -136,7 +132,6 @@ MP_PROPERTY_GETSET(audiomixer_mixervoice_level_obj,
 
 //|     playing: bool
 //|     """True when this voice is being output. (read-only)"""
-//|
 
 STATIC mp_obj_t audiomixer_mixervoice_obj_get_playing(mp_obj_t self_in) {
     audiomixer_mixervoice_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/audiomixer/__init__.c
+++ b/shared-bindings/audiomixer/__init__.c
@@ -33,7 +33,6 @@
 #include "shared-bindings/audiomixer/Mixer.h"
 
 //| """Support for audio mixing"""
-//|
 
 STATIC const mp_rom_map_elem_t audiomixer_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audiomixer) },

--- a/shared-bindings/audiomp3/MP3Decoder.c
+++ b/shared-bindings/audiomp3/MP3Decoder.c
@@ -87,7 +87,6 @@
 //|           print("stopped")
 //|         """
 //|         ...
-//|
 
 STATIC mp_obj_t audiomp3_mp3file_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 2, false);
@@ -119,7 +118,6 @@ STATIC mp_obj_t audiomp3_mp3file_make_new(const mp_obj_type_t *type, size_t n_ar
 //|     def deinit(self) -> None:
 //|         """Deinitialises the MP3 and releases all memory resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t audiomp3_mp3file_deinit(mp_obj_t self_in) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_audiomp3_mp3file_deinit(self);
@@ -136,14 +134,12 @@ STATIC void check_for_deinit(audiomp3_mp3file_obj_t *self) {
 //|     def __enter__(self) -> MP3Decoder:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t audiomp3_mp3file_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_audiomp3_mp3file_deinit(args[0]);
@@ -153,7 +149,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiomp3_mp3file___exit___obj, 4, 4, 
 
 //|     file: typing.BinaryIO
 //|     """File to play back."""
-//|
 STATIC mp_obj_t audiomp3_mp3file_obj_get_file(mp_obj_t self_in) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -175,7 +170,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(audiomp3_mp3file_set_file_obj, audiomp3_mp3file_obj_se
 //|     def open(self, filepath: str) -> None:
 //|         """Takes in the name of a mp3 file, opens it, and replaces the old playback file."""
 //|         ...
-//|
 STATIC mp_obj_t audiomp3_mp3file_obj_open(mp_obj_t self_in, mp_obj_t path) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -197,7 +191,6 @@ MP_PROPERTY_GETSET(audiomp3_mp3file_file_obj,
 //|     """32 bit value that dictates how quickly samples are loaded into the DAC
 //|     in Hertz (cycles per second). When the sample is looped, this can change
 //|     the pitch output without changing the underlying sample."""
-//|
 STATIC mp_obj_t audiomp3_mp3file_obj_get_sample_rate(mp_obj_t self_in) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -219,7 +212,6 @@ MP_PROPERTY_GETSET(audiomp3_mp3file_sample_rate_obj,
 
 //|     bits_per_sample: int
 //|     """Bits per sample. (read only)"""
-//|
 STATIC mp_obj_t audiomp3_mp3file_obj_get_bits_per_sample(mp_obj_t self_in) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -232,7 +224,6 @@ MP_PROPERTY_GETTER(audiomp3_mp3file_bits_per_sample_obj,
 
 //|     channel_count: int
 //|     """Number of audio channels. (read only)"""
-//|
 STATIC mp_obj_t audiomp3_mp3file_obj_get_channel_count(mp_obj_t self_in) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -245,7 +236,6 @@ MP_PROPERTY_GETTER(audiomp3_mp3file_channel_count_obj,
 
 //|     rms_level: float
 //|     """The RMS audio level of a recently played moment of audio. (read only)"""
-//|
 STATIC mp_obj_t audiomp3_mp3file_obj_get_rms_level(mp_obj_t self_in) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -258,7 +248,6 @@ MP_PROPERTY_GETTER(audiomp3_mp3file_rms_level_obj,
 
 //|     samples_decoded: int
 //|     """The number of audio samples decoded from the current file. (read only)"""
-//|
 STATIC mp_obj_t audiomp3_mp3file_obj_get_samples_decoded(mp_obj_t self_in) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audiomp3/__init__.c
+++ b/shared-bindings/audiomp3/__init__.c
@@ -37,7 +37,6 @@
 //| see `this CircuitPython Essentials Learn guide page
 //| <https://learn.adafruit.com/circuitpython-essentials/circuitpython-mp3-audio>`_.
 //| """
-//|
 
 STATIC const mp_rom_map_elem_t audiomp3_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audiomp3) },

--- a/shared-bindings/audiopwmio/PWMAudioOut.c
+++ b/shared-bindings/audiopwmio/PWMAudioOut.c
@@ -39,7 +39,13 @@
 //| class PWMAudioOut:
 //|     """Output an analog audio signal by varying the PWM duty cycle."""
 //|
-//|     def __init__(self, left_channel: microcontroller.Pin, *, right_channel: Optional[microcontroller.Pin] = None, quiescent_value: int = 0x8000) -> None:
+//|     def __init__(
+//|         self,
+//|         left_channel: microcontroller.Pin,
+//|         *,
+//|         right_channel: Optional[microcontroller.Pin] = None,
+//|         quiescent_value: int = 0x8000
+//|     ) -> None:
 //|         """Create a PWMAudioOut object associated with the given pin(s). This allows you to
 //|         play audio signals out on the given pin(s).  In contrast to mod:`audioio`,
 //|         the pin(s) specified are digital pins, and are driven with a device-dependent PWM
@@ -92,7 +98,6 @@
 //|             pass
 //|           print("stopped")"""
 //|         ...
-//|
 STATIC mp_obj_t audiopwmio_pwmaudioout_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_left_channel, ARG_right_channel, ARG_quiescent_value };
     static const mp_arg_t allowed_args[] = {
@@ -117,7 +122,6 @@ STATIC mp_obj_t audiopwmio_pwmaudioout_make_new(const mp_obj_type_t *type, size_
 //|     def deinit(self) -> None:
 //|         """Deinitialises the PWMAudioOut and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t audiopwmio_pwmaudioout_deinit(mp_obj_t self_in) {
     audiopwmio_pwmaudioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_audiopwmio_pwmaudioout_deinit(self);
@@ -133,7 +137,6 @@ STATIC void check_for_deinit(audiopwmio_pwmaudioout_obj_t *self) {
 //|     def __enter__(self) -> PWMAudioOut:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
@@ -157,7 +160,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audiopwmio_pwmaudioout___exit___obj, 
 //|         The sample itself should consist of 16 bit samples. Microcontrollers with a lower output
 //|         resolution will use the highest order bits to output."""
 //|         ...
-//|
 STATIC mp_obj_t audiopwmio_pwmaudioout_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_sample, ARG_loop };
     static const mp_arg_t allowed_args[] = {
@@ -179,7 +181,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiopwmio_pwmaudioout_play_obj, 1, audiopwmio_pwmaud
 //|     def stop(self) -> None:
 //|         """Stops playback and resets to the start of the sample."""
 //|         ...
-//|
 STATIC mp_obj_t audiopwmio_pwmaudioout_obj_stop(mp_obj_t self_in) {
     audiopwmio_pwmaudioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -190,7 +191,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiopwmio_pwmaudioout_stop_obj, audiopwmio_pwmaudioou
 
 //|     playing: bool
 //|     """True when an audio sample is being output even if `paused`. (read-only)"""
-//|
 STATIC mp_obj_t audiopwmio_pwmaudioout_obj_get_playing(mp_obj_t self_in) {
     audiopwmio_pwmaudioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -204,7 +204,6 @@ MP_PROPERTY_GETTER(audiopwmio_pwmaudioout_playing_obj,
 //|     def pause(self) -> None:
 //|         """Stops playback temporarily while remembering the position. Use `resume` to resume playback."""
 //|         ...
-//|
 STATIC mp_obj_t audiopwmio_pwmaudioout_obj_pause(mp_obj_t self_in) {
     audiopwmio_pwmaudioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -220,7 +219,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiopwmio_pwmaudioout_pause_obj, audiopwmio_pwmaudioo
 //|     def resume(self) -> None:
 //|         """Resumes sample playback after :py:func:`pause`."""
 //|         ...
-//|
 STATIC mp_obj_t audiopwmio_pwmaudioout_obj_resume(mp_obj_t self_in) {
     audiopwmio_pwmaudioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -235,7 +233,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiopwmio_pwmaudioout_resume_obj, audiopwmio_pwmaudio
 
 //|     paused: bool
 //|     """True when playback is paused. (read-only)"""
-//|
 STATIC mp_obj_t audiopwmio_pwmaudioout_obj_get_paused(mp_obj_t self_in) {
     audiopwmio_pwmaudioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audiopwmio/__init__.c
+++ b/shared-bindings/audiopwmio/__init__.c
@@ -44,7 +44,6 @@
 //|
 //| Since CircuitPython 5, `Mixer`, `RawSample` and `WaveFile` are moved
 //| to :mod:`audiocore`."""
-//|
 
 STATIC const mp_rom_map_elem_t audiopwmio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audiopwmio) },

--- a/shared-bindings/bitbangio/I2C.c
+++ b/shared-bindings/bitbangio/I2C.c
@@ -40,7 +40,14 @@
 //| class I2C:
 //|     """Two wire serial protocol"""
 //|
-//|     def __init__(self, scl: microcontroller.Pin, sda: microcontroller.Pin, *, frequency: int = 400000, timeout: int = 255) -> None:
+//|     def __init__(
+//|         self,
+//|         scl: microcontroller.Pin,
+//|         sda: microcontroller.Pin,
+//|         *,
+//|         frequency: int = 400000,
+//|         timeout: int = 255
+//|     ) -> None:
 //|         """I2C is a two-wire protocol for communicating between devices.  At the
 //|         physical level it consists of 2 wires: SCL and SDA, the clock and data
 //|         lines respectively.
@@ -58,7 +65,6 @@
 //|         :param int frequency: The clock frequency of the bus
 //|         :param int timeout: The maximum clock stretching timeout in microseconds"""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_scl, ARG_sda, ARG_frequency, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
@@ -82,7 +88,6 @@ STATIC mp_obj_t bitbangio_i2c_make_new(const mp_obj_type_t *type, size_t n_args,
 //|     def deinit(self) -> None:
 //|         """Releases control of the underlying hardware so other classes can use it."""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_i2c_obj_deinit(mp_obj_t self_in) {
     bitbangio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
     shared_module_bitbangio_i2c_deinit(self);
@@ -99,14 +104,12 @@ STATIC void check_for_deinit(bitbangio_i2c_obj_t *self) {
 //|     def __enter__(self) -> I2C:
 //|         """No-op used in Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware on context exit. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_i2c_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     shared_module_bitbangio_i2c_deinit(args[0]);
@@ -125,7 +128,6 @@ static void check_lock(bitbangio_i2c_obj_t *self) {
 //|         those that respond.  A device responds if it pulls the SDA line low after
 //|         its address (including a read bit) is sent on the bus."""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_i2c_scan(mp_obj_t self_in) {
     bitbangio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -145,7 +147,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_i2c_scan_obj, bitbangio_i2c_scan);
 //|     def try_lock(self) -> bool:
 //|         """Attempts to grab the I2C lock. Returns True on success."""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_i2c_obj_try_lock(mp_obj_t self_in) {
     bitbangio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -156,7 +157,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_i2c_try_lock_obj, bitbangio_i2c_obj_try_lock
 //|     def unlock(self) -> None:
 //|         """Releases the I2C lock."""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_i2c_obj_unlock(mp_obj_t self_in) {
     bitbangio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -166,7 +166,9 @@ STATIC mp_obj_t bitbangio_i2c_obj_unlock(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_i2c_unlock_obj, bitbangio_i2c_obj_unlock);
 
 //|     import sys
-//|     def readfrom_into(self, address: int, buffer: WriteableBuffer, *, start: int = 0, end: int = sys.maxsize) -> None:
+//|     def readfrom_into(
+//|         self, address: int, buffer: WriteableBuffer, *, start: int = 0, end: int = sys.maxsize
+//|     ) -> None:
 //|         """Read into ``buffer`` from the device selected by ``address``.
 //|         The number of bytes read will be the length of ``buffer``.
 //|         At least one byte must be read.
@@ -180,7 +182,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_i2c_unlock_obj, bitbangio_i2c_obj_unlock);
 //|         :param int start: Index to start writing at
 //|         :param int end: Index to write up to but not include"""
 //|         ...
-//|
 // Shared arg parsing for readfrom_into and writeto_then_readfrom.
 STATIC void readfrom(bitbangio_i2c_obj_t *self, mp_int_t address, mp_obj_t buffer, int32_t start, mp_int_t end) {
     mp_buffer_info_t bufinfo;
@@ -217,7 +218,9 @@ STATIC mp_obj_t bitbangio_i2c_readfrom_into(size_t n_args, const mp_obj_t *pos_a
 MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_i2c_readfrom_into_obj, 1, bitbangio_i2c_readfrom_into);
 
 //|     import sys
-//|     def writeto(self, address: int, buffer: ReadableBuffer, *, start: int = 0, end: int = sys.maxsize) -> None:
+//|     def writeto(
+//|         self, address: int, buffer: ReadableBuffer, *, start: int = 0, end: int = sys.maxsize
+//|     ) -> None:
 //|         """Write the bytes from ``buffer`` to the device selected by ``address`` and then transmits a
 //|         stop bit. Use `writeto_then_readfrom` when needing a write, no stop and repeated start
 //|         before a read.
@@ -235,7 +238,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_i2c_readfrom_into_obj, 1, bitbangio_i2c_rea
 //|         :param int end: end of buffer slice; if not specified, use ``len(buffer)``
 //|         """
 //|         ...
-//|
 // Shared arg parsing for writeto and writeto_then_readfrom.
 STATIC void writeto(bitbangio_i2c_obj_t *self, mp_int_t address, mp_obj_t buffer, int32_t start, mp_int_t end, bool stop) {
     // get the buffer to write the data from
@@ -276,7 +278,17 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_i2c_writeto_obj, 1, bitbangio_i2c_wr
 
 
 //|     import sys
-//|     def writeto_then_readfrom(self, address: int, out_buffer: ReadableBuffer, in_buffer: ReadableBuffer, *, out_start: int = 0, out_end: int = sys.maxsize, in_start: int = 0, in_end: int = sys.maxsize) -> None:
+//|     def writeto_then_readfrom(
+//|         self,
+//|         address: int,
+//|         out_buffer: ReadableBuffer,
+//|         in_buffer: ReadableBuffer,
+//|         *,
+//|         out_start: int = 0,
+//|         out_end: int = sys.maxsize,
+//|         in_start: int = 0,
+//|         in_end: int = sys.maxsize
+//|     ) -> None:
 //|         """Write the bytes from ``out_buffer`` to the device selected by ``address``, generate no stop
 //|         bit, generate a repeated start and read into ``in_buffer``. ``out_buffer`` and
 //|         ``in_buffer`` can be the same buffer because they are used sequentially.
@@ -298,7 +310,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_i2c_writeto_obj, 1, bitbangio_i2c_wr
 //|         :param int in_end: end of ``in_buffer slice``; if not specified, use ``len(in_buffer)``
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_i2c_writeto_then_readfrom(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_address, ARG_out_buffer, ARG_in_buffer, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/bitbangio/I2C.c
+++ b/shared-bindings/bitbangio/I2C.c
@@ -288,7 +288,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_i2c_writeto_obj, 1, bitbangio_i2c_wr
 //|         If ``in_start`` or ``in_end`` is provided, then the input buffer will be sliced
 //|         as if ``in_buffer[in_start:in_end]`` were passed,
 //|         The number of bytes read will be the length of ``out_buffer[in_start:in_end]``.
-
+//|
 //|         :param int address: 7-bit device address
 //|         :param ~circuitpython_typing.ReadableBuffer out_buffer: buffer containing the bytes to write
 //|         :param ~circuitpython_typing.WriteableBuffer in_buffer: buffer to write into

--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -51,7 +51,12 @@
 //|     multiple secondaries can share the `!clock`, `!MOSI` and `!MISO` lines
 //|     and therefore the hardware.)"""
 //|
-//|     def __init__(self, clock: microcontroller.Pin, MOSI: Optional[microcontroller.Pin] = None, MISO: Optional[microcontroller.Pin] = None) -> None:
+//|     def __init__(
+//|         self,
+//|         clock: microcontroller.Pin,
+//|         MOSI: Optional[microcontroller.Pin] = None,
+//|         MISO: Optional[microcontroller.Pin] = None,
+//|     ) -> None:
 //|         """Construct an SPI object on the given pins.
 //|
 //|         .. seealso:: Using this class directly requires careful lock management.
@@ -67,7 +72,6 @@
 //|         :param ~microcontroller.Pin MOSI: the Main Out Selected In pin.
 //|         :param ~microcontroller.Pin MISO: the Main In Selected Out pin."""
 //|         ...
-//|
 
 // TODO(tannewt): Support LSB SPI.
 STATIC mp_obj_t bitbangio_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
@@ -93,7 +97,6 @@ STATIC mp_obj_t bitbangio_spi_make_new(const mp_obj_type_t *type, size_t n_args,
 //|     def deinit(self) -> None:
 //|         """Turn off the SPI bus."""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_spi_obj_deinit(mp_obj_t self_in) {
     bitbangio_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
     shared_module_bitbangio_spi_deinit(self);
@@ -110,14 +113,12 @@ STATIC void check_for_deinit(bitbangio_spi_obj_t *self) {
 //|     def __enter__(self) -> SPI:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_spi_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     shared_module_bitbangio_spi_deinit(args[0]);
@@ -132,7 +133,9 @@ static void check_lock(bitbangio_spi_obj_t *self) {
     }
 }
 
-//|     def configure(self, *, baudrate: int = 100000, polarity: int = 0, phase: int = 0, bits: int = 8) -> None:
+//|     def configure(
+//|         self, *, baudrate: int = 100000, polarity: int = 0, phase: int = 0, bits: int = 8
+//|     ) -> None:
 //|         """Configures the SPI bus. Only valid when locked.
 //|
 //|         :param int baudrate: the clock rate in Hertz
@@ -141,7 +144,6 @@ static void check_lock(bitbangio_spi_obj_t *self) {
 //|           or second (1). Rising or falling depends on clock polarity.
 //|         :param int bits: the number of bits per word"""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_spi_configure(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits };
     static const mp_arg_t allowed_args[] = {
@@ -172,7 +174,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_spi_configure_obj, 1, bitbangio_spi_configu
 //|         :return: True when lock has been grabbed
 //|         :rtype: bool"""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_spi_obj_try_lock(mp_obj_t self_in) {
     bitbangio_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -183,7 +184,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_spi_try_lock_obj, bitbangio_spi_obj_try_lock
 //|     def unlock(self) -> None:
 //|         """Releases the SPI lock."""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_spi_obj_unlock(mp_obj_t self_in) {
     bitbangio_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -196,7 +196,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(bitbangio_spi_unlock_obj, bitbangio_spi_obj_unlock);
 //|         """Write the data contained in ``buf``. Requires the SPI being locked.
 //|         If the buffer is empty, nothing happens."""
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_spi_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_start, ARG_end };
     static const mp_arg_t allowed_args[] = {
@@ -230,7 +229,14 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_spi_write_obj, 1, bitbangio_spi_write);
 
 
 //|     import sys
-//|     def readinto(self, buffer: WriteableBuffer, *, start: int = 0, end: int = sys.maxsize, write_value: int = 0) -> None:
+//|     def readinto(
+//|         self,
+//|         buffer: WriteableBuffer,
+//|         *,
+//|         start: int = 0,
+//|         end: int = sys.maxsize,
+//|         write_value: int = 0
+//|     ) -> None:
 //|         """Read into ``buffer`` while writing ``write_value`` for each byte read.
 //|         The SPI object must be locked.
 //|         If the number of bytes to read is 0, nothing happens.
@@ -245,7 +251,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_spi_write_obj, 1, bitbangio_spi_write);
 //|         :param int write_value: value to write while reading
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_spi_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_start, ARG_end, ARG_write_value };
     static const mp_arg_t allowed_args[] = {
@@ -279,7 +284,16 @@ STATIC mp_obj_t bitbangio_spi_readinto(size_t n_args, const mp_obj_t *pos_args, 
 MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_spi_readinto_obj, 1, bitbangio_spi_readinto);
 
 //|     import sys
-//|     def write_readinto(self, out_buffer: ReadableBuffer, in_buffer: WriteableBuffer, *, out_start: int = 0, out_end: int = sys.maxsize, in_start: int = 0, in_end: int = sys.maxsize) -> None:
+//|     def write_readinto(
+//|         self,
+//|         out_buffer: ReadableBuffer,
+//|         in_buffer: WriteableBuffer,
+//|         *,
+//|         out_start: int = 0,
+//|         out_end: int = sys.maxsize,
+//|         in_start: int = 0,
+//|         in_end: int = sys.maxsize
+//|     ) -> None:
 //|         """Write out the data in ``out_buffer`` while simultaneously reading data into ``in_buffer``.
 //|         The SPI object must be locked.
 //|
@@ -303,7 +317,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_spi_readinto_obj, 1, bitbangio_spi_readinto
 //|         :param int in_end: end of ``in_buffer slice``; if not specified, use ``len(in_buffer)``
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t bitbangio_spi_write_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_out_buffer, ARG_in_buffer, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/bitbangio/__init__.c
+++ b/shared-bindings/bitbangio/__init__.c
@@ -66,7 +66,6 @@
 //| :py:meth:`~bitbangio.I2C.scan` and then :py:meth:`~bitbangio.I2C.deinit` the
 //| hardware. The last step is optional because CircuitPython automatically
 //| resets hardware after a program finishes."""
-//|
 
 STATIC const mp_rom_map_elem_t bitbangio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_bitbangio) },

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -50,7 +50,6 @@
 //|     <https://learn.adafruit.com/circuitpython-display-support-using-displayio>`_
 //|     for information about using the :py:mod:`displayio` module.
 //| """
-//|
 
 STATIC int16_t validate_point(mp_obj_t point, int16_t default_value) {
     // Checks if point is None and returns default_value, otherwise decodes integer value
@@ -126,46 +125,54 @@ STATIC void validate_clip_region(displayio_bitmap_t *bitmap, mp_obj_t clip0_tupl
 
 }
 
-//|
 //| def rotozoom(
-//|        dest_bitmap: displayio.Bitmap, source_bitmap: displayio.Bitmap,
-//|        *,
-//|        ox: int, oy: int, dest_clip0: Tuple[int, int], dest_clip1: Tuple[int, int],
-//|        px: int, py: int, source_clip0: Tuple[int, int], source_clip1: Tuple[int, int],
-//|        angle: float, scale: float, skip_index: int) -> None:
-//|      """Inserts the source bitmap region into the destination bitmap with rotation
-//|      (angle), scale and clipping (both on source and destination bitmaps).
+//|     dest_bitmap: displayio.Bitmap,
+//|     source_bitmap: displayio.Bitmap,
+//|     *,
+//|     ox: int,
+//|     oy: int,
+//|     dest_clip0: Tuple[int, int],
+//|     dest_clip1: Tuple[int, int],
+//|     px: int,
+//|     py: int,
+//|     source_clip0: Tuple[int, int],
+//|     source_clip1: Tuple[int, int],
+//|     angle: float,
+//|     scale: float,
+//|     skip_index: int
+//| ) -> None:
+//|     """Inserts the source bitmap region into the destination bitmap with rotation
+//|     (angle), scale and clipping (both on source and destination bitmaps).
 //|
-//|      :param bitmap dest_bitmap: Destination bitmap that will be copied into
-//|      :param bitmap source_bitmap: Source bitmap that contains the graphical region to be copied
-//|      :param int ox: Horizontal pixel location in destination bitmap where source bitmap
-//|             point (px,py) is placed. Defaults to None which causes it to use the horizontal
-//|             midway point of the destination bitmap.
-//|      :param int oy: Vertical pixel location in destination bitmap where source bitmap
-//|             point (px,py) is placed. Defaults to None which causes it to use the vertical
-//|             midway point of the destination bitmap.
-//|      :param Tuple[int,int] dest_clip0: First corner of rectangular destination clipping
-//|             region that constrains region of writing into destination bitmap
-//|      :param Tuple[int,int] dest_clip1: Second corner of rectangular destination clipping
-//|             region that constrains region of writing into destination bitmap
-//|      :param int px: Horizontal pixel location in source bitmap that is placed into the
-//|             destination bitmap at (ox,oy). Defaults to None which causes it to use the
-//|             horizontal midway point in the source bitmap.
-//|      :param int py: Vertical pixel location in source bitmap that is placed into the
-//|             destination bitmap at (ox,oy). Defaults to None which causes it to use the
-//|             vertical midway point in the source bitmap.
-//|      :param Tuple[int,int] source_clip0: First corner of rectangular source clipping
-//|             region that constrains region of reading from the source bitmap
-//|      :param Tuple[int,int] source_clip1: Second corner of rectangular source clipping
-//|             region that constrains region of reading from the source bitmap
-//|      :param float angle: Angle of rotation, in radians (positive is clockwise direction).
-//|             Defaults to None which gets treated as 0.0 radians or no rotation.
-//|      :param float scale: Scaling factor. Defaults to None which gets treated as 1.0 or same
-//|             as original source size.
-//|      :param int skip_index: Bitmap palette index in the source that will not be copied,
-//|             set to None to copy all pixels"""
-//|      ...
-//|
+//|     :param bitmap dest_bitmap: Destination bitmap that will be copied into
+//|     :param bitmap source_bitmap: Source bitmap that contains the graphical region to be copied
+//|     :param int ox: Horizontal pixel location in destination bitmap where source bitmap
+//|            point (px,py) is placed. Defaults to None which causes it to use the horizontal
+//|            midway point of the destination bitmap.
+//|     :param int oy: Vertical pixel location in destination bitmap where source bitmap
+//|            point (px,py) is placed. Defaults to None which causes it to use the vertical
+//|            midway point of the destination bitmap.
+//|     :param Tuple[int,int] dest_clip0: First corner of rectangular destination clipping
+//|            region that constrains region of writing into destination bitmap
+//|     :param Tuple[int,int] dest_clip1: Second corner of rectangular destination clipping
+//|            region that constrains region of writing into destination bitmap
+//|     :param int px: Horizontal pixel location in source bitmap that is placed into the
+//|            destination bitmap at (ox,oy). Defaults to None which causes it to use the
+//|            horizontal midway point in the source bitmap.
+//|     :param int py: Vertical pixel location in source bitmap that is placed into the
+//|            destination bitmap at (ox,oy). Defaults to None which causes it to use the
+//|            vertical midway point in the source bitmap.
+//|     :param Tuple[int,int] source_clip0: First corner of rectangular source clipping
+//|            region that constrains region of reading from the source bitmap
+//|     :param Tuple[int,int] source_clip1: Second corner of rectangular source clipping
+//|            region that constrains region of reading from the source bitmap
+//|     :param float angle: Angle of rotation, in radians (positive is clockwise direction).
+//|            Defaults to None which gets treated as 0.0 radians or no rotation.
+//|     :param float scale: Scaling factor. Defaults to None which gets treated as 1.0 or same
+//|            as original source size.
+//|     :param int skip_index: Bitmap palette index in the source that will not be copied,
+//|            set to None to copy all pixels"""
+//|     ...
 STATIC mp_obj_t bitmaptools_obj_rotozoom(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_dest_bitmap, ARG_source_bitmap,
           ARG_ox, ARG_oy, ARG_dest_clip0, ARG_dest_clip1,
@@ -266,8 +273,14 @@ STATIC mp_obj_t bitmaptools_obj_rotozoom(size_t n_args, const mp_obj_t *pos_args
 MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_rotozoom_obj, 0, bitmaptools_obj_rotozoom);
 // requires at least 2 arguments (destination bitmap and source bitmap)
 
-//|
-//| def alphablend(dest_bitmap: displayio.Bitmap , source_bitmap_1: displayio.Bitmap, source_bitmap_2: displayio.Bitmap, colorspace: displayio.Colorspace, factor1: float=.5, factor2: Optional[float]=None) -> None:
+//| def alphablend(
+//|     dest_bitmap: displayio.Bitmap,
+//|     source_bitmap_1: displayio.Bitmap,
+//|     source_bitmap_2: displayio.Bitmap,
+//|     colorspace: displayio.Colorspace,
+//|     factor1: float = 0.5,
+//|     factor2: Optional[float] = None,
+//| ) -> None:
 //|     """Alpha blend the two source bitmaps into the destination.
 //|
 //|     It is permitted for the destination bitmap to be one of the two
@@ -282,7 +295,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_rotozoom_obj, 0, bitmaptools_obj_rotozoom
 //|
 //|     For the L8 colorspace, the bitmaps must have a bits-per-value of 8.
 //|     For the RGB colorspaces, they must have a bits-per-value of 16."""
-//|
 
 STATIC mp_obj_t bitmaptools_alphablend(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_dest_bitmap, ARG_source_bitmap_1, ARG_source_bitmap_2, ARG_colorspace, ARG_factor_1, ARG_factor_2};
@@ -343,24 +355,20 @@ STATIC mp_obj_t bitmaptools_alphablend(size_t n_args, const mp_obj_t *pos_args, 
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_alphablend_obj, 0, bitmaptools_alphablend);
 
-//|
 //| def fill_region(
-//|        dest_bitmap: displayio.Bitmap,
-//|        x1: int, y1: int,
-//|        x2: int, y2: int,
-//|        value: int) -> None:
-//|      """Draws the color value into the destination bitmap within the
-//|      rectangular region bounded by (x1,y1) and (x2,y2), exclusive.
+//|     dest_bitmap: displayio.Bitmap, x1: int, y1: int, x2: int, y2: int, value: int
+//| ) -> None:
+//|     """Draws the color value into the destination bitmap within the
+//|     rectangular region bounded by (x1,y1) and (x2,y2), exclusive.
 //|
-//|      :param bitmap dest_bitmap: Destination bitmap that will be written into
-//|      :param int x1: x-pixel position of the first corner of the rectangular fill region
-//|      :param int y1: y-pixel position of the first corner of the rectangular fill region
-//|      :param int x2: x-pixel position of the second corner of the rectangular fill region (exclusive)
-//|      :param int y2: y-pixel position of the second corner of the rectangular fill region (exclusive)
-//|      :param int value: Bitmap palette index that will be written into the rectangular
-//|             fill region in the destination bitmap"""
-//|      ...
-//|
+//|     :param bitmap dest_bitmap: Destination bitmap that will be written into
+//|     :param int x1: x-pixel position of the first corner of the rectangular fill region
+//|     :param int y1: y-pixel position of the first corner of the rectangular fill region
+//|     :param int x2: x-pixel position of the second corner of the rectangular fill region (exclusive)
+//|     :param int y2: y-pixel position of the second corner of the rectangular fill region (exclusive)
+//|     :param int value: Bitmap palette index that will be written into the rectangular
+//|            fill region in the destination bitmap"""
+//|     ...
 STATIC mp_obj_t bitmaptools_obj_fill_region(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_dest_bitmap, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_value};
 
@@ -395,24 +403,25 @@ STATIC mp_obj_t bitmaptools_obj_fill_region(size_t n_args, const mp_obj_t *pos_a
 }
 
 MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_fill_region_obj, 0, bitmaptools_obj_fill_region);
-//|
 //| def boundary_fill(
-//|        dest_bitmap: displayio.Bitmap,
-//|        x: int, y: int,
-//|        fill_color_value: int, replaced_color_value: int) -> None:
-//|      """Draws the color value into the destination bitmap enclosed
-//|      area of pixels of the background_value color. Like "Paint Bucket"
-//|      fill tool.
+//|     dest_bitmap: displayio.Bitmap,
+//|     x: int,
+//|     y: int,
+//|     fill_color_value: int,
+//|     replaced_color_value: int,
+//| ) -> None:
+//|     """Draws the color value into the destination bitmap enclosed
+//|     area of pixels of the background_value color. Like "Paint Bucket"
+//|     fill tool.
 //|
-//|      :param bitmap dest_bitmap: Destination bitmap that will be written into
-//|      :param int x: x-pixel position of the first pixel to check and fill if needed
-//|      :param int y: y-pixel position of the first pixel to check and fill if needed
-//|      :param int fill_color_value: Bitmap palette index that will be written into the
-//|             enclosed area in the destination bitmap
-//|      :param int replaced_color_value: Bitmap palette index that will filled with the
-//|             value color in the enclosed area in the destination bitmap"""
-//|      ...
-//|
+//|     :param bitmap dest_bitmap: Destination bitmap that will be written into
+//|     :param int x: x-pixel position of the first pixel to check and fill if needed
+//|     :param int y: y-pixel position of the first pixel to check and fill if needed
+//|     :param int fill_color_value: Bitmap palette index that will be written into the
+//|            enclosed area in the destination bitmap
+//|     :param int replaced_color_value: Bitmap palette index that will filled with the
+//|            value color in the enclosed area in the destination bitmap"""
+//|     ...
 STATIC mp_obj_t bitmaptools_obj_boundary_fill(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_dest_bitmap, ARG_x, ARG_y, ARG_fill_color_value, ARG_replaced_color_value};
 
@@ -459,23 +468,19 @@ STATIC mp_obj_t bitmaptools_obj_boundary_fill(size_t n_args, const mp_obj_t *pos
 MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_boundary_fill_obj, 0, bitmaptools_obj_boundary_fill);
 // requires all 6 arguments
 
-//|
 //| def draw_line(
-//|        dest_bitmap: displayio.Bitmap,
-//|        x1: int, y1: int,
-//|        x2: int, y2: int,
-//|        value: int) -> None:
-//|      """Draws a line into a bitmap specified two endpoints (x1,y1) and (x2,y2).
+//|     dest_bitmap: displayio.Bitmap, x1: int, y1: int, x2: int, y2: int, value: int
+//| ) -> None:
+//|     """Draws a line into a bitmap specified two endpoints (x1,y1) and (x2,y2).
 //|
-//|      :param bitmap dest_bitmap: Destination bitmap that will be written into
-//|      :param int x1: x-pixel position of the line's first endpoint
-//|      :param int y1: y-pixel position of the line's first endpoint
-//|      :param int x2: x-pixel position of the line's second endpoint
-//|      :param int y2: y-pixel position of the line's second endpoint
-//|      :param int value: Bitmap palette index that will be written into the
-//|             line in the destination bitmap"""
-//|      ...
-//|
+//|     :param bitmap dest_bitmap: Destination bitmap that will be written into
+//|     :param int x1: x-pixel position of the line's first endpoint
+//|     :param int y1: y-pixel position of the line's first endpoint
+//|     :param int x2: x-pixel position of the line's second endpoint
+//|     :param int y2: y-pixel position of the line's second endpoint
+//|     :param int value: Bitmap palette index that will be written into the
+//|            line in the destination bitmap"""
+//|     ...
 STATIC mp_obj_t bitmaptools_obj_draw_line(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_dest_bitmap, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_value};
 
@@ -519,7 +524,15 @@ STATIC mp_obj_t bitmaptools_obj_draw_line(size_t n_args, const mp_obj_t *pos_arg
 MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_draw_line_obj, 0, bitmaptools_obj_draw_line);
 // requires all 6 arguments
 
-//| def arrayblit(bitmap: displayio.Bitmap, data: ReadableBuffer, x1: int=0, y1: int=0, x2: Optional[int]=None, y2: Optional[int]=None, skip_index:Optional[int]=None) -> None:
+//| def arrayblit(
+//|     bitmap: displayio.Bitmap,
+//|     data: ReadableBuffer,
+//|     x1: int = 0,
+//|     y1: int = 0,
+//|     x2: Optional[int] = None,
+//|     y2: Optional[int] = None,
+//|     skip_index: Optional[int] = None,
+//| ) -> None:
 //|     """Inserts pixels from ``data`` into the rectangle of width×height pixels with the upper left corner at ``(x,y)``
 //|
 //|     The values from ``data`` are taken modulo the number of color values
@@ -547,7 +560,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_draw_line_obj, 0, bitmaptools_obj_draw_li
 //|             set to None to copy all pixels
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t bitmaptools_arrayblit(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bitmap, ARG_data, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_skip_index };
     static const mp_arg_t allowed_args[] = {
@@ -593,7 +605,15 @@ STATIC mp_obj_t bitmaptools_arrayblit(size_t n_args, const mp_obj_t *pos_args, m
 MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_arrayblit_obj, 0, bitmaptools_arrayblit);
 
 
-//| def readinto(bitmap: displayio.Bitmap, file: typing.BinaryIO, bits_per_pixel: int, element_size: int = 1, reverse_pixels_in_element: bool = False, swap_bytes_in_element: bool = False, reverse_rows: bool = False) -> None:
+//| def readinto(
+//|     bitmap: displayio.Bitmap,
+//|     file: typing.BinaryIO,
+//|     bits_per_pixel: int,
+//|     element_size: int = 1,
+//|     reverse_pixels_in_element: bool = False,
+//|     swap_bytes_in_element: bool = False,
+//|     reverse_rows: bool = False,
+//| ) -> None:
 //|     """Reads from a binary file into a bitmap.
 //|
 //|     The file must be positioned so that it consists of ``bitmap.height`` rows of pixel data, where each row is the smallest multiple of ``element_size`` bytes that can hold ``bitmap.width`` pixels.
@@ -612,7 +632,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_arrayblit_obj, 0, bitmaptools_arrayblit);
 //|     :param bool reverse_rows: Reverse the direction of the row loading (required for some bitmap images).
 //|     """
 //|     ...
-//|
 
 STATIC mp_obj_t bitmaptools_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bitmap, ARG_file, ARG_bits_per_pixel, ARG_element_size, ARG_reverse_pixels_in_element, ARG_swap_bytes_in_element, ARG_reverse_rows };
@@ -674,7 +693,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_readinto_obj, 0, bitmaptools_readinto);
 //|
 //|     FloydStenberg: "DitherAlgorithm"
 //|     """The Floyd-Stenberg dither"""
-//|
 MAKE_ENUM_VALUE(bitmaptools_dither_algorithm_type, dither_algorithm, Atkinson, DITHER_ALGORITHM_ATKINSON);
 MAKE_ENUM_VALUE(bitmaptools_dither_algorithm_type, dither_algorithm, FloydStenberg, DITHER_ALGORITHM_FLOYD_STENBERG);
 
@@ -688,7 +706,12 @@ MAKE_PRINTER(bitmaptools, bitmaptools_dither_algorithm);
 
 MAKE_ENUM_TYPE(bitmaptools, DitherAlgorithm, bitmaptools_dither_algorithm);
 
-//| def dither(dest_bitmap: displayio.Bitmap, source_bitmapp: displayio.Bitmap, source_colorspace: displayio.Colorspace, algorithm: DitherAlgorithm=DitherAlgorithm.Atkinson) -> None:
+//| def dither(
+//|     dest_bitmap: displayio.Bitmap,
+//|     source_bitmapp: displayio.Bitmap,
+//|     source_colorspace: displayio.Colorspace,
+//|     algorithm: DitherAlgorithm = DitherAlgorithm.Atkinson,
+//| ) -> None:
 //|     """Convert the input image into a 2-level output image using the given dither algorithm.
 //|
 //|     :param bitmap dest_bitmap: Destination bitmap.  It must have a value_count of 2 or 65536.  The stored values are 0 and the maximum pixel value.
@@ -697,7 +720,6 @@ MAKE_ENUM_TYPE(bitmaptools, DitherAlgorithm, bitmaptools_dither_algorithm);
 //|     :param algorithm: The dither algorithm to use, one of the `DitherAlgorithm` values.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t bitmaptools_dither(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_dest_bitmap, ARG_source_bitmap, ARG_source_colorspace, ARG_algorithm };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/bitops/__init__.c
+++ b/shared-bindings/bitops/__init__.c
@@ -30,11 +30,11 @@
 #include "shared-bindings/bitops/__init__.h"
 
 //| """Routines for low-level manipulation of binary data"""
-//|
-//|
 
-//| def bit_transpose(input: ReadableBuffer, output: WriteableBuffer, width:int = 8) -> WriteableBuffer:
-//|     """"Transpose" a buffer by assembling each output byte with bits taken from each of ``width`` different input bytes.
+//| def bit_transpose(
+//|     input: ReadableBuffer, output: WriteableBuffer, width: int = 8
+//| ) -> WriteableBuffer:
+//|     """ "Transpose" a buffer by assembling each output byte with bits taken from each of ``width`` different input bytes.
 //|
 //|     This can be useful to convert a sequence of pixel values into a single
 //|     stream of bytes suitable for sending via a parallel conversion method.

--- a/shared-bindings/board/__init__.c
+++ b/shared-bindings/board/__init__.c
@@ -63,7 +63,6 @@
 //|     """Returns the `busio.I2C` object for the board's designated I2C bus(es).
 //|     The object created is a singleton, and uses the default parameter values for `busio.I2C`."""
 //|     ...
-//|
 #if CIRCUITPY_BOARD_I2C
 STATIC mp_obj_t board_i2c_0(void) {
     return common_hal_board_create_i2c(0);
@@ -80,7 +79,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(board_i2c_obj, board_i2c_0);
 //|     """Returns the `busio.SPI` object for the board's designated SPI bus(es).
 //|     The object created is a singleton, and uses the default parameter values for `busio.SPI`."""
 //|     ...
-//|
 #if CIRCUITPY_BOARD_SPI
 STATIC mp_obj_t board_spi_0(void) {
     return common_hal_board_create_spi(0);
@@ -97,7 +95,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(board_spi_obj, board_spi_0);
 //|     """Returns the `busio.UART` object for the board's designated UART bus(es).
 //|     The object created is a singleton, and uses the default parameter values for `busio.UART`."""
 //|     ...
-//|
 #if CIRCUITPY_BOARD_UART
 STATIC mp_obj_t board_uart_0(void) {
     return common_hal_board_create_uart(0);

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -39,7 +39,14 @@
 //| class I2C:
 //|     """Two wire serial protocol"""
 //|
-//|     def __init__(self, scl: microcontroller.Pin, sda: microcontroller.Pin, *, frequency: int = 100000, timeout: int = 255) -> None:
+//|     def __init__(
+//|         self,
+//|         scl: microcontroller.Pin,
+//|         sda: microcontroller.Pin,
+//|         *,
+//|         frequency: int = 100000,
+//|         timeout: int = 255
+//|     ) -> None:
 //|
 //|         """I2C is a two-wire protocol for communicating between devices.  At the
 //|         physical level it consists of 2 wires: SCL and SDA, the clock and data
@@ -60,7 +67,6 @@
 //|             :class:`bitbangio.I2C`; ignored for :class:`busio.I2C`)
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t busio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     busio_i2c_obj_t *self = m_new_obj(busio_i2c_obj_t);
     self->base.type = &busio_i2c_type;
@@ -84,7 +90,6 @@ STATIC mp_obj_t busio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
 //|     def deinit(self) -> None:
 //|         """Releases control of the underlying hardware so other classes can use it."""
 //|         ...
-//|
 STATIC mp_obj_t busio_i2c_obj_deinit(mp_obj_t self_in) {
     busio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_busio_i2c_deinit(self);
@@ -101,14 +106,12 @@ STATIC void check_for_deinit(busio_i2c_obj_t *self) {
 //|     def __enter__(self) -> I2C:
 //|         """No-op used in Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware on context exit. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t busio_i2c_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_busio_i2c_deinit(MP_OBJ_TO_PTR(args[0]));
@@ -130,7 +133,6 @@ static void check_lock(busio_i2c_obj_t *self) {
 //|         :return: List of device ids on the I2C bus
 //|         :rtype: list"""
 //|         ...
-//|
 STATIC mp_obj_t busio_i2c_scan(mp_obj_t self_in) {
     busio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -153,7 +155,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_i2c_scan_obj, busio_i2c_scan);
 //|         :return: True when lock has been grabbed
 //|         :rtype: bool"""
 //|         ...
-//|
 STATIC mp_obj_t busio_i2c_obj_try_lock(mp_obj_t self_in) {
     busio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -164,7 +165,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_i2c_try_lock_obj, busio_i2c_obj_try_lock);
 //|     def unlock(self) -> None:
 //|         """Releases the I2C lock."""
 //|         ...
-//|
 STATIC mp_obj_t busio_i2c_obj_unlock(mp_obj_t self_in) {
     busio_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -174,7 +174,9 @@ STATIC mp_obj_t busio_i2c_obj_unlock(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(busio_i2c_unlock_obj, busio_i2c_obj_unlock);
 
 //|     import sys
-//|     def readfrom_into(self, address: int, buffer: WriteableBuffer, *, start: int = 0, end: int = sys.maxsize) -> None:
+//|     def readfrom_into(
+//|         self, address: int, buffer: WriteableBuffer, *, start: int = 0, end: int = sys.maxsize
+//|     ) -> None:
 //|         """Read into ``buffer`` from the device selected by ``address``.
 //|         At least one byte must be read.
 //|
@@ -187,7 +189,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_i2c_unlock_obj, busio_i2c_obj_unlock);
 //|         :param int start: beginning of buffer slice
 //|         :param int end: end of buffer slice; if not specified, use ``len(buffer)``"""
 //|         ...
-//|
 STATIC mp_obj_t busio_i2c_readfrom_into(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_address, ARG_buffer, ARG_start, ARG_end };
     static const mp_arg_t allowed_args[] = {
@@ -223,7 +224,9 @@ STATIC mp_obj_t busio_i2c_readfrom_into(size_t n_args, const mp_obj_t *pos_args,
 MP_DEFINE_CONST_FUN_OBJ_KW(busio_i2c_readfrom_into_obj, 1, busio_i2c_readfrom_into);
 
 //|     import sys
-//|     def writeto(self, address: int, buffer: ReadableBuffer, *, start: int = 0, end: int = sys.maxsize) -> None:
+//|     def writeto(
+//|         self, address: int, buffer: ReadableBuffer, *, start: int = 0, end: int = sys.maxsize
+//|     ) -> None:
 //|         """Write the bytes from ``buffer`` to the device selected by ``address`` and
 //|         then transmit a stop bit.
 //|
@@ -240,7 +243,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_i2c_readfrom_into_obj, 1, busio_i2c_readfrom_in
 //|         :param int end: end of buffer slice; if not specified, use ``len(buffer)``
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t busio_i2c_writeto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_address, ARG_buffer, ARG_start, ARG_end };
     static const mp_arg_t allowed_args[] = {
@@ -277,7 +279,17 @@ STATIC mp_obj_t busio_i2c_writeto(size_t n_args, const mp_obj_t *pos_args, mp_ma
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(busio_i2c_writeto_obj, 1, busio_i2c_writeto);
 
 //|     import sys
-//|     def writeto_then_readfrom(self, address: int, out_buffer: ReadableBuffer, in_buffer: WriteableBuffer, *, out_start: int = 0, out_end: int = sys.maxsize, in_start: int = 0, in_end: int = sys.maxsize) -> None:
+//|     def writeto_then_readfrom(
+//|         self,
+//|         address: int,
+//|         out_buffer: ReadableBuffer,
+//|         in_buffer: WriteableBuffer,
+//|         *,
+//|         out_start: int = 0,
+//|         out_end: int = sys.maxsize,
+//|         in_start: int = 0,
+//|         in_end: int = sys.maxsize
+//|     ) -> None:
 //|         """Write the bytes from ``out_buffer`` to the device selected by ``address``, generate no stop
 //|         bit, generate a repeated start and read into ``in_buffer``. ``out_buffer`` and
 //|         ``in_buffer`` can be the same buffer because they are used sequentially.
@@ -299,7 +311,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(busio_i2c_writeto_obj, 1, busio_i2c_writeto);
 //|         :param int in_end: end of ``in_buffer slice``; if not specified, use ``len(in_buffer)``
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t busio_i2c_writeto_then_readfrom(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_address, ARG_out_buffer, ARG_in_buffer, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -289,7 +289,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(busio_i2c_writeto_obj, 1, busio_i2c_writeto);
 //|         If ``in_start`` or ``in_end`` is provided, then the input buffer will be sliced
 //|         as if ``in_buffer[in_start:in_end]`` were passed,
 //|         The number of bytes read will be the length of ``out_buffer[in_start:in_end]``.
-
+//|
 //|         :param int address: 7-bit device address
 //|         :param ~circuitpython_typing.ReadableBuffer out_buffer: buffer containing the bytes to write
 //|         :param ~circuitpython_typing.WriteableBuffer in_buffer: buffer to write into

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -53,7 +53,13 @@
 //|     multiple secondaries can share the `!clock`, `!MOSI` and `!MISO` lines
 //|     and therefore the hardware.)"""
 //|
-//|     def __init__(self, clock: microcontroller.Pin, MOSI: Optional[microcontroller.Pin] = None, MISO: Optional[microcontroller.Pin] = None, half_duplex: bool = False) -> None:
+//|     def __init__(
+//|         self,
+//|         clock: microcontroller.Pin,
+//|         MOSI: Optional[microcontroller.Pin] = None,
+//|         MISO: Optional[microcontroller.Pin] = None,
+//|         half_duplex: bool = False,
+//|     ) -> None:
 //|
 //|         """Construct an SPI object on the given pins.
 //|
@@ -77,7 +83,6 @@
 //|         :param ~microcontroller.Pin MISO: the Main In Selected Out pin.
 //|         :param bool half_duplex: True when MOSI is used for bidirectional data. False when SPI is full-duplex or simplex."""
 //|         ...
-//|
 
 
 // TODO(tannewt): Support LSB SPI.
@@ -114,7 +119,6 @@ STATIC mp_obj_t busio_spi_make_new(const mp_obj_type_t *type, size_t n_args, siz
 //|     def deinit(self) -> None:
 //|         """Turn off the SPI bus."""
 //|         ...
-//|
 STATIC mp_obj_t busio_spi_obj_deinit(mp_obj_t self_in) {
     busio_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_busio_spi_deinit(self);
@@ -126,13 +130,11 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_spi_deinit_obj, busio_spi_obj_deinit);
 //|         """No-op used by Context Managers.
 //|         Provided by context manager helper."""
 //|         ...
-//|
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t busio_spi_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_busio_spi_deinit(MP_OBJ_TO_PTR(args[0]));
@@ -153,7 +155,9 @@ STATIC void check_for_deinit(busio_spi_obj_t *self) {
     }
 }
 
-//|     def configure(self, *, baudrate: int = 100000, polarity: int = 0, phase: int = 0, bits: int = 8) -> None:
+//|     def configure(
+//|         self, *, baudrate: int = 100000, polarity: int = 0, phase: int = 0, bits: int = 8
+//|     ) -> None:
 //|         """Configures the SPI bus. The SPI object must be locked.
 //|
 //|         :param int baudrate: the desired clock rate in Hertz. The actual clock rate may be higher or lower
@@ -175,7 +179,6 @@ STATIC void check_for_deinit(busio_spi_obj_t *self) {
 //|           Two SPI objects may be created, except on the Circuit Playground Bluefruit,
 //|           which allows only one (to allow for an additional I2C object)."""
 //|         ...
-//|
 
 STATIC mp_obj_t busio_spi_configure(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits };
@@ -209,7 +212,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_configure_obj, 1, busio_spi_configure);
 //|         :return: True when lock has been grabbed
 //|         :rtype: bool"""
 //|         ...
-//|
 
 STATIC mp_obj_t busio_spi_obj_try_lock(mp_obj_t self_in) {
     busio_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -220,7 +222,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_spi_try_lock_obj, busio_spi_obj_try_lock);
 //|     def unlock(self) -> None:
 //|         """Releases the SPI lock."""
 //|         ...
-//|
 
 STATIC mp_obj_t busio_spi_obj_unlock(mp_obj_t self_in) {
     busio_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -244,7 +245,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(busio_spi_unlock_obj, busio_spi_obj_unlock);
 //|         :param int end: end of buffer slice; if not specified, use ``len(buffer)``
 //|         """
 //|         ...
-//|
 
 STATIC mp_obj_t busio_spi_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_start, ARG_end };
@@ -279,7 +279,14 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_write_obj, 1, busio_spi_write);
 
 
 //|     import sys
-//|     def readinto(self, buffer: WriteableBuffer, *, start: int = 0, end: int = sys.maxsize, write_value: int = 0) -> None:
+//|     def readinto(
+//|         self,
+//|         buffer: WriteableBuffer,
+//|         *,
+//|         start: int = 0,
+//|         end: int = sys.maxsize,
+//|         write_value: int = 0
+//|     ) -> None:
 //|         """Read into ``buffer`` while writing ``write_value`` for each byte read.
 //|         The SPI object must be locked.
 //|         If the number of bytes to read is 0, nothing happens.
@@ -296,7 +303,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_write_obj, 1, busio_spi_write);
 //|         :param int write_value: value to write while reading
 //|         """
 //|         ...
-//|
 
 STATIC mp_obj_t busio_spi_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_start, ARG_end, ARG_write_value };
@@ -331,7 +337,16 @@ STATIC mp_obj_t busio_spi_readinto(size_t n_args, const mp_obj_t *pos_args, mp_m
 MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_readinto_obj, 1, busio_spi_readinto);
 
 //|     import sys
-//|     def write_readinto(self, out_buffer: ReadableBuffer, in_buffer: WriteableBuffer, *, out_start: int = 0, out_end: int = sys.maxsize, in_start: int = 0, in_end: int = sys.maxsize) -> None:
+//|     def write_readinto(
+//|         self,
+//|         out_buffer: ReadableBuffer,
+//|         in_buffer: WriteableBuffer,
+//|         *,
+//|         out_start: int = 0,
+//|         out_end: int = sys.maxsize,
+//|         in_start: int = 0,
+//|         in_end: int = sys.maxsize
+//|     ) -> None:
 //|         """Write out the data in ``out_buffer`` while simultaneously reading data into ``in_buffer``.
 //|         The SPI object must be locked.
 //|
@@ -355,7 +370,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_readinto_obj, 1, busio_spi_readinto);
 //|         :param int in_end: end of ``in_buffer slice``; if not specified, use ``len(in_buffer)``
 //|         """
 //|         ...
-//|
 
 STATIC mp_obj_t busio_spi_write_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_out_buffer, ARG_in_buffer, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end };
@@ -407,7 +421,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_write_readinto_obj, 1, busio_spi_write_read
 //|     frequency: int
 //|     """The actual SPI bus frequency. This may not match the frequency requested
 //|     due to internal limitations."""
-//|
 
 STATIC mp_obj_t busio_spi_obj_get_frequency(mp_obj_t self_in) {
     busio_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -45,7 +45,19 @@
 
 //| class UART:
 //|     """A bidirectional serial protocol"""
-//|     def __init__(self, tx: microcontroller.Pin, rx: microcontroller.Pin, *, baudrate: int = 9600, bits: int = 8, parity: Optional[Parity] = None, stop: int = 1, timeout: float = 1, receiver_buffer_size: int = 64) -> None:
+//|
+//|     def __init__(
+//|         self,
+//|         tx: microcontroller.Pin,
+//|         rx: microcontroller.Pin,
+//|         *,
+//|         baudrate: int = 9600,
+//|         bits: int = 8,
+//|         parity: Optional[Parity] = None,
+//|         stop: int = 1,
+//|         timeout: float = 1,
+//|         receiver_buffer_size: int = 64
+//|     ) -> None:
 //|         """A common bidirectional serial protocol that uses an an agreed upon speed
 //|         rather than a shared clock line.
 //|
@@ -70,7 +82,6 @@
 //|            RS485 specifications intermittently.
 //|         """
 //|         ...
-//|
 typedef struct {
     mp_obj_base_t base;
 } busio_uart_parity_obj_t;
@@ -165,7 +176,6 @@ STATIC busio_uart_obj_t *native_uart(mp_obj_t uart_obj) {
 //|     def deinit(self) -> None:
 //|         """Deinitialises the UART and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t busio_uart_obj_deinit(mp_obj_t self_in) {
     busio_uart_obj_t *self = native_uart(self_in);
     common_hal_busio_uart_deinit(self);
@@ -182,14 +192,12 @@ STATIC void check_for_deinit(busio_uart_obj_t *self) {
 //|     def __enter__(self) -> UART:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t busio_uart_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_busio_uart_deinit(MP_OBJ_TO_PTR(args[0]));
@@ -212,7 +220,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_uart___exit___obj, 4, 4, busio_
 //|         :return: Data read
 //|         :rtype: bytes or None"""
 //|         ...
-//|
 
 //|     def readinto(self, buf: WriteableBuffer) -> Optional[int]:
 //|         """Read bytes into the ``buf``. Read at most ``len(buf)`` bytes.
@@ -222,7 +229,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_uart___exit___obj, 4, 4, busio_
 //|
 //|         *New in CircuitPython 4.0:* No length parameter is permitted."""
 //|         ...
-//|
 
 //|     def readline(self) -> bytes:
 //|         """Read a line, ending in a newline character, or
@@ -233,17 +239,15 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(busio_uart___exit___obj, 4, 4, busio_
 //|         :return: the line read
 //|         :rtype: bytes or None"""
 //|         ...
-//|
 
 //|     def write(self, buf: ReadableBuffer) -> Optional[int]:
 //|         """Write the buffer of bytes to the bus.
 //|
-//|       *New in CircuitPython 4.0:* ``buf`` must be bytes, not a string.
+//|         *New in CircuitPython 4.0:* ``buf`` must be bytes, not a string.
 //|
-//|         :return: the number of bytes written
-//|         :rtype: int or None"""
+//|           :return: the number of bytes written
+//|           :rtype: int or None"""
 //|         ...
-//|
 
 // These three methods are used by the shared stream methods.
 STATIC mp_uint_t busio_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
@@ -290,7 +294,6 @@ STATIC mp_uint_t busio_uart_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_t
 
 //|     baudrate: int
 //|     """The current baudrate."""
-//|
 STATIC mp_obj_t busio_uart_obj_get_baudrate(mp_obj_t self_in) {
     busio_uart_obj_t *self = native_uart(self_in);
     check_for_deinit(self);
@@ -313,7 +316,6 @@ MP_PROPERTY_GETSET(busio_uart_baudrate_obj,
 
 //|     in_waiting: int
 //|     """The number of bytes in the input buffer, available to be read"""
-//|
 STATIC mp_obj_t busio_uart_obj_get_in_waiting(mp_obj_t self_in) {
     busio_uart_obj_t *self = native_uart(self_in);
     check_for_deinit(self);
@@ -326,7 +328,6 @@ MP_PROPERTY_GETTER(busio_uart_in_waiting_obj,
 
 //|     timeout: float
 //|     """The current timeout, in seconds (float)."""
-//|
 STATIC mp_obj_t busio_uart_obj_get_timeout(mp_obj_t self_in) {
     busio_uart_obj_t *self = native_uart(self_in);
     check_for_deinit(self);
@@ -352,7 +353,6 @@ MP_PROPERTY_GETSET(busio_uart_timeout_obj,
 //|     def reset_input_buffer(self) -> None:
 //|         """Discard any unread characters in the input buffer."""
 //|         ...
-//|
 STATIC mp_obj_t busio_uart_obj_reset_input_buffer(mp_obj_t self_in) {
     busio_uart_obj_t *self = native_uart(self_in);
     check_for_deinit(self);
@@ -370,7 +370,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(busio_uart_reset_input_buffer_obj, busio_uart_o
 //|
 //|     EVEN: int
 //|     """Total number of ones should be even."""
-//|
 const mp_obj_type_t busio_uart_parity_type;
 
 const busio_uart_parity_obj_t busio_uart_parity_odd_obj = {

--- a/shared-bindings/busio/__init__.c
+++ b/shared-bindings/busio/__init__.c
@@ -78,7 +78,6 @@
 //| Tutorial for UART:
 //| https://learn.adafruit.com/circuitpython-essentials/circuitpython-uart-serial
 //| """
-//|
 
 STATIC const mp_rom_map_elem_t busio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_busio) },

--- a/shared-bindings/camera/Camera.c
+++ b/shared-bindings/camera/Camera.c
@@ -55,12 +55,10 @@
 //|         size = cam.take_picture(buffer, width=1920, height=1080, format=camera.ImageFormat.JPG)
 //|         file.write(buffer, size)
 //|         file.close()"""
-//|
 
 //|     def __init__(self) -> None:
 //|         """Initialize camera."""
 //|         ...
-//|
 STATIC mp_obj_t camera_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     camera_obj_t *self = m_new_obj(camera_obj_t);
     self->base.type = &camera_type;
@@ -74,7 +72,6 @@ STATIC mp_obj_t camera_make_new(const mp_obj_type_t *type, size_t n_args, size_t
 //|     def deinit(self) -> None:
 //|         """De-initialize camera."""
 //|         ...
-//|
 STATIC mp_obj_t camera_obj_deinit(mp_obj_t self_in) {
     camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_camera_deinit(self);
@@ -95,7 +92,6 @@ STATIC void check_for_deinit(camera_obj_t *self) {
 //|         :return: the number of bytes written into buf
 //|         :rtype: int"""
 //|         ...
-//|
 STATIC mp_obj_t camera_obj_take_picture(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_width, ARG_height, ARG_format };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/camera/ImageFormat.c
+++ b/shared-bindings/camera/ImageFormat.c
@@ -31,13 +31,11 @@
 //|
 //|     def __init__(self) -> None:
 //|         """Enum-like class to define the image format."""
-//|
 //|     JPG: ImageFormat
 //|     """JPG format."""
 //|
 //|     RGB565: ImageFormat
 //|     """RGB565 format."""
-//|
 
 const camera_imageformat_obj_t camera_imageformat_jpg_obj = {
     { &camera_imageformat_type },

--- a/shared-bindings/camera/__init__.c
+++ b/shared-bindings/camera/__init__.c
@@ -33,7 +33,6 @@
 //| """Support for camera input
 //|
 //| The `camera` module contains classes to control the camera and take pictures."""
-//|
 STATIC const mp_rom_map_elem_t camera_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_camera) },
     { MP_ROM_QSTR(MP_QSTR_Camera), MP_ROM_PTR(&camera_type) },

--- a/shared-bindings/canio/CAN.c
+++ b/shared-bindings/canio/CAN.c
@@ -37,19 +37,19 @@
 #include "py/objproperty.h"
 #include "py/runtime.h"
 
-//|
 //| class CAN:
 //|     """CAN bus protocol"""
 //|
-//|     def __init__(self,
-//|             tx: microcontroller.Pin,
-//|             rx: microcontroller.Pin,
-//|             *,
-//|             baudrate: int = 250000,
-//|             loopback: bool = False,
-//|             silent: bool = False,
-//|             auto_restart: bool = False,
-//|         ) -> None:
+//|     def __init__(
+//|         self,
+//|         tx: microcontroller.Pin,
+//|         rx: microcontroller.Pin,
+//|         *,
+//|         baudrate: int = 250000,
+//|         loopback: bool = False,
+//|         silent: bool = False,
+//|         auto_restart: bool = False,
+//|     ) -> None:
 //|         """A common shared-bus protocol.  The rx and tx pins are generally
 //|         connected to a transceiver which controls the H and L pins on a
 //|         shared bus.
@@ -62,7 +62,6 @@
 //|         :param bool auto_restart: If True, will restart communications after entering bus-off state
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t canio_can_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_tx, ARG_rx, ARG_baudrate, ARG_loopback, ARG_silent, ARG_auto_restart, NUM_ARGS };
     static const mp_arg_t allowed_args[] = {
@@ -96,7 +95,6 @@ STATIC mp_obj_t canio_can_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
 //|     auto_restart: bool
 //|     """If True, will restart communications after entering bus-off state"""
-//|
 STATIC mp_obj_t canio_can_auto_restart_get(mp_obj_t self_in) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_can_check_for_deinit(self);
@@ -119,7 +117,6 @@ MP_PROPERTY_GETSET(canio_can_auto_restart_obj,
 
 //|     baudrate: int
 //|     """The baud rate (read-only)"""
-//|
 STATIC mp_obj_t canio_can_baudrate_get(mp_obj_t self_in) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_can_check_for_deinit(self);
@@ -132,7 +129,6 @@ MP_PROPERTY_GETTER(canio_can_baudrate_obj,
 
 //|     transmit_error_count: int
 //|     """The number of transmit errors (read-only).  Increased for a detected transmission error, decreased for successful transmission.  Limited to the range from 0 to 255 inclusive.  Also called TEC."""
-//|
 STATIC mp_obj_t canio_can_transmit_error_count_get(mp_obj_t self_in) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_can_check_for_deinit(self);
@@ -145,7 +141,6 @@ MP_PROPERTY_GETTER(canio_can_transmit_error_count_obj,
 
 //|     receive_error_count: int
 //|     """The number of receive errors (read-only).  Increased for a detected reception error, decreased for successful reception.  Limited to the range from 0 to 255 inclusive.  Also called REC."""
-//|
 STATIC mp_obj_t canio_can_receive_error_count_get(mp_obj_t self_in) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_can_check_for_deinit(self);
@@ -173,7 +168,6 @@ MP_PROPERTY_GETTER(canio_can_state_obj,
 //|     def restart(self) -> None:
 //|         """If the device is in the bus off state, restart it."""
 //|         ...
-//|
 STATIC mp_obj_t canio_can_restart(mp_obj_t self_in) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_can_check_for_deinit(self);
@@ -182,7 +176,9 @@ STATIC mp_obj_t canio_can_restart(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_can_restart_obj, canio_can_restart);
 
-//|     def listen(self, matches: Optional[Sequence[Match]]=None, *, timeout: float=10) -> Listener:
+//|     def listen(
+//|         self, matches: Optional[Sequence[Match]] = None, *, timeout: float = 10
+//|     ) -> Listener:
 //|         """Start receiving messages that match any one of the filters.
 //|
 //|         Creating a listener is an expensive operation and can interfere with reception of messages by other listeners.
@@ -214,7 +210,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_can_restart_obj, canio_can_restart);
 //|         standard address with mask or an extended address with mask.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t canio_can_listen(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     common_hal_canio_can_check_for_deinit(self);
@@ -256,7 +251,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(canio_can_listen_obj, 1, canio_can_listen);
 //|     loopback: bool
 //|     """True if the device was created in loopback mode, False
 //|     otherwise (read-only)"""
-//|
 STATIC mp_obj_t canio_can_loopback_get(mp_obj_t self_in) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_can_check_for_deinit(self);
@@ -273,7 +267,6 @@ MP_PROPERTY_GETTER(canio_can_loopback_obj,
 //|         If the message could not be sent due to a full fifo or a bus error condition, RuntimeError is raised.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t canio_can_send(mp_obj_t self_in, mp_obj_t message_in) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_can_check_for_deinit(self);
@@ -291,7 +284,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(canio_can_send_obj, canio_can_send);
 //|     silent: bool
 //|     """True if the device was created in silent mode, False
 //|     otherwise (read-only)"""
-//|
 STATIC mp_obj_t canio_can_silent_get(mp_obj_t self_in) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_can_check_for_deinit(self);
@@ -306,7 +298,6 @@ MP_PROPERTY_GETTER(canio_can_silent_obj,
 //|     def deinit(self) -> None:
 //|         """Deinitialize this object, freeing its hardware resources"""
 //|         ...
-//|
 STATIC mp_obj_t canio_can_deinit(mp_obj_t self_in) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_can_deinit(self);
@@ -317,7 +308,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_can_deinit_obj, canio_can_deinit);
 //|     def __enter__(self) -> CAN:
 //|         """Returns self, to allow the object to be used in a `with` statement for resource control"""
 //|         ...
-//|
 STATIC mp_obj_t canio_can_enter(mp_obj_t self_in) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_can_check_for_deinit(self);
@@ -325,7 +315,12 @@ STATIC mp_obj_t canio_can_enter(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_can_enter_obj, canio_can_enter);
 
-//|     def __exit__(self, unused1: Optional[Type[BaseException]], unused2: Optional[BaseException], unused3: Optional[TracebackType]) -> None:
+//|     def __exit__(
+//|         self,
+//|         unused1: Optional[Type[BaseException]],
+//|         unused2: Optional[BaseException],
+//|         unused3: Optional[TracebackType],
+//|     ) -> None:
 //|         """Calls deinit()"""
 //|         ...
 STATIC mp_obj_t canio_can_exit(size_t num_args, const mp_obj_t args[]) {

--- a/shared-bindings/canio/Listener.c
+++ b/shared-bindings/canio/Listener.c
@@ -41,15 +41,13 @@
 //|     the `in_waiting` method to check for an available message, a
 //|     listener can be used as an iterable, yielding messages until no
 //|     message arrives within ``self.timeout`` seconds."""
-//|
 
-//|     def receive(self) -> Optional[Union[RemoteTransmissionRequest,Message]]:
+//|     def receive(self) -> Optional[Union[RemoteTransmissionRequest, Message]]:
 //|         """Reads a message, after waiting up to ``self.timeout`` seconds
 //|
 //|         If no message is received in time, `None` is returned.  Otherwise,
 //|         a `Message` or `RemoteTransmissionRequest` is returned."""
 //|         ...
-//|
 STATIC mp_obj_t canio_listener_receive(mp_obj_t self_in) {
     canio_listener_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_listener_check_for_deinit(self);
@@ -68,7 +66,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_listener_receive_obj, canio_listener_rece
 //|         """Returns the number of messages (including remote
 //|         transmission requests) waiting"""
 //|         ...
-//|
 STATIC mp_obj_t canio_listener_in_waiting(mp_obj_t self_in) {
     canio_listener_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_listener_check_for_deinit(self);
@@ -82,8 +79,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_listener_in_waiting_obj, canio_listener_i
 //|         This method exists so that `Listener` can be used as an
 //|         iterable"""
 //|         ...
-//|
-//|     def __next__(self) -> Union[RemoteTransmissionRequest,Message]:
+//|     def __next__(self) -> Union[RemoteTransmissionRequest, Message]:
 //|         """Reads a message, after waiting up to self.timeout seconds
 //|
 //|         If no message is received in time, raises StopIteration.  Otherwise,
@@ -92,7 +88,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_listener_in_waiting_obj, canio_listener_i
 //|         This method enables the `Listener` to be used as an
 //|         iterable, for instance in a for-loop."""
 //|         ...
-//|
 STATIC mp_obj_t canio_iternext(mp_obj_t self_in) {
     mp_obj_t result = canio_listener_receive(self_in);
     if (result == mp_const_none) {
@@ -104,7 +99,6 @@ STATIC mp_obj_t canio_iternext(mp_obj_t self_in) {
 //|     def deinit(self) -> None:
 //|         """Deinitialize this object, freeing its hardware resources"""
 //|         ...
-//|
 STATIC mp_obj_t canio_listener_deinit(mp_obj_t self_in) {
     canio_listener_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_listener_deinit(self);
@@ -115,7 +109,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_listener_deinit_obj, canio_listener_deini
 //|     def __enter__(self) -> CAN:
 //|         """Returns self, to allow the object to be used in a `with` statement for resource control"""
 //|         ...
-//|
 STATIC mp_obj_t canio_listener_enter(mp_obj_t self_in) {
     canio_listener_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_listener_check_for_deinit(self);
@@ -123,7 +116,12 @@ STATIC mp_obj_t canio_listener_enter(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_listener_enter_obj, canio_listener_enter);
 
-//|     def __exit__(self, unused1: Optional[Type[BaseException]], unused2: Optional[BaseException], unused3: Optional[TracebackType]) -> None:
+//|     def __exit__(
+//|         self,
+//|         unused1: Optional[Type[BaseException]],
+//|         unused2: Optional[BaseException],
+//|         unused3: Optional[TracebackType],
+//|     ) -> None:
 //|         """Calls deinit()"""
 //|         ...
 STATIC mp_obj_t canio_listener_exit(size_t num_args, const mp_obj_t args[]) {
@@ -134,7 +132,7 @@ STATIC mp_obj_t canio_listener_exit(size_t num_args, const mp_obj_t args[]) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(canio_listener_exit_obj, 4, 4, canio_listener_exit);
 
 
-//|     timeout : float
+//|     timeout: float
 STATIC mp_obj_t canio_listener_timeout_get(mp_obj_t self_in) {
     canio_listener_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_listener_check_for_deinit(self);

--- a/shared-bindings/canio/Match.c
+++ b/shared-bindings/canio/Match.c
@@ -32,7 +32,6 @@
 //| class Match:
 //|     """Describe CAN bus messages to match"""
 //|
-//|
 //|     def __init__(self, id: int, *, mask: Optional[int] = None, extended: bool = False) -> None:
 //|         """Construct a Match with the given properties.
 //|
@@ -40,7 +39,6 @@
 //|         the nonzero bits in mask. Otherwise, it matches exactly the given id.
 //|         If extended is true then only extended ids are matched, otherwise
 //|         only standard ids are matched."""
-//|
 
 STATIC mp_obj_t canio_match_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_id, ARG_mask, ARG_extended, NUM_ARGS };
@@ -74,7 +72,6 @@ STATIC mp_obj_t canio_match_make_new(const mp_obj_type_t *type, size_t n_args, s
 
 //|     id: int
 //|     """The id to match"""
-//|
 
 STATIC mp_obj_t canio_match_id_get(mp_obj_t self_in) {
     canio_match_obj_t *self = self_in;
@@ -85,10 +82,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(canio_match_id_get_obj, canio_match_id_get);
 MP_PROPERTY_GETTER(canio_match_id_obj,
     (mp_obj_t)&canio_match_id_get_obj);
 
-//|
 //|     mask: int
 //|     """The optional mask of ids to match"""
-//|
 
 STATIC mp_obj_t canio_match_mask_get(mp_obj_t self_in) {
     canio_match_obj_t *self = self_in;
@@ -101,7 +96,6 @@ MP_PROPERTY_GETTER(canio_match_mask_obj,
 
 //|     extended: bool
 //|     """True to match extended ids, False to match standard ides"""
-//|
 
 STATIC mp_obj_t canio_match_extended_get(mp_obj_t self_in) {
     canio_match_obj_t *self = self_in;

--- a/shared-bindings/canio/Message.c
+++ b/shared-bindings/canio/Message.c
@@ -41,7 +41,6 @@
 //|         In CAN, messages can have a length from 0 to 8 bytes.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t canio_message_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_id, ARG_data, ARG_extended, NUM_ARGS };
     static const mp_arg_t allowed_args[] = {
@@ -67,7 +66,6 @@ STATIC mp_obj_t canio_message_make_new(const mp_obj_type_t *type, size_t n_args,
 
 //|     id: int
 //|     """The numeric ID of the message"""
-//|
 STATIC mp_obj_t canio_message_id_get(const mp_obj_t self_in) {
     canio_message_obj_t *self = self_in;
     return MP_OBJ_NEW_SMALL_INT(common_hal_canio_message_get_id(self));
@@ -87,7 +85,6 @@ MP_PROPERTY_GETSET(canio_message_id_obj,
 
 //|     data: bytes
 //|     """The content of the message"""
-//|
 STATIC mp_obj_t canio_message_data_get(const mp_obj_t self_in) {
     canio_message_obj_t *self = self_in;
     return mp_obj_new_bytes((const byte *)common_hal_canio_message_get_data(self), common_hal_canio_message_get_length(self));
@@ -114,7 +111,6 @@ MP_PROPERTY_GETSET(canio_message_data_obj,
 
 //|     extended: bool
 //|     """True if the message's id is an extended id"""
-//|
 STATIC mp_obj_t canio_message_extended_get(const mp_obj_t self_in) {
     canio_message_obj_t *self = self_in;
     return mp_obj_new_bool(common_hal_canio_message_get_extended(self));

--- a/shared-bindings/canio/RemoteTransmissionRequest.c
+++ b/shared-bindings/canio/RemoteTransmissionRequest.c
@@ -41,7 +41,6 @@
 //|         In CAN, messages can have a length from 0 to 8 bytes.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t canio_remote_transmission_request_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_id, ARG_length, ARG_extended, NUM_ARGS };
     static const mp_arg_t allowed_args[] = {
@@ -68,7 +67,6 @@ STATIC mp_obj_t canio_remote_transmission_request_make_new(const mp_obj_type_t *
 
 //|     id: int
 //|     """The numeric ID of the message"""
-//|
 STATIC mp_obj_t canio_remote_transmission_request_id_get(const mp_obj_t self_in) {
     canio_remote_transmission_request_obj_t *self = self_in;
     return MP_OBJ_NEW_SMALL_INT(common_hal_canio_remote_transmission_request_get_id(self));
@@ -88,7 +86,6 @@ MP_PROPERTY_GETSET(canio_remote_transmission_request_id_obj,
 
 //|     extended: bool
 //|     """True if the message's id is an extended id"""
-//|
 STATIC mp_obj_t canio_remote_transmission_request_extended_get(const mp_obj_t self_in) {
     canio_remote_transmission_request_obj_t *self = self_in;
     return mp_obj_new_bool(common_hal_canio_remote_transmission_request_get_extended(self));
@@ -109,7 +106,6 @@ MP_PROPERTY_GETSET(canio_remote_transmission_request_extended_obj,
 
 //|     length: int
 //|     """The length of the requested message."""
-//|
 STATIC mp_obj_t canio_remote_transmission_request_length_get(const mp_obj_t self_in) {
     canio_remote_transmission_request_obj_t *self = self_in;
     return MP_OBJ_NEW_SMALL_INT(common_hal_canio_remote_transmission_request_get_length(self));

--- a/shared-bindings/canio/__init__.c
+++ b/shared-bindings/canio/__init__.c
@@ -58,7 +58,6 @@
 //| For more information on working with this module, refer to
 //| `this Learn Guide on using it <https://learn.adafruit.com/using-canio-circuitpython>`_.
 //| """
-//|
 
 #include "py/obj.h"
 #include "py/enum.h"
@@ -97,7 +96,6 @@ MAKE_ENUM_VALUE(canio_bus_state_type, bus_state, BUS_OFF, BUS_STATE_OFF);
 //|     """The bus has turned off due to the number of errors that have
 //|     occurred recently.  It must be restarted before it will send or receive
 //|     packets.  This device will neither send or acknowledge packets on the bus."""
-//|
 MAKE_ENUM_MAP(canio_bus_state) {
     MAKE_ENUM_MAP_ENTRY(bus_state, ERROR_ACTIVE),
     MAKE_ENUM_MAP_ENTRY(bus_state, ERROR_PASSIVE),

--- a/shared-bindings/countio/Counter.c
+++ b/shared-bindings/countio/Counter.c
@@ -11,10 +11,15 @@
 #include "shared-bindings/util.h"
 
 //| class Counter:
-//|     """Count the number of rising- and/or falling-edge transitions on a given pin.
-//|     """
+//|     """Count the number of rising- and/or falling-edge transitions on a given pin."""
 //|
-//|     def __init__(self, pin: microcontroller.Pin, *, edge: Edge = Edge.FALL, pull: Optional[digitalio.Pull] = None) -> None:
+//|     def __init__(
+//|         self,
+//|         pin: microcontroller.Pin,
+//|         *,
+//|         edge: Edge = Edge.FALL,
+//|         pull: Optional[digitalio.Pull] = None
+//|     ) -> None:
 //|         """Create a Counter object associated with the given pin that counts
 //|         rising- and/or falling-edge transitions. At least one of ``rise`` and ``fall`` must be True.
 //|         The default is to count only falling edges, and is for historical backward compatibility.
@@ -38,7 +43,6 @@
 //|                 print(pin_counter.count)
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t countio_counter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pin, ARG_edge, ARG_pull };
     static const mp_arg_t allowed_args[] = {
@@ -63,7 +67,6 @@ STATIC mp_obj_t countio_counter_make_new(const mp_obj_type_t *type, size_t n_arg
 
 //|     def deinit(self) -> None:
 //|         """Deinitializes the Counter and releases any hardware resources for reuse."""
-//|
 STATIC mp_obj_t countio_counter_deinit(mp_obj_t self_in) {
     countio_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_countio_counter_deinit(self);
@@ -79,13 +82,11 @@ STATIC void check_for_deinit(countio_counter_obj_t *self) {
 
 //|     def __enter__(self) -> Counter:
 //|         """No-op used by Context Managers."""
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
-//|            :ref:`lifetime-and-contextmanagers` for more info."""
-//|
+//|         :ref:`lifetime-and-contextmanagers` for more info."""
 STATIC mp_obj_t countio_counter_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_countio_counter_deinit(args[0]);
@@ -96,7 +97,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(countio_counter___exit___obj, 4, 4, c
 
 //|     count: int
 //|     """The current count in terms of pulses."""
-//|
 STATIC mp_obj_t countio_counter_obj_get_count(mp_obj_t self_in) {
     countio_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -120,7 +120,6 @@ MP_PROPERTY_GETSET(countio_counter_count_obj,
 
 //|     def reset(self) -> None:
 //|         """Resets the count back to 0."""
-//|
 STATIC mp_obj_t countio_counter_reset(mp_obj_t self_in) {
     countio_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/countio/Edge.c
+++ b/shared-bindings/countio/Edge.c
@@ -40,7 +40,6 @@ MAKE_ENUM_VALUE(countio_edge_type, edge, RISE_AND_FALL, EDGE_RISE_AND_FALL);
 //|     def __init__(self) -> None:
 //|         """Enum-like class to define which signal transitions to count."""
 //|         ...
-//|
 //|     RISE: Edge
 //|     """Count the rising edges."""
 //|
@@ -49,7 +48,6 @@ MAKE_ENUM_VALUE(countio_edge_type, edge, RISE_AND_FALL, EDGE_RISE_AND_FALL);
 //|
 //|     RISE_AND_FALL: Edge
 //|     """Count the rising and falling edges."""
-//|
 MAKE_ENUM_MAP(countio_edge) {
     MAKE_ENUM_MAP_ENTRY(edge, RISE),
     MAKE_ENUM_MAP_ENTRY(edge, FALL),

--- a/shared-bindings/countio/__init__.c
+++ b/shared-bindings/countio/__init__.c
@@ -21,7 +21,6 @@
 //| are no longer needed if the program continues after use. To do so, either
 //| call :py:meth:`!deinit` or use a context manager. See
 //| :ref:`lifetime-and-contextmanagers` for more info."""
-//|
 
 STATIC const mp_rom_map_elem_t countio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_countio) },

--- a/shared-bindings/digitalio/DigitalInOut.c
+++ b/shared-bindings/digitalio/DigitalInOut.c
@@ -57,7 +57,6 @@
 //|
 //|         :param ~microcontroller.Pin pin: The pin to control"""
 //|         ...
-//|
 STATIC mp_obj_t digitalio_digitalinout_make_new(const mp_obj_type_t *type,
     size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
@@ -74,7 +73,6 @@ STATIC mp_obj_t digitalio_digitalinout_make_new(const mp_obj_type_t *type,
 //|     def deinit(self) -> None:
 //|         """Turn off the DigitalInOut and release the pin for other use."""
 //|         ...
-//|
 STATIC mp_obj_t digitalio_digitalinout_obj_deinit(mp_obj_t self_in) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_digitalio_digitalinout_deinit(self);
@@ -85,14 +83,12 @@ MP_DEFINE_CONST_FUN_OBJ_1(digitalio_digitalinout_deinit_obj, digitalio_digitalin
 //|     def __enter__(self) -> DigitalInOut:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t digitalio_digitalinout_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_digitalio_digitalinout_deinit(MP_OBJ_TO_PTR(args[0]));
@@ -106,7 +102,9 @@ STATIC void check_for_deinit(digitalio_digitalinout_obj_t *self) {
     }
 }
 
-//|     def switch_to_output(self, value: bool = False, drive_mode: DriveMode = DriveMode.PUSH_PULL) -> None:
+//|     def switch_to_output(
+//|         self, value: bool = False, drive_mode: DriveMode = DriveMode.PUSH_PULL
+//|     ) -> None:
 //|         """Set the drive mode and value and then switch to writing out digital
 //|         values.
 //|
@@ -114,7 +112,6 @@ STATIC void check_for_deinit(digitalio_digitalinout_obj_t *self) {
 //|         :param ~digitalio.DriveMode drive_mode: drive mode for the output
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t digitalio_digitalinout_switch_to_output(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_value, ARG_drive_mode };
     static const mp_arg_t allowed_args[] = {
@@ -155,7 +152,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(digitalio_digitalinout_switch_to_output_obj, 1, digit
 //|           switch.pull = digitalio.Pull.UP
 //|           print(switch.value)"""
 //|         ...
-//|
 STATIC mp_obj_t digitalio_digitalinout_switch_to_input(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_pull };
     static const mp_arg_t allowed_args[] = {
@@ -178,7 +174,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(digitalio_digitalinout_switch_to_input_obj, 1, digita
 //|     :py:meth:`switch_to_input` or :py:meth:`switch_to_output` method. If
 //|     you want to set pull, value or drive mode prior to switching, then use
 //|     those methods instead."""
-//|
 typedef struct {
     mp_obj_base_t base;
 } digitalio_digitalio_direction_obj_t;
@@ -219,7 +214,6 @@ MP_PROPERTY_GETSET(digitalio_digitalio_direction_obj,
 
 //|     value: bool
 //|     """The digital logic level of the pin."""
-//|
 STATIC mp_obj_t digitalio_digitalinout_obj_get_value(mp_obj_t self_in) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -249,7 +243,6 @@ MP_PROPERTY_GETSET(digitalio_digitalinout_value_obj,
 //|
 //|     - `digitalio.DriveMode.PUSH_PULL`
 //|     - `digitalio.DriveMode.OPEN_DRAIN`"""
-//|
 STATIC mp_obj_t digitalio_digitalinout_obj_get_drive_mode(mp_obj_t self_in) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -293,7 +286,6 @@ MP_PROPERTY_GETSET(digitalio_digitalio_drive_mode_obj,
 //|     - `None`
 //|
 //|     :raises AttributeError: if `direction` is :py:data:`~digitalio.Direction.OUTPUT`."""
-//|
 STATIC mp_obj_t digitalio_digitalinout_obj_get_pull(mp_obj_t self_in) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/digitalio/Direction.c
+++ b/shared-bindings/digitalio/Direction.c
@@ -45,13 +45,11 @@
 //|         """Enum-like class to define which direction the digital values are
 //|         going."""
 //|         ...
-//|
 //|     INPUT: Direction
 //|     """Read digital data in"""
 //|
 //|     OUTPUT: Direction
 //|     """Write digital data out"""
-//|
 const mp_obj_type_t digitalio_direction_type;
 
 const digitalio_direction_obj_t digitalio_direction_input_obj = {

--- a/shared-bindings/digitalio/DriveMode.c
+++ b/shared-bindings/digitalio/DriveMode.c
@@ -33,14 +33,12 @@
 //|         """Enum-like class to define the drive mode used when outputting
 //|         digital values."""
 //|         ...
-//|
 //|     PUSH_PULL: DriveMode
 //|     """Output both high and low digital values"""
 //|
 //|     OPEN_DRAIN: DriveMode
 //|     """Output low digital values but go into high z for digital high. This is
 //|     useful for i2c and other protocols that share a digital line."""
-//|
 const mp_obj_type_t digitalio_drive_mode_type;
 
 const digitalio_drive_mode_obj_t digitalio_drive_mode_push_pull_obj = {

--- a/shared-bindings/digitalio/Pull.c
+++ b/shared-bindings/digitalio/Pull.c
@@ -35,7 +35,6 @@
 //|         """Enum-like class to define the pull value, if any, used while reading
 //|         digital values in."""
 //|         ...
-//|
 //|     UP: Pull
 //|     """When the input line isn't being driven the pull up can pull the state
 //|     of the line high so it reads as true."""
@@ -43,7 +42,6 @@
 //|     DOWN: Pull
 //|     """When the input line isn't being driven the pull down can pull the
 //|     state of the line low so it reads as false."""
-//|
 const mp_obj_type_t digitalio_pull_type;
 
 const digitalio_pull_obj_t digitalio_pull_up_obj = {

--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -39,18 +39,17 @@
 //| class Bitmap:
 //|     """Stores values of a certain size in a 2D array
 //|
-//| Bitmaps can be treated as read-only buffers. If the number of bits in a pixel is 8, 16, or 32; and the number of bytes
-//| per row is a multiple of 4, then the resulting memoryview will correspond directly with the bitmap's contents. Otherwise,
-//| the bitmap data is packed into the memoryview with unspecified padding.
+//|     Bitmaps can be treated as read-only buffers. If the number of bits in a pixel is 8, 16, or 32; and the number of bytes
+//|     per row is a multiple of 4, then the resulting memoryview will correspond directly with the bitmap's contents. Otherwise,
+//|     the bitmap data is packed into the memoryview with unspecified padding.
 //|
-//| A Bitmap can be treated as a buffer, allowing its content to be
-//| viewed and modified using e.g., with ``ulab.numpy.frombuffer``,
-//| but the `displayio.Bitmap.dirty` method must be used to inform
-//| displayio when a bitmap was modified through the buffer interface.
+//|     A Bitmap can be treated as a buffer, allowing its content to be
+//|     viewed and modified using e.g., with ``ulab.numpy.frombuffer``,
+//|     but the `displayio.Bitmap.dirty` method must be used to inform
+//|     displayio when a bitmap was modified through the buffer interface.
 //|
-//| `bitmaptools.arrayblit` can also be useful to move data efficiently
-//| into a Bitmap.
-//| """
+//|     `bitmaptools.arrayblit` can also be useful to move data efficiently
+//|     into a Bitmap."""
 //|
 //|     def __init__(self, width: int, height: int, value_count: int) -> None:
 //|         """Create a Bitmap object with the given fixed size. Each pixel stores a value that is used to
@@ -61,7 +60,6 @@
 //|         :param int height: The number of values high
 //|         :param int value_count: The number of possible pixel values."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_bitmap_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     mp_arg_check_num(n_args, n_kw, 3, 3, false);
     uint32_t width = mp_obj_get_int(all_args[0]);
@@ -88,7 +86,6 @@ STATIC mp_obj_t displayio_bitmap_make_new(const mp_obj_type_t *type, size_t n_ar
 }
 //|     width: int
 //|     """Width of the bitmap. (read only)"""
-//|
 STATIC mp_obj_t displayio_bitmap_obj_get_width(mp_obj_t self_in) {
     displayio_bitmap_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -102,7 +99,6 @@ MP_PROPERTY_GETTER(displayio_bitmap_width_obj,
 
 //|     height: int
 //|     """Height of the bitmap. (read only)"""
-//|
 STATIC mp_obj_t displayio_bitmap_obj_get_height(mp_obj_t self_in) {
     displayio_bitmap_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -122,7 +118,6 @@ MP_PROPERTY_GETTER(displayio_bitmap_height_obj,
 //|
 //|           print(bitmap[0,1])"""
 //|         ...
-//|
 //|     def __setitem__(self, index: Union[Tuple[int, int], int], value: int) -> None:
 //|         """Sets the value at the given index. The index can either be an x,y tuple or an int equal
 //|         to ``y * width + x``.
@@ -131,7 +126,6 @@ MP_PROPERTY_GETTER(displayio_bitmap_height_obj,
 //|
 //|           bitmap[0,1] = 3"""
 //|         ...
-//|
 STATIC mp_obj_t bitmap_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t value_obj) {
     if (value_obj == mp_const_none) {
         // delete item
@@ -177,7 +171,18 @@ STATIC mp_obj_t bitmap_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t val
     return mp_const_none;
 }
 
-//|     def blit(self, x: int, y: int, source_bitmap: Bitmap, *, x1: int, y1: int, x2: int, y2: int, skip_index: int) -> None:
+//|     def blit(
+//|         self,
+//|         x: int,
+//|         y: int,
+//|         source_bitmap: Bitmap,
+//|         *,
+//|         x1: int,
+//|         y1: int,
+//|         x2: int,
+//|         y2: int,
+//|         skip_index: int
+//|     ) -> None:
 //|         """Inserts the source_bitmap region defined by rectangular boundaries
 //|                     (x1,y1) and (x2,y2) into the bitmap at the specified (x,y) location.
 //|
@@ -193,7 +198,6 @@ STATIC mp_obj_t bitmap_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t val
 //|         :param int skip_index: bitmap palette index in the source that will not be copied,
 //|                                set to None to copy all pixels"""
 //|         ...
-//|
 STATIC mp_obj_t displayio_bitmap_obj_blit(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_x, ARG_y, ARG_source, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_skip_index};
     static const mp_arg_t allowed_args[] = {
@@ -282,7 +286,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(displayio_bitmap_blit_obj, 1, displayio_bitmap_obj_bl
 //|     def fill(self, value: int) -> None:
 //|         """Fills the bitmap with the supplied palette index value."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_bitmap_obj_fill(mp_obj_t self_in, mp_obj_t value_obj) {
     displayio_bitmap_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -296,7 +299,7 @@ STATIC mp_obj_t displayio_bitmap_obj_fill(mp_obj_t self_in, mp_obj_t value_obj) 
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_bitmap_fill_obj, displayio_bitmap_obj_fill);
 
-//|     def dirty(self, x1: int=0, y1: int=0, x2: int=-1, y2:int = -1) -> None:
+//|     def dirty(self, x1: int = 0, y1: int = 0, x2: int = -1, y2: int = -1) -> None:
 //|         """Inform displayio of bitmap updates done via the buffer
 //|         protocol.
 //|
@@ -315,7 +318,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_bitmap_fill_obj, displayio_bitmap_obj_fill);
 //|         notified of the "dirty rectangle" that encloses all modified
 //|         pixels."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_bitmap_obj_dirty(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     displayio_bitmap_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     enum { ARG_x1, ARG_y1, ARG_x2, ARG_y2 };

--- a/shared-bindings/displayio/ColorConverter.c
+++ b/shared-bindings/displayio/ColorConverter.c
@@ -39,13 +39,14 @@
 //| class ColorConverter:
 //|     """Converts one color format to another."""
 //|
-//|     def __init__(self, *, input_colorspace: Colorspace=Colorspace.RGB888, dither: bool = False) -> None:
+//|     def __init__(
+//|         self, *, input_colorspace: Colorspace = Colorspace.RGB888, dither: bool = False
+//|     ) -> None:
 //|         """Create a ColorConverter object to convert color formats.
 //|
 //|         :param Colorspace colorspace: The source colorspace, one of the Colorspace constants
 //|         :param bool dither: Adds random noise to dither the output image"""
 //|         ...
-//|
 
 STATIC mp_obj_t displayio_colorconverter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_dither, ARG_input_colorspace };
@@ -68,7 +69,6 @@ STATIC mp_obj_t displayio_colorconverter_make_new(const mp_obj_type_t *type, siz
 //|     def convert(self, color: int) -> int:
 //|         """Converts the given color to RGB565 according to the Colorspace"""
 //|         ...
-//|
 STATIC mp_obj_t displayio_colorconverter_obj_convert(mp_obj_t self_in, mp_obj_t color_obj) {
     displayio_colorconverter_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -84,7 +84,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_colorconverter_convert_obj, displayio_colorc
 //|     dither: bool
 //|     """When `True` the ColorConverter dithers the output by adding random noise when
 //|     truncating to display bitdepth"""
-//|
 STATIC mp_obj_t displayio_colorconverter_obj_get_dither(mp_obj_t self_in) {
     displayio_colorconverter_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_displayio_colorconverter_get_dither(self));
@@ -109,7 +108,6 @@ MP_PROPERTY_GETSET(displayio_colorconverter_dither_obj,
 //|         raise an Exception if there is already a selected transparent index.
 //|
 //|         :param int color: The color to be transparent"""
-//|
 STATIC mp_obj_t displayio_colorconverter_make_transparent(mp_obj_t self_in, mp_obj_t transparent_color_obj) {
     displayio_colorconverter_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -123,7 +121,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_colorconverter_make_transparent_obj, display
 //|         """Make the ColorConverter be opaque and have no transparent pixels.
 //|
 //|         :param int color: [IGNORED] Use any value"""
-//|
 STATIC mp_obj_t displayio_colorconverter_make_opaque(mp_obj_t self_in, mp_obj_t transparent_color_obj) {
     displayio_colorconverter_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/displayio/Colorspace.c
+++ b/shared-bindings/displayio/Colorspace.c
@@ -58,7 +58,6 @@ MAKE_ENUM_VALUE(displayio_colorspace_type, displayio_colorspace, L8, DISPLAYIO_C
 //|
 //|     RGB555_SWAPPED: Colorspace
 //|     """The swapped 15-bit colorspace.  First, the high and low 8 bits of the number are swapped, then they are interpreted as for RGB555"""
-//|
 MAKE_ENUM_MAP(displayio_colorspace) {
     MAKE_ENUM_MAP_ENTRY(displayio_colorspace, RGB888),
     MAKE_ENUM_MAP_ENTRY(displayio_colorspace, RGB565),

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -39,11 +39,9 @@
 #include "shared-module/displayio/__init__.h"
 #include "supervisor/shared/translate/translate.h"
 
-//| _DisplayBus = Union['FourWire', 'paralleldisplay.ParallelBus', 'I2CDisplay']
+//| _DisplayBus = Union["FourWire", "paralleldisplay.ParallelBus", "I2CDisplay"]
 //| """:py:class:`FourWire`, :py:class:`paralleldisplay.ParallelBus` or :py:class:`I2CDisplay`"""
-//|
 
-//|
 //| class Display:
 //|     """Manage updating a display over a display bus
 //|
@@ -54,7 +52,34 @@
 //|     Most people should not use this class directly. Use a specific display driver instead that will
 //|     contain the initialization sequence at minimum."""
 //|
-//|     def __init__(self, display_bus: _DisplayBus, init_sequence: ReadableBuffer, *, width: int, height: int, colstart: int = 0, rowstart: int = 0, rotation: int = 0, color_depth: int = 16, grayscale: bool = False, pixels_in_byte_share_row: bool = True, bytes_per_cell: int = 1, reverse_pixels_in_byte: bool = False, set_column_command: int = 0x2a, set_row_command: int = 0x2b, write_ram_command: int = 0x2c, backlight_pin: Optional[microcontroller.Pin] = None, brightness_command: Optional[int] = None, brightness: float = 1.0, single_byte_bounds: bool = False, data_as_commands: bool = False,  auto_refresh: bool = True, native_frames_per_second: int = 60, backlight_on_high: bool = True, SH1107_addressing: bool = False) -> None:
+//|     def __init__(
+//|         self,
+//|         display_bus: _DisplayBus,
+//|         init_sequence: ReadableBuffer,
+//|         *,
+//|         width: int,
+//|         height: int,
+//|         colstart: int = 0,
+//|         rowstart: int = 0,
+//|         rotation: int = 0,
+//|         color_depth: int = 16,
+//|         grayscale: bool = False,
+//|         pixels_in_byte_share_row: bool = True,
+//|         bytes_per_cell: int = 1,
+//|         reverse_pixels_in_byte: bool = False,
+//|         set_column_command: int = 0x2A,
+//|         set_row_command: int = 0x2B,
+//|         write_ram_command: int = 0x2C,
+//|         backlight_pin: Optional[microcontroller.Pin] = None,
+//|         brightness_command: Optional[int] = None,
+//|         brightness: float = 1.0,
+//|         single_byte_bounds: bool = False,
+//|         data_as_commands: bool = False,
+//|         auto_refresh: bool = True,
+//|         native_frames_per_second: int = 60,
+//|         backlight_on_high: bool = True,
+//|         SH1107_addressing: bool = False
+//|     ) -> None:
 //|         r"""Create a Display object on the given display bus (`FourWire`, `ParallelBus` or `I2CDisplay`).
 //|
 //|         The ``init_sequence`` is bitpacked to minimize the ram impact. Every command begins with a
@@ -113,7 +138,6 @@
 //|         :param int backlight_pwm_frequency: The frequency to use to drive the PWM for backlight brightness control. Default is 50000.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t displayio_display_make_new(const mp_obj_type_t *type, size_t n_args,
     size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_display_bus, ARG_init_sequence, ARG_width, ARG_height, ARG_colstart, ARG_rowstart,
@@ -219,7 +243,6 @@ static displayio_display_obj_t *native_display(mp_obj_t display_obj) {
 //|
 //|         :param Group group: The group to show."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_display_obj_show(mp_obj_t self_in, mp_obj_t group_in) {
     displayio_display_obj_t *self = native_display(self_in);
     displayio_group_t *group = NULL;
@@ -235,7 +258,12 @@ STATIC mp_obj_t displayio_display_obj_show(mp_obj_t self_in, mp_obj_t group_in) 
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_display_show_obj, displayio_display_obj_show);
 
-//|     def refresh(self, *, target_frames_per_second: Optional[int] = None, minimum_frames_per_second: int = 0) -> bool:
+//|     def refresh(
+//|         self,
+//|         *,
+//|         target_frames_per_second: Optional[int] = None,
+//|         minimum_frames_per_second: int = 0
+//|     ) -> bool:
 //|         """When auto_refresh is off, and :py:attr:`target_frames_per_second` is not `None` this waits
 //|         for the target frame rate and then refreshes the display,
 //|         returning `True`. If the call has taken too long since the last refresh call for the given
@@ -255,7 +283,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_display_show_obj, displayio_display_obj_show
 //|             achieve. Set to `None` for immediate refresh.
 //|         :param int minimum_frames_per_second: The minimum number of times the screen should be updated per second."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_display_obj_refresh(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_target_frames_per_second, ARG_minimum_frames_per_second };
     static const mp_arg_t allowed_args[] = {
@@ -287,7 +314,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(displayio_display_refresh_obj, 1, displayio_display_o
 
 //|     auto_refresh: bool
 //|     """True when the display is refreshed automatically."""
-//|
 STATIC mp_obj_t displayio_display_obj_get_auto_refresh(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);
     return mp_obj_new_bool(common_hal_displayio_display_get_auto_refresh(self));
@@ -309,7 +335,6 @@ MP_PROPERTY_GETSET(displayio_display_auto_refresh_obj,
 
 //|     brightness: float
 //|     """The brightness of the display as a float. 0.0 is off and 1.0 is full brightness."""
-//|
 STATIC mp_obj_t displayio_display_obj_get_brightness(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);
     mp_float_t brightness = common_hal_displayio_display_get_brightness(self);
@@ -340,7 +365,6 @@ MP_PROPERTY_GETSET(displayio_display_brightness_obj,
 
 //|     width: int
 //|     """Gets the width of the board"""
-//|
 STATIC mp_obj_t displayio_display_obj_get_width(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_display_get_width(self));
@@ -352,7 +376,6 @@ MP_PROPERTY_GETTER(displayio_display_width_obj,
 
 //|     height: int
 //|     """Gets the height of the board"""
-//|
 STATIC mp_obj_t displayio_display_obj_get_height(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_display_get_height(self));
@@ -364,7 +387,6 @@ MP_PROPERTY_GETTER(displayio_display_height_obj,
 
 //|     rotation: int
 //|     """The rotation of the display as an int in degrees."""
-//|
 STATIC mp_obj_t displayio_display_obj_get_rotation(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_display_get_rotation(self));
@@ -384,8 +406,6 @@ MP_PROPERTY_GETSET(displayio_display_rotation_obj,
 
 //|     bus: _DisplayBus
 //|     """The bus being used by the display"""
-//|
-//|
 STATIC mp_obj_t displayio_display_obj_get_bus(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);
     return common_hal_displayio_display_get_bus(self);
@@ -397,8 +417,6 @@ MP_PROPERTY_GETTER(displayio_display_bus_obj,
 
 //|     root_group: Group
 //|     """The root group on the display."""
-//|
-//|
 STATIC mp_obj_t displayio_display_obj_get_root_group(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);
     return common_hal_displayio_display_get_root_group(self);
@@ -415,7 +433,6 @@ MP_PROPERTY_GETTER(displayio_display_root_group_obj,
 //|         :param int y: The top edge of the area
 //|         :param ~circuitpython_typing.WriteableBuffer buffer: The buffer in which to place the pixel data"""
 //|         ...
-//|
 STATIC mp_obj_t displayio_display_obj_fill_row(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_y, ARG_buffer };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/displayio/EPaperDisplay.c
+++ b/shared-bindings/displayio/EPaperDisplay.c
@@ -49,21 +49,37 @@
 //|     Most people should not use this class directly. Use a specific display driver instead that will
 //|     contain the startup and shutdown sequences at minimum."""
 //|
-//|     def __init__(self, display_bus: _DisplayBus,
-//|                  start_sequence: ReadableBuffer, stop_sequence: ReadableBuffer, *,
-//|                  width: int, height: int, ram_width: int, ram_height: int,
-//|                  colstart: int = 0, rowstart: int = 0, rotation: int = 0,
-//|                  set_column_window_command: Optional[int] = None,
-//|                  set_row_window_command: Optional[int] = None,
-//|                  set_current_column_command: Optional[int] = None,
-//|                  set_current_row_command: Optional[int] = None,
-//|                  write_black_ram_command: int, black_bits_inverted: bool = False,
-//|                  write_color_ram_command: Optional[int] = None,
-//|                  color_bits_inverted: bool = False, highlight_color: int = 0x000000,
-//|                  refresh_display_command: int, refresh_time: float = 40,
-//|                  busy_pin: Optional[microcontroller.Pin] = None, busy_state: bool = True,
-//|                  seconds_per_frame: float = 180, always_toggle_chip_select: bool = False,
-//|                  grayscale: bool = False, two_byte_sequence_length: bool = False) -> None:
+//|     def __init__(
+//|         self,
+//|         display_bus: _DisplayBus,
+//|         start_sequence: ReadableBuffer,
+//|         stop_sequence: ReadableBuffer,
+//|         *,
+//|         width: int,
+//|         height: int,
+//|         ram_width: int,
+//|         ram_height: int,
+//|         colstart: int = 0,
+//|         rowstart: int = 0,
+//|         rotation: int = 0,
+//|         set_column_window_command: Optional[int] = None,
+//|         set_row_window_command: Optional[int] = None,
+//|         set_current_column_command: Optional[int] = None,
+//|         set_current_row_command: Optional[int] = None,
+//|         write_black_ram_command: int,
+//|         black_bits_inverted: bool = False,
+//|         write_color_ram_command: Optional[int] = None,
+//|         color_bits_inverted: bool = False,
+//|         highlight_color: int = 0x000000,
+//|         refresh_display_command: int,
+//|         refresh_time: float = 40,
+//|         busy_pin: Optional[microcontroller.Pin] = None,
+//|         busy_state: bool = True,
+//|         seconds_per_frame: float = 180,
+//|         always_toggle_chip_select: bool = False,
+//|         grayscale: bool = False,
+//|         two_byte_sequence_length: bool = False
+//|     ) -> None:
 //|         """Create a EPaperDisplay object on the given display bus (`displayio.FourWire` or `paralleldisplay.ParallelBus`).
 //|
 //|         The ``start_sequence`` and ``stop_sequence`` are bitpacked to minimize the ram impact. Every
@@ -103,7 +119,6 @@
 //|         :param bool grayscale: When true, the color ram is the low bit of 2-bit grayscale
 //|         :param bool two_byte_sequence_length: When true, use two bytes to define sequence length"""
 //|         ...
-//|
 STATIC mp_obj_t displayio_epaperdisplay_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_display_bus, ARG_start_sequence, ARG_stop_sequence, ARG_width, ARG_height,
            ARG_ram_width, ARG_ram_height, ARG_colstart, ARG_rowstart, ARG_rotation,
@@ -203,7 +218,6 @@ static displayio_epaperdisplay_obj_t *native_display(mp_obj_t display_obj) {
 //|
 //|         :param Group group: The group to show."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_epaperdisplay_obj_show(mp_obj_t self_in, mp_obj_t group_in) {
     displayio_epaperdisplay_obj_t *self = native_display(self_in);
     displayio_group_t *group = NULL;
@@ -219,10 +233,11 @@ STATIC mp_obj_t displayio_epaperdisplay_obj_show(mp_obj_t self_in, mp_obj_t grou
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_epaperdisplay_show_obj, displayio_epaperdisplay_obj_show);
 
-//|     def update_refresh_mode(self, start_sequence: ReadableBuffer, seconds_per_frame: float = 180) -> None:
+//|     def update_refresh_mode(
+//|         self, start_sequence: ReadableBuffer, seconds_per_frame: float = 180
+//|     ) -> None:
 //|         """Updates the ``start_sequence`` and ``seconds_per_frame`` parameters to enable
 //|         varying the refresh mode of the display."""
-//|
 STATIC mp_obj_t displayio_epaperdisplay_update_refresh_mode(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_start_sequence, ARG_seconds_per_frame };
     static const mp_arg_t allowed_args[] = {
@@ -248,7 +263,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(displayio_epaperdisplay_update_refresh_mode_obj, 1, d
 //|         """Refreshes the display immediately or raises an exception if too soon. Use
 //|         ``time.sleep(display.time_to_refresh)`` to sleep until a refresh can occur."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_epaperdisplay_obj_refresh(mp_obj_t self_in) {
     displayio_epaperdisplay_obj_t *self = native_display(self_in);
     bool ok = common_hal_displayio_epaperdisplay_refresh(self);
@@ -261,7 +275,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(displayio_epaperdisplay_refresh_obj, displayio_epaperd
 
 //|     time_to_refresh: float
 //|     """Time, in fractional seconds, until the ePaper display can be refreshed."""
-//|
 STATIC mp_obj_t displayio_epaperdisplay_obj_get_time_to_refresh(mp_obj_t self_in) {
     displayio_epaperdisplay_obj_t *self = native_display(self_in);
     return mp_obj_new_float(common_hal_displayio_epaperdisplay_get_time_to_refresh(self) / 1000.0);
@@ -274,7 +287,6 @@ MP_PROPERTY_GETTER(displayio_epaperdisplay_time_to_refresh_obj,
 //|     busy: bool
 //|     """True when the display is refreshing. This uses the ``busy_pin`` when available or the
 //|        ``refresh_time`` otherwise."""
-//|
 STATIC mp_obj_t displayio_epaperdisplay_obj_get_busy(mp_obj_t self_in) {
     displayio_epaperdisplay_obj_t *self = native_display(self_in);
     return mp_obj_new_bool(common_hal_displayio_epaperdisplay_get_busy(self));
@@ -286,7 +298,6 @@ MP_PROPERTY_GETTER(displayio_epaperdisplay_busy_obj,
 
 //|     width: int
 //|     """Gets the width of the display in pixels"""
-//|
 STATIC mp_obj_t displayio_epaperdisplay_obj_get_width(mp_obj_t self_in) {
     displayio_epaperdisplay_obj_t *self = native_display(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_epaperdisplay_get_width(self));
@@ -298,7 +309,6 @@ MP_PROPERTY_GETTER(displayio_epaperdisplay_width_obj,
 
 //|     height: int
 //|     """Gets the height of the display in pixels"""
-//|
 STATIC mp_obj_t displayio_epaperdisplay_obj_get_height(mp_obj_t self_in) {
     displayio_epaperdisplay_obj_t *self = native_display(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_epaperdisplay_get_height(self));
@@ -310,7 +320,6 @@ MP_PROPERTY_GETTER(displayio_epaperdisplay_height_obj,
 
 //|     rotation: int
 //|     """The rotation of the display as an int in degrees."""
-//|
 STATIC mp_obj_t displayio_epaperdisplay_obj_get_rotation(mp_obj_t self_in) {
     displayio_epaperdisplay_obj_t *self = native_display(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_epaperdisplay_get_rotation(self));
@@ -330,7 +339,6 @@ MP_PROPERTY_GETSET(displayio_epaperdisplay_rotation_obj,
 
 //|     bus: _DisplayBus
 //|     """The bus being used by the display"""
-//|
 STATIC mp_obj_t displayio_epaperdisplay_obj_get_bus(mp_obj_t self_in) {
     displayio_epaperdisplay_obj_t *self = native_display(self_in);
     return common_hal_displayio_epaperdisplay_get_bus(self);

--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -43,7 +43,17 @@
 //|     """Manage updating a display over SPI four wire protocol in the background while Python code runs.
 //|     It doesn't handle display initialization."""
 //|
-//|     def __init__(self, spi_bus: busio.SPI, *, command: Optional[microcontroller.Pin], chip_select: microcontroller.Pin, reset: Optional[microcontroller.Pin] = None, baudrate: int = 24000000, polarity: int = 0, phase: int = 0) -> None:
+//|     def __init__(
+//|         self,
+//|         spi_bus: busio.SPI,
+//|         *,
+//|         command: Optional[microcontroller.Pin],
+//|         chip_select: microcontroller.Pin,
+//|         reset: Optional[microcontroller.Pin] = None,
+//|         baudrate: int = 24000000,
+//|         polarity: int = 0,
+//|         phase: int = 0
+//|     ) -> None:
 //|         """Create a FourWire object associated with the given pins.
 //|
 //|         The SPI bus and pins are then in use by the display until `displayio.release_displays()` is
@@ -65,7 +75,6 @@
 //|         :param int phase: the edge of the clock that data is captured. First (0)
 //|             or second (1). Rising or falling depends on clock polarity."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_spi_bus, ARG_command, ARG_chip_select, ARG_reset, ARG_baudrate, ARG_polarity, ARG_phase };
     static const mp_arg_t allowed_args[] = {
@@ -101,7 +110,6 @@ STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_
 //|         """Performs a hardware reset via the reset pin. Raises an exception if called when no reset pin
 //|         is available."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_fourwire_obj_reset(mp_obj_t self_in) {
     displayio_fourwire_obj_t *self = self_in;
 
@@ -112,11 +120,12 @@ STATIC mp_obj_t displayio_fourwire_obj_reset(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(displayio_fourwire_reset_obj, displayio_fourwire_obj_reset);
 
-//|     def send(self, command: int, data: ReadableBuffer, *, toggle_every_byte: bool = False) -> None:
+//|     def send(
+//|         self, command: int, data: ReadableBuffer, *, toggle_every_byte: bool = False
+//|     ) -> None:
 //|         """Sends the given command value followed by the full set of data. Display state, such as
 //|         vertical scroll, set via ``send`` may or may not be reset once the code is done."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_fourwire_obj_send(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_command, ARG_data, ARG_toggle_every_byte };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -46,7 +46,6 @@
 //|         :param int x: Initial x position within the parent.
 //|         :param int y: Initial y position within the parent."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_group_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_scale, ARG_x, ARG_y };
     static const mp_arg_t allowed_args[] = {
@@ -79,7 +78,6 @@ displayio_group_t *native_group(mp_obj_t group_obj) {
 //|     hidden: bool
 //|     """True when the Group and all of it's layers are not visible. When False, the Group's layers
 //|     are visible if they haven't been hidden."""
-//|
 STATIC mp_obj_t displayio_group_obj_get_hidden(mp_obj_t self_in) {
     displayio_group_t *self = native_group(self_in);
     return mp_obj_new_bool(common_hal_displayio_group_get_hidden(self));
@@ -101,7 +99,6 @@ MP_PROPERTY_GETSET(displayio_group_hidden_obj,
 //|     scale: int
 //|     """Scales each pixel within the Group in both directions. For example, when scale=2 each pixel
 //|     will be represented by 2x2 pixels."""
-//|
 STATIC mp_obj_t displayio_group_obj_get_scale(mp_obj_t self_in) {
     displayio_group_t *self = native_group(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_group_get_scale(self));
@@ -124,7 +121,6 @@ MP_PROPERTY_GETSET(displayio_group_scale_obj,
 
 //|     x: int
 //|     """X position of the Group in the parent."""
-//|
 STATIC mp_obj_t displayio_group_obj_get_x(mp_obj_t self_in) {
     displayio_group_t *self = native_group(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_group_get_x(self));
@@ -146,7 +142,6 @@ MP_PROPERTY_GETSET(displayio_group_x_obj,
 
 //|     y: int
 //|     """Y position of the Group in the parent."""
-//|
 STATIC mp_obj_t displayio_group_obj_get_y(mp_obj_t self_in) {
     displayio_group_t *self = native_group(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_group_get_y(self));
@@ -166,10 +161,12 @@ MP_PROPERTY_GETSET(displayio_group_y_obj,
     (mp_obj_t)&displayio_group_get_y_obj,
     (mp_obj_t)&displayio_group_set_y_obj);
 
-//|     def append(self, layer: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid]) -> None:
+//|     def append(
+//|         self,
+//|         layer: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid],
+//|     ) -> None:
 //|         """Append a layer to the group. It will be drawn above other layers."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_group_obj_append(mp_obj_t self_in, mp_obj_t layer) {
     displayio_group_t *self = native_group(self_in);
     common_hal_displayio_group_insert(self, common_hal_displayio_group_get_len(self), layer);
@@ -177,10 +174,13 @@ STATIC mp_obj_t displayio_group_obj_append(mp_obj_t self_in, mp_obj_t layer) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_group_append_obj, displayio_group_obj_append);
 
-//|     def insert(self, index: int, layer: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid]) -> None:
+//|     def insert(
+//|         self,
+//|         index: int,
+//|         layer: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid],
+//|     ) -> None:
 //|         """Insert a layer into the group."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_group_obj_insert(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t layer) {
     displayio_group_t *self = native_group(self_in);
     if ((size_t)MP_OBJ_SMALL_INT_VALUE(index_obj) == common_hal_displayio_group_get_len(self)) {
@@ -193,10 +193,12 @@ STATIC mp_obj_t displayio_group_obj_insert(mp_obj_t self_in, mp_obj_t index_obj,
 MP_DEFINE_CONST_FUN_OBJ_3(displayio_group_insert_obj, displayio_group_obj_insert);
 
 
-//|     def index(self, layer: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid]) -> int:
+//|     def index(
+//|         self,
+//|         layer: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid],
+//|     ) -> int:
 //|         """Returns the index of the first copy of layer. Raises ValueError if not found."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_group_obj_index(mp_obj_t self_in, mp_obj_t layer) {
     displayio_group_t *self = native_group(self_in);
     mp_int_t index = common_hal_displayio_group_index(self, layer);
@@ -207,10 +209,11 @@ STATIC mp_obj_t displayio_group_obj_index(mp_obj_t self_in, mp_obj_t layer) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_group_index_obj, displayio_group_obj_index);
 
-//|     def pop(self, i: int = -1) -> Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid]:
+//|     def pop(
+//|         self, i: int = -1
+//|     ) -> Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid]:
 //|         """Remove the ith item and return it."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_group_obj_pop(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_i };
     static const mp_arg_t allowed_args[] = {
@@ -230,10 +233,12 @@ STATIC mp_obj_t displayio_group_obj_pop(size_t n_args, const mp_obj_t *pos_args,
 MP_DEFINE_CONST_FUN_OBJ_KW(displayio_group_pop_obj, 1, displayio_group_obj_pop);
 
 
-//|     def remove(self, layer: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid]) -> None:
+//|     def remove(
+//|         self,
+//|         layer: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid],
+//|     ) -> None:
 //|         """Remove the first copy of layer. Raises ValueError if it is not present."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_group_obj_remove(mp_obj_t self_in, mp_obj_t layer) {
     mp_obj_t index = displayio_group_obj_index(self_in, layer);
     displayio_group_t *self = native_group(self_in);
@@ -243,13 +248,10 @@ STATIC mp_obj_t displayio_group_obj_remove(mp_obj_t self_in, mp_obj_t layer) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_group_remove_obj, displayio_group_obj_remove);
 
-//|     def __bool__(self) -> bool:
-//|         ...
-//|
+//|     def __bool__(self) -> bool: ...
 //|     def __len__(self) -> int:
 //|         """Returns the number of layers in a Group"""
 //|         ...
-//|
 STATIC mp_obj_t group_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     displayio_group_t *self = native_group(self_in);
     uint16_t len = common_hal_displayio_group_get_len(self);
@@ -263,22 +265,26 @@ STATIC mp_obj_t group_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     }
 }
 
-//|     def __getitem__(self, index: int) -> Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid]:
+//|     def __getitem__(
+//|         self, index: int
+//|     ) -> Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid]:
 //|         """Returns the value at the given index.
 //|
 //|         This allows you to::
 //|
 //|           print(group[0])"""
 //|         ...
-//|
-//|     def __setitem__(self, index: int, value: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid]) -> None:
+//|     def __setitem__(
+//|         self,
+//|         index: int,
+//|         value: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid],
+//|     ) -> None:
 //|         """Sets the value at the given index.
 //|
 //|         This allows you to::
 //|
 //|           group[0] = sprite"""
 //|         ...
-//|
 //|     def __delitem__(self, index: int) -> None:
 //|         """Deletes the value at the given index.
 //|
@@ -286,7 +292,6 @@ STATIC mp_obj_t group_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 //|
 //|           del group[0]"""
 //|         ...
-//|
 STATIC mp_obj_t group_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t value) {
     displayio_group_t *self = native_group(self_in);
 
@@ -310,7 +315,6 @@ STATIC mp_obj_t group_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t valu
 //|     def sort(self, key: function, reverse: bool) -> None:
 //|         """Sort the members of the group."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_group_obj_sort(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     displayio_group_t *self = native_group(pos_args[0]);
     mp_obj_t *args = m_new(mp_obj_t, n_args);

--- a/shared-bindings/displayio/I2CDisplay.c
+++ b/shared-bindings/displayio/I2CDisplay.c
@@ -43,7 +43,13 @@
 //|     """Manage updating a display over I2C in the background while Python code runs.
 //|     It doesn't handle display initialization."""
 //|
-//|     def __init__(self, i2c_bus: busio.I2C, *, device_address: int, reset: Optional[microcontroller.Pin] = None) -> None:
+//|     def __init__(
+//|         self,
+//|         i2c_bus: busio.I2C,
+//|         *,
+//|         device_address: int,
+//|         reset: Optional[microcontroller.Pin] = None
+//|     ) -> None:
 //|         """Create a I2CDisplay object associated with the given I2C bus and reset pin.
 //|
 //|         The I2C bus and pins are then in use by the display until `displayio.release_displays()` is
@@ -55,7 +61,6 @@
 //|         :param int device_address: The I2C address of the device
 //|         :param microcontroller.Pin reset: Reset pin. When None only software reset can be used"""
 //|         ...
-//|
 STATIC mp_obj_t displayio_i2cdisplay_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_i2c_bus, ARG_device_address, ARG_reset };
     static const mp_arg_t allowed_args[] = {
@@ -81,7 +86,6 @@ STATIC mp_obj_t displayio_i2cdisplay_make_new(const mp_obj_type_t *type, size_t 
 //|         """Performs a hardware reset via the reset pin. Raises an exception if called when no reset pin
 //|         is available."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_i2cdisplay_obj_reset(mp_obj_t self_in) {
     displayio_i2cdisplay_obj_t *self = self_in;
 
@@ -96,7 +100,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(displayio_i2cdisplay_reset_obj, displayio_i2cdisplay_o
 //|         """Sends the given command value followed by the full set of data. Display state, such as
 //|         vertical scroll, set via ``send`` may or may not be reset once the code is done."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_i2cdisplay_obj_send(mp_obj_t self, mp_obj_t command_obj, mp_obj_t data_obj) {
     mp_int_t command_int = mp_obj_get_int(command_obj);
     mp_arg_validate_int_range(command_int, 0, 255, MP_QSTR_command);

--- a/shared-bindings/displayio/OnDiskBitmap.c
+++ b/shared-bindings/displayio/OnDiskBitmap.c
@@ -67,7 +67,7 @@
 //|       while True:
 //|           pass"""
 //|
-//|     def __init__(self, file: Union[str,typing.BinaryIO]) -> None:
+//|     def __init__(self, file: Union[str, typing.BinaryIO]) -> None:
 //|         """Create an OnDiskBitmap object with the given file.
 //|
 //|         :param file file: The name of the bitmap file.  For backwards compatibility, a file opened in binary mode may also be passed.
@@ -78,7 +78,6 @@
 //|         of CircuitPython will remove the ability to pass in an opened file.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t displayio_ondiskbitmap_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
     mp_obj_t arg = all_args[0];
@@ -99,7 +98,6 @@ STATIC mp_obj_t displayio_ondiskbitmap_make_new(const mp_obj_type_t *type, size_
 
 //|     width: int
 //|     """Width of the bitmap. (read only)"""
-//|
 STATIC mp_obj_t displayio_ondiskbitmap_obj_get_width(mp_obj_t self_in) {
     displayio_ondiskbitmap_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -113,7 +111,6 @@ MP_PROPERTY_GETTER(displayio_ondiskbitmap_width_obj,
 
 //|     height: int
 //|     """Height of the bitmap. (read only)"""
-//|
 STATIC mp_obj_t displayio_ondiskbitmap_obj_get_height(mp_obj_t self_in) {
     displayio_ondiskbitmap_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -129,7 +126,6 @@ MP_PROPERTY_GETTER(displayio_ondiskbitmap_height_obj,
 //|     """The image's pixel_shader.  The type depends on the underlying
 //|     bitmap's structure.  The pixel shader can be modified (e.g., to set the
 //|     transparent pixel or, for palette shaded images, to update the palette.)"""
-//|
 STATIC mp_obj_t displayio_ondiskbitmap_obj_get_pixel_shader(mp_obj_t self_in) {
     displayio_ondiskbitmap_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_displayio_ondiskbitmap_get_pixel_shader(self);

--- a/shared-bindings/displayio/Palette.c
+++ b/shared-bindings/displayio/Palette.c
@@ -45,7 +45,6 @@
 //|
 //|         :param int color_count: The number of colors in the Palette"""
 //|         ...
-//|
 // TODO(tannewt): Add support for other color formats.
 // TODO(tannewt): Add support for 8-bit alpha blending.
 //|
@@ -64,13 +63,10 @@ STATIC mp_obj_t displayio_palette_make_new(const mp_obj_type_t *type, size_t n_a
     return MP_OBJ_FROM_PTR(self);
 }
 
-//|     def __bool__(self) -> bool:
-//|         ...
-//|
+//|     def __bool__(self) -> bool: ...
 //|     def __len__(self) -> int:
 //|         """Returns the number of colors in a Palette"""
 //|         ...
-//|
 STATIC mp_obj_t group_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     displayio_palette_t *self = MP_OBJ_TO_PTR(self_in);
     switch (op) {
@@ -86,8 +82,9 @@ STATIC mp_obj_t group_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 //|     def __getitem__(self, index: int) -> Optional[int]:
 //|         r"""Return the pixel color at the given index as an integer."""
 //|         ...
-//|
-//|     def __setitem__(self, index: int, value: Union[int, ReadableBuffer, Tuple[int, int, int]]) -> None:
+//|     def __setitem__(
+//|         self, index: int, value: Union[int, ReadableBuffer, Tuple[int, int, int]]
+//|     ) -> None:
 //|         r"""Sets the pixel color at the given index. The index should be an integer in the range 0 to color_count-1.
 //|
 //|         The value argument represents a color, and can be from 0x000000 to 0xFFFFFF (to represent an RGB value).
@@ -102,7 +99,6 @@ STATIC mp_obj_t group_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 //|           palette[3] = bytearray(b'\x00\x00\xFF')   # set using a bytearay of 3 or 4 bytes
 //|           palette[4] = (10, 20, 30)                 # set using a tuple of 3 integers"""
 //|         ...
-//|
 STATIC mp_obj_t palette_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {
     if (value == MP_OBJ_NULL) {
         // delete item
@@ -150,9 +146,7 @@ STATIC mp_obj_t palette_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t val
     return mp_const_none;
 }
 
-//|     def make_transparent(self, palette_index: int) -> None:
-//|         ...
-//|
+//|     def make_transparent(self, palette_index: int) -> None: ...
 STATIC mp_obj_t displayio_palette_obj_make_transparent(mp_obj_t self_in, mp_obj_t palette_index_obj) {
     displayio_palette_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -164,9 +158,7 @@ STATIC mp_obj_t displayio_palette_obj_make_transparent(mp_obj_t self_in, mp_obj_
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_palette_make_transparent_obj, displayio_palette_obj_make_transparent);
 
-//|     def make_opaque(self, palette_index: int) -> None:
-//|         ...
-//|
+//|     def make_opaque(self, palette_index: int) -> None: ...
 STATIC mp_obj_t displayio_palette_obj_make_opaque(mp_obj_t self_in, mp_obj_t palette_index_obj) {
     displayio_palette_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -181,7 +173,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_palette_make_opaque_obj, displayio_palette_o
 //|     def is_transparent(self, palette_index: int) -> bool:
 //|         """Returns `True` if the palette index is transparent.  Returns `False` if opaque."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_palette_obj_is_transparent(mp_obj_t self_in, mp_obj_t palette_index_obj) {
     displayio_palette_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/displayio/Shape.c
+++ b/shared-bindings/displayio/Shape.c
@@ -37,7 +37,9 @@
 //| class Shape:
 //|     """Represents a shape made by defining boundaries that may be mirrored."""
 //|
-//|     def __init__(self, width: int, height: int, *, mirror_x: bool = False, mirror_y: bool = False) -> None:
+//|     def __init__(
+//|         self, width: int, height: int, *, mirror_x: bool = False, mirror_y: bool = False
+//|     ) -> None:
 //|         """Create a Shape object with the given fixed size. Each pixel is one bit and is stored by the
 //|         column boundaries of the shape on each row. Each row's boundary defaults to the full row.
 //|
@@ -46,7 +48,6 @@
 //|         :param bool mirror_x: When true the left boundary is mirrored to the right.
 //|         :param bool mirror_y: When true the top boundary is mirrored to the bottom."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_shape_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_width, ARG_height, ARG_mirror_x, ARG_mirror_y };
     static const mp_arg_t allowed_args[] = {
@@ -76,7 +77,6 @@ STATIC mp_obj_t displayio_shape_make_new(const mp_obj_type_t *type, size_t n_arg
 //|     def set_boundary(self, y: int, start_x: int, end_x: int) -> None:
 //|         """Loads pre-packed data into the given row."""
 //|         ...
-//|
 STATIC mp_obj_t displayio_shape_obj_set_boundary(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     displayio_shape_t *self = MP_OBJ_TO_PTR(args[0]);

--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -48,7 +48,19 @@
 //|
 //|     A single tile grid is also known as a Sprite."""
 //|
-//|     def __init__(self, bitmap: Union[Bitmap, OnDiskBitmap, Shape], *, pixel_shader: Union[ColorConverter, Palette], width: int = 1, height: int = 1, tile_width: Optional[int] = None, tile_height: Optional[int] = None, default_tile: int = 0, x: int = 0, y: int = 0) -> None:
+//|     def __init__(
+//|         self,
+//|         bitmap: Union[Bitmap, OnDiskBitmap, Shape],
+//|         *,
+//|         pixel_shader: Union[ColorConverter, Palette],
+//|         width: int = 1,
+//|         height: int = 1,
+//|         tile_width: Optional[int] = None,
+//|         tile_height: Optional[int] = None,
+//|         default_tile: int = 0,
+//|         x: int = 0,
+//|         y: int = 0
+//|     ) -> None:
 //|         """Create a TileGrid object. The bitmap is source for 2d pixels. The pixel_shader is used to
 //|         convert the value and its location to a display native pixel color. This may be a simple color
 //|         palette lookup, a gradient, a pattern or a color transformer.
@@ -66,7 +78,6 @@
 //|         :param int default_tile: Default tile index to show.
 //|         :param int x: Initial x position of the left edge within the parent.
 //|         :param int y: Initial y position of the top edge within the parent."""
-//|
 STATIC mp_obj_t displayio_tilegrid_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_bitmap, ARG_pixel_shader, ARG_width, ARG_height, ARG_tile_width, ARG_tile_height, ARG_default_tile, ARG_x, ARG_y };
     static const mp_arg_t allowed_args[] = {
@@ -146,7 +157,6 @@ static displayio_tilegrid_t *native_tilegrid(mp_obj_t tilegrid_obj) {
 
 //|     hidden: bool
 //|     """True when the TileGrid is hidden. This may be False even when a part of a hidden Group."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_hidden(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return mp_obj_new_bool(common_hal_displayio_tilegrid_get_hidden(self));
@@ -167,7 +177,6 @@ MP_PROPERTY_GETSET(displayio_tilegrid_hidden_obj,
 
 //|     x: int
 //|     """X position of the left edge in the parent."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_x(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_tilegrid_get_x(self));
@@ -189,7 +198,6 @@ MP_PROPERTY_GETSET(displayio_tilegrid_x_obj,
 
 //|     y: int
 //|     """Y position of the top edge in the parent."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_y(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_tilegrid_get_y(self));
@@ -211,7 +219,6 @@ MP_PROPERTY_GETSET(displayio_tilegrid_y_obj,
 
 //|     width: int
 //|     """Width of the tilegrid in tiles."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_width(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_tilegrid_get_width(self));
@@ -223,7 +230,6 @@ MP_PROPERTY_GETTER(displayio_tilegrid_width_obj,
 
 //|     height: int
 //|     """Height of the tilegrid in tiles."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_height(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_tilegrid_get_height(self));
@@ -235,7 +241,6 @@ MP_PROPERTY_GETTER(displayio_tilegrid_height_obj,
 
 //|     tile_width: int
 //|     """Width of a single tile in pixels."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_tile_width(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_tilegrid_get_tile_width(self));
@@ -247,7 +252,6 @@ MP_PROPERTY_GETTER(displayio_tilegrid_tile_width_obj,
 
 //|     tile_height: int
 //|     """Height of a single tile in pixels."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_tile_height(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_displayio_tilegrid_get_tile_height(self));
@@ -259,7 +263,6 @@ MP_PROPERTY_GETTER(displayio_tilegrid_tile_height_obj,
 
 //|     flip_x: bool
 //|     """If true, the left edge rendered will be the right edge of the right-most tile."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_flip_x(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return mp_obj_new_bool(common_hal_displayio_tilegrid_get_flip_x(self));
@@ -280,7 +283,6 @@ MP_PROPERTY_GETSET(displayio_tilegrid_flip_x_obj,
 
 //|     flip_y: bool
 //|     """If true, the top edge rendered will be the bottom edge of the bottom-most tile."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_flip_y(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return mp_obj_new_bool(common_hal_displayio_tilegrid_get_flip_y(self));
@@ -303,7 +305,6 @@ MP_PROPERTY_GETSET(displayio_tilegrid_flip_y_obj,
 //|     transpose_xy: bool
 //|     """If true, the TileGrid's axis will be swapped. When combined with mirroring, any 90 degree
 //|     rotation can be achieved along with the corresponding mirrored version."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_transpose_xy(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return mp_obj_new_bool(common_hal_displayio_tilegrid_get_transpose_xy(self));
@@ -324,8 +325,7 @@ MP_PROPERTY_GETSET(displayio_tilegrid_transpose_xy_obj,
 
 //|     def contains(self, touch_tuple: tuple) -> bool:
 //|         """Returns True if the first two values in ``touch_tuple`` represent an x,y coordinate
-//|            inside the tilegrid rectangle bounds."""
-//|
+//|         inside the tilegrid rectangle bounds."""
 STATIC mp_obj_t displayio_tilegrid_obj_contains(mp_obj_t self_in, mp_obj_t touch_tuple) {
     displayio_tilegrid_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -342,7 +342,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_tilegrid_contains_obj, displayio_tilegrid_ob
 
 //|     pixel_shader: Union[ColorConverter, Palette]
 //|     """The pixel shader of the tilegrid."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_pixel_shader(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return common_hal_displayio_tilegrid_get_pixel_shader(self);
@@ -365,9 +364,8 @@ MP_PROPERTY_GETSET(displayio_tilegrid_pixel_shader_obj,
     (mp_obj_t)&displayio_tilegrid_get_pixel_shader_obj,
     (mp_obj_t)&displayio_tilegrid_set_pixel_shader_obj);
 
-//|     bitmap: Union[Bitmap,OnDiskBitmap,Shape]
+//|     bitmap: Union[Bitmap, OnDiskBitmap, Shape]
 //|     """The bitmap of the tilegrid."""
-//|
 STATIC mp_obj_t displayio_tilegrid_obj_get_bitmap(mp_obj_t self_in) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     return common_hal_displayio_tilegrid_get_bitmap(self);
@@ -436,7 +434,6 @@ MP_PROPERTY_GETSET(displayio_tilegrid_bitmap_obj,
 //|
 //|           print(grid[0])"""
 //|         ...
-//|
 //|     def __setitem__(self, index: Union[Tuple[int, int], int], value: int) -> None:
 //|         """Sets the tile index at the given index. The index can either be an x,y tuple or an int equal
 //|         to ``y * width + x``.
@@ -449,7 +446,6 @@ MP_PROPERTY_GETSET(displayio_tilegrid_bitmap_obj,
 //|
 //|           grid[0,0] = 10"""
 //|         ...
-//|
 STATIC mp_obj_t tilegrid_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t value_obj) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
 

--- a/shared-bindings/displayio/__init__.c
+++ b/shared-bindings/displayio/__init__.c
@@ -55,7 +55,6 @@
 //| refer to `this Learn guide
 //| <https://learn.adafruit.com/circuitpython-display-support-using-displayio>`_.
 //| """
-//|
 
 //| import paralleldisplay
 
@@ -67,7 +66,6 @@
 //|     Use this once in your code.py if you initialize a display. Place it right before the
 //|     initialization so the display is active as long as possible."""
 //|     ...
-//|
 STATIC mp_obj_t displayio_release_displays(void) {
     common_hal_displayio_release_displays();
     return mp_const_none;

--- a/shared-bindings/dotenv/__init__.c
+++ b/shared-bindings/dotenv/__init__.c
@@ -65,11 +65,10 @@
 
 //| def get_key(dotenv_path: str, key_to_get: str) -> Optional[str]:
 //|     """Get the value for the given key from the given .env file. If the key occurs multiple
-//|        times in the file, then the last value will be returned.
+//|     times in the file, then the last value will be returned.
 //|
-//|        Returns None if the key isn't found or doesn't have a value."""
+//|     Returns None if the key isn't found or doesn't have a value."""
 //|     ...
-//|
 STATIC mp_obj_t _dotenv_get_key(mp_obj_t path_in, mp_obj_t key_to_get_in) {
     return common_hal_dotenv_get_key(mp_obj_str_get_str(path_in),
         mp_obj_str_get_str(key_to_get_in));
@@ -78,11 +77,10 @@ MP_DEFINE_CONST_FUN_OBJ_2(dotenv_get_key_obj, _dotenv_get_key);
 
 //| def load_dotenv() -> None:
 //|     """Does nothing in CircuitPython because os.getenv will automatically read .env when
-//|        available.
+//|     available.
 //|
-//|        Present in CircuitPython so CPython-compatible code can use it without error."""
+//|     Present in CircuitPython so CPython-compatible code can use it without error."""
 //|     ...
-//|
 STATIC mp_obj_t dotenv_load_dotenv(void) {
     return mp_const_none;
 }

--- a/shared-bindings/dualbank/__init__.c
+++ b/shared-bindings/dualbank/__init__.c
@@ -54,16 +54,14 @@
 //|     dualbank.switch()
 //| """
 //| ...
-//|
 
-//| def flash(buffer: ReadableBuffer, offset: int=0) -> None:
+//| def flash(buffer: ReadableBuffer, offset: int = 0) -> None:
 //|     """Writes one of two app partitions at the given offset.
 //|
 //|     This can be called multiple times when flashing the firmware
 //|     in small chunks.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t dualbank_flash(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_offset };
     static const mp_arg_t allowed_args[] = {
@@ -93,7 +91,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(dualbank_flash_obj, 0, dualbank_flash);
 //|     just switched over to.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t dualbank_switch(void) {
     common_hal_dualbank_switch();
     return mp_const_none;

--- a/shared-bindings/floppyio/__init__.c
+++ b/shared-bindings/floppyio/__init__.c
@@ -34,7 +34,9 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 
-//| def flux_readinto(buffer: WriteableBuffer, data: digitalio.DigitalInOut, index: digitalio.DigitalInOut) -> int:
+//| def flux_readinto(
+//|     buffer: WriteableBuffer, data: digitalio.DigitalInOut, index: digitalio.DigitalInOut
+//| ) -> int:
 //|     """Read flux transition information into the buffer.
 //|
 //|     The function returns when the buffer has filled, or when the index input
@@ -48,7 +50,6 @@
 //|     :return: The actual number of bytes of read
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t floppyio_flux_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_data, ARG_index };
     static const mp_arg_t allowed_args[] = {
@@ -68,7 +69,9 @@ STATIC mp_obj_t floppyio_flux_readinto(size_t n_args, const mp_obj_t *pos_args, 
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(floppyio_flux_readinto_obj, 0, floppyio_flux_readinto);
 
-//| def mfm_readinto(buffer: WriteableBuffer, data: digitalio.DigitalInOut, index: digitalio.DigitalInOut) -> int:
+//| def mfm_readinto(
+//|     buffer: WriteableBuffer, data: digitalio.DigitalInOut, index: digitalio.DigitalInOut
+//| ) -> int:
 //|     """Read mfm blocks into the buffer.
 //|
 //|     The track is assumed to consist of 512-byte sectors.
@@ -83,7 +86,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(floppyio_flux_readinto_obj, 0, floppyio_flux_readinto
 //|     :return: The actual number of sectors read
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t floppyio_mfm_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_data, ARG_index };
     static const mp_arg_t allowed_args[] = {
@@ -109,7 +111,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(floppyio_mfm_readinto_obj, 0, floppyio_mfm_readinto);
 
 //| samplerate: int
 //| """The approximate sample rate in Hz used by flux_readinto."""
-//|
 
 STATIC const mp_rom_map_elem_t floppyio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_floppyio) },

--- a/shared-bindings/fontio/BuiltinFont.c
+++ b/shared-bindings/fontio/BuiltinFont.c
@@ -36,10 +36,11 @@
 #include "shared-bindings/util.h"
 #include "supervisor/shared/translate/translate.h"
 
-//| from typing_extensions import Protocol # for compat with python < 3.8
+//| from typing_extensions import Protocol  # for compat with python < 3.8
 //|
 //| class FontProtocol(Protocol):
 //|     """A protocol shared by `BuiltinFont` and classes in ``adafruit_bitmap_font``"""
+//|
 //|     def get_bounding_box(self) -> Union[Tuple[int, int], Tuple[int, int, int, int]]:
 //|         """Retrieve the maximum bounding box of any glyph in the font.
 //|
@@ -47,13 +48,11 @@
 //|         The two element version is ``(width, height)``, in which
 //|         ``x_offset`` and ``y_offset`` are assumed to be zero."""
 //|         pass
-//|
 //|     def get_glyph(self, codepoint: int) -> Optional[Glyph]:
 //|         """Retrieve the Glyph for a given code point
 //|
 //|         If the code point is not present in the font, `None` is returned."""
 //|         pass
-//|
 
 //| class BuiltinFont:
 //|     """A font built into CircuitPython"""
@@ -63,13 +62,11 @@
 //|         `Adafruit_CircuitPython_Bitmap_Font <https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font>`_
 //|         library for dynamically loaded fonts."""
 //|         ...
-//|
 
 //|     bitmap: displayio.Bitmap
 //|     """Bitmap containing all font glyphs starting with ASCII and followed by unicode. Use
 //|     `get_glyph` in most cases. This is useful for use with `displayio.TileGrid` and
 //|     `terminalio.Terminal`."""
-//|
 STATIC mp_obj_t fontio_builtinfont_obj_get_bitmap(mp_obj_t self_in) {
     fontio_builtinfont_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_fontio_builtinfont_get_bitmap(self);
@@ -82,7 +79,6 @@ MP_PROPERTY_GETTER(fontio_builtinfont_bitmap_obj,
 //|     def get_bounding_box(self) -> Tuple[int, int]:
 //|         """Returns the maximum bounds of all glyphs in the font in a tuple of two values: width, height."""
 //|         ...
-//|
 STATIC mp_obj_t fontio_builtinfont_obj_get_bounding_box(mp_obj_t self_in) {
     fontio_builtinfont_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -94,7 +90,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(fontio_builtinfont_get_bounding_box_obj, fontio_builti
 //|     def get_glyph(self, codepoint: int) -> Glyph:
 //|         """Returns a `fontio.Glyph` for the given codepoint or None if no glyph is available."""
 //|         ...
-//|
 STATIC mp_obj_t fontio_builtinfont_obj_get_glyph(mp_obj_t self_in, mp_obj_t codepoint_obj) {
     fontio_builtinfont_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/fontio/Glyph.c
+++ b/shared-bindings/fontio/Glyph.c
@@ -31,15 +31,17 @@
 //| class Glyph:
 //|     """Storage of glyph info"""
 //|
-//|     def __init__(self,
-//|                  bitmap: displayio.Bitmap,
-//|                  tile_index: int,
-//|                  width: int,
-//|                  height: int,
-//|                  dx: int,
-//|                  dy: int,
-//|                  shift_x: int,
-//|                  shift_y: int) -> None:
+//|     def __init__(
+//|         self,
+//|         bitmap: displayio.Bitmap,
+//|         tile_index: int,
+//|         width: int,
+//|         height: int,
+//|         dx: int,
+//|         dy: int,
+//|         shift_x: int,
+//|         shift_y: int,
+//|     ) -> None:
 //|         """Named tuple used to capture a single glyph and its attributes.
 //|
 //|         :param bitmap: the bitmap including the glyph
@@ -51,7 +53,6 @@
 //|         :param shift_x: the x difference to the next glyph
 //|         :param shift_y: the y difference to the next glyph"""
 //|         ...
-//|
 const mp_obj_namedtuple_type_t fontio_glyph_type = {
     .base = {
         .base = {

--- a/shared-bindings/fontio/__init__.c
+++ b/shared-bindings/fontio/__init__.c
@@ -42,7 +42,6 @@
 //|     `this Learn guide <https://learn.adafruit.com/custom-fonts-for-pyportal-circuitpython-display>`_
 //|
 //| """
-//|
 
 STATIC const mp_rom_map_elem_t fontio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_fontio) },

--- a/shared-bindings/framebufferio/FramebufferDisplay.c
+++ b/shared-bindings/framebufferio/FramebufferDisplay.c
@@ -47,14 +47,19 @@
 //|     objects in CircuitPython, Display objects live until `displayio.release_displays()`
 //|     is called. This is done so that CircuitPython can use the display itself."""
 //|
-//|     def __init__(self, framebuffer: circuitpython_typing.FrameBuffer, *, rotation: int = 0, auto_refresh: bool = True) -> None:
+//|     def __init__(
+//|         self,
+//|         framebuffer: circuitpython_typing.FrameBuffer,
+//|         *,
+//|         rotation: int = 0,
+//|         auto_refresh: bool = True
+//|     ) -> None:
 //|         """Create a Display object with the given framebuffer (a buffer, array, ulab.array, etc)
 //|
 //|         :param ~circuitpython_typing.FrameBuffer framebuffer: The framebuffer that the display is connected to
 //|         :param bool auto_refresh: Automatically refresh the screen
 //|         :param int rotation: The rotation of the display in degrees clockwise. Must be in 90 degree increments (0, 90, 180, 270)"""
 //|         ...
-//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_framebuffer, ARG_rotation, ARG_auto_refresh, NUM_ARGS };
     static const mp_arg_t allowed_args[] = {
@@ -99,7 +104,6 @@ static framebufferio_framebufferdisplay_obj_t *native_display(mp_obj_t display_o
 //|
 //|         :param Group group: The group to show."""
 //|         ...
-//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_show(mp_obj_t self_in, mp_obj_t group_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     displayio_group_t *group = NULL;
@@ -115,7 +119,9 @@ STATIC mp_obj_t framebufferio_framebufferdisplay_obj_show(mp_obj_t self_in, mp_o
 }
 MP_DEFINE_CONST_FUN_OBJ_2(framebufferio_framebufferdisplay_show_obj, framebufferio_framebufferdisplay_obj_show);
 
-//|     def refresh(self, *, target_frames_per_second: int = 60, minimum_frames_per_second: int = 1) -> bool:
+//|     def refresh(
+//|         self, *, target_frames_per_second: int = 60, minimum_frames_per_second: int = 1
+//|     ) -> bool:
 //|         """When auto refresh is off, waits for the target frame rate and then refreshes the display,
 //|         returning True. If the call has taken too long since the last refresh call for the given
 //|         target frame rate, then the refresh returns False immediately without updating the screen to
@@ -130,7 +136,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(framebufferio_framebufferdisplay_show_obj, framebuffer
 //|         :param int target_frames_per_second: How many times a second `refresh` should be called and the screen updated.
 //|         :param int minimum_frames_per_second: The minimum number of times the screen should be updated per second."""
 //|         ...
-//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_refresh(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_target_frames_per_second, ARG_minimum_frames_per_second };
     static const mp_arg_t allowed_args[] = {
@@ -152,7 +157,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(framebufferio_framebufferdisplay_refresh_obj, 1, fram
 
 //|     auto_refresh: bool
 //|     """True when the display is refreshed automatically."""
-//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_auto_refresh(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     return mp_obj_new_bool(common_hal_framebufferio_framebufferdisplay_get_auto_refresh(self));
@@ -174,7 +178,6 @@ MP_PROPERTY_GETSET(framebufferio_framebufferdisplay_auto_refresh_obj,
 
 //|     brightness: float
 //|     """The brightness of the display as a float. 0.0 is off and 1.0 is full brightness."""
-//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_brightness(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     mp_float_t brightness = common_hal_framebufferio_framebufferdisplay_get_brightness(self);
@@ -205,7 +208,6 @@ MP_PROPERTY_GETSET(framebufferio_framebufferdisplay_brightness_obj,
 
 //|     width: int
 //|     """Gets the width of the framebuffer"""
-//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_width(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_framebufferio_framebufferdisplay_get_width(self));
@@ -217,7 +219,6 @@ MP_PROPERTY_GETTER(framebufferio_framebufferdisplay_width_obj,
 
 //|     height: int
 //|     """Gets the height of the framebuffer"""
-//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_height(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_framebufferio_framebufferdisplay_get_height(self));
@@ -229,7 +230,6 @@ MP_PROPERTY_GETTER(framebufferio_framebufferdisplay_height_obj,
 
 //|     rotation: int
 //|     """The rotation of the display as an int in degrees."""
-//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_rotation(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_framebufferio_framebufferdisplay_get_rotation(self));
@@ -249,8 +249,6 @@ MP_PROPERTY_GETSET(framebufferio_framebufferdisplay_rotation_obj,
 
 //|     framebuffer: circuitpython_typing.FrameBuffer
 //|     """The framebuffer being used by the display"""
-//|
-//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_framebuffer(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     return common_hal_framebufferio_framebufferdisplay_get_framebuffer(self);
@@ -267,7 +265,6 @@ MP_PROPERTY_GETTER(framebufferio_framebufferframebuffer_obj,
 //|         :param int y: The top edge of the area
 //|         :param ~circuitpython_typing.WriteableBuffer buffer: The buffer in which to place the pixel data"""
 //|         ...
-//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_fill_row(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_y, ARG_buffer };
     static const mp_arg_t allowed_args[] = {
@@ -324,8 +321,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(framebufferio_framebufferdisplay_fill_row_obj, 1, fra
 
 //|     root_group: displayio.Group
 //|     """The root group on the display."""
-//|
-//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_root_group(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     return common_hal_framebufferio_framebufferdisplay_get_root_group(self);

--- a/shared-bindings/framebufferio/__init__.c
+++ b/shared-bindings/framebufferio/__init__.c
@@ -35,7 +35,6 @@
 //| It is used in conjunction with classes from `displayio` to actually
 //| place items on the display; and classes like `RGBMatrix` to actually
 //| drive the display."""
-//|
 
 #if CIRCUITPY_FRAMEBUFFERIO
 static const mp_rom_map_elem_t framebufferio_module_globals_table[] = {

--- a/shared-bindings/frequencyio/FrequencyIn.c
+++ b/shared-bindings/frequencyio/FrequencyIn.c
@@ -70,7 +70,6 @@
 //|               # as the value.
 //|               frequency.clear()"""
 //|         ...
-//|
 STATIC mp_obj_t frequencyio_frequencyin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, true);
 
@@ -96,7 +95,6 @@ STATIC mp_obj_t frequencyio_frequencyin_make_new(const mp_obj_type_t *type, size
 //|     def deinit(self) -> None:
 //|         """Deinitialises the FrequencyIn and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t frequencyio_frequencyin_deinit(mp_obj_t self_in) {
     frequencyio_frequencyin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_frequencyio_frequencyin_deinit(self);
@@ -113,14 +111,12 @@ STATIC void check_for_deinit(frequencyio_frequencyin_obj_t *self) {
 //|     def __enter__(self) -> FrequencyIn:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t frequencyio_frequencyin_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_frequencyio_frequencyin_deinit(args[0]);
@@ -131,7 +127,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(frequencyio_frequencyin___exit___obj,
 //|     def pause(self) -> None:
 //|         """Pause frequency capture."""
 //|         ...
-//|
 STATIC mp_obj_t frequencyio_frequencyin_obj_pause(mp_obj_t self_in) {
     frequencyio_frequencyin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -144,7 +139,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(frequencyio_frequencyin_pause_obj, frequencyio_frequen
 //|     def resume(self) -> None:
 //|         """Resumes frequency capture."""
 //|         ...
-//|
 STATIC mp_obj_t frequencyio_frequencyin_obj_resume(mp_obj_t self_in) {
     frequencyio_frequencyin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -157,7 +151,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(frequencyio_frequencyin_resume_obj, frequencyio_freque
 //|     def clear(self) -> None:
 //|         """Clears the last detected frequency capture value."""
 //|         ...
-//|
 
 STATIC mp_obj_t frequencyio_frequencyin_obj_clear(mp_obj_t self_in) {
     frequencyio_frequencyin_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -175,7 +168,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(frequencyio_frequencyin_clear_obj, frequencyio_frequen
 //|
 //|     .. note:: When setting a new ``capture_period``, all previous capture information is
 //|               cleared with a call to ``clear()``."""
-//|
 STATIC mp_obj_t frequencyio_frequencyin_obj_get_capture_period(mp_obj_t self_in) {
     frequencyio_frequencyin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -200,7 +192,6 @@ MP_PROPERTY_GETSET(frequencyio_frequencyin_capture_period_obj,
 //|     def __get__(self, index: int) -> int:
 //|         """Returns the value of the last frequency captured."""
 //|         ...
-//|
 STATIC mp_obj_t frequencyio_frequencyin_obj_get_value(mp_obj_t self_in) {
     frequencyio_frequencyin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/frequencyio/__init__.c
+++ b/shared-bindings/frequencyio/__init__.c
@@ -58,7 +58,6 @@
 //| CircuitPython will automatically turn off FrequencyIn capture when it resets all
 //| hardware after program completion. Use ``deinit()`` or a ``with`` statement
 //| to do it yourself."""
-//|
 
 STATIC const mp_rom_map_elem_t frequencyio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_frequencyio) },

--- a/shared-bindings/frequencyio/__init__.c
+++ b/shared-bindings/frequencyio/__init__.c
@@ -38,7 +38,6 @@
 //| .. warning:: This module is not available in SAMD21 builds. See the
 //|   :ref:`module-support-matrix` for more info.
 //|
-
 //| All classes change hardware state and should be deinitialized when they
 //| are no longer needed if the program continues after use. To do so, either
 //| call :py:meth:`!deinit` or use a context manager. See

--- a/shared-bindings/getpass/__init__.c
+++ b/shared-bindings/getpass/__init__.c
@@ -33,9 +33,8 @@
 //|
 //| """
 //| ...
-//|
 
-//| def getpass(prompt: Optional[str] = 'Password: ', stream: Optional[io.FileIO] = None) -> str:
+//| def getpass(prompt: Optional[str] = "Password: ", stream: Optional[io.FileIO] = None) -> str:
 //|
 //|     """Prompt the user without echoing.
 //|
@@ -44,7 +43,6 @@
 //|
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t getpass_getpass(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_prompt, ARG_stream };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/gifio/GifWriter.c
+++ b/shared-bindings/gifio/GifWriter.c
@@ -34,7 +34,15 @@
 #include "shared/runtime/context_manager_helpers.h"
 
 //| class GifWriter:
-//|     def __init__(self, file: Union[typing.BinaryIO, str], width:int, height:int, colorspace: displayio.Colorspace, loop:bool=True, dither:bool=False) -> None:
+//|     def __init__(
+//|         self,
+//|         file: Union[typing.BinaryIO, str],
+//|         width: int,
+//|         height: int,
+//|         colorspace: displayio.Colorspace,
+//|         loop: bool = True,
+//|         dither: bool = False,
+//|     ) -> None:
 //|         """Construct a GifWriter object
 //|
 //|         :param file: Either a file open in bytes mode, or the name of a file to open in bytes mode.
@@ -45,7 +53,6 @@
 //|         :param dither: If True, and the image is in color, a simple ordered dither is applied.
 //|         """
 //|         ...
-//|
 static mp_obj_t gifio_gifwriter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_file, ARG_width, ARG_height, ARG_colorspace, ARG_loop, ARG_dither };
     static const mp_arg_t allowed_args[] = {
@@ -91,7 +98,6 @@ static mp_obj_t gifio_gifwriter_make_new(const mp_obj_type_t *type, size_t n_arg
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 static mp_obj_t gifio_gifwriter___exit__(size_t n_args, const mp_obj_t *args) {
     gifio_gifwriter_t *self = MP_OBJ_TO_PTR(args[0]);
     shared_module_gifio_gifwriter_deinit(self);
@@ -102,7 +108,6 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(gifio_gifwriter___exit___obj, 4, 4, gifio_gi
 //|     def deinit(self) -> None:
 //|         """Close the underlying file."""
 //|         ...
-//|
 static mp_obj_t gifio_gifwriter_deinit(mp_obj_t self_in) {
     gifio_gifwriter_t *self = MP_OBJ_TO_PTR(self_in);
     shared_module_gifio_gifwriter_deinit(self);

--- a/shared-bindings/gifio/__init__.c
+++ b/shared-bindings/gifio/__init__.c
@@ -31,7 +31,6 @@
 
 //| """Access GIF-format images
 //| """
-//|
 STATIC const mp_rom_map_elem_t gifio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_gifio) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_GifWriter),  MP_ROM_PTR(&gifio_gifwriter_type)},

--- a/shared-bindings/gnss/GNSS.c
+++ b/shared-bindings/gnss/GNSS.c
@@ -29,14 +29,12 @@
 //|                     continue
 //|                 print("Latitude: {0:.6f} degrees".format(nav.latitude))
 //|                 print("Longitude: {0:.6f} degrees".format(nav.longitude))"""
-//|
 
 //|     def __init__(self, system: Union[SatelliteSystem, List[SatelliteSystem]]) -> None:
 //|         """Turn on the GNSS.
 //|
 //|         :param system: satellite system to use"""
 //|         ...
-//|
 STATIC mp_obj_t gnss_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     gnss_obj_t *self = m_new_obj(gnss_obj_t);
     self->base.type = &gnss_type;
@@ -71,7 +69,6 @@ STATIC mp_obj_t gnss_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
 //|     def deinit(self) -> None:
 //|         """Turn off the GNSS."""
 //|         ...
-//|
 STATIC mp_obj_t gnss_obj_deinit(mp_obj_t self_in) {
     gnss_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_gnss_deinit(self);
@@ -88,7 +85,6 @@ STATIC void check_for_deinit(gnss_obj_t *self) {
 //|     def update(self) -> None:
 //|         """Update GNSS positioning information."""
 //|         ...
-//|
 STATIC mp_obj_t gnss_obj_update(mp_obj_t self_in) {
     gnss_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -100,7 +96,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(gnss_update_obj, gnss_obj_update);
 
 //|     latitude: float
 //|     """Latitude of current position in degrees (float)."""
-//|
 STATIC mp_obj_t gnss_obj_get_latitude(mp_obj_t self_in) {
     gnss_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -113,7 +108,6 @@ MP_PROPERTY_GETTER(gnss_latitude_obj,
 
 //|     longitude: float
 //|     """Longitude of current position in degrees (float)."""
-//|
 STATIC mp_obj_t gnss_obj_get_longitude(mp_obj_t self_in) {
     gnss_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -126,7 +120,6 @@ MP_PROPERTY_GETTER(gnss_longitude_obj,
 
 //|     altitude: float
 //|     """Altitude of current position in meters (float)."""
-//|
 STATIC mp_obj_t gnss_obj_get_altitude(mp_obj_t self_in) {
     gnss_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -139,7 +132,6 @@ MP_PROPERTY_GETTER(gnss_altitude_obj,
 
 //|     timestamp: time.struct_time
 //|     """Time when the position data was updated."""
-//|
 STATIC mp_obj_t gnss_obj_get_timestamp(mp_obj_t self_in) {
     gnss_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -154,7 +146,6 @@ MP_PROPERTY_GETTER(gnss_timestamp_obj,
 
 //|     fix: PositionFix
 //|     """Fix mode."""
-//|
 STATIC mp_obj_t gnss_obj_get_fix(mp_obj_t self_in) {
     gnss_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/gnss/PositionFix.c
+++ b/shared-bindings/gnss/PositionFix.c
@@ -9,7 +9,6 @@
 //|
 //|     def __init__(self) -> None:
 //|         """Enum-like class to define the position fix mode."""
-//|
 //|     INVALID: PositionFix
 //|     """No measurement."""
 //|
@@ -18,7 +17,6 @@
 //|
 //|     FIX_3D: PositionFix
 //|     """3D fix."""
-//|
 const mp_obj_type_t gnss_positionfix_type;
 
 const gnss_positionfix_obj_t gnss_positionfix_invalid_obj = {

--- a/shared-bindings/gnss/SatelliteSystem.c
+++ b/shared-bindings/gnss/SatelliteSystem.c
@@ -9,7 +9,6 @@
 //|
 //|     def __init__(self) -> None:
 //|         """Enum-like class to define the satellite system type."""
-//|
 //|     GPS: SatelliteSystem
 //|     """Global Positioning System."""
 //|
@@ -24,7 +23,6 @@
 //|
 //|     QZSS_L1S: SatelliteSystem
 //|     """Quasi-Zenith Satellite System L1S."""
-//|
 const mp_obj_type_t gnss_satellitesystem_type;
 
 const gnss_satellitesystem_obj_t gnss_satellitesystem_gps_obj = {

--- a/shared-bindings/gnss/__init__.c
+++ b/shared-bindings/gnss/__init__.c
@@ -13,7 +13,6 @@
 //| """Global Navigation Satellite System
 //|
 //| The `gnss` module contains classes to control the GNSS and acquire positioning information."""
-//|
 STATIC const mp_rom_map_elem_t gnss_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_gnss) },
     { MP_ROM_QSTR(MP_QSTR_GNSS), MP_ROM_PTR(&gnss_type) },

--- a/shared-bindings/hashlib/Hash.c
+++ b/shared-bindings/hashlib/Hash.c
@@ -33,12 +33,10 @@
 
 //| class Hash:
 //|     """In progress hash algorithm. This object is always created by a `hashlib.new()`. It has no
-//|        user-visible constructor."""
-//|
+//|     user-visible constructor."""
 
 //|     digest_size: int
 //|     """Digest size in bytes"""
-//|
 STATIC mp_obj_t hashlib_hash_digest_size_get(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &hashlib_hash_type));
     hashlib_hash_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -52,7 +50,6 @@ MP_PROPERTY_GETTER(hashlib_hash_digest_size_obj, (mp_obj_t)&hashlib_hash_digest_
 //|
 //|         :param ~circuitpython_typing.ReadableBuffer data: Update the hash from data in this buffer"""
 //|         ...
-//|
 mp_obj_t hashlib_hash_update(mp_obj_t self_in, mp_obj_t buf_in) {
     mp_check_self(mp_obj_is_type(self_in, &hashlib_hash_type));
     hashlib_hash_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -68,7 +65,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(hashlib_hash_update_obj, hashlib_hash_update);
 //|     def digest(self) -> bytes:
 //|         """Returns the current digest as bytes() with a length of `hashlib.Hash.digest_size`."""
 //|         ...
-//|
 STATIC mp_obj_t hashlib_hash_digest(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &hashlib_hash_type));
     hashlib_hash_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/hashlib/__init__.c
+++ b/shared-bindings/hashlib/__init__.c
@@ -38,14 +38,13 @@
 //| |see_cpython_module| :mod:`cpython:hashlib`.
 //| """
 //|
-//| def new(name: str, data: bytes=b"") -> hashlib.Hash:
+//| def new(name: str, data: bytes = b"") -> hashlib.Hash:
 //|     """Returns a Hash object setup for the named algorithm. Raises ValueError when the named
 //|        algorithm is unsupported.
 //|
 //|     :return: a hash object for the given algorithm
 //|     :rtype: hashlib.Hash"""
 //|     ...
-//|
 STATIC mp_obj_t hashlib_new(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_name, ARG_data };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/hashlib/__init__.c
+++ b/shared-bindings/hashlib/__init__.c
@@ -38,7 +38,7 @@
 //| |see_cpython_module| :mod:`cpython:hashlib`.
 //| """
 //|
-//| def new(name, data=b"") -> hashlib.Hash:
+//| def new(name: str, data: bytes=b"") -> hashlib.Hash:
 //|     """Returns a Hash object setup for the named algorithm. Raises ValueError when the named
 //|        algorithm is unsupported.
 //|

--- a/shared-bindings/i2ctarget/I2CTarget.c
+++ b/shared-bindings/i2ctarget/I2CTarget.c
@@ -52,7 +52,13 @@ STATIC mp_obj_t mp_obj_new_i2ctarget_i2c_target_request(i2ctarget_i2c_target_obj
 //| class I2CTarget:
 //|     """Two wire serial protocol target"""
 //|
-//|     def __init__(self, scl: microcontroller.Pin, sda: microcontroller.Pin, addresses: Sequence[int], smbus: bool = False) -> None:
+//|     def __init__(
+//|         self,
+//|         scl: microcontroller.Pin,
+//|         sda: microcontroller.Pin,
+//|         addresses: Sequence[int],
+//|         smbus: bool = False,
+//|     ) -> None:
 //|         """I2C is a two-wire protocol for communicating between devices.
 //|         This implements the target (peripheral, sensor, secondary) side.
 //|
@@ -62,7 +68,6 @@ STATIC mp_obj_t mp_obj_new_i2ctarget_i2c_target_request(i2ctarget_i2c_target_obj
 //|         :type addresses: list[int]
 //|         :param bool smbus: Use SMBUS timings if the hardware supports it"""
 //|         ...
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     i2ctarget_i2c_target_obj_t *self = m_new_obj(i2ctarget_i2c_target_obj_t);
     self->base.type = &i2ctarget_i2c_target_type;
@@ -100,7 +105,6 @@ STATIC mp_obj_t i2ctarget_i2c_target_make_new(const mp_obj_type_t *type, size_t 
 //|     def deinit(self) -> None:
 //|         """Releases control of the underlying hardware so other classes can use it."""
 //|         ...
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_obj_deinit(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &i2ctarget_i2c_target_type));
     i2ctarget_i2c_target_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -112,14 +116,12 @@ MP_DEFINE_CONST_FUN_OBJ_1(i2ctarget_i2c_target_deinit_obj, i2ctarget_i2c_target_
 //|     def __enter__(self) -> I2CTarget:
 //|         """No-op used in Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware on context exit. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_obj___exit__(size_t n_args, const mp_obj_t *args) {
     mp_check_self(mp_obj_is_type(args[0], &i2ctarget_i2c_target_type));
     i2ctarget_i2c_target_obj_t *self = MP_OBJ_TO_PTR(args[0]);
@@ -134,7 +136,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(i2ctarget_i2c_target___exit___obj, 4,
 //|         :param float timeout: Timeout in seconds. Zero means wait forever, a negative value means check once
 //|         :return: I2CTargetRequest or None if timeout=-1 and there's no request
 //|         :rtype: ~i2ctarget.I2CTargetRequest"""
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_request(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mp_check_self(mp_obj_is_type(pos_args[0], &i2ctarget_i2c_target_type));
     i2ctarget_i2c_target_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
@@ -221,8 +222,9 @@ const mp_obj_type_t i2ctarget_i2c_target_type = {
 };
 
 //| class I2CTargetRequest:
-//|
-//|     def __init__(self, target: i2ctarget.I2CTarget, address: int, is_read: bool, is_restart: bool) -> None:
+//|     def __init__(
+//|         self, target: i2ctarget.I2CTarget, address: int, is_read: bool, is_restart: bool
+//|     ) -> None:
 //|         """Information about an I2C transfer request
 //|         This cannot be instantiated directly, but is returned by :py:meth:`I2CTarget.request`.
 //|
@@ -230,7 +232,6 @@ const mp_obj_type_t i2ctarget_i2c_target_type = {
 //|         :param address: I2C address
 //|         :param is_read: True if the main target is requesting data
 //|         :param is_restart: Repeated Start Condition"""
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_request_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 4, 4, false);
     return mp_obj_new_i2ctarget_i2c_target_request(args[0], mp_obj_get_int(args[1]), mp_obj_is_true(args[2]), mp_obj_is_true(args[3]));
@@ -239,13 +240,11 @@ STATIC mp_obj_t i2ctarget_i2c_target_request_make_new(const mp_obj_type_t *type,
 //|     def __enter__(self) -> I2CTargetRequest:
 //|         """No-op used in Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Close the request."""
 //|         ...
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_request_obj___exit__(size_t n_args, const mp_obj_t *args) {
     mp_check_self(mp_obj_is_type(args[0], &i2ctarget_i2c_target_request_type));
     i2ctarget_i2c_target_request_obj_t *self = MP_OBJ_TO_PTR(args[0]);
@@ -256,7 +255,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(i2ctarget_i2c_target_request___exit__
 
 //|     address: int
 //|     """The I2C address of the request."""
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_request_get_address(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &i2ctarget_i2c_target_request_type));
     i2ctarget_i2c_target_request_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -266,7 +264,6 @@ MP_DEFINE_CONST_PROP_GET(i2ctarget_i2c_target_request_address_obj, i2ctarget_i2c
 
 //|     is_read: bool
 //|     """The I2C main controller is reading from this target."""
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_request_get_is_read(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &i2ctarget_i2c_target_request_type));
     i2ctarget_i2c_target_request_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -276,7 +273,6 @@ MP_DEFINE_CONST_PROP_GET(i2ctarget_i2c_target_request_is_read_obj, i2ctarget_i2c
 
 //|     is_restart: bool
 //|     """Is Repeated Start Condition."""
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_request_get_is_restart(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &i2ctarget_i2c_target_request_type));
     i2ctarget_i2c_target_request_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -292,7 +288,6 @@ MP_DEFINE_CONST_PROP_GET(i2ctarget_i2c_target_request_is_restart_obj, i2ctarget_
 //|         :param ack: Whether or not to send an ACK after the n'th byte
 //|         :return: Bytes read"""
 //|         ...
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_request_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mp_check_self(mp_obj_is_type(pos_args[0], &i2ctarget_i2c_target_request_type));
     i2ctarget_i2c_target_request_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
@@ -350,7 +345,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(i2ctarget_i2c_target_request_read_obj, 1, i2ctarget_i
 //|         :param ~circuitpython_typing.ReadableBuffer buffer: Write out the data in this buffer
 //|         :return: Number of bytes written"""
 //|         ...
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_request_write(mp_obj_t self_in, mp_obj_t buf_in) {
     mp_check_self(mp_obj_is_type(self_in, &i2ctarget_i2c_target_request_type));
     i2ctarget_i2c_target_request_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -384,7 +378,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(i2ctarget_i2c_target_request_write_obj, i2ctarg
 //|
 //|         :param ack: Whether to send an ACK or NACK"""
 //|         ...
-//|
 STATIC mp_obj_t i2ctarget_i2c_target_request_ack(uint n_args, const mp_obj_t *args) {
     mp_check_self(mp_obj_is_type(args[0], &i2ctarget_i2c_target_request_type));
     i2ctarget_i2c_target_request_obj_t *self = MP_OBJ_TO_PTR(args[0]);

--- a/shared-bindings/i2ctarget/__init__.c
+++ b/shared-bindings/i2ctarget/__init__.c
@@ -91,7 +91,6 @@
 //|    Raspberry Pi in particular does not support this with its I2C hw block.
 //|    This can be worked around by using the ``i2c-gpio`` bit banging driver.
 //|    Since the RPi firmware uses the hw i2c, it's not possible to emulate a HAT eeprom."""
-//|
 
 STATIC const mp_rom_map_elem_t i2ctarget_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_i2ctarget) },

--- a/shared-bindings/imagecapture/ParallelImageCapture.c
+++ b/shared-bindings/imagecapture/ParallelImageCapture.c
@@ -55,7 +55,6 @@
 //|         :param microcontroller.Pin href: The horizontal reference input, which is high whenever the camera is transmitting valid pixel information.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t imagecapture_parallelimagecapture_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_data_pins, ARG_clock, ARG_vsync, ARG_href,
            NUM_ARGS };
@@ -90,7 +89,6 @@ STATIC mp_obj_t imagecapture_parallelimagecapture_make_new(const mp_obj_type_t *
 //|
 //|         This will stop a continuous-mode capture, if one is in progress."""
 //|         ...
-//|
 STATIC mp_obj_t imagecapture_parallelimagecapture_capture(mp_obj_t self_in, mp_obj_t buffer) {
     imagecapture_parallelimagecapture_obj_t *self = (imagecapture_parallelimagecapture_obj_t *)self_in;
     common_hal_imagecapture_parallelimagecapture_singleshot_capture(self, buffer);
@@ -99,7 +97,9 @@ STATIC mp_obj_t imagecapture_parallelimagecapture_capture(mp_obj_t self_in, mp_o
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(imagecapture_parallelimagecapture_capture_obj, imagecapture_parallelimagecapture_capture);
 
-//|     def continuous_capture_start(self, buffer1: WriteableBuffer, buffer2: WriteableBuffer, /) -> None:
+//|     def continuous_capture_start(
+//|         self, buffer1: WriteableBuffer, buffer2: WriteableBuffer, /
+//|     ) -> None:
 //|         """Begin capturing into the given buffers in the background.
 //|
 //|         Call `continuous_capture_get_frame` to get the next available
@@ -109,7 +109,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(imagecapture_parallelimagecapture_capture_obj, 
 //|         `ParallelImageCapture` object keeps references to ``buffer1`` and
 //|         ``buffer2``, so the objects will not be garbage collected."""
 //|         ...
-//|
 STATIC mp_obj_t imagecapture_parallelimagecapture_continuous_capture_start(mp_obj_t self_in, mp_obj_t buffer1, mp_obj_t buffer2) {
     imagecapture_parallelimagecapture_obj_t *self = (imagecapture_parallelimagecapture_obj_t *)self_in;
     common_hal_imagecapture_parallelimagecapture_continuous_capture_start(self, buffer1, buffer2);
@@ -121,7 +120,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(imagecapture_parallelimagecapture_continuous_ca
 //|     def continuous_capture_get_frame(self) -> WriteableBuffer:
 //|         """Return the next available frame, one of the two buffers passed to `continuous_capture_start`"""
 //|         ...
-//|
 STATIC mp_obj_t imagecapture_parallelimagecapture_continuous_capture_get_frame(mp_obj_t self_in) {
     imagecapture_parallelimagecapture_obj_t *self = (imagecapture_parallelimagecapture_obj_t *)self_in;
     return common_hal_imagecapture_parallelimagecapture_continuous_capture_get_frame(self);
@@ -137,7 +135,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(imagecapture_parallelimagecapture_continuous_ca
 //|         references to the buffers passed to `continuous_capture_start`,
 //|         potentially allowing the objects to be garbage collected."""
 //|         ...
-//|
 STATIC mp_obj_t imagecapture_parallelimagecapture_continuous_capture_stop(mp_obj_t self_in) {
     imagecapture_parallelimagecapture_obj_t *self = (imagecapture_parallelimagecapture_obj_t *)self_in;
     common_hal_imagecapture_parallelimagecapture_continuous_capture_stop(self);
@@ -152,7 +149,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(imagecapture_parallelimagecapture_continuous_ca
 //|     def deinit(self) -> None:
 //|         """Deinitialize this instance"""
 //|         ...
-//|
 STATIC mp_obj_t imagecapture_parallelimagecapture_deinit(mp_obj_t self_in) {
     imagecapture_parallelimagecapture_obj_t *self = (imagecapture_parallelimagecapture_obj_t *)self_in;
     common_hal_imagecapture_parallelimagecapture_deinit(self);
@@ -164,14 +160,12 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(imagecapture_parallelimagecapture_deinit_obj, i
 //|     def __enter__(self) -> ParallelImageCapture:
 //|         """No-op used in Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware on context exit. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t imagecapture_parallelimagecapture___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_imagecapture_parallelimagecapture_deinit(args[0]);

--- a/shared-bindings/ipaddress/IPv4Address.c
+++ b/shared-bindings/ipaddress/IPv4Address.c
@@ -37,14 +37,12 @@
 
 //| class IPv4Address:
 //|     """Encapsulates an IPv4 address."""
-//|
 
 //|     def __init__(self, address: Union[int, str, bytes]) -> None:
 //|         """Create a new IPv4Address object encapsulating the address value.
 //|
-//|            The value itself can either be bytes or a string formatted address."""
+//|         The value itself can either be bytes or a string formatted address."""
 //|         ...
-//|
 STATIC mp_obj_t ipaddress_ipv4address_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_address };
     static const mp_arg_t allowed_args[] = {
@@ -88,7 +86,6 @@ STATIC mp_obj_t ipaddress_ipv4address_make_new(const mp_obj_type_t *type, size_t
 
 //|     packed: bytes
 //|     """The bytes that make up the address (read-only)."""
-//|
 STATIC mp_obj_t ipaddress_ipv4address_get_packed(mp_obj_t self_in) {
     ipaddress_ipv4address_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -101,7 +98,6 @@ MP_PROPERTY_GETTER(ipaddress_ipv4address_packed_obj,
 
 //|     version: int
 //|     """4 for IPv4, 6 for IPv6"""
-//|
 STATIC mp_obj_t ipaddress_ipv4address_get_version(mp_obj_t self_in) {
     ipaddress_ipv4address_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_buffer_info_t buf_info;
@@ -122,7 +118,6 @@ MP_PROPERTY_GETTER(ipaddress_ipv4address_version_obj,
 //|     def __eq__(self, other: object) -> bool:
 //|         """Two Address objects are equal if their addresses and address types are equal."""
 //|         ...
-//|
 STATIC mp_obj_t ipaddress_ipv4address_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
     switch (op) {
         // Two Addresses are equal if their address bytes and address_type are equal
@@ -146,7 +141,6 @@ STATIC mp_obj_t ipaddress_ipv4address_binary_op(mp_binary_op_t op, mp_obj_t lhs_
 //|     def __hash__(self) -> int:
 //|         """Returns a hash for the IPv4Address data."""
 //|         ...
-//|
 STATIC mp_obj_t ipaddress_ipv4address_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     switch (op) {
         // Two Addresses are equal if their address bytes and address_type are equal

--- a/shared-bindings/ipaddress/__init__.c
+++ b/shared-bindings/ipaddress/__init__.c
@@ -35,7 +35,6 @@
 //| The `ipaddress` module provides types for IP addresses. It is a subset of CPython's ipaddress
 //| module.
 //| """
-//|
 
 
 bool ipaddress_parse_ipv4address(const char *str_data, size_t str_len, uint32_t *ip_out) {
@@ -79,7 +78,6 @@ bool ipaddress_parse_ipv4address(const char *str_data, size_t str_len, uint32_t 
 //| def ip_address(obj: Union[int, str]) -> IPv4Address:
 //|     """Return a corresponding IP address object or raise ValueError if not possible."""
 //|     ...
-//|
 
 STATIC mp_obj_t ipaddress_ip_address(mp_obj_t ip_in) {
     uint32_t value;

--- a/shared-bindings/is31fl3741/FrameBuffer.c
+++ b/shared-bindings/is31fl3741/FrameBuffer.c
@@ -40,8 +40,17 @@
 //| class IS31FL3741_FrameBuffer:
 //|     """Creates an in-memory framebuffer for a IS31FL3741 device."""
 //|
-//|     def __init__(self, is31: is31fl3741.IS31FL3741, width: int, height: int, mapping: Tuple[int, ...], *,
-//|         framebuffer: Optional[WriteableBuffer] = None, scale: bool = False, gamma: bool = False) -> None:
+//|     def __init__(
+//|         self,
+//|         is31: is31fl3741.IS31FL3741,
+//|         width: int,
+//|         height: int,
+//|         mapping: Tuple[int, ...],
+//|         *,
+//|         framebuffer: Optional[WriteableBuffer] = None,
+//|         scale: bool = False,
+//|         gamma: bool = False
+//|     ) -> None:
 //|         """Create a IS31FL3741_FrameBuffer object with the given attributes.
 //|
 //|         The framebuffer is in "RGB888" format using 4 bytes per pixel.
@@ -62,7 +71,6 @@
 //|         :param bool scale: if True display is scaled down by 3 when displayed
 //|         :param bool gamma: if True apply gamma correction to all LEDs"""
 //|         ...
-//|
 STATIC mp_obj_t is31fl3741_FrameBuffer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_is31, ARG_width, ARG_height, ARG_mapping, ARG_framebuffer, ARG_scale, ARG_gamma };
     static const mp_arg_t allowed_args[] = {
@@ -123,7 +131,6 @@ STATIC mp_obj_t is31fl3741_FrameBuffer_make_new(const mp_obj_type_t *type, size_
 //|         IS31FL3741 instance.  After deinitialization, no further operations
 //|         may be performed."""
 //|         ...
-//|
 STATIC mp_obj_t is31fl3741_FrameBuffer_deinit(mp_obj_t self_in) {
     is31fl3741_FrameBuffer_obj_t *self = (is31fl3741_FrameBuffer_obj_t *)self_in;
     common_hal_is31fl3741_FrameBuffer_deinit(self);
@@ -140,7 +147,6 @@ static void check_for_deinit(is31fl3741_FrameBuffer_obj_t *self) {
 //|     brightness: float
 //|     """In the current implementation, 0.0 turns the display off entirely
 //|     and any other value up to 1.0 turns the display on fully."""
-//|
 STATIC mp_obj_t is31fl3741_FrameBuffer_get_brightness(mp_obj_t self_in) {
     is31fl3741_FrameBuffer_obj_t *self = (is31fl3741_FrameBuffer_obj_t *)self_in;
     check_for_deinit(self);
@@ -174,7 +180,6 @@ MP_PROPERTY_GETSET(is31fl3741_FrameBuffer_brightness_obj,
 //|         """Transmits the color data in the buffer to the pixels so that
 //|         they are shown."""
 //|         ...
-//|
 STATIC mp_obj_t is31fl3741_FrameBuffer_refresh(mp_obj_t self_in) {
     is31fl3741_FrameBuffer_obj_t *self = (is31fl3741_FrameBuffer_obj_t *)self_in;
     check_for_deinit(self);
@@ -185,7 +190,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(is31fl3741_FrameBuffer_refresh_obj, is31fl3741_FrameBu
 
 //|     width: int
 //|     """The width of the display, in pixels"""
-//|
 STATIC mp_obj_t is31fl3741_FrameBuffer_get_width(mp_obj_t self_in) {
     is31fl3741_FrameBuffer_obj_t *self = (is31fl3741_FrameBuffer_obj_t *)self_in;
     check_for_deinit(self);
@@ -197,7 +201,6 @@ MP_PROPERTY_GETTER(is31fl3741_FrameBuffer_width_obj,
 
 //|     height: int
 //|     """The height of the display, in pixels"""
-//|
 STATIC mp_obj_t is31fl3741_FrameBuffer_get_height(mp_obj_t self_in) {
     is31fl3741_FrameBuffer_obj_t *self = (is31fl3741_FrameBuffer_obj_t *)self_in;
     check_for_deinit(self);

--- a/shared-bindings/is31fl3741/IS31FL3741.c
+++ b/shared-bindings/is31fl3741/IS31FL3741.c
@@ -46,7 +46,6 @@
 //|         :param ~busio.I2C i2c: I2C bus the IS31FL3741 is on
 //|         :param int addr: device address"""
 //|         ...
-//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_i2c, ARG_addr };
     static const mp_arg_t allowed_args[] = {
@@ -74,7 +73,6 @@ STATIC mp_obj_t is31fl3741_IS31FL3741_make_new(const mp_obj_type_t *type, size_t
 //|         IS31FL3741 instance.  After deinitialization, no further operations
 //|         may be performed."""
 //|         ...
-//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_deinit(mp_obj_t self_in) {
     is31fl3741_IS31FL3741_obj_t *self = (is31fl3741_IS31FL3741_obj_t *)self_in;
     common_hal_is31fl3741_IS31FL3741_deinit(self);
@@ -85,7 +83,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(is31fl3741_IS31FL3741_deinit_obj, is31fl3741_IS
 //| def reset(self) -> None:
 //|     """Resets the IS31FL3741 chip."""
 //|     ...
-//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_reset(mp_obj_t self_in) {
     is31fl3741_IS31FL3741_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_is31fl3741_send_reset(self);
@@ -96,7 +93,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(is31fl3741_IS31FL3741_reset_obj, is31fl3741_IS31FL3741
 //| def enable(self) -> None:
 //|     """Enables the IS31FL3741 chip."""
 //|     ...
-//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_enable(mp_obj_t self_in) {
     is31fl3741_IS31FL3741_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_is31fl3741_send_enable(self);
@@ -109,7 +105,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(is31fl3741_IS31FL3741_enable_obj, is31fl3741_IS31FL374
 //|
 //|     :param int current: global current value 0x00 to 0xFF"""
 //|     ...
-//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_set_global_current(mp_obj_t self_in, mp_obj_t value) {
     is31fl3741_IS31FL3741_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_int_t current = mp_obj_get_int(value);
@@ -127,7 +122,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(is31fl3741_IS31FL3741_set_global_current_obj, is31fl37
 //|       the routine will automatically write to page 1 or 3 (instead
 //|       of 0 or 2)"""
 //|     ...
-//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_set_led(size_t n_args, const mp_obj_t *args) {
     is31fl3741_IS31FL3741_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     mp_int_t led = mp_obj_get_int(args[1]);

--- a/shared-bindings/keypad/Event.c
+++ b/shared-bindings/keypad/Event.c
@@ -33,7 +33,10 @@
 
 //| class Event:
 //|     """A key transition event."""
-//|     def __init__(self, key_number: int=0, pressed: bool=True, timestamp:Optional[int]=None) -> None:
+//|
+//|     def __init__(
+//|         self, key_number: int = 0, pressed: bool = True, timestamp: Optional[int] = None
+//|     ) -> None:
 //|         """Create a key transition event, which reports a key-pressed or key-released transition.
 //|
 //|         :param int key_number: The key number.
@@ -41,7 +44,6 @@
 //|         :param int timestamp: The time in milliseconds that the keypress occurred in the `supervisor.ticks_ms` time system.  If specified as None, the current value of `supervisor.ticks_ms` is used.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t keypad_event_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     keypad_event_obj_t *self = m_new_obj(keypad_event_obj_t);
     self->base.type = &keypad_event_type;
@@ -69,7 +71,6 @@ STATIC mp_obj_t keypad_event_make_new(const mp_obj_type_t *type, size_t n_args, 
 
 //|     key_number: int
 //|     """The key number."""
-//|
 STATIC mp_obj_t keypad_event_get_key_number(mp_obj_t self_in) {
     keypad_event_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_keypad_event_get_key_number(self));
@@ -83,7 +84,6 @@ MP_PROPERTY_GETTER(keypad_event_key_number_obj,
 //|     """``True`` if the event represents a key down (pressed) transition.
 //|     The opposite of `released`.
 //|     """
-//|
 STATIC mp_obj_t keypad_event_get_pressed(mp_obj_t self_in) {
     keypad_event_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_keypad_event_get_pressed(self));
@@ -97,7 +97,6 @@ MP_PROPERTY_GETTER(keypad_event_pressed_obj,
 //|     """``True`` if the event represents a key up (released) transition.
 //|     The opposite of `pressed`.
 //|     """
-//|
 STATIC mp_obj_t keypad_event_get_released(mp_obj_t self_in) {
     keypad_event_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_keypad_event_get_released(self));
@@ -109,7 +108,6 @@ MP_PROPERTY_GETTER(keypad_event_released_obj,
 
 //|     timestamp: int
 //|     """The timestamp."""
-//|
 STATIC mp_obj_t keypad_event_get_timestamp(mp_obj_t self_in) {
     keypad_event_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_keypad_event_get_timestamp(self);
@@ -126,7 +124,6 @@ MP_PROPERTY_GETTER(keypad_event_timestamp_obj,
 //|         Note that this does not compare the event timestamps.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t keypad_event_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
     switch (op) {
         case MP_BINARY_OP_EQUAL:
@@ -153,7 +150,6 @@ STATIC mp_obj_t keypad_event_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_ob
 //|
 //|         Note that as events with different timestamps compare equal, they also hash to the same value."""
 //|         ...
-//|
 STATIC mp_obj_t keypad_event_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     keypad_event_obj_t *self = MP_OBJ_TO_PTR(self_in);
     switch (op) {

--- a/shared-bindings/keypad/EventQueue.c
+++ b/shared-bindings/keypad/EventQueue.c
@@ -38,6 +38,7 @@
 //|     You cannot create an instance of `EventQueue` directly. Each scanner creates an
 //|     instance when it is created.
 //|     """
+//|
 //|     ...
 
 //|     def get(self) -> Optional[Event]:
@@ -52,7 +53,6 @@
 //|         :rtype: Optional[Event]
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t keypad_eventqueue_get(mp_obj_t self_in) {
     keypad_eventqueue_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -75,7 +75,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(keypad_eventqueue_get_obj, keypad_eventqueue_get);
 //|         :rtype: bool
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t keypad_eventqueue_get_into(mp_obj_t self_in, mp_obj_t event_in) {
     keypad_eventqueue_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -86,10 +85,8 @@ STATIC mp_obj_t keypad_eventqueue_get_into(mp_obj_t self_in, mp_obj_t event_in) 
 MP_DEFINE_CONST_FUN_OBJ_2(keypad_eventqueue_get_into_obj, keypad_eventqueue_get_into);
 
 //|     def clear(self) -> None:
-//|         """Clear any queued key transition events. Also sets `overflowed` to ``False``.
-//|         """
+//|         """Clear any queued key transition events. Also sets `overflowed` to ``False``."""
 //|         ...
-//|
 STATIC mp_obj_t keypad_eventqueue_clear(mp_obj_t self_in) {
     keypad_eventqueue_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -103,11 +100,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(keypad_eventqueue_clear_obj, keypad_eventqueue_clear);
 //|         This is an easy way to check if the queue is empty.
 //|         """
 //|         ...
-//|
 //|     def __len__(self) -> int:
 //|         """Return the number of events currently in the queue. Used to implement ``len()``."""
 //|         ...
-//|
 STATIC mp_obj_t keypad_eventqueue_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     keypad_eventqueue_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint16_t len = common_hal_keypad_eventqueue_get_length(self);
@@ -125,7 +120,6 @@ STATIC mp_obj_t keypad_eventqueue_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 //|     """``True`` if an event could not be added to the event queue because it was full. (read-only)
 //|     Set to ``False`` by  `clear()`.
 //|     """
-//|
 STATIC mp_obj_t keypad_eventqueue_get_overflowed(mp_obj_t self_in) {
     keypad_eventqueue_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_keypad_eventqueue_get_overflowed(self));

--- a/shared-bindings/keypad/KeyMatrix.c
+++ b/shared-bindings/keypad/KeyMatrix.c
@@ -37,7 +37,14 @@
 //| class KeyMatrix:
 //|     """Manage a 2D matrix of keys with row and column pins."""
 //|
-//|     def __init__(self, row_pins: Sequence[microcontroller.Pin], column_pins: Sequence[microcontroller.Pin], columns_to_anodes: bool = True, interval: float = 0.020, max_events: int = 64) -> None:
+//|     def __init__(
+//|         self,
+//|         row_pins: Sequence[microcontroller.Pin],
+//|         column_pins: Sequence[microcontroller.Pin],
+//|         columns_to_anodes: bool = True,
+//|         interval: float = 0.020,
+//|         max_events: int = 64,
+//|     ) -> None:
 //|         """
 //|         Create a `Keys` object that will scan the key matrix attached to the given row and column pins.
 //|         There should not be any external pull-ups or pull-downs on the matrix:
@@ -112,7 +119,6 @@ STATIC mp_obj_t keypad_keymatrix_make_new(const mp_obj_type_t *type, size_t n_ar
 //|     def deinit(self) -> None:
 //|         """Stop scanning and release the pins."""
 //|         ...
-//|
 STATIC mp_obj_t keypad_keymatrix_deinit(mp_obj_t self_in) {
     keypad_keymatrix_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_keypad_keymatrix_deinit(self);
@@ -123,14 +129,12 @@ MP_DEFINE_CONST_FUN_OBJ_1(keypad_keymatrix_deinit_obj, keypad_keymatrix_deinit);
 //|     def __enter__(self) -> KeyMatrix:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t keypad_keymatrix___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_keypad_keymatrix_deinit(args[0]);
@@ -150,12 +154,10 @@ STATIC void check_for_deinit(keypad_keymatrix_obj_t *self) {
 //|         a new key-pressed event to occur.
 //|         """
 //|         ...
-//|
 
 //|     key_count: int
 //|     """The number of keys that are being scanned. (read-only)
 //|     """
-//|
 
 //|     def key_number_to_row_column(self, key_number: int) -> Tuple[int]:
 //|         """Return the row and column for the given key number.
@@ -166,7 +168,6 @@ STATIC void check_for_deinit(keypad_keymatrix_obj_t *self) {
 //|         :rtype: Tuple[int]
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t keypad_keymatrix_key_number_to_row_column(mp_obj_t self_in, mp_obj_t key_number_in) {
     keypad_keymatrix_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -193,7 +194,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(keypad_keymatrix_key_number_to_row_column_obj, keypad_
 //|         The key number is ``row * len(column_pins) + column``.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t keypad_keymatrix_row_column_to_key_number(mp_obj_t self_in, mp_obj_t row_in, mp_obj_t column_in) {
     keypad_keymatrix_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -212,7 +212,6 @@ MP_DEFINE_CONST_FUN_OBJ_3(keypad_keymatrix_row_column_to_key_number_obj, keypad_
 //|     events: EventQueue
 //|     """The `EventQueue` associated with this `Keys` object. (read-only)
 //|     """
-//|
 
 STATIC const mp_rom_map_elem_t keypad_keymatrix_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit),                   MP_ROM_PTR(&keypad_keymatrix_deinit_obj) },

--- a/shared-bindings/keypad/Keys.c
+++ b/shared-bindings/keypad/Keys.c
@@ -37,7 +37,15 @@
 //| class Keys:
 //|     """Manage a set of independent keys."""
 //|
-//|     def __init__(self, pins: Sequence[microcontroller.Pin], *, value_when_pressed: bool, pull: bool = True, interval: float = 0.020, max_events: int = 64) -> None:
+//|     def __init__(
+//|         self,
+//|         pins: Sequence[microcontroller.Pin],
+//|         *,
+//|         value_when_pressed: bool,
+//|         pull: bool = True,
+//|         interval: float = 0.020,
+//|         max_events: int = 64
+//|     ) -> None:
 //|         """
 //|         Create a `Keys` object that will scan keys attached to the given sequence of pins.
 //|         Each key is independent and attached to its own pin.
@@ -103,7 +111,6 @@ STATIC mp_obj_t keypad_keys_make_new(const mp_obj_type_t *type, size_t n_args, s
 //|     def deinit(self) -> None:
 //|         """Stop scanning and release the pins."""
 //|         ...
-//|
 STATIC mp_obj_t keypad_keys_deinit(mp_obj_t self_in) {
     keypad_keys_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -115,14 +122,12 @@ MP_DEFINE_CONST_FUN_OBJ_1(keypad_keys_deinit_obj, keypad_keys_deinit);
 //|     def __enter__(self) -> Keys:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t keypad_keys___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_keypad_keys_deinit(args[0]);
@@ -137,17 +142,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(keypad_keys___exit___obj, 4, 4, keypa
 //|         a new key-pressed event to occur.
 //|         """
 //|         ...
-//|
 
 //|     key_count: int
 //|     """The number of keys that are being scanned. (read-only)
 //|     """
-//|
 
 //|     events: EventQueue
 //|     """The `EventQueue` associated with this `Keys` object. (read-only)
 //|     """
-//|
 STATIC const mp_rom_map_elem_t keypad_keys_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit),       MP_ROM_PTR(&keypad_keys_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR___enter__),    MP_ROM_PTR(&default___enter___obj) },

--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -37,7 +37,18 @@
 //| class ShiftRegisterKeys:
 //|     """Manage a set of keys attached to an incoming shift register."""
 //|
-//|     def __init__(self, *, clock: microcontroller.Pin, data: microcontroller.Pin, latch: microcontroller.Pin, value_to_latch: bool = True, key_count: int, value_when_pressed: bool, interval: float = 0.020, max_events: int = 64) -> None:
+//|     def __init__(
+//|         self,
+//|         *,
+//|         clock: microcontroller.Pin,
+//|         data: microcontroller.Pin,
+//|         latch: microcontroller.Pin,
+//|         value_to_latch: bool = True,
+//|         key_count: int,
+//|         value_when_pressed: bool,
+//|         interval: float = 0.020,
+//|         max_events: int = 64
+//|     ) -> None:
 //|         """
 //|         Create a `Keys` object that will scan keys attached to a parallel-in serial-out shift register
 //|         like the 74HC165 or CD4021.
@@ -107,7 +118,6 @@ STATIC mp_obj_t keypad_shiftregisterkeys_make_new(const mp_obj_type_t *type, siz
 //|     def deinit(self) -> None:
 //|         """Stop scanning and release the pins."""
 //|         ...
-//|
 STATIC mp_obj_t keypad_shiftregisterkeys_deinit(mp_obj_t self_in) {
     keypad_shiftregisterkeys_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -119,14 +129,12 @@ MP_DEFINE_CONST_FUN_OBJ_1(keypad_shiftregisterkeys_deinit_obj, keypad_shiftregis
 //|     def __enter__(self) -> Keys:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t keypad_shiftregisterkeys___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_keypad_shiftregisterkeys_deinit(args[0]);
@@ -140,17 +148,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(keypad_shiftregisterkeys___exit___obj
 //|         a new key-pressed event to occur.
 //|         """
 //|         ...
-//|
 
 //|     key_count: int
 //|     """The number of keys that are being scanned. (read-only)
 //|     """
-//|
 
 //|     events: EventQueue
 //|     """The `EventQueue` associated with this `Keys` object. (read-only)
 //|     """
-//|
 
 STATIC const mp_rom_map_elem_t keypad_shiftregisterkeys_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit),       MP_ROM_PTR(&keypad_shiftregisterkeys_deinit_obj) },

--- a/shared-bindings/keypad/__init__.c
+++ b/shared-bindings/keypad/__init__.c
@@ -90,7 +90,6 @@ const mp_obj_property_t keypad_generic_events_obj = {
 //| For more information about working with the `keypad` module in CircuitPython,
 //| see `this Learn guide <https://learn.adafruit.com/key-pad-matrix-scanning-in-circuitpython>`_.
 //| """
-//|
 
 STATIC mp_rom_map_elem_t keypad_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),          MP_OBJ_NEW_QSTR(MP_QSTR_keypad) },

--- a/shared-bindings/math/__init__.c
+++ b/shared-bindings/math/__init__.c
@@ -45,7 +45,6 @@
 //|
 //| |see_cpython_module| :mod:`cpython:math`.
 //| """
-//|
 
 STATIC NORETURN void math_error(void) {
     mp_raise_ValueError(translate("math domain error"));
@@ -87,7 +86,6 @@ STATIC NORETURN void math_error(void) {
 //|
 //| pi: float
 //| """the ratio of a circle's circumference to its diameter"""
-//|
 
 //| def acos(x: float) -> float:
 //|     """Return the inverse cosine of ``x``."""
@@ -191,7 +189,6 @@ STATIC NORETURN void math_error(void) {
 //| def trunc(x: float) -> int:
 //|     """Return an integer, being ``x`` rounded towards 0."""
 //|     ...
-//|
 MATH_FUN_1_ERRCOND(sqrt, sqrt, (x < (mp_float_t)0.0))
 
 MATH_FUN_2(pow, pow)
@@ -204,7 +201,6 @@ MATH_FUN_1(exp, exp)
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1(expm1, expm1)
 
 //| def log2(x: float) -> float:
@@ -213,7 +209,6 @@ MATH_FUN_1(expm1, expm1)
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1_ERRCOND(log2, log2, (x <= (mp_float_t)0.0))
 
 //| def log10(x: float) -> float:
@@ -222,7 +217,6 @@ MATH_FUN_1_ERRCOND(log2, log2, (x <= (mp_float_t)0.0))
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1_ERRCOND(log10, log10, (x <= (mp_float_t)0.0))
 
 //| def cosh(x: float) -> float:
@@ -231,7 +225,6 @@ MATH_FUN_1_ERRCOND(log10, log10, (x <= (mp_float_t)0.0))
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1(cosh, cosh)
 
 //| def sinh(x: float) -> float:
@@ -240,7 +233,6 @@ MATH_FUN_1(cosh, cosh)
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1(sinh, sinh)
 
 //| def tanh(x: float) -> float:
@@ -249,7 +241,6 @@ MATH_FUN_1(sinh, sinh)
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1(tanh, tanh)
 
 //| def acosh(x: float) -> float:
@@ -258,7 +249,6 @@ MATH_FUN_1(tanh, tanh)
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1(acosh, acosh)
 
 //| def asinh(x: float) -> float:
@@ -267,7 +257,6 @@ MATH_FUN_1(acosh, acosh)
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1(asinh, asinh)
 
 //| def atanh(x: float) -> float:
@@ -276,7 +265,6 @@ MATH_FUN_1(asinh, asinh)
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1(atanh, atanh)
 #endif
 
@@ -321,7 +309,6 @@ MATH_FUN_2(ldexp, ldexp)
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1(erf, erf)
 
 //| def erfc(x: float) -> float:
@@ -330,7 +317,6 @@ MATH_FUN_1(erf, erf)
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1(erfc, erfc)
 
 //| def gamma(x: float) -> float:
@@ -339,7 +325,6 @@ MATH_FUN_1(erfc, erfc)
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1(gamma, tgamma)
 
 //| def lgamma(x: float) -> float:
@@ -348,7 +333,6 @@ MATH_FUN_1(gamma, tgamma)
 //|     May not be available on some boards.
 //|     """
 //|     ...
-//|
 MATH_FUN_1(lgamma, lgamma)
 #endif
 // TODO: factorial, fsum

--- a/shared-bindings/mdns/RemoteService.c
+++ b/shared-bindings/mdns/RemoteService.c
@@ -35,16 +35,13 @@
 //| class RemoteService:
 //|     """Encapsulates information about a remote service that was found during a search. This
 //|     object may only be created by a `mdns.Server`. It has no user-visible constructor."""
-//|
 
 //|     def __init__(self) -> None:
 //|         """Cannot be instantiated directly. Use `mdns.Server.find`."""
 //|         ...
-//|
 
 //|     hostname: str
 //|     """The hostname of the device (read-only),."""
-//|
 STATIC mp_obj_t mdns_remoteservice_get_hostname(mp_obj_t self_in) {
     mdns_remoteservice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     const char *hostname = common_hal_mdns_remoteservice_get_hostname(self);
@@ -57,7 +54,6 @@ MP_PROPERTY_GETTER(mdns_remoteservice_hostname_obj,
 
 //|     instance_name: str
 //|     """The human readable instance name for the service. (read-only)"""
-//|
 STATIC mp_obj_t remoteservice_get_instance_name(mp_obj_t self_in) {
     mdns_remoteservice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     const char *instance_name = common_hal_mdns_remoteservice_get_instance_name(self);
@@ -70,7 +66,6 @@ MP_PROPERTY_GETTER(mdns_remoteservice_instance_name_obj,
 
 //|     service_type: str
 //|     """The service type string such as ``_http``. (read-only)"""
-//|
 STATIC mp_obj_t remoteservice_get_service_type(mp_obj_t self_in) {
     mdns_remoteservice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     const char *service_type = common_hal_mdns_remoteservice_get_service_type(self);
@@ -83,7 +78,6 @@ MP_PROPERTY_GETTER(mdns_remoteservice_service_type_obj,
 
 //|     protocol: str
 //|     """The protocol string such as ``_tcp``. (read-only)"""
-//|
 STATIC mp_obj_t remoteservice_get_protocol(mp_obj_t self_in) {
     mdns_remoteservice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     const char *protocol = common_hal_mdns_remoteservice_get_protocol(self);
@@ -96,7 +90,6 @@ MP_PROPERTY_GETTER(mdns_remoteservice_protocol_obj,
 
 //|     port: int
 //|     """Port number used for the service. (read-only)"""
-//|
 STATIC mp_obj_t remoteservice_get_port(mp_obj_t self_in) {
     mdns_remoteservice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_mdns_remoteservice_get_port(self));
@@ -108,7 +101,6 @@ MP_PROPERTY_GETTER(mdns_remoteservice_port_obj,
 
 //|     ipv4_address: Optional[ipaddress.IPv4Address]
 //|     """IP v4 Address of the remote service. None if no A records are found."""
-//|
 STATIC mp_obj_t _mdns_remoteservice_get_ipv4_address(mp_obj_t self) {
     return common_hal_mdns_remoteservice_get_ipv4_address(self);
 
@@ -121,7 +113,6 @@ MP_PROPERTY_GETTER(mdns_remoteservice_ipv4_address_obj,
 //|     def __del__(self) -> None:
 //|         """Deletes the RemoteService object."""
 //|         ...
-//|
 STATIC mp_obj_t mdns_remoteservice_obj_deinit(mp_obj_t self_in) {
     mdns_remoteservice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_mdns_remoteservice_deinit(self);

--- a/shared-bindings/mdns/Server.c
+++ b/shared-bindings/mdns/Server.c
@@ -35,8 +35,7 @@
 
 //| class Server:
 //|     """The MDNS Server responds to queries for this device's information and allows for querying
-//|        other devices."""
-//|
+//|     other devices."""
 
 //|     def __init__(self, network_interface: wifi.Radio) -> None:
 //|         """
@@ -44,7 +43,6 @@
 //|         may already be using it.) Only native interfaces are currently supported.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t mdns_server_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_network_interface };
     static const mp_arg_t allowed_args[] = {
@@ -64,7 +62,6 @@ STATIC mp_obj_t mdns_server_make_new(const mp_obj_type_t *type, size_t n_args, s
 //|     def deinit(self) -> None:
 //|         """Stops the server"""
 //|         ...
-//|
 STATIC mp_obj_t mdns_server_obj_deinit(mp_obj_t self_in) {
     mdns_server_obj_t *self = (mdns_server_obj_t *)self_in;
     common_hal_mdns_server_deinit(self);
@@ -78,12 +75,10 @@ STATIC void check_for_deinit(mdns_server_obj_t *self) {
     }
 }
 
-//|
 //|     hostname: str
 //|     """Hostname resolvable as ``<hostname>.local`` in addition to ``circuitpython.local``. Make
 //|        sure this is unique across all devices on the network. It defaults to ``cpy-######``
 //|        where ``######`` is the hex digits of the last three bytes of the mac address."""
-//|
 STATIC mp_obj_t mdns_server_get_hostname(mp_obj_t self) {
     check_for_deinit(self);
     const char *hostname = common_hal_mdns_server_get_hostname(self);
@@ -105,7 +100,6 @@ MP_PROPERTY_GETSET(mdns_server_hostname_obj,
 
 //|     instance_name: str
 //|     """Human readable name to describe the device."""
-//|
 STATIC mp_obj_t mdns_server_get_instance_name(mp_obj_t self) {
     check_for_deinit(self);
     const char *instance_name = common_hal_mdns_server_get_instance_name(self);
@@ -125,7 +119,9 @@ MP_PROPERTY_GETSET(mdns_server_instance_name_obj,
     (mp_obj_t)&mdns_server_set_instance_name_obj);
 
 
-//|     def find(self, service_type: str, protocol: str, *, timeout: float = 1) -> Tuple[RemoteService]:
+//|     def find(
+//|         self, service_type: str, protocol: str, *, timeout: float = 1
+//|     ) -> Tuple[RemoteService]:
 //|         """Find all locally available remote services with the given service type and protocol.
 //|
 //|         This doesn't allow for direct hostname lookup. To do that, use
@@ -135,7 +131,6 @@ MP_PROPERTY_GETSET(mdns_server_instance_name_obj,
 //|         :param str protocol: The service protocol such as "_tcp"
 //|         :param float/int timeout: Time to wait for responses"""
 //|         ...
-//|
 STATIC mp_obj_t _mdns_server_find(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mdns_server_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     check_for_deinit(self);
@@ -158,7 +153,7 @@ STATIC mp_obj_t _mdns_server_find(mp_uint_t n_args, const mp_obj_t *pos_args, mp
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mdns_server_find_obj, 1, _mdns_server_find);
 
-//|     def advertise_service(self, *,  service_type: str, protocol: str, port: int) -> None:
+//|     def advertise_service(self, *, service_type: str, protocol: str, port: int) -> None:
 //|         """Respond to queries for the given service with the given port.
 //|
 //|         ``service_type`` and ``protocol`` can only occur on one port. Any call after the first
@@ -168,7 +163,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mdns_server_find_obj, 1, _mdns_server_find);
 //|         :param str protocol: The service protocol such as "_tcp"
 //|         :param int port: The port used by the service"""
 //|         ...
-//|
 STATIC mp_obj_t mdns_server_advertise_service(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mdns_server_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     check_for_deinit(self);

--- a/shared-bindings/mdns/__init__.c
+++ b/shared-bindings/mdns/__init__.c
@@ -38,7 +38,6 @@
 //| Basic use provides hostname resolution under the .local TLD. This module
 //| also supports DNS Service Discovery that allows for discovering other hosts
 //| that provide a desired service."""
-//|
 
 STATIC const mp_rom_map_elem_t mdns_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),             MP_ROM_QSTR(MP_QSTR_mdns) },

--- a/shared-bindings/memorymonitor/AllocationAlarm.c
+++ b/shared-bindings/memorymonitor/AllocationAlarm.c
@@ -34,7 +34,6 @@
 #include "supervisor/shared/translate/translate.h"
 
 //| class AllocationAlarm:
-//|
 //|     def __init__(self, *, minimum_block_count: int = 1) -> None:
 //|         """Throw an exception when an allocation of ``minimum_block_count`` or more blocks
 //|            occurs while active.
@@ -55,7 +54,6 @@
 //|
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t memorymonitor_allocationalarm_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *all_args, mp_map_t *kw_args) {
     enum { ARG_minimum_block_count };
     static const mp_arg_t allowed_args[] = {
@@ -78,16 +76,15 @@ STATIC mp_obj_t memorymonitor_allocationalarm_make_new(const mp_obj_type_t *type
 
 //|     def ignore(self, count: int) -> AllocationAlarm:
 //|         """Sets the number of applicable allocations to ignore before raising the exception.
-//|            Automatically set back to zero at context exit.
+//|         Automatically set back to zero at context exit.
 //|
-//|            Use it within a ``with`` block::
+//|         Use it within a ``with`` block::
 //|
-//|              # Will not alarm because the bytearray allocation will be ignored.
-//|              with aa.ignore(2):
-//|                  x = bytearray(20)
-//|            """
+//|           # Will not alarm because the bytearray allocation will be ignored.
+//|           with aa.ignore(2):
+//|               x = bytearray(20)
+//|         """
 //|         ...
-//|
 STATIC mp_obj_t memorymonitor_allocationalarm_obj_ignore(mp_obj_t self_in, mp_obj_t count_obj) {
     mp_int_t count = mp_obj_get_int(count_obj);
     mp_arg_validate_int_min(count, 0, MP_QSTR_count);
@@ -100,7 +97,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(memorymonitor_allocationalarm_ignore_obj, memorymonito
 //|     def __enter__(self) -> AllocationAlarm:
 //|         """Enables the alarm."""
 //|         ...
-//|
 STATIC mp_obj_t memorymonitor_allocationalarm_obj___enter__(mp_obj_t self_in) {
     common_hal_memorymonitor_allocationalarm_resume(self_in);
     return self_in;
@@ -111,7 +107,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(memorymonitor_allocationalarm___enter___obj, memorymon
 //|         """Automatically disables the allocation alarm when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t memorymonitor_allocationalarm_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_memorymonitor_allocationalarm_set_ignore(args[0], 0);

--- a/shared-bindings/memorymonitor/AllocationSize.c
+++ b/shared-bindings/memorymonitor/AllocationSize.c
@@ -34,7 +34,6 @@
 #include "supervisor/shared/translate/translate.h"
 
 //| class AllocationSize:
-//|
 //|     def __init__(self) -> None:
 //|         """Tracks the number of allocations in power of two buckets.
 //|
@@ -62,7 +61,6 @@
 //|
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t memorymonitor_allocationsize_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *all_args, mp_map_t *kw_args) {
     memorymonitor_allocationsize_obj_t *self = m_new_obj(memorymonitor_allocationsize_obj_t);
     self->base.type = &memorymonitor_allocationsize_type;
@@ -75,7 +73,6 @@ STATIC mp_obj_t memorymonitor_allocationsize_make_new(const mp_obj_type_t *type,
 //|     def __enter__(self) -> AllocationSize:
 //|         """Clears counts and resumes tracking."""
 //|         ...
-//|
 STATIC mp_obj_t memorymonitor_allocationsize_obj___enter__(mp_obj_t self_in) {
     common_hal_memorymonitor_allocationsize_clear(self_in);
     common_hal_memorymonitor_allocationsize_resume(self_in);
@@ -87,7 +84,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(memorymonitor_allocationsize___enter___obj, memorymoni
 //|         """Automatically pauses allocation tracking when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t memorymonitor_allocationsize_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_memorymonitor_allocationsize_pause(args[0]);
@@ -97,7 +93,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(memorymonitor_allocationsize___exit__
 
 //|     bytes_per_block: int
 //|     """Number of bytes per block"""
-//|
 STATIC mp_obj_t memorymonitor_allocationsize_obj_get_bytes_per_block(mp_obj_t self_in) {
     memorymonitor_allocationsize_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -116,7 +111,6 @@ MP_PROPERTY_GETTER(memorymonitor_allocationsize_bytes_per_block_obj,
 //|           mm = memorymonitor.AllocationSize()
 //|           print(len(mm))"""
 //|         ...
-//|
 STATIC mp_obj_t memorymonitor_allocationsize_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     memorymonitor_allocationsize_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint16_t len = common_hal_memorymonitor_allocationsize_get_len(self);
@@ -138,7 +132,6 @@ STATIC mp_obj_t memorymonitor_allocationsize_unary_op(mp_unary_op_t op, mp_obj_t
 //|           mm = memorymonitor.AllocationSize()
 //|           print(mm[0])"""
 //|         ...
-//|
 STATIC mp_obj_t memorymonitor_allocationsize_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t value) {
     if (value == mp_const_none) {
         // delete item

--- a/shared-bindings/memorymonitor/__init__.c
+++ b/shared-bindings/memorymonitor/__init__.c
@@ -34,10 +34,10 @@
 #include "shared-bindings/memorymonitor/AllocationSize.h"
 
 //| """Memory monitoring helpers"""
-//|
 
 //| class AllocationError(Exception):
 //|     """Catchall exception for allocation related errors."""
+//|
 //|     ...
 MP_DEFINE_MEMORYMONITOR_EXCEPTION(AllocationError, Exception)
 

--- a/shared-bindings/microcontroller/Pin.c
+++ b/shared-bindings/microcontroller/Pin.c
@@ -41,12 +41,10 @@
 //|         hardware so they cannot be constructed on demand. Instead, use
 //|         :mod:`board` or :mod:`microcontroller.pin` to reference the desired pin."""
 //|         ...
-//|
 
 //|     def __hash__(self) -> int:
 //|         """Returns a hash for the Pin."""
 //|         ...
-//|
 // Provided by mp_generic_unary_op().
 
 static void get_pin_name(const mcu_pin_obj_t *self, qstr *package, qstr *module, qstr *name) {

--- a/shared-bindings/microcontroller/Processor.c
+++ b/shared-bindings/microcontroller/Processor.c
@@ -57,17 +57,14 @@
 //|
 //|        print(microcontroller.cpus[0].temperature)
 //|        print(microcontroller.cpus[1].frequency)"""
-//|
 
 //|     def __init__(self) -> None:
 //|         """You cannot create an instance of `microcontroller.Processor`.
 //|         Use `microcontroller.cpu` to access the sole instance available."""
 //|         ...
-//|
 
 //|     frequency: int
 //|     """The CPU operating frequency in Hertz. (read-only)"""
-//|
 
 STATIC mp_obj_t mcu_processor_set_frequency(mp_obj_t self, mp_obj_t freq) {
     #if CIRCUITPY_SETTABLE_PROCESSOR_FREQUENCY
@@ -94,7 +91,6 @@ MP_PROPERTY_GETSET(mcu_processor_frequency_obj,
 
 //|     reset_reason: microcontroller.ResetReason
 //|     """The reason the microcontroller started up from reset state."""
-//|
 STATIC mp_obj_t mcu_processor_get_reset_reason(mp_obj_t self) {
     return cp_enum_find(&mcu_reset_reason_type, common_hal_mcu_processor_get_reset_reason());
 }
@@ -108,7 +104,6 @@ MP_PROPERTY_GETTER(mcu_processor_reset_reason_obj,
 //|     """The on-chip temperature, in Celsius, as a float. (read-only)
 //|
 //|     Is `None` if the temperature is not available."""
-//|
 STATIC mp_obj_t mcu_processor_get_temperature(mp_obj_t self) {
     float temperature = common_hal_mcu_processor_get_temperature();
     return isnan(temperature) ? mp_const_none : mp_obj_new_float(temperature);
@@ -121,7 +116,6 @@ MP_PROPERTY_GETTER(mcu_processor_temperature_obj,
 
 //|     uid: bytearray
 //|     """The unique id (aka serial number) of the chip as a `bytearray`. (read-only)"""
-//|
 STATIC mp_obj_t mcu_processor_get_uid(mp_obj_t self) {
     uint8_t raw_id[COMMON_HAL_MCU_PROCESSOR_UID_LENGTH];
     common_hal_mcu_processor_get_uid(raw_id);
@@ -137,7 +131,6 @@ MP_PROPERTY_GETTER(mcu_processor_uid_obj,
 //|     """The input voltage to the microcontroller, as a float. (read-only)
 //|
 //|     Is `None` if the voltage is not available."""
-//|
 STATIC mp_obj_t mcu_processor_get_voltage(mp_obj_t self) {
     float voltage = common_hal_mcu_processor_get_voltage();
     return isnan(voltage) ? mp_const_none : mp_obj_new_float(voltage);

--- a/shared-bindings/microcontroller/ResetReason.c
+++ b/shared-bindings/microcontroller/ResetReason.c
@@ -64,7 +64,6 @@ MAKE_ENUM_VALUE(mcu_reset_reason_type, reset_reason, RESCUE_DEBUG, RESET_REASON_
 //|
 //|     RESCUE_DEBUG: object
 //|     """The microntroller was reset by the rescue debug port."""
-//|
 MAKE_ENUM_MAP(mcu_reset_reason) {
     MAKE_ENUM_MAP_ENTRY(reset_reason, POWER_ON),
     MAKE_ENUM_MAP_ENTRY(reset_reason, BROWNOUT),

--- a/shared-bindings/microcontroller/RunMode.c
+++ b/shared-bindings/microcontroller/RunMode.c
@@ -32,7 +32,6 @@
 //|     def __init__(self) -> None:
 //|         """Enum-like class to define the run mode of the microcontroller and
 //|         CircuitPython."""
-//|
 //|     NORMAL: RunMode
 //|     """Run CircuitPython as normal.
 //|
@@ -53,7 +52,6 @@
 //|     """Run the default bootloader.
 //|
 //|     :type microcontroller.RunMode:"""
-//|
 const mp_obj_type_t mcu_runmode_type;
 
 const mcu_runmode_obj_t mcu_runmode_uf2_obj = {

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -49,19 +49,16 @@
 //|
 //| from nvm import ByteArray
 //| from watchdog import WatchDogTimer
-//|
 
 //| cpu: Processor
 //| """CPU information and control, such as ``cpu.temperature`` and ``cpu.frequency``
 //| (clock frequency).
 //| This object is an instance of `microcontroller.Processor`."""
-//|
 
 //| cpus: Processor
 //| """CPU information and control, such as ``cpus[0].temperature`` and ``cpus[1].frequency``
 //| (clock frequency) on chips with more than 1 cpu. The index selects which cpu.
 //| This object is an instance of `microcontroller.Processor`."""
-//|
 
 //| def delay_us(delay: int) -> None:
 //|     """Dedicated delay method used for very short delays. **Do not** do long delays
@@ -71,7 +68,6 @@
 //|     processing while you are waiting, explore a different avenue such as using
 //|     `time.sleep()`."""
 //|     ...
-//|
 STATIC mp_obj_t mcu_delay_us(mp_obj_t delay_obj) {
     uint32_t delay = mp_obj_get_int(delay_obj);
 
@@ -84,7 +80,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mcu_delay_us_obj, mcu_delay_us);
 //| def disable_interrupts() -> None:
 //|     """Disable all interrupts. Be very careful, this can stall everything."""
 //|     ...
-//|
 STATIC mp_obj_t mcu_disable_interrupts(void) {
     common_hal_mcu_disable_interrupts();
     return mp_const_none;
@@ -94,7 +89,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mcu_disable_interrupts_obj, mcu_disable_interru
 //| def enable_interrupts() -> None:
 //|     """Enable the interrupts that were enabled at the last disable."""
 //|     ...
-//|
 STATIC mp_obj_t mcu_enable_interrupts(void) {
     common_hal_mcu_enable_interrupts();
     return mp_const_none;
@@ -107,7 +101,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mcu_enable_interrupts_obj, mcu_enable_interrupt
 //|
 //|     :param ~microcontroller.RunMode run_mode: The next run mode"""
 //|     ...
-//|
 STATIC mp_obj_t mcu_on_next_reset(mp_obj_t run_mode_obj) {
     mcu_runmode_t run_mode;
     if (run_mode_obj == MP_OBJ_FROM_PTR(&mcu_runmode_uf2_obj)) {
@@ -134,7 +127,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mcu_on_next_reset_obj, mcu_on_next_reset);
 //|       host computer. Be very careful when calling this! Make sure the device
 //|       "Safely removed" on Windows or "ejected" on Mac OSX and Linux."""
 //|     ...
-//|
 STATIC mp_obj_t mcu_reset(void) {
     common_hal_mcu_reset();
     // We won't actually get here because we're resetting.
@@ -147,12 +139,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mcu_reset_obj, mcu_reset);
 //| This object is the sole instance of `nvm.ByteArray` when available or ``None`` otherwise.
 //|
 //| :type: nvm.ByteArray or None"""
-//|
 
 //| watchdog: Optional[WatchDogTimer]
 //| """Available watchdog timer.
 //| This object is the sole instance of `watchdog.WatchDogTimer` when available or ``None`` otherwise."""
-//|
 
 const mp_obj_module_t mcu_pin_module = {
     .base = { &mp_type_module },

--- a/shared-bindings/msgpack/ExtType.c
+++ b/shared-bindings/msgpack/ExtType.c
@@ -31,11 +31,11 @@
 
 //| class ExtType:
 //|     """ExtType represents ext type in msgpack."""
+//|
 //|     def __init__(self, code: int, data: bytes) -> None:
 //|         """Constructor
 //|         :param int code: type code in range 0~127.
 //|         :param bytes data: representation."""
-//|
 STATIC mp_obj_t mod_msgpack_exttype_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     mod_msgpack_extype_obj_t *self = m_new_obj(mod_msgpack_extype_obj_t);
     self->base.type = &mod_msgpack_exttype_type;
@@ -60,7 +60,6 @@ STATIC mp_obj_t mod_msgpack_exttype_make_new(const mp_obj_type_t *type, size_t n
 //|     code: int
 //|     """The type code, in range 0~127."""
 //|     ...
-//|
 STATIC mp_obj_t mod_msgpack_exttype_get_code(mp_obj_t self_in) {
     mod_msgpack_extype_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(self->code);
@@ -85,7 +84,6 @@ MP_PROPERTY_GETSET(mod_msgpack_exttype_code_obj,
 //|     data: bytes
 //|     """Data."""
 //|     ...
-//|
 STATIC mp_obj_t mod_msgpack_exttype_get_data(mp_obj_t self_in) {
     mod_msgpack_extype_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return self->data;

--- a/shared-bindings/msgpack/__init__.c
+++ b/shared-bindings/msgpack/__init__.c
@@ -84,9 +84,13 @@
 //|    print(f"{data} -> {buffer.getvalue()} -> {decoded}")
 //|
 //| """
-//|
 
-//| def pack(obj: object, stream: circuitpython_typing.ByteStream, *, default: Union[Callable[[object], None], None] = None) -> None:
+//| def pack(
+//|     obj: object,
+//|     stream: circuitpython_typing.ByteStream,
+//|     *,
+//|     default: Union[Callable[[object], None], None] = None
+//| ) -> None:
 //|     """Output object to stream in msgpack format.
 //|
 //|     :param object obj: Object to convert to msgpack format.
@@ -96,7 +100,6 @@
 //|           a representation in msgpack format.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t mod_msgpack_pack(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_obj, ARG_buffer, ARG_default };
     STATIC const mp_arg_t allowed_args[] = {
@@ -118,7 +121,12 @@ STATIC mp_obj_t mod_msgpack_pack(size_t n_args, const mp_obj_t *pos_args, mp_map
 MP_DEFINE_CONST_FUN_OBJ_KW(mod_msgpack_pack_obj, 0, mod_msgpack_pack);
 
 
-//| def unpack(stream: circuitpython_typing.ByteStream, *, ext_hook: Union[Callable[[int, bytes], object], None] = None, use_list: bool=True) -> object:
+//| def unpack(
+//|     stream: circuitpython_typing.ByteStream,
+//|     *,
+//|     ext_hook: Union[Callable[[int, bytes], object], None] = None,
+//|     use_list: bool = True
+//| ) -> object:
 //|     """Unpack and return one object from stream.
 //|
 //|     :param ~circuitpython_typing.ByteStream stream: stream to read from
@@ -129,7 +137,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(mod_msgpack_pack_obj, 0, mod_msgpack_pack);
 //|     :return object: object read from stream.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t mod_msgpack_unpack(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_ext_hook, ARG_use_list };
     STATIC const mp_arg_t allowed_args[] = {

--- a/shared-bindings/multiterminal/__init__.c
+++ b/shared-bindings/multiterminal/__init__.c
@@ -35,12 +35,10 @@
 //| The `multiterminal` module allows you to configure an additional serial
 //| terminal source. Incoming characters are accepted from both the internal
 //| serial connection and the optional secondary connection."""
-//|
 
 //| def get_secondary_terminal() -> Optional[typing.BinaryIO]:
 //|     """Returns the current secondary terminal."""
 //|     ...
-//|
 STATIC mp_obj_t multiterminal_obj_get_secondary_terminal() {
     return common_hal_multiterminal_get_secondary_terminal();
 }
@@ -53,7 +51,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(multiterminal_get_secondary_terminal_obj, multitermina
 //|
 //|     :param stream stream: secondary stream"""
 //|     ...
-//|
 STATIC mp_obj_t multiterminal_obj_set_secondary_terminal(mp_obj_t secondary_terminal) {
     mp_obj_t write_m[3];
     mp_load_method_maybe(secondary_terminal, MP_QSTR_write, write_m);
@@ -71,7 +68,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(multiterminal_set_secondary_terminal_obj, multitermina
 //| def clear_secondary_terminal() -> None:
 //|     """Clears the secondary terminal."""
 //|     ...
-//|
 STATIC mp_obj_t multiterminal_obj_clear_secondary_terminal() {
     common_hal_multiterminal_clear_secondary_terminal();
     return mp_const_none;
@@ -83,7 +79,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(multiterminal_clear_secondary_terminal_obj, multitermi
 //|     the OS when more data is available on the socket to read. This is useful
 //|     as a callback for lwip sockets."""
 //|     ...
-//|
 // TODO(tannewt): This is a funny API. Replace it with a direct call into the OS
 // by the lwip object.
 STATIC mp_obj_t multiterminal_obj_schedule_secondary_terminal_read(mp_obj_t socket) {

--- a/shared-bindings/nvm/ByteArray.c
+++ b/shared-bindings/nvm/ByteArray.c
@@ -43,20 +43,15 @@
 //|        import microcontroller
 //|        microcontroller.nvm[0:3] = b"\xcc\x10\x00"
 //|     """
-//|
 
 //|     def __init__(self) -> None:
 //|         """Not currently dynamically supported. Access the sole instance through `microcontroller.nvm`."""
 //|         ...
-//|
 
-//|     def __bool__(self) -> bool:
-//|         ...
-//|
+//|     def __bool__(self) -> bool: ...
 //|     def __len__(self) -> int:
 //|         """Return the length. This is used by (`len`)"""
 //|         ...
-//|
 STATIC mp_obj_t nvm_bytearray_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     nvm_bytearray_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint16_t len = common_hal_nvm_bytearray_get_length(self);
@@ -81,14 +76,12 @@ STATIC MP_DEFINE_CONST_DICT(nvm_bytearray_locals_dict, nvm_bytearray_locals_dict
 //|     def __getitem__(self, index: int) -> int:
 //|         """Returns the value at the given index."""
 //|         ...
-//|
 //|     @overload
 //|     def __setitem__(self, index: slice, value: ReadableBuffer) -> None: ...
 //|     @overload
 //|     def __setitem__(self, index: int, value: int) -> None:
 //|         """Set the value at the given index."""
 //|         ...
-//|
 STATIC mp_obj_t nvm_bytearray_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {
     if (value == MP_OBJ_NULL) {
         // delete item

--- a/shared-bindings/nvm/__init__.c
+++ b/shared-bindings/nvm/__init__.c
@@ -39,7 +39,6 @@
 //| Note that this module can't be imported and used directly. The sole
 //| instance of :class:`ByteArray` is available at
 //| :attr:`microcontroller.nvm`."""
-//|
 STATIC const mp_rom_map_elem_t nvm_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_nvm) },
     { MP_ROM_QSTR(MP_QSTR_ByteArray),   MP_ROM_PTR(&nvm_bytearray_type) },

--- a/shared-bindings/onewireio/OneWire.c
+++ b/shared-bindings/onewireio/OneWire.c
@@ -38,22 +38,21 @@
 //|     def __init__(self, pin: microcontroller.Pin) -> None:
 //|         """Create a OneWire object associated with the given pin.
 //|
-//|           The object implements the lowest level timing-sensitive bits of the protocol.
+//|         The object implements the lowest level timing-sensitive bits of the protocol.
 //|
-//|           :param ~microcontroller.Pin pin: Pin connected to the OneWire bus
+//|         :param ~microcontroller.Pin pin: Pin connected to the OneWire bus
 //|
-//|           Read a short series of pulses::
+//|         Read a short series of pulses::
 //|
-//|             import onewireio
-//|             import board
+//|           import onewireio
+//|           import board
 //|
-//|             onewire = onewireio.OneWire(board.D7)
-//|             onewire.reset()
-//|             onewire.write_bit(True)
-//|             onewire.write_bit(False)
-//|             print(onewire.read_bit())"""
+//|           onewire = onewireio.OneWire(board.D7)
+//|           onewire.reset()
+//|           onewire.write_bit(True)
+//|           onewire.write_bit(False)
+//|           print(onewire.read_bit())"""
 //|         ...
-//|
 STATIC mp_obj_t onewireio_onewire_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pin };
     static const mp_arg_t allowed_args[] = {
@@ -73,7 +72,6 @@ STATIC mp_obj_t onewireio_onewire_make_new(const mp_obj_type_t *type, size_t n_a
 //|     def deinit(self) -> None:
 //|         """Deinitialize the OneWire bus and release any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t onewireio_onewire_deinit(mp_obj_t self_in) {
     onewireio_onewire_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_onewireio_onewire_deinit(self);
@@ -90,14 +88,12 @@ STATIC void check_for_deinit(onewireio_onewire_obj_t *self) {
 //|     def __enter__(self) -> OneWire:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t onewireio_onewire_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_onewireio_onewire_deinit(args[0]);
@@ -111,7 +107,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(onewireio_onewire___exit___obj, 4, 4,
 //|         :returns: False when at least one device is present
 //|         :rtype: bool"""
 //|         ...
-//|
 STATIC mp_obj_t onewireio_onewire_obj_reset(mp_obj_t self_in) {
     onewireio_onewire_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -126,7 +121,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(onewireio_onewire_reset_obj, onewireio_onewire_obj_res
 //|         :returns: bit state read
 //|         :rtype: bool"""
 //|         ...
-//|
 STATIC mp_obj_t onewireio_onewire_obj_read_bit(mp_obj_t self_in) {
     onewireio_onewire_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -138,7 +132,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(onewireio_onewire_read_bit_obj, onewireio_onewire_obj_
 //|     def write_bit(self, value: bool) -> None:
 //|         """Write out a bit based on value."""
 //|         ...
-//|
 STATIC mp_obj_t onewireio_onewire_obj_write_bit(mp_obj_t self_in, mp_obj_t bool_obj) {
     onewireio_onewire_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/onewireio/__init__.c
+++ b/shared-bindings/onewireio/__init__.c
@@ -38,7 +38,6 @@
 //| """Low-level bit primitives for Maxim (formerly Dallas Semi) one-wire protocol.
 //|
 //|    Protocol definition is here: https://www.maximintegrated.com/en/app-notes/index.mvp/id/126"""
-//|
 
 STATIC const mp_rom_map_elem_t onewireio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_onewireio) },

--- a/shared-bindings/os/__init__.c
+++ b/shared-bindings/os/__init__.c
@@ -58,7 +58,6 @@
 //|     release: str
 //|     version: str
 //|     machine: str
-//|
 STATIC mp_obj_t os_uname(void) {
     return common_hal_os_uname();
 }
@@ -67,7 +66,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(os_uname_obj, os_uname);
 //| def chdir(path: str) -> None:
 //|     """Change current directory."""
 //|     ...
-//|
 STATIC mp_obj_t os_chdir(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     common_hal_os_chdir(path);
@@ -78,7 +76,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_chdir_obj, os_chdir);
 //| def getcwd() -> str:
 //|     """Get the current directory."""
 //|     ...
-//|
 STATIC mp_obj_t os_getcwd(void) {
     return common_hal_os_getcwd();
 }
@@ -87,9 +84,8 @@ MP_DEFINE_CONST_FUN_OBJ_0(os_getcwd_obj, os_getcwd);
 //| def getenv(key: str, default: Optional[str] = None) -> Optional[str]:
 //|     """Get the environment variable value for the given key or return ``default``.
 //|
-//|        This may load values from disk so cache the result instead of calling this often."""
+//|     This may load values from disk so cache the result instead of calling this often."""
 //|     ...
-//|
 STATIC mp_obj_t os_getenv(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_key, ARG_default };
     static const mp_arg_t allowed_args[] = {
@@ -106,7 +102,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(os_getenv_obj, 1, os_getenv);
 //| def listdir(dir: str) -> str:
 //|     """With no argument, list the current directory.  Otherwise list the given directory."""
 //|     ...
-//|
 STATIC mp_obj_t os_listdir(size_t n_args, const mp_obj_t *args) {
     const char *path;
     if (n_args == 1) {
@@ -121,7 +116,6 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(os_listdir_obj, 0, 1, os_listdir);
 //| def mkdir(path: str) -> None:
 //|     """Create a new directory."""
 //|     ...
-//|
 STATIC mp_obj_t os_mkdir(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     common_hal_os_mkdir(path);
@@ -132,7 +126,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_mkdir_obj, os_mkdir);
 //| def remove(path: str) -> None:
 //|     """Remove a file."""
 //|     ...
-//|
 STATIC mp_obj_t os_remove(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     common_hal_os_remove(path);
@@ -143,7 +136,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_remove_obj, os_remove);
 //| def rmdir(path: str) -> None:
 //|     """Remove a directory."""
 //|     ...
-//|
 STATIC mp_obj_t os_rename(mp_obj_t old_path_in, mp_obj_t new_path_in) {
     const char *old_path = mp_obj_str_get_str(old_path_in);
     const char *new_path = mp_obj_str_get_str(new_path_in);
@@ -155,7 +147,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(os_rename_obj, os_rename);
 //| def rename(old_path: str, new_path: str) -> str:
 //|     """Rename a file."""
 //|     ...
-//|
 STATIC mp_obj_t os_rmdir(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     common_hal_os_rmdir(path);
@@ -185,7 +176,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_rmdir_obj, os_rmdir);
 //|        So the time fields return 946684800,
 //|        which is the number of seconds corresponding to 1999-12-31."""
 //|     ...
-//|
 STATIC mp_obj_t os_stat(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     return common_hal_os_stat(path);
@@ -212,7 +202,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_stat_obj, os_stat);
 //|     and the ``f_flags`` parameter may return ``0`` as they can be unavailable
 //|     in a port-specific implementation."""
 //|     ...
-//|
 STATIC mp_obj_t os_statvfs(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     return common_hal_os_statvfs(path);
@@ -222,7 +211,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_statvfs_obj, os_statvfs);
 //| def sync() -> None:
 //|     """Sync all filesystems."""
 //|     ...
-//|
 STATIC mp_obj_t os_sync(void) {
     for (mp_vfs_mount_t *vfs = MP_STATE_VM(vfs_mount_table); vfs != NULL; vfs = vfs->next) {
         // this assumes that vfs->obj is fs_user_mount_t with block device functions
@@ -236,7 +224,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(os_sync_obj, os_sync);
 //|     """Returns a string of *size* random bytes based on a hardware True Random
 //|     Number Generator. When not available, it will raise a NotImplementedError."""
 //|     ...
-//|
 STATIC mp_obj_t os_urandom(mp_obj_t size_in) {
     mp_int_t size = mp_obj_get_int(size_in);
     mp_obj_str_t *result = MP_OBJ_TO_PTR(mp_obj_new_bytes_of_zeros(size));
@@ -268,10 +255,8 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_urandom), MP_ROM_PTR(&os_urandom_obj) },
 
-//|
 //| sep: str
 //| """Separator used to delineate path components such as folder and file names."""
-//|
     { MP_ROM_QSTR(MP_QSTR_sep), MP_ROM_QSTR(MP_QSTR__slash_) },
 };
 

--- a/shared-bindings/paralleldisplay/ParallelBus.c
+++ b/shared-bindings/paralleldisplay/ParallelBus.c
@@ -42,7 +42,17 @@
 //|     protocol may be refered to as 8080-I Series Parallel Interface in datasheets. It doesn't handle
 //|     display initialization."""
 //|
-//|     def __init__(self, *, data0: microcontroller.Pin, command: microcontroller.Pin, chip_select: microcontroller.Pin, write: microcontroller.Pin, read: Optional[microcontroller.Pin], reset: Optional[microcontroller.Pin] = None, frequency: int = 30_000_000) -> None:
+//|     def __init__(
+//|         self,
+//|         *,
+//|         data0: microcontroller.Pin,
+//|         command: microcontroller.Pin,
+//|         chip_select: microcontroller.Pin,
+//|         write: microcontroller.Pin,
+//|         read: Optional[microcontroller.Pin],
+//|         reset: Optional[microcontroller.Pin] = None,
+//|         frequency: int = 30_000_000,
+//|     ) -> None:
 //|         """Create a ParallelBus object associated with the given pins. The bus is inferred from data0
 //|         by implying the next 7 additional pins on a given GPIO port.
 //|
@@ -60,7 +70,6 @@
 //|         :param microcontroller.Pin reset: Reset pin, optional
 //|         :param int frequency: The communication frequency in Hz for the display on the bus"""
 //|         ...
-//|
 STATIC mp_obj_t paralleldisplay_parallelbus_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_data0, ARG_data_pins, ARG_command, ARG_chip_select, ARG_write, ARG_read, ARG_reset, ARG_frequency };
     static const mp_arg_t allowed_args[] = {
@@ -108,7 +117,6 @@ STATIC mp_obj_t paralleldisplay_parallelbus_make_new(const mp_obj_type_t *type, 
 //|         """Performs a hardware reset via the reset pin. Raises an exception if called when no reset pin
 //|         is available."""
 //|         ...
-//|
 
 STATIC mp_obj_t paralleldisplay_parallelbus_obj_reset(mp_obj_t self_in) {
     paralleldisplay_parallelbus_obj_t *self = self_in;
@@ -124,7 +132,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(paralleldisplay_parallelbus_reset_obj, paralleldisplay
 //|         """Sends the given command value followed by the full set of data. Display state, such as
 //|         vertical scroll, set via ``send`` may or may not be reset once the code is done."""
 //|         ...
-//|
 STATIC mp_obj_t paralleldisplay_parallelbus_obj_send(mp_obj_t self, mp_obj_t command_obj, mp_obj_t data_obj) {
     mp_int_t command_int = mp_arg_validate_int_range(mp_obj_get_int(command_obj), 0, 255, MP_QSTR_command);
 

--- a/shared-bindings/ps2io/Ps2.c
+++ b/shared-bindings/ps2io/Ps2.c
@@ -66,7 +66,6 @@
 //|           print(kbd.sendcmd(0xed))
 //|           print(kbd.sendcmd(0x01))"""
 //|         ...
-//|
 STATIC mp_obj_t ps2io_ps2_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_data_pin, ARG_clock_pin };
     static const mp_arg_t allowed_args[] = {
@@ -90,7 +89,6 @@ STATIC mp_obj_t ps2io_ps2_make_new(const mp_obj_type_t *type, size_t n_args, siz
 //|     def deinit(self) -> None:
 //|         """Deinitialises the Ps2 and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t ps2io_ps2_deinit(mp_obj_t self_in) {
     ps2io_ps2_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_ps2io_ps2_deinit(self);
@@ -107,14 +105,12 @@ STATIC void check_for_deinit(ps2io_ps2_obj_t *self) {
 //|     def __enter__(self) -> Ps2:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t ps2io_ps2_obj___exit__(size_t n_args, const mp_obj_t *args) {
     mp_check_self(mp_obj_is_type(args[0], &ps2io_ps2_type));
     ps2io_ps2_obj_t *self = MP_OBJ_TO_PTR(args[0]);
@@ -127,7 +123,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ps2io_ps2___exit___obj, 4, 4, ps2io_p
 //|         """Removes and returns the oldest received byte. When buffer
 //|         is empty, raises an IndexError exception."""
 //|         ...
-//|
 STATIC mp_obj_t ps2io_ps2_obj_popleft(mp_obj_t self_in) {
     ps2io_ps2_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -152,7 +147,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(ps2io_ps2_popleft_obj, ps2io_ps2_obj_popleft);
 //|
 //|         :param int byte: byte value of the command"""
 //|         ...
-//|
 STATIC mp_obj_t ps2io_ps2_obj_sendcmd(mp_obj_t self_in, mp_obj_t ob) {
     ps2io_ps2_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -194,7 +188,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(ps2io_ps2_sendcmd_obj, ps2io_ps2_obj_sendcmd);
 //|
 //|         0x2000: device didn't send a response byte in time"""
 //|         ...
-//|
 STATIC mp_obj_t ps2io_ps2_obj_clear_errors(mp_obj_t self_in) {
     ps2io_ps2_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -204,12 +197,10 @@ STATIC mp_obj_t ps2io_ps2_obj_clear_errors(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(ps2io_ps2_clear_errors_obj, ps2io_ps2_obj_clear_errors);
 
 //|     def __bool__(self) -> bool: ...
-//|
 //|     def __len__(self) -> int:
 //|         """Returns the number of received bytes in buffer, available
 //|         to :py:func:`popleft()`."""
 //|         ...
-//|
 STATIC mp_obj_t ps2_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     ps2io_ps2_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/ps2io/__init__.c
+++ b/shared-bindings/ps2io/__init__.c
@@ -37,11 +37,9 @@
 //|
 //| The `ps2io` module contains classes to provide PS/2 communication.
 //|
-
 //| .. warning:: This module is not available in some SAMD21 builds. See the
 //|   :ref:`module-support-matrix` for more info.
 //|
-
 //| All classes change hardware state and should be deinitialized when they
 //| are no longer needed if the program continues after use. To do so, either
 //| call :py:meth:`!deinit` or use a context manager. See

--- a/shared-bindings/ps2io/__init__.c
+++ b/shared-bindings/ps2io/__init__.c
@@ -44,7 +44,6 @@
 //| are no longer needed if the program continues after use. To do so, either
 //| call :py:meth:`!deinit` or use a context manager. See
 //| :ref:`lifetime-and-contextmanagers` for more info."""
-//|
 
 STATIC const mp_rom_map_elem_t ps2io_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ps2io) },

--- a/shared-bindings/pulseio/PulseIn.c
+++ b/shared-bindings/pulseio/PulseIn.c
@@ -37,10 +37,12 @@
 
 //| class PulseIn:
 //|     """Measure a series of active and idle pulses. This is commonly used in infrared receivers
-//|        and low cost temperature sensors (DHT). The pulsed signal consists of timed active and
-//|        idle periods. Unlike PWM, there is no set duration for active and idle pairs."""
+//|     and low cost temperature sensors (DHT). The pulsed signal consists of timed active and
+//|     idle periods. Unlike PWM, there is no set duration for active and idle pairs."""
 //|
-//|     def __init__(self, pin: microcontroller.Pin, maxlen: int = 2, *, idle_state: bool = False) -> None:
+//|     def __init__(
+//|         self, pin: microcontroller.Pin, maxlen: int = 2, *, idle_state: bool = False
+//|     ) -> None:
 //|         """Create a PulseIn object associated with the given pin. The object acts as
 //|         a read-only sequence of pulse lengths with a given max length. When it is
 //|         active, new pulse lengths are added to the end of the list. When there is
@@ -75,7 +77,6 @@
 //|           # Resume with an 80 microsecond active pulse
 //|           pulses.resume(80)"""
 //|         ...
-//|
 STATIC mp_obj_t pulseio_pulsein_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pin, ARG_maxlen, ARG_idle_state };
     static const mp_arg_t allowed_args[] = {
@@ -100,7 +101,6 @@ STATIC mp_obj_t pulseio_pulsein_make_new(const mp_obj_type_t *type, size_t n_arg
 //|     def deinit(self) -> None:
 //|         """Deinitialises the PulseIn and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t pulseio_pulsein_deinit(mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_pulseio_pulsein_deinit(self);
@@ -117,14 +117,12 @@ STATIC void check_for_deinit(pulseio_pulsein_obj_t *self) {
 //|     def __enter__(self) -> PulseIn:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t pulseio_pulsein_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_pulseio_pulsein_deinit(args[0]);
@@ -135,7 +133,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pulseio_pulsein___exit___obj, 4, 4, p
 //|     def pause(self) -> None:
 //|         """Pause pulse capture"""
 //|         ...
-//|
 STATIC mp_obj_t pulseio_pulsein_obj_pause(mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -155,7 +152,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(pulseio_pulsein_pause_obj, pulseio_pulsein_obj_pause);
 //|
 //|         :param int trigger_duration: trigger pulse duration in microseconds"""
 //|         ...
-//|
 STATIC mp_obj_t pulseio_pulsein_obj_resume(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_trigger_duration };
     static const mp_arg_t allowed_args[] = {
@@ -175,7 +171,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(pulseio_pulsein_resume_obj, 1, pulseio_pulsein_obj_re
 //|     def clear(self) -> None:
 //|         """Clears all captured pulses"""
 //|         ...
-//|
 STATIC mp_obj_t pulseio_pulsein_obj_clear(mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -188,7 +183,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(pulseio_pulsein_clear_obj, pulseio_pulsein_obj_clear);
 //|     def popleft(self) -> int:
 //|         """Removes and returns the oldest read pulse."""
 //|         ...
-//|
 STATIC mp_obj_t pulseio_pulsein_obj_popleft(mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -200,7 +194,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(pulseio_pulsein_popleft_obj, pulseio_pulsein_obj_pople
 //|     maxlen: int
 //|     """The maximum length of the PulseIn. When len() is equal to maxlen,
 //|     it is unclear which pulses are active and which are idle."""
-//|
 STATIC mp_obj_t pulseio_pulsein_obj_get_maxlen(mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -215,7 +208,6 @@ MP_PROPERTY_GETTER(pulseio_pulsein_maxlen_obj,
 //|     paused: bool
 //|     """True when pulse capture is paused as a result of :py:func:`pause` or an error during capture
 //|     such as a signal that is too fast."""
-//|
 STATIC mp_obj_t pulseio_pulsein_obj_get_paused(mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -228,7 +220,6 @@ MP_PROPERTY_GETTER(pulseio_pulsein_paused_obj,
     (mp_obj_t)&pulseio_pulsein_get_paused_obj);
 
 //|     def __bool__(self) -> bool: ...
-//|
 //|     def __len__(self) -> int:
 //|         """Returns the number of pulse durations currently stored.
 //|
@@ -237,7 +228,6 @@ MP_PROPERTY_GETTER(pulseio_pulsein_paused_obj,
 //|           pulses = pulseio.PulseIn(pin)
 //|           print(len(pulses))"""
 //|         ...
-//|
 STATIC mp_obj_t pulsein_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     pulseio_pulsein_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -260,7 +250,6 @@ STATIC mp_obj_t pulsein_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 //|           pulses = pulseio.PulseIn(pin)
 //|           print(pulses[0])"""
 //|         ...
-//|
 STATIC mp_obj_t pulsein_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t value) {
     if (value == mp_const_none) {
         // delete item

--- a/shared-bindings/pulseio/PulseOut.c
+++ b/shared-bindings/pulseio/PulseOut.c
@@ -38,10 +38,12 @@
 
 //| class PulseOut:
 //|     """Pulse PWM "carrier" output on and off. This is commonly used in infrared remotes. The
-//|        pulsed signal consists of timed on and off periods. Unlike PWM, there is no set duration
-//|        for on and off pairs."""
+//|     pulsed signal consists of timed on and off periods. Unlike PWM, there is no set duration
+//|     for on and off pairs."""
 //|
-//|     def __init__(self, pin: microcontroller.Pin, *, frequency: int = 38000, duty_cycle: int = 1 << 15) -> None:
+//|     def __init__(
+//|         self, pin: microcontroller.Pin, *, frequency: int = 38000, duty_cycle: int = 1 << 15
+//|     ) -> None:
 //|         """Create a PulseOut object associated with the given pin.
 //|
 //|         :param ~microcontroller.Pin pin: Signal output pin
@@ -65,7 +67,6 @@
 //|           pulses[0] = 200
 //|           pulse.send(pulses)"""
 //|         ...
-//|
 STATIC mp_obj_t pulseio_pulseout_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pin, ARG_frequency, ARG_duty_cycle};
     static const mp_arg_t allowed_args[] = {
@@ -89,7 +90,6 @@ STATIC mp_obj_t pulseio_pulseout_make_new(const mp_obj_type_t *type, size_t n_ar
 //|     def deinit(self) -> None:
 //|         """Deinitialises the PulseOut and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t pulseio_pulseout_deinit(mp_obj_t self_in) {
     pulseio_pulseout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_pulseio_pulseout_deinit(self);
@@ -100,14 +100,12 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(pulseio_pulseout_deinit_obj, pulseio_pulseout_d
 //|     def __enter__(self) -> PulseOut:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t pulseio_pulseout_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_pulseio_pulseout_deinit(args[0]);
@@ -125,7 +123,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pulseio_pulseout___exit___obj, 4, 4, 
 //|
 //|         :param array.array pulses: pulse durations in microseconds"""
 //|         ...
-//|
 STATIC mp_obj_t pulseio_pulseout_obj_send(mp_obj_t self_in, mp_obj_t pulses) {
     pulseio_pulseout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (common_hal_pulseio_pulseout_deinited(self)) {

--- a/shared-bindings/pulseio/__init__.c
+++ b/shared-bindings/pulseio/__init__.c
@@ -44,7 +44,6 @@
 //| are no longer needed if the program continues after use. To do so, either
 //| call :py:meth:`!deinit` or use a context manager. See
 //| :ref:`lifetime-and-contextmanagers` for more info."""
-//|
 
 STATIC const mp_rom_map_elem_t pulseio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_pulseio) },

--- a/shared-bindings/pwmio/PWMOut.c
+++ b/shared-bindings/pwmio/PWMOut.c
@@ -71,7 +71,14 @@ void common_hal_pwmio_pwmout_raise_error(pwmout_result_t result) {
 //| class PWMOut:
 //|     """Output a Pulse Width Modulated signal on a given pin."""
 //|
-//|     def __init__(self, pin: microcontroller.Pin, *, duty_cycle: int = 0, frequency: int = 500, variable_frequency: bool = False) -> None:
+//|     def __init__(
+//|         self,
+//|         pin: microcontroller.Pin,
+//|         *,
+//|         duty_cycle: int = 0,
+//|         frequency: int = 500,
+//|         variable_frequency: bool = False
+//|     ) -> None:
 //|         """Create a PWM object associated with the given pin. This allows you to
 //|         write PWM signals out on the given pin. Frequency is fixed after init
 //|         unless ``variable_frequency`` is True.
@@ -129,7 +136,6 @@ void common_hal_pwmio_pwmout_raise_error(pwmout_result_t result) {
 //|           pwm.frequency = 880
 //|           time.sleep(0.1)"""
 //|         ...
-//|
 STATIC mp_obj_t pwmio_pwmout_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     enum { ARG_pin, ARG_duty_cycle, ARG_frequency, ARG_variable_frequency };
     static const mp_arg_t allowed_args[] = {
@@ -159,7 +165,6 @@ STATIC mp_obj_t pwmio_pwmout_make_new(const mp_obj_type_t *type, size_t n_args, 
 //|     def deinit(self) -> None:
 //|         """Deinitialises the PWMOut and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t pwmio_pwmout_deinit(mp_obj_t self_in) {
     pwmio_pwmout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_pwmio_pwmout_deinit(self);
@@ -176,14 +181,12 @@ STATIC void check_for_deinit(pwmio_pwmout_obj_t *self) {
 //|     def __enter__(self) -> PWMOut:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t pwmio_pwmout_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_pwmio_pwmout_deinit(args[0]);
@@ -200,7 +203,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pwmio_pwmout___exit___obj, 4, 4, pwmi
 //|     representation for duty cycle might have less than 16 bits of resolution.
 //|     Reading this property will return the value from the internal representation,
 //|     so it may differ from the value set."""
-//|
 STATIC mp_obj_t pwmio_pwmout_obj_get_duty_cycle(mp_obj_t self_in) {
     pwmio_pwmout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -233,7 +235,6 @@ MP_PROPERTY_GETSET(pwmio_pwmout_duty_cycle_obj,
 //|     changes. In these cases, the duty cycle is automatically recalculated
 //|     from the original duty cycle value. This should happen without any need
 //|     to manually re-set the duty cycle."""
-//|
 STATIC mp_obj_t pwmio_pwmout_obj_get_frequency(mp_obj_t self_in) {
     pwmio_pwmout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/pwmio/__init__.c
+++ b/shared-bindings/pwmio/__init__.c
@@ -37,7 +37,6 @@
 //|
 //| The `pwmio` module contains classes to provide access to basic pulse IO.
 //|
-
 //| All classes change hardware state and should be deinitialized when they
 //| are no longer needed if the program continues after use. To do so, either
 //| call :py:meth:`!deinit` or use a context manager. See

--- a/shared-bindings/pwmio/__init__.c
+++ b/shared-bindings/pwmio/__init__.c
@@ -61,7 +61,6 @@
 //| For the essentials of `pwmio`, see the `CircuitPython Essentials
 //| Learn guide <https://learn.adafruit.com/circuitpython-essentials/circuitpython-pwm>`_.
 //| """
-//|
 
 STATIC const mp_rom_map_elem_t pwmio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_pwmio) },

--- a/shared-bindings/qrio/PixelPolicy.c
+++ b/shared-bindings/qrio/PixelPolicy.c
@@ -44,7 +44,6 @@
 //|
 //|     RGB565: PixelPolicy
 //|     """The input buffer to `QRDecoder.decode` consists of RGB565 values in native order. The green component is used."""
-//|
 
 MAKE_ENUM_VALUE(qrio_pixel_policy_type, qrio_pixel_policy, EVERY_BYTE, QRIO_EVERY_BYTE);
 MAKE_ENUM_VALUE(qrio_pixel_policy_type, qrio_pixel_policy, RGB565, QRIO_RGB565);

--- a/shared-bindings/qrio/QRDecoder.c
+++ b/shared-bindings/qrio/QRDecoder.c
@@ -33,7 +33,6 @@
 #include "py/enum.h"
 
 //| class QRDecoder:
-//|
 //|     def __init__(self, width: int, height: int) -> None:
 //|         """Construct a QRDecoder object
 //|
@@ -58,9 +57,10 @@ STATIC mp_obj_t qrio_qrdecoder_make_new(const mp_obj_type_t *type, size_t n_args
     return self;
 }
 
-//|     def decode(self, buffer: ReadableBuffer, pixel_policy: PixelPolicy = PixelPolicy.EVERY_BYTE) -> List[QRInfo]:
+//|     def decode(
+//|         self, buffer: ReadableBuffer, pixel_policy: PixelPolicy = PixelPolicy.EVERY_BYTE
+//|     ) -> List[QRInfo]:
 //|         """Decode zero or more QR codes from the given image.  The size of the buffer must be at least ``length``×``width`` bytes for `EVERY_BYTE`, and 2×``length``×``width`` bytes for `EVEN_BYTES` or `ODD_BYTES`."""
-//|
 STATIC mp_obj_t qrio_qrdecoder_decode(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     qrio_qrdecoder_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
@@ -92,7 +92,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(qrio_qrdecoder_decode_obj, 1, qrio_qrdecoder_decode);
 
 //|     width: int
 //|     """The width of image the decoder expects"""
-//|
 STATIC mp_obj_t qrio_qrdecoder_get_width(mp_obj_t self_in) {
     qrio_qrdecoder_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(shared_module_qrio_qrdecoder_get_width(self));
@@ -113,7 +112,6 @@ MP_PROPERTY_GETSET(qrio_qrdecoder_width_obj,
 
 //|     height: int
 //|     """The height of image the decoder expects"""
-//|
 STATIC mp_obj_t qrio_qrdecoder_get_height(mp_obj_t self_in) {
     qrio_qrdecoder_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(shared_module_qrio_qrdecoder_get_height(self));

--- a/shared-bindings/qrio/__init__.c
+++ b/shared-bindings/qrio/__init__.c
@@ -40,7 +40,6 @@
 //| .. note:: This module only handles decoding QR codes.  If you are looking
 //|     to generate a QR code, use the
 //|     `adafruit_miniqr library <https://github.com/adafruit/Adafruit_CircuitPython_miniQR>`_"""
-//|
 
 STATIC const mp_rom_map_elem_t qrio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_qrio) },

--- a/shared-bindings/rainbowio/__init__.c
+++ b/shared-bindings/rainbowio/__init__.c
@@ -35,7 +35,6 @@
 //|     """C implementation of the common colorwheel() function found in many examples.
 //|     Returns the colorwheel RGB value as an integer value for n (usable in neopixel and dotstar)."""
 //|     ...
-//|
 STATIC mp_obj_t rainbowio_colorwheel(mp_obj_t n) {
     mp_float_t f = mp_obj_get_float(n);
     return MP_OBJ_NEW_SMALL_INT(colorwheel(f));

--- a/shared-bindings/random/__init__.c
+++ b/shared-bindings/random/__init__.c
@@ -45,14 +45,13 @@
 //|   bytes from `os.urandom` directly for true randomness."""
 //|
 //| from typing import TypeVar
-//| _T = TypeVar('_T')
 //|
+//| _T = TypeVar("_T")
 
 //| def seed(seed: int) -> None:
 //|     """Sets the starting seed of the random  number generation. Further calls to
 //|     `random` will return deterministic results afterwards."""
 //|     ...
-//|
 STATIC mp_obj_t random_seed(mp_obj_t seed_in) {
     mp_uint_t seed = mp_obj_get_int_truncated(seed_in);
     shared_modules_random_seed(seed);
@@ -63,7 +62,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(random_seed_obj, random_seed);
 //| def getrandbits(k: int) -> int:
 //|     """Returns an integer with *k* random bits."""
 //|     ...
-//|
 STATIC mp_obj_t random_getrandbits(mp_obj_t num_in) {
     int n = mp_obj_get_int(num_in);
     if (n > 32 || n == 0) {
@@ -81,7 +79,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(random_getrandbits_obj, random_getrandbits);
 //| def randrange(start: int, stop: int, step: int) -> int:
 //|     """Returns a randomly selected integer from ``range(start[, stop[, step]])``."""
 //|     ...
-//|
 STATIC mp_obj_t random_randrange(size_t n_args, const mp_obj_t *args) {
     mp_int_t start = 0;
     mp_int_t stop = mp_obj_get_int(args[0]);
@@ -124,7 +121,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(random_randrange_obj, 1, 3, random_ra
 //|     """Returns a randomly selected integer between a and b inclusive. Equivalent
 //|     to ``randrange(a, b + 1, 1)``"""
 //|     ...
-//|
 STATIC mp_obj_t random_randint(mp_obj_t a_in, mp_obj_t b_in) {
     mp_int_t a = mp_obj_get_int(a_in);
     mp_int_t b = mp_obj_get_int(b_in);
@@ -139,7 +135,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(random_randint_obj, random_randint);
 //|     """Returns a randomly selected element from the given sequence. Raises
 //|     IndexError when the sequence is empty."""
 //|     ...
-//|
 STATIC mp_obj_t random_choice(mp_obj_t seq) {
     mp_int_t len = mp_obj_get_int(mp_obj_len(seq));
     if (len == 0) {
@@ -152,7 +147,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(random_choice_obj, random_choice);
 //| def random() -> float:
 //|     """Returns a random float between 0 and 1.0."""
 //|     ...
-//|
 STATIC mp_obj_t random_random(void) {
     return mp_obj_new_float(shared_modules_random_random());
 }
@@ -162,7 +156,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(random_random_obj, random_random);
 //|     """Returns a random float between a and b. It may or may not be inclusive
 //|     depending on float rounding."""
 //|     ...
-//|
 STATIC mp_obj_t random_uniform(mp_obj_t a_in, mp_obj_t b_in) {
     mp_float_t a = mp_obj_get_float(a_in);
     mp_float_t b = mp_obj_get_float(b_in);

--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -40,7 +40,6 @@
 
 //| class RGBMatrix:
 //|     """Displays an in-memory framebuffer to a HUB75-style RGB LED matrix."""
-//|
 
 extern Protomatter_core *_PM_protoPtr;
 
@@ -132,15 +131,22 @@ STATIC void preflight_pins_or_throw(uint8_t clock_pin, uint8_t *rgb_pins, uint8_
     }
 }
 
-//|     def __init__(self, *, width: int, bit_depth: int,
-//|                  rgb_pins: Sequence[digitalio.DigitalInOut],
-//|                  addr_pins: Sequence[digitalio.DigitalInOut],
-//|                  clock_pin: digitalio.DigitalInOut,
-//|                  latch_pin: digitalio.DigitalInOut,
-//|                  output_enable_pin: digitalio.DigitalInOut,
-//|                  doublebuffer: bool = True,
-//|                  framebuffer: Optional[WriteableBuffer] = None,
-//|                  height: int = 0, tile: int = 1, serpentine: bool = True) -> None:
+//|     def __init__(
+//|         self,
+//|         *,
+//|         width: int,
+//|         bit_depth: int,
+//|         rgb_pins: Sequence[digitalio.DigitalInOut],
+//|         addr_pins: Sequence[digitalio.DigitalInOut],
+//|         clock_pin: digitalio.DigitalInOut,
+//|         latch_pin: digitalio.DigitalInOut,
+//|         output_enable_pin: digitalio.DigitalInOut,
+//|         doublebuffer: bool = True,
+//|         framebuffer: Optional[WriteableBuffer] = None,
+//|         height: int = 0,
+//|         tile: int = 1,
+//|         serpentine: bool = True
+//|     ) -> None:
 //|         """Create a RGBMatrix object with the given attributes.  The height of
 //|         the display is determined by the number of rgb and address pins and the number of tiles:
 //|         ``len(rgb_pins) // 3 * 2 ** len(address_pins) * abs(tile)``.  With 6 RGB pins, 4
@@ -176,7 +182,6 @@ STATIC void preflight_pins_or_throw(uint8_t clock_pin, uint8_t *rgb_pins, uint8_
 //|
 //|         A RGBMatrix is often used in conjunction with a
 //|         `framebufferio.FramebufferDisplay`."""
-//|
 
 STATIC mp_obj_t rgbmatrix_rgbmatrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_width, ARG_bit_depth, ARG_rgb_list, ARG_addr_list,
@@ -259,7 +264,6 @@ STATIC mp_obj_t rgbmatrix_rgbmatrix_make_new(const mp_obj_type_t *type, size_t n
 //|         rgbmatrix instance.  After deinitialization, no further operations
 //|         may be performed."""
 //|         ...
-//|
 STATIC mp_obj_t rgbmatrix_rgbmatrix_deinit(mp_obj_t self_in) {
     rgbmatrix_rgbmatrix_obj_t *self = (rgbmatrix_rgbmatrix_obj_t *)self_in;
     common_hal_rgbmatrix_rgbmatrix_deinit(self);
@@ -277,7 +281,6 @@ static void check_for_deinit(rgbmatrix_rgbmatrix_obj_t *self) {
 //|     brightness: float
 //|     """In the current implementation, 0.0 turns the display off entirely
 //|     and any other value up to 1.0 turns the display on fully."""
-//|
 STATIC mp_obj_t rgbmatrix_rgbmatrix_get_brightness(mp_obj_t self_in) {
     rgbmatrix_rgbmatrix_obj_t *self = (rgbmatrix_rgbmatrix_obj_t *)self_in;
     check_for_deinit(self);
@@ -306,7 +309,6 @@ MP_PROPERTY_GETSET(rgbmatrix_rgbmatrix_brightness_obj,
 //|         """Transmits the color data in the buffer to the pixels so that
 //|         they are shown."""
 //|         ...
-//|
 STATIC mp_obj_t rgbmatrix_rgbmatrix_refresh(mp_obj_t self_in) {
     rgbmatrix_rgbmatrix_obj_t *self = (rgbmatrix_rgbmatrix_obj_t *)self_in;
     check_for_deinit(self);
@@ -317,7 +319,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(rgbmatrix_rgbmatrix_refresh_obj, rgbmatrix_rgbmatrix_r
 
 //|     width: int
 //|     """The width of the display, in pixels"""
-//|
 STATIC mp_obj_t rgbmatrix_rgbmatrix_get_width(mp_obj_t self_in) {
     rgbmatrix_rgbmatrix_obj_t *self = (rgbmatrix_rgbmatrix_obj_t *)self_in;
     check_for_deinit(self);
@@ -329,7 +330,6 @@ MP_PROPERTY_GETTER(rgbmatrix_rgbmatrix_width_obj,
 
 //|     height: int
 //|     """The height of the display, in pixels"""
-//|
 STATIC mp_obj_t rgbmatrix_rgbmatrix_get_height(mp_obj_t self_in) {
     rgbmatrix_rgbmatrix_obj_t *self = (rgbmatrix_rgbmatrix_obj_t *)self_in;
     check_for_deinit(self);

--- a/shared-bindings/rgbmatrix/__init__.c
+++ b/shared-bindings/rgbmatrix/__init__.c
@@ -32,7 +32,6 @@
 #include "shared-bindings/rgbmatrix/RGBMatrix.h"
 
 //| """Low-level routines for bitbanged LED matrices"""
-//|
 
 STATIC const mp_rom_map_elem_t rgbmatrix_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_rgbmatrix) },

--- a/shared-bindings/rotaryio/IncrementalEncoder.c
+++ b/shared-bindings/rotaryio/IncrementalEncoder.c
@@ -37,7 +37,9 @@
 //| class IncrementalEncoder:
 //|     """IncrementalEncoder determines the relative rotational position based on two series of pulses."""
 //|
-//|     def __init__(self, pin_a: microcontroller.Pin, pin_b: microcontroller.Pin, divisor: int = 4) -> None:
+//|     def __init__(
+//|         self, pin_a: microcontroller.Pin, pin_b: microcontroller.Pin, divisor: int = 4
+//|     ) -> None:
 //|         """Create an IncrementalEncoder object associated with the given pins. It tracks the positional
 //|         state of an incremental rotary encoder (also known as a quadrature encoder.) Position is
 //|         relative to the position when the object is contructed.
@@ -60,7 +62,6 @@
 //|                   print(position)
 //|               last_position = position"""
 //|         ...
-//|
 STATIC mp_obj_t rotaryio_incrementalencoder_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pin_a, ARG_pin_b, ARG_divisor };
     static const mp_arg_t allowed_args[] = {
@@ -87,7 +88,6 @@ STATIC mp_obj_t rotaryio_incrementalencoder_make_new(const mp_obj_type_t *type, 
 //|     def deinit(self) -> None:
 //|         """Deinitializes the IncrementalEncoder and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t rotaryio_incrementalencoder_deinit(mp_obj_t self_in) {
     rotaryio_incrementalencoder_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_rotaryio_incrementalencoder_deinit(self);
@@ -104,14 +104,12 @@ STATIC void check_for_deinit(rotaryio_incrementalencoder_obj_t *self) {
 //|     def __enter__(self) -> IncrementalEncoder:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t rotaryio_incrementalencoder_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_rotaryio_incrementalencoder_deinit(args[0]);
@@ -124,7 +122,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(rotaryio_incrementalencoder___exit___
 //|     """The divisor of the quadrature signal.  Use 1 for encoders without
 //|     detents, or encoders with 4 detents per cycle.  Use 2 for encoders with 2
 //|     detents per cycle.  Use 4 for encoders with 1 detent per cycle."""
-//|
 STATIC mp_obj_t rotaryio_incrementalencoder_obj_get_divisor(mp_obj_t self_in) {
     rotaryio_incrementalencoder_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -149,7 +146,6 @@ MP_PROPERTY_GETSET(rotaryio_incrementalencoder_divisor_obj,
 //|     position: int
 //|     """The current position in terms of pulses. The number of pulses per rotation is defined by the
 //|     specific hardware and by the divisor."""
-//|
 STATIC mp_obj_t rotaryio_incrementalencoder_obj_get_position(mp_obj_t self_in) {
     rotaryio_incrementalencoder_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/rotaryio/__init__.c
+++ b/shared-bindings/rotaryio/__init__.c
@@ -46,7 +46,6 @@
 //| are no longer needed if the program continues after use. To do so, either
 //| call :py:meth:`!deinit` or use a context manager. See
 //| :ref:`lifetime-and-contextmanagers` for more info."""
-//|
 
 STATIC const mp_rom_map_elem_t rotaryio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_rotaryio) },

--- a/shared-bindings/rtc/RTC.c
+++ b/shared-bindings/rtc/RTC.c
@@ -44,7 +44,6 @@ const rtc_rtc_obj_t rtc_rtc_obj = {{&rtc_rtc_type}};
 //|     def __init__(self) -> None:
 //|         """This class represents the onboard Real Time Clock. It is a singleton and will always return the same instance."""
 //|         ...
-//|
 STATIC mp_obj_t rtc_rtc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // No arguments
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
@@ -71,7 +70,6 @@ STATIC mp_obj_t rtc_rtc_make_new(const mp_obj_type_t *type, size_t n_args, size_
 //|       current_time = r.datetime
 //|       print(current_time)
 //|       # struct_time(tm_year=2019, tm_month=5, ...)"""
-//|
 STATIC mp_obj_t rtc_rtc_obj_get_datetime(mp_obj_t self_in) {
     timeutils_struct_time_t tm;
     common_hal_rtc_get_time(&tm);
@@ -102,7 +100,6 @@ MP_PROPERTY_GETSET(rtc_rtc_datetime_obj,
 //|
 //|       r = rtc.RTC()
 //|       r.calibration = 1"""
-//|
 STATIC mp_obj_t rtc_rtc_obj_get_calibration(mp_obj_t self_in) {
     int calibration = common_hal_rtc_get_calibration();
     return mp_obj_new_int(calibration);

--- a/shared-bindings/rtc/__init__.c
+++ b/shared-bindings/rtc/__init__.c
@@ -36,7 +36,6 @@
 //| The `rtc` module provides support for a Real Time Clock. You can access and manage the
 //| RTC using :class:`rtc.RTC`. It also backs the :func:`time.time` and :func:`time.localtime`
 //| functions using the onboard RTC if present."""
-//|
 
 void rtc_reset(void) {
     MP_STATE_VM(rtc_time_source) = (mp_obj_t)&rtc_rtc_obj;
@@ -66,7 +65,6 @@ mp_obj_t rtc_get_time_source_time(void) {
 //|       r = RTC()
 //|       rtc.set_time_source(r)"""
 //|     ...
-//|
 STATIC mp_obj_t rtc_set_time_source(mp_obj_t time_source) {
     MP_STATE_VM(rtc_time_source) = time_source;
 

--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -44,7 +44,9 @@
 //|     `busio.SPI`, not `bitbangio.SPI`.  Usually an SDCard object is used
 //|     with ``storage.VfsFat`` to allow file I/O to an SD card."""
 //|
-//|     def __init__(self, bus: busio.SPI, cs: microcontroller.Pin, baudrate: int = 8000000) -> None:
+//|     def __init__(
+//|         self, bus: busio.SPI, cs: microcontroller.Pin, baudrate: int = 8000000
+//|     ) -> None:
 //|         """Construct an SPI SD Card object with the given properties
 //|
 //|         :param busio.SPI spi: The SPI bus
@@ -105,7 +107,6 @@ STATIC mp_obj_t sdcardio_sdcard_make_new(const mp_obj_type_t *type, size_t n_arg
 //|         Due to technical limitations, this is a function and not a property.
 //|
 //|         :return: The number of 512-byte blocks, as a number"""
-//|
 STATIC mp_obj_t sdcardio_sdcard_count(mp_obj_t self_in) {
     sdcardio_sdcard_obj_t *self = (sdcardio_sdcard_obj_t *)self_in;
     return mp_obj_new_int_from_ull(common_hal_sdcardio_sdcard_get_blockcount(self));
@@ -116,7 +117,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(sdcardio_sdcard_count_obj, sdcardio_sdcard_count);
 //|         """Disable permanently.
 //|
 //|         :return: None"""
-//|
 STATIC mp_obj_t sdcardio_sdcard_deinit(mp_obj_t self_in) {
     sdcardio_sdcard_obj_t *self = (sdcardio_sdcard_obj_t *)self_in;
     common_hal_sdcardio_sdcard_deinit(self);
@@ -133,7 +133,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(sdcardio_sdcard_deinit_obj, sdcardio_sdcard_deinit);
 //|         :param ~circuitpython_typing.WriteableBuffer buf: The buffer to write into.  Length must be multiple of 512.
 //|
 //|         :return: None"""
-//|
 
 STATIC mp_obj_t sdcardio_sdcard_readblocks(mp_obj_t self_in, mp_obj_t start_block_in, mp_obj_t buf_in) {
     uint32_t start_block = mp_obj_get_int(start_block_in);
@@ -174,7 +173,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(sdcardio_sdcard_sync_obj, sdcardio_sdcard_sync);
 //|         :param ~circuitpython_typing.ReadableBuffer buf: The buffer to read from.  Length must be multiple of 512.
 //|
 //|         :return: None"""
-//|
 
 STATIC mp_obj_t sdcardio_sdcard_writeblocks(mp_obj_t self_in, mp_obj_t start_block_in, mp_obj_t buf_in) {
     uint32_t start_block = mp_obj_get_int(start_block_in);

--- a/shared-bindings/sdioio/SDCard.c
+++ b/shared-bindings/sdioio/SDCard.c
@@ -49,7 +49,13 @@
 //|     25MHz.  Usually an SDCard object is used with ``storage.VfsFat``
 //|     to allow file I/O to an SD card."""
 //|
-//|     def __init__(self, clock: microcontroller.Pin, command: microcontroller.Pin, data: Sequence[microcontroller.Pin], frequency: int) -> None:
+//|     def __init__(
+//|         self,
+//|         clock: microcontroller.Pin,
+//|         command: microcontroller.Pin,
+//|         data: Sequence[microcontroller.Pin],
+//|         frequency: int,
+//|     ) -> None:
 //|         """Construct an SDIO SD Card object with the given properties
 //|
 //|         :param ~microcontroller.Pin clock: the pin to use for the clock.
@@ -76,7 +82,6 @@
 //|             storage.mount(vfs, '/sd')
 //|             os.listdir('/sd')"""
 //|         ...
-//|
 
 STATIC mp_obj_t sdioio_sdcard_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     sdioio_sdcard_obj_t *self = m_new_obj(sdioio_sdcard_obj_t);
@@ -116,7 +121,6 @@ STATIC void check_for_deinit(sdioio_sdcard_obj_t *self) {
 //|         :param int width: the number of data lines to use.  Must be 1 or 4 and must also not exceed the number of data lines at construction
 //|
 //|         .. note:: Leaving a value unspecified or 0 means the current setting is kept"""
-//|
 STATIC mp_obj_t sdioio_sdcard_configure(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_frequency, ARG_width, NUM_ARGS };
     static const mp_arg_t allowed_args[] = {
@@ -148,7 +152,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(sdioio_sdcard_configure_obj, 1, sdioio_sdcard_configu
 //|         Due to technical limitations, this is a function and not a property.
 //|
 //|         :return: The number of 512-byte blocks, as a number"""
-//|
 STATIC mp_obj_t sdioio_sdcard_count(mp_obj_t self_in) {
     sdioio_sdcard_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -186,7 +189,6 @@ MP_DEFINE_CONST_FUN_OBJ_3(sdioio_sdcard_readblocks_obj, sdioio_sdcard_readblocks
 //|         :param ~circuitpython_typing.ReadableBuffer buf: The buffer to read from.  Length must be multiple of 512.
 //|
 //|         :return: None"""
-//|
 STATIC mp_obj_t sdioio_sdcard_writeblocks(mp_obj_t self_in, mp_obj_t start_block_in, mp_obj_t buf_in) {
     uint32_t start_block = mp_obj_get_int(start_block_in);
     mp_buffer_info_t bufinfo;
@@ -204,7 +206,6 @@ MP_DEFINE_CONST_FUN_OBJ_3(sdioio_sdcard_writeblocks_obj, sdioio_sdcard_writebloc
 //|     frequency: int
 //|     """The actual SDIO bus frequency. This may not match the frequency
 //|     requested due to internal limitations."""
-//|
 STATIC mp_obj_t sdioio_sdcard_obj_get_frequency(mp_obj_t self_in) {
     sdioio_sdcard_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -215,9 +216,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(sdioio_sdcard_get_frequency_obj, sdioio_sdcard_obj_get
 MP_PROPERTY_GETTER(sdioio_sdcard_frequency_obj,
     (mp_obj_t)&sdioio_sdcard_get_frequency_obj);
 
-//|     width:int
+//|     width: int
 //|     """The actual SDIO bus width, in bits"""
-//|
 STATIC mp_obj_t sdioio_sdcard_obj_get_width(mp_obj_t self_in) {
     sdioio_sdcard_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -243,13 +243,11 @@ MP_DEFINE_CONST_FUN_OBJ_1(sdioio_sdcard_deinit_obj, sdioio_sdcard_obj_deinit);
 //|         """No-op used by Context Managers.
 //|         Provided by context manager helper."""
 //|         ...
-//|
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t sdioio_sdcard_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_sdioio_sdcard_deinit(args[0]);

--- a/shared-bindings/sharpdisplay/__init__.c
+++ b/shared-bindings/sharpdisplay/__init__.c
@@ -36,7 +36,6 @@
 //| For more information about working with Sharp Memory Displays,
 //| see `this Learn guide <https://learn.adafruit.com/adafruit-sharp-memory-display-breakout/circuitpython-displayio-setup>`_.
 //| """
-//|
 STATIC const mp_rom_map_elem_t sharpdisplay_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_sharpdisplay) },
     { MP_ROM_QSTR(MP_QSTR_SharpMemoryFramebuffer), MP_ROM_PTR(&sharpdisplay_framebuffer_type) },

--- a/shared-bindings/socketpool/Socket.c
+++ b/shared-bindings/socketpool/Socket.c
@@ -40,29 +40,25 @@
 
 //| class Socket:
 //|     """TCP, UDP and RAW socket. Cannot be created directly. Instead, call
-//|        `SocketPool.socket()`.
+//|     `SocketPool.socket()`.
 //|
-//|        Provides a subset of CPython's `socket.socket` API. It only implements the versions of
-//|        recv that do not allocate bytes objects."""
-//|
+//|     Provides a subset of CPython's `socket.socket` API. It only implements the versions of
+//|     recv that do not allocate bytes objects."""
 
 //|     def __hash__(self) -> int:
 //|         """Returns a hash for the Socket."""
 //|         ...
-//|
 // Provided by mp_generic_unary_op().
 
 //|     def __enter__(self) -> Socket:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically closes the Socket when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t socketpool_socket___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_socketpool_socket_close(args[0]);
@@ -74,7 +70,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socketpool_socket___exit___obj, 4, 4,
 //|         """Accept a connection on a listening socket of type SOCK_STREAM,
 //|         creating a new socket of type SOCK_STREAM.
 //|         Returns a tuple of (new_socket, remote_address)"""
-//|
 STATIC mp_obj_t _socketpool_socket_accept(mp_obj_t self_in) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint8_t ip[4];
@@ -94,7 +89,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(socketpool_socket_accept_obj, _socketpool_socke
 //|
 //|         :param ~tuple address: tuple of (remote_address, remote_port)"""
 //|         ...
-//|
 STATIC mp_obj_t socketpool_socket_bind(mp_obj_t self_in, mp_obj_t addr_in) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -119,7 +113,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socketpool_socket_bind_obj, socketpool_socket_b
 
 //|     def close(self) -> None:
 //|         """Closes this Socket and makes its resources available to its SocketPool."""
-//|
 STATIC mp_obj_t _socketpool_socket_close(mp_obj_t self_in) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_socketpool_socket_close(self);
@@ -132,7 +125,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(socketpool_socket_close_obj, _socketpool_socket
 //|
 //|         :param ~tuple address: tuple of (remote_address, remote_port)"""
 //|         ...
-//|
 STATIC mp_obj_t socketpool_socket_connect(mp_obj_t self_in, mp_obj_t addr_in) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -157,7 +149,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socketpool_socket_connect_obj, socketpool_socke
 //|
 //|         :param ~int backlog: length of backlog queue for waiting connections"""
 //|         ...
-//|
 STATIC mp_obj_t socketpool_socket_listen(mp_obj_t self_in, mp_obj_t backlog_in) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -177,7 +168,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socketpool_socket_listen_obj, socketpool_socket
 //|
 //|         :param object buffer: buffer to read into"""
 //|         ...
-//|
 STATIC mp_obj_t socketpool_socket_recvfrom_into(mp_obj_t self_in, mp_obj_t data_in) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_buffer_info_t bufinfo;
@@ -207,7 +197,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socketpool_socket_recvfrom_into_obj, socketpool
 //|         :param bytearray buffer: buffer to receive into
 //|         :param int bufsize: optionally, a maximum number of bytes to read."""
 //|         ...
-//|
 STATIC mp_obj_t _socketpool_socket_recv_into(size_t n_args, const mp_obj_t *args) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     if (common_hal_socketpool_socket_get_closed(self)) {
@@ -246,7 +235,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socketpool_socket_recv_into_obj, 2, 3
 //|
 //|         :param ~bytes bytes: some bytes to send"""
 //|         ...
-//|
 STATIC mp_obj_t _socketpool_socket_send(mp_obj_t self_in, mp_obj_t buf_in) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (common_hal_socketpool_socket_get_closed(self)) {
@@ -273,7 +261,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socketpool_socket_send_obj, _socketpool_socket_
 //|         :param ~bytes bytes: some bytes to send
 //|         :param ~tuple address: tuple of (remote_address, remote_port)"""
 //|         ...
-//|
 STATIC mp_obj_t socketpool_socket_sendto(mp_obj_t self_in, mp_obj_t data_in, mp_obj_t addr_in) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -302,7 +289,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(socketpool_socket_sendto_obj, socketpool_socket
 //|
 //|         :param ~bool flag: False means non-blocking, True means block indefinitely."""
 //|         ...
-//|
 // method socket.setblocking(flag)
 STATIC mp_obj_t socketpool_socket_setblocking(mp_obj_t self_in, mp_obj_t blocking) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -354,7 +340,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socketpool_socket_setblocking_obj, socketpool_s
 //|
 //|         :param ~int value: timeout in seconds.  0 means non-blocking.  None means block indefinitely."""
 //|         ...
-//|
 STATIC mp_obj_t socketpool_socket_settimeout(mp_obj_t self_in, mp_obj_t timeout_in) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_uint_t timeout_ms;

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -81,7 +81,6 @@ STATIC mp_obj_t socketpool_socketpool_make_new(const mp_obj_type_t *type, size_t
 //|         in CPython are not supported.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t socketpool_socketpool_socket(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_family, ARG_type };
     static const mp_arg_t allowed_args[] = {
@@ -100,14 +99,21 @@ STATIC mp_obj_t socketpool_socketpool_socket(size_t n_args, const mp_obj_t *pos_
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(socketpool_socketpool_socket_obj, 1, socketpool_socketpool_socket);
 
-//|     def getaddrinfo(self, host: str, port: int, family: int = 0, type: int = 0, proto: int = 0, flags: int = 0) -> Tuple[int, int, int, str, Tuple[str, int]]:
+//|     def getaddrinfo(
+//|         self,
+//|         host: str,
+//|         port: int,
+//|         family: int = 0,
+//|         type: int = 0,
+//|         proto: int = 0,
+//|         flags: int = 0,
+//|     ) -> Tuple[int, int, int, str, Tuple[str, int]]:
 //|         """Gets the address information for a hostname and port
 //|
 //|         Returns the appropriate family, socket type, socket protocol and
 //|         address information to call socket.socket() and socket.connect() with,
 //|         as a tuple."""
 //|         ...
-//|
 STATIC mp_obj_t socketpool_socketpool_getaddrinfo(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_host, ARG_port, ARG_family, ARG_type, ARG_proto, ARG_flags };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/socketpool/__init__.c
+++ b/shared-bindings/socketpool/__init__.c
@@ -39,7 +39,6 @@
 //| For more information about the `socket` module, see the CPython documentation:
 //| https://docs.python.org/3/library/socket.html
 //| """
-//|
 
 STATIC const mp_rom_map_elem_t socketpool_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_socketpool) },

--- a/shared-bindings/ssl/SSLContext.c
+++ b/shared-bindings/ssl/SSLContext.c
@@ -37,9 +37,8 @@
 
 //| class SSLContext:
 //|     """Settings related to SSL that can be applied to a socket by wrapping it.
-//|        This is useful to provide SSL certificates to specific connections
-//|        rather than all of them."""
-//|
+//|     This is useful to provide SSL certificates to specific connections
+//|     rather than all of them."""
 
 STATIC mp_obj_t ssl_sslcontext_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
@@ -54,8 +53,7 @@ STATIC mp_obj_t ssl_sslcontext_make_new(const mp_obj_type_t *type, size_t n_args
 
 //|     def load_verify_locations(self, cadata: Optional[str] = None) -> None:
 //|         """Load a set of certification authority (CA) certificates used to validate
-//|            other peers' certificates."""
-//|
+//|         other peers' certificates."""
 
 STATIC mp_obj_t ssl_sslcontext_load_verify_locations(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_cadata };
@@ -76,7 +74,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ssl_sslcontext_load_verify_locations_obj, 1, s
 
 //|     def set_default_verify_paths(self) -> None:
 //|         """Load a set of default certification authority (CA) certificates."""
-//|
 
 STATIC mp_obj_t ssl_sslcontext_set_default_verify_paths(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     ssl_sslcontext_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
@@ -88,7 +85,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ssl_sslcontext_set_default_verify_paths_obj, 1
 
 //|     check_hostname: bool
 //|     """Whether to match the peer certificate's hostname."""
-//|
 
 STATIC mp_obj_t ssl_sslcontext_get_check_hostname(mp_obj_t self_in) {
     ssl_sslcontext_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -109,10 +105,15 @@ MP_PROPERTY_GETSET(ssl_sslcontext_check_hostname_obj,
     (mp_obj_t)&ssl_sslcontext_get_check_hostname_obj,
     (mp_obj_t)&ssl_sslcontext_set_check_hostname_obj);
 
-//|     def wrap_socket(self, sock: socketpool.Socket, *, server_side: bool = False, server_hostname: Optional[str] = None) -> ssl.SSLSocket:
+//|     def wrap_socket(
+//|         self,
+//|         sock: socketpool.Socket,
+//|         *,
+//|         server_side: bool = False,
+//|         server_hostname: Optional[str] = None
+//|     ) -> ssl.SSLSocket:
 //|         """Wraps the socket into a socket-compatible class that handles SSL negotiation.
-//|            The socket must be of type SOCK_STREAM."""
-//|
+//|         The socket must be of type SOCK_STREAM."""
 
 STATIC mp_obj_t ssl_sslcontext_wrap_socket(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_sock, ARG_server_side, ARG_server_hostname };

--- a/shared-bindings/ssl/SSLSocket.c
+++ b/shared-bindings/ssl/SSLSocket.c
@@ -39,29 +39,25 @@
 
 //| class SSLSocket:
 //|     """Implements TLS security on a subset of `socketpool.Socket` functions. Cannot be created
-//|        directly. Instead, call `wrap_socket` on an existing socket object.
+//|     directly. Instead, call `wrap_socket` on an existing socket object.
 //|
-//|        Provides a subset of CPython's `ssl.SSLSocket` API. It only implements the versions of
-//|        recv that do not allocate bytes objects."""
-//|
+//|     Provides a subset of CPython's `ssl.SSLSocket` API. It only implements the versions of
+//|     recv that do not allocate bytes objects."""
 
 //|     def __hash__(self) -> int:
 //|         """Returns a hash for the Socket."""
 //|         ...
-//|
 // Provided by mp_generic_unary_op().
 
 //|     def __enter__(self) -> SSLSocket:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically closes the Socket when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t ssl_sslsocket___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_ssl_sslsocket_close(args[0]);
@@ -73,7 +69,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ssl_sslsocket___exit___obj, 4, 4, ssl
 //|         """Accept a connection on a listening socket of type SOCK_STREAM,
 //|         creating a new socket of type SOCK_STREAM.
 //|         Returns a tuple of (new_socket, remote_address)"""
-//|
 STATIC mp_obj_t ssl_sslsocket_accept(mp_obj_t self_in) {
     ssl_sslsocket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     uint8_t ip[4];
@@ -93,7 +88,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(ssl_sslsocket_accept_obj, ssl_sslsocket_accept)
 //|
 //|         :param ~tuple address: tuple of (remote_address, remote_port)"""
 //|         ...
-//|
 STATIC mp_obj_t ssl_sslsocket_bind(mp_obj_t self_in, mp_obj_t addr_in) {
     ssl_sslsocket_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -118,7 +112,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ssl_sslsocket_bind_obj, ssl_sslsocket_bind);
 
 //|     def close(self) -> None:
 //|         """Closes this Socket"""
-//|
 STATIC mp_obj_t ssl_sslsocket_close(mp_obj_t self_in) {
     ssl_sslsocket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_ssl_sslsocket_close(self);
@@ -131,7 +124,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(ssl_sslsocket_close_obj, ssl_sslsocket_close);
 //|
 //|         :param ~tuple address: tuple of (remote_address, remote_port)"""
 //|         ...
-//|
 STATIC mp_obj_t ssl_sslsocket_connect(mp_obj_t self_in, mp_obj_t addr_in) {
     ssl_sslsocket_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -156,7 +148,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ssl_sslsocket_connect_obj, ssl_sslsocket_connec
 //|
 //|         :param ~int backlog: length of backlog queue for waiting connetions"""
 //|         ...
-//|
 STATIC mp_obj_t ssl_sslsocket_listen(mp_obj_t self_in, mp_obj_t backlog_in) {
     ssl_sslsocket_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -180,7 +171,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ssl_sslsocket_listen_obj, ssl_sslsocket_listen)
 //|         :param bytearray buffer: buffer to receive into
 //|         :param int bufsize: optionally, a maximum number of bytes to read."""
 //|         ...
-//|
 STATIC mp_obj_t ssl_sslsocket_recv_into(size_t n_args, const mp_obj_t *args) {
     ssl_sslsocket_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     if (common_hal_ssl_sslsocket_get_closed(self)) {
@@ -219,7 +209,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ssl_sslsocket_recv_into_obj, 2, 3, ss
 //|
 //|         :param ~bytes bytes: some bytes to send"""
 //|         ...
-//|
 STATIC mp_obj_t ssl_sslsocket_send(mp_obj_t self_in, mp_obj_t buf_in) {
     ssl_sslsocket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (common_hal_ssl_sslsocket_get_closed(self)) {
@@ -252,7 +241,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ssl_sslsocket_send_obj, ssl_sslsocket_send);
 //|
 //|         :param ~int value: timeout in seconds.  0 means non-blocking.  None means block indefinitely."""
 //|         ...
-//|
 STATIC mp_obj_t ssl_sslsocket_settimeout(mp_obj_t self_in, mp_obj_t timeout_in) {
     ssl_sslsocket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_uint_t timeout_ms;
@@ -275,7 +263,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ssl_sslsocket_settimeout_obj, ssl_sslsocket_set
 //|
 //|         :param ~bool flag: False means non-blocking, True means block indefinitely."""
 //|         ...
-//|
 // method socket.setblocking(flag)
 STATIC mp_obj_t ssl_sslsocket_setblocking(mp_obj_t self_in, mp_obj_t blocking) {
     ssl_sslsocket_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/ssl/__init__.c
+++ b/shared-bindings/ssl/__init__.c
@@ -36,12 +36,10 @@
 //|
 //| |see_cpython_module| :mod:`cpython:ssl`.
 //| """
-//|
 
 //| def create_default_context() -> ssl.SSLContext:
 //|     """Return the default SSLContext."""
 //|     ...
-//|
 
 STATIC mp_obj_t ssl_create_default_context(void) {
     ssl_sslcontext_obj_t *s = m_new_obj(ssl_sslcontext_obj_t);

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -57,7 +57,6 @@
 //|     :param bool readonly: True when the filesystem should be readonly to CircuitPython.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t storage_mount(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_filesystem, ARG_mount_path, ARG_readonly };
     static const mp_arg_t allowed_args[] = {
@@ -94,7 +93,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(storage_mount_obj, 0, storage_mount);
 //|
 //|     This is the CircuitPython analog to the UNIX ``umount`` command."""
 //|     ...
-//|
 STATIC mp_obj_t storage_umount(mp_obj_t mnt_in) {
     if (mp_obj_is_str(mnt_in)) {
         common_hal_storage_umount_path(mp_obj_str_get_str(mnt_in));
@@ -106,17 +104,21 @@ STATIC mp_obj_t storage_umount(mp_obj_t mnt_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(storage_umount_obj, storage_umount);
 
-//| def remount(mount_path: str, readonly: bool = False, *, disable_concurrent_write_protection: bool = False) -> None:
+//| def remount(
+//|     mount_path: str,
+//|     readonly: bool = False,
+//|     *,
+//|     disable_concurrent_write_protection: bool = False
+//| ) -> None:
 //|     """Remounts the given path with new parameters.
 //|
-//|       :param str mount_path: The path to remount.
-//|       :param bool readonly: True when the filesystem should be readonly to CircuitPython.
-//|       :param bool disable_concurrent_write_protection: When True, the check that makes sure the
-//|         underlying filesystem data is written by one computer is disabled. Disabling the protection
-//|         allows CircuitPython and a host to write to the same filesystem with the risk that the
-//|         filesystem will be corrupted."""
+//|     :param str mount_path: The path to remount.
+//|     :param bool readonly: True when the filesystem should be readonly to CircuitPython.
+//|     :param bool disable_concurrent_write_protection: When True, the check that makes sure the
+//|       underlying filesystem data is written by one computer is disabled. Disabling the protection
+//|       allows CircuitPython and a host to write to the same filesystem with the risk that the
+//|       filesystem will be corrupted."""
 //|     ...
-//|
 STATIC mp_obj_t storage_remount(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_mount_path, ARG_readonly, ARG_disable_concurrent_write_protection };
     static const mp_arg_t allowed_args[] = {
@@ -139,7 +141,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(storage_remount_obj, 0, storage_remount);
 //| def getmount(mount_path: str) -> VfsFat:
 //|     """Retrieves the mount object associated with the mount path"""
 //|     ...
-//|
 STATIC mp_obj_t storage_getmount(const mp_obj_t mnt_in) {
     return common_hal_storage_getmount(mp_obj_str_get_str(mnt_in));
 }
@@ -158,7 +159,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(storage_getmount_obj, storage_getmount);
 //|     .. warning:: All the data on ``CIRCUITPY`` will be lost, and
 //|          CircuitPython will restart on certain boards."""
 //|     ...
-//|
 
 STATIC mp_obj_t storage_erase_filesystem(void) {
     common_hal_storage_erase_filesystem();
@@ -171,7 +171,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(storage_erase_filesystem_obj, storage_erase_filesystem
 //|     By default, the device is enabled and ``CIRCUITPY`` is visible.
 //|     Can be called in ``boot.py``, before USB is connected."""
 //|     ...
-//|
 STATIC mp_obj_t storage_disable_usb_drive(void) {
     #if CIRCUITPY_USB_MSC
     if (!common_hal_storage_disable_usb_drive()) {
@@ -196,7 +195,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(storage_disable_usb_drive_obj, storage_disable_usb_dri
 //|     not enough endpoints are available.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t storage_enable_usb_drive(void) {
     #if CIRCUITPY_USB_MSC
     if (!common_hal_storage_enable_usb_drive()) {
@@ -225,7 +223,6 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
 //|         """Create a new VfsFat filesystem around the given block device.
 //|
 //|         :param block_device: Block device the the filesystem lives on"""
-//|
 //|     label: str
 //|     """The filesystem label, up to 11 case-insensitive bytes.  Note that
 //|     this property can only be set when the device is writable by the
@@ -235,40 +232,33 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
 //|     def mkfs(self) -> None:
 //|         """Format the block device, deleting any data that may have been there"""
 //|         ...
-//|
 //|     def open(self, path: str, mode: str) -> None:
 //|         """Like builtin ``open()``"""
 //|         ...
-//|
-//|     def ilistdir(self, path: str) -> Iterator[Union[Tuple[AnyStr, int, int, int], Tuple[AnyStr, int, int]]]:
+//|     def ilistdir(
+//|         self, path: str
+//|     ) -> Iterator[Union[Tuple[AnyStr, int, int, int], Tuple[AnyStr, int, int]]]:
 //|         """Return an iterator whose values describe files and folders within
 //|         ``path``"""
 //|         ...
-//|
 //|     def mkdir(self, path: str) -> None:
 //|         """Like `os.mkdir`"""
 //|         ...
-//|
 //|     def rmdir(self, path: str) -> None:
 //|         """Like `os.rmdir`"""
 //|         ...
-//|
 //|     def stat(self, path: str) -> Tuple[int, int, int, int, int, int, int, int, int, int]:
 //|         """Like `os.stat`"""
 //|         ...
-//|
 //|     def statvfs(self, path: int) -> Tuple[int, int, int, int, int, int, int, int, int, int]:
 //|         """Like `os.statvfs`"""
 //|         ...
-//|
 //|     def mount(self, readonly: bool, mkfs: VfsFat) -> None:
 //|         """Don't call this directly, call `storage.mount`."""
 //|         ...
-//|
 //|     def umount(self) -> None:
 //|         """Don't call this directly, call `storage.umount`."""
 //|         ...
-//|
     { MP_ROM_QSTR(MP_QSTR_VfsFat), MP_ROM_PTR(&mp_fat_vfs_type) },
 };
 

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -41,13 +41,12 @@
 //| unmounting which is typically handled by the operating system hosting Python.
 //| CircuitPython does not have an OS, so this module provides this functionality
 //| directly.
-
+//|
 //| For more information regarding using the `storage` module, refer to the `CircuitPython
 //| Essentials Learn guide
 //| <https://learn.adafruit.com/circuitpython-essentials/circuitpython-storage>`_.
 //| """
 //|
-
 //| def mount(filesystem: VfsFat, mount_path: str, *, readonly: bool = False) -> None:
 //|     """Mounts the given filesystem object at the given path.
 //|

--- a/shared-bindings/struct/__init__.c
+++ b/shared-bindings/struct/__init__.c
@@ -46,13 +46,11 @@
 //|
 //| Supported format codes: *b*, *B*, *x*, *h*, *H*, *i*, *I*, *l*, *L*, *q*, *Q*,
 //| *s*, *P*, *f*, *d* (the latter 2 depending on the floating-point support)."""
-//|
 
 
 //| def calcsize(fmt: str) -> int:
 //|     """Return the number of bytes needed to store the given fmt."""
 //|     ...
-//|
 
 STATIC mp_obj_t struct_calcsize(mp_obj_t fmt_in) {
 
@@ -64,7 +62,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(struct_calcsize_obj, struct_calcsize);
 //|     """Pack the values according to the format string fmt.
 //|     The return value is a bytes object encoding the values."""
 //|     ...
-//|
 
 STATIC mp_obj_t struct_pack(size_t n_args, const mp_obj_t *args) {
     mp_int_t size = MP_OBJ_SMALL_INT_VALUE(struct_calcsize(args[0]));
@@ -82,7 +79,6 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(struct_pack_obj, 1, MP_OBJ_FUN_ARGS_MAX, str
 //|     """Pack the values according to the format string fmt into a buffer
 //|     starting at offset. offset may be negative to count from the end of buffer."""
 //|     ...
-//|
 
 STATIC mp_obj_t struct_pack_into(size_t n_args, const mp_obj_t *args) {
     mp_buffer_info_t bufinfo;
@@ -109,7 +105,6 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(struct_pack_into_obj, 3, MP_OBJ_FUN_ARGS_MAX
 //|     is a tuple of the unpacked values. The buffer size must match the size
 //|     required by the format."""
 //|     ...
-//|
 
 STATIC mp_obj_t struct_unpack(size_t n_args, const mp_obj_t *args) {
     mp_buffer_info_t bufinfo;
@@ -128,7 +123,6 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(struct_unpack_obj, 2, 3, struct_unpack);
 //|     a tuple of the unpacked values. The buffer size must be at least as big
 //|     as the size required by the form."""
 //|     ...
-//|
 
 STATIC mp_obj_t struct_unpack_from(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_format, ARG_buffer, ARG_offset };

--- a/shared-bindings/supervisor/RunReason.c
+++ b/shared-bindings/supervisor/RunReason.c
@@ -48,7 +48,6 @@ MAKE_ENUM_VALUE(supervisor_run_reason_type, run_reason, REPL_RELOAD, RUN_REASON_
 //|
 //|     REPL_RELOAD: object
 //|     """CircuitPython started due to the user typing CTRL-D in the REPL."""
-//|
 MAKE_ENUM_MAP(supervisor_run_reason) {
     MAKE_ENUM_MAP_ENTRY(run_reason, STARTUP),
     MAKE_ENUM_MAP_ENTRY(run_reason, AUTO_RELOAD),

--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -51,17 +51,14 @@ STATIC supervisor_run_reason_t _run_reason;
 //|        import supervisor
 //|        if supervisor.runtime.serial_connected:
 //|            print("Hello World!")"""
-//|
 
 //|     def __init__(self) -> None:
 //|         """You cannot create an instance of `supervisor.Runtime`.
 //|         Use `supervisor.runtime` to access the sole instance available."""
 //|         ...
-//|
 
 //|     usb_connected: bool
 //|     """Returns the USB enumeration status (read-only)."""
-//|
 STATIC mp_obj_t supervisor_runtime_get_usb_connected(mp_obj_t self) {
     #if CIRCUITPY_USB
     return mp_obj_new_bool(tud_ready());
@@ -76,7 +73,6 @@ MP_PROPERTY_GETTER(supervisor_runtime_usb_connected_obj,
 
 //|     serial_connected: bool
 //|     """Returns the USB serial communication status (read-only)."""
-//|
 STATIC mp_obj_t supervisor_runtime_get_serial_connected(mp_obj_t self) {
     return mp_obj_new_bool(common_hal_supervisor_runtime_get_serial_connected());
 }
@@ -89,7 +85,6 @@ MP_PROPERTY_GETTER(supervisor_runtime_serial_connected_obj,
 //|     """Returns the whether any bytes are available to read
 //|     on the USB serial input.  Allows for polling to see whether
 //|     to call the built-in input() or wait. (read-only)"""
-//|
 STATIC mp_obj_t supervisor_runtime_get_serial_bytes_available(mp_obj_t self) {
     return mp_obj_new_bool(common_hal_supervisor_runtime_get_serial_bytes_available());
 }
@@ -108,7 +103,6 @@ void supervisor_set_run_reason(supervisor_run_reason_t run_reason) {
 
 //|     run_reason: RunReason
 //|     """Why CircuitPython started running this particular time."""
-//|
 STATIC mp_obj_t supervisor_runtime_get_run_reason(mp_obj_t self) {
     return cp_enum_find(&supervisor_run_reason_type, _run_reason);
 }
@@ -119,7 +113,6 @@ MP_PROPERTY_GETTER(supervisor_runtime_run_reason_obj,
 
 //|     autoreload: bool
 //|     """Whether CircuitPython may autoreload based on workflow writes to the filesystem."""
-//|
 STATIC mp_obj_t supervisor_runtime_get_autoreload(mp_obj_t self) {
     return mp_obj_new_bool(autoreload_is_enabled());
 }

--- a/shared-bindings/supervisor/StatusBar.c
+++ b/shared-bindings/supervisor/StatusBar.c
@@ -40,13 +40,11 @@
 //|
 //|        supervisor.status_bar.console = False
 //|     """
-//|
 
 //|     def __init__(self) -> None:
 //|         """You cannot create an instance of `supervisor.StatusBar`.
 //|         Use `supervisor.status_bar` to access the sole instance available."""
 //|         ...
-//|
 
 //|     console: bool
 //|     """Whether status bar information is sent over the console (REPL) serial connection,
@@ -54,7 +52,6 @@
 //|     If set to ``False``, status bar will be cleared and then disabled.
 //|     May be set in ``boot.py`` or later. Persists across soft restarts.
 //|     """
-//|
 STATIC mp_obj_t supervisor_status_bar_get_console(mp_obj_t self_in) {
     #if CIRCUITPY_STATUS_BAR
     supervisor_status_bar_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -86,7 +83,6 @@ MP_PROPERTY_GETSET(supervisor_status_bar_console_obj,
 //|     May be set in ``boot.py`` or later.  Persists across soft restarts.
 //|     Not available if `terminalio` is not available.
 //|     """
-//|
 STATIC mp_obj_t supervisor_status_bar_get_display(mp_obj_t self_in) {
     #if CIRCUITPY_STATUS_BAR && CIRCUITPY_TERMINALIO
     supervisor_status_bar_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -309,7 +309,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(supervisor_reset_terminal_obj, supervisor_reset_termin
 //|     characters. Any omitted arguments will be left at their default values.
 //|
 //|     This method must be called in boot.py to have any effect.
-
+//|
 //|     Not available on boards without native USB support.
 //|     """
 //|     ...

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -50,13 +50,11 @@
 #include "shared-bindings/supervisor/StatusBar.h"
 
 //| """Supervisor settings"""
-//|
 
 //| runtime: Runtime
 //| """Runtime information, such as ``runtime.serial_connected``
 //| (USB serial connection status).
 //| This object is the sole instance of `supervisor.Runtime`."""
-//|
 
 //| status_bar: StatusBar
 //| """The status bar, shown on an attached display, and also sent to
@@ -64,14 +62,12 @@
 //| The status bar reports the current IP or BLE connection, what file is running,
 //| the last exception name and location, and firmware version information.
 //| This object is the sole instance of `supervisor.StatusBar`."""
-//|
 
 //| def set_rgb_status_brightness(brightness: int) -> None:
 //|     """Set brightness of status RGB LED from 0-255. This will take effect
-//|        after the current code finishes and the status LED is used to show
-//|        the finish state."""
+//|     after the current code finishes and the status LED is used to show
+//|     the finish state."""
 //|     ...
-//|
 STATIC mp_obj_t supervisor_set_rgb_status_brightness(mp_obj_t lvl) {
     // This must be int. If cast to uint8_t first, will never raise a ValueError.
     int brightness_int = mp_obj_get_int(lvl);
@@ -84,7 +80,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(supervisor_set_rgb_status_brightness_obj, supervisor_s
 //| def reload() -> None:
 //|     """Reload the main Python code and run it (equivalent to hitting Ctrl-D at the REPL)."""
 //|     ...
-//|
 STATIC mp_obj_t supervisor_reload(void) {
     reload_initiate(RUN_REASON_SUPERVISOR_RELOAD);
     return mp_const_none;
@@ -94,7 +89,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(supervisor_reload_obj, supervisor_reload);
 //| def set_next_stack_limit(size: int) -> None:
 //|     """Set the size of the stack for the next vm run. If its too large, the default will be used."""
 //|     ...
-//|
 STATIC mp_obj_t supervisor_set_next_stack_limit(mp_obj_t size_obj) {
     mp_int_t size = mp_obj_get_int(size_obj);
 
@@ -106,7 +100,15 @@ STATIC mp_obj_t supervisor_set_next_stack_limit(mp_obj_t size_obj) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(supervisor_set_next_stack_limit_obj, supervisor_set_next_stack_limit);
 
-//| def set_next_code_file(filename: Optional[str], *, reload_on_success : bool = False, reload_on_error: bool = False, sticky_on_success: bool = False, sticky_on_error: bool = False, sticky_on_reload: bool = False) -> None:
+//| def set_next_code_file(
+//|     filename: Optional[str],
+//|     *,
+//|     reload_on_success: bool = False,
+//|     reload_on_error: bool = False,
+//|     sticky_on_success: bool = False,
+//|     sticky_on_error: bool = False,
+//|     sticky_on_reload: bool = False
+//| ) -> None:
 //|     """Set what file to run on the next vm run.
 //|
 //|     When not ``None``, the given ``filename`` is inserted at the front of the usual ['code.py',
@@ -138,7 +140,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(supervisor_set_next_stack_limit_obj, supervisor_set_ne
 //|     settings made by previous ones. This is the main use of passing ``None`` as a filename: to
 //|     reset to the standard search sequence."""
 //|     ...
-//|
 STATIC mp_obj_t supervisor_set_next_code_file(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_filename, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
@@ -254,7 +255,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(supervisor_ticks_ms_obj, supervisor_ticks_ms);
 //|
 //|     Only code (main or boot) runs are considered, not REPL runs."""
 //|     ...
-//|
 STATIC mp_obj_t supervisor_get_previous_traceback(void) {
     if (prev_traceback_allocation) {
         size_t len = strlen((const char *)prev_traceback_allocation->ptr);
@@ -274,9 +274,8 @@ MP_DEFINE_CONST_FUN_OBJ_0(supervisor_get_previous_traceback_obj, supervisor_get_
 
 //| def disable_ble_workflow() -> None:
 //|     """Disable ble workflow until a reset. This prevents BLE advertising outside of the VM and
-//|        the services used for it."""
+//|     the services used for it."""
 //|     ...
-//|
 STATIC mp_obj_t supervisor_disable_ble_workflow(void) {
     #if !CIRCUITPY_BLE_FILE_SERVICE && !CIRCUITPY_SERIAL_BLE
     mp_raise_NotImplementedError(NULL);
@@ -290,7 +289,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(supervisor_disable_ble_workflow_obj, supervisor_disabl
 //| def reset_terminal(x_pixels: int, y_pixels: int) -> None:
 //|     """Reset the CircuitPython serial terminal with new dimensions."""
 //|     ...
-//|
 STATIC mp_obj_t supervisor_reset_terminal(mp_obj_t x_pixels, mp_obj_t y_pixels) {
     #if CIRCUITPY_DISPLAYIO
     supervisor_stop_terminal();
@@ -302,7 +300,12 @@ STATIC mp_obj_t supervisor_reset_terminal(mp_obj_t x_pixels, mp_obj_t y_pixels) 
 }
 MP_DEFINE_CONST_FUN_OBJ_2(supervisor_reset_terminal_obj, supervisor_reset_terminal);
 
-//| def set_usb_identification(manufacturer: Optional[str] = None, product: Optional[str] = None, vid: int = -1, pid: int = -1) -> None:
+//| def set_usb_identification(
+//|     manufacturer: Optional[str] = None,
+//|     product: Optional[str] = None,
+//|     vid: int = -1,
+//|     pid: int = -1,
+//| ) -> None:
 //|     """Override identification constants in the USB Device Descriptor.
 //|
 //|     If passed, `manufacturer` and `product` must be ASCII strings (or buffers) of at most 126
@@ -313,7 +316,6 @@ MP_DEFINE_CONST_FUN_OBJ_2(supervisor_reset_terminal_obj, supervisor_reset_termin
 //|     Not available on boards without native USB support.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t supervisor_set_usb_identification(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     #if CIRCUITPY_USB_IDENTIFICATION
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/synthio/MidiTrack.c
+++ b/shared-bindings/synthio/MidiTrack.c
@@ -37,7 +37,9 @@
 //| class MidiTrack:
 //|     """Simple square-wave MIDI synth"""
 //|
-//|     def __init__(self, buffer: ReadableBuffer, tempo: int, *, sample_rate: int = 11025) -> None:
+//|     def __init__(
+//|         self, buffer: ReadableBuffer, tempo: int, *, sample_rate: int = 11025
+//|     ) -> None:
 //|         """Create a MidiTrack from the given stream of MIDI events. Only "Note On" and "Note Off" events
 //|         are supported; channel numbers and key velocities are ignored. Up to two notes may be on at the
 //|         same time.
@@ -62,7 +64,6 @@
 //|             pass
 //|           print("stopped")"""
 //|         ...
-//|
 STATIC mp_obj_t synthio_miditrack_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_buffer, ARG_tempo, ARG_sample_rate };
     static const mp_arg_t allowed_args[] = {
@@ -90,7 +91,6 @@ STATIC mp_obj_t synthio_miditrack_make_new(const mp_obj_type_t *type, size_t n_a
 //|     def deinit(self) -> None:
 //|         """Deinitialises the MidiTrack and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t synthio_miditrack_deinit(mp_obj_t self_in) {
     synthio_miditrack_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_synthio_miditrack_deinit(self);
@@ -107,14 +107,12 @@ STATIC void check_for_deinit(synthio_miditrack_obj_t *self) {
 //|     def __enter__(self) -> MidiTrack:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t synthio_miditrack_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_synthio_miditrack_deinit(args[0]);
@@ -124,7 +122,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(synthio_miditrack___exit___obj, 4, 4,
 
 //|     sample_rate: Optional[int]
 //|     """32 bit value that tells how quickly samples are played in Hertz (cycles per second)."""
-//|
 STATIC mp_obj_t synthio_miditrack_obj_get_sample_rate(mp_obj_t self_in) {
     synthio_miditrack_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/synthio/__init__.c
+++ b/shared-bindings/synthio/__init__.c
@@ -60,7 +60,6 @@
 //|             pass
 //|           print("stopped")"""
 //|     ...
-//|
 STATIC mp_obj_t synthio_from_file(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_file, ARG_sample_rate };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/terminalio/Terminal.c
+++ b/shared-bindings/terminalio/Terminal.c
@@ -40,27 +40,32 @@
 //| class Terminal:
 //|     """Display a character stream with a TileGrid
 //|
-//|        ASCII control:
-//|        * ``\\r`` - Move cursor to column 1
-//|        * ``\\n`` - Move cursor down a row
-//|        * ``\\b`` - Move cursor left one if possible
+//|     ASCII control:
+//|     * ``\\r`` - Move cursor to column 1
+//|     * ``\\n`` - Move cursor down a row
+//|     * ``\\b`` - Move cursor left one if possible
 //|
-//|        OSC control sequences:
-//|        * ``ESC ] 0; <s> ESC \\`` - Set title bar to <s>
-//|        * ``ESC ] ####; <s> ESC \\`` - Ignored
+//|     OSC control sequences:
+//|     * ``ESC ] 0; <s> ESC \\`` - Set title bar to <s>
+//|     * ``ESC ] ####; <s> ESC \\`` - Ignored
 //|
-//|        VT100 control sequences:
-//|        * ``ESC [ K`` - Clear the remainder of the line
-//|        * ``ESC [ #### D`` - Move the cursor to the left by ####
-//|        * ``ESC [ 2 J`` - Erase the entire display
-//|        * ``ESC [ nnnn ; mmmm H`` - Move the cursor to mmmm, nnnn.
+//|     VT100 control sequences:
+//|     * ``ESC [ K`` - Clear the remainder of the line
+//|     * ``ESC [ #### D`` - Move the cursor to the left by ####
+//|     * ``ESC [ 2 J`` - Erase the entire display
+//|     * ``ESC [ nnnn ; mmmm H`` - Move the cursor to mmmm, nnnn.
 //|     """
 //|
-//|     def __init__(self, scroll_area: displayio.TileGrid, font: fontio.BuiltinFont, *, status_bar: displayio.TileGrid = None) -> None:
+//|     def __init__(
+//|         self,
+//|         scroll_area: displayio.TileGrid,
+//|         font: fontio.BuiltinFont,
+//|         *,
+//|         status_bar: displayio.TileGrid = None
+//|     ) -> None:
 //|         """Terminal manages tile indices and cursor position based on VT100 commands. The font should be
 //|         a `fontio.BuiltinFont` and the TileGrid's bitmap should match the font's bitmap."""
 //|         ...
-//|
 
 STATIC mp_obj_t terminalio_terminal_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_scroll_area, ARG_font, ARG_status_bar };
@@ -95,7 +100,6 @@ STATIC mp_obj_t terminalio_terminal_make_new(const mp_obj_type_t *type, size_t n
 //|         :return: the number of bytes written
 //|         :rtype: int or None"""
 //|         ...
-//|
 STATIC mp_uint_t terminalio_terminal_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
     terminalio_terminal_obj_t *self = MP_OBJ_TO_PTR(self_in);
     const byte *buf = buf_in;

--- a/shared-bindings/terminalio/__init__.c
+++ b/shared-bindings/terminalio/__init__.c
@@ -47,7 +47,6 @@
 //|
 //| FONT: fontio.BuiltinFont
 //| """The built in font"""
-//|
 STATIC const mp_rom_map_elem_t terminalio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_terminalio) },
     { MP_ROM_QSTR(MP_QSTR_Terminal),   MP_OBJ_FROM_PTR(&terminalio_terminal_type) },

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -62,7 +62,6 @@
 //|     :return: the current monotonic time
 //|     :rtype: float"""
 //|     ...
-//|
 STATIC mp_obj_t time_monotonic(void) {
     uint64_t ticks_ms = common_hal_time_monotonic_ms();
     return mp_obj_new_float(uint64_to_float(ticks_ms) / 1000.0f);
@@ -74,7 +73,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(time_monotonic_obj, time_monotonic);
 //|
 //|     :param float seconds: the time to sleep in fractional seconds"""
 //|     ...
-//|
 STATIC mp_obj_t time_sleep(mp_obj_t seconds_o) {
     #if MICROPY_PY_BUILTINS_FLOAT
     mp_float_t seconds = mp_obj_get_float(seconds_o);
@@ -119,7 +117,6 @@ STATIC mp_obj_t struct_time_make_new(const mp_obj_type_t *type, size_t n_args, s
 //|           * ``tm_yday``: the day of the year, range [1, 366], -1 indicates not known
 //|           * ``tm_isdst``: 1 when in daylight savings, 0 when not, -1 if unknown."""
 //|         ...
-//|
 const mp_obj_namedtuple_type_t struct_time_type_obj = {
     .base = {
         .base = {
@@ -218,7 +215,6 @@ mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
 //|     :return: the current time
 //|     :rtype: int"""
 //|     ...
-//|
 STATIC mp_obj_t time_time(void) {
     timeutils_struct_time_t tm;
     struct_time_to_tm(rtc_get_time_source_time(), &tm);
@@ -235,7 +231,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 //|     :return: the current time
 //|     :rtype: int"""
 //|     ...
-//|
 STATIC mp_obj_t time_monotonic_ns(void) {
     uint64_t time64 = common_hal_time_monotonic_ns();
     return mp_obj_new_int_from_ll((long long)time64);
@@ -251,7 +246,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(time_monotonic_ns_obj, time_monotonic_ns);
 //|     :return: the current time
 //|     :rtype: time.struct_time"""
 //|     ...
-//|
 STATIC mp_obj_t time_localtime(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0 || args[0] == mp_const_none) {
         return rtc_get_time_source_time();
@@ -288,7 +282,6 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_localtime_obj, 0, 1, time_localtime);
 //|     :return: seconds
 //|     :rtype: int"""
 //|     ...
-//|
 STATIC mp_obj_t time_mktime(mp_obj_t t) {
     mp_obj_t *elem;
     size_t len;

--- a/shared-bindings/touchio/TouchIn.c
+++ b/shared-bindings/touchio/TouchIn.c
@@ -50,14 +50,12 @@
 //|        while True:
 //|            if touch.value:
 //|                print("touched!")"""
-//|
 
 //|     def __init__(self, pin: microcontroller.Pin) -> None:
 //|         """Use the TouchIn on the given pin.
 //|
 //|         :param ~microcontroller.Pin pin: the pin to read from"""
 //|         ...
-//|
 STATIC mp_obj_t touchio_touchin_make_new(const mp_obj_type_t *type,
     size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // check number of arguments
@@ -76,7 +74,6 @@ STATIC mp_obj_t touchio_touchin_make_new(const mp_obj_type_t *type,
 //|     def deinit(self) -> None:
 //|         """Deinitialises the TouchIn and releases any hardware resources for reuse."""
 //|         ...
-//|
 STATIC mp_obj_t touchio_touchin_deinit(mp_obj_t self_in) {
     touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_touchio_touchin_deinit(self);
@@ -93,14 +90,12 @@ STATIC void check_for_deinit(touchio_touchin_obj_t *self) {
 //|     def __enter__(self) -> TouchIn:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t touchio_touchin_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_touchio_touchin_deinit(args[0]);
@@ -112,7 +107,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(touchio_touchin___exit___obj, 4, 4, t
 //|     """Whether the touch pad is being touched or not. (read-only)
 //|
 //|     True when `raw_value` > `threshold`."""
-//|
 STATIC mp_obj_t touchio_touchin_obj_get_value(mp_obj_t self_in) {
     touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -126,7 +120,6 @@ MP_PROPERTY_GETTER(touchio_touchin_value_obj,
 
 //|     raw_value: int
 //|     """The raw touch measurement as an `int`. (read-only)"""
-//|
 STATIC mp_obj_t touchio_touchin_obj_get_raw_value(mp_obj_t self_in) {
     touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
@@ -152,7 +145,6 @@ MP_PROPERTY_GETTER(touchio_touchin_raw_value_obj,
 //|
 //|       touch = touchio.TouchIn(board.A1)
 //|       touch.threshold = 7300"""
-//|
 STATIC mp_obj_t touchio_touchin_obj_get_threshold(mp_obj_t self_in) {
     touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/touchio/__init__.c
+++ b/shared-bindings/touchio/__init__.c
@@ -58,7 +58,6 @@
 //|
 //| This example will initialize the the device, and print the
 //| :py:data:`~touchio.TouchIn.value`."""
-//|
 
 STATIC const mp_rom_map_elem_t touchio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_touchio) },

--- a/shared-bindings/traceback/__init__.c
+++ b/shared-bindings/traceback/__init__.c
@@ -37,7 +37,6 @@
 //| |see_cpython_module| :mod:`cpython:traceback`.
 //| """
 //| ...
-//|
 
 STATIC void traceback_exception_common(mp_print_t *print, mp_obj_t value, mp_obj_t tb_obj, mp_obj_t limit_obj) {
     if (!mp_obj_is_exception_instance(value)) {
@@ -64,8 +63,13 @@ STATIC void traceback_exception_common(mp_print_t *print, mp_obj_t value, mp_obj
     exc->traceback = trace_backup;
 }
 
-//| def format_exception(etype: Type[BaseException], value: BaseException, tb: TracebackType,
-//|                     limit: Optional[int] = None, chain: Optional[bool] = True) -> None:
+//| def format_exception(
+//|     etype: Type[BaseException],
+//|     value: BaseException,
+//|     tb: TracebackType,
+//|     limit: Optional[int] = None,
+//|     chain: Optional[bool] = True,
+//| ) -> None:
 //|     """Format a stack trace and the exception information.
 //|
 //|     The arguments have the same meaning as the corresponding arguments
@@ -85,7 +89,6 @@ STATIC void traceback_exception_common(mp_print_t *print, mp_obj_t value, mp_obj
 //|
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t traceback_format_exception(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_etype, ARG_value, ARG_tb, ARG_limit, ARG_chain };
     static const mp_arg_t allowed_args[] = {
@@ -108,8 +111,14 @@ STATIC mp_obj_t traceback_format_exception(size_t n_args, const mp_obj_t *pos_ar
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(traceback_format_exception_obj, 0, traceback_format_exception);
 
-//| def print_exception(etype: Type[BaseException], value: BaseException, tb: TracebackType,
-//|                     limit: Optional[int] = None, file: Optional[io.FileIO] = None, chain: Optional[bool] = True) -> None:
+//| def print_exception(
+//|     etype: Type[BaseException],
+//|     value: BaseException,
+//|     tb: TracebackType,
+//|     limit: Optional[int] = None,
+//|     file: Optional[io.FileIO] = None,
+//|     chain: Optional[bool] = True,
+//| ) -> None:
 //|
 //|     """Prints exception information and stack trace entries.
 //|
@@ -126,7 +135,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(traceback_format_exception_obj, 0, traceback_f
 //|
 //|     """
 //|     ...
-//|
 
 STATIC mp_obj_t traceback_print_exception(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_etype, ARG_value, ARG_tb, ARG_limit, ARG_file, ARG_chain };

--- a/shared-bindings/uheap/__init__.c
+++ b/shared-bindings/uheap/__init__.c
@@ -32,13 +32,11 @@
 #include "shared-bindings/uheap/__init__.h"
 
 //| """Heap size analysis"""
-//|
 
 //| def info(object: object) -> int:
 //|     """Prints memory debugging info for the given object and returns the
 //|     estimated size."""
 //|     ...
-//|
 STATIC mp_obj_t uheap_info(mp_obj_t obj) {
     uint32_t size = shared_module_uheap_info(obj);
 

--- a/shared-bindings/usb/__init__.c
+++ b/shared-bindings/usb/__init__.c
@@ -35,7 +35,6 @@
 //|
 //| The `usb` is a subset of PyUSB that allows you to communicate to USB devices.
 //| """
-//|
 
 STATIC mp_rom_map_elem_t usb_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),        MP_OBJ_NEW_QSTR(MP_QSTR_usb) },

--- a/shared-bindings/usb/core/Device.c
+++ b/shared-bindings/usb/core/Device.c
@@ -130,7 +130,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(usb_core_device_get_manufacturer_obj, usb_core_device_
 MP_PROPERTY_GETTER(usb_core_device_manufacturer_obj,
     (mp_obj_t)&usb_core_device_get_manufacturer_obj);
 
-//|     def write(self, endpoint: int, data: ReadableBuffer, timeout = None) -> int:
+//|     def write(self, endpoint: int, data: ReadableBuffer, timeout:Optional[int] = None) -> int:
 //|         """Write data to a specific endpoint on the device.
 //|
 //|            :param int endpoint: the bEndpointAddress you want to communicate with.
@@ -159,7 +159,7 @@ STATIC mp_obj_t usb_core_device_write(size_t n_args, const mp_obj_t *pos_args, m
 MP_DEFINE_CONST_FUN_OBJ_KW(usb_core_device_write_obj, 2, usb_core_device_write);
 
 
-//|     def read(self, endpoint: int, size_or_buffer: array.array, timeout = None) -> int:
+//|     def read(self, endpoint: int, size_or_buffer: array.array, timeout:Optional[int] = None) -> int:
 //|         """Read data from the endpoint.
 //|
 //|            :param int endpoint: the bEndpointAddress you want to communicate with.
@@ -186,8 +186,8 @@ STATIC mp_obj_t usb_core_device_read(size_t n_args, const mp_obj_t *pos_args, mp
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(usb_core_device_read_obj, 2, usb_core_device_read);
 
-//|     def ctrl_transfer(self, bmRequestType, bRequest, wValue=0, wIndex=0,
-//|                       data_or_wLength: Optional[array.array] = None, timeout = None) -> int:
+//|     def ctrl_transfer(self, bmRequestType:int, bRequest:int, wValue:int=0, wIndex:int=0,
+//|                       data_or_wLength: Optional[array.array] = None, timeout:Optional[int] = None) -> int:
 //|         """Do a control transfer on the endpoint 0. The parameters bmRequestType,
 //|            bRequest, wValue and wIndex are the same of the USB Standard Control
 //|            Request format.
@@ -254,7 +254,7 @@ STATIC mp_obj_t usb_core_device_is_kernel_driver_active(mp_obj_t self_in, mp_obj
 }
 MP_DEFINE_CONST_FUN_OBJ_2(usb_core_device_is_kernel_driver_active_obj, usb_core_device_is_kernel_driver_active);
 
-//|     def detach_kernel_driver(self, interface: int):
+//|     def detach_kernel_driver(self, interface: int) -> None:
 //|         """Stop CircuitPython from using the interface. If successful, you
 //|            will then be able to perform I/O. CircuitPython will automatically
 //|            re-start using the interface on reload.
@@ -271,7 +271,7 @@ STATIC mp_obj_t usb_core_device_detach_kernel_driver(mp_obj_t self_in, mp_obj_t 
 }
 MP_DEFINE_CONST_FUN_OBJ_2(usb_core_device_detach_kernel_driver_obj, usb_core_device_detach_kernel_driver);
 
-//|     def attach_kernel_driver(self, interface: int):
+//|     def attach_kernel_driver(self, interface: int) -> None:
 //|         """Allow CircuitPython to use the interface if it wants to.
 //|
 //|            :param int interface: the device interface number to allow CircuitPython to use

--- a/shared-bindings/usb/core/Device.c
+++ b/shared-bindings/usb/core/Device.c
@@ -62,17 +62,14 @@
 #include "py/runtime.h"
 
 //| class Device:
-//|
 //|     def __init__(self) -> None:
 //|         """User code cannot create Device objects. Instead, get them from
-//|            `usb.core.find`.
+//|         `usb.core.find`.
 //|         """
 //|         ...
-//|
 
 //|     idVendor: int
 //|     """The USB vendor ID of the device"""
-//|
 STATIC mp_obj_t usb_core_device_obj_get_idVendor(mp_obj_t self_in) {
     usb_core_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_usb_core_device_get_idVendor(self));
@@ -84,7 +81,6 @@ MP_PROPERTY_GETTER(usb_core_device_idVendor_obj,
 
 //|     idProduct: int
 //|     """The USB product ID of the device"""
-//|
 STATIC mp_obj_t usb_core_device_obj_get_idProduct(mp_obj_t self_in) {
     usb_core_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_usb_core_device_get_idProduct(self));
@@ -96,7 +92,6 @@ MP_PROPERTY_GETTER(usb_core_device_idProduct_obj,
 
 //|     serial_number: str
 //|     """The USB device's serial number string."""
-//|
 STATIC mp_obj_t usb_core_device_obj_get_serial_number(mp_obj_t self_in) {
     usb_core_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_usb_core_device_get_serial_number(self);
@@ -108,7 +103,6 @@ MP_PROPERTY_GETTER(usb_core_device_serial_number_obj,
 
 //|     product: str
 //|     """The USB device's product string."""
-//|
 STATIC mp_obj_t usb_core_device_obj_get_product(mp_obj_t self_in) {
     usb_core_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_usb_core_device_get_product(self);
@@ -120,7 +114,6 @@ MP_PROPERTY_GETTER(usb_core_device_product_obj,
 
 //|     manufacturer: str
 //|     """The USB device's manufacturer string."""
-//|
 STATIC mp_obj_t usb_core_device_obj_get_manufacturer(mp_obj_t self_in) {
     usb_core_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_usb_core_device_get_manufacturer(self);
@@ -130,16 +123,15 @@ MP_DEFINE_CONST_FUN_OBJ_1(usb_core_device_get_manufacturer_obj, usb_core_device_
 MP_PROPERTY_GETTER(usb_core_device_manufacturer_obj,
     (mp_obj_t)&usb_core_device_get_manufacturer_obj);
 
-//|     def write(self, endpoint: int, data: ReadableBuffer, timeout:Optional[int] = None) -> int:
+//|     def write(self, endpoint: int, data: ReadableBuffer, timeout: Optional[int] = None) -> int:
 //|         """Write data to a specific endpoint on the device.
 //|
-//|            :param int endpoint: the bEndpointAddress you want to communicate with.
-//|            :param ReadableBuffer data: the data to send
-//|            :param int timeout: Time to wait specified in milliseconds. (Different from most CircuitPython!)
-//|            :returns: the number of bytes written
+//|         :param int endpoint: the bEndpointAddress you want to communicate with.
+//|         :param ReadableBuffer data: the data to send
+//|         :param int timeout: Time to wait specified in milliseconds. (Different from most CircuitPython!)
+//|         :returns: the number of bytes written
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t usb_core_device_write(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_endpoint, ARG_data, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
@@ -159,13 +151,15 @@ STATIC mp_obj_t usb_core_device_write(size_t n_args, const mp_obj_t *pos_args, m
 MP_DEFINE_CONST_FUN_OBJ_KW(usb_core_device_write_obj, 2, usb_core_device_write);
 
 
-//|     def read(self, endpoint: int, size_or_buffer: array.array, timeout:Optional[int] = None) -> int:
+//|     def read(
+//|         self, endpoint: int, size_or_buffer: array.array, timeout: Optional[int] = None
+//|     ) -> int:
 //|         """Read data from the endpoint.
 //|
-//|            :param int endpoint: the bEndpointAddress you want to communicate with.
-//|            :param array.array size_or_buffer: the array to read data into. PyUSB also allows size but CircuitPython only support array to force deliberate memory use.
-//|            :param int timeout: Time to wait specified in milliseconds. (Different from most CircuitPython!)
-//|            :returns: the number of bytes read
+//|         :param int endpoint: the bEndpointAddress you want to communicate with.
+//|         :param array.array size_or_buffer: the array to read data into. PyUSB also allows size but CircuitPython only support array to force deliberate memory use.
+//|         :param int timeout: Time to wait specified in milliseconds. (Different from most CircuitPython!)
+//|         :returns: the number of bytes read
 //|         """
 //|         ...
 STATIC mp_obj_t usb_core_device_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -186,27 +180,33 @@ STATIC mp_obj_t usb_core_device_read(size_t n_args, const mp_obj_t *pos_args, mp
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(usb_core_device_read_obj, 2, usb_core_device_read);
 
-//|     def ctrl_transfer(self, bmRequestType:int, bRequest:int, wValue:int=0, wIndex:int=0,
-//|                       data_or_wLength: Optional[array.array] = None, timeout:Optional[int] = None) -> int:
+//|     def ctrl_transfer(
+//|         self,
+//|         bmRequestType: int,
+//|         bRequest: int,
+//|         wValue: int = 0,
+//|         wIndex: int = 0,
+//|         data_or_wLength: Optional[array.array] = None,
+//|         timeout: Optional[int] = None,
+//|     ) -> int:
 //|         """Do a control transfer on the endpoint 0. The parameters bmRequestType,
-//|            bRequest, wValue and wIndex are the same of the USB Standard Control
-//|            Request format.
+//|         bRequest, wValue and wIndex are the same of the USB Standard Control
+//|         Request format.
 //|
-//|            Control requests may or may not have a data payload to write/read.
-//|            In cases which it has, the direction bit of the bmRequestType
-//|            field is used to infer the desired request direction.
+//|         Control requests may or may not have a data payload to write/read.
+//|         In cases which it has, the direction bit of the bmRequestType
+//|         field is used to infer the desired request direction.
 //|
-//|            For host to device requests (OUT), data_or_wLength parameter is
-//|            the data payload to send, and it must be a sequence type convertible
-//|            to an array object. In this case, the return value is the number
-//|            of bytes written in the data payload.
+//|         For host to device requests (OUT), data_or_wLength parameter is
+//|         the data payload to send, and it must be a sequence type convertible
+//|         to an array object. In this case, the return value is the number
+//|         of bytes written in the data payload.
 //|
-//|            For device to host requests (IN), data_or_wLength is an array
-//|            object which the data will be read to, and the return value is the
-//|            number of bytes read.
-//|            """
+//|         For device to host requests (IN), data_or_wLength is an array
+//|         object which the data will be read to, and the return value is the
+//|         number of bytes read.
+//|         """
 //|         ...
-//|
 STATIC mp_obj_t usb_core_device_ctrl_transfer(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bmRequestType, ARG_bRequest, ARG_wValue, ARG_wIndex, ARG_data_or_wLength, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
@@ -240,12 +240,11 @@ MP_DEFINE_CONST_FUN_OBJ_KW(usb_core_device_ctrl_transfer_obj, 2, usb_core_device
 
 //|     def is_kernel_driver_active(self, interface: int) -> bool:
 //|         """Determine if CircuitPython is using the interface. If it is, the
-//|            object will be unable to perform I/O.
+//|         object will be unable to perform I/O.
 //|
-//|            :param int interface: the device interface number to check
-//|             """
+//|         :param int interface: the device interface number to check
+//|         """
 //|         ...
-//|
 STATIC mp_obj_t usb_core_device_is_kernel_driver_active(mp_obj_t self_in, mp_obj_t interface_in) {
     usb_core_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_int_t interface = mp_obj_get_int(interface_in);
@@ -256,13 +255,12 @@ MP_DEFINE_CONST_FUN_OBJ_2(usb_core_device_is_kernel_driver_active_obj, usb_core_
 
 //|     def detach_kernel_driver(self, interface: int) -> None:
 //|         """Stop CircuitPython from using the interface. If successful, you
-//|            will then be able to perform I/O. CircuitPython will automatically
-//|            re-start using the interface on reload.
+//|         will then be able to perform I/O. CircuitPython will automatically
+//|         re-start using the interface on reload.
 //|
-//|            :param int interface: the device interface number to stop CircuitPython on
+//|         :param int interface: the device interface number to stop CircuitPython on
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t usb_core_device_detach_kernel_driver(mp_obj_t self_in, mp_obj_t interface_in) {
     usb_core_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_int_t interface = mp_obj_get_int(interface_in);
@@ -274,10 +272,9 @@ MP_DEFINE_CONST_FUN_OBJ_2(usb_core_device_detach_kernel_driver_obj, usb_core_dev
 //|     def attach_kernel_driver(self, interface: int) -> None:
 //|         """Allow CircuitPython to use the interface if it wants to.
 //|
-//|            :param int interface: the device interface number to allow CircuitPython to use
+//|         :param int interface: the device interface number to allow CircuitPython to use
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t usb_core_device_attach_kernel_driver(mp_obj_t self_in, mp_obj_t interface_in) {
     usb_core_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_int_t interface = mp_obj_get_int(interface_in);

--- a/shared-bindings/usb/core/__init__.c
+++ b/shared-bindings/usb/core/__init__.c
@@ -40,10 +40,10 @@
 //|
 //| This is a subset of the PyUSB core module.
 //| """
-//|
 
 //| class USBError(OSError):
 //|     """Catchall exception for USB related errors."""
+//|
 //|     ...
 MP_DEFINE_USB_CORE_EXCEPTION(USBError, OSError)
 NORETURN void mp_raise_usb_core_USBError(const compressed_string_t *fmt, ...) {
@@ -56,21 +56,22 @@ NORETURN void mp_raise_usb_core_USBError(const compressed_string_t *fmt, ...) {
 
 //| class USBTimeoutError(USBError):
 //|     """Raised when a USB transfer times out."""
-//|     ...
 //|
+//|     ...
 MP_DEFINE_USB_CORE_EXCEPTION(USBTimeoutError, usb_core_USBError)
 NORETURN void mp_raise_usb_core_USBTimeoutError(void) {
     mp_raise_type(&mp_type_usb_core_USBTimeoutError);
 }
 
 
-//| def find(find_all:bool=False, *, idVendor:Optional[int]=None, idProduct:Optional[int]=None) -> Device:
-//|    """Find the first device that matches the given requirements or, if
-//|       find_all is True, return a generator of all matching devices.
+//| def find(
+//|     find_all: bool = False, *, idVendor: Optional[int] = None, idProduct: Optional[int] = None
+//| ) -> Device:
+//|     """Find the first device that matches the given requirements or, if
+//|     find_all is True, return a generator of all matching devices.
 //|
-//|       Returns None if no device matches.
-//|    """
-//|
+//|     Returns None if no device matches.
+//|     """
 typedef struct {
     mp_obj_base_t base;
     mp_int_t vid;

--- a/shared-bindings/usb/core/__init__.c
+++ b/shared-bindings/usb/core/__init__.c
@@ -64,7 +64,7 @@ NORETURN void mp_raise_usb_core_USBTimeoutError(void) {
 }
 
 
-//| def find(find_all=False, *, idVendor=None, idProduct=None):
+//| def find(find_all:bool=False, *, idVendor:Optional[int]=None, idProduct:Optional[int]=None) -> Device:
 //|    """Find the first device that matches the given requirements or, if
 //|       find_all is True, return a generator of all matching devices.
 //|

--- a/shared-bindings/usb_cdc/Serial.c
+++ b/shared-bindings/usb_cdc/Serial.c
@@ -42,7 +42,6 @@
 //|         """You cannot create an instance of `usb_cdc.Serial`.
 //|         The available instances are in the ``usb_cdc.serials`` tuple."""
 //|         ...
-//|
 //|     def read(self, size: int = 1) -> bytes:
 //|         """Read at most ``size`` bytes. If ``size`` exceeds the internal buffer size
 //|         only the bytes in the buffer will be read. If `timeout` is > 0 or ``None``,
@@ -52,7 +51,6 @@
 //|         :return: Data read
 //|         :rtype: bytes"""
 //|         ...
-//|
 //|     def readinto(self, buf: WriteableBuffer) -> int:
 //|         """Read bytes into the ``buf``. Read at most ``len(buf)`` bytes. If `timeout`
 //|         is > 0 or ``None``, keep waiting until the timeout expires or ``len(buf)``
@@ -61,7 +59,6 @@
 //|         :return: number of bytes read and stored into ``buf``
 //|         :rtype: int"""
 //|         ...
-//|
 //|     def readline(self, size: int = -1) -> Optional[bytes]:
 //|         r"""Read a line ending in a newline character ("\\n"), including the newline.
 //|         Return everything readable if no newline is found and ``timeout`` is 0.
@@ -74,7 +71,6 @@
 //|         :return: the line read
 //|         :rtype: bytes or None"""
 //|         ...
-//|
 //|     def readlines(self) -> List[Optional[bytes]]:
 //|         """Read multiple lines as a list, using `readline()`.
 //|
@@ -84,18 +80,15 @@
 //|         :return: a list of the line read
 //|         :rtype: list"""
 //|         ...
-//|
 //|     def write(self, buf: ReadableBuffer) -> int:
 //|         """Write as many bytes as possible from the buffer of bytes.
 //|
 //|         :return: the number of bytes written
 //|         :rtype: int"""
 //|         ...
-//|
 //|     def flush(self) -> None:
 //|         """Force out any unwritten bytes, waiting until they are written."""
 //|         ...
-//|
 
 // These three methods are used by the shared stream methods.
 STATIC mp_uint_t usb_cdc_serial_read_stream(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
@@ -151,7 +144,6 @@ STATIC mp_uint_t usb_cdc_serial_ioctl_stream(mp_obj_t self_in, mp_uint_t request
 //|       Most terminal programs and ``pyserial`` assert DTR when opening a serial connection.
 //|       However, the C# ``SerialPort`` API does not. You must set ``SerialPort.DtrEnable``.
 //|     """
-//|
 STATIC mp_obj_t usb_cdc_serial_get_connected(mp_obj_t self_in) {
     usb_cdc_serial_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_usb_cdc_serial_get_connected(self));
@@ -163,7 +155,6 @@ MP_PROPERTY_GETTER(usb_cdc_serial_connected_obj,
 
 //|     in_waiting: int
 //|     """Returns the number of bytes waiting to be read on the USB serial input. (read-only)"""
-//|
 STATIC mp_obj_t usb_cdc_serial_get_in_waiting(mp_obj_t self_in) {
     usb_cdc_serial_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(common_hal_usb_cdc_serial_get_in_waiting(self));
@@ -175,7 +166,6 @@ MP_PROPERTY_GETTER(usb_cdc_serial_in_waiting_obj,
 
 //|     out_waiting: int
 //|     """Returns the number of bytes waiting to be written on the USB serial output. (read-only)"""
-//|
 STATIC mp_obj_t usb_cdc_serial_get_out_waiting(mp_obj_t self_in) {
     usb_cdc_serial_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(common_hal_usb_cdc_serial_get_out_waiting(self));
@@ -188,7 +178,6 @@ MP_PROPERTY_GETTER(usb_cdc_serial_out_waiting_obj,
 //|     def reset_input_buffer(self) -> None:
 //|         """Clears any unread bytes."""
 //|         ...
-//|
 STATIC mp_obj_t usb_cdc_serial_reset_input_buffer(mp_obj_t self_in) {
     usb_cdc_serial_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_usb_cdc_serial_reset_input_buffer(self);
@@ -199,7 +188,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(usb_cdc_serial_reset_input_buffer_obj, usb_cdc_serial_
 //|     def reset_output_buffer(self) -> None:
 //|         """Clears any unwritten bytes."""
 //|         ...
-//|
 STATIC mp_obj_t usb_cdc_serial_reset_output_buffer(mp_obj_t self_in) {
     usb_cdc_serial_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_usb_cdc_serial_reset_output_buffer(self);
@@ -210,7 +198,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(usb_cdc_serial_reset_output_buffer_obj, usb_cdc_serial
 //|     timeout: Optional[float]
 //|     """The initial value of `timeout` is ``None``. If ``None``, wait indefinitely to satisfy
 //|     the conditions of a read operation. If 0, do not wait. If > 0, wait only ``timeout`` seconds."""
-//|
 STATIC mp_obj_t usb_cdc_serial_get_timeout(mp_obj_t self_in) {
     usb_cdc_serial_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_float_t timeout = common_hal_usb_cdc_serial_get_timeout(self);
@@ -234,7 +221,6 @@ MP_PROPERTY_GETSET(usb_cdc_serial_timeout_obj,
 //|     """The initial value of `write_timeout` is ``None``. If ``None``, wait indefinitely to finish
 //|     writing all the bytes passed to ``write()``.If 0, do not wait.
 //|     If > 0, wait only ``write_timeout`` seconds."""
-//|
 STATIC mp_obj_t usb_cdc_serial_get_write_timeout(mp_obj_t self_in) {
     usb_cdc_serial_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_float_t write_timeout = common_hal_usb_cdc_serial_get_write_timeout(self);

--- a/shared-bindings/usb_cdc/__init__.c
+++ b/shared-bindings/usb_cdc/__init__.c
@@ -68,7 +68,6 @@
 //|     Can be called in ``boot.py``, before USB is connected.
 //|     Equivalent to ``usb_cdc.enable(console=False, data=False)``."""
 //|     ...
-//|
 STATIC mp_obj_t usb_cdc_disable(void) {
     if (!common_hal_usb_cdc_disable()) {
         mp_raise_RuntimeError(translate("Cannot change USB devices now"));
@@ -91,7 +90,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(usb_cdc_disable_obj, usb_cdc_disable);
 //|     not enough endpoints are available.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t usb_cdc_enable(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_console, ARG_data };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -32,7 +32,16 @@
 //| class Device:
 //|     """HID Device specification"""
 //|
-//|     def __init__(self, *, report_descriptor: ReadableBuffer, usage_page: int, usage: int, report_ids: Sequence[int], in_report_lengths: Sequence[int], out_report_lengths: Sequence[int]) -> None:
+//|     def __init__(
+//|         self,
+//|         *,
+//|         report_descriptor: ReadableBuffer,
+//|         usage_page: int,
+//|         usage: int,
+//|         report_ids: Sequence[int],
+//|         in_report_lengths: Sequence[int],
+//|         out_report_lengths: Sequence[int]
+//|     ) -> None:
 //|         """Create a description of a USB HID device. The actual device is created when you
 //|         pass a `Device` to `usb_hid.enable()`.
 //|
@@ -66,7 +75,6 @@
 //|             )
 //|         """
 //|         ...
-//|
 //|     KEYBOARD: Device
 //|     """Standard keyboard device supporting keycodes 0x00-0xDD, modifiers 0xE-0xE7, and five LED indicators.
 //|     Uses Report ID 1 for its IN and OUT reports.
@@ -81,7 +89,6 @@
 //|     CONSUMER_CONTROL: Device
 //|     """Consumer Control device supporting sent values from 1-652, with no rollover.
 //|     Uses Report ID 3 for its IN report."""
-//|
 
 STATIC mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     usb_hid_device_obj_t *self = m_new_obj(usb_hid_device_obj_t);
@@ -163,7 +170,6 @@ STATIC mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type, size_t n_args
 //|         Otherwise you must specify which report id to use when sending the report.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t usb_hid_device_send_report(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     usb_hid_device_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
@@ -198,7 +204,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(usb_hid_device_send_report_obj, 1, usb_hid_device_sen
 //|         will return `None` until next report is received.
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t usb_hid_device_get_last_received_report(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     usb_hid_device_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 
@@ -222,7 +227,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(usb_hid_device_get_last_received_report_obj, 1, usb_h
 
 //|     usage_page: int
 //|     """The device usage page identifier, which designates a category of device. (read-only)"""
-//|
 STATIC mp_obj_t usb_hid_device_obj_get_usage_page(mp_obj_t self_in) {
     usb_hid_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_usb_hid_device_get_usage_page(self));
@@ -237,7 +241,6 @@ MP_PROPERTY_GETTER(usb_hid_device_usage_page_obj,
 //|
 //|     For example, Keyboard is 0x06 within the generic desktop usage page 0x01.
 //|     Mouse is 0x02 within the same usage page."""
-//|
 STATIC mp_obj_t usb_hid_device_obj_get_usage(mp_obj_t self_in) {
     usb_hid_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_usb_hid_device_get_usage(self));

--- a/shared-bindings/usb_hid/__init__.c
+++ b/shared-bindings/usb_hid/__init__.c
@@ -36,7 +36,6 @@
 //| """USB Human Interface Device
 //|
 //| The `usb_hid` module allows you to output data as a HID device."""
-//|
 
 //| devices: Tuple[Device, ...]
 //| """Tuple of all active HID device interfaces.
@@ -48,7 +47,6 @@
 //| containing a `Device` that describes the boot device chosen (keyboard or mouse).
 //| The request for a boot device overrides any other HID devices.
 //| """
-//|
 
 //| def disable() -> None:
 //|     """Do not present any USB HID devices to the host computer.
@@ -58,7 +56,6 @@
 //|     it is disabled by default. You must turn off another USB device such
 //|     as `usb_cdc` or `storage` to free up endpoints for use by `usb_hid`.
 //|     """
-//|
 STATIC mp_obj_t usb_hid_disable(void) {
     if (!common_hal_usb_hid_disable()) {
         mp_raise_RuntimeError(translate("Cannot change USB devices now"));
@@ -110,7 +107,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(usb_hid_disable_obj, usb_hid_disable);
 //|     will enter safe mode to report this error.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t usb_hid_enable(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_devices, ARG_boot_device };
     static const mp_arg_t allowed_args[] = {
@@ -154,7 +150,6 @@ MP_DEFINE_CONST_FUN_OBJ_KW(usb_hid_enable_obj, 1, usb_hid_enable);
 //|       if you are using those devices.
 //|     :rtype int:
 //|     """
-//|
 STATIC mp_obj_t usb_hid_get_boot_device(void) {
     return MP_OBJ_NEW_SMALL_INT(common_hal_usb_hid_get_boot_device());
 }

--- a/shared-bindings/usb_host/Port.c
+++ b/shared-bindings/usb_host/Port.c
@@ -35,14 +35,13 @@
 //|
 //|     def __init__(self, dp: microcontroller.Pin, dm: microcontroller.Pin) -> None:
 //|         """Create a USB host port on the given pins. Access attached devices
-//|            through the `usb` module. Keep this object referenced while
-//|            interacting with devices, otherwise they will be disconnected.
+//|         through the `usb` module. Keep this object referenced while
+//|         interacting with devices, otherwise they will be disconnected.
 //|
-//|            :param ~microcontroller.Pin dp: The data plus pin
-//|            :param ~microcontroller.Pin dm: The data minus pin
+//|         :param ~microcontroller.Pin dp: The data plus pin
+//|         :param ~microcontroller.Pin dm: The data minus pin
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t usb_host_port_make_new(const mp_obj_type_t *type,
     size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // check number of arguments
@@ -61,7 +60,6 @@ STATIC mp_obj_t usb_host_port_make_new(const mp_obj_type_t *type,
 //|     def deinit(self) -> None:
 //|         """Turn off the USB host port and release the pins for other use."""
 //|         ...
-//|
 STATIC mp_obj_t usb_host_port_obj_deinit(mp_obj_t self_in) {
     usb_host_port_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_usb_host_port_deinit(self);
@@ -72,14 +70,12 @@ MP_DEFINE_CONST_FUN_OBJ_1(usb_host_port_deinit_obj, usb_host_port_obj_deinit);
 //|     def __enter__(self) -> Port:
 //|         """No-op used by Context Managers."""
 //|         ...
-//|
 //  Provided by context manager helper.
 
 //|     def __exit__(self) -> None:
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
-//|
 STATIC mp_obj_t usb_host_port_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_usb_host_port_deinit(MP_OBJ_TO_PTR(args[0]));

--- a/shared-bindings/usb_host/__init__.c
+++ b/shared-bindings/usb_host/__init__.c
@@ -36,7 +36,6 @@
 //| The `usb_host` module allows you to manage USB host ports. To communicate
 //| with devices use the `usb` module that is a subset of PyUSB's API.
 //| """
-//|
 
 STATIC mp_map_elem_t usb_host_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),        MP_OBJ_NEW_QSTR(MP_QSTR_usb_host) },

--- a/shared-bindings/usb_midi/PortIn.c
+++ b/shared-bindings/usb_midi/PortIn.c
@@ -44,7 +44,6 @@
 //|         PortIn objects are constructed for every corresponding entry in the USB
 //|         descriptor and added to the ``usb_midi.ports`` tuple."""
 //|         ...
-//|
 
 // These are standard stream methods. Code is in py/stream.c.
 //
@@ -57,7 +56,6 @@
 //|         :return: Data read
 //|         :rtype: bytes or None"""
 //|         ...
-//|
 //|     def readinto(self, buf: WriteableBuffer, nbytes: Optional[int] = None) -> Optional[bytes]:
 //|         """Read bytes into the ``buf``.  If ``nbytes`` is specified then read at most
 //|         that many bytes.  Otherwise, read at most ``len(buf)`` bytes.
@@ -65,7 +63,6 @@
 //|         :return: number of bytes read and stored into ``buf``
 //|         :rtype: bytes or None"""
 //|         ...
-//|
 
 // These three methods are used by the shared stream methods.
 STATIC mp_uint_t usb_midi_portin_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {

--- a/shared-bindings/usb_midi/PortOut.c
+++ b/shared-bindings/usb_midi/PortOut.c
@@ -43,7 +43,6 @@
 //|
 //|         PortOut objects are constructed for every corresponding entry in the USB
 //|         descriptor and added to the ``usb_midi.ports`` tuple."""
-//|
 
 // These are standard stream methods. Code is in py/stream.c.
 //
@@ -53,7 +52,6 @@
 //|         :return: the number of bytes written
 //|         :rtype: int or None"""
 //|         ...
-//|
 
 STATIC mp_uint_t usb_midi_portout_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
     usb_midi_portout_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/usb_midi/__init__.c
+++ b/shared-bindings/usb_midi/__init__.c
@@ -42,7 +42,6 @@
 //|
 //| ports: Tuple[Union[PortIn, PortOut], ...]
 //| """Tuple of all MIDI ports. Each item is ether `PortIn` or `PortOut`."""
-//|
 
 //| def disable() -> None:
 //|     """Disable presenting a USB MIDI device to the host.
@@ -50,7 +49,6 @@
 //|     including ESP32-S2 and certain STM boards, it is disabled by default.
 //|     Can be called in ``boot.py``, before USB is connected."""
 //|     ...
-//|
 STATIC mp_obj_t usb_midi_disable(void) {
     if (!common_hal_usb_midi_disable()) {
         mp_raise_RuntimeError(translate("Cannot change USB devices now"));
@@ -70,7 +68,6 @@ MP_DEFINE_CONST_FUN_OBJ_0(usb_midi_disable_obj, usb_midi_disable);
 //|     not enough endpoints are available.
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t usb_midi_enable(void) {
     if (!common_hal_usb_midi_enable()) {
         mp_raise_RuntimeError(translate("Cannot change USB devices now"));

--- a/shared-bindings/ustack/__init__.c
+++ b/shared-bindings/ustack/__init__.c
@@ -35,13 +35,11 @@
 
 
 //| """Stack information and analysis"""
-//|
 
 #if MICROPY_MAX_STACK_USAGE
 //| def max_stack_usage() -> int:
 //|     """Return the maximum excursion of the stack so far."""
 //|     ...
-//|
 STATIC mp_obj_t max_stack_usage(void) {
     return MP_OBJ_NEW_SMALL_INT(shared_module_ustack_max_stack_usage());
 }
@@ -54,7 +52,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(max_stack_usage_obj, max_stack_usage);
 //|     Same as in micropython.mem_info(), but returns a value instead
 //|     of just printing it."""
 //|     ...
-//|
 STATIC mp_obj_t stack_size(void) {
     return MP_OBJ_NEW_SMALL_INT(shared_module_ustack_stack_size());
 }
@@ -64,7 +61,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(stack_size_obj, stack_size);
 //|     """Return how much stack is currently in use.
 //|     Same as micropython.stack_use(); duplicated here for convenience."""
 //|     ...
-//|
 STATIC mp_obj_t stack_usage(void) {
     return MP_OBJ_NEW_SMALL_INT(shared_module_ustack_stack_usage());
 }

--- a/shared-bindings/vectorio/Circle.c
+++ b/shared-bindings/vectorio/Circle.c
@@ -11,16 +11,20 @@
 #include "supervisor/shared/translate/translate.h"
 
 //| class Circle:
-//|
-//|     def __init__(self, pixel_shader: Union[displayio.ColorConverter, displayio.Palette], radius: int, x: int, y: int) -> None:
+//|     def __init__(
+//|         self,
+//|         pixel_shader: Union[displayio.ColorConverter, displayio.Palette],
+//|         radius: int,
+//|         x: int,
+//|         y: int,
+//|     ) -> None:
 //|         """Circle is positioned on screen by its center point.
 //|
-//|            :param Union[~displayio.ColorConverter,~displayio.Palette] pixel_shader: The pixel shader that produces colors from values
-//|            :param int radius: The radius of the circle in pixels
-//|            :param int x: Initial x position of the axis.
-//|            :param int y: Initial y position of the axis.
-//|            :param int color_index: Initial color_index to use when selecting color from the palette."""
-//|
+//|         :param Union[~displayio.ColorConverter,~displayio.Palette] pixel_shader: The pixel shader that produces colors from values
+//|         :param int radius: The radius of the circle in pixels
+//|         :param int x: Initial x position of the axis.
+//|         :param int y: Initial y position of the axis.
+//|         :param int color_index: Initial color_index to use when selecting color from the palette."""
 static mp_obj_t vectorio_circle_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pixel_shader, ARG_radius, ARG_x, ARG_y, ARG_color_index };
     static const mp_arg_t allowed_args[] = {
@@ -58,9 +62,8 @@ STATIC const vectorio_draw_protocol_t circle_draw_protocol = {
 };
 
 
-//|     radius : int
+//|     radius: int
 //|     """The radius of the circle in pixels."""
-//|
 STATIC mp_obj_t vectorio_circle_obj_get_radius(mp_obj_t self_in) {
     vectorio_circle_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(common_hal_vectorio_circle_get_radius(self));
@@ -78,9 +81,8 @@ MP_PROPERTY_GETSET(vectorio_circle_radius_obj,
     (mp_obj_t)&vectorio_circle_get_radius_obj,
     (mp_obj_t)&vectorio_circle_set_radius_obj);
 
-//|     color_index : int
+//|     color_index: int
 //|     """The color_index of the circle as 0 based index of the palette."""
-//|
 STATIC mp_obj_t vectorio_circle_obj_get_color_index(mp_obj_t self_in) {
     vectorio_circle_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(common_hal_vectorio_circle_get_color_index(self));
@@ -101,18 +103,17 @@ MP_PROPERTY_GETSET(vectorio_circle_color_index_obj,
 
 // Documentation for properties inherited from VectorShape.
 
-//|     x : int
+//|     x: int
 //|     """X position of the center point of the circle in the parent."""
 //|
-//|     y : int
+//|     y: int
 //|     """Y position of the center point of the circle in the parent."""
 //|
-//|     location : Tuple[int,int]
+//|     location: Tuple[int, int]
 //|     """(X,Y) position of the center point of the circle in the parent."""
 //|
-//|     pixel_shader : Union[displayio.ColorConverter,displayio.Palette]
+//|     pixel_shader: Union[displayio.ColorConverter, displayio.Palette]
 //|     """The pixel shader of the circle."""
-//|
 
 STATIC const mp_rom_map_elem_t vectorio_circle_locals_dict_table[] = {
     // Functions

--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -17,7 +17,13 @@
 
 
 //| class Polygon:
-//|     def __init__(self, pixel_shader: Union[displayio.ColorConverter, displayio.Palette], points: List[Tuple[int, int]], x: int, y: int) -> None:
+//|     def __init__(
+//|         self,
+//|         pixel_shader: Union[displayio.ColorConverter, displayio.Palette],
+//|         points: List[Tuple[int, int]],
+//|         x: int,
+//|         y: int,
+//|     ) -> None:
 //|         """Represents a closed shape by ordered vertices. The path will be treated as
 //|         'closed', the last point will connect to the first point.
 //|
@@ -27,7 +33,6 @@
 //|         :param int x: Initial screen x position of the 0,0 origin in the points list.
 //|         :param int y: Initial screen y position of the 0,0 origin in the points list.
 //|         :param int color_index: Initial color_index to use when selecting color from the palette."""
-//|
 static mp_obj_t vectorio_polygon_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pixel_shader, ARG_points_list, ARG_x, ARG_y, ARG_color_index };
     static const mp_arg_t allowed_args[] = {
@@ -67,7 +72,6 @@ STATIC const vectorio_draw_protocol_t polygon_draw_protocol = {
 
 //|     points: List[Tuple[int, int]]
 //|     """Vertices for the polygon."""
-//|
 STATIC mp_obj_t vectorio_polygon_obj_get_points(mp_obj_t self_in) {
     vectorio_polygon_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_vectorio_polygon_get_points(self);
@@ -86,9 +90,8 @@ MP_PROPERTY_GETSET(vectorio_polygon_points_obj,
     (mp_obj_t)&vectorio_polygon_get_points_obj,
     (mp_obj_t)&vectorio_polygon_set_points_obj);
 
-//|     color_index : int
+//|     color_index: int
 //|     """The color_index of the polygon as 0 based index of the palette."""
-//|
 STATIC mp_obj_t vectorio_polygon_obj_get_color_index(mp_obj_t self_in) {
     vectorio_polygon_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(common_hal_vectorio_polygon_get_color_index(self));
@@ -109,18 +112,17 @@ MP_PROPERTY_GETSET(vectorio_polygon_color_index_obj,
 
 // Documentation for properties inherited from VectorShape.
 
-//|     x : int
+//|     x: int
 //|     """X position of the 0,0 origin in the points list."""
 //|
-//|     y : int
+//|     y: int
 //|     """Y position of the 0,0 origin in the points list."""
 //|
-//|     location : Tuple[int,int]
+//|     location: Tuple[int, int]
 //|     """(X,Y) position of the 0,0 origin in the points list."""
 //|
-//|     pixel_shader : Union[displayio.ColorConverter,displayio.Palette]
+//|     pixel_shader: Union[displayio.ColorConverter, displayio.Palette]
 //|     """The pixel shader of the polygon."""
-//|
 
 STATIC const mp_rom_map_elem_t vectorio_polygon_locals_dict_table[] = {
     // Functions

--- a/shared-bindings/vectorio/Rectangle.c
+++ b/shared-bindings/vectorio/Rectangle.c
@@ -10,16 +10,22 @@
 #include "supervisor/shared/translate/translate.h"
 
 //| class Rectangle:
-//|     def __init__(self, pixel_shader: Union[displayio.ColorConverter, displayio.Palette], width: int, height: int, x: int, y: int) -> None:
+//|     def __init__(
+//|         self,
+//|         pixel_shader: Union[displayio.ColorConverter, displayio.Palette],
+//|         width: int,
+//|         height: int,
+//|         x: int,
+//|         y: int,
+//|     ) -> None:
 //|         """Represents a rectangle by defining its bounds
 //|
-//|            :param Union[~displayio.ColorConverter,~displayio.Palette] pixel_shader: The pixel shader that produces colors from values
-//|            :param int width: The number of pixels wide
-//|            :param int height: The number of pixels high
-//|            :param int x: Initial x position of the top left corner.
-//|            :param int y: Initial y position of the top left corner.
-//|            :param int color_index: Initial color_index to use when selecting color from the palette."""
-//|
+//|         :param Union[~displayio.ColorConverter,~displayio.Palette] pixel_shader: The pixel shader that produces colors from values
+//|         :param int width: The number of pixels wide
+//|         :param int height: The number of pixels high
+//|         :param int x: Initial x position of the top left corner.
+//|         :param int y: Initial y position of the top left corner.
+//|         :param int color_index: Initial color_index to use when selecting color from the palette."""
 static mp_obj_t vectorio_rectangle_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pixel_shader, ARG_width, ARG_height, ARG_x, ARG_y, ARG_color_index };
     static const mp_arg_t allowed_args[] = {
@@ -59,9 +65,8 @@ STATIC const vectorio_draw_protocol_t rectangle_draw_protocol = {
     .draw_protocol_impl = &vectorio_vector_shape_draw_protocol_impl
 };
 
-//|     width : int
+//|     width: int
 //|     """The width of the rectangle in pixels."""
-//|
 STATIC mp_obj_t vectorio_rectangle_obj_get_width(mp_obj_t self_in) {
     vectorio_rectangle_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(common_hal_vectorio_rectangle_get_width(self));
@@ -82,9 +87,8 @@ const mp_obj_property_t vectorio_rectangle_width_obj = {
               MP_ROM_NONE},
 };
 
-//|     height : int
+//|     height: int
 //|     """The height of the rectangle in pixels."""
-//|
 STATIC mp_obj_t vectorio_rectangle_obj_get_height(mp_obj_t self_in) {
     vectorio_rectangle_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(common_hal_vectorio_rectangle_get_height(self));
@@ -105,9 +109,8 @@ const mp_obj_property_t vectorio_rectangle_height_obj = {
               MP_ROM_NONE},
 };
 
-//|     color_index : int
+//|     color_index: int
 //|     """The color_index of the rectangle in 1 based index of the palette."""
-//|
 STATIC mp_obj_t vectorio_rectangle_obj_get_color_index(mp_obj_t self_in) {
     vectorio_rectangle_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(common_hal_vectorio_rectangle_get_color_index(self));
@@ -130,18 +133,17 @@ const mp_obj_property_t vectorio_rectangle_color_index_obj = {
 
 // Documentation for properties inherited from VectorShape.
 
-//|     x : int
+//|     x: int
 //|     """X position of the top left corner of the rectangle in the parent."""
 //|
-//|     y : int
+//|     y: int
 //|     """Y position of the top left corner of the rectangle in the parent."""
 //|
-//|     location : Tuple[int,int]
+//|     location: Tuple[int, int]
 //|     """(X,Y) position of the top left corner of the rectangle in the parent."""
 //|
-//|     pixel_shader : Union[displayio.ColorConverter,displayio.Palette]
+//|     pixel_shader: Union[displayio.ColorConverter, displayio.Palette]
 //|     """The pixel shader of the rectangle."""
-//|
 
 STATIC const mp_rom_map_elem_t vectorio_rectangle_locals_dict_table[] = {
     // Functions

--- a/shared-bindings/vectorio/__init__.c
+++ b/shared-bindings/vectorio/__init__.c
@@ -30,7 +30,6 @@
 //|     group.append(polygon)
 //|
 //| """
-//|
 
 STATIC const mp_rom_map_elem_t vectorio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_vectorio) },

--- a/shared-bindings/watchdog/WatchDogMode.c
+++ b/shared-bindings/watchdog/WatchDogMode.c
@@ -31,7 +31,6 @@
 //|
 //|     def __init__(self) -> None:
 //|         """Enum-like class to define the run mode of the watchdog timer."""
-//|
 //|     RAISE: WatchDogMode
 //|     """Raise an exception when the WatchDogTimer expires.
 //|
@@ -41,7 +40,6 @@
 //|     """Reset the system if the WatchDogTimer expires.
 //|
 //|     :type WatchDogMode:"""
-//|
 const mp_obj_type_t watchdog_watchdogmode_type;
 
 const watchdog_watchdogmode_obj_t watchdog_watchdogmode_raise_obj = {

--- a/shared-bindings/watchdog/WatchDogTimer.c
+++ b/shared-bindings/watchdog/WatchDogTimer.c
@@ -42,23 +42,20 @@
 
 //| class WatchDogTimer:
 //|     """Timer that is used to detect code lock ups and automatically reset the microcontroller
-//|        when one is detected.
+//|     when one is detected.
 //|
-//|        A lock up is detected when the watchdog hasn't been fed after a given duration. So, make
-//|        sure to call `feed` within the timeout.
+//|     A lock up is detected when the watchdog hasn't been fed after a given duration. So, make
+//|     sure to call `feed` within the timeout.
 //|     """
-//|
 
 //|     def __init__(self) -> None:
 //|         """Not currently dynamically supported. Access the sole instance through `microcontroller.watchdog`."""
 //|         ...
-//|
 
 //|     def feed(self) -> None:
 //|         """Feed the watchdog timer. This must be called regularly, otherwise
 //|         the timer will expire."""
 //|         ...
-//|
 STATIC mp_obj_t watchdog_watchdogtimer_feed(mp_obj_t self_in) {
     watchdog_watchdogtimer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     watchdog_watchdogmode_t current_mode = common_hal_watchdog_get_mode(self);
@@ -76,7 +73,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(watchdog_watchdogtimer_feed_obj, watchdog_watch
 //|         """Stop the watchdog timer. This may raise an error if the watchdog
 //|         timer cannot be disabled on this platform."""
 //|         ...
-//|
 STATIC mp_obj_t watchdog_watchdogtimer_deinit(mp_obj_t self_in) {
     watchdog_watchdogtimer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_watchdog_deinit(self);
@@ -87,7 +83,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(watchdog_watchdogtimer_deinit_obj, watchdog_wat
 //|     timeout: float
 //|     """The maximum number of seconds that can elapse between calls
 //|     to feed()"""
-//|
 STATIC mp_obj_t watchdog_watchdogtimer_obj_get_timeout(mp_obj_t self_in) {
     watchdog_watchdogtimer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_float(common_hal_watchdog_get_timeout(self));
@@ -125,7 +120,6 @@ MP_PROPERTY_GETSET(watchdog_watchdogtimer_timeout_obj,
 //|
 //|
 //|     Once set, the WatchDogTimer will perform the specified action if the timer expires."""
-//|
 STATIC mp_obj_t watchdog_watchdogtimer_obj_get_mode(mp_obj_t self_in) {
     watchdog_watchdogtimer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return watchdog_watchdogmode_type_to_obj(common_hal_watchdog_get_mode(self));

--- a/shared-bindings/wifi/AuthMode.c
+++ b/shared-bindings/wifi/AuthMode.c
@@ -59,7 +59,6 @@ MAKE_ENUM_VALUE(wifi_authmode_type, authmode, ENTERPRISE, AUTHMODE_ENTERPRISE);
 //|
 //|     ENTERPRISE: object
 //|     """Each user has a unique credential."""
-//|
 MAKE_ENUM_MAP(wifi_authmode) {
     MAKE_ENUM_MAP_ENTRY(authmode, OPEN),
     MAKE_ENUM_MAP_ENTRY(authmode, WEP),

--- a/shared-bindings/wifi/Monitor.c
+++ b/shared-bindings/wifi/Monitor.c
@@ -34,7 +34,6 @@
 
 //| class Monitor:
 //|     """For monitoring WiFi packets."""
-//|
 
 //| def __init__(self, channel: Optional[int] = 1, queue: Optional[int] = 128) -> None:
 //|     """Initialize `wifi.Monitor` singleton.
@@ -44,7 +43,6 @@
 //|
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t wifi_monitor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_channel, ARG_queue };
     static const mp_arg_t allowed_args[] = {
@@ -71,7 +69,6 @@ STATIC mp_obj_t wifi_monitor_make_new(const mp_obj_type_t *type, size_t n_args, 
 
 //| channel: int
 //| """The WiFi channel to scan."""
-//|
 STATIC mp_obj_t wifi_monitor_obj_get_channel(mp_obj_t self_in) {
     return common_hal_wifi_monitor_get_channel(self_in);
 }
@@ -93,7 +90,6 @@ MP_PROPERTY_GETSET(wifi_monitor_channel_obj,
 
 //| queue: int
 //| """The queue size for buffering the packet."""
-//|
 STATIC mp_obj_t wifi_monitor_obj_get_queue(mp_obj_t self_in) {
     return common_hal_wifi_monitor_get_queue(self_in);
 }
@@ -105,7 +101,6 @@ MP_PROPERTY_GETTER(wifi_monitor_queue_obj,
 //| def deinit(self) -> None:
 //|     """De-initialize `wifi.Monitor` singleton."""
 //|     ...
-//|
 STATIC mp_obj_t wifi_monitor_obj_deinit(mp_obj_t self_in) {
     common_hal_wifi_monitor_deinit(self_in);
     return mp_const_none;
@@ -115,7 +110,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(wifi_monitor_deinit_obj, wifi_monitor_obj_deini
 //| def lost(self) -> int:
 //|     """Returns the packet loss count. The counter resets after each poll."""
 //|     ...
-//|
 STATIC mp_obj_t wifi_monitor_obj_get_lost(mp_obj_t self_in) {
     return common_hal_wifi_monitor_get_lost(self_in);
 }
@@ -124,7 +118,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_monitor_lost_obj, wifi_monitor_obj_get_lost);
 //| def queued(self) -> int:
 //|     """Returns the packet queued count."""
 //|     ...
-//|
 STATIC mp_obj_t wifi_monitor_obj_get_queued(mp_obj_t self_in) {
     if (common_hal_wifi_monitor_deinited()) {
         return mp_obj_new_int_from_uint(0);
@@ -136,7 +129,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_monitor_queued_obj, wifi_monitor_obj_get_queued);
 //| def packet(self) -> dict:
 //|     """Returns the monitor packet."""
 //|     ...
-//|
 STATIC mp_obj_t wifi_monitor_obj_get_packet(mp_obj_t self_in) {
     if (common_hal_wifi_monitor_deinited()) {
         raise_deinited_error();

--- a/shared-bindings/wifi/Network.c
+++ b/shared-bindings/wifi/Network.c
@@ -31,19 +31,14 @@
 #include "shared-bindings/wifi/Network.h"
 
 //| class Network:
-//|     """A wifi network provided by a nearby access point.
-//|
-//|     """
-//|
+//|     """A wifi network provided by a nearby access point."""
 
 //|     def __init__(self) -> None:
 //|         """You cannot create an instance of `wifi.Network`. They are returned by `wifi.Radio.start_scanning_networks`."""
 //|         ...
-//|
 
 //|     ssid: str
 //|     """String id of the network"""
-//|
 STATIC mp_obj_t wifi_network_get_ssid(mp_obj_t self) {
     return common_hal_wifi_network_get_ssid(self);
 
@@ -56,7 +51,6 @@ MP_PROPERTY_GETTER(wifi_network_ssid_obj,
 
 //|     bssid: bytes
 //|     """BSSID of the network (usually the AP's MAC address)"""
-//|
 STATIC mp_obj_t wifi_network_get_bssid(mp_obj_t self) {
     return common_hal_wifi_network_get_bssid(self);
 
@@ -69,7 +63,6 @@ MP_PROPERTY_GETTER(wifi_network_bssid_obj,
 
 //|     rssi: int
 //|     """Signal strength of the network"""
-//|
 STATIC mp_obj_t wifi_network_get_rssi(mp_obj_t self) {
     return common_hal_wifi_network_get_rssi(self);
 
@@ -82,7 +75,6 @@ MP_PROPERTY_GETTER(wifi_network_rssi_obj,
 
 //|     channel: int
 //|     """Channel number the network is operating on"""
-//|
 STATIC mp_obj_t wifi_network_get_channel(mp_obj_t self) {
     return common_hal_wifi_network_get_channel(self);
 
@@ -94,7 +86,6 @@ MP_PROPERTY_GETTER(wifi_network_channel_obj,
 
 //|     country: str
 //|     """String id of the country code"""
-//|
 STATIC mp_obj_t wifi_network_get_country(mp_obj_t self) {
     return common_hal_wifi_network_get_country(self);
 
@@ -106,7 +97,6 @@ MP_PROPERTY_GETTER(wifi_network_country_obj,
 
 //|     authmode: str
 //|     """String id of the authmode"""
-//|
 STATIC mp_obj_t wifi_network_get_authmode(mp_obj_t self) {
     return common_hal_wifi_network_get_authmode(self);
 

--- a/shared-bindings/wifi/Packet.c
+++ b/shared-bindings/wifi/Packet.c
@@ -47,7 +47,6 @@ MAKE_ENUM_VALUE(wifi_packet_type, packet, RSSI, PACKET_RSSI);
 //|
 //|     RSSI: object
 //|     """The packet's rssi."""
-//|
 MAKE_ENUM_MAP(wifi_packet) {
     MAKE_ENUM_MAP_ENTRY(packet, CH),
     MAKE_ENUM_MAP_ENTRY(packet, LEN),

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -38,23 +38,20 @@
 //| class Radio:
 //|     """Native wifi radio.
 //|
-//|        This class manages the station and access point functionality of the native
-//|        Wifi radio.
+//|     This class manages the station and access point functionality of the native
+//|     Wifi radio.
 //|
 //|     """
-//|
 
 //|     def __init__(self) -> None:
 //|         """You cannot create an instance of `wifi.Radio`.
 //|         Use `wifi.radio` to access the sole instance available."""
 //|         ...
-//|
 
 //|     enabled: bool
 //|     """``True`` when the wifi radio is enabled.
 //|     If you set the value to ``False``, any open sockets will be closed.
 //|     """
-//|
 STATIC mp_obj_t wifi_radio_get_enabled(mp_obj_t self) {
     return mp_obj_new_bool(common_hal_wifi_radio_get_enabled(self));
 }
@@ -76,7 +73,6 @@ MP_PROPERTY_GETSET(wifi_radio_enabled_obj,
 //|     hostname: Union[str | ReadableBuffer]
 //|     """Hostname for wifi interface. When the hostname is altered after interface started/connected
 //|        the changes would only be reflected once the interface restarts/reconnects."""
-//|
 STATIC mp_obj_t wifi_radio_get_hostname(mp_obj_t self_in) {
     wifi_radio_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_wifi_radio_get_hostname(self);
@@ -112,7 +108,6 @@ MP_PROPERTY_GETSET(wifi_radio_hostname_obj,
 //|     mac_address: ReadableBuffer
 //|     """MAC address for the station. When the address is altered after interface is connected
 //|        the changes would only be reflected once the interface reconnects."""
-//|
 STATIC mp_obj_t wifi_radio_get_mac_address(mp_obj_t self_in) {
     wifi_radio_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_FROM_PTR(common_hal_wifi_radio_get_mac_address(self));
@@ -140,7 +135,6 @@ MP_PROPERTY_GETSET(wifi_radio_mac_address_obj,
 
 //|     tx_power: float
 //|     """Wifi transmission power, in dBm."""
-//|
 STATIC mp_obj_t wifi_radio_get_tx_power(mp_obj_t self_in) {
     wifi_radio_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_float(common_hal_wifi_radio_get_tx_power(self));
@@ -162,7 +156,6 @@ MP_PROPERTY_GETSET(wifi_radio_tx_power_obj,
 //|     mac_address_ap: ReadableBuffer
 //|     """MAC address for the AP. When the address is altered after interface is started
 //|        the changes would only be reflected once the interface restarts."""
-//|
 STATIC mp_obj_t wifi_radio_get_mac_address_ap(mp_obj_t self_in) {
     wifi_radio_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_FROM_PTR(common_hal_wifi_radio_get_mac_address_ap(self));
@@ -188,10 +181,11 @@ MP_PROPERTY_GETSET(wifi_radio_mac_address_ap_obj,
     (mp_obj_t)&wifi_radio_get_mac_address_ap_obj,
     (mp_obj_t)&wifi_radio_set_mac_address_ap_obj);
 
-//|     def start_scanning_networks(self, *, start_channel: int = 1, stop_channel: int = 11) -> Iterable[Network]:
+//|     def start_scanning_networks(
+//|         self, *, start_channel: int = 1, stop_channel: int = 11
+//|     ) -> Iterable[Network]:
 //|         """Scans for available wifi networks over the given channel range. Make sure the channels are allowed in your country."""
 //|         ...
-//|
 STATIC mp_obj_t wifi_radio_start_scanning_networks(mp_obj_t self_in) {
     wifi_radio_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -202,7 +196,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_start_scanning_networks_obj, wifi_ra
 //|     def stop_scanning_networks(self) -> None:
 //|         """Stop scanning for Wifi networks and free any resources used to do it."""
 //|         ...
-//|
 STATIC mp_obj_t wifi_radio_stop_scanning_networks(mp_obj_t self_in) {
     wifi_radio_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
@@ -215,7 +208,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_scanning_networks_obj, wifi_rad
 //|     def start_station(self) -> None:
 //|         """Starts a Station."""
 //|         ...
-//|
 STATIC mp_obj_t wifi_radio_start_station(mp_obj_t self) {
     common_hal_wifi_radio_start_station(self);
     return mp_const_none;
@@ -225,34 +217,34 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_start_station_obj, wifi_radio_start_station
 //|     def stop_station(self) -> None:
 //|         """Stops the Station."""
 //|         ...
-//|
 STATIC mp_obj_t wifi_radio_stop_station(mp_obj_t self) {
     common_hal_wifi_radio_stop_station(self);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_station_obj, wifi_radio_stop_station);
 
-//|     def start_ap(self,
-//|                  ssid: Union[str | ReadableBuffer],
-//|                  password: Union[str | ReadableBuffer] = "",
-//|                  *,
-//|                  channel: Optional[int] = 1,
-//|                  authmode: Optional[AuthMode],
-//|                  max_connections: Optional[int] = 4) -> None:
+//|     def start_ap(
+//|         self,
+//|         ssid: Union[str | ReadableBuffer],
+//|         password: Union[str | ReadableBuffer] = "",
+//|         *,
+//|         channel: Optional[int] = 1,
+//|         authmode: Optional[AuthMode],
+//|         max_connections: Optional[int] = 4
+//|     ) -> None:
 //|         """Starts an Access Point with the specified ssid and password.
 //|
-//|            If ``channel`` is given, the access point will use that channel unless
-//|            a station is already operating on a different channel.
+//|         If ``channel`` is given, the access point will use that channel unless
+//|         a station is already operating on a different channel.
 //|
-//|            If ``authmode`` is given, the access point will use that Authentication
-//|            mode. If a password is given, ``authmode`` must not be ``OPEN``.
-//|            If ``authmode`` isn't given, ``OPEN`` will be used when password isn't provided,
-//|            otherwise ``WPA_WPA2_PSK``.
+//|         If ``authmode`` is given, the access point will use that Authentication
+//|         mode. If a password is given, ``authmode`` must not be ``OPEN``.
+//|         If ``authmode`` isn't given, ``OPEN`` will be used when password isn't provided,
+//|         otherwise ``WPA_WPA2_PSK``.
 //|
-//|            If ``max_connections`` is given, the access point will allow up to
-//|            that number of stations to connect."""
+//|         If ``max_connections`` is given, the access point will allow up to
+//|         that number of stations to connect."""
 //|         ...
-//|
 STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_ssid, ARG_password, ARG_channel, ARG_authmode, ARG_max_connections };
     static const mp_arg_t allowed_args[] = {
@@ -302,34 +294,34 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_start_ap_obj, 1, wifi_radio_start_a
 //|     def stop_ap(self) -> None:
 //|         """Stops the Access Point."""
 //|         ...
-//|
 STATIC mp_obj_t wifi_radio_stop_ap(mp_obj_t self) {
     common_hal_wifi_radio_stop_ap(self);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_ap_obj, wifi_radio_stop_ap);
 
-//|     def connect(self,
-//|                 ssid: Union[str | ReadableBuffer],
-//|                 password: Union[str | ReadableBuffer] = "",
-//|                 *,
-//|                 channel: Optional[int] = 0,
-//|                 bssid: Optional[Union[str | ReadableBuffer]] = "",
-//|                 timeout: Optional[float] = None) -> None:
+//|     def connect(
+//|         self,
+//|         ssid: Union[str | ReadableBuffer],
+//|         password: Union[str | ReadableBuffer] = "",
+//|         *,
+//|         channel: Optional[int] = 0,
+//|         bssid: Optional[Union[str | ReadableBuffer]] = "",
+//|         timeout: Optional[float] = None
+//|     ) -> None:
 //|         """Connects to the given ssid and waits for an ip address. Reconnections are handled
-//|            automatically once one connection succeeds.
+//|         automatically once one connection succeeds.
 //|
-//|            By default, this will scan all channels and connect to the access point (AP) with the
-//|            given ``ssid`` and greatest signal strength (rssi).
+//|         By default, this will scan all channels and connect to the access point (AP) with the
+//|         given ``ssid`` and greatest signal strength (rssi).
 //|
-//|            If ``channel`` is given, the scan will begin with the given channel and connect to
-//|            the first AP with the given ``ssid``. This can speed up the connection time
-//|            significantly because a full scan doesn't occur.
+//|         If ``channel`` is given, the scan will begin with the given channel and connect to
+//|         the first AP with the given ``ssid``. This can speed up the connection time
+//|         significantly because a full scan doesn't occur.
 //|
-//|            If ``bssid`` is given, the scan will start at the first channel or the one given and
-//|            connect to the AP with the given ``bssid`` and ``ssid``."""
+//|         If ``bssid`` is given, the scan will start at the first channel or the one given and
+//|         connect to the AP with the given ``bssid`` and ``ssid``."""
 //|         ...
-//|
 STATIC mp_obj_t wifi_radio_connect(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_ssid, ARG_password, ARG_channel, ARG_bssid, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
@@ -388,7 +380,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_connect_obj, 1, wifi_radio_connect)
 
 //|     ipv4_gateway: Optional[ipaddress.IPv4Address]
 //|     """IP v4 Address of the station gateway when connected to an access point. None otherwise."""
-//|
 STATIC mp_obj_t wifi_radio_get_ipv4_gateway(mp_obj_t self) {
     return common_hal_wifi_radio_get_ipv4_gateway(self);
 
@@ -400,7 +391,6 @@ MP_PROPERTY_GETTER(wifi_radio_ipv4_gateway_obj,
 
 //|     ipv4_gateway_ap: Optional[ipaddress.IPv4Address]
 //|     """IP v4 Address of the access point gateway, when enabled. None otherwise."""
-//|
 STATIC mp_obj_t wifi_radio_get_ipv4_gateway_ap(mp_obj_t self) {
     return common_hal_wifi_radio_get_ipv4_gateway_ap(self);
 
@@ -412,7 +402,6 @@ MP_PROPERTY_GETTER(wifi_radio_ipv4_gateway_ap_obj,
 
 //|     ipv4_subnet: Optional[ipaddress.IPv4Address]
 //|     """IP v4 Address of the station subnet when connected to an access point. None otherwise."""
-//|
 STATIC mp_obj_t wifi_radio_get_ipv4_subnet(mp_obj_t self) {
     return common_hal_wifi_radio_get_ipv4_subnet(self);
 
@@ -424,7 +413,6 @@ MP_PROPERTY_GETTER(wifi_radio_ipv4_subnet_obj,
 
 //|     ipv4_subnet_ap: Optional[ipaddress.IPv4Address]
 //|     """IP v4 Address of the access point subnet, when enabled. None otherwise."""
-//|
 STATIC mp_obj_t wifi_radio_get_ipv4_subnet_ap(mp_obj_t self) {
     return common_hal_wifi_radio_get_ipv4_subnet_ap(self);
 
@@ -434,9 +422,16 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_get_ipv4_subnet_ap_obj, wifi_radio_get_ipv4
 MP_PROPERTY_GETTER(wifi_radio_ipv4_subnet_ap_obj,
     (mp_obj_t)&wifi_radio_get_ipv4_subnet_ap_obj);
 
-//|     def set_ipv4_address(self, *, ipv4: ipaddress.IPv4Address, netmask: ipaddress.IPv4Address, gateway: ipaddress.IPv4Address, ipv4_dns: Optional[ipaddress.IPv4Address]) -> None:
+//|     def set_ipv4_address(
+//|         self,
+//|         *,
+//|         ipv4: ipaddress.IPv4Address,
+//|         netmask: ipaddress.IPv4Address,
+//|         gateway: ipaddress.IPv4Address,
+//|         ipv4_dns: Optional[ipaddress.IPv4Address]
+//|     ) -> None:
 //|         """Sets the IP v4 address of the station. Must include the netmask and gateway. DNS address is optional.
-//|            Setting the address manually will stop the DHCP client."""
+//|         Setting the address manually will stop the DHCP client."""
 //|         ...
 STATIC mp_obj_t wifi_radio_set_ipv4_address(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_ipv4, ARG_netmask, ARG_gateway, ARG_ipv4_dns };
@@ -458,7 +453,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_set_ipv4_address_obj, 1, wifi_radio
 
 //|     ipv4_address: Optional[ipaddress.IPv4Address]
 //|     """IP v4 Address of the station when connected to an access point. None otherwise."""
-//|
 STATIC mp_obj_t _wifi_radio_get_ipv4_address(mp_obj_t self) {
     return common_hal_wifi_radio_get_ipv4_address(self);
 
@@ -470,7 +464,6 @@ MP_PROPERTY_GETTER(wifi_radio_ipv4_address_obj,
 
 //|     ipv4_address_ap: Optional[ipaddress.IPv4Address]
 //|     """IP v4 Address of the access point, when enabled. None otherwise."""
-//|
 STATIC mp_obj_t wifi_radio_get_ipv4_address_ap(mp_obj_t self) {
     return common_hal_wifi_radio_get_ipv4_address_ap(self);
 
@@ -482,7 +475,6 @@ MP_PROPERTY_GETTER(wifi_radio_ipv4_address_ap_obj,
 
 //|     ipv4_dns: ipaddress.IPv4Address
 //|     """IP v4 Address of the DNS server to be used."""
-//|
 STATIC mp_obj_t wifi_radio_get_ipv4_dns(mp_obj_t self) {
     return common_hal_wifi_radio_get_ipv4_dns(self);
 
@@ -502,7 +494,6 @@ MP_PROPERTY_GETSET(wifi_radio_ipv4_dns_obj,
 
 //|     ap_info: Optional[Network]
 //|     """Network object containing BSSID, SSID, authmode, channel, country and RSSI when connected to an access point. None otherwise."""
-//|
 STATIC mp_obj_t wifi_radio_get_ap_info(mp_obj_t self) {
     return common_hal_wifi_radio_get_ap_info(self);
 
@@ -512,7 +503,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_get_ap_info_obj, wifi_radio_get_ap_info);
 //|     def start_dhcp(self) -> None:
 //|         """Starts the DHCP client."""
 //|         ...
-//|
 STATIC mp_obj_t wifi_radio_start_dhcp_client(mp_obj_t self) {
     common_hal_wifi_radio_start_dhcp_client(self);
     return mp_const_none;
@@ -522,7 +512,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_start_dhcp_client_obj, wifi_radio_start_dhc
 //|     def stop_dhcp(self) -> None:
 //|         """Stops the DHCP client. Needed to assign a static IP address."""
 //|         ...
-//|
 STATIC mp_obj_t wifi_radio_stop_dhcp_client(mp_obj_t self) {
     common_hal_wifi_radio_stop_dhcp_client(self);
     return mp_const_none;
@@ -532,11 +521,12 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_dhcp_client_obj, wifi_radio_stop_dhcp_
 MP_PROPERTY_GETTER(wifi_radio_ap_info_obj,
     (mp_obj_t)&wifi_radio_get_ap_info_obj);
 
-//|     def ping(self, ip: ipaddress.IPv4Address, *, timeout: Optional[float] = 0.5) -> Optional[float]:
+//|     def ping(
+//|         self, ip: ipaddress.IPv4Address, *, timeout: Optional[float] = 0.5
+//|     ) -> Optional[float]:
 //|         """Ping an IP to test connectivity. Returns echo time in seconds.
-//|            Returns None when it times out."""
+//|         Returns None when it times out."""
 //|         ...
-//|
 STATIC mp_obj_t wifi_radio_ping(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_ip, ARG_timeout };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/wifi/ScannedNetworks.c
+++ b/shared-bindings/wifi/ScannedNetworks.c
@@ -35,7 +35,6 @@
 //| class ScannedNetworks:
 //|     """Iterates over all `wifi.Network` objects found while scanning. This object is always created
 //|     by a `wifi.Radio`: it has no user-visible constructor."""
-//|
 STATIC mp_obj_t scannednetworks_iternext(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &wifi_scannednetworks_type));
     wifi_scannednetworks_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -50,16 +49,13 @@ STATIC mp_obj_t scannednetworks_iternext(mp_obj_t self_in) {
 //|     def __init__(self) -> None:
 //|         """Cannot be instantiated directly. Use `wifi.Radio.start_scanning_networks`."""
 //|         ...
-//|
 //|     def __iter__(self) -> Iterator[Network]:
 //|         """Returns itself since it is the iterator."""
 //|         ...
-//|
 //|     def __next__(self) -> Network:
 //|         """Returns the next `wifi.Network`.
-//|            Raises `StopIteration` if scanning is finished and no other results are available."""
+//|         Raises `StopIteration` if scanning is finished and no other results are available."""
 //|         ...
-//|
 
 const mp_obj_type_t wifi_scannednetworks_type = {
     { &mp_type_type },

--- a/shared-bindings/wifi/__init__.c
+++ b/shared-bindings/wifi/__init__.c
@@ -38,7 +38,6 @@
 //| radio: Radio
 //| """Wifi radio used to manage both station and AP modes.
 //| This object is the sole instance of `wifi.Radio`."""
-//|
 
 // Called when wifi is imported.
 STATIC mp_obj_t wifi___init__(void) {

--- a/shared-bindings/zlib/__init__.c
+++ b/shared-bindings/zlib/__init__.c
@@ -46,9 +46,10 @@
 //| The `zlib` module allows limited functionality similar to the CPython zlib library.
 //| This module allows to decompress binary data compressed with DEFLATE algorithm
 //| (commonly used in zlib library and gzip archiver). Compression is not yet implemented."""
-//|
 
-//| def zlib_decompress(data: bytes, wbits: Optional[int] = 0, bufsize: Optional[int] = 0) -> bytes:
+//| def zlib_decompress(
+//|     data: bytes, wbits: Optional[int] = 0, bufsize: Optional[int] = 0
+//| ) -> bytes:
 //|     """Return decompressed *data* as bytes. *wbits* is DEFLATE dictionary window
 //|     size used during compression (8-15, the dictionary size is power of 2 of
 //|     that value). Additionally, if value is positive, *data* is assumed to be
@@ -69,7 +70,6 @@
 //|     :param int bufsize: ignored for compatibility with CPython only
 //|     """
 //|     ...
-//|
 STATIC mp_obj_t zlib_decompress(size_t n_args, const mp_obj_t *args) {
     bool is_zlib = true;
     if (n_args > 1 && MP_OBJ_SMALL_INT_VALUE(args[1]) < 0) {

--- a/tools/black_bindings.py
+++ b/tools/black_bindings.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+from concurrent.futures import ThreadPoolExecutor
+import os
+import re
+import subprocess
+import sys
+
+
+def transform(fn, s):
+    lines = s.rstrip().split("\n")
+    lines = [line.removeprefix("//| ").removeprefix("//|") for line in lines]
+    while lines and not lines[0]:
+        del lines[0]
+
+    s = "\n".join(lines) + "\n"
+    if s[0] == " ":
+        prefix = "if 0:\n"
+    else:
+        prefix = ""
+    s = prefix + s
+    try:
+        # Line length is 95 so that with "//| " the max is 99
+        result = subprocess.run(
+            ["black", "--pyi", "-l95", "-q", "-"],
+            input=s,
+            check=True,
+            stdout=subprocess.PIPE,
+            encoding="utf-8",
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"{fn}:0: Failed to process block:\n{s}")
+        raise
+
+    result = result.stdout[len(prefix) :].strip("\n")
+    result = (result.rstrip()).split("\n")
+    return "\n".join("//| " + line if line else "//|" for line in result) + "\n"
+
+
+def process_one_file(fn):
+    with open(fn, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    old_end = 0
+
+    parts = []
+    for m in re.finditer("(?m)((?:^//\|.*\n)(?:^//\|.*\n)*)", content):
+        parts.append(content[old_end : m.start()])
+        parts.append(transform(fn, m.group()))
+        old_end = m.end()
+    parts.append(content[old_end:])
+    newcontent = "".join(parts)
+
+    if newcontent != content:
+        with open(fn, "w", encoding="utf-8") as f:
+            f.write(newcontent)
+
+
+if __name__ == "__main__":
+    # Use a thread pool because most processing is inside black!
+    executor = ThreadPoolExecutor(max_workers=os.cpu_count())
+    futures = [executor.submit(process_one_file, fn) for fn in sys.argv[1:]]
+    status = 0
+    for f in futures:
+        try:
+            f.result()
+        except Exception as e:
+            status = 1
+    executor.shutdown()
+    raise SystemExit(status)

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -214,8 +214,13 @@ def main():
             if os.path.splitext(file)[1].lower() in exts:
                 yield file
 
+    def bindings_files():
+        for file in lang_files(C_EXTS):
+            if file.startswith("shared-bindings/") or "/bindings/" in file:
+                yield file
+
     # Run tool on N files at a time (to avoid making the command line too long).
-    def batch(cmd, files, N=200):
+    def batch(cmd, files, N=200, check=False):
         while True:
             file_args = list(itertools.islice(files, N))
             if not file_args:
@@ -223,7 +228,10 @@ def main():
             if args.dry_run:
                 print(" ".join(cmd + file_args))
             else:
-                subprocess.call(cmd + file_args)
+                if check:
+                    subprocess.check_call(cmd + file_args)
+                else:
+                    subprocess.run(cmd + file_args)
 
     # Format C files with uncrustify.
     if format_c:
@@ -234,6 +242,10 @@ def main():
         batch(command, lang_files(C_EXTS))
         for file in lang_files(C_EXTS):
             fixup_c(file)
+        # Format bindings with black_bindings
+        if format_py:
+            command = ["python3", "tools/black_bindings.py"]
+            batch(command, bindings_files(), check=True)
 
     # Format Python files with black.
     if format_py:


### PR DESCRIPTION
As an alternative to #6950 arrange to run black on each "//|" stubs block within bindings and shared-bindings, so that the formatting is made consistent at every commit.

Reasons not to do this right now: It churns a LOT and I was not attentive enough to review everything.