### PR TITLE
Add missing PY_FUNCTION_ATTRS and PY_REVERSE_SPECIAL_METHODS

### DIFF
--- a/ports/broadcom/mpconfigport.h
+++ b/ports/broadcom/mpconfigport.h
@@ -15,6 +15,7 @@
 #define MICROPY_PY_SYS_PLATFORM                     "BROADCOM"
 #define MICROPY_PY_BUILTINS_NOTIMPLEMENTED          (1)
 #define MICROPY_PY_FUNCTION_ATTRS                   (1)
+#define MICROPY_PY_REVERSE_SPECIAL_METHODS          (1)
 #if BCM_VERSION == 2837 || BCM_VERSION == 2711
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_A)
 #elif BCM_VERSION == 2835

--- a/ports/cxd56/mpconfigport.h
+++ b/ports/cxd56/mpconfigport.h
@@ -8,6 +8,9 @@
 
 #define MICROPY_PY_SYS_PLATFORM                 "CXD56"
 
+#define MICROPY_PY_FUNCTION_ATTRS                (1)
+#define MICROPY_PY_REVERSE_SPECIAL_METHODS       (1)
+
 // 64kiB stack
 #define CIRCUITPY_DEFAULT_STACK_SIZE            (0x10000)
 

--- a/ports/espressif/mpconfigport.h
+++ b/ports/espressif/mpconfigport.h
@@ -22,6 +22,9 @@
 #define MICROPY_NLR_SETJMP                  (1)
 #define CIRCUITPY_DEFAULT_STACK_SIZE        0x6000
 
+#define MICROPY_PY_FUNCTION_ATTRS           (1)
+#define MICROPY_PY_REVERSE_SPECIAL_METHODS  (1)
+
 // Nearly all boards have this because it is used to enter the ROM bootloader.
 #ifndef CIRCUITPY_BOOT_BUTTON
   #if defined(CONFIG_IDF_TARGET_ESP32C2) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32H2)

--- a/ports/litex/mpconfigport.h
+++ b/ports/litex/mpconfigport.h
@@ -9,6 +9,7 @@
 
 #define CIRCUITPY_INTERNAL_NVM_SIZE         (0)
 #define MICROPY_NLR_THUMB                   (0)
+#define MICROPY_PY_FUNCTION_ATTRS           (1)
 #define MICROPY_PY_REVERSE_SPECIAL_METHODS  (1)
 
 #include "py/circuitpy_mpconfig.h"

--- a/ports/raspberrypi/mpconfigport.h
+++ b/ports/raspberrypi/mpconfigport.h
@@ -16,6 +16,9 @@
 #define MICROPY_PY_SYS_PLATFORM             "RP2350"
 #endif
 
+#define MICROPY_PY_FUNCTION_ATTRS           (1)
+#define MICROPY_PY_REVERSE_SPECIAL_METHODS  (1)
+
 // Setting a non-default value also requires a non-default link.ld
 #ifndef CIRCUITPY_FIRMWARE_SIZE
 #define CIRCUITPY_FIRMWARE_SIZE (1020 * 1024)

--- a/ports/renode/mpconfigport.h
+++ b/ports/renode/mpconfigport.h
@@ -8,6 +8,9 @@
 
 #define MICROPY_PY_SYS_PLATFORM             "Renode"
 
+#define MICROPY_PY_FUNCTION_ATTRS           (1)
+#define MICROPY_PY_REVERSE_SPECIAL_METHODS  (1)
+
 #define MICROPY_USE_INTERNAL_PRINTF         (1)
 
 // This also includes mpconfigboard.h.


### PR DESCRIPTION
This PR resolves issue #10132. In addition to PY_FUNCTION_ATTRS it also adds PY_REVERSE_SPECIAL_METHODS which was similarly missing from several ports. The ports affected are:
- broadcom
- cxd56
- espressif
- litex
- raspberrypi
- renode