### PR TITLE
improve start_ap() doc; make "authmode" use consistent internally

### DIFF
--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -206,22 +206,22 @@ void common_hal_wifi_radio_stop_station(wifi_radio_obj_t *self) {
     set_mode_station(self, false);
 }
 
-void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, uint32_t authmodes, uint8_t max_connections) {
+void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, uint32_t authmode, uint8_t max_connections) {
     set_mode_ap(self, true);
 
-    uint8_t authmode = 0;
-    switch (authmodes) {
+    uint8_t esp_authmode = 0;
+    switch (authmode) {
         case AUTHMODE_OPEN:
-            authmode = WIFI_AUTH_OPEN;
+            esp_authmode = WIFI_AUTH_OPEN;
             break;
         case AUTHMODE_WPA | AUTHMODE_PSK:
-            authmode = WIFI_AUTH_WPA_PSK;
+            esp_authmode = WIFI_AUTH_WPA_PSK;
             break;
         case AUTHMODE_WPA2 | AUTHMODE_PSK:
-            authmode = WIFI_AUTH_WPA2_PSK;
+            esp_authmode = WIFI_AUTH_WPA2_PSK;
             break;
         case AUTHMODE_WPA | AUTHMODE_WPA2 | AUTHMODE_PSK:
-            authmode = WIFI_AUTH_WPA_WPA2_PSK;
+            esp_authmode = WIFI_AUTH_WPA_WPA2_PSK;
             break;
         default:
             mp_arg_error_invalid(MP_QSTR_authmode);
@@ -234,7 +234,7 @@ void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_
     memcpy(&config->ap.password, password, password_len);
     config->ap.password[password_len] = 0;
     config->ap.channel = channel;
-    config->ap.authmode = authmode;
+    config->ap.authmode = esp_authmode;
 
     mp_arg_validate_int_range(max_connections, 0, 10, MP_QSTR_max_connections);
 

--- a/ports/raspberrypi/common-hal/wifi/Radio.c
+++ b/ports/raspberrypi/common-hal/wifi/Radio.c
@@ -175,7 +175,7 @@ void common_hal_wifi_radio_stop_station(wifi_radio_obj_t *self) {
     bindings_cyw43_wifi_enforce_pm();
 }
 
-void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, uint32_t authmodes, uint8_t max_connections) {
+void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, uint32_t authmode, uint8_t max_connections) {
     if (!common_hal_wifi_radio_get_enabled(self)) {
         mp_raise_RuntimeError(translate("Wifi is not enabled"));
     }

--- a/shared-bindings/wifi/Radio.h
+++ b/shared-bindings/wifi/Radio.h
@@ -93,7 +93,7 @@ extern void common_hal_wifi_radio_stop_scanning_networks(wifi_radio_obj_t *self)
 extern void common_hal_wifi_radio_start_station(wifi_radio_obj_t *self);
 extern void common_hal_wifi_radio_stop_station(wifi_radio_obj_t *self);
 
-extern void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, uint32_t authmodes, uint8_t max_connections);
+extern void common_hal_wifi_radio_start_ap(wifi_radio_obj_t *self, uint8_t *ssid, size_t ssid_len, uint8_t *password, size_t password_len, uint8_t channel, uint32_t authmode, uint8_t max_connections);
 extern void common_hal_wifi_radio_stop_ap(wifi_radio_obj_t *self);
 extern bool common_hal_wifi_radio_get_ap_active(wifi_radio_obj_t *self);
 


### PR DESCRIPTION
- Fixes #7680.

- Documentation corrections and improvement.
- Use `authmode` instead of `authmodes` internally. Originally I thought I would rename the `start_ap()` keyword argfrom `authmode` to `authmodes`. But the plural usage is not consistent with the naming used internally in Espressif and Pico W, and elsewhere. An "authmode" can be a combination like WPA/WPA2/PSK.

EDIT: forgot to say that I did test this on ESP32-S2.