### PR TITLE
Improve type validation error messages, especially for pins

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -105,6 +105,10 @@ msgstr ""
 msgid "%q failure: %d"
 msgstr ""
 
+#: py/argcheck.c
+msgid "%q in %q must be of type %q, not %q"
+msgstr ""
+
 #: ports/espressif/common-hal/espulp/ULP.c
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #: shared-bindings/digitalio/DigitalInOut.c
@@ -172,12 +176,13 @@ msgstr ""
 msgid "%q must be a bytearray or array of type 'h', 'H', 'b', or 'B'"
 msgstr ""
 
-#: py/argcheck.c py/obj.c py/objstrunicode.c
-msgid "%q must be of type %q"
+#: ports/raspberrypi/bindings/cyw43/__init__.c py/argcheck.c py/objexcept.c
+#: shared-bindings/canio/CAN.c shared-bindings/digitalio/Pull.c
+msgid "%q must be of type %q or %q, not %q"
 msgstr ""
 
-#: py/objexcept.c shared-bindings/digitalio/Pull.c
-msgid "%q must be of type %q or None"
+#: py/argcheck.c py/obj.c py/objstrunicode.c
+msgid "%q must be of type %q, not %q"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/busio/UART.c
@@ -932,20 +937,8 @@ msgstr ""
 msgid "Error: Failure to bind"
 msgstr ""
 
-#: ports/espressif/bindings/espulp/ULP.c py/enum.c
-#: shared-bindings/_bleio/__init__.c shared-bindings/aesio/aes.c
-#: shared-bindings/alarm/__init__.c shared-bindings/busio/SPI.c
-#: shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c
-msgid "Expected a %q"
-msgstr ""
-
-#: ports/raspberrypi/bindings/cyw43/__init__.c
-msgid "Expected a %q or %q"
-msgstr ""
-
 #: shared-bindings/alarm/__init__.c
-msgid "Expected an %q"
+msgid "Expected a kind of %q"
 msgstr ""
 
 #: ports/espressif/common-hal/_bleio/Adapter.c
@@ -1116,11 +1109,6 @@ msgstr ""
 
 #: shared-bindings/audiobusio/I2SOut.c
 msgid "I2SOut not available"
-msgstr ""
-
-#: shared-bindings/aesio/aes.c
-#, c-format
-msgid "IV must be %d bytes long"
 msgstr ""
 
 #: ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -1583,10 +1571,6 @@ msgstr ""
 msgid "Not playing"
 msgstr ""
 
-#: shared-bindings/_bleio/__init__.c
-msgid "Not settable"
-msgstr ""
-
 #: ports/espressif/common-hal/paralleldisplay/ParallelBus.c
 #, c-format
 msgid "Number of data_pins must be 8 or 16, not %d"
@@ -1859,6 +1843,7 @@ msgstr ""
 msgid "Random number generation error"
 msgstr ""
 
+#: shared-bindings/_bleio/__init__.c
 #: shared-bindings/memorymonitor/AllocationSize.c
 #: shared-bindings/pulseio/PulseIn.c shared-module/displayio/Bitmap.c
 msgid "Read-only"
@@ -2045,7 +2030,10 @@ msgstr ""
 msgid "The above exception was the direct cause of the following exception:"
 msgstr ""
 
+#: ports/espressif/boards/m5stack_atom_echo/mpconfigboard.h
 #: ports/espressif/boards/m5stack_atom_lite/mpconfigboard.h
+#: ports/espressif/boards/m5stack_atom_matrix/mpconfigboard.h
+#: ports/espressif/boards/m5stack_atom_u/mpconfigboard.h
 msgid "The central button was pressed at start up.\n"
 msgstr ""
 
@@ -2967,14 +2955,6 @@ msgstr ""
 
 #: py/runtime.c
 msgid "exceptions must derive from BaseException"
-msgstr ""
-
-#: shared-bindings/canio/CAN.c
-msgid "expected '%q' but got '%q'"
-msgstr ""
-
-#: shared-bindings/canio/CAN.c
-msgid "expected '%q' or '%q' but got '%q'"
 msgstr ""
 
 #: py/objstr.c

--- a/ports/espressif/bindings/esp32_camera/Camera.c
+++ b/ports/espressif/bindings/esp32_camera/Camera.c
@@ -121,14 +121,21 @@ STATIC mp_obj_t esp32_camera_camera_make_new(const mp_obj_type_t *type, size_t n
     validate_pins(MP_QSTR_data_pins, data_pins, MP_ARRAY_SIZE(data_pins), args[ARG_data_pins].u_obj, &data_pin_count);
     mp_arg_validate_length(data_pin_count, 8, MP_QSTR_data_pins);
 
-    const mcu_pin_obj_t *pixel_clock_pin = validate_obj_is_free_pin(args[ARG_pixel_clock_pin].u_obj);
-    const mcu_pin_obj_t *vsync_pin = validate_obj_is_free_pin(args[ARG_vsync_pin].u_obj);
-    const mcu_pin_obj_t *href_pin = validate_obj_is_free_pin(args[ARG_href_pin].u_obj);
+    const mcu_pin_obj_t *pixel_clock_pin =
+        validate_obj_is_free_pin(args[ARG_pixel_clock_pin].u_obj, MP_QSTR_pixel_clock_pin);
+    const mcu_pin_obj_t *vsync_pin =
+        validate_obj_is_free_pin(args[ARG_vsync_pin].u_obj, MP_QSTR_vsync_pin);
+    const mcu_pin_obj_t *href_pin =
+        validate_obj_is_free_pin(args[ARG_href_pin].u_obj, MP_QSTR_href_pin);
     busio_i2c_obj_t *i2c = MP_OBJ_TO_PTR(mp_arg_validate_type(args[ARG_i2c].u_obj, &busio_i2c_type, MP_QSTR_i2c));
-    const mcu_pin_obj_t *external_clock_pin = validate_obj_is_free_pin_or_none(args[ARG_external_clock_pin].u_obj);
-    const mcu_pin_obj_t *powerdown_pin = validate_obj_is_free_pin_or_none(args[ARG_powerdown_pin].u_obj);
-    const mcu_pin_obj_t *reset_pin = validate_obj_is_free_pin_or_none(args[ARG_reset_pin].u_obj);
-    const mp_int_t external_clock_frequency = mp_arg_validate_int_range(args[ARG_external_clock_frequency].u_int, 0, 40000000, MP_QSTR_clock_frequency);
+    const mcu_pin_obj_t *external_clock_pin =
+        validate_obj_is_free_pin_or_none(args[ARG_external_clock_pin].u_obj, MP_QSTR_external_clock_pin);
+    const mcu_pin_obj_t *powerdown_pin =
+        validate_obj_is_free_pin_or_none(args[ARG_powerdown_pin].u_obj, MP_QSTR_powerdown_pin);
+    const mcu_pin_obj_t *reset_pin =
+        validate_obj_is_free_pin_or_none(args[ARG_reset_pin].u_obj, MP_QSTR_reset_pin);
+    const mp_int_t external_clock_frequency =
+        mp_arg_validate_int_range(args[ARG_external_clock_frequency].u_int, 0, 40000000, MP_QSTR_external_clock_frequency);
 
     camera_grab_mode_t grab_mode = validate_grab_mode(args[ARG_grab_mode].u_obj, MP_QSTR_grab_mode);
     framesize_t frame_size = validate_frame_size(args[ARG_frame_size].u_obj, MP_QSTR_frame_size);

--- a/ports/espressif/bindings/esp32_camera/__init__.c
+++ b/ports/espressif/bindings/esp32_camera/__init__.c
@@ -69,7 +69,7 @@ MAKE_PRINTER(esp32_camera, esp32_camera_grab_mode);
 MAKE_ENUM_TYPE(esp32_camera, GrabMode, esp32_camera_grab_mode);
 
 camera_grab_mode_t validate_grab_mode(mp_obj_t obj, qstr arg_name) {
-    return cp_enum_value(&esp32_camera_grab_mode_type, mp_arg_validate_type(obj, &esp32_camera_grab_mode_type, arg_name));
+    return cp_enum_value(&esp32_camera_grab_mode_type, obj, arg_name);
 }
 
 //| class PixelFormat:
@@ -100,7 +100,7 @@ MAKE_PRINTER(esp32_camera, esp32_camera_pixel_format);
 MAKE_ENUM_TYPE(esp32_camera, PixelFormat, esp32_camera_pixel_format);
 
 pixformat_t validate_pixel_format(mp_obj_t obj, qstr arg_name) {
-    return cp_enum_value(&esp32_camera_pixel_format_type, mp_arg_validate_type(obj, &esp32_camera_pixel_format_type, arg_name));
+    return cp_enum_value(&esp32_camera_pixel_format_type, obj, arg_name);
 }
 
 //| class FrameSize:
@@ -225,7 +225,7 @@ MAKE_PRINTER(esp32_camera, esp32_camera_frame_size);
 MAKE_ENUM_TYPE(esp32_camera, FrameSize, esp32_camera_frame_size);
 
 framesize_t validate_frame_size(mp_obj_t obj, qstr arg_name) {
-    return cp_enum_value(&esp32_camera_frame_size_type, mp_arg_validate_type(obj, &esp32_camera_frame_size_type, arg_name));
+    return cp_enum_value(&esp32_camera_frame_size_type, obj, arg_name);
 }
 
 //| class GainCeiling:
@@ -265,7 +265,7 @@ MAKE_PRINTER(esp32_camera, esp32_camera_gain_ceiling);
 MAKE_ENUM_TYPE(esp32_camera, GainCeiling, esp32_camera_gain_ceiling);
 
 gainceiling_t validate_gain_ceiling(mp_obj_t obj, qstr arg_name) {
-    return cp_enum_value(&esp32_camera_gain_ceiling_type, mp_arg_validate_type(obj, &esp32_camera_gain_ceiling_type, arg_name));
+    return cp_enum_value(&esp32_camera_gain_ceiling_type, obj, arg_name);
 }
 
 STATIC const mp_rom_map_elem_t esp32_camera_module_globals_table[] = {

--- a/ports/espressif/bindings/espulp/__init__.c
+++ b/ports/espressif/bindings/espulp/__init__.c
@@ -61,7 +61,7 @@
 //|
 
 STATIC mp_obj_t espulp_get_rtc_gpio_number(mp_obj_t pin_obj) {
-    const mcu_pin_obj_t *pin = validate_obj_is_pin(pin_obj);
+    const mcu_pin_obj_t *pin = validate_obj_is_pin(pin_obj, MP_QSTR_pin);
     mp_int_t number = common_hal_espulp_get_rtc_gpio_number(pin);
     if (number < 0) {
         return mp_const_none;

--- a/ports/espressif/common-hal/paralleldisplay/ParallelBus.c
+++ b/ports/espressif/common-hal/paralleldisplay/ParallelBus.c
@@ -118,7 +118,8 @@ void common_hal_paralleldisplay_parallelbus_construct(paralleldisplay_parallelbu
     const mcu_pin_obj_t *data_pins[8];
     for (int i = 0; i < 8; i++) {
         snprintf(buf, sizeof(buf), "GPIO%d", data0->number + i);
-        data_pins[i] = validate_obj_is_free_pin(mp_obj_dict_get(MP_OBJ_FROM_PTR(&mcu_pin_globals), mp_obj_new_str(buf, strlen(buf))));
+        data_pins[i] = validate_obj_is_free_pin(
+            mp_obj_dict_get(MP_OBJ_FROM_PTR(&mcu_pin_globals), mp_obj_new_str(buf, strlen(buf))), MP_QSTR_pin);
     }
     common_hal_paralleldisplay_parallelbus_construct_nonsequential(self, 8, data_pins, command, chip_select, write, read, reset, frequency);
 }

--- a/ports/raspberrypi/bindings/cyw43/__init__.c
+++ b/ports/raspberrypi/bindings/cyw43/__init__.c
@@ -116,23 +116,23 @@ STATIC mp_obj_t cyw43_get_power_management() {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(cyw43_get_power_management_obj, cyw43_get_power_management);
 
-const mcu_pin_obj_t *validate_obj_is_pin_including_cyw43(mp_obj_t obj) {
+const mcu_pin_obj_t *validate_obj_is_pin_including_cyw43(mp_obj_t obj, qstr arg_name) {
     if (!mp_obj_is_type(obj, &mcu_pin_type) && !mp_obj_is_type(obj, &cyw43_pin_type)) {
-        mp_raise_TypeError_varg(translate("Expected a %q or %q"), mcu_pin_type.name, cyw43_pin_type.name);
+        mp_raise_TypeError_varg(translate("%q must be of type %q or %q, not %q"), arg_name, mcu_pin_type.name, cyw43_pin_type.name, mp_obj_get_type(obj)->name);
     }
     return MP_OBJ_TO_PTR(obj);
 }
 
-const mcu_pin_obj_t *validate_obj_is_free_pin_or_gpio29(mp_obj_t obj) {
-    const mcu_pin_obj_t *pin = validate_obj_is_pin(obj);
+const mcu_pin_obj_t *validate_obj_is_free_pin_or_gpio29(mp_obj_t obj, qstr arg_name) {
+    const mcu_pin_obj_t *pin = validate_obj_is_pin(obj, arg_name);
     if (obj != &pin_GPIO29) {
         assert_pin_free(pin);
     }
     return pin;
 }
 
-const mcu_pin_obj_t *validate_obj_is_free_pin_including_cyw43(mp_obj_t obj) {
-    const mcu_pin_obj_t *pin = validate_obj_is_pin_including_cyw43(obj);
+const mcu_pin_obj_t *validate_obj_is_free_pin_including_cyw43(mp_obj_t obj, qstr arg_name) {
+    const mcu_pin_obj_t *pin = validate_obj_is_pin_including_cyw43(obj, arg_name);
     assert_pin_free(pin);
     return pin;
 }

--- a/ports/raspberrypi/bindings/cyw43/__init__.h
+++ b/ports/raspberrypi/bindings/cyw43/__init__.h
@@ -31,9 +31,9 @@
 #include "common-hal/microcontroller/Pin.h"
 
 extern const mp_obj_type_t cyw43_pin_type;
-const mcu_pin_obj_t *validate_obj_is_free_pin_including_cyw43(mp_obj_t obj);
-const mcu_pin_obj_t *validate_obj_is_free_pin_or_gpio29(mp_obj_t obj);
-const mcu_pin_obj_t *validate_obj_is_pin_including_cyw43(mp_obj_t obj);
+const mcu_pin_obj_t *validate_obj_is_free_pin_including_cyw43(mp_obj_t obj, qstr arg_name);
+const mcu_pin_obj_t *validate_obj_is_free_pin_or_gpio29(mp_obj_t obj, qstr arg_name);
+const mcu_pin_obj_t *validate_obj_is_pin_including_cyw43(mp_obj_t obj, qstr arg_name);
 
 #define CONSTANT_CYW43_PM_VALUE(pm_mode, pm2_sleep_ret_ms, li_beacon_period, li_dtim_period, li_assoc) \
     (li_assoc << 20 | /* listen interval sent to ap */ \

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -222,19 +222,25 @@ STATIC mp_obj_t rp2pio_statemachine_make_new(const mp_obj_type_t *type, size_t n
     mp_get_buffer(args[ARG_init].u_obj, &init_bufinfo, MP_BUFFER_READ);
 
     // We don't validate pin in use here because we may be ok sharing them within a PIO.
-    const mcu_pin_obj_t *first_out_pin = validate_obj_is_pin_or_none(args[ARG_first_out_pin].u_obj);
+    const mcu_pin_obj_t *first_out_pin =
+        validate_obj_is_pin_or_none(args[ARG_first_out_pin].u_obj, MP_QSTR_first_out_pin);
     mp_int_t out_pin_count = mp_arg_validate_int_min(args[ARG_out_pin_count].u_int, 1, MP_QSTR_out_pin_count);
 
-    const mcu_pin_obj_t *first_in_pin = validate_obj_is_pin_or_none(args[ARG_first_in_pin].u_obj);
+    const mcu_pin_obj_t *first_in_pin =
+        validate_obj_is_pin_or_none(args[ARG_first_in_pin].u_obj, MP_QSTR_first_in_pin);
     mp_int_t in_pin_count = mp_arg_validate_int_min(args[ARG_in_pin_count].u_int, 1, MP_QSTR_in_pin_count);
 
-    const mcu_pin_obj_t *first_set_pin = validate_obj_is_pin_or_none(args[ARG_first_set_pin].u_obj);
+    const mcu_pin_obj_t *first_set_pin =
+        validate_obj_is_pin_or_none(args[ARG_first_set_pin].u_obj, MP_QSTR_first_set_pin);
     mp_int_t set_pin_count = mp_arg_validate_int_range(args[ARG_set_pin_count].u_int, 1, 5, MP_QSTR_set_pin_count);
 
-    const mcu_pin_obj_t *first_sideset_pin = validate_obj_is_pin_or_none(args[ARG_first_sideset_pin].u_obj);
-    mp_int_t sideset_pin_count = mp_arg_validate_int_range(args[ARG_sideset_pin_count].u_int, 1, 5, MP_QSTR_set_pin_count);
+    const mcu_pin_obj_t *first_sideset_pin =
+        validate_obj_is_pin_or_none(args[ARG_first_sideset_pin].u_obj, MP_QSTR_first_sideset_pin);
+    mp_int_t sideset_pin_count =
+        mp_arg_validate_int_range(args[ARG_sideset_pin_count].u_int, 1, 5, MP_QSTR_set_pin_count);
 
-    const mcu_pin_obj_t *jmp_pin = validate_obj_is_pin_or_none(args[ARG_jmp_pin].u_obj);
+    const mcu_pin_obj_t *jmp_pin =
+        validate_obj_is_pin_or_none(args[ARG_jmp_pin].u_obj, MP_QSTR_jmp_pin);
     digitalio_pull_t jmp_pin_pull = validate_pull(args[ARG_jmp_pin_pull].u_rom_obj, MP_QSTR_jmp_pull);
 
     mp_int_t pull_threshold =

--- a/ports/raspberrypi/bindings/rp2pio/__init__.c
+++ b/ports/raspberrypi/bindings/rp2pio/__init__.c
@@ -43,11 +43,17 @@
 //|     """Return True if the pins have sequential GPIO numbers, False otherwise"""
 //|     ...
 //|
-STATIC mp_obj_t rp2pio_pins_are_sequential(const mp_obj_t pins) {
+STATIC mp_obj_t rp2pio_pins_are_sequential(mp_obj_t pins_obj) {
     size_t len;
     mp_obj_t *items;
-    mp_obj_get_array(pins, &len, &items);
-    return mp_obj_new_bool(common_hal_rp2pio_pins_are_sequential(len, items));
+    mp_obj_get_array(pins_obj, &len, &items);
+
+    const mcu_pin_obj_t *pins[len];
+    for (size_t i = 0; i < len; i++) {
+        pins[i] = validate_obj_is_pin(items[i], MP_QSTR_pins);
+    }
+
+    return mp_obj_new_bool(common_hal_rp2pio_pins_are_sequential(len, pins));
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_pins_are_sequential_obj, rp2pio_pins_are_sequential);

--- a/ports/raspberrypi/bindings/rp2pio/__init__.h
+++ b/ports/raspberrypi/bindings/rp2pio/__init__.h
@@ -26,4 +26,6 @@
 
 #pragma once
 
-bool common_hal_rp2pio_pins_are_sequential(size_t len, mp_obj_t *items);
+#include "shared-bindings/microcontroller/Pin.h"
+
+bool common_hal_rp2pio_pins_are_sequential(size_t len, const mcu_pin_obj_t **pins);

--- a/ports/raspberrypi/common-hal/analogio/AnalogIn.c
+++ b/ports/raspberrypi/common-hal/analogio/AnalogIn.c
@@ -44,7 +44,7 @@
 #define SPECIAL_PIN(pin) (pin->number == 29)
 
 const mcu_pin_obj_t *common_hal_analogio_analogin_validate_pin(mp_obj_t obj) {
-    return validate_obj_is_free_pin_or_gpio29(obj);
+    return validate_obj_is_free_pin_or_gpio29(obj, MP_QSTR_pin);
 }
 #else
 #define SPECIAL_PIN(pin) false

--- a/ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
+++ b/ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
@@ -43,7 +43,7 @@
 #define IS_CYW(self) ((self)->pin->base.type == &cyw43_pin_type)
 
 const mcu_pin_obj_t *common_hal_digitalio_validate_pin(mp_obj_t obj) {
-    return validate_obj_is_free_pin_including_cyw43(obj);
+    return validate_obj_is_free_pin_including_cyw43(obj, MP_QSTR_pin);
 }
 #endif
 

--- a/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
@@ -61,12 +61,13 @@ STATIC void incrementalencoder_interrupt_handler(void *self_in);
 
 void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencoder_obj_t *self,
     const mcu_pin_obj_t *pin_a, const mcu_pin_obj_t *pin_b) {
-    mp_obj_t pins[] = {MP_OBJ_FROM_PTR(pin_a), MP_OBJ_FROM_PTR(pin_b)};
+    const mcu_pin_obj_t *pins[] = { pin_a, pin_b };
+
     // Start out with swapped to match behavior with other ports.
     self->swapped = true;
     if (!common_hal_rp2pio_pins_are_sequential(2, pins)) {
-        pins[0] = MP_OBJ_FROM_PTR(pin_b);
-        pins[1] = MP_OBJ_FROM_PTR(pin_a);
+        pins[0] = pin_b;
+        pins[1] = pin_a;
         self->swapped = false;
         if (!common_hal_rp2pio_pins_are_sequential(2, pins)) {
             mp_raise_RuntimeError(translate("Pins must be sequential GPIO pins"));

--- a/ports/raspberrypi/common-hal/rp2pio/__init__.c
+++ b/ports/raspberrypi/common-hal/rp2pio/__init__.c
@@ -28,13 +28,13 @@
 #include "shared-bindings/microcontroller/Pin.h"
 #include "bindings/rp2pio/__init__.h"
 
-bool common_hal_rp2pio_pins_are_sequential(size_t len, mp_obj_t *items) {
+bool common_hal_rp2pio_pins_are_sequential(size_t len, const mcu_pin_obj_t **pins) {
     if (len == 0) {
         return true;
     }
-    const mcu_pin_obj_t *last_pin = validate_obj_is_pin(items[0]);
+    const mcu_pin_obj_t *last_pin = pins[0];
     for (size_t i = 1; i < len; i++) {
-        const mcu_pin_obj_t *pin = validate_obj_is_pin(items[i]);
+        const mcu_pin_obj_t *pin = pins[i];
         if (pin->number != last_pin->number + 1) {
             return false;
         }

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -234,14 +234,28 @@ mp_int_t mp_arg_validate_index_range(mp_int_t index, mp_int_t min, mp_int_t max,
 
 mp_obj_t mp_arg_validate_type(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name) {
     if (!mp_obj_is_type(obj, type)) {
-        mp_raise_TypeError_varg(translate("%q must be of type %q"), arg_name, type->name);
+        mp_raise_TypeError_varg(translate("%q must be of type %q, not %q"), arg_name, type->name, mp_obj_get_type(obj)->name);
+    }
+    return obj;
+}
+
+mp_obj_t mp_arg_validate_type_in(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name) {
+    if (!mp_obj_is_type(obj, type)) {
+        mp_raise_TypeError_varg(translate("%q in %q must be of type %q, not %q"), MP_QSTR_object, arg_name, type->name, mp_obj_get_type(obj)->name);
+    }
+    return obj;
+}
+
+mp_obj_t mp_arg_validate_type_or_none(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name) {
+    if (obj != mp_const_none && !mp_obj_is_type(obj, type)) {
+        mp_raise_TypeError_varg(translate("%q must be of type %q or %q, not %q"), arg_name, type->name, MP_QSTR_None, mp_obj_get_type(obj)->name);
     }
     return obj;
 }
 
 mp_obj_t mp_arg_validate_type_string(mp_obj_t obj, qstr arg_name) {
     if (!mp_obj_is_str(obj)) {
-        mp_raise_TypeError_varg(translate("%q must be of type %q"), arg_name, MP_QSTR_str);
+        mp_raise_TypeError_varg(translate("%q must be of type %q, not %q"), arg_name, MP_QSTR_str, mp_obj_get_type(obj)->name);
     }
     return obj;
 }
@@ -249,7 +263,7 @@ mp_obj_t mp_arg_validate_type_string(mp_obj_t obj, qstr arg_name) {
 mp_int_t mp_arg_validate_type_int(mp_obj_t obj, qstr arg_name) {
     mp_int_t an_int;
     if (!mp_obj_get_int_maybe(obj, &an_int)) {
-        mp_raise_TypeError_varg(translate("%q must be of type %q"), arg_name, MP_QSTR_int);
+        mp_raise_TypeError_varg(translate("%q must be of type %q, not %q"), arg_name, MP_QSTR_int, mp_obj_get_type(obj)->name);
     }
     return an_int;
 }

--- a/py/enum.c
+++ b/py/enum.c
@@ -40,10 +40,8 @@ mp_obj_t cp_enum_find(const mp_obj_type_t *type, int value) {
     return mp_const_none;
 }
 
-int cp_enum_value(const mp_obj_type_t *type, mp_obj_t obj) {
-    if (!mp_obj_is_type(obj, type)) {
-        mp_raise_TypeError_varg(MP_ERROR_TEXT("Expected a %q"), type->name);
-    }
+int cp_enum_value(const mp_obj_type_t *type, mp_obj_t obj, qstr arg_name) {
+    (void)mp_arg_validate_type(obj, type, arg_name);
     return ((cp_enum_obj_t *)MP_OBJ_TO_PTR(obj))->value;
 }
 

--- a/py/enum.h
+++ b/py/enum.h
@@ -61,5 +61,5 @@ typedef struct {
 
 
 mp_obj_t cp_enum_find(const mp_obj_type_t *type, int value);
-int cp_enum_value(const mp_obj_type_t *type, mp_obj_t obj);
+int cp_enum_value(const mp_obj_type_t *type, mp_obj_t obj, qstr arg_name);
 void cp_enum_obj_print_helper(uint16_t module, const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);

--- a/py/obj.c
+++ b/py/obj.c
@@ -521,7 +521,7 @@ size_t mp_get_index(const mp_obj_type_t *type, size_t len, mp_obj_t index, bool 
     if (mp_obj_is_small_int(index)) {
         i = MP_OBJ_SMALL_INT_VALUE(index);
     } else if (!mp_obj_get_int_maybe(index, &i)) {
-        mp_raise_TypeError_varg(translate("%q must be of type %q"), MP_QSTR_index, MP_QSTR_int);
+        mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q, not %q"), MP_QSTR_index, MP_QSTR_int, mp_obj_get_type(index)->name);
     }
 
     if (i < 0) {

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -228,7 +228,7 @@ void mp_obj_exception_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
                 self->traceback = (mp_obj_traceback_t *)&mp_const_empty_traceback_obj;
             } else {
                 if (!mp_obj_is_type(dest[1], &mp_type_traceback)) {
-                    mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q or None"), MP_QSTR___context__, MP_QSTR_traceback);
+                    mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q or %q, not %q"), MP_QSTR___context__, MP_QSTR_traceback, MP_QSTR_None, mp_obj_get_type(dest[1])->name);
                 }
                 self->traceback = MP_OBJ_TO_PTR(dest[1]);
             }
@@ -240,7 +240,7 @@ void mp_obj_exception_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
             } else if (!mp_obj_is_type(dest[1], &mp_type_BaseException)) {
                 self->cause = dest[1];
             } else {
-                mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q or None"), attr, MP_QSTR_BaseException);
+                mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q or %q, not %q"), attr, MP_QSTR_BaseException, MP_QSTR_None, mp_obj_get_type(dest[1])->name);
             }
             self->suppress_context = true;
             dest[0] = MP_OBJ_NULL; // indicate success
@@ -250,7 +250,7 @@ void mp_obj_exception_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
             } else if (!mp_obj_is_type(dest[1], &mp_type_BaseException)) {
                 self->context = dest[1];
             } else {
-                mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q or None"), attr, MP_QSTR_BaseException);
+                mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q or %q, not %q"), attr, MP_QSTR_BaseException, MP_QSTR_None, mp_obj_get_type(dest[1])->name);
             }
             dest[0] = MP_OBJ_NULL; // indicate success
         } else if (attr == MP_QSTR___suppress_context__) {

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -159,7 +159,7 @@ const byte *str_index_to_ptr(const mp_obj_type_t *type, const byte *self_data, s
     if (mp_obj_is_small_int(index)) {
         i = MP_OBJ_SMALL_INT_VALUE(index);
     } else if (!mp_obj_get_int_maybe(index, &i)) {
-        mp_raise_TypeError_varg(translate("%q must be of type %q"), MP_QSTR_index, MP_QSTR_int);
+        mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q, not %q"), MP_QSTR_index, MP_QSTR_int, mp_obj_get_type(index)->name);
     }
     const byte *s, *top = self_data + self_len;
     if (i < 0) {

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -110,6 +110,8 @@ mp_uint_t mp_arg_validate_length_range(mp_uint_t length, mp_uint_t min, mp_uint_
 mp_uint_t mp_arg_validate_length(mp_uint_t length, mp_uint_t required_length, qstr arg_name);
 mp_int_t mp_arg_validate_index_range(mp_int_t index, mp_int_t min, mp_int_t max, qstr arg_name);
 mp_obj_t mp_arg_validate_type(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name);
+mp_obj_t mp_arg_validate_type_in(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name);
+mp_obj_t mp_arg_validate_type_or_none(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name);
 mp_int_t mp_arg_validate_type_int(mp_obj_t obj, qstr arg_name);
 mp_obj_t mp_arg_validate_type_string(mp_obj_t obj, qstr arg_name);
 

--- a/shared-bindings/_bleio/__init__.c
+++ b/shared-bindings/_bleio/__init__.c
@@ -121,9 +121,7 @@ STATIC mp_obj_dict_t bleio_module_globals;
 //|
 mp_obj_t bleio_set_adapter(mp_obj_t adapter_obj) {
     #if CIRCUITPY_BLEIO_HCI
-    if (adapter_obj != mp_const_none && !mp_obj_is_type(adapter_obj, &bleio_adapter_type)) {
-        mp_raise_TypeError_varg(translate("Expected a %q"), bleio_adapter_type.name);
-    }
+    (void)mp_arg_validate_type_or_none(adapter_obj, &bleio_adapter_type, MP_QSTR_adapter);
 
     // Equivalent of:
     // bleio.adapter = adapter_obj
@@ -132,7 +130,7 @@ mp_obj_t bleio_set_adapter(mp_obj_t adapter_obj) {
         elem->value = adapter_obj;
     }
     #else
-    mp_raise_NotImplementedError(translate("Not settable"));
+    mp_raise_NotImplementedError(translate("Read-only"));
     #endif
     return mp_const_none;
 }

--- a/shared-bindings/alarm/__init__.c
+++ b/shared-bindings/alarm/__init__.c
@@ -86,7 +86,7 @@ STATIC void validate_objs_are_alarms(size_t n_args, const mp_obj_t *objs) {
             mp_obj_is_type(objs[i], &alarm_touch_touchalarm_type)) {
             continue;
         }
-        mp_raise_TypeError_varg(translate("Expected an %q"), MP_QSTR_Alarm);
+        mp_raise_TypeError_varg(translate("Expected a kind of %q"), MP_QSTR_Alarm);
     }
 }
 
@@ -207,10 +207,7 @@ STATIC mp_obj_t alarm_exit_and_deep_sleep_until_alarms(size_t n_args, const mp_o
 
     for (mp_uint_t i = 0; i < num_dios; i++) {
         mp_obj_t dio = mp_obj_subscr(preserve_dios, MP_OBJ_NEW_SMALL_INT(i), MP_OBJ_SENTINEL);
-        if (!mp_obj_is_type(dio, &digitalio_digitalinout_type)) {
-            mp_raise_TypeError_varg(translate("Expected a %q"), MP_QSTR_DigitalInOut);
-        }
-        dios_array[i] = MP_OBJ_TO_PTR(dio);
+        dios_array[i] = mp_arg_validate_type(dio, &digitalio_digitalinout_type, MP_QSTR_alarm);
     }
 
     common_hal_alarm_set_deep_sleep_alarms(n_args, pos_args, num_dios, dios_array);

--- a/shared-bindings/alarm/pin/PinAlarm.c
+++ b/shared-bindings/alarm/pin/PinAlarm.c
@@ -74,7 +74,7 @@ STATIC mp_obj_t alarm_pin_pinalarm_make_new(const mp_obj_type_t *type, mp_uint_t
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj);
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
 
     common_hal_alarm_pin_pinalarm_construct(self,
         pin,

--- a/shared-bindings/alarm/touch/TouchAlarm.c
+++ b/shared-bindings/alarm/touch/TouchAlarm.c
@@ -56,7 +56,7 @@ STATIC mp_obj_t alarm_touch_touchalarm_make_new(const mp_obj_type_t *type,
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj);
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
 
     common_hal_alarm_touch_touchalarm_construct(self, pin);
 

--- a/shared-bindings/analogbufio/BufferedIn.c
+++ b/shared-bindings/analogbufio/BufferedIn.c
@@ -76,7 +76,7 @@ STATIC mp_obj_t analogbufio_bufferedin_make_new(const mp_obj_type_t *type, size_
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // Validate Pin
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj);
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
 
     // Create local object
     analogbufio_bufferedin_obj_t *self = m_new_obj_with_finaliser(analogbufio_bufferedin_obj_t);

--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -37,7 +37,7 @@
 #include "shared-bindings/util.h"
 
 MP_WEAK const mcu_pin_obj_t *common_hal_analogio_analogin_validate_pin(mp_obj_t obj) {
-    return validate_obj_is_free_pin(obj);
+    return validate_obj_is_free_pin(obj, MP_QSTR_pin);
 }
 
 //| class AnalogIn:

--- a/shared-bindings/analogio/AnalogOut.c
+++ b/shared-bindings/analogio/AnalogOut.c
@@ -61,7 +61,7 @@ STATIC mp_obj_t analogio_analogout_make_new(const mp_obj_type_t *type, mp_uint_t
     // check arguments
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
 
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[0]);
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[0], MP_QSTR_pin);
 
     analogio_analogout_obj_t *self = m_new_obj(analogio_analogout_obj_t);
     self->base.type = &analogio_analogout_type;

--- a/shared-bindings/audiobusio/I2SOut.c
+++ b/shared-bindings/audiobusio/I2SOut.c
@@ -110,9 +110,9 @@ STATIC mp_obj_t audiobusio_i2sout_make_new(const mp_obj_type_t *type, size_t n_a
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *bit_clock = validate_obj_is_free_pin(args[ARG_bit_clock].u_obj);
-    const mcu_pin_obj_t *word_select = validate_obj_is_free_pin(args[ARG_word_select].u_obj);
-    const mcu_pin_obj_t *data = validate_obj_is_free_pin(args[ARG_data].u_obj);
+    const mcu_pin_obj_t *bit_clock = validate_obj_is_free_pin(args[ARG_bit_clock].u_obj, MP_QSTR_bit_clock);
+    const mcu_pin_obj_t *word_select = validate_obj_is_free_pin(args[ARG_word_select].u_obj, MP_QSTR_word_select);
+    const mcu_pin_obj_t *data = validate_obj_is_free_pin(args[ARG_data].u_obj, MP_QSTR_data);
 
     audiobusio_i2sout_obj_t *self = m_new_obj_with_finaliser(audiobusio_i2sout_obj_t);
     self->base.type = &audiobusio_i2sout_type;

--- a/shared-bindings/audiobusio/PDMIn.c
+++ b/shared-bindings/audiobusio/PDMIn.c
@@ -112,8 +112,8 @@ STATIC mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_ar
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *clock_pin = validate_obj_is_free_pin(args[ARG_clock_pin].u_obj);
-    const mcu_pin_obj_t *data_pin = validate_obj_is_free_pin(args[ARG_data_pin].u_obj);
+    const mcu_pin_obj_t *clock_pin = validate_obj_is_free_pin(args[ARG_clock_pin].u_obj, MP_QSTR_clock_pin);
+    const mcu_pin_obj_t *data_pin = validate_obj_is_free_pin(args[ARG_data_pin].u_obj, MP_QSTR_data_pin);
 
     // create PDMIn object from the given pin
     audiobusio_pdmin_obj_t *self = m_new_obj(audiobusio_pdmin_obj_t);

--- a/shared-bindings/audioio/AudioOut.c
+++ b/shared-bindings/audioio/AudioOut.c
@@ -105,8 +105,10 @@ STATIC mp_obj_t audioio_audioout_make_new(const mp_obj_type_t *type, size_t n_ar
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *left_channel_pin = validate_obj_is_free_pin(args[ARG_left_channel].u_obj);
-    const mcu_pin_obj_t *right_channel_pin = validate_obj_is_free_pin_or_none(args[ARG_right_channel].u_obj);
+    const mcu_pin_obj_t *left_channel_pin =
+        validate_obj_is_free_pin(args[ARG_left_channel].u_obj, MP_QSTR_left_channel);
+    const mcu_pin_obj_t *right_channel_pin =
+        validate_obj_is_free_pin_or_none(args[ARG_right_channel].u_obj, MP_QSTR_right_channel);
 
     // create AudioOut object from the given pin
     audioio_audioout_obj_t *self = m_new_obj(audioio_audioout_obj_t);

--- a/shared-bindings/audiopwmio/PWMAudioOut.c
+++ b/shared-bindings/audiopwmio/PWMAudioOut.c
@@ -108,8 +108,10 @@ STATIC mp_obj_t audiopwmio_pwmaudioout_make_new(const mp_obj_type_t *type, size_
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *left_channel_pin = validate_obj_is_free_pin(args[ARG_left_channel].u_obj);
-    const mcu_pin_obj_t *right_channel_pin = validate_obj_is_free_pin_or_none(args[ARG_right_channel].u_obj);
+    const mcu_pin_obj_t *left_channel_pin =
+        validate_obj_is_free_pin(args[ARG_left_channel].u_obj, MP_QSTR_left_channel);
+    const mcu_pin_obj_t *right_channel_pin =
+        validate_obj_is_free_pin_or_none(args[ARG_right_channel].u_obj, MP_QSTR_right_channel);
 
     // create AudioOut object from the given pin
     audiopwmio_pwmaudioout_obj_t *self = m_new_obj(audiopwmio_pwmaudioout_obj_t);

--- a/shared-bindings/bitbangio/I2C.c
+++ b/shared-bindings/bitbangio/I2C.c
@@ -76,8 +76,8 @@ STATIC mp_obj_t bitbangio_i2c_make_new(const mp_obj_type_t *type, size_t n_args,
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *scl = validate_obj_is_free_pin(args[ARG_scl].u_obj);
-    const mcu_pin_obj_t *sda = validate_obj_is_free_pin(args[ARG_sda].u_obj);
+    const mcu_pin_obj_t *scl = validate_obj_is_free_pin(args[ARG_scl].u_obj, MP_QSTR_scl);
+    const mcu_pin_obj_t *sda = validate_obj_is_free_pin(args[ARG_sda].u_obj, MP_QSTR_sda);
 
     bitbangio_i2c_obj_t *self = m_new_obj(bitbangio_i2c_obj_t);
     self->base.type = &bitbangio_i2c_type;

--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -84,9 +84,9 @@ STATIC mp_obj_t bitbangio_spi_make_new(const mp_obj_type_t *type, size_t n_args,
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *clock = validate_obj_is_free_pin(args[ARG_clock].u_obj);
-    const mcu_pin_obj_t *mosi = validate_obj_is_free_pin_or_none(args[ARG_MOSI].u_obj);
-    const mcu_pin_obj_t *miso = validate_obj_is_free_pin_or_none(args[ARG_MISO].u_obj);
+    const mcu_pin_obj_t *clock = validate_obj_is_free_pin(args[ARG_clock].u_obj, MP_QSTR_clock);
+    const mcu_pin_obj_t *mosi = validate_obj_is_free_pin_or_none(args[ARG_MOSI].u_obj, MP_QSTR_mosi);
+    const mcu_pin_obj_t *miso = validate_obj_is_free_pin_or_none(args[ARG_MISO].u_obj, MP_QSTR_miso);
 
     bitbangio_spi_obj_t *self = m_new_obj(bitbangio_spi_obj_t);
     self->base.type = &bitbangio_spi_type;

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -319,7 +319,7 @@ STATIC mp_obj_t bitmaptools_alphablend(size_t n_args, const mp_obj_t *pos_args, 
     mp_float_t factor1 = (args[ARG_factor_1].u_obj == mp_const_none) ? MICROPY_FLOAT_CONST(.5) : mp_obj_get_float(args[ARG_factor_1].u_obj);
     mp_float_t factor2 = (args[ARG_factor_2].u_obj == mp_const_none) ? 1 - factor1 : mp_obj_get_float(args[ARG_factor_2].u_obj);
 
-    displayio_colorspace_t colorspace = (displayio_colorspace_t)cp_enum_value(&displayio_colorspace_type, args[ARG_colorspace].u_obj);
+    displayio_colorspace_t colorspace = (displayio_colorspace_t)cp_enum_value(&displayio_colorspace_type, args[ARG_colorspace].u_obj, MP_QSTR_colorspace);
 
     if (destination->width != source1->width
         || destination->height != source1->height
@@ -741,8 +741,8 @@ STATIC mp_obj_t bitmaptools_dither(size_t n_args, const mp_obj_t *pos_args, mp_m
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     displayio_bitmap_t *source_bitmap = mp_arg_validate_type(args[ARG_source_bitmap].u_obj, &displayio_bitmap_type, MP_QSTR_source_bitmap);
     displayio_bitmap_t *dest_bitmap = mp_arg_validate_type(args[ARG_dest_bitmap].u_obj, &displayio_bitmap_type, MP_QSTR_dest_bitmap);
-    bitmaptools_dither_algorithm_t algorithm = cp_enum_value(&bitmaptools_dither_algorithm_type, args[ARG_algorithm].u_obj);
-    displayio_colorspace_t colorspace = cp_enum_value(&displayio_colorspace_type, args[ARG_source_colorspace].u_obj);
+    bitmaptools_dither_algorithm_t algorithm = cp_enum_value(&bitmaptools_dither_algorithm_type, args[ARG_algorithm].u_obj, MP_QSTR_algorithm);
+    displayio_colorspace_t colorspace = cp_enum_value(&displayio_colorspace_type, args[ARG_source_colorspace].u_obj, MP_QSTR_source_colorspace);
 
     if (source_bitmap->width != dest_bitmap->width || source_bitmap->height != dest_bitmap->height) {
         mp_raise_TypeError(translate("bitmap sizes must match"));

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -80,8 +80,8 @@ STATIC mp_obj_t busio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *scl = validate_obj_is_free_pin(args[ARG_scl].u_obj);
-    const mcu_pin_obj_t *sda = validate_obj_is_free_pin(args[ARG_sda].u_obj);
+    const mcu_pin_obj_t *scl = validate_obj_is_free_pin(args[ARG_scl].u_obj, MP_QSTR_scl);
+    const mcu_pin_obj_t *sda = validate_obj_is_free_pin(args[ARG_sda].u_obj, MP_QSTR_sda);
 
     common_hal_busio_i2c_construct(self, scl, sda, args[ARG_frequency].u_int, args[ARG_timeout].u_int);
     return (mp_obj_t)self;

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -103,9 +103,9 @@ STATIC mp_obj_t busio_spi_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *clock = validate_obj_is_free_pin(args[ARG_clock].u_obj);
-    const mcu_pin_obj_t *mosi = validate_obj_is_free_pin_or_none(args[ARG_MOSI].u_obj);
-    const mcu_pin_obj_t *miso = validate_obj_is_free_pin_or_none(args[ARG_MISO].u_obj);
+    const mcu_pin_obj_t *clock = validate_obj_is_free_pin(args[ARG_clock].u_obj, MP_QSTR_clock);
+    const mcu_pin_obj_t *mosi = validate_obj_is_free_pin_or_none(args[ARG_MOSI].u_obj, MP_QSTR_mosi);
+    const mcu_pin_obj_t *miso = validate_obj_is_free_pin_or_none(args[ARG_MISO].u_obj, MP_QSTR_miso);
 
     if (!miso && !mosi) {
         mp_raise_ValueError(translate("Must provide MISO or MOSI pin"));
@@ -463,9 +463,6 @@ const mp_obj_type_t busio_spi_type = {
     .locals_dict = (mp_obj_dict_t *)&busio_spi_locals_dict,
 };
 
-busio_spi_obj_t *validate_obj_is_spi_bus(mp_obj_t obj) {
-    if (!mp_obj_is_type(obj, &busio_spi_type)) {
-        mp_raise_TypeError_varg(translate("Expected a %q"), busio_spi_type.name);
-    }
-    return MP_OBJ_TO_PTR(obj);
+busio_spi_obj_t *validate_obj_is_spi_bus(mp_obj_t obj, qstr arg_name) {
+    return mp_arg_validate_type(obj, &busio_spi_type, arg_name);
 }

--- a/shared-bindings/busio/SPI.h
+++ b/shared-bindings/busio/SPI.h
@@ -70,6 +70,6 @@ uint8_t common_hal_busio_spi_get_polarity(busio_spi_obj_t *self);
 // This is used by the supervisor to claim SPI devices indefinitely.
 extern void common_hal_busio_spi_never_reset(busio_spi_obj_t *self);
 
-extern busio_spi_obj_t *validate_obj_is_spi_bus(mp_obj_t obj_in);
+extern busio_spi_obj_t *validate_obj_is_spi_bus(mp_obj_t obj_in, qstr arg_name);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_BUSIO_SPI_H

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -116,8 +116,8 @@ STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, si
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *rx = validate_obj_is_free_pin_or_none(args[ARG_rx].u_obj);
-    const mcu_pin_obj_t *tx = validate_obj_is_free_pin_or_none(args[ARG_tx].u_obj);
+    const mcu_pin_obj_t *rx = validate_obj_is_free_pin_or_none(args[ARG_rx].u_obj, MP_QSTR_rx);
+    const mcu_pin_obj_t *tx = validate_obj_is_free_pin_or_none(args[ARG_tx].u_obj, MP_QSTR_tx);
 
     if ((tx == NULL) && (rx == NULL)) {
         mp_raise_ValueError(translate("tx and rx cannot both be None"));
@@ -137,9 +137,9 @@ STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, si
     mp_float_t timeout = mp_obj_get_float(args[ARG_timeout].u_obj);
     validate_timeout(timeout);
 
-    const mcu_pin_obj_t *rts = validate_obj_is_free_pin_or_none(args[ARG_rts].u_obj);
-    const mcu_pin_obj_t *cts = validate_obj_is_free_pin_or_none(args[ARG_cts].u_obj);
-    const mcu_pin_obj_t *rs485_dir = validate_obj_is_free_pin_or_none(args[ARG_rs485_dir].u_obj);
+    const mcu_pin_obj_t *rts = validate_obj_is_free_pin_or_none(args[ARG_rts].u_obj, MP_QSTR_rts);
+    const mcu_pin_obj_t *cts = validate_obj_is_free_pin_or_none(args[ARG_cts].u_obj, MP_QSTR_cts);
+    const mcu_pin_obj_t *rs485_dir = validate_obj_is_free_pin_or_none(args[ARG_rs485_dir].u_obj, MP_QSTR_rs485_dir);
 
     const bool rs485_invert = args[ARG_rs485_invert].u_bool;
 

--- a/shared-bindings/canio/CAN.c
+++ b/shared-bindings/canio/CAN.c
@@ -77,8 +77,8 @@ STATIC mp_obj_t canio_can_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *rx_pin = validate_obj_is_free_pin_or_none(args[ARG_rx].u_obj);
-    const mcu_pin_obj_t *tx_pin = validate_obj_is_free_pin_or_none(args[ARG_tx].u_obj);
+    const mcu_pin_obj_t *rx_pin = validate_obj_is_free_pin_or_none(args[ARG_rx].u_obj, MP_QSTR_rx);
+    const mcu_pin_obj_t *tx_pin = validate_obj_is_free_pin_or_none(args[ARG_tx].u_obj, MP_QSTR_tx);
     if (!rx_pin && !tx_pin) {
         mp_raise_ValueError(translate("tx and rx cannot both be None"));
     }
@@ -233,11 +233,7 @@ STATIC mp_obj_t canio_can_listen(size_t n_args, const mp_obj_t *pos_args, mp_map
 
     canio_match_obj_t *matches[nmatch];
     for (size_t i = 0; i < nmatch; i++) {
-        const mp_obj_type_t *type = mp_obj_get_type(match_objects[i]);
-        if (type != &canio_match_type) {
-            mp_raise_TypeError_varg(translate("expected '%q' but got '%q'"), MP_QSTR_Match, type->name);
-        }
-        matches[i] = MP_OBJ_TO_PTR(match_objects[i]);
+        matches[i] = mp_arg_validate_type_in(match_objects[i], &canio_match_type, MP_QSTR_matches);
     }
 
     float timeout = args[ARG_timeout].u_obj ? mp_obj_get_float(args[ARG_timeout].u_obj) : 10.0f;
@@ -272,7 +268,7 @@ STATIC mp_obj_t canio_can_send(mp_obj_t self_in, mp_obj_t message_in) {
     common_hal_canio_can_check_for_deinit(self);
     const mp_obj_type_t *message_type = mp_obj_get_type(message_in);
     if (message_type != &canio_message_type && message_type != &canio_remote_transmission_request_type) {
-        mp_raise_TypeError_varg(translate("expected '%q' or '%q' but got '%q'"), MP_QSTR_Message, MP_QSTR_RemoteTransmissionRequest, message_type->name);
+        mp_raise_TypeError_varg(translate("%q must be of type %q or %q, not %q"), MP_QSTR_message, MP_QSTR_Message, MP_QSTR_RemoteTransmissionRequest, message_type->name);
     }
 
     canio_message_obj_t *message = message_in;

--- a/shared-bindings/countio/Counter.c
+++ b/shared-bindings/countio/Counter.c
@@ -53,7 +53,7 @@ STATIC mp_obj_t countio_counter_make_new(const mp_obj_type_t *type, size_t n_arg
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj);
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
     const countio_edge_t edge = validate_edge(args[ARG_edge].u_obj, MP_QSTR_edge);
     const digitalio_pull_t pull = validate_pull(args[ARG_pull].u_obj, MP_QSTR_pull);
     // Make long-lived because some implementations use a pointer to the object as interrupt-handler data.

--- a/shared-bindings/countio/Edge.c
+++ b/shared-bindings/countio/Edge.c
@@ -65,5 +65,5 @@ MAKE_PRINTER(countio, countio_edge);
 MAKE_ENUM_TYPE(countio, Edge, countio_edge);
 
 countio_edge_t validate_edge(mp_obj_t obj, qstr arg_name) {
-    return cp_enum_value(&countio_edge_type, mp_arg_validate_type(obj, &countio_edge_type, arg_name));
+    return cp_enum_value(&countio_edge_type, obj, arg_name);
 }

--- a/shared-bindings/digitalio/DigitalInOut.c
+++ b/shared-bindings/digitalio/DigitalInOut.c
@@ -69,7 +69,7 @@ STATIC void check_result(digitalinout_result_t result) {
 }
 
 MP_WEAK const mcu_pin_obj_t *common_hal_digitalio_validate_pin(mp_obj_t obj) {
-    return validate_obj_is_free_pin(obj);
+    return validate_obj_is_free_pin(obj, MP_QSTR_pin);
 }
 
 //| class DigitalInOut:

--- a/shared-bindings/digitalio/Pull.c
+++ b/shared-bindings/digitalio/Pull.c
@@ -83,5 +83,5 @@ digitalio_pull_t validate_pull(mp_rom_obj_t obj, qstr arg_name) {
     if (obj == MP_ROM_NONE) {
         return PULL_NONE;
     }
-    mp_raise_TypeError_varg(translate("%q must be of type %q or None"), arg_name, MP_QSTR_Pull);
+    mp_raise_TypeError_varg(translate("%q must be of type %q or %q, not %q"), arg_name, MP_QSTR_Pull, MP_QSTR_None, mp_obj_get_type(obj)->name);
 }

--- a/shared-bindings/displayio/ColorConverter.c
+++ b/shared-bindings/displayio/ColorConverter.c
@@ -61,7 +61,7 @@ STATIC mp_obj_t displayio_colorconverter_make_new(const mp_obj_type_t *type, siz
     displayio_colorconverter_t *self = m_new_obj(displayio_colorconverter_t);
     self->base.type = &displayio_colorconverter_type;
 
-    common_hal_displayio_colorconverter_construct(self, args[ARG_dither].u_bool, (displayio_colorspace_t)cp_enum_value(&displayio_colorspace_type, args[ARG_input_colorspace].u_obj));
+    common_hal_displayio_colorconverter_construct(self, args[ARG_dither].u_bool, (displayio_colorspace_t)cp_enum_value(&displayio_colorspace_type, args[ARG_input_colorspace].u_obj, MP_QSTR_input_colorspace));
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -185,7 +185,8 @@ STATIC mp_obj_t displayio_display_make_new(const mp_obj_type_t *type, size_t n_a
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[ARG_init_sequence].u_obj, &bufinfo, MP_BUFFER_READ);
 
-    const mcu_pin_obj_t *backlight_pin = validate_obj_is_free_pin_or_none(args[ARG_backlight_pin].u_obj);
+    const mcu_pin_obj_t *backlight_pin =
+        validate_obj_is_free_pin_or_none(args[ARG_backlight_pin].u_obj, MP_QSTR_backlight_pin);
 
     mp_float_t brightness = mp_obj_get_float(args[ARG_brightness].u_obj);
 

--- a/shared-bindings/displayio/EPaperDisplay.c
+++ b/shared-bindings/displayio/EPaperDisplay.c
@@ -167,7 +167,7 @@ STATIC mp_obj_t displayio_epaperdisplay_make_new(const mp_obj_type_t *type, size
     mp_get_buffer_raise(args[ARG_stop_sequence].u_obj, &stop_bufinfo, MP_BUFFER_READ);
 
 
-    const mcu_pin_obj_t *busy_pin = validate_obj_is_free_pin_or_none(args[ARG_busy_pin].u_obj);
+    const mcu_pin_obj_t *busy_pin = validate_obj_is_free_pin_or_none(args[ARG_busy_pin].u_obj, MP_QSTR_busy_pin);
 
     mp_int_t rotation = args[ARG_rotation].u_int;
     if (rotation % 90 != 0) {

--- a/shared-bindings/displayio/FourWire.c
+++ b/shared-bindings/displayio/FourWire.c
@@ -89,9 +89,9 @@ STATIC mp_obj_t displayio_fourwire_make_new(const mp_obj_type_t *type, size_t n_
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *command = validate_obj_is_free_pin_or_none(args[ARG_command].u_obj);
-    const mcu_pin_obj_t *chip_select = validate_obj_is_free_pin(args[ARG_chip_select].u_obj);
-    const mcu_pin_obj_t *reset = validate_obj_is_free_pin_or_none(args[ARG_reset].u_obj);
+    const mcu_pin_obj_t *command = validate_obj_is_free_pin_or_none(args[ARG_command].u_obj, MP_QSTR_command);
+    const mcu_pin_obj_t *chip_select = validate_obj_is_free_pin(args[ARG_chip_select].u_obj, MP_QSTR_chip_select);
+    const mcu_pin_obj_t *reset = validate_obj_is_free_pin_or_none(args[ARG_reset].u_obj, MP_QSTR_reset);
 
     mp_obj_t spi = mp_arg_validate_type(args[ARG_spi_bus].u_obj, &busio_spi_type, MP_QSTR_spi_bus);
 

--- a/shared-bindings/displayio/I2CDisplay.c
+++ b/shared-bindings/displayio/I2CDisplay.c
@@ -71,7 +71,7 @@ STATIC mp_obj_t displayio_i2cdisplay_make_new(const mp_obj_type_t *type, size_t 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *reset = validate_obj_is_free_pin_or_none(args[ARG_reset].u_obj);
+    const mcu_pin_obj_t *reset = validate_obj_is_free_pin_or_none(args[ARG_reset].u_obj, MP_QSTR_reset);
 
     mp_obj_t i2c = mp_arg_validate_type(args[ARG_i2c_bus].u_obj, &busio_i2c_type, MP_QSTR_i2c_bus);
     displayio_i2cdisplay_obj_t *self = &allocate_display_bus_or_raise()->i2cdisplay_bus;

--- a/shared-bindings/frequencyio/FrequencyIn.c
+++ b/shared-bindings/frequencyio/FrequencyIn.c
@@ -83,7 +83,7 @@ STATIC mp_obj_t frequencyio_frequencyin_make_new(const mp_obj_type_t *type, size
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj);
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
 
     const uint16_t capture_period = args[ARG_capture_period].u_int;
 

--- a/shared-bindings/gifio/GifWriter.c
+++ b/shared-bindings/gifio/GifWriter.c
@@ -80,7 +80,7 @@ static mp_obj_t gifio_gifwriter_make_new(const mp_obj_type_t *type, size_t n_arg
         file,
         args[ARG_width].u_int,
         args[ARG_height].u_int,
-        (displayio_colorspace_t)cp_enum_value(&displayio_colorspace_type, args[ARG_colorspace].u_obj),
+        (displayio_colorspace_t)cp_enum_value(&displayio_colorspace_type, args[ARG_colorspace].u_obj, MP_QSTR_colorspace),
         args[ARG_loop].u_bool,
         args[ARG_dither].u_bool,
         own_file);

--- a/shared-bindings/i2ctarget/I2CTarget.c
+++ b/shared-bindings/i2ctarget/I2CTarget.c
@@ -81,8 +81,8 @@ STATIC mp_obj_t i2ctarget_i2c_target_make_new(const mp_obj_type_t *type, size_t 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *scl = validate_obj_is_free_pin(args[ARG_scl].u_obj);
-    const mcu_pin_obj_t *sda = validate_obj_is_free_pin(args[ARG_sda].u_obj);
+    const mcu_pin_obj_t *scl = validate_obj_is_free_pin(args[ARG_scl].u_obj, MP_QSTR_scl);
+    const mcu_pin_obj_t *sda = validate_obj_is_free_pin(args[ARG_sda].u_obj, MP_QSTR_sda);
 
     mp_obj_iter_buf_t iter_buf;
     mp_obj_t iterable = mp_getiter(args[ARG_addresses].u_obj, &iter_buf);

--- a/shared-bindings/imagecapture/ParallelImageCapture.c
+++ b/shared-bindings/imagecapture/ParallelImageCapture.c
@@ -72,9 +72,9 @@ STATIC mp_obj_t imagecapture_parallelimagecapture_make_new(const mp_obj_type_t *
     uint8_t pin_count;
     validate_pins(MP_QSTR_data, pins, MP_ARRAY_SIZE(pins), args[ARG_data_pins].u_obj, &pin_count);
 
-    const mcu_pin_obj_t *clock = validate_obj_is_free_pin(args[ARG_clock].u_obj);
-    const mcu_pin_obj_t *vsync = validate_obj_is_free_pin_or_none(args[ARG_vsync].u_obj);
-    const mcu_pin_obj_t *href = validate_obj_is_free_pin_or_none(args[ARG_href].u_obj);
+    const mcu_pin_obj_t *clock = validate_obj_is_free_pin(args[ARG_clock].u_obj, MP_QSTR_clock);
+    const mcu_pin_obj_t *vsync = validate_obj_is_free_pin_or_none(args[ARG_vsync].u_obj, MP_QSTR_vsync);
+    const mcu_pin_obj_t *href = validate_obj_is_free_pin_or_none(args[ARG_href].u_obj, MP_QSTR_href);
 
     imagecapture_parallelimagecapture_obj_t *self = m_new_obj(imagecapture_parallelimagecapture_obj_t);
     self->base.type = &imagecapture_parallelimagecapture_type;

--- a/shared-bindings/keypad/KeyMatrix.c
+++ b/shared-bindings/keypad/KeyMatrix.c
@@ -102,13 +102,13 @@ STATIC mp_obj_t keypad_keymatrix_make_new(const mp_obj_type_t *type, size_t n_ar
 
     for (size_t row = 0; row < num_row_pins; row++) {
         const mcu_pin_obj_t *pin =
-            validate_obj_is_free_pin(mp_obj_subscr(row_pins, MP_OBJ_NEW_SMALL_INT(row), MP_OBJ_SENTINEL));
+            validate_obj_is_free_pin(mp_obj_subscr(row_pins, MP_OBJ_NEW_SMALL_INT(row), MP_OBJ_SENTINEL), MP_QSTR_pin);
         row_pins_array[row] = pin;
     }
 
     for (size_t column = 0; column < num_column_pins; column++) {
         const mcu_pin_obj_t *pin =
-            validate_obj_is_free_pin(mp_obj_subscr(column_pins, MP_OBJ_NEW_SMALL_INT(column), MP_OBJ_SENTINEL));
+            validate_obj_is_free_pin(mp_obj_subscr(column_pins, MP_OBJ_NEW_SMALL_INT(column), MP_OBJ_SENTINEL), MP_QSTR_pin);
         column_pins_array[column] = pin;
     }
 

--- a/shared-bindings/keypad/Keys.c
+++ b/shared-bindings/keypad/Keys.c
@@ -100,7 +100,7 @@ STATIC mp_obj_t keypad_keys_make_new(const mp_obj_type_t *type, size_t n_args, s
 
     for (mp_uint_t i = 0; i < num_pins; i++) {
         pins_array[i] =
-            validate_obj_is_free_pin(mp_obj_subscr(pins, MP_OBJ_NEW_SMALL_INT(i), MP_OBJ_SENTINEL));
+            validate_obj_is_free_pin(mp_obj_subscr(pins, MP_OBJ_NEW_SMALL_INT(i), MP_OBJ_SENTINEL), MP_QSTR_pin);
     }
 
     common_hal_keypad_keys_construct(self, num_pins, pins_array, value_when_pressed, args[ARG_pull].u_bool, interval, max_events);

--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -98,9 +98,9 @@ STATIC mp_obj_t keypad_shiftregisterkeys_make_new(const mp_obj_type_t *type, siz
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *clock = validate_obj_is_free_pin(args[ARG_clock].u_obj);
-    const mcu_pin_obj_t *data = validate_obj_is_free_pin(args[ARG_data].u_obj);
-    const mcu_pin_obj_t *latch = validate_obj_is_free_pin(args[ARG_latch].u_obj);
+    const mcu_pin_obj_t *clock = validate_obj_is_free_pin(args[ARG_clock].u_obj, MP_QSTR_clock);
+    const mcu_pin_obj_t *data = validate_obj_is_free_pin(args[ARG_data].u_obj, MP_QSTR_data);
+    const mcu_pin_obj_t *latch = validate_obj_is_free_pin(args[ARG_latch].u_obj, MP_QSTR_latch);
     const bool value_to_latch = args[ARG_value_to_latch].u_bool;
 
     const size_t key_count = (size_t)mp_arg_validate_int_min(args[ARG_key_count].u_int, 1, MP_QSTR_key_count);

--- a/shared-bindings/microcontroller/Pin.c
+++ b/shared-bindings/microcontroller/Pin.c
@@ -93,23 +93,21 @@ const mp_obj_type_t mcu_pin_type = {
         )
 };
 
-const mcu_pin_obj_t *validate_obj_is_pin(mp_obj_t obj) {
-    if (!mp_obj_is_type(obj, &mcu_pin_type)) {
-        mp_raise_TypeError_varg(translate("Expected a %q"), mcu_pin_type.name);
-    }
-    return MP_OBJ_TO_PTR(obj);
+const mcu_pin_obj_t *validate_obj_is_pin(mp_obj_t obj, qstr arg_name) {
+    return MP_OBJ_TO_PTR(mp_arg_validate_type(obj, &mcu_pin_type, arg_name));
+}
+
+const mcu_pin_obj_t *validate_obj_is_pin_in(mp_obj_t obj, qstr arg_name) {
+    return MP_OBJ_TO_PTR(mp_arg_validate_type_in(obj, &mcu_pin_type, arg_name));
 }
 
 // Validate that the obj is a pin or None. Return an mcu_pin_obj_t* or NULL, correspondingly.
-const mcu_pin_obj_t *validate_obj_is_pin_or_none(mp_obj_t obj) {
-    if (obj == mp_const_none) {
-        return NULL;
-    }
-    return validate_obj_is_pin(obj);
+const mcu_pin_obj_t *validate_obj_is_pin_or_none(mp_obj_t obj, qstr arg_name) {
+    return MP_OBJ_TO_PTR(mp_arg_validate_type(obj, &mcu_pin_type, arg_name));
 }
 
-const mcu_pin_obj_t *validate_obj_is_free_pin(mp_obj_t obj) {
-    const mcu_pin_obj_t *pin = validate_obj_is_pin(obj);
+const mcu_pin_obj_t *validate_obj_is_free_pin(mp_obj_t obj, qstr arg_name) {
+    const mcu_pin_obj_t *pin = validate_obj_is_pin(obj, arg_name);
     assert_pin_free(pin);
     return pin;
 }
@@ -120,11 +118,11 @@ void validate_no_duplicate_pins(mp_obj_t seq, qstr arg_name) {
 
     for (size_t pin_cnt = 0; pin_cnt < num_pins; pin_cnt++) {
         mp_obj_t pin1_obj = mp_obj_subscr(seq, MP_OBJ_NEW_SMALL_INT(pin_cnt), MP_OBJ_SENTINEL);
-        const mcu_pin_obj_t *pin1 = validate_obj_is_pin(pin1_obj);
+        const mcu_pin_obj_t *pin1 = validate_obj_is_pin_in(pin1_obj, arg_name);
 
         for (size_t pin_cnt_2 = pin_cnt + 1; pin_cnt_2 < num_pins; pin_cnt_2++) {
             mp_obj_t pin2_obj = mp_obj_subscr(seq, MP_OBJ_NEW_SMALL_INT(pin_cnt_2), MP_OBJ_SENTINEL);
-            const mcu_pin_obj_t *pin2 = validate_obj_is_pin(pin2_obj);
+            const mcu_pin_obj_t *pin2 = validate_obj_is_pin_in(pin2_obj, arg_name);
             if (pin1 == pin2) {
                 mp_raise_TypeError_varg(translate("%q contains duplicate pins"), arg_name);
             }
@@ -141,11 +139,11 @@ void validate_no_duplicate_pins_2(mp_obj_t seq1, mp_obj_t seq2, qstr arg_name1, 
 
     for (size_t pin_cnt_1 = 0; pin_cnt_1 < num_pins_1; pin_cnt_1++) {
         mp_obj_t pin1_obj = mp_obj_subscr(seq1, MP_OBJ_NEW_SMALL_INT(pin_cnt_1), MP_OBJ_SENTINEL);
-        const mcu_pin_obj_t *pin1 = validate_obj_is_pin(pin1_obj);
+        const mcu_pin_obj_t *pin1 = validate_obj_is_pin_in(pin1_obj, arg_name1);
 
         for (size_t pin_cnt_2 = 0; pin_cnt_2 < num_pins_2; pin_cnt_2++) {
             mp_obj_t pin2_obj = mp_obj_subscr(seq2, MP_OBJ_NEW_SMALL_INT(pin_cnt_2), MP_OBJ_SENTINEL);
-            const mcu_pin_obj_t *pin2 = validate_obj_is_pin(pin2_obj);
+            const mcu_pin_obj_t *pin2 = validate_obj_is_pin_in(pin2_obj, arg_name2);
             if (pin1 == pin2) {
                 mp_raise_TypeError_varg(translate("%q and %q contain duplicate pins"), arg_name1, arg_name2);
             }
@@ -159,16 +157,18 @@ void validate_list_is_free_pins(qstr what, const mcu_pin_obj_t **pins_out, mp_in
     mp_arg_validate_length_max(len, max_pins, what);
     *count_out = len;
     for (mp_int_t i = 0; i < len; i++) {
-        pins_out[i] = validate_obj_is_free_pin(mp_obj_subscr(seq, MP_OBJ_NEW_SMALL_INT(i), MP_OBJ_SENTINEL));
+        pins_out[i] =
+            validate_obj_is_pin_in(mp_obj_subscr(seq, MP_OBJ_NEW_SMALL_INT(i), MP_OBJ_SENTINEL), what);
+        assert_pin_free(pins_out[i]);
     }
 }
 
 // Validate that the obj is a free pin or None. Return an mcu_pin_obj_t* or NULL, correspondingly.
-const mcu_pin_obj_t *validate_obj_is_free_pin_or_none(mp_obj_t obj) {
+const mcu_pin_obj_t *validate_obj_is_free_pin_or_none(mp_obj_t obj, qstr arg_name) {
     if (obj == mp_const_none) {
         return NULL;
     }
-    const mcu_pin_obj_t *pin = validate_obj_is_pin(obj);
+    const mcu_pin_obj_t *pin = validate_obj_is_pin(obj, arg_name);
     assert_pin_free(pin);
     return pin;
 }

--- a/shared-bindings/microcontroller/Pin.h
+++ b/shared-bindings/microcontroller/Pin.h
@@ -33,10 +33,11 @@
 // Type object used in Python. Should be shared between ports.
 extern const mp_obj_type_t mcu_pin_type;
 
-const mcu_pin_obj_t *validate_obj_is_pin(mp_obj_t obj);
-const mcu_pin_obj_t *validate_obj_is_pin_or_none(mp_obj_t obj);
-const mcu_pin_obj_t *validate_obj_is_free_pin(mp_obj_t obj);
-const mcu_pin_obj_t *validate_obj_is_free_pin_or_none(mp_obj_t obj);
+const mcu_pin_obj_t *validate_obj_is_pin(mp_obj_t obj, qstr arg_name);
+const mcu_pin_obj_t *validate_obj_is_pin_in(mp_obj_t obj, qstr arg_name);
+const mcu_pin_obj_t *validate_obj_is_pin_or_none(mp_obj_t obj, qstr arg_name);
+const mcu_pin_obj_t *validate_obj_is_free_pin(mp_obj_t obj, qstr arg_name);
+const mcu_pin_obj_t *validate_obj_is_free_pin_or_none(mp_obj_t obj, qstr arg_name);
 void validate_no_duplicate_pins(mp_obj_t seq, qstr arg_name);
 void validate_no_duplicate_pins_2(mp_obj_t seq1, mp_obj_t seq2, qstr arg_name1, qstr arg_name2);
 void validate_list_is_free_pins(qstr what, const mcu_pin_obj_t **pins_out, mp_int_t max_pins, mp_obj_t seq, uint8_t *count_out);

--- a/shared-bindings/neopixel_write/__init__.c
+++ b/shared-bindings/neopixel_write/__init__.c
@@ -113,12 +113,8 @@ STATIC void check_for_deinit(digitalio_digitalinout_obj_t *self) {
 //|     ...
 //|
 STATIC mp_obj_t neopixel_write_neopixel_write_(mp_obj_t digitalinout_obj, mp_obj_t buf) {
-    if (!mp_obj_is_type(digitalinout_obj, &digitalio_digitalinout_type)) {
-        mp_raise_TypeError_varg(translate("Expected a %q"), digitalio_digitalinout_type.name);
-    }
-
-    // Convert parameters into expected types.
-    const digitalio_digitalinout_obj_t *digitalinout = MP_OBJ_TO_PTR(digitalinout_obj);
+    const digitalio_digitalinout_obj_t *digitalinout =
+        mp_arg_validate_type(digitalinout_obj, &digitalio_digitalinout_type, MP_QSTR_digitalinout);
 
     // Check to see if the NeoPixel has been deinited before writing to it.
     check_for_deinit(digitalinout_obj);

--- a/shared-bindings/onewireio/OneWire.c
+++ b/shared-bindings/onewireio/OneWire.c
@@ -60,7 +60,7 @@ STATIC mp_obj_t onewireio_onewire_make_new(const mp_obj_type_t *type, size_t n_a
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj);
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
 
     onewireio_onewire_obj_t *self = m_new_obj(onewireio_onewire_obj_t);
     self->base.type = &onewireio_onewire_type;

--- a/shared-bindings/paralleldisplay/ParallelBus.c
+++ b/shared-bindings/paralleldisplay/ParallelBus.c
@@ -85,11 +85,11 @@ STATIC mp_obj_t paralleldisplay_parallelbus_make_new(const mp_obj_type_t *type, 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *command = validate_obj_is_free_pin(args[ARG_command].u_obj);
-    const mcu_pin_obj_t *chip_select = validate_obj_is_free_pin(args[ARG_chip_select].u_obj);
-    const mcu_pin_obj_t *write = validate_obj_is_free_pin(args[ARG_write].u_obj);
-    const mcu_pin_obj_t *read = validate_obj_is_free_pin_or_none(args[ARG_read].u_obj);
-    const mcu_pin_obj_t *reset = validate_obj_is_free_pin_or_none(args[ARG_reset].u_obj);
+    const mcu_pin_obj_t *command = validate_obj_is_free_pin(args[ARG_command].u_obj, MP_QSTR_command);
+    const mcu_pin_obj_t *chip_select = validate_obj_is_free_pin(args[ARG_chip_select].u_obj, MP_QSTR_chip_select);
+    const mcu_pin_obj_t *write = validate_obj_is_free_pin(args[ARG_write].u_obj, MP_QSTR_write);
+    const mcu_pin_obj_t *read = validate_obj_is_free_pin_or_none(args[ARG_read].u_obj, MP_QSTR_read);
+    const mcu_pin_obj_t *reset = validate_obj_is_free_pin_or_none(args[ARG_reset].u_obj, MP_QSTR_reset);
 
     paralleldisplay_parallelbus_obj_t *self = &allocate_display_bus_or_raise()->parallel_bus;
     self->base.type = &paralleldisplay_parallelbus_type;
@@ -102,7 +102,7 @@ STATIC mp_obj_t paralleldisplay_parallelbus_make_new(const mp_obj_type_t *type, 
     }
 
     if (specified_data0) {
-        const mcu_pin_obj_t *data0 = validate_obj_is_free_pin(args[ARG_data0].u_obj);
+        const mcu_pin_obj_t *data0 = validate_obj_is_free_pin(args[ARG_data0].u_obj, MP_QSTR_data0);
         common_hal_paralleldisplay_parallelbus_construct(self, data0, command, chip_select, write, read, reset, args[ARG_frequency].u_int);
     } else {
         uint8_t num_pins;

--- a/shared-bindings/ps2io/Ps2.c
+++ b/shared-bindings/ps2io/Ps2.c
@@ -75,8 +75,8 @@ STATIC mp_obj_t ps2io_ps2_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *clock_pin = validate_obj_is_free_pin(args[ARG_clock_pin].u_obj);
-    const mcu_pin_obj_t *data_pin = validate_obj_is_free_pin(args[ARG_data_pin].u_obj);
+    const mcu_pin_obj_t *clock_pin = validate_obj_is_free_pin(args[ARG_clock_pin].u_obj, MP_QSTR_clock_pin);
+    const mcu_pin_obj_t *data_pin = validate_obj_is_free_pin(args[ARG_data_pin].u_obj, MP_QSTR_data_pin);
 
     ps2io_ps2_obj_t *self = m_new_obj(ps2io_ps2_obj_t);
     self->base.type = &ps2io_ps2_type;

--- a/shared-bindings/pulseio/PulseIn.c
+++ b/shared-bindings/pulseio/PulseIn.c
@@ -86,7 +86,7 @@ STATIC mp_obj_t pulseio_pulsein_make_new(const mp_obj_type_t *type, size_t n_arg
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj);
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
 
     // Make object long-lived to avoid moving between imports
     pulseio_pulsein_obj_t *self = m_new_ll_obj(pulseio_pulsein_obj_t);

--- a/shared-bindings/pulseio/PulseOut.c
+++ b/shared-bindings/pulseio/PulseOut.c
@@ -77,10 +77,10 @@ STATIC mp_obj_t pulseio_pulseout_make_new(const mp_obj_type_t *type, size_t n_ar
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *pin = args[ARG_pin].u_obj;
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
     mp_int_t frequency = args[ARG_frequency].u_int;
     mp_int_t duty_cycle = args[ARG_duty_cycle].u_int;
-    validate_obj_is_free_pin(MP_OBJ_FROM_PTR(pin));
+
     pulseio_pulseout_obj_t *self = m_new_obj(pulseio_pulseout_obj_t);
     self->base.type = &pulseio_pulseout_type;
     common_hal_pulseio_pulseout_construct(self, pin, frequency, duty_cycle);

--- a/shared-bindings/pwmio/PWMOut.c
+++ b/shared-bindings/pwmio/PWMOut.c
@@ -147,7 +147,7 @@ STATIC mp_obj_t pwmio_pwmout_make_new(const mp_obj_type_t *type, size_t n_args, 
     mp_arg_val_t parsed_args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, args, MP_ARRAY_SIZE(allowed_args), allowed_args, parsed_args);
 
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(parsed_args[ARG_pin].u_obj);
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(parsed_args[ARG_pin].u_obj, MP_QSTR_pin);
 
     uint16_t duty_cycle = parsed_args[ARG_duty_cycle].u_int;
     uint32_t frequency = parsed_args[ARG_frequency].u_int;

--- a/shared-bindings/qrio/QRDecoder.c
+++ b/shared-bindings/qrio/QRDecoder.c
@@ -80,7 +80,7 @@ STATIC mp_obj_t qrio_qrdecoder_decode(size_t n_args, const mp_obj_t *pos_args, m
 
     // verify that the buffer is big enough
     int sz = width * height;
-    qrio_pixel_policy_t policy = cp_enum_value(&qrio_pixel_policy_type, args[ARG_pixel_policy].u_obj);
+    qrio_pixel_policy_t policy = cp_enum_value(&qrio_pixel_policy_type, args[ARG_pixel_policy].u_obj, MP_QSTR_pixel_policy);
     if (policy != QRIO_EVERY_BYTE) {
         sz *= 2;
     }

--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -44,8 +44,8 @@
 
 extern Protomatter_core *_PM_protoPtr;
 
-STATIC uint8_t validate_pin(mp_obj_t obj) {
-    const mcu_pin_obj_t *result = validate_obj_is_free_pin(obj);
+STATIC uint8_t validate_pin(mp_obj_t obj, qstr arg_name) {
+    const mcu_pin_obj_t *result = validate_obj_is_free_pin(obj, arg_name);
     return common_hal_mcu_pin_number(result);
 }
 
@@ -210,9 +210,9 @@ STATIC mp_obj_t rgbmatrix_rgbmatrix_make_new(const mp_obj_type_t *type, size_t n
     uint8_t rgb_count, addr_count;
     uint8_t rgb_pins[MP_ARRAY_SIZE(self->rgb_pins)];
     uint8_t addr_pins[MP_ARRAY_SIZE(self->addr_pins)];
-    uint8_t clock_pin = validate_pin(args[ARG_clock_pin].u_obj);
-    uint8_t latch_pin = validate_pin(args[ARG_latch_pin].u_obj);
-    uint8_t output_enable_pin = validate_pin(args[ARG_output_enable_pin].u_obj);
+    uint8_t clock_pin = validate_pin(args[ARG_clock_pin].u_obj, MP_QSTR_clock_pin);
+    uint8_t latch_pin = validate_pin(args[ARG_latch_pin].u_obj, MP_QSTR_latch_pin);
+    uint8_t output_enable_pin = validate_pin(args[ARG_output_enable_pin].u_obj, MP_QSTR_output_enable_pin);
     mp_int_t bit_depth = mp_arg_validate_int_range(args[ARG_bit_depth].u_int, 1, 6, MP_QSTR_bit_depth);
 
     validate_pins(MP_QSTR_rgb_pins, rgb_pins, MP_ARRAY_SIZE(self->rgb_pins), args[ARG_rgb_list].u_obj, &rgb_count);

--- a/shared-bindings/rotaryio/IncrementalEncoder.c
+++ b/shared-bindings/rotaryio/IncrementalEncoder.c
@@ -72,8 +72,8 @@ STATIC mp_obj_t rotaryio_incrementalencoder_make_new(const mp_obj_type_t *type, 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *pin_a = validate_obj_is_free_pin(args[ARG_pin_a].u_obj);
-    const mcu_pin_obj_t *pin_b = validate_obj_is_free_pin(args[ARG_pin_b].u_obj);
+    const mcu_pin_obj_t *pin_a = validate_obj_is_free_pin(args[ARG_pin_a].u_obj, MP_QSTR_pin_a);
+    const mcu_pin_obj_t *pin_b = validate_obj_is_free_pin(args[ARG_pin_b].u_obj, MP_QSTR_pin_b);
 
     // Make long-lived because some implementations use a pointer to the object as interrupt-handler data.
     rotaryio_incrementalencoder_obj_t *self = m_new_ll_obj(rotaryio_incrementalencoder_obj_t);

--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -89,8 +89,8 @@ STATIC mp_obj_t sdcardio_sdcard_make_new(const mp_obj_type_t *type, size_t n_arg
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    busio_spi_obj_t *spi = validate_obj_is_spi_bus(args[ARG_spi].u_obj);
-    const mcu_pin_obj_t *cs = validate_obj_is_free_pin(args[ARG_cs].u_obj);
+    busio_spi_obj_t *spi = validate_obj_is_spi_bus(args[ARG_spi].u_obj, MP_QSTR_spi);
+    const mcu_pin_obj_t *cs = validate_obj_is_free_pin(args[ARG_cs].u_obj, MP_QSTR_cs);
 
     sdcardio_sdcard_obj_t *self = m_new_obj(sdcardio_sdcard_obj_t);
     self->base.type = &sdcardio_SDCard_type;

--- a/shared-bindings/sdioio/SDCard.c
+++ b/shared-bindings/sdioio/SDCard.c
@@ -98,8 +98,8 @@ STATIC mp_obj_t sdioio_sdcard_make_new(const mp_obj_type_t *type, size_t n_args,
 
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *clock = validate_obj_is_free_pin(args[ARG_clock].u_obj);
-    const mcu_pin_obj_t *command = validate_obj_is_free_pin(args[ARG_command].u_obj);
+    const mcu_pin_obj_t *clock = validate_obj_is_free_pin(args[ARG_clock].u_obj, MP_QSTR_clock);
+    const mcu_pin_obj_t *command = validate_obj_is_free_pin(args[ARG_command].u_obj, MP_QSTR_command);
     const mcu_pin_obj_t *data_pins[4];
     uint8_t num_data;
     validate_list_is_free_pins(MP_QSTR_data, data_pins, MP_ARRAY_SIZE(data_pins), args[ARG_data].u_obj, &num_data);

--- a/shared-bindings/sharpdisplay/SharpMemoryFramebuffer.c
+++ b/shared-bindings/sharpdisplay/SharpMemoryFramebuffer.c
@@ -47,8 +47,8 @@ STATIC mp_obj_t sharpdisplay_framebuffer_make_new(const mp_obj_type_t *type, siz
 
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    const mcu_pin_obj_t *chip_select = validate_obj_is_free_pin(args[ARG_chip_select].u_obj);
-    busio_spi_obj_t *spi = validate_obj_is_spi_bus(args[ARG_spi_bus].u_obj);
+    const mcu_pin_obj_t *chip_select = validate_obj_is_free_pin(args[ARG_chip_select].u_obj, MP_QSTR_chip_select);
+    busio_spi_obj_t *spi = validate_obj_is_spi_bus(args[ARG_spi_bus].u_obj, MP_QSTR_spi_bus);
 
     sharpdisplay_framebuffer_obj_t *self = &allocate_display_bus_or_raise()->sharpdisplay;
     self->base.type = &sharpdisplay_framebuffer_type;

--- a/shared-bindings/touchio/TouchIn.c
+++ b/shared-bindings/touchio/TouchIn.c
@@ -63,7 +63,7 @@ STATIC mp_obj_t touchio_touchin_make_new(const mp_obj_type_t *type,
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
 
     // 1st argument is the pin
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[0]);
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[0], MP_QSTR_pin);
 
     touchio_touchin_obj_t *self = m_new_obj(touchio_touchin_obj_t);
     self->base.type = &touchio_touchin_type;

--- a/shared-bindings/usb_host/Port.c
+++ b/shared-bindings/usb_host/Port.c
@@ -47,8 +47,8 @@ STATIC mp_obj_t usb_host_port_make_new(const mp_obj_type_t *type,
     // check number of arguments
     mp_arg_check_num(n_args, n_kw, 2, 2, false);
 
-    const mcu_pin_obj_t *dp = validate_obj_is_free_pin(args[0]);
-    const mcu_pin_obj_t *dm = validate_obj_is_free_pin(args[1]);
+    const mcu_pin_obj_t *dp = validate_obj_is_free_pin(args[0], MP_QSTR_dp);
+    const mcu_pin_obj_t *dm = validate_obj_is_free_pin(args[1], MP_QSTR_dm);
 
     usb_host_port_obj_t *self = m_new_obj(usb_host_port_obj_t);
     self->base.type = &usb_host_port_type;

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -344,7 +344,7 @@ STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_
         mp_obj_iter_buf_t iter_buf;
         mp_obj_t item, iterable = mp_getiter(args[ARG_authmode].u_obj, &iter_buf);
         while ((item = mp_iternext(iterable)) != MP_OBJ_STOP_ITERATION) {
-            authmodes |= cp_enum_value(&wifi_authmode_type, item);
+            authmodes |= cp_enum_value(&wifi_authmode_type, item, MP_QSTR_authmode);
         }
     }
 


### PR DESCRIPTION
Fixes #7238, but does a lot more also.

- Per @jepler's [suggestion](https://github.com/adafruit/circuitpython/issues/7238#issuecomment-1320979886), expands `%q must be of type %q` to `%q must be of type %q, not %q`.
- Adds a new validator for objects in a collection: `object in %q must be of type %q, not %q`. Used a lot for pin lists.
- Adds `arg_name` to a lot of pin validation routines.
- Adds `arg_name` to SPI bus validation routine.
- Adds `arg_name` to `cp_enum_value` to use when validation fails.
- Replaces some `Expected ...` messages with standard type validation messages.
- Consolidated some `%q must be %q or None` and `%q must be %q or %q` to all be `%q must be %q or %q, not %q`.
- Standardized a few other error messages to reduce the number of messages.
- Removed redundant type validations in `esp32_camera/__init__.c`.
- Removed redundant type validations in `aesio/aes.c` and did some minor cleanup.
- Minor cleanup in `espulp/ULP.c`.
- Minor rework of sequential pin checking in `rp2pio`.

Examples:
```py
>>> busio.I2C(1.0, 2.0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: scl must be of type Pin, not float
```
```py
>>> keypad.Keys([34,52], value_when_pressed=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: object in row_pins must be of type Pin, not int
```

This is all probably a net size increase, but hopefully not too much.
