### PR TITLE
Suspected typo: last "S" in "STM32F412xGS"

### DIFF
--- a/ports/stm/boards/stm32f412zg_discovery/mpconfigboard.h
+++ b/ports/stm/boards/stm32f412zg_discovery/mpconfigboard.h
@@ -9,7 +9,7 @@
 // Micropython setup
 
 #define MICROPY_HW_BOARD_NAME       "STM32F412G_DISCO"
-#define MICROPY_HW_MCU_NAME         "STM32F412xGS"
+#define MICROPY_HW_MCU_NAME         "STM32F412xG"
 
 #define FLASH_SIZE                  (0x100000)
 #define FLASH_PAGE_SIZE             (0x4000)


### PR DESCRIPTION
Because https://www.st.com/resource/en/data_brief/32f412gdiscovery.pdf says "STM32F412ZGT6"