### PR TITLE
Remove deprecated apis

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -84,8 +84,10 @@ shared-bindings/frequencyio/__init__.rst shared-bindings/frequencyio/
 shared-bindings/gnss/__init__.rst shared-bindings/gnss/
 shared-bindings/i2cperipheral/__init__.rst shared-bindings/i2cperipheral/
 shared-bindings/i2csecondary/__init__.rst shared-bindings/i2csecondary/
-shared-bindings/i2cslave/I2CSlave.rst shared-bindings/i2cperipheral/#i2cperipheral.I2CPeripheral
-shared-bindings/i2cslave/I2CSlaveRequest.rst shared-bindings/i2cperipheral/#i2cperipheral.I2CPeripheralRequest
+shared-bindings/i2cslave/I2CSlave.rst shared-bindings/i2cperipheral/#i2ctarget.Target
+shared-bindings/i2cslave/I2CSlaveRequest.rst shared-bindings/i2cperipheral/#i2ctarget.I2CTargetRequest
+shared-bindings/i2cperipheral/I2CPeripheral.rst shared-bindings/i2ctarget/#i2ctarget.I2CTarget
+shared-bindings/i2cperipheral/I2CPeripheralRequest.rst shared-bindings/i2ctarget/#i2ctarget.I2CTargetRequest
 shared-bindings/math/__init__.rst shared-bindings/math/
 shared-bindings/microcontroller/Pin.rst shared-bindings/microcontroller/#microcontroller.Pin
 shared-bindings/microcontroller/Processor.rst shared-bindings/microcontroller/#microcontroller.Processor

--- a/shared-bindings/displayio/Display.c
+++ b/shared-bindings/displayio/Display.c
@@ -239,33 +239,6 @@ static displayio_display_obj_t *native_display(mp_obj_t display_obj) {
     return MP_OBJ_TO_PTR(native_display);
 }
 
-//|     def show(self, group: Group) -> None:
-//|         """
-//|         .. note:: `show()` is deprecated and will be removed in CircuitPython 9.0.0.
-//|           Use ``.root_group = group`` instead.
-//|
-//|         Switches to displaying the given group of layers. When group is None, the default
-//|         CircuitPython terminal will be shown.
-//|
-//|         :param Group group: The group to show.
-//|
-//|         """
-//|         ...
-STATIC mp_obj_t displayio_display_obj_show(mp_obj_t self_in, mp_obj_t group_in) {
-    displayio_display_obj_t *self = native_display(self_in);
-    displayio_group_t *group = NULL;
-    if (group_in != mp_const_none) {
-        group = MP_OBJ_TO_PTR(native_group(group_in));
-    }
-
-    bool ok = common_hal_displayio_display_show(self, group);
-    if (!ok) {
-        mp_raise_ValueError(translate("Group already used"));
-    }
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_2(displayio_display_show_obj, displayio_display_obj_show);
-
 //|     def refresh(
 //|         self,
 //|         *,
@@ -512,7 +485,6 @@ STATIC mp_obj_t displayio_display_obj_fill_row(size_t n_args, const mp_obj_t *po
 MP_DEFINE_CONST_FUN_OBJ_KW(displayio_display_fill_row_obj, 1, displayio_display_obj_fill_row);
 
 STATIC const mp_rom_map_elem_t displayio_display_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_show), MP_ROM_PTR(&displayio_display_show_obj) },
     { MP_ROM_QSTR(MP_QSTR_refresh), MP_ROM_PTR(&displayio_display_refresh_obj) },
     { MP_ROM_QSTR(MP_QSTR_fill_row), MP_ROM_PTR(&displayio_display_fill_row_obj) },
 

--- a/shared-bindings/displayio/Display.h
+++ b/shared-bindings/displayio/Display.h
@@ -46,9 +46,6 @@ void common_hal_displayio_display_construct(displayio_display_obj_t *self,
     bool single_byte_bounds, bool data_as_commands, bool auto_refresh, uint16_t native_frames_per_second,
     bool backlight_on_high, bool SH1107_addressing, uint16_t backlight_pwm_frequency);
 
-bool common_hal_displayio_display_show(displayio_display_obj_t *self,
-    displayio_group_t *root_group);
-
 bool common_hal_displayio_display_refresh(displayio_display_obj_t *self, uint32_t target_ms_per_frame, uint32_t maximum_ms_per_real_frame);
 
 bool common_hal_displayio_display_get_auto_refresh(displayio_display_obj_t *self);

--- a/shared-bindings/displayio/EPaperDisplay.c
+++ b/shared-bindings/displayio/EPaperDisplay.c
@@ -245,31 +245,6 @@ static displayio_epaperdisplay_obj_t *native_display(mp_obj_t display_obj) {
     return MP_OBJ_TO_PTR(native_display);
 }
 
-//|     def show(self, group: Group) -> None:
-//|         """
-//|         .. note:: `show()` is deprecated and will be removed in CircuitPython 9.0.0.
-//|           Use ``.root_group = group`` instead.
-//|
-//|         Switches to displaying the given group of layers. When group is None, the default
-//|         CircuitPython terminal will be shown.
-//|
-//|         :param Group group: The group to show."""
-//|         ...
-STATIC mp_obj_t displayio_epaperdisplay_obj_show(mp_obj_t self_in, mp_obj_t group_in) {
-    displayio_epaperdisplay_obj_t *self = native_display(self_in);
-    displayio_group_t *group = NULL;
-    if (group_in != mp_const_none) {
-        group = MP_OBJ_TO_PTR(native_group(group_in));
-    }
-
-    bool ok = common_hal_displayio_epaperdisplay_show(self, group);
-    if (!ok) {
-        mp_raise_ValueError(translate("Group already used"));
-    }
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_2(displayio_epaperdisplay_show_obj, displayio_epaperdisplay_obj_show);
-
 //|     def update_refresh_mode(
 //|         self, start_sequence: ReadableBuffer, seconds_per_frame: float = 180
 //|     ) -> None:
@@ -415,7 +390,6 @@ MP_PROPERTY_GETSET(displayio_epaperdisplay_root_group_obj,
     (mp_obj_t)&displayio_epaperdisplay_set_root_group_obj);
 
 STATIC const mp_rom_map_elem_t displayio_epaperdisplay_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_show), MP_ROM_PTR(&displayio_epaperdisplay_show_obj) },
     { MP_ROM_QSTR(MP_QSTR_update_refresh_mode), MP_ROM_PTR(&displayio_epaperdisplay_update_refresh_mode_obj) },
     { MP_ROM_QSTR(MP_QSTR_refresh), MP_ROM_PTR(&displayio_epaperdisplay_refresh_obj) },
 

--- a/shared-bindings/displayio/EPaperDisplay.h
+++ b/shared-bindings/displayio/EPaperDisplay.h
@@ -52,8 +52,6 @@ void common_hal_displayio_epaperdisplay_construct(displayio_epaperdisplay_obj_t 
 
 bool common_hal_displayio_epaperdisplay_refresh(displayio_epaperdisplay_obj_t *self);
 
-bool common_hal_displayio_epaperdisplay_show(displayio_epaperdisplay_obj_t *self, displayio_group_t *root_group);
-
 mp_obj_t common_hal_displayio_epaperdisplay_get_root_group(displayio_epaperdisplay_obj_t *self);
 bool common_hal_displayio_epaperdisplay_set_root_group(displayio_epaperdisplay_obj_t *self, displayio_group_t *root_group);
 

--- a/shared-bindings/displayio/OnDiskBitmap.c
+++ b/shared-bindings/displayio/OnDiskBitmap.c
@@ -50,7 +50,7 @@
 //|
 //|       board.DISPLAY.brightness = 0
 //|       splash = displayio.Group()
-//|       board.DISPLAY.show(splash)
+//|       board.DISPLAY.root_group = splash
 //|
 //|       odb = displayio.OnDiskBitmap('/sample.bmp')
 //|       face = displayio.TileGrid(odb, pixel_shader=odb.pixel_shader)

--- a/shared-bindings/framebufferio/FramebufferDisplay.c
+++ b/shared-bindings/framebufferio/FramebufferDisplay.c
@@ -99,27 +99,6 @@ static framebufferio_framebufferdisplay_obj_t *native_display(mp_obj_t display_o
     return MP_OBJ_TO_PTR(native_display);
 }
 
-//|     def show(self, group: displayio.Group) -> None:
-//|         """Switches to displaying the given group of layers. When group is None, the default
-//|         CircuitPython terminal will be shown.
-//|
-//|         :param Group group: The group to show."""
-//|         ...
-STATIC mp_obj_t framebufferio_framebufferdisplay_obj_show(mp_obj_t self_in, mp_obj_t group_in) {
-    framebufferio_framebufferdisplay_obj_t *self = native_display(self_in);
-    displayio_group_t *group = NULL;
-    if (group_in != mp_const_none) {
-        group = MP_OBJ_TO_PTR(native_group(group_in));
-    }
-
-    bool ok = common_hal_framebufferio_framebufferdisplay_show(self, group);
-    if (!ok) {
-        mp_raise_ValueError(translate("Group already used"));
-    }
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_2(framebufferio_framebufferdisplay_show_obj, framebufferio_framebufferdisplay_obj_show);
-
 //|     def refresh(
 //|         self, *, target_frames_per_second: int = 60, minimum_frames_per_second: int = 1
 //|     ) -> bool:
@@ -354,7 +333,6 @@ MP_PROPERTY_GETSET(framebufferio_framebufferdisplay_root_group_obj,
     (mp_obj_t)&framebufferio_framebufferdisplay_set_root_group_obj);
 
 STATIC const mp_rom_map_elem_t framebufferio_framebufferdisplay_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR_show), MP_ROM_PTR(&framebufferio_framebufferdisplay_show_obj) },
     { MP_ROM_QSTR(MP_QSTR_refresh), MP_ROM_PTR(&framebufferio_framebufferdisplay_refresh_obj) },
     { MP_ROM_QSTR(MP_QSTR_fill_row), MP_ROM_PTR(&framebufferio_framebufferdisplay_fill_row_obj) },
 

--- a/shared-bindings/framebufferio/FramebufferDisplay.h
+++ b/shared-bindings/framebufferio/FramebufferDisplay.h
@@ -42,9 +42,6 @@ void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebu
     uint16_t rotation,
     bool auto_refresh);
 
-bool common_hal_framebufferio_framebufferdisplay_show(framebufferio_framebufferdisplay_obj_t *self,
-    displayio_group_t *root_group);
-
 bool common_hal_framebufferio_framebufferdisplay_refresh(framebufferio_framebufferdisplay_obj_t *self, uint32_t target_ms_per_frame, uint32_t maximum_ms_per_real_frame);
 
 bool common_hal_framebufferio_framebufferdisplay_get_auto_refresh(framebufferio_framebufferdisplay_obj_t *self);

--- a/shared-bindings/i2ctarget/__init__.c
+++ b/shared-bindings/i2ctarget/__init__.c
@@ -30,7 +30,6 @@
 #include "py/runtime.h"
 
 #include "shared-bindings/microcontroller/Pin.h"
-// #include "shared-bindings/i2ctarget/__init__.h"
 #include "shared-bindings/i2ctarget/I2CTarget.h"
 
 #include "py/runtime.h"
@@ -95,8 +94,6 @@
 STATIC const mp_rom_map_elem_t i2ctarget_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_i2ctarget) },
     { MP_ROM_QSTR(MP_QSTR_I2CTarget), MP_ROM_PTR(&i2ctarget_i2c_target_type) },
-    // TODO: Remove for CircuitPython 9.0.0
-    { MP_ROM_QSTR(MP_QSTR_I2CPeripheral), MP_ROM_PTR(&i2ctarget_i2c_target_type) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(i2ctarget_module_globals, i2ctarget_module_globals_table);

--- a/shared-module/displayio/Display.c
+++ b/shared-module/displayio/Display.c
@@ -140,13 +140,6 @@ void common_hal_displayio_display_construct(displayio_display_obj_t *self,
     common_hal_displayio_display_set_auto_refresh(self, auto_refresh);
 }
 
-bool common_hal_displayio_display_show(displayio_display_obj_t *self, displayio_group_t *root_group) {
-    if (root_group == NULL) {
-        root_group = &circuitpython_splash;
-    }
-    return displayio_display_core_set_root_group(&self->core, root_group);
-}
-
 uint16_t common_hal_displayio_display_get_width(displayio_display_obj_t *self) {
     return displayio_display_core_get_width(&self->core);
 }

--- a/shared-module/displayio/EPaperDisplay.c
+++ b/shared-module/displayio/EPaperDisplay.c
@@ -116,14 +116,7 @@ void common_hal_displayio_epaperdisplay_construct(displayio_epaperdisplay_obj_t 
 
     // Set the group after initialization otherwise we may send pixels while we delay in
     // initialization.
-    common_hal_displayio_epaperdisplay_show(self, &circuitpython_splash);
-}
-
-bool common_hal_displayio_epaperdisplay_show(displayio_epaperdisplay_obj_t *self, displayio_group_t *root_group) {
-    if (root_group == NULL) {
-        root_group = &circuitpython_splash;
-    }
-    return displayio_display_core_set_root_group(&self->core, root_group);
+    common_hal_displayio_epaperdisplay_set_root_group(self, &circuitpython_splash);
 }
 
 bool common_hal_displayio_epaperdisplay_set_root_group(displayio_epaperdisplay_obj_t *self, displayio_group_t *root_group) {
@@ -501,6 +494,11 @@ void release_epaperdisplay(displayio_epaperdisplay_obj_t *self) {
     if (self->busy.base.type == &digitalio_digitalinout_type) {
         common_hal_digitalio_digitalinout_deinit(&self->busy);
     }
+}
+
+void displayio_epaperdisplay_reset(displayio_epaperdisplay_obj_t *self) {
+    displayio_display_core_set_root_group(&self->core, &circuitpython_splash);
+    self->core.full_refresh = true;
 }
 
 void displayio_epaperdisplay_collect_ptrs(displayio_epaperdisplay_obj_t *self) {

--- a/shared-module/displayio/EPaperDisplay.h
+++ b/shared-module/displayio/EPaperDisplay.h
@@ -62,6 +62,7 @@ typedef struct {
 void displayio_epaperdisplay_change_refresh_mode_parameters(displayio_epaperdisplay_obj_t *self,
     mp_buffer_info_t *start_sequence, float seconds_per_frame);
 void displayio_epaperdisplay_background(displayio_epaperdisplay_obj_t *self);
+void displayio_epaperdisplay_reset(displayio_epaperdisplay_obj_t *self);
 void release_epaperdisplay(displayio_epaperdisplay_obj_t *self);
 size_t maybe_refresh_epaperdisplay(void);
 

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -302,7 +302,7 @@ void reset_displays(void) {
             reset_display(&displays[i].display);
         } else if (display_type == &displayio_epaperdisplay_type) {
             displayio_epaperdisplay_obj_t *display = &displays[i].epaper_display;
-            common_hal_displayio_epaperdisplay_show(display, NULL);
+            displayio_epaperdisplay_reset(display);
         #if CIRCUITPY_FRAMEBUFFERIO
         } else if (display_type == &framebufferio_framebufferdisplay_type) {
             framebufferio_framebufferdisplay_reset(&displays[i].framebuffer_display);

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -100,15 +100,8 @@ void common_hal_framebufferio_framebufferdisplay_construct(framebufferio_framebu
 
     // Set the group after initialization otherwise we may send pixels while we delay in
     // initialization.
-    common_hal_framebufferio_framebufferdisplay_show(self, &circuitpython_splash);
+    displayio_display_core_set_root_group(&self->core, &circuitpython_splash);
     common_hal_framebufferio_framebufferdisplay_set_auto_refresh(self, auto_refresh);
-}
-
-bool common_hal_framebufferio_framebufferdisplay_show(framebufferio_framebufferdisplay_obj_t *self, displayio_group_t *root_group) {
-    if (root_group == NULL) {
-        root_group = &circuitpython_splash;
-    }
-    return displayio_display_core_set_root_group(&self->core, root_group);
 }
 
 uint16_t common_hal_framebufferio_framebufferdisplay_get_width(framebufferio_framebufferdisplay_obj_t *self) {
@@ -360,7 +353,7 @@ void framebufferio_framebufferdisplay_reset(framebufferio_framebufferdisplay_obj
     const mp_obj_type_t *fb_type = mp_obj_get_type(self->framebuffer);
     if (fb_type != NULL && fb_type != &mp_type_NoneType) {
         common_hal_framebufferio_framebufferdisplay_set_auto_refresh(self, true);
-        common_hal_framebufferio_framebufferdisplay_show(self, NULL);
+        displayio_display_core_set_root_group(&self->core, &circuitpython_splash);
         self->core.full_refresh = true;
     } else {
         release_framebufferdisplay(self);


### PR DESCRIPTION
This removes `.show()` in favor of `.root_group = `. One other spot for `I2CPeripheral` removed too.