### PR TITLE
Add NeoPixel Library for Datanoise PicoADK.

### DIFF
--- a/ports/raspberrypi/boards/datanoise_picoadk/mpconfigboard.mk
+++ b/ports/raspberrypi/boards/datanoise_picoadk/mpconfigboard.mk
@@ -7,3 +7,6 @@ CHIP_VARIANT = RP2040
 CHIP_FAMILY = rp2
 
 EXTERNAL_FLASH_DEVICES = "GD25Q32C,W25Q32JVxQ"
+
+# Include these Python libraries in firmware.
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel


### PR DESCRIPTION
The PicoADK has an WS2812-compatible addressable LED on board, so
the NeoPixel MPY should be included in the firmware.