### PR TITLE
add looping to rp2040 analogbufio.BufferedIn

### DIFF
--- a/ports/espressif/common-hal/analogbufio/BufferedIn.c
+++ b/ports/espressif/common-hal/analogbufio/BufferedIn.c
@@ -215,7 +215,7 @@ static bool check_valid_data(const adc_digi_output_data_t *data, const mcu_pin_o
     return true;
 }
 
-uint32_t common_hal_analogbufio_bufferedin_readinto(analogbufio_bufferedin_obj_t *self, uint8_t *buffer, uint32_t len, uint8_t bytes_per_sample) {
+uint32_t common_hal_analogbufio_bufferedin_readinto(analogbufio_bufferedin_obj_t *self, uint8_t *buffer, uint32_t len, uint8_t bytes_per_sample, bool loop) {
     uint8_t result[NUM_SAMPLES_PER_INTERRUPT * SOC_ADC_DIGI_DATA_BYTES_PER_CONV] __attribute__ ((aligned(4))) = {0};
     uint32_t captured_samples = 0;
     uint32_t captured_bytes = 0;

--- a/ports/raspberrypi/common-hal/analogbufio/BufferedIn.h
+++ b/ports/raspberrypi/common-hal/analogbufio/BufferedIn.h
@@ -17,6 +17,6 @@ typedef struct {
     mp_obj_base_t base;
     const mcu_pin_obj_t *pin;
     uint8_t chan;
-    uint dma_chan;
-    dma_channel_config cfg;
+    uint dma_chan[2];
+    dma_channel_config cfg[2];
 } analogbufio_bufferedin_obj_t;

--- a/shared-bindings/analogbufio/BufferedIn.c
+++ b/shared-bindings/analogbufio/BufferedIn.c
@@ -36,7 +36,6 @@
 //|         ``reference_voltage`` to read the configured setting.
 //|         (TODO) Provide mechanism to read CPU Temperature."""
 //|
-
 //|     def __init__(self, pin: microcontroller.Pin, *, sample_rate: int) -> None:
 //|         """Create a `BufferedIn` on the given pin and given sample rate.
 //|
@@ -96,47 +95,53 @@ static mp_obj_t analogbufio_bufferedin___exit__(size_t n_args, const mp_obj_t *a
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(analogbufio_bufferedin___exit___obj, 4, 4, analogbufio_bufferedin___exit__);
 
-//|     def readinto(self, buffer: WriteableBuffer) -> int:
+//|     def readinto(self, buffer: WriteableBuffer, loop: bool) -> int:
 //|         """Fills the provided buffer with ADC voltage values.
 //|
 //|         ADC values will be read into the given buffer at the supplied sample_rate.
 //|         Depending on the buffer typecode, 'B', 'H', samples are 8-bit byte-arrays or
 //|         16-bit half-words and are always unsigned.
-//|         The ADC most significant bits of the ADC are kept. (See
-//|         https://docs.circuitpython.org/en/latest/docs/library/array.html)
+//|         (See https://docs.circuitpython.org/en/latest/docs/library/array.html)
+//|         For 8-bit samples, the most significant bits of the 12-bit ADC values are kept.
+//|         For 16-bit samples, if loop=False, the 12-bit ADC values are scaled up to fill the 16 bit range.
+//|         If loop=True, ADC values are stored without scaling.
 //|
-//|         :param ~circuitpython_typing.WriteableBuffer buffer: buffer: A buffer for samples"""
+//|         :param ~circuitpython_typing.WriteableBuffer buffer: buffer: A buffer for samples
+//|         :param ~bool loop: loop: Set to true for continuous conversions, False to fill buffer once then stop
+//|         """
 //|         ...
 //|
-static mp_obj_t analogbufio_bufferedin_obj_readinto(mp_obj_t self_in, mp_obj_t buffer_obj) {
-    analogbufio_bufferedin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+static mp_obj_t analogbufio_bufferedin_obj_readinto(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_buffer, ARG_loop };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_buffer,    MP_ARG_OBJ | MP_ARG_REQUIRED, {} },
+        { MP_QSTR_loop,      MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
+    };
+    analogbufio_bufferedin_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     check_for_deinit(self);
-
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_obj_t buffer = args[ARG_buffer].u_obj;
     // Buffer defined and allocated by user
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(buffer_obj, &bufinfo, MP_BUFFER_READ);
-
+    mp_get_buffer_raise(buffer, &bufinfo, MP_BUFFER_READ);
     uint8_t bytes_per_sample = 1;
-
-    // Bytes Per Sample
     if (bufinfo.typecode == 'H') {
         bytes_per_sample = 2;
     } else if (bufinfo.typecode != 'B' && bufinfo.typecode != BYTEARRAY_TYPECODE) {
         mp_raise_ValueError_varg(MP_ERROR_TEXT("%q must be a bytearray or array of type 'H' or 'B'"), MP_QSTR_buffer);
     }
-
-    mp_uint_t captured = common_hal_analogbufio_bufferedin_readinto(self, bufinfo.buf, bufinfo.len, bytes_per_sample);
+    mp_uint_t captured = common_hal_analogbufio_bufferedin_readinto(self, bufinfo.buf, bufinfo.len, bytes_per_sample, args[ARG_loop].u_bool);
     return MP_OBJ_NEW_SMALL_INT(captured);
 }
-MP_DEFINE_CONST_FUN_OBJ_2(analogbufio_bufferedin_readinto_obj, analogbufio_bufferedin_obj_readinto);
+MP_DEFINE_CONST_FUN_OBJ_KW(analogbufio_bufferedin_readinto_obj, 1, analogbufio_bufferedin_obj_readinto);
 
 static const mp_rom_map_elem_t analogbufio_bufferedin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___del__),    MP_ROM_PTR(&analogbufio_bufferedin_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit),     MP_ROM_PTR(&analogbufio_bufferedin_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR___enter__),  MP_ROM_PTR(&default___enter___obj) },
     { MP_ROM_QSTR(MP_QSTR___exit__),   MP_ROM_PTR(&analogbufio_bufferedin___exit___obj) },
-    { MP_ROM_QSTR(MP_QSTR_readinto),       MP_ROM_PTR(&analogbufio_bufferedin_readinto_obj)},
-
+    { MP_ROM_QSTR(MP_QSTR_readinto),   MP_ROM_PTR(&analogbufio_bufferedin_readinto_obj)},
 };
 
 static MP_DEFINE_CONST_DICT(analogbufio_bufferedin_locals_dict, analogbufio_bufferedin_locals_dict_table);

--- a/shared-bindings/analogbufio/BufferedIn.c
+++ b/shared-bindings/analogbufio/BufferedIn.c
@@ -95,7 +95,7 @@ static mp_obj_t analogbufio_bufferedin___exit__(size_t n_args, const mp_obj_t *a
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(analogbufio_bufferedin___exit___obj, 4, 4, analogbufio_bufferedin___exit__);
 
-//|     def readinto(self, buffer: WriteableBuffer, loop: bool) -> int:
+//|     def readinto(self, buffer: WriteableBuffer, loop: bool = False) -> int:
 //|         """Fills the provided buffer with ADC voltage values.
 //|
 //|         ADC values will be read into the given buffer at the supplied sample_rate.

--- a/shared-bindings/analogbufio/BufferedIn.h
+++ b/shared-bindings/analogbufio/BufferedIn.h
@@ -14,4 +14,4 @@ extern const mp_obj_type_t analogbufio_bufferedin_type;
 void common_hal_analogbufio_bufferedin_construct(analogbufio_bufferedin_obj_t *self, const mcu_pin_obj_t *pin, uint32_t sample_rate);
 void common_hal_analogbufio_bufferedin_deinit(analogbufio_bufferedin_obj_t *self);
 bool common_hal_analogbufio_bufferedin_deinited(analogbufio_bufferedin_obj_t *self);
-uint32_t common_hal_analogbufio_bufferedin_readinto(analogbufio_bufferedin_obj_t *self, uint8_t *buffer, uint32_t len, uint8_t bytes_per_sample);
+uint32_t common_hal_analogbufio_bufferedin_readinto(analogbufio_bufferedin_obj_t *self, uint8_t *buffer, uint32_t len, uint8_t bytes_per_sample, bool loop);

--- a/tests/circuitpython-manual/live_audio/analogbufio_bufferedin_loop.py
+++ b/tests/circuitpython-manual/live_audio/analogbufio_bufferedin_loop.py
@@ -1,0 +1,23 @@
+import analogbufio
+import array
+import audiocore
+import audiopwmio
+import board
+
+samples = 100
+buffer = array.array("H", [0x0000] * samples)
+adc = analogbufio.BufferedIn(board.A0, sample_rate=100000)
+
+adc.readinto(buffer)
+
+print("Sample,Print 1, Print 2,Print 3, Print 4")
+for i in range(4):
+    for j in range(samples):
+        print(j, "," * (i + 1), buffer[j])
+
+adc.readinto(buffer, loop=True)
+
+print("Sample,Print 1, Print 2,Print 3, Print 4")
+for i in range(4):
+    for j in range(samples):
+        print(j, "," * (i + 1), buffer[j])


### PR DESCRIPTION
This PR contains part of the changes necessary to implement the processing of live sampled audio as described in https://github.com/adafruit/circuitpython/issues/2676.  Here `analogbufio.BufferedIn` is modified to add a `loop` keyword argument to `BufferedIn.readinto()`.  If called without the keyword or with `loop=False`, behavior is identical to the current `readinto()`.  If called with `loop=True`, `readinto()` sets up chained DMA which continuously writes ADC values into the buffer.

The contrast between the two modes can be seen by plotting the output of [test code](https://github.com/timchinowsky/circuitpython/blob/analogbufio-loop/tests/circuitpython-manual/live_audio/analogbufio_bufferedin_loop.py) listed here:

```python
import analogbufio
import array
import audiocore
import audiopwmio
import board

samples = 100
buffer = array.array("H", [0x0000] * samples)
adc = analogbufio.BufferedIn(board.A0, sample_rate=100000)

adc.readinto(buffer)

print("Sample,Print 1, Print 2,Print 3, Print 4")
for i in range(4):
    for j in range(samples):
        print(j, "," * (i + 1), buffer[j])

adc.readinto(buffer, loop=True)

print("Sample,Print 1, Print 2,Print 3, Print 4")
for i in range(4):
    for j in range(samples):
        print(j, "," * (i + 1), buffer[j])
```
Here is a plot of the data output by the first print loop when pin `A0` is driven by a 1 kHz sine wave:

![chart (1)](https://github.com/user-attachments/assets/f8727df1-aa6f-4936-a78d-1254d5fdbbd0)

The buffer is plotted 4 times, but you can only see one (green) series, because when `loop=False` the buffer is static.  Compare the plot generated from the second print loop:

![chart (2)](https://github.com/user-attachments/assets/e9e0464d-12e3-44c2-8702-741aa0feac15)
 
The slight scatter between the series shows that the data in the buffer is different in each of the 4 print sequences.  If the print loop is repeated again, the plot is similar, but has drifted in phase due to small differences between the clock rates of the ADC and the signal generator:

![chart (3)](https://github.com/user-attachments/assets/22a88501-8948-439d-83e2-cb8b0292af4c)

These plots are deceptively simple, because the signal frequency was chosen to put exactly one period of the signal in each buffer.  If you change the frequency to 500 Hz instead the complications can be seen:

![chart (4)](https://github.com/user-attachments/assets/85e2a45a-53d7-41d7-8b30-2a3b5cf981ee)

During the ~241 ms required to print the buffer 4 times, it has been refilled by DMA 241 times, alternating between the upward-going half of the sine wave and the downward-going half.  Which half shows up at each printed sample will depend upon when exactly in the sequence that particular sample value was observed.

The other difference between `loop=False` and `loop=True` is that while `readinto(buffer, loop=False)` blocks until DMA is complete, then scales the ADC values to 16 bits before returning, `readinto(buffer, loop=True)` returns immediately after starting DMA, and the buffer values are raw unscaled ADC data. 
   
 