### PR TITLE
Increase the memory for the lwip stack

### DIFF
--- a/ports/raspberrypi/lwip_inc/lwipopts.h
+++ b/ports/raspberrypi/lwip_inc/lwipopts.h
@@ -20,7 +20,7 @@
 #define MEM_LIBC_MALLOC             0
 #endif
 #define MEM_ALIGNMENT               4
-#define MEM_SIZE                    4000
+#define MEM_SIZE                    8000
 #define MEMP_NUM_TCP_SEG            32
 #define MEMP_NUM_ARP_QUEUE          10
 #define PBUF_POOL_SIZE              24


### PR DESCRIPTION
This is a speeculative fix for #7346. The theory is that having some active socket objects uses up the small (4000-byte) pool reserved for lwip and prevents mdns from operating properly. However, as I wasn't able to reproduce the problem with the given script, this is just a guess.

@retiredwizard testing with artifacts from this PR would be appreciated, if you're able to do so!