### PR TITLE
espressif: Set socket type on accepted socket

### DIFF
--- a/ports/espressif/common-hal/socketpool/Socket.c
+++ b/ports/espressif/common-hal/socketpool/Socket.c
@@ -307,6 +307,7 @@ int socketpool_socket_accept(socketpool_socket_obj_t *self, uint8_t *ip, uint32_
         accepted->num = newsoc;
         accepted->pool = self->pool;
         accepted->connected = true;
+        accepted->type = self->type;
     }
 
     return newsoc;
@@ -324,6 +325,7 @@ socketpool_socket_obj_t *common_hal_socketpool_socket_accept(socketpool_socket_o
         sock->num = newsoc;
         sock->pool = self->pool;
         sock->connected = true;
+        sock->type = self->type;
 
         return sock;
     } else {


### PR DESCRIPTION
With this change, https serving "works for me" on a matrixportal s3 with a modified version of
https://github.com/ide/circuitpython-https-server/ (it bundles mpy files incompatible with cpy9 and is not compatible with current adafruit_httpserver); a PR to circuitpython-https-server will also be forthcoming