### PR TITLE
Possible fix for stm32H7 crashes

### DIFF
--- a/ports/stm/Makefile
+++ b/ports/stm/Makefile
@@ -48,8 +48,8 @@ CFLAGS += $(OPTIMIZATION_FLAGS)
 # Add -ftree-vrp optimization and checking to all builds. It's not enabled for -Os by default.
 CFLAGS += -ftree-vrp
 
-# MCU Series is defined by the HAL package and doesn't need to be specified here
-C_DEFS = -D$(MCU_PACKAGE) -DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER -D$(MCU_VARIANT)
+# STM32 MCU series must be defined. See supervisor/linker.h
+C_DEFS = -D$(MCU_PACKAGE) -DUSE_HAL_DRIVER -DUSE_FULL_LL_DRIVER -D$(MCU_VARIANT) -DSTM32$(MCU_SERIES)
 
 CFLAGS += $(INC) -Werror -Wall -std=gnu11 -fshort-enums $(BASE_CFLAGS) $(C_DEFS) $(CFLAGS_MOD) $(COPT) -nostdlib -nostartfiles
 

--- a/ports/stm/supervisor/port.c
+++ b/ports/stm/supervisor/port.c
@@ -284,8 +284,9 @@ uint32_t *port_heap_get_bottom(void) {
     return &_ld_heap_start;
 }
 
+// heap memory can be set in SRAM and stack can be set in DTCM
 uint32_t *port_heap_get_top(void) {
-    return port_stack_get_limit();
+    return &_ld_heap_end;
 }
 
 uint32_t *port_stack_get_limit(void) {

--- a/supervisor/linker.h
+++ b/supervisor/linker.h
@@ -8,11 +8,16 @@
 
 #pragma once
 
-#if defined(IMXRT1XXX) || defined(FOMU) || defined(STM32H7) || defined(RASPBERRYPI)
+#if defined(IMXRT1XXX) || defined(FOMU) || defined(RASPBERRYPI)
 #define PLACE_IN_DTCM_DATA(name) name __attribute__((section(".dtcm_data." #name)))
 #define PLACE_IN_DTCM_BSS(name) name __attribute__((section(".dtcm_bss." #name)))
 // Don't inline ITCM functions because that may pull them out of ITCM into other sections.
 #define PLACE_IN_ITCM(name) __attribute__((section(".itcm." #name), noinline, aligned(4))) name
+#elif defined(STM32H7)
+#define PLACE_IN_DTCM_DATA(name) name __attribute__((section(".dtcm_data." #name)))
+#define PLACE_IN_DTCM_BSS(name) name __attribute__((section(".dtcm_bss." #name)))
+// using ITCM on the H7 generates hard fault exception
+#define PLACE_IN_ITCM(name) name
 #else
 #define PLACE_IN_DTCM_DATA(name) name
 #define PLACE_IN_DTCM_BSS(name) name


### PR DESCRIPTION
From this open issue https://github.com/adafruit/circuitpython/issues/5470 and discussions in the Adafruit discord server, it looks like the builds for the stm32H7 family have been broken for a while. 

Based on my tests, it seems the problem is using the ITCM memory -- it generates a hard fault at runtime. Using the default code placement with no ITCM allows CircuitPython to run correctly. 

I am still investigating what causes the hard fault -- help would be welcome -- but these changes are a temporary workaround to make the existing stm32H7 builds usable again. 