### PR TITLE
Sunton 8048S050: Configure display frequency in settings.toml

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -125,7 +125,7 @@ a rotation of 0. Attempting to initialize the screen with a rotation other than 
 CIRCUITPY_DISPLAY_FREQUENCY
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Allows the entry of a display frequency used during the "dotclock" framebuffer construction.
-If a valid fequency is not defined the board will initialize the framebuffer with a
+If a valid frequency is not defined the board will initialize the framebuffer with a
 frequency of 12500000hz (12.5Mhz). The value should be entered as an integer in hertz
-i.e. CIRCUITPY_DISPLAY_FREQUENCY=16000000 will override the default value with a 16Mhz 
+i.e. CIRCUITPY_DISPLAY_FREQUENCY=16000000 will override the default value with a 16Mhz
 display frequency.

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -119,3 +119,13 @@ If the CIRCUITPY_DISPLAY_ROTATION parameter is set the display will be initializ
 during power up with the selected rotation, otherwise the display will be initialized with
 a rotation of 0. Attempting to initialize the screen with a rotation other than 0,
 90, 180 or 270 is not supported and will result in an unexpected screen rotation.
+
+`Sunton ESP32-8048S050 <https://circuitpython.org/board/sunton_esp32_8048S050/>`_
+
+CIRCUITPY_DISPLAY_FREQUENCY
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Allows the entry of a display frequency used during the "dotclock" framebuffer construction.
+If a valid fequency is not defined the board will initialize the framebuffer with a
+frequency of 12500000hz (12.5Mhz). The value should be entered as an integer in hertz
+i.e. CIRCUITPY_DISPLAY_FREQUENCY=16000000 will override the default value with a 16Mhz 
+display frequency.

--- a/ports/espressif/boards/sunton_esp32_8048S050/board.c
+++ b/ports/espressif/boards/sunton_esp32_8048S050/board.c
@@ -12,6 +12,7 @@
 #include "shared-bindings/framebufferio/FramebufferDisplay.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-module/displayio/__init__.h"
+#include "shared-module/os/__init__.h"
 
 static const mcu_pin_obj_t *blue_pins[] = {
     &pin_GPIO8,
@@ -37,6 +38,7 @@ static const mcu_pin_obj_t *red_pins[] = {
 };
 
 static void display_init(void) {
+    mp_int_t frequency;
 
     // Turn on backlight
     gpio_set_direction(2, GPIO_MODE_DEF_OUTPUT);
@@ -45,6 +47,10 @@ static void display_init(void) {
 
     dotclockframebuffer_framebuffer_obj_t *framebuffer = &allocate_display_bus_or_raise()->dotclock;
     framebuffer->base.type = &dotclockframebuffer_framebuffer_type;
+    os_getenv_err_t result = common_hal_os_getenv_int("CIRCUITPY_DISPLAY_FREQUENCY", &frequency);
+    if (result != GETENV_OK) {
+        frequency = 12500000;
+    }
 
     common_hal_dotclockframebuffer_framebuffer_construct(
         framebuffer,
@@ -55,7 +61,7 @@ static void display_init(void) {
         red_pins, MP_ARRAY_SIZE(red_pins),
         green_pins, MP_ARRAY_SIZE(green_pins),
         blue_pins, MP_ARRAY_SIZE(blue_pins),
-        12500000,       // Frequency
+        frequency,       // Frequency
         800,            // width
         480,            // height
         4, 8, 8, true, // horiz: pulse, back porch, front porch, idle low


### PR DESCRIPTION
As indicated in #9661 @sandzco appears to have purchased a variant of this board that requires a different display frequency. I don't have either the original or variant boards but I have put this firmware on the makerfabs 7" board, which seems to be a close cousin, and the firmware at least loads without boot looping.

This update will allow the default display frequency to be overridden through a settings.toml parameter.

If this PR is merged I'll submit a PR to circuipython-org updating the board description to include the new parameter as well.