### PR TITLE
added explorer badge RP2040 board

### DIFF
--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/board.c
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/board.c
@@ -1,0 +1,336 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Bradán Lane STUDIO
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+    The Explorer Badge(s) have more than one specific hardware configuration.
+    This is a result of small changes in parts availability. The changes are
+    insignificant to the end user but require changes to the initialization.
+    The hardware revisions use a voltage divider connected to pin GP29 to
+    indicate which hardware configuration exists. The code generates a
+    "version ID" or VID which is used by the code to perform the correct
+    initialization. The VID is also exposed to the end user in case there is
+    a need - either for documentation, support requests, or tutorial materials.
+*/
+
+#include "mpconfigboard.h"
+
+#include "supervisor/board.h"
+#include "shared-bindings/board/__init__.h"
+
+#include "shared-bindings/busio/SPI.h"
+#include "shared-bindings/fourwire/FourWire.h"
+#include "shared-bindings/microcontroller/Pin.h"
+#include "shared-module/displayio/__init__.h"
+#include "supervisor/shared/board.h"
+
+#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+
+#include "src/rp2_common/hardware_adc/include/hardware/adc.h"
+#define ADC_FIRST_PIN_NUMBER 26
+#define ADC_PIN_COUNT 4
+extern void common_hal_mcu_delay_us(uint32_t);
+
+#define HEIGHT      200
+#define WIDTH       200
+
+#define DELAY_FLAG  0x80
+
+#define EPD_RAM_BW  0x10
+#define EPD_RAM_RED 0x13
+
+#define DISPLAY_EN_PIN 8
+
+// These commands are the combination of SSD1608 and SSD1681 and not all commands are supported for each controller
+#define SSD_DRIVER_CONTROL         0x01
+#define SSD_GATE_VOLTAGE           0x03
+#define SSD_SOURCE_VOLTAGE         0x04
+#define SSD_DISPLAY_CONTROL        0x07
+#define SSD_PROGOTP_INITIAL        0x08
+#define SSD_WRITEREG_INITIAL       0x09
+#define SSD_READREG_INITIAL        0x0A
+#define SSD_NON_OVERLAP            0x0B
+#define SSD_BOOST_SOFT_START       0x0C
+#define SSD_GATE_SCAN_START        0x0F
+#define SSD_DEEP_SLEEP             0x10
+#define SSD_DATA_MODE              0x11
+#define SSD_SW_RESET               0x12
+#define SSD_HV_DETECT              0x14
+#define SSD_VCI_DETECT             0x15
+#define SSD_TEMP_CONTROL_1681      0x18
+#define SSD_TEMP_CONTROL_1608      0x1C
+#define SSD_TEMP_WRITE             0x1A
+#define SSD_TEMP_READ              0x1B
+#define SSD_TEMP_EXTERN            0x1C
+#define SSD_MASTER_ACTIVATE        0x20
+#define SSD_DISP_CTRL1             0x21
+#define SSD_DISP_CTRL2             0x22
+#define SSD_WRITE_RAM_BLK          0x24
+#define SSD_READ_RAM_BLK           0x25
+#define SSD_WRITE_RAM_RED          0x26
+#define SSD_READ_RAM_RED           0x27
+#define SSD_VCOM_SENSE             0x28
+#define SSD_VCOM_DURRATION         0x29
+#define SSD_PROG_VCOM              0x2A
+#define SSD_CTRL_VCOM              0x2B
+#define SSD_WRITE_VCOM             0x2C
+#define SSD_READ_OTP               0x2D
+#define SSD_READ_ID                0x2E
+#define SSD_READ_STATUS            0x2F
+#define SSD_WRITE_LUT              0x32
+#define SSD_WRITE_DUMMY            0x3A
+#define SSD_WRITE_GATELINE_1608    0x3B
+#define SSD_WRITE_BORDER           0x3C
+#define SSD_SET_RAMXPOS            0x44
+#define SSD_SET_RAMYPOS            0x45
+#define SSD_SET_RAMXCOUNT          0x4E
+#define SSD_SET_RAMYCOUNT          0x4F
+#define SSD_NOP                    0xFF
+
+const uint8_t _start_sequence_ssd1681[] = {
+    SSD_SW_RESET,           DELAY_FLAG + 0, 20,                                                         // soft reset and wait 20ms
+    SSD_DATA_MODE,          1,              0x03,                                                       // Data entry sequence
+    SSD_WRITE_BORDER,       1,              0x05,                                                       // border color
+    SSD_TEMP_CONTROL_1681,  1,              0x80,                                                       // Temperature control
+    SSD_SET_RAMXCOUNT,      1,              0x00,
+    SSD_SET_RAMYCOUNT,      2,              0x00, 0x00,
+    SSD_DRIVER_CONTROL,     3,              ((WIDTH - 1) & 0xFF), (((WIDTH >> 8) - 1) & 0xFF), 0x00,    // set display size
+    SSD_DISP_CTRL2,         1,              0xf7,                                                       // Set DISP only full refreshes
+};
+const uint8_t _stop_sequence_ssd1681[] = {
+    SSD_DEEP_SLEEP,         DELAY_FLAG + 1, 0x01, 0x64                                                  // Enter deep sleep
+};
+const uint8_t _refresh_sequence_ssd1681[] = {
+    SSD_MASTER_ACTIVATE, 0,
+};
+
+
+const uint8_t _start_sequence_ssd1608[] = {
+    SSD_SW_RESET,           DELAY_FLAG + 0, 20,                                                         // soft reset and wait 20ms
+    SSD_DRIVER_CONTROL,     3,              ((WIDTH - 1) & 0xFF), (((WIDTH - 1) >> 8) & 0xFF), 0x00,    // set display size
+    SSD_WRITE_GATELINE_1608, 1,             0x0B,   // gate line width
+    SSD_DATA_MODE,          1,              0x03,                                                       // Data entry sequence
+    SSD_WRITE_VCOM,         1,              0x70,
+    SSD_WRITE_LUT,         30,              0x02, 0x02, 0x01, 0x11, 0x12, 0x12, 0x22, 0x22, 0x66, 0x69,
+    0x69, 0x59, 0x58, 0x99, 0x99, 0x88, 0x00, 0x00, 0x00, 0x00,
+    0xf8, 0xb4, 0x13, 0x51, 0x35, 0x51, 0x51, 0x19, 0x01, 0x00,
+    SSD_DISP_CTRL2,         1,              0xC7,                                                       // Set DISP only full refreshes
+};
+const uint8_t _stop_sequence_ssd1608[] = {
+    SSD_DEEP_SLEEP,         DELAY_FLAG + 1, 0x01, 0x64                                                  // Enter deep sleep
+};
+const uint8_t _refresh_sequence_ssd1608[] = {
+    SSD_MASTER_ACTIVATE, 0,
+};
+
+
+extern uint16_t vid_setting;    // declared in pins.c
+// _set_vid() uses the GPIO29 analog pin (which is connected to a voltage divider) to computer a revision code for the board
+// this allows multiple similar boards to chare the same CP build
+static int _set_vid(void) {
+    vid_setting = 9999;
+
+    #define DCK01_VID_PIN 29
+    uint16_t value;
+    adc_init();
+    adc_gpio_init(DCK01_VID_PIN);
+    adc_select_input(DCK01_VID_PIN - ADC_FIRST_PIN_NUMBER); // the VID pin is 29 and the first ADC pin is 26
+    common_hal_mcu_delay_us(100);
+    uint32_t accum = 0;
+    for (int i = 0; i < 10; i++) {
+        accum += adc_read();
+    }
+    value = accum / 10; // average the readings
+    vid_setting = value;
+    /*
+        Voltage Divider with 3.3V: (1241 * V)
+         10K/ 15K = 1.98V = 2458
+         15K/ 10K = 1.32V = 1638
+         15K/4.7K = 0.79V =  980
+         15K/  2K = 1.32V =  482
+         15K/  1K = 1.32V =  256
+        Note: extreme values (using 100K or greater) will not create a strong enough current for the ADC to read accurately
+        Note: we do not get a usable value when the voltage divider is missing
+    */
+
+    // TODO change to min/max to tighten up the ranges (requires sampling of the initial boards)
+    if (value > 2800) {
+        vid_setting = 9;
+    } else if (value > 2000) {
+        vid_setting = 5;
+    } else if (value > 1200) {
+        vid_setting = 4;
+    } else if (value > 600) {
+        vid_setting = 3;
+    } else if (value > 300) {
+        vid_setting = 2;
+    } else if (value > 150) {
+        vid_setting = 1;
+    } else {
+        vid_setting = 0;
+    }
+
+    return vid_setting;
+}
+
+
+// Note: board_reset_pin_number() is new to CP9 and allows a board to handle pin resets on a per-pin basis
+// we use it to prevent the DISPLAY_EN pin from automatically changing state
+bool board_reset_pin_number(uint8_t pin_number) {
+    static bool _display_pin_inited = false;
+
+    if (pin_number == DISPLAY_EN_PIN) {
+        // init the pin the first time; do nothing after that
+        if (!_display_pin_inited) {
+            _display_pin_inited = true;
+            // doing this (rather than gpio_init) in this specific order ensures no
+            // glitch if pin was already configured as a high output. gpio_init() temporarily
+            // configures the pin as an input, so the power enable value would potentially
+            // glitch.
+            gpio_put(pin_number, 1);
+            gpio_set_dir(pin_number, GPIO_OUT);
+            hw_write_masked(&padsbank0_hw->io[pin_number], PADS_BANK0_GPIO0_DRIVE_VALUE_12MA << PADS_BANK0_GPIO0_DRIVE_LSB, PADS_BANK0_GPIO0_DRIVE_BITS);
+            gpio_set_function(pin_number, GPIO_FUNC_SIO);
+        }
+        return true;
+    }
+    return false;
+}
+
+void board_init(void) {
+    board_reset_pin_number(DISPLAY_EN_PIN);
+    _set_vid(); // sets vid_setting global
+
+    fourwire_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
+    common_hal_busio_spi_construct(spi, &pin_GPIO14, &pin_GPIO15, NULL, false);
+    common_hal_busio_spi_never_reset(spi);
+
+    bus->base.type = &fourwire_fourwire_type;
+    common_hal_fourwire_fourwire_construct(bus,
+        spi,
+        &pin_GPIO11, // DEFAULT_SPI_BUS_DC,                                                             // EPD_DC Command or data
+        &pin_GPIO13, // DEFAULT_SPI_BUS_CS,                                                             // EPD_CS Chip select
+        &pin_GPIO10, // DEFAULT_SPI_BUS_RESET,                                                          // EPD_RST Reset
+        1000000,                                                                                        // Baudrate
+        0,                                                                                              // Polarity
+        0);                                                                                             // Phase
+
+    // board_vid is a computed flag to let us know what hardware is active
+    // currently, we only know two codes '1' and '2' and these indicate what ePaper display is installed
+
+    epaperdisplay_epaperdisplay_obj_t *display = NULL;
+
+    // Set up the DisplayIO epaper object
+    display = &allocate_display()->epaper_display;
+    display->base.type = &epaperdisplay_epaperdisplay_type;
+
+    // VID codes: 1 = tricolor ePaper (BWR), 2 = monochrome ePaper (BW), other codes are TBD
+    if (vid_setting == 1) {
+        common_hal_epaperdisplay_epaperdisplay_construct(
+            display,
+            bus,
+            _start_sequence_ssd1681, sizeof(_start_sequence_ssd1681),
+            1.0,         // start up time
+            _stop_sequence_ssd1681, sizeof(_stop_sequence_ssd1681),
+            WIDTH,                                                                                          // width
+            HEIGHT,                                                                                         // height
+            WIDTH,                                                                                          // ram_width
+            HEIGHT + 0x60,                                                                                  // ram_height RAM is actually only 200 bits high but we use 296 to match the 9 bits
+            0,                                                                                              // colstart
+            0,                                                                                              // rowstart
+            270,                                                                                            // rotation
+            SSD_SET_RAMXPOS,                                                                                // set_column_window_command
+            SSD_SET_RAMYPOS,                                                                                // set_row_window_command
+            SSD_SET_RAMXCOUNT,                                                                              // set_current_column_command
+            SSD_SET_RAMYCOUNT,                                                                              // set_current_row_command
+            SSD_WRITE_RAM_BLK,                                                                              // write_black_ram_command
+            false,                                                                                          // black_bits_inverted
+            SSD_WRITE_RAM_RED,                                                                              // write_color_ram_command
+            false,                                                                                          // color_bits_inverted
+            0xFF0000,                                                                                       // highlight_color (RED for tri-color display)
+            _refresh_sequence_ssd1681, sizeof(_refresh_sequence_ssd1681),                                   // refresh_display_command
+            15.0,                                                                                           // refresh_time
+            &pin_GPIO9, // DEFAULT_SPI_BUS_BUSY,                                                            // busy_pin
+            true,                                                                                           // busy_state
+            20.0,                                                                                           // seconds_per_frame (does not seem the user can change this)
+            true,                                                                                           // always_toggle_chip_select
+            false,                                                                                          // not grayscale
+            false,                                                                                          // not acep
+            false,                                                                                          // not two_byte_sequence_length
+            true);                                                                                          // address_little_endian
+    } else if (vid_setting == 2) {
+        common_hal_epaperdisplay_epaperdisplay_construct(
+            display,
+            bus,
+            _start_sequence_ssd1608, sizeof(_start_sequence_ssd1608),
+            1.0,         // start up time
+            _stop_sequence_ssd1608, sizeof(_stop_sequence_ssd1608),
+            WIDTH,                                                                                          // width
+            HEIGHT,                                                                                         // height
+            WIDTH,                                                                                          // ram_width
+            HEIGHT /* + 0x60 */,                                                                             // ram_height RAM is actually only 200 bits high but we use 296 to match the 9 bits
+            0,                                                                                              // colstart
+            0,                                                                                              // rowstart
+            0,                                                                                            // rotation
+            SSD_SET_RAMXPOS,                                                                                // set_column_window_command
+            SSD_SET_RAMYPOS,                                                                                // set_row_window_command
+            SSD_SET_RAMXCOUNT,                                                                              // set_current_column_command
+            SSD_SET_RAMYCOUNT,                                                                              // set_current_row_command
+            SSD_WRITE_RAM_BLK,                                                                              // write_black_ram_command
+            false,                                                                                          // black_bits_inverted
+            NO_COMMAND,                                                                                     // write_color_ram_command
+            false,                                                                                          // color_bits_inverted
+            0x000000,                                                                                       // highlight_color (RED for tri-color display)
+            _refresh_sequence_ssd1608, sizeof(_refresh_sequence_ssd1608),                                   // refresh_display_command
+            1.0,                                                                                            // refresh_time
+            &pin_GPIO9, // DEFAULT_SPI_BUS_BUSY,                                                            // busy_pin
+            true,                                                                                           // busy_state
+            5.0,                                                                                            // seconds_per_frame (does not seem the user can change this)
+            true,                                                                                           // always_toggle_chip_select
+            false,                                                                                          // not grayscale
+            false,                                                                                          // not acep
+            false,                                                                                          // not two_byte_sequence_length
+            true);                                                                                          // address_little_endian
+    } else {
+        // what should happen if this firmware is installed on some other board?
+        // currently, we mark the display as None
+        display->base.type = &mp_type_NoneType;
+    }
+
+}
+
+void board_deinit(void) {
+    if ((vid_setting == 1) || (vid_setting == 2)) {
+        // we initialized an ePaper display so we can de-init it
+        epaperdisplay_epaperdisplay_obj_t *display = &displays[0].epaper_display;
+        if (display->base.type == &epaperdisplay_epaperdisplay_type) {
+            while (common_hal_epaperdisplay_epaperdisplay_get_busy(display)) {
+                // RUN_BACKGROUND_TASKS;
+            }
+        }
+        common_hal_displayio_release_displays();
+    }
+}
+
+// Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/mpconfigboard.h
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/mpconfigboard.h
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Bradán Lane STUDIO
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#define MICROPY_HW_BOARD_NAME   "Bradán Lane STUDIO Explorer Badge"
+#define MICROPY_HW_MCU_NAME     "rp2040"
+
+#define MICROPY_HW_LED_STATUS   (&pin_GPIO4)
+// #define DEFAULT_UART_BUS_TX     (&pin_GPIO0)
+// #define DEFAULT_UART_BUS_RX     (&pin_GPIO1)
+#define DEFAULT_I2C_BUS_SDA     (&pin_GPIO2)
+#define DEFAULT_I2C_BUS_SCL     (&pin_GPIO3)
+
+#define DEFAULT_SPI_BUS_BUSY    (&pin_GPIO9)
+#define DEFAULT_SPI_BUS_RESET   (&pin_GPIO10)
+#define DEFAULT_SPI_BUS_DC      (&pin_GPIO11)
+#define DEFAULT_SPI_BUS_MISO    (&pin_GPIO12)
+#define DEFAULT_SPI_BUS_CS      (&pin_GPIO13)
+#define DEFAULT_SPI_BUS_SCK     (&pin_GPIO14)
+#define DEFAULT_SPI_BUS_MOSI    (&pin_GPIO15)

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/mpconfigboard.mk
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/mpconfigboard.mk
@@ -1,0 +1,16 @@
+USB_VID = 0x2E8A
+USB_PID = 0x1073
+USB_PRODUCT = "Explorer Badge"
+USB_MANUFACTURER = "Bradán Lane STUDIO"
+CHIP_VARIANT = RP2040
+CHIP_FAMILY = rp2
+
+EXTERNAL_FLASH_DEVICES = "GD25Q64C"
+
+CIRCUITPY__EVE = 1
+
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Bitmap_Font
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Display_Text
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Display_Shapes
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_HID

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/pico-sdk-configboard.h
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/pico-sdk-configboard.h
@@ -1,0 +1,4 @@
+// Put board-specific pico-sdk definitions here. This file must exist.
+
+// Allow extra time for xosc to start.
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/pins.c
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/pins.c
@@ -1,0 +1,146 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Bradán Lane STUDIO
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "mpconfigboard.h"
+
+#include "shared-bindings/board/__init__.h"
+#include "shared-module/displayio/__init__.h"
+
+
+uint16_t vid_setting = 123;
+
+//| def foo() -> None:
+//|     """Return a value set in board.c"""
+//|     ...
+//|
+STATIC mp_obj_t board_vid(void) {
+    return mp_obj_new_int(vid_setting);
+}
+MP_DEFINE_CONST_FUN_OBJ_0(board_vid_obj, board_vid);
+
+#if 0
+extern int dck01_vid_value; // will hold a computed value to identify any board variations (like different e-paper displays)
+
+STATIC mp_obj_t board_vid(void) {
+    return mp_obj_new_int(dck01_vid_value);
+}
+
+MP_DEFINE_CONST_FUN_OBJ_0(board_vid_obj, board_vid);
+#endif
+
+STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
+    CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
+
+    { MP_ROM_QSTR(MP_QSTR_GP0), MP_ROM_PTR(&pin_GPIO0) },
+    { MP_ROM_QSTR(MP_QSTR_GP1), MP_ROM_PTR(&pin_GPIO1) },
+    // GPIO0 and GPIO1 are also the UART
+    { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO0) },
+    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO1) },
+
+    { MP_ROM_QSTR(MP_QSTR_GP2), MP_ROM_PTR(&pin_GPIO2) },
+    { MP_ROM_QSTR(MP_QSTR_GP3), MP_ROM_PTR(&pin_GPIO3) },
+    // GPIO2 and GPIO3 are also the I2C
+    { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO2) },
+    { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO3) },
+
+    { MP_ROM_QSTR(MP_QSTR_GP4), MP_ROM_PTR(&pin_GPIO4) },
+    // GPIO4 is also the LED
+    { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO4) },
+
+    { MP_ROM_QSTR(MP_QSTR_GP5), MP_ROM_PTR(&pin_GPIO5) },
+    // GPIO5 is also the NEOPIXEL
+    { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO5) },
+
+    { MP_ROM_QSTR(MP_QSTR_GP6), MP_ROM_PTR(&pin_GPIO6) },
+    { MP_ROM_QSTR(MP_QSTR_GP7), MP_ROM_PTR(&pin_GPIO7) },
+    // GPIO6 is also the speaker (PWM) and GPIO7 is the enable
+    { MP_ROM_QSTR(MP_QSTR_SPEAKER), MP_ROM_PTR(&pin_GPIO6) },
+    { MP_ROM_QSTR(MP_QSTR_SPEAKER_EN), MP_ROM_PTR(&pin_GPIO7) },
+
+    { MP_ROM_QSTR(MP_QSTR_GP8), MP_ROM_PTR(&pin_GPIO8) },
+    // GPIO8 is also the display enable
+    { MP_ROM_QSTR(MP_QSTR_DISPLAY_EN), MP_ROM_PTR(&pin_GPIO8) },
+
+    { MP_ROM_QSTR(MP_QSTR_GP9), MP_ROM_PTR(&pin_GPIO9) },
+    { MP_ROM_QSTR(MP_QSTR_GP10), MP_ROM_PTR(&pin_GPIO10) },
+    { MP_ROM_QSTR(MP_QSTR_GP11), MP_ROM_PTR(&pin_GPIO11) },
+    { MP_ROM_QSTR(MP_QSTR_GP12), MP_ROM_PTR(&pin_GPIO12) },
+    { MP_ROM_QSTR(MP_QSTR_GP13), MP_ROM_PTR(&pin_GPIO13) },
+    { MP_ROM_QSTR(MP_QSTR_GP14), MP_ROM_PTR(&pin_GPIO14) },
+    { MP_ROM_QSTR(MP_QSTR_GP15), MP_ROM_PTR(&pin_GPIO15) },
+    // GPIO9 thru GPIO15 are the SPI for the ePaper display
+    { MP_ROM_QSTR(MP_QSTR_SPI_BUSY), MP_ROM_PTR(&pin_GPIO9) },
+    { MP_ROM_QSTR(MP_QSTR_SPI_RESET), MP_ROM_PTR(&pin_GPIO10) },
+    { MP_ROM_QSTR(MP_QSTR_SPI_DC), MP_ROM_PTR(&pin_GPIO11) },
+    { MP_ROM_QSTR(MP_QSTR_SPI_MISO), MP_ROM_PTR(&pin_GPIO12) },
+    { MP_ROM_QSTR(MP_QSTR_SPI_CS), MP_ROM_PTR(&pin_GPIO13) },
+    { MP_ROM_QSTR(MP_QSTR_SPI_SCK), MP_ROM_PTR(&pin_GPIO14) },
+    { MP_ROM_QSTR(MP_QSTR_SPI_MOSI), MP_ROM_PTR(&pin_GPIO15) },
+
+    { MP_ROM_QSTR(MP_QSTR_GP16), MP_ROM_PTR(&pin_GPIO16) },
+    { MP_ROM_QSTR(MP_QSTR_GP17), MP_ROM_PTR(&pin_GPIO17) },
+    { MP_ROM_QSTR(MP_QSTR_GP18), MP_ROM_PTR(&pin_GPIO18) },
+    // GPIO16 thru GPIO18 are also the I2S audio
+    { MP_ROM_QSTR(MP_QSTR_I2S_DATA), MP_ROM_PTR(&pin_GPIO16) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_BCK), MP_ROM_PTR(&pin_GPIO17) },
+    { MP_ROM_QSTR(MP_QSTR_I2S_LRCK), MP_ROM_PTR(&pin_GPIO18) },
+
+    { MP_ROM_QSTR(MP_QSTR_GP19), MP_ROM_PTR(&pin_GPIO19) },
+    { MP_ROM_QSTR(MP_QSTR_GP20), MP_ROM_PTR(&pin_GPIO20) },
+    { MP_ROM_QSTR(MP_QSTR_GP21), MP_ROM_PTR(&pin_GPIO21) },
+    { MP_ROM_QSTR(MP_QSTR_GP22), MP_ROM_PTR(&pin_GPIO22) },
+    { MP_ROM_QSTR(MP_QSTR_GP23), MP_ROM_PTR(&pin_GPIO23) },
+    { MP_ROM_QSTR(MP_QSTR_GP24), MP_ROM_PTR(&pin_GPIO24) },
+    { MP_ROM_QSTR(MP_QSTR_GP25), MP_ROM_PTR(&pin_GPIO25) },
+    { MP_ROM_QSTR(MP_QSTR_GP26), MP_ROM_PTR(&pin_GPIO26) },
+    { MP_ROM_QSTR(MP_QSTR_GP27), MP_ROM_PTR(&pin_GPIO27) },
+    // GPIO19 thru GPIO27 are also the touch sensors
+    { MP_ROM_QSTR(MP_QSTR_TOUCH1), MP_ROM_PTR(&pin_GPIO19) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH2), MP_ROM_PTR(&pin_GPIO20) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH3), MP_ROM_PTR(&pin_GPIO21) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH4), MP_ROM_PTR(&pin_GPIO22) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH5), MP_ROM_PTR(&pin_GPIO23) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH6), MP_ROM_PTR(&pin_GPIO24) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH7), MP_ROM_PTR(&pin_GPIO25) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH8), MP_ROM_PTR(&pin_GPIO26) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH9), MP_ROM_PTR(&pin_GPIO27) },
+
+    { MP_ROM_QSTR(MP_QSTR_GP28), MP_ROM_PTR(&pin_GPIO28) },
+    // GPIO28 is also the interrupt pin of the accelerometer
+    { MP_ROM_QSTR(MP_QSTR_ACCEL_INT), MP_ROM_PTR(&pin_GPIO28) },
+
+    { MP_ROM_QSTR(MP_QSTR_GP29), MP_ROM_PTR(&pin_GPIO29) },
+    // GPIO29 is also the ID value of the board (an analog read value between 0 .. 4096)
+    // { MP_ROM_QSTR(MP_QSTR_VID), MP_ROM_PTR(&pin_GPIO29) },
+
+
+    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    // { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].epaper_display)},
+
+    { MP_ROM_QSTR(MP_QSTR_VID), MP_ROM_PTR(&board_vid_obj) },
+};
+
+MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/pins.c
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/pins.c
@@ -30,7 +30,7 @@
 
 uint16_t vid_setting = 123;
 
-//| def foo() -> None:
+//| def VID() -> int:
 //|     """Return a value set in board.c"""
 //|     ...
 //|


### PR DESCRIPTION
The "Explorer Badge" is an RP2040 based CircuitPython board with integrated features to provide an _all-in-one_ learning device.

The board includes:
- 1.54" ePaper display
- neopixels
- touch sensors
- accelerometer
- IR (receiver and emitter)
- I2C STEMMA-QT
- sound (both PWM and I2S support)

There is also a tutorial series associated with the Explore Badge to get users started with Python and then CircuitPython with the integrated hardware. The badge has been tested with the related CircuitPython Learning Guides.

There will be at least two physical implementations of the Explorer Badge. One will be used at a conference in 2024 (that implementation will have a focus on youth education). The other will be generally available through Tindie and other options.