### PR TITLE
update github actions to use macos-13, ubuntu-24.04

### DIFF
--- a/.github/workflows/build-board-custom.yml
+++ b/.github/workflows/build-board-custom.yml
@@ -36,7 +36,7 @@ run-name: ${{ inputs.board }}-${{ inputs.language }}-${{ inputs.version }}${{ in
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Set up repository
       run: |

--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   board:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CP_VERSION: ${{ inputs.cp-version }}
     strategy:

--- a/.github/workflows/build-mpy-cross.yml
+++ b/.github/workflows/build-mpy-cross.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   scheduler:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       docs: ${{ steps.set-matrix.outputs.docs }}
       ports: ${{ steps.set-matrix.outputs.ports }}
@@ -158,7 +158,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: scheduler
     if: needs.scheduler.outputs.docs == 'True'
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
       cp-version: ${{ needs.scheduler.outputs.cp-version }}
 
   mpy-cross-mac:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: scheduler
     if: needs.scheduler.outputs.ports != '{}'
     env:

--- a/.github/workflows/create-website-pr.yml
+++ b/.github/workflows/create-website-pr.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   website:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Dump GitHub context
       run: echo "$GITHUB_CONTEXT"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Set up repository
       uses: actions/checkout@v4


### PR DESCRIPTION
`macos-12` is deprecated as a runner for GitHub actions and will be subject to brownouts in November. Update to `macos-13`.

Also try updating all the `ubuntu-22.04` to `ubuntu-24.04` and see what breaks, in a separate commit.