### PR TITLE
Revert "Correctly raise OS error in socketpool_socket_recv_into()"

### DIFF
--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -1109,7 +1109,7 @@ int socketpool_socket_recv_into(socketpool_socket_obj_t *socket,
             break;
     }
     if (ret == (unsigned)-1) {
-        mp_raise_OSError(_errno);
+        return -_errno;
     }
     return ret;
 }


### PR DESCRIPTION
Reverts adafruit/circuitpython#7623.

@DavePutz: @jepler brought up that the `mp_raise` is being done in the internal routine `socketpool_socket_recv_into()`. There is already a raise in `common_halsocket_pool_socket_recv_into()` In general these routines below `common_hal...()` do not raise, because they are called from other places that don't expect them to raise, like the web workflow implementation.

So I think we need to revert this, and figure out what routine is leaking the -116 returned by `socketpool_socket_recv_into()` into a general "count" return. I looked at this a bit, but couldn't find such a place.