### PR TITLE
Fix Scorpio on-board neopixel pin

### DIFF
--- a/ports/raspberrypi/boards/adafruit_feather_rp2040_scorpio/mpconfigboard.h
+++ b/ports/raspberrypi/boards/adafruit_feather_rp2040_scorpio/mpconfigboard.h
@@ -1,7 +1,7 @@
 #define MICROPY_HW_BOARD_NAME "Adafruit Feather RP2040 Scorpio"
 #define MICROPY_HW_MCU_NAME "rp2040"
 
-#define MICROPY_HW_NEOPIXEL (&pin_GPIO16)
+#define MICROPY_HW_NEOPIXEL (&pin_GPIO4)
 
 #define DEFAULT_I2C_BUS_SCL (&pin_GPIO3)
 #define DEFAULT_I2C_BUS_SDA (&pin_GPIO2)


### PR DESCRIPTION
The status LED is assigned to the NEOPIXEL0 pin (16), instead of the board's neopixel pin (4).

I note that board.NEOPIXEL is broken out on the side of the board as D4, meaning that pin has to be used carefully if the status LED is enabled, but I feel that disabling the status LED altogether would be weird.