### PR TITLE
M5Stack Cardputer keyboard handling improvements.

### DIFF
--- a/ports/espressif/boards/m5stack_cardputer/board.c
+++ b/ports/espressif/boards/m5stack_cardputer/board.c
@@ -4,52 +4,19 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "board.h"
-#include "keymap.h"
+#include "mpconfigboard.h"
 #include "supervisor/board.h"
 #include "supervisor/shared/serial.h"
-#include "mpconfigboard.h"
 #include "shared-bindings/busio/SPI.h"
 #include "shared-bindings/fourwire/FourWire.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-module/displayio/__init__.h"
 #include "shared-module/displayio/mipi_constants.h"
-#include "shared-module/os/__init__.h"
 #include "shared-bindings/board/__init__.h"
-#include "shared-bindings/keypad/EventQueue.h"
-#include "shared-bindings/keypad/Event.h"
-#include "supervisor/shared/reload.h"
 #include "py/runtime.h"
 #include "py/ringbuf.h"
 #include "shared/runtime/interrupt_char.h"
 
-keypad_demux_demuxkeymatrix_obj_t board_keyboard;
-bool board_keyboard_serial_enabled = false;
-
-void update_keyboard(keypad_eventqueue_obj_t *queue);
-void keyboard_seq(const char *seq);
-
-const mcu_pin_obj_t *row_addr_pins[] = {
-    &pin_GPIO8,
-    &pin_GPIO9,
-    &pin_GPIO11,
-};
-
-const mcu_pin_obj_t *column_pins[] = {
-    &pin_GPIO13,
-    &pin_GPIO15,
-    &pin_GPIO3,
-    &pin_GPIO4,
-    &pin_GPIO5,
-    &pin_GPIO6,
-    &pin_GPIO7
-};
-
-keypad_event_obj_t event;
-
-char keystate[56];
-ringbuf_t keyqueue;
-char keybuf[32];
 
 #define DELAY 0x80
 
@@ -73,6 +40,7 @@ uint8_t display_init_sequence[] = {
 };
 
 
+// Overrides the weakly linked function from supervisor/shared/board.c
 void board_init(void) {
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
     fourwire_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
@@ -123,125 +91,5 @@ void board_init(void) {
         350             // backlight pwm frequency
         );
 }
-
-void board_serial_init() {
-    board_keyboard.base.type = &keypad_demux_demuxkeymatrix_type;
-    common_hal_keypad_demux_demuxkeymatrix_construct(
-        &board_keyboard,     // self
-        3,     // num_row_addr_pins
-        row_addr_pins,     // row_addr_pins
-        7,     // num_column_pins
-        column_pins,     // column_pins
-        0.01f,     // interval
-        20,     // max_events
-        2     // debounce_threshold
-        );
-    demuxkeymatrix_never_reset(&board_keyboard);
-
-    // Wire the keyboard input to serial input (sys.stdin)
-    // unless M5STACK_CARDPUTER_KEYBOARD_SERIAL=0 in /settings.toml
-    mp_int_t enable_keyboard_serial;
-    os_getenv_err_t enable_keyboard_err = common_hal_os_getenv_int("M5STACK_CARDPUTER_KEYBOARD_SERIAL", &enable_keyboard_serial);
-    board_keyboard_serial_enabled = (enable_keyboard_err != GETENV_OK) || enable_keyboard_serial > 0;
-    if (!board_keyboard_serial_enabled) {
-        return;
-    }
-
-    ringbuf_init(&keyqueue, (uint8_t *)keybuf, sizeof(keybuf));
-    common_hal_keypad_eventqueue_set_event_handler(board_keyboard.events, update_keyboard);
-}
-
-bool board_serial_connected() {
-    return board_keyboard_serial_enabled;
-}
-
-uint32_t board_serial_bytes_available() {
-    if (board_keyboard_serial_enabled) {
-        return ringbuf_num_filled(&keyqueue);
-    } else {
-        return 0;
-    }
-}
-
-void keyboard_seq(const char *seq) {
-    while (*seq) {
-        ringbuf_put(&keyqueue, *seq++);
-    }
-}
-
-void update_keyboard(keypad_eventqueue_obj_t *queue) {
-    uint8_t ascii = 0;
-
-    if (common_hal_keypad_eventqueue_get_length(queue) == 0) {
-        return;
-    }
-
-    while (common_hal_keypad_eventqueue_get_into(queue, &event)) {
-        if (event.pressed) {
-            keystate[event.key_number] = 1;
-
-            if (keystate[KEY_CTRL]) {
-                if (keystate[KEY_ALT] && keystate[KEY_BACKSPACE]) {
-                    reload_initiate(RUN_REASON_REPL_RELOAD);
-                }
-                ascii = keymap[event.key_number];
-                if (ascii >= 'a' && ascii <= 'z') {
-                    ascii -= 'a' - 1;
-                }
-
-                if (ascii == mp_interrupt_char) {
-                    mp_sched_keyboard_interrupt();
-                }
-            } else if (keystate[KEY_SHIFT]) {
-                ascii = keymap_shifted[event.key_number];
-            } else if (keystate[KEY_FN] && event.key_number != KEY_FN) {
-                switch (event.key_number | FN_MOD) {
-                    case KEY_DOWN:
-                        keyboard_seq("\e[B");
-                        break;
-                    case KEY_UP:
-                        keyboard_seq("\e[A");
-                        break;
-                    case KEY_DELETE:
-                        keyboard_seq("\e[3~");
-                        break;
-                    case KEY_LEFT:
-                        keyboard_seq("\e[D");
-                        break;
-                    case KEY_RIGHT:
-                        keyboard_seq("\e[C");
-                        break;
-                    case KEY_ESC:
-                        ringbuf_put(&keyqueue, '\e');
-                        break;
-                }
-            } else {
-                ascii = keymap[event.key_number];
-            }
-
-            if (ascii > 0) {
-                if (keystate[KEY_ALT]) {
-                    ringbuf_put(&keyqueue, '\e');
-                } else if (keystate[KEY_OPT]) {
-                    ringbuf_put(&keyqueue, '\x10');
-                }
-                ringbuf_put(&keyqueue, ascii);
-            }
-
-        } else {
-            keystate[event.key_number] = 0;
-        }
-    }
-}
-
-char board_serial_read() {
-    if (board_keyboard_serial_enabled) {
-        return ringbuf_get(&keyqueue);
-    } else {
-        return 0;
-    }
-}
-
-// Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.
 
 // TODO: Should we turn off the display when asleep, in board_deinit() ?

--- a/ports/espressif/boards/m5stack_cardputer/board.h
+++ b/ports/espressif/boards/m5stack_cardputer/board.h
@@ -1,0 +1,9 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2020 Scott Shawcroft for Adafruit Industries
+//
+// SPDX-License-Identifier: MIT
+
+#include "shared-bindings/keypad_demux/DemuxKeyMatrix.h"
+
+extern keypad_demux_demuxkeymatrix_obj_t board_keyboard;

--- a/ports/espressif/boards/m5stack_cardputer/board.h
+++ b/ports/espressif/boards/m5stack_cardputer/board.h
@@ -1,9 +1,0 @@
-// This file is part of the CircuitPython project: https://circuitpython.org
-//
-// SPDX-FileCopyrightText: Copyright (c) 2020 Scott Shawcroft for Adafruit Industries
-//
-// SPDX-License-Identifier: MIT
-
-#include "shared-bindings/keypad_demux/DemuxKeyMatrix.h"
-
-extern keypad_demux_demuxkeymatrix_obj_t board_keyboard;

--- a/ports/espressif/boards/m5stack_cardputer/cardputer_keyboard.c
+++ b/ports/espressif/boards/m5stack_cardputer/cardputer_keyboard.c
@@ -1,0 +1,236 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2016 Scott Shawcroft
+//
+// SPDX-License-Identifier: MIT
+
+#include "py/obj.h"
+#include "py/objstr.h"
+#include "py/runtime.h"
+
+#include "supervisor/shared/serial.h"
+#include "shared-bindings/keypad/EventQueue.h"
+#include "shared-bindings/keypad_demux/DemuxKeyMatrix.h"
+#include "shared-bindings/microcontroller/Pin.h"
+#include "shared-module/keypad/EventQueue.h"
+#include "shared-module/keypad_demux/DemuxKeyMatrix.h"
+#include "supervisor/shared/reload.h"
+
+#include "keymap.h"
+
+//| """M5Stack Cardputer keyboard integration.
+//| """
+//|
+//| """The KEYBOARD object is an instance of DemuxKeyMatrix, configured with correct pins.
+//| The pins cannot be used for any other purposes (even though exposed in the board module).
+//| By default all keyboard events are consumed and routed to the standard input - there is
+//| not much use of the KEYBOARD object in this configuration - just read the input via sys.stdin.
+//|
+//| If you need to manually process individual key up / key down events via KEYBOARD.events,
+//| call `detach_serial()`.
+//| """"
+//| KEYBOARD: keypad_demux.DemuxKeymatrix
+//|
+keypad_demux_demuxkeymatrix_obj_t cardputer_keyboard_obj;
+bool cardputer_keyboard_serial_attached = false;
+
+void cardputer_keyboard_init(void);
+void keyboard_seq(const char *seq);
+void update_keyboard(keypad_eventqueue_obj_t *queue);
+
+//| def detach_serial() -> None:
+//|     """Stops consuming keyboard events and routing them to sys.stdin."""
+//|     ...
+//|
+static mp_obj_t detach_serial(void) {
+    cardputer_keyboard_serial_attached = false;
+    common_hal_keypad_eventqueue_set_event_handler(cardputer_keyboard_obj.events, NULL);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(detach_serial_obj, detach_serial);
+
+//| def attach_serial() -> None:
+//|     """Starts consuming keyboard events and routing them to sys.stdin."""
+//|     ...
+//|
+static mp_obj_t attach_serial(void) {
+    common_hal_keypad_eventqueue_set_event_handler(cardputer_keyboard_obj.events, update_keyboard);
+    cardputer_keyboard_serial_attached = true;
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(attach_serial_obj, attach_serial);
+
+//| def key_to_char(key: int, shifted: bool) -> str | None:
+//|     """Converts a key index to the respective key (with or without shift modifier).
+//|     Returns None for functional & modifier keys or whenever not 0 <= key < 56.
+//|     """
+//|     ...
+//|
+static mp_obj_t key_to_char(mp_obj_t key_obj, mp_obj_t shifted_obj) {
+    mp_int_t key = mp_obj_get_int(key_obj);
+    if (key < 0 || key > (mp_int_t)(sizeof keymap / sizeof *keymap) || keymap[key] == 0) {
+        return mp_const_none;
+    } else if (shifted_obj == mp_const_true) {
+        return mp_obj_new_str(&keymap_shifted[key], 1);
+    } else {
+        return mp_obj_new_str(&keymap[key], 1);
+    }
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(key_to_char_obj, key_to_char);
+
+// Ring buffer of characters consumed from keyboard events (when serial attached)
+ringbuf_t keyqueue;
+char keybuf[32];
+
+keypad_event_obj_t event;
+char keystate[56];
+
+// Keyboard pins
+const mcu_pin_obj_t *row_addr_pins[] = {
+    &pin_GPIO8,
+    &pin_GPIO9,
+    &pin_GPIO11,
+};
+
+const mcu_pin_obj_t *column_pins[] = {
+    &pin_GPIO13,
+    &pin_GPIO15,
+    &pin_GPIO3,
+    &pin_GPIO4,
+    &pin_GPIO5,
+    &pin_GPIO6,
+    &pin_GPIO7
+};
+
+void cardputer_keyboard_init(void) {
+    cardputer_keyboard_obj.base.type = &keypad_demux_demuxkeymatrix_type;
+    common_hal_keypad_demux_demuxkeymatrix_construct(
+        &cardputer_keyboard_obj, // self
+        3,                       // num_row_addr_pins
+        row_addr_pins,           // row_addr_pins
+        7,                       // num_column_pins
+        column_pins,             // column_pins
+        0.01f,                   // interval
+        20,                      // max_events
+        2                        // debounce_threshold
+        );
+    demuxkeymatrix_never_reset(&cardputer_keyboard_obj);
+
+    ringbuf_init(&keyqueue, (uint8_t *)keybuf, sizeof(keybuf));
+    attach_serial();
+}
+
+// Overrides the weakly linked function from supervisor/shared/serial.c
+void board_serial_init(void) {
+    cardputer_keyboard_init();
+}
+
+// Overrides the weakly linked function from supervisor/shared/serial.c
+bool board_serial_connected(void) {
+    return cardputer_keyboard_serial_attached;
+}
+
+// Overrides the weakly linked function from supervisor/shared/serial.c
+uint32_t board_serial_bytes_available(void) {
+    if (cardputer_keyboard_serial_attached) {
+        return ringbuf_num_filled(&keyqueue);
+    } else {
+        return 0;
+    }
+}
+
+// Overrides the weakly linked function from supervisor/shared/serial.c
+char board_serial_read(void) {
+    if (cardputer_keyboard_serial_attached) {
+        return ringbuf_get(&keyqueue);
+    } else {
+        return 0;
+    }
+}
+
+void keyboard_seq(const char *seq) {
+    while (*seq) {
+        ringbuf_put(&keyqueue, *seq++);
+    }
+}
+
+void update_keyboard(keypad_eventqueue_obj_t *queue) {
+    uint8_t ascii = 0;
+
+    if (common_hal_keypad_eventqueue_get_length(queue) == 0) {
+        return;
+    }
+
+    while (common_hal_keypad_eventqueue_get_into(queue, &event)) {
+        if (event.pressed) {
+            keystate[event.key_number] = 1;
+
+            if (keystate[KEY_CTRL]) {
+                if (keystate[KEY_ALT] && keystate[KEY_BACKSPACE]) {
+                    reload_initiate(RUN_REASON_REPL_RELOAD);
+                }
+                ascii = keymap[event.key_number];
+                if (ascii >= 'a' && ascii <= 'z') {
+                    ascii -= 'a' - 1;
+                }
+
+                if (ascii == mp_interrupt_char) {
+                    mp_sched_keyboard_interrupt();
+                }
+            } else if (keystate[KEY_SHIFT]) {
+                ascii = keymap_shifted[event.key_number];
+            } else if (keystate[KEY_FN] && event.key_number != KEY_FN) {
+                switch (event.key_number | FN_MOD)
+                {
+                    case KEY_DOWN:
+                        keyboard_seq("\e[B");
+                        break;
+                    case KEY_UP:
+                        keyboard_seq("\e[A");
+                        break;
+                    case KEY_DELETE:
+                        keyboard_seq("\e[3~");
+                        break;
+                    case KEY_LEFT:
+                        keyboard_seq("\e[D");
+                        break;
+                    case KEY_RIGHT:
+                        keyboard_seq("\e[C");
+                        break;
+                    case KEY_ESC:
+                        ringbuf_put(&keyqueue, '\e');
+                        break;
+                }
+            } else {
+                ascii = keymap[event.key_number];
+            }
+
+            if (ascii > 0) {
+                if (keystate[KEY_ALT]) {
+                    ringbuf_put(&keyqueue, '\e');
+                } else if (keystate[KEY_OPT]) {
+                    ringbuf_put(&keyqueue, '\x10');
+                }
+                ringbuf_put(&keyqueue, ascii);
+            }
+        } else {
+            keystate[event.key_number] = 0;
+        }
+    }
+}
+
+static const mp_rom_map_elem_t cardputer_keyboard_module_globals_table[] = {
+    {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_cardputer_keyboard)},
+    {MP_ROM_QSTR(MP_QSTR_KEYBOARD), MP_ROM_PTR(&cardputer_keyboard_obj)},
+    {MP_ROM_QSTR(MP_QSTR_attach_serial), MP_ROM_PTR(&attach_serial_obj)},
+    {MP_ROM_QSTR(MP_QSTR_detach_serial), MP_ROM_PTR(&detach_serial_obj)},
+    {MP_ROM_QSTR(MP_QSTR_key_to_char), MP_ROM_PTR(&key_to_char_obj)},
+};
+MP_DEFINE_CONST_DICT(cardputer_keyboard_module_globals, cardputer_keyboard_module_globals_table);
+
+const mp_obj_module_t cardputer_keyboard_module = {
+    .base = {&mp_type_module},
+    .globals = (mp_obj_dict_t *)&cardputer_keyboard_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_cardputer_keyboard, cardputer_keyboard_module);

--- a/ports/espressif/boards/m5stack_cardputer/keymap.h
+++ b/ports/espressif/boards/m5stack_cardputer/keymap.h
@@ -95,7 +95,7 @@
 #define KEY_RIGHT (34 | FN_MOD)
 #define KEY_ESC (49 | FN_MOD)
 
-int keymap[56] = {
+const char keymap[56] = {
     0,   // KEY_OPT
     'z', // KEY_Z
     'c', // KEY_C
@@ -154,7 +154,7 @@ int keymap[56] = {
     '='  // KEY_EQUALS
 };
 
-int keymap_shifted[56] = {
+const char keymap_shifted[56] = {
     0,   // KEY_OPT
     'Z', // KEY_Z
     'C', // KEY_C

--- a/ports/espressif/boards/m5stack_cardputer/mpconfigboard.mk
+++ b/ports/espressif/boards/m5stack_cardputer/mpconfigboard.mk
@@ -12,3 +12,5 @@ CIRCUITPY_ESPCAMERA = 0
 
 CIRCUITPY_GIFIO = 1
 CIRCUITPY_MAX3421E = 0
+
+SRC_C += boards/$(BOARD)/cardputer_keyboard.c

--- a/ports/espressif/boards/m5stack_cardputer/pins.c
+++ b/ports/espressif/boards/m5stack_cardputer/pins.c
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include "board.h"
 #include "shared-bindings/board/__init__.h"
 
 #include "shared-module/displayio/__init__.h"
@@ -80,6 +81,10 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_TFT_SPI), MP_ROM_PTR(&board_spi_obj) },
     { MP_ROM_QSTR(MP_QSTR_SD_SPI), MP_ROM_PTR(&board_sd_spi_obj) },
 
-    { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display)}
+    // Display object
+    { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display)},
+
+    // Keyboard object
+    { MP_ROM_QSTR(MP_QSTR_KEYBOARD), MP_ROM_PTR(&board_keyboard)},
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/espressif/boards/m5stack_cardputer/pins.c
+++ b/ports/espressif/boards/m5stack_cardputer/pins.c
@@ -4,7 +4,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "board.h"
 #include "shared-bindings/board/__init__.h"
 
 #include "shared-module/displayio/__init__.h"
@@ -83,8 +82,5 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
 
     // Display object
     { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display)},
-
-    // Keyboard object
-    { MP_ROM_QSTR(MP_QSTR_KEYBOARD), MP_ROM_PTR(&board_keyboard)},
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
* Exposed the DemuxKeyMatrix object as board.KEYBOARD.
* Implemented the ability to not have the keyboard assigned as serial input (sys.stdin) by specifying M5STACK_CARDPUTER_KEYBOARD_SERIAL=0 in settings.toml. This enables custom handling of individual key up/key down events.

For context, see discussion in https://github.com/adafruit/circuitpython/commit/090f330ad5e30acf2030900b45386d784cbcc1da