### PR TITLE
feat: add `Task` methods to make `_asyncio` more similar to cpython

### DIFF
--- a/extmod/modasyncio.c
+++ b/extmod/modasyncio.c
@@ -202,6 +202,12 @@ STATIC mp_obj_t task_done(mp_obj_t self_in) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(task_done_obj, task_done);
 
+STATIC mp_obj_t task_get_coro(mp_obj_t self_in) {
+    mp_obj_task_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_FROM_PTR(self->coro);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(task_get_coro_obj, task_get_coro);
+
 STATIC mp_obj_t task_cancel(mp_obj_t self_in) {
     mp_obj_task_t *self = MP_OBJ_TO_PTR(self_in);
     // Check if task is already finished.
@@ -276,6 +282,9 @@ STATIC void task_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
         } else if (attr == MP_QSTR___await__) {
             dest[0] = MP_OBJ_FROM_PTR(&task_await_obj);
             dest[1] = self_in;
+        } else if (attr == MP_QSTR_get_coro) {
+            dest[0] = MP_OBJ_FROM_PTR(&task_get_coro_obj);
+            dest[1] = self_in;
         }
     } else if (dest[1] != MP_OBJ_NULL) {
         // Store
@@ -286,6 +295,15 @@ STATIC void task_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
             self->state = dest[1];
             dest[0] = MP_OBJ_NULL;
         }
+    }
+}
+
+STATIC mp_obj_t task_unary_op(mp_unary_op_t op, mp_obj_t o_in) {
+    switch(op) {
+        case MP_UNARY_OP_HASH:
+            return MP_OBJ_NEW_SMALL_INT((mp_uint_t) o_in);
+        default:
+            return MP_OBJ_NULL;      // op not supported
     }
 }
 
@@ -337,7 +355,8 @@ STATIC MP_DEFINE_CONST_OBJ_TYPE(
     MP_TYPE_FLAG_ITER_IS_CUSTOM,
     make_new, task_make_new,
     attr, task_attr,
-    iter, &task_getiter_iternext
+    iter, &task_getiter_iternext,
+    unary_op, task_unary_op
     );
 
 /******************************************************************************/

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -958,6 +958,10 @@ msgstr ""
 msgid "Error: Failure to bind"
 msgstr ""
 
+#: extmod/modasyncio.c
+msgid "Exception is not set."
+msgstr ""
+
 #: shared-bindings/alarm/__init__.c
 msgid "Expected a kind of %q"
 msgstr ""
@@ -1858,6 +1862,10 @@ msgstr ""
 msgid "Requested resource not found"
 msgstr ""
 
+#: extmod/modasyncio.c
+msgid "Result is not ready."
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Right channel unsupported"
 msgstr ""
@@ -1961,6 +1969,14 @@ msgstr ""
 
 #: shared-bindings/gnss/GNSS.c
 msgid "System entry must be gnss.SatelliteSystem"
+msgstr ""
+
+#: extmod/modasyncio.c
+msgid "Task does not support set_exception operation"
+msgstr ""
+
+#: extmod/modasyncio.c
+msgid "Task does not support set_result operation"
 msgstr ""
 
 #: ports/stm/common-hal/microcontroller/Processor.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1979,6 +1979,10 @@ msgstr ""
 msgid "Task does not support set_result operation"
 msgstr ""
 
+#: extmod/modasyncio.c
+msgid "Tasks only support one done callback."
+msgstr ""
+
 #: ports/stm/common-hal/microcontroller/Processor.c
 msgid "Temperature read timed out"
 msgstr ""

--- a/tests/extmod/asyncio_task_add_done_callback.py
+++ b/tests/extmod/asyncio_task_add_done_callback.py
@@ -1,0 +1,50 @@
+# Test the Task.done() method
+
+try:
+    import asyncio
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+async def task(t, exc=None):
+    if t >= 0:
+        await asyncio.sleep(t)
+    if exc:
+        raise exc
+
+
+async def main():
+    # Tasks that aren't done only execute done callback after finishing
+    print("=" * 10)
+    t = asyncio.create_task(task(-1))
+    t.add_done_callback(lambda: print("done"))
+    print("Waiting for task to complete")
+    await asyncio.sleep(0)
+    print("Task has completed")
+
+    # Task that are done run the callback immediately
+    print("=" * 10)
+    t = asyncio.create_task(task(-1))
+    await asyncio.sleep(0)
+    print("Task has completed")
+    t.add_done_callback(lambda: print("done"))
+    print("Callback Added")
+
+    # Task that starts, runs and finishes without an exception should return None
+    print("=" * 10)
+    t = asyncio.create_task(task(0.01))
+    t.add_done_callback(lambda: print("done"))
+    try:
+        t.add_done_callback(lambda: print("done"))
+    except RuntimeError as e:
+        print("Second call to add_done_callback emits error:", repr(e))
+
+    # Task that raises immediately should still run done callback
+    print("=" * 10)
+    t = asyncio.create_task(task(-1, ValueError))
+    t.add_done_callback(lambda: print("done"))
+    await asyncio.sleep(0)
+
+
+asyncio.run(main())

--- a/tests/extmod/asyncio_task_add_done_callback.py.exp
+++ b/tests/extmod/asyncio_task_add_done_callback.py.exp
@@ -1,0 +1,14 @@
+==========
+Waiting for task to complete
+done
+Task has completed
+==========
+Task has completed
+done
+Callback added
+==========
+Second call to add_done_callback emits error: Tasks only support one done callback.
+==========
+Waiting for task to complete
+done
+Exception handled

--- a/tests/extmod/asyncio_task_cancelled.py
+++ b/tests/extmod/asyncio_task_cancelled.py
@@ -1,0 +1,54 @@
+# Test cancelling a task
+
+try:
+    import asyncio
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+async def task(t):
+    await asyncio.sleep(t)
+
+
+async def main():
+    # Cancel task immediately doesn't mark the task as cancelled
+    print("=" * 10)
+    t = asyncio.create_task(task(2))
+    t.cancel()
+    print("Expecting task to not be cancelled because it is not done:", t.cancelled())
+
+    # Cancel task immediately and wait for cancellation to complete
+    print("=" * 10)
+    t = asyncio.create_task(task(2))
+    t.cancel()
+    await asyncio.sleep(0)
+    print("Expecting Task to be Cancelled:", t.cancelled())
+
+    # Cancel task and wait for cancellation to complete
+    print("=" * 10)
+    t = asyncio.create_task(task(2))
+    await asyncio.sleep(0.01)
+    t.cancel()
+    await asyncio.sleep(0)
+    print("Expecting Task to be Cancelled:", t.cancelled())
+
+    # Cancel task multiple times after it has started
+    print("=" * 10)
+    t = asyncio.create_task(task(2))
+    await asyncio.sleep(0.01)
+    for _ in range(4):
+        t.cancel()
+    await asyncio.sleep(0.01)
+
+    print("Expecting Task to be Cancelled:", t.cancelled())
+
+    # Cancel task after it has finished
+    print("=" * 10)
+    t = asyncio.create_task(task(0.01))
+    await asyncio.sleep(0.05)
+    t.cancel()
+    print("Expecting task to not be Cancelled:", t.cancelled())
+
+
+asyncio.run(main())

--- a/tests/extmod/asyncio_task_cancelled.py.exp
+++ b/tests/extmod/asyncio_task_cancelled.py.exp
@@ -1,0 +1,10 @@
+==========
+Expecting task to not be cancelled because it is not done: False
+==========
+Expecting Task to be Cancelled: True
+==========
+Expecting Task to be Cancelled: True
+==========
+Expecting Task to be Cancelled: True
+==========
+Expecting task to not be Cancelled: False

--- a/tests/extmod/asyncio_task_exception.py
+++ b/tests/extmod/asyncio_task_exception.py
@@ -1,0 +1,57 @@
+# Test the Task.done() method
+
+try:
+    import asyncio
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+async def task(t, exc=None):
+    if t >= 0:
+        await asyncio.sleep(t)
+    if exc:
+        raise exc
+
+
+async def main():
+    # Task that is not done yet raises an InvalidStateError
+    print("=" * 10)
+    t = asyncio.create_task(task(1))
+    await asyncio.sleep(0)
+    try:
+        t.exception()
+        assert False, "Should not get here"
+    except Exception as e:
+        print("Tasks that aren't done yet raise an InvalidStateError:", repr(e))
+
+    # Task that is cancelled raises CancelledError
+    print("=" * 10)
+    t = asyncio.create_task(task(1))
+    t.cancel()
+    await asyncio.sleep(0)
+    try:
+        print(repr(t.exception()))
+        print(t.cancelled())
+        assert False, "Should not get here"
+    except asyncio.CancelledError as e:
+        print("Cancelled tasks cannot retrieve exception:", repr(e))
+
+    # Task that starts, runs and finishes without an exception should return None
+    print("=" * 10)
+    t = asyncio.create_task(task(0.01))
+    await t
+    print("None when no exception:", t.exception())
+
+    # Task that raises immediately should return that exception
+    print("=" * 10)
+    t = asyncio.create_task(task(-1, ValueError))
+    try:
+        await t
+        assert False, "Should not get here"
+    except ValueError as e:
+        pass
+    print("Returned Exception:", repr(t.exception()))
+
+
+asyncio.run(main())

--- a/tests/extmod/asyncio_task_exception.py.exp
+++ b/tests/extmod/asyncio_task_exception.py.exp
@@ -1,0 +1,8 @@
+==========
+Tasks that aren't done yet raise an InvalidStateError: InvalidStateError('Exception is not set.',)
+==========
+Cancelled tasks cannot retrieve exception: CancelledError()
+==========
+None when no exception: None
+==========
+Returned Exception: ValueError()

--- a/tests/extmod/asyncio_task_remove_done_callback.py
+++ b/tests/extmod/asyncio_task_remove_done_callback.py
@@ -1,0 +1,59 @@
+# Test the Task.done() method
+
+try:
+    import asyncio
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+async def task(t, exc=None):
+    if t >= 0:
+        await asyncio.sleep(t)
+    if exc:
+        raise exc
+
+
+def done_callback():
+    print("done")
+
+
+def done_callback_2():
+    print("done 2")
+
+
+async def main():
+    # Removing a callback returns 0 when no callbacks have been set
+    print("=" * 10)
+    t = asyncio.create_task(task(1))
+    print("Returns 0 when no done callback has been set:", t.remove_done_callback(done_callback))
+
+    # Done callback removal only works once
+    print("=" * 10)
+    t = asyncio.create_task(task(1))
+    t.add_done_callback(done_callback)
+    print(
+        "Returns 1 when a callback matches and is removed:", t.remove_done_callback(done_callback)
+    )
+    print(
+        "Returns 0 on second attempt to remove the callback:",
+        t.remove_done_callback(done_callback),
+    )
+
+    # Only removes done callback when match
+    print("=" * 10)
+    t = asyncio.create_task(task(0.01))
+    t.add_done_callback(done_callback)
+    print("Returns 0 when done callbacks don't match:", t.remove_done_callback(done_callback_2))
+
+    # A removed done callback does not execute
+    print("=" * 10)
+    t = asyncio.create_task(task(-1))
+    t.add_done_callback(done_callback)
+    t.remove_done_callback(done_callback)
+    print("Waiting for task to complete")
+    await t
+    print("Task completed")
+
+
+asyncio.run(main())

--- a/tests/extmod/asyncio_task_remove_done_callback.py.exp
+++ b/tests/extmod/asyncio_task_remove_done_callback.py.exp
@@ -1,0 +1,10 @@
+==========
+Returns 0 when no done callback has been set: 0
+==========
+Returns 1 when a callback matches and is removed: 1
+Returns 0 on second attempt to remove the callback: 0
+==========
+Returns 0 when done callbacks don't match: 0
+==========
+Waiting for task to complete
+Task completed

--- a/tests/extmod/asyncio_task_result.py
+++ b/tests/extmod/asyncio_task_result.py
@@ -1,0 +1,69 @@
+# Test the Task.done() method
+
+try:
+    import asyncio
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+async def task(t, exc=None, ret=None):
+    if t >= 0:
+        await asyncio.sleep(t)
+    if exc:
+        raise exc
+    return ret
+
+
+async def main():
+    # Task that is not done yet raises an InvalidStateError
+    print("=" * 10)
+    t = asyncio.create_task(task(1))
+    await asyncio.sleep(0)
+    try:
+        t.result()
+        assert False, "Should not get here"
+    except Exception as e:
+        print("InvalidStateError if still running:", repr(e))
+
+    # Task that is cancelled raises CancelledError
+    print("=" * 10)
+    t = asyncio.create_task(task(1))
+    t.cancel()
+    await asyncio.sleep(0)
+    try:
+        t.result()
+        assert False, "Should not get here"
+    except asyncio.CancelledError as e:
+        print("CancelledError when retrieving result from cancelled task:", repr(e))
+
+    # Task that raises immediately should raise that exception when calling result
+    print("=" * 10)
+    t = asyncio.create_task(task(-1, ValueError))
+    try:
+        await t
+        assert False, "Should not get here"
+    except ValueError as e:
+        pass
+
+    try:
+        t.result()
+        assert False, "Should not get here"
+    except ValueError as e:
+        print("Error raised when result is attempted on task with error:", repr(e))
+
+    # Task that starts, runs and finishes without an exception or value should return None
+    print("=" * 10)
+    t = asyncio.create_task(task(0.01))
+    await t
+    print("Empty Result should be None:", t.result())
+    assert t.result() is None
+
+    # Task that starts, runs and finishes without exception should return result
+    print("=" * 10)
+    t = asyncio.create_task(task(0.01, None, "hello world"))
+    await t
+    print("Happy path, result is returned:", t.result())
+
+
+asyncio.run(main())

--- a/tests/extmod/asyncio_task_result.py.exp
+++ b/tests/extmod/asyncio_task_result.py.exp
@@ -1,0 +1,10 @@
+==========
+InvalidStateError if still running: InvalidStateError('Result is not ready.',)
+==========
+CancelledError when retrieving result from cancelled task: CancelledError()
+==========
+Error raised when result is attempted on task with error: ValueError()
+==========
+Empty Result should be None: None
+==========
+Happy path, result is returned: hello world


### PR DESCRIPTION
This updates the way that Task is handled in the C module for asyncio which implements tasks & task queues.  The goal is to bring `asyncio` in CircuitPython slightly closer to CPython.

This adds the following methods to `Task`:

* `get_coro()` - how CPython exposes the coroutine backing the task ([CPython Docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.get_coro))
* `result()` - a helper method from CPython for returning the successful response ([CPython Docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.result))
* `exception()` - a helper method from CPython for returning the raised values ([CPython Docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.exception))
* `cancelled()` - helper for true / false if the task has been cancelled ([CPython Docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancelled))
* `add_done_callback()` - adds a callback to the task for completion or if already complete executes it ([CPython docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.add_done_callback))
* `remove_done_callback()` - removes a specific "done" callback from the task ([CPython docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.remove_done_callback))

Moves `CancelledError` & creates `InvalidStateError` in the extmod

Adds a `hash` unary operation so `Task`s can be added to sets.

To Do:

* [x] Support `add_done_callback` / `remove_done_callback`
* [ ] Add tests for new features
