### PR TITLE
M5X lower reserved PSRAM since it's unneeded

### DIFF
--- a/ports/espressif/boards/m5stack_timer_camera_x/mpconfigboard.h
+++ b/ports/espressif/boards/m5stack_timer_camera_x/mpconfigboard.h
@@ -45,4 +45,4 @@
 #define CIRCUITPY_I2C_ALLOW_INTERNAL_PULL_UP (1)
 
 // `espcamera.FrameSize.QXGA` & wifi connected only use 834028.
-#define DEFAULT_RESERVED_PSRAM      (1048576)
+#define DEFAULT_RESERVED_PSRAM      (1572864)

--- a/ports/espressif/boards/m5stack_timer_camera_x/mpconfigboard.h
+++ b/ports/espressif/boards/m5stack_timer_camera_x/mpconfigboard.h
@@ -44,5 +44,5 @@
 
 #define CIRCUITPY_I2C_ALLOW_INTERNAL_PULL_UP (1)
 
-// espcamera.FrameSize.QXGA, half a megabyte result image.jpeg
-#define DEFAULT_RESERVED_PSRAM      (1572864)
+// `espcamera.FrameSize.QXGA` & wifi connected only use 834028.
+#define DEFAULT_RESERVED_PSRAM      (1048576)


### PR DESCRIPTION
Tested with:

```py
a = espcamera.Camera(data_pins=board.D, pixel_clock_pin=board.PCLK, vsync_pin=board.VSYNC, href_pin=board.HREF, i2c=board.SSCB_I2C(), external_clock_pin=board.XCLK, external_clock_frequency=20_000_000, powerdown_pin=None, reset_pin=board.RESET, pixel_format=espcamera.PixelFormat.JPEG, frame_size=espcamera.FrameSize.QXGA, jpeg_quality=55, framebuffer_count=2, grab_mode=espcamera.GrabMode.LATEST)
```

Which is the absolute maximum and the wifi connected.