### PR TITLE
displayio: add, check "readonly" flag for groups

### DIFF
--- a/shared-module/displayio/Group.c
+++ b/shared-module/displayio/Group.c
@@ -35,7 +35,7 @@
 #endif
 
 static void check_rom(displayio_group_t *self) {
-    if (self->in_rom) {
+    if (self->readonly) {
         mp_raise_RuntimeError(MP_ERROR_TEXT("Read-only"));
     }
 }
@@ -383,7 +383,7 @@ void displayio_group_construct(displayio_group_t *self, mp_obj_list_t *members, 
     self->item_removed = false;
     self->scale = scale;
     self->in_group = false;
-    self->in_rom = false;
+    self->readonly = false;
 }
 
 bool displayio_group_fill_area(displayio_group_t *self, const _displayio_colorspace_t *colorspace, const displayio_area_t *area, uint32_t *mask, uint32_t *buffer) {

--- a/shared-module/displayio/Group.c
+++ b/shared-module/displayio/Group.c
@@ -34,7 +34,7 @@
 #include "shared-bindings/vectorio/VectorShape.h"
 #endif
 
-static void check_rom(displayio_group_t *self) {
+static void check_readonly(displayio_group_t *self) {
     if (self->readonly) {
         mp_raise_RuntimeError(MP_ERROR_TEXT("Read-only"));
     }
@@ -53,7 +53,7 @@ void common_hal_displayio_group_set_hidden(displayio_group_t *self, bool hidden)
     if (self->hidden == hidden) {
         return;
     }
-    check_rom(self);
+    check_readonly(self);
     self->hidden = hidden;
     if (self->hidden_by_parent) {
         return;
@@ -87,7 +87,7 @@ void displayio_group_set_hidden_by_parent(displayio_group_t *self, bool hidden) 
     if (self->hidden_by_parent == hidden) {
         return;
     }
-    check_rom(self);
+    check_readonly(self);
     self->hidden_by_parent = hidden;
     // If we're already hidden, then we're done.
     if (self->hidden) {
@@ -216,7 +216,7 @@ void common_hal_displayio_group_set_scale(displayio_group_t *self, uint32_t scal
     if (self->scale == scale) {
         return;
     }
-    check_rom(self);
+    check_readonly(self);
     uint8_t parent_scale = self->absolute_transform.scale / self->scale;
     self->absolute_transform.dx = self->absolute_transform.dx / self->scale * scale;
     self->absolute_transform.dy = self->absolute_transform.dy / self->scale * scale;
@@ -233,7 +233,7 @@ void common_hal_displayio_group_set_x(displayio_group_t *self, mp_int_t x) {
     if (self->x == x) {
         return;
     }
-    check_rom(self);
+    check_readonly(self);
     if (self->absolute_transform.transpose_xy) {
         int16_t dy = self->absolute_transform.dy / self->scale;
         self->absolute_transform.y += dy * (x - self->x);
@@ -254,7 +254,7 @@ void common_hal_displayio_group_set_y(displayio_group_t *self, mp_int_t y) {
     if (self->y == y) {
         return;
     }
-    check_rom(self);
+    check_readonly(self);
     if (self->absolute_transform.transpose_xy) {
         int8_t dx = self->absolute_transform.dx / self->scale;
         self->absolute_transform.x += dx * (y - self->y);
@@ -267,7 +267,7 @@ void common_hal_displayio_group_set_y(displayio_group_t *self, mp_int_t y) {
 }
 
 static void _add_layer(displayio_group_t *self, mp_obj_t layer) {
-    check_rom(self);
+    check_readonly(self);
     #if CIRCUITPY_VECTORIO
     const vectorio_draw_protocol_t *draw_protocol = mp_proto_get(MP_QSTR_protocol_draw, layer);
     if (draw_protocol != NULL) {
@@ -305,7 +305,7 @@ static void _add_layer(displayio_group_t *self, mp_obj_t layer) {
 }
 
 static void _remove_layer(displayio_group_t *self, size_t index) {
-    check_rom(self);
+    check_readonly(self);
     mp_obj_t layer;
     displayio_area_t layer_area;
     bool rendered_last_frame = false;

--- a/shared-module/displayio/Group.c
+++ b/shared-module/displayio/Group.c
@@ -34,6 +34,11 @@
 #include "shared-bindings/vectorio/VectorShape.h"
 #endif
 
+static void check_rom(displayio_group_t *self) {
+    if (self->in_rom) {
+        mp_raise_RuntimeError(MP_ERROR_TEXT("Read-only"));
+    }
+}
 
 void common_hal_displayio_group_construct(displayio_group_t *self, uint32_t scale, mp_int_t x, mp_int_t y) {
     mp_obj_list_t *members = mp_obj_new_list(0, NULL);
@@ -48,6 +53,7 @@ void common_hal_displayio_group_set_hidden(displayio_group_t *self, bool hidden)
     if (self->hidden == hidden) {
         return;
     }
+    check_rom(self);
     self->hidden = hidden;
     if (self->hidden_by_parent) {
         return;
@@ -81,6 +87,7 @@ void displayio_group_set_hidden_by_parent(displayio_group_t *self, bool hidden) 
     if (self->hidden_by_parent == hidden) {
         return;
     }
+    check_rom(self);
     self->hidden_by_parent = hidden;
     // If we're already hidden, then we're done.
     if (self->hidden) {
@@ -209,6 +216,7 @@ void common_hal_displayio_group_set_scale(displayio_group_t *self, uint32_t scal
     if (self->scale == scale) {
         return;
     }
+    check_rom(self);
     uint8_t parent_scale = self->absolute_transform.scale / self->scale;
     self->absolute_transform.dx = self->absolute_transform.dx / self->scale * scale;
     self->absolute_transform.dy = self->absolute_transform.dy / self->scale * scale;
@@ -225,6 +233,7 @@ void common_hal_displayio_group_set_x(displayio_group_t *self, mp_int_t x) {
     if (self->x == x) {
         return;
     }
+    check_rom(self);
     if (self->absolute_transform.transpose_xy) {
         int16_t dy = self->absolute_transform.dy / self->scale;
         self->absolute_transform.y += dy * (x - self->x);
@@ -245,6 +254,7 @@ void common_hal_displayio_group_set_y(displayio_group_t *self, mp_int_t y) {
     if (self->y == y) {
         return;
     }
+    check_rom(self);
     if (self->absolute_transform.transpose_xy) {
         int8_t dx = self->absolute_transform.dx / self->scale;
         self->absolute_transform.x += dx * (y - self->y);
@@ -257,6 +267,7 @@ void common_hal_displayio_group_set_y(displayio_group_t *self, mp_int_t y) {
 }
 
 static void _add_layer(displayio_group_t *self, mp_obj_t layer) {
+    check_rom(self);
     #if CIRCUITPY_VECTORIO
     const vectorio_draw_protocol_t *draw_protocol = mp_proto_get(MP_QSTR_protocol_draw, layer);
     if (draw_protocol != NULL) {
@@ -294,6 +305,7 @@ static void _add_layer(displayio_group_t *self, mp_obj_t layer) {
 }
 
 static void _remove_layer(displayio_group_t *self, size_t index) {
+    check_rom(self);
     mp_obj_t layer;
     displayio_area_t layer_area;
     bool rendered_last_frame = false;
@@ -371,6 +383,7 @@ void displayio_group_construct(displayio_group_t *self, mp_obj_list_t *members, 
     self->item_removed = false;
     self->scale = scale;
     self->in_group = false;
+    self->in_rom = false;
 }
 
 bool displayio_group_fill_area(displayio_group_t *self, const _displayio_colorspace_t *colorspace, const displayio_area_t *area, uint32_t *mask, uint32_t *buffer) {

--- a/shared-module/displayio/Group.h
+++ b/shared-module/displayio/Group.h
@@ -47,7 +47,7 @@ typedef struct {
     bool in_group : 1;
     bool hidden : 1;
     bool hidden_by_parent : 1;
-    bool in_rom : 1;
+    bool readonly : 1;
     uint8_t padding : 3;
 } displayio_group_t;
 

--- a/shared-module/displayio/Group.h
+++ b/shared-module/displayio/Group.h
@@ -47,7 +47,8 @@ typedef struct {
     bool in_group : 1;
     bool hidden : 1;
     bool hidden_by_parent : 1;
-    uint8_t padding : 4;
+    bool in_rom : 1;
+    uint8_t padding : 3;
 } displayio_group_t;
 
 void displayio_group_construct(displayio_group_t *self, mp_obj_list_t *members, uint32_t scale, mp_int_t x, mp_int_t y);

--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -226,5 +226,5 @@ displayio_group_t circuitpython_splash = {
     .in_group = false,
     .hidden = false,
     .hidden_by_parent = false,
-    .in_rom = true,
+    .readonly = true,
 };

--- a/supervisor/shared/display.c
+++ b/supervisor/shared/display.c
@@ -225,5 +225,6 @@ displayio_group_t circuitpython_splash = {
     .item_removed = false,
     .in_group = false,
     .hidden = false,
-    .hidden_by_parent = false
+    .hidden_by_parent = false,
+    .in_rom = true,
 };


### PR DESCRIPTION
Testing performed on pycamera / memento

 - the "filter demo" program works
 - trying to append something to dispoayio.CIRCUITPYTHON_TERMINAL raises "RuntimeError: Read-only"

However, for some reason serial output wasn't echoing back to the computer(!) during my test, I could only read it on the LCD(!).  I can't guess why this could be related to this PR but maybe it is; I haven't seen it before now and it's a weird failure to go unnoticed for any length of time. [reproduced with c84c066 but not on a different computer, so I'll chalk it up to "laptop needs to be rebooted and is acting out"]

closes: #8873