### PR TITLE
Issue 7352 - set max value of a pulsein

### DIFF
--- a/ports/espressif/common-hal/pulseio/PulseIn.c
+++ b/ports/espressif/common-hal/pulseio/PulseIn.c
@@ -41,7 +41,12 @@ STATIC void update_internal_buffer(pulseio_pulsein_obj_t *self) {
         length /= 4;
         for (size_t i = 0; i < length; i++) {
             uint16_t pos = (self->start + self->len) % self->maxlen;
-            self->buffer[pos] = items[i].duration0 * 3;
+            uint32_t val = items[i].duration0 * 3;
+            // make sure the value returned does not exceed the max uint16 value.
+            if (val > 65535) {
+                val = 65535;
+            }
+            self->buffer[pos] = (uint16_t)val;
             if (self->len < self->maxlen) {
                 self->len++;
             } else {
@@ -50,7 +55,11 @@ STATIC void update_internal_buffer(pulseio_pulsein_obj_t *self) {
             // Check if second item exists
             if (items[i].duration1) {
                 pos = (self->start + self->len) % self->maxlen;
-                self->buffer[pos] = items[i].duration1 * 3;
+                val = items[i].duration1 * 3;
+                if (val > 65535) {
+                    val = 65535;
+                }
+                self->buffer[pos] = (uint16_t)val;
                 if (self->len < self->maxlen) {
                     self->len++;
                 } else {


### PR DESCRIPTION
Fix for issue #7352. Since pulsein values are defined as 16-bit across all boards, put in a check for Espressif boards. When a pulse exceeds 65535 to set it to 65535 (max value of 16 bits). 