### PR TITLE
Fix GPIO state when initializing CYW43 pin

### DIFF
--- a/ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
+++ b/ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
@@ -50,6 +50,12 @@ digitalinout_result_t common_hal_digitalio_digitalinout_construct(
     self->output = false;
     self->open_drain = false;
 
+    #if CIRCUITPY_CYW43
+    if (IS_CYW(self)) {
+        return DIGITALINOUT_OK;
+    }
+    #endif
+
     // Set to input. No output value.
     gpio_init(pin->number);
     return DIGITALINOUT_OK;


### PR DESCRIPTION
Closes: #7063