### PR TITLE
Add pin for charge rate for Seeed XIAO nRF52840 Sense

### DIFF
--- a/ports/nrf/boards/Seeed_XIAO_nRF52840_Sense/pins.c
+++ b/ports/nrf/boards/Seeed_XIAO_nRF52840_Sense/pins.c
@@ -52,6 +52,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR_READ_BATT_ENABLE),MP_ROM_PTR(&pin_P0_14)},
     {MP_ROM_QSTR(MP_QSTR_VBATT),MP_ROM_PTR(&pin_P0_31)},
     {MP_ROM_QSTR(MP_QSTR_CHARGE_STATUS),MP_ROM_PTR(&pin_P0_17)},
+    {MP_ROM_QSTR(MP_QSTR_CHARGE_RATE),MP_ROM_PTR(&pin_P0_13)},
 
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },


### PR DESCRIPTION
Fixes #7251 by adding a pin name for the battery charge control rate pin.

Pinging @PheebeUK on this.