### PR TITLE
[Doc] Fix referencing board.SPI() instead of busio.SPI()

### DIFF
--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -69,11 +69,13 @@
 //|             import os
 //|
 //|             import board
-//|             import busio
+//|             #import busio           # If you need to use `busio.SPI` instead of `board.SPI`
 //|             import sdcardio
 //|             import storage
 //|
-//|             sd = sdcardio.SDCard(busio.SPI(), board.SD_CS)
+//|             sd = sdcardio.SDCard(board.SPI(), board.SD_CS)
+//|             # If board.SPI is not defined on the board being used
+//|             # sd = sdcardio.SDCard(busio.SPI(board.SCK,board.MOSI,board.MISO), board.SD_CS)
 //|             vfs = storage.VfsFat(sd)
 //|             storage.mount(vfs, '/sd')
 //|             os.listdir('/sd')"""

--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -69,10 +69,11 @@
 //|             import os
 //|
 //|             import board
+//|             import busio
 //|             import sdcardio
 //|             import storage
 //|
-//|             sd = sdcardio.SDCard(board.SPI(), board.SD_CS)
+//|             sd = sdcardio.SDCard(busio.SPI(), board.SD_CS)
 //|             vfs = storage.VfsFat(sd)
 //|             storage.mount(vfs, '/sd')
 //|             os.listdir('/sd')"""

--- a/shared-module/board/__init__.c
+++ b/shared-module/board/__init__.c
@@ -92,7 +92,7 @@ mp_obj_t common_hal_board_create_i2c(const mp_int_t instance) {
 
 #if CIRCUITPY_BOARD_SPI
 // Statically allocate the SPI object so it can live past the end of the heap and into the next VM.
-// That way it can be used by built-in FourWire displays and be accessible through board.SPI().
+// That way it can be used by built-in FourWire displays and be accessible through boardio.SPI().
 
 typedef struct {
     const mcu_pin_obj_t *clock;


### PR DESCRIPTION
There was a small mistake in the example code for `sdcardio.SDCard` ([this section in the docs](https://docs.circuitpython.org/en/latest/shared-bindings/sdcardio/index.html#sdcardio.SDCard)). It initialized SPI with `board.SPI()`, instead of `busio.SPI()`.