### PR TITLE
raspberrypi: Don't block DMA_IRQ_1 during common_hal_mcu_disable_interrupts

### DIFF
--- a/ports/raspberrypi/common-hal/microcontroller/__init__.c
+++ b/ports/raspberrypi/common-hal/microcontroller/__init__.c
@@ -23,12 +23,14 @@
 #include "src/rp2_common/hardware_sync/include/hardware/sync.h"
 
 #include "hardware/watchdog.h"
+#include "hardware/irq.h"
 
 void common_hal_mcu_delay_us(uint32_t delay) {
     mp_hal_delay_us(delay);
 }
 
 volatile uint32_t nesting_count = 0;
+#ifdef PICO_RP2040
 void common_hal_mcu_disable_interrupts(void) {
     // We don't use save_and_disable_interrupts() from the sdk because we don't want to worry about PRIMASK.
     // This is what we do on the SAMD21 via CMSIS.
@@ -48,6 +50,38 @@ void common_hal_mcu_enable_interrupts(void) {
     __dmb();
     asm volatile ("cpsie i" : : : "memory");
 }
+#else
+#include "src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Include/RP2350.h"
+#define PICO_ELEVATED_IRQ_PRIORITY (0x60) // between PICO_DEFAULT and PIOCO_HIGHEST_IRQ_PRIORITY
+static uint32_t oldBasePri = 0; // 0 (default) masks nothing, other values mask equal-or-larger priority values
+void common_hal_mcu_disable_interrupts(void) {
+    if (nesting_count == 0) {
+        // We must keep DMA_IRQ_1 (reserved for pico dvi) enabled at all times,
+        // including during flash writes. Do this by setting the priority mask (BASEPRI
+        // register).
+        // grab old base priority
+        oldBasePri = __get_BASEPRI();
+        // and set the new one
+        __set_BASEPRI_MAX(PICO_ELEVATED_IRQ_PRIORITY);
+        __isb(); // Instruction synchronization barrier
+    }
+    nesting_count++;
+}
+
+void common_hal_mcu_enable_interrupts(void) {
+    uint32_t my_interrupts = save_and_disable_interrupts();
+    if (nesting_count == 0) {
+        reset_into_safe_mode(SAFE_MODE_INTERRUPT_ERROR);
+    }
+    nesting_count--;
+    if (nesting_count == 0) {
+        // return to the old priority setting
+        __set_BASEPRI(oldBasePri);
+        __isb(); // Instruction synchronization barrier
+    }
+    restore_interrupts(my_interrupts);
+}
+#endif
 
 static bool next_reset_to_bootloader = false;
 

--- a/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2350.c
+++ b/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2350.c
@@ -430,6 +430,7 @@ void common_hal_picodvi_framebuffer_construct(picodvi_framebuffer_obj_t *self,
     dma_hw->inte1 = (1u << self->dma_pixel_channel);
     irq_set_exclusive_handler(DMA_IRQ_1, dma_irq_handler);
     irq_set_enabled(DMA_IRQ_1, true);
+    irq_set_priority(DMA_IRQ_1, PICO_HIGHEST_IRQ_PRIORITY);
 
     bus_ctrl_hw->priority = BUSCTRL_BUS_PRIORITY_DMA_W_BITS | BUSCTRL_BUS_PRIORITY_DMA_R_BITS;
 


### PR DESCRIPTION
doing so causes the picodvi display on rp2350 to blank, because this irq is handed by cpu0.

Instead, use the BASEPRI register so that common_hal_mcu_disable_interrupts masks interrupts with lower priority (higher priority values) than PICO_ELEVATED_IRQ_PRIORITY. This has the effect of masking "regular" interrupts while still letting this priority interrupt occur.

port_idle_until_interrupt now needs to directly manipulate the interrupt enable state, because an interrupt masked via BASEPRI also does not cause the WFI instruction to complete. Since I don't know that `nesting_count==0` is a precondition of `port_idle_until_interrupt`, also set and restore BASEPRI before WFI.

Testing performed: display on metro rp2350 doesn't blank while writing to flash. neopixel status LED still works, though that's not a comprehensive test that DMA is still working properly.

Closes #10031