### PR TITLE
make the default variant 'coverage'

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -4,8 +4,9 @@ ifdef VARIANT_DIR
 # the path as the variant name.
 VARIANT ?= $(notdir $(VARIANT_DIR:/=))
 else
-# If not given on the command line, then default to standard.
-VARIANT ?= standard
+# CIRCUITPY-CHANGE: default variant is coverage
+# If not given on the command line, then default to coverage.
+VARIANT ?= coverage
 VARIANT_DIR ?= variants/$(VARIANT)
 endif
 


### PR DESCRIPTION
This means that the variant no longer needs to be explicitly named and you can just run `make test`. (I suspect this is what happened to @FoamyGuy over in #9793 but I'm not sure)