### PR TITLE
Consistency improvement on I2S mclk support for Espressif port #8570

### DIFF
--- a/ports/espressif/common-hal/audiobusio/I2SOut.c
+++ b/ports/espressif/common-hal/audiobusio/I2SOut.c
@@ -69,6 +69,9 @@ void common_hal_audiobusio_i2sout_construct(audiobusio_i2sout_obj_t *self,
     self->data = data;
     claim_pin(bit_clock);
     claim_pin(word_select);
+    if (main_clock) {
+        claim_pin(main_clock);
+    }
     claim_pin(data);
 }
 


### PR DESCRIPTION
Followup to #8571 on the fix of issue #8570.

While testing with more complex board layouts I reviewed my code more thoroughly and noticed that I didn't use `claim_pin` to claim mclk. Adding this small improvement for consistency.