### PR TITLE
Extended ShiftRegisterKeys to support multiple data pins with shared clock and latch

### DIFF
--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -84,7 +84,7 @@
 //|         ...
 
 STATIC mp_obj_t keypad_shiftregisterkeys_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-#if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
+    #if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
     keypad_shiftregisterkeys_obj_t *self = m_new_obj(keypad_shiftregisterkeys_obj_t);
     self->base.type = &keypad_shiftregisterkeys_type;
     enum { ARG_clock, ARG_data, ARG_latch, ARG_value_to_latch, ARG_key_count, ARG_value_when_pressed, ARG_interval, ARG_max_events };
@@ -159,9 +159,9 @@ STATIC mp_obj_t keypad_shiftregisterkeys_make_new(const mp_obj_type_t *type, siz
 
     return MP_OBJ_FROM_PTR(self);
 
-#else
+    #else
     mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_ShiftRegisterKeys);
-#endif
+    #endif
 }
 
 #if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
@@ -225,7 +225,7 @@ const mp_obj_type_t keypad_shiftregisterkeys_type = {
     { &mp_type_type },
     .name = MP_QSTR_ShiftRegisterKeys,
     .make_new = keypad_shiftregisterkeys_make_new,
-#if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
+    #if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
     .locals_dict = (mp_obj_t)&keypad_shiftregisterkeys_locals_dict,
-#endif
+    #endif
 };

--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -53,11 +53,11 @@
 //|         Create a `Keys` object that will scan keys attached to a parallel-in serial-out shift register
 //|         like the 74HC165 or CD4021.
 //|         Note that you may chain shift registers to load in as many values as you need.
+//|         Furthermore, you can put multiple shift registers in parallel and share clock and latch.
 //|
 //|         Key number 0 is the first (or more properly, the zero-th) bit read. In the
 //|         74HC165, this bit is labeled ``Q7``. Key number 1 will be the value of ``Q6``, etc.
-//|         When specifying multiple data pins, the key numbers are sequential.
-//|         So with two data Pins in parallel and key_count[0] = 32, the keys of data[1] will start with 32.
+//|         With multiple data pins, key numbers of the next pin are sequentially to the current pin.
 //|
 //|         An `EventQueue` is created when this object is created and is available in the `events` attribute.
 //|

--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -41,10 +41,10 @@
 //|         self,
 //|         *,
 //|         clock: microcontroller.Pin,
-//|         data: microcontroller.Pin,
+//|         data: Union[microcontroller.Pin, List[microcontroller.Pin]],
 //|         latch: microcontroller.Pin,
 //|         value_to_latch: bool = True,
-//|         key_count: int,
+//|         key_count: Union[int, List[int]]
 //|         value_when_pressed: bool,
 //|         interval: float = 0.020,
 //|         max_events: int = 64
@@ -56,13 +56,14 @@
 //|
 //|         Key number 0 is the first (or more properly, the zero-th) bit read. In the
 //|         74HC165, this bit is labeled ``Q7``. Key number 1 will be the value of ``Q6``, etc.
+//|         When specifying multiple data pins, the key numbers are sequential.
+//|         So with two data Pins in parallel and key_count[0] = 32, the keys of data[1] will start with 32.
 //|
 //|         An `EventQueue` is created when this object is created and is available in the `events` attribute.
 //|
 //|         :param microcontroller.Pin clock: The shift register clock pin.
 //|           The shift register should clock on a low-to-high transition.
-//|         :param microcontroller.Pin data: the incoming shift register data pin
-//|         :param Sequence[microcontroller.Pin] data: a list of incoming shift register data pins
+//|         :param Union[microcontroller.Pin, List[microcontroller.Pin]] data: the incoming shift register data pin(s)
 //|         :param microcontroller.Pin latch:
 //|           Pin used to latch parallel data going into the shift register.
 //|         :param bool value_to_latch: Pin state to latch data being read.
@@ -70,8 +71,7 @@
 //|           ``False`` if the data is latched when ``latch`` goes low.
 //|           The default is ``True``, which is how the 74HC165 operates. The CD4021 latch is the opposite.
 //|           Once the data is latched, it will be shifted out by toggling the clock pin.
-//|         :param int key_count: number of data lines to clock in
-//|         :param Sequence[int] key_count: a list of key_counts equal sized to data pins
+//|         :param Union[int, List[int]] key_count: number of data lines to clock in (per data pin)
 //|         :param bool value_when_pressed: ``True`` if the pin reads high when the key is pressed.
 //|           ``False`` if the pin reads low (is grounded) when the key is pressed.
 //|         :param float interval: Scan keys no more often than ``interval`` to allow for debouncing.
@@ -84,7 +84,7 @@
 //|         ...
 
 STATIC mp_obj_t keypad_shiftregisterkeys_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    #if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
+#if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
     keypad_shiftregisterkeys_obj_t *self = m_new_obj(keypad_shiftregisterkeys_obj_t);
     self->base.type = &keypad_shiftregisterkeys_type;
     enum { ARG_clock, ARG_data, ARG_latch, ARG_value_to_latch, ARG_key_count, ARG_value_when_pressed, ARG_interval, ARG_max_events };
@@ -159,9 +159,9 @@ STATIC mp_obj_t keypad_shiftregisterkeys_make_new(const mp_obj_type_t *type, siz
 
     return MP_OBJ_FROM_PTR(self);
 
-    #else
+#else
     mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_ShiftRegisterKeys);
-    #endif
+#endif
 }
 
 #if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
@@ -225,7 +225,7 @@ const mp_obj_type_t keypad_shiftregisterkeys_type = {
     { &mp_type_type },
     .name = MP_QSTR_ShiftRegisterKeys,
     .make_new = keypad_shiftregisterkeys_make_new,
-    #if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
+#if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
     .locals_dict = (mp_obj_t)&keypad_shiftregisterkeys_locals_dict,
-    #endif
+#endif
 };

--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -62,6 +62,7 @@
 //|         :param microcontroller.Pin clock: The shift register clock pin.
 //|           The shift register should clock on a low-to-high transition.
 //|         :param microcontroller.Pin data: the incoming shift register data pin
+//|         :param Sequence[microcontroller.Pin] data: a list of incoming shift register data pins
 //|         :param microcontroller.Pin latch:
 //|           Pin used to latch parallel data going into the shift register.
 //|         :param bool value_to_latch: Pin state to latch data being read.
@@ -70,6 +71,7 @@
 //|           The default is ``True``, which is how the 74HC165 operates. The CD4021 latch is the opposite.
 //|           Once the data is latched, it will be shifted out by toggling the clock pin.
 //|         :param int key_count: number of data lines to clock in
+//|         :param Sequence[int] key_count: a list of key_counts equal sized to data pins
 //|         :param bool value_when_pressed: ``True`` if the pin reads high when the key is pressed.
 //|           ``False`` if the pin reads low (is grounded) when the key is pressed.
 //|         :param float interval: Scan keys no more often than ``interval`` to allow for debouncing.
@@ -91,7 +93,7 @@ STATIC mp_obj_t keypad_shiftregisterkeys_make_new(const mp_obj_type_t *type, siz
         { MP_QSTR_data, MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_latch, MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_value_to_latch, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = true} },
-        { MP_QSTR_key_count, MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_key_count, MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_value_when_pressed, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_BOOL },
         { MP_QSTR_interval, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_max_events, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 64} },
@@ -99,21 +101,64 @@ STATIC mp_obj_t keypad_shiftregisterkeys_make_new(const mp_obj_type_t *type, siz
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
+    size_t num_data_pins;
+
+    if (mp_obj_is_type(args[ARG_data].u_obj, &mcu_pin_type)) {
+        num_data_pins = 1;
+    } else {
+        num_data_pins = (size_t)MP_OBJ_SMALL_INT_VALUE(mp_obj_len(args[ARG_data].u_obj));
+    }
+
+    const mcu_pin_obj_t *data_pins_array[num_data_pins];
+
+    if (mp_obj_is_type(args[ARG_data].u_obj, &mcu_pin_type)) {
+        const mcu_pin_obj_t *datapin = validate_obj_is_free_pin(args[ARG_data].u_obj, MP_QSTR_data);
+        data_pins_array[0] = datapin;
+    } else {
+        for (size_t pin = 0; pin < num_data_pins; pin++) {
+            const mcu_pin_obj_t *datapin =
+                validate_obj_is_free_pin(mp_obj_subscr(args[ARG_data].u_obj, MP_OBJ_NEW_SMALL_INT(pin), MP_OBJ_SENTINEL), MP_QSTR_data);
+            data_pins_array[pin] = datapin;
+        }
+    }
+
+    size_t num_key_counts;
+
+    if (mp_obj_is_int(args[ARG_key_count].u_obj)) {
+        num_key_counts = 1;
+    } else {
+        num_key_counts = (size_t)MP_OBJ_SMALL_INT_VALUE(mp_obj_len(args[ARG_key_count].u_obj));
+    }
+
+    mp_arg_validate_length(num_key_counts, num_data_pins, MP_QSTR_key_count);
+
+    size_t key_count_array[num_key_counts];
+
+    if (mp_obj_is_int(args[ARG_key_count].u_obj)) {
+        const size_t key_count = (size_t)mp_arg_validate_int_min(args[ARG_key_count].u_int, 1, MP_QSTR_key_count);
+        key_count_array[0] = key_count;
+    } else {
+        for (size_t kc = 0; kc < num_key_counts; kc++) {
+            mp_int_t mpint = mp_obj_get_int(mp_obj_subscr(args[ARG_key_count].u_obj, MP_OBJ_NEW_SMALL_INT(kc), MP_OBJ_SENTINEL));
+            const size_t key_count = (size_t)mp_arg_validate_int_min(mpint, 1, MP_QSTR_key_count);
+            key_count_array[kc] = key_count;
+        }
+    }
+
     const mcu_pin_obj_t *clock = validate_obj_is_free_pin(args[ARG_clock].u_obj, MP_QSTR_clock);
-    const mcu_pin_obj_t *data = validate_obj_is_free_pin(args[ARG_data].u_obj, MP_QSTR_data);
     const mcu_pin_obj_t *latch = validate_obj_is_free_pin(args[ARG_latch].u_obj, MP_QSTR_latch);
     const bool value_to_latch = args[ARG_value_to_latch].u_bool;
 
-    const size_t key_count = (size_t)mp_arg_validate_int_min(args[ARG_key_count].u_int, 1, MP_QSTR_key_count);
     const bool value_when_pressed = args[ARG_value_when_pressed].u_bool;
     const mp_float_t interval =
         mp_arg_validate_obj_float_non_negative(args[ARG_interval].u_obj, 0.020f, MP_QSTR_interval);
     const size_t max_events = (size_t)mp_arg_validate_int_min(args[ARG_max_events].u_int, 1, MP_QSTR_max_events);
 
     common_hal_keypad_shiftregisterkeys_construct(
-        self, clock, data, latch, value_to_latch, key_count, value_when_pressed, interval, max_events);
+        self, clock, num_data_pins, data_pins_array, latch, value_to_latch, num_key_counts, key_count_array, value_when_pressed, interval, max_events);
 
     return MP_OBJ_FROM_PTR(self);
+
     #else
     mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_ShiftRegisterKeys);
     #endif

--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -44,7 +44,7 @@
 //|         data: Union[microcontroller.Pin, List[microcontroller.Pin]],
 //|         latch: microcontroller.Pin,
 //|         value_to_latch: bool = True,
-//|         key_count: Union[int, List[int]]
+//|         key_count: Union[int, List[int]],
 //|         value_when_pressed: bool,
 //|         interval: float = 0.020,
 //|         max_events: int = 64

--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -41,10 +41,10 @@
 //|         self,
 //|         *,
 //|         clock: microcontroller.Pin,
-//|         data: Union[microcontroller.Pin, List[microcontroller.Pin]],
+//|         data: Union[microcontroller.Pin, Sequence[microcontroller.Pin]],
 //|         latch: microcontroller.Pin,
 //|         value_to_latch: bool = True,
-//|         key_count: Union[int, List[int]],
+//|         key_count: Union[int, Sequence[int]],
 //|         value_when_pressed: bool,
 //|         interval: float = 0.020,
 //|         max_events: int = 64
@@ -63,7 +63,7 @@
 //|
 //|         :param microcontroller.Pin clock: The shift register clock pin.
 //|           The shift register should clock on a low-to-high transition.
-//|         :param Union[microcontroller.Pin, List[microcontroller.Pin]] data: the incoming shift register data pin(s)
+//|         :param Union[microcontroller.Pin, Sequence[microcontroller.Pin]] data: the incoming shift register data pin(s)
 //|         :param microcontroller.Pin latch:
 //|           Pin used to latch parallel data going into the shift register.
 //|         :param bool value_to_latch: Pin state to latch data being read.
@@ -71,7 +71,7 @@
 //|           ``False`` if the data is latched when ``latch`` goes low.
 //|           The default is ``True``, which is how the 74HC165 operates. The CD4021 latch is the opposite.
 //|           Once the data is latched, it will be shifted out by toggling the clock pin.
-//|         :param Union[int, List[int]] key_count: number of data lines to clock in (per data pin)
+//|         :param Union[int, Sequence[int]] key_count: number of data lines to clock in (per data pin)
 //|         :param bool value_when_pressed: ``True`` if the pin reads high when the key is pressed.
 //|           ``False`` if the pin reads low (is grounded) when the key is pressed.
 //|         :param float interval: Scan keys no more often than ``interval`` to allow for debouncing.
@@ -200,7 +200,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(keypad_shiftregisterkeys___exit___obj
 //|         ...
 
 //|     key_count: int
-//|     """The number of keys that are being scanned. (read-only)
+//|     """The total number of keys that are being scanned. (read-only)
 //|     """
 
 //|     events: EventQueue

--- a/shared-bindings/keypad/ShiftRegisterKeys.h
+++ b/shared-bindings/keypad/ShiftRegisterKeys.h
@@ -32,7 +32,7 @@
 
 extern const mp_obj_type_t keypad_shiftregisterkeys_type;
 
-void common_hal_keypad_shiftregisterkeys_construct(keypad_shiftregisterkeys_obj_t *self, const mcu_pin_obj_t *clock_pin, const mcu_pin_obj_t *data_pin, const mcu_pin_obj_t *latch_pin, bool value_to_latch, size_t key_count, bool value_when_pressed, mp_float_t interval, size_t max_events);
+void common_hal_keypad_shiftregisterkeys_construct(keypad_shiftregisterkeys_obj_t *self, const mcu_pin_obj_t *clock_pin, mp_uint_t num_data_pins, const mcu_pin_obj_t *data_pins[], const mcu_pin_obj_t *latch_pin, bool value_to_latch, size_t num_key_count, size_t key_counts[], bool value_when_pressed, mp_float_t interval, size_t max_events);
 
 void common_hal_keypad_shiftregisterkeys_deinit(keypad_shiftregisterkeys_obj_t *self);
 

--- a/shared-module/keypad/ShiftRegisterKeys.c
+++ b/shared-module/keypad/ShiftRegisterKeys.c
@@ -70,7 +70,7 @@ void common_hal_keypad_shiftregisterkeys_construct(keypad_shiftregisterkeys_obj_
     }
 
     // Allocate a tuple object with the data pins
-    self->data = mp_obj_new_tuple(num_data_pins, dios);
+    self->data_pins = mp_obj_new_tuple(num_data_pins, dios);
 
     self->key_counts = (mp_uint_t *)gc_alloc(sizeof(mp_uint_t) * num_key_counts, false, false);
     self->num_key_counts = num_key_counts;
@@ -109,18 +109,13 @@ void common_hal_keypad_shiftregisterkeys_deinit(keypad_shiftregisterkeys_obj_t *
     common_hal_digitalio_digitalinout_deinit(self->clock);
     self->clock = MP_ROM_NONE;
 
-/*
-    common_hal_digitalio_digitalinout_deinit(self->data);
-    self->data = MP_ROM_NONE;
-*/
-
     common_hal_digitalio_digitalinout_deinit(self->latch);
     self->latch = MP_ROM_NONE;
 
-    for (size_t key = 0; key < self->datas->len; key++) {
-        common_hal_digitalio_digitalinout_deinit(self->datas->items[key]);
+    for (size_t key = 0; key < self->data_pins->len; key++) {
+        common_hal_digitalio_digitalinout_deinit(self->data_pins->items[key]);
     }
-    self->data = MP_ROM_NONE;
+    self->data_pins = MP_ROM_NONE;
 
     common_hal_keypad_deinit_core(self);
 }
@@ -153,7 +148,7 @@ static void shiftregisterkeys_scan_now(void *self_in, mp_obj_t timestamp) {
         // Loop through all the data pins that share the latch
         mp_uint_t index = 0;
 
-        for (mp_uint_t i = 0; i < self->datas->len; i++) {
+        for (mp_uint_t i = 0; i < self->data_pins->len; i++) {
 
             // When this data pin has less shiftable bits, ignore it
             if (scan_number >= self->key_counts[i]) {
@@ -168,7 +163,7 @@ static void shiftregisterkeys_scan_now(void *self_in, mp_obj_t timestamp) {
 
             // Get the current state.
             const bool current =
-                common_hal_digitalio_digitalinout_get_value(self->datas->items[i]) == self->value_when_pressed;
+                common_hal_digitalio_digitalinout_get_value(self->data_pins->items[i]) == self->value_when_pressed;
             self->currently_pressed[key_number] = current;
 
             // Record any transitions.

--- a/shared-module/keypad/ShiftRegisterKeys.c
+++ b/shared-module/keypad/ShiftRegisterKeys.c
@@ -44,7 +44,7 @@ static keypad_scanner_funcs_t shiftregisterkeys_funcs = {
     .get_key_count = shiftregisterkeys_get_key_count,
 };
 
-void common_hal_keypad_shiftregisterkeys_construct(keypad_shiftregisterkeys_obj_t *self, const mcu_pin_obj_t *clock_pin, const mcu_pin_obj_t *data_pin, const mcu_pin_obj_t *latch_pin, bool value_to_latch, size_t key_count, bool value_when_pressed, mp_float_t interval, size_t max_events) {
+void common_hal_keypad_shiftregisterkeys_construct(keypad_shiftregisterkeys_obj_t *self, const mcu_pin_obj_t *clock_pin, mp_uint_t num_data_pins, const mcu_pin_obj_t *data_pins[], const mcu_pin_obj_t *latch_pin, bool value_to_latch, mp_uint_t num_key_counts, size_t key_counts[], bool value_when_pressed, mp_float_t interval, size_t max_events) {
 
     digitalio_digitalinout_obj_t *clock = m_new_obj(digitalio_digitalinout_obj_t);
     clock->base.type = &digitalio_digitalinout_type;
@@ -52,22 +52,46 @@ void common_hal_keypad_shiftregisterkeys_construct(keypad_shiftregisterkeys_obj_
     common_hal_digitalio_digitalinout_switch_to_output(clock, false, DRIVE_MODE_PUSH_PULL);
     self->clock = clock;
 
-    digitalio_digitalinout_obj_t *data = m_new_obj(digitalio_digitalinout_obj_t);
-    data->base.type = &digitalio_digitalinout_type;
-    common_hal_digitalio_digitalinout_construct(data, data_pin);
-    common_hal_digitalio_digitalinout_switch_to_input(data, PULL_NONE);
-    self->data = data;
-
     digitalio_digitalinout_obj_t *latch = m_new_obj(digitalio_digitalinout_obj_t);
     latch->base.type = &digitalio_digitalinout_type;
 
     common_hal_digitalio_digitalinout_construct(latch, latch_pin);
     common_hal_digitalio_digitalinout_switch_to_output(latch, true, DRIVE_MODE_PUSH_PULL);
     self->latch = latch;
-    self->value_to_latch = value_to_latch;
 
+    mp_obj_t dios[num_data_pins];
+
+    for (size_t i = 0; i < num_data_pins; i++) {
+        digitalio_digitalinout_obj_t *dio = m_new_obj(digitalio_digitalinout_obj_t);
+        dio->base.type = &digitalio_digitalinout_type;
+        common_hal_digitalio_digitalinout_construct(dio, data_pins[i]);
+        common_hal_digitalio_digitalinout_switch_to_input(dio, PULL_NONE);
+        dios[i] = dio;
+    }
+
+    // Allocate a tuple object with the data pins
+    self->data = mp_obj_new_tuple(num_data_pins, dios);
+
+    self->key_counts = (mp_uint_t *)gc_alloc(sizeof(mp_uint_t) * num_key_counts, false, false);
+    self->num_key_counts = num_key_counts;
+
+    // copy to a gc_alloc() and on the fly record pin with largest Shift register
+    mp_uint_t max = 0;
+
+    for (mp_uint_t i = 0; i < self->num_key_counts; i++) {
+        mp_uint_t cnt = key_counts[i];
+
+        if (cnt > max) {
+            max = cnt;
+        }
+
+        self->key_counts[i] = cnt;
+    }
+
+    self->max_key_count = max;
+
+    self->value_to_latch = value_to_latch;
     self->value_when_pressed = value_when_pressed;
-    self->key_count = key_count;
     self->funcs = &shiftregisterkeys_funcs;
 
     keypad_construct_common((keypad_scanner_obj_t *)self, interval, max_events);
@@ -85,18 +109,33 @@ void common_hal_keypad_shiftregisterkeys_deinit(keypad_shiftregisterkeys_obj_t *
     common_hal_digitalio_digitalinout_deinit(self->clock);
     self->clock = MP_ROM_NONE;
 
+/*
     common_hal_digitalio_digitalinout_deinit(self->data);
     self->data = MP_ROM_NONE;
+*/
 
     common_hal_digitalio_digitalinout_deinit(self->latch);
     self->latch = MP_ROM_NONE;
+
+    for (size_t key = 0; key < self->datas->len; key++) {
+        common_hal_digitalio_digitalinout_deinit(self->datas->items[key]);
+    }
+    self->data = MP_ROM_NONE;
 
     common_hal_keypad_deinit_core(self);
 }
 
 size_t shiftregisterkeys_get_key_count(void *self_in) {
     keypad_shiftregisterkeys_obj_t *self = self_in;
-    return self->key_count;
+
+    size_t total = 0;
+
+    for (mp_uint_t i = 0; i < self->num_key_counts; i++)
+    {
+        total += self->key_counts[i];
+    }
+
+    return total;
 }
 
 static void shiftregisterkeys_scan_now(void *self_in, mp_obj_t timestamp) {
@@ -105,28 +144,44 @@ static void shiftregisterkeys_scan_now(void *self_in, mp_obj_t timestamp) {
     // Latch (freeze) the current state of the input pins.
     common_hal_digitalio_digitalinout_set_value(self->latch, self->value_to_latch);
 
-    const size_t key_count = shiftregisterkeys_get_key_count(self);
-
-    for (mp_uint_t key_number = 0; key_number < key_count; key_number++) {
-        // Zero-th data appears on on the data pin immediately, without shifting.
+    // Scan for max_key_count bit
+    for (mp_uint_t scan_number = 0; scan_number < self->max_key_count; scan_number++) {
         common_hal_digitalio_digitalinout_set_value(self->clock, false);
 
-        // Remember the previous up/down state.
-        const bool previous = self->currently_pressed[key_number];
-        self->previously_pressed[key_number] = previous;
+        // Zero-th data appears on on the data pin immediately, without shifting.
 
-        // Get the current state.
-        const bool current =
-            common_hal_digitalio_digitalinout_get_value(self->data) == self->value_when_pressed;
-        self->currently_pressed[key_number] = current;
+        // Loop through all the data pins that share the latch
+        mp_uint_t index = 0;
+
+        for (mp_uint_t i = 0; i < self->datas->len; i++) {
+
+            // When this data pin has less shiftable bits, ignore it
+            if (scan_number >= self->key_counts[i]) {
+                continue;
+            }
+
+            mp_uint_t key_number = scan_number + index;
+
+            // Remember the previous up/down state.
+            const bool previous = self->currently_pressed[key_number];
+            self->previously_pressed[key_number] = previous;
+
+            // Get the current state.
+            const bool current =
+                common_hal_digitalio_digitalinout_get_value(self->datas->items[i]) == self->value_when_pressed;
+            self->currently_pressed[key_number] = current;
+
+            // Record any transitions.
+            if (previous != current) {
+                keypad_eventqueue_record(self->events, key_number, current, timestamp);
+            }
+
+            index += self->key_counts[i];
+        }
 
         // Trigger a shift to get the next bit.
         common_hal_digitalio_digitalinout_set_value(self->clock, true);
 
-        // Record any transitions.
-        if (previous != current) {
-            keypad_eventqueue_record(self->events, key_number, current, timestamp);
-        }
     }
 
     // Start reading the input pins again.

--- a/shared-module/keypad/ShiftRegisterKeys.c
+++ b/shared-module/keypad/ShiftRegisterKeys.c
@@ -116,6 +116,7 @@ void common_hal_keypad_shiftregisterkeys_deinit(keypad_shiftregisterkeys_obj_t *
         common_hal_digitalio_digitalinout_deinit(self->data_pins->items[key]);
     }
     self->data_pins = MP_ROM_NONE;
+    self->key_counts = MP_ROM_NONE;
 
     common_hal_keypad_deinit_core(self);
 }
@@ -125,8 +126,7 @@ size_t shiftregisterkeys_get_key_count(void *self_in) {
 
     size_t total = 0;
 
-    for (mp_uint_t i = 0; i < self->num_key_counts; i++)
-    {
+    for (mp_uint_t i = 0; i < self->num_key_counts; i++) {
         total += self->key_counts[i];
     }
 

--- a/shared-module/keypad/ShiftRegisterKeys.h
+++ b/shared-module/keypad/ShiftRegisterKeys.h
@@ -37,9 +37,11 @@
 typedef struct {
     KEYPAD_SCANNER_COMMON_FIELDS;
     digitalio_digitalinout_obj_t *clock;
-    digitalio_digitalinout_obj_t *data;
     digitalio_digitalinout_obj_t *latch;
-    size_t key_count;
+    mp_obj_tuple_t *data;
+    mp_uint_t *key_counts;
+    mp_uint_t num_key_counts;
+    mp_uint_t max_key_count;
     bool value_when_pressed;
     bool value_to_latch;
 } keypad_shiftregisterkeys_obj_t;

--- a/shared-module/keypad/ShiftRegisterKeys.h
+++ b/shared-module/keypad/ShiftRegisterKeys.h
@@ -38,7 +38,7 @@ typedef struct {
     KEYPAD_SCANNER_COMMON_FIELDS;
     digitalio_digitalinout_obj_t *clock;
     digitalio_digitalinout_obj_t *latch;
-    mp_obj_tuple_t *data;
+    mp_obj_tuple_t *data_pins;
     mp_uint_t *key_counts;
     mp_uint_t num_key_counts;
     mp_uint_t max_key_count;


### PR DESCRIPTION
Added support for multiple data pins which share the same latch and clock, e.g.

```
k = keypad.ShiftRegisterKeys(
    latch=board.GP2,
    clock=board.GP3,
    data=[ board.GP10, board.GP0 ],
    key_count=[ 32, 16 ],
    value_when_pressed=False,
)
```

Backwards compatible, data can also be a single pin instead of a list. The key_count numbers are consecutive, e.g. in the example the first key of GP0 will have number 32.