### PR TITLE
Handle change in tar file name caused by setuptools update

### DIFF
--- a/tools/test-stubs.sh
+++ b/tools/test-stubs.sh
@@ -5,7 +5,8 @@ python3 -m venv test-stubs
 pip install mypy isort black adafruit-circuitpython-typing wheel build
 rm -rf circuitpython-stubs .mypy_cache
 make stubs
-pip install --force-reinstall circuitpython-stubs/dist/circuitpython-stubs-*.tar.gz
+# Filename separator changed from "-" to "_" in setuptools v69.3.0. Allow either.
+pip install --force-reinstall circuitpython-stubs/dist/circuitpython[-_]stubs-*.tar.gz
 export MYPYPATH=circuitpython-stubs/
 echo "The following test should pass:"
 mypy -c 'import busio; b: busio.I2C; b.writeto(0x30, b"")'


### PR DESCRIPTION
Stubs `.tar.gz` filename changed to use an underscore instead of a hypen, by `setuptools` v69.3.0. See https://github.com/pypa/setuptools/issues/4300. This does not seem likely to be reverted. Handle old and new filenames.