### PR TITLE
Enable Audio Channel A and B Swapping for RP2040

### DIFF
--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -122,6 +122,14 @@ STATIC size_t audio_dma_convert_samples(audio_dma_t *dma, uint8_t *input, uint32
         // Not currently used, but might be in the future.
         mp_raise_RuntimeError(MP_ERROR_TEXT("Audio conversion not implemented"));
     }
+    if (dma->swap_channel){
+    // Loop for swapping left and right channels
+        for (uint32_t i = 0; i < out_i; i += 2) {
+            uint16_t temp = ((uint16_t *)output)[i];
+            ((uint16_t *)output)[i] = ((uint16_t *)output)[i + 1];
+            ((uint16_t *)output)[i + 1] = temp;
+        }
+    }
     #pragma GCC diagnostic pop
     return output_length_used;
 }
@@ -183,7 +191,8 @@ audio_dma_result audio_dma_setup_playback(
     bool output_signed,
     uint8_t output_resolution,
     uint32_t output_register_address,
-    uint8_t dma_trigger_source) {
+    uint8_t dma_trigger_source,
+    bool swap_channel) {
 
     // Use two DMA channels to play because the DMA can't wrap to itself without the
     // buffer being power of two aligned.
@@ -212,6 +221,7 @@ audio_dma_result audio_dma_setup_playback(
     dma->output_resolution = output_resolution;
     dma->sample_resolution = audiosample_bits_per_sample(sample);
     dma->output_register_address = output_register_address;
+    dma->swap_channel = swap_channel;
 
     audiosample_reset_buffer(sample, single_channel_output, audio_channel);
 

--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -122,7 +122,7 @@ STATIC size_t audio_dma_convert_samples(audio_dma_t *dma, uint8_t *input, uint32
         // Not currently used, but might be in the future.
         mp_raise_RuntimeError(MP_ERROR_TEXT("Audio conversion not implemented"));
     }
-    if (dma->swap_channel){
+    if (dma->swap_channel) {
         // Loop for swapping left and right channels
         for (uint32_t i = 0; i < out_i; i += 2) {
             uint16_t temp = ((uint16_t *)output)[i];

--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -123,7 +123,7 @@ STATIC size_t audio_dma_convert_samples(audio_dma_t *dma, uint8_t *input, uint32
         mp_raise_RuntimeError(MP_ERROR_TEXT("Audio conversion not implemented"));
     }
     if (dma->swap_channel){
-    // Loop for swapping left and right channels
+        // Loop for swapping left and right channels
         for (uint32_t i = 0; i < out_i; i += 2) {
             uint16_t temp = ((uint16_t *)output)[i];
             ((uint16_t *)output)[i] = ((uint16_t *)output)[i + 1];

--- a/ports/raspberrypi/audio_dma.h
+++ b/ports/raspberrypi/audio_dma.h
@@ -51,6 +51,7 @@ typedef struct {
     bool unsigned_to_signed;
     bool output_signed;
     bool playing_in_progress;
+    bool swap_channel;
 } audio_dma_t;
 
 typedef enum {
@@ -81,7 +82,8 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t *dma,
     bool output_signed,
     uint8_t output_resolution,
     uint32_t output_register_address,
-    uint8_t dma_trigger_source);
+    uint8_t dma_trigger_source,
+    bool swap_channel);
 
 void audio_dma_stop(audio_dma_t *dma);
 bool audio_dma_get_playing(audio_dma_t *dma);

--- a/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+++ b/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
@@ -202,7 +202,8 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t *self,
         true,  // output signed
         bits_per_sample,
         (uint32_t)&self->state_machine.pio->txf[self->state_machine.state_machine],  // output register
-        self->state_machine.tx_dreq); // data request line
+        self->state_machine.tx_dreq, // data request line
+        false); // swap channel
 
     if (result == AUDIO_DMA_DMA_BUSY) {
         common_hal_audiobusio_i2sout_stop(self);

--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -111,18 +111,14 @@ void audiopwmout_reset() {
 void common_hal_audiopwmio_pwmaudioout_construct(audiopwmio_pwmaudioout_obj_t *self,
     const mcu_pin_obj_t *left_channel, const mcu_pin_obj_t *right_channel, uint16_t quiescent_value) {
 
-    self->stereo = right_channel != NULL;
+    self->stereo = left_channel != NULL && right_channel != NULL;
 
     if (self->stereo) {
         if (pwm_gpio_to_slice_num(left_channel->number) != pwm_gpio_to_slice_num(right_channel->number)) {
             mp_raise_ValueError(MP_ERROR_TEXT("Pins must share PWM slice"));
         }
-        if (pwm_gpio_to_channel(left_channel->number) != 0) {
-            mp_raise_ValueError(MP_ERROR_TEXT("Stereo left must be on PWM channel A"));
-        }
-        if (pwm_gpio_to_channel(right_channel->number) != 1) {
-            mp_raise_ValueError(MP_ERROR_TEXT("Stereo right must be on PWM channel B"));
-        }
+        // Check channel swapping, by default left_channel == 0
+        self->swap_channel = pwm_gpio_to_channel(left_channel->number) != 0;
     }
 
     // Typically pwmout doesn't let us change frequency with two objects on the
@@ -233,7 +229,8 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, 
         false,  // output signed
         BITS_PER_SAMPLE,
         (uint32_t)tx_register,  // output register: PWM cc register
-        0x3b + pacing_timer); // data request line
+        0x3b + pacing_timer, // data request line
+        self->swap_channel); 
 
     if (result == AUDIO_DMA_DMA_BUSY) {
         common_hal_audiopwmio_pwmaudioout_stop(self);

--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -230,7 +230,7 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, 
         BITS_PER_SAMPLE,
         (uint32_t)tx_register,  // output register: PWM cc register
         0x3b + pacing_timer, // data request line
-        self->swap_channel); 
+        self->swap_channel);
 
     if (result == AUDIO_DMA_DMA_BUSY) {
         common_hal_audiopwmio_pwmaudioout_stop(self);

--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.h
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.h
@@ -39,6 +39,7 @@ typedef struct {
     uint16_t quiescent_value;
     uint8_t pacing_timer;
     bool stereo;     // if false, only using left_pwm.
+    bool swap_channel;
 } audiopwmio_pwmaudioout_obj_t;
 
 void audiopwmout_reset(void);


### PR DESCRIPTION
Addresses issue #8681, enabling the Raspberry Pi Pico/Pico W to swap audio channels A and B in the audiopwmio library.

Notes:  
- Adjust the stereo condition in **PWMAudioOut.c**, it will checking both channels are defined.
- Also, remove error handling messages in **PWMAudioOut.c** if the left channel is assigned to pin channel B since the channels can be swapped.
- Introduce a new variable, `swap_channel`.
- Update the code inside **I2SOut.c** to align with `audio_dma_setup_playback` and set the `swap_channel` to false.

Can you help review this?

Thank you.

Closes #8681