### PR TITLE
Add index.html as a redirect to README.html (for 8.2.x)

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -1,3 +1,4 @@
+index.rst README.html
 shared-bindings//__init__.rst shared-bindings//
 shared-bindings/_bleio/Adapter.rst shared-bindings/_bleio/#_bleio.Adapter
 shared-bindings/_bleio/Address.rst shared-bindings/_bleio/#_bleio.Address


### PR DESCRIPTION
closes #8246

can't really verify this one until pushed to rtd on main branch :( but I looked locally and now have an index.html with content
```html
<html>
  <head><meta http-equiv="refresh" content="0; url=README.html"/></head>
</html>
```

this version is for 8.2.x. If we're going to merge 8.2.x to main soon then #8247 can be closed.