### PR TITLE
Include `synthio.Biquad` methods within `audiofilters.Filter`

### DIFF
--- a/shared-bindings/audiofilters/Filter.c
+++ b/shared-bindings/audiofilters/Filter.c
@@ -155,7 +155,7 @@ MP_PROPERTY_GETSET(audiofilters_filter_filter_obj,
 
 //|     def low_pass_filter(
 //|         self, frequency: float, q_factor: float = 0.7071067811865475
-//|     ) -> Biquad:
+//|     ) -> synthio.Biquad:
 //|         """Construct a low-pass filter with the given parameters and update the `filter` property.
 //|
 //|         ``frequency``, called f0 in the cookbook, is the corner frequency in Hz
@@ -198,7 +198,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_filter_lpf_obj, 1, audiofilters_filter_o
 
 //|     def high_pass_filter(
 //|         self, frequency: float, q_factor: float = 0.7071067811865475
-//|     ) -> Biquad:
+//|     ) -> synthio.Biquad:
 //|         """Construct a high-pass filter with the given parameters and update the `filter` property.
 //|
 //|         ``frequency``, called f0 in the cookbook, is the corner frequency in Hz
@@ -230,7 +230,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_filter_hpf_obj, 1, audiofilters_filter_o
 
 //|     def band_pass_filter(
 //|         self, frequency: float, q_factor: float = 0.7071067811865475
-//|     ) -> Biquad:
+//|     ) -> synthio.Biquad:
 //|         """Construct a band-pass filter with the given parameters and update the `filter` property.
 //|
 //|         ``frequency``, called f0 in the cookbook, is the center frequency in Hz

--- a/shared-bindings/audiofilters/Filter.c
+++ b/shared-bindings/audiofilters/Filter.c
@@ -188,9 +188,7 @@ static mp_obj_t audiofilters_filter_obj_lpf(size_t n_args, const mp_obj_t *pos_a
 
     mp_float_t w0 = f0 / self->sample_rate * 2 * MP_PI;
 
-    mp_obj_t biquad = common_hal_synthio_new_lpf(w0, Q);
-    common_hal_audiofilters_filter_set_filter(self, biquad);
-    return biquad;
+    return common_hal_synthio_new_lpf(w0, Q);
 }
 
 MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_filter_lpf_obj, 1, audiofilters_filter_obj_lpf);
@@ -220,9 +218,7 @@ static mp_obj_t audiofilters_filter_obj_hpf(size_t n_args, const mp_obj_t *pos_a
 
     mp_float_t w0 = f0 / self->sample_rate * 2 * MP_PI;
 
-    mp_obj_t biquad = common_hal_synthio_new_hpf(w0, Q);
-    common_hal_audiofilters_filter_set_filter(self, biquad);
-    return biquad;
+    return common_hal_synthio_new_hpf(w0, Q);
 }
 
 MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_filter_hpf_obj, 1, audiofilters_filter_obj_hpf);
@@ -254,9 +250,7 @@ static mp_obj_t audiofilters_filter_obj_bpf(size_t n_args, const mp_obj_t *pos_a
 
     mp_float_t w0 = f0 / self->sample_rate * 2 * MP_PI;
 
-    mp_obj_t biquad = common_hal_synthio_new_bpf(w0, Q);
-    common_hal_audiofilters_filter_set_filter(self, biquad);
-    return biquad;
+    return common_hal_synthio_new_bpf(w0, Q);
 }
 
 MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_filter_bpf_obj, 1, audiofilters_filter_obj_bpf);

--- a/shared-bindings/audiofilters/Filter.c
+++ b/shared-bindings/audiofilters/Filter.c
@@ -156,7 +156,9 @@ MP_PROPERTY_GETSET(audiofilters_filter_filter_obj,
 //|     def low_pass_filter(
 //|         self, frequency: float, q_factor: float = 0.7071067811865475
 //|     ) -> synthio.Biquad:
-//|         """Construct a low-pass filter with the given parameters and update the `filter` property.
+//|         """Construct a low-pass filter with the given parameters and update the `filter` property. **DEPRECATED**
+//|
+//|         Instead, construct a `synthio.BlockBiquad` directly.
 //|
 //|         ``frequency``, called f0 in the cookbook, is the corner frequency in Hz
 //|         of the filter.
@@ -197,7 +199,9 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_filter_lpf_obj, 1, audiofilters_filter_o
 //|     def high_pass_filter(
 //|         self, frequency: float, q_factor: float = 0.7071067811865475
 //|     ) -> synthio.Biquad:
-//|         """Construct a high-pass filter with the given parameters and update the `filter` property.
+//|         """Construct a high-pass filter with the given parameters and update the `filter` property. **DEPRECATED**
+//|
+//|         Instead, construct a `synthio.BlockBiquad` directly.
 //|
 //|         ``frequency``, called f0 in the cookbook, is the corner frequency in Hz
 //|         of the filter.
@@ -227,7 +231,9 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_filter_hpf_obj, 1, audiofilters_filter_o
 //|     def band_pass_filter(
 //|         self, frequency: float, q_factor: float = 0.7071067811865475
 //|     ) -> synthio.Biquad:
-//|         """Construct a band-pass filter with the given parameters and update the `filter` property.
+//|         """Construct a band-pass filter with the given parameters and update the `filter` property. **DEPRECATED**
+//|
+//|         Instead, construct a `synthio.BlockBiquad` directly.
 //|
 //|         ``frequency``, called f0 in the cookbook, is the center frequency in Hz
 //|         of the filter.


### PR DESCRIPTION
This is a minor modification to the previously merged PR https://github.com/adafruit/circuitpython/pull/9744.

This modification adds the following methods to the `audiofilters.Filter` class:
- `audiofilters.Filter.low_pass_filter`
- `audiofilters.Filter.high_pass_filter`
- `audiofilters.Filter.bass_pass_filter`

These new methods help facilitate the generation of `synthio.Biquad` objects for the filter effect without requiring an instance of `synthio.Synthesizer`. It also ensures that the sample rate used for the filter calculations matches the effect.

Here is a modified version of the example provided in https://github.com/adafruit/circuitpython/pull/9744 with this change in place:

``` python3
import board
import audiobusio
import audiofilters
import audiocore
import digitalio
import adafruit_debouncer

Q = 2.0

audio = audiobusio.I2SOut(bit_clock=board.GP2, word_select=board.GP3, data=board.GP4)

wave_file = open("StreetChicken.wav", "rb")
wave = audiocore.WaveFile(wave_file)

effect = audiofilters.Filter(buffer_size=1024, channel_count=wave.channel_count, sample_rate=wave.sample_rate, mix=1.0)
effect.play(wave, loop=True)
audio.play(effect)

button_up_pin = digitalio.DigitalInOut(board.GP0)
button_up_pin.direction = digitalio.Direction.INPUT
button_up = adafruit_debouncer.Debouncer(button_up_pin)

button_down_pin = digitalio.DigitalInOut(board.GP1)
button_down_pin.direction = digitalio.Direction.INPUT
button_down = adafruit_debouncer.Debouncer(button_down_pin)

position = 1.0
def update_filter():
    frequency = (min(max(position, 0.0), 1.0) ** 2) * (wave.sample_rate / 2 - 25) + 25
    print("{}hz".format(frequency))
    effect.low_pass_filter(frequency, Q)
update_filter()

while True:
    button_up.update()
    if button_up.rose:
        position = min(position + 0.025, 1.0)
        update_filter()
        
    button_down.update()
    if button_down.rose:
        position = max(position - 0.025, 0.0)
        update_filter()
```

The only consideration I have is whether or not to automatically update the filter internally or return the `synthio.Biquad` object to set manually. This is how that implementation would look like:

``` python3
effect.filter = effect.low_pass_filter(frequency, Q)
```