### PR TITLE
Documentation Typo fix in RTC.c to fix rp2040 chip name

### DIFF
--- a/shared-bindings/rtc/RTC.c
+++ b/shared-bindings/rtc/RTC.c
@@ -73,7 +73,7 @@ MP_PROPERTY_GETSET(rtc_rtc_datetime_obj,
 //|
 //|     A positive value speeds up the clock and a negative value slows it down.
 //|
-//|     **Limitations:** Calibration not supported on SAMD, Nordic, RP240, Spresense, and STM.
+//|     **Limitations:** Calibration not supported on SAMD, Nordic, RP2040, Spresense, and STM.
 //|
 //|     Range and value is hardware specific, but one step is often approximately 1 ppm::
 //|


### PR DESCRIPTION
This is very minor and only has one typo fix so it's low priority.

I did start to try to look into figuring out if the RP2350 also lacked the calibration function, but the honest issue I ran into was an absence of a reason why any of the chipsets lacked or had rtc calibration options in the first place. 

So if this should be updated to include the RP2350 let me know! 