### PR TITLE
CI: Update to newer actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,12 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
     - name: Set up Python 3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
     - name: Get CP deps
@@ -92,25 +92,25 @@ jobs:
       working-directory: tests
     - name: Build mpy-cross.static-aarch64
       run: make -C mpy-cross -j2 -f Makefile.static-aarch64
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: mpy-cross.static-aarch64
         path: mpy-cross/mpy-cross.static-aarch64
     - name: Build mpy-cross.static-raspbian
       run: make -C mpy-cross -j2 -f Makefile.static-raspbian
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: mpy-cross.static-raspbian
         path: mpy-cross/mpy-cross.static-raspbian
     - name: Build mpy-cross.static
       run: make -C mpy-cross -j2 -f Makefile.static
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: mpy-cross.static-amd64-linux
         path: mpy-cross/mpy-cross.static
     - name: Build mpy-cross.static-mingw
       run: make -C mpy-cross -j2 -f Makefile.static-mingw
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: mpy-cross.static-x64-windows
         path: mpy-cross/mpy-cross.static.exe
@@ -149,12 +149,12 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
     - name: Set up Python 3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
     - name: Get CP deps
@@ -174,19 +174,19 @@ jobs:
         msgfmt --version
     - name: Build mpy-cross
       run: make -C mpy-cross -j2
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: mpy-cross-macos-11-x64
         path: mpy-cross/mpy-cross
     - name: Build mpy-cross (arm64)
       run: make -C mpy-cross -j2 -f Makefile.m1 V=2
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: mpy-cross-macos-11-arm64
         path: mpy-cross/mpy-cross-arm64
     - name: Make universal binary
       run: lipo -create -output mpy-cross-macos-universal mpy-cross/mpy-cross mpy-cross/mpy-cross-arm64
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: mpy-cross-macos-11-universal
         path: mpy-cross-macos-universal
@@ -207,7 +207,7 @@ jobs:
     needs: test
     if: ${{ needs.test.outputs.build-doc == 'True' }}
     steps:
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
@@ -218,7 +218,7 @@ jobs:
         tools/describe || git log --parents HEAD~4..
         echo >>$GITHUB_ENV CP_VERSION=$(tools/describe)
     - name: Set up Python 3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
     - name: Install dependencies
@@ -229,20 +229,20 @@ jobs:
         pip install -r requirements-ci.txt -r requirements-doc.txt
     - name: Build and Validate Stubs
       run: make check-stubs -j2
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: stubs
         path: circuitpython-stubs/dist/*
     - name: Test Documentation Build (HTML)
       run: sphinx-build -E -W -b html -D version=${{ env.CP_VERSION }} -D release=${{ env.CP_VERSION }} . _build/html
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: docs
         path: _build/html
     - name: Test Documentation Build (LaTeX/PDF)
       run: |
         make latexpdf
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: docs
         path: _build/latex
@@ -276,10 +276,10 @@ jobs:
     if: ${{ needs.test.outputs.boards-arm != '[]' }}
     steps:
     - name: Set up Python 3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
@@ -306,7 +306,7 @@ jobs:
       working-directory: tools
       env:
         BOARDS: ${{ matrix.board }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
@@ -329,10 +329,10 @@ jobs:
     if: ${{ needs.test.outputs.boards-riscv != '[]' }}
     steps:
     - name: Set up Python 3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
@@ -358,7 +358,7 @@ jobs:
       working-directory: tools
       env:
         BOARDS: ${{ matrix.board }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
@@ -385,7 +385,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
@@ -395,7 +395,7 @@ jobs:
       run: |
         tools/describe || git log --parents HEAD~4..
         echo >>$GITHUB_ENV CP_VERSION=$(tools/describe)
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       name: Fetch IDF tool cache
       id: idf-cache
       with:
@@ -449,7 +449,7 @@ jobs:
         IDF_PATH: ${{ github.workspace }}/ports/espressif/esp-idf
         IDF_TOOLS_PATH: ${{ github.workspace }}/.idf_tools
         BOARDS: ${{ matrix.board }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
@@ -471,10 +471,10 @@ jobs:
     if: ${{ needs.test.outputs.boards-aarch != '[]' }}
     steps:
     - name: Set up Python 3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
@@ -514,7 +514,7 @@ jobs:
       working-directory: tools
       env:
         BOARDS: ${{ matrix.board }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}

--- a/.github/workflows/create_website_pr.yml
+++ b/.github/workflows/create_website_pr.yml
@@ -16,12 +16,12 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
     - name: Set up Python 3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
     - name: Get CP deps

--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -71,7 +71,7 @@ jobs:
         which python; python --version; python -c "import cascadetoml"
         which python3; python3 --version; python3 -c "import cascadetoml"
 
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,9 +16,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v3
     - name: Set up Python 3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.x"
     - name: Install deps
@@ -29,17 +29,17 @@ jobs:
       run: git submodule update --init extmod/ulab
     - name: Set PY
       run: echo >>$GITHUB_ENV PY="$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.1.0
+    - uses: pre-commit/action@v3.0.0
     - name: Make patch
       if: failure()
       run: git diff > ~/pre-commit.patch
     - name: Upload patch
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: patch
         path: ~/pre-commit.patch


### PR DESCRIPTION
Update to resolve the following deprecation warning:
```
Node.js 12 actions are deprecated.
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: actions/cache, actions/checkout, actions/setup-python, actions/upload-artifact, pre-commit/action
```
