### PR TITLE
Esp touch alarm fix

### DIFF
--- a/ports/espressif/common-hal/microcontroller/Pin.h
+++ b/ports/espressif/common-hal/microcontroller/Pin.h
@@ -41,6 +41,7 @@ extern void reset_all_pins(void);
 // reset_pin_number takes the pin number instead of the pointer so that objects don't
 // need to store a full pointer.
 extern void reset_pin_number(gpio_num_t pin_number);
+extern void skip_reset_once_pin_number(gpio_num_t pin_number);
 extern void claim_pin(const mcu_pin_obj_t *pin);
 extern void claim_pin_number(gpio_num_t pin_number);
 extern bool pin_number_is_free(gpio_num_t pin_number);

--- a/ports/espressif/peripherals/touch.c
+++ b/ports/espressif/peripherals/touch.c
@@ -43,7 +43,7 @@ void peripherals_touch_never_reset(const bool enable) {
 void peripherals_touch_init(const touch_pad_t touchpad) {
     if (!touch_inited) {
         touch_pad_init();
-        touch_pad_set_fsm_mode(TOUCH_FSM_MODE_SW);
+        touch_pad_set_fsm_mode(TOUCH_FSM_MODE_TIMER);
     }
     // touch_pad_config() must be done before touch_pad_fsm_start() the first time.
     // Otherwise the calibration is wrong and we get maximum raw values if there is

--- a/ports/espressif/peripherals/touch.c
+++ b/ports/espressif/peripherals/touch.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "py/gc.h"
 #include "peripherals/touch.h"
 
 static bool touch_inited = false;
@@ -61,14 +62,12 @@ uint16_t peripherals_touch_read(touch_pad_t touchpad) {
     #if defined(CONFIG_IDF_TARGET_ESP32)
     uint16_t touch_value;
     touch_pad_read(touchpad, &touch_value);
+
     // ESP32 touch_pad_read() returns a lower value when a pin is touched instead of a higher value.
     // Flip the values around to be consistent with TouchIn assumptions.
     return UINT16_MAX - touch_value;
     #else
     uint32_t touch_value;
-    touch_pad_sw_start();
-    while (!touch_pad_meas_is_done()) {
-    }
     touch_pad_read_raw_data(touchpad, &touch_value);
     if (touch_value > UINT16_MAX) {
         return UINT16_MAX;


### PR DESCRIPTION
- Fixes #7994.

Two problems:
- #5892 made pin reset set a pull-up, which is recommended by Espressif for minimal power draw (and prevents glitches on random pins). Needed to not set the pull-up to make touch waking work. Added a new capability in `microcontroller/Pin.c` to not reset just once. I was originally using never-reset to do this, but I can't always clear never-reset at the right time, so sometimes it sticks around and causes the pin to appear to be in use.
- #6772 fixed touch on plain ESP32 and switched from `TOUCH_FSM_MODE_TIMER` to `TOUCH_FSM_MODE_SW`. `SW` does not work with sleep touch awakening. I had changed it to `SW` in #6772, but I don't know why, and `TIMER` seems to work fine on ESP32, ESP32-S2, and ESP32-S3.

Tested on Metro ESP32-S2, Feather ESP32-S3 8MB/no-psram, and Feather ESP32 V2.

ESP32 `TouchAlarm` wakeup does not work -- I spent several hours on it, and can't figure out why it's not working. I'll open another issue for that. ESP32 `TouchIn` works fine. Some of my residual changes to help that along are in this PR, because the original code was clearly wrong in some cases.

@mikeysklar you may want to test.
@rxhfcy did you encounter the original issue? You may want to test.