### PR TITLE
Handle errors during audio DMA playback setup for RP2 ports 

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -603,6 +603,11 @@ msgstr ""
 msgid "Audio conversion not implemented"
 msgstr ""
 
+#: ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+#: ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+msgid "Audio source error"
+msgstr ""
+
 #: shared-bindings/wifi/Radio.c
 msgid "AuthMode.OPEN is not used with password"
 msgstr ""
@@ -2334,6 +2339,7 @@ msgstr ""
 
 #: ports/espressif/boards/adafruit_feather_esp32c6_4mbflash_nopsram/mpconfigboard.h
 #: ports/espressif/boards/adafruit_itsybitsy_esp32/mpconfigboard.h
+#: ports/espressif/boards/waveshare_esp32_c6_lcd_1_47/mpconfigboard.h
 msgid "You pressed the BOOT button at start up."
 msgstr ""
 

--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -159,7 +159,6 @@ static void audio_dma_load_next_block(audio_dma_t *dma, size_t buffer_idx) {
                 !dma_channel_is_busy(dma->channel[1])) {
                 // No data has been read, and both DMA channels have now finished, so it's safe to stop.
                 audio_dma_stop(dma);
-                assert(dma->channel[buffer_idx] < NUM_DMA_CHANNELS);
             }
         }
     }

--- a/ports/raspberrypi/audio_dma.h
+++ b/ports/raspberrypi/audio_dma.h
@@ -11,6 +11,13 @@
 
 #include "src/rp2_common/hardware_dma/include/hardware/dma.h"
 
+typedef enum {
+    AUDIO_DMA_OK,
+    AUDIO_DMA_DMA_BUSY,
+    AUDIO_DMA_MEMORY_ERROR,
+    AUDIO_DMA_SOURCE_ERROR,
+} audio_dma_result;
+
 typedef struct {
     mp_obj_t sample;
     uint8_t *buffer[2];
@@ -24,6 +31,7 @@ typedef struct {
     uint8_t sample_spacing;
     uint8_t output_resolution; // in bits
     uint8_t sample_resolution; // in bits
+    audio_dma_result dma_result;
     bool loop;
     bool single_channel_output;
     bool signed_to_unsigned;
@@ -32,13 +40,6 @@ typedef struct {
     bool playing_in_progress;
     bool swap_channel;
 } audio_dma_t;
-
-typedef enum {
-    AUDIO_DMA_OK,
-    AUDIO_DMA_DMA_BUSY,
-    AUDIO_DMA_MEMORY_ERROR,
-} audio_dma_result;
-
 
 void audio_dma_init(audio_dma_t *dma);
 void audio_dma_deinit(audio_dma_t *dma);

--- a/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+++ b/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
@@ -274,6 +274,9 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t *self,
     } else if (result == AUDIO_DMA_MEMORY_ERROR) {
         common_hal_audiobusio_i2sout_stop(self);
         mp_raise_RuntimeError(MP_ERROR_TEXT("Unable to allocate buffers for signed conversion"));
+    } else if (result == AUDIO_DMA_SOURCE_ERROR) {
+        common_hal_audiobusio_i2sout_stop(self);
+        mp_raise_RuntimeError(MP_ERROR_TEXT("Audio source error"));
     }
 
     self->playing = true;

--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -214,6 +214,10 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, 
         common_hal_audiopwmio_pwmaudioout_stop(self);
         mp_raise_RuntimeError(MP_ERROR_TEXT("Unable to allocate buffers for signed conversion"));
     }
+    if (result == AUDIO_DMA_SOURCE_ERROR) {
+        common_hal_audiopwmio_pwmaudioout_stop(self);
+        mp_raise_RuntimeError(MP_ERROR_TEXT("Audio source error"));
+    }
     // OK! We got all of the resources we need and dma is ready.
 }
 


### PR DESCRIPTION
Fixes #9983.

Add handling for errors that may occur during setup of an audio DMA player. `audio_dma_setup_playback()` calls `audio_dma_load_next_block()` to fill one or two buffers with audio source data. This PR adds preservation of the error indication in the new `dma_result` field in `audio_dma_t` and examines it in `audio_dma_setup_playback()`. If an error indication is present, shuts down the player and throws an "Audio source error".

For #9983, the error indication occurs frequently due to the MP3 decoder being unable to synchronize with the incoming MP3 stream. The app can now retry (sometimes a few times) to synchronize with the stream.  