### PR TITLE
Fix crash with fast ping on espressif

### DIFF
--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -29,6 +29,7 @@
 
 #include <string.h>
 
+#include "bindings/espidf/__init__.h"
 #include "common-hal/wifi/__init__.h"
 #include "shared/runtime/interrupt_char.h"
 #include "py/gc.h"
@@ -497,7 +498,7 @@ mp_int_t common_hal_wifi_radio_ping(wifi_radio_obj_t *self, mp_obj_t ip_address,
     size_t timeout_ms = timeout * 1000;
 
     esp_ping_handle_t ping;
-    esp_ping_new_session(&ping_config, NULL, &ping);
+    CHECK_ESP_RESULT(esp_ping_new_session(&ping_config, NULL, &ping));
     esp_ping_start(ping);
 
     uint32_t received = 0;


### PR DESCRIPTION
espressif: check return value from esp_ping_new_session

esp_ping_new_session can fail, particularly if ping is called quickly many times in succession.

This is because `esp_ping_new_session` has to do a bunch of stuff including creating a task and a socket. Calling `esp_ping_delete_session` doesn't clean up these resources immediately. Instead, it signals the task to clean up resources and exit 'soon', but 'soon' is defined as 1 second.

When the calls are frequent, the in-use sockets and tasks fill up available slots—I didn't actually check which resource gets used up first.

With this change, the ping call will raise an exception instead of continuing with a call to esp_ping_start that crashes:
```
>>> while True: wifi.radio.ping(wifi.radio.ipv4_gateway)
... 
0.0
0.0
0.002
0.001
0.0
0.0
0.004
0.001
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
espidf.IDFError: Generic Failure
>>> 
```
Closes #5980 based on my testing on an ESP32S3-N8R2.