### PR TITLE
redo pin never resetting for mimxrt10xx

### DIFF
--- a/ports/mimxrt10xx/boards/feather_m7_1011/board.c
+++ b/ports/mimxrt10xx/boards/feather_m7_1011/board.c
@@ -26,21 +26,40 @@
  */
 
 #include "supervisor/board.h"
-#include "boards/flash_config.h"
-#include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
-    // SWD Pins
-    common_hal_never_reset_pin(&pin_GPIO_AD_13);// SWDIO
-    common_hal_never_reset_pin(&pin_GPIO_AD_12);// SWCLK
+// These pins should never ever be reset; doing so could interfere with basic operation.
+STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+    &pin_GPIO_AD_13,// SWDIO
+    &pin_GPIO_AD_12,// SWCLK
 
     // FLEX flash
-    common_hal_never_reset_pin(&pin_GPIO_SD_12);
-    common_hal_never_reset_pin(&pin_GPIO_SD_11);
-    common_hal_never_reset_pin(&pin_GPIO_SD_10);
-    common_hal_never_reset_pin(&pin_GPIO_SD_09);
-    common_hal_never_reset_pin(&pin_GPIO_SD_08);
-    common_hal_never_reset_pin(&pin_GPIO_SD_07);
-    common_hal_never_reset_pin(&pin_GPIO_SD_06);
+    &pin_GPIO_SD_12,
+    &pin_GPIO_SD_11,
+    &pin_GPIO_SD_10,
+    &pin_GPIO_SD_09,
+    &pin_GPIO_SD_08,
+    &pin_GPIO_SD_07,
+    &pin_GPIO_SD_06,
+};
+
+STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
+    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
+        if (pin == _reset_forbidden_pins[i]) {
+            return true;
+        }
+    }
+    return false;
 }
+
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    if (_reset_forbidden(pin)) {
+        return true;
+    }
+
+    // Other reset variations would go here.
+
+    return false;
+}
+
+// Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/feather_m7_1011/board.c
+++ b/ports/mimxrt10xx/boards/feather_m7_1011/board.c
@@ -29,7 +29,8 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 // These pins should never ever be reset; doing so could interfere with basic operation.
-STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+// Used in common-hal/microcontroller/Pin.c
+const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     &pin_GPIO_AD_13,// SWDIO
     &pin_GPIO_AD_12,// SWCLK
 
@@ -41,25 +42,7 @@ STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     &pin_GPIO_SD_08,
     &pin_GPIO_SD_07,
     &pin_GPIO_SD_06,
+    NULL,                       // Must end in NULL.
 };
-
-STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
-    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
-        if (pin == _reset_forbidden_pins[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
-    if (_reset_forbidden(pin)) {
-        return true;
-    }
-
-    // Other reset variations would go here.
-
-    return false;
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/feather_mimxrt1011/board.c
+++ b/ports/mimxrt10xx/boards/feather_mimxrt1011/board.c
@@ -26,23 +26,41 @@
  */
 
 #include "supervisor/board.h"
-#include "boards/flash_config.h"
-#include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
-    // SWD Pins
-    common_hal_never_reset_pin(&pin_GPIO_AD_13);// SWDIO
-    common_hal_never_reset_pin(&pin_GPIO_AD_12);// SWCLK
+// These pins should never ever be reset; doing so could interfere with basic operation.
+STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+    &pin_GPIO_AD_13,// SWDIO
+    &pin_GPIO_AD_12,// SWCLK
 
     // FLEX flash
-    common_hal_never_reset_pin(&pin_GPIO_SD_12);
-    common_hal_never_reset_pin(&pin_GPIO_SD_11);
-    common_hal_never_reset_pin(&pin_GPIO_SD_10);
-    common_hal_never_reset_pin(&pin_GPIO_SD_09);
-    common_hal_never_reset_pin(&pin_GPIO_SD_08);
-    common_hal_never_reset_pin(&pin_GPIO_SD_07);
-    common_hal_never_reset_pin(&pin_GPIO_SD_06);
+    &pin_GPIO_SD_12,
+    &pin_GPIO_SD_11,
+    &pin_GPIO_SD_10,
+    &pin_GPIO_SD_09,
+    &pin_GPIO_SD_08,
+    &pin_GPIO_SD_07,
+    &pin_GPIO_SD_06,
+};
+
+STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
+    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
+        if (pin == _reset_forbidden_pins[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    if (_reset_forbidden(pin)) {
+        return true;
+    }
+
+    // Other reset variations would go here.
+
+    return false;
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/feather_mimxrt1011/board.c
+++ b/ports/mimxrt10xx/boards/feather_mimxrt1011/board.c
@@ -29,7 +29,8 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 // These pins should never ever be reset; doing so could interfere with basic operation.
-STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+// Used in common-hal/microcontroller/Pin.c
+const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     &pin_GPIO_AD_13,// SWDIO
     &pin_GPIO_AD_12,// SWCLK
 
@@ -41,26 +42,7 @@ STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     &pin_GPIO_SD_08,
     &pin_GPIO_SD_07,
     &pin_GPIO_SD_06,
+    NULL,                       // Must end in NULL.
 };
-
-STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
-    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
-        if (pin == _reset_forbidden_pins[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-
-bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
-    if (_reset_forbidden(pin)) {
-        return true;
-    }
-
-    // Other reset variations would go here.
-
-    return false;
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/feather_mimxrt1062/board.c
+++ b/ports/mimxrt10xx/boards/feather_mimxrt1062/board.c
@@ -26,22 +26,40 @@
  */
 
 #include "supervisor/board.h"
-#include "boards/flash_config.h"
-#include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
+// These pins should never ever be reset; doing so could interfere with basic operation.
+STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     // SWD Pins
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_06);// SWDIO
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_07);// SWCLK
+    &pin_GPIO_AD_B0_06,// SWDIO
+    &pin_GPIO_AD_B0_07,// SWCLK
 
     // FLEX flash
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_06);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_07);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_08);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_09);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_10);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_11);
+    &pin_GPIO_SD_B1_06,
+    &pin_GPIO_SD_B1_07,
+    &pin_GPIO_SD_B1_08,
+    &pin_GPIO_SD_B1_09,
+    &pin_GPIO_SD_B1_10,
+    &pin_GPIO_SD_B1_11,
+};
+
+STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
+    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
+        if (pin == _reset_forbidden_pins[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    if (_reset_forbidden(pin)) {
+        return true;
+    }
+
+    // Other reset variations would go here.
+
+    return false;
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/feather_mimxrt1062/board.c
+++ b/ports/mimxrt10xx/boards/feather_mimxrt1062/board.c
@@ -29,7 +29,8 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 // These pins should never ever be reset; doing so could interfere with basic operation.
-STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+// Used in common-hal/microcontroller/Pin.c
+const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     // SWD Pins
     &pin_GPIO_AD_B0_06,// SWDIO
     &pin_GPIO_AD_B0_07,// SWCLK
@@ -41,25 +42,7 @@ STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     &pin_GPIO_SD_B1_09,
     &pin_GPIO_SD_B1_10,
     &pin_GPIO_SD_B1_11,
+    NULL,                       // Must end in NULL.
 };
-
-STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
-    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
-        if (pin == _reset_forbidden_pins[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
-    if (_reset_forbidden(pin)) {
-        return true;
-    }
-
-    // Other reset variations would go here.
-
-    return false;
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/imxrt1010_evk/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1010_evk/board.c
@@ -26,25 +26,42 @@
  */
 
 #include "supervisor/board.h"
-#include "boards/flash_config.h"
-#include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
-    // SWD Pins
-    common_hal_never_reset_pin(&pin_GPIO_AD_13); // SWDIO
-    common_hal_never_reset_pin(&pin_GPIO_AD_12); // SWCLK
+// These pins should never ever be reset; doing so could interfere with basic operation.
+STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+    &pin_GPIO_AD_13, // SWDIO
+    &pin_GPIO_AD_12, // SWCLK
     // FLEX flash
-    common_hal_never_reset_pin(&pin_GPIO_SD_12);
-    common_hal_never_reset_pin(&pin_GPIO_SD_11);
-    common_hal_never_reset_pin(&pin_GPIO_SD_10);
-    common_hal_never_reset_pin(&pin_GPIO_SD_09);
-    common_hal_never_reset_pin(&pin_GPIO_SD_08);
-    common_hal_never_reset_pin(&pin_GPIO_SD_07);
-    common_hal_never_reset_pin(&pin_GPIO_SD_06);
+    &pin_GPIO_SD_12,
+    &pin_GPIO_SD_11,
+    &pin_GPIO_SD_10,
+    &pin_GPIO_SD_09,
+    &pin_GPIO_SD_08,
+    &pin_GPIO_SD_07,
+    &pin_GPIO_SD_06,
     // USB Pins
-    common_hal_never_reset_pin(&pin_GPIO_12);
-    common_hal_never_reset_pin(&pin_GPIO_13);
+    &pin_GPIO_12,
+    &pin_GPIO_13,
+};
+
+STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
+    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
+        if (pin == _reset_forbidden_pins[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    if (_reset_forbidden(pin)) {
+        return true;
+    }
+
+    // Other reset variations would go here.
+
+    return false;
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/imxrt1010_evk/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1010_evk/board.c
@@ -29,7 +29,8 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 // These pins should never ever be reset; doing so could interfere with basic operation.
-STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+// Used in common-hal/microcontroller/Pin.c
+const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     &pin_GPIO_AD_13, // SWDIO
     &pin_GPIO_AD_12, // SWCLK
     // FLEX flash
@@ -43,25 +44,7 @@ STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     // USB Pins
     &pin_GPIO_12,
     &pin_GPIO_13,
+    NULL,                       // Must end in NULL.
 };
-
-STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
-    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
-        if (pin == _reset_forbidden_pins[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
-    if (_reset_forbidden(pin)) {
-        return true;
-    }
-
-    // Other reset variations would go here.
-
-    return false;
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/imxrt1020_evk/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1020_evk/board.c
@@ -26,26 +26,44 @@
  */
 
 #include "supervisor/board.h"
-#include "boards/flash_config.h"
-#include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
+// These pins should never ever be reset; doing so could interfere with basic operation.
+STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     // SWD Pins
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_00);// SWDIO
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_01);// SWCLK
+    &pin_GPIO_AD_B0_00,// SWDIO
+    &pin_GPIO_AD_B0_01,// SWCLK
 
     // FLEX flash
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_06);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_07);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_08);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_09);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_10);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_11);
+    &pin_GPIO_SD_B1_06,
+    &pin_GPIO_SD_B1_07,
+    &pin_GPIO_SD_B1_08,
+    &pin_GPIO_SD_B1_09,
+    &pin_GPIO_SD_B1_10,
+    &pin_GPIO_SD_B1_11,
 
     // USB Pins
-    common_hal_never_reset_pin(&pin_GPIO_AD_B1_11);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B1_12);
+    &pin_GPIO_AD_B1_11,
+    &pin_GPIO_AD_B1_12,
+};
+
+STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
+    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
+        if (pin == _reset_forbidden_pins[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    if (_reset_forbidden(pin)) {
+        return true;
+    }
+
+    // Other reset variations would go here.
+
+    return false;
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/imxrt1020_evk/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1020_evk/board.c
@@ -29,7 +29,8 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 // These pins should never ever be reset; doing so could interfere with basic operation.
-STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+// Used in common-hal/microcontroller/Pin.c
+const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     // SWD Pins
     &pin_GPIO_AD_B0_00,// SWDIO
     &pin_GPIO_AD_B0_01,// SWCLK
@@ -45,25 +46,7 @@ STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     // USB Pins
     &pin_GPIO_AD_B1_11,
     &pin_GPIO_AD_B1_12,
+    NULL,                       // Must end in NULL.
 };
-
-STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
-    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
-        if (pin == _reset_forbidden_pins[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
-    if (_reset_forbidden(pin)) {
-        return true;
-    }
-
-    // Other reset variations would go here.
-
-    return false;
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/imxrt1060_evk/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1060_evk/board.c
@@ -26,30 +26,51 @@
  */
 
 #include "supervisor/board.h"
-#include "boards/flash_config.h"
-#include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
+// These pins should never ever be reset; doing so could interfere with basic operation.
+STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     // SWD Pins
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_06);// SWDIO
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_07);// SWCLK
+    &pin_GPIO_AD_B0_06, // SWDIO
+    &pin_GPIO_AD_B0_07, // SWCLK
 
     // FLEX flash
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_00);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_01);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_02);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_03);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_04);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_05);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_06);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_07);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_08);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_09);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_10);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_11);
+    &pin_GPIO_SD_B1_00,
+    &pin_GPIO_SD_B1_01,
+    &pin_GPIO_SD_B1_02,
+    &pin_GPIO_SD_B1_03,
+    &pin_GPIO_SD_B1_04,
+    &pin_GPIO_SD_B1_05,
+    &pin_GPIO_SD_B1_06,
+    &pin_GPIO_SD_B1_07,
+    &pin_GPIO_SD_B1_08,
+    &pin_GPIO_SD_B1_09,
+    &pin_GPIO_SD_B1_10,
+    &pin_GPIO_SD_B1_11,
 
     // USB Pins
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_01);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_03);
+    &pin_GPIO_AD_B0_01,
+    &pin_GPIO_AD_B0_03,
+};
+
+STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
+    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
+        if (pin == _reset_forbidden_pins[i]) {
+            return true;
+        }
+    }
+    return false;
 }
+
+
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    if (_reset_forbidden(pin)) {
+        return true;
+    }
+
+    // Other reset variations would go here.
+
+    return false;
+}
+
+// Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/imxrt1060_evk/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1060_evk/board.c
@@ -29,7 +29,8 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 // These pins should never ever be reset; doing so could interfere with basic operation.
-STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+// Used in common-hal/microcontroller/Pin.c
+const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     // SWD Pins
     &pin_GPIO_AD_B0_06, // SWDIO
     &pin_GPIO_AD_B0_07, // SWCLK
@@ -51,26 +52,7 @@ STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     // USB Pins
     &pin_GPIO_AD_B0_01,
     &pin_GPIO_AD_B0_03,
+    NULL,                       // Must end in NULL.
 };
-
-STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
-    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
-        if (pin == _reset_forbidden_pins[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-
-bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
-    if (_reset_forbidden(pin)) {
-        return true;
-    }
-
-    // Other reset variations would go here.
-
-    return false;
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/metro_m7_1011/board.c
+++ b/ports/mimxrt10xx/boards/metro_m7_1011/board.c
@@ -26,23 +26,41 @@
  */
 
 #include "supervisor/board.h"
-#include "boards/flash_config.h"
-#include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
+// These pins should never ever be reset; doing so could interfere with basic operation.
+STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     // SWD Pins
-    common_hal_never_reset_pin(&pin_GPIO_AD_13);// SWDIO
-    common_hal_never_reset_pin(&pin_GPIO_AD_12);// SWCLK
+    &pin_GPIO_AD_13,// SWDIO
+    &pin_GPIO_AD_12,// SWCLK
 
     // FLEX flash
-    common_hal_never_reset_pin(&pin_GPIO_SD_12);
-    common_hal_never_reset_pin(&pin_GPIO_SD_11);
-    common_hal_never_reset_pin(&pin_GPIO_SD_10);
-    common_hal_never_reset_pin(&pin_GPIO_SD_09);
-    common_hal_never_reset_pin(&pin_GPIO_SD_08);
-    common_hal_never_reset_pin(&pin_GPIO_SD_07);
-    common_hal_never_reset_pin(&pin_GPIO_SD_06);
+    &pin_GPIO_SD_12,
+    &pin_GPIO_SD_11,
+    &pin_GPIO_SD_10,
+    &pin_GPIO_SD_09,
+    &pin_GPIO_SD_08,
+    &pin_GPIO_SD_07,
+    &pin_GPIO_SD_06,
+};
+
+STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
+    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
+        if (pin == _reset_forbidden_pins[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    if (_reset_forbidden(pin)) {
+        return true;
+    }
+
+    // Other reset variations would go here.
+
+    return false;
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/metro_m7_1011/board.c
+++ b/ports/mimxrt10xx/boards/metro_m7_1011/board.c
@@ -29,7 +29,8 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 // These pins should never ever be reset; doing so could interfere with basic operation.
-STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+// Used in common-hal/microcontroller/Pin.c
+const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     // SWD Pins
     &pin_GPIO_AD_13,// SWDIO
     &pin_GPIO_AD_12,// SWCLK
@@ -42,25 +43,7 @@ STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     &pin_GPIO_SD_08,
     &pin_GPIO_SD_07,
     &pin_GPIO_SD_06,
+    NULL,                       // Must end in NULL.
 };
-
-STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
-    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
-        if (pin == _reset_forbidden_pins[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
-    if (_reset_forbidden(pin)) {
-        return true;
-    }
-
-    // Other reset variations would go here.
-
-    return false;
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/sparkfun_teensy_micromod/board.c
+++ b/ports/mimxrt10xx/boards/sparkfun_teensy_micromod/board.c
@@ -29,7 +29,8 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 // These pins should never ever be reset; doing so could interfere with basic operation.
-STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+// Used in common-hal/microcontroller/Pin.c
+const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     &pin_GPIO_SD_B1_06,
     &pin_GPIO_SD_B1_07,
     &pin_GPIO_SD_B1_08,
@@ -49,25 +50,7 @@ STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     &pin_GPIO_AD_B0_11,
     // Data strobe needs protection despite being grounded
     &pin_GPIO_SD_B1_05,
+    NULL,                       // Must end in NULL.
 };
-
-STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
-    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
-        if (pin == _reset_forbidden_pins[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
-    if (_reset_forbidden(pin)) {
-        return true;
-    }
-
-    // Other reset variations would go here.
-
-    return false;
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/sparkfun_teensy_micromod/board.c
+++ b/ports/mimxrt10xx/boards/sparkfun_teensy_micromod/board.c
@@ -26,31 +26,48 @@
  */
 
 #include "supervisor/board.h"
-#include "boards/flash_config.h"
-#include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
-    // FLEX flash
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_06);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_07);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_08);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_09);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_10);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_11);
+// These pins should never ever be reset; doing so could interfere with basic operation.
+STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+    &pin_GPIO_SD_B1_06,
+    &pin_GPIO_SD_B1_07,
+    &pin_GPIO_SD_B1_08,
+    &pin_GPIO_SD_B1_09,
+    &pin_GPIO_SD_B1_10,
+    &pin_GPIO_SD_B1_11,
 
     // FLEX flash 2
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_04);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_06);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_07);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_08);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_09);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_10);
-    common_hal_never_reset_pin(&pin_GPIO_EMC_01);
-    common_hal_never_reset_pin(&pin_GPIO_B0_13);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_11);
+    &pin_GPIO_AD_B0_04,
+    &pin_GPIO_AD_B0_06,
+    &pin_GPIO_AD_B0_07,
+    &pin_GPIO_AD_B0_08,
+    &pin_GPIO_AD_B0_09,
+    &pin_GPIO_AD_B0_10,
+    &pin_GPIO_EMC_01,
+    &pin_GPIO_B0_13,
+    &pin_GPIO_AD_B0_11,
     // Data strobe needs protection despite being grounded
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_05);
+    &pin_GPIO_SD_B1_05,
+};
+
+STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
+    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
+        if (pin == _reset_forbidden_pins[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    if (_reset_forbidden(pin)) {
+        return true;
+    }
+
+    // Other reset variations would go here.
+
+    return false;
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/teensy40/board.c
+++ b/ports/mimxrt10xx/boards/teensy40/board.c
@@ -26,31 +26,49 @@
  */
 
 #include "supervisor/board.h"
-#include "boards/flash_config.h"
-#include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
+// These pins should never ever be reset; doing so could interfere with basic operation.
+STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     // FLEX flash
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_06);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_07);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_08);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_09);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_10);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_11);
+    &pin_GPIO_SD_B1_06,
+    &pin_GPIO_SD_B1_07,
+    &pin_GPIO_SD_B1_08,
+    &pin_GPIO_SD_B1_09,
+    &pin_GPIO_SD_B1_10,
+    &pin_GPIO_SD_B1_11,
 
     // FLEX flash 2
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_04);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_06);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_07);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_08);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_09);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_10);
-    common_hal_never_reset_pin(&pin_GPIO_EMC_01);
-    common_hal_never_reset_pin(&pin_GPIO_B0_13);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_11);
+    &pin_GPIO_AD_B0_04,
+    &pin_GPIO_AD_B0_06,
+    &pin_GPIO_AD_B0_07,
+    &pin_GPIO_AD_B0_08,
+    &pin_GPIO_AD_B0_09,
+    &pin_GPIO_AD_B0_10,
+    &pin_GPIO_EMC_01,
+    &pin_GPIO_B0_13,
+    &pin_GPIO_AD_B0_11,
     // Data strobe needs protection despite being grounded
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_05);
+    &pin_GPIO_SD_B1_05,
+};
+
+STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
+    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
+        if (pin == _reset_forbidden_pins[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    if (_reset_forbidden(pin)) {
+        return true;
+    }
+
+    // Other reset variations would go here.
+
+    return false;
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/teensy40/board.c
+++ b/ports/mimxrt10xx/boards/teensy40/board.c
@@ -29,7 +29,8 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 // These pins should never ever be reset; doing so could interfere with basic operation.
-STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+// Used in common-hal/microcontroller/Pin.c
+const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     // FLEX flash
     &pin_GPIO_SD_B1_06,
     &pin_GPIO_SD_B1_07,
@@ -50,25 +51,7 @@ STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     &pin_GPIO_AD_B0_11,
     // Data strobe needs protection despite being grounded
     &pin_GPIO_SD_B1_05,
+    NULL,                       // Must end in NULL.
 };
-
-STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
-    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
-        if (pin == _reset_forbidden_pins[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
-    if (_reset_forbidden(pin)) {
-        return true;
-    }
-
-    // Other reset variations would go here.
-
-    return false;
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/teensy41/board.c
+++ b/ports/mimxrt10xx/boards/teensy41/board.c
@@ -26,29 +26,49 @@
  */
 
 #include "supervisor/board.h"
-#include "boards/flash_config.h"
-#include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
+// These pins should never ever be reset; doing so could interfere with basic operation.
+STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     // FLEX flash
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_06);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_07);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_08);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_09);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_10);
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_11);
+    &pin_GPIO_SD_B1_06,
+    &pin_GPIO_SD_B1_07,
+    &pin_GPIO_SD_B1_08,
+    &pin_GPIO_SD_B1_09,
+    &pin_GPIO_SD_B1_10,
+    &pin_GPIO_SD_B1_11,
 
     // FLEX flash 2
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_04);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_06);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_07);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_08);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_09);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_10);
-    common_hal_never_reset_pin(&pin_GPIO_EMC_01);
-    common_hal_never_reset_pin(&pin_GPIO_B0_13);
-    common_hal_never_reset_pin(&pin_GPIO_AD_B0_11);
+    &pin_GPIO_AD_B0_04,
+    &pin_GPIO_AD_B0_06,
+    &pin_GPIO_AD_B0_07,
+    &pin_GPIO_AD_B0_08,
+    &pin_GPIO_AD_B0_09,
+    &pin_GPIO_AD_B0_10,
+    &pin_GPIO_EMC_01,
+    &pin_GPIO_B0_13,
+    &pin_GPIO_AD_B0_11,
     // Data strobe needs protection despite being grounded
-    common_hal_never_reset_pin(&pin_GPIO_SD_B1_05);
+    &pin_GPIO_SD_B1_05,
+};
+
+STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
+    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
+        if (pin == _reset_forbidden_pins[i]) {
+            return true;
+        }
+    }
+    return false;
 }
+
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    if (_reset_forbidden(pin)) {
+        return true;
+    }
+
+    // Other reset variations would go here.
+
+    return false;
+}
+
+// Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/teensy41/board.c
+++ b/ports/mimxrt10xx/boards/teensy41/board.c
@@ -29,7 +29,8 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 // These pins should never ever be reset; doing so could interfere with basic operation.
-STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
+// Used in common-hal/microcontroller/Pin.c
+const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     // FLEX flash
     &pin_GPIO_SD_B1_06,
     &pin_GPIO_SD_B1_07,
@@ -50,25 +51,7 @@ STATIC const mcu_pin_obj_t *_reset_forbidden_pins[] = {
     &pin_GPIO_AD_B0_11,
     // Data strobe needs protection despite being grounded
     &pin_GPIO_SD_B1_05,
+    NULL,                       // Must end in NULL.
 };
-
-STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
-    for (size_t i = 0; i < MP_ARRAY_SIZE(_reset_forbidden_pins); i++) {
-        if (pin == _reset_forbidden_pins[i]) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
-    if (_reset_forbidden(pin)) {
-        return true;
-    }
-
-    // Other reset variations would go here.
-
-    return false;
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/common-hal/microcontroller/Pin.c
+++ b/ports/mimxrt10xx/common-hal/microcontroller/Pin.c
@@ -44,9 +44,12 @@ void reset_all_pins(void) {
         if (never_reset_pins[pin->mux_idx]) {
             continue;
         }
-        *(uint32_t *)pin->mux_reg = pin->mux_reset;
-        *(uint32_t *)pin->cfg_reg = pin->pad_reset;
+        common_hal_reset_pin(pin);
     }
+}
+
+MP_WEAK bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    return false;
 }
 
 // Since i.MX pins need extra register and reset information to reset properly,
@@ -55,6 +58,12 @@ void common_hal_reset_pin(const mcu_pin_obj_t *pin) {
     if (pin == NULL) {
         return;
     }
+
+    // Give the board a chance to reset the pin in a particular way, or not reset it at all.
+    if (mimxrt10xx_board_reset_pin_number(pin)) {
+        return;
+    }
+
     never_reset_pins[pin->mux_idx] = false;
     claimed_pins[pin->mux_idx] = false;
     *(uint32_t *)pin->mux_reg = pin->mux_reset;

--- a/ports/mimxrt10xx/common-hal/microcontroller/Pin.c
+++ b/ports/mimxrt10xx/common-hal/microcontroller/Pin.c
@@ -31,6 +31,22 @@
 STATIC bool claimed_pins[IOMUXC_SW_PAD_CTL_PAD_COUNT];
 STATIC bool never_reset_pins[IOMUXC_SW_PAD_CTL_PAD_COUNT];
 
+// Default is that no pins are forbidden to reset.
+MP_WEAK const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
+    NULL,
+};
+
+STATIC bool _reset_forbidden(const mcu_pin_obj_t *pin) {
+    const mcu_pin_obj_t **forbidden_pin = &mimxrt10xx_reset_forbidden_pins[0];
+    while (*forbidden_pin) {
+        if (pin == *forbidden_pin) {
+            return true;
+        }
+        forbidden_pin++;
+    }
+    return false;
+}
+
 // There are two numbering systems used here:
 // IOMUXC index, used for iterating through pins and accessing reset information,
 // and GPIO port and number, used to store claimed and reset tagging. The two number
@@ -55,7 +71,12 @@ MP_WEAK bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
 // Since i.MX pins need extra register and reset information to reset properly,
 // resetting pins by number alone has been removed.
 void common_hal_reset_pin(const mcu_pin_obj_t *pin) {
+    return;
     if (pin == NULL) {
+        return;
+    }
+
+    if (_reset_forbidden(pin)) {
         return;
     }
 

--- a/ports/mimxrt10xx/common-hal/microcontroller/Pin.h
+++ b/ports/mimxrt10xx/common-hal/microcontroller/Pin.h
@@ -35,4 +35,11 @@
 void reset_all_pins(void);
 void claim_pin(const mcu_pin_obj_t *pin);
 
+// Allow the board to reset a pin in a board-specific way. This can be used
+// for LEDs or enable pins to put them in a state beside the default pull-up,
+// or to simply not reset the pin at all.
+// Return true to indicate that the pin was handled in a special way. Returning false will lead to
+// the port-default reset behavior.
+extern bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin);
+
 #endif // MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_MICROCONTROLLER_PIN_H

--- a/ports/mimxrt10xx/common-hal/microcontroller/Pin.h
+++ b/ports/mimxrt10xx/common-hal/microcontroller/Pin.h
@@ -35,6 +35,9 @@
 void reset_all_pins(void);
 void claim_pin(const mcu_pin_obj_t *pin);
 
+// List of pins that should never be reset.
+extern const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[];
+
 // Allow the board to reset a pin in a board-specific way. This can be used
 // for LEDs or enable pins to put them in a state beside the default pull-up,
 // or to simply not reset the pin at all.


### PR DESCRIPTION
Fixes #7312.

Redo pin resetting logic to never ever reset vital pins. Thanks to @RetiredWizard for diagnosis.

The only board I had to test is the Teensy 4.1, which does come up in the REPL. I did make it blink `board.LED`.