### PR TITLE
espressif: enable PCNT accumulator for Counter, FrequencyIn, Incremental Encoder

### DIFF
--- a/ports/espressif/common-hal/countio/Counter.c
+++ b/ports/espressif/common-hal/countio/Counter.c
@@ -20,14 +20,18 @@ void common_hal_countio_counter_construct(countio_counter_obj_t *self,
 
     pcnt_unit_config_t unit_config = {
         // Set counter limit
-        .low_limit = -1,
+        .low_limit = INT16_MIN,
         .high_limit = INT16_MAX
     };
-    // The pulse count driver automatically counts roll overs.
+    // Enable PCNT internal accumulator to count overflows.
     unit_config.flags.accum_count = true;
 
     // initialize PCNT
     CHECK_ESP_RESULT(pcnt_new_unit(&unit_config, &self->unit));
+    
+    // Set watchpoints at limis, to auto-accumulate overflows.
+    pcnt_unit_add_watch_point(self->unit, INT16_MIN);
+    pcnt_unit_add_watch_point(self->unit, INT16_MAX);
 
     self->pin = pin->number;
     pcnt_chan_config_t channel_config = {

--- a/ports/espressif/common-hal/countio/Counter.c
+++ b/ports/espressif/common-hal/countio/Counter.c
@@ -28,7 +28,7 @@ void common_hal_countio_counter_construct(countio_counter_obj_t *self,
 
     // initialize PCNT
     CHECK_ESP_RESULT(pcnt_new_unit(&unit_config, &self->unit));
-    
+
     // Set watchpoints at limis, to auto-accumulate overflows.
     pcnt_unit_add_watch_point(self->unit, INT16_MIN);
     pcnt_unit_add_watch_point(self->unit, INT16_MAX);

--- a/ports/espressif/common-hal/frequencyio/FrequencyIn.c
+++ b/ports/espressif/common-hal/frequencyio/FrequencyIn.c
@@ -30,10 +30,10 @@ static IRAM_ATTR bool timer_interrupt_handler(gptimer_handle_t timer,
 static esp_err_t init_pcnt(frequencyio_frequencyin_obj_t *self) {
     pcnt_unit_config_t unit_config = {
         // Set counter limit
-        .low_limit = -INT16_MAX + 1,
+        .low_limit = INT16_MIN,
         .high_limit = INT16_MAX
     };
-    // The pulse count driver automatically counts roll overs.
+    // Enable PCNT internal accumulator to count overflows.
     unit_config.flags.accum_count = true;
 
     // initialize PCNT
@@ -41,6 +41,10 @@ static esp_err_t init_pcnt(frequencyio_frequencyin_obj_t *self) {
     if (result != ESP_OK) {
         return result;
     }
+    
+    // Set watchpoints at limis, to auto-accumulate overflows.
+    pcnt_unit_add_watch_point(self->unit, INT16_MIN);
+    pcnt_unit_add_watch_point(self->unit, INT16_MAX);
 
     pcnt_chan_config_t channel_config = {
         .edge_gpio_num = self->pin,

--- a/ports/espressif/common-hal/frequencyio/FrequencyIn.c
+++ b/ports/espressif/common-hal/frequencyio/FrequencyIn.c
@@ -41,10 +41,10 @@ static esp_err_t init_pcnt(frequencyio_frequencyin_obj_t *self) {
     if (result != ESP_OK) {
         return result;
     }
-    
+
     // Set watchpoints at limis, to auto-accumulate overflows.
-    pcnt_unit_add_watch_point(self->unit, INT16_MIN);
-    pcnt_unit_add_watch_point(self->unit, INT16_MAX);
+    pcnt_unit_add_watch_point(self->internal_data->unit, INT16_MIN);
+    pcnt_unit_add_watch_point(self->internal_data->unit, INT16_MAX);
 
     pcnt_chan_config_t channel_config = {
         .edge_gpio_num = self->pin,

--- a/ports/espressif/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/espressif/common-hal/rotaryio/IncrementalEncoder.c
@@ -23,14 +23,18 @@ void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencode
     // in CircuitPython.
     pcnt_unit_config_t unit_config = {
         // Set counter limit
-        .low_limit = -INT16_MAX,
+        .low_limit = INT16_MIN,
         .high_limit = INT16_MAX
     };
-    // The pulse count driver automatically counts roll overs.
+    // Enable PCNT internal accumulator to count overflows.
     unit_config.flags.accum_count = true;
 
     // initialize PCNT
     CHECK_ESP_RESULT(pcnt_new_unit(&unit_config, &self->unit));
+
+    // Set watchpoints at limits, to auto-accumulate overflows.
+    pcnt_unit_add_watch_point(self->unit, INT16_MIN);
+    pcnt_unit_add_watch_point(self->unit, INT16_MAX);
 
     pcnt_chan_config_t channel_a_config = {
         .edge_gpio_num = pin_a->number,


### PR DESCRIPTION
Same as #9459, but against 9.1.x branch, and enabled accumulator for other classes using PCNT: Counter and FrequencyIn.