### PR TITLE
Add builtin display to lolin pico

### DIFF
--- a/ports/espressif/boards/lolin_s2_pico/board.c
+++ b/ports/espressif/boards/lolin_s2_pico/board.c
@@ -27,8 +27,76 @@
 #include "supervisor/board.h"
 #include "mpconfigboard.h"
 #include "shared-bindings/microcontroller/Pin.h"
+#include "shared-bindings/board/__init__.h"
+#include "shared-bindings/displayio/I2CDisplay.h"
+#include "shared-module/displayio/__init__.h"
+#include "shared-module/displayio/mipi_constants.h"
+#include "shared-bindings/busio/I2C.h"
+#include "supervisor/shared/board.h"
+#include "shared-bindings/board/__init__.h"
+
+uint8_t display_init_sequence[] = { // SSD1306
+    0xAE, 0, // DISPLAY_OFF
+    0x20, 1, 0x00, // Set memory addressing to horizontal mode.
+    0x81, 1, 0xcf, // set contrast control
+    0xA1, 0, // Column 127 is segment 0
+    0xA6, 0, // Normal display
+    0xc8, 0, // Normal display
+    0xA8, 1, 0x1f, // Mux ratio is height-1
+    0xd5, 1, 0x80, // Set divide ratio
+    0xd9, 1, 0xf1, // Set pre-charge period
+    0xda, 1, 0x02, // Set com configuration to 2 if height is 32 and width not 64
+    0xdb, 1, 0x40, // Set vcom configuration
+    0x8d, 1, 0x14, // Enable charge pump
+    0xAF, 0, // DISPLAY_ON
+};
+
+static void display_init(void) {
+    busio_i2c_obj_t *i2c = common_hal_board_create_i2c(0);
+
+    displayio_i2cdisplay_obj_t *bus = &displays[0].i2cdisplay_bus;
+    bus->base.type = &displayio_i2cdisplay_type;
+    common_hal_displayio_i2cdisplay_construct(bus,
+        i2c,
+        0x3c,
+        &pin_GPIO18 // reset
+        );
+
+    displayio_display_obj_t *display = &displays[0].display;
+    display->base.type = &displayio_display_type;
+    common_hal_displayio_display_construct(display,
+        bus,
+        128, // Width
+        32, // Height
+        0, // column start
+        0, // row start
+        0, // rotation
+        1, // Color depth
+        true, // grayscale
+        false, // pixels in byte share row. Only used with depth < 8
+        1, // bytes per cell. Only valid for depths < 8
+        false, // reverse_pixels_in_byte. Only valid for depths < 8
+        true, // reverse_pixels_in_word
+        0x21, // Set column command
+        0x22, // Set row command
+        44, // Write ram command
+        display_init_sequence,
+        sizeof(display_init_sequence),
+        NULL, // no backlight pin
+        0x81, // brightness command
+        1.0f, // brightness
+        true, // single_byte_bounds
+        true, // data as commands
+        true, // auto_refresh
+        60, // native_frames_per_second
+        true, // backlight_on_high
+        false, // SH1107_addressing
+        0); // backlight pwm frequency
+}
 
 void board_init(void) {
+    // init display
+    display_init();
     // Debug UART
     #ifdef DEBUG
     common_hal_never_reset_pin(&pin_GPIO43);

--- a/ports/espressif/boards/lolin_s2_pico/pins.c
+++ b/ports/espressif/boards/lolin_s2_pico/pins.c
@@ -1,4 +1,5 @@
 #include "shared-bindings/board/__init__.h"
+#include "shared-module/displayio/__init__.h"
 
 STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
@@ -52,5 +53,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SCK),  MP_ROM_PTR(&pin_GPIO36) }, // Not labelled on booard, on schematic
     { MP_ROM_QSTR(MP_QSTR_MISO),  MP_ROM_PTR(&pin_GPIO37) },// Not labelled on booard, on schematic
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display)}
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
Add builtin display support with shared board.I2C to Lolin S2 Pico.
Like the feather TFT (for SPI), the I2C bus therefore has to be used with board.I2C() unless the display is released first.