### PR TITLE
Rename compressed_string_t to mp_rom_error_text_t to match upstream

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/att.c
+++ b/devices/ble_hci/common-hal/_bleio/att.c
@@ -1722,7 +1722,7 @@ void att_process_data(uint16_t conn_handle, uint8_t dlen, uint8_t data[]) {
 
 // FIX Do we need all of these?
 static void check_att_err(uint8_t err) {
-    const compressed_string_t *msg = NULL;
+    const mp_rom_error_text_t *msg = NULL;
     switch (err) {
         case 0:
             return;

--- a/devices/ble_hci/common-hal/_bleio/att.c
+++ b/devices/ble_hci/common-hal/_bleio/att.c
@@ -1722,7 +1722,7 @@ void att_process_data(uint16_t conn_handle, uint8_t dlen, uint8_t data[]) {
 
 // FIX Do we need all of these?
 static void check_att_err(uint8_t err) {
-    const mp_rom_error_text_t *msg = NULL;
+    mp_rom_error_text_t msg = NULL;
     switch (err) {
         case 0:
             return;

--- a/ports/espressif/common-hal/espidf/__init__.c
+++ b/ports/espressif/common-hal/espidf/__init__.c
@@ -122,7 +122,7 @@ intptr_t common_hal_espidf_get_psram_end(void) {
 }
 
 void raise_esp_error(esp_err_t err) {
-    const mp_rom_error_text_t *msg = NULL;
+    mp_rom_error_text_t msg = NULL;
     const mp_obj_type_t *exception_type = &mp_type_espidf_IDFError;
     switch (err) {
         case ESP_FAIL:

--- a/ports/espressif/common-hal/espidf/__init__.c
+++ b/ports/espressif/common-hal/espidf/__init__.c
@@ -122,7 +122,7 @@ intptr_t common_hal_espidf_get_psram_end(void) {
 }
 
 void raise_esp_error(esp_err_t err) {
-    const compressed_string_t *msg = NULL;
+    const mp_rom_error_text_t *msg = NULL;
     const mp_obj_type_t *exception_type = &mp_type_espidf_IDFError;
     switch (err) {
         case ESP_FAIL:

--- a/ports/espressif/common-hal/wifi/Monitor.c
+++ b/ports/espressif/common-hal/wifi/Monitor.c
@@ -78,7 +78,7 @@ static void wifi_monitor_cb(void *recv_buf, wifi_promiscuous_pkt_type_t type) {
 }
 
 void common_hal_wifi_monitor_construct(wifi_monitor_obj_t *self, uint8_t channel, size_t queue) {
-    const compressed_string_t *monitor_mode_init_error = translate("monitor init failed");
+    const mp_rom_error_text_t *monitor_mode_init_error = translate("monitor init failed");
 
     self->queue = xQueueCreate(queue, sizeof(monitor_packet_t));
     if (!self->queue) {

--- a/ports/espressif/common-hal/wifi/Monitor.c
+++ b/ports/espressif/common-hal/wifi/Monitor.c
@@ -78,7 +78,7 @@ static void wifi_monitor_cb(void *recv_buf, wifi_promiscuous_pkt_type_t type) {
 }
 
 void common_hal_wifi_monitor_construct(wifi_monitor_obj_t *self, uint8_t channel, size_t queue) {
-    const mp_rom_error_text_t *monitor_mode_init_error = translate("monitor init failed");
+    mp_rom_error_text_t monitor_mode_init_error = translate("monitor init failed");
 
     self->queue = xQueueCreate(queue, sizeof(monitor_packet_t));
     if (!self->queue) {

--- a/py/argcheck.c
+++ b/py/argcheck.c
@@ -179,28 +179,28 @@ NORETURN void mp_arg_error_unimpl_kw(void) {
 
 mp_int_t mp_arg_validate_int(mp_int_t i, mp_int_t required_i, qstr arg_name) {
     if (i != required_i) {
-        mp_raise_ValueError_varg(translate("%q must be %d"), arg_name, required_i);
+        mp_raise_ValueError_varg(MP_ERROR_TEXT("%q must be %d"), arg_name, required_i);
     }
     return i;
 }
 
 mp_int_t mp_arg_validate_int_min(mp_int_t i, mp_int_t min, qstr arg_name) {
     if (i < min) {
-        mp_raise_ValueError_varg(translate("%q must be >= %d"), arg_name, min);
+        mp_raise_ValueError_varg(MP_ERROR_TEXT("%q must be >= %d"), arg_name, min);
     }
     return i;
 }
 
 mp_int_t mp_arg_validate_int_max(mp_int_t i, mp_int_t max, qstr arg_name) {
     if (i > max) {
-        mp_raise_ValueError_varg(translate("%q must be <= %d"), arg_name, max);
+        mp_raise_ValueError_varg(MP_ERROR_TEXT("%q must be <= %d"), arg_name, max);
     }
     return i;
 }
 
 mp_int_t mp_arg_validate_int_range(mp_int_t i, mp_int_t min, mp_int_t max, qstr arg_name) {
     if (i < min || i > max) {
-        mp_raise_ValueError_varg(translate("%q must be %d-%d"), arg_name, min, max);
+        mp_raise_ValueError_varg(MP_ERROR_TEXT("%q must be %d-%d"), arg_name, min, max);
     }
     return i;
 }
@@ -208,7 +208,7 @@ mp_int_t mp_arg_validate_int_range(mp_int_t i, mp_int_t min, mp_int_t max, qstr 
 mp_float_t mp_arg_validate_type_float(mp_obj_t obj, qstr arg_name) {
     mp_float_t a_float;
     if (!mp_obj_get_float_maybe(obj, &a_float)) {
-        mp_raise_TypeError_varg(translate("%q must be of type %q, not %q"), arg_name, MP_QSTR_float, mp_obj_get_type(obj)->name);
+        mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q, not %q"), arg_name, MP_QSTR_float, mp_obj_get_type(obj)->name);
     }
     return a_float;
 }
@@ -220,7 +220,7 @@ mp_float_t mp_arg_validate_obj_float_range(mp_obj_t float_in, mp_int_t min, mp_i
 
 mp_float_t mp_arg_validate_float_range(mp_float_t f, mp_int_t min, mp_int_t max, qstr arg_name) {
     if (f < (mp_float_t)min || f > (mp_float_t)max) {
-        mp_raise_ValueError_varg(translate("%q must be %d-%d"), arg_name, min, max);
+        mp_raise_ValueError_varg(MP_ERROR_TEXT("%q must be %d-%d"), arg_name, min, max);
     }
     return f;
 }
@@ -230,35 +230,35 @@ mp_float_t mp_arg_validate_obj_float_non_negative(mp_obj_t float_in, mp_float_t 
         ? default_for_null
         : mp_arg_validate_type_float(float_in, arg_name);
     if (f < (mp_float_t)0.0) {
-        mp_raise_ValueError_varg(translate("%q must be >= %d"), arg_name, 0);
+        mp_raise_ValueError_varg(MP_ERROR_TEXT("%q must be >= %d"), arg_name, 0);
     }
     return f;
 }
 
 mp_uint_t mp_arg_validate_length_range(mp_uint_t length, mp_uint_t min, mp_uint_t max, qstr arg_name) {
     if (length < min || length > max) {
-        mp_raise_ValueError_varg(translate("%q length must be %d-%d"), arg_name, min, max);
+        mp_raise_ValueError_varg(MP_ERROR_TEXT("%q length must be %d-%d"), arg_name, min, max);
     }
     return length;
 }
 
 mp_uint_t mp_arg_validate_length_min(mp_uint_t length, mp_uint_t min, qstr arg_name) {
     if (length < min) {
-        mp_raise_ValueError_varg(translate("%q length must be >= %d"), arg_name, min);
+        mp_raise_ValueError_varg(MP_ERROR_TEXT("%q length must be >= %d"), arg_name, min);
     }
     return length;
 }
 
 mp_uint_t mp_arg_validate_length_max(mp_uint_t length, mp_uint_t max, qstr arg_name) {
     if (length > max) {
-        mp_raise_ValueError_varg(translate("%q length must be <= %d"), arg_name, max);
+        mp_raise_ValueError_varg(MP_ERROR_TEXT("%q length must be <= %d"), arg_name, max);
     }
     return length;
 }
 
 mp_uint_t mp_arg_validate_length(mp_uint_t length, mp_uint_t required_length, qstr arg_name) {
     if (length != required_length) {
-        mp_raise_ValueError_varg(translate("%q length must be %d"), arg_name, required_length);
+        mp_raise_ValueError_varg(MP_ERROR_TEXT("%q length must be %d"), arg_name, required_length);
     }
     return length;
 }
@@ -266,35 +266,35 @@ mp_uint_t mp_arg_validate_length(mp_uint_t length, mp_uint_t required_length, qs
 // int instead of uint because an index can be negative in some cases.
 mp_int_t mp_arg_validate_index_range(mp_int_t index, mp_int_t min, mp_int_t max, qstr arg_name) {
     if (index < min || index > max) {
-        mp_raise_IndexError_varg(translate("%q out of range"), arg_name, min, max);
+        mp_raise_IndexError_varg(MP_ERROR_TEXT("%q out of range"), arg_name, min, max);
     }
     return index;
 }
 
 mp_obj_t mp_arg_validate_type(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name) {
     if (!mp_obj_is_type(obj, type)) {
-        mp_raise_TypeError_varg(translate("%q must be of type %q, not %q"), arg_name, type->name, mp_obj_get_type(obj)->name);
+        mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q, not %q"), arg_name, type->name, mp_obj_get_type(obj)->name);
     }
     return obj;
 }
 
 mp_obj_t mp_arg_validate_type_in(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name) {
     if (!mp_obj_is_type(obj, type)) {
-        mp_raise_TypeError_varg(translate("%q in %q must be of type %q, not %q"), MP_QSTR_object, arg_name, type->name, mp_obj_get_type(obj)->name);
+        mp_raise_TypeError_varg(MP_ERROR_TEXT("%q in %q must be of type %q, not %q"), MP_QSTR_object, arg_name, type->name, mp_obj_get_type(obj)->name);
     }
     return obj;
 }
 
 mp_obj_t mp_arg_validate_type_or_none(mp_obj_t obj, const mp_obj_type_t *type, qstr arg_name) {
     if (obj != mp_const_none && !mp_obj_is_type(obj, type)) {
-        mp_raise_TypeError_varg(translate("%q must be of type %q or %q, not %q"), arg_name, type->name, MP_QSTR_None, mp_obj_get_type(obj)->name);
+        mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q or %q, not %q"), arg_name, type->name, MP_QSTR_None, mp_obj_get_type(obj)->name);
     }
     return obj;
 }
 
 mp_obj_t mp_arg_validate_type_string(mp_obj_t obj, qstr arg_name) {
     if (!mp_obj_is_str(obj)) {
-        mp_raise_TypeError_varg(translate("%q must be of type %q, not %q"), arg_name, MP_QSTR_str, mp_obj_get_type(obj)->name);
+        mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q, not %q"), arg_name, MP_QSTR_str, mp_obj_get_type(obj)->name);
     }
     return obj;
 }
@@ -302,11 +302,11 @@ mp_obj_t mp_arg_validate_type_string(mp_obj_t obj, qstr arg_name) {
 mp_int_t mp_arg_validate_type_int(mp_obj_t obj, qstr arg_name) {
     mp_int_t an_int;
     if (!mp_obj_get_int_maybe(obj, &an_int)) {
-        mp_raise_TypeError_varg(translate("%q must be of type %q, not %q"), arg_name, MP_QSTR_int, mp_obj_get_type(obj)->name);
+        mp_raise_TypeError_varg(MP_ERROR_TEXT("%q must be of type %q, not %q"), arg_name, MP_QSTR_int, mp_obj_get_type(obj)->name);
     }
     return an_int;
 }
 
 NORETURN void mp_arg_error_invalid(qstr arg_name) {
-    mp_raise_ValueError_varg(translate("Invalid %q"), arg_name);
+    mp_raise_ValueError_varg(MP_ERROR_TEXT("Invalid %q"), arg_name);
 }

--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -122,7 +122,7 @@ STATIC void mp_help_print_modules(void) {
 
     #if MICROPY_ENABLE_EXTERNAL_IMPORT
     // let the user know there may be other modules available from the filesystem
-    serial_write_compressed(translate("Plus any modules on the filesystem\n"));
+    serial_write_compressed(MP_ERROR_TEXT("Plus any modules on the filesystem\n"));
     #endif
 }
 #endif
@@ -138,10 +138,10 @@ STATIC void mp_help_print_obj(const mp_obj_t obj) {
     const mp_obj_type_t *type = mp_obj_get_type(obj);
 
     // try to print something sensible about the given object
-    mp_cprintf(MP_PYTHON_PRINTER, translate("object "));
+    mp_cprintf(MP_PYTHON_PRINTER, MP_ERROR_TEXT("object "));
     mp_obj_print(obj, PRINT_STR);
 
-    mp_cprintf(MP_PYTHON_PRINTER, translate(" is of type %q\n"), type->name);
+    mp_cprintf(MP_PYTHON_PRINTER, MP_ERROR_TEXT(" is of type %q\n"), type->name);
 
     mp_map_t *map = NULL;
     if (type == &mp_type_module) {
@@ -168,7 +168,7 @@ STATIC mp_obj_t mp_builtin_help(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
         // print a general help message. Translate only works on single strings on one line.
         mp_cprintf(MP_PYTHON_PRINTER,
-            translate("Welcome to Adafruit CircuitPython %s!\n\nVisit circuitpython.org for more information.\n\nTo list built-in modules type `help(\"modules\")`.\n"),
+            MP_ERROR_TEXT("Welcome to Adafruit CircuitPython %s!\n\nVisit circuitpython.org for more information.\n\nTo list built-in modules type `help(\"modules\")`.\n"),
             MICROPY_GIT_TAG);
     } else {
         // try to print something sensible about the given object

--- a/py/compile.c
+++ b/py/compile.c
@@ -2740,7 +2740,7 @@ STATIC void compile_yield_expr(compiler_t *comp, mp_parse_node_struct_t *pns) {
         pns = (mp_parse_node_struct_t *)pns->nodes[0];
         #if MICROPY_PY_ASYNC_AWAIT
         if (comp->scope_cur->scope_flags & MP_SCOPE_FLAG_ASYNC) {
-            compile_syntax_error(comp, (mp_parse_node_t)pns, translate("'yield from' inside async function"));
+            compile_syntax_error(comp, (mp_parse_node_t)pns, MP_ERROR_TEXT("'yield from' inside async function"));
             return;
         }
         #endif

--- a/py/compile.c
+++ b/py/compile.c
@@ -255,7 +255,7 @@ STATIC void compile_error_set_line(compiler_t *comp, mp_parse_node_t pn) {
     }
 }
 
-STATIC void compile_syntax_error(compiler_t *comp, mp_parse_node_t pn, const mp_rom_error_text_t *msg) {
+STATIC void compile_syntax_error(compiler_t *comp, mp_parse_node_t pn, mp_rom_error_text_t msg) {
     // only register the error if there has been no other error
     if (comp->compile_error == MP_OBJ_NULL) {
         comp->compile_error = mp_obj_new_exception_msg(&mp_type_SyntaxError, msg);

--- a/py/compile.c
+++ b/py/compile.c
@@ -255,7 +255,7 @@ STATIC void compile_error_set_line(compiler_t *comp, mp_parse_node_t pn) {
     }
 }
 
-STATIC void compile_syntax_error(compiler_t *comp, mp_parse_node_t pn, const compressed_string_t *msg) {
+STATIC void compile_syntax_error(compiler_t *comp, mp_parse_node_t pn, const mp_rom_error_text_t *msg) {
     // only register the error if there has been no other error
     if (comp->compile_error == MP_OBJ_NULL) {
         comp->compile_error = mp_obj_new_exception_msg(&mp_type_SyntaxError, msg);

--- a/py/emitinlinethumb.c
+++ b/py/emitinlinethumb.c
@@ -74,8 +74,7 @@ static inline bool emit_inline_thumb_allow_float(emit_inline_asm_t *emit) {
 
 #endif
 
-// CIRCUITPY-CHANGE
-STATIC void emit_inline_thumb_error_msg(emit_inline_asm_t *emit, const mp_rom_error_text_t *msg) {
+STATIC void emit_inline_thumb_error_msg(emit_inline_asm_t *emit, mp_rom_error_text_t msg) {
     *emit->error_slot = mp_obj_new_exception_msg(&mp_type_SyntaxError, msg);
 }
 

--- a/py/emitinlinethumb.c
+++ b/py/emitinlinethumb.c
@@ -75,7 +75,7 @@ static inline bool emit_inline_thumb_allow_float(emit_inline_asm_t *emit) {
 #endif
 
 // CIRCUITPY-CHANGE
-STATIC void emit_inline_thumb_error_msg(emit_inline_asm_t *emit, const compressed_string_t *msg) {
+STATIC void emit_inline_thumb_error_msg(emit_inline_asm_t *emit, const mp_rom_error_text_t *msg) {
     *emit->error_slot = mp_obj_new_exception_msg(&mp_type_SyntaxError, msg);
 }
 

--- a/py/emitinlinextensa.c
+++ b/py/emitinlinextensa.c
@@ -44,7 +44,7 @@ struct _emit_inline_asm_t {
 };
 
 // CIRCUITPY-CHANGE
-STATIC void emit_inline_xtensa_error_msg(emit_inline_asm_t *emit, const compressed_string_t *msg) {
+STATIC void emit_inline_xtensa_error_msg(emit_inline_asm_t *emit, const mp_rom_error_text_t *msg) {
     *emit->error_slot = mp_obj_new_exception_msg(&mp_type_SyntaxError, msg);
 }
 

--- a/py/emitinlinextensa.c
+++ b/py/emitinlinextensa.c
@@ -43,8 +43,7 @@ struct _emit_inline_asm_t {
     qstr *label_lookup;
 };
 
-// CIRCUITPY-CHANGE
-STATIC void emit_inline_xtensa_error_msg(emit_inline_asm_t *emit, const mp_rom_error_text_t *msg) {
+STATIC void emit_inline_xtensa_error_msg(emit_inline_asm_t *emit, mp_rom_error_text_t msg) {
     *emit->error_slot = mp_obj_new_exception_msg(&mp_type_SyntaxError, msg);
 }
 

--- a/py/maketranslationdata.py
+++ b/py/maketranslationdata.py
@@ -595,7 +595,7 @@ def output_translation_data(encoding_table, i18ns, out):
             decompressed = decompressed.replace(c, C_ESCAPES[c])
         formatted = ["{:d}".format(x) for x in compressed]
         out.write(
-            "const compressed_string_t translation{} = {{ .data = {}, .tail = {{ {} }} }}; // {}\n".format(
+            "const mp_rom_error_text_t translation{} = {{ .data = {}, .tail = {{ {} }} }}; // {}\n".format(
                 i, formatted[0], ", ".join(formatted[1:]), original, decompressed
             )
         )

--- a/py/maketranslationdata.py
+++ b/py/maketranslationdata.py
@@ -595,7 +595,7 @@ def output_translation_data(encoding_table, i18ns, out):
             decompressed = decompressed.replace(c, C_ESCAPES[c])
         formatted = ["{:d}".format(x) for x in compressed]
         out.write(
-            "const mp_rom_error_text_t translation{} = {{ .data = {}, .tail = {{ {} }} }}; // {}\n".format(
+            "const struct compressed_string translation{} = {{ .data = {}, .tail = {{ {} }} }}; // {}\n".format(
                 i, formatted[0], ", ".join(formatted[1:]), original, decompressed
             )
         )

--- a/py/misc.h
+++ b/py/misc.h
@@ -297,7 +297,6 @@ typedef union _mp_float_union_t {
 // So leave MP_COMPRESSED_ROM_TEXT in place for makeqstrdefs.py / makecompresseddata.py to find them.
 
 #else
-
 // Compression enabled and doing a regular build.
 // Map MP_COMPRESSED_ROM_TEXT to the compressed strings.
 
@@ -327,10 +326,9 @@ inline MP_ALWAYSINLINE const char *MP_COMPRESSED_ROM_TEXT(const char *msg) {
 
     return msg;
 }
-
 #endif
 
-#elif CIRCUITPY
+#elif defined(CIRCUITPY)
 #include "supervisor/shared/translate/translate.h"
 #else
 
@@ -339,6 +337,10 @@ inline MP_ALWAYSINLINE const char *MP_COMPRESSED_ROM_TEXT(const char *msg) {
 typedef const char *mp_rom_error_text_t;
 #define MP_COMPRESSED_ROM_TEXT(x) x
 
-#endif // MICROPY_ROM_TEXT_COMPRESSION // CIRCUITPY
+#endif // MICROPY_ROM_TEXT_COMPRESSION
+
+// Might add more types of compressed text in the future.
+// For now, forward directly to MP_COMPRESSED_ROM_TEXT.
+#define MP_ERROR_TEXT(x) (mp_rom_error_text_t)MP_COMPRESSED_ROM_TEXT(x)
 
 #endif // MICROPY_INCLUDED_PY_MISC_H

--- a/py/misc.h
+++ b/py/misc.h
@@ -330,6 +330,8 @@ inline MP_ALWAYSINLINE const char *MP_COMPRESSED_ROM_TEXT(const char *msg) {
 
 #endif
 
+#elif CIRCUITPY
+#include "supervisor/shared/translate/translate.h"
 #else
 
 // Compression not enabled, just make it a no-op.
@@ -337,15 +339,6 @@ inline MP_ALWAYSINLINE const char *MP_COMPRESSED_ROM_TEXT(const char *msg) {
 typedef const char *mp_rom_error_text_t;
 #define MP_COMPRESSED_ROM_TEXT(x) x
 
-#endif // MICROPY_ROM_TEXT_COMPRESSION
-
-// Might add more types of compressed text in the future.
-// For now, forward directly to MP_COMPRESSED_ROM_TEXT.
-// CIRCUITPY-CHANGE: MP_ERROR_TEXT() -> translate()
-#if CIRCUITPY
-#include "supervisor/shared/translate/translate.h"
-#else
-#define MP_ERROR_TEXT(x) (mp_rom_error_text_t)MP_COMPRESSED_ROM_TEXT(x)
-#endif
+#endif // MICROPY_ROM_TEXT_COMPRESSION // CIRCUITPY
 
 #endif // MICROPY_INCLUDED_PY_MISC_H

--- a/py/moderrno.c
+++ b/py/moderrno.c
@@ -127,7 +127,7 @@ const char *mp_common_errno_to_str(mp_obj_t errno_val, char *buf, size_t len) {
         return NULL;
     }
 
-    const mp_rom_error_text_t *desc = NULL;
+    mp_rom_error_text_t desc = NULL;
     switch (MP_OBJ_SMALL_INT_VALUE(errno_val)) {
         case EPERM:
             desc = MP_ERROR_TEXT("Operation not permitted");

--- a/py/moderrno.c
+++ b/py/moderrno.c
@@ -127,7 +127,7 @@ const char *mp_common_errno_to_str(mp_obj_t errno_val, char *buf, size_t len) {
         return NULL;
     }
 
-    const compressed_string_t *desc = NULL;
+    const mp_rom_error_text_t *desc = NULL;
     switch (MP_OBJ_SMALL_INT_VALUE(errno_val)) {
         case EPERM:
             desc = MP_ERROR_TEXT("Operation not permitted");

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -496,7 +496,7 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
                 break;
             }
             case 'S': {
-                mp_rom_error_text_t *arg = va_arg(args, mp_rom_error_text_t *);
+                mp_rom_error_text_t arg = va_arg(args, mp_rom_error_text_t );
                 size_t len_with_nul = decompress_length(arg);
                 size_t len = len_with_nul - 1;
                 char str[len_with_nul];
@@ -593,7 +593,7 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
     return chrs;
 }
 
-int mp_cprintf(const mp_print_t *print, const mp_rom_error_text_t *compressed_fmt, ...) {
+int mp_cprintf(const mp_print_t *print, mp_rom_error_text_t compressed_fmt, ...) {
     va_list ap;
     va_start(ap, compressed_fmt);
     int ret = mp_vcprintf(print, compressed_fmt, ap);
@@ -601,7 +601,7 @@ int mp_cprintf(const mp_print_t *print, const mp_rom_error_text_t *compressed_fm
     return ret;
 }
 
-int mp_vcprintf(const mp_print_t *print, const mp_rom_error_text_t *compressed_fmt, va_list args) {
+int mp_vcprintf(const mp_print_t *print, mp_rom_error_text_t compressed_fmt, va_list args) {
     char fmt[decompress_length(compressed_fmt)];
     // TODO: Optimise this to format-while-decompressing (and not require the temp stack space).
     decompress(compressed_fmt, fmt);

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -496,7 +496,7 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
                 break;
             }
             case 'S': {
-                compressed_string_t *arg = va_arg(args, compressed_string_t *);
+                mp_rom_error_text_t *arg = va_arg(args, mp_rom_error_text_t *);
                 size_t len_with_nul = decompress_length(arg);
                 size_t len = len_with_nul - 1;
                 char str[len_with_nul];
@@ -593,7 +593,7 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
     return chrs;
 }
 
-int mp_cprintf(const mp_print_t *print, const compressed_string_t *compressed_fmt, ...) {
+int mp_cprintf(const mp_print_t *print, const mp_rom_error_text_t *compressed_fmt, ...) {
     va_list ap;
     va_start(ap, compressed_fmt);
     int ret = mp_vcprintf(print, compressed_fmt, ap);
@@ -601,7 +601,7 @@ int mp_cprintf(const mp_print_t *print, const compressed_string_t *compressed_fm
     return ret;
 }
 
-int mp_vcprintf(const mp_print_t *print, const compressed_string_t *compressed_fmt, va_list args) {
+int mp_vcprintf(const mp_print_t *print, const mp_rom_error_text_t *compressed_fmt, va_list args) {
     char fmt[decompress_length(compressed_fmt)];
     // TODO: Optimise this to format-while-decompressing (and not require the temp stack space).
     decompress(compressed_fmt, fmt);

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -496,7 +496,7 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
                 break;
             }
             case 'S': {
-                mp_rom_error_text_t arg = va_arg(args, mp_rom_error_text_t );
+                mp_rom_error_text_t arg = va_arg(args, mp_rom_error_text_t);
                 size_t len_with_nul = decompress_length(arg);
                 size_t len = len_with_nul - 1;
                 char str[len_with_nul];

--- a/py/mpprint.h
+++ b/py/mpprint.h
@@ -27,7 +27,6 @@
 #define MICROPY_INCLUDED_PY_MPPRINT_H
 
 #include "py/mpconfig.h"
-#include "py/misc.h"
 
 #define PF_FLAG_LEFT_ADJUST       (0x001)
 #define PF_FLAG_SHOW_SIGN         (0x002)

--- a/py/mpprint.h
+++ b/py/mpprint.h
@@ -27,6 +27,7 @@
 #define MICROPY_INCLUDED_PY_MPPRINT_H
 
 #include "py/mpconfig.h"
+#include "py/misc.h"
 
 #define PF_FLAG_LEFT_ADJUST       (0x001)
 #define PF_FLAG_SHOW_SIGN         (0x002)
@@ -79,11 +80,9 @@ int mp_printf(const mp_print_t *print, const char *fmt, ...);
 int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args);
 #endif
 
-// CIRCUITPY-CHANGE
-struct compressed_string;
-int mp_cprintf(const mp_print_t *print, const struct compressed_string *compressed_fmt, ...);
+int mp_cprintf(const mp_print_t *print, const mp_rom_error_text_t *compressed_fmt, ...);
 #ifdef va_start
-int mp_vcprintf(const mp_print_t *print, const struct compressed_string *compressed_fmt, va_list args);
+int mp_vcprintf(const mp_print_t *print, const mp_rom_error_text_t *compressed_fmt, va_list args);
 #endif
 
 #endif // MICROPY_INCLUDED_PY_MPPRINT_H

--- a/py/mpprint.h
+++ b/py/mpprint.h
@@ -79,9 +79,11 @@ int mp_printf(const mp_print_t *print, const char *fmt, ...);
 int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args);
 #endif
 
-int mp_cprintf(const mp_print_t *print, const mp_rom_error_text_t *compressed_fmt, ...);
+// CIRCUITPY-CHANGE
+struct compressed_string;
+int mp_cprintf(const mp_print_t *print, const struct compressed_string *compressed_fmt, ...);
 #ifdef va_start
-int mp_vcprintf(const mp_print_t *print, const mp_rom_error_text_t *compressed_fmt, va_list args);
+int mp_vcprintf(const mp_print_t *print, const struct compressed_string *compressed_fmt, va_list args);
 #endif
 
 #endif // MICROPY_INCLUDED_PY_MPPRINT_H

--- a/py/obj.c
+++ b/py/obj.c
@@ -147,7 +147,7 @@ void mp_obj_print(mp_obj_t o_in, mp_print_kind_t kind) {
 static void mp_obj_print_inner_exception(const mp_print_t *print, mp_obj_t self_in, mp_int_t limit) {
     #if MICROPY_CPYTHON_EXCEPTION_CHAIN
     mp_obj_exception_t *self = mp_obj_exception_get_native(self_in);
-    const mp_rom_error_text_t *msg = MP_ERROR_TEXT("During handling of the above exception, another exception occurred:");
+    mp_rom_error_text_t msg = MP_ERROR_TEXT("During handling of the above exception, another exception occurred:");
     mp_obj_exception_t *inner = NULL;
     if (self->cause) {
         msg = MP_ERROR_TEXT("The above exception was the direct cause of the following exception:");
@@ -177,11 +177,11 @@ void mp_obj_print_exception_with_limit(const mp_print_t *print, mp_obj_t exc, mp
         if (n > 0) {
             assert(n % 3 == 0);
             #if MICROPY_ENABLE_SOURCE_LINE
-            const mp_rom_error_text_t *frame = MP_ERROR_TEXT("  File \"%q\", line %d");
+            mp_rom_error_text_t frame = MP_ERROR_TEXT("  File \"%q\", line %d");
             #else
-            const mp_rom_error_text_t *frame = MP_ERROR_TEXT("  File \"%q\"");
+            mp_rom_error_text_t frame = MP_ERROR_TEXT("  File \"%q\"");
             #endif
-            const mp_rom_error_text_t *block_fmt = MP_ERROR_TEXT(", in %q\n");
+            mp_rom_error_text_t block_fmt = MP_ERROR_TEXT(", in %q\n");
 
             // Set traceback formatting
             // Default: Print full traceback

--- a/py/obj.c
+++ b/py/obj.c
@@ -147,7 +147,7 @@ void mp_obj_print(mp_obj_t o_in, mp_print_kind_t kind) {
 static void mp_obj_print_inner_exception(const mp_print_t *print, mp_obj_t self_in, mp_int_t limit) {
     #if MICROPY_CPYTHON_EXCEPTION_CHAIN
     mp_obj_exception_t *self = mp_obj_exception_get_native(self_in);
-    const compressed_string_t *msg = MP_ERROR_TEXT("During handling of the above exception, another exception occurred:");
+    const mp_rom_error_text_t *msg = MP_ERROR_TEXT("During handling of the above exception, another exception occurred:");
     mp_obj_exception_t *inner = NULL;
     if (self->cause) {
         msg = MP_ERROR_TEXT("The above exception was the direct cause of the following exception:");
@@ -177,11 +177,11 @@ void mp_obj_print_exception_with_limit(const mp_print_t *print, mp_obj_t exc, mp
         if (n > 0) {
             assert(n % 3 == 0);
             #if MICROPY_ENABLE_SOURCE_LINE
-            const compressed_string_t *frame = MP_ERROR_TEXT("  File \"%q\", line %d");
+            const mp_rom_error_text_t *frame = MP_ERROR_TEXT("  File \"%q\", line %d");
             #else
-            const compressed_string_t *frame = MP_ERROR_TEXT("  File \"%q\"");
+            const mp_rom_error_text_t *frame = MP_ERROR_TEXT("  File \"%q\"");
             #endif
-            const compressed_string_t *block_fmt = MP_ERROR_TEXT(", in %q\n");
+            const mp_rom_error_text_t *block_fmt = MP_ERROR_TEXT(", in %q\n");
 
             // Set traceback formatting
             // Default: Print full traceback

--- a/py/obj.h
+++ b/py/obj.h
@@ -34,9 +34,6 @@
 #include "py/mpprint.h"
 #include "py/runtime0.h"
 
-// CIRCUITPY-CHANGE
-#include "supervisor/shared/translate/compressed_string.h"
-
 // This is the definition of the opaque MicroPython object type.
 // All concrete objects have an encoding within this type and the
 // particular encoding is specified by MICROPY_OBJ_REPR.
@@ -1037,12 +1034,12 @@ mp_obj_t mp_obj_new_exception_args(const mp_obj_type_t *exc_type, size_t n_args,
 #define mp_obj_new_exception_msg_varg(exc_type, ...) mp_obj_new_exception(exc_type)
 #else
 // CIRCUITPY-CHANGE
-mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const compressed_string_t *msg);
-mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, ...);  // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
+mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *msg);
+mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...);  // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
 #endif
 #ifdef va_start
 // CIRCUITPY-CHANGE
-mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, va_list arg);  // same fmt restrictions as above
+mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, va_list arg);  // same fmt restrictions as above
 #endif
 mp_obj_t mp_obj_new_gen_wrap(mp_obj_t fun);
 mp_obj_t mp_obj_new_closure(mp_obj_t fun, size_t n_closed, const mp_obj_t *closed);

--- a/py/obj.h
+++ b/py/obj.h
@@ -614,17 +614,25 @@ typedef struct _mp_getiter_iternext_custom_t {
 } mp_getiter_iternext_custom_t;
 
 // Buffer protocol
+
 typedef struct _mp_buffer_info_t {
     void *buf;      // can be NULL if len == 0
     size_t len;     // in bytes
     int typecode;   // as per binary.h
 } mp_buffer_info_t;
+
 #define MP_BUFFER_READ  (1)
 #define MP_BUFFER_WRITE (2)
 #define MP_BUFFER_RW (MP_BUFFER_READ | MP_BUFFER_WRITE)
+#define MP_BUFFER_RAISE_IF_UNSUPPORTED (4)
+
 typedef mp_int_t (*mp_buffer_fun_t)(mp_obj_t obj, mp_buffer_info_t *bufinfo, mp_uint_t flags);
+
 bool mp_get_buffer(mp_obj_t obj, mp_buffer_info_t *bufinfo, mp_uint_t flags);
-void mp_get_buffer_raise(mp_obj_t obj, mp_buffer_info_t *bufinfo, mp_uint_t flags);
+
+static inline void mp_get_buffer_raise(mp_obj_t obj, mp_buffer_info_t *bufinfo, mp_uint_t flags) {
+    mp_get_buffer(obj, bufinfo, flags | MP_BUFFER_RAISE_IF_UNSUPPORTED);
+}
 
 // This struct will be updated to become a variable sized struct. In order to
 // use this as a member, or allocate dynamically, use the mp_obj_empty_type_t
@@ -1033,13 +1041,11 @@ mp_obj_t mp_obj_new_exception_args(const mp_obj_type_t *exc_type, size_t n_args,
 #define mp_obj_new_exception_msg(exc_type, msg) mp_obj_new_exception(exc_type)
 #define mp_obj_new_exception_msg_varg(exc_type, ...) mp_obj_new_exception(exc_type)
 #else
-// CIRCUITPY-CHANGE
 mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, mp_rom_error_text_t msg);
-mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, ...);  // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
+mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, ...); // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
 #endif
 #ifdef va_start
-// CIRCUITPY-CHANGE
-mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, va_list arg);  // same fmt restrictions as above
+mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, va_list arg); // same fmt restrictions as above
 #endif
 mp_obj_t mp_obj_new_gen_wrap(mp_obj_t fun);
 mp_obj_t mp_obj_new_closure(mp_obj_t fun, size_t n_closed, const mp_obj_t *closed);

--- a/py/obj.h
+++ b/py/obj.h
@@ -1034,12 +1034,12 @@ mp_obj_t mp_obj_new_exception_args(const mp_obj_type_t *exc_type, size_t n_args,
 #define mp_obj_new_exception_msg_varg(exc_type, ...) mp_obj_new_exception(exc_type)
 #else
 // CIRCUITPY-CHANGE
-mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *msg);
-mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...);  // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
+mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, mp_rom_error_text_t msg);
+mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, ...);  // counts args by number of % symbols in fmt, excluding %%; can only handle void* sizes (ie no float/double!)
 #endif
 #ifdef va_start
 // CIRCUITPY-CHANGE
-mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, va_list arg);  // same fmt restrictions as above
+mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, va_list arg);  // same fmt restrictions as above
 #endif
 mp_obj_t mp_obj_new_gen_wrap(mp_obj_t fun);
 mp_obj_t mp_obj_new_closure(mp_obj_t fun, size_t n_closed, const mp_obj_t *closed);

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -479,7 +479,7 @@ mp_obj_t mp_obj_new_exception_args(const mp_obj_type_t *exc_type, size_t n_args,
 }
 
 #if MICROPY_ERROR_REPORTING != MICROPY_ERROR_REPORTING_NONE
-mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *msg) {
+mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, mp_rom_error_text_t msg) {
     // CIRCUITPY-CHANGE: is different here and for many lines below.
     return mp_obj_new_exception_msg_varg(exc_type, msg);
 }
@@ -517,7 +517,7 @@ STATIC void exc_add_strn(void *data, const char *str, size_t len) {
     pr->len += len;
 }
 
-mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...) {
+mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, ...) {
     va_list args;
     va_start(args, fmt);
     mp_obj_t exc = mp_obj_new_exception_msg_vlist(exc_type, fmt, args);
@@ -525,7 +525,7 @@ mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const mp_r
     return exc;
 }
 
-mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, va_list ap) {
+mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, va_list ap) {
     assert(fmt != NULL);
 
     // Check that the given type is an exception type

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -479,7 +479,7 @@ mp_obj_t mp_obj_new_exception_args(const mp_obj_type_t *exc_type, size_t n_args,
 }
 
 #if MICROPY_ERROR_REPORTING != MICROPY_ERROR_REPORTING_NONE
-mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const compressed_string_t *msg) {
+mp_obj_t mp_obj_new_exception_msg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *msg) {
     // CIRCUITPY-CHANGE: is different here and for many lines below.
     return mp_obj_new_exception_msg_varg(exc_type, msg);
 }
@@ -517,7 +517,7 @@ STATIC void exc_add_strn(void *data, const char *str, size_t len) {
     pr->len += len;
 }
 
-mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, ...) {
+mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     mp_obj_t exc = mp_obj_new_exception_msg_vlist(exc_type, fmt, args);
@@ -525,7 +525,7 @@ mp_obj_t mp_obj_new_exception_msg_varg(const mp_obj_type_t *exc_type, const comp
     return exc;
 }
 
-mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, va_list ap) {
+mp_obj_t mp_obj_new_exception_msg_vlist(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, va_list ap) {
     assert(fmt != NULL);
 
     // Check that the given type is an exception type

--- a/py/qstr.c
+++ b/py/qstr.c
@@ -370,7 +370,7 @@ STATIC const byte *find_uncompressed_string(uint8_t n) {
 
 // Given a compressed string in src, decompresses it into dst.
 // dst must be large enough (use MP_MAX_UNCOMPRESSED_TEXT_LEN+1).
-void mp_decompress_rom_string(byte *dst, const mp_rom_error_text_t src_chr) {
+void mp_decompress_rom_string(byte *dst, mp_rom_error_text_t src_chr) {
     // Skip past the 0xff marker.
     const byte *src = (byte *)src_chr + 1;
     // Need to add spaces around compressed words, except for the first (i.e. transition from 1<->2).

--- a/py/qstr.h
+++ b/py/qstr.h
@@ -97,7 +97,7 @@ void qstr_pool_info(size_t *n_pool, size_t *n_qstr, size_t *n_str_data_bytes, si
 void qstr_dump_data(void);
 
 #if MICROPY_ROM_TEXT_COMPRESSION
-void mp_decompress_rom_string(byte *dst, const mp_rom_error_text_t src);
+void mp_decompress_rom_string(byte *dst, mp_rom_error_text_t src);
 #define MP_IS_COMPRESSED_ROM_STRING(s) (*(byte *)(s) == 0xff)
 #endif
 

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1744,7 +1744,7 @@ NORETURN MP_COLD void mp_raise_NotImplementedError_no_msg(void) {
 
 #else
 
-NORETURN MP_COLD void mp_raise_msg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *msg) {
+NORETURN MP_COLD void mp_raise_msg(const mp_obj_type_t *exc_type, mp_rom_error_text_t msg) {
     if (msg == NULL) {
         nlr_raise(mp_obj_new_exception(exc_type));
     } else {
@@ -1752,12 +1752,12 @@ NORETURN MP_COLD void mp_raise_msg(const mp_obj_type_t *exc_type, const mp_rom_e
     }
 }
 
-NORETURN MP_COLD void mp_raise_msg_vlist(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, va_list argptr) {
+NORETURN MP_COLD void mp_raise_msg_vlist(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, va_list argptr) {
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(exc_type, fmt, argptr);
     nlr_raise(exception);
 }
 
-NORETURN MP_COLD void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_msg_varg(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(exc_type, fmt, argptr);
@@ -1772,59 +1772,59 @@ NORETURN MP_COLD void mp_raise_msg_str(const mp_obj_type_t *exc_type, const char
     }
 }
 
-NORETURN MP_COLD void mp_raise_AttributeError(const mp_rom_error_text_t *msg) {
+NORETURN MP_COLD void mp_raise_AttributeError(mp_rom_error_text_t msg) {
     mp_raise_msg(&mp_type_AttributeError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_RuntimeError(const mp_rom_error_text_t *msg) {
+NORETURN MP_COLD void mp_raise_RuntimeError(mp_rom_error_text_t msg) {
     mp_raise_msg(&mp_type_RuntimeError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_RuntimeError_varg(const mp_rom_error_text_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_RuntimeError_varg(mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_RuntimeError, fmt, argptr);
     va_end(argptr);
 }
 
-NORETURN MP_COLD void mp_raise_ImportError(const mp_rom_error_text_t *msg) {
+NORETURN MP_COLD void mp_raise_ImportError(mp_rom_error_text_t msg) {
     mp_raise_msg(&mp_type_ImportError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_IndexError(const mp_rom_error_text_t *msg) {
+NORETURN MP_COLD void mp_raise_IndexError(mp_rom_error_text_t msg) {
     mp_raise_msg(&mp_type_IndexError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_IndexError_varg(const mp_rom_error_text_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_IndexError_varg(mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_IndexError, fmt, argptr);
     va_end(argptr);
 }
 
-NORETURN MP_COLD void mp_raise_ValueError(const mp_rom_error_text_t *msg) {
+NORETURN MP_COLD void mp_raise_ValueError(mp_rom_error_text_t msg) {
     mp_raise_msg(&mp_type_ValueError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_ValueError_varg(const mp_rom_error_text_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_ValueError_varg(mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_ValueError, fmt, argptr);
     va_end(argptr);
 }
 
-NORETURN MP_COLD void mp_raise_TypeError(const mp_rom_error_text_t *msg) {
+NORETURN MP_COLD void mp_raise_TypeError(mp_rom_error_text_t msg) {
     mp_raise_msg(&mp_type_TypeError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_TypeError_varg(const mp_rom_error_text_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_TypeError_varg(mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_TypeError, fmt, argptr);
     va_end(argptr);
 }
 
-NORETURN MP_COLD void mp_raise_OSError_msg(const mp_rom_error_text_t *msg) {
+NORETURN MP_COLD void mp_raise_OSError_msg(mp_rom_error_text_t msg) {
     mp_raise_msg(&mp_type_OSError, msg);
 }
 
@@ -1836,14 +1836,14 @@ NORETURN MP_COLD void mp_raise_OSError_errno_str(int errno_, mp_obj_t str) {
     nlr_raise(mp_obj_new_exception_args(&mp_type_OSError, 2, args));
 }
 
-NORETURN MP_COLD void mp_raise_OSError_msg_varg(const mp_rom_error_text_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_OSError_msg_varg(mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_OSError, fmt, argptr);
     va_end(argptr);
 }
 
-NORETURN MP_COLD void mp_raise_ConnectionError(const mp_rom_error_text_t *msg) {
+NORETURN MP_COLD void mp_raise_ConnectionError(mp_rom_error_text_t msg) {
     mp_raise_msg(&mp_type_ConnectionError, msg);
 }
 
@@ -1851,11 +1851,11 @@ NORETURN MP_COLD void mp_raise_BrokenPipeError(void) {
     mp_raise_type_arg(&mp_type_BrokenPipeError, MP_OBJ_NEW_SMALL_INT(MP_EPIPE));
 }
 
-NORETURN MP_COLD void mp_raise_NotImplementedError(const mp_rom_error_text_t *msg) {
+NORETURN MP_COLD void mp_raise_NotImplementedError(mp_rom_error_text_t msg) {
     mp_raise_msg(&mp_type_NotImplementedError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_NotImplementedError_varg(const mp_rom_error_text_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_NotImplementedError_varg(mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_NotImplementedError, fmt, argptr);
@@ -1863,7 +1863,7 @@ NORETURN MP_COLD void mp_raise_NotImplementedError_varg(const mp_rom_error_text_
 }
 
 
-NORETURN MP_COLD void mp_raise_OverflowError_varg(const mp_rom_error_text_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_OverflowError_varg(mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_OverflowError, fmt, argptr);

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1744,7 +1744,7 @@ NORETURN MP_COLD void mp_raise_NotImplementedError_no_msg(void) {
 
 #else
 
-NORETURN MP_COLD void mp_raise_msg(const mp_obj_type_t *exc_type, const compressed_string_t *msg) {
+NORETURN MP_COLD void mp_raise_msg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *msg) {
     if (msg == NULL) {
         nlr_raise(mp_obj_new_exception(exc_type));
     } else {
@@ -1752,12 +1752,12 @@ NORETURN MP_COLD void mp_raise_msg(const mp_obj_type_t *exc_type, const compress
     }
 }
 
-NORETURN MP_COLD void mp_raise_msg_vlist(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, va_list argptr) {
+NORETURN MP_COLD void mp_raise_msg_vlist(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, va_list argptr) {
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(exc_type, fmt, argptr);
     nlr_raise(exception);
 }
 
-NORETURN MP_COLD void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(exc_type, fmt, argptr);
@@ -1772,59 +1772,59 @@ NORETURN MP_COLD void mp_raise_msg_str(const mp_obj_type_t *exc_type, const char
     }
 }
 
-NORETURN MP_COLD void mp_raise_AttributeError(const compressed_string_t *msg) {
+NORETURN MP_COLD void mp_raise_AttributeError(const mp_rom_error_text_t *msg) {
     mp_raise_msg(&mp_type_AttributeError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_RuntimeError(const compressed_string_t *msg) {
+NORETURN MP_COLD void mp_raise_RuntimeError(const mp_rom_error_text_t *msg) {
     mp_raise_msg(&mp_type_RuntimeError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_RuntimeError_varg(const compressed_string_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_RuntimeError_varg(const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_RuntimeError, fmt, argptr);
     va_end(argptr);
 }
 
-NORETURN MP_COLD void mp_raise_ImportError(const compressed_string_t *msg) {
+NORETURN MP_COLD void mp_raise_ImportError(const mp_rom_error_text_t *msg) {
     mp_raise_msg(&mp_type_ImportError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_IndexError(const compressed_string_t *msg) {
+NORETURN MP_COLD void mp_raise_IndexError(const mp_rom_error_text_t *msg) {
     mp_raise_msg(&mp_type_IndexError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_IndexError_varg(const compressed_string_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_IndexError_varg(const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_IndexError, fmt, argptr);
     va_end(argptr);
 }
 
-NORETURN MP_COLD void mp_raise_ValueError(const compressed_string_t *msg) {
+NORETURN MP_COLD void mp_raise_ValueError(const mp_rom_error_text_t *msg) {
     mp_raise_msg(&mp_type_ValueError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_ValueError_varg(const compressed_string_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_ValueError_varg(const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_ValueError, fmt, argptr);
     va_end(argptr);
 }
 
-NORETURN MP_COLD void mp_raise_TypeError(const compressed_string_t *msg) {
+NORETURN MP_COLD void mp_raise_TypeError(const mp_rom_error_text_t *msg) {
     mp_raise_msg(&mp_type_TypeError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_TypeError_varg(const compressed_string_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_TypeError_varg(const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_TypeError, fmt, argptr);
     va_end(argptr);
 }
 
-NORETURN MP_COLD void mp_raise_OSError_msg(const compressed_string_t *msg) {
+NORETURN MP_COLD void mp_raise_OSError_msg(const mp_rom_error_text_t *msg) {
     mp_raise_msg(&mp_type_OSError, msg);
 }
 
@@ -1836,14 +1836,14 @@ NORETURN MP_COLD void mp_raise_OSError_errno_str(int errno_, mp_obj_t str) {
     nlr_raise(mp_obj_new_exception_args(&mp_type_OSError, 2, args));
 }
 
-NORETURN MP_COLD void mp_raise_OSError_msg_varg(const compressed_string_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_OSError_msg_varg(const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_OSError, fmt, argptr);
     va_end(argptr);
 }
 
-NORETURN MP_COLD void mp_raise_ConnectionError(const compressed_string_t *msg) {
+NORETURN MP_COLD void mp_raise_ConnectionError(const mp_rom_error_text_t *msg) {
     mp_raise_msg(&mp_type_ConnectionError, msg);
 }
 
@@ -1851,11 +1851,11 @@ NORETURN MP_COLD void mp_raise_BrokenPipeError(void) {
     mp_raise_type_arg(&mp_type_BrokenPipeError, MP_OBJ_NEW_SMALL_INT(MP_EPIPE));
 }
 
-NORETURN MP_COLD void mp_raise_NotImplementedError(const compressed_string_t *msg) {
+NORETURN MP_COLD void mp_raise_NotImplementedError(const mp_rom_error_text_t *msg) {
     mp_raise_msg(&mp_type_NotImplementedError, msg);
 }
 
-NORETURN MP_COLD void mp_raise_NotImplementedError_varg(const compressed_string_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_NotImplementedError_varg(const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_NotImplementedError, fmt, argptr);
@@ -1863,7 +1863,7 @@ NORETURN MP_COLD void mp_raise_NotImplementedError_varg(const compressed_string_
 }
 
 
-NORETURN MP_COLD void mp_raise_OverflowError_varg(const compressed_string_t *fmt, ...) {
+NORETURN MP_COLD void mp_raise_OverflowError_varg(const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_raise_msg_vlist(&mp_type_OverflowError, fmt, argptr);

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -242,44 +242,44 @@ NORETURN void mp_raise_NotImplementedError_no_msg(void);
 #define mp_raise_NotImplementedError(msg) mp_raise_NotImplementedError_no_msg()
 #else
 #define mp_raise_type(exc_type) mp_raise_msg(exc_type, NULL)
-NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...);
-NORETURN void mp_raise_ValueError(const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_TypeError(const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_NotImplementedError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, mp_rom_error_text_t msg);
+NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, ...);
+NORETURN void mp_raise_ValueError(mp_rom_error_text_t msg);
+NORETURN void mp_raise_TypeError(mp_rom_error_text_t msg);
+NORETURN void mp_raise_NotImplementedError(mp_rom_error_text_t msg);
 #endif
 
 NORETURN void mp_raise_type_arg(const mp_obj_type_t *exc_type, mp_obj_t arg);
-NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt
+NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, mp_rom_error_text_t msg);
+NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt
     , ...);
-NORETURN void mp_raise_msg_vlist(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, va_list argptr);
+NORETURN void mp_raise_msg_vlist(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, va_list argptr);
 // Only use this string version in native mpy files. Otherwise, use the compressed string version.
 NORETURN void mp_raise_msg_str(const mp_obj_type_t *exc_type, const char *msg);
 
-NORETURN void mp_raise_AttributeError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_AttributeError(mp_rom_error_text_t msg);
 NORETURN void mp_raise_BrokenPipeError(void);
-NORETURN void mp_raise_ConnectionError(const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_ImportError(const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_IndexError(const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_IndexError_varg(const mp_rom_error_text_t *msg, ...);
-NORETURN void mp_raise_NotImplementedError(const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_NotImplementedError_varg(const mp_rom_error_text_t *fmt, ...);
+NORETURN void mp_raise_ConnectionError(mp_rom_error_text_t msg);
+NORETURN void mp_raise_ImportError(mp_rom_error_text_t msg);
+NORETURN void mp_raise_IndexError(mp_rom_error_text_t msg);
+NORETURN void mp_raise_IndexError_varg(mp_rom_error_text_t msg, ...);
+NORETURN void mp_raise_NotImplementedError(mp_rom_error_text_t msg);
+NORETURN void mp_raise_NotImplementedError_varg(mp_rom_error_text_t fmt, ...);
 NORETURN void mp_raise_OSError_errno_str(int errno_, mp_obj_t str);
 NORETURN void mp_raise_OSError(int errno_);
-NORETURN void mp_raise_OSError_msg(const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_OSError_msg_varg(const mp_rom_error_text_t *fmt, ...);
+NORETURN void mp_raise_OSError_msg(mp_rom_error_text_t msg);
+NORETURN void mp_raise_OSError_msg_varg(mp_rom_error_text_t fmt, ...);
 NORETURN void mp_raise_OSError_with_filename(int errno_, const char *filename);
-NORETURN void mp_raise_OverflowError_varg(const mp_rom_error_text_t *fmt, ...);
+NORETURN void mp_raise_OverflowError_varg(mp_rom_error_text_t fmt, ...);
 NORETURN void mp_raise_recursion_depth(void);
-NORETURN void mp_raise_RuntimeError(const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_RuntimeError_varg(const mp_rom_error_text_t *fmt, ...);
+NORETURN void mp_raise_RuntimeError(mp_rom_error_text_t msg);
+NORETURN void mp_raise_RuntimeError_varg(mp_rom_error_text_t fmt, ...);
 NORETURN void mp_raise_StopIteration(mp_obj_t arg);
-NORETURN void mp_raise_TypeError(const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_TypeError_varg(const mp_rom_error_text_t *fmt, ...);
+NORETURN void mp_raise_TypeError(mp_rom_error_text_t msg);
+NORETURN void mp_raise_TypeError_varg(mp_rom_error_text_t fmt, ...);
 NORETURN void mp_raise_TypeError_int_conversion(mp_const_obj_t arg);
-NORETURN void mp_raise_ValueError(const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_ValueError_varg(const mp_rom_error_text_t *fmt, ...);
+NORETURN void mp_raise_ValueError(mp_rom_error_text_t msg);
+NORETURN void mp_raise_ValueError_varg(mp_rom_error_text_t fmt, ...);
 NORETURN void mp_raise_ZeroDivisionError(void);
 
 #if MICROPY_BUILTIN_METHOD_CHECK_SELF_ARG

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -242,44 +242,44 @@ NORETURN void mp_raise_NotImplementedError_no_msg(void);
 #define mp_raise_NotImplementedError(msg) mp_raise_NotImplementedError_no_msg()
 #else
 #define mp_raise_type(exc_type) mp_raise_msg(exc_type, NULL)
-NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const compressed_string_t *msg);
-NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, ...);
-NORETURN void mp_raise_ValueError(const compressed_string_t *msg);
-NORETURN void mp_raise_TypeError(const compressed_string_t *msg);
-NORETURN void mp_raise_NotImplementedError(const compressed_string_t *msg);
+NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...);
+NORETURN void mp_raise_ValueError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_TypeError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_NotImplementedError(const mp_rom_error_text_t *msg);
 #endif
 
 NORETURN void mp_raise_type_arg(const mp_obj_type_t *exc_type, mp_obj_t arg);
-NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const compressed_string_t *msg);
-NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const compressed_string_t *fmt
+NORETURN void mp_raise_msg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_msg_varg(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt
     , ...);
-NORETURN void mp_raise_msg_vlist(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, va_list argptr);
+NORETURN void mp_raise_msg_vlist(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, va_list argptr);
 // Only use this string version in native mpy files. Otherwise, use the compressed string version.
 NORETURN void mp_raise_msg_str(const mp_obj_type_t *exc_type, const char *msg);
 
-NORETURN void mp_raise_AttributeError(const compressed_string_t *msg);
+NORETURN void mp_raise_AttributeError(const mp_rom_error_text_t *msg);
 NORETURN void mp_raise_BrokenPipeError(void);
-NORETURN void mp_raise_ConnectionError(const compressed_string_t *msg);
-NORETURN void mp_raise_ImportError(const compressed_string_t *msg);
-NORETURN void mp_raise_IndexError(const compressed_string_t *msg);
-NORETURN void mp_raise_IndexError_varg(const compressed_string_t *msg, ...);
-NORETURN void mp_raise_NotImplementedError(const compressed_string_t *msg);
-NORETURN void mp_raise_NotImplementedError_varg(const compressed_string_t *fmt, ...);
+NORETURN void mp_raise_ConnectionError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_ImportError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_IndexError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_IndexError_varg(const mp_rom_error_text_t *msg, ...);
+NORETURN void mp_raise_NotImplementedError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_NotImplementedError_varg(const mp_rom_error_text_t *fmt, ...);
 NORETURN void mp_raise_OSError_errno_str(int errno_, mp_obj_t str);
 NORETURN void mp_raise_OSError(int errno_);
-NORETURN void mp_raise_OSError_msg(const compressed_string_t *msg);
-NORETURN void mp_raise_OSError_msg_varg(const compressed_string_t *fmt, ...);
+NORETURN void mp_raise_OSError_msg(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_OSError_msg_varg(const mp_rom_error_text_t *fmt, ...);
 NORETURN void mp_raise_OSError_with_filename(int errno_, const char *filename);
-NORETURN void mp_raise_OverflowError_varg(const compressed_string_t *fmt, ...);
+NORETURN void mp_raise_OverflowError_varg(const mp_rom_error_text_t *fmt, ...);
 NORETURN void mp_raise_recursion_depth(void);
-NORETURN void mp_raise_RuntimeError(const compressed_string_t *msg);
-NORETURN void mp_raise_RuntimeError_varg(const compressed_string_t *fmt, ...);
+NORETURN void mp_raise_RuntimeError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_RuntimeError_varg(const mp_rom_error_text_t *fmt, ...);
 NORETURN void mp_raise_StopIteration(mp_obj_t arg);
-NORETURN void mp_raise_TypeError(const compressed_string_t *msg);
-NORETURN void mp_raise_TypeError_varg(const compressed_string_t *fmt, ...);
+NORETURN void mp_raise_TypeError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_TypeError_varg(const mp_rom_error_text_t *fmt, ...);
 NORETURN void mp_raise_TypeError_int_conversion(mp_const_obj_t arg);
-NORETURN void mp_raise_ValueError(const compressed_string_t *msg);
-NORETURN void mp_raise_ValueError_varg(const compressed_string_t *fmt, ...);
+NORETURN void mp_raise_ValueError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_ValueError_varg(const mp_rom_error_text_t *fmt, ...);
 NORETURN void mp_raise_ZeroDivisionError(void);
 
 #if MICROPY_BUILTIN_METHOD_CHECK_SELF_ARG

--- a/shared-bindings/_bleio/__init__.c
+++ b/shared-bindings/_bleio/__init__.c
@@ -66,7 +66,7 @@
 //|     ...
 //|
 MP_DEFINE_BLEIO_EXCEPTION(BluetoothError, Exception)
-NORETURN void mp_raise_bleio_BluetoothError(const mp_rom_error_text_t *fmt, ...) {
+NORETURN void mp_raise_bleio_BluetoothError(mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_bleio_BluetoothError, fmt, argptr);
@@ -81,7 +81,7 @@ NORETURN void mp_raise_bleio_BluetoothError(const mp_rom_error_text_t *fmt, ...)
 //|     ...
 //|
 MP_DEFINE_BLEIO_EXCEPTION(RoleError, bleio_BluetoothError)
-NORETURN void mp_raise_bleio_RoleError(const mp_rom_error_text_t *msg) {
+NORETURN void mp_raise_bleio_RoleError(mp_rom_error_text_t msg) {
     mp_raise_msg(&mp_type_bleio_RoleError, msg);
 }
 
@@ -91,7 +91,7 @@ NORETURN void mp_raise_bleio_RoleError(const mp_rom_error_text_t *msg) {
 //|     ...
 //|
 MP_DEFINE_BLEIO_EXCEPTION(SecurityError, bleio_BluetoothError)
-NORETURN void mp_raise_bleio_SecurityError(const mp_rom_error_text_t *fmt, ...) {
+NORETURN void mp_raise_bleio_SecurityError(mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_bleio_SecurityError, fmt, argptr);

--- a/shared-bindings/_bleio/__init__.c
+++ b/shared-bindings/_bleio/__init__.c
@@ -66,7 +66,7 @@
 //|     ...
 //|
 MP_DEFINE_BLEIO_EXCEPTION(BluetoothError, Exception)
-NORETURN void mp_raise_bleio_BluetoothError(const compressed_string_t *fmt, ...) {
+NORETURN void mp_raise_bleio_BluetoothError(const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_bleio_BluetoothError, fmt, argptr);
@@ -81,7 +81,7 @@ NORETURN void mp_raise_bleio_BluetoothError(const compressed_string_t *fmt, ...)
 //|     ...
 //|
 MP_DEFINE_BLEIO_EXCEPTION(RoleError, bleio_BluetoothError)
-NORETURN void mp_raise_bleio_RoleError(const compressed_string_t *msg) {
+NORETURN void mp_raise_bleio_RoleError(const mp_rom_error_text_t *msg) {
     mp_raise_msg(&mp_type_bleio_RoleError, msg);
 }
 
@@ -91,7 +91,7 @@ NORETURN void mp_raise_bleio_RoleError(const compressed_string_t *msg) {
 //|     ...
 //|
 MP_DEFINE_BLEIO_EXCEPTION(SecurityError, bleio_BluetoothError)
-NORETURN void mp_raise_bleio_SecurityError(const compressed_string_t *fmt, ...) {
+NORETURN void mp_raise_bleio_SecurityError(const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_bleio_SecurityError, fmt, argptr);

--- a/shared-bindings/_bleio/__init__.h
+++ b/shared-bindings/_bleio/__init__.h
@@ -62,9 +62,9 @@ void bleio_reset(void);
 
 extern mp_obj_t bleio_set_adapter(mp_obj_t adapter_obj);
 
-NORETURN void mp_raise_bleio_BluetoothError(const mp_rom_error_text_t *msg, ...);
-NORETURN void mp_raise_bleio_RoleError(const mp_rom_error_text_t *msg);
-NORETURN void mp_raise_bleio_SecurityError(const mp_rom_error_text_t *msg, ...);
+NORETURN void mp_raise_bleio_BluetoothError(mp_rom_error_text_t msg, ...);
+NORETURN void mp_raise_bleio_RoleError(mp_rom_error_text_t msg);
+NORETURN void mp_raise_bleio_SecurityError(mp_rom_error_text_t msg, ...);
 
 bleio_adapter_obj_t *common_hal_bleio_allocate_adapter_or_raise(void);
 void common_hal_bleio_check_connected(uint16_t conn_handle);

--- a/shared-bindings/_bleio/__init__.h
+++ b/shared-bindings/_bleio/__init__.h
@@ -62,9 +62,9 @@ void bleio_reset(void);
 
 extern mp_obj_t bleio_set_adapter(mp_obj_t adapter_obj);
 
-NORETURN void mp_raise_bleio_BluetoothError(const compressed_string_t *msg, ...);
-NORETURN void mp_raise_bleio_RoleError(const compressed_string_t *msg);
-NORETURN void mp_raise_bleio_SecurityError(const compressed_string_t *msg, ...);
+NORETURN void mp_raise_bleio_BluetoothError(const mp_rom_error_text_t *msg, ...);
+NORETURN void mp_raise_bleio_RoleError(const mp_rom_error_text_t *msg);
+NORETURN void mp_raise_bleio_SecurityError(const mp_rom_error_text_t *msg, ...);
 
 bleio_adapter_obj_t *common_hal_bleio_allocate_adapter_or_raise(void);
 void common_hal_bleio_check_connected(uint16_t conn_handle);

--- a/shared-bindings/memorymonitor/__init__.c
+++ b/shared-bindings/memorymonitor/__init__.c
@@ -43,7 +43,7 @@
 //|
 MP_DEFINE_MEMORYMONITOR_EXCEPTION(AllocationError, Exception)
 
-NORETURN void mp_raise_memorymonitor_AllocationError(const compressed_string_t *fmt, ...) {
+NORETURN void mp_raise_memorymonitor_AllocationError(const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_memorymonitor_AllocationError, fmt, argptr);

--- a/shared-bindings/memorymonitor/__init__.c
+++ b/shared-bindings/memorymonitor/__init__.c
@@ -43,7 +43,7 @@
 //|
 MP_DEFINE_MEMORYMONITOR_EXCEPTION(AllocationError, Exception)
 
-NORETURN void mp_raise_memorymonitor_AllocationError(const mp_rom_error_text_t *fmt, ...) {
+NORETURN void mp_raise_memorymonitor_AllocationError(mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_obj_t exception = mp_obj_new_exception_msg_vlist(&mp_type_memorymonitor_AllocationError, fmt, argptr);

--- a/shared-bindings/memorymonitor/__init__.h
+++ b/shared-bindings/memorymonitor/__init__.h
@@ -44,6 +44,6 @@ void memorymonitor_exception_print(const mp_print_t *print, mp_obj_t o_in, mp_pr
 
 extern const mp_obj_type_t mp_type_memorymonitor_AllocationError;
 
-NORETURN void mp_raise_memorymonitor_AllocationError(const mp_rom_error_text_t *msg, ...);
+NORETURN void mp_raise_memorymonitor_AllocationError(mp_rom_error_text_t msg, ...);
 
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_MEMORYMONITOR___INIT___H

--- a/shared-bindings/memorymonitor/__init__.h
+++ b/shared-bindings/memorymonitor/__init__.h
@@ -44,6 +44,6 @@ void memorymonitor_exception_print(const mp_print_t *print, mp_obj_t o_in, mp_pr
 
 extern const mp_obj_type_t mp_type_memorymonitor_AllocationError;
 
-NORETURN void mp_raise_memorymonitor_AllocationError(const compressed_string_t *msg, ...);
+NORETURN void mp_raise_memorymonitor_AllocationError(const mp_rom_error_text_t *msg, ...);
 
 #endif  // MICROPY_INCLUDED_SHARED_BINDINGS_MEMORYMONITOR___INIT___H

--- a/shared-bindings/usb/core/__init__.c
+++ b/shared-bindings/usb/core/__init__.c
@@ -48,7 +48,7 @@
 //|     ...
 //|
 MP_DEFINE_USB_CORE_EXCEPTION(USBError, OSError)
-NORETURN void mp_raise_usb_core_USBError(const compressed_string_t *fmt, ...) {
+NORETURN void mp_raise_usb_core_USBError(const mp_rom_error_text_t *fmt, ...) {
     mp_obj_t exception;
     if (fmt == NULL) {
         exception = mp_obj_new_exception(&mp_type_usb_core_USBError);

--- a/shared-bindings/usb/core/__init__.c
+++ b/shared-bindings/usb/core/__init__.c
@@ -48,7 +48,7 @@
 //|     ...
 //|
 MP_DEFINE_USB_CORE_EXCEPTION(USBError, OSError)
-NORETURN void mp_raise_usb_core_USBError(const mp_rom_error_text_t *fmt, ...) {
+NORETURN void mp_raise_usb_core_USBError(mp_rom_error_text_t fmt, ...) {
     mp_obj_t exception;
     if (fmt == NULL) {
         exception = mp_obj_new_exception(&mp_type_usb_core_USBError);

--- a/shared-bindings/usb/core/__init__.h
+++ b/shared-bindings/usb/core/__init__.h
@@ -45,7 +45,7 @@ void usb_core_exception_print(const mp_print_t *print, mp_obj_t o_in, mp_print_k
 extern const mp_obj_type_t mp_type_usb_core_USBError;
 extern const mp_obj_type_t mp_type_usb_core_USBTimeoutError;
 
-NORETURN void mp_raise_usb_core_USBError(const compressed_string_t *fmt, ...);
+NORETURN void mp_raise_usb_core_USBError(const mp_rom_error_text_t *fmt, ...);
 NORETURN void mp_raise_usb_core_USBTimeoutError(void);
 
 // Find is all Python object oriented so we don't need a separate common-hal API

--- a/shared-bindings/usb/core/__init__.h
+++ b/shared-bindings/usb/core/__init__.h
@@ -45,7 +45,7 @@ void usb_core_exception_print(const mp_print_t *print, mp_obj_t o_in, mp_print_k
 extern const mp_obj_type_t mp_type_usb_core_USBError;
 extern const mp_obj_type_t mp_type_usb_core_USBTimeoutError;
 
-NORETURN void mp_raise_usb_core_USBError(const mp_rom_error_text_t *fmt, ...);
+NORETURN void mp_raise_usb_core_USBError(mp_rom_error_text_t fmt, ...);
 NORETURN void mp_raise_usb_core_USBTimeoutError(void);
 
 // Find is all Python object oriented so we don't need a separate common-hal API

--- a/shared-module/os/getenv.c
+++ b/shared-module/os/getenv.c
@@ -314,7 +314,7 @@ STATIC os_getenv_err_t os_getenv_buf_terminated(const char *key, char *value, si
     return result;
 }
 
-STATIC void print_dont_raise(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...) {
+STATIC void print_dont_raise(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_vcprintf(&mp_plat_print, fmt, argptr);
@@ -322,7 +322,7 @@ STATIC void print_dont_raise(const mp_obj_type_t *exc_type, const mp_rom_error_t
     va_end(argptr);
 }
 
-STATIC void handle_getenv_error(os_getenv_err_t error, void (*handle)(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...)) {
+STATIC void handle_getenv_error(os_getenv_err_t error, void (*handle)(const mp_obj_type_t *exc_type, mp_rom_error_text_t fmt, ...)) {
     if (error == GETENV_OK) {
         return;
     }

--- a/shared-module/os/getenv.c
+++ b/shared-module/os/getenv.c
@@ -314,7 +314,7 @@ STATIC os_getenv_err_t os_getenv_buf_terminated(const char *key, char *value, si
     return result;
 }
 
-STATIC void print_dont_raise(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, ...) {
+STATIC void print_dont_raise(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...) {
     va_list argptr;
     va_start(argptr, fmt);
     mp_vcprintf(&mp_plat_print, fmt, argptr);
@@ -322,7 +322,7 @@ STATIC void print_dont_raise(const mp_obj_type_t *exc_type, const compressed_str
     va_end(argptr);
 }
 
-STATIC void handle_getenv_error(os_getenv_err_t error, void (*handle)(const mp_obj_type_t *exc_type, const compressed_string_t *fmt, ...)) {
+STATIC void handle_getenv_error(os_getenv_err_t error, void (*handle)(const mp_obj_type_t *exc_type, const mp_rom_error_text_t *fmt, ...)) {
     if (error == GETENV_OK) {
         return;
     }

--- a/shared-module/sdcardio/SDCard.c
+++ b/shared-module/sdcardio/SDCard.c
@@ -199,7 +199,7 @@ STATIC int block_cmd(sdcardio_sdcard_obj_t *self, int cmd_, int block, void *res
     return cmd(self, cmd_, block * self->cdv, response_buf, response_len, true, true);
 }
 
-STATIC const compressed_string_t *init_card_v1(sdcardio_sdcard_obj_t *self) {
+STATIC const mp_rom_error_text_t *init_card_v1(sdcardio_sdcard_obj_t *self) {
     for (int i = 0; i < CMD_TIMEOUT; i++) {
         if (cmd(self, 41, 0, NULL, 0, true, true) == 0) {
             return NULL;
@@ -208,7 +208,7 @@ STATIC const compressed_string_t *init_card_v1(sdcardio_sdcard_obj_t *self) {
     return translate("timeout waiting for v1 card");
 }
 
-STATIC const compressed_string_t *init_card_v2(sdcardio_sdcard_obj_t *self) {
+STATIC const mp_rom_error_text_t *init_card_v2(sdcardio_sdcard_obj_t *self) {
     for (int i = 0; i < CMD_TIMEOUT; i++) {
         uint8_t ocr[4];
         common_hal_time_delay_ms(50);
@@ -225,7 +225,7 @@ STATIC const compressed_string_t *init_card_v2(sdcardio_sdcard_obj_t *self) {
     return translate("timeout waiting for v2 card");
 }
 
-STATIC const compressed_string_t *init_card(sdcardio_sdcard_obj_t *self) {
+STATIC const mp_rom_error_text_t *init_card(sdcardio_sdcard_obj_t *self) {
     clock_card(self, 10);
 
     common_hal_digitalio_digitalinout_set_value(&self->cs, false);
@@ -256,12 +256,12 @@ STATIC const compressed_string_t *init_card(sdcardio_sdcard_obj_t *self) {
         uint8_t rb7[4];
         int response = cmd(self, 8, 0x1AA, rb7, sizeof(rb7), false, true);
         if (response == R1_IDLE_STATE) {
-            const compressed_string_t *result = init_card_v2(self);
+            const mp_rom_error_text_t *result = init_card_v2(self);
             if (result != NULL) {
                 return result;
             }
         } else if (response == (R1_IDLE_STATE | R1_ILLEGAL_COMMAND)) {
-            const compressed_string_t *result = init_card_v1(self);
+            const mp_rom_error_text_t *result = init_card_v1(self);
             if (result != NULL) {
                 return result;
             }
@@ -314,7 +314,7 @@ void common_hal_sdcardio_sdcard_construct(sdcardio_sdcard_obj_t *self, busio_spi
     self->baudrate = 250000;
 
     lock_bus_or_throw(self);
-    const compressed_string_t *result = init_card(self);
+    const mp_rom_error_text_t *result = init_card(self);
     extraclock_and_unlock_bus(self);
 
     if (result != NULL) {

--- a/shared-module/sdcardio/SDCard.c
+++ b/shared-module/sdcardio/SDCard.c
@@ -199,7 +199,7 @@ STATIC int block_cmd(sdcardio_sdcard_obj_t *self, int cmd_, int block, void *res
     return cmd(self, cmd_, block * self->cdv, response_buf, response_len, true, true);
 }
 
-STATIC const mp_rom_error_text_t *init_card_v1(sdcardio_sdcard_obj_t *self) {
+STATIC mp_rom_error_text_t init_card_v1(sdcardio_sdcard_obj_t *self) {
     for (int i = 0; i < CMD_TIMEOUT; i++) {
         if (cmd(self, 41, 0, NULL, 0, true, true) == 0) {
             return NULL;
@@ -208,7 +208,7 @@ STATIC const mp_rom_error_text_t *init_card_v1(sdcardio_sdcard_obj_t *self) {
     return translate("timeout waiting for v1 card");
 }
 
-STATIC const mp_rom_error_text_t *init_card_v2(sdcardio_sdcard_obj_t *self) {
+STATIC mp_rom_error_text_t init_card_v2(sdcardio_sdcard_obj_t *self) {
     for (int i = 0; i < CMD_TIMEOUT; i++) {
         uint8_t ocr[4];
         common_hal_time_delay_ms(50);
@@ -225,7 +225,7 @@ STATIC const mp_rom_error_text_t *init_card_v2(sdcardio_sdcard_obj_t *self) {
     return translate("timeout waiting for v2 card");
 }
 
-STATIC const mp_rom_error_text_t *init_card(sdcardio_sdcard_obj_t *self) {
+STATIC mp_rom_error_text_t init_card(sdcardio_sdcard_obj_t *self) {
     clock_card(self, 10);
 
     common_hal_digitalio_digitalinout_set_value(&self->cs, false);
@@ -256,12 +256,12 @@ STATIC const mp_rom_error_text_t *init_card(sdcardio_sdcard_obj_t *self) {
         uint8_t rb7[4];
         int response = cmd(self, 8, 0x1AA, rb7, sizeof(rb7), false, true);
         if (response == R1_IDLE_STATE) {
-            const mp_rom_error_text_t *result = init_card_v2(self);
+            mp_rom_error_text_t result = init_card_v2(self);
             if (result != NULL) {
                 return result;
             }
         } else if (response == (R1_IDLE_STATE | R1_ILLEGAL_COMMAND)) {
-            const mp_rom_error_text_t *result = init_card_v1(self);
+            mp_rom_error_text_t result = init_card_v1(self);
             if (result != NULL) {
                 return result;
             }
@@ -314,7 +314,7 @@ void common_hal_sdcardio_sdcard_construct(sdcardio_sdcard_obj_t *self, busio_spi
     self->baudrate = 250000;
 
     lock_bus_or_throw(self);
-    const mp_rom_error_text_t *result = init_card(self);
+    mp_rom_error_text_t result = init_card(self);
     extraclock_and_unlock_bus(self);
 
     if (result != NULL) {

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -148,7 +148,7 @@ void print_safe_mode_message(safe_mode_t reason) {
 
     serial_write_compressed(translate("\nYou are in safe mode because:\n"));
 
-    const mp_rom_error_text_t *message = NULL;
+    mp_rom_error_text_t message = NULL;
 
     // First check for safe mode reasons that do not necessarily reflect bugs.
 

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -148,7 +148,7 @@ void print_safe_mode_message(safe_mode_t reason) {
 
     serial_write_compressed(translate("\nYou are in safe mode because:\n"));
 
-    const compressed_string_t *message = NULL;
+    const mp_rom_error_text_t *message = NULL;
 
     // First check for safe mode reasons that do not necessarily reflect bugs.
 

--- a/supervisor/shared/translate/compressed_string.h
+++ b/supervisor/shared/translate/compressed_string.h
@@ -94,12 +94,12 @@
 typedef struct compressed_string {
     uint8_t data;
     const uint8_t tail[];
-} compressed_string_t;
+} mp_rom_error_text_t;
 
 // Return the compressed, translated version of a source string
 // Usually, due to LTO, this is optimized into a load of a constant
 // pointer.
-// const compressed_string_t *translate(const char *c);
-void serial_write_compressed(const compressed_string_t *compressed);
-char *decompress(const compressed_string_t *compressed, char *decompressed);
-uint16_t decompress_length(const compressed_string_t *compressed);
+// const mp_rom_error_text_t *translate(const char *c);
+void serial_write_compressed(const mp_rom_error_text_t *compressed);
+char *decompress(const mp_rom_error_text_t *compressed, char *decompressed);
+uint16_t decompress_length(const mp_rom_error_text_t *compressed);

--- a/supervisor/shared/translate/compressed_string.h
+++ b/supervisor/shared/translate/compressed_string.h
@@ -94,12 +94,12 @@
 typedef struct compressed_string {
     uint8_t data;
     const uint8_t tail[];
-} *mp_rom_error_text_t;
+} const *mp_rom_error_text_t;
 
 // Return the compressed, translated version of a source string
 // Usually, due to LTO, this is optimized into a load of a constant
 // pointer.
-// const mp_rom_error_text_t *translate(const char *c);
-void serial_write_compressed(const mp_rom_error_text_t *compressed);
-char *decompress(const mp_rom_error_text_t *compressed, char *decompressed);
-uint16_t decompress_length(const mp_rom_error_text_t *compressed);
+// mp_rom_error_text_t translate(const char *c);
+void serial_write_compressed(mp_rom_error_text_t compressed);
+char *decompress(mp_rom_error_text_t compressed, char *decompressed);
+uint16_t decompress_length(mp_rom_error_text_t compressed);

--- a/supervisor/shared/translate/compressed_string.h
+++ b/supervisor/shared/translate/compressed_string.h
@@ -94,7 +94,7 @@
 typedef struct compressed_string {
     uint8_t data;
     const uint8_t tail[];
-} mp_rom_error_text_t;
+} *mp_rom_error_text_t;
 
 // Return the compressed, translated version of a source string
 // Usually, due to LTO, this is optimized into a load of a constant

--- a/supervisor/shared/translate/translate.c
+++ b/supervisor/shared/translate/translate.c
@@ -39,7 +39,7 @@
 #include "py/mpprint.h"
 #include "supervisor/serial.h"
 
-void serial_write_compressed(const compressed_string_t *compressed) {
+void serial_write_compressed(const mp_rom_error_text_t *compressed) {
     mp_printf(MP_PYTHON_PRINTER, "%S", compressed);
 }
 
@@ -90,7 +90,7 @@ STATIC int put_utf8(char *buf, int u) {
     }
 }
 
-uint16_t decompress_length(const compressed_string_t *compressed) {
+uint16_t decompress_length(const mp_rom_error_text_t *compressed) {
     #ifndef NO_QSTR
     #if (compress_max_length_bits <= 8)
     return 1 + (compressed->data >> (8 - compress_max_length_bits));
@@ -123,7 +123,7 @@ static int get_nbits(bitstream_state_t *st, int n) {
     return r;
 }
 
-char *decompress(const compressed_string_t *compressed, char *decompressed) {
+char *decompress(const mp_rom_error_text_t *compressed, char *decompressed) {
     bitstream_state_t b = {
         .ptr = &(compressed->data) + (compress_max_length_bits >> 3),
         .bit = 1 << (7 - ((compress_max_length_bits) & 0x7)),

--- a/supervisor/shared/translate/translate.c
+++ b/supervisor/shared/translate/translate.c
@@ -39,7 +39,7 @@
 #include "py/mpprint.h"
 #include "supervisor/serial.h"
 
-void serial_write_compressed(const mp_rom_error_text_t *compressed) {
+void serial_write_compressed(mp_rom_error_text_t compressed) {
     mp_printf(MP_PYTHON_PRINTER, "%S", compressed);
 }
 
@@ -90,7 +90,7 @@ STATIC int put_utf8(char *buf, int u) {
     }
 }
 
-uint16_t decompress_length(const mp_rom_error_text_t *compressed) {
+uint16_t decompress_length(mp_rom_error_text_t compressed) {
     #ifndef NO_QSTR
     #if (compress_max_length_bits <= 8)
     return 1 + (compressed->data >> (8 - compress_max_length_bits));
@@ -123,7 +123,7 @@ static int get_nbits(bitstream_state_t *st, int n) {
     return r;
 }
 
-char *decompress(const mp_rom_error_text_t *compressed, char *decompressed) {
+char *decompress(mp_rom_error_text_t compressed, char *decompressed) {
     bitstream_state_t b = {
         .ptr = &(compressed->data) + (compress_max_length_bits >> 3),
         .bit = 1 << (7 - ((compress_max_length_bits) & 0x7)),

--- a/supervisor/shared/translate/translate.h
+++ b/supervisor/shared/translate/translate.h
@@ -49,5 +49,5 @@
 #else
 // In link time optimized (LTO) builds, we can compile this once into a .o and
 // at link time the calls will be optimized.
-const compressed_string_t *translate(const char *c);
+const mp_rom_error_text_t *translate(const char *c);
 #endif

--- a/supervisor/shared/translate/translate.h
+++ b/supervisor/shared/translate/translate.h
@@ -33,9 +33,7 @@
 #include "supervisor/shared/translate/compressed_string.h"
 
 // Map MicroPython's error messages to our translations.
-#if !defined(MICROPY_ENABLE_DYNRUNTIME) || !MICROPY_ENABLE_DYNRUNTIME
-#define MP_ERROR_TEXT(x) translate(x)
-#endif
+#define MP_COMPRESSED_ROM_TEXT(x) translate(x)
 
 // translate() is a giant function with many strcmp calls. The assumption is
 // that the build process will optimize this away and replace it with the

--- a/supervisor/shared/translate/translate.h
+++ b/supervisor/shared/translate/translate.h
@@ -30,9 +30,10 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "supervisor/shared/translate/compressed_string.h"
 
 // Map MicroPython's error messages to our translations.
+#if !defined(MICROPY_ENABLE_DYNRUNTIME) || !MICROPY_ENABLE_DYNRUNTIME
+#include "supervisor/shared/translate/compressed_string.h"
 #define MP_COMPRESSED_ROM_TEXT(x) translate(x)
 
 // translate() is a giant function with many strcmp calls. The assumption is
@@ -47,5 +48,10 @@
 #else
 // In link time optimized (LTO) builds, we can compile this once into a .o and
 // at link time the calls will be optimized.
-const mp_rom_error_text_t *translate(const char *c);
+mp_rom_error_text_t translate(const char *c);
+#endif
+
+#else
+typedef const char *mp_rom_error_text_t;
+#define MP_COMPRESSED_ROM_TEXT(x) x
 #endif

--- a/supervisor/shared/translate/translate_impl.h
+++ b/supervisor/shared/translate/translate_impl.h
@@ -34,7 +34,7 @@
 
 #ifndef NO_QSTR
 #define QDEF(id, hash, len, str)
-#define TRANSLATION(english_id, number) extern compressed_string_t translation##number;
+#define TRANSLATION(english_id, number) extern mp_rom_error_text_t translation##number;
 #include "genhdr/qstrdefs.generated.h"
 #undef TRANSLATION
 #undef QDEF
@@ -50,7 +50,7 @@ __attribute__((always_inline))
 #endif
 // Prevent instrumenting this because that disables the inlining we rely of for code size
 // optimization.
-__attribute__((no_instrument_function)) const compressed_string_t *translate(const char *original) {
+__attribute__((no_instrument_function)) const mp_rom_error_text_t *translate(const char *original) {
     #ifndef NO_QSTR
     #define QDEF(id, hash, len, str)
     #define TRANSLATION(english_id, number) if (strcmp(original, english_id) == 0) { return &translation##number; } else

--- a/supervisor/shared/translate/translate_impl.h
+++ b/supervisor/shared/translate/translate_impl.h
@@ -34,7 +34,7 @@
 
 #ifndef NO_QSTR
 #define QDEF(id, hash, len, str)
-#define TRANSLATION(english_id, number) extern mp_rom_error_text_t translation##number;
+#define TRANSLATION(english_id, number) extern struct compressed_string translation##number;
 #include "genhdr/qstrdefs.generated.h"
 #undef TRANSLATION
 #undef QDEF
@@ -50,10 +50,10 @@ __attribute__((always_inline))
 #endif
 // Prevent instrumenting this because that disables the inlining we rely of for code size
 // optimization.
-__attribute__((no_instrument_function)) const mp_rom_error_text_t *translate(const char *original) {
+__attribute__((no_instrument_function)) mp_rom_error_text_t translate(const char *original) {
     #ifndef NO_QSTR
     #define QDEF(id, hash, len, str)
-    #define TRANSLATION(english_id, number) if (strcmp(original, english_id) == 0) { return &translation##number; } else
+    #define TRANSLATION(english_id, number) if (strcmp(original, english_id) == 0) { return (mp_rom_error_text_t)&translation##number; } else
     #include "genhdr/qstrdefs.generated.h"
 #undef TRANSLATION
 #undef QDEF


### PR DESCRIPTION
.. and also use MP_ERROR_TEXT instead of translate in py/

this hopefully gets us a bit closer to upstream.

Closes #8511