### PR TITLE
bleio_user_reset(): check if BLE running before doing any BLE ops

### DIFF
--- a/ports/nordic/common-hal/_bleio/__init__.c
+++ b/ports/nordic/common-hal/_bleio/__init__.c
@@ -78,9 +78,11 @@ void common_hal_bleio_init(void) {
 }
 
 void bleio_user_reset() {
-    // Stop any user scanning or advertising.
-    common_hal_bleio_adapter_stop_scan(&common_hal_bleio_adapter_obj);
-    common_hal_bleio_adapter_stop_advertising(&common_hal_bleio_adapter_obj);
+    if (common_hal_bleio_adapter_get_enabled(&common_hal_bleio_adapter_obj)) {
+        // Stop any user scanning or advertising.
+        common_hal_bleio_adapter_stop_scan(&common_hal_bleio_adapter_obj);
+        common_hal_bleio_adapter_stop_advertising(&common_hal_bleio_adapter_obj);
+    }
 
     ble_drv_remove_heap_handlers();
 


### PR DESCRIPTION
- Fixes #9442 

`bleio_user_reset()` was trying to do SoftDevice operations after the `Adapter` was disabled, causing `NRF_ERROR_SOFTDEVICE_NOT_ENABLED`, which tried to raise an exception after the VM was shut down. Check before trying to do these operations.