### PR TITLE
missed a spot to update filename to synthetic.pot

### DIFF
--- a/tools/check_translations.py
+++ b/tools/check_translations.py
@@ -13,7 +13,7 @@ import polib
 template_filename = sys.argv[1]
 po_filenames = sys.argv[2:]
 
-synthetic = polib.pofile("locale/synthetic.po")
+synthetic = polib.pofile("locale/synthetic.pot")
 synthetic_ids = set([x.msgid for x in synthetic])
 template = polib.pofile(template_filename)
 all_ids = set([x.msgid for x in template]) - synthetic_ids


### PR DESCRIPTION
This caused the build failure during pre-commit / `make check-translate`.

It's not clear to me why this didn't come up during #8617's CI though!