### PR TITLE
implement self hidden property for vectorio shapes

### DIFF
--- a/shared-bindings/vectorio/Circle.c
+++ b/shared-bindings/vectorio/Circle.c
@@ -109,6 +109,9 @@ MP_PROPERTY_GETSET(vectorio_circle_color_index_obj,
 //|     y: int
 //|     """Y position of the center point of the circle in the parent."""
 //|
+//|     hidden: boolean
+//|     """Hide the circle or not."""
+//|
 //|     location: Tuple[int, int]
 //|     """(X,Y) position of the center point of the circle in the parent."""
 //|
@@ -123,6 +126,7 @@ STATIC const mp_rom_map_elem_t vectorio_circle_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_radius), MP_ROM_PTR(&vectorio_circle_radius_obj) },
     { MP_ROM_QSTR(MP_QSTR_x), MP_ROM_PTR(&vectorio_vector_shape_x_obj) },
     { MP_ROM_QSTR(MP_QSTR_y), MP_ROM_PTR(&vectorio_vector_shape_y_obj) },
+    { MP_ROM_QSTR(MP_QSTR_hidden), MP_ROM_PTR(&vectorio_vector_shape_hidden_obj) },
     { MP_ROM_QSTR(MP_QSTR_color_index), MP_ROM_PTR(&vectorio_circle_color_index_obj) },
     { MP_ROM_QSTR(MP_QSTR_location), MP_ROM_PTR(&vectorio_vector_shape_location_obj) },
     { MP_ROM_QSTR(MP_QSTR_pixel_shader), MP_ROM_PTR(&vectorio_vector_shape_pixel_shader_obj) },

--- a/shared-bindings/vectorio/Circle.c
+++ b/shared-bindings/vectorio/Circle.c
@@ -109,7 +109,7 @@ MP_PROPERTY_GETSET(vectorio_circle_color_index_obj,
 //|     y: int
 //|     """Y position of the center point of the circle in the parent."""
 //|
-//|     hidden: boolean
+//|     hidden: bool
 //|     """Hide the circle or not."""
 //|
 //|     location: Tuple[int, int]

--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -118,7 +118,7 @@ MP_PROPERTY_GETSET(vectorio_polygon_color_index_obj,
 //|     y: int
 //|     """Y position of the 0,0 origin in the points list."""
 //|
-//|     hidden: boolean
+//|     hidden: bool
 //|     """Hide the polygon or not."""
 //|
 //|     location: Tuple[int, int]

--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -118,6 +118,9 @@ MP_PROPERTY_GETSET(vectorio_polygon_color_index_obj,
 //|     y: int
 //|     """Y position of the 0,0 origin in the points list."""
 //|
+//|     hidden: boolean
+//|     """Hide the polygon or not."""
+//|
 //|     location: Tuple[int, int]
 //|     """(X,Y) position of the 0,0 origin in the points list."""
 //|
@@ -132,6 +135,7 @@ STATIC const mp_rom_map_elem_t vectorio_polygon_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_points), MP_ROM_PTR(&vectorio_polygon_points_obj) },
     { MP_ROM_QSTR(MP_QSTR_x), MP_ROM_PTR(&vectorio_vector_shape_x_obj) },
     { MP_ROM_QSTR(MP_QSTR_y), MP_ROM_PTR(&vectorio_vector_shape_y_obj) },
+    { MP_ROM_QSTR(MP_QSTR_hidden), MP_ROM_PTR(&vectorio_vector_shape_hidden_obj) },
     { MP_ROM_QSTR(MP_QSTR_color_index), MP_ROM_PTR(&vectorio_polygon_color_index_obj) },
     { MP_ROM_QSTR(MP_QSTR_location), MP_ROM_PTR(&vectorio_vector_shape_location_obj) },
     { MP_ROM_QSTR(MP_QSTR_pixel_shader), MP_ROM_PTR(&vectorio_vector_shape_pixel_shader_obj) },

--- a/shared-bindings/vectorio/Rectangle.c
+++ b/shared-bindings/vectorio/Rectangle.c
@@ -139,6 +139,9 @@ const mp_obj_property_t vectorio_rectangle_color_index_obj = {
 //|     y: int
 //|     """Y position of the top left corner of the rectangle in the parent."""
 //|
+//|     hidden: boolean
+//|     """Hide the rectangle or not."""
+//|
 //|     location: Tuple[int, int]
 //|     """(X,Y) position of the top left corner of the rectangle in the parent."""
 //|
@@ -152,6 +155,7 @@ STATIC const mp_rom_map_elem_t vectorio_rectangle_locals_dict_table[] = {
     // Properties
     { MP_ROM_QSTR(MP_QSTR_x), MP_ROM_PTR(&vectorio_vector_shape_x_obj) },
     { MP_ROM_QSTR(MP_QSTR_y), MP_ROM_PTR(&vectorio_vector_shape_y_obj) },
+    { MP_ROM_QSTR(MP_QSTR_hidden), MP_ROM_PTR(&vectorio_vector_shape_hidden_obj) },
     { MP_ROM_QSTR(MP_QSTR_color_index), MP_ROM_PTR(&vectorio_rectangle_color_index_obj) },
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&vectorio_rectangle_width_obj) },
     { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&vectorio_rectangle_height_obj) },

--- a/shared-bindings/vectorio/Rectangle.c
+++ b/shared-bindings/vectorio/Rectangle.c
@@ -139,7 +139,7 @@ const mp_obj_property_t vectorio_rectangle_color_index_obj = {
 //|     y: int
 //|     """Y position of the top left corner of the rectangle in the parent."""
 //|
-//|     hidden: boolean
+//|     hidden: bool
 //|     """Hide the rectangle or not."""
 //|
 //|     location: Tuple[int, int]

--- a/shared-bindings/vectorio/VectorShape.c
+++ b/shared-bindings/vectorio/VectorShape.c
@@ -181,6 +181,33 @@ MP_PROPERTY_GETSET(vectorio_vector_shape_location_obj,
     (mp_obj_t)&vectorio_vector_shape_set_location_obj);
 
 
+// Stub checker does not approve of these shared properties.
+//     hidden: bool
+//     """Hide the shape or not."""
+//
+STATIC mp_obj_t vectorio_vector_shape_obj_get_hidden(mp_obj_t wrapper_shape) {
+    // Relies on the fact that only vector_shape impl gets matched with a VectorShape.
+    const vectorio_draw_protocol_t *draw_protocol = mp_proto_get(MP_QSTR_protocol_draw, wrapper_shape);
+    vectorio_vector_shape_t *self = MP_OBJ_TO_PTR(draw_protocol->draw_get_protocol_self(wrapper_shape));
+    return mp_obj_new_bool(common_hal_vectorio_vector_shape_get_hidden(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(vectorio_vector_shape_get_hidden_obj, vectorio_vector_shape_obj_get_hidden);
+
+STATIC mp_obj_t vectorio_vector_shape_obj_set_hidden(mp_obj_t wrapper_shape, mp_obj_t hidden_obj) {
+    // Relies on the fact that only vector_shape impl gets matched with a VectorShape.
+    const vectorio_draw_protocol_t *draw_protocol = mp_proto_get(MP_QSTR_protocol_draw, wrapper_shape);
+    vectorio_vector_shape_t *self = MP_OBJ_TO_PTR(draw_protocol->draw_get_protocol_self(wrapper_shape));
+
+    common_hal_vectorio_vector_shape_set_hidden(self, mp_obj_is_true(hidden_obj));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(vectorio_vector_shape_set_hidden_obj, vectorio_vector_shape_obj_set_hidden);
+
+MP_PROPERTY_GETSET(vectorio_vector_shape_hidden_obj,
+    (mp_obj_t)&vectorio_vector_shape_get_hidden_obj,
+    (mp_obj_t)&vectorio_vector_shape_set_hidden_obj);
+
+
 //     pixel_shader: Union[ColorConverter, Palette]
 //     """The pixel shader of the shape."""
 //

--- a/shared-bindings/vectorio/VectorShape.h
+++ b/shared-bindings/vectorio/VectorShape.h
@@ -31,6 +31,9 @@ void common_hal_vectorio_vector_shape_set_location(vectorio_vector_shape_t *self
 mp_int_t common_hal_vectorio_vector_shape_get_y(vectorio_vector_shape_t *self);
 void common_hal_vectorio_vector_shape_set_y(vectorio_vector_shape_t *self, mp_int_t y);
 
+mp_int_t common_hal_vectorio_vector_shape_get_hidden(vectorio_vector_shape_t *self);
+void common_hal_vectorio_vector_shape_set_hidden(vectorio_vector_shape_t *self, bool hidden);
+
 mp_obj_t common_hal_vectorio_vector_shape_get_pixel_shader(vectorio_vector_shape_t *self);
 void common_hal_vectorio_vector_shape_set_pixel_shader(vectorio_vector_shape_t *self, mp_obj_t pixel_shader);
 
@@ -40,6 +43,7 @@ void vectorio_vector_shape_update_transform(vectorio_vector_shape_t *self, displ
 extern vectorio_draw_protocol_impl_t vectorio_vector_shape_draw_protocol_impl;
 extern const mp_obj_property_getset_t vectorio_vector_shape_x_obj;
 extern const mp_obj_property_getset_t vectorio_vector_shape_y_obj;
+extern const mp_obj_property_getset_t vectorio_vector_shape_hidden_obj;
 extern const mp_obj_property_getset_t vectorio_vector_shape_location_obj;
 extern const mp_obj_property_getset_t vectorio_vector_shape_pixel_shader_obj;
 extern const mp_obj_fun_builtin_fixed_t vectorio_vector_shape_contains_obj;

--- a/shared-module/vectorio/VectorShape.c
+++ b/shared-module/vectorio/VectorShape.c
@@ -293,6 +293,16 @@ void common_hal_vectorio_vector_shape_set_location(vectorio_vector_shape_t *self
     }
 }
 
+mp_int_t common_hal_vectorio_vector_shape_get_hidden(vectorio_vector_shape_t *self) {
+    VECTORIO_SHAPE_DEBUG("%p get_hidden\n", self);
+    return self->hidden;
+}
+
+void common_hal_vectorio_vector_shape_set_hidden(vectorio_vector_shape_t *self, bool hidden) {
+    VECTORIO_SHAPE_DEBUG("%p set_hidden %d\n", self, x);
+    self->hidden = hidden;
+    common_hal_vectorio_vector_shape_set_dirty(self);
+}
 
 mp_obj_t common_hal_vectorio_vector_shape_get_pixel_shader(vectorio_vector_shape_t *self) {
     VECTORIO_SHAPE_DEBUG("%p get_pixel_shader\n", self);
@@ -315,6 +325,11 @@ bool vectorio_vector_shape_fill_area(vectorio_vector_shape_t *self, const _displ
     uint64_t start = common_hal_time_monotonic_ns();
     uint64_t pixel_time = 0;
     #endif
+
+    if (self->hidden) {
+        return false;
+    }
+
     VECTORIO_SHAPE_DEBUG("%p fill_area: fill: {(%5d,%5d), (%5d,%5d)}",
         self,
         area->x1, area->y1, area->x2, area->y2

--- a/shared-module/vectorio/VectorShape.h
+++ b/shared-module/vectorio/VectorShape.h
@@ -30,6 +30,7 @@ typedef struct {
     mp_obj_t pixel_shader;
     int16_t x;
     int16_t y;
+    bool hidden : 1;
     displayio_buffer_transform_t *absolute_transform;
     // Tracks current shape footprint and expands outward as the shape dirties and changes.
     // This is suboptimal if you move your shape far.  Could add more state to only redraw

--- a/shared-module/vectorio/VectorShape.h
+++ b/shared-module/vectorio/VectorShape.h
@@ -30,7 +30,6 @@ typedef struct {
     mp_obj_t pixel_shader;
     int16_t x;
     int16_t y;
-    bool hidden : 1;
     displayio_buffer_transform_t *absolute_transform;
     // Tracks current shape footprint and expands outward as the shape dirties and changes.
     // This is suboptimal if you move your shape far.  Could add more state to only redraw
@@ -38,6 +37,7 @@ typedef struct {
     displayio_area_t ephemeral_dirty_area;
     displayio_area_t current_area;
     bool current_area_dirty;
+    bool hidden;
 } vectorio_vector_shape_t;
 
 displayio_area_t *vectorio_vector_shape_get_refresh_areas(vectorio_vector_shape_t *self, displayio_area_t *tail);


### PR DESCRIPTION
This allows vectorio shapes to be hidden with a property on the objects. Previously the only way to hide them was by putting them into a Group and then hiding the Group. With these changes they can be hidden directly without a parent group.

I used this code for testing the new functionality:
```py
import displayio
import vectorio
import board
from adafruit_display_shapes.circle import Circle
import time

display = board.DISPLAY
main_group = displayio.Group()

palette = displayio.Palette(1)
palette[0] = 0x125690

vec_circle = vectorio.Circle(pixel_shader=palette, radius=25, x=70, y=40)
main_group.append(vec_circle)

rectangle = vectorio.Rectangle(pixel_shader=palette, width=40, height=30, x=155, y=45)
main_group.append(rectangle)

circle = Circle(100, 100, 20, fill=0x00FF00, outline=0xFF00FF)
main_group.append(circle)

points=[(5, 5), (100, 20), (20, 20), (20, 100)]
polygon = vectorio.Polygon(pixel_shader=palette, points=points, x=0, y=0)
main_group.append(polygon)

display.show(main_group)
while True:
    circle.hidden = not circle.hidden
    vec_circle.hidden = not vec_circle.hidden
    rectangle.hidden = not rectangle.hidden
    polygon.hidden = not polygon.hidden
    #print(vec_circle.hidden)
    time.sleep(.5)
```
Tested the changes successfully on a Feather S2 TFT device.

