### PR TITLE
require specific ruff version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ requests-cache
 polib
 
 # For pre-commit
-ruff
+ruff==0.9.4 # ruff version must exactly match pre-commit-config.yaml
 pyyaml
 pre-commit
 micropython-uncrustify


### PR DESCRIPTION
I was having trouble with pre-commit always finding files to change, because the ruff run during two different steps of pre-commit were different.

Installing the requirements with `pip install -r requirements-dev.txt` didn't resolve the problem, because the ruff version was not pinned. So, pin it now.