### PR TITLE
Report SPI frequency accurately on Espressif

### DIFF
--- a/ports/espressif/common-hal/busio/SPI.c
+++ b/ports/espressif/common-hal/busio/SPI.c
@@ -56,8 +56,10 @@ void spi_reset(void) {
 
 static void set_spi_config(busio_spi_obj_t *self,
     uint32_t baudrate, uint8_t polarity, uint8_t phase, uint8_t bits) {
+    // 128 is a 50% duty cycle.
+    const int closest_clock = spi_get_actual_clock(APB_CLK_FREQ, baudrate, 128);
     const spi_device_interface_config_t device_config = {
-        .clock_speed_hz = baudrate,
+        .clock_speed_hz = closest_clock,
         .mode = phase | (polarity << 1),
         .spics_io_num = -1, // No CS pin
         .queue_size = MAX_SPI_TRANSACTIONS,
@@ -67,7 +69,7 @@ static void set_spi_config(busio_spi_obj_t *self,
     if (result != ESP_OK) {
         mp_raise_RuntimeError(translate("SPI configuration failed"));
     }
-    self->baudrate = baudrate;
+    self->baudrate = closest_clock;
     self->polarity = polarity;
     self->phase = phase;
     self->bits = bits;


### PR DESCRIPTION
- Fixes #7593.

Test on Metro ESP32-S2:
```py
>>> import board
>>> s = board.SPI()
>>> s.frequency
250000
>>> s.try_lock()
True
>>> s.configure(baudrate=10)
>>> s.frequency
152
>>> s.configure(baudrate=100)
>>> s.frequency
152
>>> s.configure(baudrate=1000)
>>> s.frequency
1000
>>> s.configure(baudrate=100000)
>>> s.frequency
100000
>>> s.configure(baudrate=1000000)
>>> s.frequency
1000000
>>> s.configure(baudrate=10000000)
>>> s.frequency
10000000
>>> s.configure(baudrate=100000000)
>>> s.frequency
80000000
>>> s.configure(baudrate=123456)
>>> s.frequency
123456
>>> s.configure(baudrate=123888)
>>> s.frequency
123839
```
