### PR TITLE
OnDiskGif delay was being chopped to 8 bits

### DIFF
--- a/shared-bindings/gifio/OnDiskGif.h
+++ b/shared-bindings/gifio/OnDiskGif.h
@@ -40,7 +40,7 @@ uint32_t common_hal_gifio_ondiskgif_get_pixel(gifio_ondiskgif_t *bitmap,
 uint16_t common_hal_gifio_ondiskgif_get_height(gifio_ondiskgif_t *self);
 mp_obj_t common_hal_gifio_ondiskgif_get_bitmap(gifio_ondiskgif_t *self);
 uint16_t common_hal_gifio_ondiskgif_get_width(gifio_ondiskgif_t *self);
-uint8_t common_hal_gifio_ondiskgif_next_frame(gifio_ondiskgif_t *self, bool setDirty);
+uint32_t common_hal_gifio_ondiskgif_next_frame(gifio_ondiskgif_t *self, bool setDirty);
 int32_t common_hal_gifio_ondiskgif_get_duration(gifio_ondiskgif_t *self);
 int32_t common_hal_gifio_ondiskgif_get_frame_count(gifio_ondiskgif_t *self);
 int32_t common_hal_gifio_ondiskgif_get_min_delay(gifio_ondiskgif_t *self);

--- a/shared-module/gifio/OnDiskGif.c
+++ b/shared-module/gifio/OnDiskGif.c
@@ -185,7 +185,7 @@ int32_t common_hal_gifio_ondiskgif_get_max_delay(gifio_ondiskgif_t *self) {
     return self->max_delay;
 }
 
-uint8_t common_hal_gifio_ondiskgif_next_frame(gifio_ondiskgif_t *self, bool setDirty) {
+uint32_t common_hal_gifio_ondiskgif_next_frame(gifio_ondiskgif_t *self, bool setDirty) {
     int nextDelay = 0;
     int result = GIF_playFrame(&self->gif, &nextDelay, self->bitmap);
 


### PR DESCRIPTION
`OnDiskGif.next_frame()` returns a delay, which was incorrectly chopped to 8 bits.

Thanks @TheKitty  for finding the issue, @jepler for pin-pointing it, and @TheKitty and testing the fix.