### PR TITLE
Update readme to show the support status of the new esps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,9 +223,10 @@ Ports
 
 Ports include the code unique to a microcontroller line.
 
-The following ports are available: ``atmel-samd``, ``cxd56``, ``espressif``, ``litex``, ``mimxrt10xx``, ``nordic``, ``raspberrypi``, ``silabs`` (``efr32``), ``stm``, ``unix``.
+The following ports are available: ``atmel-samd``, ``cxd56``, ``espressif``, ``litex``, ``mimxrt10xx``, ``nordic``, ``raspberrypi``, ``renode``, ``silabs`` (``efr32``), ``stm``, ``unix``.
 
-However they are not all stable. For details, refer to the `latest release <https://github.com/adafruit/circuitpython/releases/latest>`__ notes.
+However, not all ports are not fully functional. Some have limited limited functionality and known serious bugs.
+For details, refer to the **Port status** section in the `latest release <https://github.com/adafruit/circuitpython/releases/latest>`__ notes.
 
 Boards
 ~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,7 @@ Ports include the code unique to a microcontroller line.
 
 The following ports are available: ``atmel-samd``, ``cxd56``, ``espressif``, ``litex``, ``mimxrt10xx``, ``nordic``, ``raspberrypi``, ``renode``, ``silabs`` (``efr32``), ``stm``, ``unix``.
 
-However, not all ports are not fully functional. Some have limited limited functionality and known serious bugs.
+However, not all ports are fully functional. Some have limited limited functionality and known serious bugs.
 For details, refer to the **Port status** section in the `latest release <https://github.com/adafruit/circuitpython/releases/latest>`__ notes.
 
 Boards

--- a/README.rst
+++ b/README.rst
@@ -223,26 +223,9 @@ Ports
 
 Ports include the code unique to a microcontroller line.
 
-================  ============================================================
-Supported         Support status
-================  ============================================================
-atmel-samd        ``SAMD21`` stable | ``SAMD51`` stable
-cxd56             stable
-espressif         ``ESP32`` beta | ``ESP32-H2`` alpha
-..                ``ESP32-C2`` alpha | ``ESP32-C3`` beta | ``ESP32-C6`` beta
-..                ``ESP32-S2`` stable | ``ESP32-S3`` stable
-litex             alpha
-mimxrt10xx        alpha
-nordic            stable
-raspberrypi       stable
-silabs (efr32)    alpha
-stm               ``F4`` stable | ``others`` beta
-unix              alpha
-================  ============================================================
+The following ports are available: ``atmel-samd``, ``cxd56``, ``espressif``, ``litex``, ``mimxrt10xx``, ``nordic``, ``raspberrypi``, ``silabs`` (``efr32``), ``stm``, ``unix``.
 
--  ``stable`` Highly unlikely to have bugs or missing functionality.
--  ``beta``   Being actively improved but may be missing functionality and have bugs.
--  ``alpha``  Will have bugs and missing functionality.
+However they are not all stable. For details, refer to the `latest release <https://github.com/adafruit/circuitpython/releases/latest>`__ notes.
 
 Boards
 ~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -228,7 +228,9 @@ Supported         Support status
 ================  ============================================================
 atmel-samd        ``SAMD21`` stable | ``SAMD51`` stable
 cxd56             stable
-espressif         ``ESP32`` beta | ``ESP32-C3`` beta | ``ESP32-S2`` stable | ``ESP32-S3`` beta
+espressif         ``ESP32`` beta | ``ESP32-H2`` alpha
+..                ``ESP32-C2`` alpha | ``ESP32-C3`` beta | ``ESP32-C6`` beta
+..                ``ESP32-S2`` stable | ``ESP32-S3`` stable
 litex             alpha
 mimxrt10xx        alpha
 nordic            stable


### PR DESCRIPTION
H2 and C2 are alpha.
C2 outright "halts and catches fire" in some of my tests.
Memory/instruction errors, heap errors, all sorts of goodies.
I will be filing issues once I *hopefully* make repro code.

C3 and C6 are still fine being beta.
There is a lot of weirdness that isn't easily reproducible and can't be filed atm.
Also thread/zigbee is not implemented.

S3 is just as stable as S2 and ble is somewhat implemented now right?

OG ESP32 still not stable due to serial.