### PR TITLE
8.2.x backport: py/objdict: Fix fromkeys to return the right type.

### DIFF
--- a/tests/basics/ordereddict1.py
+++ b/tests/basics/ordereddict1.py
@@ -41,3 +41,14 @@ try:
     d.popitem()
 except:
     print('empty')
+
+# fromkeys returns the correct type and order
+d = dict.fromkeys('abcdefghij')
+print(type(d) == dict)
+d = OrderedDict.fromkeys('abcdefghij')
+print(type(d) == OrderedDict)
+print(''.join(d))
+
+# fromkey handles ordering with duplicates
+d = OrderedDict.fromkeys('abcdefghijjihgfedcba')
+print(''.join(d))


### PR DESCRIPTION
- Backport #8175 to 8.2.x