### PR TITLE
minor update to boards.c to fix mismatched number of Neopixels

### DIFF
--- a/ports/raspberrypi/boards/jpconstantineau_pykey18/board.c
+++ b/ports/raspberrypi/boards/jpconstantineau_pykey18/board.c
@@ -31,7 +31,7 @@
 
 void reset_board(void) {
     // turn off any left over LED
-    board_reset_user_neopixels(&pin_GPIO29, 62);
+    board_reset_user_neopixels(&pin_GPIO29, 19);
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/raspberrypi/boards/jpconstantineau_pykey44/board.c
+++ b/ports/raspberrypi/boards/jpconstantineau_pykey44/board.c
@@ -31,7 +31,7 @@
 
 void reset_board(void) {
     // turn off any left over LED
-    board_reset_user_neopixels(&pin_GPIO29, 62);
+    board_reset_user_neopixels(&pin_GPIO29, 45);
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/raspberrypi/boards/jpconstantineau_pykey87/board.c
+++ b/ports/raspberrypi/boards/jpconstantineau_pykey87/board.c
@@ -31,7 +31,7 @@
 
 void reset_board(void) {
     // turn off any left over LED
-    board_reset_user_neopixels(&pin_GPIO29, 62);
+    board_reset_user_neopixels(&pin_GPIO29, 88);
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.


### PR DESCRIPTION
Fixes issue with PyKey87 where Neopixels are not all reset on CP restart.  
Also updated the number for 2 other boards in order not to reset an excessive amount.