### PR TITLE
serial_bytes_available: don't double-count bytes on usb cdc

### DIFF
--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -309,10 +309,6 @@ uint32_t serial_bytes_available(void) {
     }
     #endif
 
-    #if CIRCUITPY_USB_DEVICE
-    count += tud_cdc_available();
-    #endif
-
     // Board-specific serial input.
     count += board_serial_bytes_available();
 


### PR DESCRIPTION
In 9.0.x, serial_bytes_available returned a bool and tud_cdc_available was harmlessly checked twice for any characters.

When the routine was changed to return an int, the double checking led to over-reporting the number of characters available. In code that would attempt to read this many bytes from sys.stdin, this made the read call block since only 1 byte was actually available.

This behavior came up in the discussion of #9393. I don't mark this bug as closing that one, because that issue seems to be reporting multiple things that this change would not address, such as delays in `sys.stdout.write()` or problems seen while using webserial.

ping @gitcnd