### PR TITLE
Add VfsFat.readonly property for getting current state

### DIFF
--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -429,6 +429,18 @@ STATIC mp_obj_t vfs_fat_utime(mp_obj_t vfs_in, mp_obj_t path_in, mp_obj_t times_
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(fat_vfs_utime_obj, vfs_fat_utime);
 
+STATIC mp_obj_t vfs_fat_getreadonly(mp_obj_t self_in) {
+    fs_user_mount_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_bool(!filesystem_is_writable_by_python(self));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(fat_vfs_getreadonly_obj, vfs_fat_getreadonly);
+STATIC const mp_obj_property_t fat_vfs_readonly_obj = {
+    .base.type = &mp_type_property,
+    .proxy = {(mp_obj_t)&fat_vfs_getreadonly_obj,
+              MP_ROM_NONE,
+              MP_ROM_NONE},
+};
+
 #if MICROPY_FATFS_USE_LABEL
 STATIC mp_obj_t vfs_fat_getlabel(mp_obj_t self_in) {
     fs_user_mount_t *self = MP_OBJ_TO_PTR(self_in);
@@ -481,6 +493,7 @@ STATIC const mp_rom_map_elem_t fat_vfs_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_mount), MP_ROM_PTR(&vfs_fat_mount_obj) },
     { MP_ROM_QSTR(MP_QSTR_umount), MP_ROM_PTR(&fat_vfs_umount_obj) },
     { MP_ROM_QSTR(MP_QSTR_utime), MP_ROM_PTR(&fat_vfs_utime_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readonly), MP_ROM_PTR(&fat_vfs_readonly_obj) },
     #if MICROPY_FATFS_USE_LABEL
     { MP_ROM_QSTR(MP_QSTR_label), MP_ROM_PTR(&fat_vfs_label_obj) },
     #endif

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -258,6 +258,10 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
 //|     this property can only be set when the device is writable by the
 //|     microcontroller."""
 //|     ...
+//|     readonly: bool
+//|     """``True`` when the device is mounted as readonly by the microcontroller.
+//|     This property cannot be changed, use `storage.remount` instead."""
+//|     ...
 //|
 //|     def mkfs(self) -> None:
 //|         """Format the block device, deleting any data that may have been there"""


### PR DESCRIPTION
Previously the only other way of determining whether the Vfs has been mounted read-write or read-only appears to be to attempt a write operation and detect a possible OSError:

```python
def is_readonly():
    try:
        with open('/.rw-test', 'w'):
            return False
    except OSError:
        return True
```

This is not only a bit clumsy but also requires extra attention to properly clean up the potentially created files/changes, changed timestamps, etc.

It's not possible for the user code to keep track of the state of the state since the boot VM has to decide whether to (re)mount read-write or read-only, but can't (easily) pass this information on to the runtime VM.