### PR TITLE
Return correct errno in raspberrypi's Socket.c

### DIFF
--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -1080,7 +1080,7 @@ int socketpool_socket_recv_into(socketpool_socket_obj_t *socket,
             ret = lwip_raw_udp_receive(socket, (byte *)buf, len, NULL, NULL, &_errno);
             break;
     }
-    if (ret < 0) {
+    if (ret == (unsigned)-1) {
         return -_errno;
     }
     return ret;
@@ -1089,7 +1089,7 @@ int socketpool_socket_recv_into(socketpool_socket_obj_t *socket,
 mp_uint_t common_hal_socketpool_socket_recv_into(socketpool_socket_obj_t *self, const uint8_t *buf, uint32_t len) {
     int received = socketpool_socket_recv_into(self, buf, len);
     if (received < 0) {
-        mp_raise_OSError(received);
+        mp_raise_OSError(-received);
     }
     return received;
 }


### PR DESCRIPTION
This PR fixes #6988

Changes seems to have been made in ca9523b814b6467ddf7626fa9cfe24d3a60d6e37 to address this, but it is still wrong.

`ret` is defined as `mp_uint_t` and is therefore never less than zero, this uses the same solution as line 1060 in the same file.
Also the value in `received` is now a negative number, and must be converted to a positive number before being raised to match up with `errno.ETIMEDOUT` and `errno.EAGAIN`.