### PR TITLE
Work around an sdk bug

### DIFF
--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -57,6 +57,19 @@ static void *_interrupt_arg[NUM_PIOS][NUM_PIO_STATE_MACHINES];
 
 static void rp2pio_statemachine_interrupt_handler(void);
 
+// Workaround for sdk bug: https://github.com/raspberrypi/pico-sdk/issues/1878
+// This workaround can be removed when we upgrade to sdk 2.0.1
+static inline void sm_config_set_in_pin_count_issue1878(pio_sm_config *c, uint in_count) {
+    #if PICO_PIO_VERSION == 0
+    // can't be changed from 32 on PIO v0
+    ((void)c);
+    valid_params_if(HARDWARE_PIO, in_count == 32);
+    #else
+    valid_params_if(HARDWARE_PIO, in_count && in_count <= 32);
+    c->shiftctrl = (c->shiftctrl & ~PIO_SM0_SHIFTCTRL_IN_COUNT_BITS) |
+        ((in_count & 0x1fu) << PIO_SM0_SHIFTCTRL_IN_COUNT_LSB);
+    #endif
+}
 static void rp2pio_statemachine_set_pull(uint32_t pull_pin_up, uint32_t pull_pin_down, uint32_t pins_we_use) {
     for (size_t i = 0; i < NUM_BANK0_GPIOS; i++) {
         bool used = pins_we_use & (1 << i);
@@ -374,7 +387,7 @@ bool rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
     sm_config_set_wrap(&c, wrap_target, wrap);
     sm_config_set_in_shift(&c, in_shift_right, auto_push, push_threshold);
     #if PICO_PIO_VERSION > 0
-    sm_config_set_in_pin_count(&c, in_pin_count);
+    sm_config_set_in_pin_count_issue1878(&c, in_pin_count);
     #endif
 
     sm_config_set_out_shift(&c, out_shift_right, auto_pull, pull_threshold);


### PR DESCRIPTION
This was already reported & fixed upstream, but the fix will not be in a released SDK until 2.0.1. It's easy enough to use our own workaround.

Testing: without this bug fix, rotaryencoder did not work on a pico 2

Note: the cut&paste code was reindented by uncrustify, giving it a slightly different style than the upstream sdk code.

Closes: #9681 

I thought I had PRd this two weeks ago, but apparently I didn't. The problem was independently rediscovered by @d3fq, thanks for the report.