### PR TITLE
Fix serial REPL bootloop for raspberrypi pico boards

### DIFF
--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -326,8 +326,6 @@ safe_mode_t port_init(void) {
     // Reset everything into a known state before board_init.
     reset_port();
 
-    serial_early_init();
-
     #ifdef CIRCUITPY_PSRAM_CHIP_SELECT
     setup_psram();
     #endif


### PR DESCRIPTION
An extra call to `serial_early_init()` causes builds with serial REPL enabled to enter a bootloop. Affects all port `raspberrypi` boards.

Regression due to #9490, looks like a leftover from debug.

Tested with `raspberrypi_pico_w` and `adafruit_feather_rp2350` covering serial REPL enabled and disabled cases.