### PR TITLE
esp32-camera: make the master_clock_pin really optional

### DIFF
--- a/ports/espressif/bindings/esp32_camera/Camera.c
+++ b/ports/espressif/bindings/esp32_camera/Camera.c
@@ -50,8 +50,8 @@
 //|         vsync_pin: microcontroller.Pin,
 //|         href_pin: microcontroller.Pin,
 //|         i2c: busio.I2C,
-//|         external_clock_pin: microcontroller.Pin,
-//|         external_clock_frequency: int,
+//|         external_clock_pin: Optional[microcontroller.Pin] = None,
+//|         external_clock_frequency: int = 20_000_000,
 //|         powerdown_pin: Optional[microcontroller.Pin] = None,
 //|         reset_pin: Optional[microcontroller.Pin] = None,
 //|         pixel_format: PixelFormat = PixelFormat.RGB565,
@@ -101,8 +101,8 @@ STATIC mp_obj_t esp32_camera_camera_make_new(const mp_obj_type_t *type, size_t n
         { MP_QSTR_vsync_pin, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_href_pin, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_i2c, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
-        { MP_QSTR_external_clock_pin, MP_ARG_OBJ | MP_ARG_KW_ONLY },
-        { MP_QSTR_external_clock_frequency, MP_ARG_INT | MP_ARG_REQUIRED },
+        { MP_QSTR_external_clock_pin, MP_ARG_OBJ | MP_ARG_KW_ONLY, { .u_obj = MP_ROM_NONE } },
+        { MP_QSTR_external_clock_frequency, MP_ARG_INT | MP_ARG_KW_ONLY, { .u_int = 20000000L } },
         { MP_QSTR_powerdown_pin, MP_ARG_OBJ | MP_ARG_KW_ONLY, { .u_obj = MP_ROM_NONE } },
         { MP_QSTR_reset_pin, MP_ARG_OBJ | MP_ARG_KW_ONLY, { .u_obj = MP_ROM_NONE } },
         { MP_QSTR_pixel_format, MP_ARG_OBJ | MP_ARG_KW_ONLY, { .u_obj = MP_ROM_PTR((void *)&pixel_format_RGB565_obj) } },
@@ -125,7 +125,7 @@ STATIC mp_obj_t esp32_camera_camera_make_new(const mp_obj_type_t *type, size_t n
     const mcu_pin_obj_t *vsync_pin = validate_obj_is_free_pin(args[ARG_vsync_pin].u_obj);
     const mcu_pin_obj_t *href_pin = validate_obj_is_free_pin(args[ARG_href_pin].u_obj);
     busio_i2c_obj_t *i2c = MP_OBJ_TO_PTR(mp_arg_validate_type(args[ARG_i2c].u_obj, &busio_i2c_type, MP_QSTR_i2c));
-    const mcu_pin_obj_t *external_clock_pin = validate_obj_is_free_pin(args[ARG_external_clock_pin].u_obj);
+    const mcu_pin_obj_t *external_clock_pin = validate_obj_is_free_pin_or_none(args[ARG_external_clock_pin].u_obj);
     const mcu_pin_obj_t *powerdown_pin = validate_obj_is_free_pin_or_none(args[ARG_powerdown_pin].u_obj);
     const mcu_pin_obj_t *reset_pin = validate_obj_is_free_pin_or_none(args[ARG_reset_pin].u_obj);
     const mp_int_t external_clock_frequency = mp_arg_validate_int_range(args[ARG_external_clock_frequency].u_int, 0, 40000000, MP_QSTR_clock_frequency);


### PR DESCRIPTION
The master_clock_pin was already optional, but not specifying it would result in a crash. This fixes it, so it really can be omitted, when the camera module has its own clock source built in.