### PR TITLE
Esp32 AnalogIn IO32 fix

### DIFF
--- a/ports/espressif/common-hal/analogio/AnalogIn.c
+++ b/ports/espressif/common-hal/analogio/AnalogIn.c
@@ -54,7 +54,7 @@
 
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self,
     const mcu_pin_obj_t *pin) {
-    if (pin->adc_index == 0 || pin->adc_channel == ADC_CHANNEL_MAX) {
+    if (pin->adc_index == NO_ADC || pin->adc_channel == NO_ADC_CHANNEL) {
         raise_ValueError_invalid_pin();
     }
     common_hal_mcu_pin_claim(pin);

--- a/ports/espressif/peripherals/esp32/pins.c
+++ b/ports/espressif/peripherals/esp32/pins.c
@@ -59,7 +59,7 @@ const mcu_pin_obj_t pin_GPIO27 = PIN(27, ADC_UNIT_2, ADC_CHANNEL_7, TOUCH_PAD_NU
 // no GPIO29
 // no GPIO30
 // no GPIO31
-const mcu_pin_obj_t pin_GPIO32 = PIN(32, ADC_UNIT_1, ADC_CHANNEL_1, TOUCH_PAD_NUM9);
+const mcu_pin_obj_t pin_GPIO32 = PIN(32, ADC_UNIT_1, ADC_CHANNEL_4, TOUCH_PAD_NUM9);
 const mcu_pin_obj_t pin_GPIO33 = PIN(33, ADC_UNIT_1, ADC_CHANNEL_5, TOUCH_PAD_NUM8);
 const mcu_pin_obj_t pin_GPIO34 = PIN(34, ADC_UNIT_1, ADC_CHANNEL_6, NO_TOUCH_CHANNEL);
 const mcu_pin_obj_t pin_GPIO35 = PIN(35, ADC_UNIT_1, ADC_CHANNEL_7, NO_TOUCH_CHANNEL);


### PR DESCRIPTION
Fixes #8313.

- Fix ADC channel for IO32.
- Use better constant names when checking pin validity.

Tested on a Feather HUZZAH32 breakout with a potentiometer and connecting to GND and 3.3V. Tested pins IO32, IO33, and IO35. 