### PR TITLE
Forbidden pins are now correctly "in use" on ESP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -340,4 +340,4 @@
 	url = https://github.com/bablokb/circuitpython-pcf85063a
 [submodule "frozen/Adafruit_CircuitPython_Wave"]
 	path = frozen/Adafruit_CircuitPython_Wave
-	url = http://github.com/adafruit/Adafruit_CircuitPython_Wave.git
+	url = https://github.com/adafruit/Adafruit_CircuitPython_Wave.git

--- a/ports/espressif/boards/adafruit_funhouse/board.c
+++ b/ports/espressif/boards/adafruit_funhouse/board.c
@@ -50,12 +50,6 @@ uint8_t display_init_sequence[] = {
 };
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO37);
-    common_hal_never_reset_pin(&pin_GPIO38);
-    #endif /* DEBUG */
-
     displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO36, &pin_GPIO35, NULL, false);

--- a/ports/espressif/boards/adafruit_funhouse/pins.c
+++ b/ports/espressif/boards/adafruit_funhouse/pins.c
@@ -44,8 +44,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO33) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO34) },
 
-    { MP_OBJ_NEW_QSTR(MP_QSTR_DEBUG_TX), MP_ROM_PTR(&pin_GPIO37) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_DEBUG_RX), MP_ROM_PTR(&pin_GPIO38) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_DEBUG_TX), MP_ROM_PTR(&pin_GPIO43) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_DEBUG_RX), MP_ROM_PTR(&pin_GPIO44) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_STEMMA_I2C), MP_ROM_PTR(&board_i2c_obj) },

--- a/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
+++ b/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
@@ -114,12 +114,6 @@ const uint8_t refresh_sequence[] = {
 };
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-
     displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
     busio_spi_obj_t *spi = &bus->inline_bus;
     common_hal_busio_spi_construct(spi, &pin_GPIO36, &pin_GPIO35, NULL, false);

--- a/ports/espressif/boards/adafruit_qtpy_esp32s3_4mbflash_2mbpsram/board.c
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s3_4mbflash_2mbpsram/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/board.c
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/ai_thinker_esp32-c3s-2m/board.c
+++ b/ports/espressif/boards/ai_thinker_esp32-c3s-2m/board.c
@@ -32,12 +32,6 @@
 #include "soc/usb_serial_jtag_struct.h"
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO20);
-    common_hal_never_reset_pin(&pin_GPIO21);
-    #endif
-
     // This board has LEDs connected to the USB pins
     USB_SERIAL_JTAG.conf0.usb_pad_enable = 0;
     USB_SERIAL_JTAG.conf0.dp_pullup = 0;

--- a/ports/espressif/boards/ai_thinker_esp32-c3s/board.c
+++ b/ports/espressif/boards/ai_thinker_esp32-c3s/board.c
@@ -32,12 +32,6 @@
 #include "soc/usb_serial_jtag_struct.h"
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO20);
-    common_hal_never_reset_pin(&pin_GPIO21);
-    #endif
-
     // This board has LEDs connected to the USB pins
     USB_SERIAL_JTAG.conf0.usb_pad_enable = 0;
     USB_SERIAL_JTAG.conf0.dp_pullup = 0;

--- a/ports/espressif/boards/ai_thinker_esp_12k_nodemcu/board.c
+++ b/ports/espressif/boards/ai_thinker_esp_12k_nodemcu/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/artisense_rd00/board.c
+++ b/ports/espressif/boards/artisense_rd00/board.c
@@ -29,12 +29,6 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-
     // Crystal
     common_hal_never_reset_pin(&pin_GPIO15);
     common_hal_never_reset_pin(&pin_GPIO16);

--- a/ports/espressif/boards/atmegazero_esp32s2/board.c
+++ b/ports/espressif/boards/atmegazero_esp32s2/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/bpi_bit_s2/board.c
+++ b/ports/espressif/boards/bpi_bit_s2/board.c
@@ -25,14 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/bpi_leaf_s3/board.c
+++ b/ports/espressif/boards/bpi_leaf_s3/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/bpi_picow_s3/board.c
+++ b/ports/espressif/boards/bpi_picow_s3/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/brainboardz_neuron/board.c
+++ b/ports/espressif/boards/brainboardz_neuron/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/crumpspace_crumps2/board.c
+++ b/ports/espressif/boards/crumpspace_crumps2/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/electroniccats_bastwifi/board.c
+++ b/ports/espressif/boards/electroniccats_bastwifi/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32c3_devkitm_1_n4/board.c
+++ b/ports/espressif/boards/espressif_esp32c3_devkitm_1_n4/board.c
@@ -24,15 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include "shared-bindings/microcontroller/Pin.h"
 #include "supervisor/board.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO20);
-    common_hal_never_reset_pin(&pin_GPIO21);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32s2_devkitc_1_n4/board.c
+++ b/ports/espressif/boards/espressif_esp32s2_devkitc_1_n4/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32s2_devkitc_1_n4r2/board.c
+++ b/ports/espressif/boards/espressif_esp32s2_devkitc_1_n4r2/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32s2_devkitc_1_n8r2/board.c
+++ b/ports/espressif/boards/espressif_esp32s2_devkitc_1_n8r2/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32s3_box/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_box/board.c
@@ -88,12 +88,6 @@ void board_init(void) {
         true, // backlight_on_high
         false, // SH1107_addressing
         50000); // backlight pwm frequency
-
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32s3_box_lite/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_box_lite/board.c
@@ -89,12 +89,6 @@ void board_init(void) {
         false, // backlight_on_high
         false, // SH1107_addressing
         50000); // backlight pwm frequency
-
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n32r8/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n32r8/board.c
@@ -25,24 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
-
-bool board_requests_safe_mode(void) {
-    return false;
-}
-
-void reset_board(void) {
-
-}
-
-void board_deinit(void) {
-}
+// Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r2/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r2/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32s3_devkitm_1_n8/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitm_1_n8/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_esp32s3_usb_otg_n8/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_usb_otg_n8/board.c
@@ -116,10 +116,6 @@ void board_init(void) {
         true, // backlight_on_high
         false, // SH1107_addressing
         50000); // backlight pwm frequency
-
-    #if CIRCUITPY_DEBUG
-    common_hal_never_reset_pin(DEFAULT_UART_BUS_TX);
-    #endif
 }
 
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {

--- a/ports/espressif/boards/espressif_kaluga_1.3/board.c
+++ b/ports/espressif/boards/espressif_kaluga_1.3/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_kaluga_1/board.c
+++ b/ports/espressif/boards/espressif_kaluga_1/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_saola_1_wroom/board.c
+++ b/ports/espressif/boards/espressif_saola_1_wroom/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/espressif_saola_1_wrover/board.c
+++ b/ports/espressif/boards/espressif_saola_1_wrover/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/franzininho_wifi_wroom/board.c
+++ b/ports/espressif/boards/franzininho_wifi_wroom/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/franzininho_wifi_wrover/board.c
+++ b/ports/espressif/boards/franzininho_wifi_wrover/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/gravitech_cucumber_m/board.c
+++ b/ports/espressif/boards/gravitech_cucumber_m/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/gravitech_cucumber_ms/board.c
+++ b/ports/espressif/boards/gravitech_cucumber_ms/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/gravitech_cucumber_r/board.c
+++ b/ports/espressif/boards/gravitech_cucumber_r/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/gravitech_cucumber_rs/board.c
+++ b/ports/espressif/boards/gravitech_cucumber_rs/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/hiibot_iots2/board.c
+++ b/ports/espressif/boards/hiibot_iots2/board.c
@@ -126,25 +126,6 @@ static void display_init(void) {
 }
 
 void board_init(void) {
-    // USB
-    common_hal_never_reset_pin(&pin_GPIO19);
-    common_hal_never_reset_pin(&pin_GPIO20);
-
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-
-    // SPI Flash and RAM
-    common_hal_never_reset_pin(&pin_GPIO26);
-    common_hal_never_reset_pin(&pin_GPIO27);
-    common_hal_never_reset_pin(&pin_GPIO28);
-    common_hal_never_reset_pin(&pin_GPIO29);
-    common_hal_never_reset_pin(&pin_GPIO30);
-    common_hal_never_reset_pin(&pin_GPIO31);
-    common_hal_never_reset_pin(&pin_GPIO32);
-
     // Display
     display_init();
 }

--- a/ports/espressif/boards/lilygo_tembed_esp32s3/board.c
+++ b/ports/espressif/boards/lilygo_tembed_esp32s3/board.c
@@ -88,12 +88,6 @@ void board_init(void) {
         true, // backlight_on_high
         false, // SH1107_addressing
         50000); // backlight pwm frequency
-
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/lilygo_ttgo_t-01c3/board.c
+++ b/ports/espressif/boards/lilygo_ttgo_t-01c3/board.c
@@ -1,14 +1,3 @@
-#include "shared-bindings/microcontroller/Pin.h"
 #include "supervisor/board.h"
-
-#include "components/driver/include/driver/gpio.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO20);
-    common_hal_never_reset_pin(&pin_GPIO21);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/lilygo_ttgo_t-oi-plus/board.c
+++ b/ports/espressif/boards/lilygo_ttgo_t-oi-plus/board.c
@@ -24,17 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include "shared-bindings/microcontroller/Pin.h"
 #include "supervisor/board.h"
-
-#include "components/driver/include/driver/gpio.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO20);
-    common_hal_never_reset_pin(&pin_GPIO21);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/lilygo_ttgo_t8_esp32_s2_wroom/board.c
+++ b/ports/espressif/boards/lilygo_ttgo_t8_esp32_s2_wroom/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/lilygo_ttgo_t8_s2/board.c
+++ b/ports/espressif/boards/lilygo_ttgo_t8_s2/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/lilygo_ttgo_t8_s2_st7789/board.c
+++ b/ports/espressif/boards/lilygo_ttgo_t8_s2_st7789/board.c
@@ -126,12 +126,6 @@ static void display_init(void) {
 }
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-
     // Display
     display_init();
 }

--- a/ports/espressif/boards/lolin_s2_mini/board.c
+++ b/ports/espressif/boards/lolin_s2_mini/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/lolin_s2_pico/board.c
+++ b/ports/espressif/boards/lolin_s2_pico/board.c
@@ -97,11 +97,6 @@ static void display_init(void) {
 void board_init(void) {
     // init display
     display_init();
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/lolin_s3_mini/board.c
+++ b/ports/espressif/boards/lolin_s3_mini/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/maker_badge/board.c
+++ b/ports/espressif/boards/maker_badge/board.c
@@ -37,16 +37,6 @@
 #define DELAY 0x80
 
 void board_init(void) {
-    // USB
-    common_hal_never_reset_pin(&pin_GPIO19);
-    common_hal_never_reset_pin(&pin_GPIO20);
-
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/espressif/boards/microdev_micro_c3/board.c
+++ b/ports/espressif/boards/microdev_micro_c3/board.c
@@ -24,15 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include "shared-bindings/microcontroller/Pin.h"
 #include "supervisor/board.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO20);
-    common_hal_never_reset_pin(&pin_GPIO21);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/microdev_micro_s2/board.c
+++ b/ports/espressif/boards/microdev_micro_s2/board.c
@@ -25,17 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-#include "components/driver/include/driver/gpio.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/mixgo_ce_serial/board.c
+++ b/ports/espressif/boards/mixgo_ce_serial/board.c
@@ -34,12 +34,6 @@
 #include "supervisor/filesystem.h"
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-
     mp_import_stat_t stat_b = mp_import_stat("boot.py");
     if (stat_b != MP_IMPORT_STAT_FILE) {
         FATFS *fatfs = filesystem_circuitpy();

--- a/ports/espressif/boards/mixgo_ce_udisk/board.c
+++ b/ports/espressif/boards/mixgo_ce_udisk/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/morpheans_morphesp-240/board.c
+++ b/ports/espressif/boards/morpheans_morphesp-240/board.c
@@ -139,12 +139,6 @@ uint8_t display_init_sequence[] = {
 
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO6);
-    common_hal_never_reset_pin(&pin_GPIO7);
-    #endif /* DEBUG */
-
     // Display
 
     displayio_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;

--- a/ports/espressif/boards/muselab_nanoesp32_s2_wroom/board.c
+++ b/ports/espressif/boards/muselab_nanoesp32_s2_wroom/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/muselab_nanoesp32_s2_wrover/board.c
+++ b/ports/espressif/boards/muselab_nanoesp32_s2_wrover/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/seeed_xiao_esp32c3/board.c
+++ b/ports/espressif/boards/seeed_xiao_esp32c3/board.c
@@ -24,17 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include "shared-bindings/microcontroller/Pin.h"
 #include "supervisor/board.h"
-
-#include "components/driver/include/driver/gpio.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO20);
-    common_hal_never_reset_pin(&pin_GPIO21);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/smartbeedesigns_bee_data_logger/board.c
+++ b/ports/espressif/boards/smartbeedesigns_bee_data_logger/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/smartbeedesigns_bee_motion_s3/board.c
+++ b/ports/espressif/boards/smartbeedesigns_bee_motion_s3/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/smartbeedesigns_bee_s3/board.c
+++ b/ports/espressif/boards/smartbeedesigns_bee_s3/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/targett_module_clip_wroom/board.c
+++ b/ports/espressif/boards/targett_module_clip_wroom/board.c
@@ -29,12 +29,6 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-
     // Crystal
     common_hal_never_reset_pin(&pin_GPIO15);
     common_hal_never_reset_pin(&pin_GPIO16);

--- a/ports/espressif/boards/targett_module_clip_wrover/board.c
+++ b/ports/espressif/boards/targett_module_clip_wrover/board.c
@@ -29,12 +29,6 @@
 #include "shared-bindings/microcontroller/Pin.h"
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-
     // Crystal
     common_hal_never_reset_pin(&pin_GPIO15);
     common_hal_never_reset_pin(&pin_GPIO16);

--- a/ports/espressif/boards/unexpectedmaker_feathers2/board.c
+++ b/ports/espressif/boards/unexpectedmaker_feathers2/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/unexpectedmaker_feathers2_neo/board.c
+++ b/ports/espressif/boards/unexpectedmaker_feathers2_neo/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/unexpectedmaker_feathers2_prerelease/board.c
+++ b/ports/espressif/boards/unexpectedmaker_feathers2_prerelease/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/unexpectedmaker_feathers3/board.c
+++ b/ports/espressif/boards/unexpectedmaker_feathers3/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/unexpectedmaker_nanos3/board.c
+++ b/ports/espressif/boards/unexpectedmaker_nanos3/board.c
@@ -25,13 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
+// Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/unexpectedmaker_pros3/board.c
+++ b/ports/espressif/boards/unexpectedmaker_pros3/board.c
@@ -25,13 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
 
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
+// Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/unexpectedmaker_tinys2/board.c
+++ b/ports/espressif/boards/unexpectedmaker_tinys2/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/unexpectedmaker_tinys3/board.c
+++ b/ports/espressif/boards/unexpectedmaker_tinys3/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.c
+++ b/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.c
@@ -126,12 +126,6 @@ static void display_init(void) {
 
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-
     // Display
     display_init();
 }

--- a/ports/espressif/boards/waveshare_esp32s2_pico/board.c
+++ b/ports/espressif/boards/waveshare_esp32s2_pico/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif /* DEBUG */
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/yd_esp32_s3_n16r8/board.c
+++ b/ports/espressif/boards/yd_esp32_s3_n16r8/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/yd_esp32_s3_n8r8/board.c
+++ b/ports/espressif/boards/yd_esp32_s3_n8r8/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/common-hal/microcontroller/Pin.c
+++ b/ports/espressif/common-hal/microcontroller/Pin.c
@@ -38,7 +38,7 @@ STATIC uint64_t _skip_reset_once_pin_mask;
 STATIC uint64_t _preserved_pin_mask;
 STATIC uint64_t _in_use_pin_mask;
 
-// Bit mask of all pins that should never EVER be reset.
+// Bit mask of all pins that should never EVER be reset or used by user code.
 // Typically these are SPI flash and PSRAM control pins, and communication pins.
 // "Reset forbidden" is stronger than "never reset" below, which may only be temporary.
 static const uint64_t pin_mask_reset_forbidden =
@@ -97,6 +97,11 @@ static const uint64_t pin_mask_reset_forbidden =
     // Never ever reset USB pins.
     GPIO_SEL_19 |         // USB D-
     GPIO_SEL_20 |         // USB D+
+    #endif
+    #if defined(CONFIG_ESP_CONSOLE_UART_DEFAULT) && CONFIG_ESP_CONSOLE_UART_DEFAULT && CONFIG_ESP_CONSOLE_UART_NUM == 0
+    // Don't reset/use the IDF UART console.
+    GPIO_SEL_43 | // UART TX
+    GPIO_SEL_44 | // UART RX
     #endif
     #endif // ESP32S2, ESP32S3
 
@@ -244,7 +249,7 @@ void reset_all_pins(void) {
         }
         _reset_pin(i);
     }
-    _in_use_pin_mask = _never_reset_pin_mask;
+    _in_use_pin_mask = _never_reset_pin_mask | pin_mask_reset_forbidden;
     // Don't continue to skip resetting these pins.
     _skip_reset_once_pin_mask = 0;
 }

--- a/ports/espressif/peripherals/esp32s3/pins.c
+++ b/ports/espressif/peripherals/esp32s3/pins.c
@@ -26,6 +26,8 @@
 
 #include "peripherals/pins.h"
 
+// NOTE: These numbers do NOT always match the package and module pin number.
+// These are by solely by GPIO numbers.
 const mcu_pin_obj_t pin_GPIO0 = PIN(0, NO_ADC, NO_ADC_CHANNEL, NO_TOUCH_CHANNEL);
 const mcu_pin_obj_t pin_GPIO1 = PIN(1, ADC_UNIT_1, ADC_CHANNEL_0, TOUCH_PAD_NUM1);
 const mcu_pin_obj_t pin_GPIO2 = PIN(2, ADC_UNIT_1, ADC_CHANNEL_1, TOUCH_PAD_NUM2);

--- a/ports/espressif/peripherals/pins.h
+++ b/ports/espressif/peripherals/pins.h
@@ -54,7 +54,7 @@ extern const mp_obj_type_t mcu_pin_type;
 
 #define NO_TOUCH_CHANNEL TOUCH_PAD_MAX
 
-// This macro is used to simplify pin definition in boards/<board>/pins.c
+// This macro is used to simplify pin definition in peripherals/<chip>/pins.c
 #define PIN(p_number, p_adc_index, p_adc_channel, p_touch_channel) \
     { \
         { &mcu_pin_type }, \


### PR DESCRIPTION
This removes duplicate code to make debug UART pins in use via never reset. It is done through forbidden pins automatically now.

Fixes #8288