### PR TITLE
remove definition of board_display_obj

### DIFF
--- a/ports/atmel-samd/boards/hallowing_m0_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m0_express/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/busio/SPI.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/atmel-samd/boards/hallowing_m4_express/board.c
+++ b/ports/atmel-samd/boards/hallowing_m4_express/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/atmel-samd/boards/monster_m4sk/board.c
+++ b/ports/atmel-samd/boards/monster_m4sk/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/atmel-samd/boards/openbook_m4/board.c
+++ b/ports/atmel-samd/boards/openbook_m4/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 #define HEIGHT 400

--- a/ports/atmel-samd/boards/pewpew_lcd/board.c
+++ b/ports/atmel-samd/boards/pewpew_lcd/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/atmel-samd/boards/pewpew_m4/board.c
+++ b/ports/atmel-samd/boards/pewpew_m4/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 typedef struct {
     const uint32_t *config_data;

--- a/ports/atmel-samd/boards/pygamer/board.c
+++ b/ports/atmel-samd/boards/pygamer/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "supervisor/shared/board.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/atmel-samd/boards/seeeduino_wio_terminal/board.c
+++ b/ports/atmel-samd/boards/seeeduino_wio_terminal/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/digitalio/DigitalInOut.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 digitalio_digitalinout_obj_t CTR_5V;
 digitalio_digitalinout_obj_t CTR_3V3;
 digitalio_digitalinout_obj_t USB_HOST_ENABLE;

--- a/ports/atmel-samd/boards/ugame10/board.c
+++ b/ports/atmel-samd/boards/ugame10/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/busio/SPI.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/espressif/boards/adafruit_esp32s3_camera/board.c
+++ b/ports/espressif/boards/adafruit_esp32s3_camera/board.c
@@ -18,7 +18,6 @@
 #include "esp_err.h"
 #include "driver/i2c.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/espressif/boards/adafruit_feather_esp32s2_reverse_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_reverse_tft/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/espressif/boards/adafruit_feather_esp32s3_reverse_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_reverse_tft/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/espressif/boards/adafruit_funhouse/board.c
+++ b/ports/espressif/boards/adafruit_funhouse/board.c
@@ -15,7 +15,6 @@
 
 #include "esp_log.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/espressif/boards/espressif_esp32s3_eye/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_eye/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/espressif/boards/hexky_s2/board.c
+++ b/ports/espressif/boards/hexky_s2/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/espressif/boards/m5stack_atoms3/board.c
+++ b/ports/espressif/boards/m5stack_atoms3/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/espressif/boards/m5stack_cardputer/board.c
+++ b/ports/espressif/boards/m5stack_cardputer/board.c
@@ -22,7 +22,6 @@
 #include "py/ringbuf.h"
 #include "shared/runtime/interrupt_char.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 keypad_demux_demuxkeymatrix_obj_t board_keyboard;
 
 void update_keyboard(keypad_eventqueue_obj_t *queue);

--- a/ports/espressif/boards/m5stack_core2/board.c
+++ b/ports/espressif/boards/m5stack_core2/board.c
@@ -21,7 +21,6 @@
 
 #include "../../pmic/axp192/axp192.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 #define PMIC_POWER_SOURCE_USB   0

--- a/ports/espressif/boards/m5stack_core_basic/board.c
+++ b/ports/espressif/boards/m5stack_core_basic/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 
 // display init sequence according to M5Gfx

--- a/ports/espressif/boards/m5stack_core_fire/board.c
+++ b/ports/espressif/boards/m5stack_core_fire/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 
 // display init sequence according to M5Gfx

--- a/ports/espressif/boards/m5stack_cores3/board.c
+++ b/ports/espressif/boards/m5stack_cores3/board.c
@@ -14,7 +14,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 #define AXP2101_I2C_ADDRESS 0x34

--- a/ports/espressif/boards/m5stack_dial/board.c
+++ b/ports/espressif/boards/m5stack_dial/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 uint8_t display_init_sequence[] = {
     0xFE, 0x00, // Inter Register Enable1 (FEh)

--- a/ports/espressif/boards/waveshare_esp32_s3_geek/board.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_geek/board.c
@@ -14,7 +14,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 
 

--- a/ports/nordic/boards/clue_nrf52840_express/board.c
+++ b/ports/nordic/boards/clue_nrf52840_express/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/nordic/boards/hiibot_bluefi/board.c
+++ b/ports/nordic/boards/hiibot_bluefi/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/nordic/boards/makerdiary_nrf52840_m2_devkit/board.c
+++ b/ports/nordic/boards/makerdiary_nrf52840_m2_devkit/board.c
@@ -13,7 +13,6 @@
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/nordic/boards/ohs2020_badge/board.c
+++ b/ports/nordic/boards/ohs2020_badge/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/raspberrypi/boards/adafruit_floppsy_rp2040/board.c
+++ b/ports/raspberrypi/boards/adafruit_floppsy_rp2040/board.c
@@ -14,7 +14,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/board/__init__.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/raspberrypi/boards/adafruit_macropad_rp2040/board.c
+++ b/ports/raspberrypi/boards/adafruit_macropad_rp2040/board.c
@@ -14,7 +14,6 @@
 #include "supervisor/board.h"
 #include "supervisor/shared/board.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/raspberrypi/boards/hack_club_sprig/board.c
+++ b/ports/raspberrypi/boards/hack_club_sprig/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "supervisor/shared/board.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 // display init sequence from CircuitPython library https://github.com/adafruit/Adafruit_CircuitPython_ST7735R/blob/dfae353330cf051d1f31db9e4b681c8d70900cc5/adafruit_st7735r.py
 uint8_t display_init_sequence[] = {

--- a/ports/raspberrypi/boards/heiafr_picomo_v2/board.c
+++ b/ports/raspberrypi/boards/heiafr_picomo_v2/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "supervisor/shared/board.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/raspberrypi/boards/pajenicko_picopad/board.c
+++ b/ports/raspberrypi/boards/pajenicko_picopad/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "supervisor/shared/board.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/raspberrypi/boards/pimoroni_picosystem/board.c
+++ b/ports/raspberrypi/boards/pimoroni_picosystem/board.c
@@ -12,7 +12,6 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "supervisor/shared/board.h"
 
-fourwire_fourwire_obj_t board_display_obj;
 
 #define DELAY 0x80
 

--- a/ports/raspberrypi/boards/waveshare_rp2040_geek/board.c
+++ b/ports/raspberrypi/boards/waveshare_rp2040_geek/board.c
@@ -14,7 +14,6 @@
 
 #define DELAY 0x80
 
-fourwire_fourwire_obj_t board_display_obj;
 
 // display init sequence according to https://github.com/adafruit/Adafruit_CircuitPython_ST7789
 uint8_t display_init_sequence[] = {


### PR DESCRIPTION
This removes definitions of the otherwise unused variable `board_display_obj` in 36 `board.c` files.

Fixes #9283