### PR TITLE
fixing the wrong rx,tx gpio related issue in 8.2.x for board waveshare-esp32-s3-pico

### DIFF
--- a/ports/espressif/boards/waveshare_esp32_s3_pico/board.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_pico/board.c
@@ -25,15 +25,5 @@
  */
 
 #include "supervisor/board.h"
-#include "mpconfigboard.h"
-#include "shared-bindings/microcontroller/Pin.h"
-
-void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
-}
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/waveshare_esp32_s3_pico/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_pico/mpconfigboard.h
@@ -26,13 +26,13 @@
 
 // Micropython setup
 
-#define MICROPY_HW_BOARD_NAME       "ESP32-S3-Pico"
+#define MICROPY_HW_BOARD_NAME       "Waveshare ESP32-S3-Pico"
 #define MICROPY_HW_MCU_NAME         "ESP32S3"
 
 #define MICROPY_HW_NEOPIXEL         (&pin_GPIO21)
 
-#define DEFAULT_UART_BUS_RX         (&pin_GPIO44)
-#define DEFAULT_UART_BUS_TX         (&pin_GPIO43)
+#define DEFAULT_UART_BUS_RX         (&pin_GPIO12)
+#define DEFAULT_UART_BUS_TX         (&pin_GPIO11)
 
 #define DEFAULT_I2C_BUS_SCL (&pin_GPIO18)
 #define DEFAULT_I2C_BUS_SDA (&pin_GPIO17)

--- a/ports/espressif/boards/waveshare_esp32_s3_pico/pins.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_pico/pins.c
@@ -39,11 +39,10 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO11) },
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO12) },
 
-    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
-
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO18) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO17) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
Updating the rx tx gpio numbers suggested by @dhalbert in #8372 .