### PR TITLE
Ignore added "line clear" characters in the Web Workflow serial

### DIFF
--- a/supervisor/shared/web_workflow/static/serial.js
+++ b/supervisor/shared/web_workflow/static/serial.js
@@ -43,6 +43,8 @@ ws.onmessage = function(e) {
   } else if (e.data == "\x1b[K") { // Clear line
     log.textContent = log.textContent.slice(0, -left_count);
     left_count = 0;
+  } else if (e.data == "\x1b[2K\x1b[0G") {
+    // ignore
   } else {
     log.textContent += e.data;
   }


### PR DESCRIPTION
Fix the printing of some control characters:
```
[2K[0GAuto-reload is on. Simply save files over USB to run them or enter REPL to disable.
[2K[0Gcode.py output:
```
to
```
Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
```
This just ignores the characters.
I don't think there is a need to implement erasing the line for the builtin web serial.