### PR TITLE
Pass subobject into native subscr

### DIFF
--- a/ports/unix/native_base_class.c
+++ b/ports/unix/native_base_class.c
@@ -76,12 +76,21 @@ STATIC const mp_rom_map_elem_t native_base_class_locals_dict_table[] = {
 };
 STATIC MP_DEFINE_CONST_DICT(native_base_class_locals_dict, native_base_class_locals_dict_table);
 
+STATIC mp_obj_t native_base_class_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value) {
+    mp_obj_t attribute_value = mp_load_attr(self_in, MP_QSTR_new_attribute);
+    mp_printf(&mp_plat_print, "native base class subscr .new_attribute set to: ");
+    mp_obj_print_helper(&mp_plat_print, attribute_value, PRINT_REPR);
+    mp_printf(&mp_plat_print, "\n");
+    return attribute_value;
+}
+
 MP_DEFINE_CONST_OBJ_TYPE(
     native_base_class_type,
     MP_QSTR_NativeBaseClass,
     MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
     make_new, &native_base_class_make_new,
-    locals_dict, &native_base_class_locals_dict
+    locals_dict, &native_base_class_locals_dict,
+    subscr, &native_base_class_subscr
     );
 
 #endif

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -855,7 +855,11 @@ STATIC mp_obj_t instance_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value
     }
     mp_obj_class_lookup(&lookup, self->base.type);
     if (member[0] == MP_OBJ_SENTINEL) {
-        return mp_obj_subscr(self->subobj[0], index, value);
+        // CIRCUITPY-CHANGE: We pass the native subscr a copy of the original
+        // object so it can access info about the subobject.
+        const mp_obj_type_t *type = mp_obj_get_type(self->subobj[0]);
+        mp_obj_t ret = MP_OBJ_TYPE_GET_SLOT(type, subscr)(self_in, index, value);
+        return ret;
     } else if (member[0] != MP_OBJ_NULL) {
         size_t n_args = value == MP_OBJ_NULL || value == MP_OBJ_SENTINEL ? 1 : 2;
         mp_obj_t ret = mp_call_method_n_kw(n_args, 0, member);

--- a/tests/unix/subclass_native.py
+++ b/tests/unix/subclass_native.py
@@ -26,10 +26,12 @@ print(".test:", a.test)
 a.test = "test set indirectly"
 print(".test:", a.test)
 
-a._new_attribute = True
-print("._new_attribute", a._new_attribute)
+a.new_attribute = True
+print(".new_attribute", a.new_attribute)
 
-a.print_subclass_attr("_new_attribute")
+a.print_subclass_attr("new_attribute")
+
+print(a[0])
 
 
 class B(NativeBaseClass):
@@ -43,7 +45,8 @@ print(".test:", b.test)
 b.test = "test set indirectly through b"
 print(".test:", b.test)
 
-b._new_attribute = True
-print("._new_attribute", b._new_attribute)
+b.new_attribute = "hello"
+print(".new_attribute", b.new_attribute)
 
-b.print_subclass_attr("_new_attribute")
+b.print_subclass_attr("new_attribute")
+print(b[0])

--- a/tests/unix/subclass_native.py.exp
+++ b/tests/unix/subclass_native.py.exp
@@ -4,10 +4,14 @@ native base class .test set to: 'test set directly'
 .test: subclass kwarg
 native base class .test set to: 'test set indirectly'
 .test: test set indirectly
-._new_attribute True
-native base class ._new_attribute set to: True
+.new_attribute True
+native base class .new_attribute set to: True
+native base class subscr .new_attribute set to: True
+True
 .test: super init suffix
 native base class .test set to: 'test set indirectly through b'
 .test: test set indirectly through b
-._new_attribute True
-native base class ._new_attribute set to: True
+.new_attribute hello
+native base class .new_attribute set to: 'hello'
+native base class subscr .new_attribute set to: 'hello'
+hello


### PR DESCRIPTION
This allows PixelBuf to call transmit after setting a value.

Fixes #8488