### PR TITLE
Use micropython-uncrustify from pypi instead of apt package

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y gettext uncrustify
+        sudo apt-get install -y gettext
     - name: Run pre-commit
       uses: pre-commit/action@v3.0.1
     - name: Make patch

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,6 +17,7 @@ polib
 black
 pyyaml
 pre-commit
+micropython-uncrustify
 
 # for combining the Nordic SoftDevice with CircuitPython
 intelhex

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,3 +36,6 @@ jsmin
 # for Silicon Labs Configurator (SLC)
 websockets
 colorama
+
+# for silabs builds
+setuptools


### PR DESCRIPTION
MicroPython depends on a particular version of `uncrustify` to format its C code. This version is available from https://launchpad.net/~pybricks/+archive/ubuntu/ppa, but not for Ubuntu 24.04. A `.deb` from a previous version could be installed, but that's not necessarily a long-term solution. (The long-term solution is to update to a newer version of uncrustify.)

See https://github.com/orgs/micropython/discussions/14496 for background.

The maintainer of that PPA has now created a PyPi package for that version of `uncrustify`: https://pypi.org/project/micropython-uncrustify/. The repo for that is here: https://github.com/dlech/micropython-uncrustify.

This PR switches to installing that uncrustify by putting it in `requirements-dev.txt`.

If and when MicroPython switches to a newer uncrustify, we can undo this.