### PR TITLE
add subticks to RP2040 port_get_raw_ticks

### DIFF
--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -267,6 +267,9 @@ static volatile bool _woken_up;
 
 uint64_t port_get_raw_ticks(uint8_t *subticks) {
     uint64_t microseconds = time_us_64();
+    if (subticks != NULL) {
+        *subticks = (uint8_t) (((microseconds % 1000000) % 977) / 31);
+    }    
     return 1024 * (microseconds / 1000000) + (microseconds % 1000000) / 977;
 }
 

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -268,8 +268,8 @@ static volatile bool _woken_up;
 uint64_t port_get_raw_ticks(uint8_t *subticks) {
     uint64_t microseconds = time_us_64();
     if (subticks != NULL) {
-        *subticks = (uint8_t) (((microseconds % 1000000) % 977) / 31);
-    }    
+        *subticks = (uint8_t)(((microseconds % 1000000) % 977) / 31);
+    }
     return 1024 * (microseconds / 1000000) + (microseconds % 1000000) / 977;
 }
 


### PR DESCRIPTION
The RP2040 port of `monotonic_ns()` only has millisecond precision - the subtick value is not used:

https://github.com/adafruit/circuitpython/blob/781c577745338128e1994d0b63fe95d75f3ef786/ports/raspberrypi/supervisor/port.c#L268-L271

Added 7234375e806f101673f3c91bf649442260588d97 to fill in the subtick field.  Testing with this code to look at deltas between successive calls to `monotonic_ns()`:

```python
import time
def test_ns(n=200):
    t0 = time.monotonic_ns()
    for i in range(n):
        t1 = time.monotonic_ns()
        print(t1-t0)
        t0 = t1
test_ns()
```
Plotting the returned data from before and after the change:

![image](https://github.com/adafruit/circuitpython/assets/5445541/6db3fdf0-8bf3-43ca-90f5-abd6ca3bfbc4)

Before the change, the data is granular to 1 ms, e.g.
```
976563
0
0
0
0
976562
0
0
0
0
976563
```

After, it does better:
```
244144
213613
183108
183108
213626
213626
213612
244144
152590
213626
244131
```





