### PR TITLE
Diskinfo api for web workflow

### DIFF
--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -805,7 +805,7 @@ static void _reply_with_version_json(socketpool_socket_obj_t *socket, _request *
     _update_encoded_ip();
     // Note: this leverages the fact that C concats consecutive string literals together.
     mp_printf(&_socket_print,
-        "{\"web_api_version\": 1, "
+        "{\"web_api_version\": 2, "
         "\"version\": \"" MICROPY_GIT_TAG "\", "
         "\"build_date\": \"" MICROPY_BUILD_DATE "\", "
         "\"board_name\": \"" MICROPY_HW_BOARD_NAME "\", "


### PR DESCRIPTION
resolves #7637 

URL is `/cp/diskinfo.json` Response sizes are in bytes.

Example of response:
```
{"free": 212992, "block_size": 512, "total": 963072}
```
Maybe we don't really need `block_size` in the results? I can remove it if not. I added it initially in order to test how it's looked up, which is needed to find the correct multiplier to get to bytes units.


Tested successfully with Feather ESP32-S2 TFT.

Thank you to: isacben, Neradoc, and anecdata who all helped me in getting this far on implementing this API. Also Scott for the pointer to t_getfree(), the FatFs docs that were linked were quite helpful as well.