### PR TITLE
Fix m_realloc/m_free when MICROPY_MALLOC_USES_ALLOCATED_SIZE is set

### DIFF
--- a/ports/atmel-samd/audio_dma.c
+++ b/ports/atmel-samd/audio_dma.c
@@ -200,15 +200,27 @@ audio_dma_result audio_dma_setup_playback(audio_dma_t *dma,
     }
 
 
-    dma->buffer[0] = (uint8_t *)m_realloc(dma->buffer[0], max_buffer_length);
+    dma->buffer[0] = (uint8_t *)m_realloc(dma->buffer[0],
+        #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+        dma->buffer_length[0], // Old size
+        #endif
+        max_buffer_length);
+
     dma->buffer_length[0] = max_buffer_length;
+
     if (dma->buffer[0] == NULL) {
         return AUDIO_DMA_MEMORY_ERROR;
     }
 
     if (!dma->single_buffer) {
-        dma->buffer[1] = (uint8_t *)m_realloc(dma->buffer[1], max_buffer_length);
+        dma->buffer[1] = (uint8_t *)m_realloc(dma->buffer[1],
+            #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+            dma->buffer_length[1], // Old size
+            #endif
+            max_buffer_length);
+
         dma->buffer_length[1] = max_buffer_length;
+
         if (dma->buffer[1] == NULL) {
             return AUDIO_DMA_MEMORY_ERROR;
         }

--- a/ports/nordic/common-hal/audiopwmio/PWMAudioOut.h
+++ b/ports/nordic/common-hal/audiopwmio/PWMAudioOut.h
@@ -12,7 +12,11 @@ typedef struct {
     mp_obj_base_t base;
     mp_obj_t *sample;
     NRF_PWM_Type *pwm;
+
     uint16_t *buffers[2];
+    #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+    size_t buffer_size[2]; // Keeps track of allocated size
+    #endif
 
     uint16_t quiescent_value;
     uint16_t scale;

--- a/ports/stm/common-hal/audiopwmio/PWMAudioOut.h
+++ b/ports/stm/common-hal/audiopwmio/PWMAudioOut.h
@@ -14,6 +14,9 @@ typedef struct {
     uint16_t quiescent_value;
 
     uint16_t *buffer[2];
+    #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+    uint16_t buffer_size[2]; // Keeps track of allocated size
+    #endif
     uint16_t buffer_length[2];
     uint16_t buffer_ptr[2];
 

--- a/ports/zephyr-cp/common-hal/wifi/ScannedNetworks.c
+++ b/ports/zephyr-cp/common-hal/wifi/ScannedNetworks.c
@@ -116,7 +116,12 @@ void wifi_scannednetworks_deinit(wifi_scannednetworks_obj_t *self) {
     // Free any results we don't need.
     while (!k_fifo_is_empty(&self->fifo)) {
         wifi_network_obj_t *entry = k_fifo_get(&self->fifo, K_NO_WAIT);
+
+        #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+        m_free(entry, sizeof(wifi_network_obj_t));
+        #else
         m_free(entry);
+        #endif
     }
     wifi_scannednetworks_done(self);
 }

--- a/shared-module/atexit/__init__.c
+++ b/shared-module/atexit/__init__.c
@@ -12,8 +12,13 @@ static size_t callback_len = 0;
 static atexit_callback_t *callback = NULL;
 
 void atexit_reset(void) {
-    callback_len = 0;
+    #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+    m_free(callback, callback_len * sizeof(atexit_callback_t));
+    #else
     m_free(callback);
+    #endif
+
+    callback_len = 0;
     callback = NULL;
 }
 
@@ -39,7 +44,13 @@ void shared_module_atexit_register(mp_obj_t *func, size_t n_args, const mp_obj_t
         cb.args[i] = kw_args->table[cb.n_kw].key;
         cb.args[i += 1] = kw_args->table[cb.n_kw].value;
     }
-    callback = (atexit_callback_t *)m_realloc(callback, (callback_len + 1) * sizeof(cb));
+
+    callback = (atexit_callback_t *)m_realloc(callback,
+        #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+        callback_len * sizeof(cb), // Old size
+        #endif
+        (callback_len + 1) * sizeof(cb));
+
     callback[callback_len++] = cb;
 }
 

--- a/shared-module/displayio/OnDiskBitmap.c
+++ b/shared-module/displayio/OnDiskBitmap.c
@@ -95,7 +95,12 @@ void common_hal_displayio_ondiskbitmap_construct(displayio_ondiskbitmap_t *self,
             for (uint16_t i = 0; i < number_of_colors; i++) {
                 common_hal_displayio_palette_set_color(palette, i, palette_data[i]);
             }
+
+            #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+            m_free(palette_data, palette_size);
+            #else
             m_free(palette_data);
+            #endif
         } else {
             common_hal_displayio_palette_set_color(palette, 0, 0x0);
             common_hal_displayio_palette_set_color(palette, 1, 0xffffff);

--- a/shared-module/keypad/EventQueue.c
+++ b/shared-module/keypad/EventQueue.c
@@ -39,7 +39,13 @@ mp_obj_t common_hal_keypad_eventqueue_get(keypad_eventqueue_obj_t *self) {
     if (result) {
         return event;
     }
+
+    #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+    m_free(event, sizeof(keypad_event_obj_t));
+    #else
     m_free(event);
+    #endif
+
     return MP_ROM_NONE;
 }
 


### PR DESCRIPTION
I wanted to build CircuitPython with `MICROPY_MEM_STATS` enabled to debug some out of memory issues I had, but encountered a few compilation errors.

`MICROPY_MEM_STATS` requires `MICROPY_MALLOC_USES_ALLOCATED_SIZE` to be set, which in turn causes `m_realloc`, `m_realloc_maybe` and `m_free` to take an extra argument: the previously allocated size.

I fixed what I could with my limited knowledge of that code. Some places of the code still lack a proper support for `MICROPY_MALLOC_USES_ALLOCATED_SIZE`.
