### PR TITLE
nordic/bluetooth/ble_drv.c: gc entire event handler list

### DIFF
--- a/ports/nordic/bluetooth/ble_drv.h
+++ b/ports/nordic/bluetooth/ble_drv.h
@@ -49,6 +49,7 @@ void ble_drv_reset(void);
 void ble_drv_remove_heap_handlers(void);
 void ble_drv_add_event_handler(ble_drv_evt_handler_t func, void *param);
 void ble_drv_remove_event_handler(ble_drv_evt_handler_t func, void *param);
+void ble_drv_gc_collect(void);
 
 // Allow for user provided entries to prevent allocations outside the VM.
 void ble_drv_add_event_handler_entry(ble_drv_evt_handler_entry_t *entry, ble_drv_evt_handler_t func, void *param);

--- a/ports/nordic/common-hal/_bleio/__init__.c
+++ b/ports/nordic/common-hal/_bleio/__init__.c
@@ -248,4 +248,5 @@ void bleio_background(void) {
 
 void common_hal_bleio_gc_collect(void) {
     bleio_adapter_gc_collect(&common_hal_bleio_adapter_obj);
+    ble_drv_gc_collect();
 }


### PR DESCRIPTION
- Fixes #9198.

Intermittently, the loop in ` ble_drv_add_event_handler_entry()` which walks down the linked list of existing event handlers, would loop infinitely. The list of handlers had a cycle in it. In addition, the entries in the list were damaged. This made me suspect a gc problem.

Some of the list entries were on the heap, and some were not. If some entry were not reachable during a gc, then that block of storage would have been recycled.

The easiest way to fix this was walk down the list when a gc was requested. I tested this with a simplified version of the test programs in #9198. Before the fix, the infinite loop would occur after around 150 iterations of the test, or less. I ran the test for 1000 iterations after the fix and could not cause the issue.

I also fixed up a couple of other extremely minor things: a missing `void` and an incorrect debugging print.