### PR TITLE
Set SPI clock line idle polarity for CPOL=1

### DIFF
--- a/shared-module/bitbangio/SPI.c
+++ b/shared-module/bitbangio/SPI.c
@@ -96,7 +96,12 @@ void shared_module_bitbangio_spi_configure(bitbangio_spi_obj_t *self,
         self->delay_half += 1;
     }
 
-    self->polarity = polarity;
+    if (polarity != self->polarity) {
+        // If the polarity has changed, make sure we re-initialize the idle state
+        // of the clock as well.
+        self->polarity = polarity;
+        common_hal_digitalio_digitalinout_switch_to_output(&self->clock, polarity == 1, DRIVE_MODE_PUSH_PULL);
+    }
     self->phase = phase;
 }
 


### PR DESCRIPTION
Fixes https://github.com/adafruit/circuitpython/issues/9074

Manually verified with this code before and after the change.
```
import board
import bitbangio
import digitalio
import time


def doit():
    with digitalio.DigitalInOut(board.GP13) as en:
        en.switch_to_output(value=True)
        time.sleep(1)
        with bitbangio.SPI(clock=board.GP15, MOSI=board.GP14) as spi:
            spi.try_lock()
            spi.configure(baudrate=10, polarity=1, phase=0, bits=8)
            en.switch_to_output(value=False)
            spi.write(b"\xaa")
            en.switch_to_output(value=True)
```

**Before**

![p1-before](https://github.com/adafruit/circuitpython/assets/1495065/ea69f360-d162-4938-a692-67b6dd594253)

**After**

![p1-after](https://github.com/adafruit/circuitpython/assets/1495065/a9e8547f-d575-4034-94c3-4e8066445151)
