### PR TITLE
Fix RP2 XOSC startup delay

### DIFF
--- a/ports/raspberrypi/sdk_config/pico/config_autogen.h
+++ b/ports/raspberrypi/sdk_config/pico/config_autogen.h
@@ -1,3 +1,5 @@
 #pragma once
 
 #include "include/cmsis/rename_exceptions.h"
+
+#include "pico-sdk-configboard.h"


### PR DESCRIPTION
It was removed from this file in the RP2350 PR.