### PR TITLE
add branch and PR number to uploaded build filenames

### DIFF
--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -72,6 +72,7 @@ jobs:
       working-directory: tools
       env:
         BOARDS: ${{ matrix.board }}
+        PULL: ${{ github.event.number }}
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
       run: python3 -u ci_set_matrix.py
       working-directory: tools
       env:
+        PULL: ${{ github.event.number }}
         LAST_FAILED_JOBS: ${{ steps.get-last-commit-with-checks.outputs.check_runs }}
 
   tests:
@@ -294,3 +295,5 @@ jobs:
     with:
       boards: ${{ toJSON(fromJSON(needs.scheduler.outputs.ports)[matrix.port]) }}
       cp-version: ${{ needs.scheduler.outputs.cp-version }}
+    env:
+      PULL: ${{ github.event.number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,6 @@ jobs:
       run: python3 -u ci_set_matrix.py
       working-directory: tools
       env:
-        PULL: ${{ github.event.number }}
         LAST_FAILED_JOBS: ${{ steps.get-last-commit-with-checks.outputs.check_runs }}
 
   tests:
@@ -295,5 +294,3 @@ jobs:
     with:
       boards: ${{ toJSON(fromJSON(needs.scheduler.outputs.ports)[matrix.port]) }}
       cp-version: ${{ needs.scheduler.outputs.cp-version }}
-    env:
-      PULL: ${{ github.event.number }}

--- a/tools/build_board_info.py
+++ b/tools/build_board_info.py
@@ -75,7 +75,20 @@ def get_version_info():
         sha = os.environ["GITHUB_SHA"]
 
     if not version:
-        version = "{}-{}".format(date.today().strftime("%Y%m%d"), sha[:7])
+        # Get branch we are PR'ing into, if any.
+        branch = os.environ.get("GITHUB_BASE_REF", "").strip().replace("/", "_")
+        if not branch:
+            branch = "no-branch"
+
+        # Get PR number, if any
+        pull_request_maybe = os.environ.get("PULL", "")
+        if pull_request_maybe:
+            pull_request_maybe = f"-PR{pull_request_maybe}"
+
+        date_stamp = date.today().strftime("%Y%m%d")
+        short_sha = sha[:7]
+        # Example: 20231121-8.2.x-PR9876-123abcd
+        version = f"{date_stamp}-{branch}{pull_request_maybe}-{short_sha}"
 
     return sha, version
 


### PR DESCRIPTION
Fixes #8321.

Adds more information to uploaded build filenames, e.g.:
was
```
adafruit-circuitpython-adafruit_feather_esp32s2-en_US-20231122-b2c32cf.uf2
```
will be
```
adafruit-circuitpython-adafruit_feather_esp32s2-en_US-20231122-main-PR8645-b2c32cf.uf2
```