### PR TITLE
Add several constants needed to use multicast UDP

### DIFF
--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -82,6 +82,10 @@ MP_DEFINE_EXCEPTION(gaierror, OSError)
 //|     TCP_NODELAY: int
 //|
 //|     IPPROTO_TCP: int
+//|     IPPROTO_IP: int
+//|
+//|     IP_MULTICAST_TTL: int
+//|
 //|     def socket(self, family: int = AF_INET, type: int = SOCK_STREAM) -> socketpool.Socket:
 //|         """Create a new socket
 //|
@@ -182,6 +186,8 @@ STATIC const mp_rom_map_elem_t socketpool_socketpool_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TCP_NODELAY), MP_ROM_INT(SOCKETPOOL_TCP_NODELAY) },
 
     { MP_ROM_QSTR(MP_QSTR_IPPROTO_TCP), MP_ROM_INT(SOCKETPOOL_IPPROTO_TCP) },
+    { MP_ROM_QSTR(MP_QSTR_IPPROTO_IP), MP_ROM_INT(SOCKETPOOL_IPPROTO_IP) },
+    { MP_ROM_QSTR(MP_QSTR_IP_MULTICAST_TTL), MP_ROM_INT(SOCKETPOOL_IP_MULTICAST_TTL) },
 
     { MP_ROM_QSTR(MP_QSTR_EAI_NONAME), MP_ROM_INT(SOCKETPOOL_EAI_NONAME) },
 };

--- a/shared-bindings/socketpool/SocketPool.h
+++ b/shared-bindings/socketpool/SocketPool.h
@@ -45,12 +45,17 @@ typedef enum {
 } socketpool_socketpool_addressfamily_t;
 
 typedef enum {
+    SOCKETPOOL_IPPROTO_IP = 0,
     SOCKETPOOL_IPPROTO_TCP = 6,
 } socketpool_socketpool_ipproto_t;
 
 typedef enum {
     SOCKETPOOL_TCP_NODELAY = 1,
 } socketpool_socketpool_tcpopt_t;
+
+typedef enum {
+    SOCKETPOOL_IP_MULTICAST_TTL = 5,
+} socketpool_socketpool_ipopt_t;
 
 typedef enum {
     SOCKETPOOL_EAI_NONAME  = -2,


### PR DESCRIPTION
This was verified by @todbot to work on esp32 s2 and s3; the constant should match any system that uses LWIP numbering.

It enables use of multicast UDP and gets rid of the need for this block in https://github.com/todbot/CircuitPython_MicroOSC/blob/main/microosc.py#L55:
```py
if impl == "circuitpython":
    # these defines are not yet in CirPy socket, known to work for ESP32 native WiFI
    IPPROTO_IP = 0  # super secret from @jepler
    IP_MULTICAST_TTL = 5  # super secret from @jepler
else:
    import socket
    IPPROTO_IP = socket.IPPROTO_IP
    IP_MULTICAST_TTL = socket.IP_MULTICAST_TTL
```