### PR TITLE
Fix docstring for stdout.buffer

### DIFF
--- a/shared/runtime/sys_stdio_mphal.c
+++ b/shared/runtime/sys_stdio_mphal.c
@@ -154,7 +154,7 @@ STATIC const mp_stream_p_t stdio_buffer_obj_stream_p = {
 
 STATIC MP_DEFINE_CONST_OBJ_TYPE(
     stdio_buffer_obj_type,
-    MP_QSTR_StringIO,
+    MP_QSTR_FileIO,
     MP_TYPE_FLAG_ITER_IS_STREAM,
     print, stdio_obj_print,
     protocol, &stdio_buffer_obj_stream_p,


### PR DESCRIPTION
Keep `stdout` as `StringIO`, but revert `stdout.buffer` type back to `FileIO`.

Earlier commit changed stdio docstring/type to StringIO and included stdio_buffer_obj in that.  Reviewing history for that object, it is intended to implement (e.g.) stdout.buffer, which is a binary stream.