### PR TITLE
fix off-by-one in ADC sample rate divisor

### DIFF
--- a/ports/raspberrypi/common-hal/analogbufio/BufferedIn.c
+++ b/ports/raspberrypi/common-hal/analogbufio/BufferedIn.c
@@ -53,7 +53,7 @@ void common_hal_analogbufio_bufferedin_construct(analogbufio_bufferedin_obj_t *s
     // sample rate determines divisor, not zero.
 
     // sample_rate is forced to be >= 1 in shared-bindings
-    float clk_div = (float)ADC_CLOCK_INPUT / (float)sample_rate;
+    float clk_div = (float)ADC_CLOCK_INPUT / (float)sample_rate - 1;
     adc_set_clkdiv(clk_div);
 
     // Set up the DMA to start transferring data as soon as it appears in FIFO

--- a/ports/raspberrypi/common-hal/analogbufio/BufferedIn.c
+++ b/ports/raspberrypi/common-hal/analogbufio/BufferedIn.c
@@ -53,6 +53,8 @@ void common_hal_analogbufio_bufferedin_construct(analogbufio_bufferedin_obj_t *s
     // sample rate determines divisor, not zero.
 
     // sample_rate is forced to be >= 1 in shared-bindings
+    // Per the datasheet: "Setting DIV.INT to some positive value n will trigger the ADC once per n + 1 cycles."
+    // So subtract 1. See PR #9396.
     float clk_div = (float)ADC_CLOCK_INPUT / (float)sample_rate - 1;
     adc_set_clkdiv(clk_div);
 


### PR DESCRIPTION
Setting of ADC clock divisor on RP2040 in `analogbufio` is off by one.  For instance, to get 10000 Hz sampling rate, you want to divide the 48 MHz ADC clock by 4800, and the current code sets DIV.INT to 4800, but you really want to set it to 4799, per datasheet page 564, "Setting DIV.INT to some positive value n will trigger the ADC once per n + 1 cycles."  I've verified this by scope, let me know if you want more info.