### PR TITLE
remove common_hal_pwmio_pwmout_never_reset and remaining pwmout_reset

### DIFF
--- a/ports/atmel-samd/boards/pycubed/board.c
+++ b/ports/atmel-samd/boards/pycubed/board.c
@@ -33,7 +33,6 @@
 void board_init(void) {
     pwmio_pwmout_obj_t pwm;
     common_hal_pwmio_pwmout_construct(&pwm, &pin_PA23, 4096, 2, false);
-    common_hal_pwmio_pwmout_never_reset(&pwm);
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/atmel-samd/boards/pycubed_mram/board.c
+++ b/ports/atmel-samd/boards/pycubed_mram/board.c
@@ -33,7 +33,6 @@
 void board_init(void) {
     pwmio_pwmout_obj_t pwm;
     common_hal_pwmio_pwmout_construct(&pwm, &pin_PA23, 4096, 2, false);
-    common_hal_pwmio_pwmout_never_reset(&pwm);
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/atmel-samd/boards/pycubed_mram_v05/board.c
+++ b/ports/atmel-samd/boards/pycubed_mram_v05/board.c
@@ -33,7 +33,6 @@
 void board_init(void) {
     pwmio_pwmout_obj_t pwm;
     common_hal_pwmio_pwmout_construct(&pwm, &pin_PA23, 4096, 2, false);
-    common_hal_pwmio_pwmout_never_reset(&pwm);
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/atmel-samd/boards/pycubed_v05/board.c
+++ b/ports/atmel-samd/boards/pycubed_v05/board.c
@@ -33,7 +33,6 @@
 void board_init(void) {
     pwmio_pwmout_obj_t pwm;
     common_hal_pwmio_pwmout_construct(&pwm, &pin_PA23, 4096, 2, false);
-    common_hal_pwmio_pwmout_never_reset(&pwm);
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/atmel-samd/common-hal/pwmio/PWMOut.c
+++ b/ports/atmel-samd/common-hal/pwmio/PWMOut.c
@@ -52,16 +52,12 @@ uint8_t tcc_refcount[TCC_INST_NUM];
 
 // This bitmask keeps track of which channels of a TCC are currently claimed.
 #ifdef SAMD21
-uint8_t tcc_channels[3];   // Set by pwmout_reset() to {0xf0, 0xfc, 0xfc} initially.
+uint8_t tcc_channels[3];
 #endif
 #ifdef SAM_D5X_E5X
-uint8_t tcc_channels[5];   // Set by pwmout_reset() to {0xc0, 0xf0, 0xf8, 0xfc, 0xfc} initially.
+uint8_t tcc_channels[5];
 #endif
 
-
-void common_hal_pwmio_pwmout_never_reset(pwmio_pwmout_obj_t *self) {
-    never_reset_pin_number(self->pin->number);
-}
 
 static uint8_t tcc_channel(const pin_timer_t *t) {
     // For the SAMD51 this hardcodes the use of OTMX == 0x0, the output matrix mapping, which uses

--- a/ports/broadcom/supervisor/port.c
+++ b/ports/broadcom/supervisor/port.c
@@ -91,17 +91,10 @@ void reset_port(void) {
     reset_uart();
     #endif
 
-    #if CIRCUITPY_PWMIO
-    pwmout_reset();
-    #endif
-
     #if CIRCUITPY_RTC
     rtc_reset();
     #endif
 
-    #if CIRCUITPY_AUDIOPWMIO
-    audiopwmout_reset();
-    #endif
     #if CIRCUITPY_AUDIOCORE
     audio_dma_reset();
     #endif

--- a/ports/cxd56/common-hal/pwmio/PWMOut.c
+++ b/ports/cxd56/common-hal/pwmio/PWMOut.c
@@ -36,7 +36,6 @@ typedef struct {
     const char *devpath;
     const mcu_pin_obj_t *pin;
     int fd;
-    bool reset;
 } pwmout_dev_t;
 
 STATIC pwmout_dev_t pwmout_dev[] = {
@@ -90,8 +89,6 @@ void common_hal_pwmio_pwmout_deinit(pwmio_pwmout_obj_t *self) {
         return;
     }
 
-    pwmout_dev[self->number].reset = true;
-
     ioctl(pwmout_dev[self->number].fd, PWMIOC_STOP, 0);
     close(pwmout_dev[self->number].fd);
     pwmout_dev[self->number].fd = -1;
@@ -128,12 +125,6 @@ uint32_t common_hal_pwmio_pwmout_get_frequency(pwmio_pwmout_obj_t *self) {
 
 bool common_hal_pwmio_pwmout_get_variable_frequency(pwmio_pwmout_obj_t *self) {
     return self->variable_frequency;
-}
-
-void common_hal_pwmio_pwmout_never_reset(pwmio_pwmout_obj_t *self) {
-    never_reset_pin_number(self->pin->number);
-
-    pwmout_dev[self->number].reset = false;
 }
 
 void pwmout_start(uint8_t pwm_num) {

--- a/ports/espressif/common-hal/pwmio/PWMOut.c
+++ b/ports/espressif/common-hal/pwmio/PWMOut.c
@@ -140,10 +140,6 @@ pwmout_result_t common_hal_pwmio_pwmout_construct(pwmio_pwmout_obj_t *self,
     return PWMOUT_OK;
 }
 
-void common_hal_pwmio_pwmout_never_reset(pwmio_pwmout_obj_t *self) {
-    never_reset_pin_number(self->pin->number);
-}
-
 bool common_hal_pwmio_pwmout_deinited(pwmio_pwmout_obj_t *self) {
     return self->deinited == true;
 }

--- a/ports/litex/supervisor/port.c
+++ b/ports/litex/supervisor/port.c
@@ -83,7 +83,6 @@ void reset_port(void) {
     // i2c_reset();
     // spi_reset();
     // uart_reset();
-    // pwmout_reset();
 }
 
 void reset_to_bootloader(void) {

--- a/ports/mimxrt10xx/common-hal/pwmio/PWMOut.c
+++ b/ports/mimxrt10xx/common-hal/pwmio/PWMOut.c
@@ -85,10 +85,6 @@ static uint16_t _outen_mask(pwm_submodule_t submodule, pwm_channels_t channel) {
     return outen_mask;
 }
 
-void common_hal_pwmio_pwmout_never_reset(pwmio_pwmout_obj_t *self) {
-    common_hal_never_reset_pin(self->pin);
-}
-
 STATIC void _maybe_disable_clock(uint8_t instance) {
     if ((_flexpwms[instance]->MCTRL & PWM_MCTRL_RUN_MASK) == 0) {
         CLOCK_DisableClock(_flexpwm_clocks[instance][0]);

--- a/ports/nrf/common-hal/pwmio/PWMOut.c
+++ b/ports/nrf/common-hal/pwmio/PWMOut.c
@@ -54,8 +54,6 @@ STATIC NRF_PWM_Type *pwms[] = {
 
 STATIC uint16_t pwm_seq[MP_ARRAY_SIZE(pwms)][CHANNELS_PER_PWM];
 
-static uint8_t never_reset_pwm[MP_ARRAY_SIZE(pwms)];
-
 STATIC int pwm_idx(NRF_PWM_Type *pwm) {
     for (size_t i = 0; i < MP_ARRAY_SIZE(pwms); i++) {
         if (pwms[i] == pwm) {
@@ -63,12 +61,6 @@ STATIC int pwm_idx(NRF_PWM_Type *pwm) {
         }
     }
     return -1;
-}
-
-void common_hal_pwmio_pwmout_never_reset(pwmio_pwmout_obj_t *self) {
-    never_reset_pwm[pwm_idx(self->pwm)] |= 1 << self->channel;
-
-    common_hal_never_reset_pin(self->pin);
 }
 
 STATIC void reset_single_pwmout(uint8_t i) {
@@ -245,8 +237,6 @@ void common_hal_pwmio_pwmout_deinit(pwmio_pwmout_obj_t *self) {
     }
 
     nrf_gpio_cfg_default(self->pin->number);
-
-    never_reset_pwm[pwm_idx(self->pwm)] &= ~(1 << self->channel);
 
     NRF_PWM_Type *pwm = self->pwm;
     self->pwm = NULL;

--- a/ports/raspberrypi/common-hal/pwmio/PWMOut.c
+++ b/ports/raspberrypi/common-hal/pwmio/PWMOut.c
@@ -42,7 +42,6 @@ uint32_t slice_variable_frequency;
 
 #define AB_CHANNELS_PER_SLICE 2
 static uint32_t channel_use;
-static uint32_t never_reset_channel;
 
 // Per the RP2040 datasheet:
 //
@@ -81,10 +80,6 @@ void pwmio_release_slice_ab_channels(uint8_t slice) {
     channel_use &= ~channel_mask;
     channel_mask = _mask(slice, 1);
     channel_use &= ~channel_mask;
-}
-
-void common_hal_pwmio_pwmout_never_reset(pwmio_pwmout_obj_t *self) {
-    never_reset_pin_number(self->pin->number);
 }
 
 pwmout_result_t pwmout_allocate(uint8_t slice, uint8_t ab_channel, bool variable_frequency, uint32_t frequency) {
@@ -168,7 +163,6 @@ bool common_hal_pwmio_pwmout_deinited(pwmio_pwmout_obj_t *self) {
 void pwmout_free(uint8_t slice, uint8_t ab_channel) {
     uint32_t channel_mask = _mask(slice, ab_channel);
     channel_use &= ~channel_mask;
-    never_reset_channel &= ~channel_mask;
     uint32_t slice_mask = ((1 << AB_CHANNELS_PER_SLICE) - 1) << (slice * AB_CHANNELS_PER_SLICE);
     if ((channel_use & slice_mask) == 0) {
         target_slice_frequencies[slice] = 0;

--- a/ports/silabs/common-hal/pwmio/PWMOut.c
+++ b/ports/silabs/common-hal/pwmio/PWMOut.c
@@ -88,15 +88,6 @@ pwmout_result_t common_hal_pwmio_pwmout_construct(pwmio_pwmout_obj_t *self,
     return PWMOUT_OK;
 }
 
-// Mark pwm obj to never reset after reload
-void common_hal_pwmio_pwmout_never_reset(pwmio_pwmout_obj_t *self) {
-    common_hal_never_reset_pin(self->tim->pin);
-}
-
-// Pwm will be reset after reloading.
-void common_hal_pwmio_pwmout_reset_ok(pwmio_pwmout_obj_t *self) {
-}
-
 // Check pwm obj status, deinited or not
 bool common_hal_pwmio_pwmout_deinited(pwmio_pwmout_obj_t *self) {
     return self->tim == NULL;

--- a/ports/stm/common-hal/pwmio/PWMOut.c
+++ b/ports/stm/common-hal/pwmio/PWMOut.c
@@ -187,10 +187,6 @@ pwmout_result_t common_hal_pwmio_pwmout_construct(pwmio_pwmout_obj_t *self,
     return PWMOUT_OK;
 }
 
-void common_hal_pwmio_pwmout_never_reset(pwmio_pwmout_obj_t *self) {
-    common_hal_never_reset_pin(self->pin);
-}
-
 bool common_hal_pwmio_pwmout_deinited(pwmio_pwmout_obj_t *self) {
     return self->tim == NULL;
 }

--- a/shared-bindings/pwmio/PWMOut.h
+++ b/shared-bindings/pwmio/PWMOut.h
@@ -56,10 +56,6 @@ extern bool common_hal_pwmio_pwmout_get_variable_frequency(pwmio_pwmout_obj_t *s
 // Don't use this! It is only used internally for backwards compatibility.
 extern const mcu_pin_obj_t *common_hal_pwmio_pwmout_get_pin(pwmio_pwmout_obj_t *self);
 
-// This is used by the supervisor to claim PWMOut devices indefinitely.
-extern void common_hal_pwmio_pwmout_never_reset(pwmio_pwmout_obj_t *self);
-extern void common_hal_pwmio_pwmout_reset_ok(pwmio_pwmout_obj_t *self);
-
 extern void common_hal_pwmio_pwmout_raise_error(pwmout_result_t result);
 
 #endif // MICROPY_INCLUDED_SHARED_BINDINGS_PWMIO_PWMOUT_H

--- a/shared-module/busdisplay/BusDisplay.c
+++ b/shared-module/busdisplay/BusDisplay.c
@@ -125,7 +125,6 @@ void common_hal_busdisplay_busdisplay_construct(busdisplay_busdisplay_obj_t *sel
             common_hal_never_reset_pin(backlight_pin);
         } else {
             self->backlight_pwm.base.type = &pwmio_pwmout_type;
-            common_hal_pwmio_pwmout_never_reset(&self->backlight_pwm);
         }
         #else
         // Otherwise default to digital


### PR DESCRIPTION
Finishes remaining needed removals from #8966 and https://github.com/adafruit/circuitpython/pull/8990#issuecomment-1970468546, and some other unused code.

Retested #8985 on MEMENTO: no regression.