### PR TITLE
Update documentation for rotaryio.IncrementalEncoder

### DIFF
--- a/shared-bindings/rotaryio/IncrementalEncoder.c
+++ b/shared-bindings/rotaryio/IncrementalEncoder.c
@@ -35,7 +35,9 @@
 #include "shared-bindings/util.h"
 
 //| class IncrementalEncoder:
-//|     """IncrementalEncoder determines the relative rotational position based on two series of pulses."""
+//|     """IncrementalEncoder determines the relative rotational position based on two series of pulses.
+//|	   It assumes that the encoder's common pin(s) are connected to ground,and enables pull-ups on
+//|	   pin_a and pin_b."""
 //|
 //|     def __init__(
 //|         self, pin_a: microcontroller.Pin, pin_b: microcontroller.Pin, divisor: int = 4


### PR DESCRIPTION
Update the documentation in circuitpython/shared-bindings/rotaryio/IncrementalEncoder.c to explicitly state that rotaryio.IncrementalEncoder assumes the encoder's pins are connected to ground and sets pull-ups on the pins accordingly.

Closes #5847