### PR TITLE
ESP32 Family: Add multiple transctions to SPI for improved efficency

### DIFF
--- a/ports/espressif/common-hal/busio/SPI.c
+++ b/ports/espressif/common-hal/busio/SPI.c
@@ -262,9 +262,8 @@ bool common_hal_busio_spi_transfer(busio_spi_obj_t *self,
 
             for (int i = 0; i < cur_trans; i++) {
                 spi_device_queue_trans(spi_handle[self->host_id], &transactions[i], portMAX_DELAY);
+                RUN_BACKGROUND_TASKS;
             }
-
-            RUN_BACKGROUND_TASKS;
 
             spi_transaction_t *rtrans;
             for (int x = 0; x < cur_trans; x++) {

--- a/ports/espressif/common-hal/busio/SPI.c
+++ b/ports/espressif/common-hal/busio/SPI.c
@@ -33,6 +33,7 @@
 #include "driver/spi_common_internal.h"
 
 #define SPI_MAX_DMA_BITS (SPI_MAX_DMA_LEN * 8)
+#define MAX_SPI_TRANSACTIONS 10
 
 static bool spi_never_reset[SOC_SPI_PERIPH_NUM];
 static spi_device_handle_t spi_handle[SOC_SPI_PERIPH_NUM];
@@ -59,7 +60,7 @@ static void set_spi_config(busio_spi_obj_t *self,
         .clock_speed_hz = baudrate,
         .mode = phase | (polarity << 1),
         .spics_io_num = -1, // No CS pin
-        .queue_size = 1,
+        .queue_size = MAX_SPI_TRANSACTIONS,
         .pre_cb = NULL
     };
     esp_err_t result = spi_bus_add_device(self->host_id, &device_config, &spi_handle[self->host_id]);
@@ -213,47 +214,62 @@ bool common_hal_busio_spi_transfer(busio_spi_obj_t *self,
         mp_raise_ValueError(translate("No MISO Pin"));
     }
 
-    spi_transaction_t transaction = { 0 };
+    spi_transaction_t transactions[MAX_SPI_TRANSACTIONS];
 
     // Round to nearest whole set of bits
     int bits_to_send = len * 8 / self->bits * self->bits;
 
     if (len <= 4) {
+        memset(&transactions[0], 0, sizeof(spi_transaction_t));
         if (data_out != NULL) {
-            memcpy(&transaction.tx_data, data_out, len);
+            memcpy(&transactions[0].tx_data, data_out, len);
         }
 
-        transaction.flags = SPI_TRANS_USE_TXDATA | SPI_TRANS_USE_RXDATA;
-        transaction.length = bits_to_send;
-        spi_device_transmit(spi_handle[self->host_id], &transaction);
+        transactions[0].flags = SPI_TRANS_USE_TXDATA | SPI_TRANS_USE_RXDATA;
+        transactions[0].length = bits_to_send;
+        spi_device_transmit(spi_handle[self->host_id], &transactions[0]);
 
         if (data_in != NULL) {
-            memcpy(data_in, &transaction.rx_data, len);
+            memcpy(data_in, &transactions[0].rx_data, len);
         }
     } else {
         int offset = 0;
         int bits_remaining = bits_to_send;
+        int cur_trans = 0;
 
         while (bits_remaining && !mp_hal_is_interrupted()) {
-            memset(&transaction, 0, sizeof(transaction));
 
-            transaction.length =
-                bits_remaining > SPI_MAX_DMA_BITS ? SPI_MAX_DMA_BITS : bits_remaining;
+            cur_trans = 0;
+            while (bits_remaining && (cur_trans != MAX_SPI_TRANSACTIONS)) {
+                memset(&transactions[cur_trans], 0, sizeof(spi_transaction_t));
 
-            if (data_out != NULL) {
-                transaction.tx_buffer = data_out + offset;
+                transactions[cur_trans].length =
+                    bits_remaining > SPI_MAX_DMA_BITS ? SPI_MAX_DMA_BITS : bits_remaining;
+
+                if (data_out != NULL) {
+                    transactions[cur_trans].tx_buffer = data_out + offset;
+                }
+                if (data_in != NULL) {
+                    transactions[cur_trans].rx_buffer = data_in + offset;
+                }
+
+                bits_remaining -= transactions[cur_trans].length;
+
+                // doesn't need ceil(); loop ends when bits_remaining is 0
+                offset += transactions[cur_trans].length / 8;
+                cur_trans++;
             }
-            if (data_in != NULL) {
-                transaction.rx_buffer = data_in + offset;
+
+            for (int i = 0; i < cur_trans; i++) {
+                spi_device_queue_trans(spi_handle[self->host_id], &transactions[i], portMAX_DELAY);
             }
-
-            spi_device_transmit(spi_handle[self->host_id], &transaction);
-            bits_remaining -= transaction.length;
-
-            // doesn't need ceil(); loop ends when bits_remaining is 0
-            offset += transaction.length / 8;
 
             RUN_BACKGROUND_TASKS;
+
+            spi_transaction_t *rtrans;
+            for (int x = 0; x < cur_trans; x++) {
+                spi_device_get_trans_result(spi_handle[self->host_id], &rtrans, portMAX_DELAY);
+            }
         }
     }
     return true;

--- a/ports/espressif/common-hal/busio/SPI.c
+++ b/ports/espressif/common-hal/busio/SPI.c
@@ -262,11 +262,11 @@ bool common_hal_busio_spi_transfer(busio_spi_obj_t *self,
 
             for (int i = 0; i < cur_trans; i++) {
                 spi_device_queue_trans(spi_handle[self->host_id], &transactions[i], portMAX_DELAY);
-                RUN_BACKGROUND_TASKS;
             }
 
             spi_transaction_t *rtrans;
             for (int x = 0; x < cur_trans; x++) {
+                RUN_BACKGROUND_TASKS;
                 spi_device_get_trans_result(spi_handle[self->host_id], &rtrans, portMAX_DELAY);
             }
         }


### PR DESCRIPTION
While doing some other work with my Saleae, I noticed large SPI transfers had a gap every 4Kb for about 300 microseconds. Over larger transfers this delay adds up and becomes more apparent the faster the SPI frequency as the delay is constant vs frequency.

This PR adds multiple transaction queuing. The current implementation sends 1 transaction at a time. In the linked [IDF example](https://github.com/espressif/esp-idf/tree/af805df3cb6117cc74f0875831fbab6446824453/examples/peripherals/spi_master/lcd) it shows how to include multiple transactions. This basically eliminates the delay (it drops to 14 microseconds).

The only downside I have found is you go from one SPI transaction in memory to 10, each transaction is 34 bytes so not a large increase.

For example:
At 80Mhz for a 100 KB transfer the ideal transfer time is 10 milliseconds. The current 300 microsecond delay every 4KB results in a total delay of ~7.2 milliseconds resulting in a total time of 17.2 milliseconds. Almost double the expected time.
At 10Mhz for a 100KB transfer the ideal transfer time is 80 milliseconds. The added 7.2 milliseconds delay for 100KB results in 87.2 milliseconds, almost 10% more then expected.

The most obvious example of the speedup having a positive effect will be in SPI graphic displays (including displayio), But any large SPI transfer will see a speedup, and the faster the frequency the more apparent.

The current transaction buffer size of 10 was arbitrarily chosen.
