### PR TITLE
mimxrt: Fix output frequency for samples that don't divide 192kHz

### DIFF
--- a/shared-bindings/audiopwmio/PWMAudioOut.c
+++ b/shared-bindings/audiopwmio/PWMAudioOut.c
@@ -56,6 +56,10 @@
 //|         :param int quiescent_value: The output value when no signal is present. Samples should start
 //|             and end with this value to prevent audible popping.
 //|
+//|         **Limitations:** On mimxrt10xx, low sample rates may have an audible
+//|         "carrier" frequency. The manufacturer datasheet states that the "MQS" peripheral
+//|         is intended for 44 kHz or 48kHz input signals.
+//|
 //|         Simple 8ksps 440 Hz sin wave::
 //|
 //|           import audiocore


### PR DESCRIPTION
This makes all the samples from Dan's collection register as 440Hz when playing on pwmio or i2sout, using https://webaudiodemos.appspot.com/pitchdetect/index.html to detect the frequency played (all should show as A 440Hz; an error of up to 20 "cents" should be treated as OK)

There's an audible carrier with PWM output and the 8kHz samples. This is probably a limitation of the peripheral which is documented as being for input signals of 44 kHz or 48 kHz; the carrier frequency is a fixed multiple of the sample frequency.

Closes #7800