### PR TITLE
Pico W: Enable, use SOF_REUSEADDR

### DIFF
--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -852,6 +852,8 @@ bool common_hal_socketpool_socket_bind(socketpool_socket_obj_t *socket,
         mp_raise_OSError(EHOSTUNREACH);
     }
 
+    ip_set_option(socket->pcb.ip, SOF_REUSEADDR);
+
     err_t err = ERR_ARG;
     switch (socket->type) {
         case MOD_NETWORK_SOCK_STREAM: {

--- a/ports/raspberrypi/common-hal/socketpool/Socket.h
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.h
@@ -37,6 +37,7 @@ typedef struct _lwip_socket_obj_t {
     mp_obj_base_t base;
 
     volatile union {
+        struct tcp_pcb *ip;
         struct tcp_pcb *tcp;
         struct udp_pcb *udp;
         struct raw_pcb *raw;

--- a/ports/raspberrypi/lwip_inc/lwipopts.h
+++ b/ports/raspberrypi/lwip_inc/lwipopts.h
@@ -52,6 +52,7 @@
 #define LWIP_NETIF_TX_SINGLE_PBUF   1
 #define DHCP_DOES_ARP_CHECK         0
 #define LWIP_DHCP_DOES_ACD_CHECK    0
+#define SO_REUSE                    1
 
 #ifndef NDEBUG
 #define LWIP_DEBUG                  1


### PR DESCRIPTION
This is the lwip no-os version of SO_REUSEADDR, which is set on all listening sockets in the espressif port; do so here as well, it makes running servers easier. The "address in use" (OSError: [Errno 112] EADDRINUSE) error does not occur.