### PR TITLE
[displayio] Better exception message

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2056,7 +2056,7 @@ msgid "Too many channels in sample."
 msgstr ""
 
 #: shared-module/displayio/__init__.c
-msgid "Too many display busses"
+msgid "Too many display busses; forgot display.release_displays() ?"
 msgstr ""
 
 #: shared-module/displayio/__init__.c

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -386,5 +386,5 @@ primary_display_bus_t *allocate_display_bus_or_raise(void) {
     if (result) {
         return result;
     }
-    mp_raise_RuntimeError(translate("Too many display busses"));
+    mp_raise_RuntimeError(translate("Too many display busses; forgot display.release_displays() ?"));
 }

--- a/tools/check_translations.py
+++ b/tools/check_translations.py
@@ -22,7 +22,9 @@ for po_filename in po_filenames:
 
     missing = all_ids - po_ids
     if missing:
-        print("Missing message id. Please run `make translate`")
+        print(
+            "Missing message id. Please run `make translate` and then `git commit locale/circuitpython.pot`"
+        )
         print(missing)
         sys.exit(-1)
     else:


### PR DESCRIPTION
Closes #8178 

Suggest releasing displays upon allocation fails (and thus exception is raised).

Along the way i had a fierce battle with pre-commit because the error message ("run `make translate`") is incomplete, so i also took care of that