### PR TITLE
rgbmatrix: Avoid leaving an incompletely configured display bus

### DIFF
--- a/ports/atmel-samd/boards/itsybitsy_m4_express/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/itsybitsy_m4_express/mpconfigboard.mk
@@ -16,3 +16,13 @@ CIRCUITPY_GIFIO = 0
 CIRCUITPY_JPEGIO = 0
 
 CIRCUITPY_BITBANG_APA102 = 1
+
+# We don't have room for the fonts for terminalio for certain languages,
+# so turn off terminalio, and if it's off and displayio is on,
+# force a clean build.
+# Note that we cannot test $(CIRCUITPY_DISPLAYIO) directly with an
+# ifeq, because it's not set yet.
+ifneq (,$(filter $(TRANSLATION),ja ko ru))
+CIRCUITPY_TERMINALIO = 0
+RELEASE_NEEDS_CLEAN_BUILD = $(CIRCUITPY_DISPLAYIO)
+endif

--- a/shared-bindings/rgbmatrix/RGBMatrix.c
+++ b/shared-bindings/rgbmatrix/RGBMatrix.c
@@ -116,6 +116,16 @@ static void preflight_pins_or_throw(uint8_t clock_pin, uint8_t *rgb_pins, uint8_
     #endif
 }
 
+typedef struct {
+    nlr_jump_callback_node_t callback;
+    mp_obj_base_t *base_ptr;
+} nlr_jump_callback_node_clear_displaybus_t;
+
+static void clear_display_bus(void *node_in) {
+    nlr_jump_callback_node_clear_displaybus_t *node = node_in;
+    node->base_ptr->type = &mp_type_NoneType;
+}
+
 //|     def __init__(
 //|         self,
 //|         *,
@@ -217,6 +227,13 @@ static mp_obj_t rgbmatrix_rgbmatrix_make_new(const mp_obj_type_t *type, size_t n
     rgbmatrix_rgbmatrix_obj_t *self = &allocate_display_bus_or_raise()->rgbmatrix;
     self->base.type = &rgbmatrix_RGBMatrix_type;
 
+    // If an exception is thrown, ensure the display bus object's type is set
+    // back to the uninitialized/deinitialied type. **note that all other resource
+    // deallocations must be handled by the shared-module code**
+    nlr_jump_callback_node_clear_displaybus_t node;
+    node.base_ptr = &self->base;
+    nlr_push_jump_callback(&node.callback, clear_display_bus);
+
     uint8_t rgb_count, addr_count;
     uint8_t rgb_pins[MP_ARRAY_SIZE(self->rgb_pins)];
     uint8_t addr_pins[MP_ARRAY_SIZE(self->addr_pins)];
@@ -254,7 +271,6 @@ static mp_obj_t rgbmatrix_rgbmatrix_make_new(const mp_obj_type_t *type, size_t n
         clock_pin, latch_pin, output_enable_pin,
         args[ARG_doublebuffer].u_bool,
         args[ARG_framebuffer].u_obj, tile, args[ARG_serpentine].u_bool, NULL);
-
     claim_and_never_reset_pins(args[ARG_rgb_list].u_obj);
     claim_and_never_reset_pins(args[ARG_addr_list].u_obj);
     claim_and_never_reset_pin(args[ARG_clock_pin].u_obj);


### PR DESCRIPTION
I did not reproduce the exact problem reported; however, I reproduced that a failure to construct an RGBMatrix object would leave CircuitPython in an inconsistent state with a display bus registered but not working:

```py
>>> import rgbmatrix, board; rgbmatrix.RGBMatrix(width=64, bit_depth=1, rgb_pins=[], addr_pins=[], clock_pin=board.A0, latch_pin=board.A1, output_enable_pin=board.A2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: The length of rgb_pins must be 6, 12, 18, 24, or 30
>>> import rgbmatrix, board; rgbmatrix.RGBMatrix(width=64, bit_depth=1, rgb_pins=[], addr_pins=[], clock_pin=board.A0, latch_pin=board.A1, output_enable_pin=board.A2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Too many display busses; forgot displayio.release_displays() ?
```

After the fix the second call also results in a ValueError, not a RuntimeError, which is correct.

Closes #9674