### PR TITLE
fix a few regexps that are better as raw strings

### DIFF
--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -11,7 +11,7 @@ TOP = pathlib.Path(__file__).parent.parent
 
 def _git_version():
     version_str = subprocess.check_output(["git", "--version"], encoding="ascii", errors="replace")
-    version_str = re.search("([0-9]\.*)*[0-9]", version_str).group(0)
+    version_str = re.search(r"([0-9]\.*)*[0-9]", version_str).group(0)
     return tuple(int(part) for part in version_str.split("."))
 
 

--- a/tools/fwsizes.py
+++ b/tools/fwsizes.py
@@ -7,7 +7,7 @@ import os, re
 
 for fn in os.listdir():
     if os.path.isfile(fn) and ("build-arm " in fn or "build-riscv " in fn):
-        board = re.split("[()]", fn)[1]
+        board = re.split(r"[()]", fn)[1]
         if board in (
             "spresense",
             "teensy40",

--- a/tools/gen_ld_files.py
+++ b/tools/gen_ld_files.py
@@ -28,7 +28,7 @@ args = parser.parse_args()
 defines = {}
 
 #
-REMOVE_UL_RE = re.compile("([0-9]+)UL")
+REMOVE_UL_RE = re.compile(r"([0-9]+)UL")
 
 
 def remove_UL(s):

--- a/tools/hci_trace_to_pcap.py
+++ b/tools/hci_trace_to_pcap.py
@@ -66,7 +66,7 @@ reassemble_packet = bytearray()
 with open(sys.argv[1], "r") as f:
     for line in f:
         line = line.strip()
-        m = re.match("([<>]) \\[ *([0-9]+)\\] ([A-Fa-f0-9:]+)", line)
+        m = re.match(r"([<>]) \[ *([0-9]+)\] ([A-Fa-f0-9:]+)", line)
         if not m:
             continue
 


### PR DESCRIPTION
@elpekenin noticed this problem:
```sh
$ make fetch-all-submodules 
python3 tools/ci_fetch_deps.py all
/home/elpekenin/circuitpython/tools/ci_fetch_deps.py:14: SyntaxWarning: invalid escape sequence '\.'
  version_str = re.search("([0-9]\.*)*[0-9]", version_str).group(0)
```
That regexp should be a raw string. The vast majority of regexp strings are now raw strings, but I found a few more. A new were not really necessary, but made them raw strings for consistency, and one is easier to understand as a raw string.