### PR TITLE
correct MP_TYPE_FLAG_NONE to  MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS

### DIFF
--- a/ports/espressif/bindings/espulp/ULPAlarm.c
+++ b/ports/espressif/bindings/espulp/ULPAlarm.c
@@ -27,7 +27,6 @@
 #include "bindings/espulp/ULPAlarm.h"
 
 #include "py/runtime.h"
-#include "py/objproperty.h"
 
 //| class ULPAlarm:
 //|     """Trigger an alarm when the ULP requests wake-up."""

--- a/shared-bindings/alarm/SleepMemory.c
+++ b/shared-bindings/alarm/SleepMemory.c
@@ -26,7 +26,6 @@
  */
 
 #include "py/binary.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "py/runtime0.h"
 

--- a/shared-bindings/analogbufio/BufferedIn.c
+++ b/shared-bindings/analogbufio/BufferedIn.c
@@ -31,7 +31,6 @@
 #include "py/binary.h"
 #include "py/mphal.h"
 #include "py/nlr.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/analogbufio/BufferedIn.h"

--- a/shared-bindings/camera/Camera.c
+++ b/shared-bindings/camera/Camera.c
@@ -24,7 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include "py/objproperty.h"
 #include "py/runtime.h"
 
 #include "shared-bindings/camera/Camera.h"

--- a/shared-bindings/i2cdisplaybus/I2CDisplayBus.c
+++ b/shared-bindings/i2cdisplaybus/I2CDisplayBus.c
@@ -31,7 +31,6 @@
 
 #include "shared/runtime/context_manager_helpers.h"
 #include "py/binary.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/busio/I2C.h"

--- a/shared-bindings/i2ctarget/I2CTarget.c
+++ b/shared-bindings/i2ctarget/I2CTarget.c
@@ -420,7 +420,7 @@ STATIC MP_DEFINE_CONST_DICT(i2ctarget_i2c_target_request_locals_dict, i2ctarget_
 MP_DEFINE_CONST_OBJ_TYPE(
     i2ctarget_i2c_target_request_type,
     MP_QSTR_I2CTargetRequest,
-    MP_TYPE_FLAG_NONE,
+    MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
     make_new, i2ctarget_i2c_target_request_make_new,
     locals_dict, &i2ctarget_i2c_target_request_locals_dict
     );

--- a/shared-bindings/imagecapture/ParallelImageCapture.c
+++ b/shared-bindings/imagecapture/ParallelImageCapture.c
@@ -25,7 +25,6 @@
  */
 
 #include "py/obj.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 
 #include "shared/runtime/context_manager_helpers.h"

--- a/shared-bindings/is31fl3741/IS31FL3741.c
+++ b/shared-bindings/is31fl3741/IS31FL3741.c
@@ -25,7 +25,6 @@
  */
 
 #include "py/obj.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "py/objarray.h"
 

--- a/shared-bindings/memorymap/AddressRange.c
+++ b/shared-bindings/memorymap/AddressRange.c
@@ -25,7 +25,6 @@
  */
 
 #include "py/binary.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "py/runtime0.h"
 #include "shared-bindings/memorymap/AddressRange.h"

--- a/shared-bindings/nvm/ByteArray.c
+++ b/shared-bindings/nvm/ByteArray.c
@@ -25,7 +25,6 @@
  */
 
 #include "py/binary.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "py/runtime0.h"
 #include "shared-bindings/nvm/ByteArray.h"

--- a/shared-bindings/onewireio/OneWire.c
+++ b/shared-bindings/onewireio/OneWire.c
@@ -27,7 +27,6 @@
 #include <stdint.h>
 
 #include "shared/runtime/context_manager_helpers.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "py/runtime0.h"
 #include "shared-bindings/microcontroller/Pin.h"

--- a/shared-bindings/paralleldisplaybus/ParallelBus.c
+++ b/shared-bindings/paralleldisplaybus/ParallelBus.c
@@ -30,7 +30,6 @@
 
 #include "shared/runtime/context_manager_helpers.h"
 #include "py/binary.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/util.h"

--- a/shared-bindings/ps2io/Ps2.c
+++ b/shared-bindings/ps2io/Ps2.c
@@ -28,7 +28,6 @@
 #include <stdint.h>
 
 #include "shared/runtime/context_manager_helpers.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "py/runtime0.h"
 #include "shared-bindings/microcontroller/Pin.h"

--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -25,7 +25,6 @@
  */
 
 #include "py/obj.h"
-#include "py/objproperty.h"
 #include "py/runtime.h"
 #include "py/objarray.h"
 

--- a/shared-bindings/vectorio/Rectangle.c
+++ b/shared-bindings/vectorio/Rectangle.c
@@ -166,7 +166,7 @@ STATIC MP_DEFINE_CONST_DICT(vectorio_rectangle_locals_dict, vectorio_rectangle_l
 MP_DEFINE_CONST_OBJ_TYPE(
     vectorio_rectangle_type,
     MP_QSTR_Rectangle,
-    MP_TYPE_FLAG_NONE,
+    MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
     make_new, vectorio_rectangle_make_new,
     locals_dict, &vectorio_rectangle_locals_dict,
     protocol, &rectangle_draw_protocol


### PR DESCRIPTION

After @jepler and @tannewt fixed a bunch of these, I looked for further existing `MP_TYPE_FLAG_NONE` uses that should be `MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS`. I did this by looking to see if those types were also using properties. Found a couple more.

As an accidental side effect, I found a bunch of files which were doing `#include "py/objproperty.h` unnecessarily, and removed that include.

