### PR TITLE
sdioio DOC update: DATA pins pass in Set

### DIFF
--- a/shared-bindings/sdioio/SDCard.c
+++ b/shared-bindings/sdioio/SDCard.c
@@ -55,7 +55,7 @@
 //|             sd = sdioio.SDCard(
 //|                 clock=board.SDIO_CLOCK,
 //|                 command=board.SDIO_COMMAND,
-//|                 data=board.SDIO_DATA,
+//|                 data=[board.SDIO_DATA],
 //|                 frequency=25000000)
 //|             vfs = storage.VfsFat(sd)
 //|             storage.mount(vfs, '/sd')


### PR DESCRIPTION
I'm not sure I resolved the issue properly but when I attempted to use the example code with SDIOIO it failed, indicating the DATA pins I passed didn't have a LEN attribute. I resolved it by passing the pin within a Set which made sense to me since the parameter description indicated a sequence of pins was required.

If a Set is the right way to go, then this PR updates the example accordingly.