### PR TITLE
fix for native is31fl3741

### DIFF
--- a/shared-module/is31fl3741/FrameBuffer.c
+++ b/shared-module/is31fl3741/FrameBuffer.c
@@ -172,7 +172,7 @@ void common_hal_is31fl3741_FrameBuffer_refresh(is31fl3741_FrameBuffer_obj_t *sel
                     } else {
                         color = (rsum << 16) + (gsum << 8) + bsum;
                     }
-                    common_hal_is31fl3741_draw_pixel(self->is31fl3741, x, y, color, self->mapping, self->height);
+                    common_hal_is31fl3741_draw_pixel(self->is31fl3741, x, y, color, self->mapping, self->scale_height);
                 }
             }
         } else {
@@ -193,7 +193,7 @@ void common_hal_is31fl3741_FrameBuffer_refresh(is31fl3741_FrameBuffer_obj_t *sel
                             color = *buffer;
                         }
 
-                        common_hal_is31fl3741_draw_pixel(self->is31fl3741, x, y, color, self->mapping, self->height);
+                        common_hal_is31fl3741_draw_pixel(self->is31fl3741, x, y, color, self->mapping, self->scale_height);
                         buffer++;
                     }
                 } else {


### PR DESCRIPTION
resolves #7516 

Tested successfully with:
```
Adafruit CircuitPython 8.0.0-rc.2-dirty on 2023-02-03; Adafruit LED Glasses Driver nRF52840 with nRF52840
Board ID:adafruit_led_glasses_nrf52840
UID:4D43A3F73BE5AE3A
```