### PR TITLE
Fix build filenames for pr merges

### DIFF
--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -31,18 +31,22 @@ jobs:
         submodules: false
         show-progress: false
         fetch-depth: 1
+
     - name: Set up python
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
+
     - name: Set up port
       id: set-up-port
       uses: ./.github/actions/deps/ports
       with:
         board: ${{ matrix.board }}
+
     - name: Set up submodules
       id: set-up-submodules
       uses: ./.github/actions/deps/submodules
+
     - name: Set up external
       uses: ./.github/actions/deps/external
       with:
@@ -68,18 +72,21 @@ jobs:
 
     - name: Set up build failure matcher
       run: echo "::add-matcher::$GITHUB_WORKSPACE/.github/workflows/match-build-fail.json"
+
     - name: Build board
       run: python3 -u build_release_files.py
       working-directory: tools
       env:
         BOARDS: ${{ matrix.board }}
         PULL: ${{ github.event.number }}
+        HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}
+
     - name: Upload to S3
       uses: ./.github/actions/upload_aws
       with:


### PR DESCRIPTION
-  Finishes fixing #8321, which was working for pull_request builds, but not for push builds (PR merges).

I did look at https://github.com/orgs/community/discussions/27071, but could not get the script given to work properly. So I extracted the PR number from the merge commit message instead.

I tested this on my fork of `circuitpython`, by making pull requests to my own repo and then merging them, and checking the build filenames.

Sample filename:
```
adafruit-circuitpython-circuitplayground_bluefruit-en_US-20240216-main-PR8930-e7d5c3e.uf2
```