### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,7 +249,7 @@ jobs:
 
 
   build-doc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: test
     if: ${{ needs.test.outputs.build-doc == 'True' }}
     env:
@@ -324,7 +324,7 @@ jobs:
 
 
   build-aarch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: test
     if: ${{ needs.test.outputs.boards-aarch != '[]' }}
     env:
@@ -406,7 +406,7 @@ jobs:
 
 
   build-arm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: test
     if: ${{ needs.test.outputs.boards-arm != '[]' }}
     env:
@@ -476,7 +476,7 @@ jobs:
 
 
   build-espressif:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: test
     if: ${{ needs.test.outputs.boards-espressif != '[]' }}
     env:
@@ -581,7 +581,7 @@ jobs:
 
 
   build-riscv:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: test
     if: ${{ needs.test.outputs.boards-riscv != '[]' }}
     env:

--- a/.github/workflows/create_website_pr.yml
+++ b/.github/workflows/create_website_pr.yml
@@ -6,41 +6,47 @@ name: Update CircuitPython.org
 
 on:
   release:
-    types: [published]
+    types: [published, rerequested]
 
 jobs:
   website:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Dump GitHub context
+      run: echo "$GITHUB_CONTEXT"
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - uses: actions/checkout@v3
+    - name: Set up repository
+      uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
-    - name: Set up Python 3
+    - name: Set up python
       uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-    - name: Get CP deps
-      run: python tools/ci_fetch_deps.py website ${{ github.sha }}
-    - name: Install deps
+    - name: CircuitPython dependencies
       run: |
-        pip install -r requirements-dev.txt
+        python tools/ci_fetch_deps.py ${{ github.job }}
+        echo "::group::Fetch history and tags"
+        git fetch --no-recurse-submodules --shallow-since="2021-07-01" --tags https://github.com/adafruit/circuitpython HEAD
+        git fetch --no-recurse-submodules --shallow-since="2021-07-01" origin $GITHUB_SHA
+        git repack -d
+        echo "::endgroup::"
+    - name: CircuitPython version
+      run: |
+        CP_VERSION=$(tools/describe)
+        echo "$CP_VERSION"
+        echo "CP_VERSION=$CP_VERSION" >> $GITHUB_ENV
+    - name: Install dependencies
+      run: pip install -r requirements-dev.txt
     - name: Versions
       run: |
         gcc --version
         python3 --version
-    - name: CircuitPython version
-      run: |
-        tools/describe || git log --parents HEAD~4..
-        echo >>$GITHUB_ENV CP_VERSION=$(tools/describe)
     - name: Website
       run: python3 build_board_info.py
       working-directory: tools
       env:
         RELEASE_TAG: ${{ github.event.release.tag_name }}
         ADABOT_GITHUB_ACCESS_TOKEN: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}
-      if: github.event_name == 'release' && (github.event.action == 'published'  || github.event.action == 'rerequested')

--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     defaults:
       run:
         # We define a custom shell script here, although `msys2.cmd` does neither exist nor is it available in the PATH yet
@@ -32,8 +32,7 @@ jobs:
       shell: bash
 
     - name: Check python coding (cmd)
-      run: |
-        python -c "import sys, locale; print(sys.getdefaultencoding(), locale.getpreferredencoding(False))"
+      run: python -c "import sys, locale; print(sys.getdefaultencoding(), locale.getpreferredencoding(False))"
       shell: cmd
 
     # We use a JS Action, which calls the system terminal or other custom terminals directly, if required
@@ -98,8 +97,9 @@ jobs:
         echo "::endgroup::"
     - name: CircuitPython version
       run: |
-        tools/describe || git log --parents HEAD~4..
-        echo >>$GITHUB_ENV CP_VERSION=$(tools/describe)
+        CP_VERSION=$(tools/describe)
+        echo "$CP_VERSION"
+        echo "CP_VERSION=$CP_VERSION" >> $GITHUB_ENV
 
     - name: build mpy-cross
       run: make -j2 -C mpy-cross

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,24 +16,23 @@ jobs:
   pre-commit:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3
+    - name: Set up repository
+      uses: actions/checkout@v3
+      with:
+        submodules: false
+        fetch-depth: 1
+    - name: Set up python
       uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-    - name: Install deps
+    - name: CircuitPython dependencies
+      run: python tools/ci_fetch_deps.py ${{ github.job }}
+    - name: Install dependencies
       run: |
         sudo apt-get install -y gettext uncrustify
         pip3 install black polib pyyaml
-    - name: Populate selected submodules
-      run: git submodule update --init extmod/ulab
-    - name: Set PY
-      run: echo >>$GITHUB_ENV PY="$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-    - uses: actions/cache@v3
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v3.0.0
+    - name: Run pre-commit
+      uses: pre-commit/action@v3.0.0
     - name: Make patch
       if: failure()
       run: git diff > ~/pre-commit.patch

--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -85,6 +85,8 @@ def main():
         submodules = ["extmod/ulab", "lib/", "tools/", "ports/", "data/nvm.toml"]
     elif TARGET == "website":
         submodules = ["tools/adabot/", "frozen/"]
+    elif TARGET == "pre-commit":
+        submodules = ["extmod/ulab"]
     else:
         p = list(pathlib.Path(".").glob(f"ports/*/boards/{TARGET}/mpconfigboard.mk"))
         if not p:


### PR DESCRIPTION
Contains some bug fixes and improvements:
- Use Ubuntu `22.04` for everything but the `test` job in `Build CI` which is on `20.04`.
- Use Windows `2022` for the `windows` job in `ports_windows.yml`.
- Fix a bug in `create_website_pr.yml` introduced by recent changes to `tools/ci_fetch_deps.py`.
- Don't cache in `pre-commit` as `pre-commit/action@v3.0.0` already maintains a cache.