### PR TITLE
Fix `_bleio` doc comments

### DIFF
--- a/shared-bindings/_bleio/Characteristic.c
+++ b/shared-bindings/_bleio/Characteristic.c
@@ -24,8 +24,9 @@
 //|         as part of remote Services."""
 //|         ...
 
+//|     @classmethod
 //|     def add_to_service(
-//|         self,
+//|         cls,
 //|         service: Service,
 //|         uuid: UUID,
 //|         *,

--- a/shared-bindings/_bleio/CharacteristicBuffer.c
+++ b/shared-bindings/_bleio/CharacteristicBuffer.c
@@ -25,7 +25,7 @@ static void raise_error_if_not_connected(bleio_characteristic_buffer_obj_t *self
 //|     """Accumulates a Characteristic's incoming values in a FIFO buffer."""
 //|
 //|     def __init__(
-//|         self, characteristic: Characteristic, *, timeout: int = 1, buffer_size: int = 64
+//|         self, characteristic: Characteristic, *, timeout: float = 1.0, buffer_size: int = 64
 //|     ) -> None:
 //|         """Monitor the given Characteristic. Each time a new value is written to the Characteristic
 //|         add the newly-written bytes to a FIFO buffer.
@@ -33,7 +33,7 @@ static void raise_error_if_not_connected(bleio_characteristic_buffer_obj_t *self
 //|         :param Characteristic characteristic: The Characteristic to monitor.
 //|           It may be a local Characteristic provided by a Peripheral Service, or a remote Characteristic
 //|           in a remote Service that a Central has connected to.
-//|         :param int timeout:  the timeout in seconds to wait for the first character and between subsequent characters.
+//|         :param float timeout:  the timeout in seconds to wait for the first character and between subsequent characters.
 //|         :param int buffer_size: Size of ring buffer that stores incoming data coming from client.
 //|           Must be >= 1."""
 //|         ...


### PR DESCRIPTION
Draft because I will be fixing anything else I find while i working on `Adafruit_CircuitPython_BLE`'s type hints

I just found out this because `mypy` complained that `add_to_service` was missing a positional arg (`self` and `service` were expected based on comment, but it really is a classmethod and only `service` has to be passed in)

This also lead me to seeing `__init__` is not defined... Does that mean that trying to run `Characteristic()` will raise? If so, should we perhaps change the type hint from `-> None` to `-> NoReturn` or the like?
