### PR TITLE
Allow zero size blit without raising exception

### DIFF
--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -45,20 +45,11 @@
 
 // This assigns to [0] and [2] because the order is x1, y1, x2, y2
 STATIC void bitmaptools_validate_coord_range(int16_t out[3], const mp_arg_val_t in[3], int lim, const qstr what[2]) {
-    if (lim - 1 > 0) {
-        out[0] = mp_arg_validate_int_range(mp_arg_validate_type_int(in[0].u_obj, what[0]), 0, lim - 1, what[0]);
-    } else {
-        out[0] = mp_arg_validate_type_int(in[0].u_obj, what[0]);
-    }
-
+    out[0] = mp_arg_validate_int_range(mp_arg_validate_type_int(in[0].u_obj, what[0]), 0, lim, what[0]);
     if (in[2].u_obj == mp_const_none) {
         out[2] = lim;
     } else {
-        if (lim > out[0] + 1) {
-            out[2] = mp_arg_validate_int_range(mp_arg_validate_type_int(in[2].u_obj, what[1]), out[0] + 1, lim, what[1]);
-        } else {
-            out[2] = mp_arg_validate_type_int(in[2].u_obj, what[1]);
-        }
+        out[2] = mp_arg_validate_int_range(mp_arg_validate_type_int(in[2].u_obj, what[1]), out[0], lim, what[1]);
     }
 }
 

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -45,18 +45,18 @@
 
 // This assigns to [0] and [2] because the order is x1, y1, x2, y2
 STATIC void bitmaptools_validate_coord_range(int16_t out[3], const mp_arg_val_t in[3], int lim, const qstr what[2]) {
-    if (lim -1 > 0){
+    if (lim - 1 > 0) {
         out[0] = mp_arg_validate_int_range(mp_arg_validate_type_int(in[0].u_obj, what[0]), 0, lim - 1, what[0]);
-    }else{
+    } else {
         out[0] = mp_arg_validate_type_int(in[0].u_obj, what[0]);
     }
 
     if (in[2].u_obj == mp_const_none) {
         out[2] = lim;
     } else {
-        if (lim > out[0] + 1){
+        if (lim > out[0] + 1) {
             out[2] = mp_arg_validate_int_range(mp_arg_validate_type_int(in[2].u_obj, what[1]), out[0] + 1, lim, what[1]);
-        }else{
+        } else {
             out[2] = mp_arg_validate_type_int(in[2].u_obj, what[1]);
         }
     }

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -45,11 +45,20 @@
 
 // This assigns to [0] and [2] because the order is x1, y1, x2, y2
 STATIC void bitmaptools_validate_coord_range(int16_t out[3], const mp_arg_val_t in[3], int lim, const qstr what[2]) {
-    out[0] = mp_arg_validate_int_range(mp_arg_validate_type_int(in[0].u_obj, what[0]), 0, lim - 1, what[0]);
+    if (lim -1 > 0){
+        out[0] = mp_arg_validate_int_range(mp_arg_validate_type_int(in[0].u_obj, what[0]), 0, lim - 1, what[0]);
+    }else{
+        out[0] = mp_arg_validate_type_int(in[0].u_obj, what[0]);
+    }
+
     if (in[2].u_obj == mp_const_none) {
         out[2] = lim;
     } else {
-        out[2] = mp_arg_validate_int_range(mp_arg_validate_type_int(in[2].u_obj, what[1]), out[0] + 1, lim, what[1]);
+        if (lim > out[0] + 1){
+            out[2] = mp_arg_validate_int_range(mp_arg_validate_type_int(in[2].u_obj, what[1]), out[0] + 1, lim, what[1]);
+        }else{
+            out[2] = mp_arg_validate_type_int(in[2].u_obj, what[1]);
+        }
     }
 }
 

--- a/tests/circuitpython/bitmaptools_blit_boundaries.py
+++ b/tests/circuitpython/bitmaptools_blit_boundaries.py
@@ -1,0 +1,75 @@
+import displayio
+import bitmaptools
+
+src_bmp = displayio.Bitmap(10, 10, 2)
+src_bmp.fill(1)
+
+dest_bmp = displayio.Bitmap(10, 10, 2)
+dest_bmp.fill(0)
+
+# valid values, non-zero size
+bitmaptools.blit(dest_bmp, src_bmp, x=0, y=0, x1=0, y1=0, x2=2, y2=2)
+print("blit 1 successful")
+
+# valid values, zero width (no effect)
+bitmaptools.blit(dest_bmp, src_bmp, x=5, y=5, x1=1, y1=1, x2=1, y2=6)
+print("blit 2 successful")
+
+# valid values, zero height (no effect)
+bitmaptools.blit(dest_bmp, src_bmp, x=5, y=5, x1=1, y1=1, x2=2, y2=1)
+print("blit 3 successful")
+
+try:
+    # invalid values, x too large
+    bitmaptools.blit(dest_bmp, src_bmp, x=20, y=5)
+    print("blit 4 successful")
+except ValueError as e:
+    print(f"Error: {e}")
+
+try:
+    # invalid values, y too large
+    bitmaptools.blit(dest_bmp, src_bmp, x=5, y=25)
+    print("blit 5 successful")
+except ValueError as e:
+    print(f"Error: {e}")
+
+try:
+    # invalid values, x2 too large
+    bitmaptools.blit(dest_bmp, src_bmp, x=5, y=5, x1=0, y1=0, x2=12, y2=5)
+    print("blit 6 successful")
+except ValueError as e:
+    print(f"Error: {e}")
+
+try:
+    # invalid values, x2 too small
+    bitmaptools.blit(dest_bmp, src_bmp, x=5, y=5, x1=3, y1=3, x2=0, y2=5)
+    print("blit 7 successful")
+except ValueError as e:
+    print(f"Error: {e}")
+
+try:
+    # invalid values, y2 too small
+    bitmaptools.blit(dest_bmp, src_bmp, x=5, y=5, x1=3, y1=3, x2=5, y2=0)
+    print("blit 8 successful")
+except ValueError as e:
+    print(f"Error: {e}")
+
+try:
+    # invalid values, y2 too large
+    bitmaptools.blit(dest_bmp, src_bmp, x=5, y=5, x1=3, y1=3, x2=5, y2=20)
+    print("blit 9 successful")
+except ValueError as e:
+    print(f"Error: {e}")
+
+# import board
+# p = displayio.Palette(2)
+# p[0] = 0xffffff
+# p[1] = 0x0000ff
+# dest_tg = displayio.TileGrid(bitmap=dest_bmp, pixel_shader=p)
+#
+# main_group = displayio.Group(scale=5)
+# main_group.append(dest_tg)
+#
+# board.DISPLAY.root_group = main_group
+# while True:
+#     pass

--- a/tests/circuitpython/bitmaptools_blit_boundaries.py.exp
+++ b/tests/circuitpython/bitmaptools_blit_boundaries.py.exp
@@ -1,0 +1,9 @@
+blit 1 successful
+blit 2 successful
+blit 3 successful
+Error: x must be 0-10
+Error: y must be 0-10
+Error: x2 must be 0-10
+Error: x2 must be 3-10
+Error: y2 must be 3-10
+Error: y2 must be 3-10


### PR DESCRIPTION
This is one potential solution for #8876.

The crux of the 0,0 size was that max was ending up less than min in the range check which causes it to fail range validation automatically.

With this build I am able to run the SMS scroller code successfully on a Matrix Portal S3. It's only scrolling the default text, I have not set up anything wtih adafruit.io or SMS for it. But I did successfully replicate the exception mentioned in the issue with that default text and confirmed this version does not raise the same exception.