### PR TITLE
Revert pull 5210, set DEBUG=1 gcc optimization flag to -Og for the RP2 port.

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -207,7 +207,7 @@ CFLAGS += $(OPTIMIZATION_FLAGS)
 CFLAGS += $(CFLAGS_CYW43)
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)
-  CFLAGS += -ggdb3 -O3
+  CFLAGS += -ggdb3 -Og
   # No LTO because we may place some functions in RAM instead of flash.
 else
   CFLAGS += -DNDEBUG


### PR DESCRIPTION
#5210 changed the optimization flag for `DEBUG=1` RP2 builds from `-Og` to `-O3` to work around an ARM toolchain bug in CRT that caused a crash during C initialization. This bug is not present in at least ARM toolchain versions 12.3 and up. Since #9779 guarantees that the toolchain will be at least 13, it is safe to revert #5210.

This change reverts to`-Og` which provides a superior `gdb` debugging experience compared to `-O3`.