### PR TITLE
Add MIC and STEMMA_I2C to MEMENTO

### DIFF
--- a/ports/espressif/boards/adafruit_esp32s3_camera/pins.c
+++ b/ports/espressif/boards/adafruit_esp32s3_camera/pins.c
@@ -31,6 +31,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_CARD_CS), MP_ROM_PTR(&pin_GPIO48) },
 
+    { MP_ROM_QSTR(MP_QSTR_MIC), MP_ROM_PTR(&pin_GPIO2) },
+
     { MP_ROM_QSTR(MP_QSTR_IRQ), MP_ROM_PTR(&pin_GPIO3) },
 
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO1) },
@@ -65,6 +67,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_CAMERA_PWDN), MP_ROM_PTR(&pin_GPIO21) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_STEMMA_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
     { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display)},
 };


### PR DESCRIPTION
Adding MIC and STEMMA_I2C to MEMENTO. Closes https://github.com/adafruit/circuitpython/issues/8730