### PR TITLE
RP2350: need cache flush in microcontroller.nvm

### DIFF
--- a/ports/raspberrypi/supervisor/internal_flash.h
+++ b/ports/raspberrypi/supervisor/internal_flash.h
@@ -9,6 +9,10 @@
 
 #include "mpconfigport.h"
 
+// These must be called before and after doing a low-level flash write.
+void supervisor_flash_pre_write(void);
+void supervisor_flash_post_write(void);
+
 // #define INTERNAL_FLASH_PART1_NUM_BLOCKS (CIRCUITPY_INTERNAL_FLASH_FILESYSTEM_SIZE / FILESYSTEM_BLOCK_SIZE)
 
 // #define INTERNAL_FLASH_SYSTICK_MASK    (0x1ff) // 512ms


### PR DESCRIPTION
- Fixes #9773.
- Fixes #9770.

The lower-level flash-write code in `supervisor/internal_flash.c` does cache flushing when PSRAM is in use. Some of that code is duplicated in `microcontroller.nvm`, but it didn't have the cache flushing.

- Make a simple API to wrap around low-level flash writes.
- Call it from the `nvm` code, and use it in `internal_flash.c`.
- Update to a safer cache-flushing scheme, as mentioned in #9770.

Also see:
https://forums.raspberrypi.com/viewtopic.php?t=378249

There may later be pico-sdk support for some of this:
https://github.com/raspberrypi/pico-sdk/issues/1983
https://github.com/raspberrypi/pico-sdk/issues/2005