### PR TITLE
Always `os.chdir("/")` when reloading

### DIFF
--- a/main.c
+++ b/main.c
@@ -473,9 +473,6 @@ STATIC bool __attribute__((noinline)) run_code_py(safe_mode_t safe_mode, bool *s
         usb_setup_with_vm();
         #endif
 
-        // Make sure we are in the root directory before looking at files.
-        common_hal_os_chdir("/");
-
         // Check if a different run file has been allocated
         if (next_code_configuration != NULL) {
             next_code_configuration->options &= ~SUPERVISOR_NEXT_CODE_OPT_NEWLY_SET;
@@ -1112,6 +1109,10 @@ int __attribute__((used)) main(void) {
                 serial_write_compressed(MP_ERROR_TEXT("soft reboot\n"));
             }
             simulate_reset = false;
+
+            // Always return to root before trying to run files.
+            common_hal_os_chdir("/");
+
             if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
                 // If code.py did a fake deep sleep, pretend that we
                 // are running code.py for the first time after a hard


### PR DESCRIPTION
~~With this PR, after every reload the current working directory will always change back to root.
With this, if the code exited while in a different directory (or autoreload was run, interrupting the code), reloading will run the code again.~~

~~Up until now, if the code had changed the working directory, CircuitPython would try to find a `code.py` in the working directory in the next reload.
This is exceptionally problematic for when autoreload is enabled, since the code may be interrupted without being given the chance to change back to root.
This would mean, the code would stop, and CircuitPython would find no `code.py` to run.~~

This PR just make CircuitPython always reset current working directory to root upon reload.