### PR TITLE
fix AuthMode printing regression

### DIFF
--- a/ports/espressif/common-hal/wifi/Network.c
+++ b/ports/espressif/common-hal/wifi/Network.c
@@ -86,9 +86,9 @@ mp_obj_t common_hal_wifi_network_get_authmode(wifi_network_obj_t *self) {
     }
     mp_obj_t authmode_list = mp_obj_new_list(0, NULL);
     if (authmode_mask != 0) {
-        for (uint8_t i = 0; i < 8; i++) {
+        for (uint8_t i = 0; i < 32; i++) {
             if ((authmode_mask >> i) & 1) {
-                mp_obj_list_append(authmode_list, cp_enum_find(&wifi_authmode_type, i));
+                mp_obj_list_append(authmode_list, cp_enum_find(&wifi_authmode_type, 1 << i));
             }
         }
     }

--- a/ports/raspberrypi/common-hal/wifi/Network.c
+++ b/ports/raspberrypi/common-hal/wifi/Network.c
@@ -53,7 +53,7 @@ mp_obj_t common_hal_wifi_network_get_country(wifi_network_obj_t *self) {
 }
 
 mp_obj_t common_hal_wifi_network_get_authmode(wifi_network_obj_t *self) {
-    uint8_t authmode_mask = 0;
+    uint32_t authmode_mask = 0;
     if (self->record.auth_mode == 0) {
         authmode_mask = AUTHMODE_OPEN;
     }
@@ -71,9 +71,9 @@ mp_obj_t common_hal_wifi_network_get_authmode(wifi_network_obj_t *self) {
     ;
     mp_obj_t authmode_list = mp_obj_new_list(0, NULL);
     if (authmode_mask != 0) {
-        for (uint8_t i = 0; i < 8; i++) {
+        for (uint32_t i = 0; i < 32; i++) {
             if ((authmode_mask >> i) & 1) {
-                mp_obj_list_append(authmode_list, cp_enum_find(&wifi_authmode_type, i));
+                mp_obj_list_append(authmode_list, cp_enum_find(&wifi_authmode_type, 1 << i));
             }
         }
     }


### PR DESCRIPTION
- Fixes #7339.

My change to make authmodes bitmasks was a tiny bit over-enthusiastic.

Tested on Metro ESP32-S2 and Pico W. Both now print authmodes properly.