### PR TITLE
Simplify argument checking to reduce translated strings

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -110,10 +110,6 @@ msgstr ""
 msgid "%q index out of range"
 msgstr ""
 
-#: py/obj.c
-msgid "%q indices must be integers, not %s"
-msgstr ""
-
 #: shared-module/bitbangio/SPI.c
 msgid "%q init failed"
 msgstr ""
@@ -2341,10 +2337,6 @@ msgstr ""
 msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
 msgstr ""
 
-#: shared-bindings/watchdog/WatchDogTimer.c
-msgid "WatchDogTimer.timeout must be greater than 0"
-msgstr ""
-
 #: py/builtinhelp.c
 #, c-format
 msgid ""
@@ -3166,10 +3158,6 @@ msgstr ""
 msgid "index out of range"
 msgstr ""
 
-#: py/obj.c
-msgid "indices must be integers"
-msgstr ""
-
 #: extmod/ulab/code/ndarray.c
 msgid "indices must be integers, slices, or Boolean lists"
 msgstr ""
@@ -3586,10 +3574,6 @@ msgstr ""
 msgid "no such attribute"
 msgstr ""
 
-#: shared-bindings/usb_hid/__init__.c
-msgid "non-Device in %q"
-msgstr ""
-
 #: ports/espressif/common-hal/_bleio/Connection.c
 #: ports/nrf/common-hal/_bleio/Connection.c
 msgid "non-UUID found in service_uuids_whitelist"
@@ -3863,11 +3847,6 @@ msgstr ""
 msgid "relative import"
 msgstr ""
 
-#: py/obj.c
-#, c-format
-msgid "requested length %d but object has length %d"
-msgstr ""
-
 #: extmod/ulab/code/ndarray_operators.c
 msgid "results cannot be cast to specified type"
 msgstr ""
@@ -3929,10 +3908,6 @@ msgstr ""
 
 #: py/objstr.c
 msgid "sign not allowed with integer format specifier 'c'"
-msgstr ""
-
-#: py/objstr.c
-msgid "single '}' encountered in format string"
 msgstr ""
 
 #: extmod/ulab/code/ulab_tools.c
@@ -4047,10 +4022,6 @@ msgstr ""
 msgid "syntax error in uctypes descriptor"
 msgstr ""
 
-#: shared-bindings/touchio/TouchIn.c
-msgid "threshold must be in the range 0-65536"
-msgstr ""
-
 #: shared-bindings/time/__init__.c
 msgid "time.struct_time() takes a 9-sequence"
 msgstr ""
@@ -4060,10 +4031,6 @@ msgstr ""
 #: ports/nrf/common-hal/watchdog/WatchDogTimer.c
 #: ports/raspberrypi/common-hal/watchdog/WatchDogTimer.c
 msgid "timeout duration exceeded the maximum supported value"
-msgstr ""
-
-#: shared-bindings/busio/UART.c
-msgid "timeout must be 0.0-100.0 seconds"
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/Adapter.c
@@ -4117,10 +4084,6 @@ msgstr ""
 
 #: extmod/ulab/code/numpy/approx.c
 msgid "trapz is defined for 1D iterables"
-msgstr ""
-
-#: py/obj.c
-msgid "tuple/list has wrong length"
 msgstr ""
 
 #: ports/espressif/common-hal/canio/CAN.c
@@ -4201,7 +4164,8 @@ msgid "unknown type '%q'"
 msgstr ""
 
 #: py/objstr.c
-msgid "unmatched '{' in format"
+#, c-format
+msgid "unmatched '%c' in format"
 msgstr ""
 
 #: py/objtype.c py/runtime.c
@@ -4270,10 +4234,6 @@ msgstr ""
 
 #: ports/espressif/common-hal/watchdog/WatchDogTimer.c
 msgid "watchdog not initialized"
-msgstr ""
-
-#: shared-bindings/watchdog/WatchDogTimer.c
-msgid "watchdog timeout must be greater than 0"
 msgstr ""
 
 #: shared-bindings/is31fl3741/FrameBuffer.c

--- a/py/obj.c
+++ b/py/obj.c
@@ -488,14 +488,7 @@ void mp_obj_get_array(mp_obj_t o, size_t *len, mp_obj_t **items) {
 void mp_obj_get_array_fixed_n(mp_obj_t o, size_t len, mp_obj_t **items) {
     size_t seq_len;
     mp_obj_get_array(o, &seq_len, items);
-    if (seq_len != len) {
-        #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
-        mp_raise_ValueError(MP_ERROR_TEXT("tuple/list has wrong length"));
-        #else
-        mp_raise_ValueError_varg(
-            MP_ERROR_TEXT("requested length %d but object has length %d"), (int)len, (int)seq_len);
-        #endif
-    }
+    mp_arg_validate_length(seq_len, len, mp_obj_get_type(o)->name);
 }
 
 // is_slice determines whether the index is a slice index
@@ -504,13 +497,7 @@ size_t mp_get_index(const mp_obj_type_t *type, size_t len, mp_obj_t index, bool 
     if (mp_obj_is_small_int(index)) {
         i = MP_OBJ_SMALL_INT_VALUE(index);
     } else if (!mp_obj_get_int_maybe(index, &i)) {
-        #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
-        mp_raise_TypeError(MP_ERROR_TEXT("indices must be integers"));
-        #else
-        mp_raise_TypeError_varg(
-            MP_ERROR_TEXT("%q indices must be integers, not %s"),
-            type->name, mp_obj_get_type_str(index));
-        #endif
+        mp_raise_TypeError_varg(translate("%q must be of type %q"), MP_QSTR_index, MP_QSTR_int);
     }
 
     if (i < 0) {
@@ -523,14 +510,7 @@ size_t mp_get_index(const mp_obj_type_t *type, size_t len, mp_obj_t index, bool 
             i = len;
         }
     } else {
-        if (i < 0 || (mp_uint_t)i >= len) {
-            #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
-            mp_raise_IndexError(MP_ERROR_TEXT("index out of range"));
-            #else
-            mp_raise_msg_varg(&mp_type_IndexError,
-                MP_ERROR_TEXT("%q index out of range"), type->name);
-            #endif
-        }
+        mp_arg_validate_index_range(i, 0, len - 1, MP_QSTR_index);
     }
 
     // By this point 0 <= i <= len and so fits in a size_t

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -986,7 +986,7 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
             #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
             terse_str_format_value_error();
             #else
-            mp_raise_ValueError(MP_ERROR_TEXT("single '}' encountered in format string"));
+            mp_raise_ValueError_varg(MP_ERROR_TEXT("unmatched '%c' in format"), '}');
             #endif
         }
         if (*str != '{') {
@@ -1063,7 +1063,7 @@ STATIC vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
             #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
             terse_str_format_value_error();
             #else
-            mp_raise_ValueError(MP_ERROR_TEXT("unmatched '{' in format"));
+            mp_raise_ValueError_varg(MP_ERROR_TEXT("unmatched '%c' in format"), '{');
             #endif
         }
         if (*str != '}') {

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -1181,9 +1181,7 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     mp_obj_t *bases_items;
     mp_obj_tuple_get(bases_tuple, &bases_len, &bases_items);
     for (size_t i = 0; i < bases_len; i++) {
-        if (!mp_obj_is_type(bases_items[i], &mp_type_type)) {
-            mp_raise_TypeError(MP_ERROR_TEXT("type is not an acceptable base type"));
-        }
+        mp_arg_validate_type(bases_items[i], &mp_type_type, MP_QSTR___class__);
         mp_obj_type_t *t = MP_OBJ_TO_PTR(bases_items[i]);
         // TODO: Verify with CPy, tested on function type
         if (t->make_new == NULL) {

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -91,9 +91,7 @@ extern const busio_uart_parity_obj_t busio_uart_parity_odd_obj;
 
 #if CIRCUITPY_BUSIO_UART
 STATIC void validate_timeout(mp_float_t timeout) {
-    if (timeout < (mp_float_t)0.0f || timeout > (mp_float_t)100.0f) {
-        mp_raise_ValueError(translate("timeout must be 0.0-100.0 seconds"));
-    }
+    mp_arg_validate_int_range((int)timeout, 0, 100, MP_QSTR_timeout);
 }
 #endif  // CIRCUITPY_BUSIO_UART
 

--- a/shared-bindings/terminalio/Terminal.c
+++ b/shared-bindings/terminalio/Terminal.c
@@ -61,7 +61,7 @@
 //|         scroll_area: displayio.TileGrid,
 //|         font: fontio.BuiltinFont,
 //|         *,
-//|         status_bar: displayio.TileGrid = None
+//|         status_bar: Optional[displayio.TileGrid] = None
 //|     ) -> None:
 //|         """Terminal manages tile indices and cursor position based on VT100 commands. The font should be
 //|         a `fontio.BuiltinFont` and the TileGrid's bitmap should match the font's bitmap."""

--- a/shared-bindings/touchio/TouchIn.c
+++ b/shared-bindings/touchio/TouchIn.c
@@ -159,10 +159,7 @@ STATIC mp_obj_t touchio_touchin_obj_set_threshold(mp_obj_t self_in, mp_obj_t thr
     touchio_touchin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
     uint32_t new_threshold = mp_obj_get_int(threshold_obj);
-    if (new_threshold < 0 || new_threshold > UINT16_MAX) {
-        // I would use MP_STRINGIFY(UINT16_MAX), but that prints "0xffff" instead of 65536.
-        mp_raise_ValueError(translate("threshold must be in the range 0-65536"));
-    }
+    mp_arg_validate_int_range(new_threshold, 0, UINT16_MAX, MP_QSTR_threshold);
     common_hal_touchio_touchin_set_threshold(self, new_threshold);
     return mp_const_none;
 }

--- a/shared-bindings/usb_hid/__init__.c
+++ b/shared-bindings/usb_hid/__init__.c
@@ -123,9 +123,7 @@ STATIC mp_obj_t usb_hid_enable(size_t n_args, const mp_obj_t *pos_args, mp_map_t
     const mp_int_t len = mp_obj_get_int(mp_obj_len(devices));
     for (mp_int_t i = 0; i < len; i++) {
         mp_obj_t item = mp_obj_subscr(devices, MP_OBJ_NEW_SMALL_INT(i), MP_OBJ_SENTINEL);
-        if (!mp_obj_is_type(item, &usb_hid_device_type)) {
-            mp_raise_ValueError_varg(translate("non-Device in %q"), MP_QSTR_devices);
-        }
+        mp_arg_validate_type(item, &usb_hid_device_type, MP_QSTR___class__);
     }
 
     uint8_t boot_device =

--- a/shared-bindings/watchdog/WatchDogTimer.c
+++ b/shared-bindings/watchdog/WatchDogTimer.c
@@ -94,9 +94,7 @@ STATIC mp_obj_t watchdog_watchdogtimer_obj_set_timeout(mp_obj_t self_in, mp_obj_
     watchdog_watchdogtimer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_float_t timeout = mp_obj_get_float(timeout_obj);
 
-    if (timeout <= 0) {
-        mp_raise_ValueError(translate("watchdog timeout must be greater than 0"));
-    }
+    mp_arg_validate_int_min((int)timeout, 0, MP_QSTR_timeout);
 
     common_hal_watchdog_set_timeout(self, timeout);
     return mp_const_none;
@@ -136,9 +134,7 @@ STATIC mp_obj_t watchdog_watchdogtimer_obj_set_mode(mp_obj_t self_in, mp_obj_t m
 
     // When setting the mode, the timeout value must be greater than zero
     if (new_mode == WATCHDOGMODE_RESET || new_mode == WATCHDOGMODE_RAISE) {
-        if (current_timeout <= 0) {
-            mp_raise_ValueError(translate("WatchDogTimer.timeout must be greater than 0"));
-        }
+        mp_arg_validate_int_min((int)current_timeout, 0, MP_QSTR_timeout);
     }
 
     // Don't allow changing the mode once the watchdog timer has been started


### PR DESCRIPTION
Build size on proxlight trinkey m0 en_US:
```
Before:  2412 (en_US)  820 (ru)
After:   2544 (en_US)  984 (ru)
Savings: +132 (en_US) +164 (ru) bytes available flash
```