### PR TITLE
Fix BLE adv timeout; ESP: don't sched handler on adv finish

### DIFF
--- a/supervisor/shared/bluetooth/bluetooth.c
+++ b/supervisor/shared/bluetooth/bluetooth.c
@@ -132,8 +132,8 @@ static void supervisor_bluetooth_start_advertising(void) {
         return;
     }
     #endif
-    uint32_t timeout = 0;
-    float interval = 0.1f;
+    const uint32_t timeout = 0;  // 0 means advertise forever.
+    const float interval = 0.1f;
     int tx_power = 0;
     const uint8_t *adv = private_advertising_data;
     size_t adv_len = sizeof(private_advertising_data);


### PR DESCRIPTION
Fixes #9359.

- Correct handling of advertising timeout value in both espressif and nordic `common_hal_bleio_adapter_start_advertising()`
  - Timeout of zero means wait forever. Use `BLE_HS_FOREVER` for espressif. Use `BLE_GAP_ADV_TIMEOUT_GENERAL_UNLIMITED` for nordic.
  - Handle zero timeout in the base routine `_common_hal_bleio_adapter_start_advertising()`, not in the parent routine `common_hal_bleio_adapter_start_advertising()`, because callers to the former expect zero to work as an unlimited timeout.
- Espressif: remove ` background_callback_add_core(&bleio_background_callback()` from `_advertising_event()`. Scheduling the background task caused advertising to start up again. This caused a tight loop of advertising starting, finishing, and restarting, slowing down CircuitPython greatly. The reschedule does not appear to be necessary: it is not done in the equivalent nordic code. There is other code to restart the BLE workflow advertising as needed.

Tested with heart rate monitor, iBBQ, and BLE UART.

@bablokb Could you test to see if this fixes #9359 for you? Thanks. It might also prevent #9362, if that error is a side effect of the tight loop mentioned above.

(Note: I have been unsuccessful in getting BLE workflow to work with PyLeap with 9.0.5 or recent builds including this, but I might be be doing something wrong.)