### PR TITLE
Ensure orderly shutdown of ssl socket

### DIFF
--- a/ports/espressif/common-hal/socketpool/Socket.h
+++ b/ports/espressif/common-hal/socketpool/Socket.h
@@ -34,6 +34,8 @@
 
 #include "components/esp-tls/esp_tls.h"
 
+typedef struct ssl_sslsocket_obj ssl_sslsocket_obj_t;
+
 typedef struct {
     mp_obj_base_t base;
     int num;
@@ -42,7 +44,7 @@ typedef struct {
     int ipproto;
     bool connected;
     socketpool_socketpool_obj_t *pool;
-    struct ssl_sslsocket_obj *ssl_socket;
+    ssl_sslsocket_obj_t *ssl_socket;
     mp_uint_t timeout_ms;
 } socketpool_socket_obj_t;
 

--- a/ports/espressif/common-hal/socketpool/Socket.h
+++ b/ports/espressif/common-hal/socketpool/Socket.h
@@ -42,6 +42,7 @@ typedef struct {
     int ipproto;
     bool connected;
     socketpool_socketpool_obj_t *pool;
+    struct ssl_sslsocket_obj *ssl_socket;
     mp_uint_t timeout_ms;
 } socketpool_socket_obj_t;
 

--- a/ports/espressif/common-hal/socketpool/Socket.h
+++ b/ports/espressif/common-hal/socketpool/Socket.h
@@ -24,8 +24,7 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_ESPRESSIF_COMMON_HAL_SOCKETPOOL_SOCKET_H
-#define MICROPY_INCLUDED_ESPRESSIF_COMMON_HAL_SOCKETPOOL_SOCKET_H
+#pragma once
 
 #include "py/obj.h"
 
@@ -49,5 +48,3 @@ typedef struct {
 } socketpool_socket_obj_t;
 
 void socket_user_reset(void);
-
-#endif // MICROPY_INCLUDED_ESPRESSIF_COMMON_HAL_SOCKETPOOL_SOCKET_H

--- a/ports/espressif/common-hal/ssl/SSLContext.c
+++ b/ports/espressif/common-hal/ssl/SSLContext.c
@@ -48,6 +48,7 @@ ssl_sslsocket_obj_t *common_hal_ssl_sslcontext_wrap_socket(ssl_sslcontext_obj_t 
     sock->base.type = &ssl_sslsocket_type;
     sock->ssl_context = self;
     sock->sock = socket;
+    socket->ssl_socket = sock;
 
     // Create a copy of the ESP-TLS config object and store the server hostname
     // Note that ESP-TLS will use common_name for both SNI and verification

--- a/ports/espressif/common-hal/ssl/SSLSocket.h
+++ b/ports/espressif/common-hal/ssl/SSLSocket.h
@@ -34,7 +34,7 @@
 
 #include "components/esp-tls/esp_tls.h"
 
-typedef struct {
+typedef struct ssl_sslsocket_obj {
     mp_obj_base_t base;
     socketpool_socket_obj_t *sock;
     esp_tls_t *tls;


### PR DESCRIPTION
A crash would occur if an SSL socket was not shut down before `gc_deinit()`.

I do not fully understand the root cause, but some object deinitialization / deallocation prior to `gc_deinit` leaves the SSL object in an inconsistent state.

Rather than resolve the root cause, instead ensure that the closing of the user socket also closes the SSL socket.

Testing performed: on Feather ESP32S3 TFT run the reproducer script >10 times. Before, it crashed after 1 time. However, running 10 times helps show I'm not using up socket file descriptors accidentally.

This feels a bit voodoo so I'd love it if instead of incorporating this blindly, someone else went deeper and found the truth.

Closes: #6502