### PR TITLE
Ci set matrix improvements

### DIFF
--- a/docs/shared_bindings_matrix.py
+++ b/docs/shared_bindings_matrix.py
@@ -80,12 +80,11 @@ This is the same list as in the preprocess_frozen_modules script."""
 repository_urls = {}
 """Cache of repository URLs for frozen modules."""
 
+root_dir = pathlib.Path(__file__).resolve().parent.parent
+
 def get_circuitpython_root_dir():
     """ The path to the root './circuitpython' directory.
     """
-    file_path = pathlib.Path(__file__).resolve()
-    root_dir = file_path.parent.parent
-
     return root_dir
 
 def get_shared_bindings():
@@ -102,7 +101,7 @@ def get_board_mapping():
     """
     boards = {}
     for port in SUPPORTED_PORTS:
-        board_path = os.path.join("../ports", port, "boards")
+        board_path = root_dir / "ports" / port / "boards"
         for board_path in os.scandir(board_path):
             if board_path.is_dir():
                 board_files = os.listdir(board_path.path)

--- a/docs/shared_bindings_matrix.py
+++ b/docs/shared_bindings_matrix.py
@@ -27,6 +27,7 @@ import pathlib
 import re
 import subprocess
 import sys
+import functools
 
 from concurrent.futures import ThreadPoolExecutor
 
@@ -275,6 +276,7 @@ def lookup_setting(settings, key, default=''):
         key = value[2:-1]
     return value
 
+@functools.cache
 def all_ports_all_boards(ports=SUPPORTED_PORTS):
     for port in ports:
 

--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -53,7 +53,7 @@ def set_output(name, value):
         with open(os.environ["GITHUB_OUTPUT"], "at") as f:
             print(f"{name}={value}", file=f)
     else:
-        print(f"Would set GitHub actions output {name} to '{value}'")
+        print("Would set GitHub actions output {name} to '{value}'")
 
 
 def set_boards_to_build(build_all):
@@ -80,7 +80,9 @@ def set_boards_to_build(build_all):
         boards_to_build = set()
         board_pattern = re.compile(r"^ports/[^/]+/boards/([^/]+)/")
         port_pattern = re.compile(r"^ports/([^/]+)/")
-        module_pattern = re.compile(r"^(ports/[^/]+/shared-bindings|shared-module)/([^/]+)/")
+        module_pattern = re.compile(
+            r"^(ports/[^/]+/common-hal|shared-bindings|shared-module)/([^/]+)/"
+        )
         for p in changed_files:
             # See if it is board specific
             board_matches = board_pattern.search(p)

--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -12,6 +12,13 @@ on the event that triggered run. Pull request runs will compare to the
 base branch while pushes will compare to the current ref. We override this
 for the adafruit/circuitpython repo so we build all docs/boards for pushes.
 
+When making changes to the script it is useful to manually test it.
+You can for instance run
+```shell
+tools/ci_set_matrix ports/raspberrypi/common-hal/socket/SSLSocket.c
+```
+and (at the time this comment was written) get a series of messages indicating
+that only the single board raspberry_pi_pico_w would be built.
 """
 
 import re
@@ -112,7 +119,7 @@ def set_boards_to_build(build_all):
         board_pattern = re.compile(r"^ports/[^/]+/boards/([^/]+)/")
         port_pattern = re.compile(r"^ports/([^/]+)/")
         module_pattern = re.compile(
-            r"^(ports/[^/]+/common-hal|shared-bindings|shared-module)/([^/]+)/"
+            r"^(ports/[^/]+/(?:common-hal|bindings)|shared-bindings|shared-module)/([^/]+)/"
         )
         for p in changed_files:
             # See if it is board specific

--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -131,9 +131,9 @@ def set_boards_to_build(build_all):
 
             # See if it is port specific
             port_matches = port_pattern.search(p)
+            port = port_matches.group(1) if port_matches else None
             module_matches = module_pattern.search(p)
-            if port_matches and not module_matches:
-                port = port_matches.group(1)
+            if port and not module_matches:
                 if port != "unix":
                     boards_to_build.update(port_to_boards[port])
                 continue
@@ -149,8 +149,7 @@ def set_boards_to_build(build_all):
             # As a (nearly) last resort, for some certain files, we compute the settings from the
             # makefile for each board and determine whether to build them that way.
             if p.startswith("frozen") or p.startswith("supervisor") or module_matches:
-                if port_matches:
-                    port = port_matches.group(1)
+                if port:
                     board_ids = port_to_boards[port]
                 else:
                     board_ids = all_board_ids


### PR DESCRIPTION
This runs faster, is more correct (I hope!) and is easier to test locally. Closes #6922 

Frozen modules:
```
$ GITHUB_OUTPUT=/dev/null ./tools/ci_set_matrix.py  frozen/Adafruit_CircuitPython_MIDI 
Using files list on commandline
Adding docs/boards to build based on changed files
Building docs: False
Building boards:
  zrichard_rp2.65-f
```

Port-specific changes to shared modules:
```
$ GITHUB_OUTPUT=/dev/null ./tools/ci_set_matrix.py  ports/raspberrypi/common-hal/ssl/SSLSocket.c 
Using files list on commandline
Adding docs/boards to build based on changed files
Building docs: False
Building boards:
  raspberry_pi_pico_w
```

Changes to port-specific modules:
```
$ GITHUB_OUTPUT=/dev/null ./tools/ci_set_matrix.py  ports/raspberrypi/bindings/cyw43/__init__.c
Using files list on commandline
Adding docs/boards to build based on changed files
Building docs: True
Building boards:
  raspberry_pi_pico_w
```