### PR TITLE
Fix for pulsein on Espressif boards

### DIFF
--- a/ports/espressif/background.c
+++ b/ports/espressif/background.c
@@ -43,12 +43,12 @@
 void port_background_tick(void) {
     // Zero delay in case FreeRTOS wants to switch to something else.
     vTaskDelay(0);
-    #if CIRCUITPY_PULSEIO
-    pulsein_background();
-    #endif
 }
 
 void port_background_task(void) {
+    #if CIRCUITPY_PULSEIO
+    pulsein_background();
+    #endif
 }
 
 void port_start_background_task(void) {


### PR DESCRIPTION
Fix for issues #7742 and #7817. Moving the call to pulsein_background() from port_background_tick() back to port_background_task(); which was changed by commit https://github.com/adafruit/circuitpython/commit/1063ec064961ab40121f1aebf2746de09a6cedcf
