### PR TITLE
ci_set_matrix: the `boards` set needs to be a copy

### DIFF
--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -187,7 +187,10 @@ def set_boards(build_all: bool):
             # As a (nearly) last resort, for some certain files, we compute the settings from the
             # makefile for each board and determine whether to build them that way
             if file.startswith("frozen") or file.startswith("supervisor") or module_matches:
-                boards = port_to_board[port] if port else all_board_ids
+                # Take a copy, because we remove items from it below. For
+                # instance, if we remove items from, say, all_board_ids, then
+                # the logic to build all boards breaks.
+                boards = set(port_to_board[port] if port else all_board_ids)
 
                 # Zephyr boards don't use make, so build them and don't compute their settings.
                 for board in port_to_board["zephyr-cp"]:


### PR DESCRIPTION
Recently in #10026 this script was altered so that sometimes items are removed from `boards`. However, this could have side effects. For instance, when a file like `shared/runtime/context_manager_helpers.c` is modified, it doesn't match any per-port or per-board rule so we execute `boards_to_build = all_board_ids`. But if the object `all_board_ids` refers to has been modified by `boards.remove(board)` in an earlier iteration, then we don't end up really building all boards.

Noticed during development of #10040.