### PR TITLE
samd21: port_disable_tick() should disable event channel

### DIFF
--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -644,6 +644,10 @@ void port_disable_tick(void) {
     RTC->MODE0.INTENCLR.reg = RTC_MODE0_INTENCLR_PER2;
     #endif
     #ifdef SAMD21
+    if (_tick_event_channel == EVSYS_SYNCH_NUM) {
+        return;
+    }
+
     if (_tick_event_channel >= 8) {
         uint8_t value = 1 << (_tick_event_channel - 8);
         EVSYS->INTENCLR.reg = EVSYS_INTENSET_EVDp8(value);
@@ -651,6 +655,7 @@ void port_disable_tick(void) {
         uint8_t value = 1 << _tick_event_channel;
         EVSYS->INTENCLR.reg = EVSYS_INTENSET_EVD(value);
     }
+    disable_event_channel(_tick_event_channel);
     _tick_event_channel = EVSYS_SYNCH_NUM;
     #endif
 }


### PR DESCRIPTION
Fixes #7105.

On SAMD21, `port_disable_tick()` did not finish the job of disabling the `_tick_event_channel`.

Also added a check to avoid doing anything if `_tick_event_channel` was already disabled.

Before this change, editing a file and causing an autoreload would use up a bunch of event channels:
(this is from some temporary logging I added:
```
[code.py edited here]
Code stopped by auto-reload. Reloading soon.
>port_disable_tick, _tick_event_channel: 0
<port_enable_tick, _tick_event_channel: 0
>port_disable_tick, _tick_event_channel: 0
<port_enable_tick, _tick_event_channel: 1
>port_disable_tick, _tick_event_channel: 1
<port_enable_tick, _tick_event_channel: 2
>port_disable_tick, _tick_event_channel: 2
<port_enable_tick, _tick_event_channel: 3
>port_disable_tick, _tick_event_channel: 3
<port_enable_tick, _tick_event_channel: 4
>port_disable_tick, _tick_event_channel: 4
<port_enable_tick, _tick_event_channel: 5
>port_disable_tick, _tick_event_channel: 5
<port_enable_tick, _tick_event_channel: 6
>port_disable_tick, _tick_event_channel: 6

```
Now it reuses the same channel:
```
[code.py edited here]
Code stopped by auto-reload. Reloading soon.
>port_disable_tick, _tick_event_channel: 0
<port_enable_tick, _tick_event_channel: 0
>port_disable_tick, _tick_event_channel: 0
<port_enable_tick, _tick_event_channel: 0
>port_disable_tick, _tick_event_channel: 0
<port_enable_tick, _tick_event_channel: 0
```

