### PR TITLE
web_workflow.c: check for empty SSID before starting web workflow

### DIFF
--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -243,7 +243,7 @@ bool supervisor_start_web_workflow(void) {
     char password[64];
 
     os_getenv_err_t result = common_hal_os_getenv_str("CIRCUITPY_WIFI_SSID", ssid, sizeof(ssid));
-    if (result != GETENV_OK) {
+    if (result != GETENV_OK || strlen(ssid) < 1) {
         return false;
     }
 


### PR DESCRIPTION
If the `CIRCUITPY_WIFI_SSID=""` in `settings.toml`, the web workflow will get an internal exception when trying to start, and will raise an exception that causes a safe mode, because there is no VM to help raising the exception. I'm assuming this starts a startup-loop, because CIRCUITPY never appears.

It is kind of easy to get `CIRCUITPY_WIFI_SSID=""` if you don't give an SSID when using the part of the web installer that adds credentials.

Fix is: don't try to start the web workflow if the SSID is empty.

In the long run:
Other internal exceptions might also cause this problem. The question is when to try starting the web workflow. We could prevent repeated failing attempts. We could also not start it when certain safemodes happen.

Tested on a QT PY ESP32-S3 with an empty SSID.