### PR TITLE
improve hard fault message

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -31,8 +31,8 @@ msgstr ""
 #: supervisor/shared/safe_mode.c
 msgid ""
 "\n"
-"Please file an issue with your program at https://github.com/adafruit/"
-"circuitpython/issues."
+"Please file an issue with your program at github.com/adafruit/circuitpython/"
+"issues."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -633,11 +633,6 @@ msgstr ""
 msgid "Buffer is not a bytearray."
 msgstr ""
 
-#: ports/cxd56/common-hal/camera/Camera.c shared-bindings/displayio/Display.c
-#: shared-bindings/framebufferio/FramebufferDisplay.c
-msgid "Buffer is too small"
-msgstr ""
-
 #: ports/stm/common-hal/audiopwmio/PWMAudioOut.c
 #, c-format
 msgid "Buffer length %d too big. It must be less than %d"
@@ -655,6 +650,12 @@ msgstr ""
 #: shared-bindings/_bleio/PacketBuffer.c
 #, c-format
 msgid "Buffer too short by %d bytes"
+msgstr ""
+
+#: ports/cxd56/common-hal/camera/Camera.c shared-bindings/displayio/Display.c
+#: shared-bindings/framebufferio/FramebufferDisplay.c
+#: shared-bindings/struct/__init__.c shared-module/struct/__init__.c
+msgid "Buffer too small"
 msgstr ""
 
 #: ports/espressif/common-hal/imagecapture/ParallelImageCapture.c
@@ -1786,6 +1787,10 @@ msgstr ""
 msgid "Polygon needs at least 3 points"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Power dipped. Make sure you are providing enough power."
+msgstr ""
+
 #: shared-bindings/_bleio/Adapter.c
 msgid "Prefix buffer must be on the heap"
 msgstr ""
@@ -2014,10 +2019,6 @@ msgstr ""
 
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 msgid "The length of rgb_pins must be 6, 12, 18, 24, or 30"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "The power dipped. Make sure you are providing enough power."
 msgstr ""
 
 #: shared-module/audiomixer/MixerVoice.c
@@ -2605,8 +2606,7 @@ msgstr ""
 msgid "buffer slices must be of equal length"
 msgstr ""
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
-#: shared-module/struct/__init__.c
+#: py/modstruct.c shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr ""
 
@@ -3861,10 +3861,6 @@ msgstr ""
 
 #: shared-bindings/bitmaptools/__init__.c
 msgid "pixel coordinates out of bounds"
-msgstr ""
-
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
-msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 msgstr ""
 
 #: extmod/vfs_posix_file.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -182,6 +182,7 @@ msgid "%q must be 1 when %q is True"
 msgstr ""
 
 #: py/argcheck.c shared-bindings/gifio/GifWriter.c
+#: shared-module/gifio/OnDiskGif.c
 msgid "%q must be <= %d"
 msgstr ""
 
@@ -1006,10 +1007,6 @@ msgstr ""
 msgid "Failed to write internal flash."
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid "Fault detected by hardware."
-msgstr ""
-
 #: py/moduerrno.c
 msgid "File exists"
 msgstr ""
@@ -1083,6 +1080,10 @@ msgstr ""
 #: ports/mimxrt10xx/common-hal/busio/SPI.c ports/nrf/common-hal/busio/SPI.c
 #: ports/raspberrypi/common-hal/busio/SPI.c
 msgid "Half duplex SPI is not implemented"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Hard fault: memory access or instruction error."
 msgstr ""
 
 #: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/I2C.c
@@ -1948,10 +1949,6 @@ msgstr ""
 
 #: ports/cxd56/common-hal/camera/Camera.c
 msgid "Size not supported"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/alarm/SleepMemory.c
-msgid "Sleep Memory not available"
 msgstr ""
 
 #: shared-bindings/alarm/SleepMemory.c shared-bindings/memorymap/AddressRange.c

--- a/ports/cxd56/common-hal/camera/Camera.c
+++ b/ports/cxd56/common-hal/camera/Camera.c
@@ -184,7 +184,7 @@ size_t common_hal_camera_take_picture(camera_obj_t *self, uint8_t *buffer, size_
         mp_raise_ValueError(translate("Size not supported"));
     }
     if (!camera_check_buffer_length(width, height, format, len)) {
-        mp_raise_ValueError(translate("Buffer is too small"));
+        mp_raise_ValueError(translate("Buffer too small"));
     }
     if (!camera_check_format(format)) {
         mp_raise_ValueError(translate("Format not supported"));

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -506,7 +506,7 @@ STATIC mp_obj_t displayio_display_obj_fill_row(size_t n_args, const mp_obj_t *po
         displayio_display_core_fill_area(&self->core, &area, mask, result_buffer);
         return result;
     } else {
-        mp_raise_ValueError(translate("Buffer is too small"));
+        mp_raise_ValueError(translate("Buffer too small"));
     }
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(displayio_display_fill_row_obj, 1, displayio_display_obj_fill_row);

--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -351,7 +351,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(displayio_tilegrid_get_pixel_shader_obj, displayio_til
 STATIC mp_obj_t displayio_tilegrid_obj_set_pixel_shader(mp_obj_t self_in, mp_obj_t pixel_shader) {
     displayio_tilegrid_t *self = native_tilegrid(self_in);
     if (!mp_obj_is_type(pixel_shader, &displayio_palette_type) && !mp_obj_is_type(pixel_shader, &displayio_colorconverter_type)) {
-        mp_raise_TypeError(translate("pixel_shader must be displayio.Palette or displayio.ColorConverter"));
+        mp_raise_TypeError_varg(translate("unsupported %q type"), MP_QSTR_pixel_shader);
     }
 
     common_hal_displayio_tilegrid_set_pixel_shader(self, pixel_shader);

--- a/shared-bindings/framebufferio/FramebufferDisplay.c
+++ b/shared-bindings/framebufferio/FramebufferDisplay.c
@@ -317,7 +317,7 @@ STATIC mp_obj_t framebufferio_framebufferdisplay_obj_fill_row(size_t n_args, con
         displayio_display_core_fill_area(&self->core, &area, mask, result_buffer);
         return result;
     } else {
-        mp_raise_ValueError(translate("Buffer is too small"));
+        mp_raise_ValueError(translate("Buffer too small"));
     }
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(framebufferio_framebufferdisplay_fill_row_obj, 1, framebufferio_framebufferdisplay_obj_fill_row);

--- a/shared-bindings/struct/__init__.c
+++ b/shared-bindings/struct/__init__.c
@@ -92,7 +92,7 @@ STATIC mp_obj_t struct_pack_into(size_t n_args, const mp_obj_t *args) {
         // negative offsets are relative to the end of the buffer
         offset = (mp_int_t)bufinfo.len + offset;
         if (offset < 0) {
-            mp_raise_RuntimeError(translate("buffer too small"));
+            mp_raise_RuntimeError(translate("Buffer too small"));
         }
     }
     byte *p = (byte *)bufinfo.buf;
@@ -151,7 +151,7 @@ STATIC mp_obj_t struct_unpack_from(size_t n_args, const mp_obj_t *pos_args, mp_m
         // negative offsets are relative to the end of the buffer
         offset = bufinfo.len + offset;
         if (offset < 0) {
-            mp_raise_RuntimeError(translate("buffer too small"));
+            mp_raise_RuntimeError(translate("Buffer too small"));
         }
     }
     p += offset;

--- a/shared-bindings/vectorio/VectorShape.c
+++ b/shared-bindings/vectorio/VectorShape.c
@@ -226,7 +226,7 @@ STATIC mp_obj_t vectorio_vector_shape_obj_set_pixel_shader(mp_obj_t wrapper_shap
     vectorio_vector_shape_t *self = MP_OBJ_TO_PTR(draw_protocol->draw_get_protocol_self(wrapper_shape));
 
     if (!mp_obj_is_type(pixel_shader, &displayio_palette_type) && !mp_obj_is_type(pixel_shader, &displayio_colorconverter_type)) {
-        mp_raise_TypeError(translate("pixel_shader must be displayio.Palette or displayio.ColorConverter"));
+        mp_raise_TypeError_varg(translate("unsupported %q type"), MP_QSTR_pixel_shader);
     }
 
     common_hal_vectorio_vector_shape_set_pixel_shader(self, pixel_shader);

--- a/shared-module/struct/__init__.c
+++ b/shared-module/struct/__init__.c
@@ -126,7 +126,7 @@ void shared_modules_struct_pack_into(mp_obj_t fmt_in, byte *p, byte *end_p, size
     const mp_uint_t total_sz = shared_modules_struct_calcsize(fmt_in);
 
     if (p + total_sz > end_p) {
-        mp_raise_RuntimeError(translate("buffer too small"));
+        mp_raise_RuntimeError(translate("Buffer too small"));
     }
 
     size_t i = 0;

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -209,7 +209,7 @@ void print_safe_mode_message(safe_mode_t reason) {
                 message = translate("Failed to write internal flash.");
                 break;
             case SAFE_MODE_HARD_FAULT:
-                message = translate("Fault detected by hardware.");
+                message = translate("Hard fault: memory access or instruction error.");
                 break;
             case SAFE_MODE_INTERRUPT_ERROR:
                 message = translate("Interrupt error.");

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -154,7 +154,7 @@ void print_safe_mode_message(safe_mode_t reason) {
 
     switch (reason) {
         case SAFE_MODE_BROWNOUT:
-            message = translate("The power dipped. Make sure you are providing enough power.");
+            message = translate("Power dipped. Make sure you are providing enough power.");
             break;
         case SAFE_MODE_USER:
             #if defined(BOARD_USER_SAFE_MODE_ACTION)
@@ -228,7 +228,7 @@ void print_safe_mode_message(safe_mode_t reason) {
                 break;
         }
         serial_write_compressed(message);
-        serial_write_compressed(translate("\nPlease file an issue with your program at https://github.com/adafruit/circuitpython/issues."));
+        serial_write_compressed(translate("\nPlease file an issue with your program at github.com/adafruit/circuitpython/issues."));
     }
 
     // Always tell user how to get out of safe mode.


### PR DESCRIPTION
I reworked the safe mode messages in #7577. I rewrote
`"Crash into the HardFault_Handler."` to be
`"Fault detected by hardware."`.

This turns out to be confusing, because it sounds like the hardware is failing. This PR changes it to
`"Hard fault: memory access or instruction error."`
which is the definition of hard fault on most CPU's.

I made this change in 8.2.x to get it into the next 8.2.x release, and it can be merged up into `main`.