### PR TITLE
Use returns_twice attribute to preserve regs in nlrthumb nlr_push()

### DIFF
--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -36,7 +36,7 @@
 // For reference, arm/thumb callee save regs are:
 //      r4-r11, r13=sp
 
-__attribute__((naked)) unsigned int nlr_push(nlr_buf_t *nlr) {
+__attribute__((naked, returns_twice)) unsigned int nlr_push(nlr_buf_t *nlr) {
 
     __asm volatile (
         "str    r4, [r0, #12]       \n" // store r4 into nlr_buf


### PR DESCRIPTION
- Fixes #7261.

This program crashed on SAMD51 when compiled with `DEBUG=1`:
```py
def crash():
    try:
        None.wrong()
    except AttributeError:
        pass
    i = None
```

The stack variable `fastn` in `mp_execute_bytecode()` in `py/vm.c` was getting smashed. It was a Heisenbug because adding print statements caused it to work.

After narrowing down the point of smashing, I looked at the assembly code and saw that a call to `nlr_push()` in `mp_execute_bytecode` assumed that register `r3` was preserved, when it was not. `nlr_push()` is a "`naked`" function that does not have the usual prologue and postlogue.

This all seemed more and more familiar as I progressed, and it turns out I fixed this problem already, about five years ago, in #506! However, the fix got undone during an upstream MicroPython merge in 2021. The problem manifested differently and we didn't see this problem again for a while.

My #506 fix involved adding "don't clobber these registers" indicators to `nlr_push()`. There is a long discussion in the related issue, #500. A MicroPython developer discovered the same problem in a different context, but it never really got fixed in MicroPython, because it occurs due to LTO, and they rarely use LTO. See https://github.com/micropython/micropython/pull/3889 (which was closed and not merged).

The fix proposed in https://github.com/micropython/micropython/pull/3889 is to declare `nlr_push()` with the attribute `returns_twice`. That is simpler than my #506 fix, so I tried that this time, and lo and behold, it works.

Note that this does not solve #7279 (-O2 not working on SAMx5x).