### PR TITLE
Add links to some built-in modules 

### DIFF
--- a/shared-bindings/audiobusio/__init__.c
+++ b/shared-bindings/audiobusio/__init__.c
@@ -44,6 +44,8 @@
 //| All classes change hardware state and should be deinitialized when they
 //| are no longer needed. To do so, either call :py:meth:`!deinit` or use a
 //| context manager."""
+//| For more information about how to utilize the 'audiobusio' module, see the link below:
+//| <https://learn.adafruit.com/make-it-sense/circuitpython-3>
 
 STATIC const mp_rom_map_elem_t audiobusio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audiobusio) },

--- a/shared-bindings/audiomixer/__init__.c
+++ b/shared-bindings/audiomixer/__init__.c
@@ -33,6 +33,8 @@
 #include "shared-bindings/audiomixer/Mixer.h"
 
 //| """Support for audio mixing"""
+//| For more information about 'audiomixer' including documentation and examples, see the link below:
+<https://docs.circuitpython.org/en/latest/shared-bindings/audiomixer/index.html>
 
 STATIC const mp_rom_map_elem_t audiomixer_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audiomixer) },

--- a/shared-bindings/audiopwmio/__init__.c
+++ b/shared-bindings/audiopwmio/__init__.c
@@ -45,6 +45,9 @@
 //| Since CircuitPython 5, `Mixer`, `RawSample` and `WaveFile` are moved
 //| to :mod:`audiocore`."""
 
+//| For more information about how to utilize the 'audiopwmio' module, see the link below:
+//| <https://learn.adafruit.com/todbot-circuitpython-tricks/audio>
+
 STATIC const mp_rom_map_elem_t audiopwmio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audiopwmio) },
     { MP_ROM_QSTR(MP_QSTR_PWMAudioOut), MP_ROM_PTR(&audiopwmio_pwmaudioout_type) },

--- a/shared-bindings/camera/__init__.c
+++ b/shared-bindings/camera/__init__.c
@@ -33,6 +33,9 @@
 //| """Support for camera input
 //|
 //| The `camera` module contains classes to control the camera and take pictures."""
+//| For more information about the 'camera' module including documentation and examples, see the link below:
+//| <https://docs.circuitpython.org/en/latest/shared-bindings/camera/index.html> 
+
 STATIC const mp_rom_map_elem_t camera_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_camera) },
     { MP_ROM_QSTR(MP_QSTR_Camera), MP_ROM_PTR(&camera_type) },

--- a/shared-bindings/ipaddress/__init__.c
+++ b/shared-bindings/ipaddress/__init__.c
@@ -36,6 +36,8 @@
 //| module.
 //| """
 //|
+//| For more information about learning how to utilize the 'ipaddress' module, see the link below:
+//| <https://learn.adafruit.com/iot-led-sign/circuitpython-internet-test>
 
 
 bool ipaddress_parse_ipv4address(const char *str_data, size_t str_len, uint32_t *ip_out) {

--- a/shared-bindings/rainbowio/__init__.c
+++ b/shared-bindings/rainbowio/__init__.c
@@ -37,6 +37,10 @@
 //|     """
 //|     ...
 //|
+
+//| For more information about how to utilize the 'rainbowio' module, see the link below:
+//| <https://learn.adafruit.com/todbot-circuitpython-tricks/neopixels-dotstars>
+
 STATIC mp_obj_t rainbowio_colorwheel(mp_obj_t n) {
     mp_float_t f = mp_obj_get_float(n);
     return MP_OBJ_NEW_SMALL_INT(colorwheel(f));

--- a/shared-bindings/rgbmatrix/__init__.c
+++ b/shared-bindings/rgbmatrix/__init__.c
@@ -32,6 +32,12 @@
 #include "shared-bindings/rgbmatrix/RGBMatrix.h"
 
 //| """Low-level routines for bitbanged LED matrices"""
+//| For more information about the 'rgbmatrix' module:
+//| <https://learn.adafruit.com/rgb-led-matrices-matrix-panels-with-circuitpython/overview>
+//|
+//| For examples on how to utilize the 'rgbmatrix' module, see the links below:
+//| <https://learn.adafruit.com/rgb-led-matrices-matrix-panels-with-circuitpython/example-simple-two-line-text-scroller>
+//| <https://learn.adafruit.com/rgb-led-matrices-matrix-panels-with-circuitpython/example-adafruit-machine>
 
 STATIC const mp_rom_map_elem_t rgbmatrix_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_rgbmatrix) },

--- a/shared-bindings/sdcardio/__init__.c
+++ b/shared-bindings/sdcardio/__init__.c
@@ -33,6 +33,8 @@
 #include "shared-bindings/sdcardio/SDCard.h"
 
 //| """Interface to an SD card via the SPI bus"""
+//| For more information about how to utilize the 'sdcardio' module, see the link below:
+//| <https://learn.adafruit.com/adafruit-microsd-spi-sdio/using-sdcardio>
 
 STATIC const mp_rom_map_elem_t sdcardio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_sdcardio) },

--- a/shared-bindings/usb_cdc/__init__.c
+++ b/shared-bindings/usb_cdc/__init__.c
@@ -70,6 +70,9 @@
 //|     Equivalent to ``usb_cdc.enable(console=False, data=False)``."""
 //|     ...
 //|
+//| For more information about how to utilize the 'usb_cdc' module, see the link below:
+//| <https://learn.adafruit.com/customizing-usb-devices-in-circuitpython?view=all>
+
 STATIC mp_obj_t usb_cdc_disable(void) {
     if (!common_hal_usb_cdc_disable()) {
         mp_raise_RuntimeError(translate("Cannot change USB devices now"));

--- a/shared-bindings/usb_hid/__init__.c
+++ b/shared-bindings/usb_hid/__init__.c
@@ -49,6 +49,9 @@
 //| """
 //|
 
+//| For more information about how to utilize the 'usb_hid' module, see the link below:
+//| <https://learn.adafruit.com/customizing-usb-devices-in-circuitpython?view=all>
+
 //| def disable() -> None:
 //|     """Do not present any USB HID devices to the host computer.
 //|     Can be called in ``boot.py``, before USB is connected.

--- a/shared-bindings/usb_midi/__init__.c
+++ b/shared-bindings/usb_midi/__init__.c
@@ -44,6 +44,9 @@
 //| """Tuple of all MIDI ports. Each item is ether `PortIn` or `PortOut`."""
 //|
 
+//| For more information about how to utilize the 'usb_midi' module, see the link below:
+//| <https://learn.adafruit.com/customizing-usb-devices-in-circuitpython?view=all>
+
 //| def disable() -> None:
 //|     """Disable presenting a USB MIDI device to the host.
 //|     The device is normally enabled by default, but on some boards with limited endpoints

--- a/shared-bindings/wifi/__init__.c
+++ b/shared-bindings/wifi/__init__.c
@@ -35,6 +35,9 @@
 //| The `wifi` module provides necessary low-level functionality for managing
 //| wifi connections. Use `socketpool` for communicating over the network."""
 //|
+//| For more information about how to utilize the 'wifi' module, see the link below:
+//| <https://learn.adafruit.com/mqtt-in-circuitpython/circuitpython-wifi-usage>
+//|
 //| radio: Radio
 //| """Wifi radio used to manage both station and AP modes.
 //| This object is the sole instance of `wifi.Radio`."""


### PR DESCRIPTION
Added other sources of documentation for users to reference when using the CircuitPython modules #6326 
The built-in modules that were changed include:
-audiobusio
-audiomixer
-audiopwm
-camera
-ipaddress
-rainbowio
-rgbmatrix
-sdcardio
-usb_cdc
-usb_hid
-usb_midi
-wifi