### PR TITLE
Allow 5V power to be controlled from user code on usb host feather

### DIFF
--- a/ports/atmel-samd/common-hal/microcontroller/Pin.c
+++ b/ports/atmel-samd/common-hal/microcontroller/Pin.c
@@ -161,12 +161,11 @@ bool pin_number_is_free(uint8_t pin_number) {
             return false;
         }
         if (pin_number == PIN_PA30
-            #ifdef SAM_D5X_E5X
-            ) {
-            #endif
             #ifdef SAMD21
-            || pin_number == PIN_PA31) {
-            #endif) {
+            || pin_number == PIN_PA31
+            #endif
+            )
+            {
             return state->bit.PMUXEN == 1 && ((pmux->reg >> (4 * pin_index % 2)) & 0xf) == SWD_MUX;
         }
     }

--- a/ports/raspberrypi/boards/adafruit_feather_rp2040_usb_host/board.c
+++ b/ports/raspberrypi/boards/adafruit_feather_rp2040_usb_host/board.c
@@ -28,15 +28,26 @@
 
 #include "shared-bindings/digitalio/DigitalInOut.h"
 #include "shared-bindings/usb_host/Port.h"
+#include "hardware/gpio.h"
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.
 
 digitalio_digitalinout_obj_t _host_power;
 
-void board_init(void) {
-    common_hal_digitalio_digitalinout_construct(&_host_power, &pin_GPIO18);
-    common_hal_digitalio_digitalinout_never_reset(&_host_power);
-    common_hal_digitalio_digitalinout_switch_to_output(&_host_power, true, DRIVE_MODE_PUSH_PULL);
+bool board_reset_pin_number(uint8_t pin_number) {
+    if (pin_number == 18) {
+        // doing this (rather than gpio_init) in this specific order ensures no
+        // glitch if pin was already configured as a high output. gpio_init() temporarily
+        // configures the pin as an input, so the power enable value would potentially
+        // glitch.
+        gpio_put(pin_number, 1);
+        gpio_set_dir(pin_number, GPIO_OUT);
+        gpio_set_function(pin_number, GPIO_FUNC_SIO);
 
+        return true;
+    }
+    return false;
+}
+void board_init(void) {
     common_hal_usb_host_port_construct(&pin_GPIO16, &pin_GPIO17);
 }

--- a/ports/raspberrypi/common-hal/microcontroller/Pin.c
+++ b/ports/raspberrypi/common-hal/microcontroller/Pin.c
@@ -73,6 +73,11 @@ void never_reset_pin_number(uint8_t pin_number) {
     never_reset_pins |= 1 << pin_number;
 }
 
+// By default, all pins get reset in the same way
+MP_WEAK bool board_reset_pin_number(uint8_t pin_number) {
+    return false;
+}
+
 void reset_pin_number(uint8_t pin_number) {
     if (pin_number >= NUM_BANK0_GPIOS) {
         return;
@@ -80,6 +85,11 @@ void reset_pin_number(uint8_t pin_number) {
 
     gpio_bank0_pin_claimed &= ~(1 << pin_number);
     never_reset_pins &= ~(1 << pin_number);
+
+    // Allow the board to override the reset state of any pin
+    if (board_reset_pin_number(pin_number)) {
+        return;
+    }
 
     // We are very aggressive in shutting down the pad fully. Both pulls are
     // disabled and both buffers are as well.

--- a/ports/raspberrypi/common-hal/microcontroller/Pin.c
+++ b/ports/raspberrypi/common-hal/microcontroller/Pin.c
@@ -31,6 +31,8 @@
 
 #include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
 
+static uint32_t gpio_bank0_pin_claimed;
+
 #if CIRCUITPY_CYW43
 #include "bindings/cyw43/__init__.h"
 #include "pico/cyw43_arch.h"
@@ -76,6 +78,7 @@ void reset_pin_number(uint8_t pin_number) {
         return;
     }
 
+    gpio_bank0_pin_claimed &= ~(1 << pin_number);
     never_reset_pins &= ~(1 << pin_number);
 
     // We are very aggressive in shutting down the pad fully. Both pulls are
@@ -105,19 +108,20 @@ void claim_pin(const mcu_pin_obj_t *pin) {
     #if CIRCUITPY_CYW43
     if (pin->base.type == &cyw43_pin_type) {
         cyw_pin_claimed |= (1 << pin->number);
+        return;
     }
     #endif
-    // Nothing to do because all changes will set the GPIO settings.
+    if (pin->number >= NUM_BANK0_GPIOS) {
+        return;
+    }
+    gpio_bank0_pin_claimed |= (1 << pin->number);
 }
 
 bool pin_number_is_free(uint8_t pin_number) {
     if (pin_number >= NUM_BANK0_GPIOS) {
         return false;
     }
-
-    uint32_t pad_state = padsbank0_hw->io[pin_number];
-    return (pad_state & PADS_BANK0_GPIO0_IE_BITS) == 0 &&
-           (pad_state & PADS_BANK0_GPIO0_OD_BITS) != 0;
+    return !(gpio_bank0_pin_claimed & (1 << pin_number));
 }
 
 bool common_hal_mcu_pin_is_free(const mcu_pin_obj_t *pin) {

--- a/ports/raspberrypi/common-hal/microcontroller/Pin.h
+++ b/ports/raspberrypi/common-hal/microcontroller/Pin.h
@@ -34,6 +34,12 @@
 
 #include "peripherals/pins.h"
 
+// If a board needs a different reset state for one or more pins, implement
+// board_reset_pin_number so that it sets this state and returns `true` for those
+// pin numbers, `false` for others.
+// A default weak implementation always returns `false`.
+bool board_reset_pin_number(uint8_t pin_number);
+
 void reset_all_pins(void);
 // reset_pin_number takes the pin number instead of the pointer so that objects don't
 // need to store a full pointer.


### PR DESCRIPTION
This involves re-working some bits of how in-use pins are tracked, because the pad state can no longer be used for that purpose.

now on my usb host feather I can create a DigitalInOut and when I toggle it the "5V" LED will turn off (slowly!) and back on (quickly)

Closes: #8471