### PR TITLE
ColorConverter output colorspace non-initialization fix

### DIFF
--- a/shared-bindings/displayio/ColorConverter.c
+++ b/shared-bindings/displayio/ColorConverter.c
@@ -73,10 +73,8 @@ STATIC mp_obj_t displayio_colorconverter_obj_convert(mp_obj_t self_in, mp_obj_t 
     displayio_colorconverter_t *self = MP_OBJ_TO_PTR(self_in);
 
     mp_int_t color = mp_arg_validate_type_int(color_obj, MP_QSTR_color);
-    _displayio_colorspace_t colorspace;
-    colorspace.depth = 16;
     uint32_t output_color;
-    common_hal_displayio_colorconverter_convert(self, &colorspace, color, &output_color);
+    common_hal_displayio_colorconverter_convert(self, &self->output_colorspace, color, &output_color);
     return MP_OBJ_NEW_SMALL_INT(output_color);
 }
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_colorconverter_convert_obj, displayio_colorconverter_obj_convert);

--- a/shared-module/displayio/ColorConverter.c
+++ b/shared-module/displayio/ColorConverter.c
@@ -45,6 +45,7 @@ void common_hal_displayio_colorconverter_construct(displayio_colorconverter_t *s
     self->dither = dither;
     self->transparent_color = NO_TRANSPARENT_COLOR;
     self->input_colorspace = input_colorspace;
+    self->output_colorspace.depth = 16;
 }
 
 uint16_t displayio_colorconverter_compute_rgb565(uint32_t color_rgb888) {

--- a/shared-module/displayio/ColorConverter.h
+++ b/shared-module/displayio/ColorConverter.h
@@ -37,6 +37,7 @@ typedef struct displayio_colorconverter {
     mp_obj_base_t base;
     bool dither;
     uint8_t input_colorspace;
+    _displayio_colorspace_t output_colorspace;
     uint32_t transparent_color;
 } displayio_colorconverter_t;
 


### PR DESCRIPTION
Fix for #7609

The output colorspace struct was created every call to convert but the structure was not initialized leading to random values. Specifically `reverse_bytes_in_word` was referenced in the conversion function with never being set. This lead to unpredictable behavior.

Moved the colorspace object to the class structure so it can be reused and is properly initialized. This also allows the output colorspace to be made to be configurable in the future.

Tested on a KB2040.

```python
import displayio
cc = displayio.ColorConverter(input_colorspace=displayio.Colorspace.RGB888)
hex(cc.convert(0x00ff00))
```

Should return `0x7e0`
Before would randomly return `0xe007`