### PR TITLE
Unset D_FORTIFY_SOURCE and remove unneeded copied functions

### DIFF
--- a/shared/libc/string0.c
+++ b/shared/libc/string0.c
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#undef _FORTIFY_SOURCE
 #include <string.h>
 
 #include "py/mpconfig.h"
@@ -73,15 +74,6 @@ void *memcpy(void *dst, const void *src, size_t n) {
     }
 
     return dst;
-}
-
-// CIRCUITPY-CHANGE: extern
-extern void *__memcpy_chk(void *dest, const void *src, size_t len, size_t slen);
-void *__memcpy_chk(void *dest, const void *src, size_t len, size_t slen) {
-    if (len > slen) {
-        return NULL;
-    }
-    return memcpy(dest, src, len);
 }
 
 void *memmove(void *dest, const void *src, size_t n) {


### PR DESCRIPTION
Commit 4e2ab71dfe2b1869ec41a3db1fe79387ff46a0fe reverts micropython/micropython@5cf71b55960651fc506df0ac41490f12dd1d63fd which solved micropython/micropython#6046, which I'm seeing again on my gentoo system with D_FORTIFY_HARDENED enabled by default.

Unfortunately we can't just revert the revertion because circuitpython enforces prototypes for defined functions, which is why 4e2ab71d was implemented initially. Micropython doesn't suffer from this issue.

The implemented fix is to just circumvent D_FORTIFY_SOURCE, a nice side-effect is we can remove the  re-implemented functions that were added on the initial `string.h` removal.