### PR TITLE
shared-module/usb_hid: allow HID to wake sleeping host computer

### DIFF
--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -72,6 +72,9 @@
 //|                 in_report_lengths=(5, 2),
 //|                 out_report_lengths=(6, 0),
 //|             )
+//|
+//|         The HID device is able to wake up a suspended (sleeping) host computer.
+//|         See `send_report()` for details.
 //|         """
 //|         ...
 //|     KEYBOARD: Device
@@ -166,6 +169,16 @@ STATIC mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type, size_t n_args
 //|         """Send an HID report. If the device descriptor specifies zero or one report id's,
 //|         you can supply `None` (the default) as the value of ``report_id``.
 //|         Otherwise you must specify which report id to use when sending the report.
+//|
+//|         If the USB host is suspended (sleeping), then `send_report()` will request that the host wake up.
+//|         The ``report`` itself will be discarded, to prevent unwanted extraneous characters,
+//|         mouse clicks, etc.
+//|
+//|         Note: Host operating systems allow enabling and disabling specific devices
+//|         and kinds of devices to do wakeup.
+//|         The defaults are different for different operating systems.
+//|         For instance, on Linux, only the primary keyboard may be enabled.
+//|         In addition, there may be USB wakeup settings in the host computer BIOS/UEFI.
 //|         """
 //|         ...
 STATIC mp_obj_t usb_hid_device_send_report(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -229,12 +229,16 @@ void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t *
         RUN_BACKGROUND_TASKS;
     }
 
-    if (!tud_hid_ready()) {
-        mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("USB busy"));
-    }
+    if (!tud_suspended()) {
+        if (!tud_hid_ready()) {
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("USB busy"));
+        }
 
-    if (!tud_hid_report(report_id, report, len)) {
-        mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("USB error"));
+        if (!tud_hid_report(report_id, report, len)) {
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("USB error"));
+        }
+    } else {
+        tud_remote_wakeup();
     }
 }
 

--- a/supervisor/shared/usb/usb_desc.c
+++ b/supervisor/shared/usb/usb_desc.c
@@ -105,7 +105,7 @@ static const uint8_t configuration_descriptor_template[] = {
 #define CONFIG_NUM_INTERFACES_INDEX (4)
     0x01,        // 5 bConfigurationValue
     0x00,        // 6 iConfiguration (String Index)
-    0x80,        // 7 bmAttributes
+    0x80 | TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP,        // 7 bmAttributes
     0x32,        // 8 bMaxPower 100mA
 };
 


### PR DESCRIPTION
- Fixes #8774.
- Fixes #5380.

Thanks very much to @meesokim for code to enable `usb_hid` to wake a sleeping host computer, and to @hathach for implementing this ability in TinyUSB in the past.

Tested successfully with MacroPad RP2040, Feather nRF52840, and Circuit Playground Express on Windows and macOS.

On Linux not all HID devices are automatically enabled to do wakeup. See @hathach's [comment](https://github.com/adafruit/circuitpython/issues/5380#issuecomment-925044500). See also https://askubuntu.com/questions/848698/wake-up-from-suspend-using-wireless-usb-keyboard-or-mouse-for-any-linux-distro/874701 for details on how to change these settings. I would have thought there was an easier way, and maybe there is for some Linux distributions.

For example on my Linux box, by default only my primary keyboard is enabled for wakeup. This is a nuisance and will mean that people using, say, a MacroPad on Linux will need to adjust these settings if they want the MacroPad to be able to initiate wakeup.
```sh
$  grep . /sys/bus/usb/devices/*/product
/sys/bus/usb/devices/1-12/product:HD Pro Webcam C920
/sys/bus/usb/devices/1-1/product:Freestyle Edge RGB Keyboard
/sys/bus/usb/devices/1-2.5/product:USB Billboard Device   
/sys/bus/usb/devices/1-2/product:USB2.0 Hub             
/sys/bus/usb/devices/1-3/product:Microsoft Basic Optical Mouse 
/sys/bus/usb/devices/1-6/product:Macropad RP2040
/sys/bus/usb/devices/2-2.1/product:USB 10/100/1000 LAN
/sys/bus/usb/devices/2-2/product:USB3.0 Hub             
/sys/bus/usb/devices/usb1/product:xHCI Host Controller
/sys/bus/usb/devices/usb2/product:xHCI Host Controller

$  grep . /sys/bus/usb/devices/*/power/wakeup
/sys/bus/usb/devices/1-10/power/wakeup:disabled
/sys/bus/usb/devices/1-1/power/wakeup:enabled
/sys/bus/usb/devices/1-2.5/power/wakeup:disabled
/sys/bus/usb/devices/1-2/power/wakeup:disabled
/sys/bus/usb/devices/1-3/power/wakeup:disabled
/sys/bus/usb/devices/1-6/power/wakeup:disabled
/sys/bus/usb/devices/1-8/power/wakeup:disabled
/sys/bus/usb/devices/2-2.1/power/wakeup:disabled
/sys/bus/usb/devices/2-2/power/wakeup:disabled
/sys/bus/usb/devices/usb1/power/wakeup:disabled
/sys/bus/usb/devices/usb2/power/wakeup:disabled
```