### PR TITLE
Allow serial "break" to trigger KeyboardInterrupt

### DIFF
--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -341,7 +341,7 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
 #endif // CIRCUITPY_USB_VENDOR
 
 
-#if MICROPY_KBD_EXCEPTION
+#if MICROPY_KBD_EXCEPTION && CIRCUITPY_USB_CDC
 
 /**
  * Callback invoked when received an "wanted" char.

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -359,4 +359,10 @@ void tud_cdc_rx_wanted_cb(uint8_t itf, char wanted_char) {
     }
 }
 
+void tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms) {
+    if (usb_cdc_console_enabled() && mp_interrupt_char != -1 && itf == 0 && duration_ms > 0) {
+        mp_sched_keyboard_interrupt();
+    }
+}
+
 #endif


### PR DESCRIPTION
When the USB serial buffer is full, the Ctrl-C code to send KeyboardInterrupt can't be sent, which creates a problem if you've pasted code or otherwise filled the buffer and need to recover. A similar problem affects advanced UIs that interact with CircuitPython and may send characters when they're unexpected, such as mu when it tries to move the cursor based on the user clicking on the screen.

The main way forward seems to be to use some kind of message that can still reach CircuitPython when its internal serial recieve buffer is full. RS232 defines a "break" signal, in which the transmitting device holds its data line in the "space" state for many entire character times. This still exists in the world of USB serial.

This does work, sort of, except that your host computer software will need to properly handle blocking serial writes; tio can send a break with the **ctrl-c b** sequence, but this only works if it hasn't yet written too much data, so it doesn't actually help in most situations :-/