### PR TITLE
Add an additional large delay time at start for pico w boards

### DIFF
--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -62,6 +62,7 @@
 #include "src/rp2_common/hardware_sync/include/hardware/sync.h"
 #include "src/rp2_common/hardware_timer/include/hardware/timer.h"
 #if CIRCUITPY_CYW43
+#include "py/mphal.h"
 #include "pico/cyw43_arch.h"
 #endif
 #include "src/common/pico_time/include/pico/time.h"
@@ -143,6 +144,11 @@ safe_mode_t port_init(void) {
     never_reset_pin_number(24);
     never_reset_pin_number(25);
     never_reset_pin_number(29);
+    // A small number of samples of pico w need an additional delay before
+    // initializing the cyw43 chip. Delays inside cyw43_arch_init_with_country
+    // are intended to meet the power on timing requirements, but apparently
+    // are inadequate. We'll back off this long delay based on future testing.
+    mp_hal_delay_ms(1000);
     // Change this as a placeholder as to how to init with country code.
     // Default country code is CYW43_COUNTRY_WORLDWIDE)
     if (cyw43_arch_init_with_country(PICO_CYW43_ARCH_DEFAULT_COUNTRY_CODE)) {


### PR DESCRIPTION
We should tune this delay down, because it appears to only affect a small number of boards.

Closes #7112 