### PR TITLE
Fixed some IO assignments and naming for UM BLING

### DIFF
--- a/ports/espressif/boards/unexpectedmaker_bling/pins.c
+++ b/ports/espressif/boards/unexpectedmaker_bling/pins.c
@@ -37,16 +37,16 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_I2S_MIC_SEL), MP_ROM_PTR(&pin_GPIO39) },
 
     // I2S Amplifier MAX98357A
-    { MP_ROM_QSTR(MP_QSTR_I2S_MIC_LRCLK), MP_ROM_PTR(&pin_GPIO1) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_MIC_BCLK), MP_ROM_PTR(&pin_GPIO2) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_MIC_DATA), MP_ROM_PTR(&pin_GPIO3) },
-    { MP_ROM_QSTR(MP_QSTR_I2S_MIC_SD), MP_ROM_PTR(&pin_GPIO4) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_AMP_LRCLK), MP_ROM_PTR(&pin_GPIO1) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_AMP_BCLK), MP_ROM_PTR(&pin_GPIO2) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_AMP_DATA), MP_ROM_PTR(&pin_GPIO3) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_AMP_SD), MP_ROM_PTR(&pin_GPIO4) },
 
     // RTC Interrupt Pin
     { MP_ROM_QSTR(MP_QSTR_RTC_INT), MP_ROM_PTR(&pin_GPIO7) },
 
     // LED Matrix
-    { MP_ROM_QSTR(MP_QSTR_MATRIX_POWER), MP_ROM_PTR(&pin_GPIO5) },
+    { MP_ROM_QSTR(MP_QSTR_MATRIX_POWER), MP_ROM_PTR(&pin_GPIO6) },
     { MP_ROM_QSTR(MP_QSTR_MATRIX_DATA), MP_ROM_PTR(&pin_GPIO18) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },


### PR DESCRIPTION
Got the LED_PWR IO wrong, and incorrectly named the I2S AMP IO and I2S MIC IO.