### PR TITLE
Extend EVE hardware opcodes for future-compatibility

### DIFF
--- a/docs/shared_bindings_matrix.py
+++ b/docs/shared_bindings_matrix.py
@@ -65,6 +65,7 @@ ALIASES_BRAND_NAMES = {
 
 ADDITIONAL_MODULES = {
     "_asyncio": "MICROPY_PY_ASYNCIO",
+    "_eve": "CIRCUITPY__EVE",
     "adafruit_bus_device": "CIRCUITPY_BUSDEVICE",
     "adafruit_pixelbuf": "CIRCUITPY_PIXELBUF",
     "array": "CIRCUITPY_ARRAY",

--- a/ports/atmel-samd/boards/feather_m4_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/feather_m4_express/mpconfigboard.h
@@ -28,6 +28,20 @@
 #define DEFAULT_UART_BUS_RX (&pin_PB17)
 #define DEFAULT_UART_BUS_TX (&pin_PB16)
 
+// Used for 32 kHZ crystal
+#define IGNORE_PIN_PA00     1
+#define IGNORE_PIN_PA01     1
+
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1
+
+// Not connected
+#define IGNORE_PIN_PA15     1
+#define IGNORE_PIN_PA27     1
+#define IGNORE_PIN_PB00     1
+#define IGNORE_PIN_PB04     1
+#define IGNORE_PIN_PB06     1
+#define IGNORE_PIN_PB07     1
+#define IGNORE_PIN_PB30     1
+#define IGNORE_PIN_PB31     1

--- a/ports/atmel-samd/boards/metro_m4_express/mpconfigboard.h
+++ b/ports/atmel-samd/boards/metro_m4_express/mpconfigboard.h
@@ -32,6 +32,19 @@
 #define DEFAULT_UART_BUS_RX (&pin_PA23)
 #define DEFAULT_UART_BUS_TX (&pin_PA22)
 
+// Used for 32 kHz crystal
+#define IGNORE_PIN_PA00     1
+#define IGNORE_PIN_PA01     1
+
 // USB is always used internally so skip the pin objects for it.
 #define IGNORE_PIN_PA24     1
 #define IGNORE_PIN_PA25     1
+
+// Not connected
+#define IGNORE_PIN_PA07     1
+#define IGNORE_PIN_PA15     1
+#define IGNORE_PIN_PB00     1
+#define IGNORE_PIN_PB01     1
+#define IGNORE_PIN_PB04     1
+#define IGNORE_PIN_PB05     1
+#define IGNORE_PIN_PB23     1

--- a/shared-bindings/_eve/__init__.c
+++ b/shared-bindings/_eve/__init__.c
@@ -677,7 +677,7 @@ static mp_obj_t _palettesource(mp_obj_t self, mp_obj_t a0) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(palettesource_obj, _palettesource);
 
-//|     def PaletteSource(self, addr: int) -> None:
+//|     def PaletteSourceH(self, addr: int) -> None:
 //|         """Set the base address of the palette
 //|
 //|         :param int addr: Address in graphics RAM, 2-byte aligned, high part.

--- a/shared-bindings/_eve/__init__.c
+++ b/shared-bindings/_eve/__init__.c
@@ -214,7 +214,7 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(bitmapsize_obj, 6, 6, _bitmapsize);
 //|     def BitmapSource(self, addr: int) -> None:
 //|         """Set the source address for bitmap graphics
 //|
-//|         :param int addr: Bitmap start address, pixel-aligned. May be in SRAM or flash. Range 0-16777215
+//|         :param int addr: Bitmap start address, pixel-aligned, low part.
 //|         """
 //|         ...
 
@@ -224,6 +224,20 @@ static mp_obj_t _bitmapsource(mp_obj_t self, mp_obj_t a0) {
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(bitmapsource_obj, _bitmapsource);
+
+//|     def BitmapSourceH(self, addr: int) -> None:
+//|         """Set the high source address for bitmap graphics
+//|
+//|         :param int addr: Bitmap start address, pixel-aligned, high part.
+//|         """
+//|         ...
+
+static mp_obj_t _bitmapsourceh(mp_obj_t self, mp_obj_t a0) {
+    uint32_t addr = mp_obj_get_int_truncated(a0);
+    common_hal__eve_BitmapSourceH(EVEHAL(self), addr);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(bitmapsourceh_obj, _bitmapsourceh);
 
 //|     def BitmapSwizzle(self, r: int, g: int, b: int, a: int) -> None:
 //|         """Set the source for the r,g,b and a channels of a bitmap
@@ -650,7 +664,7 @@ static MP_DEFINE_CONST_FUN_OBJ_1(nop_obj, _nop);
 //|     def PaletteSource(self, addr: int) -> None:
 //|         """Set the base address of the palette
 //|
-//|         :param int addr: Address in graphics SRAM, 2-byte aligned. Range 0-4194303. The initial value is 0
+//|         :param int addr: Address in graphics RAM, 2-byte aligned, low part.
 //|
 //|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`.
 //|         """
@@ -662,6 +676,22 @@ static mp_obj_t _palettesource(mp_obj_t self, mp_obj_t a0) {
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(palettesource_obj, _palettesource);
+
+//|     def PaletteSource(self, addr: int) -> None:
+//|         """Set the base address of the palette
+//|
+//|         :param int addr: Address in graphics RAM, 2-byte aligned, high part.
+//|
+//|         This value is part of the graphics context and is saved and restored by :meth:`SaveContext` and :meth:`RestoreContext`.
+//|         """
+//|         ...
+
+static mp_obj_t _palettesourceh(mp_obj_t self, mp_obj_t a0) {
+    uint32_t addr = mp_obj_get_int_truncated(a0);
+    common_hal__eve_PaletteSourceH(EVEHAL(self), addr);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(palettesourceh_obj, _palettesourceh);
 
 //|     def RestoreContext(self) -> None:
 //|         """Restore the current graphics context from the context stack"""
@@ -854,6 +884,7 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(vertex2ii_obj, 3, 5, _vertex2ii);
     { MP_ROM_QSTR(MP_QSTR_BitmapSizeH), MP_ROM_PTR(&bitmapsizeh_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_BitmapSize), MP_ROM_PTR(&bitmapsize_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_BitmapSource), MP_ROM_PTR(&bitmapsource_obj) }, \
+    { MP_ROM_QSTR(MP_QSTR_BitmapSourceH), MP_ROM_PTR(&bitmapsourceh_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_BitmapSwizzle), MP_ROM_PTR(&bitmapswizzle_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_BitmapTransformA), MP_ROM_PTR(&bitmaptransforma_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_BitmapTransformB), MP_ROM_PTR(&bitmaptransformb_obj) }, \
@@ -879,6 +910,7 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(vertex2ii_obj, 3, 5, _vertex2ii);
     { MP_ROM_QSTR(MP_QSTR_Macro), MP_ROM_PTR(&macro_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_Nop), MP_ROM_PTR(&nop_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_PaletteSource), MP_ROM_PTR(&palettesource_obj) }, \
+    { MP_ROM_QSTR(MP_QSTR_PaletteSourceH), MP_ROM_PTR(&palettesourceh_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_PointSize), MP_ROM_PTR(&pointsize_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_RestoreContext), MP_ROM_PTR(&restorecontext_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_Return), MP_ROM_PTR(&return_obj) }, \

--- a/shared-bindings/_eve/__init__.h
+++ b/shared-bindings/_eve/__init__.h
@@ -21,6 +21,7 @@ void common_hal__eve_BitmapLayout(common_hal__eve_t *eve, uint32_t format, uint3
 void common_hal__eve_BitmapSizeH(common_hal__eve_t *eve, uint32_t width, uint32_t height);
 void common_hal__eve_BitmapSize(common_hal__eve_t *eve, uint32_t filter, uint32_t wrapx, uint32_t wrapy, uint32_t width, uint32_t height);
 void common_hal__eve_BitmapSource(common_hal__eve_t *eve, uint32_t addr);
+void common_hal__eve_BitmapSourceH(common_hal__eve_t *eve, uint32_t addr);
 void common_hal__eve_BitmapSwizzle(common_hal__eve_t *eve, uint32_t r, uint32_t g, uint32_t b, uint32_t a);
 void common_hal__eve_BitmapTransformA(common_hal__eve_t *eve, uint32_t p, uint32_t v);
 void common_hal__eve_BitmapTransformB(common_hal__eve_t *eve, uint32_t p, uint32_t v);
@@ -46,6 +47,7 @@ void common_hal__eve_LineWidth(common_hal__eve_t *eve, mp_float_t width);
 void common_hal__eve_Macro(common_hal__eve_t *eve, uint32_t m);
 void common_hal__eve_Nop(common_hal__eve_t *eve);
 void common_hal__eve_PaletteSource(common_hal__eve_t *eve, uint32_t addr);
+void common_hal__eve_PaletteSourceH(common_hal__eve_t *eve, uint32_t addr);
 void common_hal__eve_PointSize(common_hal__eve_t *eve, mp_float_t size);
 void common_hal__eve_RestoreContext(common_hal__eve_t *eve);
 void common_hal__eve_Return(common_hal__eve_t *eve);

--- a/shared-module/_eve/__init__.c
+++ b/shared-module/_eve/__init__.c
@@ -75,7 +75,7 @@ void common_hal__eve_BitmapExtFormat(common_hal__eve_t *eve, uint32_t fmt) {
 
 
 void common_hal__eve_BitmapHandle(common_hal__eve_t *eve, uint32_t handle) {
-    C4(eve, ((5 << 24) | ((handle & 31))));
+    C4(eve, ((5 << 24) | ((handle & 63))));
 }
 
 
@@ -101,6 +101,11 @@ void common_hal__eve_BitmapSize(common_hal__eve_t *eve, uint32_t filter, uint32_
 
 void common_hal__eve_BitmapSource(common_hal__eve_t *eve, uint32_t addr) {
     C4(eve, ((1 << 24) | ((addr & 0xffffff))));
+}
+
+
+void common_hal__eve_BitmapSourceH(common_hal__eve_t *eve, uint32_t addr) {
+    C4(eve, ((49 << 24) | ((addr & 0xff))));
 }
 
 
@@ -175,7 +180,7 @@ void common_hal__eve_ClearStencil(common_hal__eve_t *eve, uint32_t s) {
 
 
 void common_hal__eve_ClearTag(common_hal__eve_t *eve, uint32_t s) {
-    C4(eve, ((18 << 24) | ((s & 255))));
+    C4(eve, ((18 << 24) | ((s & 0xffffff))));
 }
 
 
@@ -226,7 +231,12 @@ void common_hal__eve_Nop(common_hal__eve_t *eve) {
 
 
 void common_hal__eve_PaletteSource(common_hal__eve_t *eve, uint32_t addr) {
-    C4(eve, ((42 << 24) | (((addr) & 4194303))));
+    C4(eve, ((42 << 24) | (((addr) & 0xffffff))));
+}
+
+
+void common_hal__eve_PaletteSourceH(common_hal__eve_t *eve, uint32_t addr) {
+    C4(eve, ((50 << 24) | (((addr) & 0xff))));
 }
 
 
@@ -282,7 +292,7 @@ void common_hal__eve_TagMask(common_hal__eve_t *eve, uint32_t mask) {
 
 
 void common_hal__eve_Tag(common_hal__eve_t *eve, uint32_t s) {
-    C4(eve, ((3 << 24) | ((s & 255))));
+    C4(eve, ((3 << 24) | ((s & 0xffffff))));
 }
 
 


### PR DESCRIPTION
Extend the bitfields of these instructions: BitmapHandle, ClearTag, Tag, BitmapSource, PaletteSource
Add instructions: BitmapSourceH PaletteSourceH

All the new bits and opcodes are ignored by earlier hardware, so this change is backwards-compatible.

Passes tests on all EVE hardware.