### PR TITLE
py/objdict: Fix fromkeys to return the right type.

### DIFF
--- a/tests/basics/ordereddict1.py
+++ b/tests/basics/ordereddict1.py
@@ -41,3 +41,14 @@ try:
     d.popitem()
 except:
     print('empty')
+
+# fromkeys returns the correct type and order
+d = dict.fromkeys('abcdefghij')
+print(type(d) == dict)
+d = OrderedDict.fromkeys('abcdefghij')
+print(type(d) == OrderedDict)
+print(''.join(d))
+
+# fromkey handles ordering with duplicates
+d = OrderedDict.fromkeys('abcdefghijjihgfedcba')
+print(''.join(d))


### PR DESCRIPTION
Fixes https://github.com/adafruit/circuitpython/issues/8173

It seemed like a small fix, and mostly independent of upstream plans around https://github.com/micropython/micropython/pull/6173 - so sending it your way
to use if convenient.

I also filed an issue upstream
https://github.com/micropython/micropython/issues/12011