### PR TITLE
getenv: treat a read error like eof

### DIFF
--- a/shared-module/os/getenv.c
+++ b/shared-module/os/getenv.c
@@ -72,7 +72,7 @@ STATIC void close_file(file_arg *active_file) {
     // nothing
 }
 STATIC bool is_eof(file_arg *active_file) {
-    return f_eof(active_file) | f_error(active_file);
+    return f_eof(active_file) || f_error(active_file);
 }
 
 // Return 0 if there is no next character (EOF).

--- a/shared-module/os/getenv.c
+++ b/shared-module/os/getenv.c
@@ -72,7 +72,7 @@ STATIC void close_file(file_arg *active_file) {
     // nothing
 }
 STATIC bool is_eof(file_arg *active_file) {
-    return f_eof(active_file);
+    return f_eof(active_file) | f_error(active_file);
 }
 
 // Return 0 if there is no next character (EOF).


### PR DESCRIPTION
Otherwise, the following would occur:
 * settings.toml is in the process of being written by host computer
 * soft-reset begins
 * web workflow tries to grab CIRCUITPY_WIFI_SSID, but loops forever because FAT filesystem is in inconsistent state and file reads error
 * settings.toml write by host computer never completes and the filesystem remains corrupt
 * restarting yields a soft-bricked device, because startup reads CIRCUITPY_WIFI_SSID again