### PR TITLE
Fix split heap on ESP

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -93,7 +93,7 @@ extern void common_hal_mcu_enable_interrupts(void);
 #define MICROPY_GC_ALLOC_THRESHOLD       (0)
 #define MICROPY_GC_SPLIT_HEAP            (1)
 #define MICROPY_GC_SPLIT_HEAP_AUTO       (1)
-#define MP_PLAT_ALLOC_HEAP(size) port_malloc(size, true)
+#define MP_PLAT_ALLOC_HEAP(size) port_malloc(size, false)
 #define MP_PLAT_FREE_HEAP(ptr) port_free(ptr)
 #include "supervisor/port_heap.h"
 #define MICROPY_HELPER_LEXER_UNIX        (0)


### PR DESCRIPTION
It was setting the DMA capability requirement which excludes PSRAM.

Fixes #8597. Fixes #8573.