### PR TITLE
use raw string for grep regexp

### DIFF
--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -257,7 +257,7 @@ def set_docs(run: bool):
                 if pattern_doc.search(file) and (
                     (
                         subprocess.run(
-                            f"git diff -U0 $BASE_SHA...$HEAD_SHA {github_workspace + file} | grep -o -m 1 '^[+-]\/\/|'",
+                            rf"git diff -U0 $BASE_SHA...$HEAD_SHA {github_workspace + file} | grep -o -m 1 '^[+-]\/\/|'",
                             capture_output=True,
                             shell=True,
                         ).stdout


### PR DESCRIPTION
Fixes `ci_set_matrix.py` error only seen after merge.