### PR TITLE
Document Windows limitation on usb_midi.set_names(audio_control_interface_name=...)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(BASEOPTS)
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(BASEOPTS)
 
-TRANSLATE_SOURCES = extmod lib main.c ports/atmel-samd ports/cxd56 ports/espressif ports/mimxrt10xx ports/nordic ports/raspberrypi ports/stm py shared-bindings shared-module supervisor
+TRANSLATE_SOURCES = extmod lib main.c ports/atmel-samd ports/analog ports/cxd56 ports/espressif ports/mimxrt10xx ports/nordic ports/raspberrypi ports/renode ports/stm py shared-bindings shared-module supervisor
 # Paths to exclude from TRANSLATE_SOURCES
 # Each must be preceded by "-path"; if any wildcards, enclose in quotes.
 # Separate by "-o" (Find's "or" operand)

--- a/shared-bindings/usb_midi/__init__.c
+++ b/shared-bindings/usb_midi/__init__.c
@@ -93,6 +93,9 @@ static void set_name(mp_obj_t name_obj, qstr arg_name_qstr, char **custom_name_p
 //|     This method must be called in boot.py to have any effect.
 //|
 //|     Not available on boards without native USB support.
+//|
+//|     .. warning:: On Windows, if ``audio_control_interface_name`` is more than 31 characters long, Windows
+//|       will not recognize the device. This issue is not present on macOS or Linux.
 //|     """
 //|     ...
 //|


### PR DESCRIPTION
Fixes #9871.

`usb_midi.set_names()` prevents the MIDI device from being recognized if `audio_control_interface_name` is 32 chars or more. We can't check for this because we can't find out the host OS, but it's now documented.

I also prevented the doc build from looking inside things in `ports/analog` it shouldn't bother to look in.