### PR TITLE
espressif: Validate sample rate

### DIFF
--- a/ports/espressif/common-hal/analogbufio/BufferedIn.c
+++ b/ports/espressif/common-hal/analogbufio/BufferedIn.c
@@ -71,6 +71,8 @@ void common_hal_analogbufio_bufferedin_construct(analogbufio_bufferedin_obj_t *s
     }
     #endif
 
+    mp_arg_validate_int_range(sample_rate, SOC_ADC_SAMPLE_FREQ_THRES_LOW, SOC_ADC_SAMPLE_FREQ_THRES_HIGH, MP_QSTR_sample_rate);
+
     common_hal_mcu_pin_claim(pin);
 }
 
@@ -109,7 +111,7 @@ static void start_dma(analogbufio_bufferedin_obj_t *self, adc_digi_convert_mode_
     };
 
     #if defined(DEBUG_ANALOGBUFIO)
-    mp_printf(&mp_plat_print, "pin:%d, ADC channel:%d, ADC index:%d, adc1_chan_mask:0x%x, adc2_chan_mask:0x%x\n", pin->number, pin->adc_channel, pin->adc_index, adc1_chan_mask, adc2_chan_mask);
+    mp_printf(&mp_plat_print, "pin:%d, ADC channel:%d, ADC index:%d\n", pin->number, pin->adc_channel, pin->adc_index);
     #endif // DEBUG_ANALOGBUFIO
     esp_err_t err = adc_continuous_new_handle(&adc_dma_config, &self->handle);
     if (ESP_OK != err) {


### PR DESCRIPTION
The reported code used an invalid sample rate. This improves the error message so that it is not a generic IDFError.

The new error message says:
```
ValueError: sample_rate must be 20000-2000000
```

I verified at a sample rate of 20000 that I could read both 0 and 65535 using a jumper wire to another GPIO pin configured as a digital output.

My test code, run on a feather esp32 v2:
```
import digitalio, board, analogbufio, array

N = 30
rate = 20000

buffer = array.array("H", [0x0000] * N)
with digitalio.DigitalInOut(board.MISO) as d, analogbufio.BufferedIn(board.A3, sample_rate=rate) as adc:
    for v in (0, 1):
        d.switch_to_output(v)
        adc.readinto(buffer)
        for i in range(N):
            print(i, buffer[i])
```

Closes #9504