### PR TITLE
ensure a unique error message for each USBError

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -113,7 +113,7 @@ msgstr ""
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 #: ports/raspberrypi/common-hal/usb_host/Port.c
 #: shared-bindings/digitalio/DigitalInOut.c
-#: shared-bindings/microcontroller/Pin.c
+#: shared-bindings/microcontroller/Pin.c shared-module/max3421e/Max3421E.c
 msgid "%q in use"
 msgstr ""
 
@@ -1154,6 +1154,7 @@ msgstr ""
 #: ports/atmel-samd/common-hal/alarm/pin/PinAlarm.c
 #: ports/atmel-samd/common-hal/countio/Counter.c
 #: ports/atmel-samd/common-hal/frequencyio/FrequencyIn.c
+#: ports/atmel-samd/common-hal/max3421e/Max3421E.c
 #: ports/atmel-samd/common-hal/ps2io/Ps2.c
 #: ports/atmel-samd/common-hal/pulseio/PulseIn.c
 #: ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.c
@@ -2138,6 +2139,7 @@ msgstr ""
 msgid "Unknown BLE error: %d"
 msgstr ""
 
+#: ports/espressif/common-hal/max3421e/Max3421E.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
 #, c-format
 msgid "Unknown error code %d"
@@ -3587,6 +3589,10 @@ msgstr ""
 msgid "not all arguments converted during string formatting"
 msgstr ""
 
+#: shared-module/usb/core/Device.c
+msgid "not an open endpoint"
+msgstr ""
+
 #: py/objstr.c
 msgid "not enough arguments for format string"
 msgstr ""
@@ -3809,7 +3815,7 @@ msgstr ""
 msgid "pop from empty %q"
 msgstr ""
 
-#: shared-bindings/socketpool/Socket.c shared-bindings/ssl/SSLSocket.c
+#: shared-bindings/socketpool/Socket.c
 msgid "port must be >= 0"
 msgstr ""
 
@@ -4086,6 +4092,14 @@ msgstr ""
 
 #: extmod/ulab/code/numpy/approx.c
 msgid "trapz is defined for 1D iterables"
+msgstr ""
+
+#: shared-module/usb/core/Device.c
+msgid "tuh_control_xfer failed"
+msgstr ""
+
+#: shared-module/usb/core/Device.c
+msgid "tuh_edpt_xfer() failed"
 msgstr ""
 
 #: py/obj.c

--- a/shared-module/usb/core/Device.c
+++ b/shared-module/usb/core/Device.c
@@ -179,7 +179,7 @@ STATIC size_t _xfer(tuh_xfer_t *xfer, mp_int_t timeout) {
     _xfer_result = 0xff;
     xfer->complete_cb = _transfer_done_cb;
     if (!tuh_edpt_xfer(xfer)) {
-        mp_raise_usb_core_USBError(NULL);
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("tuh_edpt_xfer() failed"));
     }
     uint32_t start_time = supervisor_ticks_ms32();
     while ((timeout == 0 || supervisor_ticks_ms32() - start_time < (uint32_t)timeout) &&
@@ -259,7 +259,7 @@ STATIC bool _open_endpoint(usb_core_device_obj_t *self, mp_int_t endpoint) {
 
 mp_int_t common_hal_usb_core_device_write(usb_core_device_obj_t *self, mp_int_t endpoint, const uint8_t *buffer, mp_int_t len, mp_int_t timeout) {
     if (!_open_endpoint(self, endpoint)) {
-        mp_raise_usb_core_USBError(NULL);
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("not an open endpoint"));
     }
     tuh_xfer_t xfer;
     xfer.daddr = self->device_number;
@@ -271,7 +271,7 @@ mp_int_t common_hal_usb_core_device_write(usb_core_device_obj_t *self, mp_int_t 
 
 mp_int_t common_hal_usb_core_device_read(usb_core_device_obj_t *self, mp_int_t endpoint, uint8_t *buffer, mp_int_t len, mp_int_t timeout) {
     if (!_open_endpoint(self, endpoint)) {
-        mp_raise_usb_core_USBError(NULL);
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("not an open endpoint"));
     }
     tuh_xfer_t xfer;
     xfer.daddr = self->device_number;
@@ -305,7 +305,7 @@ mp_int_t common_hal_usb_core_device_ctrl_transfer(usb_core_device_obj_t *self,
     _xfer_result = 0xff;
 
     if (!tuh_control_xfer(&xfer)) {
-        mp_raise_usb_core_USBError(NULL);
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("tuh_control_xfer failed"));
     }
     uint32_t start_time = supervisor_ticks_ms32();
     while ((timeout == 0 || supervisor_ticks_ms32() - start_time < (uint32_t)timeout) &&


### PR DESCRIPTION
This may help with diagnosing #9226: it will tell us *which* site is unexpectedly failing after a first timed out transfer (which correctly raises USBTimeoutError)

This is probably not worth merging as is, as the NULL cases look like "this isn't supposed to happen" cases. It's just for diagnostic purposes, if someone wants to grab the artifacts.