### PR TITLE
Make range check test against source bitmap, not destination

### DIFF
--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -1063,9 +1063,9 @@ STATIC mp_obj_t bitmaptools_obj_blit(size_t n_args, const mp_obj_t *pos_args, mp
     uint16_t x = mp_arg_validate_int_range(args[ARG_x].u_int, 0, destination->width, MP_QSTR_x);
     uint16_t y = mp_arg_validate_int_range(args[ARG_y].u_int, 0, destination->height, MP_QSTR_y);
 
-    bitmaptools_rect_t lim = bitmaptools_validate_coord_range_pair(&args[ARG_x1], destination->width, destination->height);
-
     displayio_bitmap_t *source = mp_arg_validate_type(args[ARG_source].u_obj, &displayio_bitmap_type, MP_QSTR_source_bitmap);
+
+    bitmaptools_rect_t lim = bitmaptools_validate_coord_range_pair(&args[ARG_x1], source->width, source->height);
 
 
     // ensure that the target bitmap (self) has at least as many `bits_per_value` as the source


### PR DESCRIPTION
This is a fix for #8822 