### PR TITLE
nordic: reduce sleep current by using SENSE feature for PinAlarm when possible 

### DIFF
--- a/ports/nordic/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/nordic/common-hal/alarm/pin/PinAlarm.c
@@ -123,11 +123,16 @@ void alarm_pin_pinalarm_reset(void) {
 static void configure_pins_for_sleep(void) {
     _pinhandler_gpiote_count = 0;
 
+    int n_pin_alarms = __builtin_popcountll(high_alarms) + __builtin_popcountll(low_alarms);
+    const int MAX_N_PIN_ALARMS_FOR_SENSE_FEATURE = 2;
+
     nrfx_gpiote_in_config_t cfg = {
         .sense = NRF_GPIOTE_POLARITY_TOGGLE,
         .pull = NRF_GPIO_PIN_PULLUP,
         .is_watcher = false,
-        .hi_accuracy = true,
+        // hi_accuracy = False reduces sleep current by a factor of ~10x by using the SENSE feature,
+        // but only works if not more than MAX_N_PIN_ALARMS_FOR_SENSE_FEATURE pin alarms are used.
+        .hi_accuracy = (n_pin_alarms > MAX_N_PIN_ALARMS_FOR_SENSE_FEATURE),
         .skip_gpio_setup = false
     };
     for (size_t i = 0; i < 64; ++i) {


### PR DESCRIPTION
This PR decreases the power consumption of sleep modes with active pin interrupts by ~10x by using the SENSE feature, when possible. 
"Normal" GPIOTE interrupts increase sleep current consumption by ~20µA, but using SENSE (aka PORT events) instead can reduce this to ~2µA. 

This behaviour is documented as an Erratum [here](https://infocenter.nordicsemi.com/index.jsp?topic=%2Ferrata_nRF52832_Rev2%2FERR%2FnRF52832%2FRev2%2Flatest%2Fanomaly_832_97.html) and discussed for Zephyr [here](https://github.com/zephyrproject-rtos/zephyr/issues/28499) (both for nrf52832, but it's also present in nrf52840 and also mentioned in the datasheet, Chapter "5.2.1.1 Sleep").

The documentation of [`nrfx_gpiote_in_init`](https://github.com/adafruit/nrfx/blob/ab21106ea57b63d97b757a9f17201ddf298ffab0/drivers/include/nrfx_gpiote.h#L356C1-L381C77) says that only 1 pin can be used for SENSE at one time, but by my own testing, 2 sense pins also work and it only breaks when trying to use 3 pins for SENSE. Hence when 3 or more `PinAlarm`s are set, we stick to the previous behaviour.

I have tested and confirmed that the following still works after this change (using a makerdiary_nrf52840_mdk_usb_dongle and a ssci_isp1807_dev_board):
- Wake from deep sleep using 1 or 2 PinAlarms (with all combinations of high and low alarms)
- Wake from light sleep using all above PinAlarm combinations
- Wake from fake deep sleep using all above PinAlarm combinations
- correct value of `alarm.wake_alarm.pin` in all of the above cases.
- for 3 or more `PinAlarm`s, the behaviour is unchanged by this PR.

But I would encourage that someone else verifies this before merging, should there be interest in this PR.