### PR TITLE
Disable dotfiles on boards without native usb

### DIFF
--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -122,6 +122,7 @@ bool filesystem_init(bool create_allowed, bool force_create) {
             return false;
         }
 
+        #if CIRCUITPY_USB
         // inhibit file indexing on MacOS
         res = f_mkdir(&vfs_fat->fatfs, "/.fseventsd");
         if (res != FR_OK) {
@@ -134,7 +135,7 @@ bool filesystem_init(bool create_allowed, bool force_create) {
         make_empty_file(&vfs_fat->fatfs, "/.Trashes"); // MacOS
         make_empty_file(&vfs_fat->fatfs, "/.Trash-1000"); // Linux, XDG trash spec:
         // https://specifications.freedesktop.org/trash-spec/trashspec-latest.html
-
+        #endif
 
         #if CIRCUITPY_OS_GETENV
         make_empty_file(&vfs_fat->fatfs, "/settings.toml");


### PR DESCRIPTION
They serve no purpose on boards without usb, other than looking ugly in the web-workflow.
Even if in the future those boards were to be accessed by ftp (which I plan on doing *really* soon), they do not apply.

A board with usb:
```
>>> import storage
>>> storage.erase_filesystem()

[17:18:05.090] Disconnected
[17:18:06.092] Warning: Could not open tty device (No such file or directory)
[17:18:06.092] Waiting for tty device..
[17:18:16.105] Connected
Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.

Press any key to enter the REPL. Use CTRL-D to reload.

Adafruit CircuitPython 9.0.0-alpha.1-19-g3605d891d-dirty on 2023-08-29; Waveshare ESP32-S2-Pico with ESP32S2
>>> import os
>>> os.listdir()
['.fseventsd', '.metadata_never_index', '.Trashes', '.Trash-1000', 'settings.toml', 'code.py', 'lib', 'boot_out.txt']
>>> 
```
A possessed board without usb:
```
>>> import storage
>>> storage.erase_filesystem()

Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
Hello World!

Code done running.

Press any key to enter the REPL. Use CTRL-D to reload.

Adafruit CircuitPython 9.0.0-alpha.1-19-g3605d891d-dirty on 2023-08-29; DFRobot Beetle ESP32-C3 with ESP32-C3FN4
>>> import os
>>> os.listdir()
['settings.toml', 'code.py', 'lib', 'boot_out.txt']
>>> 
```