### PR TITLE
validate wifi Access Point channel

### DIFF
--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -374,6 +374,8 @@ STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_
         }
     }
 
+    mp_int_t channel = mp_arg_validate_int_range(args[ARG_channel].u_int, 1, 13, MP_QSTR_channel);
+
     if (authmodes == AUTHMODE_OPEN && password.len > 0) {
         mp_raise_ValueError(translate("AuthMode.OPEN is not used with password"));
     }
@@ -385,7 +387,7 @@ STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_
         }
     }
 
-    common_hal_wifi_radio_start_ap(self, ssid.buf, ssid.len, password.buf, password.len, args[ARG_channel].u_int, authmodes, args[ARG_max_connections].u_int);
+    common_hal_wifi_radio_start_ap(self, ssid.buf, ssid.len, password.buf, password.len, channel, authmodes, args[ARG_max_connections].u_int);
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(wifi_radio_start_ap_obj, 1, wifi_radio_start_ap);


### PR DESCRIPTION
Before this PR, a call to start an AP with an invalid channel (not 1-13) would succeed, but the channel would be set to 1, and on `espressif`, the supplied SSID would be superceded by the default naming, `ESP_XXYYZZ`.

This PR borrows from the `Monitor` code and adds the check that the supplied channel is 1-13:
```py
>>> wifi.radio.start_ap(ssid="ssid", password="password", authmode=[wifi.AuthMode.WPA2, wifi.AuthMode.PSK], channel=14)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: channel must be 1-13
```