### PR TITLE
Traceback module improvements

### DIFF
--- a/shared-bindings/traceback/__init__.c
+++ b/shared-bindings/traceback/__init__.c
@@ -110,7 +110,7 @@ STATIC void traceback_exception_common(bool is_print_exception, mp_print_t *prin
 //|     tb: Optional[TracebackType] = None,
 //|     limit: Optional[int] = None,
 //|     chain: Optional[bool] = True,
-//| ) -> str:
+//| ) -> List[str]:
 //|     """Format a stack trace and the exception information.
 //|
 //|     If the exception value is passed in ``exc``, then this exception value and its
@@ -143,7 +143,8 @@ STATIC mp_obj_t traceback_format_exception(size_t n_args, const mp_obj_t *pos_ar
     vstr_t vstr;
     vstr_init_print(&vstr, 0, &print);
     traceback_exception_common(false, &print, n_args, pos_args, kw_args);
-    return mp_obj_new_str_from_vstr(&mp_type_str, &vstr);
+    mp_obj_t output = mp_obj_new_str_from_vstr(&mp_type_str, &vstr);
+    return mp_obj_new_list(1, &output);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(traceback_format_exception_obj, 0, traceback_format_exception);

--- a/shared-bindings/traceback/__init__.c
+++ b/shared-bindings/traceback/__init__.c
@@ -39,11 +39,11 @@
 //| ...
 
 STATIC void traceback_exception_common(bool is_print_exception, mp_print_t *print, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_etype, ARG_value, ARG_tb, ARG_limit, ARG_file, ARG_chain };
+    enum { ARG_exc, ARG_value, ARG_tb, ARG_limit, ARG_file, ARG_chain };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_etype, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_obj = MP_OBJ_NULL} },
-        { MP_QSTR_value, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_obj = MP_OBJ_NULL} },
-        { MP_QSTR_tb,    MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_,      MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_value, MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_tb,    MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_limit, MP_ARG_OBJ,  {.u_obj = mp_const_none} },
         { MP_QSTR_file,  MP_ARG_OBJ,  {.u_obj = mp_const_none} },
         { MP_QSTR_chain, MP_ARG_BOOL, {.u_bool = true} },
@@ -53,6 +53,9 @@ STATIC void traceback_exception_common(bool is_print_exception, mp_print_t *prin
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_obj_t value = args[ARG_value].u_obj;
+    if (value == MP_OBJ_NULL) {
+        value = args[ARG_exc].u_obj;
+    }
     mp_obj_t tb_obj = args[ARG_tb].u_obj;
     mp_obj_t limit_obj = args[ARG_limit].u_obj;
 
@@ -88,7 +91,9 @@ STATIC void traceback_exception_common(bool is_print_exception, mp_print_t *prin
     mp_obj_exception_t *exc = mp_obj_exception_get_native(value);
     mp_obj_traceback_t *trace_backup = exc->traceback;
 
-    if (tb_obj != mp_const_none && print_tb) {
+    if (tb_obj == MP_OBJ_NULL) {
+        /* Print the traceback's exception as is */
+    } else if (tb_obj != mp_const_none && print_tb) {
         exc->traceback = mp_arg_validate_type(tb_obj, &mp_type_traceback, MP_QSTR_tb);
     } else {
         exc->traceback = (mp_obj_traceback_t *)&mp_const_empty_traceback_obj;

--- a/shared-bindings/traceback/__init__.c
+++ b/shared-bindings/traceback/__init__.c
@@ -104,13 +104,23 @@ STATIC void traceback_exception_common(bool is_print_exception, mp_print_t *prin
 }
 
 //| def format_exception(
-//|     etype: Type[BaseException],
-//|     value: BaseException,
-//|     tb: TracebackType,
+//|     exc: BaseException | Type[BaseException],
+//|     /,
+//|     value: Optional[BaseException] = None,
+//|     tb: Optional[TracebackType] = None,
 //|     limit: Optional[int] = None,
 //|     chain: Optional[bool] = True,
-//| ) -> None:
+//| ) -> str:
 //|     """Format a stack trace and the exception information.
+//|
+//|     If the exception value is passed in ``exc``, then this exception value and its
+//|     associated traceback are used. This is compatible with CPython 3.10 and newer.
+//|
+//|     If the exception value is passed in ``value``, then any value passed in for
+//|     ``exc`` is ignored.  ``value`` is used as the exception value and the
+//|     traceback in the ``tb`` argument is used.  In this case, if ``tb`` is None,
+//|     no traceback will be shown. This is compatible with CPython 3.5 and
+//|     newer.
 //|
 //|     The arguments have the same meaning as the corresponding arguments
 //|     to print_exception().  The return value is a list of strings, each
@@ -120,15 +130,13 @@ STATIC void traceback_exception_common(bool is_print_exception, mp_print_t *prin
 //|
 //|     .. note:: Setting ``chain`` will have no effect as chained exceptions are not yet implemented.
 //|
-//|     :param Type[BaseException] etype: This is ignored and inferred from the type of ``value``.
-//|     :param BaseException value: The exception. Must be an instance of `BaseException`.
-//|     :param TracebackType tb: The traceback object. If `None`, the traceback will not be printed.
+//|     :param exc: The exception. Must be an instance of `BaseException`. Unused if value is specified.
+//|     :param value: If specified, is used in place of ``exc``.
+//|     :param TracebackType tb: When value is alsp specified, ``tb`` is used in place of the exception's own traceback. If `None`, the traceback will not be printed.
 //|     :param int limit: Print up to limit stack trace entries (starting from the caller’s frame) if limit is positive.
 //|                       Otherwise, print the last ``abs(limit)`` entries. If limit is omitted or None, all entries are printed.
 //|     :param bool chain: If `True` then chained exceptions will be printed (note: not yet implemented).
-//|
 //|     """
-//|     ...
 //|
 STATIC mp_obj_t traceback_format_exception(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mp_print_t print;
@@ -141,21 +149,30 @@ STATIC mp_obj_t traceback_format_exception(size_t n_args, const mp_obj_t *pos_ar
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(traceback_format_exception_obj, 0, traceback_format_exception);
 
 //| def print_exception(
-//|     etype: Type[BaseException],
-//|     value: BaseException,
-//|     tb: TracebackType,
+//|     exc: BaseException | Type[BaseException],
+//|     /,
+//|     value: Optional[BaseException] = None,
+//|     tb: Optional[TracebackType] = None,
 //|     limit: Optional[int] = None,
 //|     file: Optional[io.FileIO] = None,
 //|     chain: Optional[bool] = True,
 //| ) -> None:
-//|
 //|     """Prints exception information and stack trace entries.
+//|
+//|     If the exception value is passed in ``exc``, then this exception value and its
+//|     associated traceback are used. This is compatible with CPython 3.10 and newer.
+//|
+//|     If the exception value is passed in ``value``, then any value passed in for
+//|     ``exc`` is ignored.  ``value`` is used as the exception value and the
+//|     traceback in the ``tb`` argument is used.  In this case, if ``tb`` is None,
+//|     no traceback will be shown. This is compatible with CPython 3.5 and
+//|     newer.
 //|
 //|     .. note:: Setting ``chain`` will have no effect as chained exceptions are not yet implemented.
 //|
-//|     :param Type[BaseException] etype: This is ignored and inferred from the type of ``value``.
-//|     :param BaseException value: The exception. Must be an instance of `BaseException`.
-//|     :param TracebackType tb: The traceback object. If `None`, the traceback will not be printed.
+//|     :param exc: The exception. Must be an instance of `BaseException`. Unused if value is specified.
+//|     :param value: If specified, is used in place of ``exc``.
+//|     :param tb: When value is alsp specified, ``tb`` is used in place of the exception's own traceback. If `None`, the traceback will not be printed.
 //|     :param int limit: Print up to limit stack trace entries (starting from the caller’s frame) if limit is positive.
 //|                       Otherwise, print the last ``abs(limit)`` entries. If limit is omitted or None, all entries are printed.
 //|     :param io.FileIO file: If file is omitted or `None`, the output goes to `sys.stderr`; otherwise it should be an open

--- a/tests/circuitpython/traceback_test.py
+++ b/tests/circuitpython/traceback_test.py
@@ -21,7 +21,7 @@ except Exception as exc:
     print("\nLimit=0 Trace:")
     traceback.print_exception(None, exc, exc.__traceback__, limit=0)
     print("\nLimit=-1 Trace:")
-    traceback.print_exception(None, exc, exc.__traceback__, limit=-1)
+    print(traceback.format_exception(None, exc, exc.__traceback__, limit=-1), end="")
 
 
 class NonNativeException(Exception):

--- a/tests/circuitpython/traceback_test.py
+++ b/tests/circuitpython/traceback_test.py
@@ -21,7 +21,7 @@ except Exception as exc:
     print("\nLimit=0 Trace:")
     traceback.print_exception(None, exc, exc.__traceback__, limit=0)
     print("\nLimit=-1 Trace:")
-    print(traceback.format_exception(None, exc, exc.__traceback__, limit=-1), end="")
+    print("".join(traceback.format_exception(None, exc, exc.__traceback__, limit=-1)), end="")
 
 
 class NonNativeException(Exception):

--- a/tests/circuitpython/traceback_test.py
+++ b/tests/circuitpython/traceback_test.py
@@ -15,7 +15,7 @@ except Exception as exc:
     print("\nNo Trace:")
     traceback.print_exception(None, exc, None)
     print("\nDefault Trace:")
-    traceback.print_exception(None, exc, exc.__traceback__)
+    traceback.print_exception(exc)
     print("\nLimit=1 Trace:")
     traceback.print_exception(None, exc, exc.__traceback__, limit=1)
     print("\nLimit=0 Trace:")


### PR DESCRIPTION
**Since this is incompatible (in a minor way) I'd like to get it in before an 8.0 RC**

## More convenient traceback printing, Python 3.10 compatible
Python 3.10 added the form `print_traceback(exc)` to print an exception and its associated traceback. This is equivalent to `print_traceback(type(exc), exc, exc.__traceback__`.

## CPython compatible `format_traceback`
Our function was documented as being compatible with CPython, which returns a list of strings. Now the implementation actually does so, rather than returning a single string. This is technically an incompatible change (vs older CircuitPython versions).

## Slight size decrease
By sharing code better, a net ~16 bytes of flash memory are saved on pygamer

## Tests
.. of the new way of calling, and of `format_traceback`.