### PR TITLE
Prettify espressif partition tables

### DIFF
--- a/ports/espressif/esp-idf-config/partitions-16MB-no-uf2.csv
+++ b/ports/espressif/esp-idf-config/partitions-16MB-no-uf2.csv
@@ -1,9 +1,8 @@
-# ESP-IDF Partition Table
-# Name,   Type, SubType, Offset,  Size, Flags
-# bootloader.bin,,          0x1000, 32K
-# partition table,,         0x8000, 4K
-nvs,      data, nvs,      0x9000,  20K,
-otadata,  data, ota,      0xe000,  8K,
-ota_0,    0,    ota_0,   0x10000,  2048K,
-ota_1,    0,    ota_1,  0x210000,  2048K,
-user_fs,  data, fat,    0x410000,  12224K,
+# Name,             Type,   SubType,    Offset,     Size
+# bootloader,       app,    boot,       0x1000/0x0, 28/32K
+# partition_table,  data,   table,      0x8000,     4K
+nvs,                data,   nvs,        0x9000,     20K
+otadata,            data,   ota,        0xe000,     8K
+ota_0,              app,    ota_0,      0x10000,    2048K
+ota_1,              app,    ota_1,      0x210000,   2048K
+user_fs,            data,   fat,        0x410000,   12224K

--- a/ports/espressif/esp-idf-config/partitions-16MB.csv
+++ b/ports/espressif/esp-idf-config/partitions-16MB.csv
@@ -1,10 +1,9 @@
-# ESP-IDF Partition Table
-# Name,   Type, SubType, Offset,  Size, Flags
-# bootloader.bin,,          0x1000, 32K
-# partition table,,         0x8000, 4K
-nvs,      data, nvs,      0x9000,  20K,
-otadata,  data, ota,      0xe000,  8K,
-ota_0,    0,    ota_0,   0x10000,  2048K,
-ota_1,    0,    ota_1,  0x210000,  2048K,
-uf2,      app,  factory,0x410000,  256K,
-user_fs,  data, fat,    0x450000,  11968K,
+# Name,             Type,   SubType,    Offset,     Size
+# bootloader,       app,    boot,       0x1000/0x0, 28/32K
+# partition_table,  data,   table,      0x8000,     4K
+nvs,                data,   nvs,        0x9000,     20K
+otadata,            data,   ota,        0xe000,     8K
+ota_0,              app,    ota_0,      0x10000,    2048K
+ota_1,              app,    ota_1,      0x210000,   2048K
+uf2,                app,    factory,    0x410000,   256K
+user_fs,            data,   fat,        0x450000,   11968K

--- a/ports/espressif/esp-idf-config/partitions-2MB-no-ota-no-uf2.csv
+++ b/ports/espressif/esp-idf-config/partitions-2MB-no-ota-no-uf2.csv
@@ -1,7 +1,6 @@
-# ESP-IDF Partition Table
-# Name,   Type, SubType, Offset,  Size, Flags
-# bootloader.bin,,          0x1000, 32K
-# partition table,,         0x8000, 4K
-nvs,      data, nvs,      0x9000,  20K,
-app,      app,  factory, 0x10000,  1408K,
-user_fs,  data, fat,    0x170000,  576K,
+# Name,             Type,   SubType,    Offset,     Size
+# bootloader,       app,    boot,       0x1000/0x0, 28/32K
+# partition_table,  data,   table,      0x8000,     4K
+nvs,                data,   nvs,        0x9000,     20K
+app,                app,    factory,    0x10000,    1408K,
+user_fs,            data,   fat,        0x170000,   576K,

--- a/ports/espressif/esp-idf-config/partitions-4MB-no-uf2.csv
+++ b/ports/espressif/esp-idf-config/partitions-4MB-no-uf2.csv
@@ -1,9 +1,8 @@
-# ESP-IDF Partition Table
-# Name,   Type, SubType, Offset,  Size, Flags
-# bootloader.bin,,          0x1000, 32K
-# partition table,,         0x8000, 4K
-nvs,      data, nvs,      0x9000,  20K,
-otadata,  data, ota,      0xe000,  8K,
-ota_0,    0,    ota_0,   0x10000,  1408K,
-ota_1,    0,    ota_1,  0x170000,  1408K,
-user_fs,  data, fat,    0x2d0000,  1216K,
+# Name,             Type,   SubType,    Offset,     Size
+# bootloader,       app,    boot,       0x1000/0x0, 28/32K
+# partition_table,  data,   table,      0x8000,     4K
+nvs,                data,   nvs,        0x9000,     20K
+otadata,            data,   ota,        0xe000,     8K
+ota_0,              app,    ota_0,      0x10000,    1408K
+ota_1,              app,    ota_1,      0x170000,   1408K
+user_fs,            data,   fat,        0x2d0000,   1216K

--- a/ports/espressif/esp-idf-config/partitions-4MB.csv
+++ b/ports/espressif/esp-idf-config/partitions-4MB.csv
@@ -1,10 +1,9 @@
-# ESP-IDF Partition Table
-# Name,   Type, SubType, Offset,  Size, Flags
-# bootloader.bin,,          0x1000, 32K
-# partition table,,         0x8000, 4K
-nvs,      data, nvs,      0x9000,  20K,
-otadata,  data, ota,      0xe000,  8K,
-ota_0,    0,    ota_0,   0x10000,  1408K,
-ota_1,    0,    ota_1,  0x170000,  1408K,
-uf2,      app,  factory,0x2d0000,  256K,
-user_fs,  data, fat,    0x310000,  960K,
+# Name,             Type,   SubType,    Offset,     Size
+# bootloader,       app,    boot,       0x1000/0x0, 28/32K
+# partition_table,  data,   table,      0x8000,     4K
+nvs,                data,   nvs,        0x9000,     20K
+otadata,            data,   ota,        0xe000,     8K
+ota_0,              app,    ota_0,      0x10000,    1408K
+ota_1,              app,    ota_1,      0x170000,   1408K
+uf2,                app,    factory,    0x2d0000,   256K
+user_fs,            data,   fat,        0x310000,   960K

--- a/ports/espressif/esp-idf-config/partitions-8MB-no-uf2.csv
+++ b/ports/espressif/esp-idf-config/partitions-8MB-no-uf2.csv
@@ -1,9 +1,8 @@
-# ESP-IDF Partition Table
-# Name,   Type, SubType, Offset,  Size, Flags
-# bootloader.bin,,          0x1000, 32K
-# partition table,,         0x8000, 4K
-nvs,      data, nvs,      0x9000,  20K,
-otadata,  data, ota,      0xe000,  8K,
-ota_0,    app,    ota_0,   0x10000,  2048K,
-ota_1,    app,    ota_1,  0x210000,  2048K,
-user_fs,  data, fat,    0x410000,  4032K,
+# Name,             Type,   SubType,    Offset,     Size
+# bootloader,       app,    boot,       0x1000/0x0, 28/32K
+# partition_table,  data,   table,      0x8000,     4K
+nvs,                data,   nvs,        0x9000,     20K
+otadata,            data,   ota,        0xe000,     8K
+ota_0,              app,    ota_0,      0x10000,    2048K
+ota_1,              app,    ota_1,      0x210000,   2048K
+user_fs,            data,   fat,        0x410000,   4032K

--- a/ports/espressif/esp-idf-config/partitions-8MB.csv
+++ b/ports/espressif/esp-idf-config/partitions-8MB.csv
@@ -1,10 +1,9 @@
-# ESP-IDF Partition Table
-# Name,   Type, SubType, Offset,  Size, Flags
-# bootloader.bin,,          0x1000, 32K
-# partition table,,         0x8000, 4K
-nvs,      data, nvs,      0x9000,  20K,
-otadata,  data, ota,      0xe000,  8K,
-ota_0,    0,    ota_0,   0x10000,  2048K,
-ota_1,    0,    ota_1,  0x210000,  2048K,
-uf2,      app,  factory,0x410000,  256K,
-user_fs,  data, fat,    0x450000,  3776K,
+# Name,             Type,   SubType,    Offset,     Size
+# bootloader,       app,    boot,       0x1000/0x0, 28/32K
+# partition_table,  data,   table,      0x8000,     4K
+nvs,                data,   nvs,        0x9000,     20K
+otadata,            data,   ota,        0xe000,     8K
+ota_0,              app,    ota_0,      0x10000,    2048K
+ota_1,              app,    ota_1,      0x210000,   2048K
+uf2,                app,    factory,    0x410000,   256K
+user_fs,            data,   fat,        0x450000,   3776K


### PR DESCRIPTION
Minor changes to espressif partition table.
- Correct the `bootloader` partition's `offset` and `size` fields.
- Prettify the partition tables. GitHub now renders them as searchable tables.