### PR TITLE
Change boot button message to an independent sentence

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -583,6 +583,13 @@ msgstr ""
 msgid "Both RX and TX required for flow control"
 msgstr ""
 
+#: ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+#: ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
+#: ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
+#: ports/atmel-samd/boards/meowmeow/mpconfigboard.h
+msgid "Both buttons were pressed at start up.\n"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
 msgid "Both pins must support hardware interrupts"
 msgstr ""
@@ -646,6 +653,11 @@ msgstr ""
 #: ports/raspberrypi/common-hal/paralleldisplay/ParallelBus.c
 #, c-format
 msgid "Bus pin %d is already in use"
+msgstr ""
+
+#: ports/espressif/boards/m5stack_core_basic/mpconfigboard.h
+#: ports/espressif/boards/m5stack_core_fire/mpconfigboard.h
+msgid "Button A was pressed at start up.\n"
 msgstr ""
 
 #: shared-bindings/_bleio/UUID.c
@@ -1976,15 +1988,31 @@ msgid "Temperature read timed out"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
+msgid "The BOOT button was pressed at start up.\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
 msgid ""
 "The CircuitPython heap was corrupted because the stack was too small.\n"
 "Increase the stack size if you know how. If not:"
+msgstr ""
+
+#: ports/espressif/boards/adafruit_feather_esp32_v2/mpconfigboard.h
+msgid "The SW38 button was pressed at start up.\n"
+msgstr ""
+
+#: ports/espressif/boards/hardkernel_odroid_go/mpconfigboard.h
+msgid "The VOLUME button was pressed at start up.\n"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
 "The `microcontroller` module was used to boot into safe mode. Press reset to "
 "exit safe mode."
+msgstr ""
+
+#: ports/nrf/boards/aramcon2_badge/mpconfigboard.h
+msgid "The left button was pressed at start up.\n"
 msgstr ""
 
 #: shared-bindings/rgbmatrix/RGBMatrix.c
@@ -2047,7 +2075,7 @@ msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "To exit, please reset the board without "
+msgid "To exit, please reset the board without requesting safe mode."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -2343,10 +2371,6 @@ msgstr ""
 #: supervisor/shared/safe_mode.c
 msgid ""
 "You pressed the reset button during boot. Press again to exit safe mode."
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "You requested starting safe mode by "
 msgstr ""
 
 #: py/objtype.c
@@ -3815,46 +3839,8 @@ msgstr ""
 msgid "pow() with 3 arguments requires integers"
 msgstr ""
 
-#: ports/espressif/boards/adafruit_qtpy_esp32_pico/mpconfigboard.h
-msgid "pressing BOOT button at start up.\n"
-msgstr ""
-
-#: ports/espressif/boards/adafruit_feather_esp32_v2/mpconfigboard.h
-msgid "pressing SW38 button at start up.\n"
-msgstr ""
-
-#: ports/espressif/boards/hardkernel_odroid_go/mpconfigboard.h
-msgid "pressing VOLUME button at start up.\n"
-msgstr ""
-
-#: ports/espressif/boards/adafruit_qtpy_esp32c3/mpconfigboard.h
-#: ports/espressif/boards/beetle-esp32-c3/mpconfigboard.h
-#: ports/espressif/boards/espressif_esp32s2_devkitc_1_n8r2/mpconfigboard.h
-#: ports/espressif/boards/lolin_c3_mini/mpconfigboard.h
-#: ports/espressif/boards/microdev_micro_c3/mpconfigboard.h
-#: supervisor/shared/safe_mode.c
-msgid "pressing boot button at start up.\n"
-msgstr ""
-
-#: ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
-#: ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
-#: ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
-#: ports/atmel-samd/boards/escornabot_makech/mpconfigboard.h
-#: ports/atmel-samd/boards/meowmeow/mpconfigboard.h
-msgid "pressing both buttons at start up.\n"
-msgstr ""
-
 #: ports/espressif/boards/m5stack_atom_lite/mpconfigboard.h
-msgid "pressing central button at start up.\n"
-msgstr ""
-
-#: ports/espressif/boards/m5stack_core_basic/mpconfigboard.h
-#: ports/espressif/boards/m5stack_core_fire/mpconfigboard.h
-msgid "pressing button A at start up.\n"
-msgstr ""
-
-#: ports/nrf/boards/aramcon2_badge/mpconfigboard.h
-msgid "pressing the left button at start up\n"
+msgid "The central button was pressed at start up.\n"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2011,6 +2011,10 @@ msgid ""
 "exit safe mode."
 msgstr ""
 
+#: ports/espressif/boards/m5stack_atom_lite/mpconfigboard.h
+msgid "The central button was pressed at start up.\n"
+msgstr ""
+
 #: ports/nrf/boards/aramcon2_badge/mpconfigboard.h
 msgid "The left button was pressed at start up.\n"
 msgstr ""
@@ -3837,10 +3841,6 @@ msgstr ""
 
 #: py/objint_mpz.c
 msgid "pow() with 3 arguments requires integers"
-msgstr ""
-
-#: ports/espressif/boards/m5stack_atom_lite/mpconfigboard.h
-msgid "The central button was pressed at start up.\n"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c

--- a/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
@@ -23,7 +23,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing both buttons at start up.\n")
+#define BOARD_USER_SAFE_MODE_ACTION translate("Both buttons were pressed at start up.\n")
 
 // Increase stack size slightly due to CPX library import nesting
 #define CIRCUITPY_DEFAULT_STACK_SIZE  (4248) // divisible by 8

--- a/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
@@ -23,7 +23,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing both buttons at start up.\n")
+#define BOARD_USER_SAFE_MODE_ACTION translate("Both buttons were pressed at start up.\n")
 
 // Increase stack size slightly due to CPX library import nesting
 #define CIRCUITPY_DEFAULT_STACK_SIZE  (4248) // divisible by 8

--- a/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
+++ b/ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
@@ -23,7 +23,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing both buttons at start up.\n")
+#define BOARD_USER_SAFE_MODE_ACTION translate("Both buttons were pressed at start up.\n")
 
 // Increase stack size slightly due to CPX library import nesting.
 #define CIRCUITPY_DEFAULT_STACK_SIZE  (4248)  // divisible by 8

--- a/ports/atmel-samd/boards/escornabot_makech/mpconfigboard.h
+++ b/ports/atmel-samd/boards/escornabot_makech/mpconfigboard.h
@@ -5,9 +5,6 @@
 
 #define CALIBRATE_CRYSTALLESS 1
 
-// Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing both buttons at start up.\n")
-
 #define DEFAULT_I2C_BUS_SCL (&pin_PA08)
 #define DEFAULT_I2C_BUS_SDA (&pin_PA09)
 

--- a/ports/atmel-samd/boards/meowmeow/mpconfigboard.h
+++ b/ports/atmel-samd/boards/meowmeow/mpconfigboard.h
@@ -6,7 +6,7 @@
 #define CALIBRATE_CRYSTALLESS 1
 
 // Explanation of how a user got into safe mode.
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing both buttons at start up.\n")
+#define BOARD_USER_SAFE_MODE_ACTION translate("Both buttons were pressed at start up.\n")
 
 #define DEFAULT_I2C_BUS_SCL (&pin_PA01)
 #define DEFAULT_I2C_BUS_SDA (&pin_PA00)

--- a/ports/espressif/boards/adafruit_feather_esp32_v2/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_feather_esp32_v2/mpconfigboard.h
@@ -47,7 +47,7 @@
 #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO38)
 
 // Explanation of how a user got into safe mode
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing SW38 button at start up.\n")
+#define BOARD_USER_SAFE_MODE_ACTION translate("The SW38 button was pressed at start up.\n")
 
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)

--- a/ports/espressif/boards/adafruit_qtpy_esp32_pico/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32_pico/mpconfigboard.h
@@ -41,9 +41,6 @@
 
 #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO0)
 
-// Explanation of how a user got into safe mode
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing BOOT button at start up.\n")
-
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)
 #define CIRCUITPY_CONSOLE_UART_RX (&pin_GPIO3)

--- a/ports/espressif/boards/adafruit_qtpy_esp32c3/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32c3/mpconfigboard.h
@@ -44,7 +44,4 @@
 // For entering safe mode
 #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO9)
 
-// Explanation of how a user got into safe mode
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing boot button at start up.\n")
-
 #define CIRCUITPY_ESP_USB_SERIAL_JTAG (1)

--- a/ports/espressif/boards/beetle-esp32-c3/mpconfigboard.h
+++ b/ports/espressif/boards/beetle-esp32-c3/mpconfigboard.h
@@ -41,7 +41,4 @@
 #define CIRCUITPY_BOARD_UART        (1)
 #define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO21, .rx = &pin_GPIO20}}
 
-// Explanation of how a user got into safe mode
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing boot button at start up.\n")
-
 #define CIRCUITPY_ESP_USB_SERIAL_JTAG (1)

--- a/ports/espressif/boards/espressif_esp32s2_devkitc_1_n8r2/mpconfigboard.h
+++ b/ports/espressif/boards/espressif_esp32s2_devkitc_1_n8r2/mpconfigboard.h
@@ -35,5 +35,3 @@
 
 #define DEFAULT_UART_BUS_RX         (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX         (&pin_GPIO43)
-
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing boot button at start up.\n")

--- a/ports/espressif/boards/hardkernel_odroid_go/mpconfigboard.h
+++ b/ports/espressif/boards/hardkernel_odroid_go/mpconfigboard.h
@@ -35,7 +35,7 @@
 #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO0)
 
 // Explanation of how a user got into safe mode
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing VOLUME button at start up.\n")
+#define BOARD_USER_SAFE_MODE_ACTION translate("The VOLUME button was pressed at start up.\n")
 
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)

--- a/ports/espressif/boards/lolin_c3_mini/mpconfigboard.h
+++ b/ports/espressif/boards/lolin_c3_mini/mpconfigboard.h
@@ -45,7 +45,4 @@
 #define CIRCUITPY_BOARD_UART        (1)
 #define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO21, .rx = &pin_GPIO20}}
 
-// Explanation of how a user got into safe mode
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing boot button at start up.\n")
-
 #define CIRCUITPY_ESP_USB_SERIAL_JTAG (1)

--- a/ports/espressif/boards/m5stack_atom_lite/mpconfigboard.h
+++ b/ports/espressif/boards/m5stack_atom_lite/mpconfigboard.h
@@ -42,7 +42,7 @@
 #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO39)
 
 // Explanation of how a user got into safe mode
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing central button at start up.\n")
+#define BOARD_USER_SAFE_MODE_ACTION translate("The central button was pressed at start up.\n")
 
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)

--- a/ports/espressif/boards/m5stack_core_basic/mpconfigboard.h
+++ b/ports/espressif/boards/m5stack_core_basic/mpconfigboard.h
@@ -42,7 +42,7 @@
 #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO39)
 
 // Explanation of how a user got into safe mode
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing button A at start up.\n")
+#define BOARD_USER_SAFE_MODE_ACTION translate("Button A was pressed at start up.\n")
 
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)

--- a/ports/espressif/boards/m5stack_core_fire/mpconfigboard.h
+++ b/ports/espressif/boards/m5stack_core_fire/mpconfigboard.h
@@ -43,7 +43,7 @@
 #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO39)
 
 // Explanation of how a user got into safe mode
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing button A at start up.\n")
+#define BOARD_USER_SAFE_MODE_ACTION translate("Button A was pressed at start up.\n")
 
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)

--- a/ports/espressif/boards/microdev_micro_c3/mpconfigboard.h
+++ b/ports/espressif/boards/microdev_micro_c3/mpconfigboard.h
@@ -50,6 +50,3 @@
 
 // For entering safe mode
 #define CIRCUITPY_BOOT_BUTTON           (&pin_GPIO9)
-
-// Explanation of how a user got into safe mode
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing boot button at start up.\n")

--- a/ports/espressif/boards/unexpectedmaker_tinypico/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_tinypico/mpconfigboard.h
@@ -33,11 +33,6 @@
 #define CIRCUITPY_BOARD_SPI         (1)
 #define CIRCUITPY_BOARD_SPI_PIN     {{.clock = &pin_GPIO18, .mosi = &pin_GPIO23, .miso = &pin_GPIO19}}
 
-// #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO0)
-
-// Explanation of how a user got into safe mode
-// #define BOARD_USER_SAFE_MODE_ACTION translate("pressing BOOT button at start up.\n")
-
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)
 #define CIRCUITPY_CONSOLE_UART_RX (&pin_GPIO3)

--- a/ports/espressif/boards/unexpectedmaker_tinypico_nano/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_tinypico_nano/mpconfigboard.h
@@ -33,11 +33,6 @@
 #define CIRCUITPY_BOARD_SPI         (1)
 #define CIRCUITPY_BOARD_SPI_PIN     {{.clock = &pin_GPIO18, .mosi = &pin_GPIO23, .miso = &pin_GPIO19}}
 
-// #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO0)
-
-// Explanation of how a user got into safe mode
-// #define BOARD_USER_SAFE_MODE_ACTION translate("pressing BOOT button at start up.\n")
-
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)
 #define CIRCUITPY_CONSOLE_UART_RX (&pin_GPIO3)

--- a/ports/nrf/boards/aramcon2_badge/mpconfigboard.h
+++ b/ports/nrf/boards/aramcon2_badge/mpconfigboard.h
@@ -52,7 +52,7 @@
 
 #define CIRCUITPY_BOOT_BUTTON (&pin_P0_29)
 
-#define BOARD_USER_SAFE_MODE_ACTION translate("pressing the left button at start up\n")
+#define BOARD_USER_SAFE_MODE_ACTION translate("The left button was pressed at start up.\n")
 
 #define CIRCUITPY_INTERNAL_NVM_SIZE (4096)
 

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -146,17 +146,17 @@ void print_safe_mode_message(safe_mode_t reason) {
 
     switch (reason) {
         case USER_SAFE_MODE:
-            #ifdef BOARD_USER_SAFE_MODE_ACTION
+            #if defined(BOARD_USER_SAFE_MODE_ACTION)
             message = BOARD_USER_SAFE_MODE_ACTION;
             #elif defined(CIRCUITPY_BOOT_BUTTON)
             message = translate("The BOOT button was pressed at start up.\n");
             #endif
-            if (message != NULL) {
-                // Output a user safe mode string if it's set.
-                serial_write_compressed(message);
-                message = translate("To exit, please reset the board without requesting safe mode.");
-                // The final piece is printed below.
-            }
+            #if defined(BOARD_USER_SAFE_MODE_ACTION) || defined(CIRCUITPY_BOOT_BUTTON)
+            // Output a user safe mode string if it's set.
+            serial_write_compressed(message);
+            message = translate("To exit, please reset the board without requesting safe mode.");
+            // The final piece is printed below.
+            #endif
             break;
         case MANUAL_SAFE_MODE:
             message = translate("You pressed the reset button during boot. Press again to exit safe mode.");

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -149,13 +149,12 @@ void print_safe_mode_message(safe_mode_t reason) {
             #ifdef BOARD_USER_SAFE_MODE_ACTION
             message = BOARD_USER_SAFE_MODE_ACTION;
             #elif defined(CIRCUITPY_BOOT_BUTTON)
-            message = translate("pressing boot button at start up.\n");
+            message = translate("The BOOT button was pressed at start up.\n");
             #endif
             if (message != NULL) {
                 // Output a user safe mode string if it's set.
-                serial_write_compressed(translate("You requested starting safe mode by "));
                 serial_write_compressed(message);
-                serial_write_compressed(translate("To exit, please reset the board without "));
+                message = translate("To exit, please reset the board without requesting safe mode.");
                 // The final piece is printed below.
             }
             break;


### PR DESCRIPTION
resolves #7149 
Removes a few messages mentioning the boot button, since that is the default anyway (if a boot button is defined).
The format is now:
```
You are in safe mode because:
Both buttons were pressed at start up.
To exit, please reset the board without requesting safe mode.
```