### PR TITLE
shared-bindings/zlib: Fix docs for zlib.decompress.

### DIFF
--- a/shared-bindings/zlib/__init__.c
+++ b/shared-bindings/zlib/__init__.c
@@ -48,9 +48,7 @@
 //| (commonly used in zlib library and gzip archiver). Compression is not yet implemented."""
 //|
 
-//| def zlib_decompress(
-//|     data: bytes, wbits: Optional[int] = 0, bufsize: Optional[int] = 0
-//| ) -> bytes:
+//| def decompress(data: bytes, wbits: Optional[int] = 0, bufsize: Optional[int] = 0) -> bytes:
 //|     """Return decompressed *data* as bytes. *wbits* is DEFLATE dictionary window
 //|     size used during compression (8-15, the dictionary size is power of 2 of
 //|     that value). Additionally, if value is positive, *data* is assumed to be


### PR DESCRIPTION
Noticed this while working on the `zlib` module in MicroPython. FYI we're working on adding compression support -- see https://github.com/micropython/micropython/pull/11879 -- and was looking to see if CircuitPython implemented this already.

The docs say the method is called `zlib_decompress` but should be just `decompress`. (See https://docs.circuitpython.org/en/latest/shared-bindings/zlib/index.html )
