### PR TITLE
Use a different way to force building sdkconfig early

### DIFF
--- a/ports/espressif/Makefile
+++ b/ports/espressif/Makefile
@@ -353,7 +353,7 @@ endif
 # create the config headers
 .PHONY: do-sdkconfig
 do-sdkconfig: $(BUILD)/esp-idf/config/sdkconfig.h
-Makefile: $(BUILD)/esp-idf/config/sdkconfig.h
+$(BUILD)/genhdr/qstr.i.last: $(BUILD)/esp-idf/config/sdkconfig.h
 $(BUILD)/esp-idf/config/sdkconfig.h: boards/$(BOARD)/sdkconfig CMakeLists.txt | $(BUILD)/esp-idf
 	IDF_PATH=$(IDF_PATH) cmake -S . -B $(BUILD)/esp-idf -DSDKCONFIG=$(BUILD)/esp-idf/sdkconfig -DSDKCONFIG_DEFAULTS="$(SDKCONFIGS)" -DCMAKE_TOOLCHAIN_FILE=$(IDF_PATH)/tools/cmake/toolchain-$(IDF_TARGET).cmake -DIDF_TARGET=$(IDF_TARGET) -GNinja -DCIRCUITPY_ESPCAMERA=$(CIRCUITPY_ESPCAMERA)
 

--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -55,7 +55,7 @@ IGNORE_BOARD = {
 PATTERN_DOCS = (
     r"^(?:\.github|docs|extmod\/ulab)|"
     r"^(?:(?:ports\/\w+\/bindings|shared-bindings)\S+\.c|tools\/extract_pyi\.py|\.readthedocs\.yml|conf\.py|requirements-doc\.txt)$|"
-    r"(?:-stubs|\.(?:md|MD|rst|RST))$"
+    r"(?:-stubs|\.(?:md|MD|mk|rst|RST)|/Makefile)$"
 )
 
 PATTERN_WINDOWS = {


### PR DESCRIPTION
the `Makefile:...` version broke the shared bindings matrix generation, as it would fail if esp-idf wasn't in the environment (and we wouldn't want it to do that much work anyway)

.. and the CI is modified so that changing a Makefile or a .mk file will build docs; this would have exposed the problem earlier.