### PR TITLE
Switch cyw43-driver to georgerobotics/cyw43-driver tag v1.0.3.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -307,7 +307,7 @@
 [submodule "ports/raspberrypi/lib/cyw43-driver"]
 	path = ports/raspberrypi/lib/cyw43-driver
 	url = https://github.com/georgerobotics/cyw43-driver
-	branch = circuitpython9
+	branch = MAIN
 [submodule "ports/raspberrypi/lib/lwip"]
 	path = ports/raspberrypi/lib/lwip
 	url = https://github.com/adafruit/lwip.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -306,7 +306,7 @@
 	url = https://github.com/elecfreaks/circuitpython_picoed.git
 [submodule "ports/raspberrypi/lib/cyw43-driver"]
 	path = ports/raspberrypi/lib/cyw43-driver
-	url = https://github.com/adafruit/cyw43-driver
+	url = https://github.com/georgerobotics/cyw43-driver
 	branch = circuitpython9
 [submodule "ports/raspberrypi/lib/lwip"]
 	path = ports/raspberrypi/lib/lwip

--- a/.gitmodules
+++ b/.gitmodules
@@ -307,7 +307,7 @@
 [submodule "ports/raspberrypi/lib/cyw43-driver"]
 	path = ports/raspberrypi/lib/cyw43-driver
 	url = https://github.com/georgerobotics/cyw43-driver
-	branch = MAIN
+	branch = main
 [submodule "ports/raspberrypi/lib/lwip"]
 	path = ports/raspberrypi/lib/lwip
 	url = https://github.com/adafruit/lwip.git


### PR DESCRIPTION
Switch submodule cyw43-driver back to upstream repository at tag v1.0.3.

The additional pulls in our local fork have been merged into the upstream repository. The pulls are: https://github.com/georgerobotics/cyw43-driver/pull/107 and https://github.com/georgerobotics/cyw43-driver/pull/108.