### PR TITLE
Update mpconfigboard.h with LED definition for BPI Picow_s3

### DIFF
--- a/ports/espressif/boards/bpi_picow_s3/mpconfigboard.h
+++ b/ports/espressif/boards/bpi_picow_s3/mpconfigboard.h
@@ -31,6 +31,8 @@
 
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO48)
 
+#define MICROPY_HW_LED_STATUS (&pin_GPIO46)
+
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
 


### PR DESCRIPTION
Configure LED pin for STATUS display and to prevent ESP floating pins from constantly lighting LED dimly.