### PR TITLE
update gifio example in docs

### DIFF
--- a/shared-bindings/gifio/OnDiskGif.c
+++ b/shared-bindings/gifio/OnDiskGif.c
@@ -52,7 +52,7 @@
 //|       odg = gifio.OnDiskGif('/sample.gif')
 //|
 //|       start = time.monotonic()
-//|       odg.next_frame() # Load the first frame
+//|       next_delay = odg.next_frame() # Load the first frame
 //|       end = time.monotonic()
 //|       overhead = end - start
 //|


### PR DESCRIPTION
Fix issue in gifio example code where `next_delay` is referenced before it is defined.

---

This library made displaying a gif on my macropad a walk in the park. Thanks for adding it. :smile: 

https://user-images.githubusercontent.com/23131083/225768022-2874c1b4-7bf0-4182-a37d-c16cc5d13626.mp4

