### PR TITLE
Update PIO USB

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -344,8 +344,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Wave.git
 [submodule "ports/raspberrypi/lib/Pico-PIO-USB"]
 	path = ports/raspberrypi/lib/Pico-PIO-USB
-	url = https://github.com/adafruit/Pico-PIO-USB.git
-	branch = sdk2_fix
+	url = https://github.com/sekigon-gonnoc/Pico-PIO-USB.git
 [submodule "lib/micropython-lib"]
 	path = lib/micropython-lib
 	url = https://github.com/micropython/micropython-lib.git


### PR DESCRIPTION
0.6.0 had a buffer issue that is fixed in 0.6.1. Now we can use upstream.