### PR TITLE
remove subdirectory non-existence check for better compatibility with 9.0

### DIFF
--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -178,17 +178,8 @@ void common_hal_storage_mount(mp_obj_t vfs_obj, const char *mount_path, bool rea
     args[0] = readonly ? mp_const_true : mp_const_false;
     args[1] = mp_const_false; // Don't make the file system automatically when mounting.
 
-    // Check that there's no file or directory with the same name as the mount point.
-    // But it's ok to mount '/' in any case.
-    if (strcmp(vfs->str, "/") != 0) {
-        nlr_buf_t nlr;
-        if (nlr_push(&nlr) == 0) {
-            common_hal_os_stat(mount_path);
-            nlr_pop();
-            // Something with the same name exists.
-            mp_raise_OSError(MP_EEXIST);
-        }
-    }
+    // 8.2.x: no check for existence of mount point, to ease the 8.2.x -> 9 transition
+    // 9: will require existence of mount point as directory
 
     // check that the destination mount point is unused
     const char *path_out;


### PR DESCRIPTION
This will require care when merging 8.2.x to 9, because we want to make sure and retain the version 9 functionality.