### PR TITLE
fix CIRCUITPY_ALARM availability on some espressif boards

### DIFF
--- a/ports/espressif/Makefile
+++ b/ports/espressif/Makefile
@@ -6,26 +6,6 @@
 
 include ../../py/circuitpy_mkenv.mk
 
-ifeq ($(IDF_TARGET),esp32c2)
-IDF_TARGET_ARCH = riscv
-CROSS_COMPILE = riscv32-esp-elf-
-else ifeq ($(IDF_TARGET),esp32c3)
-IDF_TARGET_ARCH = riscv
-CROSS_COMPILE = riscv32-esp-elf-
-else ifeq ($(IDF_TARGET),esp32p4)
-IDF_TARGET_ARCH = riscv
-CROSS_COMPILE = riscv32-esp-elf-
-else ifeq ($(IDF_TARGET),esp32c6)
-IDF_TARGET_ARCH = riscv
-CROSS_COMPILE = riscv32-esp-elf-
-else ifeq ($(IDF_TARGET),esp32h2)
-IDF_TARGET_ARCH = riscv
-CROSS_COMPILE = riscv32-esp-elf-
-else
-IDF_TARGET_ARCH = xtensa
-CROSS_COMPILE = xtensa-$(IDF_TARGET)-elf-
-endif
-
 ifeq ($(IDF_TARGET),esp32s3)
 BT_IDF_TARGET = esp32c3
 else

--- a/ports/espressif/mpconfigport.mk
+++ b/ports/espressif/mpconfigport.mk
@@ -1,3 +1,23 @@
+ifeq ($(IDF_TARGET),esp32c2)
+IDF_TARGET_ARCH = riscv
+CROSS_COMPILE = riscv32-esp-elf-
+else ifeq ($(IDF_TARGET),esp32c3)
+IDF_TARGET_ARCH = riscv
+CROSS_COMPILE = riscv32-esp-elf-
+else ifeq ($(IDF_TARGET),esp32p4)
+IDF_TARGET_ARCH = riscv
+CROSS_COMPILE = riscv32-esp-elf-
+else ifeq ($(IDF_TARGET),esp32c6)
+IDF_TARGET_ARCH = riscv
+CROSS_COMPILE = riscv32-esp-elf-
+else ifeq ($(IDF_TARGET),esp32h2)
+IDF_TARGET_ARCH = riscv
+CROSS_COMPILE = riscv32-esp-elf-
+else
+IDF_TARGET_ARCH = xtensa
+CROSS_COMPILE = xtensa-$(IDF_TARGET)-elf-
+endif
+
 # Use internal flash for CIRCUITPY drive
 INTERNAL_FLASH_FILESYSTEM = 1
 


### PR DESCRIPTION
ESP_IDF_ARCH was used in `mpconfigport.mk` to determine `CIRCUITPY_ALARM` setting but was not yet defined. Move definition from `espressif/Makefile` to `mpconfigport.mk`.

Hopefully, these builds will still fit.

Thanks `@Kevin` in discord, who asked why it wasn't available on a particular 4MB ESP32 board.