### PR TITLE
Fixed outdated reference link

### DIFF
--- a/shared-bindings/onewireio/__init__.c
+++ b/shared-bindings/onewireio/__init__.c
@@ -37,7 +37,7 @@
 
 //| """Low-level bit primitives for Maxim (formerly Dallas Semi) one-wire protocol.
 //|
-//|    Protocol definition is here: https://www.maximintegrated.com/en/app-notes/index.mvp/id/126"""
+//|    Protocol definition is here: https://www.analog.com/en/technical-articles/1wire-communication-through-software.html"""
 
 STATIC const mp_rom_map_elem_t onewireio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_onewireio) },


### PR DESCRIPTION
Link to Onewire software reference has changed since Analog's acquisition of Maxim Integrated.