### PR TITLE
Updated block_device type annotation

### DIFF
--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -267,7 +267,7 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
 //|     ...
 //|
 //|     @staticmethod
-//|     def mkfs(self, block_device: BlockDevice) -> None:
+//|     def mkfs(block_device: BlockDevice) -> None:
 //|         """Format the block device, deleting any data that may have been there.
 //|
 //|         **Limitations**: On SAMD21 builds, `mkfs()` will raise ``OSError(22)`` when

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -252,7 +252,7 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_enable_usb_drive),  MP_ROM_PTR(&storage_enable_usb_drive_obj) },
 
 //| class VfsFat:
-//|     def __init__(self, block_device: str) -> None:
+//|     def __init__(self, block_device: BlockDevice) -> None:
 //|         """Create a new VfsFat filesystem around the given block device.
 //|
 //|         :param block_device: Block device the the filesystem lives on"""
@@ -267,7 +267,7 @@ STATIC const mp_rom_map_elem_t storage_module_globals_table[] = {
 //|     ...
 //|
 //|     @staticmethod
-//|     def mkfs(self) -> None:
+//|     def mkfs(self, block_device: BlockDevice) -> None:
 //|         """Format the block device, deleting any data that may have been there.
 //|
 //|         **Limitations**: On SAMD21 builds, `mkfs()` will raise ``OSError(22)`` when


### PR DESCRIPTION
Hi,

With this PR I am trying to solve #7741 (Define abstract "block device" type for use in VfsFat and elsewhere)

Depends on:

https://github.com/adafruit/Adafruit_CircuitPython_Typing/pull/30

I opened the PR above in the CircuitPython_Typing repository to add the abstract class.

Please let me know if I have all the pieces or if I am missing something.

Thanks!