### PR TITLE
Add friendlier error when .show() used

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -434,6 +434,12 @@ msgstr ""
 msgid ", in %q\n"
 msgstr ""
 
+#: shared-bindings/displayio/Display.c
+#: shared-bindings/displayio/EPaperDisplay.c
+#: shared-bindings/framebufferio/FramebufferDisplay.c
+msgid ".show(x) removed. Use .root_group = x"
+msgstr ""
+
 #: py/objcomplex.c
 msgid "0.0 to a complex power"
 msgstr ""

--- a/shared-bindings/busdisplay/BusDisplay.c
+++ b/shared-bindings/busdisplay/BusDisplay.c
@@ -245,6 +245,13 @@ static busdisplay_busdisplay_obj_t *native_display(mp_obj_t display_obj) {
     return MP_OBJ_TO_PTR(native_display);
 }
 
+// Undocumented show() implementation with a friendly error message.
+STATIC mp_obj_t busdisplay_busdisplay_obj_show(mp_obj_t self_in, mp_obj_t group_in) {
+    mp_raise_AttributeError(translate(".show(x) removed. Use .root_group = x"));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(busdisplay_busdisplay_show_obj, busdisplay_busdisplay_obj_show);
+
 //|     def refresh(
 //|         self,
 //|         *,
@@ -491,6 +498,7 @@ STATIC mp_obj_t busdisplay_busdisplay_obj_fill_row(size_t n_args, const mp_obj_t
 MP_DEFINE_CONST_FUN_OBJ_KW(busdisplay_busdisplay_fill_row_obj, 1, busdisplay_busdisplay_obj_fill_row);
 
 STATIC const mp_rom_map_elem_t busdisplay_busdisplay_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_show), MP_ROM_PTR(&busdisplay_busdisplay_show_obj) },
     { MP_ROM_QSTR(MP_QSTR_refresh), MP_ROM_PTR(&busdisplay_busdisplay_refresh_obj) },
     { MP_ROM_QSTR(MP_QSTR_fill_row), MP_ROM_PTR(&busdisplay_busdisplay_fill_row_obj) },
 

--- a/shared-bindings/epaperdisplay/EPaperDisplay.c
+++ b/shared-bindings/epaperdisplay/EPaperDisplay.c
@@ -246,6 +246,13 @@ static epaperdisplay_epaperdisplay_obj_t *native_display(mp_obj_t display_obj) {
     return MP_OBJ_TO_PTR(native_display);
 }
 
+// Undocumented show() implementation with a friendly error message.
+STATIC mp_obj_t epaperdisplay_epaperdisplay_obj_show(mp_obj_t self_in, mp_obj_t group_in) {
+    mp_raise_AttributeError(translate(".show(x) removed. Use .root_group = x"));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(epaperdisplay_epaperdisplay_show_obj, epaperdisplay_epaperdisplay_obj_show);
+
 //|     def update_refresh_mode(
 //|         self, start_sequence: ReadableBuffer, seconds_per_frame: float = 180
 //|     ) -> None:
@@ -391,6 +398,7 @@ MP_PROPERTY_GETSET(epaperdisplay_epaperdisplay_root_group_obj,
     (mp_obj_t)&epaperdisplay_epaperdisplay_set_root_group_obj);
 
 STATIC const mp_rom_map_elem_t epaperdisplay_epaperdisplay_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_show), MP_ROM_PTR(&epaperdisplay_epaperdisplay_show_obj) },
     { MP_ROM_QSTR(MP_QSTR_update_refresh_mode), MP_ROM_PTR(&epaperdisplay_epaperdisplay_update_refresh_mode_obj) },
     { MP_ROM_QSTR(MP_QSTR_refresh), MP_ROM_PTR(&epaperdisplay_epaperdisplay_refresh_obj) },
 

--- a/shared-bindings/framebufferio/FramebufferDisplay.c
+++ b/shared-bindings/framebufferio/FramebufferDisplay.c
@@ -98,6 +98,13 @@ static framebufferio_framebufferdisplay_obj_t *native_display(mp_obj_t display_o
     return MP_OBJ_TO_PTR(native_display);
 }
 
+// Undocumented show() implementation with a friendly error message.
+STATIC mp_obj_t framebufferio_framebufferdisplay_obj_show(mp_obj_t self_in, mp_obj_t group_in) {
+    mp_raise_AttributeError(translate(".show(x) removed. Use .root_group = x"));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(framebufferio_framebufferdisplay_show_obj, framebufferio_framebufferdisplay_obj_show);
+
 //|     def refresh(
 //|         self,
 //|         *,
@@ -348,6 +355,7 @@ MP_PROPERTY_GETSET(framebufferio_framebufferdisplay_root_group_obj,
     (mp_obj_t)&framebufferio_framebufferdisplay_set_root_group_obj);
 
 STATIC const mp_rom_map_elem_t framebufferio_framebufferdisplay_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_show), MP_ROM_PTR(&framebufferio_framebufferdisplay_show_obj) },
     { MP_ROM_QSTR(MP_QSTR_refresh), MP_ROM_PTR(&framebufferio_framebufferdisplay_refresh_obj) },
     { MP_ROM_QSTR(MP_QSTR_fill_row), MP_ROM_PTR(&framebufferio_framebufferdisplay_fill_row_obj) },
 


### PR DESCRIPTION
Fixes #8499

```
Adafruit CircuitPython 9.0.0-alpha.1-99-gecaf9e6b14-dirty on 2023-10-24; Adafruit Feather ESP32-S3 TFT with ESP32S3
>>> import board
>>> board.DISPLAY.show(None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: .show(x) removed. Use .root_group = x
>>> 
```