### PR TITLE
Optimize hostname variable size

### DIFF
--- a/ports/espressif/boards/sunton_esp32_8048S050/sdkconfig
+++ b/ports/espressif/boards/sunton_esp32_8048S050/sdkconfig
@@ -7,7 +7,6 @@
 #
 # LWIP
 #
-CONFIG_LWIP_LOCAL_HOSTNAME="sunton-esp32-8048S050"
 # end of LWIP
 
 # end of Component config

--- a/ports/espressif/common-hal/wifi/__init__.c
+++ b/ports/espressif/common-hal/wifi/__init__.c
@@ -16,8 +16,6 @@
 #include "py/gc.h"
 #include "py/mpstate.h"
 #include "py/runtime.h"
-#include "py/objstr.h"
-#include "py/objint.h"
 
 #include "components/esp_wifi/include/esp_wifi.h"
 
@@ -41,6 +39,8 @@ wifi_radio_obj_t common_hal_wifi_radio_obj;
 #ifdef CONFIG_IDF_TARGET_ESP32
 #include "nvs_flash.h"
 #endif
+
+#define MAC_ADDRESS_LENGTH 6
 
 static const char *TAG = "CP wifi";
 
@@ -200,8 +200,8 @@ void common_hal_wifi_init(bool user_initiated) {
         return;
     }
     // set the default lwip_local_hostname
-    char cpy_default_hostname[80];
-    uint8_t mac[6];
+    char cpy_default_hostname[strlen(CIRCUITPY_BOARD_ID)+(MAC_ADDRESS_LENGTH*2)+6];
+    uint8_t mac[MAC_ADDRESS_LENGTH];
     esp_wifi_get_mac(ESP_IF_WIFI_STA, mac);
     sprintf(cpy_default_hostname, "cpy_%s_%x", CIRCUITPY_BOARD_ID, (unsigned int)mac);
     const char *default_lwip_local_hostname = cpy_default_hostname;

--- a/ports/espressif/common-hal/wifi/__init__.c
+++ b/ports/espressif/common-hal/wifi/__init__.c
@@ -200,7 +200,7 @@ void common_hal_wifi_init(bool user_initiated) {
         return;
     }
     // set the default lwip_local_hostname
-    char cpy_default_hostname[strlen(CIRCUITPY_BOARD_ID)+(MAC_ADDRESS_LENGTH*2)+6];
+    char cpy_default_hostname[strlen(CIRCUITPY_BOARD_ID) + (MAC_ADDRESS_LENGTH * 2) + 6];
     uint8_t mac[MAC_ADDRESS_LENGTH];
     esp_wifi_get_mac(ESP_IF_WIFI_STA, mac);
     sprintf(cpy_default_hostname, "cpy_%s_%x", CIRCUITPY_BOARD_ID, (unsigned int)mac);


### PR DESCRIPTION
This PR updates the `cpy_default_hostname` variable length to exactly what's needed rather than 80 characters. 

If there's any value in using an mp_obj_ type variable rather than a char array to store `cpy_default_hostname` let me know and I can try to get that to work in another PR.