### PR TITLE
fix typos: "CTX mode" -> "CTR mode" in aesio

### DIFF
--- a/shared-bindings/aesio/aes.c
+++ b/shared-bindings/aesio/aes.c
@@ -170,7 +170,7 @@ STATIC void validate_length(aesio_aes_obj_t *self, size_t src_length,
 //|
 //|         For ECB mode, the buffers must be 16 bytes long.  For CBC mode, the
 //|         buffers must be a multiple of 16 bytes, and must be equal length.  For
-//|         CTX mode, there are no restrictions."""
+//|         CTR mode, there are no restrictions."""
 //|         ...
 STATIC mp_obj_t aesio_aes_encrypt_into(mp_obj_t self_in, mp_obj_t src, mp_obj_t dest) {
     aesio_aes_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -192,7 +192,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(aesio_aes_encrypt_into_obj, aesio_aes_encrypt_i
 //|         """Decrypt the buffer from ``src`` into ``dest``.
 //|         For ECB mode, the buffers must be 16 bytes long.  For CBC mode, the
 //|         buffers must be a multiple of 16 bytes, and must be equal length.  For
-//|         CTX mode, there are no restrictions."""
+//|         CTR mode, there are no restrictions."""
 //|         ...
 //|
 STATIC mp_obj_t aesio_aes_decrypt_into(mp_obj_t self_in, mp_obj_t src, mp_obj_t dest) {


### PR DESCRIPTION
CTR mode is mistakenly called CTX mode in a couple of places in the documentation of `aesio`. Noticed by `@Fridgeman` in discord. 