### PR TITLE
Ad Led_IR pin name to ATOM Lite

### DIFF
--- a/ports/espressif/boards/m5stack_atom_lite/pins.c
+++ b/ports/espressif/boards/m5stack_atom_lite/pins.c
@@ -20,6 +20,9 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D33), MP_ROM_PTR(&pin_GPIO33) },
     { MP_ROM_QSTR(MP_QSTR_A33), MP_ROM_PTR(&pin_GPIO33) },
 
+    { MP_ROM_QSTR(MP_QSTR_IR), MP_ROM_PTR(&pin_GPIO12) },
+    { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_GPIO12) },
+
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO21) },
     { MP_ROM_QSTR(MP_QSTR_D21), MP_ROM_PTR(&pin_GPIO21) },
 


### PR DESCRIPTION
Try to fix issue #8738 by adding gpio 12 as the IR light and D12