### PR TITLE
Conditionally run jobs on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
   release:
     types: [published]
-  check_suite:
-    types: [rerequested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -64,24 +62,32 @@ jobs:
         PULL: ${{ github.event.number }}
         GITHUB_TOKEN: ${{ github.token }}
         EXCLUDE_COMMIT: ${{ github.event.pull_request.head.sha }}
-    - name: Set head sha
+    - name: Set head sha (pull)
       if: github.event_name == 'pull_request'
       run: echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
-    - name: Set base sha
+    - name: Set base sha (pull)
       if: github.event_name == 'pull_request'
       run: |
         git fetch --no-tags --no-recurse-submodules --depth=$((DEPTH + 1)) origin $HEAD_SHA
         echo "BASE_SHA=$(git rev-list $HEAD_SHA --skip=$DEPTH --max-count=1)" >> $GITHUB_ENV
       env:
         DEPTH: ${{ steps.get-last-commit-with-checks.outputs.commit_depth || github.event.pull_request.commits }}
+    - name: Set head sha (push)
+      if: github.event_name == 'push'
+      run: echo "HEAD_SHA=${{ github.event.after }}" >> $GITHUB_ENV
+    - name: Set base sha (push)
+      if: github.event_name == 'push'
+      run: git cat-file -e $SHA && echo "BASE_SHA=$SHA" >> $GITHUB_ENV || true
+      env:
+        SHA: ${{ github.event.before }}
     - name: Get changes
       id: get-changes
-      if: github.event_name == 'pull_request'
+      if: env.BASE_SHA && env.HEAD_SHA
       run: echo $(git diff $BASE_SHA...$HEAD_SHA --name-only) | echo "changed_files=[\"$(sed "s/ /\", \"/g")\"]" >> $GITHUB_OUTPUT
     - name: Set matrix
       id: set-matrix
-      working-directory: tools
       run: python3 -u ci_set_matrix.py
+      working-directory: tools
       env:
         CHANGED_FILES: ${{ steps.get-changes.outputs.changed_files }}
         LAST_FAILED_JOBS: ${{ steps.get-last-commit-with-checks.outputs.check_runs }}

--- a/.github/workflows/create-website-pr.yml
+++ b/.github/workflows/create-website-pr.yml
@@ -6,7 +6,7 @@ name: Update CircuitPython.org
 
 on:
   release:
-    types: [published, rerequested]
+    types: [published]
 
 jobs:
   website:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,8 +5,8 @@
 name: pre-commit
 
 on:
-  pull_request:
   push:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -98,9 +98,6 @@ def set_output(name: str, value):
 
 
 def set_boards(build_all: bool):
-    if last_failed_jobs.get("mpy-cross") or last_failed_jobs.get("tests"):
-        build_all = True
-
     # Get boards in json format
     boards_info_json = build_board_info.get_board_mapping()
     all_board_ids = set()


### PR DESCRIPTION
In this PR:
- Conditionally run jobs on push if a valid base sha is present. All jobs are run on push of a tag or a new branch.
  - The diff is done with `BASE_SHA = ${{ github.event.before }}` and `HEAD_SHA = ${{ github.event.after }}`.
- Explicitly check for failure of jobs which have dependent jobs. If these jobs fail, the dependent jobs complete with `skipped` status and aren't caught in `bad_runs` which only consists of `failed` and `incomlpete` jobs. Earlier this was checked in `ci_set_matrix` which set all boards to build but that isn't efficient if the PR contains changes only affecting a limited number of boards so instead check it in `ci_changes_per_commit` and don't do a commit specific diff if this is the case.  
- Remove deprecated trigger events from workflows.