### PR TITLE
only ignore sdkconfig* files in the espressif port's top directory

### DIFF
--- a/ports/espressif/.gitignore
+++ b/ports/espressif/.gitignore
@@ -1,5 +1,5 @@
 # idf.py menuconfig
-./sdkconfig*
+/sdkconfig*
 
 # lock files for examples and components
 dependencies.lock


### PR DESCRIPTION
danh and microdev1 noticed that this ignore pattern was over-broad and caused added sdkconfig files in boards/ (which should be committed) to be ignored and not proposed for addition by common tools like git status, git gui, etc.

This pattern anchors the search so that it only matches in the ports/espressif directory, so ports/espressif/sdkconfig is ignored but ports/espressif/boards/example/sdkconfig is not ignored anymore

This was noticed over in #7198 and also probably contributed to the trouble in #7135 .. or basically anyone trying to add a new espressif board would hit it