### PR TITLE
Fix pin adc unit check

### DIFF
--- a/ports/espressif/common-hal/analogio/AnalogIn.c
+++ b/ports/espressif/common-hal/analogio/AnalogIn.c
@@ -63,7 +63,7 @@
 
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self,
     const mcu_pin_obj_t *pin) {
-    if (pin->adc_index == 0 || pin->adc_channel == NO_ADC_CHANNEL) {
+    if (pin->adc_index == NO_ADC || pin->adc_channel == NO_ADC_CHANNEL) {
         raise_ValueError_invalid_pin();
     }
     common_hal_mcu_pin_claim(pin);


### PR DESCRIPTION
IDF5 made 0 valid. Use the NO_ADC macro instead