### PR TITLE
Switch to `serial_write` for the one line clear that is captured by `boot_out.txt`

### DIFF
--- a/main.c
+++ b/main.c
@@ -299,6 +299,10 @@ STATIC bool maybe_run_list(const char *const *filenames, size_t n_filenames) {
     if (_current_executing_filename == NULL) {
         return false;
     }
+
+    // This function is used for `boot.py` and is then logged into `boot_out.txt`.
+    // We do not want the line clear to be logged.
+    // The function `serial_write` is the only function that isn't logged into the file.
     serial_write(line_clear);
     mp_hal_stdout_tx_str(_current_executing_filename);
     serial_write_compressed(MP_ERROR_TEXT(" output:\n"));

--- a/main.c
+++ b/main.c
@@ -305,7 +305,7 @@ STATIC bool maybe_run_list(const char *const *filenames, size_t n_filenames) {
     // The function `serial_write` is the only function that isn't logged into the file.
     serial_write(line_clear);
     mp_hal_stdout_tx_str(_current_executing_filename);
-    mp_hal_stdout_tx_str(" output:\n");
+    serial_write_compressed(MP_ERROR_TEXT(" output:\n"));
 
     #if CIRCUITPY_STATUS_BAR
     supervisor_status_bar_update();

--- a/main.c
+++ b/main.c
@@ -305,7 +305,7 @@ STATIC bool maybe_run_list(const char *const *filenames, size_t n_filenames) {
     // The function `serial_write` is the only function that isn't logged into the file.
     serial_write(line_clear);
     mp_hal_stdout_tx_str(_current_executing_filename);
-    serial_write_compressed(MP_ERROR_TEXT(" output:\n"));
+    mp_hal_stdout_tx_str(" output:\n");
 
     #if CIRCUITPY_STATUS_BAR
     supervisor_status_bar_update();

--- a/main.c
+++ b/main.c
@@ -299,7 +299,7 @@ STATIC bool maybe_run_list(const char *const *filenames, size_t n_filenames) {
     if (_current_executing_filename == NULL) {
         return false;
     }
-    mp_hal_stdout_tx_str(line_clear);
+    serial_write(line_clear);
     mp_hal_stdout_tx_str(_current_executing_filename);
     serial_write_compressed(MP_ERROR_TEXT(" output:\n"));
 

--- a/main.c
+++ b/main.c
@@ -300,7 +300,7 @@ STATIC bool maybe_run_list(const char *const *filenames, size_t n_filenames) {
         return false;
     }
 
-    // This function is used for `boot.py` and is then logged into `boot_out.txt`.
+    // This function is used for `boot.py` and is thus logged to `boot_out.txt`.
     // We do not want the line clear to be logged.
     // The function `serial_write` is the only function that isn't logged into the file.
     serial_write(line_clear);


### PR DESCRIPTION
Fixes #9180.

This is the only function that doesn't get captured into `boot_out.txt`.
I confirmed the line clear still occurs by adding some junk text.

```
Serial console setup
amogusAdafruit CircuitPython 9.1.0-beta.0-26-gc978768d37-dirty on 2024-04-15; M5Stack Timer Camera X with ESP32
Board ID:m5stack_timer_camera_x
UID:806BF178DD44
amogusboot.py output:
Early boot log:
```
The rest of the line clears are outside of what `boot_out.txt` captures and I opted to keep the existing function calls since they seem more correct.