### PR TITLE
install most current version of CMAKE from kitware

### DIFF
--- a/.devcontainer/add_kitware_archive.sh
+++ b/.devcontainer/add_kitware_archive.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# -----------------------------------------------------------------------------
+# This script is from: https://apt.kitware.com/kitware-archive.sh
+#
+# It installs key and repo for the kitware CMAKE-archive.
+#
+# Author: Bernhard Bablok
+#
+# -----------------------------------------------------------------------------
+
+set -eu
+
+help() {
+  echo "Usage: $0 [--release <ubuntu-release>] [--rc]" > /dev/stderr
+}
+
+doing=
+rc=
+release=
+help=
+for opt in "$@"
+do
+  case "${doing}" in
+  release)
+    release="${opt}"
+    doing=
+    ;;
+  "")
+    case "${opt}" in
+    --rc)
+      rc=1
+      ;;
+    --release)
+      doing=release
+      ;;
+    --help)
+      help=1
+      ;;
+    esac
+    ;;
+  esac
+done
+
+if [ -n "${doing}" ]
+then
+  echo "--${doing} option given no argument." > /dev/stderr
+  echo > /dev/stderr
+  help
+  exit 1
+fi
+
+if [ -n "${help}" ]
+then
+  help
+  exit
+fi
+
+if [ -z "${release}" ]
+then
+  unset UBUNTU_CODENAME
+  . /etc/os-release
+
+  if [ -z "${UBUNTU_CODENAME+x}" ]
+  then
+    echo "This is not an Ubuntu system. Aborting." > /dev/stderr
+    exit 1
+  fi
+
+  release="${UBUNTU_CODENAME}"
+fi
+
+case "${release}" in
+noble|jammy|focal)
+  packages=
+  keyring_packages="ca-certificates gpg wget"
+  ;;
+*)
+  echo "Only Ubuntu Noble (24.04), Jammy (22.04), and Focal (20.04) are supported. Aborting." > /dev/stderr
+  exit 1
+  ;;
+esac
+
+get_keyring=
+if [ ! -f /usr/share/doc/kitware-archive-keyring/copyright ]
+then
+  packages="${packages} ${keyring_packages}"
+  get_keyring=1
+fi
+
+# Start the real work
+set -x
+
+apt-get update
+# shellcheck disable=SC2086
+apt-get install -y ${packages}
+
+test -n "${get_keyring}" && (wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - > /usr/share/keyrings/kitware-archive-keyring.gpg)
+
+echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ ${release} main" > /etc/apt/sources.list.d/kitware.list
+if [ -n "${rc}" ]
+then
+  echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ ${release}-rc main" >> /etc/apt/sources.list.d/kitware.list
+fi
+
+apt-get update
+test -n "${get_keyring}" && rm /usr/share/keyrings/kitware-archive-keyring.gpg
+apt-get install -y kitware-archive-keyring

--- a/.devcontainer/common_tools.sh
+++ b/.devcontainer/common_tools.sh
@@ -15,6 +15,11 @@ cd "$REPO_ROOT"
 
 # --- repositories and tools   ------------------------------------------------
 
+echo -e "[common_tools.sh] adding kitware-archive (for current CMAKE)"
+sudo .devcontainer/add_kitware_archive.sh
+echo -e "[common_tools.sh] installing current version of CMAKE"
+sudo apt-get -y install cmake
+
 echo -e "[common_tools.sh] adding pybricks/ppa"
 sudo add-apt-repository -y ppa:pybricks/ppa
 echo -e "[common_tools.sh] installing uncrustify and mtools"


### PR DESCRIPTION
The current build environment on Github codespaces provides CMAKE in a version that is too old. At least for the new Pico-SDK.

This PR updates the build-scripts to automatically install a newer version. 