### PR TITLE
fix a problem with the addressrange example

### DIFF
--- a/shared-bindings/memorymap/AddressRange.c
+++ b/shared-bindings/memorymap/AddressRange.c
@@ -39,7 +39,7 @@
 //|            # Pad control register is updated using an MP-safe atomic XOR
 //|            pad_ctrl ^= (d << 4)
 //|            pad_ctrl &= 0x00000030
-//|            pads_bank0[p*4+0x3004:p*4+0x3008] = pad_ctrl.to_bytes(4, "little")
+//|            pads_bank0[p*4+0x1004:p*4+0x1008] = pad_ctrl.to_bytes(4, "little")
 //|
 //|        def rp2040_get_pad_drive(p):
 //|            pads_bank0 = memorymap.AddressRange(start=0x4001C000, length=0x4000)
@@ -51,6 +51,10 @@
 //|
 //|        # print GPIO16 pad drive strength
 //|        print(rp2040_get_pad_drive(16))
+//|
+//|     Note that the above example does **not** work on RP2350 because base
+//|     address and  organization of the "pads0" registers changed compared
+//|     to the RP2040.
 //|     """
 //|
 


### PR DESCRIPTION
The old offset was for "atomic bitmask clear on write" not "atomic XOR on write".

I was investigating this because the example didn't seem to work on rp2350; the reason for that is the registers having a different memory layout, so I noted this too.