### PR TITLE
Unconditionally use sphinx_rtd_theme when building docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -265,19 +265,9 @@ rst_epilog = """
 
 # -- Options for HTML output ----------------------------------------------
 
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    try:
-        import sphinx_rtd_theme
-        html_theme = 'sphinx_rtd_theme'
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), '.']
-    except:
-        html_theme = 'default'
-        html_theme_path = ['.']
-else:
-    html_theme_path = ['.']
+import sphinx_rtd_theme
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), '.']
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This is a speculative fix for the latest build failure on RTD: https://readthedocs.org/projects/circuitpython/builds/21689508/ which appears to be due to a change in RTD's "conf.py.tmpl": https://github.com/readthedocs/readthedocs.org/commit/2066e3486a25bbd76431e1f8c20be3da0043f03a

failure message says in part:
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/circuitpython/envs/latest/lib/python3.11/site-packages/sphinx/config.py", line 358, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/circuitpython/checkouts/latest/conf.py", line 600, in <module>
    'html_theme': html_theme,
                  ^^^^^^^^^^
NameError: name 'html_theme' is not defined
```
which clearly WOULD happen when the `else` branch was taken, except that the conf.py changes previously performed by rtd fixed the problem magically.