### PR TITLE
Correct assignment of RMT channels on ESP32C3

### DIFF
--- a/ports/espressif/peripherals/rmt.c
+++ b/ports/espressif/peripherals/rmt.c
@@ -40,6 +40,14 @@ void peripherals_rmt_reset(void) {
 rmt_channel_t peripherals_find_and_reserve_rmt(bool mode) {
     size_t start_channel = 0;
     size_t end_channel = RMT_CHANNEL_MAX;
+    // ESP32C3 can only send on channels 0-1 and receive on channels 2-3
+    #if defined(CONFIG_IDF_TARGET_ESP32C3)
+    if (mode == RECEIVE_MODE) {
+        start_channel = 2;
+    } else {
+        end_channel = 2;
+    }
+    #endif // ESP32C3
     #if SOC_RMT_CHANNELS_PER_GROUP > 4
     if (mode == RECEIVE_MODE) {
         start_channel = 4;


### PR DESCRIPTION
Fix for issue #7419. According to the espressif docs at https://docs.espressif.com/projects/esp-idf/en/v4.3/esp32c3/api-reference/peripherals/rmt.html;
"The RMT has four channels numbered from zero to three. The first half (i.e. Channel 0 ~ 1) channels can only be configured for transmitting, and the other half (i.e. Channel 2 ~ 3) channels can only be configured for receiving." 
This fix for peripherals/rmt.c ensures that a proper channel is returned for either mode.