### PR TITLE
9.0.x - Handle change in tar file name caused by setuptools update #9185

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -110,6 +110,12 @@ autoapi_template_dir = 'docs/autoapi/templates'
 autoapi_python_class_content = "both"
 autoapi_python_use_implicit_namespaces = True
 autoapi_root = "shared-bindings"
+
+# Suppress cache warnings to prevent "unpickable" [sic] warning
+# about autoapi_prepare_jinja_env() from sphinx >= 7.3.0.
+# See https://github.com/sphinx-doc/sphinx/issues/12300
+suppress_warnings = ["config.cache"]
+
 def autoapi_prepare_jinja_env(jinja_env):
     jinja_env.globals['support_matrix_reverse'] = modules_support_matrix_reverse
 

--- a/tools/test-stubs.sh
+++ b/tools/test-stubs.sh
@@ -5,7 +5,8 @@ python3 -m venv test-stubs
 pip install mypy isort black adafruit-circuitpython-typing wheel build
 rm -rf circuitpython-stubs .mypy_cache
 make stubs
-pip install --force-reinstall circuitpython-stubs/dist/circuitpython-stubs-*.tar.gz
+# Allow either dash or underscore as separator. setuptools v69.3.0 changed from "-" to "_".
+pip install --force-reinstall circuitpython-stubs/dist/circuitpython[-_]stubs-*.tar.gz
 export MYPYPATH=circuitpython-stubs/
 echo "The following test should pass:"
 mypy -c 'import busio; b: busio.I2C; b.writeto(0x30, b"")'


### PR DESCRIPTION
Same as #9185, but on `9.0.x`

Stubs `.tar.gz` filename changed to use an underscore instead of a hypen, by `setuptools` v69.3.0. See https://github.com/pypa/setuptools/issues/4300. This does not seem likely to be reverted. Handle old and new filenames.