### PR TITLE
Add device name environment variable for web workflow

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -74,6 +74,10 @@ CIRCUITPY_WEB_API_PORT
 ~~~~~~~~~~~~~~~~~~~~~~
 TCP port number used for the web HTTP API. Defaults to 80 when omitted.
 
+CIRCUITPY_WEB_INSTANCE_NAME
+~~~~~~~~~~~~~~~~~~~
+Name the board advertises as for the WEB workflow. Defaults to human readable board name if omitted.
+
 CIRCUITPY_WIFI_PASSWORD
 ~~~~~~~~~~~~~~~~~~~~~~~
 Wi-Fi password used to auto connect to CIRCUITPY_WIFI_SSID.

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -75,7 +75,7 @@ CIRCUITPY_WEB_API_PORT
 TCP port number used for the web HTTP API. Defaults to 80 when omitted.
 
 CIRCUITPY_WEB_INSTANCE_NAME
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Name the board advertises as for the WEB workflow. Defaults to human readable board name if omitted.
 
 CIRCUITPY_WIFI_PASSWORD

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -72,7 +72,8 @@ Read-only characteristic that returns the UTF-8 encoded version string.
 The web workflow is depends on adding Wi-Fi credentials into the `settings.toml` file. The keys are
 `CIRCUITPY_WIFI_SSID` and `CIRCUITPY_WIFI_PASSWORD`. Once these are defined, CircuitPython will
 automatically connect to the network and start the webserver used for the workflow. The webserver
-is on port 80 unless overridden by `CIRCUITPY_WEB_API_PORT`. It also enables MDNS.
+is on port 80 unless overridden by `CIRCUITPY_WEB_API_PORT`. It also enables MDNS. The name
+of the board as advertised to the network can be overridden by `CIRCUITPY_WEB_INSTANCE_NAME`.
 
 Here is an example `/settings.toml`:
 
@@ -86,6 +87,7 @@ CIRCUITPY_WIFI_PASSWORD="secretpassword"
 CIRCUITPY_WEB_API_PASSWORD="passw0rd"
 
 CIRCUITPY_WEB_API_PORT=80
+CIRCUITPY_WEB_INSTANCE_NAME=""
 ```
 
 MDNS is used to resolve [`circuitpython.local`](http://circuitpython.local) to a device specific

--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -269,6 +269,7 @@ void supervisor_start_web_workflow(void) {
 
     char ssid[33];
     char password[64];
+    char web_instance_name[50];
 
     os_getenv_err_t result = common_hal_os_getenv_str("CIRCUITPY_WIFI_SSID", ssid, sizeof(ssid));
     if (result != GETENV_OK) {
@@ -281,6 +282,11 @@ void supervisor_start_web_workflow(void) {
         password[0] = '\0';
     } else if (result != GETENV_OK) {
         return;
+    }
+
+    result = common_hal_os_getenv_str("CIRCUITPY_WEB_INSTANCE_NAME", web_instance_name, sizeof(web_instance_name));
+    if (result != GETENV_OK || web_instance_name[0] == '\0') {
+        strcpy(web_instance_name, MICROPY_HW_BOARD_NAME);
     }
 
     if (!common_hal_wifi_radio_get_enabled(&common_hal_wifi_radio_obj)) {
@@ -329,7 +335,8 @@ void supervisor_start_web_workflow(void) {
         mdns_server_construct(&mdns, true);
         mdns.base.type = &mdns_server_type;
         if (!common_hal_mdns_server_deinited(&mdns)) {
-            common_hal_mdns_server_set_instance_name(&mdns, MICROPY_HW_BOARD_NAME);
+            char *instance_name = strndup(web_instance_name, strlen(web_instance_name));
+            common_hal_mdns_server_set_instance_name(&mdns, instance_name);
         }
     }
     if (!common_hal_mdns_server_deinited(&mdns)) {
@@ -796,9 +803,11 @@ static void _reply_with_version_json(socketpool_socket_obj_t *socket, _request *
     mp_print_t _socket_print = {socket, _print_chunk};
 
     const char *hostname = "";
+    const char *instance_name = "";
     #if CIRCUITPY_MDNS
     if (!common_hal_mdns_server_deinited(&mdns)) {
         hostname = common_hal_mdns_server_get_hostname(&mdns);
+        instance_name = common_hal_mdns_server_get_instance_name(&mdns);
     }
     #endif
     _update_encoded_ip();
@@ -807,13 +816,13 @@ static void _reply_with_version_json(socketpool_socket_obj_t *socket, _request *
         "{\"web_api_version\": 2, "
         "\"version\": \"" MICROPY_GIT_TAG "\", "
         "\"build_date\": \"" MICROPY_BUILD_DATE "\", "
-        "\"board_name\": \"" MICROPY_HW_BOARD_NAME "\", "
+        "\"board_name\": \"%s\", "
         "\"mcu_name\": \"" MICROPY_HW_MCU_NAME "\", "
         "\"board_id\": \"" CIRCUITPY_BOARD_ID "\", "
         "\"creator_id\": %u, "
         "\"creation_id\": %u, "
         "\"hostname\": \"%s\", "
-        "\"port\": %d, ", CIRCUITPY_CREATOR_ID, CIRCUITPY_CREATION_ID, hostname, web_api_port, _our_ip_encoded);
+        "\"port\": %d, ", instance_name, CIRCUITPY_CREATOR_ID, CIRCUITPY_CREATION_ID, hostname, web_api_port, _our_ip_encoded);
     #if CIRCUITPY_MICROCONTROLLER && COMMON_HAL_MCU_PROCESSOR_UID_LENGTH > 0
     uint8_t raw_id[COMMON_HAL_MCU_PROCESSOR_UID_LENGTH];
     common_hal_mcu_processor_get_uid(raw_id);

--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -125,6 +125,7 @@ static socketpool_socket_obj_t active;
 static _request active_request;
 
 static char _api_password[64];
+static char web_instance_name[50];
 
 // Store the encoded IP so we don't duplicate work.
 static uint32_t _encoded_ip = 0;
@@ -269,7 +270,6 @@ void supervisor_start_web_workflow(void) {
 
     char ssid[33];
     char password[64];
-    char web_instance_name[50];
 
     os_getenv_err_t result = common_hal_os_getenv_str("CIRCUITPY_WIFI_SSID", ssid, sizeof(ssid));
     if (result != GETENV_OK) {
@@ -335,8 +335,7 @@ void supervisor_start_web_workflow(void) {
         mdns_server_construct(&mdns, true);
         mdns.base.type = &mdns_server_type;
         if (!common_hal_mdns_server_deinited(&mdns)) {
-            char *instance_name = strndup(web_instance_name, strlen(web_instance_name));
-            common_hal_mdns_server_set_instance_name(&mdns, instance_name);
+            common_hal_mdns_server_set_instance_name(&mdns, web_instance_name);
         }
     }
     if (!common_hal_mdns_server_deinited(&mdns)) {


### PR DESCRIPTION
Hi,

This PR tries to resolve #7511 

1. Please let me know if the implementation is aligned with the web workflow design.
2. I tried to update the documentation.
3. Not sure if there is a `settings.toml` template that would need to be updated.
4. Tested `cp/version.json` with a `adafruit_feather_esp32s3_nopsram`
5. Could not test `cp/devices.json` because I only have one board with WIFI. It would be great if someone could help testing!

Thanks in adnvance!