### PR TITLE
[ESPCAMERA] Deinit all the pins.

### DIFF
--- a/ports/espressif/common-hal/espcamera/Camera.c
+++ b/ports/espressif/common-hal/espcamera/Camera.c
@@ -161,6 +161,10 @@ extern void common_hal_espcamera_camera_deinit(espcamera_camera_obj_t *self) {
 
     esp_camera_deinit();
 
+    reset_pin_number(self->camera_config.pin_pclk);
+    reset_pin_number(self->camera_config.pin_vsync);
+    reset_pin_number(self->camera_config.pin_href);
+
     self->camera_config.xclk_freq_hz = 0;
 }
 


### PR DESCRIPTION
What the title says.
Without this, if you deinit your camera object, you have to reload to be able to use the pins.