### PR TITLE
Fix crash when pwmio deinit for Silabs's board

### DIFF
--- a/ports/silabs/common-hal/pwmio/PWMOut.c
+++ b/ports/silabs/common-hal/pwmio/PWMOut.c
@@ -46,6 +46,8 @@ void pwmout_reset(void) {
         mcu_tim_pin_obj_t *l_tim = &mcu_tim_list[tim_index];
         if (l_tim->pin != NULL) {
             sl_pwm_deinit(&pwm_handle[tim_index]);
+            common_hal_reset_pin(l_tim->pin);
+            l_tim->pin = NULL;
         }
     }
 


### PR DESCRIPTION
Hi Team,
We have an issue with PWIO deinit.
Crash happen due to sl_pwm_deinit function run many times with same input pwm_instance.
Current code is missing a variable reset.
This pull request adds the missing code  l_tim->pin = NULL;
Thanks!