### PR TITLE
Fixes #6482

### DIFF
--- a/ports/raspberrypi/common-hal/alarm/SleepMemory.c
+++ b/ports/raspberrypi/common-hal/alarm/SleepMemory.c
@@ -34,7 +34,6 @@ void alarm_sleep_memory_reset(void) {
 }
 
 uint32_t common_hal_alarm_sleep_memory_get_length(alarm_sleep_memory_obj_t *self) {
-    mp_raise_NotImplementedError(translate("Sleep Memory not available"));
     return 0;
 }
 


### PR DESCRIPTION
Fixes #6482.

Don't throw the exception and return zero. This addresses the incorrect behavior in the issue, and doesn't cause other problems because a 0-length buffer is still unusable.