### PR TITLE
Restore setting __file__ in parse_compile_execute

### DIFF
--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -117,6 +117,13 @@ STATIC int parse_compile_execute(const void *source, mp_parse_input_kind_t input
                 }
                 // source is a lexer, parse and compile the script
                 qstr source_name = lex->source_name;
+                // CIRCUITPY-CHANGE
+                #if MICROPY_PY___FILE__
+                if (input_kind == MP_PARSE_FILE_INPUT) {
+                    mp_store_global(MP_QSTR___file__, MP_OBJ_NEW_QSTR(source_name));
+                }
+                #endif
+
                 mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
                 module_fun = mp_compile(&parse_tree, source_name, exec_flags & EXEC_FLAG_IS_REPL);
                 #else


### PR DESCRIPTION
This seems to have been lost, possibly in a merge.

Closes: #8881