### PR TITLE
Add errno.EROFS and errno.ENOSPC

### DIFF
--- a/py/moderrno.c
+++ b/py/moderrno.c
@@ -35,6 +35,7 @@
 // This list can be defined per port in mpconfigport.h to tailor it to a
 // specific port's needs.  If it's not defined then we provide a default.
 #ifndef MICROPY_PY_ERRNO_LIST
+// CIRCUITPY-CHANGE: add ENOSPC and EROFS, because they are in mp_common_errno_to_str().
 #define MICROPY_PY_ERRNO_LIST \
     X(EPERM) \
     X(ENOENT) \
@@ -47,6 +48,8 @@
     X(ENODEV) \
     X(EISDIR) \
     X(EINVAL) \
+    X(ENOSPC) \
+    X(EROFS) \
     X(EOPNOTSUPP) \
     X(EADDRINUSE) \
     X(ECONNABORTED) \


### PR DESCRIPTION
Motivated by https://forums.adafruit.com/viewtopic.php?t=214213. Fixes #9733

`errno.EROFS` and `errno.NOSPC` didn't exist, but they get nicer error messages already in `mp_common_errno_to_str()`. Add them. A user wanted to check for `errno.EROFS` and was surprised it was not available. `errno.EROFS` is common, given that CIRCUITPY is read-only when connected to USB.

These have not been added to the smallest builds, for space reasons.
