### PR TITLE
Various Espressif BLE fixes

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2007,6 +2007,10 @@ msgstr ""
 msgid "Too many channels in sample."
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Characteristic.c
+msgid "Too many descriptors"
+msgstr ""
+
 #: shared-module/displayio/__init__.c
 msgid "Too many display busses; forgot displayio.release_displays() ?"
 msgstr ""

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -2219,8 +2219,9 @@ msgstr ""
 msgid "Unsupported hash algorithm"
 msgstr ""
 
+#: ports/espressif/common-hal/_bleio/Adapter.c
 #: ports/espressif/common-hal/dualbank/__init__.c
-msgid "Update Failed"
+msgid "Update failed"
 msgstr ""
 
 #: ports/espressif/common-hal/_bleio/Characteristic.c

--- a/ports/espressif/common-hal/_bleio/Adapter.c
+++ b/ports/espressif/common-hal/_bleio/Adapter.c
@@ -24,6 +24,7 @@
 #include "shared-bindings/_bleio/Connection.h"
 #include "shared-bindings/_bleio/ScanEntry.h"
 #include "shared-bindings/time/__init__.h"
+#include "shared/runtime/interrupt_char.h"
 
 #include "controller/ble_ll_adv.h"
 #include "nimble/hci_common.h"
@@ -47,22 +48,23 @@
 #include "shared-module/os/__init__.h"
 #endif
 
-bleio_connection_internal_t bleio_connections[BLEIO_TOTAL_CONNECTION_COUNT];
+// Status variables used while busy-waiting for events.
+static volatile bool _nimble_sync;
+static volatile int _connection_status;
 
-bool ble_active = false;
+bleio_connection_internal_t bleio_connections[BLEIO_TOTAL_CONNECTION_COUNT];
 
 static void nimble_host_task(void *param) {
     nimble_port_run();
     nimble_port_freertos_deinit();
 }
 
-static TaskHandle_t cp_task = NULL;
 
 static void _on_sync(void) {
     int rc = ble_hs_util_ensure_addr(false);
     assert(rc == 0);
 
-    xTaskNotifyGive(cp_task);
+    _nimble_sync = true;
 }
 
 // All examples have this. It'd make sense in a header.
@@ -133,15 +135,26 @@ void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enable
 
         ble_store_config_init();
 
-        cp_task = xTaskGetCurrentTaskHandle();
-
+        _nimble_sync = false;
         nimble_port_freertos_init(nimble_host_task);
-        // Wait for sync.
-        ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(200));
+        // Wait for sync from nimble task.
+        const uint64_t timeout_time_ms = common_hal_time_monotonic_ms() + 200;
+        while (!_nimble_sync && (common_hal_time_monotonic_ms() < timeout_time_ms)) {
+            RUN_BACKGROUND_TASKS;
+            if (mp_hal_is_interrupted()) {
+                // Return prematurely. Then the interrupt will be raised.
+                return;
+            }
+        }
+
+        if (!_nimble_sync) {
+            mp_raise_RuntimeError(MP_ERROR_TEXT("Update failed"));
+        }
     } else {
         int ret = nimble_port_stop();
-        while (xTaskGetHandle("nimble_host") != NULL) {
-            vTaskDelay(pdMS_TO_TICKS(2));
+        while (xTaskGetHandle("nimble_host") != NULL && !mp_hal_is_interrupted()) {
+            RUN_BACKGROUND_TASKS;
+            common_hal_time_delay_ms(2);
         }
         if (ret == 0) {
             nimble_port_deinit();
@@ -309,14 +322,15 @@ static int _mtu_reply(uint16_t conn_handle,
     if (error->status == 0) {
         connection->mtu = mtu;
     }
-    xTaskNotify(cp_task, conn_handle, eSetValueWithOverwrite);
+    // Set status var to connection handle to report that connection is now established.
+    // Another routine is waiting for this.
+    _connection_status = conn_handle;
     return 0;
 }
 
 static void _new_connection(uint16_t conn_handle) {
     // Set the tx_power for the connection higher than the advertisement.
     esp_ble_tx_power_set(conn_handle, ESP_PWR_LVL_N0);
-
 
     // Find an empty connection. One should always be available because the SD has the same
     // total connection limit.
@@ -353,13 +367,14 @@ static int _connect_event(struct ble_gap_event *event, void *self_in) {
     switch (event->type) {
         case BLE_GAP_EVENT_CONNECT:
             if (event->connect.status == 0) {
-                // This triggers an MTU exchange. Its reply will unblock CP.
+                // This triggers an MTU exchange. Its reply will exit the loop waiting for a connection.
                 _new_connection(event->connect.conn_handle);
                 // Set connections objs back to NULL since we have a new
                 // connection and need a new tuple.
                 self->connection_objs = NULL;
             } else {
-                xTaskNotify(cp_task, -event->connect.status, eSetValueWithOverwrite);
+                // The loop waiting for the connection to be comnpleted will stop when _connection_status changes.
+                _connection_status = -event->connect.status;
             }
             break;
 
@@ -397,24 +412,31 @@ mp_obj_t common_hal_bleio_adapter_connect(bleio_adapter_obj_t *self, bleio_addre
     ble_addr_t addr;
     _convert_address(address, &addr);
 
-    cp_task = xTaskGetCurrentTaskHandle();
-    // Make sure we don't have a pending notification from a previous time. This
-    // can happen if a previous wait timed out before the notification was given.
-    xTaskNotifyStateClear(cp_task);
+    const int timeout_ms = SEC_TO_UNITS(timeout, UNIT_1_MS) + 0.5f;
     CHECK_NIMBLE_ERROR(
         ble_gap_connect(own_addr_type, &addr,
-            SEC_TO_UNITS(timeout, UNIT_1_MS) + 0.5f,
+            timeout_ms,
             &conn_params,
             _connect_event, self));
 
-    int error_code;
     // Wait an extra 50 ms to give the connect method the opportunity to time out.
-    CHECK_NOTIFY(xTaskNotifyWait(0, 0, (uint32_t *)&error_code, pdMS_TO_TICKS(timeout * 1000 + 50)));
-    // Negative values are error codes, connection handle otherwise.
-    if (error_code < 0) {
-        CHECK_BLE_ERROR(-error_code);
+
+    const uint64_t timeout_time_ms = common_hal_time_monotonic_ms() + timeout_ms;
+    // _connection_status gets set to either a positive connection handle or a negative error code.
+    _connection_status = BLEIO_HANDLE_INVALID;
+    while (_connection_status == BLEIO_HANDLE_INVALID && (common_hal_time_monotonic_ms() < timeout_time_ms)) {
+        RUN_BACKGROUND_TASKS;
+        if (mp_hal_is_interrupted()) {
+            // Return prematurely. Then the interrupt exception  will be raised.
+            return mp_const_none;
+        }
     }
-    uint16_t conn_handle = error_code;
+
+    // Negative values are error codes, connection handle otherwise.
+    if (_connection_status < 0) {
+        CHECK_BLE_ERROR(-_connection_status);
+    }
+    const uint16_t conn_handle = _connection_status;
 
     // TODO: If we have keys, then try and encrypt the connection.
 

--- a/ports/espressif/common-hal/_bleio/Characteristic.c
+++ b/ports/espressif/common-hal/_bleio/Characteristic.c
@@ -7,6 +7,7 @@
 #include <string.h>
 
 #include "py/runtime.h"
+#include "shared/runtime/interrupt_char.h"
 
 #include "shared-bindings/_bleio/__init__.h"
 #include "shared-bindings/_bleio/Characteristic.h"
@@ -14,12 +15,38 @@
 #include "shared-bindings/_bleio/Descriptor.h"
 #include "shared-bindings/_bleio/PacketBuffer.h"
 #include "shared-bindings/_bleio/Service.h"
+#include "shared-bindings/time/__init__.h"
 
 #include "common-hal/_bleio/Adapter.h"
 #include "common-hal/_bleio/Service.h"
 
-
 static int characteristic_on_ble_gap_evt(struct ble_gap_event *event, void *param);
+
+static volatile int _completion_status;
+static uint64_t _timeout_start_time;
+
+static void _reset_completion_status(void) {
+    _completion_status = 0;
+}
+
+// Wait for a status change, recorded in a callback.
+// Try twice because sometimes we get a BLE_HS_EAGAIN.
+// Maybe we should try more than twice.
+static int _wait_for_completion(uint32_t timeout_msecs) {
+    for (int tries = 1; tries <= 2; tries++) {
+        _timeout_start_time = common_hal_time_monotonic_ms();
+        while ((_completion_status == 0) &&
+               (common_hal_time_monotonic_ms() < _timeout_start_time + timeout_msecs) &&
+               !mp_hal_is_interrupted()) {
+            RUN_BACKGROUND_TASKS;
+        }
+        if (_completion_status != BLE_HS_EAGAIN) {
+            // Quit, because either the status is either zero (OK) or it's an error.
+            break;
+        }
+    }
+    return _completion_status;
+}
 
 void common_hal_bleio_characteristic_construct(bleio_characteristic_obj_t *self, bleio_service_obj_t *service,
     uint16_t handle, bleio_uuid_obj_t *uuid, bleio_characteristic_properties_t props,
@@ -125,7 +152,6 @@ bleio_service_obj_t *common_hal_bleio_characteristic_get_service(bleio_character
 }
 
 typedef struct {
-    TaskHandle_t task;
     uint8_t *buf;
     uint16_t len;
 } _read_info_t;
@@ -148,9 +174,9 @@ static int _read_cb(uint16_t conn_handle,
             // For debugging.
             mp_printf(&mp_plat_print, "Read status: %d\n", error->status);
             #endif
-            xTaskNotify(read_info->task, error->status, eSetValueWithOverwrite);
             break;
     }
+    _completion_status = error->status;
 
     return 0;
 }
@@ -163,14 +189,12 @@ size_t common_hal_bleio_characteristic_get_value(bleio_characteristic_obj_t *sel
     uint16_t conn_handle = bleio_connection_get_conn_handle(self->service->connection);
     if (common_hal_bleio_service_get_is_remote(self->service)) {
         _read_info_t read_info = {
-            .task = xTaskGetCurrentTaskHandle(),
             .buf = buf,
             .len = len
         };
+        _reset_completion_status();
         CHECK_NIMBLE_ERROR(ble_gattc_read(conn_handle, self->handle, _read_cb, &read_info));
-        int error_code;
-        xTaskNotifyWait(0, 0, (uint32_t *)&error_code, 200);
-        CHECK_BLE_ERROR(error_code);
+        CHECK_NIMBLE_ERROR(_wait_for_completion(2000));
         return read_info.len;
     } else {
         len = MIN(self->current_value_len, len);
@@ -189,8 +213,7 @@ static int _write_cb(uint16_t conn_handle,
     const struct ble_gatt_error *error,
     struct ble_gatt_attr *attr,
     void *arg) {
-    TaskHandle_t task = (TaskHandle_t)arg;
-    xTaskNotify(task, error->status, eSetValueWithOverwrite);
+    _completion_status = error->status;
 
     return 0;
 }
@@ -201,10 +224,9 @@ void common_hal_bleio_characteristic_set_value(bleio_characteristic_obj_t *self,
         if ((self->props & CHAR_PROP_WRITE_NO_RESPONSE) != 0) {
             CHECK_NIMBLE_ERROR(ble_gattc_write_no_rsp_flat(conn_handle, self->handle, bufinfo->buf, bufinfo->len));
         } else {
-            CHECK_NIMBLE_ERROR(ble_gattc_write_flat(conn_handle, self->handle, bufinfo->buf, bufinfo->len, _write_cb, xTaskGetCurrentTaskHandle()));
-            int error_code;
-            xTaskNotifyWait(0, 0, (uint32_t *)&error_code, 200);
-            CHECK_BLE_ERROR(error_code);
+            _reset_completion_status();
+            CHECK_NIMBLE_ERROR(ble_gattc_write_flat(conn_handle, self->handle, bufinfo->buf, bufinfo->len, _write_cb, NULL));
+            CHECK_NIMBLE_ERROR(_wait_for_completion(2000));
         }
     } else {
         // Validate data length for local characteristics only.
@@ -338,6 +360,10 @@ bleio_characteristic_properties_t common_hal_bleio_characteristic_get_properties
 void common_hal_bleio_characteristic_add_descriptor(bleio_characteristic_obj_t *self,
     bleio_descriptor_obj_t *descriptor) {
     size_t i = self->descriptor_list->len;
+    if (i >= MAX_DESCRIPTORS) {
+        mp_raise_bleio_BluetoothError(MP_ERROR_TEXT("Too many descriptors"));
+    }
+
     mp_obj_list_append(MP_OBJ_FROM_PTR(self->descriptor_list),
         MP_OBJ_FROM_PTR(descriptor));
 
@@ -368,10 +394,9 @@ void common_hal_bleio_characteristic_set_cccd(bleio_characteristic_obj_t *self, 
         (notify ? 1 << 0 : 0) |
         (indicate ? 1 << 1: 0);
 
-    CHECK_NIMBLE_ERROR(ble_gattc_write_flat(conn_handle, self->cccd_handle, &cccd_value, 2, _write_cb, xTaskGetCurrentTaskHandle()));
-    int error_code;
-    xTaskNotifyWait(0, 0, (uint32_t *)&error_code, 200);
-    CHECK_BLE_ERROR(error_code);
+    _reset_completion_status();
+    CHECK_NIMBLE_ERROR(ble_gattc_write_flat(conn_handle, self->cccd_handle, &cccd_value, 2, _write_cb, NULL));
+    CHECK_NIMBLE_ERROR(_wait_for_completion(2000));
 }
 
 void bleio_characteristic_set_observer(bleio_characteristic_obj_t *self, mp_obj_t observer) {

--- a/ports/espressif/common-hal/_bleio/Characteristic.c
+++ b/ports/espressif/common-hal/_bleio/Characteristic.c
@@ -61,7 +61,7 @@ void common_hal_bleio_characteristic_construct(bleio_characteristic_obj_t *self,
     self->props = props;
     self->read_perm = read_perm;
     self->write_perm = write_perm;
-    self->observer = NULL;
+    self->observer = mp_const_none;
 
     // Map CP's property values to Nimble's flag values.
     self->flags = 0;

--- a/ports/espressif/common-hal/_bleio/CharacteristicBuffer.c
+++ b/ports/espressif/common-hal/_bleio/CharacteristicBuffer.c
@@ -70,7 +70,6 @@ uint32_t common_hal_bleio_characteristic_buffer_read(bleio_characteristic_buffer
     }
 
     uint32_t num_bytes_read = ringbuf_get_n(&self->ringbuf, data, len);
-
     return num_bytes_read;
 }
 

--- a/ports/espressif/common-hal/_bleio/Connection.c
+++ b/ports/espressif/common-hal/_bleio/Connection.c
@@ -24,6 +24,7 @@
 #include "shared-bindings/_bleio/Characteristic.h"
 #include "shared-bindings/_bleio/Service.h"
 #include "shared-bindings/_bleio/UUID.h"
+#include "shared-bindings/time/__init__.h"
 
 #include "supervisor/shared/tick.h"
 
@@ -31,8 +32,9 @@
 
 #include "host/ble_att.h"
 
-// Give 20 seconds for discovery
-#define DISCOVERY_TIMEOUT_MS 20000
+// Uncomment to turn on debug logging just in this file.
+// #undef CIRCUITPY_VERBOSE_BLE
+// #define CIRCUITPY_VERBOSE_BLE (1)
 
 int bleio_connection_event_cb(struct ble_gap_event *event, void *connection_in) {
     bleio_connection_internal_t *connection = (bleio_connection_internal_t *)connection_in;
@@ -45,6 +47,7 @@ int bleio_connection_event_cb(struct ble_gap_event *event, void *connection_in) 
             #if CIRCUITPY_VERBOSE_BLE
             mp_printf(&mp_plat_print, "event->disconnect.reason: 0x%x\n", event->disconnect.reason);
             #endif
+
             if (connection->connection_obj != mp_const_none) {
                 bleio_connection_obj_t *obj = connection->connection_obj;
                 obj->connection = NULL;
@@ -175,8 +178,34 @@ void common_hal_bleio_connection_set_connection_interval(bleio_connection_intern
     CHECK_NIMBLE_ERROR(ble_gap_update_params(self->conn_handle, &updated));
 }
 
+// Zero when discovery is in process. BLE_HS_EDONE or a BLE_HS_ error code when done.
 static volatile int _last_discovery_status;
-static TaskHandle_t discovery_task = NULL;
+
+static uint64_t _discovery_start_time;
+
+// Give 20 seconds for discovery
+#define DISCOVERY_TIMEOUT_MS 20000
+
+static void _start_discovery_timeout(void) {
+    _discovery_start_time = common_hal_time_monotonic_ms();
+}
+
+static int _wait_for_discovery_step_done(void) {
+    while ((_last_discovery_status == 0) &&
+           (common_hal_time_monotonic_ms() < _discovery_start_time + DISCOVERY_TIMEOUT_MS)) {
+        RUN_BACKGROUND_TASKS;
+        if (mp_hal_is_interrupted()) {
+            // Return prematurely. Then the interrupt will be raised.
+            _last_discovery_status = BLE_HS_EDONE;
+        }
+    }
+    return _last_discovery_status;
+}
+
+// Record result of last discovery step: services, characteristics, descriptors.
+static void _set_discovery_step_status(int status) {
+    _last_discovery_status = status;
+}
 
 static int _discovered_service_cb(uint16_t conn_handle,
     const struct ble_gatt_error *error,
@@ -185,19 +214,11 @@ static int _discovered_service_cb(uint16_t conn_handle,
     bleio_connection_internal_t *self = (bleio_connection_internal_t *)arg;
 
     if (error->status != 0) {
-        // Keep the first error in case it's due to memory.
-        if (_last_discovery_status == 0) {
-            _last_discovery_status = error->status;
-            xTaskNotifyGive(discovery_task);
-        }
+        // BLE_HS_EDONE or some error has occurred.
+        _set_discovery_step_status(error->status);
         return 0;
     }
 
-    // If any of these memory allocations fail, we set _last_discovery_status
-    // and let the process continue.
-    if (_last_discovery_status != 0) {
-        return 0;
-    }
     bleio_service_obj_t *service = mp_obj_malloc(bleio_service_obj_t, &bleio_service_type);
 
     // Initialize several fields at once.
@@ -225,16 +246,8 @@ static int _discovered_characteristic_cb(uint16_t conn_handle,
     bleio_service_obj_t *service = (bleio_service_obj_t *)arg;
 
     if (error->status != 0) {
-        // Keep the first error in case it's due to memory.
-        if (_last_discovery_status == 0) {
-            _last_discovery_status = error->status;
-            xTaskNotifyGive(discovery_task);
-        }
-        return 0;
-    }
-    // If any of these memory allocations fail, we set _last_discovery_status
-    // and let the process continue.
-    if (_last_discovery_status != 0) {
+        // BLE_HS_EDONE or some error has occurred.
+        _set_discovery_step_status(error->status);
         return 0;
     }
 
@@ -261,11 +274,15 @@ static int _discovered_characteristic_cb(uint16_t conn_handle,
     common_hal_bleio_characteristic_construct(
         characteristic, service, chr->val_handle, uuid,
         props, SECURITY_MODE_OPEN, SECURITY_MODE_OPEN,
-        0, false,   // max_length, fixed_length: values don't matter for gattc
+        GATT_MAX_DATA_LENGTH, false,   // max_length, fixed_length: values don't matter for gattc, but don't use 0
         &mp_const_empty_bytes_bufinfo,
         NULL);
     // Set def_handle directly since it is only used in discovery.
     characteristic->def_handle = chr->def_handle;
+
+    #if CIRCUITPY_VERBOSE_BLE
+    mp_printf(&mp_plat_print, "_discovered_characteristic_cb: char handle: %d\n", characteristic->handle);
+    #endif
 
     mp_obj_list_append(MP_OBJ_FROM_PTR(service->characteristic_list),
         MP_OBJ_FROM_PTR(characteristic));
@@ -280,16 +297,14 @@ static int _discovered_descriptor_cb(uint16_t conn_handle,
     bleio_characteristic_obj_t *characteristic = (bleio_characteristic_obj_t *)arg;
 
     if (error->status != 0) {
-        // Keep the first error in case it's due to memory.
-        if (_last_discovery_status == 0) {
-            _last_discovery_status = error->status;
-        }
-        xTaskNotifyGive(discovery_task);
-        return 0;
-    }
-    // If any of these memory allocations fail, we set _last_discovery_status
-    // and let the process continue.
-    if (_last_discovery_status != 0) {
+
+        #if CIRCUITPY_VERBOSE_BLE
+        mp_printf(&mp_plat_print, "_discovered_descriptor_cb error->status: %d, handle: %d\n",
+            error->status, error->att_handle);
+        #endif
+
+        // BLE_HS_EDONE or some error has occurred.
+        _set_discovery_step_status(error->status);
         return 0;
     }
 
@@ -315,12 +330,16 @@ static int _discovered_descriptor_cb(uint16_t conn_handle,
 
     bleio_uuid_obj_t *uuid = mp_obj_malloc(bleio_uuid_obj_t, &bleio_uuid_type);
     uuid->nimble_ble_uuid = dsc->uuid;
-
     common_hal_bleio_descriptor_construct(
         descriptor, characteristic, uuid,
         SECURITY_MODE_OPEN, SECURITY_MODE_OPEN,
-        0, false, mp_const_empty_bytes);
+        GATT_MAX_DATA_LENGTH, false, mp_const_empty_bytes);
     descriptor->handle = dsc->handle;
+
+    #if CIRCUITPY_VERBOSE_BLE
+    mp_printf(&mp_plat_print, "_discovered_descriptor_cb: char handle: %d, desc handle: %d, uuid type: %d, u16 value: 0x%x\n",
+        characteristic->handle, descriptor->handle, dsc->uuid.u.type, dsc->uuid.u16.value);
+    #endif
 
     mp_obj_list_append(MP_OBJ_FROM_PTR(characteristic->descriptor_list),
         MP_OBJ_FROM_PTR(descriptor));
@@ -331,15 +350,19 @@ static void discover_remote_services(bleio_connection_internal_t *self, mp_obj_t
     // Start over with an empty list.
     self->remote_service_list = mp_obj_new_list(0, NULL);
 
-    discovery_task = xTaskGetCurrentTaskHandle();
+    // Start timeout in case discovery gets stuck.
+    _start_discovery_timeout();
+
     if (service_uuids_whitelist == mp_const_none) {
-        _last_discovery_status = 0;
+        // Reset discovery status before starting callbacks
+        _set_discovery_step_status(0);
+
         CHECK_NIMBLE_ERROR(ble_gattc_disc_all_svcs(self->conn_handle, _discovered_service_cb, self));
 
-        // Wait for sync.
-        ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(DISCOVERY_TIMEOUT_MS));
-        if (_last_discovery_status != BLE_HS_EDONE) {
-            CHECK_BLE_ERROR(_last_discovery_status);
+        // Wait for _discovered_service_cb() to be called multiple times until it's done.
+        int status = _wait_for_discovery_step_done();
+        if (status != BLE_HS_EDONE) {
+            CHECK_BLE_ERROR(status);
         }
     } else {
         mp_obj_iter_buf_t iter_buf;
@@ -351,33 +374,38 @@ static void discover_remote_services(bleio_connection_internal_t *self, mp_obj_t
             }
             bleio_uuid_obj_t *uuid = MP_OBJ_TO_PTR(uuid_obj);
 
-            _last_discovery_status = 0;
-            // Make sure we start with a clean notification state
-            ulTaskNotifyValueClear(discovery_task, 0xffffffff);
+            // Reset discovery status before starting callbacks
+            _set_discovery_step_status(0);
+
             CHECK_NIMBLE_ERROR(ble_gattc_disc_svc_by_uuid(self->conn_handle, &uuid->nimble_ble_uuid.u,
                 _discovered_service_cb, self));
-            // Wait for sync.
-            CHECK_NOTIFY(ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(DISCOVERY_TIMEOUT_MS)));
-            if (_last_discovery_status != BLE_HS_EDONE) {
-                CHECK_BLE_ERROR(_last_discovery_status);
+
+            // Wait for _discovered_service_cb() to be called multiple times until it's done.
+            int status = _wait_for_discovery_step_done();
+            if (status != BLE_HS_EDONE) {
+                CHECK_BLE_ERROR(status);
             }
         }
     }
 
+    // Now discover characteristics for each discovered service.
+
     for (size_t i = 0; i < self->remote_service_list->len; i++) {
         bleio_service_obj_t *service = MP_OBJ_TO_PTR(self->remote_service_list->items[i]);
 
-        _last_discovery_status = 0;
+        // Reset discovery status before starting callbacks
+        _set_discovery_step_status(0);
+
         CHECK_NIMBLE_ERROR(ble_gattc_disc_all_chrs(self->conn_handle,
             service->start_handle,
             service->end_handle,
             _discovered_characteristic_cb,
             service));
 
-        // Wait for sync.
-        CHECK_NOTIFY(ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(DISCOVERY_TIMEOUT_MS)));
-        if (_last_discovery_status != BLE_HS_EDONE) {
-            CHECK_BLE_ERROR(_last_discovery_status);
+        // Wait for _discovered_characteristic_cb() to be called multiple times until it's done.
+        int status = _wait_for_discovery_step_done();
+        if (status != BLE_HS_EDONE) {
+            CHECK_BLE_ERROR(status);
         }
 
         // Got characteristics for this service. Now discover descriptors for each characteristic.
@@ -395,21 +423,21 @@ static void discover_remote_services(bleio_connection_internal_t *self, mp_obj_t
 
             uint16_t end_handle = next_characteristic == NULL
                 ? service->end_handle
-                : next_characteristic->def_handle - 1;
+                : next_characteristic->handle - 1;
 
-            // Pre-check if characteristic is empty so descriptor discovery doesn't fail
-            if (end_handle <= characteristic->handle) {
-                continue;
-            }
+            // Reset discovery status before starting callbacks
+            _set_discovery_step_status(0);
 
-            _last_discovery_status = 0;
+            // The descriptor handle inclusive range is [characteristic->handle + 1, end_handle],
+            // but ble_gattc_disc_all_dscs() requires starting with characteristic->handle.
             CHECK_NIMBLE_ERROR(ble_gattc_disc_all_dscs(self->conn_handle, characteristic->handle,
                 end_handle,
                 _discovered_descriptor_cb, characteristic));
-            // Wait for sync.
-            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(DISCOVERY_TIMEOUT_MS));
-            if (_last_discovery_status != BLE_HS_EDONE) {
-                CHECK_BLE_ERROR(_last_discovery_status);
+
+            // Wait for _discovered_descriptor_cb to be called multiple times until it's done.
+            status = _wait_for_discovery_step_done();
+            if (status != BLE_HS_EDONE) {
+                CHECK_BLE_ERROR(status);
             }
         }
     }

--- a/ports/espressif/common-hal/_bleio/Connection.c
+++ b/ports/espressif/common-hal/_bleio/Connection.c
@@ -191,8 +191,8 @@ static void _start_discovery_timeout(void) {
 }
 
 static int _wait_for_discovery_step_done(void) {
-    while ((_last_discovery_status == 0) &&
-           (common_hal_time_monotonic_ms() < _discovery_start_time + DISCOVERY_TIMEOUT_MS)) {
+    const uint64_t timeout_time_ms = _discovery_start_time + DISCOVERY_TIMEOUT_MS;
+    while ((_last_discovery_status == 0) && (common_hal_time_monotonic_ms() < timeout_time_ms)) {
         RUN_BACKGROUND_TASKS;
         if (mp_hal_is_interrupted()) {
             // Return prematurely. Then the interrupt will be raised.

--- a/ports/espressif/common-hal/_bleio/Connection.c
+++ b/ports/espressif/common-hal/_bleio/Connection.c
@@ -425,6 +425,11 @@ static void discover_remote_services(bleio_connection_internal_t *self, mp_obj_t
                 ? service->end_handle
                 : next_characteristic->handle - 1;
 
+            // Pre-check if there are no descriptors to discover so descriptor discovery doesn't fail
+            if (end_handle <= characteristic->handle) {
+                continue;
+            }
+
             // Reset discovery status before starting callbacks
             _set_discovery_step_status(0);
 

--- a/ports/espressif/common-hal/_bleio/__init__.h
+++ b/ports/espressif/common-hal/_bleio/__init__.h
@@ -22,7 +22,7 @@ extern background_callback_t bleio_background_callback;
 
 // We assume variable length data.
 // 20 bytes max (23 - 3).
-#define GATT_MAX_DATA_LENGTH (BLE_GATT_ATT_MTU_DEFAULT - 3)
+#define GATT_MAX_DATA_LENGTH (23 - 3)
 
 #define NIMBLE_OK (0)
 

--- a/ports/espressif/common-hal/dualbank/__init__.c
+++ b/ports/espressif/common-hal/dualbank/__init__.c
@@ -27,7 +27,7 @@ void dualbank_reset(void) {
 
 static void __attribute__((noreturn)) task_fatal_error(void) {
     ESP_LOGE(TAG, "Exiting task due to fatal error...");
-    mp_raise_RuntimeError(MP_ERROR_TEXT("Update Failed"));
+    mp_raise_RuntimeError(MP_ERROR_TEXT("Update failed"));
 }
 
 void common_hal_dualbank_flash(const void *buf, const size_t len, const size_t offset) {


### PR DESCRIPTION
- Fixes #9361
- Fixes #9338 
- Fixes #9337

Changes:
- In `Adapter.c` and `Connection.c`, busy-wait for incoming events using status variables, instead of using FreeRTOS task notification. This fixes some breaking out-of-order notifications I saw during GATT discovery, and and also allows for background tasks to run and also allows for ctrl-C interruption.
- Characteristic `observer` when not present should have been `mp_const_none`, not `NULL`. This fixed a hard crash when there was no observer.
- Use `GATT_MAX_DATA_LENGTH`, not `0`, for default size of remote characteristics. When zero, the initial `PacketBuffer` ringbuf was set too small.
- Retry a few times after occasional `HS_BLE_EBUSY` when starting a GAP scan.
- A little cleanup here and there.

Tested with:
- `ble_ibbq_simpletest.py` - iBBQ NutriChef thermometer
- `ble_heart_rate_simpletest.py` - Schosche heart rate monitor
- `ble_uart_echo_test.py` and `ble_uart_echo_client.py` - tested both directions, talking to an nRF52840.

@jedgarpark This should fix your iBBQ project issue.
@tyeth Does this solve #9304 for you?