### PR TITLE
REDUCE WIFI TX POWER QTPY ESP32-C3

### DIFF
--- a/ports/espressif/boards/adafruit_qtpy_esp32c3/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32c3/mpconfigboard.h
@@ -25,3 +25,6 @@
 
 // For entering safe mode
 #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO9)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)


### PR DESCRIPTION
Configures the QT Py ESP32-C3 to use a reduced radio TX_POWER by default.  Fixes connectivity issues when using WIFI and Web Workflow out of the box.