### PR TITLE
adding __contains__ stub to displayio.Group

### DIFF
--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -249,6 +249,10 @@ STATIC mp_obj_t displayio_group_obj_remove(mp_obj_t self_in, mp_obj_t layer) {
 MP_DEFINE_CONST_FUN_OBJ_2(displayio_group_remove_obj, displayio_group_obj_remove);
 
 //|     def __bool__(self) -> bool: ...
+//|     def __contains__(
+//|         self,
+//|         item: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid],
+//|     ) -> bool: ...
 //|     def __len__(self) -> int:
 //|         """Returns the number of layers in a Group"""
 //|         ...

--- a/shared-bindings/displayio/Group.c
+++ b/shared-bindings/displayio/Group.c
@@ -253,6 +253,11 @@ MP_DEFINE_CONST_FUN_OBJ_2(displayio_group_remove_obj, displayio_group_obj_remove
 //|         self,
 //|         item: Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid],
 //|     ) -> bool: ...
+//|     def __iter__(
+//|         self,
+//|     ) -> Iterator[
+//|         Union[vectorio.Circle, vectorio.Rectangle, vectorio.Polygon, Group, TileGrid]
+//|     ]: ...
 //|     def __len__(self) -> int:
 //|         """Returns the number of layers in a Group"""
 //|         ...


### PR DESCRIPTION
resolves: #7948 

I noticed that mypy raises this error while testing some of the suggested fixes discussed during the weeds section of the meeting inside of this PR: https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout/pull/85 

This topic of the `in` operator didn't come up, but I noticed mypy outputting errors about it while working on that.

I tested the change successfully by building stubs and installing with `pip install . ` and then running mypy on that PR branch again. Confirmed that it no longer outputs the error.