### PR TITLE
Remove frozen libs from Funhouse

### DIFF
--- a/ports/espressif/boards/adafruit_funhouse/mpconfigboard.mk
+++ b/ports/espressif/boards/adafruit_funhouse/mpconfigboard.mk
@@ -12,8 +12,4 @@ CIRCUITPY_ESP_FLASH_SIZE = 4MB
 CIRCUITPY_ESPCAMERA = 0
 
 # Include these Python libraries in firmware.
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_PortalBase
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_FakeRequests
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Requests
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Display_Text


### PR DESCRIPTION
It seems the last time a release was done with 8.2.4, the frozen libs were not updated which is causing problems with boards like the FunHouse because the version that is frozen is not compatible with settings.toml. 

This was originally added when we were experiencing some issues with certain boards that used PortalBase. The M4 PortalBase boards (PyPortal MatrixPortal M4) still need this, but esp32-s2 boards have plenty of RAM and don't really need it. In order to make it easier to update, this PR just removes the frozen libs from the funhouse.