### PR TITLE
fixed doc of wifi.Network.authmode

### DIFF
--- a/shared-bindings/wifi/Network.c
+++ b/shared-bindings/wifi/Network.c
@@ -76,8 +76,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_network_get_country_obj, wifi_network_get_country
 MP_PROPERTY_GETTER(wifi_network_country_obj,
     (mp_obj_t)&wifi_network_get_country_obj);
 
-//|     authmode: str
-//|     """String id of the authmode"""
+//|     authmode: Sequence[wifi.AuthMode]
+//|     """List of authmodes (wifi.AuthMode) used by the network """
 //|
 static mp_obj_t wifi_network_get_authmode(mp_obj_t self) {
     return common_hal_wifi_network_get_authmode(self);


### PR DESCRIPTION
Non functional change: the field `wifi.Network.authmode` has a different type than currently documented.