### PR TITLE
correct board special pin setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,10 +255,13 @@ jobs:
         wget --no-verbose -O gcc-arm.zip https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi.zip
         unzip -q -d /tmp gcc-arm.zip
         tar -C /tmp/arm-gnu-toolchain* -cf - . | tar -C /usr/local -xf -
-        pip install wheel
-        # requirements_dev.txt doesn't install on windows. (with msys2 python)
+        # We could use a venv instead, but that requires entering the venv on each run step
+        # that runs in its own shell. There are some actions that help with that, but not for msys2
+        # that I can find. (dhalbert)
+        pip install --break-system-packages wheel
+        # requirements-dev.txt doesn't install on windows. (with msys2 python)
         # instead, pick a subset for what we want to do
-        pip install cascadetoml jinja2 typer click intelhex
+        pip install --break-system-packages cascadetoml jinja2 typer click intelhex
         # check that installed packages work....?
         which python; python --version; python -c "import cascadetoml"
         which python3; python3 --version; python3 -c "import cascadetoml"

--- a/ports/espressif/boards/adafruit_feather_esp32_v2/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32_v2/board.c
@@ -14,8 +14,7 @@
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     if (pin_number == 2) {
         // Turn on NeoPixel and I2C power by default.
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
 

--- a/ports/espressif/boards/adafruit_feather_esp32c6_4mbflash_nopsram/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32c6_4mbflash_nopsram/board.c
@@ -14,8 +14,7 @@
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     if (pin_number == 20) {
         // Turn on I2C power by default.
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
 

--- a/ports/espressif/boards/adafruit_feather_esp32s2_reverse_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_reverse_tft/board.c
@@ -103,8 +103,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Override the I2C/TFT power pin reset to prevent resetting the display.
     if (pin_number == 7) {
         // Turn on TFT and I2C
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s2_tft/board.c
@@ -103,8 +103,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Override the I2C/TFT power pin reset to prevent resetting the display.
     if (pin_number == 21) {
         // Turn on TFT and I2C
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/adafruit_feather_esp32s3_reverse_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_reverse_tft/board.c
@@ -103,8 +103,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Override the I2C/TFT power pin reset to prevent resetting the display.
     if (pin_number == 7) {
         // Turn on TFT and I2C
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_tft/board.c
@@ -103,8 +103,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Override the I2C/TFT power pin reset to prevent resetting the display.
     if (pin_number == 21) {
         // Turn on TFT and I2C
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/adafruit_itsybitsy_esp32/board.c
+++ b/ports/espressif/boards/adafruit_itsybitsy_esp32/board.c
@@ -14,8 +14,7 @@
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     if (pin_number == 2) {
         // Turn on NeoPixel and I2C power by default.
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
 

--- a/ports/espressif/boards/arduino_nano_esp32s3/board.c
+++ b/ports/espressif/boards/arduino_nano_esp32s3/board.c
@@ -12,8 +12,14 @@
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     if (pin_number == 13) {
         // Set D13 LED to input when not in use
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_INPUT);
-        gpio_set_pull_mode(pin_number, GPIO_PULLDOWN_ONLY);
+        gpio_config_t cfg = {
+            .pin_bit_mask = BIT64(pin_number),
+            .mode = GPIO_MODE_INPUT,
+            .pull_up_en = false,
+            .pull_down_en = true,
+            .intr_type = GPIO_INTR_DISABLE,
+        };
+        gpio_config(&cfg);
         return true;
     }
 

--- a/ports/espressif/boards/arduino_nano_esp32s3_inverted_statusled/board.c
+++ b/ports/espressif/boards/arduino_nano_esp32s3_inverted_statusled/board.c
@@ -12,8 +12,14 @@
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     if (pin_number == 13) {
         // Set D13 LED to input when not in use
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_INPUT);
-        gpio_set_pull_mode(pin_number, GPIO_PULLDOWN_ONLY);
+        gpio_config_t cfg = {
+            .pin_bit_mask = BIT64(pin_number),
+            .mode = GPIO_MODE_INPUT,
+            .pull_up_en = false,
+            .pull_down_en = true,
+            .intr_type = GPIO_INTR_DISABLE,
+        };
+        gpio_config(&cfg);
         return true;
     }
 

--- a/ports/espressif/boards/cytron_maker_feather_aiot_s3/board.c
+++ b/ports/espressif/boards/cytron_maker_feather_aiot_s3/board.c
@@ -58,8 +58,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
 
 void reset_board(void) {
     // Turn on VP by default.
-    gpio_set_direction(11, GPIO_MODE_DEF_OUTPUT);
-    gpio_set_level(11, true);
+    config_pin_as_output_with_level(11, true);
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/hexky_s2/board.c
+++ b/ports/espressif/boards/hexky_s2/board.c
@@ -103,8 +103,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Override the I2C/TFT power pin reset to prevent resetting the display.
     if (pin_number == 21) {
         // Turn on TFT and I2C
-        gpio_set_direction(21, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(21, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/lilygo_tdisplay_s3/board.c
+++ b/ports/espressif/boards/lilygo_tdisplay_s3/board.c
@@ -101,8 +101,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Override the I2C/TFT power pin reset to prevent resetting the display.
     if (pin_number == 15) {
         // Turn on TFT
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/lilygo_twatch_2020_v3/board.c
+++ b/ports/espressif/boards/lilygo_twatch_2020_v3/board.c
@@ -131,8 +131,7 @@ void board_init(void) {
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     if (pin_number == MOTOR_PIN) {
         // no motor
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, false);
+        config_pin_as_output_with_level(pin_number, false);
         return true;
     }
     return false;

--- a/ports/espressif/boards/m5stack_core_basic/board.c
+++ b/ports/espressif/boards/m5stack_core_basic/board.c
@@ -89,8 +89,7 @@ void board_init(void) {
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Set speaker gpio to ground to prevent noise from the speaker
     if (pin_number == 25) {
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, false);
+        config_pin_as_output_with_level(pin_number, false);
         return true;
     }
     return false;

--- a/ports/espressif/boards/m5stack_core_fire/board.c
+++ b/ports/espressif/boards/m5stack_core_fire/board.c
@@ -89,8 +89,7 @@ void board_init(void) {
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Set speaker gpio to ground to prevent noise from the speaker
     if (pin_number == 25) {
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, false);
+        config_pin_as_output_with_level(pin_number, false);
         return true;
     }
     return false;

--- a/ports/espressif/boards/m5stack_dial/board.c
+++ b/ports/espressif/boards/m5stack_dial/board.c
@@ -92,11 +92,10 @@ void board_init(void) {
 }
 
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
-    // Hold pind must be set high to avoid a power off when battery powered
+    // Hold pin must be set high to avoid a power off when battery powered
     if (pin_number == 46) {
         // Turn on hold output
-        gpio_set_direction(46, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(46, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/m5stack_stick_c/board.c
+++ b/ports/espressif/boards/m5stack_stick_c/board.c
@@ -217,8 +217,7 @@ void board_init(void) {
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Set IR led gpio high to prevent power drain from the led
     if (pin_number == 9) {
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/m5stack_stick_c_plus/board.c
+++ b/ports/espressif/boards/m5stack_stick_c_plus/board.c
@@ -217,8 +217,7 @@ void board_init(void) {
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Set IR led gpio high to prevent power drain from the led
     if (pin_number == 9) {
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/m5stack_timer_camera_x/board.c
+++ b/ports/espressif/boards/m5stack_timer_camera_x/board.c
@@ -19,8 +19,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
          * when usb is disconnected or
          * the power button is released.
          */
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
     return false;

--- a/ports/espressif/boards/seeed_xiao_esp32c6/board.c
+++ b/ports/espressif/boards/seeed_xiao_esp32c6/board.c
@@ -34,8 +34,7 @@
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     if (pin_number == 16) {
         // Turn on I2C power by default.
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, true);
+        config_pin_as_output_with_level(pin_number, true);
         return true;
     }
 

--- a/ports/espressif/boards/sqfmi_watchy/board.c
+++ b/ports/espressif/boards/sqfmi_watchy/board.c
@@ -202,20 +202,16 @@ bool board_requests_safe_mode(void) {
 
 bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     if (pin_number == 13) {
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, false);
+        config_pin_as_output_with_level(pin_number, false);
         return true;
     }
     return false;
 }
 
 void reset_board(void) {
-    gpio_set_direction(13, GPIO_MODE_OUTPUT);
-    gpio_set_level(13, false);
-
+    config_pin_as_output_with_level(13, false);
 }
 
 void board_deinit(void) {
-    gpio_set_direction(13, GPIO_MODE_DEF_OUTPUT);
-    gpio_set_level(13, false);
+    config_pin_as_output_with_level(13, false);
 }

--- a/ports/espressif/boards/sunton_esp32_2432S028/board.c
+++ b/ports/espressif/boards/sunton_esp32_2432S028/board.c
@@ -97,8 +97,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Pull the speaker pin low to reduce noise on reset
     if (pin_number == 26) {
         // Turn on TFT
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, false);
+        config_pin_as_output_with_level(pin_number, false);
         return true;
     }
     return false;

--- a/ports/espressif/boards/sunton_esp32_2432S032C/board.c
+++ b/ports/espressif/boards/sunton_esp32_2432S032C/board.c
@@ -93,8 +93,7 @@ bool espressif_board_reset_pin_number(gpio_num_t pin_number) {
     // Pull the speaker pin low to reduce noise on reset
     if (pin_number == 26) {
         // Turn on audio
-        gpio_set_direction(pin_number, GPIO_MODE_DEF_OUTPUT);
-        gpio_set_level(pin_number, false);
+        config_pin_as_output_with_level(pin_number, false);
         return true;
     }
     return false;

--- a/ports/espressif/common-hal/microcontroller/Pin.c
+++ b/ports/espressif/common-hal/microcontroller/Pin.c
@@ -393,3 +393,16 @@ bool common_hal_mcu_pin_is_free(const mcu_pin_obj_t *pin) {
 uint8_t common_hal_mcu_pin_number(const mcu_pin_obj_t *pin) {
     return pin ? pin->number : NO_PIN;
 }
+
+void config_pin_as_output_with_level(gpio_num_t pin_number, bool level) {
+    gpio_config_t cfg = {
+        .pin_bit_mask = BIT64(pin_number),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = false,
+        .pull_down_en = false,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&cfg);
+
+    gpio_set_level(pin_number, level);
+}

--- a/ports/espressif/common-hal/microcontroller/Pin.h
+++ b/ports/espressif/common-hal/microcontroller/Pin.h
@@ -36,3 +36,7 @@ extern void clear_pin_preservations(void);
 // Return true to indicate that the pin was reset. Returning false will lead to
 // the port-default reset behavior.
 extern bool espressif_board_reset_pin_number(gpio_num_t pin_number);
+
+// Configure the IOMUX for the pin as GPIO, set the pin as output, and then set output the level.
+// This ensures the IOMUX setting is correct.
+extern void config_pin_as_output_with_level(gpio_num_t pin_number, bool level);


### PR DESCRIPTION
- Fixes #9551 

`espressif_board_reset_pin_number()` was being used on many boards to  set certain pins high or low on startup. However, it was using basic `gpio` functions without ensuring that the IOMUX for pin was set to GPIO. This meant the GPIO settings were not necessarily taking effect. This may have caused issues on other boards we didn't know about besides the Feather C6 from #9551.

I added a helper routine to ensure that `gpio_config()` was called before setting the pin level. `gpio_config()` does the IOMUX configuring.

A helper routine to set pulls could also be added, but some boards use a disabled pin with a pull, and some use an input pin. So I didn't do this now.

Tested on Feather ESP32-C6, which now turns on `board.NEOPIXEL_I2C_POWER` as it should.

This PR also includes #9549, to avoid failure in the Windows build job.