### PR TITLE
adafruit_sht4x_trinkey_m0: fix board.I2C() pins

### DIFF
--- a/ports/atmel-samd/boards/adafruit_sht4x_trinkey_m0/mpconfigboard.h
+++ b/ports/atmel-samd/boards/adafruit_sht4x_trinkey_m0/mpconfigboard.h
@@ -52,5 +52,5 @@
 #define IGNORE_PIN_PB30     1
 #define IGNORE_PIN_PB31     1
 
-#define DEFAULT_I2C_BUS_SCL (&pin_PA04)
-#define DEFAULT_I2C_BUS_SDA (&pin_PA05)
+#define DEFAULT_I2C_BUS_SCL (&pin_PA05)
+#define DEFAULT_I2C_BUS_SDA (&pin_PA04)

--- a/ports/atmel-samd/boards/adafruit_sht4x_trinkey_m0/pins.c
+++ b/ports/atmel-samd/boards/adafruit_sht4x_trinkey_m0/pins.c
@@ -6,8 +6,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TOUCH), MP_ROM_PTR(&pin_PA07) },
 
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_PA03) },
-    { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_PA04) },
     { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_PA05) },
+    { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_PA04) },
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
 };


### PR DESCRIPTION
`adafruit_sht4x_trinkey_m0`: The SCL/SDA pins specified for `board.I2C()` were reversed. Fixed that and made order consistent (alphabetical) in `mpconfigboard.h` and `pins.c`