### PR TITLE
Add support for list of Biquad objects within `audiofilters.Filter`.

### DIFF
--- a/shared-bindings/audiofilters/Filter.h
+++ b/shared-bindings/audiofilters/Filter.h
@@ -11,7 +11,7 @@
 extern const mp_obj_type_t audiofilters_filter_type;
 
 void common_hal_audiofilters_filter_construct(audiofilters_filter_obj_t *self,
-    mp_obj_t filter, mp_obj_t mix,
+    mp_obj_t filters, mp_obj_t mix,
     uint32_t buffer_size, uint8_t bits_per_sample, bool samples_signed,
     uint8_t channel_count, uint32_t sample_rate);
 
@@ -22,8 +22,8 @@ uint32_t common_hal_audiofilters_filter_get_sample_rate(audiofilters_filter_obj_
 uint8_t common_hal_audiofilters_filter_get_channel_count(audiofilters_filter_obj_t *self);
 uint8_t common_hal_audiofilters_filter_get_bits_per_sample(audiofilters_filter_obj_t *self);
 
-mp_obj_t common_hal_audiofilters_filter_get_filter(audiofilters_filter_obj_t *self);
-void common_hal_audiofilters_filter_set_filter(audiofilters_filter_obj_t *self, mp_obj_t arg);
+mp_obj_t common_hal_audiofilters_filter_get_filters(audiofilters_filter_obj_t *self);
+void common_hal_audiofilters_filter_set_filters(audiofilters_filter_obj_t *self, mp_obj_t arg);
 
 mp_obj_t common_hal_audiofilters_filter_get_mix(audiofilters_filter_obj_t *self);
 void common_hal_audiofilters_filter_set_mix(audiofilters_filter_obj_t *self, mp_obj_t arg);

--- a/shared-module/audiofilters/Filter.h
+++ b/shared-module/audiofilters/Filter.h
@@ -15,10 +15,11 @@ extern const mp_obj_type_t audiofilters_filter_type;
 
 typedef struct {
     mp_obj_base_t base;
-    mp_obj_t filter_obj;
+    mp_obj_list_t *filters;
     synthio_block_slot_t mix;
 
-    biquad_filter_state filter_state;
+    uint8_t filter_states_len;
+    biquad_filter_state *filter_states;
 
     uint8_t bits_per_sample;
     bool samples_signed;
@@ -39,6 +40,8 @@ typedef struct {
 
     mp_obj_t sample;
 } audiofilters_filter_obj_t;
+
+void reset_filter_states(audiofilters_filter_obj_t *self);
 
 void audiofilters_filter_reset_buffer(audiofilters_filter_obj_t *self,
     bool single_channel_output,


### PR DESCRIPTION
Support the processing of multiple `synthio.Biquad` objects within `audiofilters.Filter` by renaming `filter` to `filters` and requiring it be a `List[synthio.Biquad]`.

``` python3
import board
import audiobusio
import audiofilters
import audiocore
import synthio

audio = audiobusio.I2SOut(bit_clock=board.GP0, word_select=board.GP1, data=board.GP2)

wave_file = open("StreetChicken.wav", "rb")
wave = audiocore.WaveFile(wave_file)

synth = synthio.Synthesizer(channel_count=wave.channel_count, sample_rate=wave.sample_rate)

effect = audiofilters.Filter(
    filters=[
        synth.high_pass_filter(200),
        synth.low_pass_filter(2000),
    ],
    buffer_size=1024,
    channel_count=wave.channel_count,
    sample_rate=wave.sample_rate,
    mix=1.0
)
effect.play(wave, loop=True)
audio.play(effect)
```

Comments:
- Direct assignment of objects in list does not call `synthio_biquad_filter_assign` (ie: `effect.filters[0] = ...`)
- `effect.filters.append(...)` and `effect.filters.remove(...)` are detected by testing length in audio buffer loop. There may be a better method of detecting these list manipulations.