### PR TITLE
Attempt to fix missing jquery in RTD

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -77,6 +77,7 @@ needs_sphinx = '1.3'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
+    "sphinxcontrib.jquery",
     'sphinxcontrib.rsvgconverter',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -13,6 +13,7 @@ sphinx!=5.2.0.post0
 sphinx-autoapi
 sphinx-rtd-theme
 sphinxcontrib-svg2pdfconverter
+sphinxcontrib-jquery
 readthedocs-sphinx-search
 myst-parser
 


### PR DESCRIPTION
On the currently live docs page: https://docs.circuitpython.org/en/latest/README.html

The version dropdown in the lower left corner, and the search functionality do not seem to work.

Looking in the console for errors reveals some missing jQuery errors:
![image](https://user-images.githubusercontent.com/2406189/228075942-5cb17078-6d9e-40f4-909e-6c5d1d7c0738.png)

At some point some code inside of `readthedocs-doc-embed.js` seems to notice the lack of jquery and injects it into the DOM. This does seem successful because you can use `$` and other jquery functions successfully from the console after everything has finished loading. 

However it seems "too late" for some of the functionality on the page. It appears that it tries to initialize and run some code involving jquery when the page first loads and since it's not there at this time it fails and then certain interactive controls on the page don't work.

I found some information that is potentially related to this here:

- https://github.com/readthedocs/blog/issues/198
- https://github.com/readthedocs/sphinx_rtd_theme/issues/1253
- https://github.com/sphinx-doc/sphinx/issues/7405#issuecomment-971893132

But honestly I'm having trouble following what the actual change is and whether it's expected to affect the way we use things, and if so what that effect would be (i.e. are the errors we are seeing expected behavior from this change?)

Interestingly when you load the docs page from a local `make html` it does not suffer from this problem. It appears to be successfully loading jquery. The resulting README.html contains this:
![image](https://user-images.githubusercontent.com/2406189/228077106-113662da-0c18-4433-a9e5-5efa312b9a9b.png)

Strangely this `<script>` tag is absent from the html page served at https://docs.circuitpython.org My best guess is RTD infrastructure is removing that somehow in the version being served live. Not really sure though, very strange.
 

This PR is an attempt to resolve it by forcing it to use the sphinxcontrib.jquery package, which is noted in one of the above linked comments. 

I don't really know if it's possible / how to test this locally since the local copy doesn't show the same errors, and doesn't have the version dropdown functionality at all.

I'm not certain if this solution will actually work for the live site, nor if it's the preferred one if so. But I'm open to ideas from anyone about how to get the live pages working again with their interactive controls.