### PR TITLE
clear any pending interrupt flag

### DIFF
--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -1038,6 +1038,8 @@ bool common_hal_rp2pio_statemachine_background_write(rp2pio_statemachine_obj_t *
         false);
 
     common_hal_mcu_disable_interrupts();
+    // Acknowledge any previous pending interrupt
+    dma_hw->ints0 |= 1u << channel;
     MP_STATE_PORT(background_pio)[channel] = self;
     dma_hw->inte0 |= 1u << channel;
     irq_set_mask_enabled(1 << DMA_IRQ_0, true);


### PR DESCRIPTION
While debugging, I found that on RP2040 the first looped background write on a StateMachine would be garbled: It the first few outputs would be as expected, but then the data would go back to the start of the buffer.

I realized that this could be due to there already being a pending interrupt on this DMA channel that had occurred previously but never been acknowledged. In fact, by printing the value of `dma_hw->intr` before this, I could see that it was the case.

After this change, both my special case reproducer from the related issue works, and the odd gaps in LED data transmission seen in the WIP code for TM1814 LEDs was fixed.

I never saw this problem on Feather RP2350, only on Metro RP2040, but I don't know why. It would depend on what had previously happened to the DMA channel that ends up allocated to this PIO state machine. Less likely, it could depend on details of the DMA peripheral that changed between the chips.

Closes: #9678

This PR was prepared so that 9.1.x could be selected as the base branch if desired, but I'm opening this PR with the base branch set to main.

Ping @ladyada 