### PR TITLE
Improve usb.core.Device exception handling and reporting

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -277,7 +277,6 @@ rst_epilog = """
 
 import sphinx_rtd_theme
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), '.']
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -915,6 +915,10 @@ msgstr ""
 msgid "ESP-IDF memory allocation failed"
 msgstr ""
 
+#: shared-module/usb/core/Device.c
+msgid "Endpt"
+msgstr ""
+
 #: extmod/modre.c
 msgid "Error in regex"
 msgstr ""
@@ -1445,10 +1449,6 @@ msgstr ""
 msgid "No bootloader present"
 msgstr ""
 
-#: shared-module/usb/core/Device.c
-msgid "No configuration set"
-msgstr ""
-
 #: shared-bindings/_bleio/PacketBuffer.c
 msgid "No connection: length cannot be determined"
 msgstr ""
@@ -1516,6 +1516,10 @@ msgstr ""
 
 #: shared-module/usb/core/Device.c
 msgid "No usb host port initialized"
+msgstr ""
+
+#: shared-module/usb/core/Device.c
+msgid "NoCfg"
 msgstr ""
 
 #: ports/nordic/common-hal/_bleio/__init__.c
@@ -1724,10 +1728,6 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
 msgid "Pins must share PWM slice"
-msgstr ""
-
-#: shared-module/usb/core/Device.c
-msgid "Pipe error"
 msgstr ""
 
 #: py/builtinhelp.c
@@ -1939,6 +1939,10 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid "Stack overflow. Increase stack size."
+msgstr ""
+
+#: shared-module/usb/core/Device.c
+msgid "Stall"
 msgstr ""
 
 #: shared-bindings/alarm/time/TimeAlarm.c
@@ -2299,6 +2303,10 @@ msgstr ""
 #: ports/espressif/common-hal/_bleio/PacketBuffer.c
 #: ports/nordic/common-hal/_bleio/PacketBuffer.c
 msgid "Writes not supported on Characteristic"
+msgstr ""
+
+#: shared-module/usb/core/Device.c
+msgid "Xfer"
 msgstr ""
 
 #: ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h

--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -915,10 +915,6 @@ msgstr ""
 msgid "ESP-IDF memory allocation failed"
 msgstr ""
 
-#: shared-module/usb/core/Device.c
-msgid "Endpt"
-msgstr ""
-
 #: extmod/modre.c
 msgid "Error in regex"
 msgstr ""
@@ -1449,6 +1445,10 @@ msgstr ""
 msgid "No bootloader present"
 msgstr ""
 
+#: shared-module/usb/core/Device.c
+msgid "No configuration set"
+msgstr ""
+
 #: shared-bindings/_bleio/PacketBuffer.c
 msgid "No connection: length cannot be determined"
 msgstr ""
@@ -1516,10 +1516,6 @@ msgstr ""
 
 #: shared-module/usb/core/Device.c
 msgid "No usb host port initialized"
-msgstr ""
-
-#: shared-module/usb/core/Device.c
-msgid "NoCfg"
 msgstr ""
 
 #: ports/nordic/common-hal/_bleio/__init__.c
@@ -1728,6 +1724,10 @@ msgstr ""
 
 #: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
 msgid "Pins must share PWM slice"
+msgstr ""
+
+#: shared-module/usb/core/Device.c
+msgid "Pipe error"
 msgstr ""
 
 #: py/builtinhelp.c
@@ -1939,10 +1939,6 @@ msgstr ""
 
 #: supervisor/shared/safe_mode.c
 msgid "Stack overflow. Increase stack size."
-msgstr ""
-
-#: shared-module/usb/core/Device.c
-msgid "Stall"
 msgstr ""
 
 #: shared-bindings/alarm/time/TimeAlarm.c
@@ -2303,10 +2299,6 @@ msgstr ""
 #: ports/espressif/common-hal/_bleio/PacketBuffer.c
 #: ports/nordic/common-hal/_bleio/PacketBuffer.c
 msgid "Writes not supported on Characteristic"
-msgstr ""
-
-#: shared-module/usb/core/Device.c
-msgid "Xfer"
 msgstr ""
 
 #: ports/atmel-samd/boards/circuitplayground_express/mpconfigboard.h

--- a/shared-module/usb/core/Device.c
+++ b/shared-module/usb/core/Device.c
@@ -159,7 +159,7 @@ static size_t _xfer(tuh_xfer_t *xfer, mp_int_t timeout) {
     _xfer_result = 0xff;
     xfer->complete_cb = _transfer_done_cb;
     if (!tuh_edpt_xfer(xfer)) {
-        mp_raise_usb_core_USBError(NULL);
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Xfer"));
     }
     uint32_t start_time = supervisor_ticks_ms32();
     while ((timeout == 0 || supervisor_ticks_ms32() - start_time < (uint32_t)timeout) &&
@@ -176,7 +176,7 @@ static size_t _xfer(tuh_xfer_t *xfer, mp_int_t timeout) {
     xfer_result_t result = _xfer_result;
     _xfer_result = 0xff;
     if (result == XFER_RESULT_STALLED) {
-        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Pipe error"));
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Stall"));
     }
     if (result == 0xff) {
         tuh_edpt_abort_xfer(xfer->daddr, xfer->ep_addr);
@@ -205,7 +205,7 @@ static bool _open_endpoint(usb_core_device_obj_t *self, mp_int_t endpoint) {
     }
 
     if (self->configuration_descriptor == NULL) {
-        mp_raise_usb_core_USBError(MP_ERROR_TEXT("No configuration set"));
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("NoCfg"));
     }
 
     tusb_desc_configuration_t *desc_cfg = (tusb_desc_configuration_t *)self->configuration_descriptor;
@@ -239,7 +239,8 @@ static bool _open_endpoint(usb_core_device_obj_t *self, mp_int_t endpoint) {
 
 mp_int_t common_hal_usb_core_device_write(usb_core_device_obj_t *self, mp_int_t endpoint, const uint8_t *buffer, mp_int_t len, mp_int_t timeout) {
     if (!_open_endpoint(self, endpoint)) {
-        mp_raise_usb_core_USBError(NULL);
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Endpt"));
+        return 0;
     }
     tuh_xfer_t xfer;
     xfer.daddr = self->device_number;
@@ -251,7 +252,8 @@ mp_int_t common_hal_usb_core_device_write(usb_core_device_obj_t *self, mp_int_t 
 
 mp_int_t common_hal_usb_core_device_read(usb_core_device_obj_t *self, mp_int_t endpoint, uint8_t *buffer, mp_int_t len, mp_int_t timeout) {
     if (!_open_endpoint(self, endpoint)) {
-        mp_raise_usb_core_USBError(NULL);
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Endpt"));
+        return 0;
     }
     tuh_xfer_t xfer;
     xfer.daddr = self->device_number;
@@ -285,7 +287,7 @@ mp_int_t common_hal_usb_core_device_ctrl_transfer(usb_core_device_obj_t *self,
     _xfer_result = 0xff;
 
     if (!tuh_control_xfer(&xfer)) {
-        mp_raise_usb_core_USBError(NULL);
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Xfer"));
     }
     uint32_t start_time = supervisor_ticks_ms32();
     while ((timeout == 0 || supervisor_ticks_ms32() - start_time < (uint32_t)timeout) &&
@@ -302,7 +304,7 @@ mp_int_t common_hal_usb_core_device_ctrl_transfer(usb_core_device_obj_t *self,
     xfer_result_t result = _xfer_result;
     _xfer_result = 0xff;
     if (result == XFER_RESULT_STALLED) {
-        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Pipe error"));
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Stall"));
     }
     if (result == 0xff) {
         tuh_edpt_abort_xfer(xfer.daddr, xfer.ep_addr);

--- a/shared-module/usb/core/Device.c
+++ b/shared-module/usb/core/Device.c
@@ -159,7 +159,7 @@ static size_t _xfer(tuh_xfer_t *xfer, mp_int_t timeout) {
     _xfer_result = 0xff;
     xfer->complete_cb = _transfer_done_cb;
     if (!tuh_edpt_xfer(xfer)) {
-        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Xfer"));
+        mp_raise_usb_core_USBError(NULL);
         return 0;
     }
     uint32_t start_time = supervisor_ticks_ms32();
@@ -177,7 +177,7 @@ static size_t _xfer(tuh_xfer_t *xfer, mp_int_t timeout) {
     xfer_result_t result = _xfer_result;
     _xfer_result = 0xff;
     if (result == XFER_RESULT_STALLED) {
-        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Stall"));
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Pipe error"));
     }
     if (result == 0xff) {
         tuh_edpt_abort_xfer(xfer->daddr, xfer->ep_addr);
@@ -206,7 +206,7 @@ static bool _open_endpoint(usb_core_device_obj_t *self, mp_int_t endpoint) {
     }
 
     if (self->configuration_descriptor == NULL) {
-        mp_raise_usb_core_USBError(MP_ERROR_TEXT("NoCfg"));
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("No configuration set"));
         return false;
     }
 
@@ -241,7 +241,7 @@ static bool _open_endpoint(usb_core_device_obj_t *self, mp_int_t endpoint) {
 
 mp_int_t common_hal_usb_core_device_write(usb_core_device_obj_t *self, mp_int_t endpoint, const uint8_t *buffer, mp_int_t len, mp_int_t timeout) {
     if (!_open_endpoint(self, endpoint)) {
-        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Endpt"));
+        mp_raise_usb_core_USBError(NULL);
         return 0;
     }
     tuh_xfer_t xfer;
@@ -254,7 +254,7 @@ mp_int_t common_hal_usb_core_device_write(usb_core_device_obj_t *self, mp_int_t 
 
 mp_int_t common_hal_usb_core_device_read(usb_core_device_obj_t *self, mp_int_t endpoint, uint8_t *buffer, mp_int_t len, mp_int_t timeout) {
     if (!_open_endpoint(self, endpoint)) {
-        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Endpt"));
+        mp_raise_usb_core_USBError(NULL);
         return 0;
     }
     tuh_xfer_t xfer;
@@ -289,7 +289,7 @@ mp_int_t common_hal_usb_core_device_ctrl_transfer(usb_core_device_obj_t *self,
     _xfer_result = 0xff;
 
     if (!tuh_control_xfer(&xfer)) {
-        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Xfer"));
+        mp_raise_usb_core_USBError(NULL);
         return 0;
     }
     uint32_t start_time = supervisor_ticks_ms32();
@@ -307,7 +307,7 @@ mp_int_t common_hal_usb_core_device_ctrl_transfer(usb_core_device_obj_t *self,
     xfer_result_t result = _xfer_result;
     _xfer_result = 0xff;
     if (result == XFER_RESULT_STALLED) {
-        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Stall"));
+        mp_raise_usb_core_USBError(MP_ERROR_TEXT("Pipe error"));
     }
     if (result == 0xff) {
         tuh_edpt_abort_xfer(xfer.daddr, xfer.ep_addr);

--- a/shared-module/usb/core/Device.c
+++ b/shared-module/usb/core/Device.c
@@ -160,6 +160,7 @@ static size_t _xfer(tuh_xfer_t *xfer, mp_int_t timeout) {
     xfer->complete_cb = _transfer_done_cb;
     if (!tuh_edpt_xfer(xfer)) {
         mp_raise_usb_core_USBError(MP_ERROR_TEXT("Xfer"));
+        return 0;
     }
     uint32_t start_time = supervisor_ticks_ms32();
     while ((timeout == 0 || supervisor_ticks_ms32() - start_time < (uint32_t)timeout) &&
@@ -206,6 +207,7 @@ static bool _open_endpoint(usb_core_device_obj_t *self, mp_int_t endpoint) {
 
     if (self->configuration_descriptor == NULL) {
         mp_raise_usb_core_USBError(MP_ERROR_TEXT("NoCfg"));
+        return false;
     }
 
     tusb_desc_configuration_t *desc_cfg = (tusb_desc_configuration_t *)self->configuration_descriptor;
@@ -288,6 +290,7 @@ mp_int_t common_hal_usb_core_device_ctrl_transfer(usb_core_device_obj_t *self,
 
     if (!tuh_control_xfer(&xfer)) {
         mp_raise_usb_core_USBError(MP_ERROR_TEXT("Xfer"));
+        return 0;
     }
     uint32_t start_time = supervisor_ticks_ms32();
     while ((timeout == 0 || supervisor_ticks_ms32() - start_time < (uint32_t)timeout) &&


### PR DESCRIPTION
This PR includes a fix for the null pointer dereference from issue #9670 and adds short error message strings to help distinguish between different types of usb.core.USBError exceptions.

I understand that adding unique strings to the core is generally problematic, but I don't know how to avoid it in this case. For writing USB device drivers, it's very helpful to be able to identify the specific causes of the different types of exceptions that get grouped together under USBError. If there were a way to set the value of USBError.errno, that would be ideal. But, my understanding is that errno is generally not supported in MicroPython. Maybe I'm wrong about that?

In my test builds, these changes add about 132 bytes to the used flash firmware space for `BOARD=adafruit_feather_esp32s3_tft`. Shortening the "Pipe error" and "No configuration set" messages saved about 16 bytes. When I experimented with using single character strings vs. 4-5 character strings, it didn't seem to save any additional space.