### PR TITLE
Blit swap bytes

### DIFF
--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -1042,7 +1042,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_draw_circle_obj, 0, bitmaptools_obj_draw_
 //|     ...
 //|
 STATIC mp_obj_t bitmaptools_obj_blit(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum {ARG_destination, ARG_source, ARG_x, ARG_y, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_skip_source_index, ARG_skip_dest_index};
+    enum {ARG_destination, ARG_source, ARG_x, ARG_y, ARG_x1, ARG_y1, ARG_x2, ARG_y2, ARG_skip_source_index, ARG_skip_dest_index, ARG_swap_bytes};
     static const mp_arg_t allowed_args[] = {
         {MP_QSTR_dest_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         {MP_QSTR_source_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
@@ -1051,6 +1051,7 @@ STATIC mp_obj_t bitmaptools_obj_blit(size_t n_args, const mp_obj_t *pos_args, mp
         ALLOWED_ARGS_X1_Y1_X2_Y2(0, 0),
         {MP_QSTR_skip_source_index, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         {MP_QSTR_skip_dest_index, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        {MP_QSTR_swap_bytes, MP_ARG_BOOL, {.u_bool = false}},
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     // mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -1094,9 +1095,10 @@ STATIC mp_obj_t bitmaptools_obj_blit(size_t n_args, const mp_obj_t *pos_args, mp
         skip_dest_index = mp_obj_get_int(args[ARG_skip_dest_index].u_obj);
         skip_dest_index_none = false;
     }
+    bool swap_bytes = args[ARG_swap_bytes].u_bool;
 
     common_hal_bitmaptools_blit(destination, source, x, y, lim.x1, lim.y1, lim.x2, lim.y2, skip_source_index, skip_source_index_none, skip_dest_index,
-        skip_dest_index_none);
+        skip_dest_index_none, swap_bytes);
 
     return mp_const_none;
 }

--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -1020,7 +1020,8 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_draw_circle_obj, 0, bitmaptools_obj_draw_
 //|     x2: int | None = None,
 //|     y2: int | None = None,
 //|     skip_source_index: int | None = None,
-//|     skip_dest_index: int | None = None
+//|     skip_dest_index: int | None = None,
+//|     swap_bytes: bool = False
 //| ) -> None:
 //|     """Inserts the source_bitmap region defined by rectangular boundaries
 //|     (x1,y1) and (x2,y2) into the bitmap at the specified (x,y) location.
@@ -1038,7 +1039,9 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_draw_circle_obj, 0, bitmaptools_obj_draw_
 //|     :param int skip_source_index: bitmap palette index in the source that will not be copied,
 //|                            set to None to copy all pixels
 //|     :param int skip_dest_index: bitmap palette index in the destination bitmap that will not get overwritten
-//|                             by the pixels from the source"""
+//|                             by the pixels from the source
+//|     :param bool swap_bytes: Swap the bytes of 565 color values as they are being blitted. Defaults to False.
+//|     """
 //|     ...
 //|
 STATIC mp_obj_t bitmaptools_obj_blit(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/bitmaptools/__init__.h
+++ b/shared-bindings/bitmaptools/__init__.h
@@ -79,7 +79,7 @@ void common_hal_bitmaptools_draw_circle(displayio_bitmap_t *destination,
 
 void common_hal_bitmaptools_blit(displayio_bitmap_t *destination, displayio_bitmap_t *source, int16_t x, int16_t y,
     int16_t x1, int16_t y1, int16_t x2, int16_t y2,
-    uint32_t skip_source_index, bool skip_source_index_none, uint32_t skip_dest_index, bool skip_dest_index_none);
+    uint32_t skip_source_index, bool skip_source_index_none, uint32_t skip_dest_index, bool skip_dest_index_none, bool swap_bytes);
 
 void common_hal_bitmaptools_draw_polygon(displayio_bitmap_t *destination, void *xs, void *ys, size_t points_len, int point_size, uint32_t value, bool close);
 void common_hal_bitmaptools_readinto(displayio_bitmap_t *self, mp_obj_t *file, int element_size, int bits_per_pixel, bool reverse_pixels_in_word, bool swap_bytes, bool reverse_rows);

--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -1122,9 +1122,9 @@ void common_hal_bitmaptools_blit(displayio_bitmap_t *destination, displayio_bitm
                     uint32_t value = common_hal_displayio_bitmap_get_pixel(source, xs_index, ys_index);
                     if (skip_dest_index_none) { // if skip_dest_index is none, then only check source skip
                         if ((skip_source_index_none) || (value != skip_source_index)) {   // write if skip_value_none is True
-                            if (swap_bytes){
+                            if (swap_bytes) {
                                 displayio_bitmap_write_pixel(destination, xd_index, yd_index, rgb565_swap(value));
-                            }else{
+                            } else {
                                 displayio_bitmap_write_pixel(destination, xd_index, yd_index, value);
                             }
                         }

--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -26,6 +26,7 @@
 
 #include "shared/runtime/interrupt_char.h"
 #include "shared-bindings/bitmaptools/__init__.h"
+#include "shared-module/bitmaptools/__init__.h"
 #include "shared-bindings/displayio/Bitmap.h"
 #include "shared-bindings/displayio/Palette.h"
 #include "shared-bindings/displayio/ColorConverter.h"
@@ -39,6 +40,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 #define BITMAP_DEBUG(...) (void)0
 // #define BITMAP_DEBUG(...) mp_printf(&mp_plat_print, __VA_ARGS__)
@@ -1054,9 +1056,24 @@ void common_hal_bitmaptools_draw_circle(displayio_bitmap_t *destination,
     draw_circle(destination, x, y, radius, value);
 }
 
+
+
+uint32_t swap_first_two_bytes(uint32_t value) {
+    // Extract the individual bytes
+    uint8_t byte1 = (value >> 24) & 0xFF; // Most significant byte
+    uint8_t byte2 = (value >> 16) & 0xFF;
+    uint8_t byte3 = (value >> 8) & 0xFF;
+    uint8_t byte4 = value & 0xFF; // Least significant byte
+
+    // Swap the first two bytes
+    //uint32_t swapped_value = (byte2 << 24) | (byte1 << 16) | (byte4 << 8) | byte3;
+    uint32_t swapped_value = (byte1 << 24) | (byte2 << 16) | (byte4 << 8) | byte3;
+    //mp_printf(&mp_plat_print, "swapped_value: 0x%" PRIx32 "\n", swapped_value);
+    return swapped_value;
+}
 void common_hal_bitmaptools_blit(displayio_bitmap_t *destination, displayio_bitmap_t *source, int16_t x, int16_t y,
     int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint32_t skip_source_index, bool skip_source_index_none, uint32_t skip_dest_index,
-    bool skip_dest_index_none) {
+    bool skip_dest_index_none, bool swap_bytes) {
 
     if (destination->read_only) {
         mp_raise_RuntimeError(MP_ERROR_TEXT("Read-only"));
@@ -1104,9 +1121,16 @@ void common_hal_bitmaptools_blit(displayio_bitmap_t *destination, displayio_bitm
 
                 if ((yd_index >= 0) && (yd_index < destination->height)) {
                     uint32_t value = common_hal_displayio_bitmap_get_pixel(source, xs_index, ys_index);
+                    //mp_printf(&mp_plat_print, "Hex value: 0x%" PRIx32 "\n", value);
                     if (skip_dest_index_none) { // if skip_dest_index is none, then only check source skip
                         if ((skip_source_index_none) || (value != skip_source_index)) {   // write if skip_value_none is True
-                            displayio_bitmap_write_pixel(destination, xd_index, yd_index, value);
+                            //displayio_bitmap_write_pixel(destination, xd_index, yd_index, swap_r_and_b(swap_first_two_bytes(value)));
+                            if (swap_bytes){
+                                displayio_bitmap_write_pixel(destination, xd_index, yd_index, swap_first_two_bytes(value));
+                            }else{
+                                displayio_bitmap_write_pixel(destination, xd_index, yd_index, value);
+                            }
+
                         }
                     } else { // check dest_value index against skip_dest_index and skip if they match
                         uint32_t dest_value = common_hal_displayio_bitmap_get_pixel(destination, xd_index, yd_index);

--- a/shared-module/bitmaptools/__init__.c
+++ b/shared-module/bitmaptools/__init__.c
@@ -1058,7 +1058,7 @@ void common_hal_bitmaptools_draw_circle(displayio_bitmap_t *destination,
 
 
 
-uint32_t swap_first_two_bytes(uint32_t value) {
+uint32_t rgb565_swap(uint32_t value) {
     // Extract the individual bytes
     uint8_t byte1 = (value >> 24) & 0xFF; // Most significant byte
     uint8_t byte2 = (value >> 16) & 0xFF;
@@ -1066,9 +1066,8 @@ uint32_t swap_first_two_bytes(uint32_t value) {
     uint8_t byte4 = value & 0xFF; // Least significant byte
 
     // Swap the first two bytes
-    //uint32_t swapped_value = (byte2 << 24) | (byte1 << 16) | (byte4 << 8) | byte3;
     uint32_t swapped_value = (byte1 << 24) | (byte2 << 16) | (byte4 << 8) | byte3;
-    //mp_printf(&mp_plat_print, "swapped_value: 0x%" PRIx32 "\n", swapped_value);
+
     return swapped_value;
 }
 void common_hal_bitmaptools_blit(displayio_bitmap_t *destination, displayio_bitmap_t *source, int16_t x, int16_t y,
@@ -1121,16 +1120,13 @@ void common_hal_bitmaptools_blit(displayio_bitmap_t *destination, displayio_bitm
 
                 if ((yd_index >= 0) && (yd_index < destination->height)) {
                     uint32_t value = common_hal_displayio_bitmap_get_pixel(source, xs_index, ys_index);
-                    //mp_printf(&mp_plat_print, "Hex value: 0x%" PRIx32 "\n", value);
                     if (skip_dest_index_none) { // if skip_dest_index is none, then only check source skip
                         if ((skip_source_index_none) || (value != skip_source_index)) {   // write if skip_value_none is True
-                            //displayio_bitmap_write_pixel(destination, xd_index, yd_index, swap_r_and_b(swap_first_two_bytes(value)));
                             if (swap_bytes){
-                                displayio_bitmap_write_pixel(destination, xd_index, yd_index, swap_first_two_bytes(value));
+                                displayio_bitmap_write_pixel(destination, xd_index, yd_index, rgb565_swap(value));
                             }else{
                                 displayio_bitmap_write_pixel(destination, xd_index, yd_index, value);
                             }
-
                         }
                     } else { // check dest_value index against skip_dest_index and skip if they match
                         uint32_t dest_value = common_hal_displayio_bitmap_get_pixel(destination, xd_index, yd_index);

--- a/shared-module/bitmaptools/__init__.h
+++ b/shared-module/bitmaptools/__init__.h
@@ -24,4 +24,4 @@
  * THE SOFTWARE.
  */
 
-uint32_t swap_first_two_bytes(uint32_t);
+uint32_t rgb565_swap(uint32_t);

--- a/shared-module/bitmaptools/__init__.h
+++ b/shared-module/bitmaptools/__init__.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the Micro Python project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Tim Cocks for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+uint32_t swap_first_two_bytes(uint32_t);

--- a/shared-module/jpegio/JpegDecoder.c
+++ b/shared-module/jpegio/JpegDecoder.c
@@ -201,7 +201,7 @@ static int bitmap_output(JDEC *jd, void *data, JRECT *rect) {
     assert(x2 <= src_width);
     assert(y2 <= src_height);
 
-    common_hal_bitmaptools_blit(self->dest, &src, x, y, x1, y1, x2, y2, self->skip_source_index, self->skip_source_index_none, self->skip_dest_index, self->skip_dest_index_none);
+    common_hal_bitmaptools_blit(self->dest, &src, x, y, x1, y1, x2, y2, self->skip_source_index, self->skip_source_index_none, self->skip_dest_index, self->skip_dest_index_none, false);
     return 1;
 }
 


### PR DESCRIPTION
This adds a new argument `swap_bytes` to `bitmaptools.blit()` which lets the caller indicate they want to perform a byte-swap on  565 color values as they are blitted. 

This allows you to blit from a source rgb888 Bitmap that came from a .bmp file (which will be using a ColorConverter to get into 565 colorspace) into a destination Bitmap that was populated by JpegDecoder from a .jpg file (which uses 565_Swapped colorspace) and have the resulting combined image look correct.

More generally it means if you have an destination Bitmap that uses the 565_Swapped Colorspace, with this change you'll be able to successfully blit data from the 565 (non-swapped) Colorspace into it by setting this argument to `True`