### PR TITLE
cache only submodules in tools/

### DIFF
--- a/.github/actions/fetch_submodules/action.yml
+++ b/.github/actions/fetch_submodules/action.yml
@@ -4,7 +4,7 @@ inputs:
   submodules:
     description: 'The submodules to cache'
     required: false
-    default: '["extmod/ulab", "lib/", "tools/"]'
+    default: '["extmod/ulab", "lib/", "tools/adabot", "tools/bitmap_font", "tools/huffman", "tools/python-semver", "tools/Tecate-bitmap-fonts", "tools/uf2", "tools/usb_descriptor"]'
     type: string
 
   cache:


### PR DESCRIPTION
Based on https://github.com/adafruit/circuitpython/pull/7497/commits/78aca074bacb1b428e278adaed9b93240753e68a.

Cache only submodules in `tools/`, not the whole directory.

List is from:
```sh
$ ag "path = tools" --nonumbers .gitmodules |sort
	path = tools/adabot
	path = tools/bitmap_font
	path = tools/huffman
	path = tools/python-semver
	path = tools/Tecate-bitmap-fonts
	path = tools/uf2
	path = tools/usb_descriptor
```

