### PR TITLE
Fix for #8093

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -114,6 +114,7 @@ SRC_NRFX = $(addprefix nrfx/,\
 	drivers/src/nrfx_spim.c \
 	drivers/src/nrfx_timer.c \
 	drivers/src/nrfx_twim.c \
+	drivers/src/nrfx_twi_twim.c \
 	drivers/src/nrfx_uarte.c \
 	drivers/src/nrfx_gpiote.c \
 	drivers/src/nrfx_rtc.c \

--- a/ports/nrf/common-hal/busio/I2C.c
+++ b/ports/nrf/common-hal/busio/I2C.c
@@ -79,13 +79,6 @@ void common_hal_busio_i2c_never_reset(busio_i2c_obj_t *self) {
     }
 }
 
-#define TWI_TWIM_PIN_CONFIGURE(_pin) nrf_gpio_cfg((_pin),                     \
-                                                  NRF_GPIO_PIN_DIR_OUTPUT,    \
-                                                  NRF_GPIO_PIN_INPUT_CONNECT, \
-                                                  NRF_GPIO_PIN_PULLUP,        \
-                                                  NRF_GPIO_PIN_S0D1,          \
-                                                  NRF_GPIO_PIN_NOSENSE)
-
 static nrfx_err_t _safe_twim_enable(busio_i2c_obj_t *self) {
     // check to see if bus is in sensible state before enabling twim
     nrfx_err_t recover_result;


### PR DESCRIPTION
This adds a check to make sure that SDA and SCL are in a sane condition before starting any I2C operation. If they are not it tries to rectify it, and then returns an error code if unable to do so.