### PR TITLE
Broadcom pi zero2w neopixel misbehaving/crash fix

### DIFF
--- a/ports/broadcom/common-hal/neopixel_write/__init__.c
+++ b/ports/broadcom/common-hal/neopixel_write/__init__.c
@@ -45,7 +45,11 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t *digitalinout,
     uint8_t *pixels, uint32_t num_bytes) {
     // Wait to make sure we don't append onto the last transmission. This should only be a tick or
     // two.
-    while (port_get_raw_ticks(NULL) < next_start_raw_ticks) {
+    int icnt;
+    while ((port_get_raw_ticks(NULL) < next_start_raw_ticks) & 
+        (next_start_raw_ticks-port_get_raw_ticks(NULL) < 100)) {
+        
+        RUN_BACKGROUND_TASKS;
     }
 
     BP_Function_Enum alt_function = GPIO_FUNCTION_OUTPUT;
@@ -92,7 +96,8 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t *digitalinout,
 
         // Wait for the clock to start up.
         COMPLETE_MEMORY_READS;
-        while (CM_PWM->CS_b.BUSY == 0) {
+        icnt = 0;
+        while ((CM_PWM->CS_b.BUSY == 0) & (icnt++ < 1000)) {
         }
     }
 
@@ -134,22 +139,41 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t *digitalinout,
                 expanded |= 0x80000000;
             }
         }
-        while (pwm->STA_b.FULL1 == 1) {
-            RUN_BACKGROUND_TASKS;
-        }
         if (channel == 1) {
+            icnt=0;
+            while ((pwm->STA_b.FULL1 == 1) & (icnt++ < 150)) {
+                RUN_BACKGROUND_TASKS;
+            }
             // Dummy value for the first channel.
             pwm->FIF1 = 0x000000;
         }
+        icnt=0;
+        while ((pwm->STA_b.FULL1 == 1) & (icnt++ < 150)) {
+            RUN_BACKGROUND_TASKS;
+        }
         pwm->FIF1 = expanded;
         if (channel == 0) {
+            icnt=0;
+            while ((pwm->STA_b.FULL1 == 1) & (icnt++ < 150)) {
+                RUN_BACKGROUND_TASKS;
+            }
             // Dummy value for the second channel.
             pwm->FIF1 = 0x000000;
         }
     }
-    // Wait just a little bit so that transmission can start.
-    common_hal_mcu_delay_us(2);
-    while (pwm->STA_b.STA1 == 1) {
+
+    icnt = 0;
+    while ((pwm->STA_b.EMPT1 == 0) & (icnt++ < 2500)) {
+        RUN_BACKGROUND_TASKS;
+    }
+    // Wait for transmission to start.
+    icnt = 0;
+    while (((pwm->STA_b.STA1 ==0) & (pwm->STA_b.STA2 == 0)) & (icnt++ < 150)) {
+        RUN_BACKGROUND_TASKS;
+    }
+    // Wait for transmission to complete.
+    icnt = 0;
+    while (((pwm->STA_b.STA1 == 1) | (pwm->STA_b.STA2 == 1)) & (icnt++ < 150)) {
         RUN_BACKGROUND_TASKS;
     }
 


### PR DESCRIPTION
These changes fix adafruit/circuitpython#5947. I've tested on both the zero2w and the pi4b (The 4b didn't exhibit the original issue) and the boards now behave properly with 1 to 30 pixels. I've run a 30 pixel animation on the zero2w for 8+ hours without a hang.


**Original corrupted rgb transmission:**
![image](https://user-images.githubusercontent.com/29083569/218270769-95a59a8e-dfc9-4c9f-b141-66b5920a43a7.png)
**Early Fix, not using transmission queue:**
![image](https://user-images.githubusercontent.com/29083569/218244620-86df6d65-d197-41c1-94b8-11d5d05e78c3.png)
**This PR:**
![image](https://user-images.githubusercontent.com/29083569/218270243-91d54478-9c7e-4c4c-b0ef-1b11fed2b133.png)
