### PR TITLE
Fix translations so that %S et al are not offered for translation

### DIFF
--- a/locale/ID.po
+++ b/locale/ID.po
@@ -74,42 +74,12 @@ msgstr "output:\n"
 msgid "%%c requires int or char"
 msgstr "%%c harus int atau char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr ""
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr ""
 "%d pin alamat, %d rgb pin dan %d ubin menunjukkan ketinggian %d, bukan %d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr ""
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -292,11 +262,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
 msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
@@ -1616,8 +1581,9 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Hanya 8 atau 16 bit mono dengan "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -1817,8 +1783,8 @@ msgstr "Buffer awalan harus ada di heap"
 #: main.c
 msgid "Press any key to enter the REPL. Use CTRL-D to reload.\n"
 msgstr ""
-"Tekan sembarang tombol untuk masuk ke REPL. Tekan CTRL-D untuk memuat ulang."
-"\n"
+"Tekan sembarang tombol untuk masuk ke REPL. Tekan CTRL-D untuk memuat "
+"ulang.\n"
 
 #: main.c
 msgid "Pretending to deep sleep until alarm, CTRL-C or file write.\n"
@@ -4428,113 +4394,19 @@ msgstr "zi harus berjenis float"
 msgid "zi must be of shape (n_section, 2)"
 msgstr "Zi harus berbentuk (n_section, 2)"
 
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr "'await', 'async for' atau 'async with' di luar fungsi async"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' diluar loop"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' diluar loop"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Memisahkan dengan menggunakan sub-captures"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "atribut belum didukung"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr "argumen keyword belum diimplementasi - gunakan args normal"
-
-#, fuzzy
-#~ msgid "offset out of bounds"
-#~ msgstr "modul tidak ditemukan"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "ADC2 sedang digunakan oleh WiFi"
-
-#~ msgid "xTaskCreate failed"
-#~ msgstr "xTaskCreate gagal"
-
-#~ msgid "queue overflow"
-#~ msgstr "antrian meluap (overflow)"
-
-#~ msgid "Buffer is too small"
-#~ msgstr "Buffer terlalu kecil"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "File .mpy rusak"
+#~ msgid ""
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kode selesai berjalan. Menunggu memuat ulang.\n"
 
 #~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
+#~ "\n"
+#~ "Code stopped by auto-reload.\n"
 #~ msgstr ""
-#~ "File .mpy tidak kompatibel. Perbarui semua file .mpy. Lihat http://adafru."
-#~ "it/mpy-update untuk info lebih lanjut."
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "tidak bisa memiliki **x ganda"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "tidak bisa memiliki *x ganda"
-
-#~ msgid "invalid format"
-#~ msgstr "format tidak valid"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "keyword harus berupa string"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "non-keyword arg setelah */**"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "non-keyword arg setelah keyword arg"
-
-#~ msgid "Too many display busses"
-#~ msgstr "Terlalu banyak tampilan bus"
-
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Perangkat keras sibuk, coba pin alternatif"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "Tidak menemukan Pin MISO atau MOSI"
-
-#~ msgid "No MISO Pin"
-#~ msgstr "Tidak ada Pin MISO"
-
-#~ msgid "No MOSI Pin"
-#~ msgstr "Tidak ada Pin MOSI"
-
-#~ msgid "No RX pin"
-#~ msgstr "Tidak pin RX"
-
-#~ msgid "No TX pin"
-#~ msgstr "Tidak ada pin TX"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "Kecerahan harus di antara 0-1.0"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "Nilai x maksimum ketika dicerminkan adalah %d"
-
-#~ msgid "x value out of bounds"
-#~ msgstr "nilai x di luar batas"
-
-#~ msgid "y value out of bounds"
-#~ msgstr "Nilai y di luar batas"
-
-#~ msgid "No key was specified"
-#~ msgstr "Tidak ada kunci yang ditentukan"
-
-#~ msgid "Scan already in progess. Stop with stop_scan."
-#~ msgstr "Pindai sudah dalam proses. Hentikan dengan stop_scan."
-
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "Berikan setidaknya satu pin UART"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "pin %q tidak valid"
+#~ "\n"
+#~ "Kode berhenti oleh auto-reload.\n"
 
 #~ msgid ""
 #~ "\n"
@@ -4545,48 +4417,24 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ "Harap ajukan masalah dengan konten drive CIRCUITPY Anda di\n"
 #~ "https://github.com/adafruit/circuitpython/issues\n"
 
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "Gagal ke HardFault_Handler."
+#~ msgid ""
+#~ "\n"
+#~ "To exit, please reset the board without "
+#~ msgstr ""
+#~ "\n"
+#~ "Untuk keluar, harap setel ulang papan tanpa"
 
-#~ msgid "Invalid memory access."
-#~ msgstr "Akses memori tidak valid."
+#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+#~ msgstr "pin alamat %d dan pin rgb %d menunjukkan tinggi %d, bukan %d"
 
-#~ msgid "%q must be of type %q"
-#~ msgstr "%q harus bertipe %q"
-
-#~ msgid "Expected a %q"
-#~ msgstr "Diharapkan %q"
-
-#, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "Panjang IV harus %d byte"
-
-#~ msgid "Read-only object"
-#~ msgstr "Objek Read-only"
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "%q indeks harus bilangan bulat, bukan %q"
 
 #~ msgid "%q length must be >= 1"
 #~ msgstr "%q panjang harus >= 1"
 
-#~ msgid "%q must be a string"
-#~ msgstr "%q harus berupa string"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "Paling banyak %d %q dapat ditentukan (bukan %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Pin-pin tidak valid"
-
-#~ msgid "zero step"
-#~ msgstr "nol langkah"
-
-#~ msgid "To exit, please reset the board without "
-#~ msgstr "Untuk keluar, silahkan reset board tanpa "
-
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "Anda mengajukan untuk memulai mode aman pada (safe mode) pada "
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "Aliran tidak menemukan metode readinto() atau write()."
+#~ msgid "%q list must be a list"
+#~ msgstr "daftar %q harus berupa daftar"
 
 #~ msgid "%q must be >= 0"
 #~ msgstr "%q harus >= 0"
@@ -4594,11 +4442,8 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "%q must be >= 1"
 #~ msgstr "%q harus >= 1"
 
-#~ msgid "address out of bounds"
-#~ msgstr "alamat di luar batas"
-
-#~ msgid "y should be an int"
-#~ msgstr "y harus menjadi int"
+#~ msgid "%q must be a string"
+#~ msgstr "%q harus berupa string"
 
 #~ msgid "%q must be a tuple of length 2"
 #~ msgstr "%q harus berupa tuple dengan panjang 2"
@@ -4606,355 +4451,14 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "%q must be between %d and %d"
 #~ msgstr "%q harus antara %d dan %d"
 
+#~ msgid "%q must be of type %q"
+#~ msgstr "%q harus bertipe %q"
+
+#~ msgid "%q pin invalid"
+#~ msgstr "pin %q tidak valid"
+
 #~ msgid "%q should be an int"
 #~ msgstr "%q harus berupa int"
-
-#~ msgid "Address type out of range"
-#~ msgstr "Jenis alamat di luar batas"
-
-#~ msgid "AnalogIn not supported on given pin"
-#~ msgstr "AnalogIn tidak didukung pada pin yang diberikan"
-
-#~ msgid "AnalogOut functionality not supported"
-#~ msgstr "fungsionalitas AnalogOut tidak didukung"
-
-#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-#~ msgstr "AnalogOut hanya 16 bit. Nilai harus kurang dari 65536."
-
-#~ msgid "AnalogOut not supported on given pin"
-#~ msgstr "pin yang dipakai tidak mendukung AnalogOut"
-
-#, c-format
-#~ msgid "Buffer incorrect size. Should be %d bytes."
-#~ msgstr "Ukuran buffer salah. Seharusnya %d byte."
-
-#~ msgid "Buffer must be at least length 1"
-#~ msgstr "Penyangga harus memiliki panjang setidaknya 1"
-
-#~ msgid "Bytes must be between 0 and 255."
-#~ msgstr "Bytes harus di antara 0 dan 255."
-
-#~ msgid "Cannot output both channels on the same pin"
-#~ msgstr ""
-#~ "Tidak dapat menggunakan output di kedua channel dengan menggunakan pin "
-#~ "yang sama"
-
-#~ msgid "Cannot read without MISO pin."
-#~ msgstr "Tidak dapat membaca tanpa pin MISO."
-
-#~ msgid "Cannot reset into bootloader because no bootloader is present."
-#~ msgstr ""
-#~ "Tidak dapat melakukan reset ke bootloader karena tidak ada bootloader "
-#~ "yang terisi"
-
-#~ msgid "Cannot transfer without MOSI and MISO pins."
-#~ msgstr "Tidak dapat transfer tanpa pin MOSI dan MISO."
-
-#~ msgid "Cannot write without MOSI pin."
-#~ msgstr "Tidak dapat menulis tanpa pin MOSI."
-
-#~ msgid "Clock pin init failed."
-#~ msgstr "Init pin clock gagal."
-
-#~ msgid "Command must be an int between 0 and 255"
-#~ msgstr "Perintah harus berupa int di antara 0 dan 255"
-
-#~ msgid "Could not initialize UART"
-#~ msgstr "Tidak dapat menginisialisasi UART"
-
-#~ msgid "Could not re-init channel"
-#~ msgstr "Tidak dapat menginisialisasi ulang kanal"
-
-#~ msgid "Could not re-init timer"
-#~ msgstr "Tidak dapat menginisialisasi ulang timer"
-
-#~ msgid "Could not restart PWM"
-#~ msgstr "Tidak dapat memulai ulang PWM"
-
-#~ msgid "Couldn't allocate first buffer"
-#~ msgstr "Tidak dapat mengalokasikan penyangga pertama"
-
-#~ msgid "Couldn't allocate input buffer"
-#~ msgstr "Tidak dapat mengalokasikan penyangga masukan"
-
-#~ msgid "Couldn't allocate second buffer"
-#~ msgstr "Tidak dapat mengalokasikan penyangga kedua"
-
-#~ msgid "DigitalInOut not supported on given pin"
-#~ msgstr "DigitalInOut tidak didukung pada pin yang diberikan"
-
-#, c-format
-#~ msgid "Expected tuple of length %d, got %d"
-#~ msgstr "Diharapkan tuple dengan panjang %d, didapatkan %d"
-
-#~ msgid "Failed to allocate RX buffer"
-#~ msgstr "Gagal untuk mengalokasikan buffer RX"
-
-#, c-format
-#~ msgid "Failed to allocate RX buffer of %d bytes"
-#~ msgstr "Gagal untuk megalokasikan buffer RX dari %d byte"
-
-#~ msgid "I2C Init Error"
-#~ msgstr "Gagal Inisialisasi I2C"
-
-#~ msgid "Invalid BMP file"
-#~ msgstr "File BMP tidak valid"
-
-#~ msgid "Invalid DAC pin supplied"
-#~ msgstr "Pin DAC yang diberikan tidak valid"
-
-#~ msgid "Invalid PWM frequency"
-#~ msgstr "Frekuensi PWM tidak valid"
-
-#~ msgid "Invalid buffer size"
-#~ msgstr "Ukuran buffer tidak valid"
-
-#~ msgid "Invalid byteorder string"
-#~ msgstr "String byteorder tidak valid"
-
-#~ msgid "Invalid capture period. Valid range: 1 - 500"
-#~ msgstr "Periode penangkapan tidak valid. Kisaran yang valid: 1 - 500"
-
-#~ msgid "Invalid channel count"
-#~ msgstr "Jumlah kanal tidak valid"
-
-#~ msgid "Invalid direction."
-#~ msgstr "Arah tidak valid."
-
-#~ msgid "Invalid file"
-#~ msgstr "File tidak valid"
-
-#~ msgid "Invalid number of bits"
-#~ msgstr "Jumlah bit tidak valid"
-
-#~ msgid "Invalid phase"
-#~ msgstr "Fase tidak valid"
-
-#~ msgid "Invalid pin"
-#~ msgstr "Pin tidak valid"
-
-#~ msgid "Invalid pin for left channel"
-#~ msgstr "Pin untuk channel kiri tidak valid"
-
-#~ msgid "Invalid pin for right channel"
-#~ msgstr "Pin untuk channel kanan tidak valid"
-
-#~ msgid "Invalid polarity"
-#~ msgstr "Polaritas tidak valid"
-
-#~ msgid "Invalid properties"
-#~ msgstr "Properti tidak valid"
-
-#~ msgid "Invalid run mode."
-#~ msgstr "Mode operasi tidak valid."
-
-#~ msgid "Invalid security_mode"
-#~ msgstr "security_mode tidak valid"
-
-#~ msgid "Invalid voice"
-#~ msgstr "Suara tidak valid"
-
-#~ msgid "Invalid voice count"
-#~ msgstr "Hitungan suara tidak valid"
-
-#~ msgid "Invalid wave file"
-#~ msgstr "File wave tidak valid"
-
-#~ msgid "Invalid word/bit length"
-#~ msgstr "Panjang kata/bit tidak valid"
-
-#~ msgid "Layer already in a group."
-#~ msgstr "Layer sudah ada dalam grup."
-
-#~ msgid "Layer must be a Group or TileGrid subclass."
-#~ msgstr "Layer harus sebuah Grup atau subklas dari TileGrid."
-
-#~ msgid "MISO pin init failed."
-#~ msgstr "Pin MISO gagal inisialisasi."
-
-#~ msgid "MOSI pin init failed."
-#~ msgstr "Pin MOSI gagal inisialisasi."
-
-#~ msgid "No hardware support on clk pin"
-#~ msgstr "Tidak ada dukungan perangkat keras pada pin clk"
-
-#~ msgid "No hardware support on pin"
-#~ msgstr "Tidak ada dukungan hardware untuk pin"
-
-#~ msgid ""
-#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-#~ msgstr "PWM duty_cycle harus antara 0 dan 65535 inklusif (resolusi 16 bit)"
-
-#~ msgid "Pin does not have ADC capabilities"
-#~ msgstr "Pin tidak mempunya kemampuan untuk ADC (Analog Digital Converter)"
-
-#~ msgid "RTC calibration is not supported on this board"
-#~ msgstr "Kalibrasi RTC tidak didukung pada board ini"
-
-#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
-#~ msgstr "RTS/CTS/RS485 Belum didukung pada perangkat ini"
-
-#~ msgid "SPI Init Error"
-#~ msgstr "Kesalahan Init SPI"
-
-#~ msgid "SPI Re-initialization error"
-#~ msgstr "Kesalahan Inisialisasi ulang SPI"
-
-#~ msgid "Sample rate must be positive"
-#~ msgstr "Tingkat sampel harus positif"
-
-#, c-format
-#~ msgid "Sample rate too high. It must be less than %d"
-#~ msgstr "Nilai sampel terlalu tinggi. Nilai harus kurang dari %d"
-
-#~ msgid "Stack size must be at least 256"
-#~ msgstr "Ukuran stack minimal harus 256"
-
-#~ msgid "Tile value out of bounds"
-#~ msgstr "Nilai ubin di luar batas"
-
-#~ msgid "UART Buffer allocation error"
-#~ msgstr "Kesalahan alokasi Buffer UART"
-
-#~ msgid "UART De-init error"
-#~ msgstr "Kesalahan UART De-init"
-
-#~ msgid "UART Init Error"
-#~ msgstr "Kesalahan Init UART"
-
-#~ msgid "UART Re-init error"
-#~ msgstr "Kesalahan Re-init UART"
-
-#~ msgid "UART write error"
-#~ msgstr "Kesalahan penulisan UART"
-
-#~ msgid "Unsupported baudrate"
-#~ msgstr "Baudrate tidak didukung"
-
-#~ msgid "bytes > 8 bits not supported"
-#~ msgstr "byte > 8 bit tidak didukung"
-
-#~ msgid "calibration value out of range +/-127"
-#~ msgstr "nilai kalibrasi keluar dari jangkauan +/-127"
-
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "waktu habis harus >= 0,0"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "Operasi yang tidak didukung"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code stopped by auto-reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Kode berhenti oleh auto-reload.\n"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "Brightness harus di antara 0 dan 255"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "tidak dapat melakukan relative import"
-
-#~ msgid "Unsupported pull value."
-#~ msgstr "Nilai tarikan yang tidak didukung."
-
-#, c-format
-#~ msgid ""
-#~ "Welcome to Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Please visit learn.adafruit.com/category/circuitpython for project "
-#~ "guides.\n"
-#~ "\n"
-#~ "To list built-in modules please do `help(\"modules\")`.\n"
-#~ msgstr ""
-#~ "Selamat datang ke Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Silahkan kunjungi learn.adafruit.com/category/circuitpython untuk panduan "
-#~ "project.\n"
-#~ "\n"
-#~ "Untuk menampilkan modul built-in silahkan ketik `help(\"modules\")`.\n"
-
-#~ msgid "abort() called"
-#~ msgstr "abort() dipanggil"
-
-#~ msgid "invalid arguments"
-#~ msgstr "argumen-argumen tidak valid"
-
-#~ msgid "%q list must be a list"
-#~ msgstr "daftar %q harus berupa daftar"
-
-#~ msgid "Column entry must be digitalio.DigitalInOut"
-#~ msgstr "Entri kolom harus digitalio.DigitalInOut"
-
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Diharapkan sebuah Karakteristik"
-
-#~ msgid "Expected a Service"
-#~ msgstr "Diharapkan sebuah Layanan"
-
-#~ msgid "Expected a UUID"
-#~ msgstr "Diharapkan sebuah UUID"
-
-#~ msgid "Expected an Address"
-#~ msgstr "Diharapkan sebuah Alamat"
-
-#~ msgid "Row entry must be digitalio.DigitalInOut"
-#~ msgstr "Entri baris harus digitalio.DigitalInOut"
-
-#~ msgid "ParallelBus not yet supported"
-#~ msgstr "ParallelBus belum didukung"
-
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "Buffer terlalu besar dan tidak dapat dialokasikan"
-
-#~ msgid ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
-#~ msgstr ""
-#~ "CircuitPython dalam mode aman karena Anda menekan tombol reset saat boot. "
-#~ "Tekan lagi untuk keluar dari mode aman.\n"
-
-#~ msgid "Not running saved code.\n"
-#~ msgstr "Tidak menjalankan kode yang disimpan.\n"
-
-#~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Please increase the stack size if you know how, or if not:"
-#~ msgstr ""
-#~ "heap dari CircuitPython rusak karena stack terlalu kecil.\n"
-#~ "Harap tambah ukuran stack jika Anda tahu caranya, atau jika tidak:"
-
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode.\n"
-#~ msgstr ""
-#~ "Modul `microcontroller` digunakan untukboot ke mode aman. Tekan reset "
-#~ "untuk keluar dari mode aman.\n"
-
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY).\n"
-#~ msgstr ""
-#~ "Kekuatan mikrokontroler menurun. Pastikan catu daya Anda menyediakan\n"
-#~ "daya yang cukup untuk seluruh rangkaian dan tekan reset (setelah "
-#~ "mengeluarkan CIRCUITPY).\n"
-
-#~ msgid "You are in safe mode: something unanticipated happened.\n"
-#~ msgstr "Anda berada dalam mode aman: sesuatu yang tidak terduga terjadi.\n"
-
-#~ msgid "Pin number already reserved by EXTI"
-#~ msgstr "Nomor pin sudah dipesan oleh EXTI"
-
-#~ msgid "USB Busy"
-#~ msgstr "USB Sibuk"
-
-#~ msgid "USB Error"
-#~ msgstr "Kesalahan USB"
-
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "%q indeks harus bilangan bulat, bukan %q"
 
 #~ msgid "'%q' object does not support item assignment"
 #~ msgstr "Objek '%q' tidak mendukung penugasan item"
@@ -4970,114 +4474,6 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 
 #~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
 #~ msgstr "'%s' integer 0x%x tidak cukup didalam mask 0x%x"
-
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "tidak dapat mendapatkan ukuran scalar secara tidak ambigu"
-
-#~ msgid "Length must be an int"
-#~ msgstr "Panjang harus berupa int"
-
-#~ msgid "Length must be non-negative"
-#~ msgstr "Panjangnya harus non-negatif"
-
-#~ msgid "name reused for argument"
-#~ msgstr "nama digunakan kembali untuk argumen"
-
-#~ msgid "struct: cannot index"
-#~ msgstr "struct: tidak bisa melakukan index"
-
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "Tidak dapat memasang kembali '/' ketika USB aktif."
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "indeks dupterm tidak valid"
-
-#~ msgid "Corrupt raw code"
-#~ msgstr "Kode raw rusak"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr "Fungsi Viper saat ini tidak mendukung lebih dari 4 argumen"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "alamat %08x tidak selaras dengan %d bytes"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "fungsi tidak dapat mengambil argumen keyword"
-
-#~ msgid "parameter annotation must be an identifier"
-#~ msgstr "anotasi parameter haruse sebuah identifier"
-
-#~ msgid "Total data to write is larger than outgoing_packet_length"
-#~ msgstr ""
-#~ "Total data yang akan ditulis lebih besar daripada outgoing_packet_length"
-
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr "Mencoba alokasi heap ketika MicroPython VM tidak berjalan."
-
-#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
-#~ msgstr "Lompatan NLR MicroPython gagal. Kemungkinan kerusakan memori."
-
-#~ msgid "MicroPython fatal error."
-#~ msgstr "Kesalahan fatal MicroPython."
-
-#~ msgid "Nordic Soft Device failure assertion."
-#~ msgstr "Pernyataan kegagalan Perangkat Lunak Nordic."
-
-#~ msgid "Unknown soft device error: %04x"
-#~ msgstr "Kesalahan perangkat lunak tidak dikenal: %04x"
-
-#~ msgid "Selected CTS pin not valid"
-#~ msgstr "Pin CTS yang dipilih tidak valid"
-
-#~ msgid "Selected RTS pin not valid"
-#~ msgstr "Pin RTS yang dipilih tidak valid"
-
-#~ msgid "Could not initialize channel"
-#~ msgstr "Tidak dapat menginisialisasi kanal"
-
-#~ msgid "Could not initialize timer"
-#~ msgstr "Tidak dapat menginisialisasi timer"
-
-#~ msgid "Invalid frequency supplied"
-#~ msgstr "Frekuensi yang diberikan tidak valid"
-
-#~ msgid "Invalid pins for PWMOut"
-#~ msgstr "Pin untuk PWMOut tidak valid"
-
-#~ msgid "No more timers available on this pin."
-#~ msgstr "Tidak ada lagi penghitung waktu yang tersedia pada pin ini."
-
-#~ msgid "Group full"
-#~ msgstr "Grup penuh"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "SDA atau SCL membutuhkan pull up"
-
-#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
-#~ msgstr "pin alamat %d dan pin rgb %d menunjukkan tinggi %d, bukan %d"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Kode selesai berjalan. Menunggu memuat ulang.\n"
-
-#~ msgid "Frequency captured is above capability. Capture Paused."
-#~ msgstr ""
-#~ "Frekuensi yang ditangkap berada di atas kemampuan. Penangkapan Ditunda."
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr ""
-#~ "Tekan tombol apa saja untuk masuk ke dalam REPL. Gunakan CTRL+D untuk "
-#~ "reset (Reload)"
-
-#~ msgid ""
-#~ "\n"
-#~ "To exit, please reset the board without "
-#~ msgstr ""
-#~ "\n"
-#~ "Untuk keluar, harap setel ulang papan tanpa"
 
 #~ msgid "'%s' object cannot assign attribute '%q'"
 #~ msgstr "Objek '%s' tidak dapat menetapkan atribut '%q'"
@@ -5103,23 +4499,66 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "'%s' object is not subscriptable"
 #~ msgstr "Objek '%s' tidak dapat disubkripsikan"
 
-#~ msgid "Invalid I2C pin selection"
-#~ msgstr "Pilihan pin I2C tidak valid"
-
-#~ msgid "Invalid SPI pin selection"
-#~ msgstr "Pilihan pin SPI tidak valid"
-
-#~ msgid "Invalid UART pin selection"
-#~ msgstr "Pilihan pin UART tidak valid"
-
-#~ msgid "Running in safe mode! Auto-reload is off.\n"
-#~ msgstr "Berjalan di mode aman(safe mode)! Auto-reload tidak aktif.\n"
-
 #~ msgid "'async for' or 'async with' outside async function"
 #~ msgstr "'async for' atau 'async with' di luar fungsi async"
 
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr "'await', 'async for' atau 'async with' di luar fungsi async"
+
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' diluar loop"
+
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' diluar loop"
+
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "ADC2 sedang digunakan oleh WiFi"
+
 #~ msgid "AP required"
 #~ msgstr "AP dibutuhkan"
+
+#~ msgid "Address type out of range"
+#~ msgstr "Jenis alamat di luar batas"
+
+#~ msgid "AnalogIn not supported on given pin"
+#~ msgstr "AnalogIn tidak didukung pada pin yang diberikan"
+
+#~ msgid "AnalogOut functionality not supported"
+#~ msgstr "fungsionalitas AnalogOut tidak didukung"
+
+#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#~ msgstr "AnalogOut hanya 16 bit. Nilai harus kurang dari 65536."
+
+#~ msgid "AnalogOut not supported on given pin"
+#~ msgstr "pin yang dipakai tidak mendukung AnalogOut"
+
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "Paling banyak %d %q dapat ditentukan (bukan %d)"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr "Mencoba alokasi heap ketika MicroPython VM tidak berjalan."
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "Kecerahan harus di antara 0-1.0"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "Brightness harus di antara 0 dan 255"
+
+#, c-format
+#~ msgid "Buffer incorrect size. Should be %d bytes."
+#~ msgstr "Ukuran buffer salah. Seharusnya %d byte."
+
+#~ msgid "Buffer is too small"
+#~ msgstr "Buffer terlalu kecil"
+
+#~ msgid "Buffer must be at least length 1"
+#~ msgstr "Penyangga harus memiliki panjang setidaknya 1"
+
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "Buffer terlalu besar dan tidak dapat dialokasikan"
+
+#~ msgid "Bytes must be between 0 and 255."
+#~ msgstr "Bytes harus di antara 0 dan 255."
 
 #~ msgid "C-level assert"
 #~ msgstr "Dukungan C-level"
@@ -5130,15 +4569,95 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "Cannot disconnect from AP"
 #~ msgstr "Tidak dapat memutuskna dari AP"
 
+#~ msgid "Cannot output both channels on the same pin"
+#~ msgstr ""
+#~ "Tidak dapat menggunakan output di kedua channel dengan menggunakan pin "
+#~ "yang sama"
+
+#~ msgid "Cannot read without MISO pin."
+#~ msgstr "Tidak dapat membaca tanpa pin MISO."
+
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "Tidak dapat memasang kembali '/' ketika USB aktif."
+
+#~ msgid "Cannot reset into bootloader because no bootloader is present."
+#~ msgstr ""
+#~ "Tidak dapat melakukan reset ke bootloader karena tidak ada bootloader "
+#~ "yang terisi"
+
 #~ msgid "Cannot set STA config"
 #~ msgstr "Tidak dapat mengatur konfigurasi STA"
+
+#~ msgid "Cannot transfer without MOSI and MISO pins."
+#~ msgstr "Tidak dapat transfer tanpa pin MOSI dan MISO."
+
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "tidak dapat mendapatkan ukuran scalar secara tidak ambigu"
 
 #~ msgid "Cannot update i/f status"
 #~ msgstr "Tidak dapat memperbarui status i/f"
 
+#~ msgid "Cannot write without MOSI pin."
+#~ msgstr "Tidak dapat menulis tanpa pin MOSI."
+
+#~ msgid ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+#~ msgstr ""
+#~ "CircuitPython dalam mode aman karena Anda menekan tombol reset saat boot. "
+#~ "Tekan lagi untuk keluar dari mode aman.\n"
+
+#~ msgid "Clock pin init failed."
+#~ msgstr "Init pin clock gagal."
+
+#~ msgid "Column entry must be digitalio.DigitalInOut"
+#~ msgstr "Entri kolom harus digitalio.DigitalInOut"
+
+#~ msgid "Command must be an int between 0 and 255"
+#~ msgstr "Perintah harus berupa int di antara 0 dan 255"
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "File .mpy rusak"
+
+#~ msgid "Corrupt raw code"
+#~ msgstr "Kode raw rusak"
+
+#~ msgid "Could not initialize UART"
+#~ msgstr "Tidak dapat menginisialisasi UART"
+
+#~ msgid "Could not initialize channel"
+#~ msgstr "Tidak dapat menginisialisasi kanal"
+
+#~ msgid "Could not initialize timer"
+#~ msgstr "Tidak dapat menginisialisasi timer"
+
+#~ msgid "Could not re-init channel"
+#~ msgstr "Tidak dapat menginisialisasi ulang kanal"
+
+#~ msgid "Could not re-init timer"
+#~ msgstr "Tidak dapat menginisialisasi ulang timer"
+
+#~ msgid "Could not restart PWM"
+#~ msgstr "Tidak dapat memulai ulang PWM"
+
+#~ msgid "Couldn't allocate first buffer"
+#~ msgstr "Tidak dapat mengalokasikan penyangga pertama"
+
+#~ msgid "Couldn't allocate input buffer"
+#~ msgstr "Tidak dapat mengalokasikan penyangga masukan"
+
+#~ msgid "Couldn't allocate second buffer"
+#~ msgstr "Tidak dapat mengalokasikan penyangga kedua"
+
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "Gagal ke HardFault_Handler."
+
 #, fuzzy
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Tidak bisa menyesuaikan data ke dalam paket advertisment"
+
+#~ msgid "DigitalInOut not supported on given pin"
+#~ msgstr "DigitalInOut tidak didukung pada pin yang diberikan"
 
 #~ msgid "Don't know how to pass object to native function"
 #~ msgstr "Tidak tahu cara meloloskan objek ke fungsi native"
@@ -5151,6 +4670,25 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 
 #~ msgid "Error in ffi_prep_cif"
 #~ msgstr "Errod pada ffi_prep_cif"
+
+#~ msgid "Expected a %q"
+#~ msgstr "Diharapkan %q"
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Diharapkan sebuah Karakteristik"
+
+#~ msgid "Expected a Service"
+#~ msgstr "Diharapkan sebuah Layanan"
+
+#~ msgid "Expected a UUID"
+#~ msgstr "Diharapkan sebuah UUID"
+
+#~ msgid "Expected an Address"
+#~ msgstr "Diharapkan sebuah Alamat"
+
+#, c-format
+#~ msgid "Expected tuple of length %d, got %d"
+#~ msgstr "Diharapkan tuple dengan panjang %d, didapatkan %d"
 
 #, fuzzy
 #~ msgid "Failed to acquire mutex"
@@ -5167,6 +4705,13 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #, fuzzy
 #~ msgid "Failed to add service, err 0x%04x"
 #~ msgstr "Gagal untuk menambahkan layanan, status: 0x%08lX"
+
+#~ msgid "Failed to allocate RX buffer"
+#~ msgstr "Gagal untuk mengalokasikan buffer RX"
+
+#, c-format
+#~ msgid "Failed to allocate RX buffer of %d bytes"
+#~ msgstr "Gagal untuk megalokasikan buffer RX dari %d byte"
 
 #, fuzzy
 #~ msgid "Failed to change softdevice state"
@@ -5256,14 +4801,68 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "Failed to write gatts value, err 0x%04x"
 #~ msgstr "Gagal untuk menulis nilai gatts, status: 0x%08lX"
 
+#~ msgid "Frequency captured is above capability. Capture Paused."
+#~ msgstr ""
+#~ "Frekuensi yang ditangkap berada di atas kemampuan. Penangkapan Ditunda."
+
 #~ msgid "GPIO16 does not support pull up."
 #~ msgstr "GPIO16 tidak mendukung pull up"
+
+#~ msgid "Group full"
+#~ msgstr "Grup penuh"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Perangkat keras sibuk, coba pin alternatif"
+
+#~ msgid "I2C Init Error"
+#~ msgstr "Gagal Inisialisasi I2C"
 
 #~ msgid "I2C operation not supported"
 #~ msgstr "operasi I2C tidak didukung"
 
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "Panjang IV harus %d byte"
+
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "File .mpy tidak kompatibel. Perbarui semua file .mpy. Lihat http://adafru."
+#~ "it/mpy-update untuk info lebih lanjut."
+
+#~ msgid "Invalid BMP file"
+#~ msgstr "File BMP tidak valid"
+
+#~ msgid "Invalid DAC pin supplied"
+#~ msgstr "Pin DAC yang diberikan tidak valid"
+
+#~ msgid "Invalid I2C pin selection"
+#~ msgstr "Pilihan pin I2C tidak valid"
+
+#~ msgid "Invalid PWM frequency"
+#~ msgstr "Frekuensi PWM tidak valid"
+
+#~ msgid "Invalid SPI pin selection"
+#~ msgstr "Pilihan pin SPI tidak valid"
+
+#~ msgid "Invalid UART pin selection"
+#~ msgstr "Pilihan pin UART tidak valid"
+
 #~ msgid "Invalid bit clock pin"
 #~ msgstr "Bit clock pada pin tidak valid"
+
+#~ msgid "Invalid buffer size"
+#~ msgstr "Ukuran buffer tidak valid"
+
+#~ msgid "Invalid byteorder string"
+#~ msgstr "String byteorder tidak valid"
+
+#~ msgid "Invalid capture period. Valid range: 1 - 500"
+#~ msgstr "Periode penangkapan tidak valid. Kisaran yang valid: 1 - 500"
+
+#~ msgid "Invalid channel count"
+#~ msgstr "Jumlah kanal tidak valid"
 
 #~ msgid "Invalid clock pin"
 #~ msgstr "Clock pada pin tidak valid"
@@ -5271,30 +4870,164 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "Invalid data pin"
 #~ msgstr "data pin tidak valid"
 
+#~ msgid "Invalid direction."
+#~ msgstr "Arah tidak valid."
+
+#~ msgid "Invalid file"
+#~ msgstr "File tidak valid"
+
+#~ msgid "Invalid frequency supplied"
+#~ msgstr "Frekuensi yang diberikan tidak valid"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "Akses memori tidak valid."
+
+#~ msgid "Invalid number of bits"
+#~ msgstr "Jumlah bit tidak valid"
+
+#~ msgid "Invalid phase"
+#~ msgstr "Fase tidak valid"
+
+#~ msgid "Invalid pin"
+#~ msgstr "Pin tidak valid"
+
+#~ msgid "Invalid pin for left channel"
+#~ msgstr "Pin untuk channel kiri tidak valid"
+
+#~ msgid "Invalid pin for right channel"
+#~ msgstr "Pin untuk channel kanan tidak valid"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Pin-pin tidak valid"
+
+#~ msgid "Invalid pins for PWMOut"
+#~ msgstr "Pin untuk PWMOut tidak valid"
+
+#~ msgid "Invalid polarity"
+#~ msgstr "Polaritas tidak valid"
+
+#~ msgid "Invalid properties"
+#~ msgstr "Properti tidak valid"
+
+#~ msgid "Invalid run mode."
+#~ msgstr "Mode operasi tidak valid."
+
+#~ msgid "Invalid security_mode"
+#~ msgstr "security_mode tidak valid"
+
+#~ msgid "Invalid voice"
+#~ msgstr "Suara tidak valid"
+
+#~ msgid "Invalid voice count"
+#~ msgstr "Hitungan suara tidak valid"
+
+#~ msgid "Invalid wave file"
+#~ msgstr "File wave tidak valid"
+
+#~ msgid "Invalid word/bit length"
+#~ msgstr "Panjang kata/bit tidak valid"
+
+#~ msgid "Layer already in a group."
+#~ msgstr "Layer sudah ada dalam grup."
+
+#~ msgid "Layer must be a Group or TileGrid subclass."
+#~ msgstr "Layer harus sebuah Grup atau subklas dari TileGrid."
+
+#~ msgid "Length must be an int"
+#~ msgstr "Panjang harus berupa int"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Panjangnya harus non-negatif"
+
+#~ msgid "MISO pin init failed."
+#~ msgstr "Pin MISO gagal inisialisasi."
+
+#~ msgid "MOSI pin init failed."
+#~ msgstr "Pin MOSI gagal inisialisasi."
+
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "Nilai maksimum frekuensi PWM adalah %dhz"
 
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "Nilai x maksimum ketika dicerminkan adalah %d"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgstr "Lompatan NLR MicroPython gagal. Kemungkinan kerusakan memori."
+
+#~ msgid "MicroPython fatal error."
+#~ msgstr "Kesalahan fatal MicroPython."
+
 #~ msgid "Minimum PWM frequency is 1hz."
 #~ msgstr "Nilai minimum frekuensi PWM is 1hz"
+
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "Tidak menemukan Pin MISO atau MOSI"
 
 #~ msgid "Multiple PWM frequencies not supported. PWM already set to %dhz."
 #~ msgstr ""
 #~ "Nilai Frekuensi PWM ganda tidak didukung. PWM sudah diatur pada %dhz"
 
+#~ msgid "No MISO Pin"
+#~ msgstr "Tidak ada Pin MISO"
+
+#~ msgid "No MOSI Pin"
+#~ msgstr "Tidak ada Pin MOSI"
+
 #~ msgid "No PulseIn support for %q"
 #~ msgstr "Tidak ada dukungan PulseIn untuk %q"
+
+#~ msgid "No RX pin"
+#~ msgstr "Tidak pin RX"
+
+#~ msgid "No TX pin"
+#~ msgstr "Tidak ada pin TX"
 
 #~ msgid "No hardware support for analog out."
 #~ msgstr "Tidak dukungan hardware untuk analog out."
 
+#~ msgid "No hardware support on clk pin"
+#~ msgstr "Tidak ada dukungan perangkat keras pada pin clk"
+
+#~ msgid "No hardware support on pin"
+#~ msgstr "Tidak ada dukungan hardware untuk pin"
+
+#~ msgid "No key was specified"
+#~ msgstr "Tidak ada kunci yang ditentukan"
+
+#~ msgid "No more timers available on this pin."
+#~ msgstr "Tidak ada lagi penghitung waktu yang tersedia pada pin ini."
+
+#~ msgid "Nordic Soft Device failure assertion."
+#~ msgstr "Pernyataan kegagalan Perangkat Lunak Nordic."
+
+#~ msgid "Not running saved code.\n"
+#~ msgstr "Tidak menjalankan kode yang disimpan.\n"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Hanya 8 atau 16 bit mono dengan "
+
 #~ msgid "Only tx supported on UART1 (GPIO2)."
 #~ msgstr "Hanya tx yang mendukung pada UART1 (GPIO2)."
+
+#~ msgid ""
+#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
+#~ msgstr "PWM duty_cycle harus antara 0 dan 65535 inklusif (resolusi 16 bit)"
 
 #~ msgid "PWM not supported on pin %d"
 #~ msgstr "PWM tidak didukung pada pin %d"
 
+#~ msgid "ParallelBus not yet supported"
+#~ msgstr "ParallelBus belum didukung"
+
 #~ msgid "Pin %q does not have ADC capabilities"
 #~ msgstr "Pin %q tidak memiliki kemampuan ADC"
+
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "Pin tidak mempunya kemampuan untuk ADC (Analog Digital Converter)"
+
+#~ msgid "Pin number already reserved by EXTI"
+#~ msgstr "Nomor pin sudah dipesan oleh EXTI"
 
 #~ msgid "Pin(16) doesn't support pull"
 #~ msgstr "Pin(16) tidak mendukung pull"
@@ -5302,15 +5035,95 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "Pins not valid for SPI"
 #~ msgstr "Pin-pin tidak valid untuk SPI"
 
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+#~ msgstr ""
+#~ "Tekan tombol apa saja untuk masuk ke dalam REPL. Gunakan CTRL+D untuk "
+#~ "reset (Reload)"
+
+#~ msgid "RTC calibration is not supported on this board"
+#~ msgstr "Kalibrasi RTC tidak didukung pada board ini"
+
+#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
+#~ msgstr "RTS/CTS/RS485 Belum didukung pada perangkat ini"
+
+#~ msgid "Read-only object"
+#~ msgstr "Objek Read-only"
+
+#~ msgid "Row entry must be digitalio.DigitalInOut"
+#~ msgstr "Entri baris harus digitalio.DigitalInOut"
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Berjalan di mode aman(safe mode)! Auto-reload tidak aktif.\n"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "SDA atau SCL membutuhkan pull up"
+
+#~ msgid "SPI Init Error"
+#~ msgstr "Kesalahan Init SPI"
+
+#~ msgid "SPI Re-initialization error"
+#~ msgstr "Kesalahan Inisialisasi ulang SPI"
+
 #~ msgid "STA must be active"
 #~ msgstr "STA harus aktif"
 
 #~ msgid "STA required"
 #~ msgstr "STA dibutuhkan"
 
+#~ msgid "Sample rate must be positive"
+#~ msgstr "Tingkat sampel harus positif"
+
+#, c-format
+#~ msgid "Sample rate too high. It must be less than %d"
+#~ msgstr "Nilai sampel terlalu tinggi. Nilai harus kurang dari %d"
+
+#~ msgid "Scan already in progess. Stop with stop_scan."
+#~ msgstr "Pindai sudah dalam proses. Hentikan dengan stop_scan."
+
+#~ msgid "Selected CTS pin not valid"
+#~ msgstr "Pin CTS yang dipilih tidak valid"
+
+#~ msgid "Selected RTS pin not valid"
+#~ msgstr "Pin RTS yang dipilih tidak valid"
+
 #, fuzzy
 #~ msgid "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 #~ msgstr "Dukungan soft device, id: 0x%08lX, pc: 0x%08l"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Memisahkan dengan menggunakan sub-captures"
+
+#~ msgid "Stack size must be at least 256"
+#~ msgstr "Ukuran stack minimal harus 256"
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "Aliran tidak menemukan metode readinto() atau write()."
+
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "Berikan setidaknya satu pin UART"
+
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase the stack size if you know how, or if not:"
+#~ msgstr ""
+#~ "heap dari CircuitPython rusak karena stack terlalu kecil.\n"
+#~ "Harap tambah ukuran stack jika Anda tahu caranya, atau jika tidak:"
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode.\n"
+#~ msgstr ""
+#~ "Modul `microcontroller` digunakan untukboot ke mode aman. Tekan reset "
+#~ "untuk keluar dari mode aman.\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "Kekuatan mikrokontroler menurun. Pastikan catu daya Anda menyediakan\n"
+#~ "daya yang cukup untuk seluruh rangkaian dan tekan reset (setelah "
+#~ "mengeluarkan CIRCUITPY).\n"
 
 #, fuzzy
 #~ msgid ""
@@ -5322,22 +5135,90 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ "Tegangan dari mikrokontroler turun atau mati. Pastikan sumber tegangan "
 #~ "memberikan daya\n"
 
+#~ msgid "Tile value out of bounds"
+#~ msgstr "Nilai ubin di luar batas"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Untuk keluar, silahkan reset board tanpa "
+
+#~ msgid "Too many display busses"
+#~ msgstr "Terlalu banyak tampilan bus"
+
+#~ msgid "Total data to write is larger than outgoing_packet_length"
+#~ msgstr ""
+#~ "Total data yang akan ditulis lebih besar daripada outgoing_packet_length"
+
+#~ msgid "UART Buffer allocation error"
+#~ msgstr "Kesalahan alokasi Buffer UART"
+
+#~ msgid "UART De-init error"
+#~ msgstr "Kesalahan UART De-init"
+
+#~ msgid "UART Init Error"
+#~ msgstr "Kesalahan Init UART"
+
+#~ msgid "UART Re-init error"
+#~ msgstr "Kesalahan Re-init UART"
+
+#~ msgid "UART write error"
+#~ msgstr "Kesalahan penulisan UART"
+
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) tidak ada"
 
 #~ msgid "UART(1) can't read"
 #~ msgstr "UART(1) tidak dapat dibaca"
 
+#~ msgid "USB Busy"
+#~ msgstr "USB Sibuk"
+
+#~ msgid "USB Error"
+#~ msgstr "Kesalahan USB"
+
 #~ msgid "Unable to remount filesystem"
 #~ msgstr "Tidak dapat memasang filesystem kembali"
 
+#~ msgid "Unknown soft device error: %04x"
+#~ msgstr "Kesalahan perangkat lunak tidak dikenal: %04x"
+
 #~ msgid "Unknown type"
 #~ msgstr "Tipe tidak diketahui"
+
+#~ msgid "Unsupported baudrate"
+#~ msgstr "Baudrate tidak didukung"
+
+#~ msgid "Unsupported operation"
+#~ msgstr "Operasi yang tidak didukung"
+
+#~ msgid "Unsupported pull value."
+#~ msgstr "Nilai tarikan yang tidak didukung."
 
 #~ msgid "Use esptool to erase flash and re-upload Python instead"
 #~ msgstr ""
 #~ "Gunakan esptool untuk menghapus flash dan upload ulang Python sebagai "
 #~ "gantinya"
+
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr "Fungsi Viper saat ini tidak mendukung lebih dari 4 argumen"
+
+#, c-format
+#~ msgid ""
+#~ "Welcome to Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Please visit learn.adafruit.com/category/circuitpython for project "
+#~ "guides.\n"
+#~ "\n"
+#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ msgstr ""
+#~ "Selamat datang ke Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Silahkan kunjungi learn.adafruit.com/category/circuitpython untuk panduan "
+#~ "project.\n"
+#~ "\n"
+#~ "Untuk menampilkan modul built-in silahkan ketik `help(\"modules\")`.\n"
+
+#~ msgid "You are in safe mode: something unanticipated happened.\n"
+#~ msgstr "Anda berada dalam mode aman: sesuatu yang tidak terduga terjadi.\n"
 
 #, fuzzy
 #~ msgid ""
@@ -5347,8 +5228,23 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ "Anda sedang menjalankan mode aman (safe mode) yang berarti sesuatu yang "
 #~ "sangat buruk telah terjadi.\n"
 
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "Anda mengajukan untuk memulai mode aman pada (safe mode) pada "
+
 #~ msgid "[addrinfo error %d]"
 #~ msgstr "[addrinfo error %d]"
+
+#~ msgid "abort() called"
+#~ msgstr "abort() dipanggil"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "alamat %08x tidak selaras dengan %d bytes"
+
+#~ msgid "address out of bounds"
+#~ msgstr "alamat di luar batas"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "atribut belum didukung"
 
 #~ msgid "bits must be 8"
 #~ msgstr "bits harus memilki nilai 8"
@@ -5359,6 +5255,12 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "buffers must be the same length"
 #~ msgstr "buffers harus mempunyai panjang yang sama"
 
+#~ msgid "bytes > 8 bits not supported"
+#~ msgstr "byte > 8 bit tidak didukung"
+
+#~ msgid "calibration value out of range +/-127"
+#~ msgstr "nilai kalibrasi keluar dari jangkauan +/-127"
+
 #~ msgid "can query only one param"
 #~ msgstr "hanya bisa melakukan query satu param"
 
@@ -5368,11 +5270,20 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "can't get STA config"
 #~ msgstr "tidak bisa mendapatkan konfigurasi STA"
 
+#~ msgid "can't have multiple **x"
+#~ msgstr "tidak bisa memiliki **x ganda"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "tidak bisa memiliki *x ganda"
+
 #~ msgid "can't set AP config"
 #~ msgstr "tidak bisa mendapatkan konfigurasi AP"
 
 #~ msgid "can't set STA config"
 #~ msgstr "tidak bisa mendapatkan konfigurasi STA"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "tidak dapat melakukan relative import"
 
 #~ msgid "either pos or kw args are allowed"
 #~ msgstr "hanya antar pos atau kw args yang diperbolehkan"
@@ -5392,6 +5303,9 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "frequency can only be either 80Mhz or 160MHz"
 #~ msgstr "frekuensi hanya bisa didefinisikan 80Mhz atau 160Mhz"
 
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "fungsi tidak dapat mengambil argumen keyword"
+
 #~ msgid "impossible baudrate"
 #~ msgstr "baudrate tidak memungkinkan"
 
@@ -5404,17 +5318,32 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "invalid alarm"
 #~ msgstr "alarm tidak valid"
 
+#~ msgid "invalid arguments"
+#~ msgstr "argumen-argumen tidak valid"
+
 #~ msgid "invalid buffer length"
 #~ msgstr "panjang buffer tidak valid"
 
 #~ msgid "invalid data bits"
 #~ msgstr "bit data tidak valid"
 
+#~ msgid "invalid dupterm index"
+#~ msgstr "indeks dupterm tidak valid"
+
+#~ msgid "invalid format"
+#~ msgstr "format tidak valid"
+
 #~ msgid "invalid pin"
 #~ msgstr "pin tidak valid"
 
 #~ msgid "invalid stop bits"
 #~ msgstr "stop bit tidak valid"
+
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr "argumen keyword belum diimplementasi - gunakan args normal"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "keyword harus berupa string"
 
 #~ msgid "len must be multiple of 4"
 #~ msgstr "len harus kelipatan dari 4"
@@ -5429,14 +5358,39 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 #~ msgid "name must be a string"
 #~ msgstr "keyword harus berupa string"
 
+#~ msgid "name reused for argument"
+#~ msgstr "nama digunakan kembali untuk argumen"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "non-keyword arg setelah */**"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "non-keyword arg setelah keyword arg"
+
 #~ msgid "not a valid ADC Channel: %d"
 #~ msgstr "tidak valid channel ADC: %d"
+
+#, fuzzy
+#~ msgid "offset out of bounds"
+#~ msgstr "modul tidak ditemukan"
+
+#~ msgid "parameter annotation must be an identifier"
+#~ msgstr "anotasi parameter haruse sebuah identifier"
 
 #~ msgid "pin does not have IRQ capabilities"
 #~ msgstr "pin tidak memiliki kemampuan IRQ"
 
+#~ msgid "queue overflow"
+#~ msgstr "antrian meluap (overflow)"
+
 #~ msgid "scan failed"
 #~ msgstr "scan gagal"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "struct: tidak bisa melakukan index"
+
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "waktu habis harus >= 0,0"
 
 #~ msgid "unknown config param"
 #~ msgstr "konfigurasi param tidak diketahui"
@@ -5446,3 +5400,18 @@ msgstr "Zi harus berbentuk (n_section, 2)"
 
 #~ msgid "wifi_set_ip_info() failed"
 #~ msgstr "wifi_set_ip_info() gagal"
+
+#~ msgid "x value out of bounds"
+#~ msgstr "nilai x di luar batas"
+
+#~ msgid "xTaskCreate failed"
+#~ msgstr "xTaskCreate gagal"
+
+#~ msgid "y should be an int"
+#~ msgstr "y harus menjadi int"
+
+#~ msgid "y value out of bounds"
+#~ msgstr "Nilai y di luar batas"
+
+#~ msgid "zero step"
+#~ msgstr "nol langkah"

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -72,11 +72,6 @@ msgstr ""
 msgid "%%c requires int or char"
 msgstr ""
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -83,41 +83,11 @@ msgstr " výstup:\n"
 msgid "%%c requires int or char"
 msgstr "%%c vyžaduje int nebo char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr "%d adresní pin, %d rgb pin a %d dlaždice indikuje výšku %d, ne %d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -301,11 +271,6 @@ msgstr "%q[%u] používá extra pin"
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
 msgstr "%q[%u] čeká na vstup mimo rozsah"
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
-msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
 #, c-format
@@ -829,7 +794,8 @@ msgstr "Není možné znovu připojit '/', pokud je viditelné pomocí USB."
 #: ports/cxd56/common-hal/microcontroller/__init__.c
 #: ports/mimxrt10xx/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present"
-msgstr "Reset do bootloaderu není možný, protože žádný bootloader není přítomen"
+msgstr ""
+"Reset do bootloaderu není možný, protože žádný bootloader není přítomen"
 
 #: ports/espressif/common-hal/socketpool/Socket.c
 msgid "Cannot set socket options"
@@ -1176,7 +1142,8 @@ msgstr "Alokace heapu při neběžícím VM."
 #: supervisor/shared/safe_mode.c
 msgid ""
 "Heap was corrupted because the stack was too small. Increase stack size."
-msgstr "Heap byl poškozen, protože je stack příliš malý. Navyš velikost stacku."
+msgstr ""
+"Heap byl poškozen, protože je stack příliš malý. Navyš velikost stacku."
 
 #: extmod/vfs_posix_file.c py/objstringio.c
 msgid "I/O operation on closed file"
@@ -1626,7 +1593,8 @@ msgstr "Ok"
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
 msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
@@ -4433,18 +4401,102 @@ msgstr ""
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
 
-#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
-#~ msgstr "Špatný CIRCUITPY_PYSTACK_SIZE\n"
-
-#~ msgid "Unable to allocate the heap."
-#~ msgstr "Nelze alokovat heap."
+#~ msgid ""
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Kód byl dokončen. Čekám na opětovné nahrání.\n"
 
 #~ msgid ""
-#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
+#~ "\n"
+#~ "Code stopped by auto-reload.\n"
 #~ msgstr ""
-#~ "espcamera.Camera vyžaduje reservovanou PSRAM. V dokumentaci nalezneš "
-#~ "instrukce."
+#~ "\n"
+#~ "Program byl zastaven automatickým načtením.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Prosím vytvořte tiket s obsahem vaší jednotky CIRCUITPY na adrese\n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "To exit, please reset the board without "
+#~ msgstr ""
+#~ "\n"
+#~ "Pro ukončení, prosím resetujte desku bez "
+
+#, c-format
+#~ msgid "%02X"
+#~ msgstr "%02X"
+
+#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+#~ msgstr "%d adresní piny a %d rgb piny označují výšku %d, nikoli %d"
+
+#~ msgid "%q"
+#~ msgstr "%q"
+
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "Indexy %q musí být celá čísla, ne %q"
+
+#~ msgid "%q length must be >= 1"
+#~ msgstr "%q délka musí být >= 1"
+
+#~ msgid "%q list must be a list"
+#~ msgstr "Seznam %q musí být seznam"
+
+#~ msgid "%q must be >= 0"
+#~ msgstr "%q musí být >= 0"
+
+#~ msgid "%q must be >= 1"
+#~ msgstr "%q musí být > = 1"
+
+#~ msgid "%q must be a string"
+#~ msgstr "%q musí být string"
+
+#~ msgid "%q must be a tuple of length 2"
+#~ msgstr "%q musí být n-tice délky 2"
+
+#~ msgid "%q must be an int"
+#~ msgstr "%q musí být int"
+
+#~ msgid "%q must be between %d and %d"
+#~ msgstr "%q musí být mezi %d a %d"
+
+#~ msgid "%q must be of type %q"
+#~ msgstr "%q musí být typu %q"
+
+#~ msgid "%q must be of type %q or None"
+#~ msgstr "%q musí být typu %q nebo None"
+
+#~ msgid "%q pin invalid"
+#~ msgstr "pin %q není platný"
+
+#~ msgid "%q should be an int"
+#~ msgstr "%q by měl být int"
+
+#~ msgid "%q with a report ID of 0 must be of length 1"
+#~ msgstr "%q s ID 0 musím být délky 1"
+
+#~ msgid "'%q' object cannot assign attribute '%q'"
+#~ msgstr "'%q' nemůže přiřadit atribut '%q'"
+
+#~ msgid "'%q' object does not support item assignment"
+#~ msgstr "Objekt '%q' nepodporuje přiřazení položek"
+
+#~ msgid "'%q' object does not support item deletion"
+#~ msgstr "Objekt '%q' nepodporuje mazání položek"
+
+#~ msgid "'%q' object has no attribute '%q'"
+#~ msgstr "Objekt '%q' nemá žádný atribut"
+
+#~ msgid "'%q' object is not subscriptable"
+#~ msgstr "Objekt '%q' nelze zapsat"
 
 #~ msgid "'await', 'async for' or 'async with' outside async function"
 #~ msgstr "'await', 'async for' nebo 'async' je volán mimo async"
@@ -4455,29 +4507,64 @@ msgstr ""
 #~ msgid "'continue' outside loop"
 #~ msgstr "'continue' je volán mimo cyklus"
 
-#~ msgid "invalid architecture"
-#~ msgstr "špatná architektura"
+#~ msgid "'coroutine' object is not an iterator"
+#~ msgstr "Objekt 'coroutine' není iterátor"
 
-#~ msgid "__init__() should return None, not '%q'"
-#~ msgstr "__init__() by měl vracet hodnotu None, nikoli '%q'"
-
-#~ msgid "cannot unambiguously get sizeof scalar"
-#~ msgstr "velikost scalar nelze jednoznačně určit"
-
-#~ msgid "Bit clock and word select must be sequential pins"
-#~ msgstr "Bitové hodiny a výběr slov musí být sekvenční piny"
+#~ msgid "64 bit types"
+#~ msgstr "64 bit typy"
 
 #~ msgid "ADC2 is being used by WiFi"
 #~ msgstr "WiFi používá ADC2"
 
-#~ msgid "'coroutine' object is not an iterator"
-#~ msgstr "Objekt 'coroutine' není iterátor"
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "Lze zadat maximálně %d %q (nikoli %d)"
+
+#~ msgid "Attempted heap allocation when VM not running."
+#~ msgstr "Pokus o alokaci haldy, když neběží VM."
+
+#~ msgid "Bit clock and word select must be sequential pins"
+#~ msgstr "Bitové hodiny a výběr slov musí být sekvenční piny"
+
+#~ msgid "Boot device must be first device (interface #0)."
+#~ msgstr "Bootovací zařízení musí být první (rozhraní #0)."
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "Jas musí být 0-1,0"
 
 #~ msgid "Buffer is too small"
 #~ msgstr "Vyrovnávací paměť je příliš malá"
 
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "CircuitPython nedokázal alokovat haldu."
+
 #~ msgid "Corrupt .mpy file"
 #~ msgstr "Poškozený soubor .mpy"
+
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "Pád do HardFault_Handler."
+
+#, c-format
+#~ msgid "Error in MIDI stream at position %d"
+#~ msgstr "Chyba v MIDI přenosu na pozici %d"
+
+#~ msgid "Expected a %q"
+#~ msgstr "Očekává se %q"
+
+#~ msgid "Failed to init wifi"
+#~ msgstr "Chyba inicializace WiFi"
+
+#~ msgid "Fatal error."
+#~ msgstr "Fatální chyba."
+
+#~ msgid "Firmware image is invalid"
+#~ msgstr "Obraz firmwaru je nevalidní"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Hardware je zaneprázdněn, zkuste alternativní piny"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IV musí být dlouhé %d bajtů"
 
 #~ msgid ""
 #~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
@@ -4486,8 +4573,18 @@ msgstr ""
 #~ "Nekompatibilní soubor .mpy. Aktualizujte prosím všechny soubory .mpy. "
 #~ "Další informace naleznete na adrese http://adafru.it/mpy-update."
 
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Hardware je zaneprázdněn, zkuste alternativní piny"
+#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
+#~ msgstr "Špatný CIRCUITPY_PYSTACK_SIZE\n"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "Neplatný přístup k paměti."
+
+#~ msgid "Invalid pins"
+#~ msgstr "Neplatné piny"
+
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "Maximální hodnota x při zrcadlení je %d"
 
 #~ msgid "Missing MISO or MOSI Pin"
 #~ msgstr "Chybí pin MISO nebo MOSI"
@@ -4513,150 +4610,28 @@ msgstr ""
 #~ msgid "No TX pin"
 #~ msgstr "Žádný TX pin"
 
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "Jas musí být 0-1,0"
-
-#, c-format
-#~ msgid "Error in MIDI stream at position %d"
-#~ msgstr "Chyba v MIDI přenosu na pozici %d"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "Maximální hodnota x při zrcadlení je %d"
-
-#~ msgid "64 bit types"
-#~ msgstr "64 bit typy"
-
 #~ msgid "No key was specified"
 #~ msgstr "Nebyl zadán klíč"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "pin %q není platný"
-
-#~ msgid ""
-#~ "\n"
-#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
-#~ "https://github.com/adafruit/circuitpython/issues\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Prosím vytvořte tiket s obsahem vaší jednotky CIRCUITPY na adrese\n"
-#~ "https://github.com/adafruit/circuitpython/issues\n"
-
-#~ msgid "Attempted heap allocation when VM not running."
-#~ msgstr "Pokus o alokaci haldy, když neběží VM."
-
-#~ msgid "Boot device must be first device (interface #0)."
-#~ msgstr "Bootovací zařízení musí být první (rozhraní #0)."
-
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "CircuitPython nedokázal alokovat haldu."
-
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "Pád do HardFault_Handler."
-
-#~ msgid "Fatal error."
-#~ msgstr "Fatální chyba."
-
-#~ msgid "Invalid memory access."
-#~ msgstr "Neplatný přístup k paměti."
-
-#~ msgid "%q must be of type %q"
-#~ msgstr "%q musí být typu %q"
-
-#~ msgid "%q must be of type %q or None"
-#~ msgstr "%q musí být typu %q nebo None"
-
-#~ msgid "Expected a %q"
-#~ msgstr "Očekává se %q"
-
-#, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IV musí být dlouhé %d bajtů"
-
-#~ msgid "%q length must be >= 1"
-#~ msgstr "%q délka musí být >= 1"
-
-#~ msgid "%q must be a string"
-#~ msgstr "%q musí být string"
-
-#~ msgid "%q must be an int"
-#~ msgstr "%q musí být int"
-
-#~ msgid "%q with a report ID of 0 must be of length 1"
-#~ msgstr "%q s ID 0 musím být délky 1"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "Lze zadat maximálně %d %q (nikoli %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Neplatné piny"
 
 #, c-format
 #~ msgid "No more than %d HID devices allowed"
 #~ msgstr "Ne více než %d HID zařízení je povoleno"
 
-#~ msgid "Firmware image is invalid"
-#~ msgstr "Obraz firmwaru je nevalidní"
+#~ msgid "Unable to allocate the heap."
+#~ msgstr "Nelze alokovat heap."
 
-#~ msgid "%q must be >= 0"
-#~ msgstr "%q musí být >= 0"
+#~ msgid "__init__() should return None, not '%q'"
+#~ msgstr "__init__() by měl vracet hodnotu None, nikoli '%q'"
 
-#~ msgid "%q must be >= 1"
-#~ msgstr "%q musí být > = 1"
-
-#~ msgid "Failed to init wifi"
-#~ msgstr "Chyba inicializace WiFi"
-
-#~ msgid "%q must be a tuple of length 2"
-#~ msgstr "%q musí být n-tice délky 2"
-
-#~ msgid "%q must be between %d and %d"
-#~ msgstr "%q musí být mezi %d a %d"
-
-#~ msgid "%q should be an int"
-#~ msgstr "%q by měl být int"
+#~ msgid "cannot unambiguously get sizeof scalar"
+#~ msgstr "velikost scalar nelze jednoznačně určit"
 
 #~ msgid ""
-#~ "\n"
-#~ "Code stopped by auto-reload.\n"
+#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
 #~ msgstr ""
-#~ "\n"
-#~ "Program byl zastaven automatickým načtením.\n"
+#~ "espcamera.Camera vyžaduje reservovanou PSRAM. V dokumentaci nalezneš "
+#~ "instrukce."
 
-#~ msgid "%q list must be a list"
-#~ msgstr "Seznam %q musí být seznam"
-
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "Indexy %q musí být celá čísla, ne %q"
-
-#~ msgid "'%q' object cannot assign attribute '%q'"
-#~ msgstr "'%q' nemůže přiřadit atribut '%q'"
-
-#~ msgid "'%q' object does not support item assignment"
-#~ msgstr "Objekt '%q' nepodporuje přiřazení položek"
-
-#~ msgid "'%q' object does not support item deletion"
-#~ msgstr "Objekt '%q' nepodporuje mazání položek"
-
-#~ msgid "'%q' object has no attribute '%q'"
-#~ msgstr "Objekt '%q' nemá žádný atribut"
-
-#~ msgid "'%q' object is not subscriptable"
-#~ msgstr "Objekt '%q' nelze zapsat"
-
-#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
-#~ msgstr "%d adresní piny a %d rgb piny označují výšku %d, nikoli %d"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Kód byl dokončen. Čekám na opětovné nahrání.\n"
-
-#~ msgid ""
-#~ "\n"
-#~ "To exit, please reset the board without "
-#~ msgstr ""
-#~ "\n"
-#~ "Pro ukončení, prosím resetujte desku bez "
+#~ msgid "invalid architecture"
+#~ msgstr "špatná architektura"

--- a/locale/de_DE.po
+++ b/locale/de_DE.po
@@ -79,16 +79,6 @@ msgstr " Ausgabe:\n"
 msgid "%%c requires int or char"
 msgstr "%%c erwartet Int oder Char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
@@ -96,26 +86,6 @@ msgid ""
 msgstr ""
 "%d Adress-Pins, %d RGB-Pins und %d Kacheln indizieren eine Höhe von %d, "
 "nicht %d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -300,11 +270,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
 msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
@@ -1639,8 +1604,9 @@ msgstr "Ok"
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Nur 8 oder 16 bit mono mit "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -1838,12 +1804,13 @@ msgstr "Präfix-Puffer muss sich auf dem Heap befinden"
 #: main.c
 msgid "Press any key to enter the REPL. Use CTRL-D to reload.\n"
 msgstr ""
-"Drücke eine beliebige Taste um REPL zu betreten. Drücke STRG-D zum neuladen."
-"\n"
+"Drücke eine beliebige Taste um REPL zu betreten. Drücke STRG-D zum "
+"neuladen.\n"
 
 #: main.c
 msgid "Pretending to deep sleep until alarm, CTRL-C or file write.\n"
-msgstr "Vortäuschen von Deep Sleep bis Alarm, Strg-C oder Schreiben in Datei.\n"
+msgstr ""
+"Vortäuschen von Deep Sleep bis Alarm, Strg-C oder Schreiben in Datei.\n"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "Program does IN without loading ISR"
@@ -2056,7 +2023,8 @@ msgstr "Die Länge von rgb_pins muss 6, 12, 18, 24 oder 30 betragen"
 
 #: shared-module/audiomixer/MixerVoice.c
 msgid "The sample's bits_per_sample does not match the mixer's"
-msgstr "Das bits_per_sample des Samples stimmt nicht mit dem des Mixers überein"
+msgstr ""
+"Das bits_per_sample des Samples stimmt nicht mit dem des Mixers überein"
 
 #: shared-module/audiomixer/MixerVoice.c
 msgid "The sample's channel count does not match the mixer's"
@@ -2106,7 +2074,8 @@ msgstr "Zeit liegt in der Vergangenheit."
 #: ports/nrf/common-hal/_bleio/Adapter.c
 #, c-format
 msgid "Timeout is too long: Maximum timeout length is %d seconds"
-msgstr "Zeitbeschränkung ist zu groß: Maximale Zeitbeschränkung ist %d Sekunden"
+msgstr ""
+"Zeitbeschränkung ist zu groß: Maximale Zeitbeschränkung ist %d Sekunden"
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample"
@@ -2903,11 +2872,13 @@ msgstr "Farbpuffer muss 3 Bytes (RGB) oder 4 Bytes (RGB + pad byte) sein"
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a buffer, tuple, list, or int"
-msgstr "Der Farbpuffer muss ein Puffer, ein Tupel, eine Liste oder ein Int sein"
+msgstr ""
+"Der Farbpuffer muss ein Puffer, ein Tupel, eine Liste oder ein Int sein"
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a bytearray or array of type 'b' or 'B'"
-msgstr "Farbpuffer muss ein Byte-Array oder ein Array vom Typ 'b' oder 'B' sein"
+msgstr ""
+"Farbpuffer muss ein Byte-Array oder ein Array vom Typ 'b' oder 'B' sein"
 
 #: shared-bindings/displayio/Palette.c
 msgid "color must be between 0x000000 and 0xffffff"
@@ -4486,329 +4457,19 @@ msgstr "zi muss eine Gleitkommazahl sein"
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi muss die Form (n_section, 2) haben"
 
-#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
-#~ msgstr "Ungültiger Wert CIRCUITPY_PYSTACK_SIZE\n"
-
-#~ msgid "Unable to allocate the heap."
-#~ msgstr "Keine Allokation auf dem Heap möglich."
-
 #~ msgid ""
-#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
 #~ msgstr ""
-#~ "espcamera.Camera benötigt reservierten PSRAM um konfiguriert zu werden. "
-#~ "Siehe Dokumentation für Anweisungen."
-
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr ""
-#~ "'await', 'async for' oder 'async with' außerhalb einer async Funktion"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' außerhalb einer Schleife"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' außerhalb einer Schleife"
-
-#~ msgid "invalid architecture"
-#~ msgstr "ungültige Architektur"
-
-#~ msgid "unsupported type for %q: '%q'"
-#~ msgstr "nicht unterstützer Typ für %q: '%q'"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Splitting mit sub-captures"
-
-#~ msgid "__init__() should return None, not '%q'"
-#~ msgstr "__init__() sollte None zurückgeben, nicht '%q'"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "Attribute werden noch nicht unterstützt"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr ""
-#~ "kann mit einer komplexen Zahl keine abgeschnittene Division ausführen"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "Name %q kann nicht importiert werden"
-
-#~ msgid "cannot unambiguously get sizeof scalar"
-#~ msgstr "Kann nicht eindeutig die Größe (sizeof) des Skalars ermitteln"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr ""
-#~ "Schlüsselwort-Argument(e) noch nicht implementiert - verwende stattdessen "
-#~ "normale Argumente"
-
-#~ msgid "length argument not allowed for this type"
-#~ msgstr "Für diesen Typ ist length nicht zulässig"
-
-#~ msgid "offset out of bounds"
-#~ msgstr "offset außerhalb der Grenzen"
-
-#~ msgid "slice step can't be zero"
-#~ msgstr "Slice-Schritt darf nicht Null sein"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr ""
-#~ "Zeichenfolgen werden nicht unterstützt; verwende bytes oder bytearray"
-
-#~ msgid "Bit clock and word select must be sequential pins"
-#~ msgstr "Bit clock und word select müssen geordnete Pins sein"
-
-#~ msgid "Initialization failed due to lack of memory"
-#~ msgstr "Initialisierung aufgrund von Speichermangel fehlgeschlagen"
-
-#~ msgid "RAISE mode is not implemented"
-#~ msgstr "RAISE-Modus ist nicht implementiert"
-
-#~ msgid "WatchDogTimer is not currently running"
-#~ msgstr "WatchDogTimer läuft aktuell nicht"
-
-#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-#~ msgstr ""
-#~ "WatchDogTimer.mode kann nicht geändert werden, nachdem er auf "
-#~ "WatchDogMode.RESET gesetzt wurde"
-
-#~ msgid "watchdog not initialized"
-#~ msgstr "watchdog nicht initialisiert"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "ADC2 wird vom WiFi benutzt"
-
-#, c-format
-#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
-#~ msgstr "ADC-DMA-Controller konnte nicht konfiguriert werden, Fehlercode: %d"
-
-#, c-format
-#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
-#~ msgstr ""
-#~ "ADC-DMA-Controller konnte nicht initialisiert werden, Fehlercode: %d"
-
-#, c-format
-#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
-#~ msgstr "ADC-DMA-Controller konnte nicht gestartet werden, Fehlercode: %d"
-
-#~ msgid "xTaskCreate failed"
-#~ msgstr "xTaskCreate fehlgeschlagen"
-
-#~ msgid "Unable to write to address."
-#~ msgstr "An die Adresse kann nicht geschrieben werden."
-
-#~ msgid "queue overflow"
-#~ msgstr "Warteschlangenüberlauf"
-
-#~ msgid "Stopping AP is not supported."
-#~ msgstr "Das Stoppen des AP wird nicht unterstützt."
-
-#~ msgid "Wifi is in access point mode."
-#~ msgstr "Das Wifi ist im Accesspoint-Modus."
-
-#~ msgid "Wifi is in station mode."
-#~ msgstr "Das Wifi ist im Station-Modus."
+#~ "\n"
+#~ "Der Code wurde ausgeführt. Warte auf reload.\n"
 
 #~ msgid ""
 #~ "\n"
-#~ "Please file an issue with your program at https://github.com/adafruit/"
-#~ "circuitpython/issues."
+#~ "Code stopped by auto-reload.\n"
 #~ msgstr ""
 #~ "\n"
-#~ "Bitte erstellen Sie ein Problem (Issue) für Ihr Programm unter https://"
-#~ "github.com/adafruit/circuitpython/issues."
-
-#~ msgid "'coroutine' object is not an iterator"
-#~ msgstr "'coroutine' Objekt ist kein Iterator"
-
-#~ msgid "Buffer is too small"
-#~ msgstr "Der Puffer ist zu klein"
-
-#~ msgid "Fault detected by hardware."
-#~ msgstr "Hardware hat Fehler festgestellt."
-
-#~ msgid "The power dipped. Make sure you are providing enough power."
-#~ msgstr ""
-#~ "Die Spannung ist eingebrochen. Stelle sicher, dass genügend Leistung "
-#~ "verfügbar ist."
-
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-#~ msgstr ""
-#~ "pixel_shader muss displayio.Palette oder displayio.ColorConverter sein"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "Beschädigte .mpy Datei"
-
-#~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
-#~ msgstr ""
-#~ "Inkompatible .mpy-Datei. Bitte aktualisiere alle .mpy-Dateien. Siehe "
-#~ "http://adafru.it/mpy-update für weitere Informationen."
-
-#~ msgid "can't convert to %q"
-#~ msgstr "kann nicht zu %q konvertieren"
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "mehrere **x sind nicht gestattet"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "mehrere *x sind nicht gestattet"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "constant muss ein integer sein"
-
-#~ msgid "incompatible native .mpy architecture"
-#~ msgstr "inkompatible native .mpy-Architektur"
-
-#~ msgid "invalid format"
-#~ msgstr "ungültiges Format"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "Schlüsselwörter müssen Zeichenfolgen sein"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "Nicht-Schlüsselwort arg nach * / **"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "Nicht-Schlüsselwort-Argument nach Schlüsselwort-Argument"
-
-#, c-format
-#~ msgid "Instruction %d shifts in more bits than pin count"
-#~ msgstr "Anweisung %d verschiebt mehr Bits als die Anzahl der Pins"
-
-#, c-format
-#~ msgid "Instruction %d shifts out more bits than pin count"
-#~ msgstr "Der Befehl %d verschiebt mehr Bits als die Anzahl der Pins"
-
-#, c-format
-#~ msgid "Instruction %d uses extra pin"
-#~ msgstr "Instruktion %d benötigt extra Pin"
-
-#, c-format
-#~ msgid "Instruction %d waits on input outside of count"
-#~ msgstr "Anweisung %d wartet auf Eingaben außerhalb der vorhandenen Anzahl"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
-#~ msgstr "Fehlender first_in_pin. Instruktion %d liest Pin(s)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
-#~ msgstr "Fehlende first_in_pin. Anweisung %d verschiebt sich um Pin(s)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
-#~ msgstr "Fehlende first_in_pin. Anweisung %d wartet basierend auf Pin"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
-#~ msgstr "First_out_pin fehlt. Befehl %d verschiebt sich zu Pin(s)"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
-#~ msgstr "Fehlender first_out_pin. Instruktion %d schreibt Pin(s)"
-
-#, c-format
-#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
-#~ msgstr "Fehlender first_set_pin. Instruktion %d setzt Pin(s)"
-
-#, c-format
-#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
-#~ msgstr "jmp_pin fehlt. Befehl %d springt auf Pin"
-
-#~ msgid "inputs are not iterable"
-#~ msgstr "Eingaben sind nicht iterierbar"
-
-#~ msgid "Too many display busses"
-#~ msgstr "Zu viele Anzeigebusse"
-
-#~ msgid "Cannot transfer without MOSI and MISO pins"
-#~ msgstr "Kann nicht ohne MISO und MOSI Pins transferieren"
-
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Hardware beschäftigt, versuche alternative Pins"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "Fehlender MISO- oder MOSI-Pin"
-
-#~ msgid "Missing MISO or MOSI pin"
-#~ msgstr "MISO oder MOSI Pin fehlt"
-
-#~ msgid "No MISO Pin"
-#~ msgstr "Kein MISO-Pin"
-
-#~ msgid "No MISO pin"
-#~ msgstr "Miso Pin fehlt"
-
-#~ msgid "No MOSI Pin"
-#~ msgstr "Kein MOSI-Pin"
-
-#~ msgid "No MOSI pin"
-#~ msgstr "MOSI Pin fehlt"
-
-#~ msgid "No RX pin"
-#~ msgstr "Kein RX-Pin"
-
-#~ msgid "No TX pin"
-#~ msgstr "Kein TX-Pin"
-
-#~ msgid "no reset pin available"
-#~ msgstr "kein Reset Pin verfügbar"
-
-#~ msgid "Sleep Memory not available"
-#~ msgstr "Sleep-Speicher nicht verfügbar"
-
-#~ msgid "input and output shapes are not compatible"
-#~ msgstr "Eingabe- und Ausgabeformen sind nicht kompatibel"
-
-#~ msgid "shape must be a tuple"
-#~ msgstr "Form muss ein Tupel sein"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "Die Helligkeit muss zwischen 0 und 1.0 liegen"
-
-#, c-format
-#~ msgid "Error in MIDI stream at position %d"
-#~ msgstr "Fehler in MIDI Datenstrom um Position %d"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "Maximaler x-Wert beim Spiegeln ist %d"
-
-#~ msgid "x value out of bounds"
-#~ msgstr "x Wert außerhalb der Grenzen"
-
-#~ msgid "y value out of bounds"
-#~ msgstr "y Wert außerhalb der Grenzen"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "I2SOut nicht verfügbar"
-
-#~ msgid "PDMIn not available"
-#~ msgstr "PDMIn nicht verfügbar"
-
-#~ msgid "out of range of source"
-#~ msgstr "Außerhalb des Bereichs der Quelle"
-
-#~ msgid "pixel value requires too many bits"
-#~ msgstr "Der Pixelwert erfordert zu viele Bits"
-
-#~ msgid "value_count must be > 0"
-#~ msgstr "value_count muss größer als 0 sein"
-
-#~ msgid "64 bit types"
-#~ msgstr "64 bit-Typen"
-
-#~ msgid "No key was specified"
-#~ msgstr "Es wurde kein Schlüssel angegeben"
-
-#~ msgid "Scan already in progess. Stop with stop_scan."
-#~ msgstr "Scannen bereits in Bearbeitung. Stoppe mit stop_scan."
-
-#, c-format
-#~ msgid "Unkown error code %d"
-#~ msgstr "Unbekannter Fehlercode %d"
-
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "zu viele Argumente mit dem angegebenen Format"
+#~ "Code durch automatisches neuladen gestoppt\n"
 
 #~ msgid ""
 #~ "\n"
@@ -4821,12 +4482,6 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ "\n"
 #~ "\n"
 
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "Gib mindestens einen UART-Pin an"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "%q Pin ungültig"
-
 #~ msgid ""
 #~ "\n"
 #~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
@@ -4836,750 +4491,41 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ "Bitte melde ein Problem mit dem Inhalt Ihres CIRCUITPY-Laufwerks unter\n"
 #~ "https://github.com/adafruit/circuitpython/issues\n"
 
-#~ msgid "Attempted heap allocation when VM not running."
-#~ msgstr "Versuchte Heap-Zuordnung wenn VM nicht läuft."
-
-#~ msgid "Boot device must be first device (interface #0)."
-#~ msgstr "Boot-Gerät muss erstes Gerät sein (interface #0)."
-
-#~ msgid "Both buttons were pressed at start up.\n"
-#~ msgstr "Beim Starten wurden beide Tasten gedrückt.\n"
-
-#~ msgid "Button A was pressed at start up.\n"
-#~ msgstr "Beim Starten wurde Taste A gedrückt.\n"
-
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "CircuitPython war es nicht möglich heap-Speicher zu allozieren."
-
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "Absturz in den HardFault_Handler."
-
-#~ msgid "Fatal error."
-#~ msgstr "Fataler Fehler."
-
-#~ msgid "Invalid memory access."
-#~ msgstr "Ungültiger Speicherzugriff."
-
-#~ msgid "Nordic system firmware failure assertion."
-#~ msgstr "Nordic System-Firmware Fehler Assertion."
-
-#~ msgid "The BOOT button was pressed at start up.\n"
-#~ msgstr "Beim Starten wurde die Taste BOOT gedrückt.\n"
+#~ msgid ""
+#~ "\n"
+#~ "Please file an issue with your program at https://github.com/adafruit/"
+#~ "circuitpython/issues."
+#~ msgstr ""
+#~ "\n"
+#~ "Bitte erstellen Sie ein Problem (Issue) für Ihr Programm unter https://"
+#~ "github.com/adafruit/circuitpython/issues."
 
 #~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Increase the stack size if you know how. If not:"
+#~ "\n"
+#~ "To exit, please reset the board without "
 #~ msgstr ""
-#~ "Der Heap von CircuitPython wurde beschädigt, weil der Stack zu klein "
-#~ "war.\n"
-#~ "Vergrößere den Stack, wenn du weißt, wie. Wenn nicht:"
-
-#~ msgid "The SW38 button was pressed at start up.\n"
-#~ msgstr "Beim Starten wurde die Taste SW38 gedrückt.\n"
-
-#~ msgid "The VOLUME button was pressed at start up.\n"
-#~ msgstr "Beim Starten wurde die Taste VOLUME gedrückt.\n"
-
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode."
-#~ msgstr ""
-#~ "Das Modul `microcontroller` wurde zum Booten in den abgesicherten Modus "
-#~ "verwendet. Drücke Reset, um den abgesicherten Modus zu verlassen."
-
-#~ msgid "The central button was pressed at start up.\n"
-#~ msgstr "Beim Starten wurde die zentrale Taste gedrückt.\n"
-
-#~ msgid "The left button was pressed at start up.\n"
-#~ msgstr "Beim Starten wurde die linke Taste gedrückt.\n"
-
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY)."
-#~ msgstr ""
-#~ "Der Mikrocontroller hatte einen Stromausfall. Vergewisser dich, dass die\n"
-#~ "Stromversorgung genügend Strom für die gesamte Schaltung liefert und\n"
-#~ "drücke Reset (nach dem Auswerfen von CIRCUITPY)."
-
-#~ msgid "To exit, please reset the board without requesting safe mode."
-#~ msgstr ""
-#~ "Zum Beenden setze bitte das Board zurück, ohne den abgesicherten Modus "
-#~ "aufzurufen."
-
-#~ msgid "You are in safe mode because:\n"
-#~ msgstr "Du befindest dich im abgesicherten Modus, weil:\n"
-
-#~ msgid ""
-#~ "You pressed the reset button during boot. Press again to exit safe mode."
-#~ msgstr ""
-#~ "Du hast beim Booten die Reset-Taste gedrückt. Drücke sie erneut, um den "
-#~ "abgesicherten Modus zu beenden."
-
-#~ msgid ""
-#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
-#~ msgstr ""
-#~ "esp32_camera.Camera benötigt reservierten PSRAM um konfiguriert werden zu "
-#~ "können. Sieh in der Dokumentation für eine Anleitung nach."
-
-#~ msgid "%q must be of type %q"
-#~ msgstr "%q muss vom Type %q sein"
-
-#~ msgid "%q must be of type %q or None"
-#~ msgstr "%q muss vom Type %q oder None sein"
-
-#~ msgid "Expected a %q"
-#~ msgstr "Erwartet ein(e) %q"
-
-#~ msgid "Expected a %q or %q"
-#~ msgstr "Erwartete ein %q oder %q"
-
-#~ msgid "Expected an %q"
-#~ msgstr "Erwartet ein %q"
+#~ "\n"
+#~ "Zum Beenden, resete bitte das Board ohne "
 
 #, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IV muss %d Bytes lang sein"
+#~ msgid "%02X"
+#~ msgstr "%02X"
 
-#~ msgid "Not settable"
-#~ msgstr "Kann nicht gesetzt werden"
+#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+#~ msgstr ""
+#~ "%d Adress-Pins und %d rgb-Pins zeigen eine Höhe von %d, nicht von %d"
 
-#~ msgid "expected '%q' but got '%q'"
-#~ msgstr "erwartet '%q' aber bekommen '%q'"
+#~ msgid "%q"
+#~ msgstr "%q"
 
-#~ msgid "expected '%q' or '%q' but got '%q'"
-#~ msgstr "erwartete '%q' oder '%q', aber bekam '%q'"
-
-#~ msgid "Read-only object"
-#~ msgstr "Schreibgeschützte Objekt"
-
-#~ msgid "frequency is read-only for this board"
-#~ msgstr "Frequenz ist für dieses Board schreibgeschützt"
-
-#~ msgid "Unable to write"
-#~ msgstr "Schreiben nicht möglich"
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "%q Indizes müssen Integer sein, nicht %q"
 
 #~ msgid "%q length must be >= 1"
 #~ msgstr "%q Länge muss >= 1 sein"
 
-#~ msgid "%q must be a string"
-#~ msgstr "%q muss ein String sein"
-
-#~ msgid "%q must be an int"
-#~ msgstr "%q muss vom Typ Integer sein"
-
-#~ msgid "%q with a report ID of 0 must be of length 1"
-#~ msgstr "%q mit Berichts-ID von 0 muss von Länge 1 sein"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "Es darf höchstens %d %q spezifiziert werden (nicht %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Ungültige Pins"
-
-#, c-format
-#~ msgid "No more than %d HID devices allowed"
-#~ msgstr "Keine weiteren %d HID-Geräte zulässig"
-
-#~ msgid "byteorder is not a string"
-#~ msgstr "Byteorder ist kein String"
-
-#~ msgid "can't convert %q to int"
-#~ msgstr "kann %q nicht nach int konvertieren"
-
-#~ msgid "complex division by zero"
-#~ msgstr "Komplexe Division durch null"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr "int() arg 2 muss >= 2 und <= 36 sein"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "long int wird in diesem Build nicht unterstützt"
-
-#~ msgid "slice step cannot be zero"
-#~ msgstr "Der Slice-Schritt kann nicht Null sein"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "Schritt (step) darf nicht Null sein"
-
-#~ msgid "string indices must be integers, not %q"
-#~ msgstr "String Indizes müssen Integer sein, nicht %q"
-
-#~ msgid "time.struct_time() takes a 9-sequence"
-#~ msgstr "time.struct_time() nimmt eine 9-Sequenz an"
-
-#~ msgid "zero step"
-#~ msgstr "Nullschritt"
-
-#~ msgid "invalid traceback"
-#~ msgstr "ungültiger Traceback"
-
-#~ msgid "WatchDogTimer.timeout must be greater than 0"
-#~ msgstr "WatchDogTimer.timeout muss größer als 0 sein"
-
-#~ msgid "non-Device in %q"
-#~ msgstr "Nicht-Gerät in %q"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "einzelne '}' in Formatierungs-String gefunden"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "threshold muss im Intervall 0-65536 liegen"
-
-#~ msgid "timeout must be 0.0-100.0 seconds"
-#~ msgstr "Das Zeitlimit muss 0,0-100,0 Sekunden betragen"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "'{' ohne passende Zuordnung im Format"
-
-#~ msgid "watchdog timeout must be greater than 0"
-#~ msgstr "watchdog Zeitlimit muss größer als 0 sein"
-
-#~ msgid "To exit, please reset the board without "
-#~ msgstr "Zum beenden, resette bitte das board ohne "
-
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "Du hast das Starten im abgesicherten Modus ausgelöst durch "
-
-#~ msgid "pressing BOOT button at start up.\n"
-#~ msgstr "BOOT Taste wird beim Starten gedrückt.\n"
-
-#~ msgid "pressing SW38 button at start up.\n"
-#~ msgstr "SW38 Taste wird beim Starten gedrückt.\n"
-
-#~ msgid "pressing VOLUME button at start up.\n"
-#~ msgstr "VOLUME Taste wird beim Starten gedrückt.\n"
-
-#~ msgid "pressing boot button at start up.\n"
-#~ msgstr "Drücken der Boot-Taste beim Start.\n"
-
-#~ msgid "pressing both buttons at start up.\n"
-#~ msgstr "Drücken Sie beim Start beide Tasten.\n"
-
-#~ msgid "pressing the left button at start up\n"
-#~ msgstr "Drücken der linken Taste beim Einschalten\n"
-
-#~ msgid "Only one TouchAlarm can be set in deep sleep."
-#~ msgstr "Nur ein TouchAlarm kann in Deep Sleep gesetzt werden."
-
-#~ msgid "Firmware image is invalid"
-#~ msgstr "Firmware Image ist ungültig"
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "Stream fehlt readinto() oder write() Methode."
-
-#~ msgid "%q must be >= 0"
-#~ msgstr "%q muss >= 0 sein"
-
-#~ msgid "%q must be >= 1"
-#~ msgstr "%q muss >= 1 sein"
-
-#~ msgid "address out of bounds"
-#~ msgstr "Adresse außerhalb der Grenzen"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr "destination_length muss ein int >= 0 sein"
-
-#~ msgid "type object 'generator' has no attribute '__await__'"
-#~ msgstr "Das Typ-Objekt 'generator' hat kein Attribut '__await__'"
-
-#~ msgid "color should be an int"
-#~ msgstr "Farbe sollte ein int sein"
-
-#~ msgid "end_x should be an int"
-#~ msgstr "end_x sollte ein int sein"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "palette_index sollte ein int sein"
-
-#~ msgid "start_x should be an int"
-#~ msgstr "start_x sollte ein int sein"
-
-#~ msgid "y should be an int"
-#~ msgstr "y sollte ein int sein"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "sample_source buffer muss ein Byte-Array oder ein Array vom Typ 'h', 'H', "
-#~ "'b' oder 'B' sein"
-
-#~ msgid "Expected an alarm"
-#~ msgstr "Alarm erwartet"
-
-#~ msgid "All I2C targets are in use"
-#~ msgstr "Alle I2C-Ziele sind in Verwendung"
-
-#~ msgid "Failed to init wifi"
-#~ msgstr "Wifi Initialisierung ist fehlgeschlagen"
-
-#~ msgid "input must be a tensor of rank 2"
-#~ msgstr "Eingabe muss ein Tensor von Rang 2 sein"
-
-#~ msgid "maximum number of dimensions is 4"
-#~ msgstr "die maximale Anzahl der Dimensionen beträgt 4"
-
-#~ msgid "Watchdog timer expired."
-#~ msgstr "Watchdog timer abgelaufen."
-
-#~ msgid "ssid can't be more than 32 bytes"
-#~ msgstr "ssid kann nicht mehr als 32 Bytes lang sein"
-
-#~ msgid "%q must be a tuple of length 2"
-#~ msgstr "%q muss ein Tupel der Länge 2 sein"
-
-#~ msgid "%q must be between %d and %d"
-#~ msgstr "%q muss zwischen %d und %d sein"
-
-#~ msgid "%q should be an int"
-#~ msgstr "%q sollte ein integer sein"
-
-#~ msgid "(x,y) integers required"
-#~ msgstr "(x,y) Integer benötigt"
-
-#~ msgid "Address type out of range"
-#~ msgstr "Adresstyp außerhalb des zulässigen Bereichs"
-
-#~ msgid "AnalogIn not supported on given pin"
-#~ msgstr "AnalogIn ist an diesem Pin nicht unterstützt"
-
-#~ msgid "AnalogOut functionality not supported"
-#~ msgstr "AnalogOut-Funktion wird nicht unterstützt"
-
-#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-#~ msgstr "AnalogOut kann nur 16 Bit. Der Wert muss unter 65536 liegen."
-
-#~ msgid "AnalogOut not supported on given pin"
-#~ msgstr "AnalogOut ist an diesem Pin nicht unterstützt"
-
-#, c-format
-#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
-#~ msgstr "Bittiefe muss zwischen 1 und 6 liegen, nicht %d"
-
-#, c-format
-#~ msgid "Buffer incorrect size. Should be %d bytes."
-#~ msgstr "Der Puffergröße ist inkorrekt. Sie sollte %d bytes haben."
-
-#~ msgid "Buffer must be at least length 1"
-#~ msgstr "Der Puffer muss eine Mindestenslänge von 1 haben"
-
-#~ msgid "Bytes must be between 0 and 255."
-#~ msgstr "Ein Bytes kann nur Werte zwischen 0 und 255 annehmen."
-
-#~ msgid "Cannot output both channels on the same pin"
-#~ msgstr "Kann nicht beite Kanäle auf dem gleichen Pin ausgeben"
-
-#~ msgid "Cannot read without MISO pin."
-#~ msgstr "Kann ohne MISO-Pin nicht lesen."
-
-#~ msgid "Cannot reset into bootloader because no bootloader is present."
-#~ msgstr "Reset zum Bootloader nicht möglich, da Bootloader nicht vorhanden."
-
-#~ msgid "Cannot transfer without MOSI and MISO pins."
-#~ msgstr "Übertragung ohne MOSI- und MISO-Pins nicht möglich."
-
-#~ msgid "Cannot write without MOSI pin."
-#~ msgstr "Kann nicht ohne MOSI-Pin schreiben."
-
-#~ msgid "Clock pin init failed."
-#~ msgstr "Clock pin init fehlgeschlagen."
-
-#~ msgid "Command must be an int between 0 and 255"
-#~ msgstr "Der Befehl muss ein int zwischen 0 und 255 sein"
-
-#~ msgid "Could not initialize Camera"
-#~ msgstr "Konnte Kamera nicht initialisieren"
-
-#~ msgid "Could not initialize GNSS"
-#~ msgstr "GNSS konnte nicht initialisiert werden"
-
-#~ msgid "Could not initialize SDCard"
-#~ msgstr "Konnte SDKarte nicht initialisieren"
-
-#~ msgid "Could not initialize UART"
-#~ msgstr "Konnte UART nicht initialisieren"
-
-#~ msgid "Could not re-init channel"
-#~ msgstr "Kanal konnte nicht neu initiiert werden"
-
-#~ msgid "Could not re-init timer"
-#~ msgstr "Timer konnte nicht neu gestartet werden"
-
-#~ msgid "Could not restart PWM"
-#~ msgstr "PWM konnte nicht neu gestartet werden"
-
-#~ msgid "Couldn't allocate first buffer"
-#~ msgstr "Konnte first buffer nicht zuteilen"
-
-#~ msgid "Couldn't allocate input buffer"
-#~ msgstr "Eingabepuffer konnte nicht zugewiesen werden"
-
-#~ msgid "Couldn't allocate second buffer"
-#~ msgstr "Konnte second buffer nicht zuteilen"
-
-#~ msgid "DigitalInOut not supported on given pin"
-#~ msgstr "DigitalInOut wird auf dem angegebenen Pin nicht unterstützt"
-
-#, c-format
-#~ msgid "Expected tuple of length %d, got %d"
-#~ msgstr "Habe ein Tupel der Länge %d erwartet aber %d erhalten"
-
-#~ msgid "Failed to allocate RX buffer"
-#~ msgstr "Konnte keinen RX Buffer allozieren"
-
-#, c-format
-#~ msgid "Failed to allocate RX buffer of %d bytes"
-#~ msgstr "Konnte keine RX Buffer mit %d allozieren"
-
-#, c-format
-#~ msgid "Framebuffer requires %d bytes"
-#~ msgstr "Framepuffer benötigt %d bytes"
-
-#~ msgid "Hostname must be between 1 and 253 characters"
-#~ msgstr "Der Hostname muss zwischen 1 und 253 Zeichen haben"
-
-#~ msgid "I2C Init Error"
-#~ msgstr "I2C-Init-Fehler"
-
-#~ msgid "Invalid %q pin selection"
-#~ msgstr "Ungültige %q Pin-Auswahl"
-
-#~ msgid "Invalid AuthMode"
-#~ msgstr "Ungültiges AuthMode"
-
-#~ msgid "Invalid BMP file"
-#~ msgstr "Ungültige BMP-Datei"
-
-#~ msgid "Invalid DAC pin supplied"
-#~ msgstr "Ungültiger DAC-Pin angegeben"
-
-#~ msgid "Invalid MIDI file"
-#~ msgstr "Ungültige MIDI Datei"
-
-#~ msgid "Invalid PWM frequency"
-#~ msgstr "Ungültige PWM Frequenz"
-
-#~ msgid "Invalid Pin"
-#~ msgstr "Ungültiger Pin"
-
-#~ msgid "Invalid buffer size"
-#~ msgstr "Ungültige Puffergröße"
-
-#~ msgid "Invalid byteorder string"
-#~ msgstr "Ungültige Byteorder-String"
-
-#~ msgid "Invalid capture period. Valid range: 1 - 500"
-#~ msgstr "Ungültiger Aufnahmezeitraum. Gültiger Bereich: 1 - 500"
-
-#~ msgid "Invalid channel count"
-#~ msgstr "Ungültige Anzahl von Kanälen"
-
-#, c-format
-#~ msgid "Invalid data_count %d"
-#~ msgstr "Ungültiger data_count %d"
-
-#~ msgid "Invalid direction."
-#~ msgstr "Ungültige Richtung."
-
-#~ msgid "Invalid file"
-#~ msgstr "Ungültige Datei"
-
-#~ msgid "Invalid mode"
-#~ msgstr "Ungültiger Modus"
-
-#~ msgid "Invalid number of bits"
-#~ msgstr "Ungültige Anzahl von Bits"
-
-#~ msgid "Invalid phase"
-#~ msgstr "Ungültige Phase"
-
-#~ msgid "Invalid pin"
-#~ msgstr "Ungültiger Pin"
-
-#~ msgid "Invalid pin for left channel"
-#~ msgstr "Ungültiger Pin für linken Kanal"
-
-#~ msgid "Invalid pin for right channel"
-#~ msgstr "Ungültiger Pin für rechten Kanal"
-
-#~ msgid "Invalid polarity"
-#~ msgstr "Ungültige Polarität"
-
-#~ msgid "Invalid properties"
-#~ msgstr "Ungültige Eigenschaften"
-
-#~ msgid "Invalid run mode."
-#~ msgstr "Ungültiger Ausführungsmodus."
-
-#~ msgid "Invalid security_mode"
-#~ msgstr "Ungültiger security_mode"
-
-#~ msgid "Invalid voice"
-#~ msgstr "Ungültige Stimme"
-
-#~ msgid "Invalid voice count"
-#~ msgstr "Ungültige Anzahl von Stimmen"
-
-#~ msgid "Invalid wave file"
-#~ msgstr "Ungültige wave Datei"
-
-#~ msgid "Invalid word/bit length"
-#~ msgstr "Ungültige Wort- / Bitlänge"
-
-#~ msgid "Layer already in a group."
-#~ msgstr "Layer ist bereits in einer Gruppe."
-
-#~ msgid "Layer must be a Group or TileGrid subclass."
-#~ msgstr "Layer muss eine Group- oder TileGrid-Unterklasse sein."
-
-#~ msgid "MISO pin init failed."
-#~ msgstr "MISO pin Initialisierung fehlgeschlagen."
-
-#~ msgid "MOSI pin init failed."
-#~ msgstr "MOSI pin Initialisierung fehlgeschlagen."
-
-#~ msgid "Messages limited to 8 bytes"
-#~ msgstr "Meldungen auf 8 Bytes limitiert"
-
-#, c-format
-#~ msgid "More than %d report ids not supported"
-#~ msgstr "Mehr als %d Berichts-IDs werden nicht unterstützt"
-
-#~ msgid "No hardware support on clk pin"
-#~ msgstr "Keine Hardwareunterstützung am clk Pin"
-
-#~ msgid "No hardware support on pin"
-#~ msgstr "Keine Hardwareunterstützung an diesem Pin"
-
-#, c-format
-#~ msgid "Output buffer must be at least %d bytes"
-#~ msgstr "Ausgabe-Buffer muss mindestens %d Bytes sein"
-
-#~ msgid ""
-#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-#~ msgstr "PWM duty_cycle muss zwischen 0 und 65535 (16 Bit-Auflösung) liegen"
-
-#~ msgid "Pin count must be at least 1"
-#~ msgstr "Pin-Anzahl muss mindestens 1 sein"
-
-#~ msgid "Pin does not have ADC capabilities"
-#~ msgstr "Pin hat keine ADC-Funktionalität"
-
-#~ msgid "Program must contain at least one 16-bit instruction."
-#~ msgstr "Programm muss mindestens eine 16-Bit-Instruktion enthalten."
-
-#~ msgid "Program too large"
-#~ msgstr "Das Programm ist zu groß"
-
-#~ msgid "RS485 Not yet supported on this device"
-#~ msgstr "RS485 wird von diesem Gerät nicht unterstützt"
-
-#~ msgid "RTC calibration is not supported on this board"
-#~ msgstr "Die RTC-Kalibrierung wird auf diesem Board nicht unterstützt"
-
-#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
-#~ msgstr "RTS / CTS / RS485 Wird von diesem Gerät noch nicht unterstützt"
-
-#~ msgid "SPI Init Error"
-#~ msgstr "SPI-Init-Fehler"
-
-#~ msgid "SPI Re-initialization error"
-#~ msgstr "SPI-Neuinitialisierungsfehler"
-
-#~ msgid "Sample rate must be positive"
-#~ msgstr "Abtastrate muss positiv sein"
-
-#, c-format
-#~ msgid "Sample rate too high. It must be less than %d"
-#~ msgstr "Abtastrate zu hoch. Wert muss unter %d liegen"
-
-#~ msgid "Set pin count must be between 1 and 5"
-#~ msgstr "Die Anzahl der Pins muss zwischen 1 und 5 liegen"
-
-#~ msgid "Side set pin count must be between 1 and 5"
-#~ msgstr "Die Anzahl der Pins für Side set muss zwischen 1 und 5 liegen"
-
-#~ msgid "Stack size must be at least 256"
-#~ msgstr "Die Stackgröße sollte mindestens 256 sein"
-
-#~ msgid "Tile value out of bounds"
-#~ msgstr "Kachelwert außerhalb der Grenzen"
-
-#~ msgid "UART Buffer allocation error"
-#~ msgstr "UART Buffer reservierungs Fehler"
-
-#~ msgid "UART De-init error"
-#~ msgstr "UART De-Init-Fehler"
-
-#~ msgid "UART Init Error"
-#~ msgstr "UART Init Fehler"
-
-#~ msgid "UART Re-init error"
-#~ msgstr "UART Re-Init-Fehler"
-
-#~ msgid "UART write error"
-#~ msgstr "UART-Schreibfehler"
-
-#~ msgid "Unsupported baudrate"
-#~ msgstr "Baudrate wird nicht unterstützt"
-
-#~ msgid "WiFi password must be between 8 and 63 characters"
-#~ msgstr "WiFi Passwort muss zwischen 8 und 63 Zeichen lang sein"
-
-#~ msgid "bits must be in range 5 to 9"
-#~ msgstr "bits müssen zwischen 5 und 9 liegen"
-
-#~ msgid "bytes > 8 bits not supported"
-#~ msgstr "bytes mit mehr als 8 bits werden nicht unterstützt"
-
-#~ msgid "calibration value out of range +/-127"
-#~ msgstr "Kalibrierwert nicht im Bereich von +/-127"
-
-#~ msgid "can only be registered in one parent"
-#~ msgstr "kann nur bei einem Elternteil registriert werden"
-
-#~ msgid "circle can only be registered in one parent"
-#~ msgstr "Kreis kann nur in einem Elternteil registriert werden"
-
-#~ msgid "max_connections must be between 0 and 10"
-#~ msgstr "max_connections muss zwischen 0 und 10 liegen"
-
-#~ msgid "max_length must be >= 0"
-#~ msgstr "max_length muss >= 0 sein"
-
-#~ msgid "polygon can only be registered in one parent"
-#~ msgstr "Polygon kann nur in einem übergeordneten Element registriert werden"
-
-#~ msgid "pull_threshold must be between 1 and 32"
-#~ msgstr "pull_threshold muss zwischen 1 und 32 liegen"
-
-#~ msgid "push_threshold must be between 1 and 32"
-#~ msgstr "push_threshold muss zwischen 1 und 32 liegen"
-
-#~ msgid "stop must be 1 or 2"
-#~ msgstr "stop muss 1 oder 2 sein"
-
-#~ msgid "tile must be greater than zero"
-#~ msgstr "Kachel muss größer als Null sein"
-
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "timeout muss >= 0.0 sein"
-
-#, c-format
-#~ msgid "width must be from 2 to 8 (inclusive), not %d"
-#~ msgstr "breite muss zwischen (inklusive) 2 und 8 liegen, nicht %d"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "Nicht unterstützte Operation"
-
-#~ msgid "divisor must be 4"
-#~ msgstr "Teiler muss 4 sein"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code stopped by auto-reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Code durch automatisches neuladen gestoppt\n"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "Die Helligkeit muss zwischen 0 und 255 liegen"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "kann keinen relativen Import durchführen"
-
-#~ msgid "Unsupported pull value."
-#~ msgstr "Nicht unterstützter Pull-Wert."
-
-#, c-format
-#~ msgid ""
-#~ "Welcome to Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Please visit learn.adafruit.com/category/circuitpython for project "
-#~ "guides.\n"
-#~ "\n"
-#~ "To list built-in modules please do `help(\"modules\")`.\n"
-#~ msgstr ""
-#~ "Willkommen bei Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Projektleitfäden findest du auf learn.adafruit.com/category/"
-#~ "circuitpython \n"
-#~ "\n"
-#~ "Um die integrierten Module aufzulisten, führe bitte `help(\"modules\")` "
-#~ "aus.\n"
-
-#~ msgid "integer required"
-#~ msgstr "integer erforderlich"
-
-#~ msgid "abort() called"
-#~ msgstr "abort() wurde aufgerufen"
-
-#~ msgid "f-string expression part cannot include a '#'"
-#~ msgstr "f-string expression Teil kann kein '#' beinhalten"
-
-#~ msgid "f-string expression part cannot include a backslash"
-#~ msgstr "Die f-String expression darf keinen Backslash enthalten"
-
-#~ msgid "f-string: empty expression not allowed"
-#~ msgstr "f-string: leere expression nicht erlaubt"
-
-#~ msgid "f-string: expecting '}'"
-#~ msgstr "f-string: erwartet '}'"
-
-#~ msgid "f-string: single '}' is not allowed"
-#~ msgstr "f-string: einzelne '}' nicht erlaubt"
-
-#~ msgid "invalid arguments"
-#~ msgstr "ungültige argumente"
-
-#~ msgid "raw f-strings are not implemented"
-#~ msgstr "rohe F-Strings sind nicht implementiert"
-
-#~ msgid "unindent does not match any outer indentation level"
-#~ msgstr ""
-#~ "Einrückung entspricht keiner äußeren Einrückungsebene. Bitte Leerzeichen "
-#~ "am Zeilenanfang kontrollieren"
-
 #~ msgid "%q list must be a list"
 #~ msgstr "%q Liste muss eine Liste sein"
-
-#~ msgid "Column entry must be digitalio.DigitalInOut"
-#~ msgstr "Spalteneintrag muss digitalio.DigitalInOut sein"
-
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Characteristic wird erwartet"
-
-#~ msgid "Expected a DigitalInOut"
-#~ msgstr "DigitanInOut wird erwartet"
-
-#~ msgid "Expected a Service"
-#~ msgstr "Ein Service wird erwartet"
-
-#~ msgid "Expected a UART"
-#~ msgstr "UART wird erwartet"
-
-#~ msgid "Expected a UUID"
-#~ msgstr "Eine UUID wird erwartet"
-
-#~ msgid "Expected an Address"
-#~ msgstr "Erwartet eine Adresse"
-
-#~ msgid "Row entry must be digitalio.DigitalInOut"
-#~ msgstr "Zeileneintrag muss ein digitalio.DigitalInOut sein"
-
-#~ msgid "buttons must be digitalio.DigitalInOut"
-#~ msgstr "Tasten müssen digitalio.DigitalInOut sein"
-
-#~ msgid "Invalid frequency"
-#~ msgstr "Ungültige Frequenz"
-
-#~ msgid "Data 0 pin must be byte aligned."
-#~ msgstr "Data 0 Pin muss Byte aligned sein."
-
-#~ msgid "ParallelBus not yet supported"
-#~ msgstr "ParallelBus wird noch nicht unterstützt"
 
 #~ msgid "%q must be 0-255"
 #~ msgstr "%q muss 0-255 sein"
@@ -5587,73 +4533,41 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "%q must be 1-255"
 #~ msgstr "%q muss 1-255 sein"
 
+#~ msgid "%q must be >= 0"
+#~ msgstr "%q muss >= 0 sein"
+
+#~ msgid "%q must be >= 1"
+#~ msgstr "%q muss >= 1 sein"
+
 #~ msgid "%q must be None or between 1 and len(report_descriptor)-1"
 #~ msgstr "%q muss None oder zwischen 1 und len(report_descriptor)-1 sein"
 
-#~ msgid "no available NIC"
-#~ msgstr "kein verfügbares Netzwerkadapter (NIC)"
+#~ msgid "%q must be a string"
+#~ msgstr "%q muss ein String sein"
 
-#~ msgid "Instruction %d jumps on pin"
-#~ msgstr "Instruktion %d springt auf Pin"
+#~ msgid "%q must be a tuple of length 2"
+#~ msgstr "%q muss ein Tupel der Länge 2 sein"
 
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "Puffer zu groß und kann nicht reserviert werden"
+#~ msgid "%q must be an int"
+#~ msgstr "%q muss vom Typ Integer sein"
 
-#~ msgid "wrong operand type"
-#~ msgstr "falscher Operandentyp"
+#~ msgid "%q must be between %d and %d"
+#~ msgstr "%q muss zwischen %d und %d sein"
 
-#~ msgid ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
-#~ msgstr ""
-#~ "CircuitPython befindet sich im abgesicherten Modus, da Sie beim Booten "
-#~ "die Reset-Taste gedrückt haben. Drücken Sie erneut, um den abgesicherten "
-#~ "Modus zu verlassen.\n"
+#~ msgid "%q must be of type %q"
+#~ msgstr "%q muss vom Type %q sein"
 
-#~ msgid "Not running saved code.\n"
-#~ msgstr "Gespeicherter Code wird nicht ausgeführt.\n"
+#~ msgid "%q must be of type %q or None"
+#~ msgstr "%q muss vom Type %q oder None sein"
 
-#~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Please increase the stack size if you know how, or if not:"
-#~ msgstr ""
-#~ "Der CircuitPython-Heap wurde beschädigt, weil der Stapel zu klein war.\n"
-#~ "Bitte erhöhen Sie die Stapelgröße, wenn Sie wissen wie oder wenn nicht:"
+#~ msgid "%q pin invalid"
+#~ msgstr "%q Pin ungültig"
 
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode.\n"
-#~ msgstr ""
-#~ "Das `Mikrocontroller` Modul wurde benutzt, um in den Sicherheitsmodus zu "
-#~ "starten. Drücke Reset um den Sicherheitsmodus zu verlassen.\n"
+#~ msgid "%q should be an int"
+#~ msgstr "%q sollte ein integer sein"
 
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY).\n"
-#~ msgstr ""
-#~ "Die Spannungsversorgung des Mikrocontrollers hat den minimal Wert "
-#~ "unterschritten.\n"
-#~ "Stellen Sie sicher, dass Ihr Netzteil genug Strom bereitstellt für den "
-#~ "gesamten Stromkreis und drücken Sie Reset (nach dem Auswerfen von "
-#~ "CIRCUITPY).\n"
-
-#~ msgid "You are in safe mode: something unanticipated happened.\n"
-#~ msgstr ""
-#~ "Sie befinden sich im abgesicherten Modus: Es ist etwas Unerwartetes "
-#~ "passiert.\n"
-
-#~ msgid "Pin number already reserved by EXTI"
-#~ msgstr "PIN-Nummer bereits von EXTI reserviert"
-
-#~ msgid "USB Busy"
-#~ msgstr "USB beschäftigt"
-
-#~ msgid "USB Error"
-#~ msgstr "USB Fehler"
-
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "%q Indizes müssen Integer sein, nicht %q"
+#~ msgid "%q with a report ID of 0 must be of length 1"
+#~ msgstr "%q mit Berichts-ID von 0 muss von Länge 1 sein"
 
 #~ msgid "'%q' object cannot assign attribute '%q'"
 #~ msgstr "'%q' Objekt kann das Attribut '%q' nicht zuweisen"
@@ -5675,221 +4589,6 @@ msgstr "zi muss die Form (n_section, 2) haben"
 
 #~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
 #~ msgstr "'%s' Integer 0x%x passt nicht in Maske 0x%x"
-
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "sizeof scalar kann nicht eindeutig bestimmt werden"
-
-#~ msgid "Length must be an int"
-#~ msgstr "Länge muss ein int sein"
-
-#~ msgid "Length must be non-negative"
-#~ msgstr "Länge darf nicht negativ sein"
-
-#~ msgid "name reused for argument"
-#~ msgstr "Name für Argumente wiederverwendet"
-
-#~ msgid "object does not support item assignment"
-#~ msgstr "Objekt unterstützt keine item assignment"
-
-#~ msgid "object does not support item deletion"
-#~ msgstr "Objekt unterstützt das Löschen von Elementen nicht"
-
-#~ msgid "object is not subscriptable"
-#~ msgstr "Objekt hat keine '__getitem__'-Methode (not subscriptable)"
-
-#~ msgid "object of type '%q' has no len()"
-#~ msgstr "Object vom Typ '%q' hat kein len()"
-
-#~ msgid "struct: cannot index"
-#~ msgstr "struct: kann nicht indexieren"
-
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "Kann '/' nicht remounten when USB aktiv ist."
-
-#~ msgid "byte code not implemented"
-#~ msgstr "Bytecode nicht implementiert"
-
-#~ msgid "can't pend throw to just-started generator"
-#~ msgstr "Ich kann den Wurf nicht an den gerade gestarteten Generator hängen"
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "ungültiger dupterm index"
-
-#~ msgid "schedule stack full"
-#~ msgstr "Der schedule stack ist voll"
-
-#~ msgid "Corrupt raw code"
-#~ msgstr "Beschädigter raw code"
-
-#~ msgid "can only save bytecode"
-#~ msgstr "kann nur Bytecode speichern"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr "Viper-Funktionen unterstützen derzeit nicht mehr als 4 Argumente"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "Addresse %08x ist nicht an %d bytes ausgerichtet"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "Funktion akzeptiert keine Schlüsselwort-Argumente"
-
-#~ msgid "parameter annotation must be an identifier"
-#~ msgstr "parameter annotation muss ein identifier sein"
-
-#~ msgid "Total data to write is larger than outgoing_packet_length"
-#~ msgstr ""
-#~ "Die Gesamtzahl der zu schreibenden Daten ist größer als "
-#~ "outgoing_packet_length"
-
-#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
-#~ msgstr "IOs 0, 2 & 4 unterstützen keinen internen Pull up im sleep-Modus"
-
-#~ msgid "buffer must be a bytes-like object"
-#~ msgstr "Puffer muss ein bytes-artiges Objekt sein"
-
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr ""
-#~ "Versuch einer Heap Reservierung, wenn die MicroPython-VM nicht ausgeführt "
-#~ "wird."
-
-#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
-#~ msgstr ""
-#~ "MicroPython NLR-Sprung fehlgeschlagen. Wahrscheinlich "
-#~ "Speicherbeschädigung."
-
-#~ msgid "MicroPython fatal error."
-#~ msgstr "Schwerwiegender MicroPython-Fehler."
-
-#~ msgid "argument must be ndarray"
-#~ msgstr "Argument muss ein ndarray sein"
-
-#~ msgid "matrix dimensions do not match"
-#~ msgstr "Matrix Dimensionen stimmen nicht überein"
-
-#~ msgid "vectors must have same lengths"
-#~ msgstr "Vektoren müssen die selbe Länge haben"
-
-#~ msgid "Nordic Soft Device failure assertion."
-#~ msgstr "Fehlerbehauptung für Nordic Soft Device."
-
-#~ msgid "Unknown soft device error: %04x"
-#~ msgstr "Unbekannter Soft Device-Fehler: %04x"
-
-#~ msgid "first argument must be an iterable"
-#~ msgstr "Das erste Argument muss iterierbar sein"
-
-#~ msgid "iterables are not of the same length"
-#~ msgstr "iterables sind nicht gleich lang"
-
-#~ msgid "Selected CTS pin not valid"
-#~ msgstr "Ausgewählter CTS-Pin ungültig"
-
-#~ msgid "Selected RTS pin not valid"
-#~ msgstr "Ausgewählter RTS-Pin ungültig"
-
-#~ msgid "Could not initialize channel"
-#~ msgstr "Kanal konnte nicht initialisiert werden"
-
-#~ msgid "Could not initialize timer"
-#~ msgstr "Timer konnte nicht initialisiert werden"
-
-#~ msgid "Invalid frequency supplied"
-#~ msgstr "Ungültige Frequenz geliefert"
-
-#~ msgid "Invalid pins for PWMOut"
-#~ msgstr "Ungültige Pins für PWMOut"
-
-#~ msgid "No more timers available on this pin."
-#~ msgstr "An diesem Pin sind keine Timer mehr verfügbar."
-
-#~ msgid "Group full"
-#~ msgstr "Gruppe voll"
-
-#~ msgid "bits must be 7, 8 or 9"
-#~ msgstr "bits muss 7, 8 oder 9 sein"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "SDA oder SCL brauchen pull up"
-
-#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
-#~ msgstr ""
-#~ "%d Adress-Pins und %d rgb-Pins zeigen eine Höhe von %d, nicht von %d"
-
-#~ msgid "input argument must be an integer or a 2-tuple"
-#~ msgstr "Das Eingabeargument muss eine Ganzzahl oder ein 2-Tupel sein"
-
-#~ msgid "tuple index out of range"
-#~ msgstr "Tupelindex außerhalb des Bereichs"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Der Code wurde ausgeführt. Warte auf reload.\n"
-
-#~ msgid "Frequency captured is above capability. Capture Paused."
-#~ msgstr ""
-#~ "Die aufgezeichnete Frequenz liegt über der Leistungsgrenze. Aufnahme "
-#~ "angehalten."
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr ""
-#~ "Drücke eine Taste um dich mit der REPL zu verbinden. Drücke Strg-D zum "
-#~ "neu laden."
-
-#~ msgid "arctan2 is implemented for scalars and ndarrays only"
-#~ msgstr "arctan2 ist nur für Skalare und ndarrays implementiert"
-
-#~ msgid "axis must be -1, 0, None, or 1"
-#~ msgstr "Die Achse muss -1, 0, Keine oder 1 sein"
-
-#~ msgid "axis must be -1, 0, or 1"
-#~ msgstr "Die Achse muss -1, 0 oder 1 sein"
-
-#~ msgid "axis must be None, 0, or 1"
-#~ msgstr "Die Achse muss None, 0 oder 1 sein"
-
-#~ msgid "cannot reshape array (incompatible input/output shape)"
-#~ msgstr ""
-#~ "Array kann nicht umgeformt werden (inkompatible Eingabe- / Ausgabeform)"
-
-#~ msgid "could not broadast input array from shape"
-#~ msgstr "Eingabearray konnte nicht aus der Form übertragen werden"
-
-#~ msgid "ddof must be smaller than length of data set"
-#~ msgstr "ddof muss kleiner als die Länge des Datensatzes sein"
-
-#~ msgid "function is implemented for scalars and ndarrays only"
-#~ msgstr "Die Funktion ist nur für Skalare und Ndarrays implementiert"
-
-#~ msgid "n must be between 0, and 9"
-#~ msgstr "n muss zwischen 0 und 9 liegen"
-
-#~ msgid "number of arguments must be 2, or 3"
-#~ msgstr "Die Anzahl der Argumente muss 2 oder 3 sein"
-
-#~ msgid "right hand side must be an ndarray, or a scalar"
-#~ msgstr "Die rechte Seite muss ein Ndarray oder ein Skalar sein"
-
-#~ msgid "shape must be a 2-tuple"
-#~ msgstr "Form muss ein 2-Tupel sein"
-
-#~ msgid "wrong argument type"
-#~ msgstr "falscher Argumenttyp"
-
-#~ msgid ""
-#~ "\n"
-#~ "To exit, please reset the board without "
-#~ msgstr ""
-#~ "\n"
-#~ "Zum Beenden, resete bitte das Board ohne "
-
-#~ msgid "PulseOut not supported on this chip"
-#~ msgstr "PulseOut wird auf diesem Chip nicht unterstützt"
-
-#~ msgid "tuple/list required on RHS"
-#~ msgstr "Tupel / Liste auf RHS erforderlich"
 
 #~ msgid "'%s' object cannot assign attribute '%q'"
 #~ msgstr "Das Objekt '%s' kann das Attribut '%q' nicht zuweisen"
@@ -5915,53 +4614,103 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "'%s' object is not subscriptable"
 #~ msgstr "'%s' Objekt hat keine '__getitem__'-Methode (not subscriptable)"
 
-#~ msgid "Invalid I2C pin selection"
-#~ msgstr "Ungültige I2C-Pinauswahl"
-
-#~ msgid "Invalid SPI pin selection"
-#~ msgstr "Ungültige SPI-Pin-Auswahl"
-
-#~ msgid "Invalid UART pin selection"
-#~ msgstr "Ungültige UART-Pinauswahl"
-
-#~ msgid "Pop from an empty Ps2 buffer"
-#~ msgstr "Pop aus einem leeren Ps2-Puffer"
-
-#~ msgid "Running in safe mode! Auto-reload is off.\n"
-#~ msgstr "Sicherheitsmodus aktiv! Automatisches Neuladen ist deaktiviert.\n"
-
-#~ msgid "can't convert address to int"
-#~ msgstr "kann Adresse nicht in int konvertieren"
-
-#~ msgid "object '%s' is not a tuple or list"
-#~ msgstr "Objekt '%s' ist weder tupel noch list"
-
-#~ msgid "pop from an empty set"
-#~ msgstr "pop von einer leeren Menge (set)"
-
-#~ msgid "pop from empty list"
-#~ msgstr "pop von einer leeren Liste"
-
-#~ msgid "popitem(): dictionary is empty"
-#~ msgstr "popitem(): dictionary ist leer"
-
-#~ msgid "unknown format code '%c' for object of type '%s'"
-#~ msgstr "unbekannter Formatcode '%c' für Objekt vom Typ '%s'"
-
-#~ msgid "unsupported types for %q: '%s', '%s'"
-#~ msgstr "nicht unterstützte Typen für %q: '%s', '%s'"
-
 #~ msgid "'async for' or 'async with' outside async function"
 #~ msgstr "'async for' oder 'async with' außerhalb der asynchronen Funktion"
 
-#~ msgid "PulseIn not supported on this chip"
-#~ msgstr "PulseIn wird auf diesem Chip nicht unterstützt"
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr ""
+#~ "'await', 'async for' oder 'async with' außerhalb einer async Funktion"
+
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' außerhalb einer Schleife"
+
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' außerhalb einer Schleife"
+
+#~ msgid "'coroutine' object is not an iterator"
+#~ msgstr "'coroutine' Objekt ist kein Iterator"
+
+#~ msgid "(x,y) integers required"
+#~ msgstr "(x,y) Integer benötigt"
+
+#~ msgid "64 bit types"
+#~ msgstr "64 bit-Typen"
+
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "ADC2 wird vom WiFi benutzt"
 
 #~ msgid "AP required"
 #~ msgstr "AP erforderlich"
 
 #~ msgid "Address is not %d bytes long or is in wrong format"
 #~ msgstr "Die Adresse ist nicht %d Bytes lang oder das Format ist falsch"
+
+#~ msgid "Address type out of range"
+#~ msgstr "Adresstyp außerhalb des zulässigen Bereichs"
+
+#~ msgid "All I2C targets are in use"
+#~ msgstr "Alle I2C-Ziele sind in Verwendung"
+
+#~ msgid "AnalogIn not supported on given pin"
+#~ msgstr "AnalogIn ist an diesem Pin nicht unterstützt"
+
+#~ msgid "AnalogOut functionality not supported"
+#~ msgstr "AnalogOut-Funktion wird nicht unterstützt"
+
+#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#~ msgstr "AnalogOut kann nur 16 Bit. Der Wert muss unter 65536 liegen."
+
+#~ msgid "AnalogOut not supported on given pin"
+#~ msgstr "AnalogOut ist an diesem Pin nicht unterstützt"
+
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "Es darf höchstens %d %q spezifiziert werden (nicht %d)"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr ""
+#~ "Versuch einer Heap Reservierung, wenn die MicroPython-VM nicht ausgeführt "
+#~ "wird."
+
+#~ msgid "Attempted heap allocation when VM not running."
+#~ msgstr "Versuchte Heap-Zuordnung wenn VM nicht läuft."
+
+#~ msgid "Bit clock and word select must be sequential pins"
+#~ msgstr "Bit clock und word select müssen geordnete Pins sein"
+
+#, c-format
+#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
+#~ msgstr "Bittiefe muss zwischen 1 und 6 liegen, nicht %d"
+
+#~ msgid "Boot device must be first device (interface #0)."
+#~ msgstr "Boot-Gerät muss erstes Gerät sein (interface #0)."
+
+#~ msgid "Both buttons were pressed at start up.\n"
+#~ msgstr "Beim Starten wurden beide Tasten gedrückt.\n"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "Die Helligkeit muss zwischen 0 und 1.0 liegen"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "Die Helligkeit muss zwischen 0 und 255 liegen"
+
+#, c-format
+#~ msgid "Buffer incorrect size. Should be %d bytes."
+#~ msgstr "Der Puffergröße ist inkorrekt. Sie sollte %d bytes haben."
+
+#~ msgid "Buffer is too small"
+#~ msgstr "Der Puffer ist zu klein"
+
+#~ msgid "Buffer must be at least length 1"
+#~ msgstr "Der Puffer muss eine Mindestenslänge von 1 haben"
+
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "Puffer zu groß und kann nicht reserviert werden"
+
+#~ msgid "Button A was pressed at start up.\n"
+#~ msgstr "Beim Starten wurde Taste A gedrückt.\n"
+
+#~ msgid "Bytes must be between 0 and 255."
+#~ msgstr "Ein Bytes kann nur Werte zwischen 0 und 255 annehmen."
 
 #~ msgid "C-level assert"
 #~ msgstr "C-Level Assert"
@@ -5987,11 +4736,35 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "Cannot disconnect from AP"
 #~ msgstr "Kann nicht trennen von AP"
 
+#~ msgid "Cannot output both channels on the same pin"
+#~ msgstr "Kann nicht beite Kanäle auf dem gleichen Pin ausgeben"
+
+#~ msgid "Cannot read without MISO pin."
+#~ msgstr "Kann ohne MISO-Pin nicht lesen."
+
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "Kann '/' nicht remounten when USB aktiv ist."
+
+#~ msgid "Cannot reset into bootloader because no bootloader is present."
+#~ msgstr "Reset zum Bootloader nicht möglich, da Bootloader nicht vorhanden."
+
 #~ msgid "Cannot set STA config"
 #~ msgstr "Kann STA Konfiguration nicht setzen"
 
+#~ msgid "Cannot transfer without MOSI and MISO pins"
+#~ msgstr "Kann nicht ohne MISO und MOSI Pins transferieren"
+
+#~ msgid "Cannot transfer without MOSI and MISO pins."
+#~ msgstr "Übertragung ohne MOSI- und MISO-Pins nicht möglich."
+
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "sizeof scalar kann nicht eindeutig bestimmt werden"
+
 #~ msgid "Cannot update i/f status"
 #~ msgstr "Kann i/f Status nicht updaten"
+
+#~ msgid "Cannot write without MOSI pin."
+#~ msgstr "Kann nicht ohne MOSI-Pin schreiben."
 
 #~ msgid "Characteristic UUID doesn't match Service UUID"
 #~ msgstr "Characteristic UUID stimmt nicht mit der Service-UUID überein"
@@ -5999,17 +4772,88 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "Characteristic already in use by another Service."
 #~ msgstr "Characteristic wird bereits von einem anderen Dienst verwendet."
 
+#~ msgid ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+#~ msgstr ""
+#~ "CircuitPython befindet sich im abgesicherten Modus, da Sie beim Booten "
+#~ "die Reset-Taste gedrückt haben. Drücken Sie erneut, um den abgesicherten "
+#~ "Modus zu verlassen.\n"
+
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "CircuitPython war es nicht möglich heap-Speicher zu allozieren."
+
+#~ msgid "Clock pin init failed."
+#~ msgstr "Clock pin init fehlgeschlagen."
+
+#~ msgid "Column entry must be digitalio.DigitalInOut"
+#~ msgstr "Spalteneintrag muss digitalio.DigitalInOut sein"
+
 #~ msgid "Command must be 0-255"
 #~ msgstr "Der Befehl muss zwischen 0 und 255 liegen"
+
+#~ msgid "Command must be an int between 0 and 255"
+#~ msgstr "Der Befehl muss ein int zwischen 0 und 255 sein"
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "Beschädigte .mpy Datei"
+
+#~ msgid "Corrupt raw code"
+#~ msgstr "Beschädigter raw code"
 
 #~ msgid "Could not decode ble_uuid, err 0x%04x"
 #~ msgstr "Konnte ble_uuid nicht decodieren. Status: 0x%04x"
 
+#~ msgid "Could not initialize Camera"
+#~ msgstr "Konnte Kamera nicht initialisieren"
+
+#~ msgid "Could not initialize GNSS"
+#~ msgstr "GNSS konnte nicht initialisiert werden"
+
+#~ msgid "Could not initialize SDCard"
+#~ msgstr "Konnte SDKarte nicht initialisieren"
+
+#~ msgid "Could not initialize UART"
+#~ msgstr "Konnte UART nicht initialisieren"
+
+#~ msgid "Could not initialize channel"
+#~ msgstr "Kanal konnte nicht initialisiert werden"
+
+#~ msgid "Could not initialize timer"
+#~ msgstr "Timer konnte nicht initialisiert werden"
+
+#~ msgid "Could not re-init channel"
+#~ msgstr "Kanal konnte nicht neu initiiert werden"
+
+#~ msgid "Could not re-init timer"
+#~ msgstr "Timer konnte nicht neu gestartet werden"
+
+#~ msgid "Could not restart PWM"
+#~ msgstr "PWM konnte nicht neu gestartet werden"
+
+#~ msgid "Couldn't allocate first buffer"
+#~ msgstr "Konnte first buffer nicht zuteilen"
+
+#~ msgid "Couldn't allocate input buffer"
+#~ msgstr "Eingabepuffer konnte nicht zugewiesen werden"
+
+#~ msgid "Couldn't allocate second buffer"
+#~ msgstr "Konnte second buffer nicht zuteilen"
+
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "Absturz in den HardFault_Handler."
+
 #~ msgid "Crash into the HardFault_Handler.\n"
 #~ msgstr "Absturz in HardFault_Handler.\n"
 
+#~ msgid "Data 0 pin must be byte aligned."
+#~ msgstr "Data 0 Pin muss Byte aligned sein."
+
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Daten sind zu groß für das advertisement packet"
+
+#~ msgid "DigitalInOut not supported on given pin"
+#~ msgstr "DigitalInOut wird auf dem angegebenen Pin nicht unterstützt"
 
 #~ msgid "Don't know how to pass object to native function"
 #~ msgstr ""
@@ -6021,11 +4865,49 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "ESP8266 does not support pull down."
 #~ msgstr "ESP8266 unterstützt pull down nicht"
 
+#, c-format
+#~ msgid "Error in MIDI stream at position %d"
+#~ msgstr "Fehler in MIDI Datenstrom um Position %d"
+
 #~ msgid "Error in ffi_prep_cif"
 #~ msgstr "Fehler in ffi_prep_cif"
 
+#~ msgid "Expected a %q"
+#~ msgstr "Erwartet ein(e) %q"
+
+#~ msgid "Expected a %q or %q"
+#~ msgstr "Erwartete ein %q oder %q"
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Characteristic wird erwartet"
+
+#~ msgid "Expected a DigitalInOut"
+#~ msgstr "DigitanInOut wird erwartet"
+
 #~ msgid "Expected a Peripheral"
 #~ msgstr "Ein Peripheriegerät wird erwartet"
+
+#~ msgid "Expected a Service"
+#~ msgstr "Ein Service wird erwartet"
+
+#~ msgid "Expected a UART"
+#~ msgstr "UART wird erwartet"
+
+#~ msgid "Expected a UUID"
+#~ msgstr "Eine UUID wird erwartet"
+
+#~ msgid "Expected an %q"
+#~ msgstr "Erwartet ein %q"
+
+#~ msgid "Expected an Address"
+#~ msgstr "Erwartet eine Adresse"
+
+#~ msgid "Expected an alarm"
+#~ msgstr "Alarm erwartet"
+
+#, c-format
+#~ msgid "Expected tuple of length %d, got %d"
+#~ msgstr "Habe ein Tupel der Länge %d erwartet aber %d erhalten"
 
 #~ msgid "Failed to acquire mutex"
 #~ msgstr "Akquirieren des Mutex gescheitert"
@@ -6041,6 +4923,13 @@ msgstr "zi muss die Form (n_section, 2) haben"
 
 #~ msgid "Failed to add service, err 0x%04x"
 #~ msgstr "Dienst konnte nicht hinzugefügt werden. Status: 0x%04x"
+
+#~ msgid "Failed to allocate RX buffer"
+#~ msgstr "Konnte keinen RX Buffer allozieren"
+
+#, c-format
+#~ msgid "Failed to allocate RX buffer of %d bytes"
+#~ msgstr "Konnte keine RX Buffer mit %d allozieren"
 
 #~ msgid "Failed to change softdevice state"
 #~ msgstr "Fehler beim Ändern des Softdevice-Status"
@@ -6065,6 +4954,9 @@ msgstr "zi muss die Form (n_section, 2) haben"
 
 #~ msgid "Failed to get softdevice state"
 #~ msgstr "Fehler beim Abrufen des Softdevice-Status"
+
+#~ msgid "Failed to init wifi"
+#~ msgstr "Wifi Initialisierung ist fehlgeschlagen"
 
 #~ msgid "Failed to notify or indicate attribute value, err %0x04x"
 #~ msgstr "Kann den Attributwert nicht mitteilen. Status: 0x%04x"
@@ -6126,6 +5018,24 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "Failed to write gatts value, err 0x%04x"
 #~ msgstr "gatts value konnte nicht geschrieben werden. Status: 0x%04x"
 
+#~ msgid "Fatal error."
+#~ msgstr "Fataler Fehler."
+
+#~ msgid "Fault detected by hardware."
+#~ msgstr "Hardware hat Fehler festgestellt."
+
+#~ msgid "Firmware image is invalid"
+#~ msgstr "Firmware Image ist ungültig"
+
+#, c-format
+#~ msgid "Framebuffer requires %d bytes"
+#~ msgstr "Framepuffer benötigt %d bytes"
+
+#~ msgid "Frequency captured is above capability. Capture Paused."
+#~ msgstr ""
+#~ "Die aufgezeichnete Frequenz liegt über der Leistungsgrenze. Aufnahme "
+#~ "angehalten."
+
 #~ msgid "Function requires lock."
 #~ msgstr ""
 #~ "Die Funktion erwartet, dass der 'lock'-Befehl zuvor ausgeführt wurde"
@@ -6133,17 +5043,192 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "GPIO16 does not support pull up."
 #~ msgstr "GPIO16 unterstützt pull up nicht"
 
+#~ msgid "Group full"
+#~ msgstr "Gruppe voll"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Hardware beschäftigt, versuche alternative Pins"
+
+#~ msgid "Hostname must be between 1 and 253 characters"
+#~ msgstr "Der Hostname muss zwischen 1 und 253 Zeichen haben"
+
+#~ msgid "I2C Init Error"
+#~ msgstr "I2C-Init-Fehler"
+
 #~ msgid "I2C operation not supported"
 #~ msgstr "I2C-operation nicht unterstützt"
 
+#~ msgid "I2SOut not available"
+#~ msgstr "I2SOut nicht verfügbar"
+
+#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
+#~ msgstr "IOs 0, 2 & 4 unterstützen keinen internen Pull up im sleep-Modus"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IV muss %d Bytes lang sein"
+
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "Inkompatible .mpy-Datei. Bitte aktualisiere alle .mpy-Dateien. Siehe "
+#~ "http://adafru.it/mpy-update für weitere Informationen."
+
+#~ msgid "Initialization failed due to lack of memory"
+#~ msgstr "Initialisierung aufgrund von Speichermangel fehlgeschlagen"
+
+#~ msgid "Instruction %d jumps on pin"
+#~ msgstr "Instruktion %d springt auf Pin"
+
+#, c-format
+#~ msgid "Instruction %d shifts in more bits than pin count"
+#~ msgstr "Anweisung %d verschiebt mehr Bits als die Anzahl der Pins"
+
+#, c-format
+#~ msgid "Instruction %d shifts out more bits than pin count"
+#~ msgstr "Der Befehl %d verschiebt mehr Bits als die Anzahl der Pins"
+
+#, c-format
+#~ msgid "Instruction %d uses extra pin"
+#~ msgstr "Instruktion %d benötigt extra Pin"
+
+#, c-format
+#~ msgid "Instruction %d waits on input outside of count"
+#~ msgstr "Anweisung %d wartet auf Eingaben außerhalb der vorhandenen Anzahl"
+
+#~ msgid "Invalid %q pin selection"
+#~ msgstr "Ungültige %q Pin-Auswahl"
+
+#~ msgid "Invalid AuthMode"
+#~ msgstr "Ungültiges AuthMode"
+
+#~ msgid "Invalid BMP file"
+#~ msgstr "Ungültige BMP-Datei"
+
+#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
+#~ msgstr "Ungültiger Wert CIRCUITPY_PYSTACK_SIZE\n"
+
+#~ msgid "Invalid DAC pin supplied"
+#~ msgstr "Ungültiger DAC-Pin angegeben"
+
+#~ msgid "Invalid I2C pin selection"
+#~ msgstr "Ungültige I2C-Pinauswahl"
+
+#~ msgid "Invalid MIDI file"
+#~ msgstr "Ungültige MIDI Datei"
+
+#~ msgid "Invalid PWM frequency"
+#~ msgstr "Ungültige PWM Frequenz"
+
+#~ msgid "Invalid Pin"
+#~ msgstr "Ungültiger Pin"
+
+#~ msgid "Invalid SPI pin selection"
+#~ msgstr "Ungültige SPI-Pin-Auswahl"
+
+#~ msgid "Invalid UART pin selection"
+#~ msgstr "Ungültige UART-Pinauswahl"
+
 #~ msgid "Invalid bit clock pin"
 #~ msgstr "Ungültiges bit clock pin"
+
+#~ msgid "Invalid buffer size"
+#~ msgstr "Ungültige Puffergröße"
+
+#~ msgid "Invalid byteorder string"
+#~ msgstr "Ungültige Byteorder-String"
+
+#~ msgid "Invalid capture period. Valid range: 1 - 500"
+#~ msgstr "Ungültiger Aufnahmezeitraum. Gültiger Bereich: 1 - 500"
+
+#~ msgid "Invalid channel count"
+#~ msgstr "Ungültige Anzahl von Kanälen"
 
 #~ msgid "Invalid clock pin"
 #~ msgstr "Ungültiger clock pin"
 
 #~ msgid "Invalid data pin"
 #~ msgstr "Ungültiger data pin"
+
+#, c-format
+#~ msgid "Invalid data_count %d"
+#~ msgstr "Ungültiger data_count %d"
+
+#~ msgid "Invalid direction."
+#~ msgstr "Ungültige Richtung."
+
+#~ msgid "Invalid file"
+#~ msgstr "Ungültige Datei"
+
+#~ msgid "Invalid frequency"
+#~ msgstr "Ungültige Frequenz"
+
+#~ msgid "Invalid frequency supplied"
+#~ msgstr "Ungültige Frequenz geliefert"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "Ungültiger Speicherzugriff."
+
+#~ msgid "Invalid mode"
+#~ msgstr "Ungültiger Modus"
+
+#~ msgid "Invalid number of bits"
+#~ msgstr "Ungültige Anzahl von Bits"
+
+#~ msgid "Invalid phase"
+#~ msgstr "Ungültige Phase"
+
+#~ msgid "Invalid pin"
+#~ msgstr "Ungültiger Pin"
+
+#~ msgid "Invalid pin for left channel"
+#~ msgstr "Ungültiger Pin für linken Kanal"
+
+#~ msgid "Invalid pin for right channel"
+#~ msgstr "Ungültiger Pin für rechten Kanal"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Ungültige Pins"
+
+#~ msgid "Invalid pins for PWMOut"
+#~ msgstr "Ungültige Pins für PWMOut"
+
+#~ msgid "Invalid polarity"
+#~ msgstr "Ungültige Polarität"
+
+#~ msgid "Invalid properties"
+#~ msgstr "Ungültige Eigenschaften"
+
+#~ msgid "Invalid run mode."
+#~ msgstr "Ungültiger Ausführungsmodus."
+
+#~ msgid "Invalid security_mode"
+#~ msgstr "Ungültiger security_mode"
+
+#~ msgid "Invalid voice"
+#~ msgstr "Ungültige Stimme"
+
+#~ msgid "Invalid voice count"
+#~ msgstr "Ungültige Anzahl von Stimmen"
+
+#~ msgid "Invalid wave file"
+#~ msgstr "Ungültige wave Datei"
+
+#~ msgid "Invalid word/bit length"
+#~ msgstr "Ungültige Wort- / Bitlänge"
+
+#~ msgid "Layer already in a group."
+#~ msgstr "Layer ist bereits in einer Gruppe."
+
+#~ msgid "Layer must be a Group or TileGrid subclass."
+#~ msgstr "Layer muss eine Group- oder TileGrid-Unterklasse sein."
+
+#~ msgid "Length must be an int"
+#~ msgstr "Länge muss ein int sein"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Länge darf nicht negativ sein"
 
 #~ msgid ""
 #~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
@@ -6155,19 +5240,78 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ "issues\n"
 #~ "mit dem Inhalt deines CIRCUITPY-Laufwerks und dieser Nachricht:\n"
 
+#~ msgid "MISO pin init failed."
+#~ msgstr "MISO pin Initialisierung fehlgeschlagen."
+
+#~ msgid "MOSI pin init failed."
+#~ msgstr "MOSI pin Initialisierung fehlgeschlagen."
+
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "Maximale PWM Frequenz ist %dHz"
+
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "Maximaler x-Wert beim Spiegeln ist %d"
+
+#~ msgid "Messages limited to 8 bytes"
+#~ msgstr "Meldungen auf 8 Bytes limitiert"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgstr ""
+#~ "MicroPython NLR-Sprung fehlgeschlagen. Wahrscheinlich "
+#~ "Speicherbeschädigung."
 
 #~ msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
 #~ msgstr ""
 #~ "MicroPython-NLR-Sprung ist fehlgeschlagen. Wahrscheinlich "
 #~ "Speicherbeschädigung.\n"
 
+#~ msgid "MicroPython fatal error."
+#~ msgstr "Schwerwiegender MicroPython-Fehler."
+
 #~ msgid "MicroPython fatal error.\n"
 #~ msgstr "Schwerwiegender MicroPython-Fehler\n"
 
 #~ msgid "Minimum PWM frequency is 1hz."
 #~ msgstr "Minimale PWM Frequenz ist %dHz"
+
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "Fehlender MISO- oder MOSI-Pin"
+
+#~ msgid "Missing MISO or MOSI pin"
+#~ msgstr "MISO oder MOSI Pin fehlt"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
+#~ msgstr "Fehlender first_in_pin. Instruktion %d liest Pin(s)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
+#~ msgstr "Fehlende first_in_pin. Anweisung %d verschiebt sich um Pin(s)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
+#~ msgstr "Fehlende first_in_pin. Anweisung %d wartet basierend auf Pin"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
+#~ msgstr "First_out_pin fehlt. Befehl %d verschiebt sich zu Pin(s)"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
+#~ msgstr "Fehlender first_out_pin. Instruktion %d schreibt Pin(s)"
+
+#, c-format
+#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+#~ msgstr "Fehlender first_set_pin. Instruktion %d setzt Pin(s)"
+
+#, c-format
+#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
+#~ msgstr "jmp_pin fehlt. Befehl %d springt auf Pin"
+
+#, c-format
+#~ msgid "More than %d report ids not supported"
+#~ msgstr "Mehr als %d Berichts-IDs werden nicht unterstützt"
 
 #~ msgid "Multiple PWM frequencies not supported. PWM already set to %dhz."
 #~ msgstr ""
@@ -6177,14 +5321,63 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "Negative step not supported"
 #~ msgstr "Negativer Schritt wird nicht unterstützt"
 
+#~ msgid "No MISO Pin"
+#~ msgstr "Kein MISO-Pin"
+
+#~ msgid "No MISO pin"
+#~ msgstr "Miso Pin fehlt"
+
+#~ msgid "No MOSI Pin"
+#~ msgstr "Kein MOSI-Pin"
+
+#~ msgid "No MOSI pin"
+#~ msgstr "MOSI Pin fehlt"
+
 #~ msgid "No PulseIn support for %q"
 #~ msgstr "Keine PulseIn Unterstützung für %q"
+
+#~ msgid "No RX pin"
+#~ msgstr "Kein RX-Pin"
+
+#~ msgid "No TX pin"
+#~ msgstr "Kein TX-Pin"
 
 #~ msgid "No hardware support for analog out."
 #~ msgstr "Keine Hardwareunterstützung für analog out"
 
+#~ msgid "No hardware support on clk pin"
+#~ msgstr "Keine Hardwareunterstützung am clk Pin"
+
+#~ msgid "No hardware support on pin"
+#~ msgstr "Keine Hardwareunterstützung an diesem Pin"
+
+#~ msgid "No key was specified"
+#~ msgstr "Es wurde kein Schlüssel angegeben"
+
+#, c-format
+#~ msgid "No more than %d HID devices allowed"
+#~ msgstr "Keine weiteren %d HID-Geräte zulässig"
+
+#~ msgid "No more timers available on this pin."
+#~ msgstr "An diesem Pin sind keine Timer mehr verfügbar."
+
+#~ msgid "Nordic Soft Device failure assertion."
+#~ msgstr "Fehlerbehauptung für Nordic Soft Device."
+
+#~ msgid "Nordic system firmware failure assertion."
+#~ msgstr "Nordic System-Firmware Fehler Assertion."
+
 #~ msgid "Not connected."
 #~ msgstr "Nicht verbunden."
+
+#~ msgid "Not running saved code.\n"
+#~ msgstr "Gespeicherter Code wird nicht ausgeführt.\n"
+
+#~ msgid "Not settable"
+#~ msgstr "Kann nicht gesetzt werden"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Nur 8 oder 16 bit mono mit "
 
 #~ msgid "Only Windows format, uncompressed BMP supported %d"
 #~ msgstr "Nur unkomprimiertes Windows-Format (BMP) unterstützt %d"
@@ -6194,14 +5387,40 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ "Es werden nur Bitmaps mit einer Farbtiefe von 8 Bit oder weniger "
 #~ "unterstützt"
 
+#~ msgid "Only one TouchAlarm can be set in deep sleep."
+#~ msgstr "Nur ein TouchAlarm kann in Deep Sleep gesetzt werden."
+
 #~ msgid "Only tx supported on UART1 (GPIO2)."
 #~ msgstr "UART1 (GPIO2) unterstützt nur tx"
+
+#, c-format
+#~ msgid "Output buffer must be at least %d bytes"
+#~ msgstr "Ausgabe-Buffer muss mindestens %d Bytes sein"
+
+#~ msgid "PDMIn not available"
+#~ msgstr "PDMIn nicht verfügbar"
+
+#~ msgid ""
+#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
+#~ msgstr "PWM duty_cycle muss zwischen 0 und 65535 (16 Bit-Auflösung) liegen"
 
 #~ msgid "PWM not supported on pin %d"
 #~ msgstr "PWM nicht unterstützt an Pin %d"
 
+#~ msgid "ParallelBus not yet supported"
+#~ msgstr "ParallelBus wird noch nicht unterstützt"
+
 #~ msgid "Pin %q does not have ADC capabilities"
 #~ msgstr "Pin %q hat keine ADC Funktion"
+
+#~ msgid "Pin count must be at least 1"
+#~ msgstr "Pin-Anzahl muss mindestens 1 sein"
+
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "Pin hat keine ADC-Funktionalität"
+
+#~ msgid "Pin number already reserved by EXTI"
+#~ msgstr "PIN-Nummer bereits von EXTI reserviert"
 
 #~ msgid "Pin(16) doesn't support pull"
 #~ msgstr "Pin(16) unterstützt kein pull"
@@ -6212,14 +5431,115 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "Pixel beyond bounds of buffer"
 #~ msgstr "Pixel außerhalb der Puffergrenzen"
 
+#~ msgid "Pop from an empty Ps2 buffer"
+#~ msgstr "Pop aus einem leeren Ps2-Puffer"
+
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+#~ msgstr ""
+#~ "Drücke eine Taste um dich mit der REPL zu verbinden. Drücke Strg-D zum "
+#~ "neu laden."
+
+#~ msgid "Program must contain at least one 16-bit instruction."
+#~ msgstr "Programm muss mindestens eine 16-Bit-Instruktion enthalten."
+
+#~ msgid "Program too large"
+#~ msgstr "Das Programm ist zu groß"
+
+#~ msgid "PulseIn not supported on this chip"
+#~ msgstr "PulseIn wird auf diesem Chip nicht unterstützt"
+
+#~ msgid "PulseOut not supported on this chip"
+#~ msgstr "PulseOut wird auf diesem Chip nicht unterstützt"
+
+#~ msgid "RAISE mode is not implemented"
+#~ msgstr "RAISE-Modus ist nicht implementiert"
+
+#~ msgid "RS485 Not yet supported on this device"
+#~ msgstr "RS485 wird von diesem Gerät nicht unterstützt"
+
+#~ msgid "RTC calibration is not supported on this board"
+#~ msgstr "Die RTC-Kalibrierung wird auf diesem Board nicht unterstützt"
+
+#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
+#~ msgstr "RTS / CTS / RS485 Wird von diesem Gerät noch nicht unterstützt"
+
 #~ msgid "Range out of bounds"
 #~ msgstr "Bereich außerhalb der Grenzen"
+
+#~ msgid "Read-only object"
+#~ msgstr "Schreibgeschützte Objekt"
+
+#~ msgid "Row entry must be digitalio.DigitalInOut"
+#~ msgstr "Zeileneintrag muss ein digitalio.DigitalInOut sein"
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Sicherheitsmodus aktiv! Automatisches Neuladen ist deaktiviert.\n"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "SDA oder SCL brauchen pull up"
+
+#~ msgid "SPI Init Error"
+#~ msgstr "SPI-Init-Fehler"
+
+#~ msgid "SPI Re-initialization error"
+#~ msgstr "SPI-Neuinitialisierungsfehler"
 
 #~ msgid "STA must be active"
 #~ msgstr "STA muss aktiv sein"
 
 #~ msgid "STA required"
 #~ msgstr "STA erforderlich"
+
+#~ msgid "Sample rate must be positive"
+#~ msgstr "Abtastrate muss positiv sein"
+
+#, c-format
+#~ msgid "Sample rate too high. It must be less than %d"
+#~ msgstr "Abtastrate zu hoch. Wert muss unter %d liegen"
+
+#~ msgid "Scan already in progess. Stop with stop_scan."
+#~ msgstr "Scannen bereits in Bearbeitung. Stoppe mit stop_scan."
+
+#~ msgid "Selected CTS pin not valid"
+#~ msgstr "Ausgewählter CTS-Pin ungültig"
+
+#~ msgid "Selected RTS pin not valid"
+#~ msgstr "Ausgewählter RTS-Pin ungültig"
+
+#~ msgid "Set pin count must be between 1 and 5"
+#~ msgstr "Die Anzahl der Pins muss zwischen 1 und 5 liegen"
+
+#~ msgid "Side set pin count must be between 1 and 5"
+#~ msgstr "Die Anzahl der Pins für Side set muss zwischen 1 und 5 liegen"
+
+#~ msgid "Sleep Memory not available"
+#~ msgstr "Sleep-Speicher nicht verfügbar"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Splitting mit sub-captures"
+
+#~ msgid "Stack size must be at least 256"
+#~ msgstr "Die Stackgröße sollte mindestens 256 sein"
+
+#~ msgid "Stopping AP is not supported."
+#~ msgstr "Das Stoppen des AP wird nicht unterstützt."
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "Stream fehlt readinto() oder write() Methode."
+
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "Gib mindestens einen UART-Pin an"
+
+#~ msgid "The BOOT button was pressed at start up.\n"
+#~ msgstr "Beim Starten wurde die Taste BOOT gedrückt.\n"
+
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Increase the stack size if you know how. If not:"
+#~ msgstr ""
+#~ "Der Heap von CircuitPython wurde beschädigt, weil der Stack zu klein "
+#~ "war.\n"
+#~ "Vergrößere den Stack, wenn du weißt, wie. Wenn nicht:"
 
 #~ msgid ""
 #~ "The CircuitPython heap was corrupted because the stack was too small.\n"
@@ -6236,6 +5556,59 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ "mit dem Inhalt deines CIRCUITPY-Laufwerks.\n"
 
 #~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase the stack size if you know how, or if not:"
+#~ msgstr ""
+#~ "Der CircuitPython-Heap wurde beschädigt, weil der Stapel zu klein war.\n"
+#~ "Bitte erhöhen Sie die Stapelgröße, wenn Sie wissen wie oder wenn nicht:"
+
+#~ msgid "The SW38 button was pressed at start up.\n"
+#~ msgstr "Beim Starten wurde die Taste SW38 gedrückt.\n"
+
+#~ msgid "The VOLUME button was pressed at start up.\n"
+#~ msgstr "Beim Starten wurde die Taste VOLUME gedrückt.\n"
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode."
+#~ msgstr ""
+#~ "Das Modul `microcontroller` wurde zum Booten in den abgesicherten Modus "
+#~ "verwendet. Drücke Reset, um den abgesicherten Modus zu verlassen."
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode.\n"
+#~ msgstr ""
+#~ "Das `Mikrocontroller` Modul wurde benutzt, um in den Sicherheitsmodus zu "
+#~ "starten. Drücke Reset um den Sicherheitsmodus zu verlassen.\n"
+
+#~ msgid "The central button was pressed at start up.\n"
+#~ msgstr "Beim Starten wurde die zentrale Taste gedrückt.\n"
+
+#~ msgid "The left button was pressed at start up.\n"
+#~ msgstr "Beim Starten wurde die linke Taste gedrückt.\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY)."
+#~ msgstr ""
+#~ "Der Mikrocontroller hatte einen Stromausfall. Vergewisser dich, dass die\n"
+#~ "Stromversorgung genügend Strom für die gesamte Schaltung liefert und\n"
+#~ "drücke Reset (nach dem Auswerfen von CIRCUITPY)."
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "Die Spannungsversorgung des Mikrocontrollers hat den minimal Wert "
+#~ "unterschritten.\n"
+#~ "Stellen Sie sicher, dass Ihr Netzteil genug Strom bereitstellt für den "
+#~ "gesamten Stromkreis und drücken Sie Reset (nach dem Auswerfen von "
+#~ "CIRCUITPY).\n"
+
+#~ msgid ""
 #~ "The microcontroller's power dipped. Please make sure your power supply "
 #~ "provides\n"
 #~ "enough power for the whole circuit and press reset (after ejecting "
@@ -6246,6 +5619,11 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ "Verfügung stellt und drücke die Reset-Taste (nach Auswurf des CIRCUITPY-"
 #~ "Laufwerks)\n"
 
+#~ msgid "The power dipped. Make sure you are providing enough power."
+#~ msgstr ""
+#~ "Die Spannung ist eingebrochen. Stelle sicher, dass genügend Leistung "
+#~ "verfügbar ist."
+
 #~ msgid ""
 #~ "The reset button was pressed while booting CircuitPython. Press again to "
 #~ "exit safe mode.\n"
@@ -6253,27 +5631,156 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ "Die Reset-Taste wurde beim Booten von CircuitPython gedrückt. Drücke sie "
 #~ "erneut um den abgesicherten Modus zu verlassen. \n"
 
+#~ msgid "Tile value out of bounds"
+#~ msgstr "Kachelwert außerhalb der Grenzen"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Zum beenden, resette bitte das board ohne "
+
+#~ msgid "To exit, please reset the board without requesting safe mode."
+#~ msgstr ""
+#~ "Zum Beenden setze bitte das Board zurück, ohne den abgesicherten Modus "
+#~ "aufzurufen."
+
+#~ msgid "Too many display busses"
+#~ msgstr "Zu viele Anzeigebusse"
+
+#~ msgid "Total data to write is larger than outgoing_packet_length"
+#~ msgstr ""
+#~ "Die Gesamtzahl der zu schreibenden Daten ist größer als "
+#~ "outgoing_packet_length"
+
+#~ msgid "UART Buffer allocation error"
+#~ msgstr "UART Buffer reservierungs Fehler"
+
+#~ msgid "UART De-init error"
+#~ msgstr "UART De-Init-Fehler"
+
+#~ msgid "UART Init Error"
+#~ msgstr "UART Init Fehler"
+
+#~ msgid "UART Re-init error"
+#~ msgstr "UART Re-Init-Fehler"
+
+#~ msgid "UART write error"
+#~ msgstr "UART-Schreibfehler"
+
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) existiert nicht"
 
 #~ msgid "UART(1) can't read"
 #~ msgstr "UART(1) kann nicht lesen"
 
+#~ msgid "USB Busy"
+#~ msgstr "USB beschäftigt"
+
+#~ msgid "USB Error"
+#~ msgstr "USB Fehler"
+
 #~ msgid "UUID integer value not in range 0 to 0xffff"
 #~ msgstr "UUID-Integer nicht im Bereich 0 bis 0xffff"
+
+#~ msgid "Unable to allocate the heap."
+#~ msgstr "Keine Allokation auf dem Heap möglich."
+
+#, c-format
+#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
+#~ msgstr "ADC-DMA-Controller konnte nicht konfiguriert werden, Fehlercode: %d"
+
+#, c-format
+#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
+#~ msgstr ""
+#~ "ADC-DMA-Controller konnte nicht initialisiert werden, Fehlercode: %d"
 
 #~ msgid "Unable to remount filesystem"
 #~ msgstr "Dateisystem konnte nicht wieder eingebunden werden."
 
+#, c-format
+#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
+#~ msgstr "ADC-DMA-Controller konnte nicht gestartet werden, Fehlercode: %d"
+
+#~ msgid "Unable to write"
+#~ msgstr "Schreiben nicht möglich"
+
+#~ msgid "Unable to write to address."
+#~ msgstr "An die Adresse kann nicht geschrieben werden."
+
+#~ msgid "Unknown soft device error: %04x"
+#~ msgstr "Unbekannter Soft Device-Fehler: %04x"
+
 #~ msgid "Unknown type"
 #~ msgstr "Unbekannter Typ"
+
+#, c-format
+#~ msgid "Unkown error code %d"
+#~ msgstr "Unbekannter Fehlercode %d"
+
+#~ msgid "Unsupported baudrate"
+#~ msgstr "Baudrate wird nicht unterstützt"
+
+#~ msgid "Unsupported operation"
+#~ msgstr "Nicht unterstützte Operation"
+
+#~ msgid "Unsupported pull value."
+#~ msgstr "Nicht unterstützter Pull-Wert."
 
 #~ msgid "Use esptool to erase flash and re-upload Python instead"
 #~ msgstr ""
 #~ "Benutze das esptool um den flash zu löschen und Python erneut hochzuladen"
 
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr "Viper-Funktionen unterstützen derzeit nicht mehr als 4 Argumente"
+
 #~ msgid "Voice index too high"
 #~ msgstr "Voice index zu hoch"
+
+#~ msgid "WatchDogTimer is not currently running"
+#~ msgstr "WatchDogTimer läuft aktuell nicht"
+
+#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+#~ msgstr ""
+#~ "WatchDogTimer.mode kann nicht geändert werden, nachdem er auf "
+#~ "WatchDogMode.RESET gesetzt wurde"
+
+#~ msgid "WatchDogTimer.timeout must be greater than 0"
+#~ msgstr "WatchDogTimer.timeout muss größer als 0 sein"
+
+#~ msgid "Watchdog timer expired."
+#~ msgstr "Watchdog timer abgelaufen."
+
+#, c-format
+#~ msgid ""
+#~ "Welcome to Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Please visit learn.adafruit.com/category/circuitpython for project "
+#~ "guides.\n"
+#~ "\n"
+#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ msgstr ""
+#~ "Willkommen bei Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Projektleitfäden findest du auf learn.adafruit.com/category/"
+#~ "circuitpython \n"
+#~ "\n"
+#~ "Um die integrierten Module aufzulisten, führe bitte `help(\"modules\")` "
+#~ "aus.\n"
+
+#~ msgid "WiFi password must be between 8 and 63 characters"
+#~ msgstr "WiFi Passwort muss zwischen 8 und 63 Zeichen lang sein"
+
+#~ msgid "Wifi is in access point mode."
+#~ msgstr "Das Wifi ist im Accesspoint-Modus."
+
+#~ msgid "Wifi is in station mode."
+#~ msgstr "Das Wifi ist im Station-Modus."
+
+#~ msgid "You are in safe mode because:\n"
+#~ msgstr "Du befindest dich im abgesicherten Modus, weil:\n"
+
+#~ msgid "You are in safe mode: something unanticipated happened.\n"
+#~ msgstr ""
+#~ "Sie befinden sich im abgesicherten Modus: Es ist etwas Unerwartetes "
+#~ "passiert.\n"
 
 #~ msgid ""
 #~ "You are running in safe mode which means something unanticipated "
@@ -6282,11 +5789,59 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ "Sie laufen im abgesicherten Modus, was bedeutet, dass etwas Unerwartetes "
 #~ "passiert ist.\n"
 
+#~ msgid ""
+#~ "You pressed the reset button during boot. Press again to exit safe mode."
+#~ msgstr ""
+#~ "Du hast beim Booten die Reset-Taste gedrückt. Drücke sie erneut, um den "
+#~ "abgesicherten Modus zu beenden."
+
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "Du hast das Starten im abgesicherten Modus ausgelöst durch "
+
+#~ msgid "__init__() should return None, not '%q'"
+#~ msgstr "__init__() sollte None zurückgeben, nicht '%q'"
+
+#~ msgid "abort() called"
+#~ msgstr "abort() wurde aufgerufen"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "Addresse %08x ist nicht an %d bytes ausgerichtet"
+
+#~ msgid "address out of bounds"
+#~ msgstr "Adresse außerhalb der Grenzen"
+
+#~ msgid "arctan2 is implemented for scalars and ndarrays only"
+#~ msgstr "arctan2 ist nur für Skalare und ndarrays implementiert"
+
+#~ msgid "argument must be ndarray"
+#~ msgstr "Argument muss ein ndarray sein"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "Attribute werden noch nicht unterstützt"
+
+#~ msgid "axis must be -1, 0, None, or 1"
+#~ msgstr "Die Achse muss -1, 0, Keine oder 1 sein"
+
+#~ msgid "axis must be -1, 0, or 1"
+#~ msgstr "Die Achse muss -1, 0 oder 1 sein"
+
+#~ msgid "axis must be None, 0, or 1"
+#~ msgstr "Die Achse muss None, 0 oder 1 sein"
+
+#~ msgid "bits must be 7, 8 or 9"
+#~ msgstr "bits muss 7, 8 oder 9 sein"
+
 #~ msgid "bits must be 8"
 #~ msgstr "bits müssen 8 sein"
 
+#~ msgid "bits must be in range 5 to 9"
+#~ msgstr "bits müssen zwischen 5 und 9 liegen"
+
 #~ msgid "buf is too small. need %d bytes"
 #~ msgstr "buf ist zu klein. brauche %d Bytes"
+
+#~ msgid "buffer must be a bytes-like object"
+#~ msgstr "Puffer muss ein bytes-artiges Objekt sein"
 
 #~ msgid "buffer too long"
 #~ msgstr "Buffer zu lang"
@@ -6294,11 +5849,114 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "buffers must be the same length"
 #~ msgstr "Buffer müssen gleich lang sein"
 
+#~ msgid "buttons must be digitalio.DigitalInOut"
+#~ msgstr "Tasten müssen digitalio.DigitalInOut sein"
+
+#~ msgid "byte code not implemented"
+#~ msgstr "Bytecode nicht implementiert"
+
+#~ msgid "byteorder is not a string"
+#~ msgstr "Byteorder ist kein String"
+
 #~ msgid "byteorder is not an instance of ByteOrder (got a %s)"
 #~ msgstr "byteorder ist keine Instanz von ByteOrder (%s erhalten)"
 
+#~ msgid "bytes > 8 bits not supported"
+#~ msgstr "bytes mit mehr als 8 bits werden nicht unterstützt"
+
+#~ msgid "calibration value out of range +/-127"
+#~ msgstr "Kalibrierwert nicht im Bereich von +/-127"
+
+#~ msgid "can only be registered in one parent"
+#~ msgstr "kann nur bei einem Elternteil registriert werden"
+
+#~ msgid "can only save bytecode"
+#~ msgstr "kann nur Bytecode speichern"
+
+#~ msgid "can't convert %q to int"
+#~ msgstr "kann %q nicht nach int konvertieren"
+
+#~ msgid "can't convert address to int"
+#~ msgstr "kann Adresse nicht in int konvertieren"
+
+#~ msgid "can't convert to %q"
+#~ msgstr "kann nicht zu %q konvertieren"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr ""
+#~ "kann mit einer komplexen Zahl keine abgeschnittene Division ausführen"
+
+#~ msgid "can't have multiple **x"
+#~ msgstr "mehrere **x sind nicht gestattet"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "mehrere *x sind nicht gestattet"
+
+#~ msgid "can't pend throw to just-started generator"
+#~ msgstr "Ich kann den Wurf nicht an den gerade gestarteten Generator hängen"
+
+#~ msgid "cannot import name %q"
+#~ msgstr "Name %q kann nicht importiert werden"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "kann keinen relativen Import durchführen"
+
+#~ msgid "cannot reshape array (incompatible input/output shape)"
+#~ msgstr ""
+#~ "Array kann nicht umgeformt werden (inkompatible Eingabe- / Ausgabeform)"
+
+#~ msgid "cannot unambiguously get sizeof scalar"
+#~ msgstr "Kann nicht eindeutig die Größe (sizeof) des Skalars ermitteln"
+
+#~ msgid "circle can only be registered in one parent"
+#~ msgstr "Kreis kann nur in einem Elternteil registriert werden"
+
 #~ msgid "color buffer must be a buffer or int"
 #~ msgstr "Farbpuffer muss ein Puffer oder ein int sein"
+
+#~ msgid "color should be an int"
+#~ msgstr "Farbe sollte ein int sein"
+
+#~ msgid "complex division by zero"
+#~ msgstr "Komplexe Division durch null"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "constant muss ein integer sein"
+
+#~ msgid "could not broadast input array from shape"
+#~ msgstr "Eingabearray konnte nicht aus der Form übertragen werden"
+
+#~ msgid "ddof must be smaller than length of data set"
+#~ msgstr "ddof muss kleiner als die Länge des Datensatzes sein"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr "destination_length muss ein int >= 0 sein"
+
+#~ msgid "divisor must be 4"
+#~ msgstr "Teiler muss 4 sein"
+
+#~ msgid "end_x should be an int"
+#~ msgstr "end_x sollte ein int sein"
+
+#~ msgid ""
+#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "esp32_camera.Camera benötigt reservierten PSRAM um konfiguriert werden zu "
+#~ "können. Sieh in der Dokumentation für eine Anleitung nach."
+
+#~ msgid ""
+#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "espcamera.Camera benötigt reservierten PSRAM um konfiguriert zu werden. "
+#~ "Siehe Dokumentation für Anweisungen."
+
+#~ msgid "expected '%q' but got '%q'"
+#~ msgstr "erwartet '%q' aber bekommen '%q'"
+
+#~ msgid "expected '%q' or '%q' but got '%q'"
+#~ msgstr "erwartete '%q' oder '%q', aber bekam '%q'"
 
 #~ msgid "expected a DigitalInOut"
 #~ msgstr "erwarte DigitalInOut"
@@ -6306,8 +5964,26 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "expecting a pin"
 #~ msgstr "Ein Pin wird erwartet"
 
+#~ msgid "f-string expression part cannot include a '#'"
+#~ msgstr "f-string expression Teil kann kein '#' beinhalten"
+
+#~ msgid "f-string expression part cannot include a backslash"
+#~ msgstr "Die f-String expression darf keinen Backslash enthalten"
+
+#~ msgid "f-string: empty expression not allowed"
+#~ msgstr "f-string: leere expression nicht erlaubt"
+
+#~ msgid "f-string: expecting '}'"
+#~ msgstr "f-string: erwartet '}'"
+
+#~ msgid "f-string: single '}' is not allowed"
+#~ msgstr "f-string: einzelne '}' nicht erlaubt"
+
 #~ msgid "ffi_prep_closure_loc"
 #~ msgstr "ffi_prep_closure_loc"
+
+#~ msgid "first argument must be an iterable"
+#~ msgstr "Das erste Argument muss iterierbar sein"
 
 #~ msgid "firstbit must be MSB"
 #~ msgstr "Erstes Bit muss das höchstwertigste Bit (MSB) sein"
@@ -6318,8 +5994,38 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "frequency can only be either 80Mhz or 160MHz"
 #~ msgstr "Die Frequenz kann nur 80Mhz oder 160Mhz sein"
 
+#~ msgid "frequency is read-only for this board"
+#~ msgstr "Frequenz ist für dieses Board schreibgeschützt"
+
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "Funktion akzeptiert keine Schlüsselwort-Argumente"
+
+#~ msgid "function is implemented for scalars and ndarrays only"
+#~ msgstr "Die Funktion ist nur für Skalare und Ndarrays implementiert"
+
 #~ msgid "impossible baudrate"
 #~ msgstr "Unmögliche Baudrate"
+
+#~ msgid "incompatible native .mpy architecture"
+#~ msgstr "inkompatible native .mpy-Architektur"
+
+#~ msgid "input and output shapes are not compatible"
+#~ msgstr "Eingabe- und Ausgabeformen sind nicht kompatibel"
+
+#~ msgid "input argument must be an integer or a 2-tuple"
+#~ msgstr "Das Eingabeargument muss eine Ganzzahl oder ein 2-Tupel sein"
+
+#~ msgid "input must be a tensor of rank 2"
+#~ msgstr "Eingabe muss ein Tensor von Rang 2 sein"
+
+#~ msgid "inputs are not iterable"
+#~ msgstr "Eingaben sind nicht iterierbar"
+
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr "int() arg 2 muss >= 2 und <= 36 sein"
+
+#~ msgid "integer required"
+#~ msgstr "integer erforderlich"
 
 #~ msgid "interval not in range 0.0020 to 10.24"
 #~ msgstr "Das Interval ist nicht im Bereich 0.0020 bis 10.24"
@@ -6333,11 +6039,23 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "invalid alarm"
 #~ msgstr "ungültiger Alarm"
 
+#~ msgid "invalid architecture"
+#~ msgstr "ungültige Architektur"
+
+#~ msgid "invalid arguments"
+#~ msgstr "ungültige argumente"
+
 #~ msgid "invalid buffer length"
 #~ msgstr "ungültige Pufferlänge"
 
 #~ msgid "invalid data bits"
 #~ msgstr "ungültige Datenbits"
+
+#~ msgid "invalid dupterm index"
+#~ msgstr "ungültiger dupterm index"
+
+#~ msgid "invalid format"
+#~ msgstr "ungültiges Format"
 
 #~ msgid "invalid pin"
 #~ msgstr "ungültiger Pin"
@@ -6345,8 +6063,40 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "invalid stop bits"
 #~ msgstr "ungültige Stopbits"
 
+#~ msgid "invalid traceback"
+#~ msgstr "ungültiger Traceback"
+
+#~ msgid "iterables are not of the same length"
+#~ msgstr "iterables sind nicht gleich lang"
+
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr ""
+#~ "Schlüsselwort-Argument(e) noch nicht implementiert - verwende stattdessen "
+#~ "normale Argumente"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "Schlüsselwörter müssen Zeichenfolgen sein"
+
 #~ msgid "len must be multiple of 4"
 #~ msgstr "len muss ein vielfaches von 4 sein"
+
+#~ msgid "length argument not allowed for this type"
+#~ msgstr "Für diesen Typ ist length nicht zulässig"
+
+#~ msgid "long int not supported in this build"
+#~ msgstr "long int wird in diesem Build nicht unterstützt"
+
+#~ msgid "matrix dimensions do not match"
+#~ msgstr "Matrix Dimensionen stimmen nicht überein"
+
+#~ msgid "max_connections must be between 0 and 10"
+#~ msgstr "max_connections muss zwischen 0 und 10 liegen"
+
+#~ msgid "max_length must be >= 0"
+#~ msgstr "max_length muss >= 0 sein"
+
+#~ msgid "maximum number of dimensions is 4"
+#~ msgstr "die maximale Anzahl der Dimensionen beträgt 4"
 
 #~ msgid "memory allocation failed, allocating %u bytes for native code"
 #~ msgstr ""
@@ -6355,14 +6105,114 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "must specify all of sck/mosi/miso"
 #~ msgstr "sck/mosi/miso müssen alle spezifiziert sein"
 
+#~ msgid "n must be between 0, and 9"
+#~ msgstr "n muss zwischen 0 und 9 liegen"
+
 #~ msgid "name must be a string"
 #~ msgstr "name muss ein String sein"
+
+#~ msgid "name reused for argument"
+#~ msgstr "Name für Argumente wiederverwendet"
+
+#~ msgid "no available NIC"
+#~ msgstr "kein verfügbares Netzwerkadapter (NIC)"
+
+#~ msgid "no reset pin available"
+#~ msgstr "kein Reset Pin verfügbar"
+
+#~ msgid "non-Device in %q"
+#~ msgstr "Nicht-Gerät in %q"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "Nicht-Schlüsselwort arg nach * / **"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "Nicht-Schlüsselwort-Argument nach Schlüsselwort-Argument"
 
 #~ msgid "not a valid ADC Channel: %d"
 #~ msgstr "Kein gültiger ADC Kanal: %d"
 
+#~ msgid "number of arguments must be 2, or 3"
+#~ msgstr "Die Anzahl der Argumente muss 2 oder 3 sein"
+
+#~ msgid "object '%s' is not a tuple or list"
+#~ msgstr "Objekt '%s' ist weder tupel noch list"
+
+#~ msgid "object does not support item assignment"
+#~ msgstr "Objekt unterstützt keine item assignment"
+
+#~ msgid "object does not support item deletion"
+#~ msgstr "Objekt unterstützt das Löschen von Elementen nicht"
+
+#~ msgid "object is not subscriptable"
+#~ msgstr "Objekt hat keine '__getitem__'-Methode (not subscriptable)"
+
+#~ msgid "object of type '%q' has no len()"
+#~ msgstr "Object vom Typ '%q' hat kein len()"
+
+#~ msgid "offset out of bounds"
+#~ msgstr "offset außerhalb der Grenzen"
+
+#~ msgid "out of range of source"
+#~ msgstr "Außerhalb des Bereichs der Quelle"
+
+#~ msgid "palette_index should be an int"
+#~ msgstr "palette_index sollte ein int sein"
+
+#~ msgid "parameter annotation must be an identifier"
+#~ msgstr "parameter annotation muss ein identifier sein"
+
 #~ msgid "pin does not have IRQ capabilities"
 #~ msgstr "Pin hat keine IRQ Fähigkeiten"
+
+#~ msgid "pixel value requires too many bits"
+#~ msgstr "Der Pixelwert erfordert zu viele Bits"
+
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+#~ msgstr ""
+#~ "pixel_shader muss displayio.Palette oder displayio.ColorConverter sein"
+
+#~ msgid "polygon can only be registered in one parent"
+#~ msgstr "Polygon kann nur in einem übergeordneten Element registriert werden"
+
+#~ msgid "pop from an empty set"
+#~ msgstr "pop von einer leeren Menge (set)"
+
+#~ msgid "pop from empty list"
+#~ msgstr "pop von einer leeren Liste"
+
+#~ msgid "popitem(): dictionary is empty"
+#~ msgstr "popitem(): dictionary ist leer"
+
+#~ msgid "pressing BOOT button at start up.\n"
+#~ msgstr "BOOT Taste wird beim Starten gedrückt.\n"
+
+#~ msgid "pressing SW38 button at start up.\n"
+#~ msgstr "SW38 Taste wird beim Starten gedrückt.\n"
+
+#~ msgid "pressing VOLUME button at start up.\n"
+#~ msgstr "VOLUME Taste wird beim Starten gedrückt.\n"
+
+#~ msgid "pressing boot button at start up.\n"
+#~ msgstr "Drücken der Boot-Taste beim Start.\n"
+
+#~ msgid "pressing both buttons at start up.\n"
+#~ msgstr "Drücken Sie beim Start beide Tasten.\n"
+
+#~ msgid "pressing the left button at start up\n"
+#~ msgstr "Drücken der linken Taste beim Einschalten\n"
+
+#~ msgid "pull_threshold must be between 1 and 32"
+#~ msgstr "pull_threshold muss zwischen 1 und 32 liegen"
+
+#~ msgid "push_threshold must be between 1 and 32"
+#~ msgstr "push_threshold muss zwischen 1 und 32 liegen"
+
+#~ msgid "queue overflow"
+#~ msgstr "Warteschlangenüberlauf"
+
+#~ msgid "raw f-strings are not implemented"
+#~ msgstr "rohe F-Strings sind nicht implementiert"
 
 #~ msgid "rawbuf is not the same size as buf"
 #~ msgstr "rawbuf hat nicht die gleiche Größe wie buf"
@@ -6370,17 +6220,148 @@ msgstr "zi muss die Form (n_section, 2) haben"
 #~ msgid "readonly attribute"
 #~ msgstr "Readonly-Attribut"
 
+#~ msgid "right hand side must be an ndarray, or a scalar"
+#~ msgstr "Die rechte Seite muss ein Ndarray oder ein Skalar sein"
+
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "sample_source buffer muss ein Byte-Array oder ein Array vom Typ 'h', 'H', "
+#~ "'b' oder 'B' sein"
+
 #~ msgid "scan failed"
 #~ msgstr "Scan fehlgeschlagen"
+
+#~ msgid "schedule stack full"
+#~ msgstr "Der schedule stack ist voll"
+
+#~ msgid "shape must be a 2-tuple"
+#~ msgstr "Form muss ein 2-Tupel sein"
+
+#~ msgid "shape must be a tuple"
+#~ msgstr "Form muss ein Tupel sein"
+
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "einzelne '}' in Formatierungs-String gefunden"
+
+#~ msgid "slice step can't be zero"
+#~ msgstr "Slice-Schritt darf nicht Null sein"
+
+#~ msgid "slice step cannot be zero"
+#~ msgstr "Der Slice-Schritt kann nicht Null sein"
+
+#~ msgid "ssid can't be more than 32 bytes"
+#~ msgstr "ssid kann nicht mehr als 32 Bytes lang sein"
+
+#~ msgid "start_x should be an int"
+#~ msgstr "start_x sollte ein int sein"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "Schritt (step) darf nicht Null sein"
+
+#~ msgid "stop must be 1 or 2"
+#~ msgstr "stop muss 1 oder 2 sein"
+
+#~ msgid "string indices must be integers, not %q"
+#~ msgstr "String Indizes müssen Integer sein, nicht %q"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr ""
+#~ "Zeichenfolgen werden nicht unterstützt; verwende bytes oder bytearray"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "struct: kann nicht indexieren"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "threshold muss im Intervall 0-65536 liegen"
+
+#~ msgid "tile must be greater than zero"
+#~ msgstr "Kachel muss größer als Null sein"
+
+#~ msgid "time.struct_time() takes a 9-sequence"
+#~ msgstr "time.struct_time() nimmt eine 9-Sequenz an"
+
+#~ msgid "timeout must be 0.0-100.0 seconds"
+#~ msgstr "Das Zeitlimit muss 0,0-100,0 Sekunden betragen"
+
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "timeout muss >= 0.0 sein"
 
 #~ msgid "too many arguments"
 #~ msgstr "zu viele Argumente"
 
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "zu viele Argumente mit dem angegebenen Format"
+
+#~ msgid "tuple index out of range"
+#~ msgstr "Tupelindex außerhalb des Bereichs"
+
+#~ msgid "tuple/list required on RHS"
+#~ msgstr "Tupel / Liste auf RHS erforderlich"
+
+#~ msgid "type object 'generator' has no attribute '__await__'"
+#~ msgstr "Das Typ-Objekt 'generator' hat kein Attribut '__await__'"
+
+#~ msgid "unindent does not match any outer indentation level"
+#~ msgstr ""
+#~ "Einrückung entspricht keiner äußeren Einrückungsebene. Bitte Leerzeichen "
+#~ "am Zeilenanfang kontrollieren"
+
+#~ msgid "unknown format code '%c' for object of type '%s'"
+#~ msgstr "unbekannter Formatcode '%c' für Objekt vom Typ '%s'"
+
 #~ msgid "unknown status param"
 #~ msgstr "Unbekannter Statusparameter"
+
+#~ msgid "unmatched '{' in format"
+#~ msgstr "'{' ohne passende Zuordnung im Format"
+
+#~ msgid "unsupported type for %q: '%q'"
+#~ msgstr "nicht unterstützer Typ für %q: '%q'"
+
+#~ msgid "unsupported types for %q: '%s', '%s'"
+#~ msgstr "nicht unterstützte Typen für %q: '%s', '%s'"
+
+#~ msgid "value_count must be > 0"
+#~ msgstr "value_count muss größer als 0 sein"
+
+#~ msgid "vectors must have same lengths"
+#~ msgstr "Vektoren müssen die selbe Länge haben"
+
+#~ msgid "watchdog not initialized"
+#~ msgstr "watchdog nicht initialisiert"
+
+#~ msgid "watchdog timeout must be greater than 0"
+#~ msgstr "watchdog Zeitlimit muss größer als 0 sein"
+
+#, c-format
+#~ msgid "width must be from 2 to 8 (inclusive), not %d"
+#~ msgstr "breite muss zwischen (inklusive) 2 und 8 liegen, nicht %d"
 
 #~ msgid "wifi_set_ip_info() failed"
 #~ msgstr "wifi_set_ip_info() fehlgeschlagen"
 
 #~ msgid "write_args must be a list, tuple, or None"
 #~ msgstr "write_args muss eine Liste, ein Tupel oder None sein"
+
+#~ msgid "wrong argument type"
+#~ msgstr "falscher Argumenttyp"
+
+#~ msgid "wrong operand type"
+#~ msgstr "falscher Operandentyp"
+
+#~ msgid "x value out of bounds"
+#~ msgstr "x Wert außerhalb der Grenzen"
+
+#~ msgid "xTaskCreate failed"
+#~ msgstr "xTaskCreate fehlgeschlagen"
+
+#~ msgid "y should be an int"
+#~ msgstr "y sollte ein int sein"
+
+#~ msgid "y value out of bounds"
+#~ msgstr "y Wert außerhalb der Grenzen"
+
+#~ msgid "zero step"
+#~ msgstr "Nullschritt"

--- a/locale/el.po
+++ b/locale/el.po
@@ -83,42 +83,12 @@ msgstr " έξοδος:\n"
 msgid "%%c requires int or char"
 msgstr "%%c απαιτεί ακέραιο ή χαρακτήρα"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr ""
 "%d pin διεύθυνσης, %d rgb ping και %d πλακίδια αναδεικνύουν ύψος %d, όχι %d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -301,11 +271,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
 msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
@@ -789,7 +754,8 @@ msgstr "Δεν μπορούν να αλλάξουν οι USB συσκευές τ
 
 #: shared-bindings/_bleio/Adapter.c
 msgid "Cannot create a new Adapter; use _bleio.adapter;"
-msgstr "Δεν μπορεί να δημιουργηθεί νέο Adapter; χρησιμοποιείστε _bleio.adapter;"
+msgstr ""
+"Δεν μπορεί να δημιουργηθεί νέο Adapter; χρησιμοποιείστε _bleio.adapter;"
 
 #: shared-bindings/displayio/Bitmap.c
 #: shared-bindings/memorymonitor/AllocationSize.c
@@ -1628,7 +1594,8 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
 msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
@@ -4427,53 +4394,6 @@ msgstr ""
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
 
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr "'await', 'async for' ή 'async with' εκτός ασύνχρονης συνάρτησης"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' εκτός επανάληψης"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' εκτός επανάληψης"
-
-#~ msgid "Bit clock and word select must be sequential pins"
-#~ msgstr "Ρολόι bit και word select πρέπει να είναι διαδοχικά pins"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "Το ADC2 χρησιμοποιείται απο το WIFI"
-
-#~ msgid ""
-#~ "\n"
-#~ "Please file an issue with your program at https://github.com/adafruit/"
-#~ "circuitpython/issues."
-#~ msgstr ""
-#~ "\n"
-#~ "Παρακαλώ δημιουργήστε ένα πρόβλημα στο https://github.com/adafruit/"
-#~ "circuitpython/issues με το πρόγραμμά σας."
-
-#~ msgid "'coroutine' object is not an iterator"
-#~ msgstr ""
-#~ "'coroutine' αντικείμενο δεν μπορεί να χρησιμοποιηθεί σαν επαναλήπτης"
-
-#~ msgid "Buffer is too small"
-#~ msgstr "Πολύ μικρό buffer"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "Κατεστραμένο .mpy αρχείο"
-
-#~ msgid "Cannot transfer without MOSI and MISO pins"
-#~ msgstr "Δεν μπορεί να γίνει μεταφορά χωρίς MOSI και MISO pins"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "Η φωτινότητα πρέπει να είναι μεταξύ 0-1.0"
-
-#, fuzzy
-#~ msgid "64 bit types"
-#~ msgstr "64 bit τύποι"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "%q άκυρο pin"
-
 #~ msgid ""
 #~ "\n"
 #~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
@@ -4484,26 +4404,30 @@ msgstr ""
 #~ "στο\n"
 #~ "https://github.com/adafruit/circuitpython/issues\n"
 
-#~ msgid "Attempted heap allocation when VM not running."
-#~ msgstr "Προσπάθεια δέσμευσης heap όταν το VM δεν τρέχει."
+#~ msgid ""
+#~ "\n"
+#~ "Please file an issue with your program at https://github.com/adafruit/"
+#~ "circuitpython/issues."
+#~ msgstr ""
+#~ "\n"
+#~ "Παρακαλώ δημιουργήστε ένα πρόβλημα στο https://github.com/adafruit/"
+#~ "circuitpython/issues με το πρόγραμμά σας."
 
-#~ msgid "Boot device must be first device (interface #0)."
-#~ msgstr "Η συσκευή boot πρέπει να είναι η πρώτη συσκευή (interface #0)."
+#, c-format
+#~ msgid "%02X"
+#~ msgstr "%02X"
 
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "Η CircuitPython δεν μπορέσε να δεσμεύσει το heap."
-
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "Κατέρευσε μέσα στο HardFault_Handler."
-
-#~ msgid "%q must be of type %q"
-#~ msgstr "%q πρέπει να είναι τύπου %q"
-
-#~ msgid "%q must be of type %q or None"
-#~ msgstr "%q πρέπει να είναι τύπου %q ή None"
+#~ msgid "%q"
+#~ msgstr "%q"
 
 #~ msgid "%q length must be >= 1"
 #~ msgstr "%q μήκος πρέπει να είναι >= 1"
+
+#~ msgid "%q must be >= 0"
+#~ msgstr "%q πρέπει να είναι >= 0"
+
+#~ msgid "%q must be >= 1"
+#~ msgstr "%q πρέπει να είναι >= 1"
 
 #~ msgid "%q must be a string"
 #~ msgstr "%q πρέπει να είναι string"
@@ -4511,14 +4435,64 @@ msgstr ""
 #~ msgid "%q must be an int"
 #~ msgstr "%q πρέπει να είναι int"
 
+#~ msgid "%q must be of type %q"
+#~ msgstr "%q πρέπει να είναι τύπου %q"
+
+#~ msgid "%q must be of type %q or None"
+#~ msgstr "%q πρέπει να είναι τύπου %q ή None"
+
+#~ msgid "%q pin invalid"
+#~ msgstr "%q άκυρο pin"
+
 #~ msgid "%q with a report ID of 0 must be of length 1"
 #~ msgstr "%q με ID αναφοράς 0 πρέπει να έχει μήκος 1"
+
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr "'await', 'async for' ή 'async with' εκτός ασύνχρονης συνάρτησης"
+
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' εκτός επανάληψης"
+
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' εκτός επανάληψης"
+
+#~ msgid "'coroutine' object is not an iterator"
+#~ msgstr ""
+#~ "'coroutine' αντικείμενο δεν μπορεί να χρησιμοποιηθεί σαν επαναλήπτης"
+
+#, fuzzy
+#~ msgid "64 bit types"
+#~ msgstr "64 bit τύποι"
+
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "Το ADC2 χρησιμοποιείται απο το WIFI"
 
 #~ msgid "At most %d %q may be specified (not %d)"
 #~ msgstr "Το πολύ %d %q μπορεί να είναι καθορισμένα (όχι %d)"
 
-#~ msgid "%q must be >= 0"
-#~ msgstr "%q πρέπει να είναι >= 0"
+#~ msgid "Attempted heap allocation when VM not running."
+#~ msgstr "Προσπάθεια δέσμευσης heap όταν το VM δεν τρέχει."
 
-#~ msgid "%q must be >= 1"
-#~ msgstr "%q πρέπει να είναι >= 1"
+#~ msgid "Bit clock and word select must be sequential pins"
+#~ msgstr "Ρολόι bit και word select πρέπει να είναι διαδοχικά pins"
+
+#~ msgid "Boot device must be first device (interface #0)."
+#~ msgstr "Η συσκευή boot πρέπει να είναι η πρώτη συσκευή (interface #0)."
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "Η φωτινότητα πρέπει να είναι μεταξύ 0-1.0"
+
+#~ msgid "Buffer is too small"
+#~ msgstr "Πολύ μικρό buffer"
+
+#~ msgid "Cannot transfer without MOSI and MISO pins"
+#~ msgstr "Δεν μπορεί να γίνει μεταφορά χωρίς MOSI και MISO pins"
+
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "Η CircuitPython δεν μπορέσε να δεσμεύσει το heap."
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "Κατεστραμένο .mpy αρχείο"
+
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "Κατέρευσε μέσα στο HardFault_Handler."

--- a/locale/en_GB.po
+++ b/locale/en_GB.po
@@ -84,42 +84,12 @@ msgstr " output:\n"
 msgid "%%c requires int or char"
 msgstr "%%c requires int or char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -303,11 +273,6 @@ msgstr "%q[%u] uses extra pin"
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
 msgstr "%q[%u] waits on input outside of count"
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
-msgstr "%s"
 
 #: ports/espressif/common-hal/espidf/__init__.c
 #, c-format
@@ -1626,8 +1591,9 @@ msgstr "Ok"
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Only 8 or 16 bit mono with "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -4442,18 +4408,108 @@ msgstr "zi must be of float type"
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi must be of shape (n_section, 2)"
 
-#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
-#~ msgstr "Invalid CIRCUITPY_PYSTACK_SIZE\n"
-
-#~ msgid "Unable to allocate the heap."
-#~ msgstr "Unable to allocate the heap."
+#~ msgid ""
+#~ "\n"
+#~ "Code stopped by auto-reload.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Code stopped by auto-reload.\n"
 
 #~ msgid ""
-#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
+#~ "\n"
+#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
 #~ msgstr ""
-#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
+#~ "\n"
+#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Please file an issue with your program at https://github.com/adafruit/"
+#~ "circuitpython/issues."
+#~ msgstr ""
+#~ "\n"
+#~ "Please file an issue with your program at https://github.com/adafruit/"
+#~ "circuitpython/issues."
+
+#, fuzzy
+#~ msgid ""
+#~ "\n"
+#~ "paste mode; Ctrl-C to cancel, Ctrl-D to finish\n"
+#~ "=== "
+#~ msgstr ""
+#~ "\n"
+#~ "paste mode; Ctrl-C to cancel, Ctrl-D to finish\n"
+#~ "=== "
+
+#, c-format
+#~ msgid "%02X"
+#~ msgstr "%02X"
+
+#~ msgid "%q"
+#~ msgstr "%q"
+
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "%q indices must be integers, not %q"
+
+#~ msgid "%q length must be >= 1"
+#~ msgstr "%q length must be >= 1"
+
+#~ msgid "%q list must be a list"
+#~ msgstr "%q list must be a list"
+
+#~ msgid "%q must <= %d"
+#~ msgstr "%q must <= %d"
+
+#~ msgid "%q must be >= 0"
+#~ msgstr "%q must be >= 0"
+
+#~ msgid "%q must be >= 1"
+#~ msgstr "%q must be >= 1"
+
+#~ msgid "%q must be a string"
+#~ msgstr "%q must be a string"
+
+#~ msgid "%q must be a tuple of length 2"
+#~ msgstr "%q must be a tuple of length 2"
+
+#~ msgid "%q must be between %d and %d"
+#~ msgstr "%q must be between %d and %d"
+
+#~ msgid "%q must of type %q"
+#~ msgstr "%q must of type %q"
+
+#~ msgid "%q pin invalid"
+#~ msgstr "%q pin invalid"
+
+#~ msgid "%q should be an int"
+#~ msgstr "%q should be an int"
+
+#, c-format
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgid "'%q' object cannot assign attribute '%q'"
+#~ msgstr "'%q' object cannot assign attribute '%q'"
+
+#~ msgid "'%q' object does not support item assignment"
+#~ msgstr "'%q' object does not support item assignment"
+
+#~ msgid "'%q' object does not support item deletion"
+#~ msgstr "'%q' object does not support item deletion"
+
+#~ msgid "'%q' object has no attribute '%q'"
+#~ msgstr "'%q' object has no attribute '%q'"
+
+#~ msgid "'%q' object is not subscriptable"
+#~ msgstr "'%q' object is not subscriptable"
+
+#~ msgid "'%s' integer %d is not within range %d..%d"
+#~ msgstr "'%s' integer %d is not within range %d..%d"
+
+#~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
+#~ msgstr "'%s' integer 0x%x does not fit in mask 0x%x"
 
 #~ msgid "'await', 'async for' or 'async with' outside async function"
 #~ msgstr "'await', 'async for' or 'async with' outside async function"
@@ -4464,533 +4520,17 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "'continue' outside loop"
 #~ msgstr "'continue' outside loop"
 
-#~ msgid "invalid architecture"
-#~ msgstr "invalid architecture"
-
-#~ msgid "unsupported type for %q: '%q'"
-#~ msgstr "unsupported type for %q: '%q'"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Splitting with sub-captures"
-
-#~ msgid "__init__() should return None, not '%q'"
-#~ msgstr "__init__() should return None, not '%q'"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "attributes not supported yet"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr "Can't do truncated division of a complex number"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "can't import name %q"
-
-#~ msgid "cannot unambiguously get sizeof scalar"
-#~ msgstr "cannot unambiguously get sizeof scalar"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr "keyword argument(s) not yet implemented - use normal args instead"
-
-#~ msgid "length argument not allowed for this type"
-#~ msgstr "length argument not allowed for this type"
-
-#~ msgid "offset out of bounds"
-#~ msgstr "offset out of bounds"
-
-#~ msgid "slice step can't be zero"
-#~ msgstr "slice step can't be zero"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr "string not supported; use bytes or bytearray"
-
-#~ msgid "Bit clock and word select must be sequential pins"
-#~ msgstr "Bit clock and word select must be sequential pins"
-
-#~ msgid "Initialization failed due to lack of memory"
-#~ msgstr "Initialisation failed due to lack of memory"
-
-#~ msgid "RAISE mode is not implemented"
-#~ msgstr "RAISE mode is not implemented"
-
-#~ msgid "WatchDogTimer is not currently running"
-#~ msgstr "WatchDogTimer is not currently running"
-
-#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-#~ msgstr "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-
-#~ msgid "watchdog not initialized"
-#~ msgstr "WatchDog not initialised"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "ADC2 is being used by WiFi"
-
-#, c-format
-#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Unable to configure ADC DMA controller, ErrorCode:%d"
-
-#, c-format
-#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Unable to initialise ADC DMA controller, ErrorCode:%d"
-
-#, c-format
-#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Unable to start ADC DMA controller, ErrorCode:%d"
-
-#~ msgid "xTaskCreate failed"
-#~ msgstr "xTaskCreate failed"
-
-#~ msgid "Unable to write to address."
-#~ msgstr "Unable to write to address."
-
-#~ msgid "queue overflow"
-#~ msgstr "queue overflow"
-
-#~ msgid "Stopping AP is not supported."
-#~ msgstr "Stopping AP is not supported."
-
-#~ msgid "Wifi is in access point mode."
-#~ msgstr "Wifi is in access point mode."
-
-#~ msgid "Wifi is in station mode."
-#~ msgstr "Wifi is in station mode."
-
-#~ msgid ""
-#~ "\n"
-#~ "Please file an issue with your program at https://github.com/adafruit/"
-#~ "circuitpython/issues."
-#~ msgstr ""
-#~ "\n"
-#~ "Please file an issue with your program at https://github.com/adafruit/"
-#~ "circuitpython/issues."
-
 #~ msgid "'coroutine' object is not an iterator"
 #~ msgstr "'coroutine' object is not an iterator"
 
-#~ msgid "Buffer is too small"
-#~ msgstr "Buffer is too small"
-
-#~ msgid "Fault detected by hardware."
-#~ msgstr "Fault detected by hardware."
-
-#~ msgid "The power dipped. Make sure you are providing enough power."
-#~ msgstr "The power dipped. Make sure you are providing enough power."
-
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-#~ msgstr "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "Corrupt .mpy file"
-
-#~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
-#~ msgstr ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See https://adafru."
-#~ "it/mpy-update for more info."
-
-#~ msgid "can't convert to %q"
-#~ msgstr "Can't convert to %q"
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "can't have multiple **x"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "can't have multiple *x"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "constant must be an integer"
-
-#~ msgid "incompatible native .mpy architecture"
-#~ msgstr "incompatible native .mpy architecture"
-
-#~ msgid "invalid format"
-#~ msgstr "invalid format"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "keywords must be strings"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "non-keyword arg after */**"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "non-keyword arg after keyword arg"
-
-#, c-format
-#~ msgid "Instruction %d shifts in more bits than pin count"
-#~ msgstr "Instruction %d shifts in more bits than pin count"
-
-#, c-format
-#~ msgid "Instruction %d shifts out more bits than pin count"
-#~ msgstr "Instruction %d shifts out more bits than pin count"
-
-#, c-format
-#~ msgid "Instruction %d uses extra pin"
-#~ msgstr "Instruction %d uses extra pin"
-
-#, c-format
-#~ msgid "Instruction %d waits on input outside of count"
-#~ msgstr "Instruction %d waits on input outside of count"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
-#~ msgstr "Missing first_in_pin. Instruction %d reads pin(s)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
-#~ msgstr "Missing first_in_pin. Instruction %d shifts in from pin(s)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
-#~ msgstr "Missing first_in_pin. Instruction %d waits based on pin"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
-#~ msgstr "Missing first_out_pin. Instruction %d shifts out to pin(s)"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
-#~ msgstr "Missing first_out_pin. Instruction %d writes pin(s)"
-
-#, c-format
-#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
-#~ msgstr "Missing first_set_pin. Instruction %d sets pin(s)"
-
-#, c-format
-#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
-#~ msgstr "Missing jmp_pin. Instruction %d jumps on pin"
-
-#~ msgid "inputs are not iterable"
-#~ msgstr "inputs are not iterable"
-
-#~ msgid "Too many display busses"
-#~ msgstr "Too many display busses"
-
-#~ msgid "Cannot transfer without MOSI and MISO pins"
-#~ msgstr "Cannot transfer without MOSI and MISO pins"
-
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Hardware busy, try alternative pins"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "Missing MISO or MOSI Pin"
-
-#~ msgid "Missing MISO or MOSI pin"
-#~ msgstr "Missing MISO or MOSI pin"
-
-#~ msgid "No MISO Pin"
-#~ msgstr "No MISO Pin"
-
-#~ msgid "No MISO pin"
-#~ msgstr "No MISO pin"
-
-#~ msgid "No MOSI Pin"
-#~ msgstr "No MOSI Pin"
-
-#~ msgid "No MOSI pin"
-#~ msgstr "No MOSI pin"
-
-#~ msgid "No RX pin"
-#~ msgstr "No RX pin"
-
-#~ msgid "No TX pin"
-#~ msgstr "No TX pin"
-
-#~ msgid "no reset pin available"
-#~ msgstr "no reset pin available"
-
-#~ msgid "Sleep Memory not available"
-#~ msgstr "Sleep Memory not available"
-
-#~ msgid "input and output shapes are not compatible"
-#~ msgstr "input and output shapes are not compatible"
-
-#~ msgid "shape must be a tuple"
-#~ msgstr "shape must be a tuple"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "Brightness must be 0-1.0"
-
-#, c-format
-#~ msgid "Error in MIDI stream at position %d"
-#~ msgstr "Error in MIDI stream at position %d"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "Maximum x value when mirrored is %d"
-
-#~ msgid "x value out of bounds"
-#~ msgstr "x value out of bounds"
-
-#~ msgid "y value out of bounds"
-#~ msgstr "y value out of bounds"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "I2SOut not available"
-
-#~ msgid "PDMIn not available"
-#~ msgstr "PDMIn not available"
-
-#~ msgid "out of range of source"
-#~ msgstr "out of range of source"
-
-#~ msgid "pixel value requires too many bits"
-#~ msgstr "pixel value requires too many bits"
-
-#~ msgid "value_count must be > 0"
-#~ msgstr "value_count must be > 0"
+#~ msgid "(x,y) integers required"
+#~ msgstr "(x,y) integers required"
 
 #~ msgid "64 bit types"
 #~ msgstr "64 bit types"
 
-#~ msgid "No key was specified"
-#~ msgstr "No key was specified"
-
-#~ msgid "Scan already in progess. Stop with stop_scan."
-#~ msgstr "Scan already in progess. Stop with stop_scan."
-
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "too many arguments provided with the given format"
-
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "Supply at least one UART pin"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "%q pin invalid"
-
-#~ msgid ""
-#~ "\n"
-#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
-#~ "https://github.com/adafruit/circuitpython/issues\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
-#~ "https://github.com/adafruit/circuitpython/issues\n"
-
-#~ msgid "Attempted heap allocation when VM not running."
-#~ msgstr "Attempted heap allocation when VM not running."
-
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "CircuitPython was unable to allocate the heap."
-
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "Crash into the HardFault_Handler."
-
-#~ msgid "Fatal error."
-#~ msgstr "Fatal error."
-
-#~ msgid "Invalid memory access."
-#~ msgstr "Invalid memory access."
-
-#~ msgid "Nordic system firmware failure assertion."
-#~ msgstr "Nordic system firmware failure assertion."
-
-#~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Increase the stack size if you know how. If not:"
-#~ msgstr ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Increase the stack size if you know how. If not:"
-
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode."
-#~ msgstr ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode."
-
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY)."
-#~ msgstr ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY)."
-
-#~ msgid "You are in safe mode because:\n"
-#~ msgstr "You are in safe mode because:\n"
-
-#~ msgid ""
-#~ "You pressed the reset button during boot. Press again to exit safe mode."
-#~ msgstr ""
-#~ "You pressed the reset button during boot. Press again to exit safe mode."
-
-#~ msgid "Expected a %q"
-#~ msgstr "Expected a %q"
-
-#, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IV must be %d bytes long"
-
-#~ msgid "Not settable"
-#~ msgstr "Not settable"
-
-#~ msgid "expected '%q' but got '%q'"
-#~ msgstr "expected '%q' but got '%q'"
-
-#~ msgid "expected '%q' or '%q' but got '%q'"
-#~ msgstr "expected '%q' or '%q' but got '%q'"
-
-#~ msgid "Read-only object"
-#~ msgstr "Read-only object"
-
-#~ msgid "%q length must be >= 1"
-#~ msgstr "%q length must be >= 1"
-
-#~ msgid "%q must be a string"
-#~ msgstr "%q must be a string"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "At most %d %q may be specified (not %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Invalid pins"
-
-#, c-format
-#~ msgid "No more than %d HID devices allowed"
-#~ msgstr "No more than %d HID devices allowed"
-
-#~ msgid "byteorder is not a string"
-#~ msgstr "Byteorder is not a string"
-
-#~ msgid "can't convert %q to int"
-#~ msgstr "can't convert %q to int"
-
-#~ msgid "complex division by zero"
-#~ msgstr "complex division by zero"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr "int() arg 2 must be >= 2 and <= 36"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "long int not supported in this build"
-
-#~ msgid "slice step cannot be zero"
-#~ msgstr "slice step cannot be zero"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "step must be non-zero"
-
-#~ msgid "string indices must be integers, not %q"
-#~ msgstr "string indices must be integers, not %q"
-
-#~ msgid "time.struct_time() takes a 9-sequence"
-#~ msgstr "time.struct_time() takes a 9-sequence"
-
-#~ msgid "zero step"
-#~ msgstr "zero step"
-
-#~ msgid "invalid traceback"
-#~ msgstr "invalid traceback"
-
-#~ msgid "WatchDogTimer.timeout must be greater than 0"
-#~ msgstr "WatchDogTimer.timeout must be greater than 0"
-
-#~ msgid "non-Device in %q"
-#~ msgstr "non-Device in %q"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "single '}' encountered in format string"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "threshold must be in the range 0-65536"
-
-#~ msgid "timeout must be 0.0-100.0 seconds"
-#~ msgstr "timeout must be 0.0-100.0 seconds"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "unmatched '{' in format"
-
-#~ msgid "watchdog timeout must be greater than 0"
-#~ msgstr "WatchDog timeout must be greater than 0"
-
-#~ msgid "To exit, please reset the board without "
-#~ msgstr "To exit, please reset the board without "
-
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "You requested starting safe mode by "
-
-#~ msgid "pressing boot button at start up.\n"
-#~ msgstr "pressing boot button at start up.\n"
-
-#~ msgid "pressing both buttons at start up.\n"
-#~ msgstr "pressing both buttons at start up.\n"
-
-#~ msgid "pressing the left button at start up\n"
-#~ msgstr "pressing the left button at start up\n"
-
-#~ msgid "Only one TouchAlarm can be set in deep sleep."
-#~ msgstr "Only one TouchAlarm can be set in deep sleep."
-
-#~ msgid "Firmware image is invalid"
-#~ msgstr "Firmware image is invalid"
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "Stream missing readinto() or write() method."
-
-#~ msgid "%q must be >= 0"
-#~ msgstr "%q must be >= 0"
-
-#~ msgid "%q must be >= 1"
-#~ msgstr "%q must be >= 1"
-
-#~ msgid "address out of bounds"
-#~ msgstr "address out of bounds"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr "destination_length must be an int >= 0"
-
-#~ msgid "type object 'generator' has no attribute '__await__'"
-#~ msgstr "type object 'generator' has no attribute '__await__'"
-
-#~ msgid "color should be an int"
-#~ msgstr "colour should be an int"
-
-#~ msgid "end_x should be an int"
-#~ msgstr "end_x should be an int"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "palette_index should be an int"
-
-#~ msgid "start_x should be an int"
-#~ msgstr "start_x should be an int"
-
-#~ msgid "y should be an int"
-#~ msgstr "y should be an int"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-
-#~ msgid "Expected an alarm"
-#~ msgstr "Expected an alarm"
-
-#~ msgid "Failed to init wifi"
-#~ msgstr "Failed to init WiFi"
-
-#~ msgid "input must be a tensor of rank 2"
-#~ msgstr "input must be a tensor of rank 2"
-
-#~ msgid "maximum number of dimensions is 4"
-#~ msgstr "maximum number of dimensions is 4"
-
-#~ msgid "Watchdog timer expired."
-#~ msgstr "WatchDog timer expired."
-
-#~ msgid "%q must be a tuple of length 2"
-#~ msgstr "%q must be a tuple of length 2"
-
-#~ msgid "%q must be between %d and %d"
-#~ msgstr "%q must be between %d and %d"
-
-#~ msgid "%q should be an int"
-#~ msgstr "%q should be an int"
-
-#~ msgid "(x,y) integers required"
-#~ msgstr "(x,y) integers required"
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "ADC2 is being used by WiFi"
 
 #~ msgid "Address type out of range"
 #~ msgstr "Address type out of range"
@@ -5007,16 +4547,40 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "AnalogOut not supported on given pin"
 #~ msgstr "AnalogOut not supported on given pin"
 
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "At most %d %q may be specified (not %d)"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr "Attempted heap allocation when MicroPython VM not running."
+
+#~ msgid "Attempted heap allocation when VM not running."
+#~ msgstr "Attempted heap allocation when VM not running."
+
+#~ msgid "Bit clock and word select must be sequential pins"
+#~ msgstr "Bit clock and word select must be sequential pins"
+
 #, c-format
 #~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
 #~ msgstr "Bit depth must be from 1 to 6 inclusive, not %d"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "Brightness must be 0-1.0"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "Brightness must be between 0 and 255"
 
 #, c-format
 #~ msgid "Buffer incorrect size. Should be %d bytes."
 #~ msgstr "Buffer incorrect size. Should be %d bytes."
 
+#~ msgid "Buffer is too small"
+#~ msgstr "Buffer is too small"
+
 #~ msgid "Buffer must be at least length 1"
 #~ msgstr "Buffer must be at least length 1"
+
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "Buffer too large and unable to allocate"
 
 #~ msgid "Bytes must be between 0 and 255."
 #~ msgstr "Bytes must be between 0 and 255."
@@ -5027,20 +4591,48 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "Cannot read without MISO pin."
 #~ msgstr "Cannot read without MISO pin."
 
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "Cannot remount '/' when USB is active."
+
 #~ msgid "Cannot reset into bootloader because no bootloader is present."
 #~ msgstr "Cannot reset into bootloader because no bootloader is present."
+
+#~ msgid "Cannot transfer without MOSI and MISO pins"
+#~ msgstr "Cannot transfer without MOSI and MISO pins"
 
 #~ msgid "Cannot transfer without MOSI and MISO pins."
 #~ msgstr "Cannot transfer without MOSI and MISO pins."
 
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "Cannot unambiguously get sizeof scalar"
+
 #~ msgid "Cannot write without MOSI pin."
 #~ msgstr "Cannot write without MOSI pin."
+
+#~ msgid ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+#~ msgstr ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "CircuitPython was unable to allocate the heap."
 
 #~ msgid "Clock pin init failed."
 #~ msgstr "Clock pin init failed."
 
+#~ msgid "Column entry must be digitalio.DigitalInOut"
+#~ msgstr "Column entry must be digitalio.DigitalInOut"
+
 #~ msgid "Command must be an int between 0 and 255"
 #~ msgstr "Command must be an int between 0 and 255"
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "Corrupt .mpy file"
+
+#~ msgid "Corrupt raw code"
+#~ msgstr "Corrupt raw code"
 
 #~ msgid "Could not initialize Camera"
 #~ msgstr "Could not initialise camera"
@@ -5072,8 +4664,42 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "Couldn't allocate second buffer"
 #~ msgstr "Couldn't allocate second buffer"
 
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "Crash into the HardFault_Handler."
+
+#~ msgid "Data 0 pin must be byte aligned."
+#~ msgstr "Data 0 pin must be byte aligned."
+
 #~ msgid "DigitalInOut not supported on given pin"
 #~ msgstr "DigitalInOut not supported on given pin"
+
+#, c-format
+#~ msgid "Error in MIDI stream at position %d"
+#~ msgstr "Error in MIDI stream at position %d"
+
+#~ msgid "Expected a %q"
+#~ msgstr "Expected a %q"
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Expected a Characteristic"
+
+#~ msgid "Expected a DigitalInOut"
+#~ msgstr "Expected a DigitalInOut"
+
+#~ msgid "Expected a Service"
+#~ msgstr "Expected a service"
+
+#~ msgid "Expected a UART"
+#~ msgstr "Expected a UART"
+
+#~ msgid "Expected a UUID"
+#~ msgstr "Expected a UUID"
+
+#~ msgid "Expected an Address"
+#~ msgstr "Expected an address"
+
+#~ msgid "Expected an alarm"
+#~ msgstr "Expected an alarm"
 
 #, c-format
 #~ msgid "Expected tuple of length %d, got %d"
@@ -5086,15 +4712,69 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "Failed to allocate RX buffer of %d bytes"
 #~ msgstr "Failed to allocate RX buffer of %d bytes"
 
+#~ msgid "Failed to init wifi"
+#~ msgstr "Failed to init WiFi"
+
+#~ msgid "Fatal error."
+#~ msgstr "Fatal error."
+
+#~ msgid "Fault detected by hardware."
+#~ msgstr "Fault detected by hardware."
+
+#~ msgid "Firmware image is invalid"
+#~ msgstr "Firmware image is invalid"
+
 #, c-format
 #~ msgid "Framebuffer requires %d bytes"
 #~ msgstr "Framebuffer requires %d bytes"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Hardware busy, try alternative pins"
 
 #~ msgid "Hostname must be between 1 and 253 characters"
 #~ msgstr "Hostname must be between 1 and 253 characters"
 
 #~ msgid "I2C Init Error"
 #~ msgstr "I2C init error"
+
+#~ msgid "I2SOut not available"
+#~ msgstr "I2SOut not available"
+
+#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
+#~ msgstr "IOs 0, 2 & 4 do not support internal pullup in sleep"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IV must be %d bytes long"
+
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See https://adafru."
+#~ "it/mpy-update for more info."
+
+#~ msgid "Initialization failed due to lack of memory"
+#~ msgstr "Initialisation failed due to lack of memory"
+
+#~ msgid "Instruction %d jumps on pin"
+#~ msgstr "Instruction %d jumps on pin"
+
+#, c-format
+#~ msgid "Instruction %d shifts in more bits than pin count"
+#~ msgstr "Instruction %d shifts in more bits than pin count"
+
+#, c-format
+#~ msgid "Instruction %d shifts out more bits than pin count"
+#~ msgstr "Instruction %d shifts out more bits than pin count"
+
+#, c-format
+#~ msgid "Instruction %d uses extra pin"
+#~ msgstr "Instruction %d uses extra pin"
+
+#, c-format
+#~ msgid "Instruction %d waits on input outside of count"
+#~ msgstr "Instruction %d waits on input outside of count"
 
 #~ msgid "Invalid %q pin selection"
 #~ msgstr "Invalid %q pin selection"
@@ -5104,6 +4784,9 @@ msgstr "zi must be of shape (n_section, 2)"
 
 #~ msgid "Invalid BMP file"
 #~ msgstr "Invalid BMP file"
+
+#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
+#~ msgstr "Invalid CIRCUITPY_PYSTACK_SIZE\n"
 
 #~ msgid "Invalid DAC pin supplied"
 #~ msgstr "Invalid DAC pin supplied"
@@ -5139,6 +4822,12 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "Invalid file"
 #~ msgstr "Invalid file"
 
+#~ msgid "Invalid frequency"
+#~ msgstr "Invalid frequency"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "Invalid memory access."
+
 #~ msgid "Invalid number of bits"
 #~ msgstr "Invalid number of bits"
 
@@ -5153,6 +4842,9 @@ msgstr "zi must be of shape (n_section, 2)"
 
 #~ msgid "Invalid pin for right channel"
 #~ msgstr "Invalid pin for right channel"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Invalid pins"
 
 #~ msgid "Invalid polarity"
 #~ msgstr "Invalid polarity"
@@ -5184,18 +4876,91 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "Layer must be a Group or TileGrid subclass."
 #~ msgstr "Layer must be a Group or TileGrid subclass."
 
+#~ msgid "Length must be an int"
+#~ msgstr "Length must be an int"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Length must be non-negative"
+
 #~ msgid "MISO pin init failed."
 #~ msgstr "MISO pin init failed."
 
 #~ msgid "MOSI pin init failed."
 #~ msgstr "MOSI pin init failed."
 
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "Maximum x value when mirrored is %d"
+
 #~ msgid "Messages limited to 8 bytes"
 #~ msgstr "Messages limited to 8 bytes"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgstr "MicroPython NLR jump failed. Likely memory corruption."
+
+#, fuzzy
+#~ msgid "MicroPython fatal error."
+#~ msgstr "CircuitPython fatal error."
+
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "Missing MISO or MOSI Pin"
+
+#~ msgid "Missing MISO or MOSI pin"
+#~ msgstr "Missing MISO or MOSI pin"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
+#~ msgstr "Missing first_in_pin. Instruction %d reads pin(s)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
+#~ msgstr "Missing first_in_pin. Instruction %d shifts in from pin(s)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
+#~ msgstr "Missing first_in_pin. Instruction %d waits based on pin"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
+#~ msgstr "Missing first_out_pin. Instruction %d shifts out to pin(s)"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
+#~ msgstr "Missing first_out_pin. Instruction %d writes pin(s)"
+
+#, c-format
+#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+#~ msgstr "Missing first_set_pin. Instruction %d sets pin(s)"
+
+#, c-format
+#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
+#~ msgstr "Missing jmp_pin. Instruction %d jumps on pin"
 
 #, c-format
 #~ msgid "More than %d report ids not supported"
 #~ msgstr "More than %d report ids not supported"
+
+#, c-format
+#~ msgid "No I2C device at address: %x"
+#~ msgstr "No I2C device at address: %x"
+
+#~ msgid "No MISO Pin"
+#~ msgstr "No MISO Pin"
+
+#~ msgid "No MISO pin"
+#~ msgstr "No MISO pin"
+
+#~ msgid "No MOSI Pin"
+#~ msgstr "No MOSI Pin"
+
+#~ msgid "No MOSI pin"
+#~ msgstr "No MOSI pin"
+
+#~ msgid "No RX pin"
+#~ msgstr "No RX pin"
+
+#~ msgid "No TX pin"
+#~ msgstr "No TX pin"
 
 #~ msgid "No hardware support on clk pin"
 #~ msgstr "No hardware support on clk pin"
@@ -5203,14 +4968,48 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "No hardware support on pin"
 #~ msgstr "No hardware support on pin"
 
+#~ msgid "No key was specified"
+#~ msgstr "No key was specified"
+
+#, c-format
+#~ msgid "No more than %d HID devices allowed"
+#~ msgstr "No more than %d HID devices allowed"
+
+#~ msgid "Nordic Soft Device failure assertion."
+#~ msgstr "Nordic Soft Device failure assertion."
+
+#~ msgid "Nordic system firmware failure assertion."
+#~ msgstr "Nordic system firmware failure assertion."
+
+#~ msgid "Not running saved code.\n"
+#~ msgstr "Not running saved code.\n"
+
+#~ msgid "Not settable"
+#~ msgstr "Not settable"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Only 8 or 16 bit mono with "
+
+#~ msgid "Only one TouchAlarm can be set in deep sleep."
+#~ msgstr "Only one TouchAlarm can be set in deep sleep."
+
+#~ msgid "Only raw int supported for ip"
+#~ msgstr "Only raw int supported for ip"
+
 #, c-format
 #~ msgid "Output buffer must be at least %d bytes"
 #~ msgstr "Output buffer must be at least %d bytes"
+
+#~ msgid "PDMIn not available"
+#~ msgstr "PDMIn not available"
 
 #~ msgid ""
 #~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
 #~ msgstr ""
 #~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
+
+#~ msgid "ParallelBus not yet supported"
+#~ msgstr "ParallelBus not yet supported"
 
 #~ msgid "Pin count must be at least 1"
 #~ msgstr "Pin count must be at least 1"
@@ -5218,11 +5017,31 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "Pin does not have ADC capabilities"
 #~ msgstr "Pin does not have ADC capabilities"
 
+#~ msgid "Pin number already reserved by EXTI"
+#~ msgstr "Pin number already reserved by EXTI"
+
+#~ msgid ""
+#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
+#~ "instead"
+#~ msgstr ""
+#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
+#~ "instead"
+
+#~ msgid ""
+#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
+#~ "Carrier instead"
+#~ msgstr ""
+#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
+#~ "Carrier instead"
+
 #~ msgid "Program must contain at least one 16-bit instruction."
 #~ msgstr "Program must contain at least one 16-bit instruction."
 
 #~ msgid "Program too large"
 #~ msgstr "Program too large"
+
+#~ msgid "RAISE mode is not implemented"
+#~ msgstr "RAISE mode is not implemented"
 
 #~ msgid "RS485 Not yet supported on this device"
 #~ msgstr "RS485 not yet supported on this device"
@@ -5232,6 +5051,15 @@ msgstr "zi must be of shape (n_section, 2)"
 
 #~ msgid "RTS/CTS/RS485 Not yet supported on this device"
 #~ msgstr "RTS/CTS/RS485 not yet supported on this device"
+
+#~ msgid "Read-only object"
+#~ msgstr "Read-only object"
+
+#~ msgid "Row entry must be digitalio.DigitalInOut"
+#~ msgstr "Row entry must be digitalio. DigitalInOut"
+
+#~ msgid "Running in safe mode! "
+#~ msgstr "Running in safe mode! "
 
 #~ msgid "SPI Init Error"
 #~ msgstr "SPI init error"
@@ -5246,17 +5074,99 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "Sample rate too high. It must be less than %d"
 #~ msgstr "Sample rate too high. It must be less than %d"
 
+#~ msgid "Scan already in progess. Stop with stop_scan."
+#~ msgstr "Scan already in progess. Stop with stop_scan."
+
+#~ msgid "Selected CTS pin not valid"
+#~ msgstr "Selected CTS pin not valid"
+
+#~ msgid "Selected RTS pin not valid"
+#~ msgstr "Selected RTS pin not valid"
+
 #~ msgid "Set pin count must be between 1 and 5"
 #~ msgstr "Set pin count must be between 1 and 5"
 
 #~ msgid "Side set pin count must be between 1 and 5"
 #~ msgstr "Side set pin count must be between 1 and 5"
 
+#~ msgid "Sleep Memory not available"
+#~ msgstr "Sleep Memory not available"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Splitting with sub-captures"
+
 #~ msgid "Stack size must be at least 256"
 #~ msgstr "Stack size must be at least 256"
 
+#~ msgid "Stopping AP is not supported."
+#~ msgstr "Stopping AP is not supported."
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "Stream missing readinto() or write() method."
+
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "Supply at least one UART pin"
+
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Increase the stack size if you know how. If not:"
+#~ msgstr ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Increase the stack size if you know how. If not:"
+
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase the stack size if you know how, or if not:"
+#~ msgstr ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase the stack size if you know how, or if not:"
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode."
+#~ msgstr ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode."
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode.\n"
+#~ msgstr ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode.\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY)."
+#~ msgstr ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY)."
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+
+#~ msgid "The power dipped. Make sure you are providing enough power."
+#~ msgstr "The power dipped. Make sure you are providing enough power."
+
 #~ msgid "Tile value out of bounds"
 #~ msgstr "Tile value out of bounds"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "To exit, please reset the board without "
+
+#~ msgid "Too many display busses"
+#~ msgstr "Too many display busses"
+
+#~ msgid "Total data to write is larger than outgoing_packet_length"
+#~ msgstr "Total data to write is larger than outgoing_packet_length"
 
 #~ msgid "UART Buffer allocation error"
 #~ msgstr "UART buffer allocation error"
@@ -5273,14 +5183,128 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "UART write error"
 #~ msgstr "UART write error"
 
+#~ msgid "USB Busy"
+#~ msgstr "USB busy"
+
+#~ msgid "USB Error"
+#~ msgstr "USB error"
+
+#~ msgid "Unable to allocate the heap."
+#~ msgstr "Unable to allocate the heap."
+
+#, c-format
+#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Unable to configure ADC DMA controller, ErrorCode:%d"
+
+#, c-format
+#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Unable to initialise ADC DMA controller, ErrorCode:%d"
+
+#, c-format
+#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Unable to start ADC DMA controller, ErrorCode:%d"
+
+#~ msgid "Unable to write to address."
+#~ msgstr "Unable to write to address."
+
+#~ msgid "Unknown soft device error: %04x"
+#~ msgstr "Unknown soft device error: %04x"
+
 #~ msgid "Unsupported baudrate"
 #~ msgstr "Unsupported baudrate"
+
+#~ msgid "Unsupported operation"
+#~ msgstr "Unsupported operation"
+
+#~ msgid "Unsupported pull value."
+#~ msgstr "Unsupported pull value."
+
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr "Viper functions don't currently support more than 4 arguments"
+
+#~ msgid "WatchDogTimer is not currently running"
+#~ msgstr "WatchDogTimer is not currently running"
+
+#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+#~ msgstr "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+
+#~ msgid "WatchDogTimer.timeout must be greater than 0"
+#~ msgstr "WatchDogTimer.timeout must be greater than 0"
+
+#~ msgid "Watchdog timer expired."
+#~ msgstr "WatchDog timer expired."
+
+#, c-format
+#~ msgid ""
+#~ "Welcome to Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Please visit learn.adafruit.com/category/circuitpython for project "
+#~ "guides.\n"
+#~ "\n"
+#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ msgstr ""
+#~ "Welcome to Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Please visit learn.adafruit.com/category/circuitpython for project "
+#~ "guides.\n"
+#~ "\n"
+#~ "To list built-in modules please do `help(\"modules\")`.\n"
 
 #~ msgid "WiFi password must be between 8 and 63 characters"
 #~ msgstr "WiFi password must be between 8 and 63 characters"
 
+#~ msgid "Wifi is in access point mode."
+#~ msgstr "Wifi is in access point mode."
+
+#~ msgid "Wifi is in station mode."
+#~ msgstr "Wifi is in station mode."
+
+#~ msgid "You are in safe mode because:\n"
+#~ msgstr "You are in safe mode because:\n"
+
+#~ msgid "You are in safe mode: something unanticipated happened.\n"
+#~ msgstr "You are in safe mode: something unanticipated happened.\n"
+
+#~ msgid ""
+#~ "You pressed the reset button during boot. Press again to exit safe mode."
+#~ msgstr ""
+#~ "You pressed the reset button during boot. Press again to exit safe mode."
+
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "You requested starting safe mode by "
+
+#~ msgid "__init__() should return None, not '%q'"
+#~ msgstr "__init__() should return None, not '%q'"
+
+#~ msgid "abort() called"
+#~ msgstr "abort() called"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "address %08x is not aligned to %d bytes"
+
+#~ msgid "address out of bounds"
+#~ msgstr "address out of bounds"
+
+#~ msgid "argument must be ndarray"
+#~ msgstr "argument must be ndarray"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "attributes not supported yet"
+
 #~ msgid "bits must be in range 5 to 9"
 #~ msgstr "bits must be in range 5 to 9"
+
+#~ msgid "buffer must be a bytes-like object"
+#~ msgstr "Buffer must be a bytes-like object"
+
+#~ msgid "buttons must be digitalio.DigitalInOut"
+#~ msgstr "Buttons must be digitalio.DigitalInOut"
+
+#~ msgid "byte code not implemented"
+#~ msgstr "Byte code not implemented"
+
+#~ msgid "byteorder is not a string"
+#~ msgstr "Byteorder is not a string"
 
 #~ msgid "bytes > 8 bits not supported"
 #~ msgstr "Bytes > 8 bits not supported"
@@ -5288,81 +5312,66 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "calibration value out of range +/-127"
 #~ msgstr "Calibration value out of range +/-127"
 
-#~ msgid "circle can only be registered in one parent"
-#~ msgstr "circle can only be registered in one parent"
+#~ msgid "can only save bytecode"
+#~ msgstr "Can only save bytecode"
 
-#~ msgid "max_length must be >= 0"
-#~ msgstr "max_length must be >= 0"
+#~ msgid "can't convert %q to int"
+#~ msgstr "can't convert %q to int"
 
-#~ msgid "polygon can only be registered in one parent"
-#~ msgstr "polygon can only be registered in one parent"
+#~ msgid "can't convert to %q"
+#~ msgstr "Can't convert to %q"
 
-#~ msgid "pull_threshold must be between 1 and 32"
-#~ msgstr "pull_threshold must be between 1 and 32"
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr "Can't do truncated division of a complex number"
 
-#~ msgid "push_threshold must be between 1 and 32"
-#~ msgstr "push_threshold must be between 1 and 32"
+#~ msgid "can't have multiple **x"
+#~ msgstr "can't have multiple **x"
 
-#~ msgid "stop must be 1 or 2"
-#~ msgstr "stop must be 1 or 2"
+#~ msgid "can't have multiple *x"
+#~ msgstr "can't have multiple *x"
 
-#~ msgid "tile must be greater than zero"
-#~ msgstr "tile must be greater than zero"
+#~ msgid "can't pend throw to just-started generator"
+#~ msgstr "can't pend throw to just-started generator"
 
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "timeout must be >= 0.0"
-
-#, c-format
-#~ msgid "width must be from 2 to 8 (inclusive), not %d"
-#~ msgstr "width must be from 2 to 8 (inclusive), not %d"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "Unsupported operation"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code stopped by auto-reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Code stopped by auto-reload.\n"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "Brightness must be between 0 and 255"
+#~ msgid "cannot import name %q"
+#~ msgstr "can't import name %q"
 
 #~ msgid "cannot perform relative import"
 #~ msgstr "can't perform relative import"
 
-#, c-format
-#~ msgid "No I2C device at address: %x"
-#~ msgstr "No I2C device at address: %x"
+#~ msgid "cannot unambiguously get sizeof scalar"
+#~ msgstr "cannot unambiguously get sizeof scalar"
 
-#~ msgid "Unsupported pull value."
-#~ msgstr "Unsupported pull value."
+#~ msgid "circle can only be registered in one parent"
+#~ msgstr "circle can only be registered in one parent"
 
-#~ msgid "%q must <= %d"
-#~ msgstr "%q must <= %d"
+#~ msgid "color should be an int"
+#~ msgstr "colour should be an int"
 
-#, c-format
+#~ msgid "complex division by zero"
+#~ msgstr "complex division by zero"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "constant must be an integer"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr "destination_length must be an int >= 0"
+
+#~ msgid "end_x should be an int"
+#~ msgstr "end_x should be an int"
+
 #~ msgid ""
-#~ "Welcome to Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Please visit learn.adafruit.com/category/circuitpython for project "
-#~ "guides.\n"
-#~ "\n"
-#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
 #~ msgstr ""
-#~ "Welcome to Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Please visit learn.adafruit.com/category/circuitpython for project "
-#~ "guides.\n"
-#~ "\n"
-#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
 
-#~ msgid "integer required"
-#~ msgstr "integer required"
+#~ msgid "expected '%q' but got '%q'"
+#~ msgstr "expected '%q' but got '%q'"
 
-#~ msgid "abort() called"
-#~ msgstr "abort() called"
+#~ msgid "expected '%q' or '%q' but got '%q'"
+#~ msgstr "expected '%q' or '%q' but got '%q'"
 
 #~ msgid "f-string expression part cannot include a '#'"
 #~ msgstr "f-string expression part cannot include a '#'"
@@ -5379,192 +5388,95 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "f-string: single '}' is not allowed"
 #~ msgstr "f-string: single '}' is not allowed"
 
-#~ msgid "invalid arguments"
-#~ msgstr "invalid arguments"
+#~ msgid "first argument must be an iterable"
+#~ msgstr "first argument must be an iterable"
 
-#~ msgid "raw f-strings are not implemented"
-#~ msgstr "raw f-strings are not implemented"
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "function does not take keyword arguments"
 
-#~ msgid "unindent does not match any outer indentation level"
-#~ msgstr "unindent does not match any outer indentation level"
+#~ msgid "incompatible native .mpy architecture"
+#~ msgstr "incompatible native .mpy architecture"
 
-#~ msgid "%q list must be a list"
-#~ msgstr "%q list must be a list"
+#~ msgid "input and output shapes are not compatible"
+#~ msgstr "input and output shapes are not compatible"
 
-#~ msgid "%q must of type %q"
-#~ msgstr "%q must of type %q"
+#~ msgid "input must be a tensor of rank 2"
+#~ msgstr "input must be a tensor of rank 2"
 
-#~ msgid "Column entry must be digitalio.DigitalInOut"
-#~ msgstr "Column entry must be digitalio.DigitalInOut"
+#~ msgid "inputs are not iterable"
+#~ msgstr "inputs are not iterable"
 
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Expected a Characteristic"
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr "int() arg 2 must be >= 2 and <= 36"
 
-#~ msgid "Expected a DigitalInOut"
-#~ msgstr "Expected a DigitalInOut"
-
-#~ msgid "Expected a Service"
-#~ msgstr "Expected a service"
-
-#~ msgid "Expected a UART"
-#~ msgstr "Expected a UART"
-
-#~ msgid "Expected a UUID"
-#~ msgstr "Expected a UUID"
-
-#~ msgid "Expected an Address"
-#~ msgstr "Expected an address"
-
-#~ msgid "Row entry must be digitalio.DigitalInOut"
-#~ msgstr "Row entry must be digitalio. DigitalInOut"
-
-#~ msgid "buttons must be digitalio.DigitalInOut"
-#~ msgstr "Buttons must be digitalio.DigitalInOut"
-
-#~ msgid "Invalid frequency"
-#~ msgstr "Invalid frequency"
-
-#~ msgid "Data 0 pin must be byte aligned."
-#~ msgstr "Data 0 pin must be byte aligned."
-
-#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
-#~ msgstr "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
-
-#, fuzzy
-#~ msgid ""
-#~ "\n"
-#~ "paste mode; Ctrl-C to cancel, Ctrl-D to finish\n"
-#~ "=== "
-#~ msgstr ""
-#~ "\n"
-#~ "paste mode; Ctrl-C to cancel, Ctrl-D to finish\n"
-#~ "=== "
-
-#~ msgid "ParallelBus not yet supported"
-#~ msgstr "ParallelBus not yet supported"
-
-#, fuzzy
-#~ msgid "raw REPL; CTRL-B to exit\n"
-#~ msgstr "raw REPL; CTRL-B to exit\n"
-
-#~ msgid "no available NIC"
-#~ msgstr "no available NIC"
-
-#~ msgid ""
-#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
-#~ "instead"
-#~ msgstr ""
-#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
-#~ "instead"
-
-#~ msgid ""
-#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
-#~ "Carrier instead"
-#~ msgstr ""
-#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
-#~ "Carrier instead"
-
-#~ msgid "Instruction %d jumps on pin"
-#~ msgstr "Instruction %d jumps on pin"
-
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "Buffer too large and unable to allocate"
+#~ msgid "integer required"
+#~ msgstr "integer required"
 
 #~ msgid "interp is defined for 1D arrays of equal length"
 #~ msgstr "interp is defined for 1D arrays of equal length"
 
-#~ msgid "trapz is defined for 1D arrays"
-#~ msgstr "trapz is defined for 1D arrays"
+#~ msgid "invalid architecture"
+#~ msgstr "invalid architecture"
 
-#~ msgid "wrong operand type"
-#~ msgstr "wrong operand type"
+#~ msgid "invalid arguments"
+#~ msgstr "invalid arguments"
 
-#~ msgid "Only raw int supported for ip"
-#~ msgstr "Only raw int supported for ip"
+#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
+#~ msgstr "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
 
-#~ msgid ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
-#~ msgstr ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
+#~ msgid "invalid dupterm index"
+#~ msgstr "invalid dupterm index"
 
-#~ msgid "Not running saved code.\n"
-#~ msgstr "Not running saved code.\n"
+#~ msgid "invalid format"
+#~ msgstr "invalid format"
 
-#~ msgid "Running in safe mode! "
-#~ msgstr "Running in safe mode! "
+#~ msgid "invalid traceback"
+#~ msgstr "invalid traceback"
 
-#~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Please increase the stack size if you know how, or if not:"
-#~ msgstr ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Please increase the stack size if you know how, or if not:"
+#~ msgid "io must be rtc io"
+#~ msgstr "io must be rtc io"
 
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode.\n"
-#~ msgstr ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode.\n"
+#~ msgid "iterables are not of the same length"
+#~ msgstr "iterables are not of the same length"
 
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY).\n"
-#~ msgstr ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY).\n"
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr "keyword argument(s) not yet implemented - use normal args instead"
 
-#~ msgid "You are in safe mode: something unanticipated happened.\n"
-#~ msgstr "You are in safe mode: something unanticipated happened.\n"
+#~ msgid "keywords must be strings"
+#~ msgstr "keywords must be strings"
 
-#~ msgid "Pin number already reserved by EXTI"
-#~ msgstr "Pin number already reserved by EXTI"
+#~ msgid "length argument not allowed for this type"
+#~ msgstr "length argument not allowed for this type"
 
-#~ msgid "USB Busy"
-#~ msgstr "USB busy"
+#~ msgid "long int not supported in this build"
+#~ msgstr "long int not supported in this build"
 
-#~ msgid "USB Error"
-#~ msgstr "USB error"
+#~ msgid "max_length must be >= 0"
+#~ msgstr "max_length must be >= 0"
 
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "%q indices must be integers, not %q"
-
-#~ msgid "'%q' object cannot assign attribute '%q'"
-#~ msgstr "'%q' object cannot assign attribute '%q'"
-
-#~ msgid "'%q' object does not support item assignment"
-#~ msgstr "'%q' object does not support item assignment"
-
-#~ msgid "'%q' object does not support item deletion"
-#~ msgstr "'%q' object does not support item deletion"
-
-#~ msgid "'%q' object has no attribute '%q'"
-#~ msgstr "'%q' object has no attribute '%q'"
-
-#~ msgid "'%q' object is not subscriptable"
-#~ msgstr "'%q' object is not subscriptable"
-
-#~ msgid "'%s' integer %d is not within range %d..%d"
-#~ msgstr "'%s' integer %d is not within range %d..%d"
-
-#~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
-#~ msgstr "'%s' integer 0x%x does not fit in mask 0x%x"
-
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "Cannot unambiguously get sizeof scalar"
-
-#~ msgid "Length must be an int"
-#~ msgstr "Length must be an int"
-
-#~ msgid "Length must be non-negative"
-#~ msgstr "Length must be non-negative"
+#~ msgid "maximum number of dimensions is 4"
+#~ msgstr "maximum number of dimensions is 4"
 
 #~ msgid "name reused for argument"
 #~ msgstr "name reused for argument"
+
+#~ msgid "no available NIC"
+#~ msgstr "no available NIC"
+
+#~ msgid "no reset pin available"
+#~ msgstr "no reset pin available"
+
+#~ msgid "non-Device in %q"
+#~ msgstr "non-Device in %q"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "non-keyword arg after */**"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "non-keyword arg after keyword arg"
+
+#~ msgid "norm is defined for 1D and 2D arrays"
+#~ msgstr "norm is defined for 1D and 2D arrays"
 
 #~ msgid "object '%q' is not a tuple or list"
 #~ msgstr "object '%q' is not a tuple or list"
@@ -5581,90 +5493,158 @@ msgstr "zi must be of shape (n_section, 2)"
 #~ msgid "object of type '%q' has no len()"
 #~ msgstr "object of type '%q' has no len()"
 
-#~ msgid "struct: cannot index"
-#~ msgstr "struct: cannot index"
+#~ msgid "offset out of bounds"
+#~ msgstr "offset out of bounds"
 
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "Cannot remount '/' when USB is active."
+#~ msgid "out of range of source"
+#~ msgstr "out of range of source"
 
-#~ msgid "byte code not implemented"
-#~ msgstr "Byte code not implemented"
-
-#~ msgid "can't pend throw to just-started generator"
-#~ msgstr "can't pend throw to just-started generator"
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "invalid dupterm index"
-
-#~ msgid "schedule stack full"
-#~ msgstr "schedule stack full"
-
-#~ msgid "Corrupt raw code"
-#~ msgstr "Corrupt raw code"
-
-#~ msgid "can only save bytecode"
-#~ msgstr "Can only save bytecode"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr "Viper functions don't currently support more than 4 arguments"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "address %08x is not aligned to %d bytes"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "function does not take keyword arguments"
+#~ msgid "palette_index should be an int"
+#~ msgstr "palette_index should be an int"
 
 #~ msgid "parameter annotation must be an identifier"
 #~ msgstr "parameter annotation must be an identifier"
 
-#~ msgid "Total data to write is larger than outgoing_packet_length"
-#~ msgstr "Total data to write is larger than outgoing_packet_length"
+#~ msgid "pixel value requires too many bits"
+#~ msgstr "pixel value requires too many bits"
 
-#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
-#~ msgstr "IOs 0, 2 & 4 do not support internal pullup in sleep"
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+#~ msgstr "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 
-#~ msgid "buffer must be a bytes-like object"
-#~ msgstr "Buffer must be a bytes-like object"
+#~ msgid "polygon can only be registered in one parent"
+#~ msgstr "polygon can only be registered in one parent"
 
-#~ msgid "io must be rtc io"
-#~ msgstr "io must be rtc io"
+#~ msgid "pressing boot button at start up.\n"
+#~ msgstr "pressing boot button at start up.\n"
+
+#~ msgid "pressing both buttons at start up.\n"
+#~ msgstr "pressing both buttons at start up.\n"
+
+#~ msgid "pressing the left button at start up\n"
+#~ msgstr "pressing the left button at start up\n"
+
+#~ msgid "pull_threshold must be between 1 and 32"
+#~ msgstr "pull_threshold must be between 1 and 32"
+
+#~ msgid "push_threshold must be between 1 and 32"
+#~ msgstr "push_threshold must be between 1 and 32"
+
+#~ msgid "queue overflow"
+#~ msgstr "queue overflow"
+
+#, fuzzy
+#~ msgid "raw REPL; CTRL-B to exit\n"
+#~ msgstr "raw REPL; CTRL-B to exit\n"
+
+#~ msgid "raw f-strings are not implemented"
+#~ msgstr "raw f-strings are not implemented"
+
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+
+#~ msgid "schedule stack full"
+#~ msgstr "schedule stack full"
+
+#~ msgid "shape must be a tuple"
+#~ msgstr "shape must be a tuple"
+
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "single '}' encountered in format string"
+
+#~ msgid "slice step can't be zero"
+#~ msgstr "slice step can't be zero"
+
+#~ msgid "slice step cannot be zero"
+#~ msgstr "slice step cannot be zero"
+
+#~ msgid "start_x should be an int"
+#~ msgstr "start_x should be an int"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "step must be non-zero"
+
+#~ msgid "stop must be 1 or 2"
+#~ msgstr "stop must be 1 or 2"
+
+#~ msgid "string indices must be integers, not %q"
+#~ msgstr "string indices must be integers, not %q"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr "string not supported; use bytes or bytearray"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "struct: cannot index"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "threshold must be in the range 0-65536"
+
+#~ msgid "tile must be greater than zero"
+#~ msgstr "tile must be greater than zero"
+
+#~ msgid "time.struct_time() takes a 9-sequence"
+#~ msgstr "time.struct_time() takes a 9-sequence"
+
+#~ msgid "timeout must be 0.0-100.0 seconds"
+#~ msgstr "timeout must be 0.0-100.0 seconds"
+
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "timeout must be >= 0.0"
+
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "too many arguments provided with the given format"
+
+#~ msgid "trapz is defined for 1D arrays"
+#~ msgstr "trapz is defined for 1D arrays"
 
 #~ msgid "trigger level must be 0 or 1"
 #~ msgstr "trigger level must be 0 or 1"
 
+#~ msgid "type object 'generator' has no attribute '__await__'"
+#~ msgstr "type object 'generator' has no attribute '__await__'"
+
+#~ msgid "unindent does not match any outer indentation level"
+#~ msgstr "unindent does not match any outer indentation level"
+
+#~ msgid "unmatched '{' in format"
+#~ msgstr "unmatched '{' in format"
+
+#~ msgid "unsupported type for %q: '%q'"
+#~ msgstr "unsupported type for %q: '%q'"
+
+#~ msgid "value_count must be > 0"
+#~ msgstr "value_count must be > 0"
+
 #~ msgid "wakeup conflict"
 #~ msgstr "wakeup conflict"
 
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr "Attempted heap allocation when MicroPython VM not running."
+#~ msgid "watchdog not initialized"
+#~ msgstr "WatchDog not initialised"
 
-#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
-#~ msgstr "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgid "watchdog timeout must be greater than 0"
+#~ msgstr "WatchDog timeout must be greater than 0"
 
-#, fuzzy
-#~ msgid "MicroPython fatal error."
-#~ msgstr "CircuitPython fatal error."
+#, c-format
+#~ msgid "width must be from 2 to 8 (inclusive), not %d"
+#~ msgstr "width must be from 2 to 8 (inclusive), not %d"
 
-#~ msgid "argument must be ndarray"
-#~ msgstr "argument must be ndarray"
+#~ msgid "wrong operand type"
+#~ msgstr "wrong operand type"
 
-#~ msgid "norm is defined for 1D and 2D arrays"
-#~ msgstr "norm is defined for 1D and 2D arrays"
+#~ msgid "x value out of bounds"
+#~ msgstr "x value out of bounds"
 
-#~ msgid "Nordic Soft Device failure assertion."
-#~ msgstr "Nordic Soft Device failure assertion."
+#~ msgid "xTaskCreate failed"
+#~ msgstr "xTaskCreate failed"
 
-#~ msgid "Unknown soft device error: %04x"
-#~ msgstr "Unknown soft device error: %04x"
+#~ msgid "y should be an int"
+#~ msgstr "y should be an int"
 
-#~ msgid "first argument must be an iterable"
-#~ msgstr "first argument must be an iterable"
+#~ msgid "y value out of bounds"
+#~ msgstr "y value out of bounds"
 
-#~ msgid "iterables are not of the same length"
-#~ msgstr "iterables are not of the same length"
-
-#~ msgid "Selected CTS pin not valid"
-#~ msgstr "Selected CTS pin not valid"
-
-#~ msgid "Selected RTS pin not valid"
-#~ msgstr "Selected RTS pin not valid"
+#~ msgid "zero step"
+#~ msgstr "zero step"

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2014 MicroPython & CircuitPython contributors (https://github.com/adafruit/circuitpython/graphs/contributors)
 #
 # SPDX-License-Identifier: MIT
-
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
@@ -19,20 +18,32 @@ msgstr ""
 #: main.c
 msgid ""
 "\n"
-"Code done running. Waiting for reload.\n"
+"Code done running.\n"
+msgstr ""
+
+#: main.c
+msgid ""
+"\n"
+"Code stopped by auto-reload. Reloading soon.\n"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
 "\n"
-"Please file an issue with the contents of your CIRCUITPY drive at \n"
-"https://github.com/adafruit/circuitpython/issues\n"
+"Please file an issue with your program at github.com/adafruit/circuitpython/"
+"issues."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
 "\n"
-"To exit, please reset the board without "
+"Press reset to exit safe mode.\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"You are in safe mode because:\n"
 msgstr ""
 
 #: py/obj.c
@@ -41,6 +52,14 @@ msgstr ""
 
 #: py/obj.c
 msgid "  File \"%q\", line %d"
+msgstr ""
+
+#: py/builtinhelp.c
+msgid " is of type %q\n"
+msgstr ""
+
+#: main.c
+msgid " not found.\n"
 msgstr ""
 
 #: main.c
@@ -54,14 +73,42 @@ msgstr ""
 
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
-msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+msgid ""
+"%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr ""
 
+#: shared-bindings/microcontroller/Pin.c
+msgid "%q and %q contain duplicate pins"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
+msgid "%q and %q must be different"
+msgstr ""
+
+#: shared-bindings/microcontroller/Pin.c
+msgid "%q contains duplicate pins"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/sdioio/SDCard.c
+msgid "%q failure: %d"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q in %q must be of type %q, not %q"
+msgstr ""
+
+#: ports/espressif/common-hal/espulp/ULP.c
+#: ports/mimxrt10xx/common-hal/audiobusio/__init__.c
+#: ports/mimxrt10xx/common-hal/usb_host/Port.c
+#: ports/raspberrypi/common-hal/picodvi/Framebuffer.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#: ports/raspberrypi/common-hal/usb_host/Port.c
+#: shared-bindings/digitalio/DigitalInOut.c
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q in use"
 msgstr ""
 
-#: py/obj.c
+#: py/objstr.c
 msgid "%q index out of range"
 msgstr ""
 
@@ -69,31 +116,173 @@ msgstr ""
 msgid "%q indices must be integers, not %s"
 msgstr ""
 
-#: shared-bindings/vectorio/Polygon.c
-msgid "%q list must be a list"
+#: shared-module/bitbangio/SPI.c
+msgid "%q init failed"
 msgstr ""
 
-#: shared-bindings/_bleio/CharacteristicBuffer.c
-#: shared-bindings/_bleio/PacketBuffer.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/Shape.c shared-bindings/vectorio/Circle.c
-#: shared-bindings/vectorio/Rectangle.c
-msgid "%q must be >= 1"
+#: ports/espressif/bindings/espnow/Peer.c shared-bindings/dualbank/__init__.c
+msgid "%q is %q"
 msgstr ""
 
-#: shared-module/vectorio/Polygon.c
-msgid "%q must be a tuple of length 2"
+#: ports/raspberrypi/common-hal/wifi/Radio.c
+msgid "%q is read-only for this board"
 msgstr ""
 
-#: shared-bindings/fontio/BuiltinFont.c
-msgid "%q should be an int"
+#: py/argcheck.c shared-bindings/usb_hid/Device.c
+msgid "%q length must be %d"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q length must be %d-%d"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q length must be <= %d"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q length must be >= %d"
+msgstr ""
+
+#: py/objmodule.c py/runtime.c
+msgid "%q moved from %q to %q"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q must be %d"
+msgstr ""
+
+#: py/argcheck.c shared-bindings/busdisplay/BusDisplay.c
+#: shared-bindings/displayio/Bitmap.c
+#: shared-bindings/framebufferio/FramebufferDisplay.c
+#: shared-bindings/is31fl3741/FrameBuffer.c
+#: shared-bindings/rgbmatrix/RGBMatrix.c
+msgid "%q must be %d-%d"
+msgstr ""
+
+#: shared-bindings/busdisplay/BusDisplay.c
+msgid "%q must be 1 when %q is True"
+msgstr ""
+
+#: py/argcheck.c shared-bindings/gifio/GifWriter.c
+#: shared-module/gifio/OnDiskGif.c
+msgid "%q must be <= %d"
+msgstr ""
+
+#: ports/espressif/common-hal/watchdog/WatchDogTimer.c
+msgid "%q must be <= %u"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q must be >= %d"
+msgstr ""
+
+#: shared-bindings/analogbufio/BufferedIn.c
+msgid "%q must be a bytearray or array of type 'H' or 'B'"
+msgstr ""
+
+#: shared-bindings/audiocore/RawSample.c
+msgid "%q must be a bytearray or array of type 'h', 'H', 'b', or 'B'"
+msgstr ""
+
+#: shared-bindings/warnings/__init__.c
+msgid "%q must be a subclass of %q"
+msgstr ""
+
+#: ports/espressif/common-hal/analogbufio/BufferedIn.c
+msgid "%q must be array of type 'H'"
+msgstr ""
+
+#: shared-module/synthio/__init__.c
+msgid "%q must be array of type 'h'"
+msgstr ""
+
+#: ports/raspberrypi/bindings/cyw43/__init__.c py/argcheck.c py/objexcept.c
+#: shared-bindings/canio/CAN.c shared-bindings/digitalio/Pull.c
+#: shared-module/synthio/Synthesizer.c
+msgid "%q must be of type %q or %q, not %q"
+msgstr ""
+
+#: py/argcheck.c shared-module/synthio/__init__.c
+msgid "%q must be of type %q, not %q"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/busio/UART.c
+msgid "%q must be power of 2"
+msgstr ""
+
+#: shared-bindings/wifi/Monitor.c
+msgid "%q out of bounds"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/cxd56/common-hal/pulseio/PulseIn.c
+#: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#: ports/stm/common-hal/pulseio/PulseIn.c py/argcheck.c
+#: shared-bindings/canio/Match.c
+msgid "%q out of range"
+msgstr ""
+
+#: py/objmodule.c py/runtime.c
+msgid "%q renamed %q"
+msgstr ""
+
+#: py/objrange.c py/objslice.c shared-bindings/random/__init__.c
+msgid "%q step cannot be zero"
 msgstr ""
 
 #: py/bc.c py/objnamedtuple.c
 msgid "%q() takes %d positional arguments but %d were given"
 msgstr ""
 
+#: shared-bindings/usb_hid/Device.c
+msgid "%q, %q, and %q must all be the same length"
+msgstr ""
+
+#: py/objint.c shared-bindings/storage/__init__.c
+msgid "%q=%q"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "%q[%u] shifts in more bits than pin count"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "%q[%u] shifts out more bits than pin count"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "%q[%u] uses extra pin"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "%q[%u] waits on input outside of count"
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+#, c-format
+msgid "%s error 0x%x"
+msgstr ""
+
 #: py/argcheck.c
 msgid "'%q' argument required"
+msgstr ""
+
+#: py/proto.c
+msgid "'%q' object does not support '%q'"
+msgstr ""
+
+#: py/runtime.c
+msgid "'%q' object is not an iterator"
+msgstr ""
+
+#: py/objtype.c py/runtime.c shared-module/atexit/__init__.c
+msgid "'%q' object is not callable"
+msgstr ""
+
+#: py/runtime.c
+msgid "'%q' object is not iterable"
 msgstr ""
 
 #: py/emitinlinethumb.c py/emitinlinextensa.c
@@ -138,54 +327,31 @@ msgstr ""
 
 #: py/emitinlinextensa.c
 #, c-format
-msgid "'%s' integer %d is not within range %d..%d"
+msgid "'%s' integer %d isn't within range %d..%d"
 msgstr ""
 
 #: py/emitinlinethumb.c
 #, c-format
-msgid "'%s' integer 0x%x does not fit in mask 0x%x"
-msgstr ""
-
-#: py/runtime.c
-msgid "'%s' object cannot assign attribute '%q'"
-msgstr ""
-
-#: py/proto.c
-msgid "'%s' object does not support '%q'"
+msgid "'%s' integer 0x%x doesn't fit in mask 0x%x"
 msgstr ""
 
 #: py/obj.c
 #, c-format
-msgid "'%s' object does not support item assignment"
+msgid "'%s' object doesn't support item assignment"
 msgstr ""
 
 #: py/obj.c
 #, c-format
-msgid "'%s' object does not support item deletion"
+msgid "'%s' object doesn't support item deletion"
 msgstr ""
 
 #: py/runtime.c
 msgid "'%s' object has no attribute '%q'"
 msgstr ""
 
-#: py/runtime.c
-#, c-format
-msgid "'%s' object is not an iterator"
-msgstr ""
-
-#: py/objtype.c py/runtime.c
-#, c-format
-msgid "'%s' object is not callable"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "'%s' object is not iterable"
-msgstr ""
-
 #: py/obj.c
 #, c-format
-msgid "'%s' object is not subscriptable"
+msgid "'%s' object isn't subscriptable"
 msgstr ""
 
 #: py/objstr.c
@@ -201,19 +367,11 @@ msgid "'align' requires 1 argument"
 msgstr ""
 
 #: py/compile.c
-msgid "'async for' or 'async with' outside async function"
-msgstr ""
-
-#: py/compile.c
 msgid "'await' outside function"
 msgstr ""
 
 #: py/compile.c
-msgid "'break' outside loop"
-msgstr ""
-
-#: py/compile.c
-msgid "'continue' outside loop"
+msgid "'break'/'continue' outside loop"
 msgstr ""
 
 #: py/compile.c
@@ -233,7 +391,15 @@ msgid "'return' outside function"
 msgstr ""
 
 #: py/compile.c
+msgid "'yield from' inside async function"
+msgstr ""
+
+#: py/compile.c
 msgid "'yield' outside function"
+msgstr ""
+
+#: py/compile.c
+msgid "* arg after **"
 msgstr ""
 
 #: py/compile.c
@@ -244,6 +410,12 @@ msgstr ""
 msgid ", in %q\n"
 msgstr ""
 
+#: shared-bindings/busdisplay/BusDisplay.c
+#: shared-bindings/epaperdisplay/EPaperDisplay.c
+#: shared-bindings/framebufferio/FramebufferDisplay.c
+msgid ".show(x) removed. Use .root_group = x"
+msgstr ""
+
 #: py/objcomplex.c
 msgid "0.0 to a complex power"
 msgstr ""
@@ -252,41 +424,88 @@ msgstr ""
 msgid "3-arg pow() not supported"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
 #: ports/atmel-samd/common-hal/countio/Counter.c
 #: ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
 msgid "A hardware interrupt channel is already in use"
 msgstr ""
 
-#: shared-bindings/_bleio/Address.c
+#: ports/raspberrypi/common-hal/wifi/Radio.c
+msgid "AP could not be started"
+msgstr ""
+
+#: shared-bindings/_bleio/Address.c shared-bindings/ipaddress/IPv4Address.c
 #, c-format
 msgid "Address must be %d bytes long"
 msgstr ""
 
-#: shared-bindings/_bleio/Address.c
-msgid "Address type out of range"
+#: ports/espressif/common-hal/memorymap/AddressRange.c
+#: ports/nrf/common-hal/memorymap/AddressRange.c
+#: ports/raspberrypi/common-hal/memorymap/AddressRange.c
+msgid "Address range not allowed"
 msgstr ""
 
+#: shared-bindings/memorymap/AddressRange.c
+msgid "Address range wraps around"
+msgstr ""
+
+#: ports/espressif/common-hal/canio/CAN.c
+msgid "All CAN peripherals are in use"
+msgstr ""
+
+#: ports/espressif/common-hal/busio/I2C.c
+#: ports/espressif/common-hal/i2ctarget/I2CTarget.c
 #: ports/nrf/common-hal/busio/I2C.c
 msgid "All I2C peripherals are in use"
 msgstr ""
 
-#: ports/nrf/common-hal/busio/SPI.c
+#: ports/espressif/common-hal/countio/Counter.c
+#: ports/espressif/common-hal/frequencyio/FrequencyIn.c
+#: ports/espressif/common-hal/rotaryio/IncrementalEncoder.c
+msgid "All PCNT units in use"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/canio/Listener.c
+#: ports/espressif/common-hal/canio/Listener.c
+#: ports/stm/common-hal/canio/Listener.c
+msgid "All RX FIFOs in use"
+msgstr ""
+
+#: ports/espressif/common-hal/busio/SPI.c ports/nrf/common-hal/busio/SPI.c
 msgid "All SPI peripherals are in use"
 msgstr ""
 
-#: ports/nrf/common-hal/busio/UART.c
+#: ports/espressif/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
 msgid "All UART peripherals are in use"
+msgstr ""
+
+#: ports/nrf/common-hal/countio/Counter.c
+#: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/nrf/common-hal/rotaryio/IncrementalEncoder.c
+#: shared-bindings/pwmio/PWMOut.c
+msgid "All channels in use"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/usb_host/Port.c
+msgid "All dma channels in use"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "All event channels in use"
 msgstr ""
 
-#: ports/atmel-samd/audio_dma.c ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+#: ports/raspberrypi/common-hal/picodvi/Framebuffer.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#: ports/raspberrypi/common-hal/usb_host/Port.c
+msgid "All state machines in use"
+msgstr ""
+
+#: ports/atmel-samd/audio_dma.c
 msgid "All sync event channels in use"
 msgstr ""
 
-#: shared-bindings/pulseio/PWMOut.c
+#: ports/raspberrypi/common-hal/picodvi/Framebuffer.c
+#: shared-bindings/pwmio/PWMOut.c
 msgid "All timers for this pin are in use"
 msgstr ""
 
@@ -296,32 +515,45 @@ msgstr ""
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
 #: ports/cxd56/common-hal/pulseio/PulseOut.c
+#: ports/espressif/common-hal/frequencyio/FrequencyIn.c
+#: ports/espressif/common-hal/neopixel_write/__init__.c
+#: ports/espressif/common-hal/pulseio/PulseIn.c
+#: ports/espressif/common-hal/pulseio/PulseOut.c
 #: ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c ports/nrf/peripherals/nrf/timers.c
-#: shared-bindings/pulseio/PWMOut.c
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+#: ports/stm/peripherals/timers.c shared-bindings/pwmio/PWMOut.c
 msgid "All timers in use"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "Already advertising."
 msgstr ""
 
-#: ports/cxd56/common-hal/analogio/AnalogIn.c
-msgid "AnalogIn not supported on given pin"
+#: ports/atmel-samd/common-hal/canio/Listener.c
+msgid "Already have all-matches listener"
 msgstr ""
 
-#: ports/cxd56/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-msgid "AnalogOut functionality not supported"
+#: ports/espressif/bindings/espnow/ESPNow.c
+#: ports/espressif/common-hal/espulp/ULP.c
+#: shared-module/memorymonitor/AllocationAlarm.c
+#: shared-module/memorymonitor/AllocationSize.c
+msgid "Already running"
 msgstr ""
 
-#: shared-bindings/analogio/AnalogOut.c
-msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#: ports/espressif/common-hal/wifi/Radio.c
+#: ports/raspberrypi/common-hal/wifi/Radio.c
+msgid "Already scanning for wifi networks"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/analogio/AnalogOut.c
-msgid "AnalogOut not supported on given pin"
+#: shared-module/os/getenv.c
+#, c-format
+msgid "An error occurred while retrieving '%s':\n"
+msgstr ""
+
+#: ports/stm/common-hal/audiopwmio/PWMAudioOut.c
+msgid "Another PWMAudioOut is already active"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
@@ -333,16 +565,26 @@ msgstr ""
 msgid "Array must contain halfwords (type 'H')"
 msgstr ""
 
+#: shared-bindings/alarm/SleepMemory.c shared-bindings/memorymap/AddressRange.c
 #: shared-bindings/nvm/ByteArray.c
 msgid "Array values should be single bytes."
 msgstr ""
 
-#: shared-bindings/rgbmatrix/RGBMatrix.c
-msgid "At most %d %q may be specified (not %d)"
+#: shared-module/memorymonitor/AllocationAlarm.c
+#, c-format
+msgid "Attempt to allocate %d blocks"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running."
+#: ports/raspberrypi/audio_dma.c
+msgid "Audio conversion not implemented"
+msgstr ""
+
+#: shared-bindings/wifi/Radio.c
+msgid "AuthMode.OPEN is not used with password"
+msgstr ""
+
+#: shared-bindings/wifi/Radio.c supervisor/shared/web_workflow/web_workflow.c
+msgid "Authentication failure"
 msgstr ""
 
 #: main.c
@@ -355,9 +597,17 @@ msgid ""
 "disable.\n"
 msgstr ""
 
-#: shared-module/displayio/Display.c
+#: ports/espressif/common-hal/canio/CAN.c
+msgid "Baudrate not supported by peripheral"
+msgstr ""
+
+#: shared-module/busdisplay/BusDisplay.c
 #: shared-module/framebufferio/FramebufferDisplay.c
 msgid "Below minimum frame rate"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+msgid "Bit clock and word select must be sequential GPIO pins"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -368,6 +618,14 @@ msgstr ""
 msgid "Bit depth must be multiple of 8."
 msgstr ""
 
+#: shared-bindings/bitmaptools/__init__.c
+msgid "Bitmap size and bits per value must match"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Boot device must be first (interface #0)."
+msgstr ""
+
 #: ports/mimxrt10xx/common-hal/busio/UART.c
 msgid "Both RX and TX required for flow control"
 msgstr ""
@@ -376,17 +634,7 @@ msgstr ""
 msgid "Both pins must support hardware interrupts"
 msgstr ""
 
-#: shared-bindings/displayio/Display.c
-#: shared-bindings/framebufferio/FramebufferDisplay.c
-#: shared-bindings/rgbmatrix/RGBMatrix.c
-msgid "Brightness must be 0-1.0"
-msgstr ""
-
-#: shared-bindings/supervisor/__init__.c
-msgid "Brightness must be between 0 and 255"
-msgstr ""
-
-#: shared-bindings/displayio/Display.c
+#: shared-bindings/busdisplay/BusDisplay.c
 #: shared-bindings/framebufferio/FramebufferDisplay.c
 msgid "Brightness not adjustable"
 msgstr ""
@@ -396,32 +644,26 @@ msgstr ""
 msgid "Buffer + offset too small %d %d %d"
 msgstr ""
 
-#: shared-module/usb_hid/Device.c
-#, c-format
-msgid "Buffer incorrect size. Should be %d bytes."
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+msgid "Buffer elements must be 4 bytes long or less"
 msgstr ""
 
-#: shared-bindings/displayio/Display.c
 #: shared-bindings/framebufferio/FramebufferDisplay.c
 msgid "Buffer is not a bytearray."
 msgstr ""
 
-#: shared-bindings/displayio/Display.c
-#: shared-bindings/framebufferio/FramebufferDisplay.c
-msgid "Buffer is too small"
-msgstr ""
-
-#: ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
+#: ports/stm/common-hal/audiopwmio/PWMAudioOut.c
 #, c-format
 msgid "Buffer length %d too big. It must be less than %d"
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
-msgid "Buffer must be at least length 1"
+#: ports/atmel-samd/common-hal/sdioio/SDCard.c
+#: ports/cxd56/common-hal/sdioio/SDCard.c shared-module/sdcardio/SDCard.c
+msgid "Buffer length must be a multiple of 512"
 msgstr ""
 
-#: ports/nrf/common-hal/_bleio/PacketBuffer.c
-msgid "Buffer too large and unable to allocate"
+#: ports/stm/common-hal/sdioio/SDCard.c shared-bindings/floppyio/__init__.c
+msgid "Buffer must be a multiple of 512 bytes"
 msgstr ""
 
 #: shared-bindings/_bleio/PacketBuffer.c
@@ -429,8 +671,21 @@ msgstr ""
 msgid "Buffer too short by %d bytes"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
-#: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/cxd56/common-hal/camera/Camera.c
+#: shared-bindings/busdisplay/BusDisplay.c
+#: shared-bindings/framebufferio/FramebufferDisplay.c
+#: shared-bindings/struct/__init__.c shared-module/struct/__init__.c
+msgid "Buffer too small"
+msgstr ""
+
+#: ports/espressif/common-hal/imagecapture/ParallelImageCapture.c
+msgid "Buffers must be same size"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/paralleldisplaybus/ParallelBus.c
+#: ports/espressif/common-hal/paralleldisplaybus/ParallelBus.c
+#: ports/nrf/common-hal/paralleldisplaybus/ParallelBus.c
+#: ports/raspberrypi/common-hal/paralleldisplaybus/ParallelBus.c
 #, c-format
 msgid "Bus pin %d is already in use"
 msgstr ""
@@ -439,29 +694,62 @@ msgstr ""
 msgid "Byte buffer must be 16 bytes."
 msgstr ""
 
-#: shared-bindings/nvm/ByteArray.c
-msgid "Bytes must be between 0 and 255."
-msgstr ""
-
 #: shared-bindings/aesio/aes.c
 msgid "CBC blocks must be multiples of 16 bytes"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "CIRCUITPY drive could not be found or created."
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "CRC or checksum was invalid"
 msgstr ""
 
 #: py/objtype.c
 msgid "Call super().__init__() before accessing native object."
 msgstr ""
 
+#: ports/cxd56/common-hal/camera/Camera.c
+msgid "Camera init"
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
+msgid "Can only alarm on RTC IO from deep sleep."
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
+msgid "Can only alarm on one low pin while others alarm high from deep sleep."
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
+msgid "Can only alarm on two low pins from deep sleep."
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 msgid "Can't set CCCD on local Characteristic"
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/storage/__init__.c shared-bindings/usb_cdc/__init__.c
+#: shared-bindings/usb_hid/__init__.c shared-bindings/usb_midi/__init__.c
+msgid "Cannot change USB devices now"
+msgstr ""
+
+#: shared-bindings/_bleio/Adapter.c
+msgid "Cannot create a new Adapter; use _bleio.adapter;"
+msgstr ""
+
+#: shared-bindings/displayio/Bitmap.c
+#: shared-bindings/memorymonitor/AllocationSize.c
+#: shared-bindings/pulseio/PulseIn.c
 msgid "Cannot delete values"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/mimxrt10xx/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -473,12 +761,8 @@ msgstr ""
 msgid "Cannot have scan responses for extended, connectable advertisements."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-msgid "Cannot output both channels on the same pin"
-msgstr ""
-
-#: shared-module/bitbangio/SPI.c
-msgid "Cannot read without MISO pin."
+#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
+msgid "Cannot pull on input-only pin."
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -486,19 +770,24 @@ msgid "Cannot record to a file"
 msgstr ""
 
 #: shared-module/storage/__init__.c
-msgid "Cannot remount '/' when USB is active."
+msgid "Cannot remount '/' when visible via USB."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/cxd56/common-hal/microcontroller/__init__.c
 #: ports/mimxrt10xx/common-hal/microcontroller/__init__.c
-msgid "Cannot reset into bootloader because no bootloader is present."
+msgid "Cannot reset into bootloader because no bootloader is present"
+msgstr ""
+
+#: ports/espressif/common-hal/socketpool/Socket.c
+msgid "Cannot set socket options"
 msgstr ""
 
 #: shared-bindings/digitalio/DigitalInOut.c
 msgid "Cannot set value when direction is input."
 msgstr ""
 
+#: ports/espressif/common-hal/busio/UART.c
 #: ports/mimxrt10xx/common-hal/busio/UART.c
 msgid "Cannot specify RTS or CTS in RS485 mode"
 msgstr ""
@@ -507,20 +796,16 @@ msgstr ""
 msgid "Cannot subclass slice"
 msgstr ""
 
-#: shared-module/bitbangio/SPI.c
-msgid "Cannot transfer without MOSI and MISO pins."
-msgstr ""
-
-#: extmod/moductypes.c
-msgid "Cannot unambiguously get sizeof scalar"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
+#: shared-bindings/pwmio/PWMOut.c
 msgid "Cannot vary frequency on a timer that is already in use"
 msgstr ""
 
-#: shared-module/bitbangio/SPI.c
-msgid "Cannot write without MOSI pin."
+#: ports/nrf/common-hal/alarm/pin/PinAlarm.c
+msgid "Cannot wake on pin edge, only level"
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
+msgid "Cannot wake on pin edge. Only level."
 msgstr ""
 
 #: shared-bindings/_bleio/CharacteristicBuffer.c
@@ -531,16 +816,6 @@ msgstr ""
 msgid "CircuitPython core code crashed hard. Whoops!\n"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"CircuitPython is in safe mode because you pressed the reset button during "
-"boot. Press again to exit safe mode.\n"
-msgstr ""
-
-#: shared-module/bitbangio/SPI.c
-msgid "Clock pin init failed."
-msgstr ""
-
 #: shared-module/bitbangio/I2C.c
 msgid "Clock stretch too long"
 msgstr ""
@@ -549,58 +824,29 @@ msgstr ""
 msgid "Clock unit in use"
 msgstr ""
 
-#: shared-bindings/_pew/PewPew.c
-msgid "Column entry must be digitalio.DigitalInOut"
-msgstr ""
-
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/I2CDisplay.c
-#: shared-bindings/displayio/ParallelBus.c
-msgid "Command must be an int between 0 and 255"
-msgstr ""
-
 #: shared-bindings/_bleio/Connection.c
 msgid ""
 "Connection has been disconnected and can no longer be used. Create a new "
 "connection."
 msgstr ""
 
-#: py/persistentcode.c
-msgid "Corrupt .mpy file"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "Coordinate arrays have different lengths"
 msgstr ""
 
-#: py/emitglue.c
-msgid "Corrupt raw code"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "Coordinate arrays types have different sizes"
 msgstr ""
 
-#: ports/cxd56/common-hal/gnss/GNSS.c
-msgid "Could not initialize GNSS"
+#: ports/espressif/common-hal/neopixel_write/__init__.c
+msgid "Could not retrieve clock"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
-msgid "Could not initialize UART"
+#: shared-bindings/_bleio/Adapter.c
+msgid "Could not set address"
 msgstr ""
 
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Could not initialize channel"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Could not initialize timer"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Could not re-init channel"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Could not re-init timer"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Could not restart PWM"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
+#: shared-bindings/pwmio/PWMOut.c
 msgid "Could not start PWM"
 msgstr ""
 
@@ -610,24 +856,6 @@ msgstr ""
 
 #: shared-module/audiomp3/MP3Decoder.c
 msgid "Couldn't allocate decoder"
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c shared-module/audiomixer/Mixer.c
-#: shared-module/audiomp3/MP3Decoder.c
-msgid "Couldn't allocate first buffer"
-msgstr ""
-
-#: shared-module/audiomp3/MP3Decoder.c
-msgid "Couldn't allocate input buffer"
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c shared-module/audiomixer/Mixer.c
-#: shared-module/audiomp3/MP3Decoder.c
-msgid "Couldn't allocate second buffer"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler."
 msgstr ""
 
 #: ports/stm/common-hal/analogio/AnalogOut.c
@@ -642,8 +870,8 @@ msgstr ""
 msgid "DAC already in use"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
-#: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/paralleldisplaybus/ParallelBus.c
+#: ports/nrf/common-hal/paralleldisplaybus/ParallelBus.c
 msgid "Data 0 pin must be byte aligned"
 msgstr ""
 
@@ -651,8 +879,18 @@ msgstr ""
 msgid "Data chunk must follow fmt chunk"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Adapter.c
+#: ports/nrf/common-hal/_bleio/Adapter.c
+msgid "Data not supported with directed advertising"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "Data too large for advertisement packet"
+msgstr ""
+
+#: ports/stm/common-hal/alarm/pin/PinAlarm.c
+msgid "Deep sleep pins must use a rising edge with pulldown"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -663,27 +901,36 @@ msgstr ""
 msgid "Device in use"
 msgstr ""
 
-#: ports/cxd56/common-hal/digitalio/DigitalInOut.c
-msgid "DigitalInOut not supported on given pin"
-msgstr ""
-
-#: shared-bindings/displayio/Display.c
+#: shared-bindings/busdisplay/BusDisplay.c
 #: shared-bindings/framebufferio/FramebufferDisplay.c
 msgid "Display must have a 16 bit colorspace."
 msgstr ""
 
-#: shared-bindings/displayio/Display.c
-#: shared-bindings/displayio/EPaperDisplay.c
+#: shared-bindings/busdisplay/BusDisplay.c
+#: shared-bindings/epaperdisplay/EPaperDisplay.c
 #: shared-bindings/framebufferio/FramebufferDisplay.c
 msgid "Display rotation must be in 90 degree increments"
+msgstr ""
+
+#: main.c
+msgid "Done"
 msgstr ""
 
 #: shared-bindings/digitalio/DigitalInOut.c
 msgid "Drive mode not used when direction is input."
 msgstr ""
 
+#: py/obj.c
+msgid "During handling of the above exception, another exception occurred:"
+msgstr ""
+
 #: shared-bindings/aesio/aes.c
 msgid "ECB only operates on 16 bytes at a time"
+msgstr ""
+
+#: ports/espressif/common-hal/busio/SPI.c
+#: ports/espressif/common-hal/canio/CAN.c
+msgid "ESP-IDF memory allocation failed"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -693,45 +940,37 @@ msgstr ""
 msgid "EXTINT channel already in use"
 msgstr ""
 
-#: extmod/modure.c
+#: extmod/modre.c
 msgid "Error in regex"
 msgstr ""
 
-#: shared-bindings/aesio/aes.c shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
-#: shared-bindings/terminalio/Terminal.c
-msgid "Expected a %q"
+#: supervisor/shared/safe_mode.c
+msgid "Error in safemode.py."
 msgstr ""
 
-#: shared-bindings/_bleio/CharacteristicBuffer.c
-#: shared-bindings/_bleio/Descriptor.c shared-bindings/_bleio/PacketBuffer.c
-msgid "Expected a Characteristic"
+#: shared-bindings/socketpool/Socket.c shared-bindings/ssl/SSLSocket.c
+msgid "Error: Failure to bind"
 msgstr ""
 
-#: shared-bindings/_bleio/Characteristic.c
-msgid "Expected a Service"
+#: shared-bindings/alarm/__init__.c
+msgid "Expected a kind of %q"
 msgstr ""
 
-#: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
-#: shared-bindings/_bleio/Service.c
-msgid "Expected a UUID"
-msgstr ""
-
-#: shared-bindings/_bleio/Adapter.c
-msgid "Expected an Address"
-msgstr ""
-
-#: shared-module/_pixelbuf/PixelBuf.c
-#, c-format
-msgid "Expected tuple of length %d, got %d"
-msgstr ""
-
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "Extended advertisements with scan response not supported."
 msgstr ""
 
-#: extmod/ulab/code/fft.c
+#: extmod/ulab/code/numpy/fft/fft_tools.c
 msgid "FFT is defined for ndarrays only"
+msgstr ""
+
+#: extmod/ulab/code/numpy/fft/fft_tools.c
+msgid "FFT is implemented for linear arrays only"
+msgstr ""
+
+#: ports/espressif/common-hal/ssl/SSLSocket.c
+msgid "Failed SSL handshake"
 msgstr ""
 
 #: shared-bindings/ps2io/Ps2.c
@@ -743,19 +982,32 @@ msgstr ""
 msgid "Failed to acquire mutex, err 0x%04x"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
-msgid "Failed to allocate RX buffer"
+#: ports/raspberrypi/common-hal/mdns/Server.c
+msgid "Failed to add service TXT record"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/cxd56/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c
-#: ports/stm/common-hal/pulseio/PulseIn.c
-#, c-format
-msgid "Failed to allocate RX buffer of %d bytes"
+#: shared-bindings/mdns/Server.c
+msgid ""
+"Failed to add service TXT record; non-string or bytes found in txt_records"
 msgstr ""
 
+#: shared-module/rgbmatrix/RGBMatrix.c
+msgid "Failed to allocate %q buffer"
+msgstr ""
+
+#: ports/espressif/common-hal/wifi/__init__.c
+msgid "Failed to allocate Wifi memory"
+msgstr ""
+
+#: ports/espressif/common-hal/wifi/ScannedNetworks.c
+msgid "Failed to allocate wifi scan memory"
+msgstr ""
+
+#: ports/stm/common-hal/audiopwmio/PWMAudioOut.c
+msgid "Failed to buffer the sample"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "Failed to connect: internal error"
 msgstr ""
@@ -777,15 +1029,50 @@ msgstr ""
 msgid "Failed to write internal flash."
 msgstr ""
 
-#: py/moduerrno.c
+#: py/moderrno.c
 msgid "File exists"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
-msgid "Frequency captured is above capability. Capture Paused."
+#: shared-module/os/getenv.c
+msgid "File not found"
 msgstr ""
 
-#: ports/stm/common-hal/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/canio/Listener.c
+#: ports/espressif/common-hal/canio/Listener.c
+#: ports/stm/common-hal/canio/Listener.c
+msgid "Filters too complex"
+msgstr ""
+
+#: ports/espressif/common-hal/dualbank/__init__.c
+msgid "Firmware is duplicate"
+msgstr ""
+
+#: ports/espressif/common-hal/dualbank/__init__.c
+msgid "Firmware is invalid"
+msgstr ""
+
+#: ports/espressif/common-hal/dualbank/__init__.c
+msgid "Firmware is too big"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "For L8 colorspace, input bitmap must have 8 bits per pixel"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "For RGB colorspaces, input bitmap must have 16 bits per pixel"
+msgstr ""
+
+#: ports/cxd56/common-hal/camera/Camera.c
+msgid "Format not supported"
+msgstr ""
+
+#: ports/mimxrt10xx/common-hal/microcontroller/Processor.c
+msgid ""
+"Frequency must be 24, 150, 396, 450, 528, 600, 720, 816, 912, 960 or 1008 Mhz"
+msgstr ""
+
+#: shared-bindings/pwmio/PWMOut.c
 msgid "Frequency must match existing PWMOut using this timer"
 msgstr ""
 
@@ -794,23 +1081,45 @@ msgstr ""
 msgid "Function requires lock"
 msgstr ""
 
-#: shared-bindings/displayio/Display.c
-#: shared-bindings/displayio/EPaperDisplay.c
+#: ports/cxd56/common-hal/gnss/GNSS.c
+msgid "GNSS init"
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Generic Failure"
+msgstr ""
+
 #: shared-bindings/framebufferio/FramebufferDisplay.c
+#: shared-module/busdisplay/BusDisplay.c
+#: shared-module/framebufferio/FramebufferDisplay.c
 msgid "Group already used"
 msgstr ""
 
-#: shared-module/displayio/Group.c
-msgid "Group full"
+#: ports/atmel-samd/common-hal/busio/SPI.c ports/cxd56/common-hal/busio/SPI.c
+#: ports/espressif/common-hal/busio/SPI.c
+#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/nrf/common-hal/busio/SPI.c
+#: ports/raspberrypi/common-hal/busio/SPI.c
+msgid "Half duplex SPI is not implemented"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/I2C.c
-#: ports/stm/common-hal/busio/SPI.c
-msgid "Hardware busy, try alternative pins"
+#: supervisor/shared/safe_mode.c
+msgid "Hard fault: memory access or instruction error."
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
+#: ports/mimxrt10xx/common-hal/busio/SPI.c
+#: ports/mimxrt10xx/common-hal/busio/UART.c ports/stm/common-hal/busio/I2C.c
+#: ports/stm/common-hal/busio/SPI.c ports/stm/common-hal/busio/UART.c
+#: ports/stm/common-hal/canio/CAN.c ports/stm/common-hal/sdioio/SDCard.c
 msgid "Hardware in use, try alternative pins"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Heap allocation when VM not running."
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"Heap was corrupted because the stack was too small. Increase stack size."
 msgstr ""
 
 #: extmod/vfs_posix_file.c py/objstringio.c
@@ -818,25 +1127,44 @@ msgid "I/O operation on closed file"
 msgstr ""
 
 #: ports/stm/common-hal/busio/I2C.c
-msgid "I2C Init Error"
+msgid "I2C init error"
 msgstr ""
 
-#: shared-bindings/aesio/aes.c
-#, c-format
-msgid "IV must be %d bytes long"
+#: ports/raspberrypi/common-hal/busio/I2C.c
+#: ports/raspberrypi/common-hal/i2ctarget/I2CTarget.c
+msgid "I2C peripheral in use"
 msgstr ""
 
-#: py/persistentcode.c
-msgid ""
-"Incompatible .mpy file. Please update all .mpy files. See http://adafru.it/"
-"mpy-update for more info."
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+msgid "In-buffer elements must be <= 4 bytes long"
 msgstr ""
 
 #: shared-bindings/_pew/PewPew.c
 msgid "Incorrect buffer size"
 msgstr ""
 
-#: py/moduerrno.c
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+msgid "Init program size invalid"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Initial set pin direction conflicts with initial out pin direction"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Initial set pin state conflicts with initial out pin state"
+msgstr ""
+
+#: shared-bindings/bitops/__init__.c
+#, c-format
+msgid "Input buffer length (%d) must be a multiple of the strand count (%d)"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+msgid "Input taking too long"
+msgstr ""
+
+#: ports/espressif/common-hal/neopixel_write/__init__.c py/moderrno.c
 msgid "Input/output error"
 msgstr ""
 
@@ -848,8 +1176,21 @@ msgstr ""
 msgid "Insufficient encryption"
 msgstr ""
 
+#: ports/espressif/common-hal/wifi/Radio.c
+msgid "Interface must be started"
+msgstr ""
+
+#: ports/atmel-samd/audio_dma.c ports/raspberrypi/audio_dma.c
+msgid "Internal audio buffer too small"
+msgstr ""
+
 #: ports/stm/common-hal/busio/UART.c
 msgid "Internal define error"
+msgstr ""
+
+#: ports/espressif/common-hal/paralleldisplaybus/ParallelBus.c
+#: shared-module/os/getenv.c
+msgid "Internal error"
 msgstr ""
 
 #: shared-module/rgbmatrix/RGBMatrix.c
@@ -857,8 +1198,27 @@ msgstr ""
 msgid "Internal error #%d"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+#: supervisor/shared/safe_mode.c
+msgid "Internal watchdog timer expired."
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Interrupt error."
+msgstr ""
+
+#: ports/mimxrt10xx/common-hal/audiobusio/__init__.c
+#: ports/mimxrt10xx/common-hal/pwmio/PWMOut.c
+#: ports/raspberrypi/bindings/picodvi/Framebuffer.c
+#: ports/raspberrypi/common-hal/picodvi/Framebuffer.c py/argcheck.c
+#: shared-bindings/digitalio/DigitalInOut.c
+#: shared-bindings/epaperdisplay/EPaperDisplay.c
+msgid "Invalid %q"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/microcontroller/Pin.c
+#: ports/espressif/common-hal/dotclockframebuffer/DotClockFramebuffer.c
+#: ports/mimxrt10xx/common-hal/microcontroller/Pin.c
+#: shared-bindings/microcontroller/Pin.c
 msgid "Invalid %q pin"
 msgstr ""
 
@@ -866,33 +1226,20 @@ msgstr ""
 msgid "Invalid ADC Unit value"
 msgstr ""
 
-#: shared-module/displayio/OnDiskBitmap.c
-msgid "Invalid BMP file"
+#: ports/espressif/common-hal/_bleio/__init__.c
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Invalid BLE parameter"
 msgstr ""
 
-#: ports/stm/common-hal/analogio/AnalogOut.c
-msgid "Invalid DAC pin supplied"
+#: shared-bindings/wifi/Radio.c
+msgid "Invalid BSSID"
 msgstr ""
 
-#: ports/stm/common-hal/busio/I2C.c
-msgid "Invalid I2C pin selection"
+#: shared-bindings/wifi/Radio.c
+msgid "Invalid MAC address"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/cxd56/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
-msgid "Invalid PWM frequency"
-msgstr ""
-
-#: ports/stm/common-hal/busio/SPI.c
-msgid "Invalid SPI pin selection"
-msgstr ""
-
-#: ports/stm/common-hal/busio/UART.c
-msgid "Invalid UART pin selection"
-msgstr ""
-
-#: py/moduerrno.c shared-module/rgbmatrix/RGBMatrix.c
+#: ports/espressif/common-hal/espidf/__init__.c py/moderrno.c
 msgid "Invalid argument"
 msgstr ""
 
@@ -900,115 +1247,59 @@ msgstr ""
 msgid "Invalid bits per value"
 msgstr ""
 
-#: ports/nrf/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
-msgid "Invalid buffer size"
+#: shared-module/os/getenv.c
+#, c-format
+msgid "Invalid byte %.*s"
 msgstr ""
 
-#: shared-bindings/_pixelbuf/PixelBuf.c
-msgid "Invalid byteorder string"
+#: ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
+#, c-format
+msgid "Invalid data_pins[%d]"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
-msgid "Invalid capture period. Valid range: 1 - 500"
-msgstr ""
-
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Invalid channel count"
-msgstr ""
-
-#: shared-bindings/digitalio/DigitalInOut.c
-msgid "Invalid direction."
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c
-msgid "Invalid file"
+#: shared-module/msgpack/__init__.c
+msgid "Invalid format"
 msgstr ""
 
 #: shared-module/audiocore/WaveFile.c
 msgid "Invalid format chunk size"
 msgstr ""
 
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Invalid frequency supplied"
+#: shared-bindings/wifi/Radio.c
+msgid "Invalid hex password"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid "Invalid memory access."
+#: ports/espressif/common-hal/wifi/Radio.c
+msgid "Invalid multicast MAC address"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
-msgid "Invalid number of bits"
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Invalid size"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
-#: shared-bindings/displayio/FourWire.c
-msgid "Invalid phase"
+#: ports/espressif/common-hal/ssl/SSLContext.c
+#: ports/raspberrypi/common-hal/ssl/SSLSocket.c
+msgid "Invalid socket for TLS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
-#: shared-bindings/pulseio/PWMOut.c shared-module/rgbmatrix/RGBMatrix.c
-msgid "Invalid pin"
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Invalid state"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-msgid "Invalid pin for left channel"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-msgid "Invalid pin for right channel"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/I2C.c
-#: ports/atmel-samd/common-hal/busio/SPI.c
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/atmel-samd/common-hal/i2cperipheral/I2CPeripheral.c
-#: ports/cxd56/common-hal/busio/I2C.c ports/cxd56/common-hal/busio/SPI.c
-#: ports/cxd56/common-hal/busio/UART.c ports/mimxrt10xx/common-hal/busio/I2C.c
-#: ports/mimxrt10xx/common-hal/busio/SPI.c
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/I2C.c
-msgid "Invalid pins"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Invalid pins for PWMOut"
-msgstr ""
-
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
-#: shared-bindings/displayio/FourWire.c
-msgid "Invalid polarity"
-msgstr ""
-
-#: shared-bindings/_bleio/Characteristic.c
-msgid "Invalid properties"
-msgstr ""
-
-#: shared-bindings/microcontroller/__init__.c
-msgid "Invalid run mode."
-msgstr ""
-
-#: shared-module/_bleio/Attribute.c
-msgid "Invalid security_mode"
-msgstr ""
-
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Invalid voice"
-msgstr ""
-
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Invalid voice count"
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c
-msgid "Invalid wave file"
-msgstr ""
-
-#: ports/stm/common-hal/busio/UART.c
-msgid "Invalid word/bit length"
+#: shared-module/os/getenv.c
+msgid "Invalid unicode escape"
 msgstr ""
 
 #: shared-bindings/aesio/aes.c
 msgid "Key must be 16, 24, or 32 bytes long"
+msgstr ""
+
+#: shared-module/os/getenv.c
+msgid "Key not found"
+msgstr ""
+
+#: shared-module/is31fl3741/FrameBuffer.c
+msgid "LED mappings must match display size"
 msgstr ""
 
 #: py/compile.c
@@ -1016,55 +1307,71 @@ msgid "LHS of keyword arg must be an id"
 msgstr ""
 
 #: shared-module/displayio/Group.c
-msgid "Layer already in a group."
+msgid "Layer already in a group"
 msgstr ""
 
 #: shared-module/displayio/Group.c
-msgid "Layer must be a Group or TileGrid subclass."
+msgid "Layer must be a Group or TileGrid subclass"
 msgstr ""
 
-#: py/objslice.c
-msgid "Length must be an int"
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "MAC address was invalid"
 msgstr ""
 
-#: py/objslice.c
-msgid "Length must be non-negative"
-msgstr ""
-
-#: shared-module/bitbangio/SPI.c
-msgid "MISO pin init failed."
-msgstr ""
-
-#: shared-module/bitbangio/SPI.c
-msgid "MOSI pin init failed."
-msgstr ""
-
-#: shared-module/displayio/Shape.c
-#, c-format
-msgid "Maximum x value when mirrored is %d"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption."
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error."
+#: shared-bindings/is31fl3741/IS31FL3741.c
+msgid "Mapping must be a tuple"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
-msgid "Missing MISO or MOSI Pin"
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Mismatched data size"
 msgstr ""
 
-#: shared-bindings/displayio/Group.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Mismatched swap flag"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_in_pin. %q[%u] reads pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_in_pin. %q[%u] shifts in from pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_in_pin. %q[%u] waits based on pin"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_out_pin. %q[%u] shifts out to pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_out_pin. %q[%u] writes pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_set_pin. %q[%u] sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing jmp_pin. %q[%u] jumps on pin"
+msgstr ""
+
+#: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
 msgid "Must be a %q subclass."
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
+#: ports/espressif/common-hal/dotclockframebuffer/DotClockFramebuffer.c
+msgid "Must provide 5/6/5 RGB pins"
+msgstr ""
+
+#: ports/mimxrt10xx/common-hal/busio/SPI.c shared-bindings/busio/SPI.c
 msgid "Must provide MISO or MOSI pin"
 msgstr ""
 
@@ -1073,10 +1380,44 @@ msgstr ""
 msgid "Must use a multiple of 6 rgb pins, not %d"
 msgstr ""
 
-#: py/parse.c
+#: supervisor/shared/safe_mode.c
+msgid "NLR jump failed. Likely memory corruption."
+msgstr ""
+
+#: ports/espressif/common-hal/nvm/ByteArray.c
+msgid "NVS Error"
+msgstr ""
+
+#: shared-bindings/socketpool/SocketPool.c
+msgid "Name or service not known"
+msgstr ""
+
+#: py/qstr.c
 msgid "Name too long"
 msgstr ""
 
+#: shared-bindings/displayio/TileGrid.c
+msgid "New bitmap must be same size as old bitmap"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/__init__.c
+msgid "Nimble out of memory"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/busio/UART.c
+#: ports/espressif/common-hal/busio/SPI.c
+#: ports/espressif/common-hal/busio/UART.c
+#: ports/mimxrt10xx/common-hal/busio/SPI.c
+#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/raspberrypi/common-hal/busio/UART.c ports/stm/common-hal/busio/SPI.c
+#: ports/stm/common-hal/busio/UART.c shared-bindings/fourwire/FourWire.c
+#: shared-bindings/i2cdisplaybus/I2CDisplayBus.c
+#: shared-bindings/paralleldisplaybus/ParallelBus.c
+#: shared-module/bitbangio/SPI.c
+msgid "No %q pin"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 msgid "No CCCD for this Characteristic"
 msgstr ""
@@ -1088,31 +1429,34 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
+#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
 msgid "No DMA channel found"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
-msgid "No MISO Pin"
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+msgid "No DMA pacing timer found"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
-msgid "No MOSI Pin"
+#: shared-module/adafruit_bus_device/i2c_device/I2CDevice.c
+#, c-format
+msgid "No I2C device at address: 0x%x"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
-#: ports/stm/common-hal/busio/UART.c
-msgid "No RX pin"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
-#: ports/stm/common-hal/busio/UART.c
-msgid "No TX pin"
+#: supervisor/shared/web_workflow/web_workflow.c
+msgid "No IP"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No available clocks"
+msgstr ""
+
+#: ports/espressif/common-hal/imagecapture/ParallelImageCapture.c
+msgid "No capture in progress"
+msgstr ""
+
+#: shared-module/usb/core/Device.c
+msgid "No configuration set"
 msgstr ""
 
 #: shared-bindings/_bleio/PacketBuffer.c
@@ -1131,36 +1475,46 @@ msgstr ""
 msgid "No hardware random available"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/ps2io/Ps2.c
-msgid "No hardware support on clk pin"
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "No in in program"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-msgid "No hardware support on pin"
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "No in or out in program"
 msgstr ""
 
-#: shared-bindings/aesio/aes.c
-msgid "No key was specified"
-msgstr ""
-
-#: shared-bindings/time/__init__.c
+#: py/objint.c shared-bindings/time/__init__.c
 msgid "No long integer support"
 msgstr ""
 
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "No more timers available on this pin."
+#: shared-bindings/wifi/Radio.c
+msgid "No network with that ssid"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "No out in program"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/espressif/common-hal/busio/I2C.c
+#: ports/mimxrt10xx/common-hal/busio/I2C.c ports/nrf/common-hal/busio/I2C.c
+#: ports/raspberrypi/common-hal/busio/I2C.c
+msgid "No pull up found on SDA or SCL; check your wiring"
 msgstr ""
 
 #: shared-module/touchio/TouchIn.c
 msgid "No pulldown on pin; 1Mohm recommended"
 msgstr ""
 
-#: py/moduerrno.c
+#: py/moderrno.c
 msgid "No space left on device"
 msgstr ""
 
-#: py/moduerrno.c
+#: py/moderrno.c
+msgid "No such device"
+msgstr ""
+
+#: py/moderrno.c
 msgid "No such file/directory"
 msgstr ""
 
@@ -1168,10 +1522,19 @@ msgstr ""
 msgid "No timer available"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid "Nordic Soft Device failure assertion."
+#: shared-module/usb/core/Device.c
+msgid "No usb host port initialized"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Nordic system firmware out of memory"
+msgstr ""
+
+#: shared-bindings/ipaddress/IPv4Address.c shared-bindings/ipaddress/__init__.c
+msgid "Not a valid IP string"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/__init__.c
 #: ports/nrf/common-hal/_bleio/__init__.c
 #: shared-bindings/_bleio/CharacteristicBuffer.c
 msgid "Not connected"
@@ -1180,6 +1543,11 @@ msgstr ""
 #: shared-bindings/audiobusio/I2SOut.c shared-bindings/audioio/AudioOut.c
 #: shared-bindings/audiopwmio/PWMAudioOut.c
 msgid "Not playing"
+msgstr ""
+
+#: ports/espressif/common-hal/paralleldisplaybus/ParallelBus.c
+#, c-format
+msgid "Number of data_pins must be 8 or 16, not %d"
 msgstr ""
 
 #: shared-bindings/util.c
@@ -1191,14 +1559,46 @@ msgstr ""
 msgid "Odd parity is not supported"
 msgstr ""
 
+#: supervisor/shared/bluetooth/bluetooth.c
+msgid "Off"
+msgstr ""
+
+#: supervisor/shared/bluetooth/bluetooth.c
+msgid "Ok"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
+#: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
+
+#: ports/espressif/common-hal/wifi/__init__.c
+#: ports/raspberrypi/common-hal/wifi/__init__.c
+msgid "Only IPv4 addresses supported"
+msgstr ""
+
+#: ports/espressif/common-hal/socketpool/Socket.c
+#: ports/raspberrypi/common-hal/socketpool/Socket.c
+msgid "Only IPv4 sockets supported"
 msgstr ""
 
 #: shared-module/displayio/OnDiskBitmap.c
 #, c-format
 msgid ""
 "Only Windows format, uncompressed BMP supported: given header size is %d"
+msgstr ""
+
+#: shared-bindings/_bleio/Adapter.c
+msgid "Only connectable advertisements can be directed"
+msgstr ""
+
+#: ports/stm/common-hal/alarm/pin/PinAlarm.c
+msgid "Only edge detection is available on this hardware"
+msgstr ""
+
+#: shared-bindings/ipaddress/__init__.c
+msgid "Only int or string supported for ip"
 msgstr ""
 
 #: shared-module/displayio/OnDiskBitmap.c
@@ -1208,47 +1608,115 @@ msgid ""
 "%d bpp given"
 msgstr ""
 
+#: ports/espressif/common-hal/alarm/touch/TouchAlarm.c
+msgid "Only one %q can be set in deep sleep."
+msgstr ""
+
+#: ports/espressif/common-hal/espulp/ULPAlarm.c
+msgid "Only one %q can be set."
+msgstr ""
+
+#: ports/espressif/common-hal/i2ctarget/I2CTarget.c
+#: ports/raspberrypi/common-hal/i2ctarget/I2CTarget.c
+msgid "Only one address is allowed"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/alarm/time/TimeAlarm.c
+#: ports/nrf/common-hal/alarm/time/TimeAlarm.c
+#: ports/stm/common-hal/alarm/time/TimeAlarm.c
+msgid "Only one alarm.time alarm can be set"
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/time/TimeAlarm.c
+#: ports/raspberrypi/common-hal/alarm/time/TimeAlarm.c
+msgid "Only one alarm.time alarm can be set."
+msgstr ""
+
+#: shared-module/displayio/ColorConverter.c
+msgid "Only one color can be transparent at a time"
+msgstr ""
+
+#: py/moderrno.c
+msgid "Operation not permitted"
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Operation or feature not supported"
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Operation timed out"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/mdns/Server.c
+msgid "Out of MDNS service slots"
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Out of memory"
+msgstr ""
+
+#: ports/espressif/common-hal/socketpool/Socket.c
+#: ports/raspberrypi/common-hal/socketpool/Socket.c
+msgid "Out of sockets"
+msgstr ""
+
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+msgid "Out-buffer elements must be <= 4 bytes long"
+msgstr ""
+
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Oversample must be multiple of 8."
 msgstr ""
 
-#: shared-bindings/pulseio/PWMOut.c
-msgid ""
-"PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-msgstr ""
-
-#: shared-bindings/pulseio/PWMOut.c
+#: shared-bindings/pwmio/PWMOut.c
 msgid ""
 "PWM frequency not writable when variable_frequency is False on construction."
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/displayio/ParallelBus.c
-#: ports/stm/common-hal/displayio/ParallelBus.c
-msgid "ParallelBus not yet supported"
+#: ports/stm/common-hal/pwmio/PWMOut.c
+msgid "PWM restart"
 msgstr ""
 
-#: py/moduerrno.c
+#: ports/raspberrypi/common-hal/countio/Counter.c
+msgid "PWM slice already in use"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/countio/Counter.c
+msgid "PWM slice channel A already in use"
+msgstr ""
+
+#: ports/espressif/common-hal/audiobusio/__init__.c
+msgid "Peripheral in use"
+msgstr ""
+
+#: py/moderrno.c
 msgid "Permission denied"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
-#: ports/cxd56/common-hal/analogio/AnalogIn.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogIn.c
-#: ports/nrf/common-hal/analogio/AnalogIn.c
-#: ports/stm/common-hal/analogio/AnalogIn.c
-msgid "Pin does not have ADC capabilities"
+#: ports/stm/common-hal/alarm/pin/PinAlarm.c
+msgid "Pin cannot wake from Deep Sleep"
 msgstr ""
 
-#: shared-bindings/digitalio/DigitalInOut.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Pin count too large"
+msgstr ""
+
+#: ports/stm/common-hal/alarm/pin/PinAlarm.c
+#: ports/stm/common-hal/pulseio/PulseIn.c
+msgid "Pin interrupt already in use"
+msgstr ""
+
+#: shared-bindings/adafruit_bus_device/spi_device/SPIDevice.c
 msgid "Pin is input only"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/countio/Counter.c
+msgid "Pin must be on PWM Channel B"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/countio/Counter.c
 msgid "Pin must support hardware interrupts"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PulseIn.c
-msgid "Pin number already reserved by EXTI"
 msgstr ""
 
 #: shared-bindings/rgbmatrix/RGBMatrix.c
@@ -1259,6 +1727,22 @@ msgid ""
 "constructor"
 msgstr ""
 
+#: ports/raspberrypi/common-hal/imagecapture/ParallelImageCapture.c
+msgid "Pins must be sequential"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
+msgid "Pins must be sequential GPIO pins"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+msgid "Pins must share PWM slice"
+msgstr ""
+
+#: shared-module/usb/core/Device.c
+msgid "Pipe error"
+msgstr ""
+
 #: py/builtinhelp.c
 msgid "Plus any modules on the filesystem\n"
 msgstr ""
@@ -1267,8 +1751,8 @@ msgstr ""
 msgid "Polygon needs at least 3 points"
 msgstr ""
 
-#: shared-bindings/ps2io/Ps2.c
-msgid "Pop from an empty Ps2 buffer"
+#: supervisor/shared/safe_mode.c
+msgid "Power dipped. Make sure you are providing enough power."
 msgstr ""
 
 #: shared-bindings/_bleio/Adapter.c
@@ -1276,19 +1760,35 @@ msgid "Prefix buffer must be on the heap"
 msgstr ""
 
 #: main.c
-msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+msgid "Press any key to enter the REPL. Use CTRL-D to reload.\n"
+msgstr ""
+
+#: main.c
+msgid "Pretending to deep sleep until alarm, CTRL-C or file write.\n"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Program does IN without loading ISR"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Program does OUT without loading OSR"
+msgstr ""
+
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+msgid "Program size invalid"
+msgstr ""
+
+#: ports/espressif/common-hal/espulp/ULP.c
+msgid "Program too long"
 msgstr ""
 
 #: shared-bindings/digitalio/DigitalInOut.c
 msgid "Pull not used when direction is output."
 msgstr ""
 
-#: ports/stm/common-hal/pulseio/PulseIn.c
-msgid "PulseIn not supported on this chip"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PulseOut.c
-msgid "PulseOut not supported on this chip"
+#: ports/raspberrypi/common-hal/countio/Counter.c
+msgid "RISE_AND_FALL not available on this chip"
 msgstr ""
 
 #: ports/stm/common-hal/os/__init__.c
@@ -1299,96 +1799,108 @@ msgstr ""
 msgid "RNG Init Error"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
+msgid "RS485"
+msgstr ""
+
+#: ports/espressif/common-hal/busio/UART.c
 #: ports/mimxrt10xx/common-hal/busio/UART.c
 msgid "RS485 inversion specified when not in RS485 mode"
 msgstr ""
 
-#: ports/cxd56/common-hal/rtc/RTC.c ports/mimxrt10xx/common-hal/rtc/RTC.c
-#: ports/nrf/common-hal/rtc/RTC.c
-msgid "RTC calibration is not supported on this board"
-msgstr ""
-
-#: shared-bindings/time/__init__.c
+#: shared-bindings/alarm/time/TimeAlarm.c shared-bindings/time/__init__.c
 msgid "RTC is not supported on this board"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
-#: ports/nrf/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
-msgid "RTS/CTS/RS485 Not yet supported on this device"
 msgstr ""
 
 #: ports/stm/common-hal/os/__init__.c
 msgid "Random number generation error"
 msgstr ""
 
-#: shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/_bleio/__init__.c
+#: shared-bindings/memorymonitor/AllocationSize.c
+#: shared-bindings/pulseio/PulseIn.c shared-module/bitmaptools/__init__.c
+#: shared-module/displayio/Bitmap.c
 msgid "Read-only"
 msgstr ""
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: extmod/vfs_fat.c py/moderrno.c
 msgid "Read-only filesystem"
 msgstr ""
 
-#: shared-module/displayio/Bitmap.c
-msgid "Read-only object"
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Received response was invalid"
 msgstr ""
 
-#: shared-bindings/displayio/EPaperDisplay.c
+#: supervisor/shared/bluetooth/bluetooth.c
+msgid "Reconnecting"
+msgstr ""
+
+#: shared-bindings/epaperdisplay/EPaperDisplay.c
 msgid "Refresh too soon"
+msgstr ""
+
+#: shared-bindings/canio/RemoteTransmissionRequest.c
+msgid "RemoteTransmissionRequests limited to 8 bytes"
 msgstr ""
 
 #: shared-bindings/aesio/aes.c
 msgid "Requested AES mode is unsupported"
 msgstr ""
 
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Requested resource not found"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Right channel unsupported"
-msgstr ""
-
-#: shared-bindings/_pew/PewPew.c
-msgid "Row entry must be digitalio.DigitalInOut"
-msgstr ""
-
-#: main.c
-msgid "Running in safe mode! Auto-reload is off.\n"
 msgstr ""
 
 #: main.c
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
-#: ports/mimxrt10xx/common-hal/busio/I2C.c ports/nrf/common-hal/busio/I2C.c
-msgid "SDA or SCL needs a pull up"
+#: shared-module/sdcardio/SDCard.c
+msgid "SD card CSD format not supported"
 msgstr ""
 
-#: ports/stm/common-hal/busio/SPI.c
-msgid "SPI Init Error"
+#: ports/cxd56/common-hal/sdioio/SDCard.c
+msgid "SDCard init"
 msgstr ""
 
-#: ports/stm/common-hal/busio/SPI.c
-msgid "SPI Re-initialization error"
-msgstr ""
-
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Sample rate must be positive"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
+#: ports/stm/common-hal/sdioio/SDCard.c
 #, c-format
-msgid "Sample rate too high. It must be less than %d"
+msgid "SDIO GetCardInfo Error %d"
 msgstr ""
 
+#: ports/stm/common-hal/sdioio/SDCard.c
+#, c-format
+msgid "SDIO Init Error %d"
+msgstr ""
+
+#: ports/espressif/common-hal/busio/SPI.c
+msgid "SPI configuration failed"
+msgstr ""
+
+#: ports/stm/common-hal/busio/SPI.c
+msgid "SPI init error"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/busio/SPI.c
+msgid "SPI peripheral in use"
+msgstr ""
+
+#: ports/stm/common-hal/busio/SPI.c
+msgid "SPI re-init"
+msgstr ""
+
+#: shared-bindings/is31fl3741/FrameBuffer.c
+msgid "Scale dimensions must divide by 3"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
-msgid "Scan already in progess. Stop with stop_scan."
-msgstr ""
-
-#: ports/mimxrt10xx/common-hal/busio/UART.c
-msgid "Selected CTS pin not valid"
-msgstr ""
-
-#: ports/mimxrt10xx/common-hal/busio/UART.c
-msgid "Selected RTS pin not valid"
+msgid "Scan already in progress. Stop with stop_scan."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -1396,33 +1908,49 @@ msgstr ""
 msgid "Serializer in use"
 msgstr ""
 
+#: shared-bindings/ssl/SSLContext.c
+msgid "Server side context cannot have hostname"
+msgstr ""
+
+#: ports/cxd56/common-hal/camera/Camera.c
+msgid "Size not supported"
+msgstr ""
+
+#: shared-bindings/alarm/SleepMemory.c shared-bindings/memorymap/AddressRange.c
 #: shared-bindings/nvm/ByteArray.c
 msgid "Slice and value different lengths."
 msgstr ""
 
 #: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/displayio/TileGrid.c
+#: shared-bindings/memorymonitor/AllocationSize.c
+#: shared-bindings/pulseio/PulseIn.c
 msgid "Slices not supported"
+msgstr ""
+
+#: ports/espressif/common-hal/socketpool/SocketPool.c
+#: ports/raspberrypi/common-hal/socketpool/SocketPool.c
+msgid "SocketPool can only be used with wifi.radio"
 msgstr ""
 
 #: shared-bindings/aesio/aes.c
 msgid "Source and destination buffers must be the same length"
 msgstr ""
 
-#: extmod/modure.c
-msgid "Splitting with sub-captures"
+#: shared-bindings/paralleldisplaybus/ParallelBus.c
+msgid "Specify exactly one of data0 or data_pins"
 msgstr ""
 
-#: shared-bindings/supervisor/__init__.c
-msgid "Stack size must be at least 256"
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+msgid "Stereo left must be on PWM channel A"
 msgstr ""
 
-#: shared-bindings/multiterminal/__init__.c
-msgid "Stream missing readinto() or write() method."
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+msgid "Stereo right must be on PWM channel B"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
-msgid "Supply at least one UART pin"
+#: shared-bindings/alarm/time/TimeAlarm.c
+msgid "Supply one of monotonic_time or epoch_time"
 msgstr ""
 
 #: shared-bindings/gnss/GNSS.c
@@ -1434,22 +1962,15 @@ msgid "Temperature read timed out"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase the stack size if you know how, or if not:"
+msgid "The `microcontroller` module was used to boot into safe mode."
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The `microcontroller` module was used to boot into safe mode. Press reset to "
-"exit safe mode.\n"
+#: py/obj.c
+msgid "The above exception was the direct cause of the following exception:"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The microcontroller's power dipped. Make sure your power supply provides\n"
-"enough power for the whole circuit and press reset (after ejecting "
-"CIRCUITPY).\n"
+#: shared-bindings/rgbmatrix/RGBMatrix.c
+msgid "The length of rgb_pins must be 6, 12, 18, 24, or 30"
 msgstr ""
 
 #: shared-module/audiomixer/MixerVoice.c
@@ -1468,6 +1989,20 @@ msgstr ""
 msgid "The sample's signedness does not match the mixer's"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Third-party firmware fatal error."
+msgstr ""
+
+#: shared-module/imagecapture/ParallelImageCapture.c
+msgid "This microcontroller does not support continuous capture."
+msgstr ""
+
+#: shared-module/paralleldisplaybus/ParallelBus.c
+msgid ""
+"This microcontroller only supports data0=, not data_pins=, because it "
+"requires contiguous pins."
+msgstr ""
+
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile height must exactly divide bitmap height"
 msgstr ""
@@ -1477,32 +2012,44 @@ msgid "Tile index out of bounds"
 msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
-msgid "Tile value out of bounds"
-msgstr ""
-
-#: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr ""
 
+#: shared-bindings/alarm/time/TimeAlarm.c
+msgid "Time is in the past."
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
 #, c-format
 msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
+msgid "Too many channels in sample"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
 msgstr ""
 
 #: shared-module/displayio/__init__.c
-msgid "Too many display busses"
+msgid "Too many display busses; forgot displayio.release_displays() ?"
 msgstr ""
 
 #: shared-module/displayio/__init__.c
 msgid "Too many displays"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/PacketBuffer.c
 #: ports/nrf/common-hal/_bleio/PacketBuffer.c
-msgid "Total data to write is larger than outgoing_packet_length"
+msgid "Total data to write is larger than %q"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/alarm/touch/TouchAlarm.c
+#: ports/raspberrypi/common-hal/alarm/touch/TouchAlarm.c
+#: ports/stm/common-hal/alarm/touch/TouchAlarm.c
+msgid "Touch alarms not available"
 msgstr ""
 
 #: py/obj.c
@@ -1514,31 +2061,44 @@ msgid "Tuple or struct_time argument required"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART Buffer allocation error"
+msgid "UART de-init"
+msgstr ""
+
+#: ports/cxd56/common-hal/busio/UART.c ports/espressif/common-hal/busio/UART.c
+#: ports/stm/common-hal/busio/UART.c
+msgid "UART init"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/busio/UART.c
+msgid "UART peripheral in use"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART De-init error"
+msgid "UART re-init"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART Init Error"
+msgid "UART write"
 msgstr ""
 
-#: ports/stm/common-hal/busio/UART.c
-msgid "UART Re-init error"
-msgstr ""
-
-#: ports/stm/common-hal/busio/UART.c
-msgid "UART write error"
+#: main.c
+msgid "UID:"
 msgstr ""
 
 #: shared-module/usb_hid/Device.c
-msgid "USB Busy"
+msgid "USB busy"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "USB devices need more endpoints than are available."
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "USB devices specify too many interface names."
 msgstr ""
 
 #: shared-module/usb_hid/Device.c
-msgid "USB Error"
+msgid "USB error"
 msgstr ""
 
 #: shared-bindings/_bleio/UUID.c
@@ -1553,12 +2113,27 @@ msgstr ""
 msgid "UUID value is not str, int or byte buffer"
 msgstr ""
 
+#: ports/raspberrypi/common-hal/memorymap/AddressRange.c
+msgid "Unable to access unaligned IO register"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
+#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
 msgid "Unable to allocate buffers for signed conversion"
 msgstr ""
 
-#: shared-module/displayio/I2CDisplay.c
+#: supervisor/shared/safe_mode.c
+msgid "Unable to allocate to the heap."
+msgstr ""
+
+#: ports/espressif/common-hal/busio/I2C.c
+msgid "Unable to create lock"
+msgstr ""
+
+#: shared-module/i2cdisplaybus/I2CDisplayBus.c
+#: shared-module/is31fl3741/IS31FL3741.c
 #, c-format
 msgid "Unable to find I2C Display at %x"
 msgstr ""
@@ -1576,12 +2151,50 @@ msgstr ""
 msgid "Unable to read color palette data"
 msgstr ""
 
+#: ports/espressif/common-hal/mdns/Server.c
+#: ports/raspberrypi/common-hal/mdns/Server.c
+msgid "Unable to start mDNS query"
+msgstr ""
+
 #: shared-bindings/nvm/ByteArray.c
 msgid "Unable to write to nvm."
 msgstr ""
 
+#: ports/raspberrypi/common-hal/memorymap/AddressRange.c
+msgid "Unable to write to read-only memory"
+msgstr ""
+
+#: shared-bindings/alarm/SleepMemory.c
+msgid "Unable to write to sleep_memory."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/UUID.c
 msgid "Unexpected nrfx uuid type"
+msgstr ""
+
+#: ports/espressif/common-hal/ssl/SSLSocket.c
+#, c-format
+msgid "Unhandled ESP TLS error %d %d %x %d"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/__init__.c
+#, c-format
+msgid "Unknown BLE error at %s:%d: %d"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/__init__.c
+#, c-format
+msgid "Unknown BLE error: %d"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/wifi/__init__.c
+#, c-format
+msgid "Unknown error code %d"
+msgstr ""
+
+#: shared-bindings/wifi/Radio.c
+#, c-format
+msgid "Unknown failure %d"
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
@@ -1589,6 +2202,7 @@ msgstr ""
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
 #: supervisor/shared/safe_mode.c
 msgid "Unknown reason."
 msgstr ""
@@ -1598,12 +2212,23 @@ msgstr ""
 msgid "Unknown security error: 0x%04x"
 msgstr ""
 
-#: ports/nrf/common-hal/_bleio/__init__.c
+#: ports/espressif/common-hal/_bleio/__init__.c
 #, c-format
-msgid "Unknown soft device error: %04x"
+msgid "Unknown system firmware error at %s:%d: %d"
 msgstr ""
 
-#: shared-bindings/_pixelbuf/PixelBuf.c
+#: ports/nrf/common-hal/_bleio/__init__.c
+#, c-format
+msgid "Unknown system firmware error: %04x"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/__init__.c
+#, c-format
+msgid "Unknown system firmware error: %d"
+msgstr ""
+
+#: shared-bindings/adafruit_pixelbuf/PixelBuf.c
+#: shared-module/_pixelmap/PixelMap.c
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
 msgstr ""
@@ -1614,12 +2239,11 @@ msgid ""
 "declined or ignored."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/I2C.c ports/cxd56/common-hal/busio/I2C.c
-#: ports/stm/common-hal/busio/I2C.c
-msgid "Unsupported baudrate"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "Unsupported colorspace"
 msgstr ""
 
-#: shared-module/displayio/display_core.c
+#: shared-module/displayio/bus_core.c
 msgid "Unsupported display bus type"
 msgstr ""
 
@@ -1627,26 +2251,30 @@ msgstr ""
 msgid "Unsupported format"
 msgstr ""
 
-#: py/moduerrno.c
-msgid "Unsupported operation"
+#: shared-bindings/hashlib/__init__.c
+msgid "Unsupported hash algorithm"
 msgstr ""
 
-#: shared-bindings/digitalio/DigitalInOut.c
-msgid "Unsupported pull value."
+#: ports/espressif/common-hal/dualbank/__init__.c
+msgid "Update Failed"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Characteristic.c
+#: ports/espressif/common-hal/_bleio/Descriptor.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Descriptor.c
 msgid "Value length != required fixed length"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Characteristic.c
+#: ports/espressif/common-hal/_bleio/Descriptor.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Descriptor.c
 msgid "Value length > max_length"
 msgstr ""
 
-#: py/emitnative.c
-msgid "Viper functions don't currently support more than 4 arguments"
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Version was invalid"
 msgstr ""
 
 #: ports/stm/common-hal/microcontroller/Processor.c
@@ -1657,24 +2285,8 @@ msgstr ""
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr ""
 
-#: shared-bindings/watchdog/WatchDogTimer.c
+#: ports/nrf/common-hal/watchdog/WatchDogTimer.c
 msgid "WatchDogTimer cannot be deinitialized once mode is set to RESET"
-msgstr ""
-
-#: shared-bindings/watchdog/WatchDogTimer.c
-msgid "WatchDogTimer is not currently running"
-msgstr ""
-
-#: shared-bindings/watchdog/WatchDogTimer.c
-msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-msgstr ""
-
-#: shared-bindings/watchdog/WatchDogTimer.c
-msgid "WatchDogTimer.timeout must be greater than 0"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "Watchdog timer expired."
 msgstr ""
 
 #: py/builtinhelp.c
@@ -1682,21 +2294,83 @@ msgstr ""
 msgid ""
 "Welcome to Adafruit CircuitPython %s!\n"
 "\n"
-"Please visit learn.adafruit.com/category/circuitpython for project guides.\n"
+"Visit circuitpython.org for more information.\n"
 "\n"
-"To list built-in modules please do `help(\"modules\")`.\n"
+"To list built-in modules type `help(\"modules\")`.\n"
 msgstr ""
 
+#: supervisor/shared/web_workflow/web_workflow.c
+msgid "Wi-Fi: "
+msgstr ""
+
+#: ports/raspberrypi/common-hal/wifi/Radio.c
+msgid "Wifi is not enabled"
+msgstr ""
+
+#: main.c
+msgid "Woken up by alarm.\n"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/PacketBuffer.c
 #: ports/nrf/common-hal/_bleio/PacketBuffer.c
 msgid "Writes not supported on Characteristic"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid "You are in safe mode: something unanticipated happened.\n"
+#: ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+#: ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
+#: ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
+#: ports/atmel-samd/boards/meowmeow/mpconfigboard.h
+msgid "You pressed both buttons at start up."
+msgstr ""
+
+#: ports/espressif/boards/m5stack_core_basic/mpconfigboard.h
+#: ports/espressif/boards/m5stack_core_fire/mpconfigboard.h
+#: ports/espressif/boards/m5stack_stick_c/mpconfigboard.h
+#: ports/espressif/boards/m5stack_stick_c_plus/mpconfigboard.h
+msgid "You pressed button A at start up."
+msgstr ""
+
+#: ports/espressif/boards/m5stack_m5paper/mpconfigboard.h
+msgid "You pressed button DOWN at start up."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "You requested starting safe mode by "
+msgid "You pressed the BOOT button at start up"
+msgstr ""
+
+#: ports/espressif/boards/adafruit_huzzah32_breakout/mpconfigboard.h
+msgid "You pressed the GPIO0 button at start up."
+msgstr ""
+
+#: ports/espressif/boards/espressif_esp32_lyrat/mpconfigboard.h
+msgid "You pressed the Rec button at start up."
+msgstr ""
+
+#: ports/espressif/boards/adafruit_feather_esp32_v2/mpconfigboard.h
+msgid "You pressed the SW38 button at start up."
+msgstr ""
+
+#: ports/espressif/boards/hardkernel_odroid_go/mpconfigboard.h
+msgid "You pressed the VOLUME button at start up."
+msgstr ""
+
+#: ports/espressif/boards/m5stack_atom_echo/mpconfigboard.h
+#: ports/espressif/boards/m5stack_atom_lite/mpconfigboard.h
+#: ports/espressif/boards/m5stack_atom_matrix/mpconfigboard.h
+#: ports/espressif/boards/m5stack_atom_u/mpconfigboard.h
+msgid "You pressed the central button at start up."
+msgstr ""
+
+#: ports/nrf/boards/aramcon2_badge/mpconfigboard.h
+msgid "You pressed the left button at start up."
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "You pressed the reset button during boot."
+msgstr ""
+
+#: supervisor/shared/micropython.c
+msgid "[truncated due to length]"
 msgstr ""
 
 #: py/objtype.c
@@ -1712,45 +2386,48 @@ msgstr ""
 msgid "__new__ arg must be a user-type"
 msgstr ""
 
-#: extmod/modubinascii.c extmod/moduhashlib.c
+#: extmod/modbinascii.c extmod/modhashlib.c py/objarray.c
 msgid "a bytes-like object is required"
 msgstr ""
 
-#: lib/embed/abort_.c
-msgid "abort() called"
-msgstr ""
-
-#: extmod/machine_mem.c
-#, c-format
-msgid "address %08x is not aligned to %d bytes"
-msgstr ""
-
-#: shared-bindings/i2cperipheral/I2CPeripheral.c
-msgid "address out of bounds"
-msgstr ""
-
-#: shared-bindings/i2cperipheral/I2CPeripheral.c
+#: shared-bindings/i2ctarget/I2CTarget.c
 msgid "addresses is empty"
 msgstr ""
 
-#: extmod/ulab/code/vectorise.c
-msgid "arctan2 is implemented for scalars and ndarrays only"
+#: py/compile.c
+msgid "annotation must be an identifier"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
+msgid "arange: cannot compute length"
 msgstr ""
 
 #: py/modbuiltins.c
 msgid "arg is an empty sequence"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: py/objobject.c
+msgid "arg must be user-type"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
 msgid "argsort argument must be an ndarray"
 msgstr ""
 
-#: py/runtime.c
+#: extmod/ulab/code/numpy/numerical.c
+msgid "argsort is not implemented for flattened arrays"
+msgstr ""
+
+#: py/runtime.c shared-bindings/supervisor/__init__.c
 msgid "argument has wrong type"
 msgstr ""
 
+#: py/compile.c
+msgid "argument name reused"
+msgstr ""
+
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr ""
 
@@ -1758,32 +2435,61 @@ msgstr ""
 msgid "argument should be a '%q' not a '%q'"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/numerical.c extmod/ulab/code/numpy/transform.c
 msgid "arguments must be ndarrays"
 msgstr ""
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: extmod/ulab/code/ndarray.c
+msgid "array and index length must be equal"
+msgstr ""
+
+#: extmod/ulab/code/numpy/io/io.c
+msgid "array has too many dimensions"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "array is too big"
+msgstr ""
+
+#: py/objarray.c shared-bindings/alarm/SleepMemory.c
+#: shared-bindings/memorymap/AddressRange.c shared-bindings/nvm/ByteArray.c
 msgid "array/bytes required on right side"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: py/asmxtensa.c
+msgid "asm overflow"
+msgstr ""
+
+#: py/compile.c
+msgid "async for/with outside async function"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
+msgid "attempt to get (arg)min/(arg)max of empty sequence"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
 msgid "attempt to get argmin/argmax of an empty sequence"
 msgstr ""
 
 #: py/objstr.c
-msgid "attributes not supported yet"
+msgid "attributes not supported"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
-msgid "axis must be -1, 0, None, or 1"
+#: extmod/ulab/code/ulab_tools.c
+msgid "axis is out of bounds"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
-msgid "axis must be -1, 0, or 1"
+#: extmod/ulab/code/numpy/numerical.c extmod/ulab/code/ulab_tools.c
+msgid "axis must be None, or an integer"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
-msgid "axis must be None, 0, or 1"
+#: extmod/ulab/code/numpy/numerical.c
+msgid "axis too long"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "background value out of range of target"
 msgstr ""
 
 #: py/builtinevex.c
@@ -1798,7 +2504,7 @@ msgstr ""
 msgid "bad format string"
 msgstr ""
 
-#: py/binary.c
+#: py/binary.c py/objarray.c
 msgid "bad typecode"
 msgstr ""
 
@@ -1806,8 +2512,12 @@ msgstr ""
 msgid "binary op %q not implemented"
 msgstr ""
 
-#: shared-bindings/busio/UART.c
-msgid "bits must be 7, 8 or 9"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "bitmap sizes must match"
+msgstr ""
+
+#: extmod/modrandom.c
+msgid "bits must be 32 or less"
 msgstr ""
 
 #: shared-bindings/audiomixer/Mixer.c
@@ -1818,8 +2528,12 @@ msgstr ""
 msgid "branch not in range"
 msgstr ""
 
-#: shared-bindings/audiocore/RawSample.c
-msgid "buffer must be a bytes-like object"
+#: extmod/ulab/code/numpy/create.c extmod/ulab/code/utils/utils.c
+msgid "buffer is smaller than requested size"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c extmod/ulab/code/utils/utils.c
+msgid "buffer size must be a multiple of element size"
 msgstr ""
 
 #: shared-module/struct/__init__.c
@@ -1830,25 +2544,20 @@ msgstr ""
 msgid "buffer slices must be of equal length"
 msgstr ""
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
-#: shared-module/struct/__init__.c
+#: py/modstruct.c shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr ""
 
-#: shared-bindings/_pew/PewPew.c
-msgid "buttons must be digitalio.DigitalInOut"
+#: shared-bindings/socketpool/Socket.c shared-bindings/ssl/SSLSocket.c
+msgid "buffer too small for requested bytes"
 msgstr ""
 
-#: py/vm.c
-msgid "byte code not implemented"
+#: py/emitbc.c
+msgid "bytecode overflow"
 msgstr ""
 
-#: shared-bindings/_pixelbuf/PixelBuf.c
-msgid "byteorder is not a string"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/UART.c
-msgid "bytes > 8 bits not supported"
+#: py/objarray.c
+msgid "bytes length not a multiple of item size"
 msgstr ""
 
 #: py/objstr.c
@@ -1863,8 +2572,9 @@ msgstr ""
 msgid "calibration is read only"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/rtc/RTC.c
-msgid "calibration value out of range +/-127"
+#: shared-module/vectorio/Circle.c shared-module/vectorio/Polygon.c
+#: shared-module/vectorio/Rectangle.c
+msgid "can only have one parent"
 msgstr ""
 
 #: py/emitinlinethumb.c
@@ -1875,8 +2585,8 @@ msgstr ""
 msgid "can only have up to 4 parameters to Xtensa assembly"
 msgstr ""
 
-#: py/persistentcode.c
-msgid "can only save bytecode"
+#: extmod/ulab/code/ndarray.c
+msgid "can only specify one unknown dimension"
 msgstr ""
 
 #: py/objtype.c
@@ -1885,6 +2595,14 @@ msgstr ""
 
 #: py/compile.c
 msgid "can't assign to expression"
+msgstr ""
+
+#: extmod/modasyncio.c
+msgid "can't cancel self"
+msgstr ""
+
+#: shared-module/adafruit_pixelbuf/PixelBuf.c
+msgid "can't convert %q to %q"
 msgstr ""
 
 #: py/obj.c
@@ -1897,7 +2615,7 @@ msgstr ""
 msgid "can't convert %s to float"
 msgstr ""
 
-#: py/obj.c
+#: py/runtime.c
 #, c-format
 msgid "can't convert %s to int"
 msgstr ""
@@ -1910,8 +2628,8 @@ msgstr ""
 msgid "can't convert NaN to int"
 msgstr ""
 
-#: shared-bindings/i2cperipheral/I2CPeripheral.c
-msgid "can't convert address to int"
+#: extmod/ulab/code/numpy/vector.c
+msgid "can't convert complex to float"
 msgstr ""
 
 #: py/objint.c
@@ -1926,7 +2644,7 @@ msgstr ""
 msgid "can't convert to float"
 msgstr ""
 
-#: py/obj.c
+#: py/runtime.c
 msgid "can't convert to int"
 msgstr ""
 
@@ -1946,20 +2664,12 @@ msgstr ""
 msgid "can't do binary op between '%q' and '%q'"
 msgstr ""
 
-#: py/objcomplex.c
-msgid "can't do truncated division of a complex number"
-msgstr ""
-
-#: py/compile.c
-msgid "can't have multiple **x"
-msgstr ""
-
-#: py/compile.c
-msgid "can't have multiple *x"
-msgstr ""
-
 #: py/emitnative.c
 msgid "can't implicitly convert '%q' to 'bool'"
+msgstr ""
+
+#: py/runtime.c
+msgid "can't import name %q"
 msgstr ""
 
 #: py/emitnative.c
@@ -1970,16 +2680,24 @@ msgstr ""
 msgid "can't load with '%q' index"
 msgstr ""
 
-#: py/objgenerator.c
-msgid "can't pend throw to just-started generator"
+#: py/builtinimport.c
+msgid "can't perform relative import"
 msgstr ""
 
 #: py/objgenerator.c
 msgid "can't send non-None value to a just-started generator"
 msgstr ""
 
-#: py/objnamedtuple.c
+#: shared-module/sdcardio/SDCard.c
+msgid "can't set 512 block size"
+msgstr ""
+
+#: py/objexcept.c py/objnamedtuple.c
 msgid "can't set attribute"
+msgstr ""
+
+#: py/runtime.c
+msgid "can't set attribute '%q'"
 msgstr ""
 
 #: py/emitnative.c
@@ -2004,6 +2722,34 @@ msgid ""
 "can't switch from manual field specification to automatic field numbering"
 msgstr ""
 
+#: py/objcomplex.c
+msgid "can't truncate-divide a complex number"
+msgstr ""
+
+#: extmod/moductypes.c
+msgid "can't unambiguously get sizeof scalar"
+msgstr ""
+
+#: extmod/modasyncio.c
+msgid "can't wait"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "cannot assign new shape"
+msgstr ""
+
+#: extmod/ulab/code/ndarray_operators.c
+msgid "cannot cast output with casting rule"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "cannot convert complex to dtype"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "cannot convert complex type"
+msgstr ""
+
 #: py/objtype.c
 msgid "cannot create '%q' instances"
 msgstr ""
@@ -2012,20 +2758,20 @@ msgstr ""
 msgid "cannot create instance"
 msgstr ""
 
-#: py/runtime.c
-msgid "cannot import name %q"
-msgstr ""
-
-#: py/builtinimport.c
-msgid "cannot perform relative import"
+#: extmod/ulab/code/ndarray.c
+msgid "cannot delete array elements"
 msgstr ""
 
 #: extmod/ulab/code/ndarray.c
-msgid "cannot reshape array (incompatible input/output shape)"
+msgid "cannot reshape array"
 msgstr ""
 
 #: py/emitnative.c
 msgid "casting"
+msgstr ""
+
+#: ports/stm/common-hal/pwmio/PWMOut.c
+msgid "channel re-init"
 msgstr ""
 
 #: shared-bindings/_stage/Text.c
@@ -2040,8 +2786,12 @@ msgstr ""
 msgid "chr() arg not in range(256)"
 msgstr ""
 
-#: shared-module/vectorio/Circle.c
-msgid "circle can only be registered in one parent"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "clip point must be (x,y) tuple"
+msgstr ""
+
+#: shared-bindings/msgpack/ExtType.c
+msgid "code outside range 0~127"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c
@@ -2060,60 +2810,69 @@ msgstr ""
 msgid "color must be between 0x000000 and 0xffffff"
 msgstr ""
 
-#: shared-bindings/displayio/ColorConverter.c
-msgid "color should be an int"
+#: py/emitnative.c
+msgid "comparison of int and uint"
 msgstr ""
 
 #: py/objcomplex.c
-msgid "complex division by zero"
+msgid "complex divide by zero"
 msgstr ""
 
 #: py/objfloat.c py/parsenum.c
 msgid "complex values not supported"
 msgstr ""
 
-#: extmod/moduzlib.c
+#: extmod/modzlib.c
 msgid "compression header"
-msgstr ""
-
-#: py/parse.c
-msgid "constant must be an integer"
 msgstr ""
 
 #: py/emitnative.c
 msgid "conversion to object"
 msgstr ""
 
-#: extmod/ulab/code/filter.c
+#: extmod/ulab/code/numpy/filter.c
 msgid "convolve arguments must be linear arrays"
 msgstr ""
 
-#: extmod/ulab/code/filter.c
+#: extmod/ulab/code/numpy/filter.c
 msgid "convolve arguments must be ndarrays"
 msgstr ""
 
-#: extmod/ulab/code/filter.c
+#: extmod/ulab/code/numpy/filter.c
 msgid "convolve arguments must not be empty"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
-msgid "could not broadast input array from shape"
+#: extmod/ulab/code/numpy/io/io.c
+msgid "corrupted file"
 msgstr ""
 
-#: extmod/ulab/code/poly.c
+#: extmod/ulab/code/numpy/poly.c
 msgid "could not invert Vandermonde matrix"
 msgstr ""
 
-#: extmod/ulab/code/approx.c
+#: shared-module/sdcardio/SDCard.c
+msgid "couldn't determine SD card version"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
+msgid "cross is defined for 1D arrays of length 3"
+msgstr ""
+
+#: extmod/ulab/code/scipy/optimize/optimize.c
 msgid "data must be iterable"
 msgstr ""
 
-#: extmod/ulab/code/approx.c
+#: extmod/ulab/code/scipy/optimize/optimize.c
 msgid "data must be of equal length"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
-msgid "ddof must be smaller than length of data set"
+#: ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
+#, c-format
+msgid "data pin #%d in use"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "data type not understood"
 msgstr ""
 
 #: py/parsenum.c
@@ -2122,6 +2881,10 @@ msgstr ""
 
 #: py/compile.c
 msgid "default 'except' must be last"
+msgstr ""
+
+#: shared-bindings/msgpack/__init__.c
+msgid "default is not a function"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -2133,28 +2896,51 @@ msgstr ""
 msgid "destination buffer must be an array of type 'H' for bit_depth = 16"
 msgstr ""
 
-#: shared-bindings/audiobusio/PDMIn.c
-msgid "destination_length must be an int >= 0"
-msgstr ""
-
 #: py/objdict.c
 msgid "dict update sequence has wrong length"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: extmod/ulab/code/numpy/numerical.c
 msgid "diff argument must be an ndarray"
 msgstr ""
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: extmod/ulab/code/numpy/numerical.c
+msgid "differentiation order out of range"
+msgstr ""
+
+#: extmod/ulab/code/numpy/transform.c
+msgid "dimensions do not match"
+msgstr ""
+
+#: py/emitnative.c
+msgid "div/mod not implemented for uint"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
+msgid "divide by zero"
+msgstr ""
+
+#: py/runtime.c
 msgid "division by zero"
+msgstr ""
+
+#: extmod/ulab/code/numpy/vector.c
+msgid "dtype must be float, or complex"
+msgstr ""
+
+#: extmod/ulab/code/ndarray_operators.c
+msgid "dtype of int32 is not supported"
 msgstr ""
 
 #: py/objdeque.c
 msgid "empty"
 msgstr ""
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/ulab/code/numpy/io/io.c
+msgid "empty file"
+msgstr ""
+
+#: extmod/modasyncio.c extmod/modheapq.c
 msgid "empty heap"
 msgstr ""
 
@@ -2170,8 +2956,8 @@ msgstr ""
 msgid "end of format while looking for conversion specifier"
 msgstr ""
 
-#: shared-bindings/displayio/Shape.c
-msgid "end_x should be an int"
+#: shared-bindings/alarm/time/TimeAlarm.c
+msgid "epoch_time not supported on this board"
 msgstr ""
 
 #: ports/nrf/common-hal/busio/UART.c
@@ -2207,6 +2993,10 @@ msgstr ""
 msgid "expecting key:value for dict"
 msgstr ""
 
+#: shared-bindings/msgpack/__init__.c
+msgid "ext_hook is not a function"
+msgstr ""
+
 #: py/argcheck.c
 msgid "extra keyword arguments given"
 msgstr ""
@@ -2215,48 +3005,33 @@ msgstr ""
 msgid "extra positional arguments given"
 msgstr ""
 
-#: py/parse.c
-msgid "f-string expression part cannot include a '#'"
-msgstr ""
-
-#: py/parse.c
-msgid "f-string expression part cannot include a backslash"
-msgstr ""
-
-#: py/parse.c
-msgid "f-string: empty expression not allowed"
-msgstr ""
-
-#: py/parse.c
-msgid "f-string: expecting '}'"
-msgstr ""
-
-#: py/parse.c
-msgid "f-string: single '}' is not allowed"
-msgstr ""
-
 #: shared-bindings/audiocore/WaveFile.c shared-bindings/audiomp3/MP3Decoder.c
-#: shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/gifio/OnDiskGif.c
+#: shared-bindings/synthio/__init__.c shared-module/gifio/GifWriter.c
 msgid "file must be a file opened in byte mode"
+msgstr ""
+
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
 msgstr ""
 
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr ""
 
-#: extmod/ulab/code/vectorise.c
+#: extmod/ulab/code/numpy/vector.c
 msgid "first argument must be a callable"
 msgstr ""
 
-#: extmod/ulab/code/approx.c
+#: extmod/ulab/code/scipy/optimize/optimize.c
 msgid "first argument must be a function"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
-msgid "first argument must be an iterable"
+#: extmod/ulab/code/numpy/create.c
+msgid "first argument must be a tuple of ndarrays"
 msgstr ""
 
-#: extmod/ulab/code/vectorise.c
+#: extmod/ulab/code/numpy/transform.c extmod/ulab/code/numpy/vector.c
 msgid "first argument must be an ndarray"
 msgstr ""
 
@@ -2264,11 +3039,15 @@ msgstr ""
 msgid "first argument to super() must be type"
 msgstr ""
 
+#: extmod/ulab/code/scipy/linalg/linalg.c
+msgid "first two arguments must be ndarrays"
+msgstr ""
+
 #: extmod/ulab/code/ndarray.c
 msgid "flattening order must be either 'C', or 'F'"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: extmod/ulab/code/numpy/numerical.c
 msgid "flip argument must be an ndarray"
 msgstr ""
 
@@ -2276,8 +3055,16 @@ msgstr ""
 msgid "float too big"
 msgstr ""
 
+#: py/nativeglue.c
+msgid "float unsupported"
+msgstr ""
+
 #: shared-bindings/_stage/Text.c
 msgid "font must be 2048 bytes long"
+msgstr ""
+
+#: extmod/moddeflate.c
+msgid "format"
 msgstr ""
 
 #: py/objstr.c
@@ -2289,7 +3076,7 @@ msgid "full"
 msgstr ""
 
 #: py/argcheck.c
-msgid "function does not take keyword arguments"
+msgid "function doesn't take keyword arguments"
 msgstr ""
 
 #: py/argcheck.c
@@ -2301,12 +3088,16 @@ msgstr ""
 msgid "function got multiple values for argument '%q'"
 msgstr ""
 
-#: extmod/ulab/code/approx.c
+#: extmod/ulab/code/scipy/optimize/optimize.c
 msgid "function has the same sign at the ends of interval"
 msgstr ""
 
-#: extmod/ulab/code/compare.c
-msgid "function is implemented for scalars and ndarrays only"
+#: extmod/ulab/code/ndarray.c
+msgid "function is defined for ndarrays only"
+msgstr ""
+
+#: extmod/ulab/code/numpy/carray/carray.c
+msgid "function is implemented for ndarrays only"
 msgstr ""
 
 #: py/argcheck.c
@@ -2327,7 +3118,7 @@ msgstr ""
 msgid "function missing required positional argument #%d"
 msgstr ""
 
-#: py/argcheck.c py/bc.c py/objnamedtuple.c
+#: py/argcheck.c py/bc.c py/objnamedtuple.c shared-bindings/time/__init__.c
 #, c-format
 msgid "function takes %d positional arguments but %d were given"
 msgstr ""
@@ -2344,11 +3135,19 @@ msgstr ""
 msgid "generator ignored GeneratorExit"
 msgstr ""
 
+#: py/objgenerator.c py/runtime.c
+msgid "generator raised StopIteration"
+msgstr ""
+
 #: shared-bindings/_stage/Layer.c
 msgid "graphic must be 2048 bytes long"
 msgstr ""
 
-#: extmod/moduheapq.c
+#: extmod/modhashlib.c
+msgid "hash is final"
+msgstr ""
+
+#: extmod/modheapq.c
 msgid "heap must be a list"
 msgstr ""
 
@@ -2360,6 +3159,18 @@ msgstr ""
 msgid "identifier redefined as nonlocal"
 msgstr ""
 
+#: py/compile.c
+msgid "import * not at module level"
+msgstr ""
+
+#: py/persistentcode.c
+msgid "incompatible .mpy arch"
+msgstr ""
+
+#: py/persistentcode.c
+msgid "incompatible .mpy file"
+msgstr ""
+
 #: py/objstr.c
 msgid "incomplete format"
 msgstr ""
@@ -2368,18 +3179,21 @@ msgstr ""
 msgid "incomplete format key"
 msgstr ""
 
-#: extmod/modubinascii.c
+#: extmod/modbinascii.c
 msgid "incorrect padding"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
+#: extmod/ulab/code/ndarray.c extmod/ulab/code/numpy/transform.c
 msgid "index is out of bounds"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/cxd56/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c
-#: ports/stm/common-hal/pulseio/PulseIn.c py/obj.c
+#: shared-bindings/_pixelmap/PixelMap.c
+msgid "index must be tuple or int"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c extmod/ulab/code/ulab_tools.c
+#: ports/espressif/common-hal/pulseio/PulseIn.c
+#: shared-bindings/bitmaptools/__init__.c
 msgid "index out of range"
 msgstr ""
 
@@ -2391,56 +3205,101 @@ msgstr ""
 msgid "indices must be integers, slices, or Boolean lists"
 msgstr ""
 
-#: extmod/ulab/code/approx.c
+#: ports/espressif/common-hal/busio/I2C.c
+msgid "init I2C"
+msgstr ""
+
+#: extmod/ulab/code/scipy/optimize/optimize.c
 msgid "initial values must be iterable"
+msgstr ""
+
+#: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
+msgid "initial_value length is wrong"
 msgstr ""
 
 #: py/compile.c
 msgid "inline assembler must be a function"
 msgstr ""
 
-#: extmod/ulab/code/create.c
-msgid "input argument must be an integer or a 2-tuple"
+#: extmod/ulab/code/numpy/vector.c
+msgid "input and output dimensions differ"
 msgstr ""
 
-#: extmod/ulab/code/fft.c
+#: extmod/ulab/code/numpy/vector.c
+msgid "input and output shapes differ"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
+msgid "input argument must be an integer, a tuple, or a list"
+msgstr ""
+
+#: extmod/ulab/code/numpy/fft/fft_tools.c
 msgid "input array length must be power of 2"
 msgstr ""
 
-#: extmod/ulab/code/poly.c
+#: extmod/ulab/code/numpy/create.c
+msgid "input arrays are not compatible"
+msgstr ""
+
+#: extmod/ulab/code/numpy/poly.c
 msgid "input data must be an iterable"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/vector.c
+msgid "input dtype must be float or complex"
+msgstr ""
+
+#: extmod/ulab/code/numpy/poly.c
+msgid "input is not iterable"
+msgstr ""
+
+#: extmod/ulab/code/numpy/linalg/linalg.c
 msgid "input matrix is asymmetric"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/linalg/linalg.c
+#: extmod/ulab/code/scipy/linalg/linalg.c
 msgid "input matrix is singular"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/create.c
+msgid "input must be 1- or 2-d"
+msgstr ""
+
+#: extmod/ulab/code/numpy/carray/carray.c
+msgid "input must be a 1D ndarray"
+msgstr ""
+
+#: extmod/ulab/code/scipy/linalg/linalg.c extmod/ulab/code/user/user.c
+msgid "input must be a dense ndarray"
+msgstr ""
+
+#: extmod/ulab/code/user/user.c
+msgid "input must be an ndarray"
+msgstr ""
+
+#: extmod/ulab/code/numpy/carray/carray.c
+msgid "input must be an ndarray, or a scalar"
+msgstr ""
+
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "input must be one-dimensional"
+msgstr ""
+
+#: extmod/ulab/code/ulab_tools.c
 msgid "input must be square matrix"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: extmod/ulab/code/numpy/numerical.c
 msgid "input must be tuple, list, range, or ndarray"
 msgstr ""
 
-#: extmod/ulab/code/poly.c
+#: extmod/ulab/code/numpy/poly.c
 msgid "input vectors must be of equal length"
 msgstr ""
 
-#: py/parsenum.c
-msgid "int() arg 2 must be >= 2 and <= 36"
-msgstr ""
-
-#: py/objstr.c
-msgid "integer required"
-msgstr ""
-
-#: extmod/ulab/code/approx.c
-msgid "interp is defined for 1D arrays of equal length"
+#: extmod/ulab/code/numpy/approx.c
+msgid "interp is defined for 1D iterables of equal length"
 msgstr ""
 
 #: shared-bindings/_bleio/Adapter.c
@@ -2448,32 +3307,51 @@ msgstr ""
 msgid "interval must be in range %s-%s"
 msgstr ""
 
-#: lib/netutils/netutils.c
-msgid "invalid arguments"
+#: py/compile.c
+msgid "invalid arch"
 msgstr ""
 
-#: extmod/modussl_axtls.c
+#: shared-bindings/bitmaptools/__init__.c
+#, c-format
+msgid "invalid bits_per_pixel %d, must be, 1, 2, 4, 8, 16, 24, or 32"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/ssl/SSLSocket.c
 msgid "invalid cert"
 msgstr ""
 
-#: extmod/uos_dupterm.c
-msgid "invalid dupterm index"
+#: shared-bindings/bitmaptools/__init__.c
+#, c-format
+msgid "invalid element size %d for bits_per_pixel %d\n"
 msgstr ""
 
-#: extmod/modframebuf.c
-msgid "invalid format"
+#: shared-bindings/bitmaptools/__init__.c
+#, c-format
+msgid "invalid element_size %d, must be, 1, 2, or 4"
+msgstr ""
+
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
 msgstr ""
 
 #: py/objstr.c
 msgid "invalid format specifier"
 msgstr ""
 
-#: extmod/modussl_axtls.c
+#: shared-bindings/wifi/Radio.c
+msgid "invalid hostname"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/ssl/SSLSocket.c
 msgid "invalid key"
 msgstr ""
 
 #: py/compile.c
 msgid "invalid micropython decorator"
+msgstr ""
+
+#: ports/espressif/common-hal/espcamera/Camera.c
+msgid "invalid setting"
 msgstr ""
 
 #: shared-bindings/random/__init__.c
@@ -2505,11 +3383,7 @@ msgstr ""
 msgid "issubclass() arg 2 must be a class or a tuple of classes"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
-msgid "iterables are not of the same length"
-msgstr ""
-
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/linalg/linalg.c
 msgid "iterations did not converge"
 msgstr ""
 
@@ -2518,11 +3392,7 @@ msgid "join expects a list of str/bytes objects consistent with self object"
 msgstr ""
 
 #: py/argcheck.c
-msgid "keyword argument(s) not yet implemented - use normal args instead"
-msgstr ""
-
-#: py/bc.c
-msgid "keywords must be strings"
+msgid "keyword argument(s) not implemented - use normal args instead"
 msgstr ""
 
 #: py/emitinlinethumb.c py/emitinlinextensa.c
@@ -2531,10 +3401,6 @@ msgstr ""
 
 #: py/compile.c
 msgid "label redefined"
-msgstr ""
-
-#: py/stream.c
-msgid "length argument not allowed for this type"
 msgstr ""
 
 #: shared-bindings/audiomixer/MixerVoice.c
@@ -2557,8 +3423,18 @@ msgstr ""
 msgid "local variable referenced before assignment"
 msgstr ""
 
-#: py/objint.c
-msgid "long int not supported in this build"
+#: ports/espressif/common-hal/canio/CAN.c
+msgid "loopback + silent mode not supported by peripheral"
+msgstr ""
+
+#: ports/espressif/common-hal/mdns/Server.c
+#: ports/raspberrypi/common-hal/mdns/Server.c
+msgid "mDNS already initialized"
+msgstr ""
+
+#: ports/espressif/common-hal/mdns/Server.c
+#: ports/raspberrypi/common-hal/mdns/Server.c
+msgid "mDNS only works with built-in WiFi"
 msgstr ""
 
 #: py/parse.c
@@ -2573,22 +3449,35 @@ msgstr ""
 msgid "math domain error"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
-msgid "matrix dimensions do not match"
-msgstr ""
-
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/linalg/linalg.c
 msgid "matrix is not positive definite"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Descriptor.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Descriptor.c
 #, c-format
 msgid "max_length must be 0-%d when fixed_length is %s"
 msgstr ""
 
+#: extmod/ulab/code/ndarray.c
+msgid "maximum number of dimensions is "
+msgstr ""
+
 #: py/runtime.c
 msgid "maximum recursion depth exceeded"
+msgstr ""
+
+#: extmod/ulab/code/scipy/optimize/optimize.c
+msgid "maxiter must be > 0"
+msgstr ""
+
+#: extmod/ulab/code/scipy/optimize/optimize.c
+msgid "maxiter should be > 0"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
+msgid "median argument must be an ndarray"
 msgstr ""
 
 #: py/runtime.c
@@ -2600,11 +3489,31 @@ msgstr ""
 msgid "memory allocation failed, heap is locked"
 msgstr ""
 
+#: py/objarray.c
+msgid "memoryview offset too large"
+msgstr ""
+
+#: py/objarray.c
+msgid "memoryview: length is not a multiple of itemsize"
+msgstr ""
+
+#: extmod/modtime.c
+msgid "mktime needs a tuple of length 8 or 9"
+msgstr ""
+
+#: extmod/ulab/code/numpy/linalg/linalg.c
+msgid "mode must be complete, or reduced"
+msgstr ""
+
 #: py/builtinimport.c
 msgid "module not found"
 msgstr ""
 
-#: extmod/ulab/code/poly.c
+#: ports/espressif/common-hal/wifi/Monitor.c
+msgid "monitor init failed"
+msgstr ""
+
+#: extmod/ulab/code/numpy/poly.c
 msgid "more degrees of freedom than data points"
 msgstr ""
 
@@ -2628,10 +3537,6 @@ msgstr ""
 msgid "must use keyword argument for key function"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
-msgid "n must be between 0, and 9"
-msgstr ""
-
 #: py/runtime.c
 msgid "name '%q' is not defined"
 msgstr ""
@@ -2640,17 +3545,29 @@ msgstr ""
 msgid "name not defined"
 msgstr ""
 
-#: py/compile.c
-msgid "name reused for argument"
+#: py/persistentcode.c
+msgid "native code in .mpy unsupported"
+msgstr ""
+
+#: py/asmthumb.c
+msgid "native method too big"
 msgstr ""
 
 #: py/emitnative.c
 msgid "native yield"
 msgstr ""
 
+#: extmod/ulab/code/ndarray.c
+msgid "ndarray length overflows"
+msgstr ""
+
 #: py/runtime.c
 #, c-format
 msgid "need more than %d values to unpack"
+msgstr ""
+
+#: py/modmath.c
+msgid "negative factorial"
 msgstr ""
 
 #: py/objint_longlong.c py/objint_mpz.c py/runtime.c
@@ -2661,31 +3578,43 @@ msgstr ""
 msgid "negative shift count"
 msgstr ""
 
-#: py/vm.c
-msgid "no active exception to reraise"
+#: shared-bindings/_pixelmap/PixelMap.c
+msgid "nested index must be int"
 msgstr ""
 
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
+#: shared-module/sdcardio/SDCard.c
+msgid "no SD card"
+msgstr ""
+
+#: py/vm.c
+msgid "no active exception to reraise"
 msgstr ""
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
 msgstr ""
 
+#: shared-module/msgpack/__init__.c
+msgid "no default packer"
+msgstr ""
+
+#: extmod/modrandom.c
+msgid "no default seed"
+msgstr ""
+
 #: py/builtinimport.c
 msgid "no module named '%q'"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/I2CDisplay.c
-#: shared-bindings/displayio/ParallelBus.c
-msgid "no reset pin available"
+#: shared-module/sdcardio/SDCard.c
+msgid "no response from SD card"
 msgstr ""
 
-#: py/runtime.c
+#: ports/espressif/common-hal/espcamera/Camera.c py/objobject.c py/runtime.c
 msgid "no such attribute"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Connection.c
 #: ports/nrf/common-hal/_bleio/Connection.c
 msgid "non-UUID found in service_uuids_whitelist"
 msgstr ""
@@ -2694,20 +3623,24 @@ msgstr ""
 msgid "non-default argument follows default argument"
 msgstr ""
 
-#: extmod/modubinascii.c
+#: py/objstr.c
 msgid "non-hex digit found"
 msgstr ""
 
-#: py/compile.c
-msgid "non-keyword arg after */**"
+#: ports/nrf/common-hal/_bleio/Adapter.c
+msgid "non-zero timeout must be > 0.01"
 msgstr ""
 
-#: py/compile.c
-msgid "non-keyword arg after keyword arg"
+#: shared-bindings/_bleio/Adapter.c
+msgid "non-zero timeout must be >= interval"
 msgstr ""
 
 #: shared-bindings/_bleio/UUID.c
 msgid "not a 128-bit UUID"
+msgstr ""
+
+#: py/parse.c
+msgid "not a constant"
 msgstr ""
 
 #: py/objstr.c
@@ -2718,25 +3651,33 @@ msgstr ""
 msgid "not enough arguments for format string"
 msgstr ""
 
-#: extmod/ulab/code/poly.c
-msgid "number of arguments must be 2, or 3"
+#: extmod/ulab/code/numpy/carray/carray_tools.c
+msgid "not implemented for complex dtype"
 msgstr ""
 
-#: extmod/ulab/code/create.c
+#: extmod/ulab/code/numpy/bitwise.c
+msgid "not supported for input types"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
 msgid "number of points must be at least 2"
+msgstr ""
+
+#: py/builtinhelp.c
+msgid "object "
 msgstr ""
 
 #: py/obj.c
 #, c-format
-msgid "object '%s' is not a tuple or list"
+msgid "object '%s' isn't a tuple or list"
 msgstr ""
 
 #: py/obj.c
-msgid "object does not support item assignment"
+msgid "object doesn't support item assignment"
 msgstr ""
 
 #: py/obj.c
-msgid "object does not support item deletion"
+msgid "object doesn't support item deletion"
 msgstr ""
 
 #: py/obj.c
@@ -2744,7 +3685,7 @@ msgid "object has no len"
 msgstr ""
 
 #: py/obj.c
-msgid "object is not subscriptable"
+msgid "object isn't subscriptable"
 msgstr ""
 
 #: py/runtime.c
@@ -2772,38 +3713,85 @@ msgstr ""
 msgid "object with buffer protocol required"
 msgstr ""
 
-#: extmod/modubinascii.c
+#: py/objstr.c
 msgid "odd-length string"
 msgstr ""
 
-#: py/objstr.c py/objstrunicode.c
-msgid "offset out of bounds"
+#: supervisor/shared/web_workflow/web_workflow.c
+msgid "off"
+msgstr ""
+
+#: extmod/ulab/code/utils/utils.c
+msgid "offset is too large"
+msgstr ""
+
+#: shared-bindings/dualbank/__init__.c
+msgid "offset must be >= 0"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
+msgid "offset must be non-negative and no greater than buffer length"
 msgstr ""
 
 #: ports/nrf/common-hal/audiobusio/PDMIn.c
+#: ports/stm/common-hal/audiobusio/PDMIn.c
 msgid "only bit_depth=16 is supported"
 msgstr ""
 
+#: ports/stm/common-hal/audiobusio/PDMIn.c
+msgid "only mono is supported"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
+msgid "only ndarrays can be concatenated"
+msgstr ""
+
+#: ports/stm/common-hal/audiobusio/PDMIn.c
+msgid "only oversample=64 is supported"
+msgstr ""
+
 #: ports/nrf/common-hal/audiobusio/PDMIn.c
+#: ports/stm/common-hal/audiobusio/PDMIn.c
 msgid "only sample_rate=16000 is supported"
 msgstr ""
 
 #: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
+#: shared-bindings/alarm/SleepMemory.c shared-bindings/memorymap/AddressRange.c
 #: shared-bindings/nvm/ByteArray.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr ""
 
-#: extmod/ulab/code/compare.c extmod/ulab/code/ndarray.c
-#: extmod/ulab/code/vectorise.c
+#: py/vm.c
+msgid "opcode"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c extmod/ulab/code/numpy/bitwise.c
+#: extmod/ulab/code/numpy/compare.c extmod/ulab/code/numpy/vector.c
 msgid "operands could not be broadcast together"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: extmod/ulab/code/numpy/linalg/linalg.c
+msgid "operation is defined for 2D arrays only"
+msgstr ""
+
+#: extmod/ulab/code/numpy/linalg/linalg.c
+msgid "operation is defined for ndarrays only"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "operation is implemented for 1D Boolean arrays only"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
 msgid "operation is not implemented on ndarrays"
 msgstr ""
 
 #: extmod/ulab/code/ndarray.c
 msgid "operation is not supported for given type"
+msgstr ""
+
+#: extmod/ulab/code/ndarray_operators.c
+msgid "operation not supported for the input types"
 msgstr ""
 
 #: py/modbuiltins.c
@@ -2815,20 +3803,45 @@ msgstr ""
 msgid "ord() expected a character, but string of length %d found"
 msgstr ""
 
+#: extmod/ulab/code/utils/utils.c
+msgid "out array is too small"
+msgstr ""
+
+#: extmod/ulab/code/numpy/vector.c
+msgid "out keyword is not supported for complex dtype"
+msgstr ""
+
+#: extmod/ulab/code/numpy/vector.c
+msgid "out keyword is not supported for function"
+msgstr ""
+
+#: extmod/ulab/code/utils/utils.c
+msgid "out must be a float dense array"
+msgstr ""
+
+#: extmod/ulab/code/numpy/vector.c
+msgid "out must be an ndarray"
+msgstr ""
+
+#: extmod/ulab/code/numpy/vector.c
+msgid "out must be of float dtype"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "out of range of target"
+msgstr ""
+
 #: py/objint_mpz.c
 msgid "overflow converting long int to machine word"
 msgstr ""
 
+#: py/modstruct.c
+#, c-format
+msgid "pack expected %d items for packing (got %d)"
+msgstr ""
+
 #: shared-bindings/_stage/Layer.c shared-bindings/_stage/Text.c
 msgid "palette must be 32 bytes long"
-msgstr ""
-
-#: shared-bindings/displayio/Palette.c
-msgid "palette_index should be an int"
-msgstr ""
-
-#: py/compile.c
-msgid "parameter annotation must be an identifier"
 msgstr ""
 
 #: py/emitinlinextensa.c
@@ -2839,39 +3852,37 @@ msgstr ""
 msgid "parameters must be registers in sequence r0 to r3"
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c
+#: shared-bindings/bitmaptools/__init__.c
 msgid "pixel coordinates out of bounds"
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c
-msgid "pixel value requires too many bits"
+#: extmod/vfs_posix_file.c
+msgid "poll on file not available on win32"
 msgstr ""
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
-msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-msgstr ""
-
-#: shared-module/vectorio/Polygon.c
-msgid "polygon can only be registered in one parent"
+#: ports/espressif/common-hal/pulseio/PulseIn.c
+msgid "pop from an empty PulseIn"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #: ports/cxd56/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
-#: ports/stm/common-hal/pulseio/PulseIn.c
-msgid "pop from an empty PulseIn"
+#: ports/raspberrypi/common-hal/pulseio/PulseIn.c
+#: ports/stm/common-hal/pulseio/PulseIn.c py/objdict.c py/objlist.c py/objset.c
+#: shared-bindings/ps2io/Ps2.c
+msgid "pop from empty %q"
 msgstr ""
 
-#: py/objset.c
-msgid "pop from an empty set"
+#: shared-bindings/socketpool/Socket.c shared-bindings/ssl/SSLSocket.c
+msgid "port must be >= 0"
 msgstr ""
 
-#: py/objlist.c
-msgid "pop from empty list"
+#: py/compile.c
+msgid "positional arg after **"
 msgstr ""
 
-#: py/objdict.c
-msgid "popitem(): dictionary is empty"
+#: py/compile.c
+msgid "positional arg after keyword arg"
 msgstr ""
 
 #: py/objint_mpz.c
@@ -2882,15 +3893,15 @@ msgstr ""
 msgid "pow() with 3 arguments requires integers"
 msgstr ""
 
-#: extmod/modutimeq.c
-msgid "queue overflow"
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "pull masks conflict with direction masks"
 msgstr ""
 
 #: py/parse.c
-msgid "raw f-strings are not implemented"
+msgid "raw f-strings are not supported"
 msgstr ""
 
-#: extmod/ulab/code/fft.c
+#: extmod/ulab/code/numpy/fft/fft_tools.c
 msgid "real and imaginary parts must be of equal length"
 msgstr ""
 
@@ -2901,6 +3912,10 @@ msgstr ""
 #: py/obj.c
 #, c-format
 msgid "requested length %d but object has length %d"
+msgstr ""
+
+#: extmod/ulab/code/ndarray_operators.c
+msgid "results cannot be cast to specified type"
 msgstr ""
 
 #: py/compile.c
@@ -2921,34 +3936,37 @@ msgstr ""
 msgid "rgb_pins[%d] is not on the same port as clock"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
-msgid "right hand side must be an ndarray, or a scalar"
+#: extmod/ulab/code/numpy/numerical.c
+msgid "roll argument must be an ndarray"
 msgstr ""
 
 #: py/objstr.c
 msgid "rsplit(None,n)"
 msgstr ""
 
-#: shared-bindings/audiocore/RawSample.c
-msgid ""
-"sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' or "
-"'B'"
-msgstr ""
-
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+#: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
 msgid "sampling rate out of range"
 msgstr ""
 
 #: py/modmicropython.c
-msgid "schedule stack full"
+msgid "schedule queue full"
 msgstr ""
 
-#: shared/runtime/pyexec.c py/builtinimport.c
+#: py/builtinimport.c
 msgid "script compilation not supported"
 msgstr ""
 
+#: py/nativeglue.c
+msgid "set unsupported"
+msgstr ""
+
 #: extmod/ulab/code/ndarray.c
-msgid "shape must be a 2-tuple"
+msgid "shape must be integer or tuple of integers"
+msgstr ""
+
+#: shared-module/msgpack/__init__.c
+msgid "short read"
 msgstr ""
 
 #: py/objstr.c
@@ -2959,11 +3977,7 @@ msgstr ""
 msgid "sign not allowed with integer format specifier 'c'"
 msgstr ""
 
-#: py/objstr.c
-msgid "single '}' encountered in format string"
-msgstr ""
-
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/ulab_tools.c
 msgid "size is defined for ndarrays only"
 msgstr ""
 
@@ -2971,8 +3985,8 @@ msgstr ""
 msgid "sleep length must be non-negative"
 msgstr ""
 
-#: py/objslice.c py/sequence.c
-msgid "slice step cannot be zero"
+#: py/nativeglue.c
+msgid "slice unsupported"
 msgstr ""
 
 #: py/objint.c py/sequence.c
@@ -2983,32 +3997,56 @@ msgstr ""
 msgid "soft reboot\n"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: extmod/ulab/code/numpy/numerical.c
 msgid "sort argument must be an ndarray"
+msgstr ""
+
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "sos array must be of shape (n_section, 6)"
+msgstr ""
+
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "sos[:, 3] should be all ones"
+msgstr ""
+
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "sosfilt requires iterable arguments"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "source palette too large"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "source_bitmap must have value_count of 2 or 65536"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "source_bitmap must have value_count of 65536"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "source_bitmap must have value_count of 8"
+msgstr ""
+
+#: extmod/modre.c
+msgid "splitting with sub-captures"
 msgstr ""
 
 #: py/objstr.c
 msgid "start/end indices"
 msgstr ""
 
-#: shared-bindings/displayio/Shape.c
-msgid "start_x should be an int"
-msgstr ""
-
-#: shared-bindings/random/__init__.c
-msgid "step must be non-zero"
-msgstr ""
-
-#: shared-bindings/busio/UART.c
-msgid "stop must be 1 or 2"
-msgstr ""
-
 #: shared-bindings/random/__init__.c
 msgid "stop not reachable from start"
 msgstr ""
 
-#: py/stream.c
+#: py/stream.c shared-bindings/getpass/__init__.c
 msgid "stream operation not supported"
+msgstr ""
+
+#: py/objarray.c py/objstr.c
+msgid "string argument without an encoding"
 msgstr ""
 
 #: py/objstrunicode.c
@@ -3020,12 +4058,8 @@ msgstr ""
 msgid "string indices must be integers, not %s"
 msgstr ""
 
-#: py/stream.c
-msgid "string not supported; use bytes or bytearray"
-msgstr ""
-
 #: extmod/moductypes.c
-msgid "struct: cannot index"
+msgid "struct: can't index"
 msgstr ""
 
 #: extmod/moductypes.c
@@ -3036,7 +4070,7 @@ msgstr ""
 msgid "struct: no fields"
 msgstr ""
 
-#: py/objstr.c
+#: py/objarray.c py/objstr.c
 msgid "substring not found"
 msgstr ""
 
@@ -3044,7 +4078,7 @@ msgstr ""
 msgid "super() can't find self"
 msgstr ""
 
-#: extmod/modujson.c
+#: extmod/modjson.c
 msgid "syntax error in JSON"
 msgstr ""
 
@@ -3052,36 +4086,52 @@ msgstr ""
 msgid "syntax error in uctypes descriptor"
 msgstr ""
 
-#: shared-bindings/touchio/TouchIn.c
-msgid "threshold must be in the range 0-65536"
-msgstr ""
-
-#: shared-bindings/time/__init__.c
-msgid "time.struct_time() takes a 9-sequence"
+#: extmod/modtime.c
+msgid "ticks interval overflow"
 msgstr ""
 
 #: ports/nrf/common-hal/watchdog/WatchDogTimer.c
 msgid "timeout duration exceeded the maximum supported value"
 msgstr ""
 
-#: shared-bindings/busio/UART.c
-msgid "timeout must be 0.0-100.0 seconds"
+#: ports/nrf/common-hal/_bleio/Adapter.c
+msgid "timeout must be < 655.35 secs"
 msgstr ""
 
-#: shared-bindings/_bleio/CharacteristicBuffer.c
-msgid "timeout must be >= 0.0"
+#: shared-module/sdcardio/SDCard.c
+msgid "timeout waiting for v1 card"
+msgstr ""
+
+#: shared-module/sdcardio/SDCard.c
+msgid "timeout waiting for v2 card"
+msgstr ""
+
+#: ports/stm/common-hal/pwmio/PWMOut.c
+msgid "timer re-init"
 msgstr ""
 
 #: shared-bindings/time/__init__.c
 msgid "timestamp out of range for platform time_t"
 msgstr ""
 
-#: shared-module/struct/__init__.c
-msgid "too many arguments provided with the given format"
+#: extmod/ulab/code/ndarray.c
+msgid "tobytes can be invoked for dense arrays only"
+msgstr ""
+
+#: py/compile.c
+msgid "too many args"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c extmod/ulab/code/numpy/create.c
+msgid "too many dimensions"
 msgstr ""
 
 #: extmod/ulab/code/ndarray.c
 msgid "too many indices"
+msgstr ""
+
+#: py/asmthumb.c
+msgid "too many locals for native method"
 msgstr ""
 
 #: py/runtime.c
@@ -3089,20 +4139,29 @@ msgstr ""
 msgid "too many values to unpack (expected %d)"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c py/objstr.c
-msgid "tuple index out of range"
+#: extmod/ulab/code/numpy/approx.c
+msgid "trapz is defined for 1D arrays of equal length"
+msgstr ""
+
+#: extmod/ulab/code/numpy/approx.c
+msgid "trapz is defined for 1D iterables"
 msgstr ""
 
 #: py/obj.c
 msgid "tuple/list has wrong length"
 msgstr ""
 
-#: shared-bindings/_pixelbuf/PixelBuf.c
-msgid "tuple/list required on RHS"
+#: ports/espressif/common-hal/canio/CAN.c
+#, c-format
+msgid "twai_driver_install returned esp-idf error #%d"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
-#: shared-bindings/busio/UART.c
+#: ports/espressif/common-hal/canio/CAN.c
+#, c-format
+msgid "twai_start returned esp-idf error #%d"
+msgstr ""
+
+#: shared-bindings/busio/UART.c shared-bindings/canio/CAN.c
 msgid "tx and rx cannot both be None"
 msgstr ""
 
@@ -3138,7 +4197,8 @@ msgstr ""
 msgid "unexpected keyword argument"
 msgstr ""
 
-#: py/bc.c py/objnamedtuple.c
+#: py/argcheck.c py/bc.c py/objnamedtuple.c
+#: shared-bindings/traceback/__init__.c
 msgid "unexpected keyword argument '%q'"
 msgstr ""
 
@@ -3147,7 +4207,7 @@ msgid "unicode name escapes"
 msgstr ""
 
 #: py/parse.c
-msgid "unindent does not match any outer indentation level"
+msgid "unindent doesn't match any outer indent level"
 msgstr ""
 
 #: py/objstr.c
@@ -3156,20 +4216,20 @@ msgid "unknown conversion specifier %c"
 msgstr ""
 
 #: py/objstr.c
-#, c-format
-msgid "unknown format code '%c' for object of type '%s'"
+msgid "unknown format code '%c' for object of type '%q'"
 msgstr ""
 
 #: py/compile.c
 msgid "unknown type"
 msgstr ""
 
-#: py/emitnative.c
+#: py/compile.c
 msgid "unknown type '%q'"
 msgstr ""
 
 #: py/objstr.c
-msgid "unmatched '{' in format"
+#, c-format
+msgid "unmatched '%c' in format"
 msgstr ""
 
 #: py/objtype.c py/runtime.c
@@ -3177,7 +4237,6 @@ msgid "unreadable attribute"
 msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
-#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr ""
 
@@ -3189,6 +4248,14 @@ msgstr ""
 #: py/emitinlinextensa.c
 #, c-format
 msgid "unsupported Xtensa instruction '%s' with %d arguments"
+msgstr ""
+
+#: shared-module/gifio/GifWriter.c
+msgid "unsupported colorspace for GifWriter"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "unsupported colorspace for dither"
 msgstr ""
 
 #: py/objstr.c
@@ -3205,7 +4272,15 @@ msgid "unsupported type for operator"
 msgstr ""
 
 #: py/runtime.c
-msgid "unsupported types for %q: '%s', '%s'"
+msgid "unsupported types for %q: '%q', '%q'"
+msgstr ""
+
+#: extmod/ulab/code/numpy/io/io.c
+msgid "usecols is too high"
+msgstr ""
+
+#: extmod/ulab/code/numpy/io/io.c
+msgid "usecols keyword must be specified"
 msgstr ""
 
 #: py/objint.c
@@ -3213,31 +4288,62 @@ msgstr ""
 msgid "value must fit in %d byte(s)"
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c
-msgid "value_count must be > 0"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "value out of range of target"
 msgstr ""
 
-#: shared-bindings/watchdog/WatchDogTimer.c
-msgid "watchdog timeout must be greater than 0"
+#: extmod/moddeflate.c
+msgid "wbits"
+msgstr ""
+
+#: shared-bindings/is31fl3741/FrameBuffer.c
+msgid "width must be greater than zero"
+msgstr ""
+
+#: ports/espressif/common-hal/wifi/Radio.c
+#: ports/raspberrypi/common-hal/wifi/Radio.c
+msgid "wifi is not enabled"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/wifi/Monitor.c
+msgid "wifi.Monitor not available"
 msgstr ""
 
 #: shared-bindings/_bleio/Adapter.c
 msgid "window must be <= interval"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
-msgid "wrong argument type"
+#: extmod/ulab/code/numpy/numerical.c
+msgid "wrong axis index"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
+#: extmod/ulab/code/numpy/create.c
+msgid "wrong axis specified"
+msgstr ""
+
+#: extmod/ulab/code/numpy/io/io.c
+msgid "wrong dtype"
+msgstr ""
+
+#: extmod/ulab/code/numpy/transform.c
 msgid "wrong index type"
 msgstr ""
 
-#: extmod/ulab/code/vectorise.c
+#: extmod/ulab/code/numpy/compare.c extmod/ulab/code/numpy/create.c
+#: extmod/ulab/code/numpy/io/io.c extmod/ulab/code/numpy/transform.c
+#: extmod/ulab/code/numpy/vector.c
 msgid "wrong input type"
 msgstr ""
 
-#: py/objstr.c
+#: extmod/ulab/code/numpy/transform.c
+msgid "wrong length of condition array"
+msgstr ""
+
+#: extmod/ulab/code/numpy/transform.c
+msgid "wrong length of index array"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c py/objarray.c py/objstr.c
 msgid "wrong number of arguments"
 msgstr ""
 
@@ -3245,26 +4351,18 @@ msgstr ""
 msgid "wrong number of values to unpack"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
-msgid "wrong operand type"
-msgstr ""
-
-#: extmod/ulab/code/vectorise.c
+#: extmod/ulab/code/numpy/vector.c
 msgid "wrong output type"
 msgstr ""
 
-#: shared-module/displayio/Shape.c
-msgid "x value out of bounds"
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "zi must be an ndarray"
 msgstr ""
 
-#: shared-bindings/displayio/Shape.c
-msgid "y should be an int"
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "zi must be of float type"
 msgstr ""
 
-#: shared-module/displayio/Shape.c
-msgid "y value out of bounds"
-msgstr ""
-
-#: py/objrange.c
-msgid "zero step"
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "zi must be of shape (n_section, 2)"
 msgstr ""

--- a/locale/en_x_pirate.po
+++ b/locale/en_x_pirate.po
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2014 MicroPython & CircuitPython contributors (https://github.com/adafruit/circuitpython/graphs/contributors)
 #
 # SPDX-License-Identifier: MIT
-
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
@@ -19,25 +18,32 @@ msgstr ""
 #: main.c
 msgid ""
 "\n"
-"Code done running. Waiting for reload.\n"
+"Code done running.\n"
 msgstr ""
+
+#: main.c
+msgid ""
 "\n"
-"Captin's orders are complete. Holdin' fast fer reload.\n"
+"Code stopped by auto-reload. Reloading soon.\n"
+msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid ""
 "\n"
-"Please file an issue with the contents of your CIRCUITPY drive at \n"
-"https://github.com/adafruit/circuitpython/issues\n"
+"Please file an issue with your program at github.com/adafruit/circuitpython/"
+"issues."
 msgstr ""
-"\n"
-"Yar, there is a hole in the keel. Let the cap'n know at\n"
-"https://github.com/adafruit/circuitpython/issues\n"
 
 #: supervisor/shared/safe_mode.c
 msgid ""
 "\n"
-"To exit, please reset the board without "
+"Press reset to exit safe mode.\n"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"\n"
+"You are in safe mode because:\n"
 msgstr ""
 
 #: py/obj.c
@@ -46,6 +52,14 @@ msgstr ""
 
 #: py/obj.c
 msgid "  File \"%q\", line %d"
+msgstr ""
+
+#: py/builtinhelp.c
+msgid " is of type %q\n"
+msgstr ""
+
+#: main.c
+msgid " not found.\n"
 msgstr ""
 
 #: main.c
@@ -59,14 +73,42 @@ msgstr ""
 
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
-msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+msgid ""
+"%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr ""
 
+#: shared-bindings/microcontroller/Pin.c
+msgid "%q and %q contain duplicate pins"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
+msgid "%q and %q must be different"
+msgstr ""
+
+#: shared-bindings/microcontroller/Pin.c
+msgid "%q contains duplicate pins"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/sdioio/SDCard.c
+msgid "%q failure: %d"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q in %q must be of type %q, not %q"
+msgstr ""
+
+#: ports/espressif/common-hal/espulp/ULP.c
+#: ports/mimxrt10xx/common-hal/audiobusio/__init__.c
+#: ports/mimxrt10xx/common-hal/usb_host/Port.c
+#: ports/raspberrypi/common-hal/picodvi/Framebuffer.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#: ports/raspberrypi/common-hal/usb_host/Port.c
+#: shared-bindings/digitalio/DigitalInOut.c
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q in use"
 msgstr ""
 
-#: py/obj.c
+#: py/objstr.c
 msgid "%q index out of range"
 msgstr ""
 
@@ -74,31 +116,173 @@ msgstr ""
 msgid "%q indices must be integers, not %s"
 msgstr ""
 
-#: shared-bindings/vectorio/Polygon.c
-msgid "%q list must be a list"
+#: shared-module/bitbangio/SPI.c
+msgid "%q init failed"
 msgstr ""
 
-#: shared-bindings/_bleio/CharacteristicBuffer.c
-#: shared-bindings/_bleio/PacketBuffer.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/Shape.c shared-bindings/vectorio/Circle.c
-#: shared-bindings/vectorio/Rectangle.c
-msgid "%q must be >= 1"
+#: ports/espressif/bindings/espnow/Peer.c shared-bindings/dualbank/__init__.c
+msgid "%q is %q"
 msgstr ""
 
-#: shared-module/vectorio/Polygon.c
-msgid "%q must be a tuple of length 2"
+#: ports/raspberrypi/common-hal/wifi/Radio.c
+msgid "%q is read-only for this board"
 msgstr ""
 
-#: shared-bindings/fontio/BuiltinFont.c
-msgid "%q should be an int"
+#: py/argcheck.c shared-bindings/usb_hid/Device.c
+msgid "%q length must be %d"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q length must be %d-%d"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q length must be <= %d"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q length must be >= %d"
+msgstr ""
+
+#: py/objmodule.c py/runtime.c
+msgid "%q moved from %q to %q"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q must be %d"
+msgstr ""
+
+#: py/argcheck.c shared-bindings/busdisplay/BusDisplay.c
+#: shared-bindings/displayio/Bitmap.c
+#: shared-bindings/framebufferio/FramebufferDisplay.c
+#: shared-bindings/is31fl3741/FrameBuffer.c
+#: shared-bindings/rgbmatrix/RGBMatrix.c
+msgid "%q must be %d-%d"
+msgstr ""
+
+#: shared-bindings/busdisplay/BusDisplay.c
+msgid "%q must be 1 when %q is True"
+msgstr ""
+
+#: py/argcheck.c shared-bindings/gifio/GifWriter.c
+#: shared-module/gifio/OnDiskGif.c
+msgid "%q must be <= %d"
+msgstr ""
+
+#: ports/espressif/common-hal/watchdog/WatchDogTimer.c
+msgid "%q must be <= %u"
+msgstr ""
+
+#: py/argcheck.c
+msgid "%q must be >= %d"
+msgstr ""
+
+#: shared-bindings/analogbufio/BufferedIn.c
+msgid "%q must be a bytearray or array of type 'H' or 'B'"
+msgstr ""
+
+#: shared-bindings/audiocore/RawSample.c
+msgid "%q must be a bytearray or array of type 'h', 'H', 'b', or 'B'"
+msgstr ""
+
+#: shared-bindings/warnings/__init__.c
+msgid "%q must be a subclass of %q"
+msgstr ""
+
+#: ports/espressif/common-hal/analogbufio/BufferedIn.c
+msgid "%q must be array of type 'H'"
+msgstr ""
+
+#: shared-module/synthio/__init__.c
+msgid "%q must be array of type 'h'"
+msgstr ""
+
+#: ports/raspberrypi/bindings/cyw43/__init__.c py/argcheck.c py/objexcept.c
+#: shared-bindings/canio/CAN.c shared-bindings/digitalio/Pull.c
+#: shared-module/synthio/Synthesizer.c
+msgid "%q must be of type %q or %q, not %q"
+msgstr ""
+
+#: py/argcheck.c shared-module/synthio/__init__.c
+msgid "%q must be of type %q, not %q"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/busio/UART.c
+msgid "%q must be power of 2"
+msgstr ""
+
+#: shared-bindings/wifi/Monitor.c
+msgid "%q out of bounds"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/cxd56/common-hal/pulseio/PulseIn.c
+#: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#: ports/stm/common-hal/pulseio/PulseIn.c py/argcheck.c
+#: shared-bindings/canio/Match.c
+msgid "%q out of range"
+msgstr ""
+
+#: py/objmodule.c py/runtime.c
+msgid "%q renamed %q"
+msgstr ""
+
+#: py/objrange.c py/objslice.c shared-bindings/random/__init__.c
+msgid "%q step cannot be zero"
 msgstr ""
 
 #: py/bc.c py/objnamedtuple.c
 msgid "%q() takes %d positional arguments but %d were given"
 msgstr ""
 
+#: shared-bindings/usb_hid/Device.c
+msgid "%q, %q, and %q must all be the same length"
+msgstr ""
+
+#: py/objint.c shared-bindings/storage/__init__.c
+msgid "%q=%q"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "%q[%u] shifts in more bits than pin count"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "%q[%u] shifts out more bits than pin count"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "%q[%u] uses extra pin"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "%q[%u] waits on input outside of count"
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+#, c-format
+msgid "%s error 0x%x"
+msgstr ""
+
 #: py/argcheck.c
 msgid "'%q' argument required"
+msgstr ""
+
+#: py/proto.c
+msgid "'%q' object does not support '%q'"
+msgstr ""
+
+#: py/runtime.c
+msgid "'%q' object is not an iterator"
+msgstr ""
+
+#: py/objtype.c py/runtime.c shared-module/atexit/__init__.c
+msgid "'%q' object is not callable"
+msgstr ""
+
+#: py/runtime.c
+msgid "'%q' object is not iterable"
 msgstr ""
 
 #: py/emitinlinethumb.c py/emitinlinextensa.c
@@ -143,54 +327,31 @@ msgstr ""
 
 #: py/emitinlinextensa.c
 #, c-format
-msgid "'%s' integer %d is not within range %d..%d"
+msgid "'%s' integer %d isn't within range %d..%d"
 msgstr ""
 
 #: py/emitinlinethumb.c
 #, c-format
-msgid "'%s' integer 0x%x does not fit in mask 0x%x"
-msgstr ""
-
-#: py/runtime.c
-msgid "'%s' object cannot assign attribute '%q'"
-msgstr ""
-
-#: py/proto.c
-msgid "'%s' object does not support '%q'"
+msgid "'%s' integer 0x%x doesn't fit in mask 0x%x"
 msgstr ""
 
 #: py/obj.c
 #, c-format
-msgid "'%s' object does not support item assignment"
+msgid "'%s' object doesn't support item assignment"
 msgstr ""
 
 #: py/obj.c
 #, c-format
-msgid "'%s' object does not support item deletion"
+msgid "'%s' object doesn't support item deletion"
 msgstr ""
 
 #: py/runtime.c
 msgid "'%s' object has no attribute '%q'"
 msgstr ""
 
-#: py/runtime.c
-#, c-format
-msgid "'%s' object is not an iterator"
-msgstr ""
-
-#: py/objtype.c py/runtime.c
-#, c-format
-msgid "'%s' object is not callable"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "'%s' object is not iterable"
-msgstr ""
-
 #: py/obj.c
 #, c-format
-msgid "'%s' object is not subscriptable"
+msgid "'%s' object isn't subscriptable"
 msgstr ""
 
 #: py/objstr.c
@@ -206,19 +367,11 @@ msgid "'align' requires 1 argument"
 msgstr ""
 
 #: py/compile.c
-msgid "'async for' or 'async with' outside async function"
-msgstr ""
-
-#: py/compile.c
 msgid "'await' outside function"
 msgstr ""
 
 #: py/compile.c
-msgid "'break' outside loop"
-msgstr ""
-
-#: py/compile.c
-msgid "'continue' outside loop"
+msgid "'break'/'continue' outside loop"
 msgstr ""
 
 #: py/compile.c
@@ -238,7 +391,15 @@ msgid "'return' outside function"
 msgstr ""
 
 #: py/compile.c
+msgid "'yield from' inside async function"
+msgstr ""
+
+#: py/compile.c
 msgid "'yield' outside function"
+msgstr ""
+
+#: py/compile.c
+msgid "* arg after **"
 msgstr ""
 
 #: py/compile.c
@@ -249,6 +410,12 @@ msgstr ""
 msgid ", in %q\n"
 msgstr ""
 
+#: shared-bindings/busdisplay/BusDisplay.c
+#: shared-bindings/epaperdisplay/EPaperDisplay.c
+#: shared-bindings/framebufferio/FramebufferDisplay.c
+msgid ".show(x) removed. Use .root_group = x"
+msgstr ""
+
 #: py/objcomplex.c
 msgid "0.0 to a complex power"
 msgstr ""
@@ -257,41 +424,88 @@ msgstr ""
 msgid "3-arg pow() not supported"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
 #: ports/atmel-samd/common-hal/countio/Counter.c
 #: ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
 msgid "A hardware interrupt channel is already in use"
 msgstr "Avast! A hardware interrupt channel be used already"
 
-#: shared-bindings/_bleio/Address.c
+#: ports/raspberrypi/common-hal/wifi/Radio.c
+msgid "AP could not be started"
+msgstr ""
+
+#: shared-bindings/_bleio/Address.c shared-bindings/ipaddress/IPv4Address.c
 #, c-format
 msgid "Address must be %d bytes long"
 msgstr ""
 
-#: shared-bindings/_bleio/Address.c
-msgid "Address type out of range"
+#: ports/espressif/common-hal/memorymap/AddressRange.c
+#: ports/nrf/common-hal/memorymap/AddressRange.c
+#: ports/raspberrypi/common-hal/memorymap/AddressRange.c
+msgid "Address range not allowed"
 msgstr ""
 
+#: shared-bindings/memorymap/AddressRange.c
+msgid "Address range wraps around"
+msgstr ""
+
+#: ports/espressif/common-hal/canio/CAN.c
+msgid "All CAN peripherals are in use"
+msgstr ""
+
+#: ports/espressif/common-hal/busio/I2C.c
+#: ports/espressif/common-hal/i2ctarget/I2CTarget.c
 #: ports/nrf/common-hal/busio/I2C.c
 msgid "All I2C peripherals are in use"
 msgstr ""
 
-#: ports/nrf/common-hal/busio/SPI.c
+#: ports/espressif/common-hal/countio/Counter.c
+#: ports/espressif/common-hal/frequencyio/FrequencyIn.c
+#: ports/espressif/common-hal/rotaryio/IncrementalEncoder.c
+msgid "All PCNT units in use"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/canio/Listener.c
+#: ports/espressif/common-hal/canio/Listener.c
+#: ports/stm/common-hal/canio/Listener.c
+msgid "All RX FIFOs in use"
+msgstr ""
+
+#: ports/espressif/common-hal/busio/SPI.c ports/nrf/common-hal/busio/SPI.c
 msgid "All SPI peripherals are in use"
 msgstr ""
 
-#: ports/nrf/common-hal/busio/UART.c
+#: ports/espressif/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
 msgid "All UART peripherals are in use"
+msgstr ""
+
+#: ports/nrf/common-hal/countio/Counter.c
+#: ports/nrf/common-hal/pulseio/PulseIn.c
+#: ports/nrf/common-hal/rotaryio/IncrementalEncoder.c
+#: shared-bindings/pwmio/PWMOut.c
+msgid "All channels in use"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/usb_host/Port.c
+msgid "All dma channels in use"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "All event channels in use"
 msgstr ""
 
-#: ports/atmel-samd/audio_dma.c ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+#: ports/raspberrypi/common-hal/picodvi/Framebuffer.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+#: ports/raspberrypi/common-hal/usb_host/Port.c
+msgid "All state machines in use"
+msgstr ""
+
+#: ports/atmel-samd/audio_dma.c
 msgid "All sync event channels in use"
 msgstr ""
 
-#: shared-bindings/pulseio/PWMOut.c
+#: ports/raspberrypi/common-hal/picodvi/Framebuffer.c
+#: shared-bindings/pwmio/PWMOut.c
 msgid "All timers for this pin are in use"
 msgstr ""
 
@@ -301,32 +515,45 @@ msgstr ""
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
 #: ports/cxd56/common-hal/pulseio/PulseOut.c
+#: ports/espressif/common-hal/frequencyio/FrequencyIn.c
+#: ports/espressif/common-hal/neopixel_write/__init__.c
+#: ports/espressif/common-hal/pulseio/PulseIn.c
+#: ports/espressif/common-hal/pulseio/PulseOut.c
 #: ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c ports/nrf/peripherals/nrf/timers.c
-#: shared-bindings/pulseio/PWMOut.c
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+#: ports/stm/peripherals/timers.c shared-bindings/pwmio/PWMOut.c
 msgid "All timers in use"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "Already advertising."
 msgstr ""
 
-#: ports/cxd56/common-hal/analogio/AnalogIn.c
-msgid "AnalogIn not supported on given pin"
+#: ports/atmel-samd/common-hal/canio/Listener.c
+msgid "Already have all-matches listener"
 msgstr ""
 
-#: ports/cxd56/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-msgid "AnalogOut functionality not supported"
+#: ports/espressif/bindings/espnow/ESPNow.c
+#: ports/espressif/common-hal/espulp/ULP.c
+#: shared-module/memorymonitor/AllocationAlarm.c
+#: shared-module/memorymonitor/AllocationSize.c
+msgid "Already running"
 msgstr ""
 
-#: shared-bindings/analogio/AnalogOut.c
-msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#: ports/espressif/common-hal/wifi/Radio.c
+#: ports/raspberrypi/common-hal/wifi/Radio.c
+msgid "Already scanning for wifi networks"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/analogio/AnalogOut.c
-msgid "AnalogOut not supported on given pin"
+#: shared-module/os/getenv.c
+#, c-format
+msgid "An error occurred while retrieving '%s':\n"
+msgstr ""
+
+#: ports/stm/common-hal/audiopwmio/PWMAudioOut.c
+msgid "Another PWMAudioOut is already active"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PulseOut.c
@@ -338,16 +565,26 @@ msgstr "Belay that! thar be another active send"
 msgid "Array must contain halfwords (type 'H')"
 msgstr ""
 
+#: shared-bindings/alarm/SleepMemory.c shared-bindings/memorymap/AddressRange.c
 #: shared-bindings/nvm/ByteArray.c
 msgid "Array values should be single bytes."
 msgstr ""
 
-#: shared-bindings/rgbmatrix/RGBMatrix.c
-msgid "At most %d %q may be specified (not %d)"
+#: shared-module/memorymonitor/AllocationAlarm.c
+#, c-format
+msgid "Attempt to allocate %d blocks"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid "Attempted heap allocation when MicroPython VM not running."
+#: ports/raspberrypi/audio_dma.c
+msgid "Audio conversion not implemented"
+msgstr ""
+
+#: shared-bindings/wifi/Radio.c
+msgid "AuthMode.OPEN is not used with password"
+msgstr ""
+
+#: shared-bindings/wifi/Radio.c supervisor/shared/web_workflow/web_workflow.c
+msgid "Authentication failure"
 msgstr ""
 
 #: main.c
@@ -362,9 +599,17 @@ msgstr ""
 "Auto-reload be on. Put yer files on USB to weigh anchor, er' bring'er about "
 "t' the REPL t' scuttle.\n"
 
-#: shared-module/displayio/Display.c
+#: ports/espressif/common-hal/canio/CAN.c
+msgid "Baudrate not supported by peripheral"
+msgstr ""
+
+#: shared-module/busdisplay/BusDisplay.c
 #: shared-module/framebufferio/FramebufferDisplay.c
 msgid "Below minimum frame rate"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+msgid "Bit clock and word select must be sequential GPIO pins"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -375,6 +620,14 @@ msgstr ""
 msgid "Bit depth must be multiple of 8."
 msgstr ""
 
+#: shared-bindings/bitmaptools/__init__.c
+msgid "Bitmap size and bits per value must match"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Boot device must be first (interface #0)."
+msgstr ""
+
 #: ports/mimxrt10xx/common-hal/busio/UART.c
 msgid "Both RX and TX required for flow control"
 msgstr ""
@@ -383,17 +636,7 @@ msgstr ""
 msgid "Both pins must support hardware interrupts"
 msgstr ""
 
-#: shared-bindings/displayio/Display.c
-#: shared-bindings/framebufferio/FramebufferDisplay.c
-#: shared-bindings/rgbmatrix/RGBMatrix.c
-msgid "Brightness must be 0-1.0"
-msgstr ""
-
-#: shared-bindings/supervisor/__init__.c
-msgid "Brightness must be between 0 and 255"
-msgstr ""
-
-#: shared-bindings/displayio/Display.c
+#: shared-bindings/busdisplay/BusDisplay.c
 #: shared-bindings/framebufferio/FramebufferDisplay.c
 msgid "Brightness not adjustable"
 msgstr ""
@@ -403,32 +646,26 @@ msgstr ""
 msgid "Buffer + offset too small %d %d %d"
 msgstr ""
 
-#: shared-module/usb_hid/Device.c
-#, c-format
-msgid "Buffer incorrect size. Should be %d bytes."
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+msgid "Buffer elements must be 4 bytes long or less"
 msgstr ""
 
-#: shared-bindings/displayio/Display.c
 #: shared-bindings/framebufferio/FramebufferDisplay.c
 msgid "Buffer is not a bytearray."
 msgstr ""
 
-#: shared-bindings/displayio/Display.c
-#: shared-bindings/framebufferio/FramebufferDisplay.c
-msgid "Buffer is too small"
-msgstr ""
-
-#: ports/nrf/common-hal/audiopwmio/PWMAudioOut.c
+#: ports/stm/common-hal/audiopwmio/PWMAudioOut.c
 #, c-format
 msgid "Buffer length %d too big. It must be less than %d"
 msgstr ""
 
-#: shared-bindings/bitbangio/I2C.c shared-bindings/busio/I2C.c
-msgid "Buffer must be at least length 1"
+#: ports/atmel-samd/common-hal/sdioio/SDCard.c
+#: ports/cxd56/common-hal/sdioio/SDCard.c shared-module/sdcardio/SDCard.c
+msgid "Buffer length must be a multiple of 512"
 msgstr ""
 
-#: ports/nrf/common-hal/_bleio/PacketBuffer.c
-msgid "Buffer too large and unable to allocate"
+#: ports/stm/common-hal/sdioio/SDCard.c shared-bindings/floppyio/__init__.c
+msgid "Buffer must be a multiple of 512 bytes"
 msgstr ""
 
 #: shared-bindings/_bleio/PacketBuffer.c
@@ -436,8 +673,21 @@ msgstr ""
 msgid "Buffer too short by %d bytes"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
-#: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/cxd56/common-hal/camera/Camera.c
+#: shared-bindings/busdisplay/BusDisplay.c
+#: shared-bindings/framebufferio/FramebufferDisplay.c
+#: shared-bindings/struct/__init__.c shared-module/struct/__init__.c
+msgid "Buffer too small"
+msgstr ""
+
+#: ports/espressif/common-hal/imagecapture/ParallelImageCapture.c
+msgid "Buffers must be same size"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/paralleldisplaybus/ParallelBus.c
+#: ports/espressif/common-hal/paralleldisplaybus/ParallelBus.c
+#: ports/nrf/common-hal/paralleldisplaybus/ParallelBus.c
+#: ports/raspberrypi/common-hal/paralleldisplaybus/ParallelBus.c
 #, c-format
 msgid "Bus pin %d is already in use"
 msgstr "Belay that! Bus pin %d already be in use"
@@ -446,29 +696,62 @@ msgstr "Belay that! Bus pin %d already be in use"
 msgid "Byte buffer must be 16 bytes."
 msgstr ""
 
-#: shared-bindings/nvm/ByteArray.c
-msgid "Bytes must be between 0 and 255."
-msgstr ""
-
 #: shared-bindings/aesio/aes.c
 msgid "CBC blocks must be multiples of 16 bytes"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "CIRCUITPY drive could not be found or created."
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "CRC or checksum was invalid"
 msgstr ""
 
 #: py/objtype.c
 msgid "Call super().__init__() before accessing native object."
 msgstr ""
 
+#: ports/cxd56/common-hal/camera/Camera.c
+msgid "Camera init"
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
+msgid "Can only alarm on RTC IO from deep sleep."
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
+msgid "Can only alarm on one low pin while others alarm high from deep sleep."
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
+msgid "Can only alarm on two low pins from deep sleep."
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 msgid "Can't set CCCD on local Characteristic"
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/storage/__init__.c shared-bindings/usb_cdc/__init__.c
+#: shared-bindings/usb_hid/__init__.c shared-bindings/usb_midi/__init__.c
+msgid "Cannot change USB devices now"
+msgstr ""
+
+#: shared-bindings/_bleio/Adapter.c
+msgid "Cannot create a new Adapter; use _bleio.adapter;"
+msgstr ""
+
+#: shared-bindings/displayio/Bitmap.c
+#: shared-bindings/memorymonitor/AllocationSize.c
+#: shared-bindings/pulseio/PulseIn.c
 msgid "Cannot delete values"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/digitalio/DigitalInOut.c
 #: ports/mimxrt10xx/common-hal/digitalio/DigitalInOut.c
 #: ports/nrf/common-hal/digitalio/DigitalInOut.c
+#: ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
 msgid "Cannot get pull while in output mode"
 msgstr ""
 
@@ -480,12 +763,8 @@ msgstr ""
 msgid "Cannot have scan responses for extended, connectable advertisements."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-msgid "Cannot output both channels on the same pin"
-msgstr ""
-
-#: shared-module/bitbangio/SPI.c
-msgid "Cannot read without MISO pin."
+#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
+msgid "Cannot pull on input-only pin."
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -493,19 +772,24 @@ msgid "Cannot record to a file"
 msgstr ""
 
 #: shared-module/storage/__init__.c
-msgid "Cannot remount '/' when USB is active."
+msgid "Cannot remount '/' when visible via USB."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/microcontroller/__init__.c
 #: ports/cxd56/common-hal/microcontroller/__init__.c
 #: ports/mimxrt10xx/common-hal/microcontroller/__init__.c
-msgid "Cannot reset into bootloader because no bootloader is present."
+msgid "Cannot reset into bootloader because no bootloader is present"
+msgstr ""
+
+#: ports/espressif/common-hal/socketpool/Socket.c
+msgid "Cannot set socket options"
 msgstr ""
 
 #: shared-bindings/digitalio/DigitalInOut.c
 msgid "Cannot set value when direction is input."
 msgstr ""
 
+#: ports/espressif/common-hal/busio/UART.c
 #: ports/mimxrt10xx/common-hal/busio/UART.c
 msgid "Cannot specify RTS or CTS in RS485 mode"
 msgstr ""
@@ -514,20 +798,16 @@ msgstr ""
 msgid "Cannot subclass slice"
 msgstr ""
 
-#: shared-module/bitbangio/SPI.c
-msgid "Cannot transfer without MOSI and MISO pins."
-msgstr ""
-
-#: extmod/moductypes.c
-msgid "Cannot unambiguously get sizeof scalar"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
+#: shared-bindings/pwmio/PWMOut.c
 msgid "Cannot vary frequency on a timer that is already in use"
 msgstr ""
 
-#: shared-module/bitbangio/SPI.c
-msgid "Cannot write without MOSI pin."
+#: ports/nrf/common-hal/alarm/pin/PinAlarm.c
+msgid "Cannot wake on pin edge, only level"
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/pin/PinAlarm.c
+msgid "Cannot wake on pin edge. Only level."
 msgstr ""
 
 #: shared-bindings/_bleio/CharacteristicBuffer.c
@@ -538,16 +818,6 @@ msgstr ""
 msgid "CircuitPython core code crashed hard. Whoops!\n"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"CircuitPython is in safe mode because you pressed the reset button during "
-"boot. Press again to exit safe mode.\n"
-msgstr ""
-
-#: shared-module/bitbangio/SPI.c
-msgid "Clock pin init failed."
-msgstr ""
-
 #: shared-module/bitbangio/I2C.c
 msgid "Clock stretch too long"
 msgstr ""
@@ -556,58 +826,29 @@ msgstr ""
 msgid "Clock unit in use"
 msgstr ""
 
-#: shared-bindings/_pew/PewPew.c
-msgid "Column entry must be digitalio.DigitalInOut"
-msgstr ""
-
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/I2CDisplay.c
-#: shared-bindings/displayio/ParallelBus.c
-msgid "Command must be an int between 0 and 255"
-msgstr ""
-
 #: shared-bindings/_bleio/Connection.c
 msgid ""
 "Connection has been disconnected and can no longer be used. Create a new "
 "connection."
 msgstr ""
 
-#: py/persistentcode.c
-msgid "Corrupt .mpy file"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "Coordinate arrays have different lengths"
 msgstr ""
 
-#: py/emitglue.c
-msgid "Corrupt raw code"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "Coordinate arrays types have different sizes"
 msgstr ""
 
-#: ports/cxd56/common-hal/gnss/GNSS.c
-msgid "Could not initialize GNSS"
+#: ports/espressif/common-hal/neopixel_write/__init__.c
+msgid "Could not retrieve clock"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
-msgid "Could not initialize UART"
+#: shared-bindings/_bleio/Adapter.c
+msgid "Could not set address"
 msgstr ""
 
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Could not initialize channel"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Could not initialize timer"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Could not re-init channel"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Could not re-init timer"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Could not restart PWM"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
+#: shared-bindings/pwmio/PWMOut.c
 msgid "Could not start PWM"
 msgstr ""
 
@@ -617,24 +858,6 @@ msgstr ""
 
 #: shared-module/audiomp3/MP3Decoder.c
 msgid "Couldn't allocate decoder"
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c shared-module/audiomixer/Mixer.c
-#: shared-module/audiomp3/MP3Decoder.c
-msgid "Couldn't allocate first buffer"
-msgstr ""
-
-#: shared-module/audiomp3/MP3Decoder.c
-msgid "Couldn't allocate input buffer"
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c shared-module/audiomixer/Mixer.c
-#: shared-module/audiomp3/MP3Decoder.c
-msgid "Couldn't allocate second buffer"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "Crash into the HardFault_Handler."
 msgstr ""
 
 #: ports/stm/common-hal/analogio/AnalogOut.c
@@ -649,8 +872,8 @@ msgstr ""
 msgid "DAC already in use"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/displayio/ParallelBus.c
-#: ports/nrf/common-hal/displayio/ParallelBus.c
+#: ports/atmel-samd/common-hal/paralleldisplaybus/ParallelBus.c
+#: ports/nrf/common-hal/paralleldisplaybus/ParallelBus.c
 msgid "Data 0 pin must be byte aligned"
 msgstr ""
 
@@ -658,8 +881,18 @@ msgstr ""
 msgid "Data chunk must follow fmt chunk"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Adapter.c
+#: ports/nrf/common-hal/_bleio/Adapter.c
+msgid "Data not supported with directed advertising"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "Data too large for advertisement packet"
+msgstr ""
+
+#: ports/stm/common-hal/alarm/pin/PinAlarm.c
+msgid "Deep sleep pins must use a rising edge with pulldown"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -670,27 +903,36 @@ msgstr ""
 msgid "Device in use"
 msgstr ""
 
-#: ports/cxd56/common-hal/digitalio/DigitalInOut.c
-msgid "DigitalInOut not supported on given pin"
-msgstr ""
-
-#: shared-bindings/displayio/Display.c
+#: shared-bindings/busdisplay/BusDisplay.c
 #: shared-bindings/framebufferio/FramebufferDisplay.c
 msgid "Display must have a 16 bit colorspace."
 msgstr ""
 
-#: shared-bindings/displayio/Display.c
-#: shared-bindings/displayio/EPaperDisplay.c
+#: shared-bindings/busdisplay/BusDisplay.c
+#: shared-bindings/epaperdisplay/EPaperDisplay.c
 #: shared-bindings/framebufferio/FramebufferDisplay.c
 msgid "Display rotation must be in 90 degree increments"
+msgstr ""
+
+#: main.c
+msgid "Done"
 msgstr ""
 
 #: shared-bindings/digitalio/DigitalInOut.c
 msgid "Drive mode not used when direction is input."
 msgstr ""
 
+#: py/obj.c
+msgid "During handling of the above exception, another exception occurred:"
+msgstr ""
+
 #: shared-bindings/aesio/aes.c
 msgid "ECB only operates on 16 bytes at a time"
+msgstr ""
+
+#: ports/espressif/common-hal/busio/SPI.c
+#: ports/espressif/common-hal/canio/CAN.c
+msgid "ESP-IDF memory allocation failed"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
@@ -700,45 +942,37 @@ msgstr ""
 msgid "EXTINT channel already in use"
 msgstr "Avast! EXTINT channel already in use"
 
-#: extmod/modure.c
+#: extmod/modre.c
 msgid "Error in regex"
 msgstr ""
 
-#: shared-bindings/aesio/aes.c shared-bindings/microcontroller/Pin.c
-#: shared-bindings/neopixel_write/__init__.c shared-bindings/pulseio/PulseOut.c
-#: shared-bindings/terminalio/Terminal.c
-msgid "Expected a %q"
+#: supervisor/shared/safe_mode.c
+msgid "Error in safemode.py."
 msgstr ""
 
-#: shared-bindings/_bleio/CharacteristicBuffer.c
-#: shared-bindings/_bleio/Descriptor.c shared-bindings/_bleio/PacketBuffer.c
-msgid "Expected a Characteristic"
+#: shared-bindings/socketpool/Socket.c shared-bindings/ssl/SSLSocket.c
+msgid "Error: Failure to bind"
 msgstr ""
 
-#: shared-bindings/_bleio/Characteristic.c
-msgid "Expected a Service"
+#: shared-bindings/alarm/__init__.c
+msgid "Expected a kind of %q"
 msgstr ""
 
-#: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
-#: shared-bindings/_bleio/Service.c
-msgid "Expected a UUID"
-msgstr ""
-
-#: shared-bindings/_bleio/Adapter.c
-msgid "Expected an Address"
-msgstr ""
-
-#: shared-module/_pixelbuf/PixelBuf.c
-#, c-format
-msgid "Expected tuple of length %d, got %d"
-msgstr ""
-
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "Extended advertisements with scan response not supported."
 msgstr ""
 
-#: extmod/ulab/code/fft.c
+#: extmod/ulab/code/numpy/fft/fft_tools.c
 msgid "FFT is defined for ndarrays only"
+msgstr ""
+
+#: extmod/ulab/code/numpy/fft/fft_tools.c
+msgid "FFT is implemented for linear arrays only"
+msgstr ""
+
+#: ports/espressif/common-hal/ssl/SSLSocket.c
+msgid "Failed SSL handshake"
 msgstr ""
 
 #: shared-bindings/ps2io/Ps2.c
@@ -750,19 +984,32 @@ msgstr ""
 msgid "Failed to acquire mutex, err 0x%04x"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
-msgid "Failed to allocate RX buffer"
+#: ports/raspberrypi/common-hal/mdns/Server.c
+msgid "Failed to add service TXT record"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/cxd56/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c
-#: ports/stm/common-hal/pulseio/PulseIn.c
-#, c-format
-msgid "Failed to allocate RX buffer of %d bytes"
+#: shared-bindings/mdns/Server.c
+msgid ""
+"Failed to add service TXT record; non-string or bytes found in txt_records"
 msgstr ""
 
+#: shared-module/rgbmatrix/RGBMatrix.c
+msgid "Failed to allocate %q buffer"
+msgstr ""
+
+#: ports/espressif/common-hal/wifi/__init__.c
+msgid "Failed to allocate Wifi memory"
+msgstr ""
+
+#: ports/espressif/common-hal/wifi/ScannedNetworks.c
+msgid "Failed to allocate wifi scan memory"
+msgstr ""
+
+#: ports/stm/common-hal/audiopwmio/PWMAudioOut.c
+msgid "Failed to buffer the sample"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
 msgid "Failed to connect: internal error"
 msgstr ""
@@ -784,15 +1031,50 @@ msgstr ""
 msgid "Failed to write internal flash."
 msgstr ""
 
-#: py/moduerrno.c
+#: py/moderrno.c
 msgid "File exists"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
-msgid "Frequency captured is above capability. Capture Paused."
+#: shared-module/os/getenv.c
+msgid "File not found"
 msgstr ""
 
-#: ports/stm/common-hal/pulseio/PWMOut.c
+#: ports/atmel-samd/common-hal/canio/Listener.c
+#: ports/espressif/common-hal/canio/Listener.c
+#: ports/stm/common-hal/canio/Listener.c
+msgid "Filters too complex"
+msgstr ""
+
+#: ports/espressif/common-hal/dualbank/__init__.c
+msgid "Firmware is duplicate"
+msgstr ""
+
+#: ports/espressif/common-hal/dualbank/__init__.c
+msgid "Firmware is invalid"
+msgstr ""
+
+#: ports/espressif/common-hal/dualbank/__init__.c
+msgid "Firmware is too big"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "For L8 colorspace, input bitmap must have 8 bits per pixel"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "For RGB colorspaces, input bitmap must have 16 bits per pixel"
+msgstr ""
+
+#: ports/cxd56/common-hal/camera/Camera.c
+msgid "Format not supported"
+msgstr ""
+
+#: ports/mimxrt10xx/common-hal/microcontroller/Processor.c
+msgid ""
+"Frequency must be 24, 150, 396, 450, 528, 600, 720, 816, 912, 960 or 1008 Mhz"
+msgstr ""
+
+#: shared-bindings/pwmio/PWMOut.c
 msgid "Frequency must match existing PWMOut using this timer"
 msgstr ""
 
@@ -801,23 +1083,45 @@ msgstr ""
 msgid "Function requires lock"
 msgstr ""
 
-#: shared-bindings/displayio/Display.c
-#: shared-bindings/displayio/EPaperDisplay.c
+#: ports/cxd56/common-hal/gnss/GNSS.c
+msgid "GNSS init"
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Generic Failure"
+msgstr ""
+
 #: shared-bindings/framebufferio/FramebufferDisplay.c
+#: shared-module/busdisplay/BusDisplay.c
+#: shared-module/framebufferio/FramebufferDisplay.c
 msgid "Group already used"
 msgstr ""
 
-#: shared-module/displayio/Group.c
-msgid "Group full"
+#: ports/atmel-samd/common-hal/busio/SPI.c ports/cxd56/common-hal/busio/SPI.c
+#: ports/espressif/common-hal/busio/SPI.c
+#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/nrf/common-hal/busio/SPI.c
+#: ports/raspberrypi/common-hal/busio/SPI.c
+msgid "Half duplex SPI is not implemented"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/I2C.c
-#: ports/stm/common-hal/busio/SPI.c
-msgid "Hardware busy, try alternative pins"
+#: supervisor/shared/safe_mode.c
+msgid "Hard fault: memory access or instruction error."
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
+#: ports/mimxrt10xx/common-hal/busio/SPI.c
+#: ports/mimxrt10xx/common-hal/busio/UART.c ports/stm/common-hal/busio/I2C.c
+#: ports/stm/common-hal/busio/SPI.c ports/stm/common-hal/busio/UART.c
+#: ports/stm/common-hal/canio/CAN.c ports/stm/common-hal/sdioio/SDCard.c
 msgid "Hardware in use, try alternative pins"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Heap allocation when VM not running."
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid ""
+"Heap was corrupted because the stack was too small. Increase stack size."
 msgstr ""
 
 #: extmod/vfs_posix_file.c py/objstringio.c
@@ -825,25 +1129,44 @@ msgid "I/O operation on closed file"
 msgstr ""
 
 #: ports/stm/common-hal/busio/I2C.c
-msgid "I2C Init Error"
+msgid "I2C init error"
 msgstr ""
 
-#: shared-bindings/aesio/aes.c
-#, c-format
-msgid "IV must be %d bytes long"
+#: ports/raspberrypi/common-hal/busio/I2C.c
+#: ports/raspberrypi/common-hal/i2ctarget/I2CTarget.c
+msgid "I2C peripheral in use"
 msgstr ""
 
-#: py/persistentcode.c
-msgid ""
-"Incompatible .mpy file. Please update all .mpy files. See http://adafru.it/"
-"mpy-update for more info."
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+msgid "In-buffer elements must be <= 4 bytes long"
 msgstr ""
 
 #: shared-bindings/_pew/PewPew.c
 msgid "Incorrect buffer size"
 msgstr ""
 
-#: py/moduerrno.c
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+msgid "Init program size invalid"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Initial set pin direction conflicts with initial out pin direction"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Initial set pin state conflicts with initial out pin state"
+msgstr ""
+
+#: shared-bindings/bitops/__init__.c
+#, c-format
+msgid "Input buffer length (%d) must be a multiple of the strand count (%d)"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+msgid "Input taking too long"
+msgstr ""
+
+#: ports/espressif/common-hal/neopixel_write/__init__.c py/moderrno.c
 msgid "Input/output error"
 msgstr ""
 
@@ -855,8 +1178,21 @@ msgstr ""
 msgid "Insufficient encryption"
 msgstr ""
 
+#: ports/espressif/common-hal/wifi/Radio.c
+msgid "Interface must be started"
+msgstr ""
+
+#: ports/atmel-samd/audio_dma.c ports/raspberrypi/audio_dma.c
+msgid "Internal audio buffer too small"
+msgstr ""
+
 #: ports/stm/common-hal/busio/UART.c
 msgid "Internal define error"
+msgstr ""
+
+#: ports/espressif/common-hal/paralleldisplaybus/ParallelBus.c
+#: shared-module/os/getenv.c
+msgid "Internal error"
 msgstr ""
 
 #: shared-module/rgbmatrix/RGBMatrix.c
@@ -864,8 +1200,27 @@ msgstr ""
 msgid "Internal error #%d"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+#: supervisor/shared/safe_mode.c
+msgid "Internal watchdog timer expired."
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "Interrupt error."
+msgstr ""
+
+#: ports/mimxrt10xx/common-hal/audiobusio/__init__.c
+#: ports/mimxrt10xx/common-hal/pwmio/PWMOut.c
+#: ports/raspberrypi/bindings/picodvi/Framebuffer.c
+#: ports/raspberrypi/common-hal/picodvi/Framebuffer.c py/argcheck.c
+#: shared-bindings/digitalio/DigitalInOut.c
+#: shared-bindings/epaperdisplay/EPaperDisplay.c
+msgid "Invalid %q"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/microcontroller/Pin.c
+#: ports/espressif/common-hal/dotclockframebuffer/DotClockFramebuffer.c
+#: ports/mimxrt10xx/common-hal/microcontroller/Pin.c
+#: shared-bindings/microcontroller/Pin.c
 msgid "Invalid %q pin"
 msgstr "Avast! %q pin be invalid"
 
@@ -873,33 +1228,20 @@ msgstr "Avast! %q pin be invalid"
 msgid "Invalid ADC Unit value"
 msgstr ""
 
-#: shared-module/displayio/OnDiskBitmap.c
-msgid "Invalid BMP file"
+#: ports/espressif/common-hal/_bleio/__init__.c
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Invalid BLE parameter"
 msgstr ""
 
-#: ports/stm/common-hal/analogio/AnalogOut.c
-msgid "Invalid DAC pin supplied"
+#: shared-bindings/wifi/Radio.c
+msgid "Invalid BSSID"
 msgstr ""
 
-#: ports/stm/common-hal/busio/I2C.c
-msgid "Invalid I2C pin selection"
+#: shared-bindings/wifi/Radio.c
+msgid "Invalid MAC address"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PWMOut.c
-#: ports/cxd56/common-hal/pulseio/PWMOut.c
-#: ports/nrf/common-hal/pulseio/PWMOut.c shared-bindings/pulseio/PWMOut.c
-msgid "Invalid PWM frequency"
-msgstr ""
-
-#: ports/stm/common-hal/busio/SPI.c
-msgid "Invalid SPI pin selection"
-msgstr ""
-
-#: ports/stm/common-hal/busio/UART.c
-msgid "Invalid UART pin selection"
-msgstr ""
-
-#: py/moduerrno.c shared-module/rgbmatrix/RGBMatrix.c
+#: ports/espressif/common-hal/espidf/__init__.c py/moderrno.c
 msgid "Invalid argument"
 msgstr ""
 
@@ -907,115 +1249,59 @@ msgstr ""
 msgid "Invalid bits per value"
 msgstr ""
 
-#: ports/nrf/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
-msgid "Invalid buffer size"
+#: shared-module/os/getenv.c
+#, c-format
+msgid "Invalid byte %.*s"
 msgstr ""
 
-#: shared-bindings/_pixelbuf/PixelBuf.c
-msgid "Invalid byteorder string"
+#: ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
+#, c-format
+msgid "Invalid data_pins[%d]"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
-msgid "Invalid capture period. Valid range: 1 - 500"
-msgstr ""
-
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Invalid channel count"
-msgstr ""
-
-#: shared-bindings/digitalio/DigitalInOut.c
-msgid "Invalid direction."
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c
-msgid "Invalid file"
+#: shared-module/msgpack/__init__.c
+msgid "Invalid format"
 msgstr ""
 
 #: shared-module/audiocore/WaveFile.c
 msgid "Invalid format chunk size"
 msgstr ""
 
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Invalid frequency supplied"
+#: shared-bindings/wifi/Radio.c
+msgid "Invalid hex password"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid "Invalid memory access."
+#: ports/espressif/common-hal/wifi/Radio.c
+msgid "Invalid multicast MAC address"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
-msgid "Invalid number of bits"
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Invalid size"
 msgstr ""
 
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
-#: shared-bindings/displayio/FourWire.c
-msgid "Invalid phase"
+#: ports/espressif/common-hal/ssl/SSLContext.c
+#: ports/raspberrypi/common-hal/ssl/SSLSocket.c
+msgid "Invalid socket for TLS"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-#: ports/atmel-samd/common-hal/touchio/TouchIn.c
-#: shared-bindings/pulseio/PWMOut.c shared-module/rgbmatrix/RGBMatrix.c
-msgid "Invalid pin"
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Invalid state"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-msgid "Invalid pin for left channel"
-msgstr "Belay that! Invalid pin for port-side channel"
-
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-msgid "Invalid pin for right channel"
-msgstr "Belay that! Invalid pin for starboard-side channel"
-
-#: ports/atmel-samd/common-hal/busio/I2C.c
-#: ports/atmel-samd/common-hal/busio/SPI.c
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/atmel-samd/common-hal/i2cperipheral/I2CPeripheral.c
-#: ports/cxd56/common-hal/busio/I2C.c ports/cxd56/common-hal/busio/SPI.c
-#: ports/cxd56/common-hal/busio/UART.c ports/mimxrt10xx/common-hal/busio/I2C.c
-#: ports/mimxrt10xx/common-hal/busio/SPI.c
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/I2C.c
-msgid "Invalid pins"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "Invalid pins for PWMOut"
-msgstr ""
-
-#: shared-bindings/bitbangio/SPI.c shared-bindings/busio/SPI.c
-#: shared-bindings/displayio/FourWire.c
-msgid "Invalid polarity"
-msgstr ""
-
-#: shared-bindings/_bleio/Characteristic.c
-msgid "Invalid properties"
-msgstr ""
-
-#: shared-bindings/microcontroller/__init__.c
-msgid "Invalid run mode."
-msgstr ""
-
-#: shared-module/_bleio/Attribute.c
-msgid "Invalid security_mode"
-msgstr ""
-
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Invalid voice"
-msgstr ""
-
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Invalid voice count"
-msgstr ""
-
-#: shared-module/audiocore/WaveFile.c
-msgid "Invalid wave file"
-msgstr ""
-
-#: ports/stm/common-hal/busio/UART.c
-msgid "Invalid word/bit length"
+#: shared-module/os/getenv.c
+msgid "Invalid unicode escape"
 msgstr ""
 
 #: shared-bindings/aesio/aes.c
 msgid "Key must be 16, 24, or 32 bytes long"
+msgstr ""
+
+#: shared-module/os/getenv.c
+msgid "Key not found"
+msgstr ""
+
+#: shared-module/is31fl3741/FrameBuffer.c
+msgid "LED mappings must match display size"
 msgstr ""
 
 #: py/compile.c
@@ -1023,55 +1309,71 @@ msgid "LHS of keyword arg must be an id"
 msgstr ""
 
 #: shared-module/displayio/Group.c
-msgid "Layer already in a group."
+msgid "Layer already in a group"
 msgstr ""
 
 #: shared-module/displayio/Group.c
-msgid "Layer must be a Group or TileGrid subclass."
+msgid "Layer must be a Group or TileGrid subclass"
 msgstr ""
 
-#: py/objslice.c
-msgid "Length must be an int"
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "MAC address was invalid"
 msgstr ""
 
-#: py/objslice.c
-msgid "Length must be non-negative"
-msgstr ""
-
-#: shared-module/bitbangio/SPI.c
-msgid "MISO pin init failed."
-msgstr ""
-
-#: shared-module/bitbangio/SPI.c
-msgid "MOSI pin init failed."
-msgstr ""
-
-#: shared-module/displayio/Shape.c
-#, c-format
-msgid "Maximum x value when mirrored is %d"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "MicroPython NLR jump failed. Likely memory corruption."
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "MicroPython fatal error."
+#: shared-bindings/is31fl3741/IS31FL3741.c
+msgid "Mapping must be a tuple"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
-msgid "Missing MISO or MOSI Pin"
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Mismatched data size"
 msgstr ""
 
-#: shared-bindings/displayio/Group.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Mismatched swap flag"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_in_pin. %q[%u] reads pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_in_pin. %q[%u] shifts in from pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_in_pin. %q[%u] waits based on pin"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_out_pin. %q[%u] shifts out to pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_out_pin. %q[%u] writes pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing first_set_pin. %q[%u] sets pin(s)"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Missing jmp_pin. %q[%u] jumps on pin"
+msgstr ""
+
+#: shared-bindings/busio/UART.c shared-bindings/displayio/Group.c
 msgid "Must be a %q subclass."
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
+#: ports/espressif/common-hal/dotclockframebuffer/DotClockFramebuffer.c
+msgid "Must provide 5/6/5 RGB pins"
+msgstr ""
+
+#: ports/mimxrt10xx/common-hal/busio/SPI.c shared-bindings/busio/SPI.c
 msgid "Must provide MISO or MOSI pin"
 msgstr ""
 
@@ -1080,10 +1382,44 @@ msgstr ""
 msgid "Must use a multiple of 6 rgb pins, not %d"
 msgstr ""
 
-#: py/parse.c
+#: supervisor/shared/safe_mode.c
+msgid "NLR jump failed. Likely memory corruption."
+msgstr ""
+
+#: ports/espressif/common-hal/nvm/ByteArray.c
+msgid "NVS Error"
+msgstr ""
+
+#: shared-bindings/socketpool/SocketPool.c
+msgid "Name or service not known"
+msgstr ""
+
+#: py/qstr.c
 msgid "Name too long"
 msgstr ""
 
+#: shared-bindings/displayio/TileGrid.c
+msgid "New bitmap must be same size as old bitmap"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/__init__.c
+msgid "Nimble out of memory"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/busio/UART.c
+#: ports/espressif/common-hal/busio/SPI.c
+#: ports/espressif/common-hal/busio/UART.c
+#: ports/mimxrt10xx/common-hal/busio/SPI.c
+#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
+#: ports/raspberrypi/common-hal/busio/UART.c ports/stm/common-hal/busio/SPI.c
+#: ports/stm/common-hal/busio/UART.c shared-bindings/fourwire/FourWire.c
+#: shared-bindings/i2cdisplaybus/I2CDisplayBus.c
+#: shared-bindings/paralleldisplaybus/ParallelBus.c
+#: shared-module/bitbangio/SPI.c
+msgid "No %q pin"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 msgid "No CCCD for this Characteristic"
 msgstr ""
@@ -1095,31 +1431,34 @@ msgstr "Shiver me timbers! There be no DAC on this chip"
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
+#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
 msgid "No DMA channel found"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
-msgid "No MISO Pin"
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+msgid "No DMA pacing timer found"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/stm/common-hal/busio/SPI.c
-msgid "No MOSI Pin"
+#: shared-module/adafruit_bus_device/i2c_device/I2CDevice.c
+#, c-format
+msgid "No I2C device at address: 0x%x"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
-#: ports/stm/common-hal/busio/UART.c
-msgid "No RX pin"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/UART.c
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
-#: ports/stm/common-hal/busio/UART.c
-msgid "No TX pin"
+#: supervisor/shared/web_workflow/web_workflow.c
+msgid "No IP"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 msgid "No available clocks"
+msgstr ""
+
+#: ports/espressif/common-hal/imagecapture/ParallelImageCapture.c
+msgid "No capture in progress"
+msgstr ""
+
+#: shared-module/usb/core/Device.c
+msgid "No configuration set"
 msgstr ""
 
 #: shared-bindings/_bleio/PacketBuffer.c
@@ -1138,36 +1477,46 @@ msgstr ""
 msgid "No hardware random available"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/ps2io/Ps2.c
-msgid "No hardware support on clk pin"
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "No in in program"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-msgid "No hardware support on pin"
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "No in or out in program"
 msgstr ""
 
-#: shared-bindings/aesio/aes.c
-msgid "No key was specified"
-msgstr ""
-
-#: shared-bindings/time/__init__.c
+#: py/objint.c shared-bindings/time/__init__.c
 msgid "No long integer support"
 msgstr ""
 
-#: ports/stm/common-hal/pulseio/PWMOut.c
-msgid "No more timers available on this pin."
+#: shared-bindings/wifi/Radio.c
+msgid "No network with that ssid"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "No out in program"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/busio/I2C.c
+#: ports/espressif/common-hal/busio/I2C.c
+#: ports/mimxrt10xx/common-hal/busio/I2C.c ports/nrf/common-hal/busio/I2C.c
+#: ports/raspberrypi/common-hal/busio/I2C.c
+msgid "No pull up found on SDA or SCL; check your wiring"
 msgstr ""
 
 #: shared-module/touchio/TouchIn.c
 msgid "No pulldown on pin; 1Mohm recommended"
 msgstr ""
 
-#: py/moduerrno.c
+#: py/moderrno.c
 msgid "No space left on device"
 msgstr ""
 
-#: py/moduerrno.c
+#: py/moderrno.c
+msgid "No such device"
+msgstr ""
+
+#: py/moderrno.c
 msgid "No such file/directory"
 msgstr ""
 
@@ -1175,10 +1524,19 @@ msgstr ""
 msgid "No timer available"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid "Nordic Soft Device failure assertion."
+#: shared-module/usb/core/Device.c
+msgid "No usb host port initialized"
 msgstr ""
 
+#: ports/nrf/common-hal/_bleio/__init__.c
+msgid "Nordic system firmware out of memory"
+msgstr ""
+
+#: shared-bindings/ipaddress/IPv4Address.c shared-bindings/ipaddress/__init__.c
+msgid "Not a valid IP string"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/__init__.c
 #: ports/nrf/common-hal/_bleio/__init__.c
 #: shared-bindings/_bleio/CharacteristicBuffer.c
 msgid "Not connected"
@@ -1187,6 +1545,11 @@ msgstr ""
 #: shared-bindings/audiobusio/I2SOut.c shared-bindings/audioio/AudioOut.c
 #: shared-bindings/audiopwmio/PWMAudioOut.c
 msgid "Not playing"
+msgstr ""
+
+#: ports/espressif/common-hal/paralleldisplaybus/ParallelBus.c
+#, c-format
+msgid "Number of data_pins must be 8 or 16, not %d"
 msgstr ""
 
 #: shared-bindings/util.c
@@ -1198,14 +1561,46 @@ msgstr ""
 msgid "Odd parity is not supported"
 msgstr ""
 
+#: supervisor/shared/bluetooth/bluetooth.c
+msgid "Off"
+msgstr ""
+
+#: supervisor/shared/bluetooth/bluetooth.c
+msgid "Ok"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
+#: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
+
+#: ports/espressif/common-hal/wifi/__init__.c
+#: ports/raspberrypi/common-hal/wifi/__init__.c
+msgid "Only IPv4 addresses supported"
+msgstr ""
+
+#: ports/espressif/common-hal/socketpool/Socket.c
+#: ports/raspberrypi/common-hal/socketpool/Socket.c
+msgid "Only IPv4 sockets supported"
 msgstr ""
 
 #: shared-module/displayio/OnDiskBitmap.c
 #, c-format
 msgid ""
 "Only Windows format, uncompressed BMP supported: given header size is %d"
+msgstr ""
+
+#: shared-bindings/_bleio/Adapter.c
+msgid "Only connectable advertisements can be directed"
+msgstr ""
+
+#: ports/stm/common-hal/alarm/pin/PinAlarm.c
+msgid "Only edge detection is available on this hardware"
+msgstr ""
+
+#: shared-bindings/ipaddress/__init__.c
+msgid "Only int or string supported for ip"
 msgstr ""
 
 #: shared-module/displayio/OnDiskBitmap.c
@@ -1215,47 +1610,115 @@ msgid ""
 "%d bpp given"
 msgstr ""
 
+#: ports/espressif/common-hal/alarm/touch/TouchAlarm.c
+msgid "Only one %q can be set in deep sleep."
+msgstr ""
+
+#: ports/espressif/common-hal/espulp/ULPAlarm.c
+msgid "Only one %q can be set."
+msgstr ""
+
+#: ports/espressif/common-hal/i2ctarget/I2CTarget.c
+#: ports/raspberrypi/common-hal/i2ctarget/I2CTarget.c
+msgid "Only one address is allowed"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/alarm/time/TimeAlarm.c
+#: ports/nrf/common-hal/alarm/time/TimeAlarm.c
+#: ports/stm/common-hal/alarm/time/TimeAlarm.c
+msgid "Only one alarm.time alarm can be set"
+msgstr ""
+
+#: ports/espressif/common-hal/alarm/time/TimeAlarm.c
+#: ports/raspberrypi/common-hal/alarm/time/TimeAlarm.c
+msgid "Only one alarm.time alarm can be set."
+msgstr ""
+
+#: shared-module/displayio/ColorConverter.c
+msgid "Only one color can be transparent at a time"
+msgstr ""
+
+#: py/moderrno.c
+msgid "Operation not permitted"
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Operation or feature not supported"
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Operation timed out"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/mdns/Server.c
+msgid "Out of MDNS service slots"
+msgstr ""
+
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Out of memory"
+msgstr ""
+
+#: ports/espressif/common-hal/socketpool/Socket.c
+#: ports/raspberrypi/common-hal/socketpool/Socket.c
+msgid "Out of sockets"
+msgstr ""
+
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+msgid "Out-buffer elements must be <= 4 bytes long"
+msgstr ""
+
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Oversample must be multiple of 8."
 msgstr ""
 
-#: shared-bindings/pulseio/PWMOut.c
-msgid ""
-"PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-msgstr ""
-
-#: shared-bindings/pulseio/PWMOut.c
+#: shared-bindings/pwmio/PWMOut.c
 msgid ""
 "PWM frequency not writable when variable_frequency is False on construction."
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/displayio/ParallelBus.c
-#: ports/stm/common-hal/displayio/ParallelBus.c
-msgid "ParallelBus not yet supported"
+#: ports/stm/common-hal/pwmio/PWMOut.c
+msgid "PWM restart"
 msgstr ""
 
-#: py/moduerrno.c
+#: ports/raspberrypi/common-hal/countio/Counter.c
+msgid "PWM slice already in use"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/countio/Counter.c
+msgid "PWM slice channel A already in use"
+msgstr ""
+
+#: ports/espressif/common-hal/audiobusio/__init__.c
+msgid "Peripheral in use"
+msgstr ""
+
+#: py/moderrno.c
 msgid "Permission denied"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/analogio/AnalogIn.c
-#: ports/cxd56/common-hal/analogio/AnalogIn.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogIn.c
-#: ports/nrf/common-hal/analogio/AnalogIn.c
-#: ports/stm/common-hal/analogio/AnalogIn.c
-msgid "Pin does not have ADC capabilities"
-msgstr "Belay that! Th' Pin be not ADC capable"
+#: ports/stm/common-hal/alarm/pin/PinAlarm.c
+msgid "Pin cannot wake from Deep Sleep"
+msgstr ""
 
-#: shared-bindings/digitalio/DigitalInOut.c
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Pin count too large"
+msgstr ""
+
+#: ports/stm/common-hal/alarm/pin/PinAlarm.c
+#: ports/stm/common-hal/pulseio/PulseIn.c
+msgid "Pin interrupt already in use"
+msgstr ""
+
+#: shared-bindings/adafruit_bus_device/spi_device/SPIDevice.c
 msgid "Pin is input only"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/countio/Counter.c
+msgid "Pin must be on PWM Channel B"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/countio/Counter.c
 msgid "Pin must support hardware interrupts"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PulseIn.c
-msgid "Pin number already reserved by EXTI"
 msgstr ""
 
 #: shared-bindings/rgbmatrix/RGBMatrix.c
@@ -1266,6 +1729,22 @@ msgid ""
 "constructor"
 msgstr ""
 
+#: ports/raspberrypi/common-hal/imagecapture/ParallelImageCapture.c
+msgid "Pins must be sequential"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
+msgid "Pins must be sequential GPIO pins"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+msgid "Pins must share PWM slice"
+msgstr ""
+
+#: shared-module/usb/core/Device.c
+msgid "Pipe error"
+msgstr ""
+
 #: py/builtinhelp.c
 msgid "Plus any modules on the filesystem\n"
 msgstr ""
@@ -1274,8 +1753,8 @@ msgstr ""
 msgid "Polygon needs at least 3 points"
 msgstr ""
 
-#: shared-bindings/ps2io/Ps2.c
-msgid "Pop from an empty Ps2 buffer"
+#: supervisor/shared/safe_mode.c
+msgid "Power dipped. Make sure you are providing enough power."
 msgstr ""
 
 #: shared-bindings/_bleio/Adapter.c
@@ -1283,19 +1762,35 @@ msgid "Prefix buffer must be on the heap"
 msgstr ""
 
 #: main.c
-msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+msgid "Press any key to enter the REPL. Use CTRL-D to reload.\n"
+msgstr ""
+
+#: main.c
+msgid "Pretending to deep sleep until alarm, CTRL-C or file write.\n"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Program does IN without loading ISR"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "Program does OUT without loading OSR"
+msgstr ""
+
+#: ports/raspberrypi/bindings/rp2pio/StateMachine.c
+msgid "Program size invalid"
+msgstr ""
+
+#: ports/espressif/common-hal/espulp/ULP.c
+msgid "Program too long"
 msgstr ""
 
 #: shared-bindings/digitalio/DigitalInOut.c
 msgid "Pull not used when direction is output."
 msgstr ""
 
-#: ports/stm/common-hal/pulseio/PulseIn.c
-msgid "PulseIn not supported on this chip"
-msgstr ""
-
-#: ports/stm/common-hal/pulseio/PulseOut.c
-msgid "PulseOut not supported on this chip"
+#: ports/raspberrypi/common-hal/countio/Counter.c
+msgid "RISE_AND_FALL not available on this chip"
 msgstr ""
 
 #: ports/stm/common-hal/os/__init__.c
@@ -1306,96 +1801,108 @@ msgstr ""
 msgid "RNG Init Error"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
+#: ports/nrf/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
+msgid "RS485"
+msgstr ""
+
+#: ports/espressif/common-hal/busio/UART.c
 #: ports/mimxrt10xx/common-hal/busio/UART.c
 msgid "RS485 inversion specified when not in RS485 mode"
 msgstr ""
 
-#: ports/cxd56/common-hal/rtc/RTC.c ports/mimxrt10xx/common-hal/rtc/RTC.c
-#: ports/nrf/common-hal/rtc/RTC.c
-msgid "RTC calibration is not supported on this board"
-msgstr ""
-
-#: shared-bindings/time/__init__.c
+#: shared-bindings/alarm/time/TimeAlarm.c shared-bindings/time/__init__.c
 msgid "RTC is not supported on this board"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/UART.c ports/cxd56/common-hal/busio/UART.c
-#: ports/nrf/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
-msgid "RTS/CTS/RS485 Not yet supported on this device"
 msgstr ""
 
 #: ports/stm/common-hal/os/__init__.c
 msgid "Random number generation error"
 msgstr ""
 
-#: shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/_bleio/__init__.c
+#: shared-bindings/memorymonitor/AllocationSize.c
+#: shared-bindings/pulseio/PulseIn.c shared-module/bitmaptools/__init__.c
+#: shared-module/displayio/Bitmap.c
 msgid "Read-only"
 msgstr ""
 
-#: extmod/vfs_fat.c py/moduerrno.c
+#: extmod/vfs_fat.c py/moderrno.c
 msgid "Read-only filesystem"
 msgstr ""
 
-#: shared-module/displayio/Bitmap.c
-msgid "Read-only object"
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Received response was invalid"
 msgstr ""
 
-#: shared-bindings/displayio/EPaperDisplay.c
+#: supervisor/shared/bluetooth/bluetooth.c
+msgid "Reconnecting"
+msgstr ""
+
+#: shared-bindings/epaperdisplay/EPaperDisplay.c
 msgid "Refresh too soon"
+msgstr ""
+
+#: shared-bindings/canio/RemoteTransmissionRequest.c
+msgid "RemoteTransmissionRequests limited to 8 bytes"
 msgstr ""
 
 #: shared-bindings/aesio/aes.c
 msgid "Requested AES mode is unsupported"
 msgstr ""
 
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Requested resource not found"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "Right channel unsupported"
 msgstr ""
-
-#: shared-bindings/_pew/PewPew.c
-msgid "Row entry must be digitalio.DigitalInOut"
-msgstr ""
-
-#: main.c
-msgid "Running in safe mode! Auto-reload is off.\n"
-msgstr "Runnin' in safe mode! Auto-reload be off.\n"
 
 #: main.c
 msgid "Running in safe mode! Not running saved code.\n"
 msgstr "Runnin' in safe mode! Nay runnin' saved code.\n"
 
-#: ports/atmel-samd/common-hal/busio/I2C.c
-#: ports/mimxrt10xx/common-hal/busio/I2C.c ports/nrf/common-hal/busio/I2C.c
-msgid "SDA or SCL needs a pull up"
+#: shared-module/sdcardio/SDCard.c
+msgid "SD card CSD format not supported"
 msgstr ""
 
-#: ports/stm/common-hal/busio/SPI.c
-msgid "SPI Init Error"
+#: ports/cxd56/common-hal/sdioio/SDCard.c
+msgid "SDCard init"
 msgstr ""
 
-#: ports/stm/common-hal/busio/SPI.c
-msgid "SPI Re-initialization error"
-msgstr ""
-
-#: shared-bindings/audiomixer/Mixer.c
-msgid "Sample rate must be positive"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
+#: ports/stm/common-hal/sdioio/SDCard.c
 #, c-format
-msgid "Sample rate too high. It must be less than %d"
+msgid "SDIO GetCardInfo Error %d"
 msgstr ""
 
+#: ports/stm/common-hal/sdioio/SDCard.c
+#, c-format
+msgid "SDIO Init Error %d"
+msgstr ""
+
+#: ports/espressif/common-hal/busio/SPI.c
+msgid "SPI configuration failed"
+msgstr ""
+
+#: ports/stm/common-hal/busio/SPI.c
+msgid "SPI init error"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/busio/SPI.c
+msgid "SPI peripheral in use"
+msgstr ""
+
+#: ports/stm/common-hal/busio/SPI.c
+msgid "SPI re-init"
+msgstr ""
+
+#: shared-bindings/is31fl3741/FrameBuffer.c
+msgid "Scale dimensions must divide by 3"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
-msgid "Scan already in progess. Stop with stop_scan."
-msgstr ""
-
-#: ports/mimxrt10xx/common-hal/busio/UART.c
-msgid "Selected CTS pin not valid"
-msgstr ""
-
-#: ports/mimxrt10xx/common-hal/busio/UART.c
-msgid "Selected RTS pin not valid"
+msgid "Scan already in progress. Stop with stop_scan."
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -1403,33 +1910,49 @@ msgstr ""
 msgid "Serializer in use"
 msgstr ""
 
+#: shared-bindings/ssl/SSLContext.c
+msgid "Server side context cannot have hostname"
+msgstr ""
+
+#: ports/cxd56/common-hal/camera/Camera.c
+msgid "Size not supported"
+msgstr ""
+
+#: shared-bindings/alarm/SleepMemory.c shared-bindings/memorymap/AddressRange.c
 #: shared-bindings/nvm/ByteArray.c
 msgid "Slice and value different lengths."
 msgstr ""
 
 #: shared-bindings/displayio/Bitmap.c shared-bindings/displayio/Group.c
-#: shared-bindings/displayio/TileGrid.c shared-bindings/pulseio/PulseIn.c
+#: shared-bindings/displayio/TileGrid.c
+#: shared-bindings/memorymonitor/AllocationSize.c
+#: shared-bindings/pulseio/PulseIn.c
 msgid "Slices not supported"
+msgstr ""
+
+#: ports/espressif/common-hal/socketpool/SocketPool.c
+#: ports/raspberrypi/common-hal/socketpool/SocketPool.c
+msgid "SocketPool can only be used with wifi.radio"
 msgstr ""
 
 #: shared-bindings/aesio/aes.c
 msgid "Source and destination buffers must be the same length"
 msgstr ""
 
-#: extmod/modure.c
-msgid "Splitting with sub-captures"
+#: shared-bindings/paralleldisplaybus/ParallelBus.c
+msgid "Specify exactly one of data0 or data_pins"
 msgstr ""
 
-#: shared-bindings/supervisor/__init__.c
-msgid "Stack size must be at least 256"
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+msgid "Stereo left must be on PWM channel A"
 msgstr ""
 
-#: shared-bindings/multiterminal/__init__.c
-msgid "Stream missing readinto() or write() method."
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+msgid "Stereo right must be on PWM channel B"
 msgstr ""
 
-#: ports/mimxrt10xx/common-hal/busio/UART.c ports/stm/common-hal/busio/UART.c
-msgid "Supply at least one UART pin"
+#: shared-bindings/alarm/time/TimeAlarm.c
+msgid "Supply one of monotonic_time or epoch_time"
 msgstr ""
 
 #: shared-bindings/gnss/GNSS.c
@@ -1441,22 +1964,15 @@ msgid "Temperature read timed out"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid ""
-"The CircuitPython heap was corrupted because the stack was too small.\n"
-"Please increase the stack size if you know how, or if not:"
+msgid "The `microcontroller` module was used to boot into safe mode."
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The `microcontroller` module was used to boot into safe mode. Press reset to "
-"exit safe mode.\n"
+#: py/obj.c
+msgid "The above exception was the direct cause of the following exception:"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid ""
-"The microcontroller's power dipped. Make sure your power supply provides\n"
-"enough power for the whole circuit and press reset (after ejecting "
-"CIRCUITPY).\n"
+#: shared-bindings/rgbmatrix/RGBMatrix.c
+msgid "The length of rgb_pins must be 6, 12, 18, 24, or 30"
 msgstr ""
 
 #: shared-module/audiomixer/MixerVoice.c
@@ -1475,6 +1991,20 @@ msgstr ""
 msgid "The sample's signedness does not match the mixer's"
 msgstr ""
 
+#: supervisor/shared/safe_mode.c
+msgid "Third-party firmware fatal error."
+msgstr ""
+
+#: shared-module/imagecapture/ParallelImageCapture.c
+msgid "This microcontroller does not support continuous capture."
+msgstr ""
+
+#: shared-module/paralleldisplaybus/ParallelBus.c
+msgid ""
+"This microcontroller only supports data0=, not data_pins=, because it "
+"requires contiguous pins."
+msgstr ""
+
 #: shared-bindings/displayio/TileGrid.c
 msgid "Tile height must exactly divide bitmap height"
 msgstr ""
@@ -1484,32 +2014,44 @@ msgid "Tile index out of bounds"
 msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c
-msgid "Tile value out of bounds"
-msgstr ""
-
-#: shared-bindings/displayio/TileGrid.c
 msgid "Tile width must exactly divide bitmap width"
 msgstr ""
 
+#: shared-bindings/alarm/time/TimeAlarm.c
+msgid "Time is in the past."
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/nrf/common-hal/_bleio/Adapter.c
 #, c-format
 msgid "Timeout is too long: Maximum timeout length is %d seconds"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
+msgid "Too many channels in sample"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
 msgid "Too many channels in sample."
 msgstr ""
 
 #: shared-module/displayio/__init__.c
-msgid "Too many display busses"
+msgid "Too many display busses; forgot displayio.release_displays() ?"
 msgstr ""
 
 #: shared-module/displayio/__init__.c
 msgid "Too many displays"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/PacketBuffer.c
 #: ports/nrf/common-hal/_bleio/PacketBuffer.c
-msgid "Total data to write is larger than outgoing_packet_length"
+msgid "Total data to write is larger than %q"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/alarm/touch/TouchAlarm.c
+#: ports/raspberrypi/common-hal/alarm/touch/TouchAlarm.c
+#: ports/stm/common-hal/alarm/touch/TouchAlarm.c
+msgid "Touch alarms not available"
 msgstr ""
 
 #: py/obj.c
@@ -1521,31 +2063,44 @@ msgid "Tuple or struct_time argument required"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART Buffer allocation error"
+msgid "UART de-init"
+msgstr ""
+
+#: ports/cxd56/common-hal/busio/UART.c ports/espressif/common-hal/busio/UART.c
+#: ports/stm/common-hal/busio/UART.c
+msgid "UART init"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/busio/UART.c
+msgid "UART peripheral in use"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART De-init error"
+msgid "UART re-init"
 msgstr ""
 
 #: ports/stm/common-hal/busio/UART.c
-msgid "UART Init Error"
+msgid "UART write"
 msgstr ""
 
-#: ports/stm/common-hal/busio/UART.c
-msgid "UART Re-init error"
-msgstr ""
-
-#: ports/stm/common-hal/busio/UART.c
-msgid "UART write error"
+#: main.c
+msgid "UID:"
 msgstr ""
 
 #: shared-module/usb_hid/Device.c
-msgid "USB Busy"
+msgid "USB busy"
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "USB devices need more endpoints than are available."
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "USB devices specify too many interface names."
 msgstr ""
 
 #: shared-module/usb_hid/Device.c
-msgid "USB Error"
+msgid "USB error"
 msgstr ""
 
 #: shared-bindings/_bleio/UUID.c
@@ -1560,12 +2115,27 @@ msgstr ""
 msgid "UUID value is not str, int or byte buffer"
 msgstr ""
 
+#: ports/raspberrypi/common-hal/memorymap/AddressRange.c
+msgid "Unable to access unaligned IO register"
+msgstr ""
+
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
+#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
 msgid "Unable to allocate buffers for signed conversion"
 msgstr ""
 
-#: shared-module/displayio/I2CDisplay.c
+#: supervisor/shared/safe_mode.c
+msgid "Unable to allocate to the heap."
+msgstr ""
+
+#: ports/espressif/common-hal/busio/I2C.c
+msgid "Unable to create lock"
+msgstr ""
+
+#: shared-module/i2cdisplaybus/I2CDisplayBus.c
+#: shared-module/is31fl3741/IS31FL3741.c
 #, c-format
 msgid "Unable to find I2C Display at %x"
 msgstr ""
@@ -1583,12 +2153,50 @@ msgstr ""
 msgid "Unable to read color palette data"
 msgstr ""
 
+#: ports/espressif/common-hal/mdns/Server.c
+#: ports/raspberrypi/common-hal/mdns/Server.c
+msgid "Unable to start mDNS query"
+msgstr ""
+
 #: shared-bindings/nvm/ByteArray.c
 msgid "Unable to write to nvm."
 msgstr ""
 
+#: ports/raspberrypi/common-hal/memorymap/AddressRange.c
+msgid "Unable to write to read-only memory"
+msgstr ""
+
+#: shared-bindings/alarm/SleepMemory.c
+msgid "Unable to write to sleep_memory."
+msgstr ""
+
 #: ports/nrf/common-hal/_bleio/UUID.c
 msgid "Unexpected nrfx uuid type"
+msgstr ""
+
+#: ports/espressif/common-hal/ssl/SSLSocket.c
+#, c-format
+msgid "Unhandled ESP TLS error %d %d %x %d"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/__init__.c
+#, c-format
+msgid "Unknown BLE error at %s:%d: %d"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/__init__.c
+#, c-format
+msgid "Unknown BLE error: %d"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/wifi/__init__.c
+#, c-format
+msgid "Unknown error code %d"
+msgstr ""
+
+#: shared-bindings/wifi/Radio.c
+#, c-format
+msgid "Unknown failure %d"
 msgstr ""
 
 #: ports/nrf/common-hal/_bleio/__init__.c
@@ -1596,6 +2204,7 @@ msgstr ""
 msgid "Unknown gatt error: 0x%04x"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
 #: supervisor/shared/safe_mode.c
 msgid "Unknown reason."
 msgstr ""
@@ -1605,12 +2214,23 @@ msgstr ""
 msgid "Unknown security error: 0x%04x"
 msgstr ""
 
-#: ports/nrf/common-hal/_bleio/__init__.c
+#: ports/espressif/common-hal/_bleio/__init__.c
 #, c-format
-msgid "Unknown soft device error: %04x"
+msgid "Unknown system firmware error at %s:%d: %d"
 msgstr ""
 
-#: shared-bindings/_pixelbuf/PixelBuf.c
+#: ports/nrf/common-hal/_bleio/__init__.c
+#, c-format
+msgid "Unknown system firmware error: %04x"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/__init__.c
+#, c-format
+msgid "Unknown system firmware error: %d"
+msgstr ""
+
+#: shared-bindings/adafruit_pixelbuf/PixelBuf.c
+#: shared-module/_pixelmap/PixelMap.c
 #, c-format
 msgid "Unmatched number of items on RHS (expected %d, got %d)."
 msgstr ""
@@ -1621,12 +2241,11 @@ msgid ""
 "declined or ignored."
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/I2C.c ports/cxd56/common-hal/busio/I2C.c
-#: ports/stm/common-hal/busio/I2C.c
-msgid "Unsupported baudrate"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "Unsupported colorspace"
 msgstr ""
 
-#: shared-module/displayio/display_core.c
+#: shared-module/displayio/bus_core.c
 msgid "Unsupported display bus type"
 msgstr ""
 
@@ -1634,26 +2253,30 @@ msgstr ""
 msgid "Unsupported format"
 msgstr ""
 
-#: py/moduerrno.c
-msgid "Unsupported operation"
+#: shared-bindings/hashlib/__init__.c
+msgid "Unsupported hash algorithm"
 msgstr ""
 
-#: shared-bindings/digitalio/DigitalInOut.c
-msgid "Unsupported pull value."
+#: ports/espressif/common-hal/dualbank/__init__.c
+msgid "Update Failed"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Characteristic.c
+#: ports/espressif/common-hal/_bleio/Descriptor.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Descriptor.c
 msgid "Value length != required fixed length"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Characteristic.c
+#: ports/espressif/common-hal/_bleio/Descriptor.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Descriptor.c
 msgid "Value length > max_length"
 msgstr ""
 
-#: py/emitnative.c
-msgid "Viper functions don't currently support more than 4 arguments"
+#: ports/espressif/common-hal/espidf/__init__.c
+msgid "Version was invalid"
 msgstr ""
 
 #: ports/stm/common-hal/microcontroller/Processor.c
@@ -1664,24 +2287,8 @@ msgstr ""
 msgid "WARNING: Your code filename has two extensions\n"
 msgstr "Blimey! Yer code filename has two extensions\n"
 
-#: shared-bindings/watchdog/WatchDogTimer.c
+#: ports/nrf/common-hal/watchdog/WatchDogTimer.c
 msgid "WatchDogTimer cannot be deinitialized once mode is set to RESET"
-msgstr ""
-
-#: shared-bindings/watchdog/WatchDogTimer.c
-msgid "WatchDogTimer is not currently running"
-msgstr ""
-
-#: shared-bindings/watchdog/WatchDogTimer.c
-msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-msgstr ""
-
-#: shared-bindings/watchdog/WatchDogTimer.c
-msgid "WatchDogTimer.timeout must be greater than 0"
-msgstr ""
-
-#: supervisor/shared/safe_mode.c
-msgid "Watchdog timer expired."
 msgstr ""
 
 #: py/builtinhelp.c
@@ -1689,21 +2296,83 @@ msgstr ""
 msgid ""
 "Welcome to Adafruit CircuitPython %s!\n"
 "\n"
-"Please visit learn.adafruit.com/category/circuitpython for project guides.\n"
+"Visit circuitpython.org for more information.\n"
 "\n"
-"To list built-in modules please do `help(\"modules\")`.\n"
+"To list built-in modules type `help(\"modules\")`.\n"
 msgstr ""
 
+#: supervisor/shared/web_workflow/web_workflow.c
+msgid "Wi-Fi: "
+msgstr ""
+
+#: ports/raspberrypi/common-hal/wifi/Radio.c
+msgid "Wifi is not enabled"
+msgstr ""
+
+#: main.c
+msgid "Woken up by alarm.\n"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/PacketBuffer.c
 #: ports/nrf/common-hal/_bleio/PacketBuffer.c
 msgid "Writes not supported on Characteristic"
 msgstr ""
 
-#: supervisor/shared/safe_mode.c
-msgid "You are in safe mode: something unanticipated happened.\n"
+#: ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h
+#: ports/atmel-samd/boards/circuitplayground_express_crickit/mpconfigboard.h
+#: ports/atmel-samd/boards/circuitplayground_express_displayio/mpconfigboard.h
+#: ports/atmel-samd/boards/meowmeow/mpconfigboard.h
+msgid "You pressed both buttons at start up."
+msgstr ""
+
+#: ports/espressif/boards/m5stack_core_basic/mpconfigboard.h
+#: ports/espressif/boards/m5stack_core_fire/mpconfigboard.h
+#: ports/espressif/boards/m5stack_stick_c/mpconfigboard.h
+#: ports/espressif/boards/m5stack_stick_c_plus/mpconfigboard.h
+msgid "You pressed button A at start up."
+msgstr ""
+
+#: ports/espressif/boards/m5stack_m5paper/mpconfigboard.h
+msgid "You pressed button DOWN at start up."
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
-msgid "You requested starting safe mode by "
+msgid "You pressed the BOOT button at start up"
+msgstr ""
+
+#: ports/espressif/boards/adafruit_huzzah32_breakout/mpconfigboard.h
+msgid "You pressed the GPIO0 button at start up."
+msgstr ""
+
+#: ports/espressif/boards/espressif_esp32_lyrat/mpconfigboard.h
+msgid "You pressed the Rec button at start up."
+msgstr ""
+
+#: ports/espressif/boards/adafruit_feather_esp32_v2/mpconfigboard.h
+msgid "You pressed the SW38 button at start up."
+msgstr ""
+
+#: ports/espressif/boards/hardkernel_odroid_go/mpconfigboard.h
+msgid "You pressed the VOLUME button at start up."
+msgstr ""
+
+#: ports/espressif/boards/m5stack_atom_echo/mpconfigboard.h
+#: ports/espressif/boards/m5stack_atom_lite/mpconfigboard.h
+#: ports/espressif/boards/m5stack_atom_matrix/mpconfigboard.h
+#: ports/espressif/boards/m5stack_atom_u/mpconfigboard.h
+msgid "You pressed the central button at start up."
+msgstr ""
+
+#: ports/nrf/boards/aramcon2_badge/mpconfigboard.h
+msgid "You pressed the left button at start up."
+msgstr ""
+
+#: supervisor/shared/safe_mode.c
+msgid "You pressed the reset button during boot."
+msgstr ""
+
+#: supervisor/shared/micropython.c
+msgid "[truncated due to length]"
 msgstr ""
 
 #: py/objtype.c
@@ -1719,45 +2388,48 @@ msgstr ""
 msgid "__new__ arg must be a user-type"
 msgstr ""
 
-#: extmod/modubinascii.c extmod/moduhashlib.c
+#: extmod/modbinascii.c extmod/modhashlib.c py/objarray.c
 msgid "a bytes-like object is required"
 msgstr ""
 
-#: lib/embed/abort_.c
-msgid "abort() called"
-msgstr ""
-
-#: extmod/machine_mem.c
-#, c-format
-msgid "address %08x is not aligned to %d bytes"
-msgstr ""
-
-#: shared-bindings/i2cperipheral/I2CPeripheral.c
-msgid "address out of bounds"
-msgstr ""
-
-#: shared-bindings/i2cperipheral/I2CPeripheral.c
+#: shared-bindings/i2ctarget/I2CTarget.c
 msgid "addresses is empty"
 msgstr ""
 
-#: extmod/ulab/code/vectorise.c
-msgid "arctan2 is implemented for scalars and ndarrays only"
+#: py/compile.c
+msgid "annotation must be an identifier"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
+msgid "arange: cannot compute length"
 msgstr ""
 
 #: py/modbuiltins.c
 msgid "arg is an empty sequence"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: py/objobject.c
+msgid "arg must be user-type"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
 msgid "argsort argument must be an ndarray"
 msgstr ""
 
-#: py/runtime.c
+#: extmod/ulab/code/numpy/numerical.c
+msgid "argsort is not implemented for flattened arrays"
+msgstr ""
+
+#: py/runtime.c shared-bindings/supervisor/__init__.c
 msgid "argument has wrong type"
 msgstr ""
 
+#: py/compile.c
+msgid "argument name reused"
+msgstr ""
+
 #: py/argcheck.c shared-bindings/_stage/__init__.c
-#: shared-bindings/digitalio/DigitalInOut.c shared-bindings/gamepad/GamePad.c
+#: shared-bindings/digitalio/DigitalInOut.c
 msgid "argument num/types mismatch"
 msgstr ""
 
@@ -1765,32 +2437,61 @@ msgstr ""
 msgid "argument should be a '%q' not a '%q'"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/numerical.c extmod/ulab/code/numpy/transform.c
 msgid "arguments must be ndarrays"
 msgstr ""
 
-#: py/objarray.c shared-bindings/nvm/ByteArray.c
+#: extmod/ulab/code/ndarray.c
+msgid "array and index length must be equal"
+msgstr ""
+
+#: extmod/ulab/code/numpy/io/io.c
+msgid "array has too many dimensions"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "array is too big"
+msgstr ""
+
+#: py/objarray.c shared-bindings/alarm/SleepMemory.c
+#: shared-bindings/memorymap/AddressRange.c shared-bindings/nvm/ByteArray.c
 msgid "array/bytes required on right side"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: py/asmxtensa.c
+msgid "asm overflow"
+msgstr ""
+
+#: py/compile.c
+msgid "async for/with outside async function"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
+msgid "attempt to get (arg)min/(arg)max of empty sequence"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
 msgid "attempt to get argmin/argmax of an empty sequence"
 msgstr ""
 
 #: py/objstr.c
-msgid "attributes not supported yet"
+msgid "attributes not supported"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
-msgid "axis must be -1, 0, None, or 1"
+#: extmod/ulab/code/ulab_tools.c
+msgid "axis is out of bounds"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
-msgid "axis must be -1, 0, or 1"
+#: extmod/ulab/code/numpy/numerical.c extmod/ulab/code/ulab_tools.c
+msgid "axis must be None, or an integer"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
-msgid "axis must be None, 0, or 1"
+#: extmod/ulab/code/numpy/numerical.c
+msgid "axis too long"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "background value out of range of target"
 msgstr ""
 
 #: py/builtinevex.c
@@ -1805,7 +2506,7 @@ msgstr ""
 msgid "bad format string"
 msgstr ""
 
-#: py/binary.c
+#: py/binary.c py/objarray.c
 msgid "bad typecode"
 msgstr ""
 
@@ -1813,8 +2514,12 @@ msgstr ""
 msgid "binary op %q not implemented"
 msgstr ""
 
-#: shared-bindings/busio/UART.c
-msgid "bits must be 7, 8 or 9"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "bitmap sizes must match"
+msgstr ""
+
+#: extmod/modrandom.c
+msgid "bits must be 32 or less"
 msgstr ""
 
 #: shared-bindings/audiomixer/Mixer.c
@@ -1825,8 +2530,12 @@ msgstr ""
 msgid "branch not in range"
 msgstr ""
 
-#: shared-bindings/audiocore/RawSample.c
-msgid "buffer must be a bytes-like object"
+#: extmod/ulab/code/numpy/create.c extmod/ulab/code/utils/utils.c
+msgid "buffer is smaller than requested size"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c extmod/ulab/code/utils/utils.c
+msgid "buffer size must be a multiple of element size"
 msgstr ""
 
 #: shared-module/struct/__init__.c
@@ -1837,25 +2546,20 @@ msgstr ""
 msgid "buffer slices must be of equal length"
 msgstr ""
 
-#: py/modstruct.c shared-bindings/struct/__init__.c
-#: shared-module/struct/__init__.c
+#: py/modstruct.c shared-module/struct/__init__.c
 msgid "buffer too small"
 msgstr ""
 
-#: shared-bindings/_pew/PewPew.c
-msgid "buttons must be digitalio.DigitalInOut"
+#: shared-bindings/socketpool/Socket.c shared-bindings/ssl/SSLSocket.c
+msgid "buffer too small for requested bytes"
 msgstr ""
 
-#: py/vm.c
-msgid "byte code not implemented"
+#: py/emitbc.c
+msgid "bytecode overflow"
 msgstr ""
 
-#: shared-bindings/_pixelbuf/PixelBuf.c
-msgid "byteorder is not a string"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/UART.c
-msgid "bytes > 8 bits not supported"
+#: py/objarray.c
+msgid "bytes length not a multiple of item size"
 msgstr ""
 
 #: py/objstr.c
@@ -1870,8 +2574,9 @@ msgstr ""
 msgid "calibration is read only"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/rtc/RTC.c
-msgid "calibration value out of range +/-127"
+#: shared-module/vectorio/Circle.c shared-module/vectorio/Polygon.c
+#: shared-module/vectorio/Rectangle.c
+msgid "can only have one parent"
 msgstr ""
 
 #: py/emitinlinethumb.c
@@ -1882,8 +2587,8 @@ msgstr ""
 msgid "can only have up to 4 parameters to Xtensa assembly"
 msgstr ""
 
-#: py/persistentcode.c
-msgid "can only save bytecode"
+#: extmod/ulab/code/ndarray.c
+msgid "can only specify one unknown dimension"
 msgstr ""
 
 #: py/objtype.c
@@ -1892,6 +2597,14 @@ msgstr ""
 
 #: py/compile.c
 msgid "can't assign to expression"
+msgstr ""
+
+#: extmod/modasyncio.c
+msgid "can't cancel self"
+msgstr ""
+
+#: shared-module/adafruit_pixelbuf/PixelBuf.c
+msgid "can't convert %q to %q"
 msgstr ""
 
 #: py/obj.c
@@ -1904,7 +2617,7 @@ msgstr ""
 msgid "can't convert %s to float"
 msgstr ""
 
-#: py/obj.c
+#: py/runtime.c
 #, c-format
 msgid "can't convert %s to int"
 msgstr ""
@@ -1917,8 +2630,8 @@ msgstr ""
 msgid "can't convert NaN to int"
 msgstr ""
 
-#: shared-bindings/i2cperipheral/I2CPeripheral.c
-msgid "can't convert address to int"
+#: extmod/ulab/code/numpy/vector.c
+msgid "can't convert complex to float"
 msgstr ""
 
 #: py/objint.c
@@ -1933,7 +2646,7 @@ msgstr ""
 msgid "can't convert to float"
 msgstr ""
 
-#: py/obj.c
+#: py/runtime.c
 msgid "can't convert to int"
 msgstr ""
 
@@ -1953,20 +2666,12 @@ msgstr ""
 msgid "can't do binary op between '%q' and '%q'"
 msgstr ""
 
-#: py/objcomplex.c
-msgid "can't do truncated division of a complex number"
-msgstr ""
-
-#: py/compile.c
-msgid "can't have multiple **x"
-msgstr ""
-
-#: py/compile.c
-msgid "can't have multiple *x"
-msgstr ""
-
 #: py/emitnative.c
 msgid "can't implicitly convert '%q' to 'bool'"
+msgstr ""
+
+#: py/runtime.c
+msgid "can't import name %q"
 msgstr ""
 
 #: py/emitnative.c
@@ -1977,16 +2682,24 @@ msgstr ""
 msgid "can't load with '%q' index"
 msgstr ""
 
-#: py/objgenerator.c
-msgid "can't pend throw to just-started generator"
+#: py/builtinimport.c
+msgid "can't perform relative import"
 msgstr ""
 
 #: py/objgenerator.c
 msgid "can't send non-None value to a just-started generator"
 msgstr ""
 
-#: py/objnamedtuple.c
+#: shared-module/sdcardio/SDCard.c
+msgid "can't set 512 block size"
+msgstr ""
+
+#: py/objexcept.c py/objnamedtuple.c
 msgid "can't set attribute"
+msgstr ""
+
+#: py/runtime.c
+msgid "can't set attribute '%q'"
 msgstr ""
 
 #: py/emitnative.c
@@ -2011,6 +2724,34 @@ msgid ""
 "can't switch from manual field specification to automatic field numbering"
 msgstr ""
 
+#: py/objcomplex.c
+msgid "can't truncate-divide a complex number"
+msgstr ""
+
+#: extmod/moductypes.c
+msgid "can't unambiguously get sizeof scalar"
+msgstr ""
+
+#: extmod/modasyncio.c
+msgid "can't wait"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "cannot assign new shape"
+msgstr ""
+
+#: extmod/ulab/code/ndarray_operators.c
+msgid "cannot cast output with casting rule"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "cannot convert complex to dtype"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "cannot convert complex type"
+msgstr ""
+
 #: py/objtype.c
 msgid "cannot create '%q' instances"
 msgstr ""
@@ -2019,20 +2760,20 @@ msgstr ""
 msgid "cannot create instance"
 msgstr ""
 
-#: py/runtime.c
-msgid "cannot import name %q"
-msgstr ""
-
-#: py/builtinimport.c
-msgid "cannot perform relative import"
+#: extmod/ulab/code/ndarray.c
+msgid "cannot delete array elements"
 msgstr ""
 
 #: extmod/ulab/code/ndarray.c
-msgid "cannot reshape array (incompatible input/output shape)"
+msgid "cannot reshape array"
 msgstr ""
 
 #: py/emitnative.c
 msgid "casting"
+msgstr ""
+
+#: ports/stm/common-hal/pwmio/PWMOut.c
+msgid "channel re-init"
 msgstr ""
 
 #: shared-bindings/_stage/Text.c
@@ -2047,8 +2788,12 @@ msgstr ""
 msgid "chr() arg not in range(256)"
 msgstr ""
 
-#: shared-module/vectorio/Circle.c
-msgid "circle can only be registered in one parent"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "clip point must be (x,y) tuple"
+msgstr ""
+
+#: shared-bindings/msgpack/ExtType.c
+msgid "code outside range 0~127"
 msgstr ""
 
 #: shared-bindings/displayio/Palette.c
@@ -2067,60 +2812,69 @@ msgstr ""
 msgid "color must be between 0x000000 and 0xffffff"
 msgstr ""
 
-#: shared-bindings/displayio/ColorConverter.c
-msgid "color should be an int"
+#: py/emitnative.c
+msgid "comparison of int and uint"
 msgstr ""
 
 #: py/objcomplex.c
-msgid "complex division by zero"
+msgid "complex divide by zero"
 msgstr ""
 
 #: py/objfloat.c py/parsenum.c
 msgid "complex values not supported"
 msgstr ""
 
-#: extmod/moduzlib.c
+#: extmod/modzlib.c
 msgid "compression header"
-msgstr ""
-
-#: py/parse.c
-msgid "constant must be an integer"
 msgstr ""
 
 #: py/emitnative.c
 msgid "conversion to object"
 msgstr ""
 
-#: extmod/ulab/code/filter.c
+#: extmod/ulab/code/numpy/filter.c
 msgid "convolve arguments must be linear arrays"
 msgstr ""
 
-#: extmod/ulab/code/filter.c
+#: extmod/ulab/code/numpy/filter.c
 msgid "convolve arguments must be ndarrays"
 msgstr ""
 
-#: extmod/ulab/code/filter.c
+#: extmod/ulab/code/numpy/filter.c
 msgid "convolve arguments must not be empty"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
-msgid "could not broadast input array from shape"
+#: extmod/ulab/code/numpy/io/io.c
+msgid "corrupted file"
 msgstr ""
 
-#: extmod/ulab/code/poly.c
+#: extmod/ulab/code/numpy/poly.c
 msgid "could not invert Vandermonde matrix"
 msgstr ""
 
-#: extmod/ulab/code/approx.c
+#: shared-module/sdcardio/SDCard.c
+msgid "couldn't determine SD card version"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
+msgid "cross is defined for 1D arrays of length 3"
+msgstr ""
+
+#: extmod/ulab/code/scipy/optimize/optimize.c
 msgid "data must be iterable"
 msgstr ""
 
-#: extmod/ulab/code/approx.c
+#: extmod/ulab/code/scipy/optimize/optimize.c
 msgid "data must be of equal length"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
-msgid "ddof must be smaller than length of data set"
+#: ports/atmel-samd/common-hal/imagecapture/ParallelImageCapture.c
+#, c-format
+msgid "data pin #%d in use"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "data type not understood"
 msgstr ""
 
 #: py/parsenum.c
@@ -2129,6 +2883,10 @@ msgstr ""
 
 #: py/compile.c
 msgid "default 'except' must be last"
+msgstr ""
+
+#: shared-bindings/msgpack/__init__.c
+msgid "default is not a function"
 msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
@@ -2140,28 +2898,51 @@ msgstr ""
 msgid "destination buffer must be an array of type 'H' for bit_depth = 16"
 msgstr ""
 
-#: shared-bindings/audiobusio/PDMIn.c
-msgid "destination_length must be an int >= 0"
-msgstr ""
-
 #: py/objdict.c
 msgid "dict update sequence has wrong length"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: extmod/ulab/code/numpy/numerical.c
 msgid "diff argument must be an ndarray"
 msgstr ""
 
-#: py/modmath.c py/objfloat.c py/objint_longlong.c py/objint_mpz.c py/runtime.c
-#: shared-bindings/math/__init__.c
+#: extmod/ulab/code/numpy/numerical.c
+msgid "differentiation order out of range"
+msgstr ""
+
+#: extmod/ulab/code/numpy/transform.c
+msgid "dimensions do not match"
+msgstr ""
+
+#: py/emitnative.c
+msgid "div/mod not implemented for uint"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
+msgid "divide by zero"
+msgstr ""
+
+#: py/runtime.c
 msgid "division by zero"
+msgstr ""
+
+#: extmod/ulab/code/numpy/vector.c
+msgid "dtype must be float, or complex"
+msgstr ""
+
+#: extmod/ulab/code/ndarray_operators.c
+msgid "dtype of int32 is not supported"
 msgstr ""
 
 #: py/objdeque.c
 msgid "empty"
 msgstr ""
 
-#: extmod/moduheapq.c extmod/modutimeq.c
+#: extmod/ulab/code/numpy/io/io.c
+msgid "empty file"
+msgstr ""
+
+#: extmod/modasyncio.c extmod/modheapq.c
 msgid "empty heap"
 msgstr ""
 
@@ -2177,8 +2958,8 @@ msgstr ""
 msgid "end of format while looking for conversion specifier"
 msgstr ""
 
-#: shared-bindings/displayio/Shape.c
-msgid "end_x should be an int"
+#: shared-bindings/alarm/time/TimeAlarm.c
+msgid "epoch_time not supported on this board"
 msgstr ""
 
 #: ports/nrf/common-hal/busio/UART.c
@@ -2214,6 +2995,10 @@ msgstr ""
 msgid "expecting key:value for dict"
 msgstr ""
 
+#: shared-bindings/msgpack/__init__.c
+msgid "ext_hook is not a function"
+msgstr ""
+
 #: py/argcheck.c
 msgid "extra keyword arguments given"
 msgstr ""
@@ -2222,48 +3007,33 @@ msgstr ""
 msgid "extra positional arguments given"
 msgstr ""
 
-#: py/parse.c
-msgid "f-string expression part cannot include a '#'"
-msgstr ""
-
-#: py/parse.c
-msgid "f-string expression part cannot include a backslash"
-msgstr ""
-
-#: py/parse.c
-msgid "f-string: empty expression not allowed"
-msgstr ""
-
-#: py/parse.c
-msgid "f-string: expecting '}'"
-msgstr ""
-
-#: py/parse.c
-msgid "f-string: single '}' is not allowed"
-msgstr ""
-
 #: shared-bindings/audiocore/WaveFile.c shared-bindings/audiomp3/MP3Decoder.c
-#: shared-bindings/displayio/OnDiskBitmap.c
+#: shared-bindings/displayio/OnDiskBitmap.c shared-bindings/gifio/OnDiskGif.c
+#: shared-bindings/synthio/__init__.c shared-module/gifio/GifWriter.c
 msgid "file must be a file opened in byte mode"
+msgstr ""
+
+#: shared-bindings/traceback/__init__.c
+msgid "file write is not available"
 msgstr ""
 
 #: shared-bindings/storage/__init__.c
 msgid "filesystem must provide mount method"
 msgstr ""
 
-#: extmod/ulab/code/vectorise.c
+#: extmod/ulab/code/numpy/vector.c
 msgid "first argument must be a callable"
 msgstr ""
 
-#: extmod/ulab/code/approx.c
+#: extmod/ulab/code/scipy/optimize/optimize.c
 msgid "first argument must be a function"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
-msgid "first argument must be an iterable"
+#: extmod/ulab/code/numpy/create.c
+msgid "first argument must be a tuple of ndarrays"
 msgstr ""
 
-#: extmod/ulab/code/vectorise.c
+#: extmod/ulab/code/numpy/transform.c extmod/ulab/code/numpy/vector.c
 msgid "first argument must be an ndarray"
 msgstr ""
 
@@ -2271,11 +3041,15 @@ msgstr ""
 msgid "first argument to super() must be type"
 msgstr ""
 
+#: extmod/ulab/code/scipy/linalg/linalg.c
+msgid "first two arguments must be ndarrays"
+msgstr ""
+
 #: extmod/ulab/code/ndarray.c
 msgid "flattening order must be either 'C', or 'F'"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: extmod/ulab/code/numpy/numerical.c
 msgid "flip argument must be an ndarray"
 msgstr ""
 
@@ -2283,8 +3057,16 @@ msgstr ""
 msgid "float too big"
 msgstr ""
 
+#: py/nativeglue.c
+msgid "float unsupported"
+msgstr ""
+
 #: shared-bindings/_stage/Text.c
 msgid "font must be 2048 bytes long"
+msgstr ""
+
+#: extmod/moddeflate.c
+msgid "format"
 msgstr ""
 
 #: py/objstr.c
@@ -2296,7 +3078,7 @@ msgid "full"
 msgstr ""
 
 #: py/argcheck.c
-msgid "function does not take keyword arguments"
+msgid "function doesn't take keyword arguments"
 msgstr ""
 
 #: py/argcheck.c
@@ -2308,12 +3090,16 @@ msgstr ""
 msgid "function got multiple values for argument '%q'"
 msgstr ""
 
-#: extmod/ulab/code/approx.c
+#: extmod/ulab/code/scipy/optimize/optimize.c
 msgid "function has the same sign at the ends of interval"
 msgstr ""
 
-#: extmod/ulab/code/compare.c
-msgid "function is implemented for scalars and ndarrays only"
+#: extmod/ulab/code/ndarray.c
+msgid "function is defined for ndarrays only"
+msgstr ""
+
+#: extmod/ulab/code/numpy/carray/carray.c
+msgid "function is implemented for ndarrays only"
 msgstr ""
 
 #: py/argcheck.c
@@ -2334,7 +3120,7 @@ msgstr ""
 msgid "function missing required positional argument #%d"
 msgstr ""
 
-#: py/argcheck.c py/bc.c py/objnamedtuple.c
+#: py/argcheck.c py/bc.c py/objnamedtuple.c shared-bindings/time/__init__.c
 #, c-format
 msgid "function takes %d positional arguments but %d were given"
 msgstr ""
@@ -2351,11 +3137,19 @@ msgstr ""
 msgid "generator ignored GeneratorExit"
 msgstr ""
 
+#: py/objgenerator.c py/runtime.c
+msgid "generator raised StopIteration"
+msgstr ""
+
 #: shared-bindings/_stage/Layer.c
 msgid "graphic must be 2048 bytes long"
 msgstr ""
 
-#: extmod/moduheapq.c
+#: extmod/modhashlib.c
+msgid "hash is final"
+msgstr ""
+
+#: extmod/modheapq.c
 msgid "heap must be a list"
 msgstr ""
 
@@ -2367,6 +3161,18 @@ msgstr ""
 msgid "identifier redefined as nonlocal"
 msgstr ""
 
+#: py/compile.c
+msgid "import * not at module level"
+msgstr ""
+
+#: py/persistentcode.c
+msgid "incompatible .mpy arch"
+msgstr ""
+
+#: py/persistentcode.c
+msgid "incompatible .mpy file"
+msgstr ""
+
 #: py/objstr.c
 msgid "incomplete format"
 msgstr ""
@@ -2375,18 +3181,21 @@ msgstr ""
 msgid "incomplete format key"
 msgstr ""
 
-#: extmod/modubinascii.c
+#: extmod/modbinascii.c
 msgid "incorrect padding"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
+#: extmod/ulab/code/ndarray.c extmod/ulab/code/numpy/transform.c
 msgid "index is out of bounds"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/pulseio/PulseIn.c
-#: ports/cxd56/common-hal/pulseio/PulseIn.c
-#: ports/nrf/common-hal/pulseio/PulseIn.c
-#: ports/stm/common-hal/pulseio/PulseIn.c py/obj.c
+#: shared-bindings/_pixelmap/PixelMap.c
+msgid "index must be tuple or int"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c extmod/ulab/code/ulab_tools.c
+#: ports/espressif/common-hal/pulseio/PulseIn.c
+#: shared-bindings/bitmaptools/__init__.c
 msgid "index out of range"
 msgstr ""
 
@@ -2398,56 +3207,101 @@ msgstr ""
 msgid "indices must be integers, slices, or Boolean lists"
 msgstr ""
 
-#: extmod/ulab/code/approx.c
+#: ports/espressif/common-hal/busio/I2C.c
+msgid "init I2C"
+msgstr ""
+
+#: extmod/ulab/code/scipy/optimize/optimize.c
 msgid "initial values must be iterable"
+msgstr ""
+
+#: shared-bindings/_bleio/Characteristic.c shared-bindings/_bleio/Descriptor.c
+msgid "initial_value length is wrong"
 msgstr ""
 
 #: py/compile.c
 msgid "inline assembler must be a function"
 msgstr ""
 
-#: extmod/ulab/code/create.c
-msgid "input argument must be an integer or a 2-tuple"
+#: extmod/ulab/code/numpy/vector.c
+msgid "input and output dimensions differ"
 msgstr ""
 
-#: extmod/ulab/code/fft.c
+#: extmod/ulab/code/numpy/vector.c
+msgid "input and output shapes differ"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
+msgid "input argument must be an integer, a tuple, or a list"
+msgstr ""
+
+#: extmod/ulab/code/numpy/fft/fft_tools.c
 msgid "input array length must be power of 2"
 msgstr ""
 
-#: extmod/ulab/code/poly.c
+#: extmod/ulab/code/numpy/create.c
+msgid "input arrays are not compatible"
+msgstr ""
+
+#: extmod/ulab/code/numpy/poly.c
 msgid "input data must be an iterable"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/vector.c
+msgid "input dtype must be float or complex"
+msgstr ""
+
+#: extmod/ulab/code/numpy/poly.c
+msgid "input is not iterable"
+msgstr ""
+
+#: extmod/ulab/code/numpy/linalg/linalg.c
 msgid "input matrix is asymmetric"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/linalg/linalg.c
+#: extmod/ulab/code/scipy/linalg/linalg.c
 msgid "input matrix is singular"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/create.c
+msgid "input must be 1- or 2-d"
+msgstr ""
+
+#: extmod/ulab/code/numpy/carray/carray.c
+msgid "input must be a 1D ndarray"
+msgstr ""
+
+#: extmod/ulab/code/scipy/linalg/linalg.c extmod/ulab/code/user/user.c
+msgid "input must be a dense ndarray"
+msgstr ""
+
+#: extmod/ulab/code/user/user.c
+msgid "input must be an ndarray"
+msgstr ""
+
+#: extmod/ulab/code/numpy/carray/carray.c
+msgid "input must be an ndarray, or a scalar"
+msgstr ""
+
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "input must be one-dimensional"
+msgstr ""
+
+#: extmod/ulab/code/ulab_tools.c
 msgid "input must be square matrix"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: extmod/ulab/code/numpy/numerical.c
 msgid "input must be tuple, list, range, or ndarray"
 msgstr ""
 
-#: extmod/ulab/code/poly.c
+#: extmod/ulab/code/numpy/poly.c
 msgid "input vectors must be of equal length"
 msgstr ""
 
-#: py/parsenum.c
-msgid "int() arg 2 must be >= 2 and <= 36"
-msgstr ""
-
-#: py/objstr.c
-msgid "integer required"
-msgstr ""
-
-#: extmod/ulab/code/approx.c
-msgid "interp is defined for 1D arrays of equal length"
+#: extmod/ulab/code/numpy/approx.c
+msgid "interp is defined for 1D iterables of equal length"
 msgstr ""
 
 #: shared-bindings/_bleio/Adapter.c
@@ -2455,32 +3309,51 @@ msgstr ""
 msgid "interval must be in range %s-%s"
 msgstr ""
 
-#: lib/netutils/netutils.c
-msgid "invalid arguments"
+#: py/compile.c
+msgid "invalid arch"
 msgstr ""
 
-#: extmod/modussl_axtls.c
+#: shared-bindings/bitmaptools/__init__.c
+#, c-format
+msgid "invalid bits_per_pixel %d, must be, 1, 2, 4, 8, 16, 24, or 32"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/ssl/SSLSocket.c
 msgid "invalid cert"
 msgstr ""
 
-#: extmod/uos_dupterm.c
-msgid "invalid dupterm index"
+#: shared-bindings/bitmaptools/__init__.c
+#, c-format
+msgid "invalid element size %d for bits_per_pixel %d\n"
 msgstr ""
 
-#: extmod/modframebuf.c
-msgid "invalid format"
+#: shared-bindings/bitmaptools/__init__.c
+#, c-format
+msgid "invalid element_size %d, must be, 1, 2, or 4"
+msgstr ""
+
+#: shared-bindings/traceback/__init__.c
+msgid "invalid exception"
 msgstr ""
 
 #: py/objstr.c
 msgid "invalid format specifier"
 msgstr ""
 
-#: extmod/modussl_axtls.c
+#: shared-bindings/wifi/Radio.c
+msgid "invalid hostname"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/ssl/SSLSocket.c
 msgid "invalid key"
 msgstr ""
 
 #: py/compile.c
 msgid "invalid micropython decorator"
+msgstr ""
+
+#: ports/espressif/common-hal/espcamera/Camera.c
+msgid "invalid setting"
 msgstr ""
 
 #: shared-bindings/random/__init__.c
@@ -2512,11 +3385,7 @@ msgstr ""
 msgid "issubclass() arg 2 must be a class or a tuple of classes"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
-msgid "iterables are not of the same length"
-msgstr ""
-
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/linalg/linalg.c
 msgid "iterations did not converge"
 msgstr ""
 
@@ -2525,11 +3394,7 @@ msgid "join expects a list of str/bytes objects consistent with self object"
 msgstr ""
 
 #: py/argcheck.c
-msgid "keyword argument(s) not yet implemented - use normal args instead"
-msgstr ""
-
-#: py/bc.c
-msgid "keywords must be strings"
+msgid "keyword argument(s) not implemented - use normal args instead"
 msgstr ""
 
 #: py/emitinlinethumb.c py/emitinlinextensa.c
@@ -2538,10 +3403,6 @@ msgstr ""
 
 #: py/compile.c
 msgid "label redefined"
-msgstr ""
-
-#: py/stream.c
-msgid "length argument not allowed for this type"
 msgstr ""
 
 #: shared-bindings/audiomixer/MixerVoice.c
@@ -2564,8 +3425,18 @@ msgstr ""
 msgid "local variable referenced before assignment"
 msgstr ""
 
-#: py/objint.c
-msgid "long int not supported in this build"
+#: ports/espressif/common-hal/canio/CAN.c
+msgid "loopback + silent mode not supported by peripheral"
+msgstr ""
+
+#: ports/espressif/common-hal/mdns/Server.c
+#: ports/raspberrypi/common-hal/mdns/Server.c
+msgid "mDNS already initialized"
+msgstr ""
+
+#: ports/espressif/common-hal/mdns/Server.c
+#: ports/raspberrypi/common-hal/mdns/Server.c
+msgid "mDNS only works with built-in WiFi"
 msgstr ""
 
 #: py/parse.c
@@ -2580,22 +3451,35 @@ msgstr ""
 msgid "math domain error"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
-msgid "matrix dimensions do not match"
-msgstr ""
-
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/numpy/linalg/linalg.c
 msgid "matrix is not positive definite"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Descriptor.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Descriptor.c
 #, c-format
 msgid "max_length must be 0-%d when fixed_length is %s"
 msgstr ""
 
+#: extmod/ulab/code/ndarray.c
+msgid "maximum number of dimensions is "
+msgstr ""
+
 #: py/runtime.c
 msgid "maximum recursion depth exceeded"
+msgstr ""
+
+#: extmod/ulab/code/scipy/optimize/optimize.c
+msgid "maxiter must be > 0"
+msgstr ""
+
+#: extmod/ulab/code/scipy/optimize/optimize.c
+msgid "maxiter should be > 0"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
+msgid "median argument must be an ndarray"
 msgstr ""
 
 #: py/runtime.c
@@ -2607,11 +3491,31 @@ msgstr ""
 msgid "memory allocation failed, heap is locked"
 msgstr ""
 
+#: py/objarray.c
+msgid "memoryview offset too large"
+msgstr ""
+
+#: py/objarray.c
+msgid "memoryview: length is not a multiple of itemsize"
+msgstr ""
+
+#: extmod/modtime.c
+msgid "mktime needs a tuple of length 8 or 9"
+msgstr ""
+
+#: extmod/ulab/code/numpy/linalg/linalg.c
+msgid "mode must be complete, or reduced"
+msgstr ""
+
 #: py/builtinimport.c
 msgid "module not found"
 msgstr ""
 
-#: extmod/ulab/code/poly.c
+#: ports/espressif/common-hal/wifi/Monitor.c
+msgid "monitor init failed"
+msgstr ""
+
+#: extmod/ulab/code/numpy/poly.c
 msgid "more degrees of freedom than data points"
 msgstr ""
 
@@ -2635,10 +3539,6 @@ msgstr ""
 msgid "must use keyword argument for key function"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
-msgid "n must be between 0, and 9"
-msgstr ""
-
 #: py/runtime.c
 msgid "name '%q' is not defined"
 msgstr ""
@@ -2647,17 +3547,29 @@ msgstr ""
 msgid "name not defined"
 msgstr ""
 
-#: py/compile.c
-msgid "name reused for argument"
+#: py/persistentcode.c
+msgid "native code in .mpy unsupported"
+msgstr ""
+
+#: py/asmthumb.c
+msgid "native method too big"
 msgstr ""
 
 #: py/emitnative.c
 msgid "native yield"
 msgstr ""
 
+#: extmod/ulab/code/ndarray.c
+msgid "ndarray length overflows"
+msgstr ""
+
 #: py/runtime.c
 #, c-format
 msgid "need more than %d values to unpack"
+msgstr ""
+
+#: py/modmath.c
+msgid "negative factorial"
 msgstr ""
 
 #: py/objint_longlong.c py/objint_mpz.c py/runtime.c
@@ -2668,31 +3580,43 @@ msgstr ""
 msgid "negative shift count"
 msgstr ""
 
-#: py/vm.c
-msgid "no active exception to reraise"
+#: shared-bindings/_pixelmap/PixelMap.c
+msgid "nested index must be int"
 msgstr ""
 
-#: shared-bindings/socket/__init__.c shared-module/network/__init__.c
-msgid "no available NIC"
+#: shared-module/sdcardio/SDCard.c
+msgid "no SD card"
+msgstr ""
+
+#: py/vm.c
+msgid "no active exception to reraise"
 msgstr ""
 
 #: py/compile.c
 msgid "no binding for nonlocal found"
 msgstr ""
 
+#: shared-module/msgpack/__init__.c
+msgid "no default packer"
+msgstr ""
+
+#: extmod/modrandom.c
+msgid "no default seed"
+msgstr ""
+
 #: py/builtinimport.c
 msgid "no module named '%q'"
 msgstr ""
 
-#: shared-bindings/displayio/FourWire.c shared-bindings/displayio/I2CDisplay.c
-#: shared-bindings/displayio/ParallelBus.c
-msgid "no reset pin available"
+#: shared-module/sdcardio/SDCard.c
+msgid "no response from SD card"
 msgstr ""
 
-#: py/runtime.c
+#: ports/espressif/common-hal/espcamera/Camera.c py/objobject.c py/runtime.c
 msgid "no such attribute"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Connection.c
 #: ports/nrf/common-hal/_bleio/Connection.c
 msgid "non-UUID found in service_uuids_whitelist"
 msgstr ""
@@ -2701,20 +3625,24 @@ msgstr ""
 msgid "non-default argument follows default argument"
 msgstr ""
 
-#: extmod/modubinascii.c
+#: py/objstr.c
 msgid "non-hex digit found"
 msgstr ""
 
-#: py/compile.c
-msgid "non-keyword arg after */**"
+#: ports/nrf/common-hal/_bleio/Adapter.c
+msgid "non-zero timeout must be > 0.01"
 msgstr ""
 
-#: py/compile.c
-msgid "non-keyword arg after keyword arg"
+#: shared-bindings/_bleio/Adapter.c
+msgid "non-zero timeout must be >= interval"
 msgstr ""
 
 #: shared-bindings/_bleio/UUID.c
 msgid "not a 128-bit UUID"
+msgstr ""
+
+#: py/parse.c
+msgid "not a constant"
 msgstr ""
 
 #: py/objstr.c
@@ -2725,25 +3653,33 @@ msgstr ""
 msgid "not enough arguments for format string"
 msgstr ""
 
-#: extmod/ulab/code/poly.c
-msgid "number of arguments must be 2, or 3"
+#: extmod/ulab/code/numpy/carray/carray_tools.c
+msgid "not implemented for complex dtype"
 msgstr ""
 
-#: extmod/ulab/code/create.c
+#: extmod/ulab/code/numpy/bitwise.c
+msgid "not supported for input types"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
 msgid "number of points must be at least 2"
+msgstr ""
+
+#: py/builtinhelp.c
+msgid "object "
 msgstr ""
 
 #: py/obj.c
 #, c-format
-msgid "object '%s' is not a tuple or list"
+msgid "object '%s' isn't a tuple or list"
 msgstr ""
 
 #: py/obj.c
-msgid "object does not support item assignment"
+msgid "object doesn't support item assignment"
 msgstr ""
 
 #: py/obj.c
-msgid "object does not support item deletion"
+msgid "object doesn't support item deletion"
 msgstr ""
 
 #: py/obj.c
@@ -2751,7 +3687,7 @@ msgid "object has no len"
 msgstr ""
 
 #: py/obj.c
-msgid "object is not subscriptable"
+msgid "object isn't subscriptable"
 msgstr ""
 
 #: py/runtime.c
@@ -2779,38 +3715,85 @@ msgstr ""
 msgid "object with buffer protocol required"
 msgstr ""
 
-#: extmod/modubinascii.c
+#: py/objstr.c
 msgid "odd-length string"
 msgstr ""
 
-#: py/objstr.c py/objstrunicode.c
-msgid "offset out of bounds"
+#: supervisor/shared/web_workflow/web_workflow.c
+msgid "off"
+msgstr ""
+
+#: extmod/ulab/code/utils/utils.c
+msgid "offset is too large"
+msgstr ""
+
+#: shared-bindings/dualbank/__init__.c
+msgid "offset must be >= 0"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
+msgid "offset must be non-negative and no greater than buffer length"
 msgstr ""
 
 #: ports/nrf/common-hal/audiobusio/PDMIn.c
+#: ports/stm/common-hal/audiobusio/PDMIn.c
 msgid "only bit_depth=16 is supported"
 msgstr ""
 
+#: ports/stm/common-hal/audiobusio/PDMIn.c
+msgid "only mono is supported"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c
+msgid "only ndarrays can be concatenated"
+msgstr ""
+
+#: ports/stm/common-hal/audiobusio/PDMIn.c
+msgid "only oversample=64 is supported"
+msgstr ""
+
 #: ports/nrf/common-hal/audiobusio/PDMIn.c
+#: ports/stm/common-hal/audiobusio/PDMIn.c
 msgid "only sample_rate=16000 is supported"
 msgstr ""
 
 #: py/objarray.c py/objstr.c py/objstrunicode.c py/objtuple.c
+#: shared-bindings/alarm/SleepMemory.c shared-bindings/memorymap/AddressRange.c
 #: shared-bindings/nvm/ByteArray.c
 msgid "only slices with step=1 (aka None) are supported"
 msgstr ""
 
-#: extmod/ulab/code/compare.c extmod/ulab/code/ndarray.c
-#: extmod/ulab/code/vectorise.c
+#: py/vm.c
+msgid "opcode"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c extmod/ulab/code/numpy/bitwise.c
+#: extmod/ulab/code/numpy/compare.c extmod/ulab/code/numpy/vector.c
 msgid "operands could not be broadcast together"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: extmod/ulab/code/numpy/linalg/linalg.c
+msgid "operation is defined for 2D arrays only"
+msgstr ""
+
+#: extmod/ulab/code/numpy/linalg/linalg.c
+msgid "operation is defined for ndarrays only"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c
+msgid "operation is implemented for 1D Boolean arrays only"
+msgstr ""
+
+#: extmod/ulab/code/numpy/numerical.c
 msgid "operation is not implemented on ndarrays"
 msgstr ""
 
 #: extmod/ulab/code/ndarray.c
 msgid "operation is not supported for given type"
+msgstr ""
+
+#: extmod/ulab/code/ndarray_operators.c
+msgid "operation not supported for the input types"
 msgstr ""
 
 #: py/modbuiltins.c
@@ -2822,20 +3805,45 @@ msgstr ""
 msgid "ord() expected a character, but string of length %d found"
 msgstr ""
 
+#: extmod/ulab/code/utils/utils.c
+msgid "out array is too small"
+msgstr ""
+
+#: extmod/ulab/code/numpy/vector.c
+msgid "out keyword is not supported for complex dtype"
+msgstr ""
+
+#: extmod/ulab/code/numpy/vector.c
+msgid "out keyword is not supported for function"
+msgstr ""
+
+#: extmod/ulab/code/utils/utils.c
+msgid "out must be a float dense array"
+msgstr ""
+
+#: extmod/ulab/code/numpy/vector.c
+msgid "out must be an ndarray"
+msgstr ""
+
+#: extmod/ulab/code/numpy/vector.c
+msgid "out must be of float dtype"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "out of range of target"
+msgstr ""
+
 #: py/objint_mpz.c
 msgid "overflow converting long int to machine word"
 msgstr ""
 
+#: py/modstruct.c
+#, c-format
+msgid "pack expected %d items for packing (got %d)"
+msgstr ""
+
 #: shared-bindings/_stage/Layer.c shared-bindings/_stage/Text.c
 msgid "palette must be 32 bytes long"
-msgstr ""
-
-#: shared-bindings/displayio/Palette.c
-msgid "palette_index should be an int"
-msgstr ""
-
-#: py/compile.c
-msgid "parameter annotation must be an identifier"
 msgstr ""
 
 #: py/emitinlinextensa.c
@@ -2846,39 +3854,37 @@ msgstr ""
 msgid "parameters must be registers in sequence r0 to r3"
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c
+#: shared-bindings/bitmaptools/__init__.c
 msgid "pixel coordinates out of bounds"
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c
-msgid "pixel value requires too many bits"
+#: extmod/vfs_posix_file.c
+msgid "poll on file not available on win32"
 msgstr ""
 
-#: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
-msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-msgstr ""
-
-#: shared-module/vectorio/Polygon.c
-msgid "polygon can only be registered in one parent"
+#: ports/espressif/common-hal/pulseio/PulseIn.c
+msgid "pop from an empty PulseIn"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #: ports/cxd56/common-hal/pulseio/PulseIn.c
 #: ports/nrf/common-hal/pulseio/PulseIn.c
-#: ports/stm/common-hal/pulseio/PulseIn.c
-msgid "pop from an empty PulseIn"
+#: ports/raspberrypi/common-hal/pulseio/PulseIn.c
+#: ports/stm/common-hal/pulseio/PulseIn.c py/objdict.c py/objlist.c py/objset.c
+#: shared-bindings/ps2io/Ps2.c
+msgid "pop from empty %q"
 msgstr ""
 
-#: py/objset.c
-msgid "pop from an empty set"
+#: shared-bindings/socketpool/Socket.c shared-bindings/ssl/SSLSocket.c
+msgid "port must be >= 0"
 msgstr ""
 
-#: py/objlist.c
-msgid "pop from empty list"
+#: py/compile.c
+msgid "positional arg after **"
 msgstr ""
 
-#: py/objdict.c
-msgid "popitem(): dictionary is empty"
+#: py/compile.c
+msgid "positional arg after keyword arg"
 msgstr ""
 
 #: py/objint_mpz.c
@@ -2889,15 +3895,15 @@ msgstr ""
 msgid "pow() with 3 arguments requires integers"
 msgstr ""
 
-#: extmod/modutimeq.c
-msgid "queue overflow"
+#: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+msgid "pull masks conflict with direction masks"
 msgstr ""
 
 #: py/parse.c
-msgid "raw f-strings are not implemented"
+msgid "raw f-strings are not supported"
 msgstr ""
 
-#: extmod/ulab/code/fft.c
+#: extmod/ulab/code/numpy/fft/fft_tools.c
 msgid "real and imaginary parts must be of equal length"
 msgstr ""
 
@@ -2908,6 +3914,10 @@ msgstr ""
 #: py/obj.c
 #, c-format
 msgid "requested length %d but object has length %d"
+msgstr ""
+
+#: extmod/ulab/code/ndarray_operators.c
+msgid "results cannot be cast to specified type"
 msgstr ""
 
 #: py/compile.c
@@ -2928,34 +3938,37 @@ msgstr ""
 msgid "rgb_pins[%d] is not on the same port as clock"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
-msgid "right hand side must be an ndarray, or a scalar"
+#: extmod/ulab/code/numpy/numerical.c
+msgid "roll argument must be an ndarray"
 msgstr ""
 
 #: py/objstr.c
 msgid "rsplit(None,n)"
 msgstr ""
 
-#: shared-bindings/audiocore/RawSample.c
-msgid ""
-"sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' or "
-"'B'"
-msgstr ""
-
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+#: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
 msgid "sampling rate out of range"
 msgstr ""
 
 #: py/modmicropython.c
-msgid "schedule stack full"
+msgid "schedule queue full"
 msgstr ""
 
-#: shared/runtime/pyexec.c py/builtinimport.c
+#: py/builtinimport.c
 msgid "script compilation not supported"
 msgstr ""
 
+#: py/nativeglue.c
+msgid "set unsupported"
+msgstr ""
+
 #: extmod/ulab/code/ndarray.c
-msgid "shape must be a 2-tuple"
+msgid "shape must be integer or tuple of integers"
+msgstr ""
+
+#: shared-module/msgpack/__init__.c
+msgid "short read"
 msgstr ""
 
 #: py/objstr.c
@@ -2966,11 +3979,7 @@ msgstr ""
 msgid "sign not allowed with integer format specifier 'c'"
 msgstr ""
 
-#: py/objstr.c
-msgid "single '}' encountered in format string"
-msgstr ""
-
-#: extmod/ulab/code/linalg.c
+#: extmod/ulab/code/ulab_tools.c
 msgid "size is defined for ndarrays only"
 msgstr ""
 
@@ -2978,8 +3987,8 @@ msgstr ""
 msgid "sleep length must be non-negative"
 msgstr ""
 
-#: py/objslice.c py/sequence.c
-msgid "slice step cannot be zero"
+#: py/nativeglue.c
+msgid "slice unsupported"
 msgstr ""
 
 #: py/objint.c py/sequence.c
@@ -2990,32 +3999,56 @@ msgstr ""
 msgid "soft reboot\n"
 msgstr ""
 
-#: extmod/ulab/code/numerical.c
+#: extmod/ulab/code/numpy/numerical.c
 msgid "sort argument must be an ndarray"
+msgstr ""
+
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "sos array must be of shape (n_section, 6)"
+msgstr ""
+
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "sos[:, 3] should be all ones"
+msgstr ""
+
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "sosfilt requires iterable arguments"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "source palette too large"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "source_bitmap must have value_count of 2 or 65536"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "source_bitmap must have value_count of 65536"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "source_bitmap must have value_count of 8"
+msgstr ""
+
+#: extmod/modre.c
+msgid "splitting with sub-captures"
 msgstr ""
 
 #: py/objstr.c
 msgid "start/end indices"
 msgstr ""
 
-#: shared-bindings/displayio/Shape.c
-msgid "start_x should be an int"
-msgstr ""
-
-#: shared-bindings/random/__init__.c
-msgid "step must be non-zero"
-msgstr ""
-
-#: shared-bindings/busio/UART.c
-msgid "stop must be 1 or 2"
-msgstr ""
-
 #: shared-bindings/random/__init__.c
 msgid "stop not reachable from start"
 msgstr ""
 
-#: py/stream.c
+#: py/stream.c shared-bindings/getpass/__init__.c
 msgid "stream operation not supported"
+msgstr ""
+
+#: py/objarray.c py/objstr.c
+msgid "string argument without an encoding"
 msgstr ""
 
 #: py/objstrunicode.c
@@ -3027,12 +4060,8 @@ msgstr ""
 msgid "string indices must be integers, not %s"
 msgstr ""
 
-#: py/stream.c
-msgid "string not supported; use bytes or bytearray"
-msgstr ""
-
 #: extmod/moductypes.c
-msgid "struct: cannot index"
+msgid "struct: can't index"
 msgstr ""
 
 #: extmod/moductypes.c
@@ -3043,7 +4072,7 @@ msgstr ""
 msgid "struct: no fields"
 msgstr ""
 
-#: py/objstr.c
+#: py/objarray.c py/objstr.c
 msgid "substring not found"
 msgstr ""
 
@@ -3051,7 +4080,7 @@ msgstr ""
 msgid "super() can't find self"
 msgstr ""
 
-#: extmod/modujson.c
+#: extmod/modjson.c
 msgid "syntax error in JSON"
 msgstr ""
 
@@ -3059,36 +4088,52 @@ msgstr ""
 msgid "syntax error in uctypes descriptor"
 msgstr ""
 
-#: shared-bindings/touchio/TouchIn.c
-msgid "threshold must be in the range 0-65536"
-msgstr ""
-
-#: shared-bindings/time/__init__.c
-msgid "time.struct_time() takes a 9-sequence"
+#: extmod/modtime.c
+msgid "ticks interval overflow"
 msgstr ""
 
 #: ports/nrf/common-hal/watchdog/WatchDogTimer.c
 msgid "timeout duration exceeded the maximum supported value"
 msgstr ""
 
-#: shared-bindings/busio/UART.c
-msgid "timeout must be 0.0-100.0 seconds"
+#: ports/nrf/common-hal/_bleio/Adapter.c
+msgid "timeout must be < 655.35 secs"
 msgstr ""
 
-#: shared-bindings/_bleio/CharacteristicBuffer.c
-msgid "timeout must be >= 0.0"
+#: shared-module/sdcardio/SDCard.c
+msgid "timeout waiting for v1 card"
+msgstr ""
+
+#: shared-module/sdcardio/SDCard.c
+msgid "timeout waiting for v2 card"
+msgstr ""
+
+#: ports/stm/common-hal/pwmio/PWMOut.c
+msgid "timer re-init"
 msgstr ""
 
 #: shared-bindings/time/__init__.c
 msgid "timestamp out of range for platform time_t"
 msgstr ""
 
-#: shared-module/struct/__init__.c
-msgid "too many arguments provided with the given format"
+#: extmod/ulab/code/ndarray.c
+msgid "tobytes can be invoked for dense arrays only"
+msgstr ""
+
+#: py/compile.c
+msgid "too many args"
+msgstr ""
+
+#: extmod/ulab/code/ndarray.c extmod/ulab/code/numpy/create.c
+msgid "too many dimensions"
 msgstr ""
 
 #: extmod/ulab/code/ndarray.c
 msgid "too many indices"
+msgstr ""
+
+#: py/asmthumb.c
+msgid "too many locals for native method"
 msgstr ""
 
 #: py/runtime.c
@@ -3096,20 +4141,29 @@ msgstr ""
 msgid "too many values to unpack (expected %d)"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c py/objstr.c
-msgid "tuple index out of range"
+#: extmod/ulab/code/numpy/approx.c
+msgid "trapz is defined for 1D arrays of equal length"
+msgstr ""
+
+#: extmod/ulab/code/numpy/approx.c
+msgid "trapz is defined for 1D iterables"
 msgstr ""
 
 #: py/obj.c
 msgid "tuple/list has wrong length"
 msgstr ""
 
-#: shared-bindings/_pixelbuf/PixelBuf.c
-msgid "tuple/list required on RHS"
+#: ports/espressif/common-hal/canio/CAN.c
+#, c-format
+msgid "twai_driver_install returned esp-idf error #%d"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/busio/UART.c ports/nrf/common-hal/busio/UART.c
-#: shared-bindings/busio/UART.c
+#: ports/espressif/common-hal/canio/CAN.c
+#, c-format
+msgid "twai_start returned esp-idf error #%d"
+msgstr ""
+
+#: shared-bindings/busio/UART.c shared-bindings/canio/CAN.c
 msgid "tx and rx cannot both be None"
 msgstr ""
 
@@ -3145,7 +4199,8 @@ msgstr ""
 msgid "unexpected keyword argument"
 msgstr ""
 
-#: py/bc.c py/objnamedtuple.c
+#: py/argcheck.c py/bc.c py/objnamedtuple.c
+#: shared-bindings/traceback/__init__.c
 msgid "unexpected keyword argument '%q'"
 msgstr ""
 
@@ -3154,7 +4209,7 @@ msgid "unicode name escapes"
 msgstr ""
 
 #: py/parse.c
-msgid "unindent does not match any outer indentation level"
+msgid "unindent doesn't match any outer indent level"
 msgstr ""
 
 #: py/objstr.c
@@ -3163,20 +4218,20 @@ msgid "unknown conversion specifier %c"
 msgstr ""
 
 #: py/objstr.c
-#, c-format
-msgid "unknown format code '%c' for object of type '%s'"
+msgid "unknown format code '%c' for object of type '%q'"
 msgstr ""
 
 #: py/compile.c
 msgid "unknown type"
 msgstr ""
 
-#: py/emitnative.c
+#: py/compile.c
 msgid "unknown type '%q'"
 msgstr ""
 
 #: py/objstr.c
-msgid "unmatched '{' in format"
+#, c-format
+msgid "unmatched '%c' in format"
 msgstr ""
 
 #: py/objtype.c py/runtime.c
@@ -3184,7 +4239,6 @@ msgid "unreadable attribute"
 msgstr ""
 
 #: shared-bindings/displayio/TileGrid.c shared-bindings/vectorio/VectorShape.c
-#: shared-module/vectorio/Polygon.c
 msgid "unsupported %q type"
 msgstr ""
 
@@ -3196,6 +4250,14 @@ msgstr ""
 #: py/emitinlinextensa.c
 #, c-format
 msgid "unsupported Xtensa instruction '%s' with %d arguments"
+msgstr ""
+
+#: shared-module/gifio/GifWriter.c
+msgid "unsupported colorspace for GifWriter"
+msgstr ""
+
+#: shared-bindings/bitmaptools/__init__.c
+msgid "unsupported colorspace for dither"
 msgstr ""
 
 #: py/objstr.c
@@ -3212,7 +4274,15 @@ msgid "unsupported type for operator"
 msgstr ""
 
 #: py/runtime.c
-msgid "unsupported types for %q: '%s', '%s'"
+msgid "unsupported types for %q: '%q', '%q'"
+msgstr ""
+
+#: extmod/ulab/code/numpy/io/io.c
+msgid "usecols is too high"
+msgstr ""
+
+#: extmod/ulab/code/numpy/io/io.c
+msgid "usecols keyword must be specified"
 msgstr ""
 
 #: py/objint.c
@@ -3220,31 +4290,62 @@ msgstr ""
 msgid "value must fit in %d byte(s)"
 msgstr ""
 
-#: shared-bindings/displayio/Bitmap.c
-msgid "value_count must be > 0"
+#: shared-bindings/bitmaptools/__init__.c
+msgid "value out of range of target"
 msgstr ""
 
-#: shared-bindings/watchdog/WatchDogTimer.c
-msgid "watchdog timeout must be greater than 0"
+#: extmod/moddeflate.c
+msgid "wbits"
+msgstr ""
+
+#: shared-bindings/is31fl3741/FrameBuffer.c
+msgid "width must be greater than zero"
+msgstr ""
+
+#: ports/espressif/common-hal/wifi/Radio.c
+#: ports/raspberrypi/common-hal/wifi/Radio.c
+msgid "wifi is not enabled"
+msgstr ""
+
+#: ports/raspberrypi/common-hal/wifi/Monitor.c
+msgid "wifi.Monitor not available"
 msgstr ""
 
 #: shared-bindings/_bleio/Adapter.c
 msgid "window must be <= interval"
 msgstr ""
 
-#: extmod/ulab/code/linalg.c
-msgid "wrong argument type"
+#: extmod/ulab/code/numpy/numerical.c
+msgid "wrong axis index"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
+#: extmod/ulab/code/numpy/create.c
+msgid "wrong axis specified"
+msgstr ""
+
+#: extmod/ulab/code/numpy/io/io.c
+msgid "wrong dtype"
+msgstr ""
+
+#: extmod/ulab/code/numpy/transform.c
 msgid "wrong index type"
 msgstr ""
 
-#: extmod/ulab/code/vectorise.c
+#: extmod/ulab/code/numpy/compare.c extmod/ulab/code/numpy/create.c
+#: extmod/ulab/code/numpy/io/io.c extmod/ulab/code/numpy/transform.c
+#: extmod/ulab/code/numpy/vector.c
 msgid "wrong input type"
 msgstr ""
 
-#: py/objstr.c
+#: extmod/ulab/code/numpy/transform.c
+msgid "wrong length of condition array"
+msgstr ""
+
+#: extmod/ulab/code/numpy/transform.c
+msgid "wrong length of index array"
+msgstr ""
+
+#: extmod/ulab/code/numpy/create.c py/objarray.c py/objstr.c
 msgid "wrong number of arguments"
 msgstr ""
 
@@ -3252,29 +4353,37 @@ msgstr ""
 msgid "wrong number of values to unpack"
 msgstr ""
 
-#: extmod/ulab/code/ndarray.c
-msgid "wrong operand type"
-msgstr ""
-
-#: extmod/ulab/code/vectorise.c
+#: extmod/ulab/code/numpy/vector.c
 msgid "wrong output type"
 msgstr ""
 
-#: shared-module/displayio/Shape.c
-msgid "x value out of bounds"
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "zi must be an ndarray"
 msgstr ""
 
-#: shared-bindings/displayio/Shape.c
-msgid "y should be an int"
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "zi must be of float type"
 msgstr ""
 
-#: shared-module/displayio/Shape.c
-msgid "y value out of bounds"
+#: extmod/ulab/code/scipy/signal/signal.c
+msgid "zi must be of shape (n_section, 2)"
 msgstr ""
 
-#: py/objrange.c
-msgid "zero step"
-msgstr ""
+#~ msgid ""
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Captin's orders are complete. Holdin' fast fer reload.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Yar, there is a hole in the keel. Let the cap'n know at\n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
 
 #~ msgid "All event channels "
 #~ msgstr "Avast! All th' event channels "
@@ -3290,6 +4399,18 @@ msgstr ""
 
 #~ msgid "Invalid clock pin"
 #~ msgstr "Avast! Clock pin be invalid"
+
+#~ msgid "Invalid pin for left channel"
+#~ msgstr "Belay that! Invalid pin for port-side channel"
+
+#~ msgid "Invalid pin for right channel"
+#~ msgstr "Belay that! Invalid pin for starboard-side channel"
+
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "Belay that! Th' Pin be not ADC capable"
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Runnin' in safe mode! Auto-reload be off.\n"
 
 #~ msgid "bits must be 8"
 #~ msgstr "pieces must be of 8"

--- a/locale/es.po
+++ b/locale/es.po
@@ -85,16 +85,6 @@ msgstr " salida:\n"
 msgid "%%c requires int or char"
 msgstr "%%c requiere int o char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
@@ -102,26 +92,6 @@ msgid ""
 msgstr ""
 "%d pines de dirección, %d pines rgb y %d tiles indican una altura de %d, y "
 "no de %d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -305,11 +275,6 @@ msgstr "%q[%u] usa un pin extra"
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
 msgstr "%q[%u] espera entrada fuera del contador"
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
-msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
 #, c-format
@@ -710,7 +675,8 @@ msgstr "Buffer no es un bytearray."
 #: ports/stm/common-hal/audiopwmio/PWMAudioOut.c
 #, c-format
 msgid "Buffer length %d too big. It must be less than %d"
-msgstr "La longitud del buffer %d es demasiado grande. Tiene que ser menor a %d"
+msgstr ""
+"La longitud del buffer %d es demasiado grande. Tiene que ser menor a %d"
 
 #: ports/atmel-samd/common-hal/sdioio/SDCard.c
 #: ports/cxd56/common-hal/sdioio/SDCard.c shared-module/sdcardio/SDCard.c
@@ -954,7 +920,8 @@ msgstr "Data es muy grande para el paquete de anuncio"
 
 #: ports/stm/common-hal/alarm/pin/PinAlarm.c
 msgid "Deep sleep pins must use a rising edge with pulldown"
-msgstr "Pines de sueño profundo deben usar eje de subida con jalado hacia abajo"
+msgstr ""
+"Pines de sueño profundo deben usar eje de subida con jalado hacia abajo"
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Destination capacity is smaller than destination_length."
@@ -1207,7 +1174,8 @@ msgstr "Dispositivo I2C en uso"
 
 #: ports/raspberrypi/bindings/rp2pio/StateMachine.c
 msgid "In-buffer elements must be <= 4 bytes long"
-msgstr "Los elementos del búfer de entrada deben ser de una longitud <= 4 bytes"
+msgstr ""
+"Los elementos del búfer de entrada deben ser de una longitud <= 4 bytes"
 
 #: shared-bindings/_pew/PewPew.c
 msgid "Incorrect buffer size"
@@ -1647,8 +1615,9 @@ msgstr "Ok"
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Solo mono de 8 ó 16 bit con "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -1839,7 +1808,8 @@ msgstr "El polígono necesita al menos 3 puntos"
 
 #: supervisor/shared/safe_mode.c
 msgid "Power dipped. Make sure you are providing enough power."
-msgstr "Falta de potencia. Asegura que estás suministrando suficiente potencia."
+msgstr ""
+"Falta de potencia. Asegura que estás suministrando suficiente potencia."
 
 #: shared-bindings/_bleio/Adapter.c
 msgid "Prefix buffer must be on the heap"
@@ -2053,7 +2023,8 @@ msgstr "Lectura de temperatura expirada"
 
 #: supervisor/shared/safe_mode.c
 msgid "The `microcontroller` module was used to boot into safe mode."
-msgstr "El modulo `microcontrolador` fue usado para inicializar en modo seguro."
+msgstr ""
+"El modulo `microcontrolador` fue usado para inicializar en modo seguro."
 
 #: py/obj.c
 msgid "The above exception was the direct cause of the following exception:"
@@ -3757,7 +3728,8 @@ msgstr "no es una constante"
 
 #: py/objstr.c
 msgid "not all arguments converted during string formatting"
-msgstr "no todos los argumentos fueron convertidos durante el formato de string"
+msgstr ""
+"no todos los argumentos fueron convertidos durante el formato de string"
 
 #: py/objstr.c
 msgid "not enough arguments for format string"
@@ -4480,331 +4452,19 @@ msgstr "zi debe ser de tipo flotante"
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi debe ser una forma (n_section,2)"
 
-#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
-#~ msgstr "CIRCUITPY_PYSTACK_SIZE inválido\n"
-
-#~ msgid "Unable to allocate the heap."
-#~ msgstr "Imposible de asignar el heap."
-
 #~ msgid ""
-#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
 #~ msgstr ""
-#~ "espcamera. La cámara requiere una configuración de PSRAM reservada. "
-#~ "Refiérase a la documentación para más instrucciones."
-
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr "'await', 'async for' o 'async with' fuera de la función async"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' fuera de un bucle"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' fuera de un bucle"
-
-#~ msgid "invalid architecture"
-#~ msgstr "arquitectura inválida"
-
-#~ msgid "unsupported type for %q: '%q'"
-#~ msgstr "tipo no soportado para %q: '%q'"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Dividiendo con sub-capturas"
-
-#~ msgid "__init__() should return None, not '%q'"
-#~ msgstr "__init__() debe retornar None, no '%q'"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "atributos aún no soportados"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr "no se puede hacer la división truncada de un número complejo"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "no se puede importar name '%q'"
-
-#~ msgid "cannot unambiguously get sizeof scalar"
-#~ msgstr "no se puede sin ambiguedades traer el sizeof del escalar"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr ""
-#~ "argumento(s) por palabra clave aún no implementados - usa argumentos "
-#~ "normales en su lugar"
-
-#~ msgid "length argument not allowed for this type"
-#~ msgstr "argumento length no permitido para este tipo"
-
-#~ msgid "offset out of bounds"
-#~ msgstr "offset fuera de límites"
-
-#~ msgid "slice step can't be zero"
-#~ msgstr "el tamaño de la división no puede ser cero"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr "string no soportado; usa bytes o bytearray"
-
-#~ msgid "Bit clock and word select must be sequential pins"
-#~ msgstr "Los pines \"clock\" y \"word-select\" deben ser consecutivos"
-
-#~ msgid "Initialization failed due to lack of memory"
-#~ msgstr "Inicializacion fallida por falta de memoria"
-
-#~ msgid "RAISE mode is not implemented"
-#~ msgstr "El modo RAISE no esta implementado"
-
-#~ msgid "WatchDogTimer is not currently running"
-#~ msgstr "WatchDogTimer no se está ejecutando en este momento"
-
-#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-#~ msgstr ""
-#~ "WatchDogTimer.mode no se puede modificar luego de configurar WatchDogMode."
-#~ "RESET"
-
-#~ msgid "watchdog not initialized"
-#~ msgstr "watchdog no inicializado"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "ADC2 está siendo usado por WiFi"
-
-#, c-format
-#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Imposible de configurar el controlador ADC DMA , código de error:%d"
-
-#, c-format
-#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
-#~ msgstr ""
-#~ "No es posible de inicializar el controlador ADC DMA, código de error:%d"
-
-#, c-format
-#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Imposible de iniciar el controlador ADC DMA, código de error:%d"
-
-#~ msgid "xTaskCreate failed"
-#~ msgstr "fallo en xTaskCreate"
-
-#~ msgid "Unable to write to address."
-#~ msgstr "Imposible de escribir en esa dirección."
-
-#~ msgid "queue overflow"
-#~ msgstr "desbordamiento de cola(queue)"
-
-#~ msgid "Stopping AP is not supported."
-#~ msgstr "Parar el AP no esta soportado."
-
-#~ msgid "Wifi is in access point mode."
-#~ msgstr "Wifi est en modo de access point."
-
-#~ msgid "Wifi is in station mode."
-#~ msgstr "Wifi esta en modo station."
+#~ "\n"
+#~ "El código terminó su ejecución. Esperando para recargar.\n"
 
 #~ msgid ""
 #~ "\n"
-#~ "Please file an issue with your program at https://github.com/adafruit/"
-#~ "circuitpython/issues."
+#~ "Code stopped by auto-reload.\n"
 #~ msgstr ""
 #~ "\n"
-#~ "Por favor describa su problema en https://github.com/adafruit/"
-#~ "circuitpython/issues."
-
-#~ msgid "'coroutine' object is not an iterator"
-#~ msgstr "el objeto 'coroutine' no es un iterador"
-
-#~ msgid "Buffer is too small"
-#~ msgstr "Buffer es muy pequeño"
-
-#~ msgid "Fault detected by hardware."
-#~ msgstr "Falló detectado por el hardware."
-
-#~ msgid "The power dipped. Make sure you are providing enough power."
-#~ msgstr ""
-#~ "La potencia calló. Asegúrese que está suministrando suficiente energía."
-
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-#~ msgstr "pixel_shader debe ser displayio.Palette o displayio.ColorConverter"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "Archivo .mpy corrupto"
-
-#~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
-#~ msgstr ""
-#~ "Archivo .mpy incompatible. Actualice todos los archivos .mpy. Consulte "
-#~ "http://adafru.it/mpy-update para más información."
-
-#~ msgid "can't convert to %q"
-#~ msgstr "no puede convertir a %q"
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "no puede tener multiples *x"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "no puede tener multiples *x"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "constant debe ser un entero"
-
-#~ msgid "incompatible native .mpy architecture"
-#~ msgstr "arquitectura nativa de .mpy incompatible"
-
-#~ msgid "invalid format"
-#~ msgstr "formato inválido"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "palabras clave deben ser strings"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "no deberia estar/tener agumento por palabra clave despues de */**"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr ""
-#~ "no deberia estar/tener agumento por palabra clave despues de argumento "
-#~ "por palabra clave"
-
-#, c-format
-#~ msgid "Instruction %d shifts in more bits than pin count"
-#~ msgstr "La instruccion %d mueve mas bits que la cuenta del pin"
-
-#, c-format
-#~ msgid "Instruction %d shifts out more bits than pin count"
-#~ msgstr "La instrucción %d mueve mas bits que la cuenta del pin"
-
-#, c-format
-#~ msgid "Instruction %d uses extra pin"
-#~ msgstr "La instrucción %d usa un pin extra"
-
-#, c-format
-#~ msgid "Instruction %d waits on input outside of count"
-#~ msgstr "La instrucción %d espera una entrada fuera del conteo"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
-#~ msgstr "first-in-pin no encontrado. La instrucción %d lee el/los pin(es)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
-#~ msgstr ""
-#~ "first_in_pin no encontrado. La instrucción %d desplaza de los pin(es)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
-#~ msgstr ""
-#~ "first_in_pin no encontrado. La instrucción %d espera basada en este pin"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
-#~ msgstr ""
-#~ "first_in_pin no encontrado. La instrucción %d mueve hacia afuera hacia el/"
-#~ "los pin(es)"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
-#~ msgstr "first_in_pin no encontrado. La instrucción %d escribe pin(es)"
-
-#, c-format
-#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
-#~ msgstr ""
-#~ "first_set_pin no encontrado. La instrucción %d configura el/los pin(es)"
-
-#, c-format
-#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
-#~ msgstr "Falta el jmp_pin. La instrucción %d se dispara en el pin"
-
-#~ msgid "inputs are not iterable"
-#~ msgstr "Entradas no son iterables"
-
-#~ msgid "Too many display busses"
-#~ msgstr "Demasiados buses de pantalla"
-
-#~ msgid "Cannot transfer without MOSI and MISO pins"
-#~ msgstr "No puede ser transferido si los pines MOSI y MISO"
-
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Hardware ocupado, pruebe pines alternativos"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "Falta el pin MISO o MOSI"
-
-#~ msgid "Missing MISO or MOSI pin"
-#~ msgstr "Falta el pin MISO o MOSI"
-
-#~ msgid "No MISO Pin"
-#~ msgstr "Sin pin MISO"
-
-#~ msgid "No MISO pin"
-#~ msgstr "No pin MISO"
-
-#~ msgid "No MOSI Pin"
-#~ msgstr "Sin pin MOSI"
-
-#~ msgid "No MOSI pin"
-#~ msgstr "No pin MOSI"
-
-#~ msgid "No RX pin"
-#~ msgstr "Sin pin RX"
-
-#~ msgid "No TX pin"
-#~ msgstr "Sin pin TX"
-
-#~ msgid "no reset pin available"
-#~ msgstr "no hay pin de reinicio disponible"
-
-#~ msgid "Sleep Memory not available"
-#~ msgstr "Memoria de sueño no disponible"
-
-#~ msgid "input and output shapes are not compatible"
-#~ msgstr "Formas de entrada y salida no son compatibles"
-
-#~ msgid "shape must be a tuple"
-#~ msgstr "forma tiene que ser una tupla"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "El brillo debe ser 0-1.0"
-
-#, c-format
-#~ msgid "Error in MIDI stream at position %d"
-#~ msgstr "Error en el flujo MIDI en la posición %d"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "Valor máximo de x cuando se refleja es %d"
-
-#~ msgid "x value out of bounds"
-#~ msgstr "valor x fuera de límites"
-
-#~ msgid "y value out of bounds"
-#~ msgstr "valor y fuera de límites"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "I2SOut no disponible"
-
-#~ msgid "PDMIn not available"
-#~ msgstr "PDMIn no esta disponible"
-
-#~ msgid "out of range of source"
-#~ msgstr "fuera de rango de fuente"
-
-#~ msgid "pixel value requires too many bits"
-#~ msgstr "valor del pixel require demasiado bits"
-
-#~ msgid "value_count must be > 0"
-#~ msgstr "value_count debe ser > 0"
-
-#~ msgid "64 bit types"
-#~ msgstr "tipos de 64 bit"
-
-#~ msgid "No key was specified"
-#~ msgstr "No se especificó ninguna llave"
-
-#~ msgid "Scan already in progess. Stop with stop_scan."
-#~ msgstr "Escaneo en progreso. Usa stop_scan para detener."
-
-#, c-format
-#~ msgid "Unkown error code %d"
-#~ msgstr "Codigo de error desconocido: %d"
-
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "demasiados argumentos provistos con el formato dado"
+#~ "El código fue detenido por el auto-reiniciado.\n"
 
 #~ msgid ""
 #~ "\n"
@@ -4817,12 +4477,6 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ "\n"
 #~ "\n"
 
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "Suministre al menos un pin UART"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "pin inválido %q"
-
 #~ msgid ""
 #~ "\n"
 #~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
@@ -4832,712 +4486,47 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ "Presente un problema con el contenido de su unidad CIRCUITPY en\n"
 #~ "https://github.com/adafruit/circuitpython/issues\n"
 
-#~ msgid "Attempted heap allocation when VM not running."
-#~ msgstr "Asignación del montículo mientras la VM no esta ejecutándose."
-
-#~ msgid "Boot device must be first device (interface #0)."
+#~ msgid ""
+#~ "\n"
+#~ "Please file an issue with your program at https://github.com/adafruit/"
+#~ "circuitpython/issues."
 #~ msgstr ""
-#~ "El dispositivo de arranque debe de ser el primer dispositivo (interfase "
-#~ "#0)."
-
-#~ msgid "Both buttons were pressed at start up.\n"
-#~ msgstr "Ambos botones fueron prensados al inicio\n"
-
-#~ msgid "Button A was pressed at start up.\n"
-#~ msgstr "Botón A fue presionado al inicio.\n"
-
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "CircuitPython no puedo encontrar el montículo."
-
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "Choque contra el HardFault_Handler."
-
-#~ msgid "Fatal error."
-#~ msgstr "Error grave."
-
-#~ msgid "Invalid memory access."
-#~ msgstr "Acceso a memoria no válido."
-
-#~ msgid "Nordic system firmware failure assertion."
-#~ msgstr "Falla en la aserción del firmware del dispositivo Nordic."
-
-#~ msgid "The BOOT button was pressed at start up.\n"
-#~ msgstr "El boton BOOT fur presionado durante el arranque.\n"
+#~ "\n"
+#~ "Por favor describa su problema en https://github.com/adafruit/"
+#~ "circuitpython/issues."
 
 #~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Increase the stack size if you know how. If not:"
+#~ "\n"
+#~ "To exit, please reset the board without "
 #~ msgstr ""
-#~ "El montículo de CircuitPython está corrupto porque la pila era muy "
-#~ "pequeña.\n"
-#~ "Aumente el tamaño de pila si sabe como. De lo contrario:"
-
-#~ msgid "The SW38 button was pressed at start up.\n"
-#~ msgstr "El boton SW38 fue presionado durante el arranque.\n"
-
-#~ msgid "The VOLUME button was pressed at start up.\n"
-#~ msgstr "El boton de Volumen fue presionado durante el arranque.\n"
-
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode."
-#~ msgstr ""
-#~ "El módulo de `microcontroller` se usó para un arranque en modo seguro. "
-#~ "Presione reset para salir del modo seguro."
-
-#~ msgid "The central button was pressed at start up.\n"
-#~ msgstr "El boton central fue presionado durante el arranque.\n"
-
-#~ msgid "The left button was pressed at start up.\n"
-#~ msgstr "El boton izquierdo fue presionado durante el arranque.\n"
-
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY)."
-#~ msgstr ""
-#~ "La corriente eléctrica de la microcontroladora bajó. Asegúrate que tu "
-#~ "fuente de poder provee\n"
-#~ "suficiente corriente para todo el circuito y presiones reset (luego de "
-#~ "expulsar CIRCUITPY)."
-
-#~ msgid "To exit, please reset the board without requesting safe mode."
-#~ msgstr "Para salir, por favor reinicialice la tarjeta sin pedir safe mode."
-
-#~ msgid "You are in safe mode because:\n"
-#~ msgstr "Estás en modo seguro por la razón:\n"
-
-#~ msgid ""
-#~ "You pressed the reset button during boot. Press again to exit safe mode."
-#~ msgstr ""
-#~ "Has presionado el botón de reset durante el arranque. Presiones de nuevo "
-#~ "para salir del modo seguro."
-
-#~ msgid ""
-#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
-#~ msgstr ""
-#~ "esp32_camera. la camara necesita PSRAM reservada para ser configurada. "
-#~ "Vea la documentacion para mas instrucciones."
-
-#~ msgid "%q must be of type %q"
-#~ msgstr "%q debe ser de typo %q"
-
-#~ msgid "%q must be of type %q or None"
-#~ msgstr "%q debe ser de tipo %q o None"
-
-#~ msgid "Expected a %q"
-#~ msgstr "Se espera un %q"
+#~ "\n"
+#~ "Para salir, favor reinicie la tarjeta sin "
 
 #, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IV debe tener %d bytes de longitud"
+#~ msgid "%02X"
+#~ msgstr "%02X"
 
-#~ msgid "Not settable"
-#~ msgstr "No configurable"
+#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+#~ msgstr ""
+#~ "%d pines de dirección y %d pines rgb indican una altura de %d, no de %d"
 
-#~ msgid "expected '%q' but got '%q'"
-#~ msgstr "se espera '%q' pero se recibe '%q'"
+#~ msgid "%q"
+#~ msgstr "%q"
 
-#~ msgid "expected '%q' or '%q' but got '%q'"
-#~ msgstr "se espera '%q' o '%q' pero se recibe '%q'"
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "índices %q deben ser enteros, no %q"
 
-#~ msgid "Read-only object"
-#~ msgstr "Objeto de solo-lectura"
+#~ msgid "%q length must be %q"
+#~ msgstr "el tamaño de %q debe ser %q"
 
 #~ msgid "%q length must be >= 1"
 #~ msgstr "%q tamaño debe ser >= 1"
 
-#~ msgid "%q must be a string"
-#~ msgstr "%q debe ser una cadena"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "Como máximo %d %q se puede especificar (no %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "pines inválidos"
-
-#, c-format
-#~ msgid "No more than %d HID devices allowed"
-#~ msgstr "No se permiten más de %d dispositivos HID permitidos"
-
-#~ msgid "byteorder is not a string"
-#~ msgstr "byteorder no es una cadena"
-
-#~ msgid "can't convert %q to int"
-#~ msgstr "no se puede convertir %q a int"
-
-#~ msgid "complex division by zero"
-#~ msgstr "división compleja por cero"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr "int() arg 2 debe ser >= 2 y <= 36"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "long int no soportado en esta compilación"
-
-#~ msgid "slice step cannot be zero"
-#~ msgstr "slice step no puede ser cero"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "paso debe ser numero no cero"
-
-#~ msgid "string indices must be integers, not %q"
-#~ msgstr "índices de cadena deben ser enteros, no %q"
-
-#~ msgid "time.struct_time() takes a 9-sequence"
-#~ msgstr "time.struct_time() toma un sequencio 9"
-
-#~ msgid "zero step"
-#~ msgstr "paso cero"
-
-#~ msgid "WatchDogTimer.timeout must be greater than 0"
-#~ msgstr "WatchDogTimer.timeout debe ser mayor a 0"
-
-#~ msgid "non-Device in %q"
-#~ msgstr "hay un no-Device en %q"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "un solo '}' encontrado en format string"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "limite debe ser en el rango 0-65536"
-
-#~ msgid "timeout must be 0.0-100.0 seconds"
-#~ msgstr "el tiempo de espera debe ser 0.0-100.0 segundos"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "No coinciden '{' en format"
-
-#~ msgid "watchdog timeout must be greater than 0"
-#~ msgstr "el tiempo de espera del perro guardián debe ser mayor a 0"
-
-#~ msgid "To exit, please reset the board without "
-#~ msgstr "Para salir, por favor reinicia la tarjeta sin "
-
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "Solicitaste iniciar en modo seguro por "
-
-#~ msgid "pressing boot button at start up.\n"
-#~ msgstr "presionando botón de arranque al inicio.\n"
-
-#~ msgid "pressing both buttons at start up.\n"
-#~ msgstr "presionando ambos botones al inicio.\n"
-
-#~ msgid "pressing the left button at start up\n"
-#~ msgstr "presione el botón izquierdo al arranque\n"
-
-#~ msgid "Only one TouchAlarm can be set in deep sleep."
-#~ msgstr "Solamente una TouchAlarm puede ser configurada durante deep sleep."
-
-#~ msgid "Firmware image is invalid"
-#~ msgstr "La imagen de firmware es inválida"
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "A Stream le falta el método readinto() o write()."
-
-#~ msgid "%q must be >= 0"
-#~ msgstr "%q debe ser >= 0"
-
-#~ msgid "%q must be >= 1"
-#~ msgstr "%q debe ser >= 1"
-
-#~ msgid "address out of bounds"
-#~ msgstr "address fuera de límites"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr "destination_length debe ser un int >= 0"
-
-#~ msgid "type object 'generator' has no attribute '__await__'"
-#~ msgstr "objeto tipo 'generator' no tiene un atributo '__await__'"
-
-#~ msgid "color should be an int"
-#~ msgstr "color deberia ser un int"
-
-#~ msgid "end_x should be an int"
-#~ msgstr "end_x debe ser un int"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "palette_index deberia ser un int"
-
-#~ msgid "start_x should be an int"
-#~ msgstr "start_x deberia ser un int"
-
-#~ msgid "y should be an int"
-#~ msgstr "y deberia ser un int"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "sample_source buffer debe ser un bytearray o un array de tipo 'h', 'H', "
-#~ "'b' o'B'"
-
-#~ msgid "Expected an alarm"
-#~ msgstr "Un objecto alarm era esperado"
-
-#~ msgid "Failed to init wifi"
-#~ msgstr "Fallo al inicializar wifi"
-
-#~ msgid "input must be a tensor of rank 2"
-#~ msgstr "Entrada tiene que ser un tensor de rango 2"
-
-#~ msgid "maximum number of dimensions is 4"
-#~ msgstr "Máximo número de dimensiones es 4"
-
-#~ msgid "Watchdog timer expired."
-#~ msgstr "Temporizador de perro guardián expirado."
-
-#~ msgid "%q must be a tuple of length 2"
-#~ msgstr "%q debe ser una tupla de longitud 2"
-
-#~ msgid "%q must be between %d and %d"
-#~ msgstr "%q debe estar entre %d y %d"
-
-#~ msgid "%q should be an int"
-#~ msgstr "%q debe ser un int"
-
-#~ msgid "Address type out of range"
-#~ msgstr "Tipo de dirección fuera de rango"
-
-#~ msgid "AnalogIn not supported on given pin"
-#~ msgstr "El pin proporcionado no soporta AnalogIn"
-
-#~ msgid "AnalogOut functionality not supported"
-#~ msgstr "Funcionalidad AnalogOut no soportada"
-
-#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-#~ msgstr "AnalogOut es solo de 16 bits. El valor debe ser menor que 65536."
-
-#~ msgid "AnalogOut not supported on given pin"
-#~ msgstr "El pin proporcionado no soporta AnalogOut"
-
-#, c-format
-#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
-#~ msgstr "Bit depth tiene que ser de 1 a 6 inclusivo, no %d"
-
-#, c-format
-#~ msgid "Buffer incorrect size. Should be %d bytes."
-#~ msgstr "Tamaño de buffer incorrecto. Debe ser de %d bytes."
-
-#~ msgid "Buffer must be at least length 1"
-#~ msgstr "Buffer debe ser de longitud 1 como minimo"
-
-#~ msgid "Bytes must be between 0 and 255."
-#~ msgstr "Bytes debe estar entre 0 y 255."
-
-#~ msgid "Cannot output both channels on the same pin"
-#~ msgstr "No se puede tener ambos canales en el mismo pin"
-
-#~ msgid "Cannot read without MISO pin."
-#~ msgstr "No se puede leer sin pin MISO."
-
-#~ msgid "Cannot reset into bootloader because no bootloader is present."
-#~ msgstr ""
-#~ "No se puede reiniciar a bootloader porque no hay bootloader presente."
-
-#~ msgid "Cannot transfer without MOSI and MISO pins."
-#~ msgstr "No se puede transmitir sin pines MOSI y MISO."
-
-#~ msgid "Cannot write without MOSI pin."
-#~ msgstr "No se puede escribir sin pin MOSI."
-
-#~ msgid "Clock pin init failed."
-#~ msgstr "Iniciado de pin de reloj fallido."
-
-#~ msgid "Command must be an int between 0 and 255"
-#~ msgstr "Command debe ser un int entre 0 y 255"
-
-#~ msgid "Could not initialize Camera"
-#~ msgstr "No se puede inicializar Camera"
-
-#~ msgid "Could not initialize GNSS"
-#~ msgstr "No se pudo inicializar el GNSS"
-
-#~ msgid "Could not initialize SDCard"
-#~ msgstr "No se pudo inicializar SDCard"
-
-#~ msgid "Could not initialize UART"
-#~ msgstr "No se puede inicializar la UART"
-
-#~ msgid "Could not re-init channel"
-#~ msgstr "No se pudo reiniciar el canal"
-
-#~ msgid "Could not re-init timer"
-#~ msgstr "No se pudo reiniciar el temporizador"
-
-#~ msgid "Could not restart PWM"
-#~ msgstr "No se pudo reiniciar el PWM"
-
-#~ msgid "Couldn't allocate first buffer"
-#~ msgstr "No se pudo asignar el primer buffer"
-
-#~ msgid "Couldn't allocate input buffer"
-#~ msgstr "No se pudo encontrar el buffer de entrada"
-
-#~ msgid "Couldn't allocate second buffer"
-#~ msgstr "No se pudo asignar el segundo buffer"
-
-#~ msgid "DigitalInOut not supported on given pin"
-#~ msgstr "DigitalInOut no es compatible con un pin dado"
-
-#, c-format
-#~ msgid "Expected tuple of length %d, got %d"
-#~ msgstr "Se esperaba un tuple de %d, se obtuvo %d"
-
-#~ msgid "Failed to allocate RX buffer"
-#~ msgstr "Ha fallado la asignación del buffer RX"
-
-#, c-format
-#~ msgid "Failed to allocate RX buffer of %d bytes"
-#~ msgstr "Falló la asignación del buffer RX de %d bytes"
-
-#, c-format
-#~ msgid "Framebuffer requires %d bytes"
-#~ msgstr "Framebuffer requiere %d bytes"
-
-#~ msgid "Hostname must be between 1 and 253 characters"
-#~ msgstr "Hostname debe ser entre 1 y 253 caracteres"
-
-#~ msgid "I2C Init Error"
-#~ msgstr "I2C Error de inicio"
-
-#~ msgid "Invalid %q pin selection"
-#~ msgstr "selección inválida de pin %q"
-
-#~ msgid "Invalid AuthMode"
-#~ msgstr "AuthMode invalido"
-
-#~ msgid "Invalid BMP file"
-#~ msgstr "Archivo BMP inválido"
-
-#~ msgid "Invalid DAC pin supplied"
-#~ msgstr "Pin suministrado inválido para DAC"
-
-#~ msgid "Invalid MIDI file"
-#~ msgstr "Archivo MIDI inválido"
-
-#~ msgid "Invalid PWM frequency"
-#~ msgstr "Frecuencia PWM inválida"
-
-#~ msgid "Invalid Pin"
-#~ msgstr "Pin inválido"
-
-#~ msgid "Invalid buffer size"
-#~ msgstr "Tamaño de buffer inválido"
-
-#~ msgid "Invalid byteorder string"
-#~ msgstr "Cadena de byteorder inválida"
-
-#~ msgid "Invalid capture period. Valid range: 1 - 500"
-#~ msgstr "Inválido periodo de captura. Rango válido: 1 - 500"
-
-#~ msgid "Invalid channel count"
-#~ msgstr "Cuenta de canales inválida"
-
-#, c-format
-#~ msgid "Invalid data_count %d"
-#~ msgstr "data_count inválido %d"
-
-#~ msgid "Invalid direction."
-#~ msgstr "Dirección inválida."
-
-#~ msgid "Invalid file"
-#~ msgstr "Archivo inválido"
-
-#~ msgid "Invalid number of bits"
-#~ msgstr "Numero inválido de bits"
-
-#~ msgid "Invalid phase"
-#~ msgstr "Fase inválida"
-
-#~ msgid "Invalid pin"
-#~ msgstr "Pin inválido"
-
-#~ msgid "Invalid pin for left channel"
-#~ msgstr "Pin inválido para canal izquierdo"
-
-#~ msgid "Invalid pin for right channel"
-#~ msgstr "Pin inválido para canal derecho"
-
-#~ msgid "Invalid polarity"
-#~ msgstr "Polaridad inválida"
-
-#~ msgid "Invalid properties"
-#~ msgstr "Propiedades inválidas"
-
-#~ msgid "Invalid run mode."
-#~ msgstr "Modo de ejecución inválido."
-
-#~ msgid "Invalid security_mode"
-#~ msgstr "'security_mode' no válido"
-
-#~ msgid "Invalid voice"
-#~ msgstr "Voz inválida"
-
-#~ msgid "Invalid voice count"
-#~ msgstr "Cuenta de voces inválida"
-
-#~ msgid "Invalid wave file"
-#~ msgstr "Archivo wave inválido"
-
-#~ msgid "Invalid word/bit length"
-#~ msgstr "Tamaño no válido de palabra/bit"
-
-#~ msgid "Layer already in a group."
-#~ msgstr "La capa ya pertenece a un grupo."
-
-#~ msgid "Layer must be a Group or TileGrid subclass."
-#~ msgstr "Layer debe ser una subclase de Group o TileGrid."
-
-#~ msgid "MISO pin init failed."
-#~ msgstr "MISO pin init fallido."
-
-#~ msgid "MOSI pin init failed."
-#~ msgstr "MOSI pin init fallido."
-
-#~ msgid "Messages limited to 8 bytes"
-#~ msgstr "Mensajes limitados a 8 bytes"
-
-#~ msgid "No hardware support on clk pin"
-#~ msgstr "Sin soporte de hardware en el pin clk"
-
-#~ msgid "No hardware support on pin"
-#~ msgstr "Sin soporte de hardware en pin"
-
-#, c-format
-#~ msgid "Output buffer must be at least %d bytes"
-#~ msgstr "buffer de salida debe ser de por lo menos %d bytes"
-
-#~ msgid ""
-#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-#~ msgstr ""
-#~ "PWM duty_cycle debe ser entre 0 y 65535 inclusivo (16 bit resolution)"
-
-#~ msgid "Pin count must be at least 1"
-#~ msgstr "El total de pines debe ser por lo menos 1"
-
-#~ msgid "Pin does not have ADC capabilities"
-#~ msgstr "Pin no tiene capacidad ADC"
-
-#~ msgid "Program must contain at least one 16-bit instruction."
-#~ msgstr "El programa debe contener por lo menos una instrucción de 16 bits."
-
-#~ msgid "Program too large"
-#~ msgstr "Programa demasiado grande"
-
-#~ msgid "RS485 Not yet supported on this device"
-#~ msgstr "RS485 no esta soportado todavía en este dispositivo"
-
-#~ msgid "RTC calibration is not supported on this board"
-#~ msgstr "Calibración de RTC no es soportada en esta placa"
-
-#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
-#~ msgstr "Sin capacidad de RTS/CTS/RS485 para este dispositivo"
-
-#~ msgid "SPI Init Error"
-#~ msgstr "Error de inicio de SPI"
-
-#~ msgid "SPI Re-initialization error"
-#~ msgstr "Error de reinicialización de SPI"
-
-#~ msgid "Sample rate must be positive"
-#~ msgstr "Sample rate debe ser positivo"
-
-#, c-format
-#~ msgid "Sample rate too high. It must be less than %d"
-#~ msgstr "Frecuencia de muestreo demasiado alta. Debe ser menor a %d"
-
-#~ msgid "Set pin count must be between 1 and 5"
-#~ msgstr "La suma de pines configurados debe estar entre 1 y 5"
-
-#~ msgid "Side set pin count must be between 1 and 5"
-#~ msgstr "El conteo de pines de Side set debe estar entre 1 y 5"
-
-#~ msgid "Stack size must be at least 256"
-#~ msgstr "El tamaño de la pila debe ser de al menos 256"
-
-#~ msgid "Tile value out of bounds"
-#~ msgstr "Valor de mosaico fuera de límites"
-
-#~ msgid "UART Buffer allocation error"
-#~ msgstr "No se pudo encontrar el búfer para UART"
-
-#~ msgid "UART De-init error"
-#~ msgstr "Error de desinicialización de UART"
-
-#~ msgid "UART Init Error"
-#~ msgstr "Error de inicialización de UART"
-
-#~ msgid "UART Re-init error"
-#~ msgstr "Error de reinicialización de UART"
-
-#~ msgid "UART write error"
-#~ msgstr "Error de escritura UART"
-
-#~ msgid "Unsupported baudrate"
-#~ msgstr "Baudrate no soportado"
-
-#~ msgid "WiFi password must be between 8 and 63 characters"
-#~ msgstr "La clave de WiFi debe ser entre 8 y 63 caracteres"
-
-#~ msgid "bits must be in range 5 to 9"
-#~ msgstr "los bits deben estar en el rango de 5 a 9"
-
-#~ msgid "bytes > 8 bits not supported"
-#~ msgstr "bytes > 8 bits no soportados"
-
-#~ msgid "calibration value out of range +/-127"
-#~ msgstr "Valor de calibración fuera del rango +/-127"
-
-#~ msgid "circle can only be registered in one parent"
-#~ msgstr "circulo solo puede ser registrado con un pariente"
-
-#~ msgid "max_length must be >= 0"
-#~ msgstr "max_length debe ser >= 0"
-
-#~ msgid "polygon can only be registered in one parent"
-#~ msgstr "el polígono solo se puede registrar en uno de los padres"
-
-#~ msgid "pull_threshold must be between 1 and 32"
-#~ msgstr "pull_threshold debe esta entre 1 y 32"
-
-#~ msgid "push_threshold must be between 1 and 32"
-#~ msgstr "push_threshold debe esta entre 1 y 32"
-
-#~ msgid "stop must be 1 or 2"
-#~ msgstr "stop debe ser 1 ó 2"
-
-#~ msgid "tile must be greater than zero"
-#~ msgstr "tile debe sera mas grande que cero"
-
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "tiempo muerto debe ser >= 0.0"
-
-#, c-format
-#~ msgid "width must be from 2 to 8 (inclusive), not %d"
-#~ msgstr "ancho debe estar entre 2 y 8 (inclusivamente), no %d"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "Operación no soportada"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code stopped by auto-reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "El código fue detenido por el auto-reiniciado.\n"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "El brillo debe estar entro 0 y 255"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "no se puedo realizar importación relativa"
-
-#, c-format
-#~ msgid "No I2C device at address: %x"
-#~ msgstr "No hay dispositivo I2C en la dirección: %x"
-
-#~ msgid "Unsupported pull value."
-#~ msgstr "valor pull no soportado."
-
-#~ msgid "%q must <= %d"
-#~ msgstr "%q debe ser <= %d"
-
-#, c-format
-#~ msgid ""
-#~ "Welcome to Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Please visit learn.adafruit.com/category/circuitpython for project "
-#~ "guides.\n"
-#~ "\n"
-#~ "To list built-in modules please do `help(\"modules\")`.\n"
-#~ msgstr ""
-#~ "Bienvenido a Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Visita learn.adafruit.com/category/circuitpython para obtener guías de "
-#~ "proyectos.\n"
-#~ "\n"
-#~ "Para listar los módulos incorporados por favor haga `help(\"modules\")`.\n"
-
-#~ msgid "integer required"
-#~ msgstr "Entero requerido"
-
-#~ msgid "abort() called"
-#~ msgstr "se llamó abort()"
-
-#~ msgid "f-string expression part cannot include a '#'"
-#~ msgstr "La parte de expresión f-string no puede incluir un '#'"
-
-#~ msgid "f-string expression part cannot include a backslash"
-#~ msgstr "La parte de expresión f-string no puede incluir una barra invertida"
-
-#~ msgid "f-string: empty expression not allowed"
-#~ msgstr "cadena-f: expresión vacía no permitida"
-
-#~ msgid "f-string: expecting '}'"
-#~ msgstr "f-string: esperando '}'"
-
-#~ msgid "f-string: single '}' is not allowed"
-#~ msgstr "cadena-f: solo '}' no está permitido"
-
-#~ msgid "invalid arguments"
-#~ msgstr "argumentos inválidos"
-
-#~ msgid "raw f-strings are not implemented"
-#~ msgstr "no está implementado cadenas-f sin procesar"
-
-#~ msgid "unindent does not match any outer indentation level"
-#~ msgstr "sangría no coincide con ningún nivel exterior"
-
 #~ msgid "%q list must be a list"
 #~ msgstr "%q lista debe ser una lista"
 
-#~ msgid "%q must of type %q"
-#~ msgstr "%q debe ser de tipo %q"
-
-#~ msgid "Column entry must be digitalio.DigitalInOut"
-#~ msgstr "Entrada de columna debe ser digitalio.DigitalInOut"
-
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Se esperaba una Característica"
-
-#~ msgid "Expected a DigitalInOut"
-#~ msgstr "Se espera un DigitalInOut"
-
-#~ msgid "Expected a Service"
-#~ msgstr "Se esperaba un servicio"
-
-#~ msgid "Expected a UART"
-#~ msgstr "Se espera un UART"
-
-#~ msgid "Expected a UUID"
-#~ msgstr "Se esperaba un UUID"
-
-#~ msgid "Expected an Address"
-#~ msgstr "Se esperaba una dirección"
-
-#~ msgid "Row entry must be digitalio.DigitalInOut"
-#~ msgstr "La entrada de la fila debe ser digitalio.DigitalInOut"
-
-#~ msgid "buttons must be digitalio.DigitalInOut"
-#~ msgstr "los botones necesitan ser digitalio.DigitalInOut"
-
-#~ msgid "Invalid frequency"
-#~ msgstr "Frecuencia inválida"
-
-#~ msgid "Data 0 pin must be byte aligned."
-#~ msgstr "El pin de datos 0 debe ser alineado a byte."
-
-#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
-#~ msgstr ""
-#~ "los bits_per_pixel %d no son validos, deben ser 1, 4, 8, 16, 24 o 32"
-
-#~ msgid "ParallelBus not yet supported"
-#~ msgstr "ParallelBus todavía no soportado"
-
-#~ msgid "%q length must be %q"
-#~ msgstr "el tamaño de %q debe ser %q"
+#~ msgid "%q must <= %d"
+#~ msgstr "%q debe ser <= %d"
 
 #~ msgid "%q must be 0-255"
 #~ msgstr "%q debe ser de 0-255"
@@ -5545,104 +4534,44 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "%q must be 1-255"
 #~ msgstr "%q debe estar entre 1-255"
 
-#~ msgid "%q must be None or between 1 and len(report_descriptor)-1"
-#~ msgstr "%q debe ser None o entre 1 y len(report_descriptor)-1"
+#~ msgid "%q must be >= 0"
+#~ msgstr "%q debe ser >= 0"
 
-#~ msgid "no available NIC"
-#~ msgstr "NIC no disponible"
-
-#~ msgid ""
-#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
-#~ "instead"
-#~ msgstr ""
-#~ "Port no acepta un carrier de PWM. Pase en cambio un pin, una frecuencia o "
-#~ "un ciclo de actividad"
-
-#~ msgid ""
-#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
-#~ "Carrier instead"
-#~ msgstr ""
-#~ "Port no acepta los pines o la frecuencia. Construya y pase en su lugar un "
-#~ "Carrier de PWMOut"
-
-#~ msgid "Instruction %d jumps on pin"
-#~ msgstr "La instruction %d salta en pin"
-
-#~ msgid "%q must store bytes"
-#~ msgstr "%q debe almacenar bytes"
-
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "Buffer demasiado grande e incapaz de asignar"
-
-#~ msgid "interp is defined for 1D arrays of equal length"
-#~ msgstr "interp está definido para arreglos de 1D del mismo tamaño"
-
-#~ msgid "trapz is defined for 1D arrays"
-#~ msgstr "trapz esta definido para matrices 1D"
-
-#~ msgid "wrong operand type"
-#~ msgstr "tipo de operando incorrecto"
+#~ msgid "%q must be >= 1"
+#~ msgstr "%q debe ser >= 1"
 
 #~ msgid "%q must be None or 1-255"
 #~ msgstr "%q debe ser None o 1-255"
 
-#~ msgid "Only raw int or string supported for ip"
-#~ msgstr "Para ip solo puede con un entero o una cadena"
+#~ msgid "%q must be None or between 1 and len(report_descriptor)-1"
+#~ msgstr "%q debe ser None o entre 1 y len(report_descriptor)-1"
 
-#~ msgid "Only raw int supported for ip"
-#~ msgstr "Solo se aceptan enteros crudos para ip"
+#~ msgid "%q must be a string"
+#~ msgstr "%q debe ser una cadena"
 
-#~ msgid ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
-#~ msgstr ""
-#~ "CircuitPython está en modo seguro porque presionó el botón de reinicio "
-#~ "durante el arranque. Presione nuevamente para salir del modo seguro.\n"
+#~ msgid "%q must be a tuple of length 2"
+#~ msgstr "%q debe ser una tupla de longitud 2"
 
-#~ msgid "Not running saved code.\n"
-#~ msgstr "No ejecutando el código almacenado.\n"
+#~ msgid "%q must be between %d and %d"
+#~ msgstr "%q debe estar entre %d y %d"
 
-#~ msgid "Running in safe mode! "
-#~ msgstr "¡Corriendo en modo seguro! "
+#~ msgid "%q must be of type %q"
+#~ msgstr "%q debe ser de typo %q"
 
-#~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Please increase the stack size if you know how, or if not:"
-#~ msgstr ""
-#~ "El heap de CircuitPython se dañó porque la pila era demasiado pequeña.\n"
-#~ "Aumente el tamaño de la pila si sabe cómo, o si no:"
+#~ msgid "%q must be of type %q or None"
+#~ msgstr "%q debe ser de tipo %q o None"
 
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode.\n"
-#~ msgstr ""
-#~ "El módulo de `microcontroller` fue utilizado para arrancar en modo "
-#~ "seguro. Presiona reset para salir del modo seguro.\n"
+#~ msgid "%q must of type %q"
+#~ msgstr "%q debe ser de tipo %q"
 
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY).\n"
-#~ msgstr ""
-#~ "La alimentación del microntrolador bajó. Asegúrate que tu fuente de "
-#~ "alimentación\n"
-#~ "pueda aportar suficiente energía para todo el circuito y presiona reset "
-#~ "(luego de expulsar CIRCUITPY)\n"
+#~ msgid "%q must store bytes"
+#~ msgstr "%q debe almacenar bytes"
 
-#~ msgid "You are in safe mode: something unanticipated happened.\n"
-#~ msgstr "Estás en modo seguro: algo inesperado ha sucedido.\n"
+#~ msgid "%q pin invalid"
+#~ msgstr "pin inválido %q"
 
-#~ msgid "Pin number already reserved by EXTI"
-#~ msgstr "Número de pin ya reservado por EXTI"
-
-#~ msgid "USB Busy"
-#~ msgstr "USB ocupado"
-
-#~ msgid "USB Error"
-#~ msgstr "Error USB"
-
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "índices %q deben ser enteros, no %q"
+#~ msgid "%q should be an int"
+#~ msgstr "%q debe ser un int"
 
 #~ msgid "'%q' object cannot assign attribute '%q'"
 #~ msgstr "el objeto '%q' no puede asignar el atributo '%q'"
@@ -5656,6 +4585,9 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "'%q' object has no attribute '%q'"
 #~ msgstr "objeto '%q' no tiene atributo '%q'"
 
+#~ msgid "'%q' object is not bytes-like"
+#~ msgstr "el objeto '%q' no es similar a bytes"
+
 #~ msgid "'%q' object is not subscriptable"
 #~ msgstr "objeto '%q' no es subscribible"
 
@@ -5664,294 +4596,6 @@ msgstr "zi debe ser una forma (n_section,2)"
 
 #~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
 #~ msgstr "'%s' entero 0x%x no cabe en la máscara 0x%x"
-
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "No se puede obtener inequívocamente sizeof escalar"
-
-#~ msgid "Length must be an int"
-#~ msgstr "Length debe ser un int"
-
-#~ msgid "Length must be non-negative"
-#~ msgstr "Length no deberia ser negativa"
-
-#~ msgid "invalid decorator"
-#~ msgstr "decorador invalido"
-
-#~ msgid "name reused for argument"
-#~ msgstr "name reusado para argumento"
-
-#~ msgid "object '%q' is not a tuple or list"
-#~ msgstr "objeto '%q' no es tupla o lista"
-
-#~ msgid "object does not support item assignment"
-#~ msgstr "el objeto no soporta la asignación de elementos"
-
-#~ msgid "object does not support item deletion"
-#~ msgstr "object no soporta la eliminación de elementos"
-
-#~ msgid "object is not subscriptable"
-#~ msgstr "el objeto no es suscriptable"
-
-#~ msgid "object of type '%q' has no len()"
-#~ msgstr "objeto de tipo '%q' no tiene len()"
-
-#~ msgid "struct: cannot index"
-#~ msgstr "struct: no se puede indexar"
-
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "No se puede volver a montar '/' cuando el USB esta activo."
-
-#~ msgid "Timeout waiting for DRDY"
-#~ msgstr "Tiempo de espera agotado esperado por DRDY"
-
-#~ msgid "Timeout waiting for VSYNC"
-#~ msgstr "Tiempo de espera agotado esperando por VSYNC"
-
-#~ msgid "byte code not implemented"
-#~ msgstr "codigo byte no implementado"
-
-#~ msgid "can't pend throw to just-started generator"
-#~ msgstr "no se puede colgar al generador recién iniciado"
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "index dupterm inválido"
-
-#~ msgid "schedule stack full"
-#~ msgstr "pila de horario llena"
-
-#~ msgid "Corrupt raw code"
-#~ msgstr "Código crudo corrupto"
-
-#~ msgid "can only save bytecode"
-#~ msgstr "solo puede almacenar bytecode"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr "funciones Viper no soportan por el momento, más de 4 argumentos"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "la dirección %08x no esta alineada a %d bytes"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "la función no tiene argumentos por palabra clave"
-
-#~ msgid "parameter annotation must be an identifier"
-#~ msgstr "parámetro de anotación debe ser un identificador"
-
-#~ msgid "Total data to write is larger than outgoing_packet_length"
-#~ msgstr ""
-#~ "Los datos totales a escribir son más grandes que outgoing_packet_length"
-
-#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
-#~ msgstr "IOs 0, 2 y 4 no soportan pullup interno durante sleep"
-
-#~ msgid "buffer must be a bytes-like object"
-#~ msgstr "buffer debe de ser un objeto bytes-like"
-
-#~ msgid "io must be rtc io"
-#~ msgstr "io debe ser rtc io"
-
-#~ msgid "trigger level must be 0 or 1"
-#~ msgstr "nivel de accionamiento debe ser 0 o 1"
-
-#~ msgid "wakeup conflict"
-#~ msgstr "conflicto de wakeup"
-
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr ""
-#~ "Se intentó asignación del montículo, sin que la VM de MicroPython esté "
-#~ "ejecutando."
-
-#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
-#~ msgstr "MicroPython NLR jump falló. Probable corrupción de la memoria."
-
-#~ msgid "MicroPython fatal error."
-#~ msgstr "Error fatal de MicroPython."
-
-#~ msgid "argument must be ndarray"
-#~ msgstr "argumento debe ser ndarray"
-
-#~ msgid "matrix dimensions do not match"
-#~ msgstr "las dimensiones de la matriz no coinciden"
-
-#~ msgid "norm is defined for 1D and 2D arrays"
-#~ msgstr "norma está definida para arrays 1D y 2D"
-
-#~ msgid "vectors must have same lengths"
-#~ msgstr "los vectores deben tener el mismo tamaño"
-
-#~ msgid "Nordic Soft Device failure assertion."
-#~ msgstr "Fallo de aserción de dispositivo Nordic Soft."
-
-#~ msgid "Nordic soft device out of memory"
-#~ msgstr "El firmaware del sistema no tiene memoria"
-
-#~ msgid "Unknown soft device error: %04x"
-#~ msgstr "Error leve desconocido en dispositivo: %04x"
-
-#~ msgid "first argument must be an iterable"
-#~ msgstr "el primer argumento debe ser un iterable"
-
-#~ msgid "iterables are not of the same length"
-#~ msgstr "los iterables no son del mismo tamaño"
-
-#~ msgid "Selected CTS pin not valid"
-#~ msgstr "Pin CTS seleccionado no válido"
-
-#~ msgid "Selected RTS pin not valid"
-#~ msgstr "Pin RTS seleccionado no válido"
-
-#~ msgid "Could not initialize channel"
-#~ msgstr "No se pudo inicializar el canal"
-
-#~ msgid "Could not initialize timer"
-#~ msgstr "No se pudo inicializar el temporizador"
-
-#~ msgid "Invalid frequency supplied"
-#~ msgstr "Frecuencia suministrada no válida"
-
-#~ msgid "Invalid pins for PWMOut"
-#~ msgstr "Pines inválidos para PWMOut"
-
-#~ msgid "No more channels available"
-#~ msgstr "No hay más canales disponibles"
-
-#~ msgid "No more timers available"
-#~ msgstr "No hay más temporizadores disponibles"
-
-#~ msgid "No more timers available on this pin."
-#~ msgstr "No hay más temporizadores disponibles en este pin."
-
-#~ msgid ""
-#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
-#~ "program"
-#~ msgstr ""
-#~ "El temporizador es utilizado para uso interno - declare los pines para "
-#~ "PWM más temprano en el programa"
-
-#~ msgid "Group full"
-#~ msgstr "Group lleno"
-
-#~ msgid "In buffer elements must be 4 bytes long or less"
-#~ msgstr ""
-#~ "Los elementos del búfer de entrada deben ser de una longitud de 4 bytes o "
-#~ "menos"
-
-#~ msgid "Out buffer elements must be 4 bytes long or less"
-#~ msgstr ""
-#~ "Los elementos del búfer de salida deben ser de una longitud de 4 bytes o "
-#~ "menos"
-
-#~ msgid "Initial set pin direcion conflicts with initial out pin direction"
-#~ msgstr ""
-#~ "La dirección inicial del pin de configuración esta en conflicto con la "
-#~ "dirección de salida inicial del pin"
-
-#~ msgid "UART not yet supported"
-#~ msgstr "UART no esta soportado todavia"
-
-#~ msgid "bits must be 7, 8 or 9"
-#~ msgstr "bits deben ser 7, 8 ó 9"
-
-#~ msgid "Only IN/OUT of up to 8 supported"
-#~ msgstr "Solamente IN/OUT hasta 8 esta soportado"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "SDA o SCL necesitan una pull up"
-
-#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
-#~ msgstr ""
-#~ "%d pines de dirección y %d pines rgb indican una altura de %d, no de %d"
-
-#~ msgid "Unknown failure"
-#~ msgstr "Fallo desconocido"
-
-#~ msgid "input argument must be an integer or a 2-tuple"
-#~ msgstr "el argumento de entrada debe ser un entero o una tupla de par"
-
-#~ msgid "operation is not implemented for flattened array"
-#~ msgstr "operación no está implementada para arrays aplanados"
-
-#~ msgid "tuple index out of range"
-#~ msgstr "tuple index fuera de rango"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "El código terminó su ejecución. Esperando para recargar.\n"
-
-#~ msgid "Frequency captured is above capability. Capture Paused."
-#~ msgstr "Frecuencia capturada por encima de la capacidad. Captura en pausa."
-
-#~ msgid "max_length must be > 0"
-#~ msgstr "max_lenght debe ser > 0"
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr ""
-#~ "Presiona cualquier tecla para entrar al REPL. Usa CTRL-D para recargar."
-
-#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
-#~ msgstr "Solo hay capacidad para enchufes IPv4 SOCK_STREAM"
-
-#~ msgid "arctan2 is implemented for scalars and ndarrays only"
-#~ msgstr "arctan2 se encuentra implementado solo para escalares y ndarrays"
-
-#~ msgid "axis must be -1, 0, None, or 1"
-#~ msgstr "eje debe ser -1, 0, None o 1"
-
-#~ msgid "axis must be -1, 0, or 1"
-#~ msgstr "eje debe ser -1, 0, o 1"
-
-#~ msgid "axis must be None, 0, or 1"
-#~ msgstr "eje debe ser None, 0, o 1"
-
-#~ msgid "cannot reshape array (incompatible input/output shape)"
-#~ msgstr ""
-#~ "no se puede reformar el arreglo (forma de entrada/salida incompatible)"
-
-#~ msgid "could not broadast input array from shape"
-#~ msgstr "no se pudo anunciar la matriz de entrada desde la forma"
-
-#~ msgid "ddof must be smaller than length of data set"
-#~ msgstr "ddof debe ser menor que la longitud del conjunto de datos"
-
-#~ msgid "function is implemented for scalars and ndarrays only"
-#~ msgstr "la función está implementada solo para escalares y ndarrays"
-
-#~ msgid "n must be between 0, and 9"
-#~ msgstr "n debe estar entre 0 y 9"
-
-#~ msgid "number of arguments must be 2, or 3"
-#~ msgstr "el número de argumentos debe ser 2 o 3"
-
-#~ msgid "right hand side must be an ndarray, or a scalar"
-#~ msgstr "el lado derecho debe ser un ndarray o escalar"
-
-#~ msgid "shape must be a 2-tuple"
-#~ msgstr "la forma debe ser una tupla de 2"
-
-#~ msgid "wrong argument type"
-#~ msgstr "tipo de argumento incorrecto"
-
-#~ msgid "specify size or data, but not both"
-#~ msgstr "especifique o tamaño o datos, pero no ambos"
-
-#~ msgid "Must provide SCK pin"
-#~ msgstr "Debes proveer un pin para SCK"
-
-#~ msgid ""
-#~ "\n"
-#~ "To exit, please reset the board without "
-#~ msgstr ""
-#~ "\n"
-#~ "Para salir, favor reinicie la tarjeta sin "
-
-#~ msgid "PulseOut not supported on this chip"
-#~ msgstr "PulseOut no es compatible con este chip"
-
-#~ msgid "tuple/list required on RHS"
-#~ msgstr "tuple/lista se require en RHS"
 
 #~ msgid "'%s' object cannot assign attribute '%q'"
 #~ msgstr "El objeto '%s' no puede asignar al atributo '%q'"
@@ -5977,50 +4621,26 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "'%s' object is not subscriptable"
 #~ msgstr "el objeto '%s' no es suscriptable"
 
-#~ msgid "Invalid I2C pin selection"
-#~ msgstr "Selección de pin I2C no válida"
-
-#~ msgid "Invalid SPI pin selection"
-#~ msgstr "Selección de pin SPI no válida"
-
-#~ msgid "Invalid UART pin selection"
-#~ msgstr "Selección de pin UART no válida"
-
-#~ msgid "Pop from an empty Ps2 buffer"
-#~ msgstr "Pop de un buffer Ps2 vacio"
-
-#~ msgid "Running in safe mode! Auto-reload is off.\n"
-#~ msgstr "Ejecutando en modo seguro! La auto-recarga esta deshabilitada.\n"
-
-#~ msgid "can't convert address to int"
-#~ msgstr "no se puede convertir address a int"
-
-#~ msgid "object '%s' is not a tuple or list"
-#~ msgstr "el objeto '%s' no es una tupla o lista"
-
-#~ msgid "pop from an empty set"
-#~ msgstr "pop desde un set vacío"
-
-#~ msgid "pop from empty list"
-#~ msgstr "pop desde una lista vacía"
-
-#~ msgid "popitem(): dictionary is empty"
-#~ msgstr "popitem(): diccionario vacío"
-
-#~ msgid "unknown format code '%c' for object of type '%s'"
-#~ msgstr "codigo format desconocido '%c' para el typo de objeto '%s'"
-
-#~ msgid "unsupported types for %q: '%s', '%s'"
-#~ msgstr "tipos no soportados para %q: '%s', '%s'"
-
-#~ msgid "'%q' object is not bytes-like"
-#~ msgstr "el objeto '%q' no es similar a bytes"
-
 #~ msgid "'async for' or 'async with' outside async function"
 #~ msgstr "'async for' o 'async with' fuera de la función async"
 
-#~ msgid "PulseIn not supported on this chip"
-#~ msgstr "PulseIn no es compatible con este chip"
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr "'await', 'async for' o 'async with' fuera de la función async"
+
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' fuera de un bucle"
+
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' fuera de un bucle"
+
+#~ msgid "'coroutine' object is not an iterator"
+#~ msgstr "el objeto 'coroutine' no es un iterador"
+
+#~ msgid "64 bit types"
+#~ msgstr "tipos de 64 bit"
+
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "ADC2 está siendo usado por WiFi"
 
 #~ msgid "AP required"
 #~ msgstr "AP requerido"
@@ -6028,10 +4648,76 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "Address is not %d bytes long or is in wrong format"
 #~ msgstr "Direción no es %d bytes largo o esta en el formato incorrecto"
 
+#~ msgid "Address type out of range"
+#~ msgstr "Tipo de dirección fuera de rango"
+
+#~ msgid "AnalogIn not supported on given pin"
+#~ msgstr "El pin proporcionado no soporta AnalogIn"
+
+#~ msgid "AnalogOut functionality not supported"
+#~ msgstr "Funcionalidad AnalogOut no soportada"
+
+#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#~ msgstr "AnalogOut es solo de 16 bits. El valor debe ser menor que 65536."
+
+#~ msgid "AnalogOut not supported on given pin"
+#~ msgstr "El pin proporcionado no soporta AnalogOut"
+
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "Como máximo %d %q se puede especificar (no %d)"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr ""
+#~ "Se intentó asignación del montículo, sin que la VM de MicroPython esté "
+#~ "ejecutando."
+
 #~ msgid "Attempted heap allocation when MicroPython VM not running.\n"
 #~ msgstr ""
 #~ "Intento de allocation de heap cuando la VM de MicroPython no estaba "
 #~ "corriendo.\n"
+
+#~ msgid "Attempted heap allocation when VM not running."
+#~ msgstr "Asignación del montículo mientras la VM no esta ejecutándose."
+
+#~ msgid "Bit clock and word select must be sequential pins"
+#~ msgstr "Los pines \"clock\" y \"word-select\" deben ser consecutivos"
+
+#, c-format
+#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
+#~ msgstr "Bit depth tiene que ser de 1 a 6 inclusivo, no %d"
+
+#~ msgid "Boot device must be first device (interface #0)."
+#~ msgstr ""
+#~ "El dispositivo de arranque debe de ser el primer dispositivo (interfase "
+#~ "#0)."
+
+#~ msgid "Both buttons were pressed at start up.\n"
+#~ msgstr "Ambos botones fueron prensados al inicio\n"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "El brillo debe ser 0-1.0"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "El brillo debe estar entro 0 y 255"
+
+#, c-format
+#~ msgid "Buffer incorrect size. Should be %d bytes."
+#~ msgstr "Tamaño de buffer incorrecto. Debe ser de %d bytes."
+
+#~ msgid "Buffer is too small"
+#~ msgstr "Buffer es muy pequeño"
+
+#~ msgid "Buffer must be at least length 1"
+#~ msgstr "Buffer debe ser de longitud 1 como minimo"
+
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "Buffer demasiado grande e incapaz de asignar"
+
+#~ msgid "Button A was pressed at start up.\n"
+#~ msgstr "Botón A fue presionado al inicio.\n"
+
+#~ msgid "Bytes must be between 0 and 255."
+#~ msgstr "Bytes debe estar entre 0 y 255."
 
 #~ msgid "Can not use dotstar with %s"
 #~ msgstr "No se puede usar dotstar con %s"
@@ -6054,11 +4740,36 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "Cannot disconnect from AP"
 #~ msgstr "No se puede desconectar de AP"
 
+#~ msgid "Cannot output both channels on the same pin"
+#~ msgstr "No se puede tener ambos canales en el mismo pin"
+
+#~ msgid "Cannot read without MISO pin."
+#~ msgstr "No se puede leer sin pin MISO."
+
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "No se puede volver a montar '/' cuando el USB esta activo."
+
+#~ msgid "Cannot reset into bootloader because no bootloader is present."
+#~ msgstr ""
+#~ "No se puede reiniciar a bootloader porque no hay bootloader presente."
+
 #~ msgid "Cannot set STA config"
 #~ msgstr "No se puede establecer STA config"
 
+#~ msgid "Cannot transfer without MOSI and MISO pins"
+#~ msgstr "No puede ser transferido si los pines MOSI y MISO"
+
+#~ msgid "Cannot transfer without MOSI and MISO pins."
+#~ msgstr "No se puede transmitir sin pines MOSI y MISO."
+
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "No se puede obtener inequívocamente sizeof escalar"
+
 #~ msgid "Cannot update i/f status"
 #~ msgstr "No se puede actualizar i/f status"
+
+#~ msgid "Cannot write without MOSI pin."
+#~ msgstr "No se puede escribir sin pin MOSI."
 
 #~ msgid "Characteristic UUID doesn't match Service UUID"
 #~ msgstr "Características UUID no concide con el Service UUID"
@@ -6066,15 +4777,85 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "Characteristic already in use by another Service."
 #~ msgstr "Características ya esta en uso por otro Serivice"
 
+#~ msgid ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+#~ msgstr ""
+#~ "CircuitPython está en modo seguro porque presionó el botón de reinicio "
+#~ "durante el arranque. Presione nuevamente para salir del modo seguro.\n"
+
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "CircuitPython no puedo encontrar el montículo."
+
+#~ msgid "Clock pin init failed."
+#~ msgstr "Iniciado de pin de reloj fallido."
+
+#~ msgid "Column entry must be digitalio.DigitalInOut"
+#~ msgstr "Entrada de columna debe ser digitalio.DigitalInOut"
+
+#~ msgid "Command must be an int between 0 and 255"
+#~ msgstr "Command debe ser un int entre 0 y 255"
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "Archivo .mpy corrupto"
+
+#~ msgid "Corrupt raw code"
+#~ msgstr "Código crudo corrupto"
+
 #~ msgid "Could not decode ble_uuid, err 0x%04x"
 #~ msgstr "No se puede descodificar ble_uuid, err 0x%04x"
+
+#~ msgid "Could not initialize Camera"
+#~ msgstr "No se puede inicializar Camera"
+
+#~ msgid "Could not initialize GNSS"
+#~ msgstr "No se pudo inicializar el GNSS"
+
+#~ msgid "Could not initialize SDCard"
+#~ msgstr "No se pudo inicializar SDCard"
+
+#~ msgid "Could not initialize UART"
+#~ msgstr "No se puede inicializar la UART"
+
+#~ msgid "Could not initialize channel"
+#~ msgstr "No se pudo inicializar el canal"
+
+#~ msgid "Could not initialize timer"
+#~ msgstr "No se pudo inicializar el temporizador"
+
+#~ msgid "Could not re-init channel"
+#~ msgstr "No se pudo reiniciar el canal"
+
+#~ msgid "Could not re-init timer"
+#~ msgstr "No se pudo reiniciar el temporizador"
+
+#~ msgid "Could not restart PWM"
+#~ msgstr "No se pudo reiniciar el PWM"
+
+#~ msgid "Couldn't allocate first buffer"
+#~ msgstr "No se pudo asignar el primer buffer"
+
+#~ msgid "Couldn't allocate input buffer"
+#~ msgstr "No se pudo encontrar el buffer de entrada"
+
+#~ msgid "Couldn't allocate second buffer"
+#~ msgstr "No se pudo asignar el segundo buffer"
+
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "Choque contra el HardFault_Handler."
 
 #~ msgid "Crash into the HardFault_Handler.\n"
 #~ msgstr "Choque en el HardFault_Handler.\n"
 
+#~ msgid "Data 0 pin must be byte aligned."
+#~ msgstr "El pin de datos 0 debe ser alineado a byte."
+
 #, fuzzy
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Los datos no caben en el paquete de anuncio."
+
+#~ msgid "DigitalInOut not supported on given pin"
+#~ msgstr "DigitalInOut no es compatible con un pin dado"
 
 #~ msgid "Don't know how to pass object to native function"
 #~ msgstr "No se sabe cómo pasar objeto a función nativa"
@@ -6085,8 +4866,40 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "ESP8266 does not support pull down."
 #~ msgstr "ESP8266 no soporta pull down."
 
+#, c-format
+#~ msgid "Error in MIDI stream at position %d"
+#~ msgstr "Error en el flujo MIDI en la posición %d"
+
 #~ msgid "Error in ffi_prep_cif"
 #~ msgstr "Error en ffi_prep_cif"
+
+#~ msgid "Expected a %q"
+#~ msgstr "Se espera un %q"
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Se esperaba una Característica"
+
+#~ msgid "Expected a DigitalInOut"
+#~ msgstr "Se espera un DigitalInOut"
+
+#~ msgid "Expected a Service"
+#~ msgstr "Se esperaba un servicio"
+
+#~ msgid "Expected a UART"
+#~ msgstr "Se espera un UART"
+
+#~ msgid "Expected a UUID"
+#~ msgstr "Se esperaba un UUID"
+
+#~ msgid "Expected an Address"
+#~ msgstr "Se esperaba una dirección"
+
+#~ msgid "Expected an alarm"
+#~ msgstr "Un objecto alarm era esperado"
+
+#, c-format
+#~ msgid "Expected tuple of length %d, got %d"
+#~ msgstr "Se esperaba un tuple de %d, se obtuvo %d"
 
 #, fuzzy
 #~ msgid "Failed to acquire mutex"
@@ -6102,6 +4915,13 @@ msgstr "zi debe ser una forma (n_section,2)"
 
 #~ msgid "Failed to add service, err 0x%04x"
 #~ msgstr "Fallo al agregar servicio. err: 0x%02x"
+
+#~ msgid "Failed to allocate RX buffer"
+#~ msgstr "Ha fallado la asignación del buffer RX"
+
+#, c-format
+#~ msgid "Failed to allocate RX buffer of %d bytes"
+#~ msgstr "Falló la asignación del buffer RX de %d bytes"
 
 #~ msgid "Failed to change softdevice state"
 #~ msgstr "No se puede cambiar el estado del softdevice"
@@ -6130,6 +4950,9 @@ msgstr "zi debe ser una forma (n_section,2)"
 
 #~ msgid "Failed to get softdevice state"
 #~ msgstr "No se puede obtener el estado del softdevice"
+
+#~ msgid "Failed to init wifi"
+#~ msgstr "Fallo al inicializar wifi"
 
 #, fuzzy
 #~ msgid "Failed to notify or indicate attribute value, err %0x04x"
@@ -6186,6 +5009,15 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "Failed to write gatts value, err 0x%04x"
 #~ msgstr "No se puede escribir el valor del atributo. err: 0x%04x"
 
+#~ msgid "Fatal error."
+#~ msgstr "Error grave."
+
+#~ msgid "Fault detected by hardware."
+#~ msgstr "Falló detectado por el hardware."
+
+#~ msgid "Firmware image is invalid"
+#~ msgstr "La imagen de firmware es inválida"
+
 #~ msgid "Flash erase failed"
 #~ msgstr "Falló borrado de flash"
 
@@ -6198,23 +5030,212 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "Flash write failed to start, err 0x%04x"
 #~ msgstr "Falló el iniciar la escritura de flash, err 0x%04x"
 
+#, c-format
+#~ msgid "Framebuffer requires %d bytes"
+#~ msgstr "Framebuffer requiere %d bytes"
+
+#~ msgid "Frequency captured is above capability. Capture Paused."
+#~ msgstr "Frecuencia capturada por encima de la capacidad. Captura en pausa."
+
 #~ msgid "Function requires lock."
 #~ msgstr "La función requiere lock"
 
 #~ msgid "GPIO16 does not support pull up."
 #~ msgstr "GPIO16 no soporta pull up."
 
+#~ msgid "Group full"
+#~ msgstr "Group lleno"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Hardware ocupado, pruebe pines alternativos"
+
+#~ msgid "Hostname must be between 1 and 253 characters"
+#~ msgstr "Hostname debe ser entre 1 y 253 caracteres"
+
+#~ msgid "I2C Init Error"
+#~ msgstr "I2C Error de inicio"
+
 #~ msgid "I2C operation not supported"
 #~ msgstr "operación I2C no soportada"
 
+#~ msgid "I2SOut not available"
+#~ msgstr "I2SOut no disponible"
+
+#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
+#~ msgstr "IOs 0, 2 y 4 no soportan pullup interno durante sleep"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IV debe tener %d bytes de longitud"
+
+#~ msgid "In buffer elements must be 4 bytes long or less"
+#~ msgstr ""
+#~ "Los elementos del búfer de entrada deben ser de una longitud de 4 bytes o "
+#~ "menos"
+
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "Archivo .mpy incompatible. Actualice todos los archivos .mpy. Consulte "
+#~ "http://adafru.it/mpy-update para más información."
+
+#~ msgid "Initial set pin direcion conflicts with initial out pin direction"
+#~ msgstr ""
+#~ "La dirección inicial del pin de configuración esta en conflicto con la "
+#~ "dirección de salida inicial del pin"
+
+#~ msgid "Initialization failed due to lack of memory"
+#~ msgstr "Inicializacion fallida por falta de memoria"
+
+#~ msgid "Instruction %d jumps on pin"
+#~ msgstr "La instruction %d salta en pin"
+
+#, c-format
+#~ msgid "Instruction %d shifts in more bits than pin count"
+#~ msgstr "La instruccion %d mueve mas bits que la cuenta del pin"
+
+#, c-format
+#~ msgid "Instruction %d shifts out more bits than pin count"
+#~ msgstr "La instrucción %d mueve mas bits que la cuenta del pin"
+
+#, c-format
+#~ msgid "Instruction %d uses extra pin"
+#~ msgstr "La instrucción %d usa un pin extra"
+
+#, c-format
+#~ msgid "Instruction %d waits on input outside of count"
+#~ msgstr "La instrucción %d espera una entrada fuera del conteo"
+
+#~ msgid "Invalid %q pin selection"
+#~ msgstr "selección inválida de pin %q"
+
+#~ msgid "Invalid AuthMode"
+#~ msgstr "AuthMode invalido"
+
+#~ msgid "Invalid BMP file"
+#~ msgstr "Archivo BMP inválido"
+
+#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
+#~ msgstr "CIRCUITPY_PYSTACK_SIZE inválido\n"
+
+#~ msgid "Invalid DAC pin supplied"
+#~ msgstr "Pin suministrado inválido para DAC"
+
+#~ msgid "Invalid I2C pin selection"
+#~ msgstr "Selección de pin I2C no válida"
+
+#~ msgid "Invalid MIDI file"
+#~ msgstr "Archivo MIDI inválido"
+
+#~ msgid "Invalid PWM frequency"
+#~ msgstr "Frecuencia PWM inválida"
+
+#~ msgid "Invalid Pin"
+#~ msgstr "Pin inválido"
+
+#~ msgid "Invalid SPI pin selection"
+#~ msgstr "Selección de pin SPI no válida"
+
+#~ msgid "Invalid UART pin selection"
+#~ msgstr "Selección de pin UART no válida"
+
 #~ msgid "Invalid bit clock pin"
 #~ msgstr "Pin bit clock inválido"
+
+#~ msgid "Invalid buffer size"
+#~ msgstr "Tamaño de buffer inválido"
+
+#~ msgid "Invalid byteorder string"
+#~ msgstr "Cadena de byteorder inválida"
+
+#~ msgid "Invalid capture period. Valid range: 1 - 500"
+#~ msgstr "Inválido periodo de captura. Rango válido: 1 - 500"
+
+#~ msgid "Invalid channel count"
+#~ msgstr "Cuenta de canales inválida"
 
 #~ msgid "Invalid clock pin"
 #~ msgstr "Pin clock inválido"
 
 #~ msgid "Invalid data pin"
 #~ msgstr "Pin de datos inválido"
+
+#, c-format
+#~ msgid "Invalid data_count %d"
+#~ msgstr "data_count inválido %d"
+
+#~ msgid "Invalid direction."
+#~ msgstr "Dirección inválida."
+
+#~ msgid "Invalid file"
+#~ msgstr "Archivo inválido"
+
+#~ msgid "Invalid frequency"
+#~ msgstr "Frecuencia inválida"
+
+#~ msgid "Invalid frequency supplied"
+#~ msgstr "Frecuencia suministrada no válida"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "Acceso a memoria no válido."
+
+#~ msgid "Invalid number of bits"
+#~ msgstr "Numero inválido de bits"
+
+#~ msgid "Invalid phase"
+#~ msgstr "Fase inválida"
+
+#~ msgid "Invalid pin"
+#~ msgstr "Pin inválido"
+
+#~ msgid "Invalid pin for left channel"
+#~ msgstr "Pin inválido para canal izquierdo"
+
+#~ msgid "Invalid pin for right channel"
+#~ msgstr "Pin inválido para canal derecho"
+
+#~ msgid "Invalid pins"
+#~ msgstr "pines inválidos"
+
+#~ msgid "Invalid pins for PWMOut"
+#~ msgstr "Pines inválidos para PWMOut"
+
+#~ msgid "Invalid polarity"
+#~ msgstr "Polaridad inválida"
+
+#~ msgid "Invalid properties"
+#~ msgstr "Propiedades inválidas"
+
+#~ msgid "Invalid run mode."
+#~ msgstr "Modo de ejecución inválido."
+
+#~ msgid "Invalid security_mode"
+#~ msgstr "'security_mode' no válido"
+
+#~ msgid "Invalid voice"
+#~ msgstr "Voz inválida"
+
+#~ msgid "Invalid voice count"
+#~ msgstr "Cuenta de voces inválida"
+
+#~ msgid "Invalid wave file"
+#~ msgstr "Archivo wave inválido"
+
+#~ msgid "Invalid word/bit length"
+#~ msgstr "Tamaño no válido de palabra/bit"
+
+#~ msgid "Layer already in a group."
+#~ msgstr "La capa ya pertenece a un grupo."
+
+#~ msgid "Layer must be a Group or TileGrid subclass."
+#~ msgstr "Layer debe ser una subclase de Group o TileGrid."
+
+#~ msgid "Length must be an int"
+#~ msgstr "Length debe ser un int"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Length no deberia ser negativa"
 
 #~ msgid ""
 #~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
@@ -6227,17 +5248,75 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ "issues\n"
 #~ " con el contenido de su unidad CIRCUITPY y este mensaje:\n"
 
+#~ msgid "MISO pin init failed."
+#~ msgstr "MISO pin init fallido."
+
+#~ msgid "MOSI pin init failed."
+#~ msgstr "MOSI pin init fallido."
+
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "La frecuencia máxima del PWM es %dhz."
 
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "Valor máximo de x cuando se refleja es %d"
+
+#~ msgid "Messages limited to 8 bytes"
+#~ msgstr "Mensajes limitados a 8 bytes"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgstr "MicroPython NLR jump falló. Probable corrupción de la memoria."
+
 #~ msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
 #~ msgstr "MicroPython NLR salto fallido. Probable corrupción de memoria.\n"
+
+#~ msgid "MicroPython fatal error."
+#~ msgstr "Error fatal de MicroPython."
 
 #~ msgid "MicroPython fatal error.\n"
 #~ msgstr "Error fatal de MicroPython.\n"
 
 #~ msgid "Minimum PWM frequency is 1hz."
 #~ msgstr "La frecuencia mínima del PWM es 1hz"
+
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "Falta el pin MISO o MOSI"
+
+#~ msgid "Missing MISO or MOSI pin"
+#~ msgstr "Falta el pin MISO o MOSI"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
+#~ msgstr "first-in-pin no encontrado. La instrucción %d lee el/los pin(es)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
+#~ msgstr ""
+#~ "first_in_pin no encontrado. La instrucción %d desplaza de los pin(es)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
+#~ msgstr ""
+#~ "first_in_pin no encontrado. La instrucción %d espera basada en este pin"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
+#~ msgstr ""
+#~ "first_in_pin no encontrado. La instrucción %d mueve hacia afuera hacia el/"
+#~ "los pin(es)"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
+#~ msgstr "first_in_pin no encontrado. La instrucción %d escribe pin(es)"
+
+#, c-format
+#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+#~ msgstr ""
+#~ "first_set_pin no encontrado. La instrucción %d configura el/los pin(es)"
+
+#, c-format
+#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
+#~ msgstr "Falta el jmp_pin. La instrucción %d se dispara en el pin"
 
 #~ msgid "Multiple PWM frequencies not supported. PWM already set to %dhz."
 #~ msgstr ""
@@ -6246,14 +5325,85 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "Must be a Group subclass."
 #~ msgstr "Debe ser una subclase de Group."
 
+#~ msgid "Must provide SCK pin"
+#~ msgstr "Debes proveer un pin para SCK"
+
+#, c-format
+#~ msgid "No I2C device at address: %x"
+#~ msgstr "No hay dispositivo I2C en la dirección: %x"
+
+#~ msgid "No MISO Pin"
+#~ msgstr "Sin pin MISO"
+
+#~ msgid "No MISO pin"
+#~ msgstr "No pin MISO"
+
+#~ msgid "No MOSI Pin"
+#~ msgstr "Sin pin MOSI"
+
+#~ msgid "No MOSI pin"
+#~ msgstr "No pin MOSI"
+
 #~ msgid "No PulseIn support for %q"
 #~ msgstr "Sin soporte PulseIn para %q"
+
+#~ msgid "No RX pin"
+#~ msgstr "Sin pin RX"
+
+#~ msgid "No TX pin"
+#~ msgstr "Sin pin TX"
 
 #~ msgid "No hardware support for analog out."
 #~ msgstr "Sin soporte de hardware para salida analógica"
 
+#~ msgid "No hardware support on clk pin"
+#~ msgstr "Sin soporte de hardware en el pin clk"
+
+#~ msgid "No hardware support on pin"
+#~ msgstr "Sin soporte de hardware en pin"
+
+#~ msgid "No key was specified"
+#~ msgstr "No se especificó ninguna llave"
+
+#~ msgid "No more channels available"
+#~ msgstr "No hay más canales disponibles"
+
+#, c-format
+#~ msgid "No more than %d HID devices allowed"
+#~ msgstr "No se permiten más de %d dispositivos HID permitidos"
+
+#~ msgid "No more timers available"
+#~ msgstr "No hay más temporizadores disponibles"
+
+#~ msgid "No more timers available on this pin."
+#~ msgstr "No hay más temporizadores disponibles en este pin."
+
+#~ msgid "Nordic Soft Device failure assertion."
+#~ msgstr "Fallo de aserción de dispositivo Nordic Soft."
+
+#~ msgid "Nordic soft device out of memory"
+#~ msgstr "El firmaware del sistema no tiene memoria"
+
+#~ msgid "Nordic system firmware failure assertion."
+#~ msgstr "Falla en la aserción del firmware del dispositivo Nordic."
+
 #~ msgid "Not connected."
 #~ msgstr "No conectado."
+
+#~ msgid "Not running saved code.\n"
+#~ msgstr "No ejecutando el código almacenado.\n"
+
+#~ msgid "Not settable"
+#~ msgstr "No configurable"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Solo mono de 8 ó 16 bit con "
+
+#~ msgid "Only IN/OUT of up to 8 supported"
+#~ msgstr "Solamente IN/OUT hasta 8 esta soportado"
+
+#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
+#~ msgstr "Solo hay capacidad para enchufes IPv4 SOCK_STREAM"
 
 #~ msgid "Only Windows format, uncompressed BMP supported %d"
 #~ msgstr "Solo formato Windows, BMP sin comprimir soportado %d"
@@ -6268,6 +5418,15 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ "Solo se admiten BMP monocromos, indexados de 8bpp y 16bpp o superiores:%d "
 #~ "bpp dado"
 
+#~ msgid "Only one TouchAlarm can be set in deep sleep."
+#~ msgstr "Solamente una TouchAlarm puede ser configurada durante deep sleep."
+
+#~ msgid "Only raw int or string supported for ip"
+#~ msgstr "Para ip solo puede con un entero o una cadena"
+
+#~ msgid "Only raw int supported for ip"
+#~ msgstr "Solo se aceptan enteros crudos para ip"
+
 #, fuzzy
 #~ msgid "Only slices with step=1 (aka None) are supported"
 #~ msgstr "Solo se admiten segmentos con step=1 (alias None)"
@@ -6278,11 +5437,40 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "Only tx supported on UART1 (GPIO2)."
 #~ msgstr "Solo tx soportada en UART1 (GPIO2)."
 
+#~ msgid "Out buffer elements must be 4 bytes long or less"
+#~ msgstr ""
+#~ "Los elementos del búfer de salida deben ser de una longitud de 4 bytes o "
+#~ "menos"
+
+#, c-format
+#~ msgid "Output buffer must be at least %d bytes"
+#~ msgstr "buffer de salida debe ser de por lo menos %d bytes"
+
+#~ msgid "PDMIn not available"
+#~ msgstr "PDMIn no esta disponible"
+
+#~ msgid ""
+#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
+#~ msgstr ""
+#~ "PWM duty_cycle debe ser entre 0 y 65535 inclusivo (16 bit resolution)"
+
 #~ msgid "PWM not supported on pin %d"
 #~ msgstr "El pin %d no soporta PWM"
 
+#~ msgid "ParallelBus not yet supported"
+#~ msgstr "ParallelBus todavía no soportado"
+
 #~ msgid "Pin %q does not have ADC capabilities"
 #~ msgstr "Pin %q no tiene capacidades de ADC"
+
+#~ msgid "Pin count must be at least 1"
+#~ msgstr "El total de pines debe ser por lo menos 1"
+
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "Pin no tiene capacidad ADC"
+
+#~ msgid "Pin number already reserved by EXTI"
+#~ msgstr "Número de pin ya reservado por EXTI"
 
 #~ msgid "Pin(16) doesn't support pull"
 #~ msgstr "Pin(16) no soporta para pull"
@@ -6293,9 +5481,75 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "Pixel beyond bounds of buffer"
 #~ msgstr "Píxel fuera de los límites del búfer"
 
+#~ msgid "Pop from an empty Ps2 buffer"
+#~ msgstr "Pop de un buffer Ps2 vacio"
+
+#~ msgid ""
+#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
+#~ "instead"
+#~ msgstr ""
+#~ "Port no acepta un carrier de PWM. Pase en cambio un pin, una frecuencia o "
+#~ "un ciclo de actividad"
+
+#~ msgid ""
+#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
+#~ "Carrier instead"
+#~ msgstr ""
+#~ "Port no acepta los pines o la frecuencia. Construya y pase en su lugar un "
+#~ "Carrier de PWMOut"
+
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+#~ msgstr ""
+#~ "Presiona cualquier tecla para entrar al REPL. Usa CTRL-D para recargar."
+
+#~ msgid "Program must contain at least one 16-bit instruction."
+#~ msgstr "El programa debe contener por lo menos una instrucción de 16 bits."
+
+#~ msgid "Program too large"
+#~ msgstr "Programa demasiado grande"
+
+#~ msgid "PulseIn not supported on this chip"
+#~ msgstr "PulseIn no es compatible con este chip"
+
+#~ msgid "PulseOut not supported on this chip"
+#~ msgstr "PulseOut no es compatible con este chip"
+
+#~ msgid "RAISE mode is not implemented"
+#~ msgstr "El modo RAISE no esta implementado"
+
+#~ msgid "RS485 Not yet supported on this device"
+#~ msgstr "RS485 no esta soportado todavía en este dispositivo"
+
+#~ msgid "RTC calibration is not supported on this board"
+#~ msgstr "Calibración de RTC no es soportada en esta placa"
+
+#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
+#~ msgstr "Sin capacidad de RTS/CTS/RS485 para este dispositivo"
+
 #, fuzzy
 #~ msgid "Range out of bounds"
 #~ msgstr "Rango fuera de límites"
+
+#~ msgid "Read-only object"
+#~ msgstr "Objeto de solo-lectura"
+
+#~ msgid "Row entry must be digitalio.DigitalInOut"
+#~ msgstr "La entrada de la fila debe ser digitalio.DigitalInOut"
+
+#~ msgid "Running in safe mode! "
+#~ msgstr "¡Corriendo en modo seguro! "
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Ejecutando en modo seguro! La auto-recarga esta deshabilitada.\n"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "SDA o SCL necesitan una pull up"
+
+#~ msgid "SPI Init Error"
+#~ msgstr "Error de inicio de SPI"
+
+#~ msgid "SPI Re-initialization error"
+#~ msgstr "Error de reinicialización de SPI"
 
 #~ msgid "STA must be active"
 #~ msgstr "STA debe estar activo"
@@ -6303,8 +5557,59 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "STA required"
 #~ msgstr "STA requerido"
 
+#~ msgid "Sample rate must be positive"
+#~ msgstr "Sample rate debe ser positivo"
+
+#, c-format
+#~ msgid "Sample rate too high. It must be less than %d"
+#~ msgstr "Frecuencia de muestreo demasiado alta. Debe ser menor a %d"
+
+#~ msgid "Scan already in progess. Stop with stop_scan."
+#~ msgstr "Escaneo en progreso. Usa stop_scan para detener."
+
+#~ msgid "Selected CTS pin not valid"
+#~ msgstr "Pin CTS seleccionado no válido"
+
+#~ msgid "Selected RTS pin not valid"
+#~ msgstr "Pin RTS seleccionado no válido"
+
+#~ msgid "Set pin count must be between 1 and 5"
+#~ msgstr "La suma de pines configurados debe estar entre 1 y 5"
+
+#~ msgid "Side set pin count must be between 1 and 5"
+#~ msgstr "El conteo de pines de Side set debe estar entre 1 y 5"
+
+#~ msgid "Sleep Memory not available"
+#~ msgstr "Memoria de sueño no disponible"
+
 #~ msgid "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 #~ msgstr "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Dividiendo con sub-capturas"
+
+#~ msgid "Stack size must be at least 256"
+#~ msgstr "El tamaño de la pila debe ser de al menos 256"
+
+#~ msgid "Stopping AP is not supported."
+#~ msgstr "Parar el AP no esta soportado."
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "A Stream le falta el método readinto() o write()."
+
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "Suministre al menos un pin UART"
+
+#~ msgid "The BOOT button was pressed at start up.\n"
+#~ msgstr "El boton BOOT fur presionado durante el arranque.\n"
+
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Increase the stack size if you know how. If not:"
+#~ msgstr ""
+#~ "El montículo de CircuitPython está corrupto porque la pila era muy "
+#~ "pequeña.\n"
+#~ "Aumente el tamaño de pila si sabe como. De lo contrario:"
 
 #~ msgid ""
 #~ "The CircuitPython heap was corrupted because the stack was too small.\n"
@@ -6321,6 +5626,59 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ "su unidad CIRCUITPY:\n"
 
 #~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase the stack size if you know how, or if not:"
+#~ msgstr ""
+#~ "El heap de CircuitPython se dañó porque la pila era demasiado pequeña.\n"
+#~ "Aumente el tamaño de la pila si sabe cómo, o si no:"
+
+#~ msgid "The SW38 button was pressed at start up.\n"
+#~ msgstr "El boton SW38 fue presionado durante el arranque.\n"
+
+#~ msgid "The VOLUME button was pressed at start up.\n"
+#~ msgstr "El boton de Volumen fue presionado durante el arranque.\n"
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode."
+#~ msgstr ""
+#~ "El módulo de `microcontroller` se usó para un arranque en modo seguro. "
+#~ "Presione reset para salir del modo seguro."
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode.\n"
+#~ msgstr ""
+#~ "El módulo de `microcontroller` fue utilizado para arrancar en modo "
+#~ "seguro. Presiona reset para salir del modo seguro.\n"
+
+#~ msgid "The central button was pressed at start up.\n"
+#~ msgstr "El boton central fue presionado durante el arranque.\n"
+
+#~ msgid "The left button was pressed at start up.\n"
+#~ msgstr "El boton izquierdo fue presionado durante el arranque.\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY)."
+#~ msgstr ""
+#~ "La corriente eléctrica de la microcontroladora bajó. Asegúrate que tu "
+#~ "fuente de poder provee\n"
+#~ "suficiente corriente para todo el circuito y presiones reset (luego de "
+#~ "expulsar CIRCUITPY)."
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "La alimentación del microntrolador bajó. Asegúrate que tu fuente de "
+#~ "alimentación\n"
+#~ "pueda aportar suficiente energía para todo el circuito y presiona reset "
+#~ "(luego de expulsar CIRCUITPY)\n"
+
+#~ msgid ""
 #~ "The microcontroller's power dipped. Please make sure your power supply "
 #~ "provides\n"
 #~ "enough power for the whole circuit and press reset (after ejecting "
@@ -6330,6 +5688,10 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ "fuente de alimentación provee\n"
 #~ "suficiente energia para todo el circuito y presiona el botón de reset "
 #~ "(despuesde expulsar CIRCUITPY).\n"
+
+#~ msgid "The power dipped. Make sure you are providing enough power."
+#~ msgstr ""
+#~ "La potencia calló. Asegúrese que está suministrando suficiente energía."
 
 #~ msgid ""
 #~ "The reset button was pressed while booting CircuitPython. Press again to "
@@ -6341,27 +5703,166 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "Tile indices must be 0 - 255"
 #~ msgstr "Los índices de Tile deben ser 0 - 255"
 
+#~ msgid "Tile value out of bounds"
+#~ msgstr "Valor de mosaico fuera de límites"
+
+#~ msgid "Timeout waiting for DRDY"
+#~ msgstr "Tiempo de espera agotado esperado por DRDY"
+
+#~ msgid "Timeout waiting for VSYNC"
+#~ msgstr "Tiempo de espera agotado esperando por VSYNC"
+
+#~ msgid ""
+#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
+#~ "program"
+#~ msgstr ""
+#~ "El temporizador es utilizado para uso interno - declare los pines para "
+#~ "PWM más temprano en el programa"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Para salir, por favor reinicia la tarjeta sin "
+
+#~ msgid "To exit, please reset the board without requesting safe mode."
+#~ msgstr "Para salir, por favor reinicialice la tarjeta sin pedir safe mode."
+
+#~ msgid "Too many display busses"
+#~ msgstr "Demasiados buses de pantalla"
+
+#~ msgid "Total data to write is larger than outgoing_packet_length"
+#~ msgstr ""
+#~ "Los datos totales a escribir son más grandes que outgoing_packet_length"
+
+#~ msgid "UART Buffer allocation error"
+#~ msgstr "No se pudo encontrar el búfer para UART"
+
+#~ msgid "UART De-init error"
+#~ msgstr "Error de desinicialización de UART"
+
+#~ msgid "UART Init Error"
+#~ msgstr "Error de inicialización de UART"
+
+#~ msgid "UART Re-init error"
+#~ msgstr "Error de reinicialización de UART"
+
+#~ msgid "UART not yet supported"
+#~ msgstr "UART no esta soportado todavia"
+
+#~ msgid "UART write error"
+#~ msgstr "Error de escritura UART"
+
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) no existe"
 
 #~ msgid "UART(1) can't read"
 #~ msgstr "UART(1) no puede leer"
 
+#~ msgid "USB Busy"
+#~ msgstr "USB ocupado"
+
+#~ msgid "USB Error"
+#~ msgstr "Error USB"
+
 #~ msgid "UUID integer value not in range 0 to 0xffff"
 #~ msgstr "El valor integer UUID no está en el rango 0 a 0xffff"
+
+#~ msgid "Unable to allocate the heap."
+#~ msgstr "Imposible de asignar el heap."
+
+#, c-format
+#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Imposible de configurar el controlador ADC DMA , código de error:%d"
+
+#, c-format
+#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
+#~ msgstr ""
+#~ "No es posible de inicializar el controlador ADC DMA, código de error:%d"
 
 #~ msgid "Unable to remount filesystem"
 #~ msgstr "Incapaz de montar de nuevo el sistema de archivos"
 
+#, c-format
+#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Imposible de iniciar el controlador ADC DMA, código de error:%d"
+
+#~ msgid "Unable to write to address."
+#~ msgstr "Imposible de escribir en esa dirección."
+
+#~ msgid "Unknown failure"
+#~ msgstr "Fallo desconocido"
+
+#~ msgid "Unknown soft device error: %04x"
+#~ msgstr "Error leve desconocido en dispositivo: %04x"
+
 #~ msgid "Unknown type"
 #~ msgstr "Tipo desconocido"
+
+#, c-format
+#~ msgid "Unkown error code %d"
+#~ msgstr "Codigo de error desconocido: %d"
+
+#~ msgid "Unsupported baudrate"
+#~ msgstr "Baudrate no soportado"
+
+#~ msgid "Unsupported operation"
+#~ msgstr "Operación no soportada"
+
+#~ msgid "Unsupported pull value."
+#~ msgstr "valor pull no soportado."
 
 #~ msgid "Use esptool to erase flash and re-upload Python instead"
 #~ msgstr ""
 #~ "Usa esptool para borrar la flash y vuelve a cargar Python en su lugar"
 
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr "funciones Viper no soportan por el momento, más de 4 argumentos"
+
 #~ msgid "Voice index too high"
 #~ msgstr "Index de voz demasiado alto"
+
+#~ msgid "WatchDogTimer is not currently running"
+#~ msgstr "WatchDogTimer no se está ejecutando en este momento"
+
+#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+#~ msgstr ""
+#~ "WatchDogTimer.mode no se puede modificar luego de configurar WatchDogMode."
+#~ "RESET"
+
+#~ msgid "WatchDogTimer.timeout must be greater than 0"
+#~ msgstr "WatchDogTimer.timeout debe ser mayor a 0"
+
+#~ msgid "Watchdog timer expired."
+#~ msgstr "Temporizador de perro guardián expirado."
+
+#, c-format
+#~ msgid ""
+#~ "Welcome to Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Please visit learn.adafruit.com/category/circuitpython for project "
+#~ "guides.\n"
+#~ "\n"
+#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ msgstr ""
+#~ "Bienvenido a Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Visita learn.adafruit.com/category/circuitpython para obtener guías de "
+#~ "proyectos.\n"
+#~ "\n"
+#~ "Para listar los módulos incorporados por favor haga `help(\"modules\")`.\n"
+
+#~ msgid "WiFi password must be between 8 and 63 characters"
+#~ msgstr "La clave de WiFi debe ser entre 8 y 63 caracteres"
+
+#~ msgid "Wifi is in access point mode."
+#~ msgstr "Wifi est en modo de access point."
+
+#~ msgid "Wifi is in station mode."
+#~ msgstr "Wifi esta en modo station."
+
+#~ msgid "You are in safe mode because:\n"
+#~ msgstr "Estás en modo seguro por la razón:\n"
+
+#~ msgid "You are in safe mode: something unanticipated happened.\n"
+#~ msgstr "Estás en modo seguro: algo inesperado ha sucedido.\n"
 
 #~ msgid ""
 #~ "You are running in safe mode which means something unanticipated "
@@ -6370,14 +5871,62 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ "Estás ejecutando en modo seguro, lo cual significa que algo realmente "
 #~ "malo ha sucedido.\n"
 
+#~ msgid ""
+#~ "You pressed the reset button during boot. Press again to exit safe mode."
+#~ msgstr ""
+#~ "Has presionado el botón de reset durante el arranque. Presiones de nuevo "
+#~ "para salir del modo seguro."
+
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "Solicitaste iniciar en modo seguro por "
+
+#~ msgid "__init__() should return None, not '%q'"
+#~ msgstr "__init__() debe retornar None, no '%q'"
+
+#~ msgid "abort() called"
+#~ msgstr "se llamó abort()"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "la dirección %08x no esta alineada a %d bytes"
+
+#~ msgid "address out of bounds"
+#~ msgstr "address fuera de límites"
+
+#~ msgid "arctan2 is implemented for scalars and ndarrays only"
+#~ msgstr "arctan2 se encuentra implementado solo para escalares y ndarrays"
+
+#~ msgid "argument must be ndarray"
+#~ msgstr "argumento debe ser ndarray"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "atributos aún no soportados"
+
+#~ msgid "axis must be -1, 0, None, or 1"
+#~ msgstr "eje debe ser -1, 0, None o 1"
+
+#~ msgid "axis must be -1, 0, or 1"
+#~ msgstr "eje debe ser -1, 0, o 1"
+
+#~ msgid "axis must be None, 0, or 1"
+#~ msgstr "eje debe ser None, 0, o 1"
+
 #~ msgid "bad GATT role"
 #~ msgstr "rol de GATT malo"
+
+#~ msgid "bits must be 7, 8 or 9"
+#~ msgstr "bits deben ser 7, 8 ó 9"
 
 #~ msgid "bits must be 8"
 #~ msgstr "bits debe ser 8"
 
+#~ msgid "bits must be in range 5 to 9"
+#~ msgstr "los bits deben estar en el rango de 5 a 9"
+
 #~ msgid "buf is too small. need %d bytes"
 #~ msgstr "buf es demasiado pequeño. necesita %d bytes"
+
+#~ msgid "buffer must be a bytes-like object"
+#~ msgstr "buffer debe de ser un objeto bytes-like"
 
 #~ msgid "buffer too long"
 #~ msgstr "buffer demasiado largo"
@@ -6385,11 +5934,41 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "buffers must be the same length"
 #~ msgstr "los buffers deben de tener la misma longitud"
 
+#~ msgid "buttons must be digitalio.DigitalInOut"
+#~ msgstr "los botones necesitan ser digitalio.DigitalInOut"
+
+#~ msgid "byte code not implemented"
+#~ msgstr "codigo byte no implementado"
+
+#~ msgid "byteorder is not a string"
+#~ msgstr "byteorder no es una cadena"
+
 #~ msgid "byteorder is not an instance of ByteOrder (got a %s)"
 #~ msgstr "byteorder no es instancia de ByteOrder (encontarmos un %s)"
 
+#~ msgid "bytes > 8 bits not supported"
+#~ msgstr "bytes > 8 bits no soportados"
+
+#~ msgid "calibration value out of range +/-127"
+#~ msgstr "Valor de calibración fuera del rango +/-127"
+
+#~ msgid "can only save bytecode"
+#~ msgstr "solo puede almacenar bytecode"
+
 #~ msgid "can query only one param"
 #~ msgstr "puede consultar solo un param"
+
+#~ msgid "can't convert %q to int"
+#~ msgstr "no se puede convertir %q a int"
+
+#~ msgid "can't convert address to int"
+#~ msgstr "no se puede convertir address a int"
+
+#~ msgid "can't convert to %q"
+#~ msgstr "no puede convertir a %q"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr "no se puede hacer la división truncada de un número complejo"
 
 #~ msgid "can't get AP config"
 #~ msgstr "no se puede obtener AP config"
@@ -6397,20 +5976,86 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "can't get STA config"
 #~ msgstr "no se puede obtener STA config"
 
+#~ msgid "can't have multiple **x"
+#~ msgstr "no puede tener multiples *x"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "no puede tener multiples *x"
+
+#~ msgid "can't pend throw to just-started generator"
+#~ msgstr "no se puede colgar al generador recién iniciado"
+
 #~ msgid "can't set AP config"
 #~ msgstr "no se puede establecer AP config"
 
 #~ msgid "can't set STA config"
 #~ msgstr "no se puede establecer STA config"
 
+#~ msgid "cannot import name %q"
+#~ msgstr "no se puede importar name '%q'"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "no se puedo realizar importación relativa"
+
+#~ msgid "cannot reshape array (incompatible input/output shape)"
+#~ msgstr ""
+#~ "no se puede reformar el arreglo (forma de entrada/salida incompatible)"
+
+#~ msgid "cannot unambiguously get sizeof scalar"
+#~ msgstr "no se puede sin ambiguedades traer el sizeof del escalar"
+
 #~ msgid "characteristics includes an object that is not a Characteristic"
 #~ msgstr "characteristics incluye un objeto que no es una Characteristic"
+
+#~ msgid "circle can only be registered in one parent"
+#~ msgstr "circulo solo puede ser registrado con un pariente"
 
 #~ msgid "color buffer must be a buffer or int"
 #~ msgstr "color buffer deber ser un buffer o un int"
 
+#~ msgid "color should be an int"
+#~ msgstr "color deberia ser un int"
+
+#~ msgid "complex division by zero"
+#~ msgstr "división compleja por cero"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "constant debe ser un entero"
+
+#~ msgid "could not broadast input array from shape"
+#~ msgstr "no se pudo anunciar la matriz de entrada desde la forma"
+
+#~ msgid "ddof must be smaller than length of data set"
+#~ msgstr "ddof debe ser menor que la longitud del conjunto de datos"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr "destination_length debe ser un int >= 0"
+
 #~ msgid "either pos or kw args are allowed"
 #~ msgstr "ya sea pos o kw args son permitidos"
+
+#~ msgid "end_x should be an int"
+#~ msgstr "end_x debe ser un int"
+
+#~ msgid ""
+#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "esp32_camera. la camara necesita PSRAM reservada para ser configurada. "
+#~ "Vea la documentacion para mas instrucciones."
+
+#~ msgid ""
+#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "espcamera. La cámara requiere una configuración de PSRAM reservada. "
+#~ "Refiérase a la documentación para más instrucciones."
+
+#~ msgid "expected '%q' but got '%q'"
+#~ msgstr "se espera '%q' pero se recibe '%q'"
+
+#~ msgid "expected '%q' or '%q' but got '%q'"
+#~ msgstr "se espera '%q' o '%q' pero se recibe '%q'"
 
 #~ msgid "expected a DigitalInOut"
 #~ msgstr "se espera un DigitalInOut"
@@ -6418,8 +6063,26 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "expecting a pin"
 #~ msgstr "esperando un pin"
 
+#~ msgid "f-string expression part cannot include a '#'"
+#~ msgstr "La parte de expresión f-string no puede incluir un '#'"
+
+#~ msgid "f-string expression part cannot include a backslash"
+#~ msgstr "La parte de expresión f-string no puede incluir una barra invertida"
+
+#~ msgid "f-string: empty expression not allowed"
+#~ msgstr "cadena-f: expresión vacía no permitida"
+
+#~ msgid "f-string: expecting '}'"
+#~ msgstr "f-string: esperando '}'"
+
+#~ msgid "f-string: single '}' is not allowed"
+#~ msgstr "cadena-f: solo '}' no está permitido"
+
 #~ msgid "ffi_prep_closure_loc"
 #~ msgstr "ffi_prep_closure_loc"
+
+#~ msgid "first argument must be an iterable"
+#~ msgstr "el primer argumento debe ser un iterable"
 
 #~ msgid "firstbit must be MSB"
 #~ msgstr "firstbit debe ser MSB"
@@ -6430,8 +6093,38 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "frequency can only be either 80Mhz or 160MHz"
 #~ msgstr "la frecuencia solo puede ser 80MHz ó 160MHz"
 
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "la función no tiene argumentos por palabra clave"
+
+#~ msgid "function is implemented for scalars and ndarrays only"
+#~ msgstr "la función está implementada solo para escalares y ndarrays"
+
 #~ msgid "impossible baudrate"
 #~ msgstr "baudrate imposible"
+
+#~ msgid "incompatible native .mpy architecture"
+#~ msgstr "arquitectura nativa de .mpy incompatible"
+
+#~ msgid "input and output shapes are not compatible"
+#~ msgstr "Formas de entrada y salida no son compatibles"
+
+#~ msgid "input argument must be an integer or a 2-tuple"
+#~ msgstr "el argumento de entrada debe ser un entero o una tupla de par"
+
+#~ msgid "input must be a tensor of rank 2"
+#~ msgstr "Entrada tiene que ser un tensor de rango 2"
+
+#~ msgid "inputs are not iterable"
+#~ msgstr "Entradas no son iterables"
+
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr "int() arg 2 debe ser >= 2 y <= 36"
+
+#~ msgid "integer required"
+#~ msgstr "Entero requerido"
+
+#~ msgid "interp is defined for 1D arrays of equal length"
+#~ msgstr "interp está definido para arreglos de 1D del mismo tamaño"
 
 #~ msgid "interval not in range 0.0020 to 10.24"
 #~ msgstr "El intervalo está fuera del rango de 0.0020 a 10.24"
@@ -6445,11 +6138,30 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "invalid alarm"
 #~ msgstr "alarma inválida"
 
+#~ msgid "invalid architecture"
+#~ msgstr "arquitectura inválida"
+
+#~ msgid "invalid arguments"
+#~ msgstr "argumentos inválidos"
+
+#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
+#~ msgstr ""
+#~ "los bits_per_pixel %d no son validos, deben ser 1, 4, 8, 16, 24 o 32"
+
 #~ msgid "invalid buffer length"
 #~ msgstr "longitud de buffer inválida"
 
 #~ msgid "invalid data bits"
 #~ msgstr "data bits inválidos"
+
+#~ msgid "invalid decorator"
+#~ msgstr "decorador invalido"
+
+#~ msgid "invalid dupterm index"
+#~ msgstr "index dupterm inválido"
+
+#~ msgid "invalid format"
+#~ msgstr "formato inválido"
 
 #~ msgid "invalid pin"
 #~ msgstr "pin inválido"
@@ -6457,8 +6169,40 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "invalid stop bits"
 #~ msgstr "stop bits inválidos"
 
+#~ msgid "io must be rtc io"
+#~ msgstr "io debe ser rtc io"
+
+#~ msgid "iterables are not of the same length"
+#~ msgstr "los iterables no son del mismo tamaño"
+
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr ""
+#~ "argumento(s) por palabra clave aún no implementados - usa argumentos "
+#~ "normales en su lugar"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "palabras clave deben ser strings"
+
 #~ msgid "len must be multiple of 4"
 #~ msgstr "len debe de ser múltiple de 4"
+
+#~ msgid "length argument not allowed for this type"
+#~ msgstr "argumento length no permitido para este tipo"
+
+#~ msgid "long int not supported in this build"
+#~ msgstr "long int no soportado en esta compilación"
+
+#~ msgid "matrix dimensions do not match"
+#~ msgstr "las dimensiones de la matriz no coinciden"
+
+#~ msgid "max_length must be > 0"
+#~ msgstr "max_lenght debe ser > 0"
+
+#~ msgid "max_length must be >= 0"
+#~ msgstr "max_length debe ser >= 0"
+
+#~ msgid "maximum number of dimensions is 4"
+#~ msgstr "Máximo número de dimensiones es 4"
 
 #~ msgid "memory allocation failed, allocating %u bytes for native code"
 #~ msgstr ""
@@ -6467,17 +6211,118 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "must specify all of sck/mosi/miso"
 #~ msgstr "se deben de especificar sck/mosi/miso"
 
+#~ msgid "n must be between 0, and 9"
+#~ msgstr "n debe estar entre 0 y 9"
+
 #~ msgid "name must be a string"
 #~ msgstr "name debe de ser un string"
+
+#~ msgid "name reused for argument"
+#~ msgstr "name reusado para argumento"
+
+#~ msgid "no available NIC"
+#~ msgstr "NIC no disponible"
+
+#~ msgid "no reset pin available"
+#~ msgstr "no hay pin de reinicio disponible"
+
+#~ msgid "non-Device in %q"
+#~ msgstr "hay un no-Device en %q"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "no deberia estar/tener agumento por palabra clave despues de */**"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr ""
+#~ "no deberia estar/tener agumento por palabra clave despues de argumento "
+#~ "por palabra clave"
+
+#~ msgid "norm is defined for 1D and 2D arrays"
+#~ msgstr "norma está definida para arrays 1D y 2D"
 
 #~ msgid "not a valid ADC Channel: %d"
 #~ msgstr "no es un canal ADC válido: %d"
 
+#~ msgid "number of arguments must be 2, or 3"
+#~ msgstr "el número de argumentos debe ser 2 o 3"
+
+#~ msgid "object '%q' is not a tuple or list"
+#~ msgstr "objeto '%q' no es tupla o lista"
+
+#~ msgid "object '%s' is not a tuple or list"
+#~ msgstr "el objeto '%s' no es una tupla o lista"
+
+#~ msgid "object does not support item assignment"
+#~ msgstr "el objeto no soporta la asignación de elementos"
+
+#~ msgid "object does not support item deletion"
+#~ msgstr "object no soporta la eliminación de elementos"
+
+#~ msgid "object is not subscriptable"
+#~ msgstr "el objeto no es suscriptable"
+
+#~ msgid "object of type '%q' has no len()"
+#~ msgstr "objeto de tipo '%q' no tiene len()"
+
+#~ msgid "offset out of bounds"
+#~ msgstr "offset fuera de límites"
+
+#~ msgid "operation is not implemented for flattened array"
+#~ msgstr "operación no está implementada para arrays aplanados"
+
+#~ msgid "out of range of source"
+#~ msgstr "fuera de rango de fuente"
+
+#~ msgid "palette_index should be an int"
+#~ msgstr "palette_index deberia ser un int"
+
+#~ msgid "parameter annotation must be an identifier"
+#~ msgstr "parámetro de anotación debe ser un identificador"
+
 #~ msgid "pin does not have IRQ capabilities"
 #~ msgstr "pin sin capacidades IRQ"
 
+#~ msgid "pixel value requires too many bits"
+#~ msgstr "valor del pixel require demasiado bits"
+
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+#~ msgstr "pixel_shader debe ser displayio.Palette o displayio.ColorConverter"
+
+#~ msgid "polygon can only be registered in one parent"
+#~ msgstr "el polígono solo se puede registrar en uno de los padres"
+
+#~ msgid "pop from an empty set"
+#~ msgstr "pop desde un set vacío"
+
+#~ msgid "pop from empty list"
+#~ msgstr "pop desde una lista vacía"
+
+#~ msgid "popitem(): dictionary is empty"
+#~ msgstr "popitem(): diccionario vacío"
+
 #~ msgid "position must be 2-tuple"
 #~ msgstr "posición debe ser 2-tuple"
+
+#~ msgid "pressing boot button at start up.\n"
+#~ msgstr "presionando botón de arranque al inicio.\n"
+
+#~ msgid "pressing both buttons at start up.\n"
+#~ msgstr "presionando ambos botones al inicio.\n"
+
+#~ msgid "pressing the left button at start up\n"
+#~ msgstr "presione el botón izquierdo al arranque\n"
+
+#~ msgid "pull_threshold must be between 1 and 32"
+#~ msgstr "pull_threshold debe esta entre 1 y 32"
+
+#~ msgid "push_threshold must be between 1 and 32"
+#~ msgstr "push_threshold debe esta entre 1 y 32"
+
+#~ msgid "queue overflow"
+#~ msgstr "desbordamiento de cola(queue)"
+
+#~ msgid "raw f-strings are not implemented"
+#~ msgstr "no está implementado cadenas-f sin procesar"
 
 #~ msgid "rawbuf is not the same size as buf"
 #~ msgstr "rawbuf no es el mismo tamaño que buf"
@@ -6486,17 +6331,75 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "readonly attribute"
 #~ msgstr "atributo no legible"
 
+#~ msgid "right hand side must be an ndarray, or a scalar"
+#~ msgstr "el lado derecho debe ser un ndarray o escalar"
+
 #~ msgid "row must be packed and word aligned"
 #~ msgstr "la fila debe estar empacada y la palabra alineada"
+
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "sample_source buffer debe ser un bytearray o un array de tipo 'h', 'H', "
+#~ "'b' o'B'"
 
 #~ msgid "scan failed"
 #~ msgstr "scan ha fallado"
 
+#~ msgid "schedule stack full"
+#~ msgstr "pila de horario llena"
+
 #~ msgid "services includes an object that is not a Service"
 #~ msgstr "services incluye un objeto que no es servicio"
 
+#~ msgid "shape must be a 2-tuple"
+#~ msgstr "la forma debe ser una tupla de 2"
+
+#~ msgid "shape must be a tuple"
+#~ msgstr "forma tiene que ser una tupla"
+
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "un solo '}' encontrado en format string"
+
+#~ msgid "slice step can't be zero"
+#~ msgstr "el tamaño de la división no puede ser cero"
+
+#~ msgid "slice step cannot be zero"
+#~ msgstr "slice step no puede ser cero"
+
+#~ msgid "specify size or data, but not both"
+#~ msgstr "especifique o tamaño o datos, pero no ambos"
+
+#~ msgid "start_x should be an int"
+#~ msgstr "start_x deberia ser un int"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "paso debe ser numero no cero"
+
+#~ msgid "stop must be 1 or 2"
+#~ msgstr "stop debe ser 1 ó 2"
+
+#~ msgid "string indices must be integers, not %q"
+#~ msgstr "índices de cadena deben ser enteros, no %q"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr "string no soportado; usa bytes o bytearray"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "struct: no se puede indexar"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "limite debe ser en el rango 0-65536"
+
 #~ msgid "tile index out of bounds"
 #~ msgstr "el indice del tile fuera de limite"
+
+#~ msgid "tile must be greater than zero"
+#~ msgstr "tile debe sera mas grande que cero"
+
+#~ msgid "time.struct_time() takes a 9-sequence"
+#~ msgstr "time.struct_time() toma un sequencio 9"
 
 #~ msgid "time.struct_time() takes exactly 1 argument"
 #~ msgstr "time.struct_time() acepta exactamente 1 argumento"
@@ -6504,11 +6407,41 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "timeout >100 (units are now seconds, not msecs)"
 #~ msgstr "timepo muerto >100 (unidades en segundos)"
 
+#~ msgid "timeout must be 0.0-100.0 seconds"
+#~ msgstr "el tiempo de espera debe ser 0.0-100.0 segundos"
+
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "tiempo muerto debe ser >= 0.0"
+
 #~ msgid "too many arguments"
 #~ msgstr "muchos argumentos"
 
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "demasiados argumentos provistos con el formato dado"
+
+#~ msgid "trapz is defined for 1D arrays"
+#~ msgstr "trapz esta definido para matrices 1D"
+
+#~ msgid "trigger level must be 0 or 1"
+#~ msgstr "nivel de accionamiento debe ser 0 o 1"
+
+#~ msgid "tuple index out of range"
+#~ msgstr "tuple index fuera de rango"
+
+#~ msgid "tuple/list required on RHS"
+#~ msgstr "tuple/lista se require en RHS"
+
+#~ msgid "type object 'generator' has no attribute '__await__'"
+#~ msgstr "objeto tipo 'generator' no tiene un atributo '__await__'"
+
+#~ msgid "unindent does not match any outer indentation level"
+#~ msgstr "sangría no coincide con ningún nivel exterior"
+
 #~ msgid "unknown config param"
 #~ msgstr "parámetro config desconocido"
+
+#~ msgid "unknown format code '%c' for object of type '%s'"
+#~ msgstr "codigo format desconocido '%c' para el typo de objeto '%s'"
 
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr "codigo format desconocido '%c' para el typo de objeto 'float'"
@@ -6519,5 +6452,54 @@ msgstr "zi debe ser una forma (n_section,2)"
 #~ msgid "unknown status param"
 #~ msgstr "status param desconocido"
 
+#~ msgid "unmatched '{' in format"
+#~ msgstr "No coinciden '{' en format"
+
+#~ msgid "unsupported type for %q: '%q'"
+#~ msgstr "tipo no soportado para %q: '%q'"
+
+#~ msgid "unsupported types for %q: '%s', '%s'"
+#~ msgstr "tipos no soportados para %q: '%s', '%s'"
+
+#~ msgid "value_count must be > 0"
+#~ msgstr "value_count debe ser > 0"
+
+#~ msgid "vectors must have same lengths"
+#~ msgstr "los vectores deben tener el mismo tamaño"
+
+#~ msgid "wakeup conflict"
+#~ msgstr "conflicto de wakeup"
+
+#~ msgid "watchdog not initialized"
+#~ msgstr "watchdog no inicializado"
+
+#~ msgid "watchdog timeout must be greater than 0"
+#~ msgstr "el tiempo de espera del perro guardián debe ser mayor a 0"
+
+#, c-format
+#~ msgid "width must be from 2 to 8 (inclusive), not %d"
+#~ msgstr "ancho debe estar entre 2 y 8 (inclusivamente), no %d"
+
 #~ msgid "wifi_set_ip_info() failed"
 #~ msgstr "wifi_set_ip_info() ha fallado"
+
+#~ msgid "wrong argument type"
+#~ msgstr "tipo de argumento incorrecto"
+
+#~ msgid "wrong operand type"
+#~ msgstr "tipo de operando incorrecto"
+
+#~ msgid "x value out of bounds"
+#~ msgstr "valor x fuera de límites"
+
+#~ msgid "xTaskCreate failed"
+#~ msgstr "fallo en xTaskCreate"
+
+#~ msgid "y should be an int"
+#~ msgstr "y deberia ser un int"
+
+#~ msgid "y value out of bounds"
+#~ msgstr "valor y fuera de límites"
+
+#~ msgid "zero step"
+#~ msgstr "paso cero"

--- a/locale/fil.po
+++ b/locale/fil.po
@@ -73,40 +73,10 @@ msgstr " output:\n"
 msgid "%%c requires int or char"
 msgstr "%%c nangangailangan ng int o char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr ""
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr "%S"
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
 msgstr ""
 
 #: shared-bindings/microcontroller/Pin.c
@@ -291,11 +261,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
 msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
@@ -940,7 +905,8 @@ msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Destination capacity is smaller than destination_length."
-msgstr "Ang kapasidad ng destinasyon ay mas maliit kaysa sa destination_length."
+msgstr ""
+"Ang kapasidad ng destinasyon ay mas maliit kaysa sa destination_length."
 
 #: ports/nrf/common-hal/audiobusio/I2SOut.c
 msgid "Device in use"
@@ -1617,8 +1583,9 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Tanging 8 o 16 na bit mono na may "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -4431,463 +4398,23 @@ msgstr ""
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
 
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' sa labas ng loop"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' sa labas ng loop"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Binibiyak gamit ang sub-captures"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "attributes hindi sinusuportahan"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr ""
-#~ "hindi maaaring gawin ang truncated division ng isang kumplikadong numero"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "hindi ma-import ang name %q"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr ""
-#~ "kindi pa ipinapatupad ang (mga) argument(s) ng keyword - gumamit ng "
-#~ "normal args"
-
-#~ msgid "length argument not allowed for this type"
-#~ msgstr "length argument ay walang pahintulot sa ganitong type"
-
-#, fuzzy
-#~ msgid "offset out of bounds"
-#~ msgstr "wala sa sakop ang address"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr "string hindi supportado; gumamit ng bytes o kaya bytearray"
-
-#~ msgid "queue overflow"
-#~ msgstr "puno na ang pila (overflow)"
-
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-#~ msgstr "pixel_shader ay dapat displayio.Palette o displayio.ColorConverter"
-
-#~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
-#~ msgstr ""
-#~ ".mpy file hindi compatible. Maaring i-update lahat ng .mpy files. See "
-#~ "http://adafru.it/mpy-update for more info."
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "hindi puede ang maraming **x"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "hindi puede ang maraming *x"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "constant ay dapat na integer"
-
-#~ msgid "invalid format"
-#~ msgstr "hindi wastong pag-format"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "ang keywords dapat strings"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "non-keyword arg sa huli ng */**"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "non-keyword arg sa huli ng keyword arg"
-
-#~ msgid "No RX pin"
-#~ msgstr "Walang RX pin"
-
-#~ msgid "No TX pin"
-#~ msgstr "Walang TX pin"
-
-#, fuzzy
-#~ msgid "x value out of bounds"
-#~ msgstr "wala sa sakop ang address"
-
-#, fuzzy
-#~ msgid "y value out of bounds"
-#~ msgstr "wala sa sakop ang address"
-
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "masyadong maraming mga argumento na ibinigay sa ibinigay na format"
-
-#~ msgid "Expected a %q"
-#~ msgstr "Umasa ng %q"
-
-#, fuzzy
-#~ msgid "Read-only object"
-#~ msgstr "Basahin-lamang"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Mali ang pins"
-
-#~ msgid "complex division by zero"
-#~ msgstr "kumplikadong dibisyon sa pamamagitan ng zero"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr "int() arg 2 ay dapat >=2 at <= 36"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "long int hindi sinusuportahan sa build na ito"
-
-#~ msgid "slice step cannot be zero"
-#~ msgstr "slice step ay hindi puedeng 0"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "step ay dapat hindi zero"
-
-#~ msgid "time.struct_time() takes a 9-sequence"
-#~ msgstr "time.struct_time() kumukuha ng 9-sequence"
-
-#~ msgid "zero step"
-#~ msgstr "zero step"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "isang '}' nasalubong sa format string"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "ang threshold ay dapat sa range 0-65536"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "hindi tugma ang '{' sa format"
-
-#~ msgid "To exit, please reset the board without "
-#~ msgstr "Para lumabas, paki-reset ang board na wala ang "
-
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "Ikaw ang humiling sa safe mode sa pamamagitan ng "
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "Stream kulang ng readinto() o write() method."
+#, c-format
+#~ msgid "%S"
+#~ msgstr "%S"
 
 #, fuzzy
 #~ msgid "%q must be >= 1"
 #~ msgstr "aarehas na haba dapat ang buffer slices"
 
-#~ msgid "address out of bounds"
-#~ msgstr "wala sa sakop ang address"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr "ang destination_length ay dapat na isang int >= 0"
-
-#~ msgid "color should be an int"
-#~ msgstr "color ay dapat na int"
-
-#, fuzzy
-#~ msgid "end_x should be an int"
-#~ msgstr "y ay dapat int"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "palette_index ay dapat na int"
-
-#, fuzzy
-#~ msgid "start_x should be an int"
-#~ msgstr "y ay dapat int"
-
-#~ msgid "y should be an int"
-#~ msgstr "y ay dapat int"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "ang sample_source buffer ay dapat na isang bytearray o array ng uri na "
-#~ "'h', 'H', 'b' o'B'"
-
 #, fuzzy
 #~ msgid "%q should be an int"
 #~ msgstr "y ay dapat int"
-
-#~ msgid "AnalogOut functionality not supported"
-#~ msgstr "Hindi supportado ang AnalogOut"
-
-#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-#~ msgstr "AnalogOut ay 16 bits. Value ay dapat hindi hihigit pa sa 65536."
-
-#~ msgid "AnalogOut not supported on given pin"
-#~ msgstr "Hindi supportado ang AnalogOut sa ibinigay na pin"
-
-#, c-format
-#~ msgid "Buffer incorrect size. Should be %d bytes."
-#~ msgstr "Mali ang size ng buffer. Dapat %d bytes."
-
-#~ msgid "Buffer must be at least length 1"
-#~ msgstr "Buffer dapat ay hindi baba sa 1 na haba"
-
-#~ msgid "Bytes must be between 0 and 255."
-#~ msgstr "Sa gitna ng 0 o 255 dapat ang bytes."
-
-#~ msgid "Cannot output both channels on the same pin"
-#~ msgstr "Hindi maaaring output ang mga parehong channel sa parehong pin"
-
-#~ msgid "Cannot read without MISO pin."
-#~ msgstr "Hindi maaring mabasa kapag walang MISO pin."
-
-#~ msgid "Cannot reset into bootloader because no bootloader is present."
-#~ msgstr "Hindi ma-reset sa bootloader dahil walang bootloader."
-
-#~ msgid "Cannot transfer without MOSI and MISO pins."
-#~ msgstr "Hindi maaaring ilipat kapag walang MOSI at MISO pin."
-
-#~ msgid "Cannot write without MOSI pin."
-#~ msgstr "Hindi maaring isulat kapag walang MOSI pin."
-
-#~ msgid "Clock pin init failed."
-#~ msgstr "Nabigo sa pag init ng Clock pin."
-
-#, fuzzy
-#~ msgid "Command must be an int between 0 and 255"
-#~ msgstr "Sa gitna ng 0 o 255 dapat ang bytes."
-
-#~ msgid "Could not initialize UART"
-#~ msgstr "Hindi ma-initialize ang UART"
-
-#~ msgid "Couldn't allocate first buffer"
-#~ msgstr "Hindi ma-iallocate ang first buffer"
-
-#~ msgid "Couldn't allocate second buffer"
-#~ msgstr "Hindi ma-iallocate ang second buffer"
-
-#~ msgid "Failed to allocate RX buffer"
-#~ msgstr "Nabigong ilaan ang RX buffer"
-
-#, c-format
-#~ msgid "Failed to allocate RX buffer of %d bytes"
-#~ msgstr "Nabigong ilaan ang RX buffer ng %d bytes"
-
-#~ msgid "Invalid BMP file"
-#~ msgstr "Mali ang BMP file"
-
-#~ msgid "Invalid PWM frequency"
-#~ msgstr "Mali ang PWM frequency"
-
-#~ msgid "Invalid buffer size"
-#~ msgstr "Mali ang buffer size"
-
-#~ msgid "Invalid channel count"
-#~ msgstr "Maling bilang ng channel"
-
-#~ msgid "Invalid direction."
-#~ msgstr "Mali ang direksyon."
-
-#~ msgid "Invalid file"
-#~ msgstr "Mali ang file"
-
-#~ msgid "Invalid number of bits"
-#~ msgstr "Mali ang bilang ng bits"
-
-#~ msgid "Invalid phase"
-#~ msgstr "Mali ang phase"
-
-#~ msgid "Invalid pin"
-#~ msgstr "Mali ang pin"
-
-#~ msgid "Invalid pin for left channel"
-#~ msgstr "Mali ang pin para sa kaliwang channel"
-
-#~ msgid "Invalid pin for right channel"
-#~ msgstr "Mali ang pin para sa kanang channel"
-
-#~ msgid "Invalid polarity"
-#~ msgstr "Mali ang polarity"
-
-#~ msgid "Invalid run mode."
-#~ msgstr "Mali ang run mode."
-
-#~ msgid "Invalid voice count"
-#~ msgstr "Maling bilang ng voice"
-
-#~ msgid "Invalid wave file"
-#~ msgstr "May hindi tama sa wave file"
-
-#~ msgid "MISO pin init failed."
-#~ msgstr "Hindi ma-initialize ang MISO pin."
-
-#~ msgid "MOSI pin init failed."
-#~ msgstr "Hindi ma-initialize ang MOSI pin."
-
-#~ msgid "No hardware support on pin"
-#~ msgstr "Walang support sa hardware ang pin"
-
-#~ msgid ""
-#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-#~ msgstr "PWM duty_cycle ay dapat sa loob ng 0 at 65535 (16 bit resolution)"
-
-#~ msgid "Pin does not have ADC capabilities"
-#~ msgstr "Ang pin ay walang kakayahan sa ADC"
-
-#~ msgid "RTC calibration is not supported on this board"
-#~ msgstr "RTC calibration ay hindi supportado ng board na ito"
-
-#~ msgid "Sample rate must be positive"
-#~ msgstr "Sample rate ay dapat positibo"
-
-#, c-format
-#~ msgid "Sample rate too high. It must be less than %d"
-#~ msgstr "Sample rate ay masyadong mataas. Ito ay dapat hindi hiigit sa %d"
-
-#~ msgid "Stack size must be at least 256"
-#~ msgstr "Ang laki ng stack ay dapat na hindi bababa sa 256"
-
-#~ msgid "Unsupported baudrate"
-#~ msgstr "Hindi supportadong baudrate"
-
-#~ msgid "bytes > 8 bits not supported"
-#~ msgstr "hindi sinusuportahan ang bytes > 8 bits"
-
-#~ msgid "calibration value out of range +/-127"
-#~ msgstr "ang halaga ng pagkakalibrate ay wala sa sakop +/-127"
-
-#~ msgid "stop must be 1 or 2"
-#~ msgstr "stop dapat 1 o 2"
-
-#, fuzzy
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "bits ay dapat walo (8)"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "Hindi sinusuportahang operasyon"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "Ang liwanag ay dapat sa gitna ng 0 o 255"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "hindi maaring isagawa ang relative import"
-
-#~ msgid "Unsupported pull value."
-#~ msgstr "Hindi suportado ang pull value."
-
-#, c-format
-#~ msgid ""
-#~ "Welcome to Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Please visit learn.adafruit.com/category/circuitpython for project "
-#~ "guides.\n"
-#~ "\n"
-#~ "To list built-in modules please do `help(\"modules\")`.\n"
-#~ msgstr ""
-#~ "Mabuhay sa Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Mangyaring bisitahin ang learn.adafruit.com/category/circuitpython para "
-#~ "sa project guides.\n"
-#~ "\n"
-#~ "Para makita ang listahan ng modules, `help(\"modules\")`.\n"
-
-#~ msgid "integer required"
-#~ msgstr "kailangan ng int"
-
-#~ msgid "abort() called"
-#~ msgstr "abort() tinawag"
-
-#~ msgid "invalid arguments"
-#~ msgstr "mali ang mga argumento"
-
-#~ msgid "unindent does not match any outer indentation level"
-#~ msgstr "unindent hindi tugma sa indentation level sa labas"
-
-#, fuzzy
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Hindi mabasa and Characteristic."
-
-#, fuzzy
-#~ msgid "Expected a UUID"
-#~ msgstr "Umasa ng %q"
-
-#~ msgid "no available NIC"
-#~ msgstr "walang magagamit na NIC"
-
-#~ msgid "USB Busy"
-#~ msgstr "Busy ang USB"
-
-#~ msgid "USB Error"
-#~ msgstr "May pagkakamali ang USB"
 
 #~ msgid "'%s' integer %d is not within range %d..%d"
 #~ msgstr "'%s' integer %d ay wala sa sakop ng %d..%d"
 
 #~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
 #~ msgstr "'%s' integer 0x%x ay wala sa mask na sakop ng 0x%x"
-
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "Hindi puedeng hindi sigurado ang get sizeof scalar"
-
-#~ msgid "Length must be an int"
-#~ msgstr "Haba ay dapat int"
-
-#~ msgid "Length must be non-negative"
-#~ msgstr "Haba ay dapat hindi negatibo"
-
-#~ msgid "name reused for argument"
-#~ msgstr "name muling ginamit para sa argument"
-
-#~ msgid "object does not support item assignment"
-#~ msgstr "ang object na '%s' ay hindi maaaring i-subscript"
-
-#~ msgid "object does not support item deletion"
-#~ msgstr "ang object ay hindi sumusuporta sa pagbura ng item"
-
-#~ msgid "object is not subscriptable"
-#~ msgstr "ang bagay ay hindi maaaring ma-subscript"
-
-#~ msgid "struct: cannot index"
-#~ msgstr "struct: hindi ma-index"
-
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "Hindi ma-remount '/' kapag aktibo ang USB."
-
-#~ msgid "byte code not implemented"
-#~ msgstr "byte code hindi pa implemented"
-
-#~ msgid "can't pend throw to just-started generator"
-#~ msgstr "hindi mapadala ang send throw sa isang kaka umpisang generator"
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "mali ang dupterm index"
-
-#~ msgid "schedule stack full"
-#~ msgstr "puno na ang schedule stack"
-
-#~ msgid "can only save bytecode"
-#~ msgstr "maaring i-save lamang ang bytecode"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr ""
-#~ "Ang mga function ng Viper ay kasalukuyang hindi sumusuporta sa higit sa 4 "
-#~ "na argumento"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "address %08x ay hindi pantay sa %d bytes"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "ang function ay hindi kumukuha ng mga argumento ng keyword"
-
-#~ msgid "parameter annotation must be an identifier"
-#~ msgstr "parameter annotation ay dapat na identifier"
-
-#~ msgid "buffer must be a bytes-like object"
-#~ msgstr "buffer ay dapat bytes-like object"
-
-#~ msgid "Group full"
-#~ msgstr "Puno ang group"
-
-#~ msgid "bits must be 7, 8 or 9"
-#~ msgstr "bits ay dapat 7, 8 o 9"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "Kailangan ng pull up resistors ang SDA o SCL"
-
-#~ msgid "tuple index out of range"
-#~ msgstr "indeks ng tuple wala sa sakop"
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr ""
-#~ "Pindutin ang anumang key upang pumasok sa REPL. Gamitin ang CTRL-D upang "
-#~ "i-reload."
 
 #~ msgid "'%s' object does not support item assignment"
 #~ msgstr "'%s' object hindi sumusuporta ng item assignment"
@@ -4907,32 +4434,36 @@ msgstr ""
 #~ msgid "'%s' object is not subscriptable"
 #~ msgstr "'%s' object ay hindi maaaring i-subscript"
 
-#~ msgid "Running in safe mode! Auto-reload is off.\n"
-#~ msgstr "Tumatakbo sa safe mode! Awtomatikong pag re-reload ay OFF.\n"
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' sa labas ng loop"
 
-#~ msgid "can't convert address to int"
-#~ msgstr "hindi ma i-convert ang address sa INT"
-
-#~ msgid "object '%s' is not a tuple or list"
-#~ msgstr "object '%s' ay hindi tuple o list"
-
-#~ msgid "pop from an empty set"
-#~ msgstr "pop sa walang laman na set"
-
-#~ msgid "pop from empty list"
-#~ msgstr "pop galing sa walang laman na list"
-
-#~ msgid "popitem(): dictionary is empty"
-#~ msgstr "popitem(): dictionary ay walang laman"
-
-#~ msgid "unknown format code '%c' for object of type '%s'"
-#~ msgstr "hindi alam ang format code '%c' para sa object na ang type ay '%s'"
-
-#~ msgid "unsupported types for %q: '%s', '%s'"
-#~ msgstr "hindi sinusuportahang type para sa %q: '%s', '%s'"
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' sa labas ng loop"
 
 #~ msgid "AP required"
 #~ msgstr "AP kailangan"
+
+#~ msgid "AnalogOut functionality not supported"
+#~ msgstr "Hindi supportado ang AnalogOut"
+
+#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#~ msgstr "AnalogOut ay 16 bits. Value ay dapat hindi hihigit pa sa 65536."
+
+#~ msgid "AnalogOut not supported on given pin"
+#~ msgstr "Hindi supportado ang AnalogOut sa ibinigay na pin"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "Ang liwanag ay dapat sa gitna ng 0 o 255"
+
+#, c-format
+#~ msgid "Buffer incorrect size. Should be %d bytes."
+#~ msgstr "Mali ang size ng buffer. Dapat %d bytes."
+
+#~ msgid "Buffer must be at least length 1"
+#~ msgstr "Buffer dapat ay hindi baba sa 1 na haba"
+
+#~ msgid "Bytes must be between 0 and 255."
+#~ msgstr "Sa gitna ng 0 o 255 dapat ang bytes."
 
 #~ msgid "C-level assert"
 #~ msgstr "C-level assert"
@@ -4955,11 +4486,48 @@ msgstr ""
 #~ msgid "Cannot disconnect from AP"
 #~ msgstr "Hindi ma disconnect sa AP"
 
+#~ msgid "Cannot output both channels on the same pin"
+#~ msgstr "Hindi maaaring output ang mga parehong channel sa parehong pin"
+
+#~ msgid "Cannot read without MISO pin."
+#~ msgstr "Hindi maaring mabasa kapag walang MISO pin."
+
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "Hindi ma-remount '/' kapag aktibo ang USB."
+
+#~ msgid "Cannot reset into bootloader because no bootloader is present."
+#~ msgstr "Hindi ma-reset sa bootloader dahil walang bootloader."
+
 #~ msgid "Cannot set STA config"
 #~ msgstr "Hindi ma-set ang STA Config"
 
+#~ msgid "Cannot transfer without MOSI and MISO pins."
+#~ msgstr "Hindi maaaring ilipat kapag walang MOSI at MISO pin."
+
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "Hindi puedeng hindi sigurado ang get sizeof scalar"
+
 #~ msgid "Cannot update i/f status"
 #~ msgstr "Hindi ma-update i/f status"
+
+#~ msgid "Cannot write without MOSI pin."
+#~ msgstr "Hindi maaring isulat kapag walang MOSI pin."
+
+#~ msgid "Clock pin init failed."
+#~ msgstr "Nabigo sa pag init ng Clock pin."
+
+#, fuzzy
+#~ msgid "Command must be an int between 0 and 255"
+#~ msgstr "Sa gitna ng 0 o 255 dapat ang bytes."
+
+#~ msgid "Could not initialize UART"
+#~ msgstr "Hindi ma-initialize ang UART"
+
+#~ msgid "Couldn't allocate first buffer"
+#~ msgstr "Hindi ma-iallocate ang first buffer"
+
+#~ msgid "Couldn't allocate second buffer"
+#~ msgstr "Hindi ma-iallocate ang second buffer"
 
 #~ msgid "Crash into the HardFault_Handler.\n"
 #~ msgstr "Nagcrash sa HardFault_Handler.\n"
@@ -4980,6 +4548,17 @@ msgstr ""
 #~ msgid "Error in ffi_prep_cif"
 #~ msgstr "Pagkakamali sa ffi_prep_cif"
 
+#~ msgid "Expected a %q"
+#~ msgstr "Umasa ng %q"
+
+#, fuzzy
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Hindi mabasa and Characteristic."
+
+#, fuzzy
+#~ msgid "Expected a UUID"
+#~ msgstr "Umasa ng %q"
+
 #, fuzzy
 #~ msgid "Failed to acquire mutex"
 #~ msgstr "Nabigo sa pag kuha ng mutex, status: 0x%08lX"
@@ -4995,6 +4574,13 @@ msgstr ""
 #, fuzzy
 #~ msgid "Failed to add service, err 0x%04x"
 #~ msgstr "Hindi matagumpay ang paglagay ng service, status: 0x%08lX"
+
+#~ msgid "Failed to allocate RX buffer"
+#~ msgstr "Nabigong ilaan ang RX buffer"
+
+#, c-format
+#~ msgid "Failed to allocate RX buffer of %d bytes"
+#~ msgstr "Nabigong ilaan ang RX buffer ng %d bytes"
 
 #, fuzzy
 #~ msgid "Failed to change softdevice state"
@@ -5091,17 +4677,81 @@ msgstr ""
 #~ msgid "GPIO16 does not support pull up."
 #~ msgstr "Walang pull down support ang GPI016."
 
+#~ msgid "Group full"
+#~ msgstr "Puno ang group"
+
 #~ msgid "I2C operation not supported"
 #~ msgstr "Hindi supportado ang operasyong I2C"
 
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ ".mpy file hindi compatible. Maaring i-update lahat ng .mpy files. See "
+#~ "http://adafru.it/mpy-update for more info."
+
+#~ msgid "Invalid BMP file"
+#~ msgstr "Mali ang BMP file"
+
+#~ msgid "Invalid PWM frequency"
+#~ msgstr "Mali ang PWM frequency"
+
 #~ msgid "Invalid bit clock pin"
 #~ msgstr "Mali ang bit clock pin"
+
+#~ msgid "Invalid buffer size"
+#~ msgstr "Mali ang buffer size"
+
+#~ msgid "Invalid channel count"
+#~ msgstr "Maling bilang ng channel"
 
 #~ msgid "Invalid clock pin"
 #~ msgstr "Mali ang clock pin"
 
 #~ msgid "Invalid data pin"
 #~ msgstr "Mali ang data pin"
+
+#~ msgid "Invalid direction."
+#~ msgstr "Mali ang direksyon."
+
+#~ msgid "Invalid file"
+#~ msgstr "Mali ang file"
+
+#~ msgid "Invalid number of bits"
+#~ msgstr "Mali ang bilang ng bits"
+
+#~ msgid "Invalid phase"
+#~ msgstr "Mali ang phase"
+
+#~ msgid "Invalid pin"
+#~ msgstr "Mali ang pin"
+
+#~ msgid "Invalid pin for left channel"
+#~ msgstr "Mali ang pin para sa kaliwang channel"
+
+#~ msgid "Invalid pin for right channel"
+#~ msgstr "Mali ang pin para sa kanang channel"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Mali ang pins"
+
+#~ msgid "Invalid polarity"
+#~ msgstr "Mali ang polarity"
+
+#~ msgid "Invalid run mode."
+#~ msgstr "Mali ang run mode."
+
+#~ msgid "Invalid voice count"
+#~ msgstr "Maling bilang ng voice"
+
+#~ msgid "Invalid wave file"
+#~ msgstr "May hindi tama sa wave file"
+
+#~ msgid "Length must be an int"
+#~ msgstr "Haba ay dapat int"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Haba ay dapat hindi negatibo"
 
 #~ msgid ""
 #~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
@@ -5112,6 +4762,12 @@ msgstr ""
 #~ "Maaring mag file ng issue sa https://github.com/adafruit/circuitpython/"
 #~ "issues\n"
 #~ "kasama ng laman ng iyong CIRCUITPY drive at ang message na ito:\n"
+
+#~ msgid "MISO pin init failed."
+#~ msgstr "Hindi ma-initialize ang MISO pin."
+
+#~ msgid "MOSI pin init failed."
+#~ msgstr "Hindi ma-initialize ang MOSI pin."
 
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "Pinakamataas na PWM frequency ay %dhz."
@@ -5133,8 +4789,20 @@ msgstr ""
 #~ msgid "No PulseIn support for %q"
 #~ msgstr "Walang PulseIn support sa %q"
 
+#~ msgid "No RX pin"
+#~ msgstr "Walang RX pin"
+
+#~ msgid "No TX pin"
+#~ msgstr "Walang TX pin"
+
 #~ msgid "No hardware support for analog out."
 #~ msgstr "Hindi supportado ng hardware ang analog out."
+
+#~ msgid "No hardware support on pin"
+#~ msgstr "Walang support sa hardware ang pin"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Tanging 8 o 16 na bit mono na may "
 
 #~ msgid "Only Windows format, uncompressed BMP supported %d"
 #~ msgstr "Tanging Windows format, uncompressed BMP lamang ang supportado %d"
@@ -5153,11 +4821,18 @@ msgstr ""
 #~ msgid "Only tx supported on UART1 (GPIO2)."
 #~ msgstr "Tanging suportado ang TX sa UART1 (GPIO2)."
 
+#~ msgid ""
+#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
+#~ msgstr "PWM duty_cycle ay dapat sa loob ng 0 at 65535 (16 bit resolution)"
+
 #~ msgid "PWM not supported on pin %d"
 #~ msgstr "Walang PWM support sa pin %d"
 
 #~ msgid "Pin %q does not have ADC capabilities"
 #~ msgstr "Walang kakayahang ADC ang pin %q"
+
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "Ang pin ay walang kakayahan sa ADC"
 
 #~ msgid "Pin(16) doesn't support pull"
 #~ msgstr "Walang pull support ang Pin(16)"
@@ -5165,15 +4840,49 @@ msgstr ""
 #~ msgid "Pins not valid for SPI"
 #~ msgstr "Mali ang pins para sa SPI"
 
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+#~ msgstr ""
+#~ "Pindutin ang anumang key upang pumasok sa REPL. Gamitin ang CTRL-D upang "
+#~ "i-reload."
+
+#~ msgid "RTC calibration is not supported on this board"
+#~ msgstr "RTC calibration ay hindi supportado ng board na ito"
+
 #, fuzzy
 #~ msgid "Range out of bounds"
 #~ msgstr "wala sa sakop ang address"
+
+#, fuzzy
+#~ msgid "Read-only object"
+#~ msgstr "Basahin-lamang"
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Tumatakbo sa safe mode! Awtomatikong pag re-reload ay OFF.\n"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "Kailangan ng pull up resistors ang SDA o SCL"
 
 #~ msgid "STA must be active"
 #~ msgstr "Dapat aktibo ang STA"
 
 #~ msgid "STA required"
 #~ msgstr "STA kailangan"
+
+#~ msgid "Sample rate must be positive"
+#~ msgstr "Sample rate ay dapat positibo"
+
+#, c-format
+#~ msgid "Sample rate too high. It must be less than %d"
+#~ msgstr "Sample rate ay masyadong mataas. Ito ay dapat hindi hiigit sa %d"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Binibiyak gamit ang sub-captures"
+
+#~ msgid "Stack size must be at least 256"
+#~ msgstr "Ang laki ng stack ay dapat na hindi bababa sa 256"
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "Stream kulang ng readinto() o write() method."
 
 #~ msgid ""
 #~ "The CircuitPython heap was corrupted because the stack was too small.\n"
@@ -5205,11 +4914,20 @@ msgstr ""
 #~ "Ang reset button ay pinindot habang nag boot ang CircuitPython. Pindutin "
 #~ "ulit para lumabas sa safe mode.\n"
 
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Para lumabas, paki-reset ang board na wala ang "
+
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "Walang UART(%d)"
 
 #~ msgid "UART(1) can't read"
 #~ msgstr "Hindi mabasa ang UART(1)"
+
+#~ msgid "USB Busy"
+#~ msgstr "Busy ang USB"
+
+#~ msgid "USB Error"
+#~ msgstr "May pagkakamali ang USB"
 
 #~ msgid "Unable to remount filesystem"
 #~ msgstr "Hindi ma-remount ang filesystem"
@@ -5217,23 +4935,74 @@ msgstr ""
 #~ msgid "Unknown type"
 #~ msgstr "Hindi alam ang type"
 
+#~ msgid "Unsupported baudrate"
+#~ msgstr "Hindi supportadong baudrate"
+
+#~ msgid "Unsupported operation"
+#~ msgstr "Hindi sinusuportahang operasyon"
+
+#~ msgid "Unsupported pull value."
+#~ msgstr "Hindi suportado ang pull value."
+
 #~ msgid "Use esptool to erase flash and re-upload Python instead"
 #~ msgstr ""
 #~ "Gamitin ang esptool upang burahin ang flash at muling i-upload ang Python"
 
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr ""
+#~ "Ang mga function ng Viper ay kasalukuyang hindi sumusuporta sa higit sa 4 "
+#~ "na argumento"
+
 #~ msgid "Voice index too high"
 #~ msgstr "Index ng Voice ay masyadong mataas"
+
+#, c-format
+#~ msgid ""
+#~ "Welcome to Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Please visit learn.adafruit.com/category/circuitpython for project "
+#~ "guides.\n"
+#~ "\n"
+#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ msgstr ""
+#~ "Mabuhay sa Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Mangyaring bisitahin ang learn.adafruit.com/category/circuitpython para "
+#~ "sa project guides.\n"
+#~ "\n"
+#~ "Para makita ang listahan ng modules, `help(\"modules\")`.\n"
 
 #~ msgid ""
 #~ "You are running in safe mode which means something unanticipated "
 #~ "happened.\n"
 #~ msgstr "Ikaw ay tumatakbo sa safe mode dahil may masamang nangyari.\n"
 
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "Ikaw ang humiling sa safe mode sa pamamagitan ng "
+
 #~ msgid "[addrinfo error %d]"
 #~ msgstr "[addrinfo error %d]"
 
+#~ msgid "abort() called"
+#~ msgstr "abort() tinawag"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "address %08x ay hindi pantay sa %d bytes"
+
+#~ msgid "address out of bounds"
+#~ msgstr "wala sa sakop ang address"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "attributes hindi sinusuportahan"
+
+#~ msgid "bits must be 7, 8 or 9"
+#~ msgstr "bits ay dapat 7, 8 o 9"
+
 #~ msgid "bits must be 8"
 #~ msgstr "bits ay dapat walo (8)"
+
+#~ msgid "buffer must be a bytes-like object"
+#~ msgstr "buffer ay dapat bytes-like object"
 
 #~ msgid "buffer too long"
 #~ msgstr "masyadong mahaba ng buffer"
@@ -5241,8 +5010,27 @@ msgstr ""
 #~ msgid "buffers must be the same length"
 #~ msgstr "ang buffers ay dapat parehas sa haba"
 
+#~ msgid "byte code not implemented"
+#~ msgstr "byte code hindi pa implemented"
+
+#~ msgid "bytes > 8 bits not supported"
+#~ msgstr "hindi sinusuportahan ang bytes > 8 bits"
+
+#~ msgid "calibration value out of range +/-127"
+#~ msgstr "ang halaga ng pagkakalibrate ay wala sa sakop +/-127"
+
+#~ msgid "can only save bytecode"
+#~ msgstr "maaring i-save lamang ang bytecode"
+
 #~ msgid "can query only one param"
 #~ msgstr "maaaring i-query lamang ang isang param"
+
+#~ msgid "can't convert address to int"
+#~ msgstr "hindi ma i-convert ang address sa INT"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr ""
+#~ "hindi maaaring gawin ang truncated division ng isang kumplikadong numero"
 
 #~ msgid "can't get AP config"
 #~ msgstr "hindi makuha ang AP config"
@@ -5250,17 +5038,48 @@ msgstr ""
 #~ msgid "can't get STA config"
 #~ msgstr "hindi makuha ang STA config"
 
+#~ msgid "can't have multiple **x"
+#~ msgstr "hindi puede ang maraming **x"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "hindi puede ang maraming *x"
+
+#~ msgid "can't pend throw to just-started generator"
+#~ msgstr "hindi mapadala ang send throw sa isang kaka umpisang generator"
+
 #~ msgid "can't set AP config"
 #~ msgstr "hindi makuha ang AP config"
 
 #~ msgid "can't set STA config"
 #~ msgstr "hindi makuha ang STA config"
 
+#~ msgid "cannot import name %q"
+#~ msgstr "hindi ma-import ang name %q"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "hindi maaring isagawa ang relative import"
+
 #~ msgid "color buffer must be a buffer or int"
 #~ msgstr "color buffer ay dapat buffer or int"
 
+#~ msgid "color should be an int"
+#~ msgstr "color ay dapat na int"
+
+#~ msgid "complex division by zero"
+#~ msgstr "kumplikadong dibisyon sa pamamagitan ng zero"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "constant ay dapat na integer"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr "ang destination_length ay dapat na isang int >= 0"
+
 #~ msgid "either pos or kw args are allowed"
 #~ msgstr "pos o kw args ang pinahihintulutan"
+
+#, fuzzy
+#~ msgid "end_x should be an int"
+#~ msgstr "y ay dapat int"
 
 #~ msgid "expected a DigitalInOut"
 #~ msgstr "umasa ng DigitalInOut"
@@ -5280,8 +5099,17 @@ msgstr ""
 #~ msgid "frequency can only be either 80Mhz or 160MHz"
 #~ msgstr "ang frequency ay dapat 80Mhz or 160MHz lamang"
 
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "ang function ay hindi kumukuha ng mga argumento ng keyword"
+
 #~ msgid "impossible baudrate"
 #~ msgstr "impossibleng baudrate"
+
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr "int() arg 2 ay dapat >=2 at <= 36"
+
+#~ msgid "integer required"
+#~ msgstr "kailangan ng int"
 
 #~ msgid "invalid I2C peripheral"
 #~ msgstr "maling I2C peripheral"
@@ -5292,11 +5120,20 @@ msgstr ""
 #~ msgid "invalid alarm"
 #~ msgstr "mali ang alarm"
 
+#~ msgid "invalid arguments"
+#~ msgstr "mali ang mga argumento"
+
 #~ msgid "invalid buffer length"
 #~ msgstr "mali ang buffer length"
 
 #~ msgid "invalid data bits"
 #~ msgstr "mali ang data bits"
+
+#~ msgid "invalid dupterm index"
+#~ msgstr "mali ang dupterm index"
+
+#~ msgid "invalid format"
+#~ msgstr "hindi wastong pag-format"
 
 #~ msgid "invalid pin"
 #~ msgstr "mali ang pin"
@@ -5304,8 +5141,22 @@ msgstr ""
 #~ msgid "invalid stop bits"
 #~ msgstr "mali ang stop bits"
 
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr ""
+#~ "kindi pa ipinapatupad ang (mga) argument(s) ng keyword - gumamit ng "
+#~ "normal args"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "ang keywords dapat strings"
+
 #~ msgid "len must be multiple of 4"
 #~ msgstr "len ay dapat multiple ng 4"
+
+#~ msgid "length argument not allowed for this type"
+#~ msgstr "length argument ay walang pahintulot sa ganitong type"
+
+#~ msgid "long int not supported in this build"
+#~ msgstr "long int hindi sinusuportahan sa build na ito"
 
 #~ msgid "memory allocation failed, allocating %u bytes for native code"
 #~ msgstr ""
@@ -5318,14 +5169,63 @@ msgstr ""
 #~ msgid "name must be a string"
 #~ msgstr "ang keywords dapat strings"
 
+#~ msgid "name reused for argument"
+#~ msgstr "name muling ginamit para sa argument"
+
+#~ msgid "no available NIC"
+#~ msgstr "walang magagamit na NIC"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "non-keyword arg sa huli ng */**"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "non-keyword arg sa huli ng keyword arg"
+
 #~ msgid "not a valid ADC Channel: %d"
 #~ msgstr "hindi tamang ADC Channel: %d"
+
+#~ msgid "object '%s' is not a tuple or list"
+#~ msgstr "object '%s' ay hindi tuple o list"
+
+#~ msgid "object does not support item assignment"
+#~ msgstr "ang object na '%s' ay hindi maaaring i-subscript"
+
+#~ msgid "object does not support item deletion"
+#~ msgstr "ang object ay hindi sumusuporta sa pagbura ng item"
+
+#~ msgid "object is not subscriptable"
+#~ msgstr "ang bagay ay hindi maaaring ma-subscript"
+
+#, fuzzy
+#~ msgid "offset out of bounds"
+#~ msgstr "wala sa sakop ang address"
+
+#~ msgid "palette_index should be an int"
+#~ msgstr "palette_index ay dapat na int"
+
+#~ msgid "parameter annotation must be an identifier"
+#~ msgstr "parameter annotation ay dapat na identifier"
 
 #~ msgid "pin does not have IRQ capabilities"
 #~ msgstr "walang IRQ capabilities ang pin"
 
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+#~ msgstr "pixel_shader ay dapat displayio.Palette o displayio.ColorConverter"
+
+#~ msgid "pop from an empty set"
+#~ msgstr "pop sa walang laman na set"
+
+#~ msgid "pop from empty list"
+#~ msgstr "pop galing sa walang laman na list"
+
+#~ msgid "popitem(): dictionary is empty"
+#~ msgstr "popitem(): dictionary ay walang laman"
+
 #~ msgid "position must be 2-tuple"
 #~ msgstr "position ay dapat 2-tuple"
+
+#~ msgid "queue overflow"
+#~ msgstr "puno na ang pila (overflow)"
 
 #, fuzzy
 #~ msgid "readonly attribute"
@@ -5334,8 +5234,46 @@ msgstr ""
 #~ msgid "row must be packed and word aligned"
 #~ msgstr "row ay dapat packed at ang word nakahanay"
 
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "ang sample_source buffer ay dapat na isang bytearray o array ng uri na "
+#~ "'h', 'H', 'b' o'B'"
+
 #~ msgid "scan failed"
 #~ msgstr "nabigo ang pag-scan"
+
+#~ msgid "schedule stack full"
+#~ msgstr "puno na ang schedule stack"
+
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "isang '}' nasalubong sa format string"
+
+#~ msgid "slice step cannot be zero"
+#~ msgstr "slice step ay hindi puedeng 0"
+
+#, fuzzy
+#~ msgid "start_x should be an int"
+#~ msgstr "y ay dapat int"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "step ay dapat hindi zero"
+
+#~ msgid "stop must be 1 or 2"
+#~ msgstr "stop dapat 1 o 2"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr "string hindi supportado; gumamit ng bytes o kaya bytearray"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "struct: hindi ma-index"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "ang threshold ay dapat sa range 0-65536"
+
+#~ msgid "time.struct_time() takes a 9-sequence"
+#~ msgstr "time.struct_time() kumukuha ng 9-sequence"
 
 #~ msgid "time.struct_time() takes exactly 1 argument"
 #~ msgstr "time.struct_time() kumukuha ng 1 argument"
@@ -5343,11 +5281,27 @@ msgstr ""
 #~ msgid "timeout >100 (units are now seconds, not msecs)"
 #~ msgstr "timeout >100 (units ay seconds, hindi na msecs)"
 
+#, fuzzy
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "bits ay dapat walo (8)"
+
 #~ msgid "too many arguments"
 #~ msgstr "masyadong maraming argumento"
 
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "masyadong maraming mga argumento na ibinigay sa ibinigay na format"
+
+#~ msgid "tuple index out of range"
+#~ msgstr "indeks ng tuple wala sa sakop"
+
+#~ msgid "unindent does not match any outer indentation level"
+#~ msgstr "unindent hindi tugma sa indentation level sa labas"
+
 #~ msgid "unknown config param"
 #~ msgstr "hindi alam na config param"
+
+#~ msgid "unknown format code '%c' for object of type '%s'"
+#~ msgstr "hindi alam ang format code '%c' para sa object na ang type ay '%s'"
 
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr "hindi alam ang format code '%c' sa object na ang type ay 'float'"
@@ -5359,5 +5313,25 @@ msgstr ""
 #~ msgid "unknown status param"
 #~ msgstr "hindi alam na status param"
 
+#~ msgid "unmatched '{' in format"
+#~ msgstr "hindi tugma ang '{' sa format"
+
+#~ msgid "unsupported types for %q: '%s', '%s'"
+#~ msgstr "hindi sinusuportahang type para sa %q: '%s', '%s'"
+
 #~ msgid "wifi_set_ip_info() failed"
 #~ msgstr "nabigo ang wifi_set_ip_info()"
+
+#, fuzzy
+#~ msgid "x value out of bounds"
+#~ msgstr "wala sa sakop ang address"
+
+#~ msgid "y should be an int"
+#~ msgstr "y ay dapat int"
+
+#, fuzzy
+#~ msgid "y value out of bounds"
+#~ msgstr "wala sa sakop ang address"
+
+#~ msgid "zero step"
+#~ msgstr "zero step"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -32,8 +32,8 @@ msgid ""
 "Code stopped by auto-reload. Reloading soon.\n"
 msgstr ""
 "\n"
-"Le code a été arrêté par l'actualisation automatique. Rechargement prochain."
-"\n"
+"Le code a été arrêté par l'actualisation automatique. Rechargement "
+"prochain.\n"
 
 #: supervisor/shared/safe_mode.c
 msgid ""
@@ -86,16 +86,6 @@ msgstr " sortie :\n"
 msgid "%%c requires int or char"
 msgstr "%%c nécessite un chiffre entier 'int' ou un caractère 'char'"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr "%S"
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
@@ -103,26 +93,6 @@ msgid ""
 msgstr ""
 "%d broches d'adresse, %d broches RGB et %d pour tile indique une hauteur de "
 "%d, et non %d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -293,11 +263,13 @@ msgstr "%q=%q"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] shifts in more bits than pin count"
-msgstr "%q[%u] décale vers l'intérieur de plus de bits que le nombre de broches"
+msgstr ""
+"%q[%u] décale vers l'intérieur de plus de bits que le nombre de broches"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] shifts out more bits than pin count"
-msgstr "%q[%u] décale vers l'extérieur de plus de bits que le nombre de broches"
+msgstr ""
+"%q[%u] décale vers l'extérieur de plus de bits que le nombre de broches"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] uses extra pin"
@@ -306,11 +278,6 @@ msgstr "%q[%u] utilise des broches supplémentaires"
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
 msgstr "%q[%u] attend sur une entrée hors du compte"
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
-msgstr "%s"
 
 #: ports/espressif/common-hal/espidf/__init__.c
 #, c-format
@@ -839,7 +806,8 @@ msgstr "Ne peut démonter '/' quand est visible par USB."
 #: ports/cxd56/common-hal/microcontroller/__init__.c
 #: ports/mimxrt10xx/common-hal/microcontroller/__init__.c
 msgid "Cannot reset into bootloader because no bootloader is present"
-msgstr "Impossible de redémarrer dans le bootloader puisque aucun n'est présent"
+msgstr ""
+"Impossible de redémarrer dans le bootloader puisque aucun n'est présent"
 
 #: ports/espressif/common-hal/socketpool/Socket.c
 msgid "Cannot set socket options"
@@ -1664,8 +1632,9 @@ msgstr "OK"
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Uniquement 8 ou 16 bit mono avec "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -3368,7 +3337,8 @@ msgstr "les formes d'entrée et de sortie sont différentes"
 
 #: extmod/ulab/code/numpy/create.c
 msgid "input argument must be an integer, a tuple, or a list"
-msgstr "le paramètre entrant doit être un nombre entier, un tuple, ou une liste"
+msgstr ""
+"le paramètre entrant doit être un nombre entier, un tuple, ou une liste"
 
 #: extmod/ulab/code/numpy/fft/fft_tools.c
 msgid "input array length must be power of 2"
@@ -4512,319 +4482,19 @@ msgstr "zi doit être de type float"
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi doit être de forme (n_section, 2)"
 
-#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
-#~ msgstr "Taille CIRCUITPY_PYSTACK_SIZE invalide\n"
-
-#~ msgid "Unable to allocate the heap."
-#~ msgstr "Impossible d'allouer le tas."
-
 #~ msgid ""
-#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
 #~ msgstr ""
-#~ "espcamera.Camera a besoin de PSRAM réservée. Voir la documentation pour "
-#~ "les instructions."
-
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr "'await', 'async for' ou 'async with' dehors d'une fonction async"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' dehors d'une boucle"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' dehors d'une boucle"
-
-#~ msgid "invalid architecture"
-#~ msgstr "architecture invalide"
-
-#~ msgid "unsupported type for %q: '%q'"
-#~ msgstr "type non supporté pour %q : '%q'"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Fractionnement avec des sous-captures"
-
-#~ msgid "__init__() should return None, not '%q'"
-#~ msgstr "__init__() doit retourner None, pas '%q'"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "attribut pas encore supporté"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr "on ne peut pas faire de division tronquée de nombres complexes"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "ne peut pas importer le nom %q"
-
-#~ msgid "cannot unambiguously get sizeof scalar"
-#~ msgstr "ne peut récupérer sans ambigüité le sizeof d'un scalaire"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr ""
-#~ "argument(s) nommé(s) pas encore implémenté(s) - utilisez les arguments "
-#~ "normaux"
-
-#~ msgid "length argument not allowed for this type"
-#~ msgstr "paramètre 'length' non-permis pour ce type"
-
-#~ msgid "offset out of bounds"
-#~ msgstr "décalage hors limites"
-
-#~ msgid "slice step can't be zero"
-#~ msgstr "le pas 'step' de la tranche ne peut être zéro"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr ""
-#~ "chaîne de carac. non supportée; utilisez des bytes ou une matrice de bytes"
-
-#~ msgid "Bit clock and word select must be sequential pins"
-#~ msgstr ""
-#~ "La sélection du bit d'horloge et de mot doit être sur des broches "
-#~ "séquentielles"
-
-#~ msgid "Initialization failed due to lack of memory"
-#~ msgstr "Échec d'initialisation par manque de mémoire"
-
-#~ msgid "RAISE mode is not implemented"
-#~ msgstr "Mode RAISE n'est pas implémenté"
-
-#~ msgid "WatchDogTimer is not currently running"
-#~ msgstr "WatchDogTimer n'est pas en cours d'exécution"
-
-#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-#~ msgstr ""
-#~ "WatchDogTimer.mode ne peut pas être changé une fois réglé à WatchDogMode."
-#~ "RESET"
-
-#~ msgid "watchdog not initialized"
-#~ msgstr "chien de garde (watchdog) non initialisé"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "ADC2 est utilisé pars le Wifi"
-
-#~ msgid "xTaskCreate failed"
-#~ msgstr "Échec de xTaskCreate"
-
-#~ msgid "Unable to write to address."
-#~ msgstr "L'écriture a échoué."
-
-#~ msgid "queue overflow"
-#~ msgstr "dépassement de file"
-
-#~ msgid "Stopping AP is not supported."
-#~ msgstr "Stopper n'est pas supporté."
-
-#~ msgid "Wifi is in access point mode."
-#~ msgstr "Wifi en mode point d'accès."
-
-#~ msgid "Wifi is in station mode."
-#~ msgstr "Wifi en mode station."
+#~ "\n"
+#~ "Fin d'exécution du code. En attente de rechargement.\n"
 
 #~ msgid ""
 #~ "\n"
-#~ "Please file an issue with your program at https://github.com/adafruit/"
-#~ "circuitpython/issues."
+#~ "Code stopped by auto-reload.\n"
 #~ msgstr ""
 #~ "\n"
-#~ "Veuillez signaler un problème avec votre programme sur https://github.com/"
-#~ "adafruit/circuitpython/issues."
-
-#~ msgid "'coroutine' object is not an iterator"
-#~ msgstr "L'objet \"coroutine\" n'est pas un itérateur"
-
-#~ msgid "Buffer is too small"
-#~ msgstr "Le tampon est trop petit"
-
-#~ msgid "The power dipped. Make sure you are providing enough power."
-#~ msgstr "La puissance a chu. Assurez vous de fournir assez de puissance."
-
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-#~ msgstr ""
-#~ "pixel_shader doit être un objet displayio.Palette ou displayio."
-#~ "ColorConverter"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "Fichier .mpy corrompu"
-
-#~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
-#~ msgstr ""
-#~ "Fichier .mpy incompatible. Merci de mettre à jour tous les fichiers .mpy. "
-#~ "Voir http://adafru.it/mpy-update pour plus d'informations."
-
-#~ msgid "can't convert to %q"
-#~ msgstr "impossible de convertir en %q"
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "il ne peut y avoir de **x multiples"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "il ne peut y avoir de *x multiples"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "constante doit être un entier"
-
-#~ msgid "incompatible native .mpy architecture"
-#~ msgstr "architecture native .mpy incompatible"
-
-#~ msgid "invalid format"
-#~ msgstr "format invalide"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "les noms doivent être des chaînes de caractères"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "argument non-nommé après */**"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "argument non-nommé après argument nommé"
-
-#, c-format
-#~ msgid "Instruction %d shifts in more bits than pin count"
-#~ msgstr ""
-#~ "Instruction %d décale vers l'intérieur de plus de bits que le nombre de "
-#~ "broches"
-
-#, c-format
-#~ msgid "Instruction %d shifts out more bits than pin count"
-#~ msgstr ""
-#~ "instruction %d décale vers l'extérieur de plus de bits que le nombre de "
-#~ "broches"
-
-#, c-format
-#~ msgid "Instruction %d uses extra pin"
-#~ msgstr "instruction %d utilise des broches supplémentaires"
-
-#, c-format
-#~ msgid "Instruction %d waits on input outside of count"
-#~ msgstr "instruction %d attend sur une entrée hors du compte"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
-#~ msgstr "first_in_pin manquant. Instruction %d lit une/des broche(s)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
-#~ msgstr ""
-#~ "first_in_pin manquant. Instruction %d est déplacée par la/les broche(s)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
-#~ msgstr ""
-#~ "first_in_pin manquant. L'instruction %d attends dépends de la broche"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
-#~ msgstr ""
-#~ "first_out_pin manquant. Instruction %d est déplacée par la/les broche(s)"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
-#~ msgstr "first_out_pin manquant. Instruction %d écrit un/des broche(s)"
-
-#, c-format
-#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
-#~ msgstr "first_set_pin manquant. L'instruction %d règle la/les broche(s)"
-
-#, c-format
-#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
-#~ msgstr "jmp_pin manquant. L'instruction %d va passer à la broche"
-
-#~ msgid "inputs are not iterable"
-#~ msgstr "les entrées ne sont pas itérables"
-
-#~ msgid "Too many display busses"
-#~ msgstr "Trop de bus d'affichage"
-
-#~ msgid "Cannot transfer without MOSI and MISO pins"
-#~ msgstr "Impossible de transférer sans une broche MOSI ou MISO"
-
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Matériel occupé, essayez d'autres broches"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "Broche MISO ou MOSI manquante"
-
-#~ msgid "Missing MISO or MOSI pin"
-#~ msgstr "La broche MISO ou MOSI est manquante"
-
-#~ msgid "No MISO Pin"
-#~ msgstr "Pas de broche MISO"
-
-#~ msgid "No MISO pin"
-#~ msgstr "Aucune broche MISO"
-
-#~ msgid "No MOSI Pin"
-#~ msgstr "Pas de broche MOSI"
-
-#~ msgid "No MOSI pin"
-#~ msgstr "Aucune broche MOSI"
-
-#~ msgid "No RX pin"
-#~ msgstr "Pas de broche RX"
-
-#~ msgid "No TX pin"
-#~ msgstr "Pas de broche TX"
-
-#~ msgid "no reset pin available"
-#~ msgstr "pas de broche de réinitialisation disponible"
-
-#~ msgid "Sleep Memory not available"
-#~ msgstr "La mémoire de sommeil n'est pas disponible"
-
-#~ msgid "input and output shapes are not compatible"
-#~ msgstr "les formes d'entrée et de sortie ne sont pas compatibles"
-
-#~ msgid "shape must be a tuple"
-#~ msgstr "forme doit être un tuple"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "La luminosité doit être de 0 à 1.0"
-
-#, c-format
-#~ msgid "Error in MIDI stream at position %d"
-#~ msgstr "Erreur dans le flot MIDI à la position %d"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "La valeur maximale de x est %d lors d'une opération miroir"
-
-#~ msgid "x value out of bounds"
-#~ msgstr "valeur x hors limites"
-
-#~ msgid "y value out of bounds"
-#~ msgstr "valeur y hors limites"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "I2SOut n'est pas disponible"
-
-#~ msgid "PDMIn not available"
-#~ msgstr "PDMIn non disponible"
-
-#~ msgid "out of range of source"
-#~ msgstr "en dehors de l'intervalle de la source"
-
-#~ msgid "pixel value requires too many bits"
-#~ msgstr "la valeur du pixel requiet trop de bits"
-
-#~ msgid "value_count must be > 0"
-#~ msgstr "'value_count' doit être > 0"
-
-#~ msgid "64 bit types"
-#~ msgstr "types à 64 bit"
-
-#~ msgid "No key was specified"
-#~ msgstr "Aucune clé n'a été spécifiée"
-
-#~ msgid "Scan already in progess. Stop with stop_scan."
-#~ msgstr "Scan déjà en cours. Arrêtez avec stop_scan."
-
-#, c-format
-#~ msgid "Unkown error code %d"
-#~ msgstr "Erreur inconnue %d"
-
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "trop d'arguments fournis avec ce format"
+#~ "Exécution du code arrêté par l'auto-rechargement.\n"
 
 #~ msgid ""
 #~ "\n"
@@ -4837,12 +4507,6 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ "\n"
 #~ "\n"
 
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "Fournissez au moins une broche UART"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "broche %q invalide"
-
 #~ msgid ""
 #~ "\n"
 #~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
@@ -4853,756 +4517,49 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ "à l'adresse\n"
 #~ "https://github.com/adafruit/circuitpython/issues\n"
 
-#~ msgid "Attempted heap allocation when VM not running."
+#~ msgid ""
+#~ "\n"
+#~ "Please file an issue with your program at https://github.com/adafruit/"
+#~ "circuitpython/issues."
 #~ msgstr ""
-#~ "Tentative d'allocation à la pile quand la Machine Virtuelle n'est pas en "
-#~ "exécution."
-
-#~ msgid "Boot device must be first device (interface #0)."
-#~ msgstr "L'appareil de démarrage doit être le premier (interface #0)."
-
-#~ msgid "Both buttons were pressed at start up.\n"
-#~ msgstr "Les deux boutons étaient pressés au démarrage.\n"
-
-#~ msgid "Button A was pressed at start up.\n"
-#~ msgstr "Le bouton A était pressé au démarrage.\n"
-
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "CircuitPython n'as pu faire l'allocation de la pile."
-
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "Échec vers le HardFault_Handler."
-
-#~ msgid "Fatal error."
-#~ msgstr "Erreurre fatale."
-
-#~ msgid "Invalid memory access."
-#~ msgstr "Accès à la mémoire invalide."
-
-#~ msgid "Nordic system firmware failure assertion."
-#~ msgstr "Assertion échouée du logiciel système Nordic."
-
-#~ msgid "The BOOT button was pressed at start up.\n"
-#~ msgstr "Le bouton BOOT était pressé au démarrage.\n"
+#~ "\n"
+#~ "Veuillez signaler un problème avec votre programme sur https://github.com/"
+#~ "adafruit/circuitpython/issues."
 
 #~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Increase the stack size if you know how. If not:"
+#~ "\n"
+#~ "To exit, please reset the board without "
 #~ msgstr ""
-#~ "La pile de CircuitPython est corrompue parce que la pile était trop "
-#~ "petite.\n"
-#~ "Augmentez la taille de la pile si vous savez comment. Sinon :"
-
-#~ msgid "The SW38 button was pressed at start up.\n"
-#~ msgstr "Le bouton SW38 était pressé au démarrage.\n"
-
-#~ msgid "The VOLUME button was pressed at start up.\n"
-#~ msgstr "Le bouton VOLUME était pressé au démarrage.\n"
-
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode."
-#~ msgstr ""
-#~ "Le module `microcontroller` a été utilisé pour démarrer en mode sûr. "
-#~ "Pressez reset pour quitter le mode sûr."
-
-#~ msgid "The central button was pressed at start up.\n"
-#~ msgstr "Le bouton central était pressé au démarrage.\n"
-
-#~ msgid "The left button was pressed at start up.\n"
-#~ msgstr "Le bouton gauche était pressé au démarrage.\n"
-
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY)."
-#~ msgstr ""
-#~ "L'alimentation du microcontrôleur a diminué. Veillez à ce que votre "
-#~ "alimentation fournisse\n"
-#~ "assez de puissance pour tout le circuit, puis appuyez sur 'reset' (après "
-#~ "avoir éjecté CIRCUITPY)."
-
-#~ msgid "To exit, please reset the board without requesting safe mode."
-#~ msgstr "Pour le quitter, redémarrez sans demander le mode sans-échec."
-
-#~ msgid "You are in safe mode because:\n"
-#~ msgstr "Vous êtes en mode sûr parce que :\n"
-
-#~ msgid ""
-#~ "You pressed the reset button during boot. Press again to exit safe mode."
-#~ msgstr ""
-#~ "Vous avez pressé le bouton reset pendant le démarrage. Pressez-le à "
-#~ "nouveau pour sortir du mode sûr."
-
-#~ msgid ""
-#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
-#~ msgstr ""
-#~ "esp32_camera.Camera nécessite la configuration de PSRAM réservée. Se "
-#~ "référer à la documentation."
-
-#~ msgid "%q must be of type %q"
-#~ msgstr "%q doit être du type %q"
-
-#~ msgid "%q must be of type %q or None"
-#~ msgstr "%q doit être du type %q ou None"
-
-#~ msgid "Expected a %q"
-#~ msgstr "Attendu un %q"
-
-#~ msgid "Expected a %q or %q"
-#~ msgstr "Attendu un %q ou %q"
+#~ "\n"
+#~ "Pour quitter, veuillez réinitialiser la carte sans "
 
 #, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IV doit être de longueur de %d octets"
+#~ msgid "%02X"
+#~ msgstr "%02X"
 
-#~ msgid "Not settable"
-#~ msgstr "Non réglable"
+#, c-format
+#~ msgid "%S"
+#~ msgstr "%S"
 
-#~ msgid "expected '%q' but got '%q'"
-#~ msgstr "'%q' était attendu, mais reçu '%q'"
+#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+#~ msgstr ""
+#~ "Les broches d'adresse %d et les broches RVB %d indiquent une hauteur de "
+#~ "%d, pas %d"
 
-#~ msgid "expected '%q' or '%q' but got '%q'"
-#~ msgstr "'%q' ou '%q' était attendu, mais reçu '%q'"
+#~ msgid "%q"
+#~ msgstr "%q"
 
-#~ msgid "Read-only object"
-#~ msgstr "Objet en lecture seule"
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "indices %q doivent être des chiffres entiers, et non %q"
 
-#~ msgid "frequency is read-only for this board"
-#~ msgstr "la fréquence est en lecture seule pour cette carte"
-
-#~ msgid "Unable to write"
-#~ msgstr "Écriture impossible"
+#~ msgid "%q length must be %q"
+#~ msgstr "La longueur de %q doit être de %q"
 
 #~ msgid "%q length must be >= 1"
 #~ msgstr "La longueur de %q doit être >= 1"
 
-#~ msgid "%q must be a string"
-#~ msgstr "%q doit être une chaîne de caractères"
-
-#~ msgid "%q must be an int"
-#~ msgstr "%q doit être un entier"
-
-#~ msgid "%q with a report ID of 0 must be of length 1"
-#~ msgstr "%q avec un identifiant de rapport à 0 doit être de longueur 1"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "Au plus %d %q peut être spécifié (pas %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Broches invalides"
-
-#, c-format
-#~ msgid "No more than %d HID devices allowed"
-#~ msgstr "Pas plus de %d appareils HID autorisés"
-
-#~ msgid "byteorder is not a string"
-#~ msgstr "byteorder n'est pas une chaîne"
-
-#~ msgid "can't convert %q to int"
-#~ msgstr "ne peut convertir %q à int"
-
-#~ msgid "complex division by zero"
-#~ msgstr "division complexe par zéro"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr ""
-#~ "Le deuxième argument de int() doit être compris entre 2 et 36 inclus"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "entiers longs non supportés dans cette build"
-
-#~ msgid "slice step cannot be zero"
-#~ msgstr "le pas 'step' de la tranche ne peut être zéro"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "le pas 'step' doit être non nul"
-
-#~ msgid "string indices must be integers, not %q"
-#~ msgstr "les indices d'une chaîne doivent être des entiers, pas %q"
-
-#~ msgid "time.struct_time() takes a 9-sequence"
-#~ msgstr "time.struct_time() prend une séquence de longueur 9"
-
-#~ msgid "zero step"
-#~ msgstr "'step' nul"
-
-#~ msgid "invalid traceback"
-#~ msgstr "traceback invalide"
-
-#~ msgid "WatchDogTimer.timeout must be greater than 0"
-#~ msgstr "WatchDogTimer.timeout doit être supérieur à 0"
-
-#~ msgid "non-Device in %q"
-#~ msgstr "aucun appareil dans %q"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "'}' seule rencontrée dans une chaîne de format"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "le seuil doit être dans la portée 0-65536"
-
-#~ msgid "timeout must be 0.0-100.0 seconds"
-#~ msgstr "le délai doit être compris entre 0.0 et 100.0 secondes"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "'{' sans correspondance dans le format"
-
-#~ msgid "watchdog timeout must be greater than 0"
-#~ msgstr "watchdog timeout doit être supérieur à 0"
-
-#~ msgid "To exit, please reset the board without "
-#~ msgstr "Pour quitter, SVP redémarrez la carte sans "
-
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "Vous avez demandé à démarrer en mode sans-échec par "
-
-#~ msgid "pressing BOOT button at start up.\n"
-#~ msgstr "presser le bouton BOOT au démarrage.\n"
-
-#~ msgid "pressing SW38 button at start up.\n"
-#~ msgstr "presser le bouton SW38 au démarrage.\n"
-
-#~ msgid "pressing VOLUME button at start up.\n"
-#~ msgstr "presser le bouton VOLUME au démarrage.\n"
-
-#~ msgid "pressing boot button at start up.\n"
-#~ msgstr "bouton boot appuyé lors du démarrage.\n"
-
-#~ msgid "pressing both buttons at start up.\n"
-#~ msgstr "les deux boutons appuyés lors du démarrage.\n"
-
-#~ msgid "pressing the left button at start up\n"
-#~ msgstr "appuyer le bouton de gauche au démarrage\n"
-
-#~ msgid "Only one TouchAlarm can be set in deep sleep."
-#~ msgstr "Seulement une TouchAlarm peut être réglée en sommeil profond."
-
-#~ msgid "Firmware image is invalid"
-#~ msgstr "Image du microprogramme est invalide"
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "Il manque une méthode readinto() ou write() au flux."
-
-#~ msgid "%q must be >= 0"
-#~ msgstr "%q doit être >= 0"
-
-#~ msgid "%q must be >= 1"
-#~ msgstr "%q doit être >= 1"
-
-#~ msgid "address out of bounds"
-#~ msgstr "adresse hors limites"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr "destination_length doit être un entier >= 0"
-
-#~ msgid "type object 'generator' has no attribute '__await__'"
-#~ msgstr "le type 'generator' n'a pas d'attribut '__await__'"
-
-#~ msgid "color should be an int"
-#~ msgstr "la couleur doit être un entier 'int'"
-
-#~ msgid "end_x should be an int"
-#~ msgstr "end_x doit être un entier 'int'"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "palette_index devrait être un entier 'int'"
-
-#~ msgid "start_x should be an int"
-#~ msgstr "'start_x' doit être un entier 'int'"
-
-#~ msgid "y should be an int"
-#~ msgstr "'y' doit être un entier 'int'"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "tampon sample_source doit être un bytearray ou une matrice de type 'h', "
-#~ "'H', 'b' ou 'B'"
-
-#~ msgid "Expected an alarm"
-#~ msgstr "Une alarme était prévue"
-
-#~ msgid "All I2C targets are in use"
-#~ msgstr "Toutes les cibles I2C sont utilisées"
-
-#~ msgid "Failed to init wifi"
-#~ msgstr "Échec de l'initialisation du Wifi"
-
-#~ msgid "input must be a tensor of rank 2"
-#~ msgstr "l'entrée doit être un tenseur de rang 2"
-
-#~ msgid "maximum number of dimensions is 4"
-#~ msgstr "nombre maximal de dimensions est 4"
-
-#~ msgid "Watchdog timer expired."
-#~ msgstr "Le minuteur Watchdog a expiré."
-
-#~ msgid "ssid can't be more than 32 bytes"
-#~ msgstr "un ssid ne peut pas faire plus de 32 octets"
-
-#~ msgid "%q must be a tuple of length 2"
-#~ msgstr "%q doit être un tuple de longueur 2"
-
-#~ msgid "%q must be between %d and %d"
-#~ msgstr "%q doit être entre %d et %d"
-
-#~ msgid "%q should be an int"
-#~ msgstr "%q doit être un chiffre entier (int)"
-
-#~ msgid "(x,y) integers required"
-#~ msgstr "Des entiers (x,y) requis"
-
-#~ msgid "Address type out of range"
-#~ msgstr "Type d'adresse hors portée"
-
-#~ msgid "AnalogIn not supported on given pin"
-#~ msgstr "'AnalogOut' n'est pas supporté sur la broche indiquée"
-
-#~ msgid "AnalogOut functionality not supported"
-#~ msgstr "Fonctionnalité AnalogOut non supportée"
-
-#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-#~ msgstr ""
-#~ "AnalogOut est seulement 16 bits. Les valeurs doivent être inférieures à "
-#~ "65536."
-
-#~ msgid "AnalogOut not supported on given pin"
-#~ msgstr "'AnalogOut' n'est pas supporté sur la broche indiquée"
-
-#, c-format
-#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
-#~ msgstr "Bit depth doit être entre 1 et 6 inclusivement, et non %d"
-
-#, c-format
-#~ msgid "Buffer incorrect size. Should be %d bytes."
-#~ msgstr "Tampon de taille incorrect. Devrait être de %d octets."
-
-#~ msgid "Buffer must be at least length 1"
-#~ msgstr "Le tampon doit être de longueur au moins 1"
-
-#~ msgid "Bytes must be between 0 and 255."
-#~ msgstr "Les octets 'bytes' doivent être entre 0 et 255."
-
-#~ msgid "Cannot output both channels on the same pin"
-#~ msgstr "Les 2 canaux de sortie ne peuvent être sur la même broche"
-
-#~ msgid "Cannot read without MISO pin."
-#~ msgstr "Impossible de lire sans broche MISO."
-
-#~ msgid "Cannot reset into bootloader because no bootloader is present."
-#~ msgstr ""
-#~ "Ne peut être redémarré vers le bootloader, car il n'y a pas de bootloader."
-
-#~ msgid "Cannot transfer without MOSI and MISO pins."
-#~ msgstr "Pas de transfert sans broches MOSI et MISO."
-
-#~ msgid "Cannot write without MOSI pin."
-#~ msgstr "Impossible d'écrire sans broche MOSI."
-
-#~ msgid "Clock pin init failed."
-#~ msgstr "Échec de l'initialisation de la broche d'horloge."
-
-#~ msgid "Command must be an int between 0 and 255"
-#~ msgstr "La commande doit être un chiffre entier entre 0 et 255"
-
-#~ msgid "Could not initialize Camera"
-#~ msgstr "Impossible d'initialiser Camera"
-
-#~ msgid "Could not initialize GNSS"
-#~ msgstr "Impossible d'initialiser GNSS"
-
-#~ msgid "Could not initialize SDCard"
-#~ msgstr "Impossible d'initialiser la carte SD"
-
-#~ msgid "Could not initialize UART"
-#~ msgstr "Impossible d'initialiser UART"
-
-#~ msgid "Could not re-init channel"
-#~ msgstr "Impossible de réinitialiser le canal"
-
-#~ msgid "Could not re-init timer"
-#~ msgstr "Impossible de réinitialiser le minuteur"
-
-#~ msgid "Could not restart PWM"
-#~ msgstr "Impossible de redémarrer PWM"
-
-#~ msgid "Couldn't allocate first buffer"
-#~ msgstr "Impossible d'allouer le premier tampon"
-
-#~ msgid "Couldn't allocate input buffer"
-#~ msgstr "Impossible d'allouer le tampon d'entrée"
-
-#~ msgid "Couldn't allocate second buffer"
-#~ msgstr "Impossible d'allouer le deuxième tampon"
-
-#~ msgid "DigitalInOut not supported on given pin"
-#~ msgstr "DigitalInOut non pris en charge sur la broche donnée"
-
-#, c-format
-#~ msgid "Expected tuple of length %d, got %d"
-#~ msgstr "Tuple de longueur %d attendu, obtenu %d"
-
-#~ msgid "Failed to allocate RX buffer"
-#~ msgstr "Échec de l'allocation du tampon RX"
-
-#, c-format
-#~ msgid "Failed to allocate RX buffer of %d bytes"
-#~ msgstr "Échec de l'allocation de %d octets du tampon RX"
-
-#, c-format
-#~ msgid "Framebuffer requires %d bytes"
-#~ msgstr "FrameBuffer nécessite %d octets"
-
-#~ msgid "Hostname must be between 1 and 253 characters"
-#~ msgstr "Hostname doit être entre 1 et 253 caractères"
-
-#~ msgid "I2C Init Error"
-#~ msgstr "Erreur d'initialisation I2C"
-
-#~ msgid "Invalid %q pin selection"
-#~ msgstr "Sélection de broche %q invalide"
-
-#~ msgid "Invalid AuthMode"
-#~ msgstr "AuthMode invalide"
-
-#~ msgid "Invalid BMP file"
-#~ msgstr "Fichier BMP invalide"
-
-#~ msgid "Invalid DAC pin supplied"
-#~ msgstr "Broche DAC non valide fournie"
-
-#~ msgid "Invalid MIDI file"
-#~ msgstr "Fichier MIDI invalide"
-
-#~ msgid "Invalid PWM frequency"
-#~ msgstr "Fréquence de PWM invalide"
-
-#~ msgid "Invalid Pin"
-#~ msgstr "Broche invalide"
-
-#~ msgid "Invalid buffer size"
-#~ msgstr "Longueur de tampon invalide"
-
-#~ msgid "Invalid byteorder string"
-#~ msgstr "Chaîne byteorder non valide"
-
-#~ msgid "Invalid capture period. Valid range: 1 - 500"
-#~ msgstr "Période de capture invalide. Portée valide : 1 à 500"
-
-#~ msgid "Invalid channel count"
-#~ msgstr "Nombre de canaux invalide"
-
-#, c-format
-#~ msgid "Invalid data_count %d"
-#~ msgstr "data_count invalide %d"
-
-#~ msgid "Invalid direction."
-#~ msgstr "Direction invalide."
-
-#~ msgid "Invalid file"
-#~ msgstr "Fichier invalide"
-
-#~ msgid "Invalid number of bits"
-#~ msgstr "Nombre de bits invalide"
-
-#~ msgid "Invalid phase"
-#~ msgstr "Phase invalide"
-
-#~ msgid "Invalid pin"
-#~ msgstr "Broche invalide"
-
-#~ msgid "Invalid pin for left channel"
-#~ msgstr "Broche invalide pour le canal gauche"
-
-#~ msgid "Invalid pin for right channel"
-#~ msgstr "Broche invalide pour le canal droit"
-
-#~ msgid "Invalid polarity"
-#~ msgstr "Polarité invalide"
-
-#~ msgid "Invalid properties"
-#~ msgstr "Propriétés invalides"
-
-#~ msgid "Invalid run mode."
-#~ msgstr "Mode de lancement invalide."
-
-#~ msgid "Invalid security_mode"
-#~ msgstr "'security_mode' invalide"
-
-#~ msgid "Invalid voice"
-#~ msgstr "Voix invalide"
-
-#~ msgid "Invalid voice count"
-#~ msgstr "Nombre de voix invalide"
-
-#~ msgid "Invalid wave file"
-#~ msgstr "Fichier WAVE invalide"
-
-#~ msgid "Invalid word/bit length"
-#~ msgstr "Longueur de mot / bit invalide"
-
-#~ msgid "Layer already in a group."
-#~ msgstr "Couche déjà dans un groupe."
-
-#~ msgid "Layer must be a Group or TileGrid subclass."
-#~ msgstr "'Layer' doit être un 'Group' ou une sous-classe 'TileGrid'."
-
-#~ msgid "MISO pin init failed."
-#~ msgstr "Échec de l'initialisation de la broche MISO."
-
-#~ msgid "MOSI pin init failed."
-#~ msgstr "Échec de l'initialisation de la broche MOSI."
-
-#~ msgid "Messages limited to 8 bytes"
-#~ msgstr "Messages limités à 8 octets"
-
-#, c-format
-#~ msgid "More than %d report ids not supported"
-#~ msgstr "Plus de %d identifiants de rapport ne sont pas supportés"
-
-#~ msgid "No hardware support on clk pin"
-#~ msgstr "Pas de support matériel sur la broche clk"
-
-#~ msgid "No hardware support on pin"
-#~ msgstr "Pas de support matériel pour cette broche"
-
-#, c-format
-#~ msgid "Output buffer must be at least %d bytes"
-#~ msgstr "Tampon de sortie doit être au moins %d octets"
-
-#~ msgid ""
-#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-#~ msgstr ""
-#~ "La valeur de duty_cycle de PWM doit être entre 0 et 65535 inclusivement "
-#~ "(résolution de 16 bits)"
-
-#~ msgid "Pin count must be at least 1"
-#~ msgstr "Nombre de broches doit être au moins 1"
-
-#~ msgid "Pin does not have ADC capabilities"
-#~ msgstr "La broche 'pin' ne supporte pas les capacités ADC"
-
-#~ msgid "Program must contain at least one 16-bit instruction."
-#~ msgstr "Le programme doit contenir au moins une instruction de 16 bits."
-
-#~ msgid "Program too large"
-#~ msgstr "Programme trop grand"
-
-#~ msgid "RS485 Not yet supported on this device"
-#~ msgstr "RS485 n'est pas encore supporté sur cet appareil"
-
-#~ msgid "RTC calibration is not supported on this board"
-#~ msgstr "La calibration du RTC non supportée sur cette carte"
-
-#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
-#~ msgstr "RTS / CTS / RS485 Pas encore supporté sur cet appareil"
-
-#~ msgid "SPI Init Error"
-#~ msgstr "Erreur d'initialisation SPI"
-
-#~ msgid "SPI Re-initialization error"
-#~ msgstr "Erreur de réinitialisation SPI"
-
-#~ msgid "Sample rate must be positive"
-#~ msgstr "Le taux d'échantillonnage doit être positif"
-
-#, c-format
-#~ msgid "Sample rate too high. It must be less than %d"
-#~ msgstr "Taux d'échantillonnage trop élevé. Doit être inférieur à %d"
-
-#~ msgid "Set pin count must be between 1 and 5"
-#~ msgstr "Nombre de broches configurées doit être entre 1 et 5"
-
-#~ msgid "Side set pin count must be between 1 and 5"
-#~ msgstr "Nombre de broches Side configurées doit être entre 1 et 5"
-
-#~ msgid "Stack size must be at least 256"
-#~ msgstr "La pile doit être au moins de 256"
-
-#~ msgid "Tile value out of bounds"
-#~ msgstr "Valeur de tuile hors limites"
-
-#~ msgid "UART Buffer allocation error"
-#~ msgstr "Erreur d'allocation de tampon UART"
-
-#~ msgid "UART De-init error"
-#~ msgstr "Erreur de désactivation UART"
-
-#~ msgid "UART Init Error"
-#~ msgstr "Erreur d'initialisation UART"
-
-#~ msgid "UART Re-init error"
-#~ msgstr "Erreur de réinitialisation UART"
-
-#~ msgid "UART write error"
-#~ msgstr "Erreur d'écriture UART"
-
-#~ msgid "Unsupported baudrate"
-#~ msgstr "Débit en bauds non supporté"
-
-#~ msgid "WiFi password must be between 8 and 63 characters"
-#~ msgstr "Le mot de passe WiFi doit faire entre 8 et 63 caractères"
-
-#~ msgid "bits must be in range 5 to 9"
-#~ msgstr "les bits doivent être compris entre 5 et 9"
-
-#~ msgid "bytes > 8 bits not supported"
-#~ msgstr "octets > 8 bits non supportés"
-
-#~ msgid "calibration value out of range +/-127"
-#~ msgstr "valeur d'étalonnage hors intervalle +/-127"
-
-#~ msgid "circle can only be registered in one parent"
-#~ msgstr "le cercle ne peut être enregistré que dans un seul parent"
-
-#~ msgid "max_length must be >= 0"
-#~ msgstr "max_length doit être >= 0"
-
-#~ msgid "polygon can only be registered in one parent"
-#~ msgstr "le polygone ne peut être enregistré que dans un parent"
-
-#~ msgid "pull_threshold must be between 1 and 32"
-#~ msgstr "pull_threshold doit être entre 1 et 32"
-
-#~ msgid "push_threshold must be between 1 and 32"
-#~ msgstr "push_threshold doit être entre 1 et 32"
-
-#~ msgid "stop must be 1 or 2"
-#~ msgstr "stop doit être 1 ou 2"
-
-#~ msgid "tile must be greater than zero"
-#~ msgstr "tile doit être plus que zéro"
-
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "'timeout' doit être >= 0.0"
-
-#, c-format
-#~ msgid "width must be from 2 to 8 (inclusive), not %d"
-#~ msgstr "width doit être entre 2 et 8 (inclusivement), non %d"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "Opération non supportée"
-
-#~ msgid "divisor must be 4"
-#~ msgstr "le diviseur doit être 4"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code stopped by auto-reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Exécution du code arrêté par l'auto-rechargement.\n"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "La luminosité doit être entre 0 et 255"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "ne peut pas réaliser un import relatif"
-
-#, c-format
-#~ msgid "No I2C device at address: %x"
-#~ msgstr "Pas de dispositif I2C à l'adresse : %x"
-
-#~ msgid "Unsupported pull value."
-#~ msgstr "Valeur de tirage 'pull' non supportée."
-
-#, c-format
-#~ msgid ""
-#~ "Welcome to Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Please visit learn.adafruit.com/category/circuitpython for project "
-#~ "guides.\n"
-#~ "\n"
-#~ "To list built-in modules please do `help(\"modules\")`.\n"
-#~ msgstr ""
-#~ "Bienvenue sur Adafruit CircuitPython %s !\n"
-#~ "\n"
-#~ "Visitez learn.adafruit.com/category/circuitpython pour les guides.\n"
-#~ "\n"
-#~ "Pour lister les modules inclus, tapez `help(\"modules\")`.\n"
-
-#~ msgid "integer required"
-#~ msgstr "entier requis"
-
-#~ msgid "abort() called"
-#~ msgstr "abort() appelé"
-
-#~ msgid "f-string expression part cannot include a '#'"
-#~ msgstr "La partie d'expression de chaîne f ne peut pas inclure de '#'"
-
-#~ msgid "f-string expression part cannot include a backslash"
-#~ msgstr ""
-#~ "La partie d'expression de chaîne f ne peut pas inclure de barre oblique "
-#~ "inverse"
-
-#~ msgid "f-string: empty expression not allowed"
-#~ msgstr "f-string : expression vide non autorisée"
-
-#~ msgid "f-string: expecting '}'"
-#~ msgstr "f-string : attend '}'"
-
-#~ msgid "f-string: single '}' is not allowed"
-#~ msgstr "f-string : single '}' n'est pas autorisé"
-
-#~ msgid "invalid arguments"
-#~ msgstr "arguments invalides"
-
-#~ msgid "raw f-strings are not implemented"
-#~ msgstr "les chaînes f brutes ne sont pas implémentées"
-
-#~ msgid "unindent does not match any outer indentation level"
-#~ msgstr "la désindentation ne correspond à aucune indentation précédente"
-
 #~ msgid "%q list must be a list"
 #~ msgstr "La liste %q doit être une liste"
-
-#~ msgid "%q must of type %q"
-#~ msgstr "%q doit être de type %q"
-
-#~ msgid "Column entry must be digitalio.DigitalInOut"
-#~ msgstr "L'entrée 'Column' doit être un digitalio.DigitalInOut"
-
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Une 'Characteristic' est attendue"
-
-#~ msgid "Expected a DigitalInOut"
-#~ msgstr "Un 'DigitalInOut' est attendu"
-
-#~ msgid "Expected a Service"
-#~ msgstr "Un Service est attendu"
-
-#~ msgid "Expected a UART"
-#~ msgstr "Un UART est attendu"
-
-#~ msgid "Expected a UUID"
-#~ msgstr "Un UUID est attendu"
-
-#~ msgid "Expected an Address"
-#~ msgstr "Un Address est attendu"
-
-#~ msgid "Row entry must be digitalio.DigitalInOut"
-#~ msgstr "L'entrée de ligne 'Row' doit être un digitalio.DigitalInOut"
-
-#~ msgid "buttons must be digitalio.DigitalInOut"
-#~ msgstr "les boutons doivent être des digitalio.DigitalInOut"
-
-#~ msgid "Invalid frequency"
-#~ msgstr "Fréquence non valide"
-
-#~ msgid "Data 0 pin must be byte aligned."
-#~ msgstr "La broche Data 0 doit être alignée sur l'octet."
-
-#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
-#~ msgstr "bits_per_pixel %d est invalid, doit être 1, 4, 8, 16, 24 ou 32"
-
-#~ msgid "ParallelBus not yet supported"
-#~ msgstr "ParallelBus pas encore supporté"
-
-#~ msgid "%q length must be %q"
-#~ msgstr "La longueur de %q doit être de %q"
 
 #~ msgid "%q must be 0-255"
 #~ msgstr "%q doit être compris entre 0 et 255"
@@ -5610,97 +4567,48 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "%q must be 1-255"
 #~ msgstr "%q doit être compris entre 1 et 255"
 
-#~ msgid "no available NIC"
-#~ msgstr "adapteur réseau non disponible"
+#~ msgid "%q must be >= 0"
+#~ msgstr "%q doit être >= 0"
 
-#~ msgid ""
-#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
-#~ "instead"
-#~ msgstr ""
-#~ "Ce port n'accepte pas de PWM carrier. Précisez plutôt les valeurs pin, "
-#~ "frequency et duty_cycle"
-
-#~ msgid ""
-#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
-#~ "Carrier instead"
-#~ msgstr ""
-#~ "Ce port n'accepte pas de broches ou de fréquence. Construisez plutôt en "
-#~ "passant un PWMOut Carrier"
-
-#~ msgid "Instruction %d jumps on pin"
-#~ msgstr "Instruction %d saute sur la broche"
-
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "Tampon trop volumineux et impossible à allouer"
-
-#~ msgid "interp is defined for 1D arrays of equal length"
-#~ msgstr "interp est défini pour les matrices 1D de longueur égale"
-
-#~ msgid "trapz is defined for 1D arrays"
-#~ msgstr "trapz est définie pour des matrices à une dimension"
-
-#~ msgid "wrong operand type"
-#~ msgstr "type d'opérande incorrect"
+#~ msgid "%q must be >= 1"
+#~ msgstr "%q doit être >= 1"
 
 #~ msgid "%q must be None or 1-255"
 #~ msgstr "%q doit être None ou compris entre 1 et 255"
 
-#~ msgid "Only raw int supported for ip"
-#~ msgstr "IP n'accepte que les chiffres entiers bruts"
+#~ msgid "%q must be a string"
+#~ msgstr "%q doit être une chaîne de caractères"
 
-#~ msgid ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
-#~ msgstr ""
-#~ "CircuitPython est en mode sans échec, car vous avez appuyé sur le bouton "
-#~ "de réinitialisation pendant le démarrage. Appuyez à nouveau pour quitter "
-#~ "le mode sans échec.\n"
+#~ msgid "%q must be a tuple of length 2"
+#~ msgstr "%q doit être un tuple de longueur 2"
 
-#~ msgid "Not running saved code.\n"
-#~ msgstr "N'exécute pas le code sauvegardé.\n"
+#~ msgid "%q must be an int"
+#~ msgstr "%q doit être un entier"
 
-#~ msgid "Running in safe mode! "
-#~ msgstr "Exécution en mode sécurisé! "
+#~ msgid "%q must be between %d and %d"
+#~ msgstr "%q doit être entre %d et %d"
 
-#~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Please increase the stack size if you know how, or if not:"
-#~ msgstr ""
-#~ "Le tas CircuitPython a été corrompu, car la pile était trop petite.\n"
-#~ "Veuillez augmenter la taille de la pile si vous savez comment, ou sinon :"
+#~ msgid "%q must be of type %q"
+#~ msgstr "%q doit être du type %q"
 
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode.\n"
-#~ msgstr ""
-#~ "Le module `microcontroller` a été utilisé pour démarrer en mode sans "
-#~ "échec. Appuyez sur reset pour quitter le mode sans échec.\n"
+#~ msgid "%q must be of type %q or None"
+#~ msgstr "%q doit être du type %q ou None"
 
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY).\n"
-#~ msgstr ""
-#~ "La puissance du microcontrôleur a baissé. Assurez-vous que votre "
-#~ "alimentation fournit\n"
-#~ "assez de puissance pour tout le circuit et appuyez sur reset (après avoir "
-#~ "éjecté CIRCUITPY).\n"
+#~ msgid "%q must of type %q"
+#~ msgstr "%q doit être de type %q"
 
-#~ msgid "You are in safe mode: something unanticipated happened.\n"
-#~ msgstr ""
-#~ "Vous êtes en mode sans échec : quelque chose d'imprévu s'est passé.\n"
+#~ msgid "%q pin invalid"
+#~ msgstr "broche %q invalide"
 
-#~ msgid "Pin number already reserved by EXTI"
-#~ msgstr "Numéro de broche 'pin' déjà réservé par EXTI"
+#~ msgid "%q should be an int"
+#~ msgstr "%q doit être un chiffre entier (int)"
 
-#~ msgid "USB Busy"
-#~ msgstr "USB occupé"
+#~ msgid "%q with a report ID of 0 must be of length 1"
+#~ msgstr "%q avec un identifiant de rapport à 0 doit être de longueur 1"
 
-#~ msgid "USB Error"
-#~ msgstr "Erreur USB"
-
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "indices %q doivent être des chiffres entiers, et non %q"
+#, c-format
+#~ msgid "%s"
+#~ msgstr "%s"
 
 #~ msgid "'%q' object cannot assign attribute '%q'"
 #~ msgstr "l'objet '%q' ne peut avoir l'attribut '%q'"
@@ -5722,300 +4630,6 @@ msgstr "zi doit être de forme (n_section, 2)"
 
 #~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
 #~ msgstr "'%s' le chiffre entier 0x%x ne correspond pas au masque 0x%x"
-
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "Impossible d'obtenir la taille (sizeof) du scalaire sans ambigüité"
-
-#~ msgid "Length must be an int"
-#~ msgstr "Length doit être un chiffre entier (int)"
-
-#~ msgid "Length must be non-negative"
-#~ msgstr "Length ne doit pas être négatif"
-
-#~ msgid "invalid decorator"
-#~ msgstr "décorateur invalide"
-
-#~ msgid "name reused for argument"
-#~ msgstr "nom réutilisé comme paramètre"
-
-#~ msgid "object '%q' is not a tuple or list"
-#~ msgstr "l'objet '%q' n'est pas un tuple ou une list"
-
-#~ msgid "object does not support item assignment"
-#~ msgstr "l'objet ne supporte pas l'assignation d'éléments"
-
-#~ msgid "object does not support item deletion"
-#~ msgstr "l'objet ne supporte pas la suppression d'éléments"
-
-#~ msgid "object is not subscriptable"
-#~ msgstr "l'objet n'est pas sous-scriptable"
-
-#~ msgid "object of type '%q' has no len()"
-#~ msgstr "len() indéfinie pour un objet de type '%q'"
-
-#~ msgid "struct: cannot index"
-#~ msgstr "struct : indexage impossible"
-
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "'/' ne peut être remonté quand l'USB est actif."
-
-#~ msgid "Timeout waiting for DRDY"
-#~ msgstr "Délai expiré en attendant DRDY"
-
-#~ msgid "Timeout waiting for VSYNC"
-#~ msgstr "Délai expiré en attendant VSYNC"
-
-#~ msgid "byte code not implemented"
-#~ msgstr "bytecode non implémenté"
-
-#~ msgid "can't pend throw to just-started generator"
-#~ msgstr ""
-#~ "on ne peut effectuer une action de type 'pend throw' sur un générateur "
-#~ "fraîchement démarré"
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "index invalide pour dupterm"
-
-#~ msgid "schedule stack full"
-#~ msgstr "pile de planification pleine"
-
-#~ msgid "Corrupt raw code"
-#~ msgstr "Code brut corrompu"
-
-#~ msgid "can only save bytecode"
-#~ msgstr "ne peut sauvegarder que du bytecode"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr ""
-#~ "les fonctions de Viper ne supportent pas plus de 4 arguments actuellement"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "l'adresse %08x n'est pas alignée sur %d octets"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "la fonction ne prend pas d'arguments nommés"
-
-#~ msgid "parameter annotation must be an identifier"
-#~ msgstr "l'annotation du paramètre doit être un identifiant"
-
-#~ msgid "Total data to write is larger than outgoing_packet_length"
-#~ msgstr ""
-#~ "Le nombre total de données à écrire est supérieur à outgoing_packet_length"
-
-#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
-#~ msgstr "IOs 0, 2 & 4 ne supportent pas de pullup interne en mode sommeil"
-
-#~ msgid "buffer must be a bytes-like object"
-#~ msgstr "le tampon doit être un objet bytes-like"
-
-#~ msgid "io must be rtc io"
-#~ msgstr "io doit être rtc io"
-
-#~ msgid "trigger level must be 0 or 1"
-#~ msgstr "niveau du déclencheur doit être 0 ou 1"
-
-#~ msgid "wakeup conflict"
-#~ msgstr "conflit au réveil"
-
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr ""
-#~ "Tentative d'allocation de segments lorsque la machine virtuelle "
-#~ "MicroPython n'est pas en cours d'exécution."
-
-#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
-#~ msgstr "Échec du saut MicroPython NLR. Corruption de la mémoire probable."
-
-#~ msgid "MicroPython fatal error."
-#~ msgstr "Erreur fatale MicroPython."
-
-#~ msgid "argument must be ndarray"
-#~ msgstr "l'argument doit être un ndarray"
-
-#~ msgid "matrix dimensions do not match"
-#~ msgstr "les dimensions de la matrice ne correspondent pas"
-
-#~ msgid "norm is defined for 1D and 2D arrays"
-#~ msgstr "norm est défini pour des tableaux 1D et 2D"
-
-#~ msgid "vectors must have same lengths"
-#~ msgstr "les vecteurs doivent avoir la même longueur"
-
-#~ msgid "Nordic Soft Device failure assertion."
-#~ msgstr "Affirmation de défaillance du Nordic Soft Device."
-
-#~ msgid "Nordic soft device out of memory"
-#~ msgstr "Appareil logiciel Nordic hors de mémoire"
-
-#~ msgid "Unknown soft device error: %04x"
-#~ msgstr "Erreur de périphérique logiciel inconnue : %04x"
-
-#~ msgid "first argument must be an iterable"
-#~ msgstr "le premier argument doit être un itérable"
-
-#~ msgid "iterables are not of the same length"
-#~ msgstr "les itérables ne sont pas de la même longueur"
-
-#~ msgid "Selected CTS pin not valid"
-#~ msgstr "La broche CTS sélectionnée n'est pas valide"
-
-#~ msgid "Selected RTS pin not valid"
-#~ msgstr "La broche RTS sélectionnée n'est pas valide"
-
-#~ msgid "Could not initialize channel"
-#~ msgstr "Impossible d'initialiser le canal"
-
-#~ msgid "Could not initialize timer"
-#~ msgstr "Impossible d'initialiser le minuteur"
-
-#~ msgid "Invalid frequency supplied"
-#~ msgstr "Fréquence invalide fournie"
-
-#~ msgid "Invalid pins for PWMOut"
-#~ msgstr "Broches invalides pour PWMOut"
-
-#~ msgid "No more channels available"
-#~ msgstr "Pas de canal supplémentaire disponible"
-
-#~ msgid "No more timers available"
-#~ msgstr "Plus de minuteurs disponibles"
-
-#~ msgid "No more timers available on this pin."
-#~ msgstr "Plus de minuteurs disponibles sur cette broche."
-
-#~ msgid ""
-#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
-#~ "program"
-#~ msgstr ""
-#~ "Le minuteur est réservé pour un usage interne - déclarez la broche PWM "
-#~ "plus tôt dans le programme"
-
-#~ msgid "Group full"
-#~ msgstr "Groupe plein"
-
-#~ msgid "UART not yet supported"
-#~ msgstr "UART n'est pas encore supporté"
-
-#~ msgid "bits must be 7, 8 or 9"
-#~ msgstr "bits doivent être 7, 8 ou 9"
-
-#~ msgid "Only IN/OUT of up to 8 supported"
-#~ msgstr "Seulement des IN/OUT jusqu'à 8 sont supportés"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "SDA ou SCL a besoin d'une résistance de tirage ('pull up')"
-
-#~ msgid "Invalid use of TLS Socket"
-#~ msgstr "Utilisation incorrecte de socket TLS"
-
-#~ msgid "Issue setting SO_REUSEADDR"
-#~ msgstr "Problème en activant SO_REUSEADDR"
-
-#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
-#~ msgstr ""
-#~ "Les broches d'adresse %d et les broches RVB %d indiquent une hauteur de "
-#~ "%d, pas %d"
-
-#~ msgid "Unknown failure"
-#~ msgstr "Échec inconnu"
-
-#~ msgid "Only one alarm.touch alarm can be set."
-#~ msgstr "Une seule alarme alarm.touch peut être réglée."
-
-#~ msgid "TouchAlarm not available in light sleep"
-#~ msgstr "TouchAlarm n'est pas disponible en mode sommeil léger"
-
-#~ msgid "input argument must be an integer or a 2-tuple"
-#~ msgstr "l'argument d'entrée doit être un entier ou un tuple 2"
-
-#~ msgid "operation is not implemented for flattened array"
-#~ msgstr "l'opération n'est pas implémentée pour un tableau aplati"
-
-#~ msgid "tuple index out of range"
-#~ msgstr "index du tuple hors de portée"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Fin d'exécution du code. En attente de rechargement.\n"
-
-#~ msgid "PinAlarm not yet implemented"
-#~ msgstr "PinAlarm pas encore implémenté"
-
-#~ msgid "Frequency captured is above capability. Capture Paused."
-#~ msgstr "La fréquence capturée est au delà des capacités. Capture en pause."
-
-#~ msgid "max_length must be > 0"
-#~ msgstr "max_length doit être > 0"
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr ""
-#~ "Appuyez sur une touche pour entrer sur REPL ou CTRL-D pour recharger."
-
-#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
-#~ msgstr "Seules les sockets IPv4 SOCK_STREAM sont pris en charge"
-
-#~ msgid "arctan2 is implemented for scalars and ndarrays only"
-#~ msgstr ""
-#~ "arctan2 est implémenté uniquement pour les scalaires et les ndarrays"
-
-#~ msgid "axis must be -1, 0, None, or 1"
-#~ msgstr "l'axe doit être -1, 0, None ou 1"
-
-#~ msgid "axis must be -1, 0, or 1"
-#~ msgstr "l'axe doit être -1, 0 ou 1"
-
-#~ msgid "axis must be None, 0, or 1"
-#~ msgstr "l'axe doit être None, 0 ou 1"
-
-#~ msgid "cannot reshape array (incompatible input/output shape)"
-#~ msgstr ""
-#~ "ne peut pas remodeler le tableau (forme d'entrée / sortie incompatible)"
-
-#~ msgid "could not broadast input array from shape"
-#~ msgstr "n'a pas pu diffuser le tableau d'entrée à partir de la forme"
-
-#~ msgid "ddof must be smaller than length of data set"
-#~ msgstr "ddof doit être inférieur à la longueur de l'ensemble de données"
-
-#~ msgid "function is implemented for scalars and ndarrays only"
-#~ msgstr ""
-#~ "la fonction est implémentée pour les scalaires et les ndarrays uniquement"
-
-#~ msgid "n must be between 0, and 9"
-#~ msgstr "n doit être compris entre 0 et 9"
-
-#~ msgid "number of arguments must be 2, or 3"
-#~ msgstr "le nombre d'arguments doit être 2 ou 3"
-
-#~ msgid "right hand side must be an ndarray, or a scalar"
-#~ msgstr "le côté droit doit être un ndarray ou un scalaire"
-
-#~ msgid "shape must be a 2-tuple"
-#~ msgstr "la forme doit être un tuple 2"
-
-#~ msgid "sorted axis can't be longer than 65535"
-#~ msgstr "sorted axis ne peut pas dépasser 65535"
-
-#~ msgid "wrong argument type"
-#~ msgstr "type d'argument incorrect"
-
-#~ msgid "Must provide SCK pin"
-#~ msgstr "Vous devez fournir un code PIN SCK"
-
-#~ msgid ""
-#~ "\n"
-#~ "To exit, please reset the board without "
-#~ msgstr ""
-#~ "\n"
-#~ "Pour quitter, veuillez réinitialiser la carte sans "
-
-#~ msgid "PulseOut not supported on this chip"
-#~ msgstr "PulseOut non pris en charge sur cette puce"
-
-#~ msgid "tuple/list required on RHS"
-#~ msgstr "tuple ou liste requis en partie droite"
 
 #~ msgid "'%s' object cannot assign attribute '%q'"
 #~ msgstr "L'objet '%s' ne peut pas attribuer '%q'"
@@ -6041,47 +4655,29 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "'%s' object is not subscriptable"
 #~ msgstr "l'objet '%s' n'est pas sous-scriptable"
 
-#~ msgid "Invalid I2C pin selection"
-#~ msgstr "Sélection de broches I2C non valide"
-
-#~ msgid "Invalid SPI pin selection"
-#~ msgstr "Sélection de broches SPI non valide"
-
-#~ msgid "Invalid UART pin selection"
-#~ msgstr "Sélection de broches UART non valide"
-
-#~ msgid "Pop from an empty Ps2 buffer"
-#~ msgstr "Pop à partir d'un tampon Ps2 vide"
-
-#~ msgid "Running in safe mode! Auto-reload is off.\n"
-#~ msgstr "Mode sans-échec ! Auto-chargement désactivé.\n"
-
-#~ msgid "can't convert address to int"
-#~ msgstr "ne peut convertir l'adresse en entier 'int'"
-
-#~ msgid "object '%s' is not a tuple or list"
-#~ msgstr "l'objet '%s' n'est pas un tuple ou une liste"
-
-#~ msgid "pop from an empty set"
-#~ msgstr "'pop' d'un ensemble set vide"
-
-#~ msgid "pop from empty list"
-#~ msgstr "'pop' d'une liste vide"
-
-#~ msgid "popitem(): dictionary is empty"
-#~ msgstr "popitem() : dictionnaire vide"
-
-#~ msgid "unknown format code '%c' for object of type '%s'"
-#~ msgstr "code de format '%c' inconnu pour un objet de type '%s'"
-
-#~ msgid "unsupported types for %q: '%s', '%s'"
-#~ msgstr "type non supporté pour %q : '%s', '%s'"
-
 #~ msgid "'async for' or 'async with' outside async function"
 #~ msgstr "'async for' ou 'async with' sans fonction asynchrone extérieure"
 
-#~ msgid "PulseIn not supported on this chip"
-#~ msgstr "PulseIn non pris en charge sur cette puce"
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr "'await', 'async for' ou 'async with' dehors d'une fonction async"
+
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' dehors d'une boucle"
+
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' dehors d'une boucle"
+
+#~ msgid "'coroutine' object is not an iterator"
+#~ msgstr "L'objet \"coroutine\" n'est pas un itérateur"
+
+#~ msgid "(x,y) integers required"
+#~ msgstr "Des entiers (x,y) requis"
+
+#~ msgid "64 bit types"
+#~ msgstr "types à 64 bit"
+
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "ADC2 est utilisé pars le Wifi"
 
 #~ msgid "AP required"
 #~ msgstr "'AP' requis"
@@ -6089,9 +4685,82 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "Address is not %d bytes long or is in wrong format"
 #~ msgstr "L'adresse n'est pas longue de %d octets ou est d'un format erroné"
 
+#~ msgid "Address type out of range"
+#~ msgstr "Type d'adresse hors portée"
+
+#~ msgid "All I2C targets are in use"
+#~ msgstr "Toutes les cibles I2C sont utilisées"
+
+#~ msgid "AnalogIn not supported on given pin"
+#~ msgstr "'AnalogOut' n'est pas supporté sur la broche indiquée"
+
+#~ msgid "AnalogOut functionality not supported"
+#~ msgstr "Fonctionnalité AnalogOut non supportée"
+
+#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#~ msgstr ""
+#~ "AnalogOut est seulement 16 bits. Les valeurs doivent être inférieures à "
+#~ "65536."
+
+#~ msgid "AnalogOut not supported on given pin"
+#~ msgstr "'AnalogOut' n'est pas supporté sur la broche indiquée"
+
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "Au plus %d %q peut être spécifié (pas %d)"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr ""
+#~ "Tentative d'allocation de segments lorsque la machine virtuelle "
+#~ "MicroPython n'est pas en cours d'exécution."
+
 #~ msgid "Attempted heap allocation when MicroPython VM not running.\n"
 #~ msgstr ""
 #~ "Tentative d'allocation de tas alors que la VM MicroPython ne tourne pas.\n"
+
+#~ msgid "Attempted heap allocation when VM not running."
+#~ msgstr ""
+#~ "Tentative d'allocation à la pile quand la Machine Virtuelle n'est pas en "
+#~ "exécution."
+
+#~ msgid "Bit clock and word select must be sequential pins"
+#~ msgstr ""
+#~ "La sélection du bit d'horloge et de mot doit être sur des broches "
+#~ "séquentielles"
+
+#, c-format
+#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
+#~ msgstr "Bit depth doit être entre 1 et 6 inclusivement, et non %d"
+
+#~ msgid "Boot device must be first device (interface #0)."
+#~ msgstr "L'appareil de démarrage doit être le premier (interface #0)."
+
+#~ msgid "Both buttons were pressed at start up.\n"
+#~ msgstr "Les deux boutons étaient pressés au démarrage.\n"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "La luminosité doit être de 0 à 1.0"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "La luminosité doit être entre 0 et 255"
+
+#, c-format
+#~ msgid "Buffer incorrect size. Should be %d bytes."
+#~ msgstr "Tampon de taille incorrect. Devrait être de %d octets."
+
+#~ msgid "Buffer is too small"
+#~ msgstr "Le tampon est trop petit"
+
+#~ msgid "Buffer must be at least length 1"
+#~ msgstr "Le tampon doit être de longueur au moins 1"
+
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "Tampon trop volumineux et impossible à allouer"
+
+#~ msgid "Button A was pressed at start up.\n"
+#~ msgstr "Le bouton A était pressé au démarrage.\n"
+
+#~ msgid "Bytes must be between 0 and 255."
+#~ msgstr "Les octets 'bytes' doivent être entre 0 et 255."
 
 #~ msgid "Can not use dotstar with %s"
 #~ msgstr "Impossible d'utiliser 'dotstar' avec %s"
@@ -6114,11 +4783,36 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "Cannot disconnect from AP"
 #~ msgstr "Impossible de se déconnecter de 'AP'"
 
+#~ msgid "Cannot output both channels on the same pin"
+#~ msgstr "Les 2 canaux de sortie ne peuvent être sur la même broche"
+
+#~ msgid "Cannot read without MISO pin."
+#~ msgstr "Impossible de lire sans broche MISO."
+
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "'/' ne peut être remonté quand l'USB est actif."
+
+#~ msgid "Cannot reset into bootloader because no bootloader is present."
+#~ msgstr ""
+#~ "Ne peut être redémarré vers le bootloader, car il n'y a pas de bootloader."
+
 #~ msgid "Cannot set STA config"
 #~ msgstr "Impossible de configurer STA"
 
+#~ msgid "Cannot transfer without MOSI and MISO pins"
+#~ msgstr "Impossible de transférer sans une broche MOSI ou MISO"
+
+#~ msgid "Cannot transfer without MOSI and MISO pins."
+#~ msgstr "Pas de transfert sans broches MOSI et MISO."
+
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "Impossible d'obtenir la taille (sizeof) du scalaire sans ambigüité"
+
 #~ msgid "Cannot update i/f status"
 #~ msgstr "l’état i/f ne peut être mis à jour"
+
+#~ msgid "Cannot write without MOSI pin."
+#~ msgstr "Impossible d'écrire sans broche MOSI."
 
 #~ msgid "Characteristic UUID doesn't match Service UUID"
 #~ msgstr "L'UUID de 'Characteristic' ne correspond pas à l'UUID du Service"
@@ -6126,14 +4820,85 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "Characteristic already in use by another Service."
 #~ msgstr "'Characteristic' déjà en utilisation par un autre service"
 
+#~ msgid ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+#~ msgstr ""
+#~ "CircuitPython est en mode sans échec, car vous avez appuyé sur le bouton "
+#~ "de réinitialisation pendant le démarrage. Appuyez à nouveau pour quitter "
+#~ "le mode sans échec.\n"
+
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "CircuitPython n'as pu faire l'allocation de la pile."
+
+#~ msgid "Clock pin init failed."
+#~ msgstr "Échec de l'initialisation de la broche d'horloge."
+
+#~ msgid "Column entry must be digitalio.DigitalInOut"
+#~ msgstr "L'entrée 'Column' doit être un digitalio.DigitalInOut"
+
+#~ msgid "Command must be an int between 0 and 255"
+#~ msgstr "La commande doit être un chiffre entier entre 0 et 255"
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "Fichier .mpy corrompu"
+
+#~ msgid "Corrupt raw code"
+#~ msgstr "Code brut corrompu"
+
 #~ msgid "Could not decode ble_uuid, err 0x%04x"
 #~ msgstr "Impossible de décoder le 'ble_uuid', err 0x%04x"
+
+#~ msgid "Could not initialize Camera"
+#~ msgstr "Impossible d'initialiser Camera"
+
+#~ msgid "Could not initialize GNSS"
+#~ msgstr "Impossible d'initialiser GNSS"
+
+#~ msgid "Could not initialize SDCard"
+#~ msgstr "Impossible d'initialiser la carte SD"
+
+#~ msgid "Could not initialize UART"
+#~ msgstr "Impossible d'initialiser UART"
+
+#~ msgid "Could not initialize channel"
+#~ msgstr "Impossible d'initialiser le canal"
+
+#~ msgid "Could not initialize timer"
+#~ msgstr "Impossible d'initialiser le minuteur"
+
+#~ msgid "Could not re-init channel"
+#~ msgstr "Impossible de réinitialiser le canal"
+
+#~ msgid "Could not re-init timer"
+#~ msgstr "Impossible de réinitialiser le minuteur"
+
+#~ msgid "Could not restart PWM"
+#~ msgstr "Impossible de redémarrer PWM"
+
+#~ msgid "Couldn't allocate first buffer"
+#~ msgstr "Impossible d'allouer le premier tampon"
+
+#~ msgid "Couldn't allocate input buffer"
+#~ msgstr "Impossible d'allouer le tampon d'entrée"
+
+#~ msgid "Couldn't allocate second buffer"
+#~ msgstr "Impossible d'allouer le deuxième tampon"
+
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "Échec vers le HardFault_Handler."
 
 #~ msgid "Crash into the HardFault_Handler.\n"
 #~ msgstr "Plantage vers le 'HardFault_Handler'.\n"
 
+#~ msgid "Data 0 pin must be byte aligned."
+#~ msgstr "La broche Data 0 doit être alignée sur l'octet."
+
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Données trop volumineuses pour le paquet de diffusion"
+
+#~ msgid "DigitalInOut not supported on given pin"
+#~ msgstr "DigitalInOut non pris en charge sur la broche donnée"
 
 #~ msgid "Don't know how to pass object to native function"
 #~ msgstr "Ne sais pas comment passer l'objet à une fonction native"
@@ -6144,8 +4909,43 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "ESP8266 does not support pull down."
 #~ msgstr "L'ESP8266 ne supporte pas le rappel (pull-down)"
 
+#, c-format
+#~ msgid "Error in MIDI stream at position %d"
+#~ msgstr "Erreur dans le flot MIDI à la position %d"
+
 #~ msgid "Error in ffi_prep_cif"
 #~ msgstr "Erreur dans ffi_prep_cif"
+
+#~ msgid "Expected a %q"
+#~ msgstr "Attendu un %q"
+
+#~ msgid "Expected a %q or %q"
+#~ msgstr "Attendu un %q ou %q"
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Une 'Characteristic' est attendue"
+
+#~ msgid "Expected a DigitalInOut"
+#~ msgstr "Un 'DigitalInOut' est attendu"
+
+#~ msgid "Expected a Service"
+#~ msgstr "Un Service est attendu"
+
+#~ msgid "Expected a UART"
+#~ msgstr "Un UART est attendu"
+
+#~ msgid "Expected a UUID"
+#~ msgstr "Un UUID est attendu"
+
+#~ msgid "Expected an Address"
+#~ msgstr "Un Address est attendu"
+
+#~ msgid "Expected an alarm"
+#~ msgstr "Une alarme était prévue"
+
+#, c-format
+#~ msgid "Expected tuple of length %d, got %d"
+#~ msgstr "Tuple de longueur %d attendu, obtenu %d"
 
 #, fuzzy
 #~ msgid "Failed to acquire mutex"
@@ -6162,6 +4962,13 @@ msgstr "zi doit être de forme (n_section, 2)"
 #, fuzzy
 #~ msgid "Failed to add service, err 0x%04x"
 #~ msgstr "Échec de l'ajout de service, err 0x%04x"
+
+#~ msgid "Failed to allocate RX buffer"
+#~ msgstr "Échec de l'allocation du tampon RX"
+
+#, c-format
+#~ msgid "Failed to allocate RX buffer of %d bytes"
+#~ msgstr "Échec de l'allocation de %d octets du tampon RX"
 
 #, fuzzy
 #~ msgid "Failed to change softdevice state"
@@ -6194,6 +5001,9 @@ msgstr "zi doit être de forme (n_section, 2)"
 #, fuzzy
 #~ msgid "Failed to get softdevice state"
 #~ msgstr "Échec de l'obtention de l'état du périphérique"
+
+#~ msgid "Failed to init wifi"
+#~ msgstr "Échec de l'initialisation du Wifi"
 
 #, fuzzy
 #~ msgid "Failed to notify or indicate attribute value, err %0x04x"
@@ -6258,6 +5068,12 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "Failed to write gatts value, err 0x%04x"
 #~ msgstr "Impossible d'écrire la valeur de 'gatts', err 0x%04x"
 
+#~ msgid "Fatal error."
+#~ msgstr "Erreurre fatale."
+
+#~ msgid "Firmware image is invalid"
+#~ msgstr "Image du microprogramme est invalide"
+
 #~ msgid "Flash erase failed"
 #~ msgstr "L'effacement de la flash a échoué"
 
@@ -6270,23 +5086,212 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "Flash write failed to start, err 0x%04x"
 #~ msgstr "Échec du démarrage de l'écriture de la flash, err 0x%04x"
 
+#, c-format
+#~ msgid "Framebuffer requires %d bytes"
+#~ msgstr "FrameBuffer nécessite %d octets"
+
+#~ msgid "Frequency captured is above capability. Capture Paused."
+#~ msgstr "La fréquence capturée est au delà des capacités. Capture en pause."
+
 #~ msgid "Function requires lock."
 #~ msgstr "La fonction nécessite un verrou."
 
 #~ msgid "GPIO16 does not support pull up."
 #~ msgstr "Le GPIO16 ne supporte pas le tirage (pull-up)"
 
+#~ msgid "Group full"
+#~ msgstr "Groupe plein"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Matériel occupé, essayez d'autres broches"
+
+#~ msgid "Hostname must be between 1 and 253 characters"
+#~ msgstr "Hostname doit être entre 1 et 253 caractères"
+
+#~ msgid "I2C Init Error"
+#~ msgstr "Erreur d'initialisation I2C"
+
 #~ msgid "I2C operation not supported"
 #~ msgstr "opération sur I2C non supportée"
 
+#~ msgid "I2SOut not available"
+#~ msgstr "I2SOut n'est pas disponible"
+
+#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
+#~ msgstr "IOs 0, 2 & 4 ne supportent pas de pullup interne en mode sommeil"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IV doit être de longueur de %d octets"
+
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "Fichier .mpy incompatible. Merci de mettre à jour tous les fichiers .mpy. "
+#~ "Voir http://adafru.it/mpy-update pour plus d'informations."
+
+#~ msgid "Initialization failed due to lack of memory"
+#~ msgstr "Échec d'initialisation par manque de mémoire"
+
+#~ msgid "Instruction %d jumps on pin"
+#~ msgstr "Instruction %d saute sur la broche"
+
+#, c-format
+#~ msgid "Instruction %d shifts in more bits than pin count"
+#~ msgstr ""
+#~ "Instruction %d décale vers l'intérieur de plus de bits que le nombre de "
+#~ "broches"
+
+#, c-format
+#~ msgid "Instruction %d shifts out more bits than pin count"
+#~ msgstr ""
+#~ "instruction %d décale vers l'extérieur de plus de bits que le nombre de "
+#~ "broches"
+
+#, c-format
+#~ msgid "Instruction %d uses extra pin"
+#~ msgstr "instruction %d utilise des broches supplémentaires"
+
+#, c-format
+#~ msgid "Instruction %d waits on input outside of count"
+#~ msgstr "instruction %d attend sur une entrée hors du compte"
+
+#~ msgid "Invalid %q pin selection"
+#~ msgstr "Sélection de broche %q invalide"
+
+#~ msgid "Invalid AuthMode"
+#~ msgstr "AuthMode invalide"
+
+#~ msgid "Invalid BMP file"
+#~ msgstr "Fichier BMP invalide"
+
+#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
+#~ msgstr "Taille CIRCUITPY_PYSTACK_SIZE invalide\n"
+
+#~ msgid "Invalid DAC pin supplied"
+#~ msgstr "Broche DAC non valide fournie"
+
+#~ msgid "Invalid I2C pin selection"
+#~ msgstr "Sélection de broches I2C non valide"
+
+#~ msgid "Invalid MIDI file"
+#~ msgstr "Fichier MIDI invalide"
+
+#~ msgid "Invalid PWM frequency"
+#~ msgstr "Fréquence de PWM invalide"
+
+#~ msgid "Invalid Pin"
+#~ msgstr "Broche invalide"
+
+#~ msgid "Invalid SPI pin selection"
+#~ msgstr "Sélection de broches SPI non valide"
+
+#~ msgid "Invalid UART pin selection"
+#~ msgstr "Sélection de broches UART non valide"
+
 #~ msgid "Invalid bit clock pin"
 #~ msgstr "Broche invalide pour 'bit clock'"
+
+#~ msgid "Invalid buffer size"
+#~ msgstr "Longueur de tampon invalide"
+
+#~ msgid "Invalid byteorder string"
+#~ msgstr "Chaîne byteorder non valide"
+
+#~ msgid "Invalid capture period. Valid range: 1 - 500"
+#~ msgstr "Période de capture invalide. Portée valide : 1 à 500"
+
+#~ msgid "Invalid channel count"
+#~ msgstr "Nombre de canaux invalide"
 
 #~ msgid "Invalid clock pin"
 #~ msgstr "Broche d'horloge invalide"
 
 #~ msgid "Invalid data pin"
 #~ msgstr "Broche de données invalide"
+
+#, c-format
+#~ msgid "Invalid data_count %d"
+#~ msgstr "data_count invalide %d"
+
+#~ msgid "Invalid direction."
+#~ msgstr "Direction invalide."
+
+#~ msgid "Invalid file"
+#~ msgstr "Fichier invalide"
+
+#~ msgid "Invalid frequency"
+#~ msgstr "Fréquence non valide"
+
+#~ msgid "Invalid frequency supplied"
+#~ msgstr "Fréquence invalide fournie"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "Accès à la mémoire invalide."
+
+#~ msgid "Invalid number of bits"
+#~ msgstr "Nombre de bits invalide"
+
+#~ msgid "Invalid phase"
+#~ msgstr "Phase invalide"
+
+#~ msgid "Invalid pin"
+#~ msgstr "Broche invalide"
+
+#~ msgid "Invalid pin for left channel"
+#~ msgstr "Broche invalide pour le canal gauche"
+
+#~ msgid "Invalid pin for right channel"
+#~ msgstr "Broche invalide pour le canal droit"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Broches invalides"
+
+#~ msgid "Invalid pins for PWMOut"
+#~ msgstr "Broches invalides pour PWMOut"
+
+#~ msgid "Invalid polarity"
+#~ msgstr "Polarité invalide"
+
+#~ msgid "Invalid properties"
+#~ msgstr "Propriétés invalides"
+
+#~ msgid "Invalid run mode."
+#~ msgstr "Mode de lancement invalide."
+
+#~ msgid "Invalid security_mode"
+#~ msgstr "'security_mode' invalide"
+
+#~ msgid "Invalid use of TLS Socket"
+#~ msgstr "Utilisation incorrecte de socket TLS"
+
+#~ msgid "Invalid voice"
+#~ msgstr "Voix invalide"
+
+#~ msgid "Invalid voice count"
+#~ msgstr "Nombre de voix invalide"
+
+#~ msgid "Invalid wave file"
+#~ msgstr "Fichier WAVE invalide"
+
+#~ msgid "Invalid word/bit length"
+#~ msgstr "Longueur de mot / bit invalide"
+
+#~ msgid "Issue setting SO_REUSEADDR"
+#~ msgstr "Problème en activant SO_REUSEADDR"
+
+#~ msgid "Layer already in a group."
+#~ msgstr "Couche déjà dans un groupe."
+
+#~ msgid "Layer must be a Group or TileGrid subclass."
+#~ msgstr "'Layer' doit être un 'Group' ou une sous-classe 'TileGrid'."
+
+#~ msgid "Length must be an int"
+#~ msgstr "Length doit être un chiffre entier (int)"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Length ne doit pas être négatif"
 
 #~ msgid ""
 #~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
@@ -6298,17 +5303,77 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ "issues\n"
 #~ "avec le contenu de votre lecteur CIRCUITPY et ce message:\n"
 
+#~ msgid "MISO pin init failed."
+#~ msgstr "Échec de l'initialisation de la broche MISO."
+
+#~ msgid "MOSI pin init failed."
+#~ msgstr "Échec de l'initialisation de la broche MOSI."
+
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "La fréquence de PWM maximale est %dHz"
 
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "La valeur maximale de x est %d lors d'une opération miroir"
+
+#~ msgid "Messages limited to 8 bytes"
+#~ msgstr "Messages limités à 8 octets"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgstr "Échec du saut MicroPython NLR. Corruption de la mémoire probable."
+
 #~ msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
 #~ msgstr "Saut MicroPython NLR a échoué. Corruption de mémoire possible.\n"
+
+#~ msgid "MicroPython fatal error."
+#~ msgstr "Erreur fatale MicroPython."
 
 #~ msgid "MicroPython fatal error.\n"
 #~ msgstr "Erreur fatale de MicroPython.\n"
 
 #~ msgid "Minimum PWM frequency is 1hz."
 #~ msgstr "La fréquence de PWM minimale est 1Hz"
+
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "Broche MISO ou MOSI manquante"
+
+#~ msgid "Missing MISO or MOSI pin"
+#~ msgstr "La broche MISO ou MOSI est manquante"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
+#~ msgstr "first_in_pin manquant. Instruction %d lit une/des broche(s)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
+#~ msgstr ""
+#~ "first_in_pin manquant. Instruction %d est déplacée par la/les broche(s)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
+#~ msgstr ""
+#~ "first_in_pin manquant. L'instruction %d attends dépends de la broche"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
+#~ msgstr ""
+#~ "first_out_pin manquant. Instruction %d est déplacée par la/les broche(s)"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
+#~ msgstr "first_out_pin manquant. Instruction %d écrit un/des broche(s)"
+
+#, c-format
+#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+#~ msgstr "first_set_pin manquant. L'instruction %d règle la/les broche(s)"
+
+#, c-format
+#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
+#~ msgstr "jmp_pin manquant. L'instruction %d va passer à la broche"
+
+#, c-format
+#~ msgid "More than %d report ids not supported"
+#~ msgstr "Plus de %d identifiants de rapport ne sont pas supportés"
 
 #~ msgid "Multiple PWM frequencies not supported. PWM already set to %dhz."
 #~ msgstr ""
@@ -6317,14 +5382,85 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "Must be a Group subclass."
 #~ msgstr "Doit être une sous-classe de 'Group'"
 
+#~ msgid "Must provide SCK pin"
+#~ msgstr "Vous devez fournir un code PIN SCK"
+
 #~ msgid "Negative step not supported"
 #~ msgstr "Étape négative non prise en charge"
+
+#, c-format
+#~ msgid "No I2C device at address: %x"
+#~ msgstr "Pas de dispositif I2C à l'adresse : %x"
+
+#~ msgid "No MISO Pin"
+#~ msgstr "Pas de broche MISO"
+
+#~ msgid "No MISO pin"
+#~ msgstr "Aucune broche MISO"
+
+#~ msgid "No MOSI Pin"
+#~ msgstr "Pas de broche MOSI"
+
+#~ msgid "No MOSI pin"
+#~ msgstr "Aucune broche MOSI"
 
 #~ msgid "No PulseIn support for %q"
 #~ msgstr "Pas de support de PulseIn pour %q"
 
+#~ msgid "No RX pin"
+#~ msgstr "Pas de broche RX"
+
+#~ msgid "No TX pin"
+#~ msgstr "Pas de broche TX"
+
 #~ msgid "No hardware support for analog out."
 #~ msgstr "Pas de support matériel pour une sortie analogique"
+
+#~ msgid "No hardware support on clk pin"
+#~ msgstr "Pas de support matériel sur la broche clk"
+
+#~ msgid "No hardware support on pin"
+#~ msgstr "Pas de support matériel pour cette broche"
+
+#~ msgid "No key was specified"
+#~ msgstr "Aucune clé n'a été spécifiée"
+
+#~ msgid "No more channels available"
+#~ msgstr "Pas de canal supplémentaire disponible"
+
+#, c-format
+#~ msgid "No more than %d HID devices allowed"
+#~ msgstr "Pas plus de %d appareils HID autorisés"
+
+#~ msgid "No more timers available"
+#~ msgstr "Plus de minuteurs disponibles"
+
+#~ msgid "No more timers available on this pin."
+#~ msgstr "Plus de minuteurs disponibles sur cette broche."
+
+#~ msgid "Nordic Soft Device failure assertion."
+#~ msgstr "Affirmation de défaillance du Nordic Soft Device."
+
+#~ msgid "Nordic soft device out of memory"
+#~ msgstr "Appareil logiciel Nordic hors de mémoire"
+
+#~ msgid "Nordic system firmware failure assertion."
+#~ msgstr "Assertion échouée du logiciel système Nordic."
+
+#~ msgid "Not running saved code.\n"
+#~ msgstr "N'exécute pas le code sauvegardé.\n"
+
+#~ msgid "Not settable"
+#~ msgstr "Non réglable"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Uniquement 8 ou 16 bit mono avec "
+
+#~ msgid "Only IN/OUT of up to 8 supported"
+#~ msgstr "Seulement des IN/OUT jusqu'à 8 sont supportés"
+
+#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
+#~ msgstr "Seules les sockets IPv4 SOCK_STREAM sont pris en charge"
 
 #~ msgid "Only Windows format, uncompressed BMP supported %d"
 #~ msgstr "Seuls les BMP non compressés au format Windows sont supportés %d"
@@ -6339,6 +5475,15 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ "Seuls les BMP monochromes, 8bit indexés et 16bit sont supportés: %d bpp "
 #~ "fourni"
 
+#~ msgid "Only one TouchAlarm can be set in deep sleep."
+#~ msgstr "Seulement une TouchAlarm peut être réglée en sommeil profond."
+
+#~ msgid "Only one alarm.touch alarm can be set."
+#~ msgstr "Une seule alarme alarm.touch peut être réglée."
+
+#~ msgid "Only raw int supported for ip"
+#~ msgstr "IP n'accepte que les chiffres entiers bruts"
+
 #, fuzzy
 #~ msgid "Only slices with step=1 (aka None) are supported"
 #~ msgstr "seuls les slices avec 'step=1' (cad 'None') sont supportées"
@@ -6349,14 +5494,42 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "Only tx supported on UART1 (GPIO2)."
 #~ msgstr "Seul le tx est supporté sur l'UART1 (GPIO2)."
 
+#, c-format
+#~ msgid "Output buffer must be at least %d bytes"
+#~ msgstr "Tampon de sortie doit être au moins %d octets"
+
+#~ msgid "PDMIn not available"
+#~ msgstr "PDMIn non disponible"
+
+#~ msgid ""
+#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
+#~ msgstr ""
+#~ "La valeur de duty_cycle de PWM doit être entre 0 et 65535 inclusivement "
+#~ "(résolution de 16 bits)"
+
 #~ msgid "PWM not supported on pin %d"
 #~ msgstr "La broche %d ne supporte pas le PWM"
+
+#~ msgid "ParallelBus not yet supported"
+#~ msgstr "ParallelBus pas encore supporté"
 
 #~ msgid "Pin %q does not have ADC capabilities"
 #~ msgstr "La broche %q n'a pas de convertisseur analogique-digital"
 
+#~ msgid "Pin count must be at least 1"
+#~ msgstr "Nombre de broches doit être au moins 1"
+
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "La broche 'pin' ne supporte pas les capacités ADC"
+
+#~ msgid "Pin number already reserved by EXTI"
+#~ msgstr "Numéro de broche 'pin' déjà réservé par EXTI"
+
 #~ msgid "Pin(16) doesn't support pull"
 #~ msgstr "Pin(16) ne supporte pas le tirage (pull)"
+
+#~ msgid "PinAlarm not yet implemented"
+#~ msgstr "PinAlarm pas encore implémenté"
 
 #~ msgid "Pins not valid for SPI"
 #~ msgstr "Broche invalide pour le SPI"
@@ -6364,9 +5537,75 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "Pixel beyond bounds of buffer"
 #~ msgstr "Pixel au-delà des limites du tampon"
 
+#~ msgid "Pop from an empty Ps2 buffer"
+#~ msgstr "Pop à partir d'un tampon Ps2 vide"
+
+#~ msgid ""
+#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
+#~ "instead"
+#~ msgstr ""
+#~ "Ce port n'accepte pas de PWM carrier. Précisez plutôt les valeurs pin, "
+#~ "frequency et duty_cycle"
+
+#~ msgid ""
+#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
+#~ "Carrier instead"
+#~ msgstr ""
+#~ "Ce port n'accepte pas de broches ou de fréquence. Construisez plutôt en "
+#~ "passant un PWMOut Carrier"
+
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+#~ msgstr ""
+#~ "Appuyez sur une touche pour entrer sur REPL ou CTRL-D pour recharger."
+
+#~ msgid "Program must contain at least one 16-bit instruction."
+#~ msgstr "Le programme doit contenir au moins une instruction de 16 bits."
+
+#~ msgid "Program too large"
+#~ msgstr "Programme trop grand"
+
+#~ msgid "PulseIn not supported on this chip"
+#~ msgstr "PulseIn non pris en charge sur cette puce"
+
+#~ msgid "PulseOut not supported on this chip"
+#~ msgstr "PulseOut non pris en charge sur cette puce"
+
+#~ msgid "RAISE mode is not implemented"
+#~ msgstr "Mode RAISE n'est pas implémenté"
+
+#~ msgid "RS485 Not yet supported on this device"
+#~ msgstr "RS485 n'est pas encore supporté sur cet appareil"
+
+#~ msgid "RTC calibration is not supported on this board"
+#~ msgstr "La calibration du RTC non supportée sur cette carte"
+
+#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
+#~ msgstr "RTS / CTS / RS485 Pas encore supporté sur cet appareil"
+
 #, fuzzy
 #~ msgid "Range out of bounds"
 #~ msgstr "adresse hors limites"
+
+#~ msgid "Read-only object"
+#~ msgstr "Objet en lecture seule"
+
+#~ msgid "Row entry must be digitalio.DigitalInOut"
+#~ msgstr "L'entrée de ligne 'Row' doit être un digitalio.DigitalInOut"
+
+#~ msgid "Running in safe mode! "
+#~ msgstr "Exécution en mode sécurisé! "
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Mode sans-échec ! Auto-chargement désactivé.\n"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "SDA ou SCL a besoin d'une résistance de tirage ('pull up')"
+
+#~ msgid "SPI Init Error"
+#~ msgstr "Erreur d'initialisation SPI"
+
+#~ msgid "SPI Re-initialization error"
+#~ msgstr "Erreur de réinitialisation SPI"
 
 #~ msgid "STA must be active"
 #~ msgstr "'STA' doit être actif"
@@ -6374,8 +5613,59 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "STA required"
 #~ msgstr "'STA' requis"
 
+#~ msgid "Sample rate must be positive"
+#~ msgstr "Le taux d'échantillonnage doit être positif"
+
+#, c-format
+#~ msgid "Sample rate too high. It must be less than %d"
+#~ msgstr "Taux d'échantillonnage trop élevé. Doit être inférieur à %d"
+
+#~ msgid "Scan already in progess. Stop with stop_scan."
+#~ msgstr "Scan déjà en cours. Arrêtez avec stop_scan."
+
+#~ msgid "Selected CTS pin not valid"
+#~ msgstr "La broche CTS sélectionnée n'est pas valide"
+
+#~ msgid "Selected RTS pin not valid"
+#~ msgstr "La broche RTS sélectionnée n'est pas valide"
+
+#~ msgid "Set pin count must be between 1 and 5"
+#~ msgstr "Nombre de broches configurées doit être entre 1 et 5"
+
+#~ msgid "Side set pin count must be between 1 and 5"
+#~ msgstr "Nombre de broches Side configurées doit être entre 1 et 5"
+
+#~ msgid "Sleep Memory not available"
+#~ msgstr "La mémoire de sommeil n'est pas disponible"
+
 #~ msgid "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 #~ msgstr "Assertion en mode 'soft-device', id: 0x%08lX, pc: 0x%08lX"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Fractionnement avec des sous-captures"
+
+#~ msgid "Stack size must be at least 256"
+#~ msgstr "La pile doit être au moins de 256"
+
+#~ msgid "Stopping AP is not supported."
+#~ msgstr "Stopper n'est pas supporté."
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "Il manque une méthode readinto() ou write() au flux."
+
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "Fournissez au moins une broche UART"
+
+#~ msgid "The BOOT button was pressed at start up.\n"
+#~ msgstr "Le bouton BOOT était pressé au démarrage.\n"
+
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Increase the stack size if you know how. If not:"
+#~ msgstr ""
+#~ "La pile de CircuitPython est corrompue parce que la pile était trop "
+#~ "petite.\n"
+#~ "Augmentez la taille de la pile si vous savez comment. Sinon :"
 
 #~ msgid ""
 #~ "The CircuitPython heap was corrupted because the stack was too small.\n"
@@ -6391,6 +5681,59 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ "Si vous n'avez pas modifié la pile, merci de remplir un ticket avec le "
 #~ "contenu  de votre lecteur CIRCUITPY :\n"
 
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase the stack size if you know how, or if not:"
+#~ msgstr ""
+#~ "Le tas CircuitPython a été corrompu, car la pile était trop petite.\n"
+#~ "Veuillez augmenter la taille de la pile si vous savez comment, ou sinon :"
+
+#~ msgid "The SW38 button was pressed at start up.\n"
+#~ msgstr "Le bouton SW38 était pressé au démarrage.\n"
+
+#~ msgid "The VOLUME button was pressed at start up.\n"
+#~ msgstr "Le bouton VOLUME était pressé au démarrage.\n"
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode."
+#~ msgstr ""
+#~ "Le module `microcontroller` a été utilisé pour démarrer en mode sûr. "
+#~ "Pressez reset pour quitter le mode sûr."
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode.\n"
+#~ msgstr ""
+#~ "Le module `microcontroller` a été utilisé pour démarrer en mode sans "
+#~ "échec. Appuyez sur reset pour quitter le mode sans échec.\n"
+
+#~ msgid "The central button was pressed at start up.\n"
+#~ msgstr "Le bouton central était pressé au démarrage.\n"
+
+#~ msgid "The left button was pressed at start up.\n"
+#~ msgstr "Le bouton gauche était pressé au démarrage.\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY)."
+#~ msgstr ""
+#~ "L'alimentation du microcontrôleur a diminué. Veillez à ce que votre "
+#~ "alimentation fournisse\n"
+#~ "assez de puissance pour tout le circuit, puis appuyez sur 'reset' (après "
+#~ "avoir éjecté CIRCUITPY)."
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "La puissance du microcontrôleur a baissé. Assurez-vous que votre "
+#~ "alimentation fournit\n"
+#~ "assez de puissance pour tout le circuit et appuyez sur reset (après avoir "
+#~ "éjecté CIRCUITPY).\n"
+
 #, fuzzy
 #~ msgid ""
 #~ "The microcontroller's power dipped. Please make sure your power supply "
@@ -6403,6 +5746,9 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ "suffisamment de puissance pour l'ensemble du circuit et appuyez sur "
 #~ "'reset' (après avoir éjecté CIRCUITPY).\n"
 
+#~ msgid "The power dipped. Make sure you are providing enough power."
+#~ msgstr "La puissance a chu. Assurez vous de fournir assez de puissance."
+
 #~ msgid ""
 #~ "The reset button was pressed while booting CircuitPython. Press again to "
 #~ "exit safe mode.\n"
@@ -6413,27 +5759,160 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "Tile indices must be 0 - 255"
 #~ msgstr "Les indices des tuiles doivent être compris entre 0 et 255 "
 
+#~ msgid "Tile value out of bounds"
+#~ msgstr "Valeur de tuile hors limites"
+
+#~ msgid "Timeout waiting for DRDY"
+#~ msgstr "Délai expiré en attendant DRDY"
+
+#~ msgid "Timeout waiting for VSYNC"
+#~ msgstr "Délai expiré en attendant VSYNC"
+
+#~ msgid ""
+#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
+#~ "program"
+#~ msgstr ""
+#~ "Le minuteur est réservé pour un usage interne - déclarez la broche PWM "
+#~ "plus tôt dans le programme"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Pour quitter, SVP redémarrez la carte sans "
+
+#~ msgid "To exit, please reset the board without requesting safe mode."
+#~ msgstr "Pour le quitter, redémarrez sans demander le mode sans-échec."
+
+#~ msgid "Too many display busses"
+#~ msgstr "Trop de bus d'affichage"
+
+#~ msgid "Total data to write is larger than outgoing_packet_length"
+#~ msgstr ""
+#~ "Le nombre total de données à écrire est supérieur à outgoing_packet_length"
+
+#~ msgid "TouchAlarm not available in light sleep"
+#~ msgstr "TouchAlarm n'est pas disponible en mode sommeil léger"
+
+#~ msgid "UART Buffer allocation error"
+#~ msgstr "Erreur d'allocation de tampon UART"
+
+#~ msgid "UART De-init error"
+#~ msgstr "Erreur de désactivation UART"
+
+#~ msgid "UART Init Error"
+#~ msgstr "Erreur d'initialisation UART"
+
+#~ msgid "UART Re-init error"
+#~ msgstr "Erreur de réinitialisation UART"
+
+#~ msgid "UART not yet supported"
+#~ msgstr "UART n'est pas encore supporté"
+
+#~ msgid "UART write error"
+#~ msgstr "Erreur d'écriture UART"
+
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) n'existe pas"
 
 #~ msgid "UART(1) can't read"
 #~ msgstr "UART(1) ne peut pas lire"
 
+#~ msgid "USB Busy"
+#~ msgstr "USB occupé"
+
+#~ msgid "USB Error"
+#~ msgstr "Erreur USB"
+
 #~ msgid "UUID integer value not in range 0 to 0xffff"
 #~ msgstr "valeur de l'entier UUID pas comprise entre 0 et 0xffff"
+
+#~ msgid "Unable to allocate the heap."
+#~ msgstr "Impossible d'allouer le tas."
 
 #~ msgid "Unable to remount filesystem"
 #~ msgstr "Impossible de remonter le système de fichiers"
 
+#~ msgid "Unable to write"
+#~ msgstr "Écriture impossible"
+
+#~ msgid "Unable to write to address."
+#~ msgstr "L'écriture a échoué."
+
+#~ msgid "Unknown failure"
+#~ msgstr "Échec inconnu"
+
+#~ msgid "Unknown soft device error: %04x"
+#~ msgstr "Erreur de périphérique logiciel inconnue : %04x"
+
 #~ msgid "Unknown type"
 #~ msgstr "Type inconnu"
+
+#, c-format
+#~ msgid "Unkown error code %d"
+#~ msgstr "Erreur inconnue %d"
+
+#~ msgid "Unsupported baudrate"
+#~ msgstr "Débit en bauds non supporté"
+
+#~ msgid "Unsupported operation"
+#~ msgstr "Opération non supportée"
+
+#~ msgid "Unsupported pull value."
+#~ msgstr "Valeur de tirage 'pull' non supportée."
 
 #~ msgid "Use esptool to erase flash and re-upload Python instead"
 #~ msgstr ""
 #~ "Utilisez 'esptool' pour effacer la flash et recharger Python à la place"
 
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr ""
+#~ "les fonctions de Viper ne supportent pas plus de 4 arguments actuellement"
+
 #~ msgid "Voice index too high"
 #~ msgstr "Index de la voix trop grand"
+
+#~ msgid "WatchDogTimer is not currently running"
+#~ msgstr "WatchDogTimer n'est pas en cours d'exécution"
+
+#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+#~ msgstr ""
+#~ "WatchDogTimer.mode ne peut pas être changé une fois réglé à WatchDogMode."
+#~ "RESET"
+
+#~ msgid "WatchDogTimer.timeout must be greater than 0"
+#~ msgstr "WatchDogTimer.timeout doit être supérieur à 0"
+
+#~ msgid "Watchdog timer expired."
+#~ msgstr "Le minuteur Watchdog a expiré."
+
+#, c-format
+#~ msgid ""
+#~ "Welcome to Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Please visit learn.adafruit.com/category/circuitpython for project "
+#~ "guides.\n"
+#~ "\n"
+#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ msgstr ""
+#~ "Bienvenue sur Adafruit CircuitPython %s !\n"
+#~ "\n"
+#~ "Visitez learn.adafruit.com/category/circuitpython pour les guides.\n"
+#~ "\n"
+#~ "Pour lister les modules inclus, tapez `help(\"modules\")`.\n"
+
+#~ msgid "WiFi password must be between 8 and 63 characters"
+#~ msgstr "Le mot de passe WiFi doit faire entre 8 et 63 caractères"
+
+#~ msgid "Wifi is in access point mode."
+#~ msgstr "Wifi en mode point d'accès."
+
+#~ msgid "Wifi is in station mode."
+#~ msgstr "Wifi en mode station."
+
+#~ msgid "You are in safe mode because:\n"
+#~ msgstr "Vous êtes en mode sûr parce que :\n"
+
+#~ msgid "You are in safe mode: something unanticipated happened.\n"
+#~ msgstr ""
+#~ "Vous êtes en mode sans échec : quelque chose d'imprévu s'est passé.\n"
 
 #, fuzzy
 #~ msgid ""
@@ -6442,14 +5921,63 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgstr ""
 #~ "Vous êtes en mode sans-échec ce qui signifie qu'un imprévu est survenu.\n"
 
+#~ msgid ""
+#~ "You pressed the reset button during boot. Press again to exit safe mode."
+#~ msgstr ""
+#~ "Vous avez pressé le bouton reset pendant le démarrage. Pressez-le à "
+#~ "nouveau pour sortir du mode sûr."
+
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "Vous avez demandé à démarrer en mode sans-échec par "
+
+#~ msgid "__init__() should return None, not '%q'"
+#~ msgstr "__init__() doit retourner None, pas '%q'"
+
+#~ msgid "abort() called"
+#~ msgstr "abort() appelé"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "l'adresse %08x n'est pas alignée sur %d octets"
+
+#~ msgid "address out of bounds"
+#~ msgstr "adresse hors limites"
+
+#~ msgid "arctan2 is implemented for scalars and ndarrays only"
+#~ msgstr ""
+#~ "arctan2 est implémenté uniquement pour les scalaires et les ndarrays"
+
+#~ msgid "argument must be ndarray"
+#~ msgstr "l'argument doit être un ndarray"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "attribut pas encore supporté"
+
+#~ msgid "axis must be -1, 0, None, or 1"
+#~ msgstr "l'axe doit être -1, 0, None ou 1"
+
+#~ msgid "axis must be -1, 0, or 1"
+#~ msgstr "l'axe doit être -1, 0 ou 1"
+
+#~ msgid "axis must be None, 0, or 1"
+#~ msgstr "l'axe doit être None, 0 ou 1"
+
 #~ msgid "bad GATT role"
 #~ msgstr "mauvais rôle GATT"
+
+#~ msgid "bits must be 7, 8 or 9"
+#~ msgstr "bits doivent être 7, 8 ou 9"
 
 #~ msgid "bits must be 8"
 #~ msgstr "les bits doivent être 8"
 
+#~ msgid "bits must be in range 5 to 9"
+#~ msgstr "les bits doivent être compris entre 5 et 9"
+
 #~ msgid "buf is too small. need %d bytes"
 #~ msgstr "'buf' est trop petit. Besoin de %d octets"
+
+#~ msgid "buffer must be a bytes-like object"
+#~ msgstr "le tampon doit être un objet bytes-like"
 
 #~ msgid "buffer too long"
 #~ msgstr "tampon trop long"
@@ -6457,11 +5985,41 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "buffers must be the same length"
 #~ msgstr "les tampons doivent être de la même longueur"
 
+#~ msgid "buttons must be digitalio.DigitalInOut"
+#~ msgstr "les boutons doivent être des digitalio.DigitalInOut"
+
+#~ msgid "byte code not implemented"
+#~ msgstr "bytecode non implémenté"
+
+#~ msgid "byteorder is not a string"
+#~ msgstr "byteorder n'est pas une chaîne"
+
 #~ msgid "byteorder is not an instance of ByteOrder (got a %s)"
 #~ msgstr "'byteorder' n'est pas une instance de ByteOrder (reçu un %s)"
 
+#~ msgid "bytes > 8 bits not supported"
+#~ msgstr "octets > 8 bits non supportés"
+
+#~ msgid "calibration value out of range +/-127"
+#~ msgstr "valeur d'étalonnage hors intervalle +/-127"
+
+#~ msgid "can only save bytecode"
+#~ msgstr "ne peut sauvegarder que du bytecode"
+
 #~ msgid "can query only one param"
 #~ msgstr "ne peut demander qu'un seul paramètre"
+
+#~ msgid "can't convert %q to int"
+#~ msgstr "ne peut convertir %q à int"
+
+#~ msgid "can't convert address to int"
+#~ msgstr "ne peut convertir l'adresse en entier 'int'"
+
+#~ msgid "can't convert to %q"
+#~ msgstr "impossible de convertir en %q"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr "on ne peut pas faire de division tronquée de nombres complexes"
 
 #~ msgid "can't get AP config"
 #~ msgstr "impossible de récupérer la config de 'AP'"
@@ -6469,19 +6027,67 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "can't get STA config"
 #~ msgstr "impossible de récupérer la config de 'STA'"
 
+#~ msgid "can't have multiple **x"
+#~ msgstr "il ne peut y avoir de **x multiples"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "il ne peut y avoir de *x multiples"
+
+#~ msgid "can't pend throw to just-started generator"
+#~ msgstr ""
+#~ "on ne peut effectuer une action de type 'pend throw' sur un générateur "
+#~ "fraîchement démarré"
+
 #~ msgid "can't set AP config"
 #~ msgstr "impossible de régler la config de 'AP'"
 
 #~ msgid "can't set STA config"
 #~ msgstr "impossible de régler la config de 'STA'"
 
+#~ msgid "cannot import name %q"
+#~ msgstr "ne peut pas importer le nom %q"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "ne peut pas réaliser un import relatif"
+
+#~ msgid "cannot reshape array (incompatible input/output shape)"
+#~ msgstr ""
+#~ "ne peut pas remodeler le tableau (forme d'entrée / sortie incompatible)"
+
+#~ msgid "cannot unambiguously get sizeof scalar"
+#~ msgstr "ne peut récupérer sans ambigüité le sizeof d'un scalaire"
+
 #~ msgid "characteristics includes an object that is not a Characteristic"
 #~ msgstr ""
 #~ "'characteristics' inclut un objet qui n'est pas une 'Characteristic'"
 
+#~ msgid "circle can only be registered in one parent"
+#~ msgstr "le cercle ne peut être enregistré que dans un seul parent"
+
 #, fuzzy
 #~ msgid "color buffer must be a buffer or int"
 #~ msgstr "le tampon de couleur doit être un tampon ou un entier 'int'"
+
+#~ msgid "color should be an int"
+#~ msgstr "la couleur doit être un entier 'int'"
+
+#~ msgid "complex division by zero"
+#~ msgstr "division complexe par zéro"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "constante doit être un entier"
+
+#~ msgid "could not broadast input array from shape"
+#~ msgstr "n'a pas pu diffuser le tableau d'entrée à partir de la forme"
+
+#~ msgid "ddof must be smaller than length of data set"
+#~ msgstr "ddof doit être inférieur à la longueur de l'ensemble de données"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr "destination_length doit être un entier >= 0"
+
+#~ msgid "divisor must be 4"
+#~ msgstr "le diviseur doit être 4"
 
 #~ msgid "either pos or kw args are allowed"
 #~ msgstr "soit 'pos', soit 'kw' est permis en argument"
@@ -6489,11 +6095,54 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "empty %q list"
 #~ msgstr "liste %q vide"
 
+#~ msgid "end_x should be an int"
+#~ msgstr "end_x doit être un entier 'int'"
+
+#~ msgid ""
+#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "esp32_camera.Camera nécessite la configuration de PSRAM réservée. Se "
+#~ "référer à la documentation."
+
+#~ msgid ""
+#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "espcamera.Camera a besoin de PSRAM réservée. Voir la documentation pour "
+#~ "les instructions."
+
+#~ msgid "expected '%q' but got '%q'"
+#~ msgstr "'%q' était attendu, mais reçu '%q'"
+
+#~ msgid "expected '%q' or '%q' but got '%q'"
+#~ msgstr "'%q' ou '%q' était attendu, mais reçu '%q'"
+
 #~ msgid "expected a DigitalInOut"
 #~ msgstr "objet DigitalInOut attendu"
 
 #~ msgid "expecting a pin"
 #~ msgstr "une broche (Pin) est attendue"
+
+#~ msgid "f-string expression part cannot include a '#'"
+#~ msgstr "La partie d'expression de chaîne f ne peut pas inclure de '#'"
+
+#~ msgid "f-string expression part cannot include a backslash"
+#~ msgstr ""
+#~ "La partie d'expression de chaîne f ne peut pas inclure de barre oblique "
+#~ "inverse"
+
+#~ msgid "f-string: empty expression not allowed"
+#~ msgstr "f-string : expression vide non autorisée"
+
+#~ msgid "f-string: expecting '}'"
+#~ msgstr "f-string : attend '}'"
+
+#~ msgid "f-string: single '}' is not allowed"
+#~ msgstr "f-string : single '}' n'est pas autorisé"
+
+#~ msgid "first argument must be an iterable"
+#~ msgstr "le premier argument doit être un itérable"
 
 #~ msgid "firstbit must be MSB"
 #~ msgstr "le 1er bit doit être le MSB"
@@ -6504,8 +6153,43 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "frequency can only be either 80Mhz or 160MHz"
 #~ msgstr "la fréquence doit être soit 80MHz soit 160MHz"
 
+#~ msgid "frequency is read-only for this board"
+#~ msgstr "la fréquence est en lecture seule pour cette carte"
+
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "la fonction ne prend pas d'arguments nommés"
+
+#~ msgid "function is implemented for scalars and ndarrays only"
+#~ msgstr ""
+#~ "la fonction est implémentée pour les scalaires et les ndarrays uniquement"
+
 #~ msgid "impossible baudrate"
 #~ msgstr "débit impossible"
+
+#~ msgid "incompatible native .mpy architecture"
+#~ msgstr "architecture native .mpy incompatible"
+
+#~ msgid "input and output shapes are not compatible"
+#~ msgstr "les formes d'entrée et de sortie ne sont pas compatibles"
+
+#~ msgid "input argument must be an integer or a 2-tuple"
+#~ msgstr "l'argument d'entrée doit être un entier ou un tuple 2"
+
+#~ msgid "input must be a tensor of rank 2"
+#~ msgstr "l'entrée doit être un tenseur de rang 2"
+
+#~ msgid "inputs are not iterable"
+#~ msgstr "les entrées ne sont pas itérables"
+
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr ""
+#~ "Le deuxième argument de int() doit être compris entre 2 et 36 inclus"
+
+#~ msgid "integer required"
+#~ msgstr "entier requis"
+
+#~ msgid "interp is defined for 1D arrays of equal length"
+#~ msgstr "interp est défini pour les matrices 1D de longueur égale"
 
 #~ msgid "interval not in range 0.0020 to 10.24"
 #~ msgstr "intervalle hors limites 0.0020 à 10.24"
@@ -6519,11 +6203,29 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "invalid alarm"
 #~ msgstr "alarme invalide"
 
+#~ msgid "invalid architecture"
+#~ msgstr "architecture invalide"
+
+#~ msgid "invalid arguments"
+#~ msgstr "arguments invalides"
+
+#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
+#~ msgstr "bits_per_pixel %d est invalid, doit être 1, 4, 8, 16, 24 ou 32"
+
 #~ msgid "invalid buffer length"
 #~ msgstr "longueur de tampon invalide"
 
 #~ msgid "invalid data bits"
 #~ msgstr "bits de données invalides"
+
+#~ msgid "invalid decorator"
+#~ msgstr "décorateur invalide"
+
+#~ msgid "invalid dupterm index"
+#~ msgstr "index invalide pour dupterm"
+
+#~ msgid "invalid format"
+#~ msgstr "format invalide"
 
 #~ msgid "invalid pin"
 #~ msgstr "broche invalide"
@@ -6531,8 +6233,43 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "invalid stop bits"
 #~ msgstr "bits d'arrêt invalides"
 
+#~ msgid "invalid traceback"
+#~ msgstr "traceback invalide"
+
+#~ msgid "io must be rtc io"
+#~ msgstr "io doit être rtc io"
+
+#~ msgid "iterables are not of the same length"
+#~ msgstr "les itérables ne sont pas de la même longueur"
+
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr ""
+#~ "argument(s) nommé(s) pas encore implémenté(s) - utilisez les arguments "
+#~ "normaux"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "les noms doivent être des chaînes de caractères"
+
 #~ msgid "len must be multiple of 4"
 #~ msgstr "'len' doit être un multiple de 4"
+
+#~ msgid "length argument not allowed for this type"
+#~ msgstr "paramètre 'length' non-permis pour ce type"
+
+#~ msgid "long int not supported in this build"
+#~ msgstr "entiers longs non supportés dans cette build"
+
+#~ msgid "matrix dimensions do not match"
+#~ msgstr "les dimensions de la matrice ne correspondent pas"
+
+#~ msgid "max_length must be > 0"
+#~ msgstr "max_length doit être > 0"
+
+#~ msgid "max_length must be >= 0"
+#~ msgstr "max_length doit être >= 0"
+
+#~ msgid "maximum number of dimensions is 4"
+#~ msgstr "nombre maximal de dimensions est 4"
 
 #~ msgid "memory allocation failed, allocating %u bytes for native code"
 #~ msgstr ""
@@ -6541,19 +6278,129 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "must specify all of sck/mosi/miso"
 #~ msgstr "sck, mosi et miso doivent tous être spécifiés"
 
+#~ msgid "n must be between 0, and 9"
+#~ msgstr "n doit être compris entre 0 et 9"
+
 #, fuzzy
 #~ msgid "name must be a string"
 #~ msgstr "les noms doivent être des chaînes de caractère"
 
+#~ msgid "name reused for argument"
+#~ msgstr "nom réutilisé comme paramètre"
+
+#~ msgid "no available NIC"
+#~ msgstr "adapteur réseau non disponible"
+
+#~ msgid "no reset pin available"
+#~ msgstr "pas de broche de réinitialisation disponible"
+
+#~ msgid "non-Device in %q"
+#~ msgstr "aucun appareil dans %q"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "argument non-nommé après */**"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "argument non-nommé après argument nommé"
+
+#~ msgid "norm is defined for 1D and 2D arrays"
+#~ msgstr "norm est défini pour des tableaux 1D et 2D"
+
 #~ msgid "not a valid ADC Channel: %d"
 #~ msgstr "canal ADC non valide : %d"
+
+#~ msgid "number of arguments must be 2, or 3"
+#~ msgstr "le nombre d'arguments doit être 2 ou 3"
+
+#~ msgid "object '%q' is not a tuple or list"
+#~ msgstr "l'objet '%q' n'est pas un tuple ou une list"
+
+#~ msgid "object '%s' is not a tuple or list"
+#~ msgstr "l'objet '%s' n'est pas un tuple ou une liste"
+
+#~ msgid "object does not support item assignment"
+#~ msgstr "l'objet ne supporte pas l'assignation d'éléments"
+
+#~ msgid "object does not support item deletion"
+#~ msgstr "l'objet ne supporte pas la suppression d'éléments"
+
+#~ msgid "object is not subscriptable"
+#~ msgstr "l'objet n'est pas sous-scriptable"
+
+#~ msgid "object of type '%q' has no len()"
+#~ msgstr "len() indéfinie pour un objet de type '%q'"
+
+#~ msgid "offset out of bounds"
+#~ msgstr "décalage hors limites"
+
+#~ msgid "operation is not implemented for flattened array"
+#~ msgstr "l'opération n'est pas implémentée pour un tableau aplati"
+
+#~ msgid "out of range of source"
+#~ msgstr "en dehors de l'intervalle de la source"
+
+#~ msgid "palette_index should be an int"
+#~ msgstr "palette_index devrait être un entier 'int'"
+
+#~ msgid "parameter annotation must be an identifier"
+#~ msgstr "l'annotation du paramètre doit être un identifiant"
 
 #~ msgid "pin does not have IRQ capabilities"
 #~ msgstr "la broche ne supporte pas les interruptions (IRQ)"
 
+#~ msgid "pixel value requires too many bits"
+#~ msgstr "la valeur du pixel requiet trop de bits"
+
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+#~ msgstr ""
+#~ "pixel_shader doit être un objet displayio.Palette ou displayio."
+#~ "ColorConverter"
+
+#~ msgid "polygon can only be registered in one parent"
+#~ msgstr "le polygone ne peut être enregistré que dans un parent"
+
+#~ msgid "pop from an empty set"
+#~ msgstr "'pop' d'un ensemble set vide"
+
+#~ msgid "pop from empty list"
+#~ msgstr "'pop' d'une liste vide"
+
+#~ msgid "popitem(): dictionary is empty"
+#~ msgstr "popitem() : dictionnaire vide"
+
 #, fuzzy
 #~ msgid "position must be 2-tuple"
 #~ msgstr "position doit être un 2-tuple"
+
+#~ msgid "pressing BOOT button at start up.\n"
+#~ msgstr "presser le bouton BOOT au démarrage.\n"
+
+#~ msgid "pressing SW38 button at start up.\n"
+#~ msgstr "presser le bouton SW38 au démarrage.\n"
+
+#~ msgid "pressing VOLUME button at start up.\n"
+#~ msgstr "presser le bouton VOLUME au démarrage.\n"
+
+#~ msgid "pressing boot button at start up.\n"
+#~ msgstr "bouton boot appuyé lors du démarrage.\n"
+
+#~ msgid "pressing both buttons at start up.\n"
+#~ msgstr "les deux boutons appuyés lors du démarrage.\n"
+
+#~ msgid "pressing the left button at start up\n"
+#~ msgstr "appuyer le bouton de gauche au démarrage\n"
+
+#~ msgid "pull_threshold must be between 1 and 32"
+#~ msgstr "pull_threshold doit être entre 1 et 32"
+
+#~ msgid "push_threshold must be between 1 and 32"
+#~ msgstr "push_threshold doit être entre 1 et 32"
+
+#~ msgid "queue overflow"
+#~ msgstr "dépassement de file"
+
+#~ msgid "raw f-strings are not implemented"
+#~ msgstr "les chaînes f brutes ne sont pas implémentées"
 
 #~ msgid "rawbuf is not the same size as buf"
 #~ msgstr "'rawbuf' n'est pas de la même taille que 'buf'"
@@ -6562,14 +6409,76 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "readonly attribute"
 #~ msgstr "attribut en lecture seule"
 
+#~ msgid "right hand side must be an ndarray, or a scalar"
+#~ msgstr "le côté droit doit être un ndarray ou un scalaire"
+
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "tampon sample_source doit être un bytearray ou une matrice de type 'h', "
+#~ "'H', 'b' ou 'B'"
+
 #~ msgid "scan failed"
 #~ msgstr "échec du scan"
+
+#~ msgid "schedule stack full"
+#~ msgstr "pile de planification pleine"
 
 #~ msgid "services includes an object that is not a Service"
 #~ msgstr "'services' inclut un objet qui n'est pas un 'Service'"
 
+#~ msgid "shape must be a 2-tuple"
+#~ msgstr "la forme doit être un tuple 2"
+
+#~ msgid "shape must be a tuple"
+#~ msgstr "forme doit être un tuple"
+
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "'}' seule rencontrée dans une chaîne de format"
+
+#~ msgid "slice step can't be zero"
+#~ msgstr "le pas 'step' de la tranche ne peut être zéro"
+
+#~ msgid "slice step cannot be zero"
+#~ msgstr "le pas 'step' de la tranche ne peut être zéro"
+
+#~ msgid "sorted axis can't be longer than 65535"
+#~ msgstr "sorted axis ne peut pas dépasser 65535"
+
+#~ msgid "ssid can't be more than 32 bytes"
+#~ msgstr "un ssid ne peut pas faire plus de 32 octets"
+
+#~ msgid "start_x should be an int"
+#~ msgstr "'start_x' doit être un entier 'int'"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "le pas 'step' doit être non nul"
+
+#~ msgid "stop must be 1 or 2"
+#~ msgstr "stop doit être 1 ou 2"
+
+#~ msgid "string indices must be integers, not %q"
+#~ msgstr "les indices d'une chaîne doivent être des entiers, pas %q"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr ""
+#~ "chaîne de carac. non supportée; utilisez des bytes ou une matrice de bytes"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "struct : indexage impossible"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "le seuil doit être dans la portée 0-65536"
+
 #~ msgid "tile index out of bounds"
 #~ msgstr "indice de tuile hors limites"
+
+#~ msgid "tile must be greater than zero"
+#~ msgstr "tile doit être plus que zéro"
+
+#~ msgid "time.struct_time() takes a 9-sequence"
+#~ msgstr "time.struct_time() prend une séquence de longueur 9"
 
 #~ msgid "time.struct_time() takes exactly 1 argument"
 #~ msgstr "time.struct_time() prend exactement 1 argument"
@@ -6577,11 +6486,41 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "timeout >100 (units are now seconds, not msecs)"
 #~ msgstr "timeout >100 (exprimé en secondes, pas en ms)"
 
+#~ msgid "timeout must be 0.0-100.0 seconds"
+#~ msgstr "le délai doit être compris entre 0.0 et 100.0 secondes"
+
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "'timeout' doit être >= 0.0"
+
 #~ msgid "too many arguments"
 #~ msgstr "trop d'arguments"
 
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "trop d'arguments fournis avec ce format"
+
+#~ msgid "trapz is defined for 1D arrays"
+#~ msgstr "trapz est définie pour des matrices à une dimension"
+
+#~ msgid "trigger level must be 0 or 1"
+#~ msgstr "niveau du déclencheur doit être 0 ou 1"
+
+#~ msgid "tuple index out of range"
+#~ msgstr "index du tuple hors de portée"
+
+#~ msgid "tuple/list required on RHS"
+#~ msgstr "tuple ou liste requis en partie droite"
+
+#~ msgid "type object 'generator' has no attribute '__await__'"
+#~ msgstr "le type 'generator' n'a pas d'attribut '__await__'"
+
+#~ msgid "unindent does not match any outer indentation level"
+#~ msgstr "la désindentation ne correspond à aucune indentation précédente"
+
 #~ msgid "unknown config param"
 #~ msgstr "paramètre de config. inconnu"
+
+#~ msgid "unknown format code '%c' for object of type '%s'"
+#~ msgstr "code de format '%c' inconnu pour un objet de type '%s'"
 
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr "code de format '%c' inconnu pour un objet de type 'float'"
@@ -6592,8 +6531,57 @@ msgstr "zi doit être de forme (n_section, 2)"
 #~ msgid "unknown status param"
 #~ msgstr "paramètre de statut inconnu"
 
+#~ msgid "unmatched '{' in format"
+#~ msgstr "'{' sans correspondance dans le format"
+
+#~ msgid "unsupported type for %q: '%q'"
+#~ msgstr "type non supporté pour %q : '%q'"
+
+#~ msgid "unsupported types for %q: '%s', '%s'"
+#~ msgstr "type non supporté pour %q : '%s', '%s'"
+
+#~ msgid "value_count must be > 0"
+#~ msgstr "'value_count' doit être > 0"
+
+#~ msgid "vectors must have same lengths"
+#~ msgstr "les vecteurs doivent avoir la même longueur"
+
+#~ msgid "wakeup conflict"
+#~ msgstr "conflit au réveil"
+
+#~ msgid "watchdog not initialized"
+#~ msgstr "chien de garde (watchdog) non initialisé"
+
+#~ msgid "watchdog timeout must be greater than 0"
+#~ msgstr "watchdog timeout doit être supérieur à 0"
+
+#, c-format
+#~ msgid "width must be from 2 to 8 (inclusive), not %d"
+#~ msgstr "width doit être entre 2 et 8 (inclusivement), non %d"
+
 #~ msgid "wifi_set_ip_info() failed"
 #~ msgstr "wifi_set_ip_info() a échoué"
 
 #~ msgid "write_args must be a list, tuple, or None"
 #~ msgstr "'write_args' doit être une liste, un tuple ou 'None'"
+
+#~ msgid "wrong argument type"
+#~ msgstr "type d'argument incorrect"
+
+#~ msgid "wrong operand type"
+#~ msgstr "type d'opérande incorrect"
+
+#~ msgid "x value out of bounds"
+#~ msgstr "valeur x hors limites"
+
+#~ msgid "xTaskCreate failed"
+#~ msgstr "Échec de xTaskCreate"
+
+#~ msgid "y should be an int"
+#~ msgstr "'y' doit être un entier 'int'"
+
+#~ msgid "y value out of bounds"
+#~ msgstr "valeur y hors limites"
+
+#~ msgid "zero step"
+#~ msgstr "'step' nul"

--- a/locale/hi.po
+++ b/locale/hi.po
@@ -74,40 +74,10 @@ msgstr ""
 msgid "%%c requires int or char"
 msgstr ""
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr ""
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
 msgstr ""
 
 #: shared-bindings/microcontroller/Pin.c
@@ -291,11 +261,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
 msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
@@ -1607,7 +1572,8 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
 msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c

--- a/locale/it_IT.po
+++ b/locale/it_IT.po
@@ -75,42 +75,12 @@ msgstr " output:\n"
 msgid "%%c requires int or char"
 msgstr "%%c necessita di int o char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr ""
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr ""
 "%d pin indirizzo, %d pin rgb e %d tessere indicano l'altezza di %d, non %d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr ""
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -293,11 +263,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
 msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
@@ -1621,7 +1586,8 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
 msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
@@ -2866,7 +2832,8 @@ msgstr ""
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a bytearray or array of type 'b' or 'B'"
-msgstr "buffer del colore deve essere un bytearray o un array di tipo 'b' o 'B'"
+msgstr ""
+"buffer del colore deve essere un bytearray o un array di tipo 'b' o 'B'"
 
 #: shared-bindings/displayio/Palette.c
 msgid "color must be between 0x000000 and 0xffffff"
@@ -3186,7 +3153,8 @@ msgstr "mancante il #%d argomento posizonale obbligatorio della funzione"
 #: py/argcheck.c py/bc.c py/objnamedtuple.c shared-bindings/time/__init__.c
 #, c-format
 msgid "function takes %d positional arguments but %d were given"
-msgstr "la funzione prende %d argomenti posizionali ma ne sono stati forniti %d"
+msgstr ""
+"la funzione prende %d argomenti posizionali ma ne sono stati forniti %d"
 
 #: shared-bindings/time/__init__.c
 msgid "function takes exactly 9 arguments"
@@ -4440,110 +4408,12 @@ msgstr ""
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
 
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr ""
-#~ "'await', 'async for' o 'async with' fuori della funzione sincronizzazione"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' fuori del ciclo"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' fuori del ciclo"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Suddivisione con sotto-catture"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "attributi non ancora supportati"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr "impossibile fare il modulo di un numero complesso"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "impossibile imporate il nome %q"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr ""
-#~ "argomento(i) nominati non ancora implementati - usare invece argomenti "
-#~ "normali"
-
-#, fuzzy
-#~ msgid "offset out of bounds"
-#~ msgstr "indirizzo fuori limite"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "ADC2 sta usando il WiFi"
-
-#~ msgid "queue overflow"
-#~ msgstr "overflow della coda"
-
-#~ msgid "'coroutine' object is not an iterator"
-#~ msgstr "L'oggetto 'coroutine' non è un iteratore"
-
-#~ msgid "Buffer is too small"
-#~ msgstr "Buffer troppo piccolo"
-
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-#~ msgstr ""
-#~ "pixel_shader deve essere displayio.Palette o displayio.ColorConverter"
-
 #~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
+#~ "\n"
+#~ "Code stopped by auto-reload.\n"
 #~ msgstr ""
-#~ "File .mpy incompatibile. Aggiorna tutti i file .mpy. Vedi http://adafru."
-#~ "it/mpy-update per più informazioni."
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "impossibile usare **x multipli"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "impossibile usare *x multipli"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "la costante deve essere un intero"
-
-#~ msgid "invalid format"
-#~ msgstr "formato non valido"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "argomenti nominati devono essere stringhe"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "argomento non nominato dopo */**"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "argomento non nominato seguito da argomento nominato"
-
-#~ msgid "No RX pin"
-#~ msgstr "Nessun pin RX"
-
-#~ msgid "No TX pin"
-#~ msgstr "Nessun pin TX"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "La luminosità deve essere tra 0-1.0"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "Valore massimo di x quando rispachiato è %d"
-
-#, fuzzy
-#~ msgid "x value out of bounds"
-#~ msgstr "indirizzo fuori limite"
-
-#, fuzzy
-#~ msgid "y value out of bounds"
-#~ msgstr "indirizzo fuori limite"
-
-#~ msgid "64 bit types"
-#~ msgstr "Tipo 64 bits"
-
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "troppi argomenti forniti con il formato specificato"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "%q pin non valido"
+#~ "\n"
+#~ "Codice fermato dall'auto-ricarica.\n"
 
 #~ msgid ""
 #~ "\n"
@@ -4554,54 +4424,11 @@ msgstr ""
 #~ "Per favore, segnala il problema con il contenuto del tuo CIRCUITPY a\n"
 #~ "https://github.com/adafruit/circuitpython/issues\n"
 
-#~ msgid "Expected a %q"
-#~ msgstr "Atteso un %q"
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "%q gli indici devono essere interi, non %q"
 
-#, fuzzy
-#~ msgid "Read-only object"
-#~ msgstr "Sola lettura"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "Almeno %d %q devono essere specificati (non %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Pin non validi"
-
-#~ msgid "complex division by zero"
-#~ msgstr "complex divisione per zero"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr "il secondo argomanto di int() deve essere >= 2 e <= 36"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "long int non supportata in questa build"
-
-#~ msgid "slice step cannot be zero"
-#~ msgstr "la step della slice non può essere zero"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "step deve essere non zero"
-
-#~ msgid "zero step"
-#~ msgstr "zero step"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "'}' singolo presente nella stringa di formattazione"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "la soglia deve essere nell'intervallo 0-65536"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "'{' spaiato nella stringa di formattazione"
-
-#~ msgid "To exit, please reset the board without "
-#~ msgstr "Per uscire resettare la scheda senza "
-
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "È stato richiesto l'avvio in modalità sicura da "
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "Metodi mancanti readinto() o write() allo stream."
+#~ msgid "%q list must be a list"
+#~ msgstr "lista %q deve essere una lista"
 
 #~ msgid "%q must be >= 0"
 #~ msgstr "%q deve essere >= 0"
@@ -4610,262 +4437,14 @@ msgstr ""
 #~ msgid "%q must be >= 1"
 #~ msgstr "slice del buffer devono essere della stessa lunghezza"
 
-#~ msgid "address out of bounds"
-#~ msgstr "indirizzo fuori limite"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr "destination_length deve essere un int >= 0"
-
-#~ msgid "color should be an int"
-#~ msgstr "il colore deve essere un int"
-
-#, fuzzy
-#~ msgid "end_x should be an int"
-#~ msgstr "y dovrebbe essere un int"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "palette_index deve essere un int"
-
-#, fuzzy
-#~ msgid "start_x should be an int"
-#~ msgstr "y dovrebbe essere un int"
-
-#~ msgid "y should be an int"
-#~ msgstr "y dovrebbe essere un int"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "il buffer sample_source deve essere un bytearray o un array di tipo 'h', "
-#~ "'H', 'b' o 'B'"
-
 #~ msgid "%q must be a tuple of length 2"
 #~ msgstr "%q deve essere una tupla di lunghezza 2"
 
+#~ msgid "%q pin invalid"
+#~ msgstr "%q pin non valido"
+
 #~ msgid "%q should be an int"
 #~ msgstr "%q dovrebbe essere un int"
-
-#~ msgid "Address type out of range"
-#~ msgstr "Tipo di indirizzo fuori intervallo"
-
-#~ msgid "AnalogOut functionality not supported"
-#~ msgstr "funzionalità AnalogOut non supportata"
-
-#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-#~ msgstr "AnalogOut ha solo 16 bit. Il valore deve essere meno di 65536."
-
-#~ msgid "AnalogOut not supported on given pin"
-#~ msgstr "AnalogOut non supportato sul pin scelto"
-
-#, c-format
-#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
-#~ msgstr "La profondità dei bit deve essere inclusiva da 1 a 6, non %d"
-
-#, c-format
-#~ msgid "Buffer incorrect size. Should be %d bytes."
-#~ msgstr "Buffer di lunghezza non valida. Dovrebbe essere di %d bytes."
-
-#~ msgid "Buffer must be at least length 1"
-#~ msgstr "Il buffer deve essere lungo almeno 1"
-
-#~ msgid "Bytes must be between 0 and 255."
-#~ msgstr "I byte devono essere compresi tra 0 e 255."
-
-#~ msgid "Cannot output both channels on the same pin"
-#~ msgstr "Impossibile dare in output entrambi i canal sullo stesso pin"
-
-#~ msgid "Cannot read without MISO pin."
-#~ msgstr "Impossibile leggere senza pin MISO."
-
-#~ msgid "Cannot reset into bootloader because no bootloader is present."
-#~ msgstr ""
-#~ "Impossibile resettare nel bootloader poiché nessun bootloader è presente."
-
-#~ msgid "Cannot transfer without MOSI and MISO pins."
-#~ msgstr "Impossibile trasferire senza i pin MOSI e MISO."
-
-#~ msgid "Cannot write without MOSI pin."
-#~ msgstr "Impossibile scrivere senza pin MOSI."
-
-#~ msgid "Clock pin init failed."
-#~ msgstr "Inizializzazione del pin di clock fallita."
-
-#, fuzzy
-#~ msgid "Command must be an int between 0 and 255"
-#~ msgstr "I byte devono essere compresi tra 0 e 255"
-
-#~ msgid "Could not initialize UART"
-#~ msgstr "Impossibile inizializzare l'UART"
-
-#~ msgid "Couldn't allocate first buffer"
-#~ msgstr "Impossibile allocare il primo buffer"
-
-#~ msgid "Couldn't allocate second buffer"
-#~ msgstr "Impossibile allocare il secondo buffer"
-
-#~ msgid "Failed to allocate RX buffer"
-#~ msgstr "Impossibile allocare buffer RX"
-
-#, c-format
-#~ msgid "Failed to allocate RX buffer of %d bytes"
-#~ msgstr "Fallita allocazione del buffer RX di %d byte"
-
-#~ msgid "Invalid BMP file"
-#~ msgstr "File BMP non valido"
-
-#~ msgid "Invalid PWM frequency"
-#~ msgstr "Frequenza PWM non valida"
-
-#, fuzzy
-#~ msgid "Invalid buffer size"
-#~ msgstr "lunghezza del buffer non valida"
-
-#~ msgid "Invalid capture period. Valid range: 1 - 500"
-#~ msgstr "periodo di cattura invalido. Zona valida: 1 - 500"
-
-#, fuzzy
-#~ msgid "Invalid channel count"
-#~ msgstr "Argomento non valido"
-
-#~ msgid "Invalid direction."
-#~ msgstr "Direzione non valida."
-
-#~ msgid "Invalid file"
-#~ msgstr "File non valido"
-
-#~ msgid "Invalid number of bits"
-#~ msgstr "Numero di bit non valido"
-
-#~ msgid "Invalid phase"
-#~ msgstr "Fase non valida"
-
-#~ msgid "Invalid pin"
-#~ msgstr "Pin non valido"
-
-#~ msgid "Invalid pin for left channel"
-#~ msgstr "Pin non valido per il canale sinistro"
-
-#~ msgid "Invalid pin for right channel"
-#~ msgstr "Pin non valido per il canale destro"
-
-#~ msgid "Invalid polarity"
-#~ msgstr "Polarità non valida"
-
-#~ msgid "Invalid run mode."
-#~ msgstr "Modalità di esecuzione non valida."
-
-#, fuzzy
-#~ msgid "Invalid voice count"
-#~ msgstr "Tipo di servizio non valido"
-
-#~ msgid "Invalid wave file"
-#~ msgstr "File wave non valido"
-
-#~ msgid "Layer must be a Group or TileGrid subclass."
-#~ msgstr "Layer deve essere un Group o TileGrid subclass"
-
-#~ msgid "MISO pin init failed."
-#~ msgstr "inizializzazione del pin MISO fallita."
-
-#~ msgid "MOSI pin init failed."
-#~ msgstr "inizializzazione del pin MOSI fallita."
-
-#~ msgid "No hardware support on pin"
-#~ msgstr "Nessun supporto hardware sul pin"
-
-#~ msgid ""
-#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-#~ msgstr ""
-#~ "duty_cycle del PWM deve essere compresa tra 0 e 65535 inclusiva "
-#~ "(risoluzione a 16 bit)"
-
-#~ msgid "Pin does not have ADC capabilities"
-#~ msgstr "Il pin non ha capacità di ADC"
-
-#~ msgid "RTC calibration is not supported on this board"
-#~ msgstr "calibrazione RTC non supportata su questa scheda"
-
-#, fuzzy
-#~ msgid "Sample rate must be positive"
-#~ msgstr "STA deve essere attiva"
-
-#, c-format
-#~ msgid "Sample rate too high. It must be less than %d"
-#~ msgstr ""
-#~ "Frequenza di campionamento troppo alta. Il valore deve essere inferiore a "
-#~ "%d"
-
-#~ msgid "Stack size must be at least 256"
-#~ msgstr "La dimensione dello stack deve essere almeno 256"
-
-#~ msgid "Unsupported baudrate"
-#~ msgstr "baudrate non supportato"
-
-#~ msgid "bytes > 8 bits not supported"
-#~ msgstr "byte > 8 bit non supportati"
-
-#~ msgid "calibration value out of range +/-127"
-#~ msgstr "valore di calibrazione fuori intervallo +/-127"
-
-#, fuzzy
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "i bit devono essere 8"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "Operazione non supportata"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code stopped by auto-reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Codice fermato dall'auto-ricarica.\n"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "La luminosità deve essere compresa tra 0 e 255"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "impossibile effettuare l'importazione relativa"
-
-#~ msgid "Unsupported pull value."
-#~ msgstr "Valore di pull non supportato."
-
-#~ msgid "integer required"
-#~ msgstr "intero richiesto"
-
-#~ msgid "abort() called"
-#~ msgstr "abort() chiamato"
-
-#~ msgid "invalid arguments"
-#~ msgstr "argomenti non validi"
-
-#~ msgid "%q list must be a list"
-#~ msgstr "lista %q deve essere una lista"
-
-#, fuzzy
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Non è possibile aggiungere Characteristic."
-
-#, fuzzy
-#~ msgid "Expected a UUID"
-#~ msgstr "Atteso un %q"
-
-#, fuzzy
-#~ msgid "no available NIC"
-#~ msgstr "busio.UART non ancora implementato"
-
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "Buffer troppo grande ed impossibile allocare"
-
-#~ msgid "USB Busy"
-#~ msgstr "USB occupata"
-
-#~ msgid "USB Error"
-#~ msgstr "Errore USB"
-
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "%q gli indici devono essere interi, non %q"
 
 #~ msgid "'%q' object cannot assign attribute '%q'"
 #~ msgstr "L'oggetto '%q' non può assegnare l'attributo '%q'"
@@ -4888,62 +4467,6 @@ msgstr ""
 #~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
 #~ msgstr "Valore intero '%s' 0x%x non rientra nella maschera 0x%x"
 
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr ""
-#~ "Impossibile ricavare la grandezza scalare di sizeof inequivocabilmente"
-
-#~ msgid "Length must be an int"
-#~ msgstr "Length deve essere un intero"
-
-#~ msgid "Length must be non-negative"
-#~ msgstr "Length deve essere non negativo"
-
-#~ msgid "name reused for argument"
-#~ msgstr "nome riutilizzato come argomento"
-
-#~ msgid "struct: cannot index"
-#~ msgstr "struct: impossibile indicizzare"
-
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "Non è possibile rimontare '/' mentre l'USB è attiva."
-
-#~ msgid "byte code not implemented"
-#~ msgstr "byte code non implementato"
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "indice dupterm non valido"
-
-#~ msgid "can only save bytecode"
-#~ msgstr "È possibile salvare solo bytecode"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr "Le funzioni Viper non supportano più di 4 argomenti al momento"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "l'indirizzo %08x non è allineato a %d bytes"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "la funzione non prende argomenti nominati"
-
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr "Provo l'allocazione quando MicroPython VM non è attivo."
-
-#~ msgid "Group full"
-#~ msgstr "Gruppo pieno"
-
-#~ msgid "bits must be 7, 8 or 9"
-#~ msgstr "i bit devono essere 7, 8 o 9"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "SDA o SCL necessitano un pull-up"
-
-#~ msgid "tuple index out of range"
-#~ msgstr "indice della tupla fuori intervallo"
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr ""
-#~ "Premi un qualunque tasto per entrare nel REPL. Usa CTRL-D per ricaricare."
-
 #~ msgid "'%s' object does not support item assignment"
 #~ msgstr "oggeto '%s' non supporta assengnamento di item"
 
@@ -4962,32 +4485,71 @@ msgstr ""
 #~ msgid "'%s' object is not subscriptable"
 #~ msgstr "oggeto '%s' non è "
 
-#~ msgid "Running in safe mode! Auto-reload is off.\n"
-#~ msgstr "Modalità sicura in esecuzione! Auto-reload disattivato.\n"
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr ""
+#~ "'await', 'async for' o 'async with' fuori della funzione sincronizzazione"
 
-#~ msgid "can't convert address to int"
-#~ msgstr "impossible convertire indirizzo in int"
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' fuori del ciclo"
 
-#~ msgid "object '%s' is not a tuple or list"
-#~ msgstr "oggetto '%s' non è una tupla o una lista"
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' fuori del ciclo"
 
-#~ msgid "pop from an empty set"
-#~ msgstr "pop da un set vuoto"
+#~ msgid "'coroutine' object is not an iterator"
+#~ msgstr "L'oggetto 'coroutine' non è un iteratore"
 
-#~ msgid "pop from empty list"
-#~ msgstr "pop da una lista vuota"
+#~ msgid "64 bit types"
+#~ msgstr "Tipo 64 bits"
 
-#~ msgid "popitem(): dictionary is empty"
-#~ msgstr "popitem(): il dizionario è vuoto"
-
-#~ msgid "unknown format code '%c' for object of type '%s'"
-#~ msgstr "codice di formattaione '%c' sconosciuto per oggetto di tipo '%s'"
-
-#~ msgid "unsupported types for %q: '%s', '%s'"
-#~ msgstr "tipi non supportati per %q: '%s', '%s'"
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "ADC2 sta usando il WiFi"
 
 #~ msgid "AP required"
 #~ msgstr "AP richiesto"
+
+#~ msgid "Address type out of range"
+#~ msgstr "Tipo di indirizzo fuori intervallo"
+
+#~ msgid "AnalogOut functionality not supported"
+#~ msgstr "funzionalità AnalogOut non supportata"
+
+#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#~ msgstr "AnalogOut ha solo 16 bit. Il valore deve essere meno di 65536."
+
+#~ msgid "AnalogOut not supported on given pin"
+#~ msgstr "AnalogOut non supportato sul pin scelto"
+
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "Almeno %d %q devono essere specificati (non %d)"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr "Provo l'allocazione quando MicroPython VM non è attivo."
+
+#, c-format
+#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
+#~ msgstr "La profondità dei bit deve essere inclusiva da 1 a 6, non %d"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "La luminosità deve essere tra 0-1.0"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "La luminosità deve essere compresa tra 0 e 255"
+
+#, c-format
+#~ msgid "Buffer incorrect size. Should be %d bytes."
+#~ msgstr "Buffer di lunghezza non valida. Dovrebbe essere di %d bytes."
+
+#~ msgid "Buffer is too small"
+#~ msgstr "Buffer troppo piccolo"
+
+#~ msgid "Buffer must be at least length 1"
+#~ msgstr "Il buffer deve essere lungo almeno 1"
+
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "Buffer troppo grande ed impossibile allocare"
+
+#~ msgid "Bytes must be between 0 and 255."
+#~ msgstr "I byte devono essere compresi tra 0 e 255."
 
 #~ msgid "C-level assert"
 #~ msgstr "assert a livello C"
@@ -5013,17 +4575,56 @@ msgstr ""
 #~ msgid "Cannot disconnect from AP"
 #~ msgstr "Impossible disconnettersi all'AP"
 
+#~ msgid "Cannot output both channels on the same pin"
+#~ msgstr "Impossibile dare in output entrambi i canal sullo stesso pin"
+
+#~ msgid "Cannot read without MISO pin."
+#~ msgstr "Impossibile leggere senza pin MISO."
+
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "Non è possibile rimontare '/' mentre l'USB è attiva."
+
+#~ msgid "Cannot reset into bootloader because no bootloader is present."
+#~ msgstr ""
+#~ "Impossibile resettare nel bootloader poiché nessun bootloader è presente."
+
 #~ msgid "Cannot set STA config"
 #~ msgstr "Impossibile impostare la configurazione della STA"
 
+#~ msgid "Cannot transfer without MOSI and MISO pins."
+#~ msgstr "Impossibile trasferire senza i pin MOSI e MISO."
+
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr ""
+#~ "Impossibile ricavare la grandezza scalare di sizeof inequivocabilmente"
+
 #~ msgid "Cannot update i/f status"
 #~ msgstr "Impossibile aggiornare status di i/f"
+
+#~ msgid "Cannot write without MOSI pin."
+#~ msgstr "Impossibile scrivere senza pin MOSI."
 
 #~ msgid "Characteristic UUID doesn't match Service UUID"
 #~ msgstr "caratteristico UUID non assomiglia servizio UUID"
 
 #~ msgid "Characteristic already in use by another Service."
 #~ msgstr "caratteristico già usato da un altro servizio"
+
+#~ msgid "Clock pin init failed."
+#~ msgstr "Inizializzazione del pin di clock fallita."
+
+#, fuzzy
+#~ msgid "Command must be an int between 0 and 255"
+#~ msgstr "I byte devono essere compresi tra 0 e 255"
+
+#~ msgid "Could not initialize UART"
+#~ msgstr "Impossibile inizializzare l'UART"
+
+#~ msgid "Couldn't allocate first buffer"
+#~ msgstr "Impossibile allocare il primo buffer"
+
+#~ msgid "Couldn't allocate second buffer"
+#~ msgstr "Impossibile allocare il secondo buffer"
 
 #, fuzzy
 #~ msgid "Data too large for the advertisement packet"
@@ -5041,6 +4642,17 @@ msgstr ""
 #~ msgid "Error in ffi_prep_cif"
 #~ msgstr "Errore in ffi_prep_cif"
 
+#~ msgid "Expected a %q"
+#~ msgstr "Atteso un %q"
+
+#, fuzzy
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Non è possibile aggiungere Characteristic."
+
+#, fuzzy
+#~ msgid "Expected a UUID"
+#~ msgstr "Atteso un %q"
+
 #, fuzzy
 #~ msgid "Failed to acquire mutex"
 #~ msgstr "Impossibile allocare buffer RX"
@@ -5056,6 +4668,13 @@ msgstr ""
 #, fuzzy
 #~ msgid "Failed to add service, err 0x%04x"
 #~ msgstr "Impossibile fermare advertisement. status: 0x%02x"
+
+#~ msgid "Failed to allocate RX buffer"
+#~ msgstr "Impossibile allocare buffer RX"
+
+#, c-format
+#~ msgid "Failed to allocate RX buffer of %d bytes"
+#~ msgstr "Fallita allocazione del buffer RX di %d byte"
 
 #, fuzzy
 #~ msgid "Failed to change softdevice state"
@@ -5162,11 +4781,38 @@ msgstr ""
 #~ msgid "GPIO16 does not support pull up."
 #~ msgstr "GPIO16 non supporta pull-up"
 
+#~ msgid "Group full"
+#~ msgstr "Gruppo pieno"
+
 #~ msgid "I2C operation not supported"
 #~ msgstr "operazione I2C non supportata"
 
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "File .mpy incompatibile. Aggiorna tutti i file .mpy. Vedi http://adafru."
+#~ "it/mpy-update per più informazioni."
+
+#~ msgid "Invalid BMP file"
+#~ msgstr "File BMP non valido"
+
+#~ msgid "Invalid PWM frequency"
+#~ msgstr "Frequenza PWM non valida"
+
 #~ msgid "Invalid bit clock pin"
 #~ msgstr "Pin del clock di bit non valido"
+
+#, fuzzy
+#~ msgid "Invalid buffer size"
+#~ msgstr "lunghezza del buffer non valida"
+
+#~ msgid "Invalid capture period. Valid range: 1 - 500"
+#~ msgstr "periodo di cattura invalido. Zona valida: 1 - 500"
+
+#, fuzzy
+#~ msgid "Invalid channel count"
+#~ msgstr "Argomento non valido"
 
 #~ msgid "Invalid clock pin"
 #~ msgstr "Pin di clock non valido"
@@ -5174,8 +4820,64 @@ msgstr ""
 #~ msgid "Invalid data pin"
 #~ msgstr "Pin dati non valido"
 
+#~ msgid "Invalid direction."
+#~ msgstr "Direzione non valida."
+
+#~ msgid "Invalid file"
+#~ msgstr "File non valido"
+
+#~ msgid "Invalid number of bits"
+#~ msgstr "Numero di bit non valido"
+
+#~ msgid "Invalid phase"
+#~ msgstr "Fase non valida"
+
+#~ msgid "Invalid pin"
+#~ msgstr "Pin non valido"
+
+#~ msgid "Invalid pin for left channel"
+#~ msgstr "Pin non valido per il canale sinistro"
+
+#~ msgid "Invalid pin for right channel"
+#~ msgstr "Pin non valido per il canale destro"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Pin non validi"
+
+#~ msgid "Invalid polarity"
+#~ msgstr "Polarità non valida"
+
+#~ msgid "Invalid run mode."
+#~ msgstr "Modalità di esecuzione non valida."
+
+#, fuzzy
+#~ msgid "Invalid voice count"
+#~ msgstr "Tipo di servizio non valido"
+
+#~ msgid "Invalid wave file"
+#~ msgstr "File wave non valido"
+
+#~ msgid "Layer must be a Group or TileGrid subclass."
+#~ msgstr "Layer deve essere un Group o TileGrid subclass"
+
+#~ msgid "Length must be an int"
+#~ msgstr "Length deve essere un intero"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Length deve essere non negativo"
+
+#~ msgid "MISO pin init failed."
+#~ msgstr "inizializzazione del pin MISO fallita."
+
+#~ msgid "MOSI pin init failed."
+#~ msgstr "inizializzazione del pin MOSI fallita."
+
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "Frequenza massima su PWM è %dhz"
+
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "Valore massimo di x quando rispachiato è %d"
 
 #~ msgid "MicroPython fatal error.\n"
 #~ msgstr "Errore fatale in MicroPython.\n"
@@ -5192,8 +4894,17 @@ msgstr ""
 #~ msgid "No PulseIn support for %q"
 #~ msgstr "Nessun supporto per PulseIn per %q"
 
+#~ msgid "No RX pin"
+#~ msgstr "Nessun pin RX"
+
+#~ msgid "No TX pin"
+#~ msgstr "Nessun pin TX"
+
 #~ msgid "No hardware support for analog out."
 #~ msgstr "Nessun supporto hardware per l'uscita analogica."
+
+#~ msgid "No hardware support on pin"
+#~ msgstr "Nessun supporto hardware sul pin"
 
 #~ msgid "Only Windows format, uncompressed BMP supported %d"
 #~ msgstr "Formato solo di Windows, BMP non compresso supportato %d"
@@ -5211,11 +4922,20 @@ msgstr ""
 #~ msgid "Only tx supported on UART1 (GPIO2)."
 #~ msgstr "Solo tx supportato su UART1 (GPIO2)."
 
+#~ msgid ""
+#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
+#~ msgstr ""
+#~ "duty_cycle del PWM deve essere compresa tra 0 e 65535 inclusiva "
+#~ "(risoluzione a 16 bit)"
+
 #~ msgid "PWM not supported on pin %d"
 #~ msgstr "PWM non è supportato sul pin %d"
 
 #~ msgid "Pin %q does not have ADC capabilities"
 #~ msgstr "Il pin %q non ha capacità ADC"
+
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "Il pin non ha capacità di ADC"
 
 #~ msgid "Pin(16) doesn't support pull"
 #~ msgstr "Pin(16) non supporta pull"
@@ -5223,15 +4943,51 @@ msgstr ""
 #~ msgid "Pins not valid for SPI"
 #~ msgstr "Pin non validi per SPI"
 
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+#~ msgstr ""
+#~ "Premi un qualunque tasto per entrare nel REPL. Usa CTRL-D per ricaricare."
+
+#~ msgid "RTC calibration is not supported on this board"
+#~ msgstr "calibrazione RTC non supportata su questa scheda"
+
 #, fuzzy
 #~ msgid "Range out of bounds"
 #~ msgstr "indirizzo fuori limite"
+
+#, fuzzy
+#~ msgid "Read-only object"
+#~ msgstr "Sola lettura"
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Modalità sicura in esecuzione! Auto-reload disattivato.\n"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "SDA o SCL necessitano un pull-up"
 
 #~ msgid "STA must be active"
 #~ msgstr "STA deve essere attiva"
 
 #~ msgid "STA required"
 #~ msgstr "STA richiesta"
+
+#, fuzzy
+#~ msgid "Sample rate must be positive"
+#~ msgstr "STA deve essere attiva"
+
+#, c-format
+#~ msgid "Sample rate too high. It must be less than %d"
+#~ msgstr ""
+#~ "Frequenza di campionamento troppo alta. Il valore deve essere inferiore a "
+#~ "%d"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Suddivisione con sotto-catture"
+
+#~ msgid "Stack size must be at least 256"
+#~ msgstr "La dimensione dello stack deve essere almeno 256"
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "Metodi mancanti readinto() o write() allo stream."
 
 #, fuzzy
 #~ msgid ""
@@ -5243,11 +4999,20 @@ msgstr ""
 #~ "La potenza del microcontrollore è calata. Assicurati che l'alimentazione "
 #~ "sia attaccata correttamente\n"
 
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Per uscire resettare la scheda senza "
+
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) non esistente"
 
 #~ msgid "UART(1) can't read"
 #~ msgstr "UART(1) non leggibile"
+
+#~ msgid "USB Busy"
+#~ msgstr "USB occupata"
+
+#~ msgid "USB Error"
+#~ msgstr "Errore USB"
 
 #~ msgid "Unable to remount filesystem"
 #~ msgstr "Imposssibile rimontare il filesystem"
@@ -5255,8 +5020,20 @@ msgstr ""
 #~ msgid "Unknown type"
 #~ msgstr "Tipo sconosciuto"
 
+#~ msgid "Unsupported baudrate"
+#~ msgstr "baudrate non supportato"
+
+#~ msgid "Unsupported operation"
+#~ msgstr "Operazione non supportata"
+
+#~ msgid "Unsupported pull value."
+#~ msgstr "Valore di pull non supportato."
+
 #~ msgid "Use esptool to erase flash and re-upload Python instead"
 #~ msgstr "Usa esptool per cancellare la flash e ricaricare Python invece"
+
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr "Le funzioni Viper non supportano più di 4 argomenti al momento"
 
 #, fuzzy
 #~ msgid ""
@@ -5266,8 +5043,26 @@ msgstr ""
 #~ "Sei nella modalità sicura che significa che qualcosa di molto brutto è "
 #~ "successo.\n"
 
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "È stato richiesto l'avvio in modalità sicura da "
+
 #~ msgid "[addrinfo error %d]"
 #~ msgstr "[errore addrinfo %d]"
+
+#~ msgid "abort() called"
+#~ msgstr "abort() chiamato"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "l'indirizzo %08x non è allineato a %d bytes"
+
+#~ msgid "address out of bounds"
+#~ msgstr "indirizzo fuori limite"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "attributi non ancora supportati"
+
+#~ msgid "bits must be 7, 8 or 9"
+#~ msgstr "i bit devono essere 7, 8 o 9"
 
 #~ msgid "bits must be 8"
 #~ msgstr "i bit devono essere 8"
@@ -5278,8 +5073,26 @@ msgstr ""
 #~ msgid "buffers must be the same length"
 #~ msgstr "i buffer devono essere della stessa lunghezza"
 
+#~ msgid "byte code not implemented"
+#~ msgstr "byte code non implementato"
+
+#~ msgid "bytes > 8 bits not supported"
+#~ msgstr "byte > 8 bit non supportati"
+
+#~ msgid "calibration value out of range +/-127"
+#~ msgstr "valore di calibrazione fuori intervallo +/-127"
+
+#~ msgid "can only save bytecode"
+#~ msgstr "È possibile salvare solo bytecode"
+
 #~ msgid "can query only one param"
 #~ msgstr "è possibile interrogare solo un parametro"
+
+#~ msgid "can't convert address to int"
+#~ msgstr "impossible convertire indirizzo in int"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr "impossibile fare il modulo di un numero complesso"
 
 #~ msgid "can't get AP config"
 #~ msgstr "impossibile recuperare le configurazioni dell'AP"
@@ -5287,17 +5100,45 @@ msgstr ""
 #~ msgid "can't get STA config"
 #~ msgstr "impossibile recuperare la configurazione della STA"
 
+#~ msgid "can't have multiple **x"
+#~ msgstr "impossibile usare **x multipli"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "impossibile usare *x multipli"
+
 #~ msgid "can't set AP config"
 #~ msgstr "impossibile impostare le configurazioni dell'AP"
 
 #~ msgid "can't set STA config"
 #~ msgstr "impossibile impostare le configurazioni della STA"
 
+#~ msgid "cannot import name %q"
+#~ msgstr "impossibile imporate il nome %q"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "impossibile effettuare l'importazione relativa"
+
 #~ msgid "color buffer must be a buffer or int"
 #~ msgstr "il buffer del colore deve essere un buffer o un int"
 
+#~ msgid "color should be an int"
+#~ msgstr "il colore deve essere un int"
+
+#~ msgid "complex division by zero"
+#~ msgstr "complex divisione per zero"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "la costante deve essere un intero"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr "destination_length deve essere un int >= 0"
+
 #~ msgid "either pos or kw args are allowed"
 #~ msgstr "sono permesse solo gli argomenti pos o kw"
+
+#, fuzzy
+#~ msgid "end_x should be an int"
+#~ msgstr "y dovrebbe essere un int"
 
 #~ msgid "expected a DigitalInOut"
 #~ msgstr "DigitalInOut atteso"
@@ -5317,8 +5158,17 @@ msgstr ""
 #~ msgid "frequency can only be either 80Mhz or 160MHz"
 #~ msgstr "la frequenza può essere o 80Mhz o 160Mhz"
 
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "la funzione non prende argomenti nominati"
+
 #~ msgid "impossible baudrate"
 #~ msgstr "baudrate impossibile"
+
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr "il secondo argomanto di int() deve essere >= 2 e <= 36"
+
+#~ msgid "integer required"
+#~ msgstr "intero richiesto"
 
 #~ msgid "invalid I2C peripheral"
 #~ msgstr "periferica I2C invalida"
@@ -5329,11 +5179,20 @@ msgstr ""
 #~ msgid "invalid alarm"
 #~ msgstr "alarm non valido"
 
+#~ msgid "invalid arguments"
+#~ msgstr "argomenti non validi"
+
 #~ msgid "invalid buffer length"
 #~ msgstr "lunghezza del buffer non valida"
 
 #~ msgid "invalid data bits"
 #~ msgstr "bit dati invalidi"
+
+#~ msgid "invalid dupterm index"
+#~ msgstr "indice dupterm non valido"
+
+#~ msgid "invalid format"
+#~ msgstr "formato non valido"
 
 #~ msgid "invalid pin"
 #~ msgstr "pin non valido"
@@ -5341,8 +5200,19 @@ msgstr ""
 #~ msgid "invalid stop bits"
 #~ msgstr "bit di stop invalidi"
 
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr ""
+#~ "argomento(i) nominati non ancora implementati - usare invece argomenti "
+#~ "normali"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "argomenti nominati devono essere stringhe"
+
 #~ msgid "len must be multiple of 4"
 #~ msgstr "len deve essere multiplo di 4"
+
+#~ msgid "long int not supported in this build"
+#~ msgstr "long int non supportata in questa build"
 
 #~ msgid "memory allocation failed, allocating %u bytes for native code"
 #~ msgstr ""
@@ -5355,14 +5225,53 @@ msgstr ""
 #~ msgid "name must be a string"
 #~ msgstr "argomenti nominati devono essere stringhe"
 
+#~ msgid "name reused for argument"
+#~ msgstr "nome riutilizzato come argomento"
+
+#, fuzzy
+#~ msgid "no available NIC"
+#~ msgstr "busio.UART non ancora implementato"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "argomento non nominato dopo */**"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "argomento non nominato seguito da argomento nominato"
+
 #~ msgid "not a valid ADC Channel: %d"
 #~ msgstr "canale ADC non valido: %d"
+
+#~ msgid "object '%s' is not a tuple or list"
+#~ msgstr "oggetto '%s' non è una tupla o una lista"
+
+#, fuzzy
+#~ msgid "offset out of bounds"
+#~ msgstr "indirizzo fuori limite"
+
+#~ msgid "palette_index should be an int"
+#~ msgstr "palette_index deve essere un int"
 
 #~ msgid "pin does not have IRQ capabilities"
 #~ msgstr "il pin non implementa IRQ"
 
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+#~ msgstr ""
+#~ "pixel_shader deve essere displayio.Palette o displayio.ColorConverter"
+
+#~ msgid "pop from an empty set"
+#~ msgstr "pop da un set vuoto"
+
+#~ msgid "pop from empty list"
+#~ msgstr "pop da una lista vuota"
+
+#~ msgid "popitem(): dictionary is empty"
+#~ msgstr "popitem(): il dizionario è vuoto"
+
 #~ msgid "position must be 2-tuple"
 #~ msgstr "position deve essere una 2-tuple"
+
+#~ msgid "queue overflow"
+#~ msgstr "overflow della coda"
 
 #, fuzzy
 #~ msgid "readonly attribute"
@@ -5371,17 +5280,56 @@ msgstr ""
 #~ msgid "row must be packed and word aligned"
 #~ msgstr "la riga deve essere compattata e allineata alla parola"
 
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "il buffer sample_source deve essere un bytearray o un array di tipo 'h', "
+#~ "'H', 'b' o 'B'"
+
 #~ msgid "scan failed"
 #~ msgstr "scansione fallita"
+
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "'}' singolo presente nella stringa di formattazione"
+
+#~ msgid "slice step cannot be zero"
+#~ msgstr "la step della slice non può essere zero"
+
+#, fuzzy
+#~ msgid "start_x should be an int"
+#~ msgstr "y dovrebbe essere un int"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "step deve essere non zero"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "struct: impossibile indicizzare"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "la soglia deve essere nell'intervallo 0-65536"
 
 #~ msgid "time.struct_time() takes exactly 1 argument"
 #~ msgstr "time.struct_time() prende esattamente un argomento"
 
+#, fuzzy
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "i bit devono essere 8"
+
 #~ msgid "too many arguments"
 #~ msgstr "troppi argomenti"
 
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "troppi argomenti forniti con il formato specificato"
+
+#~ msgid "tuple index out of range"
+#~ msgstr "indice della tupla fuori intervallo"
+
 #~ msgid "unknown config param"
 #~ msgstr "parametro di configurazione sconosciuto"
+
+#~ msgid "unknown format code '%c' for object of type '%s'"
+#~ msgstr "codice di formattaione '%c' sconosciuto per oggetto di tipo '%s'"
 
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr ""
@@ -5393,5 +5341,25 @@ msgstr ""
 #~ msgid "unknown status param"
 #~ msgstr "prametro di stato sconosciuto"
 
+#~ msgid "unmatched '{' in format"
+#~ msgstr "'{' spaiato nella stringa di formattazione"
+
+#~ msgid "unsupported types for %q: '%s', '%s'"
+#~ msgstr "tipi non supportati per %q: '%s', '%s'"
+
 #~ msgid "wifi_set_ip_info() failed"
 #~ msgstr "wifi_set_ip_info() faillito"
+
+#, fuzzy
+#~ msgid "x value out of bounds"
+#~ msgstr "indirizzo fuori limite"
+
+#~ msgid "y should be an int"
+#~ msgstr "y dovrebbe essere un int"
+
+#, fuzzy
+#~ msgid "y value out of bounds"
+#~ msgstr "indirizzo fuori limite"
+
+#~ msgid "zero step"
+#~ msgstr "zero step"

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -78,42 +78,11 @@ msgstr " 出力:\n"
 msgid "%%c requires int or char"
 msgstr "%%c にはintまたはcharが必要"
 
-#: main.c
-#, fuzzy, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr "%dアドレスピン、%dRGBピン、%dタイルは%dの高さを指示する。%dではない。"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-#, fuzzy
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -296,11 +265,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
 msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
@@ -638,7 +602,8 @@ msgstr "オートリロードはオフです。\n"
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
-msgstr "オートリロードがオンです。ファイルをUSB経由で保存するだけで実行できます。REPL"
+msgstr ""
+"オートリロードがオンです。ファイルをUSB経由で保存するだけで実行できます。REPL"
 "に入ると無効化します。\n"
 
 #: ports/espressif/common-hal/canio/CAN.c
@@ -752,8 +717,9 @@ msgstr ""
 
 #: py/objtype.c
 msgid "Call super().__init__() before accessing native object."
-msgstr "ネイティブオブジェクトにアクセスする前にsuper()."
-"__init__()を呼び出してください"
+msgstr ""
+"ネイティブオブジェクトにアクセスする前にsuper().__init__()を呼び出してくださ"
+"い"
 
 #: ports/cxd56/common-hal/camera/Camera.c
 msgid "Camera init"
@@ -1598,7 +1564,8 @@ msgstr ""
 #: shared-bindings/util.c
 msgid ""
 "Object has been deinitialized and can no longer be used. Create a new object."
-msgstr "オブジェクトは解放済みでもう使われていません。新しいオブジェクトを作成してく"
+msgstr ""
+"オブジェクトは解放済みでもう使われていません。新しいオブジェクトを作成してく"
 "ださい"
 
 #: ports/nrf/common-hal/busio/UART.c
@@ -1615,8 +1582,9 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "8または16ビットの "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -1806,7 +1774,8 @@ msgstr "Prefixバッファはヒープ上になければなりません"
 
 #: main.c
 msgid "Press any key to enter the REPL. Use CTRL-D to reload.\n"
-msgstr "REPLに入るため、エンターキーを押す。リーロードするため、Ctl-Dを入力する。\n"
+msgstr ""
+"REPLに入るため、エンターキーを押す。リーロードするため、Ctl-Dを入力する。\n"
 
 #: main.c
 msgid "Pretending to deep sleep until alarm, CTRL-C or file write.\n"
@@ -2152,7 +2121,8 @@ msgstr "UUIDの整数値は0から0xffffの間でなければなりません"
 
 #: shared-bindings/_bleio/UUID.c
 msgid "UUID string not 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'"
-msgstr "UUID文字列が 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' の形式になっていません"
+msgstr ""
+"UUID文字列が 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' の形式になっていません"
 
 #: shared-bindings/_bleio/UUID.c
 msgid "UUID value is not str, int or byte buffer"
@@ -2841,7 +2811,8 @@ msgstr ""
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be 3 bytes (RGB) or 4 bytes (RGB + pad byte)"
-msgstr "色バッファは3バイト (RGB) か4バイト (RGB + pad byte) でなければなりません"
+msgstr ""
+"色バッファは3バイト (RGB) か4バイト (RGB + pad byte) でなければなりません"
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a buffer, tuple, list, or int"
@@ -2849,7 +2820,8 @@ msgstr "カラーバッファはbuffer, tuple, list, int のいずれかです"
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a bytearray or array of type 'b' or 'B'"
-msgstr "色バッファは、bytearrayまたはタイプが 'b' か 'B' のarrayでなければなりません"
+msgstr ""
+"色バッファは、bytearrayまたはタイプが 'b' か 'B' のarrayでなければなりません"
 
 #: shared-bindings/displayio/Palette.c
 msgid "color must be between 0x000000 and 0xffffff"
@@ -2935,8 +2907,9 @@ msgstr ""
 #: shared-bindings/audiobusio/PDMIn.c
 msgid ""
 "destination buffer must be a bytearray or array of type 'B' for bit_depth = 8"
-msgstr "bit_depth = "
-"8のとき、宛先バッファはbytearrayまたはタイプ'B'のarrayでなければなりません"
+msgstr ""
+"bit_depth = 8のとき、宛先バッファはbytearrayまたはタイプ'B'のarrayでなければ"
+"なりません"
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "destination buffer must be an array of type 'H' for bit_depth = 16"
@@ -3249,7 +3222,8 @@ msgstr "インデクスは整数でなければなりません"
 
 #: extmod/ulab/code/ndarray.c
 msgid "indices must be integers, slices, or Boolean lists"
-msgstr "インデクスは、整数、スライス、boolのリストのいずれかでなければなりません"
+msgstr ""
+"インデクスは、整数、スライス、boolのリストのいずれかでなければなりません"
 
 #: ports/espressif/common-hal/busio/I2C.c
 msgid "init I2C"
@@ -4413,137 +4387,12 @@ msgstr "ziはfloat値でなければなりません"
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
 
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr "async関数外での await, async for, async with"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "ループ外でのbreak"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "ループ外でのcontinue"
-
-#~ msgid "unsupported type for %q: '%q'"
-#~ msgstr "%q が対応していない型: '%q'"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "属性は未対応です"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr "複素数の切り捨て除算はできません"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr "キーワード引数は未実装。通常の引数を使ってください"
-
-#~ msgid "slice step can't be zero"
-#~ msgstr "スライスのステップは0にできません"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr "文字列ではなくbytesまたはbytesarrayが必要"
-
-#~ msgid "WatchDogTimer is not currently running"
-#~ msgstr "WatchDogTimerは現在動作していません"
-
-#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-#~ msgstr "WatchDogTimer.modeはいったんWatchDogMode.RESETに設定すると変更不可"
-
-#~ msgid "queue overflow"
-#~ msgstr "キューがオーバーフローしました"
-
-#~ msgid "'coroutine' object is not an iterator"
-#~ msgstr "'coroutine' オブジェクトはイテレータではありません"
-
-#~ msgid "Buffer is too small"
-#~ msgstr "バッファが小さすぎます"
-
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-#~ msgstr ""
-#~ "pixel_shaderはdisplayio.Paletteかdisplayio.ColorConverterのどちらかでなけ"
-#~ "ればなりません"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "破損した .mpy ファイル"
-
 #~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
 #~ msgstr ""
-#~ "非互換の.mpyファイル。全.mpyファイルを更新してください。詳細は http://"
-#~ "adafru.it/mpy-update を参照"
-
-#~ msgid "can't convert to %q"
-#~ msgstr "%q に変換できません"
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "複数の **x は持てません"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "複数の *x は持てません"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "定数は整数でなければなりません"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "キーワードは文字列でなければなりません"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "*/** の後に非キーワード引数は置けません"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "キーワード引数の後に非キーワード引数は置けません"
-
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "ハードウェアビジー。代替のピンを試してください"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "MISOまたはMOSIピンがありません"
-
-#~ msgid "No MISO Pin"
-#~ msgstr "MISOピンなし"
-
-#~ msgid "No MOSI Pin"
-#~ msgstr "MOSIピンがありません"
-
-#~ msgid "No RX pin"
-#~ msgstr "RXピンがありません"
-
-#~ msgid "No TX pin"
-#~ msgstr "TXピンがありません"
-
-#~ msgid "no reset pin available"
-#~ msgstr "利用可能なリセットピンがありません"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "brightnessは0から1.0まででなければなりません"
-
-#~ msgid "x value out of bounds"
-#~ msgstr "xが範囲外"
-
-#~ msgid "y value out of bounds"
-#~ msgstr "yが範囲外"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "I2SOutが利用できません"
-
-#~ msgid "out of range of source"
-#~ msgstr "ソースが範囲外"
-
-#~ msgid "value_count must be > 0"
-#~ msgstr "value_countは0より大きくなければなりません"
-
-#~ msgid "No key was specified"
-#~ msgstr "キーが指定されていません"
-
-#~ msgid "Scan already in progess. Stop with stop_scan."
-#~ msgstr "既にスキャン進行中。stop_scanで停止してください"
-
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "指定された書式に対して引数が多すぎます"
-
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "少なくとも1つのUARTピンが必要"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "%q ピンは無効"
+#~ "\n"
+#~ "コードの実行が完了しました。リロードを待っています。\n"
 
 #~ msgid ""
 #~ "\n"
@@ -4554,75 +4403,26 @@ msgstr ""
 #~ "CIRCUITPYドライブの内容を添えて問題を以下で報告してください：\n"
 #~ "https://github.com/adafruit/circuitpython/issues\n"
 
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "CircuitPythonはヒープを確保できませんでした"
+#~ msgid ""
+#~ "\n"
+#~ "To exit, please reset the board without "
+#~ msgstr ""
+#~ "\n"
+#~ "終了するには、次の操作をせずにリセットしてください: "
 
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "クラッシュしてHardFault_Handlerに入りました"
+#, fuzzy, c-format
+#~ msgid "%02X"
+#~ msgstr "%02X"
 
-#~ msgid "Invalid memory access."
-#~ msgstr "不正なメモリアクセス"
+#, fuzzy
+#~ msgid "%q"
+#~ msgstr "%q"
 
-#~ msgid "Expected a %q"
-#~ msgstr "%qが必要"
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "%q インデクスは %q でなく整数でなければなりません"
 
-#, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IVは%dバイト長でなければなりません"
-
-#~ msgid "Read-only object"
-#~ msgstr "読み込み専用のオブジェクト"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "最大で %d個の %q が指定できます（%d個でなく）"
-
-#~ msgid "Invalid pins"
-#~ msgstr "ピンが不正"
-
-#~ msgid "byteorder is not a string"
-#~ msgstr "byteorderが文字列ではありません"
-
-#~ msgid "complex division by zero"
-#~ msgstr "複素数ゼロ除算"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr "int()の第2引数は2以上36以下でなければなりません"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "このビルドはlong intに非対応"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "stepは非ゼロ値でなければなりません"
-
-#~ msgid "string indices must be integers, not %q"
-#~ msgstr "文字列のインデクスは整数でなければなりません (%qでなく)"
-
-#~ msgid "time.struct_time() takes a 9-sequence"
-#~ msgstr "time.struct_time()は9要素のシーケンスを受け取ります"
-
-#~ msgid "zero step"
-#~ msgstr "ステップが0"
-
-#~ msgid "WatchDogTimer.timeout must be greater than 0"
-#~ msgstr "WatchDogTimer.timeoutは0以上でなければなりません"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "文字列フォーマット中に孤立した '}' があります"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "threshouldは0から65536まで"
-
-#~ msgid "timeout must be 0.0-100.0 seconds"
-#~ msgstr "timeoutは0.0〜100.0秒でなければなりません"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "書式中にマッチしない '{' があります"
-
-#~ msgid "watchdog timeout must be greater than 0"
-#~ msgstr "watchdogのtimeoutは0以上でなければなりません"
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "ストリームにreadinto()またはwrite()メソッドがありません"
+#~ msgid "%q list must be a list"
+#~ msgstr "%q リストはリストでなければなりません"
 
 #~ msgid "%q must be >= 0"
 #~ msgstr "%qは0以上でなければなりません"
@@ -4630,32 +4430,41 @@ msgstr ""
 #~ msgid "%q must be >= 1"
 #~ msgstr "%qは1以上でなければなりません"
 
-#~ msgid "address out of bounds"
-#~ msgstr "アドレスが範囲外"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr "desitination_lengthは正の整数でなければなりません"
-
-#~ msgid "end_x should be an int"
-#~ msgstr "end_xは整数でなければなりません"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "palette_indexには整数が必要"
-
-#~ msgid "y should be an int"
-#~ msgstr "yは整数でなければなりません"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "sample_source バッファには bytearray または 'h','H','b','B'型のarrayが必要"
-
 #~ msgid "%q must be a tuple of length 2"
 #~ msgstr "%qは長さ2のタプルでなければなりません"
 
+#~ msgid "%q pin invalid"
+#~ msgstr "%q ピンは無効"
+
 #~ msgid "%q should be an int"
 #~ msgstr "%qはint型でなければなりません"
+
+#~ msgid "'%q' object cannot assign attribute '%q'"
+#~ msgstr "オブジェクト'%q'に属性'%q'を割り当てられません"
+
+#~ msgid "'%q' object does not support item assignment"
+#~ msgstr "'%q' オブジェクトは要素の代入に対応していません"
+
+#~ msgid "'%q' object does not support item deletion"
+#~ msgstr "'%q' オブジェクトは要素の削除に対応していません"
+
+#~ msgid "'%q' object has no attribute '%q'"
+#~ msgstr "オブジェクト'%q'に属性'%q'はありません"
+
+#~ msgid "'%q' object is not subscriptable"
+#~ msgstr "オブジェクト'%q'は要素の取得ができません"
+
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr "async関数外での await, async for, async with"
+
+#~ msgid "'break' outside loop"
+#~ msgstr "ループ外でのbreak"
+
+#~ msgid "'continue' outside loop"
+#~ msgstr "ループ外でのcontinue"
+
+#~ msgid "'coroutine' object is not an iterator"
+#~ msgstr "'coroutine' オブジェクトはイテレータではありません"
 
 #~ msgid "Address type out of range"
 #~ msgstr "address_typeが範囲外"
@@ -4672,12 +4481,30 @@ msgstr ""
 #~ msgid "AnalogOut not supported on given pin"
 #~ msgstr "指定のピンはAnalogOutに対応していません"
 
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "最大で %d個の %q が指定できます（%d個でなく）"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr "MicroPython VMの非実行時にヒープ確保を試みました"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "brightnessは0から1.0まででなければなりません"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "Brightnessは0から255の間でなければなりません"
+
 #, c-format
 #~ msgid "Buffer incorrect size. Should be %d bytes."
 #~ msgstr "バッファサイズが不正です。%dバイトでなければなりません"
 
+#~ msgid "Buffer is too small"
+#~ msgstr "バッファが小さすぎます"
+
 #~ msgid "Buffer must be at least length 1"
 #~ msgstr "バッファ長は少なくとも1以上でなければなりません"
+
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "バッファが大きすぎて確保できません"
 
 #~ msgid "Bytes must be between 0 and 255."
 #~ msgstr "バイト値は0から255の間でなければなりません"
@@ -4688,20 +4515,45 @@ msgstr ""
 #~ msgid "Cannot read without MISO pin."
 #~ msgstr "MISOピンなしで読み込めません"
 
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "USBがアクティブの時に'/'を再マウントできません"
+
 #~ msgid "Cannot reset into bootloader because no bootloader is present."
 #~ msgstr "ブートローダが存在しないためブートローダへとリセットできません"
 
 #~ msgid "Cannot transfer without MOSI and MISO pins."
 #~ msgstr "MOSIピンとMISOピンなしに転送できません"
 
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "スカラのサイズを曖昧さなしに取得できません"
+
 #~ msgid "Cannot write without MOSI pin."
 #~ msgstr "MOSIピンなしで書き込みできません"
+
+#~ msgid ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+#~ msgstr ""
+#~ "起動中にリセットボタンを押したためCircuitPythonはセーフモードにいます。も"
+#~ "う一度押すとセーフモードを終了します。\n"
+
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "CircuitPythonはヒープを確保できませんでした"
 
 #~ msgid "Clock pin init failed."
 #~ msgstr "クロックピン初期化に失敗"
 
+#~ msgid "Column entry must be digitalio.DigitalInOut"
+#~ msgstr "Columnの要素は digitalio.DigitalInOut でなければなりません"
+
 #~ msgid "Command must be an int between 0 and 255"
 #~ msgstr "commandは0から255の間の整数でなければなりません"
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "破損した .mpy ファイル"
+
+#~ msgid "Corrupt raw code"
+#~ msgstr "破損したraw code"
 
 #~ msgid "Could not initialize Camera"
 #~ msgstr "カメラを初期化できません"
@@ -4714,6 +4566,12 @@ msgstr ""
 
 #~ msgid "Could not initialize UART"
 #~ msgstr "UARTを初期化できません"
+
+#~ msgid "Could not initialize channel"
+#~ msgstr "チャネルを初期化できません"
+
+#~ msgid "Could not initialize timer"
+#~ msgstr "タイマーを初期化できません"
 
 #~ msgid "Could not re-init channel"
 #~ msgstr "チャネルを再初期化できません"
@@ -4733,8 +4591,32 @@ msgstr ""
 #~ msgid "Couldn't allocate second buffer"
 #~ msgstr "2つ目のバッファを確保できません"
 
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "クラッシュしてHardFault_Handlerに入りました"
+
 #~ msgid "DigitalInOut not supported on given pin"
 #~ msgstr "指定されたピンはDigitalInOutに対応していません"
+
+#~ msgid "Expected a %q"
+#~ msgstr "%qが必要"
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Characteristicが必要"
+
+#~ msgid "Expected a DigitalInOut"
+#~ msgstr "DigitalInOutが必要"
+
+#~ msgid "Expected a Service"
+#~ msgstr "Serviceが必要"
+
+#~ msgid "Expected a UART"
+#~ msgstr "UARTが必要"
+
+#~ msgid "Expected a UUID"
+#~ msgstr "UUIDが必要"
+
+#~ msgid "Expected an Address"
+#~ msgstr "Addressが必要"
 
 #~ msgid "Failed to allocate RX buffer"
 #~ msgstr "RXバッファの確保に失敗"
@@ -4743,8 +4625,31 @@ msgstr ""
 #~ msgid "Failed to allocate RX buffer of %d bytes"
 #~ msgstr "%dバイトのRXバッファの確保に失敗"
 
+#~ msgid "Frequency captured is above capability. Capture Paused."
+#~ msgstr "キャプチャした周波数は能力を超えています。キャプチャ停止"
+
+#~ msgid "Group full"
+#~ msgstr "グループが一杯"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "ハードウェアビジー。代替のピンを試してください"
+
 #~ msgid "I2C Init Error"
 #~ msgstr "I2C初期化エラー"
+
+#~ msgid "I2SOut not available"
+#~ msgstr "I2SOutが利用できません"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IVは%dバイト長でなければなりません"
+
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "非互換の.mpyファイル。全.mpyファイルを更新してください。詳細は http://"
+#~ "adafru.it/mpy-update を参照"
 
 #~ msgid "Invalid %q pin selection"
 #~ msgstr "不正な%qピン選択"
@@ -4755,8 +4660,17 @@ msgstr ""
 #~ msgid "Invalid DAC pin supplied"
 #~ msgstr "不正なDACピンが与えられました"
 
+#~ msgid "Invalid I2C pin selection"
+#~ msgstr "I2Cピンの選択が不正です"
+
 #~ msgid "Invalid PWM frequency"
 #~ msgstr "無効なPWM周波数"
+
+#~ msgid "Invalid SPI pin selection"
+#~ msgstr "SPIピンの選択が不正です"
+
+#~ msgid "Invalid UART pin selection"
+#~ msgstr "UARTピンの選択が不正です"
 
 #~ msgid "Invalid buffer size"
 #~ msgstr "不正なバッファサイズ"
@@ -4776,6 +4690,15 @@ msgstr ""
 #~ msgid "Invalid file"
 #~ msgstr "不正なファイル"
 
+#~ msgid "Invalid frequency"
+#~ msgstr "不正な周波数"
+
+#~ msgid "Invalid frequency supplied"
+#~ msgstr "不正な周波数が与えられました"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "不正なメモリアクセス"
+
 #~ msgid "Invalid number of bits"
 #~ msgstr "不正なビット数"
 
@@ -4790,6 +4713,12 @@ msgstr ""
 
 #~ msgid "Invalid pin for right channel"
 #~ msgstr "右チャネルのピンが不正"
+
+#~ msgid "Invalid pins"
+#~ msgstr "ピンが不正"
+
+#~ msgid "Invalid pins for PWMOut"
+#~ msgstr "PWMOutのピンが不正"
 
 #~ msgid "Invalid polarity"
 #~ msgstr "不正な極性"
@@ -4821,11 +4750,41 @@ msgstr ""
 #~ msgid "Layer must be a Group or TileGrid subclass."
 #~ msgstr "レイヤはGroupかTileGridのサブクラスでなければなりません"
 
+#~ msgid "Length must be an int"
+#~ msgstr "長さには整数が必要"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Lengthは非負数でなければなりません"
+
 #~ msgid "MISO pin init failed."
 #~ msgstr "MISOピン初期化に失敗"
 
 #~ msgid "MOSI pin init failed."
 #~ msgstr "MOSIピン初期化に失敗"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgstr "MicroPython NLRジャンプ失敗。メモリ破壊の可能性あり"
+
+#~ msgid "MicroPython fatal error."
+#~ msgstr "MicroPython致命的エラー"
+
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "MISOまたはMOSIピンがありません"
+
+#~ msgid "Must provide SCK pin"
+#~ msgstr "SCKピンが必要"
+
+#~ msgid "No MISO Pin"
+#~ msgstr "MISOピンなし"
+
+#~ msgid "No MOSI Pin"
+#~ msgstr "MOSIピンがありません"
+
+#~ msgid "No RX pin"
+#~ msgstr "RXピンがありません"
+
+#~ msgid "No TX pin"
+#~ msgstr "TXピンがありません"
 
 #~ msgid "No hardware support on clk pin"
 #~ msgstr "clkピンにハードウェア対応がありません"
@@ -4833,19 +4792,58 @@ msgstr ""
 #~ msgid "No hardware support on pin"
 #~ msgstr "ピンにハードウェア対応がありません"
 
+#~ msgid "No key was specified"
+#~ msgstr "キーが指定されていません"
+
+#~ msgid "No more channels available"
+#~ msgstr "使えるチャネルがもうありません"
+
+#~ msgid "No more timers available"
+#~ msgstr "使えるタイマーがもうありません"
+
+#~ msgid "No more timers available on this pin."
+#~ msgstr "このピンには使えるタイマーがもうありません"
+
+#~ msgid "Not running saved code.\n"
+#~ msgstr "保存されたコードは実行していません。\n"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "8または16ビットの "
+
 #~ msgid ""
 #~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
 #~ msgstr ""
 #~ "PWMのduty_cycle値は0から65535の間でなければなりません（16ビット解像度）"
 
+#~ msgid "ParallelBus not yet supported"
+#~ msgstr "ParallelBusにはまだ対応していません"
+
 #~ msgid "Pin does not have ADC capabilities"
 #~ msgstr "ピンにADCの能力がありません"
+
+#~ msgid "Pin number already reserved by EXTI"
+#~ msgstr "ピン番号はすでにEXTIによって予約されています"
+
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+#~ msgstr "何らかのキーを押すとREPLに入ります。CTRL-Dでリロード。"
+
+#~ msgid "PulseOut not supported on this chip"
+#~ msgstr "PulseOutはこのチップでサポートされていません"
 
 #~ msgid "RTC calibration is not supported on this board"
 #~ msgstr "このボードはRTCのキャリブレーションに非対応"
 
 #~ msgid "RTS/CTS/RS485 Not yet supported on this device"
 #~ msgstr "RTS/CTS/RS485はこのデバイスでは未対応"
+
+#~ msgid "Read-only object"
+#~ msgstr "読み込み専用のオブジェクト"
+
+#~ msgid "Row entry must be digitalio.DigitalInOut"
+#~ msgstr "Rowの各要素は digitalio.DigitalInOut でなければなりません"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "SDAとSCLにプルアップが必要"
 
 #~ msgid "SPI Init Error"
 #~ msgstr "SPI初期化エラー"
@@ -4860,132 +4858,23 @@ msgstr ""
 #~ msgid "Sample rate too high. It must be less than %d"
 #~ msgstr "サンプルレートは%d以下でなければなりません"
 
+#~ msgid "Scan already in progess. Stop with stop_scan."
+#~ msgstr "既にスキャン進行中。stop_scanで停止してください"
+
+#~ msgid "Selected CTS pin not valid"
+#~ msgstr "選択されたCTSピンが不正"
+
+#~ msgid "Selected RTS pin not valid"
+#~ msgstr "選択されたRTSピンが正しくありません"
+
 #~ msgid "Stack size must be at least 256"
 #~ msgstr "スタックサイズは少なくとも256以上でなければなりません"
 
-#~ msgid "Tile value out of bounds"
-#~ msgstr "タイル値が範囲外"
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "ストリームにreadinto()またはwrite()メソッドがありません"
 
-#~ msgid "UART Buffer allocation error"
-#~ msgstr "UARTバッファの確保エラー"
-
-#~ msgid "UART De-init error"
-#~ msgstr "UART解放エラー"
-
-#~ msgid "UART Init Error"
-#~ msgstr "UARTの初期化エラー"
-
-#~ msgid "UART Re-init error"
-#~ msgstr "UARTの再初期化エラー"
-
-#~ msgid "UART write error"
-#~ msgstr "UART書き込みエラー"
-
-#~ msgid "Unsupported baudrate"
-#~ msgstr "非対応のbaudrate"
-
-#~ msgid "WiFi password must be between 8 and 63 characters"
-#~ msgstr "WiFiパスワードは8〜63文字でなければなりません"
-
-#~ msgid "stop must be 1 or 2"
-#~ msgstr "stopは1または2のいずれか"
-
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "timeoutは0.0以上でなければなりません"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "非対応の操作"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "Brightnessは0から255の間でなければなりません"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "相対インポートはできません"
-
-#~ msgid "Unsupported pull value."
-#~ msgstr "非対応のpull値"
-
-#~ msgid "integer required"
-#~ msgstr "整数が必要"
-
-#~ msgid "abort() called"
-#~ msgstr "abort()が呼ばれました"
-
-#~ msgid "f-string expression part cannot include a '#'"
-#~ msgstr "f-文字列の表現部は '#' を持てません"
-
-#~ msgid "f-string expression part cannot include a backslash"
-#~ msgstr "f-文字列の表現部はバックスラッシュを持てません"
-
-#~ msgid "f-string: empty expression not allowed"
-#~ msgstr "f-文字列: 空の表現は許されません"
-
-#~ msgid "f-string: expecting '}'"
-#~ msgstr "f-string: '}'が必要"
-
-#~ msgid "f-string: single '}' is not allowed"
-#~ msgstr "f-string: 1つだけの'}'は許されません"
-
-#~ msgid "invalid arguments"
-#~ msgstr "不正な引数"
-
-#~ msgid "raw f-strings are not implemented"
-#~ msgstr "raw f-文字列は実装されていません"
-
-#~ msgid "unindent does not match any outer indentation level"
-#~ msgstr "インデントの解除が、外側のどのインデントにも一致していません"
-
-#~ msgid "%q list must be a list"
-#~ msgstr "%q リストはリストでなければなりません"
-
-#~ msgid "Column entry must be digitalio.DigitalInOut"
-#~ msgstr "Columnの要素は digitalio.DigitalInOut でなければなりません"
-
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Characteristicが必要"
-
-#~ msgid "Expected a DigitalInOut"
-#~ msgstr "DigitalInOutが必要"
-
-#~ msgid "Expected a Service"
-#~ msgstr "Serviceが必要"
-
-#~ msgid "Expected a UART"
-#~ msgstr "UARTが必要"
-
-#~ msgid "Expected a UUID"
-#~ msgstr "UUIDが必要"
-
-#~ msgid "Expected an Address"
-#~ msgstr "Addressが必要"
-
-#~ msgid "Row entry must be digitalio.DigitalInOut"
-#~ msgstr "Rowの各要素は digitalio.DigitalInOut でなければなりません"
-
-#~ msgid "buttons must be digitalio.DigitalInOut"
-#~ msgstr "buttonsはdigitalio.DigitalInOutでなければなりません"
-
-#~ msgid "Invalid frequency"
-#~ msgstr "不正な周波数"
-
-#~ msgid "ParallelBus not yet supported"
-#~ msgstr "ParallelBusにはまだ対応していません"
-
-#~ msgid "no available NIC"
-#~ msgstr "利用可能なNICがありません"
-
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "バッファが大きすぎて確保できません"
-
-#~ msgid ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
-#~ msgstr ""
-#~ "起動中にリセットボタンを押したためCircuitPythonはセーフモードにいます。も"
-#~ "う一度押すとセーフモードを終了します。\n"
-
-#~ msgid "Not running saved code.\n"
-#~ msgstr "保存されたコードは実行していません。\n"
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "少なくとも1つのUARTピンが必要"
 
 #~ msgid ""
 #~ "The CircuitPython heap was corrupted because the stack was too small.\n"
@@ -5009,8 +4898,23 @@ msgstr ""
 #~ "マイコンの電力が降下しました。使っている電源が十分な電力を回路に供給するこ"
 #~ "とを確認し (CIRCUITPYを取り出してから) リセットを押してください。\n"
 
-#~ msgid "Pin number already reserved by EXTI"
-#~ msgstr "ピン番号はすでにEXTIによって予約されています"
+#~ msgid "Tile value out of bounds"
+#~ msgstr "タイル値が範囲外"
+
+#~ msgid "UART Buffer allocation error"
+#~ msgstr "UARTバッファの確保エラー"
+
+#~ msgid "UART De-init error"
+#~ msgstr "UART解放エラー"
+
+#~ msgid "UART Init Error"
+#~ msgstr "UARTの初期化エラー"
+
+#~ msgid "UART Re-init error"
+#~ msgstr "UARTの再初期化エラー"
+
+#~ msgid "UART write error"
+#~ msgstr "UART書き込みエラー"
 
 #~ msgid "USB Busy"
 #~ msgstr "USBビジー"
@@ -5018,35 +4922,164 @@ msgstr ""
 #~ msgid "USB Error"
 #~ msgstr "USBエラー"
 
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "%q インデクスは %q でなく整数でなければなりません"
+#~ msgid "Unknown soft device error: %04x"
+#~ msgstr "不明なソフトデバイスエラー: %04x"
 
-#~ msgid "'%q' object cannot assign attribute '%q'"
-#~ msgstr "オブジェクト'%q'に属性'%q'を割り当てられません"
+#~ msgid "Unsupported baudrate"
+#~ msgstr "非対応のbaudrate"
 
-#~ msgid "'%q' object does not support item assignment"
-#~ msgstr "'%q' オブジェクトは要素の代入に対応していません"
+#~ msgid "Unsupported operation"
+#~ msgstr "非対応の操作"
 
-#~ msgid "'%q' object does not support item deletion"
-#~ msgstr "'%q' オブジェクトは要素の削除に対応していません"
+#~ msgid "Unsupported pull value."
+#~ msgstr "非対応のpull値"
 
-#~ msgid "'%q' object has no attribute '%q'"
-#~ msgstr "オブジェクト'%q'に属性'%q'はありません"
+#~ msgid "WatchDogTimer is not currently running"
+#~ msgstr "WatchDogTimerは現在動作していません"
 
-#~ msgid "'%q' object is not subscriptable"
-#~ msgstr "オブジェクト'%q'は要素の取得ができません"
+#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+#~ msgstr "WatchDogTimer.modeはいったんWatchDogMode.RESETに設定すると変更不可"
 
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "スカラのサイズを曖昧さなしに取得できません"
+#~ msgid "WatchDogTimer.timeout must be greater than 0"
+#~ msgstr "WatchDogTimer.timeoutは0以上でなければなりません"
 
-#~ msgid "Length must be an int"
-#~ msgstr "長さには整数が必要"
+#~ msgid "WiFi password must be between 8 and 63 characters"
+#~ msgstr "WiFiパスワードは8〜63文字でなければなりません"
 
-#~ msgid "Length must be non-negative"
-#~ msgstr "Lengthは非負数でなければなりません"
+#~ msgid "abort() called"
+#~ msgstr "abort()が呼ばれました"
+
+#~ msgid "address out of bounds"
+#~ msgstr "アドレスが範囲外"
+
+#~ msgid "argument must be ndarray"
+#~ msgstr "引数はndarrayでなければなりません"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "属性は未対応です"
+
+#~ msgid "axis must be -1, 0, None, or 1"
+#~ msgstr "axisは -1, 0, 1, None のいずれかでなければなりません"
+
+#~ msgid "axis must be -1, 0, or 1"
+#~ msgstr "axisは -1, 0, 1 のいずれかでなければなりません"
+
+#~ msgid "axis must be None, 0, or 1"
+#~ msgstr "axisは None, 0, 1 のいずれか"
+
+#~ msgid "bits must be 7, 8 or 9"
+#~ msgstr "bitsは7, 8, 9のいずれかでなければなりません"
+
+#~ msgid "buffer must be a bytes-like object"
+#~ msgstr "バッファはbytes-likeオブジェクトでなければなりません"
+
+#~ msgid "buttons must be digitalio.DigitalInOut"
+#~ msgstr "buttonsはdigitalio.DigitalInOutでなければなりません"
+
+#~ msgid "byteorder is not a string"
+#~ msgstr "byteorderが文字列ではありません"
+
+#~ msgid "can't convert to %q"
+#~ msgstr "%q に変換できません"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr "複素数の切り捨て除算はできません"
+
+#~ msgid "can't have multiple **x"
+#~ msgstr "複数の **x は持てません"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "複数の *x は持てません"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "相対インポートはできません"
+
+#~ msgid "cannot reshape array (incompatible input/output shape)"
+#~ msgstr "入力/出力シェイプが互換でなくreshapeできません"
+
+#~ msgid "complex division by zero"
+#~ msgstr "複素数ゼロ除算"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "定数は整数でなければなりません"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr "desitination_lengthは正の整数でなければなりません"
+
+#~ msgid "end_x should be an int"
+#~ msgstr "end_xは整数でなければなりません"
+
+#~ msgid "f-string expression part cannot include a '#'"
+#~ msgstr "f-文字列の表現部は '#' を持てません"
+
+#~ msgid "f-string expression part cannot include a backslash"
+#~ msgstr "f-文字列の表現部はバックスラッシュを持てません"
+
+#~ msgid "f-string: empty expression not allowed"
+#~ msgstr "f-文字列: 空の表現は許されません"
+
+#~ msgid "f-string: expecting '}'"
+#~ msgstr "f-string: '}'が必要"
+
+#~ msgid "f-string: single '}' is not allowed"
+#~ msgstr "f-string: 1つだけの'}'は許されません"
+
+#~ msgid "first argument must be an iterable"
+#~ msgstr "1つ目の引数はイテレート可能でなければなりません"
+
+#~ msgid "function is implemented for scalars and ndarrays only"
+#~ msgstr "スカラ値およびndarrayのみを受け取ります"
+
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr "int()の第2引数は2以上36以下でなければなりません"
+
+#~ msgid "integer required"
+#~ msgstr "整数が必要"
+
+#~ msgid "invalid arguments"
+#~ msgstr "不正な引数"
+
+#~ msgid "invalid dupterm index"
+#~ msgstr "不正なduptermインデクス"
+
+#~ msgid "iterables are not of the same length"
+#~ msgstr "iterableが同じ長さではありません"
+
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr "キーワード引数は未実装。通常の引数を使ってください"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "キーワードは文字列でなければなりません"
+
+#~ msgid "long int not supported in this build"
+#~ msgstr "このビルドはlong intに非対応"
+
+#~ msgid "matrix dimensions do not match"
+#~ msgstr "行列の次元が一致しません"
+
+#~ msgid "max_length must be > 0"
+#~ msgstr "max_lengthは0より大きくなければなりません"
+
+#~ msgid "n must be between 0, and 9"
+#~ msgstr "nは0から9まで"
 
 #~ msgid "name reused for argument"
 #~ msgstr "引数で名前が再利用されています"
+
+#~ msgid "no available NIC"
+#~ msgstr "利用可能なNICがありません"
+
+#~ msgid "no reset pin available"
+#~ msgstr "利用可能なリセットピンがありません"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "*/** の後に非キーワード引数は置けません"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "キーワード引数の後に非キーワード引数は置けません"
+
+#~ msgid "number of arguments must be 2, or 3"
+#~ msgstr "引数は2個または3個でなければなりません"
 
 #~ msgid "object '%q' is not a tuple or list"
 #~ msgstr "オブジェクト'%q'がタプルやリストでありません"
@@ -5063,148 +5096,100 @@ msgstr ""
 #~ msgid "object of type '%q' has no len()"
 #~ msgstr "オブジェクト（型 '%q'）はlen()を持ちません"
 
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "USBがアクティブの時に'/'を再マウントできません"
+#~ msgid "out of range of source"
+#~ msgstr "ソースが範囲外"
 
-#~ msgid "invalid dupterm index"
-#~ msgstr "不正なduptermインデクス"
-
-#~ msgid "schedule stack full"
-#~ msgstr "スケジュールスタックが一杯"
-
-#~ msgid "Corrupt raw code"
-#~ msgstr "破損したraw code"
+#~ msgid "palette_index should be an int"
+#~ msgstr "palette_indexには整数が必要"
 
 #~ msgid "parameter annotation must be an identifier"
 #~ msgstr "引数アノテーションは識別子でなければなりません"
 
-#~ msgid "buffer must be a bytes-like object"
-#~ msgstr "バッファはbytes-likeオブジェクトでなければなりません"
-
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr "MicroPython VMの非実行時にヒープ確保を試みました"
-
-#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
-#~ msgstr "MicroPython NLRジャンプ失敗。メモリ破壊の可能性あり"
-
-#~ msgid "MicroPython fatal error."
-#~ msgstr "MicroPython致命的エラー"
-
-#~ msgid "argument must be ndarray"
-#~ msgstr "引数はndarrayでなければなりません"
-
-#~ msgid "matrix dimensions do not match"
-#~ msgstr "行列の次元が一致しません"
-
-#~ msgid "Unknown soft device error: %04x"
-#~ msgstr "不明なソフトデバイスエラー: %04x"
-
-#~ msgid "first argument must be an iterable"
-#~ msgstr "1つ目の引数はイテレート可能でなければなりません"
-
-#~ msgid "iterables are not of the same length"
-#~ msgstr "iterableが同じ長さではありません"
-
-#~ msgid "Selected CTS pin not valid"
-#~ msgstr "選択されたCTSピンが不正"
-
-#~ msgid "Selected RTS pin not valid"
-#~ msgstr "選択されたRTSピンが正しくありません"
-
-#~ msgid "Could not initialize channel"
-#~ msgstr "チャネルを初期化できません"
-
-#~ msgid "Could not initialize timer"
-#~ msgstr "タイマーを初期化できません"
-
-#~ msgid "Invalid frequency supplied"
-#~ msgstr "不正な周波数が与えられました"
-
-#~ msgid "Invalid pins for PWMOut"
-#~ msgstr "PWMOutのピンが不正"
-
-#~ msgid "No more channels available"
-#~ msgstr "使えるチャネルがもうありません"
-
-#~ msgid "No more timers available"
-#~ msgstr "使えるタイマーがもうありません"
-
-#~ msgid "No more timers available on this pin."
-#~ msgstr "このピンには使えるタイマーがもうありません"
-
-#~ msgid "Group full"
-#~ msgstr "グループが一杯"
-
-#~ msgid "bits must be 7, 8 or 9"
-#~ msgstr "bitsは7, 8, 9のいずれかでなければなりません"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "SDAとSCLにプルアップが必要"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 #~ msgstr ""
-#~ "\n"
-#~ "コードの実行が完了しました。リロードを待っています。\n"
+#~ "pixel_shaderはdisplayio.Paletteかdisplayio.ColorConverterのどちらかでなけ"
+#~ "ればなりません"
 
-#~ msgid "Frequency captured is above capability. Capture Paused."
-#~ msgstr "キャプチャした周波数は能力を超えています。キャプチャ停止"
+#~ msgid "queue overflow"
+#~ msgstr "キューがオーバーフローしました"
 
-#~ msgid "max_length must be > 0"
-#~ msgstr "max_lengthは0より大きくなければなりません"
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr "何らかのキーを押すとREPLに入ります。CTRL-Dでリロード。"
-
-#~ msgid "axis must be -1, 0, None, or 1"
-#~ msgstr "axisは -1, 0, 1, None のいずれかでなければなりません"
-
-#~ msgid "axis must be -1, 0, or 1"
-#~ msgstr "axisは -1, 0, 1 のいずれかでなければなりません"
-
-#~ msgid "axis must be None, 0, or 1"
-#~ msgstr "axisは None, 0, 1 のいずれか"
-
-#~ msgid "cannot reshape array (incompatible input/output shape)"
-#~ msgstr "入力/出力シェイプが互換でなくreshapeできません"
-
-#~ msgid "function is implemented for scalars and ndarrays only"
-#~ msgstr "スカラ値およびndarrayのみを受け取ります"
-
-#~ msgid "n must be between 0, and 9"
-#~ msgstr "nは0から9まで"
-
-#~ msgid "number of arguments must be 2, or 3"
-#~ msgstr "引数は2個または3個でなければなりません"
+#~ msgid "raw f-strings are not implemented"
+#~ msgstr "raw f-文字列は実装されていません"
 
 #~ msgid "right hand side must be an ndarray, or a scalar"
 #~ msgstr "右辺は ndarray またはスカラ値でなければなりません"
 
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "sample_source バッファには bytearray または 'h','H','b','B'型のarrayが必要"
+
+#~ msgid "schedule stack full"
+#~ msgstr "スケジュールスタックが一杯"
+
 #~ msgid "shape must be a 2-tuple"
 #~ msgstr "shapeは2値のタプルでなければなりません"
+
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "文字列フォーマット中に孤立した '}' があります"
+
+#~ msgid "slice step can't be zero"
+#~ msgstr "スライスのステップは0にできません"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "stepは非ゼロ値でなければなりません"
+
+#~ msgid "stop must be 1 or 2"
+#~ msgstr "stopは1または2のいずれか"
+
+#~ msgid "string indices must be integers, not %q"
+#~ msgstr "文字列のインデクスは整数でなければなりません (%qでなく)"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr "文字列ではなくbytesまたはbytesarrayが必要"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "threshouldは0から65536まで"
+
+#~ msgid "time.struct_time() takes a 9-sequence"
+#~ msgstr "time.struct_time()は9要素のシーケンスを受け取ります"
+
+#~ msgid "timeout must be 0.0-100.0 seconds"
+#~ msgstr "timeoutは0.0〜100.0秒でなければなりません"
+
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "timeoutは0.0以上でなければなりません"
+
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "指定された書式に対して引数が多すぎます"
+
+#~ msgid "unindent does not match any outer indentation level"
+#~ msgstr "インデントの解除が、外側のどのインデントにも一致していません"
+
+#~ msgid "unmatched '{' in format"
+#~ msgstr "書式中にマッチしない '{' があります"
+
+#~ msgid "unsupported type for %q: '%q'"
+#~ msgstr "%q が対応していない型: '%q'"
+
+#~ msgid "value_count must be > 0"
+#~ msgstr "value_countは0より大きくなければなりません"
+
+#~ msgid "watchdog timeout must be greater than 0"
+#~ msgstr "watchdogのtimeoutは0以上でなければなりません"
 
 #~ msgid "wrong argument type"
 #~ msgstr "引数の型が不正"
 
-#~ msgid "Must provide SCK pin"
-#~ msgstr "SCKピンが必要"
+#~ msgid "x value out of bounds"
+#~ msgstr "xが範囲外"
 
-#~ msgid ""
-#~ "\n"
-#~ "To exit, please reset the board without "
-#~ msgstr ""
-#~ "\n"
-#~ "終了するには、次の操作をせずにリセットしてください: "
+#~ msgid "y should be an int"
+#~ msgstr "yは整数でなければなりません"
 
-#~ msgid "PulseOut not supported on this chip"
-#~ msgstr "PulseOutはこのチップでサポートされていません"
+#~ msgid "y value out of bounds"
+#~ msgstr "yが範囲外"
 
-#~ msgid "Invalid I2C pin selection"
-#~ msgstr "I2Cピンの選択が不正です"
-
-#~ msgid "Invalid SPI pin selection"
-#~ msgstr "SPIピンの選択が不正です"
-
-#~ msgid "Invalid UART pin selection"
-#~ msgstr "UARTピンの選択が不正です"
+#~ msgid "zero step"
+#~ msgstr "ステップが0"

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -73,40 +73,10 @@ msgstr " 산출:\n"
 msgid "%%c requires int or char"
 msgstr "%%c 전수(int)또는 캐릭터(char)필요합니다"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr ""
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
 msgstr ""
 
 #: shared-bindings/microcontroller/Pin.c
@@ -290,11 +260,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
 msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
@@ -632,8 +597,9 @@ msgstr "자동 재 장전이 꺼져 있습니다\n"
 msgid ""
 "Auto-reload is on. Simply save files over USB to run them or enter REPL to "
 "disable.\n"
-msgstr "자동 새로 고침이 켜져 있습니다. USB를 통해 파일을 저장하여 실행하십시오. "
-"비활성화하려면 REPL을 입력하십시오.\n"
+msgstr ""
+"자동 새로 고침이 켜져 있습니다. USB를 통해 파일을 저장하여 실행하십시오. 비활"
+"성화하려면 REPL을 입력하십시오.\n"
 
 #: ports/espressif/common-hal/canio/CAN.c
 msgid "Baudrate not supported by peripheral"
@@ -1607,7 +1573,8 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
 msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
@@ -2148,7 +2115,8 @@ msgstr "UUID문자열이 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'형식이 아닙�
 
 #: shared-bindings/_bleio/UUID.c
 msgid "UUID value is not str, int or byte buffer"
-msgstr "UUID값이 문자열(str), 정수(int) 또는 바이트버퍼가(byte buffer) 아닙니다"
+msgstr ""
+"UUID값이 문자열(str), 정수(int) 또는 바이트버퍼가(byte buffer) 아닙니다"
 
 #: ports/raspberrypi/common-hal/memorymap/AddressRange.c
 msgid "Unable to access unaligned IO register"
@@ -4404,26 +4372,42 @@ msgstr ""
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
 
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' 는 루프 외부에 있습니다"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' 는 루프 외부에 있습니다"
-
-#~ msgid "invalid format"
-#~ msgstr "형식가 유효하지 않습니다"
-
-#~ msgid "Expected a %q"
-#~ msgstr "%q 이 예상되었습니다."
-
-#~ msgid "Invalid pins"
-#~ msgstr "핀이 유효하지 않습니다"
+#~ msgid ""
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "실행 완료 코드. 재장전 을 기다리는 중입니다\n"
 
 #~ msgid "%q must be >= 1"
 #~ msgstr "%q 는 >=1이어야합니다"
 
 #~ msgid "%q should be an int"
 #~ msgstr "%q 는 정수(int) 여야합니다"
+
+#~ msgid "'%s' object does not support item assignment"
+#~ msgstr "'%s' 을 지정할 수 없습니다"
+
+#~ msgid "'%s' object does not support item deletion"
+#~ msgstr "'%s' 은 삭제할 수 없습니다"
+
+#~ msgid "'%s' object is not an iterator"
+#~ msgstr "'%s' 은 수정할 수 없습니다"
+
+#~ msgid "'%s' object is not callable"
+#~ msgstr "'%s' 을 검색 할 수 없습니다"
+
+#~ msgid "'%s' object is not iterable"
+#~ msgstr "'%s' 은 변경할 수 없습니다"
+
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' 는 루프 외부에 있습니다"
+
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' 는 루프 외부에 있습니다"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "밝기는 0에서 255 사이 여야합니다"
 
 #, c-format
 #~ msgid "Buffer incorrect size. Should be %d bytes."
@@ -4435,11 +4419,47 @@ msgstr ""
 #~ msgid "Bytes must be between 0 and 255."
 #~ msgstr "바이트는 0에서 255 사이 여야합니다."
 
+#~ msgid "Can't add services in Central mode"
+#~ msgstr "센트랄(중앙) 모드에서는 서비스를 추가 할 수 없습니다"
+
+#~ msgid "Can't advertise in Central mode"
+#~ msgstr "센트랄(중앙) 모드로 광고 (브로드 캐스트) 할 수 없습니다"
+
+#~ msgid "Can't change the name in Central mode"
+#~ msgstr "센트랄(중앙) 모드에서는 이름을 변경할 수 없습니다"
+
 #~ msgid "Cannot read without MISO pin."
 #~ msgstr "MISO핀이 없으면 읽을 수 없습니다"
 
 #~ msgid "Command must be an int between 0 and 255"
 #~ msgstr "명령은 0에서 255 사이의 정수(int) 여야합니다"
+
+#~ msgid "Data too large for the advertisement packet"
+#~ msgstr "광고 (브로드 캐스트) 패킷에 대한 데이터가 너무 큽니다"
+
+#~ msgid "Expected a %q"
+#~ msgstr "%q 이 예상되었습니다."
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "특성(Characteristic)이 예상되었습니다."
+
+#~ msgid "Expected a UUID"
+#~ msgstr "UUID이 예상되었습니다."
+
+#~ msgid "Failed to add service"
+#~ msgstr "서비스를 추가하지 못했습니다"
+
+#~ msgid "Failed to add service, err 0x%04x"
+#~ msgstr "서비스를 추가하지 못했습니다., 오류 0x%04x"
+
+#~ msgid "Failed to connect:"
+#~ msgstr "연결할 수 없다"
+
+#~ msgid "Failed to continue scanning"
+#~ msgstr "스캔을 계속할 수 없습니다"
+
+#~ msgid "Failed to continue scanning, err 0x%04x"
+#~ msgstr "스캔을 계속할 수 없습니다, 오류 0x%04x"
 
 #~ msgid "Invalid file"
 #~ msgstr "파일이 유효하지 않습니다"
@@ -4459,81 +4479,29 @@ msgstr ""
 #~ msgid "Invalid pin for right channel"
 #~ msgstr "오른쪽 채널 핀이 잘못되었습니다"
 
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "밝기는 0에서 255 사이 여야합니다"
-
-#~ msgid "integer required"
-#~ msgstr "정수가 필요합니다"
-
-#~ msgid "Expected a Characteristic"
-#~ msgstr "특성(Characteristic)이 예상되었습니다."
-
-#~ msgid "Expected a UUID"
-#~ msgstr "UUID이 예상되었습니다."
+#~ msgid "Invalid pins"
+#~ msgstr "핀이 유효하지 않습니다"
 
 #~ msgid "Length must be an int"
 #~ msgstr "길이는 정수(int) 여야합니다"
 
-#~ msgid "invalid dupterm index"
-#~ msgstr "Dupterm index가 유효하지 않습니다"
-
 #~ msgid "bits must be 7, 8 or 9"
 #~ msgstr "비트(bits)는 7, 8 또는 9 여야합니다"
 
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "실행 완료 코드. 재장전 을 기다리는 중입니다\n"
-
-#~ msgid "'%s' object does not support item assignment"
-#~ msgstr "'%s' 을 지정할 수 없습니다"
-
-#~ msgid "'%s' object does not support item deletion"
-#~ msgstr "'%s' 은 삭제할 수 없습니다"
-
-#~ msgid "'%s' object is not an iterator"
-#~ msgstr "'%s' 은 수정할 수 없습니다"
-
-#~ msgid "'%s' object is not callable"
-#~ msgstr "'%s' 을 검색 할 수 없습니다"
-
-#~ msgid "'%s' object is not iterable"
-#~ msgstr "'%s' 은 변경할 수 없습니다"
-
-#~ msgid "Can't add services in Central mode"
-#~ msgstr "센트랄(중앙) 모드에서는 서비스를 추가 할 수 없습니다"
-
-#~ msgid "Can't advertise in Central mode"
-#~ msgstr "센트랄(중앙) 모드로 광고 (브로드 캐스트) 할 수 없습니다"
-
-#~ msgid "Can't change the name in Central mode"
-#~ msgstr "센트랄(중앙) 모드에서는 이름을 변경할 수 없습니다"
-
-#~ msgid "Data too large for the advertisement packet"
-#~ msgstr "광고 (브로드 캐스트) 패킷에 대한 데이터가 너무 큽니다"
-
-#~ msgid "Failed to add service"
-#~ msgstr "서비스를 추가하지 못했습니다"
-
-#~ msgid "Failed to add service, err 0x%04x"
-#~ msgstr "서비스를 추가하지 못했습니다., 오류 0x%04x"
-
-#~ msgid "Failed to connect:"
-#~ msgstr "연결할 수 없다"
-
-#~ msgid "Failed to continue scanning"
-#~ msgstr "스캔을 계속할 수 없습니다"
-
-#~ msgid "Failed to continue scanning, err 0x%04x"
-#~ msgstr "스캔을 계속할 수 없습니다, 오류 0x%04x"
-
 #~ msgid "bits must be 8"
 #~ msgstr "비트(bits)는 8이어야합니다"
+
+#~ msgid "integer required"
+#~ msgstr "정수가 필요합니다"
 
 #~ msgid "invalid I2C peripheral"
 #~ msgstr "ICT주변 기기가 유효하지 않습니다"
 
 #~ msgid "invalid SPI peripheral"
 #~ msgstr "SPI주변 기기가 유효하지 않습니다"
+
+#~ msgid "invalid dupterm index"
+#~ msgstr "Dupterm index가 유효하지 않습니다"
+
+#~ msgid "invalid format"
+#~ msgstr "형식가 유효하지 않습니다"

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -72,40 +72,10 @@ msgstr " uitvoer:\n"
 msgid "%%c requires int or char"
 msgstr "%%c vereist een int of char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr ""
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
 msgstr ""
 
 #: shared-bindings/microcontroller/Pin.c
@@ -289,11 +259,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
 msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
@@ -1613,8 +1578,9 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Alleen 8 of 16 bit mono met "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -4431,186 +4397,12 @@ msgstr "zi moet van type float zijn"
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi moet vorm (n_section, 2) hebben"
 
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr "'await', 'async for' of 'async with' buiten async functie"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' buiten de loop"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' buiten de loop"
-
-#~ msgid "unsupported type for %q: '%q'"
-#~ msgstr "niet ondersteund type voor %q: '%q'"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Splitting met sub-captures"
-
-#~ msgid "__init__() should return None, not '%q'"
-#~ msgstr "__init__() moet None teruggeven, niet '%q'"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "attributen nog niet ondersteund"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr "kan geen afgekapte deling doen van een comlex nummer"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "kan naam %q niet importeren"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr ""
-#~ "trefwoord argument(en) zijn niet geïmplementeerd, gebruik normale "
-#~ "argumenten"
-
-#~ msgid "length argument not allowed for this type"
-#~ msgstr "voor dit type is length niet toegestaan"
-
-#~ msgid "offset out of bounds"
-#~ msgstr "offset buiten bereik"
-
-#~ msgid "slice step can't be zero"
-#~ msgstr "segmentstap mag niet nul zijn"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr "string niet ondersteund; gebruik bytes of bytearray"
-
-#~ msgid "Initialization failed due to lack of memory"
-#~ msgstr "De initialisatie is mislukt vanwege een gebrek aan geheugen"
-
-#~ msgid "WatchDogTimer is not currently running"
-#~ msgstr "WatchDogTimer is momenteel niet actief"
-
-#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-#~ msgstr ""
-#~ "WatchDogTimer.mode kan niet worden gewijzigd zodra de modus is ingesteld "
-#~ "op WatchDogMode.RESET"
-
-#~ msgid "watchdog not initialized"
-#~ msgstr "watchdog niet geïnitialiseerd"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "ADC2 wordt gebruikt door WiFi"
-
-#~ msgid "queue overflow"
-#~ msgstr "wachtrij overloop"
-
-#~ msgid "'coroutine' object is not an iterator"
-#~ msgstr "'coroutine' object is geen iterator"
-
-#~ msgid "Buffer is too small"
-#~ msgstr "Buffer is te klein"
-
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-#~ msgstr ""
-#~ "pixel_shader moet displayio.Palette of displayio.ColorConverter zijn"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "Corrupt .mpy bestand"
-
 #~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
 #~ msgstr ""
-#~ "Incompatibel .mpy bestand. Update alle .mpy bestanden. Zie http://adafru."
-#~ "it/mpy-update voor meer informatie."
-
-#~ msgid "can't convert to %q"
-#~ msgstr "kan niet naar %q converteren"
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "kan niet meerdere **x hebben"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "kan geen meerdere *x hebben"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "constant moet een integer zijn"
-
-#~ msgid "invalid format"
-#~ msgstr "ongeldig formaat"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "trefwoorden moeten van type string zijn"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "niet-trefwoord argument na */**"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "niet-trefwoord argument na trefwoord argument"
-
-#~ msgid "inputs are not iterable"
-#~ msgstr "invoer is niet itereerbaar"
-
-#~ msgid "Too many display busses"
-#~ msgstr "Teveel beeldscherm bussen"
-
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Hardware bezig, probeer alternatieve pinnen"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "Ontbrekende MISO of MOSI Pin"
-
-#~ msgid "No MISO Pin"
-#~ msgstr "Geen MISO pin"
-
-#~ msgid "No MOSI Pin"
-#~ msgstr "Geen MOSI pin"
-
-#~ msgid "No RX pin"
-#~ msgstr "Geen RX pin"
-
-#~ msgid "No TX pin"
-#~ msgstr "Geen TX pin"
-
-#~ msgid "no reset pin available"
-#~ msgstr "geen reset pin beschikbaar"
-
-#~ msgid "input and output shapes are not compatible"
-#~ msgstr "in- en uitvoervormen zijn niet compatibel"
-
-#~ msgid "shape must be a tuple"
-#~ msgstr "vorm moet een tupel zijn"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "Helderheid moet tussen de 0 en 1.0 liggen"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "Maximale x waarde indien gespiegeld is %d"
-
-#~ msgid "x value out of bounds"
-#~ msgstr "x-waarde buiten bereik"
-
-#~ msgid "y value out of bounds"
-#~ msgstr "y-waarde buiten bereik"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "I2SOut is niet beschikbaar"
-
-#~ msgid "out of range of source"
-#~ msgstr "buiten bereik van bron"
-
-#~ msgid "pixel value requires too many bits"
-#~ msgstr "pixel waarde vereist te veel bits"
-
-#~ msgid "value_count must be > 0"
-#~ msgstr "value_count moet groter dan 0 zijn"
-
-#~ msgid "No key was specified"
-#~ msgstr "Een sleutel was niet gespecificeerd"
-
-#~ msgid "Scan already in progess. Stop with stop_scan."
-#~ msgstr "Scan wordt al uitvoerd. Stop met stop_scan."
-
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "te veel argumenten opgegeven bij dit formaat"
-
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "Geef op zijn minst 1 UART pin op"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "%q pin onjuist"
+#~ "\n"
+#~ "Code is uitgevoerd. Wachten op herladen.\n"
 
 #~ msgid ""
 #~ "\n"
@@ -4621,102 +4413,21 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ "Meld een probleem met de inhoud van de CIRCUITPY drive op:\n"
 #~ "https://github.com/adafruit/circuitpython/issues\n"
 
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "CircuitPython kon het heap geheugen niet toewijzen."
+#~ msgid ""
+#~ "\n"
+#~ "To exit, please reset the board without "
+#~ msgstr ""
+#~ "\n"
+#~ "Om te verlaten, herstart de module zonder "
 
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "Crash naar de HardFault_Handler."
+#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+#~ msgstr "%d adres pins en %d RGB pins geven een hoogte van %d aan, niet %d"
 
-#~ msgid "Invalid memory access."
-#~ msgstr "Ongeldig geheugen adres."
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "%q indices moeten integers zijn, geen %q"
 
-#~ msgid "Expected a %q"
-#~ msgstr "Verwacht een %q"
-
-#, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IV %d bytes lang zijn"
-
-#~ msgid "Not settable"
-#~ msgstr "Niet instelbaar"
-
-#~ msgid "expected '%q' but got '%q'"
-#~ msgstr "verwachtte '%q' maar ontving '%q'"
-
-#~ msgid "expected '%q' or '%q' but got '%q'"
-#~ msgstr "verwachtte '%q' of '%q' maar ontving '%q'"
-
-#~ msgid "Read-only object"
-#~ msgstr "Alleen-lezen object"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "Op zijn meest %d %q mogen worden gespecificeerd (niet %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Ongeldige pinnen"
-
-#~ msgid "byteorder is not a string"
-#~ msgstr "byteorder is geen string"
-
-#~ msgid "complex division by zero"
-#~ msgstr "complexe deling door 0"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr "int() argument 2 moet >=2 en <= 36 zijn"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "long int wordt niet ondersteund in deze build"
-
-#~ msgid "slice step cannot be zero"
-#~ msgstr "segmentstap mag niet nul zijn"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "step mag geen nul zijn"
-
-#~ msgid "string indices must be integers, not %q"
-#~ msgstr "string indices moeten integers zijn, geen %q"
-
-#~ msgid "time.struct_time() takes a 9-sequence"
-#~ msgstr "time.struct_time() accepteert een 9-rij"
-
-#~ msgid "zero step"
-#~ msgstr "nul-stap"
-
-#~ msgid "WatchDogTimer.timeout must be greater than 0"
-#~ msgstr "WatchDogTimer.timeout moet groter dan 0 zijn"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "enkele '}' aangetroffen in formaat tekenreeks (string)"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "drempelwaarde moet in het bereik 0-65536 liggen"
-
-#~ msgid "timeout must be 0.0-100.0 seconds"
-#~ msgstr "timeout moet tussen 0.0 en 100.0 seconden zijn"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "'{' zonder overeenkomst in formaat"
-
-#~ msgid "watchdog timeout must be greater than 0"
-#~ msgstr "watchdog time-out moet groter zijn dan 0"
-
-#~ msgid "To exit, please reset the board without "
-#~ msgstr "Om te beëindigen, reset het bord zonder "
-
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "Je hebt aangeven de veilige modus te starten door "
-
-#~ msgid "pressing boot button at start up.\n"
-#~ msgstr "druk bootknop in bij opstarten.\n"
-
-#~ msgid "pressing both buttons at start up.\n"
-#~ msgstr "druk beide knoppen in bij opstarten.\n"
-
-#~ msgid "Firmware image is invalid"
-#~ msgstr "Firmware image is ongeldig"
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "Stream mist readinto() of write() methode."
+#~ msgid "%q list must be a list"
+#~ msgstr "%q lijst moet een lijst zijn"
 
 #~ msgid "%q must be >= 0"
 #~ msgstr "%q moet >= 0 zijn"
@@ -4724,58 +4435,80 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "%q must be >= 1"
 #~ msgstr "%q moet >= 1 zijn"
 
-#~ msgid "address out of bounds"
-#~ msgstr "adres buiten bereik"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr ""
-#~ "destination_lengte moest een int groter dan of gelijk zijn aan 0 zijn"
-
-#~ msgid "type object 'generator' has no attribute '__await__'"
-#~ msgstr "het type object 'generator' heeft geen attribuut '__await__'"
-
-#~ msgid "color should be an int"
-#~ msgstr "kleur moet een int zijn"
-
-#~ msgid "end_x should be an int"
-#~ msgstr "end_x moet een int zijn"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "palette_index moet een int zijn"
-
-#~ msgid "start_x should be an int"
-#~ msgstr "start_x moet een int zijn"
-
-#~ msgid "y should be an int"
-#~ msgstr "y moet een int zijn"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "sample_source buffer moet een bytearray of array van type 'h', 'H', 'b' "
-#~ "of 'B' zijn"
-
-#~ msgid "Expected an alarm"
-#~ msgstr "Verwachtte een alarm"
-
-#~ msgid "Failed to init wifi"
-#~ msgstr "Kon WiFi niet initialiseren"
-
-#~ msgid "input must be a tensor of rank 2"
-#~ msgstr "invoer moet een tensor van rang 2 zijn"
-
-#~ msgid "maximum number of dimensions is 4"
-#~ msgstr "maximaal aantal dimensies is 4"
-
-#~ msgid "Watchdog timer expired."
-#~ msgstr "Watchdog-timer verstreken."
-
 #~ msgid "%q must be a tuple of length 2"
 #~ msgstr "%q moet een tuple van lengte 2 zijn"
 
+#~ msgid "%q pin invalid"
+#~ msgstr "%q pin onjuist"
+
 #~ msgid "%q should be an int"
 #~ msgstr "%q moet een int zijn"
+
+#~ msgid "'%q' object cannot assign attribute '%q'"
+#~ msgstr "'%q' object kan attribuut ' %q' niet toewijzen"
+
+#~ msgid "'%q' object does not support item assignment"
+#~ msgstr "'%q' object ondersteunt toewijzing van items niet"
+
+#~ msgid "'%q' object does not support item deletion"
+#~ msgstr "'%q' object ondersteunt verwijderen van items niet"
+
+#~ msgid "'%q' object has no attribute '%q'"
+#~ msgstr "'%q' object heeft geen attribuut '%q'"
+
+#~ msgid "'%q' object is not bytes-like"
+#~ msgstr "'%q' object is niet bytes-achtig"
+
+#~ msgid "'%q' object is not subscriptable"
+#~ msgstr "kan niet abonneren op '%q' object"
+
+#~ msgid "'%s' integer %d is not within range %d..%d"
+#~ msgstr "'%s' integer %d is niet in bereik %d..%d"
+
+#~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
+#~ msgstr "'%s' integer 0x%x past niet in mask 0x%x"
+
+#~ msgid "'%s' object cannot assign attribute '%q'"
+#~ msgstr "'%s' object kan niet aan attribuut '%q' toewijzen"
+
+#~ msgid "'%s' object does not support '%q'"
+#~ msgstr "'%s' object ondersteunt '%q' niet"
+
+#~ msgid "'%s' object does not support item assignment"
+#~ msgstr "'%s' object ondersteunt item toewijzing niet"
+
+#~ msgid "'%s' object does not support item deletion"
+#~ msgstr "'%s' object ondersteunt item verwijdering niet"
+
+#~ msgid "'%s' object is not an iterator"
+#~ msgstr "'%s' object is geen iterator"
+
+#~ msgid "'%s' object is not callable"
+#~ msgstr "'%s' object is niet aanroepbaar"
+
+#~ msgid "'%s' object is not iterable"
+#~ msgstr "'%s' object is niet itereerbaar"
+
+#~ msgid "'%s' object is not subscriptable"
+#~ msgstr "'%s' object is niet onderschrijfbaar"
+
+#~ msgid "'async for' or 'async with' outside async function"
+#~ msgstr "'async for' of 'async with' buiten async functie"
+
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr "'await', 'async for' of 'async with' buiten async functie"
+
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' buiten de loop"
+
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' buiten de loop"
+
+#~ msgid "'coroutine' object is not an iterator"
+#~ msgstr "'coroutine' object is geen iterator"
+
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "ADC2 wordt gebruikt door WiFi"
 
 #~ msgid "Address type out of range"
 #~ msgstr "Adres type buiten bereik"
@@ -4792,16 +4525,34 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "AnalogOut not supported on given pin"
 #~ msgstr "AnalogOut niet ondersteund door gegeven pin"
 
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "Op zijn meest %d %q mogen worden gespecificeerd (niet %d)"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr "heap allocatie geprobeerd terwijl MicroPython VM niet draait."
+
 #, c-format
 #~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
 #~ msgstr "Bitdiepte moet tussen 1 en 6 liggen, niet %d"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "Helderheid moet tussen de 0 en 1.0 liggen"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "Helderheid moet tussen de 0 en 255 liggen"
 
 #, c-format
 #~ msgid "Buffer incorrect size. Should be %d bytes."
 #~ msgstr "Buffer heeft incorrect grootte. Moet %d bytes zijn."
 
+#~ msgid "Buffer is too small"
+#~ msgstr "Buffer is te klein"
+
 #~ msgid "Buffer must be at least length 1"
 #~ msgstr "Buffer moet op zijn minst lengte 1 zijn"
+
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "Buffer is te groot en niet in staat te alloceren"
 
 #~ msgid "Bytes must be between 0 and 255."
 #~ msgstr "Bytes moeten tussen 0 en 255 liggen."
@@ -4812,6 +4563,9 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "Cannot read without MISO pin."
 #~ msgstr "Kan niet lezen zonder MISO pin."
 
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "Kan '/' niet hermounten als USB actief is."
+
 #~ msgid "Cannot reset into bootloader because no bootloader is present."
 #~ msgstr ""
 #~ "Kan niet resetten naar bootloader omdat er geen bootloader aanwezig is."
@@ -4819,14 +4573,36 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "Cannot transfer without MOSI and MISO pins."
 #~ msgstr "Kan niet overdragen zonder MOSI en MISO pinnen."
 
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "Kan niet ondubbelzinning sizeof scalar verkrijgen"
+
 #~ msgid "Cannot write without MOSI pin."
 #~ msgstr "Kan niet schrijven zonder MOSI pin."
+
+#~ msgid ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+#~ msgstr ""
+#~ "CircuitPython is in veilige modus omdat de rest knop werd ingedrukt "
+#~ "tijdens het opstarten. Druk nogmaals om veilige modus te verlaten\n"
+
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "CircuitPython kon het heap geheugen niet toewijzen."
 
 #~ msgid "Clock pin init failed."
 #~ msgstr "Clock pin init mislukt."
 
+#~ msgid "Column entry must be digitalio.DigitalInOut"
+#~ msgstr "Column entry moet digitalio.DigitalInOut zijn"
+
 #~ msgid "Command must be an int between 0 and 255"
 #~ msgstr "Command moet een int tussen 0 en 255 zijn"
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "Corrupt .mpy bestand"
+
+#~ msgid "Corrupt raw code"
+#~ msgstr "Corrupt raw code"
 
 #~ msgid "Could not initialize Camera"
 #~ msgstr "Kon camera niet initialiseren"
@@ -4839,6 +4615,12 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 
 #~ msgid "Could not initialize UART"
 #~ msgstr "Kan UART niet initialiseren"
+
+#~ msgid "Could not initialize channel"
+#~ msgstr "Kan kanaal niet initialiseren"
+
+#~ msgid "Could not initialize timer"
+#~ msgstr "Kan timer niet initialiseren"
 
 #~ msgid "Could not re-init channel"
 #~ msgstr "Kan kanaal niet her-initialiseren"
@@ -4858,8 +4640,35 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "Couldn't allocate second buffer"
 #~ msgstr "Kan tweede buffer niet alloceren"
 
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "Crash naar de HardFault_Handler."
+
 #~ msgid "DigitalInOut not supported on given pin"
 #~ msgstr "DigitalInOut niet ondersteund door gegeven pin"
+
+#~ msgid "Expected a %q"
+#~ msgstr "Verwacht een %q"
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Verwachtte een Characteristic"
+
+#~ msgid "Expected a DigitalInOut"
+#~ msgstr "Verwachtte een DigitalInOut"
+
+#~ msgid "Expected a Service"
+#~ msgstr "Verwachtte een Service"
+
+#~ msgid "Expected a UART"
+#~ msgstr "Verwachtte een UART"
+
+#~ msgid "Expected a UUID"
+#~ msgstr "Verwachtte een UUID"
+
+#~ msgid "Expected an Address"
+#~ msgstr "Verwachtte een adres"
+
+#~ msgid "Expected an alarm"
+#~ msgstr "Verwachtte een alarm"
 
 #, c-format
 #~ msgid "Expected tuple of length %d, got %d"
@@ -4872,15 +4681,54 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "Failed to allocate RX buffer of %d bytes"
 #~ msgstr "Mislukt een RX buffer van %d bytes te alloceren"
 
+#~ msgid "Failed to init wifi"
+#~ msgstr "Kon WiFi niet initialiseren"
+
+#~ msgid "Firmware image is invalid"
+#~ msgstr "Firmware image is ongeldig"
+
 #, c-format
 #~ msgid "Framebuffer requires %d bytes"
 #~ msgstr "Framebuffer benodigd %d bytes"
+
+#~ msgid "Frequency captured is above capability. Capture Paused."
+#~ msgstr ""
+#~ "De vastgelegde frequentie is boven de capaciteit. Vastleggen gepauzeerd."
+
+#~ msgid "Group full"
+#~ msgstr "Groep is vol"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Hardware bezig, probeer alternatieve pinnen"
 
 #~ msgid "Hostname must be between 1 and 253 characters"
 #~ msgstr "Hostnaam moet tussen 1 en 253 karakters zijn"
 
 #~ msgid "I2C Init Error"
 #~ msgstr "I2C Init Fout"
+
+#~ msgid "I2C operation not supported"
+#~ msgstr "I2C actie niet ondersteund"
+
+#~ msgid "I2SOut not available"
+#~ msgstr "I2SOut is niet beschikbaar"
+
+#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
+#~ msgstr "IO's 0, 2 en 4 ondersteunen geen interne pullup in slaapstand"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IV %d bytes lang zijn"
+
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "Incompatibel .mpy bestand. Update alle .mpy bestanden. Zie http://adafru."
+#~ "it/mpy-update voor meer informatie."
+
+#~ msgid "Initialization failed due to lack of memory"
+#~ msgstr "De initialisatie is mislukt vanwege een gebrek aan geheugen"
 
 #~ msgid "Invalid %q pin selection"
 #~ msgstr "Ongeldige %q pin selectie"
@@ -4896,6 +4744,12 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 
 #~ msgid "Invalid Pin"
 #~ msgstr "Ongeldige Pin"
+
+#~ msgid "Invalid SPI pin selection"
+#~ msgstr "Ongeldige SPI pin selectie"
+
+#~ msgid "Invalid UART pin selection"
+#~ msgstr "Ongeldige UART pin selectie"
 
 #~ msgid "Invalid buffer size"
 #~ msgstr "Ongeldige buffer grootte"
@@ -4915,6 +4769,15 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "Invalid file"
 #~ msgstr "Ongeldig bestand"
 
+#~ msgid "Invalid frequency"
+#~ msgstr "Onjuiste frequentie"
+
+#~ msgid "Invalid frequency supplied"
+#~ msgstr "Ongeldige frequentie opgegeven"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "Ongeldig geheugen adres."
+
 #~ msgid "Invalid number of bits"
 #~ msgstr "Ongeldig aantal bits"
 
@@ -4929,6 +4792,12 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 
 #~ msgid "Invalid pin for right channel"
 #~ msgstr "Ongeldige pin voor rechter kanaal"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Ongeldige pinnen"
+
+#~ msgid "Invalid pins for PWMOut"
+#~ msgstr "Ongeldige pinnen voor PWMOut"
 
 #~ msgid "Invalid polarity"
 #~ msgstr "Ongeldige polariteit"
@@ -4960,14 +4829,55 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "Layer must be a Group or TileGrid subclass."
 #~ msgstr "Laag moet een Groep of TileGrid subklasse zijn."
 
+#~ msgid "Length must be an int"
+#~ msgstr "Lengte moet een int zijn"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Lengte moet niet negatief zijn"
+
 #~ msgid "MISO pin init failed."
 #~ msgstr "MISO pin init mislukt."
 
 #~ msgid "MOSI pin init failed."
 #~ msgstr "MOSI pin init mislukt."
 
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "Maximale x waarde indien gespiegeld is %d"
+
 #~ msgid "Messages limited to 8 bytes"
 #~ msgstr "Berichten zijn beperkt tot 8 bytes"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgstr "MicroPython NLR sprong mislukt. Waarschijnlijk geheugen corruptie."
+
+#~ msgid "MicroPython fatal error."
+#~ msgstr "MicroPython fatale fout."
+
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "Ontbrekende MISO of MOSI Pin"
+
+#~ msgid "Must provide SCK pin"
+#~ msgstr "SCK pin moet opgegeven worden"
+
+#~ msgid "Negative step not supported"
+#~ msgstr "Negatieve stappen niet ondersteund"
+
+#, c-format
+#~ msgid "No I2C device at address: %x"
+#~ msgstr "Geen I2C-apparaat op adres: %x"
+
+#~ msgid "No MISO Pin"
+#~ msgstr "Geen MISO pin"
+
+#~ msgid "No MOSI Pin"
+#~ msgstr "Geen MOSI pin"
+
+#~ msgid "No RX pin"
+#~ msgstr "Geen RX pin"
+
+#~ msgid "No TX pin"
+#~ msgstr "Geen TX pin"
 
 #~ msgid "No hardware support on clk pin"
 #~ msgstr "Geen hardware ondersteuning beschikbaar op clk pin"
@@ -4975,181 +4885,55 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "No hardware support on pin"
 #~ msgstr "Geen hardware ondersteuning op pin"
 
+#~ msgid "No key was specified"
+#~ msgstr "Een sleutel was niet gespecificeerd"
+
+#~ msgid "No more channels available"
+#~ msgstr "Geen kanalen meer beschikbaar"
+
+#~ msgid "No more timers available"
+#~ msgstr "Geen timers meer beschikbaar"
+
+#~ msgid "No more timers available on this pin."
+#~ msgstr "Geen timers meer beschikbaar op deze pin."
+
+#~ msgid "Nordic Soft Device failure assertion."
+#~ msgstr "Nordic Soft Device assertion mislukt."
+
+#~ msgid "Not running saved code.\n"
+#~ msgstr "Opgeslagen code wordt niet uitgevoerd.\n"
+
+#~ msgid "Not settable"
+#~ msgstr "Niet instelbaar"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Alleen 8 of 16 bit mono met "
+
+#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
+#~ msgstr "Alleen IPv4 SOCK_STREAM sockets worden ondersteund"
+
+#~ msgid "Only raw int supported for ip"
+#~ msgstr "Alleen raw int ondersteund voor IP"
+
 #~ msgid ""
 #~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
 #~ msgstr ""
 #~ "PWM duty_cycle moet tussen 0 en 65535 inclusief zijn (16 bit resolutie)"
 
-#~ msgid "Pin does not have ADC capabilities"
-#~ msgstr "Pin heeft geen ADC mogelijkheden"
-
-#~ msgid "RTC calibration is not supported on this board"
-#~ msgstr "RTC calibratie niet ondersteund door dit board"
-
-#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
-#~ msgstr "RTS/CTS/RS485 Nog niet ondersteund door dit apparaat"
-
-#~ msgid "SPI Init Error"
-#~ msgstr "SPI Init Fout"
-
-#~ msgid "SPI Re-initialization error"
-#~ msgstr "SPI Herinitialisatie Fout"
-
-#~ msgid "Sample rate must be positive"
-#~ msgstr "Sample rate moet positief zijn"
-
-#, c-format
-#~ msgid "Sample rate too high. It must be less than %d"
-#~ msgstr "Sample rate is te hoog. Moet minder dan %d zijn"
-
-#~ msgid "Stack size must be at least 256"
-#~ msgstr "Stack grootte moet op zijn minst 256 zijn"
-
-#~ msgid "Tile value out of bounds"
-#~ msgstr "Tile waarde buiten bereik"
-
-#~ msgid "UART Buffer allocation error"
-#~ msgstr "UART Buffer allocatie fout"
-
-#~ msgid "UART De-init error"
-#~ msgstr "UART De-init fout"
-
-#~ msgid "UART Init Error"
-#~ msgstr "UART Init Fout"
-
-#~ msgid "UART Re-init error"
-#~ msgstr "UART Re-init Fout"
-
-#~ msgid "UART write error"
-#~ msgstr "UART schrijf fout"
-
-#~ msgid "Unsupported baudrate"
-#~ msgstr "Niet-ondersteunde baudsnelheid"
-
-#~ msgid "WiFi password must be between 8 and 63 characters"
-#~ msgstr "WiFi wachtwoord moet tussen 8 en 63 karakters bevatten"
-
-#~ msgid "bytes > 8 bits not supported"
-#~ msgstr "butes > 8 niet ondersteund"
-
-#~ msgid "calibration value out of range +/-127"
-#~ msgstr "calibration waarde buiten bereik +/-127"
-
-#~ msgid "circle can only be registered in one parent"
-#~ msgstr ""
-#~ "cirkel kan slechts bij één object van een hoger niveau worden "
-#~ "geregistreerd"
-
-#~ msgid "polygon can only be registered in one parent"
-#~ msgstr ""
-#~ "polygoon kan slechts bij één object van een hoger niveau worden "
-#~ "geregistreerd"
-
-#~ msgid "stop must be 1 or 2"
-#~ msgstr "stop moet 1 of 2 zijn"
-
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "timeout moet groter dan 0.0 zijn"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "Niet-ondersteunde operatie"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "Helderheid moet tussen de 0 en 255 liggen"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "kan geen relatieve import uitvoeren"
-
-#, c-format
-#~ msgid "No I2C device at address: %x"
-#~ msgstr "Geen I2C-apparaat op adres: %x"
-
-#~ msgid "Unsupported pull value."
-#~ msgstr "Niet-ondersteunde pull-waarde."
-
-#, c-format
-#~ msgid ""
-#~ "Welcome to Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Please visit learn.adafruit.com/category/circuitpython for project "
-#~ "guides.\n"
-#~ "\n"
-#~ "To list built-in modules please do `help(\"modules\")`.\n"
-#~ msgstr ""
-#~ "Welkom bij Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Bezoek learn.adafruit.com/category/circuitpython voor projectgidsen.\n"
-#~ "\n"
-#~ "Voor een lijst van ingebouwde modules, gebruik `help(\"modules\")`.\n"
-
-#~ msgid "integer required"
-#~ msgstr "integer vereist"
-
-#~ msgid "abort() called"
-#~ msgstr "abort() aangeroepen"
-
-#~ msgid "f-string expression part cannot include a '#'"
-#~ msgstr "f-string expressie deel kan geen '#' bevatten"
-
-#~ msgid "f-string expression part cannot include a backslash"
-#~ msgstr "f-string expressie deel kan geen backslash bevatten"
-
-#~ msgid "f-string: empty expression not allowed"
-#~ msgstr "f-string: lege expressie niet toegestaan"
-
-#~ msgid "f-string: expecting '}'"
-#~ msgstr "f-string: verwacht '}'"
-
-#~ msgid "f-string: single '}' is not allowed"
-#~ msgstr "f-string: enkele '}' is niet toegestaan"
-
-#~ msgid "invalid arguments"
-#~ msgstr "ongeldige argumenten"
-
-#~ msgid "raw f-strings are not implemented"
-#~ msgstr "ruwe f-strings zijn niet geïmplementeerd"
-
-#~ msgid "unindent does not match any outer indentation level"
-#~ msgstr "inspringing komt niet overeen met hoger gelegen inspringingsniveaus"
-
-#~ msgid "%q list must be a list"
-#~ msgstr "%q lijst moet een lijst zijn"
-
-#~ msgid "Column entry must be digitalio.DigitalInOut"
-#~ msgstr "Column entry moet digitalio.DigitalInOut zijn"
-
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Verwachtte een Characteristic"
-
-#~ msgid "Expected a DigitalInOut"
-#~ msgstr "Verwachtte een DigitalInOut"
-
-#~ msgid "Expected a Service"
-#~ msgstr "Verwachtte een Service"
-
-#~ msgid "Expected a UART"
-#~ msgstr "Verwachtte een UART"
-
-#~ msgid "Expected a UUID"
-#~ msgstr "Verwachtte een UUID"
-
-#~ msgid "Expected an Address"
-#~ msgstr "Verwachtte een adres"
-
-#~ msgid "Row entry must be digitalio.DigitalInOut"
-#~ msgstr "Rij invoeging moet digitalio.DigitalInOut zijn"
-
-#~ msgid "buttons must be digitalio.DigitalInOut"
-#~ msgstr "buttons moeten digitalio.DigitalInOut zijn"
-
-#~ msgid "Invalid frequency"
-#~ msgstr "Onjuiste frequentie"
-
 #~ msgid "ParallelBus not yet supported"
 #~ msgstr "ParallelBus nog niet ondersteund"
 
-#~ msgid "no available NIC"
-#~ msgstr "geen netwerkadapter (NIC) beschikbaar"
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "Pin heeft geen ADC mogelijkheden"
+
+#~ msgid "Pin number already reserved by EXTI"
+#~ msgstr "Pin nummer al gereserveerd door EXTI"
+
+#~ msgid "PinAlarm not yet implemented"
+#~ msgstr "PinAlarm nog niet geïmplementeerd"
+
+#~ msgid "Pop from an empty Ps2 buffer"
+#~ msgstr "Pop van een lege Ps2 buffer"
 
 #~ msgid ""
 #~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
@@ -5165,31 +4949,76 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ "Poort accepteert geen pin of frequentie. Stel een PWMOut Carrier samen en "
 #~ "geef die op"
 
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "Buffer is te groot en niet in staat te alloceren"
-
-#~ msgid "interp is defined for 1D arrays of equal length"
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
 #~ msgstr ""
-#~ "interp is gedefinieerd voor eendimensionale arrays van gelijke lengte"
+#~ "Druk een willekeurige toets om de REPL te starten. Gebruik CTRL+D om te "
+#~ "herstarten."
 
-#~ msgid "wrong operand type"
-#~ msgstr "verkeerd operandtype"
-
-#~ msgid "Only raw int supported for ip"
-#~ msgstr "Alleen raw int ondersteund voor IP"
-
-#~ msgid ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
+#~ msgid "Pretending to deep sleep until alarm, any key or file write.\n"
 #~ msgstr ""
-#~ "CircuitPython is in veilige modus omdat de rest knop werd ingedrukt "
-#~ "tijdens het opstarten. Druk nogmaals om veilige modus te verlaten\n"
+#~ "Simuleert diepe slaapstand tot alarm, een willekeurige toets of schrijven "
+#~ "naar bestand.\n"
 
-#~ msgid "Not running saved code.\n"
-#~ msgstr "Opgeslagen code wordt niet uitgevoerd.\n"
+#~ msgid "PulseIn not supported on this chip"
+#~ msgstr "PusleIn niet ondersteund door deze chip"
+
+#~ msgid "PulseOut not supported on this chip"
+#~ msgstr "PulseOut niet ondersteund door deze chip"
+
+#~ msgid "RTC calibration is not supported on this board"
+#~ msgstr "RTC calibratie niet ondersteund door dit board"
+
+#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
+#~ msgstr "RTS/CTS/RS485 Nog niet ondersteund door dit apparaat"
+
+#~ msgid "Read-only object"
+#~ msgstr "Alleen-lezen object"
+
+#~ msgid "Row entry must be digitalio.DigitalInOut"
+#~ msgstr "Rij invoeging moet digitalio.DigitalInOut zijn"
 
 #~ msgid "Running in safe mode! "
 #~ msgstr "Veilige modus wordt uitgevoerd! "
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Draaiende in veilige modus! Auto-herlaad is uit.\n"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "SDA of SCL hebben een pullup nodig"
+
+#~ msgid "SPI Init Error"
+#~ msgstr "SPI Init Fout"
+
+#~ msgid "SPI Re-initialization error"
+#~ msgstr "SPI Herinitialisatie Fout"
+
+#~ msgid "Sample rate must be positive"
+#~ msgstr "Sample rate moet positief zijn"
+
+#, c-format
+#~ msgid "Sample rate too high. It must be less than %d"
+#~ msgstr "Sample rate is te hoog. Moet minder dan %d zijn"
+
+#~ msgid "Scan already in progess. Stop with stop_scan."
+#~ msgstr "Scan wordt al uitvoerd. Stop met stop_scan."
+
+#~ msgid "Selected CTS pin not valid"
+#~ msgstr "Geselecteerde CTS pin niet geldig"
+
+#~ msgid "Selected RTS pin not valid"
+#~ msgstr "Geselecteerde RTS pin niet geldig"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Splitting met sub-captures"
+
+#~ msgid "Stack size must be at least 256"
+#~ msgstr "Stack grootte moet op zijn minst 256 zijn"
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "Stream mist readinto() of write() methode."
+
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "Geef op zijn minst 1 UART pin op"
 
 #~ msgid ""
 #~ "The CircuitPython heap was corrupted because the stack was too small.\n"
@@ -5215,11 +5044,39 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ "voldoende vermogen heeft voor het hele systeem en druk reset (na "
 #~ "uitwerpen van CIRCUITPY).\n"
 
-#~ msgid "You are in safe mode: something unanticipated happened.\n"
-#~ msgstr "Je bent in de veilige modus: er is iets onverwachts gebeurd.\n"
+#~ msgid "Tile value out of bounds"
+#~ msgstr "Tile waarde buiten bereik"
 
-#~ msgid "Pin number already reserved by EXTI"
-#~ msgstr "Pin nummer al gereserveerd door EXTI"
+#~ msgid ""
+#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
+#~ "program"
+#~ msgstr ""
+#~ "Timer is gereserveerd voor intern gebruik - wijs PWM pins eerder in het "
+#~ "programma toe"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Om te beëindigen, reset het bord zonder "
+
+#~ msgid "Too many display busses"
+#~ msgstr "Teveel beeldscherm bussen"
+
+#~ msgid "Total data to write is larger than outgoing_packet_length"
+#~ msgstr "Totale data om te schrijven is groter dan outgoing_packet_length"
+
+#~ msgid "UART Buffer allocation error"
+#~ msgstr "UART Buffer allocatie fout"
+
+#~ msgid "UART De-init error"
+#~ msgstr "UART De-init fout"
+
+#~ msgid "UART Init Error"
+#~ msgstr "UART Init Fout"
+
+#~ msgid "UART Re-init error"
+#~ msgstr "UART Re-init Fout"
+
+#~ msgid "UART write error"
+#~ msgstr "UART schrijf fout"
 
 #~ msgid "USB Busy"
 #~ msgstr "USB Bezet"
@@ -5227,44 +5084,307 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "USB Error"
 #~ msgstr "USB Fout"
 
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "%q indices moeten integers zijn, geen %q"
+#~ msgid "Unknown failure"
+#~ msgstr "Onbekende fout"
 
-#~ msgid "'%q' object cannot assign attribute '%q'"
-#~ msgstr "'%q' object kan attribuut ' %q' niet toewijzen"
+#~ msgid "Unknown soft device error: %04x"
+#~ msgstr "Onbekende soft device fout: %04x"
 
-#~ msgid "'%q' object does not support item assignment"
-#~ msgstr "'%q' object ondersteunt toewijzing van items niet"
+#~ msgid "Unsupported baudrate"
+#~ msgstr "Niet-ondersteunde baudsnelheid"
 
-#~ msgid "'%q' object does not support item deletion"
-#~ msgstr "'%q' object ondersteunt verwijderen van items niet"
+#~ msgid "Unsupported operation"
+#~ msgstr "Niet-ondersteunde operatie"
 
-#~ msgid "'%q' object has no attribute '%q'"
-#~ msgstr "'%q' object heeft geen attribuut '%q'"
+#~ msgid "Unsupported pull value."
+#~ msgstr "Niet-ondersteunde pull-waarde."
 
-#~ msgid "'%q' object is not subscriptable"
-#~ msgstr "kan niet abonneren op '%q' object"
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr "Viper-functies ondersteunen momenteel niet meer dan 4 argumenten"
 
-#~ msgid "'%s' integer %d is not within range %d..%d"
-#~ msgstr "'%s' integer %d is niet in bereik %d..%d"
+#~ msgid "WatchDogTimer is not currently running"
+#~ msgstr "WatchDogTimer is momenteel niet actief"
 
-#~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
-#~ msgstr "'%s' integer 0x%x past niet in mask 0x%x"
+#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+#~ msgstr ""
+#~ "WatchDogTimer.mode kan niet worden gewijzigd zodra de modus is ingesteld "
+#~ "op WatchDogMode.RESET"
 
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "Kan niet ondubbelzinning sizeof scalar verkrijgen"
+#~ msgid "WatchDogTimer.timeout must be greater than 0"
+#~ msgstr "WatchDogTimer.timeout moet groter dan 0 zijn"
 
-#~ msgid "Length must be an int"
-#~ msgstr "Lengte moet een int zijn"
+#~ msgid "Watchdog timer expired."
+#~ msgstr "Watchdog-timer verstreken."
 
-#~ msgid "Length must be non-negative"
-#~ msgstr "Lengte moet niet negatief zijn"
+#, c-format
+#~ msgid ""
+#~ "Welcome to Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Please visit learn.adafruit.com/category/circuitpython for project "
+#~ "guides.\n"
+#~ "\n"
+#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ msgstr ""
+#~ "Welkom bij Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Bezoek learn.adafruit.com/category/circuitpython voor projectgidsen.\n"
+#~ "\n"
+#~ "Voor een lijst van ingebouwde modules, gebruik `help(\"modules\")`.\n"
+
+#~ msgid "WiFi password must be between 8 and 63 characters"
+#~ msgstr "WiFi wachtwoord moet tussen 8 en 63 karakters bevatten"
+
+#~ msgid "You are in safe mode: something unanticipated happened.\n"
+#~ msgstr "Je bent in de veilige modus: er is iets onverwachts gebeurd.\n"
+
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "Je hebt aangeven de veilige modus te starten door "
+
+#~ msgid "__init__() should return None, not '%q'"
+#~ msgstr "__init__() moet None teruggeven, niet '%q'"
+
+#~ msgid "abort() called"
+#~ msgstr "abort() aangeroepen"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "adres %08x is niet afgestemd op %d bytes"
+
+#~ msgid "address out of bounds"
+#~ msgstr "adres buiten bereik"
+
+#~ msgid "arctan2 is implemented for scalars and ndarrays only"
+#~ msgstr "arctan2 is alleen geïmplementeerd voor scalars en ndarrays"
+
+#~ msgid "argument must be ndarray"
+#~ msgstr "argument moet ndarray zijn"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "attributen nog niet ondersteund"
+
+#~ msgid "axis must be -1, 0, None, or 1"
+#~ msgstr "as moet -1, 0, None, of 1 zijn"
+
+#~ msgid "axis must be -1, 0, or 1"
+#~ msgstr "as moet -1, 0, of 1 zijn"
+
+#~ msgid "axis must be None, 0, or 1"
+#~ msgstr "as moet None, 0, of 1 zijn"
+
+#~ msgid "bits must be 7, 8 or 9"
+#~ msgstr "bits moet 7, 8, of 9 zijn"
+
+#~ msgid "bits must be 8"
+#~ msgstr "bits moet 8 zijn"
+
+#~ msgid "buffer must be a bytes-like object"
+#~ msgstr "buffer moet een byte-achtig object zijn"
+
+#~ msgid "buffers must be the same length"
+#~ msgstr "buffers moeten dezelfde lengte hebben"
+
+#~ msgid "buttons must be digitalio.DigitalInOut"
+#~ msgstr "buttons moeten digitalio.DigitalInOut zijn"
+
+#~ msgid "byte code not implemented"
+#~ msgstr "byte code niet geïmplementeerd"
+
+#~ msgid "byteorder is not a string"
+#~ msgstr "byteorder is geen string"
+
+#~ msgid "bytes > 8 bits not supported"
+#~ msgstr "butes > 8 niet ondersteund"
+
+#~ msgid "calibration value out of range +/-127"
+#~ msgstr "calibration waarde buiten bereik +/-127"
+
+#~ msgid "can only save bytecode"
+#~ msgstr "kan alleen byte-code opslaan"
+
+#~ msgid "can't convert address to int"
+#~ msgstr "kan adres niet omzetten naar int"
+
+#~ msgid "can't convert to %q"
+#~ msgstr "kan niet naar %q converteren"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr "kan geen afgekapte deling doen van een comlex nummer"
+
+#~ msgid "can't have multiple **x"
+#~ msgstr "kan niet meerdere **x hebben"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "kan geen meerdere *x hebben"
+
+#~ msgid "can't pend throw to just-started generator"
+#~ msgstr "kan throw niet aan net gestartte generator toevoegen"
+
+#~ msgid "cannot import name %q"
+#~ msgstr "kan naam %q niet importeren"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "kan geen relatieve import uitvoeren"
+
+#~ msgid "cannot reshape array (incompatible input/output shape)"
+#~ msgstr "kan de array niet hervormen (niet verenigbare input/output vorm)"
+
+#~ msgid "circle can only be registered in one parent"
+#~ msgstr ""
+#~ "cirkel kan slechts bij één object van een hoger niveau worden "
+#~ "geregistreerd"
+
+#~ msgid "color should be an int"
+#~ msgstr "kleur moet een int zijn"
+
+#~ msgid "complex division by zero"
+#~ msgstr "complexe deling door 0"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "constant moet een integer zijn"
+
+#~ msgid "could not broadast input array from shape"
+#~ msgstr "kon de invoerarray niet vanuit vorm uitzenden"
+
+#~ msgid "ddof must be smaller than length of data set"
+#~ msgstr "ddof kleiner dan de lengte van de data set"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr ""
+#~ "destination_lengte moest een int groter dan of gelijk zijn aan 0 zijn"
+
+#~ msgid "end_x should be an int"
+#~ msgstr "end_x moet een int zijn"
+
+#~ msgid "expected '%q' but got '%q'"
+#~ msgstr "verwachtte '%q' maar ontving '%q'"
+
+#~ msgid "expected '%q' or '%q' but got '%q'"
+#~ msgstr "verwachtte '%q' of '%q' maar ontving '%q'"
+
+#~ msgid "f-string expression part cannot include a '#'"
+#~ msgstr "f-string expressie deel kan geen '#' bevatten"
+
+#~ msgid "f-string expression part cannot include a backslash"
+#~ msgstr "f-string expressie deel kan geen backslash bevatten"
+
+#~ msgid "f-string: empty expression not allowed"
+#~ msgstr "f-string: lege expressie niet toegestaan"
+
+#~ msgid "f-string: expecting '}'"
+#~ msgstr "f-string: verwacht '}'"
+
+#~ msgid "f-string: single '}' is not allowed"
+#~ msgstr "f-string: enkele '}' is niet toegestaan"
+
+#~ msgid "first argument must be an iterable"
+#~ msgstr "eerst argument moet een iterabel zijn"
+
+#~ msgid "firstbit must be MSB"
+#~ msgstr "het eerste bit moet het MSB zijn"
+
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "functie accepteert geen keyword argumenten"
+
+#~ msgid "function is implemented for scalars and ndarrays only"
+#~ msgstr "funtie is alleen geïmplementeerd voor scalars en ndarrays"
+
+#~ msgid "input and output shapes are not compatible"
+#~ msgstr "in- en uitvoervormen zijn niet compatibel"
+
+#~ msgid "input argument must be an integer or a 2-tuple"
+#~ msgstr "invoerargument moet een integer of 2-tuple zijn"
+
+#~ msgid "input must be a tensor of rank 2"
+#~ msgstr "invoer moet een tensor van rang 2 zijn"
+
+#~ msgid "inputs are not iterable"
+#~ msgstr "invoer is niet itereerbaar"
+
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr "int() argument 2 moet >=2 en <= 36 zijn"
+
+#~ msgid "integer required"
+#~ msgstr "integer vereist"
+
+#~ msgid "interp is defined for 1D arrays of equal length"
+#~ msgstr ""
+#~ "interp is gedefinieerd voor eendimensionale arrays van gelijke lengte"
+
+#~ msgid "invalid I2C peripheral"
+#~ msgstr "onjuist I2C randapparaat"
+
+#~ msgid "invalid SPI peripheral"
+#~ msgstr "onjuist SPI randapparaat"
+
+#~ msgid "invalid arguments"
+#~ msgstr "ongeldige argumenten"
+
+#~ msgid "invalid dupterm index"
+#~ msgstr "ongeldige dupterm index"
+
+#~ msgid "invalid format"
+#~ msgstr "ongeldig formaat"
+
+#~ msgid "io must be rtc io"
+#~ msgstr "io moet rtc io zijn"
+
+#~ msgid "iterables are not of the same length"
+#~ msgstr "itereerbare objecten hebben niet dezelfde lengte"
+
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr ""
+#~ "trefwoord argument(en) zijn niet geïmplementeerd, gebruik normale "
+#~ "argumenten"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "trefwoorden moeten van type string zijn"
+
+#~ msgid "length argument not allowed for this type"
+#~ msgstr "voor dit type is length niet toegestaan"
+
+#~ msgid "long int not supported in this build"
+#~ msgstr "long int wordt niet ondersteund in deze build"
+
+#~ msgid "matrix dimensions do not match"
+#~ msgstr "matrix afmetingen komen niet overeen"
+
+#~ msgid "max_length must be > 0"
+#~ msgstr "max_length moet >0 zijn"
+
+#~ msgid "maximum number of dimensions is 4"
+#~ msgstr "maximaal aantal dimensies is 4"
+
+#~ msgid "must specify all of sck/mosi/miso"
+#~ msgstr "sck/mosi/miso moeten alle gespecificeerd worden"
+
+#~ msgid "n must be between 0, and 9"
+#~ msgstr "n moet tussen 0 en 9 liggen"
 
 #~ msgid "name reused for argument"
 #~ msgstr "naam hergebruikt voor argument"
 
+#~ msgid "no available NIC"
+#~ msgstr "geen netwerkadapter (NIC) beschikbaar"
+
+#~ msgid "no reset pin available"
+#~ msgstr "geen reset pin beschikbaar"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "niet-trefwoord argument na */**"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "niet-trefwoord argument na trefwoord argument"
+
+#~ msgid "norm is defined for 1D and 2D arrays"
+#~ msgstr "norm is gedefinieerd voor 1D en 2D arrays"
+
+#~ msgid "number of arguments must be 2, or 3"
+#~ msgstr "aantal argumenten moet 2 of 3 zijn"
+
 #~ msgid "object '%q' is not a tuple or list"
 #~ msgstr "object '%q' is geen tuple of lijst"
+
+#~ msgid "object '%s' is not a tuple or list"
+#~ msgstr "object '%s' is geen tuple of lijst"
 
 #~ msgid "object does not support item assignment"
 #~ msgstr "object ondersteund toewijzen van elementen niet"
@@ -5278,277 +5398,32 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "object of type '%q' has no len()"
 #~ msgstr "object van type '%q' heeft geen len()"
 
-#~ msgid "struct: cannot index"
-#~ msgstr "struct: kan niet indexeren"
-
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "Kan '/' niet hermounten als USB actief is."
-
-#~ msgid "byte code not implemented"
-#~ msgstr "byte code niet geïmplementeerd"
-
-#~ msgid "can't pend throw to just-started generator"
-#~ msgstr "kan throw niet aan net gestartte generator toevoegen"
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "ongeldige dupterm index"
-
-#~ msgid "schedule stack full"
-#~ msgstr "schedule stack is vol"
-
-#~ msgid "Corrupt raw code"
-#~ msgstr "Corrupt raw code"
-
-#~ msgid "can only save bytecode"
-#~ msgstr "kan alleen byte-code opslaan"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr "Viper-functies ondersteunen momenteel niet meer dan 4 argumenten"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "adres %08x is niet afgestemd op %d bytes"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "functie accepteert geen keyword argumenten"
-
-#~ msgid "parameter annotation must be an identifier"
-#~ msgstr "parameter annotatie moet een identifier zijn"
-
-#~ msgid "Total data to write is larger than outgoing_packet_length"
-#~ msgstr "Totale data om te schrijven is groter dan outgoing_packet_length"
-
-#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
-#~ msgstr "IO's 0, 2 en 4 ondersteunen geen interne pullup in slaapstand"
-
-#~ msgid "buffer must be a bytes-like object"
-#~ msgstr "buffer moet een byte-achtig object zijn"
-
-#~ msgid "io must be rtc io"
-#~ msgstr "io moet rtc io zijn"
-
-#~ msgid "trigger level must be 0 or 1"
-#~ msgstr "triggerniveau moet 0 of 1 zijn"
-
-#~ msgid "wakeup conflict"
-#~ msgstr "conflict bij ontwaken"
-
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr "heap allocatie geprobeerd terwijl MicroPython VM niet draait."
-
-#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
-#~ msgstr "MicroPython NLR sprong mislukt. Waarschijnlijk geheugen corruptie."
-
-#~ msgid "MicroPython fatal error."
-#~ msgstr "MicroPython fatale fout."
-
-#~ msgid "argument must be ndarray"
-#~ msgstr "argument moet ndarray zijn"
-
-#~ msgid "matrix dimensions do not match"
-#~ msgstr "matrix afmetingen komen niet overeen"
-
-#~ msgid "norm is defined for 1D and 2D arrays"
-#~ msgstr "norm is gedefinieerd voor 1D en 2D arrays"
-
-#~ msgid "vectors must have same lengths"
-#~ msgstr "vectoren moeten van gelijke lengte zijn"
-
-#~ msgid "Nordic Soft Device failure assertion."
-#~ msgstr "Nordic Soft Device assertion mislukt."
-
-#~ msgid "Unknown soft device error: %04x"
-#~ msgstr "Onbekende soft device fout: %04x"
-
-#~ msgid "first argument must be an iterable"
-#~ msgstr "eerst argument moet een iterabel zijn"
-
-#~ msgid "iterables are not of the same length"
-#~ msgstr "itereerbare objecten hebben niet dezelfde lengte"
-
-#~ msgid "Selected CTS pin not valid"
-#~ msgstr "Geselecteerde CTS pin niet geldig"
-
-#~ msgid "Selected RTS pin not valid"
-#~ msgstr "Geselecteerde RTS pin niet geldig"
-
-#~ msgid "Could not initialize channel"
-#~ msgstr "Kan kanaal niet initialiseren"
-
-#~ msgid "Could not initialize timer"
-#~ msgstr "Kan timer niet initialiseren"
-
-#~ msgid "Invalid frequency supplied"
-#~ msgstr "Ongeldige frequentie opgegeven"
-
-#~ msgid "Invalid pins for PWMOut"
-#~ msgstr "Ongeldige pinnen voor PWMOut"
-
-#~ msgid "No more channels available"
-#~ msgstr "Geen kanalen meer beschikbaar"
-
-#~ msgid "No more timers available"
-#~ msgstr "Geen timers meer beschikbaar"
-
-#~ msgid "No more timers available on this pin."
-#~ msgstr "Geen timers meer beschikbaar op deze pin."
-
-#~ msgid ""
-#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
-#~ "program"
-#~ msgstr ""
-#~ "Timer is gereserveerd voor intern gebruik - wijs PWM pins eerder in het "
-#~ "programma toe"
-
-#~ msgid "Group full"
-#~ msgstr "Groep is vol"
-
-#~ msgid "bits must be 7, 8 or 9"
-#~ msgstr "bits moet 7, 8, of 9 zijn"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "SDA of SCL hebben een pullup nodig"
-
-#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
-#~ msgstr "%d adres pins en %d RGB pins geven een hoogte van %d aan, niet %d"
-
-#~ msgid "Unknown failure"
-#~ msgstr "Onbekende fout"
-
-#~ msgid "input argument must be an integer or a 2-tuple"
-#~ msgstr "invoerargument moet een integer of 2-tuple zijn"
+#~ msgid "offset out of bounds"
+#~ msgstr "offset buiten bereik"
 
 #~ msgid "operation is not implemented for flattened array"
 #~ msgstr "operatie is niet geïmplementeerd voor vlakke array"
 
-#~ msgid "tuple index out of range"
-#~ msgstr "tuple index buiten bereik"
+#~ msgid "out of range of source"
+#~ msgstr "buiten bereik van bron"
 
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
+#~ msgid "palette_index should be an int"
+#~ msgstr "palette_index moet een int zijn"
+
+#~ msgid "parameter annotation must be an identifier"
+#~ msgstr "parameter annotatie moet een identifier zijn"
+
+#~ msgid "pixel value requires too many bits"
+#~ msgstr "pixel waarde vereist te veel bits"
+
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 #~ msgstr ""
-#~ "\n"
-#~ "Code is uitgevoerd. Wachten op herladen.\n"
+#~ "pixel_shader moet displayio.Palette of displayio.ColorConverter zijn"
 
-#~ msgid "PinAlarm not yet implemented"
-#~ msgstr "PinAlarm nog niet geïmplementeerd"
-
-#~ msgid "Pretending to deep sleep until alarm, any key or file write.\n"
+#~ msgid "polygon can only be registered in one parent"
 #~ msgstr ""
-#~ "Simuleert diepe slaapstand tot alarm, een willekeurige toets of schrijven "
-#~ "naar bestand.\n"
-
-#~ msgid "Frequency captured is above capability. Capture Paused."
-#~ msgstr ""
-#~ "De vastgelegde frequentie is boven de capaciteit. Vastleggen gepauzeerd."
-
-#~ msgid "max_length must be > 0"
-#~ msgstr "max_length moet >0 zijn"
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr ""
-#~ "Druk een willekeurige toets om de REPL te starten. Gebruik CTRL+D om te "
-#~ "herstarten."
-
-#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
-#~ msgstr "Alleen IPv4 SOCK_STREAM sockets worden ondersteund"
-
-#~ msgid "arctan2 is implemented for scalars and ndarrays only"
-#~ msgstr "arctan2 is alleen geïmplementeerd voor scalars en ndarrays"
-
-#~ msgid "axis must be -1, 0, None, or 1"
-#~ msgstr "as moet -1, 0, None, of 1 zijn"
-
-#~ msgid "axis must be -1, 0, or 1"
-#~ msgstr "as moet -1, 0, of 1 zijn"
-
-#~ msgid "axis must be None, 0, or 1"
-#~ msgstr "as moet None, 0, of 1 zijn"
-
-#~ msgid "cannot reshape array (incompatible input/output shape)"
-#~ msgstr "kan de array niet hervormen (niet verenigbare input/output vorm)"
-
-#~ msgid "could not broadast input array from shape"
-#~ msgstr "kon de invoerarray niet vanuit vorm uitzenden"
-
-#~ msgid "ddof must be smaller than length of data set"
-#~ msgstr "ddof kleiner dan de lengte van de data set"
-
-#~ msgid "function is implemented for scalars and ndarrays only"
-#~ msgstr "funtie is alleen geïmplementeerd voor scalars en ndarrays"
-
-#~ msgid "n must be between 0, and 9"
-#~ msgstr "n moet tussen 0 en 9 liggen"
-
-#~ msgid "number of arguments must be 2, or 3"
-#~ msgstr "aantal argumenten moet 2 of 3 zijn"
-
-#~ msgid "right hand side must be an ndarray, or a scalar"
-#~ msgstr "de rechterkant moet een ndarray of scalar zijn"
-
-#~ msgid "shape must be a 2-tuple"
-#~ msgstr "vorm moet een 2-tuple zijn"
-
-#~ msgid "wrong argument type"
-#~ msgstr "onjuist argumenttype"
-
-#~ msgid "Must provide SCK pin"
-#~ msgstr "SCK pin moet opgegeven worden"
-
-#~ msgid ""
-#~ "\n"
-#~ "To exit, please reset the board without "
-#~ msgstr ""
-#~ "\n"
-#~ "Om te verlaten, herstart de module zonder "
-
-#~ msgid "PulseOut not supported on this chip"
-#~ msgstr "PulseOut niet ondersteund door deze chip"
-
-#~ msgid "tuple/list required on RHS"
-#~ msgstr "tuple of lijst vereist op RHS"
-
-#~ msgid "Invalid SPI pin selection"
-#~ msgstr "Ongeldige SPI pin selectie"
-
-#~ msgid "Invalid UART pin selection"
-#~ msgstr "Ongeldige UART pin selectie"
-
-#~ msgid "'%s' object cannot assign attribute '%q'"
-#~ msgstr "'%s' object kan niet aan attribuut '%q' toewijzen"
-
-#~ msgid "'%s' object does not support '%q'"
-#~ msgstr "'%s' object ondersteunt '%q' niet"
-
-#~ msgid "'%s' object does not support item assignment"
-#~ msgstr "'%s' object ondersteunt item toewijzing niet"
-
-#~ msgid "'%s' object does not support item deletion"
-#~ msgstr "'%s' object ondersteunt item verwijdering niet"
-
-#~ msgid "'%s' object is not an iterator"
-#~ msgstr "'%s' object is geen iterator"
-
-#~ msgid "'%s' object is not callable"
-#~ msgstr "'%s' object is niet aanroepbaar"
-
-#~ msgid "'%s' object is not iterable"
-#~ msgstr "'%s' object is niet itereerbaar"
-
-#~ msgid "'%s' object is not subscriptable"
-#~ msgstr "'%s' object is niet onderschrijfbaar"
-
-#~ msgid "Pop from an empty Ps2 buffer"
-#~ msgstr "Pop van een lege Ps2 buffer"
-
-#~ msgid "Running in safe mode! Auto-reload is off.\n"
-#~ msgstr "Draaiende in veilige modus! Auto-herlaad is uit.\n"
-
-#~ msgid "can't convert address to int"
-#~ msgstr "kan adres niet omzetten naar int"
-
-#~ msgid "object '%s' is not a tuple or list"
-#~ msgstr "object '%s' is geen tuple of lijst"
+#~ "polygoon kan slechts bij één object van een hoger niveau worden "
+#~ "geregistreerd"
 
 #~ msgid "pop from an empty set"
 #~ msgstr "pop van een lege set"
@@ -5559,41 +5434,135 @@ msgstr "zi moet vorm (n_section, 2) hebben"
 #~ msgid "popitem(): dictionary is empty"
 #~ msgstr "popitem(): dictionary is leeg"
 
+#~ msgid "pressing boot button at start up.\n"
+#~ msgstr "druk bootknop in bij opstarten.\n"
+
+#~ msgid "pressing both buttons at start up.\n"
+#~ msgstr "druk beide knoppen in bij opstarten.\n"
+
+#~ msgid "queue overflow"
+#~ msgstr "wachtrij overloop"
+
+#~ msgid "raw f-strings are not implemented"
+#~ msgstr "ruwe f-strings zijn niet geïmplementeerd"
+
+#~ msgid "right hand side must be an ndarray, or a scalar"
+#~ msgstr "de rechterkant moet een ndarray of scalar zijn"
+
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "sample_source buffer moet een bytearray of array van type 'h', 'H', 'b' "
+#~ "of 'B' zijn"
+
+#~ msgid "schedule stack full"
+#~ msgstr "schedule stack is vol"
+
+#~ msgid "shape must be a 2-tuple"
+#~ msgstr "vorm moet een 2-tuple zijn"
+
+#~ msgid "shape must be a tuple"
+#~ msgstr "vorm moet een tupel zijn"
+
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "enkele '}' aangetroffen in formaat tekenreeks (string)"
+
+#~ msgid "slice step can't be zero"
+#~ msgstr "segmentstap mag niet nul zijn"
+
+#~ msgid "slice step cannot be zero"
+#~ msgstr "segmentstap mag niet nul zijn"
+
+#~ msgid "start_x should be an int"
+#~ msgstr "start_x moet een int zijn"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "step mag geen nul zijn"
+
+#~ msgid "stop must be 1 or 2"
+#~ msgstr "stop moet 1 of 2 zijn"
+
+#~ msgid "string indices must be integers, not %q"
+#~ msgstr "string indices moeten integers zijn, geen %q"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr "string niet ondersteund; gebruik bytes of bytearray"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "struct: kan niet indexeren"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "drempelwaarde moet in het bereik 0-65536 liggen"
+
+#~ msgid "time.struct_time() takes a 9-sequence"
+#~ msgstr "time.struct_time() accepteert een 9-rij"
+
+#~ msgid "timeout must be 0.0-100.0 seconds"
+#~ msgstr "timeout moet tussen 0.0 en 100.0 seconden zijn"
+
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "timeout moet groter dan 0.0 zijn"
+
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "te veel argumenten opgegeven bij dit formaat"
+
+#~ msgid "trigger level must be 0 or 1"
+#~ msgstr "triggerniveau moet 0 of 1 zijn"
+
+#~ msgid "tuple index out of range"
+#~ msgstr "tuple index buiten bereik"
+
+#~ msgid "tuple/list required on RHS"
+#~ msgstr "tuple of lijst vereist op RHS"
+
+#~ msgid "type object 'generator' has no attribute '__await__'"
+#~ msgstr "het type object 'generator' heeft geen attribuut '__await__'"
+
+#~ msgid "unindent does not match any outer indentation level"
+#~ msgstr "inspringing komt niet overeen met hoger gelegen inspringingsniveaus"
+
 #~ msgid "unknown format code '%c' for object of type '%s'"
 #~ msgstr "onbekende formaatcode '%c' voor object van type '%s'"
+
+#~ msgid "unmatched '{' in format"
+#~ msgstr "'{' zonder overeenkomst in formaat"
+
+#~ msgid "unsupported type for %q: '%q'"
+#~ msgstr "niet ondersteund type voor %q: '%q'"
 
 #~ msgid "unsupported types for %q: '%s', '%s'"
 #~ msgstr "niet ondersteunde types voor %q: '%s', '%s'"
 
-#~ msgid "'async for' or 'async with' outside async function"
-#~ msgstr "'async for' of 'async with' buiten async functie"
+#~ msgid "value_count must be > 0"
+#~ msgstr "value_count moet groter dan 0 zijn"
 
-#~ msgid "PulseIn not supported on this chip"
-#~ msgstr "PusleIn niet ondersteund door deze chip"
+#~ msgid "vectors must have same lengths"
+#~ msgstr "vectoren moeten van gelijke lengte zijn"
 
-#~ msgid "I2C operation not supported"
-#~ msgstr "I2C actie niet ondersteund"
+#~ msgid "wakeup conflict"
+#~ msgstr "conflict bij ontwaken"
 
-#~ msgid "Negative step not supported"
-#~ msgstr "Negatieve stappen niet ondersteund"
+#~ msgid "watchdog not initialized"
+#~ msgstr "watchdog niet geïnitialiseerd"
 
-#~ msgid "bits must be 8"
-#~ msgstr "bits moet 8 zijn"
+#~ msgid "watchdog timeout must be greater than 0"
+#~ msgstr "watchdog time-out moet groter zijn dan 0"
 
-#~ msgid "buffers must be the same length"
-#~ msgstr "buffers moeten dezelfde lengte hebben"
+#~ msgid "wrong argument type"
+#~ msgstr "onjuist argumenttype"
 
-#~ msgid "firstbit must be MSB"
-#~ msgstr "het eerste bit moet het MSB zijn"
+#~ msgid "wrong operand type"
+#~ msgstr "verkeerd operandtype"
 
-#~ msgid "invalid I2C peripheral"
-#~ msgstr "onjuist I2C randapparaat"
+#~ msgid "x value out of bounds"
+#~ msgstr "x-waarde buiten bereik"
 
-#~ msgid "invalid SPI peripheral"
-#~ msgstr "onjuist SPI randapparaat"
+#~ msgid "y should be an int"
+#~ msgstr "y moet een int zijn"
 
-#~ msgid "must specify all of sck/mosi/miso"
-#~ msgstr "sck/mosi/miso moeten alle gespecificeerd worden"
+#~ msgid "y value out of bounds"
+#~ msgstr "y-waarde buiten bereik"
 
-#~ msgid "'%q' object is not bytes-like"
-#~ msgstr "'%q' object is niet bytes-achtig"
+#~ msgid "zero step"
+#~ msgstr "nul-stap"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -80,41 +80,11 @@ msgstr " wyjście:\n"
 msgid "%%c requires int or char"
 msgstr "%%c wymaga int lub char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr ""
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -298,11 +268,6 @@ msgstr "%q[%u] wykorzystuje dodatkowy pin"
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
 msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
-msgstr "%s"
 
 #: ports/espressif/common-hal/espidf/__init__.c
 #, c-format
@@ -1630,8 +1595,9 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Tylko 8 lub 16 bitów mono z "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -4437,146 +4403,12 @@ msgstr ""
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
 
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr "'await', 'async for' lub 'async with' poza funkcją asynchroniczną"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' poza pętlą"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' poza pętlą"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Podział z podgrupami"
-
-#~ msgid "__init__() should return None, not '%q'"
-#~ msgstr "__init__() powinno zwrócić None, a nie '%q'"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "atrybuty nie są jeszcze obsługiwane"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr "nie można wykonać dzielenia całkowitego na liczbie zespolonej"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "nie można zaimportować nazwy %q"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr "argumenty nazwane nieobsługiwane - proszę użyć zwykłych argumentów"
-
-#~ msgid "length argument not allowed for this type"
-#~ msgstr "ten typ nie pozawala na podanie długości"
-
-#~ msgid "offset out of bounds"
-#~ msgstr "offset poza zakresem"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr "łańcuchy nieobsługiwane; użyj bytes lub bytearray"
-
-#~ msgid "Initialization failed due to lack of memory"
-#~ msgstr "Inicjalizacja nie powiodła się z powodu braku pamięci"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "ADC2 jest używany przez WiFi"
-
-#~ msgid "queue overflow"
-#~ msgstr "przepełnienie kolejki"
-
-#~ msgid "Buffer is too small"
-#~ msgstr "Bufor jest za mały"
-
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-#~ msgstr ""
-#~ "pixel_shader musi być typu displayio.Palette lub dispalyio.ColorConverter"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "Uszkodzony plik .mpy"
-
 #~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
 #~ msgstr ""
-#~ "Niekompatybilny plik .mpy. Proszę odświeżyć wszystkie pliki .mpy. Więcej "
-#~ "informacji na http://adafrui.it/mpy-update."
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "nie można mieć wielu **x"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "nie można mieć wielu *x"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "stała musi być liczbą całkowitą"
-
-#~ msgid "invalid format"
-#~ msgstr "zły format"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "słowa kluczowe muszą być łańcuchami"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "argument nienazwany po */**"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "argument nienazwany po nazwanym"
-
-#~ msgid "Too many display busses"
-#~ msgstr "Zbyt wiele magistrali"
-
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Sprzęt zajęty, wypróbuj alternatywne piny"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "Brak pinu MISO lub MOSI"
-
-#~ msgid "No MISO Pin"
-#~ msgstr "Brak pinu MISO"
-
-#~ msgid "No MOSI Pin"
-#~ msgstr "Brak pinu MOSI"
-
-#~ msgid "No RX pin"
-#~ msgstr "Brak nóżki RX"
-
-#~ msgid "No TX pin"
-#~ msgstr "Brak nóżki TX"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "Jasność musi wynosić 0-1,0"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "Największa wartość x przy odwróceniu to %d"
-
-#~ msgid "x value out of bounds"
-#~ msgstr "x poza zakresem"
-
-#~ msgid "y value out of bounds"
-#~ msgstr "y poza zakresem"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "I2SOut niedostępne"
-
-#~ msgid "pixel value requires too many bits"
-#~ msgstr "wartość piksela wymaga zbyt wielu bitów"
-
-#~ msgid "value_count must be > 0"
-#~ msgstr "value_count musi być > 0"
-
-#~ msgid "No key was specified"
-#~ msgstr "Nie określono klucza"
-
-#~ msgid "Scan already in progess. Stop with stop_scan."
-#~ msgstr "Skanuj już w toku. Zatrzymaj za pomocą stop_scan."
-
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "zbyt wiele argumentów podanych dla tego formatu"
-
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "Podaj co najmniej jeden pin UART"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "nieprawidłowy pin %q"
+#~ "\n"
+#~ "Kod wykonany. Czekam na przeładowanie.\n"
 
 #~ msgid ""
 #~ "\n"
@@ -4587,66 +4419,15 @@ msgstr ""
 #~ "Zgłoś problem z zawartością dysku CIRCUITPY pod adresem\n"
 #~ "https://github.com/adafruit/circuitpython/issues\n"
 
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "CircuitPython nie mógł przydzielić sterty."
-
-#~ msgid "Invalid memory access."
-#~ msgstr "Nieprawidłowy dostęp do pamięci."
-
-#~ msgid "Expected a %q"
-#~ msgstr "Oczekiwano %q"
-
 #, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IV musi mieć długość %d bajtów"
+#~ msgid "%02X"
+#~ msgstr "%02X"
 
-#~ msgid "Read-only object"
-#~ msgstr "Obiekt tylko do odczytu"
+#~ msgid "%q"
+#~ msgstr "%q"
 
-#~ msgid "Invalid pins"
-#~ msgstr "Złe nóżki"
-
-#~ msgid "complex division by zero"
-#~ msgstr "zespolone dzielenie przez zero"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr "argument 2 do int() busi być pomiędzy 2 a 36"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "long int jest nieobsługiwany"
-
-#~ msgid "slice step cannot be zero"
-#~ msgstr "zerowy krok"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "step nie może być zerowe"
-
-#~ msgid "time.struct_time() takes a 9-sequence"
-#~ msgstr "time.struct_time() wymaga 9-elementowej sekwencji"
-
-#~ msgid "zero step"
-#~ msgstr "zerowy krok"
-
-#~ msgid "WatchDogTimer.timeout must be greater than 0"
-#~ msgstr "WatchDogTimer.timeout musi być większe od 0"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "pojedynczy '}' w specyfikacji formatu"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "threshold musi być w zakresie 0-65536"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "niepasujące '{' for formacie"
-
-#~ msgid "To exit, please reset the board without "
-#~ msgstr "By wyjść, proszę zresetować płytkę bez "
-
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "Zażądano trybu bezpieczeństwa przez "
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "Strumień nie ma metod readinto() lub write()."
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "%q indeksy muszą być liczbami typu int, a nie %q"
 
 #~ msgid "%q must be >= 0"
 #~ msgstr "%q musi być >= 0"
@@ -4654,346 +4435,18 @@ msgstr ""
 #~ msgid "%q must be >= 1"
 #~ msgstr "%q musi być >= 1"
 
-#~ msgid "address out of bounds"
-#~ msgstr "adres poza zakresem"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr "destination_length musi być nieujemną liczbą całkowitą"
-
-#~ msgid "color should be an int"
-#~ msgstr "kolor powinien być liczbą całkowitą"
-
-#~ msgid "end_x should be an int"
-#~ msgstr "end_x powinien być całkowity"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "palette_index powinien być całkowity"
-
-#~ msgid "start_x should be an int"
-#~ msgstr "start_x powinien być całkowity"
-
-#~ msgid "y should be an int"
-#~ msgstr "y powinno być całkowite"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "bufor sample_source musi być bytearray lub tablicą typu 'h', 'H', 'b' lub "
-#~ "'B'"
-
 #~ msgid "%q must be a tuple of length 2"
 #~ msgstr "%q musi być krotką o długości 2"
+
+#~ msgid "%q pin invalid"
+#~ msgstr "nieprawidłowy pin %q"
 
 #~ msgid "%q should be an int"
 #~ msgstr "%q powinno być typu int"
 
-#~ msgid "Address type out of range"
-#~ msgstr "Typ adresu poza zakresem"
-
-#~ msgid "AnalogIn not supported on given pin"
-#~ msgstr "AnalogIn nie jest obsługiwany na danym pinie"
-
-#~ msgid "AnalogOut functionality not supported"
-#~ msgstr "AnalogOut jest niewspierane"
-
-#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-#~ msgstr "AnalogOut ma 16 bitów. Wartość musi być mniejsza od 65536."
-
-#~ msgid "AnalogOut not supported on given pin"
-#~ msgstr "AnalogOut niewspierany na tej nóżce"
-
 #, c-format
-#~ msgid "Buffer incorrect size. Should be %d bytes."
-#~ msgstr "Zła wielkość bufora. Powinno być %d bajtów."
-
-#~ msgid "Buffer must be at least length 1"
-#~ msgstr "Bufor musi mieć długość 1 lub więcej"
-
-#~ msgid "Bytes must be between 0 and 255."
-#~ msgstr "Bytes musi być między 0 a 255."
-
-#~ msgid "Cannot output both channels on the same pin"
-#~ msgstr "Nie można mieć obu kanałów na tej samej nóżce"
-
-#~ msgid "Cannot read without MISO pin."
-#~ msgstr "Nie można czytać bez nóżki MISO."
-
-#~ msgid "Cannot reset into bootloader because no bootloader is present."
-#~ msgstr "Nie można zrestartować -- nie ma bootloadera."
-
-#~ msgid "Cannot transfer without MOSI and MISO pins."
-#~ msgstr "Nie można przesyłać bez nóżek MOSI i MISO."
-
-#~ msgid "Cannot write without MOSI pin."
-#~ msgstr "Nie można pisać bez nóżki MOSI."
-
-#~ msgid "Clock pin init failed."
-#~ msgstr "Inicjalizacja nóżki zegara nie powiodła się."
-
-#~ msgid "Command must be an int between 0 and 255"
-#~ msgstr "Komenda musi być int pomiędzy 0 a 255"
-
-#~ msgid "Could not initialize GNSS"
-#~ msgstr "Nie można zainicjować GNSS"
-
-#~ msgid "Could not initialize SDCard"
-#~ msgstr "Nie można zainicjować SDCard"
-
-#~ msgid "Could not initialize UART"
-#~ msgstr "Ustawienie UART nie powiodło się"
-
-#~ msgid "Could not re-init channel"
-#~ msgstr "Nie można ponownie zainicjować kanału"
-
-#~ msgid "Could not re-init timer"
-#~ msgstr "Nie można ponownie zainicjować timera"
-
-#~ msgid "Could not restart PWM"
-#~ msgstr "Nie można ponownie uruchomić PWM"
-
-#~ msgid "Couldn't allocate first buffer"
-#~ msgstr "Nie udała się alokacja pierwszego bufora"
-
-#~ msgid "Couldn't allocate input buffer"
-#~ msgstr "Nie można przydzielić bufora wejściowego"
-
-#~ msgid "Couldn't allocate second buffer"
-#~ msgstr "Nie udała się alokacja drugiego bufora"
-
-#~ msgid "DigitalInOut not supported on given pin"
-#~ msgstr "DigitalInOut nie jest obsługiwany na podanym pinie"
-
-#, c-format
-#~ msgid "Expected tuple of length %d, got %d"
-#~ msgstr "Oczekiwano krotkę długości %d, otrzymano %d"
-
-#~ msgid "Failed to allocate RX buffer"
-#~ msgstr "Nie udała się alokacja bufora RX"
-
-#, c-format
-#~ msgid "Failed to allocate RX buffer of %d bytes"
-#~ msgstr "Nie udała się alokacja %d bajtów na bufor RX"
-
-#, c-format
-#~ msgid "Framebuffer requires %d bytes"
-#~ msgstr "Bufor ramki wymaga %d bajtów"
-
-#~ msgid "I2C Init Error"
-#~ msgstr "Błąd inicjalizacji I2C"
-
-#~ msgid "Invalid BMP file"
-#~ msgstr "Zły BMP"
-
-#~ msgid "Invalid PWM frequency"
-#~ msgstr "Zła częstotliwość PWM"
-
-#~ msgid "Invalid buffer size"
-#~ msgstr "Zła wielkość bufora"
-
-#~ msgid "Invalid capture period. Valid range: 1 - 500"
-#~ msgstr "Zły okres. Poprawny zakres to: 1 - 500"
-
-#~ msgid "Invalid channel count"
-#~ msgstr "Zła liczba kanałów"
-
-#~ msgid "Invalid direction."
-#~ msgstr "Nieprawidłowy kierunek."
-
-#~ msgid "Invalid file"
-#~ msgstr "Zły plik"
-
-#~ msgid "Invalid number of bits"
-#~ msgstr "Zła liczba bitów"
-
-#~ msgid "Invalid phase"
-#~ msgstr "Zła faza"
-
-#~ msgid "Invalid pin"
-#~ msgstr "Zła nóżka"
-
-#~ msgid "Invalid pin for left channel"
-#~ msgstr "Zła nóżka dla lewego kanału"
-
-#~ msgid "Invalid pin for right channel"
-#~ msgstr "Zła nóżka dla prawego kanału"
-
-#~ msgid "Invalid polarity"
-#~ msgstr "Zła polaryzacja"
-
-#~ msgid "Invalid properties"
-#~ msgstr "Nieprawidłowe właściwości"
-
-#~ msgid "Invalid run mode."
-#~ msgstr "Zły tryb uruchomienia."
-
-#~ msgid "Invalid security_mode"
-#~ msgstr "Nieprawidłowy security_mode"
-
-#~ msgid "Invalid voice count"
-#~ msgstr "Zła liczba głosów"
-
-#~ msgid "Invalid wave file"
-#~ msgstr "Zły plik wave"
-
-#~ msgid "Invalid word/bit length"
-#~ msgstr "Niepoprawna długość słowa/bitu"
-
-#~ msgid "Layer must be a Group or TileGrid subclass."
-#~ msgstr "Layer musi dziedziczyć z Group albo TileGrid."
-
-#~ msgid "MISO pin init failed."
-#~ msgstr "Nie powiodło się ustawienie pinu MISO."
-
-#~ msgid "MOSI pin init failed."
-#~ msgstr "Nie powiodło się ustawienie pinu MOSI."
-
-#~ msgid "Messages limited to 8 bytes"
-#~ msgstr "Wiadomości ograniczone do 8 bajtów"
-
-#~ msgid "No hardware support on pin"
-#~ msgstr "Brak sprzętowej obsługi na nóżce"
-
-#~ msgid ""
-#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-#~ msgstr ""
-#~ "duty_cycle musi być pomiędzy 0 a 65535 włącznie (rozdzielczość 16 bit)"
-
-#~ msgid "Pin does not have ADC capabilities"
-#~ msgstr "Nóżka nie obsługuje ADC"
-
-#~ msgid "RTC calibration is not supported on this board"
-#~ msgstr "Brak obsługi kalibracji RTC"
-
-#~ msgid "SPI Init Error"
-#~ msgstr "Błąd inicjowania SPI"
-
-#~ msgid "SPI Re-initialization error"
-#~ msgstr "Błąd ponownej inicjalizacji SPI"
-
-#~ msgid "Sample rate must be positive"
-#~ msgstr "Częstotliwość próbkowania musi być dodatnia"
-
-#, c-format
-#~ msgid "Sample rate too high. It must be less than %d"
-#~ msgstr "Zbyt wysoka częstotliwość próbkowania. Musi być mniejsza niż %d"
-
-#~ msgid "Stack size must be at least 256"
-#~ msgstr "Stos musi mieć co najmniej 256 bajtów"
-
-#~ msgid "UART Buffer allocation error"
-#~ msgstr "Błąd alokacji bufora UART"
-
-#~ msgid "UART write error"
-#~ msgstr "Błąd zapisu UART"
-
-#~ msgid "Unsupported baudrate"
-#~ msgstr "Zła szybkość transmisji"
-
-#~ msgid "bytes > 8 bits not supported"
-#~ msgstr "bajty większe od 8 bitów są niewspierane"
-
-#~ msgid "calibration value out of range +/-127"
-#~ msgstr "wartość kalibracji poza zakresem +/-127"
-
-#~ msgid "stop must be 1 or 2"
-#~ msgstr "stop musi być 1 lub 2"
-
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "timeout musi być >= 0.0"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "Zła operacja"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "Jasność musi być pomiędzy 0 a 255"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "nie można wykonać relatywnego importu"
-
-#~ msgid "Unsupported pull value."
-#~ msgstr "Zła wartość podciągnięcia."
-
-#, c-format
-#~ msgid ""
-#~ "Welcome to Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Please visit learn.adafruit.com/category/circuitpython for project "
-#~ "guides.\n"
-#~ "\n"
-#~ "To list built-in modules please do `help(\"modules\")`.\n"
-#~ msgstr ""
-#~ "Witamy w Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Aby zapoznać się z przewodnikami do projektu, odwiedź stronę learn."
-#~ "adafruit.com/category/circuitpython.\n"
-#~ "\n"
-#~ "Aby wyświetlić listę wbudowanych modułów, wpisz `help(\"modules\")`.\n"
-
-#~ msgid "integer required"
-#~ msgstr "wymagana liczba całkowita"
-
-#~ msgid "abort() called"
-#~ msgstr "Wywołano abort()"
-
-#~ msgid "invalid arguments"
-#~ msgstr "złe arguemnty"
-
-#~ msgid "unindent does not match any outer indentation level"
-#~ msgstr "wcięcie nie pasuje do żadnego wcześniejszego wcięcia"
-
-#~ msgid "Column entry must be digitalio.DigitalInOut"
-#~ msgstr "Kolumny muszą być typu digitalio.DigitalInOut"
-
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Oczekiwano charakterystyki"
-
-#~ msgid "Expected a DigitalInOut"
-#~ msgstr "Oczekiwano DigitalInOut"
-
-#~ msgid "Expected a UUID"
-#~ msgstr "Oczekiwano UUID"
-
-#~ msgid "Expected an Address"
-#~ msgstr "Oczekiwano adresu"
-
-#~ msgid "Row entry must be digitalio.DigitalInOut"
-#~ msgstr "Rzędy muszą być digitalio.DigitalInOut"
-
-#~ msgid "buttons must be digitalio.DigitalInOut"
-#~ msgstr "buttons musi być digitalio.DigitalInOut"
-
-#~ msgid "Invalid frequency"
-#~ msgstr "Nieprawidłowa częstotliwość"
-
-#~ msgid "ParallelBus not yet supported"
-#~ msgstr "ParallelBus nie jest jeszcze obsługiwany"
-
-#~ msgid "no available NIC"
-#~ msgstr "brak wolnego NIC"
-
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "Bufor jest zbyt duży i nie można go przydzielić"
-
-#~ msgid "wrong operand type"
-#~ msgstr "zły typ operandu"
-
-#~ msgid ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
-#~ msgstr ""
-#~ "CircuitPython jest w trybie awaryjnym, ponieważ podczas rozruchu "
-#~ "naciśnięto przycisk resetowania. Naciśnij ponownie, aby wyjść z trybu "
-#~ "awaryjnego.\n"
-
-#~ msgid "USB Busy"
-#~ msgstr "USB Zajęte"
-
-#~ msgid "USB Error"
-#~ msgstr "Błąd USB"
-
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "%q indeksy muszą być liczbami typu int, a nie %q"
+#~ msgid "%s"
+#~ msgstr "%s"
 
 #~ msgid "'%q' object does not support item assignment"
 #~ msgstr "'%q' obiekt nie wspiera dopisywania elementów"
@@ -5013,140 +4466,6 @@ msgstr ""
 #~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
 #~ msgstr "'%s' liczba 0x%x nie pasuje do maski 0x%x"
 
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "Wielkość skalara jest niejednoznaczna"
-
-#~ msgid "Length must be an int"
-#~ msgstr "Długość musi być całkowita"
-
-#~ msgid "Length must be non-negative"
-#~ msgstr "Długość musi być nieujemna"
-
-#~ msgid "name reused for argument"
-#~ msgstr "nazwa użyta ponownie jako argument"
-
-#~ msgid "object does not support item assignment"
-#~ msgstr "obiekt nie obsługuje przypisania do elementów"
-
-#~ msgid "object does not support item deletion"
-#~ msgstr "obiekt nie obsługuje usuwania elementów"
-
-#~ msgid "object is not subscriptable"
-#~ msgstr "obiekt nie ma elementów"
-
-#~ msgid "struct: cannot index"
-#~ msgstr "struct: nie można indeksować"
-
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "Nie można przemontować '/' gdy USB działa."
-
-#~ msgid "byte code not implemented"
-#~ msgstr "bajtkod niezaimplemntowany"
-
-#~ msgid "can't pend throw to just-started generator"
-#~ msgstr "nie można skoczyć do świeżo stworzonego generatora"
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "zły indeks dupterm"
-
-#~ msgid "schedule stack full"
-#~ msgstr "stos planu pełen"
-
-#~ msgid "can only save bytecode"
-#~ msgstr "można zapisać tylko bytecode"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr "Funkcje Viper nie obsługują obecnie więcej niż 4 argumentów"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "adres %08x nie jest wyrównany do %d bajtów"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "funkcja nie bierze argumentów nazwanych"
-
-#~ msgid "parameter annotation must be an identifier"
-#~ msgstr "anotacja parametru musi być identyfikatorem"
-
-#~ msgid "buffer must be a bytes-like object"
-#~ msgstr "bufor mysi być typu bytes"
-
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr "Próba przydziału sterty, gdy MicroPython VM nie działa."
-
-#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
-#~ msgstr ""
-#~ "Skok MicroRython NLR nie powiódł się. Prawdopodobne uszkodzenie pamięci."
-
-#~ msgid "MicroPython fatal error."
-#~ msgstr "Błąd krytyczny MicroPython."
-
-#~ msgid "vectors must have same lengths"
-#~ msgstr "wektory muszą mieć identyczną długość"
-
-#~ msgid "first argument must be an iterable"
-#~ msgstr "pierwszy argument musi być iterowalny"
-
-#~ msgid "Selected CTS pin not valid"
-#~ msgstr "Wybrany pin CTS jest nieprawidłowy"
-
-#~ msgid "Selected RTS pin not valid"
-#~ msgstr "Wybrany pin RTS jest nieprawidłowy"
-
-#~ msgid "Could not initialize channel"
-#~ msgstr "Nie można zainicjować kanału"
-
-#~ msgid "Could not initialize timer"
-#~ msgstr "Nie można zainicjować timera"
-
-#~ msgid "Invalid frequency supplied"
-#~ msgstr "Podano nieprawidłową częstotliwość"
-
-#~ msgid "Invalid pins for PWMOut"
-#~ msgstr "Nieprawidłowe piny dla PWMOut"
-
-#~ msgid "No more channels available"
-#~ msgstr "Brak dostępnych kanałów"
-
-#~ msgid "Group full"
-#~ msgstr "Grupa pełna"
-
-#~ msgid "bits must be 7, 8 or 9"
-#~ msgstr "bits musi być 7, 8 lub 9"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "SDA lub SCL wymagają podciągnięcia"
-
-#~ msgid "tuple index out of range"
-#~ msgstr "indeks krotki poza zakresem"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Kod wykonany. Czekam na przeładowanie.\n"
-
-#~ msgid "Frequency captured is above capability. Capture Paused."
-#~ msgstr "Uzyskana częstotliwość jest niemożliwa. Spauzowano."
-
-#~ msgid "max_length must be > 0"
-#~ msgstr "max_length musi być > 0"
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr "Dowolny klawisz aby uruchomić konsolę. CTRL-D aby przeładować."
-
-#~ msgid "number of arguments must be 2, or 3"
-#~ msgstr "liczba argumentów musi wynosić 2 lub 3"
-
-#~ msgid "wrong argument type"
-#~ msgstr "zły typ argumentu"
-
-#~ msgid "Must provide SCK pin"
-#~ msgstr "Należy podać pin SCK"
-
-#~ msgid "tuple/list required on RHS"
-#~ msgstr "wymagana krotka/lista po prawej stronie"
-
 #~ msgid "'%s' object does not support item assignment"
 #~ msgstr "'%s' obiekt nie wspiera przypisania do elementów"
 
@@ -5165,35 +4484,63 @@ msgstr ""
 #~ msgid "'%s' object is not subscriptable"
 #~ msgstr "'%s' nie można indeksować obiektu"
 
-#~ msgid "Running in safe mode! Auto-reload is off.\n"
-#~ msgstr "Uruchomiony tryb bezpieczeństwa! Samo-przeładowanie wyłączone.\n"
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr "'await', 'async for' lub 'async with' poza funkcją asynchroniczną"
 
-#~ msgid "can't convert address to int"
-#~ msgstr "nie można skonwertować adresu do int"
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' poza pętlą"
 
-#~ msgid "object '%s' is not a tuple or list"
-#~ msgstr "obiekt '%s' nie jest krotką ani listą"
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' poza pętlą"
 
-#~ msgid "pop from an empty set"
-#~ msgstr "pop z pustego zbioru"
-
-#~ msgid "pop from empty list"
-#~ msgstr "pop z pustej listy"
-
-#~ msgid "popitem(): dictionary is empty"
-#~ msgstr "popitem(): słownik jest pusty"
-
-#~ msgid "unknown format code '%c' for object of type '%s'"
-#~ msgstr "zły kod formatowania '%c' dla obiektu typu '%s'"
-
-#~ msgid "unsupported types for %q: '%s', '%s'"
-#~ msgstr "złe typy dla %q: '%s', '%s'"
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "ADC2 jest używany przez WiFi"
 
 #~ msgid "Address is not %d bytes long or is in wrong format"
 #~ msgstr "Adres nie ma długości %d bajtów lub zły format"
 
+#~ msgid "Address type out of range"
+#~ msgstr "Typ adresu poza zakresem"
+
+#~ msgid "AnalogIn not supported on given pin"
+#~ msgstr "AnalogIn nie jest obsługiwany na danym pinie"
+
+#~ msgid "AnalogOut functionality not supported"
+#~ msgstr "AnalogOut jest niewspierane"
+
+#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#~ msgstr "AnalogOut ma 16 bitów. Wartość musi być mniejsza od 65536."
+
+#~ msgid "AnalogOut not supported on given pin"
+#~ msgstr "AnalogOut niewspierany na tej nóżce"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr "Próba przydziału sterty, gdy MicroPython VM nie działa."
+
 #~ msgid "Attempted heap allocation when MicroPython VM not running.\n"
 #~ msgstr "Próba alokacji pamięci na stercie gdy VM nie działa.\n"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "Jasność musi wynosić 0-1,0"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "Jasność musi być pomiędzy 0 a 255"
+
+#, c-format
+#~ msgid "Buffer incorrect size. Should be %d bytes."
+#~ msgstr "Zła wielkość bufora. Powinno być %d bajtów."
+
+#~ msgid "Buffer is too small"
+#~ msgstr "Bufor jest za mały"
+
+#~ msgid "Buffer must be at least length 1"
+#~ msgstr "Bufor musi mieć długość 1 lub więcej"
+
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "Bufor jest zbyt duży i nie można go przydzielić"
+
+#~ msgid "Bytes must be between 0 and 255."
+#~ msgstr "Bytes musi być między 0 a 255."
 
 #~ msgid "Can not use dotstar with %s"
 #~ msgstr "Nie można używać dotstar z %s"
@@ -5210,20 +4557,119 @@ msgstr ""
 #~ msgid "Can't connect in Peripheral mode"
 #~ msgstr "Nie można się łączyć w trybie Peripheral"
 
+#~ msgid "Cannot output both channels on the same pin"
+#~ msgstr "Nie można mieć obu kanałów na tej samej nóżce"
+
+#~ msgid "Cannot read without MISO pin."
+#~ msgstr "Nie można czytać bez nóżki MISO."
+
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "Nie można przemontować '/' gdy USB działa."
+
+#~ msgid "Cannot reset into bootloader because no bootloader is present."
+#~ msgstr "Nie można zrestartować -- nie ma bootloadera."
+
+#~ msgid "Cannot transfer without MOSI and MISO pins."
+#~ msgstr "Nie można przesyłać bez nóżek MOSI i MISO."
+
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "Wielkość skalara jest niejednoznaczna"
+
+#~ msgid "Cannot write without MOSI pin."
+#~ msgstr "Nie można pisać bez nóżki MOSI."
+
 #~ msgid "Characteristic UUID doesn't match Service UUID"
 #~ msgstr "UUID charakterystyki inny niż UUID serwisu"
 
 #~ msgid "Characteristic already in use by another Service."
 #~ msgstr "Charakterystyka w użyciu w innym serwisie"
 
+#~ msgid ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+#~ msgstr ""
+#~ "CircuitPython jest w trybie awaryjnym, ponieważ podczas rozruchu "
+#~ "naciśnięto przycisk resetowania. Naciśnij ponownie, aby wyjść z trybu "
+#~ "awaryjnego.\n"
+
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "CircuitPython nie mógł przydzielić sterty."
+
+#~ msgid "Clock pin init failed."
+#~ msgstr "Inicjalizacja nóżki zegara nie powiodła się."
+
+#~ msgid "Column entry must be digitalio.DigitalInOut"
+#~ msgstr "Kolumny muszą być typu digitalio.DigitalInOut"
+
+#~ msgid "Command must be an int between 0 and 255"
+#~ msgstr "Komenda musi być int pomiędzy 0 a 255"
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "Uszkodzony plik .mpy"
+
 #~ msgid "Could not decode ble_uuid, err 0x%04x"
 #~ msgstr "Nie można zdekodować ble_uuid, błąd 0x%04x"
+
+#~ msgid "Could not initialize GNSS"
+#~ msgstr "Nie można zainicjować GNSS"
+
+#~ msgid "Could not initialize SDCard"
+#~ msgstr "Nie można zainicjować SDCard"
+
+#~ msgid "Could not initialize UART"
+#~ msgstr "Ustawienie UART nie powiodło się"
+
+#~ msgid "Could not initialize channel"
+#~ msgstr "Nie można zainicjować kanału"
+
+#~ msgid "Could not initialize timer"
+#~ msgstr "Nie można zainicjować timera"
+
+#~ msgid "Could not re-init channel"
+#~ msgstr "Nie można ponownie zainicjować kanału"
+
+#~ msgid "Could not re-init timer"
+#~ msgstr "Nie można ponownie zainicjować timera"
+
+#~ msgid "Could not restart PWM"
+#~ msgstr "Nie można ponownie uruchomić PWM"
+
+#~ msgid "Couldn't allocate first buffer"
+#~ msgstr "Nie udała się alokacja pierwszego bufora"
+
+#~ msgid "Couldn't allocate input buffer"
+#~ msgstr "Nie można przydzielić bufora wejściowego"
+
+#~ msgid "Couldn't allocate second buffer"
+#~ msgstr "Nie udała się alokacja drugiego bufora"
 
 #~ msgid "Crash into the HardFault_Handler.\n"
 #~ msgstr "Katastrofa w HardFault_Handler.\n"
 
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Zbyt dużo danych pakietu rozgłoszeniowego"
+
+#~ msgid "DigitalInOut not supported on given pin"
+#~ msgstr "DigitalInOut nie jest obsługiwany na podanym pinie"
+
+#~ msgid "Expected a %q"
+#~ msgstr "Oczekiwano %q"
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Oczekiwano charakterystyki"
+
+#~ msgid "Expected a DigitalInOut"
+#~ msgstr "Oczekiwano DigitalInOut"
+
+#~ msgid "Expected a UUID"
+#~ msgstr "Oczekiwano UUID"
+
+#~ msgid "Expected an Address"
+#~ msgstr "Oczekiwano adresu"
+
+#, c-format
+#~ msgid "Expected tuple of length %d, got %d"
+#~ msgstr "Oczekiwano krotkę długości %d, otrzymano %d"
 
 #~ msgid "Failed to acquire mutex"
 #~ msgstr "Nie udało się uzyskać blokady"
@@ -5237,6 +4683,13 @@ msgstr ""
 
 #~ msgid "Failed to add service, err 0x%04x"
 #~ msgstr "Nie udało się dodać serwisu, błąd 0x%04x"
+
+#~ msgid "Failed to allocate RX buffer"
+#~ msgstr "Nie udała się alokacja bufora RX"
+
+#, c-format
+#~ msgid "Failed to allocate RX buffer of %d bytes"
+#~ msgstr "Nie udała się alokacja %d bajtów na bufor RX"
 
 #~ msgid "Failed to change softdevice state"
 #~ msgstr "Nie udało się zmienić stanu softdevice"
@@ -5316,17 +4769,131 @@ msgstr ""
 #~ msgid "Flash write failed to start, err 0x%04x"
 #~ msgstr "Nie udało się rozpocząć zapisu do flash, błąd 0x%04x"
 
+#, c-format
+#~ msgid "Framebuffer requires %d bytes"
+#~ msgstr "Bufor ramki wymaga %d bajtów"
+
+#~ msgid "Frequency captured is above capability. Capture Paused."
+#~ msgstr "Uzyskana częstotliwość jest niemożliwa. Spauzowano."
+
+#~ msgid "Group full"
+#~ msgstr "Grupa pełna"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Sprzęt zajęty, wypróbuj alternatywne piny"
+
+#~ msgid "I2C Init Error"
+#~ msgstr "Błąd inicjalizacji I2C"
+
 #~ msgid "I2C operation not supported"
 #~ msgstr "Operacja I2C nieobsługiwana"
 
+#~ msgid "I2SOut not available"
+#~ msgstr "I2SOut niedostępne"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IV musi mieć długość %d bajtów"
+
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "Niekompatybilny plik .mpy. Proszę odświeżyć wszystkie pliki .mpy. Więcej "
+#~ "informacji na http://adafrui.it/mpy-update."
+
+#~ msgid "Initialization failed due to lack of memory"
+#~ msgstr "Inicjalizacja nie powiodła się z powodu braku pamięci"
+
+#~ msgid "Invalid BMP file"
+#~ msgstr "Zły BMP"
+
+#~ msgid "Invalid PWM frequency"
+#~ msgstr "Zła częstotliwość PWM"
+
 #~ msgid "Invalid bit clock pin"
 #~ msgstr "Zła nóżka zegara"
+
+#~ msgid "Invalid buffer size"
+#~ msgstr "Zła wielkość bufora"
+
+#~ msgid "Invalid capture period. Valid range: 1 - 500"
+#~ msgstr "Zły okres. Poprawny zakres to: 1 - 500"
+
+#~ msgid "Invalid channel count"
+#~ msgstr "Zła liczba kanałów"
 
 #~ msgid "Invalid clock pin"
 #~ msgstr "Zła nóżka zegara"
 
 #~ msgid "Invalid data pin"
 #~ msgstr "Zła nóżka danych"
+
+#~ msgid "Invalid direction."
+#~ msgstr "Nieprawidłowy kierunek."
+
+#~ msgid "Invalid file"
+#~ msgstr "Zły plik"
+
+#~ msgid "Invalid frequency"
+#~ msgstr "Nieprawidłowa częstotliwość"
+
+#~ msgid "Invalid frequency supplied"
+#~ msgstr "Podano nieprawidłową częstotliwość"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "Nieprawidłowy dostęp do pamięci."
+
+#~ msgid "Invalid number of bits"
+#~ msgstr "Zła liczba bitów"
+
+#~ msgid "Invalid phase"
+#~ msgstr "Zła faza"
+
+#~ msgid "Invalid pin"
+#~ msgstr "Zła nóżka"
+
+#~ msgid "Invalid pin for left channel"
+#~ msgstr "Zła nóżka dla lewego kanału"
+
+#~ msgid "Invalid pin for right channel"
+#~ msgstr "Zła nóżka dla prawego kanału"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Złe nóżki"
+
+#~ msgid "Invalid pins for PWMOut"
+#~ msgstr "Nieprawidłowe piny dla PWMOut"
+
+#~ msgid "Invalid polarity"
+#~ msgstr "Zła polaryzacja"
+
+#~ msgid "Invalid properties"
+#~ msgstr "Nieprawidłowe właściwości"
+
+#~ msgid "Invalid run mode."
+#~ msgstr "Zły tryb uruchomienia."
+
+#~ msgid "Invalid security_mode"
+#~ msgstr "Nieprawidłowy security_mode"
+
+#~ msgid "Invalid voice count"
+#~ msgstr "Zła liczba głosów"
+
+#~ msgid "Invalid wave file"
+#~ msgstr "Zły plik wave"
+
+#~ msgid "Invalid word/bit length"
+#~ msgstr "Niepoprawna długość słowa/bitu"
+
+#~ msgid "Layer must be a Group or TileGrid subclass."
+#~ msgstr "Layer musi dziedziczyć z Group albo TileGrid."
+
+#~ msgid "Length must be an int"
+#~ msgstr "Długość musi być całkowita"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Długość musi być nieujemna"
 
 #~ msgid ""
 #~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
@@ -5338,15 +4905,65 @@ msgstr ""
 #~ "circuitpython/issues\n"
 #~ " z zawartością dysku CIRCUITPY oraz tym komunikatem:\n"
 
+#~ msgid "MISO pin init failed."
+#~ msgstr "Nie powiodło się ustawienie pinu MISO."
+
+#~ msgid "MOSI pin init failed."
+#~ msgstr "Nie powiodło się ustawienie pinu MOSI."
+
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "Największa wartość x przy odwróceniu to %d"
+
+#~ msgid "Messages limited to 8 bytes"
+#~ msgstr "Wiadomości ograniczone do 8 bajtów"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgstr ""
+#~ "Skok MicroRython NLR nie powiódł się. Prawdopodobne uszkodzenie pamięci."
+
 #~ msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
 #~ msgstr ""
 #~ "Skok NLR MicroPythona nie powiódł się. Prawdopodobne skażenie pamięci.\n"
 
+#~ msgid "MicroPython fatal error."
+#~ msgstr "Błąd krytyczny MicroPython."
+
 #~ msgid "MicroPython fatal error.\n"
 #~ msgstr "Krytyczny błąd MicroPythona.\n"
 
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "Brak pinu MISO lub MOSI"
+
 #~ msgid "Must be a Group subclass."
 #~ msgstr "Musi dziedziczyć z Group."
+
+#~ msgid "Must provide SCK pin"
+#~ msgstr "Należy podać pin SCK"
+
+#~ msgid "No MISO Pin"
+#~ msgstr "Brak pinu MISO"
+
+#~ msgid "No MOSI Pin"
+#~ msgstr "Brak pinu MOSI"
+
+#~ msgid "No RX pin"
+#~ msgstr "Brak nóżki RX"
+
+#~ msgid "No TX pin"
+#~ msgstr "Brak nóżki TX"
+
+#~ msgid "No hardware support on pin"
+#~ msgstr "Brak sprzętowej obsługi na nóżce"
+
+#~ msgid "No key was specified"
+#~ msgstr "Nie określono klucza"
+
+#~ msgid "No more channels available"
+#~ msgstr "Brak dostępnych kanałów"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Tylko 8 lub 16 bitów mono z "
 
 #~ msgid ""
 #~ "Only monochrome, indexed 8bpp, and 16bpp or greater BMPs supported: %d "
@@ -5356,14 +4973,77 @@ msgstr ""
 #~ msgid "Only slices with step=1 (aka None) are supported"
 #~ msgstr "Wspierane są tylko fragmenty z step=1 (albo None)"
 
+#~ msgid ""
+#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
+#~ msgstr ""
+#~ "duty_cycle musi być pomiędzy 0 a 65535 włącznie (rozdzielczość 16 bit)"
+
+#~ msgid "ParallelBus not yet supported"
+#~ msgstr "ParallelBus nie jest jeszcze obsługiwany"
+
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "Nóżka nie obsługuje ADC"
+
 #~ msgid "Pixel beyond bounds of buffer"
 #~ msgstr "Piksel poza granicami bufora"
+
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+#~ msgstr "Dowolny klawisz aby uruchomić konsolę. CTRL-D aby przeładować."
+
+#~ msgid "RTC calibration is not supported on this board"
+#~ msgstr "Brak obsługi kalibracji RTC"
 
 #~ msgid "Range out of bounds"
 #~ msgstr "Zakres poza granicami"
 
+#~ msgid "Read-only object"
+#~ msgstr "Obiekt tylko do odczytu"
+
+#~ msgid "Row entry must be digitalio.DigitalInOut"
+#~ msgstr "Rzędy muszą być digitalio.DigitalInOut"
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Uruchomiony tryb bezpieczeństwa! Samo-przeładowanie wyłączone.\n"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "SDA lub SCL wymagają podciągnięcia"
+
+#~ msgid "SPI Init Error"
+#~ msgstr "Błąd inicjowania SPI"
+
+#~ msgid "SPI Re-initialization error"
+#~ msgstr "Błąd ponownej inicjalizacji SPI"
+
+#~ msgid "Sample rate must be positive"
+#~ msgstr "Częstotliwość próbkowania musi być dodatnia"
+
+#, c-format
+#~ msgid "Sample rate too high. It must be less than %d"
+#~ msgstr "Zbyt wysoka częstotliwość próbkowania. Musi być mniejsza niż %d"
+
+#~ msgid "Scan already in progess. Stop with stop_scan."
+#~ msgstr "Skanuj już w toku. Zatrzymaj za pomocą stop_scan."
+
+#~ msgid "Selected CTS pin not valid"
+#~ msgstr "Wybrany pin CTS jest nieprawidłowy"
+
+#~ msgid "Selected RTS pin not valid"
+#~ msgstr "Wybrany pin RTS jest nieprawidłowy"
+
 #~ msgid "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 #~ msgstr "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Podział z podgrupami"
+
+#~ msgid "Stack size must be at least 256"
+#~ msgstr "Stos musi mieć co najmniej 256 bajtów"
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "Strumień nie ma metod readinto() lub write()."
+
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "Podaj co najmniej jeden pin UART"
 
 #~ msgid ""
 #~ "The CircuitPython heap was corrupted because the stack was too small.\n"
@@ -5398,11 +5078,60 @@ msgstr ""
 #~ msgid "Tile indices must be 0 - 255"
 #~ msgstr "Indeks kafelka musi być pomiędzy 0 a 255 włącznie"
 
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "By wyjść, proszę zresetować płytkę bez "
+
+#~ msgid "Too many display busses"
+#~ msgstr "Zbyt wiele magistrali"
+
+#~ msgid "UART Buffer allocation error"
+#~ msgstr "Błąd alokacji bufora UART"
+
+#~ msgid "UART write error"
+#~ msgstr "Błąd zapisu UART"
+
+#~ msgid "USB Busy"
+#~ msgstr "USB Zajęte"
+
+#~ msgid "USB Error"
+#~ msgstr "Błąd USB"
+
 #~ msgid "UUID integer value not in range 0 to 0xffff"
 #~ msgstr "Wartość UUID poza zakresem 0 do 0xffff"
 
+#~ msgid "Unsupported baudrate"
+#~ msgstr "Zła szybkość transmisji"
+
+#~ msgid "Unsupported operation"
+#~ msgstr "Zła operacja"
+
+#~ msgid "Unsupported pull value."
+#~ msgstr "Zła wartość podciągnięcia."
+
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr "Funkcje Viper nie obsługują obecnie więcej niż 4 argumentów"
+
 #~ msgid "Voice index too high"
 #~ msgstr "Zbyt wysoki indeks głosu"
+
+#~ msgid "WatchDogTimer.timeout must be greater than 0"
+#~ msgstr "WatchDogTimer.timeout musi być większe od 0"
+
+#, c-format
+#~ msgid ""
+#~ "Welcome to Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Please visit learn.adafruit.com/category/circuitpython for project "
+#~ "guides.\n"
+#~ "\n"
+#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ msgstr ""
+#~ "Witamy w Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Aby zapoznać się z przewodnikami do projektu, odwiedź stronę learn."
+#~ "adafruit.com/category/circuitpython.\n"
+#~ "\n"
+#~ "Aby wyświetlić listę wbudowanych modułów, wpisz `help(\"modules\")`.\n"
 
 #~ msgid ""
 #~ "You are running in safe mode which means something unanticipated "
@@ -5410,8 +5139,29 @@ msgstr ""
 #~ msgstr ""
 #~ "Uruchomiono w trybie bezpieczeństwa, gdyż nastąpiło coś nieoczekiwanego.\n"
 
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "Zażądano trybu bezpieczeństwa przez "
+
+#~ msgid "__init__() should return None, not '%q'"
+#~ msgstr "__init__() powinno zwrócić None, a nie '%q'"
+
+#~ msgid "abort() called"
+#~ msgstr "Wywołano abort()"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "adres %08x nie jest wyrównany do %d bajtów"
+
+#~ msgid "address out of bounds"
+#~ msgstr "adres poza zakresem"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "atrybuty nie są jeszcze obsługiwane"
+
 #~ msgid "bad GATT role"
 #~ msgstr "zła rola GATT"
+
+#~ msgid "bits must be 7, 8 or 9"
+#~ msgstr "bits musi być 7, 8 lub 9"
 
 #~ msgid "bits must be 8"
 #~ msgstr "bits musi być 8"
@@ -5419,11 +5169,50 @@ msgstr ""
 #~ msgid "buf is too small. need %d bytes"
 #~ msgstr "buf zbyt mały. Wymagane %d bajtów"
 
+#~ msgid "buffer must be a bytes-like object"
+#~ msgstr "bufor mysi być typu bytes"
+
 #~ msgid "buffers must be the same length"
 #~ msgstr "bufory muszą mieć tę samą długość"
 
+#~ msgid "buttons must be digitalio.DigitalInOut"
+#~ msgstr "buttons musi być digitalio.DigitalInOut"
+
+#~ msgid "byte code not implemented"
+#~ msgstr "bajtkod niezaimplemntowany"
+
 #~ msgid "byteorder is not an instance of ByteOrder (got a %s)"
 #~ msgstr "byteorder musi być typu ByteOrder (jest %s)"
+
+#~ msgid "bytes > 8 bits not supported"
+#~ msgstr "bajty większe od 8 bitów są niewspierane"
+
+#~ msgid "calibration value out of range +/-127"
+#~ msgstr "wartość kalibracji poza zakresem +/-127"
+
+#~ msgid "can only save bytecode"
+#~ msgstr "można zapisać tylko bytecode"
+
+#~ msgid "can't convert address to int"
+#~ msgstr "nie można skonwertować adresu do int"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr "nie można wykonać dzielenia całkowitego na liczbie zespolonej"
+
+#~ msgid "can't have multiple **x"
+#~ msgstr "nie można mieć wielu **x"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "nie można mieć wielu *x"
+
+#~ msgid "can't pend throw to just-started generator"
+#~ msgstr "nie można skoczyć do świeżo stworzonego generatora"
+
+#~ msgid "cannot import name %q"
+#~ msgstr "nie można zaimportować nazwy %q"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "nie można wykonać relatywnego importu"
 
 #~ msgid "characteristics includes an object that is not a Characteristic"
 #~ msgstr ""
@@ -5432,8 +5221,35 @@ msgstr ""
 #~ msgid "color buffer must be a buffer or int"
 #~ msgstr "bufor kolorów musi być typu buffer lub int"
 
+#~ msgid "color should be an int"
+#~ msgstr "kolor powinien być liczbą całkowitą"
+
+#~ msgid "complex division by zero"
+#~ msgstr "zespolone dzielenie przez zero"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "stała musi być liczbą całkowitą"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr "destination_length musi być nieujemną liczbą całkowitą"
+
+#~ msgid "end_x should be an int"
+#~ msgstr "end_x powinien być całkowity"
+
+#~ msgid "first argument must be an iterable"
+#~ msgstr "pierwszy argument musi być iterowalny"
+
 #~ msgid "firstbit must be MSB"
 #~ msgstr "firstbit musi być MSB"
+
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "funkcja nie bierze argumentów nazwanych"
+
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr "argument 2 do int() busi być pomiędzy 2 a 36"
+
+#~ msgid "integer required"
+#~ msgstr "wymagana liczba całkowita"
 
 #~ msgid "interval not in range 0.0020 to 10.24"
 #~ msgstr "przedział poza zakresem 0.0020 do 10.24"
@@ -5444,20 +5260,136 @@ msgstr ""
 #~ msgid "invalid SPI peripheral"
 #~ msgstr "złe SPI"
 
+#~ msgid "invalid arguments"
+#~ msgstr "złe arguemnty"
+
+#~ msgid "invalid dupterm index"
+#~ msgstr "zły indeks dupterm"
+
+#~ msgid "invalid format"
+#~ msgstr "zły format"
+
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr "argumenty nazwane nieobsługiwane - proszę użyć zwykłych argumentów"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "słowa kluczowe muszą być łańcuchami"
+
+#~ msgid "length argument not allowed for this type"
+#~ msgstr "ten typ nie pozawala na podanie długości"
+
+#~ msgid "long int not supported in this build"
+#~ msgstr "long int jest nieobsługiwany"
+
+#~ msgid "max_length must be > 0"
+#~ msgstr "max_length musi być > 0"
+
 #~ msgid "must specify all of sck/mosi/miso"
 #~ msgstr "sck/mosi/miso muszą być podane"
 
 #~ msgid "name must be a string"
 #~ msgstr "nazwa musi być łańcuchem"
 
+#~ msgid "name reused for argument"
+#~ msgstr "nazwa użyta ponownie jako argument"
+
+#~ msgid "no available NIC"
+#~ msgstr "brak wolnego NIC"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "argument nienazwany po */**"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "argument nienazwany po nazwanym"
+
+#~ msgid "number of arguments must be 2, or 3"
+#~ msgstr "liczba argumentów musi wynosić 2 lub 3"
+
+#~ msgid "object '%s' is not a tuple or list"
+#~ msgstr "obiekt '%s' nie jest krotką ani listą"
+
+#~ msgid "object does not support item assignment"
+#~ msgstr "obiekt nie obsługuje przypisania do elementów"
+
+#~ msgid "object does not support item deletion"
+#~ msgstr "obiekt nie obsługuje usuwania elementów"
+
+#~ msgid "object is not subscriptable"
+#~ msgstr "obiekt nie ma elementów"
+
+#~ msgid "offset out of bounds"
+#~ msgstr "offset poza zakresem"
+
+#~ msgid "palette_index should be an int"
+#~ msgstr "palette_index powinien być całkowity"
+
+#~ msgid "parameter annotation must be an identifier"
+#~ msgstr "anotacja parametru musi być identyfikatorem"
+
+#~ msgid "pixel value requires too many bits"
+#~ msgstr "wartość piksela wymaga zbyt wielu bitów"
+
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+#~ msgstr ""
+#~ "pixel_shader musi być typu displayio.Palette lub dispalyio.ColorConverter"
+
+#~ msgid "pop from an empty set"
+#~ msgstr "pop z pustego zbioru"
+
+#~ msgid "pop from empty list"
+#~ msgstr "pop z pustej listy"
+
+#~ msgid "popitem(): dictionary is empty"
+#~ msgstr "popitem(): słownik jest pusty"
+
+#~ msgid "queue overflow"
+#~ msgstr "przepełnienie kolejki"
+
 #~ msgid "rawbuf is not the same size as buf"
 #~ msgstr "rawbuf nie jest tej samej wielkości co buf"
+
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "bufor sample_source musi być bytearray lub tablicą typu 'h', 'H', 'b' lub "
+#~ "'B'"
+
+#~ msgid "schedule stack full"
+#~ msgstr "stos planu pełen"
 
 #~ msgid "services includes an object that is not a Service"
 #~ msgstr "obiekt typu innego niż Service w services"
 
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "pojedynczy '}' w specyfikacji formatu"
+
+#~ msgid "slice step cannot be zero"
+#~ msgstr "zerowy krok"
+
+#~ msgid "start_x should be an int"
+#~ msgstr "start_x powinien być całkowity"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "step nie może być zerowe"
+
+#~ msgid "stop must be 1 or 2"
+#~ msgstr "stop musi być 1 lub 2"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr "łańcuchy nieobsługiwane; użyj bytes lub bytearray"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "struct: nie można indeksować"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "threshold musi być w zakresie 0-65536"
+
 #~ msgid "tile index out of bounds"
 #~ msgstr "indeks kafelka poza zakresem"
+
+#~ msgid "time.struct_time() takes a 9-sequence"
+#~ msgstr "time.struct_time() wymaga 9-elementowej sekwencji"
 
 #~ msgid "time.struct_time() takes exactly 1 argument"
 #~ msgstr "time.struct_time() wymaga jednego argumentu"
@@ -5465,11 +5397,59 @@ msgstr ""
 #~ msgid "timeout >100 (units are now seconds, not msecs)"
 #~ msgstr "timeout > 100 (jednostkami są sekundy)"
 
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "timeout musi być >= 0.0"
+
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "zbyt wiele argumentów podanych dla tego formatu"
+
+#~ msgid "tuple index out of range"
+#~ msgstr "indeks krotki poza zakresem"
+
+#~ msgid "tuple/list required on RHS"
+#~ msgstr "wymagana krotka/lista po prawej stronie"
+
+#~ msgid "unindent does not match any outer indentation level"
+#~ msgstr "wcięcie nie pasuje do żadnego wcześniejszego wcięcia"
+
+#~ msgid "unknown format code '%c' for object of type '%s'"
+#~ msgstr "zły kod formatowania '%c' dla obiektu typu '%s'"
+
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr "zły kod foratowania '%c' dla obiektu typu 'float'"
 
 #~ msgid "unknown format code '%c' for object of type 'str'"
 #~ msgstr "zły kod formatowania '%c' dla obiektu typu 'str'"
 
+#~ msgid "unmatched '{' in format"
+#~ msgstr "niepasujące '{' for formacie"
+
+#~ msgid "unsupported types for %q: '%s', '%s'"
+#~ msgstr "złe typy dla %q: '%s', '%s'"
+
+#~ msgid "value_count must be > 0"
+#~ msgstr "value_count musi być > 0"
+
+#~ msgid "vectors must have same lengths"
+#~ msgstr "wektory muszą mieć identyczną długość"
+
 #~ msgid "write_args must be a list, tuple, or None"
 #~ msgstr "write_args musi być listą, krotką lub None"
+
+#~ msgid "wrong argument type"
+#~ msgstr "zły typ argumentu"
+
+#~ msgid "wrong operand type"
+#~ msgstr "zły typ operandu"
+
+#~ msgid "x value out of bounds"
+#~ msgstr "x poza zakresem"
+
+#~ msgid "y should be an int"
+#~ msgstr "y powinno być całkowite"
+
+#~ msgid "y value out of bounds"
+#~ msgstr "y poza zakresem"
+
+#~ msgid "zero step"
+#~ msgstr "zerowy krok"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -83,16 +83,6 @@ msgstr " saída:\n"
 msgid "%%c requires int or char"
 msgstr "%%c requer int ou char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
@@ -100,26 +90,6 @@ msgid ""
 msgstr ""
 "%d pinos de endereço, %d pinos rgb e %d blocos indicam uma altura com %d, "
 "não %d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -303,11 +273,6 @@ msgstr "%q[%u] usa pino extra"
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
 msgstr "%q[%u] espera na entrada fora da contagem"
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
-msgstr "%s"
 
 #: ports/espressif/common-hal/espidf/__init__.c
 #, c-format
@@ -1125,7 +1090,8 @@ msgstr "Para o espaço de cor L8, o bitmap da entrada deve ter 8 bits por pixel"
 
 #: shared-bindings/bitmaptools/__init__.c
 msgid "For RGB colorspaces, input bitmap must have 16 bits per pixel"
-msgstr "Para espaços de cor RGB, o bitmap da entrada deve ter 16 bits por pixel"
+msgstr ""
+"Para espaços de cor RGB, o bitmap da entrada deve ter 16 bits por pixel"
 
 #: ports/cxd56/common-hal/camera/Camera.c
 msgid "Format not supported"
@@ -1647,8 +1613,9 @@ msgstr "Ok"
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Apenas mono com 8 ou 16 bits com "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -1839,7 +1806,8 @@ msgstr "O Polígono precisa de pelo menos 3 pontos"
 
 #: supervisor/shared/safe_mode.c
 msgid "Power dipped. Make sure you are providing enough power."
-msgstr "Falta de energia. Certifique-se que está fornecendo energia suficiente."
+msgstr ""
+"Falta de energia. Certifique-se que está fornecendo energia suficiente."
 
 #: shared-bindings/_bleio/Adapter.c
 msgid "Prefix buffer must be on the heap"
@@ -2132,8 +2100,8 @@ msgstr "Muitos canais na amostra."
 #: shared-module/displayio/__init__.c
 msgid "Too many display busses; forgot displayio.release_displays() ?"
 msgstr ""
-"Excesso de barramentos de exibição; esqueceu do displayio.release_displays() "
-"?"
+"Excesso de barramentos de exibição; esqueceu do displayio."
+"release_displays() ?"
 
 #: shared-module/displayio/__init__.c
 msgid "Too many displays"
@@ -3010,7 +2978,8 @@ msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "destination buffer must be an array of type 'H' for bit_depth = 16"
-msgstr "o buffer do destino deve ser uma matriz do tipo 'H' para bit_depth = 16"
+msgstr ""
+"o buffer do destino deve ser uma matriz do tipo 'H' para bit_depth = 16"
 
 #: py/objdict.c
 msgid "dict update sequence has wrong length"
@@ -3347,7 +3316,8 @@ msgstr "as formas da entrada e da saída diferem"
 
 #: extmod/ulab/code/numpy/create.c
 msgid "input argument must be an integer, a tuple, or a list"
-msgstr "argumento da entrada deve ser um número inteiro, uma tupla ou uma lista"
+msgstr ""
+"argumento da entrada deve ser um número inteiro, uma tupla ou uma lista"
 
 #: extmod/ulab/code/numpy/fft/fft_tools.c
 msgid "input array length must be power of 2"
@@ -3607,8 +3577,8 @@ msgstr "falha na alocação de memória, alocando %u bytes"
 #: py/runtime.c
 msgid "memory allocation failed, heap is locked"
 msgstr ""
-"falha na alocação de memória, a área de alocação dinâmica de variáveis (heap)"
-" está bloqueada"
+"falha na alocação de memória, a área de alocação dinâmica de variáveis "
+"(heap) está bloqueada"
 
 #: py/objarray.c
 msgid "memoryview offset too large"
@@ -4493,326 +4463,19 @@ msgstr "zi deve ser de um tipo float"
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi deve estar na forma (n_section, 2)"
 
-#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
-#~ msgstr "CIRCUITPY_PYSTACK_SIZE inválido\n"
-
-#~ msgid "Unable to allocate the heap."
-#~ msgstr "Não é possível alocar a área de alocação dinâmica de variáveis."
-
 #~ msgid ""
-#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
 #~ msgstr ""
-#~ "O espcamera.Camera requer que o PSRAM seja reservado para que possa ser "
-#~ "configurado. Consulte a documentação para obter mais informações."
-
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr ""
-#~ "'await', 'async for' (async para) ou 'async with' (async com) estão fora "
-#~ "da função async"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' fora do loop"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' fora do loop"
-
-#~ msgid "invalid architecture"
-#~ msgstr "arquitetura inválida"
-
-#~ msgid "unsupported type for %q: '%q'"
-#~ msgstr "tipo sem suporte para %q: '%q'"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Divisão com sub-capturas"
-
-#~ msgid "__init__() should return None, not '%q'"
-#~ msgstr "O __init__() deve retornar Nenhum, não '%q'"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "atributos ainda não suportados"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr "não é possível fazer a divisão truncada de um número complexo"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "não pode importar nome %q"
-
-#~ msgid "cannot unambiguously get sizeof scalar"
-#~ msgstr "Não é possível obter de forma inequívoca a escala do sizeof"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr ""
-#~ "o(s) argumento(s) de palavra-chave ainda não foi implementado - em vez "
-#~ "disso, use argumentos normais"
-
-#~ msgid "length argument not allowed for this type"
-#~ msgstr "o argumento de comprimento não é permitido para este tipo"
-
-#~ msgid "offset out of bounds"
-#~ msgstr "desvio fora dos limites"
-
-#~ msgid "slice step can't be zero"
-#~ msgstr "a etapa da fatia não pode ser zero"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr "a string não é compatível; use bytes ou bytearray"
-
-#~ msgid "Bit clock and word select must be sequential pins"
-#~ msgstr "O Bit clock e o word select devem ser pinos sequenciais"
-
-#~ msgid "Initialization failed due to lack of memory"
-#~ msgstr "A inicialização falhou devido à falta de memória"
-
-#~ msgid "RAISE mode is not implemented"
-#~ msgstr "O modo RAISE não foi implementado"
-
-#~ msgid "WatchDogTimer is not currently running"
-#~ msgstr "O WatchDogTimer não está em execução"
-
-#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-#~ msgstr ""
-#~ "O WatchDogTimer.mode não pode ser alterado uma vez definido para "
-#~ "WatchDogMode.RESET"
-
-#~ msgid "watchdog not initialized"
-#~ msgstr "o watchdog não foi inicializado"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "O ADC2 está sendo usado pelo WiFi"
-
-#, c-format
-#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Não foi possível configurar o controlador ADC DMA, ErrorCode:%d"
-
-#, c-format
-#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Não foi possível inicializar o controlador ADC DMA, ErrorCode:%d"
-
-#, c-format
-#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Não foi possível iniciar o controlador ADC DMA, ErrorCode:%d"
-
-#~ msgid "xTaskCreate failed"
-#~ msgstr "o xTaskCreate falhou"
-
-#~ msgid "Unable to write to address."
-#~ msgstr "Não é possível gravar no endereço."
-
-#~ msgid "queue overflow"
-#~ msgstr "estouro de fila"
-
-#~ msgid "Stopping AP is not supported."
-#~ msgstr "Não há suporte para a interrupção do AP."
-
-#~ msgid "Wifi is in access point mode."
-#~ msgstr "O Wi-Fi está em modo de ponto de acesso."
-
-#~ msgid "Wifi is in station mode."
-#~ msgstr "O Wi-Fi está em modo estação."
+#~ "\n"
+#~ "O código concluiu a execução. Esperando pela recarga.\n"
 
 #~ msgid ""
 #~ "\n"
-#~ "Please file an issue with your program at https://github.com/adafruit/"
-#~ "circuitpython/issues."
+#~ "Code stopped by auto-reload.\n"
 #~ msgstr ""
 #~ "\n"
-#~ "Relate o problema com seu programa em https://github.com/adafruit/"
-#~ "circuitpython/issues."
-
-#~ msgid "'coroutine' object is not an iterator"
-#~ msgstr "O objeto 'corrotina' não é um iterador"
-
-#~ msgid "Buffer is too small"
-#~ msgstr "O buffer é muito pequeno"
-
-#~ msgid "Fault detected by hardware."
-#~ msgstr "Falha detectada pelo hardware."
-
-#~ msgid "The power dipped. Make sure you are providing enough power."
-#~ msgstr ""
-#~ "A alimentação foi reduzida. Certifique-se de fornecer energia suficiente."
-
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-#~ msgstr ""
-#~ "o pixel_shader deve ser displayio.Palette ou displayio.ColorConverter"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "Arquivo .mpy corrompido"
-
-#~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
-#~ msgstr ""
-#~ "Arquivo .mpy incompatível. Atualize todos os arquivos .mpy. Consulte "
-#~ "http://adafru.it/mpy-update para mais informações."
-
-#~ msgid "can't convert to %q"
-#~ msgstr "não é possível converter para %q"
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "não pode haver vários **x"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "não pode haver vários *x"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "constante deve ser um inteiro"
-
-#~ msgid "incompatible native .mpy architecture"
-#~ msgstr "arquivo .mpy com arquitetura nativa incompatível"
-
-#~ msgid "invalid format"
-#~ msgstr "formato inválido"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "as palavras-chave devem ser uma cadeia de caracteres"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "um arg sem palavra-chave após */ **"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "um arg não-palavra-chave após a palavra-chave arg"
-
-#, c-format
-#~ msgid "Instruction %d shifts in more bits than pin count"
-#~ msgstr "A instrução %d muda com mais bits do que a quantidade dos pinos"
-
-#, c-format
-#~ msgid "Instruction %d shifts out more bits than pin count"
-#~ msgstr "A instrução %d desloca mais bits do que a quantidade dos pinos"
-
-#, c-format
-#~ msgid "Instruction %d uses extra pin"
-#~ msgstr "A instrução %d usa um pino extra"
-
-#, c-format
-#~ msgid "Instruction %d waits on input outside of count"
-#~ msgstr "A instrução %d aguarda a entrada de fora da contagem"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
-#~ msgstr "Faltando first_in_pin. A instrução %d lê pinos(s)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
-#~ msgstr "Faltando first_in_pin. A instrução %d muda a partir do(s) pino(s)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
-#~ msgstr "Faltando first_in_pin. A instrução %d aguarda com base no pino"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
-#~ msgstr "Faltando first_out_pin. A instrução %d muda para o(s) pinos(s)"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
-#~ msgstr "Faltando first_out_pin. A instrução %d escreve nos pinos(s)"
-
-#, c-format
-#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
-#~ msgstr "Faltando first_set_pin. A instrução %d define os pinos(s)"
-
-#, c-format
-#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
-#~ msgstr "Falta o jmp_pin. A instrução %d salta no pino"
-
-#~ msgid "inputs are not iterable"
-#~ msgstr "as entradas não são iteráveis"
-
-#~ msgid "Too many display busses"
-#~ msgstr "Muitos barramentos estão sendo exibidos"
-
-#~ msgid "Cannot transfer without MOSI and MISO pins"
-#~ msgstr "Não é possível transferir sem os pinos MOSI e MISO"
-
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "O hardware está ocupado, tente os pinos alternativos"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "O pino MISO ou MOSI está ausente"
-
-#~ msgid "Missing MISO or MOSI pin"
-#~ msgstr "Falta o pino MISO ou o MOSI"
-
-#~ msgid "No MISO Pin"
-#~ msgstr "Nenhum pino MISO"
-
-#~ msgid "No MISO pin"
-#~ msgstr "Nenhum pino MISO"
-
-#~ msgid "No MOSI Pin"
-#~ msgstr "Nenhum pino MOSI"
-
-#~ msgid "No MOSI pin"
-#~ msgstr "Nenhum pino MOSI"
-
-#~ msgid "No RX pin"
-#~ msgstr "Nenhum pino RX"
-
-#~ msgid "No TX pin"
-#~ msgstr "Nenhum pino TX"
-
-#~ msgid "no reset pin available"
-#~ msgstr "nenhum pino de redefinição está disponível"
-
-#~ msgid "Sleep Memory not available"
-#~ msgstr "Sleep memory não está disponível"
-
-#~ msgid "input and output shapes are not compatible"
-#~ msgstr "as formas de entrada e saída não são compatíveis"
-
-#~ msgid "shape must be a tuple"
-#~ msgstr "a forma deve ser uma tupla"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "O brilho deve ser 0-1,0"
-
-#, c-format
-#~ msgid "Error in MIDI stream at position %d"
-#~ msgstr "Houve um erro no fluxo MIDI na posição %d"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "O valor máximo de x quando espelhado é %d"
-
-#~ msgid "x value out of bounds"
-#~ msgstr "o valor x está fora dos limites"
-
-#~ msgid "y value out of bounds"
-#~ msgstr "o valor y está fora dos limites"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "O I2SOut não está disponível"
-
-#~ msgid "PDMIn not available"
-#~ msgstr "O PDMIn não está disponível"
-
-#~ msgid "out of range of source"
-#~ msgstr "fora do alcance da fonte"
-
-#~ msgid "pixel value requires too many bits"
-#~ msgstr "o valor do pixel requer bits demais"
-
-#~ msgid "value_count must be > 0"
-#~ msgstr "o value_count deve ser > 0"
-
-#~ msgid "64 bit types"
-#~ msgstr "Tipos 64 bit"
-
-#~ msgid "No key was specified"
-#~ msgstr "Nenhuma chave foi definida"
-
-#~ msgid "Scan already in progess. Stop with stop_scan."
-#~ msgstr "O escaneamento já está em andamento. Interrompa com stop_scan."
-
-#, c-format
-#~ msgid "Unkown error code %d"
-#~ msgstr "Código de erro desconhecido %d"
-
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "Muitos argumentos fornecidos com o formato dado"
+#~ "O código parou através do auto-reload.\n"
 
 #~ msgid ""
 #~ "\n"
@@ -4825,12 +4488,6 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ "\n"
 #~ "\n"
 
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "Forneça pelo menos um pino UART"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "%q pino inválido"
-
 #~ msgid ""
 #~ "\n"
 #~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
@@ -4840,778 +4497,21 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ "Registre um problema com o conteúdo do seu controlador no CIRCUITPY\n"
 #~ "https://github.com/adafruit/circuitpython/issues\n"
 
-#~ msgid "Attempted heap allocation when VM not running."
-#~ msgstr ""
-#~ "Tentativa de alocação das pilhas quando o VM não estiver em funcionamento."
-
-#~ msgid "Boot device must be first device (interface #0)."
-#~ msgstr ""
-#~ "O dispositivo de inicialização deve ser o primeiro dispositivo (interface "
-#~ "#0)."
-
-#~ msgid "Both buttons were pressed at start up.\n"
-#~ msgstr "Ambos os botões foram pressionados na inicialização.\n"
-
-#~ msgid "Button A was pressed at start up.\n"
-#~ msgstr "O botão A foi pressionado na inicialização.\n"
-
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "O CircuitPython não conseguiu alocar o heap."
-
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "Falha no HardFault_Handler."
-
-#~ msgid "Fatal error."
-#~ msgstr "Erro fatal."
-
-#~ msgid "Invalid memory access."
-#~ msgstr "O acesso da memória é inválido."
-
-#~ msgid "Nordic system firmware failure assertion."
-#~ msgstr "Declaração de falha do firmware do sistema nórdico."
-
-#~ msgid "The BOOT button was pressed at start up.\n"
-#~ msgstr "O botão BOOT foi pressionado na inicialização.\n"
-
 #~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Increase the stack size if you know how. If not:"
+#~ "\n"
+#~ "Please file an issue with your program at https://github.com/adafruit/"
+#~ "circuitpython/issues."
 #~ msgstr ""
-#~ "A área de alocação dinâmica de variáveis (heap) do CircuitPython foi "
-#~ "corrompido pois a pilha era muito pequena.\n"
-#~ "Aumente o tamanho da pilha se souber como. Senão:"
-
-#~ msgid "The SW38 button was pressed at start up.\n"
-#~ msgstr "O botão SW38 foi pressionado na inicialização.\n"
-
-#~ msgid "The VOLUME button was pressed at start up.\n"
-#~ msgstr "O botão VOLUME foi pressionado na inicialização.\n"
-
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode."
-#~ msgstr ""
-#~ "O módulo `microcontrolador` foi utilizado para iniciar em modo seguro. "
-#~ "Pressione reset para encerrar do modo de segurança."
-
-#~ msgid "The central button was pressed at start up.\n"
-#~ msgstr "O botão central foi pressionado na inicialização.\n"
-
-#~ msgid "The left button was pressed at start up.\n"
-#~ msgstr "O botão esquerdo foi pressionado na inicialização.\n"
-
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY)."
-#~ msgstr ""
-#~ "O alimentação do micro controlador diminuiu. Certifique-se de que a sua "
-#~ "fonte de alimentação fornece\n"
-#~ "corrente suficiente para todo o circuito e pressione reset (depois de "
-#~ "ejetar o CIRCUITPY)."
-
-#~ msgid "To exit, please reset the board without requesting safe mode."
-#~ msgstr "Para sair, reinicie a placa sem solicitar o modo de segurança."
-
-#~ msgid "You are in safe mode because:\n"
-#~ msgstr "Você está no modo de segurança pois:\n"
-
-#~ msgid ""
-#~ "You pressed the reset button during boot. Press again to exit safe mode."
-#~ msgstr ""
-#~ "Você pressionou o botão reset durante a inicialização. Pressione-o "
-#~ "novamente para sair do modo de segurança."
-
-#~ msgid ""
-#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
-#~ msgstr ""
-#~ "esp32_camera.Camera requer que uma reserva PSRAM seja configurada. "
-#~ "Consulte a documentação para obter mais informações."
-
-#~ msgid "%q must be of type %q"
-#~ msgstr "%q deve ser do tipo %q"
-
-#~ msgid "%q must be of type %q or None"
-#~ msgstr "%q deve ser do tipo %q ou nenhum"
-
-#~ msgid "Expected a %q"
-#~ msgstr "Esperado um"
-
-#~ msgid "Expected a %q or %q"
-#~ msgstr "Era esperado um %q ou %q"
-
-#~ msgid "Expected an %q"
-#~ msgstr "Esperava-se um(a) %q"
-
-#, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "O IV deve ter %d bytes de comprimento"
-
-#~ msgid "Not settable"
-#~ msgstr "Não configurável"
-
-#~ msgid "expected '%q' but got '%q'"
-#~ msgstr "o retorno esperado era '%q', porém obteve '%q'"
-
-#~ msgid "expected '%q' or '%q' but got '%q'"
-#~ msgstr "o retorno esperado era '%q' ou '%q', porém obteve '%q'"
-
-#~ msgid "Read-only object"
-#~ msgstr "Objeto de leitura apenas"
-
-#~ msgid "frequency is read-only for this board"
-#~ msgstr "nesta placa, a frequência é de apenas leitura"
-
-#~ msgid "Pins 21+ not supported from ULP"
-#~ msgstr "Os pinos 21+ não são suportados pelo ULP"
-
-#~ msgid "Unable to write"
-#~ msgstr "Não é possível escrever"
-
-#~ msgid "%q length must be >= 1"
-#~ msgstr "o comprimento %q deve ser >=1"
-
-#~ msgid "%q must be a string"
-#~ msgstr "%q deve ser uma string"
-
-#~ msgid "%q must be an int"
-#~ msgstr "%q deve ser um inteiro"
-
-#~ msgid "%q with a report ID of 0 must be of length 1"
-#~ msgstr "%q com um relatório com ID de 0 deve ter comprimento 1"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "Pelo menos %d %q pode ser definido (não %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Pinos inválidos"
-
-#, c-format
-#~ msgid "No more than %d HID devices allowed"
-#~ msgstr "Não são permitidos mais do que %d dispositivos HID"
-
-#~ msgid "byteorder is not a string"
-#~ msgstr "a ordem dos bytes não é uma cadeia de caracteres"
-
-#~ msgid "can't convert %q to int"
-#~ msgstr "Não é possível converter %q para int"
-
-#~ msgid "complex division by zero"
-#~ msgstr "divisão complexa por zero"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr "int() arg 2 deve ser >= 2 e <= 36"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "o long int não é suportado nesta compilação"
-
-#~ msgid "slice step cannot be zero"
-#~ msgstr "a etapa da fatia não pode ser zero"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "o passo deve ser diferente de zero"
-
-#~ msgid "string indices must be integers, not %q"
-#~ msgstr "a sequência dos índices devem ser inteiros, não %q"
-
-#~ msgid "time.struct_time() takes a 9-sequence"
-#~ msgstr "time.struct_time() leva uma sequência com 9"
-
-#~ msgid "zero step"
-#~ msgstr "passo zero"
-
-#~ msgid "invalid traceback"
-#~ msgstr "rastreamento inválido"
-
-#~ msgid "WatchDogTimer.timeout must be greater than 0"
-#~ msgstr "O WatchDogTimer.timeout deve ser maior que 0"
-
-#~ msgid "non-Device in %q"
-#~ msgstr "não dispositivo em %q"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "único '}' encontrado na string do formato"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "Limite deve estar no alcance de 0-65536"
-
-#~ msgid "timeout must be 0.0-100.0 seconds"
-#~ msgstr "o tempo limite deve ser entre 0.0 a 100.0 segundos"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "um '{' sem par no formato"
-
-#~ msgid "watchdog timeout must be greater than 0"
-#~ msgstr "o tempo limite do watchdog deve ser maior que 0"
-
-#~ msgid "To exit, please reset the board without "
-#~ msgstr "Para sair, por favor, reinicie a placa sem "
-
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "Você solicitou o início do modo de segurança através do "
-
-#~ msgid "pressing BOOT button at start up.\n"
-#~ msgstr "pressionando o botão BOOT na inicialização.\n"
-
-#~ msgid "pressing SW38 button at start up.\n"
-#~ msgstr "pressionando o botão SW38 na inicialização.\n"
-
-#~ msgid "pressing VOLUME button at start up.\n"
-#~ msgstr "pressionando o botão VOLUME na inicialização.\n"
-
-#~ msgid "pressing boot button at start up.\n"
-#~ msgstr "pressionando o botão de boot na inicialização.\n"
-
-#~ msgid "pressing both buttons at start up.\n"
-#~ msgstr "pressionando ambos os botões durante a inicialização.\n"
-
-#~ msgid "pressing central button at start up.\n"
-#~ msgstr "pressionando o botão central na inicialização.\n"
-
-#~ msgid "pressing button A at start up.\n"
-#~ msgstr "pressionando o botão A na inicialização.\n"
-
-#~ msgid "pressing the left button at start up\n"
-#~ msgstr "pressionando o botão esquerdo durante a inicialização\n"
-
-#~ msgid "Only one TouchAlarm can be set in deep sleep."
-#~ msgstr "Apenas um TouchAlarm pode ser colocado em deep sleep."
-
-#~ msgid "Firmware image is invalid"
-#~ msgstr "A imagem do firmware é invalida"
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "Transmita o método ausente readinto() ou write()."
-
-#~ msgid "%q must be >= 0"
-#~ msgstr "%q deve ser >= 0"
-
-#~ msgid "%q must be >= 1"
-#~ msgstr "%q deve ser >= 1"
-
-#~ msgid "address out of bounds"
-#~ msgstr "endereço fora dos limites"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr "destination_length deve ser um int >= 0"
-
-#~ msgid "type object 'generator' has no attribute '__await__'"
-#~ msgstr ""
-#~ "o tipo do objeto 'generator' não possui qualquer atributo '__await__'"
-
-#~ msgid "color should be an int"
-#~ msgstr "cor deve ser um int"
-
-#~ msgid "end_x should be an int"
-#~ msgstr "end_x deve ser um int"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "palette_index deve ser um int"
-
-#~ msgid "start_x should be an int"
-#~ msgstr "start_x deve ser um int"
-
-#~ msgid "y should be an int"
-#~ msgstr "y deve ser um int"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "O buffer sample_source deve ser um bytearray ou matriz do tipo 'h', 'H', "
-#~ "'b' ou 'B'"
-
-#~ msgid "Expected an alarm"
-#~ msgstr "Um alarme era esperado"
-
-#~ msgid "All I2C targets are in use"
-#~ msgstr "Todos os alvos I2C já estão em uso"
-
-#~ msgid "Failed to init wifi"
-#~ msgstr "Houve uma falha ao iniciar o wifi"
-
-#~ msgid "input must be a tensor of rank 2"
-#~ msgstr "a entrada dos dados deve ser um tensor de nível 2"
-
-#~ msgid "maximum number of dimensions is 4"
-#~ msgstr "O número máximo de dimensões são 4"
-
-#~ msgid "Watchdog timer expired."
-#~ msgstr "O temporizador Watchdog expirou."
-
-#~ msgid "ssid can't be more than 32 bytes"
-#~ msgstr "O ssid não pode ter mais do que 32 bytes"
-
-#~ msgid "%q must be a tuple of length 2"
-#~ msgstr "%q deve ser uma tupla de comprimento 2"
-
-#~ msgid "%q must be between %d and %d"
-#~ msgstr "%q deve estar entre %d e %d"
-
-#~ msgid "%q should be an int"
-#~ msgstr "%q deve ser um int"
-
-#~ msgid "(x,y) integers required"
-#~ msgstr "(x,y) é obrigatório o uso de números inteiros"
-
-#~ msgid "Address type out of range"
-#~ msgstr "O tipo do endereço está fora do alcance"
-
-#~ msgid "AnalogIn not supported on given pin"
-#~ msgstr "O AnalogIn não é compatível no pino informado"
-
-#~ msgid "AnalogOut functionality not supported"
-#~ msgstr "Funcionalidade AnalogOut não suportada"
-
-#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-#~ msgstr "O AnalogOut é de apenas 16 bits. O valor deve ser menor que 65536."
-
-#~ msgid "AnalogOut not supported on given pin"
-#~ msgstr "Saída analógica não suportada no pino fornecido"
-
-#, c-format
-#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
-#~ msgstr "A profundidade dos bits deve ser de 1 até 6 inclusive, porém não %d"
-
-#, c-format
-#~ msgid "Buffer incorrect size. Should be %d bytes."
-#~ msgstr "Buffer de tamanho incorreto. Deve ser %d bytes."
-
-#~ msgid "Buffer must be at least length 1"
-#~ msgstr "O comprimento do buffer deve ter pelo menos 1"
-
-#~ msgid "Bytes must be between 0 and 255."
-#~ msgstr "Os bytes devem estar entre 0 e 255."
-
-#~ msgid "Cannot output both channels on the same pin"
-#~ msgstr "Não é possível emitir os dois canais no mesmo pino"
-
-#~ msgid "Cannot read without MISO pin."
-#~ msgstr "Não é possível ler sem o pino MISO."
-
-#~ msgid "Cannot reset into bootloader because no bootloader is present."
-#~ msgstr ""
-#~ "Não é possível redefinir para o bootloader porque o mesmo não está "
-#~ "presente."
-
-#~ msgid "Cannot transfer without MOSI and MISO pins."
-#~ msgstr "Não é possível transferir sem os pinos MOSI e MISO."
-
-#~ msgid "Cannot write without MOSI pin."
-#~ msgstr "Não é possível fazer a escrita sem um pino MOSI."
-
-#~ msgid "Clock pin init failed."
-#~ msgstr "Inicialização do pino de Clock falhou."
-
-#~ msgid "Command must be an int between 0 and 255"
-#~ msgstr "O comando deve ser um int entre 0 e 255"
-
-#~ msgid "Could not initialize Camera"
-#~ msgstr "Não foi possível inicializar a Câmera"
-
-#~ msgid "Could not initialize GNSS"
-#~ msgstr "Não foi possível inicializar o GNSS"
-
-#~ msgid "Could not initialize SDCard"
-#~ msgstr "Não foi possível inicializar o SDCard"
-
-#~ msgid "Could not initialize UART"
-#~ msgstr "Não foi possível inicializar o UART"
-
-#~ msgid "Could not re-init channel"
-#~ msgstr "Não foi possível reiniciar o canal"
-
-#~ msgid "Could not re-init timer"
-#~ msgstr "Não foi possível reiniciar o temporizador"
-
-#~ msgid "Could not restart PWM"
-#~ msgstr "Não foi possível reiniciar o PWM"
-
-#~ msgid "Couldn't allocate first buffer"
-#~ msgstr "Não pôde alocar primeiro buffer"
-
-#~ msgid "Couldn't allocate input buffer"
-#~ msgstr "Não foi possível alocar o buffer de entrada"
-
-#~ msgid "Couldn't allocate second buffer"
-#~ msgstr "Não pôde alocar segundo buffer"
-
-#~ msgid "DigitalInOut not supported on given pin"
-#~ msgstr "O DigitalInOut não é compatível em um determinado pino"
-
-#, c-format
-#~ msgid "Expected tuple of length %d, got %d"
-#~ msgstr "Tupla esperada com comprimento %d, obteve %d"
-
-#~ msgid "Failed to allocate RX buffer"
-#~ msgstr "Falha ao alocar buffer RX"
-
-#, c-format
-#~ msgid "Failed to allocate RX buffer of %d bytes"
-#~ msgstr "Falha ao alocar buffer RX de %d bytes"
-
-#, c-format
-#~ msgid "Framebuffer requires %d bytes"
-#~ msgstr "O Framebuffer requer %d bytes"
-
-#~ msgid "Hostname must be between 1 and 253 characters"
-#~ msgstr "O nome do host deve ter entre 1 e 253 caracteres"
-
-#~ msgid "I2C Init Error"
-#~ msgstr "Erro de inicialização do I2C"
-
-#~ msgid "Invalid %q pin selection"
-#~ msgstr "Seleção inválida dos pinos %q"
-
-#~ msgid "Invalid AuthMode"
-#~ msgstr "AuthMode inválido"
-
-#~ msgid "Invalid BMP file"
-#~ msgstr "Arquivo BMP inválido"
-
-#~ msgid "Invalid DAC pin supplied"
-#~ msgstr "O pino DAC informado é inválido"
-
-#~ msgid "Invalid MIDI file"
-#~ msgstr "O arquivo MIDI é inválido"
-
-#~ msgid "Invalid PWM frequency"
-#~ msgstr "Frequência PWM inválida"
-
-#~ msgid "Invalid Pin"
-#~ msgstr "Pino inválido"
-
-#~ msgid "Invalid buffer size"
-#~ msgstr "O tamanho do buffer é inválido"
-
-#~ msgid "Invalid byteorder string"
-#~ msgstr "A cadeia de bytes é inválida"
-
-#~ msgid "Invalid capture period. Valid range: 1 - 500"
-#~ msgstr "O período de captura é inválido. O intervalo válido é: 1 - 500"
-
-#~ msgid "Invalid channel count"
-#~ msgstr "A contagem do canal é inválido"
-
-#, c-format
-#~ msgid "Invalid data_count %d"
-#~ msgstr "data_count %d inválido"
-
-#~ msgid "Invalid direction."
-#~ msgstr "Direção inválida."
-
-#~ msgid "Invalid file"
-#~ msgstr "Arquivo inválido"
-
-#~ msgid "Invalid mode"
-#~ msgstr "Modo inválido"
-
-#~ msgid "Invalid number of bits"
-#~ msgstr "Número inválido de bits"
-
-#~ msgid "Invalid phase"
-#~ msgstr "Fase Inválida"
-
-#~ msgid "Invalid pin"
-#~ msgstr "Pino inválido"
-
-#~ msgid "Invalid pin for left channel"
-#~ msgstr "Pino inválido para canal esquerdo"
-
-#~ msgid "Invalid pin for right channel"
-#~ msgstr "Pino inválido para canal direito"
-
-#~ msgid "Invalid polarity"
-#~ msgstr "Polaridade inválida"
-
-#~ msgid "Invalid properties"
-#~ msgstr "Propriedades inválidas"
-
-#~ msgid "Invalid run mode."
-#~ msgstr "O modo de execução é inválido."
-
-#~ msgid "Invalid security_mode"
-#~ msgstr "O Security_mode é inválido"
-
-#~ msgid "Invalid voice"
-#~ msgstr "A voz é inválida"
-
-#~ msgid "Invalid voice count"
-#~ msgstr "A contagem da voz é inválida"
-
-#~ msgid "Invalid wave file"
-#~ msgstr "Aqruivo de ondas inválido"
-
-#~ msgid "Invalid word/bit length"
-#~ msgstr "O comprimento do bit/palavra são inválidos"
-
-#~ msgid "Layer already in a group."
-#~ msgstr "A camada já existe em um grupo."
-
-#~ msgid "Layer must be a Group or TileGrid subclass."
-#~ msgstr "A camada deve ser uma subclasse Group ou TileGrid."
-
-#~ msgid "MISO pin init failed."
-#~ msgstr "A inicialização do pino MISO falhou."
-
-#~ msgid "MOSI pin init failed."
-#~ msgstr "Inicialização do pino MOSI falhou."
-
-#~ msgid "Messages limited to 8 bytes"
-#~ msgstr "As mensagens estão limitadas a 8 bytes"
-
-#, c-format
-#~ msgid "More than %d report ids not supported"
-#~ msgstr "Mais de %d reportam ids não compatíveis"
-
-#~ msgid "No hardware support on clk pin"
-#~ msgstr "Sem suporte de hardware no pino de clock"
-
-#~ msgid "No hardware support on pin"
-#~ msgstr "Nenhum suporte de hardware no pino"
-
-#, c-format
-#~ msgid "Output buffer must be at least %d bytes"
-#~ msgstr "O buffer de saída deve ter ao menos %d bytes"
-
-#~ msgid ""
-#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-#~ msgstr ""
-#~ "O duty_cycle do PWM deve estar entre 0 e inclusive 65535 (com resolução "
-#~ "de 16 bits)"
-
-#~ msgid "Pin count must be at least 1"
-#~ msgstr "A contagem dos pinos deve ser com pelo menos 1"
-
-#~ msgid "Pin does not have ADC capabilities"
-#~ msgstr "O pino não tem recursos de ADC"
-
-#~ msgid "Program must contain at least one 16-bit instruction."
-#~ msgstr "O programa deve conter pelo menos uma instrução com 16 bits."
-
-#~ msgid "Program too large"
-#~ msgstr "O programa é muito grande"
-
-#~ msgid "RS485 Not yet supported on this device"
-#~ msgstr "Ainda não há suporte para o RS485 neste dispositivo"
-
-#~ msgid "RTC calibration is not supported on this board"
-#~ msgstr "A calibração RTC não é suportada nesta placa"
-
-#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
-#~ msgstr "RTS/CTS/RS485 Ainda não é compatível neste dispositivo"
-
-#~ msgid "SPI Init Error"
-#~ msgstr "Houve um erro na inicialização SPI"
-
-#~ msgid "SPI Re-initialization error"
-#~ msgstr "Houve um erro na reinicialização SPI"
-
-#~ msgid "Sample rate must be positive"
-#~ msgstr "A taxa de amostragem deve ser positiva"
-
-#, c-format
-#~ msgid "Sample rate too high. It must be less than %d"
-#~ msgstr "Taxa de amostragem muito alta. Deve ser menor que %d"
-
-#~ msgid "Set pin count must be between 1 and 5"
-#~ msgstr "A definição da contagem dos pinos deve estar entre 1 e 5"
-
-#~ msgid "Side set pin count must be between 1 and 5"
-#~ msgstr ""
-#~ "A definição da contagem dos pinos do conjunto lateral deve estar entre 1 "
-#~ "e 5"
-
-#~ msgid "Stack size must be at least 256"
-#~ msgstr "O tamanho da pilha deve ser pelo menos 256"
-
-#~ msgid "Tile value out of bounds"
-#~ msgstr "O valor do bloco está fora dos limites"
-
-#~ msgid "UART Buffer allocation error"
-#~ msgstr "Houve um erro na alocação do Buffer UART"
-
-#~ msgid "UART De-init error"
-#~ msgstr "Houve um erro da não inicialização do UART"
-
-#~ msgid "UART Init Error"
-#~ msgstr "Houve um erro na inicialização do UART"
-
-#~ msgid "UART Re-init error"
-#~ msgstr "Houve um erro na reinicialização do UART"
-
-#~ msgid "UART write error"
-#~ msgstr "Houve um erro na gravação UART"
-
-#~ msgid "Unsupported baudrate"
-#~ msgstr "Taxa de transmissão não suportada"
-
-#~ msgid "WiFi password must be between 8 and 63 characters"
-#~ msgstr "A senha do Wi-Fi deve ter entre 8 e 63 caracteres"
-
-#~ msgid "bits must be in range 5 to 9"
-#~ msgstr "os bits devem estar na faixa entre 5 a 9"
-
-#~ msgid "bytes > 8 bits not supported"
-#~ msgstr "bytes > 8 bits não suportado"
-
-#~ msgid "calibration value out of range +/-127"
-#~ msgstr "Valor de calibração fora do intervalo +/- 127"
-
-#~ msgid "can only be registered in one parent"
-#~ msgstr "pode ser registrado apenas numa principal"
-
-#~ msgid "circle can only be registered in one parent"
-#~ msgstr "o círculo só pode ser registrado em um pai"
-
-#~ msgid "max_connections must be between 0 and 10"
-#~ msgstr "max_connections deve estar entre 0 e 10"
-
-#~ msgid "max_length must be >= 0"
-#~ msgstr "max_length deve ser >= 0"
-
-#~ msgid "polygon can only be registered in one parent"
-#~ msgstr "o polígono só pode ser registrado em um pai"
-
-#~ msgid "pull_threshold must be between 1 and 32"
-#~ msgstr "O pull_threshold deve ser entre 1 e 32"
-
-#~ msgid "push_threshold must be between 1 and 32"
-#~ msgstr "O pull_threshold deve ser entre 1 e 32"
-
-#~ msgid "stop must be 1 or 2"
-#~ msgstr "o stop deve ser 1 ou 2"
-
-#~ msgid "tile must be greater than zero"
-#~ msgstr "o bloco deve ser maior que zero"
-
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "o tempo limite deve ser >= 0,0"
-
-#, c-format
-#~ msgid "width must be from 2 to 8 (inclusive), not %d"
-#~ msgstr "a largura deve ser entre 2 a 8 (inclusive), não %d"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "Operação não suportada"
-
-#~ msgid "divisor must be 4"
-#~ msgstr "o divisor deve ser 4"
+#~ "\n"
+#~ "Relate o problema com seu programa em https://github.com/adafruit/"
+#~ "circuitpython/issues."
 
 #~ msgid ""
 #~ "\n"
-#~ "Code stopped by auto-reload.\n"
+#~ "To exit, please reset the board without "
 #~ msgstr ""
 #~ "\n"
-#~ "O código parou através do auto-reload.\n"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "O brilho deve estar entre 0 e 255"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "não pode executar a importação relativa"
-
-#, c-format
-#~ msgid "No I2C device at address: %x"
-#~ msgstr "Nenhum dispositivo I2C no endereço: %x"
-
-#~ msgid "Unsupported pull value."
-#~ msgstr "O valor pull não é compatível."
-
-#~ msgid "Station must be started"
-#~ msgstr "A estação deve ser iniciada"
-
-#~ msgid "%q must <= %d"
-#~ msgstr "o %q deve ser <= %d"
-
-#, c-format
-#~ msgid ""
-#~ "Welcome to Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Please visit learn.adafruit.com/category/circuitpython for project "
-#~ "guides.\n"
-#~ "\n"
-#~ "To list built-in modules please do `help(\"modules\")`.\n"
-#~ msgstr ""
-#~ "Bem-vindo ao Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Para obter guias de projeto, visite learn.adafruit.com/category/"
-#~ "circuitpython.\n"
-#~ "\n"
-#~ "Para listar os módulos internos, faça `help(\"modules\")`.\n"
-
-#~ msgid "integer required"
-#~ msgstr "inteiro requerido"
-
-#~ msgid "abort() called"
-#~ msgstr "abort() chamado"
-
-#~ msgid "f-string expression part cannot include a '#'"
-#~ msgstr "A parte da expressão f-string não pode incluir um '#'"
-
-#~ msgid "f-string expression part cannot include a backslash"
-#~ msgstr "A parte da expressão f-string não pode incluir uma barra invertida"
-
-#~ msgid "f-string: empty expression not allowed"
-#~ msgstr "f-string: expressão vazia não é permitida"
-
-#~ msgid "f-string: expecting '}'"
-#~ msgstr "f-string: esperando '}'"
-
-#~ msgid "f-string: single '}' is not allowed"
-#~ msgstr "f-string: um único '}' não é permitido"
-
-#~ msgid "invalid arguments"
-#~ msgstr "argumentos inválidos"
-
-#~ msgid "raw f-strings are not implemented"
-#~ msgstr "o f-strings bruto não estão implementados"
-
-#~ msgid "unindent does not match any outer indentation level"
-#~ msgstr "o unindent não coincide com nenhum nível de recuo externo"
-
-#~ msgid "%q list must be a list"
-#~ msgstr "A lista %q deve ser uma lista"
-
-#~ msgid "%q must of type %q"
-#~ msgstr "o %q deve ser do tipo %q"
-
-#~ msgid "Column entry must be digitalio.DigitalInOut"
-#~ msgstr "A entrada da coluna deve ser digitalio.DigitalInOut"
-
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Uma característica é necessária"
-
-#~ msgid "Expected a DigitalInOut"
-#~ msgstr "Espera-se um DigitalInOut"
-
-#~ msgid "Expected a Service"
-#~ msgstr "Esperava um Serviço"
-
-#~ msgid "Expected a UART"
-#~ msgstr "Espera-se uma UART"
-
-#~ msgid "Expected a UUID"
-#~ msgstr "Um UUID é necessário"
-
-#~ msgid "Expected an Address"
-#~ msgstr "Um endereço esperado"
-
-#~ msgid "Row entry must be digitalio.DigitalInOut"
-#~ msgstr "A entrada da linha deve ser digitalio.DigitalInOut"
-
-#~ msgid "buttons must be digitalio.DigitalInOut"
-#~ msgstr "os botões devem ser digitalio.DigitalInOut"
-
-#~ msgid "Invalid frequency"
-#~ msgstr "Frequência inválida"
-
-#~ msgid "Data 0 pin must be byte aligned."
-#~ msgstr "O pino de dados 0 deve ser alinhado por bytes."
-
-#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
-#~ msgstr "bits_per_pixel %d é inválido, deve ser, 1, 4, 8, 16, 24, ou 32"
+#~ "Para encerrar, redefina a placa sem "
 
 #~ msgid ""
 #~ "\n"
@@ -5622,14 +4522,31 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ "modo colar; Ctrl-C para cancelar, Ctrl-D para concluir\n"
 #~ "=== "
 
-#~ msgid "ParallelBus not yet supported"
-#~ msgstr "O ParallelBus ainda não é compatível"
+#, c-format
+#~ msgid "%02X"
+#~ msgstr "%02X"
 
-#~ msgid "raw REPL; CTRL-B to exit\n"
-#~ msgstr "REPL bruto; CTRL-B para encerrar\n"
+#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+#~ msgstr ""
+#~ "%d endereços dos pinos e %d pinos rgb indicam uma altura do %d, não %d"
+
+#~ msgid "%q"
+#~ msgstr "%q"
+
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "Os indicadores %q devem ser inteiros, não %q"
 
 #~ msgid "%q length must be %q"
 #~ msgstr "o comprimento %q deve ser %q"
+
+#~ msgid "%q length must be >= 1"
+#~ msgstr "o comprimento %q deve ser >=1"
+
+#~ msgid "%q list must be a list"
+#~ msgstr "A lista %q deve ser uma lista"
+
+#~ msgid "%q must <= %d"
+#~ msgstr "o %q deve ser <= %d"
 
 #~ msgid "%q must be 0-255"
 #~ msgstr "%q deve ser entre 0-255"
@@ -5637,109 +4554,54 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "%q must be 1-255"
 #~ msgstr "%q deve ser 1-255"
 
-#~ msgid "%q must be None or between 1 and len(report_descriptor)-1"
-#~ msgstr "%q deve ser None ou entre 1 e len(report_descriptor)-1"
+#~ msgid "%q must be >= 0"
+#~ msgstr "%q deve ser >= 0"
 
-#~ msgid "limit should be an int"
-#~ msgstr "o limite deve ser um inteiro"
-
-#~ msgid "no available NIC"
-#~ msgstr "não há uma Placa de Rede disponível"
-
-#~ msgid ""
-#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
-#~ "instead"
-#~ msgstr ""
-#~ "A porta não aceita portadora PWM. Em vez disso informe um pino, "
-#~ "frequência e o ciclo de trabalho"
-
-#~ msgid ""
-#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
-#~ "Carrier instead"
-#~ msgstr ""
-#~ "A porta não aceita pinos ou frequência. Em vez disso, construa e passe um "
-#~ "PWMOut Carrier"
-
-#~ msgid "Instruction %d jumps on pin"
-#~ msgstr "A instrução %d salta no pino"
-
-#~ msgid "%q must store bytes"
-#~ msgstr "o %q deve armazenar bytes"
-
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "O buffer é muito grande e incapaz de alocar"
-
-#~ msgid "interp is defined for 1D arrays of equal length"
-#~ msgstr "o interp é definido para matrizes 1D de igual comprimento"
-
-#~ msgid "trapz is defined for 1D arrays"
-#~ msgstr "Trapz está definido para arrays 1D"
-
-#~ msgid "wrong operand type"
-#~ msgstr "tipo do operando errado"
+#~ msgid "%q must be >= 1"
+#~ msgstr "%q deve ser >= 1"
 
 #~ msgid "%q must be None or 1-255"
 #~ msgstr "%q deve ser Nenhum ou 1-255"
 
-#~ msgid "Only raw int or string supported for ip"
-#~ msgstr "Apenas int ou string bruto é compatível para o ip"
+#~ msgid "%q must be None or between 1 and len(report_descriptor)-1"
+#~ msgstr "%q deve ser None ou entre 1 e len(report_descriptor)-1"
 
-#~ msgid "Only raw int supported for ip"
-#~ msgstr "Apenas o int bruto é compatível para o ip"
+#~ msgid "%q must be a string"
+#~ msgstr "%q deve ser uma string"
 
-#~ msgid ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
-#~ msgstr ""
-#~ "O CircuitPython está no modo de segurança porque você pressionou o botão "
-#~ "de redefinição durante a inicialização. Pressione novamente para sair do "
-#~ "modo de segurança.\n"
+#~ msgid "%q must be a tuple of length 2"
+#~ msgstr "%q deve ser uma tupla de comprimento 2"
 
-#~ msgid "Not running saved code.\n"
-#~ msgstr "O código salvo não está em execução.\n"
+#~ msgid "%q must be an int"
+#~ msgstr "%q deve ser um inteiro"
 
-#~ msgid "Running in safe mode! "
-#~ msgstr "Executando no modo de segurança! "
+#~ msgid "%q must be between %d and %d"
+#~ msgstr "%q deve estar entre %d e %d"
 
-#~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Please increase the stack size if you know how, or if not:"
-#~ msgstr ""
-#~ "A área de alocação dinâmica de variáveis (heap) do CircuitPython foi "
-#~ "corrompida porque a pilha de funções (stack) era muito pequena.\n"
-#~ "Aumente o tamanho da pilha de funções caso saiba como, ou caso não saiba:"
+#~ msgid "%q must be of type %q"
+#~ msgstr "%q deve ser do tipo %q"
 
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode.\n"
-#~ msgstr ""
-#~ "O módulo `microcontrolador` foi utilizado para inicializar no modo de "
-#~ "segurança. Pressione reset para encerrar do modo de segurança.\n"
+#~ msgid "%q must be of type %q or None"
+#~ msgstr "%q deve ser do tipo %q ou nenhum"
 
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY).\n"
-#~ msgstr ""
-#~ "A força do microcontrolador caiu. Verifique se a fonte de alimentação "
-#~ "fornece\n"
-#~ "energia suficiente para todo o circuito e pressione reset (após a ejeção "
-#~ "CIRCUITPY).\n"
+#~ msgid "%q must of type %q"
+#~ msgstr "o %q deve ser do tipo %q"
 
-#~ msgid "You are in safe mode: something unanticipated happened.\n"
-#~ msgstr "Você está no modo de segurança: algo inesperado aconteceu.\n"
+#~ msgid "%q must store bytes"
+#~ msgstr "o %q deve armazenar bytes"
 
-#~ msgid "Pin number already reserved by EXTI"
-#~ msgstr "Número do PIN já está reservado através da EXTI"
+#~ msgid "%q pin invalid"
+#~ msgstr "%q pino inválido"
 
-#~ msgid "USB Busy"
-#~ msgstr "USB ocupada"
+#~ msgid "%q should be an int"
+#~ msgstr "%q deve ser um int"
 
-#~ msgid "USB Error"
-#~ msgstr "Erro na USB"
+#~ msgid "%q with a report ID of 0 must be of length 1"
+#~ msgstr "%q com um relatório com ID de 0 deve ter comprimento 1"
 
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "Os indicadores %q devem ser inteiros, não %q"
+#, c-format
+#~ msgid "%s"
+#~ msgstr "%s"
 
 #~ msgid "'%q' object cannot assign attribute '%q'"
 #~ msgstr "O objeto '%q' não pode definir o atributo '%q'"
@@ -5753,6 +4615,9 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "'%q' object has no attribute '%q'"
 #~ msgstr "O objeto '%q' não possui qualquer atributo '%q'"
 
+#~ msgid "'%q' object is not bytes-like"
+#~ msgstr "objetos '%q' não são bytes-like"
+
 #~ msgid "'%q' object is not subscriptable"
 #~ msgstr "O objeto '%q' não é subscritível"
 
@@ -5761,322 +4626,6 @@ msgstr "zi deve estar na forma (n_section, 2)"
 
 #~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
 #~ msgstr "O número inteiro '%s' 0x%x não cabe na máscara 0x%x"
-
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "Não é possível obter inequivocamente o tamanho do escalar"
-
-#~ msgid "Length must be an int"
-#~ msgstr "Tamanho deve ser um int"
-
-#~ msgid "Length must be non-negative"
-#~ msgstr "O comprimento deve ser positivo"
-
-#~ msgid "invalid decorator"
-#~ msgstr "decorador inválido"
-
-#~ msgid "name reused for argument"
-#~ msgstr "o nome foi reutilizado para o argumento"
-
-#~ msgid "object '%q' is not a tuple or list"
-#~ msgstr "o objeto '%q' não é uma tupla ou uma lista"
-
-#~ msgid "object does not support item assignment"
-#~ msgstr "O objeto não suporta a atribuição dos itens"
-
-#~ msgid "object does not support item deletion"
-#~ msgstr "objeto não suporta a exclusão do item"
-
-#~ msgid "object is not subscriptable"
-#~ msgstr "O objeto não é subroteirizável"
-
-#~ msgid "object of type '%q' has no len()"
-#~ msgstr "o objeto do tipo '%q' não tem len()"
-
-#~ msgid "struct: cannot index"
-#~ msgstr "struct: não pode indexar"
-
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "Não é possível remontar '/' enquanto o USB estiver ativo."
-
-#~ msgid "Timeout waiting for DRDY"
-#~ msgstr "Esgotou-se o tempo limite de espera pelo DRDY"
-
-#~ msgid "Timeout waiting for VSYNC"
-#~ msgstr "Esgotou-se o tempo de espera pelo VSYNC"
-
-#~ msgid "byte code not implemented"
-#~ msgstr "o código dos bytes ainda não foi implementado"
-
-#~ msgid "can't pend throw to just-started generator"
-#~ msgstr "não pode pendurar o lançamento para o gerador recém-iniciado"
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "Índice de dupterm inválido"
-
-#~ msgid "schedule stack full"
-#~ msgstr "agende a pilha de função completa"
-
-#~ msgid "Corrupt raw code"
-#~ msgstr "Código bruto corrompido"
-
-#~ msgid "can only save bytecode"
-#~ msgstr "apenas o bytecode pode ser salvo"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr "Atualmente, as funções do Viper não suportam mais de 4 argumentos"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "endereço %08x não está alinhado com %d bytes"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "função não aceita argumentos de palavras-chave"
-
-#~ msgid "parameter annotation must be an identifier"
-#~ msgstr "a anotação do parâmetro deve ser um identificador"
-
-#~ msgid "Total data to write is larger than outgoing_packet_length"
-#~ msgstr ""
-#~ "O total dos dados que serão gravados é maior que outgoing_packet_length"
-
-#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
-#~ msgstr "IOs 0, 2 e 4 não suportam pullup interno em repouso (sleep)"
-
-#~ msgid "buffer must be a bytes-like object"
-#~ msgstr "o buffer deve ser um objeto como bytes"
-
-#~ msgid "io must be rtc io"
-#~ msgstr "O io deve ser rtc io"
-
-#~ msgid "trigger level must be 0 or 1"
-#~ msgstr "nível do gatilho deve ser 0 ou 1"
-
-#~ msgid "wakeup conflict"
-#~ msgstr "conflito de wakeup"
-
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr ""
-#~ "A tentativa da área de alocação dinâmica de variáveis (heap) quando o "
-#~ "MicroPython VM não está em execução."
-
-#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
-#~ msgstr "O salto do MicroPython NLR falhou. Possível corrupção de memória."
-
-#~ msgid "MicroPython fatal error."
-#~ msgstr "Houve um erro fatal do MicroPython."
-
-#~ msgid "argument must be ndarray"
-#~ msgstr "o argumento deve ser ndarray"
-
-#~ msgid "matrix dimensions do not match"
-#~ msgstr "as dimensões da matriz não coincidem"
-
-#~ msgid "norm is defined for 1D and 2D arrays"
-#~ msgstr "a norma é definida para matrizes 1D e 2D"
-
-#~ msgid "vectors must have same lengths"
-#~ msgstr "os vetores devem ter os mesmos comprimentos"
-
-#~ msgid "Nordic Soft Device failure assertion."
-#~ msgstr "Declaração de falha do dispositivo Nordic Soft."
-
-#~ msgid "Nordic soft device out of memory"
-#~ msgstr "O soft do dispositivo nórdico está sem memória"
-
-#~ msgid "Unknown soft device error: %04x"
-#~ msgstr "Erro desconhecido do dispositivo de soft: %04x"
-
-#~ msgid "first argument must be an iterable"
-#~ msgstr "o primeiro argumento deve ser um iterável"
-
-#~ msgid "iterables are not of the same length"
-#~ msgstr "os iteráveis não têm o mesmo comprimento"
-
-#~ msgid "Selected CTS pin not valid"
-#~ msgstr "O pino CTS selecionado é inválido"
-
-#~ msgid "Selected RTS pin not valid"
-#~ msgstr "O pino RTS selecionado é inválido"
-
-#~ msgid "Could not initialize channel"
-#~ msgstr "Não foi possível inicializar o canal"
-
-#~ msgid "Could not initialize timer"
-#~ msgstr "Não foi possível inicializar o temporizador"
-
-#~ msgid "Invalid frequency supplied"
-#~ msgstr "A frequência informada é inválida"
-
-#~ msgid "Invalid pins for PWMOut"
-#~ msgstr "Os pinos para o PWMOut são inválidos"
-
-#~ msgid "No more channels available"
-#~ msgstr "Não há mais canais disponíveis"
-
-#~ msgid "No more timers available"
-#~ msgstr "Não há mais temporizadores disponíveis"
-
-#~ msgid "No more timers available on this pin."
-#~ msgstr "Não há mais temporizadores disponíveis neste pino."
-
-#~ msgid ""
-#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
-#~ "program"
-#~ msgstr ""
-#~ "O temporizador foi reservado para uso interno - declare os pinos PWM no "
-#~ "início do programa"
-
-#~ msgid "Group full"
-#~ msgstr "Grupo cheio"
-
-#~ msgid "In buffer elements must be 4 bytes long or less"
-#~ msgstr "No buffer, os elementos devem ter 4 bytes ou menos"
-
-#~ msgid "Out buffer elements must be 4 bytes long or less"
-#~ msgstr "Os elementos da saída do buffer devem ter 4 bytes ou menos"
-
-#~ msgid "Initial set pin direcion conflicts with initial out pin direction"
-#~ msgstr ""
-#~ "A direção do pino inicial está em conflito com a direção inicial do pino"
-
-#~ msgid "UART not yet supported"
-#~ msgstr "O UART ainda não é suportado"
-
-#~ msgid "bits must be 7, 8 or 9"
-#~ msgstr "os bits devem ser 7, 8 ou 9"
-
-#~ msgid "Only IN/OUT of up to 8 supported"
-#~ msgstr "Somente IN/OUT de até 8 suportados"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "SDA ou SCL precisa de um pull up"
-
-#~ msgid "Invalid use of TLS Socket"
-#~ msgstr "Uso inválido do soquete TLS"
-
-#~ msgid "Issue setting SO_REUSEADDR"
-#~ msgstr "Problema na configuração do SO_REUSEADDR"
-
-#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
-#~ msgstr ""
-#~ "%d endereços dos pinos e %d pinos rgb indicam uma altura do %d, não %d"
-
-#~ msgid "Unknown failure"
-#~ msgstr "Falha desconhecida"
-
-#~ msgid "Only one alarm.touch alarm can be set."
-#~ msgstr "Apenas um alarme alarm.touch pode ser definido."
-
-#~ msgid "TouchAlarm not available in light sleep"
-#~ msgstr "O TouchAlarm não está disponívle no modo light sleep"
-
-#~ msgid "input argument must be an integer or a 2-tuple"
-#~ msgstr "o argumento da entrada deve ser um número inteiro ou uma tupla de 2"
-
-#~ msgid "operation is not implemented for flattened array"
-#~ msgstr "a operação não é implementada para a matriz achatada"
-
-#~ msgid "tuple index out of range"
-#~ msgstr "o índice da tupla está fora do intervalo"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "O código concluiu a execução. Esperando pela recarga.\n"
-
-#~ msgid "PinAlarm not yet implemented"
-#~ msgstr "PinAlarm ainda não foi implementado"
-
-#~ msgid "Pretending to deep sleep until alarm, any key or file write.\n"
-#~ msgstr ""
-#~ "Simular o deep sleep até o alarme, até qualquer chave ou até a escrita do "
-#~ "arquivo.\n"
-
-#~ msgid "Frequency captured is above capability. Capture Paused."
-#~ msgstr ""
-#~ "A frequência capturada está acima da capacidade. A captura está em pausa."
-
-#~ msgid "max_length must be > 0"
-#~ msgstr "max_length deve ser > 0"
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr ""
-#~ "Pressione qualquer tecla para entrar no REPL. Use CTRL-D para recarregar."
-
-#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
-#~ msgstr "São suportados apenas soquetes IPv4 SOCK_STREAM"
-
-#~ msgid "arctan2 is implemented for scalars and ndarrays only"
-#~ msgstr "O arctan2 está implementado apenas para escalares e ndarrays"
-
-#~ msgid "axis must be -1, 0, None, or 1"
-#~ msgstr "o eixo deve ser -1, 0, Nenhum ou 1"
-
-#~ msgid "axis must be -1, 0, or 1"
-#~ msgstr "o eixo deve ser -1, 0 ou 1"
-
-#~ msgid "axis must be None, 0, or 1"
-#~ msgstr "o eixo deve ser Nenhum, 0 ou 1"
-
-#~ msgid "cannot reshape array (incompatible input/output shape)"
-#~ msgstr ""
-#~ "não é possível remodelar a matriz (formato de entrada/saída incompatível)"
-
-#~ msgid "could not broadast input array from shape"
-#~ msgstr "não foi possível transmitir a matriz da entrada a partir da forma"
-
-#~ msgid "ddof must be smaller than length of data set"
-#~ msgstr "O ddof deve ser menor que o comprimento do conjunto dos dados"
-
-#~ msgid "function is implemented for scalars and ndarrays only"
-#~ msgstr "A função foi implementada apenas para escalares e ndarrays"
-
-#~ msgid "n must be between 0, and 9"
-#~ msgstr "n deve estar entre 0 e 9"
-
-#~ msgid "number of arguments must be 2, or 3"
-#~ msgstr "a quantidade dos argumentos deve ser 2 ou 3"
-
-#~ msgid "right hand side must be an ndarray, or a scalar"
-#~ msgstr "o lado direito deve ser um ndarray ou um escalar"
-
-#~ msgid "shape must be a 2-tuple"
-#~ msgstr "a forma deve ser uma tupla de 2"
-
-#~ msgid "sorted axis can't be longer than 65535"
-#~ msgstr "o eixo ordenado não pode ser maior do que 65535"
-
-#~ msgid "wrong argument type"
-#~ msgstr "tipo do argumento errado"
-
-#~ msgid "specify size or data, but not both"
-#~ msgstr "defina o tamanho ou os dados, porém não ambos"
-
-#~ msgid "Must provide SCK pin"
-#~ msgstr "É obrigatório informar o pino SCK"
-
-#~ msgid ""
-#~ "\n"
-#~ "To exit, please reset the board without "
-#~ msgstr ""
-#~ "\n"
-#~ "Para encerrar, redefina a placa sem "
-
-#~ msgid "PulseOut not supported on this chip"
-#~ msgstr "O PulseOut não é compatível neste CI"
-
-#~ msgid ""
-#~ "Port does not accept pins or "
-#~ "frequency.                                     Construct and pass a "
-#~ "PWMOut Carrier instead"
-#~ msgstr ""
-#~ "A porta não aceita pinos ou "
-#~ "frequência.                                     Em vez disso, Construa e "
-#~ "encaminhe um PWMOut Carrier"
-
-#~ msgid "tuple/list required on RHS"
-#~ msgstr "a tupla/lista necessária no RHS"
 
 #~ msgid "'%s' object cannot assign attribute '%q'"
 #~ msgstr "O objeto '%s' não pode definir o atributo '%q'"
@@ -6102,53 +4651,104 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "'%s' object is not subscriptable"
 #~ msgstr "O objeto '%s' não é subroteirizável"
 
-#~ msgid "Invalid I2C pin selection"
-#~ msgstr "A seleção dos pinos I2C é inválido"
-
-#~ msgid "Invalid SPI pin selection"
-#~ msgstr "A seleção do pino SPI é inválido"
-
-#~ msgid "Invalid UART pin selection"
-#~ msgstr "A seleção dos pinos UART é inválido"
-
-#~ msgid "Pop from an empty Ps2 buffer"
-#~ msgstr "Buffer Ps2 vazio"
-
-#~ msgid "Running in safe mode! Auto-reload is off.\n"
-#~ msgstr "Rodando em modo seguro! Atualização automática está desligada.\n"
-
-#~ msgid "can't convert address to int"
-#~ msgstr "não é possível converter o endereço para int"
-
-#~ msgid "object '%s' is not a tuple or list"
-#~ msgstr "o objeto '%s' não é uma tupla ou uma lista"
-
-#~ msgid "pop from an empty set"
-#~ msgstr "pop a partir de um conjunto vazio"
-
-#~ msgid "pop from empty list"
-#~ msgstr "pop a partir da lista vazia"
-
-#~ msgid "popitem(): dictionary is empty"
-#~ msgstr "popitem(): o dicionário está vazio"
-
-#~ msgid "unknown format code '%c' for object of type '%s'"
-#~ msgstr "código de formato desconhecido '%c' para o objeto do tipo '%s'"
-
-#~ msgid "unsupported types for %q: '%s', '%s'"
-#~ msgstr "tipos não compatíveis para %q: '%s', '%s'"
-
-#~ msgid "'%q' object is not bytes-like"
-#~ msgstr "objetos '%q' não são bytes-like"
-
 #~ msgid "'async for' or 'async with' outside async function"
 #~ msgstr "'assíncrono para' ou 'assíncrono com' função assíncrona externa"
 
-#~ msgid "PulseIn not supported on this chip"
-#~ msgstr "O PulseIn não é compatível neste CI"
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr ""
+#~ "'await', 'async for' (async para) ou 'async with' (async com) estão fora "
+#~ "da função async"
+
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' fora do loop"
+
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' fora do loop"
+
+#~ msgid "'coroutine' object is not an iterator"
+#~ msgstr "O objeto 'corrotina' não é um iterador"
+
+#~ msgid "(x,y) integers required"
+#~ msgstr "(x,y) é obrigatório o uso de números inteiros"
+
+#~ msgid "64 bit types"
+#~ msgstr "Tipos 64 bit"
+
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "O ADC2 está sendo usado pelo WiFi"
 
 #~ msgid "AP required"
 #~ msgstr "AP requerido"
+
+#~ msgid "Address type out of range"
+#~ msgstr "O tipo do endereço está fora do alcance"
+
+#~ msgid "All I2C targets are in use"
+#~ msgstr "Todos os alvos I2C já estão em uso"
+
+#~ msgid "AnalogIn not supported on given pin"
+#~ msgstr "O AnalogIn não é compatível no pino informado"
+
+#~ msgid "AnalogOut functionality not supported"
+#~ msgstr "Funcionalidade AnalogOut não suportada"
+
+#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#~ msgstr "O AnalogOut é de apenas 16 bits. O valor deve ser menor que 65536."
+
+#~ msgid "AnalogOut not supported on given pin"
+#~ msgstr "Saída analógica não suportada no pino fornecido"
+
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "Pelo menos %d %q pode ser definido (não %d)"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr ""
+#~ "A tentativa da área de alocação dinâmica de variáveis (heap) quando o "
+#~ "MicroPython VM não está em execução."
+
+#~ msgid "Attempted heap allocation when VM not running."
+#~ msgstr ""
+#~ "Tentativa de alocação das pilhas quando o VM não estiver em funcionamento."
+
+#~ msgid "Bit clock and word select must be sequential pins"
+#~ msgstr "O Bit clock e o word select devem ser pinos sequenciais"
+
+#, c-format
+#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
+#~ msgstr "A profundidade dos bits deve ser de 1 até 6 inclusive, porém não %d"
+
+#~ msgid "Boot device must be first device (interface #0)."
+#~ msgstr ""
+#~ "O dispositivo de inicialização deve ser o primeiro dispositivo (interface "
+#~ "#0)."
+
+#~ msgid "Both buttons were pressed at start up.\n"
+#~ msgstr "Ambos os botões foram pressionados na inicialização.\n"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "O brilho deve ser 0-1,0"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "O brilho deve estar entre 0 e 255"
+
+#, c-format
+#~ msgid "Buffer incorrect size. Should be %d bytes."
+#~ msgstr "Buffer de tamanho incorreto. Deve ser %d bytes."
+
+#~ msgid "Buffer is too small"
+#~ msgstr "O buffer é muito pequeno"
+
+#~ msgid "Buffer must be at least length 1"
+#~ msgstr "O comprimento do buffer deve ter pelo menos 1"
+
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "O buffer é muito grande e incapaz de alocar"
+
+#~ msgid "Button A was pressed at start up.\n"
+#~ msgstr "O botão A foi pressionado na inicialização.\n"
+
+#~ msgid "Bytes must be between 0 and 255."
+#~ msgstr "Os bytes devem estar entre 0 e 255."
 
 #~ msgid "Cannot connect to AP"
 #~ msgstr "Não é possível conectar-se ao AP"
@@ -6156,15 +4756,112 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "Cannot disconnect from AP"
 #~ msgstr "Não é possível desconectar do AP"
 
+#~ msgid "Cannot output both channels on the same pin"
+#~ msgstr "Não é possível emitir os dois canais no mesmo pino"
+
+#~ msgid "Cannot read without MISO pin."
+#~ msgstr "Não é possível ler sem o pino MISO."
+
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "Não é possível remontar '/' enquanto o USB estiver ativo."
+
+#~ msgid "Cannot reset into bootloader because no bootloader is present."
+#~ msgstr ""
+#~ "Não é possível redefinir para o bootloader porque o mesmo não está "
+#~ "presente."
+
 #~ msgid "Cannot set STA config"
 #~ msgstr "Não é possível definir a configuração STA"
+
+#~ msgid "Cannot transfer without MOSI and MISO pins"
+#~ msgstr "Não é possível transferir sem os pinos MOSI e MISO"
+
+#~ msgid "Cannot transfer without MOSI and MISO pins."
+#~ msgstr "Não é possível transferir sem os pinos MOSI e MISO."
+
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "Não é possível obter inequivocamente o tamanho do escalar"
 
 #~ msgid "Cannot update i/f status"
 #~ msgstr "Não é possível atualizar o status i/f"
 
+#~ msgid "Cannot write without MOSI pin."
+#~ msgstr "Não é possível fazer a escrita sem um pino MOSI."
+
+#~ msgid ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+#~ msgstr ""
+#~ "O CircuitPython está no modo de segurança porque você pressionou o botão "
+#~ "de redefinição durante a inicialização. Pressione novamente para sair do "
+#~ "modo de segurança.\n"
+
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "O CircuitPython não conseguiu alocar o heap."
+
+#~ msgid "Clock pin init failed."
+#~ msgstr "Inicialização do pino de Clock falhou."
+
+#~ msgid "Column entry must be digitalio.DigitalInOut"
+#~ msgstr "A entrada da coluna deve ser digitalio.DigitalInOut"
+
+#~ msgid "Command must be an int between 0 and 255"
+#~ msgstr "O comando deve ser um int entre 0 e 255"
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "Arquivo .mpy corrompido"
+
+#~ msgid "Corrupt raw code"
+#~ msgstr "Código bruto corrompido"
+
+#~ msgid "Could not initialize Camera"
+#~ msgstr "Não foi possível inicializar a Câmera"
+
+#~ msgid "Could not initialize GNSS"
+#~ msgstr "Não foi possível inicializar o GNSS"
+
+#~ msgid "Could not initialize SDCard"
+#~ msgstr "Não foi possível inicializar o SDCard"
+
+#~ msgid "Could not initialize UART"
+#~ msgstr "Não foi possível inicializar o UART"
+
+#~ msgid "Could not initialize channel"
+#~ msgstr "Não foi possível inicializar o canal"
+
+#~ msgid "Could not initialize timer"
+#~ msgstr "Não foi possível inicializar o temporizador"
+
+#~ msgid "Could not re-init channel"
+#~ msgstr "Não foi possível reiniciar o canal"
+
+#~ msgid "Could not re-init timer"
+#~ msgstr "Não foi possível reiniciar o temporizador"
+
+#~ msgid "Could not restart PWM"
+#~ msgstr "Não foi possível reiniciar o PWM"
+
+#~ msgid "Couldn't allocate first buffer"
+#~ msgstr "Não pôde alocar primeiro buffer"
+
+#~ msgid "Couldn't allocate input buffer"
+#~ msgstr "Não foi possível alocar o buffer de entrada"
+
+#~ msgid "Couldn't allocate second buffer"
+#~ msgstr "Não pôde alocar segundo buffer"
+
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "Falha no HardFault_Handler."
+
+#~ msgid "Data 0 pin must be byte aligned."
+#~ msgstr "O pino de dados 0 deve ser alinhado por bytes."
+
 #, fuzzy
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Não é possível ajustar dados no pacote de anúncios."
+
+#~ msgid "DigitalInOut not supported on given pin"
+#~ msgstr "O DigitalInOut não é compatível em um determinado pino"
 
 #~ msgid "Don't know how to pass object to native function"
 #~ msgstr "Não sabe como passar o objeto para a função nativa"
@@ -6175,8 +4872,46 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "ESP8266 does not support pull down."
 #~ msgstr "ESP8266 não suporta pull down."
 
+#, c-format
+#~ msgid "Error in MIDI stream at position %d"
+#~ msgstr "Houve um erro no fluxo MIDI na posição %d"
+
 #~ msgid "Error in ffi_prep_cif"
 #~ msgstr "Erro no ffi_prep_cif"
+
+#~ msgid "Expected a %q"
+#~ msgstr "Esperado um"
+
+#~ msgid "Expected a %q or %q"
+#~ msgstr "Era esperado um %q ou %q"
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Uma característica é necessária"
+
+#~ msgid "Expected a DigitalInOut"
+#~ msgstr "Espera-se um DigitalInOut"
+
+#~ msgid "Expected a Service"
+#~ msgstr "Esperava um Serviço"
+
+#~ msgid "Expected a UART"
+#~ msgstr "Espera-se uma UART"
+
+#~ msgid "Expected a UUID"
+#~ msgstr "Um UUID é necessário"
+
+#~ msgid "Expected an %q"
+#~ msgstr "Esperava-se um(a) %q"
+
+#~ msgid "Expected an Address"
+#~ msgstr "Um endereço esperado"
+
+#~ msgid "Expected an alarm"
+#~ msgstr "Um alarme era esperado"
+
+#, c-format
+#~ msgid "Expected tuple of length %d, got %d"
+#~ msgstr "Tupla esperada com comprimento %d, obteve %d"
 
 #, fuzzy
 #~ msgid "Failed to acquire mutex"
@@ -6193,6 +4928,13 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #, fuzzy
 #~ msgid "Failed to add service, err 0x%04x"
 #~ msgstr "Não pode parar propaganda. status: 0x%02x"
+
+#~ msgid "Failed to allocate RX buffer"
+#~ msgstr "Falha ao alocar buffer RX"
+
+#, c-format
+#~ msgid "Failed to allocate RX buffer of %d bytes"
+#~ msgstr "Falha ao alocar buffer RX de %d bytes"
 
 #, fuzzy
 #~ msgid "Failed to change softdevice state"
@@ -6213,6 +4955,9 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #, fuzzy
 #~ msgid "Failed to get softdevice state"
 #~ msgstr "Não pode parar propaganda. status: 0x%02x"
+
+#~ msgid "Failed to init wifi"
+#~ msgstr "Houve uma falha ao iniciar o wifi"
 
 #, fuzzy
 #~ msgid "Failed to notify or indicate attribute value, err %0x04x"
@@ -6271,14 +5016,134 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "Failed to write gatts value, err 0x%04x"
 #~ msgstr "Não é possível gravar o valor do atributo. status: 0x%02x"
 
+#~ msgid "Fatal error."
+#~ msgstr "Erro fatal."
+
+#~ msgid "Fault detected by hardware."
+#~ msgstr "Falha detectada pelo hardware."
+
+#~ msgid "Firmware image is invalid"
+#~ msgstr "A imagem do firmware é invalida"
+
+#, c-format
+#~ msgid "Framebuffer requires %d bytes"
+#~ msgstr "O Framebuffer requer %d bytes"
+
+#~ msgid "Frequency captured is above capability. Capture Paused."
+#~ msgstr ""
+#~ "A frequência capturada está acima da capacidade. A captura está em pausa."
+
 #~ msgid "GPIO16 does not support pull up."
 #~ msgstr "GPIO16 não suporta pull up."
+
+#~ msgid "Group full"
+#~ msgstr "Grupo cheio"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "O hardware está ocupado, tente os pinos alternativos"
+
+#~ msgid "Hostname must be between 1 and 253 characters"
+#~ msgstr "O nome do host deve ter entre 1 e 253 caracteres"
+
+#~ msgid "I2C Init Error"
+#~ msgstr "Erro de inicialização do I2C"
 
 #~ msgid "I2C operation not supported"
 #~ msgstr "I2C operação não suportada"
 
+#~ msgid "I2SOut not available"
+#~ msgstr "O I2SOut não está disponível"
+
+#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
+#~ msgstr "IOs 0, 2 e 4 não suportam pullup interno em repouso (sleep)"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "O IV deve ter %d bytes de comprimento"
+
+#~ msgid "In buffer elements must be 4 bytes long or less"
+#~ msgstr "No buffer, os elementos devem ter 4 bytes ou menos"
+
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "Arquivo .mpy incompatível. Atualize todos os arquivos .mpy. Consulte "
+#~ "http://adafru.it/mpy-update para mais informações."
+
+#~ msgid "Initial set pin direcion conflicts with initial out pin direction"
+#~ msgstr ""
+#~ "A direção do pino inicial está em conflito com a direção inicial do pino"
+
+#~ msgid "Initialization failed due to lack of memory"
+#~ msgstr "A inicialização falhou devido à falta de memória"
+
+#~ msgid "Instruction %d jumps on pin"
+#~ msgstr "A instrução %d salta no pino"
+
+#, c-format
+#~ msgid "Instruction %d shifts in more bits than pin count"
+#~ msgstr "A instrução %d muda com mais bits do que a quantidade dos pinos"
+
+#, c-format
+#~ msgid "Instruction %d shifts out more bits than pin count"
+#~ msgstr "A instrução %d desloca mais bits do que a quantidade dos pinos"
+
+#, c-format
+#~ msgid "Instruction %d uses extra pin"
+#~ msgstr "A instrução %d usa um pino extra"
+
+#, c-format
+#~ msgid "Instruction %d waits on input outside of count"
+#~ msgstr "A instrução %d aguarda a entrada de fora da contagem"
+
+#~ msgid "Invalid %q pin selection"
+#~ msgstr "Seleção inválida dos pinos %q"
+
+#~ msgid "Invalid AuthMode"
+#~ msgstr "AuthMode inválido"
+
+#~ msgid "Invalid BMP file"
+#~ msgstr "Arquivo BMP inválido"
+
+#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
+#~ msgstr "CIRCUITPY_PYSTACK_SIZE inválido\n"
+
+#~ msgid "Invalid DAC pin supplied"
+#~ msgstr "O pino DAC informado é inválido"
+
+#~ msgid "Invalid I2C pin selection"
+#~ msgstr "A seleção dos pinos I2C é inválido"
+
+#~ msgid "Invalid MIDI file"
+#~ msgstr "O arquivo MIDI é inválido"
+
+#~ msgid "Invalid PWM frequency"
+#~ msgstr "Frequência PWM inválida"
+
+#~ msgid "Invalid Pin"
+#~ msgstr "Pino inválido"
+
+#~ msgid "Invalid SPI pin selection"
+#~ msgstr "A seleção do pino SPI é inválido"
+
+#~ msgid "Invalid UART pin selection"
+#~ msgstr "A seleção dos pinos UART é inválido"
+
 #~ msgid "Invalid bit clock pin"
 #~ msgstr "Pino de bit clock inválido"
+
+#~ msgid "Invalid buffer size"
+#~ msgstr "O tamanho do buffer é inválido"
+
+#~ msgid "Invalid byteorder string"
+#~ msgstr "A cadeia de bytes é inválida"
+
+#~ msgid "Invalid capture period. Valid range: 1 - 500"
+#~ msgstr "O período de captura é inválido. O intervalo válido é: 1 - 500"
+
+#~ msgid "Invalid channel count"
+#~ msgstr "A contagem do canal é inválido"
 
 #~ msgid "Invalid clock pin"
 #~ msgstr "Pino do Clock inválido"
@@ -6286,21 +5151,234 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "Invalid data pin"
 #~ msgstr "Pino de dados inválido"
 
+#, c-format
+#~ msgid "Invalid data_count %d"
+#~ msgstr "data_count %d inválido"
+
+#~ msgid "Invalid direction."
+#~ msgstr "Direção inválida."
+
+#~ msgid "Invalid file"
+#~ msgstr "Arquivo inválido"
+
+#~ msgid "Invalid frequency"
+#~ msgstr "Frequência inválida"
+
+#~ msgid "Invalid frequency supplied"
+#~ msgstr "A frequência informada é inválida"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "O acesso da memória é inválido."
+
+#~ msgid "Invalid mode"
+#~ msgstr "Modo inválido"
+
+#~ msgid "Invalid number of bits"
+#~ msgstr "Número inválido de bits"
+
+#~ msgid "Invalid phase"
+#~ msgstr "Fase Inválida"
+
+#~ msgid "Invalid pin"
+#~ msgstr "Pino inválido"
+
+#~ msgid "Invalid pin for left channel"
+#~ msgstr "Pino inválido para canal esquerdo"
+
+#~ msgid "Invalid pin for right channel"
+#~ msgstr "Pino inválido para canal direito"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Pinos inválidos"
+
+#~ msgid "Invalid pins for PWMOut"
+#~ msgstr "Os pinos para o PWMOut são inválidos"
+
+#~ msgid "Invalid polarity"
+#~ msgstr "Polaridade inválida"
+
+#~ msgid "Invalid properties"
+#~ msgstr "Propriedades inválidas"
+
+#~ msgid "Invalid run mode."
+#~ msgstr "O modo de execução é inválido."
+
+#~ msgid "Invalid security_mode"
+#~ msgstr "O Security_mode é inválido"
+
+#~ msgid "Invalid use of TLS Socket"
+#~ msgstr "Uso inválido do soquete TLS"
+
+#~ msgid "Invalid voice"
+#~ msgstr "A voz é inválida"
+
+#~ msgid "Invalid voice count"
+#~ msgstr "A contagem da voz é inválida"
+
+#~ msgid "Invalid wave file"
+#~ msgstr "Aqruivo de ondas inválido"
+
+#~ msgid "Invalid word/bit length"
+#~ msgstr "O comprimento do bit/palavra são inválidos"
+
+#~ msgid "Issue setting SO_REUSEADDR"
+#~ msgstr "Problema na configuração do SO_REUSEADDR"
+
+#~ msgid "Layer already in a group."
+#~ msgstr "A camada já existe em um grupo."
+
+#~ msgid "Layer must be a Group or TileGrid subclass."
+#~ msgstr "A camada deve ser uma subclasse Group ou TileGrid."
+
+#~ msgid "Length must be an int"
+#~ msgstr "Tamanho deve ser um int"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "O comprimento deve ser positivo"
+
+#~ msgid "MISO pin init failed."
+#~ msgstr "A inicialização do pino MISO falhou."
+
+#~ msgid "MOSI pin init failed."
+#~ msgstr "Inicialização do pino MOSI falhou."
+
 #~ msgid "Maximum PWM frequency is %dhz."
 #~ msgstr "A frequência máxima PWM é de %dhz."
 
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "O valor máximo de x quando espelhado é %d"
+
+#~ msgid "Messages limited to 8 bytes"
+#~ msgstr "As mensagens estão limitadas a 8 bytes"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgstr "O salto do MicroPython NLR falhou. Possível corrupção de memória."
+
+#~ msgid "MicroPython fatal error."
+#~ msgstr "Houve um erro fatal do MicroPython."
+
 #~ msgid "Minimum PWM frequency is 1hz."
 #~ msgstr "A frequência mínima PWM é de 1hz"
+
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "O pino MISO ou MOSI está ausente"
+
+#~ msgid "Missing MISO or MOSI pin"
+#~ msgstr "Falta o pino MISO ou o MOSI"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
+#~ msgstr "Faltando first_in_pin. A instrução %d lê pinos(s)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
+#~ msgstr "Faltando first_in_pin. A instrução %d muda a partir do(s) pino(s)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
+#~ msgstr "Faltando first_in_pin. A instrução %d aguarda com base no pino"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
+#~ msgstr "Faltando first_out_pin. A instrução %d muda para o(s) pinos(s)"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
+#~ msgstr "Faltando first_out_pin. A instrução %d escreve nos pinos(s)"
+
+#, c-format
+#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+#~ msgstr "Faltando first_set_pin. A instrução %d define os pinos(s)"
+
+#, c-format
+#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
+#~ msgstr "Falta o jmp_pin. A instrução %d salta no pino"
+
+#, c-format
+#~ msgid "More than %d report ids not supported"
+#~ msgstr "Mais de %d reportam ids não compatíveis"
 
 #~ msgid "Multiple PWM frequencies not supported. PWM already set to %dhz."
 #~ msgstr ""
 #~ "Múltiplas frequências PWM não suportadas. PWM já definido para %dhz."
 
+#~ msgid "Must provide SCK pin"
+#~ msgstr "É obrigatório informar o pino SCK"
+
+#, c-format
+#~ msgid "No I2C device at address: %x"
+#~ msgstr "Nenhum dispositivo I2C no endereço: %x"
+
+#~ msgid "No MISO Pin"
+#~ msgstr "Nenhum pino MISO"
+
+#~ msgid "No MISO pin"
+#~ msgstr "Nenhum pino MISO"
+
+#~ msgid "No MOSI Pin"
+#~ msgstr "Nenhum pino MOSI"
+
+#~ msgid "No MOSI pin"
+#~ msgstr "Nenhum pino MOSI"
+
 #~ msgid "No PulseIn support for %q"
 #~ msgstr "Não há suporte para PulseIn no pino %q"
 
+#~ msgid "No RX pin"
+#~ msgstr "Nenhum pino RX"
+
+#~ msgid "No TX pin"
+#~ msgstr "Nenhum pino TX"
+
 #~ msgid "No hardware support for analog out."
 #~ msgstr "Nenhum suporte de hardware para saída analógica."
+
+#~ msgid "No hardware support on clk pin"
+#~ msgstr "Sem suporte de hardware no pino de clock"
+
+#~ msgid "No hardware support on pin"
+#~ msgstr "Nenhum suporte de hardware no pino"
+
+#~ msgid "No key was specified"
+#~ msgstr "Nenhuma chave foi definida"
+
+#~ msgid "No more channels available"
+#~ msgstr "Não há mais canais disponíveis"
+
+#, c-format
+#~ msgid "No more than %d HID devices allowed"
+#~ msgstr "Não são permitidos mais do que %d dispositivos HID"
+
+#~ msgid "No more timers available"
+#~ msgstr "Não há mais temporizadores disponíveis"
+
+#~ msgid "No more timers available on this pin."
+#~ msgstr "Não há mais temporizadores disponíveis neste pino."
+
+#~ msgid "Nordic Soft Device failure assertion."
+#~ msgstr "Declaração de falha do dispositivo Nordic Soft."
+
+#~ msgid "Nordic soft device out of memory"
+#~ msgstr "O soft do dispositivo nórdico está sem memória"
+
+#~ msgid "Nordic system firmware failure assertion."
+#~ msgstr "Declaração de falha do firmware do sistema nórdico."
+
+#~ msgid "Not running saved code.\n"
+#~ msgstr "O código salvo não está em execução.\n"
+
+#~ msgid "Not settable"
+#~ msgstr "Não configurável"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Apenas mono com 8 ou 16 bits com "
+
+#~ msgid "Only IN/OUT of up to 8 supported"
+#~ msgstr "Somente IN/OUT de até 8 suportados"
+
+#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
+#~ msgstr "São suportados apenas soquetes IPv4 SOCK_STREAM"
 
 #~ msgid "Only Windows format, uncompressed BMP supported %d"
 #~ msgstr "Apenas formato Windows, BMP descomprimido suportado"
@@ -6308,23 +5386,149 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "Only bit maps of 8 bit color or less are supported"
 #~ msgstr "Apenas bit maps de cores de 8 bit ou menos são suportados"
 
+#~ msgid "Only one TouchAlarm can be set in deep sleep."
+#~ msgstr "Apenas um TouchAlarm pode ser colocado em deep sleep."
+
+#~ msgid "Only one alarm.touch alarm can be set."
+#~ msgstr "Apenas um alarme alarm.touch pode ser definido."
+
+#~ msgid "Only raw int or string supported for ip"
+#~ msgstr "Apenas int ou string bruto é compatível para o ip"
+
+#~ msgid "Only raw int supported for ip"
+#~ msgstr "Apenas o int bruto é compatível para o ip"
+
 #~ msgid "Only true color (24 bpp or higher) BMP supported %x"
 #~ msgstr "Apenas cores verdadeiras (24 bpp ou maior) BMP suportadas"
 
 #~ msgid "Only tx supported on UART1 (GPIO2)."
 #~ msgstr "Apenas TX suportado no UART1 (GPIO2)."
 
+#~ msgid "Out buffer elements must be 4 bytes long or less"
+#~ msgstr "Os elementos da saída do buffer devem ter 4 bytes ou menos"
+
+#, c-format
+#~ msgid "Output buffer must be at least %d bytes"
+#~ msgstr "O buffer de saída deve ter ao menos %d bytes"
+
+#~ msgid "PDMIn not available"
+#~ msgstr "O PDMIn não está disponível"
+
+#~ msgid ""
+#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
+#~ msgstr ""
+#~ "O duty_cycle do PWM deve estar entre 0 e inclusive 65535 (com resolução "
+#~ "de 16 bits)"
+
 #~ msgid "PWM not supported on pin %d"
 #~ msgstr "PWM não suportado no pino %d"
+
+#~ msgid "ParallelBus not yet supported"
+#~ msgstr "O ParallelBus ainda não é compatível"
 
 #~ msgid "Pin %q does not have ADC capabilities"
 #~ msgstr "Pino %q não tem recursos de ADC"
 
+#~ msgid "Pin count must be at least 1"
+#~ msgstr "A contagem dos pinos deve ser com pelo menos 1"
+
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "O pino não tem recursos de ADC"
+
+#~ msgid "Pin number already reserved by EXTI"
+#~ msgstr "Número do PIN já está reservado através da EXTI"
+
 #~ msgid "Pin(16) doesn't support pull"
 #~ msgstr "Pino (16) não suporta pull"
 
+#~ msgid "PinAlarm not yet implemented"
+#~ msgstr "PinAlarm ainda não foi implementado"
+
+#~ msgid "Pins 21+ not supported from ULP"
+#~ msgstr "Os pinos 21+ não são suportados pelo ULP"
+
 #~ msgid "Pins not valid for SPI"
 #~ msgstr "Pinos não válidos para SPI"
+
+#~ msgid "Pop from an empty Ps2 buffer"
+#~ msgstr "Buffer Ps2 vazio"
+
+#~ msgid ""
+#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
+#~ "instead"
+#~ msgstr ""
+#~ "A porta não aceita portadora PWM. Em vez disso informe um pino, "
+#~ "frequência e o ciclo de trabalho"
+
+#~ msgid ""
+#~ "Port does not accept pins or "
+#~ "frequency.                                     Construct and pass a "
+#~ "PWMOut Carrier instead"
+#~ msgstr ""
+#~ "A porta não aceita pinos ou "
+#~ "frequência.                                     Em vez disso, Construa e "
+#~ "encaminhe um PWMOut Carrier"
+
+#~ msgid ""
+#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
+#~ "Carrier instead"
+#~ msgstr ""
+#~ "A porta não aceita pinos ou frequência. Em vez disso, construa e passe um "
+#~ "PWMOut Carrier"
+
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+#~ msgstr ""
+#~ "Pressione qualquer tecla para entrar no REPL. Use CTRL-D para recarregar."
+
+#~ msgid "Pretending to deep sleep until alarm, any key or file write.\n"
+#~ msgstr ""
+#~ "Simular o deep sleep até o alarme, até qualquer chave ou até a escrita do "
+#~ "arquivo.\n"
+
+#~ msgid "Program must contain at least one 16-bit instruction."
+#~ msgstr "O programa deve conter pelo menos uma instrução com 16 bits."
+
+#~ msgid "Program too large"
+#~ msgstr "O programa é muito grande"
+
+#~ msgid "PulseIn not supported on this chip"
+#~ msgstr "O PulseIn não é compatível neste CI"
+
+#~ msgid "PulseOut not supported on this chip"
+#~ msgstr "O PulseOut não é compatível neste CI"
+
+#~ msgid "RAISE mode is not implemented"
+#~ msgstr "O modo RAISE não foi implementado"
+
+#~ msgid "RS485 Not yet supported on this device"
+#~ msgstr "Ainda não há suporte para o RS485 neste dispositivo"
+
+#~ msgid "RTC calibration is not supported on this board"
+#~ msgstr "A calibração RTC não é suportada nesta placa"
+
+#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
+#~ msgstr "RTS/CTS/RS485 Ainda não é compatível neste dispositivo"
+
+#~ msgid "Read-only object"
+#~ msgstr "Objeto de leitura apenas"
+
+#~ msgid "Row entry must be digitalio.DigitalInOut"
+#~ msgstr "A entrada da linha deve ser digitalio.DigitalInOut"
+
+#~ msgid "Running in safe mode! "
+#~ msgstr "Executando no modo de segurança! "
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Rodando em modo seguro! Atualização automática está desligada.\n"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "SDA ou SCL precisa de um pull up"
+
+#~ msgid "SPI Init Error"
+#~ msgstr "Houve um erro na inicialização SPI"
+
+#~ msgid "SPI Re-initialization error"
+#~ msgstr "Houve um erro na reinicialização SPI"
 
 #~ msgid "STA must be active"
 #~ msgstr "STA deve estar ativo"
@@ -6332,23 +5536,329 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "STA required"
 #~ msgstr "STA requerido"
 
+#~ msgid "Sample rate must be positive"
+#~ msgstr "A taxa de amostragem deve ser positiva"
+
+#, c-format
+#~ msgid "Sample rate too high. It must be less than %d"
+#~ msgstr "Taxa de amostragem muito alta. Deve ser menor que %d"
+
+#~ msgid "Scan already in progess. Stop with stop_scan."
+#~ msgstr "O escaneamento já está em andamento. Interrompa com stop_scan."
+
+#~ msgid "Selected CTS pin not valid"
+#~ msgstr "O pino CTS selecionado é inválido"
+
+#~ msgid "Selected RTS pin not valid"
+#~ msgstr "O pino RTS selecionado é inválido"
+
+#~ msgid "Set pin count must be between 1 and 5"
+#~ msgstr "A definição da contagem dos pinos deve estar entre 1 e 5"
+
+#~ msgid "Side set pin count must be between 1 and 5"
+#~ msgstr ""
+#~ "A definição da contagem dos pinos do conjunto lateral deve estar entre 1 "
+#~ "e 5"
+
+#~ msgid "Sleep Memory not available"
+#~ msgstr "Sleep memory não está disponível"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Divisão com sub-capturas"
+
+#~ msgid "Stack size must be at least 256"
+#~ msgstr "O tamanho da pilha deve ser pelo menos 256"
+
+#~ msgid "Station must be started"
+#~ msgstr "A estação deve ser iniciada"
+
+#~ msgid "Stopping AP is not supported."
+#~ msgstr "Não há suporte para a interrupção do AP."
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "Transmita o método ausente readinto() ou write()."
+
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "Forneça pelo menos um pino UART"
+
+#~ msgid "The BOOT button was pressed at start up.\n"
+#~ msgstr "O botão BOOT foi pressionado na inicialização.\n"
+
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Increase the stack size if you know how. If not:"
+#~ msgstr ""
+#~ "A área de alocação dinâmica de variáveis (heap) do CircuitPython foi "
+#~ "corrompido pois a pilha era muito pequena.\n"
+#~ "Aumente o tamanho da pilha se souber como. Senão:"
+
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase the stack size if you know how, or if not:"
+#~ msgstr ""
+#~ "A área de alocação dinâmica de variáveis (heap) do CircuitPython foi "
+#~ "corrompida porque a pilha de funções (stack) era muito pequena.\n"
+#~ "Aumente o tamanho da pilha de funções caso saiba como, ou caso não saiba:"
+
+#~ msgid "The SW38 button was pressed at start up.\n"
+#~ msgstr "O botão SW38 foi pressionado na inicialização.\n"
+
+#~ msgid "The VOLUME button was pressed at start up.\n"
+#~ msgstr "O botão VOLUME foi pressionado na inicialização.\n"
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode."
+#~ msgstr ""
+#~ "O módulo `microcontrolador` foi utilizado para iniciar em modo seguro. "
+#~ "Pressione reset para encerrar do modo de segurança."
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode.\n"
+#~ msgstr ""
+#~ "O módulo `microcontrolador` foi utilizado para inicializar no modo de "
+#~ "segurança. Pressione reset para encerrar do modo de segurança.\n"
+
+#~ msgid "The central button was pressed at start up.\n"
+#~ msgstr "O botão central foi pressionado na inicialização.\n"
+
+#~ msgid "The left button was pressed at start up.\n"
+#~ msgstr "O botão esquerdo foi pressionado na inicialização.\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY)."
+#~ msgstr ""
+#~ "O alimentação do micro controlador diminuiu. Certifique-se de que a sua "
+#~ "fonte de alimentação fornece\n"
+#~ "corrente suficiente para todo o circuito e pressione reset (depois de "
+#~ "ejetar o CIRCUITPY)."
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "A força do microcontrolador caiu. Verifique se a fonte de alimentação "
+#~ "fornece\n"
+#~ "energia suficiente para todo o circuito e pressione reset (após a ejeção "
+#~ "CIRCUITPY).\n"
+
+#~ msgid "The power dipped. Make sure you are providing enough power."
+#~ msgstr ""
+#~ "A alimentação foi reduzida. Certifique-se de fornecer energia suficiente."
+
+#~ msgid "Tile value out of bounds"
+#~ msgstr "O valor do bloco está fora dos limites"
+
+#~ msgid "Timeout waiting for DRDY"
+#~ msgstr "Esgotou-se o tempo limite de espera pelo DRDY"
+
+#~ msgid "Timeout waiting for VSYNC"
+#~ msgstr "Esgotou-se o tempo de espera pelo VSYNC"
+
+#~ msgid ""
+#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
+#~ "program"
+#~ msgstr ""
+#~ "O temporizador foi reservado para uso interno - declare os pinos PWM no "
+#~ "início do programa"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Para sair, por favor, reinicie a placa sem "
+
+#~ msgid "To exit, please reset the board without requesting safe mode."
+#~ msgstr "Para sair, reinicie a placa sem solicitar o modo de segurança."
+
+#~ msgid "Too many display busses"
+#~ msgstr "Muitos barramentos estão sendo exibidos"
+
+#~ msgid "Total data to write is larger than outgoing_packet_length"
+#~ msgstr ""
+#~ "O total dos dados que serão gravados é maior que outgoing_packet_length"
+
+#~ msgid "TouchAlarm not available in light sleep"
+#~ msgstr "O TouchAlarm não está disponívle no modo light sleep"
+
+#~ msgid "UART Buffer allocation error"
+#~ msgstr "Houve um erro na alocação do Buffer UART"
+
+#~ msgid "UART De-init error"
+#~ msgstr "Houve um erro da não inicialização do UART"
+
+#~ msgid "UART Init Error"
+#~ msgstr "Houve um erro na inicialização do UART"
+
+#~ msgid "UART Re-init error"
+#~ msgstr "Houve um erro na reinicialização do UART"
+
+#~ msgid "UART not yet supported"
+#~ msgstr "O UART ainda não é suportado"
+
+#~ msgid "UART write error"
+#~ msgstr "Houve um erro na gravação UART"
+
 #~ msgid "UART(%d) does not exist"
 #~ msgstr "UART(%d) não existe"
 
 #~ msgid "UART(1) can't read"
 #~ msgstr "UART(1) não pode ler"
 
+#~ msgid "USB Busy"
+#~ msgstr "USB ocupada"
+
+#~ msgid "USB Error"
+#~ msgstr "Erro na USB"
+
+#~ msgid "Unable to allocate the heap."
+#~ msgstr "Não é possível alocar a área de alocação dinâmica de variáveis."
+
+#, c-format
+#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Não foi possível configurar o controlador ADC DMA, ErrorCode:%d"
+
+#, c-format
+#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Não foi possível inicializar o controlador ADC DMA, ErrorCode:%d"
+
 #~ msgid "Unable to remount filesystem"
 #~ msgstr "Não é possível remontar o sistema de arquivos"
+
+#, c-format
+#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Não foi possível iniciar o controlador ADC DMA, ErrorCode:%d"
+
+#~ msgid "Unable to write"
+#~ msgstr "Não é possível escrever"
+
+#~ msgid "Unable to write to address."
+#~ msgstr "Não é possível gravar no endereço."
+
+#~ msgid "Unknown failure"
+#~ msgstr "Falha desconhecida"
+
+#~ msgid "Unknown soft device error: %04x"
+#~ msgstr "Erro desconhecido do dispositivo de soft: %04x"
 
 #~ msgid "Unknown type"
 #~ msgstr "Tipo desconhecido"
 
+#, c-format
+#~ msgid "Unkown error code %d"
+#~ msgstr "Código de erro desconhecido %d"
+
+#~ msgid "Unsupported baudrate"
+#~ msgstr "Taxa de transmissão não suportada"
+
+#~ msgid "Unsupported operation"
+#~ msgstr "Operação não suportada"
+
+#~ msgid "Unsupported pull value."
+#~ msgstr "O valor pull não é compatível."
+
 #~ msgid "Use esptool to erase flash and re-upload Python instead"
 #~ msgstr "Use o esptool para apagar o flash e recarregar o Python"
 
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr "Atualmente, as funções do Viper não suportam mais de 4 argumentos"
+
+#~ msgid "WatchDogTimer is not currently running"
+#~ msgstr "O WatchDogTimer não está em execução"
+
+#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+#~ msgstr ""
+#~ "O WatchDogTimer.mode não pode ser alterado uma vez definido para "
+#~ "WatchDogMode.RESET"
+
+#~ msgid "WatchDogTimer.timeout must be greater than 0"
+#~ msgstr "O WatchDogTimer.timeout deve ser maior que 0"
+
+#~ msgid "Watchdog timer expired."
+#~ msgstr "O temporizador Watchdog expirou."
+
+#, c-format
+#~ msgid ""
+#~ "Welcome to Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Please visit learn.adafruit.com/category/circuitpython for project "
+#~ "guides.\n"
+#~ "\n"
+#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ msgstr ""
+#~ "Bem-vindo ao Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Para obter guias de projeto, visite learn.adafruit.com/category/"
+#~ "circuitpython.\n"
+#~ "\n"
+#~ "Para listar os módulos internos, faça `help(\"modules\")`.\n"
+
+#~ msgid "WiFi password must be between 8 and 63 characters"
+#~ msgstr "A senha do Wi-Fi deve ter entre 8 e 63 caracteres"
+
+#~ msgid "Wifi is in access point mode."
+#~ msgstr "O Wi-Fi está em modo de ponto de acesso."
+
+#~ msgid "Wifi is in station mode."
+#~ msgstr "O Wi-Fi está em modo estação."
+
+#~ msgid "You are in safe mode because:\n"
+#~ msgstr "Você está no modo de segurança pois:\n"
+
+#~ msgid "You are in safe mode: something unanticipated happened.\n"
+#~ msgstr "Você está no modo de segurança: algo inesperado aconteceu.\n"
+
+#~ msgid ""
+#~ "You pressed the reset button during boot. Press again to exit safe mode."
+#~ msgstr ""
+#~ "Você pressionou o botão reset durante a inicialização. Pressione-o "
+#~ "novamente para sair do modo de segurança."
+
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "Você solicitou o início do modo de segurança através do "
+
+#~ msgid "__init__() should return None, not '%q'"
+#~ msgstr "O __init__() deve retornar Nenhum, não '%q'"
+
+#~ msgid "abort() called"
+#~ msgstr "abort() chamado"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "endereço %08x não está alinhado com %d bytes"
+
+#~ msgid "address out of bounds"
+#~ msgstr "endereço fora dos limites"
+
+#~ msgid "arctan2 is implemented for scalars and ndarrays only"
+#~ msgstr "O arctan2 está implementado apenas para escalares e ndarrays"
+
+#~ msgid "argument must be ndarray"
+#~ msgstr "o argumento deve ser ndarray"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "atributos ainda não suportados"
+
+#~ msgid "axis must be -1, 0, None, or 1"
+#~ msgstr "o eixo deve ser -1, 0, Nenhum ou 1"
+
+#~ msgid "axis must be -1, 0, or 1"
+#~ msgstr "o eixo deve ser -1, 0 ou 1"
+
+#~ msgid "axis must be None, 0, or 1"
+#~ msgstr "o eixo deve ser Nenhum, 0 ou 1"
+
+#~ msgid "bits must be 7, 8 or 9"
+#~ msgstr "os bits devem ser 7, 8 ou 9"
+
 #~ msgid "bits must be 8"
 #~ msgstr "bits devem ser 8"
+
+#~ msgid "bits must be in range 5 to 9"
+#~ msgstr "os bits devem estar na faixa entre 5 a 9"
+
+#~ msgid "buffer must be a bytes-like object"
+#~ msgstr "o buffer deve ser um objeto como bytes"
 
 #~ msgid "buffer too long"
 #~ msgstr "buffer muito longo"
@@ -6356,8 +5866,41 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "buffers must be the same length"
 #~ msgstr "buffers devem ser o mesmo tamanho"
 
+#~ msgid "buttons must be digitalio.DigitalInOut"
+#~ msgstr "os botões devem ser digitalio.DigitalInOut"
+
+#~ msgid "byte code not implemented"
+#~ msgstr "o código dos bytes ainda não foi implementado"
+
+#~ msgid "byteorder is not a string"
+#~ msgstr "a ordem dos bytes não é uma cadeia de caracteres"
+
+#~ msgid "bytes > 8 bits not supported"
+#~ msgstr "bytes > 8 bits não suportado"
+
+#~ msgid "calibration value out of range +/-127"
+#~ msgstr "Valor de calibração fora do intervalo +/- 127"
+
+#~ msgid "can only be registered in one parent"
+#~ msgstr "pode ser registrado apenas numa principal"
+
+#~ msgid "can only save bytecode"
+#~ msgstr "apenas o bytecode pode ser salvo"
+
 #~ msgid "can query only one param"
 #~ msgstr "pode consultar apenas um parâmetro"
+
+#~ msgid "can't convert %q to int"
+#~ msgstr "Não é possível converter %q para int"
+
+#~ msgid "can't convert address to int"
+#~ msgstr "não é possível converter o endereço para int"
+
+#~ msgid "can't convert to %q"
+#~ msgstr "não é possível converter para %q"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr "não é possível fazer a divisão truncada de um número complexo"
 
 #~ msgid "can't get AP config"
 #~ msgstr "não pode obter configuração de AP"
@@ -6365,20 +5908,107 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "can't get STA config"
 #~ msgstr "não pode obter a configuração STA"
 
+#~ msgid "can't have multiple **x"
+#~ msgstr "não pode haver vários **x"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "não pode haver vários *x"
+
+#~ msgid "can't pend throw to just-started generator"
+#~ msgstr "não pode pendurar o lançamento para o gerador recém-iniciado"
+
 #~ msgid "can't set AP config"
 #~ msgstr "não é possível definir a configuração do AP"
 
 #~ msgid "can't set STA config"
 #~ msgstr "não é possível definir a configuração STA"
 
+#~ msgid "cannot import name %q"
+#~ msgstr "não pode importar nome %q"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "não pode executar a importação relativa"
+
+#~ msgid "cannot reshape array (incompatible input/output shape)"
+#~ msgstr ""
+#~ "não é possível remodelar a matriz (formato de entrada/saída incompatível)"
+
+#~ msgid "cannot unambiguously get sizeof scalar"
+#~ msgstr "Não é possível obter de forma inequívoca a escala do sizeof"
+
+#~ msgid "circle can only be registered in one parent"
+#~ msgstr "o círculo só pode ser registrado em um pai"
+
+#~ msgid "color should be an int"
+#~ msgstr "cor deve ser um int"
+
+#~ msgid "complex division by zero"
+#~ msgstr "divisão complexa por zero"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "constante deve ser um inteiro"
+
+#~ msgid "could not broadast input array from shape"
+#~ msgstr "não foi possível transmitir a matriz da entrada a partir da forma"
+
+#~ msgid "ddof must be smaller than length of data set"
+#~ msgstr "O ddof deve ser menor que o comprimento do conjunto dos dados"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr "destination_length deve ser um int >= 0"
+
+#~ msgid "divisor must be 4"
+#~ msgstr "o divisor deve ser 4"
+
 #~ msgid "either pos or kw args are allowed"
 #~ msgstr "pos ou kw args são permitidos"
+
+#~ msgid "end_x should be an int"
+#~ msgstr "end_x deve ser um int"
+
+#~ msgid ""
+#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "esp32_camera.Camera requer que uma reserva PSRAM seja configurada. "
+#~ "Consulte a documentação para obter mais informações."
+
+#~ msgid ""
+#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "O espcamera.Camera requer que o PSRAM seja reservado para que possa ser "
+#~ "configurado. Consulte a documentação para obter mais informações."
+
+#~ msgid "expected '%q' but got '%q'"
+#~ msgstr "o retorno esperado era '%q', porém obteve '%q'"
+
+#~ msgid "expected '%q' or '%q' but got '%q'"
+#~ msgstr "o retorno esperado era '%q' ou '%q', porém obteve '%q'"
 
 #~ msgid "expecting a pin"
 #~ msgstr "esperando um pino"
 
+#~ msgid "f-string expression part cannot include a '#'"
+#~ msgstr "A parte da expressão f-string não pode incluir um '#'"
+
+#~ msgid "f-string expression part cannot include a backslash"
+#~ msgstr "A parte da expressão f-string não pode incluir uma barra invertida"
+
+#~ msgid "f-string: empty expression not allowed"
+#~ msgstr "f-string: expressão vazia não é permitida"
+
+#~ msgid "f-string: expecting '}'"
+#~ msgstr "f-string: esperando '}'"
+
+#~ msgid "f-string: single '}' is not allowed"
+#~ msgstr "f-string: um único '}' não é permitido"
+
 #~ msgid "ffi_prep_closure_loc"
 #~ msgstr "ffi_prep_closure_loc"
+
+#~ msgid "first argument must be an iterable"
+#~ msgstr "o primeiro argumento deve ser um iterável"
 
 #~ msgid "firstbit must be MSB"
 #~ msgstr "firstbit devem ser MSB"
@@ -6389,8 +6019,41 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "frequency can only be either 80Mhz or 160MHz"
 #~ msgstr "A frequência só pode ser 80Mhz ou 160MHz"
 
+#~ msgid "frequency is read-only for this board"
+#~ msgstr "nesta placa, a frequência é de apenas leitura"
+
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "função não aceita argumentos de palavras-chave"
+
+#~ msgid "function is implemented for scalars and ndarrays only"
+#~ msgstr "A função foi implementada apenas para escalares e ndarrays"
+
 #~ msgid "impossible baudrate"
 #~ msgstr "taxa de transmissão impossível"
+
+#~ msgid "incompatible native .mpy architecture"
+#~ msgstr "arquivo .mpy com arquitetura nativa incompatível"
+
+#~ msgid "input and output shapes are not compatible"
+#~ msgstr "as formas de entrada e saída não são compatíveis"
+
+#~ msgid "input argument must be an integer or a 2-tuple"
+#~ msgstr "o argumento da entrada deve ser um número inteiro ou uma tupla de 2"
+
+#~ msgid "input must be a tensor of rank 2"
+#~ msgstr "a entrada dos dados deve ser um tensor de nível 2"
+
+#~ msgid "inputs are not iterable"
+#~ msgstr "as entradas não são iteráveis"
+
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr "int() arg 2 deve ser >= 2 e <= 36"
+
+#~ msgid "integer required"
+#~ msgstr "inteiro requerido"
+
+#~ msgid "interp is defined for 1D arrays of equal length"
+#~ msgstr "o interp é definido para matrizes 1D de igual comprimento"
 
 #~ msgid "invalid I2C peripheral"
 #~ msgstr "periférico I2C inválido"
@@ -6401,11 +6064,29 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "invalid alarm"
 #~ msgstr "Alarme inválido"
 
+#~ msgid "invalid architecture"
+#~ msgstr "arquitetura inválida"
+
+#~ msgid "invalid arguments"
+#~ msgstr "argumentos inválidos"
+
+#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
+#~ msgstr "bits_per_pixel %d é inválido, deve ser, 1, 4, 8, 16, 24, ou 32"
+
 #~ msgid "invalid buffer length"
 #~ msgstr "comprimento de buffer inválido"
 
 #~ msgid "invalid data bits"
 #~ msgstr "Bits de dados inválidos"
+
+#~ msgid "invalid decorator"
+#~ msgstr "decorador inválido"
+
+#~ msgid "invalid dupterm index"
+#~ msgstr "Índice de dupterm inválido"
+
+#~ msgid "invalid format"
+#~ msgstr "formato inválido"
 
 #~ msgid "invalid pin"
 #~ msgstr "Pino inválido"
@@ -6413,8 +6094,49 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "invalid stop bits"
 #~ msgstr "Bits de parada inválidos"
 
+#~ msgid "invalid traceback"
+#~ msgstr "rastreamento inválido"
+
+#~ msgid "io must be rtc io"
+#~ msgstr "O io deve ser rtc io"
+
+#~ msgid "iterables are not of the same length"
+#~ msgstr "os iteráveis não têm o mesmo comprimento"
+
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr ""
+#~ "o(s) argumento(s) de palavra-chave ainda não foi implementado - em vez "
+#~ "disso, use argumentos normais"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "as palavras-chave devem ser uma cadeia de caracteres"
+
 #~ msgid "len must be multiple of 4"
 #~ msgstr "len deve ser múltiplo de 4"
+
+#~ msgid "length argument not allowed for this type"
+#~ msgstr "o argumento de comprimento não é permitido para este tipo"
+
+#~ msgid "limit should be an int"
+#~ msgstr "o limite deve ser um inteiro"
+
+#~ msgid "long int not supported in this build"
+#~ msgstr "o long int não é suportado nesta compilação"
+
+#~ msgid "matrix dimensions do not match"
+#~ msgstr "as dimensões da matriz não coincidem"
+
+#~ msgid "max_connections must be between 0 and 10"
+#~ msgstr "max_connections deve estar entre 0 e 10"
+
+#~ msgid "max_length must be > 0"
+#~ msgstr "max_length deve ser > 0"
+
+#~ msgid "max_length must be >= 0"
+#~ msgstr "max_length deve ser >= 0"
+
+#~ msgid "maximum number of dimensions is 4"
+#~ msgstr "O número máximo de dimensões são 4"
 
 #~ msgid "memory allocation failed, allocating %u bytes for native code"
 #~ msgstr "alocação de memória falhou, alocando %u bytes para código nativo"
@@ -6422,34 +6144,296 @@ msgstr "zi deve estar na forma (n_section, 2)"
 #~ msgid "must specify all of sck/mosi/miso"
 #~ msgstr "deve especificar todos sck/mosi/miso"
 
+#~ msgid "n must be between 0, and 9"
+#~ msgstr "n deve estar entre 0 e 9"
+
 #, fuzzy
 #~ msgid "name must be a string"
 #~ msgstr "heap deve ser uma lista"
 
+#~ msgid "name reused for argument"
+#~ msgstr "o nome foi reutilizado para o argumento"
+
+#~ msgid "no available NIC"
+#~ msgstr "não há uma Placa de Rede disponível"
+
+#~ msgid "no reset pin available"
+#~ msgstr "nenhum pino de redefinição está disponível"
+
+#~ msgid "non-Device in %q"
+#~ msgstr "não dispositivo em %q"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "um arg sem palavra-chave após */ **"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "um arg não-palavra-chave após a palavra-chave arg"
+
+#~ msgid "norm is defined for 1D and 2D arrays"
+#~ msgstr "a norma é definida para matrizes 1D e 2D"
+
 #~ msgid "not a valid ADC Channel: %d"
 #~ msgstr "não é um canal ADC válido: %d"
 
+#~ msgid "number of arguments must be 2, or 3"
+#~ msgstr "a quantidade dos argumentos deve ser 2 ou 3"
+
+#~ msgid "object '%q' is not a tuple or list"
+#~ msgstr "o objeto '%q' não é uma tupla ou uma lista"
+
+#~ msgid "object '%s' is not a tuple or list"
+#~ msgstr "o objeto '%s' não é uma tupla ou uma lista"
+
+#~ msgid "object does not support item assignment"
+#~ msgstr "O objeto não suporta a atribuição dos itens"
+
+#~ msgid "object does not support item deletion"
+#~ msgstr "objeto não suporta a exclusão do item"
+
+#~ msgid "object is not subscriptable"
+#~ msgstr "O objeto não é subroteirizável"
+
+#~ msgid "object of type '%q' has no len()"
+#~ msgstr "o objeto do tipo '%q' não tem len()"
+
+#~ msgid "offset out of bounds"
+#~ msgstr "desvio fora dos limites"
+
+#~ msgid "operation is not implemented for flattened array"
+#~ msgstr "a operação não é implementada para a matriz achatada"
+
+#~ msgid "out of range of source"
+#~ msgstr "fora do alcance da fonte"
+
+#~ msgid "palette_index should be an int"
+#~ msgstr "palette_index deve ser um int"
+
+#~ msgid "parameter annotation must be an identifier"
+#~ msgstr "a anotação do parâmetro deve ser um identificador"
+
 #~ msgid "pin does not have IRQ capabilities"
 #~ msgstr "Pino não tem recursos de IRQ"
+
+#~ msgid "pixel value requires too many bits"
+#~ msgstr "o valor do pixel requer bits demais"
+
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+#~ msgstr ""
+#~ "o pixel_shader deve ser displayio.Palette ou displayio.ColorConverter"
+
+#~ msgid "polygon can only be registered in one parent"
+#~ msgstr "o polígono só pode ser registrado em um pai"
+
+#~ msgid "pop from an empty set"
+#~ msgstr "pop a partir de um conjunto vazio"
+
+#~ msgid "pop from empty list"
+#~ msgstr "pop a partir da lista vazia"
+
+#~ msgid "popitem(): dictionary is empty"
+#~ msgstr "popitem(): o dicionário está vazio"
+
+#~ msgid "pressing BOOT button at start up.\n"
+#~ msgstr "pressionando o botão BOOT na inicialização.\n"
+
+#~ msgid "pressing SW38 button at start up.\n"
+#~ msgstr "pressionando o botão SW38 na inicialização.\n"
+
+#~ msgid "pressing VOLUME button at start up.\n"
+#~ msgstr "pressionando o botão VOLUME na inicialização.\n"
+
+#~ msgid "pressing boot button at start up.\n"
+#~ msgstr "pressionando o botão de boot na inicialização.\n"
+
+#~ msgid "pressing both buttons at start up.\n"
+#~ msgstr "pressionando ambos os botões durante a inicialização.\n"
+
+#~ msgid "pressing button A at start up.\n"
+#~ msgstr "pressionando o botão A na inicialização.\n"
+
+#~ msgid "pressing central button at start up.\n"
+#~ msgstr "pressionando o botão central na inicialização.\n"
+
+#~ msgid "pressing the left button at start up\n"
+#~ msgstr "pressionando o botão esquerdo durante a inicialização\n"
+
+#~ msgid "pull_threshold must be between 1 and 32"
+#~ msgstr "O pull_threshold deve ser entre 1 e 32"
+
+#~ msgid "push_threshold must be between 1 and 32"
+#~ msgstr "O pull_threshold deve ser entre 1 e 32"
+
+#~ msgid "queue overflow"
+#~ msgstr "estouro de fila"
+
+#~ msgid "raw REPL; CTRL-B to exit\n"
+#~ msgstr "REPL bruto; CTRL-B para encerrar\n"
+
+#~ msgid "raw f-strings are not implemented"
+#~ msgstr "o f-strings bruto não estão implementados"
 
 #, fuzzy
 #~ msgid "readonly attribute"
 #~ msgstr "atributo ilegível"
 
+#~ msgid "right hand side must be an ndarray, or a scalar"
+#~ msgstr "o lado direito deve ser um ndarray ou um escalar"
+
 #~ msgid "row must be packed and word aligned"
 #~ msgstr "Linha deve ser comprimida e com as palavras alinhadas"
+
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "O buffer sample_source deve ser um bytearray ou matriz do tipo 'h', 'H', "
+#~ "'b' ou 'B'"
 
 #~ msgid "scan failed"
 #~ msgstr "varredura falhou"
 
+#~ msgid "schedule stack full"
+#~ msgstr "agende a pilha de função completa"
+
+#~ msgid "shape must be a 2-tuple"
+#~ msgstr "a forma deve ser uma tupla de 2"
+
+#~ msgid "shape must be a tuple"
+#~ msgstr "a forma deve ser uma tupla"
+
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "único '}' encontrado na string do formato"
+
+#~ msgid "slice step can't be zero"
+#~ msgstr "a etapa da fatia não pode ser zero"
+
+#~ msgid "slice step cannot be zero"
+#~ msgstr "a etapa da fatia não pode ser zero"
+
+#~ msgid "sorted axis can't be longer than 65535"
+#~ msgstr "o eixo ordenado não pode ser maior do que 65535"
+
+#~ msgid "specify size or data, but not both"
+#~ msgstr "defina o tamanho ou os dados, porém não ambos"
+
+#~ msgid "ssid can't be more than 32 bytes"
+#~ msgstr "O ssid não pode ter mais do que 32 bytes"
+
+#~ msgid "start_x should be an int"
+#~ msgstr "start_x deve ser um int"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "o passo deve ser diferente de zero"
+
+#~ msgid "stop must be 1 or 2"
+#~ msgstr "o stop deve ser 1 ou 2"
+
+#~ msgid "string indices must be integers, not %q"
+#~ msgstr "a sequência dos índices devem ser inteiros, não %q"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr "a string não é compatível; use bytes ou bytearray"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "struct: não pode indexar"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "Limite deve estar no alcance de 0-65536"
+
+#~ msgid "tile must be greater than zero"
+#~ msgstr "o bloco deve ser maior que zero"
+
+#~ msgid "time.struct_time() takes a 9-sequence"
+#~ msgstr "time.struct_time() leva uma sequência com 9"
+
+#~ msgid "timeout must be 0.0-100.0 seconds"
+#~ msgstr "o tempo limite deve ser entre 0.0 a 100.0 segundos"
+
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "o tempo limite deve ser >= 0,0"
+
 #~ msgid "too many arguments"
 #~ msgstr "muitos argumentos"
+
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "Muitos argumentos fornecidos com o formato dado"
+
+#~ msgid "trapz is defined for 1D arrays"
+#~ msgstr "Trapz está definido para arrays 1D"
+
+#~ msgid "trigger level must be 0 or 1"
+#~ msgstr "nível do gatilho deve ser 0 ou 1"
+
+#~ msgid "tuple index out of range"
+#~ msgstr "o índice da tupla está fora do intervalo"
+
+#~ msgid "tuple/list required on RHS"
+#~ msgstr "a tupla/lista necessária no RHS"
+
+#~ msgid "type object 'generator' has no attribute '__await__'"
+#~ msgstr ""
+#~ "o tipo do objeto 'generator' não possui qualquer atributo '__await__'"
+
+#~ msgid "unindent does not match any outer indentation level"
+#~ msgstr "o unindent não coincide com nenhum nível de recuo externo"
 
 #~ msgid "unknown config param"
 #~ msgstr "parâmetro configuração desconhecido"
 
+#~ msgid "unknown format code '%c' for object of type '%s'"
+#~ msgstr "código de formato desconhecido '%c' para o objeto do tipo '%s'"
+
 #~ msgid "unknown status param"
 #~ msgstr "parâmetro de status desconhecido"
 
+#~ msgid "unmatched '{' in format"
+#~ msgstr "um '{' sem par no formato"
+
+#~ msgid "unsupported type for %q: '%q'"
+#~ msgstr "tipo sem suporte para %q: '%q'"
+
+#~ msgid "unsupported types for %q: '%s', '%s'"
+#~ msgstr "tipos não compatíveis para %q: '%s', '%s'"
+
+#~ msgid "value_count must be > 0"
+#~ msgstr "o value_count deve ser > 0"
+
+#~ msgid "vectors must have same lengths"
+#~ msgstr "os vetores devem ter os mesmos comprimentos"
+
+#~ msgid "wakeup conflict"
+#~ msgstr "conflito de wakeup"
+
+#~ msgid "watchdog not initialized"
+#~ msgstr "o watchdog não foi inicializado"
+
+#~ msgid "watchdog timeout must be greater than 0"
+#~ msgstr "o tempo limite do watchdog deve ser maior que 0"
+
+#, c-format
+#~ msgid "width must be from 2 to 8 (inclusive), not %d"
+#~ msgstr "a largura deve ser entre 2 a 8 (inclusive), não %d"
+
 #~ msgid "wifi_set_ip_info() failed"
 #~ msgstr "wifi_set_ip_info() falhou"
+
+#~ msgid "wrong argument type"
+#~ msgstr "tipo do argumento errado"
+
+#~ msgid "wrong operand type"
+#~ msgstr "tipo do operando errado"
+
+#~ msgid "x value out of bounds"
+#~ msgstr "o valor x está fora dos limites"
+
+#~ msgid "xTaskCreate failed"
+#~ msgstr "o xTaskCreate falhou"
+
+#~ msgid "y should be an int"
+#~ msgstr "y deve ser um int"
+
+#~ msgid "y value out of bounds"
+#~ msgstr "o valor y está fora dos limites"
+
+#~ msgid "zero step"
+#~ msgstr "passo zero"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -85,16 +85,6 @@ msgstr " вывод:\n"
 msgid "%%c requires int or char"
 msgstr "%%c требует int или char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
@@ -102,26 +92,6 @@ msgid ""
 msgstr ""
 "Адресные контакты %d, контакты rgb %d и плитки %d обозначают высоту %d, а не "
 "%d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -305,11 +275,6 @@ msgstr "%q[%u] использует дополнительный контакт"
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
 msgstr "%q [%u] ожидает ввода за пределами графа"
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
-msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
 #, c-format
@@ -782,7 +747,8 @@ msgstr ""
 
 #: ports/espressif/common-hal/alarm/pin/PinAlarm.c
 msgid "Can only alarm on two low pins from deep sleep."
-msgstr "Из глубокого сна может сигнализировать только по двум низким контактам."
+msgstr ""
+"Из глубокого сна может сигнализировать только по двум низким контактам."
 
 #: ports/espressif/common-hal/_bleio/Characteristic.c
 #: ports/nrf/common-hal/_bleio/Characteristic.c
@@ -862,7 +828,8 @@ msgstr "Невозможно изменить частоту на таймере
 
 #: ports/nrf/common-hal/alarm/pin/PinAlarm.c
 msgid "Cannot wake on pin edge, only level"
-msgstr "Невозможно проснуться по изменению логического уровня, только по уровню"
+msgstr ""
+"Невозможно проснуться по изменению логического уровня, только по уровню"
 
 #: ports/espressif/common-hal/alarm/pin/PinAlarm.c
 msgid "Cannot wake on pin edge. Only level."
@@ -1652,8 +1619,9 @@ msgstr "Да"
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Только 8- или 16-битное моно с "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -1843,7 +1811,8 @@ msgstr "Полигону необходимо как минимум 3 точки
 
 #: supervisor/shared/safe_mode.c
 msgid "Power dipped. Make sure you are providing enough power."
-msgstr "Мощность просела. Убедитесь, что вы обеспечиваете достаточную мощность."
+msgstr ""
+"Мощность просела. Убедитесь, что вы обеспечиваете достаточную мощность."
 
 #: shared-bindings/_bleio/Adapter.c
 msgid "Prefix buffer must be on the heap"
@@ -2703,7 +2672,8 @@ msgstr "Можно указать только одно неизвестное �
 
 #: py/objtype.c
 msgid "can't add special method to already-subclassed class"
-msgstr "Не удается добавить специальный метод к уже имеющемуся подклассу классу"
+msgstr ""
+"Не удается добавить специальный метод к уже имеющемуся подклассу классу"
 
 #: py/compile.c
 msgid "can't assign to expression"
@@ -3015,7 +2985,8 @@ msgstr ""
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "destination buffer must be an array of type 'H' for bit_depth = 16"
-msgstr "буфер назначения должен быть массивом типа «H» для битовой_глубины = 16"
+msgstr ""
+"буфер назначения должен быть массивом типа «H» для битовой_глубины = 16"
 
 #: py/objdict.c
 msgid "dict update sequence has wrong length"
@@ -4496,18 +4467,65 @@ msgstr "zi должно быть типа float"
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi должен иметь форму (n_section, 2)"
 
-#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
-#~ msgstr "Недопустимый CIRCUITPY_PYSTACK_SIZE\n"
-
-#~ msgid "Unable to allocate the heap."
-#~ msgstr "Невозможно выделить кучу."
+#~ msgid ""
+#~ "\n"
+#~ "Code stopped by auto-reload.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Программа остановлена автоматической перезагрузкой.\n"
 
 #~ msgid ""
-#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
+#~ "\n"
+#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
 #~ msgstr ""
-#~ "espcamera.Для настройки камеры требуется зарезервированная PSRAM. "
-#~ "Инструкции см. в документации."
+#~ "\n"
+#~ "Пожалуйста, сообщите о проблеме, приложив содержимое вашего диска "
+#~ "CIRCUITPY на\n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
+
+#, c-format
+#~ msgid "%02X"
+#~ msgstr "%02X"
+
+#~ msgid "%q"
+#~ msgstr "%q"
+
+#~ msgid "%q length must be >= 1"
+#~ msgstr "Длинна %q должна быть >= 1"
+
+#~ msgid "%q must be >= 0"
+#~ msgstr "%q должен быть >= 0"
+
+#~ msgid "%q must be >= 1"
+#~ msgstr "%q должен быть >= 1"
+
+#~ msgid "%q must be a string"
+#~ msgstr "%q должно быть строкой"
+
+#~ msgid "%q must be a tuple of length 2"
+#~ msgstr "%q должен быть кортежем длинной 2"
+
+#~ msgid "%q must be an int"
+#~ msgstr "%q должно быть int"
+
+#~ msgid "%q must be between %d and %d"
+#~ msgstr "%q должен быть между %d и %d"
+
+#~ msgid "%q must be of type %q"
+#~ msgstr "%q должно быть типа %q"
+
+#~ msgid "%q must be of type %q or None"
+#~ msgstr "%q должно быть типа %q или None"
+
+#~ msgid "%q pin invalid"
+#~ msgstr "Пин %q не допустим"
+
+#~ msgid "%q should be an int"
+#~ msgstr "%q должен быть int"
+
+#~ msgid "%q with a report ID of 0 must be of length 1"
+#~ msgstr "%q с идентификатором отчёта 0 должен иметь длину 1"
 
 #~ msgid "'await', 'async for' or 'async with' outside async function"
 #~ msgstr ""
@@ -4520,329 +4538,17 @@ msgstr "zi должен иметь форму (n_section, 2)"
 #~ msgid "'continue' outside loop"
 #~ msgstr "«продолжить» вне цикла"
 
-#~ msgid "invalid architecture"
-#~ msgstr "Недопустимая архитектура"
-
-#~ msgid "unsupported type for %q: '%q'"
-#~ msgstr "Неподдерживаемый тип для %q: '%q'"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Разделение с помощью субзахватов"
-
-#~ msgid "__init__() should return None, not '%q'"
-#~ msgstr "__init__() должен возвращать None, а не '%q'"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "Атрибуты пока не поддерживаются"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr "Не могу сделать усеченное деление комплексного числа"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "Не удается импортировать имя %Q"
-
-#~ msgid "cannot unambiguously get sizeof scalar"
-#~ msgstr "не может однозначно получить размер скаляра"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr ""
-#~ "Аргументы ключевого слова еще не реализованы - вместо этого используйте "
-#~ "обычные аргументы"
-
-#~ msgid "length argument not allowed for this type"
-#~ msgstr "аргумент длины не допускается для этого типа"
-
-#~ msgid "offset out of bounds"
-#~ msgstr "Смещение за пределы"
-
-#~ msgid "slice step can't be zero"
-#~ msgstr "Шаг среза не может быть равен нулю"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr "строка не поддерживается; Использование байтов или массива байтов"
-
-#~ msgid "Bit clock and word select must be sequential pins"
-#~ msgstr ""
-#~ "Битовый тактовый генератор и выбор слова должны быть последовательными "
-#~ "пинами"
-
-#~ msgid "Initialization failed due to lack of memory"
-#~ msgstr "Инициализация не удалась из-за нехватки памяти"
-
-#~ msgid "RAISE mode is not implemented"
-#~ msgstr "Режим RAISE не реализован"
-
-#~ msgid "WatchDogTimer is not currently running"
-#~ msgstr "Таймер Watch Dog в настоящее время не работает"
-
-#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-#~ msgstr ""
-#~ "WatchDogTimer.mode не может быть изменен после установки значения "
-#~ "WatchDogMode.RESET"
-
-#~ msgid "watchdog not initialized"
-#~ msgstr "Сторожевой таймер не инициализирован"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "ADC2 используется WiFi"
-
-#, c-format
-#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Невозможно настроить контроллер ADC DMA, код ошибки:%d"
-
-#, c-format
-#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Невозможно инициализировать контроллер ADC DMA, код ошибки:%d"
-
-#, c-format
-#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Не удается запустить контроллер ADC DMA, код ошибки:%d"
-
-#~ msgid "xTaskCreate failed"
-#~ msgstr "x Создать задачу не удалось"
-
-#~ msgid "Unable to write to address."
-#~ msgstr "Невозможно написать на адрес."
-
-#~ msgid "queue overflow"
-#~ msgstr "Переполнение очереди"
-
 #~ msgid "'coroutine' object is not an iterator"
 #~ msgstr "Объект 'coroutine' не является итератором"
 
-#~ msgid "Buffer is too small"
-#~ msgstr "Буфер слишком мал"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "Файл .mpy поврежден"
-
-#~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
-#~ msgstr ""
-#~ "Несовместимый файл .mpy. Пожалуйста, обновите все файлы .mpy. См. http://"
-#~ "adafru.it/mpy-update для получения дополнительной информации."
-
-#, c-format
-#~ msgid "Instruction %d shifts in more bits than pin count"
-#~ msgstr ""
-#~ "Инструкция %d вводит (shifts in) большее количество бит, чем количество "
-#~ "пинов"
-
-#, c-format
-#~ msgid "Instruction %d shifts out more bits than pin count"
-#~ msgstr ""
-#~ "Инструкция %d выводит (shifts out) большее количество бит, чем количество "
-#~ "пинов"
-
-#, c-format
-#~ msgid "Instruction %d uses extra pin"
-#~ msgstr "Инструкция %d использует дополнительный пин"
-
-#, c-format
-#~ msgid "Instruction %d waits on input outside of count"
-#~ msgstr "Инструкция %d ожидает ввода за пределами count"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
-#~ msgstr "Отсутствует first_in_pin. Инструкция %d читает состояние пина (-ов)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
-#~ msgstr ""
-#~ "Отсутствует first_out_pin. Инструкция %d вводит (shifts out) на пин(ы)"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
-#~ msgstr "Отсутствует first_in_pin. Инструкция %d ожидает на основе пина"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
-#~ msgstr ""
-#~ "Отсутствует first_out_pin. Инструкция %d выводит (shifts out) на пин(ы)"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
-#~ msgstr "Отсутствует first_out_pin. Инструкция %d записывает пин(ы)"
-
-#, c-format
-#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
-#~ msgstr "Отсутствует first_set_pin. Инструкция %d устанавливает пин(ы)"
-
-#, c-format
-#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
-#~ msgstr "Отсутствует jmp_pin. Инструкция %d перепрыгивает на пин"
-
-#~ msgid "Cannot transfer without MOSI and MISO pins"
-#~ msgstr "Невозможно передать данные без пинов MOSI и MISO"
-
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Оборудование занято, попробуйте использовать другие пины"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "Отсутствует пин MISO или MOSI"
-
-#~ msgid "Missing MISO or MOSI pin"
-#~ msgstr "Отсутствует пин MISO или MOSI"
-
-#~ msgid "No MISO Pin"
-#~ msgstr "Нет пина MISO"
-
-#~ msgid "No MISO pin"
-#~ msgstr "Нет пина MISO"
-
-#~ msgid "No MOSI Pin"
-#~ msgstr "Нет пина MOSI"
-
-#~ msgid "No MOSI pin"
-#~ msgstr "Нет пина MOSI"
-
-#~ msgid "No RX pin"
-#~ msgstr "Нет пина RX"
-
-#~ msgid "No TX pin"
-#~ msgstr "Нет пина TX"
-
-#~ msgid "no reset pin available"
-#~ msgstr "нет доступного контакта сброса"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "Яркость должна быть в диапазоне от 0 до 1.0"
-
-#, c-format
-#~ msgid "Error in MIDI stream at position %d"
-#~ msgstr "Ошибка в MIDI-потоке на позиции %d"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "Максимальное значение x при зеркальном отображении - %d"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "I2SOut недоступен"
+#~ msgid "(x,y) integers required"
+#~ msgstr "Требуются целые числа (x,y)"
 
 #~ msgid "64 bit types"
 #~ msgstr "64-битные типы"
 
-#~ msgid "No key was specified"
-#~ msgstr "Ключ не был указан"
-
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "Предоставьте хотяб один пин UART"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "Пин %q не допустим"
-
-#~ msgid ""
-#~ "\n"
-#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
-#~ "https://github.com/adafruit/circuitpython/issues\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Пожалуйста, сообщите о проблеме, приложив содержимое вашего диска "
-#~ "CIRCUITPY на\n"
-#~ "https://github.com/adafruit/circuitpython/issues\n"
-
-#~ msgid "Attempted heap allocation when VM not running."
-#~ msgstr "Попытка выделения heap пока виртуальная машина не запущена."
-
-#~ msgid "Boot device must be first device (interface #0)."
-#~ msgstr ""
-#~ "Загрузочное устройство должно быть первым устройством (интерфейс #0)."
-
-#~ msgid "Both buttons were pressed at start up.\n"
-#~ msgstr "Обе кнопки были нажаты при загрузке.\n"
-
-#~ msgid "Button A was pressed at start up.\n"
-#~ msgstr "Кнопка A была нажата при загрузке\n"
-
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "CircuitPython не смог выделить heap."
-
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "Крашнулся в HardFault_Handler."
-
-#~ msgid "Fatal error."
-#~ msgstr "Фатальная ошибка."
-
-#~ msgid "Invalid memory access."
-#~ msgstr "Неправильный доступ к памяти."
-
-#, fuzzy
-#~ msgid "Nordic system firmware failure assertion."
-#~ msgstr "Сбой системной прошивки Nordic (assertion)."
-
-#~ msgid "%q must be of type %q"
-#~ msgstr "%q должно быть типа %q"
-
-#~ msgid "%q must be of type %q or None"
-#~ msgstr "%q должно быть типа %q или None"
-
-#~ msgid "Expected a %q"
-#~ msgstr "Ожидалось(ся) %q"
-
-#~ msgid "Expected a %q or %q"
-#~ msgstr "Ожидалось %q или %q"
-
-#, fuzzy
-#~ msgid "Expected an %q"
-#~ msgstr "Ожидалось %q"
-
-#, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IV должен быть длиной %d байт"
-
-#, fuzzy
-#~ msgid "Not settable"
-#~ msgstr "Невозможно установить"
-
-#~ msgid "%q length must be >= 1"
-#~ msgstr "Длинна %q должна быть >= 1"
-
-#~ msgid "%q must be a string"
-#~ msgstr "%q должно быть строкой"
-
-#~ msgid "%q must be an int"
-#~ msgstr "%q должно быть int"
-
-#~ msgid "%q with a report ID of 0 must be of length 1"
-#~ msgstr "%q с идентификатором отчёта 0 должен иметь длину 1"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "Может быть указано не более %d %q (не %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Недопустимые пины"
-
-#, c-format
-#~ msgid "No more than %d HID devices allowed"
-#~ msgstr "Допускается не более %d HID устройств"
-
-#~ msgid "Firmware image is invalid"
-#~ msgstr "Образ прошивки неправильный"
-
-#~ msgid "%q must be >= 0"
-#~ msgstr "%q должен быть >= 0"
-
-#~ msgid "%q must be >= 1"
-#~ msgstr "%q должен быть >= 1"
-
-#~ msgid "Expected an alarm"
-#~ msgstr "Ожидался сигнал"
-
-#~ msgid "Failed to init wifi"
-#~ msgstr "Не удалось инициировать wifi"
-
-#~ msgid "%q must be a tuple of length 2"
-#~ msgstr "%q должен быть кортежем длинной 2"
-
-#~ msgid "%q must be between %d and %d"
-#~ msgstr "%q должен быть между %d и %d"
-
-#~ msgid "%q should be an int"
-#~ msgstr "%q должен быть int"
-
-#~ msgid "(x,y) integers required"
-#~ msgstr "Требуются целые числа (x,y)"
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "ADC2 используется WiFi"
 
 #~ msgid "Address type out of range"
 #~ msgstr "Тип адреса вне диапазона"
@@ -4859,16 +4565,46 @@ msgstr "zi должен иметь форму (n_section, 2)"
 #~ msgid "AnalogOut not supported on given pin"
 #~ msgstr "AnalogOut не поддерживается на данном пине"
 
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "Может быть указано не более %d %q (не %d)"
+
+#~ msgid "Attempted heap allocation when VM not running."
+#~ msgstr "Попытка выделения heap пока виртуальная машина не запущена."
+
+#~ msgid "Bit clock and word select must be sequential pins"
+#~ msgstr ""
+#~ "Битовый тактовый генератор и выбор слова должны быть последовательными "
+#~ "пинами"
+
 #, c-format
 #~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
 #~ msgstr "Битовая глубина должна быть от 1 до 6 включительно, а не %d"
+
+#~ msgid "Boot device must be first device (interface #0)."
+#~ msgstr ""
+#~ "Загрузочное устройство должно быть первым устройством (интерфейс #0)."
+
+#~ msgid "Both buttons were pressed at start up.\n"
+#~ msgstr "Обе кнопки были нажаты при загрузке.\n"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "Яркость должна быть в диапазоне от 0 до 1.0"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "Яркость должна быть в диапазоне от 0 до 255"
 
 #, c-format
 #~ msgid "Buffer incorrect size. Should be %d bytes."
 #~ msgstr "Неправильный размер буфера. Должен быть %d байт."
 
+#~ msgid "Buffer is too small"
+#~ msgstr "Буфер слишком мал"
+
 #~ msgid "Buffer must be at least length 1"
 #~ msgstr "Буфер должен быть размером не менее 1"
+
+#~ msgid "Button A was pressed at start up.\n"
+#~ msgstr "Кнопка A была нажата при загрузке\n"
 
 #~ msgid "Bytes must be between 0 and 255."
 #~ msgstr "Bytes должен быть в диапазоне от 0 до 255."
@@ -4882,17 +4618,26 @@ msgstr "zi должен иметь форму (n_section, 2)"
 #~ msgid "Cannot reset into bootloader because no bootloader is present."
 #~ msgstr "Невозможно перезагрузится в загрузчик так как он отсутствует."
 
+#~ msgid "Cannot transfer without MOSI and MISO pins"
+#~ msgstr "Невозможно передать данные без пинов MOSI и MISO"
+
 #~ msgid "Cannot transfer without MOSI and MISO pins."
 #~ msgstr "Передача данных невозможна без пинов MOSI и MISO."
 
 #~ msgid "Cannot write without MOSI pin."
 #~ msgstr "Запись невозможна без пина MOSI."
 
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "CircuitPython не смог выделить heap."
+
 #~ msgid "Clock pin init failed."
 #~ msgstr "Не удалось инициализировать пин Clock."
 
 #~ msgid "Command must be an int between 0 and 255"
 #~ msgstr "Команда должна быть целым числом (int) от 0 до 255"
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "Файл .mpy поврежден"
 
 #~ msgid "Could not initialize Camera"
 #~ msgstr "Не удалось инициализировать камеру"
@@ -4924,8 +4669,28 @@ msgstr "zi должен иметь форму (n_section, 2)"
 #~ msgid "Couldn't allocate second buffer"
 #~ msgstr "Не удалось выделить второй буфер"
 
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "Крашнулся в HardFault_Handler."
+
 #~ msgid "DigitalInOut not supported on given pin"
 #~ msgstr "DigitalInOut не поддерживается на данном пине"
+
+#, c-format
+#~ msgid "Error in MIDI stream at position %d"
+#~ msgstr "Ошибка в MIDI-потоке на позиции %d"
+
+#~ msgid "Expected a %q"
+#~ msgstr "Ожидалось(ся) %q"
+
+#~ msgid "Expected a %q or %q"
+#~ msgstr "Ожидалось %q или %q"
+
+#, fuzzy
+#~ msgid "Expected an %q"
+#~ msgstr "Ожидалось %q"
+
+#~ msgid "Expected an alarm"
+#~ msgstr "Ожидался сигнал"
 
 #, c-format
 #~ msgid "Expected tuple of length %d, got %d"
@@ -4938,15 +4703,64 @@ msgstr "zi должен иметь форму (n_section, 2)"
 #~ msgid "Failed to allocate RX buffer of %d bytes"
 #~ msgstr "Не удалось выделить буфер RX размером %d байт"
 
+#~ msgid "Failed to init wifi"
+#~ msgstr "Не удалось инициировать wifi"
+
+#~ msgid "Fatal error."
+#~ msgstr "Фатальная ошибка."
+
+#~ msgid "Firmware image is invalid"
+#~ msgstr "Образ прошивки неправильный"
+
 #, c-format
 #~ msgid "Framebuffer requires %d bytes"
 #~ msgstr "Фреймбуфер требует %d байт"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Оборудование занято, попробуйте использовать другие пины"
 
 #~ msgid "Hostname must be between 1 and 253 characters"
 #~ msgstr "Имя хоста должно содержать от 1 до 253 символов"
 
 #~ msgid "I2C Init Error"
 #~ msgstr "Ошибка инициализации I2C"
+
+#~ msgid "I2SOut not available"
+#~ msgstr "I2SOut недоступен"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IV должен быть длиной %d байт"
+
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "Несовместимый файл .mpy. Пожалуйста, обновите все файлы .mpy. См. http://"
+#~ "adafru.it/mpy-update для получения дополнительной информации."
+
+#~ msgid "Initialization failed due to lack of memory"
+#~ msgstr "Инициализация не удалась из-за нехватки памяти"
+
+#, c-format
+#~ msgid "Instruction %d shifts in more bits than pin count"
+#~ msgstr ""
+#~ "Инструкция %d вводит (shifts in) большее количество бит, чем количество "
+#~ "пинов"
+
+#, c-format
+#~ msgid "Instruction %d shifts out more bits than pin count"
+#~ msgstr ""
+#~ "Инструкция %d выводит (shifts out) большее количество бит, чем количество "
+#~ "пинов"
+
+#, c-format
+#~ msgid "Instruction %d uses extra pin"
+#~ msgstr "Инструкция %d использует дополнительный пин"
+
+#, c-format
+#~ msgid "Instruction %d waits on input outside of count"
+#~ msgstr "Инструкция %d ожидает ввода за пределами count"
 
 #~ msgid "Invalid %q pin selection"
 #~ msgstr "Неверный выбор пина %q"
@@ -4956,6 +4770,9 @@ msgstr "zi должен иметь форму (n_section, 2)"
 
 #~ msgid "Invalid BMP file"
 #~ msgstr "Неправилный файл BMP"
+
+#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
+#~ msgstr "Недопустимый CIRCUITPY_PYSTACK_SIZE\n"
 
 #~ msgid "Invalid DAC pin supplied"
 #~ msgstr "Передан неверный пин ЦАП"
@@ -4991,6 +4808,9 @@ msgstr "zi должен иметь форму (n_section, 2)"
 #~ msgid "Invalid file"
 #~ msgstr "Неверный файл"
 
+#~ msgid "Invalid memory access."
+#~ msgstr "Неправильный доступ к памяти."
+
 #~ msgid "Invalid number of bits"
 #~ msgstr "Неверное количество бит"
 
@@ -5005,6 +4825,9 @@ msgstr "zi должен иметь форму (n_section, 2)"
 
 #~ msgid "Invalid pin for right channel"
 #~ msgstr "Недопустимый пин для правого канала"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Недопустимые пины"
 
 #~ msgid "Invalid polarity"
 #~ msgstr "Неправильная полярность"
@@ -5042,12 +4865,74 @@ msgstr "zi должен иметь форму (n_section, 2)"
 #~ msgid "MOSI pin init failed."
 #~ msgstr "Не удалось инициализировать пин MOSI."
 
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "Максимальное значение x при зеркальном отображении - %d"
+
 #~ msgid "Messages limited to 8 bytes"
 #~ msgstr "Сообщения ограничены 8 байтами"
+
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "Отсутствует пин MISO или MOSI"
+
+#~ msgid "Missing MISO or MOSI pin"
+#~ msgstr "Отсутствует пин MISO или MOSI"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
+#~ msgstr "Отсутствует first_in_pin. Инструкция %d читает состояние пина (-ов)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
+#~ msgstr ""
+#~ "Отсутствует first_out_pin. Инструкция %d вводит (shifts out) на пин(ы)"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
+#~ msgstr "Отсутствует first_in_pin. Инструкция %d ожидает на основе пина"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
+#~ msgstr ""
+#~ "Отсутствует first_out_pin. Инструкция %d выводит (shifts out) на пин(ы)"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
+#~ msgstr "Отсутствует first_out_pin. Инструкция %d записывает пин(ы)"
+
+#, c-format
+#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+#~ msgstr "Отсутствует first_set_pin. Инструкция %d устанавливает пин(ы)"
+
+#, c-format
+#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
+#~ msgstr "Отсутствует jmp_pin. Инструкция %d перепрыгивает на пин"
 
 #, c-format
 #~ msgid "More than %d report ids not supported"
 #~ msgstr "Не поддерживается более %d идентификаторов отчетов (report ids)"
+
+#, c-format
+#~ msgid "No I2C device at address: %x"
+#~ msgstr "Нет устройства I2C по адресу: %x"
+
+#~ msgid "No MISO Pin"
+#~ msgstr "Нет пина MISO"
+
+#~ msgid "No MISO pin"
+#~ msgstr "Нет пина MISO"
+
+#~ msgid "No MOSI Pin"
+#~ msgstr "Нет пина MOSI"
+
+#~ msgid "No MOSI pin"
+#~ msgstr "Нет пина MOSI"
+
+#~ msgid "No RX pin"
+#~ msgstr "Нет пина RX"
+
+#~ msgid "No TX pin"
+#~ msgstr "Нет пина TX"
 
 #~ msgid "No hardware support on clk pin"
 #~ msgstr "Отсутствует аппаратная поддержка пина clk"
@@ -5055,25 +4940,121 @@ msgstr "zi должен иметь форму (n_section, 2)"
 #~ msgid "No hardware support on pin"
 #~ msgstr "Отсутствует аппаратная поддержка на пине"
 
+#~ msgid "No key was specified"
+#~ msgstr "Ключ не был указан"
+
+#, c-format
+#~ msgid "No more than %d HID devices allowed"
+#~ msgstr "Допускается не более %d HID устройств"
+
+#, fuzzy
+#~ msgid "Nordic system firmware failure assertion."
+#~ msgstr "Сбой системной прошивки Nordic (assertion)."
+
+#, fuzzy
+#~ msgid "Not settable"
+#~ msgstr "Невозможно установить"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Только 8- или 16-битное моно с "
+
 #~ msgid "Pin count must be at least 1"
 #~ msgstr "Количество пинов должно быть не менее 1"
 
 #~ msgid "Pin does not have ADC capabilities"
 #~ msgstr "Пин не имеет возможности АЦП"
 
+#~ msgid "RAISE mode is not implemented"
+#~ msgstr "Режим RAISE не реализован"
+
 #~ msgid "Set pin count must be between 1 and 5"
 #~ msgstr "Число Set пинов должно быть от 1 до 5"
 
-#~ msgid ""
-#~ "\n"
-#~ "Code stopped by auto-reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Программа остановлена автоматической перезагрузкой.\n"
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Разделение с помощью субзахватов"
 
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "Яркость должна быть в диапазоне от 0 до 255"
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "Предоставьте хотяб один пин UART"
+
+#~ msgid "Unable to allocate the heap."
+#~ msgstr "Невозможно выделить кучу."
 
 #, c-format
-#~ msgid "No I2C device at address: %x"
-#~ msgstr "Нет устройства I2C по адресу: %x"
+#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Невозможно настроить контроллер ADC DMA, код ошибки:%d"
+
+#, c-format
+#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Невозможно инициализировать контроллер ADC DMA, код ошибки:%d"
+
+#, c-format
+#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Не удается запустить контроллер ADC DMA, код ошибки:%d"
+
+#~ msgid "Unable to write to address."
+#~ msgstr "Невозможно написать на адрес."
+
+#~ msgid "WatchDogTimer is not currently running"
+#~ msgstr "Таймер Watch Dog в настоящее время не работает"
+
+#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+#~ msgstr ""
+#~ "WatchDogTimer.mode не может быть изменен после установки значения "
+#~ "WatchDogMode.RESET"
+
+#~ msgid "__init__() should return None, not '%q'"
+#~ msgstr "__init__() должен возвращать None, а не '%q'"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "Атрибуты пока не поддерживаются"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr "Не могу сделать усеченное деление комплексного числа"
+
+#~ msgid "cannot import name %q"
+#~ msgstr "Не удается импортировать имя %Q"
+
+#~ msgid "cannot unambiguously get sizeof scalar"
+#~ msgstr "не может однозначно получить размер скаляра"
+
+#~ msgid ""
+#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "espcamera.Для настройки камеры требуется зарезервированная PSRAM. "
+#~ "Инструкции см. в документации."
+
+#~ msgid "invalid architecture"
+#~ msgstr "Недопустимая архитектура"
+
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr ""
+#~ "Аргументы ключевого слова еще не реализованы - вместо этого используйте "
+#~ "обычные аргументы"
+
+#~ msgid "length argument not allowed for this type"
+#~ msgstr "аргумент длины не допускается для этого типа"
+
+#~ msgid "no reset pin available"
+#~ msgstr "нет доступного контакта сброса"
+
+#~ msgid "offset out of bounds"
+#~ msgstr "Смещение за пределы"
+
+#~ msgid "queue overflow"
+#~ msgstr "Переполнение очереди"
+
+#~ msgid "slice step can't be zero"
+#~ msgstr "Шаг среза не может быть равен нулю"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr "строка не поддерживается; Использование байтов или массива байтов"
+
+#~ msgid "unsupported type for %q: '%q'"
+#~ msgstr "Неподдерживаемый тип для %q: '%q'"
+
+#~ msgid "watchdog not initialized"
+#~ msgstr "Сторожевой таймер не инициализирован"
+
+#~ msgid "xTaskCreate failed"
+#~ msgstr "x Создать задачу не удалось"

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -83,42 +83,12 @@ msgstr " utdata:\n"
 msgid "%%c requires int or char"
 msgstr "%%c kräver int eller char"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr "%S"
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
 "%d address pins, %d rgb pins and %d tiles indicate a height of %d, not %d"
 msgstr ""
 "%d adresspinnar, %d rgb-pinnar och %d brickor anger en höjd på %d, inte %d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -304,11 +274,6 @@ msgstr "%q[%u] använder extra pinnar"
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
 msgstr "%q[%u] väntar på input utanför count"
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
-msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
 #, c-format
@@ -1385,7 +1350,8 @@ msgstr "Mappning måste vara en tuple"
 
 #: shared-bindings/audiobusio/PDMIn.c
 msgid "Microphone startup delay must be in range 0.0 to 1.0"
-msgstr "Startfördröjningen för mikrofonen måste vara i intervallet 0,0 till 1,0"
+msgstr ""
+"Startfördröjningen för mikrofonen måste vara i intervallet 0,0 till 1,0"
 
 #: ports/raspberrypi/bindings/rp2pio/StateMachine.c
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -1632,8 +1598,9 @@ msgstr "OK"
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Endast 8 eller 16 bitars mono med "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -1832,8 +1799,8 @@ msgstr "Prefixbufferten måste finnas på heap"
 #: main.c
 msgid "Press any key to enter the REPL. Use CTRL-D to reload.\n"
 msgstr ""
-"Tryck på valfri tangent för att gå in i REPL. Använd CTRL-D för att ladda om."
-"\n"
+"Tryck på valfri tangent för att gå in i REPL. Använd CTRL-D för att ladda "
+"om.\n"
 
 #: main.c
 msgid "Pretending to deep sleep until alarm, CTRL-C or file write.\n"
@@ -4455,120 +4422,39 @@ msgstr "zi måste vara av typ float"
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi måste vara i formen (n_section, 2)"
 
-#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
-#~ msgstr "Ogiltig CIRCUITPY_PYSTACK_SIZE\n"
-
-#~ msgid "Unable to allocate the heap."
-#~ msgstr "Kan inte allokera heap."
+#~ msgid ""
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Koden har kört klart. Väntar på omladdning.\n"
 
 #~ msgid ""
-#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
+#~ "\n"
+#~ "Code stopped by auto-reload.\n"
 #~ msgstr ""
-#~ "espcamera.Camera kräver reserverat PSRAM att vara konfigurerat. Se "
-#~ "dokumentationen för instruktioner."
+#~ "\n"
+#~ "Koden stoppades av auto-omladdning.\n"
 
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr "'await', 'async for' eller 'async with' utanför asynk-funktion"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' utanför loop"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' utanför loop"
-
-#~ msgid "invalid architecture"
-#~ msgstr "ogiltig arkitektur"
-
-#~ msgid "unsupported type for %q: '%q'"
-#~ msgstr "typen %q stöder inte '%q'"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Splitting med sub-captures"
-
-#~ msgid "__init__() should return None, not '%q'"
-#~ msgstr "__init__() ska returnera None, inte '%q'"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "attribut stöds inte än"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr "kan inte göra trunkerad division av komplext tal"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "kan inte importera namn %q"
-
-#~ msgid "cannot unambiguously get sizeof scalar"
-#~ msgstr "Kan inte entydigt få sizeof scalar"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgid ""
+#~ "\n"
+#~ "Invalid CIRCUITPY_PYSTACK_SIZE\n"
+#~ "\n"
+#~ "\r"
 #~ msgstr ""
-#~ "nyckelordsargument är ännu inte implementerade - använd vanliga argument"
+#~ "\n"
+#~ "Ogiltig CIRCUITPY_PYSTACK_SIZE\n"
+#~ "\n"
+#~ "\n"
 
-#~ msgid "length argument not allowed for this type"
-#~ msgstr "argumentet length är inte är tillåten för denna typ"
-
-#~ msgid "offset out of bounds"
-#~ msgstr "offset utanför gränserna"
-
-#~ msgid "slice step can't be zero"
-#~ msgstr "segmentsteg kan inte vara noll"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr "sträng stöds inte; använd bytes eller bytearray"
-
-#~ msgid "Bit clock and word select must be sequential pins"
-#~ msgstr "Bitklocka och word select måste vara sekventiella pinnar"
-
-#~ msgid "Initialization failed due to lack of memory"
-#~ msgstr "Initieringen misslyckades på grund av minnesbrist"
-
-#~ msgid "RAISE mode is not implemented"
-#~ msgstr "RAISE-läge är inte implementerat"
-
-#~ msgid "WatchDogTimer is not currently running"
-#~ msgstr "WatchDogTimer körs för närvarande inte"
-
-#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+#~ msgid ""
+#~ "\n"
+#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
 #~ msgstr ""
-#~ "WatchDogTimer.mode kan inte ändras när den är inställd på WatchDogMode."
-#~ "RESET"
-
-#~ msgid "watchdog not initialized"
-#~ msgstr "watchdog är inte initierad"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "ADC2 används av WiFi"
-
-#, c-format
-#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Kan inte konfigurera ADC DMA controller, Felkod:%d"
-
-#, c-format
-#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Kan inte inititiera ADC DMA-controller, Felkod:%d"
-
-#, c-format
-#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
-#~ msgstr "Kan inte starta ADC DMA controller, Felkod:%d"
-
-#~ msgid "xTaskCreate failed"
-#~ msgstr "xTaskCreate misslyckades"
-
-#~ msgid "Unable to write to address."
-#~ msgstr "Det går inte att skriva till adress."
-
-#~ msgid "queue overflow"
-#~ msgstr "köstorlek överskreds"
-
-#~ msgid "Stopping AP is not supported."
-#~ msgstr "Stoppa AP stöds inte."
-
-#~ msgid "Wifi is in access point mode."
-#~ msgstr "WiFi är i accesspunktläge."
-
-#~ msgid "Wifi is in station mode."
-#~ msgstr "WiFi är i stationsläge."
+#~ "\n"
+#~ "Vänligen skapa ett ärende med innehållet i din CIRCUITPY-enhet på\n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
 
 #~ msgid ""
 #~ "\n"
@@ -4579,24 +4465,432 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ "Skicka in ett ärende med ditt program till https://github.com/adafruit/"
 #~ "circuitpython/issues."
 
+#~ msgid ""
+#~ "\n"
+#~ "To exit, please reset the board without "
+#~ msgstr ""
+#~ "\n"
+#~ "För att avsluta, gör reset på kortet utan "
+
+#~ msgid ""
+#~ "\n"
+#~ "paste mode; Ctrl-C to cancel, Ctrl-D to finish\n"
+#~ "=== "
+#~ msgstr ""
+#~ "\n"
+#~ "klistra in-läge; Ctrl-C för att avbryta, Ctrl-D för att avsluta\n"
+#~ "=== "
+
+#, c-format
+#~ msgid "%02X"
+#~ msgstr "%02X"
+
+#, c-format
+#~ msgid "%S"
+#~ msgstr "%S"
+
+#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+#~ msgstr "%d adresspinnar och %d RGB-pinnar indikerar en höjd av %d, inte %d"
+
+#~ msgid "%q"
+#~ msgstr "%q"
+
+#~ msgid "%q ``must`` be a bytearray or array of type 'h', 'H', 'b' or 'B'"
+#~ msgstr ""
+#~ "%q ``måste`` vara en bytearray eller matris av typen 'h', 'H', 'b' eller "
+#~ "'B'"
+
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "%q index måste vara heltal, inte %q"
+
+#~ msgid "%q length must be %q"
+#~ msgstr "längden på %q måste vara %q"
+
+#~ msgid "%q length must be >= 1"
+#~ msgstr "längden på %q måste vara >= 1"
+
+#~ msgid "%q list must be a list"
+#~ msgstr "%q-listan måste vara en lista"
+
+#~ msgid "%q must <= %d"
+#~ msgstr "%q måste vara <=%d"
+
+#~ msgid "%q must be 0-255"
+#~ msgstr "%q måste vara 0-255"
+
+#~ msgid "%q must be 1-255"
+#~ msgstr "%q måste vara 1-255"
+
+#~ msgid "%q must be >= 0"
+#~ msgstr "%q måste vara >= 0"
+
+#~ msgid "%q must be >= 1"
+#~ msgstr "%q måste vara >= 1"
+
+#~ msgid "%q must be None or 1-255"
+#~ msgstr "%q måste vara None eller 1-255"
+
+#~ msgid "%q must be None or between 1 and len(report_descriptor)-1"
+#~ msgstr "%q måste vara None eller mellan 1 och len(report_descriptor)-1"
+
+#~ msgid "%q must be a string"
+#~ msgstr "%q måste vara en sträng"
+
+#~ msgid "%q must be a tuple of length 2"
+#~ msgstr "%q måste vara en tuple av längd 2"
+
+#~ msgid "%q must be an int"
+#~ msgstr "%q måste vara en int"
+
+#~ msgid "%q must be between %d and %d"
+#~ msgstr "%q måste vara mellan %d och %d"
+
+#~ msgid "%q must be of type %q"
+#~ msgstr "%q måste vara av typen %q"
+
+#~ msgid "%q must be of type %q or None"
+#~ msgstr "%q måste vara av typen %q eller None"
+
+#~ msgid "%q must of type %q"
+#~ msgstr "%q måste av typen %q"
+
+#~ msgid "%q must store bytes"
+#~ msgstr "%q måste lagra bytes"
+
+#~ msgid "%q pin invalid"
+#~ msgstr "Pinne %q ogiltig"
+
+#~ msgid "%q should be an int"
+#~ msgstr "%q ska vara en int"
+
+#~ msgid "%q with a report ID of 0 must be of length 1"
+#~ msgstr "%q med report-ID 0 måste ha längd 1"
+
+#~ msgid "'%q' object cannot assign attribute '%q'"
+#~ msgstr "Objektet '%q' kan inte tilldela attributet '%q'"
+
+#~ msgid "'%q' object does not support item assignment"
+#~ msgstr "Objektet '%q' stöder inte tilldelning"
+
+#~ msgid "'%q' object does not support item deletion"
+#~ msgstr "Objektet '%q' stöder inte borttagning av objekt"
+
+#~ msgid "'%q' object has no attribute '%q'"
+#~ msgstr "Objektet '%q' har inget attribut '%q'"
+
+#~ msgid "'%q' object is not bytes-like"
+#~ msgstr "%q-objektet är inte byte-lik"
+
+#~ msgid "'%q' object is not subscriptable"
+#~ msgstr "Objektet '%q' är inte indexbar"
+
+#~ msgid "'%s' integer %d is not within range %d..%d"
+#~ msgstr "'%s' heltal %d ligger inte inom intervallet %d..%d"
+
+#~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
+#~ msgstr "'%s' heltal 0x%x ryms inte i mask 0x%x"
+
+#~ msgid "'%s' object cannot assign attribute '%q'"
+#~ msgstr "Objektet '%s' kan inte tilldela attributet '%q'"
+
+#~ msgid "'%s' object does not support '%q'"
+#~ msgstr "Objektet '%s' har inte stöd för '%q'"
+
+#~ msgid "'%s' object does not support item assignment"
+#~ msgstr "Objektet '%s' stöder inte tilldelningen"
+
+#~ msgid "'%s' object does not support item deletion"
+#~ msgstr "Objektet '%s' stöder inte borttagning av objekt"
+
+#~ msgid "'%s' object is not an iterator"
+#~ msgstr "Objektet '%s' är inte en iterator"
+
+#~ msgid "'%s' object is not callable"
+#~ msgstr "Objektet '%s' kan inte anropas"
+
+#~ msgid "'%s' object is not iterable"
+#~ msgstr "Objektet '%s' är inte itererable"
+
+#~ msgid "'%s' object is not subscriptable"
+#~ msgstr "Objektet '%s' är inte indexbar"
+
+#~ msgid "'async for' or 'async with' outside async function"
+#~ msgstr "'async for' eller 'async with' utanför async-funktion"
+
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr "'await', 'async for' eller 'async with' utanför asynk-funktion"
+
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' utanför loop"
+
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' utanför loop"
+
 #~ msgid "'coroutine' object is not an iterator"
 #~ msgstr "objektet 'coroutine\" är inte en iterator"
+
+#~ msgid "(x,y) integers required"
+#~ msgstr "(x,y) heltal krävs"
+
+#~ msgid "64 bit types"
+#~ msgstr "64-bitars typer"
+
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "ADC2 används av WiFi"
+
+#~ msgid "Address type out of range"
+#~ msgstr "Adresstyp utanför intervallet"
+
+#~ msgid "All I2C targets are in use"
+#~ msgstr "Alla I2C-mål används"
+
+#~ msgid "AnalogIn not supported on given pin"
+#~ msgstr "AnalogIn stöds inte på angiven pinne"
+
+#~ msgid "AnalogOut functionality not supported"
+#~ msgstr "AnalogOut-funktionalitet stöds inte"
+
+#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#~ msgstr ""
+#~ "AnalogOut hanterar bara 16 bitar. Värdet måste vara mindre än 65536."
+
+#~ msgid "AnalogOut not supported on given pin"
+#~ msgstr "AnalogOut stöds inte på angiven pinne"
+
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "Högst %d %q kan anges (inte %d)"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr "Försökte tilldela heap när MicroPython VM inte körs."
+
+#~ msgid "Attempted heap allocation when VM not running."
+#~ msgstr ""
+#~ "Försök till heap-allokering när den virtuella maskinen inte är igång."
+
+#~ msgid "Bit clock and word select must be sequential pins"
+#~ msgstr "Bitklocka och word select måste vara sekventiella pinnar"
+
+#, c-format
+#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
+#~ msgstr "Bitdjup måste vara inom 1 till 6, inte %d"
+
+#~ msgid "Boot device must be first device (interface #0)."
+#~ msgstr "Startenheten måste vara den första enheten (gränssnitt #0)."
+
+#~ msgid "Both buttons were pressed at start up.\n"
+#~ msgstr "Båda knapparna trycktes ned vid start.\n"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "Ljusstyrkan måste vara mellan 0 och 1,0"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "Ljusstyrka måste vara mellan 0 och 255"
+
+#, c-format
+#~ msgid "Buffer incorrect size. Should be %d bytes."
+#~ msgstr "Buffert har felaktig storlek. Ska vara %d byte."
 
 #~ msgid "Buffer is too small"
 #~ msgstr "Bufferten är för liten"
 
-#~ msgid "Fault detected by hardware."
-#~ msgstr "Fel upptäckt av hårdvara."
+#~ msgid "Buffer must be at least length 1"
+#~ msgstr "Bufferten måste ha minst längd 1"
 
-#~ msgid "The power dipped. Make sure you are providing enough power."
-#~ msgstr "Spänningen sjönk. Se till att du ger tillräckligt med ström."
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "Bufferten är för stor och kan inte allokeras"
 
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+#~ msgid "Button A was pressed at start up.\n"
+#~ msgstr "Knapp A trycktes ned vid start.\n"
+
+#~ msgid "Bytes must be between 0 and 255."
+#~ msgstr "Bytes måste vara mellan 0 och 255."
+
+#~ msgid "Cannot output both channels on the same pin"
+#~ msgstr "Det går inte att mata ut båda kanalerna på samma pinne"
+
+#~ msgid "Cannot read without MISO pin."
+#~ msgstr "Kan inte läsa utan MISO-pinne."
+
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "Kan inte återmontera '/' när USB är aktivt."
+
+#~ msgid "Cannot reset into bootloader because no bootloader is present."
 #~ msgstr ""
-#~ "pixel_shader måste vara displayio.Palette eller displayio.ColorConverter"
+#~ "Det går inte att återställa till bootloader eftersom bootloader saknas."
+
+#~ msgid "Cannot transfer without MOSI and MISO pins"
+#~ msgstr "Det går inte att överföra utan MOSI- och MISO-pinnar"
+
+#~ msgid "Cannot transfer without MOSI and MISO pins."
+#~ msgstr "Kan inte överföra utan MOSI- och MISO-pinnar."
+
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "Kan inte entydigt få sizeof scalar"
+
+#~ msgid "Cannot write without MOSI pin."
+#~ msgstr "Kan inte skriva utan MOSI-pinne."
+
+#~ msgid ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+#~ msgstr ""
+#~ "CircuitPython är i säkert läge eftersom du tryckte på "
+#~ "återställningsknappen under start. Tryck igen för att lämna säkert läge.\n"
+
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "CircuitPython kunde inte allokera heap."
+
+#~ msgid "Clock pin init failed."
+#~ msgstr "Initiering av klockpinne misslyckades."
+
+#~ msgid "Column entry must be digitalio.DigitalInOut"
+#~ msgstr "Kolumnposten måste vara digitalio. DigitalInOut"
+
+#~ msgid "Command must be an int between 0 and 255"
+#~ msgstr "Kommandot måste vara en int mellan 0 och 255"
 
 #~ msgid "Corrupt .mpy file"
 #~ msgstr "Skadad .mpy-fil"
+
+#~ msgid "Corrupt raw code"
+#~ msgstr "Korrupt rå kod"
+
+#~ msgid "Could not initialize Camera"
+#~ msgstr "Kunde inte initiera Camera"
+
+#~ msgid "Could not initialize GNSS"
+#~ msgstr "Kan inte initiera GNSS"
+
+#~ msgid "Could not initialize SDCard"
+#~ msgstr "Kan inte initiera SD-kort"
+
+#~ msgid "Could not initialize UART"
+#~ msgstr "Det gick inte att initiera UART"
+
+#~ msgid "Could not initialize channel"
+#~ msgstr "Det gick inte att initiera kanalen"
+
+#~ msgid "Could not initialize timer"
+#~ msgstr "Det gick inte att initialisera timern"
+
+#~ msgid "Could not re-init channel"
+#~ msgstr "Det gick inte att återinitiera kanalen"
+
+#~ msgid "Could not re-init timer"
+#~ msgstr "Det gick inte att återinitiera timern"
+
+#~ msgid "Could not restart PWM"
+#~ msgstr "Det gick inte att starta om PWM"
+
+#~ msgid "Couldn't allocate first buffer"
+#~ msgstr "Det gick inte att allokera den första bufferten"
+
+#~ msgid "Couldn't allocate input buffer"
+#~ msgstr "Det gick inte att allokera indatabufferten"
+
+#~ msgid "Couldn't allocate second buffer"
+#~ msgstr "Det gick inte att allokera den andra bufferten"
+
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "Krasch in i HardFault_Handler."
+
+#~ msgid "Data 0 pin must be byte aligned."
+#~ msgstr "Datapinne 0 måste vara byte-justerad."
+
+#~ msgid "DigitalInOut not supported on given pin"
+#~ msgstr "DigitalInOut stöds inte på given pinne"
+
+#, c-format
+#~ msgid "Error in MIDI stream at position %d"
+#~ msgstr "Fel i MIDI-ström vid position %d"
+
+#~ msgid "Expected a %q"
+#~ msgstr "Förväntade %q"
+
+#~ msgid "Expected a %q or %q"
+#~ msgstr "Förväntade %q eller %q"
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Förväntade en karaktäristik"
+
+#~ msgid "Expected a DigitalInOut"
+#~ msgstr "Förväntar en DigitalInOut"
+
+#~ msgid "Expected a Service"
+#~ msgstr "Förväntade en tjänst"
+
+#~ msgid "Expected a UART"
+#~ msgstr "Förväntar en UART"
+
+#~ msgid "Expected a UUID"
+#~ msgstr "Förväntade en UUID"
+
+#~ msgid "Expected an %q"
+#~ msgstr "Förväntade en %q"
+
+#~ msgid "Expected an Address"
+#~ msgstr "Förväntade en adress"
+
+#~ msgid "Expected an alarm"
+#~ msgstr "Förväntade ett larm"
+
+#, c-format
+#~ msgid "Expected tuple of length %d, got %d"
+#~ msgstr "Förväntad tupel med längd %d, fick %d"
+
+#~ msgid "Failed to allocate RX buffer"
+#~ msgstr "Det gick inte att tilldela RX-buffert"
+
+#, c-format
+#~ msgid "Failed to allocate RX buffer of %d bytes"
+#~ msgstr "Det gick inte att allokera RX-bufferten på %d byte"
+
+#~ msgid "Failed to init wifi"
+#~ msgstr "Kunde inte initiera WiFi"
+
+#~ msgid "Fatal error."
+#~ msgstr "Fatalt fel."
+
+#~ msgid "Fault detected by hardware."
+#~ msgstr "Fel upptäckt av hårdvara."
+
+#~ msgid "Firmware image is invalid"
+#~ msgstr "Firmware-avbilden är ogiltig"
+
+#, c-format
+#~ msgid "Framebuffer requires %d bytes"
+#~ msgstr "Framebuffer kräver %d byte"
+
+#~ msgid "Frequency captured is above capability. Capture Paused."
+#~ msgstr "Infångningsfrekvens är för hög. Infångning pausad."
+
+#~ msgid "Group full"
+#~ msgstr "Gruppen är full"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Hårdvaran är upptagen, prova alternativa pinnar"
+
+#~ msgid "Hostname must be between 1 and 253 characters"
+#~ msgstr "Hostname måste vara mellan 1 och 253 tecken"
+
+#~ msgid "I2C Init Error"
+#~ msgstr "I2C init-fel"
+
+#~ msgid "I2C operation not supported"
+#~ msgstr "I2C-åtgärd stöds inte"
+
+#~ msgid "I2SOut not available"
+#~ msgstr "I2SOut är inte tillgängligt"
+
+#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
+#~ msgstr "IO 0, 2 & 4 stöder inte intern pullup för sovläge"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IV måste vara %d byte lång"
+
+#~ msgid "In buffer elements must be 4 bytes long or less"
+#~ msgstr "Inbuffertelement måste vara 4 byte långa eller mindre"
 
 #~ msgid ""
 #~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
@@ -4605,32 +4899,14 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ "Inkompatibel .mpy-fil. Uppdatera alla .mpy-filer. Se http://adafru.it/mpy-"
 #~ "update för mer information."
 
-#~ msgid "can't convert to %q"
-#~ msgstr "kan inte konvertera till %q"
+#~ msgid "Initial set pin direcion conflicts with initial out pin direction"
+#~ msgstr "Initial pinn-riktning står i konflikt med initial utpinn-riktning"
 
-#~ msgid "can't have multiple **x"
-#~ msgstr "kan inte ha flera **x"
+#~ msgid "Initialization failed due to lack of memory"
+#~ msgstr "Initieringen misslyckades på grund av minnesbrist"
 
-#~ msgid "can't have multiple *x"
-#~ msgstr "kan inte ha flera *x"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "konstant måste vara ett heltal"
-
-#~ msgid "incompatible native .mpy architecture"
-#~ msgstr "inkompatibel nativ .mpy-arkitektur"
-
-#~ msgid "invalid format"
-#~ msgstr "ogiltigt format"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "nyckelord måste vara strängar"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "icke nyckelord arg efter * / **"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "icke nyckelord arg efter nyckelord arg"
+#~ msgid "Instruction %d jumps on pin"
+#~ msgstr "Instruktion %d hoppar på pinne"
 
 #, c-format
 #~ msgid "Instruction %d shifts in more bits than pin count"
@@ -4647,6 +4923,161 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #, c-format
 #~ msgid "Instruction %d waits on input outside of count"
 #~ msgstr "Instruktion %d väntar på inmatning utanför intervallet"
+
+#~ msgid "Invalid %q pin selection"
+#~ msgstr "Ogiltigt val av %q pinne"
+
+#~ msgid "Invalid AuthMode"
+#~ msgstr "Ogiltig AuthMode"
+
+#~ msgid "Invalid BMP file"
+#~ msgstr "Ogiltig BMP-fil"
+
+#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
+#~ msgstr "Ogiltig CIRCUITPY_PYSTACK_SIZE\n"
+
+#~ msgid "Invalid DAC pin supplied"
+#~ msgstr "Ogiltig DAC-pinne angiven"
+
+#~ msgid "Invalid I2C pin selection"
+#~ msgstr "Ogiltigt val av I2C-pinne"
+
+#~ msgid "Invalid MIDI file"
+#~ msgstr "Ogiltig MIDI-fil"
+
+#~ msgid "Invalid PWM frequency"
+#~ msgstr "Ogiltig PWM-frekvens"
+
+#~ msgid "Invalid Pin"
+#~ msgstr "Ogiltig pinne"
+
+#~ msgid "Invalid SPI pin selection"
+#~ msgstr "Ogiltigt val av SPI-pinne"
+
+#~ msgid "Invalid UART pin selection"
+#~ msgstr "Ogiltigt val av UART-pinne"
+
+#~ msgid "Invalid buffer size"
+#~ msgstr "Ogiltig buffertstorlek"
+
+#~ msgid "Invalid byteorder string"
+#~ msgstr "Ogiltig byteorder-sträng"
+
+#~ msgid "Invalid capture period. Valid range: 1 - 500"
+#~ msgstr "Ogiltig inspelningsperiod. Giltigt intervall: 1 - 500"
+
+#~ msgid "Invalid channel count"
+#~ msgstr "Ogiltigt kanalantal"
+
+#, c-format
+#~ msgid "Invalid data_count %d"
+#~ msgstr "Ogiltig data_count %d"
+
+#~ msgid "Invalid direction."
+#~ msgstr "Ogiltig riktning."
+
+#~ msgid "Invalid file"
+#~ msgstr "Felaktig fil"
+
+#~ msgid "Invalid frequency"
+#~ msgstr "Ogiltig frekvens"
+
+#~ msgid "Invalid frequency supplied"
+#~ msgstr "Ogiltig frekvens angiven"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "Ogiltig minnesåtkomst."
+
+#~ msgid "Invalid mode"
+#~ msgstr "Ogiltigt läge"
+
+#~ msgid "Invalid number of bits"
+#~ msgstr "Ogiltigt antal bitar"
+
+#~ msgid "Invalid phase"
+#~ msgstr "Ogiltig fas"
+
+#~ msgid "Invalid pin"
+#~ msgstr "Ogiltig pinne"
+
+#~ msgid "Invalid pin for left channel"
+#~ msgstr "Ogiltig pinne för vänster kanal"
+
+#~ msgid "Invalid pin for right channel"
+#~ msgstr "Ogiltig pinne för höger kanal"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Ogiltiga pinnar"
+
+#~ msgid "Invalid pins for PWMOut"
+#~ msgstr "Ogiltiga pinnar för PWMOut"
+
+#~ msgid "Invalid polarity"
+#~ msgstr "Ogiltig polaritet"
+
+#~ msgid "Invalid properties"
+#~ msgstr "Ogiltiga egenskaper"
+
+#~ msgid "Invalid run mode."
+#~ msgstr "Ogiltigt körläge."
+
+#~ msgid "Invalid security_mode"
+#~ msgstr "Ogiltigt säkerhetsläge"
+
+#~ msgid "Invalid use of TLS Socket"
+#~ msgstr "Ogiltig användning av TLS Socket"
+
+#~ msgid "Invalid voice"
+#~ msgstr "Ogiltig kanal"
+
+#~ msgid "Invalid voice count"
+#~ msgstr "Ogiltigt kanalantal"
+
+#~ msgid "Invalid wave file"
+#~ msgstr "Ogiltig wave-fil"
+
+#~ msgid "Invalid word/bit length"
+#~ msgstr "Ogiltig word-/bitlängd"
+
+#~ msgid "Issue setting SO_REUSEADDR"
+#~ msgstr "Misslyckades att sätta SO_REUSEADDR"
+
+#~ msgid "Layer already in a group."
+#~ msgstr "Lagret finns redan i en grupp."
+
+#~ msgid "Layer must be a Group or TileGrid subclass."
+#~ msgstr "Layer måste vara en subklass av Group eller TileGrid."
+
+#~ msgid "Length must be an int"
+#~ msgstr "Length måste vara en int"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Length måste vara positiv"
+
+#~ msgid "MISO pin init failed."
+#~ msgstr "init för MISO-pinne misslyckades."
+
+#~ msgid "MOSI pin init failed."
+#~ msgstr "init för MOSI-pinne misslyckades."
+
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "Maximum x-värde vid spegling är %d"
+
+#~ msgid "Messages limited to 8 bytes"
+#~ msgstr "Meddelanden begränsad till 8 byte"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgstr "MicroPython NLR jump misslyckades. Troligen korrupt minne."
+
+#~ msgid "MicroPython fatal error."
+#~ msgstr "MicroPython fatalt fel."
+
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "MISO- eller MOSI-pinne saknas"
+
+#~ msgid "Missing MISO or MOSI pin"
+#~ msgstr "Saknad MISO- eller MOSI-pinne"
 
 #, c-format
 #~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
@@ -4676,23 +5107,19 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
 #~ msgstr "Saknar jmp_pin. Instruktion %d hoppar på pin"
 
-#~ msgid "inputs are not iterable"
-#~ msgstr "indata är inte iterbara"
+#, c-format
+#~ msgid "More than %d report ids not supported"
+#~ msgstr "Fler än %d rapport-id stöds inte"
 
-#~ msgid "Too many display busses"
-#~ msgstr "För många display-bussar"
+#~ msgid "Must provide SCK pin"
+#~ msgstr "Måste ange SCK-pinne"
 
-#~ msgid "Cannot transfer without MOSI and MISO pins"
-#~ msgstr "Det går inte att överföra utan MOSI- och MISO-pinnar"
+#~ msgid "Negative step not supported"
+#~ msgstr "Negativt step stöds inte"
 
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Hårdvaran är upptagen, prova alternativa pinnar"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "MISO- eller MOSI-pinne saknas"
-
-#~ msgid "Missing MISO or MOSI pin"
-#~ msgstr "Saknad MISO- eller MOSI-pinne"
+#, c-format
+#~ msgid "No I2C device at address: %x"
+#~ msgstr "Ingen I2C-enhet på adress: %x"
 
 #~ msgid "No MISO Pin"
 #~ msgstr "Ingen MISO-pinne"
@@ -4712,119 +5139,208 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ msgid "No TX pin"
 #~ msgstr "Ingen TX-pinne"
 
-#~ msgid "no reset pin available"
-#~ msgstr "ingen reset-pinne tillgänglig"
+#~ msgid "No hardware support on clk pin"
+#~ msgstr "Inget hårdvarustöd på clk-pinne"
 
-#~ msgid "Sleep Memory not available"
-#~ msgstr "Sömnminne inte tillgängligt"
-
-#~ msgid "input and output shapes are not compatible"
-#~ msgstr "indata- och utdataformer är inte kompatibla"
-
-#~ msgid "shape must be a tuple"
-#~ msgstr "shape måste vara en tuple"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "Ljusstyrkan måste vara mellan 0 och 1,0"
-
-#, c-format
-#~ msgid "Error in MIDI stream at position %d"
-#~ msgstr "Fel i MIDI-ström vid position %d"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "Maximum x-värde vid spegling är %d"
-
-#~ msgid "x value out of bounds"
-#~ msgstr "x-värde utanför intervall"
-
-#~ msgid "y value out of bounds"
-#~ msgstr "y-värde utanför intervall"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "I2SOut är inte tillgängligt"
-
-#~ msgid "PDMIn not available"
-#~ msgstr "PDMIn inte tillgänglig"
-
-#~ msgid "out of range of source"
-#~ msgstr "utanför räckvidd för source"
-
-#~ msgid "pixel value requires too many bits"
-#~ msgstr "pixelvärdet kräver för många bitar"
-
-#~ msgid "value_count must be > 0"
-#~ msgstr "value_count måste vara > 0"
-
-#~ msgid "64 bit types"
-#~ msgstr "64-bitars typer"
+#~ msgid "No hardware support on pin"
+#~ msgstr "Inget hårdvarustöd på pinne"
 
 #~ msgid "No key was specified"
 #~ msgstr "Ingen nyckel angavs"
 
-#~ msgid "Scan already in progess. Stop with stop_scan."
-#~ msgstr "Skanning pågår redan. Avsluta med stop_scan."
+#~ msgid "No more channels available"
+#~ msgstr "Inga fler kanaler tillgängliga"
 
 #, c-format
-#~ msgid "Unkown error code %d"
-#~ msgstr "Okänd felkod %d"
+#~ msgid "No more than %d HID devices allowed"
+#~ msgstr "Högst %d HID-enheter är tillåtna"
 
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "för många argument för det givna formatet"
+#~ msgid "No more timers available"
+#~ msgstr "Ingen timer tillgänglig"
 
-#~ msgid ""
-#~ "\n"
-#~ "Invalid CIRCUITPY_PYSTACK_SIZE\n"
-#~ "\n"
-#~ "\r"
-#~ msgstr ""
-#~ "\n"
-#~ "Ogiltig CIRCUITPY_PYSTACK_SIZE\n"
-#~ "\n"
-#~ "\n"
+#~ msgid "No more timers available on this pin."
+#~ msgstr "Inga fler timers tillgängliga på denna pinne."
 
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "Ange minst en UART-pinne"
+#~ msgid "Nordic Soft Device failure assertion."
+#~ msgstr "Påståendet om Nordic Soft Device-fel."
 
-#~ msgid "%q pin invalid"
-#~ msgstr "Pinne %q ogiltig"
-
-#~ msgid ""
-#~ "\n"
-#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
-#~ "https://github.com/adafruit/circuitpython/issues\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Vänligen skapa ett ärende med innehållet i din CIRCUITPY-enhet på\n"
-#~ "https://github.com/adafruit/circuitpython/issues\n"
-
-#~ msgid "Attempted heap allocation when VM not running."
-#~ msgstr ""
-#~ "Försök till heap-allokering när den virtuella maskinen inte är igång."
-
-#~ msgid "Boot device must be first device (interface #0)."
-#~ msgstr "Startenheten måste vara den första enheten (gränssnitt #0)."
-
-#~ msgid "Both buttons were pressed at start up.\n"
-#~ msgstr "Båda knapparna trycktes ned vid start.\n"
-
-#~ msgid "Button A was pressed at start up.\n"
-#~ msgstr "Knapp A trycktes ned vid start.\n"
-
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "CircuitPython kunde inte allokera heap."
-
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "Krasch in i HardFault_Handler."
-
-#~ msgid "Fatal error."
-#~ msgstr "Fatalt fel."
-
-#~ msgid "Invalid memory access."
-#~ msgstr "Ogiltig minnesåtkomst."
+#~ msgid "Nordic soft device out of memory"
+#~ msgstr "Nordic soft-enheten har slut på minne"
 
 #~ msgid "Nordic system firmware failure assertion."
 #~ msgstr "Felaktigt tillstånd i Nordic systemfirmware."
+
+#~ msgid "Not running saved code.\n"
+#~ msgstr "Kör inte sparad kod.\n"
+
+#~ msgid "Not settable"
+#~ msgstr "Går inte sätta"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Endast 8 eller 16 bitars mono med "
+
+#~ msgid "Only IN/OUT of up to 8 supported"
+#~ msgstr "Endast IN/OUT på upp till 8 stöds"
+
+#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
+#~ msgstr "Endast IPv4 SOCK_STREAM sockets stöds"
+
+#~ msgid "Only one TouchAlarm can be set in deep sleep."
+#~ msgstr "Endast ett TouchAlarm kan ställas in för djupsömn."
+
+#~ msgid "Only one alarm.touch alarm can be set."
+#~ msgstr "Endast ett larm av typ alarm.touch kan ställas in."
+
+#~ msgid "Only raw int or string supported for ip"
+#~ msgstr "Enbart int eller string stöds för ip"
+
+#~ msgid "Only raw int supported for ip"
+#~ msgstr "Endast raw int stöds för ip"
+
+#~ msgid "Out buffer elements must be 4 bytes long or less"
+#~ msgstr "Utbuffertelement ska vara max fyra byte långa"
+
+#, c-format
+#~ msgid "Output buffer must be at least %d bytes"
+#~ msgstr "Utdatabuffert måste vara minst %d byte"
+
+#~ msgid "PDMIn not available"
+#~ msgstr "PDMIn inte tillgänglig"
+
+#~ msgid ""
+#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
+#~ msgstr "PWM duty_cykel måste vara mellan 0 och 65535 (16 bitars upplösning)"
+
+#~ msgid "ParallelBus not yet supported"
+#~ msgstr "ParallelBus stöds ännu inte"
+
+#~ msgid "Pin count must be at least 1"
+#~ msgstr "Antalet pinnar måste vara minst 1"
+
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "Pinnen har inte ADC-funktionalitet"
+
+#~ msgid "Pin number already reserved by EXTI"
+#~ msgstr "PInn-nummer redan reserverat av EXTI"
+
+#~ msgid "PinAlarm not yet implemented"
+#~ msgstr "PinAlarm är inte implementerat ännu"
+
+#~ msgid "Pins 21+ not supported from ULP"
+#~ msgstr "Pins 21+ stöds inte av ULP"
+
+#~ msgid "Pop from an empty Ps2 buffer"
+#~ msgstr "Pop från en tom Ps2-buffert"
+
+#~ msgid ""
+#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
+#~ "instead"
+#~ msgstr ""
+#~ "Port accepterar inte PWM carrier. Ange pinne frekvens och arbetscykel "
+#~ "istället"
+
+#~ msgid ""
+#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
+#~ "Carrier instead"
+#~ msgstr ""
+#~ "Porten accepterar inte pinne eller frekvens. Skapa och skicka en PWMOut "
+#~ "Carrier istället"
+
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+#~ msgstr ""
+#~ "Tryck på valfri knapp för att gå in i REPL. Använd CTRL-D för att ladda "
+#~ "om."
+
+#~ msgid "Pretending to deep sleep until alarm, any key or file write.\n"
+#~ msgstr "Fingerar djup sömn tills larm, valfri tangent eller filskrivning.\n"
+
+#~ msgid "Program must contain at least one 16-bit instruction."
+#~ msgstr "Programmet måste innehålla minst en 16-bitars instruktion."
+
+#~ msgid "Program too large"
+#~ msgstr "Programmet är för stort"
+
+#~ msgid "PulseIn not supported on this chip"
+#~ msgstr "PulseIn stöds inte av detta chip"
+
+#~ msgid "PulseOut not supported on this chip"
+#~ msgstr "PulseIn stöds inte av detta chip"
+
+#~ msgid "RAISE mode is not implemented"
+#~ msgstr "RAISE-läge är inte implementerat"
+
+#~ msgid "RS485 Not yet supported on this device"
+#~ msgstr "RS485 stöds ännu inte på den här enheten"
+
+#~ msgid "RTC calibration is not supported on this board"
+#~ msgstr "RTC-kalibrering stöds inte av detta kort"
+
+#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
+#~ msgstr "RTS/CTS/RS485 Stöds ännu inte på den här enheten"
+
+#~ msgid "Read-only object"
+#~ msgstr "Skrivskyddat objekt"
+
+#~ msgid "Row entry must be digitalio.DigitalInOut"
+#~ msgstr "Radvärdet måste vara digitalio.DigitalInOut"
+
+#~ msgid "Running in safe mode! "
+#~ msgstr "Kör i säkert läge! "
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Kör i säkert läge! Autoladdning är avstängd.\n"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "SDA eller SCL behöver en pullup"
+
+#~ msgid "SPI Init Error"
+#~ msgstr "SPI Init-fel"
+
+#~ msgid "SPI Re-initialization error"
+#~ msgstr "SPI reinitialiseringsfel"
+
+#~ msgid "Sample rate must be positive"
+#~ msgstr "Samplingsfrekvensen måste vara positiv"
+
+#, c-format
+#~ msgid "Sample rate too high. It must be less than %d"
+#~ msgstr "Samplingsfrekvensen är för hög. Den måste vara mindre än %d"
+
+#~ msgid "Scan already in progess. Stop with stop_scan."
+#~ msgstr "Skanning pågår redan. Avsluta med stop_scan."
+
+#~ msgid "Selected CTS pin not valid"
+#~ msgstr "Vald CTS-pinne är inte giltig"
+
+#~ msgid "Selected RTS pin not valid"
+#~ msgstr "Vald CTS-pinne är inte giltig"
+
+#~ msgid "Set pin count must be between 1 and 5"
+#~ msgstr "Inställt antal pinnar måste vara mellan 1 och 5"
+
+#~ msgid "Side set pin count must be between 1 and 5"
+#~ msgstr "Sido-setets antal pinnar måste vara mellan 1 och 5"
+
+#~ msgid "Sleep Memory not available"
+#~ msgstr "Sömnminne inte tillgängligt"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Splitting med sub-captures"
+
+#~ msgid "Stack size must be at least 256"
+#~ msgstr "Stackstorleken måste vara minst 256"
+
+#~ msgid "Station must be started"
+#~ msgstr "Stationen måste startas"
+
+#~ msgid "Stopping AP is not supported."
+#~ msgstr "Stoppa AP stöds inte."
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "Stream saknar readinto() eller write() metod."
+
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "Ange minst en UART-pinne"
 
 #~ msgid "The BOOT button was pressed at start up.\n"
 #~ msgstr "BOOT-knappen trycktes ner vid start.\n"
@@ -4834,6 +5350,13 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ "Increase the stack size if you know how. If not:"
 #~ msgstr ""
 #~ "CircuitPython-heapen blev korrupt eftersom stacken är för liten.\n"
+#~ "Öka stackstorleken om du vet hur, eller om inte:"
+
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase the stack size if you know how, or if not:"
+#~ msgstr ""
+#~ "CircuitPythons heap blev korrupt eftersom stacken var för liten.\n"
 #~ "Öka stackstorleken om du vet hur, eller om inte:"
 
 #~ msgid "The SW38 button was pressed at start up.\n"
@@ -4848,6 +5371,13 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ msgstr ""
 #~ "Modulen `microcontroller` användes för att starta upp i felsäkert läge. "
 #~ "Tryck på reset för att avsluta felsäkert läget."
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode.\n"
+#~ msgstr ""
+#~ "Modulen \"microkontroller\" användes för att starta i säkert läge. Tryck "
+#~ "på reset för att lämna säkert läge.\n"
 
 #~ msgid "The central button was pressed at start up.\n"
 #~ msgstr "Mittknappen trycktes in vid start.\n"
@@ -4865,524 +5395,46 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ "tillräckligt med ström för hela kretsen och tryck på reset (efter "
 #~ "utmatning av CIRCUITPY)."
 
-#~ msgid "To exit, please reset the board without requesting safe mode."
-#~ msgstr "För att avsluta, återställ kortet utan att begära säkert läge."
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "Mikrokontrollerns matningsspänning droppade. Se till att "
+#~ "strömförsörjningen ger\n"
+#~ "tillräckligt med ström för hela kretsen och tryck på reset (efter "
+#~ "utmatning av CIRCUITPY).\n"
 
-#~ msgid "You are in safe mode because:\n"
-#~ msgstr "Du är i felsäkert läge eftersom:\n"
+#~ msgid "The power dipped. Make sure you are providing enough power."
+#~ msgstr "Spänningen sjönk. Se till att du ger tillräckligt med ström."
+
+#~ msgid "Tile value out of bounds"
+#~ msgstr "Tile-värde utanför intervall"
+
+#~ msgid "Timeout waiting for DRDY"
+#~ msgstr "Timeout i väntan på DRDY"
+
+#~ msgid "Timeout waiting for VSYNC"
+#~ msgstr "Timeout i väntan på VSYNC"
 
 #~ msgid ""
-#~ "You pressed the reset button during boot. Press again to exit safe mode."
+#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
+#~ "program"
 #~ msgstr ""
-#~ "Du tryckte på resetknappen under uppstarten. Tryck igen för att avsluta "
-#~ "felsäkert läge."
-
-#~ msgid ""
-#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
-#~ msgstr ""
-#~ "esp32_camera.Camera kräver reserverad PSRAM att konfigureras. Se "
-#~ "dokumentationen för instruktioner."
-
-#~ msgid "%q must be of type %q"
-#~ msgstr "%q måste vara av typen %q"
-
-#~ msgid "%q must be of type %q or None"
-#~ msgstr "%q måste vara av typen %q eller None"
-
-#~ msgid "Expected a %q"
-#~ msgstr "Förväntade %q"
-
-#~ msgid "Expected a %q or %q"
-#~ msgstr "Förväntade %q eller %q"
-
-#~ msgid "Expected an %q"
-#~ msgstr "Förväntade en %q"
-
-#, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IV måste vara %d byte lång"
-
-#~ msgid "Not settable"
-#~ msgstr "Går inte sätta"
-
-#~ msgid "expected '%q' but got '%q'"
-#~ msgstr "förväntade '%q' men fick '%q'"
-
-#~ msgid "expected '%q' or '%q' but got '%q'"
-#~ msgstr "förväntade '%q' eller '%q' men fick '%q'"
-
-#~ msgid "Read-only object"
-#~ msgstr "Skrivskyddat objekt"
-
-#~ msgid "frequency is read-only for this board"
-#~ msgstr "frekvens är skrivskyddad för detta kort"
-
-#~ msgid "Pins 21+ not supported from ULP"
-#~ msgstr "Pins 21+ stöds inte av ULP"
-
-#~ msgid "Unable to write"
-#~ msgstr "Kan inte skriva"
-
-#~ msgid "%q length must be >= 1"
-#~ msgstr "längden på %q måste vara >= 1"
-
-#~ msgid "%q must be a string"
-#~ msgstr "%q måste vara en sträng"
-
-#~ msgid "%q must be an int"
-#~ msgstr "%q måste vara en int"
-
-#~ msgid "%q with a report ID of 0 must be of length 1"
-#~ msgstr "%q med report-ID 0 måste ha längd 1"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "Högst %d %q kan anges (inte %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Ogiltiga pinnar"
-
-#, c-format
-#~ msgid "No more than %d HID devices allowed"
-#~ msgstr "Högst %d HID-enheter är tillåtna"
-
-#~ msgid "byteorder is not a string"
-#~ msgstr "byteorder är inte en sträng"
-
-#~ msgid "can't convert %q to int"
-#~ msgstr "kan inte konvertera %q till int"
-
-#~ msgid "complex division by zero"
-#~ msgstr "komplex division med noll"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr "int() arg 2 måste vara >= 2 och <= 36"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "long int stöds inte i denna build"
-
-#~ msgid "slice step cannot be zero"
-#~ msgstr "segmentsteg kan inte vara noll"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "step måste vara icke-noll"
-
-#~ msgid "string indices must be integers, not %q"
-#~ msgstr "strängindex måste vara heltal, inte %q"
-
-#~ msgid "time.struct_time() takes a 9-sequence"
-#~ msgstr "time.struct_time() kräver en 9-sekvens"
-
-#~ msgid "zero step"
-#~ msgstr "noll steg"
-
-#~ msgid "invalid traceback"
-#~ msgstr "Ogilitig källspårning"
-
-#~ msgid "WatchDogTimer.timeout must be greater than 0"
-#~ msgstr "WatchDogTimer.timeout måste vara större än 0"
-
-#~ msgid "non-Device in %q"
-#~ msgstr "icke-enhet i %q"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "Enkelt '}' påträffades i formatsträngen"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "tröskelvärdet måste ligga i intervallet 0-65536"
-
-#~ msgid "timeout must be 0.0-100.0 seconds"
-#~ msgstr "timeout måste vara 0.0-100.0 sekunder"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "omatchad '{' i format"
-
-#~ msgid "watchdog timeout must be greater than 0"
-#~ msgstr "watchdog timeout måste vara större än 0"
+#~ "Timern är reserverad för internt bruk - deklarera PWM-pinne tidigare i "
+#~ "programmet"
 
 #~ msgid "To exit, please reset the board without "
 #~ msgstr "För att avsluta, gör reset på kortet utan "
 
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "Du begärt att starta i felsäkert läge genom att "
+#~ msgid "To exit, please reset the board without requesting safe mode."
+#~ msgstr "För att avsluta, återställ kortet utan att begära säkert läge."
 
-#~ msgid "pressing BOOT button at start up.\n"
-#~ msgstr "genom att trycka på BOOT-knappen vid start.\n"
+#~ msgid "Too many display busses"
+#~ msgstr "För många display-bussar"
 
-#~ msgid "pressing SW38 button at start up.\n"
-#~ msgstr "genom att trycka på SW38-knappen vid start.\n"
-
-#~ msgid "pressing VOLUME button at start up.\n"
-#~ msgstr "genom att trycka på VOLUME-knappen vid start.\n"
-
-#~ msgid "pressing boot button at start up.\n"
-#~ msgstr "genom att trycka på startknappen vid start.\n"
-
-#~ msgid "pressing both buttons at start up.\n"
-#~ msgstr "genom att trycka båda knapparna vid uppstart.\n"
-
-#~ msgid "pressing central button at start up.\n"
-#~ msgstr "trycka på mittknappen vid start.\n"
-
-#~ msgid "pressing button A at start up.\n"
-#~ msgstr "genom att tryck på knappen A vid start.\n"
-
-#~ msgid "pressing the left button at start up\n"
-#~ msgstr "genom att håll ner vänster knapp vid start\n"
-
-#~ msgid "Only one TouchAlarm can be set in deep sleep."
-#~ msgstr "Endast ett TouchAlarm kan ställas in för djupsömn."
-
-#~ msgid "Firmware image is invalid"
-#~ msgstr "Firmware-avbilden är ogiltig"
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "Stream saknar readinto() eller write() metod."
-
-#~ msgid "%q must be >= 0"
-#~ msgstr "%q måste vara >= 0"
-
-#~ msgid "%q must be >= 1"
-#~ msgstr "%q måste vara >= 1"
-
-#~ msgid "address out of bounds"
-#~ msgstr "adress utanför gränsen"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr "destination_length måste vara ett heltal >= 0"
-
-#~ msgid "type object 'generator' has no attribute '__await__'"
-#~ msgstr "typobjekt 'generator' har inget attribut '__await__'"
-
-#~ msgid "color should be an int"
-#~ msgstr "color ska vara en int"
-
-#~ msgid "end_x should be an int"
-#~ msgstr "color ska vara en int"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "palette_index ska vara en int"
-
-#~ msgid "start_x should be an int"
-#~ msgstr "start_x ska vara en int"
-
-#~ msgid "y should be an int"
-#~ msgstr "y ska vara en int"
-
-#~ msgid "%q ``must`` be a bytearray or array of type 'h', 'H', 'b' or 'B'"
-#~ msgstr ""
-#~ "%q ``måste`` vara en bytearray eller matris av typen 'h', 'H', 'b' eller "
-#~ "'B'"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "sample_source buffert måste vara en bytearray eller matris av typ 'h', "
-#~ "'H', 'b' eller 'B'"
-
-#~ msgid "Expected an alarm"
-#~ msgstr "Förväntade ett larm"
-
-#~ msgid "All I2C targets are in use"
-#~ msgstr "Alla I2C-mål används"
-
-#~ msgid "Failed to init wifi"
-#~ msgstr "Kunde inte initiera WiFi"
-
-#~ msgid "input must be a tensor of rank 2"
-#~ msgstr "indata måste vara en tensor av rank 2"
-
-#~ msgid "maximum number of dimensions is 4"
-#~ msgstr "maximalt antal dimensioner är 4"
-
-#~ msgid "Watchdog timer expired."
-#~ msgstr "Watchdog-timern har löpt ut."
-
-#~ msgid "ssid can't be more than 32 bytes"
-#~ msgstr "ssid kan vara max 32 bytes"
-
-#~ msgid "%q must be a tuple of length 2"
-#~ msgstr "%q måste vara en tuple av längd 2"
-
-#~ msgid "%q must be between %d and %d"
-#~ msgstr "%q måste vara mellan %d och %d"
-
-#~ msgid "%q should be an int"
-#~ msgstr "%q ska vara en int"
-
-#~ msgid "(x,y) integers required"
-#~ msgstr "(x,y) heltal krävs"
-
-#~ msgid "Address type out of range"
-#~ msgstr "Adresstyp utanför intervallet"
-
-#~ msgid "AnalogIn not supported on given pin"
-#~ msgstr "AnalogIn stöds inte på angiven pinne"
-
-#~ msgid "AnalogOut functionality not supported"
-#~ msgstr "AnalogOut-funktionalitet stöds inte"
-
-#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-#~ msgstr ""
-#~ "AnalogOut hanterar bara 16 bitar. Värdet måste vara mindre än 65536."
-
-#~ msgid "AnalogOut not supported on given pin"
-#~ msgstr "AnalogOut stöds inte på angiven pinne"
-
-#, c-format
-#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
-#~ msgstr "Bitdjup måste vara inom 1 till 6, inte %d"
-
-#, c-format
-#~ msgid "Buffer incorrect size. Should be %d bytes."
-#~ msgstr "Buffert har felaktig storlek. Ska vara %d byte."
-
-#~ msgid "Buffer must be at least length 1"
-#~ msgstr "Bufferten måste ha minst längd 1"
-
-#~ msgid "Bytes must be between 0 and 255."
-#~ msgstr "Bytes måste vara mellan 0 och 255."
-
-#~ msgid "Cannot output both channels on the same pin"
-#~ msgstr "Det går inte att mata ut båda kanalerna på samma pinne"
-
-#~ msgid "Cannot read without MISO pin."
-#~ msgstr "Kan inte läsa utan MISO-pinne."
-
-#~ msgid "Cannot reset into bootloader because no bootloader is present."
-#~ msgstr ""
-#~ "Det går inte att återställa till bootloader eftersom bootloader saknas."
-
-#~ msgid "Cannot transfer without MOSI and MISO pins."
-#~ msgstr "Kan inte överföra utan MOSI- och MISO-pinnar."
-
-#~ msgid "Cannot write without MOSI pin."
-#~ msgstr "Kan inte skriva utan MOSI-pinne."
-
-#~ msgid "Clock pin init failed."
-#~ msgstr "Initiering av klockpinne misslyckades."
-
-#~ msgid "Command must be an int between 0 and 255"
-#~ msgstr "Kommandot måste vara en int mellan 0 och 255"
-
-#~ msgid "Could not initialize Camera"
-#~ msgstr "Kunde inte initiera Camera"
-
-#~ msgid "Could not initialize GNSS"
-#~ msgstr "Kan inte initiera GNSS"
-
-#~ msgid "Could not initialize SDCard"
-#~ msgstr "Kan inte initiera SD-kort"
-
-#~ msgid "Could not initialize UART"
-#~ msgstr "Det gick inte att initiera UART"
-
-#~ msgid "Could not re-init channel"
-#~ msgstr "Det gick inte att återinitiera kanalen"
-
-#~ msgid "Could not re-init timer"
-#~ msgstr "Det gick inte att återinitiera timern"
-
-#~ msgid "Could not restart PWM"
-#~ msgstr "Det gick inte att starta om PWM"
-
-#~ msgid "Couldn't allocate first buffer"
-#~ msgstr "Det gick inte att allokera den första bufferten"
-
-#~ msgid "Couldn't allocate input buffer"
-#~ msgstr "Det gick inte att allokera indatabufferten"
-
-#~ msgid "Couldn't allocate second buffer"
-#~ msgstr "Det gick inte att allokera den andra bufferten"
-
-#~ msgid "DigitalInOut not supported on given pin"
-#~ msgstr "DigitalInOut stöds inte på given pinne"
-
-#, c-format
-#~ msgid "Expected tuple of length %d, got %d"
-#~ msgstr "Förväntad tupel med längd %d, fick %d"
-
-#~ msgid "Failed to allocate RX buffer"
-#~ msgstr "Det gick inte att tilldela RX-buffert"
-
-#, c-format
-#~ msgid "Failed to allocate RX buffer of %d bytes"
-#~ msgstr "Det gick inte att allokera RX-bufferten på %d byte"
-
-#, c-format
-#~ msgid "Framebuffer requires %d bytes"
-#~ msgstr "Framebuffer kräver %d byte"
-
-#~ msgid "Hostname must be between 1 and 253 characters"
-#~ msgstr "Hostname måste vara mellan 1 och 253 tecken"
-
-#~ msgid "I2C Init Error"
-#~ msgstr "I2C init-fel"
-
-#~ msgid "Invalid %q pin selection"
-#~ msgstr "Ogiltigt val av %q pinne"
-
-#~ msgid "Invalid AuthMode"
-#~ msgstr "Ogiltig AuthMode"
-
-#~ msgid "Invalid BMP file"
-#~ msgstr "Ogiltig BMP-fil"
-
-#~ msgid "Invalid DAC pin supplied"
-#~ msgstr "Ogiltig DAC-pinne angiven"
-
-#~ msgid "Invalid MIDI file"
-#~ msgstr "Ogiltig MIDI-fil"
-
-#~ msgid "Invalid PWM frequency"
-#~ msgstr "Ogiltig PWM-frekvens"
-
-#~ msgid "Invalid Pin"
-#~ msgstr "Ogiltig pinne"
-
-#~ msgid "Invalid buffer size"
-#~ msgstr "Ogiltig buffertstorlek"
-
-#~ msgid "Invalid byteorder string"
-#~ msgstr "Ogiltig byteorder-sträng"
-
-#~ msgid "Invalid capture period. Valid range: 1 - 500"
-#~ msgstr "Ogiltig inspelningsperiod. Giltigt intervall: 1 - 500"
-
-#~ msgid "Invalid channel count"
-#~ msgstr "Ogiltigt kanalantal"
-
-#, c-format
-#~ msgid "Invalid data_count %d"
-#~ msgstr "Ogiltig data_count %d"
-
-#~ msgid "Invalid direction."
-#~ msgstr "Ogiltig riktning."
-
-#~ msgid "Invalid file"
-#~ msgstr "Felaktig fil"
-
-#~ msgid "Invalid mode"
-#~ msgstr "Ogiltigt läge"
-
-#~ msgid "Invalid number of bits"
-#~ msgstr "Ogiltigt antal bitar"
-
-#~ msgid "Invalid phase"
-#~ msgstr "Ogiltig fas"
-
-#~ msgid "Invalid pin"
-#~ msgstr "Ogiltig pinne"
-
-#~ msgid "Invalid pin for left channel"
-#~ msgstr "Ogiltig pinne för vänster kanal"
-
-#~ msgid "Invalid pin for right channel"
-#~ msgstr "Ogiltig pinne för höger kanal"
-
-#~ msgid "Invalid polarity"
-#~ msgstr "Ogiltig polaritet"
-
-#~ msgid "Invalid properties"
-#~ msgstr "Ogiltiga egenskaper"
-
-#~ msgid "Invalid run mode."
-#~ msgstr "Ogiltigt körläge."
-
-#~ msgid "Invalid security_mode"
-#~ msgstr "Ogiltigt säkerhetsläge"
-
-#~ msgid "Invalid voice"
-#~ msgstr "Ogiltig kanal"
-
-#~ msgid "Invalid voice count"
-#~ msgstr "Ogiltigt kanalantal"
-
-#~ msgid "Invalid wave file"
-#~ msgstr "Ogiltig wave-fil"
-
-#~ msgid "Invalid word/bit length"
-#~ msgstr "Ogiltig word-/bitlängd"
-
-#~ msgid "Layer already in a group."
-#~ msgstr "Lagret finns redan i en grupp."
-
-#~ msgid "Layer must be a Group or TileGrid subclass."
-#~ msgstr "Layer måste vara en subklass av Group eller TileGrid."
-
-#~ msgid "MISO pin init failed."
-#~ msgstr "init för MISO-pinne misslyckades."
-
-#~ msgid "MOSI pin init failed."
-#~ msgstr "init för MOSI-pinne misslyckades."
-
-#~ msgid "Messages limited to 8 bytes"
-#~ msgstr "Meddelanden begränsad till 8 byte"
-
-#, c-format
-#~ msgid "More than %d report ids not supported"
-#~ msgstr "Fler än %d rapport-id stöds inte"
-
-#~ msgid "No hardware support on clk pin"
-#~ msgstr "Inget hårdvarustöd på clk-pinne"
-
-#~ msgid "No hardware support on pin"
-#~ msgstr "Inget hårdvarustöd på pinne"
-
-#, c-format
-#~ msgid "Output buffer must be at least %d bytes"
-#~ msgstr "Utdatabuffert måste vara minst %d byte"
-
-#~ msgid ""
-#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-#~ msgstr "PWM duty_cykel måste vara mellan 0 och 65535 (16 bitars upplösning)"
-
-#~ msgid "Pin count must be at least 1"
-#~ msgstr "Antalet pinnar måste vara minst 1"
-
-#~ msgid "Pin does not have ADC capabilities"
-#~ msgstr "Pinnen har inte ADC-funktionalitet"
-
-#~ msgid "Program must contain at least one 16-bit instruction."
-#~ msgstr "Programmet måste innehålla minst en 16-bitars instruktion."
-
-#~ msgid "Program too large"
-#~ msgstr "Programmet är för stort"
-
-#~ msgid "RS485 Not yet supported on this device"
-#~ msgstr "RS485 stöds ännu inte på den här enheten"
-
-#~ msgid "RTC calibration is not supported on this board"
-#~ msgstr "RTC-kalibrering stöds inte av detta kort"
-
-#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
-#~ msgstr "RTS/CTS/RS485 Stöds ännu inte på den här enheten"
-
-#~ msgid "SPI Init Error"
-#~ msgstr "SPI Init-fel"
-
-#~ msgid "SPI Re-initialization error"
-#~ msgstr "SPI reinitialiseringsfel"
-
-#~ msgid "Sample rate must be positive"
-#~ msgstr "Samplingsfrekvensen måste vara positiv"
-
-#, c-format
-#~ msgid "Sample rate too high. It must be less than %d"
-#~ msgstr "Samplingsfrekvensen är för hög. Den måste vara mindre än %d"
-
-#~ msgid "Set pin count must be between 1 and 5"
-#~ msgstr "Inställt antal pinnar måste vara mellan 1 och 5"
-
-#~ msgid "Side set pin count must be between 1 and 5"
-#~ msgstr "Sido-setets antal pinnar måste vara mellan 1 och 5"
-
-#~ msgid "Stack size must be at least 256"
-#~ msgstr "Stackstorleken måste vara minst 256"
-
-#~ msgid "Tile value out of bounds"
-#~ msgstr "Tile-värde utanför intervall"
+#~ msgid "Total data to write is larger than outgoing_packet_length"
+#~ msgstr "Total data som ska skrivas är större än outgoing_packet_length"
 
 #~ msgid "UART Buffer allocation error"
 #~ msgstr "UART-buffertallokeringsfel"
@@ -5396,89 +5448,74 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ msgid "UART Re-init error"
 #~ msgstr "UART reinit-fel"
 
+#~ msgid "UART not yet supported"
+#~ msgstr "UART stöds ännu inte"
+
 #~ msgid "UART write error"
 #~ msgstr "UART skrivfel"
+
+#~ msgid "USB Busy"
+#~ msgstr "USB upptagen"
+
+#~ msgid "USB Error"
+#~ msgstr "USB-fel"
+
+#~ msgid "Unable to allocate the heap."
+#~ msgstr "Kan inte allokera heap."
+
+#, c-format
+#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Kan inte konfigurera ADC DMA controller, Felkod:%d"
+
+#, c-format
+#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Kan inte inititiera ADC DMA-controller, Felkod:%d"
+
+#, c-format
+#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
+#~ msgstr "Kan inte starta ADC DMA controller, Felkod:%d"
+
+#~ msgid "Unable to write"
+#~ msgstr "Kan inte skriva"
+
+#~ msgid "Unable to write to address."
+#~ msgstr "Det går inte att skriva till adress."
+
+#~ msgid "Unknown failure"
+#~ msgstr "Okänt fel"
+
+#~ msgid "Unknown soft device error: %04x"
+#~ msgstr "Okänt mjukvarufel: %04x"
+
+#, c-format
+#~ msgid "Unkown error code %d"
+#~ msgstr "Okänd felkod %d"
 
 #~ msgid "Unsupported baudrate"
 #~ msgstr "Baudrate stöd inte"
 
-#~ msgid "WiFi password must be between 8 and 63 characters"
-#~ msgstr "WiFi-lösenord måste vara mellan 8 och 63 tecken"
-
-#~ msgid "bits must be in range 5 to 9"
-#~ msgstr "bits måste mellan 5 och 9"
-
-#~ msgid "bytes > 8 bits not supported"
-#~ msgstr "bytes> 8 bitar stöds inte"
-
-#~ msgid "calibration value out of range +/-127"
-#~ msgstr "kalibreringsvärde utanför intervallet +/- 127"
-
-#~ msgid "can only be registered in one parent"
-#~ msgstr "kan endast registreras med en förälder"
-
-#~ msgid "circle can only be registered in one parent"
-#~ msgstr "circle kan endast registreras i en förälder"
-
-#~ msgid "max_connections must be between 0 and 10"
-#~ msgstr "max_connections måste vara mellan 0 och 10"
-
-#~ msgid "max_length must be >= 0"
-#~ msgstr "max_length måste vara >= 0"
-
-#~ msgid "polygon can only be registered in one parent"
-#~ msgstr "polygon kan endast registreras i en förälder"
-
-#~ msgid "pull_threshold must be between 1 and 32"
-#~ msgstr "pull_threshold måste vara mellan 1 och 32"
-
-#~ msgid "push_threshold must be between 1 and 32"
-#~ msgstr "push_threshold måste vara mellan 1 och 32"
-
-#~ msgid "stop must be 1 or 2"
-#~ msgstr "stop måste vara 1 eller 2"
-
-#~ msgid "tile must be greater than zero"
-#~ msgstr "tile måste vara större än noll"
-
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "timeout måste vara >= 0.0"
-
-#, c-format
-#~ msgid "width must be from 2 to 8 (inclusive), not %d"
-#~ msgstr "width måste vara mellan 2 och 8, inte %d"
-
 #~ msgid "Unsupported operation"
 #~ msgstr "Åtgärd som inte stöds"
-
-#~ msgid "divisor must be 4"
-#~ msgstr "divisor måste vara 4"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code stopped by auto-reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Koden stoppades av auto-omladdning.\n"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "Ljusstyrka måste vara mellan 0 och 255"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "kan inte utföra relativ import"
-
-#, c-format
-#~ msgid "No I2C device at address: %x"
-#~ msgstr "Ingen I2C-enhet på adress: %x"
 
 #~ msgid "Unsupported pull value."
 #~ msgstr "Ogiltigt Pull-värde."
 
-#~ msgid "Station must be started"
-#~ msgstr "Stationen måste startas"
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr "Viper-funktioner stöder för närvarande inte mer än fyra argument"
 
-#~ msgid "%q must <= %d"
-#~ msgstr "%q måste vara <=%d"
+#~ msgid "WatchDogTimer is not currently running"
+#~ msgstr "WatchDogTimer körs för närvarande inte"
+
+#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+#~ msgstr ""
+#~ "WatchDogTimer.mode kan inte ändras när den är inställd på WatchDogMode."
+#~ "RESET"
+
+#~ msgid "WatchDogTimer.timeout must be greater than 0"
+#~ msgstr "WatchDogTimer.timeout måste vara större än 0"
+
+#~ msgid "Watchdog timer expired."
+#~ msgstr "Watchdog-timern har löpt ut."
 
 #, c-format
 #~ msgid ""
@@ -5495,11 +5532,178 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ "\n"
 #~ "För att lista inbyggda moduler, ange `help(\"modules\")`.\n"
 
-#~ msgid "integer required"
-#~ msgstr "heltal krävs"
+#~ msgid "WiFi password must be between 8 and 63 characters"
+#~ msgstr "WiFi-lösenord måste vara mellan 8 och 63 tecken"
+
+#~ msgid "Wifi is in access point mode."
+#~ msgstr "WiFi är i accesspunktläge."
+
+#~ msgid "Wifi is in station mode."
+#~ msgstr "WiFi är i stationsläge."
+
+#~ msgid "You are in safe mode because:\n"
+#~ msgstr "Du är i felsäkert läge eftersom:\n"
+
+#~ msgid "You are in safe mode: something unanticipated happened.\n"
+#~ msgstr "Du är i säkert läge: något öväntat hände.\n"
+
+#~ msgid ""
+#~ "You pressed the reset button during boot. Press again to exit safe mode."
+#~ msgstr ""
+#~ "Du tryckte på resetknappen under uppstarten. Tryck igen för att avsluta "
+#~ "felsäkert läge."
+
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "Du begärt att starta i felsäkert läge genom att "
+
+#~ msgid "__init__() should return None, not '%q'"
+#~ msgstr "__init__() ska returnera None, inte '%q'"
 
 #~ msgid "abort() called"
 #~ msgstr "abort() anropad"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "adressen %08x är inte justerad till %d byte"
+
+#~ msgid "address out of bounds"
+#~ msgstr "adress utanför gränsen"
+
+#~ msgid "arctan2 is implemented for scalars and ndarrays only"
+#~ msgstr "arctan2 är enbart implementerad för scalar och ndarray"
+
+#~ msgid "argument must be ndarray"
+#~ msgstr "argument måste vara ndarray"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "attribut stöds inte än"
+
+#~ msgid "axis must be -1, 0, None, or 1"
+#~ msgstr "axis ska vara -1, 0, None eller 1"
+
+#~ msgid "axis must be -1, 0, or 1"
+#~ msgstr "axis ska vara -1, 0 eller 1"
+
+#~ msgid "axis must be None, 0, or 1"
+#~ msgstr "axis ska vara None, 0, eller 1"
+
+#~ msgid "bits must be 7, 8 or 9"
+#~ msgstr "bits måste vara 7, 8 eller 9"
+
+#~ msgid "bits must be 8"
+#~ msgstr "bits måste vara 8"
+
+#~ msgid "bits must be in range 5 to 9"
+#~ msgstr "bits måste mellan 5 och 9"
+
+#~ msgid "buffer must be a bytes-like object"
+#~ msgstr "buffer måste vara en byte-liknande objekt"
+
+#~ msgid "buffers must be the same length"
+#~ msgstr "buffertar måste vara samma längd"
+
+#~ msgid "buttons must be digitalio.DigitalInOut"
+#~ msgstr "buttons måste vara digitalio.DigitalInOut"
+
+#~ msgid "byte code not implemented"
+#~ msgstr "byte-kod inte implementerad"
+
+#~ msgid "byteorder is not a string"
+#~ msgstr "byteorder är inte en sträng"
+
+#~ msgid "bytes > 8 bits not supported"
+#~ msgstr "bytes> 8 bitar stöds inte"
+
+#~ msgid "calibration value out of range +/-127"
+#~ msgstr "kalibreringsvärde utanför intervallet +/- 127"
+
+#~ msgid "can only be registered in one parent"
+#~ msgstr "kan endast registreras med en förälder"
+
+#~ msgid "can only save bytecode"
+#~ msgstr "kan bara spara bytecode"
+
+#~ msgid "can't convert %q to int"
+#~ msgstr "kan inte konvertera %q till int"
+
+#~ msgid "can't convert address to int"
+#~ msgstr "kan inte konvertera address till int"
+
+#~ msgid "can't convert to %q"
+#~ msgstr "kan inte konvertera till %q"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr "kan inte göra trunkerad division av komplext tal"
+
+#~ msgid "can't have multiple **x"
+#~ msgstr "kan inte ha flera **x"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "kan inte ha flera *x"
+
+#~ msgid "can't pend throw to just-started generator"
+#~ msgstr "kan inte 'pend throw' för nystartad generator"
+
+#~ msgid "cannot import name %q"
+#~ msgstr "kan inte importera namn %q"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "kan inte utföra relativ import"
+
+#~ msgid "cannot reshape array (incompatible input/output shape)"
+#~ msgstr "kan inte omforma matris (inkompatibel indata-/utdataform)"
+
+#~ msgid "cannot unambiguously get sizeof scalar"
+#~ msgstr "Kan inte entydigt få sizeof scalar"
+
+#~ msgid "circle can only be registered in one parent"
+#~ msgstr "circle kan endast registreras i en förälder"
+
+#~ msgid "color should be an int"
+#~ msgstr "color ska vara en int"
+
+#~ msgid "complex division by zero"
+#~ msgstr "komplex division med noll"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "konstant måste vara ett heltal"
+
+#~ msgid "could not broadast input array from shape"
+#~ msgstr "Kan inte sända indatamatris från form"
+
+#~ msgid "ddof must be smaller than length of data set"
+#~ msgstr "ddof måste vara mindre än längden på datauppsättningen"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr "destination_length måste vara ett heltal >= 0"
+
+#~ msgid "divisor must be 4"
+#~ msgstr "divisor måste vara 4"
+
+#~ msgid "empty %q list"
+#~ msgstr "tom %q-lista"
+
+#~ msgid "end_x should be an int"
+#~ msgstr "color ska vara en int"
+
+#~ msgid ""
+#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "esp32_camera.Camera kräver reserverad PSRAM att konfigureras. Se "
+#~ "dokumentationen för instruktioner."
+
+#~ msgid ""
+#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "espcamera.Camera kräver reserverat PSRAM att vara konfigurerat. Se "
+#~ "dokumentationen för instruktioner."
+
+#~ msgid "expected '%q' but got '%q'"
+#~ msgstr "förväntade '%q' men fick '%q'"
+
+#~ msgid "expected '%q' or '%q' but got '%q'"
+#~ msgstr "förväntade '%q' eller '%q' men fick '%q'"
 
 #~ msgid "f-string expression part cannot include a '#'"
 #~ msgstr "f-stränguttrycksdelen kan inte innehålla en '#'"
@@ -5516,221 +5720,144 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ msgid "f-string: single '}' is not allowed"
 #~ msgstr "f-string: singel '}' är inte tillåten"
 
-#~ msgid "invalid arguments"
-#~ msgstr "ogiltiga argument"
+#~ msgid "first argument must be an iterable"
+#~ msgstr "första argumentet måste vara en iterable"
 
-#~ msgid "raw f-strings are not implemented"
-#~ msgstr "råa f-strängar inte implementerade"
+#~ msgid "firstbit must be MSB"
+#~ msgstr "firstbit måste vara MSB"
 
-#~ msgid "unindent does not match any outer indentation level"
-#~ msgstr "indentering inte matchar någon yttre indenteringsnivå"
+#~ msgid "frequency is read-only for this board"
+#~ msgstr "frekvens är skrivskyddad för detta kort"
 
-#~ msgid "%q list must be a list"
-#~ msgstr "%q-listan måste vara en lista"
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "funktionen tar inte nyckelordsargument"
 
-#~ msgid "%q must of type %q"
-#~ msgstr "%q måste av typen %q"
+#~ msgid "function is implemented for scalars and ndarrays only"
+#~ msgstr "funktionen är endast implementerad för scalar och ndarray"
 
-#~ msgid "Column entry must be digitalio.DigitalInOut"
-#~ msgstr "Kolumnposten måste vara digitalio. DigitalInOut"
+#~ msgid "incompatible native .mpy architecture"
+#~ msgstr "inkompatibel nativ .mpy-arkitektur"
 
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Förväntade en karaktäristik"
+#~ msgid "input and output shapes are not compatible"
+#~ msgstr "indata- och utdataformer är inte kompatibla"
 
-#~ msgid "Expected a DigitalInOut"
-#~ msgstr "Förväntar en DigitalInOut"
+#~ msgid "input argument must be an integer or a 2-tuple"
+#~ msgstr "indataargumentet måste vara ett heltal eller en 2-tupel"
 
-#~ msgid "Expected a Service"
-#~ msgstr "Förväntade en tjänst"
+#~ msgid "input must be a tensor of rank 2"
+#~ msgstr "indata måste vara en tensor av rank 2"
 
-#~ msgid "Expected a UART"
-#~ msgstr "Förväntar en UART"
+#~ msgid "inputs are not iterable"
+#~ msgstr "indata är inte iterbara"
 
-#~ msgid "Expected a UUID"
-#~ msgstr "Förväntade en UUID"
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr "int() arg 2 måste vara >= 2 och <= 36"
 
-#~ msgid "Expected an Address"
-#~ msgstr "Förväntade en adress"
-
-#~ msgid "Row entry must be digitalio.DigitalInOut"
-#~ msgstr "Radvärdet måste vara digitalio.DigitalInOut"
-
-#~ msgid "buttons must be digitalio.DigitalInOut"
-#~ msgstr "buttons måste vara digitalio.DigitalInOut"
-
-#~ msgid "Invalid frequency"
-#~ msgstr "Ogiltig frekvens"
-
-#~ msgid "Data 0 pin must be byte aligned."
-#~ msgstr "Datapinne 0 måste vara byte-justerad."
-
-#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
-#~ msgstr "ogiltig bits_per_pixel %d, måste vara 1, 4, 8, 16, 24 eller 32"
-
-#~ msgid ""
-#~ "\n"
-#~ "paste mode; Ctrl-C to cancel, Ctrl-D to finish\n"
-#~ "=== "
-#~ msgstr ""
-#~ "\n"
-#~ "klistra in-läge; Ctrl-C för att avbryta, Ctrl-D för att avsluta\n"
-#~ "=== "
-
-#~ msgid "ParallelBus not yet supported"
-#~ msgstr "ParallelBus stöds ännu inte"
-
-#~ msgid "raw REPL; CTRL-B to exit\n"
-#~ msgstr "rå REPL. CTRL-B för att avsluta\n"
-
-#~ msgid "%q length must be %q"
-#~ msgstr "längden på %q måste vara %q"
-
-#~ msgid "%q must be 0-255"
-#~ msgstr "%q måste vara 0-255"
-
-#~ msgid "%q must be 1-255"
-#~ msgstr "%q måste vara 1-255"
-
-#~ msgid "%q must be None or between 1 and len(report_descriptor)-1"
-#~ msgstr "%q måste vara None eller mellan 1 och len(report_descriptor)-1"
-
-#~ msgid "limit should be an int"
-#~ msgstr "limit måste vara en int"
-
-#~ msgid "no available NIC"
-#~ msgstr "ingen tillgänglig NIC"
-
-#~ msgid ""
-#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
-#~ "instead"
-#~ msgstr ""
-#~ "Port accepterar inte PWM carrier. Ange pinne frekvens och arbetscykel "
-#~ "istället"
-
-#~ msgid ""
-#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
-#~ "Carrier instead"
-#~ msgstr ""
-#~ "Porten accepterar inte pinne eller frekvens. Skapa och skicka en PWMOut "
-#~ "Carrier istället"
-
-#~ msgid "Instruction %d jumps on pin"
-#~ msgstr "Instruktion %d hoppar på pinne"
-
-#~ msgid "%q must store bytes"
-#~ msgstr "%q måste lagra bytes"
-
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "Bufferten är för stor och kan inte allokeras"
+#~ msgid "integer required"
+#~ msgstr "heltal krävs"
 
 #~ msgid "interp is defined for 1D arrays of equal length"
 #~ msgstr "interp är definierad för 1D-matriser med samma längd"
 
-#~ msgid "trapz is defined for 1D arrays"
-#~ msgstr "trapz är definierat för 1D-matriser"
+#~ msgid "invalid I2C peripheral"
+#~ msgstr "ogiltig I2C-kringutrustning"
 
-#~ msgid "wrong operand type"
-#~ msgstr "fel operandtyp"
+#~ msgid "invalid SPI peripheral"
+#~ msgstr "ogiltig SPI-kringutrustning"
 
-#~ msgid "%q must be None or 1-255"
-#~ msgstr "%q måste vara None eller 1-255"
+#~ msgid "invalid architecture"
+#~ msgstr "ogiltig arkitektur"
 
-#~ msgid "Only raw int or string supported for ip"
-#~ msgstr "Enbart int eller string stöds för ip"
+#~ msgid "invalid arguments"
+#~ msgstr "ogiltiga argument"
 
-#~ msgid "Only raw int supported for ip"
-#~ msgstr "Endast raw int stöds för ip"
-
-#~ msgid ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
-#~ msgstr ""
-#~ "CircuitPython är i säkert läge eftersom du tryckte på "
-#~ "återställningsknappen under start. Tryck igen för att lämna säkert läge.\n"
-
-#~ msgid "Not running saved code.\n"
-#~ msgstr "Kör inte sparad kod.\n"
-
-#~ msgid "Running in safe mode! "
-#~ msgstr "Kör i säkert läge! "
-
-#~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Please increase the stack size if you know how, or if not:"
-#~ msgstr ""
-#~ "CircuitPythons heap blev korrupt eftersom stacken var för liten.\n"
-#~ "Öka stackstorleken om du vet hur, eller om inte:"
-
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode.\n"
-#~ msgstr ""
-#~ "Modulen \"microkontroller\" användes för att starta i säkert läge. Tryck "
-#~ "på reset för att lämna säkert läge.\n"
-
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY).\n"
-#~ msgstr ""
-#~ "Mikrokontrollerns matningsspänning droppade. Se till att "
-#~ "strömförsörjningen ger\n"
-#~ "tillräckligt med ström för hela kretsen och tryck på reset (efter "
-#~ "utmatning av CIRCUITPY).\n"
-
-#~ msgid "You are in safe mode: something unanticipated happened.\n"
-#~ msgstr "Du är i säkert läge: något öväntat hände.\n"
-
-#~ msgid "Pin number already reserved by EXTI"
-#~ msgstr "PInn-nummer redan reserverat av EXTI"
-
-#~ msgid "USB Busy"
-#~ msgstr "USB upptagen"
-
-#~ msgid "USB Error"
-#~ msgstr "USB-fel"
-
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "%q index måste vara heltal, inte %q"
-
-#~ msgid "'%q' object cannot assign attribute '%q'"
-#~ msgstr "Objektet '%q' kan inte tilldela attributet '%q'"
-
-#~ msgid "'%q' object does not support item assignment"
-#~ msgstr "Objektet '%q' stöder inte tilldelning"
-
-#~ msgid "'%q' object does not support item deletion"
-#~ msgstr "Objektet '%q' stöder inte borttagning av objekt"
-
-#~ msgid "'%q' object has no attribute '%q'"
-#~ msgstr "Objektet '%q' har inget attribut '%q'"
-
-#~ msgid "'%q' object is not subscriptable"
-#~ msgstr "Objektet '%q' är inte indexbar"
-
-#~ msgid "'%s' integer %d is not within range %d..%d"
-#~ msgstr "'%s' heltal %d ligger inte inom intervallet %d..%d"
-
-#~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
-#~ msgstr "'%s' heltal 0x%x ryms inte i mask 0x%x"
-
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "Kan inte entydigt få sizeof scalar"
-
-#~ msgid "Length must be an int"
-#~ msgstr "Length måste vara en int"
-
-#~ msgid "Length must be non-negative"
-#~ msgstr "Length måste vara positiv"
+#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
+#~ msgstr "ogiltig bits_per_pixel %d, måste vara 1, 4, 8, 16, 24 eller 32"
 
 #~ msgid "invalid decorator"
 #~ msgstr "ogiltig dekorator"
 
+#~ msgid "invalid dupterm index"
+#~ msgstr "ogiltigt dupterm index"
+
+#~ msgid "invalid format"
+#~ msgstr "ogiltigt format"
+
+#~ msgid "invalid traceback"
+#~ msgstr "Ogilitig källspårning"
+
+#~ msgid "io must be rtc io"
+#~ msgstr "io måste vara rtc io"
+
+#~ msgid "iterables are not of the same length"
+#~ msgstr "iterables är inte av samma längd"
+
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr ""
+#~ "nyckelordsargument är ännu inte implementerade - använd vanliga argument"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "nyckelord måste vara strängar"
+
+#~ msgid "length argument not allowed for this type"
+#~ msgstr "argumentet length är inte är tillåten för denna typ"
+
+#~ msgid "limit should be an int"
+#~ msgstr "limit måste vara en int"
+
+#~ msgid "long int not supported in this build"
+#~ msgstr "long int stöds inte i denna build"
+
+#~ msgid "matrix dimensions do not match"
+#~ msgstr "matrisdimensioner matchar inte"
+
+#~ msgid "max_connections must be between 0 and 10"
+#~ msgstr "max_connections måste vara mellan 0 och 10"
+
+#~ msgid "max_length must be > 0"
+#~ msgstr "max_length måste vara > 0"
+
+#~ msgid "max_length must be >= 0"
+#~ msgstr "max_length måste vara >= 0"
+
+#~ msgid "maximum number of dimensions is 4"
+#~ msgstr "maximalt antal dimensioner är 4"
+
+#~ msgid "must specify all of sck/mosi/miso"
+#~ msgstr "måste ange alla av sck/mosi/miso"
+
+#~ msgid "n must be between 0, and 9"
+#~ msgstr "n måste vara mellan 0 och 9"
+
 #~ msgid "name reused for argument"
 #~ msgstr "namn återanvänt för argument"
 
+#~ msgid "no available NIC"
+#~ msgstr "ingen tillgänglig NIC"
+
+#~ msgid "no reset pin available"
+#~ msgstr "ingen reset-pinne tillgänglig"
+
+#~ msgid "non-Device in %q"
+#~ msgstr "icke-enhet i %q"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "icke nyckelord arg efter * / **"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "icke nyckelord arg efter nyckelord arg"
+
+#~ msgid "norm is defined for 1D and 2D arrays"
+#~ msgstr "norm är definierad för 1D- och 2D-matriser"
+
+#~ msgid "number of arguments must be 2, or 3"
+#~ msgstr "antal argument måste vara 2 eller 3"
+
 #~ msgid "object '%q' is not a tuple or list"
 #~ msgstr "objektet '%q' är inte en tuple eller list"
+
+#~ msgid "object '%s' is not a tuple or list"
+#~ msgstr "objektet '%s' är inte en tupel eller lista"
 
 #~ msgid "object does not support item assignment"
 #~ msgstr "Objektet stöder inte tilldelning"
@@ -5744,316 +5871,30 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ msgid "object of type '%q' has no len()"
 #~ msgstr "objekt av typen '%q' har inte len()"
 
-#~ msgid "struct: cannot index"
-#~ msgstr "struct: kan inte indexera"
-
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "Kan inte återmontera '/' när USB är aktivt."
-
-#~ msgid "Timeout waiting for DRDY"
-#~ msgstr "Timeout i väntan på DRDY"
-
-#~ msgid "Timeout waiting for VSYNC"
-#~ msgstr "Timeout i väntan på VSYNC"
-
-#~ msgid "byte code not implemented"
-#~ msgstr "byte-kod inte implementerad"
-
-#~ msgid "can't pend throw to just-started generator"
-#~ msgstr "kan inte 'pend throw' för nystartad generator"
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "ogiltigt dupterm index"
-
-#~ msgid "schedule stack full"
-#~ msgstr "schemastack full"
-
-#~ msgid "Corrupt raw code"
-#~ msgstr "Korrupt rå kod"
-
-#~ msgid "can only save bytecode"
-#~ msgstr "kan bara spara bytecode"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr "Viper-funktioner stöder för närvarande inte mer än fyra argument"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "adressen %08x är inte justerad till %d byte"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "funktionen tar inte nyckelordsargument"
-
-#~ msgid "parameter annotation must be an identifier"
-#~ msgstr "parametern annotation måste vara en identifierare"
-
-#~ msgid "Total data to write is larger than outgoing_packet_length"
-#~ msgstr "Total data som ska skrivas är större än outgoing_packet_length"
-
-#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
-#~ msgstr "IO 0, 2 & 4 stöder inte intern pullup för sovläge"
-
-#~ msgid "buffer must be a bytes-like object"
-#~ msgstr "buffer måste vara en byte-liknande objekt"
-
-#~ msgid "io must be rtc io"
-#~ msgstr "io måste vara rtc io"
-
-#~ msgid "trigger level must be 0 or 1"
-#~ msgstr "triggernivå måste vara 0 eller 1"
-
-#~ msgid "wakeup conflict"
-#~ msgstr "wakeup-konflikt"
-
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr "Försökte tilldela heap när MicroPython VM inte körs."
-
-#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
-#~ msgstr "MicroPython NLR jump misslyckades. Troligen korrupt minne."
-
-#~ msgid "MicroPython fatal error."
-#~ msgstr "MicroPython fatalt fel."
-
-#~ msgid "argument must be ndarray"
-#~ msgstr "argument måste vara ndarray"
-
-#~ msgid "matrix dimensions do not match"
-#~ msgstr "matrisdimensioner matchar inte"
-
-#~ msgid "norm is defined for 1D and 2D arrays"
-#~ msgstr "norm är definierad för 1D- och 2D-matriser"
-
-#~ msgid "vectors must have same lengths"
-#~ msgstr "vektorer måste ha samma längd"
-
-#~ msgid "Nordic Soft Device failure assertion."
-#~ msgstr "Påståendet om Nordic Soft Device-fel."
-
-#~ msgid "Nordic soft device out of memory"
-#~ msgstr "Nordic soft-enheten har slut på minne"
-
-#~ msgid "Unknown soft device error: %04x"
-#~ msgstr "Okänt mjukvarufel: %04x"
-
-#~ msgid "first argument must be an iterable"
-#~ msgstr "första argumentet måste vara en iterable"
-
-#~ msgid "iterables are not of the same length"
-#~ msgstr "iterables är inte av samma längd"
-
-#~ msgid "Selected CTS pin not valid"
-#~ msgstr "Vald CTS-pinne är inte giltig"
-
-#~ msgid "Selected RTS pin not valid"
-#~ msgstr "Vald CTS-pinne är inte giltig"
-
-#~ msgid "Could not initialize channel"
-#~ msgstr "Det gick inte att initiera kanalen"
-
-#~ msgid "Could not initialize timer"
-#~ msgstr "Det gick inte att initialisera timern"
-
-#~ msgid "Invalid frequency supplied"
-#~ msgstr "Ogiltig frekvens angiven"
-
-#~ msgid "Invalid pins for PWMOut"
-#~ msgstr "Ogiltiga pinnar för PWMOut"
-
-#~ msgid "No more channels available"
-#~ msgstr "Inga fler kanaler tillgängliga"
-
-#~ msgid "No more timers available"
-#~ msgstr "Ingen timer tillgänglig"
-
-#~ msgid "No more timers available on this pin."
-#~ msgstr "Inga fler timers tillgängliga på denna pinne."
-
-#~ msgid ""
-#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
-#~ "program"
-#~ msgstr ""
-#~ "Timern är reserverad för internt bruk - deklarera PWM-pinne tidigare i "
-#~ "programmet"
-
-#~ msgid "Group full"
-#~ msgstr "Gruppen är full"
-
-#~ msgid "In buffer elements must be 4 bytes long or less"
-#~ msgstr "Inbuffertelement måste vara 4 byte långa eller mindre"
-
-#~ msgid "Out buffer elements must be 4 bytes long or less"
-#~ msgstr "Utbuffertelement ska vara max fyra byte långa"
-
-#~ msgid "Initial set pin direcion conflicts with initial out pin direction"
-#~ msgstr "Initial pinn-riktning står i konflikt med initial utpinn-riktning"
-
-#~ msgid "UART not yet supported"
-#~ msgstr "UART stöds ännu inte"
-
-#~ msgid "bits must be 7, 8 or 9"
-#~ msgstr "bits måste vara 7, 8 eller 9"
-
-#~ msgid "Only IN/OUT of up to 8 supported"
-#~ msgstr "Endast IN/OUT på upp till 8 stöds"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "SDA eller SCL behöver en pullup"
-
-#~ msgid "Invalid use of TLS Socket"
-#~ msgstr "Ogiltig användning av TLS Socket"
-
-#~ msgid "Issue setting SO_REUSEADDR"
-#~ msgstr "Misslyckades att sätta SO_REUSEADDR"
-
-#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
-#~ msgstr "%d adresspinnar och %d RGB-pinnar indikerar en höjd av %d, inte %d"
-
-#~ msgid "Unknown failure"
-#~ msgstr "Okänt fel"
-
-#~ msgid "Only one alarm.touch alarm can be set."
-#~ msgstr "Endast ett larm av typ alarm.touch kan ställas in."
-
-#~ msgid "input argument must be an integer or a 2-tuple"
-#~ msgstr "indataargumentet måste vara ett heltal eller en 2-tupel"
+#~ msgid "offset out of bounds"
+#~ msgstr "offset utanför gränserna"
 
 #~ msgid "operation is not implemented for flattened array"
 #~ msgstr "operationen inte implementeras för tillplattad matris"
 
-#~ msgid "tuple index out of range"
-#~ msgstr "tupelindex utanför intervallet"
+#~ msgid "out of range of source"
+#~ msgstr "utanför räckvidd för source"
 
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
+#~ msgid "palette_index should be an int"
+#~ msgstr "palette_index ska vara en int"
+
+#~ msgid "parameter annotation must be an identifier"
+#~ msgstr "parametern annotation måste vara en identifierare"
+
+#~ msgid "pixel value requires too many bits"
+#~ msgstr "pixelvärdet kräver för många bitar"
+
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
 #~ msgstr ""
-#~ "\n"
-#~ "Koden har kört klart. Väntar på omladdning.\n"
+#~ "pixel_shader måste vara displayio.Palette eller displayio.ColorConverter"
 
-#~ msgid "PinAlarm not yet implemented"
-#~ msgstr "PinAlarm är inte implementerat ännu"
-
-#~ msgid "Pretending to deep sleep until alarm, any key or file write.\n"
-#~ msgstr "Fingerar djup sömn tills larm, valfri tangent eller filskrivning.\n"
-
-#~ msgid "Frequency captured is above capability. Capture Paused."
-#~ msgstr "Infångningsfrekvens är för hög. Infångning pausad."
-
-#~ msgid "max_length must be > 0"
-#~ msgstr "max_length måste vara > 0"
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr ""
-#~ "Tryck på valfri knapp för att gå in i REPL. Använd CTRL-D för att ladda "
-#~ "om."
-
-#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
-#~ msgstr "Endast IPv4 SOCK_STREAM sockets stöds"
-
-#~ msgid "arctan2 is implemented for scalars and ndarrays only"
-#~ msgstr "arctan2 är enbart implementerad för scalar och ndarray"
-
-#~ msgid "axis must be -1, 0, None, or 1"
-#~ msgstr "axis ska vara -1, 0, None eller 1"
-
-#~ msgid "axis must be -1, 0, or 1"
-#~ msgstr "axis ska vara -1, 0 eller 1"
-
-#~ msgid "axis must be None, 0, or 1"
-#~ msgstr "axis ska vara None, 0, eller 1"
-
-#~ msgid "cannot reshape array (incompatible input/output shape)"
-#~ msgstr "kan inte omforma matris (inkompatibel indata-/utdataform)"
-
-#~ msgid "could not broadast input array from shape"
-#~ msgstr "Kan inte sända indatamatris från form"
-
-#~ msgid "ddof must be smaller than length of data set"
-#~ msgstr "ddof måste vara mindre än längden på datauppsättningen"
-
-#~ msgid "function is implemented for scalars and ndarrays only"
-#~ msgstr "funktionen är endast implementerad för scalar och ndarray"
-
-#~ msgid "n must be between 0, and 9"
-#~ msgstr "n måste vara mellan 0 och 9"
-
-#~ msgid "number of arguments must be 2, or 3"
-#~ msgstr "antal argument måste vara 2 eller 3"
-
-#~ msgid "right hand side must be an ndarray, or a scalar"
-#~ msgstr "höger sida måste vara en ndarray, eller en scalar"
-
-#~ msgid "shape must be a 2-tuple"
-#~ msgstr "shape måste vara en 2-tupel"
-
-#~ msgid "sorted axis can't be longer than 65535"
-#~ msgstr "sorterad axel kan inte vara längre än 65535"
-
-#~ msgid "wrong argument type"
-#~ msgstr "fel typ av argument"
-
-#~ msgid "specify size or data, but not both"
-#~ msgstr "ange storlek eller data, men inte båda"
-
-#~ msgid "Must provide SCK pin"
-#~ msgstr "Måste ange SCK-pinne"
-
-#~ msgid ""
-#~ "\n"
-#~ "To exit, please reset the board without "
-#~ msgstr ""
-#~ "\n"
-#~ "För att avsluta, gör reset på kortet utan "
-
-#~ msgid "PulseOut not supported on this chip"
-#~ msgstr "PulseIn stöds inte av detta chip"
-
-#~ msgid "tuple/list required on RHS"
-#~ msgstr "tupel/lista krävs för RHS"
-
-#~ msgid "'%s' object cannot assign attribute '%q'"
-#~ msgstr "Objektet '%s' kan inte tilldela attributet '%q'"
-
-#~ msgid "'%s' object does not support '%q'"
-#~ msgstr "Objektet '%s' har inte stöd för '%q'"
-
-#~ msgid "'%s' object does not support item assignment"
-#~ msgstr "Objektet '%s' stöder inte tilldelningen"
-
-#~ msgid "'%s' object does not support item deletion"
-#~ msgstr "Objektet '%s' stöder inte borttagning av objekt"
-
-#~ msgid "'%s' object is not an iterator"
-#~ msgstr "Objektet '%s' är inte en iterator"
-
-#~ msgid "'%s' object is not callable"
-#~ msgstr "Objektet '%s' kan inte anropas"
-
-#~ msgid "'%s' object is not iterable"
-#~ msgstr "Objektet '%s' är inte itererable"
-
-#~ msgid "'%s' object is not subscriptable"
-#~ msgstr "Objektet '%s' är inte indexbar"
-
-#~ msgid "Invalid I2C pin selection"
-#~ msgstr "Ogiltigt val av I2C-pinne"
-
-#~ msgid "Invalid SPI pin selection"
-#~ msgstr "Ogiltigt val av SPI-pinne"
-
-#~ msgid "Invalid UART pin selection"
-#~ msgstr "Ogiltigt val av UART-pinne"
-
-#~ msgid "Pop from an empty Ps2 buffer"
-#~ msgstr "Pop från en tom Ps2-buffert"
-
-#~ msgid "Running in safe mode! Auto-reload is off.\n"
-#~ msgstr "Kör i säkert läge! Autoladdning är avstängd.\n"
-
-#~ msgid "can't convert address to int"
-#~ msgstr "kan inte konvertera address till int"
-
-#~ msgid "object '%s' is not a tuple or list"
-#~ msgstr "objektet '%s' är inte en tupel eller lista"
+#~ msgid "polygon can only be registered in one parent"
+#~ msgstr "polygon kan endast registreras i en förälder"
 
 #~ msgid "pop from an empty set"
 #~ msgstr "pop från en tom uppsättning"
@@ -6064,44 +5905,184 @@ msgstr "zi måste vara i formen (n_section, 2)"
 #~ msgid "popitem(): dictionary is empty"
 #~ msgstr "popitem(): ordlistan är tom"
 
+#~ msgid "pressing BOOT button at start up.\n"
+#~ msgstr "genom att trycka på BOOT-knappen vid start.\n"
+
+#~ msgid "pressing SW38 button at start up.\n"
+#~ msgstr "genom att trycka på SW38-knappen vid start.\n"
+
+#~ msgid "pressing VOLUME button at start up.\n"
+#~ msgstr "genom att trycka på VOLUME-knappen vid start.\n"
+
+#~ msgid "pressing boot button at start up.\n"
+#~ msgstr "genom att trycka på startknappen vid start.\n"
+
+#~ msgid "pressing both buttons at start up.\n"
+#~ msgstr "genom att trycka båda knapparna vid uppstart.\n"
+
+#~ msgid "pressing button A at start up.\n"
+#~ msgstr "genom att tryck på knappen A vid start.\n"
+
+#~ msgid "pressing central button at start up.\n"
+#~ msgstr "trycka på mittknappen vid start.\n"
+
+#~ msgid "pressing the left button at start up\n"
+#~ msgstr "genom att håll ner vänster knapp vid start\n"
+
+#~ msgid "pull_threshold must be between 1 and 32"
+#~ msgstr "pull_threshold måste vara mellan 1 och 32"
+
+#~ msgid "push_threshold must be between 1 and 32"
+#~ msgstr "push_threshold måste vara mellan 1 och 32"
+
+#~ msgid "queue overflow"
+#~ msgstr "köstorlek överskreds"
+
+#~ msgid "raw REPL; CTRL-B to exit\n"
+#~ msgstr "rå REPL. CTRL-B för att avsluta\n"
+
+#~ msgid "raw f-strings are not implemented"
+#~ msgstr "råa f-strängar inte implementerade"
+
+#~ msgid "right hand side must be an ndarray, or a scalar"
+#~ msgstr "höger sida måste vara en ndarray, eller en scalar"
+
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "sample_source buffert måste vara en bytearray eller matris av typ 'h', "
+#~ "'H', 'b' eller 'B'"
+
+#~ msgid "schedule stack full"
+#~ msgstr "schemastack full"
+
+#~ msgid "shape must be a 2-tuple"
+#~ msgstr "shape måste vara en 2-tupel"
+
+#~ msgid "shape must be a tuple"
+#~ msgstr "shape måste vara en tuple"
+
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "Enkelt '}' påträffades i formatsträngen"
+
+#~ msgid "slice step can't be zero"
+#~ msgstr "segmentsteg kan inte vara noll"
+
+#~ msgid "slice step cannot be zero"
+#~ msgstr "segmentsteg kan inte vara noll"
+
+#~ msgid "sorted axis can't be longer than 65535"
+#~ msgstr "sorterad axel kan inte vara längre än 65535"
+
+#~ msgid "specify size or data, but not both"
+#~ msgstr "ange storlek eller data, men inte båda"
+
+#~ msgid "ssid can't be more than 32 bytes"
+#~ msgstr "ssid kan vara max 32 bytes"
+
+#~ msgid "start_x should be an int"
+#~ msgstr "start_x ska vara en int"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "step måste vara icke-noll"
+
+#~ msgid "stop must be 1 or 2"
+#~ msgstr "stop måste vara 1 eller 2"
+
+#~ msgid "string indices must be integers, not %q"
+#~ msgstr "strängindex måste vara heltal, inte %q"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr "sträng stöds inte; använd bytes eller bytearray"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "struct: kan inte indexera"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "tröskelvärdet måste ligga i intervallet 0-65536"
+
+#~ msgid "tile must be greater than zero"
+#~ msgstr "tile måste vara större än noll"
+
+#~ msgid "time.struct_time() takes a 9-sequence"
+#~ msgstr "time.struct_time() kräver en 9-sekvens"
+
+#~ msgid "timeout must be 0.0-100.0 seconds"
+#~ msgstr "timeout måste vara 0.0-100.0 sekunder"
+
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "timeout måste vara >= 0.0"
+
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "för många argument för det givna formatet"
+
+#~ msgid "trapz is defined for 1D arrays"
+#~ msgstr "trapz är definierat för 1D-matriser"
+
+#~ msgid "trigger level must be 0 or 1"
+#~ msgstr "triggernivå måste vara 0 eller 1"
+
+#~ msgid "tuple index out of range"
+#~ msgstr "tupelindex utanför intervallet"
+
+#~ msgid "tuple/list required on RHS"
+#~ msgstr "tupel/lista krävs för RHS"
+
+#~ msgid "type object 'generator' has no attribute '__await__'"
+#~ msgstr "typobjekt 'generator' har inget attribut '__await__'"
+
+#~ msgid "unindent does not match any outer indentation level"
+#~ msgstr "indentering inte matchar någon yttre indenteringsnivå"
+
 #~ msgid "unknown format code '%c' for object of type '%s'"
 #~ msgstr "okänt format '%c' för objekt av typ '%s'"
+
+#~ msgid "unmatched '{' in format"
+#~ msgstr "omatchad '{' i format"
+
+#~ msgid "unsupported type for %q: '%q'"
+#~ msgstr "typen %q stöder inte '%q'"
 
 #~ msgid "unsupported types for %q: '%s', '%s'"
 #~ msgstr "typ som inte stöds för %q: '%s', '%s'"
 
-#~ msgid "'%q' object is not bytes-like"
-#~ msgstr "%q-objektet är inte byte-lik"
+#~ msgid "value_count must be > 0"
+#~ msgstr "value_count måste vara > 0"
 
-#~ msgid "'async for' or 'async with' outside async function"
-#~ msgstr "'async for' eller 'async with' utanför async-funktion"
+#~ msgid "vectors must have same lengths"
+#~ msgstr "vektorer måste ha samma längd"
 
-#~ msgid "PulseIn not supported on this chip"
-#~ msgstr "PulseIn stöds inte av detta chip"
+#~ msgid "wakeup conflict"
+#~ msgstr "wakeup-konflikt"
 
-#~ msgid "I2C operation not supported"
-#~ msgstr "I2C-åtgärd stöds inte"
+#~ msgid "watchdog not initialized"
+#~ msgstr "watchdog är inte initierad"
 
-#~ msgid "Negative step not supported"
-#~ msgstr "Negativt step stöds inte"
+#~ msgid "watchdog timeout must be greater than 0"
+#~ msgstr "watchdog timeout måste vara större än 0"
 
-#~ msgid "bits must be 8"
-#~ msgstr "bits måste vara 8"
+#, c-format
+#~ msgid "width must be from 2 to 8 (inclusive), not %d"
+#~ msgstr "width måste vara mellan 2 och 8, inte %d"
 
-#~ msgid "buffers must be the same length"
-#~ msgstr "buffertar måste vara samma längd"
+#~ msgid "wrong argument type"
+#~ msgstr "fel typ av argument"
 
-#~ msgid "empty %q list"
-#~ msgstr "tom %q-lista"
+#~ msgid "wrong operand type"
+#~ msgstr "fel operandtyp"
 
-#~ msgid "firstbit must be MSB"
-#~ msgstr "firstbit måste vara MSB"
+#~ msgid "x value out of bounds"
+#~ msgstr "x-värde utanför intervall"
 
-#~ msgid "invalid I2C peripheral"
-#~ msgstr "ogiltig I2C-kringutrustning"
+#~ msgid "xTaskCreate failed"
+#~ msgstr "xTaskCreate misslyckades"
 
-#~ msgid "invalid SPI peripheral"
-#~ msgstr "ogiltig SPI-kringutrustning"
+#~ msgid "y should be an int"
+#~ msgstr "y ska vara en int"
 
-#~ msgid "must specify all of sck/mosi/miso"
-#~ msgstr "måste ange alla av sck/mosi/miso"
+#~ msgid "y value out of bounds"
+#~ msgstr "y-värde utanför intervall"
+
+#~ msgid "zero step"
+#~ msgstr "noll steg"

--- a/locale/synthetic.pot
+++ b/locale/synthetic.pot
@@ -3,6 +3,10 @@ msgid "en_US"
 msgstr ""
 
 # This string should never be translated, but for technical reasons it has to appear as an MP_ERROR_TEXT
+msgid "%02X"
+msgstr ""
+
+# This string should never be translated, but for technical reasons it has to appear as an MP_ERROR_TEXT
 msgid "%S"
 msgstr ""
 

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -78,16 +78,6 @@ msgstr " çıktı:\n"
 msgid "%%c requires int or char"
 msgstr "%%c int veya char tipine ihtiyaç duyar"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
@@ -95,26 +85,6 @@ msgid ""
 msgstr ""
 "%d adres pinleri, %d RGB pinleri ve %d döşemeleri %d'nin yüksekliği "
 "gösterir, %d'nin değil"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -297,11 +267,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
-msgstr ""
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
 msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
@@ -1621,7 +1586,8 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
 msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
@@ -4421,6 +4387,66 @@ msgstr ""
 msgid "zi must be of shape (n_section, 2)"
 msgstr ""
 
+#~ msgid ""
+#~ "\n"
+#~ "Code stopped by auto-reload.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Program otomatik yeniden yükleme tarafından sonlandırıldı.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Lütfen, şu adrese CIRCUITPY sürücünüzün içerikleri ile beraber bir hata/"
+#~ "konu kaydı ekleyin\n"
+#~ "https://github.com/adafruit/circuitpython/issues\n"
+
+#, c-format
+#~ msgid "%02X"
+#~ msgstr "%02X"
+
+#~ msgid "%q"
+#~ msgstr "%q"
+
+#~ msgid "%q length must be >= 1"
+#~ msgstr "%q boyutu >=1 olmalıdır"
+
+#~ msgid "%q must be >= 0"
+#~ msgstr "%q >= 0 olmalıdır"
+
+#~ msgid "%q must be >= 1"
+#~ msgstr "%q >= 1 olmalıdır"
+
+#~ msgid "%q must be a string"
+#~ msgstr "%q bir string olmalıdır"
+
+#~ msgid "%q must be a tuple of length 2"
+#~ msgstr "%q, boyutu 2 olan bir tuple olmalıdır"
+
+#~ msgid "%q must be an int"
+#~ msgstr "%q bir tam sayı olmalıdır"
+
+#~ msgid "%q must be between %d and %d"
+#~ msgstr "%q, %d ile %d arasında olmalıdır"
+
+#~ msgid "%q must be of type %q"
+#~ msgstr "%q, %q türünde olmalıdır"
+
+#~ msgid "%q must be of type %q or None"
+#~ msgstr "%q, %q ya da None türünde olmalıdır"
+
+#~ msgid "%q pin invalid"
+#~ msgstr "%q pini geçersiz"
+
+#~ msgid "%q should be an int"
+#~ msgstr "%q bir int olmalıdır"
+
+#~ msgid "%q with a report ID of 0 must be of length 1"
+#~ msgstr "Rapor kimliği 0 olan %q, 1 uzunluğunda olmalıdır"
+
 #~ msgid "'await', 'async for' or 'async with' outside async function"
 #~ msgstr ""
 #~ "asenkron fonksiyon dışında kullanılan 'await', 'async for' ya da 'async "
@@ -4432,23 +4458,102 @@ msgstr ""
 #~ msgid "'continue' outside loop"
 #~ msgstr "döngü dışında 'continue'"
 
-#~ msgid "Bit clock and word select must be sequential pins"
-#~ msgstr "Bit saati ve kelime seçimi pinleri sıralı olmalıdır"
+#~ msgid "'coroutine' object is not an iterator"
+#~ msgstr "'coroutine' nesnesi bir iteratör değildir"
 
-#~ msgid "Initialization failed due to lack of memory"
-#~ msgstr "Bellek yetersizliği nedeniyle başlatma başarısız oldu"
+#~ msgid "(x,y) integers required"
+#~ msgstr "(x, y) integerları gereklidir"
+
+#~ msgid "64 bit types"
+#~ msgstr "64 bit tipler"
 
 #~ msgid "ADC2 is being used by WiFi"
 #~ msgstr "ADC2, WiFi tarafından kullanılmaktadır"
 
-#~ msgid "'coroutine' object is not an iterator"
-#~ msgstr "'coroutine' nesnesi bir iteratör değildir"
+#~ msgid "Address type out of range"
+#~ msgstr "Adres tipi beklenen aralığın dışında"
+
+#~ msgid "All I2C targets are in use"
+#~ msgstr "Tüm I2C hedefleri kullanımda"
+
+#~ msgid "AnalogIn not supported on given pin"
+#~ msgstr "Verilen pin için AnalogIn desteklenmemektedir"
+
+#~ msgid "AnalogOut functionality not supported"
+#~ msgstr "AnalogOut işlevi desteklenmemektedir"
+
+#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#~ msgstr "AnalogOut yalnızca 16 bitlik. Değer 65536'dan küçük olmalıdır."
+
+#~ msgid "AnalogOut not supported on given pin"
+#~ msgstr "Verilen pin için AnalogOut desteklenmemektedir"
+
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "En az %d %q belirtilmeli (%d değil)"
+
+#~ msgid "Attempted heap allocation when VM not running."
+#~ msgstr "VM çalışmazken heap'ten alan tahsis edilmeye çalışıldı."
+
+#~ msgid "Bit clock and word select must be sequential pins"
+#~ msgstr "Bit saati ve kelime seçimi pinleri sıralı olmalıdır"
+
+#, c-format
+#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
+#~ msgstr "Bit derinliği 1-6 aralığında olmalı, %d değil"
+
+#~ msgid "Boot device must be first device (interface #0)."
+#~ msgstr "Önyükleme cihazı ilk cihaz olmalı (arayüz #0)."
+
+#~ msgid "Both buttons were pressed at start up.\n"
+#~ msgstr "Başlatma sırasında her iki düğmeye de basıldı.\n"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "Parlaklık 0-1.0 aralığında olmalı"
+
+#, c-format
+#~ msgid "Buffer incorrect size. Should be %d bytes."
+#~ msgstr "Geçersiz arabellek boyutu. %d kadar olmalı"
 
 #~ msgid "Buffer is too small"
 #~ msgstr "Arabellek çok küçük"
 
+#~ msgid "Buffer must be at least length 1"
+#~ msgstr "Arabellek boyutu en az 1 olmalı"
+
+#~ msgid "Button A was pressed at start up.\n"
+#~ msgstr "Başlatma sırasında A düğmesine basıldı.\n"
+
+#~ msgid "Bytes must be between 0 and 255."
+#~ msgstr "Baytlar 0-255 aralığında olmalı"
+
+#~ msgid "Cannot transfer without MOSI and MISO pins"
+#~ msgstr "MOSI ve MISO pinleri olmadan transfer edilemiyor"
+
 #~ msgid "Corrupt .mpy file"
 #~ msgstr "Bozuk .mpy dosyası"
+
+#, c-format
+#~ msgid "Error in MIDI stream at position %d"
+#~ msgstr "%d konumundaki MIDI akışında hata"
+
+#~ msgid "Expected a %q"
+#~ msgstr "%q bekleniyor"
+
+#~ msgid "Expected a %q or %q"
+#~ msgstr "%q yada %q bekleniyor"
+
+#~ msgid "Expected an %q"
+#~ msgstr "%q bekleniyor"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Donanım meşgul, alternatif pinleri deneyin"
+
+#~ msgid "I2SOut not available"
+#~ msgstr "I2SOut uygundeğil"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IV %d bayt uzunluğunda olmalı"
 
 #~ msgid ""
 #~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
@@ -4456,6 +4561,9 @@ msgstr ""
 #~ msgstr ""
 #~ "Uyumsuz .mpy dosyası. Lütfen tüm .mpy dosyalarını güncelleyin. Daha fazla "
 #~ "bilgi için http://adafru.it/mpy-update ."
+
+#~ msgid "Initialization failed due to lack of memory"
+#~ msgstr "Bellek yetersizliği nedeniyle başlatma başarısız oldu"
 
 #, c-format
 #~ msgid "Instruction %d shifts in more bits than pin count"
@@ -4473,11 +4581,12 @@ msgstr ""
 #~ msgid "Instruction %d waits on input outside of count"
 #~ msgstr "Komut %d sayım dışında, girişte bekler"
 
-#~ msgid "Cannot transfer without MOSI and MISO pins"
-#~ msgstr "MOSI ve MISO pinleri olmadan transfer edilemiyor"
+#~ msgid "Invalid memory access."
+#~ msgstr "Geçersiz bellek erişimi."
 
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Donanım meşgul, alternatif pinleri deneyin"
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "İkizlendiğinde maksimum x değeri %d'dir"
 
 #~ msgid "Missing MISO or MOSI Pin"
 #~ msgstr "Eksik MISO veya MOSI pini"
@@ -4502,139 +4611,3 @@ msgstr ""
 
 #~ msgid "No TX pin"
 #~ msgstr "TX pini yok"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "Parlaklık 0-1.0 aralığında olmalı"
-
-#, c-format
-#~ msgid "Error in MIDI stream at position %d"
-#~ msgstr "%d konumundaki MIDI akışında hata"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "İkizlendiğinde maksimum x değeri %d'dir"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "I2SOut uygundeğil"
-
-#~ msgid "64 bit types"
-#~ msgstr "64 bit tipler"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "%q pini geçersiz"
-
-#~ msgid ""
-#~ "\n"
-#~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
-#~ "https://github.com/adafruit/circuitpython/issues\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Lütfen, şu adrese CIRCUITPY sürücünüzün içerikleri ile beraber bir hata/"
-#~ "konu kaydı ekleyin\n"
-#~ "https://github.com/adafruit/circuitpython/issues\n"
-
-#~ msgid "Attempted heap allocation when VM not running."
-#~ msgstr "VM çalışmazken heap'ten alan tahsis edilmeye çalışıldı."
-
-#~ msgid "Boot device must be first device (interface #0)."
-#~ msgstr "Önyükleme cihazı ilk cihaz olmalı (arayüz #0)."
-
-#~ msgid "Both buttons were pressed at start up.\n"
-#~ msgstr "Başlatma sırasında her iki düğmeye de basıldı.\n"
-
-#~ msgid "Button A was pressed at start up.\n"
-#~ msgstr "Başlatma sırasında A düğmesine basıldı.\n"
-
-#~ msgid "Invalid memory access."
-#~ msgstr "Geçersiz bellek erişimi."
-
-#~ msgid "%q must be of type %q"
-#~ msgstr "%q, %q türünde olmalıdır"
-
-#~ msgid "%q must be of type %q or None"
-#~ msgstr "%q, %q ya da None türünde olmalıdır"
-
-#~ msgid "Expected a %q"
-#~ msgstr "%q bekleniyor"
-
-#~ msgid "Expected a %q or %q"
-#~ msgstr "%q yada %q bekleniyor"
-
-#~ msgid "Expected an %q"
-#~ msgstr "%q bekleniyor"
-
-#, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IV %d bayt uzunluğunda olmalı"
-
-#~ msgid "%q length must be >= 1"
-#~ msgstr "%q boyutu >=1 olmalıdır"
-
-#~ msgid "%q must be a string"
-#~ msgstr "%q bir string olmalıdır"
-
-#~ msgid "%q must be an int"
-#~ msgstr "%q bir tam sayı olmalıdır"
-
-#~ msgid "%q with a report ID of 0 must be of length 1"
-#~ msgstr "Rapor kimliği 0 olan %q, 1 uzunluğunda olmalıdır"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "En az %d %q belirtilmeli (%d değil)"
-
-#~ msgid "%q must be >= 0"
-#~ msgstr "%q >= 0 olmalıdır"
-
-#~ msgid "%q must be >= 1"
-#~ msgstr "%q >= 1 olmalıdır"
-
-#~ msgid "All I2C targets are in use"
-#~ msgstr "Tüm I2C hedefleri kullanımda"
-
-#~ msgid "%q must be a tuple of length 2"
-#~ msgstr "%q, boyutu 2 olan bir tuple olmalıdır"
-
-#~ msgid "%q must be between %d and %d"
-#~ msgstr "%q, %d ile %d arasında olmalıdır"
-
-#~ msgid "%q should be an int"
-#~ msgstr "%q bir int olmalıdır"
-
-#~ msgid "(x,y) integers required"
-#~ msgstr "(x, y) integerları gereklidir"
-
-#~ msgid "Address type out of range"
-#~ msgstr "Adres tipi beklenen aralığın dışında"
-
-#~ msgid "AnalogIn not supported on given pin"
-#~ msgstr "Verilen pin için AnalogIn desteklenmemektedir"
-
-#~ msgid "AnalogOut functionality not supported"
-#~ msgstr "AnalogOut işlevi desteklenmemektedir"
-
-#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-#~ msgstr "AnalogOut yalnızca 16 bitlik. Değer 65536'dan küçük olmalıdır."
-
-#~ msgid "AnalogOut not supported on given pin"
-#~ msgstr "Verilen pin için AnalogOut desteklenmemektedir"
-
-#, c-format
-#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
-#~ msgstr "Bit derinliği 1-6 aralığında olmalı, %d değil"
-
-#, c-format
-#~ msgid "Buffer incorrect size. Should be %d bytes."
-#~ msgstr "Geçersiz arabellek boyutu. %d kadar olmalı"
-
-#~ msgid "Buffer must be at least length 1"
-#~ msgstr "Arabellek boyutu en az 1 olmalı"
-
-#~ msgid "Bytes must be between 0 and 255."
-#~ msgstr "Baytlar 0-255 aralığında olmalı"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code stopped by auto-reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Program otomatik yeniden yükleme tarafından sonlandırıldı.\n"

--- a/locale/zh_Latn_pinyin.po
+++ b/locale/zh_Latn_pinyin.po
@@ -31,8 +31,8 @@ msgid ""
 "Code stopped by auto-reload. Reloading soon.\n"
 msgstr ""
 "\n"
-"dài mǎ yīn zì dòng chóng xīn jiā zǎi ér tíng zhǐ. jí jiāng chóng xīn jiā zǎi."
-"\n"
+"dài mǎ yīn zì dòng chóng xīn jiā zǎi ér tíng zhǐ. jí jiāng chóng xīn jiā "
+"zǎi.\n"
 
 #: supervisor/shared/safe_mode.c
 msgid ""
@@ -84,16 +84,6 @@ msgstr " shūchū:\n"
 msgid "%%c requires int or char"
 msgstr "%%c xūyào zhěngshù huòzhě zìfú"
 
-#: main.c
-#, c-format
-msgid "%02X"
-msgstr "%02X"
-
-#: shared-module/os/getenv.c
-#, c-format
-msgid "%S"
-msgstr ""
-
 #: shared-bindings/rgbmatrix/RGBMatrix.c
 #, c-format
 msgid ""
@@ -101,26 +91,6 @@ msgid ""
 msgstr ""
 "%d de zhǐ yǐn jiǎo, %d rgb yǐn jiǎo hé %d qiē piàn biǎo shì %d de gāo dù, ér "
 "bù shì %d"
-
-#: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/audiobusio/I2SOut.c
-#: ports/espressif/common-hal/rtc/RTC.c
-#: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
-#: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c
-#: ports/nrf/common-hal/audiobusio/I2SOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
-#: ports/raspberrypi/common-hal/analogio/AnalogOut.c
-#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
-#: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
-#: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
-#: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
-#: shared-bindings/keypad/KeyMatrix.c shared-bindings/keypad/Keys.c
-#: shared-bindings/keypad/ShiftRegisterKeys.c
-msgid "%q"
-msgstr "%q"
 
 #: shared-bindings/microcontroller/Pin.c
 msgid "%q and %q contain duplicate pins"
@@ -305,11 +275,6 @@ msgstr "%q[%u] shǐyòng éwài de yǐnjiǎo"
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "%q[%u] waits on input outside of count"
 msgstr "%q[%u] děngdài jìshù zhīwài de shūrù"
-
-#: py/runtime.c
-#, c-format
-msgid "%s"
-msgstr "%s"
 
 #: ports/espressif/common-hal/espidf/__init__.c
 #, c-format
@@ -979,7 +944,8 @@ msgstr "Fāngxiàng shūrù shí qūdòng móshì méiyǒu shǐyòng."
 
 #: py/obj.c
 msgid "During handling of the above exception, another exception occurred:"
-msgstr "zài chǔ lǐ shàng shù yì cháng qī jiān, fā shēng le lìng yí gè yì cháng:"
+msgstr ""
+"zài chǔ lǐ shàng shù yì cháng qī jiān, fā shēng le lìng yí gè yì cháng:"
 
 #: shared-bindings/aesio/aes.c
 msgid "ECB only operates on 16 bytes at a time"
@@ -1636,8 +1602,9 @@ msgstr "hái hǎo"
 
 #: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/raspberrypi/common-hal/audiobusio/PDMIn.c
-msgid "Only 8 or 16 bit mono with "
-msgstr "Zhǐyǒu 8 huò 16 wèi dānwèi "
+#, c-format
+msgid "Only 8 or 16 bit mono with %dx oversampling supported."
+msgstr ""
 
 #: ports/espressif/common-hal/wifi/__init__.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
@@ -1839,8 +1806,8 @@ msgstr "àn rèn hé jiàn jìn rù REPL. shǐ yòng CTRL-D zhòng xīn jiā zǎ
 #: main.c
 msgid "Pretending to deep sleep until alarm, CTRL-C or file write.\n"
 msgstr ""
-"jiǎ zhuāng shēn dù shuì mián , zhí dào bào jǐng , CTRL-C huò wén jiàn xiě rù "
-".\n"
+"jiǎ zhuāng shēn dù shuì mián , zhí dào bào jǐng , CTRL-C huò wén jiàn xiě "
+"rù .\n"
 
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "Program does IN without loading ISR"
@@ -2824,7 +2791,8 @@ msgstr "wú fǎ fēn pèi xīn xíng zhuàng"
 
 #: extmod/ulab/code/ndarray_operators.c
 msgid "cannot cast output with casting rule"
-msgstr "wú fǎ shǐ yòng qiáng zhì zhuǎn huàn guī zé qiáng zhì zhuǎn huàn shū chū"
+msgstr ""
+"wú fǎ shǐ yòng qiáng zhì zhuǎn huàn guī zé qiáng zhì zhuǎn huàn shū chū"
 
 #: extmod/ulab/code/ndarray.c
 msgid "cannot convert complex to dtype"
@@ -2885,7 +2853,8 @@ msgstr ""
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a buffer, tuple, list, or int"
-msgstr "Yánsè huǎnchōng qū bìxū shì huǎnchōng qū, yuán zǔ, lièbiǎo huò zhěngshù"
+msgstr ""
+"Yánsè huǎnchōng qū bìxū shì huǎnchōng qū, yuán zǔ, lièbiǎo huò zhěngshù"
 
 #: shared-bindings/displayio/Palette.c
 msgid "color buffer must be a bytearray or array of type 'b' or 'B'"
@@ -3477,7 +3446,8 @@ msgstr "diédài méiyǒu shōuliǎn"
 
 #: py/objstr.c
 msgid "join expects a list of str/bytes objects consistent with self object"
-msgstr "tiānjiā yīgè fúhé zìshēn duìxiàng de zìfú chuàn/zì jié duìxiàng lièbiǎo"
+msgstr ""
+"tiānjiā yīgè fúhé zìshēn duìxiàng de zìfú chuàn/zì jié duìxiàng lièbiǎo"
 
 #: py/argcheck.c
 msgid "keyword argument(s) not implemented - use normal args instead"
@@ -4458,324 +4428,19 @@ msgstr "zi bìxū wèi fú diǎn xíng"
 msgid "zi must be of shape (n_section, 2)"
 msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 
-#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
-#~ msgstr "wú xiào CIRCUITPY_PYSTACK_SIZE\n"
-
-#~ msgid "Unable to allocate the heap."
-#~ msgstr "wú fǎ fēn pèi duī."
-
 #~ msgid ""
-#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
+#~ "\n"
+#~ "Code done running. Waiting for reload.\n"
 #~ msgstr ""
-#~ "espcamera.Camera xū yào pèi zhì bǎo liú de PSRAM. yǒu guān shuō míng, "
-#~ "qǐng cān yuè wén dàng."
-
-#~ msgid "'await', 'async for' or 'async with' outside async function"
-#~ msgstr ""
-#~ "'await', 'async for' huò 'async with' wèiyú yìbù (async) hánshù zhīwài"
-
-#~ msgid "'break' outside loop"
-#~ msgstr "'break' wèiyú xúnhuán zhīwài"
-
-#~ msgid "'continue' outside loop"
-#~ msgstr "'continue' wèiyú xúnhuán zhīwài"
-
-#~ msgid "invalid architecture"
-#~ msgstr "wú xiào de jià gòu"
-
-#~ msgid "unsupported type for %q: '%q'"
-#~ msgstr "%q de bù shòu zhīchí de lèixíng: '%q'"
-
-#~ msgid "Splitting with sub-captures"
-#~ msgstr "Yǔ zi bǔhuò fēnliè"
-
-#~ msgid "__init__() should return None, not '%q'"
-#~ msgstr "__Init __() yīnggāi fǎnhuí None, ér bùshì '%q'"
-
-#~ msgid "attributes not supported yet"
-#~ msgstr "shǔxìng shàngwèi zhīchí"
-
-#~ msgid "can't do truncated division of a complex number"
-#~ msgstr "bùnéng fēnjiě fùzá de shùzì"
-
-#~ msgid "cannot import name %q"
-#~ msgstr "wúfǎ dǎorù míngchēng %q"
-
-#~ msgid "cannot unambiguously get sizeof scalar"
-#~ msgstr "bù néng háo bù hán hu de dé dào dà xiǎo de lín"
-
-#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
-#~ msgstr "guānjiàn zì cānshù shàngwèi shíxiàn - qǐng shǐyòng chángguī cānshù"
-
-#~ msgid "length argument not allowed for this type"
-#~ msgstr "bù yǔnxǔ gāi lèixíng de chángdù cānshù"
-
-#~ msgid "offset out of bounds"
-#~ msgstr "piānlí biānjiè"
-
-#~ msgid "slice step can't be zero"
-#~ msgstr "qiēpiàn bù cháng bùnéng wéi líng"
-
-#~ msgid "string not supported; use bytes or bytearray"
-#~ msgstr "zìfú chuàn bù zhīchí; shǐyòng zì jié huò zì jié zǔ"
-
-#~ msgid "Bit clock and word select must be sequential pins"
-#~ msgstr "wèi shízhōng hé zì xuǎnzé bìxū shì liánxù de yǐn jiǎo"
-
-#~ msgid "Initialization failed due to lack of memory"
-#~ msgstr "yóu yú nèi cún bù zú, chū shǐ huà shī bài"
-
-#~ msgid "RAISE mode is not implemented"
-#~ msgstr "wèi shí xiàn tí shēng mó shì"
-
-#~ msgid "WatchDogTimer is not currently running"
-#~ msgstr "WatchDogTimer dāngqián wèi yùnxíng"
-
-#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
-#~ msgstr ""
-#~ "Yīdàn shèzhì wèi WatchDogMode.RESET, zé bùnéng gēnggǎi WatchDogTimer.Mode"
-
-#~ msgid "watchdog not initialized"
-#~ msgstr "wèi chū shǐ huà jiān shì qì"
-
-#~ msgid "ADC2 is being used by WiFi"
-#~ msgstr "ADC2 zhèngzài bèi WiFi shǐ yòng"
-
-#, c-format
-#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
-#~ msgstr "wú fǎ pèi zhì ADC DMA kòng zhì qì, cuò wù dài mǎ:%d"
-
-#, c-format
-#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
-#~ msgstr "wú fǎ chū shǐ huà ADC DMA kòng zhì qì, cuò wù dài mǎ:%d"
-
-#, c-format
-#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
-#~ msgstr "wú fǎ qǐ dòng ADC DMA kòng zhì qì, cuò wù dài mǎ:%d"
-
-#~ msgid "xTaskCreate failed"
-#~ msgstr "xTaskCreate shī bài"
-
-#~ msgid "Unable to write to address."
-#~ msgstr "Wú fǎ xiě rù dì zhǐ."
-
-#~ msgid "queue overflow"
-#~ msgstr "duìliè yìchū"
-
-#~ msgid "Stopping AP is not supported."
-#~ msgstr "bù zhī chí tíng zhǐ AP."
-
-#~ msgid "Wifi is in access point mode."
-#~ msgstr "Wú xiàn wǎng luò chǔ yú jiē rù diǎn mó shì."
-
-#~ msgid "Wifi is in station mode."
-#~ msgstr "Wú xiàn wǎng luò chǔ yú gōng zuò zhàn mó shì."
+#~ "\n"
+#~ "Dàimǎ yǐ wánchéng yùnxíng. Zhèngzài děngdài chóngxīn jiāzài.\n"
 
 #~ msgid ""
 #~ "\n"
-#~ "Please file an issue with your program at https://github.com/adafruit/"
-#~ "circuitpython/issues."
+#~ "Code stopped by auto-reload.\n"
 #~ msgstr ""
 #~ "\n"
-#~ "qǐng zài https://github.com/adafruit/circuitpython/issues tí jiāo nín de "
-#~ "chéng xù wèn tí."
-
-#~ msgid "'coroutine' object is not an iterator"
-#~ msgstr "'coroutine' duìxiàng búshì yígè diédàiqì"
-
-#~ msgid "Buffer is too small"
-#~ msgstr "Huǎnchōng qū tài xiǎo"
-
-#~ msgid "Fault detected by hardware."
-#~ msgstr "yìng jiàn jiǎn cè dào gù zhàng."
-
-#~ msgid "The power dipped. Make sure you are providing enough power."
-#~ msgstr "lì liàng xià jiàng le. què bǎo nín tí gòng zú gòu de diàn lì."
-
-#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
-#~ msgstr ""
-#~ "pixel_shader bìxū shì displayio.Palette huò displayio.ColorConverter"
-
-#~ msgid "Corrupt .mpy file"
-#~ msgstr "sǔnhuài de .mpy wénjiàn"
-
-#~ msgid ""
-#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
-#~ "it/mpy-update for more info."
-#~ msgstr ""
-#~ "Bù jiānróng.Mpy wénjiàn. Qǐng gēngxīn suǒyǒu.Mpy wénjiàn. Yǒuguān xiángxì "
-#~ "xìnxī, qǐng cānyuè http://Adafru.It/mpy-update."
-
-#~ msgid "can't convert to %q"
-#~ msgstr "wúfǎ zhuǎnhuàn wèi %q"
-
-#~ msgid "can't have multiple **x"
-#~ msgstr "wúfǎ yǒu duō gè **x"
-
-#~ msgid "can't have multiple *x"
-#~ msgstr "wúfǎ yǒu duō gè *x"
-
-#~ msgid "constant must be an integer"
-#~ msgstr "chángshù bìxū shì yīgè zhěngshù"
-
-#~ msgid "incompatible native .mpy architecture"
-#~ msgstr "bù jiān róng de yuán shēng .mpy jià gòu"
-
-#~ msgid "invalid format"
-#~ msgstr "wúxiào géshì"
-
-#~ msgid "keywords must be strings"
-#~ msgstr "guānjiàn zì bìxū shì zìfú chuàn"
-
-#~ msgid "non-keyword arg after */**"
-#~ msgstr "zài */** zhīhòu fēi guānjiàn cí cānshù"
-
-#~ msgid "non-keyword arg after keyword arg"
-#~ msgstr "guānjiàn zì cānshù zhīhòu de fēi guānjiàn zì cānshù"
-
-#, c-format
-#~ msgid "Instruction %d shifts in more bits than pin count"
-#~ msgstr "zhǐ lìng %d yí wèi chāo guò yǐn jiǎo jì shù"
-
-#, c-format
-#~ msgid "Instruction %d shifts out more bits than pin count"
-#~ msgstr "zhǐ lìng %d yí chū de wèi bǐ yǐn jiǎo shù duō"
-
-#, c-format
-#~ msgid "Instruction %d uses extra pin"
-#~ msgstr "zhǐ lìng %d shǐ yòng é wài de yǐn jiǎo"
-
-#, c-format
-#~ msgid "Instruction %d waits on input outside of count"
-#~ msgstr "zhǐ lìng %d děng dài jì shù zhī wài de shū rù"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
-#~ msgstr "shǒu xiān zài yǐn jiǎo zhōng quē shī. zhǐ lìng %d dú qǔ yǐn jiǎo"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
-#~ msgstr ""
-#~ "shǒu xiān zài yǐn jiǎo zhōng quē shī. zhǐ lìng %d cóng yǐn jiǎo yí wèi"
-
-#, c-format
-#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
-#~ msgstr ""
-#~ "shǒu xiān zài yǐn jiǎo zhōng quē shī. jī yú yǐn jiǎo de zhǐ lìng %d děng "
-#~ "dài"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
-#~ msgstr "xiān lòu chū yǐn jiǎo. zhǐ lìng %d yí chū dào yǐn jiǎo"
-
-#, c-format
-#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
-#~ msgstr "xiān lòu chū yǐn jiǎo. zhǐ lìng %d xiě rù yǐn jiǎo"
-
-#, c-format
-#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
-#~ msgstr "quē shǎo dì yī zǔ yǐn jiǎo. zhǐ lìng %d shè zhì yǐn jiǎo"
-
-#, c-format
-#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
-#~ msgstr "shī zōng de jmp_pin. zhǐ lìng %d zài yǐn jiǎo shàng tiào yuè"
-
-#~ msgid "inputs are not iterable"
-#~ msgstr "shū rù bù kě yí dòng"
-
-#~ msgid "Too many display busses"
-#~ msgstr "Xiǎnshì zǒngxiàn tài duōle"
-
-#~ msgid "Cannot transfer without MOSI and MISO pins"
-#~ msgstr "méiyǒu MOSI hé MISO yǐnjiǎo, wúfǎ chuánshū"
-
-#~ msgid "Hardware busy, try alternative pins"
-#~ msgstr "Yìngjiàn máng, qǐng chángshì qítā zhēnjiǎo"
-
-#~ msgid "Missing MISO or MOSI Pin"
-#~ msgstr "Quēshǎo MISO huò MOSI yǐn jiǎo"
-
-#~ msgid "Missing MISO or MOSI pin"
-#~ msgstr "quēshǎo MISO huò MOSI yǐn jiǎo"
-
-#~ msgid "No MISO Pin"
-#~ msgstr "Méiyǒu MISO yǐn jiǎo"
-
-#~ msgid "No MISO pin"
-#~ msgstr "wú MISO pin"
-
-#~ msgid "No MOSI Pin"
-#~ msgstr "Méiyǒu MOSI yǐn jiǎo"
-
-#~ msgid "No MOSI pin"
-#~ msgstr "wú MOSI pin"
-
-#~ msgid "No RX pin"
-#~ msgstr "Wèi zhǎodào RX yǐn jiǎo"
-
-#~ msgid "No TX pin"
-#~ msgstr "Wèi zhǎodào TX yǐn jiǎo"
-
-#~ msgid "no reset pin available"
-#~ msgstr "Méiyǒu kěyòng de fùwèi yǐn jiǎo"
-
-#~ msgid "Sleep Memory not available"
-#~ msgstr "shuì mián jì yì bù kě yòng"
-
-#~ msgid "input and output shapes are not compatible"
-#~ msgstr "shū rù hé shū chū xíng zhuàng bù jiān róng"
-
-#~ msgid "shape must be a tuple"
-#~ msgstr "xíng zhuàng bì xū shì yí gè yuán zǔ"
-
-#~ msgid "Brightness must be 0-1.0"
-#~ msgstr "Liàngdù bìxū wèi 0-1.0"
-
-#, c-format
-#~ msgid "Error in MIDI stream at position %d"
-#~ msgstr "wèi yú %d wèi zhì de MIDI liú zhōng de cuò wù"
-
-#, c-format
-#~ msgid "Maximum x value when mirrored is %d"
-#~ msgstr "Jìngxiàng shí de zuìdà X zhí wèi%d"
-
-#~ msgid "x value out of bounds"
-#~ msgstr "x zhí chāochū biānjiè"
-
-#~ msgid "y value out of bounds"
-#~ msgstr "y zhí chāochū biānjiè"
-
-#~ msgid "I2SOut not available"
-#~ msgstr "I2SOut bù kě yòng"
-
-#~ msgid "PDMIn not available"
-#~ msgstr "PDMIn bù kě yòng"
-
-#~ msgid "out of range of source"
-#~ msgstr "yuán fàn wéi wài"
-
-#~ msgid "pixel value requires too many bits"
-#~ msgstr "xiàngsù zhí xūyào tài duō wèi"
-
-#~ msgid "value_count must be > 0"
-#~ msgstr "zhí jìshù bìxū wèi > 0"
-
-#~ msgid "64 bit types"
-#~ msgstr "64 wèi lèixíng"
-
-#~ msgid "No key was specified"
-#~ msgstr "Wèi zhǐdìng mì yào"
-
-#~ msgid "Scan already in progess. Stop with stop_scan."
-#~ msgstr "Zhèngzài jìn háng sǎomiáo. Shǐyòng stop_scan tíngzhǐ."
-
-#, c-format
-#~ msgid "Unkown error code %d"
-#~ msgstr "wèi zhī cuò wù dài %d"
-
-#~ msgid "too many arguments provided with the given format"
-#~ msgstr "tígōng jǐ dìng géshì de cānshù tài duō"
+#~ "dàimǎ de yùnxíng yīnwéi zìdòng chóngxīn jiāzǎi ér tíngzhǐ.\n"
 
 #~ msgid ""
 #~ "\n"
@@ -4788,12 +4453,6 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ "\n"
 #~ "\n"
 
-#~ msgid "Supply at least one UART pin"
-#~ msgstr "Dìngyì zhìshǎo yīgè UART yǐn jiǎo"
-
-#~ msgid "%q pin invalid"
-#~ msgstr "%q yǐn jiǎo wúxiào"
-
 #~ msgid ""
 #~ "\n"
 #~ "Please file an issue with the contents of your CIRCUITPY drive at \n"
@@ -4803,758 +4462,21 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ "Qǐng tōngguò https://github.com/adafruit/circuitpython/issues\n"
 #~ "tíjiāo yǒuguān nín de CIRCUITPY qūdòngqì nèiróng de wèntí \n"
 
-#~ msgid "Attempted heap allocation when VM not running."
-#~ msgstr "shìtú zài xūnǐjī (VM) yùn xíng shí fēnpèi duī (heap)."
-
-#~ msgid "Boot device must be first device (interface #0)."
-#~ msgstr "yǐndǎo shèbèi bìxū shì dìyī tái shèbèi (interface #0)."
-
-#~ msgid "Both buttons were pressed at start up.\n"
-#~ msgstr "qǐ dòng shí àn xià le liǎng gè àn niǔ.\n"
-
-#~ msgid "Button A was pressed at start up.\n"
-#~ msgstr "qǐ dòng shí àn xià àn niǔ A.\n"
-
-#~ msgid "CircuitPython was unable to allocate the heap."
-#~ msgstr "CircuitPython wúfǎ fēnpèi duī."
-
-#~ msgid "Crash into the HardFault_Handler."
-#~ msgstr "gu4zhang4, jin4ru4 HardFault_Handler."
-
-#~ msgid "Fatal error."
-#~ msgstr "zhì mìng cuò wù."
-
-#~ msgid "Invalid memory access."
-#~ msgstr "Wúxiào de nèicún fǎngwèn."
-
-#~ msgid "Nordic system firmware failure assertion."
-#~ msgstr "běi ōu xì tǒng gù jiàn gù zhàng duàn yán."
-
-#~ msgid "The BOOT button was pressed at start up.\n"
-#~ msgstr "qǐ dòng shí àn xià le yǐn dǎo àn niǔ.\n"
-
 #~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Increase the stack size if you know how. If not:"
+#~ "\n"
+#~ "Please file an issue with your program at https://github.com/adafruit/"
+#~ "circuitpython/issues."
 #~ msgstr ""
-#~ "diàn lù dàn duī bèi sǔn huài, yīn wéi duī zhàn tài xiǎo.\n"
-#~ "rú guǒ nín zhī dào rú hé zēng jiā duī zhàn dà xiǎo. rú guǒ méi yǒu:"
-
-#~ msgid "The SW38 button was pressed at start up.\n"
-#~ msgstr "qǐ dòng shí àn xià le SW38 àn niǔ .\n"
-
-#~ msgid "The VOLUME button was pressed at start up.\n"
-#~ msgstr "qǐ dòng shí àn xià yīn liàng àn niǔ.\n"
-
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode."
-#~ msgstr ""
-#~ "`wēi kòng zhì qì` mó kuài yòng yú qǐ dòng dào ān quán mó shì. àn chóng "
-#~ "zhì tuì chū ān quán mó shì."
-
-#~ msgid "The central button was pressed at start up.\n"
-#~ msgstr "qǐ dòng shí àn xià zhōng yāng àn niǔ.\n"
-
-#~ msgid "The left button was pressed at start up.\n"
-#~ msgstr "qǐ dòng shí àn xià zuǒ àn niǔ.\n"
-
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY)."
-#~ msgstr ""
-#~ "wēi kòng zhì qì de gōng lǜ xià jiàng. què bǎo diàn yuán tí gòng\n"
-#~ "zú gòu de gōng lǜ yòng yú zhěng gè diàn lù hé àn chóng zhì (tán chū "
-#~ "CIRCUITPY hòu)."
-
-#~ msgid "To exit, please reset the board without requesting safe mode."
-#~ msgstr ""
-#~ "yào tuì chū, qǐng zài bù qǐng qiú ān quán mó shì de qíng kuàng xià chóng "
-#~ "zhì zhǔ bǎn."
-
-#~ msgid "You are in safe mode because:\n"
-#~ msgstr "nín chǔ yú ān quán mó shì, yīn wéi:\n"
-
-#~ msgid ""
-#~ "You pressed the reset button during boot. Press again to exit safe mode."
-#~ msgstr ""
-#~ "zài qǐ dòng guò chéng zhōng, nín àn xià le chóng zhì àn niǔ. zài cì àn "
-#~ "xià yǐ tuì chū ān quán mó shì."
-
-#~ msgid ""
-#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
-#~ "documentation for instructions."
-#~ msgstr ""
-#~ "esp32_camera. shè xiàng jī xū yào pèi zhì yù liú de PSRAM. yǒu guān shuō "
-#~ "míng, qǐng cān yuè wén dàng."
-
-#~ msgid "%q must be of type %q"
-#~ msgstr "%q bì xū shì %q lèi xíng"
-
-#~ msgid "%q must be of type %q or None"
-#~ msgstr "%q lèi xíng bì xū wéi %q huò wú"
-
-#~ msgid "Expected a %q"
-#~ msgstr "Yù qí %q"
-
-#~ msgid "Expected a %q or %q"
-#~ msgstr "yù qī wéi %q huò %q"
-
-#~ msgid "Expected an %q"
-#~ msgstr "yù qī wéi %q"
-
-#, c-format
-#~ msgid "IV must be %d bytes long"
-#~ msgstr "IV bì xū wéi %d zì jié cháng"
-
-#~ msgid "Not settable"
-#~ msgstr "bù kě shè zhì"
-
-#~ msgid "expected '%q' but got '%q'"
-#~ msgstr "yùqí wèi'%q'dàn dédàole'%q'"
-
-#~ msgid "expected '%q' or '%q' but got '%q'"
-#~ msgstr "yùqí wèi'%q'huò'%q', dàn huòdéle'%q'"
-
-#~ msgid "Read-only object"
-#~ msgstr "Zhǐ dú duìxiàng"
-
-#~ msgid "frequency is read-only for this board"
-#~ msgstr "cǐ zhǔ bǎn de pín lǜ wéi zhǐ dú"
-
-#~ msgid "Unable to write"
-#~ msgstr "wú fǎ xiě rù"
-
-#~ msgid "%q length must be >= 1"
-#~ msgstr "%q cháng dù bìxū >= 1"
-
-#~ msgid "%q must be a string"
-#~ msgstr "%q bìxū shì yí gè zì fú chuàn"
-
-#~ msgid "%q must be an int"
-#~ msgstr "%q bìxū shì zhěng xíng"
-
-#~ msgid "%q with a report ID of 0 must be of length 1"
-#~ msgstr "bào gào ID shì 0 de %q bì xū cháng dù wéi 1"
-
-#~ msgid "At most %d %q may be specified (not %d)"
-#~ msgstr "zuìduō kěyǐ zhǐdìng %d gè %q (érbúshì %d)"
-
-#~ msgid "Invalid pins"
-#~ msgstr "Wúxiào de yǐn jiǎo"
-
-#, c-format
-#~ msgid "No more than %d HID devices allowed"
-#~ msgstr "bù yǔn xǔ chāo guò %d HID shè bèi"
-
-#~ msgid "byteorder is not a string"
-#~ msgstr "byteorder bùshì zìfú chuàn"
-
-#~ msgid "can't convert %q to int"
-#~ msgstr "wú fǎ jiāng %q zhuǎn huàn wéi nèi zài"
-
-#~ msgid "complex division by zero"
-#~ msgstr "fùzá de fēngé wèi 0"
-
-#~ msgid "int() arg 2 must be >= 2 and <= 36"
-#~ msgstr "zhěngshù() cānshù 2 bìxū > = 2 qiě <= 36"
-
-#~ msgid "long int not supported in this build"
-#~ msgstr "cǐ bǎnběn bù zhīchí zhǎng zhěngshù"
-
-#~ msgid "slice step cannot be zero"
-#~ msgstr "qiēpiàn bù bùnéng wéi líng"
-
-#~ msgid "step must be non-zero"
-#~ msgstr "bùzhòu bìxū shìfēi líng"
-
-#~ msgid "string indices must be integers, not %q"
-#~ msgstr "zìfú chuàn suǒyǐn bìxū shì zhěngshù, ér bùshì %q"
-
-#~ msgid "time.struct_time() takes a 9-sequence"
-#~ msgstr "time.struct_time() xūyào 9 xùliè"
-
-#~ msgid "zero step"
-#~ msgstr "líng bù"
-
-#~ msgid "invalid traceback"
-#~ msgstr "wú xiào zhuī sù"
-
-#~ msgid "WatchDogTimer.timeout must be greater than 0"
-#~ msgstr "WatchDogTimer.Timeout bìxū dàyú 0"
-
-#~ msgid "non-Device in %q"
-#~ msgstr "fēi shè bèi zài %q"
-
-#~ msgid "single '}' encountered in format string"
-#~ msgstr "zài géshì zìfú chuàn zhōng yù dào de dāngè '}'"
-
-#~ msgid "threshold must be in the range 0-65536"
-#~ msgstr "yùzhí bìxū zài fànwéi 0-65536"
-
-#~ msgid "timeout must be 0.0-100.0 seconds"
-#~ msgstr "Chāo shí shíjiān bìxū wèi 0.0 Dào 100.0 Miǎo"
-
-#~ msgid "unmatched '{' in format"
-#~ msgstr "géshì wèi pǐpèi '{'"
-
-#~ msgid "watchdog timeout must be greater than 0"
-#~ msgstr "kān mén gǒu chāoshí bìxū dàyú 0"
-
-#~ msgid "To exit, please reset the board without "
-#~ msgstr "Yào tuìchū, qǐng chóng zhì bǎnkuài ér bùyòng "
-
-#~ msgid "You requested starting safe mode by "
-#~ msgstr "Nín qǐngqiú qǐdòng ānquán móshì "
-
-#~ msgid "pressing BOOT button at start up.\n"
-#~ msgstr "zài qǐdòng shí àn BOOT ànniǔ.\n"
-
-#~ msgid "pressing SW38 button at start up.\n"
-#~ msgstr "zài qǐdòng shí àn SW38 ànniǔ.\n"
-
-#~ msgid "pressing VOLUME button at start up.\n"
-#~ msgstr "zài qǐdòng shí àn SW38 ànniǔ.\n"
-
-#~ msgid "pressing boot button at start up.\n"
-#~ msgstr "Zài qǐdòng shí àn qǐdòng ànniǔ.\n"
-
-#~ msgid "pressing both buttons at start up.\n"
-#~ msgstr "zài qǐdòng shí tóngshí àn xià liǎng gè ànniǔ.\n"
-
-#~ msgid "pressing the left button at start up\n"
-#~ msgstr "qǐ dòng shí àn xià zuǒ àn niǔ\n"
-
-#~ msgid "Only one TouchAlarm can be set in deep sleep."
-#~ msgstr "zhǐ yǒu yí gè chù mō bì kě yǐ shè zhì zài shēn dù shuì mián."
-
-#~ msgid "Firmware image is invalid"
-#~ msgstr "gù jiàn yìng xiàng wú xiào"
-
-#~ msgid "Stream missing readinto() or write() method."
-#~ msgstr "Liú quēshǎo readinto() huò write() fāngfǎ."
-
-#~ msgid "%q must be >= 0"
-#~ msgstr "%q bìxū > = 0"
-
-#~ msgid "%q must be >= 1"
-#~ msgstr "%q bìxū >= 1"
-
-#~ msgid "address out of bounds"
-#~ msgstr "dìzhǐ chāochū biānjiè"
-
-#~ msgid "destination_length must be an int >= 0"
-#~ msgstr "mùbiāo chángdù bìxū shì > = 0 de zhěngshù"
-
-#~ msgid "type object 'generator' has no attribute '__await__'"
-#~ msgstr "lèi xíng duì xiàng 'generator' méi yǒu shǔ xìng '__await__'"
-
-#~ msgid "color should be an int"
-#~ msgstr "yánsè yīng wèi zhěngshù"
-
-#~ msgid "end_x should be an int"
-#~ msgstr "jiéwěi_x yīnggāi shì yīgè zhěngshù"
-
-#~ msgid "palette_index should be an int"
-#~ msgstr "yánsè suǒyǐn yīnggāi shì yīgè zhěngshù"
-
-#~ msgid "start_x should be an int"
-#~ msgstr "kāishǐ_x yīnggāi shì yīgè zhěngshù"
-
-#~ msgid "y should be an int"
-#~ msgstr "y yīnggāi shì yīgè zhěngshù"
-
-#~ msgid ""
-#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
-#~ "or 'B'"
-#~ msgstr ""
-#~ "yàngběn yuán_yuán huǎnchōng qū bìxū shì zì yǎnlèi huò lèixíng 'h', 'H', "
-#~ "'b' huò 'B' de shùzǔ"
-
-#~ msgid "Expected an alarm"
-#~ msgstr "yù qī yǒu jǐng bào"
-
-#~ msgid "All I2C targets are in use"
-#~ msgstr "suǒyǒu I2C mùbiāo dōu zài shǐyòng zhōng"
-
-#~ msgid "Failed to init wifi"
-#~ msgstr "Wúfǎ chūshǐhuà wifi"
-
-#~ msgid "input must be a tensor of rank 2"
-#~ msgstr "shū rù bì xū shì děng jí 2 de zhāng liàng"
-
-#~ msgid "maximum number of dimensions is 4"
-#~ msgstr "zuì dà chǐ cùn shù wéi 4"
-
-#~ msgid "Watchdog timer expired."
-#~ msgstr "Kān mén gǒu dìngshí qì yǐ guòqí."
-
-#~ msgid "ssid can't be more than 32 bytes"
-#~ msgstr "ssid bù néng chāo guò 32 gè zì jié"
-
-#~ msgid "%q must be a tuple of length 2"
-#~ msgstr "%q bìxū shì chángdù wèi 2 de yuánzǔ"
-
-#~ msgid "%q must be between %d and %d"
-#~ msgstr "%q bì xū zài %d hé %d zhī jiān"
-
-#~ msgid "%q should be an int"
-#~ msgstr "%q yīnggāi shì yīgè zhěngshù (int)"
-
-#~ msgid "(x,y) integers required"
-#~ msgstr "xūyào zhěngshù (x,y)"
-
-#~ msgid "Address type out of range"
-#~ msgstr "Dìzhǐ lèixíng chāochū fànwéi"
-
-#~ msgid "AnalogIn not supported on given pin"
-#~ msgstr "gěidìng de yǐnjiǎo bù zhīchí AnalogIn"
-
-#~ msgid "AnalogOut functionality not supported"
-#~ msgstr "Bù zhīchí AnalogOut gōngnéng"
-
-#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
-#~ msgstr "AnalogOut jǐn wèi 16 wèi. Zhí bìxū xiǎoyú 65536."
-
-#~ msgid "AnalogOut not supported on given pin"
-#~ msgstr "zhǐdìng de yǐn jiǎo bù zhīchí AnalogOut"
-
-#, c-format
-#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
-#~ msgstr "wèi shēndù bìxū shì 1 dào 6, ér búshì %d"
-
-#, c-format
-#~ msgid "Buffer incorrect size. Should be %d bytes."
-#~ msgstr "Huǎnchōng qū dàxiǎo bù zhèngquè. Yīnggāi shì %d zì jié."
-
-#~ msgid "Buffer must be at least length 1"
-#~ msgstr "Huǎnchōng qū bìxū zhìshǎo chángdù wéi 1"
-
-#~ msgid "Bytes must be between 0 and 255."
-#~ msgstr "Zìjié bìxū jiè yú 0 dào 255 zhījiān."
-
-#~ msgid "Cannot output both channels on the same pin"
-#~ msgstr "Wúfǎ shūchū tóng yīgè yǐn jiǎo shàng de liǎng gè píndào"
-
-#~ msgid "Cannot read without MISO pin."
-#~ msgstr "Wúfǎ dòu qǔ méiyǒu MISO de yǐn jiǎo."
-
-#~ msgid "Cannot reset into bootloader because no bootloader is present."
-#~ msgstr "Wúfǎ chóng zhì wèi bootloader, yīnwèi méiyǒu bootloader cúnzài."
-
-#~ msgid "Cannot transfer without MOSI and MISO pins."
-#~ msgstr "Méiyǒu MOSI/MISO jiù wúfǎ zhuǎnyí."
-
-#~ msgid "Cannot write without MOSI pin."
-#~ msgstr "Wúfǎ xiě rù MOSI de yǐn jiǎo."
-
-#~ msgid "Clock pin init failed."
-#~ msgstr "Shízhōng de yǐn jiǎo chūshǐhuà shībài."
-
-#~ msgid "Command must be an int between 0 and 255"
-#~ msgstr "Mìnglìng bìxū shì 0 dào 255 zhī jiān de int"
-
-#~ msgid "Could not initialize Camera"
-#~ msgstr "Wúfǎ chūshǐhuà xiàngjī"
-
-#~ msgid "Could not initialize GNSS"
-#~ msgstr "wú fǎ chū shǐ huà GNSS"
-
-#~ msgid "Could not initialize SDCard"
-#~ msgstr "wú fǎ chū shǐ huà SDCard"
-
-#~ msgid "Could not initialize UART"
-#~ msgstr "Wúfǎ chūshǐhuà UART"
-
-#~ msgid "Could not re-init channel"
-#~ msgstr "Wúfǎ chóngxīn chūshǐhuà píndào"
-
-#~ msgid "Could not re-init timer"
-#~ msgstr "Wúfǎ chóngxīn qǐdòng jìshí qì"
-
-#~ msgid "Could not restart PWM"
-#~ msgstr "Wúfǎ chóngqǐ PWM"
-
-#~ msgid "Couldn't allocate first buffer"
-#~ msgstr "Wúfǎ fēnpèi dì yī gè huǎnchōng qū"
-
-#~ msgid "Couldn't allocate input buffer"
-#~ msgstr "Wúfǎ fēnpèi shūrù huǎnchōng qū"
-
-#~ msgid "Couldn't allocate second buffer"
-#~ msgstr "Wúfǎ fēnpèi dì èr gè huǎnchōng qū"
-
-#~ msgid "DigitalInOut not supported on given pin"
-#~ msgstr "Gěi dìng de yǐn jiǎo bù zhīchí DigitalInOut"
-
-#, c-format
-#~ msgid "Expected tuple of length %d, got %d"
-#~ msgstr "Qīwàng de chángdù wèi %d de yuán zǔ, dédào %d"
-
-#~ msgid "Failed to allocate RX buffer"
-#~ msgstr "Fēnpèi RX huǎnchōng shībài"
-
-#, c-format
-#~ msgid "Failed to allocate RX buffer of %d bytes"
-#~ msgstr "Fēnpèi RX huǎnchōng qū%d zì jié shībài"
-
-#, c-format
-#~ msgid "Framebuffer requires %d bytes"
-#~ msgstr "zhēn huǎn chōng qū xū yào %d zì jié"
-
-#~ msgid "Hostname must be between 1 and 253 characters"
-#~ msgstr "zhǔ jī míng bì xū jiè yú 1 hé 253 gè zì fú zhī jiān"
-
-#~ msgid "I2C Init Error"
-#~ msgstr "I2C chūshǐhuà cuòwù"
-
-#~ msgid "Invalid %q pin selection"
-#~ msgstr "wú xiào %q yǐn jiǎo xuǎn zé"
-
-#~ msgid "Invalid AuthMode"
-#~ msgstr "wú xiào AuthMode"
-
-#~ msgid "Invalid BMP file"
-#~ msgstr "Wúxiào de BMP wénjiàn"
-
-#~ msgid "Invalid DAC pin supplied"
-#~ msgstr "Tí gōng liǎo wúxiào de DAC yǐn jiǎo"
-
-#~ msgid "Invalid MIDI file"
-#~ msgstr "wú xiào de MIDI wén jiàn"
-
-#~ msgid "Invalid PWM frequency"
-#~ msgstr "Wúxiào de PWM pínlǜ"
-
-#~ msgid "Invalid Pin"
-#~ msgstr "wú xiào yǐn jiǎo"
-
-#~ msgid "Invalid buffer size"
-#~ msgstr "Wúxiào de huǎnchōng qū dàxiǎo"
-
-#~ msgid "Invalid byteorder string"
-#~ msgstr "Wúxiào de zì jié shùnxù zìfú chuàn"
-
-#~ msgid "Invalid capture period. Valid range: 1 - 500"
-#~ msgstr "Wúxiào de bǔhuò zhōuqí. Yǒuxiào fànwéi: 1-500"
-
-#~ msgid "Invalid channel count"
-#~ msgstr "Wúxiào de tōngdào jìshù"
-
-#, c-format
-#~ msgid "Invalid data_count %d"
-#~ msgstr "wú xiào data_count %d"
-
-#~ msgid "Invalid direction."
-#~ msgstr "Wúxiào de fāngxiàng."
-
-#~ msgid "Invalid file"
-#~ msgstr "Wúxiào de wénjiàn"
-
-#~ msgid "Invalid mode"
-#~ msgstr "wú xiào mó shì"
-
-#~ msgid "Invalid number of bits"
-#~ msgstr "Wèi shù wúxiào"
-
-#~ msgid "Invalid phase"
-#~ msgstr "Jiēduàn wúxiào"
-
-#~ msgid "Invalid pin"
-#~ msgstr "Wúxiào de yǐn jiǎo"
-
-#~ msgid "Invalid pin for left channel"
-#~ msgstr "Zuǒ tōngdào de yǐn jiǎo wúxiào"
-
-#~ msgid "Invalid pin for right channel"
-#~ msgstr "Yòuxián tōngdào yǐn jiǎo wúxiào"
-
-#~ msgid "Invalid polarity"
-#~ msgstr "Wúxiào liǎng jí zhí"
-
-#~ msgid "Invalid properties"
-#~ msgstr "Wúxiào de shǔxìng"
-
-#~ msgid "Invalid run mode."
-#~ msgstr "Wúxiào de yùnxíng móshì."
-
-#~ msgid "Invalid security_mode"
-#~ msgstr "Ānquán móshì wúxiào"
-
-#~ msgid "Invalid voice"
-#~ msgstr "Yǔyīn wúxiào"
-
-#~ msgid "Invalid voice count"
-#~ msgstr "Wúxiào de yǔyīn jìshù"
-
-#~ msgid "Invalid wave file"
-#~ msgstr "Wúxiào de làng làngcháo wénjiàn"
-
-#~ msgid "Invalid word/bit length"
-#~ msgstr "Wúxiào de zì/wèi chángdù"
-
-#~ msgid "Layer already in a group."
-#~ msgstr "Tú céng yǐjīng zài yīgè zǔ zhōng."
-
-#~ msgid "Layer must be a Group or TileGrid subclass."
-#~ msgstr "Layer bìxū shì Group huò TileGrid zi lèi."
-
-#~ msgid "MISO pin init failed."
-#~ msgstr "MISO yǐn jiǎo chūshǐhuà shībài."
-
-#~ msgid "MOSI pin init failed."
-#~ msgstr "MOSI yǐn jiǎo shūrù shībài."
-
-#~ msgid "Messages limited to 8 bytes"
-#~ msgstr "Yóujiàn xiànzhì wèi 8 gè zì jié"
-
-#, c-format
-#~ msgid "More than %d report ids not supported"
-#~ msgstr "chāo guò %d bào gào bù zhī chí de ID"
-
-#~ msgid "No hardware support on clk pin"
-#~ msgstr "Shízhōng yǐn jiǎo wú yìngjiàn zhīchí"
-
-#~ msgid "No hardware support on pin"
-#~ msgstr "Méiyǒu zài yǐn jiǎo shàng de yìngjiàn zhīchí"
-
-#, c-format
-#~ msgid "Output buffer must be at least %d bytes"
-#~ msgstr "shū chū huǎn chōng qū bì xū zhì shǎo wéi %d zì jié"
-
-#~ msgid ""
-#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
-#~ msgstr ""
-#~ "PWM yìwù zhōuqí bìxū jiè yú 0 zhì 65535 de bāoróng xìng (16 wèi fēnbiàn "
-#~ "lǜ)"
-
-#~ msgid "Pin count must be at least 1"
-#~ msgstr "yǐn jiǎo jì shù bì xū zhì shǎo wéi 1"
-
-#~ msgid "Pin does not have ADC capabilities"
-#~ msgstr "Pin méiyǒu ADC nénglì"
-
-#~ msgid "Program must contain at least one 16-bit instruction."
-#~ msgstr "chéng xù bì xū zhì shǎo bāo hán yí gè 16 wèi zhǐ lìng ."
-
-#~ msgid "Program too large"
-#~ msgstr "chéng xù tài dà"
-
-#~ msgid "RS485 Not yet supported on this device"
-#~ msgstr "RS485 cǐ shè bèi shàng bù zhī chí"
-
-#~ msgid "RTC calibration is not supported on this board"
-#~ msgstr "Cǐ bǎn bù zhīchí RTC jiàozhǔn"
-
-#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
-#~ msgstr "RTS/CTS/RS485 gāi shèbèi shàng bù zhīchí"
-
-#~ msgid "SPI Init Error"
-#~ msgstr "SPI chūshǐhuà cuòwù"
-
-#~ msgid "SPI Re-initialization error"
-#~ msgstr "SPI chóngxīn chūshǐhuà cuòwù"
-
-#~ msgid "Sample rate must be positive"
-#~ msgstr "Cǎiyàng lǜ bìxū wèi zhèng shù"
-
-#, c-format
-#~ msgid "Sample rate too high. It must be less than %d"
-#~ msgstr "Cǎiyàng lǜ tài gāo. Tā bìxū xiǎoyú %d"
-
-#~ msgid "Set pin count must be between 1 and 5"
-#~ msgstr "shè zhì yǐn jiǎo shù bì xū jiè yú 1 hé 5 zhī jiān"
-
-#~ msgid "Side set pin count must be between 1 and 5"
-#~ msgstr "cè miàn shè zhì yǐn jiǎo shù bì xū jiè yú 1 hé 5 zhī jiān"
-
-#~ msgid "Stack size must be at least 256"
-#~ msgstr "Duīzhàn dàxiǎo bìxū zhìshǎo 256"
-
-#~ msgid "Tile value out of bounds"
-#~ msgstr "Píng pū zhí chāochū fànwéi"
-
-#~ msgid "UART Buffer allocation error"
-#~ msgstr "UART huǎnchōng qū fēnpèi cuòwù"
-
-#~ msgid "UART De-init error"
-#~ msgstr "UART qǔxiāo chūshǐhuà cuòwù"
-
-#~ msgid "UART Init Error"
-#~ msgstr "UART chūshǐhuà cuòwù"
-
-#~ msgid "UART Re-init error"
-#~ msgstr "UART chóngxīn chūshǐhuà cuòwù"
-
-#~ msgid "UART write error"
-#~ msgstr "UART xiě cuòwù"
-
-#~ msgid "Unsupported baudrate"
-#~ msgstr "Bù zhīchí de baudrate"
-
-#~ msgid "WiFi password must be between 8 and 63 characters"
-#~ msgstr "WiFi mìmǎ bìxū jiè yú 8 dào 63 gè zìfú zhī jiān"
-
-#~ msgid "bits must be in range 5 to 9"
-#~ msgstr "wèi bì xū zài fàn wéi nèi 5 zhì 9"
-
-#~ msgid "bytes > 8 bits not supported"
-#~ msgstr "zì jié > 8 wèi"
-
-#~ msgid "calibration value out of range +/-127"
-#~ msgstr "jiàozhǔn zhí chāochū fànwéi +/-127"
-
-#~ msgid "can only be registered in one parent"
-#~ msgstr "zhǐ néng zài yí gè jiā zhǎng zhōng zhù cè"
-
-#~ msgid "circle can only be registered in one parent"
-#~ msgstr "quānzi zhǐ néng zài yī wèi jiāzhǎng zhōng zhùcè"
-
-#~ msgid "max_connections must be between 0 and 10"
-#~ msgstr "max_connections bì xū jiè yú 0 hé 10 zhī jiān"
-
-#~ msgid "max_length must be >= 0"
-#~ msgstr "zuì dà cháng dù bì xū >= 0"
-
-#~ msgid "polygon can only be registered in one parent"
-#~ msgstr "duōbiānxíng zhī néng zài yīgè fù jí zhōng zhùcè"
-
-#~ msgid "pull_threshold must be between 1 and 32"
-#~ msgstr "lā lì yù zhí bì xū jiè yú 1 hé 32 zhī jiān"
-
-#~ msgid "push_threshold must be between 1 and 32"
-#~ msgstr "tuī sòng yù zhí bì xū jiè yú 1 hé 32 zhī jiān"
-
-#~ msgid "stop must be 1 or 2"
-#~ msgstr "tíngzhǐ bìxū wèi 1 huò 2"
-
-#~ msgid "tile must be greater than zero"
-#~ msgstr "cí tiē bì xū dà yú líng"
-
-#~ msgid "timeout must be >= 0.0"
-#~ msgstr "chāoshí bìxū shì >= 0.0"
-
-#, c-format
-#~ msgid "width must be from 2 to 8 (inclusive), not %d"
-#~ msgstr "kuān dù bì xū cóng 2 dào 8 ( hán ), ér bù shì %d"
-
-#~ msgid "Unsupported operation"
-#~ msgstr "Bù zhīchí de cāozuò"
-
-#~ msgid "divisor must be 4"
-#~ msgstr "èr chóng zòu bì xū shì 4"
+#~ "\n"
+#~ "qǐng zài https://github.com/adafruit/circuitpython/issues tí jiāo nín de "
+#~ "chéng xù wèn tí."
 
 #~ msgid ""
 #~ "\n"
-#~ "Code stopped by auto-reload.\n"
+#~ "To exit, please reset the board without "
 #~ msgstr ""
 #~ "\n"
-#~ "dàimǎ de yùnxíng yīnwéi zìdòng chóngxīn jiāzǎi ér tíngzhǐ.\n"
-
-#~ msgid "Brightness must be between 0 and 255"
-#~ msgstr "liàngdù bìxū jièyú 0 dào 255 zhījiān"
-
-#~ msgid "cannot perform relative import"
-#~ msgstr "wúfǎ zhíxíng xiāngguān dǎorù"
-
-#, c-format
-#~ msgid "No I2C device at address: %x"
-#~ msgstr "dì zhǐ wú I2C shè bèi: %x"
-
-#~ msgid "Unsupported pull value."
-#~ msgstr "Bù zhīchí de lādòng zhí."
-
-#~ msgid "%q must <= %d"
-#~ msgstr "%q bì xū <= %d"
-
-#, c-format
-#~ msgid ""
-#~ "Welcome to Adafruit CircuitPython %s!\n"
-#~ "\n"
-#~ "Please visit learn.adafruit.com/category/circuitpython for project "
-#~ "guides.\n"
-#~ "\n"
-#~ "To list built-in modules please do `help(\"modules\")`.\n"
-#~ msgstr ""
-#~ "Huānyíng lái dào Adafruit CircuitPython%s!\n"
-#~ "\n"
-#~ "Qǐng fǎngwèn learn.Adafruit.Com/category/circuitpython yǐ huòqǔ xiàngmù "
-#~ "zhǐnán.\n"
-#~ "\n"
-#~ "Yào liè chū nèizhì mókuài, qǐng zhíxíng `help(“modules”)`\n"
-
-#~ msgid "integer required"
-#~ msgstr "xūyào zhěngshù"
-
-#~ msgid "abort() called"
-#~ msgstr "abort() diàoyòng"
-
-#~ msgid "f-string expression part cannot include a '#'"
-#~ msgstr "f-string biǎodá shì bùfèn bùnéng bāohán '#'"
-
-#~ msgid "f-string expression part cannot include a backslash"
-#~ msgstr "f-string biǎodá shì bùfèn bùnéng bāohán fǎn xié gāng"
-
-#~ msgid "f-string: empty expression not allowed"
-#~ msgstr "f-string: bù yǔnxǔ shǐyòng kōng biǎodá shì"
-
-#~ msgid "f-string: expecting '}'"
-#~ msgstr "f-string: qídài '}'"
-
-#~ msgid "f-string: single '}' is not allowed"
-#~ msgstr "f-string: bù yǔnxǔ shǐyòng dāngè '}'"
-
-#~ msgid "invalid arguments"
-#~ msgstr "wúxiào de cānshù"
-
-#~ msgid "raw f-strings are not implemented"
-#~ msgstr "wèi zhíxíng yuánshǐ f-strings"
-
-#~ msgid "unindent does not match any outer indentation level"
-#~ msgstr "bùsuō jìn yǔ rènhé wàibù suō jìn jíbié dōu bù pǐpèi"
-
-#~ msgid "%q list must be a list"
-#~ msgstr "%q lièbiǎo bìxū shì lièbiǎo"
-
-#~ msgid "%q must of type %q"
-#~ msgstr "%q bì xū lèi xíng %q"
-
-#~ msgid "Column entry must be digitalio.DigitalInOut"
-#~ msgstr "Liè tiáomù bìxū shì digitalio.DigitalInOut"
-
-#~ msgid "Expected a Characteristic"
-#~ msgstr "Yùqí de tèdiǎn"
-
-#~ msgid "Expected a DigitalInOut"
-#~ msgstr "yù qī shù zì huà"
-
-#~ msgid "Expected a Service"
-#~ msgstr "Yùqí fúwù"
-
-#~ msgid "Expected a UART"
-#~ msgstr "qī dài UART"
-
-#~ msgid "Expected a UUID"
-#~ msgstr "Yùqí UUID"
-
-#~ msgid "Expected an Address"
-#~ msgstr "Qídài yīgè dìzhǐ"
-
-#~ msgid "Row entry must be digitalio.DigitalInOut"
-#~ msgstr "Xíng xiàng bìxū shì digitalio.DigitalInOut"
-
-#~ msgid "buttons must be digitalio.DigitalInOut"
-#~ msgstr "ànniǔ bìxū shì digitalio.DigitalInOut"
-
-#~ msgid "Invalid frequency"
-#~ msgstr "Wúxiào de pínlǜ"
-
-#~ msgid "Data 0 pin must be byte aligned."
-#~ msgstr "shù jù 0 yǐn jiǎo bì xū àn zì jié duì qí."
-
-#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
-#~ msgstr "wú xiào bits_per_pixel %d, bì xū shì, 1, 4, 8, 16, 24, huò 32"
+#~ "Qǐng zài méiyǒu _ de qíngkuàng xià chóng zhì bǎn zǐ yǐ tuìchū "
 
 #~ msgid ""
 #~ "\n"
@@ -5565,14 +4487,32 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ "zhān tiē mó shì; Ctrl-C qǔ xiāo, Ctrl-D wán chéngh\n"
 #~ "=== "
 
-#~ msgid "ParallelBus not yet supported"
-#~ msgstr "Shàng bù zhīchí ParallelBus"
+#, c-format
+#~ msgid "%02X"
+#~ msgstr "%02X"
 
-#~ msgid "raw REPL; CTRL-B to exit\n"
-#~ msgstr "yuán shǐ REPL; CTRL-B tuì chū\n"
+#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
+#~ msgstr ""
+#~ "%d dìzhǐ yǐn jiǎo hé %d rgb yǐn jiǎo jiāng gāodù biǎoshì wèi %d, ér bùshì "
+#~ "%d"
+
+#~ msgid "%q"
+#~ msgstr "%q"
+
+#~ msgid "%q indices must be integers, not %q"
+#~ msgstr "%q suǒyǐn bìxū shì zhěngshù, ér bùshì %q"
 
 #~ msgid "%q length must be %q"
 #~ msgstr "%q cháng dù bì xū wéi %q"
+
+#~ msgid "%q length must be >= 1"
+#~ msgstr "%q cháng dù bìxū >= 1"
+
+#~ msgid "%q list must be a list"
+#~ msgstr "%q lièbiǎo bìxū shì lièbiǎo"
+
+#~ msgid "%q must <= %d"
+#~ msgstr "%q bì xū <= %d"
 
 #~ msgid "%q must be 0-255"
 #~ msgstr "%q bì xū wéi 0-255"
@@ -5580,98 +4520,54 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "%q must be 1-255"
 #~ msgstr "%q bì xū wéi 1-255"
 
-#~ msgid "%q must be None or between 1 and len(report_descriptor)-1"
-#~ msgstr "%q bì xū wéi wú huò zài 1 hé len(report_descriptor)-1 zhī jiān"
+#~ msgid "%q must be >= 0"
+#~ msgstr "%q bìxū > = 0"
 
-#~ msgid "no available NIC"
-#~ msgstr "méiyǒu kěyòng de NIC"
-
-#~ msgid ""
-#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
-#~ "instead"
-#~ msgstr ""
-#~ "Duānkǒu bù jiēshòu PWM zàibō. Tōngguò yǐn jiǎo, pínlǜ hé zhàn kōng bǐ"
-
-#~ msgid ""
-#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
-#~ "Carrier instead"
-#~ msgstr ""
-#~ "Duānkǒu bù jiēshòu yǐn jiǎo huò pínlǜ. Gòuzào bìng chuándì PWMOut zàibō"
-
-#~ msgid "Instruction %d jumps on pin"
-#~ msgstr "zhǐ lìng %d zài yǐn jiǎo shàng tiào zhuǎn"
-
-#~ msgid "%q must store bytes"
-#~ msgstr "%q bì xū cún chǔ zì jié"
-
-#~ msgid "Buffer too large and unable to allocate"
-#~ msgstr "Huǎn chōng qū tài dà , wú fǎ fēn pèi"
-
-#~ msgid "interp is defined for 1D arrays of equal length"
-#~ msgstr "interp shì wèi děng zhǎng de 1D shùzǔ dìngyì de"
-
-#~ msgid "trapz is defined for 1D arrays"
-#~ msgstr "wéi 1D shù zǔ dìng yì xiàn jǐng"
-
-#~ msgid "wrong operand type"
-#~ msgstr "cuòwù de cāozuò shù lèixíng"
+#~ msgid "%q must be >= 1"
+#~ msgstr "%q bìxū >= 1"
 
 #~ msgid "%q must be None or 1-255"
 #~ msgstr "%q bì xū wéi wú huò 1-255"
 
-#~ msgid "Only raw int supported for ip"
-#~ msgstr "Ip jǐn zhīchí raw int"
+#~ msgid "%q must be None or between 1 and len(report_descriptor)-1"
+#~ msgstr "%q bì xū wéi wú huò zài 1 hé len(report_descriptor)-1 zhī jiān"
 
-#~ msgid ""
-#~ "CircuitPython is in safe mode because you pressed the reset button during "
-#~ "boot. Press again to exit safe mode.\n"
-#~ msgstr ""
-#~ "CircuitPython chǔyú ānquán móshì, yīnwèi zài yǐndǎo guòchéng zhōng àn "
-#~ "xiàle chóng zhì ànniǔ. Zài àn yīcì tuìchū ānquán móshì.\n"
+#~ msgid "%q must be a string"
+#~ msgstr "%q bìxū shì yí gè zì fú chuàn"
 
-#~ msgid "Not running saved code.\n"
-#~ msgstr "Méiyǒu yùnxíng yǐ bǎocún de dàimǎ.\n"
+#~ msgid "%q must be a tuple of length 2"
+#~ msgstr "%q bìxū shì chángdù wèi 2 de yuánzǔ"
 
-#~ msgid "Running in safe mode! "
-#~ msgstr "Zài ānquán móshì xià yùnxíng! "
+#~ msgid "%q must be an int"
+#~ msgstr "%q bìxū shì zhěng xíng"
 
-#~ msgid ""
-#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
-#~ "Please increase the stack size if you know how, or if not:"
-#~ msgstr ""
-#~ "Yóuyú duīzhàn tài xiǎo,CircuitPython duī yǐ sǔnhuài.\n"
-#~ "Rúguǒ nín zhīdào rúhé zēngjiā duīzhàn dàxiǎo, fǒuzé:"
+#~ msgid "%q must be between %d and %d"
+#~ msgstr "%q bì xū zài %d hé %d zhī jiān"
 
-#~ msgid ""
-#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
-#~ "to exit safe mode.\n"
-#~ msgstr ""
-#~ "“Wēi kòngzhì qì” mókuài yòng yú qǐdòng ānquán móshì. Àn chóng zhì kě "
-#~ "tuìchū ānquán móshì.\n"
+#~ msgid "%q must be of type %q"
+#~ msgstr "%q bì xū shì %q lèi xíng"
 
-#~ msgid ""
-#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
-#~ "enough power for the whole circuit and press reset (after ejecting "
-#~ "CIRCUITPY).\n"
-#~ msgstr ""
-#~ "wēi kòng zhì qì de gōng lǜ jiàng dī. Quèbǎo nín de diànyuán wèi zhěnggè\n"
-#~ "diànlù tígōng zúgòu de diànyuán, bìng àn xià fùwèi (Dànchū CIRCUITPY "
-#~ "zhīhòu).\n"
+#~ msgid "%q must be of type %q or None"
+#~ msgstr "%q lèi xíng bì xū wéi %q huò wú"
 
-#~ msgid "You are in safe mode: something unanticipated happened.\n"
-#~ msgstr "Nín chǔyú ānquán móshì: Chū hū yìliào de shìqíng fāshēngle.\n"
+#~ msgid "%q must of type %q"
+#~ msgstr "%q bì xū lèi xíng %q"
 
-#~ msgid "Pin number already reserved by EXTI"
-#~ msgstr "Zhēn hào yǐ bèi EXTI bǎoliú"
+#~ msgid "%q must store bytes"
+#~ msgstr "%q bì xū cún chǔ zì jié"
 
-#~ msgid "USB Busy"
-#~ msgstr "USB máng"
+#~ msgid "%q pin invalid"
+#~ msgstr "%q yǐn jiǎo wúxiào"
 
-#~ msgid "USB Error"
-#~ msgstr "USB Cuòwù"
+#~ msgid "%q should be an int"
+#~ msgstr "%q yīnggāi shì yīgè zhěngshù (int)"
 
-#~ msgid "%q indices must be integers, not %q"
-#~ msgstr "%q suǒyǐn bìxū shì zhěngshù, ér bùshì %q"
+#~ msgid "%q with a report ID of 0 must be of length 1"
+#~ msgstr "bào gào ID shì 0 de %q bì xū cháng dù wéi 1"
+
+#, c-format
+#~ msgid "%s"
+#~ msgstr "%s"
 
 #~ msgid "'%q' object cannot assign attribute '%q'"
 #~ msgstr "'%q' duì xiàng wú fǎ fēn pèi shǔ xìng '%q'"
@@ -5694,273 +4590,6 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "'%s' integer 0x%x does not fit in mask 0x%x"
 #~ msgstr "'%s' zhěngshù 0x%x bù shìyòng yú yǎn mǎ 0x%x"
 
-#~ msgid "Cannot unambiguously get sizeof scalar"
-#~ msgstr "Wúfǎ míngquè de huòdé biāoliàng de dàxiǎo"
-
-#~ msgid "Length must be an int"
-#~ msgstr "Chángdù bìxū shì yīgè zhěngshù"
-
-#~ msgid "Length must be non-negative"
-#~ msgstr "Chángdù bìxū shìfēi fùshù"
-
-#~ msgid "invalid decorator"
-#~ msgstr "wú xiào zhuāng shì"
-
-#~ msgid "name reused for argument"
-#~ msgstr "cān shǔ míngchēng bèi chóngxīn shǐyòng"
-
-#~ msgid "object '%q' is not a tuple or list"
-#~ msgstr "duìxiàng '%q' bùshì yuán zǔ huò lièbiǎo"
-
-#~ msgid "object does not support item assignment"
-#~ msgstr "duìxiàng bù zhīchí xiàngmù fēnpèi"
-
-#~ msgid "object does not support item deletion"
-#~ msgstr "duìxiàng bù zhīchí shānchú xiàngmù"
-
-#~ msgid "object is not subscriptable"
-#~ msgstr "duìxiàng bùnéng xià biāo"
-
-#~ msgid "object of type '%q' has no len()"
-#~ msgstr "lèixíng '%q' de duìxiàng méiyǒu len()"
-
-#~ msgid "struct: cannot index"
-#~ msgstr "jiégòu: bùnéng suǒyǐn"
-
-#~ msgid "Cannot remount '/' when USB is active."
-#~ msgstr "USB jīhuó shí wúfǎ chóngxīn bǎng ding '/'."
-
-#~ msgid "byte code not implemented"
-#~ msgstr "zì jié dàimǎ wèi zhíxíng"
-
-#~ msgid "can't pend throw to just-started generator"
-#~ msgstr "bùnéng bǎ tā rēng dào gāng qǐdòng de fā diànjī shàng"
-
-#~ msgid "invalid dupterm index"
-#~ msgstr "dupterm suǒyǐn wúxiào"
-
-#~ msgid "schedule stack full"
-#~ msgstr "jìhuà duīzhàn yǐ mǎn"
-
-#~ msgid "Corrupt raw code"
-#~ msgstr "Sǔnhuài de yuánshǐ dàimǎ"
-
-#~ msgid "can only save bytecode"
-#~ msgstr "zhǐ néng bǎocún zì jié mǎ jìlù"
-
-#~ msgid "Viper functions don't currently support more than 4 arguments"
-#~ msgstr "Viper hánshù mùqián bù zhīchí chāoguò 4 gè cānshù"
-
-#~ msgid "address %08x is not aligned to %d bytes"
-#~ msgstr "wèi zhǐ %08x wèi yǔ %d wèi yuán zǔ duìqí"
-
-#~ msgid "function does not take keyword arguments"
-#~ msgstr "hánshù méiyǒu guānjiàn cí cānshù"
-
-#~ msgid "parameter annotation must be an identifier"
-#~ msgstr "cānshù zhùshì bìxū shì biāozhì fú"
-
-#~ msgid "Total data to write is larger than outgoing_packet_length"
-#~ msgstr "Yào xiě rù de zǒng shùjù dàyú outgoing_packet_length"
-
-#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
-#~ msgstr "IOS 0, 2 + 4 bù zhī chí shuì mián zhōng de nèi bù shàng lā"
-
-#~ msgid "buffer must be a bytes-like object"
-#~ msgstr "huǎnchōng qū bìxū shì zì jié lèi duìxiàng"
-
-#~ msgid "io must be rtc io"
-#~ msgstr "IO bì xū shì RTC IO"
-
-#~ msgid "trigger level must be 0 or 1"
-#~ msgstr "chù fā jí bié bì xū wéi 0 huò 1"
-
-#~ msgid "wakeup conflict"
-#~ msgstr "huàn xǐng chōng tū"
-
-#~ msgid "Attempted heap allocation when MicroPython VM not running."
-#~ msgstr "MicroPython VM zài wèi yùnxíng shí chángshì fēnpèi duī."
-
-#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
-#~ msgstr "MicroPython NLR tiào zhuǎn shībài. Kěnéng shì nèicún sǔnhuài."
-
-#~ msgid "MicroPython fatal error."
-#~ msgstr "MicroPython zhìmìng cuòwù."
-
-#~ msgid "argument must be ndarray"
-#~ msgstr "Cānshù bìxū shì ndarray"
-
-#~ msgid "matrix dimensions do not match"
-#~ msgstr "jǔzhèn chǐcùn bù pǐpèi"
-
-#~ msgid "norm is defined for 1D and 2D arrays"
-#~ msgstr "wéi 1D hé 2D shù zǔ dìng yì guī fàn"
-
-#~ msgid "vectors must have same lengths"
-#~ msgstr "xiàngliàng bìxū jùyǒu xiāngtóng de chángdù"
-
-#~ msgid "Nordic Soft Device failure assertion."
-#~ msgstr "Nordic ruǎn shèbèi gùzhàng shēngmíng."
-
-#~ msgid "Unknown soft device error: %04x"
-#~ msgstr "Wèizhī de ruǎn shèbèi cuòwù: %04x"
-
-#~ msgid "first argument must be an iterable"
-#~ msgstr "dì yī gè cānshù bìxū shì kě diédài de"
-
-#~ msgid "iterables are not of the same length"
-#~ msgstr "kě diédài xiàng de chángdù bùtóng"
-
-#~ msgid "Selected CTS pin not valid"
-#~ msgstr "Suǒ xuǎn de CTS yǐn jiǎo wúxiào"
-
-#~ msgid "Selected RTS pin not valid"
-#~ msgstr "Suǒ xuǎn de RTS yǐn jiǎo wúxiào"
-
-#~ msgid "Could not initialize channel"
-#~ msgstr "Wúfǎ chūshǐhuà píndào"
-
-#~ msgid "Could not initialize timer"
-#~ msgstr "Wúfǎ chūshǐhuà jìshí qì"
-
-#~ msgid "Invalid frequency supplied"
-#~ msgstr "Tígōng de pínlǜ wúxiào"
-
-#~ msgid "Invalid pins for PWMOut"
-#~ msgstr "PWMOut de yǐn jiǎo wú xiào"
-
-#~ msgid "No more channels available"
-#~ msgstr "Méiyǒu gèng duō kěyòng píndào"
-
-#~ msgid "No more timers available"
-#~ msgstr "Méiyǒu gèng duō kěyòng de jìshí qì"
-
-#~ msgid "No more timers available on this pin."
-#~ msgstr "Gāi yǐn jiǎo shàng méiyǒu kěyòng de dìngshí qì."
-
-#~ msgid ""
-#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
-#~ "program"
-#~ msgstr ""
-#~ "Dìngshí qì bǎoliú gōng nèibù shǐyòng-zài chéngxù de qiánmiàn shēngmíng "
-#~ "PWM yǐn jiǎo"
-
-#~ msgid "Group full"
-#~ msgstr "Fēnzǔ yǐ mǎn"
-
-#~ msgid "In buffer elements must be 4 bytes long or less"
-#~ msgstr ""
-#~ "zài huǎn chōng yuán jiàn zhōng bì xū shì 4 zì jié cháng huò gèng shǎo"
-
-#~ msgid "Out buffer elements must be 4 bytes long or less"
-#~ msgstr "chū huǎn chōng yuán jiàn bì xū shì 4 zì jié cháng huò gèng shǎo"
-
-#~ msgid "UART not yet supported"
-#~ msgstr "UART shàng wèi shòu zhī chí"
-
-#~ msgid "bits must be 7, 8 or 9"
-#~ msgstr "bǐtè bìxū shì 7,8 huò 9"
-
-#~ msgid "Only IN/OUT of up to 8 supported"
-#~ msgstr "jǐn zhī chí zuì duō 8 gè IN/OUT"
-
-#~ msgid "SDA or SCL needs a pull up"
-#~ msgstr "SDA huò SCL xūyào lādòng"
-
-#~ msgid "Invalid use of TLS Socket"
-#~ msgstr "TLS tào jiē zì de wú xiào shǐ yòng"
-
-#~ msgid "Issue setting SO_REUSEADDR"
-#~ msgstr "wèn tí shè zhì SO_REUSEADDR"
-
-#~ msgid "%d address pins and %d rgb pins indicate a height of %d, not %d"
-#~ msgstr ""
-#~ "%d dìzhǐ yǐn jiǎo hé %d rgb yǐn jiǎo jiāng gāodù biǎoshì wèi %d, ér bùshì "
-#~ "%d"
-
-#~ msgid "Unknown failure"
-#~ msgstr "Wèizhī gùzhàng"
-
-#~ msgid "input argument must be an integer or a 2-tuple"
-#~ msgstr "shūrù cānshù bìxū shì zhěngshù huò 2 yuán zǔ"
-
-#~ msgid "tuple index out of range"
-#~ msgstr "yuán zǔ suǒyǐn chāochū fànwéi"
-
-#~ msgid ""
-#~ "\n"
-#~ "Code done running. Waiting for reload.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Dàimǎ yǐ wánchéng yùnxíng. Zhèngzài děngdài chóngxīn jiāzài.\n"
-
-#~ msgid "Frequency captured is above capability. Capture Paused."
-#~ msgstr "Pínlǜ bǔhuò gāo yú nénglì. Bǔhuò zàntíng."
-
-#~ msgid "max_length must be > 0"
-#~ msgstr "Max_length bìxū > 0"
-
-#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
-#~ msgstr "Àn xià rènhé jiàn jìnrù REPL. Shǐyòng CTRL-D chóngxīn jiāzài."
-
-#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
-#~ msgstr "Jǐn zhīchí IPv4 SOCK_STREAM tào jiē zì"
-
-#~ msgid "arctan2 is implemented for scalars and ndarrays only"
-#~ msgstr "arctan2 jǐn zhēnduì biāoliàng hé ndarray shíxiàn"
-
-#~ msgid "axis must be -1, 0, None, or 1"
-#~ msgstr "zhóu bìxū wèi-1,0, wú huò 1"
-
-#~ msgid "axis must be -1, 0, or 1"
-#~ msgstr "zhóu bìxū wèi-1,0 huò 1"
-
-#~ msgid "axis must be None, 0, or 1"
-#~ msgstr "zhóu bìxū wèi None,0 huò 1"
-
-#~ msgid "cannot reshape array (incompatible input/output shape)"
-#~ msgstr "wúfǎ zhěngxíng shùzǔ (bù jiānróng de shūrù/shūchū xíngzhuàng)"
-
-#~ msgid "could not broadast input array from shape"
-#~ msgstr "wúfǎ guǎngbò xíngzhuàng de shūrù shùzǔ"
-
-#~ msgid "ddof must be smaller than length of data set"
-#~ msgstr "ddof bìxū xiǎoyú shùjù jí de chángdù"
-
-#~ msgid "function is implemented for scalars and ndarrays only"
-#~ msgstr "gāi hánshù jǐn zhēnduì biāoliàng hé ndarray shíxiàn"
-
-#~ msgid "n must be between 0, and 9"
-#~ msgstr "n bìxū jiè yú 0 dào 9 zhī jiān"
-
-#~ msgid "number of arguments must be 2, or 3"
-#~ msgstr "cānshù shùliàng bìxū wèi 2 huò 3"
-
-#~ msgid "right hand side must be an ndarray, or a scalar"
-#~ msgstr "yòubiān bìxū shì ndarray huò biāoliàng"
-
-#~ msgid "shape must be a 2-tuple"
-#~ msgstr "xíngzhuàng bìxū shì 2 yuán zǔ"
-
-#~ msgid "sorted axis can't be longer than 65535"
-#~ msgstr "pái xù zhóu bù néng chāo guò 65535"
-
-#~ msgid "wrong argument type"
-#~ msgstr "cuòwù de cānshù lèixíng"
-
-#~ msgid "Must provide SCK pin"
-#~ msgstr "bì xū tí gòng SCK yǐn jiǎo"
-
-#~ msgid ""
-#~ "\n"
-#~ "To exit, please reset the board without "
-#~ msgstr ""
-#~ "\n"
-#~ "Qǐng zài méiyǒu _ de qíngkuàng xià chóng zhì bǎn zǐ yǐ tuìchū "
-
-#~ msgid "tuple/list required on RHS"
-#~ msgstr "RHS yāoqiú de yuán zǔ/lièbiǎo"
-
 #~ msgid "'%s' object does not support '%q'"
 #~ msgstr "'%s' duì xiàng bù zhīchí '%q'"
 
@@ -5982,48 +4611,98 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "'%s' object is not subscriptable"
 #~ msgstr "'%s' duìxiàng bùnéng fēnshù"
 
-#~ msgid "Invalid I2C pin selection"
-#~ msgstr "Wúxiào de I2C yǐn jiǎo xuǎnzé"
+#~ msgid "'await', 'async for' or 'async with' outside async function"
+#~ msgstr ""
+#~ "'await', 'async for' huò 'async with' wèiyú yìbù (async) hánshù zhīwài"
 
-#~ msgid "Invalid SPI pin selection"
-#~ msgstr "Wúxiào de SPI yǐn jiǎo xuǎnzé"
+#~ msgid "'break' outside loop"
+#~ msgstr "'break' wèiyú xúnhuán zhīwài"
 
-#~ msgid "Invalid UART pin selection"
-#~ msgstr "Wúxiào de UART yǐn jiǎo xuǎnzé"
+#~ msgid "'continue' outside loop"
+#~ msgstr "'continue' wèiyú xúnhuán zhīwài"
 
-#~ msgid "Pop from an empty Ps2 buffer"
-#~ msgstr "Cóng kōng de Ps2 huǎnchōng qū dànchū"
+#~ msgid "'coroutine' object is not an iterator"
+#~ msgstr "'coroutine' duìxiàng búshì yígè diédàiqì"
 
-#~ msgid "Running in safe mode! Auto-reload is off.\n"
-#~ msgstr "Zài ānquán móshì xià yùnxíng! Zìdòng chóngxīn jiāzài yǐ guānbì.\n"
+#~ msgid "(x,y) integers required"
+#~ msgstr "xūyào zhěngshù (x,y)"
 
-#~ msgid "can't convert address to int"
-#~ msgstr "wúfǎ jiāng dìzhǐ zhuǎnhuàn wèi int"
+#~ msgid "64 bit types"
+#~ msgstr "64 wèi lèixíng"
 
-#~ msgid "object '%s' is not a tuple or list"
-#~ msgstr "duìxiàng '%s' bùshì yuán zǔ huò lièbiǎo"
-
-#~ msgid "pop from an empty set"
-#~ msgstr "cóng kōng jí dànchū"
-
-#~ msgid "pop from empty list"
-#~ msgstr "cóng kōng lièbiǎo zhòng dànchū"
-
-#~ msgid "popitem(): dictionary is empty"
-#~ msgstr "dànchū xiàngmù (): Zìdiǎn wèi kōng"
-
-#, fuzzy
-#~ msgid "unknown format code '%c' for object of type '%s'"
-#~ msgstr "lèixíng '%s' duìxiàng wèizhī de géshì dàimǎ '%c'"
-
-#~ msgid "unsupported types for %q: '%s', '%s'"
-#~ msgstr "bù zhīchí de lèixíng wèi %q: '%s', '%s'"
+#~ msgid "ADC2 is being used by WiFi"
+#~ msgstr "ADC2 zhèngzài bèi WiFi shǐ yòng"
 
 #~ msgid "Address is not %d bytes long or is in wrong format"
 #~ msgstr "Dìzhǐ bùshì %d zì jié zhǎng, huòzhě géshì cuòwù"
 
+#~ msgid "Address type out of range"
+#~ msgstr "Dìzhǐ lèixíng chāochū fànwéi"
+
+#~ msgid "All I2C targets are in use"
+#~ msgstr "suǒyǒu I2C mùbiāo dōu zài shǐyòng zhōng"
+
+#~ msgid "AnalogIn not supported on given pin"
+#~ msgstr "gěidìng de yǐnjiǎo bù zhīchí AnalogIn"
+
+#~ msgid "AnalogOut functionality not supported"
+#~ msgstr "Bù zhīchí AnalogOut gōngnéng"
+
+#~ msgid "AnalogOut is only 16 bits. Value must be less than 65536."
+#~ msgstr "AnalogOut jǐn wèi 16 wèi. Zhí bìxū xiǎoyú 65536."
+
+#~ msgid "AnalogOut not supported on given pin"
+#~ msgstr "zhǐdìng de yǐn jiǎo bù zhīchí AnalogOut"
+
+#~ msgid "At most %d %q may be specified (not %d)"
+#~ msgstr "zuìduō kěyǐ zhǐdìng %d gè %q (érbúshì %d)"
+
+#~ msgid "Attempted heap allocation when MicroPython VM not running."
+#~ msgstr "MicroPython VM zài wèi yùnxíng shí chángshì fēnpèi duī."
+
 #~ msgid "Attempted heap allocation when MicroPython VM not running.\n"
 #~ msgstr "MicroPython VM wèi yùnxíng shí chángshì duī fēnpèi.\n"
+
+#~ msgid "Attempted heap allocation when VM not running."
+#~ msgstr "shìtú zài xūnǐjī (VM) yùn xíng shí fēnpèi duī (heap)."
+
+#~ msgid "Bit clock and word select must be sequential pins"
+#~ msgstr "wèi shízhōng hé zì xuǎnzé bìxū shì liánxù de yǐn jiǎo"
+
+#, c-format
+#~ msgid "Bit depth must be from 1 to 6 inclusive, not %d"
+#~ msgstr "wèi shēndù bìxū shì 1 dào 6, ér búshì %d"
+
+#~ msgid "Boot device must be first device (interface #0)."
+#~ msgstr "yǐndǎo shèbèi bìxū shì dìyī tái shèbèi (interface #0)."
+
+#~ msgid "Both buttons were pressed at start up.\n"
+#~ msgstr "qǐ dòng shí àn xià le liǎng gè àn niǔ.\n"
+
+#~ msgid "Brightness must be 0-1.0"
+#~ msgstr "Liàngdù bìxū wèi 0-1.0"
+
+#~ msgid "Brightness must be between 0 and 255"
+#~ msgstr "liàngdù bìxū jièyú 0 dào 255 zhījiān"
+
+#, c-format
+#~ msgid "Buffer incorrect size. Should be %d bytes."
+#~ msgstr "Huǎnchōng qū dàxiǎo bù zhèngquè. Yīnggāi shì %d zì jié."
+
+#~ msgid "Buffer is too small"
+#~ msgstr "Huǎnchōng qū tài xiǎo"
+
+#~ msgid "Buffer must be at least length 1"
+#~ msgstr "Huǎnchōng qū bìxū zhìshǎo chángdù wéi 1"
+
+#~ msgid "Buffer too large and unable to allocate"
+#~ msgstr "Huǎn chōng qū tài dà , wú fǎ fēn pèi"
+
+#~ msgid "Button A was pressed at start up.\n"
+#~ msgstr "qǐ dòng shí àn xià àn niǔ A.\n"
+
+#~ msgid "Bytes must be between 0 and 255."
+#~ msgstr "Zìjié bìxū jiè yú 0 dào 255 zhījiān."
 
 #~ msgid "Can not use dotstar with %s"
 #~ msgstr "Wúfǎ yǔ dotstar yīqǐ shǐyòng %s"
@@ -6043,26 +4722,158 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "Can't set CCCD for local Characteristic"
 #~ msgstr "Wúfǎ wéi běndì tèzhēng shèzhì CCCD"
 
+#~ msgid "Cannot output both channels on the same pin"
+#~ msgstr "Wúfǎ shūchū tóng yīgè yǐn jiǎo shàng de liǎng gè píndào"
+
+#~ msgid "Cannot read without MISO pin."
+#~ msgstr "Wúfǎ dòu qǔ méiyǒu MISO de yǐn jiǎo."
+
+#~ msgid "Cannot remount '/' when USB is active."
+#~ msgstr "USB jīhuó shí wúfǎ chóngxīn bǎng ding '/'."
+
+#~ msgid "Cannot reset into bootloader because no bootloader is present."
+#~ msgstr "Wúfǎ chóng zhì wèi bootloader, yīnwèi méiyǒu bootloader cúnzài."
+
+#~ msgid "Cannot transfer without MOSI and MISO pins"
+#~ msgstr "méiyǒu MOSI hé MISO yǐnjiǎo, wúfǎ chuánshū"
+
+#~ msgid "Cannot transfer without MOSI and MISO pins."
+#~ msgstr "Méiyǒu MOSI/MISO jiù wúfǎ zhuǎnyí."
+
+#~ msgid "Cannot unambiguously get sizeof scalar"
+#~ msgstr "Wúfǎ míngquè de huòdé biāoliàng de dàxiǎo"
+
+#~ msgid "Cannot write without MOSI pin."
+#~ msgstr "Wúfǎ xiě rù MOSI de yǐn jiǎo."
+
 #~ msgid "Characteristic UUID doesn't match Service UUID"
 #~ msgstr "Zìfú UUID bù fúhé fúwù UUID"
 
 #~ msgid "Characteristic already in use by another Service."
 #~ msgstr "Qítā fúwù bùmén yǐ shǐyòng de gōngnéng."
 
+#~ msgid ""
+#~ "CircuitPython is in safe mode because you pressed the reset button during "
+#~ "boot. Press again to exit safe mode.\n"
+#~ msgstr ""
+#~ "CircuitPython chǔyú ānquán móshì, yīnwèi zài yǐndǎo guòchéng zhōng àn "
+#~ "xiàle chóng zhì ànniǔ. Zài àn yīcì tuìchū ānquán móshì.\n"
+
+#~ msgid "CircuitPython was unable to allocate the heap."
+#~ msgstr "CircuitPython wúfǎ fēnpèi duī."
+
+#~ msgid "Clock pin init failed."
+#~ msgstr "Shízhōng de yǐn jiǎo chūshǐhuà shībài."
+
+#~ msgid "Column entry must be digitalio.DigitalInOut"
+#~ msgstr "Liè tiáomù bìxū shì digitalio.DigitalInOut"
+
 #~ msgid "Command must be 0-255"
 #~ msgstr "Mìnglìng bìxū wèi 0-255"
+
+#~ msgid "Command must be an int between 0 and 255"
+#~ msgstr "Mìnglìng bìxū shì 0 dào 255 zhī jiān de int"
+
+#~ msgid "Corrupt .mpy file"
+#~ msgstr "sǔnhuài de .mpy wénjiàn"
+
+#~ msgid "Corrupt raw code"
+#~ msgstr "Sǔnhuài de yuánshǐ dàimǎ"
 
 #~ msgid "Could not decode ble_uuid, err 0x%04x"
 #~ msgstr "Wúfǎ jiěmǎ kě dú_uuid, err 0x%04x"
 
+#~ msgid "Could not initialize Camera"
+#~ msgstr "Wúfǎ chūshǐhuà xiàngjī"
+
+#~ msgid "Could not initialize GNSS"
+#~ msgstr "wú fǎ chū shǐ huà GNSS"
+
+#~ msgid "Could not initialize SDCard"
+#~ msgstr "wú fǎ chū shǐ huà SDCard"
+
+#~ msgid "Could not initialize UART"
+#~ msgstr "Wúfǎ chūshǐhuà UART"
+
+#~ msgid "Could not initialize channel"
+#~ msgstr "Wúfǎ chūshǐhuà píndào"
+
+#~ msgid "Could not initialize timer"
+#~ msgstr "Wúfǎ chūshǐhuà jìshí qì"
+
+#~ msgid "Could not re-init channel"
+#~ msgstr "Wúfǎ chóngxīn chūshǐhuà píndào"
+
+#~ msgid "Could not re-init timer"
+#~ msgstr "Wúfǎ chóngxīn qǐdòng jìshí qì"
+
+#~ msgid "Could not restart PWM"
+#~ msgstr "Wúfǎ chóngqǐ PWM"
+
+#~ msgid "Couldn't allocate first buffer"
+#~ msgstr "Wúfǎ fēnpèi dì yī gè huǎnchōng qū"
+
+#~ msgid "Couldn't allocate input buffer"
+#~ msgstr "Wúfǎ fēnpèi shūrù huǎnchōng qū"
+
+#~ msgid "Couldn't allocate second buffer"
+#~ msgstr "Wúfǎ fēnpèi dì èr gè huǎnchōng qū"
+
+#~ msgid "Crash into the HardFault_Handler."
+#~ msgstr "gu4zhang4, jin4ru4 HardFault_Handler."
+
 #~ msgid "Crash into the HardFault_Handler.\n"
 #~ msgstr "Bēngkuì dào HardFault_Handler.\n"
+
+#~ msgid "Data 0 pin must be byte aligned."
+#~ msgstr "shù jù 0 yǐn jiǎo bì xū àn zì jié duì qí."
 
 #~ msgid "Data too large for the advertisement packet"
 #~ msgstr "Guǎnggào bāo de shùjù tài dà"
 
+#~ msgid "DigitalInOut not supported on given pin"
+#~ msgstr "Gěi dìng de yǐn jiǎo bù zhīchí DigitalInOut"
+
+#, c-format
+#~ msgid "Error in MIDI stream at position %d"
+#~ msgstr "wèi yú %d wèi zhì de MIDI liú zhōng de cuò wù"
+
+#~ msgid "Expected a %q"
+#~ msgstr "Yù qí %q"
+
+#~ msgid "Expected a %q or %q"
+#~ msgstr "yù qī wéi %q huò %q"
+
+#~ msgid "Expected a Characteristic"
+#~ msgstr "Yùqí de tèdiǎn"
+
+#~ msgid "Expected a DigitalInOut"
+#~ msgstr "yù qī shù zì huà"
+
 #~ msgid "Expected a Peripheral"
 #~ msgstr "Qídài yīgè wàiwéi shèbèi"
+
+#~ msgid "Expected a Service"
+#~ msgstr "Yùqí fúwù"
+
+#~ msgid "Expected a UART"
+#~ msgstr "qī dài UART"
+
+#~ msgid "Expected a UUID"
+#~ msgstr "Yùqí UUID"
+
+#~ msgid "Expected an %q"
+#~ msgstr "yù qī wéi %q"
+
+#~ msgid "Expected an Address"
+#~ msgstr "Qídài yīgè dìzhǐ"
+
+#~ msgid "Expected an alarm"
+#~ msgstr "yù qī yǒu jǐng bào"
+
+#, c-format
+#~ msgid "Expected tuple of length %d, got %d"
+#~ msgstr "Qīwàng de chángdù wèi %d de yuán zǔ, dédào %d"
 
 #~ msgid "Failed to acquire mutex"
 #~ msgstr "Wúfǎ huòdé mutex"
@@ -6078,6 +4889,13 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 
 #~ msgid "Failed to add service, err 0x%04x"
 #~ msgstr "Tiānjiā fúwù shībài, err 0x%04x"
+
+#~ msgid "Failed to allocate RX buffer"
+#~ msgstr "Fēnpèi RX huǎnchōng shībài"
+
+#, c-format
+#~ msgid "Failed to allocate RX buffer of %d bytes"
+#~ msgstr "Fēnpèi RX huǎnchōng qū%d zì jié shībài"
 
 #~ msgid "Failed to change softdevice state"
 #~ msgstr "Gēnggǎi ruǎn shèbèi zhuàngtài shībài"
@@ -6105,6 +4923,9 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 
 #~ msgid "Failed to get softdevice state"
 #~ msgstr "Wúfǎ huòdé ruǎnjiàn shèbèi zhuàngtài"
+
+#~ msgid "Failed to init wifi"
+#~ msgstr "Wúfǎ chūshǐhuà wifi"
 
 #~ msgid "Failed to notify or indicate attribute value, err 0x%04x"
 #~ msgstr "Wúfǎ tōngzhī huò xiǎnshì shǔxìng zhí, err 0x%04x"
@@ -6163,6 +4984,15 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "Failed to write gatts value, err 0x%04x"
 #~ msgstr "Xiě rù gatts zhí,err 0x%04x shībài"
 
+#~ msgid "Fatal error."
+#~ msgstr "zhì mìng cuò wù."
+
+#~ msgid "Fault detected by hardware."
+#~ msgstr "yìng jiàn jiǎn cè dào gù zhàng."
+
+#~ msgid "Firmware image is invalid"
+#~ msgstr "gù jiàn yìng xiàng wú xiào"
+
 #~ msgid "Flash erase failed"
 #~ msgstr "Flash cā chú shībài"
 
@@ -6175,17 +5005,209 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "Flash write failed to start, err 0x%04x"
 #~ msgstr "Flash xiě rù shībài, err 0x%04x"
 
+#, c-format
+#~ msgid "Framebuffer requires %d bytes"
+#~ msgstr "zhēn huǎn chōng qū xū yào %d zì jié"
+
+#~ msgid "Frequency captured is above capability. Capture Paused."
+#~ msgstr "Pínlǜ bǔhuò gāo yú nénglì. Bǔhuò zàntíng."
+
+#~ msgid "Group full"
+#~ msgstr "Fēnzǔ yǐ mǎn"
+
+#~ msgid "Hardware busy, try alternative pins"
+#~ msgstr "Yìngjiàn máng, qǐng chángshì qítā zhēnjiǎo"
+
+#~ msgid "Hostname must be between 1 and 253 characters"
+#~ msgstr "zhǔ jī míng bì xū jiè yú 1 hé 253 gè zì fú zhī jiān"
+
+#~ msgid "I2C Init Error"
+#~ msgstr "I2C chūshǐhuà cuòwù"
+
 #~ msgid "I2C operation not supported"
 #~ msgstr "I2C cāozuò bù zhīchí"
 
+#~ msgid "I2SOut not available"
+#~ msgstr "I2SOut bù kě yòng"
+
+#~ msgid "IOs 0, 2 & 4 do not support internal pullup in sleep"
+#~ msgstr "IOS 0, 2 + 4 bù zhī chí shuì mián zhōng de nèi bù shàng lā"
+
+#, c-format
+#~ msgid "IV must be %d bytes long"
+#~ msgstr "IV bì xū wéi %d zì jié cháng"
+
+#~ msgid "In buffer elements must be 4 bytes long or less"
+#~ msgstr ""
+#~ "zài huǎn chōng yuán jiàn zhōng bì xū shì 4 zì jié cháng huò gèng shǎo"
+
+#~ msgid ""
+#~ "Incompatible .mpy file. Please update all .mpy files. See http://adafru."
+#~ "it/mpy-update for more info."
+#~ msgstr ""
+#~ "Bù jiānróng.Mpy wénjiàn. Qǐng gēngxīn suǒyǒu.Mpy wénjiàn. Yǒuguān xiángxì "
+#~ "xìnxī, qǐng cānyuè http://Adafru.It/mpy-update."
+
+#~ msgid "Initialization failed due to lack of memory"
+#~ msgstr "yóu yú nèi cún bù zú, chū shǐ huà shī bài"
+
+#~ msgid "Instruction %d jumps on pin"
+#~ msgstr "zhǐ lìng %d zài yǐn jiǎo shàng tiào zhuǎn"
+
+#, c-format
+#~ msgid "Instruction %d shifts in more bits than pin count"
+#~ msgstr "zhǐ lìng %d yí wèi chāo guò yǐn jiǎo jì shù"
+
+#, c-format
+#~ msgid "Instruction %d shifts out more bits than pin count"
+#~ msgstr "zhǐ lìng %d yí chū de wèi bǐ yǐn jiǎo shù duō"
+
+#, c-format
+#~ msgid "Instruction %d uses extra pin"
+#~ msgstr "zhǐ lìng %d shǐ yòng é wài de yǐn jiǎo"
+
+#, c-format
+#~ msgid "Instruction %d waits on input outside of count"
+#~ msgstr "zhǐ lìng %d děng dài jì shù zhī wài de shū rù"
+
+#~ msgid "Invalid %q pin selection"
+#~ msgstr "wú xiào %q yǐn jiǎo xuǎn zé"
+
+#~ msgid "Invalid AuthMode"
+#~ msgstr "wú xiào AuthMode"
+
+#~ msgid "Invalid BMP file"
+#~ msgstr "Wúxiào de BMP wénjiàn"
+
+#~ msgid "Invalid CIRCUITPY_PYSTACK_SIZE\n"
+#~ msgstr "wú xiào CIRCUITPY_PYSTACK_SIZE\n"
+
+#~ msgid "Invalid DAC pin supplied"
+#~ msgstr "Tí gōng liǎo wúxiào de DAC yǐn jiǎo"
+
+#~ msgid "Invalid I2C pin selection"
+#~ msgstr "Wúxiào de I2C yǐn jiǎo xuǎnzé"
+
+#~ msgid "Invalid MIDI file"
+#~ msgstr "wú xiào de MIDI wén jiàn"
+
+#~ msgid "Invalid PWM frequency"
+#~ msgstr "Wúxiào de PWM pínlǜ"
+
+#~ msgid "Invalid Pin"
+#~ msgstr "wú xiào yǐn jiǎo"
+
+#~ msgid "Invalid SPI pin selection"
+#~ msgstr "Wúxiào de SPI yǐn jiǎo xuǎnzé"
+
+#~ msgid "Invalid UART pin selection"
+#~ msgstr "Wúxiào de UART yǐn jiǎo xuǎnzé"
+
 #~ msgid "Invalid bit clock pin"
 #~ msgstr "Wúxiào de wèi shízhōng yǐn jiǎo"
+
+#~ msgid "Invalid buffer size"
+#~ msgstr "Wúxiào de huǎnchōng qū dàxiǎo"
+
+#~ msgid "Invalid byteorder string"
+#~ msgstr "Wúxiào de zì jié shùnxù zìfú chuàn"
+
+#~ msgid "Invalid capture period. Valid range: 1 - 500"
+#~ msgstr "Wúxiào de bǔhuò zhōuqí. Yǒuxiào fànwéi: 1-500"
+
+#~ msgid "Invalid channel count"
+#~ msgstr "Wúxiào de tōngdào jìshù"
 
 #~ msgid "Invalid clock pin"
 #~ msgstr "Wúxiào de shízhōng yǐn jiǎo"
 
 #~ msgid "Invalid data pin"
 #~ msgstr "Wúxiào de shùjù yǐn jiǎo"
+
+#, c-format
+#~ msgid "Invalid data_count %d"
+#~ msgstr "wú xiào data_count %d"
+
+#~ msgid "Invalid direction."
+#~ msgstr "Wúxiào de fāngxiàng."
+
+#~ msgid "Invalid file"
+#~ msgstr "Wúxiào de wénjiàn"
+
+#~ msgid "Invalid frequency"
+#~ msgstr "Wúxiào de pínlǜ"
+
+#~ msgid "Invalid frequency supplied"
+#~ msgstr "Tígōng de pínlǜ wúxiào"
+
+#~ msgid "Invalid memory access."
+#~ msgstr "Wúxiào de nèicún fǎngwèn."
+
+#~ msgid "Invalid mode"
+#~ msgstr "wú xiào mó shì"
+
+#~ msgid "Invalid number of bits"
+#~ msgstr "Wèi shù wúxiào"
+
+#~ msgid "Invalid phase"
+#~ msgstr "Jiēduàn wúxiào"
+
+#~ msgid "Invalid pin"
+#~ msgstr "Wúxiào de yǐn jiǎo"
+
+#~ msgid "Invalid pin for left channel"
+#~ msgstr "Zuǒ tōngdào de yǐn jiǎo wúxiào"
+
+#~ msgid "Invalid pin for right channel"
+#~ msgstr "Yòuxián tōngdào yǐn jiǎo wúxiào"
+
+#~ msgid "Invalid pins"
+#~ msgstr "Wúxiào de yǐn jiǎo"
+
+#~ msgid "Invalid pins for PWMOut"
+#~ msgstr "PWMOut de yǐn jiǎo wú xiào"
+
+#~ msgid "Invalid polarity"
+#~ msgstr "Wúxiào liǎng jí zhí"
+
+#~ msgid "Invalid properties"
+#~ msgstr "Wúxiào de shǔxìng"
+
+#~ msgid "Invalid run mode."
+#~ msgstr "Wúxiào de yùnxíng móshì."
+
+#~ msgid "Invalid security_mode"
+#~ msgstr "Ānquán móshì wúxiào"
+
+#~ msgid "Invalid use of TLS Socket"
+#~ msgstr "TLS tào jiē zì de wú xiào shǐ yòng"
+
+#~ msgid "Invalid voice"
+#~ msgstr "Yǔyīn wúxiào"
+
+#~ msgid "Invalid voice count"
+#~ msgstr "Wúxiào de yǔyīn jìshù"
+
+#~ msgid "Invalid wave file"
+#~ msgstr "Wúxiào de làng làngcháo wénjiàn"
+
+#~ msgid "Invalid word/bit length"
+#~ msgstr "Wúxiào de zì/wèi chángdù"
+
+#~ msgid "Issue setting SO_REUSEADDR"
+#~ msgstr "wèn tí shè zhì SO_REUSEADDR"
+
+#~ msgid "Layer already in a group."
+#~ msgstr "Tú céng yǐjīng zài yīgè zǔ zhōng."
+
+#~ msgid "Layer must be a Group or TileGrid subclass."
+#~ msgstr "Layer bìxū shì Group huò TileGrid zi lèi."
+
+#~ msgid "Length must be an int"
+#~ msgstr "Chángdù bìxū shì yīgè zhěngshù"
+
+#~ msgid "Length must be non-negative"
+#~ msgstr "Chángdù bìxū shìfēi fùshù"
 
 #~ msgid ""
 #~ "Looks like our core CircuitPython code crashed hard. Whoops!\n"
@@ -6197,17 +5219,102 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ "shàng tíjiāo yīgè wèntí, qízhōng bāohán nín de CIRCUITPY qūdòngqì de "
 #~ "nèiróng hé cǐ xiāoxī:\n"
 
+#~ msgid "MISO pin init failed."
+#~ msgstr "MISO yǐn jiǎo chūshǐhuà shībài."
+
+#~ msgid "MOSI pin init failed."
+#~ msgstr "MOSI yǐn jiǎo shūrù shībài."
+
+#, c-format
+#~ msgid "Maximum x value when mirrored is %d"
+#~ msgstr "Jìngxiàng shí de zuìdà X zhí wèi%d"
+
+#~ msgid "Messages limited to 8 bytes"
+#~ msgstr "Yóujiàn xiànzhì wèi 8 gè zì jié"
+
+#~ msgid "MicroPython NLR jump failed. Likely memory corruption."
+#~ msgstr "MicroPython NLR tiào zhuǎn shībài. Kěnéng shì nèicún sǔnhuài."
+
 #~ msgid "MicroPython NLR jump failed. Likely memory corruption.\n"
 #~ msgstr "MicroPython NLR tiàoyuè shībài. Kěnéng nèicún fǔbài.\n"
+
+#~ msgid "MicroPython fatal error."
+#~ msgstr "MicroPython zhìmìng cuòwù."
 
 #~ msgid "MicroPython fatal error.\n"
 #~ msgstr "MicroPython zhìmìng cuòwù.\n"
 
+#~ msgid "Missing MISO or MOSI Pin"
+#~ msgstr "Quēshǎo MISO huò MOSI yǐn jiǎo"
+
+#~ msgid "Missing MISO or MOSI pin"
+#~ msgstr "quēshǎo MISO huò MOSI yǐn jiǎo"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d reads pin(s)"
+#~ msgstr "shǒu xiān zài yǐn jiǎo zhōng quē shī. zhǐ lìng %d dú qǔ yǐn jiǎo"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d shifts in from pin(s)"
+#~ msgstr ""
+#~ "shǒu xiān zài yǐn jiǎo zhōng quē shī. zhǐ lìng %d cóng yǐn jiǎo yí wèi"
+
+#, c-format
+#~ msgid "Missing first_in_pin. Instruction %d waits based on pin"
+#~ msgstr ""
+#~ "shǒu xiān zài yǐn jiǎo zhōng quē shī. jī yú yǐn jiǎo de zhǐ lìng %d děng "
+#~ "dài"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d shifts out to pin(s)"
+#~ msgstr "xiān lòu chū yǐn jiǎo. zhǐ lìng %d yí chū dào yǐn jiǎo"
+
+#, c-format
+#~ msgid "Missing first_out_pin. Instruction %d writes pin(s)"
+#~ msgstr "xiān lòu chū yǐn jiǎo. zhǐ lìng %d xiě rù yǐn jiǎo"
+
+#, c-format
+#~ msgid "Missing first_set_pin. Instruction %d sets pin(s)"
+#~ msgstr "quē shǎo dì yī zǔ yǐn jiǎo. zhǐ lìng %d shè zhì yǐn jiǎo"
+
+#, c-format
+#~ msgid "Missing jmp_pin. Instruction %d jumps on pin"
+#~ msgstr "shī zōng de jmp_pin. zhǐ lìng %d zài yǐn jiǎo shàng tiào yuè"
+
+#, c-format
+#~ msgid "More than %d report ids not supported"
+#~ msgstr "chāo guò %d bào gào bù zhī chí de ID"
+
 #~ msgid "Must be a Group subclass."
 #~ msgstr "Bìxū shì fēnzǔ zi lèi."
 
+#~ msgid "Must provide SCK pin"
+#~ msgstr "bì xū tí gòng SCK yǐn jiǎo"
+
 #~ msgid "Negative step not supported"
 #~ msgstr "Bù zhīchí fù bù"
+
+#, c-format
+#~ msgid "No I2C device at address: %x"
+#~ msgstr "dì zhǐ wú I2C shè bèi: %x"
+
+#~ msgid "No MISO Pin"
+#~ msgstr "Méiyǒu MISO yǐn jiǎo"
+
+#~ msgid "No MISO pin"
+#~ msgstr "wú MISO pin"
+
+#~ msgid "No MOSI Pin"
+#~ msgstr "Méiyǒu MOSI yǐn jiǎo"
+
+#~ msgid "No MOSI pin"
+#~ msgstr "wú MOSI pin"
+
+#~ msgid "No RX pin"
+#~ msgstr "Wèi zhǎodào RX yǐn jiǎo"
+
+#~ msgid "No TX pin"
+#~ msgstr "Wèi zhǎodào TX yǐn jiǎo"
 
 #~ msgid "No default I2C bus"
 #~ msgstr "Méiyǒu mòrèn I2C gōnggòng qìchē"
@@ -6218,6 +5325,49 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "No default UART bus"
 #~ msgstr "Méiyǒu mòrèn UART gōnggòng qìchē"
 
+#~ msgid "No hardware support on clk pin"
+#~ msgstr "Shízhōng yǐn jiǎo wú yìngjiàn zhīchí"
+
+#~ msgid "No hardware support on pin"
+#~ msgstr "Méiyǒu zài yǐn jiǎo shàng de yìngjiàn zhīchí"
+
+#~ msgid "No key was specified"
+#~ msgstr "Wèi zhǐdìng mì yào"
+
+#~ msgid "No more channels available"
+#~ msgstr "Méiyǒu gèng duō kěyòng píndào"
+
+#, c-format
+#~ msgid "No more than %d HID devices allowed"
+#~ msgstr "bù yǔn xǔ chāo guò %d HID shè bèi"
+
+#~ msgid "No more timers available"
+#~ msgstr "Méiyǒu gèng duō kěyòng de jìshí qì"
+
+#~ msgid "No more timers available on this pin."
+#~ msgstr "Gāi yǐn jiǎo shàng méiyǒu kěyòng de dìngshí qì."
+
+#~ msgid "Nordic Soft Device failure assertion."
+#~ msgstr "Nordic ruǎn shèbèi gùzhàng shēngmíng."
+
+#~ msgid "Nordic system firmware failure assertion."
+#~ msgstr "běi ōu xì tǒng gù jiàn gù zhàng duàn yán."
+
+#~ msgid "Not running saved code.\n"
+#~ msgstr "Méiyǒu yùnxíng yǐ bǎocún de dàimǎ.\n"
+
+#~ msgid "Not settable"
+#~ msgstr "bù kě shè zhì"
+
+#~ msgid "Only 8 or 16 bit mono with "
+#~ msgstr "Zhǐyǒu 8 huò 16 wèi dānwèi "
+
+#~ msgid "Only IN/OUT of up to 8 supported"
+#~ msgstr "jǐn zhī chí zuì duō 8 gè IN/OUT"
+
+#~ msgid "Only IPv4 SOCK_STREAM sockets supported"
+#~ msgstr "Jǐn zhīchí IPv4 SOCK_STREAM tào jiē zì"
+
 #~ msgid "Only bit maps of 8 bit color or less are supported"
 #~ msgstr "Jǐn zhīchí 8 wèi yánsè huò xiǎoyú"
 
@@ -6227,11 +5377,69 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgstr ""
 #~ "Jǐn zhīchí dān sè, suǒyǐn 8bpp hé 16bpp huò gèng dà de BMP: %d bpp tígōng"
 
+#~ msgid "Only one TouchAlarm can be set in deep sleep."
+#~ msgstr "zhǐ yǒu yí gè chù mō bì kě yǐ shè zhì zài shēn dù shuì mián."
+
+#~ msgid "Only raw int supported for ip"
+#~ msgstr "Ip jǐn zhīchí raw int"
+
 #~ msgid "Only slices with step=1 (aka None) are supported"
 #~ msgstr "Jǐn zhīchí 1 bù qiēpiàn"
 
+#~ msgid "Out buffer elements must be 4 bytes long or less"
+#~ msgstr "chū huǎn chōng yuán jiàn bì xū shì 4 zì jié cháng huò gèng shǎo"
+
+#, c-format
+#~ msgid "Output buffer must be at least %d bytes"
+#~ msgstr "shū chū huǎn chōng qū bì xū zhì shǎo wéi %d zì jié"
+
+#~ msgid "PDMIn not available"
+#~ msgstr "PDMIn bù kě yòng"
+
+#~ msgid ""
+#~ "PWM duty_cycle must be between 0 and 65535 inclusive (16 bit resolution)"
+#~ msgstr ""
+#~ "PWM yìwù zhōuqí bìxū jiè yú 0 zhì 65535 de bāoróng xìng (16 wèi fēnbiàn "
+#~ "lǜ)"
+
+#~ msgid "ParallelBus not yet supported"
+#~ msgstr "Shàng bù zhīchí ParallelBus"
+
+#~ msgid "Pin count must be at least 1"
+#~ msgstr "yǐn jiǎo jì shù bì xū zhì shǎo wéi 1"
+
+#~ msgid "Pin does not have ADC capabilities"
+#~ msgstr "Pin méiyǒu ADC nénglì"
+
+#~ msgid "Pin number already reserved by EXTI"
+#~ msgstr "Zhēn hào yǐ bèi EXTI bǎoliú"
+
 #~ msgid "Pixel beyond bounds of buffer"
 #~ msgstr "Xiàngsù chāochū huǎnchōng qū biānjiè"
+
+#~ msgid "Pop from an empty Ps2 buffer"
+#~ msgstr "Cóng kōng de Ps2 huǎnchōng qū dànchū"
+
+#~ msgid ""
+#~ "Port does not accept PWM carrier. Pass a pin, frequency and duty cycle "
+#~ "instead"
+#~ msgstr ""
+#~ "Duānkǒu bù jiēshòu PWM zàibō. Tōngguò yǐn jiǎo, pínlǜ hé zhàn kōng bǐ"
+
+#~ msgid ""
+#~ "Port does not accept pins or frequency. Construct and pass a PWMOut "
+#~ "Carrier instead"
+#~ msgstr ""
+#~ "Duānkǒu bù jiēshòu yǐn jiǎo huò pínlǜ. Gòuzào bìng chuándì PWMOut zàibō"
+
+#~ msgid "Press any key to enter the REPL. Use CTRL-D to reload."
+#~ msgstr "Àn xià rènhé jiàn jìnrù REPL. Shǐyòng CTRL-D chóngxīn jiāzài."
+
+#~ msgid "Program must contain at least one 16-bit instruction."
+#~ msgstr "chéng xù bì xū zhì shǎo bāo hán yí gè 16 wèi zhǐ lìng ."
+
+#~ msgid "Program too large"
+#~ msgstr "chéng xù tài dà"
 
 #~ msgid "PulseIn not yet supported"
 #~ msgstr "Shàng bù zhīchí PulseIn"
@@ -6239,11 +5447,94 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "PulseOut not yet supported"
 #~ msgstr "Shàng bù zhīchí PulseOut"
 
+#~ msgid "RAISE mode is not implemented"
+#~ msgstr "wèi shí xiàn tí shēng mó shì"
+
+#~ msgid "RS485 Not yet supported on this device"
+#~ msgstr "RS485 cǐ shè bèi shàng bù zhī chí"
+
+#~ msgid "RTC calibration is not supported on this board"
+#~ msgstr "Cǐ bǎn bù zhīchí RTC jiàozhǔn"
+
+#~ msgid "RTS/CTS/RS485 Not yet supported on this device"
+#~ msgstr "RTS/CTS/RS485 gāi shèbèi shàng bù zhīchí"
+
 #~ msgid "Range out of bounds"
 #~ msgstr "Fànwéi chāochū biānjiè"
 
+#~ msgid "Read-only object"
+#~ msgstr "Zhǐ dú duìxiàng"
+
+#~ msgid "Row entry must be digitalio.DigitalInOut"
+#~ msgstr "Xíng xiàng bìxū shì digitalio.DigitalInOut"
+
+#~ msgid "Running in safe mode! "
+#~ msgstr "Zài ānquán móshì xià yùnxíng! "
+
+#~ msgid "Running in safe mode! Auto-reload is off.\n"
+#~ msgstr "Zài ānquán móshì xià yùnxíng! Zìdòng chóngxīn jiāzài yǐ guānbì.\n"
+
+#~ msgid "SDA or SCL needs a pull up"
+#~ msgstr "SDA huò SCL xūyào lādòng"
+
+#~ msgid "SPI Init Error"
+#~ msgstr "SPI chūshǐhuà cuòwù"
+
+#~ msgid "SPI Re-initialization error"
+#~ msgstr "SPI chóngxīn chūshǐhuà cuòwù"
+
+#~ msgid "Sample rate must be positive"
+#~ msgstr "Cǎiyàng lǜ bìxū wèi zhèng shù"
+
+#, c-format
+#~ msgid "Sample rate too high. It must be less than %d"
+#~ msgstr "Cǎiyàng lǜ tài gāo. Tā bìxū xiǎoyú %d"
+
+#~ msgid "Scan already in progess. Stop with stop_scan."
+#~ msgstr "Zhèngzài jìn háng sǎomiáo. Shǐyòng stop_scan tíngzhǐ."
+
+#~ msgid "Selected CTS pin not valid"
+#~ msgstr "Suǒ xuǎn de CTS yǐn jiǎo wúxiào"
+
+#~ msgid "Selected RTS pin not valid"
+#~ msgstr "Suǒ xuǎn de RTS yǐn jiǎo wúxiào"
+
+#~ msgid "Set pin count must be between 1 and 5"
+#~ msgstr "shè zhì yǐn jiǎo shù bì xū jiè yú 1 hé 5 zhī jiān"
+
+#~ msgid "Side set pin count must be between 1 and 5"
+#~ msgstr "cè miàn shè zhì yǐn jiǎo shù bì xū jiè yú 1 hé 5 zhī jiān"
+
+#~ msgid "Sleep Memory not available"
+#~ msgstr "shuì mián jì yì bù kě yòng"
+
 #~ msgid "Soft device assert, id: 0x%08lX, pc: 0x%08lX"
 #~ msgstr "Ruǎn shèbèi wéihù, id: 0X%08lX, pc: 0X%08lX"
+
+#~ msgid "Splitting with sub-captures"
+#~ msgstr "Yǔ zi bǔhuò fēnliè"
+
+#~ msgid "Stack size must be at least 256"
+#~ msgstr "Duīzhàn dàxiǎo bìxū zhìshǎo 256"
+
+#~ msgid "Stopping AP is not supported."
+#~ msgstr "bù zhī chí tíng zhǐ AP."
+
+#~ msgid "Stream missing readinto() or write() method."
+#~ msgstr "Liú quēshǎo readinto() huò write() fāngfǎ."
+
+#~ msgid "Supply at least one UART pin"
+#~ msgstr "Dìngyì zhìshǎo yīgè UART yǐn jiǎo"
+
+#~ msgid "The BOOT button was pressed at start up.\n"
+#~ msgstr "qǐ dòng shí àn xià le yǐn dǎo àn niǔ.\n"
+
+#~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Increase the stack size if you know how. If not:"
+#~ msgstr ""
+#~ "diàn lù dàn duī bèi sǔn huài, yīn wéi duī zhàn tài xiǎo.\n"
+#~ "rú guǒ nín zhī dào rú hé zēng jiā duī zhàn dà xiǎo. rú guǒ méi yǒu:"
 
 #~ msgid ""
 #~ "The CircuitPython heap was corrupted because the stack was too small.\n"
@@ -6259,6 +5550,57 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ "zài rù nín de CIRCUITPY qūdòngqì:\n"
 
 #~ msgid ""
+#~ "The CircuitPython heap was corrupted because the stack was too small.\n"
+#~ "Please increase the stack size if you know how, or if not:"
+#~ msgstr ""
+#~ "Yóuyú duīzhàn tài xiǎo,CircuitPython duī yǐ sǔnhuài.\n"
+#~ "Rúguǒ nín zhīdào rúhé zēngjiā duīzhàn dàxiǎo, fǒuzé:"
+
+#~ msgid "The SW38 button was pressed at start up.\n"
+#~ msgstr "qǐ dòng shí àn xià le SW38 àn niǔ .\n"
+
+#~ msgid "The VOLUME button was pressed at start up.\n"
+#~ msgstr "qǐ dòng shí àn xià yīn liàng àn niǔ.\n"
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode."
+#~ msgstr ""
+#~ "`wēi kòng zhì qì` mó kuài yòng yú qǐ dòng dào ān quán mó shì. àn chóng "
+#~ "zhì tuì chū ān quán mó shì."
+
+#~ msgid ""
+#~ "The `microcontroller` module was used to boot into safe mode. Press reset "
+#~ "to exit safe mode.\n"
+#~ msgstr ""
+#~ "“Wēi kòngzhì qì” mókuài yòng yú qǐdòng ānquán móshì. Àn chóng zhì kě "
+#~ "tuìchū ānquán móshì.\n"
+
+#~ msgid "The central button was pressed at start up.\n"
+#~ msgstr "qǐ dòng shí àn xià zhōng yāng àn niǔ.\n"
+
+#~ msgid "The left button was pressed at start up.\n"
+#~ msgstr "qǐ dòng shí àn xià zuǒ àn niǔ.\n"
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY)."
+#~ msgstr ""
+#~ "wēi kòng zhì qì de gōng lǜ xià jiàng. què bǎo diàn yuán tí gòng\n"
+#~ "zú gòu de gōng lǜ yòng yú zhěng gè diàn lù hé àn chóng zhì (tán chū "
+#~ "CIRCUITPY hòu)."
+
+#~ msgid ""
+#~ "The microcontroller's power dipped. Make sure your power supply provides\n"
+#~ "enough power for the whole circuit and press reset (after ejecting "
+#~ "CIRCUITPY).\n"
+#~ msgstr ""
+#~ "wēi kòng zhì qì de gōng lǜ jiàng dī. Quèbǎo nín de diànyuán wèi zhěnggè\n"
+#~ "diànlù tígōng zúgòu de diànyuán, bìng àn xià fùwèi (Dànchū CIRCUITPY "
+#~ "zhīhòu).\n"
+
+#~ msgid ""
 #~ "The microcontroller's power dipped. Please make sure your power supply "
 #~ "provides\n"
 #~ "enough power for the whole circuit and press reset (after ejecting "
@@ -6268,6 +5610,9 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ "wèi\n"
 #~ "zhěnggè diànlù tígōng zúgòu de diànyuán bìng àn xià fùwèi (zài dànchū "
 #~ "CIRCUITPY hòu).\n"
+
+#~ msgid "The power dipped. Make sure you are providing enough power."
+#~ msgstr "lì liàng xià jiàng le. què bǎo nín tí gòng zú gòu de diàn lì."
 
 #~ msgid ""
 #~ "The reset button was pressed while booting CircuitPython. Press again to "
@@ -6279,11 +5624,146 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "Tile indices must be 0 - 255"
 #~ msgstr "Píng pū zhǐshù bìxū wèi 0 - 255"
 
+#~ msgid "Tile value out of bounds"
+#~ msgstr "Píng pū zhí chāochū fànwéi"
+
+#~ msgid ""
+#~ "Timer was reserved for internal use - declare PWM pins earlier in the "
+#~ "program"
+#~ msgstr ""
+#~ "Dìngshí qì bǎoliú gōng nèibù shǐyòng-zài chéngxù de qiánmiàn shēngmíng "
+#~ "PWM yǐn jiǎo"
+
+#~ msgid "To exit, please reset the board without "
+#~ msgstr "Yào tuìchū, qǐng chóng zhì bǎnkuài ér bùyòng "
+
+#~ msgid "To exit, please reset the board without requesting safe mode."
+#~ msgstr ""
+#~ "yào tuì chū, qǐng zài bù qǐng qiú ān quán mó shì de qíng kuàng xià chóng "
+#~ "zhì zhǔ bǎn."
+
+#~ msgid "Too many display busses"
+#~ msgstr "Xiǎnshì zǒngxiàn tài duōle"
+
+#~ msgid "Total data to write is larger than outgoing_packet_length"
+#~ msgstr "Yào xiě rù de zǒng shùjù dàyú outgoing_packet_length"
+
+#~ msgid "UART Buffer allocation error"
+#~ msgstr "UART huǎnchōng qū fēnpèi cuòwù"
+
+#~ msgid "UART De-init error"
+#~ msgstr "UART qǔxiāo chūshǐhuà cuòwù"
+
+#~ msgid "UART Init Error"
+#~ msgstr "UART chūshǐhuà cuòwù"
+
+#~ msgid "UART Re-init error"
+#~ msgstr "UART chóngxīn chūshǐhuà cuòwù"
+
+#~ msgid "UART not yet supported"
+#~ msgstr "UART shàng wèi shòu zhī chí"
+
+#~ msgid "UART write error"
+#~ msgstr "UART xiě cuòwù"
+
+#~ msgid "USB Busy"
+#~ msgstr "USB máng"
+
+#~ msgid "USB Error"
+#~ msgstr "USB Cuòwù"
+
 #~ msgid "UUID integer value not in range 0 to 0xffff"
 #~ msgstr "UUID zhěngshù zhí bùzài fànwéi 0 zhì 0xffff"
 
+#~ msgid "Unable to allocate the heap."
+#~ msgstr "wú fǎ fēn pèi duī."
+
+#, c-format
+#~ msgid "Unable to configure ADC DMA controller, ErrorCode:%d"
+#~ msgstr "wú fǎ pèi zhì ADC DMA kòng zhì qì, cuò wù dài mǎ:%d"
+
+#, c-format
+#~ msgid "Unable to initialize ADC DMA controller, ErrorCode:%d"
+#~ msgstr "wú fǎ chū shǐ huà ADC DMA kòng zhì qì, cuò wù dài mǎ:%d"
+
+#, c-format
+#~ msgid "Unable to start ADC DMA controller, ErrorCode:%d"
+#~ msgstr "wú fǎ qǐ dòng ADC DMA kòng zhì qì, cuò wù dài mǎ:%d"
+
+#~ msgid "Unable to write"
+#~ msgstr "wú fǎ xiě rù"
+
+#~ msgid "Unable to write to address."
+#~ msgstr "Wú fǎ xiě rù dì zhǐ."
+
+#~ msgid "Unknown failure"
+#~ msgstr "Wèizhī gùzhàng"
+
+#~ msgid "Unknown soft device error: %04x"
+#~ msgstr "Wèizhī de ruǎn shèbèi cuòwù: %04x"
+
+#, c-format
+#~ msgid "Unkown error code %d"
+#~ msgstr "wèi zhī cuò wù dài %d"
+
+#~ msgid "Unsupported baudrate"
+#~ msgstr "Bù zhīchí de baudrate"
+
+#~ msgid "Unsupported operation"
+#~ msgstr "Bù zhīchí de cāozuò"
+
+#~ msgid "Unsupported pull value."
+#~ msgstr "Bù zhīchí de lādòng zhí."
+
+#~ msgid "Viper functions don't currently support more than 4 arguments"
+#~ msgstr "Viper hánshù mùqián bù zhīchí chāoguò 4 gè cānshù"
+
 #~ msgid "Voice index too high"
 #~ msgstr "Yǔyīn suǒyǐn tài gāo"
+
+#~ msgid "WatchDogTimer is not currently running"
+#~ msgstr "WatchDogTimer dāngqián wèi yùnxíng"
+
+#~ msgid "WatchDogTimer.mode cannot be changed once set to WatchDogMode.RESET"
+#~ msgstr ""
+#~ "Yīdàn shèzhì wèi WatchDogMode.RESET, zé bùnéng gēnggǎi WatchDogTimer.Mode"
+
+#~ msgid "WatchDogTimer.timeout must be greater than 0"
+#~ msgstr "WatchDogTimer.Timeout bìxū dàyú 0"
+
+#~ msgid "Watchdog timer expired."
+#~ msgstr "Kān mén gǒu dìngshí qì yǐ guòqí."
+
+#, c-format
+#~ msgid ""
+#~ "Welcome to Adafruit CircuitPython %s!\n"
+#~ "\n"
+#~ "Please visit learn.adafruit.com/category/circuitpython for project "
+#~ "guides.\n"
+#~ "\n"
+#~ "To list built-in modules please do `help(\"modules\")`.\n"
+#~ msgstr ""
+#~ "Huānyíng lái dào Adafruit CircuitPython%s!\n"
+#~ "\n"
+#~ "Qǐng fǎngwèn learn.Adafruit.Com/category/circuitpython yǐ huòqǔ xiàngmù "
+#~ "zhǐnán.\n"
+#~ "\n"
+#~ "Yào liè chū nèizhì mókuài, qǐng zhíxíng `help(“modules”)`\n"
+
+#~ msgid "WiFi password must be between 8 and 63 characters"
+#~ msgstr "WiFi mìmǎ bìxū jiè yú 8 dào 63 gè zìfú zhī jiān"
+
+#~ msgid "Wifi is in access point mode."
+#~ msgstr "Wú xiàn wǎng luò chǔ yú jiē rù diǎn mó shì."
+
+#~ msgid "Wifi is in station mode."
+#~ msgstr "Wú xiàn wǎng luò chǔ yú gōng zuò zhàn mó shì."
+
+#~ msgid "You are in safe mode because:\n"
+#~ msgstr "nín chǔ yú ān quán mó shì, yīn wéi:\n"
+
+#~ msgid "You are in safe mode: something unanticipated happened.\n"
+#~ msgstr "Nín chǔyú ānquán móshì: Chū hū yìliào de shìqíng fāshēngle.\n"
 
 #~ msgid ""
 #~ "You are running in safe mode which means something unanticipated "
@@ -6292,32 +5772,232 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ "Nǐ zhèngzài ānquán móshì xià yùnxíng, zhè yì wèi zhuó yìwài fāshēng de "
 #~ "shìqíng.\n"
 
+#~ msgid ""
+#~ "You pressed the reset button during boot. Press again to exit safe mode."
+#~ msgstr ""
+#~ "zài qǐ dòng guò chéng zhōng, nín àn xià le chóng zhì àn niǔ. zài cì àn "
+#~ "xià yǐ tuì chū ān quán mó shì."
+
+#~ msgid "You requested starting safe mode by "
+#~ msgstr "Nín qǐngqiú qǐdòng ānquán móshì "
+
+#~ msgid "__init__() should return None, not '%q'"
+#~ msgstr "__Init __() yīnggāi fǎnhuí None, ér bùshì '%q'"
+
+#~ msgid "abort() called"
+#~ msgstr "abort() diàoyòng"
+
+#~ msgid "address %08x is not aligned to %d bytes"
+#~ msgstr "wèi zhǐ %08x wèi yǔ %d wèi yuán zǔ duìqí"
+
+#~ msgid "address out of bounds"
+#~ msgstr "dìzhǐ chāochū biānjiè"
+
+#~ msgid "arctan2 is implemented for scalars and ndarrays only"
+#~ msgstr "arctan2 jǐn zhēnduì biāoliàng hé ndarray shíxiàn"
+
+#~ msgid "argument must be ndarray"
+#~ msgstr "Cānshù bìxū shì ndarray"
+
+#~ msgid "attributes not supported yet"
+#~ msgstr "shǔxìng shàngwèi zhīchí"
+
+#~ msgid "axis must be -1, 0, None, or 1"
+#~ msgstr "zhóu bìxū wèi-1,0, wú huò 1"
+
+#~ msgid "axis must be -1, 0, or 1"
+#~ msgstr "zhóu bìxū wèi-1,0 huò 1"
+
+#~ msgid "axis must be None, 0, or 1"
+#~ msgstr "zhóu bìxū wèi None,0 huò 1"
+
 #~ msgid "bad GATT role"
 #~ msgstr "zǒng xiédìng de bùliáng juésè"
+
+#~ msgid "bits must be 7, 8 or 9"
+#~ msgstr "bǐtè bìxū shì 7,8 huò 9"
 
 #~ msgid "bits must be 8"
 #~ msgstr "bǐtè bìxū shì 8"
 
+#~ msgid "bits must be in range 5 to 9"
+#~ msgstr "wèi bì xū zài fàn wéi nèi 5 zhì 9"
+
 #~ msgid "buf is too small. need %d bytes"
 #~ msgstr "huǎnchōng tài xiǎo. Xūyào%d zì jié"
+
+#~ msgid "buffer must be a bytes-like object"
+#~ msgstr "huǎnchōng qū bìxū shì zì jié lèi duìxiàng"
 
 #~ msgid "buffers must be the same length"
 #~ msgstr "huǎnchōng qū bìxū shì chángdù xiāngtóng"
 
+#~ msgid "buttons must be digitalio.DigitalInOut"
+#~ msgstr "ànniǔ bìxū shì digitalio.DigitalInOut"
+
+#~ msgid "byte code not implemented"
+#~ msgstr "zì jié dàimǎ wèi zhíxíng"
+
+#~ msgid "byteorder is not a string"
+#~ msgstr "byteorder bùshì zìfú chuàn"
+
 #~ msgid "byteorder is not an instance of ByteOrder (got a %s)"
 #~ msgstr "zì jié bùshì zì jié xù shílì (yǒu %s)"
+
+#~ msgid "bytes > 8 bits not supported"
+#~ msgstr "zì jié > 8 wèi"
+
+#~ msgid "calibration value out of range +/-127"
+#~ msgstr "jiàozhǔn zhí chāochū fànwéi +/-127"
+
+#~ msgid "can only be registered in one parent"
+#~ msgstr "zhǐ néng zài yí gè jiā zhǎng zhōng zhù cè"
+
+#~ msgid "can only save bytecode"
+#~ msgstr "zhǐ néng bǎocún zì jié mǎ jìlù"
+
+#~ msgid "can't convert %q to int"
+#~ msgstr "wú fǎ jiāng %q zhuǎn huàn wéi nèi zài"
+
+#~ msgid "can't convert address to int"
+#~ msgstr "wúfǎ jiāng dìzhǐ zhuǎnhuàn wèi int"
+
+#~ msgid "can't convert to %q"
+#~ msgstr "wúfǎ zhuǎnhuàn wèi %q"
+
+#~ msgid "can't do truncated division of a complex number"
+#~ msgstr "bùnéng fēnjiě fùzá de shùzì"
+
+#~ msgid "can't have multiple **x"
+#~ msgstr "wúfǎ yǒu duō gè **x"
+
+#~ msgid "can't have multiple *x"
+#~ msgstr "wúfǎ yǒu duō gè *x"
+
+#~ msgid "can't pend throw to just-started generator"
+#~ msgstr "bùnéng bǎ tā rēng dào gāng qǐdòng de fā diànjī shàng"
+
+#~ msgid "cannot import name %q"
+#~ msgstr "wúfǎ dǎorù míngchēng %q"
+
+#~ msgid "cannot perform relative import"
+#~ msgstr "wúfǎ zhíxíng xiāngguān dǎorù"
+
+#~ msgid "cannot reshape array (incompatible input/output shape)"
+#~ msgstr "wúfǎ zhěngxíng shùzǔ (bù jiānróng de shūrù/shūchū xíngzhuàng)"
+
+#~ msgid "cannot unambiguously get sizeof scalar"
+#~ msgstr "bù néng háo bù hán hu de dé dào dà xiǎo de lín"
 
 #~ msgid "characteristics includes an object that is not a Characteristic"
 #~ msgstr "tèxìng bāokuò bùshì zìfú de wùtǐ"
 
+#~ msgid "circle can only be registered in one parent"
+#~ msgstr "quānzi zhǐ néng zài yī wèi jiāzhǎng zhōng zhùcè"
+
 #~ msgid "color buffer must be a buffer or int"
 #~ msgstr "yánsè huǎnchōng qū bìxū shì huǎnchōng qū huò zhěngshù"
+
+#~ msgid "color should be an int"
+#~ msgstr "yánsè yīng wèi zhěngshù"
+
+#~ msgid "complex division by zero"
+#~ msgstr "fùzá de fēngé wèi 0"
+
+#~ msgid "constant must be an integer"
+#~ msgstr "chángshù bìxū shì yīgè zhěngshù"
+
+#~ msgid "could not broadast input array from shape"
+#~ msgstr "wúfǎ guǎngbò xíngzhuàng de shūrù shùzǔ"
+
+#~ msgid "ddof must be smaller than length of data set"
+#~ msgstr "ddof bìxū xiǎoyú shùjù jí de chángdù"
+
+#~ msgid "destination_length must be an int >= 0"
+#~ msgstr "mùbiāo chángdù bìxū shì > = 0 de zhěngshù"
+
+#~ msgid "divisor must be 4"
+#~ msgstr "èr chóng zòu bì xū shì 4"
+
+#~ msgid "end_x should be an int"
+#~ msgstr "jiéwěi_x yīnggāi shì yīgè zhěngshù"
+
+#~ msgid ""
+#~ "esp32_camera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "esp32_camera. shè xiàng jī xū yào pèi zhì yù liú de PSRAM. yǒu guān shuō "
+#~ "míng, qǐng cān yuè wén dàng."
+
+#~ msgid ""
+#~ "espcamera.Camera requires reserved PSRAM to be configured. See the "
+#~ "documentation for instructions."
+#~ msgstr ""
+#~ "espcamera.Camera xū yào pèi zhì bǎo liú de PSRAM. yǒu guān shuō míng, "
+#~ "qǐng cān yuè wén dàng."
+
+#~ msgid "expected '%q' but got '%q'"
+#~ msgstr "yùqí wèi'%q'dàn dédàole'%q'"
+
+#~ msgid "expected '%q' or '%q' but got '%q'"
+#~ msgstr "yùqí wèi'%q'huò'%q', dàn huòdéle'%q'"
 
 #~ msgid "expected a DigitalInOut"
 #~ msgstr "qídài de DigitalInOut"
 
+#~ msgid "f-string expression part cannot include a '#'"
+#~ msgstr "f-string biǎodá shì bùfèn bùnéng bāohán '#'"
+
+#~ msgid "f-string expression part cannot include a backslash"
+#~ msgstr "f-string biǎodá shì bùfèn bùnéng bāohán fǎn xié gāng"
+
+#~ msgid "f-string: empty expression not allowed"
+#~ msgstr "f-string: bù yǔnxǔ shǐyòng kōng biǎodá shì"
+
+#~ msgid "f-string: expecting '}'"
+#~ msgstr "f-string: qídài '}'"
+
+#~ msgid "f-string: single '}' is not allowed"
+#~ msgstr "f-string: bù yǔnxǔ shǐyòng dāngè '}'"
+
+#~ msgid "first argument must be an iterable"
+#~ msgstr "dì yī gè cānshù bìxū shì kě diédài de"
+
 #~ msgid "firstbit must be MSB"
 #~ msgstr "dì yī wèi bìxū shì MSB"
+
+#~ msgid "frequency is read-only for this board"
+#~ msgstr "cǐ zhǔ bǎn de pín lǜ wéi zhǐ dú"
+
+#~ msgid "function does not take keyword arguments"
+#~ msgstr "hánshù méiyǒu guānjiàn cí cānshù"
+
+#~ msgid "function is implemented for scalars and ndarrays only"
+#~ msgstr "gāi hánshù jǐn zhēnduì biāoliàng hé ndarray shíxiàn"
+
+#~ msgid "incompatible native .mpy architecture"
+#~ msgstr "bù jiān róng de yuán shēng .mpy jià gòu"
+
+#~ msgid "input and output shapes are not compatible"
+#~ msgstr "shū rù hé shū chū xíng zhuàng bù jiān róng"
+
+#~ msgid "input argument must be an integer or a 2-tuple"
+#~ msgstr "shūrù cānshù bìxū shì zhěngshù huò 2 yuán zǔ"
+
+#~ msgid "input must be a tensor of rank 2"
+#~ msgstr "shū rù bì xū shì děng jí 2 de zhāng liàng"
+
+#~ msgid "inputs are not iterable"
+#~ msgstr "shū rù bù kě yí dòng"
+
+#~ msgid "int() arg 2 must be >= 2 and <= 36"
+#~ msgstr "zhěngshù() cānshù 2 bìxū > = 2 qiě <= 36"
+
+#~ msgid "integer required"
+#~ msgstr "xūyào zhěngshù"
+
+#~ msgid "interp is defined for 1D arrays of equal length"
+#~ msgstr "interp shì wèi děng zhǎng de 1D shùzǔ dìngyì de"
 
 #~ msgid "interval not in range 0.0020 to 10.24"
 #~ msgstr "jùlí 0.0020 Zhì 10.24 Zhī jiān de jiàngé shíjiān"
@@ -6328,23 +6008,247 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "invalid SPI peripheral"
 #~ msgstr "wúxiào de SPI wàiwéi qì"
 
+#~ msgid "invalid architecture"
+#~ msgstr "wú xiào de jià gòu"
+
+#~ msgid "invalid arguments"
+#~ msgstr "wúxiào de cānshù"
+
+#~ msgid "invalid bits_per_pixel %d, must be, 1, 4, 8, 16, 24, or 32"
+#~ msgstr "wú xiào bits_per_pixel %d, bì xū shì, 1, 4, 8, 16, 24, huò 32"
+
+#~ msgid "invalid decorator"
+#~ msgstr "wú xiào zhuāng shì"
+
+#~ msgid "invalid dupterm index"
+#~ msgstr "dupterm suǒyǐn wúxiào"
+
+#~ msgid "invalid format"
+#~ msgstr "wúxiào géshì"
+
+#~ msgid "invalid traceback"
+#~ msgstr "wú xiào zhuī sù"
+
+#~ msgid "io must be rtc io"
+#~ msgstr "IO bì xū shì RTC IO"
+
+#~ msgid "iterables are not of the same length"
+#~ msgstr "kě diédài xiàng de chángdù bùtóng"
+
+#~ msgid "keyword argument(s) not yet implemented - use normal args instead"
+#~ msgstr "guānjiàn zì cānshù shàngwèi shíxiàn - qǐng shǐyòng chángguī cānshù"
+
+#~ msgid "keywords must be strings"
+#~ msgstr "guānjiàn zì bìxū shì zìfú chuàn"
+
+#~ msgid "length argument not allowed for this type"
+#~ msgstr "bù yǔnxǔ gāi lèixíng de chángdù cānshù"
+
+#~ msgid "long int not supported in this build"
+#~ msgstr "cǐ bǎnběn bù zhīchí zhǎng zhěngshù"
+
+#~ msgid "matrix dimensions do not match"
+#~ msgstr "jǔzhèn chǐcùn bù pǐpèi"
+
+#~ msgid "max_connections must be between 0 and 10"
+#~ msgstr "max_connections bì xū jiè yú 0 hé 10 zhī jiān"
+
+#~ msgid "max_length must be > 0"
+#~ msgstr "Max_length bìxū > 0"
+
+#~ msgid "max_length must be >= 0"
+#~ msgstr "zuì dà cháng dù bì xū >= 0"
+
+#~ msgid "maximum number of dimensions is 4"
+#~ msgstr "zuì dà chǐ cùn shù wéi 4"
+
 #~ msgid "must specify all of sck/mosi/miso"
 #~ msgstr "bìxū zhǐdìng suǒyǒu sck/mosi/misco"
+
+#~ msgid "n must be between 0, and 9"
+#~ msgstr "n bìxū jiè yú 0 dào 9 zhī jiān"
 
 #~ msgid "name must be a string"
 #~ msgstr "míngchēng bìxū shì yīgè zìfú chuàn"
 
+#~ msgid "name reused for argument"
+#~ msgstr "cān shǔ míngchēng bèi chóngxīn shǐyòng"
+
+#~ msgid "no available NIC"
+#~ msgstr "méiyǒu kěyòng de NIC"
+
+#~ msgid "no reset pin available"
+#~ msgstr "Méiyǒu kěyòng de fùwèi yǐn jiǎo"
+
+#~ msgid "non-Device in %q"
+#~ msgstr "fēi shè bèi zài %q"
+
+#~ msgid "non-keyword arg after */**"
+#~ msgstr "zài */** zhīhòu fēi guānjiàn cí cānshù"
+
+#~ msgid "non-keyword arg after keyword arg"
+#~ msgstr "guānjiàn zì cānshù zhīhòu de fēi guānjiàn zì cānshù"
+
+#~ msgid "norm is defined for 1D and 2D arrays"
+#~ msgstr "wéi 1D hé 2D shù zǔ dìng yì guī fàn"
+
+#~ msgid "number of arguments must be 2, or 3"
+#~ msgstr "cānshù shùliàng bìxū wèi 2 huò 3"
+
+#~ msgid "object '%q' is not a tuple or list"
+#~ msgstr "duìxiàng '%q' bùshì yuán zǔ huò lièbiǎo"
+
+#~ msgid "object '%s' is not a tuple or list"
+#~ msgstr "duìxiàng '%s' bùshì yuán zǔ huò lièbiǎo"
+
+#~ msgid "object does not support item assignment"
+#~ msgstr "duìxiàng bù zhīchí xiàngmù fēnpèi"
+
+#~ msgid "object does not support item deletion"
+#~ msgstr "duìxiàng bù zhīchí shānchú xiàngmù"
+
+#~ msgid "object is not subscriptable"
+#~ msgstr "duìxiàng bùnéng xià biāo"
+
+#~ msgid "object of type '%q' has no len()"
+#~ msgstr "lèixíng '%q' de duìxiàng méiyǒu len()"
+
+#~ msgid "offset out of bounds"
+#~ msgstr "piānlí biānjiè"
+
+#~ msgid "out of range of source"
+#~ msgstr "yuán fàn wéi wài"
+
+#~ msgid "palette_index should be an int"
+#~ msgstr "yánsè suǒyǐn yīnggāi shì yīgè zhěngshù"
+
+#~ msgid "parameter annotation must be an identifier"
+#~ msgstr "cānshù zhùshì bìxū shì biāozhì fú"
+
+#~ msgid "pixel value requires too many bits"
+#~ msgstr "xiàngsù zhí xūyào tài duō wèi"
+
+#~ msgid "pixel_shader must be displayio.Palette or displayio.ColorConverter"
+#~ msgstr ""
+#~ "pixel_shader bìxū shì displayio.Palette huò displayio.ColorConverter"
+
+#~ msgid "polygon can only be registered in one parent"
+#~ msgstr "duōbiānxíng zhī néng zài yīgè fù jí zhōng zhùcè"
+
+#~ msgid "pop from an empty set"
+#~ msgstr "cóng kōng jí dànchū"
+
+#~ msgid "pop from empty list"
+#~ msgstr "cóng kōng lièbiǎo zhòng dànchū"
+
+#~ msgid "popitem(): dictionary is empty"
+#~ msgstr "dànchū xiàngmù (): Zìdiǎn wèi kōng"
+
+#~ msgid "pressing BOOT button at start up.\n"
+#~ msgstr "zài qǐdòng shí àn BOOT ànniǔ.\n"
+
+#~ msgid "pressing SW38 button at start up.\n"
+#~ msgstr "zài qǐdòng shí àn SW38 ànniǔ.\n"
+
+#~ msgid "pressing VOLUME button at start up.\n"
+#~ msgstr "zài qǐdòng shí àn SW38 ànniǔ.\n"
+
+#~ msgid "pressing boot button at start up.\n"
+#~ msgstr "Zài qǐdòng shí àn qǐdòng ànniǔ.\n"
+
+#~ msgid "pressing both buttons at start up.\n"
+#~ msgstr "zài qǐdòng shí tóngshí àn xià liǎng gè ànniǔ.\n"
+
+#~ msgid "pressing the left button at start up\n"
+#~ msgstr "qǐ dòng shí àn xià zuǒ àn niǔ\n"
+
+#~ msgid "pull_threshold must be between 1 and 32"
+#~ msgstr "lā lì yù zhí bì xū jiè yú 1 hé 32 zhī jiān"
+
+#~ msgid "push_threshold must be between 1 and 32"
+#~ msgstr "tuī sòng yù zhí bì xū jiè yú 1 hé 32 zhī jiān"
+
+#~ msgid "queue overflow"
+#~ msgstr "duìliè yìchū"
+
+#~ msgid "raw REPL; CTRL-B to exit\n"
+#~ msgstr "yuán shǐ REPL; CTRL-B tuì chū\n"
+
+#~ msgid "raw f-strings are not implemented"
+#~ msgstr "wèi zhíxíng yuánshǐ f-strings"
+
 #~ msgid "rawbuf is not the same size as buf"
 #~ msgstr "yuánshǐ huǎnchōng qū hé huǎnchōng qū de dàxiǎo bùtóng"
+
+#~ msgid "right hand side must be an ndarray, or a scalar"
+#~ msgstr "yòubiān bìxū shì ndarray huò biāoliàng"
 
 #~ msgid "row must be packed and word aligned"
 #~ msgstr "xíng bìxū dǎbāo bìngqiě zì duìqí"
 
+#~ msgid ""
+#~ "sample_source buffer must be a bytearray or array of type 'h', 'H', 'b' "
+#~ "or 'B'"
+#~ msgstr ""
+#~ "yàngběn yuán_yuán huǎnchōng qū bìxū shì zì yǎnlèi huò lèixíng 'h', 'H', "
+#~ "'b' huò 'B' de shùzǔ"
+
+#~ msgid "schedule stack full"
+#~ msgstr "jìhuà duīzhàn yǐ mǎn"
+
 #~ msgid "services includes an object that is not a Service"
 #~ msgstr "fúwù bāokuò yīgè bùshì fúwù de wùjiàn"
 
+#~ msgid "shape must be a 2-tuple"
+#~ msgstr "xíngzhuàng bìxū shì 2 yuán zǔ"
+
+#~ msgid "shape must be a tuple"
+#~ msgstr "xíng zhuàng bì xū shì yí gè yuán zǔ"
+
+#~ msgid "single '}' encountered in format string"
+#~ msgstr "zài géshì zìfú chuàn zhōng yù dào de dāngè '}'"
+
+#~ msgid "slice step can't be zero"
+#~ msgstr "qiēpiàn bù cháng bùnéng wéi líng"
+
+#~ msgid "slice step cannot be zero"
+#~ msgstr "qiēpiàn bù bùnéng wéi líng"
+
+#~ msgid "sorted axis can't be longer than 65535"
+#~ msgstr "pái xù zhóu bù néng chāo guò 65535"
+
+#~ msgid "ssid can't be more than 32 bytes"
+#~ msgstr "ssid bù néng chāo guò 32 gè zì jié"
+
+#~ msgid "start_x should be an int"
+#~ msgstr "kāishǐ_x yīnggāi shì yīgè zhěngshù"
+
+#~ msgid "step must be non-zero"
+#~ msgstr "bùzhòu bìxū shìfēi líng"
+
+#~ msgid "stop must be 1 or 2"
+#~ msgstr "tíngzhǐ bìxū wèi 1 huò 2"
+
+#~ msgid "string indices must be integers, not %q"
+#~ msgstr "zìfú chuàn suǒyǐn bìxū shì zhěngshù, ér bùshì %q"
+
+#~ msgid "string not supported; use bytes or bytearray"
+#~ msgstr "zìfú chuàn bù zhīchí; shǐyòng zì jié huò zì jié zǔ"
+
+#~ msgid "struct: cannot index"
+#~ msgstr "jiégòu: bùnéng suǒyǐn"
+
+#~ msgid "threshold must be in the range 0-65536"
+#~ msgstr "yùzhí bìxū zài fànwéi 0-65536"
+
 #~ msgid "tile index out of bounds"
 #~ msgstr "kuài suǒyǐn chāochū fànwéi"
+
+#~ msgid "tile must be greater than zero"
+#~ msgstr "cí tiē bì xū dà yú líng"
+
+#~ msgid "time.struct_time() takes a 9-sequence"
+#~ msgstr "time.struct_time() xūyào 9 xùliè"
 
 #~ msgid "time.struct_time() takes exactly 1 argument"
 #~ msgstr "time.struct_time() xūyào wánquán 1 cānshù"
@@ -6352,8 +6256,39 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "timeout >100 (units are now seconds, not msecs)"
 #~ msgstr "chāoshí >100 (dānwèi shì miǎo, ér bùshì háomiǎo)"
 
+#~ msgid "timeout must be 0.0-100.0 seconds"
+#~ msgstr "Chāo shí shíjiān bìxū wèi 0.0 Dào 100.0 Miǎo"
+
+#~ msgid "timeout must be >= 0.0"
+#~ msgstr "chāoshí bìxū shì >= 0.0"
+
 #~ msgid "too many arguments"
 #~ msgstr "tài duō cānshù"
+
+#~ msgid "too many arguments provided with the given format"
+#~ msgstr "tígōng jǐ dìng géshì de cānshù tài duō"
+
+#~ msgid "trapz is defined for 1D arrays"
+#~ msgstr "wéi 1D shù zǔ dìng yì xiàn jǐng"
+
+#~ msgid "trigger level must be 0 or 1"
+#~ msgstr "chù fā jí bié bì xū wéi 0 huò 1"
+
+#~ msgid "tuple index out of range"
+#~ msgstr "yuán zǔ suǒyǐn chāochū fànwéi"
+
+#~ msgid "tuple/list required on RHS"
+#~ msgstr "RHS yāoqiú de yuán zǔ/lièbiǎo"
+
+#~ msgid "type object 'generator' has no attribute '__await__'"
+#~ msgstr "lèi xíng duì xiàng 'generator' méi yǒu shǔ xìng '__await__'"
+
+#~ msgid "unindent does not match any outer indentation level"
+#~ msgstr "bùsuō jìn yǔ rènhé wàibù suō jìn jíbié dōu bù pǐpèi"
+
+#, fuzzy
+#~ msgid "unknown format code '%c' for object of type '%s'"
+#~ msgstr "lèixíng '%s' duìxiàng wèizhī de géshì dàimǎ '%c'"
 
 #~ msgid "unknown format code '%c' for object of type 'float'"
 #~ msgstr "lèixíng 'float' duìxiàng wèizhī de géshì dàimǎ '%c'"
@@ -6361,8 +6296,57 @@ msgstr "zi bìxū jùyǒu xíngzhuàng (n_section,2)"
 #~ msgid "unknown format code '%c' for object of type 'str'"
 #~ msgstr "lèixíng 'str' duìxiàng wèizhī de géshì dàimǎ '%c'"
 
+#~ msgid "unmatched '{' in format"
+#~ msgstr "géshì wèi pǐpèi '{'"
+
 #~ msgid "unsupported bitmap type"
 #~ msgstr "bù zhīchí de bitmap lèixíng"
 
+#~ msgid "unsupported type for %q: '%q'"
+#~ msgstr "%q de bù shòu zhīchí de lèixíng: '%q'"
+
+#~ msgid "unsupported types for %q: '%s', '%s'"
+#~ msgstr "bù zhīchí de lèixíng wèi %q: '%s', '%s'"
+
+#~ msgid "value_count must be > 0"
+#~ msgstr "zhí jìshù bìxū wèi > 0"
+
+#~ msgid "vectors must have same lengths"
+#~ msgstr "xiàngliàng bìxū jùyǒu xiāngtóng de chángdù"
+
+#~ msgid "wakeup conflict"
+#~ msgstr "huàn xǐng chōng tū"
+
+#~ msgid "watchdog not initialized"
+#~ msgstr "wèi chū shǐ huà jiān shì qì"
+
+#~ msgid "watchdog timeout must be greater than 0"
+#~ msgstr "kān mén gǒu chāoshí bìxū dàyú 0"
+
+#, c-format
+#~ msgid "width must be from 2 to 8 (inclusive), not %d"
+#~ msgstr "kuān dù bì xū cóng 2 dào 8 ( hán ), ér bù shì %d"
+
 #~ msgid "write_args must be a list, tuple, or None"
 #~ msgstr "xiě cānshù bìxū shì yuán zǔ, lièbiǎo huò None"
+
+#~ msgid "wrong argument type"
+#~ msgstr "cuòwù de cānshù lèixíng"
+
+#~ msgid "wrong operand type"
+#~ msgstr "cuòwù de cāozuò shù lèixíng"
+
+#~ msgid "x value out of bounds"
+#~ msgstr "x zhí chāochū biānjiè"
+
+#~ msgid "xTaskCreate failed"
+#~ msgstr "xTaskCreate shī bài"
+
+#~ msgid "y should be an int"
+#~ msgstr "y yīnggāi shì yīgè zhěngshù"
+
+#~ msgid "y value out of bounds"
+#~ msgstr "y zhí chāochū biānjiè"
+
+#~ msgid "zero step"
+#~ msgstr "líng bù"


### PR DESCRIPTION
In #8639 Dan noticed that weblate was still offering "%S" as a string to translate. I don't understand why this occurs, because the string is no longer in circuitpython.pot; so weblate should move it to the "fuzzy" section of the .po files when it synchronizes them.

I also noticed that the "%02X" string should never be localized and moved it to synthetic.pot.

After making that change, I ran "make translate" followed by "make msgmerge"; normally we rely on weblate running this step, but for whatever reason this is not the case this time.

This change looks bigger than it really is because msgmerge totally re-ordered the "fuzzy messages" section of each po file.

After this, I will force reset weblate back to match our main branch again and re-open translations on weblate.