### PR TITLE
backport to 9.0.x: Move the nRF saved word

### DIFF
--- a/ports/nrf/supervisor/port.c
+++ b/ports/nrf/supervisor/port.c
@@ -283,14 +283,16 @@ uint32_t *port_stack_get_top(void) {
     return &_estack;
 }
 
-// Place the word in the uninitialized section so it won't get overwritten.
-__attribute__((section(".uninitialized"))) uint32_t _saved_word;
+// Place the word in the first 32k of RAM. This is saved by us and the
+// bootloader for the soft device. We only use it before the soft device uses
+// that memory.
+#define SAVED_WORD ((uint32_t *)(0x20008000 - 4))
 void port_set_saved_word(uint32_t value) {
-    _saved_word = value;
+    *SAVED_WORD = value;
 }
 
 uint32_t port_get_saved_word(void) {
-    return _saved_word;
+    return *SAVED_WORD;
 }
 
 uint64_t port_get_raw_ticks(uint8_t *subticks) {


### PR DESCRIPTION
Cherry-picked from https://github.com/adafruit/circuitpython/pull/9160/commits/bcae6ae5cfc989b4c518d98ca2d49961746efb42

From #9160:

> Instead of putting it in our uninit section, we need to ensure it is also uninit by the UF2 bootloader. We both leave at least the first 32k of RAM for the soft device, so place our word just before the end of 32k. This is ok because we only use it before the SD is started.

> Fixes #9143 and doesn't require a bootloader change.