### PR TITLE
synthio: improvements based on feedback

### DIFF
--- a/shared-bindings/synthio/Note.c
+++ b/shared-bindings/synthio/Note.c
@@ -79,7 +79,7 @@ STATIC mp_obj_t synthio_note_make_new(const mp_obj_type_t *type_in, size_t n_arg
     return result;
 };
 
-//|     frequency: BlockInput
+//|     frequency: float
 //|     """The base frequency of the note, in Hz."""
 STATIC mp_obj_t synthio_note_get_frequency(mp_obj_t self_in) {
     synthio_note_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/synthio/Synthesizer.c
+++ b/shared-bindings/synthio/Synthesizer.c
@@ -270,22 +270,22 @@ MP_DEFINE_CONST_FUN_OBJ_1(synthio_synthesizer_get_pressed_obj, synthio_synthesiz
 MP_PROPERTY_GETTER(synthio_synthesizer_pressed_obj,
     (mp_obj_t)&synthio_synthesizer_get_pressed_obj);
 
-//|     lfos: List[LFO]
-//|     """A list of LFOs to advance whether or not they are associated with a playing note.
+//|     blocks: List[BlockInput]
+//|     """A list of blocks to advance whether or not they are associated with a playing note.
 //|
 //|     This can be used to implement 'free-running' LFOs. LFOs associated with playing notes are advanced whether or not they are in this list.
 //|
-//|     This property is read-only but its contents may be modified by e.g., calling ``synth.lfos.append()`` or ``synth.lfos.remove()``. It is initially an empty list."""
+//|     This property is read-only but its contents may be modified by e.g., calling ``synth.blocks.append()`` or ``synth.blocks.remove()``. It is initially an empty list."""
 //|
-STATIC mp_obj_t synthio_synthesizer_obj_get_lfos(mp_obj_t self_in) {
+STATIC mp_obj_t synthio_synthesizer_obj_get_blocks(mp_obj_t self_in) {
     synthio_synthesizer_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
-    return common_hal_synthio_synthesizer_get_lfos(self);
+    return common_hal_synthio_synthesizer_get_blocks(self);
 }
-MP_DEFINE_CONST_FUN_OBJ_1(synthio_synthesizer_get_lfos_obj, synthio_synthesizer_obj_get_lfos);
+MP_DEFINE_CONST_FUN_OBJ_1(synthio_synthesizer_get_blocks_obj, synthio_synthesizer_obj_get_blocks);
 
-MP_PROPERTY_GETTER(synthio_synthesizer_lfos_obj,
-    (mp_obj_t)&synthio_synthesizer_get_lfos_obj);
+MP_PROPERTY_GETTER(synthio_synthesizer_blocks_obj,
+    (mp_obj_t)&synthio_synthesizer_get_blocks_obj);
 
 //|     max_polyphony: int
 //|     """Maximum polyphony of the synthesizer (read-only class property)"""
@@ -308,7 +308,7 @@ STATIC const mp_rom_map_elem_t synthio_synthesizer_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_sample_rate), MP_ROM_PTR(&synthio_synthesizer_sample_rate_obj) },
     { MP_ROM_QSTR(MP_QSTR_max_polyphony), MP_ROM_INT(CIRCUITPY_SYNTHIO_MAX_CHANNELS) },
     { MP_ROM_QSTR(MP_QSTR_pressed), MP_ROM_PTR(&synthio_synthesizer_pressed_obj) },
-    { MP_ROM_QSTR(MP_QSTR_lfos), MP_ROM_PTR(&synthio_synthesizer_lfos_obj) },
+    { MP_ROM_QSTR(MP_QSTR_blocks), MP_ROM_PTR(&synthio_synthesizer_blocks_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(synthio_synthesizer_locals_dict, synthio_synthesizer_locals_dict_table);
 

--- a/shared-bindings/synthio/Synthesizer.c
+++ b/shared-bindings/synthio/Synthesizer.c
@@ -52,6 +52,7 @@
 //|         channel_count: int = 1,
 //|         waveform: Optional[ReadableBuffer] = None,
 //|         envelope: Optional[Envelope] = None,
+//|         filter: Optional[ReadableBuffer] = None,
 //|     ) -> None:
 //|         """Create a synthesizer object.
 //|

--- a/shared-bindings/synthio/Synthesizer.h
+++ b/shared-bindings/synthio/Synthesizer.h
@@ -44,4 +44,4 @@ void common_hal_synthio_synthesizer_press(synthio_synthesizer_obj_t *self, mp_ob
 void common_hal_synthio_synthesizer_retrigger(synthio_synthesizer_obj_t *self, mp_obj_t to_retrigger);
 void common_hal_synthio_synthesizer_release_all(synthio_synthesizer_obj_t *self);
 mp_obj_t common_hal_synthio_synthesizer_get_pressed_notes(synthio_synthesizer_obj_t *self);
-mp_obj_t common_hal_synthio_synthesizer_get_lfos(synthio_synthesizer_obj_t *self);
+mp_obj_t common_hal_synthio_synthesizer_get_blocks(synthio_synthesizer_obj_t *self);

--- a/shared-bindings/synthio/__init__.c
+++ b/shared-bindings/synthio/__init__.c
@@ -281,17 +281,17 @@ STATIC mp_obj_t midi_to_hz(mp_obj_t arg) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(synthio_midi_to_hz_obj, midi_to_hz);
 
-//| def onevo_to_hz(ctrl: float) -> float:
+//| def voct_to_hz(ctrl: float) -> float:
 //|     """Converts a 1v/octave signal to Hz.
 //|
-//|     60/12 (5.0) corresponds to middle C, 69/12 is concert A."""
+//|     24/12 (2.0) corresponds to middle C, 33/12 (2.75) is concert A."""
 //|
 
-STATIC mp_obj_t onevo_to_hz(mp_obj_t arg) {
-    mp_float_t note = mp_arg_validate_obj_float_range(arg, 0, 11, MP_QSTR_ctrl);
-    return mp_obj_new_float(common_hal_synthio_onevo_to_hz_float(note));
+STATIC mp_obj_t voct_to_hz(mp_obj_t arg) {
+    mp_float_t note = mp_arg_validate_obj_float_range(arg, -11, 11, MP_QSTR_ctrl);
+    return mp_obj_new_float(common_hal_synthio_voct_to_hz_float(note));
 }
-MP_DEFINE_CONST_FUN_OBJ_1(synthio_onevo_to_hz_obj, onevo_to_hz);
+MP_DEFINE_CONST_FUN_OBJ_1(synthio_voct_to_hz_obj, voct_to_hz);
 
 #if CIRCUITPY_AUDIOCORE_DEBUG
 STATIC mp_obj_t synthio_lfo_tick(size_t n, const mp_obj_t *args) {
@@ -319,7 +319,7 @@ STATIC const mp_rom_map_elem_t synthio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_from_file), MP_ROM_PTR(&synthio_from_file_obj) },
     { MP_ROM_QSTR(MP_QSTR_Envelope), MP_ROM_PTR(&synthio_envelope_type_obj) },
     { MP_ROM_QSTR(MP_QSTR_midi_to_hz), MP_ROM_PTR(&synthio_midi_to_hz_obj) },
-    { MP_ROM_QSTR(MP_QSTR_onevo_to_hz), MP_ROM_PTR(&synthio_midi_to_hz_obj) },
+    { MP_ROM_QSTR(MP_QSTR_voct_to_hz), MP_ROM_PTR(&synthio_voct_to_hz_obj) },
     #if CIRCUITPY_AUDIOCORE_DEBUG
     { MP_ROM_QSTR(MP_QSTR_lfo_tick), MP_ROM_PTR(&synthio_lfo_tick_obj) },
     #endif

--- a/shared-bindings/synthio/__init__.h
+++ b/shared-bindings/synthio/__init__.h
@@ -41,4 +41,4 @@ extern const mp_obj_namedtuple_type_t synthio_envelope_type_obj;
 void synthio_synth_envelope_set(synthio_synth_t *synth, mp_obj_t envelope_obj);
 mp_obj_t synthio_synth_envelope_get(synthio_synth_t *synth);
 mp_float_t common_hal_synthio_midi_to_hz_float(mp_float_t note);
-mp_float_t common_hal_synthio_onevo_to_hz_float(mp_float_t note);
+mp_float_t common_hal_synthio_voct_to_hz_float(mp_float_t note);

--- a/shared-module/synthio/Synthesizer.c
+++ b/shared-module/synthio/Synthesizer.c
@@ -37,7 +37,7 @@ void common_hal_synthio_synthesizer_construct(synthio_synthesizer_obj_t *self,
     mp_obj_t envelope_obj) {
 
     synthio_synth_init(&self->synth, sample_rate, channel_count, waveform_obj, filter_obj, envelope_obj);
-    self->lfos = mp_obj_new_list(0, NULL);
+    self->blocks = mp_obj_new_list(0, NULL);
 }
 
 void common_hal_synthio_synthesizer_deinit(synthio_synthesizer_obj_t *self) {
@@ -75,7 +75,7 @@ audioio_get_buffer_result_t synthio_synthesizer_get_buffer(synthio_synthesizer_o
 
     // free-running LFOs
     mp_obj_iter_buf_t iter_buf;
-    mp_obj_t iterable = mp_getiter(self->lfos, &iter_buf);
+    mp_obj_t iterable = mp_getiter(self->blocks, &iter_buf);
     mp_obj_t item;
     while ((item = mp_iternext(iterable)) != MP_OBJ_STOP_ITERATION) {
         if (!synthio_obj_is_block(item)) {
@@ -185,6 +185,6 @@ mp_obj_t common_hal_synthio_synthesizer_get_pressed_notes(synthio_synthesizer_ob
     return MP_OBJ_FROM_PTR(result);
 }
 
-mp_obj_t common_hal_synthio_synthesizer_get_lfos(synthio_synthesizer_obj_t *self) {
-    return self->lfos;
+mp_obj_t common_hal_synthio_synthesizer_get_blocks(synthio_synthesizer_obj_t *self) {
+    return self->blocks;
 }

--- a/shared-module/synthio/Synthesizer.h
+++ b/shared-module/synthio/Synthesizer.h
@@ -34,7 +34,7 @@
 typedef struct {
     mp_obj_base_t base;
     synthio_synth_t synth;
-    mp_obj_t lfos;
+    mp_obj_t blocks;
 } synthio_synthesizer_obj_t;
 
 

--- a/shared-module/synthio/__init__.c
+++ b/shared-module/synthio/__init__.c
@@ -46,11 +46,11 @@ STATIC int64_t round_float_to_int64(mp_float_t f) {
 }
 
 mp_float_t common_hal_synthio_midi_to_hz_float(mp_float_t arg) {
-    return common_hal_synthio_onevo_to_hz_float(arg / 12.);
+    return common_hal_synthio_voct_to_hz_float(arg / 12. - 3);
 }
 
-mp_float_t common_hal_synthio_onevo_to_hz_float(mp_float_t octave) {
-    return notes[0] * MICROPY_FLOAT_C_FUN(pow)(2., octave - 10);
+mp_float_t common_hal_synthio_voct_to_hz_float(mp_float_t octave) {
+    return notes[0] * MICROPY_FLOAT_C_FUN(pow)(2., octave - 7);
 }
 
 STATIC int16_t convert_time_to_rate(uint32_t sample_rate, mp_obj_t time_in, int16_t difference) {


### PR DESCRIPTION
Thanks @todbot!

 * Incompatible change: `Synthesizer.blocks` replaces `Synthesizer.lfos`; the functionality is unchanged
 * Incompatible change: `voct_to_hz` added, replaces `onveo_to_hz` (which was totally incorrect in its implementation).
 * Docs: correctly show `filter` in the Synthesizer constructor
 * Docs: correctly show the type of `Note.frequency` as `float`.