### PR TITLE
correction in pin assignment for Challenger RP2040 LTE

### DIFF
--- a/ports/raspberrypi/boards/challenger_rp2040_lte/pins.c
+++ b/ports/raspberrypi/boards/challenger_rp2040_lte/pins.c
@@ -56,11 +56,11 @@ STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_GP17), MP_ROM_PTR(&pin_GPIO17) },
 
     // SPI
+    { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_GPIO20) },
     { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_GPIO22) },
     { MP_ROM_QSTR(MP_QSTR_GP22), MP_ROM_PTR(&pin_GPIO22) },
     { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_GPIO23) },
     { MP_ROM_QSTR(MP_QSTR_GP23), MP_ROM_PTR(&pin_GPIO23) },
-    { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_GPIO24) },
     { MP_ROM_QSTR(MP_QSTR_GP24), MP_ROM_PTR(&pin_GPIO24) },
 
     // Analog input / Generic IO


### PR DESCRIPTION
the board's [v0.2 revision](https://gitlab.com/invectorlabs/hw/challenger-rp2040-lte/-/blob/main/V0.2/challenger-rp2040-lte.pdf?ref_type=heads) moved SDI (MISO) from GP24 to GP20 for the SPI0 bus.

there shouldn't be any backwards compatibility issues since on the [rp2040 datasheet, table 2](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf), GP24 can not be used for SPI0 (only SPI1) so SPI on any of the old revisions of the board is non-functional since all the other SPI pins are on SPI0.

Closes: #8272 