### PR TITLE
STM: monotonic time even when RTC is changed

### DIFF
--- a/ports/stm/peripherals/rtc.h
+++ b/ports/stm/peripherals/rtc.h
@@ -36,7 +36,7 @@
 
 uint32_t stm32_peripherals_get_rtc_freq(void);
 void stm32_peripherals_rtc_init(void);
-uint64_t stm32_peripherals_rtc_raw_ticks(uint8_t *subticks);
+uint64_t stm32_peripherals_rtc_monotonic_ticks(uint8_t *subticks);
 
 void stm32_peripherals_rtc_assign_wkup_callback(void (*callback)(void));
 void stm32_peripherals_rtc_set_wakeup_mode_seconds(uint32_t seconds);

--- a/ports/stm/supervisor/port.c
+++ b/ports/stm/supervisor/port.c
@@ -385,7 +385,7 @@ __attribute__((used)) void HardFault_Handler(void) {
 }
 
 uint64_t port_get_raw_ticks(uint8_t *subticks) {
-    return stm32_peripherals_rtc_raw_ticks(subticks);
+    return stm32_peripherals_rtc_monotonic_ticks(subticks);
 }
 
 // Enable 1/1024 second tick.

--- a/shared-module/time/__init__.c
+++ b/shared-module/time/__init__.c
@@ -38,6 +38,8 @@ uint64_t common_hal_time_monotonic_ns(void) {
     uint64_t ticks = port_get_raw_ticks(&subticks);
     // A tick is 976562.5 nanoseconds so multiply it by the base and add half instead of doing float
     // math.
+    // A subtick is 1/32 of a tick.
+    // 30518 is 1e9 / 32768
     return 976562 * ticks + ticks / 2 + 30518 * subticks;
 }
 


### PR DESCRIPTION
- Fixes #7808

Test:
```py
>> import time,rtc
>>> r = rtc.RTC()
>>> print(time.monotonic()); r.datetime = time.struct_time((2023,1,1,0,0,0,0,0,0)); print(time.monotonic())
1329.49
1329.49
>>> print(time.monotonic()); r.datetime = time.struct_time((2022,1,1,0,0,0,0,0,0)); print(time.monotonic())
1339.38
1339.38
>>> print(time.monotonic_ns()); r.datetime = time.struct_time((2022,1,1,0,0,0,0,0,0)); print(time.monotonic_ns())
1353792083741
1353791992187
>>> print(time.monotonic_ns()); r.datetime = time.struct_time((2024,1,1,0,0,0,0,0,0)); print(time.monotonic_ns())
1362228332530
1362227539062
>>> 
```
I also tested after ctrl-D: time.monotonic() is not reset to zero, which I think is OK.

The change looks bigger than it is: I had to reorder some things to avoid a forward declaration.
