### PR TITLE
ISSUE_TEMPLATES/bug_report.yml: ask for board name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: 🐞 Bug Report
-description: Create a bug report to help us improve
+description: Create a bug report to help us improve CircuitPython
 labels:
   - bug
 body:
@@ -7,14 +7,14 @@ body:
     attributes:
       value: >-
         Thanks for testing out CircuitPython! Now that you have encountered a
-        bug... you can file a report for it.
+        bug, you can file a report for it.
   - type: textarea
     id: firmware
     attributes:
-      label: CircuitPython version
+      label: CircuitPython version and board name
       description: >-
-        Include the version of CircuitPython you're running. You can see it in
-        the `boot_out.txt` file, as well as in the `REPL`.
+        Include the version of CircuitPython you're running and the name of the board you're using.
+        You can find this information in the `boot_out.txt` file, as well as in the REPL.
       placeholder: Adafruit CircuitPython 6.2.0 on 2021-03-01; Raspberry Pi Pico with rp2040
       render: python
     validations:
@@ -23,7 +23,7 @@ body:
     id: code
     attributes:
       label: Code/REPL
-      description: This is automatically rendered as Python, so no need for backticks.
+      description: Code here is automatically rendered as Python, so you don't need to include backticks.
       placeholder: |
         import busio, bitbangio
         i2c = bitbangio.I2C(board.GP1, board.GP0)


### PR DESCRIPTION
The bug report issue template doesn't explicitly ask for the board name. Do that. (I've seen several reports recently where I had to ask for the board name.)

I also touched up the wording in a few other places.