### PR TITLE
Allow lines with ends out of bitmap in `bitmaptools_obj_draw_line`

### DIFF
--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -514,13 +514,6 @@ STATIC mp_obj_t bitmaptools_obj_draw_line(size_t n_args, const mp_obj_t *pos_arg
     int16_t x2 = args[ARG_x2].u_int;
     int16_t y2 = args[ARG_y2].u_int;
 
-    // verify points are within the bitmap boundary (inclusive)
-    if ((x1 < 0) || (x2 < 0) || (y1 < 0) || (y2 < 0) ||
-        (x1 >= destination->width) || (x2 >= destination->width) ||
-        (y1 >= destination->height) || (y2 >= destination->height)) {
-        mp_raise_ValueError(translate("out of range of target"));
-    }
-
     common_hal_bitmaptools_draw_line(destination, x1, y1, x2, y2, value);
 
     return mp_const_none;

--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -423,6 +423,8 @@ void common_hal_bitmaptools_draw_line(displayio_bitmap_t *destination,
             y0 = y1;
             y1 = temp;
         }
+        y0 = max(0, y0); // only draw inside bitmap
+        y1 = min(y1, destination->height - 1);
         for (y = y0; y < (y1 + 1); y++) { // write a horizontal line
             displayio_bitmap_write_pixel(destination, x0, y, value);
         }
@@ -432,6 +434,8 @@ void common_hal_bitmaptools_draw_line(displayio_bitmap_t *destination,
             x0 = x1;
             x1 = temp;
         }
+        x0 = max(0, x0); // only draw inside bitmap
+        x1 = min(x1, destination->width - 1);
         for (x = x0; x < (x1 + 1); x++) { // write a horizontal line
             displayio_bitmap_write_pixel(destination, x, y0, value);
         }

--- a/shared-module/displayio/Bitmap.c
+++ b/shared-module/displayio/Bitmap.c
@@ -131,6 +131,11 @@ void displayio_bitmap_write_pixel(displayio_bitmap_t *self, int16_t x, int16_t y
     // Writes the color index value into a pixel position
     // Must update the dirty area separately
 
+    // Don't write if out of area
+    if (0 > x || x >= self->width || 0 > y || y >= self->height) {
+        return;
+    }
+
     // Update one pixel of data
     int32_t row_start = y * self->stride;
     uint32_t bytes_per_value = self->bits_per_value / 8;


### PR DESCRIPTION
There is a reason for it: it may be easier to provide line end which is out of bitmap than to compute its intersection point with bitmap border.