### PR TITLE
9.2.x fruit jam buttons

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,9 @@ repos:
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
-        exclude: '^(tests/.*\.exp|tests/cmdline/.*|tests/.*/data/.*|ports/raspberrypi/sdk|lib/tinyusb)'
+        exclude: '^(tests/.*\.exp|tests/cmdline/.*|tests/.*/data/.*|ports/mimxrt10xx/sdk|ports/raspberrypi/sdk|lib/tinyusb)'
     -   id: trailing-whitespace
-        exclude: '^(tests/.*\.exp|tests/cmdline/.*|tests/.*/data/.*|lib/mbedtls_errors/generate_errors.diff|ports/raspberrypi/sdk|lib/tinyusb)'
+        exclude: '^(tests/.*\.exp|tests/cmdline/.*|tests/.*/data/.*|lib/mbedtls_errors/generate_errors.diff|ports/raspberrypi/sdk|ports/mimxrt10xx/sdk|lib/tinyusb)'
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.4
     hooks:
@@ -59,3 +59,4 @@ repos:
   rev: "v2.5.0"
   hooks:
     - id: pyproject-fmt
+      exclude: '^(ports/mimxrt10xx/sdk)'

--- a/ports/raspberrypi/boards/adafruit_fruit_jam/pins.c
+++ b/ports/raspberrypi/boards/adafruit_fruit_jam/pins.c
@@ -13,6 +13,7 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     // On JST PH connector.
     { MP_OBJ_NEW_QSTR(MP_QSTR_A0), MP_ROM_PTR(&pin_GPIO40) },
 
+    // On header
     { MP_OBJ_NEW_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_GPIO41) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_A2), MP_ROM_PTR(&pin_GPIO42) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_GPIO43) },
@@ -27,11 +28,11 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO29) },
 
-    { MP_OBJ_NEW_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO0) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_BUTTON1), MP_ROM_PTR(&pin_GPIO0) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_BOOT), MP_ROM_PTR(&pin_GPIO0) },
 
-    { MP_OBJ_NEW_QSTR(MP_QSTR_BUTTON1), MP_ROM_PTR(&pin_GPIO4) },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_BUTTON2), MP_ROM_PTR(&pin_GPIO5) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_BUTTON2), MP_ROM_PTR(&pin_GPIO4) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_BUTTON3), MP_ROM_PTR(&pin_GPIO5) },
 
     { MP_OBJ_NEW_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO20) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO21) },


### PR DESCRIPTION
Correct Fruit Jam button names to match silkscreen.

Also, prevent pre-commit from trying to reformat Python code inside the i.MX SDK.

@ladyada