### PR TITLE
Add typing shorthand for display-related types

### DIFF
--- a/shared-bindings/displayio/__init__.c
+++ b/shared-bindings/displayio/__init__.c
@@ -45,6 +45,23 @@
 //| """
 //|
 
+//| AnyDisplayBus: fourwire.FourWire | i2cdisplaybus.I2cDisplayBus
+//| """Type-checking shorthand for any kind of display bus. Not actually defined in CircuitPython."""
+//|
+//| AnyFramebuffer: (
+//|     rgbmatrix.RGBMatrix
+//|     | is31fl3741.FrameBuffer
+//|     | sharpdisplay.SharpMemoryFramebuffer
+//|     | videocore.Framebuffer
+//|     | picodvi.Framebuffer
+//|     | aurora_epaper.AuroraMemoryFramebuffer
+//| )
+//| """Type-checking shorthand for any kind of framebuffer. Not actually defined in CircuitPython."""
+//|
+//| AnyDisplay: (
+//|     busdisplay.BusDisplay | epaperdisplay.EPaperDisplay | framebufferio.FrameBufferDisplay
+//| )
+//| """Type-checking shorthand for any kind of display. Not actually defined in CircuitPython."""
 //| CIRCUITPYTHON_TERMINAL: Group
 //| """The `displayio.Group` that is the displayed serial terminal (REPL)."""
 //|

--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -208,7 +208,7 @@ MP_PROPERTY_GETSET(supervisor_runtime_rgb_status_brightness_obj,
     (mp_obj_t)&supervisor_runtime_set_rgb_status_brightness_obj);
 
 #if CIRCUITPY_DISPLAYIO
-//|     display: Any
+//|     display: displayio.AnyDisplay | None
 //|     """The primary configured displayio display, if any.
 //|
 //|     If the board has a display that is hard coded, or that was explicitly set

--- a/shared-bindings/supervisor/Runtime.c
+++ b/shared-bindings/supervisor/Runtime.c
@@ -213,7 +213,7 @@ MP_PROPERTY_GETSET(supervisor_runtime_rgb_status_brightness_obj,
 //|
 //|     If the board has a display that is hard coded, or that was explicitly set
 //|     in boot.py or code.py (including a previous run of code.py), it is
-//|     available here until it is released with ``displayio.releasee_displays()``.
+//|     available here until it is released with ``displayio.release_displays()``.
 //|
 //|     The display can be of any supported display type, such as `busdisplay.BusDisplay`.
 //|


### PR DESCRIPTION
.. and use it to give a better type hint for supervisor.runtime.display.