### PR TITLE
fix: Add delay to DemuxKeyMatrix along with columns_to_anodes and transpose options

### DIFF
--- a/ports/espressif/boards/m5stack_cardputer/cardputer_keyboard.c
+++ b/ports/espressif/boards/m5stack_cardputer/cardputer_keyboard.c
@@ -110,6 +110,8 @@ void cardputer_keyboard_init(void) {
         row_addr_pins,           // row_addr_pins
         7,                       // num_column_pins
         column_pins,             // column_pins
+        true,                    // columns_to_anodes
+        false,                   // transpose
         0.01f,                   // interval
         20,                      // max_events
         2                        // debounce_threshold

--- a/shared-bindings/keypad_demux/DemuxKeyMatrix.c
+++ b/shared-bindings/keypad_demux/DemuxKeyMatrix.c
@@ -36,6 +36,8 @@
 //|         self,
 //|         row_addr_pins: Sequence[microcontroller.Pin],
 //|         column_pins: Sequence[microcontroller.Pin],
+//|         columns_to_anodes: bool = True,
+//|         transpose: bool = False,
 //|         interval: float = 0.020,
 //|         max_events: int = 64,
 //|         debounce_threshold: int = 1,
@@ -51,7 +53,18 @@
 //|         An `keypad.EventQueue` is created when this object is created and is available in the `events` attribute.
 //|
 //|         :param Sequence[microcontroller.Pin] row_addr_pins: The pins attached to the rows demultiplexer.
+//|           If your columns are multiplexed, set ``transpose`` to ``True``.
 //|         :param Sequence[microcontroller.Pin] column_pins: The pins attached to the columns.
+//|         :param bool columns_to_anodes: Default ``True``.
+//|           If the matrix uses diodes, the diode anodes are typically connected to the column pins
+//|           with the cathodes connected to the row pins.  This implies an inverting multiplexer that drives
+//|           the selected row pin low.  If your diodes are reversed, with a non-inverting multiplexer
+//|           that drives the selected row high, set ``columns_to_anodes`` to ``False``.
+//|           If ``transpose`` is ``True`` the sense of columns and rows are reversed here.
+//|         :param bool transpose: Default ``False``.
+//|           If your matrix is multiplexed on columns rather than rows, set ``transpose`` to ``True``.
+//|           This swaps the meaning of ``row_addr_pins`` to ``column_addr_pins``;
+//|           ``column_pins`` to ``row_pins``; and ``columns_to_anodes`` to ``rows_to_anodes``.
 //|         :param float interval: Scan keys no more often than ``interval`` to allow for debouncing.
 //|           ``interval`` is in float seconds. The default is 0.020 (20 msecs).
 //|         :param int max_events: maximum size of `events` `keypad.EventQueue`:
@@ -67,10 +80,12 @@
 
 static mp_obj_t keypad_demux_demuxkeymatrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     keypad_demux_demuxkeymatrix_obj_t *self = mp_obj_malloc(keypad_demux_demuxkeymatrix_obj_t, &keypad_demux_demuxkeymatrix_type);
-    enum { ARG_row_addr_pins, ARG_column_pins, ARG_interval, ARG_max_events, ARG_debounce_threshold };
+    enum { ARG_row_addr_pins, ARG_column_pins, ARG_columns_to_anodes, ARG_transpose, ARG_interval, ARG_max_events, ARG_debounce_threshold };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_row_addr_pins, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_column_pins, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_columns_to_anodes, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = true} },
+        { MP_QSTR_transpose, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
         { MP_QSTR_interval, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_max_events, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 64} },
         { MP_QSTR_debounce_threshold, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
@@ -107,7 +122,7 @@ static mp_obj_t keypad_demux_demuxkeymatrix_make_new(const mp_obj_type_t *type, 
         column_pins_array[column] = pin;
     }
 
-    common_hal_keypad_demux_demuxkeymatrix_construct(self, num_row_addr_pins, row_addr_pins_array, num_column_pins, column_pins_array, interval, max_events, debounce_threshold);
+    common_hal_keypad_demux_demuxkeymatrix_construct(self, num_row_addr_pins, row_addr_pins_array, num_column_pins, column_pins_array, args[ARG_columns_to_anodes].u_bool, args[ARG_transpose].u_bool, interval, max_events, debounce_threshold);
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/keypad_demux/DemuxKeyMatrix.h
+++ b/shared-bindings/keypad_demux/DemuxKeyMatrix.h
@@ -11,7 +11,7 @@
 
 extern const mp_obj_type_t keypad_demux_demuxkeymatrix_type;
 
-void common_hal_keypad_demux_demuxkeymatrix_construct(keypad_demux_demuxkeymatrix_obj_t *self, mp_uint_t num_row_addr_pins, const mcu_pin_obj_t *row_addr_pins[], mp_uint_t num_column_pins, const mcu_pin_obj_t *column_pins[],  bool columns_to_anodes,  bool transpose, mp_float_t interval, size_t max_events, uint8_t debounce_threshold);
+void common_hal_keypad_demux_demuxkeymatrix_construct(keypad_demux_demuxkeymatrix_obj_t *self, mp_uint_t num_row_addr_pins, const mcu_pin_obj_t *row_addr_pins[], mp_uint_t num_column_pins, const mcu_pin_obj_t *column_pins[], bool columns_to_anodes, bool transpose, mp_float_t interval, size_t max_events, uint8_t debounce_threshold);
 
 void common_hal_keypad_demux_demuxkeymatrix_deinit(keypad_demux_demuxkeymatrix_obj_t *self);
 

--- a/shared-bindings/keypad_demux/DemuxKeyMatrix.h
+++ b/shared-bindings/keypad_demux/DemuxKeyMatrix.h
@@ -11,7 +11,7 @@
 
 extern const mp_obj_type_t keypad_demux_demuxkeymatrix_type;
 
-void common_hal_keypad_demux_demuxkeymatrix_construct(keypad_demux_demuxkeymatrix_obj_t *self, mp_uint_t num_row_addr_pins, const mcu_pin_obj_t *row_addr_pins[], mp_uint_t num_column_pins, const mcu_pin_obj_t *column_pins[], mp_float_t interval, size_t max_events, uint8_t debounce_threshold);
+void common_hal_keypad_demux_demuxkeymatrix_construct(keypad_demux_demuxkeymatrix_obj_t *self, mp_uint_t num_row_addr_pins, const mcu_pin_obj_t *row_addr_pins[], mp_uint_t num_column_pins, const mcu_pin_obj_t *column_pins[],  bool columns_to_anodes,  bool transpose, mp_float_t interval, size_t max_events, uint8_t debounce_threshold);
 
 void common_hal_keypad_demux_demuxkeymatrix_deinit(keypad_demux_demuxkeymatrix_obj_t *self);
 

--- a/shared-bindings/keypad_demux/__init__.c
+++ b/shared-bindings/keypad_demux/__init__.c
@@ -11,8 +11,14 @@
 
 //| """Support for scanning key matrices that use a demultiplexer
 //|
-//| The `keypad_demux` module provides native support to scan sets of keys or buttons,
-//| connected in a row-and-column matrix.
+//| The `keypad_demux` module provides native support to scan a matrix of keys or buttons
+//| where either the row or column axis is controlled by a demultiplexer or decoder IC
+//| such as the 74LS138 or 74LS238.  In this arrangement a binary input value
+//| determines which column (or row) to select, thereby reducing the number of input pins.
+//| For example the input 101 would select line 5 in the matrix.
+//| Set ``columns_to_anodes`` to ``False`` with a non-inverting demultiplexer
+//| which drives the selected line high.
+//| Set ``transpose`` to ``True`` if columns are multiplexed rather than rows.
 //|
 //| .. jinja
 //| """

--- a/shared-module/keypad_demux/DemuxKeyMatrix.h
+++ b/shared-module/keypad_demux/DemuxKeyMatrix.h
@@ -17,6 +17,8 @@ typedef struct {
     KEYPAD_SCANNER_COMMON_FIELDS;
     mp_obj_tuple_t *row_addr_digitalinouts;
     mp_obj_tuple_t *column_digitalinouts;
+    bool columns_to_anodes;
+    bool transpose;
 } keypad_demux_demuxkeymatrix_obj_t;
 
 void keypad_demux_demuxkeymatrix_scan(keypad_demux_demuxkeymatrix_obj_t *self);


### PR DESCRIPTION
I'm using a nullbitsco nibble which has a 16x5 matrix with the multiplexed via two '138 3:8 decoders.
With no delay the DemuxKeyMatrix scanner was giving phantom key strokes on almost every key press, where (r,c) is
pressed but (r,c), (r+1,c) and sometimes (r+2,c) register.   I tried the same 1us delay as the basic KeyMatrix but
still saw echoes, especially where many bits change in the demux input.  The qmk implementation uses a 5us delay
which also works here.

In passing this class would be more flexible if it supported the same columns_to_anodes parameter as KeyMatrix, and perhaps a way to transpose rows and columns.  For example with the nibble it's actually the columns that are multiplexed not the rows but I can work around by pretending they're rows and transposing back to the keymap.