### PR TITLE
Fix gzip Decompression Support

### DIFF
--- a/extmod/moduzlib.c
+++ b/extmod/moduzlib.c
@@ -175,13 +175,18 @@ STATIC mp_obj_t mod_uzlib_decompress(size_t n_args, const mp_obj_t *args) {
     decomp->source_limit = (byte *)bufinfo.buf + bufinfo.len;
 
     int st;
-    bool is_zlib = true;
+    mp_int_t wbits = 0;
 
-    if (n_args > 1 && MP_OBJ_SMALL_INT_VALUE(args[1]) < 0) {
-        is_zlib = false;
+    if (n_args > 1) {
+        wbits = MP_OBJ_SMALL_INT_VALUE(args[1]);
     }
 
-    if (is_zlib) {
+    if (wbits >= 16) {
+        st = uzlib_gzip_parse_header(decomp);
+        if (st < 0) {
+            goto error;
+        }
+    } else if (wbits >= 0) {
         st = uzlib_zlib_parse_header(decomp);
         if (st < 0) {
             goto error;

--- a/shared-bindings/zlib/__init__.c
+++ b/shared-bindings/zlib/__init__.c
@@ -71,12 +71,12 @@
 //|     ...
 //|
 STATIC mp_obj_t zlib_decompress(size_t n_args, const mp_obj_t *args) {
-    bool is_zlib = true;
-    if (n_args > 1 && MP_OBJ_SMALL_INT_VALUE(args[1]) < 0) {
-        is_zlib = false;
+    mp_int_t wbits = 0;
+    if (n_args > 1) {
+        wbits = MP_OBJ_SMALL_INT_VALUE(args[1]);
     }
 
-    return common_hal_zlib_decompress(args[0], is_zlib);
+    return common_hal_zlib_decompress(args[0], wbits);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(zlib_decompress_obj, 1, 3, zlib_decompress);
 

--- a/shared-bindings/zlib/__init__.h
+++ b/shared-bindings/zlib/__init__.h
@@ -27,6 +27,6 @@
 #ifndef MICROPY_INCLUDED_SHARED_BINDINGS_ZLIB___INIT___H
 #define MICROPY_INCLUDED_SHARED_BINDINGS_ZLIB___INIT___H
 
-mp_obj_t common_hal_zlib_decompress(mp_obj_t data, bool is_zlib);
+mp_obj_t common_hal_zlib_decompress(mp_obj_t data, mp_int_t wbits);
 
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_ZLIB___INIT___H

--- a/shared-module/zlib/__init__.c
+++ b/shared-module/zlib/__init__.c
@@ -48,7 +48,7 @@
 #define DEBUG_printf(...) (void)0
 #endif
 
-mp_obj_t common_hal_zlib_decompress(mp_obj_t data, bool is_zlib) {
+mp_obj_t common_hal_zlib_decompress(mp_obj_t data, mp_int_t wbits) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(data, &bufinfo, MP_BUFFER_READ);
 
@@ -66,7 +66,12 @@ mp_obj_t common_hal_zlib_decompress(mp_obj_t data, bool is_zlib) {
     decomp->source_limit = (unsigned char *)bufinfo.buf + bufinfo.len;
     int st;
 
-    if (is_zlib) {
+    if (wbits >= 16) {
+        st = uzlib_gzip_parse_header(decomp);
+        if (st < 0) {
+            goto error;
+        }
+    } else if (wbits >= 0) {
         st = uzlib_zlib_parse_header(decomp);
         if (st < 0) {
             goto error;


### PR DESCRIPTION
Currently, [gzip decompression](https://docs.circuitpython.org/en/latest/shared-bindings/zlib/index.html#zlib.decompress) fails. I noticed when trying to decompress RESTful content bytes in my project that uses `gzip` for `content-type` that the headers are not read correctly and I get a failure message of `-3`.

I suspected I could get around this by slicing the byte array of the raw content. I came across [a comment](https://github.com/adafruit/circuitpython/pull/6069#issuecomment-1046090079) from @FoamyGuy , whom knowingly or not, also found this bug, and had the same idea. That workaround also works in my own code.

I know there are some tests in [tests/circuitpython/zlib_decompress.py](https://github.com/adafruit/circuitpython/blob/70ce576390c7b21007b1f75f16e6fc591c0f61d7/tests/circuitpython/zlib_decompress.py), but not sure how these things are done here.

My project partner and I worked together to come up with the solution shown in this PR. The tested inputs used are the the same text input compressed each using **deflate** **gzip**, and **zlib**. The new code can reverse each into the original decompressed text. These are included below:

---

**deflate**: [dtst.txt](https://github.com/adafruit/circuitpython/files/12447096/dtst.txt)

b'\x0b\xc9HU(,\xcdL\xceVH*\xca/\xcfSH\xcb\xafP\xc8*\xcd-(V\xc8/K-R(\x01J\xe7$VU*\x94gd\x96\xa4*\xa4\xe4\xa7+\x18\x1a\x19\x9b\x98\x9a\x99[X\x1a(\x94d\xe6\xa6\x16\xeb\x01\x00'

---

**gzip**: [gtst.txt](https://github.com/adafruit/circuitpython/files/12447097/gtst.txt)

b'\x1f\x8b\x08\x08\x94\xaf\xead\x00\x03tst.txt\x00\x0b\xc9HU(,\xcdL\xceVH*\xca/\xcfSH\xcb\xafP\xc8*\xcd-(V\xc8/K-R(\x01J\xe7$VU*\x94gd\x96\xa4*\xa4\xe4\xa7+\x18\x1a\x19\x9b\x98\x9a\x99[X\x1a(\x94d\xe6\xa6\x16\xeb\x01\x00\xbe\x98\x07*C\x00\x00\x00'

---

**zlib**: [ztst.txt](https://github.com/adafruit/circuitpython/files/12447099/ztst.txt)

b'x\x9c\x0b\xc9HU(,\xcdL\xceVH*\xca/\xcfSH\xcb\xafP\xc8*\xcd-(V\xc8/K-R(\x01J\xe7$VU*\x94gd\x96\xa4*\xa4\xe4\xa7+\x18\x1a\x19\x9b\x98\x9a\x99[X\x1a(\x94d\xe6\xa6\x16\xeb\x01\x00.x\x16\xb8'

---

**decompressed**: [tst.txt](https://github.com/adafruit/circuitpython/files/12447098/tst.txt)

b'The quick brown fox jumps over the lazy white dog 1234567890 times.'