### PR TITLE
Fix : Update GPIO pin assignments for BTN5 and BUTTON in oxocard_connect board

### DIFF
--- a/ports/espressif/boards/oxocard_connect/pins.c
+++ b/ports/espressif/boards/oxocard_connect/pins.c
@@ -12,8 +12,8 @@ CIRCUITPY_BOARD_BUS_SINGLETON(stemma_i2c, i2c, 1)
 static const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
 
-    { MP_ROM_QSTR(MP_QSTR_BTN5), MP_ROM_PTR(&pin_GPIO0) },
-    { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO0) },
+    { MP_ROM_QSTR(MP_QSTR_BTN5), MP_ROM_PTR(&pin_GPIO2) },
+    { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO2) },
     { MP_ROM_QSTR(MP_QSTR_BOOT0), MP_ROM_PTR(&pin_GPIO0) },
 
     { MP_ROM_QSTR(MP_QSTR_LCD_LED), MP_ROM_PTR(&pin_GPIO19) },
@@ -38,7 +38,6 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IO05), MP_ROM_PTR(&pin_GPIO33) },
     { MP_ROM_QSTR(MP_QSTR_IN06), MP_ROM_PTR(&pin_GPIO34) },
     { MP_ROM_QSTR(MP_QSTR_IN07), MP_ROM_PTR(&pin_GPIO35) },
-
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },


### PR DESCRIPTION
Here is a PR to fix an incorrect PIN assignment for the Oxocard Connect.

Note that the pre-commit hook also changed the `.pot` file, but this is not part of my change.