### PR TITLE
mimxrt10xx gpio pins don't deinit

### DIFF
--- a/ports/mimxrt10xx/common-hal/microcontroller/Pin.c
+++ b/ports/mimxrt10xx/common-hal/microcontroller/Pin.c
@@ -71,7 +71,6 @@ MP_WEAK bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
 // Since i.MX pins need extra register and reset information to reset properly,
 // resetting pins by number alone has been removed.
 void common_hal_reset_pin(const mcu_pin_obj_t *pin) {
-    return;
     if (pin == NULL) {
         return;
     }


### PR DESCRIPTION
It looks like a rogue "return" made its way into the reset pin code for the mimxrt10xx port resulting in pin.deinit() not working.