### PR TITLE
Revert "Use specific pid for Flipper Wifi"

### DIFF
--- a/ports/espressif/boards/flipperzero_wifi_dev/mpconfigboard.mk
+++ b/ports/espressif/boards/flipperzero_wifi_dev/mpconfigboard.mk
@@ -1,5 +1,5 @@
 USB_VID = 0x303A
-USB_PID = 0x81CF
+USB_PID = 0x4001
 USB_PRODUCT = "Flipper Zero Wi-Fi Dev"
 USB_MANUFACTURER = "Flipper Devices Inc."
 


### PR DESCRIPTION
@maewolfsky Reverting.
The PID was not assigned by espressif yet. See https://github.com/espressif/usb-pids/pull/129, which conflicts with https://github.com/espressif/usb-pids/pull/128.

Could you submit a new PR after Espressif has approved the newly assigned PID?