### PR TITLE
Refactor so that all sites of name lookup failure result in gaierror

### DIFF
--- a/ports/espressif/common-hal/socketpool/Socket.c
+++ b/ports/espressif/common-hal/socketpool/Socket.c
@@ -369,7 +369,7 @@ void common_hal_socketpool_socket_connect(socketpool_socket_obj_t *self,
     struct addrinfo *result_i;
     int error = lwip_getaddrinfo(host, NULL, &hints, &result_i);
     if (error != 0 || result_i == NULL) {
-        mp_raise_OSError(EHOSTUNREACH);
+        common_hal_socketpool_socketpool_raise_gaierror(SOCKETPOOL_EAI_NONAME, MP_QSTR_Name_space_or_space_service_space_not_space_known);
     }
 
     // Set parameters
@@ -550,7 +550,7 @@ mp_uint_t common_hal_socketpool_socket_sendto(socketpool_socket_obj_t *self,
     struct addrinfo *result_i;
     int error = lwip_getaddrinfo(host, NULL, &hints, &result_i);
     if (error != 0 || result_i == NULL) {
-        mp_raise_OSError(EHOSTUNREACH);
+        common_hal_socketpool_socketpool_raise_gaierror(SOCKETPOOL_EAI_NONAME, MP_QSTR_Name_space_or_space_service_space_not_space_known);
     }
 
     // Set parameters

--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -872,11 +872,7 @@ bool common_hal_socketpool_socket_bind(socketpool_socket_obj_t *socket,
     ip_addr_t bind_addr;
     const ip_addr_t *bind_addr_ptr = &bind_addr;
     if (hostlen > 0) {
-        int error = socketpool_resolve_host(socket->pool, host, &bind_addr);
-        if (error != 0) {
-            mp_raise_OSError(EHOSTUNREACH);
-        }
-
+        socketpool_resolve_host_raise(socket->pool, host, &bind_addr);
     } else {
         bind_addr_ptr = IP_ANY_TYPE;
     }
@@ -965,10 +961,7 @@ void common_hal_socketpool_socket_connect(socketpool_socket_obj_t *socket,
 
     // get address
     ip_addr_t dest;
-    int error = socketpool_resolve_host(socket->pool, host, &dest);
-    if (error != 0) {
-        mp_raise_OSError(EHOSTUNREACH);
-    }
+    socketpool_resolve_host_raise(socket->pool, host, &dest);
 
     err_t err = ERR_ARG;
     switch (socket->type) {
@@ -1163,10 +1156,7 @@ mp_uint_t common_hal_socketpool_socket_sendto(socketpool_socket_obj_t *socket,
     const char *host, size_t hostlen, uint32_t port, const uint8_t *buf, uint32_t len) {
     int _errno;
     ip_addr_t ip;
-    int error = socketpool_resolve_host(socket->pool, host, &ip);
-    if (error != 0) {
-        mp_raise_OSError(EHOSTUNREACH);
-    }
+    socketpool_resolve_host_raise(socket->pool, host, &ip);
 
     mp_uint_t ret = 0;
     switch (socket->type) {

--- a/ports/raspberrypi/common-hal/socketpool/SocketPool.h
+++ b/ports/raspberrypi/common-hal/socketpool/SocketPool.h
@@ -32,4 +32,4 @@ typedef struct {
     mp_obj_base_t base;
 } socketpool_socketpool_obj_t;
 
-int socketpool_resolve_host(socketpool_socketpool_obj_t *self, const char *host, ip_addr_t *addr);
+void socketpool_resolve_host_raise(socketpool_socketpool_obj_t *self, const char *host, ip_addr_t *addr);

--- a/shared-bindings/socketpool/SocketPool.h
+++ b/shared-bindings/socketpool/SocketPool.h
@@ -52,6 +52,10 @@ typedef enum {
     SOCKETPOOL_TCP_NODELAY = 1,
 } socketpool_socketpool_tcpopt_t;
 
+typedef enum {
+    SOCKETPOOL_EAI_NONAME  = -2,
+} socketpool_eai_t;
+
 void common_hal_socketpool_socketpool_construct(socketpool_socketpool_obj_t *self, mp_obj_t radio);
 
 socketpool_socket_obj_t *common_hal_socketpool_socket(socketpool_socketpool_obj_t *self,
@@ -59,11 +63,16 @@ socketpool_socket_obj_t *common_hal_socketpool_socket(socketpool_socketpool_obj_
 
 mp_obj_t common_hal_socketpool_socketpool_gethostbyname(socketpool_socketpool_obj_t *self,
     const char *host);
+// raises an exception instead of returning mp_const_none in the case of error
+mp_obj_t common_hal_socketpool_socketpool_gethostbyname_raise(socketpool_socketpool_obj_t *self,
+    const char *host);
 
 // Non-allocating version for internal use. These sockets are not registered and, therefore, not
 // closed automatically.
 bool socketpool_socket(socketpool_socketpool_obj_t *self,
     socketpool_socketpool_addressfamily_t family, socketpool_socketpool_sock_t type,
     socketpool_socket_obj_t *sock);
+
+NORETURN void common_hal_socketpool_socketpool_raise_gaierror(int value, qstr name);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_SOCKETPOOL_SOCKETPOOL_H


### PR DESCRIPTION
While investigating #7333 I noticed that the work in #7269 was incomplete: multiple paths would still result in an OSError, and for one API it was unclear whether it was intended to throw or return a sentinel value in the case of failed lookup.

This tidies things up, and I think catches all the error paths.