### PR TITLE
Fix pad assignments on atmel-samd UART

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1987,10 +1987,6 @@ msgstr ""
 msgid "Stopping AP is not supported."
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
-msgid "Supply at least one UART pin"
-msgstr ""
-
 #: shared-bindings/alarm/time/TimeAlarm.c
 msgid "Supply one of monotonic_time or epoch_time"
 msgstr ""
@@ -4116,8 +4112,6 @@ msgstr ""
 msgid "twai_start returned esp-idf error #%d"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/espressif/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
 #: shared-bindings/busio/UART.c shared-bindings/canio/CAN.c
 msgid "tx and rx cannot both be None"
 msgstr ""

--- a/ports/espressif/common-hal/busio/UART.c
+++ b/ports/espressif/common-hal/busio/UART.c
@@ -112,9 +112,8 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
 
     uart_config_t uart_config = {0};
     bool have_rs485_dir = rs485_dir != NULL;
-    if (!have_tx && !have_rx) {
-        mp_raise_ValueError(translate("tx and rx cannot both be None"));
-    }
+
+    // shared-bindings checks that TX and RX are not both None, so we don't need to check here.
 
     // Filter for sane settings for RS485
     if (have_rs485_dir) {

--- a/ports/mimxrt10xx/common-hal/busio/UART.c
+++ b/ports/mimxrt10xx/common-hal/busio/UART.c
@@ -179,7 +179,8 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             break;
         }
     } else {
-        mp_raise_ValueError(translate("tx and rx cannot both be None"));
+        // TX and RX are both None. But this is already handled in shared-bindings, so
+        // we won't get here.
     }
 
     if (rx && !rx_config) {

--- a/ports/mimxrt10xx/common-hal/busio/UART.c
+++ b/ports/mimxrt10xx/common-hal/busio/UART.c
@@ -179,7 +179,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             break;
         }
     } else {
-        mp_raise_ValueError(translate("Supply at least one UART pin"));
+        mp_raise_ValueError(translate("tx and rx cannot both be None"));
     }
 
     if (rx && !rx_config) {

--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -183,9 +183,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         mp_raise_ValueError(translate("All UART peripherals are in use"));
     }
 
-    if ((tx == NULL) && (rx == NULL)) {
-        mp_raise_ValueError(translate("tx and rx cannot both be None"));
-    }
+    // shared-bindings checks that TX and RX are not both None, so we don't need to check here.
 
     mp_arg_validate_int_min(receiver_buffer_size, 1, MP_QSTR_receiver_buffer_size);
 

--- a/ports/stm/common-hal/busio/UART.c
+++ b/ports/stm/common-hal/busio/UART.c
@@ -160,7 +160,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
             periph_index, uart_taken);
     } else {
         // both pins cannot be empty
-        mp_raise_ValueError(translate("Supply at least one UART pin"));
+        mp_raise_ValueError(translate("tx and rx cannot both be None"));
     }
 
     // Other errors

--- a/ports/stm/common-hal/busio/UART.c
+++ b/ports/stm/common-hal/busio/UART.c
@@ -85,7 +85,7 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
     bool sigint_enabled) {
 
     // match pins to UART objects
-    USART_TypeDef *USARTx;
+    USART_TypeDef *USARTx = NULL;
 
     uint8_t tx_len = MP_ARRAY_SIZE(mcu_uart_tx_list);
     uint8_t rx_len = MP_ARRAY_SIZE(mcu_uart_rx_list);
@@ -159,8 +159,8 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
         USARTx = assign_uart_or_throw(self, (self->tx != NULL),
             periph_index, uart_taken);
     } else {
-        // both pins cannot be empty
-        mp_raise_ValueError(translate("tx and rx cannot both be None"));
+        // TX and RX are both None. But this is already handled in shared-bindings, so
+        // we won't get here.
     }
 
     // Other errors


### PR DESCRIPTION
- Fixes #7612.

- SERCOM USART TXPO computation was not correct on SAMD21 for TX pins using pad 2, due to changes introduced in #6434. SAMD21 and SAMx5x are different: SAMx5x does not allow pad 2 for TX. In addition, checking for allowed pins based on their pads was not as rigorous as it should have been. Code is somewhat restructured.
- Signature for `busio.UART()` was missing several arguments and did not account for `None` values.
- Did more pin validation in `shared-bindings` `busio.UART()`. Ensure pins are distinct, and that both TX and RX are not None. Removed now-redundant checks for TX and RX both being none in `ports/*/common-hal/busio/UART.c`.

Tested that original bug (#7612) is now fixed. Did not test that flow control is working. Did verify that TXPO and RXPO are correct for a variety of pin choices, with and without RTS/CTS. It's not clear whether TXPO 0x2 is OK on SAMD51 if RTS and CTS are not used, but did the safe thing.

Also tested on a Metro M4, confirming that the standard TX and RX still work in both directions.

@stonehippo You may want to re-test with these changes.