### PR TITLE
Revert "nrf: prevent I2C hangs"

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -114,7 +114,6 @@ SRC_NRFX = $(addprefix nrfx/,\
 	drivers/src/nrfx_spim.c \
 	drivers/src/nrfx_timer.c \
 	drivers/src/nrfx_twim.c \
-	drivers/src/nrfx_twi_twim.c \
 	drivers/src/nrfx_uarte.c \
 	drivers/src/nrfx_gpiote.c \
 	drivers/src/nrfx_rtc.c \

--- a/ports/nrf/common-hal/busio/I2C.c
+++ b/ports/nrf/common-hal/busio/I2C.c
@@ -79,59 +79,20 @@ void common_hal_busio_i2c_never_reset(busio_i2c_obj_t *self) {
     }
 }
 
-static bool _bus_is_sane(uint32_t scl_pin, uint32_t sda_pin) {
-    #if CIRCUITPY_REQUIRE_I2C_PULLUPS
-    nrf_gpio_cfg_input(scl_pin, NRF_GPIO_PIN_PULLDOWN);
-    nrf_gpio_cfg_input(sda_pin, NRF_GPIO_PIN_PULLDOWN);
-
-    common_hal_mcu_delay_us(10);
-
-    nrf_gpio_cfg_input(scl_pin, NRF_GPIO_PIN_NOPULL);
-    nrf_gpio_cfg_input(sda_pin, NRF_GPIO_PIN_NOPULL);
-
-    // We must pull up within 3us to achieve 400khz.
-    common_hal_mcu_delay_us(3);
-    if (!nrf_gpio_pin_read(sda_pin) || !nrf_gpio_pin_read(scl_pin)) {
-        return false;
-    } else {
-        return true;
-    }
-    #else
-    return true;
-    #endif
-}
-
-static nrfx_err_t _safe_twim_enable(busio_i2c_obj_t *self) {
-    // check to see if bus is in sensible state before enabling twim
-    nrfx_err_t recover_result;
-
-    if (!_bus_is_sane(self->scl_pin_number, self->sda_pin_number)) {
-        // bus not in a sane state - try to recover
-        recover_result = nrfx_twim_bus_recover(self->scl_pin_number, self->sda_pin_number);
-        if (NRFX_SUCCESS != recover_result) {
-            // return error message if unable to recover the bus
-            return recover_result;
-        }
-    }
-
-    nrfx_twim_enable(&self->twim_peripheral->twim);
-    return NRFX_SUCCESS;
-}
-
 static uint8_t twi_error_to_mp(const nrfx_err_t err) {
     switch (err) {
         case NRFX_ERROR_DRV_TWI_ERR_ANACK:
             return MP_ENODEV;
         case NRFX_ERROR_BUSY:
             return MP_EBUSY;
-        case NRFX_SUCCESS:
-            return 0;
         case NRFX_ERROR_DRV_TWI_ERR_DNACK:
         case NRFX_ERROR_INVALID_ADDR:
-        case NRFX_ERROR_INTERNAL:
-        default:
             return MP_EIO;
+        default:
+            break;
     }
+
+    return 0;
 }
 
 void common_hal_busio_i2c_construct(busio_i2c_obj_t *self, const mcu_pin_obj_t *scl, const mcu_pin_obj_t *sda, uint32_t frequency, uint32_t timeout) {
@@ -153,12 +114,25 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self, const mcu_pin_obj_t *
         mp_raise_ValueError(translate("All I2C peripherals are in use"));
     }
 
-    // check bus is in a sane state
-    if (!_bus_is_sane(scl->number,sda->number)) {
+    #if CIRCUITPY_REQUIRE_I2C_PULLUPS
+    // Test that the pins are in a high state. (Hopefully indicating they are pulled up.)
+    nrf_gpio_cfg_input(scl->number, NRF_GPIO_PIN_PULLDOWN);
+    nrf_gpio_cfg_input(sda->number, NRF_GPIO_PIN_PULLDOWN);
+
+    common_hal_mcu_delay_us(10);
+
+    nrf_gpio_cfg_input(scl->number, NRF_GPIO_PIN_NOPULL);
+    nrf_gpio_cfg_input(sda->number, NRF_GPIO_PIN_NOPULL);
+
+    // We must pull up within 3us to achieve 400khz.
+    common_hal_mcu_delay_us(3);
+
+    if (!nrf_gpio_pin_read(sda->number) || !nrf_gpio_pin_read(scl->number)) {
         reset_pin_number(sda->number);
         reset_pin_number(scl->number);
         mp_raise_RuntimeError(translate("No pull up found on SDA or SCL; check your wiring"));
     }
+    #endif
 
     nrfx_twim_config_t config = NRFX_TWIM_DEFAULT_CONFIG(scl->number, sda->number);
 
@@ -214,9 +188,7 @@ bool common_hal_busio_i2c_probe(busio_i2c_obj_t *self, uint8_t addr) {
     NRF_TWIM_Type *reg = self->twim_peripheral->twim.p_twim;
     bool found = true;
 
-    if (NRFX_SUCCESS != _safe_twim_enable(self)) {
-        return false;
-    }
+    nrfx_twim_enable(&self->twim_peripheral->twim);
 
     nrf_twim_address_set(reg, addr);
     nrf_twim_tx_buffer_set(reg, NULL, 0);
@@ -274,10 +246,7 @@ STATIC uint8_t _common_hal_busio_i2c_write(busio_i2c_obj_t *self, uint16_t addr,
 
     nrfx_err_t err = NRFX_SUCCESS;
 
-    err = _safe_twim_enable(self);
-    if (NRFX_SUCCESS != err) {
-        return twi_error_to_mp(err);
-    }
+    nrfx_twim_enable(&self->twim_peripheral->twim);
 
     // break into MAX_XFER_LEN transaction
     while (len) {
@@ -309,10 +278,7 @@ uint8_t common_hal_busio_i2c_read(busio_i2c_obj_t *self, uint16_t addr, uint8_t 
 
     nrfx_err_t err = NRFX_SUCCESS;
 
-    err = _safe_twim_enable(self);
-    if (NRFX_SUCCESS != err) {
-        return twi_error_to_mp(err);
-    }
+    nrfx_twim_enable(&self->twim_peripheral->twim);
 
     // break into MAX_XFER_LEN transaction
     while (len) {


### PR DESCRIPTION
Reverts adafruit/circuitpython#8094.

@furbrain: I merged #8094 but have reverted if after considering that it's going to cause a minimum 13 us delay on any I2C transaction. That is quite significant, considering that 100 kHz is 10 us.