### PR TITLE
Fix several mistakes discovered by clang scan-build

### DIFF
--- a/py/objtype.c
+++ b/py/objtype.c
@@ -106,7 +106,9 @@ STATIC mp_obj_t native_base_init_wrapper(size_t n_args, const mp_obj_t *pos_args
     // copy in args
     memcpy(args2, pos_args, n_args * sizeof(mp_obj_t));
     // copy in kwargs
-    memcpy(args2 + n_args, kw_args->table, 2 * n_kw * sizeof(mp_obj_t));
+    if (n_kw) {
+        memcpy(args2 + n_args, kw_args->table, 2 * n_kw * sizeof(mp_obj_t));
+    }
     self->subobj[0] = native_base->make_new(native_base, n_args, n_kw, args2);
     m_del(mp_obj_t, args2, n_args + 2 * n_kw);
 

--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -689,7 +689,7 @@ STATIC void fill_row(displayio_bitmap_t *bitmap, int swap, int16_t *luminance_da
 static void write_pixels(displayio_bitmap_t *bitmap, int y, bool *data) {
     if (bitmap->bits_per_value == 1) {
         uint32_t *pixel_data = (uint32_t *)(bitmap->data + bitmap->stride * y);
-        for (int i = 0; i < bitmap->stride; i++) {
+        for (int i = 0; i < bitmap->width; i++) {
             uint32_t p = 0;
             for (int j = 0; j < 32; j++) {
                 p = (p << 1);

--- a/shared-module/displayio/Bitmap.c
+++ b/shared-module/displayio/Bitmap.c
@@ -30,12 +30,12 @@
 
 #include "py/runtime.h"
 
-enum { align_bits = 8 * sizeof(uint32_t) };
+enum { ALIGN_BITS = 8 * sizeof(uint32_t) };
 
 static int stride(uint32_t width, uint32_t bits_per_value) {
     uint32_t row_width = width * bits_per_value;
     // align to uint32_t
-    return (row_width + align_bits - 1) / align_bits;
+    return (row_width + ALIGN_BITS - 1) / ALIGN_BITS;
 }
 
 void common_hal_displayio_bitmap_construct(displayio_bitmap_t *self, uint32_t width,
@@ -66,7 +66,7 @@ void common_hal_displayio_bitmap_construct_from_buffer(displayio_bitmap_t *self,
     self->x_shift = 0; // Used to divide the index by the number of pixels per word. Its used in a
                        // shift which effectively divides by 2 ** x_shift.
     uint32_t power_of_two = 1;
-    while (power_of_two < align_bits / bits_per_value) {
+    while (power_of_two < ALIGN_BITS / bits_per_value) {
         self->x_shift++;
         power_of_two <<= 1;
     }

--- a/shared-module/displayio/Bitmap.c
+++ b/shared-module/displayio/Bitmap.c
@@ -70,8 +70,8 @@ void common_hal_displayio_bitmap_construct_from_buffer(displayio_bitmap_t *self,
         self->x_shift++;
         power_of_two <<= 1;
     }
-    self->x_mask = (1 << self->x_shift) - 1; // Used as a modulus on the x value
-    self->bitmask = (1 << bits_per_value) - 1;
+    self->x_mask = (1u << self->x_shift) - 1u; // Used as a modulus on the x value
+    self->bitmask = (1u << bits_per_value) - 1u;
 
     self->dirty_area.x1 = 0;
     self->dirty_area.x2 = width;


### PR DESCRIPTION
I used `scan-build make CC=analyze-cc` with clang-11 on the unix coverage build. It uncovered several interesting things (but also a bunch of irrelevant things as well as some things that appeared to be false positives). No testing performed.