### PR TITLE
fix display of the 'host not found' message

### DIFF
--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -65,6 +65,7 @@ name2codepoint["tilde"] = ord("~")
 # These are just vexing!
 del name2codepoint["and"]
 del name2codepoint["or"]
+del name2codepoint["not"]
 
 
 def preprocess():


### PR DESCRIPTION
The conversion of characters like `_space_` in qstrs is a bit ad-hoc. Because `_not_` stands for the logical negation character ¬ the recently added message was displayed incorrectly:
```
>>> socket.getaddrinfo('does.not.exist', 0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
gaierror: (-2, 'Name or service_space¬space_known')
```
I had noticed this, but evidently failed to include the fix in the problem in #7269.