### PR TITLE
Improve OnDiskGif doc; check image width

### DIFF
--- a/shared-bindings/gifio/OnDiskGif.c
+++ b/shared-bindings/gifio/OnDiskGif.c
@@ -114,6 +114,12 @@
 //|         `displayio` expects little-endian, so the example above uses `Colorspace.RGB565_SWAPPED`.
 //|
 //|         :param file file: The name of the GIF file.
+//|
+//|         If the image is too large it will be cropped at the bottom and right when displayed.
+//|
+//|         **Limitations**: The image width is limited to 320 pixels at present. `ValueError`
+//|         will be raised if the image is too wide. The height
+//|         is not limited but images that are too large will cause a memory exception.
 //|         """
 //|         ...
 STATIC mp_obj_t gifio_ondiskgif_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/shared-module/gifio/OnDiskGif.c
+++ b/shared-module/gifio/OnDiskGif.c
@@ -169,7 +169,14 @@ void common_hal_gifio_ondiskgif_construct(gifio_ondiskgif_t *self, pyb_file_obj_
 
     int result = GIF_init(&self->gif);
     if (result != 1) {
-        mp_arg_error_invalid(MP_QSTR_file);
+        switch (self->gif.iError) {
+            case GIF_TOO_WIDE:
+                mp_raise_ValueError_varg(translate("%q must be <= %d"), MP_QSTR_width, MAX_WIDTH);
+                break;
+            default:
+                mp_arg_error_invalid(MP_QSTR_file);
+                break;
+        }
     }
 
     int bpp = 16;


### PR DESCRIPTION
Fixes #7685.

- Expcitly check error code from gif animation library for image too wide.
- Add more info to `OnDiskGif` doc.