### PR TITLE
Implement certain supervisor functions as properties

### DIFF
--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -201,9 +201,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(supervisor_runtime_get_rgb_status_brightness_obj, supe
 STATIC mp_obj_t supervisor_runtime_set_rgb_status_brightness(mp_obj_t self, mp_obj_t lvl) {
     #if CIRCUITPY_STATUS_LED
     // This must be int. If cast to uint8_t first, will never raise a ValueError.
-    int brightness_int = mp_obj_get_int(lvl);
-    mp_arg_validate_int_range(brightness_int, 0, 255, MP_QSTR_brightness);
-    set_status_brightness((uint8_t)brightness_int);
+    set_status_brightness((uint8_t)mp_arg_validate_int_range(mp_obj_get_int(lvl), 0, 255, MP_QSTR_brightness));
     #else
     mp_raise_NotImplementedError(NULL);
     #endif

--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -34,6 +34,9 @@
 #include "shared-bindings/supervisor/Runtime.h"
 
 #include "supervisor/shared/reload.h"
+#include "supervisor/shared/stack.h"
+#include "supervisor/shared/status_leds.h"
+#include "supervisor/shared/bluetooth/bluetooth.h"
 
 #if (CIRCUITPY_USB)
 #include "tusb.h"
@@ -134,12 +137,93 @@ MP_PROPERTY_GETSET(supervisor_runtime_autoreload_obj,
     (mp_obj_t)&supervisor_runtime_get_autoreload_obj,
     (mp_obj_t)&supervisor_runtime_set_autoreload_obj);
 
+//|     ble_workflow: bool
+//|     """Enable/Disable ble workflow until a reset. This prevents BLE advertising outside of the VM and
+//|     the services used for it."""
+//|
+STATIC mp_obj_t supervisor_runtime_get_ble_workflow(mp_obj_t self) {
+    #if CIRCUITPY_BLE_FILE_SERVICE && CIRCUITPY_SERIAL_BLE
+    return mp_obj_new_bool(supervisor_bluetooth_workflow_is_enabled());
+    #else
+    return mp_const_false;
+    #endif
+}
+MP_DEFINE_CONST_FUN_OBJ_1(supervisor_runtime_get_ble_workflow_obj, supervisor_runtime_get_ble_workflow);
+
+STATIC mp_obj_t supervisor_runtime_set_ble_workflow(mp_obj_t self, mp_obj_t state_in) {
+    #if CIRCUITPY_BLE_FILE_SERVICE && CIRCUITPY_SERIAL_BLE
+    if (mp_obj_is_true(state_in)) {
+        supervisor_bluetooth_enable_workflow();
+    } else {
+        supervisor_bluetooth_disable_workflow();
+    }
+    #else
+    mp_raise_NotImplementedError(NULL);
+    #endif
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(supervisor_runtime_set_ble_workflow_obj, supervisor_runtime_set_ble_workflow);
+
+MP_PROPERTY_GETSET(supervisor_runtime_ble_workflow_obj,
+    (mp_obj_t)&supervisor_runtime_get_ble_workflow_obj,
+    (mp_obj_t)&supervisor_runtime_set_ble_workflow_obj);
+
+//|     next_stack_limit: int
+//|     """The size of the stack for the next vm run. If its too large, the default will be used."""
+//|
+STATIC mp_obj_t supervisor_runtime_get_next_stack_limit(mp_obj_t self) {
+    return mp_obj_new_int(get_next_stack_size());
+}
+MP_DEFINE_CONST_FUN_OBJ_1(supervisor_runtime_get_next_stack_limit_obj, supervisor_runtime_get_next_stack_limit);
+
+STATIC mp_obj_t supervisor_runtime_set_next_stack_limit(mp_obj_t self, mp_obj_t size_obj) {
+    mp_int_t size = mp_obj_get_int(size_obj);
+    mp_arg_validate_int_min(size, 256, MP_QSTR_size);
+    set_next_stack_size(size);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(supervisor_runtime_set_next_stack_limit_obj, supervisor_runtime_set_next_stack_limit);
+
+MP_PROPERTY_GETSET(supervisor_runtime_next_stack_limit_obj,
+    (mp_obj_t)&supervisor_runtime_get_next_stack_limit_obj,
+    (mp_obj_t)&supervisor_runtime_set_next_stack_limit_obj);
+
+//|     rgb_status_brightness: int
+//|     """Set brightness of status RGB LED from 0-255. This will take effect
+//|     after the current code finishes and the status LED is used to show
+//|     the finish state."""
+//|
+STATIC mp_obj_t supervisor_runtime_get_rgb_status_brightness(mp_obj_t self) {
+    return MP_OBJ_NEW_SMALL_INT(get_status_brightness());
+}
+MP_DEFINE_CONST_FUN_OBJ_1(supervisor_runtime_get_rgb_status_brightness_obj, supervisor_runtime_get_rgb_status_brightness);
+
+STATIC mp_obj_t supervisor_runtime_set_rgb_status_brightness(mp_obj_t self, mp_obj_t lvl) {
+    #if CIRCUITPY_STATUS_LED
+    // This must be int. If cast to uint8_t first, will never raise a ValueError.
+    int brightness_int = mp_obj_get_int(lvl);
+    mp_arg_validate_int_range(brightness_int, 0, 255, MP_QSTR_brightness);
+    set_status_brightness((uint8_t)brightness_int);
+    #else
+    mp_raise_NotImplementedError(NULL);
+    #endif
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(supervisor_runtime_set_rgb_status_brightness_obj, supervisor_runtime_set_rgb_status_brightness);
+
+MP_PROPERTY_GETSET(supervisor_runtime_rgb_status_brightness_obj,
+    (mp_obj_t)&supervisor_runtime_get_rgb_status_brightness_obj,
+    (mp_obj_t)&supervisor_runtime_set_rgb_status_brightness_obj);
+
 STATIC const mp_rom_map_elem_t supervisor_runtime_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_usb_connected), MP_ROM_PTR(&supervisor_runtime_usb_connected_obj) },
     { MP_ROM_QSTR(MP_QSTR_serial_connected), MP_ROM_PTR(&supervisor_runtime_serial_connected_obj) },
     { MP_ROM_QSTR(MP_QSTR_serial_bytes_available), MP_ROM_PTR(&supervisor_runtime_serial_bytes_available_obj) },
     { MP_ROM_QSTR(MP_QSTR_run_reason), MP_ROM_PTR(&supervisor_runtime_run_reason_obj) },
     { MP_ROM_QSTR(MP_QSTR_autoreload), MP_ROM_PTR(&supervisor_runtime_autoreload_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ble_workflow),  MP_ROM_PTR(&supervisor_runtime_ble_workflow_obj) },
+    { MP_ROM_QSTR(MP_QSTR_next_stack_limit),  MP_ROM_PTR(&supervisor_runtime_next_stack_limit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rgb_status_brightness),  MP_ROM_PTR(&supervisor_runtime_rgb_status_brightness_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(supervisor_runtime_locals_dict, supervisor_runtime_locals_dict_table);

--- a/shared-bindings/supervisor/__init__.c
+++ b/shared-bindings/supervisor/__init__.c
@@ -30,11 +30,8 @@
 #include "py/objstr.h"
 
 #include "shared/runtime/interrupt_char.h"
-#include "supervisor/shared/bluetooth/bluetooth.h"
 #include "supervisor/shared/display.h"
-#include "supervisor/shared/status_leds.h"
 #include "supervisor/shared/reload.h"
-#include "supervisor/shared/stack.h"
 #include "supervisor/shared/traceback.h"
 #include "supervisor/shared/translate/translate.h"
 #include "supervisor/shared/workflow.h"
@@ -63,21 +60,6 @@
 //| the last exception name and location, and firmware version information.
 //| This object is the sole instance of `supervisor.StatusBar`."""
 
-//| def set_rgb_status_brightness(brightness: int) -> None:
-//|     """Set brightness of status RGB LED from 0-255. This will take effect
-//|     after the current code finishes and the status LED is used to show
-//|     the finish state."""
-//|     ...
-//|
-STATIC mp_obj_t supervisor_set_rgb_status_brightness(mp_obj_t lvl) {
-    // This must be int. If cast to uint8_t first, will never raise a ValueError.
-    int brightness_int = mp_obj_get_int(lvl);
-    mp_arg_validate_int_range(brightness_int, 0, 255, MP_QSTR_brightness);
-    set_status_brightness((uint8_t)brightness_int);
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_1(supervisor_set_rgb_status_brightness_obj, supervisor_set_rgb_status_brightness);
-
 //| def reload() -> None:
 //|     """Reload the main Python code and run it (equivalent to hitting Ctrl-D at the REPL)."""
 //|     ...
@@ -87,21 +69,6 @@ STATIC mp_obj_t supervisor_reload(void) {
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(supervisor_reload_obj, supervisor_reload);
-
-//| def set_next_stack_limit(size: int) -> None:
-//|     """Set the size of the stack for the next vm run. If its too large, the default will be used."""
-//|     ...
-//|
-STATIC mp_obj_t supervisor_set_next_stack_limit(mp_obj_t size_obj) {
-    mp_int_t size = mp_obj_get_int(size_obj);
-
-    mp_arg_validate_int_min(size, 256, MP_QSTR_size);
-
-    set_next_stack_size(size);
-
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_1(supervisor_set_next_stack_limit_obj, supervisor_set_next_stack_limit);
 
 //| def set_next_code_file(
 //|     filename: Optional[str],
@@ -278,21 +245,6 @@ STATIC mp_obj_t supervisor_get_previous_traceback(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(supervisor_get_previous_traceback_obj, supervisor_get_previous_traceback);
 
-//| def disable_ble_workflow() -> None:
-//|     """Disable ble workflow until a reset. This prevents BLE advertising outside of the VM and
-//|     the services used for it."""
-//|     ...
-//|
-STATIC mp_obj_t supervisor_disable_ble_workflow(void) {
-    #if !CIRCUITPY_BLE_FILE_SERVICE && !CIRCUITPY_SERIAL_BLE
-    mp_raise_NotImplementedError(NULL);
-    #else
-    supervisor_bluetooth_disable_workflow();
-    #endif
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_0(supervisor_disable_ble_workflow_obj, supervisor_disable_ble_workflow);
-
 //| def reset_terminal(x_pixels: int, y_pixels: int) -> None:
 //|     """Reset the CircuitPython serial terminal with new dimensions."""
 //|     ...
@@ -380,15 +332,12 @@ MP_DEFINE_CONST_FUN_OBJ_KW(supervisor_set_usb_identification_obj, 0, supervisor_
 
 STATIC const mp_rom_map_elem_t supervisor_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_supervisor) },
-    { MP_ROM_QSTR(MP_QSTR_set_rgb_status_brightness),  MP_ROM_PTR(&supervisor_set_rgb_status_brightness_obj) },
     { MP_ROM_QSTR(MP_QSTR_runtime),  MP_ROM_PTR(&common_hal_supervisor_runtime_obj) },
     { MP_ROM_QSTR(MP_QSTR_reload),  MP_ROM_PTR(&supervisor_reload_obj) },
     { MP_ROM_QSTR(MP_QSTR_RunReason),  MP_ROM_PTR(&supervisor_run_reason_type) },
-    { MP_ROM_QSTR(MP_QSTR_set_next_stack_limit),  MP_ROM_PTR(&supervisor_set_next_stack_limit_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_next_code_file),  MP_ROM_PTR(&supervisor_set_next_code_file_obj) },
     { MP_ROM_QSTR(MP_QSTR_ticks_ms),  MP_ROM_PTR(&supervisor_ticks_ms_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_previous_traceback),  MP_ROM_PTR(&supervisor_get_previous_traceback_obj) },
-    { MP_ROM_QSTR(MP_QSTR_disable_ble_workflow),  MP_ROM_PTR(&supervisor_disable_ble_workflow_obj) },
     { MP_ROM_QSTR(MP_QSTR_reset_terminal),  MP_ROM_PTR(&supervisor_reset_terminal_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_usb_identification),  MP_ROM_PTR(&supervisor_set_usb_identification_obj) },
     { MP_ROM_QSTR(MP_QSTR_status_bar),  MP_ROM_PTR(&shared_module_supervisor_status_bar_obj) },

--- a/supervisor/shared/bluetooth/bluetooth.c
+++ b/supervisor/shared/bluetooth/bluetooth.c
@@ -354,7 +354,6 @@ void supervisor_bluetooth_enable_workflow(void) {
     if (workflow_state == WORKFLOW_DISABLED) {
         return;
     }
-
     workflow_state = WORKFLOW_ENABLED;
     #endif
 }
@@ -363,4 +362,13 @@ void supervisor_bluetooth_disable_workflow(void) {
     #if CIRCUITPY_BLE_FILE_SERVICE || CIRCUITPY_SERIAL_BLE
     workflow_state = WORKFLOW_DISABLED;
     #endif
+}
+
+bool supervisor_bluetooth_workflow_is_enabled(void) {
+    #if CIRCUITPY_BLE_FILE_SERVICE || CIRCUITPY_SERIAL_BLE
+    if (workflow_state == 1) {
+        return true;
+    }
+    #endif
+    return false;
 }

--- a/supervisor/shared/bluetooth/bluetooth.h
+++ b/supervisor/shared/bluetooth/bluetooth.h
@@ -37,6 +37,7 @@ void supervisor_stop_bluetooth(void);
 // Enable only works if it hasn't been set yet.
 void supervisor_bluetooth_enable_workflow(void);
 void supervisor_bluetooth_disable_workflow(void);
+bool supervisor_bluetooth_workflow_is_enabled(void);
 
 // Title bar status
 bool supervisor_bluetooth_status_dirty(void);

--- a/supervisor/shared/stack.c
+++ b/supervisor/shared/stack.c
@@ -107,6 +107,10 @@ void set_next_stack_size(uint32_t size) {
     next_stack_size = size;
 }
 
+uint32_t get_next_stack_size(void) {
+    return next_stack_size;
+}
+
 uint32_t get_current_stack_size(void) {
     return current_stack_size;
 }

--- a/supervisor/shared/stack.h
+++ b/supervisor/shared/stack.h
@@ -38,6 +38,7 @@ uint32_t *stack_get_bottom(void);
 size_t stack_get_length(void);
 // Next/current requested stack size.
 void set_next_stack_size(uint32_t size);
+uint32_t get_next_stack_size(void);
 uint32_t get_current_stack_size(void);
 bool stack_ok(void);
 

--- a/supervisor/shared/status_leds.c
+++ b/supervisor/shared/status_leds.c
@@ -330,6 +330,14 @@ void set_status_brightness(uint8_t level) {
     #endif
 }
 
+uint8_t get_status_brightness(void) {
+    #if CIRCUITPY_STATUS_LED
+    return rgb_status_brightness;
+    #else
+    return 0;
+    #endif
+}
+
 void init_rxtx_leds(void) {
     #if CIRCUITPY_DIGITALIO && defined(MICROPY_HW_LED_RX)
     common_hal_digitalio_digitalinout_construct(&rx_led, MICROPY_HW_LED_RX);

--- a/supervisor/shared/status_leds.h
+++ b/supervisor/shared/status_leds.h
@@ -53,6 +53,7 @@ void new_status_color(uint32_t rgb);
 
 uint32_t color_brightness(uint32_t color, uint8_t brightness);
 void set_status_brightness(uint8_t level);
+uint8_t get_status_brightness(void);
 
 void init_rxtx_leds(void);
 void deinit_rxtx_leds(void);


### PR DESCRIPTION
Implements the following as `supervisor.runtime` properties:
- disable_ble_workflow
- set_next_stack_limit
- set_rgb_status_brightness