### PR TITLE
Simplify CORS checks and don't restrict host names.

### DIFF
--- a/ports/espressif/common-hal/socketpool/Socket.c
+++ b/ports/espressif/common-hal/socketpool/Socket.c
@@ -88,7 +88,6 @@ STATIC void socket_select_task(void *arg) {
         }
 
         assert(num_triggered > 0);
-        assert(!FD_ISSET(socket_change_fd, &excptfds));
 
         // Notice event trigger
         if (FD_ISSET(socket_change_fd, &readfds)) {


### PR DESCRIPTION
Validate Origin/Host headers as follows:
1. If No Origin: specified, then return OK
2. If Origin: does not have http: scheme, treat as # 1 above
3. If No Host given, and Origin: specified, return 403
4. If both Host: and Origin: are specified, check for hostname match (including port #)
    Origin: is OK if same as Host: --> return Origin:, otherwise 403.
5. Special debugging case allowed for Origin: equal "localhost" (ignoring port #)


See discussion in #7875 for rationale and details.
