### PR TITLE
Remove redundant header files in STM port

### DIFF
--- a/ports/stm/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/stm/common-hal/alarm/pin/PinAlarm.c
@@ -27,8 +27,6 @@
 #include "py/runtime.h"
 
 #include "shared-bindings/alarm/pin/PinAlarm.h"
-#include "shared-bindings/microcontroller/__init__.h"
-#include "shared-bindings/microcontroller/Pin.h"
 
 #include "peripherals/exti.h"
 

--- a/ports/stm/common-hal/alarm/time/TimeAlarm.c
+++ b/ports/stm/common-hal/alarm/time/TimeAlarm.c
@@ -28,7 +28,6 @@
 
 #include "shared-bindings/alarm/time/TimeAlarm.h"
 #include "shared-bindings/time/__init__.h"
-#include "supervisor/port.h"
 #include "peripherals/rtc.h"
 
 #include STM32_HAL_H

--- a/ports/stm/common-hal/analogio/AnalogOut.c
+++ b/ports/stm/common-hal/analogio/AnalogOut.c
@@ -28,8 +28,11 @@
 #include <stdint.h>
 #include <string.h>
 
+
 #include "py/mperrno.h"
 #include "py/runtime.h"
+
+
 
 #include "shared-bindings/analogio/AnalogOut.h"
 #include "shared-bindings/microcontroller/Pin.h"

--- a/ports/stm/common-hal/busio/I2C.c
+++ b/ports/stm/common-hal/busio/I2C.c
@@ -30,7 +30,6 @@
 #include "py/mperrno.h"
 #include "py/runtime.h"
 
-#include "shared-bindings/microcontroller/__init__.h"
 #include "supervisor/shared/translate/translate.h"
 #include "shared-bindings/microcontroller/Pin.h"
 

--- a/ports/stm/common-hal/busio/SPI.c
+++ b/ports/stm/common-hal/busio/SPI.c
@@ -28,11 +28,8 @@
 #include <string.h>
 
 #include "shared-bindings/busio/SPI.h"
-#include "py/mperrno.h"
 #include "py/runtime.h"
 
-#include "shared-bindings/microcontroller/__init__.h"
-#include "supervisor/board.h"
 #include "supervisor/shared/translate/translate.h"
 #include "shared-bindings/microcontroller/Pin.h"
 

--- a/ports/stm/common-hal/digitalio/DigitalInOut.c
+++ b/ports/stm/common-hal/digitalio/DigitalInOut.c
@@ -27,8 +27,6 @@
 
 #include "shared-bindings/digitalio/DigitalInOut.h"
 #include "shared-bindings/microcontroller/Pin.h"
-#include "py/runtime.h"
-#include "supervisor/shared/translate/translate.h"
 
 // The HAL is sparse on obtaining register information, so we use the LLs here.
 #if (CPY_STM32H7)

--- a/ports/stm/common-hal/microcontroller/Pin.c
+++ b/ports/stm/common-hal/microcontroller/Pin.c
@@ -26,9 +26,7 @@
  */
 
 #include "shared-bindings/microcontroller/Pin.h"
-#include "shared-bindings/digitalio/DigitalInOut.h"
 
-#include "py/mphal.h"
 #include "pins.h"
 
 #if defined(TFBGA216)

--- a/ports/stm/common-hal/pulseio/PulseIn.c
+++ b/ports/stm/common-hal/pulseio/PulseIn.c
@@ -28,7 +28,6 @@
 #include <stdint.h>
 #include <string.h>
 #include "py/mpconfig.h"
-#include "py/gc.h"
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/Pin.h"

--- a/ports/stm/common-hal/pulseio/PulseOut.c
+++ b/ports/stm/common-hal/pulseio/PulseOut.c
@@ -29,14 +29,10 @@
 #include <stdint.h>
 
 #include "py/mpconfig.h"
-#include "py/gc.h"
-#include "py/runtime.h"
 #include "shared-bindings/pulseio/PulseOut.h"
 #include "shared-bindings/pwmio/PWMOut.h"
-#include "supervisor/shared/translate/translate.h"
 
 #include STM32_HAL_H
-#include "shared-bindings/microcontroller/Pin.h"
 #include "timers.h"
 
 // A single timer is shared amongst all PulseOut objects under the assumption that

--- a/ports/stm/common-hal/pwmio/PWMOut.c
+++ b/ports/stm/common-hal/pwmio/PWMOut.c
@@ -31,7 +31,6 @@
 #include "shared-bindings/pwmio/PWMOut.h"
 #include "supervisor/shared/translate/translate.h"
 
-#include "shared-bindings/microcontroller/__init__.h"
 #include STM32_HAL_H
 #include "shared-bindings/microcontroller/Pin.h"
 

--- a/ports/stm/common-hal/rtc/RTC.c
+++ b/ports/stm/common-hal/rtc/RTC.c
@@ -26,13 +26,9 @@
 
 #include <stdio.h>
 
-#include "py/obj.h"
 #include "py/runtime.h"
 #include "shared/timeutils/timeutils.h"
-#include "shared-bindings/rtc/__init__.h"
-#include "common-hal/rtc/RTC.h"
 #include "shared-bindings/rtc/RTC.h"
-#include "supervisor/port.h"
 #include "supervisor/shared/translate/translate.h"
 #include "peripherals/rtc.h"
 

--- a/ports/stm/mphalport.c
+++ b/ports/stm/mphalport.c
@@ -28,11 +28,8 @@
 #include <string.h>
 
 #include "py/mphal.h"
-#include "py/mpstate.h"
-#include "py/gc.h"
 
 #include "shared-bindings/microcontroller/__init__.h"
-#include "supervisor/shared/tick.h"
 
 void mp_hal_delay_us(mp_uint_t delay) {
     common_hal_mcu_delay_us(delay);

--- a/ports/stm/peripherals/exti.c
+++ b/ports/stm/peripherals/exti.c
@@ -26,9 +26,6 @@
 
 #include <stdbool.h>
 #include "py/mpconfig.h"
-#include "py/gc.h"
-#include "py/obj.h"
-#include "py/runtime.h"
 
 #include "peripherals/exti.h"
 
@@ -128,7 +125,7 @@ void EXTI4_IRQHandler(void) {
 #endif
 void EXTI9_5_IRQHandler(void) {
     uint32_t pending = EXTI->PR;
-    for (uint i = 5; i <= 9; i++) {
+    for (uint8_t i = 5; i <= 9; i++) {
         if (pending & (1 << i)) {
             stm_exti_callback[i](i);
         }
@@ -137,7 +134,7 @@ void EXTI9_5_IRQHandler(void) {
 
 void EXTI15_10_IRQHandler(void) {
     uint32_t pending = EXTI->PR;
-    for (uint i = 10; i <= 15; i++) {
+    for (uint8_t i = 10; i <= 15; i++) {
         if (pending & (1 << i)) {
             stm_exti_callback[i](i);
         }

--- a/ports/stm/peripherals/exti.c
+++ b/ports/stm/peripherals/exti.c
@@ -26,6 +26,7 @@
 
 #include <stdbool.h>
 #include "py/mpconfig.h"
+#include "py/misc.h"
 
 #include "peripherals/exti.h"
 
@@ -125,7 +126,7 @@ void EXTI4_IRQHandler(void) {
 #endif
 void EXTI9_5_IRQHandler(void) {
     uint32_t pending = EXTI->PR;
-    for (uint8_t i = 5; i <= 9; i++) {
+    for (uint i = 5; i <= 9; i++) {
         if (pending & (1 << i)) {
             stm_exti_callback[i](i);
         }
@@ -134,7 +135,7 @@ void EXTI9_5_IRQHandler(void) {
 
 void EXTI15_10_IRQHandler(void) {
     uint32_t pending = EXTI->PR;
-    for (uint8_t i = 10; i <= 15; i++) {
+    for (uint i = 10; i <= 15; i++) {
         if (pending & (1 << i)) {
             stm_exti_callback[i](i);
         }

--- a/ports/stm/peripherals/rtc.c
+++ b/ports/stm/peripherals/rtc.c
@@ -29,9 +29,6 @@
 #include STM32_HAL_H
 
 #include "py/mpconfig.h"
-#include "py/gc.h"
-#include "py/obj.h"
-#include "py/runtime.h"
 #include "shared/timeutils/timeutils.h"
 
 // Default period for ticks is 1/1024 second

--- a/ports/stm/peripherals/timers.c
+++ b/ports/stm/peripherals/timers.c
@@ -26,7 +26,6 @@
 #include "timers.h"
 
 #include "py/mpconfig.h"
-#include "py/gc.h"
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "supervisor/shared/translate/translate.h"

--- a/ports/stm/supervisor/internal_flash.c
+++ b/ports/stm/supervisor/internal_flash.c
@@ -29,12 +29,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "extmod/vfs.h"
-#include "extmod/vfs_fat.h"
-#include "py/mphal.h"
 #include "py/obj.h"
-#include "py/runtime.h"
-#include "lib/oofatfs/ff.h"
 #include "supervisor/flash.h"
 #include "supervisor/shared/safe_mode.h"
 

--- a/ports/stm/supervisor/port.c
+++ b/ports/stm/supervisor/port.c
@@ -29,7 +29,6 @@
 #include "supervisor/background_callback.h"
 #include "supervisor/board.h"
 #include "supervisor/port.h"
-#include "shared/timeutils/timeutils.h"
 
 #include "common-hal/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/__init__.h"

--- a/ports/stm/supervisor/usb.c
+++ b/ports/stm/supervisor/usb.c
@@ -27,9 +27,7 @@
 
 
 #include "supervisor/usb.h"
-#include "shared/runtime/interrupt_char.h"
 #include "shared/readline/readline.h"
-#include "lib/tinyusb/src/device/usbd.h"
 
 #include "py/mpconfig.h"
 


### PR DESCRIPTION
Hi everyone,

Working with the SMT32 ports, I have found a few header files being included that don't seem to have any role in the build. I made this change to remove them, and tested it on all the stm builds.  

If you confirm that these includes are redundant, the change could be made for the other ports as well.

