### PR TITLE
Update C6 IO14 pin name

### DIFF
--- a/ports/espressif/boards/adafruit_feather_esp32c6_4mbflash_nopsram/pins.c
+++ b/ports/espressif/boards/adafruit_feather_esp32c6_4mbflash_nopsram/pins.c
@@ -54,7 +54,7 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IO15), MP_ROM_PTR(&pin_GPIO15) },
     { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_GPIO15) },
 
-    { MP_ROM_QSTR(MP_QSTR_IO14), MP_ROM_PTR(&pin_GPIO14) },
+    { MP_ROM_QSTR(MP_QSTR_IO12), MP_ROM_PTR(&pin_GPIO14) },
     { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_GPIO14) },
 
     { MP_ROM_QSTR(MP_QSTR_IO0), MP_ROM_PTR(&pin_GPIO0) },


### PR DESCRIPTION
There's a pin named IO14 for the Feather ESP32-C6, but it's marked 12 on the silkscreen so was sticking in a PR to rename IO12 matching the other silkscreen pin naming (IO pin names), but not quite sure how I verify the GPIO name is correct as there is no PCB repo / guide yet. It's set as GPIO14 currently:
https://github.com/adafruit/circuitpython/blob/main/ports/espressif/boards/adafruit_feather_esp32c6_4mbflash_nopsram/pins.c#L57-L58

This closes #9523 