### PR TITLE
Avoid crashing when printing DeepSleepRequest objects

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -277,7 +277,6 @@ rst_epilog = """
 
 import sphinx_rtd_theme
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), '.']
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/shared-bindings/alarm/__init__.c
+++ b/shared-bindings/alarm/__init__.c
@@ -196,7 +196,7 @@ static mp_obj_t alarm_exit_and_deep_sleep_until_alarms(size_t n_args, const mp_o
     common_hal_alarm_set_deep_sleep_alarms(n_args, pos_args, num_dios, dios_array);
 
     // Raise an exception, which will be processed in main.c.
-    mp_raise_type_arg(&mp_type_DeepSleepRequest, NULL);
+    mp_raise_type(&mp_type_DeepSleepRequest);
 
     // Doesn't get here.
     return mp_const_none;


### PR DESCRIPTION
Before, this would crash trying to print a NULL object. `mp_raise_type` is the correct way to raise an exception without an associated object or message.
```
>>> import alarm
>>> try:
...     alarm.exit_and_deep_sleep_until_alarms()
... except BaseException as e:
...     ee = e
... 
>>> ee
DeepSleepRequest()
```

I also looked at including the deep sleep arguments in the args, but it was confusing because it would seem to print the TimeAlarm rather than the DeepSleepRequest:
```
=== import alarm
=== try:
===     alarm.exit_and_deep_sleep_until_alarms(
===         alarm.time.TimeAlarm(monotonic_time=12345)
===     )
=== except BaseException as e:
===     print(e)
===     print(e.args)
=== 
<TimeAlarm>
(<TimeAlarm>,)
```

(that was passing the args to exception_make_new:
```diff
-    mp_raise_type(&mp_type_DeepSleepRequest);
+    nlr_raise(mp_obj_exception_make_new(&mp_type_DeepSleepRequest, n_args, 0, pos_args));
```
)

Closes: #7447
Closes: #9691 