### PR TITLE
Add qrio.QRDecoder.find() to locate codes without decoding

### DIFF
--- a/shared-bindings/qrio/QRDecoder.c
+++ b/shared-bindings/qrio/QRDecoder.c
@@ -56,6 +56,19 @@ STATIC mp_obj_t qrio_qrdecoder_make_new(const mp_obj_type_t *type, size_t n_args
     return self;
 }
 
+
+STATIC void verify_buffer_size(qrio_qrdecoder_obj_t *self, mp_obj_t *buffer, size_t len, qrio_pixel_policy_t policy) {
+    int width = shared_module_qrio_qrdecoder_get_width(self);
+    int height = shared_module_qrio_qrdecoder_get_height(self);
+
+    // verify that the buffer is big enough
+    int sz = width * height;
+    if (policy != QRIO_EVERY_BYTE) {
+        sz *= 2;
+    }
+    mp_get_index(mp_obj_get_type(*buffer), len, MP_OBJ_NEW_SMALL_INT(sz - 1), false);
+}
+
 //|     def decode(
 //|         self, buffer: ReadableBuffer, pixel_policy: PixelPolicy = PixelPolicy.EVERY_BYTE
 //|     ) -> List[QRInfo]:
@@ -73,21 +86,38 @@ STATIC mp_obj_t qrio_qrdecoder_decode(size_t n_args, const mp_obj_t *pos_args, m
 
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_READ);
-
-    int width = shared_module_qrio_qrdecoder_get_width(self);
-    int height = shared_module_qrio_qrdecoder_get_height(self);
-
-    // verify that the buffer is big enough
-    int sz = width * height;
     qrio_pixel_policy_t policy = cp_enum_value(&qrio_pixel_policy_type, args[ARG_pixel_policy].u_obj, MP_QSTR_pixel_policy);
-    if (policy != QRIO_EVERY_BYTE) {
-        sz *= 2;
-    }
-    mp_get_index(mp_obj_get_type(args[ARG_buffer].u_obj), bufinfo.len, MP_OBJ_NEW_SMALL_INT(sz - 1), false);
+    verify_buffer_size(self, &args[ARG_buffer].u_obj, bufinfo.len, policy);
 
     return shared_module_qrio_qrdecoder_decode(self, &bufinfo, policy);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(qrio_qrdecoder_decode_obj, 1, qrio_qrdecoder_decode);
+
+
+//|     def find(
+//|         self, buffer: ReadableBuffer, pixel_policy: PixelPolicy = PixelPolicy.EVERY_BYTE
+//|     ) -> List[QRPosition]:
+//|         """Find all visible QR codes from the given image.  The size of the buffer must be at least ``length``×``width`` bytes for `EVERY_BYTE`, and 2×``length``×``width`` bytes for `EVEN_BYTES` or `ODD_BYTES`."""
+STATIC mp_obj_t qrio_qrdecoder_find(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    qrio_qrdecoder_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+
+    enum { ARG_buffer, ARG_pixel_policy };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_buffer, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_int = 0} },
+        { MP_QSTR_pixel_policy, MP_ARG_OBJ, {.u_obj = MP_ROM_PTR((mp_obj_t *)&qrio_pixel_policy_EVERY_BYTE_obj)} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_READ);
+    qrio_pixel_policy_t policy = cp_enum_value(&qrio_pixel_policy_type, args[ARG_pixel_policy].u_obj, MP_QSTR_pixel_policy);
+    verify_buffer_size(self, &args[ARG_buffer].u_obj, bufinfo.len, policy);
+
+    return shared_module_qrio_qrdecoder_find(self, &bufinfo, policy);
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(qrio_qrdecoder_find_obj, 1, qrio_qrdecoder_find);
+
 
 //|     width: int
 //|     """The width of image the decoder expects"""
@@ -135,6 +165,7 @@ STATIC const mp_rom_map_elem_t qrio_qrdecoder_locals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&qrio_qrdecoder_width_obj) },
     { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&qrio_qrdecoder_height_obj) },
     { MP_ROM_QSTR(MP_QSTR_decode), MP_ROM_PTR(&qrio_qrdecoder_decode_obj) },
+    { MP_ROM_QSTR(MP_QSTR_find), MP_ROM_PTR(&qrio_qrdecoder_find_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(qrio_qrdecoder_locals, qrio_qrdecoder_locals_table);

--- a/shared-bindings/qrio/QRInfo.c
+++ b/shared-bindings/qrio/QRInfo.c
@@ -63,3 +63,66 @@ const mp_obj_namedtuple_type_t qrio_qrinfo_type_obj = {
         MP_QSTR_data_type,
     },
 };
+
+//| class QRPosition:
+//|     """Information about a non-decoded QR code"""
+//|
+//|     top_left_x: int
+//|     """X coordinate of the top left corner"""
+//|
+//|     top_left_y: int
+//|     """Y coordinate of the top left corner"""
+//|
+//|     top_right_x: int
+//|     """X coordinate of the top right corner"""
+//|
+//|     top_right_y: int
+//|     """Y coordinate of the top right corner"""
+//|
+//|     bottom_right_x: int
+//|     """X coordinate of the bottom right corner"""
+//|
+//|     bottom_right_y: int
+//|     """Y coordinate of the bottom right corner"""
+//|
+//|     bottom_left_x: int
+//|     """X coordinate of the bottom left corner"""
+//|
+//|     bottom_left_y: int
+//|     """Y coordinate of the bottom left corner"""
+//|
+//|     size: int
+//|     """The number of bits the code contains"""
+//|
+
+const mp_obj_namedtuple_type_t qrio_qrposition_type_obj = {
+    .base = {
+        .base = {
+            .type = &mp_type_type
+        },
+        .flags = MP_TYPE_FLAG_EXTENDED,
+        .name = MP_QSTR_QRPosition,
+        .print = namedtuple_print,
+        .parent = &mp_type_tuple,
+        .make_new = namedtuple_make_new,
+        .attr = namedtuple_attr,
+        MP_TYPE_EXTENDED_FIELDS(
+            .unary_op = mp_obj_tuple_unary_op,
+            .binary_op = mp_obj_tuple_binary_op,
+            .subscr = mp_obj_tuple_subscr,
+            .getiter = mp_obj_tuple_getiter,
+            ),
+    },
+    .n_fields = 9,
+    .fields = {
+        MP_QSTR_top_left_x,
+        MP_QSTR_top_left_y,
+        MP_QSTR_top_right_x,
+        MP_QSTR_top_right_y,
+        MP_QSTR_bottom_right_x,
+        MP_QSTR_bottom_right_y,
+        MP_QSTR_bottom_left_x,
+        MP_QSTR_bottom_left_y,
+        MP_QSTR_size,
+    },
+};

--- a/shared-bindings/qrio/QRInfo.h
+++ b/shared-bindings/qrio/QRInfo.h
@@ -29,3 +29,4 @@
 #include "py/objnamedtuple.h"
 
 extern const mp_obj_namedtuple_type_t qrio_qrinfo_type_obj;
+extern const mp_obj_namedtuple_type_t qrio_qrposition_type_obj;

--- a/shared-module/qrio/QRDecoder.h
+++ b/shared-module/qrio/QRDecoder.h
@@ -43,3 +43,4 @@ int shared_module_qrio_qrdecoder_get_width(qrdecoder_qrdecoder_obj_t *);
 void shared_module_qrio_qrdecoder_set_height(qrdecoder_qrdecoder_obj_t *, int height);
 void shared_module_qrio_qrdecoder_set_width(qrdecoder_qrdecoder_obj_t *, int width);
 mp_obj_t shared_module_qrio_qrdecoder_decode(qrdecoder_qrdecoder_obj_t *, const mp_buffer_info_t *bufinfo, qrio_pixel_policy_t policy);
+mp_obj_t shared_module_qrio_qrdecoder_find(qrdecoder_qrdecoder_obj_t *, const mp_buffer_info_t *bufinfo, qrio_pixel_policy_t policy);


### PR DESCRIPTION
Fix #8452