### PR TITLE
Update tlsf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -354,7 +354,8 @@
 	url = https://github.com/adafruit/certificates
 [submodule "lib/tlsf"]
 	path = lib/tlsf
-	url = https://github.com/espressif/tlsf.git
+	url = https://github.com/adafruit/tlsf.git
+	branch = circuitpython
 [submodule "frozen/CircuitPython_AXP313A"]
 	path = frozen/CircuitPython_AXP313A
 	url = https://github.com/bill88t/CircuitPython_AXP313A


### PR DESCRIPTION
The original implementation couldn't allocate to a region that was just freed even though the freed region was the same size as the new request. This was due to allocation sizes being rounded up during search but not when marking the region in use.

Fixes https://github.com/adafruit/Adafruit_Learning_System_Guides/issues/2746