### PR TITLE
Add a Pointer hid device with horizontal scrolling (panning)

### DIFF
--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -80,6 +80,12 @@
 //|     Uses Report ID 1 for its IN and OUT reports.
 //|     """
 //|
+//|     POINTER: Device
+//|     """Standard mouse device supporting five mouse buttons, X and Y relative movements from -127 to 127
+//|     in each report, a relative mouse wheel change from -127 to 127, and a relative mouse pan change from -127 to 127 in each report.
+//|     Uses Report ID 5 for its IN report.
+//|     """
+//|
 //|     MOUSE: Device
 //|     """Standard mouse device supporting five mouse buttons, X and Y relative movements from -127 to 127
 //|     in each report, and a relative mouse wheel change from -127 to 127 in each report.
@@ -259,6 +265,7 @@ STATIC const mp_rom_map_elem_t usb_hid_device_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_usage),                    MP_ROM_PTR(&usb_hid_device_usage_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_KEYBOARD),                 MP_ROM_PTR(&usb_hid_device_keyboard_obj) },
+    { MP_ROM_QSTR(MP_QSTR_POINTER),                  MP_ROM_PTR(&usb_hid_device_pointer_obj) },
     { MP_ROM_QSTR(MP_QSTR_MOUSE),                    MP_ROM_PTR(&usb_hid_device_mouse_obj) },
     { MP_ROM_QSTR(MP_QSTR_CONSUMER_CONTROL),         MP_ROM_PTR(&usb_hid_device_consumer_control_obj) },
 };

--- a/shared-bindings/usb_hid/__init__.c
+++ b/shared-bindings/usb_hid/__init__.c
@@ -39,7 +39,7 @@
 
 //| devices: Tuple[Device, ...]
 //| """Tuple of all active HID device interfaces.
-//| The default set of devices is ``Device.KEYBOARD, Device.MOUSE, Device.CONSUMER_CONTROL``,
+//| The default set of devices is ``Device.KEYBOARD, Device.POINTER, Device.MOUSE, Device.CONSUMER_CONTROL``,
 //| On boards where `usb_hid` is disabled by default, `devices` is an empty tuple.
 //|
 //| If a boot device is enabled by `usb_hid.enable()`, *and* the host has requested a boot device,

--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -136,6 +136,63 @@ const usb_hid_device_obj_t usb_hid_device_mouse_obj = {
     .out_report_lengths = { 0, },
 };
 
+static const uint8_t pointer_report_descriptor[] = {
+    0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
+    0x09, 0x01,        // Usage (Pointer)
+    0xA1, 0x01,        // Collection (Application)
+    0x09, 0x01,        //   Usage (Pointer)
+    0xA1, 0x00,        //   Collection (Physical)
+    0x85, 0x05,        //     10, 11 Report ID (2)
+    0x05, 0x09,        //     Usage Page (Button)
+    0x19, 0x01,        //     Usage Minimum (0x01)
+    0x29, 0x05,        //     Usage Maximum (0x05)
+    0x15, 0x00,        //     Logical Minimum (0)
+    0x25, 0x01,        //     Logical Maximum (1)
+    0x95, 0x05,        //     Report Count (5)
+    0x75, 0x01,        //     Report Size (1)
+    0x81, 0x02,        //     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x95, 0x01,        //     Report Count (1)
+    0x75, 0x03,        //     Report Size (3)
+    0x81, 0x01,        //     Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x05, 0x01,        //     Usage Page (Generic Desktop Ctrls)
+    0x09, 0x30,        //     Usage (X)
+    0x09, 0x31,        //     Usage (Y)
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x02,        //     Report Count (2)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0x09, 0x38,        //     Usage (Wheel)
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0x05, 0x0C,        //     Usage Page (Consumer Page)
+    0x0A, 0x38, 0x02,  //     Usage (Pan)
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              //   End Collection
+    0xC0,              // End Collection
+};
+
+const usb_hid_device_obj_t usb_hid_device_pointer_obj = {
+    .base = {
+        .type = &usb_hid_device_type,
+    },
+    .report_descriptor = pointer_report_descriptor,
+    .report_descriptor_length = sizeof(pointer_report_descriptor),
+    .usage_page = 0x01,
+    .usage = 0x01,
+    .num_report_ids = 1,
+    .report_ids = { 0x05 },
+    .in_report_lengths = { 5, },
+    .out_report_lengths = { 0, },
+};
+
 static const uint8_t consumer_control_report_descriptor[] = {
     0x05, 0x0C,        // Usage Page (Consumer)
     0x09, 0x01,        // Usage (Consumer Control)

--- a/shared-module/usb_hid/Device.h
+++ b/shared-module/usb_hid/Device.h
@@ -50,6 +50,7 @@ typedef struct  {
 
 extern const usb_hid_device_obj_t usb_hid_device_keyboard_obj;
 extern const usb_hid_device_obj_t usb_hid_device_mouse_obj;
+extern const usb_hid_device_obj_t usb_hid_device_pointer_obj;
 extern const usb_hid_device_obj_t usb_hid_device_consumer_control_obj;
 
 void usb_hid_device_create_report_buffers(usb_hid_device_obj_t *self);

--- a/shared-module/usb_hid/__init__.c
+++ b/shared-module/usb_hid/__init__.c
@@ -99,11 +99,12 @@ static mp_obj_tuple_t default_hid_devices_tuple = {
     .base = {
         .type = &mp_type_tuple,
     },
-    .len = 3,
+    .len = 4,
     .items = {
         MP_OBJ_FROM_PTR(&usb_hid_device_keyboard_obj),
         MP_OBJ_FROM_PTR(&usb_hid_device_mouse_obj),
         MP_OBJ_FROM_PTR(&usb_hid_device_consumer_control_obj),
+        MP_OBJ_FROM_PTR(&usb_hid_device_pointer_obj),
     },
 };
 


### PR DESCRIPTION
# Issue
Users want to implement Mouse firmware with horizontal scrolling, and back and forward buttons, but the default Mouse HID Device has a report descriptor without them

# Solution
Add a 4th default HID device. It's a `Pointer` with a similar report descriptor as the `Mouse`, with the addition of Panning, and Forward and Back

The 5th byte in a report is for the Panning value. The 6th byte has 1 bit for Forward, 1 bit for Back, and 6 padding bits.

I chose to implement as a new Device, instead of improving the existing Mouse device, because this changes the length of the HID Report, which would break existing firmware built using the Mouse device.

This should https://github.com/adafruit/Adafruit_CircuitPython_HID/issues/94