### PR TITLE
Revert "Correctly raise OS error in socketpool_socket_recv_into()"

### DIFF
--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -1109,7 +1109,7 @@ int socketpool_socket_recv_into(socketpool_socket_obj_t *socket,
             break;
     }
     if (ret == (unsigned)-1) {
-        mp_raise_OSError(_errno);
+        return -_errno;
     }
     return ret;
 }


### PR DESCRIPTION
This reverts commit 7e6e824d5655026906b6515070aeb604d2ef3426.

Fixes #7770

The change in #7623 needs to be revered; the raise-site added in #7632 is the correct one and the one in socketpool needs to be reverted.

This is not affecting 8.0.x because #7623 was not back-ported to there before we realized it was not a full fix.

Both #7770 and #7606 should be re-tested. I didn't test.