### PR TITLE
remove UART object and use pins for IR

### DIFF
--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/mpconfigboard.h
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/mpconfigboard.h
@@ -10,6 +10,7 @@
 #define MICROPY_HW_MCU_NAME     "rp2040"
 
 #define MICROPY_HW_LED_STATUS   (&pin_GPIO4)
+// the UART pins are used for IR
 // #define DEFAULT_UART_BUS_TX     (&pin_GPIO0)
 // #define DEFAULT_UART_BUS_RX     (&pin_GPIO1)
 #define DEFAULT_I2C_BUS_SDA     (&pin_GPIO2)

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/mpconfigboard.mk
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/mpconfigboard.mk
@@ -20,3 +20,6 @@ FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Bitmap_Font
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Display_Text
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Display_Shapes
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_HID
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_IRRemote
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_asyncio
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Ticks

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/mpconfigboard.mk
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/mpconfigboard.mk
@@ -15,11 +15,11 @@ EXTERNAL_FLASH_DEVICES = "GD25Q64C"
 
 CIRCUITPY__EVE = 1
 
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_asyncio
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Bitmap_Font
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Display_Text
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Display_Shapes
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Display_Text
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_HID
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_IRRemote
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_asyncio
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Ticks

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/pins.c
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/pins.c
@@ -39,8 +39,8 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_GP0), MP_ROM_PTR(&pin_GPIO0) },
     { MP_ROM_QSTR(MP_QSTR_GP1), MP_ROM_PTR(&pin_GPIO1) },
     // GPIO0 and GPIO1 are used for IR and not for  UART
-    { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO0) },
-    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO1) },
+    { MP_ROM_QSTR(MP_QSTR_IR_TX), MP_ROM_PTR(&pin_GPIO0) },
+    { MP_ROM_QSTR(MP_QSTR_IR_RX), MP_ROM_PTR(&pin_GPIO1) },
 
     { MP_ROM_QSTR(MP_QSTR_GP2), MP_ROM_PTR(&pin_GPIO2) },
     { MP_ROM_QSTR(MP_QSTR_GP3), MP_ROM_PTR(&pin_GPIO3) },
@@ -111,16 +111,13 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TOUCH9), MP_ROM_PTR(&pin_GPIO27) },
 
     { MP_ROM_QSTR(MP_QSTR_GP28), MP_ROM_PTR(&pin_GPIO28) },
-    // GPIO28 is also the interrupt pin of the accelerometer on some boards
+    // GPIO28 is also the interrupt pin of the accelerometer on one version of the board
 
     { MP_ROM_QSTR(MP_QSTR_GP29), MP_ROM_PTR(&pin_GPIO29) },
     // GPIO29 is also the ID value of the board (an analog read value between 0 .. 4096)
-    // { MP_ROM_QSTR(MP_QSTR_VID), MP_ROM_PTR(&pin_GPIO29) },
-
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
-    // { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
     { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].epaper_display)},
 
     { MP_ROM_QSTR(MP_QSTR_VID), MP_ROM_PTR(&board_vid_obj) },

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/pins.c
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/pins.c
@@ -38,7 +38,7 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_GP0), MP_ROM_PTR(&pin_GPIO0) },
     { MP_ROM_QSTR(MP_QSTR_GP1), MP_ROM_PTR(&pin_GPIO1) },
-    // GPIO0 and GPIO1 are also the UART
+    // GPIO0 and GPIO1 are used for IR and not for  UART
     { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO0) },
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO1) },
 
@@ -111,8 +111,7 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TOUCH9), MP_ROM_PTR(&pin_GPIO27) },
 
     { MP_ROM_QSTR(MP_QSTR_GP28), MP_ROM_PTR(&pin_GPIO28) },
-    // GPIO28 is also the interrupt pin of the accelerometer
-    { MP_ROM_QSTR(MP_QSTR_ACCEL_INT), MP_ROM_PTR(&pin_GPIO28) },
+    // GPIO28 is also the interrupt pin of the accelerometer on some boards
 
     { MP_ROM_QSTR(MP_QSTR_GP29), MP_ROM_PTR(&pin_GPIO29) },
     // GPIO29 is also the ID value of the board (an analog read value between 0 .. 4096)
@@ -120,8 +119,8 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
 
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
     // { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
-
     { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].epaper_display)},
 
     { MP_ROM_QSTR(MP_QSTR_VID), MP_ROM_PTR(&board_vid_obj) },


### PR DESCRIPTION
The RP2040 Explorer Badge used traditional IR capabilities. These use GP0 and GP1 which were previously anticipated to be exposed for UART. They are no longer exposed as pins and are dedicated to the RI emitter and IR receiver.