### PR TITLE
espnow.Peer: fix argument types and default values

### DIFF
--- a/ports/espressif/bindings/espnow/ESPNow.c
+++ b/ports/espressif/bindings/espnow/ESPNow.c
@@ -53,7 +53,7 @@ static void espnow_check_for_deinit(espnow_obj_t *self) {
 //| class ESPNow:
 //|     """Provides access to the ESP-NOW protocol."""
 //|
-//|     def __init__(self, buffer_size: int = 526, phy_rate: Optional[int] = None) -> None:
+//|     def __init__(self, buffer_size: int = 526, phy_rate: int = 0) -> None:
 //|         """Allocate and initialize `ESPNow` instance as a singleton.
 //|
 //|         :param int buffer_size: The size of the internal ring buffer. Default: 526 bytes.

--- a/ports/espressif/bindings/espnow/ESPNow.c
+++ b/ports/espressif/bindings/espnow/ESPNow.c
@@ -53,7 +53,7 @@ static void espnow_check_for_deinit(espnow_obj_t *self) {
 //| class ESPNow:
 //|     """Provides access to the ESP-NOW protocol."""
 //|
-//|     def __init__(self, buffer_size: Optional[int], phy_rate: Optional[int]) -> None:
+//|     def __init__(self, buffer_size: int = 526, phy_rate: Optional[int] = None) -> None:
 //|         """Allocate and initialize `ESPNow` instance as a singleton.
 //|
 //|         :param int buffer_size: The size of the internal ring buffer. Default: 526 bytes.

--- a/ports/espressif/bindings/espnow/Peer.c
+++ b/ports/espressif/bindings/espnow/Peer.c
@@ -40,6 +40,7 @@
 //|     def __init__(
 //|         self,
 //|         mac: bytes,
+//|         *,
 //|         lmk: Optional[bytes],
 //|         channel: int = 0,
 //|         interface: int = 0,
@@ -58,10 +59,10 @@ STATIC mp_obj_t espnow_peer_make_new(const mp_obj_type_t *type, size_t n_args, s
     enum { ARG_mac, ARG_lmk, ARG_channel, ARG_interface, ARG_encrypt };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_mac,      MP_ARG_OBJ | MP_ARG_REQUIRED },
-        { MP_QSTR_lmk,      MP_ARG_OBJ, { .u_obj = mp_const_none } },
-        { MP_QSTR_channel,  MP_ARG_INT, { .u_obj = mp_const_none } },
-        { MP_QSTR_interface,MP_ARG_INT, { .u_obj = mp_const_none } },
-        { MP_QSTR_encrypt,  MP_ARG_BOOL,{ .u_obj = mp_const_none } },
+        { MP_QSTR_lmk,      MP_ARG_OBJ | MP_ARG_KW_ONLY, { .u_obj = mp_const_none } },
+        { MP_QSTR_channel,  MP_ARG_INT | MP_ARG_KW_ONLY, { .u_int = 0 } },
+        { MP_QSTR_interface,MP_ARG_INT | MP_ARG_KW_ONLY, { .u_int = 0 } },
+        { MP_QSTR_encrypt,  MP_ARG_BOOL | MP_ARG_KW_ONLY,{ .u_bool = false } },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -77,20 +78,11 @@ STATIC mp_obj_t espnow_peer_make_new(const mp_obj_type_t *type, size_t n_args, s
 
     memcpy(self->peer_info.peer_addr, common_hal_espnow_get_bytes_len(args[ARG_mac].u_obj, ESP_NOW_ETH_ALEN), ESP_NOW_ETH_ALEN);
 
-    const mp_obj_t channel = args[ARG_channel].u_obj;
-    if (channel != mp_const_none) {
-        self->peer_info.channel = mp_arg_validate_int_range(mp_obj_get_int(channel), 0, 14, MP_QSTR_channel);
-    }
+    self->peer_info.channel = mp_arg_validate_int_range(args[ARG_channel].u_int, 0, 14, MP_QSTR_channel);
 
-    const mp_obj_t interface = args[ARG_interface].u_obj;
-    if (interface != mp_const_none) {
-        self->peer_info.ifidx = (wifi_interface_t)mp_arg_validate_int_range(mp_obj_get_int(interface), 0, 1, MP_QSTR_interface);
-    }
+    self->peer_info.ifidx = (wifi_interface_t)mp_arg_validate_int_range(args[ARG_interface].u_int, 0, 1, MP_QSTR_interface);
 
-    const mp_obj_t encrypt = args[ARG_encrypt].u_obj;
-    if (encrypt != mp_const_none) {
-        self->peer_info.encrypt = mp_obj_is_true(encrypt);
-    }
+    self->peer_info.encrypt = args[ARG_encrypt].u_bool;
 
     const mp_obj_t lmk = args[ARG_lmk].u_obj;
     if (lmk != mp_const_none) {

--- a/ports/espressif/bindings/espnow/Peer.c
+++ b/ports/espressif/bindings/espnow/Peer.c
@@ -44,7 +44,7 @@
 //|         lmk: Optional[bytes],
 //|         channel: int = 0,
 //|         interface: int = 0,
-//|         encrypt: bool = False,
+//|         encrypted: bool = False,
 //|     ) -> None:
 //|         """Construct a new peer object.
 //|
@@ -52,17 +52,17 @@
 //|         :param bytes lmk: The Local Master Key (lmk) of the peer.
 //|         :param int channel: The peer's channel. Default: 0 ie. use the current channel.
 //|         :param int interface: The WiFi interface to use. Default: 0 ie. STA.
-//|         :param bool encrypt: Whether or not to use encryption.
+//|         :param bool encrypted: Whether or not to use encryption.
 //|         """
 //|         ...
 STATIC mp_obj_t espnow_peer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    enum { ARG_mac, ARG_lmk, ARG_channel, ARG_interface, ARG_encrypt };
+    enum { ARG_mac, ARG_lmk, ARG_channel, ARG_interface, ARG_encrypted };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_mac,      MP_ARG_OBJ | MP_ARG_REQUIRED },
         { MP_QSTR_lmk,      MP_ARG_OBJ | MP_ARG_KW_ONLY, { .u_obj = mp_const_none } },
         { MP_QSTR_channel,  MP_ARG_INT | MP_ARG_KW_ONLY, { .u_int = 0 } },
         { MP_QSTR_interface,MP_ARG_INT | MP_ARG_KW_ONLY, { .u_int = 0 } },
-        { MP_QSTR_encrypt,  MP_ARG_BOOL | MP_ARG_KW_ONLY,{ .u_bool = false } },
+        { MP_QSTR_encrypted,MP_ARG_BOOL | MP_ARG_KW_ONLY, { .u_bool = false } },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -82,7 +82,7 @@ STATIC mp_obj_t espnow_peer_make_new(const mp_obj_type_t *type, size_t n_args, s
 
     self->peer_info.ifidx = (wifi_interface_t)mp_arg_validate_int_range(args[ARG_interface].u_int, 0, 1, MP_QSTR_interface);
 
-    self->peer_info.encrypt = args[ARG_encrypt].u_bool;
+    self->peer_info.encrypt = args[ARG_encrypted].u_bool;
 
     const mp_obj_t lmk = args[ARG_lmk].u_obj;
     if (lmk != mp_const_none) {


### PR DESCRIPTION
This fixes the int and bool arguments checks to `espnow.Peer()`.
I also made the optional arguments kwarg-only, if that's ok ? I don't know if that fits the intended API.

Also, maybe we should make the `encrypt` argument and `encrypted` property use the same name ? 