### PR TITLE
cyw43-driver: Update to upstream repo tag v1.0.3.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -306,8 +306,8 @@
 	url = https://github.com/elecfreaks/circuitpython_picoed.git
 [submodule "ports/raspberrypi/lib/cyw43-driver"]
 	path = ports/raspberrypi/lib/cyw43-driver
-	url = https://github.com/adafruit/cyw43-driver
-	branch = circuitpython9
+	url = https://github.com/georgerobotics/cyw43-driver
+	branch = main
 [submodule "ports/raspberrypi/lib/lwip"]
 	path = ports/raspberrypi/lib/lwip
 	url = https://github.com/adafruit/lwip.git


### PR DESCRIPTION
Resubmit #9016.