### PR TITLE
picow: Turn off wifi co-processor regulator when entering deep sleep

### DIFF
--- a/ports/raspberrypi/bindings/cyw43/__init__.c
+++ b/ports/raspberrypi/bindings/cyw43/__init__.c
@@ -35,6 +35,12 @@
 
 static int power_management_value = PM_DISABLED;
 
+void cyw43_enter_deep_sleep(void) {
+#define WL_REG_ON 23
+    gpio_set_dir(WL_REG_ON, GPIO_OUT);
+    gpio_put(WL_REG_ON, false);
+}
+
 void bindings_cyw43_wifi_enforce_pm() {
     cyw43_wifi_pm(&cyw43_state, power_management_value);
 }

--- a/ports/raspberrypi/bindings/cyw43/__init__.h
+++ b/ports/raspberrypi/bindings/cyw43/__init__.h
@@ -51,3 +51,4 @@ const mcu_pin_obj_t *validate_obj_is_pin_including_cyw43(mp_obj_t obj);
 #define PM_DISABLED CONSTANT_CYW43_PM_VALUE(CYW43_NO_POWERSAVE_MODE, 200, 1, 1, 10)
 
 extern void bindings_cyw43_wifi_enforce_pm(void);
+void cyw43_enter_deep_sleep(void);

--- a/ports/raspberrypi/common-hal/alarm/__init__.c
+++ b/ports/raspberrypi/common-hal/alarm/__init__.c
@@ -38,6 +38,10 @@
 
 #include "shared-bindings/microcontroller/__init__.h"
 
+#if CIRCUITPY_CYW43
+#include "bindings/cyw43/__init__.h"
+#endif
+
 #include "supervisor/port.h"
 #include "supervisor/shared/workflow.h"
 
@@ -203,6 +207,10 @@ void common_hal_alarm_set_deep_sleep_alarms(size_t n_alarms, const mp_obj_t *ala
 
 void NORETURN common_hal_alarm_enter_deep_sleep(void) {
     bool timealarm_set = alarm_time_timealarm_is_set();
+
+    #if CIRCUITPY_CYW43
+    cyw43_enter_deep_sleep();
+    #endif
 
     // If there's a timealarm, just enter a very deep light sleep
     if (timealarm_set) {


### PR DESCRIPTION
This reduces power consumption during true deep sleep.

In my measurements with ppk2 and a program that _irrevocably_ entered deep sleep (no time alarm or pin alarm), power usage as measured on a ppk2 decreased from ~10mA to ~1mA.

Closes: #7047 (or at least improves on the status quo)

ppk graph, before (right hand side represents deep sleep):
![image](https://user-images.githubusercontent.com/1517291/195739570-dee58e86-5471-4c41-85ce-eed688bcbfc2.png)
zoomed in on the right:
![image](https://user-images.githubusercontent.com/1517291/195739593-c0fcb3d0-ee24-4742-9b4b-a992dbbb1b42.png)

after, zoomed in on deep sleep:
![image](https://user-images.githubusercontent.com/1517291/195739611-4d7ab237-ea81-417f-be04-500fa1653f8e.png)

Using pin alarms or time alarms still incurs a power cost. Light sleep and fake deep sleep are not improved/changed by this PR.