### PR TITLE
rgbframebuffer: round up internal size to multiple of 16 pixels

### DIFF
--- a/ports/espressif/common-hal/dotclockframebuffer/DotClockFramebuffer.h
+++ b/ports/espressif/common-hal/dotclockframebuffer/DotClockFramebuffer.h
@@ -37,7 +37,7 @@
 typedef struct dotclockframebuffer_framebuffer_obj {
     mp_obj_base_t base;
     mp_buffer_info_t bufinfo;
-    mp_int_t row_stride;
+    mp_int_t width, row_stride;
     uint32_t frequency, refresh_rate;
     uint32_t first_pixel_offset;
     uint64_t used_pins_mask;


### PR DESCRIPTION
For a (width + left_overscan) of 360, e.g., debug info shows the following:
```
E (3410) cache: esp_cache_msync(35): size isn't aligned with the data cache line size (32)B
E (3410) lcd_panel.rgb: rgb_panel_draw_bitmap(742): flush cache buffer failed
```

Internally add extra pixels as needed at the end of a pixel row, like an automatic overscan_right.

This may not be compatible with all panels, but there's not really another alternative with this peripheral. So let's try this!

Closes: #8697