### PR TITLE
add __del__() to busio.I2C, which now has a finaliser

### DIFF
--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -379,6 +379,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_i2c_writeto_then_readfrom_obj, 1, busio_i2c_wri
 static const mp_rom_map_elem_t busio_i2c_locals_dict_table[] = {
     #if CIRCUITPY_BUSIO_I2C
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&busio_i2c_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&busio_i2c_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&default___enter___obj) },
     { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&busio_i2c___exit___obj) },
     { MP_ROM_QSTR(MP_QSTR_probe), MP_ROM_PTR(&busio_i2c_probe_obj) },


### PR DESCRIPTION
- Fixes #9703 

`busio.I2C()` became a class with a finaliser in #9671, but it also needed `__del__()` to  be defined for the finaliser to work properly.

Tested on a Metro RP2040, a PyPortal, and a Pico 2.