### PR TITLE
Collect refresh sequence pointer

### DIFF
--- a/shared-module/epaperdisplay/EPaperDisplay.c
+++ b/shared-module/epaperdisplay/EPaperDisplay.c
@@ -507,6 +507,7 @@ void epaperdisplay_epaperdisplay_collect_ptrs(epaperdisplay_epaperdisplay_obj_t 
     displayio_display_bus_collect_ptrs(&self->bus);
     gc_collect_ptr((void *)self->start_sequence);
     gc_collect_ptr((void *)self->stop_sequence);
+    gc_collect_ptr((void *)self->refresh_sequence);
 }
 
 size_t maybe_refresh_epaperdisplay(void) {


### PR DESCRIPTION
Otherwise it will be freed during a collect and potentially overwritten. This is a bug in 8.x but isn't seen as early as in 9.x because 9.x will collect before expanding the split heap further.

Fixes #8793