### PR TITLE
pin sphinx temporarily while debugging doc build

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -10,7 +10,7 @@ setuptools>=45
 setuptools_scm
 
 # For sphinx
-sphinx!=5.2.0.post0
+sphinx!=5.2.0.post0,<8.1.0
 sphinx-autoapi
 sphinx-rtd-theme
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Sphinx 8.1.0 just came out today. It breaks the `latexpdf` build, and also causes new messages like:
```
checking consistency... /home/halbert/repos/circuitpython/BUILDING.md: document is referenced in multiple toctrees: ['docs/index', 'docs/pdf'], selecting: docs/pdf <- BUILDING
/home/halbert/repos/circuitpython/CODE_OF_CONDUCT.md: document is referenced in multiple toctrees: ['docs/index', 'docs/pdf'], selecting: docs/pdf <- CODE_OF_CONDUCT
/home/halbert/repos/circuitpython/CONTRIBUTING.md: document is referenced in multiple toctrees: ['docs/index', 'docs/pdf'], selecting: docs/pdf <- CONTRIBUTING
...
```
I haven't been able to reduce this to a small case to file an issue with sphinx, but I've added a discussion reply here:
https://github.com/orgs/sphinx-doc/discussions/12999#discussioncomment-10909269