### PR TITLE
ShiftRegisterKeys key_count value was wrong

### DIFF
--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -136,7 +136,8 @@ static mp_obj_t keypad_shiftregisterkeys_make_new(const mp_obj_type_t *type, siz
     size_t key_count_array[num_key_counts];
 
     if (mp_obj_is_int(args[ARG_key_count].u_obj)) {
-        const size_t key_count = (size_t)mp_arg_validate_int_min(args[ARG_key_count].u_int, 1, MP_QSTR_key_count);
+        const size_t key_count =
+            (size_t)mp_arg_validate_int_min(mp_obj_get_int(args[ARG_key_count].u_obj), 1, MP_QSTR_key_count);
         key_count_array[0] = key_count;
     } else {
         for (size_t kc = 0; kc < num_key_counts; kc++) {


### PR DESCRIPTION
- Fixes #9718 

When `keypad.ShiftRegisterKeys(..., key_count=some_integer, ...)` had an integer argument, the argument was not correctly converted to an integer. This error was inadvertently introduced by #8143.

Testing:
```py
import board
import keypad

keys = keypad.ShiftRegisterKeys(
    data               = board.GP0,
   clock              = board.GP1,
   latch              = board.GP2,
   key_count          = 8,
   value_when_pressed = True,
   value_to_latch     = True,
   )
```
The bug is that `.u_int` was used instead of `.u_obj`. When the bug is present, `keys.key_count` produces `17` (which is the encoded micropython representation of `8`). This fix returns `8` correctly.


