### PR TITLE
espressif: Allow mbedtls data in psram if available

### DIFF
--- a/ports/espressif/esp-idf-config/sdkconfig-psram.defaults
+++ b/ports/espressif/esp-idf-config/sdkconfig-psram.defaults
@@ -22,6 +22,11 @@ CONFIG_SPIRAM_USE_CAPS_ALLOC=y
 CONFIG_ESP_WIFI_CACHE_TX_BUFFER_NUM=16
 # end of Wi-Fi
 
+#
+# mbedTLS
+#
+CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y
+
 # end of Component config
 
 # end of Espressif IoT Development Framework Configuration


### PR DESCRIPTION
This is a speculative fix. No testing performed. (it builds for magtag though)

Closes: #8968