### PR TITLE
Changes required for new Spresense SDK 3.2.0

### DIFF
--- a/ports/cxd56/Makefile
+++ b/ports/cxd56/Makefile
@@ -73,7 +73,6 @@ CFLAGS += \
 	-DCONFIG_WCHAR_BUILTIN \
 	-DCONFIG_HAVE_DOUBLE \
 	-DNDEBUG \
-	-Dmain=spresense_main \
 	-D_estack=__stack \
 	-DCIRCUITPY_BOARD_ID="\"$(BOARD)\"" \
 	-c \

--- a/ports/cxd56/common-hal/camera/Camera.c
+++ b/ports/cxd56/common-hal/camera/Camera.c
@@ -169,7 +169,7 @@ void common_hal_camera_deinit(camera_obj_t *self) {
         return;
     }
 
-    video_uninitialize();
+    video_uninitialize(camera_dev.devpath);
 
     close(camera_dev.fd);
     camera_dev.fd = -1;

--- a/ports/cxd56/supervisor/port.c
+++ b/ports/cxd56/supervisor/port.c
@@ -165,3 +165,11 @@ void port_interrupt_after_ticks(uint32_t ticks) {
 void port_idle_until_interrupt(void) {
     // TODO: Implement sleep.
 }
+
+// Wrap main in spresense_main
+extern void main(void);
+extern int spresense_main(int argc, FAR char *argv[]);
+int spresense_main(int argc, FAR char *argv[]) {
+    main();
+    return 0;
+}


### PR DESCRIPTION
- Wrapped main function in spresense_main
- video_uninitialize now requires dev path as parameter