### PR TITLE
raspberrypi: Honor the requested offset= of a StateMachine

### DIFF
--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -322,7 +322,7 @@ bool rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
     pio_program_t program_struct = {
         .instructions = (uint16_t *)program,
         .length = program_len,
-        .origin = -1
+        .origin = offset,
     };
     PIO pio;
     uint state_machine;


### PR DESCRIPTION
The logic to do this was lost in my recent re-organization. Happily, just setting this field appropriately fixes it.