### PR TITLE
Fix mask for minutes field when computing modified_ns

### DIFF
--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -660,7 +660,7 @@ static void _reply_directory_json(socketpool_socket_obj_t *socket, _request *req
             (file_info.fdate >> 5) & 0xf,
             file_info.fdate & 0x1f,
             file_info.ftime >> 11,
-            (file_info.ftime >> 5) & 0x1f,
+            (file_info.ftime >> 5) & 0x3f,
             (file_info.ftime & 0x1f) * 2);
 
         // Manually append zeros to make the time nanoseconds. Support for printing 64 bit numbers


### PR DESCRIPTION
While building a tool that syncs code to my board via web workflow, I noticed that even after syncing, some files had mtimes 32 minutes older than the file being copied. 

I found that _reply_directory_json was using a 5-bit mask for the minutes field when decoding the file time, but the minutes field is 6 bits wide. This PR corrects the mask.