### PR TITLE
Pico W grab bag

### DIFF
--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -504,6 +504,11 @@ STATIC mp_uint_t lwip_tcp_send(socketpool_socket_obj_t *socket, const byte *buf,
         if (err != ERR_MEM) {
             break;
         }
+        if (err == ERR_MEM && write_len > TCP_MSS) {
+            // Try writing just one MSS worth of data
+            write_len = TCP_MSS;
+            continue;
+        }
         err = tcp_output(socket->pcb.tcp);
         if (err != ERR_OK) {
             break;

--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -505,8 +505,8 @@ STATIC mp_uint_t lwip_tcp_send(socketpool_socket_obj_t *socket, const byte *buf,
             break;
         }
         if (err == ERR_MEM && write_len > TCP_MSS) {
-            // Try writing just one MSS worth of data
-            write_len = TCP_MSS;
+            // Decreasing the amount sent to the next lower number of MSS
+            write_len = (write_len - 1) / TCP_MSS * TCP_MSS;
             continue;
         }
         err = tcp_output(socket->pcb.tcp);

--- a/ports/raspberrypi/common-hal/wifi/Radio.c
+++ b/ports/raspberrypi/common-hal/wifi/Radio.c
@@ -158,6 +158,13 @@ void common_hal_wifi_radio_start_station(wifi_radio_obj_t *self) {
 }
 
 void common_hal_wifi_radio_stop_station(wifi_radio_obj_t *self) {
+    cyw43_wifi_leave(&cyw43_state, CYW43_ITF_STA);
+    // This is wrong, but without this call the state of ITF_STA is still
+    // reported as CYW43_LINK_JOIN (by wifi_link_status) and CYW43_LINK_UP
+    // (by tcpip_link_status). Until AP support is added, we can ignore the
+    // problem.
+    cyw43_wifi_leave(&cyw43_state, CYW43_ITF_AP);
+    bindings_cyw43_wifi_enforce_pm();
 }
 
 void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, uint8_t authmode, uint8_t max_connections) {

--- a/ports/raspberrypi/lwip_inc/lwipopts.h
+++ b/ports/raspberrypi/lwip_inc/lwipopts.h
@@ -92,4 +92,13 @@
 
 #define LWIP_NO_CTYPE_H 1
 
+#define X8_F  "02x"
+#define U16_F "u"
+#define U32_F "lu"
+#define S32_F "ld"
+#define X32_F "lx"
+
+#define S16_F "d"
+#define X16_F "x"
+#define SZT_F "u"
 #endif /* __LWIPOPTS_H__ */

--- a/ports/raspberrypi/lwip_inc/lwipopts.h
+++ b/ports/raspberrypi/lwip_inc/lwipopts.h
@@ -47,6 +47,7 @@
 #define LWIP_TCP                    1
 #define LWIP_UDP                    1
 #define LWIP_DNS                    1
+#define LWIP_DNS_SUPPORT_MDNS_QUERIES   1
 #define LWIP_TCP_KEEPALIVE          1
 #define LWIP_NETIF_TX_SINGLE_PBUF   1
 #define DHCP_DOES_ARP_CHECK         0


### PR DESCRIPTION
 * Fix large `send()` requests on stream packets. Now, they will correctly send only part of the buffer. Typically, 2920 bytes (2×MSS) can be sent on an idle socket, or 1460 bytes (1×MSS) on a socket that's recently seen a transmission. This has always been according to the documentation of `send` but previously send was expected to act like sendall by e.g., adafruit_httpserver. Closes: #7077 
 * Add `sendall()`, compatible with CPython, to send a whole buffer with multiple underlying `send` calls.
 * When lwip debugging is enabled, 16-bit values weren't formatted correctly, because "hu" was not a good string format for mp_printf
 * enabled resolution of `.local` MDNS names. This still doesn't enable picow to *HAVE* a ".local" MDNS name.
 * Implemented `wifi.Radio.stop_station`. After `stop_station`, the ip address is None. A new connection can be made with `connect`. There's something weird about the implementation, but I commented on it for future generations / me in 2 weeks from now.