### PR TITLE
Update mpconfigboard.h  with LED definition for BPI-Bit-S2.

### DIFF
--- a/ports/espressif/boards/bpi_bit_s2/mpconfigboard.h
+++ b/ports/espressif/boards/bpi_bit_s2/mpconfigboard.h
@@ -30,6 +30,7 @@
 #define MICROPY_HW_MCU_NAME         "ESP32S2"
 
 // #define MICROPY_HW_NEOPIXEL  (&pin_GPIO18)
+#define MICROPY_HW_LED_STATUS (&pin_GPIO0)
 
 #define DEFAULT_I2C_BUS_SCL (&pin_GPIO16)
 #define DEFAULT_I2C_BUS_SDA (&pin_GPIO15)


### PR DESCRIPTION
Configure LED pin for STATUS display.

The LED on this board does not go off after reset because GPIO0 on which it is located remains high after reset.

Refer to the description of Chip Boot Control (BOOTCTRL) in this [Technical Reference Manual](https://www.espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf).

But I think it may still be necessary to enable this configuration.

Thank @RetiredWizard for reminding me in #7315 .