### PR TITLE
Fixes USER_LED/LED which is on GPIO_AD_B0_08 not _09.

### DIFF
--- a/ports/mimxrt10xx/boards/imxrt1060_evk/pins.c
+++ b/ports/mimxrt10xx/boards/imxrt1060_evk/pins.c
@@ -35,8 +35,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_A4), MP_ROM_PTR(&pin_GPIO_AD_B1_01) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_A5), MP_ROM_PTR(&pin_GPIO_AD_B1_00) },
 
-    { MP_OBJ_NEW_QSTR(MP_QSTR_USER_LED), MP_ROM_PTR(&pin_GPIO_AD_B0_09) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO_AD_B0_09) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_USER_LED), MP_ROM_PTR(&pin_GPIO_AD_B0_08) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO_AD_B0_08) },
 
     // Camera Sensor Interface
     { MP_OBJ_NEW_QSTR(MP_QSTR_CSI_VSYNC), MP_ROM_PTR(&pin_GPIO_AD_B1_06) },


### PR DESCRIPTION
USER_LED/LED on MIMXRT1060-EVKB  is on GPIO_AD_B0_08 not _09.

The following code works, where as if you use board.USER_LED, it does not.

```
def blink():
    #led = digitalio.DigitalInOut(board.USER_LED)
    led = digitalio.DigitalInOut(microcontroller.pin.GPIO_AD_B0_08)
    led.direction = digitalio.Direction.OUTPUT

    while True:
        led.value = True
        time.sleep(0.5)
        led.value = False
        time.sleep(0.5)

```