### PR TITLE
fix shape.set_boundary()

### DIFF
--- a/shared-bindings/displayio/Shape.c
+++ b/shared-bindings/displayio/Shape.c
@@ -82,8 +82,8 @@ STATIC mp_obj_t displayio_shape_obj_set_boundary(size_t n_args, const mp_obj_t *
     (void)n_args;
     displayio_shape_t *self = MP_OBJ_TO_PTR(args[0]);
     mp_int_t y = mp_arg_validate_type_int(args[1], MP_QSTR_y);
-    mp_int_t start_x = mp_arg_validate_type_int(args[1], MP_QSTR_start_x);
-    mp_int_t end_x = mp_arg_validate_type_int(args[1], MP_QSTR_end_x);
+    mp_int_t start_x = mp_arg_validate_type_int(args[2], MP_QSTR_start_x);
+    mp_int_t end_x = mp_arg_validate_type_int(args[3], MP_QSTR_end_x);
     common_hal_displayio_shape_set_boundary(self, y, start_x, end_x);
 
     return mp_const_none;


### PR DESCRIPTION
resolves: #8113 

Tested successfully on a PyPortal by making a build from the PR branch with the test code posted in the issue.

I found that this is the commit where this was changed from 1,2,3 to 1,1,1: https://github.com/adafruit/circuitpython/commit/267ec1dc4fd1299ce63156a1ba57fb7f903e64b7#diff-045888a0fd2effa9301d468829a4e6c6b0d17137019ad774f57ed0924e897243

This PR essentially reverts the change to indexes from this commit, but keeps the simplified arg validation.