### PR TITLE
no need to support kwargs in a setter

### DIFF
--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -82,26 +82,13 @@ static mp_obj_t audiomixer_mixervoice_obj_get_level(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audiomixer_mixervoice_get_level_obj, audiomixer_mixervoice_obj_get_level);
 
-static mp_obj_t audiomixer_mixervoice_obj_set_level(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_level };
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_level,     MP_ARG_OBJ | MP_ARG_REQUIRED, {} },
-    };
-    audiomixer_mixervoice_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-    mp_float_t level = mp_obj_get_float(args[ARG_level].u_obj);
-
-    if (level > 1 || level < 0) {
-        mp_raise_ValueError(MP_ERROR_TEXT("level must be between 0 and 1"));
-    }
-
+static mp_obj_t audiomixer_mixervoice_obj_set_level(mp_obj_t self_in, mp_obj_t level_in) {
+    audiomixer_mixervoice_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_float_t level = mp_arg_validate_obj_float_range(level_in, 0, 1, MP_QSTR_level);
     common_hal_audiomixer_mixervoice_set_level(self, level);
-
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_set_level_obj, 1, audiomixer_mixervoice_obj_set_level);
+MP_DEFINE_CONST_FUN_OBJ_2(audiomixer_mixervoice_set_level_obj, audiomixer_mixervoice_obj_set_level);
 
 MP_PROPERTY_GETSET(audiomixer_mixervoice_level_obj,
     (mp_obj_t)&audiomixer_mixervoice_get_level_obj,


### PR DESCRIPTION
Noticed during review of #9861

This saves 88 bytes on Feather RP2350. Should not represent any functional change, as a setter function is never called directly.

ping for interest: @pdw-mb @gamblor21 @relic-se