### PR TITLE
Deinit the reset pin when displayio.I2CDisplay fails

### DIFF
--- a/shared-module/displayio/I2CDisplay.c
+++ b/shared-module/displayio/I2CDisplay.c
@@ -54,6 +54,7 @@ void common_hal_displayio_i2cdisplay_construct(displayio_i2cdisplay_obj_t *self,
     // Probe the bus to see if a device acknowledges the given address.
     if (!common_hal_busio_i2c_probe(i2c, device_address)) {
         self->base.type = &mp_type_NoneType;
+        common_hal_displayio_i2cdisplay_deinit(self);
         mp_raise_ValueError_varg(translate("Unable to find I2C Display at %x"), device_address);
     }
 


### PR DESCRIPTION
Fixes an issue when displayio.I2CDisplay raises an exception because of a bad address for example. The reset pin (if any) remains "never reset" (ironically) and raises a "pin in use" error on subsequent reloads.

Deinits self before raising the exception.
Is this the right way to do that ? Or should it just deinit the resest pin (if set).

Example code:
```py
import board
import displayio
import adafruit_displayio_ssd1306

displayio.release_displays()
reset = board.D9

i2c = board.I2C()
bus = displayio.I2CDisplay(i2c, device_address=0, reset=reset)
display = adafruit_displayio_ssd1306.SSD1306(bus, width=128, height=64)
```
Output defore the fix:
```
code.py output:
Traceback (most recent call last):
  File "code.py", line 12, in <module>
ValueError: Unable to find I2C Display at 0

Code done running.

Press any key to enter the REPL. Use CTRL-D to reload.

Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
Traceback (most recent call last):
  File "code.py", line 12, in <module>
ValueError: D9 in use

Code done running.

Press any key to enter the REPL. Use CTRL-D to reload.
```