### PR TITLE
Environment Variables doc to note possible board specific keys

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -117,4 +117,5 @@ CIRCUITPY_DISPLAY_ROTATION
 Selects the correct screen rotation (0, 90, 180 or 270) for the particular board variant.
 If the CIRCUITPY_DISPLAY_ROTATION parameter is set the display will be initialized
 during power up with the selected rotation, otherwise the display will be initialized with
-a rotation of 0.
+a rotation of 0. Attempting to initialize the screen with a rotation other than 0,
+90, 180 or 270 is not supported and will result in an unexpected screen rotation.

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -56,6 +56,9 @@ CircuitPython behavior
 CircuitPython will also read the environment to configure its behavior. Other
 keys are ignored by CircuitPython. Here are the keys it uses:
 
+Core CircuitPython keys
+^^^^^^^^^^^^^^^^^^^^^^^
+
 CIRCUITPY_BLE_NAME
 ~~~~~~~~~~~~~~~~~~
 Default BLE name the board advertises as, including for the BLE workflow.
@@ -95,5 +98,23 @@ CIRCUITPY_WIFI_SSID
 ~~~~~~~~~~~~~~~~~~~
 Wi-Fi SSID to auto-connect to even if user code is not running.
 
-In some cases there are additional board specific keys, consult the board
-descriptions on https://circuitpython.org/downloads for more information.
+Additional board specific keys
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`MaTouch ESP32-S3 Parallel TFT with Touch 7“ <https://circuitpython.org/board/makerfabs_tft7/>`_
+
+CIRCUITPY_DISPLAY_WIDTH
+~~~~~~~~~~~~~~~~~~~~~~~
+Selects the correct screen resolution (1024x600 or 800x640) for the particular board variant.
+If the CIRCUITPY_DISPLAY_WIDTH parameter is set to a value of 1024 the display is initalized
+during power up at 1024x600 otherwise the display will be initialized at a resolution 
+of 800x480.
+
+`Sunton ESP32-2432S028 <https://circuitpython.org/board/sunton_esp32_2432S028/>`_
+
+CIRCUITPY_DISPLAY_ROTATION
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Selects the correct screen rotation (0, 90, 180 or 270) for the particular board variant.
+If the CIRCUITPY_DISPLAY_ROTATION parameter is set the display will be initalized 
+during power up with the selected rotation, otherwise the display will be initialized with
+a rotation of 0.

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -106,8 +106,8 @@ Additional board specific keys
 CIRCUITPY_DISPLAY_WIDTH
 ~~~~~~~~~~~~~~~~~~~~~~~
 Selects the correct screen resolution (1024x600 or 800x640) for the particular board variant.
-If the CIRCUITPY_DISPLAY_WIDTH parameter is set to a value of 1024 the display is initalized
-during power up at 1024x600 otherwise the display will be initialized at a resolution 
+If the CIRCUITPY_DISPLAY_WIDTH parameter is set to a value of 1024 the display is initialized
+during power up at 1024x600 otherwise the display will be initialized at a resolution
 of 800x480.
 
 `Sunton ESP32-2432S028 <https://circuitpython.org/board/sunton_esp32_2432S028/>`_
@@ -115,6 +115,6 @@ of 800x480.
 CIRCUITPY_DISPLAY_ROTATION
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 Selects the correct screen rotation (0, 90, 180 or 270) for the particular board variant.
-If the CIRCUITPY_DISPLAY_ROTATION parameter is set the display will be initalized 
+If the CIRCUITPY_DISPLAY_ROTATION parameter is set the display will be initialized
 during power up with the selected rotation, otherwise the display will be initialized with
 a rotation of 0.

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -94,3 +94,6 @@ Wi-Fi password used to auto connect to CIRCUITPY_WIFI_SSID.
 CIRCUITPY_WIFI_SSID
 ~~~~~~~~~~~~~~~~~~~
 Wi-Fi SSID to auto-connect to even if user code is not running.
+
+In some cases there are additional board specific keys, consult the board 
+descriptions on https://circuitpython.org/downloads for more informaton.

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -95,5 +95,5 @@ CIRCUITPY_WIFI_SSID
 ~~~~~~~~~~~~~~~~~~~
 Wi-Fi SSID to auto-connect to even if user code is not running.
 
-In some cases there are additional board specific keys, consult the board 
-descriptions on https://circuitpython.org/downloads for more informaton.
+In some cases there are additional board specific keys, consult the board
+descriptions on https://circuitpython.org/downloads for more information.


### PR DESCRIPTION
Assuming adafruit/circuitpython-org#1479 is appropriate and approved, this adds a note to the list of documented CircuitPython settings.toml keys indicating that there may be additional board specific keys and that information may be found on circuitpython.org/downloads.