### PR TITLE
Networking docs updates: Access Point, MDNS

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -94,6 +94,10 @@ MDNS is used to resolve [`circuitpython.local`](http://circuitpython.local) to a
 hostname of the form `cpy-XXXXXX.local`. The `XXXXXX` is based on network MAC address. The device
 also provides the MDNS service with service type `_circuitpython` and protocol `_tcp`.
 
+Since port 80 (or the port assigned to `CIRCUITPY_WEB_API_PORT`) is used for MDNS, the `mdns`
+[module](https://docs.circuitpython.org/en/latest/shared-bindings/mdns/index.html#mdns.Server.advertise_service)
+can't also advertise a service on that port.
+
 ### HTTP
 The web server is HTTP 1.1 and may use chunked responses so that it doesn't need to precompute
 content length.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -94,9 +94,9 @@ MDNS is used to resolve [`circuitpython.local`](http://circuitpython.local) to a
 hostname of the form `cpy-XXXXXX.local`. The `XXXXXX` is based on network MAC address. The device
 also provides the MDNS service with service type `_circuitpython` and protocol `_tcp`.
 
-Since port 80 (or the port assigned to `CIRCUITPY_WEB_API_PORT`) is used for MDNS, the `mdns`
+Since port 80 (or the port assigned to `CIRCUITPY_WEB_API_PORT`) is used for web workflow, the `mdns`
 [module](https://docs.circuitpython.org/en/latest/shared-bindings/mdns/index.html#mdns.Server.advertise_service)
-can't also advertise a service on that port.
+can't advertise an additional service on that port.
 
 ### HTTP
 The web server is HTTP 1.1 and may use chunked responses so that it doesn't need to precompute

--- a/shared-bindings/mdns/Server.c
+++ b/shared-bindings/mdns/Server.c
@@ -171,6 +171,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mdns_server_find_obj, 1, _mdns_server_find);
 //|         ``service_type`` and ``protocol`` can only occur on one port. Any call after the first
 //|         will update the entry's port.
 //|
+//|         If web workflow is active, the port it uses can't also be used to advertise a service.
+//|
 //|         :param str service_type: The service type such as "_http"
 //|         :param str protocol: The service protocol such as "_tcp"
 //|         :param int port: The port used by the service"""

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -339,7 +339,12 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_station_obj, wifi_radio_stop_station);
 //|         or exactly 64 hexadecimal characters if it is the hex form of the 256-bit key.
 //|
 //|         If ``max_connections`` is given, the access point will allow up to
-//|         that number of stations to connect."""
+//|         that number of stations to connect.
+//|
+//|         .. note::
+//|
+//|             In the raspberrypi port (RP2040 CYW43), ``max_connections`` is ignored.
+//|         """
 //|         ...
 STATIC mp_obj_t wifi_radio_start_ap(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_ssid, ARG_password, ARG_channel, ARG_authmode, ARG_max_connections };

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -564,7 +564,7 @@ MP_PROPERTY_GETTER(wifi_radio_ipv4_subnet_ap_obj,
 //|         ipv4_dns: Optional[ipaddress.IPv4Address],
 //|     ) -> None:
 //|         """Sets the IP v4 address of the station. Must include the netmask and gateway. DNS address is optional.
-//|         Setting the address manually will stop the DHCP client."""
+//|         Setting the address manually will stop the DHCP client.
 //|
 //|         .. note::
 //|

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -565,6 +565,11 @@ MP_PROPERTY_GETTER(wifi_radio_ipv4_subnet_ap_obj,
 //|     ) -> None:
 //|         """Sets the IP v4 address of the station. Must include the netmask and gateway. DNS address is optional.
 //|         Setting the address manually will stop the DHCP client."""
+//|
+//|         .. note::
+//|
+//|             In the raspberrypi port (RP2040 CYW43), the access point needs to be started before the IP v4 address can be set.
+//|         """
 //|         ...
 STATIC mp_obj_t wifi_radio_set_ipv4_address(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_ipv4, ARG_netmask, ARG_gateway, ARG_ipv4_dns };


### PR DESCRIPTION
- `raspberrypi` port-specific notes:
    - `start_ap()`: `max_connections` is ignored
    - AP needs to be started before a static IPv4 address can be set (https://github.com/adafruit/circuitpython/pull/7976#issue-1708806458)

- potential service slot conflict between web workflow & `mdns`ports (#8149)