### PR TITLE
Allow Access Point static IPv4 on the raspberrypi port

### DIFF
--- a/ports/raspberrypi/common-hal/wifi/Radio.c
+++ b/ports/raspberrypi/common-hal/wifi/Radio.c
@@ -359,11 +359,11 @@ void common_hal_wifi_radio_stop_dhcp_client(wifi_radio_obj_t *self) {
 }
 
 void common_hal_wifi_radio_start_dhcp_server(wifi_radio_obj_t *self) {
-    mp_raise_NotImplementedError(NULL);
+    dhcp_stop(NETIF_AP);
 }
 
 void common_hal_wifi_radio_stop_dhcp_server(wifi_radio_obj_t *self) {
-    mp_raise_NotImplementedError(NULL);
+    dhcp_stop(NETIF_AP);
 }
 
 void common_hal_wifi_radio_set_ipv4_address(wifi_radio_obj_t *self, mp_obj_t ipv4, mp_obj_t netmask, mp_obj_t gateway, mp_obj_t ipv4_dns) {
@@ -380,7 +380,15 @@ void common_hal_wifi_radio_set_ipv4_address(wifi_radio_obj_t *self, mp_obj_t ipv
 }
 
 void common_hal_wifi_radio_set_ipv4_address_ap(wifi_radio_obj_t *self, mp_obj_t ipv4, mp_obj_t netmask, mp_obj_t gateway) {
-    mp_raise_NotImplementedError(NULL);
+    common_hal_wifi_radio_stop_dhcp_server(self);
+
+    ip4_addr_t ipv4_addr, netmask_addr, gateway_addr;
+    ipaddress_ipaddress_to_lwip(ipv4, &ipv4_addr);
+    ipaddress_ipaddress_to_lwip(netmask, &netmask_addr);
+    ipaddress_ipaddress_to_lwip(gateway, &gateway_addr);
+    netif_set_addr(NETIF_AP, &ipv4_addr, &netmask_addr, &gateway_addr);
+
+    common_hal_wifi_radio_start_dhcp_server(self);
 }
 
 volatile bool ping_received;

--- a/ports/raspberrypi/common-hal/wifi/Radio.c
+++ b/ports/raspberrypi/common-hal/wifi/Radio.c
@@ -359,11 +359,9 @@ void common_hal_wifi_radio_stop_dhcp_client(wifi_radio_obj_t *self) {
 }
 
 void common_hal_wifi_radio_start_dhcp_server(wifi_radio_obj_t *self) {
-    dhcp_start(NETIF_AP);
 }
 
 void common_hal_wifi_radio_stop_dhcp_server(wifi_radio_obj_t *self) {
-    dhcp_stop(NETIF_AP);
 }
 
 void common_hal_wifi_radio_set_ipv4_address(wifi_radio_obj_t *self, mp_obj_t ipv4, mp_obj_t netmask, mp_obj_t gateway, mp_obj_t ipv4_dns) {

--- a/ports/raspberrypi/common-hal/wifi/Radio.c
+++ b/ports/raspberrypi/common-hal/wifi/Radio.c
@@ -359,7 +359,7 @@ void common_hal_wifi_radio_stop_dhcp_client(wifi_radio_obj_t *self) {
 }
 
 void common_hal_wifi_radio_start_dhcp_server(wifi_radio_obj_t *self) {
-    dhcp_stop(NETIF_AP);
+    dhcp_start(NETIF_AP);
 }
 
 void common_hal_wifi_radio_stop_dhcp_server(wifi_radio_obj_t *self) {

--- a/ports/raspberrypi/common-hal/wifi/Radio.c
+++ b/ports/raspberrypi/common-hal/wifi/Radio.c
@@ -48,6 +48,8 @@
 #include "lwip/raw.h"
 #include "lwip_src/ping.h"
 
+#include "shared/netutils/dhcpserver.h"
+
 #define MAC_ADDRESS_LENGTH 6
 
 #define NETIF_STA (&cyw43_state.netif[CYW43_ITF_STA])
@@ -359,9 +361,14 @@ void common_hal_wifi_radio_stop_dhcp_client(wifi_radio_obj_t *self) {
 }
 
 void common_hal_wifi_radio_start_dhcp_server(wifi_radio_obj_t *self) {
+    ip4_addr_t ipv4_addr, netmask_addr;
+    ipaddress_ipaddress_to_lwip(common_hal_wifi_radio_get_ipv4_address_ap(self), &ipv4_addr);
+    ipaddress_ipaddress_to_lwip(common_hal_wifi_radio_get_ipv4_subnet_ap(self), &netmask_addr);
+    dhcp_server_init(&cyw43_state.dhcp_server, &ipv4_addr, &netmask_addr);
 }
 
 void common_hal_wifi_radio_stop_dhcp_server(wifi_radio_obj_t *self) {
+    dhcp_server_deinit(&cyw43_state.dhcp_server);
 }
 
 void common_hal_wifi_radio_set_ipv4_address(wifi_radio_obj_t *self, mp_obj_t ipv4, mp_obj_t netmask, mp_obj_t gateway, mp_obj_t ipv4_dns) {


### PR DESCRIPTION
Like #7946 but for `raspberrypi`. The two PRs together should fully address #7931.

Draft for now... took a first stab at PicoW AP static IPv4. A couple of oddities...

1. Unlike `espressif`, AP needs to be started before the IPv4 address can be set:
```py
Adafruit CircuitPython 8.1.0-beta.2-33-gcd41fb101 on 2023-05-14; Raspberry Pi Pico W with rp2040
>>> import wifi
>>> import ipaddress
>>> 
>>> ipv4 = ipaddress.IPv4Address("192.168.251.2")
>>> netmask = ipaddress.IPv4Address("255.255.255.0")
>>> gateway = ipaddress.IPv4Address("192.168.251.1")
>>> wifi.radio.set_ipv4_address_ap(ipv4=ipv4, netmask=netmask, gateway=gateway)
>>> wifi.radio.ipv4_address_ap
>>> 
>>> wifi.radio.start_ap("Bob", "YourUncle")
>>> wifi.radio.ipv4_address_ap
192.168.4.1
>>> 
>>> wifi.radio.set_ipv4_address_ap(ipv4=ipv4, netmask=netmask, gateway=gateway)
>>> wifi.radio.ipv4_address_ap
192.168.251.2
```
This means that there will be an interval where something could connect to the AP with the wrong IP range, and that address could conflict with another network.

2. The connecting station gets IP address 192.168.4.16 (expected 192.168.251.3), so something more needs to be done with the AP DHCP server.