### PR TITLE
displayio arg validation tweaking

### DIFF
--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -220,8 +220,8 @@ STATIC mp_obj_t displayio_bitmap_obj_blit(size_t n_args, const mp_obj_t *pos_arg
     check_for_deinit(self);
 
     // Check x,y are within self (target) bitmap boundary
-    int16_t x = mp_arg_validate_int_range(args[ARG_x].u_int, 0, self->width, MP_QSTR_x);
-    int16_t y = mp_arg_validate_int_range(args[ARG_y].u_int, 0, self->height, MP_QSTR_y);
+    int16_t x = mp_arg_validate_int_range(args[ARG_x].u_int, 0, MAX(0, self->width - 1), MP_QSTR_x);
+    int16_t y = mp_arg_validate_int_range(args[ARG_y].u_int, 0, MAX(0, self->height - 1), MP_QSTR_y);
 
     displayio_bitmap_t *source = mp_arg_validate_type(args[ARG_source].u_obj, &displayio_bitmap_type, MP_QSTR_source_bitmap);
 
@@ -232,8 +232,8 @@ STATIC mp_obj_t displayio_bitmap_obj_blit(size_t n_args, const mp_obj_t *pos_arg
     }
 
     // Check x1,y1,x2,y2 are within source bitmap boundary
-    int16_t x1 = mp_arg_validate_int_range(args[ARG_x1].u_int, 0, source->width, MP_QSTR_x1);
-    int16_t y1 = mp_arg_validate_int_range(args[ARG_y1].u_int, 0, source->height, MP_QSTR_y1);
+    int16_t x1 = mp_arg_validate_int_range(args[ARG_x1].u_int, 0, MAX(0, source->width - 1), MP_QSTR_x1);
+    int16_t y1 = mp_arg_validate_int_range(args[ARG_y1].u_int, 0, MAX(0, source->height - 1), MP_QSTR_y1);
     int16_t x2, y2;
     // if x2 or y2 is None, then set as the maximum size of the source bitmap
     if (args[ARG_x2].u_obj == mp_const_none) {

--- a/shared-bindings/displayio/Bitmap.c
+++ b/shared-bindings/displayio/Bitmap.c
@@ -62,8 +62,8 @@
 //|         ...
 STATIC mp_obj_t displayio_bitmap_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     mp_arg_check_num(n_args, n_kw, 3, 3, false);
-    uint32_t width = mp_arg_validate_int_range(mp_obj_get_int(all_args[0]), 1, 32767, MP_QSTR_width);
-    uint32_t height = mp_arg_validate_int_range(mp_obj_get_int(all_args[1]), 1, 32767, MP_QSTR_height);
+    uint32_t width = mp_arg_validate_int_range(mp_obj_get_int(all_args[0]), 0, 32767, MP_QSTR_width);
+    uint32_t height = mp_arg_validate_int_range(mp_obj_get_int(all_args[1]), 0, 32767, MP_QSTR_height);
     uint32_t value_count = mp_arg_validate_int_range(mp_obj_get_int(all_args[2]), 1, 65535, MP_QSTR_value_count);
     uint32_t bits = 1;
 
@@ -220,8 +220,8 @@ STATIC mp_obj_t displayio_bitmap_obj_blit(size_t n_args, const mp_obj_t *pos_arg
     check_for_deinit(self);
 
     // Check x,y are within self (target) bitmap boundary
-    int16_t x = mp_arg_validate_int_range(args[ARG_x].u_int, 0, self->width - 1, MP_QSTR_x);
-    int16_t y = mp_arg_validate_int_range(args[ARG_y].u_int, 0, self->height - 1, MP_QSTR_y);
+    int16_t x = mp_arg_validate_int_range(args[ARG_x].u_int, 0, self->width, MP_QSTR_x);
+    int16_t y = mp_arg_validate_int_range(args[ARG_y].u_int, 0, self->height, MP_QSTR_y);
 
     displayio_bitmap_t *source = mp_arg_validate_type(args[ARG_source].u_obj, &displayio_bitmap_type, MP_QSTR_source_bitmap);
 
@@ -232,8 +232,8 @@ STATIC mp_obj_t displayio_bitmap_obj_blit(size_t n_args, const mp_obj_t *pos_arg
     }
 
     // Check x1,y1,x2,y2 are within source bitmap boundary
-    int16_t x1 = mp_arg_validate_int_range(args[ARG_x1].u_int, 0, source->width - 1, MP_QSTR_x1);
-    int16_t y1 = mp_arg_validate_int_range(args[ARG_y1].u_int, 0, source->height - 1, MP_QSTR_y1);
+    int16_t x1 = mp_arg_validate_int_range(args[ARG_x1].u_int, 0, source->width, MP_QSTR_x1);
+    int16_t y1 = mp_arg_validate_int_range(args[ARG_y1].u_int, 0, source->height, MP_QSTR_y1);
     int16_t x2, y2;
     // if x2 or y2 is None, then set as the maximum size of the source bitmap
     if (args[ARG_x2].u_obj == mp_const_none) {


### PR DESCRIPTION
The Magtag Google Calendar from the learning guide uses some Arial PCF fonts that apparently contain bitmap elements with a width and height of 0. The DisplayIO argument validations introduced in https://github.com/adafruit/circuitpython/pull/7548 cause the example code to fail. 

```
Traceback (most recent call last):
  File "code.py", line 233, in <module>
  File "adafruit_magtag/magtag.py", line 170, in set_text
  File "adafruit_portalbase/__init__.py", line 291, in set_text
  File "adafruit_display_text/bitmap_label.py", line 113, in __init__
  File "adafruit_display_text/bitmap_label.py", line 176, in _reset_text
  File "adafruit_display_text/bitmap_label.py", line 306, in _text_bounding_box
  File "/lib/adafruit_bitmap_font/glyph_cache.py", line 54, in get_glyph
  File "/lib/adafruit_bitmap_font/pcf.py", line 374, in load_glyphs
ValueError: width must be 1-32767
```

This PR increases the valid range for width and height from 1-32767 to 0-32767 and increases the maximum valid value for x, y, x1 and y1 in the `displayio_bitmap_obj_blit` function by 1 (I believe this was how it was validated prior to https://github.com/adafruit/circuitpython/pull/7548). This prevents a bitmap object of width or height of zero from being validated against a range of 0 to -1.

In looking through the original issue https://github.com/adafruit/circuitpython/issues/7540, it looks like the `displayio_bitmap_obj_blit` function change might have been introduced to cause a crash with a useful error message rather than incorrectly wrapping the display, but I didn't know if it was worth throwing in the extra code to identify the 0 width and/or height case and validating it separately from the potential wrap case. I also have not actually tested if the border wrap occurs.