### PR TITLE
Restore console_uart_printf, fix use of __ZEPHYR__.

### DIFF
--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -524,3 +524,15 @@ void print_hexdump(const mp_print_t *printer, const char *prefix, const uint8_t 
         mp_printf(printer, "\n");
     }
 }
+
+int console_uart_printf(const char *fmt, ...) {
+    #if CIRCUITPY_CONSOLE_UART
+    va_list args;
+    va_start(args, fmt);
+    int ret = mp_vprintf(&console_uart_print, fmt, args);
+    va_end(args);
+    return ret;
+    #else
+    return 0;
+    #endif
+}

--- a/supervisor/shared/serial.h
+++ b/supervisor/shared/serial.h
@@ -50,4 +50,6 @@ void board_serial_write_substring(const char *text, uint32_t length);
 
 extern const mp_print_t console_uart_print;
 
+int console_uart_printf(const char *fmt, ...);
+
 void print_hexdump(const mp_print_t *printer, const char *prefix, const uint8_t *buf, size_t len);

--- a/supervisor/shared/usb/tusb_config.h
+++ b/supervisor/shared/usb/tusb_config.h
@@ -55,7 +55,7 @@ extern "C" {
 // When debugging TinyUSB, only output to the console UART link.
 #if CIRCUITPY_DEBUG_TINYUSB > 0 && defined(CIRCUITPY_CONSOLE_UART)
 #define CFG_TUSB_DEBUG              CIRCUITPY_DEBUG_TINYUSB
-#if __ZEPHYR__
+#ifdef __ZEPHYR__
 #define CFG_TUSB_DEBUG_PRINTF       zephyr_printk
 #else
 #define CFG_TUSB_DEBUG_PRINTF       console_uart_printf


### PR DESCRIPTION
Restores `console_uart_printf` and fixes usage of `__ZEPHYR__`.