### PR TITLE
don't consider refresh areas for hidden groups or tilegrids

### DIFF
--- a/shared-module/displayio/Group.c
+++ b/shared-module/displayio/Group.c
@@ -438,32 +438,36 @@ void displayio_group_finish_refresh(displayio_group_t *self) {
 }
 
 displayio_area_t *displayio_group_get_refresh_areas(displayio_group_t *self, displayio_area_t *tail) {
-    if (self->item_removed) {
-        self->dirty_area.next = tail;
-        tail = &self->dirty_area;
-    }
+    if (! self->hidden){
+        if (self->item_removed) {
+            self->dirty_area.next = tail;
+            tail = &self->dirty_area;
+        }
 
-    for (int32_t i = self->members->len - 1; i >= 0; i--) {
-        mp_obj_t layer;
-        #if CIRCUITPY_VECTORIO
-        const vectorio_draw_protocol_t *draw_protocol = mp_proto_get(MP_QSTR_protocol_draw, self->members->items[i]);
-        if (draw_protocol != NULL) {
-            layer = draw_protocol->draw_get_protocol_self(self->members->items[i]);
-            tail = draw_protocol->draw_protocol_impl->draw_get_refresh_areas(layer, tail);
-            continue;
-        }
-        #endif
-        layer = mp_obj_cast_to_native_base(
-            self->members->items[i], &displayio_tilegrid_type);
-        if (layer != MP_OBJ_NULL) {
-            tail = displayio_tilegrid_get_refresh_areas(layer, tail);
-            continue;
-        }
-        layer = mp_obj_cast_to_native_base(
-            self->members->items[i], &displayio_group_type);
-        if (layer != MP_OBJ_NULL) {
-            tail = displayio_group_get_refresh_areas(layer, tail);
-            continue;
+        for (int32_t i = self->members->len - 1; i >= 0; i--) {
+            mp_obj_t layer;
+            #if CIRCUITPY_VECTORIO
+            const vectorio_draw_protocol_t *draw_protocol = mp_proto_get(MP_QSTR_protocol_draw, self->members->items[i]);
+            if (draw_protocol != NULL) {
+                layer = draw_protocol->draw_get_protocol_self(self->members->items[i]);
+                tail = draw_protocol->draw_protocol_impl->draw_get_refresh_areas(layer, tail);
+                continue;
+            }
+            #endif
+            layer = mp_obj_cast_to_native_base(
+                    self->members->items[i], &displayio_tilegrid_type);
+            if (layer != MP_OBJ_NULL) {
+                if (!common_hal_displayio_tilegrid_get_hidden(layer)){
+                    tail = displayio_tilegrid_get_refresh_areas(layer, tail);
+                }
+                continue;
+            }
+            layer = mp_obj_cast_to_native_base(
+                    self->members->items[i], &displayio_group_type);
+            if (layer != MP_OBJ_NULL) {
+                tail = displayio_group_get_refresh_areas(layer, tail);
+                continue;
+            }
         }
     }
 


### PR DESCRIPTION
resolves: #8013 

The diff shown on the changes pages is cut into a way that makes it a bit harder to follow at least for me.

The are two main changes.

1. wrap everything except the return in here: https://github.com/adafruit/circuitpython/blob/bf67ea36405f3285bacc564e17076263ba1a5c6a/shared-module/displayio/Group.c#L441-L468 with an if statement that makes it skip looking into the members of a group that is hidden. This covers a case that wasn't mentioned in the issue which is when all of the Lines (or other hidden elements) would be added together into a Group and that Group be hidden instead of the members individually. 


2. wrap this statement: https://github.com/adafruit/circuitpython/blob/bf67ea36405f3285bacc564e17076263ba1a5c6a/shared-module/displayio/Group.c#L459 with an if statement that makes it skip calling `displayio_tilegrid_get_refresh_areas()` of hidden tilegrids. This covers the specific case in the issue where the elements that are hidden are all directly inside of of some Group together with other elements that aren't hidden.


All of my testing was performed on a Feather ESP32-S2 TFT. I was able to get much faster refresh times with this build compared to currently released versions with this reprocer script modelled after the code in the issue:

```
from adafruit_display_shapes.rect import Rect
from adafruit_display_shapes.line import Line
import board
import time
from displayio import Group

display = board.DISPLAY
display.auto_refresh = False

main_group = Group()

line_group = Group()

for i in range(70):
    r = Rect(x=i*3, y=0, width=3, height=display.height//2, fill=0xFFFFFF)
    main_group.append(r)

main_group.append(line_group)

for i in range(150):
    l = Line(x0=i, y0=0, x1=100+i, y1=100, color=0xFFFFFF)
    if i % 2 == 0:
        l.hidden = True

    #l.hidden = True
    line_group.append(l)
    # main_group.append(l)

    #r = Rect(x=0, y=0, width=100, height=100, fill=0xFFFFFF)
    #r._palette.make_transparent(0)
    #r.hidden = True
    #line_group.append(r)

# line_group.hidden = True
display.show(main_group)

color = 0xffffff
while True:

    for display_obj in main_group:
        if hasattr(display_obj, "fill"):
            display_obj.fill = color
        #display.refresh()

    print(time.monotonic())
    display.refresh()

    # Colour shift for the next pass...
    color += 1600000

    # ... but don't exceed what's possible
    if color > 0xFFFFFF:
        color -= 0xFFFFFF

```

I never did get as extreme slow times as what was reported in the issue, but I didn't test on the exact same ports and my display is smaller so I think these may account for the differences. I did see that the rendering was quite noticeably slower with hidden lines vs. visible ones and with these changes the refreshing with hidden lines is considerably faster now on my test device.