### PR TITLE
silabs/supervisor/port.c Add call to rtc_reset to prevent crash to safe mode

### DIFF
--- a/ports/silabs/supervisor/port.c
+++ b/ports/silabs/supervisor/port.c
@@ -188,6 +188,10 @@ void reset_port(void) {
     #if CIRCUITPY_BLEIO
     bleio_reset();
     #endif
+
+    #if CIRCUITPY_RTC
+    rtc_reset();
+    #endif
 }
 
 void reset_to_bootloader(void) {


### PR DESCRIPTION
I'm using:
```
Adafruit CircuitPython 8.1.0-beta.2-12-g018f15de9-dirty on 2023-05-06; Sparkfun Thing Plus MGM240P with MGM240PB32VNA
```

Calls to the time module
```py
import time
time.localtime()
```
were crashing the board into safe mode.

Apparently the rtc_time_source wasn't being initialized and calls to rtc_get_time_source_time would then crash. Adding a call to rtc_reset in silabs/supervisor/port.c (reset_port) seems to have resolved the problem.