### PR TITLE
Fix formatting of "Limitations:" in a couple of modules

### DIFF
--- a/shared-bindings/analogio/AnalogOut.c
+++ b/shared-bindings/analogio/AnalogOut.c
@@ -39,6 +39,9 @@
 //| class AnalogOut:
 //|     """Output analog values (a specific voltage).
 //|
+//|     **Limitations:** Not available on nRF, RP2040, Spresense, as there is no on-chip DAC.
+//|     On Espressif, available only on ESP32 and ESP32-S2; other chips do not have a DAC.
+//|
 //|     Example usage::
 //|
 //|         import analogio
@@ -52,8 +55,6 @@
 //|
 //|         :param ~microcontroller.Pin pin: the pin to output to
 //|
-//|         **Limitations:** Not available on nRF, RP2040, Spresense: there is no on-chip DAC.
-//|          Espressif: available only on ESP32 and ESP32-S2; other chips do not have a DAC.
 //|         """
 //|         ...
 STATIC mp_obj_t analogio_analogout_make_new(const mp_obj_type_t *type, mp_uint_t n_args, size_t n_kw, const mp_obj_t *args) {

--- a/shared-bindings/microcontroller/Processor.c
+++ b/shared-bindings/microcontroller/Processor.c
@@ -107,7 +107,7 @@ MP_PROPERTY_GETTER(mcu_processor_reset_reason_obj,
 //|     Is `None` if the temperature is not available.
 //|
 //|     **Limitations:** Not available on ESP32 or ESP32-S3. On small SAMD21 builds without external flash,
-//|       the reported temperature has reduced accuracy and precision, to save code space.
+//|     the reported temperature has reduced accuracy and precision, to save code space.
 //|     """
 STATIC mp_obj_t mcu_processor_get_temperature(mp_obj_t self) {
     float temperature = common_hal_mcu_processor_get_temperature();


### PR DESCRIPTION
When "Limitations:" is in the class docstring, it is sometimes taken as a class attribute name because of the colon. When exactly is not clear, but changing embedded colons or various indentations fixes the problem.