### PR TITLE
Save code space by packing rgbw values into C union

### DIFF
--- a/shared-bindings/adafruit_pixelbuf/PixelBuf.h
+++ b/shared-bindings/adafruit_pixelbuf/PixelBuf.h
@@ -31,6 +31,13 @@
 
 extern const mp_obj_type_t pixelbuf_pixelbuf_type;
 
+typedef union {
+    struct {
+        uint8_t r, g, b, w;
+    };
+    uint32_t rgbw;
+} color_u;
+
 void common_hal_adafruit_pixelbuf_pixelbuf_construct(pixelbuf_pixelbuf_obj_t *self, size_t n,
     pixelbuf_byteorder_details_t *byteorder, mp_float_t brightness, bool auto_write, uint8_t *header,
     size_t header_len, uint8_t *trailer, size_t trailer_len);

--- a/shared-module/adafruit_pixelbuf/PixelBuf.c
+++ b/shared-module/adafruit_pixelbuf/PixelBuf.c
@@ -198,10 +198,10 @@ STATIC color_u _pixelbuf_parse_color(pixelbuf_pixelbuf_obj_t *self, mp_obj_t col
 }
 
 STATIC void _pixelbuf_set_pixel_color(pixelbuf_pixelbuf_obj_t *self, size_t index, color_u rgbw) {
-    int r = rgbw.r;
-    int g = rgbw.g;
-    int b = rgbw.b;
-    int w = rgbw.w;
+    uint8_t r = rgbw.r;
+    uint8_t g = rgbw.g;
+    uint8_t b = rgbw.b;
+    uint8_t w = rgbw.w;
     // DotStars don't have white, instead they have 5 bit brightness so pack it into w. Shift right
     // by three to leave the top five bits.
     if (self->bytes_per_pixel == 4 && self->byteorder.is_dotstar) {

--- a/shared-module/adafruit_pixelbuf/PixelBuf.c
+++ b/shared-module/adafruit_pixelbuf/PixelBuf.c
@@ -143,8 +143,10 @@ void common_hal_adafruit_pixelbuf_pixelbuf_set_brightness(mp_obj_t self_in, mp_f
 STATIC uint8_t _pixelbuf_get_as_uint8(mp_obj_t obj) {
     if (mp_obj_is_small_int(obj)) {
         return MP_OBJ_SMALL_INT_VALUE(obj);
+    #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
     } else if (mp_obj_is_int(obj)) {
         return mp_obj_get_int_truncated(obj);
+    #endif
     } else if (mp_obj_is_float(obj)) {
         return (uint8_t)mp_obj_get_float(obj);
     }


### PR DESCRIPTION
It's more efficient passing one register-sized structure than 4 arguments or 4 pointers; working on intermediate values of 'int' size is also more efficient in code size!

On raspberry pi pico w, this increased free flash space by +104 bytes. It also increased the speed of my testing animation very slightly, from 187fps to 189fps when run 'unthrottled'

Interestingly the code savings on BOARD=adafruit_neokey_trinkey_m0 is smaller, just 28 bytes. The difference is probably because samd21 boards were already optimized for space ("-Os" optimization) However, there is still a savings.