### PR TITLE
only add circuitpython_splash to display if it's not in another group

### DIFF
--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -439,7 +439,9 @@ void reset_display(displayio_display_obj_t *self) {
     circuitpython_splash.x = 0; // reset position in case someone moved it.
     circuitpython_splash.y = 0;
     supervisor_start_terminal(self->core.width, self->core.height);
-    common_hal_displayio_display_set_root_group(self, &circuitpython_splash);
+    if (!circuitpython_splash.in_group) {
+        common_hal_displayio_display_set_root_group(self, &circuitpython_splash);
+    }
 }
 
 void displayio_display_collect_ptrs(displayio_display_obj_t *self) {

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -136,7 +136,9 @@ void common_hal_displayio_display_construct(displayio_display_obj_t *self,
 
     // Set the group after initialization otherwise we may send pixels while we delay in
     // initialization.
-    common_hal_displayio_display_set_root_group(self, &circuitpython_splash);
+    if (!circuitpython_splash.in_group) {
+        common_hal_displayio_display_set_root_group(self, &circuitpython_splash);
+    }
     common_hal_displayio_display_set_auto_refresh(self, auto_refresh);
 }
 


### PR DESCRIPTION
resolves #7824 

Tested successfully on Monster M4sk

Not sure if we need to guard more cautiously against `circuitpython_splash` being null or not having `in_group`. This code assumes it will exist and have that property to check. It does seem safe after testing on Monster M4sk but I don't know if there are other scenarios that could be problematic.