### PR TITLE
Added notes re the RTL8720D pins

### DIFF
--- a/ports/atmel-samd/boards/seeeduino_wio_terminal/pins.c
+++ b/ports/atmel-samd/boards/seeeduino_wio_terminal/pins.c
@@ -95,13 +95,13 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_I2S_SDIN),  MP_ROM_PTR(&pin_PA22) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_I2S_BCLK),  MP_ROM_PTR(&pin_PB16) },
 
-    // RTL8720D
+    // RTL8720D - follows the schematic, but see comments
     { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_PWR),  MP_ROM_PTR(&pin_PA18) },       // CHIP_PU
-    { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_RXD),  MP_ROM_PTR(&pin_PC22) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_TXD),  MP_ROM_PTR(&pin_PC23) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_MOSI),  MP_ROM_PTR(&pin_PB24) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_RXD),  MP_ROM_PTR(&pin_PC22) },       // *NOT* THE MAIN RX FOR THE RTL CHIP (may be a log UART?)
+    { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_TXD),  MP_ROM_PTR(&pin_PC23) },       // *NOT* THE MAIN TX FOR THE RTL CHIP (may be a log UART?)
+    { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_MOSI),  MP_ROM_PTR(&pin_PB24) },      // used as the UART TX for the RTL chip
     { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_CLK),  MP_ROM_PTR(&pin_PB25) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_MISO),  MP_ROM_PTR(&pin_PC24) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_MISO),  MP_ROM_PTR(&pin_PC24) },      // used as the UART RX for the RTL chip
     { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_CS),  MP_ROM_PTR(&pin_PC25) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_READY),  MP_ROM_PTR(&pin_PC20) },     // IRQ0
     { MP_OBJ_NEW_QSTR(MP_QSTR_RTL_DIR),  MP_ROM_PTR(&pin_PA19) },       // SYNC


### PR DESCRIPTION
The Wio Terminal includes a RealTek RTL8720D as a companion to the main chip to provide WiFi and Bluetooth capabilities via eRPC over a UART connection. The WIO Terminal schematic labels some pins as the RXD/TXD for the UART, and that was captured in the board definition for CircuitPython. However, these pins may be used for logging in another mode, but they are not the main pins used to communicate with the RTL chip. The correct configuration is RX on PC24/pad 2 and TX on PB24/pad 0 of SERCOM 0. The comments on the pin definitions now reflect this situation, for anyone trying to get the WiFi/BLE to work on the Wio Terminal.