### PR TITLE
Espressif: do not hold pins during deep sleep if not necessary

### DIFF
--- a/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
@@ -88,9 +88,6 @@ void board_init(void) {
     displayio_display_obj_t *display = &displays[0].display;
     display->base.type = &displayio_display_type;
 
-    // workaround as board_init() is called before reset_port() in main.c
-///    pwmout_reset();
-
     common_hal_displayio_display_construct(
         display,
         bus,
@@ -127,8 +124,8 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Override the I2C/TFT power pin reset to prevent resetting the display.
     if (pin_number == 21) {
         // Turn on TFT and I2C
-        gpio_set_direction(21, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(21, true);
+        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
+        gpio_set_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/common-hal/alarm/__init__.c
+++ b/ports/espressif/common-hal/alarm/__init__.c
@@ -173,9 +173,6 @@ void NORETURN common_hal_alarm_enter_deep_sleep(void) {
     // We no longer need to remember the pin preservations, since any pin resets are all done.
     clear_pin_preservations();
 
-    // Allow pin holds to work during deep sleep.
-    gpio_deep_sleep_hold_en();
-
     // The ESP-IDF caches the deep sleep settings and applies them before sleep.
     // We don't need to worry about resetting them in the interim.
     esp_deep_sleep_start();

--- a/ports/espressif/common-hal/microcontroller/Pin.c
+++ b/ports/espressif/common-hal/microcontroller/Pin.c
@@ -173,6 +173,12 @@ void preserve_pin_number(gpio_num_t pin_number) {
         gpio_hold_en(pin_number);
         _preserved_pin_mask |= PIN_BIT(pin_number);
     }
+    if (_preserved_pin_mask) {
+        // Allow pin holds to work during deep sleep. This increases power consumption noticeably
+        // during deep sleep, so enable holds only if we actually are holding some pins.
+        // 270uA or so extra current is consumed even with no pins held.
+        gpio_deep_sleep_hold_en();
+    }
 }
 
 void clear_pin_preservations(void) {

--- a/shared-bindings/alarm/__init__.c
+++ b/shared-bindings/alarm/__init__.c
@@ -143,6 +143,12 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(alarm_light_sleep_until_alarms_obj, 1, MP_OB
 //|
 //|     On some microcontrollers, some pins cannot remain in their original state for hardware reasons.
 //|
+//|     .. note::
+//|       On Espressif chips, preserving pin settings during deep sleep may consume extra current.
+//|       On ESP32, this was measured to be 250 uA or more.
+//|       Consider not preserving pins unless you need to.
+//|       Measure power consumption carefully both with no pins preserved and with the pins you might want to
+//|       preserve to achieve the lowest consumption.
 //|
 //|     **If CircuitPython is connected to a host computer via USB or BLE
 //|     the first time a deep sleep is requested,


### PR DESCRIPTION
On ESP32, merely enabling the pin-setting holding mechanism during deep sleep consumed at least 250 uA of extra current, even if no pins were being hold. This compared with about 75 uA total on Feather ESP32 V2 when the mechanism was not being used. Rework the pin-holding logic so that the hardware mechanism is not invoked unless needed. Added a caveat in the documentation.

I think this idiosyncrasy may be explained here: https://github.com/espressif/esp-idf/issues/8249.

Also did a minor cleanup in Feather ESP32-S2 TFT.

@ladyada This turns out to be the reason for the confusing behavior I mentioned yesterday. I have achieved Arduino-level deep sleep power levels now with this fix.

@kattni You may want to re-test with this fix.