### PR TITLE
RP2040: ignore pin changes before deep sleep

### DIFF
--- a/ports/raspberrypi/common-hal/alarm/__init__.c
+++ b/ports/raspberrypi/common-hal/alarm/__init__.c
@@ -234,6 +234,9 @@ void NORETURN common_hal_alarm_enter_deep_sleep(void) {
 
     // Reset uses the watchdog. Use scratch registers to store wake reason
     watchdog_hw->scratch[RP_WKUP_SCRATCH_REG] = _get_wakeup_cause();
+
+    // Just before reset, enable the pinalarm interrupt.
+    alarm_pin_pinalarm_entering_deep_sleep();
     reset_cpu();
 }
 

--- a/ports/raspberrypi/common-hal/alarm/pin/PinAlarm.h
+++ b/ports/raspberrypi/common-hal/alarm/pin/PinAlarm.h
@@ -46,4 +46,4 @@ void alarm_pin_pinalarm_reset(void);
 void alarm_pin_pinalarm_light_reset(void);
 void alarm_pin_pinalarm_set_alarms(bool deep_sleep, size_t n_alarms, const mp_obj_t *alarms);
 bool alarm_pin_pinalarm_woke_this_cycle(void);
-bool alarm_pin_pinalarm_is_set(void);
+void alarm_pin_pinalarm_entering_deep_sleep(void);


### PR DESCRIPTION
Fixes #7081 

Ignore pin alarm changes before deep sleep has started. Previously, the pin could change, triggering the interrupt handler, and clearing the alarm setup, preventing detecting pin change during deep sleep. Now the interrupt routine ignores changes until the last possible moment. There is a tiny sliver of a race condition, but it is very, very narrow.

@billedluh Could you test this? IThanks.  tested on a Feather RP2040, grounding a jumper many times before sleep. I was able to reproduce your #7081 problem, but could not after this fix.

To find a build to try, wait until the builds have finished. Then click on the "Details" link next to an RP2040 build below, then click on Summary at the top of the left sidebar, and then scroll down to find the "Artifacts". Download the .zip and unpack it to find a .uf2 to load.