### PR TITLE
Update cyw43-driver, fix no-password wifi

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -233,7 +233,7 @@ SRC_SDK := \
 	$(SRC_SDK_CYW43) \
 
 SRC_SDK := $(addprefix sdk/, $(SRC_SDK))
-$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK) $(SRC_CYW43)): CFLAGS += -Wno-missing-prototypes -Wno-undef -Wno-unused-function -Wno-nested-externs -Wno-strict-prototypes -Wno-double-promotion -Wno-sign-compare -Wno-unused-variable -Wno-strict-overflow
+$(patsubst %.c,$(BUILD)/%.o,$(SRC_SDK) $(SRC_CYW43)): CFLAGS += -Wno-missing-prototypes -Wno-undef -Wno-unused-function -Wno-nested-externs -Wno-strict-prototypes -Wno-double-promotion -Wno-sign-compare -Wno-unused-variable -Wno-strict-overflow -Ilib/cyw43-driver
 
 SRC_C += \
 	boards/$(BOARD)/board.c \

--- a/ports/raspberrypi/common-hal/wifi/Radio.c
+++ b/ports/raspberrypi/common-hal/wifi/Radio.c
@@ -244,7 +244,8 @@ wifi_radio_error_t common_hal_wifi_radio_connect(wifi_radio_obj_t *self, uint8_t
     common_hal_wifi_radio_stop_station(self);
 
     // connect
-    cyw43_arch_wifi_connect_async((const char *)ssid, (const char *)password, CYW43_AUTH_WPA2_AES_PSK);
+    int auth_mode = password_len ? CYW43_AUTH_WPA2_AES_PSK : CYW43_AUTH_OPEN;
+    cyw43_arch_wifi_connect_async((const char *)ssid, (const char *)password, auth_mode);
     // TODO: Implement authmode check like in espressif
 
     while (port_get_raw_ticks(NULL) < deadline) {

--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -264,7 +264,10 @@ void supervisor_start_web_workflow(void) {
     }
 
     result = common_hal_os_getenv_str("CIRCUITPY_WIFI_PASSWORD", password, sizeof(password));
-    if (result != GETENV_OK) {
+    if (result == GETENV_ERR_NOT_FOUND) {
+        // if password is unspecified, assume an open network
+        password[0] = '\0';
+    } else if (result != GETENV_OK) {
         return;
     }
 


### PR DESCRIPTION
Now, open wifi works on Pico W, so this closes #7438.

For the web workflow it's now OK to either
 * specify an empty password string (as before)
 * not have the CIRCUITPY_WIFI_PASSWORD key at all (new functionality)