### PR TITLE
Numerous iMX fixes and SDK update

### DIFF
--- a/ports/mimxrt10xx/common-hal/busio/I2C.c
+++ b/ports/mimxrt10xx/common-hal/busio/I2C.c
@@ -138,6 +138,10 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
                 continue;
             }
 
+            if (reserved_i2c[mcu_i2c_scl_list[j].bank_idx - 1]) {
+                continue;
+            }
+
             self->sda = &mcu_i2c_sda_list[i];
             self->scl = &mcu_i2c_scl_list[j];
 
@@ -150,6 +154,9 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
     } else {
         self->i2c = mcu_i2c_banks[self->sda->bank_idx - 1];
     }
+
+
+    reserved_i2c[self->sda->bank_idx - 1] = true;
 
     config_periph_pin(self->sda);
     config_periph_pin(self->scl);

--- a/ports/mimxrt10xx/common-hal/busio/I2C.h
+++ b/ports/mimxrt10xx/common-hal/busio/I2C.h
@@ -25,8 +25,7 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_BUSIO_I2C_H
-#define MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_BUSIO_I2C_H
+#pragma once
 
 #include "common-hal/microcontroller/Pin.h"
 #include "fsl_common.h"
@@ -42,5 +41,3 @@ typedef struct {
 } busio_i2c_obj_t;
 
 void i2c_reset(void);
-
-#endif // MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_BUSIO_I2C_H

--- a/ports/mimxrt10xx/common-hal/busio/SPI.h
+++ b/ports/mimxrt10xx/common-hal/busio/SPI.h
@@ -25,8 +25,7 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_BUSIO_SPI_H
-#define MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_BUSIO_SPI_H
+#pragma once
 
 #include "common-hal/microcontroller/Pin.h"
 #include "fsl_common.h"
@@ -44,5 +43,3 @@ typedef struct {
 } busio_spi_obj_t;
 
 void spi_reset(void);
-
-#endif // MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_BUSIO_SPI_H

--- a/ports/mimxrt10xx/common-hal/busio/UART.h
+++ b/ports/mimxrt10xx/common-hal/busio/UART.h
@@ -25,8 +25,7 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_BUSIO_UART_H
-#define MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_BUSIO_UART_H
+#pragma once
 
 #include "common-hal/microcontroller/Pin.h"
 
@@ -43,7 +42,6 @@ typedef struct {
     uint8_t *ringbuf;
     uint32_t baudrate;
     uint32_t timeout_ms;
-    bool rx_ongoing;
     uint8_t character_bits;
     uint8_t index;
     const mcu_pin_obj_t *rx;
@@ -54,6 +52,3 @@ typedef struct {
     bool rs485_invert;
 
 } busio_uart_obj_t;
-
-void uart_reset(void);
-#endif // MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_BUSIO_UART_H

--- a/ports/mimxrt10xx/common-hal/digitalio/DigitalInOut.h
+++ b/ports/mimxrt10xx/common-hal/digitalio/DigitalInOut.h
@@ -25,8 +25,7 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_DIGITALIO_DIGITALINOUT_H
-#define MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_DIGITALIO_DIGITALINOUT_H
+#pragma once
 
 #include "common-hal/microcontroller/Pin.h"
 #include "shared-bindings/digitalio/Pull.h"
@@ -41,5 +40,3 @@ typedef struct {
 } digitalio_digitalinout_obj_t;
 
 void pin_config(const mcu_pin_obj_t *pin, bool open_drain, digitalio_pull_t pull);
-
-#endif // MICROPY_INCLUDED_MIMXRT10XX_COMMON_HAL_DIGITALIO_DIGITALINOUT_H

--- a/ports/mimxrt10xx/common-hal/pwmio/PWMOut.c
+++ b/ports/mimxrt10xx/common-hal/pwmio/PWMOut.c
@@ -213,7 +213,6 @@ pwmout_result_t common_hal_pwmio_pwmout_construct(pwmio_pwmout_obj_t *self,
 
         /*
          * pwmConfig.enableDebugMode = false;
-         * pwmConfig.enableWait = false;
          * pwmConfig.reloadSelect = kPWM_LocalReload;
          * pwmConfig.faultFilterCount = 0;
          * pwmConfig.faultFilterPeriod = 0;
@@ -228,7 +227,6 @@ pwmout_result_t common_hal_pwmio_pwmout_construct(pwmio_pwmout_obj_t *self,
         PWM_GetDefaultConfig(&pwmConfig);
 
         pwmConfig.reloadLogic = kPWM_ReloadPwmFullCycle;
-        pwmConfig.enableWait = true;
         pwmConfig.enableDebugMode = true;
 
         pwmConfig.prescale = self->prescaler;

--- a/ports/mimxrt10xx/supervisor/port.c
+++ b/ports/mimxrt10xx/supervisor/port.c
@@ -43,6 +43,7 @@
 #include "common-hal/microcontroller/Pin.h"
 #include "common-hal/pwmio/PWMOut.h"
 #include "common-hal/rtc/RTC.h"
+#include "common-hal/busio/I2C.h"
 #include "common-hal/busio/SPI.h"
 #include "shared-bindings/microcontroller/__init__.h"
 
@@ -447,6 +448,7 @@ safe_mode_t port_init(void) {
 
 void reset_port(void) {
     #if CIRCUITPY_BUSIO
+    i2c_reset();
     spi_reset();
     #endif
 

--- a/shared-bindings/busio/I2C.h
+++ b/shared-bindings/busio/I2C.h
@@ -24,15 +24,7 @@
  * THE SOFTWARE.
  */
 
-// Machine is the HAL for low-level, hardware accelerated functions. It is not
-// meant to simplify APIs, its only meant to unify them so that other modules
-// do not require port specific logic.
-//
-// This file includes externs for all functions a port should implement to
-// support the machine module.
-
-#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_BUSIO_I2C_H
-#define MICROPY_INCLUDED_SHARED_BINDINGS_BUSIO_I2C_H
+#pragma once
 
 #include "py/obj.h"
 
@@ -74,5 +66,3 @@ uint8_t common_hal_busio_i2c_write_read(busio_i2c_obj_t *self, uint16_t address,
 
 // This is used by the supervisor to claim I2C devices indefinitely.
 extern void common_hal_busio_i2c_never_reset(busio_i2c_obj_t *self);
-
-#endif // MICROPY_INCLUDED_SHARED_BINDINGS_BUSIO_I2C_H

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -155,6 +155,8 @@ STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, si
 
     uint8_t bits = (uint8_t)mp_arg_validate_int_range(args[ARG_bits].u_int, 5, 9, MP_QSTR_bits);
 
+    uint16_t buffer_size = (uint16_t)mp_arg_validate_int_range(args[ARG_receiver_buffer_size].u_int, 1, 0xffff, MP_QSTR_receiver_buffer_size);
+
     busio_uart_parity_t parity = BUSIO_UART_PARITY_NONE;
     if (args[ARG_parity].u_obj == MP_OBJ_FROM_PTR(&busio_uart_parity_even_obj)) {
         parity = BUSIO_UART_PARITY_EVEN;
@@ -174,7 +176,7 @@ STATIC mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, si
 
     common_hal_busio_uart_construct(self, tx, rx, rts, cts, rs485_dir, rs485_invert,
         args[ARG_baudrate].u_int, bits, parity, stop, timeout,
-        args[ARG_receiver_buffer_size].u_int, NULL, false);
+        buffer_size, NULL, false);
     return (mp_obj_t)self;
     #else
     mp_raise_NotImplementedError(NULL);


### PR DESCRIPTION
* Fixes #4954. Leaving GPIO in output mode messed with ADC readings.
* Fixes #8018 and fixes #6537. UART rx was more complicated than it needed to be.
* Fixes #5581. uart reset is handled by finalizer. Added i2c_reset() call and reservation check.