### PR TITLE
Fix IncrementalEncoder overflow on ESP32

### DIFF
--- a/ports/espressif/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/espressif/common-hal/rotaryio/IncrementalEncoder.c
@@ -23,7 +23,7 @@ void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencode
     // in CircuitPython.
     pcnt_unit_config_t unit_config = {
         // Set counter limit
-        .low_limit  = INT16_MIN,
+        .low_limit = INT16_MIN,
         .high_limit = INT16_MAX
     };
     // Enable PCNT internal accumulator to count overflows.

--- a/ports/espressif/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/espressif/common-hal/rotaryio/IncrementalEncoder.c
@@ -23,14 +23,18 @@ void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencode
     // in CircuitPython.
     pcnt_unit_config_t unit_config = {
         // Set counter limit
-        .low_limit = -INT16_MAX,
+        .low_limit  = INT16_MIN,
         .high_limit = INT16_MAX
     };
-    // The pulse count driver automatically counts roll overs.
+    // Enable PCNT internal accumulator to count overflows.
     unit_config.flags.accum_count = true;
 
     // initialize PCNT
     CHECK_ESP_RESULT(pcnt_new_unit(&unit_config, &self->unit));
+
+    // Set low and high watchpoints, to auto-accumulate overflows. Reflected in pcnt_unit_get_count().
+    pcnt_unit_add_watch_point(self->unit, INT16_MAX);
+    pcnt_unit_add_watch_point(self->unit, INT16_MIN);
 
     pcnt_chan_config_t channel_a_config = {
         .edge_gpio_num = pin_a->number,


### PR DESCRIPTION
While using a rotary encoder with ESP32-S3, I noticed both the high and low limits were returning to 0 on overflow, which is the default behavior of the ESP32 PCNT when the internal accumulator is disabled.

`unit_config.flags.accum_count = true;` is set in the code, but watchpoints matching the high and low limits also need to be created for the internal accumulator to work.

This PR should fix that.