### PR TITLE
Add missing ESP32-S3 pins to microcontroller module

### DIFF
--- a/ports/espressif/common-hal/microcontroller/__init__.c
+++ b/ports/espressif/common-hal/microcontroller/__init__.c
@@ -304,5 +304,11 @@ STATIC const mp_rom_map_elem_t mcu_pin_global_dict_table[] = {
     #ifdef GPIO46_EXISTS
     { MP_ROM_QSTR(MP_QSTR_GPIO46), MP_ROM_PTR(&pin_GPIO46) },
     #endif
+    #ifdef GPIO47_EXISTS
+    { MP_ROM_QSTR(MP_QSTR_GPIO47), MP_ROM_PTR(&pin_GPIO47) },
+    #endif
+    #ifdef GPIO48_EXISTS
+    { MP_ROM_QSTR(MP_QSTR_GPIO48), MP_ROM_PTR(&pin_GPIO48) },
+    #endif
 };
 MP_DEFINE_CONST_DICT(mcu_pin_globals, mcu_pin_global_dict_table);


### PR DESCRIPTION
ESP32-S3 defines two additional general use pins in
https://github.com/adafruit/circuitpython/blob/137e55696ebc46cdb20b444b9d7d01241c9930c1/ports/espressif/peripherals/esp32s3/pins.h#L120-L123
for which support is missing in the microcontroller module HAL.