### PR TITLE
Fix: Docstring for stdio indicates binary #9543

### DIFF
--- a/shared/runtime/sys_stdio_mphal.c
+++ b/shared/runtime/sys_stdio_mphal.c
@@ -54,7 +54,7 @@ STATIC const sys_stdio_obj_t stdio_buffer_obj;
 
 STATIC void stdio_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     sys_stdio_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<io.FileIO %d>", self->fd);
+    mp_printf(print, "<io.StringIO %d>", self->fd);
 }
 
 STATIC mp_uint_t stdio_read(mp_obj_t self_in, void *buf, mp_uint_t size, int *errcode) {
@@ -122,7 +122,7 @@ STATIC const mp_stream_p_t stdio_obj_stream_p = {
 
 MP_DEFINE_CONST_OBJ_TYPE(
     stdio_obj_type,
-    MP_QSTR_FileIO,
+    MP_QSTR_StringIO,
     MP_TYPE_FLAG_ITER_IS_STREAM,
     print, stdio_obj_print,
     protocol, &stdio_obj_stream_p,
@@ -155,7 +155,7 @@ STATIC const mp_stream_p_t stdio_buffer_obj_stream_p = {
 
 STATIC MP_DEFINE_CONST_OBJ_TYPE(
     stdio_buffer_obj_type,
-    MP_QSTR_FileIO,
+    MP_QSTR_StringIO,
     MP_TYPE_FLAG_ITER_IS_STREAM,
     print, stdio_obj_print,
     protocol, &stdio_buffer_obj_stream_p,


### PR DESCRIPTION
Fixes #9543.

Docstring for stdio indicates "FileIO", which is a binary IO stream. As detailed in #553, stdio is not binary by design; its docstring should indicate "StringIO".