### PR TITLE
don't build other ports due to common-hal changes

### DIFF
--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -53,7 +53,7 @@ def set_output(name, value):
         with open(os.environ["GITHUB_OUTPUT"], "at") as f:
             print(f"{name}={value}", file=f)
     else:
-        print("Would set GitHub actions output {name} to '{value}'")
+        print(f"Would set GitHub actions output {name} to '{value}'")
 
 
 def set_boards_to_build(build_all):
@@ -80,9 +80,7 @@ def set_boards_to_build(build_all):
         boards_to_build = set()
         board_pattern = re.compile(r"^ports/[^/]+/boards/([^/]+)/")
         port_pattern = re.compile(r"^ports/([^/]+)/")
-        module_pattern = re.compile(
-            r"^(ports/[^/]+/common-hal|shared-bindings|shared-module)/([^/]+)/"
-        )
+        module_pattern = re.compile(r"^(ports/[^/]+/shared-bindings|shared-module)/([^/]+)/")
         for p in changed_files:
             # See if it is board specific
             board_matches = board_pattern.search(p)


### PR DESCRIPTION
A change in a `common-hal` file built other ports that had a `common-hal` file of the same name. Example of this happening is in the #7051 CI runs.