### PR TITLE
improve _bleio.Connection.bind() doc, validation, and error messages

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -268,7 +268,8 @@ msgstr ""
 msgid "%q, %q, and %q must all be the same length"
 msgstr ""
 
-#: py/objint.c shared-bindings/storage/__init__.c
+#: py/objint.c shared-bindings/_bleio/Connection.c
+#: shared-bindings/storage/__init__.c
 msgid "%q=%q"
 msgstr ""
 
@@ -548,6 +549,10 @@ msgstr ""
 
 #: ports/atmel-samd/common-hal/canio/Listener.c
 msgid "Already have all-matches listener"
+msgstr ""
+
+#: ports/espressif/common-hal/_bleio/__init__.c
+msgid "Already in progress"
 msgstr ""
 
 #: ports/espressif/bindings/espnow/ESPNow.c
@@ -3171,10 +3176,6 @@ msgstr ""
 
 #: extmod/ulab/code/ndarray.c
 msgid "indices must be integers, slices, or Boolean lists"
-msgstr ""
-
-#: ports/espressif/common-hal/busio/I2C.c
-msgid "init I2C"
 msgstr ""
 
 #: extmod/ulab/code/scipy/optimize/optimize.c

--- a/ports/espressif/common-hal/_bleio/__init__.c
+++ b/ports/espressif/common-hal/_bleio/__init__.c
@@ -103,6 +103,9 @@ void check_nimble_error(int rc, const char *file, size_t line) {
         case BLE_HS_ENOTCONN:
             mp_raise_ConnectionError(MP_ERROR_TEXT("Not connected"));
             return;
+        case BLE_HS_EALREADY:
+            mp_raise_bleio_BluetoothError(MP_ERROR_TEXT("Already in progress"));
+            return;
         default:
             #if CIRCUITPY_VERBOSE_BLE || CIRCUITPY_DEBUG
             if (file) {

--- a/ports/nordic/common-hal/_bleio/__init__.c
+++ b/ports/nordic/common-hal/_bleio/__init__.c
@@ -35,6 +35,9 @@ void check_nrf_error(uint32_t err_code) {
         case NRF_ERROR_INVALID_PARAM:
             mp_raise_ValueError(MP_ERROR_TEXT("Invalid BLE parameter"));
             return;
+        case NRF_ERROR_INVALID_STATE:
+            mp_raise_bleio_BluetoothError(MP_ERROR_TEXT("Invalid state"));
+            return;
         case BLE_ERROR_INVALID_CONN_HANDLE:
             mp_raise_ConnectionError(MP_ERROR_TEXT("Not connected"));
             return;

--- a/shared-bindings/_bleio/Connection.c
+++ b/shared-bindings/_bleio/Connection.c
@@ -66,7 +66,10 @@ static MP_DEFINE_CONST_FUN_OBJ_1(bleio_connection_disconnect_obj, bleio_connecti
 
 
 //|     def pair(self, *, bond: bool = True) -> None:
-//|         """Pair to the peer to improve security."""
+//|         """Pair to the peer to improve security.
+//|
+//|         **Limitation**: Currently ``bond``must be ``True``: bonding always occurs.
+//|         """
 //|         ...
 static mp_obj_t bleio_connection_pair(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     bleio_connection_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
@@ -79,6 +82,9 @@ static mp_obj_t bleio_connection_pair(mp_uint_t n_args, const mp_obj_t *pos_args
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
+    if (args[ARG_bond].u_bool == false) {
+        mp_raise_NotImplementedError_varg(MP_ERROR_TEXT("%q=%q"), MP_QSTR_bond, MP_QSTR_False);
+    }
     bleio_connection_ensure_connected(self);
 
     common_hal_bleio_connection_pair(self->connection, args[ARG_bond].u_bool);


### PR DESCRIPTION
- fixes _some_ issues raised in #9708 

Changes:
- Note in documentation that `_bleio.Connection.pair(bond=False)` is not implemented, and validate that `bond` == `True`.
- Print a better message on espressif and nordic when trying to pair when pairing is already in progress. Right now it prints "unknown ..." and gives a numeric error code.