### PR TITLE
Correct custom board build branch logic

### DIFF
--- a/.github/workflows/build-board-custom.yml
+++ b/.github/workflows/build-board-custom.yml
@@ -50,7 +50,11 @@ jobs:
         git remote add fork https://github.com/${{github.repository}}.git
         git fetch fork --filter=tree:0
     - name: branch compatibility
-      if: inputs.branch != '' && inputs.version == 'latest'
+      if: inputs.branch != 'main' && inputs.version == 'latest' && github.repository_owner == 'adafruit'
+      run: |
+        git checkout ${{inputs.branch}}
+    - name: branch compatibility (fork)
+      if: inputs.branch != '' && inputs.version == 'latest' && github.repository_owner != 'adafruit'
       run: |
         git checkout -b fork-branch fork/${{inputs.branch}}
     - name: Set up identifier


### PR DESCRIPTION
Sorry Dan, I was initially under the impression I didn't have push ability to adafruit/circuitpython so I couldn't test it running with the adafruit repo owner. I did obviously test it against forks. 
Turned out I mised something in the logic for branches when not a fork, so I've now resolved it and tested and it runs on adafruit repo fine.