### PR TITLE
Rewrite pystack logic & Update auto-reload

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -28,14 +28,6 @@ msgid ""
 "Code stopped by auto-reload. Reloading soon.\n"
 msgstr ""
 
-#: main.c
-msgid ""
-"\n"
-"Invalid CIRCUITPY_PYSTACK_SIZE\n"
-"\n"
-"\r"
-msgstr ""
-
 #: supervisor/shared/safe_mode.c
 msgid ""
 "\n"
@@ -1250,6 +1242,10 @@ msgstr ""
 
 #: shared-bindings/wifi/Radio.c
 msgid "Invalid BSSID"
+msgstr ""
+
+#: main.c
+msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
 msgstr ""
 
 #: shared-bindings/wifi/Radio.c


### PR DESCRIPTION
Two unrelated fixes:

- Rewrite `allocate_pystack` logic:
  - Saves space, fixes translation string, allow pystack to be set only when `SAFE_MODE_NONE` and remove upper size limit.
- Don't call `reload_initiate` if already initiated:
  - Stumbled upon this while trying to investigate #3502.