### PR TITLE
usb_hid.set_interface_name

### DIFF
--- a/shared-bindings/usb_hid/__init__.c
+++ b/shared-bindings/usb_hid/__init__.c
@@ -155,6 +155,37 @@ STATIC mp_obj_t usb_hid_get_boot_device(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(usb_hid_get_boot_device_obj, usb_hid_get_boot_device);
 
+
+//| def set_interface_name(
+//|     interface_name: str
+//| ) -> None:
+//|     """Override HID interface name in the USB Interface Descriptor.
+//|
+//|     `interface_name` must be ASCII string (or buffers) of at most 126.
+//|
+//|     This method must be called in boot.py to have any effect.
+//|
+//|     Not available on boards without native USB support.
+//|     """
+//|     ...
+//|
+STATIC mp_obj_t usb_hid_set_interface_name(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_interface_name, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_rom_obj = mp_const_none} }
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, (mp_arg_val_t *)&args);
+
+    mp_buffer_info_t interface_name;
+    mp_get_buffer_raise(args[0].u_obj, &interface_name, MP_BUFFER_READ);
+    mp_arg_validate_length_range(interface_name.len, 1, 126, MP_QSTR_interface_name);
+    memcpy(usb_hid_interface_name_obj.interface_name, interface_name.buf, interface_name.len);
+    usb_hid_interface_name_obj.interface_name[interface_name.len] = 0;
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(usb_hid_set_interface_name_obj, 1, usb_hid_set_interface_name);
+
 // usb_hid.devices is set once the usb devices are determined, after boot.py runs.
 STATIC mp_map_elem_t usb_hid_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),        MP_OBJ_NEW_QSTR(MP_QSTR_usb_hid) },
@@ -163,6 +194,7 @@ STATIC mp_map_elem_t usb_hid_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_disable),         MP_OBJ_FROM_PTR(&usb_hid_disable_obj) },
     { MP_ROM_QSTR(MP_QSTR_enable),          MP_OBJ_FROM_PTR(&usb_hid_enable_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_boot_device), MP_OBJ_FROM_PTR(&usb_hid_get_boot_device_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_interface_name), MP_OBJ_FROM_PTR(&usb_hid_set_interface_name_obj) },
 };
 
 STATIC MP_DEFINE_MUTABLE_DICT(usb_hid_module_globals, usb_hid_module_globals_table);

--- a/shared-bindings/usb_hid/__init__.c
+++ b/shared-bindings/usb_hid/__init__.c
@@ -161,7 +161,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(usb_hid_get_boot_device_obj, usb_hid_get_boot_device);
 //| ) -> None:
 //|     """Override HID interface name in the USB Interface Descriptor.
 //|
-//|     `interface_name` must be ASCII string (or buffers) of at most 126.
+//|     `interface_name` must be an ASCII string (or buffer) of at most 126.
 //|
 //|     This method must be called in boot.py to have any effect.
 //|

--- a/shared-bindings/usb_hid/__init__.c
+++ b/shared-bindings/usb_hid/__init__.c
@@ -156,12 +156,10 @@ STATIC mp_obj_t usb_hid_get_boot_device(void) {
 MP_DEFINE_CONST_FUN_OBJ_0(usb_hid_get_boot_device_obj, usb_hid_get_boot_device);
 
 
-//| def set_interface_name(
-//|     interface_name: str
-//| ) -> None:
+//| def set_interface_name(interface_name: str) -> None:
 //|     """Override HID interface name in the USB Interface Descriptor.
 //|
-//|     `interface_name` must be an ASCII string (or buffer) of at most 126.
+//|     ``interface_name`` must be an ASCII string (or buffer) of at most 126.
 //|
 //|     This method must be called in boot.py to have any effect.
 //|
@@ -179,8 +177,12 @@ STATIC mp_obj_t usb_hid_set_interface_name(size_t n_args, const mp_obj_t *pos_ar
     mp_buffer_info_t interface_name;
     mp_get_buffer_raise(args[0].u_obj, &interface_name, MP_BUFFER_READ);
     mp_arg_validate_length_range(interface_name.len, 1, 126, MP_QSTR_interface_name);
-    memcpy(usb_hid_interface_name_obj.interface_name, interface_name.buf, interface_name.len);
-    usb_hid_interface_name_obj.interface_name[interface_name.len] = 0;
+
+    if (custom_usb_hid_interface_name == NULL) {
+        custom_usb_hid_interface_name = port_malloc(sizeof(char) * 128, false);
+    }
+    memcpy(custom_usb_hid_interface_name, interface_name.buf, interface_name.len);
+    custom_usb_hid_interface_name[interface_name.len] = 0;
 
     return mp_const_none;
 }

--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -164,9 +164,7 @@ const usb_hid_device_obj_t usb_hid_device_consumer_control_obj = {
     .out_report_lengths = { 0, },
 };
 
-usb_hid_interface_name_t usb_hid_interface_name_obj = {
-    .interface_name = USB_INTERFACE_NAME " HID",
-};
+char *custom_usb_hid_interface_name;
 
 STATIC size_t get_report_id_idx(usb_hid_device_obj_t *self, size_t report_id) {
     for (size_t i = 0; i < self->num_report_ids; i++) {

--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -164,6 +164,10 @@ const usb_hid_device_obj_t usb_hid_device_consumer_control_obj = {
     .out_report_lengths = { 0, },
 };
 
+usb_hid_interface_name_t usb_hid_interface_name_obj = {
+    .interface_name = USB_INTERFACE_NAME " HID",
+};
+
 STATIC size_t get_report_id_idx(usb_hid_device_obj_t *self, size_t report_id) {
     for (size_t i = 0; i < self->num_report_ids; i++) {
         if (report_id == self->report_ids[i]) {

--- a/shared-module/usb_hid/Device.h
+++ b/shared-module/usb_hid/Device.h
@@ -54,4 +54,10 @@ extern const usb_hid_device_obj_t usb_hid_device_consumer_control_obj;
 
 void usb_hid_device_create_report_buffers(usb_hid_device_obj_t *self);
 
+typedef struct {
+    char interface_name[128];
+} usb_hid_interface_name_t;
+
+extern usb_hid_interface_name_t usb_hid_interface_name_obj;
+
 #endif /* SHARED_MODULE_USB_HID_DEVICE_H */

--- a/shared-module/usb_hid/Device.h
+++ b/shared-module/usb_hid/Device.h
@@ -54,10 +54,6 @@ extern const usb_hid_device_obj_t usb_hid_device_consumer_control_obj;
 
 void usb_hid_device_create_report_buffers(usb_hid_device_obj_t *self);
 
-typedef struct {
-    char interface_name[128];
-} usb_hid_interface_name_t;
-
-extern usb_hid_interface_name_t usb_hid_interface_name_obj;
+extern char *custom_usb_hid_interface_name;
 
 #endif /* SHARED_MODULE_USB_HID_DEVICE_H */

--- a/shared-module/usb_hid/__init__.c
+++ b/shared-module/usb_hid/__init__.c
@@ -165,6 +165,8 @@ size_t usb_hid_descriptor_length(void) {
 
 // This is the interface descriptor, not the report descriptor.
 size_t usb_hid_add_descriptor(uint8_t *descriptor_buf, descriptor_counts_t *descriptor_counts, uint8_t *current_interface_string, uint16_t report_descriptor_length, uint8_t boot_device) {
+    const char *usb_hid_interface_name;
+
     memcpy(descriptor_buf, usb_hid_descriptor_template, sizeof(usb_hid_descriptor_template));
 
     descriptor_buf[HID_DESCRIPTOR_INTERFACE_INDEX] = descriptor_counts->current_interface;
@@ -175,7 +177,12 @@ size_t usb_hid_add_descriptor(uint8_t *descriptor_buf, descriptor_counts_t *desc
         descriptor_buf[HID_DESCRIPTOR_INTERFACE_PROTOCOL_INDEX] = boot_device; // 1: keyboard, 2: mouse
     }
 
-    usb_add_interface_string(*current_interface_string, usb_hid_interface_name_obj.interface_name);
+    if (custom_usb_hid_interface_name == NULL) {
+        usb_hid_interface_name = USB_INTERFACE_NAME " HID";
+    } else {
+        usb_hid_interface_name = custom_usb_hid_interface_name;
+    }
+    usb_add_interface_string(*current_interface_string, usb_hid_interface_name);
     descriptor_buf[HID_DESCRIPTOR_INTERFACE_STRING_INDEX] = *current_interface_string;
     (*current_interface_string)++;
 

--- a/shared-module/usb_hid/__init__.c
+++ b/shared-module/usb_hid/__init__.c
@@ -163,8 +163,6 @@ size_t usb_hid_descriptor_length(void) {
     return sizeof(usb_hid_descriptor_template);
 }
 
-static const char usb_hid_interface_name[] = USB_INTERFACE_NAME " HID";
-
 // This is the interface descriptor, not the report descriptor.
 size_t usb_hid_add_descriptor(uint8_t *descriptor_buf, descriptor_counts_t *descriptor_counts, uint8_t *current_interface_string, uint16_t report_descriptor_length, uint8_t boot_device) {
     memcpy(descriptor_buf, usb_hid_descriptor_template, sizeof(usb_hid_descriptor_template));
@@ -177,7 +175,7 @@ size_t usb_hid_add_descriptor(uint8_t *descriptor_buf, descriptor_counts_t *desc
         descriptor_buf[HID_DESCRIPTOR_INTERFACE_PROTOCOL_INDEX] = boot_device; // 1: keyboard, 2: mouse
     }
 
-    usb_add_interface_string(*current_interface_string, usb_hid_interface_name);
+    usb_add_interface_string(*current_interface_string, usb_hid_interface_name_obj.interface_name);
     descriptor_buf[HID_DESCRIPTOR_INTERFACE_STRING_INDEX] = *current_interface_string;
     (*current_interface_string)++;
 


### PR DESCRIPTION
By default on Windows HID device is seen as `CircuitPython HID`, see also #5445

This PR adds new method `usb_hid.set_interface_name` that provides means to change the name of USB HID interface.

Example:
```python
usb_hid.set_interface_name("My HID device")
```

```bash
$ sudo lsusb -vd 239A:80F4 | grep iInterface
      iInterface              4 CircuitPython CDC control
      iInterface              5 CircuitPython CDC data
      iInterface              6 CircuitPython Mass Storage
      iInterface              7 My HID device
      iInterface              9 CircuitPython Audio
      iInterface              8 CircuitPython MIDI
```

On Windows the device is now seen as:

![circuitpython-hid](https://github.com/adafruit/circuitpython/assets/47976407/67e5b21d-6706-4c35-8b42-8e912f7101f2)

I have tested it with Raspberry Pico.