### PR TITLE
Reject RLE-compressed BMP files

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -206,6 +206,10 @@ msgstr ""
 msgid "%q must be array of type 'h'"
 msgstr ""
 
+#: shared-bindings/audiobusio/PDMIn.c
+msgid "%q must be multiple of 8."
+msgstr ""
+
 #: ports/raspberrypi/bindings/cyw43/__init__.c py/argcheck.c py/objexcept.c
 #: shared-bindings/canio/CAN.c shared-bindings/digitalio/Pull.c
 #: shared-module/synthio/Synthesizer.c
@@ -593,10 +597,6 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Bit clock and word select must share a clock unit"
-msgstr ""
-
-#: shared-bindings/audiobusio/PDMIn.c
-msgid "Bit depth must be multiple of 8."
 msgstr ""
 
 #: shared-bindings/bitmaptools/__init__.c
@@ -1339,10 +1339,6 @@ msgstr ""
 msgid "Mapping must be a tuple"
 msgstr ""
 
-#: shared-bindings/audiobusio/PDMIn.c
-msgid "Microphone startup delay must be in range 0.0 to 1.0"
-msgstr ""
-
 #: ports/raspberrypi/bindings/rp2pio/StateMachine.c
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "Mismatched data size"
@@ -1703,10 +1699,6 @@ msgstr ""
 
 #: ports/raspberrypi/bindings/rp2pio/StateMachine.c
 msgid "Out-buffer elements must be <= 4 bytes long"
-msgstr ""
-
-#: shared-bindings/audiobusio/PDMIn.c
-msgid "Oversample must be multiple of 8."
 msgstr ""
 
 #: shared-bindings/pwmio/PWMOut.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1832,6 +1832,10 @@ msgstr ""
 msgid "RISE_AND_FALL not available on this chip"
 msgstr ""
 
+#: shared-module/displayio/OnDiskBitmap.c
+msgid "RLE-compressed BMP not supported"
+msgstr ""
+
 #: ports/stm/common-hal/os/__init__.c
 msgid "RNG DeInit Error"
 msgstr ""
@@ -1991,10 +1995,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
 msgid "Stereo right must be on PWM channel B"
-msgstr ""
-
-#: ports/raspberrypi/common-hal/wifi/Radio.c
-msgid "Stopping AP is not supported."
 msgstr ""
 
 #: shared-bindings/alarm/time/TimeAlarm.c

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -89,13 +89,19 @@ msgid ""
 msgstr ""
 
 #: ports/atmel-samd/common-hal/alarm/__init__.c
-#: ports/cxd56/common-hal/analogio/AnalogOut.c ports/cxd56/common-hal/rtc/RTC.c
-#: ports/espressif/common-hal/rtc/RTC.c
+#: ports/atmel-samd/common-hal/alarm/touch/TouchAlarm.c
+#: ports/atmel-samd/common-hal/audioio/AudioOut.c
+#: ports/atmel-samd/common-hal/busio/SPI.c
+#: ports/cxd56/common-hal/analogio/AnalogOut.c
+#: ports/cxd56/common-hal/busio/SPI.c ports/cxd56/common-hal/rtc/RTC.c
+#: ports/espressif/common-hal/busio/SPI.c ports/espressif/common-hal/rtc/RTC.c
 #: ports/mimxrt10xx/common-hal/analogio/AnalogOut.c
+#: ports/mimxrt10xx/common-hal/busio/SPI.c
 #: ports/mimxrt10xx/common-hal/rtc/RTC.c ports/nrf/common-hal/alarm/__init__.c
-#: ports/nrf/common-hal/analogio/AnalogOut.c ports/nrf/common-hal/rtc/RTC.c
-#: ports/raspberrypi/common-hal/alarm/__init__.c
+#: ports/nrf/common-hal/analogio/AnalogOut.c ports/nrf/common-hal/busio/SPI.c
+#: ports/nrf/common-hal/rtc/RTC.c ports/raspberrypi/common-hal/alarm/__init__.c
 #: ports/raspberrypi/common-hal/analogio/AnalogOut.c
+#: ports/raspberrypi/common-hal/busio/SPI.c
 #: ports/raspberrypi/common-hal/rtc/RTC.c ports/stm/common-hal/alarm/__init__.c
 #: ports/stm/common-hal/canio/Listener.c ports/stm/common-hal/rtc/RTC.c
 #: shared-bindings/audiobusio/I2SOut.c shared-bindings/audiobusio/PDMIn.c
@@ -110,6 +116,10 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/audioio/AudioOut.c
 msgid "%q and %q must be different"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
+msgid "%q and %q must share a clock unit"
 msgstr ""
 
 #: shared-bindings/microcontroller/Pin.c
@@ -239,6 +249,10 @@ msgstr ""
 
 #: py/objrange.c py/objslice.c shared-bindings/random/__init__.c
 msgid "%q step cannot be zero"
+msgstr ""
+
+#: shared-module/bitbangio/I2C.c
+msgid "%q too long"
 msgstr ""
 
 #: py/bc.c py/objnamedtuple.c
@@ -419,12 +433,6 @@ msgstr ""
 msgid "3-arg pow() not supported"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
-#: ports/atmel-samd/common-hal/countio/Counter.c
-#: ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
-msgid "A hardware interrupt channel is already in use"
-msgstr ""
-
 #: ports/espressif/common-hal/analogio/AnalogIn.c
 msgid "ADC2 is being used by WiFi"
 msgstr ""
@@ -595,10 +603,6 @@ msgstr ""
 msgid "Bit clock and word select must be sequential pins"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-msgid "Bit clock and word select must share a clock unit"
-msgstr ""
-
 #: shared-bindings/bitmaptools/__init__.c
 msgid "Bitmap size and bits per value must match"
 msgstr ""
@@ -609,10 +613,6 @@ msgstr ""
 
 #: ports/mimxrt10xx/common-hal/busio/UART.c
 msgid "Both RX and TX required for flow control"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
-msgid "Both pins must support hardware interrupts"
 msgstr ""
 
 #: shared-bindings/displayio/Display.c
@@ -800,10 +800,6 @@ msgstr ""
 msgid "CircuitPython core code crashed hard. Whoops!\n"
 msgstr ""
 
-#: shared-module/bitbangio/I2C.c
-msgid "Clock stretch too long"
-msgstr ""
-
 #: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
 msgid "Clock unit in use"
 msgstr ""
@@ -921,9 +917,12 @@ msgstr ""
 msgid "ESP-IDF memory allocation failed"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
+#: ports/atmel-samd/common-hal/countio/Counter.c
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
 #: ports/atmel-samd/common-hal/ps2io/Ps2.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
+#: ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
 #: ports/cxd56/common-hal/pulseio/PulseIn.c
 msgid "EXTINT channel already in use"
 msgstr ""
@@ -1074,13 +1073,6 @@ msgstr ""
 #: shared-module/displayio/Display.c
 #: shared-module/framebufferio/FramebufferDisplay.c
 msgid "Group already used"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/busio/SPI.c ports/cxd56/common-hal/busio/SPI.c
-#: ports/espressif/common-hal/busio/SPI.c
-#: ports/mimxrt10xx/common-hal/busio/SPI.c ports/nrf/common-hal/busio/SPI.c
-#: ports/raspberrypi/common-hal/busio/SPI.c
-msgid "Half duplex SPI is not implemented"
 msgstr ""
 
 #: supervisor/shared/safe_mode.c
@@ -1508,8 +1500,13 @@ msgstr ""
 msgid "No default %q bus"
 msgstr ""
 
+#: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
 #: ports/atmel-samd/common-hal/touchio/TouchIn.c
 msgid "No free GCLKs"
+msgstr ""
+
+#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
+msgid "No free GLCKs"
 msgstr ""
 
 #: shared-bindings/os/__init__.c
@@ -1748,6 +1745,7 @@ msgid "Pin must be on PWM Channel B"
 msgstr ""
 
 #: ports/atmel-samd/common-hal/countio/Counter.c
+#: ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
 msgid "Pin must support hardware interrupts"
 msgstr ""
 
@@ -1886,10 +1884,6 @@ msgstr ""
 
 #: ports/espressif/common-hal/espidf/__init__.c
 msgid "Requested resource not found"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/audioio/AudioOut.c
-msgid "Right channel unsupported"
 msgstr ""
 
 #: main.c
@@ -2086,7 +2080,6 @@ msgstr ""
 msgid "Total data to write is larger than %q"
 msgstr ""
 
-#: ports/atmel-samd/common-hal/alarm/touch/TouchAlarm.c
 #: ports/raspberrypi/common-hal/alarm/touch/TouchAlarm.c
 #: ports/stm/common-hal/alarm/touch/TouchAlarm.c
 msgid "Touch alarms not available"
@@ -2176,11 +2169,6 @@ msgstr ""
 #: shared-module/displayio/I2CDisplay.c shared-module/is31fl3741/IS31FL3741.c
 #, c-format
 msgid "Unable to find I2C Display at %x"
-msgstr ""
-
-#: ports/atmel-samd/common-hal/audiobusio/I2SOut.c
-#: ports/atmel-samd/common-hal/audiobusio/PDMIn.c
-msgid "Unable to find free GCLK"
 msgstr ""
 
 #: py/parse.c
@@ -2655,11 +2643,6 @@ msgstr ""
 msgid "can't convert %q to %q"
 msgstr ""
 
-#: py/obj.c
-#, c-format
-msgid "can't convert %s to complex"
-msgstr ""
-
 #: py/objstr.c
 msgid "can't convert '%q' object to %q implicitly"
 msgstr ""
@@ -2668,16 +2651,8 @@ msgstr ""
 msgid "can't convert complex to float"
 msgstr ""
 
-#: py/obj.c
+#: py/obj.c py/runtime.c
 msgid "can't convert to %q"
-msgstr ""
-
-#: py/obj.c
-msgid "can't convert to complex"
-msgstr ""
-
-#: py/runtime.c
-msgid "can't convert to int"
 msgstr ""
 
 #: py/objstr.c

--- a/ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
@@ -235,7 +235,7 @@ static void pinalarm_set_alarms_light(size_t n_alarms, const mp_obj_t *alarms) {
         case PINALARM_ERR_NOEXTINT:
             raise_ValueError_invalid_pin();
         case PINALARM_ERR_NOCHANNEL:
-            mp_raise_RuntimeError(translate("A hardware interrupt channel is already in use"));
+            mp_raise_RuntimeError(translate("EXTINT channel already in use"));
         default:
             mp_raise_RuntimeError(translate("Unknown reason."));
     }

--- a/ports/atmel-samd/common-hal/alarm/touch/TouchAlarm.c
+++ b/ports/atmel-samd/common-hal/alarm/touch/TouchAlarm.c
@@ -28,5 +28,5 @@
 #include "shared-bindings/microcontroller/__init__.h"
 
 void common_hal_alarm_touch_touchalarm_construct(alarm_touch_touchalarm_obj_t *self, const mcu_pin_obj_t *pin) {
-    mp_raise_NotImplementedError(translate("Touch alarms not available"));
+    mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_TouchAlarm);
 }

--- a/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
+++ b/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -157,7 +157,7 @@ void common_hal_audiobusio_i2sout_construct(audiobusio_i2sout_obj_t *self,
         raise_ValueError_invalid_pin_name(MP_QSTR_word_select);
     }
     if (bc_clock_unit != ws_clock_unit) {
-        mp_raise_ValueError(translate("Bit clock and word select must share a clock unit"));
+        mp_raise_ValueError_varg(translate("%q and %q must share a clock unit"), MP_QSTR_bit_clock, MP_QSTR_word_select);
     }
     if (serializer == 0xff) {
         raise_ValueError_invalid_pin_name(MP_QSTR_data);
@@ -241,7 +241,7 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t *self,
     // Find a free GCLK to generate the MCLK signal.
     uint8_t gclk = find_free_gclk(divisor);
     if (gclk > GCLK_GEN_NUM) {
-        mp_raise_RuntimeError(translate("Unable to find free GCLK"));
+        mp_raise_RuntimeError(translate("No free GLCKs"));
     }
     self->gclk = gclk;
 

--- a/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
+++ b/ports/atmel-samd/common-hal/audiobusio/PDMIn.c
@@ -195,7 +195,7 @@ void common_hal_audiobusio_pdmin_construct(audiobusio_pdmin_obj_t *self,
     // Find a free GCLK to generate the MCLK signal.
     uint8_t gclk = find_free_gclk(clock_divisor);
     if (gclk > GCLK_GEN_NUM) {
-        mp_raise_RuntimeError(translate("Unable to find free GCLK"));
+        mp_raise_RuntimeError(translate("No free GCLKs"));
     }
     self->gclk = gclk;
 

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -133,7 +133,7 @@ void common_hal_audioio_audioout_construct(audioio_audioout_obj_t *self,
     }
     #ifdef SAMD21
     if (right_channel != NULL) {
-        mp_raise_ValueError(translate("Right channel unsupported"));
+        mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_right_channel);
     }
     if (left_channel != &pin_PA02) {
         raise_ValueError_invalid_pin();

--- a/ports/atmel-samd/common-hal/busio/SPI.c
+++ b/ports/atmel-samd/common-hal/busio/SPI.c
@@ -59,7 +59,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     uint8_t dopo = 255;
 
     if (half_duplex) {
-        mp_raise_NotImplementedError(translate("Half duplex SPI is not implemented"));
+        mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_half_duplex);
     }
 
     // Ensure the object starts in its deinit state.

--- a/ports/atmel-samd/common-hal/countio/Counter.c
+++ b/ports/atmel-samd/common-hal/countio/Counter.c
@@ -18,7 +18,7 @@ void common_hal_countio_counter_construct(countio_counter_obj_t *self,
 
     if (eic_get_enable()) {
         if (!eic_channel_free(pin->extint_channel)) {
-            mp_raise_RuntimeError(translate("A hardware interrupt channel is already in use"));
+            mp_raise_RuntimeError(translate("EXTINT channel already in use"));
         }
     } else {
         turn_on_external_interrupt_controller();

--- a/ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
@@ -38,7 +38,7 @@
 void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencoder_obj_t *self,
     const mcu_pin_obj_t *pin_a, const mcu_pin_obj_t *pin_b) {
     if (!pin_a->has_extint || !pin_b->has_extint) {
-        mp_raise_RuntimeError(translate("Both pins must support hardware interrupts"));
+        mp_raise_RuntimeError(translate("Pin must support hardware interrupts"));
     }
 
     // TODO: The SAMD51 has a peripheral dedicated to quadrature encoder debugging. Use it instead
@@ -46,7 +46,7 @@ void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencode
 
     if (eic_get_enable()) {
         if (!eic_channel_free(pin_a->extint_channel) || !eic_channel_free(pin_b->extint_channel)) {
-            mp_raise_RuntimeError(translate("A hardware interrupt channel is already in use"));
+            mp_raise_RuntimeError(translate("EXTINT channel already in use"));
         }
     } else {
         turn_on_external_interrupt_controller();

--- a/ports/cxd56/common-hal/busio/SPI.c
+++ b/ports/cxd56/common-hal/busio/SPI.c
@@ -40,7 +40,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self, const mcu_pin_obj_t *
     int port = -1;
 
     if (half_duplex) {
-        mp_raise_NotImplementedError(translate("Half duplex SPI is not implemented"));
+        mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_half_duplex);
     }
 
     if (clock->number == PIN_SPI4_SCK &&

--- a/ports/espressif/common-hal/busio/SPI.c
+++ b/ports/espressif/common-hal/busio/SPI.c
@@ -88,7 +88,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     };
 
     if (half_duplex) {
-        mp_raise_NotImplementedError(translate("Half duplex SPI is not implemented"));
+        mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_half_duplex);
     }
 
     for (spi_host_device_t host_id = SPI2_HOST; host_id < SOC_SPI_PERIPH_NUM; host_id++) {

--- a/ports/mimxrt10xx/common-hal/busio/SPI.c
+++ b/ports/mimxrt10xx/common-hal/busio/SPI.c
@@ -99,7 +99,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     bool spi_taken = false;
 
     if (half_duplex) {
-        mp_raise_NotImplementedError(translate("Half duplex SPI is not implemented"));
+        mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_half_duplex);
     }
 
     for (uint i = 0; i < sck_count; i++) {

--- a/ports/nrf/common-hal/busio/SPI.c
+++ b/ports/nrf/common-hal/busio/SPI.c
@@ -146,7 +146,7 @@ static nrf_spim_frequency_t baudrate_to_spim_frequency(const uint32_t baudrate) 
 void common_hal_busio_spi_construct(busio_spi_obj_t *self, const mcu_pin_obj_t *clock, const mcu_pin_obj_t *mosi, const mcu_pin_obj_t *miso, bool half_duplex) {
 
     if (half_duplex) {
-        mp_raise_NotImplementedError(translate("Half duplex SPI is not implemented"));
+        mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_half_duplex);
     }
 
     // Find a free instance, with most desirable (highest freq and not shared) allocated first.

--- a/ports/raspberrypi/common-hal/busio/SPI.c
+++ b/ports/raspberrypi/common-hal/busio/SPI.c
@@ -58,7 +58,7 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     size_t instance_index = NO_INSTANCE;
 
     if (half_duplex) {
-        mp_raise_NotImplementedError(translate("Half duplex SPI is not implemented"));
+        mp_raise_NotImplementedError_varg(translate("%q"), MP_QSTR_half_duplex);
     }
 
     if (clock->number % 4 == 2) {

--- a/py/obj.c
+++ b/py/obj.c
@@ -482,10 +482,10 @@ bool mp_obj_get_complex_maybe(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) 
 void mp_obj_get_complex(mp_obj_t arg, mp_float_t *real, mp_float_t *imag) {
     if (!mp_obj_get_complex_maybe(arg, real, imag)) {
         #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
-        mp_raise_TypeError(MP_ERROR_TEXT("can't convert to complex"));
+        mp_raise_TypeError_varg(MP_ERROR_TEXT("can't convert to %q"), MP_QSTR_complex);
         #else
         mp_raise_TypeError_varg(
-            MP_ERROR_TEXT("can't convert %s to complex"), mp_obj_get_type_str(arg));
+            MP_ERROR_TEXT("can't convert %q to %q"), mp_obj_get_type_qstr(arg), MP_QSTR_complex);
         #endif
     }
 }

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -300,7 +300,7 @@ mp_obj_t mp_unary_op(mp_unary_op_t op, mp_obj_t arg) {
         // In this case provide a more focused error message to not confuse, e.g. chr(1.0)
         #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
         if (op == MP_UNARY_OP_INT) {
-            mp_raise_TypeError(MP_ERROR_TEXT("can't convert to int"));
+            mp_raise_TypeError_varg(MP_ERROR_TEXT("can't convert to %q"), MP_QSTR_int);
         } else {
             mp_raise_TypeError(MP_ERROR_TEXT("unsupported type for operator"));
         }

--- a/shared-bindings/audiobusio/PDMIn.c
+++ b/shared-bindings/audiobusio/PDMIn.c
@@ -122,20 +122,18 @@ STATIC mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_ar
     uint32_t sample_rate = args[ARG_sample_rate].u_int;
     uint8_t bit_depth = args[ARG_bit_depth].u_int;
     if (bit_depth % 8 != 0) {
-        mp_raise_ValueError(translate("Bit depth must be multiple of 8."));
+        mp_raise_ValueError_varg(translate("%q must be multiple of 8."), MP_QSTR_bit_depth);
     }
     uint8_t oversample = args[ARG_oversample].u_int;
     if (oversample % 8 != 0) {
-        mp_raise_ValueError(translate("Oversample must be multiple of 8."));
+        mp_raise_ValueError_varg(translate("%q must be multiple of 8."), MP_QSTR_oversample);
     }
     bool mono = args[ARG_mono].u_bool;
 
     mp_float_t startup_delay = (args[ARG_startup_delay].u_obj == MP_OBJ_NULL)
         ? (mp_float_t)STARTUP_DELAY_DEFAULT
         : mp_obj_get_float(args[ARG_startup_delay].u_obj);
-    if (startup_delay < 0.0 || startup_delay > 1.0) {
-        mp_raise_ValueError(translate("Microphone startup delay must be in range 0.0 to 1.0"));
-    }
+    mp_arg_validate_float_range(startup_delay, 0.0f, 1.0f, MP_QSTR_startup_delay);
 
     common_hal_audiobusio_pdmin_construct(self, clock_pin, data_pin, sample_rate,
         bit_depth, mono, oversample);

--- a/shared-module/bitbangio/I2C.c
+++ b/shared-module/bitbangio/I2C.c
@@ -56,7 +56,7 @@ STATIC void scl_release(bitbangio_i2c_obj_t *self) {
     common_hal_digitalio_digitalinout_switch_to_output(&self->scl, true, DRIVE_MODE_OPEN_DRAIN);
     // raise exception on timeout
     if (count == 0) {
-        mp_raise_msg(&mp_type_TimeoutError, translate("Clock stretch too long"));
+        mp_raise_msg_varg(&mp_type_TimeoutError, translate("%q too long"), MP_QSTR_timeout);
     }
 }
 

--- a/shared-module/displayio/OnDiskBitmap.c
+++ b/shared-module/displayio/OnDiskBitmap.c
@@ -61,6 +61,11 @@ void common_hal_displayio_ondiskbitmap_construct(displayio_ondiskbitmap_t *self,
     uint32_t compression = read_word(bmp_header, 15);
     uint32_t number_of_colors = read_word(bmp_header, 23);
 
+    // 0 is uncompressed; 3 is bitfield compressed. 1 and 2 are RLE compression.
+    if (compression != 0 && compression != 3) {
+        mp_raise_ValueError(MP_ERROR_TEXT("RLE-compressed BMP not supported"));
+    }
+
     bool indexed = bits_per_pixel <= 8;
     self->bitfield_compressed = (compression == 3);
     self->bits_per_pixel = bits_per_pixel;


### PR DESCRIPTION
Fixes #7450. Fixes #8374.

`OnDiskBitmap` did not check for compression values 1 and 2, which indicate RLE compression.

Tested with files from #8374 on a Matrix Portal S3. `NYJ.bmp` throws the new exception, as expected: it is RLE-compressed. `NYJ1.bmp` is not compressed and works.

