### PR TITLE
[Feature] `OrderedDict.move_to_end`

### DIFF
--- a/py/objdict.c
+++ b/py/objdict.c
@@ -641,16 +641,15 @@ const mp_obj_type_t mp_type_dict = {
 
 STATIC mp_obj_t dict_move_to_end(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // parse args
-    enum { ARG_self, ARG_key, ARG_last };
+    enum { ARG_key, ARG_last };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
         { MP_QSTR_key, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
         { MP_QSTR_last, MP_ARG_BOOL, {.u_bool = true } }
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_obj_dict_t *self = MP_OBJ_TO_PTR(args[ARG_self].u_obj);
+    mp_obj_dict_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     mp_obj_t *key = args[ARG_key].u_obj;
     bool last = args[ARG_last].u_bool;
 

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -624,7 +624,7 @@ const mp_obj_type_t mp_type_dict = {
 //| ):
 //|     """
 //|     :param key: The key of the element to be moved.
-//|     :param last: Whether it moves to the start(False) or start(default behaviour) of the dict.
+//|     :param last: Whether it moves to the start(False) or end(default behaviour) of the dict.
 //|     """
 //|     ...
 //|

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -618,6 +618,15 @@ const mp_obj_type_t mp_type_dict = {
 };
 
 #if MICROPY_PY_COLLECTIONS_ORDEREDDICT
+/* ------------------------------------------------------------------
+ * Only real difference between OrderedDict and regular dict is that
+ * ordered has `move_to_end`. This method is only added if asked
+ * for (due to flash constrains), thus we can just alias the locals'
+ * table to the one for dicts one when the method is not present.
+ * ------------------------------------------------------------------*/
+#if !MICROPY_CPYTHON_COMPAT
+#define ordered_dict_locals_dict dict_locals_dict
+#else     // !MICROPY_CPYTHON_COMPAT
 //| def move_to_end(
 //|     key: Any,
 //|     last: Optional[bool] = True
@@ -701,6 +710,7 @@ STATIC const mp_rom_map_elem_t ordered_dict_locals_dict_table[] = {
 };
 
 STATIC MP_DEFINE_CONST_DICT(ordered_dict_locals_dict, ordered_dict_locals_dict_table);
+#endif     // !MICROPY_CPYTHON_COMPAT
 
 const mp_obj_type_t mp_type_ordereddict = {
     { &mp_type_type },

--- a/tests/basics/ordereddict1.py
+++ b/tests/basics/ordereddict1.py
@@ -52,3 +52,25 @@ print(''.join(d))
 # fromkey handles ordering with duplicates
 d = OrderedDict.fromkeys('abcdefghijjihgfedcba')
 print(''.join(d))
+
+# move_to_end works as expected
+d = OrderedDict.fromkeys("ab")
+print(d.keys())
+
+d.move_to_end("a")
+print(d.keys())
+
+d.move_to_end("a", False)
+print(d.keys())
+
+d.move_to_end(key="a")
+print(d.keys())
+
+d.move_to_end("a", last=False)
+print(d.keys())
+
+d.move_to_end(key="a", last=True)
+print(d.keys())
+
+d.move_to_end(last=False, key="a")
+print(d.keys())

--- a/tests/basics/ordereddict1.py
+++ b/tests/basics/ordereddict1.py
@@ -54,23 +54,23 @@ d = OrderedDict.fromkeys('abcdefghijjihgfedcba')
 print(''.join(d))
 
 # move_to_end works as expected
-d = OrderedDict.fromkeys("ab")
-print(d.keys())
+d = OrderedDict()
+try:
+    d.move_to_end("empty")
+except KeyError:
+    print("empty")
 
+d = OrderedDict.fromkeys("ab")
 d.move_to_end("a")
-print(d.keys())
+print(''.join(d))
 
 d.move_to_end("a", False)
-print(d.keys())
+print(''.join(d))
 
-d.move_to_end(key="a")
-print(d.keys())
+try:
+    d.move_to_end("KeyError")
+except KeyError:
+    print("KeyError")
 
-d.move_to_end("a", last=False)
-print(d.keys())
-
-d.move_to_end(key="a", last=True)
-print(d.keys())
-
-d.move_to_end(last=False, key="a")
-print(d.keys())
+d.move_to_end("a", "not_a_bool")
+print(''.join(d))


### PR DESCRIPTION
Closes #4408

Adds the method in the title. First time i write a C-Python binding, please let me know if anything should be changed
- Should maybe remove the doctstring to follow other funcs not having it on the file
- Is there a way to extend existing array instead of duplicating? Could save a bit of space

---
My little test:
```py
Adafruit CircuitPython 8.2.0-47-g8050b07a6-dirty on 2023-07-30; WeAct ESP32S3-B-N16R8 with ESP32S3R8

>>> from collections import OrderedDict
>>> d = OrderedDict.fromkeys("abcd")
>>> print(d)
OrderedDict({'a': None, 'b': None, 'c': None, 'd': None})
>>> d.move_to_end("a")
>>> print(d)
OrderedDict({'b': None, 'c': None, 'd': None, 'a': None})
>>> d.move_to_end("d", False)
>>> print(d)
OrderedDict({'d': None, 'b': None, 'c': None, 'a': None})
>>> d.move_to_end("b", last=False)
>>> print(d)
OrderedDict({'b': None, 'd': None, 'c': None, 'a': None})
```