### PR TITLE
Implement `audiomixer.MixerVoice.level` as `synthio.BlockInput`

### DIFF
--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -13,6 +13,7 @@
 #include "py/objproperty.h"
 #include "py/runtime.h"
 #include "shared-bindings/util.h"
+#include "shared-module/synthio/block.h"
 
 //| class MixerVoice:
 //|     """Voice objects used with Mixer
@@ -75,17 +76,16 @@ static mp_obj_t audiomixer_mixervoice_obj_stop(size_t n_args, const mp_obj_t *po
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_stop_obj, 1, audiomixer_mixervoice_obj_stop);
 
-//|     level: float
+//|     level: synthio.BlockInput
 //|     """The volume level of a voice, as a floating point number between 0 and 1."""
 static mp_obj_t audiomixer_mixervoice_obj_get_level(mp_obj_t self_in) {
-    return mp_obj_new_float(common_hal_audiomixer_mixervoice_get_level(self_in));
+    return common_hal_audiomixer_mixervoice_get_level(self_in);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(audiomixer_mixervoice_get_level_obj, audiomixer_mixervoice_obj_get_level);
 
 static mp_obj_t audiomixer_mixervoice_obj_set_level(mp_obj_t self_in, mp_obj_t level_in) {
     audiomixer_mixervoice_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_float_t level = mp_arg_validate_obj_float_range(level_in, 0, 1, MP_QSTR_level);
-    common_hal_audiomixer_mixervoice_set_level(self, level);
+    common_hal_audiomixer_mixervoice_set_level(self, level_in);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_2(audiomixer_mixervoice_set_level_obj, audiomixer_mixervoice_obj_set_level);

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -13,7 +13,9 @@
 #include "py/objproperty.h"
 #include "py/runtime.h"
 #include "shared-bindings/util.h"
+#if CIRCUITPY_SYNTHIO
 #include "shared-module/synthio/block.h"
+#endif
 
 //| class MixerVoice:
 //|     """Voice objects used with Mixer
@@ -77,7 +79,9 @@ static mp_obj_t audiomixer_mixervoice_obj_stop(size_t n_args, const mp_obj_t *po
 MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_stop_obj, 1, audiomixer_mixervoice_obj_stop);
 
 //|     level: synthio.BlockInput
-//|     """The volume level of a voice, as a floating point number between 0 and 1."""
+//|     """The volume level of a voice, as a floating point number between 0 and 1. If your board
+//|     does not support synthio, this property will only accept a float value.
+//|     """
 static mp_obj_t audiomixer_mixervoice_obj_get_level(mp_obj_t self_in) {
     return common_hal_audiomixer_mixervoice_get_level(self_in);
 }

--- a/shared-bindings/audiomixer/MixerVoice.h
+++ b/shared-bindings/audiomixer/MixerVoice.h
@@ -15,8 +15,8 @@ void common_hal_audiomixer_mixervoice_construct(audiomixer_mixervoice_obj_t *sel
 void common_hal_audiomixer_mixervoice_set_parent(audiomixer_mixervoice_obj_t *self, audiomixer_mixer_obj_t *parent);
 void common_hal_audiomixer_mixervoice_play(audiomixer_mixervoice_obj_t *self, mp_obj_t sample, bool loop);
 void common_hal_audiomixer_mixervoice_stop(audiomixer_mixervoice_obj_t *self);
-mp_float_t common_hal_audiomixer_mixervoice_get_level(audiomixer_mixervoice_obj_t *self);
-void common_hal_audiomixer_mixervoice_set_level(audiomixer_mixervoice_obj_t *self, mp_float_t gain);
+mp_obj_t common_hal_audiomixer_mixervoice_get_level(audiomixer_mixervoice_obj_t *self);
+void common_hal_audiomixer_mixervoice_set_level(audiomixer_mixervoice_obj_t *self, mp_obj_t gain);
 
 bool common_hal_audiomixer_mixervoice_get_playing(audiomixer_mixervoice_obj_t *self);
 

--- a/shared-module/audiomixer/Mixer.c
+++ b/shared-module/audiomixer/Mixer.c
@@ -188,12 +188,18 @@ static void mix_down_one_voice(audiomixer_mixer_obj_t *self,
             }
         }
 
-        uint32_t n = MIN(MIN(voice->buffer_length, length), SYNTHIO_MAX_DUR * self->channel_count);
         uint32_t *src = voice->remaining_buffer;
+
+        #if CIRCUITPY_SYNTHIO
+        uint32_t n = MIN(MIN(voice->buffer_length, length), SYNTHIO_MAX_DUR * self->channel_count);
 
         // Get the current level from the BlockInput. These may change at run time so you need to do bounds checking if required.
         shared_bindings_synthio_lfo_tick(self->sample_rate);
         uint16_t level = (uint16_t)(synthio_block_slot_get_limited(&voice->level, MICROPY_FLOAT_CONST(0.0), MICROPY_FLOAT_CONST(1.0)) * (1 << 15));
+        #else
+        uint32_t n = MIN(voice->buffer_length, length);
+        uint16_t level = voice->level;
+        #endif
 
         // First active voice gets copied over verbatim.
         if (!voices_active) {

--- a/shared-module/audiomixer/Mixer.c
+++ b/shared-module/audiomixer/Mixer.c
@@ -188,9 +188,12 @@ static void mix_down_one_voice(audiomixer_mixer_obj_t *self,
             }
         }
 
-        uint32_t n = MIN(voice->buffer_length, length);
+        uint32_t n = MIN(MIN(voice->buffer_length, length), SYNTHIO_MAX_DUR * self->channel_count);
         uint32_t *src = voice->remaining_buffer;
-        uint16_t level = voice->level;
+
+        // Get the current level from the BlockInput. These may change at run time so you need to do bounds checking if required.
+        shared_bindings_synthio_lfo_tick(self->sample_rate); //, n / self->channel_count); // Requires #9776
+        uint16_t level = (uint16_t)(synthio_block_slot_get_limited(&voice->level, MICROPY_FLOAT_CONST(0.0), MICROPY_FLOAT_CONST(1.0)) * (1 << 15));
 
         // First active voice gets copied over verbatim.
         if (!voices_active) {

--- a/shared-module/audiomixer/Mixer.c
+++ b/shared-module/audiomixer/Mixer.c
@@ -192,7 +192,7 @@ static void mix_down_one_voice(audiomixer_mixer_obj_t *self,
         uint32_t *src = voice->remaining_buffer;
 
         // Get the current level from the BlockInput. These may change at run time so you need to do bounds checking if required.
-        shared_bindings_synthio_lfo_tick(self->sample_rate); //, n / self->channel_count); // Requires #9776
+        shared_bindings_synthio_lfo_tick(self->sample_rate);
         uint16_t level = (uint16_t)(synthio_block_slot_get_limited(&voice->level, MICROPY_FLOAT_CONST(0.0), MICROPY_FLOAT_CONST(1.0)) * (1 << 15));
 
         // First active voice gets copied over verbatim.

--- a/shared-module/audiomixer/MixerVoice.c
+++ b/shared-module/audiomixer/MixerVoice.c
@@ -15,19 +15,19 @@
 
 void common_hal_audiomixer_mixervoice_construct(audiomixer_mixervoice_obj_t *self) {
     self->sample = NULL;
-    self->level = 1 << 15;
+    common_hal_audiomixer_mixervoice_set_level(self, mp_obj_new_float(1.0));
 }
 
 void common_hal_audiomixer_mixervoice_set_parent(audiomixer_mixervoice_obj_t *self, audiomixer_mixer_obj_t *parent) {
     self->parent = parent;
 }
 
-mp_float_t common_hal_audiomixer_mixervoice_get_level(audiomixer_mixervoice_obj_t *self) {
-    return (mp_float_t)self->level / (1 << 15);
+mp_obj_t common_hal_audiomixer_mixervoice_get_level(audiomixer_mixervoice_obj_t *self) {
+    return self->level.obj;
 }
 
-void common_hal_audiomixer_mixervoice_set_level(audiomixer_mixervoice_obj_t *self, mp_float_t level) {
-    self->level = (uint16_t)(level * (1 << 15));
+void common_hal_audiomixer_mixervoice_set_level(audiomixer_mixervoice_obj_t *self, mp_obj_t arg) {
+    synthio_block_assign_slot(arg, &self->level, MP_QSTR_level);
 }
 
 bool common_hal_audiomixer_mixervoice_get_loop(audiomixer_mixervoice_obj_t *self) {

--- a/shared-module/audiomixer/MixerVoice.c
+++ b/shared-module/audiomixer/MixerVoice.c
@@ -23,11 +23,19 @@ void common_hal_audiomixer_mixervoice_set_parent(audiomixer_mixervoice_obj_t *se
 }
 
 mp_obj_t common_hal_audiomixer_mixervoice_get_level(audiomixer_mixervoice_obj_t *self) {
+    #if CIRCUITPY_SYNTHIO
     return self->level.obj;
+    #else
+    return mp_obj_new_float((mp_float_t)self->level / (1 << 15));
+    #endif
 }
 
 void common_hal_audiomixer_mixervoice_set_level(audiomixer_mixervoice_obj_t *self, mp_obj_t arg) {
+    #if CIRCUITPY_SYNTHIO
     synthio_block_assign_slot(arg, &self->level, MP_QSTR_level);
+    #else
+    self->level = (uint16_t)(mp_arg_validate_obj_float_range(arg, 0, 1, MP_QSTR_level) * (1 << 15));
+    #endif
 }
 
 bool common_hal_audiomixer_mixervoice_get_loop(audiomixer_mixervoice_obj_t *self) {

--- a/shared-module/audiomixer/MixerVoice.h
+++ b/shared-module/audiomixer/MixerVoice.h
@@ -9,7 +9,9 @@
 
 #include "shared-module/audiomixer/__init__.h"
 #include "shared-module/audiomixer/Mixer.h"
+#if CIRCUITPY_SYNTHIO
 #include "shared-module/synthio/block.h"
+#endif
 
 typedef struct {
     mp_obj_base_t base;
@@ -19,5 +21,9 @@ typedef struct {
     bool more_data;
     uint32_t *remaining_buffer;
     uint32_t buffer_length;
+    #if CIRCUITPY_SYNTHIO
     synthio_block_slot_t level;
+    #else
+    uint16_t level;
+    #endif
 } audiomixer_mixervoice_obj_t;

--- a/shared-module/audiomixer/MixerVoice.h
+++ b/shared-module/audiomixer/MixerVoice.h
@@ -9,6 +9,7 @@
 
 #include "shared-module/audiomixer/__init__.h"
 #include "shared-module/audiomixer/Mixer.h"
+#include "shared-module/synthio/block.h"
 
 typedef struct {
     mp_obj_base_t base;
@@ -18,5 +19,5 @@ typedef struct {
     bool more_data;
     uint32_t *remaining_buffer;
     uint32_t buffer_length;
-    uint16_t level;
+    synthio_block_slot_t level;
 } audiomixer_mixervoice_obj_t;


### PR DESCRIPTION
Allow tremolo-style effects using `audiomixer.MixerVoice` by implementing block input on `level` property.

LFO ticking is not completely implemented yet because it relies on changes to `shared_bindings_synthio_lfo_tick` introduced in #9776 to allow for a duration less than `SYNTHIO_MAX_DUR`.

Demonstration:
``` python
import audiobusio
import audiocore
import audiomixer
import board
import synthio
import time

DELAY = 3.0

wave_file = open("StreetChicken.wav", "rb")
wave = audiocore.WaveFile(wave_file)

mixer = audiomixer.Mixer(
    voice_count=1,
    sample_rate=wave.sample_rate,
    channel_count=wave.channel_count,
)

audio = audiobusio.I2SOut(
    bit_clock=board.GP3,
    word_select=board.GP4,
    data=board.GP5,
)

audio.play(mixer)
mixer.play(wave, loop=True)

print("full")
time.sleep(DELAY)
mixer.voice[0].level = 0.5
print("half")
time.sleep(DELAY)
mixer.voice[0].level = synthio.LFO(rate=0.5, scale=0.5, offset=0.5)
print("lfo")
time.sleep(DELAY)
mixer.voice[0].stop()
```