### PR TITLE
asyncio: we should dogfood our own asyncio implementation during automated tests

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -309,6 +309,10 @@ test_full: $(PROG) $(TOP)/tests/run-tests.py
 	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) --emit native -d basics float micropython
 	cat $(TOP)/tests/basics/0prelim.py | ./$(PROG) | grep -q 'abc'
 
+.PHONY: print-failures clean-failures
+print-failures clean-failures:
+	../../tests/run-tests.py --$@
+
 test_gcov: test_full
 	gcov -o $(BUILD)/py $(TOP)/py/*.c
 	gcov -o $(BUILD)/extmod $(TOP)/extmod/*.c

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -870,8 +870,14 @@ the last matching regex is used:
 
     if not args.keep_path:
         # clear search path to make sure tests use only builtin modules and those in extmod
-        os.environ["MICROPYPATH"] = os.pathsep + ".frozen" + os.pathsep + base_path("../extmod")
-
+        os.environ["MICROPYPATH"] = os.pathsep.join(
+            [
+                "",
+                ".frozen",
+                base_path("../frozen/Adafruit_CircuitPython_asyncio"),
+                base_path("../frozen/Adafruit_CircuitPython_Ticks"),
+            ]
+        )
     try:
         os.makedirs(args.result_dir, exist_ok=True)
         res = run_tests(pyb, tests, args, args.result_dir, args.jobs)


### PR DESCRIPTION
This doesn't work yet. It needs https://github.com/adafruit/Adafruit_CircuitPython_Ticks/pull/8 in order to even fail (rather than skipping the tests). After that, some tests fail and one loops/hangs indefinitely.

We should fix the failures (probably mostly through changes in Adafruit_CircuitPython_asyncio) and then incorporate this patch so that we know if asyncio works.