### PR TITLE
Use MICROPY_HW_MCU_NAME for sysname and nodename for all ports.

### DIFF
--- a/ports/analog/common-hal/os/__init__.c
+++ b/ports/analog/common-hal/os/__init__.c
@@ -19,8 +19,8 @@ static const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, "max32");
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, "max32");
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
 
 static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
 static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);

--- a/ports/analog/common-hal/os/__init__.c
+++ b/ports/analog/common-hal/os/__init__.c
@@ -15,32 +15,6 @@
 
 // #include "peripherals/periph.h"
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 bool common_hal_os_urandom(uint8_t *buffer, uint32_t length) {
     #if (HAS_TRNG)
     // todo (low prior): implement

--- a/ports/atmel-samd/common-hal/os/__init__.c
+++ b/ports/atmel-samd/common-hal/os/__init__.c
@@ -20,14 +20,8 @@ static const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
-#ifdef SAMD21
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, "samd21");
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, "samd21");
-#endif
-#ifdef SAM_D5X_E5X
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, "samd51");
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, "samd51");
-#endif
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
 static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
 static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
 static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);

--- a/ports/atmel-samd/common-hal/os/__init__.c
+++ b/ports/atmel-samd/common-hal/os/__init__.c
@@ -16,32 +16,6 @@
 #include "hal/include/hal_rand_sync.h"
 #endif
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 bool common_hal_os_urandom(uint8_t *buffer, mp_uint_t length) {
     #ifdef SAM_D5X_E5X
     hri_mclk_set_APBCMASK_TRNG_bit(MCLK);

--- a/ports/broadcom/common-hal/os/__init__.c
+++ b/ports/broadcom/common-hal/os/__init__.c
@@ -10,33 +10,6 @@
 #include "py/objtuple.h"
 #include "py/qstr.h"
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 bool common_hal_os_urandom(uint8_t *buffer, uint32_t length) {
     return false;
 }

--- a/ports/cxd56/common-hal/os/__init__.c
+++ b/ports/cxd56/common-hal/os/__init__.c
@@ -10,32 +10,6 @@
 #include "py/objstr.h"
 #include "py/objtuple.h"
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 bool common_hal_os_urandom(uint8_t *buffer, mp_uint_t length) {
     uint32_t i = 0;
 

--- a/ports/cxd56/common-hal/os/__init__.c
+++ b/ports/cxd56/common-hal/os/__init__.c
@@ -15,8 +15,8 @@ static const qstr os_uname_info_fields[] = {
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
 
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, "spresense");
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, "spresense");
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
 static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
 static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
 static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);

--- a/ports/espressif/common-hal/os/__init__.c
+++ b/ports/espressif/common-hal/os/__init__.c
@@ -15,32 +15,6 @@
 #include "esp_system.h"
 #include "esp_random.h"
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 bool common_hal_os_urandom(uint8_t *buffer, mp_uint_t length) {
     uint32_t i = 0;
     while (i < length) {

--- a/ports/litex/common-hal/os/__init__.c
+++ b/ports/litex/common-hal/os/__init__.c
@@ -16,8 +16,8 @@ static const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, "litex");
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, "litex");
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
 static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
 static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
 static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);

--- a/ports/litex/common-hal/os/__init__.c
+++ b/ports/litex/common-hal/os/__init__.c
@@ -12,32 +12,6 @@
 
 #include "shared-bindings/os/__init__.h"
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 bool common_hal_os_urandom(uint8_t *buffer, mp_uint_t length) {
     return false;
 }

--- a/ports/mimxrt10xx/common-hal/os/__init__.c
+++ b/ports/mimxrt10xx/common-hal/os/__init__.c
@@ -17,31 +17,6 @@
 #include "sdk/drivers/trng/fsl_trng.h"
 #endif
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 bool common_hal_os_urandom(uint8_t *buffer, mp_uint_t length) {
     #if CIRCUITPY_RANDOM
     trng_config_t trngConfig;

--- a/ports/mimxrt10xx/common-hal/os/__init__.c
+++ b/ports/mimxrt10xx/common-hal/os/__init__.c
@@ -21,8 +21,8 @@ static const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, "mimxrt10xx");
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, "mimxrt10xx");
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
 static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
 static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
 static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);

--- a/ports/nordic/common-hal/os/__init__.c
+++ b/ports/nordic/common-hal/os/__init__.c
@@ -21,8 +21,8 @@ static const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, "nrf52");
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, "nrf52");
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
 
 static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
 static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);

--- a/ports/nordic/common-hal/os/__init__.c
+++ b/ports/nordic/common-hal/os/__init__.c
@@ -17,32 +17,6 @@
 
 #include "nrf_rng.h"
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 bool common_hal_os_urandom(uint8_t *buffer, mp_uint_t length) {
     #ifdef BLUETOOTH_SD
     uint8_t sd_en = 0;

--- a/ports/raspberrypi/common-hal/os/__init__.c
+++ b/ports/raspberrypi/common-hal/os/__init__.c
@@ -18,32 +18,6 @@
 
 #include <string.h>
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 // NIST Special Publication 800-90B (draft) recommends several extractors,
 // including the SHA hash family and states that if the amount of entropy input
 // is twice the number of bits output from them, that output can be considered

--- a/ports/renode/common-hal/os/__init__.c
+++ b/ports/renode/common-hal/os/__init__.c
@@ -16,8 +16,8 @@ static const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, "renode");
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, "renode");
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
 static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
 static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
 static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);

--- a/ports/renode/common-hal/os/__init__.c
+++ b/ports/renode/common-hal/os/__init__.c
@@ -12,32 +12,6 @@
 
 #include "shared-bindings/os/__init__.h"
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 bool common_hal_os_urandom(uint8_t *buffer, mp_uint_t length) {
     return false;
 }

--- a/ports/silabs/common-hal/os/__init__.c
+++ b/ports/silabs/common-hal/os/__init__.c
@@ -39,8 +39,8 @@ static const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, EFR32_SERIES_LOWER);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, EFR32_SERIES_LOWER);
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
 
 static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
 static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);

--- a/ports/silabs/common-hal/os/__init__.c
+++ b/ports/silabs/common-hal/os/__init__.c
@@ -35,31 +35,6 @@
 #include "peripherals/periph.h"
 #define RNG_TIMEOUT 5
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj);
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 bool common_hal_os_urandom(uint8_t *buffer, uint32_t length) {
 
     return false;

--- a/ports/stm/common-hal/os/__init__.c
+++ b/ports/stm/common-hal/os/__init__.c
@@ -15,32 +15,6 @@
 #include STM32_HAL_H
 #include "peripherals/periph.h"
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 #define RNG_TIMEOUT 5
 
 bool common_hal_os_urandom(uint8_t *buffer, uint32_t length) {

--- a/ports/stm/common-hal/os/__init__.c
+++ b/ports/stm/common-hal/os/__init__.c
@@ -19,8 +19,8 @@ static const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, STM32_SERIES_LOWER);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, STM32_SERIES_LOWER);
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
 
 static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
 static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);

--- a/ports/zephyr-cp/common-hal/os/__init__.c
+++ b/ports/zephyr-cp/common-hal/os/__init__.c
@@ -17,8 +17,8 @@ static const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, "nrf52");
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, "nrf52");
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
 
 static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
 static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);

--- a/ports/zephyr-cp/common-hal/os/__init__.c
+++ b/ports/zephyr-cp/common-hal/os/__init__.c
@@ -13,32 +13,6 @@
 
 #include <zephyr/random/random.h>
 
-static const qstr os_uname_info_fields[] = {
-    MP_QSTR_sysname, MP_QSTR_nodename,
-    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
-};
-static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
-static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
-
-static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
-static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
-static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
-
-static MP_DEFINE_ATTRTUPLE(
-    os_uname_info_obj,
-    os_uname_info_fields,
-    5,
-    (mp_obj_t)&os_uname_info_sysname_obj,
-    (mp_obj_t)&os_uname_info_nodename_obj,
-    (mp_obj_t)&os_uname_info_release_obj,
-    (mp_obj_t)&os_uname_info_version_obj,
-    (mp_obj_t)&os_uname_info_machine_obj
-    );
-
-mp_obj_t common_hal_os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
-}
-
 bool common_hal_os_urandom(uint8_t *buffer, mp_uint_t length) {
     #if !DT_HAS_CHOSEN(zephyr_entropy)
     return false;

--- a/shared-bindings/os/__init__.c
+++ b/shared-bindings/os/__init__.c
@@ -44,8 +44,30 @@
 //|     machine: str
 //|
 //|
+static const qstr os_uname_info_fields[] = {
+    MP_QSTR_sysname, MP_QSTR_nodename,
+    MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
+};
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, MICROPY_VERSION_STRING);
+static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE);
+static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROPY_HW_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
+
+
+static MP_DEFINE_ATTRTUPLE(
+    os_uname_info_obj,
+    os_uname_info_fields,
+    5,
+    (mp_obj_t)&os_uname_info_sysname_obj,
+    (mp_obj_t)&os_uname_info_nodename_obj,
+    (mp_obj_t)&os_uname_info_release_obj,
+    (mp_obj_t)&os_uname_info_version_obj,
+    (mp_obj_t)&os_uname_info_machine_obj
+    );
+
 static mp_obj_t os_uname(void) {
-    return common_hal_os_uname();
+    return (mp_obj_t)&os_uname_info_obj;
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(os_uname_obj, os_uname);
 

--- a/shared-bindings/os/__init__.h
+++ b/shared-bindings/os/__init__.h
@@ -11,9 +11,6 @@
 
 #include "py/objtuple.h"
 
-extern const mp_rom_obj_tuple_t common_hal_os_uname_info_obj;
-
-mp_obj_t common_hal_os_uname(void);
 void common_hal_os_chdir(const char *path);
 mp_obj_t common_hal_os_getcwd(void);
 mp_obj_t common_hal_os_getenv(const char *key, mp_obj_t default_);

--- a/shared-module/os/__init__.c
+++ b/shared-module/os/__init__.c
@@ -17,7 +17,7 @@
 #include "shared-bindings/os/__init__.h"
 
 // This provides all VFS related OS functions so that ports can share the code
-// as needed. It does not provide uname.
+// as needed.
 
 // Version of mp_vfs_lookup_path that takes and returns uPy string objects.
 static mp_vfs_mount_t *lookup_path(const char *path, mp_obj_t *path_out) {


### PR DESCRIPTION
Use `MICROPY_HW_MCU_NAME` for `os.uname().sysname` and `os.uname().nodename` for all ports.

Resolves #9686.