### PR TITLE
Collect refresh sequence pointer: backport to 8.2.x of #8839

### DIFF
--- a/shared-module/displayio/EPaperDisplay.c
+++ b/shared-module/displayio/EPaperDisplay.c
@@ -507,6 +507,7 @@ void displayio_epaperdisplay_collect_ptrs(displayio_epaperdisplay_obj_t *self) {
     displayio_display_core_collect_ptrs(&self->core);
     gc_collect_ptr((void *)self->start_sequence);
     gc_collect_ptr((void *)self->stop_sequence);
+    gc_collect_ptr((void *)self->refresh_sequence);
 }
 
 size_t maybe_refresh_epaperdisplay(void) {


### PR DESCRIPTION
Backport of #8839:
Otherwise it will be freed during a collect and potentially overwritten. This is a bug in 8.x but isn't seen as early as in 9.x because 9.x will collect before expanding the split heap further.

Fixes #8793