### PR TITLE
Use low power RTC on mimxrt10xx (Teensy41) boards

### DIFF
--- a/ports/mimxrt10xx/Makefile
+++ b/ports/mimxrt10xx/Makefile
@@ -109,6 +109,7 @@ SRC_SDK := \
 	drivers/fsl_ocotp.c \
 	drivers/fsl_pwm.c \
 	drivers/fsl_snvs_hp.c \
+	drivers/fsl_snvs_lp.c \
 	drivers/fsl_tempmon.c \
 	drivers/fsl_trng.c \
 	system_$(CHIP_FAMILY).c \

--- a/ports/mimxrt10xx/common-hal/rtc/RTC.c
+++ b/ports/mimxrt10xx/common-hal/rtc/RTC.c
@@ -36,18 +36,26 @@
 #include "supervisor/shared/translate/translate.h"
 
 #include "fsl_snvs_hp.h"
+#include "fsl_snvs_lp.h"
 
 void rtc_init(void) {
-    snvs_hp_rtc_config_t config;
-    SNVS_HP_RTC_GetDefaultConfig(&config);
+    snvs_hp_rtc_config_t hpconfig;
+    SNVS_HP_RTC_GetDefaultConfig(&hpconfig);
 
-    SNVS_HP_RTC_Init(SNVS, &config);
+    SNVS_HP_RTC_Init(SNVS, &hpconfig);
+
+    snvs_lp_srtc_config_t lpconfig;
+    SNVS_LP_SRTC_GetDefaultConfig(&lpconfig);
+
+    SNVS_LP_SRTC_Init(SNVS, &lpconfig);
+
+    SNVS_LP_SRTC_StartTimer(SNVS);
     SNVS_HP_RTC_StartTimer(SNVS);
 }
 
 void common_hal_rtc_get_time(timeutils_struct_time_t *tm) {
-    snvs_hp_rtc_datetime_t rtcDate;
-    SNVS_HP_RTC_GetDatetime(SNVS, &rtcDate);
+    snvs_lp_srtc_datetime_t rtcDate;
+    SNVS_LP_SRTC_GetDatetime(SNVS, &rtcDate);
 
     tm->tm_year = rtcDate.year;
     tm->tm_mon = rtcDate.month;
@@ -58,7 +66,7 @@ void common_hal_rtc_get_time(timeutils_struct_time_t *tm) {
 }
 
 void common_hal_rtc_set_time(timeutils_struct_time_t *tm) {
-    snvs_hp_rtc_datetime_t rtcDate;
+    snvs_lp_srtc_datetime_t rtcDate;
     rtcDate.year = tm->tm_year;
     rtcDate.month = tm->tm_mon;
     rtcDate.day = tm->tm_mday;
@@ -66,7 +74,7 @@ void common_hal_rtc_set_time(timeutils_struct_time_t *tm) {
     rtcDate.minute = tm->tm_min;
     rtcDate.second = tm->tm_sec;
 
-    SNVS_HP_RTC_SetDatetime(SNVS, &rtcDate);
+    SNVS_LP_SRTC_SetDatetime(SNVS, &rtcDate);
 }
 
 int common_hal_rtc_get_calibration(void) {


### PR DESCRIPTION
There are apparently two RTC interfaces in the mimxrt10xx dev kit. The low power interface access the battery backed up hardware.

I've tested this on the Teensy41 and it seems to fix issue #4574 (fixes #4574)