### PR TITLE
RFC: Web Workflow reliability and performance improvements

### DIFF
--- a/ports/espressif/common-hal/socketpool/Socket.h
+++ b/ports/espressif/common-hal/socketpool/Socket.h
@@ -48,3 +48,5 @@ typedef struct {
 } socketpool_socket_obj_t;
 
 void socket_user_reset(void);
+// Unblock workflow socket select thread (platform specific)
+void socketpool_socket_poll_resume(void);

--- a/ports/raspberrypi/common-hal/socketpool/Socket.h
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.h
@@ -75,4 +75,7 @@ typedef struct _lwip_socket_obj_t {
     socketpool_socketpool_obj_t *pool;
 } socketpool_socket_obj_t;
 
+// Not required for RPi socket positive callbacks
+#define socketpool_socket_poll_resume(x)
+
 void socket_user_reset(void);

--- a/supervisor/shared/web_workflow/web_workflow.h
+++ b/supervisor/shared/web_workflow/web_workflow.h
@@ -33,7 +33,7 @@
 
 // This background function should be called repeatedly. It cannot be done based
 // on events.
-void supervisor_web_workflow_background(void);
+void supervisor_web_workflow_background(void *data);
 bool supervisor_web_workflow_status_dirty(void);
 void supervisor_web_workflow_status(void);
 void supervisor_start_web_workflow(void);

--- a/supervisor/shared/web_workflow/websocket.c
+++ b/supervisor/shared/web_workflow/websocket.c
@@ -42,7 +42,6 @@ typedef struct {
     uint8_t frame_len;
     uint8_t payload_len_size;
     bool masked;
-    bool closed;
     uint8_t mask[4];
     int frame_index;
     size_t payload_remaining;
@@ -59,17 +58,16 @@ static _websocket cp_serial;
 
 void websocket_init(void) {
     socketpool_socket_reset(&cp_serial.socket);
-    cp_serial.closed = true;
 
     ringbuf_init(&_incoming_ringbuf, _buf, sizeof(_buf) - 1);
 }
 
 void websocket_handoff(socketpool_socket_obj_t *socket) {
-    if (!cp_serial.closed) {
+    if (!common_hal_socketpool_socket_get_closed(&cp_serial.socket)) {
         common_hal_socketpool_socket_close(&cp_serial.socket);
     }
+
     socketpool_socket_move(socket, &cp_serial.socket);
-    cp_serial.closed = false;
     cp_serial.opcode = 0;
     cp_serial.frame_index = 0;
     cp_serial.frame_len = 2;
@@ -81,12 +79,14 @@ void websocket_handoff(socketpool_socket_obj_t *socket) {
 }
 
 bool websocket_connected(void) {
-    return _incoming_ringbuf.size > 0 && !cp_serial.closed && common_hal_socketpool_socket_get_connected(&cp_serial.socket);
+    return _incoming_ringbuf.size > 0 &&
+           !common_hal_socketpool_socket_get_closed(&cp_serial.socket) &&
+           common_hal_socketpool_socket_get_connected(&cp_serial.socket);
 }
 
 static bool _read_byte(uint8_t *c) {
     int len = socketpool_socket_recv_into(&cp_serial.socket, c, 1);
-    if (len != 1) {
+    if (len < 1) {
         return false;
     }
     return true;
@@ -160,8 +160,6 @@ static void _read_next_frame_header(void) {
         if (cp_serial.payload_remaining == 0) {
             cp_serial.frame_index = 0;
             if (cp_serial.opcode == 0x8) {
-                cp_serial.closed = true;
-
                 common_hal_socketpool_socket_close(&cp_serial.socket);
             }
         }


### PR DESCRIPTION
What started as an investigation of un-explained 403 errors from what I think
is a questionable CORS implementation along with interface hangs and connection
timeouts, I would like to propose the attached changes to the web_workflow
service. [Note: The CORS implementation is another topic not covered here.]

Observed problems (ESP32 platforms):

1. Listening socket closed at lower level lwip resets not re-opened.
2. User sockets being added to socket select fd lists causing errors.
3. REST HTTP recv/parsing character-at-a-time causing select thread to continuously
   run and attempt to post background task requests.
4. Active HTTP request socket not being closed or believed to be closed when it
   is still in use by select polling thread.
5. HTTP request response timeouts due to looping background tasks.

These changes address, in no particular order:

- Fixes polling thread looping forever hangs preventing new connections.
- Don't lose listening sockets on mp resets and re-init.
- Keep better separation of "system" and "user" sockets.
- Track socket states to prevent re-use of sockets before closed.
- Close REST socket when transaction completes. No post-init.
- Remove unnecessary/redundant state flags.

There may be other issues here and I am hoping for some more eyes/testing on these proposed
changes. I have been running these changes for over 2-weeks on an UMFeatherS2 now with
no loss of service. The device sleeps for 20min, then wakes and takes a number of
sensor readings and posts them to a MQTT server and adafruit.io and goes back to sleep.
The device also polls the MQTT server for notice to not sleep in order to allow connection
via Web Workflow for maintenance.

After stabilizing the ESP32 environment, I have testing these changes on the RPi
implementation. The Web Workflow processing model works fine now with both the ESP32
and RPi given the significant differences in socket handling (polling vs. callbacks).
No further work was required to the RPi socket layer as was necessary with the ESP32
sockets/lwip layer. In fact, the ESP32 implementation seems to be a lot more responsive
and on-par with the RPi now.
