### PR TITLE
Update STM DFU mode software implementation.

### DIFF
--- a/ports/stm/supervisor/port.c
+++ b/ports/stm/supervisor/port.c
@@ -291,7 +291,7 @@ condition and generating hardware reset or using Go command to execute user code
     HAL_DeInit();
 
     // Disable all pending interrupts using NVIC
-    for (uint8_t i = 0; i < (sizeof(NVIC->ICER) / sizeof(NVIC->ICER[0])); ++i) {
+    for (uint8_t i = 0; i < MP_ARRAY_SIZE(NVIC->ICER); ++i) {
         NVIC->ICER[i] = 0xFFFFFFFF;
     }
 
@@ -302,7 +302,7 @@ condition and generating hardware reset or using Go command to execute user code
     __ISB();
 
     // Clear all pending interrupts using NVIC
-    for (uint8_t i = 0; i < (sizeof(NVIC->ICPR) / sizeof(NVIC->ICPR[0])); ++i) {
+    for (uint8_t i = 0; i < MP_ARRAY_SIZE(NVIC->ICPR); ++i) {
         NVIC->ICPR[i] = 0xFFFFFFFF;
     }
 


### PR DESCRIPTION
Hello,

I found a couple of issues with my first implementation of the STM DFU mode https://github.com/adafruit/circuitpython/pull/6919

1. the size of the interrupt clear array was not computed correctly
2. the recommendation to disable interrupts using NVIC from ARM (nested vector interrupt controller) was not followed
 
I retested with my STM32 Nucleo-F446RE board, attached picture bellow:

![image](https://user-images.githubusercontent.com/3575408/193121200-68e4ea16-c298-46bf-b1c3-12d56e4394bf.png)
