### PR TITLE
Configure Lilygo ttgo T8 S2 ST7789 screen with no rotation

### DIFF
--- a/ports/espressif/boards/lilygo_ttgo_t8_s2_st7789/board.c
+++ b/ports/espressif/boards/lilygo_ttgo_t8_s2_st7789/board.c
@@ -100,7 +100,7 @@ static void display_init(void) {
         135,            // height (after rotation)
         40,             // column start
         53,             // row start
-        0,             // rotation
+        0,              // rotation
         16,             // color depth
         false,          // grayscale
         false,          // pixels in a byte share a row. Only valid for depths < 8

--- a/ports/espressif/boards/lilygo_ttgo_t8_s2_st7789/board.c
+++ b/ports/espressif/boards/lilygo_ttgo_t8_s2_st7789/board.c
@@ -41,7 +41,7 @@ uint8_t display_init_sequence[] = {
     // normal display mode on
     0x13, 0,
     // display and color format settings
-    0x36, 1, 0x08,
+    0x36, 1, 0x68,
     0xB6, 2, 0x0A, 0x82,
     0x3A, 1 | DELAY,  0x55, 10,
     // ST7789V frame rate setting
@@ -98,9 +98,9 @@ static void display_init(void) {
         bus,
         240,            // width (after rotation)
         135,            // height (after rotation)
-        52,             // column start
-        40,             // row start
-        90,             // rotation
+        40,             // column start
+        53,             // row start
+        0,             // rotation
         16,             // color depth
         false,          // grayscale
         false,          // pixels in a byte share a row. Only valid for depths < 8


### PR DESCRIPTION
I don't have the hardware to test #8772 but the S2 version of the board was rotating the screen 90 degrees and I do have that board so I stole @kreier's changes and tested them on the Lilygo ttgo T8 S2 ST7789.

I did run a color test and the 0x68 on board.c line 44 results in the proper colors being displayed.

I changed the row start to 53 to remove the bottom noise line that showed up when rotation was set to zero.