### PR TITLE
Fix json parse issue in ci_set_matrix.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,14 +140,14 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: tj-actions/changed-files@v34
       with:
-        json: "true"
+        json: true
         sha: ${{ steps.get-last-commit-with-checks.outputs.commit && github.event.after }}
         base_sha: ${{ steps.get-last-commit-with-checks.outputs.commit }}
     - name: Set matrix
       id: set-matrix
       working-directory: tools
       env:
-        CHANGED_FILES: ${{ toJSON(steps.get-changes.outputs.all_changed_and_modified_files) }}
+        CHANGED_FILES: ${{ steps.get-changes.outputs.all_changed_and_modified_files }}
         LAST_FAILED_JOBS: ${{ steps.get-last-commit-with-checks.outputs.checkruns }}
       run: python3 -u ci_set_matrix.py
 

--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -69,7 +69,7 @@ else:
         changed_files = []
     else:
         print("Using files list in CHANGED_FILES")
-        changed_files = json.loads(c)
+        changed_files = json.loads(c.replace("\\", ""))
 
     j = os.environ["LAST_FAILED_JOBS"]
     if j == "":
@@ -203,7 +203,7 @@ def set_boards_to_build(build_all):
     # Split boards by architecture.
     print("Building boards:")
     arch_to_boards = {"aarch": [], "arm": [], "riscv": [], "espressif": []}
-    for board in boards_to_build:
+    for board in sorted(boards_to_build):
         print(" ", board)
         port = board_to_port.get(board)
         # A board can appear due to its _deletion_ (rare)
@@ -220,6 +220,7 @@ def set_boards_to_build(build_all):
             failed_boards = last_failed_jobs[f"build-{arch}"]
             for board in failed_boards:
                 if not board in arch_to_boards[arch]:
+                    print(" ", board)
                     arch_to_boards[arch].append(board)
         # Set Output
         set_output(f"boards-{arch}", json.dumps(sorted(arch_to_boards[arch])))


### PR DESCRIPTION
I noticed that all the boards were being queued for changes specific to a port or a board.
I traced the issue to `changed_files` being incorrectly set since the switch to `tj-actions/changed-files@v34`.