### PR TITLE
82.x - Remove keyword-only requirement for SSLContext.load_verify_locations() arg

### DIFF
--- a/shared-bindings/ssl/SSLContext.c
+++ b/shared-bindings/ssl/SSLContext.c
@@ -101,7 +101,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(ssl_sslcontext_load_cert_chain_obj, 1, ssl_ssl
 STATIC mp_obj_t ssl_sslcontext_load_verify_locations(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_cadata };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_cadata, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_cadata, MP_ARG_OBJ, {.u_obj = mp_const_none} },
     };
     ssl_sslcontext_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
 


### PR DESCRIPTION
- Fixes #8380.