### PR TITLE
Add loop_start and loop_end properties to synthio.Note for waveshaping and sampling capabilities.

### DIFF
--- a/shared-bindings/synthio/Note.c
+++ b/shared-bindings/synthio/Note.c
@@ -45,6 +45,8 @@ static const mp_arg_t note_properties[] = {
     { MP_QSTR_ring_frequency, MP_ARG_OBJ, {.u_obj = MP_ROM_INT(0) } },
     { MP_QSTR_ring_bend, MP_ARG_OBJ, {.u_obj = MP_ROM_INT(0) } },
     { MP_QSTR_ring_waveform, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = MP_ROM_NONE } },
+    { MP_QSTR_loop_start, MP_ARG_OBJ, {.u_obj = MP_ROM_INT(0) } },
+    { MP_QSTR_loop_end, MP_ARG_OBJ, {.u_obj = MP_ROM_INT(0) } },
 };
 //| class Note:
 //|     def __init__(
@@ -60,6 +62,8 @@ static const mp_arg_t note_properties[] = {
 //|         ring_frequency: float = 0.0,
 //|         ring_bend: float = 0.0,
 //|         ring_waveform: Optional[ReadableBuffer] = 0.0,
+//|         loop_start: int = 0,
+//|         loop_end: int = 0,
 //|     ) -> None:
 //|         """Construct a Note object, with a frequency in Hz, and optional panning, waveform, envelope, tremolo (volume change) and bend (frequency change).
 //|
@@ -296,6 +300,43 @@ MP_PROPERTY_GETSET(synthio_note_ring_waveform_obj,
     (mp_obj_t)&synthio_note_get_ring_waveform_obj,
     (mp_obj_t)&synthio_note_set_ring_waveform_obj);
 
+//|     loop_start: int
+//|     """The index of where to begin looping waveform data. Must be greater than 0 and less than the total size of the waveform data."""
+STATIC mp_obj_t synthio_note_get_loop_start(mp_obj_t self_in) {
+    synthio_note_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_int(common_hal_synthio_note_get_loop_start(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(synthio_note_get_loop_start_obj, synthio_note_get_loop_start);
+
+STATIC mp_obj_t synthio_note_set_loop_start(mp_obj_t self_in, mp_obj_t arg) {
+    synthio_note_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_synthio_note_set_loop_start(self, mp_obj_get_int(arg));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(synthio_note_set_loop_start_obj, synthio_note_set_loop_start);
+MP_PROPERTY_GETSET(synthio_note_loop_start_obj,
+    (mp_obj_t)&synthio_note_get_loop_start_obj,
+    (mp_obj_t)&synthio_note_set_loop_start_obj);
+
+//|     loop_end: int
+//|     """The index of where to end looping waveform data. Must be greater than 0 or ``loop_start`` and less than the total size of the waveform data."""
+//|
+STATIC mp_obj_t synthio_note_get_loop_end(mp_obj_t self_in) {
+    synthio_note_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_int(common_hal_synthio_note_get_loop_end(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(synthio_note_get_loop_end_obj, synthio_note_get_loop_end);
+
+STATIC mp_obj_t synthio_note_set_loop_end(mp_obj_t self_in, mp_obj_t arg) {
+    synthio_note_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_synthio_note_set_loop_end(self, mp_obj_get_int(arg));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(synthio_note_set_loop_end_obj, synthio_note_set_loop_end);
+MP_PROPERTY_GETSET(synthio_note_loop_end_obj,
+    (mp_obj_t)&synthio_note_get_loop_end_obj,
+    (mp_obj_t)&synthio_note_set_loop_end_obj);
+
 
 
 static void note_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
@@ -314,6 +355,8 @@ STATIC const mp_rom_map_elem_t synthio_note_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ring_frequency), MP_ROM_PTR(&synthio_note_ring_frequency_obj) },
     { MP_ROM_QSTR(MP_QSTR_ring_bend), MP_ROM_PTR(&synthio_note_ring_bend_obj) },
     { MP_ROM_QSTR(MP_QSTR_ring_waveform), MP_ROM_PTR(&synthio_note_ring_waveform_obj) },
+    { MP_ROM_QSTR(MP_QSTR_loop_start), MP_ROM_PTR(&synthio_note_loop_start_obj) },
+    { MP_ROM_QSTR(MP_QSTR_loop_end), MP_ROM_PTR(&synthio_note_loop_end_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(synthio_note_locals_dict, synthio_note_locals_dict_table);
 

--- a/shared-bindings/synthio/Note.h
+++ b/shared-bindings/synthio/Note.h
@@ -35,3 +35,9 @@ void common_hal_synthio_note_set_ring_waveform(synthio_note_obj_t *self, mp_obj_
 
 mp_obj_t common_hal_synthio_note_get_envelope_obj(synthio_note_obj_t *self);
 void common_hal_synthio_note_set_envelope(synthio_note_obj_t *self, mp_obj_t value);
+
+mp_int_t common_hal_synthio_note_get_loop_start(synthio_note_obj_t *self);
+void common_hal_synthio_note_set_loop_start(synthio_note_obj_t *self, mp_int_t value_in);
+
+mp_int_t common_hal_synthio_note_get_loop_end(synthio_note_obj_t *self);
+void common_hal_synthio_note_set_loop_end(synthio_note_obj_t *self, mp_int_t value_in);

--- a/shared-module/synthio/Note.c
+++ b/shared-module/synthio/Note.c
@@ -135,6 +135,24 @@ void common_hal_synthio_note_set_ring_waveform(synthio_note_obj_t *self, mp_obj_
     self->ring_waveform_obj = ring_waveform_in;
 }
 
+mp_int_t common_hal_synthio_note_get_loop_start(synthio_note_obj_t *self) {
+    return self->loop_start;
+}
+
+void common_hal_synthio_note_set_loop_start(synthio_note_obj_t *self, mp_int_t value_in) {
+    mp_int_t val = mp_arg_validate_int_range(value_in, 0, 32767, MP_QSTR_loop_start);
+    self->loop_start = val;
+}
+
+mp_int_t common_hal_synthio_note_get_loop_end(synthio_note_obj_t *self) {
+    return self->loop_end;
+}
+
+void common_hal_synthio_note_set_loop_end(synthio_note_obj_t *self, mp_int_t value_in) {
+    mp_int_t val = mp_arg_validate_int_range(value_in, 0, 32767, MP_QSTR_loop_end);
+    self->loop_end = val;
+}
+
 void synthio_note_recalculate(synthio_note_obj_t *self, int32_t sample_rate) {
     if (sample_rate == self->sample_rate) {
         return;

--- a/shared-module/synthio/Note.h
+++ b/shared-module/synthio/Note.h
@@ -50,6 +50,8 @@ typedef struct synthio_note_obj {
     mp_buffer_info_t waveform_buf;
     mp_buffer_info_t ring_waveform_buf;
     synthio_envelope_definition_t envelope_def;
+
+    uint32_t loop_start, loop_end;
 } synthio_note_obj_t;
 
 void synthio_note_recalculate(synthio_note_obj_t *self, int32_t sample_rate);


### PR DESCRIPTION
Lately, I have been experimenting with utilizing `synthio.Note` as a sampling engine. This is done by loading audio data into the `note.waveform` property and manipulating the `note.bend` in such a way that the frequency of the note object reflects the actual frequency of the audio sample data ([view code](https://github.com/dcooperdalrymple/pico_synth_sandbox/blob/de76342c0ae3f2eb7722026ebb9969ea69eef793/pico_synth_sandbox/voice/sample.py#L27)).

Currently, a limitation is that waveform data will always loop from 0 to buffer size - 1 (inclusive). By implementing simple `loop_start` and `loop_end` properties and some basic boolean logic, you can modify the looping start and end point of the waveform data when filling the audio buffer.

Additionally, when an envelope is triggered the accumulator will begin at 0 regardless of the loop settings and only start looping at `loop_start` once it's hit either `loop_end` or the end of waveform data.

### Relevant Links
- [Simple Demonstration Code](https://gist.github.com/dcooperdalrymple/628b0faf12039f665af24d6bd9b3e491)
- [Video Demonstration](https://youtu.be/1zWH17K5ShI) (includes sampling examples)

**NOTE:** _This is my first attempt at a contribution to `adafruit/circuitpython`. Feel free to correct any improper formatting or language in the provided code updates._
