### PR TITLE
Handle HID OUT reports with no report ID

### DIFF
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -116,12 +116,12 @@ else
   # -finline-limit=80 or so is similar to not having it on.
   # There is no simple default value, though.
   ifeq ($(SHRINK_BUILD), 1)
-    CFLAGS += -finline-limit=45
+    CFLAGS += -finline-limit=45 --param max-inline-insns-auto=110
   endif
 
   # We used to do this but it seems to not reduce space any more, at least in gcc 11.
   # Leave it here, commented out, just for reference.
-  # --param inline-unit-growth=15 --param max-inline-insns-auto=20
+  # --param inline-unit-growth=15
 
   ifdef CFLAGS_BOARD
     CFLAGS += $(CFLAGS_BOARD)

--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -104,19 +104,16 @@ else
   CFLAGS += -DNDEBUG
 
   # Do a default shrink for small builds, including all SAMD21 builds.
-  ifeq ($(CIRCUITPY_FULL_BUILD),0)
-    SHRINK_BUILD = 1
-  else
-    ifeq ($(CHIP_FAMILY), samd21)
-      SHRINK_BUILD = 1
-    endif
-  endif
-
   # -finline-limit can shrink the image size.
   # -finline-limit=80 or so is similar to not having it on.
   # There is no simple default value, though.
-  ifeq ($(SHRINK_BUILD), 1)
-    CFLAGS += -finline-limit=45 --param max-inline-insns-auto=110
+  ifeq ($(CIRCUITPY_FULL_BUILD),0)
+    CFLAGS += -finline-limit=45
+  else
+    ifeq ($(CHIP_FAMILY), samd21)
+      # max-inline-insns-auto increases the size of SAMD51 builds.
+      CFLAGS += -finline-limit=45 --param max-inline-insns-auto=110
+    endif
   endif
 
   # We used to do this but it seems to not reduce space any more, at least in gcc 11.


### PR DESCRIPTION
Raw HID OUT reports (to the peripheral from the host), with no report ID, were not being parsed correctly. The code assumed the first byte was the report id. However, this is not always the case.

Instead, see if there is a defined HID device with report ID 0, whose report length matches the incoming report. If so, assume the incoming report is for that device.

The long-term fix is for TinyUSB to know which reports are for which report ID's, but that requires https://github.com/hathach/tinyusb/issues/1095 to be addressed.

Tested with `hidapitester` on Linux:
```sh
sudo /home/halbert/bin/hidapitester --vidpid 239a/80f2 --open --length 64 --send-output 7,8,9
Opening device, vid/pid: 0x239A/0x80F2
Writing output report of 64-bytes...wrote 64 bytes:
 07 08 09 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Closing device
```
On the CPy side:
```py
>>> import rawread
None
None
None
b'\x07\x08\t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
None
```
test program (rawread.py):
```py
import usb_hid
import time

d = usb_hid.devices[0]

while True:
    print(d.get_last_received_report())
    time.sleep(2)
```
boot.py:
```py
import usb_hid

RAWHID_REPORT_DESCRIPTOR = bytes((
    0x06, 0x00, 0xFF,  # Usage Page (Vendor Defined 0xFF00)
    0x09, 0x01,        # Usage (0x01)
    0xA1, 0x01,        # Collection (Application)
    0x09, 0x02,        #   Usage (0x02)
    0x15, 0x00,        #   Logical Minimum (0)
    0x26, 0xFF, 0x00,  #   Logical Maximum (255)
    0x75, 0x08,        #   Report Size (8)
    0x95, 0x40,        #   Report Count (64)
    0x81, 0x02,        #   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
    0x09, 0x03,        #   Usage (0x03)
    0x15, 0x00,        #   Logical Minimum (0)
    0x26, 0xFF, 0x00,  #   Logical Maximum (255)
    0x75, 0x08,        #   Report Size (8)
    0x95, 0x40,        #   Report Count (64)
    0x91, 0x02,        #   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
    0xC0,              # End Collection
))

raw_hid = usb_hid.Device(
    report_descriptor=RAWHID_REPORT_DESCRIPTOR,
    usage_page=0xFF00,
    usage=0x01,
    report_ids=(0,),
    in_report_lengths=(64,),
    out_report_lengths=(64,),
)

usb_hid.enable((raw_hid,))
#usb_hid.enable((usb_hid.Device.KEYBOARD,))
```