### PR TITLE
Improve boot_out.txt truncation

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2410,6 +2410,10 @@ msgid ""
 "You pressed the reset button during boot. Press again to exit safe mode."
 msgstr ""
 
+#: supervisor/shared/micropython.c
+msgid "[truncated due to length]"
+msgstr ""
+
 #: py/objtype.c
 msgid "__init__() should return None"
 msgstr ""

--- a/supervisor/shared/micropython.c
+++ b/supervisor/shared/micropython.c
@@ -62,8 +62,15 @@ void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     #ifdef CIRCUITPY_BOOT_OUTPUT_FILE
     if (boot_output != NULL) {
         // Ensure boot_out.txt is capped at 1 filesystem block and ends with a newline
-        if (len + boot_output->len > 508) {
-            vstr_add_str(boot_output, "...\n");
+        #define TRUNCATED translate("[truncated due to length]")
+        size_t truncated_message_len = decompress_length(TRUNCATED);
+        size_t maxlen = 512 - truncated_message_len; // includes trailing '\0' so we do not need to account for trailing newline '\n' in vstr_add_byte
+        if (len + boot_output->len > maxlen) {
+            size_t remaining_len = maxlen - boot_output->len;
+            vstr_add_strn(boot_output, str, remaining_len);
+            char buf[truncated_message_len];
+            vstr_add_str(boot_output, decompress(TRUNCATED, buf));
+            vstr_add_byte(boot_output, '\n');
             boot_output = NULL;
         } else {
             vstr_add_strn(boot_output, str, len);


### PR DESCRIPTION
 * write any partial message
 * instead of "..." show a sensible (translatable) message

This does slightly lower the amount of data that can be printed, and makes the exact amount dependent on the language. However, if boot.py intentionally needs to produce larger amounts of output, it can deliberately mount the filesystem in RW mode and perform any writes needed. In that case it's up to the boot.py to choose an appropriate way to limit the number of writes if needed for the application.