### PR TITLE
Fix frozen libraries version numbers

### DIFF
--- a/tools/preprocess_frozen_modules.py
+++ b/tools/preprocess_frozen_modules.py
@@ -78,6 +78,7 @@ def copy_and_process(in_dir, out_dir):
                         if line.startswith("__version__"):
                             module_version = version_string(root, valid_semver=True)
                             line = line.replace("0.0.0-auto.0", module_version)
+                            line = line.replace("0.0.0+auto.0", module_version)
                         output.write(line)
 
 


### PR DESCRIPTION
When [we switched to the PEP 440 compatible version number](https://github.com/adafruit/circuitpython-build-tools/issues/91) "0.0.0+auto.0" instead of "0.0.0-auto.0" we didn't update the preprocess script for frozen modules, so they have been having a wrong version number ever since. Sorry :D
This PR fixes that.

before
```
Adafruit CircuitPython 9.2.2 on 2025-01-09; Adafruit PyPortal with samd51j20
>>> import adafruit_fakerequests
>>> adafruit_fakerequests.__version__
'0.0.0+auto.0'
```
after
```
Adafruit CircuitPython 9.2.2-6-g9004f20af0-dirty on 2025-01-14; Adafruit PyPortal with samd51j20
>>> import adafruit_fakerequests
>>> adafruit_fakerequests.__version__
'1.0.14'
```
Note that some community modules still use the other format, so I kept it.
```
❯ ag 0.0.0-
circuitpython_ef_music/elecfreaks_music.py
17:__version__ = "0.0.0-auto.0"

Adafruit_CircuitPython_ImageLoad/adafruit_imageload/png.py
28:__version__ = "0.0.0-auto.0"

mixgo_cp_lib/mixgoce_lib/matrix.py
33:__version__ = "0.0.0-auto.0"

mixgo_cp_lib/mixgoce_lib/adafruit_minimqtt.py
35:__version__ = "0.0.0-auto.0"

mixgo_cp_lib/mixgoce_lib/adafruit_framebuf.py
45:__version__ = "0.0.0-auto.0"

mixgo_cp_lib/mixgoce_lib/adafruit_irremote.py
77:__version__ = "0.0.0-auto.0"
```
(The adafruit_imageload one is one of the submodules, it does not really impact anything).