### PR TITLE
ignore .devcontainer/*

### DIFF
--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -58,6 +58,8 @@ IGNORE = [
     "tools/ci_check_duplicate_usb_vid_pid.py",
 ]
 
+IGNORE_DIRS = ["tests", "docs", ".devcontainer"]
+
 if len(sys.argv) > 1:
     print("Using files list on commandline")
     changed_files = sys.argv[1:]
@@ -150,7 +152,7 @@ def set_boards_to_build(build_all):
                 continue
 
             # Boards don't run tests or docs so ignore those as well.
-            if p.startswith("tests") or p.startswith("docs"):
+            if any([p.startswith(d) for d in IGNORE_DIRS]):
                 continue
 
             # As a (nearly) last resort, for some certain files, we compute the settings from the


### PR DESCRIPTION
This is a PR as suggested by @jepler  in https://github.com/adafruit/circuitpython/pull/7350