### PR TITLE
fix board.BUTTON on espressif_esp32c3_devkitm_1_n4

### DIFF
--- a/ports/espressif/boards/espressif_esp32c3_devkitm_1_n4/pins.c
+++ b/ports/espressif/boards/espressif_esp32c3_devkitm_1_n4/pins.c
@@ -53,7 +53,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_MTCK), MP_ROM_PTR(&pin_GPIO6) },
     { MP_ROM_QSTR(MP_QSTR_MTDO), MP_ROM_PTR(&pin_GPIO7) },
 
-    { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO2) },
+    { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO9) },
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO8) },
 
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },


### PR DESCRIPTION
Fixes #5918
Checked [the schematics (pdf)](https://dl.espressif.com/dl/schematics/SCH_ESP32-C3-DEVKITM-1_V1_20200915A.pdf), and tested on the board.