### PR TITLE
Use pre-commit/action@v3.0.1 to get Node.js 20 support

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -35,7 +35,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gettext uncrustify
     - name: Run pre-commit
-      uses: pre-commit/action@v3.0.0
+      uses: pre-commit/action@v3.0.1
     - name: Make patch
       if: failure()
       run: git diff > ~/pre-commit.patch


### PR DESCRIPTION
Fixes this warning which is appearing when running pre-commit.yml:
```
pre-commit
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

`pre-commit/actions@v3.0.1` updates to Node.js 20. ~~Let's do `@v3` to pick up further bug fixes automatically.~~ EDIT: `@v3` doesn't work: must be forbidden somehow. Use `@v3.0.1`. 