### PR TITLE
partial clone for submodules added in git 2.36.0

### DIFF
--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -16,7 +16,7 @@ def _git_version():
 
 
 clone_supports_filter = (
-    False if "NO_USE_CLONE_FILTER" in os.environ else _git_version() >= (2, 27, 0)
+    False if "NO_USE_CLONE_FILTER" in os.environ else _git_version() >= (2, 36, 0)
 )
 
 if clone_supports_filter:


### PR DESCRIPTION
`--filter` was partly added in git 2.27.0, but was not available for submodules until 2.36.0.