### PR TITLE
Use only DMA0 for PIO background read/write

### DIFF
--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -486,27 +486,13 @@ void __not_in_flash_func(isr_dma_0)(void) {
             dma->channels_to_load_mask |= mask;
             background_callback_add(&dma->callback, dma_callback_fun, (void *)dma);
         }
-        if (MP_STATE_PORT(background_pio)[i] != NULL) {
-            rp2pio_statemachine_obj_t *pio = MP_STATE_PORT(background_pio)[i];
+        if (MP_STATE_PORT(background_pio_read)[i] != NULL) {
+            rp2pio_statemachine_obj_t *pio = MP_STATE_PORT(background_pio_read)[i];
             rp2pio_statemachine_dma_complete_write(pio, i);
         }
-    }
-}
-
-void __not_in_flash_func(isr_dma_1)(void) {
-    for (size_t i = 0; i < NUM_DMA_CHANNELS; i++) {
-        uint32_t mask = 1 << i;
-        if ((dma_hw->intr & mask) == 0) {
-            continue;
-        }
-        // acknowledge interrupt early. Doing so late means that you could lose an
-        // interrupt if the buffer is very small and the DMA operation
-        // completed by the time callback_add() / dma_complete() returned. This
-        // affected PIO continuous write more than audio.
-        dma_hw->ints1 = mask;
-        if (MP_STATE_PORT(background_pio)[i] != NULL) {
-            rp2pio_statemachine_obj_t *pio = MP_STATE_PORT(background_pio)[i];
-            rp2pio_statemachine_dma_complete_read(pio, i);
+        if (MP_STATE_PORT(background_pio_write)[i] != NULL) {
+            rp2pio_statemachine_obj_t *pio = MP_STATE_PORT(background_pio_write)[i];
+            rp2pio_statemachine_dma_complete_write(pio, i);
         }
     }
 }

--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -488,7 +488,7 @@ void __not_in_flash_func(isr_dma_0)(void) {
         }
         if (MP_STATE_PORT(background_pio_read)[i] != NULL) {
             rp2pio_statemachine_obj_t *pio = MP_STATE_PORT(background_pio_read)[i];
-            rp2pio_statemachine_dma_complete_write(pio, i);
+            rp2pio_statemachine_dma_complete_read(pio, i);
         }
         if (MP_STATE_PORT(background_pio_write)[i] != NULL) {
             rp2pio_statemachine_obj_t *pio = MP_STATE_PORT(background_pio_write)[i];

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -96,7 +96,7 @@ static void rp2pio_statemachine_clear_dma_write(int pio_index, int sm) {
         if (!dma_hw->inte0) {
             irq_set_mask_enabled(1 << DMA_IRQ_0, false);
         }
-        MP_STATE_PORT(background_pio)[channel_write] = NULL;
+        MP_STATE_PORT(background_pio_write)[channel_write] = NULL;
         dma_channel_abort(channel_write);
         dma_channel_unclaim(channel_write);
     }
@@ -111,7 +111,7 @@ static void rp2pio_statemachine_clear_dma_read(int pio_index, int sm) {
         if (!dma_hw->inte0) {
             irq_set_mask_enabled(1 << DMA_IRQ_0, false);
         }
-        MP_STATE_PORT(background_pio)[channel_read] = NULL;
+        MP_STATE_PORT(background_pio_read)[channel_read] = NULL;
         dma_channel_abort(channel_read);
         dma_channel_unclaim(channel_read);
     }
@@ -1229,7 +1229,7 @@ bool common_hal_rp2pio_statemachine_background_write(rp2pio_statemachine_obj_t *
 
     // Acknowledge any previous pending interrupt
     dma_hw->ints0 |= 1u << channel_write;
-    MP_STATE_PORT(background_pio)[channel_write] = self;
+    MP_STATE_PORT(background_pio_write)[channel_write] = self;
     dma_hw->inte0 |= 1u << channel_write;
 
     irq_set_mask_enabled(1 << DMA_IRQ_0, true);
@@ -1393,9 +1393,9 @@ bool common_hal_rp2pio_statemachine_background_read(rp2pio_statemachine_obj_t *s
     common_hal_mcu_disable_interrupts();
     // Acknowledge any previous pending interrupt
     dma_hw->ints1 |= 1u << channel_read;
-    MP_STATE_PORT(background_pio)[channel_read] = self;
+    MP_STATE_PORT(background_pio_read)[channel_read] = self;
     dma_hw->inte1 |= 1u << channel_read;
-    irq_set_mask_enabled(1 << DMA_IRQ_1, true);
+    irq_set_mask_enabled(1 << DMA_IRQ_0, true);
     dma_start_channel_mask((1u << channel_read));
     common_hal_mcu_enable_interrupts();
 
@@ -1485,4 +1485,5 @@ mp_obj_t common_hal_rp2pio_statemachine_get_last_write(rp2pio_statemachine_obj_t
 
 // Use a compile-time constant for MP_REGISTER_POINTER so the preprocessor will
 // not split the expansion across multiple lines.
-MP_REGISTER_ROOT_POINTER(mp_obj_t background_pio[enum_NUM_DMA_CHANNELS]);
+MP_REGISTER_ROOT_POINTER(mp_obj_t background_pio_read[enum_NUM_DMA_CHANNELS]);
+MP_REGISTER_ROOT_POINTER(mp_obj_t background_pio_write[enum_NUM_DMA_CHANNELS]);

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -1392,9 +1392,9 @@ bool common_hal_rp2pio_statemachine_background_read(rp2pio_statemachine_obj_t *s
 
     common_hal_mcu_disable_interrupts();
     // Acknowledge any previous pending interrupt
-    dma_hw->ints1 |= 1u << channel_read;
+    dma_hw->ints0 |= 1u << channel_read;
     MP_STATE_PORT(background_pio_read)[channel_read] = self;
-    dma_hw->inte1 |= 1u << channel_read;
+    dma_hw->inte0 |= 1u << channel_read;
     irq_set_mask_enabled(1 << DMA_IRQ_0, true);
     dma_start_channel_mask((1u << channel_read));
     common_hal_mcu_enable_interrupts();


### PR DESCRIPTION
- Fixes #9868

Changes PIO background read/write to use only DMA0, not DMA1. This is a minimal change that does not change the current use of a static IRQ handler in `ports/raspberrypi/audio_dma.c`. It reverts to using only DMA0, and uses two `background_pio...` arrays to distinguish between read and write. `picodvi` now works again.

If this works, then I can explore using `irq_add_shared_handler()` as discussed in #9868.

@timchinowsky I tried to test this using a loopback test from https://github.com/timchinowsky/tac5/blob/main/README.md. But those tests as written use a `test=` arg which is no longer present. Could you test this (and update the loopback tests)? Thanks.