### PR TITLE
rp2pio: Support PIOv1 (rp2350) features

### DIFF
--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -86,64 +86,69 @@
 //|     ) -> None:
 //|         """Construct a StateMachine object on the given pins with the given program.
 //|
+//|         The following parameters are usually supplied directly:
+//|
 //|         :param ReadableBuffer program: the program to run with the state machine
 //|         :param int frequency: the target clock frequency of the state machine. Actual may be less. Use 0 for system clock speed.
 //|         :param ReadableBuffer init: a program to run once at start up. This is run after program
 //|              is started so instructions may be intermingled
-//|         :param int pio_version: The version of the PIO peripheral required by the program. The constructor will raise an error if the actual hardware is not compatible with this program version.
 //|         :param ReadableBuffer may_exec: Instructions that may be executed via `StateMachine.run` calls.
 //|             Some elements of the `StateMachine`'s configuration are inferred from the instructions used;
 //|             for instance, if there is no ``in`` or ``push`` instruction, then the `StateMachine` is configured without a receive FIFO.
 //|             In this case, passing a ``may_exec`` program containing an ``in`` instruction such as ``in x``, a receive FIFO will be configured.
 //|         :param ~microcontroller.Pin first_out_pin: the first pin to use with the OUT instruction
-//|         :param int out_pin_count: the count of consecutive pins to use with OUT starting at first_out_pin
 //|         :param int initial_out_pin_state: the initial output value for out pins starting at first_out_pin
 //|         :param int initial_out_pin_direction: the initial output direction for out pins starting at first_out_pin
 //|         :param ~microcontroller.Pin first_in_pin: the first pin to use with the IN instruction
-//|         :param int in_pin_count: the count of consecutive pins to use with IN starting at first_in_pin
 //|         :param int pull_in_pin_up: a 1-bit in this mask sets pull up on the corresponding in pin
 //|         :param int pull_in_pin_down: a 1-bit in this mask sets pull down on the corresponding in pin. Setting both pulls enables a "bus keep" function, i.e. a weak pull to whatever is current high/low state of GPIO.
 //|         :param ~microcontroller.Pin first_set_pin: the first pin to use with the SET instruction
-//|         :param int set_pin_count: the count of consecutive pins to use with SET starting at first_set_pin
 //|         :param int initial_set_pin_state: the initial output value for set pins starting at first_set_pin
 //|         :param int initial_set_pin_direction: the initial output direction for set pins starting at first_set_pin
 //|         :param ~microcontroller.Pin first_sideset_pin: the first pin to use with a side set
-//|         :param int sideset_pin_count: the count of consecutive pins to use with a side set starting at first_sideset_pin. Does not include sideset enable
 //|         :param int initial_sideset_pin_state: the initial output value for sideset pins starting at first_sideset_pin
 //|         :param int initial_sideset_pin_direction: the initial output direction for sideset pins starting at first_sideset_pin
 //|         :param bool sideset_enable: True when the top sideset bit is to enable. This should be used with the ".side_set # opt" directive
 //|         :param ~microcontroller.Pin jmp_pin: the pin which determines the branch taken by JMP PIN instructions
 //|         :param ~digitalio.Pull jmp_pin_pull: The pull value for the jmp pin, default is no pull.
 //|         :param bool exclusive_pin_use: When True, do not share any pins with other state machines. Pins are never shared with other peripherals
-//|         :param bool auto_pull: When True, automatically load data from the tx FIFO into the
-//|             output shift register (OSR) when an OUT instruction shifts more than pull_threshold bits
-//|         :param int pull_threshold: Number of bits to shift before loading a new value into the OSR from the tx FIFO
-//|         :param bool out_shift_right: When True, data is shifted out the right side (LSB) of the
-//|             OSR. It is shifted out the left (MSB) otherwise. NOTE! This impacts data alignment
-//|             when the number of bytes is not a power of two (1, 2 or 4 bytes).
 //|         :param bool wait_for_txstall: When True, writing data out will block until the TX FIFO and OSR are empty
 //|             and an instruction is stalled waiting for more data. When False, data writes won't
 //|             wait for the OSR to empty (only the TX FIFO) so make sure you give enough time before
 //|             deiniting or stopping the state machine.
-//|         :param bool auto_push: When True, automatically save data from input shift register
-//|              (ISR) into the rx FIFO when an IN instruction shifts more than push_threshold bits
-//|         :param int push_threshold: Number of bits to shift before saving the ISR value to the RX FIFO
-//|         :param bool in_shift_right: When True, data is shifted into the right side (LSB) of the
-//|             ISR. It is shifted into the left (MSB) otherwise. NOTE! This impacts data alignment
-//|             when the number of bytes is not a power of two (1, 2 or 4 bytes).
 //|         :param bool user_interruptible: When True (the default),
 //|             `write()`, `readinto()`, and `write_readinto()` can be interrupted by a ctrl-C.
 //|             This is useful when developing a PIO program: if there is an error in the program
 //|             that causes an infinite loop, you will be able to interrupt the loop.
 //|             However, if you are writing to a device that can get into a bad state if a read or write
 //|             is interrupted, you may want to set this to False after your program has been vetted.
+//|         :param int offset: A specific offset in the state machine's program memory where the program must be loaded.
+//|             The default value, -1, allows the program to be loaded at any offset.
+//|             This is appropriate for most programs.
+//|
+//|         The following parameters are usually set via assembler directives and passed using a ``**program.pio_kwargs`` argument but may also be specified directly:
+//|
+//|         :param int out_pin_count: the count of consecutive pins to use with OUT starting at first_out_pin
+//|         :param int in_pin_count: the count of consecutive pins to use with IN starting at first_in_pin
+//|         :param int set_pin_count: the count of consecutive pins to use with SET starting at first_set_pin
+//|         :param int sideset_pin_count: the count of consecutive pins to use with a side set starting at first_sideset_pin. Does not include sideset enable
+//|         :param int pio_version: The version of the PIO peripheral required by the program. The constructor will raise an error if the actual hardware is not compatible with this program version.
+//|         :param bool auto_push: When True, automatically save data from input shift register
+//|              (ISR) into the rx FIFO when an IN instruction shifts more than push_threshold bits
+//|         :param int push_threshold: Number of bits to shift before saving the ISR value to the RX FIFO
+//|         :param bool in_shift_right: When True, data is shifted into the right side (LSB) of the
+//|             ISR. It is shifted into the left (MSB) otherwise. NOTE! This impacts data alignment
+//|             when the number of bytes is not a power of two (1, 2 or 4 bytes).
+//|         :param bool auto_pull: When True, automatically load data from the tx FIFO into the
+//|             output shift register (OSR) when an OUT instruction shifts more than pull_threshold bits
+//|         :param int pull_threshold: Number of bits to shift before loading a new value into the OSR from the tx FIFO
+//|         :param bool out_shift_right: When True, data is shifted out the right side (LSB) of the
+//|             OSR. It is shifted out the left (MSB) otherwise. NOTE! This impacts data alignment
+//|             when the number of bytes is not a power of two (1, 2 or 4 bytes).
 //|         :param int wrap_target: The target instruction number of automatic wrap. Defaults to the first instruction of the program.
 //|         :param int wrap: The instruction after which to wrap to the ``wrap``
 //|             instruction. As a special case, -1 (the default) indicates the
 //|             last instruction of the program.
-//|         :param int offset: A specific offset in the state machine's program memory where the program must be loaded.
-//|             The default value, -1, allows the program to be loaded at any offset.
-//|             This is appropriate for most programs.
 //|         :param FifoType fifo_type: How the program accessess the FIFOs. PIO version 0 only supports a subset of values.
 //|         :param MovStatusType mov_status_type: What condition the ``mov status`` instruction checks. PIO version 0 only supports a subset of values.
 //|         :param MovStatusType mov_status_n: The FIFO depth or IRQ the ``mov status`` instruction checks for. For ``mov_status irq`` this includes the encoding of the ``next``/``prev`` selection bits.

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -21,6 +21,8 @@
 #include "py/objproperty.h"
 #include "py/runtime.h"
 
+//| import memorymap
+//|
 //| FifoType = Literal["auto", "txrx", "tx", "rx", "txput", "txget", "putget"]
 //| FifoType_piov0 = Literal["auto", "txrx", "tx", "rx"]
 //| MovStatusType = Literal["txfifo", "rxfifo", "irq"]
@@ -909,7 +911,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(rp2pio_statemachine_get_pc_obj, rp2pio_statemachine_ob
 MP_PROPERTY_GETTER(rp2pio_statemachine_pc_obj,
     (mp_obj_t)&rp2pio_statemachine_get_pc_obj);
 
-//|     rxfifo: AddressRange
+//|     rxfifo: memorymap.AddressRange
 //|     """Accecss the state machine's rxfifo directly
 //|
 //|     If the state machine's fifo mode is ``txput`` then accessing this object

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -912,7 +912,7 @@ MP_PROPERTY_GETTER(rp2pio_statemachine_pc_obj,
     (mp_obj_t)&rp2pio_statemachine_get_pc_obj);
 
 //|     rxfifo: memorymap.AddressRange
-//|     """Accecss the state machine's rxfifo directly
+//|     """Access the state machine's rxfifo directly
 //|
 //|     If the state machine's fifo mode is ``txput`` then accessing this object
 //|     reads values stored by the ``mov rxfifo[], isr`` PIO instruction, and the
@@ -920,7 +920,7 @@ MP_PROPERTY_GETTER(rp2pio_statemachine_pc_obj,
 //|
 //|     If the state machine's fifo mode is ``txget`` then modifying this object
 //|     writes values accessed by the ``mov osr, rxfifo[]`` PIO instruction, and
-//|     the result of accessing it is undefined..
+//|     the result of accessing it is undefined.
 //|
 //|     If this state machine's mode is something else, then the property's value is `None`.
 //|

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -234,7 +234,7 @@ static mp_obj_t rp2pio_statemachine_make_new(const mp_obj_type_t *type, size_t n
 
         { MP_QSTR_offset, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = PIO_ANY_OFFSET} },
 
-        { MP_QSTR_fifo_type, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_ROM_QSTR(MP_QSTR_rxtx) } },
+        { MP_QSTR_fifo_type, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_ROM_QSTR(MP_QSTR_auto) } },
         { MP_QSTR_mov_status_type, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_ROM_QSTR(MP_QSTR_txfifo) } },
         { MP_QSTR_mov_status_n, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
     };

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.h
@@ -34,7 +34,10 @@ void common_hal_rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
     bool auto_push, uint8_t push_threshold, bool in_shift_right,
     bool user_interruptible,
     int wrap_taget, int wrap,
-    int offset);
+    int offset,
+    int fifo_type,
+    int mov_status_type,
+    int mov_status_n);
 
 void common_hal_rp2pio_statemachine_deinit(rp2pio_statemachine_obj_t *self);
 bool common_hal_rp2pio_statemachine_deinited(rp2pio_statemachine_obj_t *self);

--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.h
@@ -73,3 +73,5 @@ int common_hal_rp2pio_statemachine_get_offset(rp2pio_statemachine_obj_t *self);
 int common_hal_rp2pio_statemachine_get_pc(rp2pio_statemachine_obj_t *self);
 
 void common_hal_rp2pio_statemachine_set_interrupt_handler(rp2pio_statemachine_obj_t *self, void (*handler)(void *), void *arg, int mask);
+
+mp_obj_t common_hal_rp2pio_statemachine_get_rxfifo(rp2pio_statemachine_obj_t *self);

--- a/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+++ b/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
@@ -198,7 +198,11 @@ void common_hal_audiobusio_i2sout_construct(audiobusio_i2sout_obj_t *self,
         false, 32, false, // in settings
         false, // Not user-interruptible.
         0, -1, // wrap settings
-        PIO_ANY_OFFSET);
+        PIO_ANY_OFFSET,
+        PIO_FIFO_TYPE_DEFAULT,
+        PIO_MOV_STATUS_DEFAULT,
+        PIO_MOV_N_DEFAULT
+        );
 
     self->playing = false;
     audio_dma_init(&self->dma);

--- a/ports/raspberrypi/common-hal/audiobusio/PDMIn.c
+++ b/ports/raspberrypi/common-hal/audiobusio/PDMIn.c
@@ -60,7 +60,9 @@ void common_hal_audiobusio_pdmin_construct(audiobusio_pdmin_obj_t *self,
         false, 32, true, // in settings
         false, // Not user-interruptible.
         0, -1, // wrap settings
-        PIO_ANY_OFFSET);
+        PIO_ANY_OFFSET,
+        PIO_FIFO_TYPE_DEFAULT,
+        PIO_MOV_STATUS_DEFAULT, PIO_MOV_N_DEFAULT);
     uint32_t actual_frequency = common_hal_rp2pio_statemachine_get_frequency(&self->state_machine);
     if (actual_frequency < MIN_MIC_CLOCK) {
         mp_raise_ValueError(MP_ERROR_TEXT("sampling rate out of range"));

--- a/ports/raspberrypi/common-hal/floppyio/__init__.c
+++ b/ports/raspberrypi/common-hal/floppyio/__init__.c
@@ -99,7 +99,9 @@ int common_hal_floppyio_flux_readinto(void *buf, size_t len, digitalio_digitalin
         false, // Not user-interruptible.
         false, // No sideset enable
         0, -1, // wrap
-        PIO_ANY_OFFSET  // offset
+        PIO_ANY_OFFSET,  // offset
+        PIO_FIFO_TYPE_DEFAULT,
+        PIO_MOV_STATUS_DEFAULT, PIO_MOV_N_DEFAULT
         );
     if (!ok) {
         mp_raise_RuntimeError(MP_ERROR_TEXT("All state machines in use"));

--- a/ports/raspberrypi/common-hal/imagecapture/ParallelImageCapture.c
+++ b/ports/raspberrypi/common-hal/imagecapture/ParallelImageCapture.c
@@ -101,7 +101,9 @@ void common_hal_imagecapture_parallelimagecapture_construct(imagecapture_paralle
         true, 32, true,  // in settings
         false, // Not user-interruptible.
         2, 5, // wrap settings
-        PIO_ANY_OFFSET);
+        PIO_ANY_OFFSET,
+        PIO_FIFO_TYPE_DEFAULT,
+        PIO_MOV_STATUS_DEFAULT, PIO_MOV_N_DEFAULT);
 }
 
 void common_hal_imagecapture_parallelimagecapture_deinit(imagecapture_parallelimagecapture_obj_t *self) {

--- a/ports/raspberrypi/common-hal/neopixel_write/__init__.c
+++ b/ports/raspberrypi/common-hal/neopixel_write/__init__.c
@@ -60,8 +60,9 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t *digitalinout,
         false, // Not user-interruptible.
         false, // No sideset enable
         0, -1, // wrap
-        PIO_ANY_OFFSET  // offset
-        );
+        PIO_ANY_OFFSET,  // offset
+        PIO_FIFO_TYPE_DEFAULT,
+        PIO_MOV_STATUS_DEFAULT, PIO_MOV_N_DEFAULT);
     if (!ok) {
         // Do nothing. Maybe bitbang?
         return;

--- a/ports/raspberrypi/common-hal/paralleldisplaybus/ParallelBus.c
+++ b/ports/raspberrypi/common-hal/paralleldisplaybus/ParallelBus.c
@@ -92,7 +92,9 @@ void common_hal_paralleldisplaybus_parallelbus_construct(paralleldisplaybus_para
         false, 32, true, // RX setting we don't use
         false, // Not user-interruptible.
         0, -1, // wrap settings
-        PIO_ANY_OFFSET);
+        PIO_ANY_OFFSET,
+        PIO_FIFO_TYPE_DEFAULT,
+        PIO_MOV_STATUS_DEFAULT, PIO_MOV_N_DEFAULT);
 
     common_hal_rp2pio_statemachine_never_reset(&self->state_machine);
 }

--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.c
@@ -54,7 +54,9 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self,
         true, 32, true, // RX auto pull every 32 bits. shift left to output msb first
         false, // Not user-interruptible.
         0, -1, // wrap settings
-        PIO_ANY_OFFSET);
+        PIO_ANY_OFFSET,
+        PIO_FIFO_TYPE_DEFAULT,
+        PIO_MOV_STATUS_DEFAULT, PIO_MOV_N_DEFAULT);
 
     common_hal_pulseio_pulsein_pause(self);
 

--- a/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
+++ b/ports/raspberrypi/common-hal/rotaryio/IncrementalEncoder.c
@@ -76,8 +76,9 @@ void common_hal_rotaryio_incrementalencoder_construct(rotaryio_incrementalencode
         false, 32, false, // in settings
         false, // Not user-interruptible.
         0, MP_ARRAY_SIZE(encoder) - 1, // wrap settings
-        PIO_ANY_OFFSET
-        );
+        PIO_ANY_OFFSET,
+        PIO_FIFO_TYPE_DEFAULT,
+        PIO_MOV_STATUS_DEFAULT, PIO_MOV_N_DEFAULT);
 
     // We're guaranteed by the init code that some output will be available promptly
     uint8_t quiescent_state;

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -635,7 +635,7 @@ void common_hal_rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
             pull_up |= jmp_mask;
         }
         if (jmp_pull == PULL_DOWN) {
-            pull_up |= jmp_mask;
+            pull_down |= jmp_mask;
         }
     }
     if (initial_pin_direction & (pull_up | pull_down)) {

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -181,7 +181,7 @@ static uint add_program(PIO pio, const pio_program_t *program, int offset) {
     }
 }
 
-static pio_fifo_join compute_fifo_type(int fifo_type_in, bool rx_fifo, bool tx_fifo) {
+static enum pio_fifo_join compute_fifo_type(int fifo_type_in, bool rx_fifo, bool tx_fifo) {
     if (fifo_type_in != PIO_FIFO_JOIN_AUTO) {
         return fifo_type_in;
     }
@@ -194,7 +194,7 @@ static pio_fifo_join compute_fifo_type(int fifo_type_in, bool rx_fifo, bool tx_f
     return PIO_FIFO_JOIN_NONE;
 }
 
-static int compute_fifo_depth(pio_fifo_join join) {
+static int compute_fifo_depth(enum pio_fifo_join join) {
     if (join == PIO_FIFO_JOIN_TX || join == PIO_FIFO_JOIN_RX) {
         return 8;
     }

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
@@ -9,6 +9,7 @@
 #include "py/obj.h"
 
 #include "common-hal/microcontroller/Pin.h"
+#include "common-hal/memorymap/AddressRange.h"
 #include "src/rp2_common/hardware_pio/include/hardware/pio.h"
 
 enum { PIO_ANY_OFFSET = -1 };
@@ -50,6 +51,7 @@ typedef struct {
     sm_buf_info current, once, loop;
     int background_stride_in_bytes;
     bool dma_completed, byteswap;
+    memorymap_addressrange_obj_t rxfifo_obj;
 } rp2pio_statemachine_obj_t;
 
 void reset_rp2pio_statemachine(void);

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
@@ -51,7 +51,9 @@ typedef struct {
     sm_buf_info current, once, loop;
     int background_stride_in_bytes;
     bool dma_completed, byteswap;
+    #if PICO_PIO_VERSION > 0
     memorymap_addressrange_obj_t rxfifo_obj;
+    #endif
 } rp2pio_statemachine_obj_t;
 
 void reset_rp2pio_statemachine(void);

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
@@ -12,6 +12,9 @@
 #include "src/rp2_common/hardware_pio/include/hardware/pio.h"
 
 enum { PIO_ANY_OFFSET = -1 };
+enum { PIO_FIFO_JOIN_AUTO = -1, PIO_FIFO_TYPE_DEFAULT = PIO_FIFO_JOIN_AUTO };
+enum { PIO_MOV_STATUS_DEFAULT = STATUS_TX_LESSTHAN };
+enum { PIO_MOV_N_DEFAULT = 0 };
 
 typedef struct sm_buf_info {
     mp_obj_t obj;
@@ -70,7 +73,10 @@ bool rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
     bool claim_pins,
     bool interruptible,
     bool sideset_enable,
-    int wrap_target, int wrap, int offset);
+    int wrap_target, int wrap, int offset,
+    int fifo_type,
+    int mov_status_type, int mov_status_n
+    );
 
 uint8_t rp2pio_statemachine_program_offset(rp2pio_statemachine_obj_t *self);
 


### PR DESCRIPTION
This is needed to fully support the .mov_status and .fifo directives, as well as checking for PIO version compatibility between program & runtime hardware.

- [ ] does consider_instruction need to be extended
- [x] test on HW & test new instructions & new HW features

This works in tandem with https://github.com/adafruit/Adafruit_CircuitPython_PIOASM/pull/68