### PR TITLE
ports/espressif/common-hal/busio/I2C.c: add delay after probe

### DIFF
--- a/ports/espressif/common-hal/busio/I2C.c
+++ b/ports/espressif/common-hal/busio/I2C.c
@@ -6,6 +6,7 @@
 
 #include "shared-bindings/busio/I2C.h"
 #include "py/mperrno.h"
+#include "py/mphal.h"
 #include "py/runtime.h"
 
 #include "components/driver/i2c/include/driver/i2c.h"
@@ -134,6 +135,12 @@ void common_hal_busio_i2c_deinit(busio_i2c_obj_t *self) {
 
 bool common_hal_busio_i2c_probe(busio_i2c_obj_t *self, uint8_t addr) {
     esp_err_t result = i2c_master_probe(self->handle, addr, 10);
+
+    #if defined(CONFIG_IDF_TARGET_ESP32S2)
+    // ESP32-S2 gives spurious results when probe is called multiple times in succession without this delay.
+    mp_hal_delay_ms(1);
+    #endif
+
     return result == ESP_OK;
 }
 


### PR DESCRIPTION
- Fixes #9931 

ESP32-S2 started returning bogus I2C probe successes after #9671, when I switched to using `i2c_master_probe()` instead of using our home-grown bus probe.

I inserted a debugging print and the problem went away. That suggested a timing issue. I added a 1ms delay and it's now fine.

I tested ESP32-S3, ESP32-C6, and ESP32, and they all don't have this problem. I could conditionalize the delay to just ESP32-S2, but it's a short delay and might prevent future problems.

I also wondered whether the problem was peculiar to boards with the MAX17048 or other I2C battery gauge. But I was able to reproduce the problem on a Metro ESP32-S2 with an I2C OLED display. So it's as more general problem.

I didn't find any reports of this in https://github.com/espressif/esp-idf/issues, so I may open an issue there at some point.