### PR TITLE
epaperdisplay: fix delay when two_byte_sequence_length is true

### DIFF
--- a/shared-module/epaperdisplay/EPaperDisplay.c
+++ b/shared-module/epaperdisplay/EPaperDisplay.c
@@ -157,7 +157,7 @@ static void send_command_sequence(epaperdisplay_epaperdisplay_obj_t *self,
         uint16_t delay_length_ms = 0;
         if (delay) {
             data_size++;
-            delay_length_ms = *(cmd + 1 + data_size);
+            delay_length_ms = *(cmd + 1 + data_size + self->two_byte_sequence_length);
             if (delay_length_ms == 255) {
                 delay_length_ms = 500;
             }


### PR DESCRIPTION
When playing around with custom LUT waveforms on an epaperdisplay, I needed `two_byte_sequence_length=True`, in order to be able to send more than 128 bytes of `start_sequence` data. However, I noticed that the delays between commands were read incorrectly in this case.

When `two_byte_sequence_length=True`, the adress of the delay (if present) is shifted back by 1 byte as compared to when `two_byte_sequence_length=False`, but prior to this PR the delay was always read from the same adress.

The memory layout for one command is: "`command` (1 byte), `data_size` (1-2 bytes), `data` (`data_size` bytes), `delay` (0-1 bytes)".