### PR TITLE
run_tests.py: keep PYTHONPATH when requested

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -829,6 +829,10 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
                 "PATH": os.environ["PATH"],
                 "LANG": "en_US.UTF-8",
             }
+            # CIRCUITPY-CHANGE: --keep-path applies to PYTHONPATH as well
+            if args.keep_path and os.getenv("PYTHONPATH"):
+                e["PYTHONPATH"] += ":" + os.getenv("PYTHONPATH")
+
             # run CPython to work out expected output
             try:
                 output_expected = subprocess.check_output(


### PR DESCRIPTION
This turns out to be needed by the testsuite of jepler_udecimal, which needs to add the `jepler_udecimal` directory both to PYTHONPATH and MICROPYPATH.