### PR TITLE
initial broadcom 2d accel code

### DIFF
--- a/ports/broadcom/Makefile
+++ b/ports/broadcom/Makefile
@@ -54,6 +54,8 @@ INC += -I. \
 
 SRC_C += bindings/videocore/__init__.c \
          bindings/videocore/Framebuffer.c \
+         bindings/videocore/Sprite.c \
+         bindings/videocore/Hvs.c \
 		 boards/$(BOARD)/board.c \
 	     boards/$(BOARD)/pins.c \
 	     background.c \

--- a/ports/broadcom/bcm283x.h
+++ b/ports/broadcom/bcm283x.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#if BCM_VERSION == 2835
+#define BCM_PERIPH_BASE_VIRT 0x20000000
+#elif BCM_VERSION == 2836
+#define BCM_PERIPH_BASE_VIRT 0x3f000000
+#elif BCM_VERSION == 2837
+#define BCM_PERIPH_BASE_VIRT 0x3f000000
+#endif
+
+#define REG32(r) ((volatile uint32_t*)r)
+
+#undef PM_BASE
+#define PM_BASE     (BCM_PERIPH_BASE_VIRT + 0x100000)
+#define SCALER_BASE (BCM_PERIPH_BASE_VIRT + 0x400000)

--- a/ports/broadcom/bindings/videocore/Hvs.c
+++ b/ports/broadcom/bindings/videocore/Hvs.c
@@ -6,7 +6,11 @@
 
 #include "bindings/videocore/Sprite.h"
 #include "shared-bindings/displayio/Bitmap.h"
+#include "shared-module/displayio/Group.h"
+#include "shared-bindings/displayio/Group.h"
 #include "py/runtime.h"
+#include "shared-bindings/displayio/TileGrid.h"
+#include "shared-bindings/displayio/Palette.h"
 
 #include "bindings/videocore/hvs.h"
 #include "bindings/videocore/Hvs.h"
@@ -17,7 +21,6 @@ volatile uint32_t* dlist_memory = (volatile uint32_t*)SCALER5_LIST_MEMORY;
 volatile uint32_t* dlist_memory = (volatile uint32_t*)SCALER_LIST_MEMORY;
 #endif
 
-extern const mp_obj_type_t hvs_channel_type;
 volatile struct hvs_channel *hvs_hw_channels = (volatile struct hvs_channel*)SCALER_DISPCTRL0;
 uint32_t dlist_slot = 128; // start a bit in, to not trash the firmware list
 
@@ -37,12 +40,21 @@ hvs_channel_t hvs_channels[3] = {
 };
 
 static mp_obj_t c_set_sprite_list(mp_obj_t self_in, mp_obj_t list) {
+  mp_obj_t *unique_palettes = mp_obj_new_set(0, NULL);
   hvs_channel_t *self = MP_OBJ_TO_PTR(self_in);
   mp_obj_t sprite_list = mp_arg_validate_type(list, &mp_type_list, MP_QSTR_sprites);
   size_t len = 0;
   mp_obj_t *items;
   mp_obj_list_get(sprite_list, &len, &items);
+  // first loop, find unique palettes
+  for (uint32_t i=0; i<len; i++) {
+    mp_obj_t sprite = mp_arg_validate_type(items[i], &hvs_sprite_type, MP_QSTR_todo);
+    sprite_t *s = MP_OBJ_TO_PTR(sprite);
+    if (s->palette) mp_obj_set_store(unique_palettes, s->palette);
+  }
+  // TODO, copy each palette to the dlist memory and set sprite->palette_addr to the addr its copied to
   uint32_t needed_slots = 1; // one more, to terminate the list
+  // second loop, regenerate any display lists and count the total size
   for (uint32_t i=0; i<len; i++) {
     mp_obj_t sprite = mp_arg_validate_type(items[i], &hvs_sprite_type, MP_QSTR_todo);
     sprite_t *s = MP_OBJ_TO_PTR(sprite);
@@ -54,10 +66,10 @@ static mp_obj_t c_set_sprite_list(mp_obj_t self_in, mp_obj_t list) {
     mp_raise_ValueError(translate("too many sprites, unable to pageflip reliably"));
   }
   if ((dlist_slot + needed_slots) > 4096) {
-    // early loop)
     dlist_slot = 128;
   }
   uint32_t starting_slot = dlist_slot;
+  // third loop, copy dlist fragments to hw
   for (uint32_t i=0; i<len; i++) {
     mp_obj_t sprite = mp_arg_validate_type(items[i], &hvs_sprite_type, MP_QSTR_todo);
     sprite_t *s = MP_OBJ_TO_PTR(sprite);
@@ -80,7 +92,71 @@ static mp_obj_t c_set_sprite_list(mp_obj_t self_in, mp_obj_t list) {
   }
   return mp_const_none;
 }
+
+static mp_obj_t c_hvs_show(mp_obj_t self_in, mp_obj_t root_group_in) {
+  mp_obj_list_t *sprites = mp_obj_new_list(0, NULL);
+
+  hvs_channel_t *self = MP_OBJ_TO_PTR(self_in);
+  displayio_group_t *root_group = mp_arg_validate_type(root_group_in, &displayio_group_type, MP_QSTR_bitmap);
+  printf("hvs channel: %ld\n", self->channel);
+  printf("root group x: %d y: %d\n", root_group->x, root_group->y);
+  printf("group scale (not implemented): %d\n", root_group->scale);
+  size_t len = 0;
+  mp_obj_t *items;
+  mp_obj_list_get(root_group->members, &len, &items);
+  printf("%d elements\n", len);
+  for (uint i=0; i<len; i++) {
+    printf("%d: %p\n", i, mp_obj_get_type(items[i]));
+    if (mp_obj_get_type(items[i]) == &displayio_tilegrid_type) {
+      displayio_tilegrid_t *tg = mp_arg_validate_type(items[i], &displayio_tilegrid_type, MP_QSTR_tilegrid);
+      displayio_bitmap_t *bitmap = mp_arg_validate_type(tg->bitmap, &displayio_bitmap_type, MP_QSTR_bitmap);
+      uint8_t *arr;
+      if (tg->inline_tiles) arr = (uint8_t*)&tg->tiles;
+      else arr = tg->tiles;
+      /*
+      printf("found tilegrid: %p\n", tg);
+      printf("x %d, y %d\n", tg->x, tg->y);
+      printf("w %d, h %d\n", tg->width_in_tiles, tg->height_in_tiles);
+      printf("w %d, h %d\n", tg->pixel_width, tg->pixel_height);
+      printf("w %d, h %d\n", tg->tile_width, tg->tile_height);
+      printf("shader type: %p\n", mp_obj_get_type(tg->pixel_shader));
+      */
+      enum hvs_pixel_format format = HVS_PIXEL_FORMAT_RGB332;
+      int order = HVS_PIXEL_ORDER_ABGR;
+      if (mp_obj_get_type(tg->pixel_shader) == &displayio_palette_type) {
+        puts("tg uses a palette");
+        format = HVS_PIXEL_FORMAT_PALETTE;
+      }
+      for (uint row=0; row < tg->height_in_tiles; row++) {
+        for (uint col=0; col < tg->width_in_tiles; col++) {
+          uint tile_offset = col + (row * tg->width_in_tiles);
+          sprite_t *sprite = mp_obj_malloc(sprite_t, &hvs_sprite_type);
+          sprite->bitmap = bitmap;
+          if (format == HVS_PIXEL_FORMAT_PALETTE) sprite->palette = tg->pixel_shader;
+          else sprite->palette = NULL;
+          sprite->x = root_group->x + tg->x + (col * tg->tile_width);
+          sprite->y = root_group->y + tg->y + (row * tg->tile_height);
+          uint tile = arr[tile_offset];
+          sprite->x_offset = (tile % tg->bitmap_width_in_tiles) * tg->tile_width;
+          sprite->y_offset = (tile / tg->bitmap_width_in_tiles) * tg->tile_height;
+          sprite->width = tg->tile_width;
+          sprite->height = tg->tile_height;
+          sprite->dirty = true;
+          sprite->color_order = order;
+          sprite->pixel_format = format;
+          mp_obj_list_append(sprites, sprite);
+        }
+      }
+    } else {
+      puts("unexpected item in group");
+    }
+  }
+  c_set_sprite_list(self_in, sprites);
+  return mp_const_none;
+}
+
 MP_DEFINE_CONST_FUN_OBJ_2(fun_set_sprite_list, c_set_sprite_list);
+MP_DEFINE_CONST_FUN_OBJ_2(fun_hvs_show, c_hvs_show);
 
 #define simpleprop(name) \
   static MP_DEFINE_CONST_FUN_OBJ_1(fun_get_##name, c_getter_##name); \
@@ -104,15 +180,32 @@ static mp_obj_t c_getter_enabled(mp_obj_t self_in) {
   return mp_obj_new_bool(ctrl & SCALER_DISPCTRLX_ENABLE);
 }
 
+static mp_obj_t c_getter_frame(mp_obj_t self_in) {
+  hvs_channel_t *self = MP_OBJ_TO_PTR(self_in);
+  uint32_t stat = hvs_hw_channels[self->channel].dispstat;
+  return MP_OBJ_NEW_SMALL_INT((stat >> 12) & 0x3f);
+}
+
+static mp_obj_t c_getter_scanline(mp_obj_t self_in) {
+  hvs_channel_t *self = MP_OBJ_TO_PTR(self_in);
+  uint32_t stat = hvs_hw_channels[self->channel].dispstat;
+  return MP_OBJ_NEW_SMALL_INT(stat & 0xfff);
+}
+
 simpleprop(width);
 simpleprop(height);
 simpleprop(enabled);
+simpleprop(frame);
+simpleprop(scanline);
 
 static const mp_rom_map_elem_t hvs_channel_locals_dict_table[] = {
   prop_entry(width),
   prop_entry(height),
   prop_entry(enabled),
+  prop_entry(frame),
+  prop_entry(scanline),
   { MP_ROM_QSTR(MP_QSTR_set_sprite_list), MP_ROM_PTR(&fun_set_sprite_list) },
+  { MP_ROM_QSTR(MP_QSTR_show), MP_ROM_PTR(&fun_hvs_show) },
 };
 
 static MP_DEFINE_CONST_DICT(hvs_channel_locals_dict, hvs_channel_locals_dict_table);

--- a/ports/broadcom/bindings/videocore/Hvs.c
+++ b/ports/broadcom/bindings/videocore/Hvs.c
@@ -1,0 +1,125 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "py/obj.h"
+#include "py/objproperty.h"
+
+#include "bindings/videocore/Sprite.h"
+#include "shared-bindings/displayio/Bitmap.h"
+#include "py/runtime.h"
+
+#include "bindings/videocore/hvs.h"
+#include "bindings/videocore/Hvs.h"
+
+#if BCM_VERSION == 2711
+volatile uint32_t* dlist_memory = (volatile uint32_t*)SCALER5_LIST_MEMORY;
+#else
+volatile uint32_t* dlist_memory = (volatile uint32_t*)SCALER_LIST_MEMORY;
+#endif
+
+extern const mp_obj_type_t hvs_channel_type;
+volatile struct hvs_channel *hvs_hw_channels = (volatile struct hvs_channel*)SCALER_DISPCTRL0;
+uint32_t dlist_slot = 128; // start a bit in, to not trash the firmware list
+
+hvs_channel_t hvs_channels[3] = {
+  [0] = {
+    .base.type = &hvs_channel_type,
+    .channel = 0,
+  },
+  [1] = {
+    .base.type = &hvs_channel_type,
+    .channel = 1,
+  },
+  [2] = {
+    .base.type = &hvs_channel_type,
+    .channel = 2,
+  },
+};
+
+static mp_obj_t c_set_sprite_list(mp_obj_t self_in, mp_obj_t list) {
+  hvs_channel_t *self = MP_OBJ_TO_PTR(self_in);
+  mp_obj_t sprite_list = mp_arg_validate_type(list, &mp_type_list, MP_QSTR_sprites);
+  size_t len = 0;
+  mp_obj_t *items;
+  mp_obj_list_get(sprite_list, &len, &items);
+  uint32_t needed_slots = 1; // one more, to terminate the list
+  for (uint32_t i=0; i<len; i++) {
+    mp_obj_t sprite = mp_arg_validate_type(items[i], &hvs_sprite_type, MP_QSTR_todo);
+    sprite_t *s = MP_OBJ_TO_PTR(sprite);
+    c_maybe_regen(sprite);
+    uint8_t length = (s->dlist[0] >> 24) & 0x3f;
+    needed_slots += length;
+  }
+  if (needed_slots > (4096/2)) {
+    mp_raise_ValueError(translate("too many sprites, unable to pageflip reliably"));
+  }
+  if ((dlist_slot + needed_slots) > 4096) {
+    // early loop)
+    dlist_slot = 128;
+  }
+  uint32_t starting_slot = dlist_slot;
+  for (uint32_t i=0; i<len; i++) {
+    mp_obj_t sprite = mp_arg_validate_type(items[i], &hvs_sprite_type, MP_QSTR_todo);
+    sprite_t *s = MP_OBJ_TO_PTR(sprite);
+    uint8_t length = (s->dlist[0] >> 24) & 0x3f;
+    for (int j=0; j<length; j++) {
+      dlist_memory[dlist_slot++] = s->dlist[j];
+    }
+  }
+  dlist_memory[dlist_slot++] = CONTROL_END;
+  switch (self->channel) {
+  case 0:
+    *((volatile uint32_t*)SCALER_DISPLIST0) = starting_slot;
+    break;
+  case 1:
+    *((volatile uint32_t*)SCALER_DISPLIST1) = starting_slot;
+    break;
+  case 2:
+    *((volatile uint32_t*)SCALER_DISPLIST2) = starting_slot;
+    break;
+  }
+  return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(fun_set_sprite_list, c_set_sprite_list);
+
+#define simpleprop(name) \
+  static MP_DEFINE_CONST_FUN_OBJ_1(fun_get_##name, c_getter_##name); \
+  static MP_PROPERTY_GETTER(prop_##name, (mp_obj_t)&fun_get_##name)
+
+#define prop_entry(name) { MP_ROM_QSTR(MP_QSTR_##name), MP_ROM_PTR(&prop_##name) }
+
+static mp_obj_t c_getter_width(mp_obj_t self_in) {
+  hvs_channel_t *self = MP_OBJ_TO_PTR(self_in);
+  uint32_t ctrl = hvs_hw_channels[self->channel].dispctrl;
+  return MP_OBJ_NEW_SMALL_INT((ctrl >> 12) & 0xfff);
+}
+static mp_obj_t c_getter_height(mp_obj_t self_in) {
+  hvs_channel_t *self = MP_OBJ_TO_PTR(self_in);
+  uint32_t ctrl = hvs_hw_channels[self->channel].dispctrl;
+  return MP_OBJ_NEW_SMALL_INT(ctrl & 0xfff);
+}
+static mp_obj_t c_getter_enabled(mp_obj_t self_in) {
+  hvs_channel_t *self = MP_OBJ_TO_PTR(self_in);
+  uint32_t ctrl = hvs_hw_channels[self->channel].dispctrl;
+  return mp_obj_new_bool(ctrl & SCALER_DISPCTRLX_ENABLE);
+}
+
+simpleprop(width);
+simpleprop(height);
+simpleprop(enabled);
+
+static const mp_rom_map_elem_t hvs_channel_locals_dict_table[] = {
+  prop_entry(width),
+  prop_entry(height),
+  prop_entry(enabled),
+  { MP_ROM_QSTR(MP_QSTR_set_sprite_list), MP_ROM_PTR(&fun_set_sprite_list) },
+};
+
+static MP_DEFINE_CONST_DICT(hvs_channel_locals_dict, hvs_channel_locals_dict_table);
+
+const mp_obj_type_t hvs_channel_type = {
+  { &mp_type_type },
+  .name = MP_QSTR_HvsChannel,
+  .locals_dict = (mp_obj_dict_t*)&hvs_channel_locals_dict,
+};
+

--- a/ports/broadcom/bindings/videocore/Hvs.h
+++ b/ports/broadcom/bindings/videocore/Hvs.h
@@ -1,0 +1,8 @@
+#pragma once
+
+typedef struct {
+  mp_obj_base_t base;
+  uint32_t channel;
+} hvs_channel_t;
+
+extern hvs_channel_t hvs_channels[3];

--- a/ports/broadcom/bindings/videocore/Hvs.h
+++ b/ports/broadcom/bindings/videocore/Hvs.h
@@ -6,3 +6,4 @@ typedef struct {
 } hvs_channel_t;
 
 extern hvs_channel_t hvs_channels[3];
+extern const mp_obj_type_t hvs_channel_type;

--- a/ports/broadcom/bindings/videocore/Sprite.c
+++ b/ports/broadcom/bindings/videocore/Sprite.c
@@ -1,0 +1,120 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "py/obj.h"
+#include "py/objproperty.h"
+
+#include "bindings/videocore/Sprite.h"
+#include "py/runtime.h"
+
+
+STATIC mp_obj_t hvs_sprite_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+  sprite_t *sprite = m_new_obj(sprite_t);
+  sprite->base.type = &hvs_sprite_type;
+  sprite->bitmap = NULL;
+  sprite->dirty = true;
+  sprite->alpha_mode = alpha_mode_fixed;
+  printf("sprite is at %p\n", sprite);
+  return MP_OBJ_FROM_PTR(sprite);
+}
+
+enum hvs_pixel_format bitmap_to_hvs(const displayio_bitmap_t *bitmap) {
+  switch (bitmap->bits_per_value) {
+  case 16:
+    return HVS_PIXEL_FORMAT_RGB555;
+  }
+  return HVS_PIXEL_FORMAT_RGB332;
+}
+
+#if BCM_VERSION == 2711
+#error not implemented yet
+#else
+void hvs_regen_noscale_noviewport(sprite_t *s) {
+  uint32_t *d = s->dlist;
+  // CTL0
+  d[0] = CONTROL_VALID
+    | CONTROL_PIXEL_ORDER(HVS_PIXEL_ORDER_ABGR)
+    | CONTROL_UNITY
+    | CONTROL_FORMAT(bitmap_to_hvs(s->bitmap))
+    | CONTROL_WORDS(7);
+  // POS0
+  d[1] = POS0_X(s->x) | POS0_Y(s->y) | POS0_ALPHA(0xff);
+  // POS2, input size
+  d[2] = POS2_H(s->bitmap->height) | POS2_W(s->bitmap->width) | (s->alpha_mode << 30);
+  // POS3, context
+  d[3] = 0xDEADBEEF;
+  // PTR0
+  d[4] = ((uint32_t)s->bitmap->data) // assumes identity map, should be physical addr
+    | 0xc0000000; // and tell HVS to do uncached reads
+  // context 0
+  d[5] = 0xDEADBEEF;
+  // pitch 0
+  d[6] = s->bitmap->stride * 4;
+
+  //printf("w: %d, h: %d, stride: %d, bits per value: %d\n", s->bitmap->width, s->bitmap->height, s->bitmap->stride, s->bitmap->bits_per_value);
+}
+#endif
+
+mp_obj_t c_maybe_regen(mp_obj_t self_in) {
+  sprite_t *self = MP_OBJ_TO_PTR(self_in);
+  if (self->dirty) {
+    //printf("regen time\n");
+    hvs_regen_noscale_noviewport(self);
+    self->dirty = false;
+  } else puts("not dirty");
+  return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(fun_maybe_regen, c_maybe_regen);
+
+STATIC mp_obj_t get_image_c(mp_obj_t self_in) {
+  sprite_t *self = MP_OBJ_TO_PTR(self_in);
+  if (self->bitmap) return MP_OBJ_FROM_PTR(self->bitmap);
+  else return mp_const_none;
+}
+STATIC mp_obj_t set_image_c(mp_obj_t self_in, mp_obj_t value) {
+  displayio_bitmap_t *bitmap = mp_arg_validate_type(value, &displayio_bitmap_type, MP_QSTR_bitmap);
+  sprite_t *self = MP_OBJ_TO_PTR(self_in);
+  self->bitmap = bitmap;
+  self->dirty = true;
+  if (self->width == 0) self->width = bitmap->width;
+  if (self->height == 0) self->height = bitmap->height;
+  return value;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(get_image_fun, get_image_c);
+MP_DEFINE_CONST_FUN_OBJ_2(set_image_fun, set_image_c);
+MP_PROPERTY_GETSET(image_prop, (mp_obj_t)&get_image_fun, (mp_obj_t)&set_image_fun);
+
+#define simpleprop(name) \
+    static mp_obj_t c_getter_##name(mp_obj_t self_in) { sprite_t *self = MP_OBJ_TO_PTR(self_in); return MP_OBJ_NEW_SMALL_INT(self->name); } \
+    static mp_obj_t c_setter_##name(mp_obj_t self_in, mp_obj_t value) { sprite_t *self = MP_OBJ_TO_PTR(self_in); self->name = mp_obj_get_int(value); self->dirty = true; return mp_const_none; } \
+    static MP_DEFINE_CONST_FUN_OBJ_1(fun_get_##name, c_getter_##name); \
+    static MP_DEFINE_CONST_FUN_OBJ_2(fun_set_##name, c_setter_##name); \
+    static MP_PROPERTY_GETSET(prop_##name, (mp_obj_t)&fun_get_##name, (mp_obj_t)&fun_set_##name)
+
+#define prop_entry(name) { MP_ROM_QSTR(MP_QSTR_##name), MP_ROM_PTR(&prop_##name) }
+
+simpleprop(width);
+simpleprop(height);
+simpleprop(x);
+simpleprop(y);
+
+STATIC const mp_rom_map_elem_t hvs_sprite_locals_dict_table[] = {
+  { MP_ROM_QSTR(MP_QSTR_image), MP_ROM_PTR(&image_prop) },
+  prop_entry(width),
+  prop_entry(height),
+  prop_entry(x),
+  prop_entry(y),
+  { MP_ROM_QSTR(MP_QSTR_maybe_regen), MP_ROM_PTR(&fun_maybe_regen) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(hvs_sprite_locals_dict, hvs_sprite_locals_dict_table);
+
+const mp_obj_type_t hvs_sprite_type = {
+    { &mp_type_type },
+    .flags = 0, //MP_TYPE_FLAG_EXTENDED,
+    .name = MP_QSTR_Sprite,
+    .locals_dict = (mp_obj_dict_t*)&hvs_sprite_locals_dict,
+    .make_new = hvs_sprite_make_new,
+    //MP_TYPE_EXTENDED_FIELDS(
+    //),
+};

--- a/ports/broadcom/bindings/videocore/Sprite.c
+++ b/ports/broadcom/bindings/videocore/Sprite.c
@@ -14,14 +14,15 @@ STATIC mp_obj_t hvs_sprite_make_new(const mp_obj_type_t *type, size_t n_args, si
   sprite->bitmap = NULL;
   sprite->dirty = true;
   sprite->alpha_mode = alpha_mode_fixed;
-  printf("sprite is at %p\n", sprite);
+  sprite->color_order = HVS_PIXEL_ORDER_ABGR;
+  sprite->pixel_format = HVS_PIXEL_FORMAT_RGB565;
   return MP_OBJ_FROM_PTR(sprite);
 }
 
 enum hvs_pixel_format bitmap_to_hvs(const displayio_bitmap_t *bitmap) {
   switch (bitmap->bits_per_value) {
   case 16:
-    return HVS_PIXEL_FORMAT_RGB555;
+    return HVS_PIXEL_FORMAT_RGB565;
   }
   return HVS_PIXEL_FORMAT_RGB332;
 }
@@ -33,9 +34,9 @@ void hvs_regen_noscale_noviewport(sprite_t *s) {
   uint32_t *d = s->dlist;
   // CTL0
   d[0] = CONTROL_VALID
-    | CONTROL_PIXEL_ORDER(HVS_PIXEL_ORDER_ABGR)
+    | CONTROL_PIXEL_ORDER(s->color_order)
     | CONTROL_UNITY
-    | CONTROL_FORMAT(bitmap_to_hvs(s->bitmap))
+    | CONTROL_FORMAT(s->pixel_format)
     | CONTROL_WORDS(7);
   // POS0
   d[1] = POS0_X(s->x) | POS0_Y(s->y) | POS0_ALPHA(0xff);
@@ -97,6 +98,8 @@ simpleprop(width);
 simpleprop(height);
 simpleprop(x);
 simpleprop(y);
+simpleprop(color_order);
+simpleprop(pixel_format);
 
 STATIC const mp_rom_map_elem_t hvs_sprite_locals_dict_table[] = {
   { MP_ROM_QSTR(MP_QSTR_image), MP_ROM_PTR(&image_prop) },
@@ -104,6 +107,8 @@ STATIC const mp_rom_map_elem_t hvs_sprite_locals_dict_table[] = {
   prop_entry(height),
   prop_entry(x),
   prop_entry(y),
+  prop_entry(color_order),
+  prop_entry(pixel_format),
   { MP_ROM_QSTR(MP_QSTR_maybe_regen), MP_ROM_PTR(&fun_maybe_regen) },
 };
 

--- a/ports/broadcom/bindings/videocore/Sprite.h
+++ b/ports/broadcom/bindings/videocore/Sprite.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "shared-bindings/displayio/Bitmap.h"
+#include "bindings/videocore/hvs.h"
+
+typedef struct {
+  mp_obj_base_t base;
+  displayio_bitmap_t *bitmap;
+  bool dirty;
+  uint32_t width;
+  uint32_t height;
+  uint32_t x;
+  uint32_t y;
+  uint32_t dlist[32];
+  enum alpha_mode alpha_mode;
+} sprite_t;
+
+extern const mp_obj_type_t hvs_sprite_type;
+mp_obj_t c_maybe_regen(mp_obj_t self_in);

--- a/ports/broadcom/bindings/videocore/Sprite.h
+++ b/ports/broadcom/bindings/videocore/Sprite.h
@@ -13,6 +13,8 @@ typedef struct {
   uint32_t y;
   uint32_t dlist[32];
   enum alpha_mode alpha_mode;
+  uint32_t color_order;
+  enum hvs_pixel_format pixel_format;
 } sprite_t;
 
 extern const mp_obj_type_t hvs_sprite_type;

--- a/ports/broadcom/bindings/videocore/Sprite.h
+++ b/ports/broadcom/bindings/videocore/Sprite.h
@@ -11,10 +11,14 @@ typedef struct {
   uint32_t height;
   uint32_t x;
   uint32_t y;
+  uint32_t x_offset;
+  uint32_t y_offset;
   uint32_t dlist[32];
   enum alpha_mode alpha_mode;
   uint32_t color_order;
+  uint32_t palette_addr;
   enum hvs_pixel_format pixel_format;
+  mp_obj_t palette;
 } sprite_t;
 
 extern const mp_obj_type_t hvs_sprite_type;

--- a/ports/broadcom/bindings/videocore/__init__.c
+++ b/ports/broadcom/bindings/videocore/__init__.c
@@ -30,12 +30,18 @@
 #include "py/runtime.h"
 
 #include "bindings/videocore/Framebuffer.h"
+#include "bindings/videocore/Sprite.h"
+#include "bindings/videocore/Hvs.h"
 
 //| """Low-level routines for interacting with the Broadcom VideoCore GPU"""
 
 STATIC const mp_rom_map_elem_t videocore_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_videocore) },
     { MP_ROM_QSTR(MP_QSTR_Framebuffer), MP_ROM_PTR(&videocore_framebuffer_type) },
+    { MP_ROM_QSTR(MP_QSTR_Sprite), MP_ROM_PTR(&hvs_sprite_type) },
+    { MP_ROM_QSTR(MP_QSTR_HvsChannel0), MP_OBJ_FROM_PTR(&hvs_channels[0]) },
+    { MP_ROM_QSTR(MP_QSTR_HvsChannel1), MP_OBJ_FROM_PTR(&hvs_channels[1]) },
+    { MP_ROM_QSTR(MP_QSTR_HvsChannel2), MP_OBJ_FROM_PTR(&hvs_channels[2]) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(videocore_module_globals, videocore_module_globals_table);

--- a/ports/broadcom/bindings/videocore/code.py
+++ b/ports/broadcom/bindings/videocore/code.py
@@ -1,0 +1,86 @@
+import videocore
+import gifio
+import time
+import displayio
+import bitmaptools
+
+def gif_animate():
+  gif = gifio.OnDiskGif("/discord-minecraft.gif", le=True)
+  sprite = videocore.Sprite()
+
+  start = time.monotonic()
+  next_delay = gif.next_frame()
+  end = time.monotonic()
+  overhead = end - start
+  sprite.image = gif.bitmap
+  sprite.color_order = 2
+  videocore.HvsChannel1.set_sprite_list([sprite])
+  xmax = videocore.HvsChannel1.width - gif.width
+  ymax = videocore.HvsChannel1.height - gif.height
+
+  xinc = 3;
+  yinc = 4;
+
+  x = 5
+  y = 5
+
+  while True:
+    time.sleep(max(0, next_delay - overhead))
+    next_delay = gif.next_frame()
+    if (x > 0) and (x < xmax):
+      x += xinc
+    else:
+      xinc = xinc * -1
+      x += xinc
+
+    if (y > 0) and (y < ymax):
+      y += yinc
+    else:
+      yinc = yinc * -1
+      y += yinc
+
+    if x < 0:
+      x = 0
+    if y < 0:
+      y = 0
+    sprite.x = x
+    sprite.y = y
+    start = time.monotonic()
+    videocore.HvsChannel1.set_sprite_list([sprite])
+    end = time.monotonic()
+    refresh = end-start
+    #print("refresh time:")
+    #print(refresh)
+
+def make_color_sweep(pixel_format, y, color_order, red_start, red_max, green_start, green_max, blue_start, blue_max):
+  bitmap = displayio.Bitmap(32 * 3, 512 , (1<<16)-1)
+  red = red_max
+  def green(n):
+    return int(n) << green_start
+  def blue(n):
+    return int(n) << blue_start
+  for row in range(512):
+    bitmaptools.draw_line(bitmap, 0, row, 32, row, int(red * (row/512)))
+    bitmaptools.draw_line(bitmap, 32, row, 64, row, int(green(green_max * (row/512))))
+    bitmaptools.draw_line(bitmap, 64, row, 96, row, int(blue(blue_max * (row/512))))
+  sprite = videocore.Sprite()
+  sprite.image = bitmap
+  sprite.color_order = color_order
+  sprite.x = y
+  sprite.pixel_format = pixel_format
+  return sprite
+
+#gif = gifio.OnDiskGif("/ResD1_720X480.gif")
+
+def many_formats():
+  dist = 32*4
+  format1 = make_color_sweep(1, dist * 0, color_order=2, red_start=0, red_max=15, green_start=4, green_max=15, blue_start=8, blue_max=15)
+  format2 = make_color_sweep(2, dist * 1, color_order=2, red_start=0, red_max=31, green_start=5, green_max=31, blue_start=10, blue_max=31)
+  format3 = make_color_sweep(3, dist * 2, color_order=2, red_start=0, red_max=31, green_start=5, green_max=31, blue_start=10, blue_max=31)
+  format4 = make_color_sweep(4, dist * 3, color_order=3, red_start=0, red_max=31, green_start=5, green_max=63, blue_start = 11, blue_max=31)
+  videocore.HvsChannel1.set_sprite_list([format1, format2, format3, format4])
+
+#many_formats()
+gif_animate()
+
+print("Hello World!")

--- a/ports/broadcom/bindings/videocore/code.py
+++ b/ports/broadcom/bindings/videocore/code.py
@@ -23,9 +23,19 @@ def gif_animate():
 
   x = 5
   y = 5
+  lastframe = videocore.HvsChannel1.frame
+  start = time.monotonic()
 
   while True:
+    framedelta = videocore.HvsChannel1.frame - lastframe
+    lastframe = videocore.HvsChannel1.frame
+    #print(f"delta: {framedelta} scanline: {videocore.HvsChannel1.scanline}/{videocore.HvsChannel1.height} overhead: {overhead} next: {next_delay}")
+    end = time.monotonic()
+    overhead = end - start
+
     time.sleep(max(0, next_delay - overhead))
+
+    start = time.monotonic()
     next_delay = gif.next_frame()
     if (x > 0) and (x < xmax):
       x += xinc
@@ -45,10 +55,7 @@ def gif_animate():
       y = 0
     sprite.x = x
     sprite.y = y
-    start = time.monotonic()
     videocore.HvsChannel1.set_sprite_list([sprite])
-    end = time.monotonic()
-    refresh = end-start
     #print("refresh time:")
     #print(refresh)
 
@@ -80,7 +87,29 @@ def many_formats():
   format4 = make_color_sweep(4, dist * 3, color_order=3, red_start=0, red_max=31, green_start=5, green_max=63, blue_start = 11, blue_max=31)
   videocore.HvsChannel1.set_sprite_list([format1, format2, format3, format4])
 
-#many_formats()
-gif_animate()
+def tilegrid():
+  import adafruit_imageload
+  import displayio
+  import board
+  # https://learn.adafruit.com/circuitpython-display-support-using-displayio/sprite-sheet
+  sprite_sheet, palette = adafruit_imageload.load("/cp_sprite_sheet.bmp", bitmap=displayio.Bitmap, palette=displayio.Palette)
+  sprite = displayio.TileGrid(sprite_sheet, pixel_shader=palette, width=2, height=2, tile_width=16, tile_height=16)
+  group = displayio.Group(scale=8)
+  group.append(sprite)
+  display = board.DISPLAY
+  group.x = 30
+  group.y = 30
+  for i in range(30):
+    sprite[0] = i % 6
+    sprite[1] = (i+1) % 6
+    sprite[2] = (i+2) % 6
+    sprite[3] = (i+3) % 6
+    for j in range(100):
+      group.x = j
+      display.show(group)
+      return
+      time.sleep(0.01)
 
-print("Hello World!")
+#many_formats()
+#gif_animate()
+tilegrid()

--- a/ports/broadcom/bindings/videocore/hvs.h
+++ b/ports/broadcom/bindings/videocore/hvs.h
@@ -1,0 +1,95 @@
+#pragma once
+
+enum alpha_mode {
+  alpha_mode_pipeline = 0,      // per-pixel alpha allowed, POS0_ALPHA ignored
+  alpha_mode_fixed = 1,         // use POS0_ALPHA() for entire sprite
+  alpha_mode_fixed_nonzero = 2, // POS0_ALPHA() and per-pixel both have an effect
+  alpha_mode_fixed_over_7 = 3,
+};
+
+enum hvs_pixel_format {
+	/* 8bpp */
+	HVS_PIXEL_FORMAT_RGB332 = 0,
+	/* 16bpp */
+	HVS_PIXEL_FORMAT_RGBA4444 = 1,
+	HVS_PIXEL_FORMAT_RGB555 = 2,
+	HVS_PIXEL_FORMAT_RGBA5551 = 3,
+	HVS_PIXEL_FORMAT_RGB565 = 4,
+	/* 24bpp */
+	HVS_PIXEL_FORMAT_RGB888 = 5,
+	HVS_PIXEL_FORMAT_RGBA6666 = 6,
+	/* 32bpp */
+	HVS_PIXEL_FORMAT_RGBA8888 = 7,
+
+	HVS_PIXEL_FORMAT_YCBCR_YUV420_3PLANE = 8,
+	HVS_PIXEL_FORMAT_YCBCR_YUV420_2PLANE = 9,
+	HVS_PIXEL_FORMAT_YCBCR_YUV422_3PLANE = 10,
+	HVS_PIXEL_FORMAT_YCBCR_YUV422_2PLANE = 11,
+	HVS_PIXEL_FORMAT_H264 = 12,
+	HVS_PIXEL_FORMAT_PALETTE = 13,
+	HVS_PIXEL_FORMAT_YUV444_RGB = 14,
+	HVS_PIXEL_FORMAT_AYUV444_RGB = 15,
+	HVS_PIXEL_FORMAT_RGBA1010102 = 16,
+	HVS_PIXEL_FORMAT_YCBCR_10BIT = 17,
+};
+
+struct hvs_channel {
+  volatile uint32_t dispctrl;
+  volatile uint32_t dispbkgnd;
+  volatile uint32_t dispstat;
+  // 31:30  mode
+  // 29     full
+  // 28     empty
+  // 17:12  frame count
+  // 11:0   line
+  volatile uint32_t dispbase;
+};
+
+extern volatile struct hvs_channel *hvs_hw_channels;
+
+#define CONTROL_FORMAT(n)       (n & 0xf)
+#define CONTROL_END             (1<<31)
+#define CONTROL_VALID           (1<<30)
+#define CONTROL_WORDS(n)        (((n) & 0x3f) << 24)
+#define CONTROL0_FIXED_ALPHA    (1<<19)
+#define CONTROL0_HFLIP          (1<<16)
+#define CONTROL0_VFLIP          (1<<15)
+#define CONTROL_PIXEL_ORDER(n)  ((n & 3) << 13)
+#define CONTROL_SCL1(scl)       (scl << 8)
+#define CONTROL_SCL0(scl)       (scl << 5)
+#define CONTROL_UNITY           (1<<4)
+
+#define POS0_X(n) (n & 0xfff)
+#define POS0_Y(n) ((n & 0xfff) << 12)
+#define POS0_ALPHA(n) ((n & 0xff) << 24)
+
+#define POS2_W(n) (n & 0xffff)
+#define POS2_H(n) ((n & 0xffff) << 16)
+
+#define HVS_PIXEL_ORDER_RGBA			0
+#define HVS_PIXEL_ORDER_BGRA			1
+#define HVS_PIXEL_ORDER_ARGB			2
+#define HVS_PIXEL_ORDER_ABGR			3
+
+#define HVS_PIXEL_ORDER_XBRG			0
+#define HVS_PIXEL_ORDER_XRBG			1
+#define HVS_PIXEL_ORDER_XRGB			2
+#define HVS_PIXEL_ORDER_XBGR			3
+
+#if BCM_VERSION == 2835
+#define BCM_PERIPH_BASE_VIRT 0x20000000
+#endif
+#define SCALER_BASE (BCM_PERIPH_BASE_VIRT + 0x400000)
+
+#define SCALER_DISPCTRL0    (SCALER_BASE + 0x40)
+#define SCALER_DISPCTRLX_ENABLE (1<<31)
+#define SCALER_DISPCTRLX_RESET  (1<<30)
+#define SCALER_DISPCTRL_W(n)    ((n & 0xfff) << 12)
+#define SCALER_DISPCTRL_H(n)    (n & 0xfff)
+
+#define SCALER_DISPLIST0    (SCALER_BASE + 0x20)
+#define SCALER_DISPLIST1    (SCALER_BASE + 0x24)
+#define SCALER_DISPLIST2    (SCALER_BASE + 0x28)
+
+#define SCALER_LIST_MEMORY  (SCALER_BASE + 0x2000)
+#define SCALER5_LIST_MEMORY  (SCALER_BASE + 0x4000)

--- a/ports/broadcom/bindings/videocore/hvs.h
+++ b/ports/broadcom/bindings/videocore/hvs.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "bcm283x.h"
 
 enum alpha_mode {
   alpha_mode_pipeline = 0,      // per-pixel alpha allowed, POS0_ALPHA ignored
@@ -75,11 +76,6 @@ extern volatile struct hvs_channel *hvs_hw_channels;
 #define HVS_PIXEL_ORDER_XRBG			1
 #define HVS_PIXEL_ORDER_XRGB			2
 #define HVS_PIXEL_ORDER_XBGR			3
-
-#if BCM_VERSION == 2835
-#define BCM_PERIPH_BASE_VIRT 0x20000000
-#endif
-#define SCALER_BASE (BCM_PERIPH_BASE_VIRT + 0x400000)
 
 #define SCALER_DISPCTRL0    (SCALER_BASE + 0x40)
 #define SCALER_DISPCTRLX_ENABLE (1<<31)

--- a/ports/broadcom/boards/raspberrypi_zero/board.c
+++ b/ports/broadcom/boards/raspberrypi_zero/board.c
@@ -30,8 +30,14 @@
 #include "bindings/videocore/Framebuffer.h"
 #include "shared-module/displayio/__init__.h"
 #include "shared-bindings/framebufferio/FramebufferDisplay.h"
+#include "bindings/videocore/Hvs.h"
 
 void board_init(void) {
+  hvs_channel_t *display = &allocate_display()->hvs_display;
+  display->channel = 1;
+  display->base.type = &hvs_channel_type;
+  return;
+  /*
     videocore_framebuffer_obj_t *fb = &allocate_display_bus()->videocore;
     fb->base.type = &videocore_framebuffer_type;
     common_hal_videocore_framebuffer_construct(fb, 640, 480);
@@ -43,6 +49,7 @@ void board_init(void) {
         MP_OBJ_FROM_PTR(fb),
         0,
         true);
+  */
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/broadcom/common-hal/microcontroller/__init__.c
+++ b/ports/broadcom/common-hal/microcontroller/__init__.c
@@ -60,7 +60,7 @@ void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
   // there is room for a 6bit int to be smuggled across reset, look into using that
 }
 
-
+// https://learn.adafruit.com/circuitpython-essentials/circuitpython-resetting
 void common_hal_mcu_reset(void) {
   common_hal_mcu_disable_interrupts();
   *REG32(PM_WDOG) = PM_PASSWORD | (1 & PM_WDOG_MASK);

--- a/ports/broadcom/common-hal/microcontroller/__init__.c
+++ b/ports/broadcom/common-hal/microcontroller/__init__.c
@@ -33,6 +33,7 @@
 #include "peripherals/broadcom/interrupts.h"
 
 #include "mphalport.h"
+#include "pm.h"
 
 void common_hal_mcu_delay_us(uint32_t delay) {
     mp_hal_delay_us(delay);
@@ -56,9 +57,18 @@ void common_hal_mcu_enable_interrupts(void) {
 }
 
 void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
+  // there is room for a 6bit int to be smuggled across reset, look into using that
 }
 
+
 void common_hal_mcu_reset(void) {
+  common_hal_mcu_disable_interrupts();
+  *REG32(PM_WDOG) = PM_PASSWORD | (1 & PM_WDOG_MASK);
+  uint32_t t = *REG32(PM_RSTC);
+  t &= PM_RSTC_WRCFG_CLR;
+  t |= 0x20;
+  *REG32(PM_RSTC) = PM_PASSWORD | t;
+  for (;;);
 }
 
 // The singleton microcontroller.Processor object, bound to microcontroller.cpu

--- a/ports/broadcom/pm.h
+++ b/ports/broadcom/pm.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "bcm283x.h"
+
+#define PM_PASSWORD 0x5a000000
+#define PM_RSTC                 (PM_BASE + 0x1c)
+#define PM_RSTC_WRCFG_CLR       0xffffffcf
+#define PM_WDOG                 (PM_BASE + 0x24)
+#define PM_WDOG_MASK            0x00000fff

--- a/shared-bindings/gifio/OnDiskGif.c
+++ b/shared-bindings/gifio/OnDiskGif.c
@@ -123,10 +123,11 @@
 //|         """
 //|         ...
 STATIC mp_obj_t gifio_ondiskgif_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    enum { ARG_filename, ARG_use_palette, NUM_ARGS };
+    enum { ARG_filename, ARG_use_palette, ARG_le, NUM_ARGS };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_filename, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_use_palette, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
+        { MP_QSTR_le, MP_ARG_BOOL | MP_ARG_KW_ONLY, { .u_bool = false} },
     };
     MP_STATIC_ASSERT(MP_ARRAY_SIZE(allowed_args) == NUM_ARGS);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -142,7 +143,7 @@ STATIC mp_obj_t gifio_ondiskgif_make_new(const mp_obj_type_t *type, size_t n_arg
     }
 
     gifio_ondiskgif_t *self = mp_obj_malloc(gifio_ondiskgif_t, &gifio_ondiskgif_type);
-    common_hal_gifio_ondiskgif_construct(self, MP_OBJ_TO_PTR(filename), args[ARG_use_palette].u_bool);
+    common_hal_gifio_ondiskgif_construct(self, MP_OBJ_TO_PTR(filename), args[ARG_use_palette].u_bool, args[ARG_le].u_bool);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/gifio/OnDiskGif.h
+++ b/shared-bindings/gifio/OnDiskGif.h
@@ -32,7 +32,7 @@
 
 extern const mp_obj_type_t gifio_ondiskgif_type;
 
-void common_hal_gifio_ondiskgif_construct(gifio_ondiskgif_t *self, pyb_file_obj_t *file, bool use_palette);
+void common_hal_gifio_ondiskgif_construct(gifio_ondiskgif_t *self, pyb_file_obj_t *file, bool use_palette, bool le);
 
 uint32_t common_hal_gifio_ondiskgif_get_pixel(gifio_ondiskgif_t *bitmap,
     int16_t x, int16_t y);

--- a/shared-module/displayio/TileGrid.c
+++ b/shared-module/displayio/TileGrid.c
@@ -38,7 +38,7 @@ void common_hal_displayio_tilegrid_construct(displayio_tilegrid_t *self, mp_obj_
     mp_obj_t pixel_shader, uint16_t width, uint16_t height,
     uint16_t tile_width, uint16_t tile_height, uint16_t x, uint16_t y, uint8_t default_tile) {
     uint32_t total_tiles = width * height;
-    // Sprites will only have one tile so save a little memory by inlining values in the pointer.
+    // Sprites with only have one tile so save a little memory by inlining values in the pointer.
     uint8_t inline_tiles = sizeof(uint8_t *);
     if (total_tiles <= inline_tiles) {
         self->tiles = 0;

--- a/shared-module/displayio/TileGrid.h
+++ b/shared-module/displayio/TileGrid.h
@@ -40,7 +40,7 @@ typedef struct {
     mp_obj_t pixel_shader;
     int16_t x;
     int16_t y;
-    uint16_t pixel_width;
+    uint16_t pixel_width; // of the entire grid, covering width_in_tiles tiles
     uint16_t pixel_height;
     uint16_t bitmap_width_in_tiles;
     ;

--- a/shared-module/displayio/__init__.h
+++ b/shared-module/displayio/__init__.h
@@ -50,6 +50,7 @@
 // Port unique frame buffers.
 #if CIRCUITPY_VIDEOCORE
 #include "bindings/videocore/Framebuffer.h"
+#include "bindings/videocore/Hvs.h"
 #endif
 #if CIRCUITPY_PICODVI
 #include "bindings/picodvi/Framebuffer.h"
@@ -88,6 +89,7 @@ typedef struct {
         displayio_epaperdisplay_obj_t epaper_display;
         #if CIRCUITPY_FRAMEBUFFERIO
         framebufferio_framebufferdisplay_obj_t framebuffer_display;
+        hvs_channel_t hvs_display;
         #endif
     };
 } primary_display_t;

--- a/shared-module/gifio/OnDiskGif.c
+++ b/shared-module/gifio/OnDiskGif.c
@@ -147,13 +147,17 @@ static void GIFDraw(GIFDRAW *pDraw) {
     }
 }
 
-void common_hal_gifio_ondiskgif_construct(gifio_ondiskgif_t *self, pyb_file_obj_t *file, bool use_palette) {
+void common_hal_gifio_ondiskgif_construct(gifio_ondiskgif_t *self, pyb_file_obj_t *file, bool use_palette, bool le) {
     self->file = file;
 
     if (use_palette == true) {
         GIF_begin(&self->gif, GIF_PALETTE_RGB888);
     } else {
-        GIF_begin(&self->gif, GIF_PALETTE_RGB565_BE);
+        if (le) {
+          GIF_begin(&self->gif, GIF_PALETTE_RGB565_LE);
+        } else {
+          GIF_begin(&self->gif, GIF_PALETTE_RGB565_BE);
+        }
     }
 
     self->gif.iError = GIF_SUCCESS;


### PR DESCRIPTION
the initial 2d accel code, tested and working on a pi-zero
it should work on the entire vc4 family, bcm2836/2836/2837, just need to update `BCM_PERIPH_BASE_VIRT`, or find an existing constant that does the same job

will work on it more tomorrow, but am open to comments

features:
- [x] displaying a bitmap at set coords, with 1:1 scale
- [ ] up/down scaling
- [ ] sprite wide alpha
- [ ] moving the REPL framebuffer into a sprite
- [x] properly handling colors
- [ ] vsync updating
- [ ] aarch64 support
- [ ] bcm2711 support

example `code.py`:
```python
import videocore
import gifio
import time

sprite = videocore.Sprite()
gif = gifio.OnDiskGif("/discord-minecraft.gif")
start = time.monotonic()
next_delay = gif.next_frame()
end = time.monotonic()
overhead = end - start
sprite.image = gif.bitmap

start = time.monotonic()
videocore.HvsChannel1.set_sprite_list([sprite])
end = time.monotonic()
refresh = end-start
print("refresh time:")
print(refresh)

xinc = 3;
yinc = 4;

x = 5
y = 5

while True:
  time.sleep(max(0, next_delay - overhead))
  next_delay = gif.next_frame()
  if (x > 0) and (x < 100):
    x += xinc
  else:
    xinc = xinc * -1
    x += xinc

  if (y > 0) and (y < 100):
    y += yinc
  else:
    yinc = yinc * -1
    y += yinc

  if x < 0:
    x = 0
  if y < 0:
    y = 0
  sprite.x = x
  sprite.y = y
  start = time.monotonic()
  videocore.HvsChannel1.set_sprite_list([sprite])
  end = time.monotonic()
  refresh = end-start
  #print("refresh time:")
  #print(refresh)
```