### PR TITLE
[Fix] Wrong fix of cache use for STM32

### DIFF
--- a/ports/stm/supervisor/internal_flash.c
+++ b/ports/stm/supervisor/internal_flash.c
@@ -302,9 +302,9 @@ mp_uint_t supervisor_flash_read_blocks(uint8_t *dest, uint32_t block, uint32_t n
     uint32_t sector_start_addr;
     flash_get_sector_info(src, &sector_start_addr, &sector_size);
     // Count how many blocks are left in the sector
-    uint32_t count = (sector_size - (src - sector_start_addr)) / FILESYSTEM_BLOCK_SIZE;
+    uint32_t blocks_left_in_sector = (sector_size - (src - sector_start_addr)) / FILESYSTEM_BLOCK_SIZE;
 
-    if (count <= num_blocks && _cache_flash_addr == sector_start_addr) {
+    if (num_blocks <= blocks_left_in_sector && _cache_flash_addr == sector_start_addr) {
         // Read is contained in the cache, so just read cache
         memcpy(dest, (_flash_cache + (src - sector_start_addr)), FILESYSTEM_BLOCK_SIZE * num_blocks);
     } else {


### PR DESCRIPTION
As title, correcting #8235 (see comments)

Apparently i cant make PRs without introducing further isues :,) This should sort it out for once and for all. Didn't rename the argument because it is part of the API (also used on other functions) and didnt feel like changing every port's code just to get slightly-easier-to-read code.

@tannewt friendly ping 