### PR TITLE
py/objint.c: int.from_bytes() and .to_bytes() can omit byteorder arg

### DIFF
--- a/py/objint.c
+++ b/py/objint.c
@@ -490,7 +490,7 @@ static mp_obj_t int_from_bytes(size_t n_args, const mp_obj_t *pos_args, mp_map_t
     enum { ARG_bytes, ARG_byteorder, ARG_signed };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_bytes, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = NULL} },
-        { MP_QSTR_byteorder, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = NULL} },
+        { MP_QSTR_byteorder, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_QSTR(MP_QSTR_big)} },
         { MP_QSTR_signed, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -527,7 +527,7 @@ static mp_obj_t int_from_bytes(size_t n_args, const mp_obj_t *pos_args, mp_map_t
     return mp_obj_new_int_from_uint(value);
 }
 
-static MP_DEFINE_CONST_FUN_OBJ_KW(int_from_bytes_fun_obj, 3, int_from_bytes);
+static MP_DEFINE_CONST_FUN_OBJ_KW(int_from_bytes_fun_obj, 2, int_from_bytes);
 static MP_DEFINE_CONST_CLASSMETHOD_OBJ(int_from_bytes_obj, MP_ROM_PTR(&int_from_bytes_fun_obj));
 
 // CIRCUITPY-CHANGE: supports signed
@@ -535,7 +535,7 @@ static mp_obj_t int_to_bytes(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
     enum { ARG_length, ARG_byteorder, ARG_signed };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_length,    MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
-        { MP_QSTR_byteorder, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_byteorder, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_QSTR(MP_QSTR_big)} },
         { MP_QSTR_signed,    MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -575,7 +575,7 @@ static mp_obj_t int_to_bytes(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
 
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
-static MP_DEFINE_CONST_FUN_OBJ_KW(int_to_bytes_obj, 3, int_to_bytes);
+static MP_DEFINE_CONST_FUN_OBJ_KW(int_to_bytes_obj, 2, int_to_bytes);
 
 static const mp_rom_map_elem_t int_locals_dict_table[] = {
     // CIRCUITPY-CHANGE

--- a/py/objint.c
+++ b/py/objint.c
@@ -490,6 +490,7 @@ static mp_obj_t int_from_bytes(size_t n_args, const mp_obj_t *pos_args, mp_map_t
     enum { ARG_bytes, ARG_byteorder, ARG_signed };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_bytes, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = NULL} },
+        // CIRCUITPY-CHANGE: not required and given a default value.
         { MP_QSTR_byteorder, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_QSTR(MP_QSTR_big)} },
         { MP_QSTR_signed, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
     };
@@ -527,6 +528,7 @@ static mp_obj_t int_from_bytes(size_t n_args, const mp_obj_t *pos_args, mp_map_t
     return mp_obj_new_int_from_uint(value);
 }
 
+// CIRCUITPY-CHANGE: only two required args.
 static MP_DEFINE_CONST_FUN_OBJ_KW(int_from_bytes_fun_obj, 2, int_from_bytes);
 static MP_DEFINE_CONST_CLASSMETHOD_OBJ(int_from_bytes_obj, MP_ROM_PTR(&int_from_bytes_fun_obj));
 
@@ -535,6 +537,7 @@ static mp_obj_t int_to_bytes(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
     enum { ARG_length, ARG_byteorder, ARG_signed };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_length,    MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
+        // CIRCUITPY-CHANGE: not required and given a default value.
         { MP_QSTR_byteorder, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_QSTR(MP_QSTR_big)} },
         { MP_QSTR_signed,    MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
     };
@@ -575,6 +578,7 @@ static mp_obj_t int_to_bytes(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
 
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
+// CIRCUITPY-CHANGE: only two required args.
 static MP_DEFINE_CONST_FUN_OBJ_KW(int_to_bytes_obj, 2, int_to_bytes);
 
 static const mp_rom_map_elem_t int_locals_dict_table[] = {

--- a/tests/basics/int_bytes.py
+++ b/tests/basics/int_bytes.py
@@ -43,3 +43,7 @@ try:
     (-256).to_bytes(2, "little", signed=False)
 except OverflowError:
     print("OverflowError")
+
+# byteorder arg can be omitted; default is "big"
+print(int.from_bytes(b"\x01\0"))
+print((100).to_bytes(10))


### PR DESCRIPTION
`int.from_bytes()` and `int.to_bytes()` required the `byteorder` argument. But in CPython that argument defaults to `"big"` and can be omitted. Fixed this.

I encountered this while porting CircuitMatter and the libraries it uses.