### PR TITLE
Fix display power on Adafruit ESP32-S3 Reverse TFT Feather

### DIFF
--- a/ports/espressif/boards/adafruit_feather_esp32s2_reverse_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_reverse_tft/board.c
@@ -101,10 +101,10 @@ void board_init(void) {
 
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Override the I2C/TFT power pin reset to prevent resetting the display.
-    if (pin_number == 21) {
+    if (pin_number == 7) {
         // Turn on TFT and I2C
-        gpio_set_direction(21, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(21, true);
+        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
+        gpio_set_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/adafruit_feather_esp32s3_reverse_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_reverse_tft/board.c
@@ -101,10 +101,10 @@ void board_init(void) {
 
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Override the I2C/TFT power pin reset to prevent resetting the display.
-    if (pin_number == 21) {
+    if (pin_number == 7) {
         // Turn on TFT and I2C
-        gpio_set_direction(21, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(21, true);
+        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
+        gpio_set_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
@@ -103,8 +103,8 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Override the I2C/TFT power pin reset to prevent resetting the display.
     if (pin_number == 21) {
         // Turn on TFT and I2C
-        gpio_set_direction(21, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(21, true);
+        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
+        gpio_set_level(pin_number, true);
         return true;
     }
     return false;


### PR DESCRIPTION
I got this board over the weekend and was unable to get anything out of the display in CircuitPython (8.2.7, 9.0.5, and 9.1.0-beta.3) but I knew the display worked fine because both the UF2 boot loader and Arduino example code for the board could display things. I ended up figuring out that the Arduino board definition was forcing the I2C power pin high, but the CircuitPython definition was forcing the NeoPixel power pin high. I confirmed this using the [pin assignment diagram](https://learn.adafruit.com/assets/123891) on the Adafruit website as well.

I was able to force the correct pin (7) high in my `code.py` and get the display to turn on, but because it wasn't done prior to the init commands, it was just showing garbage.

After making this change in the board definition, I can see the CircuitPython console go by on the display, and – more importantly – the display works correctly and I no longer need to force pin 7 high in my own code. The NeoPixel also appears to continue to work correctly.