### PR TITLE
TileGrid divmod optimization

### DIFF
--- a/ports/atmel-samd/common-hal/paralleldisplay/ParallelBus.c
+++ b/ports/atmel-samd/common-hal/paralleldisplay/ParallelBus.c
@@ -132,10 +132,10 @@ bool common_hal_paralleldisplay_parallelbus_begin_transaction(mp_obj_t obj) {
     return true;
 }
 
-void common_hal_paralleldisplay_parallelbus_send(mp_obj_t obj, display_byte_type_t byte_type,
-    display_chip_select_behavior_t chip_select, const uint8_t *data, uint32_t data_length) {
+void common_hal_paralleldisplay_parallelbus_send(mp_obj_t obj, display_write_mode_t mode,
+    const uint8_t *data, uint32_t data_length) {
     paralleldisplay_parallelbus_obj_t *self = MP_OBJ_TO_PTR(obj);
-    common_hal_digitalio_digitalinout_set_value(&self->command, byte_type == DISPLAY_DATA);
+    common_hal_digitalio_digitalinout_set_value(&self->command, (mode & MASK_DISPLAY) == DISPLAY_DATA);
     uint32_t *clear_write = (uint32_t *)&self->write_group->OUTCLR.reg;
     uint32_t *set_write = (uint32_t *)&self->write_group->OUTSET.reg;
     uint32_t mask = self->write_mask;

--- a/ports/espressif/common-hal/paralleldisplay/ParallelBus.c
+++ b/ports/espressif/common-hal/paralleldisplay/ParallelBus.c
@@ -172,11 +172,11 @@ bool common_hal_paralleldisplay_parallelbus_begin_transaction(mp_obj_t obj) {
     return r;
 }
 
-void common_hal_paralleldisplay_parallelbus_send(mp_obj_t obj, display_byte_type_t byte_type,
-    display_chip_select_behavior_t chip_select, const uint8_t *data, uint32_t data_length) {
+void common_hal_paralleldisplay_parallelbus_send(mp_obj_t obj, display_write_mode_t mode,
+    const uint8_t *data, uint32_t data_length) {
     paralleldisplay_parallelbus_obj_t *self = MP_OBJ_TO_PTR(obj);
     if (data_length) {
-        gpio_set_level(self->config.pin_num_rs, byte_type == DISPLAY_DATA);
+        gpio_set_level(self->config.pin_num_rs, (mode & MASK_DISPLAY) == DISPLAY_DATA);
         i2s_lcd_write(self->handle, data, data_length);
     }
 }

--- a/ports/nrf/common-hal/paralleldisplay/ParallelBus.c
+++ b/ports/nrf/common-hal/paralleldisplay/ParallelBus.c
@@ -141,10 +141,10 @@ bool common_hal_paralleldisplay_parallelbus_begin_transaction(mp_obj_t obj) {
 }
 
 // This ignores chip_select behaviour because data is clocked in by the write line toggling.
-void common_hal_paralleldisplay_parallelbus_send(mp_obj_t obj, display_byte_type_t byte_type,
-    display_chip_select_behavior_t chip_select, const uint8_t *data, uint32_t data_length) {
+void common_hal_paralleldisplay_parallelbus_send(mp_obj_t obj, display_write_mode_t mode,
+    const uint8_t *data, uint32_t data_length) {
     paralleldisplay_parallelbus_obj_t *self = MP_OBJ_TO_PTR(obj);
-    common_hal_digitalio_digitalinout_set_value(&self->command, byte_type == DISPLAY_DATA);
+    common_hal_digitalio_digitalinout_set_value(&self->command, (mode & MODE_DISPLAY) == DISPLAY_DATA);
     uint32_t *clear_write = (uint32_t *)&self->write_group->OUTCLR;
     uint32_t *set_write = (uint32_t *)&self->write_group->OUTSET;
     uint32_t mask = self->write_mask;

--- a/ports/raspberrypi/common-hal/paralleldisplay/ParallelBus.c
+++ b/ports/raspberrypi/common-hal/paralleldisplay/ParallelBus.c
@@ -155,12 +155,12 @@ bool common_hal_paralleldisplay_parallelbus_begin_transaction(mp_obj_t obj) {
     return true;
 }
 
-void common_hal_paralleldisplay_parallelbus_send(mp_obj_t obj, display_byte_type_t byte_type,
-    display_chip_select_behavior_t chip_select, const uint8_t *data, uint32_t data_length) {
+void common_hal_paralleldisplay_parallelbus_send(mp_obj_t obj, display_write_mode_t mode,
+    const uint8_t *data, uint32_t data_length) {
 
     paralleldisplay_parallelbus_obj_t *self = MP_OBJ_TO_PTR(obj);
 
-    common_hal_digitalio_digitalinout_set_value(&self->command, byte_type == DISPLAY_DATA);
+    common_hal_digitalio_digitalinout_set_value(&self->command, mode & DISPLAY_DATA);
     common_hal_rp2pio_statemachine_write(&self->state_machine, data, data_length, 1, false);
 }
 

--- a/shared-bindings/displayio/Bitmap.h
+++ b/shared-bindings/displayio/Bitmap.h
@@ -45,7 +45,7 @@ void common_hal_displayio_bitmap_set_pixel(displayio_bitmap_t *bitmap, int16_t x
 void common_hal_displayio_bitmap_blit(displayio_bitmap_t *self, int16_t x, int16_t y, displayio_bitmap_t *source,
     int16_t x1, int16_t y1, int16_t x2, int16_t y2,
     uint32_t skip_index, bool skip_index_none);
-uint32_t common_hal_displayio_bitmap_get_pixel(displayio_bitmap_t *bitmap, int16_t x, int16_t y);
+uint32_t common_hal_displayio_bitmap_get_pixel(void *bitmap, int16_t x, int16_t y);
 void common_hal_displayio_bitmap_fill(displayio_bitmap_t *bitmap, uint32_t value);
 int common_hal_displayio_bitmap_get_buffer(displayio_bitmap_t *self, mp_buffer_info_t *bufinfo, mp_uint_t flags);
 

--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -148,12 +148,12 @@ STATIC mp_obj_t displayio_fourwire_obj_send(size_t n_args, const mp_obj_t *pos_a
     while (!common_hal_displayio_fourwire_begin_transaction(self)) {
         RUN_BACKGROUND_TASKS;
     }
-    display_chip_select_behavior_t chip_select = CHIP_SELECT_UNTOUCHED;
+    display_write_mode_t chip_select = CHIP_SELECT_UNTOUCHED;
     if (args[ARG_toggle_every_byte].u_bool) {
         chip_select = CHIP_SELECT_TOGGLE_EVERY_BYTE;
     }
-    common_hal_displayio_fourwire_send(self, DISPLAY_COMMAND, chip_select, &command, 1);
-    common_hal_displayio_fourwire_send(self, DISPLAY_DATA, chip_select, ((uint8_t *)bufinfo.buf), bufinfo.len);
+    common_hal_displayio_fourwire_send(self, DISPLAY_COMMAND | chip_select, &command, 1);
+    common_hal_displayio_fourwire_send(self, DISPLAY_DATA | chip_select, ((uint8_t *)bufinfo.buf), bufinfo.len);
     common_hal_displayio_fourwire_end_transaction(self);
 
     return mp_const_none;

--- a/shared-bindings/displayio/FourWire.h
+++ b/shared-bindings/displayio/FourWire.h
@@ -48,8 +48,8 @@ bool common_hal_displayio_fourwire_bus_free(mp_obj_t self);
 
 bool common_hal_displayio_fourwire_begin_transaction(mp_obj_t self);
 
-void common_hal_displayio_fourwire_send(mp_obj_t self, display_byte_type_t byte_type,
-    display_chip_select_behavior_t chip_select, const uint8_t *data, uint32_t data_length);
+void common_hal_displayio_fourwire_send(mp_obj_t self, display_write_mode_t mode,
+    const uint8_t *data, uint32_t data_length);
 
 void common_hal_displayio_fourwire_end_transaction(mp_obj_t self);
 

--- a/shared-bindings/displayio/I2CDisplay.c
+++ b/shared-bindings/displayio/I2CDisplay.c
@@ -116,7 +116,7 @@ STATIC mp_obj_t displayio_i2cdisplay_obj_send(mp_obj_t self, mp_obj_t command_ob
     uint8_t full_command[bufinfo.len + 1];
     full_command[0] = command;
     memcpy(full_command + 1, ((uint8_t *)bufinfo.buf), bufinfo.len);
-    common_hal_displayio_i2cdisplay_send(self, DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, full_command, bufinfo.len + 1);
+    common_hal_displayio_i2cdisplay_send(self, DISPLAY_COMMAND | CHIP_SELECT_UNTOUCHED, full_command, bufinfo.len + 1);
     common_hal_displayio_i2cdisplay_end_transaction(self);
 
     return mp_const_none;

--- a/shared-bindings/displayio/I2CDisplay.h
+++ b/shared-bindings/displayio/I2CDisplay.h
@@ -44,8 +44,8 @@ bool common_hal_displayio_i2cdisplay_bus_free(mp_obj_t self);
 
 bool common_hal_displayio_i2cdisplay_begin_transaction(mp_obj_t self);
 
-void common_hal_displayio_i2cdisplay_send(mp_obj_t self, display_byte_type_t byte_type,
-    display_chip_select_behavior_t chip_select, const uint8_t *data, uint32_t data_length);
+void common_hal_displayio_i2cdisplay_send(mp_obj_t self, display_write_mode_t mode,
+    const uint8_t *data, uint32_t data_length);
 
 void common_hal_displayio_i2cdisplay_end_transaction(mp_obj_t self);
 

--- a/shared-bindings/displayio/OnDiskBitmap.h
+++ b/shared-bindings/displayio/OnDiskBitmap.h
@@ -34,7 +34,7 @@ extern const mp_obj_type_t displayio_ondiskbitmap_type;
 
 void common_hal_displayio_ondiskbitmap_construct(displayio_ondiskbitmap_t *self, pyb_file_obj_t *file);
 
-uint32_t common_hal_displayio_ondiskbitmap_get_pixel(displayio_ondiskbitmap_t *bitmap,
+uint32_t common_hal_displayio_ondiskbitmap_get_pixel(void *bitmap,
     int16_t x, int16_t y);
 
 uint16_t common_hal_displayio_ondiskbitmap_get_height(displayio_ondiskbitmap_t *self);

--- a/shared-bindings/displayio/__init__.h
+++ b/shared-bindings/displayio/__init__.h
@@ -31,14 +31,14 @@
 #include "py/obj.h"
 
 typedef enum {
-    DISPLAY_COMMAND,
-    DISPLAY_DATA
-} display_byte_type_t;
+    DISPLAY_COMMAND = 0,
+    DISPLAY_DATA = 1,
+    MASK_DISPLAY = DISPLAY_DATA,
 
-typedef enum {
-    CHIP_SELECT_UNTOUCHED,
-    CHIP_SELECT_TOGGLE_EVERY_BYTE
-} display_chip_select_behavior_t;
+    CHIP_SELECT_UNTOUCHED = 0,
+    CHIP_SELECT_TOGGLE_EVERY_BYTE = 2,
+    MASK_CHIP_SELECT = CHIP_SELECT_TOGGLE_EVERY_BYTE,
+} display_write_mode_t;
 
 typedef enum displayio_colorspace {
     DISPLAYIO_COLORSPACE_RGB888,
@@ -56,8 +56,7 @@ typedef enum displayio_colorspace {
 typedef bool (*display_bus_bus_reset)(mp_obj_t bus);
 typedef bool (*display_bus_bus_free)(mp_obj_t bus);
 typedef bool (*display_bus_begin_transaction)(mp_obj_t bus);
-typedef void (*display_bus_send)(mp_obj_t bus, display_byte_type_t byte_type,
-    display_chip_select_behavior_t chip_select, const uint8_t *data, uint32_t data_length);
+typedef void (*display_bus_send)(mp_obj_t bus, display_write_mode_t mode, const uint8_t *data, uint32_t data_length);
 typedef void (*display_bus_end_transaction)(mp_obj_t bus);
 
 void common_hal_displayio_release_displays(void);

--- a/shared-bindings/paralleldisplay/ParallelBus.c
+++ b/shared-bindings/paralleldisplay/ParallelBus.c
@@ -144,8 +144,8 @@ STATIC mp_obj_t paralleldisplay_parallelbus_obj_send(mp_obj_t self, mp_obj_t com
     while (!common_hal_paralleldisplay_parallelbus_begin_transaction(self)) {
         RUN_BACKGROUND_TASKS;
     }
-    common_hal_paralleldisplay_parallelbus_send(self, DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, &command, 1);
-    common_hal_paralleldisplay_parallelbus_send(self, DISPLAY_DATA, CHIP_SELECT_UNTOUCHED, ((uint8_t *)bufinfo.buf), bufinfo.len);
+    common_hal_paralleldisplay_parallelbus_send(self, DISPLAY_COMMAND | CHIP_SELECT_UNTOUCHED, &command, 1);
+    common_hal_paralleldisplay_parallelbus_send(self, DISPLAY_DATA | CHIP_SELECT_UNTOUCHED, ((uint8_t *)bufinfo.buf), bufinfo.len);
     common_hal_paralleldisplay_parallelbus_end_transaction(self);
 
     return mp_const_none;

--- a/shared-bindings/paralleldisplay/ParallelBus.h
+++ b/shared-bindings/paralleldisplay/ParallelBus.h
@@ -49,7 +49,7 @@ bool common_hal_paralleldisplay_parallelbus_bus_free(mp_obj_t self);
 
 bool common_hal_paralleldisplay_parallelbus_begin_transaction(mp_obj_t self);
 
-void common_hal_paralleldisplay_parallelbus_send(mp_obj_t self, display_byte_type_t byte_type,
-    display_chip_select_behavior_t chip_select, const uint8_t *data, uint32_t data_length);
+void common_hal_paralleldisplay_parallelbus_send(mp_obj_t self, display_write_mode_t mode,
+    const uint8_t *data, uint32_t data_length);
 
 void common_hal_paralleldisplay_parallelbus_end_transaction(mp_obj_t self);

--- a/shared-module/displayio/Bitmap.c
+++ b/shared-module/displayio/Bitmap.c
@@ -92,7 +92,8 @@ uint32_t common_hal_displayio_bitmap_get_bits_per_value(displayio_bitmap_t *self
     return self->bits_per_value;
 }
 
-uint32_t common_hal_displayio_bitmap_get_pixel(displayio_bitmap_t *self, int16_t x, int16_t y) {
+uint32_t common_hal_displayio_bitmap_get_pixel(void *self_in, int16_t x, int16_t y) {
+    displayio_bitmap_t *self = self_in;
     if (x >= self->width || x < 0 || y >= self->height || y < 0) {
         return 0;
     }

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -92,10 +92,10 @@ void common_hal_displayio_display_construct(displayio_display_obj_t *self,
             uint8_t full_command[data_size + 1];
             full_command[0] = cmd[0];
             memcpy(full_command + 1, data, data_size);
-            self->core.send(self->core.bus, DISPLAY_COMMAND, CHIP_SELECT_TOGGLE_EVERY_BYTE, full_command, data_size + 1);
+            self->core.send(self->core.bus, DISPLAY_COMMAND | CHIP_SELECT_TOGGLE_EVERY_BYTE, full_command, data_size + 1);
         } else {
-            self->core.send(self->core.bus, DISPLAY_COMMAND, CHIP_SELECT_TOGGLE_EVERY_BYTE, cmd, 1);
-            self->core.send(self->core.bus, DISPLAY_DATA, CHIP_SELECT_UNTOUCHED, data, data_size);
+            self->core.send(self->core.bus, DISPLAY_COMMAND | CHIP_SELECT_TOGGLE_EVERY_BYTE, cmd, 1);
+            self->core.send(self->core.bus, DISPLAY_DATA | CHIP_SELECT_UNTOUCHED, data, data_size);
         }
         displayio_display_core_end_transaction(&self->core);
         uint16_t delay_length_ms = 10;
@@ -184,12 +184,12 @@ bool common_hal_displayio_display_set_brightness(displayio_display_obj_t *self, 
         if (ok) {
             if (self->data_as_commands) {
                 uint8_t set_brightness[2] = {self->brightness_command, (uint8_t)(0xff * brightness)};
-                self->core.send(self->core.bus, DISPLAY_COMMAND, CHIP_SELECT_TOGGLE_EVERY_BYTE, set_brightness, 2);
+                self->core.send(self->core.bus, DISPLAY_COMMAND | CHIP_SELECT_TOGGLE_EVERY_BYTE, set_brightness, 2);
             } else {
                 uint8_t command = self->brightness_command;
                 uint8_t hex_brightness = 0xff * brightness;
-                self->core.send(self->core.bus, DISPLAY_COMMAND, CHIP_SELECT_TOGGLE_EVERY_BYTE, &command, 1);
-                self->core.send(self->core.bus, DISPLAY_DATA, CHIP_SELECT_UNTOUCHED, &hex_brightness, 1);
+                self->core.send(self->core.bus, DISPLAY_COMMAND | CHIP_SELECT_TOGGLE_EVERY_BYTE, &command, 1);
+                self->core.send(self->core.bus, DISPLAY_DATA | CHIP_SELECT_UNTOUCHED, &hex_brightness, 1);
             }
             displayio_display_core_end_transaction(&self->core);
         }
@@ -221,9 +221,9 @@ STATIC const displayio_area_t *_get_refresh_areas(displayio_display_obj_t *self)
 
 STATIC void _send_pixels(displayio_display_obj_t *self, uint8_t *pixels, uint32_t length) {
     if (!self->data_as_commands) {
-        self->core.send(self->core.bus, DISPLAY_COMMAND, CHIP_SELECT_TOGGLE_EVERY_BYTE, &self->write_ram_command, 1);
+        self->core.send(self->core.bus, DISPLAY_COMMAND | CHIP_SELECT_TOGGLE_EVERY_BYTE, &self->write_ram_command, 1);
     }
-    self->core.send(self->core.bus, DISPLAY_DATA, CHIP_SELECT_UNTOUCHED, pixels, length);
+    self->core.send(self->core.bus, DISPLAY_DATA | CHIP_SELECT_UNTOUCHED, pixels, length);
 }
 
 STATIC bool _refresh_area(displayio_display_obj_t *self, const displayio_area_t *area) {

--- a/shared-module/displayio/EPaperDisplay.c
+++ b/shared-module/displayio/EPaperDisplay.c
@@ -153,8 +153,8 @@ STATIC void send_command_sequence(displayio_epaperdisplay_obj_t *self,
             data = cmd + 3;
         }
         displayio_display_core_begin_transaction(&self->core);
-        self->core.send(self->core.bus, DISPLAY_COMMAND, self->chip_select, cmd, 1);
-        self->core.send(self->core.bus, DISPLAY_DATA, self->chip_select, data, data_size);
+        self->core.send(self->core.bus, DISPLAY_COMMAND | self->chip_select, cmd, 1);
+        self->core.send(self->core.bus, DISPLAY_DATA | self->chip_select, data, data_size);
         displayio_display_core_end_transaction(&self->core);
         uint16_t delay_length_ms = 0;
         if (delay) {
@@ -205,7 +205,7 @@ uint32_t common_hal_displayio_epaperdisplay_get_time_to_refresh(displayio_epaper
 STATIC void displayio_epaperdisplay_finish_refresh(displayio_epaperdisplay_obj_t *self) {
     // Actually refresh the display now that all pixel RAM has been updated.
     displayio_display_core_begin_transaction(&self->core);
-    self->core.send(self->core.bus, DISPLAY_COMMAND, self->chip_select, &self->refresh_display_command, 1);
+    self->core.send(self->core.bus, DISPLAY_COMMAND | self->chip_select, &self->refresh_display_command, 1);
     displayio_display_core_end_transaction(&self->core);
     supervisor_enable_tick();
     self->refreshing = true;
@@ -292,7 +292,7 @@ STATIC bool displayio_epaperdisplay_refresh_area(displayio_epaperdisplay_obj_t *
             write_command = self->write_color_ram_command;
         }
         displayio_display_core_begin_transaction(&self->core);
-        self->core.send(self->core.bus, DISPLAY_COMMAND, self->chip_select, &write_command, 1);
+        self->core.send(self->core.bus, DISPLAY_COMMAND | self->chip_select, &write_command, 1);
         displayio_display_core_end_transaction(&self->core);
 
         for (uint16_t j = 0; j < subrectangles; j++) {
@@ -339,7 +339,7 @@ STATIC bool displayio_epaperdisplay_refresh_area(displayio_epaperdisplay_obj_t *
                 // Can't acquire display bus; skip the rest of the data. Try next display.
                 return false;
             }
-            self->core.send(self->core.bus, DISPLAY_DATA, self->chip_select, (uint8_t *)buffer, subrectangle_size_bytes);
+            self->core.send(self->core.bus, DISPLAY_DATA | self->chip_select, (uint8_t *)buffer, subrectangle_size_bytes);
             displayio_display_core_end_transaction(&self->core);
 
             // TODO(tannewt): Make refresh displays faster so we don't starve other

--- a/shared-module/displayio/EPaperDisplay.h
+++ b/shared-module/displayio/EPaperDisplay.h
@@ -56,7 +56,7 @@ typedef struct {
     bool color_bits_inverted;
     bool refreshing;
     bool grayscale;
-    display_chip_select_behavior_t chip_select;
+    display_write_mode_t chip_select;
     bool two_byte_sequence_length;
 } displayio_epaperdisplay_obj_t;
 

--- a/shared-module/displayio/FourWire.c
+++ b/shared-module/displayio/FourWire.c
@@ -115,8 +115,7 @@ bool common_hal_displayio_fourwire_begin_transaction(mp_obj_t obj) {
     return true;
 }
 
-void common_hal_displayio_fourwire_send(mp_obj_t obj, display_byte_type_t data_type,
-    display_chip_select_behavior_t chip_select, const uint8_t *data, uint32_t data_length) {
+void common_hal_displayio_fourwire_send(mp_obj_t obj, display_write_mode_t mode, const uint8_t *data, uint32_t data_length) {
     displayio_fourwire_obj_t *self = MP_OBJ_TO_PTR(obj);
     if (self->command.base.type == &mp_type_NoneType) {
         // When the data/command pin is not specified, we simulate a 9-bit SPI mode, by
@@ -126,7 +125,7 @@ void common_hal_displayio_fourwire_send(mp_obj_t obj, display_byte_type_t data_t
         // transmission. We toggle the CS pin to make the receiver discard them.
         uint8_t buffer = 0;
         uint8_t bits = 0;
-        uint8_t dc = (data_type == DISPLAY_DATA);
+        uint8_t dc = mode & DISPLAY_DATA;
 
         for (size_t i = 0; i < data_length; i++) {
             bits = (bits + 1) % 8;
@@ -156,8 +155,8 @@ void common_hal_displayio_fourwire_send(mp_obj_t obj, display_byte_type_t data_t
             common_hal_digitalio_digitalinout_set_value(&self->chip_select, false);
         }
     } else {
-        common_hal_digitalio_digitalinout_set_value(&self->command, data_type == DISPLAY_DATA);
-        if (chip_select == CHIP_SELECT_TOGGLE_EVERY_BYTE) {
+        common_hal_digitalio_digitalinout_set_value(&self->command, mode & DISPLAY_DATA);
+        if (mode & CHIP_SELECT_TOGGLE_EVERY_BYTE) {
             // Toggle chip select after each command byte in case the display driver
             // IC latches commands based on it.
             for (size_t i = 0; i < data_length; i++) {

--- a/shared-module/displayio/I2CDisplay.c
+++ b/shared-module/displayio/I2CDisplay.c
@@ -103,10 +103,11 @@ bool common_hal_displayio_i2cdisplay_begin_transaction(mp_obj_t obj) {
     return common_hal_busio_i2c_try_lock(self->bus);
 }
 
-void common_hal_displayio_i2cdisplay_send(mp_obj_t obj, display_byte_type_t data_type,
-    display_chip_select_behavior_t chip_select, const uint8_t *data, uint32_t data_length) {
+void common_hal_displayio_i2cdisplay_send(mp_obj_t obj, display_write_mode_t mode,
+    const uint8_t *data, uint32_t data_length) {
     displayio_i2cdisplay_obj_t *self = MP_OBJ_TO_PTR(obj);
-    if (data_type == DISPLAY_COMMAND) {
+
+    if ((mode & MASK_DISPLAY) == DISPLAY_COMMAND) {
         uint8_t command_bytes[2 * data_length];
         for (uint32_t i = 0; i < data_length; i++) {
             command_bytes[2 * i] = 0x80;

--- a/shared-module/displayio/OnDiskBitmap.c
+++ b/shared-module/displayio/OnDiskBitmap.c
@@ -145,8 +145,9 @@ void common_hal_displayio_ondiskbitmap_construct(displayio_ondiskbitmap_t *self,
 }
 
 
-uint32_t common_hal_displayio_ondiskbitmap_get_pixel(displayio_ondiskbitmap_t *self,
+uint32_t common_hal_displayio_ondiskbitmap_get_pixel(void *self_in,
     int16_t x, int16_t y) {
+    displayio_ondiskbitmap_t *self = self_in;
     if (x < 0 || x >= self->width || y < 0 || y >= self->height) {
         return 0;
     }

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -489,6 +489,7 @@ bool displayio_tilegrid_fill_area(displayio_tilegrid_t *self,
     const int x_subgrid_start = x_pixel_start % tile_width;
     const int x_grid_start = x_pixel_start / tile_width;
 
+    int old_tile = 0, tile_row = 0, tile_col = 0;
     for (input_pixel.y = start_y; input_pixel.y < end_y; ++input_pixel.y) {
         int16_t row_start = start + (input_pixel.y - start_y + y_shift) * y_stride; // in pixels
         int16_t local_y = input_pixel.y / self->absolute_transform->scale;
@@ -528,8 +529,11 @@ bool displayio_tilegrid_fill_area(displayio_tilegrid_t *self,
             }
 
             input_pixel.tile = tiles[tile_location];
-            const int tile_row = input_pixel.tile / width_in_tiles;
-            const int tile_col = input_pixel.tile % width_in_tiles;
+            if (input_pixel.tile != old_tile) {
+                tile_row = input_pixel.tile / width_in_tiles;
+                tile_col = input_pixel.tile % width_in_tiles;
+                old_tile = input_pixel.tile;
+            }
             input_pixel.tile_y = tile_row * tile_height + y_subgrid;
             input_pixel.tile_x = tile_col * tile_width + x_subgrid;
 

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -557,6 +557,8 @@ bool displayio_tilegrid_fill_area(displayio_tilegrid_t *self,
     const int x_subgrid_start = x_pixel_start % tile_width;
     const int x_grid_start = x_pixel_start / tile_width;
 
+    const mp_obj_type_t *pixel_shader_type = mp_obj_get_type(self->pixel_shader);
+
     int old_tile = 0, tile_row = 0, tile_col = 0;
     for (input_pixel.y = start_y; input_pixel.y < end_y; ++input_pixel.y) {
         int16_t row_start = start + (input_pixel.y - start_y + y_shift) * y_stride; // in pixels
@@ -617,12 +619,12 @@ bool displayio_tilegrid_fill_area(displayio_tilegrid_t *self,
                 input_pixel.pixel = get_pixel_func(self->bitmap, input_pixel.tile_x, input_pixel.tile_y);
 
                 output_pixel.opaque = true;
-                if (self->pixel_shader == mp_const_none) {
-                    output_pixel.pixel = input_pixel.pixel;
-                } else if (mp_obj_is_type(self->pixel_shader, &displayio_palette_type)) {
+                if (pixel_shader_type == &displayio_palette_type) {
                     output_pixel.opaque = displayio_palette_get_color(self->pixel_shader, colorspace, input_pixel.pixel, &output_pixel.pixel);
-                } else if (mp_obj_is_type(self->pixel_shader, &displayio_colorconverter_type)) {
+                } else if (pixel_shader_type == &displayio_colorconverter_type) {
                     displayio_colorconverter_convert(self->pixel_shader, colorspace, &input_pixel, &output_pixel);
+                } else {
+                    output_pixel.pixel = input_pixel.pixel;
                 }
                 pixel_changed = false;
             }

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -482,6 +482,9 @@ bool displayio_tilegrid_fill_area(displayio_tilegrid_t *self,
     for (input_pixel.y = start_y; input_pixel.y < end_y; ++input_pixel.y) {
         int16_t row_start = start + (input_pixel.y - start_y + y_shift) * y_stride; // in pixels
         int16_t local_y = input_pixel.y / self->absolute_transform->scale;
+        uint16_t tile_location_start = ((local_y / self->tile_height + self->top_left_y) % self->height_in_tiles) * self->width_in_tiles;
+        input_pixel.tile_y = (input_pixel.tile / self->bitmap_width_in_tiles) * self->tile_height + local_y % self->tile_height;
+
         for (input_pixel.x = start_x; input_pixel.x < end_x; ++input_pixel.x) {
             // Compute the destination pixel in the buffer and mask based on the transformations.
             int16_t offset = row_start + (input_pixel.x - start_x + x_shift) * x_stride; // in pixels
@@ -496,10 +499,9 @@ bool displayio_tilegrid_fill_area(displayio_tilegrid_t *self,
                 continue;
             }
             int16_t local_x = input_pixel.x / self->absolute_transform->scale;
-            uint16_t tile_location = ((local_y / self->tile_height + self->top_left_y) % self->height_in_tiles) * self->width_in_tiles + (local_x / self->tile_width + self->top_left_x) % self->width_in_tiles;
+            uint16_t tile_location = tile_location_start + (local_x / self->tile_width + self->top_left_x) % self->width_in_tiles;
             input_pixel.tile = tiles[tile_location];
             input_pixel.tile_x = (input_pixel.tile % self->bitmap_width_in_tiles) * self->tile_width + local_x % self->tile_width;
-            input_pixel.tile_y = (input_pixel.tile / self->bitmap_width_in_tiles) * self->tile_height + local_y % self->tile_height;
 
             output_pixel.pixel = 0;
             input_pixel.pixel = 0;

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -421,6 +421,7 @@ static uint32_t bitmap_get_pixel32(void *self_in, int16_t x, int16_t y) {
 }
 
 
+__attribute__((optimize("O3")))
 bool displayio_tilegrid_fill_area(displayio_tilegrid_t *self,
     const _displayio_colorspace_t *colorspace, const displayio_area_t *area,
     uint32_t *mask, uint32_t *buffer) {

--- a/shared-module/displayio/display_core.c
+++ b/shared-module/displayio/display_core.c
@@ -245,7 +245,7 @@ void displayio_display_core_set_region_to_update(displayio_display_core_t *self,
     x2 -= 1;
     y2 -= 1;
 
-    display_chip_select_behavior_t chip_select = CHIP_SELECT_UNTOUCHED;
+    display_write_mode_t chip_select = CHIP_SELECT_UNTOUCHED;
     if (always_toggle_chip_select || data_as_commands) {
         chip_select = CHIP_SELECT_TOGGLE_EVERY_BYTE;
     }
@@ -255,9 +255,9 @@ void displayio_display_core_set_region_to_update(displayio_display_core_t *self,
     uint8_t data[5];
     data[0] = column_command;
     uint8_t data_length = 1;
-    display_byte_type_t data_type = DISPLAY_DATA;
+    display_write_mode_t data_type = DISPLAY_DATA;
     if (!data_as_commands) {
-        self->send(self->bus, DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, data, 1);
+        self->send(self->bus, DISPLAY_COMMAND | CHIP_SELECT_UNTOUCHED, data, 1);
         data_length = 0;
     } else {
         data_type = DISPLAY_COMMAND;
@@ -281,14 +281,14 @@ void displayio_display_core_set_region_to_update(displayio_display_core_t *self,
         data_length = 2;
     }
 
-    self->send(self->bus, data_type, chip_select, data, data_length);
+    self->send(self->bus, data_type | chip_select, data, data_length);
     displayio_display_core_end_transaction(self);
 
     if (set_current_column_command != NO_COMMAND) {
         uint8_t command = set_current_column_command;
         displayio_display_core_begin_transaction(self);
-        self->send(self->bus, DISPLAY_COMMAND, chip_select, &command, 1);
-        self->send(self->bus, DISPLAY_DATA, chip_select, data, data_length / 2);
+        self->send(self->bus, DISPLAY_COMMAND | chip_select, &command, 1);
+        self->send(self->bus, DISPLAY_DATA | chip_select, data, data_length / 2);
         displayio_display_core_end_transaction(self);
     }
 
@@ -298,7 +298,7 @@ void displayio_display_core_set_region_to_update(displayio_display_core_t *self,
     data[0] = row_command;
     data_length = 1;
     if (!data_as_commands) {
-        self->send(self->bus, DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, data, 1);
+        self->send(self->bus, DISPLAY_COMMAND | CHIP_SELECT_UNTOUCHED, data, 1);
         data_length = 0;
     }
 
@@ -320,14 +320,14 @@ void displayio_display_core_set_region_to_update(displayio_display_core_t *self,
         data_length = 1;
     }
 
-    self->send(self->bus, data_type, chip_select, data, data_length);
+    self->send(self->bus, data_type | chip_select, data, data_length);
     displayio_display_core_end_transaction(self);
 
     if (set_current_row_command != NO_COMMAND) {
         uint8_t command = set_current_row_command;
         displayio_display_core_begin_transaction(self);
-        self->send(self->bus, DISPLAY_COMMAND, chip_select, &command, 1);
-        self->send(self->bus, DISPLAY_DATA, chip_select, data, data_length / 2);
+        self->send(self->bus, DISPLAY_COMMAND | chip_select, &command, 1);
+        self->send(self->bus, DISPLAY_DATA | chip_select, data, data_length / 2);
         displayio_display_core_end_transaction(self);
     }
 }


### PR DESCRIPTION
I speculated that at least on M0 devices like the RP2040, the use of division and modulo operators inside the TileGrid's main loop.
I removed it to the greatest extent possible from the inner loop, then piled on more optimizations.

I ultimately raised the frame rate of scrolling terminal content from 2.7fps to 3.90fps on a raspberry pi pico w, as measured by this program below. Since much of the screen was blank space I'm not sure these are actually full-screen refreshes, vs just refreshing the left 1/3 of the screen.

I feel like 3.9fps is still not great but I think this is the end of the line for the low-level optimization ideas I had.

My test program:
```python
import board
import busio
import displayio
from adafruit_st7789 import ST7789
import time

displayio.release_displays()

bus = busio.SPI(clock=board.GP18, MOSI=board.GP19)
tft_cs = board.GP20
tft_rst = board.GP21
tft_dc = board.GP16
tft_bl = board.GP15

display_bus = displayio.FourWire(bus, command=tft_dc, chip_select=tft_cs, reset=tft_rst)
display = ST7789(display_bus, width=240, height=320, rowstart=0, backlight_pin=tft_bl)

display.auto_refresh = False
for i in range(30):
    print(i)
t0 = time.monotonic_ns()
for i in range(30):
    display.refresh()
    t1 = time.monotonic_ns()
    fps = 1e9 / (t1-t0)
    print(f"{fps=}")
    t0 = t1
```