### PR TITLE
Typo in BusDisplay param documentation

### DIFF
--- a/shared-bindings/busdisplay/BusDisplay.c
+++ b/shared-bindings/busdisplay/BusDisplay.c
@@ -99,8 +99,8 @@
 //|         :param ~circuitpython_typing.ReadableBuffer init_sequence: Byte-packed initialization sequence.
 //|         :param int width: Width in pixels
 //|         :param int height: Height in pixels
-//|         :param int colstart: The index if the first visible column
-//|         :param int rowstart: The index if the first visible row
+//|         :param int colstart: The index of the first visible column
+//|         :param int rowstart: The index of the first visible row
 //|         :param int rotation: The rotation of the display in degrees clockwise. Must be in 90 degree increments (0, 90, 180, 270)
 //|         :param int color_depth: The number of bits of color per pixel transmitted. (Some displays
 //|             support 18 bit but 16 is easier to transmit. The last bit is extrapolated.)


### PR DESCRIPTION
Just stumbled across this while stuck in some other weeds....