### PR TITLE
Extend error checking of str, bytes encoding and errors arguments

### DIFF
--- a/tests/basics/bytes.py
+++ b/tests/basics/bytes.py
@@ -18,9 +18,9 @@ print(repr(a))
 print(a[0], a[2])
 print(a[-1])
 print(str(a, "utf-8"))
-print(str(a, "utf-8", "ignore"))
+print(str(a, "utf-8", "strict"))
 try:
-    str(a, "utf-8", "ignore", "toomuch")
+    str(a, "utf-8", "strict", "toomuch")
 except TypeError:
     print("TypeError")
 
@@ -29,17 +29,6 @@ for i in a:
     s += i
 print(s)
 
-
-print(bytes("abc", "utf-8"))
-print(bytes("abc", "utf-8", "replace"))
-try:
-    bytes("abc")
-except TypeError:
-    print("TypeError")
-try:
-    bytes("abc", "utf-8", "replace", "toomuch")
-except TypeError:
-    print("TypeError")
 
 print(bytes(3))
 
@@ -62,3 +51,17 @@ try:
     bytes(-1)
 except ValueError:
     print('ValueError')
+
+# Test that invalid encoding names are caught
+try:
+    str(a, "cabbage", "strict")
+except Exception:
+    print("Exception")
+
+# Test that invalid error values are caught. On Python3 requires that an
+# encoding error is actually encountered; on CP, it errors prompty at the
+# time of the call
+try:
+    str("\x80", "utf-8", "banana")
+except Exception:
+    print("Exception")

--- a/tests/circuitpython/aes.py
+++ b/tests/circuitpython/aes.py
@@ -7,7 +7,7 @@ inp = b"CircuitPython!!!"  # Note: 16-bytes long
 outp = bytearray(len(inp))
 cipher = aesio.AES(key, aesio.MODE_ECB)
 cipher.encrypt_into(inp, outp)
-print(str(hexlify(outp), ""))
+print(str(hexlify(outp), "utf-8"))
 
 cipher = aesio.AES(key, aesio.MODE_ECB)
 cipher.decrypt_into(outp, outp)

--- a/tests/extmod/ujson_dump_iobase.py
+++ b/tests/extmod/ujson_dump_iobase.py
@@ -23,7 +23,7 @@ class S(io.IOBase):
     def write(self, buf):
         if type(buf) == bytearray:
             # uPy passes a bytearray, CPython passes a str
-            buf = str(buf, "ascii")
+            buf = str(buf, "utf-8")
         self.buf += buf
         return len(buf)
 


### PR DESCRIPTION
I'm not sure we _want_ to do this, it trades memory for no new functionality except more exceptions.

Tests cases are changed because "ignore" and "replace" were never supported and because the utf-8 encoding should always be specified by name, rather than depending on the empty string.

(However, the empty string is accepted as a valid encoding name for compatibility with previous versions of CircuitPython)

Because Python3 checks late for the validity of an 'errors' value, this is a new difference, failing on CP but passing on CPython:
```
>>> bytes("", "utf-8", "banana")
```

Frankly, on reflection after writing this I think we'll probably choose not to accept it which is just fine. This creates a record for someone else, perhaps.