### PR TITLE
Make CIRCUITPY_LOCALIZE a per-board setting

### DIFF
--- a/docs/shared_bindings_matrix.py
+++ b/docs/shared_bindings_matrix.py
@@ -174,7 +174,7 @@ def get_settings_from_makefile(port_dir, board_name):
     This list must explicitly include any setting queried by tools/ci_set_matrix.py.
     """
     contents = subprocess.run(
-        ["make", "-C", port_dir, "-f", "Makefile", f"BOARD={board_name}", "print-CFLAGS", "print-CIRCUITPY_BUILD_EXTENSIONS", "print-FROZEN_MPY_DIRS", "print-SRC_PATTERNS", "print-SRC_SUPERVISOR"],
+        ["make", "-C", port_dir, "-f", "Makefile", f"BOARD={board_name}", "print-CFLAGS", "print-CIRCUITPY_BUILD_EXTENSIONS", "print-CIRCUITPY_LOCALIZE", "print-FROZEN_MPY_DIRS", "print-SRC_PATTERNS", "print-SRC_SUPERVISOR"],
         encoding="utf-8",
         errors="replace",
         stdout=subprocess.PIPE,
@@ -328,6 +328,7 @@ def support_matrix_by_board(use_branded_name=True, withurl=True):
         else:
             raise OSError(f"Board extensions undefined: {board_name}.")
 
+
         frozen_modules = []
         if "FROZEN_MPY_DIRS" in settings:
             frozen_modules = frozen_modules_from_dirs(
@@ -344,6 +345,7 @@ def support_matrix_by_board(use_branded_name=True, withurl=True):
                     "modules": board_modules,
                     "frozen_libraries": frozen_modules,
                     "extensions": board_extensions,
+                    "localize": int(settings["CIRCUITPY_LOCALIZE"])
                 },
             )
         ]
@@ -361,6 +363,7 @@ def support_matrix_by_board(use_branded_name=True, withurl=True):
                             "modules": board_modules,
                             "frozen_libraries": frozen_modules,
                             "extensions": board_extensions,
+                            "localize": int(settings["CIRCUITPY_LOCALIZE"])
                         },
                     )
                 )

--- a/ports/atmel-samd/boards/feather_m0_rfm69/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/feather_m0_rfm69/mpconfigboard.mk
@@ -23,5 +23,8 @@ CIRCUITPY_TOUCHIO = 0
 CIRCUITPY_USB_MIDI = 0
 CIRCUITPY_USB_HID = 0
 
+# Board doesn't have enough flash space to support localization
+CIRCUITPY_LOCALIZE = 0
+
 # Include these Python libraries in firmware.
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_RFM69

--- a/py/circuitpy_mpconfig.mk
+++ b/py/circuitpy_mpconfig.mk
@@ -52,6 +52,11 @@ CFLAGS += -DCIRCUITPY=$(CIRCUITPY)
 CIRCUITPY_FULL_BUILD ?= 1
 CFLAGS += -DCIRCUITPY_FULL_BUILD=$(CIRCUITPY_FULL_BUILD)
 
+# Smaller builds may not have enough room for non-English translations. This
+# flag stops the CI from building them. It does NOT appear in CFLAGS and cannot
+# be tested by the C preprocessor.
+CIRCUITPY_LOCALIZE ?= 1
+
 # By default, aggressively reduce the size of in-flash messages, at the cost of
 # increased build time
 CIRCUITPY_MESSAGE_COMPRESSION_LEVEL ?= 9

--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -185,10 +185,10 @@ def print_active_user():
     response = github.get("/user")
     if response.ok:
         user = response.json()["login"]
-        print("Logged in as {}".format(user))
+        print("Logged in as {}".format(user), file=sys.stderr)
         return user
     else:
-        print("Not logged in")
+        print("Not logged in", file=sys.stderr)
     return None
 
 
@@ -237,13 +237,16 @@ def generate_download_info():
                 board_info = board_mapping[board_id]
                 for alias in [board_id] + board_info["aliases"]:
                     alias_info = board_mapping[alias]
+                    board_languages = (
+                        "languages" if support_matrix[alias]["localize"] else ["en_US"]
+                    )
                     if alias not in current_info:
                         changes["new_boards"].append(alias)
                         current_info[alias] = {"downloads": 0, "versions": []}
                     new_version = {
                         "stable": new_stable,
                         "version": new_tag,
-                        "languages": languages,
+                        "languages": board_languages,
                         # add modules, extensions, frozen_libraries explicitly
                         "modules": support_matrix[alias]["modules"],
                         "extensions": support_matrix[alias]["extensions"],
@@ -264,7 +267,7 @@ def generate_download_info():
 
 
 if __name__ == "__main__":
-    if "RELEASE_TAG" in os.environ and os.environ["RELEASE_TAG"]:
+    if os.environ.get("RELEASE_TAG") or os.environ.get("DEBUG"):
         generate_download_info()
     else:
         print("skipping website update because this isn't a tag")

--- a/tools/build_release_files.py
+++ b/tools/build_release_files.py
@@ -19,10 +19,6 @@ from shared_bindings_matrix import get_settings_from_makefile
 for port in build_info.SUPPORTED_PORTS:
     result = subprocess.run("rm -rf ../ports/{port}/build*".format(port=port), shell=True)
 
-PARALLEL = "-j 4"
-if "GITHUB_ACTION" in os.environ:
-    PARALLEL = "-j 2"
-
 all_boards = build_info.get_board_mapping()
 build_boards = list(all_boards.keys())
 if "BOARDS" in os.environ:
@@ -36,6 +32,8 @@ LANGUAGE_FIRST = "en_US"
 LANGUAGE_THRESHOLD = 10 * 1024
 
 languages = build_info.get_languages()
+languages.remove(LANGUAGE_FIRST)
+languages.insert(0, LANGUAGE_FIRST)
 
 all_languages = build_info.get_languages(list_all=True)
 
@@ -50,8 +48,9 @@ for board in build_boards:
     board_info = all_boards[board]
     board_settings = get_settings_from_makefile("../ports/" + board_info["port"], board)
 
-    languages.remove(LANGUAGE_FIRST)
-    languages.insert(0, LANGUAGE_FIRST)
+    localize = int(board_settings["CIRCUITPY_LOCALIZE"])
+    board_languages = languages if localize else ["en_US"]
+    print(f"{board}: Building languages:", ", ".join(board_languages))
 
     for language in languages:
         bin_directory = "../bin/{board}/{language}".format(board=board, language=language)


### PR DESCRIPTION
Some boards may need to disable localization as the least bad trade-off against disabling other features. However, it should only be done rarely.

This is done for the Feather M0 RFM69 as a proof-of-concept. It appears to correctly build only English during CI and only list the en_US translation in the release json file.

Tested locally with
```shell
PYTHONPATH=../docs:adabot/ BOARDS=feather_m0_rfm69 python build_release_files.py
DEBUG=yes RELEASE_TAG=testing PYTHONPATH=../docs:adabot/ BOARDS=feather_m0_rfm69 python build_board_info.py  > release-info.json
```