### PR TITLE
Update bpi_leaf_s3

### DIFF
--- a/ports/espressif/boards/bpi_leaf_s3/mpconfigboard.h
+++ b/ports/espressif/boards/bpi_leaf_s3/mpconfigboard.h
@@ -40,3 +40,5 @@
 
 #define DEFAULT_UART_BUS_RX         (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX         (&pin_GPIO43)
+
+#define DOUBLE_TAP_PIN (&pin_GPIO34)


### PR DESCRIPTION
New BPI-Leaf-S3 v1.1 version support double-clicking the reset button to enter the UF2 bootloader.

for tinyUF2 https://github.com/adafruit/tinyuf2/pull/347

for circuitpython-org https://github.com/adafruit/circuitpython-org/pull/1252