### PR TITLE
Reboot to normal mode on `storage.erase_filesystem()`

### DIFF
--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -264,6 +264,7 @@ void common_hal_storage_erase_filesystem(bool extended) {
     supervisor_flash_set_extended(extended);
     #endif
     (void)filesystem_init(false, true);  // Force a re-format. Ignore failure.
+    common_hal_mcu_on_next_reset(RUNMODE_NORMAL);
     common_hal_mcu_reset();
     // We won't actually get here, since we're resetting.
 }


### PR DESCRIPTION
What the title says. Just a one line change.
This makes sure `boot_out.txt` is created in the scenario that someone wipes from safemode, so that tools that look for it find it.