### PR TITLE
Fix error with NULL sample handling in `audiofilters.Filter`.

### DIFF
--- a/shared-module/audiodelays/Echo.c
+++ b/shared-module/audiodelays/Echo.c
@@ -342,7 +342,10 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
                 } else {
                     // For unsigned samples set to the middle which is "quiet"
                     if (MP_LIKELY(self->bits_per_sample == 16)) {
-                        memset(word_buffer, 32768, length * (self->bits_per_sample / 8));
+                        uint16_t *uword_buffer = (uint16_t *)word_buffer;
+                        while (length--) {
+                            *uword_buffer++ = 32768;
+                        }
                     } else {
                         memset(hword_buffer, 128, length * (self->bits_per_sample / 8));
                     }

--- a/shared-module/audiofilters/Filter.c
+++ b/shared-module/audiofilters/Filter.c
@@ -246,7 +246,10 @@ audioio_get_buffer_result_t audiofilters_filter_get_buffer(audiofilters_filter_o
             } else {
                 // For unsigned samples set to the middle which is "quiet"
                 if (MP_LIKELY(self->bits_per_sample == 16)) {
-                    memset(word_buffer, 32768, length * (self->bits_per_sample / 8));
+                    uint16_t *uword_buffer = (uint16_t *)word_buffer;
+                    while (length--) {
+                        *uword_buffer++ = 32768;
+                    }
                 } else {
                     memset(hword_buffer, 128, length * (self->bits_per_sample / 8));
                 }

--- a/shared-module/audiofilters/Filter.c
+++ b/shared-module/audiofilters/Filter.c
@@ -240,8 +240,21 @@ audioio_get_buffer_result_t audiofilters_filter_get_buffer(audiofilters_filter_o
             }
         }
 
-        // If we have a sample, filter it
-        if (self->sample != NULL) {
+        if (self->sample == NULL) {
+            if (self->samples_signed) {
+                memset(word_buffer, 0, length * (self->bits_per_sample / 8));
+            } else {
+                // For unsigned samples set to the middle which is "quiet"
+                if (MP_LIKELY(self->bits_per_sample == 16)) {
+                    memset(word_buffer, 32768, length * (self->bits_per_sample / 8));
+                } else {
+                    memset(hword_buffer, 128, length * (self->bits_per_sample / 8));
+                }
+            }
+
+            length = 0;
+        } else {
+            // we have a sample to play and filter
             // Determine how many bytes we can process to our buffer, the less of the sample we have left and our buffer remaining
             uint32_t n = MIN(self->sample_buffer_length, length);
 


### PR DESCRIPTION
Fixed mishandling of NULL sample within `get_buffer` method (used by audiosample api) of the newly added `audiofilters.Filter` class in 9.2.0. The error would occur when either no sample was loaded (ie: `.play(...)`) or `.stop()` was called when feeding into another audiosample object. See https://github.com/adafruit/circuitpython/issues/9778 for more details and examples.

The method now feeds "silence" audio data into the output buffer and prevents an infinite while loop.