### PR TITLE
Only use pyi files for autoapi doc generation

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -110,6 +110,7 @@ autoapi_template_dir = 'docs/autoapi/templates'
 autoapi_python_class_content = "both"
 autoapi_python_use_implicit_namespaces = True
 autoapi_root = "shared-bindings"
+autoapi_file_patterns = ["*.pyi"]
 
 # Suppress cache warnings to prevent "unpickable" [sic] warning
 # about autoapi_prepare_jinja_env() from sphinx >= 7.3.0.


### PR DESCRIPTION
Closes #9465

Please check the RTD html build when reviewing this bug! Last time we thought we fixed this, I think only local builds were checked (or something? not sure why the previous PR passed muster)

Will want to merge 9.1.x up to main after this. This is required for fixing the builds of various bundle libraries, fixing e.g., the failure seen in https://github.com/adafruit/Adafruit_CircuitPython_EMC2101/pull/34