### PR TITLE
Improve web workflow error handling

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -368,6 +368,31 @@ curl -v -L http://circuitpython.local/cp/devices.json
 }
 ```
 
+#### `/cp/diskinfo.json`
+
+Returns information about the attached disk(s). A list of objects, one per disk.
+
+* `root`: File sysstem path to the root of the disk.
+* `free`: Count of free bytes on the disk.
+* `block_size`: Size of a block in bytes.
+* `writable`: True when CircuitPython and the web workflow can write to the disk. USB may claim a disk instead.
+* `total`: Total bytes that make up the disk.
+
+Example:
+```sh
+curl -v -L http://circuitpython.local/cp/diskinfo.json
+```
+
+```json
+[{
+	"root": "/",
+	"free": 2964992,
+	"block_size": 512,
+	"writable": true,
+	"total": 2967552
+}]
+```
+
 #### `/cp/serial/`
 
 
@@ -380,7 +405,7 @@ This is an authenticated endpoint in both modes.
 
 Returns information about the device.
 
-* `web_api_version`: Always `1`. This versions the rest of the API and new versions may not be backwards compatible.
+* `web_api_version`: Between `1` and `3`. This versions the rest of the API and new versions may not be backwards compatible. See below for more info.
 * `version`: CircuitPython build version.
 * `build_date`: CircuitPython build date.
 * `board_name`: Human readable name of the board.
@@ -436,3 +461,9 @@ CircuitPython is expected to be masked UTF-8, as the spec requires. Data from Ci
 client is unmasked. It is also unbuffered so the client will get a variety of frame sizes.
 
 Only one WebSocket at a time is supported.
+
+### Versions
+
+* `1` - Initial version.
+* `2` - Added `/cp/diskinfo.json`.
+* `3` - Changed `/cp/diskinfo.json` to return a list in preparation for multi-disk support.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -372,7 +372,7 @@ curl -v -L http://circuitpython.local/cp/devices.json
 
 Returns information about the attached disk(s). A list of objects, one per disk.
 
-* `root`: File sysstem path to the root of the disk.
+* `root`: Filesystem path to the root of the disk.
 * `free`: Count of free bytes on the disk.
 * `block_size`: Size of a block in bytes.
 * `writable`: True when CircuitPython and the web workflow can write to the disk. USB may claim a disk instead.

--- a/supervisor/shared/web_workflow/static/directory.html
+++ b/supervisor/shared/web_workflow/static/directory.html
@@ -4,7 +4,7 @@
     <title></title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="/style.css">
-    <link rel="stylesheet" href="http://circuitpython.org/assets/css/webworkflow-8.css">
+    <link rel="stylesheet" href="http://circuitpython.org/assets/css/webworkflow-9.css">
 </head>
 <body>
     <h1><a href="/"><img src="/favicon.ico"/></a>&nbsp;<span id="path"></span></h1>

--- a/supervisor/shared/web_workflow/static/edit.html
+++ b/supervisor/shared/web_workflow/static/edit.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Offline Code Edit</title>
-    <link rel="stylesheet" href="http://circuitpython.org/assets/css/webworkflow-8.css">
+    <link rel="stylesheet" href="http://circuitpython.org/assets/css/webworkflow-9.css">
     <link rel="stylesheet" href="/style.css">
 </head>
 <body>

--- a/supervisor/shared/web_workflow/static/serial.html
+++ b/supervisor/shared/web_workflow/static/serial.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="/style.css">
-  <link rel="stylesheet" href="http://circuitpython.org/assets/css/webworkflow-8.css">
+  <link rel="stylesheet" href="http://circuitpython.org/assets/css/webworkflow-9.css">
 </head>
 <body style="flex-direction: column; display: flex; height: 100%; width: 100%; margin: 0; font-size: 1rem;">
   <div style="flex: auto; display: flex; overflow: auto; flex-direction: column;">

--- a/supervisor/shared/web_workflow/static/welcome.html
+++ b/supervisor/shared/web_workflow/static/welcome.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/style.css">
-    <link rel="stylesheet" href="http://circuitpython.org/assets/css/webworkflow-8.css">
+    <link rel="stylesheet" href="http://circuitpython.org/assets/css/webworkflow-9.css">
 </head>
 <body>
 

--- a/supervisor/shared/web_workflow/web_workflow.h
+++ b/supervisor/shared/web_workflow/web_workflow.h
@@ -43,4 +43,4 @@ void supervisor_stop_web_workflow(void);
 mdns_server_obj_t *supervisor_web_workflow_mdns(mp_obj_t network_interface);
 
 // To share with websocket.
-void web_workflow_send_raw(socketpool_socket_obj_t *socket, const uint8_t *buf, int len);
+void web_workflow_send_raw(socketpool_socket_obj_t *socket, bool flush, const uint8_t *buf, int len);


### PR DESCRIPTION
* Disable Nagle at the end of error messages so they are sent before the socket is closed.
* Correctly discard file contents when the PUT file is too large.
* Correctly reset file size after failure to setting it too large.
* Change diskinfo.json to be list of disks in preparation of supporting multiple disks.
* Bump version to 3 for the above change.
* Document diskinfo.json.

Fixes #8109