### PR TITLE
Update `tj-actions` & Revert `fetch-depth` change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
     - name: Get changes
       id: get-changes
       if: github.event_name == 'pull_request'
-      uses: tj-actions/changed-files@v34.5.3
+      uses: tj-actions/changed-files@v34.5.1
       with:
         json: true
         sha: ${{ steps.get-last-commit-with-checks.outputs.commit && github.event.after }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: false
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up Python 3
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
     - name: Get changes
       id: get-changes
       if: github.event_name == 'pull_request'
-      uses: tj-actions/changed-files@v34.5.1
+      uses: tj-actions/changed-files@v34
       with:
         json: true
         sha: ${{ steps.get-last-commit-with-checks.outputs.commit && github.event.after }}


### PR DESCRIPTION
The latest working `tj-actions/changed-files` version is `v34.5.1`. Also, reverts `fetch-depth` change introduced in #7329.