### PR TITLE
Makerdiary M60 keyboard: allow run on battery

### DIFF
--- a/ports/nrf/boards/makerdiary_m60_keyboard/board.c
+++ b/ports/nrf/boards/makerdiary_m60_keyboard/board.c
@@ -25,6 +25,39 @@
  */
 
 #include "supervisor/board.h"
+#include "supervisor/shared/board.h"
+#include "mpconfigboard.h"
 
+static void power_on(void) {
+    // turn on internal battery
+    nrf_gpio_cfg(POWER_SWITCH_PIN->number,
+        NRF_GPIO_PIN_DIR_OUTPUT,
+        NRF_GPIO_PIN_INPUT_DISCONNECT,
+        NRF_GPIO_PIN_NOPULL,
+        NRF_GPIO_PIN_S0S1,
+        NRF_GPIO_PIN_NOSENSE);
+    nrf_gpio_pin_write(POWER_SWITCH_PIN->number, true);
+}
+
+static void preserve_and_release_battery_pin(void) {
+    // Preserve the battery state. The battery is enabled by default in factory bootloader.
+    // Reset claimed_pins so user can control pin's state in the vm.
+    // The code below doesn't actually reset the pin's state, but only set the flags.
+    reset_pin_number(POWER_SWITCH_PIN->number);       // clear claimed_pins and never_reset_pins
+    never_reset_pin_number(POWER_SWITCH_PIN->number); // set never_reset_pins
+}
+
+void board_init(void) {
+    // As of cpy 8.1.0, board_init() runs after reset_ports() on first run. That means
+    // never_reset_pins won't be set at boot, the battery pin is reset, causing system
+    // shutdown.
+    // So if we need to run on battery, we must enable the battery here.
+    power_on();
+    preserve_and_release_battery_pin();
+}
+
+void reset_board(void) {
+    preserve_and_release_battery_pin();
+}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/nrf/boards/makerdiary_m60_keyboard/mpconfigboard.h
+++ b/ports/nrf/boards/makerdiary_m60_keyboard/mpconfigboard.h
@@ -49,3 +49,5 @@
 
 #define DEFAULT_I2C_BUS_SCL         (&pin_P1_06)
 #define DEFAULT_I2C_BUS_SDA         (&pin_P1_05)
+
+#define POWER_SWITCH_PIN            (&pin_P0_28)

--- a/ports/nrf/boards/makerdiary_m60_keyboard/pins.c
+++ b/ports/nrf/boards/makerdiary_m60_keyboard/pins.c
@@ -39,6 +39,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_CHARGING), MP_ROM_PTR(&pin_P0_03) },
     { MP_ROM_QSTR(MP_QSTR_VOLTAGE_MONITOR), MP_ROM_PTR(&pin_P0_02) },
     { MP_ROM_QSTR(MP_QSTR_BATTERY), MP_ROM_PTR(&pin_P0_02) },
+    { MP_ROM_QSTR(MP_QSTR_BATTERY_ENABLE), MP_ROM_PTR(&pin_P0_28) },
 
     { MP_ROM_QSTR(MP_QSTR_RGB_POWER), MP_ROM_PTR(&pin_P1_04) },
 


### PR DESCRIPTION
Original board support doesn't allow the device to run on battery. But for most M60 keyboard users, they use the keyboard wirelessly. This PR makes it possible to run latest CircuitPython on M60 keyboard without first being connected to a USB power source.

This also expose the battery control pin as BATTERY_ENABLE, so users can fully power off the keyboard just by initialize this pin.