### PR TITLE
waveshare_esp32_s3_geek: fix SPI busses and board_init()

### DIFF
--- a/ports/espressif/boards/waveshare_esp32_s3_geek/board.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_geek/board.c
@@ -30,17 +30,8 @@ uint8_t display_init_sequence[] = {
 };
 
 static void display_init(void) {
-
     busio_spi_obj_t *spi = common_hal_board_create_spi(0);
     fourwire_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
-
-    common_hal_busio_spi_construct(
-        spi,
-        &pin_GPIO12,    // CLK
-        &pin_GPIO11,    // MOSI
-        NULL,           // MISO not connected
-        false);         // Not half-duplex
-
 
     bus->base.type = &fourwire_fourwire_type;
 

--- a/ports/espressif/boards/waveshare_esp32_s3_geek/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_geek/mpconfigboard.h
@@ -17,6 +17,6 @@
 #define DEFAULT_I2C_BUS_SCL (&pin_GPIO17)
 #define DEFAULT_I2C_BUS_SDA (&pin_GPIO16)
 
-#define DEFAULT_SPI_BUS_SCK (&pin_GPIO36)
-#define DEFAULT_SPI_BUS_MOSI (&pin_GPIO35)
-#define DEFAULT_SPI_BUS_MISO (&pin_GPIO37)
+#define CIRCUITPY_BOARD_SPI         (2)
+#define CIRCUITPY_BOARD_SPI_PIN     {{.clock = &pin_GPIO12, .mosi = &pin_GPIO11}, \
+                                     {.clock = &pin_GPIO36, .mosi = &pin_GPIO35, .miso = &pin_GPIO37}}

--- a/ports/espressif/boards/waveshare_esp32_s3_geek/pins.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_geek/pins.c
@@ -5,8 +5,10 @@
 // SPDX-License-Identifier: MIT
 
 #include "shared-bindings/board/__init__.h"
-
 #include "shared-module/displayio/__init__.h"
+
+CIRCUITPY_BOARD_BUS_SINGLETON(sd_spi, spi, 1)
+
 static const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
 
@@ -64,11 +66,11 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
 
     // SD Card
-    { MP_ROM_QSTR(MP_QSTR_SD_SCK),  MP_ROM_PTR(&pin_GPIO36)},
-    { MP_ROM_QSTR(MP_QSTR_SD_MOSI), MP_ROM_PTR(&pin_GPIO35)},
-    { MP_ROM_QSTR(MP_QSTR_SD_MISO), MP_ROM_PTR(&pin_GPIO37)},
-    { MP_ROM_QSTR(MP_QSTR_SD_CS),   MP_ROM_PTR(&pin_GPIO34)},
-    { MP_ROM_QSTR(MP_QSTR_SD_SPI), MP_ROM_PTR(&board_spi_obj) },
+    { MP_ROM_QSTR(MP_QSTR_SD_SCK),  MP_ROM_PTR(&pin_GPIO36) },
+    { MP_ROM_QSTR(MP_QSTR_SD_MOSI), MP_ROM_PTR(&pin_GPIO35) },
+    { MP_ROM_QSTR(MP_QSTR_SD_MISO), MP_ROM_PTR(&pin_GPIO37) },
+    { MP_ROM_QSTR(MP_QSTR_SD_CS),   MP_ROM_PTR(&pin_GPIO34) },
+    { MP_ROM_QSTR(MP_QSTR_SD_SPI), MP_ROM_PTR(&board_sd_spi_obj) },
     // Pin 38 is for the SDIO interface, and therefore not included in the SPI object
 
     // LCD
@@ -78,6 +80,7 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_LCD_RST), MP_ROM_PTR(&pin_GPIO9) },
     { MP_ROM_QSTR(MP_QSTR_LCD_BACKLIGHT), MP_ROM_PTR(&pin_GPIO7) },
     { MP_ROM_QSTR(MP_QSTR_LCD_DC), MP_ROM_PTR(&pin_GPIO8) },
+    { MP_ROM_QSTR(MP_QSTR_LCD_SPI), MP_ROM_PTR(&board_spi_obj) },
     { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display) },
 
 };


### PR DESCRIPTION
Adds board.SPI for the display SPI bus, and use it in `board.c`.

Previously the code accidentally instantiated both the SD bus (board.SD_SPI) and overwrote it with the display bus in display_init(), making the SD pins unusable. I can't test it.
Should fix #10161

(fixed rebase shenanigans... I think)