### PR TITLE
Allow 64 char WiFi passwords in wifi.radio.connect

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -98,6 +98,9 @@ msgstr ""
 #: ports/raspberrypi/common-hal/analogio/AnalogOut.c
 #: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
 #: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
+#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
+#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
+#: shared-bindings/keypad/ShiftRegisterKeys.c
 msgid "%q"
 msgstr ""
 
@@ -193,7 +196,7 @@ msgstr ""
 msgid "%q must be array of type 'H'"
 msgstr ""
 
-#: shared-bindings/synthio/MidiTrack.c shared-bindings/synthio/__init__.c
+#: shared-module/synthio/__init__.c
 msgid "%q must be array of type 'h'"
 msgstr ""
 
@@ -1117,10 +1120,6 @@ msgstr ""
 msgid "I2C peripheral in use"
 msgstr ""
 
-#: shared-bindings/audiobusio/I2SOut.c
-msgid "I2SOut not available"
-msgstr ""
-
 #: ports/raspberrypi/bindings/rp2pio/StateMachine.c
 msgid "In-buffer elements must be <= 4 bytes long"
 msgstr ""
@@ -1280,6 +1279,10 @@ msgstr ""
 
 #: shared-module/audiocore/WaveFile.c
 msgid "Invalid format chunk size"
+msgstr ""
+
+#: shared-bindings/wifi/Radio.c
+msgid "Invalid hex password"
 msgstr ""
 
 #: ports/espressif/common-hal/wifi/Radio.c
@@ -1706,10 +1709,6 @@ msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Oversample must be multiple of 8."
-msgstr ""
-
-#: shared-bindings/audiobusio/PDMIn.c
-msgid "PDMIn not available"
 msgstr ""
 
 #: shared-bindings/pwmio/PWMOut.c

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -268,19 +268,6 @@ mp_int_t mp_arg_validate_type_int(mp_obj_t obj, qstr arg_name) {
     return an_int;
 }
 
-mp_int_t mp_arg_validate_valid_hex_password(mp_uint_t length, uint8_t *buf) {
-    unsigned int i=0;
-    while (i<length) {
-        if (!(('0' <= buf[i] && buf[i] <= '9') ||
-              ('a' <= buf[i] && buf[i] <= 'f') ||
-              ('A' <= buf[i] && buf[i] <= 'F'))) {
-            mp_raise_ValueError_varg(translate("Invalid hex character in password."));
-        }
-        i++;
-    }
-    return 0;
-}
-
 NORETURN void mp_arg_error_invalid(qstr arg_name) {
     mp_raise_ValueError_varg(translate("Invalid %q"), arg_name);
 }

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -268,6 +268,19 @@ mp_int_t mp_arg_validate_type_int(mp_obj_t obj, qstr arg_name) {
     return an_int;
 }
 
+mp_int_t mp_arg_validate_valid_hex_password(mp_uint_t length, uint8_t *buf) {
+    unsigned int i=0;
+    while (i<length) {
+        if (!(('0' <= buf[i] && buf[i] <= '9') ||
+              ('a' <= buf[i] && buf[i] <= 'f') ||
+              ('A' <= buf[i] && buf[i] <= 'F'))) {
+            mp_raise_ValueError_varg(translate("Invalid hex character in password."));
+        }
+        i++;
+    }
+    return 0;
+}
+
 NORETURN void mp_arg_error_invalid(qstr arg_name) {
     mp_raise_ValueError_varg(translate("Invalid %q"), arg_name);
 }

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -114,7 +114,6 @@ mp_obj_t mp_arg_validate_type_in(mp_obj_t obj, const mp_obj_type_t *type, qstr a
 mp_obj_t mp_arg_validate_type_or_none(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name);
 mp_int_t mp_arg_validate_type_int(mp_obj_t obj, qstr arg_name);
 mp_obj_t mp_arg_validate_type_string(mp_obj_t obj, qstr arg_name);
-mp_int_t mp_arg_validate_valid_hex_password(mp_uint_t length, uint8_t *buf);
 
 static MP_INLINE mp_obj_dict_t *mp_locals_get(void) {
     return MP_STATE_THREAD(dict_locals);

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -114,6 +114,7 @@ mp_obj_t mp_arg_validate_type_in(mp_obj_t obj, const mp_obj_type_t *type, qstr a
 mp_obj_t mp_arg_validate_type_or_none(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name);
 mp_int_t mp_arg_validate_type_int(mp_obj_t obj, qstr arg_name);
 mp_obj_t mp_arg_validate_type_string(mp_obj_t obj, qstr arg_name);
+mp_int_t mp_arg_validate_valid_hex_password(mp_uint_t length, uint8_t *buf);
 
 static MP_INLINE mp_obj_dict_t *mp_locals_get(void) {
     return MP_STATE_THREAD(dict_locals);

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -29,6 +29,7 @@
 
 #include <string.h>
 
+#include "py/unicode.h"
 #include "py/runtime.h"
 #include "py/objproperty.h"
 
@@ -68,6 +69,14 @@ STATIC bool hostname_valid(const char *ptr, size_t len) {
     }
     // check length of last part
     return !(partlen > 63);
+}
+
+STATIC void validate_hex_password(const uint8_t *buf, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        if (!unichar_isxdigit(buf[i])) {
+            mp_raise_ValueError_varg(translate("Invalid hex password"));
+        }
+    }
 }
 
 
@@ -321,6 +330,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_station_obj, wifi_radio_stop_station);
 //|         ``OPEN`` will be used when the password is the empty string,
 //|         otherwise ``authmode`` will be ``WPA_WPA2_PSK``.
 //|
+//|         The length of ``password`` must be 8-63 characters if it is ASCII,
+//|         or exactly 64 hexadecimal characters if it is the hex form of the 256-bit key.
+//|
 //|         If ``max_connections`` is given, the access point will allow up to
 //|         that number of stations to connect."""
 //|         ...
@@ -368,8 +380,8 @@ STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_
 
     if (authmodes != AUTHMODE_OPEN) {
         mp_arg_validate_length_range(password.len, 8, 64, MP_QSTR_password);
-        if (password.len==64) {
-            mp_arg_validate_valid_hex_password(password.len, password.buf);
+        if (password.len == 64) {
+            validate_hex_password(password.buf, password.len);
         }
     }
 
@@ -408,6 +420,9 @@ MP_PROPERTY_GETTER(wifi_radio_ap_active_obj,
 //|     ) -> None:
 //|         """Connects to the given ssid and waits for an ip address. Reconnections are handled
 //|         automatically once one connection succeeds.
+//|
+//|         The length of ``password`` must be 0 if there is no password, 8-63 characters if it is ASCII,
+//|         or exactly 64 hexadecimal characters if it is the hex form of the 256-bit key.
 //|
 //|         By default, this will scan all channels and connect to the access point (AP) with the
 //|         given ``ssid`` and greatest signal strength (rssi).
@@ -449,8 +464,8 @@ STATIC mp_obj_t wifi_radio_connect(size_t n_args, const mp_obj_t *pos_args, mp_m
         mp_get_buffer_raise(args[ARG_password].u_obj, &password, MP_BUFFER_READ);
         if (password.len != 0) {
             mp_arg_validate_length_range(password.len, 8, 64, MP_QSTR_password);
-            if (password.len==64) {
-                mp_arg_validate_valid_hex_password(password.len, password.buf);
+            if (password.len == 64) {
+                validate_hex_password(password.buf, password.len);
             }
         }
     }

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -367,7 +367,10 @@ STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_
     }
 
     if (authmodes != AUTHMODE_OPEN) {
-        mp_arg_validate_length_range(password.len, 8, 63, MP_QSTR_password);
+        mp_arg_validate_length_range(password.len, 8, 64, MP_QSTR_password);
+        if (password.len==64) {
+            mp_arg_validate_valid_hex_password(password.len, password.buf);
+        }
     }
 
     common_hal_wifi_radio_start_ap(self, ssid.buf, ssid.len, password.buf, password.len, args[ARG_channel].u_int, authmodes, args[ARG_max_connections].u_int);
@@ -445,7 +448,10 @@ STATIC mp_obj_t wifi_radio_connect(size_t n_args, const mp_obj_t *pos_args, mp_m
     if (args[ARG_password].u_obj != mp_const_none) {
         mp_get_buffer_raise(args[ARG_password].u_obj, &password, MP_BUFFER_READ);
         if (password.len != 0) {
-            mp_arg_validate_length_range(password.len, 8, 63, MP_QSTR_password);
+            mp_arg_validate_length_range(password.len, 8, 64, MP_QSTR_password);
+            if (password.len==64) {
+                mp_arg_validate_valid_hex_password(password.len, password.buf);
+            }
         }
     }
 


### PR DESCRIPTION
Code changes to allow 64 character hex WiFi passwords to be used with wifi.radio.connect.
    
Fixes adafruit/circuitpython#7677.