### PR TITLE
usb host: add keyboard map control in usb workflow

### DIFF
--- a/shared-bindings/usb/__init__.c
+++ b/shared-bindings/usb/__init__.c
@@ -30,15 +30,48 @@
 
 #include "shared-bindings/usb/__init__.h"
 #include "shared-bindings/usb/core/__init__.h"
+#include "supervisor/usb.h"
 
 //| """PyUSB-compatible USB host API
 //|
 //| The `usb` is a subset of PyUSB that allows you to communicate to USB devices.
 //| """
+//|
+//| def set_user_keymap(keymap: ReadableBuffer, /) -> None:
+//|     """Set the keymap used by a USB HID keyboard in kernel mode
+//|
+//|     The keymap consists of 256 or 384 1-byte entries that map from USB keycodes
+//|     to ASCII codes. The first 128 entries are for unmodified keys,
+//|     the next 128 entries are for shifted keys,and the next optional 128 entries are
+//|     for altgr-modified keys.
+//|
+//|     The values must all be ASCII (32 through 126 inclusive); other values are not valid.
+//|
+//|     The values at index 0, 128, and 256 (if the keymap has 384 entries) must be
+//|     0; other values are reserved for future expansion to indicate alternate
+//|     keymap formats.
+//|
+//|     At other indices, the value 0 is used to indicate that the normal
+//|     definition is still used. For instance, the entry for HID_KEY_ARROW_UP
+//|     (0x52) is usually 0 so that the default behavior of sending an escape code
+//|     is preserved.
+//|
+//|     This function is a CircuitPython extension not present in PyUSB
+//|     """
+//|
+STATIC mp_obj_t usb_set_user_keymap(mp_obj_t buf_in) {
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
+    usb_keymap_set(bufinfo.buf, bufinfo.len);
+    return mp_const_none;
+}
+
+MP_DEFINE_CONST_FUN_OBJ_1(usb_set_user_keymap_obj, usb_set_user_keymap);
 
 STATIC mp_rom_map_elem_t usb_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),        MP_OBJ_NEW_QSTR(MP_QSTR_usb) },
     { MP_ROM_QSTR(MP_QSTR_core),          MP_OBJ_FROM_PTR(&usb_core_module) },
+    { MP_ROM_QSTR(MP_QSTR_set_user_keymap),          MP_OBJ_FROM_PTR(&usb_set_user_keymap_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(usb_module_globals, usb_module_globals_table);

--- a/shared-bindings/usb/__init__.c
+++ b/shared-bindings/usb/__init__.c
@@ -37,41 +37,10 @@
 //| The `usb` is a subset of PyUSB that allows you to communicate to USB devices.
 //| """
 //|
-//| def set_user_keymap(keymap: ReadableBuffer, /) -> None:
-//|     """Set the keymap used by a USB HID keyboard in kernel mode
-//|
-//|     The keymap consists of 256 or 384 1-byte entries that map from USB keycodes
-//|     to ASCII codes. The first 128 entries are for unmodified keys,
-//|     the next 128 entries are for shifted keys,and the next optional 128 entries are
-//|     for altgr-modified keys.
-//|
-//|     The values must all be ASCII (32 through 126 inclusive); other values are not valid.
-//|
-//|     The values at index 0, 128, and 256 (if the keymap has 384 entries) must be
-//|     0; other values are reserved for future expansion to indicate alternate
-//|     keymap formats.
-//|
-//|     At other indices, the value 0 is used to indicate that the normal
-//|     definition is still used. For instance, the entry for HID_KEY_ARROW_UP
-//|     (0x52) is usually 0 so that the default behavior of sending an escape code
-//|     is preserved.
-//|
-//|     This function is a CircuitPython extension not present in PyUSB
-//|     """
-//|
-STATIC mp_obj_t usb_set_user_keymap(mp_obj_t buf_in) {
-    mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
-    usb_keymap_set(bufinfo.buf, bufinfo.len);
-    return mp_const_none;
-}
-
-MP_DEFINE_CONST_FUN_OBJ_1(usb_set_user_keymap_obj, usb_set_user_keymap);
 
 STATIC mp_rom_map_elem_t usb_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),        MP_OBJ_NEW_QSTR(MP_QSTR_usb) },
     { MP_ROM_QSTR(MP_QSTR_core),          MP_OBJ_FROM_PTR(&usb_core_module) },
-    { MP_ROM_QSTR(MP_QSTR_set_user_keymap),          MP_OBJ_FROM_PTR(&usb_set_user_keymap_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(usb_module_globals, usb_module_globals_table);

--- a/shared-bindings/usb_host/__init__.c
+++ b/shared-bindings/usb_host/__init__.c
@@ -30,16 +30,49 @@
 
 #include "shared-bindings/usb_host/__init__.h"
 #include "shared-bindings/usb_host/Port.h"
+#include "supervisor/usb.h"
 
 //| """USB Host
 //|
 //| The `usb_host` module allows you to manage USB host ports. To communicate
 //| with devices use the `usb` module that is a subset of PyUSB's API.
 //| """
+//|
+//| def set_user_keymap(keymap: ReadableBuffer, /) -> None:
+//|     """Set the keymap used by a USB HID keyboard in kernel mode
+//|
+//|     The keymap consists of 256 or 384 1-byte entries that map from USB keycodes
+//|     to ASCII codes. The first 128 entries are for unmodified keys,
+//|     the next 128 entries are for shifted keys,and the next optional 128 entries are
+//|     for altgr-modified keys.
+//|
+//|     The values must all be ASCII (32 through 126 inclusive); other values are not valid.
+//|
+//|     The values at index 0, 128, and 256 (if the keymap has 384 entries) must be
+//|     0; other values are reserved for future expansion to indicate alternate
+//|     keymap formats.
+//|
+//|     At other indices, the value 0 is used to indicate that the normal
+//|     definition is still used. For instance, the entry for HID_KEY_ARROW_UP
+//|     (0x52) is usually 0 so that the default behavior of sending an escape code
+//|     is preserved.
+//|
+//|     This function is a CircuitPython extension not present in PyUSB
+//|     """
+//|
+STATIC mp_obj_t usb_set_user_keymap(mp_obj_t buf_in) {
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
+    usb_keymap_set(bufinfo.buf, bufinfo.len);
+    return mp_const_none;
+}
+
+MP_DEFINE_CONST_FUN_OBJ_1(usb_set_user_keymap_obj, usb_set_user_keymap);
 
 STATIC mp_map_elem_t usb_host_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),        MP_OBJ_NEW_QSTR(MP_QSTR_usb_host) },
     { MP_ROM_QSTR(MP_QSTR_Port),          MP_OBJ_FROM_PTR(&usb_host_port_type) },
+    { MP_ROM_QSTR(MP_QSTR_set_user_keymap),          MP_OBJ_FROM_PTR(&usb_set_user_keymap_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(usb_host_module_globals, usb_host_module_globals_table);

--- a/shared-module/usb/utf16le.c
+++ b/shared-module/usb/utf16le.c
@@ -26,60 +26,49 @@
 
 #include "shared-module/usb/utf16le.h"
 
-STATIC void _convert_utf16le_to_utf8(const uint16_t *utf16, size_t utf16_len, uint8_t *utf8, size_t utf8_len) {
-    // TODO: Check for runover.
-    (void)utf8_len;
+typedef struct {
+    const uint16_t *buf;
+    size_t len;
+} utf16_str;
 
-    for (size_t i = 0; i < utf16_len; i++) {
-        uint16_t chr = utf16[i];
-        if (chr < 0x80) {
-            *utf8++ = chr & 0xff;
-        } else if (chr < 0x800) {
-            *utf8++ = (uint8_t)(0xC0 | (chr >> 6 & 0x1F));
-            *utf8++ = (uint8_t)(0x80 | (chr >> 0 & 0x3F));
-        } else if (chr < 0x10000) {
-            // TODO: Verify surrogate.
-            *utf8++ = (uint8_t)(0xE0 | (chr >> 12 & 0x0F));
-            *utf8++ = (uint8_t)(0x80 | (chr >> 6 & 0x3F));
-            *utf8++ = (uint8_t)(0x80 | (chr >> 0 & 0x3F));
-        } else {
-            // TODO: Handle UTF-16 code points that take two entries.
-            uint32_t hc = ((chr & 0xFFFF0000) - 0xD8000000) >> 6;    /* Get high 10 bits */
-            chr = (chr & 0xFFFF) - 0xDC00;                  /* Get low 10 bits */
-            chr = (hc | chr) + 0x10000;
-            *utf8++ = (uint8_t)(0xF0 | (chr >> 18 & 0x07));
-            *utf8++ = (uint8_t)(0x80 | (chr >> 12 & 0x3F));
-            *utf8++ = (uint8_t)(0x80 | (chr >> 6 & 0x3F));
-            *utf8++ = (uint8_t)(0x80 | (chr >> 0 & 0x3F));
-        }
+STATIC uint32_t utf16str_peek_unit(utf16_str *utf) {
+    if (!utf->len) {
+        return 0;
     }
+    return *utf->buf;
 }
 
-// Count how many bytes a utf-16-le encoded string will take in utf-8.
-STATIC mp_int_t _count_utf8_bytes(const uint16_t *buf, size_t len) {
-    size_t total_bytes = 0;
-    for (size_t i = 0; i < len; i++) {
-        uint16_t chr = buf[i];
-        if (chr < 0x80) {
-            total_bytes += 1;
-        } else if (chr < 0x800) {
-            total_bytes += 2;
-        } else if (chr < 0x10000) {
-            total_bytes += 3;
-        } else {
-            total_bytes += 4;
+STATIC uint32_t utf16str_next_unit(utf16_str *utf) {
+    uint32_t result = utf16str_peek_unit(utf);
+    if (utf->len) {
+        utf->len--;
+        utf->buf++;
+    }
+    return result;
+}
+STATIC uint32_t utf16str_next_codepoint(utf16_str *utf) {
+    uint32_t unichr = utf16str_next_unit(utf);
+    if (unichr >= 0xd800 && unichr < 0xdc00) {
+        uint32_t low_surrogate = utf16str_peek_unit(utf);
+        if (low_surrogate >= 0xdc00 && low_surrogate < 0xe000) {
+            (void)utf16str_next_unit(utf);
+            unichr = (unichr - 0xd800) * 0x400 + low_surrogate - 0xdc00 + 0x10000;
         }
     }
-    return total_bytes;
+    return unichr;
+}
+
+STATIC void _convert_utf16le_to_utf8(vstr_t *vstr, utf16_str *utf) {
+    while (utf->len) {
+        vstr_add_char(vstr, utf16str_next_codepoint(utf));
+    }
 }
 
 mp_obj_t utf16le_to_string(const uint16_t *buf, size_t utf16_len) {
-    size_t size = _count_utf8_bytes(buf, utf16_len);
+    // will grow if necessary, but will never grow for an all-ASCII descriptor
     vstr_t vstr;
-    vstr_init_len(&vstr, size + 1);
-    byte *p = (byte *)vstr.buf;
-    // Null terminate.
-    p[size] = '\0';
-    _convert_utf16le_to_utf8(buf, utf16_len, p, size);
+    vstr_init(&vstr, utf16_len);
+    utf16_str utf = {buf, utf16_len};
+    _convert_utf16le_to_utf8(&vstr, &utf);
     return mp_obj_new_str_from_vstr(&mp_type_str, &vstr);
 }

--- a/supervisor/shared/usb/host_keyboard.c
+++ b/supervisor/shared/usb/host_keyboard.c
@@ -246,6 +246,7 @@ STATIC void process_event(uint8_t dev_addr, uint8_t instance, const hid_keyboard
                 if (mapper->flags & FLAG_STRING) {
                     const char *msg = skip_nuls(mapper->data, keycode - mapper->first);
                     send_bufz(msg);
+                    break;
                 } else if (mapper->data) {
                     code = mapper->data[keycode - mapper->first];
                 } else {

--- a/supervisor/usb.h
+++ b/supervisor/usb.h
@@ -104,6 +104,7 @@ char usb_keyboard_read_char(void);
 bool usb_keyboard_in_use(uint8_t dev_addr, uint8_t interface);
 void usb_keyboard_detach(uint8_t dev_addr, uint8_t interface);
 void usb_keyboard_attach(uint8_t dev_addr, uint8_t interface);
+void usb_keymap_set(const uint8_t *buf, size_t len);
 #endif
 
 #endif // MICROPY_INCLUDED_SUPERVISOR_USB_H


### PR DESCRIPTION
also, improve reading properties like 'product' and 'manufacturer' by handling surrogate pairs (untested) and avoiding  trailing '\0' that was not present in standard pyusb