### PR TITLE
8.2.x revert #8089 nrf uart power saving

### DIFF
--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -266,15 +266,8 @@ bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {
 }
 
 void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
-    volatile uint32_t *power_cycle = (void*)(self->uarte->p_reg) + 0xFFC;
     if (!common_hal_busio_uart_deinited(self)) {
-        nrfx_uarte_rx_abort(self->uarte);
-        nrfx_uarte_tx_abort(self->uarte);
         nrfx_uarte_uninit(self->uarte);
-        // power cycle the peripheral as per https://devzone.nordicsemi.com/f/nordic-q-a/26030/how-to-reach-nrf52840-uarte-current-supply-specification/102605#102605
-        *power_cycle = 0;
-        *power_cycle;
-        *power_cycle = 1;
         reset_pin_number(self->tx_pin_number);
         reset_pin_number(self->rx_pin_number);
         reset_pin_number(self->rts_pin_number);

--- a/ports/nrf/common-hal/busio/UART.c
+++ b/ports/nrf/common-hal/busio/UART.c
@@ -266,7 +266,7 @@ bool common_hal_busio_uart_deinited(busio_uart_obj_t *self) {
 }
 
 void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
-    volatile uint32_t *power_cycle = (void *)(self->uarte->p_reg) + 0xFFC;
+    volatile uint32_t *power_cycle = (void*)(self->uarte->p_reg) + 0xFFC;
     if (!common_hal_busio_uart_deinited(self)) {
         nrfx_uarte_rx_abort(self->uarte);
         nrfx_uarte_tx_abort(self->uarte);


### PR DESCRIPTION
- Fixes #8366.

It would be nice to rework #8089 in the long run, since it does address a sleep power problem.

I had to manually revert the commits to do this on the 8.2.x branch. Pressing the "revert" button and changing the base did not work out.

Tagging @furbrain for interest.