### PR TITLE
Fix displayio when CIRCUITPY_REPL_LOGO is disabled

### DIFF
--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -128,10 +128,8 @@ void supervisor_start_terminal(uint16_t width_px, uint16_t height_px) {
         status_bar->full_change = true;
 
         scroll_area->width_in_tiles = width_in_tiles;
-        scroll_area->height_in_tiles = height_in_tiles;
-        #if CIRCUITPY_REPL_LOGO
-        scroll_area->height_in_tiles -= 1;
-        #endif
+        // Leave space for the status bar, no matter if we have logo or not.
+        scroll_area->height_in_tiles = height_in_tiles - 1;
         scroll_area->pixel_width = scroll_area->width_in_tiles * scroll_area->tile_width;
         scroll_area->pixel_height = scroll_area->height_in_tiles * scroll_area->tile_height;
         // Right align the scroll area to give margin to the start of each line.

--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -195,7 +195,7 @@ def set_boards(build_all: bool):
                     # Check supervisor files
                     # This is useful for limiting workflow changes to the relevant boards
                     if file.startswith("supervisor"):
-                        if file in settings["SRC_SUPERVISOR"]:
+                        if file in settings.get("SRC_SUPERVISOR", ""):
                             boards_to_build.add(board)
                             continue
 


### PR DESCRIPTION
We have to make room for the status bar no matter if the logo is enabled or not. We probably should add a similar option for disabling the status bar.

This makes the PewPew M4 port stop crashing.