### PR TITLE
Enable & Address -Wtype-limits diagnostics in raspberrypi port

### DIFF
--- a/main.c
+++ b/main.c
@@ -131,9 +131,9 @@ static uint8_t *_allocate_memory(safe_mode_t safe_mode, const char *env_key, siz
     *final_size = default_size;
     #if CIRCUITPY_OS_GETENV
     if (safe_mode == SAFE_MODE_NONE) {
-        (void)common_hal_os_getenv_int(env_key, (mp_int_t *)final_size);
-        if (*final_size < 0) {
-            *final_size = default_size;
+        mp_int_t size;
+        if (common_hal_os_getenv_int(env_key, &size) == GETENV_OK && size > 0) {
+            *final_size = size;
         }
     }
     #endif

--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -222,7 +222,7 @@ endif
 
 DISABLE_WARNINGS = -Wno-cast-align
 
-CFLAGS += $(INC) -Wall -Werror -std=gnu11 -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT) $(DISABLE_WARNINGS) -Werror=missing-prototypes
+CFLAGS += $(INC) -Wtype-limits -Wall -Werror -std=gnu11 -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT) $(DISABLE_WARNINGS) -Werror=missing-prototypes
 
 PICO_LDFLAGS = --specs=nosys.specs --specs=nano.specs
 

--- a/ports/raspberrypi/common-hal/usb_host/Port.c
+++ b/ports/raspberrypi/common-hal/usb_host/Port.c
@@ -138,10 +138,11 @@ usb_host_port_obj_t *common_hal_usb_host_port_construct(const mcu_pin_obj_t *dp,
     }
     pio_cfg.pio_tx_num = get_usb_pio();
     pio_cfg.pio_rx_num = pio_cfg.pio_tx_num;
-    pio_cfg.tx_ch = dma_claim_unused_channel(false); // DMA channel
-    if (pio_cfg.tx_ch < 0) {
+    int dma_ch = dma_claim_unused_channel(false);
+    if (dma_ch < 0) {
         mp_raise_RuntimeError(MP_ERROR_TEXT("All dma channels in use"));
     }
+    pio_cfg.tx_ch = dma_ch;
 
     self->base.type = &usb_host_port_type;
     self->dp = dp;

--- a/py/circuitpy_defns.mk
+++ b/py/circuitpy_defns.mk
@@ -944,7 +944,7 @@ SRC_CIRCUITPY_COMMON = \
 
 ifeq ($(CIRCUITPY_QRIO),1)
 SRC_CIRCUITPY_COMMON += lib/quirc/lib/decode.c lib/quirc/lib/identify.c lib/quirc/lib/quirc.c lib/quirc/lib/version_db.c
-$(BUILD)/lib/quirc/lib/%.o: CFLAGS += -Wno-shadow -Wno-sign-compare -include shared-module/qrio/quirc_alloc.h
+$(BUILD)/lib/quirc/lib/%.o: CFLAGS += -Wno-type-limits -Wno-shadow -Wno-sign-compare -include shared-module/qrio/quirc_alloc.h
 endif
 
 ifdef LD_TEMPLATE_FILE

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -103,10 +103,6 @@ static mp_obj_t socketpool_socketpool_socket(size_t n_args, const mp_obj_t *pos_
     socketpool_socketpool_sock_t type = args[ARG_type].u_int;
     socketpool_socketpool_ipproto_t proto = args[ARG_proto].u_int;
 
-    if (proto < 0) {
-        proto = 0;
-    }
-
     return common_hal_socketpool_socket(self, family, type, proto);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(socketpool_socketpool_socket_obj, 1, socketpool_socketpool_socket);

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -298,7 +298,7 @@ char serial_read(void) {
 
     #if CIRCUITPY_WEB_WORKFLOW
     if (websocket_available()) {
-        char c = websocket_read_char();
+        int c = websocket_read_char();
         if (c != -1) {
             return c;
         }


### PR DESCRIPTION
This fixes an unlikely problem with the USB host implementation on rp2350 that would not have detected failure to allocate a DMA channel.
    
Together with #10186 this should give a clean build. As such, this PR includes the current version of #10168 changes. If that PR is rebased, this PR should be rebased as well. The change of interest is https://github.com/adafruit/circuitpython/commit/8097e3dde6645ff1ee63c588fa8949e61153aab5