### PR TITLE
webworkflow warn before leaving page during upload

### DIFF
--- a/supervisor/shared/web_workflow/static/directory.js
+++ b/supervisor/shared/web_workflow/static/directory.js
@@ -191,7 +191,17 @@ async function mkdir(e) {
     }
 }
 
+const beforeUnloadHandler = function(event){
+    // Recommended
+    event.preventDefault();
+
+    // Included for legacy support, e.g. Chrome/Edge < 119
+    event.returnValue = true;
+}
+
 async function upload(e) {
+    const upload_path = current_path;
+    window.addEventListener("beforeunload",  beforeUnloadHandler);
     set_upload_enabled(false);
     let progress = document.querySelector("#progress");
     let made_dirs = new Set();
@@ -213,7 +223,7 @@ async function upload(e) {
                 made_dirs.add(parent_dir);
             }
         }
-        let file_path = new URL("/fs" + current_path + file_name, url_base);
+        let file_path = new URL("/fs" + upload_path + file_name, url_base);
         const response = await fetch(file_path,
             {
                 method: "PUT",
@@ -242,6 +252,7 @@ async function upload(e) {
     files.value = "";
     dirs.value = "";
     set_upload_enabled(true);
+    window.removeEventListener("beforeunload",  beforeUnloadHandler);
 }
 
 async function del(e) {


### PR DESCRIPTION
resolves: #9606 

There turned out to be two different cases to handle for this:

1) When the user attempts to navigate to a different page by clicking a link to a file, or refreshing the page
2) When the user clicks a directory which is a link containing a hash value instead of going to a different page which does not trigger the beforeunload event


For 1 the solution of adding the event listener for `beforeunload` event and then preventing the default behavior causes the alert to the shown to the user confirming whether they want to leave. As far as I understand it, it's not longer possible to customize the message in that confirmation it will always be a generic message, in the past it was possible, but not in modern browsers.

For 2 since the page doesn't technically change it doesn't trigger the event. I tried for a bit to dispatch the beforeunload event "manually" but it wasn't working. In the end I realized that we could make the upload succeed instead of fail by storing the value of `current_path` into a local variable and using it throughout the rest of `upload()` rather than getting the value from the possibly changed by user action `current_path` variable. With this change when the user navigates to a new directory the upload just continues working and the remaining files succeed to upload, so there is no need to warn the user about leaving the page since technically the aren't, and now the remaining uploads can succeed.