### PR TITLE
Fix RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@
 version: 2
 
 build:
-    os: ubuntu-20.04
+    os: ubuntu-24.04
     tools:
         python: "3"
     jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.setuptools_scm]
+# can be empty if no extra settings are needed, presence enables setuptools-scm

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -11,7 +11,7 @@ setuptools_scm
 
 # For sphinx
 sphinx!=5.2.0.post0
-sphinx-autoapi
+sphinx-autoapi<3.3.0
 sphinx-rtd-theme
 sphinxcontrib-svg2pdfconverter
 sphinxcontrib-jquery


### PR DESCRIPTION
AutoAPI 3.3.0 release broke our build. So, pin at a lower version for now.