### PR TITLE
only import a module if we use something from it

### DIFF
--- a/tools/extract_pyi.py
+++ b/tools/extract_pyi.py
@@ -228,7 +228,8 @@ def convert_folder(top_level, stub_directory):
     imports, type_imports = extract_imports(tree)
     import_lines = ["from __future__ import annotations"]
     for type_module, used_types in type_imports.items():
-        import_lines.append(f"from {type_module} import {', '.join(sorted(used_types))}")
+        if used_types:
+            import_lines.append(f"from {type_module} import {', '.join(sorted(used_types))}")
     import_lines.extend(f"import {m}" for m in sorted(imports))
     import_body = "\n".join(import_lines)
     m = re.match(r'(\s*""".*?""")', stub_contents, flags=re.DOTALL)


### PR DESCRIPTION
This prevents a bogus line such as `from types import ` from being generated.

surprisingly this was not detected as a problem until a change in isort! Formerly it would remove the bad line, but now it (correctly!) errors