### PR TITLE
Test empty settings.toml

### DIFF
--- a/tests/basics/string_format_error.py.exp
+++ b/tests/basics/string_format_error.py.exp
@@ -1,0 +1,17 @@
+ValueError
+IndexError
+ValueError
+ValueError
+ValueError
+ValueError
+ValueError
+ValueError
+IndexError
+KeyError
+ValueError
+IndexError
+ValueError
+ValueError
+ValueError
+ValueError
+ValueError

--- a/tests/circuitpython/getenv.py
+++ b/tests/circuitpython/getenv.py
@@ -72,6 +72,8 @@ def run_test(key, content):
         print(key, str(e))
 
 
+run_test("key", b"")
+
 for i in range(13):
     run_test(f"key{i}", content_good)
 

--- a/tests/circuitpython/getenv.py.exp
+++ b/tests/circuitpython/getenv.py.exp
@@ -1,3 +1,4 @@
+key None
 key0 'hello world'
 key1 7
 key2 '\n'


### PR DESCRIPTION
@tannewt wondered if this could be a cause of instability. Many boards in the wild are probably running with an empty settings.toml, since formatting the CIRCUITPY drive creates one
```
shared/filesystem.c:        make_empty_file(&vfs_fat->fatfs, "/settings.toml");
```
but it also wouldn't hurt to add a test for it in the core tests.

This also adds an expected-result file for the test basics/string_format_error, because the behavior of the test under python 3.11.2 (debian bookworm) differs from 3.9. CP follows the 3.9 behavior. This allows the testsuite to pass on the new stable debian.