### PR TITLE
Makerfab TFT7" settings.toml parameter to set screen variant

### DIFF
--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8_hacktablet/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n8r8_hacktablet/board.c
@@ -77,11 +77,6 @@ static void display_init(void) {
 }
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
     display_init();
 }
 

--- a/ports/espressif/boards/makerfabs_tft7/board.c
+++ b/ports/espressif/boards/makerfabs_tft7/board.c
@@ -98,11 +98,6 @@ static void display_init(void) {
 }
 
 void board_init(void) {
-    // Debug UART
-    #ifdef DEBUG
-    common_hal_never_reset_pin(&pin_GPIO43);
-    common_hal_never_reset_pin(&pin_GPIO44);
-    #endif
     display_init();
 }
 

--- a/ports/espressif/boards/makerfabs_tft7/board.c
+++ b/ports/espressif/boards/makerfabs_tft7/board.c
@@ -6,9 +6,117 @@
 
 #include "supervisor/board.h"
 #include "mpconfigboard.h"
+#include "shared-bindings/board/__init__.h"
+#include "shared-bindings/dotclockframebuffer/DotClockFramebuffer.h"
+#include "shared-bindings/dotclockframebuffer/__init__.h"
+#include "shared-bindings/framebufferio/FramebufferDisplay.h"
 #include "shared-bindings/microcontroller/Pin.h"
+#include "shared-module/displayio/__init__.h"
+#include "shared-module/os/__init__.h"
+
+static const mcu_pin_obj_t *blue_pins[] = {
+    &pin_GPIO8,
+    &pin_GPIO3,
+    &pin_GPIO46,
+    &pin_GPIO9,
+    &pin_GPIO1
+};
+static const mcu_pin_obj_t *green_pins[] = {
+    &pin_GPIO5,
+    &pin_GPIO6,
+    &pin_GPIO7,
+    &pin_GPIO15,
+    &pin_GPIO16,
+    &pin_GPIO4
+};
+static const mcu_pin_obj_t *red_pins[] = {
+    &pin_GPIO45,
+    &pin_GPIO48,
+    &pin_GPIO47,
+    &pin_GPIO21,
+    &pin_GPIO14
+};
+
+static void display_init(void) {
+
+    mp_int_t height=0, width=0, frequency=0;
+    os_getenv_err_t result;
+
+    // Turn on backlight
+    // gpio_set_direction(2, GPIO_MODE_DEF_OUTPUT);
+    // gpio_set_level(2, true);
+    common_hal_never_reset_pin(&pin_GPIO39);
+
+    result = common_hal_os_getenv_int("CIRCUITPY_DISPLAY_WIDTH", &width);
+    if (result == GETENV_OK && width == 800) {
+        width = 800;
+        height = 480;
+        frequency = 6500000;
+    } else if (result == GETENV_OK) {
+        width = 1024;
+        height = 600;
+        frequency = 10000000;
+    }
+
+    if (height == 0) {
+        result = common_hal_os_getenv_int("CIRCUITPY_DISPLAY_HEIGHT", &height);
+        if (result == GETENV_OK && height == 480) {
+            width = 800;
+            height = 480;
+            frequency = 6500000;
+        } else if (result == GETENV_OK) {
+            width = 1024;
+            height = 600;
+            frequency = 10000000;
+        }
+    }
+
+    if (width == 0) {
+        width = 800;
+        height = 480;
+        frequency = 6500000;
+    }
+
+    dotclockframebuffer_framebuffer_obj_t *framebuffer = &allocate_display_bus_or_raise()->dotclock;
+    framebuffer->base.type = &dotclockframebuffer_framebuffer_type;
+
+    common_hal_dotclockframebuffer_framebuffer_construct(
+        framebuffer,
+        &pin_GPIO40,    // de
+        &pin_GPIO41,    // vsync
+        &pin_GPIO39,    // hsync
+        &pin_GPIO42,    // pclk
+        red_pins, MP_ARRAY_SIZE(red_pins),
+        green_pins, MP_ARRAY_SIZE(green_pins),
+        blue_pins, MP_ARRAY_SIZE(blue_pins),
+        frequency,        // Frequency
+        width,            // width
+        height,            // height
+        30, 16, 210, false, // horiz: pulse, back porch, front porch, idle low
+        13, 10, 22, false,  // vert: pulse, back porch, front porch, idle low
+        false,          // DE idle high
+        false,          // pclk active high
+        false,          // pclk idle high
+        0               // overscan left
+        );
+
+    framebufferio_framebufferdisplay_obj_t *display = &allocate_display_or_raise()->framebuffer_display;
+    display->base.type = &framebufferio_framebufferdisplay_type;
+    common_hal_framebufferio_framebufferdisplay_construct(
+        display,
+        framebuffer,
+        0,    // rotation
+        true  // auto-refresh
+        );
+}
 
 void board_init(void) {
+    // Debug UART
+    #ifdef DEBUG
+    common_hal_never_reset_pin(&pin_GPIO43);
+    common_hal_never_reset_pin(&pin_GPIO44);
+    #endif
+    display_init();
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/makerfabs_tft7/board.c
+++ b/ports/espressif/boards/makerfabs_tft7/board.c
@@ -52,26 +52,13 @@ static void display_init(void) {
         width = 800;
         height = 480;
         frequency = 6500000;
-    } else if (result == GETENV_OK) {
+    } else if (result == GETENV_OK && width == 1024) {
         width = 1024;
         height = 600;
         frequency = 10000000;
     }
 
     if (height == 0) {
-        result = common_hal_os_getenv_int("CIRCUITPY_DISPLAY_HEIGHT", &height);
-        if (result == GETENV_OK && height == 480) {
-            width = 800;
-            height = 480;
-            frequency = 6500000;
-        } else if (result == GETENV_OK) {
-            width = 1024;
-            height = 600;
-            frequency = 10000000;
-        }
-    }
-
-    if (width == 0) {
         width = 800;
         height = 480;
         frequency = 6500000;

--- a/ports/espressif/boards/makerfabs_tft7/board.c
+++ b/ports/espressif/boards/makerfabs_tft7/board.c
@@ -39,7 +39,7 @@ static const mcu_pin_obj_t *red_pins[] = {
 
 static void display_init(void) {
 
-    mp_int_t height=0, width=0, frequency=0;
+    mp_int_t height = 0, width = 0, frequency = 0;
     os_getenv_err_t result;
 
     // Turn on backlight

--- a/ports/espressif/boards/makerfabs_tft7/board.c
+++ b/ports/espressif/boards/makerfabs_tft7/board.c
@@ -42,11 +42,6 @@ static void display_init(void) {
     mp_int_t height = 0, width = 0, frequency = 0;
     os_getenv_err_t result;
 
-    // Turn on backlight
-    // gpio_set_direction(2, GPIO_MODE_DEF_OUTPUT);
-    // gpio_set_level(2, true);
-    common_hal_never_reset_pin(&pin_GPIO39);
-
     result = common_hal_os_getenv_int("CIRCUITPY_DISPLAY_WIDTH", &width);
     if (result == GETENV_OK && width == 800) {
         width = 800;

--- a/ports/espressif/boards/makerfabs_tft7/pins.c
+++ b/ports/espressif/boards/makerfabs_tft7/pins.c
@@ -6,6 +6,7 @@
 
 #include "py/objtuple.h"
 #include "shared-bindings/board/__init__.h"
+#include "shared-module/displayio/__init__.h"
 
 static const mp_rom_obj_tuple_t tft_r_pins = {
     {&mp_type_tuple},
@@ -124,6 +125,8 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     // { MP_ROM_QSTR(MP_QSTR_SDIO_CMD), MP_ROM_PTR(&pin_GPIO11) },
     // { MP_ROM_QSTR(MP_QSTR_SDIO_D0), MP_ROM_PTR(&pin_GPIO13) },
     // { MP_ROM_QSTR(MP_QSTR_SDIO_CLK), MP_ROM_PTR(&pin_GPIO12) },
+
+    { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display) },
 
     // boot mode button can be used in SW as well
     { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO1) },


### PR DESCRIPTION
After using settings.toml to deal with the Sunton display board variants I thought the same technique might be used to deal with the Makerfabs MaTouch TFT 7" board which comes in two different screen resolutions (800x480 & 1024x600). Currently we were not initializing the display in board.c because of the variants so instead, the display needed to be initialized using python code.

This update will default to initializing the board at 800x480 (which results in a partially readable display on the 1024x600 variant) but use the 1024x600 settings if the new CIRCUITPY_DISPLAY_WIDTH settings.toml parameter is set to 1024. If an invalid value is entered the display will be initialized using the 800x480 parameters.

I've tested this on the 1024x600 display variant but don't have the 800x480 version.