### PR TITLE
unix: enable vectorio in coverage build

### DIFF
--- a/ports/unix/displayio_min.c
+++ b/ports/unix/displayio_min.c
@@ -74,3 +74,16 @@ const mp_obj_module_t displayio_module = {
 };
 
 MP_REGISTER_MODULE(MP_QSTR_displayio, displayio_module);
+
+displayio_buffer_transform_t null_transform = {
+    .x = 0,
+    .y = 0,
+    .dx = 1,
+    .dy = 1,
+    .scale = 1,
+    .width = 0,
+    .height = 0,
+    .mirror_x = false,
+    .mirror_y = false,
+    .transpose_xy = false
+};

--- a/ports/unix/variants/coverage/mpconfigvariant.mk
+++ b/ports/unix/variants/coverage/mpconfigvariant.mk
@@ -59,6 +59,11 @@ SRC_BITMAP := \
 	shared-bindings/synthio/Synthesizer.c \
 	shared-bindings/traceback/__init__.c \
 	shared-bindings/util.c \
+	shared-bindings/vectorio/Circle.c \
+	shared-bindings/vectorio/__init__.c \
+	shared-bindings/vectorio/Polygon.c \
+	shared-bindings/vectorio/Rectangle.c \
+	shared-bindings/vectorio/VectorShape.c \
 	shared-bindings/zlib/__init__.c \
 	shared-module/aesio/aes.c \
 	shared-module/aesio/__init__.c \
@@ -88,6 +93,12 @@ SRC_BITMAP := \
 	shared-module/synthio/Note.c \
 	shared-module/synthio/Biquad.c \
 	shared-module/synthio/Synthesizer.c \
+	shared-bindings/vectorio/Circle.c \
+	shared-module/vectorio/Circle.c \
+	shared-module/vectorio/__init__.c \
+	shared-module/vectorio/Polygon.c \
+	shared-module/vectorio/Rectangle.c \
+	shared-module/vectorio/VectorShape.c \
 	shared-module/traceback/__init__.c \
 	shared-module/zlib/__init__.c \
 
@@ -134,6 +145,7 @@ CFLAGS += \
 	-DCIRCUITPY_SYNTHIO=1 \
 	-DCIRCUITPY_SYNTHIO_MAX_CHANNELS=14 \
 	-DCIRCUITPY_TRACEBACK=1 \
+	-DCIRCUITPY_VECTORIO=1 \
 	-DCIRCUITPY_ZLIB=1
 
 # CIRCUITPY-CHANGE: test native base classes.

--- a/shared-bindings/vectorio/Circle.c
+++ b/shared-bindings/vectorio/Circle.c
@@ -34,8 +34,8 @@
 static mp_obj_t vectorio_circle_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pixel_shader, ARG_radius, ARG_x, ARG_y, ARG_color_index };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_pixel_shader, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
-        { MP_QSTR_radius, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_pixel_shader, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED, { .u_obj = NULL } },
+        { MP_QSTR_radius, MP_ARG_REQUIRED | MP_ARG_INT, { .u_obj = NULL } },
         { MP_QSTR_x, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
         { MP_QSTR_y, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
         { MP_QSTR_color_index, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },

--- a/shared-bindings/vectorio/Polygon.c
+++ b/shared-bindings/vectorio/Polygon.c
@@ -42,7 +42,7 @@
 static mp_obj_t vectorio_polygon_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pixel_shader, ARG_points_list, ARG_x, ARG_y, ARG_color_index };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_pixel_shader, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
+        { MP_QSTR_pixel_shader, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED, { .u_obj = NULL } },
         { MP_QSTR_points, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_x, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
         { MP_QSTR_y, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },

--- a/shared-bindings/vectorio/Rectangle.c
+++ b/shared-bindings/vectorio/Rectangle.c
@@ -35,9 +35,9 @@
 static mp_obj_t vectorio_rectangle_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_pixel_shader, ARG_width, ARG_height, ARG_x, ARG_y, ARG_color_index };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_pixel_shader, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
-        { MP_QSTR_width, MP_ARG_REQUIRED | MP_ARG_INT },
-        { MP_QSTR_height, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_pixel_shader, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED, {.u_obj = NULL } },
+        { MP_QSTR_width, MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0 } },
+        { MP_QSTR_height, MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0 } },
         { MP_QSTR_x, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
         { MP_QSTR_y, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },
         { MP_QSTR_color_index, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 0} },


### PR DESCRIPTION
I noticed https://github.com/adafruit/circuitpython/pull/9753 and thought: wouldn't it be nice if we could test it on host computers. It turned out to be relatively easy to add the vectorio module to unix coverage builds.

```py
$ ./build-coverage/micropython 
CircuitPython 9.2.0-rc.0-1-g2f1102da6a-dirty on 2024-10-28; linux [GCC 12.2.0] version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> import displayio, vectorio
>>> palette = displayio.Palette(1)
>>> circle = vectorio.Circle(pixel_shader=palette, radius=25, x=70, y=40)
>>> circle.contains(0,0)
False
>>> circle.contains(74-24, 40)
True
>>> circle.contains(74-26, 40)
True
```

this would enable writing tests of vectorio features (other than rendering anyway) that can run during CI on a host computer.