### PR TITLE
Fix building with sphinx 7.2.2 and newer

### DIFF
--- a/docs/rstjinja.py
+++ b/docs/rstjinja.py
@@ -9,6 +9,11 @@ def rstjinja(app, docname, source):
     if app.builder.format not in ("html", "latex"):
         return
 
+    # In the case of an inclusion, docname can be None (https://github.com/sphinx-doc/sphinx/pull/11510) so
+    # avoid an exception just below
+    if docname is None:
+        return
+
     # we only want our one jinja template to run through this func
     if "shared-bindings/support_matrix" not in docname:
         return


### PR DESCRIPTION
The following error would occur otherwise
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/circuitpython/envs/latest/lib/python3.11/site-packages/sphinx/events.py", line 96, in emit
    results.append(listener.handler(self.app, *args))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/circuitpython/checkouts/latest/docs/rstjinja.py", line 13, in rstjinja
    if "shared-bindings/support_matrix" not in docname:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable

The above exception was the direct cause of the following exception:
```