### PR TITLE
Update notification workflow

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -7,8 +7,12 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    permissions:
+        issues: write
     steps:
-        - uses: jenschelkopf/issue-label-notification-action@1.3
+        - uses: tekktrik/issue-labeled-ping@v1
           with:
-             recipients: |
-                  ulab=@v923z
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+                user: v923z
+                label: ulab
+                message: Heads up {user} - the "{label}" label was applied to this issue.


### PR DESCRIPTION
Updates a part of the CI with deprecation warning by using a new, custom GitHub Action.  I intend to transfer this over to Adafruit, but if it makes more sense to hold onto it I'm more than happy to do so.  In that case, I'll update this CI step accordingly after transferring.

Configured so that it results in the existing message from the old action step.