### PR TITLE
Board: sunton_esp32_2432S028 Add Frozen Libraries

### DIFF
--- a/ports/espressif/boards/sunton_esp32_2432S028/mpconfigboard.mk
+++ b/ports/espressif/boards/sunton_esp32_2432S028/mpconfigboard.mk
@@ -8,3 +8,9 @@ CIRCUITPY_ESP_FLASH_FREQ = 80m
 CIRCUITPY_ESP_FLASH_SIZE = 4MB
 
 CIRCUITPY_ESPCAMERA = 0
+
+# Include these Python libraries in firmware.
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_ConnectionManager
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Requests
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Display_Text
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_ImageLoad


### PR DESCRIPTION
I'm going back and forth on this. Adding the frozen library appears to save about 10K when running applications that use the libraries which isn't a huge amount but the device only has 520K and has some memory hungry devices (WiFi, LCD and Touch Screen).

I figured I'd go ahead and submit it, but if freezing libraries isn't desirable for some reason it's probably not critical.