### PR TITLE
Update build_board_info.py to sh module 2.0.0

### DIFF
--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import sh
 import base64
+from io import StringIO
 from datetime import date
 from sh.contrib import git
 
@@ -58,9 +59,13 @@ def get_languages(list_all=False):
 
 def get_version_info():
     version = None
-    sha = git("rev-parse", "--short", "HEAD").stdout.decode("utf-8")
+    buffer = StringIO()
+    git("rev-parse", "--short", "HEAD", _out=buffer)
+    sha = buffer.getvalue().strip()
     try:
-        version = git("describe", "--tags", "--exact-match").stdout.decode("utf-8").strip()
+        buffer = StringIO()
+        git("describe", "--tags", "--exact-match", _out=buffer)
+        version = buffer.getvalue().strip()
     except sh.ErrorReturnCode_128:
         # No exact match
         pass


### PR DESCRIPTION
Due to today's release of the `sh` python module 2.0.0, the CI fails in build_board_info.py
see https://github.com/adafruit/circuitpython/actions/runs/4140380646
```py
Run python3 -u build_release_files.py
Traceback (most recent call last):
  File "/home/runner/work/circuitpython/circuitpython/tools/build_release_files.py", line 30, in <module>
    sha, version = build_info.get_version_info()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/circuitpython/circuitpython/tools/build_board_info.py", line 61, in get_version_info
    sha = git("rev-parse", "--short", "HEAD").stdout.decode("utf-8")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'stdout'
Error: Process completed with exit code 1.
```
Because it now returns a string:
https://github.com/amoffat/sh/blob/develop/MIGRATION.md#return-value-now-a-true-string
Adabot doesn't seem to need to be updated since it uses the `_out = ...` argument (with StringIO).