### PR TITLE
Port/Broadcom Switch to "unmeasured" core clock speed check

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -324,7 +324,3 @@
 [submodule "frozen/Adafruit_CircuitPython_SSD1680"]
 	path = frozen/Adafruit_CircuitPython_SSD1680
 	url = https://github.com/adafruit/Adafruit_CircuitPython_SSD1680
-[submodule "ports/broadcom/peripherals"]
-	path = ports/broadcom/peripherals
-	url = https://github.com/adafruit/broadcom-peripherals.git
-	branch = main-build

--- a/.gitmodules
+++ b/.gitmodules
@@ -324,3 +324,7 @@
 [submodule "frozen/Adafruit_CircuitPython_SSD1680"]
 	path = frozen/Adafruit_CircuitPython_SSD1680
 	url = https://github.com/adafruit/Adafruit_CircuitPython_SSD1680
+[submodule "ports/broadcom/peripherals"]
+	path = ports/broadcom/peripherals
+	url = https://github.com/adafruit/broadcom-peripherals.git
+	branch = main-build

--- a/.gitmodules
+++ b/.gitmodules
@@ -187,10 +187,6 @@
 [submodule "frozen/Adafruit_CircuitPython_APDS9960"]
 	path = frozen/Adafruit_CircuitPython_APDS9960
 	url = https://github.com/adafruit/Adafruit_CircuitPython_APDS9960
-[submodule "ports/broadcom/peripherals"]
-	path = ports/broadcom/peripherals
-	url = https://github.com/adafruit/broadcom-peripherals.git
-	branch = main-build
 [submodule "rpi-firmware"]
 	path = ports/broadcom/firmware
 	url = https://github.com/raspberrypi/rpi-firmware.git

--- a/ports/broadcom/common-hal/busio/I2C.c
+++ b/ports/broadcom/common-hal/busio/I2C.c
@@ -98,7 +98,7 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     self->sda_pin = sda;
     self->scl_pin = scl;
 
-    uint32_t source_clock = vcmailbox_get_clock_rate_measured(VCMAILBOX_CLOCK_CORE);
+    uint32_t source_clock = vcmailbox_get_clock_rate(VCMAILBOX_CLOCK_CORE);
     uint16_t clock_divider = source_clock / frequency;
     self->peripheral->DIV_b.CDIV = clock_divider;
 

--- a/ports/broadcom/common-hal/busio/SPI.c
+++ b/ports/broadcom/common-hal/busio/SPI.c
@@ -183,7 +183,7 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
 
     if (self->index == 1 || self->index == 2) {
         SPI1_Type *p = aux_spi[self->index];
-        uint32_t source_clock = vcmailbox_get_clock_rate_measured(VCMAILBOX_CLOCK_CORE);
+        uint32_t source_clock = vcmailbox_get_clock_rate(VCMAILBOX_CLOCK_CORE);
         uint16_t clock_divider = source_clock / baudrate;
         if (source_clock % baudrate > 0) {
             clock_divider += 2;

--- a/ports/broadcom/common-hal/busio/SPI.c
+++ b/ports/broadcom/common-hal/busio/SPI.c
@@ -87,6 +87,8 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         mp_raise_NotImplementedError(translate("Half duplex SPI is not implemented"));
     }
 
+    // BCM_VERSION != 2711 have 3 SPI but as listed in peripherals/gen/pins.c two are on
+    // index 0, once one index 0 SPI is found the other will throw an invalid_pins error.
     for (size_t i = 0; i < NUM_SPI; i++) {
         if (spi_in_use[i]) {
             continue;
@@ -157,6 +159,7 @@ void common_hal_busio_spi_deinit(busio_spi_obj_t *self) {
     common_hal_reset_pin(self->MOSI);
     common_hal_reset_pin(self->MISO);
     self->clock = NULL;
+    spi_in_use[self->index] = false;
 
     if (self->index == 1 ||
         self->index == 2) {
@@ -198,7 +201,7 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
         SPI0_Type *p = spi[self->index];
         p->CS = polarity << SPI0_CS_CPOL_Pos |
             phase << SPI0_CS_CPHA_Pos;
-        uint32_t source_clock = vcmailbox_get_clock_rate_measured(VCMAILBOX_CLOCK_CORE);
+        uint32_t source_clock = vcmailbox_get_clock_rate(VCMAILBOX_CLOCK_CORE);
         uint16_t clock_divider = source_clock / baudrate;
         if (source_clock % baudrate > 0) {
             clock_divider += 2;

--- a/ports/broadcom/common-hal/busio/UART.c
+++ b/ports/broadcom/common-hal/busio/UART.c
@@ -460,7 +460,7 @@ uint32_t common_hal_busio_uart_get_baudrate(busio_uart_obj_t *self) {
 
 void common_hal_busio_uart_set_baudrate(busio_uart_obj_t *self, uint32_t baudrate) {
     if (self->uart_id == 1) {
-        uint32_t source_clock = vcmailbox_get_clock_rate_measured(VCMAILBOX_CLOCK_CORE);
+        uint32_t source_clock = vcmailbox_get_clock_rate(VCMAILBOX_CLOCK_CORE);
         UART1->BAUD = ((source_clock / (baudrate * 8)) - 1);
     } else {
         ARM_UART_PL011_Type *pl011 = uart[self->uart_id];

--- a/ports/broadcom/common-hal/busio/UART.c
+++ b/ports/broadcom/common-hal/busio/UART.c
@@ -124,7 +124,7 @@ void pl011_IRQHandler(uint8_t index) {
     // Clear the interrupt in case we weren't able to clear it by emptying the
     // FIFO. (This won't clear the FIFO.)
     ARM_UART_PL011_Type *pl011 = uart[index];
-    pl011->ICR = UART0_ICR_RXIC_Msk;
+    pl011->ICR = ARM_UART_PL011_ICR_RXIC_Msk;
 }
 
 void UART0_IRQHandler(void) {
@@ -258,31 +258,31 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
 
         common_hal_busio_uart_set_baudrate(self, baudrate);
 
-        uint32_t line_control = UART0_LCR_H_FEN_Msk;
-        line_control |= (bits - 5) << UART0_LCR_H_WLEN_Pos;
+        uint32_t line_control = ARM_UART_PL011_LCR_H_FEN_Msk;
+        line_control |= (bits - 5) << ARM_UART_PL011_LCR_H_WLEN_Pos;
         if (stop == 2) {
-            line_control |= UART0_LCR_H_STP2_Msk;
+            line_control |= ARM_UART_PL011_LCR_H_STP2_Msk;
         }
         if (parity != BUSIO_UART_PARITY_NONE) {
-            line_control |= UART0_LCR_H_PEN_Msk;
+            line_control |= ARM_UART_PL011_LCR_H_PEN_Msk;
         }
         if (parity == BUSIO_UART_PARITY_EVEN) {
-            line_control |= UART0_LCR_H_EPS_Msk;
+            line_control |= ARM_UART_PL011_LCR_H_EPS_Msk;
         }
         pl011->LCR_H = line_control;
 
-        uint32_t control = UART0_CR_UARTEN_Msk;
+        uint32_t control = ARM_UART_PL011_CR_UARTEN_Msk;
         if (tx != NULL) {
-            control |= UART0_CR_TXE_Msk;
+            control |= ARM_UART_PL011_CR_TXE_Msk;
         }
         if (rx != NULL) {
-            control |= UART0_CR_RXE_Msk;
+            control |= ARM_UART_PL011_CR_RXE_Msk;
         }
         if (cts != NULL) {
-            control |= UART0_CR_CTSEN_Msk;
+            control |= ARM_UART_PL011_CR_CTSEN_Msk;
         }
         if (rts != NULL) {
-            control |= UART0_CR_RTSEN_Msk;
+            control |= ARM_UART_PL011_CR_RTSEN_Msk;
         }
         pl011->CR = control;
     }

--- a/ports/broadcom/common-hal/sdioio/SDCard.c
+++ b/ports/broadcom/common-hal/sdioio/SDCard.c
@@ -122,27 +122,27 @@ STATIC sdmmc_err_t _do_transaction(int slot, sdmmc_command_t *cmdinfo) {
         if (EMMC->STATUS_b.DAT_INHIBIT) {
             return SDMMC_ERR_BUSY;
         }
-        cmd_flags = EMMC_CMDTM_TM_BLKCNT_EN_Msk | EMMC_CMDTM_CMD_ISDATA_Msk;
+        cmd_flags = Arasan_EMMC_Distributor_CMDTM_TM_BLKCNT_EN_Msk | Arasan_EMMC_Distributor_CMDTM_CMD_ISDATA_Msk;
         if (cmdinfo->datalen > cmdinfo->blklen) {
-            cmd_flags |= EMMC_CMDTM_TM_MULTI_BLOCK_Msk;
+            cmd_flags |= Arasan_EMMC_Distributor_CMDTM_TM_MULTI_BLOCK_Msk;
             if ((cmdinfo->flags & SCF_AUTO_STOP) != 0) {
-                cmd_flags |= 1 << EMMC_CMDTM_TM_AUTO_CMD_EN_Pos;
+                cmd_flags |= 1 << Arasan_EMMC_Distributor_CMDTM_TM_AUTO_CMD_EN_Pos;
             }
         }
         if (read) {
-            cmd_flags |= EMMC_CMDTM_TM_DAT_DIR_Msk;
+            cmd_flags |= Arasan_EMMC_Distributor_CMDTM_TM_DAT_DIR_Msk;
         }
-        EMMC->BLKSIZECNT = (cmdinfo->datalen / cmdinfo->blklen) << EMMC_BLKSIZECNT_BLKCNT_Pos |
-            cmdinfo->blklen << EMMC_BLKSIZECNT_BLKSIZE_Pos;
+        EMMC->BLKSIZECNT = (cmdinfo->datalen / cmdinfo->blklen) << Arasan_EMMC_Distributor_BLKSIZECNT_BLKCNT_Pos |
+            cmdinfo->blklen << Arasan_EMMC_Distributor_BLKSIZECNT_BLKSIZE_Pos;
     }
 
     uint32_t response_type = EMMC_CMDTM_CMD_RSPNS_TYPE_RESPONSE_48BITS;
     uint32_t crc = 0;
     if ((cmdinfo->flags & SCF_RSP_CRC) != 0) {
-        crc |= EMMC_CMDTM_CMD_CRCCHK_EN_Msk;
+        crc |= Arasan_EMMC_Distributor_CMDTM_CMD_CRCCHK_EN_Msk;
     }
     if ((cmdinfo->flags & SCF_RSP_IDX) != 0) {
-        crc |= EMMC_CMDTM_CMD_IXCHK_EN_Msk;
+        crc |= Arasan_EMMC_Distributor_CMDTM_CMD_IXCHK_EN_Msk;
     }
     if ((cmdinfo->flags & SCF_RSP_136) != 0) {
         response_type = EMMC_CMDTM_CMD_RSPNS_TYPE_RESPONSE_136BITS;
@@ -152,8 +152,8 @@ STATIC sdmmc_err_t _do_transaction(int slot, sdmmc_command_t *cmdinfo) {
         response_type = EMMC_CMDTM_CMD_RSPNS_TYPE_RESPONSE_NONE;
     }
     uint32_t full_cmd = cmd_flags | crc |
-        cmdinfo->opcode << EMMC_CMDTM_CMD_INDEX_Pos |
-        response_type << EMMC_CMDTM_CMD_RSPNS_TYPE_Pos;
+        cmdinfo->opcode << Arasan_EMMC_Distributor_CMDTM_CMD_INDEX_Pos |
+        response_type << Arasan_EMMC_Distributor_CMDTM_CMD_RSPNS_TYPE_Pos;
     EMMC->CMDTM = full_cmd;
 
     // Wait for an interrupt to indicate completion of the command.
@@ -170,7 +170,7 @@ STATIC sdmmc_err_t _do_transaction(int slot, sdmmc_command_t *cmdinfo) {
         }
         return SDMMC_ERR_TIMEOUT;
     } else {
-        EMMC->INTERRUPT = EMMC_INTERRUPT_CMD_DONE_Msk;
+        EMMC->INTERRUPT = Arasan_EMMC_Distributor_INTERRUPT_CMD_DONE_Msk;
     }
 
     // Transfer the data.
@@ -197,7 +197,7 @@ STATIC sdmmc_err_t _do_transaction(int slot, sdmmc_command_t *cmdinfo) {
                 EMMC->DATA = ((uint32_t *)cmdinfo->data)[i];
             }
         }
-        uint32_t data_done_mask = EMMC_INTERRUPT_ERR_Msk | EMMC_INTERRUPT_DATA_DONE_Msk;
+        uint32_t data_done_mask = Arasan_EMMC_Distributor_INTERRUPT_ERR_Msk | Arasan_EMMC_Distributor_INTERRUPT_DATA_DONE_Msk;
         start_ticks = port_get_raw_ticks(NULL);
         while ((EMMC->INTERRUPT & data_done_mask) == 0 && (port_get_raw_ticks(NULL) - start_ticks) < (size_t)cmdinfo->timeout_ms) {
         }
@@ -282,7 +282,7 @@ void common_hal_sdioio_sdcard_construct(sdioio_sdcard_obj_t *self,
 
     }
     // Set max timeout
-    EMMC->CONTROL1 |= EMMC_CONTROL1_CLK_INTLEN_Msk | (0xe << EMMC_CONTROL1_DATA_TOUNIT_Pos);
+    EMMC->CONTROL1 |= Arasan_EMMC_Distributor_CONTROL1_CLK_INTLEN_Msk | (0xe << Arasan_EMMC_Distributor_CONTROL1_DATA_TOUNIT_Pos);
 
     EMMC->IRPT_MASK = 0xffffffff;
 


### PR DESCRIPTION
When sending requests to the video core to return the "measured" CORE clock rate the mailbox registers frequently hang preventing any further access to the video core. This PR replaces the "measured" CORE clock rate checks with an unmeasured request. Fixes #5887 & fixes #5913.

A separate pull request to adafruit/broadcom-peripherals (https://github.com/adafruit/broadcom-peripherals/pull/1) is being submitted to add the additional mailbox call routine.

This will also resolve the deinit issue noted in #5887

Tested on zero2w, zero_w and pi4b.