### PR TITLE
Fix print of "soft reboot" when the user presses ^D

### DIFF
--- a/main.c
+++ b/main.c
@@ -1078,17 +1078,16 @@ int __attribute__((used)) main(void) {
     int exit_code = PYEXEC_FORCED_EXIT;
     bool skip_repl = true;
     bool simulate_reset = true;
-    bool first_run = true;
     for (;;) {
         if (!skip_repl) {
             exit_code = run_repl(get_safe_mode());
             supervisor_set_run_reason(RUN_REASON_REPL_RELOAD);
         }
         if (exit_code == PYEXEC_FORCED_EXIT) {
-            if (!first_run) {
+            if (!simulate_reset) {
                 serial_write_compressed(translate("soft reboot\n"));
             }
-            first_run = false;
+            simulate_reset = false;
             if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
                 // If code.py did a fake deep sleep, pretend that we
                 // are running code.py for the first time after a hard

--- a/main.c
+++ b/main.c
@@ -1078,15 +1078,17 @@ int __attribute__((used)) main(void) {
     int exit_code = PYEXEC_FORCED_EXIT;
     bool skip_repl = true;
     bool simulate_reset = true;
+    bool first_run = true;
     for (;;) {
         if (!skip_repl) {
             exit_code = run_repl(get_safe_mode());
             supervisor_set_run_reason(RUN_REASON_REPL_RELOAD);
         }
         if (exit_code == PYEXEC_FORCED_EXIT) {
-            if (!simulate_reset) {
+            if (!first_run) {
                 serial_write_compressed(translate("soft reboot\n"));
             }
+            first_run = false;
             if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
                 // If code.py did a fake deep sleep, pretend that we
                 // are running code.py for the first time after a hard


### PR DESCRIPTION
The logic of the main loop was changed between version 7 and 8 ([Commit](https://github.com/adafruit/circuitpython/commit/9307b62ad54bcd27c493e8d63dc91059e6612b79)). Something is wrong with the existing version 8 logic so the serial write of "soft reboot" is never executed when the user does a soft reboot.
A consequence of this is that tools like `tools/pyboard.py`, `ampy` and `mpremote` are not able to activate the raw REPL since they execute a soft reboot and wait for this to be printed to the console.