### PR TITLE
Disable 9.0.0 displayio warnings

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -38,6 +38,12 @@
 // Always 1: defined in circuitpy_mpconfig.mk
 // #define CIRCUITPY (1)
 
+// Can be removed once CircuitPython 10 is released.
+// Print warnings or not about deprecated names. See objmodule.c.
+#ifndef CIRCUITPY_8_9_WARNINGS
+#define CIRCUITPY_8_9_WARNINGS (0)
+#endif
+
 // REPR_C encodes qstrs, 31-bit ints, and 30-bit floats in a single 32-bit word.
 #ifndef MICROPY_OBJ_REPR
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -66,7 +66,7 @@ STATIC void module_attr_try_delegation(mp_obj_t self_in, qstr attr, mp_obj_t *de
 STATIC void module_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     mp_obj_module_t *self = MP_OBJ_TO_PTR(self_in);
     if (dest[0] == MP_OBJ_NULL) {
-        #if CIRCUITPY_DISPLAYIO && CIRCUITPY_WARNINGS
+        #if CIRCUITPY_8_9_WARNINGS && CIRCUITPY_DISPLAYIO && CIRCUITPY_WARNINGS
         if (self == &displayio_module) {
             #if CIRCUITPY_BUSDISPLAY
             if (attr == MP_QSTR_Display) {


### PR DESCRIPTION
Turn off displayio warnings when using 8.x naming. This was intrusive and confusing for some users. Turn this back on when 8.x bundles are no longer being built.