### PR TITLE
Update Framebuffer_RP2350.c to use correct screen height for 640x480

### DIFF
--- a/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2350.c
+++ b/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2350.c
@@ -134,7 +134,7 @@ bool common_hal_picodvi_framebuffer_preflight(
     mp_uint_t color_depth) {
 
     // for each supported resolution, check the color depth is supported
-    if (width == 640 && height == 640) {
+    if (width == 640 && height == 480) {
         return color_depth == 1 || color_depth == 2 || color_depth == 4 || color_depth == 8;
     }
     if (width == 320 && height == 240) {


### PR DESCRIPTION
Corrected height value which had been incorrectly set at 640 not 480.