### PR TITLE
USB device_info test check if pins exist before using

### DIFF
--- a/tests/circuitpython-manual/usb/device_info.py
+++ b/tests/circuitpython-manual/usb/device_info.py
@@ -9,7 +9,8 @@ if hasattr(board, "USB_HOST_POWER"):
     d.switch_to_output(value=True)
     print("USB power on")
 
-h = usb_host.Port(board.USB_HOST_DP, board.USB_HOST_DM)
+if hasattr(board, "USB_HOST_DP") and hasattr(board, "USB_HOST_DM"):
+    h = usb_host.Port(board.USB_HOST_DP, board.USB_HOST_DM)
 
 while True:
     for device in usb.core.find(find_all=True):


### PR DESCRIPTION
This script currently errors on the fruit jam due to not having pins with these names. Wrapping it with these hasattr checks allows it to run and successfully print info from the connected devices. 