### PR TITLE
rp2040: uart: check all pins before claiming any

### DIFF
--- a/ports/raspberrypi/common-hal/busio/UART.c
+++ b/ports/raspberrypi/common-hal/busio/UART.c
@@ -42,12 +42,15 @@ void never_reset_uart(uint8_t num) {
     uart_status[num] = STATUS_NEVER_RESET;
 }
 
+static void pin_check(const uint8_t uart, const mcu_pin_obj_t *pin, const uint8_t pin_type) {
+    if (!(((pin->number % 4) == pin_type) && ((((pin->number + 4) / 8) % NUM_UARTS) == uart))) {
+        raise_ValueError_invalid_pins();
+    }
+}
+
 static uint8_t pin_init(const uint8_t uart, const mcu_pin_obj_t *pin, const uint8_t pin_type) {
     if (pin == NULL) {
         return NO_PIN;
-    }
-    if (!(((pin->number % 4) == pin_type) && ((((pin->number + 4) / 8) % NUM_UARTS) == uart))) {
-        raise_ValueError_invalid_pins();
     }
     claim_pin(pin);
     gpio_set_function(pin->number, GPIO_FUNC_UART);
@@ -90,10 +93,15 @@ void common_hal_busio_uart_construct(busio_uart_obj_t *self,
 
     uint8_t uart_id = ((((tx != NULL) ? tx->number : rx->number) + 4) / 8) % NUM_UARTS;
 
+    pin_check(uart_id, tx, 0);
+    pin_check(uart_id, rx, 1);
+    pin_check(uart_id, cts, 2);
+    pin_check(uart_id, rts, 3);
+
     if (uart_status[uart_id] != STATUS_FREE) {
         mp_raise_ValueError(MP_ERROR_TEXT("UART peripheral in use"));
     }
-    // These may raise exceptions if pins are already in use.
+
     self->tx_pin = pin_init(uart_id, tx, 0);
     self->rx_pin = pin_init(uart_id, rx, 1);
     self->cts_pin = pin_init(uart_id, cts, 2);

--- a/ports/raspberrypi/common-hal/busio/UART.c
+++ b/ports/raspberrypi/common-hal/busio/UART.c
@@ -43,6 +43,9 @@ void never_reset_uart(uint8_t num) {
 }
 
 static void pin_check(const uint8_t uart, const mcu_pin_obj_t *pin, const uint8_t pin_type) {
+    if (pin == NULL) {
+        return;
+    }
     if (!(((pin->number % 4) == pin_type) && ((((pin->number + 4) / 8) % NUM_UARTS) == uart))) {
         raise_ValueError_invalid_pins();
     }


### PR DESCRIPTION
also remove the comment that pin_init may raise an exception for an in-use pin; this is incorrect. The unclaimed status of all pins was verified in shared-bindings before calling construct.

closes #9424