### PR TITLE
add adafruit_circuitpython_bitmap_fonts to frozen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -383,3 +383,6 @@
 [submodule "frozen/Adafruit_CircuitPython_SHT4x"]
 	path = frozen/Adafruit_CircuitPython_SHT4x
 	url = https://github.com/adafruit/Adafruit_CircuitPython_SHT4x
+[submodule "frozen/Adafruit_CircuitPython_Bitmap_Font"]
+	path = frozen/Adafruit_CircuitPython_Bitmap_Font
+	url = https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font


### PR DESCRIPTION
add the Adafruit_CircuitPython_Bitmap_Fonts library as a submodule in frozen so it is available to boards which wish to include it as a frozen module in their firmware.

_Note: This is my first PR and if I missed a step, my apologies._