### PR TITLE
Fix typo in AtomS3U pins

### DIFF
--- a/ports/espressif/boards/m5stack_atoms3u/pins.c
+++ b/ports/espressif/boards/m5stack_atoms3u/pins.c
@@ -7,7 +7,7 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_GPIO1) },
     { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_GPIO1) },
 
-    { MP_ROM_QSTR(MP_QSTR_PORTA_SCL), MP_ROM_PTR(&pin_GPIO2) },
+    { MP_ROM_QSTR(MP_QSTR_PORTA_SDA), MP_ROM_PTR(&pin_GPIO2) },
     { MP_ROM_QSTR(MP_QSTR_A2), MP_ROM_PTR(&pin_GPIO2) },
     { MP_ROM_QSTR(MP_QSTR_D2), MP_ROM_PTR(&pin_GPIO2) },
 


### PR DESCRIPTION
G2 should be SDA based on https://docs.m5stack.com/en/core/AtomS3U

Fixes #9209