### PR TITLE
serial.c filter uart console non utf-8 on startup

### DIFF
--- a/main.c
+++ b/main.c
@@ -1016,6 +1016,11 @@ int __attribute__((used)) main(void) {
         set_safe_mode(wait_for_safe_mode_reset());
     }
 
+    // Clear serial input buffer of newly created console/board UART
+    while (serial_bytes_available()) {
+        serial_read();
+    }
+
     stack_init();
 
     #if CIRCUITPY_STATUS_BAR

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -29,7 +29,6 @@
 
 #include "py/mpconfig.h"
 #include "py/mphal.h"
-#include "py/unicode.h"
 
 #include "supervisor/shared/cpu.h"
 #include "supervisor/shared/display.h"

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -220,11 +220,6 @@ char serial_read(void) {
         int uart_errcode;
         char text;
         common_hal_busio_uart_read(&console_uart, (uint8_t *)&text, 1, &uart_errcode);
-        #if MICROPY_PY_BUILTINS_STR_UNICODE && MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
-        if (!utf8_check((byte *)&text, (size_t)1)) {
-            text = (char)65534; // utf8 Noncharacter
-        }
-        #endif // MICROPY_PY_BUILTINS_STR_UNICODE && MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
         return text;
     }
     #endif

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -29,6 +29,7 @@
 
 #include "py/mpconfig.h"
 #include "py/mphal.h"
+#include "py/unicode.h"
 
 #include "supervisor/shared/cpu.h"
 #include "supervisor/shared/display.h"
@@ -219,6 +220,11 @@ char serial_read(void) {
         int uart_errcode;
         char text;
         common_hal_busio_uart_read(&console_uart, (uint8_t *)&text, 1, &uart_errcode);
+        #if MICROPY_PY_BUILTINS_STR_UNICODE && MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
+        if (!utf8_check((byte *)&text, (size_t)1)) {
+            text = (char)65534; // utf8 Noncharacter
+        }
+        #endif // MICROPY_PY_BUILTINS_STR_UNICODE && MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
         return text;
     }
     #endif


### PR DESCRIPTION
Replace non UTF-8 character on serial UART input buffer during board startup at "Press any key to enter REPL" prompt.

Fixes #9104 