### PR TITLE
adafruit_bus_device SPIDevice can have None for chip select

### DIFF
--- a/shared-bindings/adafruit_bus_device/spi_device/SPIDevice.c
+++ b/shared-bindings/adafruit_bus_device/spi_device/SPIDevice.c
@@ -44,7 +44,7 @@
 //|     def __init__(
 //|         self,
 //|         spi: busio.SPI,
-//|         chip_select: digitalio.DigitalInOut,
+//|         chip_select: Optional[digitalio.DigitalInOut] = None,
 //|         *,
 //|         baudrate: int = 100000,
 //|         polarity: int = 0,
@@ -55,7 +55,7 @@
 //|         Represents a single SPI device and manages locking the bus and the device address.
 //|
 //|         :param ~busio.SPI spi: The SPI bus the device is on
-//|         :param ~digitalio.DigitalInOut chip_select: The chip select pin object that implements the DigitalInOut API.
+//|         :param ~digitalio.DigitalInOut chip_select: The chip select pin object that implements the DigitalInOut API. ``None`` if a chip select pin is not being used.
 //|         :param bool cs_active_value: Set to true if your device requires CS to be active high. Defaults to false.
 //|         :param int extra_clocks: The minimum number of clock cycles to cycle the bus after CS is high. (Used for SD cards.)
 //|
@@ -84,7 +84,7 @@ STATIC mp_obj_t adafruit_bus_device_spidevice_make_new(const mp_obj_type_t *type
     enum { ARG_spi, ARG_chip_select, ARG_cs_active_value, ARG_baudrate, ARG_polarity, ARG_phase, ARG_extra_clocks };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_spi, MP_ARG_REQUIRED | MP_ARG_OBJ },
-        { MP_QSTR_chip_select, MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_chip_select, MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_cs_active_value, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
         { MP_QSTR_baudrate, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 100000} },
         { MP_QSTR_polarity, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
@@ -96,12 +96,12 @@ STATIC mp_obj_t adafruit_bus_device_spidevice_make_new(const mp_obj_type_t *type
 
     busio_spi_obj_t *spi = args[ARG_spi].u_obj;
 
-    mp_arg_validate_type(args[ARG_chip_select].u_obj, &digitalio_digitalinout_type, MP_QSTR_chip_select);
+    mp_arg_validate_type_or_none(args[ARG_chip_select].u_obj, &digitalio_digitalinout_type, MP_QSTR_chip_select);
 
     common_hal_adafruit_bus_device_spidevice_construct(MP_OBJ_TO_PTR(self), spi, args[ARG_chip_select].u_obj, args[ARG_cs_active_value].u_bool, args[ARG_baudrate].u_int, args[ARG_polarity].u_int,
         args[ARG_phase].u_int, args[ARG_extra_clocks].u_int);
 
-    if (args[ARG_chip_select].u_obj != MP_OBJ_NULL) {
+    if (args[ARG_chip_select].u_obj != mp_const_none) {
         digitalinout_result_t result = common_hal_digitalio_digitalinout_switch_to_output(MP_OBJ_TO_PTR(args[ARG_chip_select].u_obj),
             true, DRIVE_MODE_PUSH_PULL);
         #if CIRCUITPY_DIGITALIO_HAVE_INPUT_ONLY

--- a/shared-module/adafruit_bus_device/spi_device/SPIDevice.c
+++ b/shared-module/adafruit_bus_device/spi_device/SPIDevice.c
@@ -38,6 +38,7 @@ void common_hal_adafruit_bus_device_spidevice_construct(adafruit_bus_device_spid
     self->polarity = polarity;
     self->phase = phase;
     self->extra_clocks = extra_clocks;
+    // May be mp_const_none if CS not used.
     self->chip_select = cs;
     self->cs_active_value = cs_active_value;
 }
@@ -66,14 +67,14 @@ mp_obj_t common_hal_adafruit_bus_device_spidevice_enter(adafruit_bus_device_spid
         mp_call_method_n_kw(0, 4, dest);
     }
 
-    if (self->chip_select != MP_OBJ_NULL) {
+    if (self->chip_select != mp_const_none) {
         common_hal_digitalio_digitalinout_set_value(MP_OBJ_TO_PTR(self->chip_select), self->cs_active_value);
     }
     return self->spi;
 }
 
 void common_hal_adafruit_bus_device_spidevice_exit(adafruit_bus_device_spidevice_obj_t *self) {
-    if (self->chip_select != MP_OBJ_NULL) {
+    if (self->chip_select != mp_const_none) {
         common_hal_digitalio_digitalinout_set_value(MP_OBJ_TO_PTR(self->chip_select), !(self->cs_active_value));
     }
 


### PR DESCRIPTION
- Fixes #7968 

The native version of `adafruit_bus_device.spi_device.SPIDevice` did not allow `chip_select` to be `None`. The CircuitPython library did allow this. Also it would have not allowed passing `None` explicitly. Fixed those things, and also fixed documentation.