### PR TITLE
Make `supervisor.reload()` from REPL work

### DIFF
--- a/main.c
+++ b/main.c
@@ -1099,7 +1099,7 @@ int __attribute__((used)) main(void) {
             exit_code = run_repl(get_safe_mode());
             supervisor_set_run_reason(RUN_REASON_REPL_RELOAD);
         }
-        if (exit_code == PYEXEC_FORCED_EXIT) {
+        if (exit_code & (PYEXEC_FORCED_EXIT | PYEXEC_RELOAD)) {
             if (!simulate_reset) {
                 serial_write_compressed(MP_ERROR_TEXT("soft reboot\n"));
             }

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -602,7 +602,7 @@ raw_repl_reset:
         }
 
         int ret = parse_compile_execute(&line, MP_PARSE_FILE_INPUT, EXEC_FLAG_PRINT_EOF | EXEC_FLAG_SOURCE_IS_VSTR, NULL);
-        if (ret & PYEXEC_FORCED_EXIT) {
+        if (ret & (PYEXEC_FORCED_EXIT | PYEXEC_RELOAD)) {
             return ret;
         }
     }
@@ -739,7 +739,7 @@ friendly_repl_reset:
         }
 
         ret = parse_compile_execute(&line, parse_input_kind, EXEC_FLAG_ALLOW_DEBUGGING | EXEC_FLAG_IS_REPL | EXEC_FLAG_SOURCE_IS_VSTR, NULL);
-        if (ret & PYEXEC_FORCED_EXIT) {
+        if (ret & (PYEXEC_FORCED_EXIT | PYEXEC_RELOAD)) {
             return ret;
         }
     }


### PR DESCRIPTION
It will then run the next script.

Fixes #8148