### PR TITLE
Rotate display on Sunton ESP32 2432S028

### DIFF
--- a/ports/espressif/boards/sunton_esp32_2432S028/board.c
+++ b/ports/espressif/boards/sunton_esp32_2432S028/board.c
@@ -65,7 +65,7 @@ static void display_init(void) {
         240, // Height
         0, // column start
         0, // row start
-        0, // rotation
+        270, // rotation
         16, // Color depth
         false, // Grayscale
         false, // pixels in a byte share a row. Only valid for depths < 8


### PR DESCRIPTION
The display is 240w x 320h. We could swap the width and height, or rotate it by 270 degrees.

### Before
![PXL_20240616_002411510](https://github.com/adafruit/circuitpython/assets/140330290/faf4138e-f55d-4c15-9b7e-0fa1c9af9c58)

### After
![PXL_20240616_010042463](https://github.com/adafruit/circuitpython/assets/140330290/014b8911-2ad0-489e-a419-cbf7481a269b)
