### PR TITLE
use `values` in this error message ...

### DIFF
--- a/shared-module/struct/__init__.c
+++ b/shared-module/struct/__init__.c
@@ -167,7 +167,7 @@ void shared_modules_struct_pack_into(mp_obj_t fmt_in, byte *p, byte *end_p, size
         }
         fmt++;
     }
-    (void)mp_arg_validate_length(n_args, i, MP_QSTR_args);
+    (void)mp_arg_validate_length(n_args, i, MP_QSTR_values);
 }
 
 mp_obj_tuple_t *shared_modules_struct_unpack_from(mp_obj_t fmt_in, byte *p, byte *end_p, bool exact_size) {


### PR DESCRIPTION
matching the documentation of struct.pack, which has `def pack(fmt: str, *values: Any)` as the signature.