### PR TITLE
use right DBL_TAP_REG when resetting to bootloader

### DIFF
--- a/ports/mimxrt10xx/common-hal/microcontroller/__init__.c
+++ b/ports/mimxrt10xx/common-hal/microcontroller/__init__.c
@@ -39,8 +39,6 @@
 #include "supervisor/shared/safe_mode.h"
 #include "supervisor/shared/translate/translate.h"
 
-#define DBL_TAP_REG              SNVS->LPGPR[3]
-
 void common_hal_mcu_delay_us(uint32_t delay) {
     mp_hal_delay_us(delay);
 }

--- a/ports/mimxrt10xx/reset.h
+++ b/ports/mimxrt10xx/reset.h
@@ -33,6 +33,7 @@
 #include "py/mpconfig.h"
 
 // Copied from inc/uf2.h in https://github.com/Microsoft/uf2-samd21
+#define DBL_TAP_REG              SNVS->LPGPR[3]
 #define DBL_TAP_MAGIC 0xf01669ef // Randomly selected, adjusted to have first and last bit set
 #define DBL_TAP_MAGIC_QUICK_BOOT 0xf02669ef
 

--- a/ports/mimxrt10xx/supervisor/port.c
+++ b/ports/mimxrt10xx/supervisor/port.c
@@ -301,7 +301,7 @@ void reset_port(void) {
 }
 
 void reset_to_bootloader(void) {
-    SNVS->LPGPR[0] = DBL_TAP_MAGIC;
+    DBL_TAP_REG = DBL_TAP_MAGIC;
     reset();
 }
 


### PR DESCRIPTION
This helps my development scripts work better, and probably also fixes a problem switching from the circuitpython environment back to arduino. (specifically, the "1200 baud" serial trick was not rebooting into the bootloader but was just resetting)