### PR TITLE
Feather nRF52840 Rev E: NEOPIXEL_POWER pin

### DIFF
--- a/ports/nordic/boards/feather_nrf52840_express/mpconfigboard.h
+++ b/ports/nordic/boards/feather_nrf52840_express/mpconfigboard.h
@@ -31,6 +31,9 @@
 #define MICROPY_HW_MCU_NAME         "nRF52840"
 
 #define MICROPY_HW_NEOPIXEL         (&pin_P0_16)
+// power control available only on Rev E and later.
+#define CIRCUITPY_STATUS_LED_POWER (&pin_P1_14)
+
 
 #define MICROPY_HW_LED_STATUS       (&pin_P1_15)
 

--- a/ports/nordic/boards/feather_nrf52840_express/pins.c
+++ b/ports/nordic/boards/feather_nrf52840_express/pins.c
@@ -30,6 +30,8 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_P1_09) },
 
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_P0_16) },
+    // NEOPIXEL_POWER only works on Rev E and later.
+    { MP_ROM_QSTR(MP_QSTR_NEOPIXEL_POWER), MP_ROM_PTR(&pin_P1_14) },
 
     { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_P0_14) },
     { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_P0_13) },


### PR DESCRIPTION
Feather nRF52840 Rev E has a new NEOPIXEL_POWER pin. Provide a pin definition and set up for control by status LED code.