### PR TITLE
Improve make translation data performance.

### DIFF
--- a/py/maketranslationdata.py
+++ b/py/maketranslationdata.py
@@ -303,7 +303,7 @@ def compute_huffman_coding(qstrs, translation_name, translations, f, compression
         # picking to top 100 scores.
 
         counter = sorted(counter.items(), key=lambda x: math.log(x[1]) * len(x[0]), reverse=True)[
-                :100
+            :100
         ]
         scores = sorted(
             ((s, -est_net_savings(s, occ)) for (s, occ) in counter if occ > 1),

--- a/py/maketranslationdata.py
+++ b/py/maketranslationdata.py
@@ -222,7 +222,7 @@ def compute_huffman_coding(qstrs, translation_name, translations, f, compression
             f"Translation {translation_name} expected to fit in 8 bits but required 16 bits"
         )
 
-    # Prune the qstrs to only those longer than 3 characters that appear in the texts
+    # Prune the qstrs to only those that appear in the texts
     qstr_counters = collections.Counter()
     qstr_extractor = TextSplitter(qstr_strs)
     for t in texts:
@@ -302,7 +302,9 @@ def compute_huffman_coding(qstrs, translation_name, translations, f, compression
         # The set of candidates is pruned by estimating their relative value and
         # picking to top 100 scores.
 
-        counter = sorted(counter.items(), key=lambda x: math.log(x[1]) * len(x[0]), reverse=True)[:100]
+        counter = sorted(
+            counter.items(), key=lambda x: math.log(x[1]) * len(x[0]), reverse=True
+        )[:100]
         scores = sorted(
             ((s, -est_net_savings(s, occ)) for (s, occ) in counter if occ > 1),
             key=lambda x: x[1],

--- a/py/maketranslationdata.py
+++ b/py/maketranslationdata.py
@@ -302,9 +302,9 @@ def compute_huffman_coding(qstrs, translation_name, translations, f, compression
         # The set of candidates is pruned by estimating their relative value and
         # picking to top 100 scores.
 
-        counter = sorted(
-            counter.items(), key=lambda x: math.log(x[1]) * len(x[0]), reverse=True
-        )[:100]
+        counter = sorted(counter.items(), key=lambda x: math.log(x[1]) * len(x[0]), reverse=True)[
+                :100
+        ]
         scores = sorted(
             ((s, -est_net_savings(s, occ)) for (s, occ) in counter if occ > 1),
             key=lambda x: x[1],


### PR DESCRIPTION
Speed up `maketranslationdata.py` by reducing work done in optimization loop.

|Port| Optimization Setting | Build Time -j16 | Bytes Saved |
| --- | --- | --- | --- |
|RP2 Pico W|1|16.3 sec|8336|
||9 (before this pull)|31.6 sec|12873|
||9 (with this pull)|17.8 sec|13093|
|Atmel-SAMD Pyruler|9 (before this pull)|12.87 sec|4494|
||9 (with this pull)|12.83|4476|

Speed improves, slight variation in compression (improves on RP2, very slightly worse on Atmel-SAMD). Speed on RP2 optimization setting 9 is now close to setting 1, perhaps consider reverting level settings for RP2 port?