### PR TITLE
circuitpython_setboard support py39

### DIFF
--- a/tools/board_stubs/circuitpython_setboard/__init__.py
+++ b/tools/board_stubs/circuitpython_setboard/__init__.py
@@ -7,8 +7,6 @@ import sys
 import shutil
 import site
 from collections import defaultdict
-from importlib import resources
-from importlib.abc import Traversable
 
 
 def get_definitions_or_exit(board: str) -> str:


### PR DESCRIPTION
resolves: #9363 

Removed usage of importlib.resources opting for `os.path.join`, `os.listdir`, and `site.getsitepackages` to serve the same function in the code.