### PR TITLE
ESP32: Control rx Echo when pasting into REPL paste mode in order to prevent data loss 

### DIFF
--- a/ports/atmel-samd/common-hal/busio/UART.c
+++ b/ports/atmel-samd/common-hal/busio/UART.c
@@ -427,6 +427,9 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, 
     if (self->tx_pin == NO_PIN) {
         mp_raise_ValueError_varg(MP_ERROR_TEXT("No %q pin"), MP_QSTR_tx);
     }
+    if ((int)len < 0) {
+        len = -(int)len;
+    }
 
     // This assignment is only here because the usart_async routines take a *const argument.
     struct usart_async_descriptor *const usart_desc_p = (struct usart_async_descriptor *const)&self->usart_desc;

--- a/ports/broadcom/common-hal/busio/UART.c
+++ b/ports/broadcom/common-hal/busio/UART.c
@@ -328,6 +328,9 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, 
     if (self->tx_pin == NULL) {
         mp_raise_ValueError_varg(MP_ERROR_TEXT("No %q pin"), MP_QSTR_tx);
     }
+    if ((int)len < 0) {
+        len = -(int)len;
+    }
 
     COMPLETE_MEMORY_READS;
     ARM_UART_PL011_Type *pl011 = uart[self->uart_id];

--- a/ports/broadcom/mphalport.h
+++ b/ports/broadcom/mphalport.h
@@ -19,7 +19,7 @@ void mp_hal_delay_us(mp_uint_t us);
 
 void mp_hal_set_interrupt_char(int c);
 int mp_hal_stdin_rx_chr(void);
-void mp_hal_stdout_tx_strn(const char *str, size_t len);
+size_t mp_hal_stdout_tx_strn(const char *str, size_t len);
 
 #ifdef MICROPY_HW_USBHOST
 #include "usbkbd.h"

--- a/ports/cxd56/common-hal/busio/UART.c
+++ b/ports/cxd56/common-hal/busio/UART.c
@@ -141,6 +141,10 @@ size_t common_hal_busio_uart_read(busio_uart_obj_t *self, uint8_t *data, size_t 
 }
 
 size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, size_t len, int *errcode) {
+    if ((int)len < 0) {
+        len = -(int)len;
+    }
+
     int bytes_written = write(busio_uart_dev[self->number].fd, data, len);
     if (bytes_written < 0) {
         *errcode = MP_EAGAIN;

--- a/ports/espressif/common-hal/busio/UART.c
+++ b/ports/espressif/common-hal/busio/UART.c
@@ -347,7 +347,7 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, 
 
     if ((int)len < 0) {
         noWait = true;
-        write_tries = 1;
+        write_tries = -(int)len;
         len = -(int)len;
     } else {
         noWait = false;

--- a/ports/mimxrt10xx/common-hal/busio/UART.c
+++ b/ports/mimxrt10xx/common-hal/busio/UART.c
@@ -413,6 +413,9 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, 
     if (self->tx == NULL) {
         mp_raise_ValueError_varg(MP_ERROR_TEXT("No %q pin"), MP_QSTR_tx);
     }
+    if ((int)len < 0) {
+        len = -(int)len;
+    }
     if (self->rs485_dir && len) {
         GPIO_PinWrite(self->rs485_dir->gpio, self->rs485_dir->number, !self->rs485_invert);
         LPUART_WriteBlocking(self->uart, data, len);

--- a/ports/nordic/common-hal/busio/UART.c
+++ b/ports/nordic/common-hal/busio/UART.c
@@ -319,6 +319,9 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, 
     if (len == 0) {
         return 0;
     }
+    if ((int)len < 0) {
+        len = -(int)len;
+    }
 
     // EasyDMA can only access SRAM
     uint8_t *tx_buf = (uint8_t *)data;

--- a/ports/raspberrypi/common-hal/busio/UART.c
+++ b/ports/raspberrypi/common-hal/busio/UART.c
@@ -199,6 +199,10 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, 
         mp_raise_ValueError_varg(MP_ERROR_TEXT("No %q pin"), MP_QSTR_tx);
     }
 
+    if ((int)len < 0) {
+        len = -(int)len;
+    }
+
     if (self->rs485_dir_pin != NO_PIN) {
         uart_tx_wait_blocking(self->uart);
         gpio_put(self->rs485_dir_pin, !self->rs485_invert);

--- a/ports/renode/common-hal/busio/UART.c
+++ b/ports/renode/common-hal/busio/UART.c
@@ -32,6 +32,10 @@ void common_hal_busio_uart_deinit(busio_uart_obj_t *self) {
 
 // Write characters.
 size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, size_t len, int *errcode) {
+    if ((int)len < 0) {
+        len = -(int)len;
+    }
+
     for (size_t i = 0; i < len; i++) {
         *RXTX = data[i];
     }

--- a/ports/silabs/common-hal/busio/UART.c
+++ b/ports/silabs/common-hal/busio/UART.c
@@ -239,6 +239,10 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self,
     size_t len,
     int *errcode) {
 
+    if ((int)len < 0) {
+        len = -(int)len;
+    }
+
     Ecode_t ret = UARTDRV_TransmitB(self->handle, (uint8_t *)data, len);
     if (ret != ECODE_EMDRV_UARTDRV_OK) {
         mp_raise_RuntimeError(MP_ERROR_TEXT("UART write"));

--- a/ports/stm/common-hal/busio/UART.c
+++ b/ports/stm/common-hal/busio/UART.c
@@ -302,6 +302,9 @@ size_t common_hal_busio_uart_write(busio_uart_obj_t *self, const uint8_t *data, 
     if (self->tx == NULL) {
         mp_raise_ValueError_varg(MP_ERROR_TEXT("No %q pin"), MP_QSTR_tx);
     }
+    if ((int)len < 0) {
+        len = -(int)len;
+    }
 
     // Disable UART IRQ to avoid resource hazards in Rx IRQ handler
     HAL_NVIC_DisableIRQ(self->irq);

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -197,6 +197,7 @@ size_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
     #if MICROPY_PY_OS_DUPTERM
     mp_os_dupterm_tx_strn(str, len);
     #endif
+    return len;
 }
 
 // cooked is same as uncooked because the terminal does some postprocessing

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -190,7 +190,7 @@ main_term:;
     return c;
 }
 
-void mp_hal_stdout_tx_strn(const char *str, size_t len) {
+size_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
     ssize_t ret;
     MP_HAL_RETRY_SYSCALL(ret, write(STDOUT_FILENO, str, len), {});
     // CIRCUITPY-CHANGE: need to conditionalize MICROPY_PY_OS_DUPTERM

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -48,7 +48,7 @@ void mp_hal_stdout_tx_str(const char *str);
 #endif
 
 #ifndef mp_hal_stdout_tx_strn
-void mp_hal_stdout_tx_strn(const char *str, size_t len);
+size_t mp_hal_stdout_tx_strn(const char *str, size_t len);
 #endif
 
 #ifndef mp_hal_stdout_tx_strn_cooked

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -745,7 +745,7 @@ friendly_repl_reset:
                     if (curr_ms < strtPause) {
                         strtPause = curr_ms;
                     }
-                    if (!serial_bytes_available() && curr_ms >= strtPause+pauseTX) {
+                    if (!serial_bytes_available() && curr_ms >= strtPause + pauseTX) {
                         pauseTX = 0;
                         ptr = (const char *)(((const char *)vstr_null_terminated_str(&line)) + curloc);
                         if (*(ptr) == '\r') {

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -720,9 +720,9 @@ friendly_repl_reset:
                     // add char to buffer and echo
                     vstr_add_byte(&line, c);
                     if (c == '\r') {
-                        mp_hal_stdout_tx_str("\r\n=== ");
+                        mp_hal_stdout_tx_strn("\r\n=== ",-6);
                     } else {
-                        mp_hal_stdout_tx_strn(&c, 1);
+                        mp_hal_stdout_tx_strn(&c, -1);
                     }
                 }
             }

--- a/supervisor/shared/micropython.c
+++ b/supervisor/shared/micropython.c
@@ -39,6 +39,9 @@ int mp_hal_stdin_rx_chr(void) {
 void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     toggle_tx_led();
 
+    int txlen = len;
+    len = abs(len);
+
     #ifdef CIRCUITPY_BOOT_OUTPUT_FILE
     if (boot_output != NULL) {
         // Ensure boot_out.txt is capped at 1 filesystem block and ends with a newline
@@ -58,7 +61,7 @@ void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     }
     #endif
 
-    serial_write_substring(str, len);
+    serial_write_substring(str, (uint32_t)txlen);
 }
 
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {

--- a/supervisor/shared/micropython.c
+++ b/supervisor/shared/micropython.c
@@ -40,7 +40,9 @@ size_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
     toggle_tx_led();
 
     int txlen = len;
-    len = abs(len);
+    if (len < 0) {
+        len = -len;
+    }
 
     #ifdef CIRCUITPY_BOOT_OUTPUT_FILE
     if (boot_output != NULL) {

--- a/supervisor/shared/micropython.c
+++ b/supervisor/shared/micropython.c
@@ -36,7 +36,7 @@ int mp_hal_stdin_rx_chr(void) {
     }
 }
 
-void mp_hal_stdout_tx_strn(const char *str, size_t len) {
+size_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
     toggle_tx_led();
 
     int txlen = len;
@@ -61,7 +61,7 @@ void mp_hal_stdout_tx_strn(const char *str, size_t len) {
     }
     #endif
 
-    serial_write_substring(str, (uint32_t)txlen);
+    return serial_write_substring(str, (uint32_t)txlen);
 }
 
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -321,7 +321,9 @@ uint32_t serial_bytes_available(void) {
 size_t serial_write_substring(const char *text, uint32_t length) {
     int txlen = (int)length;
     size_t uarttx_len = 0;
-    length = abs(txlen);
+    if (txlen < 0) {
+        length = -txlen;
+    }
 
     if (length == 0) {
         return uarttx_len;

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -319,6 +319,9 @@ uint32_t serial_bytes_available(void) {
 }
 
 void serial_write_substring(const char *text, uint32_t length) {
+    int txlen = (int)length;
+    length = abs(txlen);
+
     if (length == 0) {
         return;
     }
@@ -345,8 +348,8 @@ void serial_write_substring(const char *text, uint32_t length) {
         mp_hal_delay_ms(50);
         _first_write_done = true;
     }
-    int uart_errcode;
-    common_hal_busio_uart_write(&console_uart, (const uint8_t *)text, length, &uart_errcode);
+    int uart_errcode = 0;
+    common_hal_busio_uart_write(&console_uart, (const uint8_t *)text, (size_t)txlen, &uart_errcode);
     #endif
 
     #if CIRCUITPY_SERIAL_BLE

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -325,6 +325,8 @@ size_t serial_write_substring(const char *text, uint32_t length) {
 
     if (length == 0) {
         return uarttx_len;
+    } else {
+        uarttx_len = length;
     }
 
     #if CIRCUITPY_TERMINALIO
@@ -351,7 +353,7 @@ size_t serial_write_substring(const char *text, uint32_t length) {
     }
     int uart_errcode = 0;
     uarttx_len = common_hal_busio_uart_write(&console_uart, (const uint8_t *)text, (size_t)txlen, &uart_errcode);
-    if (uarttx_len < 0) {
+    if (uart_errcode != 0 || uarttx_len < 0) {
         uarttx_len = 0;
     }
     #endif
@@ -366,7 +368,7 @@ size_t serial_write_substring(const char *text, uint32_t length) {
 
     #if CIRCUITPY_USB_DEVICE && CIRCUITPY_USB_CDC
     if (!usb_cdc_console_enabled()) {
-        return;
+        return uarttx_len;
     }
     #endif
 

--- a/supervisor/shared/serial.h
+++ b/supervisor/shared/serial.h
@@ -23,7 +23,7 @@ void serial_early_init(void);
 void serial_init(void);
 void serial_write(const char *text);
 // Only writes up to given length. Does not check for null termination at all.
-void serial_write_substring(const char *text, uint32_t length);
+size_t serial_write_substring(const char *text, uint32_t length);
 char serial_read(void);
 uint32_t serial_bytes_available(void);
 bool serial_connected(void);


### PR DESCRIPTION
Fixes #9429 

I took this further than I was planning, but these changes do resolve the UART issues when pasting large files into the REPL paste (CTRL-E) mode on ESP32 boards that don't have uart flow control capability.

The first [commit](https://github.com/adafruit/circuitpython/commit/e1e6aed68515bd2974af910233fcc1387e6e6c7a) simply drops any echo characters when the ESP-IDF indicates the transmit buffer is not available (full?) and does allow the successful paste of large files, however the echo'd output is pretty sparse and doesn't much resemble the transmitted file.

The final version uses the vstr variable the pasted data is being loaded into as a UART output buffer so that the echo (tx process) can fall behind the pasted data input (rx). The routine doesn't attempt to echo if there is serial data available for input and whenever serial input is detected or the tx routines detect that the transmit buffer is unavailable no more attempts to transmit are made for 100ms.

Other than the CTRL-E pasting loop in pyexec.c there were basically two changes made to get this to work. 

The first was a bit of a hack, because I didn't want to add a new parameter to all of the modules in the uart tx chain (mp_hal_stdout_tx_strn->serial_write_substring->common_hal_busio_uart_write) as that would involve updating any module that called any of those routines. So instead I used the sign of the "length" argument as a flag to indicate whether the common_hal_busio_uart_write module should do it's normal retry loop until the data was transmitted or simply try once for each character being transmitted. If a negative length was passed, the uart_write module would essentially not retry the writes and would also not kick off the BACKGROUND_TASKS that normally ran while the retries were occurring.

The second change was to update the serial TX modules to properly pass back the number of bytes actually transmitted. After making this change, it turned out that the ESP32 uart tx functions are not completely reliable in detecting when a tx fails (my guess is that if between the time the routines check the availability of the tx buffer and the time the data is put onto the output registers the tx buffer becomes unavailable, then the data will not transmit). Since the tx failure detection was not completely reliable some of the echo output were still being lost (the echo'd display did much more closely resemble the pasted data though), adding the 100ms delay to tx write seems to resolve any lost echo'd data issues.

I don't have any training or real experience in writing C code so if the Adafruit folks think this PR is worth pursuing, don't worry about commenting on what I'm sure are my many poor programming style/functional choices :grin: