### PR TITLE
Correct `ble_serial_connected()` when BLE workflow was never started

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/PacketBuffer.c
+++ b/devices/ble_hci/common-hal/_bleio/PacketBuffer.c
@@ -247,3 +247,7 @@ void common_hal_bleio_packet_buffer_deinit(bleio_packet_buffer_obj_t *self) {
         ringbuf_deinit(&self->ringbuf);
     }
 }
+
+bool common_hal_bleio_packet_buffer_connected(bleio_packet_buffer_obj_t *self) {
+    return !common_hal_bleio_packet_buffer_deinited(self) && self->conn_handle != BLE_CONN_HANDLE_INVALID;
+}

--- a/ports/espressif/common-hal/_bleio/PacketBuffer.c
+++ b/ports/espressif/common-hal/_bleio/PacketBuffer.c
@@ -440,3 +440,7 @@ void common_hal_bleio_packet_buffer_deinit(bleio_packet_buffer_obj_t *self) {
     ble_event_remove_handler(packet_buffer_on_ble_client_evt, self);
     ringbuf_deinit(&self->ringbuf);
 }
+
+bool common_hal_bleio_packet_buffer_connected(bleio_packet_buffer_obj_t *self) {
+    return !common_hal_bleio_packet_buffer_deinited(self) && self->conn_handle != BLEIO_HANDLE_INVALID;
+}

--- a/ports/nordic/common-hal/_bleio/PacketBuffer.c
+++ b/ports/nordic/common-hal/_bleio/PacketBuffer.c
@@ -485,3 +485,7 @@ void common_hal_bleio_packet_buffer_deinit(bleio_packet_buffer_obj_t *self) {
         ringbuf_deinit(&self->ringbuf);
     }
 }
+
+bool common_hal_bleio_packet_buffer_connected(bleio_packet_buffer_obj_t *self) {
+    return !common_hal_bleio_packet_buffer_deinited(self) && self->conn_handle != BLE_CONN_HANDLE_INVALID;
+}

--- a/shared-bindings/_bleio/PacketBuffer.h
+++ b/shared-bindings/_bleio/PacketBuffer.h
@@ -35,3 +35,4 @@ mp_int_t common_hal_bleio_packet_buffer_get_outgoing_packet_length(bleio_packet_
 void common_hal_bleio_packet_buffer_flush(bleio_packet_buffer_obj_t *self);
 bool common_hal_bleio_packet_buffer_deinited(bleio_packet_buffer_obj_t *self);
 void common_hal_bleio_packet_buffer_deinit(bleio_packet_buffer_obj_t *self);
+bool common_hal_bleio_packet_buffer_connected(bleio_packet_buffer_obj_t *self);

--- a/supervisor/shared/bluetooth/serial.c
+++ b/supervisor/shared/bluetooth/serial.c
@@ -156,7 +156,7 @@ void supervisor_stop_bluetooth_serial(void) {
 }
 
 bool ble_serial_connected(void) {
-    return _tx_packet_buffer.conn_handle != BLEIO_HANDLE_INVALID;
+    return common_hal_bleio_packet_buffer_connected(&_tx_packet_buffer);
 }
 
 uint32_t ble_serial_available(void) {


### PR DESCRIPTION
- Fixes #9626.
- Fixes #9464 (already closed in favor of #9626).

`ble_serial_connected()` was checking `_tx_packet_buffer.conn_handle` as an indicator of whether BLE was connected. But that value was not initialized when BLE hadn't started up at all, and so `ble_serial_connected()` was returning `true` incorrectly in that case. The check should have also included a check for deinited. I added that and refactored it into a common-hal routine.

I asked the issue authors to test. It fixed the problem for at least one of them: https://github.com/adafruit/circuitpython/issues/9626#issuecomment-2392618882