### PR TITLE
RP2040 SleepMemory

### DIFF
--- a/ports/raspberrypi/common-hal/alarm/SleepMemory.c
+++ b/ports/raspberrypi/common-hal/alarm/SleepMemory.c
@@ -30,18 +30,47 @@
 #include "common-hal/alarm/SleepMemory.h"
 #include "shared-bindings/alarm/SleepMemory.h"
 
-void alarm_sleep_memory_reset(void) {
-}
+__attribute__((section(".uninitialized"))) static uint8_t _sleepmem[SLEEP_MEMORY_LENGTH];
+__attribute__((section(".uninitialized"))) static uint32_t _sleepmem_magicnum;
+#define SLEEP_MEMORY_DATA_GUARD 0xad0000af
+#define SLEEP_MEMORY_DATA_GUARD_MASK 0xff0000ff
 
-uint32_t common_hal_alarm_sleep_memory_get_length(alarm_sleep_memory_obj_t *self) {
+static int is_sleep_memory_valid(void) {
+    if ((_sleepmem_magicnum & SLEEP_MEMORY_DATA_GUARD_MASK)
+        == SLEEP_MEMORY_DATA_GUARD) {
+        return 1;
+    }
     return 0;
 }
 
+static void initialize_sleep_memory(void) {
+    memset((uint8_t *)_sleepmem, 0, SLEEP_MEMORY_LENGTH);
+
+    _sleepmem_magicnum = SLEEP_MEMORY_DATA_GUARD;
+}
+
+void alarm_sleep_memory_reset(void) {
+    if (!is_sleep_memory_valid()) {
+        initialize_sleep_memory();
+    }
+}
+
+uint32_t common_hal_alarm_sleep_memory_get_length(alarm_sleep_memory_obj_t *self) {
+    return sizeof(_sleepmem);
+}
+
 bool common_hal_alarm_sleep_memory_set_bytes(alarm_sleep_memory_obj_t *self, uint32_t start_index, const uint8_t *values, uint32_t len) {
-    mp_raise_NotImplementedError(translate("Sleep Memory not available"));
-    return false;
+    if (start_index + len > sizeof(_sleepmem)) {
+        return false;
+    }
+
+    memcpy((uint8_t *)(_sleepmem + start_index), values, len);
+    return true;
 }
 
 void common_hal_alarm_sleep_memory_get_bytes(alarm_sleep_memory_obj_t *self, uint32_t start_index, uint8_t *values, uint32_t len) {
-    mp_raise_NotImplementedError(translate("Sleep Memory not available"));
+    if (start_index + len > sizeof(_sleepmem)) {
+        return;
+    }
+    memcpy(values, (uint8_t *)(_sleepmem + start_index), len);
 }

--- a/ports/raspberrypi/common-hal/alarm/SleepMemory.h
+++ b/ports/raspberrypi/common-hal/alarm/SleepMemory.h
@@ -28,6 +28,8 @@
 
 #include "py/obj.h"
 
+#define SLEEP_MEMORY_LENGTH (256)
+
 typedef struct {
     mp_obj_base_t base;
 } alarm_sleep_memory_obj_t;


### PR DESCRIPTION
Implements `alarm.sleep_memory` on RP2040. Implementation taken from nRF. It's just a 256-byte block of RAM, since RP2040 does not power down RAM when sleeping.

Fixes #5081. That issue says other things must be done, including removing a watchdog that zeros out RAM. But I didn't do that and it still works?!

https://forums.adafruit.com/viewtopic.php?p=973288 asked about RP2040 sleep memory, and it seemed easy to implement.

Test program, tested with fake deep sleep and with power just via a 5V adapter:
```py
import alarm
import board
import os
import time

time.sleep(1)

u = board.UART()
u.baudrate = 115200

LEN = 16

print(alarm.wake_alarm)
print("previous bytes:", alarm.sleep_memory[0:LEN])
u.write(b"previous bytes: " + str(alarm.sleep_memory[0:LEN]) + b"\r\n")

time_alarm = alarm.time.TimeAlarm(monotonic_time=time.monotonic() + 5)
b = os.urandom(LEN)
print("storing", b)
alarm.sleep_memory[0:LEN] = b

u.write(b"storing " + str(b) + b"\r\n")
time.sleep(1)

alarm.exit_and_deep_sleep_until_alarms(time_alarm)
```