### PR TITLE
Don't reset USB_HOST_POWER on teensy 4.1 and teensy micromod

### DIFF
--- a/ports/mimxrt10xx/boards/sparkfun_teensy_micromod/board.c
+++ b/ports/mimxrt10xx/boards/sparkfun_teensy_micromod/board.c
@@ -53,4 +53,13 @@ const mcu_pin_obj_t *mimxrt10xx_reset_forbidden_pins[] = {
     NULL,                       // Must end in NULL.
 };
 
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    #if CIRCUITPY_USB_HOST
+    if (pin == &pin_GPIO_EMC_40) {
+        // Don't reset the USB_HOST_POWER pin, because it will need to be enabled in boot.py.
+        return true;
+    }
+    #endif
+    return false;
+}
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/mimxrt10xx/boards/teensy41/board.c
+++ b/ports/mimxrt10xx/boards/teensy41/board.c
@@ -60,4 +60,14 @@ void board_init(void) {
     common_hal_usb_host_port_construct(&pin_USB_OTG2_DP, &pin_USB_OTG2_DN);
 }
 
+bool mimxrt10xx_board_reset_pin_number(const mcu_pin_obj_t *pin) {
+    #if CIRCUITPY_USB_HOST
+    if (pin == &pin_GPIO_EMC_40) {
+        // Don't reset the USB_HOST_POWER pin, because it will need to be enabled in boot.py.
+        return true;
+    }
+    #endif
+    return false;
+}
+
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.


### PR DESCRIPTION
- Fixes #9047.

I think the issue was due to https://github.com/adafruit/circuitpython/blob/4d1f558361ed25fbfdbd01ead0d5d2df7b2cb9ab/ports/mimxrt10xx/common-hal/microcontroller/Pin.c#L96-L99 which was added in #8928: pins were reset to inputs by default.