### PR TITLE
Allow the framebuffer size of an rgbmatrix to be >65535 bytes

### DIFF
--- a/shared-module/rgbmatrix/RGBMatrix.h
+++ b/shared-module/rgbmatrix/RGBMatrix.h
@@ -38,7 +38,8 @@ typedef struct {
     supervisor_allocation *allocation;
     Protomatter_core protomatter;
     void *timer;
-    uint16_t bufsize, width;
+    uint32_t bufsize;
+    uint16_t width;
     uint8_t rgb_pins[30];
     uint8_t addr_pins[10];
     uint8_t clock_pin, latch_pin, oe_pin;


### PR DESCRIPTION
Closes #8846 if my analysis is correct