### PR TITLE
Added missing library dependency for Cytron IRIV IO Controller.

### DIFF
--- a/ports/raspberrypi/boards/cytron_iriv_io_controller/mpconfigboard.mk
+++ b/ports/raspberrypi/boards/cytron_iriv_io_controller/mpconfigboard.mk
@@ -17,7 +17,9 @@ CIRCUITPY_USB_HOST = 0
 # Include these Python libraries in firmware.
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_SimpleIO
 FROZEN_MPY_DIRS += $(TOP)/frozen/circuitpython-pcf85063a
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Register
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Wiznet5k
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Requests
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_FakeRequests
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_ConnectionManager
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Ticks


### PR DESCRIPTION
Added dependencies for Cytron IRIV IO Controller frozen library.
Sorry for not adding them during last PR.