### PR TITLE
Pin python version 3.10 for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - name: Get CP deps
       run: python tools/ci_fetch_deps.py test ${{ github.sha }}
     - name: CircuitPython version
@@ -156,7 +156,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - name: Get CP deps
       run: python tools/ci_fetch_deps.py mpy-cross-mac ${{ github.sha }}
     - name: CircuitPython version
@@ -220,7 +220,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -278,7 +278,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - uses: actions/checkout@v3
       with:
         submodules: false
@@ -331,7 +331,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - uses: actions/checkout@v3
       with:
         submodules: false
@@ -384,7 +384,7 @@ jobs:
       id: py3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - uses: actions/checkout@v3
       with:
         submodules: false
@@ -473,7 +473,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - uses: actions/checkout@v3
       with:
         submodules: false

--- a/.github/workflows/create_website_pr.yml
+++ b/.github/workflows/create_website_pr.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - name: Get CP deps
       run: python tools/ci_fetch_deps.py website ${{ github.sha }}
     - name: Install deps

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10"
     - name: Install deps
       run: |
         sudo apt-get install -y gettext uncrustify


### PR DESCRIPTION
Python 3.11 started to roll out to github actions, and .. it doesn't work. This MAY affect just the espressif build, but I'm pinning it back at 3.10 for all builds.

Typical failure, during "Run $IDF_PATH/tools/idf_tools.py --non-interactive install required" shows a lot of failures building gevent:
```
...
Collecting gevent<2.0,>=1.2.2
  Downloading gevent-1.5.0.tar.gz (5.3 MB)
...
  Building wheel for gevent (pyproject.toml): finished with status 'error'
...
      src/gevent/_greenlet_primitives.c:216:12: fatal error: longintrepr.h: No such file or directory
        216 |   #include "longintrepr.h"
            |            ^~~~~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/gcc' failed with exit code 1
```

I notice that gevent is pinned at <2.0 while the current version is 22.10.2! This is a dependency of gdbgui==0.13.2.0, which is installed by esp-idf pinned at that version.