### PR TITLE
Tweak the UART in use message on RP2040

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -438,7 +438,6 @@ msgid "All SPI peripherals are in use"
 msgstr ""
 
 #: ports/espressif/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
-#: ports/raspberrypi/common-hal/busio/UART.c
 msgid "All UART peripherals are in use"
 msgstr ""
 
@@ -2147,6 +2146,10 @@ msgstr ""
 #: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
 #: ports/espressif/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
 msgid "UART init"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/busio/UART.c
+msgid "UART peripheral in use"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c

--- a/ports/raspberrypi/common-hal/busio/UART.c
+++ b/ports/raspberrypi/common-hal/busio/UART.c
@@ -111,7 +111,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     uint8_t uart_id = ((((tx != NULL) ? tx->number : rx->number) + 4) / 8) % NUM_UARTS;
 
     if (uart_status[uart_id] != STATUS_FREE) {
-        mp_raise_RuntimeError(translate("All UART peripherals are in use"));
+        mp_raise_ValueError(translate("UART peripheral in use"));
     }
     // These may raise exceptions if pins are already in use.
     self->tx_pin = pin_init(uart_id, tx, 0);


### PR DESCRIPTION
The message `All UART peripherals are in use` was incorrect, since it would be shown when reusing the same peripheral while the other was free. SPI and I2C also only say "peripheral in use".
