### PR TITLE
rp2pio: Add offset & pc (program counter) properties

### DIFF
--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -813,6 +813,35 @@ MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_get_in_waiting_obj, rp2pio_statema
 MP_PROPERTY_GETTER(rp2pio_statemachine_in_waiting_obj,
     (mp_obj_t)&rp2pio_statemachine_get_in_waiting_obj);
 
+//|     offset: int
+//|     """The instruction offset where the program was actually loaded"""
+//|
+
+static mp_obj_t rp2pio_statemachine_obj_get_offset(mp_obj_t self_in) {
+    rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    check_for_deinit(self);
+    return MP_OBJ_NEW_SMALL_INT(common_hal_rp2pio_statemachine_get_offset(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_get_offset_obj, rp2pio_statemachine_obj_get_offset);
+
+MP_PROPERTY_GETTER(rp2pio_statemachine_offset_obj,
+    (mp_obj_t)&rp2pio_statemachine_get_offset_obj);
+
+//|     pc: int
+//|     """The current program counter of the state machine"""
+//|
+
+static mp_obj_t rp2pio_statemachine_obj_get_pc(mp_obj_t self_in) {
+    rp2pio_statemachine_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    check_for_deinit(self);
+    return MP_OBJ_NEW_SMALL_INT(common_hal_rp2pio_statemachine_get_pc(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_get_pc_obj, rp2pio_statemachine_obj_get_pc);
+
+MP_PROPERTY_GETTER(rp2pio_statemachine_pc_obj,
+    (mp_obj_t)&rp2pio_statemachine_get_pc_obj);
+
+
 static const mp_rom_map_elem_t rp2pio_statemachine_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&rp2pio_statemachine_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&default___enter___obj) },
@@ -836,6 +865,9 @@ static const mp_rom_map_elem_t rp2pio_statemachine_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_rxstall), MP_ROM_PTR(&rp2pio_statemachine_rxstall_obj) },
     { MP_ROM_QSTR(MP_QSTR_txstall), MP_ROM_PTR(&rp2pio_statemachine_txstall_obj) },
     { MP_ROM_QSTR(MP_QSTR_in_waiting), MP_ROM_PTR(&rp2pio_statemachine_in_waiting_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_offset), MP_ROM_PTR(&rp2pio_statemachine_offset_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pc), MP_ROM_PTR(&rp2pio_statemachine_pc_obj) },
 };
 static MP_DEFINE_CONST_DICT(rp2pio_statemachine_locals_dict, rp2pio_statemachine_locals_dict_table);
 

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.h
@@ -66,4 +66,7 @@ bool common_hal_rp2pio_statemachine_get_txstall(rp2pio_statemachine_obj_t *self)
 void common_hal_rp2pio_statemachine_clear_txstall(rp2pio_statemachine_obj_t *self);
 size_t common_hal_rp2pio_statemachine_get_in_waiting(rp2pio_statemachine_obj_t *self);
 
+int common_hal_rp2pio_statemachine_get_offset(rp2pio_statemachine_obj_t *self);
+int common_hal_rp2pio_statemachine_get_pc(rp2pio_statemachine_obj_t *self);
+
 void common_hal_rp2pio_statemachine_set_interrupt_handler(rp2pio_statemachine_obj_t *self, void (*handler)(void *), void *arg, int mask);

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -1088,6 +1088,20 @@ int common_hal_rp2pio_statemachine_get_pending(rp2pio_statemachine_obj_t *self) 
     return self->pending_buffers;
 }
 
+int common_hal_rp2pio_statemachine_get_offset(rp2pio_statemachine_obj_t *self) {
+    uint8_t pio_index = pio_get_index(self->pio);
+    uint8_t sm = self->state_machine;
+    uint8_t offset = _current_program_offset[pio_index][sm];
+    return offset;
+}
+
+int common_hal_rp2pio_statemachine_get_pc(rp2pio_statemachine_obj_t *self) {
+    uint8_t pio_index = pio_get_index(self->pio);
+    PIO pio = pio_instances[pio_index];
+    uint8_t sm = self->state_machine;
+    return pio_sm_get_pc(pio, sm);
+}
+
 // Use a compile-time constant for MP_REGISTER_POINTER so the preprocessor will
 // not split the expansion across multiple lines.
 MP_REGISTER_ROOT_POINTER(mp_obj_t background_pio[enum_NUM_DMA_CHANNELS]);


### PR DESCRIPTION
If StateMachine.run needs to contain a JMP instruction, the offset property can be used to correctly encode the target address.

StateMachine.pc is useful for debugging, as it can give an overall statistical idea of which state machine instructions are executing, or show the instruction where the machine is stalled.