### PR TITLE
Add IO4 and IO7 to Feather RP2350

### DIFF
--- a/ports/raspberrypi/boards/adafruit_feather_rp2350/pins.c
+++ b/ports/raspberrypi/boards/adafruit_feather_rp2350/pins.c
@@ -30,7 +30,9 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D9), MP_ROM_PTR(&pin_GPIO9) },
     { MP_ROM_QSTR(MP_QSTR_D10), MP_ROM_PTR(&pin_GPIO10) },
     { MP_ROM_QSTR(MP_QSTR_D11), MP_ROM_PTR(&pin_GPIO11) },
+    { MP_ROM_QSTR(MP_QSTR_IO4), MP_ROM_PTR(&pin_GPIO4) },
     { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_GPIO4) },
+    { MP_ROM_QSTR(MP_QSTR_IO7), MP_ROM_PTR(&pin_GPIO7) },
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO7) },
     { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_GPIO7) },
 


### PR DESCRIPTION
These match the silkscreen but not the standard feather pin naming D12 and D13 are left so code is compatible.

Brought up on the forums:
https://forums.adafruit.com/viewtopic.php?p=1030324