### PR TITLE
Fix build error when frozen modules are updated

### DIFF
--- a/py/circuitpy_defns.mk
+++ b/py/circuitpy_defns.mk
@@ -877,4 +877,4 @@ invalid-board:
 # Print out the value of a make variable.
 # https://stackoverflow.com/questions/16467718/how-to-print-out-a-variable-in-makefile
 print-%:
-	@echo $* = $($*)
+	@echo "$* = "$($*)


### PR DESCRIPTION
When a frozen module was added or updated, a build error would occur during CI: `KeyError: 'FROZEN_MPY_DIRS'`.

In e40abda1bc I decided that it should be an error if all the expected keys were not defined in the board settings dict. I made this change and all seemed to be well; however, my testing did not exercise the case that a frozen module was changed.

It turns out that `FROZEN_MPY_DIRS` was not being set in the board settings dict because the output of print-`FROZEN_MPY_DIRS` was "`FROZEN_MPY_DIRS =`" (which does not match the regular expression) instead of "`FROZEN_MPY_DIRS = `" (with a trailing space).

This change fixes the problem by ensuring that an undefined or empty variable still prints with a space character after the equal character.

Tested by running locally:
```
tools/ci_set_matrix.py frozen/Adafruit_CircuitPython_asyncio
```
(prints a blank line, expected)

as well as simulating a change to the asyncio frozen submodule:
```
python3 -c 'import shared_bindings_matrix; print(shared_bindings_matrix.get_settings_from_makefile("ports/atmel-samd", "trinket_m0")["FROZEN_MPY_DIRS"])'
```
(which will build the elecfreaks_picoed board)