### PR TITLE
Multiple CI Enhancements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,29 +21,54 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       build-doc: ${{ steps.set-matrix.outputs.build-doc }}
-      boards-arm: ${{ steps.set-matrix.outputs.boards-arm }}
-      boards-riscv: ${{ steps.set-matrix.outputs.boards-riscv }}
-      boards-espressif: ${{ steps.set-matrix.outputs.boards-espressif }}
       boards-aarch: ${{ steps.set-matrix.outputs.boards-aarch }}
+      boards-arm: ${{ steps.set-matrix.outputs.boards-arm }}
+      boards-espressif: ${{ steps.set-matrix.outputs.boards-espressif }}
+      boards-riscv: ${{ steps.set-matrix.outputs.boards-riscv }}
+      cp-version: ${{ steps.cp-version.outputs.cp-version }}
     steps:
     - name: Dump GitHub context
       run: echo "$GITHUB_CONTEXT"
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
-    - uses: actions/checkout@v3
+    - name: Set up repository
+      uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
-    - name: Set up Python 3
+    - name: Set up python
       uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-    - name: Get CP deps
-      run: python tools/ci_fetch_deps.py test ${{ github.sha }}
-    - name: CircuitPython version
+    - name: Duplicate USB VID/PID check
+      run: python3 -u -m tools.ci_check_duplicate_usb_vid_pid
+    - name: Create submodule status
+      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+    - name: Cache submodules
+      uses: actions/cache@v3
+      with:
+        path: |
+          .git/modules/
+          extmod/ulab
+          frozen/
+          lib/
+          tools/
+        key: submodules-common-${{ hashFiles('submodule_status') }}
+    - name: CircuitPython dependencies
       run: |
-        tools/describe || git log --parents HEAD~4..
-        echo >>$GITHUB_ENV CP_VERSION=$(tools/describe)
+        python tools/ci_fetch_deps.py ${{ github.job }}
+        echo "::group::Fetch history and tags"
+        git fetch --no-recurse-submodules --shallow-since="2021-07-01" --tags https://github.com/adafruit/circuitpython HEAD
+        git fetch --no-recurse-submodules --shallow-since="2021-07-01" origin $GITHUB_SHA
+        git repack -d
+        echo "::endgroup::"
+    - name: CircuitPython version
+      id: cp-version
+      run: |
+        CP_VERSION=$(tools/describe)
+        echo "$CP_VERSION"
+        echo "CP_VERSION=$CP_VERSION" >> $GITHUB_ENV
+        echo "cp-version=$CP_VERSION" >> $GITHUB_OUTPUT
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -54,8 +79,6 @@ jobs:
       run: |
         gcc --version
         python3 --version
-    - name: Duplicate USB VID/PID Check
-      run: python3 -u -m tools.ci_check_duplicate_usb_vid_pid
     - name: Build mpy-cross
       run: make -C mpy-cross -j2
     - name: Build unix port
@@ -160,25 +183,36 @@ jobs:
 
   mpy-cross-mac:
     runs-on: macos-11
+    needs: test
+    if: ${{ needs.test.outputs.boards-aarch != '[]' || needs.test.outputs.boards-arm != '[]' || needs.scheduler.test.boards-espressif != '[]' || needs.scheduler.test.boards-riscv != '[]' }}
+    env:
+      CP_VERSION: ${{ needs.test.outputs.cp-version }}
     steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - uses: actions/checkout@v3
+    - name: Set up repository
+      uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
-    - name: Set up Python 3
+    - name: Set up python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
-    - name: Get CP deps
-      run: python tools/ci_fetch_deps.py mpy-cross-mac ${{ github.sha }}
+        python-version: "3.x"
+    - name: Create submodule status
+      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+    - name: Restore submodules
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          .git/modules/
+          extmod/ulab
+          frozen/
+          lib/
+          tools/
+        key: submodules-common-${{ hashFiles('submodule_status') }}
+    - name: CircuitPython dependencies
+      run: python tools/ci_fetch_deps.py ${{ github.job }}
     - name: CircuitPython version
-      run: |
-        tools/describe || git log --parents HEAD~4..
-        echo >>$GITHUB_ENV CP_VERSION=$(tools/describe)
+      run: tools/describe
     - name: Install dependencies
       run: |
         brew install gettext
@@ -222,21 +256,34 @@ jobs:
     runs-on: ubuntu-20.04
     needs: test
     if: ${{ needs.test.outputs.build-doc == 'True' }}
+    env:
+      CP_VERSION: ${{ needs.test.outputs.cp-version }}
     steps:
-    - uses: actions/checkout@v3
+    - name: Set up repository
+      uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
-    - name: Get CP deps
-      run: python tools/ci_fetch_deps.py docs ${{ github.sha }}
+    - name: Create submodule status
+      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+    - name: Restore submodules
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          .git/modules/
+          extmod/ulab
+          frozen/
+          lib/
+          tools/
+        key: submodules-common-${{ hashFiles('submodule_status') }}
+    - name: CircuitPython dependencies
+      run: python tools/ci_fetch_deps.py ${{ github.job }}
     - name: CircuitPython version
-      run: |
-        tools/describe || git log --parents HEAD~4..
-        echo >>$GITHUB_ENV CP_VERSION=$(tools/describe)
-    - name: Set up Python 3
+      run: tools/describe
+    - name: Set up python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.x"
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -285,22 +332,37 @@ jobs:
   build-arm:
     runs-on: ubuntu-20.04
     needs: test
+    if: ${{ needs.test.outputs.boards-arm != '[]' }}
+    env:
+      CP_VERSION: ${{ needs.test.outputs.cp-version }}
     strategy:
       fail-fast: false
       matrix:
         board: ${{ fromJSON(needs.test.outputs.boards-arm) }}
-    if: ${{ needs.test.outputs.boards-arm != '[]' }}
     steps:
-    - name: Set up Python 3
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-    - uses: actions/checkout@v3
+    - name: Set up repository
+      uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
-    - name: Get CP deps
-      run: python tools/ci_fetch_deps.py ${{ matrix.board }} ${{ github.sha }}
+    - name: Set up python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Create submodule status
+      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+    - name: Restore submodules
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          .git/modules/
+          extmod/ulab
+          frozen/
+          lib/
+          tools/
+        key: submodules-common-${{ hashFiles('submodule_status') }}
+    - name: CircuitPython dependencies
+      run: python tools/ci_fetch_deps.py ${{ matrix.board }}
     - uses: carlosperate/arm-none-eabi-gcc-action@v1
       with:
         release: '10-2020-q4'
@@ -338,22 +400,37 @@ jobs:
   build-riscv:
     runs-on: ubuntu-20.04
     needs: test
+    if: ${{ needs.test.outputs.boards-riscv != '[]' }}
+    env:
+      CP_VERSION: ${{ needs.test.outputs.cp-version }}
     strategy:
       fail-fast: false
       matrix:
         board: ${{ fromJSON(needs.test.outputs.boards-riscv) }}
-    if: ${{ needs.test.outputs.boards-riscv != '[]' }}
     steps:
-    - name: Set up Python 3
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-    - uses: actions/checkout@v3
+    - name: Set up repository
+      uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
-    - name: Get CP deps
-      run: python tools/ci_fetch_deps.py ${{ matrix.board }} ${{ github.sha }}
+    - name: Set up python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Create submodule status
+      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+    - name: Restore submodules
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          .git/modules/
+          extmod/ulab
+          frozen/
+          lib/
+          tools/
+        key: submodules-common-${{ hashFiles('submodule_status') }}
+    - name: CircuitPython dependencies
+      run: python tools/ci_fetch_deps.py ${{ matrix.board }}
     - name: Install dependencies
       run: |
         sudo apt-get install -y gettext
@@ -390,27 +467,40 @@ jobs:
   build-espressif:
     runs-on: ubuntu-20.04
     needs: test
+    if: ${{ needs.test.outputs.boards-espressif != '[]' }}
+    env:
+      CP_VERSION: ${{ needs.test.outputs.cp-version }}
     strategy:
       fail-fast: false
       matrix:
         board: ${{ fromJSON(needs.test.outputs.boards-espressif) }}
-    if: ${{ needs.test.outputs.boards-espressif != '[]' }}
     steps:
-    - name: Set up Python 3
+    - name: Set up repository
+      uses: actions/checkout@v3
+      with:
+        submodules: false
+        fetch-depth: 1
+    - name: Set up python
       id: py3
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-    - uses: actions/checkout@v3
+    - name: Create submodule status
+      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+    - name: Restore submodules
+      uses: actions/cache/restore@v3
       with:
-        submodules: false
-        fetch-depth: 1
-    - name: Get CP deps
-      run: python tools/ci_fetch_deps.py ${{ matrix.board }} ${{ github.sha }}
+        path: |
+          .git/modules/
+          extmod/ulab
+          frozen/
+          lib/
+          tools/
+        key: submodules-common-${{ hashFiles('submodule_status') }}
+    - name: CircuitPython dependencies
+      run: python tools/ci_fetch_deps.py ${{ matrix.board }}
     - name: CircuitPython version
-      run: |
-        tools/describe || git log --parents HEAD~4..
-        echo >>$GITHUB_ENV CP_VERSION=$(tools/describe)
+      run: tools/describe
     - uses: actions/cache@v3
       name: Fetch IDF tool cache
       id: idf-cache
@@ -481,22 +571,37 @@ jobs:
   build-aarch:
     runs-on: ubuntu-20.04
     needs: test
+    if: ${{ needs.test.outputs.boards-aarch != '[]' }}
+    env:
+      CP_VERSION: ${{ needs.test.outputs.cp-version }}
     strategy:
       fail-fast: false
       matrix:
         board: ${{ fromJSON(needs.test.outputs.boards-aarch) }}
-    if: ${{ needs.test.outputs.boards-aarch != '[]' }}
     steps:
-    - name: Set up Python 3
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-    - uses: actions/checkout@v3
+    - name: Set up repository
+      uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
-    - name: Get CP deps
-      run: python tools/ci_fetch_deps.py ${{ matrix.board }} ${{ github.sha }}
+    - name: Set up python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Create submodule status
+      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+    - name: Restore submodules
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          .git/modules/
+          extmod/ulab
+          frozen/
+          lib/
+          tools/
+        key: submodules-common-${{ hashFiles('submodule_status') }}
+    - name: CircuitPython dependencies
+      run: python tools/ci_fetch_deps.py ${{ matrix.board }}
     - name: Install dependencies
       run: |
         sudo apt-get install -y gettext mtools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -523,7 +523,7 @@ jobs:
         path: ${{ github.workspace }}/.idf_tools
         key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/espressif/esp-idf/HEAD') }}-${{ steps.py3.outputs.python-path }}-20220404
     - name: Clone IDF submodules
-      run: git submodule update --init $IDF_PATH
+      run: cd $IDF_PATH && git submodule update --init --depth=1
       env:
         IDF_PATH: ${{ github.workspace }}/ports/espressif/esp-idf
     - name: Install IDF tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y eatmydata
         sudo eatmydata apt-get install -y gettext gcc-aarch64-linux-gnu mingw-w64
-        pip install -r requirements-ci.txt -r requirements-dev.txt
+        pip install -r requirements-dev.txt
     - name: Versions
       run: |
         gcc --version
@@ -136,13 +136,14 @@ jobs:
       with:
         name: mpy-cross.static-x64-windows
         path: mpy-cross/mpy-cross.static.exe
-    - name: Upload mpy-cross builds to S3
+    - name: Upload to S3
       if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
+        pip install awscli
         [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross/mpy-cross.static-aarch64 s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross.static-aarch64-${{ env.CP_VERSION }} --no-progress --region us-east-1
         [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross/mpy-cross.static-raspbian s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross.static-raspbian-${{ env.CP_VERSION }} --no-progress --region us-east-1
         [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp mpy-cross/mpy-cross.static s3://adafruit-circuit-python/bin/mpy-cross/mpy-cross.static-amd64-linux-${{ env.CP_VERSION }} --no-progress --region us-east-1
@@ -286,7 +287,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y eatmydata
         sudo eatmydata apt-get install -y latexmk librsvg2-bin texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra
-        pip install -r requirements-ci.txt -r requirements-doc.txt
+        pip install -r requirements-doc.txt
     - name: Build and Validate Stubs
       run: make check-stubs -j2
     - uses: actions/upload-artifact@v3
@@ -306,13 +307,14 @@ jobs:
       with:
         name: docs
         path: _build/latex
-    - name: Upload stubs to S3
+    - name: Upload to S3
       if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
+        pip install awscli
         zip -9r circuitpython-stubs.zip circuitpython-stubs
         [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp circuitpython-stubs/dist/*.tar.gz s3://adafruit-circuit-python/bin/stubs/circuitpython-stubs-${{ env.CP_VERSION }}.zip --no-progress --region us-east-1
     - name: Upload stubs to PyPi
@@ -363,7 +365,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y gettext mtools
-        pip install -r requirements-ci.txt -r requirements-dev.txt
+        pip install -r requirements-dev.txt
         wget --no-verbose https://adafruit-circuit-python.s3.amazonaws.com/gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz
         sudo tar -C /usr --strip-components=1 -xaf gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz
     - uses: carlosperate/arm-none-eabi-gcc-action@v1
@@ -400,7 +402,9 @@ jobs:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
     - name: Upload to S3
-      run: "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
+      run: |
+        pip install awscli
+        "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -448,7 +452,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y gettext
-        pip install -r requirements-ci.txt -r requirements-dev.txt
+        pip install -r requirements-dev.txt
     - name: Versions
       run: |
         gcc --version
@@ -469,7 +473,9 @@ jobs:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
     - name: Upload to S3
-      run: "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
+      run: |
+        pip install awscli
+        "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -539,7 +545,7 @@ jobs:
       run: |
         source $IDF_PATH/export.sh
         sudo apt-get install -y gettext ninja-build
-        pip install -r requirements-ci.txt -r requirements-dev.txt
+        pip install -r requirements-dev.txt
       env:
         IDF_PATH: ${{ github.workspace }}/ports/espressif/esp-idf
         IDF_TOOLS_PATH: ${{ github.workspace }}/.idf_tools
@@ -574,7 +580,9 @@ jobs:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
     - name: Upload to S3
-      run: "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
+      run: |
+        pip install awscli
+        "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -619,7 +627,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y gettext
-        pip install -r requirements-ci.txt -r requirements-dev.txt
+        pip install -r requirements-dev.txt
         wget https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-centos6.tar.gz
         sudo tar -C /usr --strip-components=1 -xaf riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-centos6.tar.gz
     - name: Versions
@@ -642,7 +650,9 @@ jobs:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
     - name: Upload to S3
-      run: "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
+      run: |
+        pip install awscli
+        "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,14 +43,13 @@ jobs:
     - name: Duplicate USB VID/PID check
       run: python3 -u -m tools.ci_check_duplicate_usb_vid_pid
     - name: Create submodule status
-      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
     - name: Cache submodules
       uses: actions/cache@v3
       with:
         path: |
           .git/modules/
           extmod/ulab
-          frozen/
           lib/
           tools/
         key: submodules-common-${{ hashFiles('submodule_status') }}
@@ -198,14 +197,13 @@ jobs:
       with:
         python-version: "3.x"
     - name: Create submodule status
-      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
         path: |
           .git/modules/
           extmod/ulab
-          frozen/
           lib/
           tools/
         key: submodules-common-${{ hashFiles('submodule_status') }}
@@ -265,14 +263,13 @@ jobs:
         submodules: false
         fetch-depth: 1
     - name: Create submodule status
-      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
         path: |
           .git/modules/
           extmod/ulab
-          frozen/
           lib/
           tools/
         key: submodules-common-${{ hashFiles('submodule_status') }}
@@ -350,18 +347,18 @@ jobs:
       with:
         python-version: "3.x"
     - name: Create submodule status
-      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
         path: |
           .git/modules/
           extmod/ulab
-          frozen/
           lib/
           tools/
         key: submodules-common-${{ hashFiles('submodule_status') }}
     - name: CircuitPython dependencies
+      id: cp-deps
       run: python tools/ci_fetch_deps.py ${{ matrix.board }}
     - uses: carlosperate/arm-none-eabi-gcc-action@v1
       with:
@@ -375,11 +372,12 @@ jobs:
         gcc --version
         arm-none-eabi-gcc --version
         python3 --version
-    - name: mpy-cross
+    - name: Build mpy-cross
+      if: ${{ steps.cp-deps.outputs.frozen_tags == 'True' }}
       run: make -C mpy-cross -j2
     - name: Setup build failure matcher
       run: echo "::add-matcher::$GITHUB_WORKSPACE/.github/workflows/match-build-fail.json"
-    - name: build
+    - name: Build
       run: python3 -u build_release_files.py
       working-directory: tools
       env:
@@ -418,18 +416,18 @@ jobs:
       with:
         python-version: "3.x"
     - name: Create submodule status
-      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
         path: |
           .git/modules/
           extmod/ulab
-          frozen/
           lib/
           tools/
         key: submodules-common-${{ hashFiles('submodule_status') }}
     - name: CircuitPython dependencies
+      id: cp-deps
       run: python tools/ci_fetch_deps.py ${{ matrix.board }}
     - name: Install dependencies
       run: |
@@ -442,11 +440,12 @@ jobs:
         gcc --version
         riscv64-unknown-elf-gcc --version
         python3 --version
-    - name: mpy-cross
+    - name: Build mpy-cross
+      if: ${{ steps.cp-deps.outputs.frozen_tags == 'True' }}
       run: make -C mpy-cross -j2
     - name: Setup build failure matcher
       run: echo "::add-matcher::$GITHUB_WORKSPACE/.github/workflows/match-build-fail.json"
-    - name: build
+    - name: Build
       run: python3 -u build_release_files.py
       working-directory: tools
       env:
@@ -486,18 +485,18 @@ jobs:
       with:
         python-version: "3.10"
     - name: Create submodule status
-      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
         path: |
           .git/modules/
           extmod/ulab
-          frozen/
           lib/
           tools/
         key: submodules-common-${{ hashFiles('submodule_status') }}
     - name: CircuitPython dependencies
+      id: cp-deps
       run: python tools/ci_fetch_deps.py ${{ matrix.board }}
     - name: CircuitPython version
       run: tools/describe
@@ -541,11 +540,12 @@ jobs:
       env:
         IDF_PATH: ${{ github.workspace }}/ports/espressif/esp-idf
         IDF_TOOLS_PATH: ${{ github.workspace }}/.idf_tools
-    - name: mpy-cross
+    - name: Build mpy-cross
+      if: ${{ steps.cp-deps.outputs.frozen_tags == 'True' }}
       run: make -C mpy-cross -j2
     - name: Setup build failure matcher
       run: echo "::add-matcher::$GITHUB_WORKSPACE/.github/workflows/match-build-fail.json"
-    - name: build
+    - name: Build
       run: |
         source $IDF_PATH/export.sh
         python3 -u build_release_files.py
@@ -589,18 +589,18 @@ jobs:
       with:
         python-version: "3.x"
     - name: Create submodule status
-      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
         path: |
           .git/modules/
           extmod/ulab
-          frozen/
           lib/
           tools/
         key: submodules-common-${{ hashFiles('submodule_status') }}
     - name: CircuitPython dependencies
+      id: cp-deps
       run: python tools/ci_fetch_deps.py ${{ matrix.board }}
     - name: Install dependencies
       run: |
@@ -627,11 +627,12 @@ jobs:
         arm-none-eabi-gcc --version
         python3 --version
         mkfs.fat --version || true
-    - name: mpy-cross
+    - name: Build mpy-cross
+      if: ${{ steps.cp-deps.outputs.frozen_tags == 'True' }}
       run: make -C mpy-cross -j2
     - name: Setup build failure matcher
       run: echo "::add-matcher::$GITHUB_WORKSPACE/.github/workflows/match-build-fail.json"
-    - name: build
+    - name: Build
       run: python3 -u build_release_files.py
       working-directory: tools
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  CACHE_SUBMODULES: "['extmod/ulab', 'lib/', 'tools/']"
+
 jobs:
   test:
     runs-on: ubuntu-20.04
@@ -43,15 +46,11 @@ jobs:
     - name: Duplicate USB VID/PID check
       run: python3 -u -m tools.ci_check_duplicate_usb_vid_pid
     - name: Create submodule status
-      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
+      run: git submodule status ${{ join(fromJSON(env.CACHE_SUBMODULES), ' ') }} >> submodule_status
     - name: Cache submodules
       uses: actions/cache@v3
       with:
-        path: |
-          .git/modules/
-          extmod/ulab
-          lib/
-          tools/
+        path: ".git/modules/\n${{ join(fromJSON(env.CACHE_SUBMODULES), '\n') }}"
         key: submodules-common-${{ hashFiles('submodule_status') }}
     - name: CircuitPython dependencies
       run: |
@@ -137,7 +136,9 @@ jobs:
         name: mpy-cross.static-x64-windows
         path: mpy-cross/mpy-cross.static.exe
     - name: Upload to S3
-      if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
+      if: >-
+        (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') ||
+        (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -184,7 +185,11 @@ jobs:
   mpy-cross-mac:
     runs-on: macos-11
     needs: test
-    if: ${{ needs.test.outputs.boards-aarch != '[]' || needs.test.outputs.boards-arm != '[]' || needs.scheduler.test.boards-espressif != '[]' || needs.scheduler.test.boards-riscv != '[]' }}
+    if: >-
+      needs.test.outputs.boards-aarch != '[]' ||
+      needs.test.outputs.boards-arm != '[]' ||
+      needs.test.outputs.boards-espressif != '[]' ||
+      needs.test.outputs.boards-riscv != '[]'
     env:
       CP_VERSION: ${{ needs.test.outputs.cp-version }}
     steps:
@@ -198,15 +203,11 @@ jobs:
       with:
         python-version: "3.x"
     - name: Create submodule status
-      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
+      run: git submodule status ${{ join(fromJSON(env.CACHE_SUBMODULES), ' ') }} >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
-        path: |
-          .git/modules/
-          extmod/ulab
-          lib/
-          tools/
+        path: ".git/modules/\n${{ join(fromJSON(env.CACHE_SUBMODULES), '\n') }}"
         key: submodules-common-${{ hashFiles('submodule_status') }}
     - name: CircuitPython dependencies
       run: python tools/ci_fetch_deps.py ${{ github.job }}
@@ -260,15 +261,11 @@ jobs:
         submodules: false
         fetch-depth: 1
     - name: Create submodule status
-      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
+      run: git submodule status ${{ join(fromJSON(env.CACHE_SUBMODULES), ' ') }} >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
-        path: |
-          .git/modules/
-          extmod/ulab
-          lib/
-          tools/
+        path: ".git/modules/\n${{ join(fromJSON(env.CACHE_SUBMODULES), '\n') }}"
         key: submodules-common-${{ hashFiles('submodule_status') }}
     - name: CircuitPython dependencies
       run: python tools/ci_fetch_deps.py ${{ github.job }}
@@ -304,7 +301,9 @@ jobs:
         name: docs
         path: _build/latex
     - name: Upload to S3
-      if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
+      if: >-
+        (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') ||
+        (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -345,15 +344,11 @@ jobs:
       with:
         python-version: "3.x"
     - name: Create submodule status
-      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
+      run: git submodule status ${{ join(fromJSON(env.CACHE_SUBMODULES), ' ') }} >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
-        path: |
-          .git/modules/
-          extmod/ulab
-          lib/
-          tools/
+        path: ".git/modules/\n${{ join(fromJSON(env.CACHE_SUBMODULES), '\n') }}"
         key: submodules-common-${{ hashFiles('submodule_status') }}
     - name: CircuitPython dependencies
       id: cp-deps
@@ -398,14 +393,16 @@ jobs:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
     - name: Upload to S3
+      if: >-
+        (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') ||
+        (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
       run: |
         pip install awscli
-        "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
+        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
 
 
   build-arm:
@@ -429,15 +426,11 @@ jobs:
       with:
         python-version: "3.x"
     - name: Create submodule status
-      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
+      run: git submodule status ${{ join(fromJSON(env.CACHE_SUBMODULES), ' ') }} >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
-        path: |
-          .git/modules/
-          extmod/ulab
-          lib/
-          tools/
+        path: ".git/modules/\n${{ join(fromJSON(env.CACHE_SUBMODULES), '\n') }}"
         key: submodules-common-${{ hashFiles('submodule_status') }}
     - name: CircuitPython dependencies
       id: cp-deps
@@ -469,14 +462,17 @@ jobs:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
     - name: Upload to S3
+      if: >-
+        (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') ||
+        (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
       run: |
         pip install awscli
-        "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
+        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
+
 
 
   build-espressif:
@@ -503,15 +499,11 @@ jobs:
       with:
         python-version: "3.10"
     - name: Create submodule status
-      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
+      run: git submodule status ${{ join(fromJSON(env.CACHE_SUBMODULES), ' ') }} >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
-        path: |
-          .git/modules/
-          extmod/ulab
-          lib/
-          tools/
+        path: ".git/modules/\n${{ join(fromJSON(env.CACHE_SUBMODULES), '\n') }}"
         key: submodules-common-${{ hashFiles('submodule_status') }}
     - name: Get IDF commit
       id: idf-commit
@@ -535,7 +527,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ env.IDF_TOOLS_PATH }}
-        key: ${{ runner.os }}-idf-tools-${{ steps.idf-commit.outputs.commit }}-${{ steps.setup-python.outputs.python-version }}
+        key: ${{ runner.os }}-Python-${{ steps.setup-python.outputs.python-version }}-tools-idf-${{ steps.idf-commit.outputs.commit }}
     - name: Clone IDF submodules
       run: git submodule update --init --depth=1
       working-directory: ${{ env.IDF_PATH }}
@@ -576,14 +568,16 @@ jobs:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
     - name: Upload to S3
+      if: >-
+        (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') ||
+        (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
       run: |
         pip install awscli
-        "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
+        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
 
 
   build-riscv:
@@ -607,15 +601,11 @@ jobs:
       with:
         python-version: "3.x"
     - name: Create submodule status
-      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
+      run: git submodule status ${{ join(fromJSON(env.CACHE_SUBMODULES), ' ') }} >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
-        path: |
-          .git/modules/
-          extmod/ulab
-          lib/
-          tools/
+        path: ".git/modules/\n${{ join(fromJSON(env.CACHE_SUBMODULES), '\n') }}"
         key: submodules-common-${{ hashFiles('submodule_status') }}
     - name: CircuitPython dependencies
       id: cp-deps
@@ -646,11 +636,13 @@ jobs:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
     - name: Upload to S3
+      if: >-
+        (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') ||
+        (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
       run: |
         pip install awscli
-        "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
+        [ -z "$AWS_ACCESS_KEY_ID" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1
       env:
         AWS_PAGER: ''
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,10 +212,6 @@ jobs:
       run: python tools/ci_fetch_deps.py ${{ github.job }}
     - name: CircuitPython version
       run: tools/describe
-    - name: Install dependencies
-      run: |
-        brew install gettext
-        echo >>$GITHUB_PATH /usr/local/opt/gettext/bin
     - name: Versions
       run: |
         gcc --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -485,6 +485,8 @@ jobs:
     if: ${{ needs.test.outputs.boards-espressif != '[]' }}
     env:
       CP_VERSION: ${{ needs.test.outputs.cp-version }}
+      IDF_PATH: ${{ github.workspace }}/ports/espressif/esp-idf
+      IDF_TOOLS_PATH: ${{ github.workspace }}/.idf_tools
     strategy:
       fail-fast: false
       matrix:
@@ -496,7 +498,7 @@ jobs:
         submodules: false
         fetch-depth: 1
     - name: Set up python
-      id: py3
+      id: setup-python
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
@@ -511,21 +513,32 @@ jobs:
           lib/
           tools/
         key: submodules-common-${{ hashFiles('submodule_status') }}
+    - name: Get IDF commit
+      id: idf-commit
+      run: |
+        COMMIT=$(git submodule status ports/espressif/esp-idf | grep -o -P '(?<=^-).*(?= )')
+        echo "$COMMIT"
+        echo "commit=$COMMIT" >> $GITHUB_OUTPUT
+    - name: Cache IDF submodules
+      uses: actions/cache@v3
+      with:
+        path: |
+          .git/modules/ports/espressif/esp-idf
+          ports/espressif/esp-idf
+        key: submodules-idf-${{ steps.idf-commit.outputs.commit }}
     - name: CircuitPython dependencies
       id: cp-deps
       run: python tools/ci_fetch_deps.py ${{ matrix.board }}
     - name: CircuitPython version
       run: tools/describe
-    - uses: actions/cache@v3
-      name: Fetch IDF tool cache
-      id: idf-cache
+    - name: Cache IDF tools
+      uses: actions/cache@v3
       with:
-        path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/ports/espressif/esp-idf/HEAD') }}-${{ steps.py3.outputs.python-path }}-20220404
+        path: ${{ env.IDF_TOOLS_PATH }}
+        key: ${{ runner.os }}-idf-tools-${{ steps.idf-commit.outputs.commit }}-${{ steps.setup-python.outputs.python-version }}
     - name: Clone IDF submodules
-      run: cd $IDF_PATH && git submodule update --init --depth=1
-      env:
-        IDF_PATH: ${{ github.workspace }}/ports/espressif/esp-idf
+      run: git submodule update --init --depth=1
+      working-directory: ${{ env.IDF_PATH }}
     - name: Install IDF tools
       run: |
         echo "Installing ESP-IDF tools"
@@ -534,17 +547,11 @@ jobs:
         echo "Installing Python environment and packages"
         $IDF_PATH/tools/idf_tools.py --non-interactive install-python-env
         rm -rf $IDF_TOOLS_PATH/dist
-      env:
-        IDF_PATH: ${{ github.workspace }}/ports/espressif/esp-idf
-        IDF_TOOLS_PATH: ${{ github.workspace }}/.idf_tools
     - name: Install dependencies
       run: |
         source $IDF_PATH/export.sh
         sudo apt-get install -y gettext ninja-build
         pip install -r requirements-dev.txt
-      env:
-        IDF_PATH: ${{ github.workspace }}/ports/espressif/esp-idf
-        IDF_TOOLS_PATH: ${{ github.workspace }}/.idf_tools
     - name: Versions
       run: |
         source $IDF_PATH/export.sh
@@ -552,10 +559,6 @@ jobs:
         python3 --version
         ninja --version
         cmake --version
-      shell: bash
-      env:
-        IDF_PATH: ${{ github.workspace }}/ports/espressif/esp-idf
-        IDF_TOOLS_PATH: ${{ github.workspace }}/.idf_tools
     - name: Build mpy-cross
       if: ${{ steps.cp-deps.outputs.frozen_tags == 'True' }}
       run: make -C mpy-cross -j2
@@ -566,10 +569,7 @@ jobs:
         source $IDF_PATH/export.sh
         python3 -u build_release_files.py
       working-directory: tools
-      shell: bash
       env:
-        IDF_PATH: ${{ github.workspace }}/ports/espressif/esp-idf
-        IDF_TOOLS_PATH: ${{ github.workspace }}/.idf_tools
         BOARDS: ${{ matrix.board }}
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -326,6 +326,88 @@ jobs:
         [ -z "$TWINE_USERNAME" ] || twine upload circuitpython-stubs/dist/*
 
 
+  build-aarch:
+    runs-on: ubuntu-20.04
+    needs: test
+    if: ${{ needs.test.outputs.boards-aarch != '[]' }}
+    env:
+      CP_VERSION: ${{ needs.test.outputs.cp-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        board: ${{ fromJSON(needs.test.outputs.boards-aarch) }}
+    steps:
+    - name: Set up repository
+      uses: actions/checkout@v3
+      with:
+        submodules: false
+        fetch-depth: 1
+    - name: Set up python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Create submodule status
+      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
+    - name: Restore submodules
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          .git/modules/
+          extmod/ulab
+          lib/
+          tools/
+        key: submodules-common-${{ hashFiles('submodule_status') }}
+    - name: CircuitPython dependencies
+      id: cp-deps
+      run: python tools/ci_fetch_deps.py ${{ matrix.board }}
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y gettext mtools
+        pip install -r requirements-ci.txt -r requirements-dev.txt
+        wget --no-verbose https://adafruit-circuit-python.s3.amazonaws.com/gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz
+        sudo tar -C /usr --strip-components=1 -xaf gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz
+    - uses: carlosperate/arm-none-eabi-gcc-action@v1
+      with:
+        release: '10-2020-q4'
+    - name: Install mkfs.fat
+      run: |
+        wget https://github.com/dosfstools/dosfstools/releases/download/v4.2/dosfstools-4.2.tar.gz
+        tar -xaf dosfstools-4.2.tar.gz
+        cd dosfstools-4.2
+        ./configure
+        make -j 2
+        cd src
+        echo >>$GITHUB_PATH $(pwd)
+    - name: Versions
+      run: |
+        gcc --version
+        aarch64-none-elf-gcc --version
+        arm-none-eabi-gcc --version
+        python3 --version
+        mkfs.fat --version || true
+    - name: Build mpy-cross
+      if: ${{ steps.cp-deps.outputs.frozen_tags == 'True' }}
+      run: make -C mpy-cross -j2
+    - name: Setup build failure matcher
+      run: echo "::add-matcher::$GITHUB_WORKSPACE/.github/workflows/match-build-fail.json"
+    - name: Build
+      run: python3 -u build_release_files.py
+      working-directory: tools
+      env:
+        BOARDS: ${{ matrix.board }}
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.board }}
+        path: bin/${{ matrix.board }}
+    - name: Upload to S3
+      run: "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
+      env:
+        AWS_PAGER: ''
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
+
+
   build-arm:
     runs-on: ubuntu-20.04
     needs: test
@@ -371,74 +453,6 @@ jobs:
       run: |
         gcc --version
         arm-none-eabi-gcc --version
-        python3 --version
-    - name: Build mpy-cross
-      if: ${{ steps.cp-deps.outputs.frozen_tags == 'True' }}
-      run: make -C mpy-cross -j2
-    - name: Setup build failure matcher
-      run: echo "::add-matcher::$GITHUB_WORKSPACE/.github/workflows/match-build-fail.json"
-    - name: Build
-      run: python3 -u build_release_files.py
-      working-directory: tools
-      env:
-        BOARDS: ${{ matrix.board }}
-    - uses: actions/upload-artifact@v3
-      with:
-        name: ${{ matrix.board }}
-        path: bin/${{ matrix.board }}
-    - name: Upload to S3
-      run: "[ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp bin/ s3://adafruit-circuit-python/bin/ --recursive --no-progress --region us-east-1"
-      env:
-        AWS_PAGER: ''
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
-
-
-  build-riscv:
-    runs-on: ubuntu-20.04
-    needs: test
-    if: ${{ needs.test.outputs.boards-riscv != '[]' }}
-    env:
-      CP_VERSION: ${{ needs.test.outputs.cp-version }}
-    strategy:
-      fail-fast: false
-      matrix:
-        board: ${{ fromJSON(needs.test.outputs.boards-riscv) }}
-    steps:
-    - name: Set up repository
-      uses: actions/checkout@v3
-      with:
-        submodules: false
-        fetch-depth: 1
-    - name: Set up python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.x"
-    - name: Create submodule status
-      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
-    - name: Restore submodules
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          .git/modules/
-          extmod/ulab
-          lib/
-          tools/
-        key: submodules-common-${{ hashFiles('submodule_status') }}
-    - name: CircuitPython dependencies
-      id: cp-deps
-      run: python tools/ci_fetch_deps.py ${{ matrix.board }}
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y gettext
-        pip install -r requirements-ci.txt -r requirements-dev.txt
-        wget https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-centos6.tar.gz
-        sudo tar -C /usr --strip-components=1 -xaf riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-centos6.tar.gz
-    - name: Versions
-      run: |
-        gcc --version
-        riscv64-unknown-elf-gcc --version
         python3 --version
     - name: Build mpy-cross
       if: ${{ steps.cp-deps.outputs.frozen_tags == 'True' }}
@@ -568,16 +582,16 @@ jobs:
       if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') || (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
 
 
-  build-aarch:
+  build-riscv:
     runs-on: ubuntu-20.04
     needs: test
-    if: ${{ needs.test.outputs.boards-aarch != '[]' }}
+    if: ${{ needs.test.outputs.boards-riscv != '[]' }}
     env:
       CP_VERSION: ${{ needs.test.outputs.cp-version }}
     strategy:
       fail-fast: false
       matrix:
-        board: ${{ fromJSON(needs.test.outputs.boards-aarch) }}
+        board: ${{ fromJSON(needs.test.outputs.boards-riscv) }}
     steps:
     - name: Set up repository
       uses: actions/checkout@v3
@@ -604,29 +618,15 @@ jobs:
       run: python tools/ci_fetch_deps.py ${{ matrix.board }}
     - name: Install dependencies
       run: |
-        sudo apt-get install -y gettext mtools
+        sudo apt-get install -y gettext
         pip install -r requirements-ci.txt -r requirements-dev.txt
-        wget --no-verbose https://adafruit-circuit-python.s3.amazonaws.com/gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz
-        sudo tar -C /usr --strip-components=1 -xaf gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz
-    - uses: carlosperate/arm-none-eabi-gcc-action@v1
-      with:
-        release: '10-2020-q4'
-    - name: Install mkfs.fat
-      run: |
-        wget https://github.com/dosfstools/dosfstools/releases/download/v4.2/dosfstools-4.2.tar.gz
-        tar -xaf dosfstools-4.2.tar.gz
-        cd dosfstools-4.2
-        ./configure
-        make -j 2
-        cd src
-        echo >>$GITHUB_PATH $(pwd)
+        wget https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-centos6.tar.gz
+        sudo tar -C /usr --strip-components=1 -xaf riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-centos6.tar.gz
     - name: Versions
       run: |
         gcc --version
-        aarch64-none-elf-gcc --version
-        arm-none-eabi-gcc --version
+        riscv64-unknown-elf-gcc --version
         python3 --version
-        mkfs.fat --version || true
     - name: Build mpy-cross
       if: ${{ steps.cp-deps.outputs.frozen_tags == 'True' }}
       run: make -C mpy-cross -j2

--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
     paths:
-      - '.github/workflows/*.yml'
+      - '.github/workflows/ports_windows.yml'
       - 'extmod/**'
       - 'lib/**'
       - 'mpy-cross/**'
@@ -77,14 +77,13 @@ jobs:
         submodules: false
         fetch-depth: 1
     - name: Create submodule status
-      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+      run: git submodule status extmod/ulab lib/ tools/ >> submodule_status
     - name: Restore submodules
       uses: actions/cache/restore@v3
       with:
         path: |
           .git/modules/
           extmod/ulab
-          frozen/
           lib/
           tools/
         key: submodules-common-${{ hashFiles('submodule_status') }}

--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -71,12 +71,32 @@ jobs:
         which python; python --version; python -c "import cascadetoml"
         which python3; python3 --version; python3 -c "import cascadetoml"
 
-    - uses: actions/checkout@v3
+    - name: Set up repository
+      uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
-    - name: Get CP deps
-      run: python tools/ci_fetch_deps.py windows ${{ github.sha }}
+    - name: Create submodule status
+      run: git submodule status extmod/ulab frozen/ lib/ tools/ >> submodule_status
+    - name: Restore submodules
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          .git/modules/
+          extmod/ulab
+          frozen/
+          lib/
+          tools/
+        key: submodules-common-${{ hashFiles('submodule_status') }}
+        enableCrossOsArchive: true
+    - name: CircuitPython dependencies
+      run: |
+        python tools/ci_fetch_deps.py windows
+        echo "::group::Fetch history and tags"
+        git fetch --no-recurse-submodules --shallow-since="2021-07-01" --tags https://github.com/adafruit/circuitpython HEAD
+        git fetch --no-recurse-submodules --shallow-since="2021-07-01" origin $GITHUB_SHA
+        git repack -d
+        echo "::endgroup::"
     - name: CircuitPython version
       run: |
         tools/describe || git log --parents HEAD~4..

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,2 +1,2 @@
 # For uploading artifacts
-awscli
+# awscli

--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -4,16 +4,12 @@ import subprocess
 import sys
 import time
 
-# target will be a board, "test", "docs", "mpy-cross-mac", or "windows"
-
-target = sys.argv[1]
-ref = sys.argv[2]
-
-print(target, ref)
+# Target will be a board, "test", "docs", "mpy-cross-mac", or "windows"
+TARGET = sys.argv[1]
 
 # Submodules needed by port builds outside of their ports directory.
 # Should we try and detect these?
-port_deps = {
+PORT_DEPS = {
     "atmel-samd": [
         "extmod/ulab/",
         "lib/adafruit_floppy/",
@@ -58,73 +54,58 @@ def run(title, command, check=True):
     try:
         subprocess.run(shlex.split(command), stderr=subprocess.STDOUT, check=check)
     finally:
-        print("Duration:", time.monotonic() - start, flush=True)
         print("::endgroup::", flush=True)
+        print("Duration:", time.monotonic() - start, flush=True)
 
 
-run(
-    "Fetch back to the start of 2021 to get tag history",
-    'git fetch --tags --recurse-submodules=no --shallow-since="2021-07-01" https://github.com/adafruit/circuitpython HEAD',
-)
-run(
-    "Fetch back to the start of 2021 to get commit history",
-    f'git fetch --recurse-submodules=no --shallow-since="2021-07-01" origin {ref}',
-)
-# See https://stackoverflow.com/questions/63878612/git-fatal-error-in-object-unshallow-sha-1#comment118418373_63879454
-run('Fix for bug "fatal: error in object: unshallow"', "git repack -d")
-run("Init submodules", "git submodule init")
-run("Submodule status", "git submodule status")
+def main():
+    submodules = []
+    print("Target:", TARGET)
 
-submodules = []
+    if TARGET == "scheduler":
+        submodules = ["extmod/ulab", "lib/", "tools/", "frozen/"]
+    elif TARGET == "mpy-cross-tests":
+        submodules = ["extmod/ulab", "lib/", "tools/"]
+    elif TARGET == "build-doc":
+        # used in .readthedocs.yml to generate RTD
+        submodules = ["extmod/ulab", "frozen/"]
+    elif TARGET == "mpy-cross-mac":
+        submodules = ["tools/"]  # for huffman
+    elif TARGET == "windows":
+        # This builds one board from a number of ports so fill out a bunch of submodules
+        submodules = ["extmod/ulab", "lib/", "tools/", "ports/", "data/nvm.toml"]
+    elif TARGET == "website":
+        submodules = ["tools/adabot/", "frozen/"]
+    else:
+        p = list(pathlib.Path(".").glob(f"ports/*/boards/{TARGET}/mpconfigboard.mk"))
+        if not p:
+            raise RuntimeError(f"Unsupported target: {TARGET}")
 
-if target == "test":
-    submodules = ["extmod/", "lib/", "tools/", "extmod/ulab", "lib/berkeley-db-1.xx"]
-elif target == "docs":
-    # used in .readthedocs.yml to generate RTD
-    submodules = ["extmod/ulab/", "frozen/"]
-elif target == "mpy-cross-mac":
-    submodules = ["tools/"]  # for huffman
-elif target == "windows":
-    # This builds one board from a number of ports so fill out a bunch of submodules
-    submodules = ["extmod/", "lib/", "tools/", "ports/", "data/nvm.toml/"]
-elif target == "website":
-    submodules = ["tools/adabot/", "frozen/"]
-else:
-    p = list(pathlib.Path(".").glob(f"ports/*/boards/{target}/mpconfigboard.mk"))
-    if not p:
-        raise RuntimeError(f"Unsupported target: {target}")
+        config = p[0]
+        # Add the ports folder to init submodules
+        port_folder = config.parents[2]
+        port = port_folder.name
+        submodules.append(str(port_folder))
+        submodules.append("tools/")  # for huffman
+        submodules.extend(PORT_DEPS[port])
+        with config.open() as f:
+            for line in f.readlines():
+                prefix = "FROZEN_MPY_DIRS += $(TOP)/"
+                if line.startswith(prefix):
+                    lib_folder = line.strip()[len(prefix) :]
+                    # Drop everything after the second folder because the frozen
+                    # folder may be inside the submodule.
+                    if lib_folder.count("/") > 1:
+                        lib_folder = lib_folder.split("/", maxsplit=2)
+                        lib_folder = "/".join(lib_folder[:2])
+                    submodules.append(lib_folder)
 
-    config = p[0]
-    # Add the ports folder to init submodules
-    port_folder = config.parents[2]
-    port = port_folder.name
-    submodules.append(str(port_folder))
-    submodules.append("tools/")  # for huffman
-    submodules.extend(port_deps[port])
-    with config.open() as f:
-        for line in f.readlines():
-            prefix = "FROZEN_MPY_DIRS += $(TOP)/"
-            if line.startswith(prefix):
-                lib_folder = line.strip()[len(prefix) :]
-                # Drop everything after the second folder because the frozen
-                # folder may be inside the submodule.
-                if lib_folder.count("/") > 1:
-                    lib_folder = lib_folder.split("/", maxsplit=2)
-                    lib_folder = "/".join(lib_folder[:2])
-                submodules.append(lib_folder)
+    print("Submodule paths:", submodules)
 
-print(submodules)
-if submodules:
-    submodules = " ".join(submodules)
-    # This line will fail because the submodule's need different commits than the tip of the branch. We
-    # fix it later.
-    run(
-        "Init the submodules we'll need",
-        f"git submodule update --init -N --depth 1 {submodules}",
-        check=False,
-    )
+    if submodules:
+        submodules = " ".join(submodules)
+        run("Init the required submodules", f"git submodule update --init --depth=1 {submodules}")
 
-    run(
-        "Fetch the submodule sha",
-        "git submodule foreach 'git fetch --tags --depth 1 origin $sha1 && git checkout -q $sha1'",
-    )
+
+if __name__ == "__main__":
+    main()

--- a/tools/describe
+++ b/tools/describe
@@ -1,3 +1,6 @@
 #!/bin/sh
-# Add any supplied arguments.
-git describe --first-parent --dirty --tags --match "[1-9].*" "$@"
+if [ -z "$CP_VERSION" ]; then
+    git describe --first-parent --dirty --tags --match "[1-9].*" "$@"
+else
+    echo $CP_VERSION
+fi


### PR DESCRIPTION
This contains the following CI enhancements:

- Cache common submodules: `extmod/ulab`, `lib/` and `tools/`.
- Share CP version across jobs to avoid fetching tags in each and every job.
- Change submodule fetching strategy:
  - tags[Y]: use `git submodule update --init` for frozen.
  - tags[N]: use `git submodule update --init --depth=1` for everything else.
- Only build `mpy-cross` when required by the board.
- Refactor and alphabetically arrange matrix jobs.
- Use python `3.x` for everything except espressif which is on `3.10`.

Through multiple CI runs in my fork, I have found the following way of fetching submodules to be ideal:
- For large submodules (e.g. `ports/`): A shallow-clone with `--depth=1`.
- For smaller submodules (e.g. `extmod/ulab`, `lib/`, `tools/`): Caching has proven effective.
- For smaller submodules with tags (e.g. `frozen`): A normal fetch. I tried partial-clone with `--filter=tree:0` but it doesn't produce a significant difference for small repos.