### PR TITLE
Removed unneeded kwarg handler in setters of audiodelays and audiofilters

### DIFF
--- a/shared-bindings/audiodelays/Echo.c
+++ b/shared-bindings/audiodelays/Echo.c
@@ -153,20 +153,12 @@ static mp_obj_t audiodelays_echo_obj_get_delay_ms(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_echo_get_delay_ms_obj, audiodelays_echo_obj_get_delay_ms);
 
-static mp_obj_t audiodelays_echo_obj_set_delay_ms(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_delay_ms };
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_delay_ms,     MP_ARG_OBJ | MP_ARG_REQUIRED, {} },
-    };
-    audiodelays_echo_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-    common_hal_audiodelays_echo_set_delay_ms(self, args[ARG_delay_ms].u_obj);
-
+static mp_obj_t audiodelays_echo_obj_set_delay_ms(mp_obj_t self_in, mp_obj_t delay_ms_in) {
+    audiodelays_echo_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_audiodelays_echo_set_delay_ms(self, delay_ms_in);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_echo_set_delay_ms_obj, 1, audiodelays_echo_obj_set_delay_ms);
+MP_DEFINE_CONST_FUN_OBJ_2(audiodelays_echo_set_delay_ms_obj, audiodelays_echo_obj_set_delay_ms);
 
 MP_PROPERTY_GETSET(audiodelays_echo_delay_ms_obj,
     (mp_obj_t)&audiodelays_echo_get_delay_ms_obj,
@@ -179,20 +171,12 @@ static mp_obj_t audiodelays_echo_obj_get_decay(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_echo_get_decay_obj, audiodelays_echo_obj_get_decay);
 
-static mp_obj_t audiodelays_echo_obj_set_decay(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_decay };
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_decay,     MP_ARG_OBJ | MP_ARG_REQUIRED, {} },
-    };
-    audiodelays_echo_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-    common_hal_audiodelays_echo_set_decay(self, args[ARG_decay].u_obj);
-
+static mp_obj_t audiodelays_echo_obj_set_decay(mp_obj_t self_in, mp_obj_t decay_in) {
+    audiodelays_echo_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_audiodelays_echo_set_decay(self, decay_in);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_echo_set_decay_obj, 1, audiodelays_echo_obj_set_decay);
+MP_DEFINE_CONST_FUN_OBJ_2(audiodelays_echo_set_decay_obj, audiodelays_echo_obj_set_decay);
 
 MP_PROPERTY_GETSET(audiodelays_echo_decay_obj,
     (mp_obj_t)&audiodelays_echo_get_decay_obj,
@@ -205,20 +189,12 @@ static mp_obj_t audiodelays_echo_obj_get_mix(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_echo_get_mix_obj, audiodelays_echo_obj_get_mix);
 
-static mp_obj_t audiodelays_echo_obj_set_mix(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_mix };
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_mix,     MP_ARG_OBJ | MP_ARG_REQUIRED, {} },
-    };
-    audiodelays_echo_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-    common_hal_audiodelays_echo_set_mix(self, args[ARG_mix].u_obj);
-
+static mp_obj_t audiodelays_echo_obj_set_mix(mp_obj_t self_in, mp_obj_t mix_in) {
+    audiodelays_echo_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_audiodelays_echo_set_mix(self, mix_in);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_echo_set_mix_obj, 1, audiodelays_echo_obj_set_mix);
+MP_DEFINE_CONST_FUN_OBJ_2(audiodelays_echo_set_mix_obj, audiodelays_echo_obj_set_mix);
 
 MP_PROPERTY_GETSET(audiodelays_echo_mix_obj,
     (mp_obj_t)&audiodelays_echo_get_mix_obj,
@@ -233,20 +209,12 @@ static mp_obj_t audiodelays_echo_obj_get_freq_shift(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_echo_get_freq_shift_obj, audiodelays_echo_obj_get_freq_shift);
 
-static mp_obj_t audiodelays_echo_obj_set_freq_shift(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_freq_shift };
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_freq_shift,     MP_ARG_BOOL | MP_ARG_REQUIRED, {} },
-    };
-    audiodelays_echo_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-    common_hal_audiodelays_echo_set_freq_shift(self, args[ARG_freq_shift].u_bool);
-
+static mp_obj_t audiodelays_echo_obj_set_freq_shift(mp_obj_t self_in, mp_obj_t freq_shift_in) {
+    audiodelays_echo_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_audiodelays_echo_set_freq_shift(self, mp_obj_is_true(freq_shift_in));
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_echo_set_freq_shift_obj, 1, audiodelays_echo_obj_set_freq_shift);
+MP_DEFINE_CONST_FUN_OBJ_2(audiodelays_echo_set_freq_shift_obj, audiodelays_echo_obj_set_freq_shift);
 
 MP_PROPERTY_GETSET(audiodelays_echo_freq_shift_obj,
     (mp_obj_t)&audiodelays_echo_get_freq_shift_obj,

--- a/shared-bindings/audiofilters/Filter.c
+++ b/shared-bindings/audiofilters/Filter.c
@@ -139,20 +139,12 @@ static mp_obj_t audiofilters_filter_obj_get_filter(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audiofilters_filter_get_filter_obj, audiofilters_filter_obj_get_filter);
 
-static mp_obj_t audiofilters_filter_obj_set_filter(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_filter };
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_filter,     MP_ARG_OBJ | MP_ARG_REQUIRED, {} },
-    };
-    audiofilters_filter_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-    common_hal_audiofilters_filter_set_filter(self, args[ARG_filter].u_obj);
-
+static mp_obj_t audiofilters_filter_obj_set_filter(mp_obj_t self_in, mp_obj_t filter_in) {
+    audiofilters_filter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_audiofilters_filter_set_filter(self, filter_in);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_filter_set_filter_obj, 1, audiofilters_filter_obj_set_filter);
+MP_DEFINE_CONST_FUN_OBJ_2(audiofilters_filter_set_filter_obj, audiofilters_filter_obj_set_filter);
 
 MP_PROPERTY_GETSET(audiofilters_filter_filter_obj,
     (mp_obj_t)&audiofilters_filter_get_filter_obj,
@@ -166,20 +158,12 @@ static mp_obj_t audiofilters_filter_obj_get_mix(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audiofilters_filter_get_mix_obj, audiofilters_filter_obj_get_mix);
 
-static mp_obj_t audiofilters_filter_obj_set_mix(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_mix };
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_mix,     MP_ARG_OBJ | MP_ARG_REQUIRED, {} },
-    };
-    audiofilters_filter_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-    common_hal_audiofilters_filter_set_mix(self, args[ARG_mix].u_obj);
-
+static mp_obj_t audiofilters_filter_obj_set_mix(mp_obj_t self_in, mp_obj_t mix_in) {
+    audiofilters_filter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_audiofilters_filter_set_mix(self, mix_in);
     return mp_const_none;
 }
-MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_filter_set_mix_obj, 1, audiofilters_filter_obj_set_mix);
+MP_DEFINE_CONST_FUN_OBJ_2(audiofilters_filter_set_mix_obj, audiofilters_filter_obj_set_mix);
 
 MP_PROPERTY_GETSET(audiofilters_filter_mix_obj,
     (mp_obj_t)&audiofilters_filter_get_mix_obj,


### PR DESCRIPTION
Updated the following setters within `audiodelays` and `audiofilters` which were unnecessarily using kwargs in accordance with @jepler 's research within https://github.com/adafruit/circuitpython/issues/9863.
```
shared-bindings/audiodelays/Echo.c:static mp_obj_t audiodelays_echo_obj_set_delay_ms
shared-bindings/audiodelays/Echo.c:static mp_obj_t audiodelays_echo_obj_set_decay
shared-bindings/audiodelays/Echo.c:static mp_obj_t audiodelays_echo_obj_set_mix
shared-bindings/audiodelays/Echo.c:static mp_obj_t audiodelays_echo_obj_set_freq_shift
shared-bindings/audiofilters/Filter.c:static mp_obj_t audiofilters_filter_obj_set_filter
shared-bindings/audiofilters/Filter.c:static mp_obj_t audiofilters_filter_obj_set_mix
```

According to the change in FLASH_FIRMWARE sizes when building for raspberry_pi_pico2, 208 bytes were saved with roughly ~35 bytes per setter. Within the output UF2 size, 512 bytes were saved at ~85 bytes per setter (likely due to filesystem block sizes).

Before:
```
Memory region         Used Size  Region Size  %age Used
  FLASH_FIRMWARE:      820636 B      1020 KB     78.57%
             RAM:       60272 B       512 KB     11.50%
       SCRATCH_Y:           0 B         4 KB      0.00%
       SCRATCH_X:          2 KB         4 KB     50.00%
Converted to uf2, output size: 1641472, start address: 0x10000000
Wrote 1641472 bytes to build-raspberry_pi_pico2/firmware.uf2
```

After:
```
Memory region         Used Size  Region Size  %age Used
  FLASH_FIRMWARE:      820428 B      1020 KB     78.55%
             RAM:       60272 B       512 KB     11.50%
       SCRATCH_Y:           0 B         4 KB      0.00%
       SCRATCH_X:          2 KB         4 KB     50.00%
Converted to uf2, output size: 1640960, start address: 0x10000000
Wrote 1640960 bytes to build-raspberry_pi_pico2/firmware.uf2
```