### PR TITLE
shared-module/_bleio/ScanResults.c: make ScanEntry handling be atomic

### DIFF
--- a/shared-module/_bleio/ScanResults.c
+++ b/shared-module/_bleio/ScanResults.c
@@ -52,20 +52,25 @@ mp_obj_t common_hal_bleio_scanresults_next(bleio_scanresults_obj_t *self) {
     }
 
     // Create a ScanEntry out of the data on the buffer.
+
+    // Remove data atomically.
+    common_hal_mcu_disable_interrupts();
+
     uint8_t type = ringbuf_get(&self->buf);
     bool connectable = (type & (1 << 0)) != 0;
     bool scan_response = (type & (1 << 1)) != 0;
     uint64_t ticks_ms;
     ringbuf_get_n(&self->buf, (uint8_t *)&ticks_ms, sizeof(ticks_ms));
-    uint8_t rssi = ringbuf_get(&self->buf);
+    int8_t rssi = ringbuf_get(&self->buf);
     uint8_t peer_addr[NUM_BLEIO_ADDRESS_BYTES];
     ringbuf_get_n(&self->buf, peer_addr, sizeof(peer_addr));
     uint8_t addr_type = ringbuf_get(&self->buf);
     uint16_t len;
     ringbuf_get_n(&self->buf, (uint8_t *)&len, sizeof(len));
-
     mp_obj_str_t *o = MP_OBJ_TO_PTR(mp_obj_new_bytes_of_zeros(len));
     ringbuf_get_n(&self->buf, (uint8_t *)o->data, len);
+
+    common_hal_mcu_enable_interrupts();
 
     bleio_scanentry_obj_t *entry = mp_obj_malloc(bleio_scanentry_obj_t, &bleio_scanentry_type);
     entry->rssi = rssi;
@@ -92,13 +97,6 @@ void shared_module_bleio_scanresults_append(bleio_scanresults_obj_t *self,
     uint8_t addr_type,
     const uint8_t *data,
     uint16_t len) {
-    int32_t packet_size = sizeof(uint8_t) + sizeof(ticks_ms) + sizeof(rssi) + NUM_BLEIO_ADDRESS_BYTES +
-        sizeof(addr_type) + sizeof(len) + len;
-    int32_t empty_space = self->buf.size - ringbuf_num_filled(&self->buf);
-    if (packet_size >= empty_space) {
-        // We can't fit the packet so skip it.
-        return;
-    }
     // Filter the packet.
     if (rssi < self->minimum_rssi) {
         return;
@@ -116,14 +114,26 @@ void shared_module_bleio_scanresults_append(bleio_scanresults_obj_t *self,
         type |= 1 << 1;
     }
 
-    // Add the packet to the buffer.
-    ringbuf_put(&self->buf, type);
-    ringbuf_put_n(&self->buf, (uint8_t *)&ticks_ms, sizeof(ticks_ms));
-    ringbuf_put(&self->buf, rssi);
-    ringbuf_put_n(&self->buf, peer_addr, NUM_BLEIO_ADDRESS_BYTES);
-    ringbuf_put(&self->buf, addr_type);
-    ringbuf_put_n(&self->buf, (uint8_t *)&len, sizeof(len));
-    ringbuf_put_n(&self->buf, data, len);
+    // Add the packet to the buffer, atomically.
+    common_hal_mcu_disable_interrupts();
+
+    // Check whether  will fit.
+    int32_t packet_size = sizeof(uint8_t) + sizeof(ticks_ms) + sizeof(rssi) + NUM_BLEIO_ADDRESS_BYTES +
+        sizeof(addr_type) + sizeof(len) + len;
+    int32_t empty_space = self->buf.size - ringbuf_num_filled(&self->buf);
+
+    if (packet_size <= empty_space) {
+        // Packet will fit.
+        ringbuf_put(&self->buf, type);
+        ringbuf_put_n(&self->buf, (uint8_t *)&ticks_ms, sizeof(ticks_ms));
+        ringbuf_put(&self->buf, rssi);
+        ringbuf_put_n(&self->buf, peer_addr, NUM_BLEIO_ADDRESS_BYTES);
+        ringbuf_put(&self->buf, addr_type);
+        ringbuf_put_n(&self->buf, (uint8_t *)&len, sizeof(len));
+        ringbuf_put_n(&self->buf, data, len);
+    }
+
+    common_hal_mcu_enable_interrupts();
 }
 
 bool shared_module_bleio_scanresults_get_done(bleio_scanresults_obj_t *self) {


### PR DESCRIPTION
- Fixes #8995 

Advertisement-data read/write `ScanEntry.c` was not atomic. One side of that was done during an interrupt.

Tested with last test program in #8995. Ran for half an hour or so without failure. Previously would fail within a minute or two.

Also made minor fix re signedness of RSSI: no behavior change.