### PR TITLE
Added safe mode button and fix coyright attribution

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2642,7 +2642,7 @@ msgstr ""
 msgid "can't set 512 block size"
 msgstr ""
 
-#: py/objnamedtuple.c
+#: py/objexcept.c py/objnamedtuple.c
 msgid "can't set attribute"
 msgstr ""
 
@@ -3842,6 +3842,11 @@ msgstr ""
 #: ports/atmel-samd/boards/escornabot_makech/mpconfigboard.h
 #: ports/atmel-samd/boards/meowmeow/mpconfigboard.h
 msgid "pressing both buttons at start up.\n"
+msgstr ""
+
+#: ports/espressif/boards/m5stack_core_basic/mpconfigboard.h
+#: ports/espressif/boards/m5stack_core_fire/mpconfigboard.h
+msgid "pressing button A at start up.\n"
 msgstr ""
 
 #: ports/nrf/boards/aramcon2_badge/mpconfigboard.h

--- a/ports/espressif/boards/m5stack_core_basic/board.c
+++ b/ports/espressif/boards/m5stack_core_basic/board.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2020 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2022 CDarius
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/ports/espressif/boards/m5stack_core_basic/mpconfigboard.h
+++ b/ports/espressif/boards/m5stack_core_basic/mpconfigboard.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 Dan Halbert for Adafruit Industries
+ * Copyright (c) 2022 CDarius
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,12 @@
 
 #define CIRCUITPY_BOARD_UART        (1)
 #define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO17, .rx = &pin_GPIO16}}
+
+// For entering safe mode
+#define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO39)
+
+// Explanation of how a user got into safe mode
+#define BOARD_USER_SAFE_MODE_ACTION translate("pressing button A at start up.\n")
 
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)

--- a/ports/espressif/boards/m5stack_core_fire/board.c
+++ b/ports/espressif/boards/m5stack_core_fire/board.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2020 Scott Shawcroft for Adafruit Industries
+ * Copyright (c) 2022 CDarius
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/ports/espressif/boards/m5stack_core_fire/mpconfigboard.h
+++ b/ports/espressif/boards/m5stack_core_fire/mpconfigboard.h
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2022 Dan Halbert for Adafruit Industries
+ * Copyright (c) 2022 CDarius
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,12 @@
 // GPIO16 & GPIO17 are used for PSRAM
 // #define CIRCUITPY_BOARD_UART        (1)
 // #define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO17, .rx = &pin_GPIO16}}
+
+// For entering safe mode
+#define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO39)
+
+// Explanation of how a user got into safe mode
+#define BOARD_USER_SAFE_MODE_ACTION translate("pressing button A at start up.\n")
 
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)


### PR DESCRIPTION
I'm adding the boot in safe mode via button for M5Stack Core Basic and Fire
I've also fixed copyright attirbution on this two board files