### PR TITLE
CIRCUITPY_DEFAULT_WIFI_TX_POWER

### DIFF
--- a/ports/espressif/boards/lolin_c3_mini/mpconfigboard.h
+++ b/ports/espressif/boards/lolin_c3_mini/mpconfigboard.h
@@ -26,3 +26,6 @@
 
 #define CIRCUITPY_BOARD_UART        (1)
 #define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO21, .rx = &pin_GPIO20}}
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_REDUCE_TX_POWER   (1)

--- a/ports/espressif/boards/lolin_c3_mini/mpconfigboard.h
+++ b/ports/espressif/boards/lolin_c3_mini/mpconfigboard.h
@@ -28,4 +28,4 @@
 #define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO21, .rx = &pin_GPIO20}}
 
 // Reduce wifi.radio.tx_power due to the antenna design of this board
-#define CIRCUITPY_REDUCE_TX_POWER   (1)
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (11.0)

--- a/ports/espressif/boards/makergo_esp32c3_supermini/mpconfigboard.h
+++ b/ports/espressif/boards/makergo_esp32c3_supermini/mpconfigboard.h
@@ -24,4 +24,4 @@
 #define CIRCUITPY_BOARD_SPI_PIN     {{.clock = &pin_GPIO4, .mosi = &pin_GPIO6, .miso = &pin_GPIO5}}
 
 // Reduce wifi.radio.tx_power due to the antenna design of this board
-#define CIRCUITPY_REDUCE_TX_POWER   (1)
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (11.0)

--- a/ports/espressif/boards/makergo_esp32c3_supermini/mpconfigboard.h
+++ b/ports/espressif/boards/makergo_esp32c3_supermini/mpconfigboard.h
@@ -22,3 +22,6 @@
 
 #define CIRCUITPY_BOARD_SPI         (1)
 #define CIRCUITPY_BOARD_SPI_PIN     {{.clock = &pin_GPIO4, .mosi = &pin_GPIO6, .miso = &pin_GPIO5}}
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_REDUCE_TX_POWER   (1)

--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -86,9 +86,9 @@ void common_hal_wifi_radio_set_enabled(wifi_radio_obj_t *self, bool enabled) {
     if (!self->started && enabled) {
         ESP_ERROR_CHECK(esp_wifi_start());
         self->started = true;
-        #if CIRCUITPY_REDUCE_TX_POWER
-        common_hal_wifi_radio_set_tx_power(self, 11.0);
-        #endif
+        if (CIRCUITPY_WIFI_DEFAULT_TX_POWER != 20) {
+            common_hal_wifi_radio_set_tx_power(self, CIRCUITPY_WIFI_DEFAULT_TX_POWER);
+        }
         return;
     }
 }

--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -86,6 +86,9 @@ void common_hal_wifi_radio_set_enabled(wifi_radio_obj_t *self, bool enabled) {
     if (!self->started && enabled) {
         ESP_ERROR_CHECK(esp_wifi_start());
         self->started = true;
+        #if CIRCUITPY_REDUCE_TX_POWER
+        common_hal_wifi_radio_set_tx_power(self, 11.0);
+        #endif
         return;
     }
 }

--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -86,9 +86,7 @@ void common_hal_wifi_radio_set_enabled(wifi_radio_obj_t *self, bool enabled) {
     if (!self->started && enabled) {
         ESP_ERROR_CHECK(esp_wifi_start());
         self->started = true;
-        if (CIRCUITPY_WIFI_DEFAULT_TX_POWER != 20) {
-            common_hal_wifi_radio_set_tx_power(self, CIRCUITPY_WIFI_DEFAULT_TX_POWER);
-        }
+        common_hal_wifi_radio_set_tx_power(self, CIRCUITPY_WIFI_DEFAULT_TX_POWER);
         return;
     }
 }

--- a/ports/espressif/mpconfigport.h
+++ b/ports/espressif/mpconfigport.h
@@ -60,8 +60,8 @@ extern portMUX_TYPE background_task_mutex;
 #define CALLBACK_CRITICAL_BEGIN (taskENTER_CRITICAL(&background_task_mutex))
 #define CALLBACK_CRITICAL_END (taskEXIT_CRITICAL(&background_task_mutex))
 
-// Reduce wifi radio power
-// Only for boards with imperfect radio designs
-#ifndef CIRCUITPY_REDUCE_TX_POWER
-#define CIRCUITPY_REDUCE_TX_POWER (0)
+// 20 dBm is the default and the highest max tx power.
+// Allow a different value to be specified for boards that have trouble with using the maximum power.
+#ifndef CIRCUITPY_WIFI_DEFAULT_TX_POWER
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER (20)
 #endif

--- a/ports/espressif/mpconfigport.h
+++ b/ports/espressif/mpconfigport.h
@@ -59,3 +59,9 @@
 extern portMUX_TYPE background_task_mutex;
 #define CALLBACK_CRITICAL_BEGIN (taskENTER_CRITICAL(&background_task_mutex))
 #define CALLBACK_CRITICAL_END (taskEXIT_CRITICAL(&background_task_mutex))
+
+// Reduce wifi radio power
+// Only for boards with imperfect radio designs
+#ifndef CIRCUITPY_REDUCE_TX_POWER
+#define CIRCUITPY_REDUCE_TX_POWER (0)
+#endif


### PR DESCRIPTION
Alternative to #9357.
Fixes #9235.