### PR TITLE
Fix keypad EventQueue len(); improve doc

### DIFF
--- a/shared-bindings/keypad/EventQueue.c
+++ b/shared-bindings/keypad/EventQueue.c
@@ -23,7 +23,8 @@
 //|
 
 //|     def get(self) -> Optional[Event]:
-//|         """Return the next key transition event. Return ``None`` if no events are pending.
+//|         """Remove the next key transition event from the `EventQueue` and return it.
+//|         Return ``None`` if no events are pending.
 //|
 //|         Note that the queue size is limited; see ``max_events`` in the constructor of
 //|         a scanner such as `Keys` or `KeyMatrix`.
@@ -43,7 +44,7 @@ static mp_obj_t keypad_eventqueue_get(mp_obj_t self_in) {
 MP_DEFINE_CONST_FUN_OBJ_1(keypad_eventqueue_get_obj, keypad_eventqueue_get);
 
 //|     def get_into(self, event: Event) -> bool:
-//|         """Store the next key transition event in the supplied event, if available,
+//|         """Remove the next key transition event from the ``EventQueue`, store it in ``event``,
 //|         and return ``True``.
 //|         If there are no queued events, do not touch ``event`` and return ``False``.
 //|

--- a/shared-module/keypad/EventQueue.c
+++ b/shared-module/keypad/EventQueue.c
@@ -13,9 +13,11 @@
 #define EVENT_PRESSED (1 << 15)
 #define EVENT_KEY_NUM_MASK ((1 << 15) - 1)
 
+#define EVENT_SIZE_BYTES (sizeof(uint16_t) + sizeof(mp_obj_t))
+
 void common_hal_keypad_eventqueue_construct(keypad_eventqueue_obj_t *self, size_t max_events) {
     // Event queue is 16-bit values.
-    ringbuf_alloc(&self->encoded_events, max_events * (sizeof(uint16_t) + sizeof(mp_obj_t)));
+    ringbuf_alloc(&self->encoded_events, max_events * EVENT_SIZE_BYTES);
     self->overflowed = false;
     self->event_handler = NULL;
 }
@@ -63,7 +65,7 @@ void common_hal_keypad_eventqueue_clear(keypad_eventqueue_obj_t *self) {
 }
 
 size_t common_hal_keypad_eventqueue_get_length(keypad_eventqueue_obj_t *self) {
-    return ringbuf_num_filled(&self->encoded_events);
+    return ringbuf_num_filled(&self->encoded_events) / EVENT_SIZE_BYTES;
 }
 
 void common_hal_keypad_eventqueue_set_event_handler(keypad_eventqueue_obj_t *self, void (*event_handler)(keypad_eventqueue_obj_t *)) {


### PR DESCRIPTION
- Fixes #10183.
- Improves documentation, as suggested in https://forums.adafruit.com/viewtopic.php?t=217476.

Tested on a CPB:
```py
import keypad
import board
import time

keys = keypad.Keys((board.BUTTON_A,), value_when_pressed=True, pull=True)

while True:
    print("wait 5 seconds")
    time.sleep(5)
    print(f"{len(keys.events)=}")
    count = 0
    while (keys.events.get()):
        count+= 1
    print(f"{count=}")
```