### PR TITLE
CIRCUITPY_USB_DEVICE_INSTANCE should default to 0 on most Espressif boards

### DIFF
--- a/ports/espressif/boards/espressif_esp32p4_function_ev/mpconfigboard.h
+++ b/ports/espressif/boards/espressif_esp32p4_function_ev/mpconfigboard.h
@@ -15,3 +15,6 @@
 
 #define DEFAULT_UART_BUS_RX         (&pin_GPIO38)
 #define DEFAULT_UART_BUS_TX         (&pin_GPIO37)
+
+// Use the second USB device (numbered 0 and 1)
+#define CIRCUITPY_USB_DEVICE_INSTANCE 1

--- a/ports/espressif/mpconfigport.h
+++ b/ports/espressif/mpconfigport.h
@@ -17,8 +17,6 @@
 
 #define CIRCUITPY_DIGITALIO_HAVE_INPUT_ONLY (1)
 
-#define CIRCUITPY_USB_DEVICE_INSTANCE 1
-
 #include "py/circuitpy_mpconfig.h"
 
 #define MICROPY_NLR_SETJMP                  (1)


### PR DESCRIPTION
- Fixes #9888.

#9841 set `CIRCUITPY_USB_DEVICE_INSTANCE` to `1` as the default for all Espressif boards. However, on nearly all boards, it should be `0`, not `1`. The ESP32-P4 dev board uses `1` to use the second interface by default.

@tannewt should be it `1` for all ESP32-P4 boards, or does it depend on the board wiring?

Tested that it's fixed on a Feather ESP32-S3 4/2 board.