### PR TITLE
pico w: pins improvements

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -65,7 +65,7 @@ INC_CYW43 := \
 	-isystem sdk/src/rp2_common/pico_cyw43_arch/include/ \
 	-isystem sdk/src/rp2_common/pico_lwip/include/ \
 
-CFLAGS_CYW43 := -DCYW43_LWIP=1 -DPICO_CYW43_ARCH_THREADSAFE_BACKGROUND=1 -DCYW43_USE_SPI -DIGNORE_GPIO25 -DIGNORE_GPIO23 -DCYW43_LOGIC_DEBUG=0
+CFLAGS_CYW43 := -DCYW43_LWIP=1 -DPICO_CYW43_ARCH_THREADSAFE_BACKGROUND=1 -DCYW43_USE_SPI -DIGNORE_GPIO25 -DIGNORE_GPIO23 -DIGNORE_GPIO24 -DCYW43_LOGIC_DEBUG=0
 SRC_SDK_CYW43 := \
 	src/common/pico_sync/sem.c \
 	src/rp2_common/cyw43_driver/cyw43_bus_pio_spi.c \

--- a/ports/raspberrypi/boards/raspberry_pi_pico_w/pins.c
+++ b/ports/raspberrypi/boards/raspberry_pi_pico_w/pins.c
@@ -28,13 +28,10 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_GP22), MP_ROM_PTR(&pin_GPIO22) },
 
     { MP_ROM_QSTR(MP_QSTR_SMPS_MODE), MP_ROM_PTR(&pin_CYW1) },
-    { MP_ROM_QSTR(MP_QSTR_GP23), MP_ROM_PTR(&pin_CYW1) },
-
-    { MP_ROM_QSTR(MP_QSTR_VBUS_SENSE), MP_ROM_PTR(&pin_GPIO24) },
-    { MP_ROM_QSTR(MP_QSTR_GP24), MP_ROM_PTR(&pin_GPIO24) },
 
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_CYW0) },
-    { MP_ROM_QSTR(MP_QSTR_CYW0), MP_ROM_PTR(&pin_CYW0) },
+
+    { MP_ROM_QSTR(MP_QSTR_VBUS_SENSE), MP_ROM_PTR(&pin_CYW2) },
 
     { MP_ROM_QSTR(MP_QSTR_GP26_A0), MP_ROM_PTR(&pin_GPIO26) },
     { MP_ROM_QSTR(MP_QSTR_GP26), MP_ROM_PTR(&pin_GPIO26) },
@@ -47,8 +44,5 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_GP28_A2), MP_ROM_PTR(&pin_GPIO28) },
     { MP_ROM_QSTR(MP_QSTR_GP28), MP_ROM_PTR(&pin_GPIO28) },
     { MP_ROM_QSTR(MP_QSTR_A2), MP_ROM_PTR(&pin_GPIO28) },
-
-    { MP_ROM_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_GPIO29) },
-    { MP_ROM_QSTR(MP_QSTR_VOLTAGE_MONITOR), MP_ROM_PTR(&pin_GPIO29) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/raspberrypi/common-hal/microcontroller/__init__.c
+++ b/ports/raspberrypi/common-hal/microcontroller/__init__.c
@@ -176,7 +176,9 @@ const mp_rom_map_elem_t mcu_pin_global_dict_table[TOTAL_GPIO_COUNT] = {
     #if !defined(IGNORE_GPIO23)
     { MP_ROM_QSTR(MP_QSTR_GPIO23), MP_ROM_PTR(&pin_GPIO23) },
     #endif
+    #if !defined(IGNORE_GPIO24)
     { MP_ROM_QSTR(MP_QSTR_GPIO24), MP_ROM_PTR(&pin_GPIO24) },
+    #endif
     #if !defined(IGNORE_GPIO25)
     { MP_ROM_QSTR(MP_QSTR_GPIO25), MP_ROM_PTR(&pin_GPIO25) },
     #endif
@@ -187,6 +189,7 @@ const mp_rom_map_elem_t mcu_pin_global_dict_table[TOTAL_GPIO_COUNT] = {
     #if CIRCUITPY_CYW43
     { MP_ROM_QSTR(MP_QSTR_CYW0), MP_ROM_PTR(&pin_CYW0) },
     { MP_ROM_QSTR(MP_QSTR_CYW1), MP_ROM_PTR(&pin_CYW1) },
+    { MP_ROM_QSTR(MP_QSTR_CYW2), MP_ROM_PTR(&pin_CYW2) },
     #endif
 };
 MP_DEFINE_CONST_DICT(mcu_pin_globals, mcu_pin_global_dict_table);

--- a/ports/raspberrypi/peripherals/pins.c
+++ b/ports/raspberrypi/peripherals/pins.c
@@ -64,8 +64,12 @@ PIN(19);
 PIN(20);
 PIN(21);
 PIN(22);
+#if !defined(IGNORE_GPIO23)
 PIN(23);
+#endif
+#if !defined(IGNORE_GPIO24)
 PIN(24);
+#endif
 #if !defined(IGNORE_GPIO25)
 PIN(25);
 #endif
@@ -76,4 +80,5 @@ PIN(29);
 #if CIRCUITPY_CYW43
 CYW_PIN(0);
 CYW_PIN(1);
+CYW_PIN(2);
 #endif

--- a/ports/raspberrypi/peripherals/pins.h
+++ b/ports/raspberrypi/peripherals/pins.h
@@ -73,6 +73,7 @@ extern const mcu_pin_obj_t pin_GPIO29;
 #if CIRCUITPY_CYW43
 extern const mcu_pin_obj_t pin_CYW0;
 extern const mcu_pin_obj_t pin_CYW1;
+extern const mcu_pin_obj_t pin_CYW2;
 #endif
 
 #endif  // MICROPY_INCLUDED_RASPBERRYPI_PERIPHERALS_PINS_H


### PR DESCRIPTION
Closes: #7017

 * Remove the 'GP23' alias for CYW1
 * Remove the 'CYW0' alias for CYW0
 * Switch VBUS_SENSE to CYW2, remove 'GP24' alias

Code that wants to use SMPS_MODE, VBUS_SENSE and LED while being portable to the W and non-W variants should use those names, not alias names.

 * Remove A3 / VOLTAGE_MONITOR

Right now the voltage monitor cannot be used. The ability to check the voltage monitor should be added back in some fashion in the future. (#7020)