### PR TITLE
Waveshare pico S3: change the color order of the RBG LED

### DIFF
--- a/ports/espressif/boards/waveshare_esp32_s3_pico/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_pico/mpconfigboard.h
@@ -11,6 +11,7 @@
 #define MICROPY_HW_BOARD_NAME       "Waveshare ESP32-S3-Pico"
 #define MICROPY_HW_MCU_NAME         "ESP32S3"
 
+#define MICROPY_HW_NEOPIXEL_ORDER_GRB (1)
 #define MICROPY_HW_NEOPIXEL         (&pin_GPIO21)
 
 #define DEFAULT_UART_BUS_RX         (&pin_GPIO12)


### PR DESCRIPTION
I didn't find a clear documentation of the color order of the neopixel on the board, but the Micropython demo from Waveshare does swap red and green instead of the default (1, 0, 2, 3), so I think it's good.
```py
# Set the color order for the NeoPixel object
rgb_led.ORDER = (0, 1, 2, 3)
```
Tested and the color is now correct (exceptions blink red instead of green).