### PR TITLE
RP2040: have clock start high when SPI polarity high

### DIFF
--- a/ports/raspberrypi/common-hal/busio/SPI.c
+++ b/ports/raspberrypi/common-hal/busio/SPI.c
@@ -151,6 +151,15 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
 
     spi_set_format(self->peripheral, bits, polarity, phase, SPI_MSB_FIRST);
 
+    // Workaround to start with clock line high if polarity=1. The hw SPI peripheral does not do this
+    // automatically. See https://github.com/raspberrypi/pico-sdk/issues/868 and
+    // https://forums.raspberrypi.com/viewtopic.php?t=336142
+    // TODO: scheduled to be be fixed in pico-sdk 1.5.0.
+    if (polarity) {
+        hw_clear_bits(&spi_get_hw(self->peripheral)->cr1, SPI_SSPCR1_SSE_BITS); // disable the SPI
+        hw_set_bits(&spi_get_hw(self->peripheral)->cr1, SPI_SSPCR1_SSE_BITS); // re-enable the SPI
+    }
+
     self->polarity = polarity;
     self->phase = phase;
     self->bits = bits;


### PR DESCRIPTION
While testing for #6510, I found a different problem on RP2040. The hw peripheral does not start with SCK high when polarity set to high. This is discussed here:

https://github.com/raspberrypi/pico-sdk/issues/868
https://forums.raspberrypi.com/viewtopic.php?t=336142

Add a workaround, which can be removed when pico-sdk is fixed (scheduled for 1.5.0).

Tested on a Feather RP2040 with a mode 3 sensor, ADXL343.
