### PR TITLE
remove abs() from radius

### DIFF
--- a/shared-module/vectorio/Circle.c
+++ b/shared-module/vectorio/Circle.c
@@ -23,7 +23,7 @@ void common_hal_vectorio_circle_set_on_dirty(vectorio_circle_t *self, vectorio_e
 
 uint32_t common_hal_vectorio_circle_get_pixel(void *obj, int16_t x, int16_t y) {
     vectorio_circle_t *self = obj;
-    int16_t radius = abs(self->radius);
+    int16_t radius = self->radius;
     x = abs(x);
     y = abs(y);
     if (x + y <= radius) {


### PR DESCRIPTION
Attempt to resolve #7883 

This removes the unnecessary absolute value call from radius variable. 

Honestly I don't quite follow the rest of the conversation about x and y calculations and casting. If there are other proposed changes that need to be tested out I'm happy to try those if someone can point me more specifically to what the code would look like.