### PR TITLE
Document consequences of RP2350-E9 erratum for CircuitPython

### DIFF
--- a/ports/raspberrypi/bindings/rp2pio/__init__.c
+++ b/ports/raspberrypi/bindings/rp2pio/__init__.c
@@ -17,6 +17,11 @@
 //|     introduction and guide to working with PIO in CircuitPython, see `this
 //|     Learn guide <https://learn.adafruit.com/intro-to-rp2040-pio-with-circuitpython>`_.
 //|
+//| .. warning:: Using PIO inputs on Raspberry Pi RP2350 A2 stepping has some limitations
+//|    due to a GPIO hardware issue that causes excessive leakage current (~120uA).
+//|    A pin can read as high even when driven or pulled low, if the input signal is high
+//|    impedance or if an attached pull-down resistor is too weak (has too high a value).
+//|    See the warning in `digitalio` for more information.
 //| """
 //|
 

--- a/shared-bindings/digitalio/__init__.c
+++ b/shared-bindings/digitalio/__init__.c
@@ -58,6 +58,27 @@
 //|
 //| For more information on using `digitalio`, see `this additional Learn guide
 //| <https://learn.adafruit.com/circuitpython-digital-inputs-and-outputs>`_
+//|
+//| .. warning:: `digitalio.DigitalInOut` on Raspberry Pi RP2350 A2 stepping has some limitations
+//|    due to a GPIO hardware issue that causes excessive leakage current (~120uA).
+//|    A pin can read as high even when driven or pulled low, if the input signal is high
+//|    impedance or if an attached pull-down resistor is too weak (has too high a value).
+//|
+//|    To prevent this problem, drive the the input pin with a strong signal that can overcome
+//|    the leakage current. If you need to use a pull-down,
+//|    connect a strong external pull-down resistor that is 8.2k ohms or less.
+//|
+//|    The internal pull-down resistor (``digitalio.DigitalInOut.pull = digitalio.Pull.DOWN``)
+//|    is not strong enough, and is not useful.
+//|
+//|    Typical push-pull outputs from attached peripherals or other microcontrollers will drive
+//|    input pins adequately, with no resistor needed.
+//|
+//|    There is no problem when pull-ups are used, even weak ones. Using the internal pull-up resistor
+//|    (``digitalioDigitalInOut.pull = digitalio.Pull.UP``) will work fine.
+//|
+//|    For more information, see the RP2350-E9 erratum in the
+//|    `RP2350 datasheet <https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf>`_
 //| """
 
 static const mp_rom_map_elem_t digitalio_module_globals_table[] = {

--- a/shared-bindings/keypad/__init__.c
+++ b/shared-bindings/keypad/__init__.c
@@ -70,6 +70,12 @@ const mp_obj_property_t keypad_generic_events_obj = {
 //| For more information about working with the `keypad` module in CircuitPython,
 //| see `this Learn guide <https://learn.adafruit.com/key-pad-matrix-scanning-in-circuitpython>`_.
 //|
+//| .. warning:: Using pull-downs with `keypad` on Raspberry Pi RP2350 A2 stepping has some limitations
+//|    due to a GPIO hardware issue that causes excessive leakage current (~120uA).
+//|    A pin can read as high even when driven or pulled low, if the input signal is high
+//|    impedance or if an attached pull-down resistor is too weak (has too high a value).
+//|    See the warning in `digitalio` for more information.
+//|
 //| .. jinja
 //| """
 

--- a/shared-bindings/touchio/__init__.c
+++ b/shared-bindings/touchio/__init__.c
@@ -28,6 +28,9 @@
 //| For more information about working with the `touchio` module in CircuitPython,
 //| see `this Learn guide page <https://learn.adafruit.com/circuitpython-essentials/circuitpython-cap-touch>`_.
 //|
+//| **Limitations**: `touchio` is available on Raspberry Pi RP2040 builds,
+//| but not on RP2350, due to GPIO hardware limitations.
+//|
 //| Example::
 //|
 //|   import touchio


### PR DESCRIPTION
Main explanation is in `digitalio`. Briefer mentions in `keypad` and `rp2pio`, xref-ing to the `digitalio` writeup. 

Also document that `touchio` is not available on RP2350.

@BlitzCityDIY See how this is for the guide, and whether you have any suggestions.