### PR TITLE
fix fetch-submodules.sh for older git

### DIFF
--- a/tools/fetch-submodules.sh
+++ b/tools/fetch-submodules.sh
@@ -16,9 +16,8 @@ done
 echo ${abs_submodules}
 
 # Fetch submodules as partial clones if possible. If that fails due to an older version of git,
-# do a shallow init with no fetch and then check out the proper commit.
+# do a shallow init and fetch tags.
 git submodule update --init --filter=blob:none ${abs_submodules} || \
-    git submodule update --init --no-fetch --depth 1 ${abs_submodules} || \
-    git submodule foreach $* \
-        'git fetch --tags --depth 1 origin $$sha1 && git checkout -q $$sha1' || \
+    git submodule update --init --depth 1 ${abs_submodules} && \
+    git submodule foreach 'git fetch --tags --depth 1' || \
     echo "ERROR: fetch-submodules.sh FAILED"


### PR DESCRIPTION
#8070 did not work properly with older versions of git that could not do partial clones (before git 2.36). I tested this with git 2.30.1 on several ports, starting with no submodules each time. I was able to simplify the older shallow-depth commands a bit.

Thanks @jposada202020 who found the initial problem.

If you has an older version of git (before 2.36) and are interested in testing, you could try this. The simplest way is probably just replacing `tools/fetch-submodules.sh` from `main` with the new version here.