### PR TITLE
I2ctarget doc function request: a) mods to doc text & function signature. b) small mod of the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ TAGS
 
 # Uncrustify formatting
 *.uncrustify
+ports/broadcom/firmware

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,4 @@ TAGS
 .venv
 .env
 
-# Uncrustify formatting
-*.uncrustify
-ports/broadcom/firmware
+

--- a/.gitignore
+++ b/.gitignore
@@ -88,4 +88,6 @@ TAGS
 .venv
 .env
 
+# Uncrustify formatting
+*.uncrustify
 

--- a/shared-bindings/i2ctarget/I2CTarget.c
+++ b/shared-bindings/i2ctarget/I2CTarget.c
@@ -130,7 +130,7 @@ STATIC mp_obj_t i2ctarget_i2c_target_obj___exit__(size_t n_args, const mp_obj_t 
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(i2ctarget_i2c_target___exit___obj, 4, 4, i2ctarget_i2c_target_obj___exit__);
 
-//|     def request(self, *, timeout: int = -1) -> I2CTargetRequest:
+//|     def request(self, *, timeout: float = -1) -> I2CTargetRequest:
 //|         """Wait for an I2C request.
 //|
 //|         :param float timeout: Timeout in seconds. Zero means wait forever, a negative value means check once

--- a/shared-bindings/i2ctarget/I2CTarget.c
+++ b/shared-bindings/i2ctarget/I2CTarget.c
@@ -130,7 +130,7 @@ STATIC mp_obj_t i2ctarget_i2c_target_obj___exit__(size_t n_args, const mp_obj_t 
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(i2ctarget_i2c_target___exit___obj, 4, 4, i2ctarget_i2c_target_obj___exit__);
 
-//|     def request(self, timeout: float = -1) -> I2CTargetRequest:
+//|     def request(self, *, timeout: int = -1) -> I2CTargetRequest:
 //|         """Wait for an I2C request.
 //|
 //|         :param float timeout: Timeout in seconds. Zero means wait forever, a negative value means check once

--- a/shared-bindings/i2ctarget/I2CTarget.c
+++ b/shared-bindings/i2ctarget/I2CTarget.c
@@ -159,7 +159,7 @@ STATIC mp_obj_t i2ctarget_i2c_target_request(size_t n_args, const mp_obj_t *pos_
 
     bool forever = false;
     uint64_t timeout_end = 0;
-    if (timeout_ms == 0) {
+    if (timeout_ms <= 0) {
         forever = true;
     } else if (timeout_ms > 0) {
         timeout_end = common_hal_time_monotonic_ms() + timeout_ms;


### PR DESCRIPTION
**Intro**

First a remark to the choice of the name of my branch 'i2ctarget_doc_text_mod'. This title was chosen because, initially, the (first) modification suggested in this PR was limited to the doc text of the function 'request' of the class 'I2CTarget' and the function signature inside that text. 
As I will explain below, in this moment, the title of this PR is broader. This PR also contains a suggestion for a small change into the code of the function 'request'.

**Subject 1: Initial error**

While busy with a test script using the I2CTarget class, a run of my script, when calling the function 'request', resulted in the error 'Extra positional arguments given'

On October 1, at 1:58 pm (utc +1) I posted a question on Discord > Adafruit > circuitpython-dev:

![2022-10-01_13h48_I2CTarget request_error](https://user-images.githubusercontent.com/9107950/193599239-ccb74455-6746-49d5-a844-611acc87d120.png)

@jepler answered to my question. He explained me that his was caused because of the function signature:

![I2CTarget request_function_signature_original](https://user-images.githubusercontent.com/9107950/193602198-2b5d15cb-1027-4ddb-bad9-4e026444fd8c.png)

@jepler showed me that the following change would solve the error:

![I2CTarget request_doc_txt_change_suggestion](https://user-images.githubusercontent.com/9107950/193602722-e554e6ab-a59a-4cd2-9a2e-c16dbf2bb4e4.png)

At the end of our conversation @jepler showed me a REPL test output as well as his suggestion to me: 'An issue, or better yet a PR to fix it, would be appreciated from you once you've verified it as well. '

![2022-10-01_14h16_Discord_Adafruit_CPY-dev_2nd_reply_fm_jepler](https://user-images.githubusercontent.com/9107950/193599498-4bb7a011-f7f3-4dc9-9c2d-c73301a2ef89.png)

As result of the conversation with @jepler I suggest the following change in the function signature of function 'request':


![I2CTarget request_doc_txt_change_suggestion](https://user-images.githubusercontent.com/9107950/193600535-296dcb38-eb28-4a3f-9a1f-4ede657a2b57.png)

**Subject 2: range parameter timeout**

Today, October 3, 2022, I was studying the code of file I2CTarget.c
My attention went in particular to: Class I2CTarget, function: 'request'

While the conversation with @jepler on Discord is the reason for this PR and the suggested change is concerning the doc text preceding the function 'request' and a change of the function signature, today I discovered that the definition of function 'request' defaults parameter 'timeout to -1'. However, the code inside the function checks timeout in the 'if block' for value 0 and - in the 'else if' block - for values > 0. (see below). While the function defaults parameter 'timeout' to -1, the block: ```

```
if (timeout_ms == 0) {
        forever = true;
    } else if (timeout_ms > 0) {
        timeout_end = common_hal_time_monotonic_ms() + timeout_ms;
    }
```

does not check for parameter timeout values < 0.
That is why I suggest the following change: ```

```
if (timeout_ms <= 0) {
        forever = true;
    } else if (timeout_ms > 0) {
        timeout_end = common_hal_time_monotonic_ms() + timeout_ms;
    }
```

![truth_table](https://user-images.githubusercontent.com/9107950/193595949-a7574465-cc0e-4d12-be22-6d8ba8d5d85e.png)

The result of my modification is that parameter 'timeout' now is checked for a full range of possible float values:

(float max negative)  <= 0  > (float max positive)

while the current code checks a limited range of values for timeout:

 0 > (float max positive)

**Final note: concerning  the first commit to this branch**

To be able to create this PR, online I created a fresh fork of Circuitpython. Next, using the MS Windows 11 Github desktop app, I created a local clone of the fork. Then I created this branch. After the Github desktop app was ready with cloning and arranging things, the app immediately confronted me with a 'change' it assumed I had done in file /ports/broadcom/firmware. 

![uncrustify_initial](https://user-images.githubusercontent.com/9107950/193609419-3e9525aa-895c-4a31-9d2a-38a126b899ca.png)

However I did not do such a thing. Since I am not very familiar with the ins and outs of Github commands regarding cloning, creating branches and so on, I did not know what to do with it. Today I discovered that the possible reason for Github desktop app to tell me I made a change in /ports/broadcom/firmware, was that I saw this file being mentioned at the end of the '.gitignore' under 'uncrustify'.
I removed the filename '/ports/broadcom/firmware' entry there, resulting in:

![uncrustify](https://user-images.githubusercontent.com/9107950/193607428-1551f77b-e752-4aeb-a0a2-c269442b164a.png)

Now the contents of the .gitignore file in this branch (at least the last few lines of it) is equal to the contents of  the .gitignore file of the 'main' branch of the 'circuitpython repo.

This ends my description of the reasons for creating this PR and the examples/clarifications to the matter.
I thank @jepler for his replies, assistance and to 'push' me (kindly) to create this PR.

Lisbon, October, 3, 4:16 pm local (utc +1),
Paulus Schulinck, @PaulskPt
