### PR TITLE
Enable bus device on hallowing M0

### DIFF
--- a/ports/atmel-samd/boards/hallowing_m0_express/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/hallowing_m0_express/mpconfigboard.mk
@@ -12,6 +12,7 @@ LONGINT_IMPL = NONE
 
 # To keep the build small
 CIRCUITPY_AUDIOBUSIO = 0
+CIRCUITPY_BUSDEVICE = 1  # lis3dh needs it
 CIRCUITPY_KEYPAD = 0
 
 # Include these Python libraries in firmware.


### PR DESCRIPTION
The Hallowing M0 has the adafruit_lis3dh library frozen in, which requires adafruit_bus_device.
So might as well enable it rather than depend on an external library.

In the futture if there are size issues, I noticed that `paralleldisplay` is enabled on it, which doesn't seem useful on a board with a builtin SPI display.