### PR TITLE
shared-bindings: Get rid of CYW43 special cases in shared-bindings

### DIFF
--- a/ports/raspberrypi/common-hal/analogio/AnalogIn.c
+++ b/ports/raspberrypi/common-hal/analogio/AnalogIn.c
@@ -40,7 +40,12 @@
 // voltage monitor function and the wifi function. Special handling is required
 // to read the analog voltage.
 #if CIRCUITPY_CYW43
+#include "bindings/cyw43/__init__.h"
 #define SPECIAL_PIN(pin) (pin->number == 29)
+
+const mcu_pin_obj_t *common_hal_analogio_analogin_validate_pin(mp_obj_t obj) {
+    return validate_obj_is_free_pin_or_gpio29(obj);
+}
 #else
 #define SPECIAL_PIN(pin) false
 #endif

--- a/ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
+++ b/ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
@@ -41,6 +41,10 @@
 #include "pico/cyw43_arch.h"
 #include "bindings/cyw43/__init__.h"
 #define IS_CYW(self) ((self)->pin->base.type == &cyw43_pin_type)
+
+const mcu_pin_obj_t *common_hal_digitalio_validate_pin(mp_obj_t obj) {
+    return validate_obj_is_free_pin_including_cyw43(obj);
+}
 #endif
 
 digitalinout_result_t common_hal_digitalio_digitalinout_construct(

--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -36,9 +36,9 @@
 #include "shared-bindings/analogio/AnalogIn.h"
 #include "shared-bindings/util.h"
 
-#if CIRCUITPY_CYW43
-#include "bindings/cyw43/__init__.h"
-#endif
+MP_WEAK const mcu_pin_obj_t *common_hal_analogio_analogin_validate_pin(mp_obj_t obj) {
+    return validate_obj_is_free_pin(obj);
+}
 
 //| class AnalogIn:
 //|     """Read analog voltage levels
@@ -64,11 +64,7 @@ STATIC mp_obj_t analogio_analogin_make_new(const mp_obj_type_t *type,
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
 
     // 1st argument is the pin
-    #if CIRCUITPY_CYW43
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin_or_gpio29(args[0]);
-    #else
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[0]);
-    #endif
+    const mcu_pin_obj_t *pin = common_hal_analogio_analogin_validate_pin(args[0]);
     analogio_analogin_obj_t *self = m_new_obj(analogio_analogin_obj_t);
     self->base.type = &analogio_analogin_type;
     common_hal_analogio_analogin_construct(self, pin);

--- a/shared-bindings/analogio/AnalogIn.h
+++ b/shared-bindings/analogio/AnalogIn.h
@@ -32,6 +32,7 @@
 
 extern const mp_obj_type_t analogio_analogin_type;
 
+const mcu_pin_obj_t *common_hal_analogio_analogin_validate_pin(mp_obj_t obj);
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self, const mcu_pin_obj_t *pin);
 void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self);
 bool common_hal_analogio_analogin_deinited(analogio_analogin_obj_t *self);

--- a/shared-bindings/digitalio/DigitalInOut.c
+++ b/shared-bindings/digitalio/DigitalInOut.c
@@ -66,6 +66,10 @@ STATIC void check_result(digitalinout_result_t result) {
     }
 }
 
+MP_WEAK const mcu_pin_obj_t *common_hal_digitalio_validate_pin(mp_obj_t obj) {
+    return validate_obj_is_free_pin(obj);
+}
+
 //| class DigitalInOut:
 //|     """Digital input and output
 //|
@@ -87,14 +91,7 @@ STATIC mp_obj_t digitalio_digitalinout_make_new(const mp_obj_type_t *type,
     digitalio_digitalinout_obj_t *self = m_new_obj(digitalio_digitalinout_obj_t);
     self->base.type = &digitalio_digitalinout_type;
 
-    #if CIRCUITPY_CYW43
-    // The GPIO pin attached to the CYW43 co-processor can only be used for
-    // DigitalInOut, not for other purposes like PWM. That's why this check
-    // is here, and it's not rolled into validate_obj_is_free_pin.
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin_including_cyw43(args[0]);
-    #else
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[0]);
-    #endif
+    const mcu_pin_obj_t *pin = common_hal_digitalio_validate_pin(args[0]);
     common_hal_digitalio_digitalinout_construct(self, pin);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/digitalio/DigitalInOut.h
+++ b/shared-bindings/digitalio/DigitalInOut.h
@@ -55,6 +55,7 @@ typedef enum {
     DIGITALINOUT_REG_TOGGLE,
 } digitalinout_reg_op_t;
 
+const mcu_pin_obj_t *common_hal_digitalio_validate_pin(mp_obj_t obj);
 digitalinout_result_t common_hal_digitalio_digitalinout_construct(digitalio_digitalinout_obj_t *self, const mcu_pin_obj_t *pin);
 void common_hal_digitalio_digitalinout_deinit(digitalio_digitalinout_obj_t *self);
 bool common_hal_digitalio_digitalinout_deinited(digitalio_digitalinout_obj_t *self);


### PR DESCRIPTION
.. by moving it into a new weak function that can be replaced just by the picow build.

I was stewing about this and Dan also mentioned that the way that cyw43 poked its head out into shared-bindings was gross. A weak function that allows the port to substitute a different check is a way to move the complexity back where it belongs.