### PR TITLE
save about 112 bytes

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -60,6 +60,11 @@ msgstr ""
 msgid "%%c requires int or char"
 msgstr ""
 
+#: main.c
+#, c-format
+msgid "%02X"
+msgstr ""
+
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
@@ -2075,6 +2080,10 @@ msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
 msgid "UART write"
+msgstr ""
+
+#: main.c
+msgid "UID:"
 msgstr ""
 
 #: shared-module/usb_hid/Device.c

--- a/main.c
+++ b/main.c
@@ -779,9 +779,9 @@ STATIC void __attribute__ ((noinline)) run_boot_py(safe_mode_t safe_mode) {
         #if CIRCUITPY_MICROCONTROLLER && COMMON_HAL_MCU_PROCESSOR_UID_LENGTH > 0
         uint8_t raw_id[COMMON_HAL_MCU_PROCESSOR_UID_LENGTH];
         common_hal_mcu_processor_get_uid(raw_id);
-        mp_printf(&mp_plat_print, "UID:");
-        for (uint8_t i = 0; i < COMMON_HAL_MCU_PROCESSOR_UID_LENGTH; i++) {
-            mp_printf(&mp_plat_print, "%02X", raw_id[i]);
+        mp_cprintf(&mp_plat_print, translate("UID:"));
+        for (size_t i = 0; i < COMMON_HAL_MCU_PROCESSOR_UID_LENGTH; i++) {
+            mp_cprintf(&mp_plat_print, translate("%02X"), raw_id[i]);
         }
         mp_printf(&mp_plat_print, "\n");
         port_boot_info();

--- a/ports/atmel-samd/common-hal/busio/I2C.c
+++ b/ports/atmel-samd/common-hal/busio/I2C.c
@@ -125,8 +125,6 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     // exact cutoff, but no frequency well under 100kHz is available)
     if ((frequency < 95000) ||
         (i2c_m_sync_set_baudrate(&self->i2c_desc, 0, frequency / 1000) != ERR_NONE)) {
-        reset_pin_number(sda->number);
-        reset_pin_number(scl->number);
         common_hal_busio_i2c_deinit(self);
         mp_arg_error_invalid(MP_QSTR_frequency);
     }

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -759,7 +759,6 @@ STATIC const mp_rom_map_elem_t mp_module_builtins_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_KeyError), MP_ROM_PTR(&mp_type_KeyError) },
     { MP_ROM_QSTR(MP_QSTR_LookupError), MP_ROM_PTR(&mp_type_LookupError) },
     { MP_ROM_QSTR(MP_QSTR_MemoryError), MP_ROM_PTR(&mp_type_MemoryError) },
-    { MP_ROM_QSTR(MP_QSTR_MpyError), MP_ROM_PTR(&mp_type_MpyError) },
     { MP_ROM_QSTR(MP_QSTR_NameError), MP_ROM_PTR(&mp_type_NameError) },
     { MP_ROM_QSTR(MP_QSTR_NotImplementedError), MP_ROM_PTR(&mp_type_NotImplementedError) },
     { MP_ROM_QSTR(MP_QSTR_OSError), MP_ROM_PTR(&mp_type_OSError) },

--- a/py/obj.h
+++ b/py/obj.h
@@ -742,7 +742,6 @@ extern const mp_obj_type_t mp_type_ReloadException;
 extern const mp_obj_type_t mp_type_KeyError;
 extern const mp_obj_type_t mp_type_LookupError;
 extern const mp_obj_type_t mp_type_MemoryError;
-extern const mp_obj_type_t mp_type_MpyError;
 extern const mp_obj_type_t mp_type_NameError;
 extern const mp_obj_type_t mp_type_NotImplementedError;
 extern const mp_obj_type_t mp_type_OSError;

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -347,7 +347,6 @@ MP_DEFINE_EXCEPTION(UnicodeError, ValueError)
 #if CIRCUITPY_ALARM
 MP_DEFINE_EXCEPTION(DeepSleepRequest, BaseException)
 #endif
-MP_DEFINE_EXCEPTION(MpyError, ValueError)
 /*
   MP_DEFINE_EXCEPTION(Warning, Exception)
     MP_DEFINE_EXCEPTION(DeprecationWarning, Warning)

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -582,7 +582,7 @@ mp_raw_code_t *mp_raw_code_load(mp_reader_t *reader) {
         || MPY_FEATURE_DECODE_FLAGS(header[2]) != MPY_FEATURE_FLAGS
         || header[3] > mp_small_int_bits()
         || read_uint(reader, NULL) > QSTR_WINDOW_SIZE) {
-        mp_raise_MpyError(MP_ERROR_TEXT("Incompatible .mpy file. Please update all .mpy files. See http://adafru.it/mpy-update for more info."));
+        mp_raise_ValueError(MP_ERROR_TEXT("Incompatible .mpy file. Please update all .mpy files. See http://adafru.it/mpy-update for more info."));
     }
     if (MPY_FEATURE_DECODE_ARCH(header[2]) != MP_NATIVE_ARCH_NONE) {
         byte arch = MPY_FEATURE_DECODE_ARCH(header[2]);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1742,10 +1742,6 @@ NORETURN void mp_raise_OverflowError_varg(const compressed_string_t *fmt, ...) {
     va_end(argptr);
 }
 
-NORETURN void mp_raise_MpyError(const compressed_string_t *msg) {
-    mp_raise_msg(&mp_type_MpyError, msg);
-}
-
 NORETURN void mp_raise_type_arg(const mp_obj_type_t *exc_type, mp_obj_t arg) {
     nlr_raise(mp_obj_new_exception_arg1(exc_type, arg));
 }

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -225,7 +225,6 @@ NORETURN void mp_raise_BrokenPipeError(void);
 NORETURN void mp_raise_NotImplementedError(const compressed_string_t *msg);
 NORETURN void mp_raise_NotImplementedError_varg(const compressed_string_t *fmt, ...);
 NORETURN void mp_raise_OverflowError_varg(const compressed_string_t *fmt, ...);
-NORETURN void mp_raise_MpyError(const compressed_string_t *msg);
 NORETURN void mp_raise_recursion_depth(void);
 #endif
 


### PR DESCRIPTION
Saves about 112 bytes on non-Express M0 builds:

- Remove `MpyError` exception, which wasn't used anywhere by us.
- Remove two redundant calls to `reset_pin_number()` in atmel-samd I2C. These calls are done in the deinit code, and don't need to be done before deinit is called.
- Change a few `mp_printf()` calls to `mp_cprintf()` with a translated string. I tried this in a number of places, and the only significant difference was the on ine `main.c`. Very surprisingly, this change in `run_boot_py()` saves about 60 bytes:
```c
        mp_printf(&mp_plat_print, "%s\nBoard ID:%s\n", MICROPY_FULL_VERSION_INFO, CIRCUITPY_BOARD_ID);
        #if CIRCUITPY_MICROCONTROLLER && COMMON_HAL_MCU_PROCESSOR_UID_LENGTH > 0
        uint8_t raw_id[COMMON_HAL_MCU_PROCESSOR_UID_LENGTH];
        common_hal_mcu_processor_get_uid(raw_id);
        mp_cprintf(&mp_plat_print, translate("UID:"));
        for (size_t i = 0; i < COMMON_HAL_MCU_PROCESSOR_UID_LENGTH; i++) {
            mp_cprintf(&mp_plat_print, translate("%02X"), raw_id[i]);
        }
        mp_printf(&mp_plat_print, "\n");
```
Both `"UID:"` and `"%02X"` must be translated to get the savings. If either one is omitted, the savings is much less. I looked at the assembly output, and it might be doing a better of optimization, but I'm not sure why. Or something in the translation table construction reaches some inflection point. It's very odd. Neither string will need to actually be translated by the translators.