### PR TITLE
Add `CoprocAlarm`

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -100,6 +100,7 @@ msgstr ""
 msgid "%q failure: %d"
 msgstr ""
 
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #: shared-bindings/digitalio/DigitalInOut.c
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q in use"
@@ -913,9 +914,9 @@ msgid "Error: Failure to bind"
 msgstr ""
 
 #: py/enum.c shared-bindings/_bleio/__init__.c shared-bindings/aesio/aes.c
-#: shared-bindings/alarm/__init__.c shared-bindings/busio/SPI.c
-#: shared-bindings/coproc/Coproc.c shared-bindings/coproc/__init__.c
-#: shared-bindings/microcontroller/Pin.c
+#: shared-bindings/alarm/__init__.c shared-bindings/alarm/coproc/CoprocAlarm.c
+#: shared-bindings/busio/SPI.c shared-bindings/coproc/Coproc.c
+#: shared-bindings/coproc/__init__.c shared-bindings/microcontroller/Pin.c
 #: shared-bindings/neopixel_write/__init__.c
 msgid "Expected a %q"
 msgstr ""
@@ -1615,8 +1616,9 @@ msgid ""
 "%d bpp given"
 msgstr ""
 
+#: ports/espressif/common-hal/alarm/coproc/CoprocAlarm.c
 #: ports/espressif/common-hal/alarm/touch/TouchAlarm.c
-msgid "Only one TouchAlarm can be set in deep sleep."
+msgid "Only one %q can be set in deep sleep."
 msgstr ""
 
 #: ports/espressif/common-hal/i2ctarget/I2CTarget.c

--- a/ports/atmel-samd/common-hal/alarm/coproc/CoprocAlarm.c
+++ b/ports/atmel-samd/common-hal/alarm/coproc/CoprocAlarm.c
@@ -1,0 +1,1 @@
+// empty file

--- a/ports/atmel-samd/common-hal/alarm/coproc/CoprocAlarm.h
+++ b/ports/atmel-samd/common-hal/alarm/coproc/CoprocAlarm.h
@@ -1,0 +1,1 @@
+// empty file

--- a/ports/espressif/common-hal/alarm/coproc/CoprocAlarm.c
+++ b/ports/espressif/common-hal/alarm/coproc/CoprocAlarm.c
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 microDev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "shared-bindings/alarm/coproc/CoprocAlarm.h"
+#include "shared-bindings/coproc/__init__.h"
+
+#include "esp_sleep.h"
+
+#if CIRCUITPY_COPROC
+
+mp_obj_t alarm_coproc_coprocalarm_find_triggered_alarm(const size_t n_alarms, const mp_obj_t *alarms) {
+    for (size_t i = 0; i < n_alarms; i++) {
+        if (mp_obj_is_type(alarms[i], &alarm_coproc_coprocalarm_type)) {
+            return alarms[i];
+        }
+    }
+    return mp_const_none;
+}
+
+mp_obj_t alarm_coproc_coprocalarm_create_wakeup_alarm(void) {
+    // Create CoprocAlarm object.
+    alarm_coproc_coprocalarm_obj_t *alarm = m_new_obj(alarm_coproc_coprocalarm_obj_t);
+    alarm->base.type = &alarm_coproc_coprocalarm_type;
+    return alarm;
+}
+
+void alarm_coproc_coprocalarm_set_alarm(const bool deep_sleep, const size_t n_alarms, const mp_obj_t *alarms) {
+    bool coproc_alarm_set = false;
+    alarm_coproc_coprocalarm_obj_t *coproc_alarm = MP_OBJ_NULL;
+
+    for (size_t i = 0; i < n_alarms; i++) {
+        if (mp_obj_is_type(alarms[i], &alarm_coproc_coprocalarm_type)) {
+            if (deep_sleep && coproc_alarm_set) {
+                mp_raise_ValueError_varg(translate("Only one %q can be set in deep sleep."), MP_QSTR_CoprocAlarm);
+            }
+            coproc_alarm = MP_OBJ_TO_PTR(alarms[i]);
+            coproc_alarm_set = true;
+        }
+    }
+
+    if (!coproc_alarm_set) {
+        return;
+    }
+
+    // load coproc program
+    common_hal_coproc_load(coproc_alarm->coproc);
+}
+
+void alarm_coproc_coprocalarm_prepare_for_deep_sleep(void) {
+    // start coproc program
+    common_hal_coproc_run(NULL);
+
+    // enable coproc wakeup
+    esp_sleep_enable_ulp_wakeup();
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_SLOW_MEM, ESP_PD_OPTION_ON);
+}
+
+bool alarm_coproc_coprocalarm_woke_this_cycle(void) {
+    return false;
+}
+
+void alarm_coproc_coprocalarm_reset(void) {
+}
+
+#else // CIRCUITPY_COPROC
+
+mp_obj_t alarm_coproc_coprocalarm_find_triggered_alarm(const size_t n_alarms, const mp_obj_t *alarms) {
+    return mp_const_none;
+}
+
+mp_obj_t alarm_coproc_coprocalarm_create_wakeup_alarm(void) {
+    return mp_const_none;
+}
+
+void alarm_coproc_coprocalarm_set_alarm(const bool deep_sleep, const size_t n_alarms, const mp_obj_t *alarms) {
+}
+
+void alarm_coproc_coprocalarm_prepare_for_deep_sleep(void) {
+}
+
+bool alarm_coproc_coprocalarm_woke_this_cycle(void) {
+    return false;
+}
+
+void alarm_coproc_coprocalarm_reset(void) {
+}
+
+#endif // CIRCUITPY_COPROC

--- a/ports/espressif/common-hal/alarm/coproc/CoprocAlarm.h
+++ b/ports/espressif/common-hal/alarm/coproc/CoprocAlarm.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -24,15 +24,25 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_COPROC___INIT___H
-#define MICROPY_INCLUDED_SHARED_BINDINGS_COPROC___INIT___H
+#ifndef MICROPY_INCLUDED_COMMON_HAL_ALARM_COPROC_COPROCALARM_H
+#define MICROPY_INCLUDED_COMMON_HAL_ALARM_COPROC_COPROCALARM_H
 
 #include "py/obj.h"
+#include "py/runtime.h"
+
 #include "common-hal/coproc/Coproc.h"
 
-extern void common_hal_coproc_run(coproc_coproc_obj_t *self);
-extern void common_hal_coproc_halt(coproc_coproc_obj_t *self);
-extern void common_hal_coproc_load(coproc_coproc_obj_t *self);
-extern mp_obj_t common_hal_coproc_memory(coproc_coproc_obj_t *self);
+typedef struct {
+    mp_obj_base_t base;
+    coproc_coproc_obj_t *coproc;
+} alarm_coproc_coprocalarm_obj_t;
 
-#endif  // MICROPY_INCLUDED_SHARED_BINDINGS_COPROC___INIT___H
+mp_obj_t alarm_coproc_coprocalarm_find_triggered_alarm(const size_t n_alarms, const mp_obj_t *alarms);
+mp_obj_t alarm_coproc_coprocalarm_create_wakeup_alarm(void);
+
+void alarm_coproc_coprocalarm_prepare_for_deep_sleep(void);
+void alarm_coproc_coprocalarm_reset(void);
+void alarm_coproc_coprocalarm_set_alarm(const bool deep_sleep, const size_t n_alarms, const mp_obj_t *alarms);
+bool alarm_coproc_coprocalarm_woke_this_cycle(void);
+
+#endif  // MICROPY_INCLUDED_COMMON_HAL_ALARM_COPROC_COPROCALARM_H

--- a/ports/espressif/common-hal/alarm/touch/TouchAlarm.c
+++ b/ports/espressif/common-hal/alarm/touch/TouchAlarm.c
@@ -96,7 +96,7 @@ void alarm_touch_touchalarm_set_alarm(const bool deep_sleep, const size_t n_alar
     for (size_t i = 0; i < n_alarms; i++) {
         if (mp_obj_is_type(alarms[i], &alarm_touch_touchalarm_type)) {
             if (deep_sleep && touch_alarm_set) {
-                mp_raise_ValueError(translate("Only one TouchAlarm can be set in deep sleep."));
+                mp_raise_ValueError_varg(translate("Only one %q can be set in deep sleep."), MP_QSTR_TouchAlarm);
             }
             touch_alarm = MP_OBJ_TO_PTR(alarms[i]);
             touch_channel_mask |= 1 << touch_alarm->pin->number;

--- a/ports/espressif/common-hal/coproc/__init__.c
+++ b/ports/espressif/common-hal/coproc/__init__.c
@@ -40,11 +40,6 @@
 #include "soc/rtc_cntl_reg.h"
 
 void common_hal_coproc_run(coproc_coproc_obj_t *self) {
-    if (ulp_riscv_load_binary(self->buf, self->buf_len) != ESP_OK) {
-        mp_raise_RuntimeError(translate("Firmware is too big"));
-    }
-    m_free(self->buf);
-    self->buf = (uint8_t *)RTC_SLOW_MEM;
     ulp_riscv_run();
 }
 
@@ -62,6 +57,14 @@ void common_hal_coproc_halt(coproc_coproc_obj_t *self) {
     SET_PERI_REG_MASK(RTC_CNTL_COCPU_CTRL_REG, RTC_CNTL_COCPU_DONE);
     // Resets the processor
     SET_PERI_REG_MASK(RTC_CNTL_COCPU_CTRL_REG, RTC_CNTL_COCPU_SHUT_RESET_EN);
+}
+
+void common_hal_coproc_load(coproc_coproc_obj_t *self) {
+    if (ulp_riscv_load_binary(self->buf, self->buf_len) != ESP_OK) {
+        mp_raise_RuntimeError(translate("Firmware is too big"));
+    }
+    m_free(self->buf);
+    self->buf = (uint8_t *)RTC_SLOW_MEM;
 }
 
 mp_obj_t common_hal_coproc_memory(coproc_coproc_obj_t *self) {

--- a/ports/nrf/common-hal/alarm/coproc/CoprocAlarm.c
+++ b/ports/nrf/common-hal/alarm/coproc/CoprocAlarm.c
@@ -1,0 +1,1 @@
+// empty file

--- a/ports/nrf/common-hal/alarm/coproc/CoprocAlarm.h
+++ b/ports/nrf/common-hal/alarm/coproc/CoprocAlarm.h
@@ -1,0 +1,1 @@
+// empty file

--- a/ports/raspberrypi/common-hal/alarm/coproc/CoprocAlarm.c
+++ b/ports/raspberrypi/common-hal/alarm/coproc/CoprocAlarm.c
@@ -1,0 +1,1 @@
+// empty file

--- a/ports/raspberrypi/common-hal/alarm/coproc/CoprocAlarm.h
+++ b/ports/raspberrypi/common-hal/alarm/coproc/CoprocAlarm.h
@@ -1,0 +1,1 @@
+// empty file

--- a/ports/stm/common-hal/alarm/coproc/CoprocAlarm.c
+++ b/ports/stm/common-hal/alarm/coproc/CoprocAlarm.c
@@ -1,0 +1,1 @@
+// empty file

--- a/ports/stm/common-hal/alarm/coproc/CoprocAlarm.h
+++ b/ports/stm/common-hal/alarm/coproc/CoprocAlarm.h
@@ -1,0 +1,1 @@
+// empty file

--- a/py/circuitpy_defns.mk
+++ b/py/circuitpy_defns.mk
@@ -400,6 +400,7 @@ SRC_COMMON_HAL_ALL = \
 	alarm/pin/PinAlarm.c \
 	alarm/time/TimeAlarm.c \
 	alarm/touch/TouchAlarm.c \
+	alarm/coproc/CoprocAlarm.c \
 	analogbufio/BufferedIn.c \
 	analogbufio/__init__.c \
 	analogio/AnalogIn.c \

--- a/shared-bindings/alarm/__init__.c
+++ b/shared-bindings/alarm/__init__.c
@@ -32,6 +32,7 @@
 #include "shared-bindings/alarm/pin/PinAlarm.h"
 #include "shared-bindings/alarm/time/TimeAlarm.h"
 #include "shared-bindings/alarm/touch/TouchAlarm.h"
+#include "shared-bindings/alarm/coproc/CoprocAlarm.h"
 #include "shared-bindings/digitalio/DigitalInOut.h"
 #include "shared-bindings/supervisor/Runtime.h"
 #include "shared-bindings/time/__init__.h"
@@ -76,7 +77,8 @@ STATIC void validate_objs_are_alarms(size_t n_args, const mp_obj_t *objs) {
     for (size_t i = 0; i < n_args; i++) {
         if (mp_obj_is_type(objs[i], &alarm_pin_pinalarm_type) ||
             mp_obj_is_type(objs[i], &alarm_time_timealarm_type) ||
-            mp_obj_is_type(objs[i], &alarm_touch_touchalarm_type)) {
+            mp_obj_is_type(objs[i], &alarm_touch_touchalarm_type) ||
+            mp_obj_is_type(objs[i], &alarm_coproc_coprocalarm_type)) {
             continue;
         }
         mp_raise_TypeError_varg(translate("Expected an %q"), MP_QSTR_Alarm);
@@ -252,6 +254,18 @@ STATIC const mp_obj_module_t alarm_touch_module = {
     .globals = (mp_obj_dict_t *)&alarm_touch_globals,
 };
 
+STATIC const mp_map_elem_t alarm_coproc_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_coproc) },
+    { MP_ROM_QSTR(MP_QSTR_CoprocAlarm), MP_OBJ_FROM_PTR(&alarm_coproc_coprocalarm_type) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(alarm_coproc_globals, alarm_coproc_globals_table);
+
+STATIC const mp_obj_module_t alarm_coproc_module = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&alarm_coproc_globals,
+};
+
 // The module table is mutable because .wake_alarm is a mutable attribute.
 STATIC mp_map_elem_t alarm_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_alarm) },
@@ -266,6 +280,7 @@ STATIC mp_map_elem_t alarm_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_pin), MP_OBJ_FROM_PTR(&alarm_pin_module) },
     { MP_ROM_QSTR(MP_QSTR_time), MP_OBJ_FROM_PTR(&alarm_time_module) },
     { MP_ROM_QSTR(MP_QSTR_touch), MP_OBJ_FROM_PTR(&alarm_touch_module) },
+    { MP_ROM_QSTR(MP_QSTR_coproc), MP_OBJ_FROM_PTR(&alarm_coproc_module) },
 
     { MP_ROM_QSTR(MP_QSTR_SleepMemory),   MP_OBJ_FROM_PTR(&alarm_sleep_memory_type) },
     { MP_ROM_QSTR(MP_QSTR_sleep_memory),  MP_OBJ_FROM_PTR(&alarm_sleep_memory_obj) },

--- a/shared-bindings/alarm/coproc/CoprocAlarm.c
+++ b/shared-bindings/alarm/coproc/CoprocAlarm.c
@@ -1,0 +1,87 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 microDev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+
+#if CIRCUITPY_COPROC
+#include "shared-bindings/util.h"
+#include "shared-bindings/alarm/coproc/CoprocAlarm.h"
+#include "shared-bindings/coproc/Coproc.h"
+
+STATIC coproc_coproc_obj_t *get_coproc_obj(mp_obj_t *self_in) {
+    if (!mp_obj_is_type(*self_in, &coproc_coproc_type)) {
+        mp_raise_TypeError_varg(translate("Expected a %q"), MP_QSTR_Coproc);
+    }
+    coproc_coproc_obj_t *self = MP_OBJ_TO_PTR(*self_in);
+    if (common_hal_coproc_coproc_deinited(self)) {
+        raise_deinited_error();
+    }
+    return self;
+}
+#endif
+
+//| class CoprocAlarm:
+//|     """Trigger an alarm when another core or co-processor requests wake-up."""
+//|
+//|     def __init__(self, coproc: coproc.Coproc) -> None:
+//|         """Create an alarm that will be triggered when the co-processor requests wake-up.
+//|
+//|         The alarm is not active until it is passed to an `alarm`-enabling function, such as
+//|         `alarm.light_sleep_until_alarms()` or `alarm.exit_and_deep_sleep_until_alarms()`.
+//|
+//|         :param coproc.Coproc coproc: The coproc program to run.
+//|
+//|         """
+//|         ...
+//|
+STATIC mp_obj_t alarm_coproc_coprocalarm_make_new(const mp_obj_type_t *type,
+    size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    enum { ARG_coproc };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_coproc, MP_ARG_REQUIRED | MP_ARG_OBJ },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    #if CIRCUITPY_COPROC
+    // initialize CoprocAlarm object
+    alarm_coproc_coprocalarm_obj_t *self = m_new_obj(alarm_coproc_coprocalarm_obj_t);
+    self->base.type = &alarm_coproc_coprocalarm_type;
+    self->coproc = get_coproc_obj(&args[ARG_coproc].u_obj);
+    // return CoprocAlarm object
+    return MP_OBJ_FROM_PTR(self);
+    #else
+    mp_raise_NotImplementedError(NULL);
+    return mp_const_none;
+    #endif
+}
+
+const mp_obj_type_t alarm_coproc_coprocalarm_type = {
+    { &mp_type_type },
+    .name = MP_QSTR_CoprocAlarm,
+    .make_new = alarm_coproc_coprocalarm_make_new,
+};

--- a/shared-bindings/alarm/coproc/CoprocAlarm.h
+++ b/shared-bindings/alarm/coproc/CoprocAlarm.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -24,15 +24,11 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_COPROC___INIT___H
-#define MICROPY_INCLUDED_SHARED_BINDINGS_COPROC___INIT___H
+#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_ALARM_COPROC_COPROCALARM_H
+#define MICROPY_INCLUDED_SHARED_BINDINGS_ALARM_COPROC_COPROCALARM_H
 
-#include "py/obj.h"
-#include "common-hal/coproc/Coproc.h"
+#include "common-hal/alarm/coproc/CoprocAlarm.h"
 
-extern void common_hal_coproc_run(coproc_coproc_obj_t *self);
-extern void common_hal_coproc_halt(coproc_coproc_obj_t *self);
-extern void common_hal_coproc_load(coproc_coproc_obj_t *self);
-extern mp_obj_t common_hal_coproc_memory(coproc_coproc_obj_t *self);
+extern const mp_obj_type_t alarm_coproc_coprocalarm_type;
 
-#endif  // MICROPY_INCLUDED_SHARED_BINDINGS_COPROC___INIT___H
+#endif  // MICROPY_INCLUDED_SHARED_BINDINGS_ALARM_COPROC_COPROCALARM_H

--- a/shared-bindings/coproc/__init__.c
+++ b/shared-bindings/coproc/__init__.c
@@ -68,7 +68,9 @@ STATIC coproc_coproc_obj_t *get_coproc_obj(mp_obj_t *self_in) {
 //|     ...
 //|
 STATIC mp_obj_t coproc_run(mp_obj_t self_in) {
-    common_hal_coproc_run(get_coproc_obj(&self_in));
+    coproc_coproc_obj_t *self = get_coproc_obj(&self_in);
+    common_hal_coproc_load(self);
+    common_hal_coproc_run(self);
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(coproc_run_obj, coproc_run);


### PR DESCRIPTION
```python
# CircuitPython

import alarm
import coproc

if alarm.wake_alarm is None:
    with open("sleep.bin", "rb") as f:
        program = coproc.Coproc(buffer=f.read())
    alarm.exit_and_deep_sleep_until_alarms(alarm.coproc.CoprocAlarm(program))
else:
    print(alarm.wake_alarm)

```
```c
// ULP RISC-V

#include <stdio.h>
#include <stdint.h>
#include <stdbool.h>
#include "ulp_riscv/ulp_riscv.h"
#include "ulp_riscv/ulp_riscv_utils.h"
#include "ulp_riscv/ulp_riscv_gpio.h"

int main (void) {
    bool gpio_level = true;

    ulp_riscv_gpio_init(GPIO_NUM_21);
    ulp_riscv_gpio_output_enable(GPIO_NUM_21);

    for (uint8_t i = 0; i < 10; i++) {
        ulp_riscv_gpio_output_level(GPIO_NUM_21, gpio_level);
        ulp_riscv_delay_cycles(500 * ULP_RISCV_CYCLES_PER_MS);
        gpio_level = !gpio_level;
    }
    
    ulp_riscv_wakeup_main_processor();

    // ulp_riscv_shutdown() is called automatically when main exits
    return 0;
}
```