### PR TITLE
cyw43-driver: Update to Adafruit fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -306,7 +306,8 @@
 	url = https://github.com/elecfreaks/circuitpython_picoed.git
 [submodule "ports/raspberrypi/lib/cyw43-driver"]
 	path = ports/raspberrypi/lib/cyw43-driver
-	url = https://github.com/georgerobotics/cyw43-driver.git
+	url = https://github.com/adafruit/cyw43-driver
+	branch = circuitpython9
 [submodule "ports/raspberrypi/lib/lwip"]
 	path = ports/raspberrypi/lib/lwip
 	url = https://github.com/adafruit/lwip.git


### PR DESCRIPTION
Update `cyw43-driver` to branch `circuitpython9` of the Adafruit fork. This updates `cyw43-driver` to its upstream `MAIN` plus two patches awaiting upstream merge.

This pull resolves #8718.