### PR TITLE
Shrink root dir size for tiny (<=128K) FAT12 fs

### DIFF
--- a/lib/oofatfs/ff.c
+++ b/lib/oofatfs/ff.c
@@ -5422,7 +5422,7 @@ FRESULT f_mkfs (
 )
 {
     const UINT n_fats = 1;      /* Number of FATs for FAT/FAT32 volume (1 or 2) */
-    const UINT n_rootdir = 512; /* Number of root directory entries for FAT volume */
+    UINT n_rootdir = 512;       /* Number of root directory entries for FAT volume */
     static const WORD cst[] = {1, 4, 16, 64, 256, 512, 0};  /* Cluster size boundary for FAT volume (4Ks unit) */
 #if FF_MKFS_FAT32
     static const WORD cst32[] = {1, 2, 4, 8, 16, 32, 0};    /* Cluster size boundary for FAT32 volume (128Ks unit) */
@@ -5703,6 +5703,7 @@ FRESULT f_mkfs (
                 }
                 sz_fat = (n + ss - 1) / ss;     /* FAT size [sector] */
                 sz_rsv = 1;                     /* Number of reserved sectors */
+                n_rootdir = (sz_vol <= 256)? 64 : n_rootdir; /* Shrink root dir for <= 128K device */
                 sz_dir = (DWORD)n_rootdir * SZDIRE / ss;    /* Rootdir size [sector] */
             }
             b_fat = b_vol + sz_rsv;                     /* FAT base */

--- a/lib/oofatfs/ff.c
+++ b/lib/oofatfs/ff.c
@@ -5704,7 +5704,11 @@ FRESULT f_mkfs (
                 }
                 sz_fat = (n + ss - 1) / ss;     /* FAT size [sector] */
                 sz_rsv = 1;                     /* Number of reserved sectors */
-                n_rootdir = (sz_vol <= 256)? 64 : n_rootdir; /* Shrink root dir for <= 128K device */
+               // CIRCUITPY-CHANGE: For fewer than 256 clusters (128kB filesystem),
+               // shrink the root directory size from 512 entries to 128 entries. Note that
+               // long filenames will use two entries. This change affects only the root directory,
+               // not subdirectories
+                n_rootdir = (sz_vol <= 256) ? 128 : n_rootdir;
                 sz_dir = (DWORD)n_rootdir * SZDIRE / ss;    /* Rootdir size [sector] */
             }
             b_fat = b_vol + sz_rsv;                     /* FAT base */

--- a/lib/oofatfs/ff.c
+++ b/lib/oofatfs/ff.c
@@ -5422,7 +5422,8 @@ FRESULT f_mkfs (
 )
 {
     const UINT n_fats = 1;      /* Number of FATs for FAT/FAT32 volume (1 or 2) */
-    UINT n_rootdir = 512;       /* Number of root directory entries for FAT volume */
+    // CIRCUITPY-CHANGE: Make number of root directory entries changeable. See below.
+    UINT n_rootdir = 512;       /* Default number of root directory entries for FAT volume */
     static const WORD cst[] = {1, 4, 16, 64, 256, 512, 0};  /* Cluster size boundary for FAT volume (4Ks unit) */
 #if FF_MKFS_FAT32
     static const WORD cst32[] = {1, 2, 4, 8, 16, 32, 0};    /* Cluster size boundary for FAT32 volume (128Ks unit) */

--- a/tests/extmod/vfs_blockdev.py.exp
+++ b/tests/extmod/vfs_blockdev.py.exp
@@ -1,5 +1,5 @@
 test <class 'VfsFat'>
-(512, 512, 16, 16, 16, 0, 0, 0, 0, 255)
+(512, 512, 44, 44, 44, 0, 0, 0, 0, 255)
 [('test', 32768, 0, 90)]
 some datasome datasome datasome datasome datasome datasome datasome datasome datasome data
 test <class 'VfsLfs2'>

--- a/tests/extmod/vfs_blockdev.py.exp
+++ b/tests/extmod/vfs_blockdev.py.exp
@@ -1,5 +1,5 @@
 test <class 'VfsFat'>
-(512, 512, 44, 44, 44, 0, 0, 0, 0, 255)
+(512, 512, 40, 40, 40, 0, 0, 0, 0, 255)
 [('test', 32768, 0, 90)]
 some datasome datasome datasome datasome datasome datasome datasome datasome datasome data
 test <class 'VfsLfs2'>

--- a/tests/extmod/vfs_fat_ramdisk.py.exp
+++ b/tests/extmod/vfs_fat_ramdisk.py.exp
@@ -1,7 +1,7 @@
 True
 True
 label: LABEL TEST
-statvfs: (512, 512, 16, 16, 16, 0, 0, 0, 0, 255)
+statvfs: (512, 512, 44, 44, 44, 0, 0, 0, 0, 255)
 getcwd: /
 True
 [('foo_file.txt', 32768, 0, 6)]

--- a/tests/extmod/vfs_fat_ramdisk.py.exp
+++ b/tests/extmod/vfs_fat_ramdisk.py.exp
@@ -1,7 +1,7 @@
 True
 True
 label: LABEL TEST
-statvfs: (512, 512, 44, 44, 44, 0, 0, 0, 0, 255)
+statvfs: (512, 512, 40, 40, 40, 0, 0, 0, 0, 255)
 getcwd: /
 True
 [('foo_file.txt', 32768, 0, 6)]


### PR DESCRIPTION
Reduce the size of the root directory for a FAT12 filesystem on a tiny (<=128KB) flash device.

When `oofatfs` creates a filesystem it uses a default root directory size of 512. For most flash devices this is a reasonable choice, but for tiny flash devices this can consume a large portion of the flash. For example, a Trinket M0 has a 64KB filesystem of which 16KB is consumed by the FAT12 root directory.

This pull causes `f_mkfs()` to automatically reduce the FAT12 root directory from 512 entries to 64 entries when it detects a device <= 128KB. For the Trinket M0 case, the root directory flash size usage is reduced from 16KB to 2KB.

This pull will reduce the number of files and sub-directories that can be placed in the root directory from 256 to 32. Files and sub-directories usually take 2 entries due to LFN (Long File Name) support. The number of files and sub-directories that can be stored in sub-directories are not limited by this change due to FAT12 allocating them dynamically from the filesystem's data space.

This pull will not affect an existing filesystem. Only when the device is reformatted will the root directory size be reduced.

For background, Linux's `mkfs.msdos` has a command line option that sets the root directory size.

This pull has been tested on Linux (Ubuntu 22.04), Windows 10, and MacOS Big Sur (11.7.8).