### PR TITLE
re-enable mkfs for >4GB filesystems whenver FULL_BUILD

### DIFF
--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -60,7 +60,9 @@
     X(EISDIR) \
     X(EINVAL) \
 
-#define MICROPY_FATFS_EXFAT 0
+#define MICROPY_FATFS_EXFAT    (0)
+// FAT32 mkfs takes about 500 bytes.
+#define MICROPY_FF_MKFS_FAT32 (0)
 
 // Only support simpler HID descriptors on SAMD21.
 #define CIRCUITPY_USB_HID_MAX_REPORT_IDS_PER_DESCRIPTOR (1)

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -255,6 +255,10 @@ typedef long mp_off_t;
 #define MICROPY_FATFS_EXFAT           (CIRCUITPY_FULL_BUILD)
 #endif
 
+#ifndef MICROPY_FF_MKFS_FAT32
+#define MICROPY_FF_MKFS_FAT32           (CIRCUITPY_FULL_BUILD)
+#endif
+
 // LONGINT_IMPL_xxx are defined in the Makefile.
 //
 #ifdef LONGINT_IMPL_NONE

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -268,7 +268,13 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
 //|
 //|     @staticmethod
 //|     def mkfs(self) -> None:
-//|         """Format the block device, deleting any data that may have been there"""
+//|         """Format the block device, deleting any data that may have been there.
+//|
+//|         **Limitations**: On SAMD21 builds, `mkfs()` will raise ``OSError(22)`` when
+//|         attempting to format filesystems larger than 4GB. The extra code to format larger
+//|         filesystems will not fit on these builds. You can still access
+//|         larger filesystems, but you will need to format the filesystem on another device.
+//|         """
 //|         ...
 //|     def open(self, path: str, mode: str) -> None:
 //|         """Like builtin ``open()``"""

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -266,6 +266,7 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
 //|     This property cannot be changed, use `storage.remount` instead."""
 //|     ...
 //|
+//|     @staticmethod
 //|     def mkfs(self) -> None:
 //|         """Format the block device, deleting any data that may have been there"""
 //|         ...


### PR DESCRIPTION
We (I) disabled this across the board to save firmware size for small SAMD boards. Re-enable it everywhere where we have "full build"s.

According to my notes, 12c95ee9e96e9c5fd3609a6f095cd80fc2a849f3 saved 508 bytes of flash.

Closes: #7732 