### PR TITLE
Swap PIO allocation of USB Host for better Pico W compatibility

### DIFF
--- a/ports/raspberrypi/common-hal/usb_host/Port.c
+++ b/ports/raspberrypi/common-hal/usb_host/Port.c
@@ -122,10 +122,10 @@ usb_host_port_obj_t *common_hal_usb_host_port_construct(const mcu_pin_obj_t *dp,
     pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
     pio_cfg.skip_alarm_pool = true;
     pio_cfg.pin_dp = dp->number;
-    pio_cfg.pio_tx_num = 0;
-    pio_cfg.pio_rx_num = 1;
-    // PIO with room for 22 instructions
-    // PIO with room for 31 instructions and two free SM.
+    // Allocating the peripherals like this works on Pico W, where the
+    // "preferred PIO" for the cyw43 wifi chip is PIO 1.
+    pio_cfg.pio_tx_num = 1; // uses 22 instructions and 1 SM
+    pio_cfg.pio_rx_num = 0; // uses 31 instructions and 2 SM.
     if (!_has_program_room(pio_cfg.pio_tx_num, 22) || _sm_free_count(pio_cfg.pio_tx_num) < 1 ||
         !_has_program_room(pio_cfg.pio_rx_num, 31) || _sm_free_count(pio_cfg.pio_rx_num) < 2) {
         mp_raise_RuntimeError(MP_ERROR_TEXT("All state machines in use"));


### PR DESCRIPTION
I did not test; this was reported by a user as working in the linked bug.

Closes: #8359