### PR TITLE
Web workflow: use absolute paths to avoid paths being adjusted by current directory

### DIFF
--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -1261,8 +1261,15 @@ static bool _reply(socketpool_socket_obj_t *socket, _request *request) {
                     _reply_missing(socket, request);
                     return false;
                 }
-                path += strlen(vfs->str);
+                // Check if the vfs name is one character long: it must be "/" in that case.
+                // If so don't remove the mount point name. We must use an absolute path
+                // because otherwise the path will be adjusted by os.getcwd() when it's looked up.
+                if (strlen(vfs->str) != 1) {
+                    // Remove the mount point directory name, such as "/sd".
+                    path += strlen(vfs->str);
+                }
                 pathlen = strlen(path);
+
             }
             FATFS *fs = &fs_mount->fatfs;
             if (directory) {


### PR DESCRIPTION
- Fixes #9053 (opened by @RetiredWizard).

The web workflow was using relative paths internally when adjusting paths at the root `/`. This made them subject to whatever `os.chdir()` had been set to. Instead, use absolute paths to avoid any influence by the current directory.

I tested by doing `os.chdir("/lib")` in the REPL while using the web workflow. Previously this messed up being able to descend into directories or fetch files. Now it seems to work fine.