### PR TITLE
Fix to Issue #7224 - Servo update slow due to PWM channel duty cycle update busy-wait

### DIFF
--- a/ports/raspberrypi/common-hal/pwmio/PWMOut.c
+++ b/ports/raspberrypi/common-hal/pwmio/PWMOut.c
@@ -236,14 +236,6 @@ extern void common_hal_pwmio_pwmout_set_duty_cycle(pwmio_pwmout_obj_t *self, uin
     }
     // compare_count is the CC register value, which should be TOP+1 for 100% duty cycle.
     pwm_set_chan_level(self->slice, self->ab_channel, compare_count);
-    // Wait for wrap so that we know our new cc value has been applied. Clear
-    // the internal interrupt and then wait for it to be set. Worst case, we
-    // wait a full cycle.
-    pwm_hw->intr = 1 << self->slice;
-    while ((pwm_hw->en & (1 << self->slice)) != 0 &&
-           (pwm_hw->intr & (1 << self->slice)) == 0 &&
-           !mp_hal_is_interrupted()) {
-    }
 }
 
 uint16_t common_hal_pwmio_pwmout_get_duty_cycle(pwmio_pwmout_obj_t *self) {


### PR DESCRIPTION
Deleted the busy-wait code in PWMOut.c as referenced in Issue #7224.  As discussed with @tannewt, this fixes the slow update of servo position, and the deleted code is no longer required by the pulse out driver.
Tested using simple test code controlling seven standard 50Hz servos.