### PR TITLE
Mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -6,17 +6,31 @@
 Alec Delaney <tekktrik@gmail.com>
 Alec Delaney <tekktrik@gmail.com> <89490472+tekktrik@users.noreply.github.com>
 Alec Delaney <tekktrik@gmail.com> <tekktik@gmail.com>
+Alex Sirota <alex.sirota@icloud.com>
+Alex Sirota <alex.sirota@icloud.com> <67526318+ajs256@users.noreply.github.com>
 Alexander Steffen <devel.20.webmeister@spamgourmet.com>
 Alexander Steffen <devel.20.webmeister@spamgourmet.com> <Alexander.Steffen@infineon.com>
 Alexander Steffen <devel.20.webmeister@spamgourmet.com> <webmeister@users.noreply.github.com>
+Anson He <ansonhe1997@gmail.com>
+Ayke van Laethem <aykevanlaethem@gmail.com>
 Benjamin Vernoux <bvernoux@gmail.com>
+BennyE <bennye_hh@posteo.net>
+BennyE <bennye_hh@posteo.net> <benny@Benny-Win10.localdomain>
+Bernhard Bablok <bablokb@gmx.de>
+Bernhard Boser <boser@berkeley.edu>
+Bernhard Boser <boser@berkeley.edu> <49917707+iot49@users.noreply.github.com>
+Bernhard Boser <boser@berkeley.edu> <boser@server.home>
+Bill Sideris <bill88t@feline.gr>
+Brendan <2bndy5@gmail.com>
 Brent Rubell <robots199@me.com>
 Brent Rubell <robots199@me.com> <brent@xn.home>
 Brent Rubell <robots199@me.com> <brentru@users.noreply.github.com>
 Carlos <carlos.santiago.diaz@gmail.com>
 Carter Nelson <caternuson@gmail.com>
+Chris Dailey <nitz@users.noreply.github.com>
 Chris Packham <judge.packham@gmail.com>
 Chris Packham <judge.packham@gmail.com> <chris.packham@alliedtelesis.co.nz>
+Chris Wilson <christopher.david.wilson@gmail.com>
 Damiano Mazzella <damianomazzella@gmail.com>
 Damien George <damien.p.george@gmail.com>
 Dan Halbert <halbert@adafruit.com>
@@ -25,51 +39,92 @@ Daniel Pollard <daniel@learnweaver.com>
 Daniel Pollard <daniel@learnweaver.com> <daniel.pollard@learnweaver.com>
 Daniel Tralamazza <daniel@tralamazza.com>
 Daniel Tralamazza <daniel@tralamazza.com> <tralamazza@users.noreply.github.com>
+DavePutz <dwputz@gmail.com>
 David Glaude <david.glaude@gmail.com>
 David Glaude <david.glaude@gmail.com> <dglaude@users.noreply.github.com>
+Elvis Pfützenreuter <epxx@epxx.co>
+Enrique Casado <ecasado@bhdyn.com>
+Enrique Casado <ecasado@bhdyn.com> <32364364+ecasadod@users.noreply.github.com>
 Eva Herrada <eva.herrada@adafruit.com>
 Eva Herrada <eva.herrada@adafruit.com> <33632497+dherrada@users.noreply.github.com>
 Eva Herrada <eva.herrada@adafruit.com> <33632497+evaherrada@users.noreply.github.com>
 Eva Herrada <eva.herrada@adafruit.com> <dylan.herrada@adafruit.com>
 Eva Herrada <eva.herrada@adafruit.com> <dylan.herrada@gmail.com>
 Eva Herrada <eva.herrada@adafruit.com> dherrada <=>
+Florin Maticu <florin.maticu@gmail.com>
+Florin Maticu <florin.maticu@gmail.com> <3575408+flom84@users.noreply.github.com>
+Florin Maticu <florin.maticu@gmail.com> <flomaker84@gmail.com>
+Frédéric Pierson <fpierson@garatronic.fr>
+Fábio Souza <fs.embarcados@gmail.com>
 George Waters <gwatersdev@gmail.com>
 George Waters <gwatersdev@gmail.com> <george@georgeh2os.com>
+Glenn Moloney <glenn.moloney@gmail.com>
 Ha Thach <thach@tinyusb.org>
 Henrik Sölver <henrik.solver@gmail.com>
+Ihor Nehrutsa <Ihor.Nehrutsa@gmail.com>
+Ihor Nehrutsa <Ihor.Nehrutsa@gmail.com> <IhorNehrutsa@gmail.com>
 Ilya Dmitrichenko <errordeveloper@gmail.com>
 Ilya Dmitrichenko <errordeveloper@gmail.com> <ilya@xively.com>
+James Bowman <jamesb@excamera.com>
+James Bowman <jamesb@excamera.com> <James Bowman>
+James Carr <lesamouraipourpre@gmail.com>
+James Carr <lesamouraipourpre@gmail.com> <70200140+lesamouraipourpre@users.noreply.github.com>
+James Nadeau <james.nadeau@gmail.com>
+Jan Hrudka <jahr@atlas.cz>
 Jason Pecor <14111408+jpecor@users.noreply.github.com>
 Jeff Epler <jepler@gmail.com>
 Jeff Epler <jepler@gmail.com> <jeff@adafruit.com>
 Jeff Epler <jepler@gmail.com> <jepler@de11.u>
 Jeff Epler <jepler@gmail.com> <jepler@unpythonic.net>
+Jensen Kuras <jensechu@gmail.com>
+Jeremy Littler <brainboardz@gmail.com>
+Jeremy Littler <brainboardz@gmail.com> <87398149+BrainBoardz@users.noreply.github.com>
 Jerry Needell <jerryneedell@gmail.com>
 Joe Bakalor <jmbakalor@gmail.com>
+Jonah Yolles-Murphy <TGTechie01@gmail.com>
+Jonah Yolles-Murphy <TGTechie01@gmail.com> <39284876+TG-Techie@users.noreply.github.com>
+Jonah Yolles-Murphy <TGTechie01@gmail.com> <TGTechie01@gmial.com>
+Jonah Yolles-Murphy <TGTechie01@gmail.com> <tgtechie01@gmail.com>
+Jonathan Giles <jonathangiles@fastmail.fm>
+Jonathan Giles <jonathangiles@fastmail.fm> <jgiles@Jonathans-Air.lan>
+Jonny Bergdahl <jonny@bergdahl.it>
+Jonny Bergdahl <jonny@bergdahl.it> <bergdahl@users.noreply.github.com>
+Jos Verlinde <jos_verlinde@hotmail.com>
+Jos Verlinde <jos_verlinde@hotmail.com> <jos.verlinde@microsoft.com>
+Jos Verlinde <jos_verlinde@hotmail.com> <josverl@microsoft.com>
 Josh Klar <josh@klar.sh>
 Josh Klar <josh@klar.sh> <j@iv597.com>
 Juan Biondi <juanernestobiondi@gmail.com>
 Juan Biondi <juanernestobiondi@gmail.com> <juanernestobiondi@hotmail.com>
+Julia Hathaway <julia.hathaway@nxp.com>
 KalbeAbbas <kalbeabbas142@gmail.com>
 KalbeAbbas <kalbeabbas142@gmail.com> <kalbeabbas@142@gmail.com>
 Kamil Tomaszewski <kamil.tomaszewski@sony.com>
 Kamil Tomaszewski <kamil.tomaszewski@sony.com> <46525824+kamtom480@users.noreply.github.com>
-Kattni <kattni@adafruit.com> <kattni@kittyfish.org>
-Kattni Rembor <kattni@adafruit.com>
+Kattni Rembor <kattni@kattni.com>
+Kattni Rembor <kattni@kattni.com> <kattni@adafruit.com>
+Kattni Rembor <kattni@kattni.com> <kattni@kittyfish.org>
 Kenny <WarriorOfWire@users.noreply.github.com>
 Kenny <WarriorOfWire@users.noreply.github.com> <3454741+WarriorOfWire@users.noreply.github.com>
+Kevin Matocha <kmatocha@icloud.com>
+Kevin Matocha <kmatocha@icloud.com> <Dad@iMac.attlocal.net>
 Kevin Townsend <contact@microbuilder.eu>
 Kevin Townsend <contact@microbuilder.eu> <microbuilder@users.noreply.github.com>
 Krzysztof Blazewicz <blazewicz.krzysztof@gmail.com>
 Krzysztof Blazewicz <blazewicz.krzysztof@gmail.com> <krzysztof.blazewicz@uxeon.com>
+Lee Atkinson <latkinso42@gmail.com>
 Li Weiwei <liweiwei@yeweitech.org>
 Li Weiwei <liweiwei@yeweitech.org> <liweiwei@yeweitech.com>
 Limor "Ladyada" Fried <limor@ladyada.net>
 Limor "Ladyada" Fried <limor@ladyada.net> <ladyada>
 Lucian Copeland <hierophect@gmail.com>
 Lucian Copeland <hierophect@gmail.com> <hierophect@Lucians-MacBook-Air-2.local>
+Mariusz Ćwikła <mariuszcwikla@gmail.com>
+Mariusz Ćwikła <mariuszcwikla@gmail.com> <47976407+MariuszCwikla@users.noreply.github.com>
 Mark Olsson <post@markolsson.se>
 Mark Olsson <post@markolsson.se> <mark@markolsson.se>
+Mark Roberts <mdroberts1243@gmail.com>
+Martin Fischer <fischer.carlito@gmail.com>
 Matt Land <matt-land@users.noreply.github.com>
 Matt Land <matt-land@users.noreply.github.com> <mland@sparefoot.com>
 Matt Wozniski <godlygeek+git@gmail.com>
@@ -78,19 +133,44 @@ Melissa LeBlanc-Williams <melissa@adafruit.com>
 Melissa LeBlanc-Williams <melissa@adafruit.com> <melissa@melissagirl.com>
 Metallicow <metaliobovinus@gmail.com>
 Metallicow <metaliobovinus@gmail.com> <edg62702@yahoo.com>
+Michael McWethy <mrmcwethy@yahoo.com>
+Michael Weiss <github@mishafarms.us>
+MicroDev <70126934+microdev1@users.noreply.github.com>
+MicroDev <70126934+microdev1@users.noreply.github.com> <70126934+MicroDev1@users.noreply.github.com>
+Mike Teachman <mike.teachman@gmail.com>
+Milind Movasha <milind.movasha@gmail.com>
+Miroslav Zuzelka <mzuzelka@gmail.com>
+Noel Gaetan <gaetan.noel@viacesi.fr>
+Pablo Martinez Bernal <elpekenin@elpekenin.dev>
+Pablo Martinez Bernal <elpekenin@elpekenin.dev> <58857054+elpekenin@users.noreply.github.com>
+Paint Your Dragon <paintyourdragon@dslextreme.com>
+Patrick <4002194+askpatrickw@users.noreply.github.com>
 Peter Hinch <peter@hinch.me.uk>
 Peter Hinch <peter@hinch.me.uk> <peterhinch@users.noreply.github.com>
+Pierre Constantineau <jpconstantineau@gmail.com>
+Pierre Constantineau <jpconstantineau@gmail.com> <jponstantineau@gmail.com>
 Radomir Dopieralski <openstack@sheep.art.pl>
 Radomir Dopieralski <openstack@sheep.art.pl> <deshipu@users.noreply.github.com>
 Rafa Gould <rafagoulds@gmail.com>
 Rafa Gould <rafagoulds@gmail.com> <50337143+rafa-gould@users.noreply.github.com>
+Rami Ali <raminator626@hotmail.com>
+Rami Ali <raminator626@hotmail.com> Rami Ali <flowergrass@users.noreply.github.com>
+Reinhard Feger <feg@LT-Feger.icie.jku.at>
+Reinhard Feger <feg@LT-Feger.icie.jku.at> <47209718+rf-eng@users.noreply.github.com>
+Rick Sorensen <rick.sorensen@gmail.com>
+Rick Sorensen <rick.sorensen@gmail.com> <rick@ricklinux2>
+Robert HH <robert@hammelrath.com>
+Rose Hooper <rhooper@toybox.ca>
 Ryan Shaw <ryan.shaw@wisetechglobal.com>
 Ryan Shaw <ryan.shaw@wisetechglobal.com> <ryannathans@hotmail.com>
+Ryan T. Hamilton <astrobokonon@gmail.com>
+Ryan T. Hamilton <astrobokonon@gmail.com> <astrobokonon@users.noreply.github.com>
 Rylie Pavlik <rylie@ryliepavlik.com>
 Rylie Pavlik <rylie@ryliepavlik.com> <ryan.pavlik@gmail.com>
 Sabas <s@electroniccats.com>
 Sabas <s@electroniccats.com> <s@theinventorhouse.org>
 Sabas <s@electroniccats.com> <sabasjimenez@gmail.com>
+Scott Gauche <scott.gauche@gmail.com> <sgauche@users.noreply.github.com>
 Scott Shawcroft <scott@adafruit.com>
 Scott Shawcroft <scott@adafruit.com> <devnull@unpythonic.net>
 Scott Shawcroft <scott@adafruit.com> <scott.shawcroft@gmail.com>
@@ -100,21 +180,48 @@ Sebastian Plamauer <oeplse@gmail.com>
 Sebastian Plamauer <oeplse@gmail.com> <oepse@gmail.com>
 Senuros <Senuros@users.noreply.github.com>
 Senuros <Senuros@users.noreply.github.com> <senuros@noreply.github.com>
+Seth Kerr <skerr@aggies.ncat.edu>
+Seth Kerr <skerr@aggies.ncat.edu> <41877068+skerr92@users.noreply.github.com>
+Seth Kerr <skerr@aggies.ncat.edu> <sethkerr@Seths-Mac-mini.local>
+Shawn Hymel <hymelsr@vt.edu>
+Sky Bryant <mae@wolfsky.pet>
+Sky Bryant <mae@wolfsky.pet> <maeskywolf@protonmail.com>
+Stephane Smith <stephane.smith@titansensor.com>
 Stewart Colborne <tscolborne@outlook.com>
 Stewart Colborne <tscolborne@outlook.com> <tscolborne@hotmail.com>
-TG-Techie <TGTechie01@gmail.com>
-TG-Techie <TGTechie01@gmail.com> <39284876+TG-Techie@users.noreply.github.com>
+Sébastien Rinsoz <sebastien@yoctopuce.com>
+Takeo Takahashi <takeo.takahashi.xv@renesas.com>
 Thea Flowers <me@thea.codes>
 Thea Flowers <me@thea.codes> <theaflowers@google.com>
+Thorsten von Eicken <tve@voneicken.com>
+Thorsten von Eicken <tve@voneicken.com> <tve@users.noreply.github.com>
+Tim <timchinowsky@gmail.com>
+Tim <timchinowsky@gmail.com> <tim@gogemio.com>
 Tobias Badertscher <badi@baerospace.ch>
 Tobias Badertscher <badi@baerospace.ch> <python@baerospace.ch>
+Tobias Schmale <tschmale85@googlemail.com>
+Trammell Hudson <hudson@trmm.net>
+Tyeth Gundry <tyethgundry@googlemail.com>
+Unexpected Maker <seon@unexpectedmaker.com>
+Vladimír Smitka <vladimir.smitka@lynt.cz>
+Yuuki NAGAO <wf.yn386@gmail.com>
+adam_cummick <adamc@facts-eng.com>
+applecuckoo <nufjoysb@duck.com>
+applecuckoo <nufjoysb@duck.com> <113647417+applecuckoo@users.noreply.github.com>
+arturo182 <github@solder.party> <arturo182@tlen.pl>
 danicampora <danicampora@gmail.com>
 danicampora <danicampora@gmail.com> <daniel@wipy.io>
+foamyguy <foamyguy@gmail.com>
 glennrub <glennbakke@gmail.com>
 jposada202020 <jquintana202020@gmail.com>
 jposada202020 <jquintana202020@gmail.com> <34255413+jposada202020@users.noreply.github.com>
+mintakka <MattC867@gmail.com>
+mintakka <MattC867@gmail.com> <mattc867@gmail.com>
+noqman <noqman@cytron.io>
+noqman <noqman@cytron.io> <140384051+noqman@users.noreply.github.com>
 retoc <retoc@users.noreply.github.com>
 retoc <retoc@users.noreply.github.com> <Retoc@noreply.github.com>
+roland van straten <roland@van-straten.org>
 siddacious <nospam187+github@gmail.com>
 siddacious <nospam187+github@gmail.com> <bsiepert@gmail.com>
 siddacious <nospam187+github@gmail.com> <bsiepert@lbl.gov>

--- a/.mailmap
+++ b/.mailmap
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: 2020 Diego Elio Pettenò
+# SPDX-FileCopyrightText: 2024, Rylie Pavlik
 #
 # SPDX-License-Identifier: Unlicense
 
+Alec Delaney <tekktrik@gmail.com>
+Alec Delaney <tekktrik@gmail.com> <89490472+tekktrik@users.noreply.github.com>
+Alec Delaney <tekktrik@gmail.com> <tekktik@gmail.com>
 Alexander Steffen <devel.20.webmeister@spamgourmet.com>
 Alexander Steffen <devel.20.webmeister@spamgourmet.com> <Alexander.Steffen@infineon.com>
 Alexander Steffen <devel.20.webmeister@spamgourmet.com> <webmeister@users.noreply.github.com>
@@ -10,6 +14,7 @@ Brent Rubell <robots199@me.com>
 Brent Rubell <robots199@me.com> <brent@xn.home>
 Brent Rubell <robots199@me.com> <brentru@users.noreply.github.com>
 Carlos <carlos.santiago.diaz@gmail.com>
+Carter Nelson <caternuson@gmail.com>
 Chris Packham <judge.packham@gmail.com>
 Chris Packham <judge.packham@gmail.com> <chris.packham@alliedtelesis.co.nz>
 Damiano Mazzella <damianomazzella@gmail.com>
@@ -22,6 +27,12 @@ Daniel Tralamazza <daniel@tralamazza.com>
 Daniel Tralamazza <daniel@tralamazza.com> <tralamazza@users.noreply.github.com>
 David Glaude <david.glaude@gmail.com>
 David Glaude <david.glaude@gmail.com> <dglaude@users.noreply.github.com>
+Eva Herrada <eva.herrada@adafruit.com>
+Eva Herrada <eva.herrada@adafruit.com> <33632497+dherrada@users.noreply.github.com>
+Eva Herrada <eva.herrada@adafruit.com> <33632497+evaherrada@users.noreply.github.com>
+Eva Herrada <eva.herrada@adafruit.com> <dylan.herrada@adafruit.com>
+Eva Herrada <eva.herrada@adafruit.com> <dylan.herrada@gmail.com>
+Eva Herrada <eva.herrada@adafruit.com> dherrada <=>
 George Waters <gwatersdev@gmail.com>
 George Waters <gwatersdev@gmail.com> <george@georgeh2os.com>
 Ha Thach <thach@tinyusb.org>
@@ -75,6 +86,8 @@ Rafa Gould <rafagoulds@gmail.com>
 Rafa Gould <rafagoulds@gmail.com> <50337143+rafa-gould@users.noreply.github.com>
 Ryan Shaw <ryan.shaw@wisetechglobal.com>
 Ryan Shaw <ryan.shaw@wisetechglobal.com> <ryannathans@hotmail.com>
+Rylie Pavlik <rylie@ryliepavlik.com>
+Rylie Pavlik <rylie@ryliepavlik.com> <ryan.pavlik@gmail.com>
 Sabas <s@electroniccats.com>
 Sabas <s@electroniccats.com> <s@theinventorhouse.org>
 Sabas <s@electroniccats.com> <sabasjimenez@gmail.com>
@@ -97,10 +110,9 @@ Tobias Badertscher <badi@baerospace.ch>
 Tobias Badertscher <badi@baerospace.ch> <python@baerospace.ch>
 danicampora <danicampora@gmail.com>
 danicampora <danicampora@gmail.com> <daniel@wipy.io>
-dherrada <dylan.herrada@gmail.com>
-dherrada <dylan.herrada@gmail.com> <33632497+dherrada@users.noreply.github.com>
-dherrada <dylan.herrada@gmail.com> <=>
 glennrub <glennbakke@gmail.com>
+jposada202020 <jquintana202020@gmail.com>
+jposada202020 <jquintana202020@gmail.com> <34255413+jposada202020@users.noreply.github.com>
 retoc <retoc@users.noreply.github.com>
 retoc <retoc@users.noreply.github.com> <Retoc@noreply.github.com>
 siddacious <nospam187+github@gmail.com>


### PR DESCRIPTION
Following up from this: https://github.com/adafruit/Adafruit_CircuitPython_EMC2101/pull/34 Upgrading my name :wink: and otherwise updating the mailmap file.

I have updated the mailmap file in here too. I split my changes into two commits: One is just my own name correction and other changes that I also submitted to the EMC2101 library, the other is my best attempt at cleaning up the output of `git shortlog -s -e` and `git shortlog -s -e -n`, without making too many assumptions. That does mean there are duplicates in the shortlog still, because I didn't know which email of multiple valid-looking ones to use.

I did notice a handful of additional "name upgrades", I used `git log --author="whatever"` and sometimes github accounts to verify I was putting the most recent one in the mailmap, hopefully I got everything right.

(I swear I could spend hours every week updating mailmap files and still not get them all... So I will happily help my siblings when they've committed under both dead and upgraded names on a repo I am already messing with, if the assistance is not unwelcome.)

Feel free to edit, drop the last commit, reject everything except my own name correction, etc.

Here is the diff in `git shortlog -s -e` for the first commit, probably the easiest way to review it: 
[authors-1.diff.txt](https://github.com/user-attachments/files/16384097/authors-1.diff.txt)

Here is the diff in `git shortlog -s -e` for the second commit: 
[authors.diff.txt](https://github.com/user-attachments/files/16384085/authors.diff.txt)

I did not attempt to search the contents of files to update names, since my old name wasn't in any files, just the commit log. Future work I guess.