### PR TITLE
[Tooling] Add `--list` to `circuitpython_setboard`

### DIFF
--- a/tools/board_stubs/circuitpython_setboard/__init__.py
+++ b/tools/board_stubs/circuitpython_setboard/__init__.py
@@ -104,5 +104,5 @@ def set_board():
     shutil.copyfile(board_definitions_file, board_stubs_file)
 
     sys.stdout.write(
-        header("Information about the board") + get_doc_or_raise(args.chose_board) + "\n"
+        header("Information about the board") + get_doc_or_raise(args.chosen_board) + "\n"
     )

--- a/tools/board_stubs/circuitpython_setboard/__init__.py
+++ b/tools/board_stubs/circuitpython_setboard/__init__.py
@@ -1,26 +1,42 @@
 # SPDX-FileCopyrightText: 2024 Tim Cocks
 #
 # SPDX-License-Identifier: MIT
-from importlib import resources
-import os
+import argparse
 import sys
 import shutil
+from importlib import resources
 
 
 def set_board():
-    if len(sys.argv) != 2:
-        print(f"Incorrect args. Please call with: 'circuitpython_setboard chosen_board'")
-        return
+    parser = argparse.ArgumentParser(
+        prog=__name__,
+        usage="Install CircuitPython board-specific stubs",
+    )
+    parser.add_argument("chosen_board", help="selected board", nargs="?")
+    parser.add_argument("-l", "--list", help="show available boards", action="store_true")
 
-    chosen_board = sys.argv[1]
-    print(f"setting board: {chosen_board}")
+    args = parser.parse_args()
+
+    if args.list:
+        sys.stdout.write("Available boards are: \n")
+
+        for board in resources.files("board_definitions").iterdir():
+            sys.stdout.write(f"{board.name}\n")
+
+        sys.exit(0)
+
+    if args.chosen_board is None:
+        sys.stderr.write("Must select a board")
+        sys.exit(1)
+
+    print(f"setting board: {args.chosen_board}")
 
     board_stubs_file = resources.files("board-stubs").joinpath("__init__.pyi")
-    board_definitions_path = resources.files("board_definitions").joinpath(chosen_board)
+    board_definitions_path = resources.files("board_definitions").joinpath(args.chosen_board)
     board_definitions_file = board_definitions_path.joinpath("__init__.pyi")
 
     if not board_definitions_file.is_file():
-        print(f"Board: '{chosen_board}' was not found")
-        return
+        print(f"Board: '{args.chosen_board}' was not found")
+        sys.exit(1)
 
     shutil.copyfile(board_definitions_file, board_stubs_file)

--- a/tools/board_stubs/circuitpython_setboard/__init__.py
+++ b/tools/board_stubs/circuitpython_setboard/__init__.py
@@ -9,7 +9,7 @@ from importlib import resources
 from importlib.abc import Traversable
 
 
-def get_definitions_or_raise(board: str) -> Traversable:
+def get_definitions_or_exit(board: str) -> Traversable:
     """Get the definitions file for a board given its name."""
 
     path = resources.files("board_definitions").joinpath(board)
@@ -22,10 +22,10 @@ def get_definitions_or_raise(board: str) -> Traversable:
     return file
 
 
-def get_doc_or_raise(board: str) -> str:
+def get_doc_or_exit(board: str) -> str:
     """Get the docstring for a board given its name."""
 
-    with get_definitions_or_raise(board).open("r") as f:
+    with get_definitions_or_exit(board).open("r") as f:
         return f.read().split('"""')[1]
 
 
@@ -52,14 +52,10 @@ def set_board():
     if args.list:
         port_boards: defaultdict[str, list[str]] = defaultdict(list)
 
-        for board in resources.files("board_definitions").iterdir():
-            # if we receive both the list flag and a board name, use it as filter
-            if (
-                args.chosen_board is not None
-                and args.chosen_board.lower() not in board.name.lower()
-            ):
-                continue
+        # NOTE: "" in some_str == True
+        looking_for = "" if args.chosen_board is None else args.chosen_board.lower()
 
+        for board in resources.files("board_definitions").iterdir():
             # NOTE: For the hand-crafted finding of port in the docstring, its
             #       format is assumed to be:
             #
@@ -72,8 +68,11 @@ def set_board():
             #  - Frozen libraries: ...
             #
 
-            lines = get_doc_or_raise(board).split("\n")
+            lines = get_doc_or_exit(board).split("\n")
             port = lines[2].split("-")[1].split(":")[1].strip()
+
+            if looking_for not in board.name.lower() and looking_for not in port.lower():
+                continue
 
             port_boards[port].append(board.name)
 
@@ -98,11 +97,7 @@ def set_board():
         sys.stderr.write("Must select a board\n")
         sys.exit(1)
 
-    board_definitions_file = get_definitions_or_raise(args.chosen_board)
+    board_definitions_file = get_definitions_or_exit(args.chosen_board)
 
     board_stubs_file = resources.files("board-stubs").joinpath("__init__.pyi")
     shutil.copyfile(board_definitions_file, board_stubs_file)
-
-    sys.stdout.write(
-        header("Information about the board") + get_doc_or_raise(args.chosen_board) + "\n"
-    )

--- a/tools/board_stubs/circuitpython_setboard/__init__.py
+++ b/tools/board_stubs/circuitpython_setboard/__init__.py
@@ -4,7 +4,34 @@
 import argparse
 import sys
 import shutil
+from collections import defaultdict
 from importlib import resources
+from importlib.abc import Traversable
+
+
+def get_definitions_or_raise(board: str) -> Traversable:
+    """Get the definitions file for a board given its name."""
+
+    path = resources.files("board_definitions").joinpath(board)
+
+    file = path.joinpath("__init__.pyi")
+    if not file.is_file():
+        sys.stderr.write(f"Definitions for: '{board}' were not found\n")
+        sys.exit(1)
+
+    return file
+
+
+def get_doc_or_raise(board: str) -> str:
+    """Get the docstring for a board given its name."""
+
+    with get_definitions_or_raise(board).open("r") as f:
+        return f.read().split('"""')[1]
+
+
+def header(txt: str) -> str:
+    """Helper text formatter."""
+    return txt + "\n" + "-" * len(txt) + "\n"
 
 
 def set_board():
@@ -18,25 +45,48 @@ def set_board():
     args = parser.parse_args()
 
     if args.list:
-        sys.stdout.write("Available boards are: \n")
+        port_boards: defaultdict[str, list[str]] = defaultdict(list)
 
         for board in resources.files("board_definitions").iterdir():
-            sys.stdout.write(f"{board.name}\n")
+            # NOTE: For the hand-crafted finding of port in the docstring, its
+            #       format is assumed to be:
+            #
+            # <empty line>
+            # Board stub for ...
+            #  - port: ...
+            #  - board_id: ...
+            #  - NVM size: ...
+            #  - Included modules: ...
+            #  - Frozen libraries: ...
+            #
+
+            lines = get_doc_or_raise(board).split("\n")
+            port = lines[2].split("-")[1].split(":")[1].strip()
+
+            port_boards[port].append(board.name)
+
+        sys.stdout.write("Available boards are: \n")
+        # sort by port name
+        for port, boards in sorted(port_boards.items(), key=lambda kv: kv[0]):
+            sys.stdout.write(
+                header(port)
+                + "  * "
+                # sort by board name
+                + "\n  * ".join(sorted(boards))
+                + "\n\n"
+            )
 
         sys.exit(0)
 
     if args.chosen_board is None:
-        sys.stderr.write("Must select a board")
+        sys.stderr.write("Must select a board\n")
         sys.exit(1)
 
-    print(f"setting board: {args.chosen_board}")
+    board_definitions_file = get_definitions_or_raise(args.chosen_board)
 
     board_stubs_file = resources.files("board-stubs").joinpath("__init__.pyi")
-    board_definitions_path = resources.files("board_definitions").joinpath(args.chosen_board)
-    board_definitions_file = board_definitions_path.joinpath("__init__.pyi")
-
-    if not board_definitions_file.is_file():
-        print(f"Board: '{args.chosen_board}' was not found")
-        sys.exit(1)
-
     shutil.copyfile(board_definitions_file, board_stubs_file)
+
+    sys.stdout.write(
+        header("Information about the board") + get_doc_or_raise(args.chose_board) + "\n"
+    )


### PR DESCRIPTION
As per title, this PR adds support for `--list`/`-l` as argument to the command, which will print all the available stubs.

Furthermore, a filter can be used, eg: `circuitpython_setboard -l feather` to find a board without having to scroll that much.

As a side effect, the PR reworks hand-crafted parsing of  arguments `sys.argv` into using `argparse`, and also changes both explicit and implicit `return None` with `sys.exit` of `0` or  `1` to flag the command's success/failure

# Examples:
```
$ circuitpython_setboard -l __bad__
Nothing found, check out your filter.

$ circuitpython_setboard -l f7 
Available boards are: 
stm
---
  * nucleo_f746zg
  * nucleo_f767zi
  * stm32f746g_discovery

$ circuitpython_setboard -l
Available boards are: 
atmel
-----
   ... cropped alphabetically sorted list of boards ...

broadcom
--------
   ... see above ...
   
... rest of ports also alphabetical ...

$ circuitpython_setboard nucleo_f746zg
Information about the board
---------------------------

Board stub for NUCLEO STM32F746
 - port: stm
 - board_id: nucleo_f746zg
 - NVM size: Unknown
 - Included modules: _asyncio, _bleio, _pixelmap, adafruit_bus_device, adafruit_pixelbuf, aesio, array, atexit, binascii, bitbangio, bitmapfilter, bitmaptools, board, builtins, builtins.pow3, busdisplay, busio, busio.SPI, busio.UART, codeop, collections, digitalio, displayio, epaperdisplay, errno, fontio, fourwire, framebufferio, getpass, gifio, i2cdisplaybus, io, jpegio, json, keypad, keypad.KeyMatrix, keypad.Keys, keypad.ShiftRegisterKeys, keypad_demux, keypad_demux.DemuxKeyMatrix, locale, math, microcontroller, msgpack, onewireio, os, os.getenv, pulseio, pwmio, rainbowio, random, re, rtc, sdcardio, select, sharpdisplay, storage, struct, supervisor, sys, terminalio, time, touchio, traceback, ulab, usb_cdc, usb_hid, usb_midi, vectorio, warnings, zlib
 - Frozen libraries: 
```

PS: Not sure how useful/desirable printing the docstring is, can remove it if prefered ^^