### PR TITLE
raise kernel load addr and slip stack under kernel on both 32bit and 64bit

### DIFF
--- a/ports/broadcom/Makefile
+++ b/ports/broadcom/Makefile
@@ -171,6 +171,15 @@ $(BUILD)/firmware.disk.img.zip: $(BUILD)/kernel$(SUFFIX).img
 	$(Q)zip $@ $(BUILD)/circuitpython-disk.img
 	$(Q)rm $(BUILD)/circuitpython-disk.img
 
+.PHONY: $(BUILD)/rpiboot rpiboot
+rpiboot: $(BUILD)/rpiboot
+$(BUILD)/rpiboot: $(BUILD)/kernel$(SUFFIX).img
+	mkdir -vp $@
+	cp -vf $(BUILD)/kernel$(SUFFIX).img $@/
+	cp -vfr config.txt firmware/bootcode.bin firmware/fixup* firmware/start* firmware/*.dtb $@/
+	#sed -i -e "s/BOOT_UART=0/BOOT_UART=1/" $@/bootcode.bin $@/bootcode.bin
+	echo uart_2ndstage=1 >> $@/config.txt
+
 include $(TOP)/py/mkrules.mk
 
 

--- a/ports/broadcom/config.txt
+++ b/ports/broadcom/config.txt
@@ -7,3 +7,4 @@ enable_jtag_gpio=1
 # hdmi_group=1
 # hdmi_mode=16
 gpu_mem=16
+kernel_address=0x100000

--- a/ports/broadcom/supervisor/port.c
+++ b/ports/broadcom/supervisor/port.c
@@ -124,30 +124,18 @@ void reset_cpu(void) {
 }
 
 bool port_has_fixed_stack(void) {
-    #ifdef __aarch64__
     return true;
-    #else
-    return false;
-    #endif
 }
 
 // From the linker script
 extern uint32_t __bss_end;
 extern uint32_t _ld_ram_end;
 uint32_t *port_stack_get_limit(void) {
-    #ifdef __aarch64__
     return (uint32_t *)0x4;
-    #else
-    return &__bss_end;
-    #endif
 }
 
 uint32_t *port_stack_get_top(void) {
-    #ifdef __aarch64__
-    return (uint32_t *)0x80000;
-    #else
-    return &_ld_ram_end;
-    #endif
+    return (uint32_t *)0x100000;
 }
 
 uint32_t *port_heap_get_bottom(void) {


### PR DESCRIPTION
while using circuitpython on a pi-zero, i discovered that the stack code code was broken
32bit was operating in dynamic stack mode, but reporting entirely wrong addresses for things
but i noticed, aarch64 on the broadcom port, puts the stack below the kernel load addr

so i just used `kernel_address=0x100000` to change the load addr, for both 32bit and 64bit, raising it up a bit more
and made both 32bit and 64bit both have the stack below the kernel, allowing for the code to be simpler

edit:
confirmed the raspberrypi_zero_w build works on a zero-w
the raspberrypi_zero_w build also partially works on a pi1b, but the usb-hub blocks usb-device mode

the raspberrypi_zero2w build works on the zero2w
but hangs mid-boot on a pi3b (same SoC, but with a usb hub)

the raspberrypi_pi4b build boots on a pi4, but no usb-device or hdmi
repl works in hw uart