### PR TITLE
Use PIO DMA when transfer size exceeds FIFO length

### DIFF
--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
@@ -59,6 +59,7 @@ typedef struct {
     bool in_shift_right;
     bool user_interruptible;
     uint8_t offset;
+    uint8_t fifo_depth;  // Either 4 if FIFOs are not joined, or 8 if they are.
 
     // dma-related items
     volatile int pending_buffers;


### PR DESCRIPTION
- Fixes #8489.

As suggested in https://github.com/adafruit/circuitpython/issues/8489#issuecomment-1836574464, use DMA when the PIO transfer size exceeds the FIFO depth. Since the FIFOs might or might not be joined, figure out the FIFO depth in the constructor and remember it. (It's hard to retrieve the JOIN info from the config, so just use an extra byte to remember it.)

Tested using the test program in #8489 from 1-12 pixels. No jumping seen.

This is close to my first foray into PIO except for adjusting some NeoPixel timings, so careful review appreciated.