### PR TITLE
Remove unique error messages

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1187,10 +1187,12 @@ msgstr ""
 #: ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2040.c py/argcheck.c
 #: shared-bindings/digitalio/DigitalInOut.c
 #: shared-bindings/epaperdisplay/EPaperDisplay.c shared-bindings/pwmio/PWMOut.c
+#: shared-module/aurora_epaper/aurora_framebuffer.c
 msgid "Invalid %q"
 msgstr ""
 
 #: ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2350.c
+#: shared-module/aurora_epaper/aurora_framebuffer.c
 msgid "Invalid %q and %q"
 msgstr ""
 
@@ -1212,11 +1214,6 @@ msgstr ""
 
 #: shared-bindings/wifi/Radio.c
 msgid "Invalid BSSID"
-msgstr ""
-
-#: shared-module/aurora_epaper/aurora_framebuffer.c
-#, c-format
-msgid "Invalid CoG id=%d"
 msgstr ""
 
 #: shared-bindings/wifi/Radio.c
@@ -2166,14 +2163,6 @@ msgstr ""
 msgid "Unknown BLE error: %d"
 msgstr ""
 
-#: shared-module/aurora_epaper/aurora_framebuffer.c
-msgid "Unknown device size."
-msgstr ""
-
-#: shared-module/aurora_epaper/aurora_framebuffer.c
-msgid "Unknown display type!"
-msgstr ""
-
 #: ports/espressif/common-hal/max3421e/Max3421E.c
 #: ports/raspberrypi/common-hal/wifi/__init__.c
 #, c-format
@@ -2229,10 +2218,6 @@ msgstr ""
 
 #: shared-bindings/bitmaptools/__init__.c
 msgid "Unsupported colorspace"
-msgstr ""
-
-#: shared-module/aurora_epaper/aurora_framebuffer.c
-msgid "Unsupported device size."
 msgstr ""
 
 #: shared-module/displayio/bus_core.c

--- a/shared-module/aurora_epaper/aurora_framebuffer.c
+++ b/shared-module/aurora_epaper/aurora_framebuffer.c
@@ -63,7 +63,7 @@ void common_hal_aurora_epaper_framebuffer_construct(
     } else if (width == 232 && height == 128) {
         self->type = LARGE_2_6;
     } else {
-        mp_raise_TypeError(MP_ERROR_TEXT("Unsupported device size."));
+        mp_raise_ValueError_varg(MP_ERROR_TEXT("Invalid %q and %q"), MP_QSTR_width, MP_QSTR_height);
     }
 
     // CS
@@ -235,7 +235,7 @@ bool common_hal_aurora_epaper_framebuffer_power_on(aurora_epaper_framebuffer_obj
 
     if (cog_id != 0x12) {
         common_hal_busio_spi_unlock(self->bus);
-        mp_raise_ValueError_varg(MP_ERROR_TEXT("Invalid CoG id=%d"), cog_id);
+        mp_raise_RuntimeError_varg(MP_ERROR_TEXT("Invalid %q"), MP_QSTR_id);
         return false;
     }
 
@@ -261,7 +261,6 @@ bool common_hal_aurora_epaper_framebuffer_power_on(aurora_epaper_framebuffer_obj
             break;
         default:
             common_hal_busio_spi_unlock(self->bus);
-            mp_raise_ValueError(MP_ERROR_TEXT("Unknown display type!"));
             return false;
     }
 
@@ -523,8 +522,6 @@ void common_hal_aurora_epaper_framebuffer_draw_line(aurora_epaper_framebuffer_ob
         common_hal_busio_spi_write(self->bus, &border, 1);
 
 #undef DO_MAP
-    } else {
-        mp_raise_TypeError(MP_ERROR_TEXT("Unknown device size."));
     }
 
     common_hal_digitalio_digitalinout_set_value(&self->chip_select, true);


### PR DESCRIPTION
The two checks on self->type should be impossible to hit so they are removed. Switch to `Invalid ...` for two others.