### PR TITLE
Fix ssl.SSLSocket bind() error checking

### DIFF
--- a/shared-bindings/ssl/SSLSocket.c
+++ b/shared-bindings/ssl/SSLSocket.c
@@ -103,9 +103,9 @@ STATIC mp_obj_t ssl_sslsocket_bind(mp_obj_t self_in, mp_obj_t addr_in) {
         mp_raise_ValueError(MP_ERROR_TEXT("port must be >= 0"));
     }
 
-    bool ok = common_hal_ssl_sslsocket_bind(self, host, hostlen, (uint32_t)port);
-    if (!ok) {
-        mp_raise_ValueError(MP_ERROR_TEXT("Error: Failure to bind"));
+    size_t error = common_hal_ssl_sslsocket_bind(self, host, hostlen, (uint32_t)port);
+    if (error != 0) {
+        mp_raise_OSError(error);
     }
 
     return mp_const_none;

--- a/shared-bindings/ssl/SSLSocket.h
+++ b/shared-bindings/ssl/SSLSocket.h
@@ -24,8 +24,7 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_SHARED_BINDINGS_SSL_SSLSOCKET_H
-#define MICROPY_INCLUDED_SHARED_BINDINGS_SSL_SSLSOCKET_H
+#pragma once
 
 #if CIRCUITPY_SSL_MBEDTLS
 #include "shared-module/ssl/SSLSocket.h"
@@ -36,7 +35,7 @@
 extern const mp_obj_type_t ssl_sslsocket_type;
 
 ssl_sslsocket_obj_t *common_hal_ssl_sslsocket_accept(ssl_sslsocket_obj_t *self, uint8_t *ip, uint32_t *port);
-bool common_hal_ssl_sslsocket_bind(ssl_sslsocket_obj_t *self, const char *host, size_t hostlen, uint32_t port);
+size_t common_hal_ssl_sslsocket_bind(ssl_sslsocket_obj_t *self, const char *host, size_t hostlen, uint32_t port);
 void common_hal_ssl_sslsocket_close(ssl_sslsocket_obj_t *self);
 void common_hal_ssl_sslsocket_connect(ssl_sslsocket_obj_t *self, const char *host, size_t hostlen, uint32_t port);
 bool common_hal_ssl_sslsocket_get_closed(ssl_sslsocket_obj_t *self);
@@ -45,5 +44,3 @@ bool common_hal_ssl_sslsocket_listen(ssl_sslsocket_obj_t *self, int backlog);
 mp_uint_t common_hal_ssl_sslsocket_recv_into(ssl_sslsocket_obj_t *self, uint8_t *buf, uint32_t len);
 mp_uint_t common_hal_ssl_sslsocket_send(ssl_sslsocket_obj_t *self, const uint8_t *buf, uint32_t len);
 void common_hal_ssl_sslsocket_settimeout(ssl_sslsocket_obj_t *self, uint32_t timeout_ms);
-
-#endif // MICROPY_INCLUDED_SHARED_BINDINGS_SSL_SSLSOCKET_H

--- a/shared-module/ssl/SSLSocket.c
+++ b/shared-module/ssl/SSLSocket.c
@@ -302,7 +302,7 @@ mp_uint_t common_hal_ssl_sslsocket_send(ssl_sslsocket_obj_t *self, const uint8_t
     mp_raise_OSError(ret);
 }
 
-bool common_hal_ssl_sslsocket_bind(ssl_sslsocket_obj_t *self, const char *host, size_t hostlen, uint32_t port) {
+size_t common_hal_ssl_sslsocket_bind(ssl_sslsocket_obj_t *self, const char *host, size_t hostlen, uint32_t port) {
     return common_hal_socketpool_socket_bind(self->sock, host, hostlen, port);
 }
 


### PR DESCRIPTION
Non-ssl sockets now return size_t error numbers, not bool.

Fixes #8947

@anecdata or @michalpokusa please test this.