### PR TITLE
Have cyw43.CywPin reference the class, not a string

### DIFF
--- a/ports/raspberrypi/bindings/cyw43/__init__.c
+++ b/ports/raspberrypi/bindings/cyw43/__init__.c
@@ -125,7 +125,7 @@ const mcu_pin_obj_t *validate_obj_is_free_pin_including_cyw43(mp_obj_t obj) {
 
 STATIC const mp_rom_map_elem_t cyw43_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_cyw43) },
-    { MP_ROM_QSTR(MP_QSTR_CywPin), MP_ROM_QSTR(MP_QSTR_CywPin) },
+    { MP_ROM_QSTR(MP_QSTR_CywPin), MP_ROM_PTR(&cyw43_pin_type) },
     { MP_ROM_QSTR(MP_QSTR_set_power_management), &cyw43_set_power_management_obj },
     { MP_ROM_QSTR(MP_QSTR_get_power_management), &cyw43_get_power_management_obj },
     { MP_ROM_QSTR(MP_QSTR_PM_STANDARD), MP_ROM_INT(PM_STANDARD) },


### PR DESCRIPTION
On picow:
```py
>>> isinstance(board.LED, cyw43.CywPin)
True
```