### PR TITLE
Fix keypad classes to show the events property

### DIFF
--- a/shared-bindings/keypad/KeyMatrix.c
+++ b/shared-bindings/keypad/KeyMatrix.c
@@ -253,7 +253,7 @@ STATIC MP_DEFINE_CONST_DICT(keypad_keymatrix_locals_dict, keypad_keymatrix_local
 MP_DEFINE_CONST_OBJ_TYPE(
     keypad_keymatrix_type,
     MP_QSTR_KeyMatrix,
-    MP_TYPE_FLAG_NONE,
+    MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
     make_new, keypad_keymatrix_make_new
     #if CIRCUITPY_KEYPAD_KEYMATRIX
     , locals_dict, &keypad_keymatrix_locals_dict

--- a/shared-bindings/keypad/Keys.c
+++ b/shared-bindings/keypad/Keys.c
@@ -187,7 +187,7 @@ STATIC MP_DEFINE_CONST_DICT(keypad_keys_locals_dict, keypad_keys_locals_dict_tab
 MP_DEFINE_CONST_OBJ_TYPE(
     keypad_keys_type,
     MP_QSTR_Keys,
-    MP_TYPE_FLAG_NONE,
+    MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
     make_new, keypad_keys_make_new
     #if CIRCUITPY_KEYPAD_KEYS
     , locals_dict, &keypad_keys_locals_dict

--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -239,7 +239,7 @@ STATIC MP_DEFINE_CONST_DICT(keypad_shiftregisterkeys_locals_dict, keypad_shiftre
 MP_DEFINE_CONST_OBJ_TYPE(
     keypad_shiftregisterkeys_type,
     MP_QSTR_ShiftRegisterKeys,
-    MP_TYPE_FLAG_NONE,
+    MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
     make_new, keypad_shiftregisterkeys_make_new
     #if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
     , locals_dict, &keypad_shiftregisterkeys_locals_dict


### PR DESCRIPTION
It looks like we need the MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS flag on the class for properties to work, and the Keys, KeyMatrix and ShiftRegisterKeys classes were missing it, so the "events" property didn't appear on the instances.