### PR TITLE
Raise error with positive code in recv_into for espressif

### DIFF
--- a/ports/espressif/common-hal/socketpool/Socket.c
+++ b/ports/espressif/common-hal/socketpool/Socket.c
@@ -483,7 +483,7 @@ int socketpool_socket_recv_into(socketpool_socket_obj_t *self,
 mp_uint_t common_hal_socketpool_socket_recv_into(socketpool_socket_obj_t *self, const uint8_t *buf, uint32_t len) {
     int received = socketpool_socket_recv_into(self, buf, len);
     if (received < 0) {
-        mp_raise_OSError(received);
+        mp_raise_OSError(-received);
     }
     return received;
 }


### PR DESCRIPTION
I saw [this comment](https://github.com/adafruit/circuitpython/issues/6988#issuecomment-1289317767) of someone claiming that [miniMQTT](https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/) fails on ESP32-S2 with a similar error as I fixed for Pico W in PR #7048.

I was able to reproduce it and saw that it throws an error with the error code -11. This is a negative version of `errno.EAGAIN` (11) and causes the error not to be ignored by miniMQTT.

I've tested the fix on an UnexpectedMaker Feather S2.