### PR TITLE
validate point type is tuple in vectorio Polygon

### DIFF
--- a/shared-module/vectorio/Polygon.c
+++ b/shared-module/vectorio/Polygon.c
@@ -36,6 +36,7 @@ static void _clobber_points_list(vectorio_polygon_t *self, mp_obj_t points_tuple
     for (uint16_t i = 0; i < len; ++i) {
         size_t tuple_len = 0;
         mp_obj_t *tuple_items;
+        mp_arg_validate_type(items[i], &mp_type_tuple, MP_QSTR_point);
         mp_obj_tuple_get(items[i], &tuple_len, &tuple_items);
 
         mp_arg_validate_length(tuple_len, 2, MP_QSTR_point);


### PR DESCRIPTION
Attempt to resolve #7945 

Added validation inside of Polygon creation to ensure the values inside the points list are tuples before attempting to get values out of them.