### PR TITLE
enforce min py3.9 for setboard. create init.py in board-stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,7 @@ stubs:
 	@$(PYTHON) tools/board_stubs/build_board_specific_stubs/board_stub_builder.py
 	@cp -r tools/board_stubs/circuitpython_setboard circuitpython-stubs/circuitpython_setboard
 	@$(PYTHON) -m build circuitpython-stubs
+	@touch circuitpython-stubs/board/__init__.py
 
 .PHONY: check-stubs
 check-stubs: stubs

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,7 @@ stubs:
 	@cp -r tools/board_stubs/circuitpython_setboard circuitpython-stubs/circuitpython_setboard
 	@$(PYTHON) -m build circuitpython-stubs
 	@touch circuitpython-stubs/board/__init__.py
+	@touch circuitpython-stubs/board_definitions/__init__.py
 
 .PHONY: check-stubs
 check-stubs: stubs

--- a/tools/board_stubs/circuitpython_setboard/__init__.py
+++ b/tools/board_stubs/circuitpython_setboard/__init__.py
@@ -1,8 +1,14 @@
 # SPDX-FileCopyrightText: 2024 Tim Cocks
 #
 # SPDX-License-Identifier: MIT
-import argparse
 import sys
+
+version_info = sys.version_info
+if version_info.major < 3 or (version_info.major == 3 and version_info.minor < 9):
+    sys.stdout.write("Python 3.9 is the minimum supported version for board specific stubs.\n")
+    sys.exit(0)
+
+import argparse
 import shutil
 from collections import defaultdict
 from importlib import resources
@@ -35,10 +41,6 @@ def header(txt: str) -> str:
 
 
 def set_board():
-    version_info = sys.version_info
-    if version_info.major < 3 or (version_info.major == 3 and version_info.minor < 9):
-        sys.stdout.write("Python 3.9 is the minimum supported version for board specific stubs.\n")
-        sys.exit(0)
     parser = argparse.ArgumentParser(
         prog=__name__,
         usage="Install CircuitPython board-specific stubs",

--- a/tools/board_stubs/circuitpython_setboard/__init__.py
+++ b/tools/board_stubs/circuitpython_setboard/__init__.py
@@ -35,6 +35,10 @@ def header(txt: str) -> str:
 
 
 def set_board():
+    version_info = sys.version_info
+    if version_info.major < 3 or (version_info.major == 3 and version_info.minor < 9):
+        sys.stdout.write("Python 3.9 is the minimum supported version for board specific stubs.\n")
+        sys.exit(0)
     parser = argparse.ArgumentParser(
         prog=__name__,
         usage="Install CircuitPython board-specific stubs",


### PR DESCRIPTION
resolves: #9363 

Prints a more sensible error message for python version too low (supports min version 3.9)

Creates `__init__.py` inside of `circuitpython-stubs/board/` and `circuitpython-stubs/board_definitions/` at the end of the stubs build which allows `resources.files("board-stubs")` to succeed during `circuitpython_setboard`