### PR TITLE
Re-evaluation of pystack size

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -450,7 +450,7 @@ void supervisor_run_background_tasks_if_tick(void);
 #endif
 
 #ifndef CIRCUITPY_PYSTACK_SIZE
-#define CIRCUITPY_PYSTACK_SIZE 1536
+#define CIRCUITPY_PYSTACK_SIZE 2048
 #endif
 
 // Wait this long before sleeping immediately after startup, to see if we are connected via USB or BLE.


### PR DESCRIPTION
Currently all boards, excluding `espressif/TG-Watch`, have the exact same pystack size, defined by:
`py/circuitpy_mpconfig.h:453`: `#define CIRCUITPY_PYSTACK_SIZE 1536`

However, at least for me, this is a bottleneck.
My project has at this point, been optimised as much as it goes,
but I am still hitting the pystack limit with some of the latest changes.
(`RuntimeError: pystack exhausted`)

This pr intends to find a better value than the global 1536 that is currently applied.
As an initial test, the value is increased by 512 bytes.