### PR TITLE
Allow CIRCUITPY to mount on Android

### DIFF
--- a/supervisor/shared/flash.c
+++ b/supervisor/shared/flash.c
@@ -95,7 +95,8 @@ static mp_uint_t flash_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t n
             dest[i] = 0;
         }
 
-        build_partition(dest + 446, 0, 0x01 /* FAT12 */, PART1_START_BLOCK, supervisor_flash_get_block_count());
+        // Specifying "Big FAT12/16 CHS" allows mounting by Android
+        build_partition(dest + 446, 0, 0x06 /* Big FAT12/16 CHS */, PART1_START_BLOCK, supervisor_flash_get_block_count());
         build_partition(dest + 462, 0, 0, 0, 0);
         build_partition(dest + 478, 0, 0, 0, 0);
         build_partition(dest + 494, 0, 0, 0, 0);


### PR DESCRIPTION
Changing the partition type code reported in the fake MBR for the CIRCUITPY filesystem from 0x01 to 0x06 allows CIRCUITPY to mount on an Android system. Resolves #2751 without switching to FAT16. 

Tested on Android, MacOS, Windows and Linux.

Change does not affect existing CIRCUITPY filesystem on device.