### PR TITLE
For raspberrypi, increase MDNS_MAX_SERVICES to 25.

### DIFF
--- a/ports/raspberrypi/lwip_inc/lwipopts.h
+++ b/ports/raspberrypi/lwip_inc/lwipopts.h
@@ -111,6 +111,7 @@
 #define LWIP_NETIF_EXT_STATUS_CALLBACK 1
 #define MDNS_MAX_SECONDARY_HOSTNAMES 1
 #define MEMP_NUM_SYS_TIMEOUT        (8 + 3 * (LWIP_IPV4 + LWIP_IPV6))
+#define MDNS_MAX_SERVICES           25
 #endif
 
 #ifndef NDEBUG


### PR DESCRIPTION
Increases `MDNS_MAX_SERVICES` from default of 1 to 25. This is the value specified for the Espressif port.

Resolves #9127.