### PR TITLE
document different kinds of _bleio

### DIFF
--- a/shared-bindings/_bleio/__init__.c
+++ b/shared-bindings/_bleio/__init__.c
@@ -33,7 +33,14 @@
 //| `adafruit_ble <https://circuitpython.readthedocs.io/projects/ble/en/latest/>`_
 //| CircuitPython library instead, which builds on `_bleio`, and
 //| provides higher-level convenience functionality, including predefined beacons, clients,
-//| servers."""
+//| servers.
+//|
+//| .. note:: `_bleio` uses native BLE capability on boards that support it, including Nordic nRF,
+//|   Espressif (except ESP32-S2 and ESP32-P4), and SiLabs.
+//|   On other boards, `_bleio`, if present, supports BLE using an AirLift co-processor.
+//|   Pico W boards do *not* support BLE using the on-board CYW43 co-processor,
+//|   but do support using an external AirLift.
+//| """
 
 //| adapter: Adapter
 //| """BLE Adapter used to manage device discovery and connections.


### PR DESCRIPTION
It's confusing that `_bleio` can mean native BLE support or AirLift-based support. Explain this more thoroughly in a note in the doc