### PR TITLE
support setups with all modules in src-directory

### DIFF
--- a/tools/preprocess_frozen_modules.py
+++ b/tools/preprocess_frozen_modules.py
@@ -42,9 +42,13 @@ def version_string(path=None, *, valid_semver=False):
     return version
 
 
-# Visit all the .py files in topdir. Replace any __version__ = "0.0.0-auto.0" type of info
+# Visit all the .py files in topdir or src. Replace any __version__ = "0.0.0-auto.0" type of info
 # with actual version info derived from git.
 def copy_and_process(in_dir, out_dir):
+    # setuptools default: use modules from 'src' if the directory exists
+    src_dir = in_dir + os.path.sep + "src"
+    if os.path.exists(src_dir) and os.path.isdir(src_dir):
+        in_dir = src_dir
     for root, subdirs, files in os.walk(in_dir):
         # Skip library examples directory and subfolders.
         relative_path_parts = Path(root).relative_to(in_dir).parts


### PR DESCRIPTION
In larger libraries with multiple modules it makes more sense to put all modules into a `src`-directory and don't scatter them in the top-level directory. Python setuptools explicitly supports this setup as a default (in this case, `pyproject.toml` does not have to specify the modules explicitly, but this is only a side note and not relevant here).

This PR changes `tools/preprocess_frozen_modules.py` to support this setup. The change is backward compatible.