### PR TITLE
M5Stack Cardputer : I2S_DATA  pin name typo

### DIFF
--- a/ports/espressif/boards/m5stack_cardputer/pins.c
+++ b/ports/espressif/boards/m5stack_cardputer/pins.c
@@ -30,7 +30,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
 
     // Speaker
     { MP_ROM_QSTR(MP_QSTR_I2S_BIT_CLOCK), MP_ROM_PTR(&pin_GPIO41) },
-    { MP_ROM_QSTR(MP_QSTR_IS2_DATA), MP_ROM_PTR(&pin_GPIO42) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_DATA), MP_ROM_PTR(&pin_GPIO42) },
     { MP_ROM_QSTR(MP_QSTR_I2S_WORD_SELECT), MP_ROM_PTR(&pin_GPIO43) },
 
     // Mic


### PR DESCRIPTION
I'm sorry I didn't get a chance to test this before the merge but I was out of town most of this week and when I got back this evening my cardputer had just arrived :grin:.

I threw the latest build on and did a few quick tests which mostly seemed to work fine. I did spot this one typo though. I'll give it some more testing tomorrow.