### PR TITLE
Remove frozen libs from Funhouse (8.2.x)

### DIFF
--- a/ports/espressif/boards/adafruit_funhouse/mpconfigboard.mk
+++ b/ports/espressif/boards/adafruit_funhouse/mpconfigboard.mk
@@ -12,8 +12,4 @@ CIRCUITPY_ESP_FLASH_SIZE = 4MB
 CIRCUITPY_ESPCAMERA = 0
 
 # Include these Python libraries in firmware.
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_PortalBase
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_FakeRequests
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Requests
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Display_Text


### PR DESCRIPTION
#8348 but for 8.2.x