### PR TITLE
Additional cast through void*

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -544,7 +544,7 @@ STATIC mp_obj_t uctypes_struct_subscr(mp_obj_t base_in, mp_obj_t index_in, mp_ob
             }
 
         } else if (agg_type == PTR) {
-            byte *p = *(void **)self->addr;
+            byte *p = *(void **)(void *)self->addr;
             if (mp_obj_is_small_int(t->items[1])) {
                 uint val_type = GET_TYPE(MP_OBJ_SMALL_INT_VALUE(t->items[1]), VAL_TYPE_BITS);
                 return get_aligned(val_type, p, index);
@@ -574,7 +574,7 @@ STATIC mp_obj_t uctypes_struct_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
                 mp_int_t offset = MP_OBJ_SMALL_INT_VALUE(t->items[0]);
                 uint agg_type = GET_TYPE(offset, AGG_TYPE_BITS);
                 if (agg_type == PTR) {
-                    byte *p = *(void **)self->addr;
+                    byte *p = *(void **)(void *)self->addr;
                     return mp_obj_new_int((mp_int_t)(uintptr_t)p);
                 }
             }


### PR DESCRIPTION
Tell the compiler we know what we are doing, and that the bytes are correctly aligned, to avoid compiler warning:

```
error: cast increases required alignment of target type
```