### PR TITLE
Remove CIRCUITPY_8_9_WARNINGS and its usage.

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -17,12 +17,6 @@
 // Always 1: defined in circuitpy_mpconfig.mk
 // #define CIRCUITPY (1)
 
-// Can be removed once CircuitPython 10 is released.
-// Print warnings or not about deprecated names. See objmodule.c.
-#ifndef CIRCUITPY_8_9_WARNINGS
-#define CIRCUITPY_8_9_WARNINGS (0)
-#endif
-
 // REPR_C encodes qstrs, 31-bit ints, and 30-bit floats in a single 32-bit word.
 #ifndef MICROPY_OBJ_REPR
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -67,33 +67,6 @@ static void module_attr_try_delegation(mp_obj_t self_in, qstr attr, mp_obj_t *de
 static void module_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     mp_obj_module_t *self = MP_OBJ_TO_PTR(self_in);
     if (dest[0] == MP_OBJ_NULL) {
-        // CIRCUITPY-CHANGE
-        #if CIRCUITPY_8_9_WARNINGS && CIRCUITPY_DISPLAYIO && CIRCUITPY_WARNINGS
-        if (self == &displayio_module) {
-            #if CIRCUITPY_BUSDISPLAY
-            if (attr == MP_QSTR_Display) {
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q moved from %q to %q"), MP_QSTR_Display, MP_QSTR_displayio, MP_QSTR_busdisplay);
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q renamed %q"), MP_QSTR_Display, MP_QSTR_BusDisplay);
-            }
-            #endif
-            #if CIRCUITPY_EPAPERDISPLAY
-            if (attr == MP_QSTR_EPaperDisplay) {
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q moved from %q to %q"), MP_QSTR_EPaperDisplay, MP_QSTR_displayio, MP_QSTR_epaperdisplay);
-            }
-            #endif
-            #if CIRCUITPY_FOURWIRE
-            if (attr == MP_QSTR_FourWire) {
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q moved from %q to %q"), MP_QSTR_FourWire, MP_QSTR_displayio, MP_QSTR_fourwire);
-            }
-            #endif
-            #if CIRCUITPY_I2CDISPLAYBUS
-            if (attr == MP_QSTR_I2CDisplay) {
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q moved from %q to %q"), MP_QSTR_I2CDisplay, MP_QSTR_displayio, MP_QSTR_i2cdisplaybus);
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q renamed %q"), MP_QSTR_I2CDisplay, MP_QSTR_I2CDisplayBus);
-            }
-            #endif
-        }
-        #endif
         // load attribute
         mp_map_elem_t *elem = mp_map_lookup(&self->globals->map, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP);
         if (elem != NULL) {


### PR DESCRIPTION
Removes `CIRCUITPY_8_9_WARNINGS` and its usage.

Resolves #9596. Because the `CIRCUITPY_8_9_WARNINGS` was defined to `(0)` this change is ready to merge now.