### PR TITLE
correcting vectorshape location property

### DIFF
--- a/shared-module/vectorio/VectorShape.c
+++ b/shared-module/vectorio/VectorShape.c
@@ -278,7 +278,7 @@ void common_hal_vectorio_vector_shape_set_location(vectorio_vector_shape_t *self
     mp_arg_validate_length(tuple_len, 2, MP_QSTR_location);
 
     mp_int_t x = mp_arg_validate_type_int(tuple_items[0], MP_QSTR_x);
-    mp_int_t y = mp_arg_validate_type_int(tuple_items[0], MP_QSTR_y);
+    mp_int_t y = mp_arg_validate_type_int(tuple_items[1], MP_QSTR_y);
     bool dirty = false;
     if (self->x != x) {
         check_bounds_and_set_x(self, x);


### PR DESCRIPTION
PR to correct vectorshape location property

### Testing Code

```python
import vectorio
import displayio
import board

display = board.DISPLAY

palette = displayio.Palette(2)
palette.make_transparent(0)
palette[1] = 0xFFFFFF

reci = vectorio.Rectangle(pixel_shader=palette,width=10, height=50,x=100, y=100, color_index=1)

print(reci.location)
reci.location = (100, 5)
print(reci.location)

```

### Before PR
```python
Adafruit CircuitPython 8.0.4 on 2023-03-15; Adafruit PyPortal Titano with samd51j20
>>> import test_pr
(100, 100)
(100, 100)
>>> 
```

### After PR
```python

Adafruit CircuitPython 8.1.0-beta.0-35-g3ac696e7b-dirty on 2023-03-20; Adafruit PyPortal Titano with samd51j20
>>> import test_pr
(100, 100)
(100, 5)
>>> 

```