### PR TITLE
add minimum validation for tilegrid size in terminalio.Terminal

### DIFF
--- a/shared-bindings/terminalio/Terminal.c
+++ b/shared-bindings/terminalio/Terminal.c
@@ -85,6 +85,9 @@ STATIC mp_obj_t terminalio_terminal_make_new(const mp_obj_type_t *type, size_t n
 
     fontio_builtinfont_t *font = mp_arg_validate_type(args[ARG_font].u_obj, &fontio_builtinfont_type, MP_QSTR_font);
 
+    mp_arg_validate_int_min(scroll_area->width_in_tiles, 2, MP_QSTR_scroll_area_width);
+    mp_arg_validate_int_min(scroll_area->height_in_tiles, 2, MP_QSTR_scroll_area_height);
+
     terminalio_terminal_obj_t *self = m_new_obj(terminalio_terminal_obj_t);
     self->base.type = &terminalio_terminal_type;
 


### PR DESCRIPTION
Attempts to resolve #7885

This PR adds minimum size validation that enforces the TileGrid being no smaller than 2x2, which is arguably still too small to be practically useful. Perhaps a higher limit would be appropriate?

If there is a desire to allow 1xN sized TileGrids the logic in this will have to get reworked.

Also something for consideration would be adding an example to the docs of terminalio module that illustrate how to use it. As noted in the issue there isn't currently any sample code for it anywhere that I'm aware of.