### PR TITLE
Fixed incorrect IO assignment for UM TinyWATCH S3

### DIFF
--- a/ports/espressif/boards/unexpectedmaker_tinywatch_s3/pins.c
+++ b/ports/espressif/boards/unexpectedmaker_tinywatch_s3/pins.c
@@ -19,7 +19,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     // TFT Screen IO
     { MP_ROM_QSTR(MP_QSTR_TFT_CS), MP_ROM_PTR(&pin_GPIO16) },
     { MP_ROM_QSTR(MP_QSTR_TFT_DC), MP_ROM_PTR(&pin_GPIO15) },
-    { MP_ROM_QSTR(MP_QSTR_TFT_RESET), MP_ROM_PTR(&pin_GPIO21) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_RESET), MP_ROM_PTR(&pin_GPIO17) },
     { MP_ROM_QSTR(MP_QSTR_TFT_BACKLIGHT), MP_ROM_PTR(&pin_GPIO13) },
 
     // I2C - BUS1 - Main Peripherals


### PR DESCRIPTION
Copy and paste error I believe, sorry.