### PR TITLE
Doc fix for root_group=None behaviour

### DIFF
--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -426,7 +426,7 @@ MP_PROPERTY_GETTER(displayio_display_bus_obj,
 
 //|     root_group: Group
 //|     """The root group on the display.
-//|     If the root group is set to displayio.CIRCUITPYTHON_TERMINAL, the default CircuitPython terminal will be shown.
+//|     If the root group is set to `displayio.CIRCUITPYTHON_TERMINAL`, the default CircuitPython terminal will be shown.
 //|     If the root group is set to ``None``, no output will be shown.
 //|     """
 STATIC mp_obj_t displayio_display_obj_get_root_group(mp_obj_t self_in) {

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -426,6 +426,7 @@ MP_PROPERTY_GETTER(displayio_display_bus_obj,
 
 //|     root_group: Group
 //|     """The root group on the display.
+//|     If the root group is set to displayio.CIRCUITPYTHON_TERMINAL, the default CircuitPython terminal will be shown.
 //|     If the root group is set to ``None``, no output will be shown.
 //|     """
 STATIC mp_obj_t displayio_display_obj_get_root_group(mp_obj_t self_in) {

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -426,7 +426,7 @@ MP_PROPERTY_GETTER(displayio_display_bus_obj,
 
 //|     root_group: Group
 //|     """The root group on the display.
-//|     If the root group is set to ``None``, the default CircuitPython terminal will be shown.
+//|     If the root group is set to ``None``, no output will be shown.
 //|     """
 STATIC mp_obj_t displayio_display_obj_get_root_group(mp_obj_t self_in) {
     displayio_display_obj_t *self = native_display(self_in);

--- a/shared-bindings/displayio/EPaperDisplay.c
+++ b/shared-bindings/displayio/EPaperDisplay.c
@@ -384,7 +384,7 @@ MP_PROPERTY_GETTER(displayio_epaperdisplay_bus_obj,
 
 //|     root_group: Group
 //|     """The root group on the epaper display.
-//|     If the root group is set to ``None``, the default CircuitPython terminal will be shown.
+//|     If the root group is set to ``None``, no output will be shown.
 //|     """
 //|
 STATIC mp_obj_t displayio_epaperdisplay_obj_get_root_group(mp_obj_t self_in) {

--- a/shared-bindings/displayio/EPaperDisplay.c
+++ b/shared-bindings/displayio/EPaperDisplay.c
@@ -384,7 +384,7 @@ MP_PROPERTY_GETTER(displayio_epaperdisplay_bus_obj,
 
 //|     root_group: Group
 //|     """The root group on the epaper display.
-//|     If the root group is set to displayio.CIRCUITPYTHON_TERMINAL, the default CircuitPython terminal will be shown.
+//|     If the root group is set to `displayio.CIRCUITPYTHON_TERMINAL`, the default CircuitPython terminal will be shown.
 //|     If the root group is set to ``None``, no output will be shown.
 //|     """
 //|

--- a/shared-bindings/displayio/EPaperDisplay.c
+++ b/shared-bindings/displayio/EPaperDisplay.c
@@ -384,6 +384,7 @@ MP_PROPERTY_GETTER(displayio_epaperdisplay_bus_obj,
 
 //|     root_group: Group
 //|     """The root group on the epaper display.
+//|     If the root group is set to displayio.CIRCUITPYTHON_TERMINAL, the default CircuitPython terminal will be shown.
 //|     If the root group is set to ``None``, no output will be shown.
 //|     """
 //|

--- a/shared-bindings/displayio/__init__.c
+++ b/shared-bindings/displayio/__init__.c
@@ -57,6 +57,10 @@
 //| <https://learn.adafruit.com/circuitpython-display-support-using-displayio>`_.
 //| """
 
+//| CIRCUITPYTHON_TERMINAL: Group
+//| """The `displayio.Group` that is the displayed serial terminal (REPL)."""
+//|
+
 //| import paralleldisplay
 //|
 

--- a/shared-bindings/framebufferio/FramebufferDisplay.c
+++ b/shared-bindings/framebufferio/FramebufferDisplay.c
@@ -326,6 +326,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(framebufferio_framebufferdisplay_fill_row_obj, 1, fra
 //|     """The root group on the display.
 //|     If the root group is set to ``None``, no output will be shown.
 //|     """
+//|
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_root_group(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     return common_hal_framebufferio_framebufferdisplay_get_root_group(self);

--- a/shared-bindings/framebufferio/FramebufferDisplay.c
+++ b/shared-bindings/framebufferio/FramebufferDisplay.c
@@ -324,6 +324,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(framebufferio_framebufferdisplay_fill_row_obj, 1, fra
 
 //|     root_group: displayio.Group
 //|     """The root group on the display.
+//|     If the root group is set to displayio.CIRCUITPYTHON_TERMINAL, the default CircuitPython terminal will be shown.
 //|     If the root group is set to ``None``, no output will be shown.
 //|     """
 //|

--- a/shared-bindings/framebufferio/FramebufferDisplay.c
+++ b/shared-bindings/framebufferio/FramebufferDisplay.c
@@ -324,7 +324,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(framebufferio_framebufferdisplay_fill_row_obj, 1, fra
 
 //|     root_group: displayio.Group
 //|     """The root group on the display.
-//|     If the root group is set to displayio.CIRCUITPYTHON_TERMINAL, the default CircuitPython terminal will be shown.
+//|     If the root group is set to `displayio.CIRCUITPYTHON_TERMINAL`, the default CircuitPython terminal will be shown.
 //|     If the root group is set to ``None``, no output will be shown.
 //|     """
 //|

--- a/shared-bindings/framebufferio/FramebufferDisplay.c
+++ b/shared-bindings/framebufferio/FramebufferDisplay.c
@@ -323,8 +323,9 @@ STATIC mp_obj_t framebufferio_framebufferdisplay_obj_fill_row(size_t n_args, con
 MP_DEFINE_CONST_FUN_OBJ_KW(framebufferio_framebufferdisplay_fill_row_obj, 1, framebufferio_framebufferdisplay_obj_fill_row);
 
 //|     root_group: displayio.Group
-//|     """The root group on the display."""
-//|
+//|     """The root group on the display.
+//|     If the root group is set to ``None``, no output will be shown.
+//|     """
 STATIC mp_obj_t framebufferio_framebufferdisplay_obj_get_root_group(mp_obj_t self_in) {
     framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
     return common_hal_framebufferio_framebufferdisplay_get_root_group(self);

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -52,6 +52,7 @@
 //|             returned by :py:attr:`wifi.radio`
 //|         """
 //|         ...
+//|
 STATIC mp_obj_t socketpool_socketpool_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
 

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -52,7 +52,6 @@
 //|             returned by :py:attr:`wifi.radio`
 //|         """
 //|         ...
-//|
 STATIC mp_obj_t socketpool_socketpool_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
 


### PR DESCRIPTION
Unless I'm missing something, I believe setting root_group=None causes the display to go black and not be updated with any output. I've tested this to be the case on both a fourwire and framebuffer display.