### PR TITLE
fixed missing 'source' command on install line

### DIFF
--- a/ports/espressif/README.rst
+++ b/ports/espressif/README.rst
@@ -168,7 +168,7 @@ Run ``cd ports/espressif`` from ``circuitpython/`` to move to the espressif port
 
 .. code-block::
 
-    ./esp-idf/export.sh
+    source ./esp-idf/export.sh
 
 When CircuitPython updates the ESP-IDF to a new release, you may need to run this installation process again. The exact commands used may also vary based on your shell environment.
 


### PR DESCRIPTION
Really minor typo in the README. The line
```
./esp-idf/export.sh
```
is missing the `source` or `.` command, so the environment variables it sets would only be set in a sub shell and wouldn't affect the current shell as is necessary for this to work. I used `source` here as it's clearer and looks less like a typo.


