### PR TITLE
Jpegio fixes: swap order of size and example code Argument

### DIFF
--- a/shared-bindings/jpegio/JpegDecoder.c
+++ b/shared-bindings/jpegio/JpegDecoder.c
@@ -47,7 +47,7 @@
 //|
 //|         decoder = JpegDecoder()
 //|         width, height = decoder.open("/sd/example.jpg")
-//|         bitmap = Bitmap(width, height)
+//|         bitmap = Bitmap(width, height, 65535)
 //|         decoder.decode(bitmap)
 //|         # .. do something with bitmap
 //|     """

--- a/shared-module/jpegio/JpegDecoder.c
+++ b/shared-module/jpegio/JpegDecoder.c
@@ -88,8 +88,8 @@ static mp_obj_t common_hal_jpegio_jpegdecoder_decode_common(jpegio_jpegdecoder_o
     }
     check_jresult(result);
     mp_obj_t elems[] = {
-        MP_OBJ_NEW_SMALL_INT(self->decoder.height),
-        MP_OBJ_NEW_SMALL_INT(self->decoder.width)
+        MP_OBJ_NEW_SMALL_INT(self->decoder.width),
+        MP_OBJ_NEW_SMALL_INT(self->decoder.height)
     };
     return mp_obj_new_tuple(MP_ARRAY_SIZE(elems), elems);
 }


### PR DESCRIPTION
resolves: #8904 and #8899

My testing of the new version on a Feather TFT S3 with JPEGIO turned on in mk file. I confirmed on this version that the example code now results in Bitmap with the same size as the JPEG instead of swapped.