### PR TITLE
Correct pad count.

### DIFF
--- a/ports/mimxrt10xx/boards/imxrt1010_evk/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1010_evk/board.c
@@ -41,9 +41,6 @@ const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     &pin_GPIO_SD_08,
     &pin_GPIO_SD_07,
     &pin_GPIO_SD_06,
-    // USB Pins
-    &pin_USB_OTG1_DN,
-    &pin_USB_OTG1_DP,
     NULL,                       // Must end in NULL.
 };
 

--- a/ports/mimxrt10xx/boards/imxrt1015_evk/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1015_evk/board.c
@@ -40,9 +40,6 @@ const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     &pin_GPIO_SD_B1_09,
     &pin_GPIO_SD_B1_10,
     &pin_GPIO_SD_B1_11,
-    // USB Pins
-    &pin_USB_OTG1_DN,
-    &pin_USB_OTG1_DP,
     NULL,                       // Must end in NULL.
 };
 

--- a/ports/mimxrt10xx/boards/imxrt1020_evk/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1020_evk/board.c
@@ -42,10 +42,6 @@ const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     &pin_GPIO_SD_B1_09,
     &pin_GPIO_SD_B1_10,
     &pin_GPIO_SD_B1_11,
-
-    // USB Pins
-    &pin_USB_OTG1_DN,
-    &pin_USB_OTG1_DP,
     NULL,                       // Must end in NULL.
 };
 

--- a/ports/mimxrt10xx/boards/imxrt1040_evk/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1040_evk/board.c
@@ -44,9 +44,6 @@ const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     &pin_GPIO_SD_B1_10,
     &pin_GPIO_SD_B1_11,
 
-    &pin_USB_OTG1_DN,
-    &pin_USB_OTG1_DP,
-
     NULL,                       // Must end in NULL.
 };
 

--- a/ports/mimxrt10xx/boards/imxrt1050_evkb/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1050_evkb/board.c
@@ -45,8 +45,8 @@ const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     &pin_GPIO_SD_B1_11,
 
     // USB Pins
-    &pin_GPIO_AD_B0_01,
-    &pin_GPIO_AD_B0_03,
+    &pin_GPIO_AD_B0_01, // ID Pin
+    &pin_GPIO_AD_B0_03, // OC/Fault Pin
     NULL,                       // Must end in NULL.
 };
 

--- a/ports/mimxrt10xx/boards/imxrt1060_evk/board.c
+++ b/ports/mimxrt10xx/boards/imxrt1060_evk/board.c
@@ -50,8 +50,8 @@ const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     &pin_GPIO_SD_B1_11,
 
     // USB Pins
-    &pin_GPIO_AD_B0_01,
-    &pin_GPIO_AD_B0_03,
+    &pin_GPIO_AD_B0_01, // ID Pin
+    &pin_GPIO_AD_B0_03, // OC/Fault Pin
     NULL,                       // Must end in NULL.
 };
 

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1011/pins.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1011/pins.h
@@ -40,5 +40,7 @@
 #include "pin_names.h"
 #undef FORMAT_PIN
 
-#define PIN_COUNT (IOMUXC_SW_PAD_CTL_PAD_COUNT + 2)
+// Pads can be reset. Other pins like USB cannot be.
+#define PAD_COUNT (43)
+#define PIN_COUNT (PAD_COUNT + 2)
 extern const mcu_pin_obj_t mcu_pin_list[PIN_COUNT];

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1015/pins.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1015/pins.h
@@ -40,5 +40,7 @@
 #include "pin_names.h"
 #undef FORMAT_PIN
 
-#define PIN_COUNT (IOMUXC_SW_PAD_CTL_PAD_COUNT + 2)
+// Pads can be reset. Other pins like USB cannot be.
+#define PAD_COUNT (56)
+#define PIN_COUNT (PAD_COUNT + 2)
 extern const mcu_pin_obj_t mcu_pin_list[PIN_COUNT];

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1021/pins.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1021/pins.h
@@ -40,5 +40,7 @@
 #include "pin_names.h"
 #undef FORMAT_PIN
 
-#define PIN_COUNT (IOMUXC_SW_PAD_CTL_PAD_COUNT + 2)
+// Pads can be reset. Other pins like USB cannot be.
+#define PAD_COUNT (93)
+#define PIN_COUNT (PAD_COUNT + 2)
 extern const mcu_pin_obj_t mcu_pin_list[PIN_COUNT];

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1042/pins.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1042/pins.h
@@ -40,5 +40,7 @@
 #include "pin_names.h"
 #undef FORMAT_PIN
 
-#define PIN_COUNT (IOMUXC_SW_PAD_CTL_PAD_COUNT + 2)
+// Pads can be reset. Other pins like USB cannot be.
+#define PAD_COUNT (112)
+#define PIN_COUNT (PAD_COUNT + 2)
 extern const mcu_pin_obj_t mcu_pin_list[PIN_COUNT];

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1052/pins.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1052/pins.h
@@ -40,5 +40,7 @@
 #include "pin_names.h"
 #undef FORMAT_PIN
 
-#define PIN_COUNT (IOMUXC_SW_PAD_CTL_PAD_COUNT + 4)
+// Pads can be reset. Other pins like USB cannot be.
+#define PAD_COUNT (124)
+#define PIN_COUNT (PAD_COUNT + 4)
 extern const mcu_pin_obj_t mcu_pin_list[PIN_COUNT];

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1062/pins.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1062/pins.h
@@ -40,5 +40,7 @@
 #include "pin_names.h"
 #undef FORMAT_PIN
 
-#define PIN_COUNT (IOMUXC_SW_PAD_CTL_PAD_COUNT + 4)
+// Pads can be reset. Other pins like USB cannot be.
+#define PAD_COUNT (124)
+#define PIN_COUNT (PAD_COUNT + 4)
 extern const mcu_pin_obj_t mcu_pin_list[PIN_COUNT];

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1176/pins.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1176/pins.h
@@ -40,5 +40,7 @@
 #include "pin_names.h"
 #undef FORMAT_PIN
 
-#define PIN_COUNT (IOMUXC_SW_PAD_CTL_PAD_COUNT + 0)
+// Pads can be reset. Other pins like USB cannot be.
+#define PAD_COUNT (145)
+#define PIN_COUNT (PAD_COUNT + 0)
 extern const mcu_pin_obj_t mcu_pin_list[PIN_COUNT];

--- a/ports/mimxrt10xx/tools/gen_peripherals_data.py
+++ b/ports/mimxrt10xx/tools/gen_peripherals_data.py
@@ -190,6 +190,7 @@ for device in devices:
             split_pin = name.split("_")
             pin_name = "_".join(split_pin[4:])
             if pin_name not in all_pins:
+                print("skip", pin_name)
                 continue
             gpio_base = "_".join(split_pin[4:-1])
 
@@ -278,7 +279,10 @@ for device in devices:
     pins_c.append("")
 
     pins_h.append("")
-    pins_h.append(f"#define PIN_COUNT (IOMUXC_SW_PAD_CTL_PAD_COUNT + {len(usb_pins)})")
+
+    pins_h.append("// Pads can be reset. Other pins like USB cannot be.")
+    pins_h.append(f"#define PAD_COUNT ({pin_number})")
+    pins_h.append(f"#define PIN_COUNT (PAD_COUNT + {len(usb_pins)})")
     pins_h.append(f"extern const mcu_pin_obj_t mcu_pin_list[PIN_COUNT];")
     pins_h.append("")
 


### PR DESCRIPTION
This prevents running into the pins that cannot be reset. On 1011 it was off by one pin that isn't attached to the package. So, having the USB pins forbidden prevented resetting to a NULL address.

Fixes #7952