### PR TITLE
sys: remove nonstandard print_exception

### DIFF
--- a/docs/library/sys.rst
+++ b/docs/library/sys.rst
@@ -97,12 +97,6 @@ Constants
    If you need to check whether your program runs on CircuitPython (vs other
    Python implementation), use `sys.implementation` instead.
 
-.. data:: ps1
-          ps2
-
-   Mutable attributes holding strings, which are used for the REPL prompt.  The defaults
-   give the standard Python prompt of ``>>>`` and ``...``.
-
 .. data:: stderr
 
    Standard error ``stream``.
@@ -114,14 +108,6 @@ Constants
 .. data:: stdout
 
    Standard output ``stream``.
-
-.. data:: tracebacklimit
-
-   A mutable attribute holding an integer value which is the maximum number of traceback
-   entries to store in an exception.  Set to 0 to disable adding tracebacks.  Defaults
-   to 1000.
-
-   Note: this is not available on all ports.
 
 .. data:: version
 

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -142,6 +142,8 @@ extern void common_hal_mcu_enable_interrupts(void);
 #define MICROPY_PY_SYS                   (CIRCUITPY_SYS)
 #define MICROPY_PY_SYS_MAXSIZE           (1)
 #define MICROPY_PY_SYS_STDFILES          (1)
+// Supplanted by traceback.print_exception
+#define MICROPY_PY_SYS_PRINT_EXCEPTION   (0)
 #define MICROPY_PY___FILE__              (1)
 
 #define MICROPY_QSTR_BYTES_IN_HASH       (1)

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -302,7 +302,10 @@ STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
      * Extensions to CPython
      */
 
+    #if MICROPY_PY_SYS_PRINT_EXCEPTION
     { MP_ROM_QSTR(MP_QSTR_print_exception), MP_ROM_PTR(&mp_sys_print_exception_obj) },
+    #endif
+
     #if MICROPY_PY_SYS_ATEXIT
     { MP_ROM_QSTR(MP_QSTR_atexit), MP_ROM_PTR(&mp_sys_atexit_obj) },
     #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1478,6 +1478,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_SYS_EXIT (1)
 #endif
 
+// Whether to provide "sys.print_exception" function (MicroPython extension)
+#ifndef MICROPY_PY_SYS_PRINT_EXCEPTION
+#define MICROPY_PY_SYS_PRINT_EXCEPTION (0)
+#endif
+
 // Whether to provide "sys.atexit" function (MicroPython extension)
 #ifndef MICROPY_PY_SYS_ATEXIT
 #define MICROPY_PY_SYS_ATEXIT (0)

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1480,7 +1480,7 @@ typedef double mp_float_t;
 
 // Whether to provide "sys.print_exception" function (MicroPython extension)
 #ifndef MICROPY_PY_SYS_PRINT_EXCEPTION
-#define MICROPY_PY_SYS_PRINT_EXCEPTION (0)
+#define MICROPY_PY_SYS_PRINT_EXCEPTION (1)
 #endif
 
 // Whether to provide "sys.atexit" function (MicroPython extension)


### PR DESCRIPTION
CircuitPython provides this at `exception.print_exception()`, with improved compatibility with standard Python.

This is an alternative to #9427, which adds documentation for the non-standard function.

One reason NOT to take this change is that the traceback module is not built on samd21s, leaving non-standard `sys.print_exception` as the only way to print an exception object (besides raising it)