### PR TITLE
`/.Trash-1000` on filesystem creation.

### DIFF
--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -129,6 +129,7 @@ bool filesystem_init(bool create_allowed, bool force_create) {
         }
         make_empty_file(&vfs_fat->fatfs, "/.metadata_never_index");
         make_empty_file(&vfs_fat->fatfs, "/.Trashes");
+        make_empty_file(&vfs_fat->fatfs, "/.Trash-1000");
         make_empty_file(&vfs_fat->fatfs, "/.fseventsd/no_log");
         #if CIRCUITPY_OS_GETENV
         make_empty_file(&vfs_fat->fatfs, "/settings.toml");

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -127,10 +127,15 @@ bool filesystem_init(bool create_allowed, bool force_create) {
         if (res != FR_OK) {
             return false;
         }
-        make_empty_file(&vfs_fat->fatfs, "/.metadata_never_index");
-        make_empty_file(&vfs_fat->fatfs, "/.Trashes");
-        make_empty_file(&vfs_fat->fatfs, "/.Trash-1000");
         make_empty_file(&vfs_fat->fatfs, "/.fseventsd/no_log");
+        make_empty_file(&vfs_fat->fatfs, "/.metadata_never_index");
+
+        // Prevent storing trash on all OSes.
+        make_empty_file(&vfs_fat->fatfs, "/.Trashes"); // MacOS
+        make_empty_file(&vfs_fat->fatfs, "/.Trash-1000"); // Linux, XDG trash spec:
+        // https://specifications.freedesktop.org/trash-spec/trashspec-latest.html
+
+
         #if CIRCUITPY_OS_GETENV
         make_empty_file(&vfs_fat->fatfs, "/settings.toml");
         #endif


### PR DESCRIPTION
This ensures that on linux no `.Trash-1000` folder is created, storing deleted files.
The files will instead be sent to `~/.local/Trash`.

This only covers deletions made by the user which has the uid 1000, but that's the default user uid.
Unless you are having many users on your system and you are a secondary user, you should have uid 1000.
It's not perfect, but better than not having it there.