### PR TITLE
Fix cannot write to characteristic unless read property is set for Silabs's board

### DIFF
--- a/ports/silabs/common-hal/_bleio/Characteristic.c
+++ b/ports/silabs/common-hal/_bleio/Characteristic.c
@@ -273,7 +273,8 @@ void common_hal_bleio_characteristic_set_value(bleio_characteristic_obj_t *self,
                 bufinfo->buf);
         }
     } else {
-        if (self->props & BT_GATT_CHRC_READ) {
+        if (self->props & BT_GATT_CHRC_READ || self->props & BT_GATT_CHRC_WRITE
+            || self->props & BT_GATT_CHRC_WRITE_WITHOUT_RESP) {
             sc = sl_bt_gatt_server_write_attribute_value(self->handle,
                 0,
                 bufinfo->len,


### PR DESCRIPTION
Hi Team,
We have an issue  with characteristic properties:
    When properties = (Characteristic.READ | Characteristic.WRITE_NO_RESPONSE), can change the value of characteristic normally
    But when properties = (Characteristic.WRITE_NO_RESPONSE), cannot change the value of characteristic.
This pull request adds code handle for this case.
Thanks!