### PR TITLE
ESP32-S3 BLE fixes

### DIFF
--- a/ports/espressif/common-hal/_bleio/Adapter.c
+++ b/ports/espressif/common-hal/_bleio/Adapter.c
@@ -284,15 +284,21 @@ STATIC void _new_connection(uint16_t conn_handle) {
     esp_ble_tx_power_set(conn_handle, ESP_PWR_LVL_N0);
 
 
-    // Find an empty connection. One must always be available because the SD has the same
+    // Find an empty connection. One should always be available because the SD has the same
     // total connection limit.
-    bleio_connection_internal_t *connection;
+    bleio_connection_internal_t *connection = NULL;
     for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
         connection = &bleio_connections[i];
         if (connection->conn_handle == BLEIO_HANDLE_INVALID) {
             break;
         }
     }
+
+    // Shouldn't happen, but just return if no connection available.
+    if (!connection) {
+        return;
+    }
+
     connection->conn_handle = conn_handle;
     connection->connection_obj = mp_const_none;
     connection->pair_status = PAIR_NOT_PAIRED;

--- a/ports/espressif/common-hal/_bleio/Characteristic.c
+++ b/ports/espressif/common-hal/_bleio/Characteristic.c
@@ -50,7 +50,25 @@ void common_hal_bleio_characteristic_construct(bleio_characteristic_obj_t *self,
     self->props = props;
     self->read_perm = read_perm;
     self->write_perm = write_perm;
-    common_hal_bleio_characteristic_set_value(self, initial_value_bufinfo);
+
+    if (initial_value_bufinfo != NULL) {
+        // Copy the initial value if it's on the heap. Otherwise it's internal and we may not be able
+        // to allocate.
+        self->current_value_len = initial_value_bufinfo->len;
+        if (gc_alloc_possible()) {
+            if (gc_nbytes(initial_value_bufinfo->buf) > 0) {
+                uint8_t *initial_value = m_malloc(self->current_value_len);
+                self->current_value_alloc = self->current_value_len;
+                memcpy(initial_value, initial_value_bufinfo->buf, self->current_value_len);
+                self->current_value = initial_value;
+            } else {
+                self->current_value_alloc = 0;
+                self->current_value = initial_value_bufinfo->buf;
+            }
+        } else {
+            self->current_value = initial_value_bufinfo->buf;
+        }
+    }
 
     if (gc_alloc_possible()) {
         self->descriptor_list = mp_obj_new_list(0, NULL);

--- a/ports/espressif/common-hal/_bleio/__init__.c
+++ b/ports/espressif/common-hal/_bleio/__init__.c
@@ -112,7 +112,8 @@ void check_nimble_error(int rc, const char *file, size_t line) {
 }
 
 void check_ble_error(int error_code, const char *file, size_t line) {
-    if (error_code == BLE_ERR_SUCCESS) {
+    // 0 means success. For BLE_HS_* codes, there is no defined "SUCCESS" value.
+    if (error_code == 0) {
         return;
     }
     switch (error_code) {

--- a/ports/espressif/mpconfigport.h
+++ b/ports/espressif/mpconfigport.h
@@ -28,6 +28,9 @@
 #ifndef MICROPY_INCLUDED_ESPRESSIF_MPCONFIGPORT_H
 #define MICROPY_INCLUDED_ESPRESSIF_MPCONFIGPORT_H
 
+// Enable for debugging.
+// #define CIRCUITPY_VERBOSE_BLE               (1)
+
 #define MICROPY_NLR_THUMB                   (0)
 
 #define MICROPY_USE_INTERNAL_PRINTF         (0)

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -470,7 +470,9 @@ void background_callback_run_all(void);
 #error "boot counter requires CIRCUITPY_NVM enabled"
 #endif
 
+#ifndef CIRCUITPY_VERBOSE_BLE
 #define CIRCUITPY_VERBOSE_BLE 0
+#endif
 
 // Display the Blinka logo in the REPL on displayio displays.
 #ifndef CIRCUITPY_REPL_LOGO

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -353,7 +353,8 @@ STATIC mp_obj_t bleio_adapter_start_scan(size_t n_args, const mp_obj_t *pos_args
     prefix_bufinfo.len = 0;
     if (args[ARG_prefixes].u_obj != MP_OBJ_NULL) {
         mp_get_buffer_raise(args[ARG_prefixes].u_obj, &prefix_bufinfo, MP_BUFFER_READ);
-        if (gc_nbytes(prefix_bufinfo.buf) == 0) {
+        // An empty buffer may not be on the heap, but that doesn't matter.
+        if (prefix_bufinfo.len > 0 && gc_nbytes(prefix_bufinfo.buf) == 0) {
             mp_raise_ValueError(MP_ERROR_TEXT("Prefix buffer must be on the heap"));
         }
     }


### PR DESCRIPTION
Fixes #8631.

Seems to fix ESP32-S3 BLE acting as a simple central. See https://forums.adafruit.com/viewtopic.php?t=206024 for user problems. I will point the users in that thread to the artifacts once this has built.

Tested on a BerryMed Pulse Oximeter with the library's simpletest.

Notes:
- #8631 fix fixes a problem exposed by the new split heap use.
- `BLE_ERR_SUCCESS` is 0, but was being used in places where the return values are actually `BLE_HS_*`. Nimble has multiple sets of error return codes, but no corresponding types, so it's hard to figure out which codes to use where. `BLE_HS_*` values don't have a zero `BLE_HS_OK` or `BLE_HS_SUCCESS`, unfortunately.
- Fixed some apparent missing returns in error cases.
- `common_hal_bleio_characteristic_set_value()` was being used to set a remote Characteristic value during discovery, but this did not work.
- An initial value should have been passed as a `bufinfo`, but was not.

There may be other problems, and the functionality is still limited in several ways. But this seems to fix some basic issues that were holding up using ESP32-S3 BLE as a central.