### PR TITLE
Add support for VT100 terminal color ESC sequences

### DIFF
--- a/shared-bindings/terminalio/Terminal.c
+++ b/shared-bindings/terminalio/Terminal.c
@@ -33,6 +33,20 @@
 //|     * ``ESC [ #### D`` - Move the cursor to the left by ####
 //|     * ``ESC [ 2 J`` - Erase the entire display
 //|     * ``ESC [ nnnn ; mmmm H`` - Move the cursor to mmmm, nnnn.
+//|     * ``ESC [ nn m`` - Set the terminal display attributes.
+//|     * ``ESC [ nn ; nn m`` - Set the terminal display attributes.
+//|
+//|     Supported Display attributes:
+//|     0 - Reset all attributes
+//|     Foreground Colors    Background Colors
+//|     30 - Black           40 - Black
+//|     31 - Red             41 - Red
+//|     32 - Green           42 - Green
+//|     33 - Yellow          43 - Yellow
+//|     34 - Blue            44 - Blue
+//|     35 - Magenta         45 - Magenta
+//|     36 - Cyan            46 - Cyan
+//|     37 - White           47 - White
 //|     """
 //|
 //|     def __init__(


### PR DESCRIPTION
On Show and Tell @FoamyGuy demonstrated how he was able to modify the terminal font color which got me thinking that the same functionality could be used to enable the VT100 Escape sequences for setting the terminal background and foreground. This PR adds support for all the color attributes as well as the reset to default sequence.

I used the following code.py file to test the functionality:
```py
ans = ''
while ans.upper() != 'Q':
    ans = input('Enter ESC sequence: ')
    print(chr(27)+ans)
```
Entering `[44m` at the prompt sets the background to blue and entering `[30;41m` will set the foreground to black and the background to red.

Although many terminal programs run from host computers will respond to the same escape sequences this PR has nothing to do with controlling the attributes of a terminal session from a host computer, rather it sets the attributes on an attached display like a TFT Featherwing. If the board doesn't bring up the display automatically, you may need to add the initialization code to the code.py file as well.