### PR TITLE
Fix typos in the start_advertising() param docs

### DIFF
--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -198,8 +198,8 @@ MP_PROPERTY_GETSET(bleio_adapter_name_obj,
 //|         :param bool anonymous:  If `True` then this device's MAC address is randomized before advertising.
 //|         :param int timeout:  If set, we will only advertise for this many seconds. Zero means no timeout.
 //|         :param float interval:  advertising interval, in seconds
-//|         :param tx_power int: transmitter power while advertising in dBm
-//|         :param directed_to Address: peer to advertise directly to"""
+//|         :param int tx_power: transmitter power while advertising in dBm
+//|         :param Address directed_to: peer to advertise directly to"""
 //|         ...
 STATIC mp_obj_t bleio_adapter_start_advertising(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_adapter_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);


### PR DESCRIPTION
I noticed there are two small typos in the parameters for the `_bleio.Adapter.start_advertising()` method. In the **Parameters** list, two lines had the parameter name and data type values switched. The data type should be listed after `:param` and before the parameter's name.

The two parameters are currently listed as:
- int (tx_power) – transmitter power while advertising in dBm
- Address (directed_to) – peer to advertise directly to

The data type should be in the parentheses, not the parameter's name:
- tx_power (int) – transmitter power while advertising in dBm
- directed_to (Address) – peer to advertise directly to