### PR TITLE
Swap ESP32 RX and TX pins on Metro M7 1011

### DIFF
--- a/ports/mimxrt10xx/boards/metro_m7_1011/pins.c
+++ b/ports/mimxrt10xx/boards/metro_m7_1011/pins.c
@@ -38,8 +38,9 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_GPIO0), MP_ROM_PTR(&pin_GPIO_SD_05) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_BUSY), MP_ROM_PTR(&pin_GPIO_AD_11) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RESET), MP_ROM_PTR(&pin_GPIO_AD_07) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_TX), MP_ROM_PTR(&pin_GPIO_09) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RX), MP_ROM_PTR(&pin_GPIO_10) },
+    // These RX and TX are from the point of view of the i.MX microcontroller.
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_RX), MP_ROM_PTR(&pin_GPIO_09) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ESP_TX), MP_ROM_PTR(&pin_GPIO_10) },
 
     // SPI
     { MP_OBJ_NEW_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_GPIO_AD_06) },


### PR DESCRIPTION
The serial lines to the ESP32 AirLift processor on the Metro M7 1011 are named on the schematic from the point of view of the ESP32. But pins with the same name on other AirLift boards are named from the point of view of the main microcontroller. Flip the pins. This makes the naming congruent with what is used in the `adafruit_airlift` library.