### PR TITLE
Compare against PR head commit instead of merge ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,7 @@ jobs:
       uses: tj-actions/changed-files@v34
       with:
         json: "true"
+        sha: ${{ steps.get-last-commit-with-checks.outputs.commit && github.event.after }}
         base_sha: ${{ steps.get-last-commit-with-checks.outputs.commit }}
     - name: Set matrix
       id: set-matrix


### PR DESCRIPTION
When a commit with checks is found, compare it with head commit instead of merge ref.