### PR TITLE
Update Waveshare S3 Zero pins.c to add BOOT button

### DIFF
--- a/ports/espressif/boards/waveshare_esp32_s3_zero/pins.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_zero/pins.c
@@ -12,7 +12,7 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     // BOOT button labeled simply as "B" om silkscreen
     { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO0) },
     { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_GPIO0) },
-    
+
     // Top side of the board - left column
     // (top to bottom, preceded by 5V, GND & 3.3V)
     { MP_ROM_QSTR(MP_QSTR_IO1), MP_ROM_PTR(&pin_GPIO1) },

--- a/ports/espressif/boards/waveshare_esp32_s3_zero/pins.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_zero/pins.c
@@ -11,6 +11,7 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
 
     // BOOT button labeled simply as "B" on silkscreen
     { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO0) },
+    { MP_ROM_QSTR(MP_QSTR_IO0), MP_ROM_PTR(&pin_GPIO0) },
     { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_GPIO0) },
 
     // Top side of the board - left column

--- a/ports/espressif/boards/waveshare_esp32_s3_zero/pins.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_zero/pins.c
@@ -9,7 +9,7 @@
 static const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
 
-    // BOOT button labeled simply as "B" om silkscreen
+    // BOOT button labeled simply as "B" on silkscreen
     { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO0) },
     { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_GPIO0) },
 

--- a/ports/espressif/boards/waveshare_esp32_s3_zero/pins.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_zero/pins.c
@@ -9,6 +9,10 @@
 static const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
 
+    // BOOT button labeled simply as "B" om silkscreen
+    { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO0) },
+    { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_GPIO0) },
+    
     // Top side of the board - left column
     // (top to bottom, preceded by 5V, GND & 3.3V)
     { MP_ROM_QSTR(MP_QSTR_IO1), MP_ROM_PTR(&pin_GPIO1) },


### PR DESCRIPTION
Currently the BOOT button, which is labeled simply as "B" on the silkscreen, is not defined in the BOARD module of Circuit{Python and therefore to use this button as an input requires 

```
import microcontroller
from digitalio import DigitalInOut
button = DigitalInOut(microcontroller.pin.GPIO0)
```

This change adds "BUTTON" & "D0" aliases for the GPIO0 pin.

For reference, Waveshare ESP32-S3-Zero schematic is here: [https://files.waveshare.com/wiki/ESP32-S3-Zero/ESP32-S3-Zero-Sch.pdf](url)