### PR TITLE
Fix regression of keypad.*.reset() behavior: send key_pressed events

### DIFF
--- a/shared-bindings/keypad/KeyMatrix.c
+++ b/shared-bindings/keypad/KeyMatrix.c
@@ -159,6 +159,9 @@ static void check_for_deinit(keypad_keymatrix_obj_t *self) {
 //|         """Reset the internal state of the scanner to assume that all keys are now released.
 //|         Any key that is already pressed at the time of this call will therefore immediately cause
 //|         a new key-pressed event to occur.
+//|         For instance, if you call `reset()` immediately after creating a `KeyMatrix` object
+//|         at the beginning of your program, the events it generates will let you determine which keys
+//|         were being held down at program start.
 //|         """
 //|         ...
 

--- a/shared-bindings/keypad/Keys.c
+++ b/shared-bindings/keypad/Keys.c
@@ -147,6 +147,9 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(keypad_keys___exit___obj, 4, 4, keypa
 //|         """Reset the internal state of the scanner to assume that all keys are now released.
 //|         Any key that is already pressed at the time of this call will therefore immediately cause
 //|         a new key-pressed event to occur.
+//|         For instance, if you call `reset()` immediately after creating a `Keys` object
+//|         at the beginning of your program, the events it generates will let you determine which keys
+//|         were being held down at program start.
 //|         """
 //|         ...
 

--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -201,6 +201,9 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(keypad_shiftregisterkeys___exit___obj
 //|         """Reset the internal state of the scanner to assume that all keys are now released.
 //|         Any key that is already pressed at the time of this call will therefore immediately cause
 //|         a new key-pressed event to occur.
+//|         For instance, if you call `reset()` immediately after creating a `ShiftRegisterKeys` object
+//|         at the beginning of your program, the events it generates will let you determine which keys
+//|         were being held down at program start.
 //|         """
 //|         ...
 

--- a/shared-bindings/keypad_demux/DemuxKeyMatrix.c
+++ b/shared-bindings/keypad_demux/DemuxKeyMatrix.c
@@ -147,6 +147,9 @@ static void check_for_deinit(keypad_demux_demuxkeymatrix_obj_t *self) {
 //|         """Reset the internal state of the scanner to assume that all keys are now released.
 //|         Any key that is already pressed at the time of this call will therefore immediately cause
 //|         a new key-pressed event to occur.
+//|         For instance, if you call `reset()` immediately after creating a `DemuxKeyMatrix` object
+//|         at the beginning of your program, the events it generates will let you determine which keys
+//|         were being held down at program start.
 //|         """
 //|         ...
 

--- a/shared-module/keypad/__init__.c
+++ b/shared-module/keypad/__init__.c
@@ -140,7 +140,7 @@ void keypad_never_reset(keypad_scanner_obj_t *self) {
 void common_hal_keypad_generic_reset(void *self_in) {
     keypad_scanner_obj_t *self = self_in;
     size_t key_count = common_hal_keypad_generic_get_key_count(self);
-    memset(self->debounce_counter, self->debounce_threshold, key_count);
+    memset(self->debounce_counter, -self->debounce_threshold, key_count);
     keypad_scan_now(self, port_get_raw_ticks(NULL));
 }
 


### PR DESCRIPTION
@aseanwatson pointed out that there was a regression from 9.0.0 to 9.1.0 for `keypad.*.reset()`. It started sending `key_released` instead of `key_pressed` events. @aseanwatson also figured out the fix (thanks!), which is what is here.

Also documents how to use `reset()` to determine which keys are held down at program startup.

Fixes #9818, by fixing the mentioned bug.

Using `reset()` to determine pressed keys makes a new API unneeded (tagging @todbot on this).

Tested on a CPB:
```py
import board
import keypad
import time

keys = keypad.Keys((board.BUTTON_A, board.BUTTON_B), value_when_pressed=True, pull=True)

while True:
    print("reset in 3 seconds...")
    time.sleep(3)
    keys.events.clear()
    keys.reset()
    while event := keys.events.get():
        print(event)
```
Confirmed that it worked in 9.0.0, gave the wrong events in 9.1.0, and is fixed by the change.