### PR TITLE
Fix coproc halt esp32s3

### DIFF
--- a/ports/espressif/Makefile
+++ b/ports/espressif/Makefile
@@ -21,6 +21,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+ifneq ($(MAKECMDGOALS),print-CC)
+ifeq ($(origin IDF_PATH),undefined)
+$(error You must "source esp-idf/export.sh" before building)
+endif
+endif
 
 # Select the board to build for.
 ifeq ($(BOARD),)

--- a/ports/espressif/common-hal/coproc/__init__.c
+++ b/ports/espressif/common-hal/coproc/__init__.c
@@ -29,6 +29,8 @@
 #include "py/mphal.h"
 #include "py/runtime.h"
 
+#include "esp_idf_version.h"
+
 #if defined(CONFIG_IDF_TARGET_ESP32S2)
 #include "esp32s2/ulp.h"
 #include "esp32s2/ulp_riscv.h"


### PR DESCRIPTION
I found that on the esp32-s3-eye, `coproc.halt()` frequently caused the main CPU to crash or CircuitPython to otherwise
become unresponsive. After experimentation, I arrived at this alternate reset/halt sequence.

I didn't do any testing on S2.

Closes: #7109