### PR TITLE
.github: update actions to versions that use Node.js 20

### DIFF
--- a/.github/actions/deps/ports/broadcom/action.yml
+++ b/.github/actions/deps/ports/broadcom/action.yml
@@ -16,7 +16,7 @@ runs:
         tar -xaf dosfstools-4.2.tar.gz
         cd dosfstools-4.2
         ./configure
-        make -j 2
+        make -j4
         cd src
         echo >> $GITHUB_PATH $(pwd)
       shell: bash

--- a/.github/actions/deps/ports/espressif/action.yml
+++ b/.github/actions/deps/ports/espressif/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
 
     - name: Cache IDF submodules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           .git/modules/ports/espressif/esp-idf
@@ -26,7 +26,7 @@ runs:
         key: submodules-idf-${{ steps.idf-commit.outputs.commit }}
 
     - name: Cache IDF tools
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.IDF_TOOLS_PATH }}
         key: ${{ runner.os }}-${{ env.pythonLocation }}-tools-idf-${{ steps.idf-commit.outputs.commit }}

--- a/.github/actions/deps/python/action.yml
+++ b/.github/actions/deps/python/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Cache python dependencies
       id: cache-python-deps
       if: inputs.action == 'cache'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .cp_tools
         key: ${{ runner.os }}-${{ env.pythonLocation }}-tools-cp-${{ hashFiles('requirements-dev.txt') }}
@@ -24,7 +24,7 @@ runs:
     - name: Restore python dependencies
       id: restore-python-deps
       if: inputs.action == 'restore'
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: .cp_tools
         key: ${{ runner.os }}-${{ env.pythonLocation }}-tools-cp-${{ hashFiles('requirements-dev.txt') }}

--- a/.github/actions/deps/submodules/action.yml
+++ b/.github/actions/deps/submodules/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - name: Cache submodules
       if: ${{ inputs.action == 'cache' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ".git/modules/\n${{ join(fromJSON(steps.create-submodule-status.outputs.submodules), '\n') }}"
         key: submodules-common-${{ hashFiles('submodule_status') }}
@@ -56,7 +56,7 @@ runs:
 
     - name: Restore submodules
       if: ${{ inputs.action == 'restore' }}
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ".git/modules/\n${{ join(fromJSON(steps.create-submodule-status.outputs.submodules), '\n') }}"
         key: submodules-common-${{ hashFiles('submodule_status') }}

--- a/.github/actions/mpy_cross/action.yml
+++ b/.github/actions/mpy_cross/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Build mpy-cross
       if: inputs.download == 'false' || steps.download-mpy-cross.outcome == 'failure'
-      run: make -C mpy-cross -j2
+      run: make -C mpy-cross -j4
       shell: bash
       env:
         CP_VERSION: ${{ inputs.cp-version }}

--- a/.github/actions/mpy_cross/action.yml
+++ b/.github/actions/mpy_cross/action.yml
@@ -16,7 +16,7 @@ runs:
       id: download-mpy-cross
       if: inputs.download == 'true'
       continue-on-error: true
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: mpy-cross
         path: mpy-cross/build
@@ -36,7 +36,7 @@ runs:
     - name: Upload mpy-cross
       if: inputs.download == 'false' || steps.download-mpy-cross.outcome == 'failure'
       continue-on-error: true
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mpy-cross
         path: mpy-cross/build/mpy-cross

--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -26,12 +26,13 @@ jobs:
         board: ${{ fromJSON(inputs.boards) }}
     steps:
     - name: Set up repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: false
+        show-progress: false
         fetch-depth: 1
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Set up port
@@ -75,7 +76,7 @@ jobs:
         PULL: ${{ github.event.number }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}

--- a/.github/workflows/build-mpy-cross.yml
+++ b/.github/workflows/build-mpy-cross.yml
@@ -54,7 +54,7 @@ jobs:
         sudo apt-get install -y mingw-w64
 
     - name: Build mpy-cross.${{ matrix.mpy-cross }}
-      run: make -C mpy-cross -j2 -f Makefile.${{ matrix.mpy-cross }}
+      run: make -C mpy-cross -j4 -f Makefile.${{ matrix.mpy-cross }}
 
     - name: Set output
       run: |

--- a/.github/workflows/build-mpy-cross.yml
+++ b/.github/workflows/build-mpy-cross.yml
@@ -28,12 +28,13 @@ jobs:
       OS_static-raspbian: linux-raspbian
     steps:
     - name: Set up repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: false
+        show-progress: false
         fetch-depth: 1
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Set up submodules
@@ -61,7 +62,7 @@ jobs:
         echo >> $GITHUB_ENV "OS=${{ env[format('OS_{0}', matrix.mpy-cross)] }}"
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mpy-cross.${{ env.EX }}
         path: mpy-cross/build-${{ matrix.mpy-cross }}/mpy-cross.${{ env.EX }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: false
-        progress: false
+        show-progress: false
         fetch-depth: 1
     - name: Set up python
       uses: actions/setup-python@v5
@@ -112,7 +112,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: false
-        progress: false
+        show-progress: false
         fetch-depth: 1
     - name: Set up python
       uses: actions/setup-python@v5
@@ -127,20 +127,20 @@ jobs:
         msgfmt --version
     - name: Build mpy-cross
       run: make -C mpy-cross -j2
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: mpy-cross-macos-11-x64
         path: mpy-cross/build/mpy-cross
     - name: Build mpy-cross (arm64)
       run: make -C mpy-cross -j2 -f Makefile.m1 V=2
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: mpy-cross-macos-11-arm64
         path: mpy-cross/build-arm64/mpy-cross-arm64
     - name: Make universal binary
       run: lipo -create -output mpy-cross-macos-universal mpy-cross/build/mpy-cross mpy-cross/build-arm64/mpy-cross-arm64
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mpy-cross-macos-11-universal
         path: mpy-cross-macos-universal
@@ -168,7 +168,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: false
-        progress: false
+        show-progress: false
         fetch-depth: 1
     - name: Set up python
       uses: actions/setup-python@v5
@@ -183,20 +183,20 @@ jobs:
         pip install -r requirements-doc.txt
     - name: Build and Validate Stubs
       run: make check-stubs -j2
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: stubs
         path: circuitpython-stubs/dist/*
     - name: Test Documentation Build (HTML)
       run: sphinx-build -E -W -b html -D version=${{ env.CP_VERSION }} -D release=${{ env.CP_VERSION }} . _build/html
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: docs
         path: _build/html
     - name: Test Documentation Build (LaTeX/PDF)
       run: |
         make latexpdf
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: docs
         path: _build/latex
@@ -266,7 +266,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: false
-        progress: false
+        show-progress: false
         fetch-depth: 1
     - name: Set up submodules
       uses: ./.github/actions/deps/submodules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,13 +126,13 @@ jobs:
         python3 --version
         msgfmt --version
     - name: Build mpy-cross
-      run: make -C mpy-cross -j2
+      run: make -C mpy-cross -j4
     - uses: actions/upload-artifact@v4
       with:
         name: mpy-cross-macos-11-x64
         path: mpy-cross/build/mpy-cross
     - name: Build mpy-cross (arm64)
-      run: make -C mpy-cross -j2 -f Makefile.m1 V=2
+      run: make -C mpy-cross -j4 -f Makefile.m1 V=2
     - uses: actions/upload-artifact@v4
       with:
         name: mpy-cross-macos-11-arm64
@@ -182,7 +182,7 @@ jobs:
         sudo apt-get install -y latexmk librsvg2-bin texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra
         pip install -r requirements-doc.txt
     - name: Build and Validate Stubs
-      run: make check-stubs -j2
+      run: make check-stubs -j4
     - uses: actions/upload-artifact@v4
       with:
         name: stubs
@@ -191,14 +191,14 @@ jobs:
       run: sphinx-build -E -W -b html -D version=${{ env.CP_VERSION }} -D release=${{ env.CP_VERSION }} . _build/html
     - uses: actions/upload-artifact@v4
       with:
-        name: docs
+        name: docs-html
         path: _build/html
     - name: Test Documentation Build (LaTeX/PDF)
       run: |
         make latexpdf
     - uses: actions/upload-artifact@v4
       with:
-        name: docs
+        name: docs-latexpdf
         path: _build/latex
     - name: Upload to S3
       uses: ./.github/actions/upload_aws
@@ -271,17 +271,17 @@ jobs:
     - name: Set up submodules
       uses: ./.github/actions/deps/submodules
     - name: build mpy-cross
-      run: make -j2 -C mpy-cross
+      run: make -j4 -C mpy-cross
     - name: build rp2040
-      run: make -j2 -C ports/raspberrypi BOARD=adafruit_feather_rp2040 TRANSLATION=de_DE
+      run: make -j4 -C ports/raspberrypi BOARD=adafruit_feather_rp2040 TRANSLATION=de_DE
     - name: build samd21
-      run: make -j2 -C ports/atmel-samd BOARD=feather_m0_express TRANSLATION=zh_Latn_pinyin
+      run: make -j4 -C ports/atmel-samd BOARD=feather_m0_express TRANSLATION=zh_Latn_pinyin
     - name: build samd51
-      run: make -j2 -C ports/atmel-samd BOARD=feather_m4_express TRANSLATION=es
+      run: make -j4 -C ports/atmel-samd BOARD=feather_m4_express TRANSLATION=es
     - name: build nrf
-      run: make -j2 -C ports/nrf BOARD=feather_nrf52840_express TRANSLATION=fr
+      run: make -j4 -C ports/nrf BOARD=feather_nrf52840_express TRANSLATION=fr
     - name: build stm
-      run: make -j2 -C ports/stm BOARD=feather_stm32f405_express TRANSLATION=pt_BR
+      run: make -j4 -C ports/stm BOARD=feather_stm32f405_express TRANSLATION=pt_BR
     # I gave up trying to do esp builds on windows when I saw
     # ERROR: Platform MINGW64_NT-10.0-17763-x86_64 appears to be unsupported
     # https://github.com/espressif/esp-idf/issues/7062

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,13 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
     - name: Set up repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: false
+        progress: false
         fetch-depth: 1
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Duplicate USB VID/PID check
@@ -108,12 +109,13 @@ jobs:
       CP_VERSION: ${{ needs.scheduler.outputs.cp-version }}
     steps:
     - name: Set up repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: false
+        progress: false
         fetch-depth: 1
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Set up submodules
@@ -163,12 +165,13 @@ jobs:
       CP_VERSION: ${{ needs.scheduler.outputs.cp-version }}
     steps:
     - name: Set up repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: false
+        progress: false
         fetch-depth: 1
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Set up submodules
@@ -260,9 +263,10 @@ jobs:
         which python; python --version; python -c "import cascadetoml"
         which python3; python3 --version; python3 -c "import cascadetoml"
     - name: Set up repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: false
+        progress: false
         fetch-depth: 1
     - name: Set up submodules
       uses: ./.github/actions/deps/submodules

--- a/.github/workflows/create-website-pr.yml
+++ b/.github/workflows/create-website-pr.yml
@@ -17,12 +17,13 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
     - name: Set up repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: false
+        progress: false
         fetch-depth: 1
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Set up submodules

--- a/.github/workflows/create-website-pr.yml
+++ b/.github/workflows/create-website-pr.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: false
-        progress: false
+        show-progress: false
         fetch-depth: 1
     - name: Set up python
       uses: actions/setup-python@v5

--- a/.github/workflows/custom-board-build.yml
+++ b/.github/workflows/custom-board-build.yml
@@ -84,7 +84,7 @@ jobs:
       run: make -j2 ${{ inputs.flags }} BOARD=${{ inputs.board }} DEBUG=${{ inputs.debug && '1' || '0' }} TRANSLATION=${{ inputs.language }}
       working-directory: ports/${{ steps.set-up-port.outputs.port }}
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.board }}-${{ inputs.language }}-${{ inputs.version }}${{ inputs.flags != '' && '-custom' || '' }}${{ inputs.debug && '-debug' || '' }}
         path: ports/${{ steps.set-up-port.outputs.port }}/build-${{ inputs.board }}/firmware.*

--- a/.github/workflows/custom-board-build.yml
+++ b/.github/workflows/custom-board-build.yml
@@ -81,7 +81,7 @@ jobs:
         riscv64-unknown-elf-gcc --version || true
         mkfs.fat --version || true
     - name: Build board
-      run: make -j2 ${{ inputs.flags }} BOARD=${{ inputs.board }} DEBUG=${{ inputs.debug && '1' || '0' }} TRANSLATION=${{ inputs.language }}
+      run: make -j4 ${{ inputs.flags }} BOARD=${{ inputs.board }} DEBUG=${{ inputs.debug && '1' || '0' }} TRANSLATION=${{ inputs.language }}
       working-directory: ports/${{ steps.set-up-port.outputs.port }}
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/custom-board-build.yml
+++ b/.github/workflows/custom-board-build.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         > custom-build && git add custom-build
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Set up port

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: false
-        progress: false
+        show-progress: false
         fetch-depth: 1
     - name: Set up python
       uses: actions/setup-python@v5
@@ -41,7 +41,7 @@ jobs:
       run: git diff > ~/pre-commit.patch
     - name: Upload patch
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: patch
         path: ~/pre-commit.patch

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,12 +17,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Set up repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: false
+        progress: false
         fetch-depth: 1
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Set up submodules

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,12 +24,13 @@ jobs:
       TEST_native_mpy: --via-mpy --emit native -d basics float micropython
     steps:
     - name: Set up repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: false
+        progress: false
         fetch-depth: 1
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Set up submodules

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: false
-        progress: false
+        show-progress: false
         fetch-depth: 1
     - name: Set up python
       uses: actions/setup-python@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,12 +45,12 @@ jobs:
       with:
         cp-version: ${{ inputs.cp-version }}
     - name: Build unix port
-      run: make -C ports/unix VARIANT=coverage -j2
+      run: make -C ports/unix VARIANT=coverage -j4
     - name: Run tests
-      run: ./run-tests.py -j2 ${{ env[format('TEST_{0}', matrix.test)] }}
+      run: ./run-tests.py -j4 ${{ env[format('TEST_{0}', matrix.test)] }}
       working-directory: tests
     - name: Print failure info
-      run: ./run-tests.py -j2 --print-failures
+      run: ./run-tests.py -j4 --print-failures
       if: failure()
       working-directory: tests
     - name: Build native modules

--- a/tools/build_release_files.py
+++ b/tools/build_release_files.py
@@ -19,10 +19,6 @@ from shared_bindings_matrix import get_settings_from_makefile
 for port in build_info.SUPPORTED_PORTS:
     result = subprocess.run("rm -rf ../ports/{port}/build*".format(port=port), shell=True)
 
-PARALLEL = "-j 4"
-if "GITHUB_ACTION" in os.environ:
-    PARALLEL = "-j 2"
-
 all_boards = build_info.get_board_mapping()
 build_boards = list(all_boards.keys())
 if "BOARDS" in os.environ:


### PR DESCRIPTION
- Fixes #8832.

`checkout@v4` has a new `show-progress: true|false` option that allows suppressing progress lines, which can make a log a lot longer. Sounded good to me, so I added `progress:false` everywhere it was used.

`upload-artifact@v4` and `download-artifact@v4` [have been completely rewritten, with some upward incompatibilities](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/). I think they should still work for us, though. 