### PR TITLE
Settable analogio voltage reference

### DIFF
--- a/ports/espressif/common-hal/analogio/AnalogIn.h
+++ b/ports/espressif/common-hal/analogio/AnalogIn.h
@@ -37,6 +37,7 @@
 typedef struct {
     mp_obj_base_t base;
     const mcu_pin_obj_t *pin;
+    mp_int_t vref;
 } analogio_analogin_obj_t;
 
 #endif // MICROPY_INCLUDED_ESPRESSIF_COMMON_HAL_ANALOGIO_ANALOGIN_H

--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -136,8 +136,20 @@ STATIC mp_obj_t analogio_analogin_obj_get_reference_voltage(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(analogio_analogin_get_reference_voltage_obj,
     analogio_analogin_obj_get_reference_voltage);
 
-MP_PROPERTY_GETTER(analogio_analogin_reference_voltage_obj,
-    (mp_obj_t)&analogio_analogin_get_reference_voltage_obj);
+STATIC mp_obj_t analogio_analogin_obj_set_reference_voltage(mp_obj_t self_in, mp_obj_t value) {
+    analogio_analogin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    check_for_deinit(self);
+
+    common_hal_analogio_analogin_set_reference_voltage(self, mp_obj_get_float(value));
+    return mp_const_none;
+}
+
+MP_DEFINE_CONST_FUN_OBJ_2(analogio_analogin_set_reference_voltage_obj,
+    analogio_analogin_obj_set_reference_voltage);
+
+MP_PROPERTY_GETSET(analogio_analogin_reference_voltage_obj,
+    (mp_obj_t)&analogio_analogin_get_reference_voltage_obj,
+    (mp_obj_t)&analogio_analogin_set_reference_voltage_obj);
 
 STATIC const mp_rom_map_elem_t analogio_analogin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit),             MP_ROM_PTR(&analogio_analogin_deinit_obj) },

--- a/shared-bindings/analogio/AnalogIn.h
+++ b/shared-bindings/analogio/AnalogIn.h
@@ -38,5 +38,6 @@ void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self);
 bool common_hal_analogio_analogin_deinited(analogio_analogin_obj_t *self);
 uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self);
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self);
+void common_hal_analogio_analogin_set_reference_voltage(analogio_analogin_obj_t *self, mp_float_t value);
 
 #endif  // __MICROPY_INCLUDED_SHARED_BINDINGS_ANALOGIO_ANALOGIN_H__


### PR DESCRIPTION
Internally stored as int, converted on / from float to maintain compatibility.
This means getting values is just as fast as it was, since there is no float conversion.

It has to now be done for every port, so it will take a moment.

Fixes #8754.