### PR TITLE
Cache configuration descriptor

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1473,6 +1473,10 @@ msgstr ""
 msgid "No capture in progress"
 msgstr ""
 
+#: shared-module/usb/core/Device.c
+msgid "No configuration set"
+msgstr ""
+
 #: shared-bindings/_bleio/PacketBuffer.c
 msgid "No connection: length cannot be determined"
 msgstr ""

--- a/shared-bindings/usb/core/Device.c
+++ b/shared-bindings/usb/core/Device.c
@@ -123,7 +123,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(usb_core_device_get_manufacturer_obj, usb_core_device_
 MP_PROPERTY_GETTER(usb_core_device_manufacturer_obj,
     (mp_obj_t)&usb_core_device_get_manufacturer_obj);
 
-//|     def set_configuration(self, configuration=None):
+//|     def set_configuration(self, configuration=1):
 //|         """Set the active configuration.
 //|
 //|         The configuration parameter is the bConfigurationValue field of the
@@ -136,7 +136,7 @@ MP_PROPERTY_GETTER(usb_core_device_manufacturer_obj,
 STATIC mp_obj_t usb_core_device_set_configuration(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_configuration };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_configuration, MP_ARG_INT, {.u_int = 0x100} },
+        { MP_QSTR_configuration, MP_ARG_INT, {.u_int = 1} },
     };
     usb_core_device_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];

--- a/shared-module/usb/core/Device.h
+++ b/shared-module/usb/core/Device.h
@@ -32,7 +32,8 @@
 typedef struct {
     mp_obj_base_t base;
     uint8_t device_number;
-    uint8_t configuration_index; // not number
+    uint8_t configuration_index; // not bConfigurationValue
+    uint8_t *configuration_descriptor; // Contains the length of the all descriptors.
     uint8_t open_endpoints[8];
 } usb_core_device_obj_t;
 


### PR DESCRIPTION
We use it to open endpoints as they are used. Fetching the descriptor as needed can cause issues with devices that we're expecting a control packet while another transaction was ongoing. Specifically, a usb thumb drive didn't expect a control transaction while doing a SCSI transaction.

This PR also aborts transactions on timeout or ctrl-c interrupt. It doesn't always recover though...