### PR TITLE
[Fix] Mis-use of cache for STM32

### DIFF
--- a/ports/stm/supervisor/internal_flash.c
+++ b/ports/stm/supervisor/internal_flash.c
@@ -303,9 +303,8 @@ mp_uint_t supervisor_flash_read_blocks(uint8_t *dest, uint32_t block, uint32_t n
     flash_get_sector_info(src, &sector_start_addr, &sector_size);
     // Count how many blocks are left in the sector
     uint32_t count = (sector_size - (src - sector_start_addr)) / FILESYSTEM_BLOCK_SIZE;
-    count = MIN(num_blocks, count);
 
-    if (count < num_blocks && _cache_flash_addr == sector_start_addr) {
+    if (count <= num_blocks && _cache_flash_addr == sector_start_addr) {
         // Read is contained in the cache, so just read cache
         memcpy(dest, (_flash_cache + (src - sector_start_addr)), FILESYSTEM_BLOCK_SIZE * num_blocks);
     } else {


### PR DESCRIPTION
Closes #7615

Perhaps i mis-understood something on the code + i dont have any hardware to test this with, please review it throughtfully.

From my understanding:
    - `num_blocks`: amount of memory we want to read
    -  `count`: amount of memory we can read from cache

If that is correct (bold assumption):
    - `<` should have been `<=`. That is, reading **_the same_** or less amount of memory than there's in cache 
    - Why would we use `MIN` on `count` there at all? Since the variable isnt used later on, `MIN` + `<` is effectively just a convoluted way of checking which value was higher, i believe...
    
PS: I dont know which branch i should target, just went for main but let me know if i use go against another one.