### PR TITLE
Fix version in circuitpython-stubs

### DIFF
--- a/.github/actions/deps/submodules/action.yml
+++ b/.github/actions/deps/submodules/action.yml
@@ -22,7 +22,7 @@ inputs:
     - restore
 
   version:
-    description: 'Whether to generate CP version'
+    description: 'Whether to fetch tags to identify CP version'
     required: false
     default: false
     type: boolean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,8 @@ jobs:
         python-version: 3.x
     - name: Set up submodules
       uses: ./.github/actions/deps/submodules
+      with:
+        version: true
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ stubs:
 	@$(PYTHON) tools/extract_pyi.py ports/atmel-samd/bindings $(STUBDIR)
 	@$(PYTHON) tools/extract_pyi.py ports/espressif/bindings $(STUBDIR)
 	@$(PYTHON) tools/extract_pyi.py ports/raspberrypi/bindings $(STUBDIR)
-	@cp setup.py-stubs circuitpython-stubs/setup.py
+	@sed -e "s,__version__,`python -msetuptools_scm`," < setup.py-stubs > circuitpython-stubs/setup.py
 	@cp README.rst-stubs circuitpython-stubs/README.rst
 	@cp MANIFEST.in-stubs circuitpython-stubs/MANIFEST.in
 	@$(PYTHON) tools/board_stubs/build_board_specific_stubs/board_stub_builder.py

--- a/setup.py-stubs
+++ b/setup.py-stubs
@@ -45,12 +45,7 @@ setup(
     packages=list(package_data.keys()),
     package_data=package_data,
     package_dir = package_dir,
-    setup_requires=["setuptools_scm", "setuptools>=38.6.0"],
-    use_scm_version = {
-        "root": "..",
-        "relative_to": __file__,
-        "local_scheme": local_scheme,
-        "git_describe_command": "tools/describe --long",
-    },
+    setup_requires=["setuptools>=38.6.0"],
+    version="__version__",
     zip_safe=False,
 )

--- a/tools/test-stubs.sh
+++ b/tools/test-stubs.sh
@@ -2,7 +2,7 @@
 rm -rf test-stubs
 python3 -m venv test-stubs
 . test-stubs/bin/activate
-pip install mypy isort black adafruit-circuitpython-typing wheel build
+pip install mypy isort black adafruit-circuitpython-typing wheel build setuptools_scm
 rm -rf circuitpython-stubs .mypy_cache
 make stubs
 # Allow either dash or underscore as separator. setuptools v69.3.0 changed from "-" to "_".


### PR DESCRIPTION
the configuration that tried to use setuptools_scm was broken. Instead, provides circuitpython-stubs' setup.py with the version determined by setuptools_scm running in the git source directory.

This gets rid of the following message seen during the doc build in github actions:
```
WARNING setuptools_scm.pyproject_reading toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
Traceback (most recent call last):
  File "/tmp/build-env-dsk5kdxt/lib/python3.12/site-packages/setuptools_scm/_integration/pyproject_reading.py", line 36, in read_pyproject
    section = defn.get("tool", {})[tool_name]
              ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'setuptools_scm'
```

Compared to the version originally in #9947 this adds fetching tags during the doc build.

Remember to also check if this worked on RTD!