### PR TITLE
add support for "repl.py"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,8 @@ Behavior
       ``code.py`` **in the REPL anymore, as the REPL is a fresh vm.** CircuitPython's goal for this
       change includes reducing confusion about pins and memory being used.
    -  After the main code is finished the REPL can be entered by pressing any key.
+      - If the file ``repl.py`` exists, it is executed before the REPL Prompt is shown
+      - In safe mode this functionality is disabled, to ensure the REPL Prompt can always be reached
    -  Autoreload state will be maintained across reload.
 
 -  Adds a safe mode that does not run user code after a hard crash or brown out. This makes it

--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,7 @@ Behavior
 -  Re-runs ``code.py`` or other main file after file system writes by a workflow. (Disable with
    ``supervisor.disable_autoreload()``)
 -  Autoreload is disabled while the REPL is active.
--  ``code.py`` may also be named``code.txt``, ``main.py``, or ``main.txt``.
+-  ``code.py`` may also be named ``code.txt``, ``main.py``, or ``main.txt``.
 -  ``boot.py`` may also be named ``boot.txt``.
 -  ``safemode.py`` may also be named ``safemode.txt``.
 

--- a/main.c
+++ b/main.c
@@ -929,6 +929,11 @@ STATIC int run_repl(safe_mode_t safe_mode) {
 
     autoreload_suspend(AUTORELOAD_SUSPEND_REPL);
 
+    if (get_safe_mode() == SAFE_MODE_NONE) {
+        const char *const filenames[] = { "repl.py" };
+        (void)maybe_run_list(filenames, MP_ARRAY_SIZE(filenames));
+    }
+
     // Set the status LED to the REPL color before running the REPL. For
     // NeoPixels and DotStars this will be sticky but for PWM or single LED it
     // won't. This simplifies pin sharing because they won't be in use when


### PR DESCRIPTION
This file, if it exists and safe mode is not active, is executed before showing the REPL prompt.

You can use this file to do whatever you like, but often it is helpful to set up imports or functions that will be used in an interactive session:
```py
from board import *
from some_sensor import SomeSensor
...
```

You will be notified that repl.py is being used by the line "repl.py output:".

In safe mode the file is not used.

If the file encounters an exception, the exception is printed and then the REPL prompt is shown:

```

repl.py output:
loaded repl.py
Traceback (most recent call last):
  File "repl.py", line 8, in <module>
ZeroDivisionError: division by zero

Adafruit CircuitPython [version info snipped]
>>>
```