### PR TITLE
Fix displayio when CIRCUITPY_REPL_LOGO is disabled

### DIFF
--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -128,10 +128,8 @@ void supervisor_start_terminal(uint16_t width_px, uint16_t height_px) {
         status_bar->full_change = true;
 
         scroll_area->width_in_tiles = width_in_tiles;
-        scroll_area->height_in_tiles = height_in_tiles;
-        #if CIRCUITPY_REPL_LOGO
-        scroll_area->height_in_tiles -= 1;
-        #endif
+        // Leave space for the status bar, no matter if we have logo or not.
+        scroll_area->height_in_tiles = height_in_tiles - 1;
         scroll_area->pixel_width = scroll_area->width_in_tiles * scroll_area->tile_width;
         scroll_area->pixel_height = scroll_area->height_in_tiles * scroll_area->tile_height;
         // Right align the scroll area to give margin to the start of each line.


### PR DESCRIPTION
We have to make room for the status bar no matter if the logo is enabled or not. We probably should add a similar option for disabling the status bar.

This makes the PewPew M4 port stop crashing.

(cherry picked from commit b50a7fb9137383737fcc8f635a714b45f41e20ad)