### PR TITLE
Correct Firebeetle 2 ESP32-S3's I2C

### DIFF
--- a/ports/espressif/boards/firebeetle2_esp32s3/mpconfigboard.h
+++ b/ports/espressif/boards/firebeetle2_esp32s3/mpconfigboard.h
@@ -27,9 +27,8 @@
 #define MICROPY_HW_BOARD_NAME       "DFRobot FireBeetle 2 ESP32-S3"
 #define MICROPY_HW_MCU_NAME         "ESP32S3"
 
-#define CIRCUITPY_BOARD_I2C         (2)
-#define CIRCUITPY_BOARD_I2C_PIN     {{.scl = &pin_GPIO2, .sda = &pin_GPIO3}, \
-                                     {.scl = &pin_GPIO2, .sda = &pin_GPIO1}}
+#define CIRCUITPY_BOARD_I2C         (1)
+#define CIRCUITPY_BOARD_I2C_PIN     {{.scl = &pin_GPIO2, .sda = &pin_GPIO1}}
 
 #define DEFAULT_SPI_BUS_SCK (&pin_GPIO17)
 #define DEFAULT_SPI_BUS_MOSI (&pin_GPIO15)

--- a/ports/espressif/boards/firebeetle2_esp32s3/pins.c
+++ b/ports/espressif/boards/firebeetle2_esp32s3/pins.c
@@ -2,8 +2,6 @@
 #include "shared-bindings/board/__init__.h"
 #include "shared-module/displayio/__init__.h"
 
-CIRCUITPY_BOARD_BUS_SINGLETON(cam_i2c, i2c, 1) // Camera sensor
-
 STATIC const mp_rom_obj_tuple_t camera_data_tuple = {
     // The order matters.
     // They must be ordered from low to high (Y2, Y3 .. Y9).
@@ -43,9 +41,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SCL),      MP_ROM_PTR(&pin_GPIO2) },
 
     { MP_ROM_QSTR(MP_QSTR_IO1),      MP_ROM_PTR(&pin_GPIO1) },
-    { MP_ROM_QSTR(MP_QSTR_SDA),      MP_ROM_PTR(&pin_GPIO3) },
+    { MP_ROM_QSTR(MP_QSTR_SDA),      MP_ROM_PTR(&pin_GPIO1) },
 
-    // I2C cannot be used when CAM_I2C is in use.
     { MP_ROM_QSTR(MP_QSTR_I2C),  MP_ROM_PTR(&board_i2c_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_IO0),      MP_ROM_PTR(&pin_GPIO0) },
@@ -118,7 +115,5 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_CAM_HREF),  MP_ROM_PTR(&pin_GPIO42)},
     { MP_ROM_QSTR(MP_QSTR_CAM_PCLK),  MP_ROM_PTR(&pin_GPIO5) },
     { MP_ROM_QSTR(MP_QSTR_CAM_XCLK),  MP_ROM_PTR(&pin_GPIO45)},
-
-    { MP_ROM_QSTR(MP_QSTR_CAM_I2C),   MP_ROM_PTR(&board_cam_i2c_obj)},
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
Turns out the I2C bus that is mapped to the silkscreen is not correct and is instead the same as CAM_I2C.

Tested now with the camera, the pmic (these 2 are internally connected) and an ssd1306 (which was connected to the SDA and SCL pins of the silkscreen).

I don't even know why I was using IO3.
But in either case, it's now correct.

```
>>> import board
>>> from AXP313A import *
>>> i2c = board.I2C()
>>> a = AXP313A(i2c)
>>> enable_camera(a, camera_voltages.OV2640)
True
>>> import espcamera
>>> b = espcamera.Camera(data_pins=board.CAM_DATA, pixel_clock_pin=board.CAM_PCLK, vsync_pin=board.CAM_VSYNC, href_pin=board.CAM_HREF, external_clock_pin=board.CAM_XCLK, external_clock_frequency=20_000_000, powerdown_pin=None, reset_pin=None, i2c=i2c, pixel_format=espcamera.PixelFormat.JPEG, frame_size=espcamera.FrameSize.VGA, jpeg_quality=11, framebuffer_count=1, grab_mode=espcamera.GrabMode.LATEST)
>>> b.sensor_name
'OV2640'
>>> i2c.try_lock()
True
>>> i2c.scan()
[48, 54, 60]
>>> i2c.unlock()
```