### PR TITLE
Two small changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -106,7 +106,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Register.git
 [submodule "extmod/ulab"]
 	path = extmod/ulab
-	url = https://github.com/v923z/micropython-ulab
+	url = https://github.com/jepler/micropython-ulab
 [submodule "frozen/Adafruit_CircuitPython_ESP32SPI"]
 	path = frozen/Adafruit_CircuitPython_ESP32SPI
 	url = https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI

--- a/.gitmodules
+++ b/.gitmodules
@@ -106,7 +106,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Register.git
 [submodule "extmod/ulab"]
 	path = extmod/ulab
-	url = https://github.com/jepler/micropython-ulab
+	url = https://github.com/v923z/micropython-ulab
 [submodule "frozen/Adafruit_CircuitPython_ESP32SPI"]
 	path = frozen/Adafruit_CircuitPython_ESP32SPI
 	url = https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1536,6 +1536,10 @@ msgstr ""
 msgid "No timer available"
 msgstr ""
 
+#: shared-module/usb/core/Device.c
+msgid "No usb host port initialized"
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/__init__.c
 msgid "Nordic system firmware out of memory"
 msgstr ""

--- a/ports/raspberrypi/link.ld
+++ b/ports/raspberrypi/link.ld
@@ -211,7 +211,7 @@ SECTIONS
     _ld_dtcm_data_flash_copy = LOADADDR(.dtcm_data);
     _ld_dtcm_data_size = SIZEOF(.dtcm_data);
 
-    .dtcm_bss :
+    .dtcm_bss (NOLOAD) :
     {
         . = ALIGN(4);
 

--- a/shared-module/usb/core/Device.c
+++ b/shared-module/usb/core/Device.c
@@ -51,6 +51,10 @@ void tuh_umount_cb(uint8_t dev_addr) {
 STATIC xfer_result_t _xfer_result;
 STATIC size_t _actual_len;
 bool common_hal_usb_core_device_construct(usb_core_device_obj_t *self, uint8_t device_number) {
+    if (!tuh_inited()) {
+        mp_raise_RuntimeError(translate("No usb host port initialized"));
+    }
+
     if (device_number == 0 || device_number > CFG_TUH_DEVICE_MAX + CFG_TUH_HUB) {
         return false;
     }


### PR DESCRIPTION
1. Raise an exception when creating a USB device when host isn't initialized.
2. Mark RP2040 dtcm_bss as NOLOAD since it doesn't need to be loaded (just zeroed.)
3. ~~Fix submodule location for ulab to Jeff's copy.~~