### PR TITLE
Upload merged PR's to AWS for x.x.x branches

### DIFF
--- a/.github/actions/upload_aws/action.yml
+++ b/.github/actions/upload_aws/action.yml
@@ -20,8 +20,11 @@ runs:
   steps:
     - name: Upload to S3
       if: >-
-        (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'adafruit') ||
-        (github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'rerequested'))
+        (github.event_name == 'push' && github.repository_owner == 'adafruit') &&
+         (github.ref == 'refs/heads/main' ||
+          (startswith(github.ref, 'refs/heads/') && endswith(github.ref, '.x'))) ||
+        (github.event_name == 'release' &&
+         (github.event.action == 'published' || github.event.action == 'rerequested'))
       run: >-
         [ -z "$AWS_ACCESS_KEY_ID" ] ||
         aws s3 cp ${{ inputs.source }} s3://adafruit-circuit-python/bin/${{ inputs.destination }}


### PR DESCRIPTION
Currently only merged PR's to main are uploaded to https://adafruit-circuit-python.s3.amazonaws.com/index.html?prefix=bin. This is an attempt to upload merges for all branches ending in `.x`, so `9.1.x`, etc.

The string operations available in `if` statements in the CI yaml files are limited. There are ways to do regexp, etc., that involve generating a result and then using it, but it's clumsier. However, I think doing it for `*.x` branches is probably good enough.

Only way to test this is to merge it, I think.

I'm trying to use extra indentation in the `if:` to make it easier to read. Not sure if that will work.