### PR TITLE
Add ADC `.voltage` property for ease of use and calibrated voltage reads.

### DIFF
--- a/ports/atmel-samd/common-hal/analogio/AnalogIn.c
+++ b/ports/atmel-samd/common-hal/analogio/AnalogIn.c
@@ -67,6 +67,11 @@ void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self) {
 void analogin_reset() {
 }
 
+uint16_t common_hal_analogio_analogin_get_millivolts(analogio_analogin_obj_t *self) {
+    // Unused in samd
+    return 0;
+}
+
 uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     // Something else might have used the ADC in a different way,
     // so we completely re-initialize it.
@@ -104,6 +109,11 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     adc_sync_deinit(&adc);
     // Stretch 12-bit ADC reading to 16-bit range
     return (value << 4) | (value >> 8);
+}
+
+
+float common_hal_analogio_analogin_get_voltage(analogio_analogin_obj_t *self) {
+    return (float)common_hal_analogio_analogin_get_value(self) * (3.3f / 65535.0f);
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {

--- a/ports/cxd56/common-hal/analogio/AnalogIn.c
+++ b/ports/cxd56/common-hal/analogio/AnalogIn.c
@@ -86,11 +86,22 @@ bool common_hal_analogio_analogin_deinited(analogio_analogin_obj_t *self) {
 }
 
 uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
+    // Not used for cxd56
+    return 0;
+}
+
+uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     int16_t value = 0;
 
     read(analogin_dev[self->number].fd, &value, sizeof(value));
 
     return (uint16_t)32768 + (uint16_t)value;
+}
+
+float common_hal_analogio_analogin_get_voltage(analogio_analogin_obj_t *self) {
+    float value = common_hal_analogio_analogin_get_value(self);
+    float reference = common_hal_analogio_analogin_get_reference_voltage(self);
+    return value * (reference / 65535.0f);
 }
 
 // Reference voltage is a fixed value which is depending on the board.

--- a/ports/espressif/common-hal/analogio/AnalogIn.c
+++ b/ports/espressif/common-hal/analogio/AnalogIn.c
@@ -22,7 +22,7 @@
 #include <string.h>
 
 #define DEFAULT_VREF        1100
-#define NO_OF_SAMPLES       2
+#define NO_OF_SAMPLES       15
 #define ATTENUATION         ADC_ATTEN_DB_11
 #if defined(CONFIG_IDF_TARGET_ESP32)
 #define DATA_WIDTH          ADC_BITWIDTH_12
@@ -231,7 +231,8 @@ float common_hal_analogio_analogin_get_voltage(analogio_analogin_obj_t *self) {
         adc_cali_delete_scheme_line_fitting(calibration);
     }
     #endif
-    return (float)voltage / 1000.0;
+    adc_oneshot_del_unit(adc_handle);
+    return voltage / 1000.0f;
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {

--- a/ports/espressif/common-hal/analogio/AnalogIn.c
+++ b/ports/espressif/common-hal/analogio/AnalogIn.c
@@ -151,6 +151,89 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     return voltage * ((1 << 16) - 1) / 3300;
 }
 
+float common_hal_analogio_analogin_get_voltage(analogio_analogin_obj_t *self) {
+    adc_oneshot_unit_handle_t adc_handle;
+    adc_oneshot_unit_init_cfg_t adc_config = {
+        .unit_id = self->pin->adc_index,
+        .ulp_mode = ADC_ULP_MODE_DISABLE
+    };
+    CHECK_ESP_RESULT(adc_oneshot_new_unit(&adc_config, &adc_handle));
+
+    adc_oneshot_chan_cfg_t channel_config = {
+        .atten = ATTENUATION,
+        .bitwidth = DATA_WIDTH
+    };
+    adc_channel_t channel = (adc_channel_t)self->pin->adc_channel;
+    adc_oneshot_config_channel(adc_handle, channel, &channel_config);
+
+    adc_cali_scheme_ver_t supported_schemes;
+    adc_cali_check_scheme(&supported_schemes);
+    adc_cali_scheme_ver_t calibration_scheme = 0;
+    adc_cali_handle_t calibration;
+
+    #if defined(ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED) && ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+    adc_cali_curve_fitting_config_t config = {
+        .unit_id = self->pin->adc_index,
+        .chan = channel,
+        .atten = ATTENUATION,
+        .bitwidth = DATA_WIDTH
+    };
+    if (adc_cali_create_scheme_curve_fitting(&config, &calibration) == ESP_OK) {
+        calibration_scheme = ADC_CALI_SCHEME_VER_CURVE_FITTING;
+    }
+    #endif
+    #if defined(ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED) && ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+    if (calibration_scheme == 0) {
+        adc_cali_line_fitting_config_t config = {
+            .unit_id = self->pin->adc_index,
+            .atten = ATTENUATION,
+            .bitwidth = DATA_WIDTH,
+            #ifdef CONFIG_IDF_TARGET_ESP32
+            .default_vref = DEFAULT_VREF,
+            #endif
+        };
+        if (adc_cali_create_scheme_line_fitting(&config, &calibration) == ESP_OK) {
+            calibration_scheme = ADC_CALI_SCHEME_VER_LINE_FITTING;
+        }
+    }
+    #endif
+
+    uint32_t adc_reading = 0;
+    size_t sample_count = 0;
+    // Multisampling
+    esp_err_t ret = ESP_OK;
+    for (int i = 0; i < NO_OF_SAMPLES; i++) {
+        int raw;
+        ret = adc_oneshot_read(adc_handle, channel, &raw);
+        if (ret != ESP_OK) {
+            continue;
+        }
+        adc_reading += raw;
+        sample_count += 1;
+    }
+    if (sample_count == 0) {
+        raise_esp_error(ret);
+    }
+    adc_reading /= sample_count;
+
+    // This corrects non-linear regions of the ADC range with a LUT, so it's a better reading than raw
+    int voltage;
+    adc_cali_raw_to_voltage(calibration, adc_reading, &voltage);
+
+
+    #if defined(ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED) && ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+    if (calibration_scheme == ADC_CALI_SCHEME_VER_CURVE_FITTING) {
+        adc_cali_delete_scheme_curve_fitting(calibration);
+    }
+    #endif
+    #if defined(ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED) && ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+    if (calibration_scheme == ADC_CALI_SCHEME_VER_LINE_FITTING) {
+        adc_cali_delete_scheme_line_fitting(calibration);
+    }
+    #endif
+    return (float)voltage / 1000.0;
+}
+
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {
     return 3.3f;
 }

--- a/ports/espressif/common-hal/analogio/AnalogIn.c
+++ b/ports/espressif/common-hal/analogio/AnalogIn.c
@@ -67,7 +67,7 @@ void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self) {
     self->pin = NULL;
 }
 
-uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
+uint16_t common_hal_analogio_analogin_get_millivolts(analogio_analogin_obj_t *self) {
     adc_oneshot_unit_handle_t adc_handle;
     adc_oneshot_unit_init_cfg_t adc_config = {
         .unit_id = self->pin->adc_index,
@@ -148,91 +148,14 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     }
     #endif
     adc_oneshot_del_unit(adc_handle);
-    return voltage * ((1 << 16) - 1) / 3300;
+    return voltage;
+}
+uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
+    return common_hal_analogio_analogin_get_millivolts(self) * ((1 << 16) - 1) / 3300;
 }
 
 float common_hal_analogio_analogin_get_voltage(analogio_analogin_obj_t *self) {
-    adc_oneshot_unit_handle_t adc_handle;
-    adc_oneshot_unit_init_cfg_t adc_config = {
-        .unit_id = self->pin->adc_index,
-        .ulp_mode = ADC_ULP_MODE_DISABLE
-    };
-    CHECK_ESP_RESULT(adc_oneshot_new_unit(&adc_config, &adc_handle));
-
-    adc_oneshot_chan_cfg_t channel_config = {
-        .atten = ATTENUATION,
-        .bitwidth = DATA_WIDTH
-    };
-    adc_channel_t channel = (adc_channel_t)self->pin->adc_channel;
-    adc_oneshot_config_channel(adc_handle, channel, &channel_config);
-
-    adc_cali_scheme_ver_t supported_schemes;
-    adc_cali_check_scheme(&supported_schemes);
-    adc_cali_scheme_ver_t calibration_scheme = 0;
-    adc_cali_handle_t calibration;
-
-    #if defined(ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED) && ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
-    adc_cali_curve_fitting_config_t config = {
-        .unit_id = self->pin->adc_index,
-        .chan = channel,
-        .atten = ATTENUATION,
-        .bitwidth = DATA_WIDTH
-    };
-    if (adc_cali_create_scheme_curve_fitting(&config, &calibration) == ESP_OK) {
-        calibration_scheme = ADC_CALI_SCHEME_VER_CURVE_FITTING;
-    }
-    #endif
-    #if defined(ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED) && ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
-    if (calibration_scheme == 0) {
-        adc_cali_line_fitting_config_t config = {
-            .unit_id = self->pin->adc_index,
-            .atten = ATTENUATION,
-            .bitwidth = DATA_WIDTH,
-            #ifdef CONFIG_IDF_TARGET_ESP32
-            .default_vref = DEFAULT_VREF,
-            #endif
-        };
-        if (adc_cali_create_scheme_line_fitting(&config, &calibration) == ESP_OK) {
-            calibration_scheme = ADC_CALI_SCHEME_VER_LINE_FITTING;
-        }
-    }
-    #endif
-
-    uint32_t adc_reading = 0;
-    size_t sample_count = 0;
-    // Multisampling
-    esp_err_t ret = ESP_OK;
-    for (int i = 0; i < NO_OF_SAMPLES; i++) {
-        int raw;
-        ret = adc_oneshot_read(adc_handle, channel, &raw);
-        if (ret != ESP_OK) {
-            continue;
-        }
-        adc_reading += raw;
-        sample_count += 1;
-    }
-    if (sample_count == 0) {
-        raise_esp_error(ret);
-    }
-    adc_reading /= sample_count;
-
-    // This corrects non-linear regions of the ADC range with a LUT, so it's a better reading than raw
-    int voltage;
-    adc_cali_raw_to_voltage(calibration, adc_reading, &voltage);
-
-
-    #if defined(ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED) && ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
-    if (calibration_scheme == ADC_CALI_SCHEME_VER_CURVE_FITTING) {
-        adc_cali_delete_scheme_curve_fitting(calibration);
-    }
-    #endif
-    #if defined(ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED) && ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
-    if (calibration_scheme == ADC_CALI_SCHEME_VER_LINE_FITTING) {
-        adc_cali_delete_scheme_line_fitting(calibration);
-    }
-    #endif
-    adc_oneshot_del_unit(adc_handle);
-    return voltage / 1000.0f;
+    return common_hal_analogio_analogin_get_millivolts(self) / 1000.0f;
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {

--- a/ports/mimxrt10xx/common-hal/analogio/AnalogIn.c
+++ b/ports/mimxrt10xx/common-hal/analogio/AnalogIn.c
@@ -51,6 +51,11 @@ void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self) {
     self->pin = NULL;
 }
 
+uint16_t common_hal_analogio_analogin_get_millivolts(analogio_analogin_obj_t *self) {
+    // Unused in mimxrt10xx
+    return 0;
+}
+
 uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     adc_channel_config_t config = { 0 };
     config.channelNumber = self->pin->adc_channel;
@@ -65,6 +70,10 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
 
     // Stretch 12-bit ADC reading to 16-bit range
     return (value << 4) | (value >> 8);
+}
+
+float common_hal_analogio_analogin_get_voltage(analogio_analogin_obj_t *self) {
+    return (float)common_hal_analogio_analogin_get_value(self) * (3.3f / 65535.0f);
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {

--- a/ports/nordic/common-hal/analogio/AnalogIn.c
+++ b/ports/nordic/common-hal/analogio/AnalogIn.c
@@ -52,6 +52,12 @@ void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self) {
     self->pin = NULL;
 }
 
+
+uint16_t common_hal_analogio_analogin_get_millivolts(analogio_analogin_obj_t *self) {
+    // Unused on nordic.
+    return 0;
+}
+
 uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     // Something else might have used the ADC in a different way,
     // so we completely re-initialize it.
@@ -117,6 +123,10 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
 
     // Stretch 14-bit ADC reading to 16-bit range
     return (value << 2) | (value >> 12);
+}
+
+float common_hal_analogio_analogin_get_voltage(analogio_analogin_obj_t *self) {
+    return (float)common_hal_analogio_analogin_get_value(self) * (3.3f / 65535.0f);
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {

--- a/ports/raspberrypi/common-hal/analogio/AnalogIn.c
+++ b/ports/raspberrypi/common-hal/analogio/AnalogIn.c
@@ -80,6 +80,10 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     return (value << 4) | (value >> 8);
 }
 
+float common_hal_analogio_analogin_get_voltage(analogio_analogin_obj_t *self) {
+    return (float)common_hal_analogio_analogin_get_value(self) * (3.3f / 65535.0f);
+}
+
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {
     // The nominal VCC voltage
     return 3.3f;

--- a/ports/raspberrypi/common-hal/analogio/AnalogIn.c
+++ b/ports/raspberrypi/common-hal/analogio/AnalogIn.c
@@ -58,6 +58,10 @@ void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self) {
     self->pin = NULL;
 }
 
+uint16_t common_hal_analogio_analogin_get_millivolts(analogio_analogin_obj_t *self) {
+    // Unused on rp2.
+    return 0;
+}
 uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     uint16_t value;
     if (SPECIAL_PIN(self->pin)) {

--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -112,7 +112,8 @@ MP_PROPERTY_GETTER(analogio_analogin_value_obj,
 static mp_obj_t analogio_analogin_obj_get_voltage(mp_obj_t self_in) {
     analogio_analogin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
-    return MP_OBJ_NEW_FLOAT(common_hal_analogio_analogin_get_voltage(self));
+    float voltage_val = common_hal_analogio_analogin_get_voltage(self);
+    return mp_obj_new_float(voltage_val);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(analogio_analogin_get_voltage_obj, analogio_analogin_obj_get_voltage);
 

--- a/shared-bindings/analogio/AnalogIn.c
+++ b/shared-bindings/analogio/AnalogIn.c
@@ -105,6 +105,21 @@ MP_DEFINE_CONST_FUN_OBJ_1(analogio_analogin_get_value_obj, analogio_analogin_obj
 MP_PROPERTY_GETTER(analogio_analogin_value_obj,
     (mp_obj_t)&analogio_analogin_get_value_obj);
 
+//|     voltage: float
+//|     """The voltage value on the analog pin between 0.0 and reference_voltage as a
+//|     ``float`` in volts."""
+//|
+static mp_obj_t analogio_analogin_obj_get_voltage(mp_obj_t self_in) {
+    analogio_analogin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    check_for_deinit(self);
+    return MP_OBJ_NEW_FLOAT(common_hal_analogio_analogin_get_voltage(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(analogio_analogin_get_voltage_obj, analogio_analogin_obj_get_voltage);
+
+MP_PROPERTY_GETTER(analogio_analogin_voltage_obj,
+    (mp_obj_t)&analogio_analogin_get_voltage_obj);
+
+
 //|     reference_voltage: float
 //|     """The maximum voltage measurable (also known as the reference voltage) as a
 //|     ``float`` in Volts.  Note the ADC value may not scale to the actual voltage linearly
@@ -132,6 +147,7 @@ static const mp_rom_map_elem_t analogio_analogin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___enter__),          MP_ROM_PTR(&default___enter___obj) },
     { MP_ROM_QSTR(MP_QSTR___exit__),           MP_ROM_PTR(&analogio_analogin___exit___obj) },
     { MP_ROM_QSTR(MP_QSTR_value),              MP_ROM_PTR(&analogio_analogin_value_obj)},
+    { MP_ROM_QSTR(MP_QSTR_voltage),            MP_ROM_PTR(&analogio_analogin_voltage_obj)},
     { MP_ROM_QSTR(MP_QSTR_reference_voltage),  MP_ROM_PTR(&analogio_analogin_reference_voltage_obj)},
 };
 

--- a/shared-bindings/analogio/AnalogIn.h
+++ b/shared-bindings/analogio/AnalogIn.h
@@ -16,4 +16,5 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self, const
 void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self);
 bool common_hal_analogio_analogin_deinited(analogio_analogin_obj_t *self);
 uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self);
+float common_hal_analogio_analogin_get_voltage(analogio_analogin_obj_t *self);
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self);

--- a/shared-bindings/analogio/AnalogIn.h
+++ b/shared-bindings/analogio/AnalogIn.h
@@ -16,5 +16,6 @@ void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self, const
 void common_hal_analogio_analogin_deinit(analogio_analogin_obj_t *self);
 bool common_hal_analogio_analogin_deinited(analogio_analogin_obj_t *self);
 uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self);
+uint16_t common_hal_analogio_analogin_get_millivolts(analogio_analogin_obj_t *self);
 float common_hal_analogio_analogin_get_voltage(analogio_analogin_obj_t *self);
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self);


### PR DESCRIPTION
With this PR I intend to expose the calibrated voltage read on espressif mcus and provide directly converted voltages for the rest of the ports.

Why? Espressif ADC is not as accurate as I want it to be for voltage readouts.
The ESP-IDF already provides the reading to millivolts, so why convert to 16bit uint and then back to volts?

For the rest of the ports that don't have a calibrated way the raw ADC reading to millivolts, the conversion is done faithfully in software. This would allow the users to not have to do the calculations in python.
The readings of Espressif, RP2 and Nordic were verified against a digital multimeter.
(As a reminder for anyone who wishes to verify this, ESP32-SX and C3 are not very good above ~2.8V, the readings peak early. To verify full 3v3 function please try it on a C6 where all the readings are perfect.)

Additionally through testing I verified that Espressif ADC reads were fairly inaccurate at 2 samples (even at 1.5V), so I increased the number of samples (I incrementally increased, I didn't just say 15). It's now consistently pulling readings with +-0.05 precision. There is no noticable polling delay. I do think it's better to increase the number of reads here, as python `for` is notoriously slow. And if the app has to do it either way (since.. it's +-0.3 with 2 samples) it's better to have it in C since the code for it is there already.

Implementation checklist (only those that have analogio as listed):
 - [x] Espressif
 - [x] RP2
 - [x] Nordic
 - [x] SAMD
 - [x] cxd56
 - [x] mimxrt10xx
 - [ ] silabs
 - [ ] stm
 - [ ] unix

Maybe it's also worth adding sampling to all ports for more stable reads.