### PR TITLE
Tweak black_bindings

### DIFF
--- a/ports/atmel-samd/bindings/samd/Clock.c
+++ b/ports/atmel-samd/bindings/samd/Clock.c
@@ -35,6 +35,7 @@
 //|
 //|     They are fixed by the hardware so they cannot be constructed on demand. Instead, use
 //|     ``samd.clock`` to reference the desired clock."""
+//|
 
 STATIC void samd_clock_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     samd_clock_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -92,6 +93,7 @@ MP_PROPERTY_GETTER(samd_clock_frequency_obj,
 
 //|     calibration: int
 //|     """Clock calibration. Not all clocks can be calibrated."""
+//|
 STATIC mp_obj_t samd_clock_get_calibration(mp_obj_t self_in) {
     samd_clock_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int_from_uint(clock_get_calibration(self->type, self->index));

--- a/ports/broadcom/bindings/videocore/Framebuffer.c
+++ b/ports/broadcom/bindings/videocore/Framebuffer.c
@@ -98,6 +98,7 @@ MP_PROPERTY_GETTER(videocore_framebuffer_width_obj,
 
 //|     height: int
 //|     """The height of the display, in pixels"""
+//|
 STATIC mp_obj_t videocore_framebuffer_get_height(mp_obj_t self_in) {
     videocore_framebuffer_obj_t *self = (videocore_framebuffer_obj_t *)self_in;
     check_for_deinit(self);

--- a/ports/espressif/bindings/esp32_camera/Camera.c
+++ b/ports/espressif/bindings/esp32_camera/Camera.c
@@ -928,6 +928,7 @@ MP_PROPERTY_GETTER(esp32_camera_camera_grab_mode_obj,
 
 //|     framebuffer_count: int
 //|     """True if double buffering is used"""
+//|
 STATIC mp_obj_t esp32_camera_camera_get_framebuffer_count(const mp_obj_t self_in) {
     esp32_camera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/ports/espressif/bindings/esp32_camera/__init__.c
+++ b/ports/espressif/bindings/esp32_camera/__init__.c
@@ -54,6 +54,7 @@
 //|
 //|     LATEST: GrabMode
 //|     """Except when 1 frame buffer is used, queue will always contain the last ``fb_count`` frames"""
+//|
 
 MAKE_ENUM_VALUE(esp32_camera_grab_mode_type, grab_mode, WHEN_EMPTY, CAMERA_GRAB_WHEN_EMPTY);
 MAKE_ENUM_VALUE(esp32_camera_grab_mode_type, grab_mode, LATEST, CAMERA_GRAB_LATEST);
@@ -82,6 +83,7 @@ camera_grab_mode_t validate_grab_mode(mp_obj_t obj, qstr arg_name) {
 //|
 //|     JPEG: PixelFormat
 //|     """A compressed format"""
+//|
 
 MAKE_ENUM_VALUE(esp32_camera_pixel_format_type, pixel_format, RGB565, PIXFORMAT_RGB565);
 MAKE_ENUM_VALUE(esp32_camera_pixel_format_type, pixel_format, GRAYSCALE, PIXFORMAT_GRAYSCALE);
@@ -169,6 +171,7 @@ pixformat_t validate_pixel_format(mp_obj_t obj, qstr arg_name) {
 //|
 //|     QSXGA: FrameSize
 //|     """2560x1920"""
+//|
 
 MAKE_ENUM_VALUE(esp32_camera_frame_size_type, frame_size, R96X96, FRAMESIZE_96X96);
 MAKE_ENUM_VALUE(esp32_camera_frame_size_type, frame_size, R240X240, FRAMESIZE_240X240);
@@ -237,6 +240,7 @@ framesize_t validate_frame_size(mp_obj_t obj, qstr arg_name) {
 //|     GAIN_32X: GainCeiling
 //|     GAIN_64X: GainCeiling
 //|     GAIN_128X: GainCeiling
+//|
 
 MAKE_ENUM_VALUE(esp32_camera_gain_ceiling_type, gain_ceiling, GAIN_2X, GAINCEILING_2X);
 MAKE_ENUM_VALUE(esp32_camera_gain_ceiling_type, gain_ceiling, GAIN_4X, GAINCEILING_4X);

--- a/ports/espressif/bindings/espidf/__init__.c
+++ b/ports/espressif/bindings/espidf/__init__.c
@@ -41,6 +41,7 @@
 //| def heap_caps_get_total_size() -> int:
 //|     """Return the total size of the ESP-IDF, which includes the CircuitPython heap."""
 //|     ...
+//|
 
 STATIC mp_obj_t espidf_heap_caps_get_total_size(void) {
     return MP_OBJ_NEW_SMALL_INT(heap_caps_get_total_size(MALLOC_CAP_8BIT));
@@ -50,6 +51,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(espidf_heap_caps_get_total_size_obj, espidf_heap_caps_
 //| def heap_caps_get_free_size() -> int:
 //|     """Return total free memory in the ESP-IDF heap."""
 //|     ...
+//|
 
 STATIC mp_obj_t espidf_heap_caps_get_free_size(void) {
     return MP_OBJ_NEW_SMALL_INT(heap_caps_get_free_size(MALLOC_CAP_8BIT));
@@ -59,6 +61,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(espidf_heap_caps_get_free_size_obj, espidf_heap_caps_g
 //| def heap_caps_get_largest_free_block() -> int:
 //|     """Return the size of largest free memory block in the ESP-IDF heap."""
 //|     ...
+//|
 
 STATIC mp_obj_t espidf_heap_caps_get_largest_free_block(void) {
     return MP_OBJ_NEW_SMALL_INT(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
@@ -70,6 +73,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(espidf_heap_caps_get_largest_free_block_obj, espidf_he
 //|
 //|     This is necessary when upgrading from CircuitPython 6.3.0 or earlier to CircuitPython 7.0.0, because the
 //|     layout of data in nvs has changed. The old data will be lost when you perform this operation."""
+//|
 STATIC mp_obj_t espidf_erase_nvs(void) {
     ESP_ERROR_CHECK(nvs_flash_deinit());
     ESP_ERROR_CHECK(nvs_flash_erase());
@@ -105,6 +109,7 @@ const mp_obj_type_t mp_type_espidf_IDFError = {
 //|     """Raised when an ESP IDF memory allocation fails."""
 //|
 //|     ...
+//|
 NORETURN void mp_raise_espidf_MemoryError(void) {
     nlr_raise(mp_obj_new_exception(&mp_type_espidf_MemoryError));
 }
@@ -120,6 +125,7 @@ const mp_obj_type_t mp_type_espidf_MemoryError = {
 
 //| def get_total_psram() -> int:
 //|     """Returns the number of bytes of psram detected, or 0 if psram is not present or not configured"""
+//|
 STATIC mp_obj_t espidf_get_total_psram(void) {
     return MP_OBJ_NEW_SMALL_INT(common_hal_espidf_get_total_psram());
 }
@@ -127,6 +133,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(espidf_get_total_psram_obj, espidf_get_total_psram);
 
 //| def get_reserved_psram() -> int:
 //|     """Returns number of bytes of psram reserved for use by esp-idf, either a board-specific default value or the value defined in ``/.env``."""
+//|
 STATIC mp_obj_t espidf_get_reserved_psram(void) {
     return MP_OBJ_NEW_SMALL_INT(common_hal_espidf_get_reserved_psram());
 }

--- a/ports/raspberrypi/bindings/cyw43/__init__.c
+++ b/ports/raspberrypi/bindings/cyw43/__init__.c
@@ -38,6 +38,7 @@
 //|     Cannot be constructed at runtime, but may be the type of a pin object
 //|     in :py:mod:`board`. A `CywPin` can be used as a DigitalInOut, but not with other
 //|     peripherals such as `PWMOut`."""
+//|
 const mp_obj_type_t cyw43_pin_type = {
     { &mp_type_type },
     .flags = MP_TYPE_FLAG_EXTENDED,
@@ -57,6 +58,7 @@ const mp_obj_type_t cyw43_pin_type = {
 //|     Besides this value, there appears to be no other public documentation
 //|     of the values that can be used.
 //|     """
+//|
 STATIC mp_obj_t cyw43_set_power_management(const mp_obj_t value_in) {
     mp_int_t value = mp_obj_get_int(value_in);
     cyw43_wifi_pm(&cyw43_state, value);

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -359,7 +359,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_stop_obj, rp2pio_statemachine_stop
 //|         *,
 //|         start: int = 0,
 //|         end: Optional[int] = None,
-//|         swap: bool = False
+//|         swap: bool = False,
 //|     ) -> None:
 //|         """Write the data contained in ``buffer`` to the state machine. If the buffer is empty, nothing happens.
 //|
@@ -419,7 +419,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_write_obj, 2, rp2pio_statemachine
 //|         once: Optional[ReadableBuffer] = None,
 //|         *,
 //|         loop: Optional[ReadableBuffer] = None,
-//|         swap: bool = False
+//|         swap: bool = False,
 //|     ) -> None:
 //|         """Write data to the TX fifo in the background, with optional looping.
 //|
@@ -564,7 +564,7 @@ const mp_obj_property_t rp2pio_statemachine_pending_obj = {
 //|         *,
 //|         start: int = 0,
 //|         end: Optional[int] = None,
-//|         swap: bool = False
+//|         swap: bool = False,
 //|     ) -> None:
 //|         """Read into ``buffer``. If the number of bytes to read is 0, nothing happens. The buffer
 //|         includes any data added to the fifo even if it was added before this was called.
@@ -628,7 +628,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(rp2pio_statemachine_readinto_obj, 2, rp2pio_statemach
 //|         out_start: int = 0,
 //|         out_end: Optional[int] = None,
 //|         in_start: int = 0,
-//|         in_end: Optional[int] = None
+//|         in_end: Optional[int] = None,
 //|     ) -> None:
 //|         """Write out the data in ``buffer_out`` while simultaneously reading data into ``buffer_in``.
 //|         The lengths of the slices defined by ``buffer_out[out_start:out_end]`` and ``buffer_in[in_start:in_end]``
@@ -788,6 +788,7 @@ MP_PROPERTY_GETTER(rp2pio_statemachine_rxstall_obj,
 
 //|     in_waiting: int
 //|     """The number of words available to readinto"""
+//|
 
 STATIC mp_obj_t rp2pio_statemachine_obj_get_in_waiting(mp_obj_t self_in) {
     rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/ports/raspberrypi/bindings/rp2pio/__init__.c
+++ b/ports/raspberrypi/bindings/rp2pio/__init__.c
@@ -42,6 +42,7 @@
 //| def pins_are_sequential(pins: List[microcontroller.Pin]) -> bool:
 //|     """Return True if the pins have sequential GPIO numbers, False otherwise"""
 //|     ...
+//|
 STATIC mp_obj_t rp2pio_pins_are_sequential(const mp_obj_t pins) {
     size_t len;
     mp_obj_t *items;

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -62,6 +62,7 @@
 //|     The Adapter can do both parts of this process: it can scan for other device
 //|     advertisements and it can advertise its own data. Furthermore, Adapters can accept incoming
 //|     connections and also initiate connections."""
+//|
 
 //|     def __init__(
 //|         self, *, uart: busio.UART, rts: digitalio.DigitalInOut, cts: digitalio.DigitalInOut
@@ -435,6 +436,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bleio_adapter_connect_obj, 1, bleio_adapter_co
 //|     def erase_bonding(self) -> None:
 //|         """Erase all bonding information stored in flash memory."""
 //|         ...
+//|
 STATIC mp_obj_t bleio_adapter_erase_bonding(mp_obj_t self_in) {
     bleio_adapter_obj_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/_bleio/Address.c
+++ b/shared-bindings/_bleio/Address.c
@@ -36,6 +36,7 @@
 
 //| class Address:
 //|     """Encapsulates the address of a BLE device."""
+//|
 
 //|     def __init__(self, address: ReadableBuffer, address_type: int) -> None:
 //|         """Create a new Address object encapsulating the address value.
@@ -185,6 +186,7 @@ STATIC void bleio_address_print(const mp_print_t *print, mp_obj_t self_in, mp_pr
 //|
 //|     RANDOM_PRIVATE_NON_RESOLVABLE: int
 //|     """A randomly generated address that changes on every connection."""
+//|
 STATIC const mp_rom_map_elem_t bleio_address_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_address_bytes),                 MP_ROM_PTR(&bleio_address_address_bytes_obj) },
     { MP_ROM_QSTR(MP_QSTR_type),                          MP_ROM_PTR(&bleio_address_type_obj) },

--- a/shared-bindings/_bleio/Attribute.c
+++ b/shared-bindings/_bleio/Attribute.c
@@ -62,6 +62,7 @@ STATIC const mp_rom_map_elem_t bleio_attribute_locals_dict_table[] = {
 //|
 //|     SIGNED_WITH_MITM: int
 //|     """security_mode: authenticated data signing, without man-in-the-middle protection"""
+//|
     { MP_ROM_QSTR(MP_QSTR_NO_ACCESS),              MP_ROM_INT(SECURITY_MODE_NO_ACCESS) },
     { MP_ROM_QSTR(MP_QSTR_OPEN),                   MP_ROM_INT(SECURITY_MODE_OPEN) },
     { MP_ROM_QSTR(MP_QSTR_ENCRYPT_NO_MITM),        MP_ROM_INT(SECURITY_MODE_ENC_NO_MITM) },

--- a/shared-bindings/_bleio/Characteristic.c
+++ b/shared-bindings/_bleio/Characteristic.c
@@ -301,6 +301,7 @@ STATIC const mp_rom_map_elem_t bleio_characteristic_locals_dict_table[] = {
 //|
 //|     WRITE_NO_RESPONSE: int
 //|     """property: clients may write this characteristic; no response will be sent back"""
+//|
     { MP_ROM_QSTR(MP_QSTR_BROADCAST),         MP_ROM_INT(CHAR_PROP_BROADCAST) },
     { MP_ROM_QSTR(MP_QSTR_INDICATE),          MP_ROM_INT(CHAR_PROP_INDICATE) },
     { MP_ROM_QSTR(MP_QSTR_NOTIFY),            MP_ROM_INT(CHAR_PROP_NOTIFY) },

--- a/shared-bindings/_bleio/CharacteristicBuffer.c
+++ b/shared-bindings/_bleio/CharacteristicBuffer.c
@@ -181,6 +181,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_characteristic_buffer_reset_input_buffer_
 //|     def deinit(self) -> None:
 //|         """Disable permanently."""
 //|         ...
+//|
 STATIC mp_obj_t bleio_characteristic_buffer_deinit(mp_obj_t self_in) {
     bleio_characteristic_buffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_bleio_characteristic_buffer_deinit(self);

--- a/shared-bindings/_bleio/Connection.c
+++ b/shared-bindings/_bleio/Connection.c
@@ -59,6 +59,7 @@
 //|            raise Exception("'InterestingPeripheral' not found")
 //|
 //|        connection = _bleio.adapter.connect(my_entry.address, timeout=10)"""
+//|
 
 void bleio_connection_ensure_connected(bleio_connection_obj_t *self) {
     if (!common_hal_bleio_connection_get_connected(self)) {
@@ -199,6 +200,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(bleio_connection_get_connection_interval_obj, b
 //|     which must be sent in a single packet.
 //|     But for a regular characteristic read or write, may be sent in multiple packets,
 //|     so this limit does not apply."""
+//|
 STATIC mp_obj_t bleio_connection_get_max_packet_length(mp_obj_t self_in) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/_bleio/Descriptor.c
+++ b/shared-bindings/_bleio/Descriptor.c
@@ -166,6 +166,7 @@ MP_PROPERTY_GETTER(bleio_descriptor_characteristic_obj,
 
 //|     value: bytearray
 //|     """The value of this descriptor."""
+//|
 STATIC mp_obj_t bleio_descriptor_get_value(mp_obj_t self_in) {
     bleio_descriptor_obj_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/_bleio/PacketBuffer.c
+++ b/shared-bindings/_bleio/PacketBuffer.c
@@ -201,6 +201,7 @@ MP_PROPERTY_GETTER(bleio_packet_buffer_incoming_packet_length_obj,
 
 //|     outgoing_packet_length: int
 //|     """Maximum length in bytes of a packet we are writing."""
+//|
 STATIC mp_obj_t bleio_packet_buffer_get_outgoing_packet_length(mp_obj_t self_in) {
     bleio_packet_buffer_obj_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/_bleio/ScanEntry.c
+++ b/shared-bindings/_bleio/ScanEntry.c
@@ -39,6 +39,7 @@
 //|     """Encapsulates information about a device that was received during scanning. It can be
 //|     advertisement or scan response data. This object may only be created by a `_bleio.ScanResults`:
 //|     it has no user-visible constructor."""
+//|
 
 //|     def __init__(self) -> None:
 //|         """Cannot be instantiated directly. Use `_bleio.Adapter.start_scan`."""
@@ -114,6 +115,7 @@ MP_PROPERTY_GETTER(bleio_scanentry_connectable_obj,
 
 //|     scan_response: bool
 //|     """True if the entry was a scan response. (read-only)"""
+//|
 STATIC mp_obj_t scanentry_get_scan_response(mp_obj_t self_in) {
     bleio_scanentry_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_bleio_scanentry_get_scan_response(self));

--- a/shared-bindings/_bleio/ScanResults.c
+++ b/shared-bindings/_bleio/ScanResults.c
@@ -35,6 +35,7 @@
 //| class ScanResults:
 //|     """Iterates over advertising data received while scanning. This object is always created
 //|     by a `_bleio.Adapter`: it has no user-visible constructor."""
+//|
 STATIC mp_obj_t scanresults_iternext(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &bleio_scanresults_type));
     bleio_scanresults_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -55,6 +56,7 @@ STATIC mp_obj_t scanresults_iternext(mp_obj_t self_in) {
 //|         """Returns the next `_bleio.ScanEntry`. Blocks if none have been received and scanning is still
 //|         active. Raises `StopIteration` if scanning is finished and no other results are available."""
 //|         ...
+//|
 
 const mp_obj_type_t bleio_scanresults_type = {
     { &mp_type_type },

--- a/shared-bindings/_bleio/Service.c
+++ b/shared-bindings/_bleio/Service.c
@@ -109,6 +109,7 @@ MP_PROPERTY_GETTER(bleio_service_secondary_obj,
 //|     """The UUID of this service. (read-only)
 //|
 //|     Will be ``None`` if the 128-bit UUID for this service is not known."""
+//|
 STATIC mp_obj_t bleio_service_get_uuid(mp_obj_t self_in) {
     bleio_service_obj_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/_bleio/UUID.c
+++ b/shared-bindings/_bleio/UUID.c
@@ -234,6 +234,7 @@ STATIC mp_obj_t bleio_uuid_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 //|     def __eq__(self, other: object) -> bool:
 //|         """Two UUID objects are equal if their values match and they are both 128-bit or both 16-bit."""
 //|         ...
+//|
 STATIC mp_obj_t bleio_uuid_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
     switch (op) {
         // Two UUID's are equal if their uuid16 values match or their uuid128 values match.

--- a/shared-bindings/_bleio/__init__.c
+++ b/shared-bindings/_bleio/__init__.c
@@ -63,6 +63,7 @@
 //|     """Catchall exception for Bluetooth related errors."""
 //|
 //|     ...
+//|
 MP_DEFINE_BLEIO_EXCEPTION(BluetoothError, Exception)
 NORETURN void mp_raise_bleio_BluetoothError(const compressed_string_t *fmt, ...) {
     va_list argptr;
@@ -77,6 +78,7 @@ NORETURN void mp_raise_bleio_BluetoothError(const compressed_string_t *fmt, ...)
 //|     attempted to be set but they can only be set when remote."""
 //|
 //|     ...
+//|
 MP_DEFINE_BLEIO_EXCEPTION(RoleError, bleio_BluetoothError)
 NORETURN void mp_raise_bleio_RoleError(const compressed_string_t *msg) {
     mp_raise_msg(&mp_type_bleio_RoleError, msg);
@@ -86,6 +88,7 @@ NORETURN void mp_raise_bleio_RoleError(const compressed_string_t *msg) {
 //|     """Raised when a security related error occurs."""
 //|
 //|     ...
+//|
 MP_DEFINE_BLEIO_EXCEPTION(SecurityError, bleio_BluetoothError)
 NORETURN void mp_raise_bleio_SecurityError(const compressed_string_t *fmt, ...) {
     va_list argptr;
@@ -115,6 +118,7 @@ STATIC mp_obj_dict_t bleio_module_globals;
 //|     """Set the adapter to use for BLE, such as when using an HCI adapter.
 //|     Raises `NotImplementedError` when the adapter is a singleton and cannot be set."""
 //|     ...
+//|
 mp_obj_t bleio_set_adapter(mp_obj_t adapter_obj) {
     #if CIRCUITPY_BLEIO_HCI
     if (adapter_obj != mp_const_none && !mp_obj_is_type(adapter_obj, &bleio_adapter_type)) {

--- a/shared-bindings/_eve/__init__.c
+++ b/shared-bindings/_eve/__init__.c
@@ -956,6 +956,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(cmd0_obj, _cmd0);
 //|         This method is used by the ``eve`` module to efficiently add
 //|         commands to the FIFO."""
 //|         ...
+//|
 STATIC mp_obj_t _cmd(size_t n_args, const mp_obj_t *args) {
     mp_obj_t self = args[0];
     mp_obj_t num = args[1];

--- a/shared-bindings/_pew/PewPew.c
+++ b/shared-bindings/_pew/PewPew.c
@@ -61,6 +61,7 @@
 //|         is connected to the common side of all buttons (the other sides of the
 //|         buttons are connected to rows of the matrix)."""
 //|         ...
+//|
 STATIC mp_obj_t pewpew_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_buffer, ARG_rows, ARG_cols, ARG_buttons };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/_stage/Layer.c
+++ b/shared-bindings/_stage/Layer.c
@@ -109,6 +109,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(layer_move_obj, layer_move);
 //|         """Set the animation frame of the sprite, and optionally rotation its
 //|         graphic."""
 //|         ...
+//|
 STATIC mp_obj_t layer_frame(mp_obj_t self_in, mp_obj_t frame_in,
     mp_obj_t rotation_in) {
     layer_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/_stage/Text.c
+++ b/shared-bindings/_stage/Text.c
@@ -91,6 +91,7 @@ STATIC mp_obj_t text_make_new(const mp_obj_type_t *type, size_t n_args,
 //|     def move(self, x: int, y: int) -> None:
 //|         """Set the offset of the text to the specified values."""
 //|         ...
+//|
 STATIC mp_obj_t text_move(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in) {
     text_obj_t *self = MP_OBJ_TO_PTR(self_in);
     self->x = mp_obj_get_int(x_in);

--- a/shared-bindings/_stage/__init__.c
+++ b/shared-bindings/_stage/__init__.c
@@ -69,6 +69,7 @@
 //|
 //|     This function is intended for internal use in the ``stage`` library
 //|     and all the necessary checks are performed there."""
+//|
 STATIC mp_obj_t stage_render(size_t n_args, const mp_obj_t *args) {
     uint16_t x0 = mp_obj_get_int(args[0]);
     uint16_t y0 = mp_obj_get_int(args[1]);

--- a/shared-bindings/adafruit_bus_device/i2c_device/I2CDevice.c
+++ b/shared-bindings/adafruit_bus_device/i2c_device/I2CDevice.c
@@ -231,6 +231,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(adafruit_bus_device_i2cdevice_write_obj, 1, adafruit_
 //|         :param int in_end: end of ``in_buffer slice``; if not specified, use ``len(in_buffer)``
 //|         """
 //|         ...
+//|
 STATIC mp_obj_t adafruit_bus_device_i2cdevice_write_then_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_out_buffer, ARG_in_buffer, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/adafruit_bus_device/spi_device/SPIDevice.c
+++ b/shared-bindings/adafruit_bus_device/spi_device/SPIDevice.c
@@ -127,6 +127,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(adafruit_bus_device_spidevice___enter___obj, ad
 //|         """Ends a SPI transaction by deasserting chip select. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
+//|
 STATIC mp_obj_t adafruit_bus_device_spidevice_obj___exit__(size_t n_args, const mp_obj_t *args) {
     common_hal_adafruit_bus_device_spidevice_exit(MP_OBJ_TO_PTR(args[0]));
     return mp_const_none;

--- a/shared-bindings/adafruit_pixelbuf/PixelBuf.c
+++ b/shared-bindings/adafruit_pixelbuf/PixelBuf.c
@@ -296,6 +296,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(pixelbuf_pixelbuf_fill_obj, pixelbuf_pixelbuf_f
 //|         For RGBW byteorders, if given only RGB values either as an int or as a tuple, the white value
 //|         is used instead when the red, green, and blue values are the same."""
 //|         ...
+//|
 STATIC mp_obj_t pixelbuf_pixelbuf_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {
     if (value == MP_OBJ_NULL) {
         // delete item

--- a/shared-bindings/aesio/aes.c
+++ b/shared-bindings/aesio/aes.c
@@ -193,6 +193,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(aesio_aes_encrypt_into_obj,
 //|         buffers must be a multiple of 16 bytes, and must be equal length.  For
 //|         CTX mode, there are no restrictions."""
 //|         ...
+//|
 STATIC mp_obj_t aesio_aes_decrypt_into(mp_obj_t aesio_obj, mp_obj_t src,
     mp_obj_t dest) {
     if (!mp_obj_is_type(aesio_obj, &aesio_aes_type)) {

--- a/shared-bindings/alarm/SleepMemory.c
+++ b/shared-bindings/alarm/SleepMemory.c
@@ -48,6 +48,7 @@
 //|        alarm.sleep_memory[0] = True
 //|        alarm.sleep_memory[1] = 12
 //|     """
+//|
 
 //|     def __init__(self) -> None:
 //|         """Not used. Access the sole instance through `alarm.sleep_memory`."""
@@ -90,6 +91,7 @@ STATIC MP_DEFINE_CONST_DICT(alarm_sleep_memory_locals_dict, alarm_sleep_memory_l
 //|     def __setitem__(self, index: int, value: int) -> None:
 //|         """Set the value at the given index."""
 //|         ...
+//|
 STATIC mp_obj_t alarm_sleep_memory_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {
     if (value == MP_OBJ_NULL) {
         // delete item

--- a/shared-bindings/alarm/__init__.c
+++ b/shared-bindings/alarm/__init__.c
@@ -99,6 +99,7 @@ STATIC void validate_objs_are_alarms(size_t n_args, const mp_obj_t *objs) {
 //|     it may be necessary to disconnect from the host.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t alarm_light_sleep_until_alarms(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
         return mp_const_none;
@@ -172,6 +173,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(alarm_light_sleep_until_alarms_obj, 1, MP_OB
 //|         alarm.exit_and_deep_sleep_until_alarms(time_alarm, pin_alarm)
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t alarm_exit_and_deep_sleep_until_alarms(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_preserve_dios };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/alarm/pin/PinAlarm.c
+++ b/shared-bindings/alarm/pin/PinAlarm.c
@@ -102,6 +102,7 @@ MP_PROPERTY_GETTER(alarm_pin_pinalarm_pin_obj,
 
 //|     value: bool
 //|     """The value on which to trigger."""
+//|
 STATIC mp_obj_t alarm_pin_pinalarm_obj_get_value(mp_obj_t self_in) {
     alarm_pin_pinalarm_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_alarm_pin_pinalarm_get_value(self));

--- a/shared-bindings/alarm/time/TimeAlarm.c
+++ b/shared-bindings/alarm/time/TimeAlarm.c
@@ -117,6 +117,7 @@ STATIC mp_obj_t alarm_time_timealarm_make_new(const mp_obj_type_t *type,
 //|        The time may be given as ``epoch_time`` in the constructor, but it is returned
 //|        by this property only as a `time.monotonic()` time.
 //|        """
+//|
 STATIC mp_obj_t alarm_time_timealarm_obj_get_monotonic_time(mp_obj_t self_in) {
     alarm_time_timealarm_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_float(common_hal_alarm_time_timealarm_get_monotonic_time(self));

--- a/shared-bindings/alarm/touch/TouchAlarm.c
+++ b/shared-bindings/alarm/touch/TouchAlarm.c
@@ -63,6 +63,7 @@ STATIC mp_obj_t alarm_touch_touchalarm_make_new(const mp_obj_type_t *type,
 
 //|     pin: microcontroller.Pin
 //|     """The trigger pin."""
+//|
 STATIC mp_obj_t alarm_touch_touchalarm_obj_get_pin(mp_obj_t self_in) {
     alarm_touch_touchalarm_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_FROM_PTR(self->pin);

--- a/shared-bindings/analogbufio/BufferedIn.c
+++ b/shared-bindings/analogbufio/BufferedIn.c
@@ -58,6 +58,7 @@
 //|         (TODO) The reference voltage varies by platform so use
 //|         ``reference_voltage`` to read the configured setting.
 //|         (TODO) Provide mechanism to read CPU Temperature."""
+//|
 
 //|     def __init__(
 //|         self, pin: microcontroller.Pin, buffer: WriteableBuffer, *, sample_rate: int = 500000
@@ -155,6 +156,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(analogbufio_bufferedin___exit___obj, 
 //|     def read(self) -> None:
 //|         """Fills the provided buffer with ADC voltage values."""
 //|         ...
+//|
 STATIC mp_obj_t analogbufio_bufferedin_obj_read(mp_obj_t self_in) {
     analogbufio_bufferedin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -46,6 +46,7 @@
 //|
 //|        adc = analogio.AnalogIn(A1)
 //|        val = adc.value"""
+//|
 
 //|     def __init__(self, pin: microcontroller.Pin) -> None:
 //|         """Use the AnalogIn on the given pin. The reference voltage varies by
@@ -118,6 +119,7 @@ MP_PROPERTY_GETTER(analogio_analogin_value_obj,
 //|     """The maximum voltage measurable (also known as the reference voltage) as a
 //|     `float` in Volts.  Note the ADC value may not scale to the actual voltage linearly
 //|     at ends of the analog range."""
+//|
 STATIC mp_obj_t analogio_analogin_obj_get_reference_voltage(mp_obj_t self_in) {
     analogio_analogin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/analogio/AnalogOut.c
+++ b/shared-bindings/analogio/AnalogOut.c
@@ -98,6 +98,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(analogio_analogout___exit___obj, 4, 4
 //|
 //|     Even if the underlying digital to analog converter (DAC) is lower
 //|     resolution, the value is 16-bit."""
+//|
 STATIC mp_obj_t analogio_analogout_obj_set_value(mp_obj_t self_in, mp_obj_t value) {
     analogio_analogout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (common_hal_analogio_analogout_deinited(self)) {

--- a/shared-bindings/atexit/__init__.c
+++ b/shared-bindings/atexit/__init__.c
@@ -57,6 +57,7 @@
 //|
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t atexit_register(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     shared_module_atexit_register(pos_args[0], (n_args - 1), ((n_args > 1) ? &pos_args[1] : NULL), kw_args);
     return pos_args[0];
@@ -72,6 +73,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(atexit_register_obj, 1, atexit_register);
 //|
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t atexit_unregister(const mp_obj_t self_in) {
     shared_module_atexit_unregister(&self_in);
     return mp_const_none;

--- a/shared-bindings/audiobusio/I2SOut.c
+++ b/shared-bindings/audiobusio/I2SOut.c
@@ -238,6 +238,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiobusio_i2sout_resume_obj, audiobusio_i2sout_obj_re
 
 //|     paused: bool
 //|     """True when playback is paused. (read-only)"""
+//|
 STATIC mp_obj_t audiobusio_i2sout_obj_get_paused(mp_obj_t self_in) {
     audiobusio_i2sout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audiobusio/PDMIn.c
+++ b/shared-bindings/audiobusio/PDMIn.c
@@ -220,6 +220,7 @@ MP_DEFINE_CONST_FUN_OBJ_3(audiobusio_pdmin_record_obj, audiobusio_pdmin_obj_reco
 //|     sample_rate: int
 //|     """The actual sample_rate of the recording. This may not match the constructed
 //|     sample rate due to internal clock limitations."""
+//|
 STATIC mp_obj_t audiobusio_pdmin_obj_get_sample_rate(mp_obj_t self_in) {
     audiobusio_pdmin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audiocore/RawSample.c
+++ b/shared-bindings/audiocore/RawSample.c
@@ -135,6 +135,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(audioio_rawsample___exit___obj, 4, 4,
 //|     When the sample is looped, this can change the pitch output without changing the underlying
 //|     sample. This will not change the sample rate of any active playback. Call ``play`` again to
 //|     change it."""
+//|
 STATIC mp_obj_t audioio_rawsample_obj_get_sample_rate(mp_obj_t self_in) {
     audioio_rawsample_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audiocore/WaveFile.c
+++ b/shared-bindings/audiocore/WaveFile.c
@@ -165,6 +165,7 @@ MP_PROPERTY_GETTER(audioio_wavefile_bits_per_sample_obj,
     (mp_obj_t)&audioio_wavefile_get_bits_per_sample_obj);
 //|     channel_count: int
 //|     """Number of audio channels. (read only)"""
+//|
 STATIC mp_obj_t audioio_wavefile_obj_get_channel_count(mp_obj_t self_in) {
     audioio_wavefile_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audioio/AudioOut.c
+++ b/shared-bindings/audioio/AudioOut.c
@@ -231,6 +231,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(audioio_audioout_resume_obj, audioio_audioout_obj_resu
 
 //|     paused: bool
 //|     """True when playback is paused. (read-only)"""
+//|
 STATIC mp_obj_t audioio_audioout_obj_get_paused(mp_obj_t self_in) {
     audioio_audioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audiomixer/Mixer.c
+++ b/shared-bindings/audiomixer/Mixer.c
@@ -228,6 +228,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixer_play_obj, 1, audiomixer_mixer_obj_pl
 //|     def stop_voice(self, voice: int = 0) -> None:
 //|         """Stops playback of the sample on the given voice."""
 //|         ...
+//|
 STATIC mp_obj_t audiomixer_mixer_obj_stop_voice(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_voice };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -132,6 +132,7 @@ MP_PROPERTY_GETSET(audiomixer_mixervoice_level_obj,
 
 //|     playing: bool
 //|     """True when this voice is being output. (read-only)"""
+//|
 
 STATIC mp_obj_t audiomixer_mixervoice_obj_get_playing(mp_obj_t self_in) {
     audiomixer_mixervoice_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/audiomp3/MP3Decoder.c
+++ b/shared-bindings/audiomp3/MP3Decoder.c
@@ -248,6 +248,7 @@ MP_PROPERTY_GETTER(audiomp3_mp3file_rms_level_obj,
 
 //|     samples_decoded: int
 //|     """The number of audio samples decoded from the current file. (read only)"""
+//|
 STATIC mp_obj_t audiomp3_mp3file_obj_get_samples_decoded(mp_obj_t self_in) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/audiopwmio/PWMAudioOut.c
+++ b/shared-bindings/audiopwmio/PWMAudioOut.c
@@ -233,6 +233,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiopwmio_pwmaudioout_resume_obj, audiopwmio_pwmaudio
 
 //|     paused: bool
 //|     """True when playback is paused. (read-only)"""
+//|
 STATIC mp_obj_t audiopwmio_pwmaudioout_obj_get_paused(mp_obj_t self_in) {
     audiopwmio_pwmaudioout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/bitbangio/I2C.c
+++ b/shared-bindings/bitbangio/I2C.c
@@ -310,6 +310,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_i2c_writeto_obj, 1, bitbangio_i2c_wr
 //|         :param int in_end: end of ``in_buffer slice``; if not specified, use ``len(in_buffer)``
 //|         """
 //|         ...
+//|
 STATIC mp_obj_t bitbangio_i2c_writeto_then_readfrom(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_address, ARG_out_buffer, ARG_in_buffer, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -317,6 +317,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitbangio_spi_readinto_obj, 1, bitbangio_spi_readinto
 //|         :param int in_end: end of ``in_buffer slice``; if not specified, use ``len(in_buffer)``
 //|         """
 //|         ...
+//|
 STATIC mp_obj_t bitbangio_spi_write_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_out_buffer, ARG_in_buffer, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -173,6 +173,7 @@ STATIC void validate_clip_region(displayio_bitmap_t *bitmap, mp_obj_t clip0_tupl
 //|     :param int skip_index: Bitmap palette index in the source that will not be copied,
 //|            set to None to copy all pixels"""
 //|     ...
+//|
 STATIC mp_obj_t bitmaptools_obj_rotozoom(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_dest_bitmap, ARG_source_bitmap,
           ARG_ox, ARG_oy, ARG_dest_clip0, ARG_dest_clip1,
@@ -295,6 +296,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_rotozoom_obj, 0, bitmaptools_obj_rotozoom
 //|
 //|     For the L8 colorspace, the bitmaps must have a bits-per-value of 8.
 //|     For the RGB colorspaces, they must have a bits-per-value of 16."""
+//|
 
 STATIC mp_obj_t bitmaptools_alphablend(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_dest_bitmap, ARG_source_bitmap_1, ARG_source_bitmap_2, ARG_colorspace, ARG_factor_1, ARG_factor_2};
@@ -369,6 +371,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_alphablend_obj, 0, bitmaptools_alphablend
 //|     :param int value: Bitmap palette index that will be written into the rectangular
 //|            fill region in the destination bitmap"""
 //|     ...
+//|
 STATIC mp_obj_t bitmaptools_obj_fill_region(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_dest_bitmap, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_value};
 
@@ -422,6 +425,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_fill_region_obj, 0, bitmaptools_obj_fill_
 //|     :param int replaced_color_value: Bitmap palette index that will filled with the
 //|            value color in the enclosed area in the destination bitmap"""
 //|     ...
+//|
 STATIC mp_obj_t bitmaptools_obj_boundary_fill(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_dest_bitmap, ARG_x, ARG_y, ARG_fill_color_value, ARG_replaced_color_value};
 
@@ -481,6 +485,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_boundary_fill_obj, 0, bitmaptools_obj_bou
 //|     :param int value: Bitmap palette index that will be written into the
 //|            line in the destination bitmap"""
 //|     ...
+//|
 STATIC mp_obj_t bitmaptools_obj_draw_line(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_dest_bitmap, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_value};
 
@@ -560,6 +565,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_draw_line_obj, 0, bitmaptools_obj_draw_li
 //|             set to None to copy all pixels
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t bitmaptools_arrayblit(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bitmap, ARG_data, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_skip_index };
     static const mp_arg_t allowed_args[] = {
@@ -632,6 +638,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_arrayblit_obj, 0, bitmaptools_arrayblit);
 //|     :param bool reverse_rows: Reverse the direction of the row loading (required for some bitmap images).
 //|     """
 //|     ...
+//|
 
 STATIC mp_obj_t bitmaptools_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bitmap, ARG_file, ARG_bits_per_pixel, ARG_element_size, ARG_reverse_pixels_in_element, ARG_swap_bytes_in_element, ARG_reverse_rows };
@@ -693,6 +700,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_readinto_obj, 0, bitmaptools_readinto);
 //|
 //|     FloydStenberg: "DitherAlgorithm"
 //|     """The Floyd-Stenberg dither"""
+//|
 MAKE_ENUM_VALUE(bitmaptools_dither_algorithm_type, dither_algorithm, Atkinson, DITHER_ALGORITHM_ATKINSON);
 MAKE_ENUM_VALUE(bitmaptools_dither_algorithm_type, dither_algorithm, FloydStenberg, DITHER_ALGORITHM_FLOYD_STENBERG);
 
@@ -720,6 +728,7 @@ MAKE_ENUM_TYPE(bitmaptools, DitherAlgorithm, bitmaptools_dither_algorithm);
 //|     :param algorithm: The dither algorithm to use, one of the `DitherAlgorithm` values.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t bitmaptools_dither(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_dest_bitmap, ARG_source_bitmap, ARG_source_colorspace, ARG_algorithm };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/bitops/__init__.c
+++ b/shared-bindings/bitops/__init__.c
@@ -53,6 +53,7 @@
 //|
 //|     Returns the output buffer."""
 //|     ...
+//|
 
 STATIC mp_obj_t bit_transpose(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_input, ARG_output, ARG_width };

--- a/shared-bindings/board/__init__.c
+++ b/shared-bindings/board/__init__.c
@@ -63,6 +63,7 @@
 //|     """Returns the `busio.I2C` object for the board's designated I2C bus(es).
 //|     The object created is a singleton, and uses the default parameter values for `busio.I2C`."""
 //|     ...
+//|
 #if CIRCUITPY_BOARD_I2C
 STATIC mp_obj_t board_i2c_0(void) {
     return common_hal_board_create_i2c(0);
@@ -79,6 +80,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(board_i2c_obj, board_i2c_0);
 //|     """Returns the `busio.SPI` object for the board's designated SPI bus(es).
 //|     The object created is a singleton, and uses the default parameter values for `busio.SPI`."""
 //|     ...
+//|
 #if CIRCUITPY_BOARD_SPI
 STATIC mp_obj_t board_spi_0(void) {
     return common_hal_board_create_spi(0);
@@ -95,6 +97,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(board_spi_obj, board_spi_0);
 //|     """Returns the `busio.UART` object for the board's designated UART bus(es).
 //|     The object created is a singleton, and uses the default parameter values for `busio.UART`."""
 //|     ...
+//|
 #if CIRCUITPY_BOARD_UART
 STATIC mp_obj_t board_uart_0(void) {
     return common_hal_board_create_uart(0);

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -311,6 +311,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(busio_i2c_writeto_obj, 1, busio_i2c_writeto);
 //|         :param int in_end: end of ``in_buffer slice``; if not specified, use ``len(in_buffer)``
 //|         """
 //|         ...
+//|
 STATIC mp_obj_t busio_i2c_writeto_then_readfrom(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_address, ARG_out_buffer, ARG_in_buffer, ARG_out_start, ARG_out_end, ARG_in_start, ARG_in_end };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -421,6 +421,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_write_readinto_obj, 1, busio_spi_write_read
 //|     frequency: int
 //|     """The actual SPI bus frequency. This may not match the frequency requested
 //|     due to internal limitations."""
+//|
 
 STATIC mp_obj_t busio_spi_obj_get_frequency(mp_obj_t self_in) {
     busio_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -353,6 +353,7 @@ MP_PROPERTY_GETSET(busio_uart_timeout_obj,
 //|     def reset_input_buffer(self) -> None:
 //|         """Discard any unread characters in the input buffer."""
 //|         ...
+//|
 STATIC mp_obj_t busio_uart_obj_reset_input_buffer(mp_obj_t self_in) {
     busio_uart_obj_t *self = native_uart(self_in);
     check_for_deinit(self);
@@ -370,6 +371,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(busio_uart_reset_input_buffer_obj, busio_uart_o
 //|
 //|     EVEN: int
 //|     """Total number of ones should be even."""
+//|
 const mp_obj_type_t busio_uart_parity_type;
 
 const busio_uart_parity_obj_t busio_uart_parity_odd_obj = {

--- a/shared-bindings/camera/Camera.c
+++ b/shared-bindings/camera/Camera.c
@@ -55,6 +55,7 @@
 //|         size = cam.take_picture(buffer, width=1920, height=1080, format=camera.ImageFormat.JPG)
 //|         file.write(buffer, size)
 //|         file.close()"""
+//|
 
 //|     def __init__(self) -> None:
 //|         """Initialize camera."""
@@ -92,6 +93,7 @@ STATIC void check_for_deinit(camera_obj_t *self) {
 //|         :return: the number of bytes written into buf
 //|         :rtype: int"""
 //|         ...
+//|
 STATIC mp_obj_t camera_obj_take_picture(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_width, ARG_height, ARG_format };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/camera/ImageFormat.c
+++ b/shared-bindings/camera/ImageFormat.c
@@ -36,6 +36,7 @@
 //|
 //|     RGB565: ImageFormat
 //|     """RGB565 format."""
+//|
 
 const camera_imageformat_obj_t camera_imageformat_jpg_obj = {
     { &camera_imageformat_type },

--- a/shared-bindings/canio/CAN.c
+++ b/shared-bindings/canio/CAN.c
@@ -323,6 +323,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(canio_can_enter_obj, canio_can_enter);
 //|     ) -> None:
 //|         """Calls deinit()"""
 //|         ...
+//|
 STATIC mp_obj_t canio_can_exit(size_t num_args, const mp_obj_t args[]) {
     canio_can_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     common_hal_canio_can_deinit(self);

--- a/shared-bindings/canio/Listener.c
+++ b/shared-bindings/canio/Listener.c
@@ -41,6 +41,7 @@
 //|     the `in_waiting` method to check for an available message, a
 //|     listener can be used as an iterable, yielding messages until no
 //|     message arrives within ``self.timeout`` seconds."""
+//|
 
 //|     def receive(self) -> Optional[Union[RemoteTransmissionRequest, Message]]:
 //|         """Reads a message, after waiting up to ``self.timeout`` seconds
@@ -133,6 +134,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(canio_listener_exit_obj, 4, 4, canio_
 
 
 //|     timeout: float
+//|
 STATIC mp_obj_t canio_listener_timeout_get(mp_obj_t self_in) {
     canio_listener_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_canio_listener_check_for_deinit(self);

--- a/shared-bindings/canio/Match.c
+++ b/shared-bindings/canio/Match.c
@@ -96,6 +96,7 @@ MP_PROPERTY_GETTER(canio_match_mask_obj,
 
 //|     extended: bool
 //|     """True to match extended ids, False to match standard ides"""
+//|
 
 STATIC mp_obj_t canio_match_extended_get(mp_obj_t self_in) {
     canio_match_obj_t *self = self_in;

--- a/shared-bindings/canio/Message.c
+++ b/shared-bindings/canio/Message.c
@@ -111,6 +111,7 @@ MP_PROPERTY_GETSET(canio_message_data_obj,
 
 //|     extended: bool
 //|     """True if the message's id is an extended id"""
+//|
 STATIC mp_obj_t canio_message_extended_get(const mp_obj_t self_in) {
     canio_message_obj_t *self = self_in;
     return mp_obj_new_bool(common_hal_canio_message_get_extended(self));

--- a/shared-bindings/canio/RemoteTransmissionRequest.c
+++ b/shared-bindings/canio/RemoteTransmissionRequest.c
@@ -106,6 +106,7 @@ MP_PROPERTY_GETSET(canio_remote_transmission_request_extended_obj,
 
 //|     length: int
 //|     """The length of the requested message."""
+//|
 STATIC mp_obj_t canio_remote_transmission_request_length_get(const mp_obj_t self_in) {
     canio_remote_transmission_request_obj_t *self = self_in;
     return MP_OBJ_NEW_SMALL_INT(common_hal_canio_remote_transmission_request_get_length(self));

--- a/shared-bindings/canio/__init__.c
+++ b/shared-bindings/canio/__init__.c
@@ -96,6 +96,7 @@ MAKE_ENUM_VALUE(canio_bus_state_type, bus_state, BUS_OFF, BUS_STATE_OFF);
 //|     """The bus has turned off due to the number of errors that have
 //|     occurred recently.  It must be restarted before it will send or receive
 //|     packets.  This device will neither send or acknowledge packets on the bus."""
+//|
 MAKE_ENUM_MAP(canio_bus_state) {
     MAKE_ENUM_MAP_ENTRY(bus_state, ERROR_ACTIVE),
     MAKE_ENUM_MAP_ENTRY(bus_state, ERROR_PASSIVE),

--- a/shared-bindings/countio/Counter.c
+++ b/shared-bindings/countio/Counter.c
@@ -120,6 +120,7 @@ MP_PROPERTY_GETSET(countio_counter_count_obj,
 
 //|     def reset(self) -> None:
 //|         """Resets the count back to 0."""
+//|
 STATIC mp_obj_t countio_counter_reset(mp_obj_t self_in) {
     countio_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/countio/Edge.c
+++ b/shared-bindings/countio/Edge.c
@@ -48,6 +48,7 @@ MAKE_ENUM_VALUE(countio_edge_type, edge, RISE_AND_FALL, EDGE_RISE_AND_FALL);
 //|
 //|     RISE_AND_FALL: Edge
 //|     """Count the rising and falling edges."""
+//|
 MAKE_ENUM_MAP(countio_edge) {
     MAKE_ENUM_MAP_ENTRY(edge, RISE),
     MAKE_ENUM_MAP_ENTRY(edge, FALL),

--- a/shared-bindings/digitalio/DigitalInOut.c
+++ b/shared-bindings/digitalio/DigitalInOut.c
@@ -310,6 +310,7 @@ MP_PROPERTY_GETSET(digitalio_digitalio_drive_mode_obj,
 //|     - `None`
 //|
 //|     :raises AttributeError: if `direction` is :py:data:`~digitalio.Direction.OUTPUT`."""
+//|
 STATIC mp_obj_t digitalio_digitalinout_obj_get_pull(mp_obj_t self_in) {
     digitalio_digitalinout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/digitalio/Direction.c
+++ b/shared-bindings/digitalio/Direction.c
@@ -50,6 +50,7 @@
 //|
 //|     OUTPUT: Direction
 //|     """Write digital data out"""
+//|
 const mp_obj_type_t digitalio_direction_type;
 
 const digitalio_direction_obj_t digitalio_direction_input_obj = {

--- a/shared-bindings/digitalio/DriveMode.c
+++ b/shared-bindings/digitalio/DriveMode.c
@@ -39,6 +39,7 @@
 //|     OPEN_DRAIN: DriveMode
 //|     """Output low digital values but go into high z for digital high. This is
 //|     useful for i2c and other protocols that share a digital line."""
+//|
 const mp_obj_type_t digitalio_drive_mode_type;
 
 const digitalio_drive_mode_obj_t digitalio_drive_mode_push_pull_obj = {

--- a/shared-bindings/digitalio/Pull.c
+++ b/shared-bindings/digitalio/Pull.c
@@ -42,6 +42,7 @@
 //|     DOWN: Pull
 //|     """When the input line isn't being driven the pull down can pull the
 //|     state of the line low so it reads as false."""
+//|
 const mp_obj_type_t digitalio_pull_type;
 
 const digitalio_pull_obj_t digitalio_pull_up_obj = {

--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -318,6 +318,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_bitmap_fill_obj, displayio_bitmap_obj_fill);
 //|         notified of the "dirty rectangle" that encloses all modified
 //|         pixels."""
 //|         ...
+//|
 STATIC mp_obj_t displayio_bitmap_obj_dirty(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     displayio_bitmap_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     enum { ARG_x1, ARG_y1, ARG_x2, ARG_y2 };

--- a/shared-bindings/displayio/ColorConverter.c
+++ b/shared-bindings/displayio/ColorConverter.c
@@ -121,6 +121,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_colorconverter_make_transparent_obj, display
 //|         """Make the ColorConverter be opaque and have no transparent pixels.
 //|
 //|         :param int color: [IGNORED] Use any value"""
+//|
 STATIC mp_obj_t displayio_colorconverter_make_opaque(mp_obj_t self_in, mp_obj_t transparent_color_obj) {
     displayio_colorconverter_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/displayio/Colorspace.c
+++ b/shared-bindings/displayio/Colorspace.c
@@ -58,6 +58,7 @@ MAKE_ENUM_VALUE(displayio_colorspace_type, displayio_colorspace, L8, DISPLAYIO_C
 //|
 //|     RGB555_SWAPPED: Colorspace
 //|     """The swapped 15-bit colorspace.  First, the high and low 8 bits of the number are swapped, then they are interpreted as for RGB555"""
+//|
 MAKE_ENUM_MAP(displayio_colorspace) {
     MAKE_ENUM_MAP_ENTRY(displayio_colorspace, RGB888),
     MAKE_ENUM_MAP_ENTRY(displayio_colorspace, RGB565),

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -433,6 +433,7 @@ MP_PROPERTY_GETTER(displayio_display_root_group_obj,
 //|         :param int y: The top edge of the area
 //|         :param ~circuitpython_typing.WriteableBuffer buffer: The buffer in which to place the pixel data"""
 //|         ...
+//|
 STATIC mp_obj_t displayio_display_obj_fill_row(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_y, ARG_buffer };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/displayio/EPaperDisplay.c
+++ b/shared-bindings/displayio/EPaperDisplay.c
@@ -339,6 +339,7 @@ MP_PROPERTY_GETSET(displayio_epaperdisplay_rotation_obj,
 
 //|     bus: _DisplayBus
 //|     """The bus being used by the display"""
+//|
 STATIC mp_obj_t displayio_epaperdisplay_obj_get_bus(mp_obj_t self_in) {
     displayio_epaperdisplay_obj_t *self = native_display(self_in);
     return common_hal_displayio_epaperdisplay_get_bus(self);

--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -126,6 +126,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(displayio_fourwire_reset_obj, displayio_fourwire_obj_r
 //|         """Sends the given command value followed by the full set of data. Display state, such as
 //|         vertical scroll, set via ``send`` may or may not be reset once the code is done."""
 //|         ...
+//|
 STATIC mp_obj_t displayio_fourwire_obj_send(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_command, ARG_data, ARG_toggle_every_byte };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -315,6 +315,7 @@ STATIC mp_obj_t group_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t valu
 //|     def sort(self, key: function, reverse: bool) -> None:
 //|         """Sort the members of the group."""
 //|         ...
+//|
 STATIC mp_obj_t displayio_group_obj_sort(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     displayio_group_t *self = native_group(pos_args[0]);
     mp_obj_t *args = m_new(mp_obj_t, n_args);

--- a/shared-bindings/displayio/I2CDisplay.c
+++ b/shared-bindings/displayio/I2CDisplay.c
@@ -100,6 +100,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(displayio_i2cdisplay_reset_obj, displayio_i2cdisplay_o
 //|         """Sends the given command value followed by the full set of data. Display state, such as
 //|         vertical scroll, set via ``send`` may or may not be reset once the code is done."""
 //|         ...
+//|
 STATIC mp_obj_t displayio_i2cdisplay_obj_send(mp_obj_t self, mp_obj_t command_obj, mp_obj_t data_obj) {
     mp_int_t command_int = mp_obj_get_int(command_obj);
     mp_arg_validate_int_range(command_int, 0, 255, MP_QSTR_command);

--- a/shared-bindings/displayio/OnDiskBitmap.c
+++ b/shared-bindings/displayio/OnDiskBitmap.c
@@ -126,6 +126,7 @@ MP_PROPERTY_GETTER(displayio_ondiskbitmap_height_obj,
 //|     """The image's pixel_shader.  The type depends on the underlying
 //|     bitmap's structure.  The pixel shader can be modified (e.g., to set the
 //|     transparent pixel or, for palette shaded images, to update the palette.)"""
+//|
 STATIC mp_obj_t displayio_ondiskbitmap_obj_get_pixel_shader(mp_obj_t self_in) {
     displayio_ondiskbitmap_t *self = MP_OBJ_TO_PTR(self_in);
     return common_hal_displayio_ondiskbitmap_get_pixel_shader(self);

--- a/shared-bindings/displayio/Palette.c
+++ b/shared-bindings/displayio/Palette.c
@@ -173,6 +173,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_palette_make_opaque_obj, displayio_palette_o
 //|     def is_transparent(self, palette_index: int) -> bool:
 //|         """Returns `True` if the palette index is transparent.  Returns `False` if opaque."""
 //|         ...
+//|
 STATIC mp_obj_t displayio_palette_obj_is_transparent(mp_obj_t self_in, mp_obj_t palette_index_obj) {
     displayio_palette_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/displayio/Shape.c
+++ b/shared-bindings/displayio/Shape.c
@@ -77,6 +77,7 @@ STATIC mp_obj_t displayio_shape_make_new(const mp_obj_type_t *type, size_t n_arg
 //|     def set_boundary(self, y: int, start_x: int, end_x: int) -> None:
 //|         """Loads pre-packed data into the given row."""
 //|         ...
+//|
 STATIC mp_obj_t displayio_shape_obj_set_boundary(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     displayio_shape_t *self = MP_OBJ_TO_PTR(args[0]);

--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -446,6 +446,7 @@ MP_PROPERTY_GETSET(displayio_tilegrid_bitmap_obj,
 //|
 //|           grid[0,0] = 10"""
 //|         ...
+//|
 STATIC mp_obj_t tilegrid_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t value_obj) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
 

--- a/shared-bindings/displayio/__init__.c
+++ b/shared-bindings/displayio/__init__.c
@@ -57,6 +57,7 @@
 //| """
 
 //| import paralleldisplay
+//|
 
 //| def release_displays() -> None:
 //|     """Releases any actively used displays so their busses and pins can be used again. This will also
@@ -66,6 +67,7 @@
 //|     Use this once in your code.py if you initialize a display. Place it right before the
 //|     initialization so the display is active as long as possible."""
 //|     ...
+//|
 STATIC mp_obj_t displayio_release_displays(void) {
     common_hal_displayio_release_displays();
     return mp_const_none;

--- a/shared-bindings/dotenv/__init__.c
+++ b/shared-bindings/dotenv/__init__.c
@@ -62,6 +62,7 @@
 //| """
 //|
 //| import typing
+//|
 
 //| def get_key(dotenv_path: str, key_to_get: str) -> Optional[str]:
 //|     """Get the value for the given key from the given .env file. If the key occurs multiple
@@ -69,6 +70,7 @@
 //|
 //|     Returns None if the key isn't found or doesn't have a value."""
 //|     ...
+//|
 STATIC mp_obj_t _dotenv_get_key(mp_obj_t path_in, mp_obj_t key_to_get_in) {
     return common_hal_dotenv_get_key(mp_obj_str_get_str(path_in),
         mp_obj_str_get_str(key_to_get_in));
@@ -81,6 +83,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(dotenv_get_key_obj, _dotenv_get_key);
 //|
 //|     Present in CircuitPython so CPython-compatible code can use it without error."""
 //|     ...
+//|
 STATIC mp_obj_t dotenv_load_dotenv(void) {
     return mp_const_none;
 }

--- a/shared-bindings/dualbank/__init__.c
+++ b/shared-bindings/dualbank/__init__.c
@@ -62,6 +62,7 @@
 //|     in small chunks.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t dualbank_flash(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_offset };
     static const mp_arg_t allowed_args[] = {
@@ -91,6 +92,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(dualbank_flash_obj, 0, dualbank_flash);
 //|     just switched over to.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t dualbank_switch(void) {
     common_hal_dualbank_switch();
     return mp_const_none;

--- a/shared-bindings/floppyio/__init__.c
+++ b/shared-bindings/floppyio/__init__.c
@@ -50,6 +50,7 @@
 //|     :return: The actual number of bytes of read
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t floppyio_flux_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_data, ARG_index };
     static const mp_arg_t allowed_args[] = {
@@ -86,6 +87,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(floppyio_flux_readinto_obj, 0, floppyio_flux_readinto
 //|     :return: The actual number of sectors read
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t floppyio_mfm_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_data, ARG_index };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/fontio/BuiltinFont.c
+++ b/shared-bindings/fontio/BuiltinFont.c
@@ -53,6 +53,7 @@
 //|
 //|         If the code point is not present in the font, `None` is returned."""
 //|         pass
+//|
 
 //| class BuiltinFont:
 //|     """A font built into CircuitPython"""
@@ -90,6 +91,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(fontio_builtinfont_get_bounding_box_obj, fontio_builti
 //|     def get_glyph(self, codepoint: int) -> Glyph:
 //|         """Returns a `fontio.Glyph` for the given codepoint or None if no glyph is available."""
 //|         ...
+//|
 STATIC mp_obj_t fontio_builtinfont_obj_get_glyph(mp_obj_t self_in, mp_obj_t codepoint_obj) {
     fontio_builtinfont_t *self = MP_OBJ_TO_PTR(self_in);
 

--- a/shared-bindings/fontio/Glyph.c
+++ b/shared-bindings/fontio/Glyph.c
@@ -53,6 +53,7 @@
 //|         :param shift_x: the x difference to the next glyph
 //|         :param shift_y: the y difference to the next glyph"""
 //|         ...
+//|
 const mp_obj_namedtuple_type_t fontio_glyph_type = {
     .base = {
         .base = {

--- a/shared-bindings/framebufferio/FramebufferDisplay.c
+++ b/shared-bindings/framebufferio/FramebufferDisplay.c
@@ -321,6 +321,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(framebufferio_framebufferdisplay_fill_row_obj, 1, fra
 
 //|     root_group: displayio.Group
 //|     """The root group on the display."""
+//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_root_group(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     return common_hal_framebufferio_framebufferdisplay_get_root_group(self);

--- a/shared-bindings/frequencyio/FrequencyIn.c
+++ b/shared-bindings/frequencyio/FrequencyIn.c
@@ -192,6 +192,7 @@ MP_PROPERTY_GETSET(frequencyio_frequencyin_capture_period_obj,
 //|     def __get__(self, index: int) -> int:
 //|         """Returns the value of the last frequency captured."""
 //|         ...
+//|
 STATIC mp_obj_t frequencyio_frequencyin_obj_get_value(mp_obj_t self_in) {
     frequencyio_frequencyin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/getpass/__init__.c
+++ b/shared-bindings/getpass/__init__.c
@@ -43,6 +43,7 @@
 //|
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t getpass_getpass(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_prompt, ARG_stream };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/gifio/GifWriter.c
+++ b/shared-bindings/gifio/GifWriter.c
@@ -122,6 +122,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(gifio_gifwriter_deinit_obj, gifio_gifwriter_deinit);
 //|         :param delay: The frame delay in seconds.  The GIF format rounds this to the nearest 1/100 second, and the largest permitted value is 655 seconds.
 //|         """
 //|         ...
+//|
 static mp_obj_t gifio_gifwriter_add_frame(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_bitmap, ARG_delay };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/gnss/GNSS.c
+++ b/shared-bindings/gnss/GNSS.c
@@ -29,6 +29,7 @@
 //|                     continue
 //|                 print("Latitude: {0:.6f} degrees".format(nav.latitude))
 //|                 print("Longitude: {0:.6f} degrees".format(nav.longitude))"""
+//|
 
 //|     def __init__(self, system: Union[SatelliteSystem, List[SatelliteSystem]]) -> None:
 //|         """Turn on the GNSS.
@@ -146,6 +147,7 @@ MP_PROPERTY_GETTER(gnss_timestamp_obj,
 
 //|     fix: PositionFix
 //|     """Fix mode."""
+//|
 STATIC mp_obj_t gnss_obj_get_fix(mp_obj_t self_in) {
     gnss_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/gnss/PositionFix.c
+++ b/shared-bindings/gnss/PositionFix.c
@@ -17,6 +17,7 @@
 //|
 //|     FIX_3D: PositionFix
 //|     """3D fix."""
+//|
 const mp_obj_type_t gnss_positionfix_type;
 
 const gnss_positionfix_obj_t gnss_positionfix_invalid_obj = {

--- a/shared-bindings/gnss/SatelliteSystem.c
+++ b/shared-bindings/gnss/SatelliteSystem.c
@@ -23,6 +23,7 @@
 //|
 //|     QZSS_L1S: SatelliteSystem
 //|     """Quasi-Zenith Satellite System L1S."""
+//|
 const mp_obj_type_t gnss_satellitesystem_type;
 
 const gnss_satellitesystem_obj_t gnss_satellitesystem_gps_obj = {

--- a/shared-bindings/hashlib/Hash.c
+++ b/shared-bindings/hashlib/Hash.c
@@ -34,6 +34,7 @@
 //| class Hash:
 //|     """In progress hash algorithm. This object is always created by a `hashlib.new()`. It has no
 //|     user-visible constructor."""
+//|
 
 //|     digest_size: int
 //|     """Digest size in bytes"""
@@ -65,6 +66,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(hashlib_hash_update_obj, hashlib_hash_update);
 //|     def digest(self) -> bytes:
 //|         """Returns the current digest as bytes() with a length of `hashlib.Hash.digest_size`."""
 //|         ...
+//|
 STATIC mp_obj_t hashlib_hash_digest(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &hashlib_hash_type));
     hashlib_hash_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/hashlib/__init__.c
+++ b/shared-bindings/hashlib/__init__.c
@@ -45,6 +45,7 @@
 //|     :return: a hash object for the given algorithm
 //|     :rtype: hashlib.Hash"""
 //|     ...
+//|
 STATIC mp_obj_t hashlib_new(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_name, ARG_data };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/i2ctarget/I2CTarget.c
+++ b/shared-bindings/i2ctarget/I2CTarget.c
@@ -136,6 +136,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(i2ctarget_i2c_target___exit___obj, 4,
 //|         :param float timeout: Timeout in seconds. Zero means wait forever, a negative value means check once
 //|         :return: I2CTargetRequest or None if timeout=-1 and there's no request
 //|         :rtype: ~i2ctarget.I2CTargetRequest"""
+//|
 STATIC mp_obj_t i2ctarget_i2c_target_request(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mp_check_self(mp_obj_is_type(pos_args[0], &i2ctarget_i2c_target_type));
     i2ctarget_i2c_target_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
@@ -378,6 +379,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(i2ctarget_i2c_target_request_write_obj, i2ctarg
 //|
 //|         :param ack: Whether to send an ACK or NACK"""
 //|         ...
+//|
 STATIC mp_obj_t i2ctarget_i2c_target_request_ack(uint n_args, const mp_obj_t *args) {
     mp_check_self(mp_obj_is_type(args[0], &i2ctarget_i2c_target_request_type));
     i2ctarget_i2c_target_request_obj_t *self = MP_OBJ_TO_PTR(args[0]);

--- a/shared-bindings/imagecapture/ParallelImageCapture.c
+++ b/shared-bindings/imagecapture/ParallelImageCapture.c
@@ -166,6 +166,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(imagecapture_parallelimagecapture_deinit_obj, i
 //|         """Automatically deinitializes the hardware on context exit. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
+//|
 STATIC mp_obj_t imagecapture_parallelimagecapture___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_imagecapture_parallelimagecapture_deinit(args[0]);

--- a/shared-bindings/ipaddress/IPv4Address.c
+++ b/shared-bindings/ipaddress/IPv4Address.c
@@ -37,6 +37,7 @@
 
 //| class IPv4Address:
 //|     """Encapsulates an IPv4 address."""
+//|
 
 //|     def __init__(self, address: Union[int, str, bytes]) -> None:
 //|         """Create a new IPv4Address object encapsulating the address value.
@@ -141,6 +142,7 @@ STATIC mp_obj_t ipaddress_ipv4address_binary_op(mp_binary_op_t op, mp_obj_t lhs_
 //|     def __hash__(self) -> int:
 //|         """Returns a hash for the IPv4Address data."""
 //|         ...
+//|
 STATIC mp_obj_t ipaddress_ipv4address_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     switch (op) {
         // Two Addresses are equal if their address bytes and address_type are equal

--- a/shared-bindings/ipaddress/__init__.c
+++ b/shared-bindings/ipaddress/__init__.c
@@ -78,6 +78,7 @@ bool ipaddress_parse_ipv4address(const char *str_data, size_t str_len, uint32_t 
 //| def ip_address(obj: Union[int, str]) -> IPv4Address:
 //|     """Return a corresponding IP address object or raise ValueError if not possible."""
 //|     ...
+//|
 
 STATIC mp_obj_t ipaddress_ip_address(mp_obj_t ip_in) {
     uint32_t value;

--- a/shared-bindings/is31fl3741/FrameBuffer.c
+++ b/shared-bindings/is31fl3741/FrameBuffer.c
@@ -201,6 +201,7 @@ MP_PROPERTY_GETTER(is31fl3741_FrameBuffer_width_obj,
 
 //|     height: int
 //|     """The height of the display, in pixels"""
+//|
 STATIC mp_obj_t is31fl3741_FrameBuffer_get_height(mp_obj_t self_in) {
     is31fl3741_FrameBuffer_obj_t *self = (is31fl3741_FrameBuffer_obj_t *)self_in;
     check_for_deinit(self);

--- a/shared-bindings/is31fl3741/IS31FL3741.c
+++ b/shared-bindings/is31fl3741/IS31FL3741.c
@@ -73,6 +73,7 @@ STATIC mp_obj_t is31fl3741_IS31FL3741_make_new(const mp_obj_type_t *type, size_t
 //|         IS31FL3741 instance.  After deinitialization, no further operations
 //|         may be performed."""
 //|         ...
+//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_deinit(mp_obj_t self_in) {
     is31fl3741_IS31FL3741_obj_t *self = (is31fl3741_IS31FL3741_obj_t *)self_in;
     common_hal_is31fl3741_IS31FL3741_deinit(self);
@@ -83,6 +84,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(is31fl3741_IS31FL3741_deinit_obj, is31fl3741_IS
 //| def reset(self) -> None:
 //|     """Resets the IS31FL3741 chip."""
 //|     ...
+//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_reset(mp_obj_t self_in) {
     is31fl3741_IS31FL3741_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_is31fl3741_send_reset(self);
@@ -93,6 +95,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(is31fl3741_IS31FL3741_reset_obj, is31fl3741_IS31FL3741
 //| def enable(self) -> None:
 //|     """Enables the IS31FL3741 chip."""
 //|     ...
+//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_enable(mp_obj_t self_in) {
     is31fl3741_IS31FL3741_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_is31fl3741_send_enable(self);
@@ -105,6 +108,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(is31fl3741_IS31FL3741_enable_obj, is31fl3741_IS31FL374
 //|
 //|     :param int current: global current value 0x00 to 0xFF"""
 //|     ...
+//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_set_global_current(mp_obj_t self_in, mp_obj_t value) {
     is31fl3741_IS31FL3741_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_int_t current = mp_obj_get_int(value);
@@ -122,6 +126,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(is31fl3741_IS31FL3741_set_global_current_obj, is31fl37
 //|       the routine will automatically write to page 1 or 3 (instead
 //|       of 0 or 2)"""
 //|     ...
+//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_set_led(size_t n_args, const mp_obj_t *args) {
     is31fl3741_IS31FL3741_obj_t *self = MP_OBJ_TO_PTR(args[0]);
     mp_int_t led = mp_obj_get_int(args[1]);
@@ -138,6 +143,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(is31fl3741_IS31FL3741_set_led_obj, 4, 4, is3
 //|     :param ~Tuple[int, ...] mapping: map the pixels in the buffer to the order addressed by the driver chip
 //|     :param ~_typing.ReadableBuffer buf: The bytes to clock out. No assumption is made about color order"""
 //|     ...
+//|
 STATIC mp_obj_t is31fl3741_IS31FL3741_write(mp_obj_t self_in, mp_obj_t mapping, mp_obj_t buffer) {
     is31fl3741_IS31FL3741_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (!mp_obj_is_tuple_compatible(mapping)) {

--- a/shared-bindings/keypad/Event.c
+++ b/shared-bindings/keypad/Event.c
@@ -150,6 +150,7 @@ STATIC mp_obj_t keypad_event_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_ob
 //|
 //|         Note that as events with different timestamps compare equal, they also hash to the same value."""
 //|         ...
+//|
 STATIC mp_obj_t keypad_event_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     keypad_event_obj_t *self = MP_OBJ_TO_PTR(self_in);
     switch (op) {

--- a/shared-bindings/keypad/EventQueue.c
+++ b/shared-bindings/keypad/EventQueue.c
@@ -120,6 +120,7 @@ STATIC mp_obj_t keypad_eventqueue_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 //|     """``True`` if an event could not be added to the event queue because it was full. (read-only)
 //|     Set to ``False`` by  `clear()`.
 //|     """
+//|
 STATIC mp_obj_t keypad_eventqueue_get_overflowed(mp_obj_t self_in) {
     keypad_eventqueue_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_bool(common_hal_keypad_eventqueue_get_overflowed(self));

--- a/shared-bindings/keypad/KeyMatrix.c
+++ b/shared-bindings/keypad/KeyMatrix.c
@@ -212,6 +212,7 @@ MP_DEFINE_CONST_FUN_OBJ_3(keypad_keymatrix_row_column_to_key_number_obj, keypad_
 //|     events: EventQueue
 //|     """The `EventQueue` associated with this `Keys` object. (read-only)
 //|     """
+//|
 
 STATIC const mp_rom_map_elem_t keypad_keymatrix_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit),                   MP_ROM_PTR(&keypad_keymatrix_deinit_obj) },

--- a/shared-bindings/keypad/Keys.c
+++ b/shared-bindings/keypad/Keys.c
@@ -150,6 +150,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(keypad_keys___exit___obj, 4, 4, keypa
 //|     events: EventQueue
 //|     """The `EventQueue` associated with this `Keys` object. (read-only)
 //|     """
+//|
 STATIC const mp_rom_map_elem_t keypad_keys_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit),       MP_ROM_PTR(&keypad_keys_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR___enter__),    MP_ROM_PTR(&default___enter___obj) },

--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -156,6 +156,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(keypad_shiftregisterkeys___exit___obj
 //|     events: EventQueue
 //|     """The `EventQueue` associated with this `Keys` object. (read-only)
 //|     """
+//|
 
 STATIC const mp_rom_map_elem_t keypad_shiftregisterkeys_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit),       MP_ROM_PTR(&keypad_shiftregisterkeys_deinit_obj) },

--- a/shared-bindings/math/__init__.c
+++ b/shared-bindings/math/__init__.c
@@ -189,6 +189,7 @@ STATIC NORETURN void math_error(void) {
 //| def trunc(x: float) -> int:
 //|     """Return an integer, being ``x`` rounded towards 0."""
 //|     ...
+//|
 MATH_FUN_1_ERRCOND(sqrt, sqrt, (x < (mp_float_t)0.0))
 
 MATH_FUN_2(pow, pow)
@@ -201,6 +202,7 @@ MATH_FUN_1(exp, exp)
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1(expm1, expm1)
 
 //| def log2(x: float) -> float:
@@ -209,6 +211,7 @@ MATH_FUN_1(expm1, expm1)
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1_ERRCOND(log2, log2, (x <= (mp_float_t)0.0))
 
 //| def log10(x: float) -> float:
@@ -217,6 +220,7 @@ MATH_FUN_1_ERRCOND(log2, log2, (x <= (mp_float_t)0.0))
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1_ERRCOND(log10, log10, (x <= (mp_float_t)0.0))
 
 //| def cosh(x: float) -> float:
@@ -225,6 +229,7 @@ MATH_FUN_1_ERRCOND(log10, log10, (x <= (mp_float_t)0.0))
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1(cosh, cosh)
 
 //| def sinh(x: float) -> float:
@@ -233,6 +238,7 @@ MATH_FUN_1(cosh, cosh)
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1(sinh, sinh)
 
 //| def tanh(x: float) -> float:
@@ -241,6 +247,7 @@ MATH_FUN_1(sinh, sinh)
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1(tanh, tanh)
 
 //| def acosh(x: float) -> float:
@@ -249,6 +256,7 @@ MATH_FUN_1(tanh, tanh)
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1(acosh, acosh)
 
 //| def asinh(x: float) -> float:
@@ -257,6 +265,7 @@ MATH_FUN_1(acosh, acosh)
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1(asinh, asinh)
 
 //| def atanh(x: float) -> float:
@@ -265,6 +274,7 @@ MATH_FUN_1(asinh, asinh)
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1(atanh, atanh)
 #endif
 
@@ -309,6 +319,7 @@ MATH_FUN_2(ldexp, ldexp)
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1(erf, erf)
 
 //| def erfc(x: float) -> float:
@@ -317,6 +328,7 @@ MATH_FUN_1(erf, erf)
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1(erfc, erfc)
 
 //| def gamma(x: float) -> float:
@@ -325,6 +337,7 @@ MATH_FUN_1(erfc, erfc)
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1(gamma, tgamma)
 
 //| def lgamma(x: float) -> float:
@@ -333,6 +346,7 @@ MATH_FUN_1(gamma, tgamma)
 //|     May not be available on some boards.
 //|     """
 //|     ...
+//|
 MATH_FUN_1(lgamma, lgamma)
 #endif
 // TODO: factorial, fsum

--- a/shared-bindings/mdns/RemoteService.c
+++ b/shared-bindings/mdns/RemoteService.c
@@ -35,6 +35,7 @@
 //| class RemoteService:
 //|     """Encapsulates information about a remote service that was found during a search. This
 //|     object may only be created by a `mdns.Server`. It has no user-visible constructor."""
+//|
 
 //|     def __init__(self) -> None:
 //|         """Cannot be instantiated directly. Use `mdns.Server.find`."""
@@ -113,6 +114,7 @@ MP_PROPERTY_GETTER(mdns_remoteservice_ipv4_address_obj,
 //|     def __del__(self) -> None:
 //|         """Deletes the RemoteService object."""
 //|         ...
+//|
 STATIC mp_obj_t mdns_remoteservice_obj_deinit(mp_obj_t self_in) {
     mdns_remoteservice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_mdns_remoteservice_deinit(self);

--- a/shared-bindings/mdns/Server.c
+++ b/shared-bindings/mdns/Server.c
@@ -36,6 +36,7 @@
 //| class Server:
 //|     """The MDNS Server responds to queries for this device's information and allows for querying
 //|     other devices."""
+//|
 
 //|     def __init__(self, network_interface: wifi.Radio) -> None:
 //|         """
@@ -163,6 +164,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mdns_server_find_obj, 1, _mdns_server_find);
 //|         :param str protocol: The service protocol such as "_tcp"
 //|         :param int port: The port used by the service"""
 //|         ...
+//|
 STATIC mp_obj_t mdns_server_advertise_service(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mdns_server_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     check_for_deinit(self);

--- a/shared-bindings/memorymonitor/AllocationAlarm.c
+++ b/shared-bindings/memorymonitor/AllocationAlarm.c
@@ -107,6 +107,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(memorymonitor_allocationalarm___enter___obj, memorymon
 //|         """Automatically disables the allocation alarm when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
+//|
 STATIC mp_obj_t memorymonitor_allocationalarm_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_memorymonitor_allocationalarm_set_ignore(args[0], 0);

--- a/shared-bindings/memorymonitor/AllocationSize.c
+++ b/shared-bindings/memorymonitor/AllocationSize.c
@@ -132,6 +132,7 @@ STATIC mp_obj_t memorymonitor_allocationsize_unary_op(mp_unary_op_t op, mp_obj_t
 //|           mm = memorymonitor.AllocationSize()
 //|           print(mm[0])"""
 //|         ...
+//|
 STATIC mp_obj_t memorymonitor_allocationsize_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t value) {
     if (value == mp_const_none) {
         // delete item

--- a/shared-bindings/memorymonitor/__init__.c
+++ b/shared-bindings/memorymonitor/__init__.c
@@ -39,6 +39,7 @@
 //|     """Catchall exception for allocation related errors."""
 //|
 //|     ...
+//|
 MP_DEFINE_MEMORYMONITOR_EXCEPTION(AllocationError, Exception)
 
 NORETURN void mp_raise_memorymonitor_AllocationError(const compressed_string_t *fmt, ...) {

--- a/shared-bindings/microcontroller/Pin.c
+++ b/shared-bindings/microcontroller/Pin.c
@@ -45,6 +45,7 @@
 //|     def __hash__(self) -> int:
 //|         """Returns a hash for the Pin."""
 //|         ...
+//|
 // Provided by mp_generic_unary_op().
 
 static void get_pin_name(const mcu_pin_obj_t *self, qstr *package, qstr *module, qstr *name) {

--- a/shared-bindings/microcontroller/Processor.c
+++ b/shared-bindings/microcontroller/Processor.c
@@ -57,6 +57,7 @@
 //|
 //|        print(microcontroller.cpus[0].temperature)
 //|        print(microcontroller.cpus[1].frequency)"""
+//|
 
 //|     def __init__(self) -> None:
 //|         """You cannot create an instance of `microcontroller.Processor`.
@@ -131,6 +132,7 @@ MP_PROPERTY_GETTER(mcu_processor_uid_obj,
 //|     """The input voltage to the microcontroller, as a float. (read-only)
 //|
 //|     Is `None` if the voltage is not available."""
+//|
 STATIC mp_obj_t mcu_processor_get_voltage(mp_obj_t self) {
     float voltage = common_hal_mcu_processor_get_voltage();
     return isnan(voltage) ? mp_const_none : mp_obj_new_float(voltage);

--- a/shared-bindings/microcontroller/ResetReason.c
+++ b/shared-bindings/microcontroller/ResetReason.c
@@ -64,6 +64,7 @@ MAKE_ENUM_VALUE(mcu_reset_reason_type, reset_reason, RESCUE_DEBUG, RESET_REASON_
 //|
 //|     RESCUE_DEBUG: object
 //|     """The microntroller was reset by the rescue debug port."""
+//|
 MAKE_ENUM_MAP(mcu_reset_reason) {
     MAKE_ENUM_MAP_ENTRY(reset_reason, POWER_ON),
     MAKE_ENUM_MAP_ENTRY(reset_reason, BROWNOUT),

--- a/shared-bindings/microcontroller/RunMode.c
+++ b/shared-bindings/microcontroller/RunMode.c
@@ -52,6 +52,7 @@
 //|     """Run the default bootloader.
 //|
 //|     :type microcontroller.RunMode:"""
+//|
 const mp_obj_type_t mcu_runmode_type;
 
 const mcu_runmode_obj_t mcu_runmode_uf2_obj = {

--- a/shared-bindings/microcontroller/__init__.c
+++ b/shared-bindings/microcontroller/__init__.c
@@ -49,6 +49,7 @@
 //|
 //| from nvm import ByteArray
 //| from watchdog import WatchDogTimer
+//|
 
 //| cpu: Processor
 //| """CPU information and control, such as ``cpu.temperature`` and ``cpu.frequency``
@@ -68,6 +69,7 @@
 //|     processing while you are waiting, explore a different avenue such as using
 //|     `time.sleep()`."""
 //|     ...
+//|
 STATIC mp_obj_t mcu_delay_us(mp_obj_t delay_obj) {
     uint32_t delay = mp_obj_get_int(delay_obj);
 
@@ -80,6 +82,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mcu_delay_us_obj, mcu_delay_us);
 //| def disable_interrupts() -> None:
 //|     """Disable all interrupts. Be very careful, this can stall everything."""
 //|     ...
+//|
 STATIC mp_obj_t mcu_disable_interrupts(void) {
     common_hal_mcu_disable_interrupts();
     return mp_const_none;
@@ -89,6 +92,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mcu_disable_interrupts_obj, mcu_disable_interru
 //| def enable_interrupts() -> None:
 //|     """Enable the interrupts that were enabled at the last disable."""
 //|     ...
+//|
 STATIC mp_obj_t mcu_enable_interrupts(void) {
     common_hal_mcu_enable_interrupts();
     return mp_const_none;
@@ -101,6 +105,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mcu_enable_interrupts_obj, mcu_enable_interrupt
 //|
 //|     :param ~microcontroller.RunMode run_mode: The next run mode"""
 //|     ...
+//|
 STATIC mp_obj_t mcu_on_next_reset(mp_obj_t run_mode_obj) {
     mcu_runmode_t run_mode;
     if (run_mode_obj == MP_OBJ_FROM_PTR(&mcu_runmode_uf2_obj)) {
@@ -127,6 +132,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mcu_on_next_reset_obj, mcu_on_next_reset);
 //|       host computer. Be very careful when calling this! Make sure the device
 //|       "Safely removed" on Windows or "ejected" on Mac OSX and Linux."""
 //|     ...
+//|
 STATIC mp_obj_t mcu_reset(void) {
     common_hal_mcu_reset();
     // We won't actually get here because we're resetting.

--- a/shared-bindings/msgpack/ExtType.c
+++ b/shared-bindings/msgpack/ExtType.c
@@ -84,6 +84,7 @@ MP_PROPERTY_GETSET(mod_msgpack_exttype_code_obj,
 //|     data: bytes
 //|     """Data."""
 //|     ...
+//|
 STATIC mp_obj_t mod_msgpack_exttype_get_data(mp_obj_t self_in) {
     mod_msgpack_extype_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return self->data;

--- a/shared-bindings/msgpack/__init__.c
+++ b/shared-bindings/msgpack/__init__.c
@@ -100,6 +100,7 @@
 //|           a representation in msgpack format.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t mod_msgpack_pack(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_obj, ARG_buffer, ARG_default };
     STATIC const mp_arg_t allowed_args[] = {
@@ -137,6 +138,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(mod_msgpack_pack_obj, 0, mod_msgpack_pack);
 //|     :return object: object read from stream.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t mod_msgpack_unpack(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_buffer, ARG_ext_hook, ARG_use_list };
     STATIC const mp_arg_t allowed_args[] = {

--- a/shared-bindings/multiterminal/__init__.c
+++ b/shared-bindings/multiterminal/__init__.c
@@ -39,6 +39,7 @@
 //| def get_secondary_terminal() -> Optional[typing.BinaryIO]:
 //|     """Returns the current secondary terminal."""
 //|     ...
+//|
 STATIC mp_obj_t multiterminal_obj_get_secondary_terminal() {
     return common_hal_multiterminal_get_secondary_terminal();
 }
@@ -51,6 +52,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(multiterminal_get_secondary_terminal_obj, multitermina
 //|
 //|     :param stream stream: secondary stream"""
 //|     ...
+//|
 STATIC mp_obj_t multiterminal_obj_set_secondary_terminal(mp_obj_t secondary_terminal) {
     mp_obj_t write_m[3];
     mp_load_method_maybe(secondary_terminal, MP_QSTR_write, write_m);
@@ -68,6 +70,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(multiterminal_set_secondary_terminal_obj, multitermina
 //| def clear_secondary_terminal() -> None:
 //|     """Clears the secondary terminal."""
 //|     ...
+//|
 STATIC mp_obj_t multiterminal_obj_clear_secondary_terminal() {
     common_hal_multiterminal_clear_secondary_terminal();
     return mp_const_none;
@@ -79,6 +82,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(multiterminal_clear_secondary_terminal_obj, multitermi
 //|     the OS when more data is available on the socket to read. This is useful
 //|     as a callback for lwip sockets."""
 //|     ...
+//|
 // TODO(tannewt): This is a funny API. Replace it with a direct call into the OS
 // by the lwip object.
 STATIC mp_obj_t multiterminal_obj_schedule_secondary_terminal_read(mp_obj_t socket) {

--- a/shared-bindings/neopixel_write/__init__.c
+++ b/shared-bindings/neopixel_write/__init__.c
@@ -111,6 +111,7 @@ STATIC void check_for_deinit(digitalio_digitalinout_obj_t *self) {
 //|     :param ~digitalio.DigitalInOut digitalinout: the DigitalInOut to output with
 //|     :param ~circuitpython_typing.ReadableBuffer buf: The bytes to clock out. No assumption is made about color order"""
 //|     ...
+//|
 STATIC mp_obj_t neopixel_write_neopixel_write_(mp_obj_t digitalinout_obj, mp_obj_t buf) {
     if (!mp_obj_is_type(digitalinout_obj, &digitalio_digitalinout_type)) {
         mp_raise_TypeError_varg(translate("Expected a %q"), digitalio_digitalinout_type.name);

--- a/shared-bindings/nvm/ByteArray.c
+++ b/shared-bindings/nvm/ByteArray.c
@@ -82,6 +82,7 @@ STATIC MP_DEFINE_CONST_DICT(nvm_bytearray_locals_dict, nvm_bytearray_locals_dict
 //|     def __setitem__(self, index: int, value: int) -> None:
 //|         """Set the value at the given index."""
 //|         ...
+//|
 STATIC mp_obj_t nvm_bytearray_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {
     if (value == MP_OBJ_NULL) {
         // delete item

--- a/shared-bindings/onewireio/OneWire.c
+++ b/shared-bindings/onewireio/OneWire.c
@@ -132,6 +132,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(onewireio_onewire_read_bit_obj, onewireio_onewire_obj_
 //|     def write_bit(self, value: bool) -> None:
 //|         """Write out a bit based on value."""
 //|         ...
+//|
 STATIC mp_obj_t onewireio_onewire_obj_write_bit(mp_obj_t self_in, mp_obj_t bool_obj) {
     onewireio_onewire_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/os/__init__.c
+++ b/shared-bindings/os/__init__.c
@@ -44,6 +44,7 @@
 //| """
 //|
 //| import typing
+//|
 
 //| def uname() -> _Uname:
 //|     """Returns a named tuple of operating specific and CircuitPython port
@@ -58,6 +59,7 @@
 //|     release: str
 //|     version: str
 //|     machine: str
+//|
 STATIC mp_obj_t os_uname(void) {
     return common_hal_os_uname();
 }
@@ -66,6 +68,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(os_uname_obj, os_uname);
 //| def chdir(path: str) -> None:
 //|     """Change current directory."""
 //|     ...
+//|
 STATIC mp_obj_t os_chdir(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     common_hal_os_chdir(path);
@@ -76,6 +79,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_chdir_obj, os_chdir);
 //| def getcwd() -> str:
 //|     """Get the current directory."""
 //|     ...
+//|
 STATIC mp_obj_t os_getcwd(void) {
     return common_hal_os_getcwd();
 }
@@ -86,6 +90,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(os_getcwd_obj, os_getcwd);
 //|
 //|     This may load values from disk so cache the result instead of calling this often."""
 //|     ...
+//|
 STATIC mp_obj_t os_getenv(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_key, ARG_default };
     static const mp_arg_t allowed_args[] = {
@@ -102,6 +107,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(os_getenv_obj, 1, os_getenv);
 //| def listdir(dir: str) -> str:
 //|     """With no argument, list the current directory.  Otherwise list the given directory."""
 //|     ...
+//|
 STATIC mp_obj_t os_listdir(size_t n_args, const mp_obj_t *args) {
     const char *path;
     if (n_args == 1) {
@@ -116,6 +122,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(os_listdir_obj, 0, 1, os_listdir);
 //| def mkdir(path: str) -> None:
 //|     """Create a new directory."""
 //|     ...
+//|
 STATIC mp_obj_t os_mkdir(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     common_hal_os_mkdir(path);
@@ -126,6 +133,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_mkdir_obj, os_mkdir);
 //| def remove(path: str) -> None:
 //|     """Remove a file."""
 //|     ...
+//|
 STATIC mp_obj_t os_remove(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     common_hal_os_remove(path);
@@ -136,6 +144,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_remove_obj, os_remove);
 //| def rmdir(path: str) -> None:
 //|     """Remove a directory."""
 //|     ...
+//|
 STATIC mp_obj_t os_rename(mp_obj_t old_path_in, mp_obj_t new_path_in) {
     const char *old_path = mp_obj_str_get_str(old_path_in);
     const char *new_path = mp_obj_str_get_str(new_path_in);
@@ -147,6 +156,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(os_rename_obj, os_rename);
 //| def rename(old_path: str, new_path: str) -> str:
 //|     """Rename a file."""
 //|     ...
+//|
 STATIC mp_obj_t os_rmdir(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     common_hal_os_rmdir(path);
@@ -176,6 +186,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_rmdir_obj, os_rmdir);
 //|        So the time fields return 946684800,
 //|        which is the number of seconds corresponding to 1999-12-31."""
 //|     ...
+//|
 STATIC mp_obj_t os_stat(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     return common_hal_os_stat(path);
@@ -202,6 +213,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_stat_obj, os_stat);
 //|     and the ``f_flags`` parameter may return ``0`` as they can be unavailable
 //|     in a port-specific implementation."""
 //|     ...
+//|
 STATIC mp_obj_t os_statvfs(mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
     return common_hal_os_statvfs(path);
@@ -211,6 +223,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(os_statvfs_obj, os_statvfs);
 //| def sync() -> None:
 //|     """Sync all filesystems."""
 //|     ...
+//|
 STATIC mp_obj_t os_sync(void) {
     for (mp_vfs_mount_t *vfs = MP_STATE_VM(vfs_mount_table); vfs != NULL; vfs = vfs->next) {
         // this assumes that vfs->obj is fs_user_mount_t with block device functions
@@ -224,6 +237,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(os_sync_obj, os_sync);
 //|     """Returns a string of *size* random bytes based on a hardware True Random
 //|     Number Generator. When not available, it will raise a NotImplementedError."""
 //|     ...
+//|
 STATIC mp_obj_t os_urandom(mp_obj_t size_in) {
     mp_int_t size = mp_obj_get_int(size_in);
     mp_obj_str_t *result = MP_OBJ_TO_PTR(mp_obj_new_bytes_of_zeros(size));

--- a/shared-bindings/paralleldisplay/ParallelBus.c
+++ b/shared-bindings/paralleldisplay/ParallelBus.c
@@ -132,6 +132,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(paralleldisplay_parallelbus_reset_obj, paralleldisplay
 //|         """Sends the given command value followed by the full set of data. Display state, such as
 //|         vertical scroll, set via ``send`` may or may not be reset once the code is done."""
 //|         ...
+//|
 STATIC mp_obj_t paralleldisplay_parallelbus_obj_send(mp_obj_t self, mp_obj_t command_obj, mp_obj_t data_obj) {
     mp_int_t command_int = mp_arg_validate_int_range(mp_obj_get_int(command_obj), 0, 255, MP_QSTR_command);
 

--- a/shared-bindings/ps2io/Ps2.c
+++ b/shared-bindings/ps2io/Ps2.c
@@ -201,6 +201,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(ps2io_ps2_clear_errors_obj, ps2io_ps2_obj_clear_errors
 //|         """Returns the number of received bytes in buffer, available
 //|         to :py:func:`popleft()`."""
 //|         ...
+//|
 STATIC mp_obj_t ps2_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     ps2io_ps2_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/pulseio/PulseIn.c
+++ b/shared-bindings/pulseio/PulseIn.c
@@ -250,6 +250,7 @@ STATIC mp_obj_t pulsein_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 //|           pulses = pulseio.PulseIn(pin)
 //|           print(pulses[0])"""
 //|         ...
+//|
 STATIC mp_obj_t pulsein_subscr(mp_obj_t self_in, mp_obj_t index_obj, mp_obj_t value) {
     if (value == mp_const_none) {
         // delete item

--- a/shared-bindings/pulseio/PulseOut.c
+++ b/shared-bindings/pulseio/PulseOut.c
@@ -123,6 +123,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(pulseio_pulseout___exit___obj, 4, 4, 
 //|
 //|         :param array.array pulses: pulse durations in microseconds"""
 //|         ...
+//|
 STATIC mp_obj_t pulseio_pulseout_obj_send(mp_obj_t self_in, mp_obj_t pulses) {
     pulseio_pulseout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (common_hal_pulseio_pulseout_deinited(self)) {

--- a/shared-bindings/pwmio/PWMOut.c
+++ b/shared-bindings/pwmio/PWMOut.c
@@ -235,6 +235,7 @@ MP_PROPERTY_GETSET(pwmio_pwmout_duty_cycle_obj,
 //|     changes. In these cases, the duty cycle is automatically recalculated
 //|     from the original duty cycle value. This should happen without any need
 //|     to manually re-set the duty cycle."""
+//|
 STATIC mp_obj_t pwmio_pwmout_obj_get_frequency(mp_obj_t self_in) {
     pwmio_pwmout_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/qrio/PixelPolicy.c
+++ b/shared-bindings/qrio/PixelPolicy.c
@@ -44,6 +44,7 @@
 //|
 //|     RGB565: PixelPolicy
 //|     """The input buffer to `QRDecoder.decode` consists of RGB565 values in native order. The green component is used."""
+//|
 
 MAKE_ENUM_VALUE(qrio_pixel_policy_type, qrio_pixel_policy, EVERY_BYTE, QRIO_EVERY_BYTE);
 MAKE_ENUM_VALUE(qrio_pixel_policy_type, qrio_pixel_policy, RGB565, QRIO_RGB565);

--- a/shared-bindings/qrio/QRDecoder.c
+++ b/shared-bindings/qrio/QRDecoder.c
@@ -112,6 +112,7 @@ MP_PROPERTY_GETSET(qrio_qrdecoder_width_obj,
 
 //|     height: int
 //|     """The height of image the decoder expects"""
+//|
 STATIC mp_obj_t qrio_qrdecoder_get_height(mp_obj_t self_in) {
     qrio_qrdecoder_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_obj_new_int(shared_module_qrio_qrdecoder_get_height(self));

--- a/shared-bindings/qrio/QRInfo.c
+++ b/shared-bindings/qrio/QRInfo.c
@@ -37,6 +37,7 @@
 //|
 //|     data_type: Union[str, int]
 //|     """The encoding of the payload as a string (if a standard encoding) or int (if not standard)"""
+//|
 
 const mp_obj_namedtuple_type_t qrio_qrinfo_type_obj = {
     .base = {

--- a/shared-bindings/rainbowio/__init__.c
+++ b/shared-bindings/rainbowio/__init__.c
@@ -35,6 +35,7 @@
 //|     """C implementation of the common colorwheel() function found in many examples.
 //|     Returns the colorwheel RGB value as an integer value for n (usable in neopixel and dotstar)."""
 //|     ...
+//|
 STATIC mp_obj_t rainbowio_colorwheel(mp_obj_t n) {
     mp_float_t f = mp_obj_get_float(n);
     return MP_OBJ_NEW_SMALL_INT(colorwheel(f));

--- a/shared-bindings/random/__init__.c
+++ b/shared-bindings/random/__init__.c
@@ -52,6 +52,7 @@
 //|     """Sets the starting seed of the random  number generation. Further calls to
 //|     `random` will return deterministic results afterwards."""
 //|     ...
+//|
 STATIC mp_obj_t random_seed(mp_obj_t seed_in) {
     mp_uint_t seed = mp_obj_get_int_truncated(seed_in);
     shared_modules_random_seed(seed);
@@ -62,6 +63,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(random_seed_obj, random_seed);
 //| def getrandbits(k: int) -> int:
 //|     """Returns an integer with *k* random bits."""
 //|     ...
+//|
 STATIC mp_obj_t random_getrandbits(mp_obj_t num_in) {
     int n = mp_obj_get_int(num_in);
     if (n > 32 || n == 0) {
@@ -79,6 +81,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(random_getrandbits_obj, random_getrandbits);
 //| def randrange(start: int, stop: int, step: int) -> int:
 //|     """Returns a randomly selected integer from ``range(start[, stop[, step]])``."""
 //|     ...
+//|
 STATIC mp_obj_t random_randrange(size_t n_args, const mp_obj_t *args) {
     mp_int_t start = 0;
     mp_int_t stop = mp_obj_get_int(args[0]);
@@ -121,6 +124,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(random_randrange_obj, 1, 3, random_ra
 //|     """Returns a randomly selected integer between a and b inclusive. Equivalent
 //|     to ``randrange(a, b + 1, 1)``"""
 //|     ...
+//|
 STATIC mp_obj_t random_randint(mp_obj_t a_in, mp_obj_t b_in) {
     mp_int_t a = mp_obj_get_int(a_in);
     mp_int_t b = mp_obj_get_int(b_in);
@@ -135,6 +139,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(random_randint_obj, random_randint);
 //|     """Returns a randomly selected element from the given sequence. Raises
 //|     IndexError when the sequence is empty."""
 //|     ...
+//|
 STATIC mp_obj_t random_choice(mp_obj_t seq) {
     mp_int_t len = mp_obj_get_int(mp_obj_len(seq));
     if (len == 0) {
@@ -147,6 +152,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(random_choice_obj, random_choice);
 //| def random() -> float:
 //|     """Returns a random float between 0 and 1.0."""
 //|     ...
+//|
 STATIC mp_obj_t random_random(void) {
     return mp_obj_new_float(shared_modules_random_random());
 }
@@ -156,6 +162,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(random_random_obj, random_random);
 //|     """Returns a random float between a and b. It may or may not be inclusive
 //|     depending on float rounding."""
 //|     ...
+//|
 STATIC mp_obj_t random_uniform(mp_obj_t a_in, mp_obj_t b_in) {
     mp_float_t a = mp_obj_get_float(a_in);
     mp_float_t b = mp_obj_get_float(b_in);

--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -40,6 +40,7 @@
 
 //| class RGBMatrix:
 //|     """Displays an in-memory framebuffer to a HUB75-style RGB LED matrix."""
+//|
 
 extern Protomatter_core *_PM_protoPtr;
 
@@ -330,6 +331,7 @@ MP_PROPERTY_GETTER(rgbmatrix_rgbmatrix_width_obj,
 
 //|     height: int
 //|     """The height of the display, in pixels"""
+//|
 STATIC mp_obj_t rgbmatrix_rgbmatrix_get_height(mp_obj_t self_in) {
     rgbmatrix_rgbmatrix_obj_t *self = (rgbmatrix_rgbmatrix_obj_t *)self_in;
     check_for_deinit(self);

--- a/shared-bindings/rotaryio/IncrementalEncoder.c
+++ b/shared-bindings/rotaryio/IncrementalEncoder.c
@@ -146,6 +146,7 @@ MP_PROPERTY_GETSET(rotaryio_incrementalencoder_divisor_obj,
 //|     position: int
 //|     """The current position in terms of pulses. The number of pulses per rotation is defined by the
 //|     specific hardware and by the divisor."""
+//|
 STATIC mp_obj_t rotaryio_incrementalencoder_obj_get_position(mp_obj_t self_in) {
     rotaryio_incrementalencoder_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/rtc/RTC.c
+++ b/shared-bindings/rtc/RTC.c
@@ -100,6 +100,7 @@ MP_PROPERTY_GETSET(rtc_rtc_datetime_obj,
 //|
 //|       r = rtc.RTC()
 //|       r.calibration = 1"""
+//|
 STATIC mp_obj_t rtc_rtc_obj_get_calibration(mp_obj_t self_in) {
     int calibration = common_hal_rtc_get_calibration();
     return mp_obj_new_int(calibration);

--- a/shared-bindings/rtc/__init__.c
+++ b/shared-bindings/rtc/__init__.c
@@ -65,6 +65,7 @@ mp_obj_t rtc_get_time_source_time(void) {
 //|       r = RTC()
 //|       rtc.set_time_source(r)"""
 //|     ...
+//|
 STATIC mp_obj_t rtc_set_time_source(mp_obj_t time_source) {
     MP_STATE_VM(rtc_time_source) = time_source;
 

--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -173,6 +173,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(sdcardio_sdcard_sync_obj, sdcardio_sdcard_sync);
 //|         :param ~circuitpython_typing.ReadableBuffer buf: The buffer to read from.  Length must be multiple of 512.
 //|
 //|         :return: None"""
+//|
 
 STATIC mp_obj_t sdcardio_sdcard_writeblocks(mp_obj_t self_in, mp_obj_t start_block_in, mp_obj_t buf_in) {
     uint32_t start_block = mp_obj_get_int(start_block_in);

--- a/shared-bindings/sdioio/SDCard.c
+++ b/shared-bindings/sdioio/SDCard.c
@@ -248,6 +248,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(sdioio_sdcard_deinit_obj, sdioio_sdcard_obj_deinit);
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
+//|
 STATIC mp_obj_t sdioio_sdcard_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_sdioio_sdcard_deinit(args[0]);

--- a/shared-bindings/socketpool/Socket.c
+++ b/shared-bindings/socketpool/Socket.c
@@ -44,6 +44,7 @@
 //|
 //|     Provides a subset of CPython's `socket.socket` API. It only implements the versions of
 //|     recv that do not allocate bytes objects."""
+//|
 
 //|     def __hash__(self) -> int:
 //|         """Returns a hash for the Socket."""
@@ -340,6 +341,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(socketpool_socket_setblocking_obj, socketpool_s
 //|
 //|         :param ~int value: timeout in seconds.  0 means non-blocking.  None means block indefinitely."""
 //|         ...
+//|
 STATIC mp_obj_t socketpool_socket_settimeout(mp_obj_t self_in, mp_obj_t timeout_in) {
     socketpool_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_uint_t timeout_ms;

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -114,6 +114,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(socketpool_socketpool_socket_obj, 1, socketpool_socke
 //|         address information to call socket.socket() and socket.connect() with,
 //|         as a tuple."""
 //|         ...
+//|
 STATIC mp_obj_t socketpool_socketpool_getaddrinfo(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_host, ARG_port, ARG_family, ARG_type, ARG_proto, ARG_flags };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/ssl/SSLContext.c
+++ b/shared-bindings/ssl/SSLContext.c
@@ -39,6 +39,7 @@
 //|     """Settings related to SSL that can be applied to a socket by wrapping it.
 //|     This is useful to provide SSL certificates to specific connections
 //|     rather than all of them."""
+//|
 
 STATIC mp_obj_t ssl_sslcontext_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
@@ -114,6 +115,7 @@ MP_PROPERTY_GETSET(ssl_sslcontext_check_hostname_obj,
 //|     ) -> ssl.SSLSocket:
 //|         """Wraps the socket into a socket-compatible class that handles SSL negotiation.
 //|         The socket must be of type SOCK_STREAM."""
+//|
 
 STATIC mp_obj_t ssl_sslcontext_wrap_socket(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_sock, ARG_server_side, ARG_server_hostname };

--- a/shared-bindings/ssl/SSLSocket.c
+++ b/shared-bindings/ssl/SSLSocket.c
@@ -43,6 +43,7 @@
 //|
 //|     Provides a subset of CPython's `ssl.SSLSocket` API. It only implements the versions of
 //|     recv that do not allocate bytes objects."""
+//|
 
 //|     def __hash__(self) -> int:
 //|         """Returns a hash for the Socket."""
@@ -263,6 +264,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ssl_sslsocket_settimeout_obj, ssl_sslsocket_set
 //|
 //|         :param ~bool flag: False means non-blocking, True means block indefinitely."""
 //|         ...
+//|
 // method socket.setblocking(flag)
 STATIC mp_obj_t ssl_sslsocket_setblocking(mp_obj_t self_in, mp_obj_t blocking) {
     ssl_sslsocket_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/ssl/__init__.c
+++ b/shared-bindings/ssl/__init__.c
@@ -40,6 +40,7 @@
 //| def create_default_context() -> ssl.SSLContext:
 //|     """Return the default SSLContext."""
 //|     ...
+//|
 
 STATIC mp_obj_t ssl_create_default_context(void) {
     ssl_sslcontext_obj_t *s = m_new_obj(ssl_sslcontext_obj_t);

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -57,6 +57,7 @@
 //|     :param bool readonly: True when the filesystem should be readonly to CircuitPython.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t storage_mount(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_filesystem, ARG_mount_path, ARG_readonly };
     static const mp_arg_t allowed_args[] = {
@@ -93,6 +94,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(storage_mount_obj, 0, storage_mount);
 //|
 //|     This is the CircuitPython analog to the UNIX ``umount`` command."""
 //|     ...
+//|
 STATIC mp_obj_t storage_umount(mp_obj_t mnt_in) {
     if (mp_obj_is_str(mnt_in)) {
         common_hal_storage_umount_path(mp_obj_str_get_str(mnt_in));
@@ -119,6 +121,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(storage_umount_obj, storage_umount);
 //|       allows CircuitPython and a host to write to the same filesystem with the risk that the
 //|       filesystem will be corrupted."""
 //|     ...
+//|
 STATIC mp_obj_t storage_remount(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_mount_path, ARG_readonly, ARG_disable_concurrent_write_protection };
     static const mp_arg_t allowed_args[] = {
@@ -141,6 +144,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(storage_remount_obj, 0, storage_remount);
 //| def getmount(mount_path: str) -> VfsFat:
 //|     """Retrieves the mount object associated with the mount path"""
 //|     ...
+//|
 STATIC mp_obj_t storage_getmount(const mp_obj_t mnt_in) {
     return common_hal_storage_getmount(mp_obj_str_get_str(mnt_in));
 }
@@ -159,6 +163,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(storage_getmount_obj, storage_getmount);
 //|     .. warning:: All the data on ``CIRCUITPY`` will be lost, and
 //|          CircuitPython will restart on certain boards."""
 //|     ...
+//|
 
 STATIC mp_obj_t storage_erase_filesystem(void) {
     common_hal_storage_erase_filesystem();
@@ -171,6 +176,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(storage_erase_filesystem_obj, storage_erase_filesystem
 //|     By default, the device is enabled and ``CIRCUITPY`` is visible.
 //|     Can be called in ``boot.py``, before USB is connected."""
 //|     ...
+//|
 STATIC mp_obj_t storage_disable_usb_drive(void) {
     #if CIRCUITPY_USB_MSC
     if (!common_hal_storage_disable_usb_drive()) {
@@ -195,6 +201,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(storage_disable_usb_drive_obj, storage_disable_usb_dri
 //|     not enough endpoints are available.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t storage_enable_usb_drive(void) {
     #if CIRCUITPY_USB_MSC
     if (!common_hal_storage_enable_usb_drive()) {
@@ -259,6 +266,7 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
 //|     def umount(self) -> None:
 //|         """Don't call this directly, call `storage.umount`."""
 //|         ...
+//|
     { MP_ROM_QSTR(MP_QSTR_VfsFat), MP_ROM_PTR(&mp_fat_vfs_type) },
 };
 

--- a/shared-bindings/struct/__init__.c
+++ b/shared-bindings/struct/__init__.c
@@ -51,6 +51,7 @@
 //| def calcsize(fmt: str) -> int:
 //|     """Return the number of bytes needed to store the given fmt."""
 //|     ...
+//|
 
 STATIC mp_obj_t struct_calcsize(mp_obj_t fmt_in) {
 
@@ -62,6 +63,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(struct_calcsize_obj, struct_calcsize);
 //|     """Pack the values according to the format string fmt.
 //|     The return value is a bytes object encoding the values."""
 //|     ...
+//|
 
 STATIC mp_obj_t struct_pack(size_t n_args, const mp_obj_t *args) {
     mp_int_t size = MP_OBJ_SMALL_INT_VALUE(struct_calcsize(args[0]));
@@ -79,6 +81,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(struct_pack_obj, 1, MP_OBJ_FUN_ARGS_MAX, str
 //|     """Pack the values according to the format string fmt into a buffer
 //|     starting at offset. offset may be negative to count from the end of buffer."""
 //|     ...
+//|
 
 STATIC mp_obj_t struct_pack_into(size_t n_args, const mp_obj_t *args) {
     mp_buffer_info_t bufinfo;
@@ -105,6 +108,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(struct_pack_into_obj, 3, MP_OBJ_FUN_ARGS_MAX
 //|     is a tuple of the unpacked values. The buffer size must match the size
 //|     required by the format."""
 //|     ...
+//|
 
 STATIC mp_obj_t struct_unpack(size_t n_args, const mp_obj_t *args) {
     mp_buffer_info_t bufinfo;
@@ -123,6 +127,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(struct_unpack_obj, 2, 3, struct_unpack);
 //|     a tuple of the unpacked values. The buffer size must be at least as big
 //|     as the size required by the form."""
 //|     ...
+//|
 
 STATIC mp_obj_t struct_unpack_from(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_format, ARG_buffer, ARG_offset };

--- a/shared-bindings/supervisor/RunReason.c
+++ b/shared-bindings/supervisor/RunReason.c
@@ -48,6 +48,7 @@ MAKE_ENUM_VALUE(supervisor_run_reason_type, run_reason, REPL_RELOAD, RUN_REASON_
 //|
 //|     REPL_RELOAD: object
 //|     """CircuitPython started due to the user typing CTRL-D in the REPL."""
+//|
 MAKE_ENUM_MAP(supervisor_run_reason) {
     MAKE_ENUM_MAP_ENTRY(run_reason, STARTUP),
     MAKE_ENUM_MAP_ENTRY(run_reason, AUTO_RELOAD),

--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -51,6 +51,7 @@ STATIC supervisor_run_reason_t _run_reason;
 //|        import supervisor
 //|        if supervisor.runtime.serial_connected:
 //|            print("Hello World!")"""
+//|
 
 //|     def __init__(self) -> None:
 //|         """You cannot create an instance of `supervisor.Runtime`.
@@ -113,6 +114,7 @@ MP_PROPERTY_GETTER(supervisor_runtime_run_reason_obj,
 
 //|     autoreload: bool
 //|     """Whether CircuitPython may autoreload based on workflow writes to the filesystem."""
+//|
 STATIC mp_obj_t supervisor_runtime_get_autoreload(mp_obj_t self) {
     return mp_obj_new_bool(autoreload_is_enabled());
 }

--- a/shared-bindings/supervisor/StatusBar.c
+++ b/shared-bindings/supervisor/StatusBar.c
@@ -40,6 +40,7 @@
 //|
 //|        supervisor.status_bar.console = False
 //|     """
+//|
 
 //|     def __init__(self) -> None:
 //|         """You cannot create an instance of `supervisor.StatusBar`.
@@ -83,6 +84,7 @@ MP_PROPERTY_GETSET(supervisor_status_bar_console_obj,
 //|     May be set in ``boot.py`` or later.  Persists across soft restarts.
 //|     Not available if `terminalio` is not available.
 //|     """
+//|
 STATIC mp_obj_t supervisor_status_bar_get_display(mp_obj_t self_in) {
     #if CIRCUITPY_STATUS_BAR && CIRCUITPY_TERMINALIO
     supervisor_status_bar_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -68,6 +68,7 @@
 //|     after the current code finishes and the status LED is used to show
 //|     the finish state."""
 //|     ...
+//|
 STATIC mp_obj_t supervisor_set_rgb_status_brightness(mp_obj_t lvl) {
     // This must be int. If cast to uint8_t first, will never raise a ValueError.
     int brightness_int = mp_obj_get_int(lvl);
@@ -80,6 +81,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(supervisor_set_rgb_status_brightness_obj, supervisor_s
 //| def reload() -> None:
 //|     """Reload the main Python code and run it (equivalent to hitting Ctrl-D at the REPL)."""
 //|     ...
+//|
 STATIC mp_obj_t supervisor_reload(void) {
     reload_initiate(RUN_REASON_SUPERVISOR_RELOAD);
     return mp_const_none;
@@ -89,6 +91,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(supervisor_reload_obj, supervisor_reload);
 //| def set_next_stack_limit(size: int) -> None:
 //|     """Set the size of the stack for the next vm run. If its too large, the default will be used."""
 //|     ...
+//|
 STATIC mp_obj_t supervisor_set_next_stack_limit(mp_obj_t size_obj) {
     mp_int_t size = mp_obj_get_int(size_obj);
 
@@ -140,6 +143,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(supervisor_set_next_stack_limit_obj, supervisor_set_ne
 //|     settings made by previous ones. This is the main use of passing ``None`` as a filename: to
 //|     reset to the standard search sequence."""
 //|     ...
+//|
 STATIC mp_obj_t supervisor_set_next_code_file(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_filename, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
@@ -240,6 +244,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(supervisor_set_next_code_file_obj, 0, supervisor_set_
 //|
 //|     """
 //|     ...
+//|
 mp_obj_t supervisor_ticks_ms(void) {
     uint64_t ticks_ms = common_hal_time_monotonic_ms();
     return mp_obj_new_int((ticks_ms + 0x1fff0000) % (1 << 29));
@@ -255,6 +260,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(supervisor_ticks_ms_obj, supervisor_ticks_ms);
 //|
 //|     Only code (main or boot) runs are considered, not REPL runs."""
 //|     ...
+//|
 STATIC mp_obj_t supervisor_get_previous_traceback(void) {
     if (prev_traceback_allocation) {
         size_t len = strlen((const char *)prev_traceback_allocation->ptr);
@@ -276,6 +282,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(supervisor_get_previous_traceback_obj, supervisor_get_
 //|     """Disable ble workflow until a reset. This prevents BLE advertising outside of the VM and
 //|     the services used for it."""
 //|     ...
+//|
 STATIC mp_obj_t supervisor_disable_ble_workflow(void) {
     #if !CIRCUITPY_BLE_FILE_SERVICE && !CIRCUITPY_SERIAL_BLE
     mp_raise_NotImplementedError(NULL);
@@ -289,6 +296,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(supervisor_disable_ble_workflow_obj, supervisor_disabl
 //| def reset_terminal(x_pixels: int, y_pixels: int) -> None:
 //|     """Reset the CircuitPython serial terminal with new dimensions."""
 //|     ...
+//|
 STATIC mp_obj_t supervisor_reset_terminal(mp_obj_t x_pixels, mp_obj_t y_pixels) {
     #if CIRCUITPY_DISPLAYIO
     supervisor_stop_terminal();
@@ -316,6 +324,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(supervisor_reset_terminal_obj, supervisor_reset_termin
 //|     Not available on boards without native USB support.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t supervisor_set_usb_identification(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     #if CIRCUITPY_USB_IDENTIFICATION
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/synthio/MidiTrack.c
+++ b/shared-bindings/synthio/MidiTrack.c
@@ -122,6 +122,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(synthio_miditrack___exit___obj, 4, 4,
 
 //|     sample_rate: Optional[int]
 //|     """32 bit value that tells how quickly samples are played in Hertz (cycles per second)."""
+//|
 STATIC mp_obj_t synthio_miditrack_obj_get_sample_rate(mp_obj_t self_in) {
     synthio_miditrack_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/synthio/__init__.c
+++ b/shared-bindings/synthio/__init__.c
@@ -60,6 +60,7 @@
 //|             pass
 //|           print("stopped")"""
 //|     ...
+//|
 STATIC mp_obj_t synthio_from_file(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_file, ARG_sample_rate };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/terminalio/Terminal.c
+++ b/shared-bindings/terminalio/Terminal.c
@@ -100,6 +100,7 @@ STATIC mp_obj_t terminalio_terminal_make_new(const mp_obj_type_t *type, size_t n
 //|         :return: the number of bytes written
 //|         :rtype: int or None"""
 //|         ...
+//|
 STATIC mp_uint_t terminalio_terminal_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
     terminalio_terminal_obj_t *self = MP_OBJ_TO_PTR(self_in);
     const byte *buf = buf_in;

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -62,6 +62,7 @@
 //|     :return: the current monotonic time
 //|     :rtype: float"""
 //|     ...
+//|
 STATIC mp_obj_t time_monotonic(void) {
     uint64_t ticks_ms = common_hal_time_monotonic_ms();
     return mp_obj_new_float(uint64_to_float(ticks_ms) / 1000.0f);
@@ -73,6 +74,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(time_monotonic_obj, time_monotonic);
 //|
 //|     :param float seconds: the time to sleep in fractional seconds"""
 //|     ...
+//|
 STATIC mp_obj_t time_sleep(mp_obj_t seconds_o) {
     #if MICROPY_PY_BUILTINS_FLOAT
     mp_float_t seconds = mp_obj_get_float(seconds_o);
@@ -117,6 +119,7 @@ STATIC mp_obj_t struct_time_make_new(const mp_obj_type_t *type, size_t n_args, s
 //|           * ``tm_yday``: the day of the year, range [1, 366], -1 indicates not known
 //|           * ``tm_isdst``: 1 when in daylight savings, 0 when not, -1 if unknown."""
 //|         ...
+//|
 const mp_obj_namedtuple_type_t struct_time_type_obj = {
     .base = {
         .base = {
@@ -215,6 +218,7 @@ mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
 //|     :return: the current time
 //|     :rtype: int"""
 //|     ...
+//|
 STATIC mp_obj_t time_time(void) {
     timeutils_struct_time_t tm;
     struct_time_to_tm(rtc_get_time_source_time(), &tm);
@@ -231,6 +235,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 //|     :return: the current time
 //|     :rtype: int"""
 //|     ...
+//|
 STATIC mp_obj_t time_monotonic_ns(void) {
     uint64_t time64 = common_hal_time_monotonic_ns();
     return mp_obj_new_int_from_ll((long long)time64);
@@ -246,6 +251,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(time_monotonic_ns_obj, time_monotonic_ns);
 //|     :return: the current time
 //|     :rtype: time.struct_time"""
 //|     ...
+//|
 STATIC mp_obj_t time_localtime(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0 || args[0] == mp_const_none) {
         return rtc_get_time_source_time();
@@ -282,6 +288,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_localtime_obj, 0, 1, time_localtime);
 //|     :return: seconds
 //|     :rtype: int"""
 //|     ...
+//|
 STATIC mp_obj_t time_mktime(mp_obj_t t) {
     mp_obj_t *elem;
     size_t len;

--- a/shared-bindings/touchio/TouchIn.c
+++ b/shared-bindings/touchio/TouchIn.c
@@ -50,6 +50,7 @@
 //|        while True:
 //|            if touch.value:
 //|                print("touched!")"""
+//|
 
 //|     def __init__(self, pin: microcontroller.Pin) -> None:
 //|         """Use the TouchIn on the given pin.
@@ -145,6 +146,7 @@ MP_PROPERTY_GETTER(touchio_touchin_raw_value_obj,
 //|
 //|       touch = touchio.TouchIn(board.A1)
 //|       touch.threshold = 7300"""
+//|
 STATIC mp_obj_t touchio_touchin_obj_get_threshold(mp_obj_t self_in) {
     touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);

--- a/shared-bindings/traceback/__init__.c
+++ b/shared-bindings/traceback/__init__.c
@@ -89,6 +89,7 @@ STATIC void traceback_exception_common(mp_print_t *print, mp_obj_t value, mp_obj
 //|
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t traceback_format_exception(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_etype, ARG_value, ARG_tb, ARG_limit, ARG_chain };
     static const mp_arg_t allowed_args[] = {
@@ -135,6 +136,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(traceback_format_exception_obj, 0, traceback_f
 //|
 //|     """
 //|     ...
+//|
 
 STATIC mp_obj_t traceback_print_exception(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_etype, ARG_value, ARG_tb, ARG_limit, ARG_file, ARG_chain };

--- a/shared-bindings/uheap/__init__.c
+++ b/shared-bindings/uheap/__init__.c
@@ -37,6 +37,7 @@
 //|     """Prints memory debugging info for the given object and returns the
 //|     estimated size."""
 //|     ...
+//|
 STATIC mp_obj_t uheap_info(mp_obj_t obj) {
     uint32_t size = shared_module_uheap_info(obj);
 

--- a/shared-bindings/usb/core/Device.c
+++ b/shared-bindings/usb/core/Device.c
@@ -275,6 +275,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(usb_core_device_detach_kernel_driver_obj, usb_core_dev
 //|         :param int interface: the device interface number to allow CircuitPython to use
 //|         """
 //|         ...
+//|
 STATIC mp_obj_t usb_core_device_attach_kernel_driver(mp_obj_t self_in, mp_obj_t interface_in) {
     usb_core_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_int_t interface = mp_obj_get_int(interface_in);

--- a/shared-bindings/usb/core/__init__.c
+++ b/shared-bindings/usb/core/__init__.c
@@ -45,6 +45,7 @@
 //|     """Catchall exception for USB related errors."""
 //|
 //|     ...
+//|
 MP_DEFINE_USB_CORE_EXCEPTION(USBError, OSError)
 NORETURN void mp_raise_usb_core_USBError(const compressed_string_t *fmt, ...) {
     va_list argptr;
@@ -58,6 +59,7 @@ NORETURN void mp_raise_usb_core_USBError(const compressed_string_t *fmt, ...) {
 //|     """Raised when a USB transfer times out."""
 //|
 //|     ...
+//|
 MP_DEFINE_USB_CORE_EXCEPTION(USBTimeoutError, usb_core_USBError)
 NORETURN void mp_raise_usb_core_USBTimeoutError(void) {
     mp_raise_type(&mp_type_usb_core_USBTimeoutError);
@@ -72,6 +74,7 @@ NORETURN void mp_raise_usb_core_USBTimeoutError(void) {
 //|
 //|     Returns None if no device matches.
 //|     """
+//|
 typedef struct {
     mp_obj_base_t base;
     mp_int_t vid;

--- a/shared-bindings/usb_cdc/Serial.c
+++ b/shared-bindings/usb_cdc/Serial.c
@@ -221,6 +221,7 @@ MP_PROPERTY_GETSET(usb_cdc_serial_timeout_obj,
 //|     """The initial value of `write_timeout` is ``None``. If ``None``, wait indefinitely to finish
 //|     writing all the bytes passed to ``write()``.If 0, do not wait.
 //|     If > 0, wait only ``write_timeout`` seconds."""
+//|
 STATIC mp_obj_t usb_cdc_serial_get_write_timeout(mp_obj_t self_in) {
     usb_cdc_serial_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_float_t write_timeout = common_hal_usb_cdc_serial_get_write_timeout(self);

--- a/shared-bindings/usb_cdc/__init__.c
+++ b/shared-bindings/usb_cdc/__init__.c
@@ -68,6 +68,7 @@
 //|     Can be called in ``boot.py``, before USB is connected.
 //|     Equivalent to ``usb_cdc.enable(console=False, data=False)``."""
 //|     ...
+//|
 STATIC mp_obj_t usb_cdc_disable(void) {
     if (!common_hal_usb_cdc_disable()) {
         mp_raise_RuntimeError(translate("Cannot change USB devices now"));
@@ -90,6 +91,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(usb_cdc_disable_obj, usb_cdc_disable);
 //|     not enough endpoints are available.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t usb_cdc_enable(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_console, ARG_data };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -241,6 +241,7 @@ MP_PROPERTY_GETTER(usb_hid_device_usage_page_obj,
 //|
 //|     For example, Keyboard is 0x06 within the generic desktop usage page 0x01.
 //|     Mouse is 0x02 within the same usage page."""
+//|
 STATIC mp_obj_t usb_hid_device_obj_get_usage(mp_obj_t self_in) {
     usb_hid_device_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return MP_OBJ_NEW_SMALL_INT(common_hal_usb_hid_device_get_usage(self));

--- a/shared-bindings/usb_hid/__init__.c
+++ b/shared-bindings/usb_hid/__init__.c
@@ -56,6 +56,7 @@
 //|     it is disabled by default. You must turn off another USB device such
 //|     as `usb_cdc` or `storage` to free up endpoints for use by `usb_hid`.
 //|     """
+//|
 STATIC mp_obj_t usb_hid_disable(void) {
     if (!common_hal_usb_hid_disable()) {
         mp_raise_RuntimeError(translate("Cannot change USB devices now"));
@@ -107,6 +108,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(usb_hid_disable_obj, usb_hid_disable);
 //|     will enter safe mode to report this error.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t usb_hid_enable(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_devices, ARG_boot_device };
     static const mp_arg_t allowed_args[] = {
@@ -150,6 +152,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(usb_hid_enable_obj, 1, usb_hid_enable);
 //|       if you are using those devices.
 //|     :rtype int:
 //|     """
+//|
 STATIC mp_obj_t usb_hid_get_boot_device(void) {
     return MP_OBJ_NEW_SMALL_INT(common_hal_usb_hid_get_boot_device());
 }

--- a/shared-bindings/usb_host/Port.c
+++ b/shared-bindings/usb_host/Port.c
@@ -76,6 +76,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(usb_host_port_deinit_obj, usb_host_port_obj_deinit);
 //|         """Automatically deinitializes the hardware when exiting a context. See
 //|         :ref:`lifetime-and-contextmanagers` for more info."""
 //|         ...
+//|
 STATIC mp_obj_t usb_host_port_obj___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     common_hal_usb_host_port_deinit(MP_OBJ_TO_PTR(args[0]));

--- a/shared-bindings/usb_midi/PortIn.c
+++ b/shared-bindings/usb_midi/PortIn.c
@@ -63,6 +63,7 @@
 //|         :return: number of bytes read and stored into ``buf``
 //|         :rtype: bytes or None"""
 //|         ...
+//|
 
 // These three methods are used by the shared stream methods.
 STATIC mp_uint_t usb_midi_portin_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {

--- a/shared-bindings/usb_midi/PortOut.c
+++ b/shared-bindings/usb_midi/PortOut.c
@@ -52,6 +52,7 @@
 //|         :return: the number of bytes written
 //|         :rtype: int or None"""
 //|         ...
+//|
 
 STATIC mp_uint_t usb_midi_portout_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
     usb_midi_portout_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/usb_midi/__init__.c
+++ b/shared-bindings/usb_midi/__init__.c
@@ -49,6 +49,7 @@
 //|     including ESP32-S2 and certain STM boards, it is disabled by default.
 //|     Can be called in ``boot.py``, before USB is connected."""
 //|     ...
+//|
 STATIC mp_obj_t usb_midi_disable(void) {
     if (!common_hal_usb_midi_disable()) {
         mp_raise_RuntimeError(translate("Cannot change USB devices now"));
@@ -68,6 +69,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(usb_midi_disable_obj, usb_midi_disable);
 //|     not enough endpoints are available.
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t usb_midi_enable(void) {
     if (!common_hal_usb_midi_enable()) {
         mp_raise_RuntimeError(translate("Cannot change USB devices now"));

--- a/shared-bindings/ustack/__init__.c
+++ b/shared-bindings/ustack/__init__.c
@@ -40,6 +40,7 @@
 //| def max_stack_usage() -> int:
 //|     """Return the maximum excursion of the stack so far."""
 //|     ...
+//|
 STATIC mp_obj_t max_stack_usage(void) {
     return MP_OBJ_NEW_SMALL_INT(shared_module_ustack_max_stack_usage());
 }
@@ -52,6 +53,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(max_stack_usage_obj, max_stack_usage);
 //|     Same as in micropython.mem_info(), but returns a value instead
 //|     of just printing it."""
 //|     ...
+//|
 STATIC mp_obj_t stack_size(void) {
     return MP_OBJ_NEW_SMALL_INT(shared_module_ustack_stack_size());
 }
@@ -61,6 +63,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(stack_size_obj, stack_size);
 //|     """Return how much stack is currently in use.
 //|     Same as micropython.stack_use(); duplicated here for convenience."""
 //|     ...
+//|
 STATIC mp_obj_t stack_usage(void) {
     return MP_OBJ_NEW_SMALL_INT(shared_module_ustack_stack_usage());
 }

--- a/shared-bindings/vectorio/Circle.c
+++ b/shared-bindings/vectorio/Circle.c
@@ -114,6 +114,7 @@ MP_PROPERTY_GETSET(vectorio_circle_color_index_obj,
 //|
 //|     pixel_shader: Union[displayio.ColorConverter, displayio.Palette]
 //|     """The pixel shader of the circle."""
+//|
 
 STATIC const mp_rom_map_elem_t vectorio_circle_locals_dict_table[] = {
     // Functions

--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -123,6 +123,7 @@ MP_PROPERTY_GETSET(vectorio_polygon_color_index_obj,
 //|
 //|     pixel_shader: Union[displayio.ColorConverter, displayio.Palette]
 //|     """The pixel shader of the polygon."""
+//|
 
 STATIC const mp_rom_map_elem_t vectorio_polygon_locals_dict_table[] = {
     // Functions

--- a/shared-bindings/vectorio/Rectangle.c
+++ b/shared-bindings/vectorio/Rectangle.c
@@ -144,6 +144,7 @@ const mp_obj_property_t vectorio_rectangle_color_index_obj = {
 //|
 //|     pixel_shader: Union[displayio.ColorConverter, displayio.Palette]
 //|     """The pixel shader of the rectangle."""
+//|
 
 STATIC const mp_rom_map_elem_t vectorio_rectangle_locals_dict_table[] = {
     // Functions

--- a/shared-bindings/watchdog/WatchDogMode.c
+++ b/shared-bindings/watchdog/WatchDogMode.c
@@ -40,6 +40,7 @@
 //|     """Reset the system if the WatchDogTimer expires.
 //|
 //|     :type WatchDogMode:"""
+//|
 const mp_obj_type_t watchdog_watchdogmode_type;
 
 const watchdog_watchdogmode_obj_t watchdog_watchdogmode_raise_obj = {

--- a/shared-bindings/watchdog/WatchDogTimer.c
+++ b/shared-bindings/watchdog/WatchDogTimer.c
@@ -47,6 +47,7 @@
 //|     A lock up is detected when the watchdog hasn't been fed after a given duration. So, make
 //|     sure to call `feed` within the timeout.
 //|     """
+//|
 
 //|     def __init__(self) -> None:
 //|         """Not currently dynamically supported. Access the sole instance through `microcontroller.watchdog`."""
@@ -120,6 +121,7 @@ MP_PROPERTY_GETSET(watchdog_watchdogtimer_timeout_obj,
 //|
 //|
 //|     Once set, the WatchDogTimer will perform the specified action if the timer expires."""
+//|
 STATIC mp_obj_t watchdog_watchdogtimer_obj_get_mode(mp_obj_t self_in) {
     watchdog_watchdogtimer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     return watchdog_watchdogmode_type_to_obj(common_hal_watchdog_get_mode(self));

--- a/shared-bindings/watchdog/__init__.c
+++ b/shared-bindings/watchdog/__init__.c
@@ -76,6 +76,7 @@
 //|
 //|         print("Exited loop")
 //|     """
+//|
 
 const mp_obj_type_t mp_type_WatchDogTimeout = {
     { &mp_type_type },

--- a/shared-bindings/wifi/AuthMode.c
+++ b/shared-bindings/wifi/AuthMode.c
@@ -59,6 +59,7 @@ MAKE_ENUM_VALUE(wifi_authmode_type, authmode, ENTERPRISE, AUTHMODE_ENTERPRISE);
 //|
 //|     ENTERPRISE: object
 //|     """Each user has a unique credential."""
+//|
 MAKE_ENUM_MAP(wifi_authmode) {
     MAKE_ENUM_MAP_ENTRY(authmode, OPEN),
     MAKE_ENUM_MAP_ENTRY(authmode, WEP),

--- a/shared-bindings/wifi/Monitor.c
+++ b/shared-bindings/wifi/Monitor.c
@@ -34,6 +34,7 @@
 
 //| class Monitor:
 //|     """For monitoring WiFi packets."""
+//|
 
 //| def __init__(self, channel: Optional[int] = 1, queue: Optional[int] = 128) -> None:
 //|     """Initialize `wifi.Monitor` singleton.
@@ -43,6 +44,7 @@
 //|
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t wifi_monitor_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_channel, ARG_queue };
     static const mp_arg_t allowed_args[] = {
@@ -101,6 +103,7 @@ MP_PROPERTY_GETTER(wifi_monitor_queue_obj,
 //| def deinit(self) -> None:
 //|     """De-initialize `wifi.Monitor` singleton."""
 //|     ...
+//|
 STATIC mp_obj_t wifi_monitor_obj_deinit(mp_obj_t self_in) {
     common_hal_wifi_monitor_deinit(self_in);
     return mp_const_none;
@@ -110,6 +113,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(wifi_monitor_deinit_obj, wifi_monitor_obj_deini
 //| def lost(self) -> int:
 //|     """Returns the packet loss count. The counter resets after each poll."""
 //|     ...
+//|
 STATIC mp_obj_t wifi_monitor_obj_get_lost(mp_obj_t self_in) {
     return common_hal_wifi_monitor_get_lost(self_in);
 }
@@ -118,6 +122,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_monitor_lost_obj, wifi_monitor_obj_get_lost);
 //| def queued(self) -> int:
 //|     """Returns the packet queued count."""
 //|     ...
+//|
 STATIC mp_obj_t wifi_monitor_obj_get_queued(mp_obj_t self_in) {
     if (common_hal_wifi_monitor_deinited()) {
         return mp_obj_new_int_from_uint(0);
@@ -129,6 +134,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_monitor_queued_obj, wifi_monitor_obj_get_queued);
 //| def packet(self) -> dict:
 //|     """Returns the monitor packet."""
 //|     ...
+//|
 STATIC mp_obj_t wifi_monitor_obj_get_packet(mp_obj_t self_in) {
     if (common_hal_wifi_monitor_deinited()) {
         raise_deinited_error();

--- a/shared-bindings/wifi/Network.c
+++ b/shared-bindings/wifi/Network.c
@@ -32,6 +32,7 @@
 
 //| class Network:
 //|     """A wifi network provided by a nearby access point."""
+//|
 
 //|     def __init__(self) -> None:
 //|         """You cannot create an instance of `wifi.Network`. They are returned by `wifi.Radio.start_scanning_networks`."""
@@ -97,6 +98,7 @@ MP_PROPERTY_GETTER(wifi_network_country_obj,
 
 //|     authmode: str
 //|     """String id of the authmode"""
+//|
 STATIC mp_obj_t wifi_network_get_authmode(mp_obj_t self) {
     return common_hal_wifi_network_get_authmode(self);
 

--- a/shared-bindings/wifi/Packet.c
+++ b/shared-bindings/wifi/Packet.c
@@ -47,6 +47,7 @@ MAKE_ENUM_VALUE(wifi_packet_type, packet, RSSI, PACKET_RSSI);
 //|
 //|     RSSI: object
 //|     """The packet's rssi."""
+//|
 MAKE_ENUM_MAP(wifi_packet) {
     MAKE_ENUM_MAP_ENTRY(packet, CH),
     MAKE_ENUM_MAP_ENTRY(packet, LEN),

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -78,6 +78,7 @@ STATIC bool hostname_valid(const char *ptr, size_t len) {
 //|     Wifi radio.
 //|
 //|     """
+//|
 
 //|     def __init__(self) -> None:
 //|         """You cannot create an instance of `wifi.Radio`.
@@ -558,6 +559,7 @@ MP_PROPERTY_GETTER(wifi_radio_ap_info_obj,
 //|         """Ping an IP to test connectivity. Returns echo time in seconds.
 //|         Returns None when it times out."""
 //|         ...
+//|
 STATIC mp_obj_t wifi_radio_ping(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_ip, ARG_timeout };
     static const mp_arg_t allowed_args[] = {

--- a/shared-bindings/wifi/ScannedNetworks.c
+++ b/shared-bindings/wifi/ScannedNetworks.c
@@ -35,6 +35,7 @@
 //| class ScannedNetworks:
 //|     """Iterates over all `wifi.Network` objects found while scanning. This object is always created
 //|     by a `wifi.Radio`: it has no user-visible constructor."""
+//|
 STATIC mp_obj_t scannednetworks_iternext(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &wifi_scannednetworks_type));
     wifi_scannednetworks_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -56,6 +57,7 @@ STATIC mp_obj_t scannednetworks_iternext(mp_obj_t self_in) {
 //|         """Returns the next `wifi.Network`.
 //|         Raises `StopIteration` if scanning is finished and no other results are available."""
 //|         ...
+//|
 
 const mp_obj_type_t wifi_scannednetworks_type = {
     { &mp_type_type },

--- a/shared-bindings/zlib/__init__.c
+++ b/shared-bindings/zlib/__init__.c
@@ -70,6 +70,7 @@
 //|     :param int bufsize: ignored for compatibility with CPython only
 //|     """
 //|     ...
+//|
 STATIC mp_obj_t zlib_decompress(size_t n_args, const mp_obj_t *args) {
     bool is_zlib = true;
     if (n_args > 1 && MP_OBJ_SMALL_INT_VALUE(args[1]) < 0) {

--- a/tools/black_bindings.py
+++ b/tools/black_bindings.py
@@ -1,58 +1,117 @@
 #!/usr/bin/python3
-from concurrent.futures import ThreadPoolExecutor
 import os
 import re
 import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from enum import Enum, auto
+
+MARK_C_IN_PY = "##| "
+MARK_PY_IN_C = "//| "
 
 
-def transform(fn, s):
-    lines = s.rstrip().split("\n")
-    lines = [line.removeprefix("//| ").removeprefix("//|") for line in lines]
-    while lines and not lines[0]:
-        del lines[0]
+class Mode(Enum):
+    C = auto()
+    PY = auto()
 
-    s = "\n".join(lines) + "\n"
-    if s[0] == " ":
-        prefix = "if 0:\n"
+
+@dataclass(frozen=True)
+class LineWithMode:
+    data: str
+    mode: Mode
+
+
+class OutputWriter:
+    def __init__(self):
+        self.content = []
+
+    def write(self, line):
+        self.content.append(line.rstrip())
+
+    def getcontent(self):
+        return "\n".join(self.content)
+
+
+class PythonOutputWriter(OutputWriter):
+    def write(self, line):
+        if isinstance(line, str):
+            super().write(line)
+        elif line.mode == Mode.PY:
+            super().write(line.data)
+        else:  # line mode is C
+            super().write(MARK_C_IN_PY + line.data)
+
+
+class COutputWriter(OutputWriter):
+    def write(self, line):
+        if isinstance(line, str):
+            super().write(line)
+        elif line.mode == Mode.PY:
+            super().write(MARK_PY_IN_C + line.data)
+        else:  # line mode is C
+            super().write(line.data)
+
+
+def parse_line(line, defmode, mark, smark, markmode):
+    sline = line.strip()
+    if sline == smark or sline.startswith(mark):
+        return LineWithMode(sline[len(mark) :], markmode)
     else:
-        prefix = ""
-    s = prefix + s
+        return LineWithMode(line, defmode)
+
+
+def parse_lines(lines, defmode, mark, markmode):
+    smark = mark.strip()
+    return [parse_line(line, defmode, mark, smark, markmode) for line in lines]
+
+
+def swap_comment_markers(content, input_mode):
+    lines = content.rstrip().split("\n")
+
+    if input_mode == Mode.C:
+        parsed = parse_lines(lines, Mode.C, MARK_PY_IN_C, Mode.PY)
+        writer = PythonOutputWriter()
+    else:
+        parsed = parse_lines(lines, Mode.PY, MARK_C_IN_PY, Mode.C)
+        writer = COutputWriter()
+
+    for line in parsed:
+        writer.write(line)
+
+    newcontent = writer.getcontent() + "\n"
+
+    return newcontent
+
+
+def process_one_file(fn):
+    with open(fn, "r", encoding="utf-8") as f:
+        c_content = f.read()
+
+    if not "\n//| " in c_content:
+        return
+
+    py_content = swap_comment_markers(c_content, Mode.C)
+
     try:
         # Line length is 95 so that with "//| " the max is 99
         result = subprocess.run(
             ["black", "--pyi", "-l95", "-q", "-"],
-            input=s,
+            input=py_content,
             check=True,
             stdout=subprocess.PIPE,
             encoding="utf-8",
         )
     except subprocess.CalledProcessError as e:
-        print(f"{fn}:0: Failed to process block:\n{s}")
+        print(f"{fn}:0: Failed to process file ")
         raise
 
-    result = result.stdout[len(prefix) :].strip("\n")
-    result = (result.rstrip()).split("\n")
-    return "\n".join("//| " + line if line else "//|" for line in result) + "\n"
+    new_py_content = result.stdout
+    new_c_content = swap_comment_markers(new_py_content, Mode.PY)
 
-
-def process_one_file(fn):
-    with open(fn, "r", encoding="utf-8") as f:
-        content = f.read()
-
-    old_end = 0
-
-    parts = []
-    for m in re.finditer("(?m)((?:^//\|.*\n)(?:^//\|.*\n)*)", content):
-        parts.append(content[old_end : m.start()])
-        parts.append(transform(fn, m.group()))
-        old_end = m.end()
-    parts.append(content[old_end:])
-    newcontent = "".join(parts)
-
-    if newcontent != content:
+    if new_c_content != c_content:
         with open(fn, "w", encoding="utf-8") as f:
-            f.write(newcontent)
+            f.write(new_c_content)
 
 
 if __name__ == "__main__":
@@ -64,6 +123,7 @@ if __name__ == "__main__":
         try:
             f.result()
         except Exception as e:
+            print(e)
             status = 1
     executor.shutdown()
     raise SystemExit(status)


### PR DESCRIPTION
Originally, black_bindings found each contiguous "//|" block and sent it to black independently. This was slower than it needed to be.

Instead, swap the comment prefix: when running black, take off "//|" prefixes and put "##|" prefixes on all un-prefixed lines. Then, after black is run, do the opposite operation.

Also, detect if a file has no "//!" markings and skip running black at all in that case.

This more than doubles the overall speed of "pre-commit run --all", from 3m20s to 55s CPU time on my local machine (32.5s to under 10s "elapsed" time)

It also causes a small amount of churn in the bindings, because black now sees enough context to know whether one 'def' follows another or ends the 'def's in a 'class'. In the latter case, it adds an extra newline, which becomes a "//|" line.

I'm less sure why a trailing comma was omitted before down in rp2pio/StateMachine.c but let's roll with it.