### PR TITLE
Restore ability to read usb_cdc buffer when serial client is disconnected

### DIFF
--- a/shared-module/usb_cdc/Serial.c
+++ b/shared-module/usb_cdc/Serial.c
@@ -19,9 +19,7 @@ size_t common_hal_usb_cdc_serial_read(usb_cdc_serial_obj_t *self, uint8_t *data,
     // Read up to len bytes immediately.
     // The number of bytes read will not be larger than what is already in the TinyUSB FIFO.
     uint32_t total_num_read = 0;
-    if (tud_cdc_n_connected(self->idx)) {
-        total_num_read = tud_cdc_n_read(self->idx, data, len);
-    }
+    total_num_read = tud_cdc_n_read(self->idx, data, len);
 
     if (wait_forever || wait_for_timeout) {
         // Continue filling the buffer past what we already read.
@@ -48,9 +46,7 @@ size_t common_hal_usb_cdc_serial_read(usb_cdc_serial_obj_t *self, uint8_t *data,
             data += num_read;
 
             // Try to read another batch of bytes.
-            if (tud_cdc_n_connected(self->idx)) {
-                num_read = tud_cdc_n_read(self->idx, data, len);
-            }
+            num_read = tud_cdc_n_read(self->idx, data, len);
             total_num_read += num_read;
         }
     }


### PR DESCRIPTION
This is a fix for the issue I mentioned all the way here: https://github.com/adafruit/circuitpython/issues/7456#issuecomment-1383495476

The issue mentioned in #6018 is now fixed in tinyusb: https://github.com/hathach/tinyusb/pull/2630

The original solution in #7100 caused the buffer to contain inaccessible data, requiring a serial software on the host to be connected to be able to read the buffer (asserting DTR). Another solution would be to test `tud_ready()` or `tud_cdc_n_ready()` instead of connected, but that would be redundant with the tinyusb fix.

I was not able to reproduce #6018 with that PR.