### PR TITLE
Better alphablend features

### DIFF
--- a/ports/atmel-samd/boards/feather_m4_express/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/feather_m4_express/mpconfigboard.mk
@@ -11,6 +11,7 @@ EXTERNAL_FLASH_DEVICES = GD25Q16C
 LONGINT_IMPL = MPZ
 
 CIRCUITPY__EVE = 1
+CIRCUITPY_FLOPPYIO = 0
 CIRCUITPY_SYNTHIO = 0
 
 # We don't have room for the fonts for terminalio for certain languages,

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -320,8 +320,8 @@ MAKE_ENUM_TYPE(bitmaptools, BlendMode, bitmaptools_blendmode);
 //|     :param float factor2: The proportion of bitmap 2 to mix in.  If specified as `None`, ``1-factor1`` is used.  Usually the proportions should sum to 1.
 //|     :param displayio.Colorspace colorspace: The colorspace of the bitmaps. They must all have the same colorspace.  Only the following colorspaces are permitted:  ``L8``, ``RGB565``, ``RGB565_SWAPPED``, ``BGR565`` and ``BGR565_SWAPPED``.
 //|     :param bitmaptools.BlendMode blendmode: The blend mode to use. Default is Normal.
-//|     :param int skip_source1_index: bitmap palette index in source_bitmap_1 that will not be blended, set to None to blend all pixels
-//|     :param int skip_source2_index: bitmap palette index in source_bitmap_2 that will not be blended, set to None to blend all pixels
+//|     :param int skip_source1_index: Bitmap palette or luminance index in source_bitmap_1 that will not be blended, set to None to blend all pixels
+//|     :param int skip_source2_index: Bitmap palette or luminance index in source_bitmap_2 that will not be blended, set to None to blend all pixels
 //|
 //|     For the L8 colorspace, the bitmaps must have a bits-per-value of 8.
 //|     For the RGB colorspaces, they must have a bits-per-value of 16."""

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -126,27 +126,6 @@ STATIC void validate_clip_region(displayio_bitmap_t *bitmap, mp_obj_t clip0_tupl
 
 }
 
-MAKE_ENUM_VALUE(bitmaptools_blendmode_type, bitmaptools_blendmode, NORMAL, BITMAPTOOLS_BLENDMODE_NORMAL);
-MAKE_ENUM_VALUE(bitmaptools_blendmode_type, bitmaptools_blendmode, SCREEN, BITMAPTOOLS_BLENDMODE_SCREEN);
-
-//| class BlendMode:
-//|     """The blend mode for `alphablend` to operate use"""
-//|
-//|     NORMAL: Blendmode
-//|     """Blend with equal parts of the two source bitmaps"""
-//|
-//|     SCREEN: Blendmode
-//|     """Blend based on the value in each color channel. The result keeps the lighter colors and discards darker colors."""
-//|
-MAKE_ENUM_MAP(bitmaptools_blendmode) {
-    MAKE_ENUM_MAP_ENTRY(bitmaptools_blendmode, NORMAL),
-    MAKE_ENUM_MAP_ENTRY(bitmaptools_blendmode, SCREEN),
-};
-STATIC MP_DEFINE_CONST_DICT(bitmaptools_blendmode_locals_dict, bitmaptools_blendmode_locals_table);
-
-MAKE_PRINTER(bitmaptools, bitmaptools_blendmode);
-MAKE_ENUM_TYPE(bitmaptools, BlendMode, bitmaptools_blendmode);
-
 //| def rotozoom(
 //|     dest_bitmap: displayio.Bitmap,
 //|     source_bitmap: displayio.Bitmap,
@@ -295,6 +274,27 @@ STATIC mp_obj_t bitmaptools_obj_rotozoom(size_t n_args, const mp_obj_t *pos_args
 
 MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_rotozoom_obj, 0, bitmaptools_obj_rotozoom);
 
+//| class BlendMode:
+//|     """The blend mode for `alphablend` to operate use"""
+//|
+//|     Normal: BlendMode
+//|     """Blend with equal parts of the two source bitmaps"""
+//|
+//|     Screen: BlendMode
+//|     """Blend based on the value in each color channel. The result keeps the lighter colors and discards darker colors."""
+//|
+MAKE_ENUM_VALUE(bitmaptools_blendmode_type, bitmaptools_blendmode, Normal, BITMAPTOOLS_BLENDMODE_NORMAL);
+MAKE_ENUM_VALUE(bitmaptools_blendmode_type, bitmaptools_blendmode, Screen, BITMAPTOOLS_BLENDMODE_SCREEN);
+
+MAKE_ENUM_MAP(bitmaptools_blendmode) {
+    MAKE_ENUM_MAP_ENTRY(bitmaptools_blendmode, Normal),
+    MAKE_ENUM_MAP_ENTRY(bitmaptools_blendmode, Screen),
+};
+STATIC MP_DEFINE_CONST_DICT(bitmaptools_blendmode_locals_dict, bitmaptools_blendmode_locals_table);
+
+MAKE_PRINTER(bitmaptools, bitmaptools_blendmode);
+MAKE_ENUM_TYPE(bitmaptools, BlendMode, bitmaptools_blendmode);
+
 // requires at least 2 arguments (destination bitmap and source bitmap)
 
 //| def alphablend(
@@ -304,9 +304,9 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_rotozoom_obj, 0, bitmaptools_obj_rotozoom
 //|     colorspace: displayio.Colorspace,
 //|     factor1: float = 0.5,
 //|     factor2: Optional[float] = None,
-//|     blendmode: Optional[Blendmode] = Blendmode.NORMAL,
-//|     skip_source1_index: int,
-//|     skip_source2_index: int,
+//|     blendmode: Optional[BlendMode] = BlendMode.Normal,
+//|     skip_source1_index: Union[int, None] = None,
+//|     skip_source2_index: Union[int, None] = None,
 //| ) -> None:
 //|     """Alpha blend the two source bitmaps into the destination.
 //|
@@ -319,7 +319,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_rotozoom_obj, 0, bitmaptools_obj_rotozoom
 //|     :param float factor1: The proportion of bitmap 1 to mix in
 //|     :param float factor2: The proportion of bitmap 2 to mix in.  If specified as `None`, ``1-factor1`` is used.  Usually the proportions should sum to 1.
 //|     :param displayio.Colorspace colorspace: The colorspace of the bitmaps. They must all have the same colorspace.  Only the following colorspaces are permitted:  ``L8``, ``RGB565``, ``RGB565_SWAPPED``, ``BGR565`` and ``BGR565_SWAPPED``.
-//|     :param bitmaptools.BlendMode blendmode: The blend mode to use. Default is NORMAL.
+//|     :param bitmaptools.BlendMode blendmode: The blend mode to use. Default is Normal.
 //|     :param int skip_source1_index: bitmap palette index in source_bitmap_1 that will not be blended, set to None to blend all pixels
 //|     :param int skip_source2_index: bitmap palette index in source_bitmap_2 that will not be blended, set to None to blend all pixels
 //|
@@ -337,7 +337,7 @@ STATIC mp_obj_t bitmaptools_alphablend(size_t n_args, const mp_obj_t *pos_args, 
         {MP_QSTR_colorspace, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = NULL}},
         {MP_QSTR_factor_1, MP_ARG_OBJ, {.u_obj = MP_ROM_NONE}},
         {MP_QSTR_factor_2, MP_ARG_OBJ, {.u_obj = MP_ROM_NONE}},
-        {MP_QSTR_blendmode, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = (void *)&bitmaptools_blendmode_NORMAL_obj}},
+        {MP_QSTR_blendmode, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = (void *)&bitmaptools_blendmode_Normal_obj}},
         {MP_QSTR_skip_source1_index, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         {MP_QSTR_skip_source2_index, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
     };
@@ -1135,7 +1135,6 @@ STATIC const mp_rom_map_elem_t bitmaptools_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&bitmaptools_readinto_obj) },
     { MP_ROM_QSTR(MP_QSTR_rotozoom), MP_ROM_PTR(&bitmaptools_rotozoom_obj) },
     { MP_ROM_QSTR(MP_QSTR_arrayblit), MP_ROM_PTR(&bitmaptools_arrayblit_obj) },
-    { MP_ROM_QSTR(MP_QSTR_Blendmode), MP_ROM_PTR(&bitmaptools_blendmode_type) },
     { MP_ROM_QSTR(MP_QSTR_alphablend), MP_ROM_PTR(&bitmaptools_alphablend_obj) },
     { MP_ROM_QSTR(MP_QSTR_fill_region), MP_ROM_PTR(&bitmaptools_fill_region_obj) },
     { MP_ROM_QSTR(MP_QSTR_boundary_fill), MP_ROM_PTR(&bitmaptools_boundary_fill_obj) },
@@ -1144,6 +1143,7 @@ STATIC const mp_rom_map_elem_t bitmaptools_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_draw_circle), MP_ROM_PTR(&bitmaptools_draw_circle_obj) },
     { MP_ROM_QSTR(MP_QSTR_blit), MP_ROM_PTR(&bitmaptools_blit_obj) },
     { MP_ROM_QSTR(MP_QSTR_dither), MP_ROM_PTR(&bitmaptools_dither_obj) },
+    { MP_ROM_QSTR(MP_QSTR_BlendMode), MP_ROM_PTR(&bitmaptools_blendmode_type) },
     { MP_ROM_QSTR(MP_QSTR_DitherAlgorithm), MP_ROM_PTR(&bitmaptools_dither_algorithm_type) },
 };
 STATIC MP_DEFINE_CONST_DICT(bitmaptools_module_globals, bitmaptools_module_globals_table);

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -273,6 +273,28 @@ STATIC mp_obj_t bitmaptools_obj_rotozoom(size_t n_args, const mp_obj_t *pos_args
 }
 
 MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_rotozoom_obj, 0, bitmaptools_obj_rotozoom);
+
+MAKE_ENUM_VALUE(bitmaptools_blendmode_type, bitmaptools_blendmode, NORMAL, BITMAPTOOLS_BLENDMODE_NORMAL);
+MAKE_ENUM_VALUE(bitmaptools_blendmode_type, bitmaptools_blendmode, SCREEN, BITMAPTOOLS_BLENDMODE_SCREEN);
+
+//| class BlendMode:
+//|     """The blend mode for `alphablend` to operate use"""
+//|
+//|     NORMAL: Blendmode
+//|     """Blend with equal parts of the two source bitmaps"""
+//|
+//|     SCREEN: Blendmode
+//|     """Blend based on the value in each color channel. The result keeps the lighter colors and discards darker colors."""
+//|
+MAKE_ENUM_MAP(bitmaptools_blendmode) {
+    MAKE_ENUM_MAP_ENTRY(bitmaptools_blendmode, NORMAL),
+    MAKE_ENUM_MAP_ENTRY(bitmaptools_blendmode, SCREEN),
+};
+STATIC MP_DEFINE_CONST_DICT(bitmaptools_blendmode_locals_dict, bitmaptools_blendmode_locals_table);
+
+MAKE_PRINTER(bitmaptools, bitmaptools_blendmode);
+MAKE_ENUM_TYPE(bitmaptools, BlendMode, bitmaptools_blendmode);
+
 // requires at least 2 arguments (destination bitmap and source bitmap)
 
 //| def alphablend(
@@ -282,6 +304,9 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_rotozoom_obj, 0, bitmaptools_obj_rotozoom
 //|     colorspace: displayio.Colorspace,
 //|     factor1: float = 0.5,
 //|     factor2: Optional[float] = None,
+//|     blendmode: Optional[Blendmode] = Blendmode.NORMAL,
+//|     skip_source1_index: int,
+//|     skip_source2_index: int,
 //| ) -> None:
 //|     """Alpha blend the two source bitmaps into the destination.
 //|
@@ -294,13 +319,18 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_rotozoom_obj, 0, bitmaptools_obj_rotozoom
 //|     :param float factor1: The proportion of bitmap 1 to mix in
 //|     :param float factor2: The proportion of bitmap 2 to mix in.  If specified as `None`, ``1-factor1`` is used.  Usually the proportions should sum to 1.
 //|     :param displayio.Colorspace colorspace: The colorspace of the bitmaps. They must all have the same colorspace.  Only the following colorspaces are permitted:  ``L8``, ``RGB565``, ``RGB565_SWAPPED``, ``BGR565`` and ``BGR565_SWAPPED``.
+//|     :param bitmaptools.BlendMode blendmode: The blend mode to use. Default is NORMAL.
+//|     :param int skip_source1_index: bitmap palette index in the source that will not be blended,
+//|                            set to None to blended all pixels
+//|     :param int skip_source2_index: bitmap palette index in the source that will not be blended,
+//|                            set to None to blended all pixels
 //|
 //|     For the L8 colorspace, the bitmaps must have a bits-per-value of 8.
 //|     For the RGB colorspaces, they must have a bits-per-value of 16."""
 //|
 
 STATIC mp_obj_t bitmaptools_alphablend(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum {ARG_dest_bitmap, ARG_source_bitmap_1, ARG_source_bitmap_2, ARG_colorspace, ARG_factor_1, ARG_factor_2};
+    enum {ARG_dest_bitmap, ARG_source_bitmap_1, ARG_source_bitmap_2, ARG_colorspace, ARG_factor_1, ARG_factor_2, ARG_blendmode, ARG_skip_source1_index, ARG_skip_source2_index};
 
     static const mp_arg_t allowed_args[] = {
         {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = NULL}},
@@ -309,6 +339,9 @@ STATIC mp_obj_t bitmaptools_alphablend(size_t n_args, const mp_obj_t *pos_args, 
         {MP_QSTR_colorspace, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = NULL}},
         {MP_QSTR_factor_1, MP_ARG_OBJ, {.u_obj = MP_ROM_NONE}},
         {MP_QSTR_factor_2, MP_ARG_OBJ, {.u_obj = MP_ROM_NONE}},
+        {MP_QSTR_blendmode, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = (void *)&bitmaptools_blendmode_NORMAL_obj}},
+        {MP_QSTR_skip_source1_index, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        {MP_QSTR_skip_source2_index, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -321,6 +354,7 @@ STATIC mp_obj_t bitmaptools_alphablend(size_t n_args, const mp_obj_t *pos_args, 
     mp_float_t factor2 = (args[ARG_factor_2].u_obj == mp_const_none) ? 1 - factor1 : mp_obj_get_float(args[ARG_factor_2].u_obj);
 
     displayio_colorspace_t colorspace = (displayio_colorspace_t)cp_enum_value(&displayio_colorspace_type, args[ARG_colorspace].u_obj, MP_QSTR_colorspace);
+    bitmaptools_blendmode_t blendmode = (bitmaptools_blendmode_t)cp_enum_value(&bitmaptools_blendmode_type, args[ARG_blendmode].u_obj, MP_QSTR_blendmode);
 
     if (destination->width != source1->width
         || destination->height != source1->height
@@ -352,7 +386,30 @@ STATIC mp_obj_t bitmaptools_alphablend(size_t n_args, const mp_obj_t *pos_args, 
             mp_raise_ValueError(translate("Unsupported colorspace"));
     }
 
-    common_hal_bitmaptools_alphablend(destination, source1, source2, colorspace, factor1, factor2);
+    uint32_t skip_source1_index;
+    bool skip_source1_index_none; // flag whether skip_value was None
+
+    if (args[ARG_skip_source1_index].u_obj == mp_const_none) {
+        skip_source1_index = 0;
+        skip_source1_index_none = true;
+    } else {
+        skip_source1_index = mp_obj_get_int(args[ARG_skip_source1_index].u_obj);
+        skip_source1_index_none = false;
+    }
+
+    uint32_t skip_source2_index;
+    bool skip_source2_index_none; // flag whether skip_self_value was None
+
+    if (args[ARG_skip_source2_index].u_obj == mp_const_none) {
+        skip_source2_index = 0;
+        skip_source2_index_none = true;
+    } else {
+        skip_source2_index = mp_obj_get_int(args[ARG_skip_source2_index].u_obj);
+        skip_source2_index_none = false;
+    }
+
+    common_hal_bitmaptools_alphablend(destination, source1, source2, colorspace, factor1, factor2, blendmode, skip_source1_index,
+        skip_source1_index_none, skip_source2_index, skip_source2_index_none);
 
     return mp_const_none;
 }
@@ -1080,6 +1137,7 @@ STATIC const mp_rom_map_elem_t bitmaptools_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&bitmaptools_readinto_obj) },
     { MP_ROM_QSTR(MP_QSTR_rotozoom), MP_ROM_PTR(&bitmaptools_rotozoom_obj) },
     { MP_ROM_QSTR(MP_QSTR_arrayblit), MP_ROM_PTR(&bitmaptools_arrayblit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_Blendmode), MP_ROM_PTR(&bitmaptools_blendmode_type) },
     { MP_ROM_QSTR(MP_QSTR_alphablend), MP_ROM_PTR(&bitmaptools_alphablend_obj) },
     { MP_ROM_QSTR(MP_QSTR_fill_region), MP_ROM_PTR(&bitmaptools_fill_region_obj) },
     { MP_ROM_QSTR(MP_QSTR_boundary_fill), MP_ROM_PTR(&bitmaptools_boundary_fill_obj) },

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -126,6 +126,27 @@ STATIC void validate_clip_region(displayio_bitmap_t *bitmap, mp_obj_t clip0_tupl
 
 }
 
+MAKE_ENUM_VALUE(bitmaptools_blendmode_type, bitmaptools_blendmode, NORMAL, BITMAPTOOLS_BLENDMODE_NORMAL);
+MAKE_ENUM_VALUE(bitmaptools_blendmode_type, bitmaptools_blendmode, SCREEN, BITMAPTOOLS_BLENDMODE_SCREEN);
+
+//| class BlendMode:
+//|     """The blend mode for `alphablend` to operate use"""
+//|
+//|     NORMAL: Blendmode
+//|     """Blend with equal parts of the two source bitmaps"""
+//|
+//|     SCREEN: Blendmode
+//|     """Blend based on the value in each color channel. The result keeps the lighter colors and discards darker colors."""
+//|
+MAKE_ENUM_MAP(bitmaptools_blendmode) {
+    MAKE_ENUM_MAP_ENTRY(bitmaptools_blendmode, NORMAL),
+    MAKE_ENUM_MAP_ENTRY(bitmaptools_blendmode, SCREEN),
+};
+STATIC MP_DEFINE_CONST_DICT(bitmaptools_blendmode_locals_dict, bitmaptools_blendmode_locals_table);
+
+MAKE_PRINTER(bitmaptools, bitmaptools_blendmode);
+MAKE_ENUM_TYPE(bitmaptools, BlendMode, bitmaptools_blendmode);
+
 //| def rotozoom(
 //|     dest_bitmap: displayio.Bitmap,
 //|     source_bitmap: displayio.Bitmap,
@@ -274,27 +295,6 @@ STATIC mp_obj_t bitmaptools_obj_rotozoom(size_t n_args, const mp_obj_t *pos_args
 
 MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_rotozoom_obj, 0, bitmaptools_obj_rotozoom);
 
-MAKE_ENUM_VALUE(bitmaptools_blendmode_type, bitmaptools_blendmode, NORMAL, BITMAPTOOLS_BLENDMODE_NORMAL);
-MAKE_ENUM_VALUE(bitmaptools_blendmode_type, bitmaptools_blendmode, SCREEN, BITMAPTOOLS_BLENDMODE_SCREEN);
-
-//| class BlendMode:
-//|     """The blend mode for `alphablend` to operate use"""
-//|
-//|     NORMAL: Blendmode
-//|     """Blend with equal parts of the two source bitmaps"""
-//|
-//|     SCREEN: Blendmode
-//|     """Blend based on the value in each color channel. The result keeps the lighter colors and discards darker colors."""
-//|
-MAKE_ENUM_MAP(bitmaptools_blendmode) {
-    MAKE_ENUM_MAP_ENTRY(bitmaptools_blendmode, NORMAL),
-    MAKE_ENUM_MAP_ENTRY(bitmaptools_blendmode, SCREEN),
-};
-STATIC MP_DEFINE_CONST_DICT(bitmaptools_blendmode_locals_dict, bitmaptools_blendmode_locals_table);
-
-MAKE_PRINTER(bitmaptools, bitmaptools_blendmode);
-MAKE_ENUM_TYPE(bitmaptools, BlendMode, bitmaptools_blendmode);
-
 // requires at least 2 arguments (destination bitmap and source bitmap)
 
 //| def alphablend(
@@ -320,10 +320,8 @@ MAKE_ENUM_TYPE(bitmaptools, BlendMode, bitmaptools_blendmode);
 //|     :param float factor2: The proportion of bitmap 2 to mix in.  If specified as `None`, ``1-factor1`` is used.  Usually the proportions should sum to 1.
 //|     :param displayio.Colorspace colorspace: The colorspace of the bitmaps. They must all have the same colorspace.  Only the following colorspaces are permitted:  ``L8``, ``RGB565``, ``RGB565_SWAPPED``, ``BGR565`` and ``BGR565_SWAPPED``.
 //|     :param bitmaptools.BlendMode blendmode: The blend mode to use. Default is NORMAL.
-//|     :param int skip_source1_index: bitmap palette index in the source that will not be blended,
-//|                            set to None to blended all pixels
-//|     :param int skip_source2_index: bitmap palette index in the source that will not be blended,
-//|                            set to None to blended all pixels
+//|     :param int skip_source1_index: bitmap palette index in source_bitmap_1 that will not be blended, set to None to blend all pixels
+//|     :param int skip_source2_index: bitmap palette index in source_bitmap_2 that will not be blended, set to None to blend all pixels
 //|
 //|     For the L8 colorspace, the bitmaps must have a bits-per-value of 8.
 //|     For the RGB colorspaces, they must have a bits-per-value of 16."""

--- a/shared-bindings/bitmaptools/__init__.h
+++ b/shared-bindings/bitmaptools/__init__.h
@@ -40,6 +40,11 @@ typedef enum {
 
 extern const mp_obj_type_t bitmaptools_dither_algorithm_type;
 
+typedef enum bitmaptools_blendmode {
+    BITMAPTOOLS_BLENDMODE_NORMAL,
+    BITMAPTOOLS_BLENDMODE_SCREEN,
+} bitmaptools_blendmode_t;
+
 void common_hal_bitmaptools_rotozoom(displayio_bitmap_t *self, int16_t ox, int16_t oy,
     int16_t dest_clip0_x, int16_t dest_clip0_y,
     int16_t dest_clip1_x, int16_t dest_clip1_y,
@@ -78,6 +83,10 @@ void common_hal_bitmaptools_readinto(displayio_bitmap_t *self, mp_obj_t *file, i
 void common_hal_bitmaptools_arrayblit(displayio_bitmap_t *self, void *data, int element_size, int x1, int y1, int x2, int y2, bool skip_specified, uint32_t skip_index);
 void common_hal_bitmaptools_dither(displayio_bitmap_t *dest_bitmap, displayio_bitmap_t *source_bitmap, displayio_colorspace_t colorspace, bitmaptools_dither_algorithm_t algorithm);
 
-void common_hal_bitmaptools_alphablend(displayio_bitmap_t *destination, displayio_bitmap_t *source1, displayio_bitmap_t *source2, displayio_colorspace_t colorspace, mp_float_t factor1, mp_float_t factor2);
+void common_hal_bitmaptools_alphablend(displayio_bitmap_t *destination, displayio_bitmap_t *source1, displayio_bitmap_t *source2, displayio_colorspace_t colorspace, mp_float_t factor1, mp_float_t factor2,
+    bitmaptools_blendmode_t blendmode, uint32_t skip_source1_index, bool skip_source1_index_none, uint32_t skip_source2_index, bool skip_source2_index_none);
+
+extern const mp_obj_type_t bitmaptools_blendmode_type;
+extern const cp_enum_obj_t bitmaptools_blendmode_NORMAL_obj;
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_BITMAPTOOLS__INIT__H

--- a/shared-bindings/bitmaptools/__init__.h
+++ b/shared-bindings/bitmaptools/__init__.h
@@ -40,10 +40,12 @@ typedef enum {
 
 extern const mp_obj_type_t bitmaptools_dither_algorithm_type;
 
-typedef enum bitmaptools_blendmode {
-    BITMAPTOOLS_BLENDMODE_NORMAL,
-    BITMAPTOOLS_BLENDMODE_SCREEN,
+typedef enum {
+    BITMAPTOOLS_BLENDMODE_NORMAL, BITMAPTOOLS_BLENDMODE_SCREEN,
 } bitmaptools_blendmode_t;
+
+extern const mp_obj_type_t bitmaptools_blendmode_type;
+extern const cp_enum_obj_t bitmaptools_blendmode_Normal_obj;
 
 void common_hal_bitmaptools_rotozoom(displayio_bitmap_t *self, int16_t ox, int16_t oy,
     int16_t dest_clip0_x, int16_t dest_clip0_y,
@@ -85,8 +87,5 @@ void common_hal_bitmaptools_dither(displayio_bitmap_t *dest_bitmap, displayio_bi
 
 void common_hal_bitmaptools_alphablend(displayio_bitmap_t *destination, displayio_bitmap_t *source1, displayio_bitmap_t *source2, displayio_colorspace_t colorspace, mp_float_t factor1, mp_float_t factor2,
     bitmaptools_blendmode_t blendmode, uint32_t skip_source1_index, bool skip_source1_index_none, uint32_t skip_source2_index, bool skip_source2_index_none);
-
-extern const mp_obj_type_t bitmaptools_blendmode_type;
-extern const cp_enum_obj_t bitmaptools_blendmode_NORMAL_obj;
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_BITMAPTOOLS__INIT__H

--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -972,10 +972,16 @@ void common_hal_bitmaptools_alphablend(displayio_bitmap_t *dest, displayio_bitma
                     }
                 } else if (blend_source1) {
                     // Apply iFactor1 to source1 only
-                    pixel = spix1 * ifactor1 / 256;
+                    int r = (spix1 & r_mask) * ifactor1 / 256;
+                    int g = (spix1 & g_mask) * ifactor1 / 256;
+                    int b = (spix1 & b_mask) * ifactor1 / 256;
+                    pixel = r | g | b;
                 } else if (blend_source2) {
                     // Apply iFactor2 to source1 only
-                    pixel = spix2 * ifactor2 / 256;
+                    int r = (spix2 & r_mask) * ifactor2 / 256;
+                    int g = (spix2 & g_mask) * ifactor2 / 256;
+                    int b = (spix2 & b_mask) * ifactor2 / 256;
+                    pixel = r | g | b;
                 } else {
                     // Use the destination value
                     pixel = *dptr;

--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -881,8 +881,8 @@ void common_hal_bitmaptools_alphablend(displayio_bitmap_t *dest, displayio_bitma
                 blend_source2 = skip_source2_index_none || *sptr2 != (uint8_t)skip_source2_index;
                 if (blend_source1 && blend_source2) {
                     // Premultiply by the alpha factor
-                    int sca1 = *sptr1++ * ifactor1;
-                    int sca2 = *sptr2++ * ifactor2;
+                    int sca1 = *sptr1++ *ifactor1;
+                    int sca2 = *sptr2++ *ifactor2;
                     // Blend
                     int blend;
                     if (blendmode == BITMAPTOOLS_BLENDMODE_SCREEN) {
@@ -894,10 +894,10 @@ void common_hal_bitmaptools_alphablend(displayio_bitmap_t *dest, displayio_bitma
                     pixel = (blend / (256 * ifactor1 + 256 * ifactor2 - ifactor1 * ifactor2));
                 } else if (blend_source1) {
                     // Apply iFactor1 to source1 only
-                    pixel = *sptr1++ * ifactor1 / 256;
+                    pixel = *sptr1++ *ifactor1 / 256;
                 } else if (blend_source2) {
                     // Apply iFactor2 to source1 only
-                    pixel = *sptr2++ * ifactor2 / 256;
+                    pixel = *sptr2++ *ifactor2 / 256;
                 } else {
                     // Use the destination value
                     pixel = *dptr;

--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -894,10 +894,10 @@ void common_hal_bitmaptools_alphablend(displayio_bitmap_t *dest, displayio_bitma
                     pixel = (blend / (256 * ifactor1 + 256 * ifactor2 - ifactor1 * ifactor2));
                 } else if (blend_source1) {
                     // Apply iFactor1 to source1 only
-                    pixel = *sptr1++ *ifactor1 / 256;
+                    pixel = *sptr1++ * ifactor1 / 256;
                 } else if (blend_source2) {
                     // Apply iFactor2 to source1 only
-                    pixel = *sptr2++ *ifactor2 / 256;
+                    pixel = *sptr2++ * ifactor2 / 256;
                 } else {
                     // Use the destination value
                     pixel = *dptr;


### PR DESCRIPTION
This PR updates the alphablend function and adds some useful features. It allows skipping a color mask in either source file as well as updating the blending algorithm to use the same one the SVG alpha compositing spec uses. I only added a couple, but this change allows for adding additional blending methods in the future. The result of changing the algorithm is that it handles blending the darker colors much better than the existing code.