### PR TITLE
Add basic VT100 scrolling

### DIFF
--- a/shared-bindings/terminalio/Terminal.c
+++ b/shared-bindings/terminalio/Terminal.c
@@ -33,8 +33,12 @@
 //|     * ``ESC [ #### D`` - Move the cursor to the left by ####
 //|     * ``ESC [ 2 J`` - Erase the entire display
 //|     * ``ESC [ nnnn ; mmmm H`` - Move the cursor to mmmm, nnnn.
-//|     * ``ESC [ nn m`` - Set the terminal display attributes.
-//|     * ``ESC [ nn ; nn m`` - Set the terminal display attributes.
+//|     * ``ESC [ H`` - Move the cursor to 0,0.
+//|     * ``ESC M`` - Move the cursor up one line, scrolling if necessary.
+//|     * ``ESC D`` - Move the cursor down one line, scrolling if necessary.
+//|     * ``ESC [ ## m`` - Set the terminal display attributes.
+//|     * ``ESC [ ## ; ## m`` - Set the terminal display attributes.
+//|     * ``ESC [ ## ; ## ; ## m`` - Set the terminal display attributes.
 //|
 //|     Supported Display attributes:
 //|     0 - Reset all attributes


### PR DESCRIPTION
This PR adds 

- Basic VT100 scrolling (full screen only, I'm looking at scrolling range but it's fighting me)
- A place holder for the VT100 cursor On/Off sequence
     (thinking may be useful after #10102)
- Support for a third parameter passed to the screen attribute
     (allows for somewhat common reset/foreground/background sequence)
- Add `ESC[H` which does the same thing as `ESC[0;0H`