### PR TITLE
Fix json.dump/dumps() with IPv4Address

### DIFF
--- a/shared-bindings/ipaddress/IPv4Address.c
+++ b/shared-bindings/ipaddress/IPv4Address.c
@@ -146,7 +146,11 @@ static void ipaddress_ipv4address_print(const mp_print_t *print, mp_obj_t self_i
     mp_get_buffer_raise(address_bytes, &buf_info, MP_BUFFER_READ);
 
     const uint8_t *buf = (uint8_t *)buf_info.buf;
-    mp_printf(print, "%d.%d.%d.%d", buf[0], buf[1], buf[2], buf[3]);
+    if (kind == PRINT_JSON) {
+        mp_printf(print, "\"%d.%d.%d.%d\"", buf[0], buf[1], buf[2], buf[3]);
+    } else {
+        mp_printf(print, "%d.%d.%d.%d", buf[0], buf[1], buf[2], buf[3]);
+    }
 }
 
 static const mp_rom_map_elem_t ipaddress_ipv4address_locals_dict_table[] = {


### PR DESCRIPTION
Change ipaddress_ipv4address_print() to quote the IPv4Address if kind is PRINT_JSON

Fixes [issue 9768](https://github.com/adafruit/circuitpython/issues/9768)

Without fix:
<img width="465" alt="Screenshot 2024-10-28 at 11 12 40 AM" src="https://github.com/user-attachments/assets/2f92e0c2-8d3a-42dc-8e4f-9e8bf68aae4b">
With fix:
<img width="504" alt="Screenshot 2024-10-28 at 11 19 32 AM" src="https://github.com/user-attachments/assets/2d32b6a0-5064-4cb4-848d-c2159ad20a37">


