### PR TITLE
DotClock Touch Screen pin fixes/additions

### DIFF
--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8_hacktablet/mpconfigboard.h
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8_hacktablet/mpconfigboard.h
@@ -31,6 +31,9 @@
 
 #define MICROPY_HW_NEOPIXEL         (&pin_GPIO48)
 
+#define DEFAULT_I2C_BUS_SCL         (&pin_GPIO41)
+#define DEFAULT_I2C_BUS_SDA         (&pin_GPIO42)
+
 #define DEFAULT_UART_BUS_RX         (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX         (&pin_GPIO43)
 

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8_hacktablet/pins.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8_hacktablet/pins.c
@@ -71,9 +71,9 @@ MP_DEFINE_CONST_DICT(timings800_dict, timings800_table);
 STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
 
-    { MP_ROM_QSTR(MP_QSTR_TFT), MP_ROM_PTR(&tft_dict) },
-    { MP_ROM_QSTR(MP_QSTR_TIMINGS800), MP_ROM_PTR(&timings800_dict) },
-    { MP_ROM_QSTR(MP_QSTR_BACKLIGHT), MP_ROM_PTR(&pin_GPIO39) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_PINS), MP_ROM_PTR(&tft_dict) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_TIMINGS), MP_ROM_PTR(&timings800_dict) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_BACKLIGHT), MP_ROM_PTR(&pin_GPIO39) },
 
     { MP_ROM_QSTR(MP_QSTR_IO0), MP_ROM_PTR(&pin_GPIO0) },
     { MP_ROM_QSTR(MP_QSTR_IO1), MP_ROM_PTR(&pin_GPIO1) },
@@ -103,9 +103,9 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IO37), MP_ROM_PTR(&pin_GPIO37) },
     { MP_ROM_QSTR(MP_QSTR_IO38), MP_ROM_PTR(&pin_GPIO38) },
     { MP_ROM_QSTR(MP_QSTR_IO39), MP_ROM_PTR(&pin_GPIO39) },
-    { MP_ROM_QSTR(MP_QSTR_IO40), MP_ROM_PTR(&pin_GPIO40) },
-    { MP_ROM_QSTR(MP_QSTR_IO41), MP_ROM_PTR(&pin_GPIO41) },
-    { MP_ROM_QSTR(MP_QSTR_IO42), MP_ROM_PTR(&pin_GPIO42) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH_IRQ), MP_ROM_PTR(&pin_GPIO40) },
+    { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO41) },
+    { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO42) },
     { MP_ROM_QSTR(MP_QSTR_IO43), MP_ROM_PTR(&pin_GPIO43) },
     { MP_ROM_QSTR(MP_QSTR_IO44), MP_ROM_PTR(&pin_GPIO44) },
     { MP_ROM_QSTR(MP_QSTR_de), MP_ROM_PTR(&pin_GPIO45) },

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8_hacktablet/pins.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8_hacktablet/pins.c
@@ -117,6 +117,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO43) },
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO44) },
 
+    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_STEMMA_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8_hacktablet/pins.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8_hacktablet/pins.c
@@ -103,7 +103,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IO37), MP_ROM_PTR(&pin_GPIO37) },
     { MP_ROM_QSTR(MP_QSTR_IO38), MP_ROM_PTR(&pin_GPIO38) },
     { MP_ROM_QSTR(MP_QSTR_IO39), MP_ROM_PTR(&pin_GPIO39) },
-    { MP_ROM_QSTR(MP_QSTR_TOUCH_IRQ), MP_ROM_PTR(&pin_GPIO40) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH_INT), MP_ROM_PTR(&pin_GPIO40) },
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO41) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO42) },
     { MP_ROM_QSTR(MP_QSTR_IO43), MP_ROM_PTR(&pin_GPIO43) },

--- a/ports/espressif/boards/makerfabs_tft7/pins.c
+++ b/ports/espressif/boards/makerfabs_tft7/pins.c
@@ -5,11 +5,11 @@ STATIC const mp_rom_obj_tuple_t tft_r_pins = {
     {&mp_type_tuple},
     5,
     {
-        MP_ROM_PTR(&pin_GPIO14),
-        MP_ROM_PTR(&pin_GPIO21),
-        MP_ROM_PTR(&pin_GPIO47),
-        MP_ROM_PTR(&pin_GPIO48),
         MP_ROM_PTR(&pin_GPIO45),
+        MP_ROM_PTR(&pin_GPIO48),
+        MP_ROM_PTR(&pin_GPIO47),
+        MP_ROM_PTR(&pin_GPIO21),
+        MP_ROM_PTR(&pin_GPIO14),
     }
 };
 
@@ -17,12 +17,12 @@ STATIC const mp_rom_obj_tuple_t tft_g_pins = {
     {&mp_type_tuple},
     6,
     {
-        MP_ROM_PTR(&pin_GPIO4),
-        MP_ROM_PTR(&pin_GPIO16),
-        MP_ROM_PTR(&pin_GPIO15),
-        MP_ROM_PTR(&pin_GPIO7),
-        MP_ROM_PTR(&pin_GPIO6),
         MP_ROM_PTR(&pin_GPIO5),
+        MP_ROM_PTR(&pin_GPIO6),
+        MP_ROM_PTR(&pin_GPIO7),
+        MP_ROM_PTR(&pin_GPIO15),
+        MP_ROM_PTR(&pin_GPIO16),
+        MP_ROM_PTR(&pin_GPIO4),
     }
 };
 
@@ -30,11 +30,11 @@ STATIC const mp_rom_obj_tuple_t tft_b_pins = {
     {&mp_type_tuple},
     5,
     {
-        MP_ROM_PTR(&pin_GPIO1),
-        MP_ROM_PTR(&pin_GPIO9),
-        MP_ROM_PTR(&pin_GPIO46),
-        MP_ROM_PTR(&pin_GPIO3),
         MP_ROM_PTR(&pin_GPIO8),
+        MP_ROM_PTR(&pin_GPIO3),
+        MP_ROM_PTR(&pin_GPIO46),
+        MP_ROM_PTR(&pin_GPIO9),
+        MP_ROM_PTR(&pin_GPIO1),
     }
 };
 
@@ -71,7 +71,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
 
     { MP_ROM_QSTR(MP_QSTR_TFT_PINS), MP_ROM_PTR(&tft_pins_dict) },
-    { MP_ROM_QSTR(MP_QSTR_TFT_TIMINGS_800x480), MP_ROM_PTR(&timings800_dict) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_TIMINGS), MP_ROM_PTR(&timings800_dict) },
     { MP_ROM_QSTR(MP_QSTR_BACKLIGHT), MP_ROM_PTR(&pin_GPIO10) },
 
     { MP_ROM_QSTR(MP_QSTR_I2S_SCK), MP_ROM_PTR(&pin_GPIO20) },
@@ -83,6 +83,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO18) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO17) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH_RES), MP_ROM_PTR(&pin_GPIO38) },
 
     { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_GPIO11) },
     { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_GPIO13) },

--- a/ports/espressif/boards/makerfabs_tft7/pins.c
+++ b/ports/espressif/boards/makerfabs_tft7/pins.c
@@ -96,6 +96,5 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     // Permanent SDIO 1-bit mode?
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
-    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/espressif/boards/makerfabs_tft7/pins.c
+++ b/ports/espressif/boards/makerfabs_tft7/pins.c
@@ -74,6 +74,10 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TFT_TIMINGS), MP_ROM_PTR(&timings800_dict) },
     { MP_ROM_QSTR(MP_QSTR_TFT_BACKLIGHT), MP_ROM_PTR(&pin_GPIO10) },
 
+    // GPIO pins available on Mabee connector port (also shared with I2S & USB D+/D-)
+    { MP_ROM_QSTR(MP_QSTR_GPIO20), MP_ROM_PTR(&pin_GPIO20) },
+    { MP_ROM_QSTR(MP_QSTR_GPIO19), MP_ROM_PTR(&pin_GPIO19) },
+
     { MP_ROM_QSTR(MP_QSTR_I2S_BIT_CLOCK), MP_ROM_PTR(&pin_GPIO20) },
     { MP_ROM_QSTR(MP_QSTR_I2S_WORD_SELECT), MP_ROM_PTR(&pin_GPIO2) },
     { MP_ROM_QSTR(MP_QSTR_I2S_DATA), MP_ROM_PTR(&pin_GPIO19) },

--- a/ports/espressif/boards/makerfabs_tft7/pins.c
+++ b/ports/espressif/boards/makerfabs_tft7/pins.c
@@ -72,11 +72,11 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_TFT_PINS), MP_ROM_PTR(&tft_pins_dict) },
     { MP_ROM_QSTR(MP_QSTR_TFT_TIMINGS), MP_ROM_PTR(&timings800_dict) },
-    { MP_ROM_QSTR(MP_QSTR_BACKLIGHT), MP_ROM_PTR(&pin_GPIO10) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_BACKLIGHT), MP_ROM_PTR(&pin_GPIO10) },
 
-    { MP_ROM_QSTR(MP_QSTR_I2S_SCK), MP_ROM_PTR(&pin_GPIO20) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_WS), MP_ROM_PTR(&pin_GPIO2) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_SDO), MP_ROM_PTR(&pin_GPIO19) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_BIT_CLOCK), MP_ROM_PTR(&pin_GPIO20) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_WORD_SELECT), MP_ROM_PTR(&pin_GPIO2) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_DATA), MP_ROM_PTR(&pin_GPIO19) },
 
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO43) },
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO44) },
@@ -85,9 +85,9 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO17) },
     { MP_ROM_QSTR(MP_QSTR_TOUCH_RES), MP_ROM_PTR(&pin_GPIO38) },
 
-    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_GPIO11) },
-    { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_GPIO13) },
-    { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_GPIO12) },
+    { MP_ROM_QSTR(MP_QSTR_SDIO_CMD), MP_ROM_PTR(&pin_GPIO11) },
+    { MP_ROM_QSTR(MP_QSTR_SDIO_D0), MP_ROM_PTR(&pin_GPIO13) },
+    { MP_ROM_QSTR(MP_QSTR_SDIO_CLK), MP_ROM_PTR(&pin_GPIO12) },
 
     // boot mode button can be used in SW as well
     { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO1) },

--- a/ports/espressif/boards/makerfabs_tft7/pins.c
+++ b/ports/espressif/boards/makerfabs_tft7/pins.c
@@ -87,7 +87,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO18) },
     { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO17) },
-    { MP_ROM_QSTR(MP_QSTR_TOUCH_RES), MP_ROM_PTR(&pin_GPIO38) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH_RESET), MP_ROM_PTR(&pin_GPIO38) },
 
     { MP_ROM_QSTR(MP_QSTR_SDIO_CMD), MP_ROM_PTR(&pin_GPIO11) },
     { MP_ROM_QSTR(MP_QSTR_SDIO_D0), MP_ROM_PTR(&pin_GPIO13) },


### PR DESCRIPTION
This changes a few of the Hacktablet and Makerfabs pin names for consistency. I also believe the RGB pins were defined backwards on the Makerfabs board. I actually have the 1024x600 board but from everything I have seen online they should be connected the same way as the 800x480 board. Before this change, the following code drew a black line rather than a green line, reversing the order of the RGB pins resolved it.

```
import board
from adafruit_turtle import Color, turtle
import framebufferio
import dotclockframebuffer
import displayio
displayio.release_displays()
fb=dotclockframebuffer.DotClockFramebuffer(**board.TFT_PINS,**board.TFT_TIMINGS_800x480)
display = framebufferio.FramebufferDisplay(fb)
turtle = turtle(display)
turtle.pendown()
turtle.pencolor(Color.GREEN)
turtle.forward(100)
```

Removing the screen dimensions from the TIMINGS table pointer allows generic initialization code to work across boards/displays. The display dimensions are included within the table so I don't think having it as part of the name is necessary. That being said, I know generally Adafruit prefers to make separate board definitions for similar boards with different configurations (flash size, psram, etc) but building the Makerfabs board with both a TFT_TIMINGS_800x480 and a TFT_TIMINGS_1024x600 table might allow a single board firmware to be used on both board types as I believe everything else is identical.

Let me know if a single board definition for the two display dimensions on the Makerfabs board is desirable and I'll update the PR accordingly.

I sent a couple e-mail messages to Makerfabs asking about VID/PID codes for both board variants as it looks like the numbers currently being used belong to Adafruit. I don't know if that was the correct route to take or if I'll ever hear back from Makerfabs. If I do hear back, I'll go ahead and create another PR to add the 1024x600 variant of the board.

EDIT: Makerfabs responded saying they would forward the VID/PID when they received them from Espressif.