### PR TITLE
Use the ".. jinja" tag to render support_matrix template

### DIFF
--- a/docs/rstjinja.py
+++ b/docs/rstjinja.py
@@ -4,9 +4,7 @@
 import re
 
 def render_with_jinja(docname, source):
-    if "shared-bindings/support_matrix" in docname:
-        return True
-    if re.search('^\s+.. jinja$', source[0], re.M):
+    if re.search('^\s*.. jinja$', source[0], re.M):
         return True
     return False
 

--- a/shared-bindings/support_matrix.rst
+++ b/shared-bindings/support_matrix.rst
@@ -11,6 +11,8 @@ Only those boards that provide those modules will be listed.
 To exclude boards that provide a module, type a "-" in front of the module name.
 You can also type a regular expression as a filter.
 
+.. jinja
+
 .. raw:: html
 
     <p id="support-matrix-filter-block"><input placeholder="Filter the boards by available modules" id="support-matrix-filter" type="text"/><span id="support-matrix-filter-num">(all)</span></p>


### PR DESCRIPTION
.. and remove the substring check for the file.

this fixes the problem with sphinx 7.2.2 that the "docname" can be None (see https://github.com/sphinx-doc/sphinx/issues/11620)