### PR TITLE
fix `invalid pin` error when create `busio.SPI` on MIMXRT10XX port

### DIFF
--- a/ports/mimxrt10xx/common-hal/busio/SPI.c
+++ b/ports/mimxrt10xx/common-hal/busio/SPI.c
@@ -109,7 +109,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
         // if both MOSI and MISO exist, loop search normally
         if ((mosi != NULL) && (miso != NULL)) {
             for (uint j = 0; j < mosi_count; j++) {
-                if ((mcu_spi_sdo_list[i].pin != mosi)
+                if ((mcu_spi_sdo_list[j].pin != mosi)
                     || (mcu_spi_sck_list[i].bank_idx != mcu_spi_sdo_list[j].bank_idx)) {
                     continue;
                 }


### PR DESCRIPTION
on specific SCK/MOSI/MISO pins, the `common_hal_busio_spi_construct` method always skips some miso pins which will lead to a `invalid pin` exception when SPI initialized

So the problem is on second loop of searching for mosi pins:

```

for (uint i = 0; i < sck_count; i++) {
        if (mcu_spi_sck_list[i].pin != clock) {
            continue;
        }
        // if both MOSI and MISO exist, loop search normally
        if ((mosi != NULL) && (miso != NULL)) {
            for (uint j = 0; j < mosi_count; j++) {
                if ((mcu_spi_sdo_list[i].pin != mosi) // <----- problem here, should not skip some mosi pins when searching
                    || (mcu_spi_sck_list[i].bank_idx != mcu_spi_sdo_list[j].bank_idx)) {
                    continue;
                }
                for (uint k = 0; k < miso_count; k++) {
                    if ((mcu_spi_sdi_list[k].pin != miso) // everything needs the same index
                        || (mcu_spi_sck_list[i].bank_idx != mcu_spi_sdi_list[k].bank_idx)) {
                        continue;
                    }

```