### PR TITLE
Reset stuck low detection

### DIFF
--- a/shared-module/onewireio/OneWire.c
+++ b/shared-module/onewireio/OneWire.c
@@ -59,8 +59,10 @@ bool common_hal_onewireio_onewire_reset(onewireio_onewire_obj_t *self) {
     common_hal_mcu_delay_us(70);
     bool value = common_hal_digitalio_digitalinout_get_value(&self->pin);
     common_hal_mcu_delay_us(410);
+    // test if bus returned high (idle) and not stck at low
+    bool idle = common_hal_digitalio_digitalinout_get_value(&self->pin);
     common_hal_mcu_enable_interrupts();
-    return value;
+    return value || !idle;
 }
 
 bool common_hal_onewireio_onewire_read_bit(onewireio_onewire_obj_t *self) {

--- a/shared-module/onewireio/OneWire.c
+++ b/shared-module/onewireio/OneWire.c
@@ -59,7 +59,7 @@ bool common_hal_onewireio_onewire_reset(onewireio_onewire_obj_t *self) {
     common_hal_mcu_delay_us(70);
     bool value = common_hal_digitalio_digitalinout_get_value(&self->pin);
     common_hal_mcu_delay_us(410);
-    // test if bus returned high (idle) and not stck at low
+    // test if bus returned high (idle) and not stuck at low
     bool idle = common_hal_digitalio_digitalinout_get_value(&self->pin);
     common_hal_mcu_enable_interrupts();
     return value || !idle;


### PR DESCRIPTION
ref: issue #7859

Added a second read to onewireio reset function to verify reset line transitions to high state to detect stuck low faults. A return value of True indicates no devices present (i.e. no presence pulse detected) or a stuck low or stuck high fault.