### PR TITLE
set the connected status of a socket after UDP & raw connect

### DIFF
--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -1014,11 +1014,17 @@ void common_hal_socketpool_socket_connect(socketpool_socket_obj_t *socket,
         }
         case MOD_NETWORK_SOCK_DGRAM: {
             err = udp_connect(socket->pcb.udp, &dest, port);
+            if (err == ERR_OK) {
+                socket->state = STATE_CONNECTED;
+            }
             break;
         }
         #if MICROPY_PY_LWIP_SOCK_RAW
         case MOD_NETWORK_SOCK_RAW: {
             err = raw_connect(socket->pcb.raw, &dest);
+            if (err == ERR_OK) {
+                socket->state = STATE_CONNECTED;
+            }
             break;
         }
         #endif


### PR DESCRIPTION
This is a speculative fix for https://github.com/adafruit/Adafruit_CircuitPython_NTP/issues/33