### PR TITLE
fix framebuffer size for pimoroni dvi base

### DIFF
--- a/ports/raspberrypi/boards/pimoroni_pico_dv_base/board.c
+++ b/ports/raspberrypi/boards/pimoroni_pico_dv_base/board.c
@@ -33,7 +33,7 @@
 void board_init(void) {
     picodvi_framebuffer_obj_t *fb = &allocate_display_bus()->picodvi;
     fb->base.type = &picodvi_framebuffer_type;
-    common_hal_picodvi_framebuffer_construct(fb, 640, 480,
+    common_hal_picodvi_framebuffer_construct(fb, 320, 240,
         &pin_GPIO7, &pin_GPIO6,
         &pin_GPIO9, &pin_GPIO8,
         &pin_GPIO11, &pin_GPIO10,


### PR DESCRIPTION
- Fixes #8307 

@dglaude @RetiredWizard

I think is due to #7922, and the code for the Pimoroni board was not updated.

Tested and working for me, with DVI output.