### PR TITLE
Add more atomicity in usb_serial_jtag.c; handle C6 in more places

### DIFF
--- a/ports/espressif/common-hal/microcontroller/__init__.c
+++ b/ports/espressif/common-hal/microcontroller/__init__.c
@@ -81,7 +81,7 @@ void common_hal_mcu_enable_interrupts(void) {
 void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
     switch (runmode) {
         case RUNMODE_UF2:
-            #if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32C3)
+            #if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)
             mp_arg_error_invalid(MP_QSTR_run_mode);
             #else
             // 0x11F2 is APP_REQUEST_UF2_RESET_HINT & is defined by TinyUF2

--- a/ports/espressif/supervisor/port.c
+++ b/ports/espressif/supervisor/port.c
@@ -240,9 +240,12 @@ safe_mode_t port_init(void) {
 
     #if DEBUG
     // debug UART
-    #ifdef CONFIG_IDF_TARGET_ESP32C3
+    #if defined(CONFIG_IDF_TARGET_ESP32C3)
     common_hal_never_reset_pin(&pin_GPIO20);
     common_hal_never_reset_pin(&pin_GPIO21);
+    #elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    common_hal_never_reset_pin(&pin_GPIO16);
+    common_hal_never_reset_pin(&pin_GPIO17);
     #elif defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)
     common_hal_never_reset_pin(&pin_GPIO43);
     common_hal_never_reset_pin(&pin_GPIO44);
@@ -256,7 +259,7 @@ safe_mode_t port_init(void) {
     #if ENABLE_JTAG
     ESP_LOGI(TAG, "Marking JTAG pins never_reset");
     // JTAG
-    #ifdef CONFIG_IDF_TARGET_ESP32C3
+    #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)
     common_hal_never_reset_pin(&pin_GPIO4);
     common_hal_never_reset_pin(&pin_GPIO5);
     common_hal_never_reset_pin(&pin_GPIO6);

--- a/ports/espressif/supervisor/usb.c
+++ b/ports/espressif/supervisor/usb.c
@@ -20,8 +20,10 @@
 #include "driver/gpio.h"
 #include "esp_private/periph_ctrl.h"
 
-#ifdef CONFIG_IDF_TARGET_ESP32C3
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
 #include "components/esp_rom/include/esp32c3/rom/gpio.h"
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+#include "components/esp_rom/include/esp32c6/rom/gpio.h"
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)
 #include "components/esp_rom/include/esp32s2/rom/gpio.h"
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)


### PR DESCRIPTION
- Fixes #9399.
---
-- Some conditional checking for ESP32-C6 was missing.
-- Be more careful that ringbuf use in `usb_serial_jtag.c` is atomic. `ringbuf_get()` is not atomic, for instance.

I tried just leaving the `USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT` interrupt enabled all the time, which would have made the code simpler, but that did not work.

This may fix some other reported flakiness, not sure.

Tested by writing larger files with Thonny to an `espressif_esp32c6_devkitc_1_n8`. That's the only C6 board I have right now.