### PR TITLE
shared-bindings/analogio/AnalogIn.c: fix Espressif limitations doc

### DIFF
--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -38,10 +38,11 @@ MP_WEAK const mcu_pin_obj_t *common_hal_analogio_analogin_validate_pin(mp_obj_t 
 //|
 //|         :param ~microcontroller.Pin pin: the pin to read from
 //|
-//|         **Limitations:** On Espressif ESP32, `AnalogIn` is not available when WiFi is in use:
-//|         the hardware makes use of the ADC. Attempts to use `AnalogIn` will raise `espidf.IDFError`.
-//|         On other Espressif chips, the ADC is available, but is shared with WiFi.
-//|         WiFi use takes precedence and may temporarily cause `espidf.IDFError` to be raise.
+//|         **Limitations:** On Espressif ESP32, pins that use ADC2 are not available when WiFi is enabled:
+//|         the hardware makes use of ADC2.
+//|         Attempts to use `AnalogIn` in that situation will raise `espidf.IDFError`.
+//|         On other Espressif chips, ADC2 is available, but is shared with WiFi.
+//|         WiFi use takes precedence and may temporarily cause `espidf.IDFError` to be raised
 //|         when you read a value. You can retry the read.
 //|         """
 //|         ...


### PR DESCRIPTION
- Fixes #9213 