### PR TITLE
Document aeios.AES.rekey() and refactor arg validation

### DIFF
--- a/shared-bindings/aesio/aes.c
+++ b/shared-bindings/aesio/aes.c
@@ -20,7 +20,7 @@
 //|         self,
 //|         key: ReadableBuffer,
 //|         mode: int = 0,
-//|         iv: Optional[ReadableBuffer] = None,
+//|         IV: Optional[ReadableBuffer] = None,
 //|         segment_size: int = 8,
 //|     ) -> None:
 //|         """Create a new AES state with the given key.
@@ -101,7 +101,7 @@ STATIC mp_obj_t aesio_aes_make_new(const mp_obj_type_t *type, size_t n_args,
 //|     def rekey(
 //|         self,
 //|         key: ReadableBuffer,
-//|         iv: Optional[ReadableBuffer] = None,
+//|         IV: Optional[ReadableBuffer] = None,
 //|     ) -> None:
 //|         """Update the AES state with the given key.
 //|

--- a/shared-bindings/aesio/aes.c
+++ b/shared-bindings/aesio/aes.c
@@ -28,7 +28,7 @@
 //|         :param ~circuitpython_typing.ReadableBuffer key: A 16-, 24-, or 32-byte key
 //|         :param int mode: AES mode to use.  One of: `MODE_ECB`, `MODE_CBC`, or
 //|                          `MODE_CTR`
-//|         :param ~circuitpython_typing.ReadableBuffer iv: Initialization vector to use for CBC or CTR mode
+//|         :param ~circuitpython_typing.ReadableBuffer IV: Initialization vector to use for CBC or CTR mode
 //|
 //|         Additional arguments are supported for legacy reasons.
 //|
@@ -106,7 +106,7 @@ STATIC mp_obj_t aesio_aes_make_new(const mp_obj_type_t *type, size_t n_args,
 //|         """Update the AES state with the given key.
 //|
 //|         :param ~circuitpython_typing.ReadableBuffer key: A 16-, 24-, or 32-byte key
-//|         :param ~circuitpython_typing.ReadableBuffer iv: Initialization vector to use
+//|         :param ~circuitpython_typing.ReadableBuffer IV: Initialization vector to use
 //|                                                         for CBC or CTR mode"""
 //|         ...
 STATIC mp_obj_t aesio_aes_rekey(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/aesio/aes.c
+++ b/shared-bindings/aesio/aes.c
@@ -98,33 +98,49 @@ STATIC mp_obj_t aesio_aes_make_new(const mp_obj_type_t *type, size_t n_args,
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC mp_obj_t aesio_aes_rekey(size_t n_args, const mp_obj_t *pos_args) {
+//|     def rekey(
+//|         self,
+//|         key: ReadableBuffer,
+//|         iv: Optional[ReadableBuffer] = None,
+//|     ) -> None:
+//|         """Update the AES state with the given key.
+//|
+//|         :param ~circuitpython_typing.ReadableBuffer key: A 16-, 24-, or 32-byte key
+//|         :param ~circuitpython_typing.ReadableBuffer iv: Initialization vector to use
+//|                                                         for CBC or CTR mode"""
+//|         ...
+STATIC mp_obj_t aesio_aes_rekey(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     aesio_aes_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    enum { ARG_key, ARG_IV };
+    static const mp_arg_t allowed_args[] = {
+        {MP_QSTR_key, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_obj = MP_OBJ_NULL} },
+        {MP_QSTR_IV, MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(pos_args[1], &bufinfo, MP_BUFFER_READ);
+
+    mp_get_buffer_raise(args[ARG_key].u_obj, &bufinfo, MP_BUFFER_READ);
     const uint8_t *key = bufinfo.buf;
     size_t key_length = bufinfo.len;
-    if (key == NULL) {
-        mp_raise_ValueError(translate("No key was specified"));
-    }
+
     if ((key_length != 16) && (key_length != 24) && (key_length != 32)) {
         mp_raise_ValueError(translate("Key must be 16, 24, or 32 bytes long"));
     }
 
     const uint8_t *iv = NULL;
-    if (n_args > 2) {
-        mp_get_buffer_raise(pos_args[2], &bufinfo, MP_BUFFER_READ);
-        size_t iv_length = bufinfo.len;
-        iv = (const uint8_t *)bufinfo.buf;
-        (void)mp_arg_validate_length(iv_length, AES_BLOCKLEN, MP_QSTR_IV);
+    if (args[ARG_IV].u_obj != NULL &&
+        mp_get_buffer(args[ARG_IV].u_obj, &bufinfo, MP_BUFFER_READ)) {
+        (void)mp_arg_validate_length(bufinfo.len, AES_BLOCKLEN, MP_QSTR_IV);
+
+        iv = bufinfo.buf;
     }
 
     common_hal_aesio_aes_rekey(self, key, key_length, iv);
     return mp_const_none;
 }
-
-MP_DEFINE_CONST_FUN_OBJ_VAR(aesio_aes_rekey_obj, 2, aesio_aes_rekey);
+MP_DEFINE_CONST_FUN_OBJ_KW(aesio_aes_rekey_obj, 1, aesio_aes_rekey);
 
 STATIC void validate_length(aesio_aes_obj_t *self, size_t src_length,
     size_t dest_length) {


### PR DESCRIPTION
Hi,

This PR solves: aeios.AES.rekey() is not documented #7435 

a) Documented the aeios.AES.rekey() function
b) Refactored the arguments validation. Please let me know if that was the idea of "canonicalize arg checking".

Tested with `adafruit_feather_rp2040` with the following code:

```python
import aesio
import os
from binascii import hexlify, unhexlify

plaintext = unhexlify("6bc1bee22e409f96e93d7e117393172a")
key = unhexlify("2b7e151628aed2a6abf7158809cf4f3c")
iv = unhexlify("000102030405060708090a0b0c0d0e0f")

cyphertext = bytearray(len(plaintext))
output = memoryview(cyphertext)
cipher = aesio.AES(key=key, mode=aesio.MODE_CBC, IV=iv)

# Encrypt
cipher.encrypt_into(plaintext, output)

print(end='\n\n')
print('input:     ', str(hexlify(plaintext)), end='\n')
print('encrypted: ', str(hexlify(output)), end='\n')

# Decrypt
plaintext = bytearray(len(plaintext))
cipher = aesio.AES(key=key, mode=aesio.MODE_CBC, IV=iv)

output = memoryview(plaintext)
cipher.decrypt_into(cyphertext, output)
print('decrypted: ', str(hexlify(output)), end='\n')

# Rekey
plaintext = unhexlify("6bc1bee22e409f96e93d7e117393172a")
key2 = unhexlify("2b7e151628aed2a6abf7158809cAAAAA")
cyphertext = bytearray(len(plaintext))
output = memoryview(cyphertext)

cipher.rekey(key=key2, IV=iv) # update key of the existing cipher object

# Encrypt
cipher.encrypt_into(plaintext, output)

print(end='\n')
print('Rekey...', end='\n')
print('input:     ', str(hexlify(plaintext)), end='\n')
print('encrypted: ', str(hexlify(output)), end='\n')

# Decrypt
plaintext = bytearray(len(plaintext))
cipher = aesio.AES(key=key2, mode=aesio.MODE_CBC, IV=iv)

output = memoryview(plaintext)
cipher.decrypt_into(cyphertext, output)
print('decrypted: ', str(hexlify(output)), end='\n\n')
```

Output:

```
input:      b'6bc1bee22e409f96e93d7e117393172a'
encrypted:  b'7649abac8119b246cee98e9b12e9197d'
decrypted:  b'6bc1bee22e409f96e93d7e117393172a'

Rekey...
input:      b'6bc1bee22e409f96e93d7e117393172a'
encrypted:  b'ff7e2905e0af08d89121429ee15b311b'
decrypted:  b'6bc1bee22e409f96e93d7e117393172a'
```

Thank you!
