### PR TITLE
Allow Access Point static IPv4 on the espressif port

### DIFF
--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -475,8 +475,16 @@ void common_hal_wifi_radio_stop_dhcp_client(wifi_radio_obj_t *self) {
     esp_netif_dhcpc_stop(self->netif);
 }
 
+void common_hal_wifi_radio_start_dhcp_server(wifi_radio_obj_t *self) {
+    esp_netif_dhcps_start(self->ap_netif);
+}
+
+void common_hal_wifi_radio_stop_dhcp_server(wifi_radio_obj_t *self) {
+    esp_netif_dhcps_stop(self->ap_netif);
+}
+
 void common_hal_wifi_radio_set_ipv4_address(wifi_radio_obj_t *self, mp_obj_t ipv4, mp_obj_t netmask, mp_obj_t gateway, mp_obj_t ipv4_dns) {
-    common_hal_wifi_radio_stop_dhcp_client(self); // Must stop DHCP to set a manual address
+    common_hal_wifi_radio_stop_dhcp_client(self); // Must stop station DHCP to set a manual address
 
     esp_netif_ip_info_t ip_info;
     ipaddress_ipaddress_to_esp_idf_ip4(ipv4, &ip_info.ip);
@@ -488,6 +496,19 @@ void common_hal_wifi_radio_set_ipv4_address(wifi_radio_obj_t *self, mp_obj_t ipv
     if (ipv4_dns != MP_OBJ_NULL) {
         common_hal_wifi_radio_set_ipv4_dns(self, ipv4_dns);
     }
+}
+
+void common_hal_wifi_radio_set_ipv4_address_ap(wifi_radio_obj_t *self, mp_obj_t ipv4, mp_obj_t netmask, mp_obj_t gateway) {
+    common_hal_wifi_radio_stop_dhcp_server(self); // Must stop access point DHCP to set a manual address
+
+    esp_netif_ip_info_t ip_info;
+    ipaddress_ipaddress_to_esp_idf_ip4(ipv4, &ip_info.ip);
+    ipaddress_ipaddress_to_esp_idf_ip4(netmask, &ip_info.netmask);
+    ipaddress_ipaddress_to_esp_idf_ip4(gateway, &ip_info.gw);
+
+    esp_netif_set_ip_info(self->ap_netif, &ip_info);
+
+    common_hal_wifi_radio_start_dhcp_server(self); // restart access point DHCP
 }
 
 mp_int_t common_hal_wifi_radio_ping(wifi_radio_obj_t *self, mp_obj_t ip_address, mp_float_t timeout) {

--- a/ports/raspberrypi/common-hal/wifi/Radio.c
+++ b/ports/raspberrypi/common-hal/wifi/Radio.c
@@ -358,6 +358,14 @@ void common_hal_wifi_radio_stop_dhcp_client(wifi_radio_obj_t *self) {
     dhcp_stop(NETIF_STA);
 }
 
+void common_hal_wifi_radio_start_dhcp_server(wifi_radio_obj_t *self) {
+    mp_raise_NotImplementedError(NULL);
+}
+
+void common_hal_wifi_radio_stop_dhcp_server(wifi_radio_obj_t *self) {
+    mp_raise_NotImplementedError(NULL);
+}
+
 void common_hal_wifi_radio_set_ipv4_address(wifi_radio_obj_t *self, mp_obj_t ipv4, mp_obj_t netmask, mp_obj_t gateway, mp_obj_t ipv4_dns) {
     common_hal_wifi_radio_stop_dhcp_client(self);
 
@@ -369,6 +377,10 @@ void common_hal_wifi_radio_set_ipv4_address(wifi_radio_obj_t *self, mp_obj_t ipv
     if (ipv4_dns != MP_OBJ_NULL) {
         common_hal_wifi_radio_set_ipv4_dns(self, ipv4_dns);
     }
+}
+
+void common_hal_wifi_radio_set_ipv4_address_ap(wifi_radio_obj_t *self, mp_obj_t ipv4, mp_obj_t netmask, mp_obj_t gateway) {
+    mp_raise_NotImplementedError(NULL);
 }
 
 volatile bool ping_received;

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -317,7 +317,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_station_obj, wifi_radio_stop_station);
 //|         *,
 //|         channel: int = 1,
 //|         authmode: Optional[AuthMode] = None,
-//|         max_connections: Optional[int] = 4
+//|         max_connections: Optional[int] = 4,
 //|     ) -> None:
 //|         """Starts running an access point with the specified ssid and password.
 //|
@@ -416,7 +416,7 @@ MP_PROPERTY_GETTER(wifi_radio_ap_active_obj,
 //|         *,
 //|         channel: int = 0,
 //|         bssid: Optional[Union[str | ReadableBuffer]] = None,
-//|         timeout: Optional[float] = None
+//|         timeout: Optional[float] = None,
 //|     ) -> None:
 //|         """Connects to the given ssid and waits for an ip address. Reconnections are handled
 //|         automatically once one connection succeeds.
@@ -551,7 +551,7 @@ MP_PROPERTY_GETTER(wifi_radio_ipv4_subnet_ap_obj,
 //|         ipv4: ipaddress.IPv4Address,
 //|         netmask: ipaddress.IPv4Address,
 //|         gateway: ipaddress.IPv4Address,
-//|         ipv4_dns: Optional[ipaddress.IPv4Address]
+//|         ipv4_dns: Optional[ipaddress.IPv4Address],
 //|     ) -> None:
 //|         """Sets the IP v4 address of the station. Must include the netmask and gateway. DNS address is optional.
 //|         Setting the address manually will stop the DHCP client."""

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -545,34 +545,60 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_get_ipv4_subnet_ap_obj, wifi_radio_get_ipv4
 MP_PROPERTY_GETTER(wifi_radio_ipv4_subnet_ap_obj,
     (mp_obj_t)&wifi_radio_get_ipv4_subnet_ap_obj);
 
-//|     def set_ipv4_address(
-//|         self,
-//|         *,
-//|         ipv4: ipaddress.IPv4Address,
-//|         netmask: ipaddress.IPv4Address,
-//|         gateway: ipaddress.IPv4Address,
-//|         ipv4_dns: Optional[ipaddress.IPv4Address]
-//|     ) -> None:
-//|         """Sets the IP v4 address of the station. Must include the netmask and gateway. DNS address is optional.
-//|         Setting the address manually will stop the DHCP client."""
-//|         ...
-STATIC mp_obj_t wifi_radio_set_ipv4_address(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_ipv4, ARG_netmask, ARG_gateway, ARG_ipv4_dns };
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_ipv4, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
-        { MP_QSTR_netmask, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
-        { MP_QSTR_gateway, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
-        { MP_QSTR_ipv4_dns, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = MP_OBJ_NULL} },
-    };
+    //|     def set_ipv4_address(
+    //|         self,
+    //|         *,
+    //|         ipv4: ipaddress.IPv4Address,
+    //|         netmask: ipaddress.IPv4Address,
+    //|         gateway: ipaddress.IPv4Address,
+    //|         ipv4_dns: Optional[ipaddress.IPv4Address]
+    //|     ) -> None:
+    //|         """Sets the IP v4 address of the station. Must include the netmask and gateway. DNS address is optional.
+    //|         Setting the address manually will stop the DHCP client."""
+    //|         ...
+    STATIC mp_obj_t wifi_radio_set_ipv4_address(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+        enum { ARG_ipv4, ARG_netmask, ARG_gateway, ARG_ipv4_dns };
+        static const mp_arg_t allowed_args[] = {
+            { MP_QSTR_ipv4, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+            { MP_QSTR_netmask, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+            { MP_QSTR_gateway, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+            { MP_QSTR_ipv4_dns, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = MP_OBJ_NULL} },
+        };
 
-    wifi_radio_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+        wifi_radio_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+        mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    common_hal_wifi_radio_set_ipv4_address(self, args[ARG_ipv4].u_obj, args[ARG_netmask].u_obj, args[ARG_gateway].u_obj, args[ARG_ipv4_dns].u_obj);
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_set_ipv4_address_obj, 1, wifi_radio_set_ipv4_address);
+        common_hal_wifi_radio_set_ipv4_address(self, args[ARG_ipv4].u_obj, args[ARG_netmask].u_obj, args[ARG_gateway].u_obj, args[ARG_ipv4_dns].u_obj);
+        return mp_const_none;
+    }
+    STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_set_ipv4_address_obj, 1, wifi_radio_set_ipv4_address);
+
+    //|     def set_ipv4_address_ap(
+    //|         self,
+    //|         *,
+    //|         ipv4: ipaddress.IPv4Address,
+    //|         netmask: ipaddress.IPv4Address,
+    //|         gateway: ipaddress.IPv4Address,
+    //|     ) -> None:
+    //|         """Sets the IP v4 address of the access point. Must include the netmask and gateway."""
+    //|         ...
+    STATIC mp_obj_t wifi_radio_set_ipv4_address_ap(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+        enum { ARG_ipv4, ARG_netmask, ARG_gateway };
+        static const mp_arg_t allowed_args[] = {
+            { MP_QSTR_ipv4, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+            { MP_QSTR_netmask, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+            { MP_QSTR_gateway, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+        };
+
+        wifi_radio_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+        mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+        common_hal_wifi_radio_set_ipv4_address_ap(self, args[ARG_ipv4].u_obj, args[ARG_netmask].u_obj, args[ARG_gateway].u_obj);
+        return mp_const_none;
+    }
+    STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_set_ipv4_address_ap_obj, 1, wifi_radio_set_ipv4_address_ap);
 
 //|     ipv4_address: Optional[ipaddress.IPv4Address]
 //|     """IP v4 Address of the station when connected to an access point. None otherwise. (read-only)"""
@@ -620,7 +646,7 @@ STATIC mp_obj_t wifi_radio_get_ap_info(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_get_ap_info_obj, wifi_radio_get_ap_info);
 
 //|     def start_dhcp(self) -> None:
-//|         """Starts the DHCP client."""
+//|         """Starts the station DHCP client."""
 //|         ...
 STATIC mp_obj_t wifi_radio_start_dhcp_client(mp_obj_t self) {
     common_hal_wifi_radio_start_dhcp_client(self);
@@ -629,13 +655,31 @@ STATIC mp_obj_t wifi_radio_start_dhcp_client(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_start_dhcp_client_obj, wifi_radio_start_dhcp_client);
 
 //|     def stop_dhcp(self) -> None:
-//|         """Stops the DHCP client. Needed to assign a static IP address."""
+//|         """Stops the station DHCP client. Needed to assign a static IP address."""
 //|         ...
 STATIC mp_obj_t wifi_radio_stop_dhcp_client(mp_obj_t self) {
     common_hal_wifi_radio_stop_dhcp_client(self);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_dhcp_client_obj, wifi_radio_stop_dhcp_client);
+
+//|     def start_dhcp_ap(self) -> None:
+//|         """Starts the access point DHCP client."""
+//|         ...
+STATIC mp_obj_t wifi_radio_start_dhcp_server(mp_obj_t self) {
+    common_hal_wifi_radio_start_dhcp_server(self);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_start_dhcp_server_obj, wifi_radio_start_dhcp_server);
+
+//|     def stop_dhcp_ap(self) -> None:
+//|         """Stops the access point DHCP client. Needed to assign a static IP address."""
+//|         ...
+STATIC mp_obj_t wifi_radio_stop_dhcp_server(mp_obj_t self) {
+    common_hal_wifi_radio_stop_dhcp_server(self);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_dhcp_server_obj, wifi_radio_stop_dhcp_server);
 
 MP_PROPERTY_GETTER(wifi_radio_ap_info_obj,
     (mp_obj_t)&wifi_radio_get_ap_info_obj);
@@ -693,6 +737,8 @@ STATIC const mp_rom_map_elem_t wifi_radio_locals_dict_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_start_dhcp),    MP_ROM_PTR(&wifi_radio_start_dhcp_client_obj) },
     { MP_ROM_QSTR(MP_QSTR_stop_dhcp),    MP_ROM_PTR(&wifi_radio_stop_dhcp_client_obj) },
+    { MP_ROM_QSTR(MP_QSTR_start_dhcp_ap),    MP_ROM_PTR(&wifi_radio_start_dhcp_server_obj) },
+    { MP_ROM_QSTR(MP_QSTR_stop_dhcp_ap),    MP_ROM_PTR(&wifi_radio_stop_dhcp_server_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_connect),    MP_ROM_PTR(&wifi_radio_connect_obj) },
     // { MP_ROM_QSTR(MP_QSTR_connect_to_enterprise),    MP_ROM_PTR(&wifi_radio_connect_to_enterprise_obj) },
@@ -708,6 +754,7 @@ STATIC const mp_rom_map_elem_t wifi_radio_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ipv4_address_ap),    MP_ROM_PTR(&wifi_radio_ipv4_address_ap_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_set_ipv4_address),    MP_ROM_PTR(&wifi_radio_set_ipv4_address_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_ipv4_address_ap),    MP_ROM_PTR(&wifi_radio_set_ipv4_address_ap_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_ping), MP_ROM_PTR(&wifi_radio_ping_obj) },
 };

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -545,60 +545,60 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_get_ipv4_subnet_ap_obj, wifi_radio_get_ipv4
 MP_PROPERTY_GETTER(wifi_radio_ipv4_subnet_ap_obj,
     (mp_obj_t)&wifi_radio_get_ipv4_subnet_ap_obj);
 
-    //|     def set_ipv4_address(
-    //|         self,
-    //|         *,
-    //|         ipv4: ipaddress.IPv4Address,
-    //|         netmask: ipaddress.IPv4Address,
-    //|         gateway: ipaddress.IPv4Address,
-    //|         ipv4_dns: Optional[ipaddress.IPv4Address]
-    //|     ) -> None:
-    //|         """Sets the IP v4 address of the station. Must include the netmask and gateway. DNS address is optional.
-    //|         Setting the address manually will stop the DHCP client."""
-    //|         ...
-    STATIC mp_obj_t wifi_radio_set_ipv4_address(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-        enum { ARG_ipv4, ARG_netmask, ARG_gateway, ARG_ipv4_dns };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_ipv4, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
-            { MP_QSTR_netmask, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
-            { MP_QSTR_gateway, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
-            { MP_QSTR_ipv4_dns, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = MP_OBJ_NULL} },
-        };
+//|     def set_ipv4_address(
+//|         self,
+//|         *,
+//|         ipv4: ipaddress.IPv4Address,
+//|         netmask: ipaddress.IPv4Address,
+//|         gateway: ipaddress.IPv4Address,
+//|         ipv4_dns: Optional[ipaddress.IPv4Address]
+//|     ) -> None:
+//|         """Sets the IP v4 address of the station. Must include the netmask and gateway. DNS address is optional.
+//|         Setting the address manually will stop the DHCP client."""
+//|         ...
+STATIC mp_obj_t wifi_radio_set_ipv4_address(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_ipv4, ARG_netmask, ARG_gateway, ARG_ipv4_dns };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_ipv4, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+        { MP_QSTR_netmask, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+        { MP_QSTR_gateway, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+        { MP_QSTR_ipv4_dns, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = MP_OBJ_NULL} },
+    };
 
-        wifi_radio_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    wifi_radio_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-        common_hal_wifi_radio_set_ipv4_address(self, args[ARG_ipv4].u_obj, args[ARG_netmask].u_obj, args[ARG_gateway].u_obj, args[ARG_ipv4_dns].u_obj);
-        return mp_const_none;
-    }
-    STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_set_ipv4_address_obj, 1, wifi_radio_set_ipv4_address);
+    common_hal_wifi_radio_set_ipv4_address(self, args[ARG_ipv4].u_obj, args[ARG_netmask].u_obj, args[ARG_gateway].u_obj, args[ARG_ipv4_dns].u_obj);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_set_ipv4_address_obj, 1, wifi_radio_set_ipv4_address);
 
-    //|     def set_ipv4_address_ap(
-    //|         self,
-    //|         *,
-    //|         ipv4: ipaddress.IPv4Address,
-    //|         netmask: ipaddress.IPv4Address,
-    //|         gateway: ipaddress.IPv4Address,
-    //|     ) -> None:
-    //|         """Sets the IP v4 address of the access point. Must include the netmask and gateway."""
-    //|         ...
-    STATIC mp_obj_t wifi_radio_set_ipv4_address_ap(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-        enum { ARG_ipv4, ARG_netmask, ARG_gateway };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_ipv4, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
-            { MP_QSTR_netmask, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
-            { MP_QSTR_gateway, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
-        };
+//|     def set_ipv4_address_ap(
+//|         self,
+//|         *,
+//|         ipv4: ipaddress.IPv4Address,
+//|         netmask: ipaddress.IPv4Address,
+//|         gateway: ipaddress.IPv4Address,
+//|     ) -> None:
+//|         """Sets the IP v4 address of the access point. Must include the netmask and gateway."""
+//|         ...
+STATIC mp_obj_t wifi_radio_set_ipv4_address_ap(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_ipv4, ARG_netmask, ARG_gateway };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_ipv4, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+        { MP_QSTR_netmask, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+        { MP_QSTR_gateway, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, },
+    };
 
-        wifi_radio_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    wifi_radio_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-        common_hal_wifi_radio_set_ipv4_address_ap(self, args[ARG_ipv4].u_obj, args[ARG_netmask].u_obj, args[ARG_gateway].u_obj);
-        return mp_const_none;
-    }
-    STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_set_ipv4_address_ap_obj, 1, wifi_radio_set_ipv4_address_ap);
+    common_hal_wifi_radio_set_ipv4_address_ap(self, args[ARG_ipv4].u_obj, args[ARG_netmask].u_obj, args[ARG_gateway].u_obj);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_set_ipv4_address_ap_obj, 1, wifi_radio_set_ipv4_address_ap);
 
 //|     ipv4_address: Optional[ipaddress.IPv4Address]
 //|     """IP v4 Address of the station when connected to an access point. None otherwise. (read-only)"""

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -664,7 +664,7 @@ STATIC mp_obj_t wifi_radio_stop_dhcp_client(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_dhcp_client_obj, wifi_radio_stop_dhcp_client);
 
 //|     def start_dhcp_ap(self) -> None:
-//|         """Starts the access point DHCP client."""
+//|         """Starts the access point DHCP server."""
 //|         ...
 STATIC mp_obj_t wifi_radio_start_dhcp_server(mp_obj_t self) {
     common_hal_wifi_radio_start_dhcp_server(self);
@@ -673,7 +673,7 @@ STATIC mp_obj_t wifi_radio_start_dhcp_server(mp_obj_t self) {
 MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_start_dhcp_server_obj, wifi_radio_start_dhcp_server);
 
 //|     def stop_dhcp_ap(self) -> None:
-//|         """Stops the access point DHCP client. Needed to assign a static IP address."""
+//|         """Stops the access point DHCP server. Needed to assign a static IP address."""
 //|         ...
 STATIC mp_obj_t wifi_radio_stop_dhcp_server(mp_obj_t self) {
     common_hal_wifi_radio_stop_dhcp_server(self);

--- a/shared-bindings/wifi/Radio.h
+++ b/shared-bindings/wifi/Radio.h
@@ -99,6 +99,8 @@ extern bool common_hal_wifi_radio_get_ap_active(wifi_radio_obj_t *self);
 
 extern void common_hal_wifi_radio_start_dhcp_client(wifi_radio_obj_t *self);
 extern void common_hal_wifi_radio_stop_dhcp_client(wifi_radio_obj_t *self);
+extern void common_hal_wifi_radio_start_dhcp_server(wifi_radio_obj_t *self);
+extern void common_hal_wifi_radio_stop_dhcp_server(wifi_radio_obj_t *self);
 
 extern wifi_radio_error_t common_hal_wifi_radio_connect(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, mp_float_t timeout, uint8_t *bssid, size_t bssid_len);
 extern bool common_hal_wifi_radio_get_connected(wifi_radio_obj_t *self);
@@ -115,6 +117,7 @@ extern mp_obj_t common_hal_wifi_radio_get_ipv4_address(wifi_radio_obj_t *self);
 extern mp_obj_t common_hal_wifi_radio_get_ipv4_address_ap(wifi_radio_obj_t *self);
 
 extern void common_hal_wifi_radio_set_ipv4_address(wifi_radio_obj_t *self, mp_obj_t ipv4, mp_obj_t netmask, mp_obj_t gateway, mp_obj_t ipv4_dns_addr);
+extern void common_hal_wifi_radio_set_ipv4_address_ap(wifi_radio_obj_t *self, mp_obj_t ipv4, mp_obj_t netmask, mp_obj_t gateway);
 
 extern mp_int_t common_hal_wifi_radio_ping(wifi_radio_obj_t *self, mp_obj_t ip_address, mp_float_t timeout);
 


### PR DESCRIPTION
Relevant to Issue #7931 

AP:
```py
Adafruit CircuitPython 8.1.0-beta.2-12-g018f15de9-dirty on 2023-05-08; ESP32-S2-DevKitC-1-N4R2 with ESP32S2
>>> import wifi
>>> import ipaddress
>>> 
>>> ipv4 = ipaddress.IPv4Address("192.168.251.2")
>>> netmask = ipaddress.IPv4Address("255.255.255.0")
>>> gateway = ipaddress.IPv4Address("192.168.251.1")
>>> wifi.radio.ipv4_address_ap
>>> 
>>> wifi.radio.set_ipv4_address_ap(ipv4=ipv4, netmask=netmask, gateway=gateway)
>>> wifi.radio.ipv4_address_ap
>>> 
>>> wifi.radio.start_ap("Bob", "YourUncle")
>>> wifi.radio.ipv4_address_ap
192.168.251.2
>>> 
```
Station (separate device):
```py
>>> import wifi
>>> wifi.radio.ipv4_address
>>> wifi.radio.connect(ssid="Bob", password="YourUncle")
>>> wifi.radio.ipv4_address
192.168.251.3
>>> 
```

Tested by connecting to the AP from another CircuitPython device and from a desktop computer. Also ran a TCP echo [server](https://github.com/anecdata/Socket/blob/main/examples/tcp_server_CircuitPython_NATIVE.py) on the circuitpython AP, and sent packets to it from the circuitpython TCP station and from a desktop Python TCP client.

Note that connecting stations will be assigned IP addresses sequentially starting with the AP static IPv4 + 1.