### PR TITLE
Fix off-by-one in flash block read with fake MBR

### DIFF
--- a/supervisor/shared/flash.c
+++ b/supervisor/shared/flash.c
@@ -105,6 +105,7 @@ static mp_uint_t flash_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t n
         if (num_blocks > 1) {
             dest += 512;
             num_blocks -= 1;
+            block_num += 1;
             // Fall through and do a read from flash.
         } else {
             return 0; // Done and ok.


### PR DESCRIPTION
When reading multiple blocks starting at block 0 from the raw flash filesystem incorrect blocks are returned. For example:
```
root@ub2004:/home/rabeles/Development/circuitpython-fakembr/ports/raspberrypi# dd if=/dev/sdd bs=512 count=2 | hexdump -C
2+0 records in
2+0 records out
1024 bytes (1.0 kB, 1.0 KiB) copied, 4.0062e-05 s, 25.6 MB/s
00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000001b0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 ff  |................|
000001c0  ff ff 01 ff ff ff 01 00  00 00 f8 03 00 00 00 00  |................|
000001d0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000001f0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 55 aa  |..............U.|
00000200  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
*
00000400
```

This is due to an off-by-one error in `supervisor/shared/flash.c` in function `flash_read_blocks()`. With this pull applied, the multiple block read now works correctly:
```
root@ub2004:/home/rabeles/Development/circuitpython-fakembr/ports/raspberrypi# dd if=/dev/sdd bs=512 count=2 | hexdump -C
2+0 records in
2+0 records out
1024 bytes (1.0 kB, 1.0 KiB) copied, 8.1636e-05 s, 12.5 MB/s
00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000001b0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 ff  |................|
000001c0  ff ff 01 ff ff ff 01 00  00 00 f8 03 00 00 00 00  |................|
000001d0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000001f0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 55 aa  |..............U.|
00000200  eb fe 90 4d 53 44 4f 53  35 2e 30 00 02 01 01 00  |...MSDOS5.0.....|
00000210  01 00 02 f8 03 f8 03 00  3f 00 ff 00 01 00 00 00  |........?.......|
00000220  00 00 00 00 80 01 29 31  c7 43 e0 4e 4f 20 4e 41  |......)1.C.NO NA|
00000230  4d 45 20 20 20 20 46 41  54 20 20 20 20 20 00 00  |ME    FAT     ..|
00000240  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000003f0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 55 aa  |..............U.|
00000400
```