### PR TITLE
SPI().deinit() fix

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1558,6 +1558,7 @@ msgid "Number of data_pins must be 8 or 16, not %d"
 msgstr ""
 
 #: shared-bindings/util.c
+#: shared-bindings/displayio/FourWire.c
 msgid ""
 "Object has been deinitialized and can no longer be used. Create a new object."
 msgstr ""

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1557,8 +1557,7 @@ msgstr ""
 msgid "Number of data_pins must be 8 or 16, not %d"
 msgstr ""
 
-#: shared-bindings/util.c
-#: shared-bindings/displayio/FourWire.c
+#: shared-bindings/util.c shared-module/displayio/FourWire.c
 msgid ""
 "Object has been deinitialized and can no longer be used. Create a new object."
 msgstr ""

--- a/shared-module/displayio/FourWire.c
+++ b/shared-module/displayio/FourWire.c
@@ -29,12 +29,14 @@
 #include <stdint.h>
 
 #include "py/gc.h"
+#include "py/runtime.h"
 #include "shared-bindings/busio/SPI.h"
 #include "shared-bindings/digitalio/DigitalInOut.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/time/__init__.h"
 #include "shared-module/displayio/display_core.h"
+#include "supervisor/shared/translate/translate.h"
 
 void common_hal_displayio_fourwire_construct(displayio_fourwire_obj_t *self,
     busio_spi_obj_t *spi, const mcu_pin_obj_t *command,
@@ -74,7 +76,7 @@ void common_hal_displayio_fourwire_construct(displayio_fourwire_obj_t *self,
 }
 
 void common_hal_displayio_fourwire_deinit(displayio_fourwire_obj_t *self) {
-    if (self->bus == &self->inline_bus) {
+    if (!(common_hal_busio_spi_deinited(self->bus)) && (self->bus == &self->inline_bus)) {
         common_hal_busio_spi_deinit(self->bus);
     }
 
@@ -106,6 +108,10 @@ bool common_hal_displayio_fourwire_bus_free(mp_obj_t obj) {
 
 bool common_hal_displayio_fourwire_begin_transaction(mp_obj_t obj) {
     displayio_fourwire_obj_t *self = MP_OBJ_TO_PTR(obj);
+    if (common_hal_busio_spi_deinited(self->bus)) {
+        common_hal_displayio_fourwire_deinit(self);
+        mp_raise_ValueError(translate("Object has been deinitialized and can no longer be used. Create a new object."));
+    }
     if (!common_hal_busio_spi_try_lock(self->bus)) {
         return false;
     }

--- a/shared-module/displayio/FourWire.c
+++ b/shared-module/displayio/FourWire.c
@@ -29,14 +29,12 @@
 #include <stdint.h>
 
 #include "py/gc.h"
-#include "py/runtime.h"
 #include "shared-bindings/busio/SPI.h"
 #include "shared-bindings/digitalio/DigitalInOut.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/time/__init__.h"
 #include "shared-module/displayio/display_core.h"
-#include "supervisor/shared/translate/translate.h"
 
 void common_hal_displayio_fourwire_construct(displayio_fourwire_obj_t *self,
     busio_spi_obj_t *spi, const mcu_pin_obj_t *command,
@@ -99,7 +97,7 @@ bool common_hal_displayio_fourwire_reset(mp_obj_t obj) {
 
 bool common_hal_displayio_fourwire_bus_free(mp_obj_t obj) {
     displayio_fourwire_obj_t *self = MP_OBJ_TO_PTR(obj);
-    if (!common_hal_busio_spi_try_lock(self->bus)) {
+    if (common_hal_busio_spi_deinited(self->bus) || !common_hal_busio_spi_try_lock(self->bus)) {
         return false;
     }
     common_hal_busio_spi_unlock(self->bus);
@@ -110,7 +108,7 @@ bool common_hal_displayio_fourwire_begin_transaction(mp_obj_t obj) {
     displayio_fourwire_obj_t *self = MP_OBJ_TO_PTR(obj);
     if (common_hal_busio_spi_deinited(self->bus)) {
         common_hal_displayio_fourwire_deinit(self);
-        mp_raise_ValueError(translate("Object has been deinitialized and can no longer be used. Create a new object."));
+        return false;
     }
     if (!common_hal_busio_spi_try_lock(self->bus)) {
         return false;

--- a/shared-module/displayio/display_core.c
+++ b/shared-module/displayio/display_core.c
@@ -252,7 +252,9 @@ void displayio_display_core_set_region_to_update(displayio_display_core_t *self,
     }
 
     // Set column.
-    displayio_display_core_begin_transaction(self);
+    if (!displayio_display_core_begin_transaction(self)) {
+        return;
+    }
     uint8_t data[5];
     data[0] = self->column_command;
     uint8_t data_length = 1;


### PR DESCRIPTION
When the `board.SPI()` bus is deinitialised, it will fail on the next display write with a valuerror and deinit the display.
The error already exists, so no binary size increase.

Closes #8278 

Tested on my display-swapped feather s3 tft.