### PR TITLE
fix os.uname() values for rp2350

### DIFF
--- a/ports/raspberrypi/common-hal/os/__init__.c
+++ b/ports/raspberrypi/common-hal/os/__init__.c
@@ -22,8 +22,8 @@ static const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, "rp2040");
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, "rp2040");
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
 static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
 static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
 static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);


### PR DESCRIPTION
https://forums.adafruit.com/viewtopic.php?t=213955 by blakebr notes that `os.uname().sysname` and `.nodename` say `rp2040 even for `rp2350` boards. Fix this by using `MICROPY_HW_MCU_NAME` instead. Note that it would be `rp2350a` and `rp2350b`.

Note that on some ports, the name is more generic, such as `samd21` and `samd51` for `atmel-samd`. But `espressif` and `broadcom` use `MICROPY_HW_MCU_NAME`. In the long run, maybe that is better, since it's more informative, instead of using a generic name. This could be a 10.0 change.