### PR TITLE
Fix LILYGo T-Display RP2040 Display Column Start

### DIFF
--- a/ports/raspberrypi/boards/lilygo_t_display_rp2040/board.c
+++ b/ports/raspberrypi/boards/lilygo_t_display_rp2040/board.c
@@ -99,7 +99,7 @@ static void display_init(void) {
         bus,
         240,            // width (after rotation)
         135,            // height (after rotation)
-        52,             // column start
+        53,             // column start
         40,             // row start
         90,             // rotation
         16,             // color depth


### PR DESCRIPTION
Change column start from 52 to 53 to fix a line at the top of the display.

<img width="400" height="400" alt="Screenshot 2023-05-20 at 10 55 11 AM" src="https://github.com/adafruit/circuitpython/assets/6912600/eaa331ed-4932-43b5-a013-339cc9e65116">

<img width="400" height="400" alt="Screenshot 2023-05-20 at 10 55 11 AM" src="https://github.com/adafruit/circuitpython/assets/6912600/432100ba-98d1-4d28-8c5f-22cbe7c4aa67">

