### PR TITLE
Fix custom build workflow

### DIFF
--- a/.github/workflows/build-board-custom.yml
+++ b/.github/workflows/build-board-custom.yml
@@ -73,11 +73,18 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
+    - name: Board to port
+      id: board-to-port
+      run: |
+        PORT=$(python tools/board_to_port.py "${{ inputs.board }}")
+        echo "port=$PORT" >> $GITHUB_OUTPUT
+      shell: bash
     - name: Set up port
       id: set-up-port
       uses: ./.github/actions/deps/ports
       with:
         board: ${{ inputs.board }}
+        port: ${{ steps.board-to-port.outputs.port }}
     - name: Set up submodules
       id: set-up-submodules
       uses: ./.github/actions/deps/submodules
@@ -88,7 +95,7 @@ jobs:
       uses: ./.github/actions/deps/external
       with:
         action: cache
-        port: ${{ steps.set-up-port.outputs.port }}
+        port: ${{ steps.board-to-port.outputs.port }}
     - name: Set up mpy-cross
       if: steps.set-up-submodules.outputs.frozen == 'True'
       uses: ./.github/actions/mpy_cross
@@ -115,9 +122,9 @@ jobs:
         FLAGS: ${{ inputs.flags }}
         DEBUG: ${{ inputs.debug && '1' || '0' }}
       run: make -j4 $FLAGS BOARD="$BOARD" DEBUG=$DEBUG TRANSLATION="$TRANSLATION"
-      working-directory: ports/${{ steps.set-up-port.outputs.port }}
+      working-directory: ports/${{ steps.board-to-port.outputs.port }}
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.board }}-${{ inputs.language }}-${{ inputs.version }}${{ inputs.flags != '' && '-custom' || '' }}${{ inputs.debug && '-debug' || '' }}
-        path: ports/${{ steps.set-up-port.outputs.port }}/build-${{ inputs.board }}/firmware.*
+        path: ports/${{ steps.board-to-port.outputs.port }}/build-${{ inputs.board }}/firmware.*

--- a/tools/board_to_port.py
+++ b/tools/board_to_port.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025 CircuitPython contributors (https://github.com/adafruit/circuitpython/graphs/contributors)
+#
+# SPDX-License-Identifier: MIT
+
+import sys
+from pathlib import Path
+
+docs = Path(__file__).parent.parent / "docs"
+sys.path.append(str(docs))
+from shared_bindings_matrix import get_board_mapping
+
+board = sys.argv[1]
+
+board_mapping = get_board_mapping()
+if board in board_mapping:
+    board_info = board_mapping[board]
+    print(board_info["port"])
+    sys.exit(0)
+
+raise ValueError(f"No port directory associated with the board tag given {board}.")


### PR DESCRIPTION
fixes #10117 
Adds a python script to return the port directory name from the board name.
Uses that in a step of the `Build board (custom)` workflow without touching anything else.

Testing on my fork (selecting the correct branch at every step) it seems to work. Made a build of the Seeed Studio Xiao with pulseio by removing usb_midi.
https://github.com/Neradoc/circuitpython/actions/runs/13740357241