### PR TITLE
Update Standard Library sys documentation

### DIFF
--- a/docs/library/sys.rst
+++ b/docs/library/sys.rst
@@ -15,6 +15,21 @@ Functions
    function raise as `SystemExit` exception. If an argument is given, its
    value given as an argument to `SystemExit`.
 
+.. function:: print_exception(exc, file=sys.stdout, /)
+
+   Print exception with a traceback to a file-like object *file* (or
+   `sys.stdout` by default).
+
+   .. admonition:: Difference to CPython
+      :class: attention
+
+      This is simplified version of a function which appears in the
+      ``traceback`` module in CPython. Unlike ``traceback.print_exception()``,
+      this function takes just exception value instead of exception type,
+      exception value, and traceback object; *file* argument should be
+      positional; further arguments are not supported. CPython-compatible
+      ``traceback`` module can be found in `micropython-lib`.
+
 Constants
 ---------
 
@@ -97,12 +112,6 @@ Constants
    If you need to check whether your program runs on CircuitPython (vs other
    Python implementation), use `sys.implementation` instead.
 
-.. data:: ps1
-          ps2
-
-   Mutable attributes holding strings, which are used for the REPL prompt.  The defaults
-   give the standard Python prompt of ``>>>`` and ``...``.
-
 .. data:: stderr
 
    Standard error ``stream``.
@@ -114,14 +123,6 @@ Constants
 .. data:: stdout
 
    Standard output ``stream``.
-
-.. data:: tracebacklimit
-
-   A mutable attribute holding an integer value which is the maximum number of traceback
-   entries to store in an exception.  Set to 0 to disable adding tracebacks.  Defaults
-   to 1000.
-
-   Note: this is not available on all ports.
 
 .. data:: version
 

--- a/docs/library/sys.rst
+++ b/docs/library/sys.rst
@@ -27,8 +27,7 @@ Functions
       ``traceback`` module in CPython. Unlike ``traceback.print_exception()``,
       this function takes just exception value instead of exception type,
       exception value, and traceback object; *file* argument should be
-      positional; further arguments are not supported. CPython-compatible
-      ``traceback`` module can be found in `micropython-lib`.
+      positional; further arguments are not supported.
 
 Constants
 ---------

--- a/docs/library/sys.rst
+++ b/docs/library/sys.rst
@@ -24,7 +24,7 @@ Functions
       :class: attention
 
       This is simplified version of a function which appears in the
-      ``traceback`` module in CPython. Unlike ``traceback.print_exception()``,
+      `traceback` module in CPython. Unlike `traceback.print_exception()`,
       this function takes just exception value instead of exception type,
       exception value, and traceback object; *file* argument should be
       positional; further arguments are not supported.

--- a/docs/library/sys.rst
+++ b/docs/library/sys.rst
@@ -17,6 +17,9 @@ Functions
 
 .. function:: print_exception(exc, file=sys.stdout, /)
 
+   This function is being deprecated and will be removed starting in
+   CircuitPython 10.x, `traceback.print_exception()` should be used instead.
+
    Print exception with a traceback to a file-like object *file* (or
    `sys.stdout` by default).
 


### PR DESCRIPTION
I noticed the Circuit Python documentation for the Standard library sys doesn't include an entry for the print_exception function and that a couple attributes which are present in Micropython but not in Circuit Python  (tracebacklimit and ps1/ps2) were included in the Circuit Python documentation.

I found the sys.rst file which appears to be the documentation source so I've updated it by adding/removing the appropriate sections.