### PR TITLE
Update board.c for fixing color order

### DIFF
--- a/ports/espressif/boards/m5stack_atoms3/board.c
+++ b/ports/espressif/boards/m5stack_atoms3/board.c
@@ -45,7 +45,6 @@ uint8_t display_init_sequence[] = {
     0x36, 0x01, 0x08, // _MADCTL
     0x21, 0x80, 0x0A, // _INVON Hack and Delay 10ms
     0x13, 0x80, 0x0A, // _NORON and Delay 10ms
-    0x36, 0x01, 0xC0, // _MADCTL
     0x29, 0 | DELAY, 0xff // _DISPON and Delay 500ms
 };
 


### PR DESCRIPTION
This PR resolves #8998 issue.
Eliminated unnecessary color order commands.

Please review and merge.

![IMG_9587](https://github.com/adafruit/circuitpython/assets/19419464/f970eb6a-8609-4efb-97eb-5053611313dc)
