### PR TITLE
canio: add a doc note about boards like CAN feather that use mcp2515

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -443,6 +443,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {"cpython": ('https://docs.python.org/3/', None),
                        "register": ('https://circuitpython.readthedocs.io/projects/register/en/latest/', None),
+                       "mcp2515": ('https://circuitpython.readthedocs.io/projects/mcp2515/en/latest/', None),
                        "typing": ('https://circuitpython.readthedocs.io/projects/adafruit-circuitpython-typing/en/latest/', None)}
 
 # Adapted from sphinxcontrib-redirects

--- a/shared-bindings/canio/__init__.c
+++ b/shared-bindings/canio/__init__.c
@@ -27,7 +27,10 @@
 //| """CAN bus access
 //|
 //| The `canio` module contains low level classes to support the CAN bus
-//| protocol.
+//| protocol on microcontrollers that have built-in CAN peripherals.
+//|
+//| Boards like the Adafruit RP2040 CAN Bus Feather that use an MCP2515 or
+//| compatible chip use the `mcp2515:adafruit_mcp2515` module instead.
 //|
 //| CAN and Listener classes change hardware state and should be deinitialized when they
 //| are no longer needed if the program continues after use. To do so, either


### PR DESCRIPTION
Prompted by a user on discord who asked why `canio` cannot be imported on the Adafruit RP2040 CAN Bus Feather

![image](https://github.com/adafruit/circuitpython/assets/1517291/e8ae131e-627d-4e8e-a2f7-e7ce8261aea4)
