### PR TITLE
Fix subclassing dict

### DIFF
--- a/py/opmethods.c
+++ b/py/opmethods.c
@@ -27,22 +27,26 @@
 #include "py/obj.h"
 #include "py/builtin.h"
 
+// CIRCUITPY-CHANGE: These three functions are used by dict only. In CP, we hard
+// code the type to dict so that subclassed types still use the native dict
+// subscr. MP doesn't have this problem because it passes the native instance
+// in. CP passes the subclass instance.
 STATIC mp_obj_t op_getitem(mp_obj_t self_in, mp_obj_t key_in) {
-    const mp_obj_type_t *type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *type = &mp_type_dict;
     // Note: assumes type must have subscr (only used by dict).
     return MP_OBJ_TYPE_GET_SLOT(type, subscr)(self_in, key_in, MP_OBJ_SENTINEL);
 }
 MP_DEFINE_CONST_FUN_OBJ_2(mp_op_getitem_obj, op_getitem);
 
 STATIC mp_obj_t op_setitem(mp_obj_t self_in, mp_obj_t key_in, mp_obj_t value_in) {
-    const mp_obj_type_t *type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *type = &mp_type_dict;
     // Note: assumes type must have subscr (only used by dict).
     return MP_OBJ_TYPE_GET_SLOT(type, subscr)(self_in, key_in, value_in);
 }
 MP_DEFINE_CONST_FUN_OBJ_3(mp_op_setitem_obj, op_setitem);
 
 STATIC mp_obj_t op_delitem(mp_obj_t self_in, mp_obj_t key_in) {
-    const mp_obj_type_t *type = mp_obj_get_type(self_in);
+    const mp_obj_type_t *type = &mp_type_dict;
     // Note: assumes type must have subscr (only used by dict).
     return MP_OBJ_TYPE_GET_SLOT(type, subscr)(self_in, key_in, MP_OBJ_NULL);
 }

--- a/tests/basics/subclass_native_dict.py
+++ b/tests/basics/subclass_native_dict.py
@@ -1,0 +1,28 @@
+class a:
+    def __init__(self):
+        self.d = {}
+
+    def __setitem__(self, k, v):
+        print("a", k, v)
+        self.d[k] = v
+
+    def __getitem__(self, k):
+        return self.d[k]
+
+class b(a):
+    def __setitem__(self, k, v):
+        print("b", k, v)
+        super().__setitem__(k, v)
+
+b1 = b()
+b1[1] = 2
+print(b1[1])
+
+class mydict(dict):
+    def __setitem__(self, k, v):
+        print(k, v)
+        super().__setitem__(k, v)
+
+d = mydict()
+d[3] = 4
+print(d[3])


### PR DESCRIPTION
The get, set and del item methods didn't correctly lookup the value from the parent native instance because the functions took the type from the instance.

Fixes #8758