### PR TITLE
asyncio bugfixes, select bugfixes & selectable socket

### DIFF
--- a/extmod/moduasyncio.c
+++ b/extmod/moduasyncio.c
@@ -83,7 +83,7 @@ STATIC mp_obj_t ticks(void) {
 // shared-bindings/supervisor/__init__.c). We assume/require that
 // supervisor.ticks_ms is picked as the ticks implementation under
 // CircuitPython for the Python-coded bits of asyncio.
-#define ticks() MP_OBJ_NEW_SMALL_INT(supervisor_ticks_ms())
+#define ticks() supervisor_ticks_ms()
 #endif
 
 STATIC mp_int_t ticks_diff(mp_obj_t t1_in, mp_obj_t t0_in) {

--- a/extmod/moduselect.c
+++ b/extmod/moduselect.c
@@ -16,6 +16,7 @@
 #include "py/stream.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
+#include "shared/runtime/interrupt_char.h"
 
 // Flags for poll()
 #define FLAG_ONESHOT (1)
@@ -230,6 +231,9 @@ STATIC mp_uint_t poll_poll_internal(uint n_args, const mp_obj_t *args) {
             break;
         }
         RUN_BACKGROUND_TASKS;
+        if (mp_hal_is_interrupted()) {
+            return 0;
+        }
     }
 
     return n_ready;

--- a/ports/espressif/common-hal/socketpool/Socket.c
+++ b/ports/espressif/common-hal/socketpool/Socket.c
@@ -553,3 +553,27 @@ mp_uint_t common_hal_socketpool_socket_sendto(socketpool_socket_obj_t *self,
 void common_hal_socketpool_socket_settimeout(socketpool_socket_obj_t *self, uint32_t timeout_ms) {
     self->timeout_ms = timeout_ms;
 }
+
+bool common_hal_socketpool_readable(socketpool_socket_obj_t *self) {
+    struct timeval immediate = {0, 0};
+
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(self->num, &fds);
+    int num_triggered = select(self->num + 1, &fds, NULL, &fds, &immediate);
+
+    // including returning true in the error case
+    return num_triggered != 0;
+}
+
+bool common_hal_socketpool_writable(socketpool_socket_obj_t *self) {
+    struct timeval immediate = {0, 0};
+
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(self->num, &fds);
+    int num_triggered = select(self->num + 1, NULL, &fds, &fds, &immediate);
+
+    // including returning true in the error case
+    return num_triggered != 0;
+}

--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -1163,3 +1163,46 @@ mp_uint_t common_hal_socketpool_socket_sendto(socketpool_socket_obj_t *socket,
 void common_hal_socketpool_socket_settimeout(socketpool_socket_obj_t *self, uint32_t timeout_ms) {
     self->timeout = timeout_ms;
 }
+
+bool common_hal_socketpool_readable(socketpool_socket_obj_t *self) {
+
+    MICROPY_PY_LWIP_ENTER;
+
+    bool result = self->incoming.pbuf != NULL;
+
+    if (self->state == STATE_PEER_CLOSED) {
+        result = true;
+    }
+
+    if (self->type == SOCKETPOOL_SOCK_STREAM && self->pcb.tcp->state == LISTEN) {
+        struct tcp_pcb *volatile *incoming_connection = &lwip_socket_incoming_array(self)[self->incoming.connection.iget];
+        result = (incoming_connection != NULL);
+    }
+
+    MICROPY_PY_LWIP_EXIT;
+
+    return result;
+}
+
+bool common_hal_socketpool_writable(socketpool_socket_obj_t *self) {
+    bool result = false;
+
+    MICROPY_PY_LWIP_ENTER;
+
+    switch (self->type) {
+        case SOCKETPOOL_SOCK_STREAM: {
+            result = tcp_sndbuf(self->pcb.tcp) != 0;
+            break;
+        }
+        case SOCKETPOOL_SOCK_DGRAM:
+        #if MICROPY_PY_LWIP_SOCK_RAW
+        case SOCKETPOOL_SOCK_RAW:
+        #endif
+            result = true;
+            break;
+    }
+
+    MICROPY_PY_LWIP_EXIT;
+
+    return result;
+}

--- a/shared-bindings/socketpool/Socket.h
+++ b/shared-bindings/socketpool/Socket.h
@@ -46,6 +46,8 @@ mp_uint_t common_hal_socketpool_socket_send(socketpool_socket_obj_t *self, const
 mp_uint_t common_hal_socketpool_socket_sendto(socketpool_socket_obj_t *self,
     const char *host, size_t hostlen, uint32_t port, const uint8_t *buf, uint32_t len);
 void common_hal_socketpool_socket_settimeout(socketpool_socket_obj_t *self, uint32_t timeout_ms);
+bool common_hal_socketpool_readable(socketpool_socket_obj_t *self);
+bool common_hal_socketpool_writable(socketpool_socket_obj_t *self);
 
 // Non-allocating versions for internal use.
 int socketpool_socket_accept(socketpool_socket_obj_t *self, uint8_t *ip, uint32_t *port);
@@ -53,5 +55,4 @@ void socketpool_socket_close(socketpool_socket_obj_t *self);
 int socketpool_socket_send(socketpool_socket_obj_t *self, const uint8_t *buf, uint32_t len);
 int socketpool_socket_recv_into(socketpool_socket_obj_t *self,
     const uint8_t *buf, uint32_t len);
-
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_SOCKETPOOL_SOCKET_H


### PR DESCRIPTION
 1. The internal definition of ticks in moduasyncio was still wrong, in a way that deceptively seemed to work sometimes
 2. select() was not interruptable with ctrl-c
 3. socket objects are now selectable -- implementation tested on rp2040 only at this point -- needs further changes in asyncio module itself

Here's my test program, which connects to a `netcat -l 5153` already running on my laptop `bert`.  When I type something into netcat and hit enter, it's received and echoed back, with extra running commentary in the repl. also, the led toggles with each print.

@furbrain pinging in case you are interested in this

```python
import os
import asyncio

import board
import digitalio
import socketpool
import wifi

if wifi.radio.ipv4_address is None:
    ssid = os.getenv('CIRCUITPY_WIFI_SSID')
    print("Connecting to", ssid)
    wifi.radio.connect(ssid, os.getenv('CIRCUITPY_WIFI_PASSWORD'))
    print("Connected to", ssid)
else:
    print("already connected")
print("Local address", wifi.radio.ipv4_address)

pool = socketpool.SocketPool(wifi.radio)


class Socket:
    def __init__(self, s):
        self.s = s
        s.setblocking(False)

    async def recv_into(self, buf):
        await asyncio.core._io_queue.queue_read(self.s)
        return self.s.recv_into(buf)

    async def send(self, buf):
        await asyncio.core._io_queue.queue_write(self.s)
        return self.s.send(buf)

async def sock_task(sock):
    print("in sock task")
    with digitalio.DigitalInOut(board.LED) as led:
        led.switch_to_output(False)
        s = Socket(sock)
        buf = bytearray(16)
        while True:
            led.value = not led.value
            print("going to await recv")
            sz = await s.recv_into(buf)
            print(sz, bytes(buf[:sz]))
            print("going to await send")
            sz = await(s.send(buf[:sz]))
            print("sent", sz)

with pool.socket(pool.AF_INET, pool.SOCK_STREAM) as sock:
    print("connecting")
    sock.connect(("bert.u", 5123))
    print("running task")
    asyncio.run(sock_task(sock))
```