### PR TITLE
Fix PSRAM cache invalidation

### DIFF
--- a/ports/raspberrypi/supervisor/internal_flash.c
+++ b/ports/raspberrypi/supervisor/internal_flash.c
@@ -49,11 +49,13 @@ static uint32_t m1_timing;
 static void save_psram_settings(void) {
     #ifdef PICO_RP2350
     // We're about to invalidate the XIP cache, clean it first to commit any dirty writes to PSRAM
-    uint8_t *maintenance_ptr = (uint8_t *)XIP_MAINTENANCE_BASE;
+    volatile uint8_t *maintenance_ptr = (uint8_t *)XIP_MAINTENANCE_BASE;
     for (int i = 1; i < 16 * 1024; i += 8) {
         // Background info: https://forums.raspberrypi.com/viewtopic.php?t=378249
         maintenance_ptr[i] = 0; // Clean
+        __compiler_memory_barrier();
         maintenance_ptr[i - 1] = 0; // Explicitly invalidate
+        __compiler_memory_barrier();
     }
 
     m1_timing = qmi_hw->m[1].timing;

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -244,7 +244,7 @@ void port_heap_init(void) {
     _heap = tlsf_create_with_pool(heap_bottom, size, 64 * 1024 * 1024);
     _ram_pool = tlsf_get_pool(_heap);
     if (_psram_size > 0) {
-        _psram_pool = tlsf_add_pool(_heap, (void *)0x11000004, _psram_size - 4);
+        _psram_pool = tlsf_add_pool(_heap, (void *)0x11000000, _psram_size);
     }
 }
 


### PR DESCRIPTION
- Fixes #9755.

The cache invalidation in #9752 needed to use `volatile` pointers to point to the cache maintenance entries so they would be set correctly and in the right order.

Note that the code from pico-sdk does use `volatile`:
https://github.com/earlephilhower/arduino-pico/pull/2551/files
It comes from the discussion here:
https://forums.raspberrypi.com/viewtopic.php?t=378249
That code also uses `_compiler_memory_barrier()`, which may not be needed, but it helps guarantee ordering.

Besides the example in #9755, this even simpler reproducer caused a hard fault on a Feather RP2350 with PSRAM before the fix:
```
import gc
gc.mem_free()
```
After the fix, this works, which is more like the example in #9755 (#9755 doesn't have the first `gc.mem_free()`):

```
>>> import gc
>>> gc.mem_free()
8264912
>>> a = bytearray(3500000)
>>> b = bytearray(3500000)
>>> gc.mem_free()
1175376
>>>
    [press reset]
>>> import gc
>>> gc.mem_free()
8264912
```

@tannewt Also, I don't think the extra 4 bytes is needed just below the PSRAM cache, so I took that out. I looked over the `tlsf` code, and I _think_ it takes care not to write below the beginning of the pool. It does offset the first block by the size of a header. The first pool created is not passed a pointer one word up in free storage, so I think the second pool does not need to either. But you have spent a lot of time on `tlsf`, so maybe I am wrong.

@bill88t Could you test if you have a chance?