### PR TITLE
Add address_little_endian and fix display memory reuse

### DIFF
--- a/ports/atmel-samd/boards/hallowing_m0_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m0_express/board.c
@@ -69,7 +69,7 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
     common_hal_busio_spi_never_reset(spi);
@@ -82,7 +82,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/atmel-samd/boards/hallowing_m4_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m4_express/board.c
@@ -47,11 +47,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PA01, &pin_PA00, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -62,7 +62,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/atmel-samd/boards/monster_m4sk/board.c
+++ b/ports/atmel-samd/boards/monster_m4sk/board.c
@@ -48,11 +48,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PA13, &pin_PA12, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -63,7 +63,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/atmel-samd/boards/openbook_m4/board.c
+++ b/ports/atmel-samd/boards/openbook_m4/board.c
@@ -106,7 +106,8 @@ void board_init(void) {
         false, // chip_select (don't always toggle chip select)
         false, // grayscale
         false, // acep
-        false); // two_byte_sequence_length
+        false, // two_byte_sequence_length
+        false); // address_little_endian
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/atmel-samd/boards/openbook_m4/board.c
+++ b/ports/atmel-samd/boards/openbook_m4/board.c
@@ -57,11 +57,11 @@ uint8_t refresh_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -72,7 +72,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_epaperdisplay_obj_t *display = &displays[0].epaper_display;
+    displayio_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &displayio_epaperdisplay_type;
     common_hal_displayio_epaperdisplay_construct(display,
         bus,

--- a/ports/atmel-samd/boards/pewpew_lcd/board.c
+++ b/ports/atmel-samd/boards/pewpew_lcd/board.c
@@ -46,11 +46,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PA23, &pin_PA22, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -61,7 +61,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/atmel-samd/boards/pewpew_m4/board.c
+++ b/ports/atmel-samd/boards/pewpew_m4/board.c
@@ -97,11 +97,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PA13, &pin_PA15, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -115,7 +115,7 @@ void board_init(void) {
     uint32_t cfg0 = lookupCfg(CFG_DISPLAY_CFG0, 0x000000);
     uint32_t offX = (cfg0 >> 8) & 0xff;
     uint32_t offY = (cfg0 >> 16) & 0xff;
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/atmel-samd/boards/pybadge/board.c
+++ b/ports/atmel-samd/boards/pybadge/board.c
@@ -68,11 +68,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -83,7 +83,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/atmel-samd/boards/pygamer/board.c
+++ b/ports/atmel-samd/boards/pygamer/board.c
@@ -70,11 +70,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PB13, &pin_PB15, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -85,7 +85,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/atmel-samd/boards/pyportal/board.c
+++ b/ports/atmel-samd/boards/pyportal/board.c
@@ -61,7 +61,7 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    paralleldisplay_parallelbus_obj_t *bus = &displays[0].parallel_bus;
+    paralleldisplay_parallelbus_obj_t *bus = &allocate_display_bus()->parallel_bus;
     bus->base.type = &paralleldisplay_parallelbus_type;
     common_hal_paralleldisplay_parallelbus_construct(bus,
         &pin_PA16, // Data0
@@ -72,7 +72,7 @@ void board_init(void) {
         &pin_PA00, // Reset
         0); // Frequency
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/atmel-samd/boards/pyportal_titano/board.c
+++ b/ports/atmel-samd/boards/pyportal_titano/board.c
@@ -78,7 +78,7 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    paralleldisplay_parallelbus_obj_t *bus = &displays[0].parallel_bus;
+    paralleldisplay_parallelbus_obj_t *bus = &allocate_display_bus()->parallel_bus;
     bus->base.type = &paralleldisplay_parallelbus_type;
     common_hal_paralleldisplay_parallelbus_construct(bus,
         &pin_PA16, // Data0
@@ -89,7 +89,7 @@ void board_init(void) {
         &pin_PA00, // Reset
         0); // Frequency
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/atmel-samd/boards/seeeduino_wio_terminal/board.c
+++ b/ports/atmel-samd/boards/seeeduino_wio_terminal/board.c
@@ -65,11 +65,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_PB20, &pin_PB19, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -80,7 +80,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/atmel-samd/boards/ugame10/board.c
+++ b/ports/atmel-samd/boards/ugame10/board.c
@@ -70,7 +70,7 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
     common_hal_displayio_fourwire_construct(bus,
@@ -82,7 +82,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/broadcom/boards/diodes_delight_piunora/board.c
+++ b/ports/broadcom/boards/diodes_delight_piunora/board.c
@@ -36,7 +36,7 @@ void board_init(void) {
     fb->base.type = &videocore_framebuffer_type;
     common_hal_videocore_framebuffer_construct(fb, 640, 480);
 
-    framebufferio_framebufferdisplay_obj_t *display = &displays[0].framebuffer_display;
+    framebufferio_framebufferdisplay_obj_t *display = &allocate_display()->framebuffer_display;
     display->base.type = &framebufferio_framebufferdisplay_type;
     common_hal_framebufferio_framebufferdisplay_construct(
         display,

--- a/ports/broadcom/boards/raspberrypi_cm4/board.c
+++ b/ports/broadcom/boards/raspberrypi_cm4/board.c
@@ -36,7 +36,7 @@ void board_init(void) {
     fb->base.type = &videocore_framebuffer_type;
     common_hal_videocore_framebuffer_construct(fb, 640, 480);
 
-    framebufferio_framebufferdisplay_obj_t *display = &displays[0].framebuffer_display;
+    framebufferio_framebufferdisplay_obj_t *display = &allocate_display()->framebuffer_display;
     display->base.type = &framebufferio_framebufferdisplay_type;
     common_hal_framebufferio_framebufferdisplay_construct(
         display,

--- a/ports/broadcom/boards/raspberrypi_cm4io/board.c
+++ b/ports/broadcom/boards/raspberrypi_cm4io/board.c
@@ -36,7 +36,7 @@ void board_init(void) {
     fb->base.type = &videocore_framebuffer_type;
     common_hal_videocore_framebuffer_construct(fb, 640, 480);
 
-    framebufferio_framebufferdisplay_obj_t *display = &displays[0].framebuffer_display;
+    framebufferio_framebufferdisplay_obj_t *display = &allocate_display()->framebuffer_display;
     display->base.type = &framebufferio_framebufferdisplay_type;
     common_hal_framebufferio_framebufferdisplay_construct(
         display,

--- a/ports/broadcom/boards/raspberrypi_pi4b/board.c
+++ b/ports/broadcom/boards/raspberrypi_pi4b/board.c
@@ -36,7 +36,7 @@ void board_init(void) {
     fb->base.type = &videocore_framebuffer_type;
     common_hal_videocore_framebuffer_construct(fb, 640, 480);
 
-    framebufferio_framebufferdisplay_obj_t *display = &displays[0].framebuffer_display;
+    framebufferio_framebufferdisplay_obj_t *display = &allocate_display()->framebuffer_display;
     display->base.type = &framebufferio_framebufferdisplay_type;
     common_hal_framebufferio_framebufferdisplay_construct(
         display,

--- a/ports/broadcom/boards/raspberrypi_zero/board.c
+++ b/ports/broadcom/boards/raspberrypi_zero/board.c
@@ -36,7 +36,7 @@ void board_init(void) {
     fb->base.type = &videocore_framebuffer_type;
     common_hal_videocore_framebuffer_construct(fb, 640, 480);
 
-    framebufferio_framebufferdisplay_obj_t *display = &displays[0].framebuffer_display;
+    framebufferio_framebufferdisplay_obj_t *display = &allocate_display()->framebuffer_display;
     display->base.type = &framebufferio_framebufferdisplay_type;
     common_hal_framebufferio_framebufferdisplay_construct(
         display,

--- a/ports/broadcom/boards/raspberrypi_zero2w/board.c
+++ b/ports/broadcom/boards/raspberrypi_zero2w/board.c
@@ -36,7 +36,7 @@ void board_init(void) {
     fb->base.type = &videocore_framebuffer_type;
     common_hal_videocore_framebuffer_construct(fb, 640, 480);
 
-    framebufferio_framebufferdisplay_obj_t *display = &displays[0].framebuffer_display;
+    framebufferio_framebufferdisplay_obj_t *display = &allocate_display()->framebuffer_display;
     display->base.type = &framebufferio_framebufferdisplay_type;
     common_hal_framebufferio_framebufferdisplay_construct(
         display,

--- a/ports/broadcom/boards/raspberrypi_zero_w/board.c
+++ b/ports/broadcom/boards/raspberrypi_zero_w/board.c
@@ -36,7 +36,7 @@ void board_init(void) {
     fb->base.type = &videocore_framebuffer_type;
     common_hal_videocore_framebuffer_construct(fb, 640, 480);
 
-    framebufferio_framebufferdisplay_obj_t *display = &displays[0].framebuffer_display;
+    framebufferio_framebufferdisplay_obj_t *display = &allocate_display()->framebuffer_display;
     display->base.type = &framebufferio_framebufferdisplay_type;
     common_hal_framebufferio_framebufferdisplay_construct(
         display,

--- a/ports/espressif/boards/01space_lcd042_esp32c3/board.c
+++ b/ports/espressif/boards/01space_lcd042_esp32c3/board.c
@@ -55,11 +55,11 @@ void board_init(void) {
     busio_i2c_obj_t *i2c = common_hal_board_create_i2c(0);
 
     // What we would do if it wasn't the shared board I2C: (for reference)
-    // busio_i2c_obj_t *i2c = &displays[0].i2cdisplay_bus.inline_bus;
+    // busio_i2c_obj_t *i2c = &allocate_display_bus()->i2cdisplay_bus.inline_bus;
     // common_hal_busio_i2c_construct(i2c, &pin_GPIO23, &pin_GPIO22, 100000, 0);
     // common_hal_busio_i2c_never_reset(i2c);
 
-    displayio_i2cdisplay_obj_t *bus = &displays[0].i2cdisplay_bus;
+    displayio_i2cdisplay_obj_t *bus = &allocate_display_bus()->i2cdisplay_bus;
     bus->base.type = &displayio_i2cdisplay_type;
     common_hal_displayio_i2cdisplay_construct(bus,
         i2c,
@@ -67,7 +67,7 @@ void board_init(void) {
         NULL
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/espressif/boards/adafruit_esp32s2_camera/board.c
+++ b/ports/espressif/boards/adafruit_esp32s2_camera/board.c
@@ -52,7 +52,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -63,7 +63,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(
         display,

--- a/ports/espressif/boards/adafruit_feather_esp32s2_reverse_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_reverse_tft/board.c
@@ -72,7 +72,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -85,7 +85,7 @@ void board_init(void) {
         0,              // polarity
         0               // phase
         );
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
@@ -72,7 +72,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -85,7 +85,7 @@ void board_init(void) {
         0,              // polarity
         0               // phase
         );
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/adafruit_feather_esp32s3_reverse_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_reverse_tft/board.c
@@ -72,7 +72,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -85,7 +85,7 @@ void board_init(void) {
         0,              // polarity
         0               // phase
         );
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
@@ -72,7 +72,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -85,7 +85,7 @@ void board_init(void) {
         0,              // polarity
         0               // phase
         );
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/adafruit_funhouse/board.c
+++ b/ports/espressif/boards/adafruit_funhouse/board.c
@@ -56,11 +56,11 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO38);
     #endif /* DEBUG */
 
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO36, &pin_GPIO35, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -71,7 +71,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(
         display,

--- a/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
+++ b/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
@@ -120,11 +120,11 @@ void board_init(void) {
     common_hal_never_reset_pin(&pin_GPIO44);
     #endif /* DEBUG */
 
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO36, &pin_GPIO35, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -135,7 +135,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_epaperdisplay_obj_t *display = &displays[0].epaper_display;
+    displayio_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &displayio_epaperdisplay_type;
     common_hal_displayio_epaperdisplay_construct(
         display,

--- a/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
+++ b/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
@@ -167,7 +167,8 @@ void board_init(void) {
         false,  // always_toggle_chip_select
         true, // grayscale
         false, // acep
-        false);  // two_byte_sequence_length
+        false,  // two_byte_sequence_length
+        false); // address_little_endian
 }
 
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {

--- a/ports/espressif/boards/espressif_esp32s3_box/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_box/board.c
@@ -43,11 +43,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO7, &pin_GPIO6, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -58,7 +58,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/espressif/boards/espressif_esp32s3_box_lite/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_box_lite/board.c
@@ -44,11 +44,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO7, &pin_GPIO6, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -59,7 +59,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/espressif/boards/espressif_esp32s3_eye/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_eye/board.c
@@ -71,7 +71,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -84,7 +84,7 @@ void board_init(void) {
         0,              // polarity
         0               // phase
         );
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/espressif_esp32s3_usb_otg_n8/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_usb_otg_n8/board.c
@@ -71,11 +71,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO6, &pin_GPIO7, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -86,7 +86,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/espressif/boards/hardkernel_odroid_go/board.c
+++ b/ports/espressif/boards/hardkernel_odroid_go/board.c
@@ -63,11 +63,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO18, &pin_GPIO23, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -78,7 +78,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/espressif/boards/hexky_s2/board.c
+++ b/ports/espressif/boards/hexky_s2/board.c
@@ -72,7 +72,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -85,7 +85,7 @@ void board_init(void) {
         0,              // polarity
         0               // phase
         );
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/hiibot_iots2/board.c
+++ b/ports/espressif/boards/hiibot_iots2/board.c
@@ -65,7 +65,8 @@ uint8_t display_init_sequence[] = {
 };
 
 static void display_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
 
     common_hal_busio_spi_construct(
         spi,
@@ -76,7 +77,6 @@ static void display_init(void) {
 
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -90,7 +90,7 @@ static void display_init(void) {
         0               // phase
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/lilygo_tembed_esp32s3/board.c
+++ b/ports/espressif/boards/lilygo_tembed_esp32s3/board.c
@@ -43,11 +43,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO12, &pin_GPIO11, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -58,7 +58,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/espressif/boards/lilygo_ttgo_t8_s2_st7789/board.c
+++ b/ports/espressif/boards/lilygo_ttgo_t8_s2_st7789/board.c
@@ -65,7 +65,8 @@ uint8_t display_init_sequence[] = {
 };
 
 static void display_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
 
     common_hal_busio_spi_construct(
         spi,
@@ -76,7 +77,6 @@ static void display_init(void) {
 
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -90,7 +90,7 @@ static void display_init(void) {
         0               // phase
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/lilygo_ttgo_tdisplay_esp32_16m/board.c
+++ b/ports/espressif/boards/lilygo_ttgo_tdisplay_esp32_16m/board.c
@@ -45,7 +45,8 @@ uint8_t display_init_sequence[] = {
 };
 
 static void display_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
 
     common_hal_busio_spi_construct(
         spi,
@@ -56,7 +57,6 @@ static void display_init(void) {
 
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -71,7 +71,7 @@ static void display_init(void) {
         0               // phase
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/lilygo_twatch_2020_v3/board.c
+++ b/ports/espressif/boards/lilygo_twatch_2020_v3/board.c
@@ -48,7 +48,8 @@ uint8_t display_init_sequence[] = {
 };
 
 static void display_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
 
     common_hal_busio_spi_construct(
         spi,
@@ -60,7 +61,6 @@ static void display_init(void) {
 
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -74,7 +74,7 @@ static void display_init(void) {
         0               // phase
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/lolin_s2_pico/board.c
+++ b/ports/espressif/boards/lolin_s2_pico/board.c
@@ -54,7 +54,7 @@ uint8_t display_init_sequence[] = { // SSD1306
 static void display_init(void) {
     busio_i2c_obj_t *i2c = common_hal_board_create_i2c(0);
 
-    displayio_i2cdisplay_obj_t *bus = &displays[0].i2cdisplay_bus;
+    displayio_i2cdisplay_obj_t *bus = &allocate_display_bus()->i2cdisplay_bus;
     bus->base.type = &displayio_i2cdisplay_type;
     common_hal_displayio_i2cdisplay_construct(bus,
         i2c,
@@ -62,7 +62,7 @@ static void display_init(void) {
         &pin_GPIO18 // reset
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/espressif/boards/m5stack_core2/board.c
+++ b/ports/espressif/boards/m5stack_core2/board.c
@@ -333,7 +333,7 @@ static bool pmic_init(busio_i2c_obj_t *i2c) {
 
 static bool display_init(void) {
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -347,7 +347,7 @@ static bool display_init(void) {
         0               // phase
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/m5stack_core_basic/board.c
+++ b/ports/espressif/boards/m5stack_core_basic/board.c
@@ -57,7 +57,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -71,7 +71,7 @@ void board_init(void) {
         0               // phase
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/m5stack_core_fire/board.c
+++ b/ports/espressif/boards/m5stack_core_fire/board.c
@@ -57,7 +57,7 @@ uint8_t display_init_sequence[] = {
 
 void board_init(void) {
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -71,7 +71,7 @@ void board_init(void) {
         0               // phase
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/m5stack_stick_c/board.c
+++ b/ports/espressif/boards/m5stack_stick_c/board.c
@@ -165,11 +165,11 @@ static bool pmic_init(busio_i2c_obj_t *i2c) {
 }
 
 static bool display_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO13, &pin_GPIO15, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -183,7 +183,7 @@ static bool display_init(void) {
         0               // phase
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/espressif/boards/morpheans_morphesp-240/board.c
+++ b/ports/espressif/boards/morpheans_morphesp-240/board.c
@@ -147,7 +147,8 @@ void board_init(void) {
 
     // Display
 
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
 
     common_hal_busio_spi_construct(
         spi,
@@ -158,7 +159,6 @@ void board_init(void) {
 
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -172,7 +172,7 @@ void board_init(void) {
         0               // phase
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(
         display,

--- a/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.c
+++ b/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.c
@@ -64,7 +64,8 @@ uint8_t display_init_sequence[] = {
 };
 
 static void display_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
 
     common_hal_busio_spi_construct(
         spi,
@@ -75,7 +76,6 @@ static void display_init(void) {
 
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -89,7 +89,7 @@ static void display_init(void) {
         0               // phase
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
 
     common_hal_displayio_display_construct(

--- a/ports/nrf/boards/clue_nrf52840_express/board.c
+++ b/ports/nrf/boards/clue_nrf52840_express/board.c
@@ -47,11 +47,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_P0_14, &pin_P0_15, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -62,7 +62,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/nrf/boards/hiibot_bluefi/board.c
+++ b/ports/nrf/boards/hiibot_bluefi/board.c
@@ -47,11 +47,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_P0_07, &pin_P1_08, NULL, false); // SCK, MOSI, MISO, not half-duplex
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -63,7 +63,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/nrf/boards/makerdiary_nrf52840_m2_devkit/board.c
+++ b/ports/nrf/boards/makerdiary_nrf52840_m2_devkit/board.c
@@ -48,11 +48,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_P0_11, &pin_P0_12, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -63,7 +63,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/nrf/boards/ohs2020_badge/board.c
+++ b/ports/nrf/boards/ohs2020_badge/board.c
@@ -47,11 +47,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_P0_11, &pin_P0_12, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -62,7 +62,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/raspberrypi/boards/adafruit_feather_rp2040_dvi/board.c
+++ b/ports/raspberrypi/boards/adafruit_feather_rp2040_dvi/board.c
@@ -40,7 +40,7 @@ void board_init(void) {
         &pin_GPIO23, &pin_GPIO22,
         8);
 
-    framebufferio_framebufferdisplay_obj_t *display = &displays[0].framebuffer_display;
+    framebufferio_framebufferdisplay_obj_t *display = &allocate_display()->framebuffer_display;
     display->base.type = &framebufferio_framebufferdisplay_type;
     common_hal_framebufferio_framebufferdisplay_construct(
         display,

--- a/ports/raspberrypi/boards/adafruit_macropad_rp2040/board.c
+++ b/ports/raspberrypi/boards/adafruit_macropad_rp2040/board.c
@@ -59,11 +59,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO26, &pin_GPIO27, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -74,7 +74,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/raspberrypi/boards/hack_club_sprig/board.c
+++ b/ports/raspberrypi/boards/hack_club_sprig/board.c
@@ -78,11 +78,11 @@ uint8_t display_init_sequence[] = {
 
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO18, &pin_GPIO19, &pin_GPIO16, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -93,7 +93,7 @@ void board_init(void) {
         0,
         0);
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/raspberrypi/boards/pimoroni_badger2040/board.c
+++ b/ports/raspberrypi/boards/pimoroni_badger2040/board.c
@@ -274,12 +274,12 @@ void board_init(void) {
     common_hal_digitalio_digitalinout_never_reset(&enable_pin_obj);
 
     // Set up the SPI object used to control the display
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO18, &pin_GPIO19, &pin_GPIO16, false);
     common_hal_busio_spi_never_reset(spi);
 
     // Set up the DisplayIO pin object
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -291,7 +291,7 @@ void board_init(void) {
         0); // Phase
 
     // Set up the DisplayIO epaper object
-    displayio_epaperdisplay_obj_t *display = &displays[0].epaper_display;
+    displayio_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &displayio_epaperdisplay_type;
     common_hal_displayio_epaperdisplay_construct(
         display,
@@ -329,10 +329,8 @@ void board_init(void) {
 void board_deinit(void) {
     displayio_epaperdisplay_obj_t *display = &displays[0].epaper_display;
     if (display->base.type == &displayio_epaperdisplay_type) {
-        size_t i = 0;
         while (common_hal_displayio_epaperdisplay_get_busy(display)) {
             RUN_BACKGROUND_TASKS;
-            i++;
         }
     }
     common_hal_displayio_release_displays();

--- a/ports/raspberrypi/boards/pimoroni_badger2040/board.c
+++ b/ports/raspberrypi/boards/pimoroni_badger2040/board.c
@@ -323,7 +323,8 @@ void board_init(void) {
         false,  // always_toggle_chip_select
         false, // grayscale
         false, // acep
-        false);  // two_byte_sequence_length
+        false,  // two_byte_sequence_length
+        false); // address_little_endian
 }
 
 void board_deinit(void) {

--- a/ports/raspberrypi/boards/pimoroni_picosystem/board.c
+++ b/ports/raspberrypi/boards/pimoroni_picosystem/board.c
@@ -64,11 +64,11 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO6, &pin_GPIO7, NULL, false);
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     common_hal_displayio_fourwire_construct(bus,
         spi,
@@ -79,7 +79,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/ports/raspberrypi/boards/waveshare_rp2040_lcd_0_96/board.c
+++ b/ports/raspberrypi/boards/waveshare_rp2040_lcd_0_96/board.c
@@ -63,7 +63,8 @@ uint8_t display_init_sequence[] = {
 };
 
 static void display_init(void) {
-    busio_spi_obj_t *spi = &displays[0].fourwire_bus.inline_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(
         spi,
         &pin_GPIO10,    // CLK
@@ -74,7 +75,6 @@ static void display_init(void) {
 
     common_hal_busio_spi_never_reset(spi);
 
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
 
     common_hal_displayio_fourwire_construct(
@@ -88,7 +88,7 @@ static void display_init(void) {
         0               // phase
         );
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(
         display,

--- a/ports/stm/boards/meowbit_v121/board.c
+++ b/ports/stm/boards/meowbit_v121/board.c
@@ -70,7 +70,7 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    displayio_fourwire_obj_t *bus = &displays[0].fourwire_bus;
+    displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     bus->base.type = &displayio_fourwire_type;
     busio_spi_obj_t *internal_spi = &supervisor_flash_spi_bus;
     common_hal_displayio_fourwire_construct(bus,
@@ -82,7 +82,7 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-    displayio_display_obj_t *display = &displays[0].display;
+    displayio_display_obj_t *display = &allocate_display()->display;
     display->base.type = &displayio_display_type;
     common_hal_displayio_display_construct(display,
         bus,

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -358,7 +358,7 @@ STATIC mp_obj_t displayio_display_obj_set_brightness(mp_obj_t self_in, mp_obj_t 
     displayio_display_obj_t *self = native_display(self_in);
     mp_float_t brightness = mp_obj_get_float(brightness_obj);
     if (brightness < 0 || brightness > 1.0) {
-        mp_raise_ValueError(translate("Brightness must be 0-1.0"));
+        mp_raise_ValueError_varg(translate("%q must be %d-%d"), MP_QSTR_brightness, 0, 1);
     }
     bool ok = common_hal_displayio_display_set_brightness(self, brightness);
     if (!ok) {

--- a/shared-bindings/displayio/EPaperDisplay.c
+++ b/shared-bindings/displayio/EPaperDisplay.c
@@ -80,7 +80,8 @@
 //|         grayscale: bool = False,
 //|         advanced_color_epaper: bool = False,
 //|         two_byte_sequence_length: bool = False,
-//|         start_up_time: float = 0
+//|         start_up_time: float = 0,
+//|         address_little_endian: bool = False
 //|     ) -> None:
 //|         """Create a EPaperDisplay object on the given display bus (`displayio.FourWire` or `paralleldisplay.ParallelBus`).
 //|
@@ -122,6 +123,7 @@
 //|         :param bool advanced_color_epaper: When true, the display is a 7-color advanced color epaper (ACeP)
 //|         :param bool two_byte_sequence_length: When true, use two bytes to define sequence length
 //|         :param float start_up_time: Time to wait after reset before sending commands
+//|         :param bool address_little_endian: Send the least significant byte (not bit) of multi-byte addresses first. Ignored when ram is addressed with one byte
 //|         """
 //|         ...
 STATIC mp_obj_t displayio_epaperdisplay_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
@@ -132,7 +134,7 @@ STATIC mp_obj_t displayio_epaperdisplay_make_new(const mp_obj_type_t *type, size
            ARG_write_color_ram_command, ARG_color_bits_inverted, ARG_highlight_color,
            ARG_refresh_display_command,  ARG_refresh_time, ARG_busy_pin, ARG_busy_state,
            ARG_seconds_per_frame, ARG_always_toggle_chip_select, ARG_grayscale, ARG_advanced_color_epaper,
-           ARG_two_byte_sequence_length, ARG_start_up_time };
+           ARG_two_byte_sequence_length, ARG_start_up_time, ARG_address_little_endian };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_display_bus, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_start_sequence, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -163,6 +165,7 @@ STATIC mp_obj_t displayio_epaperdisplay_make_new(const mp_obj_type_t *type, size
         { MP_QSTR_advanced_color_epaper, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
         { MP_QSTR_two_byte_sequence_length, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
         { MP_QSTR_start_up_time, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = MP_OBJ_NEW_SMALL_INT(0)} },
+        { MP_QSTR_address_little_endian, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -228,7 +231,8 @@ STATIC mp_obj_t displayio_epaperdisplay_make_new(const mp_obj_type_t *type, size
         args[ARG_write_black_ram_command].u_int, args[ARG_black_bits_inverted].u_bool, write_color_ram_command,
         args[ARG_color_bits_inverted].u_bool, highlight_color, refresh_buf, refresh_buf_len, refresh_time,
         busy_pin, args[ARG_busy_state].u_bool, seconds_per_frame,
-        args[ARG_always_toggle_chip_select].u_bool, args[ARG_grayscale].u_bool, args[ARG_advanced_color_epaper].u_bool, two_byte_sequence_length
+        args[ARG_always_toggle_chip_select].u_bool, args[ARG_grayscale].u_bool, args[ARG_advanced_color_epaper].u_bool,
+        two_byte_sequence_length, args[ARG_address_little_endian].u_bool
         );
 
     return self;

--- a/shared-bindings/displayio/EPaperDisplay.h
+++ b/shared-bindings/displayio/EPaperDisplay.h
@@ -37,12 +37,18 @@ extern const mp_obj_type_t displayio_epaperdisplay_type;
 #define NO_COMMAND 0x100
 
 void common_hal_displayio_epaperdisplay_construct(displayio_epaperdisplay_obj_t *self,
-    mp_obj_t bus, const uint8_t *start_sequence, uint16_t start_sequence_len, mp_float_t start_up_time, const uint8_t *stop_sequence, uint16_t stop_sequence_len,
-    uint16_t width, uint16_t height, uint16_t ram_width, uint16_t ram_height, int16_t colstart, int16_t rowstart, uint16_t rotation,
+    mp_obj_t bus, const uint8_t *start_sequence, uint16_t start_sequence_len, mp_float_t start_up_time,
+    const uint8_t *stop_sequence, uint16_t stop_sequence_len,
+    uint16_t width, uint16_t height, uint16_t ram_width, uint16_t ram_height,
+    int16_t colstart, int16_t rowstart, uint16_t rotation,
     uint16_t set_column_window_command, uint16_t set_row_window_command,
     uint16_t set_current_column_command, uint16_t set_current_row_command,
-    uint16_t write_black_ram_command, bool black_bits_inverted, uint16_t write_color_ram_command, bool color_bits_inverted, uint32_t highlight_color, const uint8_t *refresh_sequence, uint16_t refresh_sequence_len, mp_float_t refresh_time,
-    const mcu_pin_obj_t *busy_pin, bool busy_state, mp_float_t seconds_per_frame, bool always_toggle_chip_select, bool grayscale, bool acep, bool two_byte_sequence_length);
+    uint16_t write_black_ram_command, bool black_bits_inverted,
+    uint16_t write_color_ram_command, bool color_bits_inverted, uint32_t highlight_color,
+    const uint8_t *refresh_sequence, uint16_t refresh_sequence_len, mp_float_t refresh_time,
+    const mcu_pin_obj_t *busy_pin, bool busy_state, mp_float_t seconds_per_frame,
+    bool always_toggle_chip_select, bool grayscale, bool acep, bool two_byte_sequence_length,
+    bool address_little_endian);
 
 bool common_hal_displayio_epaperdisplay_refresh(displayio_epaperdisplay_obj_t *self);
 

--- a/shared-bindings/framebufferio/FramebufferDisplay.c
+++ b/shared-bindings/framebufferio/FramebufferDisplay.c
@@ -194,7 +194,7 @@ STATIC mp_obj_t framebufferio_framebufferdisplay_obj_set_brightness(mp_obj_t sel
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     mp_float_t brightness = mp_obj_get_float(brightness_obj);
     if (brightness < 0.0f || brightness > 1.0f) {
-        mp_raise_ValueError(translate("Brightness must be 0-1.0"));
+        mp_raise_ValueError_varg(translate("%q must be %d-%d"), MP_QSTR_brightness, 0, 1);
     }
     bool ok = common_hal_framebufferio_framebufferdisplay_set_brightness(self, brightness);
     if (!ok) {

--- a/shared-bindings/is31fl3741/FrameBuffer.c
+++ b/shared-bindings/is31fl3741/FrameBuffer.c
@@ -162,7 +162,7 @@ STATIC mp_obj_t is31fl3741_FrameBuffer_set_brightness(mp_obj_t self_in, mp_obj_t
     check_for_deinit(self);
     mp_float_t brightness = mp_obj_get_float(value_in);
     if (brightness < 0.0f || brightness > 1.0f) {
-        mp_raise_ValueError(translate("Brightness must be 0-1.0"));
+        mp_raise_ValueError_varg(translate("%q must be %d-%d"), MP_QSTR_brightness, 0, 1);
     }
 
     uint8_t current = (uint8_t)(brightness * 0xFF);

--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -294,7 +294,7 @@ STATIC mp_obj_t rgbmatrix_rgbmatrix_set_brightness(mp_obj_t self_in, mp_obj_t va
     check_for_deinit(self);
     mp_float_t brightness = mp_obj_get_float(value_in);
     if (brightness < 0.0f || brightness > 1.0f) {
-        mp_raise_ValueError(translate("Brightness must be 0-1.0"));
+        mp_raise_ValueError_varg(translate("%q must be %d-%d"), MP_QSTR_brightness, 0, 1);
     }
     common_hal_rgbmatrix_rgbmatrix_set_paused(self, brightness <= 0);
 

--- a/shared-module/_stage/__init__.c
+++ b/shared-module/_stage/__init__.c
@@ -46,10 +46,7 @@ void render_stage(
     area.y1 = y0 * scale;
     area.x2 = x1 * scale;
     area.y2 = y1 * scale;
-    displayio_display_core_set_region_to_update(
-        &display->core, display->set_column_command, display->set_row_command,
-        NO_COMMAND, NO_COMMAND, display->data_as_commands, false, &area,
-        display->SH1107_addressing);
+    displayio_display_core_set_region_to_update(&display->core, &area);
 
     while (!displayio_display_core_begin_transaction(&display->core)) {
         RUN_BACKGROUND_TASKS;

--- a/shared-module/board/__init__.c
+++ b/shared-module/board/__init__.c
@@ -190,7 +190,7 @@ void reset_board_buses(void) {
         bool display_using_i2c = false;
         #if CIRCUITPY_DISPLAYIO
         for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
-            if (displays[i].bus_base.type == &displayio_i2cdisplay_type && displays[i].i2cdisplay_bus.bus == &i2c_obj[instance]) {
+            if (display_buses[i].bus_base.type == &displayio_i2cdisplay_type && display_buses[i].i2cdisplay_bus.bus == &i2c_obj[instance]) {
                 display_using_i2c = true;
                 break;
             }
@@ -211,13 +211,13 @@ void reset_board_buses(void) {
         bool display_using_spi = false;
         #if CIRCUITPY_DISPLAYIO
         for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
-            mp_const_obj_t bus_type = displays[i].bus_base.type;
-            if (bus_type == &displayio_fourwire_type && displays[i].fourwire_bus.bus == &spi_obj[instance]) {
+            mp_const_obj_t bus_type = display_buses[i].bus_base.type;
+            if (bus_type == &displayio_fourwire_type && display_buses[i].fourwire_bus.bus == &spi_obj[instance]) {
                 display_using_spi = true;
                 break;
             }
             #if CIRCUITPY_SHARPDISPLAY
-            if (displays[i].bus_base.type == &sharpdisplay_framebuffer_type && displays[i].sharpdisplay.bus == &spi_obj[instance]) {
+            if (bus_type == &sharpdisplay_framebuffer_type && display_buses[i].sharpdisplay.bus == &spi_obj[instance]) {
                 display_using_spi = true;
                 break;
             }

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -65,7 +65,7 @@ void common_hal_displayio_display_construct(displayio_display_obj_t *self,
     }
     displayio_display_core_construct(&self->core, bus, width, height, ram_width, ram_height, colstart, rowstart, rotation,
         color_depth, grayscale, pixels_in_byte_share_row, bytes_per_cell, reverse_pixels_in_byte, reverse_bytes_in_word,
-        set_column_command, set_row_command, NO_COMMAND, NO_COMMAND, self->data_as_commands, false /* always_toggle_chip_select */,
+        set_column_command, set_row_command, NO_COMMAND, NO_COMMAND, data_as_commands, false /* always_toggle_chip_select */,
         SH1107_addressing && color_depth == 1, false /*address_little_endian */);
 
     self->write_ram_command = write_ram_command;
@@ -86,7 +86,7 @@ void common_hal_displayio_display_construct(displayio_display_obj_t *self,
         while (!displayio_display_core_begin_transaction(&self->core)) {
             RUN_BACKGROUND_TASKS;
         }
-        if (self->data_as_commands) {
+        if (self->core.data_as_commands) {
             uint8_t full_command[data_size + 1];
             full_command[0] = cmd[0];
             memcpy(full_command + 1, data, data_size);
@@ -185,7 +185,7 @@ bool common_hal_displayio_display_set_brightness(displayio_display_obj_t *self, 
     } else if (self->brightness_command != NO_BRIGHTNESS_COMMAND) {
         ok = displayio_display_core_begin_transaction(&self->core);
         if (ok) {
-            if (self->data_as_commands) {
+            if (self->core.data_as_commands) {
                 uint8_t set_brightness[2] = {self->brightness_command, (uint8_t)(0xff * brightness)};
                 self->core.send(self->core.bus, DISPLAY_COMMAND, CHIP_SELECT_TOGGLE_EVERY_BYTE, set_brightness, 2);
             } else {
@@ -226,7 +226,7 @@ STATIC const displayio_area_t *_get_refresh_areas(displayio_display_obj_t *self)
 }
 
 STATIC void _send_pixels(displayio_display_obj_t *self, uint8_t *pixels, uint32_t length) {
-    if (!self->data_as_commands) {
+    if (!self->core.data_as_commands) {
         self->core.send(self->core.bus, DISPLAY_COMMAND, CHIP_SELECT_TOGGLE_EVERY_BYTE, &self->write_ram_command, 1);
     }
     self->core.send(self->core.bus, DISPLAY_DATA, CHIP_SELECT_UNTOUCHED, pixels, length);
@@ -247,7 +247,7 @@ STATIC bool _refresh_area(displayio_display_obj_t *self, const displayio_area_t 
     uint16_t subrectangles = 1;
     // for SH1107 and other boundary constrained controllers
     //      write one single row at a time
-    if (self->SH1107_addressing) {
+    if (self->core.SH1107_addressing) {
         subrectangles = rows_per_buffer / 8;  // page addressing mode writes 8 rows at a time
         rows_per_buffer = 8;
     } else if (displayio_area_size(&clipped) > buffer_size * pixels_per_word) {

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -64,16 +64,14 @@ void common_hal_displayio_display_construct(displayio_display_obj_t *self,
         ram_height = 0xff;
     }
     displayio_display_core_construct(&self->core, bus, width, height, ram_width, ram_height, colstart, rowstart, rotation,
-        color_depth, grayscale, pixels_in_byte_share_row, bytes_per_cell, reverse_pixels_in_byte, reverse_bytes_in_word);
+        color_depth, grayscale, pixels_in_byte_share_row, bytes_per_cell, reverse_pixels_in_byte, reverse_bytes_in_word,
+        set_column_command, set_row_command, NO_COMMAND, NO_COMMAND, self->data_as_commands, false /* always_toggle_chip_select */,
+        SH1107_addressing && color_depth == 1, false /*address_little_endian */);
 
-    self->set_column_command = set_column_command;
-    self->set_row_command = set_row_command;
     self->write_ram_command = write_ram_command;
     self->brightness_command = brightness_command;
     self->first_manual_refresh = !auto_refresh;
-    self->data_as_commands = data_as_commands;
     self->backlight_on_high = backlight_on_high;
-    self->SH1107_addressing = SH1107_addressing && color_depth == 1;
 
     self->native_frames_per_second = native_frames_per_second;
     self->native_ms_per_frame = 1000 / native_frames_per_second;
@@ -294,9 +292,7 @@ STATIC bool _refresh_area(displayio_display_obj_t *self, const displayio_area_t 
         }
         remaining_rows -= rows_per_buffer;
 
-        displayio_display_core_set_region_to_update(&self->core, self->set_column_command,
-            self->set_row_command, NO_COMMAND, NO_COMMAND, self->data_as_commands, false,
-            &subrectangle, self->SH1107_addressing);
+        displayio_display_core_set_region_to_update(&self->core, &subrectangle);
 
         uint16_t subrectangle_size_bytes;
         if (self->core.colorspace.depth >= 8) {

--- a/shared-module/displayio/Display.h
+++ b/shared-module/displayio/Display.h
@@ -50,15 +50,10 @@ typedef struct {
     uint16_t brightness_command;
     uint16_t native_frames_per_second;
     uint16_t native_ms_per_frame;
-    uint8_t set_column_command;
-    uint8_t set_row_command;
     uint8_t write_ram_command;
     bool auto_refresh;
     bool first_manual_refresh;
-    bool data_as_commands;
     bool backlight_on_high;
-    // new quirk for sh1107
-    bool SH1107_addressing;
 } displayio_display_obj_t;
 
 void displayio_display_background(displayio_display_obj_t *self);

--- a/shared-module/displayio/EPaperDisplay.c
+++ b/shared-module/displayio/EPaperDisplay.c
@@ -139,7 +139,8 @@ STATIC const displayio_area_t *displayio_epaperdisplay_get_refresh_areas(display
     if (self->core.current_group != NULL) {
         first_area = displayio_group_get_refresh_areas(self->core.current_group, NULL);
     }
-    if (first_area != NULL) {
+    if (first_area != NULL && self->core.row_command == NO_COMMAND) {
+        // Do a full refresh if the display doesn't support partial updates.
         self->core.area.next = NULL;
         return &self->core.area;
     }

--- a/shared-module/displayio/EPaperDisplay.c
+++ b/shared-module/displayio/EPaperDisplay.c
@@ -58,28 +58,30 @@ void common_hal_displayio_epaperdisplay_construct(displayio_epaperdisplay_obj_t 
     uint16_t write_color_ram_command, bool color_bits_inverted, uint32_t highlight_color,
     const uint8_t *refresh_sequence, uint16_t refresh_sequence_len, mp_float_t refresh_time,
     const mcu_pin_obj_t *busy_pin, bool busy_state, mp_float_t seconds_per_frame,
-    bool chip_select, bool grayscale, bool acep, bool two_byte_sequence_length) {
+    bool chip_select, bool grayscale, bool acep, bool two_byte_sequence_length, bool address_little_endian) {
     uint16_t color_depth = 1;
     bool core_grayscale = true;
     if (highlight_color != 0x000000) {
         self->core.colorspace.tricolor = true;
         self->core.colorspace.tricolor_hue = displayio_colorconverter_compute_hue(highlight_color);
         self->core.colorspace.tricolor_luma = displayio_colorconverter_compute_luma(highlight_color);
+    } else {
+        self->core.colorspace.tricolor = false;
     }
+    self->acep = acep;
+    self->core.colorspace.sevencolor = acep;
     if (acep) {
-        self->core.colorspace.sevencolor = true;
         color_depth = 4; // bits. 7 colors + clean
-        self->acep = acep;
         grayscale = false;
         core_grayscale = false;
     }
 
-    displayio_display_core_construct(&self->core, bus, width, height, ram_width, ram_height, colstart, rowstart, rotation, color_depth, core_grayscale, true, 1, true, true);
+    displayio_display_core_construct(&self->core, bus, width, height, ram_width, ram_height,
+        colstart, rowstart, rotation, color_depth, core_grayscale, true, 1, true, true,
+        set_column_window_command, set_row_window_command, set_current_column_command, set_current_row_command,
+        false /* data_as_commands */, chip_select,
+        false /* SH1107_addressing */, address_little_endian);
 
-    self->set_column_window_command = set_column_window_command;
-    self->set_row_window_command = set_row_window_command;
-    self->set_current_column_command = set_current_column_command;
-    self->set_current_row_command = set_current_row_command;
     self->write_black_ram_command = write_black_ram_command;
     self->black_bits_inverted = black_bits_inverted;
     self->write_color_ram_command = write_color_ram_command;
@@ -137,7 +139,7 @@ STATIC const displayio_area_t *displayio_epaperdisplay_get_refresh_areas(display
     if (self->core.current_group != NULL) {
         first_area = displayio_group_get_refresh_areas(self->core.current_group, NULL);
     }
-    if (first_area != NULL && self->set_row_window_command == NO_COMMAND) {
+    if (first_area != NULL) {
         self->core.area.next = NULL;
         return &self->core.area;
     }
@@ -310,10 +312,8 @@ STATIC bool displayio_epaperdisplay_refresh_area(displayio_epaperdisplay_obj_t *
     for (uint8_t pass = 0; pass < passes; pass++) {
         uint16_t remaining_rows = displayio_area_height(&clipped);
 
-        if (self->set_row_window_command != NO_COMMAND) {
-            displayio_display_core_set_region_to_update(&self->core, self->set_column_window_command,
-                self->set_row_window_command, self->set_current_column_command, self->set_current_row_command,
-                false, self->chip_select, &clipped, false /* SH1107_addressing */);
+        if (self->core.row_command != NO_COMMAND) {
+            displayio_display_core_set_region_to_update(&self->core, &clipped);
         }
 
         uint8_t write_command = self->write_black_ram_command;

--- a/shared-module/displayio/EPaperDisplay.h
+++ b/shared-module/displayio/EPaperDisplay.h
@@ -46,10 +46,6 @@ typedef struct {
     uint16_t refresh_sequence_len;
     uint16_t start_up_time_ms;
     uint16_t refresh_time;
-    uint16_t set_column_window_command;
-    uint16_t set_row_window_command;
-    uint16_t set_current_column_command;
-    uint16_t set_current_row_command;
     uint16_t write_black_ram_command;
     uint16_t write_color_ram_command;
     uint8_t hue;

--- a/shared-module/displayio/Shape.c
+++ b/shared-module/displayio/Shape.c
@@ -63,15 +63,17 @@ void common_hal_displayio_shape_construct(displayio_shape_t *self, uint32_t widt
 }
 
 void common_hal_displayio_shape_set_boundary(displayio_shape_t *self, uint16_t y, uint16_t start_x, uint16_t end_x) {
-    if (y < 0 || y >= self->height || (self->mirror_y && y >= self->half_height)) {
-        mp_raise_ValueError(translate("y value out of bounds"));
+    uint16_t max_y = self->height - 1;
+    if (self->mirror_y) {
+        max_y = self->half_height - 1;
     }
-    if (start_x < 0 || start_x >= self->width || end_x < 0 || end_x >= self->width) {
-        mp_raise_ValueError(translate("x value out of bounds"));
+    mp_arg_validate_int_range(y, 0, max_y, MP_QSTR_y);
+    uint16_t max_x = self->width - 1;
+    if (self->mirror_x) {
+        max_x = self->half_width - 1;
     }
-    if (self->mirror_x && (start_x >= self->half_width || end_x >= self->half_width)) {
-        mp_raise_ValueError_varg(translate("Maximum x value when mirrored is %d"), self->half_width);
-    }
+    mp_arg_validate_int_range(start_x, 0, max_x, MP_QSTR_start_x);
+    mp_arg_validate_int_range(end_x, 0, max_x, MP_QSTR_end_x);
 
     uint16_t lower_x, upper_x, lower_y, upper_y;
 

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -543,7 +543,6 @@ bool displayio_tilegrid_fill_area(displayio_tilegrid_t *self,
                     ((uint8_t *)buffer)[offset / pixels_per_byte] |= output_pixel.pixel << shift;
                 }
             }
-            (void)input_pixel;
         }
     }
     return full_coverage;

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -48,6 +48,7 @@
 #include "shared-module/sharpdisplay/SharpMemoryFramebuffer.h"
 #endif
 
+primary_display_bus_t display_buses[CIRCUITPY_DISPLAY_LIMIT];
 primary_display_t displays[CIRCUITPY_DISPLAY_LIMIT];
 
 displayio_buffer_transform_t null_transform = {
@@ -87,19 +88,19 @@ void displayio_background(void) {
         return;
     }
 
-
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
-        if (displays[i].display.base.type == NULL || displays[i].display.base.type == &mp_type_NoneType) {
+        mp_const_obj_t display_type = displays[i].display.base.type;
+        if (display_type == NULL || display_type == &mp_type_NoneType) {
             // Skip null display.
             continue;
         }
-        if (displays[i].display.base.type == &displayio_display_type) {
+        if (display_type == &displayio_display_type) {
             displayio_display_background(&displays[i].display);
         #if CIRCUITPY_FRAMEBUFFERIO
-        } else if (displays[i].framebuffer_display.base.type == &framebufferio_framebufferdisplay_type) {
+        } else if (display_type == &framebufferio_framebufferdisplay_type) {
             framebufferio_framebufferdisplay_background(&displays[i].framebuffer_display);
         #endif
-        } else if (displays[i].epaper_display.base.type == &displayio_epaperdisplay_type) {
+        } else if (display_type == &displayio_epaperdisplay_type) {
             displayio_epaperdisplay_background(&displays[i].epaper_display);
         }
     }
@@ -110,7 +111,7 @@ void common_hal_displayio_release_displays(void) {
     // Release displays before busses so that they can send any final commands to turn the display
     // off properly.
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
-        mp_const_obj_t display_type = displays[i].display.base.type;
+        mp_const_obj_t display_type = displays[i].display_base.type;
         if (display_type == NULL || display_type == &mp_type_NoneType) {
             continue;
         } else if (display_type == &displayio_display_type) {
@@ -125,39 +126,39 @@ void common_hal_displayio_release_displays(void) {
         displays[i].display.base.type = &mp_type_NoneType;
     }
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
-        mp_const_obj_t bus_type = displays[i].fourwire_bus.base.type;
+        mp_const_obj_t bus_type = display_buses[i].bus_base.type;
         if (bus_type == NULL || bus_type == &mp_type_NoneType) {
             continue;
         } else if (bus_type == &displayio_fourwire_type) {
-            common_hal_displayio_fourwire_deinit(&displays[i].fourwire_bus);
+            common_hal_displayio_fourwire_deinit(&display_buses[i].fourwire_bus);
         } else if (bus_type == &displayio_i2cdisplay_type) {
-            common_hal_displayio_i2cdisplay_deinit(&displays[i].i2cdisplay_bus);
+            common_hal_displayio_i2cdisplay_deinit(&display_buses[i].i2cdisplay_bus);
         #if CIRCUITPY_PARALLELDISPLAY
         } else if (bus_type == &paralleldisplay_parallelbus_type) {
-            common_hal_paralleldisplay_parallelbus_deinit(&displays[i].parallel_bus);
+            common_hal_paralleldisplay_parallelbus_deinit(&display_buses[i].parallel_bus);
         #endif
         #if CIRCUITPY_RGBMATRIX
         } else if (bus_type == &rgbmatrix_RGBMatrix_type) {
-            common_hal_rgbmatrix_rgbmatrix_deinit(&displays[i].rgbmatrix);
+            common_hal_rgbmatrix_rgbmatrix_deinit(&display_buses[i].rgbmatrix);
         #endif
         #if CIRCUITPY_IS31FL3741
         } else if (bus_type == &is31fl3741_FrameBuffer_type) {
-            common_hal_is31fl3741_FrameBuffer_deinit(&displays[i].is31fl3741);
+            common_hal_is31fl3741_FrameBuffer_deinit(&display_buses[i].is31fl3741);
         #endif
         #if CIRCUITPY_SHARPDISPLAY
-        } else if (displays[i].bus_base.type == &sharpdisplay_framebuffer_type) {
-            common_hal_sharpdisplay_framebuffer_deinit(&displays[i].sharpdisplay);
+        } else if (bus_type == &sharpdisplay_framebuffer_type) {
+            common_hal_sharpdisplay_framebuffer_deinit(&display_buses[i].sharpdisplay);
         #endif
         #if CIRCUITPY_VIDEOCORE
-        } else if (displays[i].bus_base.type == &videocore_framebuffer_type) {
-            common_hal_videocore_framebuffer_deinit(&displays[i].videocore);
+        } else if (bus_type == &videocore_framebuffer_type) {
+            common_hal_videocore_framebuffer_deinit(&display_buses[i].videocore);
         #endif
         #if CIRCUITPY_PICODVI
         } else if (displays[i].bus_base.type == &picodvi_framebuffer_type) {
             common_hal_picodvi_framebuffer_deinit(&displays[i].picodvi);
         #endif
         }
-        displays[i].fourwire_bus.base.type = &mp_type_NoneType;
+        display_buses[i].bus_base.type = &mp_type_NoneType;
     }
 
     supervisor_stop_terminal();
@@ -166,10 +167,11 @@ void common_hal_displayio_release_displays(void) {
 void reset_displays(void) {
     // The SPI buses used by FourWires may be allocated on the heap so we need to move them inline.
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
-        if (displays[i].fourwire_bus.base.type == &displayio_fourwire_type) {
-            displayio_fourwire_obj_t *fourwire = &displays[i].fourwire_bus;
-            if (((size_t)fourwire->bus) < ((size_t)&displays) ||
-                ((size_t)fourwire->bus) > ((size_t)&displays + CIRCUITPY_DISPLAY_LIMIT)) {
+        mp_const_obj_t display_bus_type = display_buses[i].bus_base.type;
+        if (display_bus_type == &displayio_fourwire_type) {
+            displayio_fourwire_obj_t *fourwire = &display_buses[i].fourwire_bus;
+            if (((size_t)fourwire->bus) < ((size_t)&display_buses) ||
+                ((size_t)fourwire->bus) > ((size_t)&display_buses + CIRCUITPY_DISPLAY_LIMIT * sizeof(primary_display_bus_t))) {
                 busio_spi_obj_t *original_spi = fourwire->bus;
                 #if CIRCUITPY_BOARD_SPI
                 // We don't need to move original_spi if it is a board.SPI object because it is
@@ -186,18 +188,19 @@ void reset_displays(void) {
                 #endif
                 memcpy(&fourwire->inline_bus, original_spi, sizeof(busio_spi_obj_t));
                 fourwire->bus = &fourwire->inline_bus;
-                // Check for other displays that use the same spi bus and swap them too.
+                // Check for other display buses that use the same spi bus and swap them too.
                 for (uint8_t j = i + 1; j < CIRCUITPY_DISPLAY_LIMIT; j++) {
-                    if (displays[i].fourwire_bus.base.type == &displayio_fourwire_type &&
-                        displays[i].fourwire_bus.bus == original_spi) {
-                        displays[i].fourwire_bus.bus = &fourwire->inline_bus;
+                    if (display_buses[j].fourwire_bus.base.type == &displayio_fourwire_type &&
+                        display_buses[j].fourwire_bus.bus == original_spi) {
+                        display_buses[j].fourwire_bus.bus = &fourwire->inline_bus;
                     }
                 }
             }
-        } else if (displays[i].i2cdisplay_bus.base.type == &displayio_i2cdisplay_type) {
-            displayio_i2cdisplay_obj_t *i2c = &displays[i].i2cdisplay_bus;
-            if (((size_t)i2c->bus) < ((size_t)&displays) ||
-                ((size_t)i2c->bus) > ((size_t)&displays + CIRCUITPY_DISPLAY_LIMIT)) {
+        } else if (display_bus_type == &displayio_i2cdisplay_type) {
+            displayio_i2cdisplay_obj_t *i2c = &display_buses[i].i2cdisplay_bus;
+            // Check to see if we need to inline the I2C bus.
+            if (((size_t)i2c->bus) < ((size_t)&display_buses) ||
+                ((size_t)i2c->bus) > ((size_t)&display_buses + CIRCUITPY_DISPLAY_LIMIT * sizeof(primary_display_bus_t))) {
                 busio_i2c_obj_t *original_i2c = i2c->bus;
                 #if CIRCUITPY_BOARD_I2C
                 // We don't need to move original_i2c if it is a board.I2C object because it is
@@ -211,15 +214,15 @@ void reset_displays(void) {
                 i2c->bus = &i2c->inline_bus;
                 // Check for other displays that use the same i2c bus and swap them too.
                 for (uint8_t j = i + 1; j < CIRCUITPY_DISPLAY_LIMIT; j++) {
-                    if (displays[i].i2cdisplay_bus.base.type == &displayio_i2cdisplay_type &&
-                        displays[i].i2cdisplay_bus.bus == original_i2c) {
-                        displays[i].i2cdisplay_bus.bus = &i2c->inline_bus;
+                    if (display_buses[j].i2cdisplay_bus.base.type == &displayio_i2cdisplay_type &&
+                        display_buses[j].i2cdisplay_bus.bus == original_i2c) {
+                        display_buses[j].i2cdisplay_bus.bus = &i2c->inline_bus;
                     }
                 }
             }
         #if CIRCUITPY_RGBMATRIX
-        } else if (displays[i].rgbmatrix.base.type == &rgbmatrix_RGBMatrix_type) {
-            rgbmatrix_rgbmatrix_obj_t *pm = &displays[i].rgbmatrix;
+        } else if (display_bus_type == &rgbmatrix_RGBMatrix_type) {
+            rgbmatrix_rgbmatrix_obj_t *pm = &display_buses[i].rgbmatrix;
             if (!any_display_uses_this_framebuffer(&pm->base)) {
                 common_hal_rgbmatrix_rgbmatrix_deinit(pm);
             } else {
@@ -227,11 +230,11 @@ void reset_displays(void) {
             }
         #endif
         #if CIRCUITPY_IS31FL3741
-        } else if (displays[i].is31fl3741.base.type == &is31fl3741_FrameBuffer_type) {
-            is31fl3741_FrameBuffer_obj_t *is31fb = &displays[i].is31fl3741;
+        } else if (display_bus_type == &is31fl3741_FrameBuffer_type) {
+            is31fl3741_FrameBuffer_obj_t *is31fb = &display_buses[i].is31fl3741;
 
-            if (((uint32_t)is31fb->is31fl3741->i2c) < ((uint32_t)&displays) ||
-                ((uint32_t)is31fb->is31fl3741->i2c) > ((uint32_t)&displays + CIRCUITPY_DISPLAY_LIMIT)) {
+            if (((uint32_t)is31fb->is31fl3741->i2c) < ((uint32_t)&display_buses) ||
+                ((uint32_t)is31fb->is31fl3741->i2c) > ((uint32_t)&display_buses + CIRCUITPY_DISPLAY_LIMIT)) {
                 #if CIRCUITPY_BOARD_I2C
                 // We don't need to move original_i2c if it is the board.I2C object because it is
                 // statically allocated already. (Doing so would also make it impossible to reference in
@@ -257,13 +260,13 @@ void reset_displays(void) {
             }
         #endif
         #if CIRCUITPY_SHARPDISPLAY
-        } else if (displays[i].bus_base.type == &sharpdisplay_framebuffer_type) {
-            sharpdisplay_framebuffer_obj_t *sharp = &displays[i].sharpdisplay;
+        } else if (display_bus_type == &sharpdisplay_framebuffer_type) {
+            sharpdisplay_framebuffer_obj_t *sharp = &display_buses[i].sharpdisplay;
             common_hal_sharpdisplay_framebuffer_reset(sharp);
         #endif
         #if CIRCUITPY_VIDEOCORE
-        } else if (displays[i].bus_base.type == &videocore_framebuffer_type) {
-            videocore_framebuffer_obj_t *vc = &displays[i].videocore;
+        } else if (display_bus_type == &videocore_framebuffer_type) {
+            videocore_framebuffer_obj_t *vc = &display_buses[i].videocore;
             if (!any_display_uses_this_framebuffer(&vc->base)) {
                 common_hal_videocore_framebuffer_deinit(vc);
             }
@@ -286,13 +289,14 @@ void reset_displays(void) {
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
         // Reset the displayed group. Only the first will get the terminal but
         // that's ok.
-        if (displays[i].display.base.type == &displayio_display_type) {
+        mp_const_obj_t display_type = displays[i].display_base.type;
+        if (display_type == &displayio_display_type) {
             reset_display(&displays[i].display);
-        } else if (displays[i].epaper_display.base.type == &displayio_epaperdisplay_type) {
+        } else if (display_type == &displayio_epaperdisplay_type) {
             displayio_epaperdisplay_obj_t *display = &displays[i].epaper_display;
             common_hal_displayio_epaperdisplay_show(display, NULL);
         #if CIRCUITPY_FRAMEBUFFERIO
-        } else if (displays[i].framebuffer_display.base.type == &framebufferio_framebufferdisplay_type) {
+        } else if (display_type == &framebufferio_framebufferdisplay_type) {
             framebufferio_framebufferdisplay_reset(&displays[i].framebuffer_display);
         #endif
         }
@@ -301,35 +305,42 @@ void reset_displays(void) {
 
 void displayio_gc_collect(void) {
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
+        mp_const_obj_t display_bus_type = display_buses[i].bus_base.type;
+        if (display_bus_type == NULL || display_bus_type == &mp_type_NoneType) {
+            continue;
+        }
         #if CIRCUITPY_RGBMATRIX
-        if (displays[i].rgbmatrix.base.type == &rgbmatrix_RGBMatrix_type) {
-            rgbmatrix_rgbmatrix_collect_ptrs(&displays[i].rgbmatrix);
+        if (display_bus_type == &rgbmatrix_RGBMatrix_type) {
+            rgbmatrix_rgbmatrix_collect_ptrs(&display_buses[i].rgbmatrix);
         }
         #endif
         #if CIRCUITPY_IS31FL3741
-        if (displays[i].is31fl3741.base.type == &is31fl3741_FrameBuffer_type) {
-            is31fl3741_FrameBuffer_collect_ptrs(&displays[i].is31fl3741);
+        if (display_bus_type == &is31fl3741_FrameBuffer_type) {
+            is31fl3741_FrameBuffer_collect_ptrs(&display_buses[i].is31fl3741);
         }
         #endif
         #if CIRCUITPY_SHARPDISPLAY
-        if (displays[i].bus_base.type == &sharpdisplay_framebuffer_type) {
-            common_hal_sharpdisplay_framebuffer_collect_ptrs(&displays[i].sharpdisplay);
+        if (display_bus_type == &sharpdisplay_framebuffer_type) {
+            common_hal_sharpdisplay_framebuffer_collect_ptrs(&display_buses[i].sharpdisplay);
         }
         #endif
+    }
 
-        if (displays[i].display.base.type == NULL) {
+    for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
+        mp_const_obj_t display_type = displays[i].display_base.type;
+        if (display_type == NULL || display_type == &mp_type_NoneType) {
             continue;
         }
 
         // Alternatively, we could use gc_collect_root over the whole object,
         // but this is more precise, and is the only field that needs marking.
-        if (displays[i].display.base.type == &displayio_display_type) {
+        if (display_type == &displayio_display_type) {
             displayio_display_collect_ptrs(&displays[i].display);
         #if CIRCUITPY_FRAMEBUFFERIO
-        } else if (displays[i].framebuffer_display.base.type == &framebufferio_framebufferdisplay_type) {
+        } else if (display_type == &framebufferio_framebufferdisplay_type) {
             framebufferio_framebufferdisplay_collect_ptrs(&displays[i].framebuffer_display);
         #endif
-        } else if (displays[i].epaper_display.base.type == &displayio_epaperdisplay_type) {
+        } else if (display_type == &displayio_epaperdisplay_type) {
             displayio_epaperdisplay_collect_ptrs(&displays[i].epaper_display);
         }
     }
@@ -339,6 +350,10 @@ primary_display_t *allocate_display(void) {
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
         mp_const_obj_t display_type = displays[i].display.base.type;
         if (display_type == NULL || display_type == &mp_type_NoneType) {
+            // Clear this memory so it is in a known state before init.
+            memset(&displays[i], 0, sizeof(displays[i]));
+            // Default to None so that it works as board.DISPLAY.
+            displays[i].display_base.type = &mp_type_NoneType;
             return &displays[i];
         }
     }
@@ -352,18 +367,22 @@ primary_display_t *allocate_display_or_raise(void) {
     }
     mp_raise_RuntimeError(translate("Too many displays"));
 }
-primary_display_t *allocate_display_bus(void) {
+
+primary_display_bus_t *allocate_display_bus(void) {
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
-        mp_const_obj_t display_bus_type = displays[i].bus_base.type;
+        mp_const_obj_t display_bus_type = display_buses[i].bus_base.type;
         if (display_bus_type == NULL || display_bus_type == &mp_type_NoneType) {
-            return &displays[i];
+            // Clear this memory so it is in a known state before init.
+            memset(&display_buses[i], 0, sizeof(display_buses[i]));
+            display_buses[i].bus_base.type = &mp_type_NoneType;
+            return &display_buses[i];
         }
     }
     return NULL;
 }
 
-primary_display_t *allocate_display_bus_or_raise(void) {
-    primary_display_t *result = allocate_display_bus();
+primary_display_bus_t *allocate_display_bus_or_raise(void) {
+    primary_display_bus_t *result = allocate_display_bus();
     if (result) {
         return result;
     }

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -154,8 +154,8 @@ void common_hal_displayio_release_displays(void) {
             common_hal_videocore_framebuffer_deinit(&display_buses[i].videocore);
         #endif
         #if CIRCUITPY_PICODVI
-        } else if (displays[i].bus_base.type == &picodvi_framebuffer_type) {
-            common_hal_picodvi_framebuffer_deinit(&displays[i].picodvi);
+        } else if (bus_type == &picodvi_framebuffer_type) {
+            common_hal_picodvi_framebuffer_deinit(&display_buses[i].picodvi);
         #endif
         }
         display_buses[i].bus_base.type = &mp_type_NoneType;
@@ -274,8 +274,8 @@ void reset_displays(void) {
             // need to be moved.
         #endif
         #if CIRCUITPY_PICODVI
-        } else if (displays[i].bus_base.type == &picodvi_framebuffer_type) {
-            picodvi_framebuffer_obj_t *vc = &displays[i].picodvi;
+        } else if (display_bus_type == &picodvi_framebuffer_type) {
+            picodvi_framebuffer_obj_t *vc = &display_buses[i].picodvi;
             if (!any_display_uses_this_framebuffer(&vc->base)) {
                 common_hal_picodvi_framebuffer_deinit(vc);
             }

--- a/shared-module/displayio/__init__.h
+++ b/shared-module/displayio/__init__.h
@@ -79,6 +79,9 @@ typedef struct {
         picodvi_framebuffer_obj_t picodvi;
         #endif
     };
+} primary_display_bus_t;
+
+typedef struct {
     union {
         mp_obj_base_t display_base;
         displayio_display_obj_t display;
@@ -89,6 +92,7 @@ typedef struct {
     };
 } primary_display_t;
 
+extern primary_display_bus_t display_buses[CIRCUITPY_DISPLAY_LIMIT];
 extern primary_display_t displays[CIRCUITPY_DISPLAY_LIMIT];
 
 extern displayio_group_t circuitpython_splash;
@@ -99,7 +103,7 @@ void displayio_gc_collect(void);
 
 primary_display_t *allocate_display(void);
 primary_display_t *allocate_display_or_raise(void);
-primary_display_t *allocate_display_bus(void);
-primary_display_t *allocate_display_bus_or_raise(void);
+primary_display_bus_t *allocate_display_bus(void);
+primary_display_bus_t *allocate_display_bus_or_raise(void);
 
 #endif // MICROPY_INCLUDED_SHARED_MODULE_DISPLAYIO___INIT___H

--- a/shared-module/displayio/display_core.h
+++ b/shared-module/displayio/display_core.h
@@ -53,13 +53,26 @@ typedef struct {
     _displayio_colorspace_t colorspace;
     int16_t colstart;
     int16_t rowstart;
+
+    // Refresh area related.
+    uint16_t column_command;
+    uint16_t row_command;
+    uint16_t set_current_column_command;
+    uint16_t set_current_row_command;
+    bool data_as_commands;
+    bool always_toggle_chip_select;
+    bool SH1107_addressing;
+    bool address_little_endian;
+
     bool full_refresh; // New group means we need to refresh the whole display.
     bool refresh_in_progress;
 } displayio_display_core_t;
 
 void displayio_display_core_construct(displayio_display_core_t *self,
     mp_obj_t bus, uint16_t width, uint16_t height, uint16_t ram_width, uint16_t ram_height, int16_t colstart, int16_t rowstart, uint16_t rotation,
-    uint16_t color_depth, bool grayscale, bool pixels_in_byte_share_row, uint8_t bytes_per_cell, bool reverse_pixels_in_byte, bool reverse_bytes_in_word);
+    uint16_t color_depth, bool grayscale, bool pixels_in_byte_share_row, uint8_t bytes_per_cell, bool reverse_pixels_in_byte, bool reverse_bytes_in_word,
+    uint16_t column_command, uint16_t row_command, uint16_t set_current_column_command, uint16_t set_current_row_command,
+    bool data_as_commands, bool always_toggle_chip_select, bool SH1107_addressing, bool address_little_endian);
 
 bool displayio_display_core_set_root_group(displayio_display_core_t *self, displayio_group_t *root_group);
 
@@ -75,10 +88,7 @@ bool displayio_display_core_bus_free(displayio_display_core_t *self);
 bool displayio_display_core_begin_transaction(displayio_display_core_t *self);
 void displayio_display_core_end_transaction(displayio_display_core_t *self);
 
-void displayio_display_core_set_region_to_update(displayio_display_core_t *self, uint8_t column_command,
-    uint8_t row_command, uint16_t set_current_column_command, uint16_t set_current_row_command,
-    bool data_as_commands, bool always_toggle_chip_select,
-    displayio_area_t *area, bool SH1107_addressing);
+void displayio_display_core_set_region_to_update(displayio_display_core_t *self, displayio_area_t *area);
 
 void release_display_core(displayio_display_core_t *self);
 

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -72,7 +72,10 @@ void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebu
         fb_getter_default(get_pixels_in_byte_share_row, false),
         fb_getter_default(get_bytes_per_cell, 2),
         fb_getter_default(get_reverse_pixels_in_byte, false),
-        fb_getter_default(get_reverse_pixels_in_word, false)
+        fb_getter_default(get_reverse_pixels_in_word, false),
+        // Region update related settings that aren't used by framebuffer display.
+        NO_COMMAND, NO_COMMAND, NO_COMMAND, NO_COMMAND,
+        false, false, false, false
         );
 
     self->first_pixel_offset = fb_getter_default(get_first_pixel_offset, 0);

--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -189,14 +189,14 @@ void supervisor_display_move_memory(void) {
     #if CIRCUITPY_DISPLAYIO
     for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
         #if CIRCUITPY_RGBMATRIX
-        if (displays[i].rgbmatrix.base.type == &rgbmatrix_RGBMatrix_type) {
-            rgbmatrix_rgbmatrix_obj_t *pm = &displays[i].rgbmatrix;
+        if (display_buses[i].rgbmatrix.base.type == &rgbmatrix_RGBMatrix_type) {
+            rgbmatrix_rgbmatrix_obj_t *pm = &display_buses[i].rgbmatrix;
             common_hal_rgbmatrix_rgbmatrix_reconstruct(pm, NULL);
         }
         #endif
         #if CIRCUITPY_SHARPDISPLAY
-        if (displays[i].bus_base.type == &sharpdisplay_framebuffer_type) {
-            sharpdisplay_framebuffer_obj_t *sharp = &displays[i].sharpdisplay;
+        if (display_buses[i].bus_base.type == &sharpdisplay_framebuffer_type) {
+            sharpdisplay_framebuffer_obj_t *sharp = &display_buses[i].sharpdisplay;
             common_hal_sharpdisplay_framebuffer_reconstruct(sharp);
         }
         #endif


### PR DESCRIPTION
Add address_little_endian for epaper displays with little endian
(low byte first) addresses.

Also clears allocated display and display bus memory so it has a
known state. The acep member wasn't always set so it varied
accidentally.

Fixes https://github.com/adafruit/circuitpython/issues/7560. May fix https://github.com/adafruit/circuitpython/issues/7778. Fixes https://github.com/adafruit/circuitpython/issues/5119.