### PR TITLE
Fix for M5Stack Cores3 camera

### DIFF
--- a/ports/espressif/boards/m5stack_cores3/board.c
+++ b/ports/espressif/boards/m5stack_cores3/board.c
@@ -114,9 +114,9 @@ static bool axp2101_init(busio_i2c_obj_t *i2c) {
     int rc;
     uint8_t write_buf[2];
 
-    // 0x90 = 0b1011_1001  // LDOS ON/OFF control 0
+    // 0x90 = 0b1011_1111  // LDOS ON/OFF control 0
     write_buf[0] = 0x90;
-    write_buf[1] = 0b10111001;
+    write_buf[1] = 0b10111111;
     rc = common_hal_busio_i2c_write(i2c, AXP2101_I2C_ADDRESS, write_buf, sizeof(write_buf));
     if (rc != 0) {
         return false;
@@ -146,7 +146,7 @@ static bool axp2101_init(busio_i2c_obj_t *i2c) {
         return false;
     }
 
-    // 0x95, 0x1C // ALDO3 set to 3.3v for TF card slot
+    // 0x95, 0x1C // ALDO4 set to 3.3v for TF card slot
     write_buf[0] = 0x95;
     write_buf[1] = 0x1C;
     rc = common_hal_busio_i2c_write(i2c, AXP2101_I2C_ADDRESS, write_buf, sizeof(write_buf));

--- a/ports/espressif/boards/m5stack_cores3/sdkconfig
+++ b/ports/espressif/boards/m5stack_cores3/sdkconfig
@@ -10,6 +10,13 @@
 CONFIG_LWIP_LOCAL_HOSTNAME="m5stack-cores3"
 # end of LWIP
 
+#
+# Camera configuration
+#
+CONFIG_GC0308_SUPPORT=y
+CONFIG_GC_SENSOR_SUBSAMPLE_MODE=y
+# end of Camera configuration
+
 # end of Component config
 
 # end of Espressif IoT Development Framework Configuration


### PR DESCRIPTION
Few fixes to enable internal camera and microphone:

* Add camera configuration in sdkconfig
* Enable at boot VDDCAM_3V3 power line (camera)
* Enable at bott VDDA_3V3 power line (microphone)