### PR TITLE
Allow setting of CIRCUITPY_DISPLAY_LIMIT in settings.toml

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -190,3 +190,27 @@ flag has been set to 0. Currently this is primarily boards with limited flash in
 of the Atmel_samd boards based on the SAMD21/M0 microprocessor.
 
 `boards that the terminalio core module is available on <https://docs.circuitpython.org/en/latest/shared-bindings/terminalio/>`_
+
+CIRCUITPY_DISPLAY_LIMIT
+~~~~~~~~~~~~~~~~~~~~~~~
+Set the maximum supported number of displayio displays. This value overrides the
+CIRCUITPY_DISPLAY_LIMIT compile-time flag defined in mpconfigport.h.
+It specifies the maximum number of active display objects that can be supported simultaneously
+on a CircuitPython board. This setting is used to manage memory and resource allocation for
+display handling.
+
+By default, the value of CIRCUITPY_DISPLAY_LIMIT is set to 1 for most boards, meaning only
+one display can be active at a time. Users can modify this value by adding a settings.toml entry
+to support additional displays, depending on the hardware capabilities and available resources.
+
+The value of CIRCUITPY_DISPLAY_LIMIT should be set to a value that is supported by the
+hardware and does not exceed the available memory and resources on the board.
+
+*** Note: Setting CIRCUITPY_DISPLAY_LIMIT to a value greater than 1 should be considered an
+ALPHA feature and may result in unexpected behavior or crashes. ***
+
+Example: Set the maximum supported number of displayio displays to 2:
+
+.. code-block::
+
+    CIRCUITPY_DISPLAY_LIMIT=2

--- a/main.c
+++ b/main.c
@@ -1057,6 +1057,11 @@ int __attribute__((used)) main(void) {
     reset_devices();
     reset_board();
 
+    #if CIRCUITPY_DISPLAYIO
+    // If number of displays has been overriden in settings.toml allocate memory and dynamic memory
+    malloc_display_memory();
+    #endif
+
     // displays init after filesystem, since they could share the flash SPI
     board_init();
 

--- a/main.c
+++ b/main.c
@@ -1058,7 +1058,7 @@ int __attribute__((used)) main(void) {
     reset_board();
 
     #if CIRCUITPY_DISPLAYIO
-    // If number of displays has been overriden in settings.toml allocate memory and dynamic memory
+    // If number of displays has been overridden in settings.toml allocate memory and dynamic memory
     malloc_display_memory();
     #endif
 

--- a/shared-module/board/__init__.c
+++ b/shared-module/board/__init__.c
@@ -10,6 +10,10 @@
 #include "mpconfigboard.h"
 #include "py/runtime.h"
 
+#if CIRCUITPY_OS_GETENV
+#include "shared-module/os/__init__.h"
+#endif
+
 #if CIRCUITPY_BUSIO
 #include "shared-bindings/busio/I2C.h"
 #include "shared-bindings/busio/SPI.h"
@@ -172,11 +176,19 @@ mp_obj_t common_hal_board_create_uart(const mp_int_t instance) {
 #endif
 
 void reset_board_buses(void) {
+    #if CIRCUITPY_BOARD_I2C || CIRCUITPY_BOARD_SPI
+    mp_int_t max_num_displays = CIRCUITPY_DISPLAY_LIMIT;
+
+    #if CIRCUITPY_OS_GETENV
+    (void)common_hal_os_getenv_int("CIRCUITPY_DISPLAY_LIMIT", &max_num_displays);
+    #endif
+    #endif
+
     #if CIRCUITPY_BOARD_I2C
     for (uint8_t instance = 0; instance < CIRCUITPY_BOARD_I2C; instance++) {
         bool display_using_i2c = false;
         #if CIRCUITPY_I2CDISPLAYBUS
-        for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
+        for (uint8_t i = 0; i < max_num_displays; i++) {
             if (display_buses[i].bus_base.type == &i2cdisplaybus_i2cdisplaybus_type && display_buses[i].i2cdisplay_bus.bus == &i2c_obj[instance]) {
                 display_using_i2c = true;
                 break;
@@ -197,7 +209,7 @@ void reset_board_buses(void) {
     for (uint8_t instance = 0; instance < CIRCUITPY_BOARD_SPI; instance++) {
         bool display_using_spi = false;
         #if CIRCUITPY_FOURWIRE || CIRCUITPY_SHARPDISPLAY || CIRCUITPY_AURORA_EPAPER
-        for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
+        for (uint8_t i = 0; i < max_num_displays; i++) {
             mp_const_obj_t bus_type = display_buses[i].bus_base.type;
             #if CIRCUITPY_FOURWIRE
             if (bus_type == &fourwire_fourwire_type && display_buses[i].fourwire_bus.bus == &spi_obj[instance]) {

--- a/shared-module/displayio/__init__.c
+++ b/shared-module/displayio/__init__.c
@@ -201,10 +201,10 @@ void malloc_display_memory(void) {
     #if CIRCUITPY_OS_GETENV
     (void)common_hal_os_getenv_int("CIRCUITPY_DISPLAY_LIMIT", &max_num_displays);
     if (max_num_displays > CIRCUITPY_DISPLAY_LIMIT) {
-        display_buses = (primary_display_bus_t*)port_malloc(sizeof(primary_display_bus_t) * max_num_displays, false);
-        displays = (primary_display_t*)port_malloc(sizeof(primary_display_t) * max_num_displays, false);
+        display_buses = (primary_display_bus_t *)port_malloc(sizeof(primary_display_bus_t) * max_num_displays, false);
+        displays = (primary_display_t *)port_malloc(sizeof(primary_display_t) * max_num_displays, false);
         memcpy(display_buses, &display_busesx[0], sizeof(primary_display_bus_t) * max_num_displays);
-        memcpy(displays, &displaysx[0], sizeof(primary_display_t) * max_num_displays);    
+        memcpy(displays, &displaysx[0], sizeof(primary_display_t) * max_num_displays);
     }
     #endif
 }

--- a/shared-module/displayio/__init__.h
+++ b/shared-module/displayio/__init__.h
@@ -99,13 +99,16 @@ typedef struct {
     };
 } primary_display_t;
 
-extern primary_display_bus_t display_buses[CIRCUITPY_DISPLAY_LIMIT];
-extern primary_display_t displays[CIRCUITPY_DISPLAY_LIMIT];
+extern primary_display_bus_t display_busesx[];
+extern primary_display_t displaysx[];
+extern primary_display_bus_t *display_buses;
+extern primary_display_t *displays;
 
 extern displayio_group_t circuitpython_splash;
 
 void displayio_background(void);
 void reset_displays(void);
+void malloc_display_memory(void);
 void displayio_gc_collect(void);
 
 primary_display_t *allocate_display(void);

--- a/shared-module/epaperdisplay/EPaperDisplay.c
+++ b/shared-module/epaperdisplay/EPaperDisplay.c
@@ -20,6 +20,10 @@
 #include "supervisor/usb.h"
 #endif
 
+#if CIRCUITPY_OS_GETENV
+#include "shared-module/os/__init__.h"
+#endif
+
 #include <stdint.h>
 #include <string.h>
 
@@ -501,7 +505,13 @@ void epaperdisplay_epaperdisplay_collect_ptrs(epaperdisplay_epaperdisplay_obj_t 
 }
 
 size_t maybe_refresh_epaperdisplay(void) {
-    for (uint8_t i = 0; i < CIRCUITPY_DISPLAY_LIMIT; i++) {
+    mp_int_t max_num_displays = CIRCUITPY_DISPLAY_LIMIT;
+
+    #if CIRCUITPY_OS_GETENV
+    (void)common_hal_os_getenv_int("CIRCUITPY_DISPLAY_LIMIT", &max_num_displays);
+    #endif
+
+    for (uint8_t i = 0; i < max_num_displays; i++) {
         if (displays[i].epaper_display.base.type != &epaperdisplay_epaperdisplay_type ||
             displays[i].epaper_display.core.current_group != &circuitpython_splash) {
             // Skip regular displays and those not showing the splash.


### PR DESCRIPTION
Set the maximum supported number of displayio displays. This value overrides the CIRCUITPY_DISPLAY_LIMIT compile-time flag. 

I do have some questions about this solution.

I'm not sure if this fixes #1760 since Tannewt has said he hopes to implement a better solution in CP 11. I'm also not sure main.c was the right location to insert the call to malloc_display_memory but I don't know displayio well enough to know if there was a better place somewhere in the displayio modules.

So far I've only been testing with the RP2350 feather (DVI display) with a TFT featherwing (SPI display). I'll go ahead and get some more configurations set up for testing but figured I get this posted so others could start reviewing.