### PR TITLE
Rp2040 fix warnings

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -198,7 +198,7 @@ else
 endif
 
 # Remove -Wno-stringop-overflow after we can test with CI's GCC 10. Mac's looks weird.
-DISABLE_WARNINGS = -Wno-stringop-overflow -Wno-unused-variable -Wno-strict-overflow -Wno-cast-align
+DISABLE_WARNINGS = -Wno-stringop-overflow -Wno-strict-overflow -Wno-cast-align
 
 CFLAGS += $(INC) -Wall -Werror -std=gnu11 -nostdlib -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT) $(DISABLE_WARNINGS) -Werror=missing-prototypes
 
@@ -256,7 +256,7 @@ SRC_SDK := \
 	$(SRC_SDK_CYW43) \
 
 SRC_SDK := $(addprefix sdk/, $(SRC_SDK))
-$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK) $(SRC_CYW43)): CFLAGS += -Wno-missing-prototypes -Wno-undef -Wno-unused-function -Wno-nested-externs -Wno-strict-prototypes -Wno-double-promotion -Wno-sign-compare
+$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK) $(SRC_CYW43)): CFLAGS += -Wno-missing-prototypes -Wno-undef -Wno-unused-function -Wno-nested-externs -Wno-strict-prototypes -Wno-double-promotion -Wno-sign-compare -Wno-unused-variable
 
 SRC_C += \
 	boards/$(BOARD)/board.c \

--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -198,7 +198,7 @@ else
 endif
 
 # Remove -Wno-stringop-overflow after we can test with CI's GCC 10. Mac's looks weird.
-DISABLE_WARNINGS = -Wno-stringop-overflow -Wno-unused-function -Wno-unused-variable -Wno-strict-overflow -Wno-cast-align -Wno-strict-prototypes -Wno-nested-externs -Wno-double-promotion -Wno-sign-compare
+DISABLE_WARNINGS = -Wno-stringop-overflow -Wno-unused-variable -Wno-strict-overflow -Wno-cast-align -Wno-strict-prototypes -Wno-nested-externs -Wno-double-promotion -Wno-sign-compare
 
 CFLAGS += $(INC) -Wall -Werror -std=gnu11 -nostdlib -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT) $(DISABLE_WARNINGS) -Werror=missing-prototypes
 
@@ -256,7 +256,7 @@ SRC_SDK := \
 	$(SRC_SDK_CYW43) \
 
 SRC_SDK := $(addprefix sdk/, $(SRC_SDK))
-$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK) $(SRC_CYW43)): CFLAGS += -Wno-missing-prototypes -Wno-undef
+$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK) $(SRC_CYW43)): CFLAGS += -Wno-missing-prototypes -Wno-undef -Wno-unused-function
 
 SRC_C += \
 	boards/$(BOARD)/board.c \

--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -198,7 +198,7 @@ else
 endif
 
 # Remove -Wno-stringop-overflow after we can test with CI's GCC 10. Mac's looks weird.
-DISABLE_WARNINGS = -Wno-stringop-overflow -Wno-unused-variable -Wno-strict-overflow -Wno-cast-align -Wno-strict-prototypes -Wno-nested-externs -Wno-double-promotion -Wno-sign-compare
+DISABLE_WARNINGS = -Wno-stringop-overflow -Wno-unused-variable -Wno-strict-overflow -Wno-cast-align
 
 CFLAGS += $(INC) -Wall -Werror -std=gnu11 -nostdlib -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT) $(DISABLE_WARNINGS) -Werror=missing-prototypes
 
@@ -256,7 +256,7 @@ SRC_SDK := \
 	$(SRC_SDK_CYW43) \
 
 SRC_SDK := $(addprefix sdk/, $(SRC_SDK))
-$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK) $(SRC_CYW43)): CFLAGS += -Wno-missing-prototypes -Wno-undef -Wno-unused-function
+$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK) $(SRC_CYW43)): CFLAGS += -Wno-missing-prototypes -Wno-undef -Wno-unused-function -Wno-nested-externs -Wno-strict-prototypes -Wno-double-promotion -Wno-sign-compare
 
 SRC_C += \
 	boards/$(BOARD)/board.c \

--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -198,7 +198,7 @@ else
 endif
 
 # Remove -Wno-stringop-overflow after we can test with CI's GCC 10. Mac's looks weird.
-DISABLE_WARNINGS = -Wno-stringop-overflow -Wno-strict-overflow -Wno-cast-align
+DISABLE_WARNINGS = -Wno-stringop-overflow -Wno-cast-align
 
 CFLAGS += $(INC) -Wall -Werror -std=gnu11 -nostdlib -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT) $(DISABLE_WARNINGS) -Werror=missing-prototypes
 
@@ -256,7 +256,7 @@ SRC_SDK := \
 	$(SRC_SDK_CYW43) \
 
 SRC_SDK := $(addprefix sdk/, $(SRC_SDK))
-$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK) $(SRC_CYW43)): CFLAGS += -Wno-missing-prototypes -Wno-undef -Wno-unused-function -Wno-nested-externs -Wno-strict-prototypes -Wno-double-promotion -Wno-sign-compare -Wno-unused-variable
+$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK) $(SRC_CYW43)): CFLAGS += -Wno-missing-prototypes -Wno-undef -Wno-unused-function -Wno-nested-externs -Wno-strict-prototypes -Wno-double-promotion -Wno-sign-compare -Wno-unused-variable -Wno-strict-overflow
 
 SRC_C += \
 	boards/$(BOARD)/board.c \

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -831,10 +831,3 @@ const mp_obj_type_t rp2pio_statemachine_type = {
     .make_new = rp2pio_statemachine_make_new,
     .locals_dict = (mp_obj_dict_t *)&rp2pio_statemachine_locals_dict,
 };
-
-static rp2pio_statemachine_obj_t *validate_obj_is_statemachine(mp_obj_t obj) {
-    if (!mp_obj_is_type(obj, &rp2pio_statemachine_type)) {
-        mp_raise_TypeError_varg(translate("Expected a %q"), rp2pio_statemachine_type.name);
-    }
-    return MP_OBJ_TO_PTR(obj);
-}

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -259,10 +259,10 @@ STATIC mp_obj_t rp2pio_statemachine_make_new(const mp_obj_type_t *type, size_t n
         bufinfo.buf, bufinfo.len / 2,
         args[ARG_frequency].u_int,
         init_bufinfo.buf, init_bufinfo.len / 2,
-        first_out_pin, args[ARG_out_pin_count].u_int, args[ARG_initial_out_pin_state].u_int, args[ARG_initial_out_pin_direction].u_int,
-        first_in_pin, args[ARG_in_pin_count].u_int, args[ARG_pull_in_pin_up].u_int, args[ARG_pull_in_pin_down].u_int,
-        first_set_pin, args[ARG_set_pin_count].u_int, args[ARG_initial_set_pin_state].u_int, args[ARG_initial_set_pin_direction].u_int,
-        first_sideset_pin, args[ARG_sideset_pin_count].u_int, args[ARG_initial_sideset_pin_state].u_int, args[ARG_initial_sideset_pin_direction].u_int,
+        first_out_pin, out_pin_count, args[ARG_initial_out_pin_state].u_int, args[ARG_initial_out_pin_direction].u_int,
+        first_in_pin, in_pin_count, args[ARG_pull_in_pin_up].u_int, args[ARG_pull_in_pin_down].u_int,
+        first_set_pin, set_pin_count, args[ARG_initial_set_pin_state].u_int, args[ARG_initial_set_pin_direction].u_int,
+        first_sideset_pin, sideset_pin_count, args[ARG_initial_sideset_pin_state].u_int, args[ARG_initial_sideset_pin_direction].u_int,
         args[ARG_sideset_enable].u_bool,
         jmp_pin, jmp_pin_pull,
         0,
@@ -397,7 +397,6 @@ STATIC mp_obj_t rp2pio_statemachine_write(size_t n_args, const mp_obj_t *pos_arg
         return mp_const_none;
     }
 
-    uint8_t *original_pointer = bufinfo.buf;
     int stride_in_bytes = mp_binary_get_size('@', bufinfo.typecode, NULL);
     if (stride_in_bytes > 4) {
         mp_raise_ValueError(translate("Buffer elements must be 4 bytes long or less"));
@@ -606,7 +605,6 @@ STATIC mp_obj_t rp2pio_statemachine_readinto(size_t n_args, const mp_obj_t *pos_
         return mp_const_none;
     }
 
-    uint8_t *original_pointer = bufinfo.buf;
     int stride_in_bytes = mp_binary_get_size('@', bufinfo.typecode, NULL);
     if (stride_in_bytes > 4) {
         mp_raise_ValueError(translate("Buffer elements must be 4 bytes long or less"));

--- a/ports/raspberrypi/common-hal/busio/I2C.c
+++ b/ports/raspberrypi/common-hal/busio/I2C.c
@@ -190,7 +190,7 @@ STATIC uint8_t _common_hal_busio_i2c_write(busio_i2c_obj_t *self, uint16_t addr,
         return status;
     }
 
-    int result = i2c_write_timeout_us(self->peripheral, addr, data, len, !transmit_stop_bit, BUS_TIMEOUT_US);
+    size_t result = i2c_write_timeout_us(self->peripheral, addr, data, len, !transmit_stop_bit, BUS_TIMEOUT_US);
     if (result == len) {
         return 0;
     }
@@ -211,7 +211,7 @@ uint8_t common_hal_busio_i2c_write(busio_i2c_obj_t *self, uint16_t addr,
 
 uint8_t common_hal_busio_i2c_read(busio_i2c_obj_t *self, uint16_t addr,
     uint8_t *data, size_t len) {
-    int result = i2c_read_timeout_us(self->peripheral, addr, data, len, false, BUS_TIMEOUT_US);
+    size_t result = i2c_read_timeout_us(self->peripheral, addr, data, len, false, BUS_TIMEOUT_US);
     if (result == len) {
         return 0;
     }

--- a/ports/raspberrypi/common-hal/countio/Counter.c
+++ b/ports/raspberrypi/common-hal/countio/Counter.c
@@ -31,7 +31,6 @@ void common_hal_countio_counter_construct(countio_counter_obj_t *self,
         mp_raise_RuntimeError(translate("PWM slice already in use"));
     }
 
-    uint8_t ab_channel = pwm_gpio_to_channel(self->pin);
     if (!pwmio_claim_slice_ab_channels(self->slice_num)) {
         mp_raise_RuntimeError(translate("PWM slice channel A already in use"));
     }

--- a/ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
+++ b/ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
@@ -158,7 +158,6 @@ digitalinout_result_t common_hal_digitalio_digitalinout_set_drive_mode(
         }
     }
     #endif
-    const uint8_t pin = self->pin->number;
     bool value = common_hal_digitalio_digitalinout_get_value(self);
     self->open_drain = drive_mode == DRIVE_MODE_OPEN_DRAIN;
     // True is implemented differently between modes so reset the value to make

--- a/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.c
+++ b/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.c
@@ -104,10 +104,6 @@ void common_hal_i2ctarget_i2c_target_deinit(i2ctarget_i2c_target_obj_t *self) {
     return;
 }
 
-static int i2c_peripheral_check_error(i2ctarget_i2c_target_obj_t *self, bool raise) {
-    return 0;
-}
-
 int common_hal_i2ctarget_i2c_target_is_addressed(i2ctarget_i2c_target_obj_t *self, uint8_t *address, bool *is_read, bool *is_restart) {
     if (!((self->peripheral->hw->raw_intr_stat & I2C_IC_INTR_STAT_R_RX_FULL_BITS) || (self->peripheral->hw->raw_intr_stat & I2C_IC_INTR_STAT_R_RD_REQ_BITS))) {
         return 0;

--- a/ports/raspberrypi/common-hal/imagecapture/ParallelImageCapture.c
+++ b/ports/raspberrypi/common-hal/imagecapture/ParallelImageCapture.c
@@ -120,11 +120,6 @@ void common_hal_imagecapture_parallelimagecapture_construct(imagecapture_paralle
         true, 32, true,  // in settings
         false, // Not user-interruptible.
         2, 5); // wrap settings
-
-
-    PIO pio = self->state_machine.pio;
-    uint8_t pio_index = pio_get_index(pio);
-    uint sm = self->state_machine.state_machine;
 }
 
 void common_hal_imagecapture_parallelimagecapture_deinit(imagecapture_parallelimagecapture_obj_t *self) {

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -71,7 +71,7 @@ STATIC void *_interrupt_arg[NUM_PIOS][NUM_PIO_STATE_MACHINES];
 STATIC void rp2pio_statemachine_interrupt_handler(void);
 
 static void rp2pio_statemachine_set_pull(uint32_t pull_pin_up, uint32_t pull_pin_down, uint32_t pins_we_use) {
-    for (int i = 0; i < TOTAL_GPIO_COUNT; i++) {
+    for (size_t i = 0; i < TOTAL_GPIO_COUNT; i++) {
         bool used = pins_we_use & (1 << i);
         if (used) {
             bool pull_up = pull_pin_up & (1 << i);
@@ -231,7 +231,7 @@ bool rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
         program_offset = 32;
     }
 
-    int state_machine = -1;
+    size_t state_machine = NUM_PIO_STATE_MACHINES;
     if (pio_index < NUM_PIOS) {
         PIO pio = pio_instances[pio_index];
         for (size_t i = 0; i < NUM_PIOS; i++) {

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -871,7 +871,7 @@ bool common_hal_rp2pio_statemachine_get_txstall(rp2pio_statemachine_obj_t *self)
 }
 
 void common_hal_rp2pio_statemachine_clear_txstall(rp2pio_statemachine_obj_t *self) {
-    uint8_t level = pio_sm_get_rx_fifo_level(self->pio, self->state_machine);
+    (void)pio_sm_get_rx_fifo_level(self->pio, self->state_machine);
     uint32_t stall_mask = 1 << (PIO_FDEBUG_TXSTALL_LSB + self->state_machine);
     self->pio->fdebug = stall_mask;
 }

--- a/ports/raspberrypi/common-hal/rp2pio/__init__.c
+++ b/ports/raspberrypi/common-hal/rp2pio/__init__.c
@@ -33,7 +33,7 @@ bool common_hal_rp2pio_pins_are_sequential(size_t len, mp_obj_t *items) {
         return true;
     }
     const mcu_pin_obj_t *last_pin = validate_obj_is_pin(items[0]);
-    for (int i = 1; i < len; i++) {
+    for (size_t i = 1; i < len; i++) {
         const mcu_pin_obj_t *pin = validate_obj_is_pin(items[i]);
         if (pin->number != last_pin->number + 1) {
             return false;

--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -409,7 +409,7 @@ STATIC mp_uint_t lwip_raw_udp_receive(socketpool_socket_obj_t *socket, byte *buf
         // Wait for data to arrive on UDP socket.
         mp_uint_t start = mp_hal_ticks_ms();
         while (socket->incoming.pbuf == NULL) {
-            if (socket->timeout != -1 && mp_hal_ticks_ms() - start > socket->timeout) {
+            if (socket->timeout != (unsigned)-1 && mp_hal_ticks_ms() - start > socket->timeout) {
                 *_errno = MP_ETIMEDOUT;
                 return -1;
             }
@@ -479,7 +479,7 @@ STATIC mp_uint_t lwip_tcp_send(socketpool_socket_obj_t *socket, const byte *buf,
         // Avoid sending too small packets, so wait until at least 16 bytes available
         while (socket->state >= STATE_CONNECTED && (available = tcp_sndbuf(socket->pcb.tcp)) < 16) {
             MICROPY_PY_LWIP_EXIT
-            if (socket->timeout != -1 && mp_hal_ticks_ms() - start > socket->timeout) {
+            if (socket->timeout != (unsigned)-1 && mp_hal_ticks_ms() - start > socket->timeout) {
                 *_errno = MP_ETIMEDOUT;
                 return MP_STREAM_ERROR;
             }
@@ -546,7 +546,7 @@ STATIC mp_uint_t lwip_tcp_receive(socketpool_socket_obj_t *socket, byte *buf, mp
 
         mp_uint_t start = mp_hal_ticks_ms();
         while (socket->state == STATE_CONNECTED && socket->incoming.pbuf == NULL) {
-            if (socket->timeout != -1 && mp_hal_ticks_ms() - start > socket->timeout) {
+            if (socket->timeout != (unsigned)-1 && mp_hal_ticks_ms() - start > socket->timeout) {
                 *_errno = MP_ETIMEDOUT;
                 return -1;
             }
@@ -778,7 +778,7 @@ socketpool_socket_obj_t *common_hal_socketpool_socket_accept(socketpool_socket_o
             MICROPY_PY_LWIP_EXIT
             m_del_obj(socketpool_socket_obj_t, socket2);
             mp_raise_OSError(MP_EAGAIN);
-        } else if (socket->timeout != -1) {
+        } else if (socket->timeout != (unsigned)-1) {
             mp_uint_t retries = socket->timeout / 100;
             while (*incoming_connection == NULL) {
                 MICROPY_PY_LWIP_EXIT
@@ -952,7 +952,7 @@ void common_hal_socketpool_socket_connect(socketpool_socket_obj_t *socket,
             MICROPY_PY_LWIP_EXIT
 
             // And now we wait...
-            if (socket->timeout != -1) {
+            if (socket->timeout != (unsigned)-1) {
                 for (mp_uint_t retries = socket->timeout / 100; retries--;) {
                     mp_hal_delay_ms(100);
                     if (socket->state != STATE_CONNECTING) {
@@ -1048,7 +1048,7 @@ mp_uint_t common_hal_socketpool_socket_recvfrom_into(socketpool_socket_obj_t *so
             ret = lwip_raw_udp_receive(socket, (byte *)buf, len, ip, port, &_errno);
             break;
     }
-    if (ret == -1) {
+    if (ret == (unsigned)-1) {
         mp_raise_OSError(_errno);
     }
 
@@ -1097,7 +1097,7 @@ int socketpool_socket_send(socketpool_socket_obj_t *socket, const uint8_t *buf, 
             ret = lwip_raw_udp_send(socket, buf, len, NULL, 0, &_errno);
             break;
     }
-    if (ret == -1) {
+    if (ret == (unsigned)-1) {
         return -_errno;
     }
     return ret;
@@ -1134,7 +1134,7 @@ mp_uint_t common_hal_socketpool_socket_sendto(socketpool_socket_obj_t *socket,
             ret = lwip_raw_udp_send(socket, buf, len, &ip, port, &_errno);
             break;
     }
-    if (ret == -1) {
+    if (ret == (unsigned)-1) {
         mp_raise_OSError(_errno);
     }
 

--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -829,7 +829,6 @@ socketpool_socket_obj_t *common_hal_socketpool_socket_accept(socketpool_socket_o
 
 bool common_hal_socketpool_socket_bind(socketpool_socket_obj_t *socket,
     const char *host, size_t hostlen, uint32_t port) {
-    uint8_t ip[NETUTILS_IPV4ADDR_BUFSIZE];
 
     // get address
     ip_addr_t bind_addr;

--- a/ports/raspberrypi/common-hal/wifi/ScannedNetworks.c
+++ b/ports/raspberrypi/common-hal/wifi/ScannedNetworks.c
@@ -52,7 +52,7 @@ static void scan_result_put(const cyw43_ev_scan_result_t *result) {
     }
 }
 
-static bool scan_result_available() {
+static bool scan_result_available(void) {
     return scan_full || (scan_get != scan_put);
 }
 
@@ -83,7 +83,7 @@ static int scan_result(void *env, const cyw43_ev_scan_result_t *result) {
 
 mp_obj_t common_hal_wifi_scannednetworks_next(wifi_scannednetworks_obj_t *self) {
     // no results available, wait for some
-    while (!scan_result_available(self) && cyw43_wifi_scan_active(&cyw43_state)) {
+    while (!scan_result_available() && cyw43_wifi_scan_active(&cyw43_state)) {
         RUN_BACKGROUND_TASKS;
         if (mp_hal_is_interrupted()) {
             return mp_const_none;
@@ -91,7 +91,7 @@ mp_obj_t common_hal_wifi_scannednetworks_next(wifi_scannednetworks_obj_t *self) 
         cyw43_arch_poll();
     }
 
-    if (!scan_result_available(self)) {
+    if (!scan_result_available()) {
         common_hal_wifi_radio_obj.current_scan = NULL;
         return mp_const_none;
     }

--- a/ports/raspberrypi/common-hal/wifi/ScannedNetworks.c
+++ b/ports/raspberrypi/common-hal/wifi/ScannedNetworks.c
@@ -44,11 +44,6 @@ static uint8_t scan_put, scan_get;
 static bool scan_full;
 
 
-static void scan_result_clear() {
-    scan_put = scan_get = 0;
-    scan_full = false;
-}
-
 static void scan_result_put(const cyw43_ev_scan_result_t *result) {
     if (!scan_full) {
         scan_results[scan_put] = *result;

--- a/ports/raspberrypi/common-hal/wifi/__init__.c
+++ b/ports/raspberrypi/common-hal/wifi/__init__.c
@@ -82,7 +82,6 @@ void wifi_reset(void) {
     }
     // the cyw43 wifi chip is not reset due to https://github.com/raspberrypi/pico-sdk/issues/980
     common_hal_wifi_monitor_deinit(MP_STATE_VM(wifi_monitor_singleton));
-    wifi_radio_obj_t *radio = &common_hal_wifi_radio_obj;
     common_hal_wifi_radio_obj.current_scan = NULL;
     // common_hal_wifi_radio_set_enabled(radio, false);
     supervisor_workflow_request_background();

--- a/ports/raspberrypi/lwip_src/ping.c
+++ b/ports/raspberrypi/lwip_src/ping.c
@@ -368,12 +368,6 @@ ping_raw_init(void) {
     sys_timeout(PING_DELAY, ping_timeout, ping_pcb);
 }
 
-static void
-ping_send_now(void) {
-    LWIP_ASSERT("ping_pcb != NULL", ping_pcb != NULL);
-    ping_send(ping_pcb, ping_target);
-}
-
 #endif /* PING_USE_SOCKETS */
 
 void


### PR DESCRIPTION
Several categories of compiler diagnostic are disabled in rp2040. Fix and deal with several of them. The diagnostic disables _ARE_ still applied to SDK source files and header files, which we don't edit when we can avoid it.

None of the code changes are intended to introduce different behaviors.