### PR TITLE
Reset UART on deinit, reduces power consumption on nRF

### DIFF
--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -266,7 +266,7 @@ bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {
 }
 
 void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
-    volatile uint32_t *power_cycle = (void*)(self->uarte->p_reg) + 0xFFC;
+    volatile uint32_t *power_cycle = (void *)(self->uarte->p_reg) + 0xFFC;
     if (!common_hal_busio_uart_deinited(self)) {
         nrfx_uarte_rx_abort(self->uarte);
         nrfx_uarte_tx_abort(self->uarte);

--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -266,8 +266,15 @@ bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {
 }
 
 void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
+    volatile uint32_t *power_cycle = (void*)(self->uarte->p_reg) + 0xFFC;
     if (!common_hal_busio_uart_deinited(self)) {
+        nrfx_uarte_rx_abort(self->uarte);
+        nrfx_uarte_tx_abort(self->uarte);
         nrfx_uarte_uninit(self->uarte);
+        // power cycle the peripheral as per https://devzone.nordicsemi.com/f/nordic-q-a/26030/how-to-reach-nrf52840-uarte-current-supply-specification/102605#102605
+        *power_cycle = 0;
+        *power_cycle;
+        *power_cycle = 1;
         reset_pin_number(self->tx_pin_number);
         reset_pin_number(self->rx_pin_number);
         reset_pin_number(self->rts_pin_number);


### PR DESCRIPTION
light sleep currently uses about 3-90 uA on nRF (depending on board).  However, if you create a ``busio.UART`` and then ``deinit`` it, the light sleep uses about 1 mA.

This change fixes that by as per [this post](https://devzone.nordicsemi.com/f/nordic-q-a/26030/how-to-reach-nrf52840-uarte-current-supply-specification/102605#102605).

It works by using an undocumented register to power cycle the UART peripheral.