### PR TITLE
Fix I2C hang when power removed from pull-ups

### DIFF
--- a/ports/nrf/common-hal/busio/I2C.c
+++ b/ports/nrf/common-hal/busio/I2C.c
@@ -105,7 +105,7 @@ static uint8_t twi_error_to_mp(const nrfx_err_t err) {
 
 static void twim_event_handler(nrfx_twim_evt_t const *p_event, void *p_context) {
     // this is the callback handler - sets transferring to false and records the most recent event.
-    twim_peripheral_t *peripheral = (twim_peripheral_t *) p_context;
+    twim_peripheral_t *peripheral = (twim_peripheral_t *)p_context;
     peripheral->last_event_type = p_event->type;
     peripheral->transferring = false;
 }

--- a/ports/nrf/common-hal/busio/I2C.c
+++ b/ports/nrf/common-hal/busio/I2C.c
@@ -41,7 +41,7 @@
 // all TWI instances have the same max size
 // 16 bits for 840, 10 bits for 810, 8 bits for 832
 #define I2C_MAX_XFER_LEN         MIN(((1UL << TWIM0_EASYDMA_MAXCNT_SIZE) - 1), 1024)
-#define I2C_TIMEOUT 1000 //1 second timeout
+#define I2C_TIMEOUT 1000 // 1 second timeout
 
 STATIC twim_peripheral_t twim_peripherals[] = {
     #if NRFX_CHECK(NRFX_TWIM0_ENABLED)
@@ -103,9 +103,9 @@ static uint8_t twi_error_to_mp(const nrfx_err_t err) {
     return 0;
 }
 
-static void twim_event_handler(nrfx_twim_evt_t const * p_event, void *p_context) {
+static void twim_event_handler(nrfx_twim_evt_t const *p_event, void *p_context) {
     // this is the callback handler - sets transferring to false and records the most recent event.
-    twim_peripheral_t *peripheral  = (twim_peripheral_t *) p_context;
+    twim_peripheral_t *peripheral = (twim_peripheral_t *) p_context;
     peripheral->last_event_type = p_event->type;
     peripheral->transferring = false;
 }
@@ -254,7 +254,7 @@ void common_hal_busio_i2c_unlock(busio_i2c_obj_t *self) {
     self->has_lock = false;
 }
 
-STATIC nrfx_err_t _twim_xfer_with_timeout(busio_i2c_obj_t *self, nrfx_twim_xfer_desc_t const * p_xfer_desc, uint32_t flags) {
+STATIC nrfx_err_t _twim_xfer_with_timeout(busio_i2c_obj_t *self, nrfx_twim_xfer_desc_t const *p_xfer_desc, uint32_t flags) {
     // does non-blocking transfer and raises and exception if it takes longer than I2C_TIMEOUT ms to complete
     uint64_t deadline = supervisor_ticks_ms64() + I2C_TIMEOUT;
     nrfx_err_t err = NRFX_SUCCESS;

--- a/ports/nrf/common-hal/busio/I2C.h
+++ b/ports/nrf/common-hal/busio/I2C.h
@@ -34,6 +34,9 @@
 typedef struct {
     nrfx_twim_t twim;
     bool in_use;
+    volatile bool transferring;
+    nrfx_twim_evt_type_t last_event_type;
+    uint32_t timeout;
 } twim_peripheral_t;
 
 typedef struct {


### PR DESCRIPTION
This PR fixes #2253 and fixes #8093.

### Explanation
This works by creating the nrfx_twim device with a callback (``twim_event_handler``). 
When the callback is triggered it marks that the transfer has finished and records any error/success code in the twim_peripheral data structure.
We replace the nrfx_twim_xfer function with our ``_twim_xfer_with_timeout`` which make a note of the start time, and waits until either the callback has triggered or 1s has elapsed.
If the timeout is triggered it generates an ``OSError: Timed out``

Trying to use the i2c bus again after power restoration fails (generates an OSError), but it can be deinited and reinited and it then works

### Sample Code
The following code now works (adapted from example in #8093:
``` python
import board
import busio
import time
from adafruit_lsm6ds.lsm6ds3 import LSM6DS3
import digitalio

# board.IMU_PWR provides the power to both the LSM6DS3 chip and also the pullups to the I2C bus
pwr = digitalio.DigitalInOut(board.IMU_PWR)
pwr.switch_to_output(True)
print("Starting")
time.sleep(5)
print("Connecting to IMU")
with busio.I2C(scl=board.IMU_SCL, sda=board.IMU_SDA) as i2c_bus:
    imu = LSM6DS3(i2c_bus, address=0x6A)
    print("This works")
    print(imu.acceleration)
    time.sleep(1)
    pwr.switch_to_output(False)
    print("This no longer crashes")
    try:
        print(imu.acceleration)
    except OSError:
        print("Error appropriately raised")
    else:
        print("Shouldn't get here")
        
    time.sleep(0.5)
    print("turn power back on")      
    pwr.switch_to_output(True)
    time.sleep(0.5)
    # trying to access the i2c bus again results in a further error - needs to deinit and reinit
    
with busio.I2C(scl=board.IMU_SCL, sda=board.IMU_SDA) as i2c_bus:
    print("Try again")
    imu = LSM6DS3(i2c_bus, address=0x6A)
    print("This works")
    print(imu.acceleration)

```