### PR TITLE
Depend on header inclusion via -isystem

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -12,6 +12,7 @@ HAL_DIR=hal/$(MCU_SERIES)
 
 ifeq ($(CIRCUITPY_CYW43),1)
 INC_CYW43 := \
+	-isystem lib/cyw43-driver \
 	-isystem lib/cyw43-driver/firmware \
 	-isystem lib/cyw43-driver/src \
 	-isystem lib/lwip/src/include \
@@ -92,8 +93,6 @@ INC += \
 	-I../shared/timeutils \
 	-Iboards/$(BOARD) \
 	-Iboards/ \
-	-isystem ./../../lib/cmsis/inc \
-	-isystem sdk/ \
 	-isystem sdk/src/common/boot_picobin_headers/include/ \
 	-isystem sdk/src/common/boot_picoboot_headers/include/ \
 	-isystem sdk/src/common/hardware_claim/include/ \
@@ -107,6 +106,8 @@ INC += \
 	-isystem sdk/src/$(CHIP_VARIANT_LOWER)/hardware_structs/include/ \
 	-isystem sdk/src/$(CHIP_VARIANT_LOWER)/pico_platform/include/ \
 	-isystem sdk/src/rp2_common/boot_bootrom_headers/include/ \
+	-isystem sdk/src/rp2_common/cmsis/stub/CMSIS/Core/Include/ \
+	-isystem sdk/src/rp2_common/cmsis/stub/CMSIS/Device/${CHIP_VARIANT}/Include \
 	-isystem sdk/src/rp2_common/cmsis/ \
 	-isystem sdk/src/rp2_common/hardware_adc/include/ \
 	-isystem sdk/src/rp2_common/hardware_base/include/ \
@@ -153,7 +154,7 @@ INC += \
 	-isystem sdk/src/rp2_common/pico_platform_panic/include/ \
 	-isystem sdk/src/rp2_common/pico_time_adapter/include/ \
 	-isystem sdk/src/rp2_common/pico_unique_id/include/ \
-$(INC_CYW43) \
+	$(INC_CYW43) \
 	-Isdk_config \
 	-I../../lib/tinyusb/src \
 	-I../../supervisor/shared/usb \

--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -15,7 +15,7 @@
 #include "py/mpstate.h"
 #include "py/runtime.h"
 
-#include "src/rp2_common/hardware_irq/include/hardware/irq.h"
+#include "hardware/irq.h"
 #include "hardware/regs/intctrl.h" // For isr_ macro.
 
 

--- a/ports/raspberrypi/audio_dma.h
+++ b/ports/raspberrypi/audio_dma.h
@@ -9,7 +9,7 @@
 #include "py/obj.h"
 #include "supervisor/background_callback.h"
 
-#include "src/rp2_common/hardware_dma/include/hardware/dma.h"
+#include "hardware/dma.h"
 
 typedef enum {
     AUDIO_DMA_OK,

--- a/ports/raspberrypi/bindings/cyw43/__init__.c
+++ b/ports/raspberrypi/bindings/cyw43/__init__.c
@@ -12,7 +12,7 @@
 #include "shared-bindings/microcontroller/Pin.h"
 #include "bindings/cyw43/__init__.h"
 
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 
 #include "lib/cyw43-driver/src/cyw43.h"
 

--- a/ports/raspberrypi/boards/adafruit_macropad_rp2040/board.c
+++ b/ports/raspberrypi/boards/adafruit_macropad_rp2040/board.c
@@ -10,7 +10,7 @@
 #include "shared-module/displayio/mipi_constants.h"
 #include "shared-bindings/busio/SPI.h"
 #include "shared-bindings/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 #include "supervisor/board.h"
 #include "supervisor/shared/board.h"
 

--- a/ports/raspberrypi/boards/adafruit_qt2040_trinkey/board.c
+++ b/ports/raspberrypi/boards/adafruit_qt2040_trinkey/board.c
@@ -7,6 +7,6 @@
 #include "supervisor/board.h"
 
 #include "shared-bindings/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/raspberrypi/boards/boardsource_blok/board.c
+++ b/ports/raspberrypi/boards/boardsource_blok/board.c
@@ -6,7 +6,7 @@
 
 #include "supervisor/board.h"
 #include "shared-bindings/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 #include "supervisor/shared/board.h"
 
 void board_init(void) {

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/board.c
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/board.c
@@ -26,9 +26,9 @@
 #include "shared-module/displayio/__init__.h"
 #include "supervisor/shared/board.h"
 
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 
-#include "src/rp2_common/hardware_adc/include/hardware/adc.h"
+#include "hardware/adc.h"
 #define ADC_FIRST_PIN_NUMBER 26
 #define ADC_PIN_COUNT 4
 extern void common_hal_mcu_delay_us(uint32_t);

--- a/ports/raspberrypi/boards/jpconstantineau_encoderpad_rp2040/board.c
+++ b/ports/raspberrypi/boards/jpconstantineau_encoderpad_rp2040/board.c
@@ -6,7 +6,7 @@
 
 #include "shared-bindings/board/__init__.h"
 #include "shared-bindings/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 #include "supervisor/shared/board.h"
 #include "supervisor/board.h"
 

--- a/ports/raspberrypi/boards/jpconstantineau_pykey18/board.c
+++ b/ports/raspberrypi/boards/jpconstantineau_pykey18/board.c
@@ -6,7 +6,7 @@
 
 #include "supervisor/board.h"
 #include "shared-bindings/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 #include "supervisor/shared/board.h"
 
 void reset_board(void) {

--- a/ports/raspberrypi/boards/jpconstantineau_pykey44/board.c
+++ b/ports/raspberrypi/boards/jpconstantineau_pykey44/board.c
@@ -6,7 +6,7 @@
 
 #include "supervisor/board.h"
 #include "shared-bindings/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 #include "supervisor/shared/board.h"
 
 void reset_board(void) {

--- a/ports/raspberrypi/boards/jpconstantineau_pykey60/board.c
+++ b/ports/raspberrypi/boards/jpconstantineau_pykey60/board.c
@@ -6,7 +6,7 @@
 
 #include "supervisor/board.h"
 #include "shared-bindings/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 #include "supervisor/shared/board.h"
 
 void reset_board(void) {

--- a/ports/raspberrypi/boards/jpconstantineau_pykey87/board.c
+++ b/ports/raspberrypi/boards/jpconstantineau_pykey87/board.c
@@ -6,7 +6,7 @@
 
 #include "supervisor/board.h"
 #include "shared-bindings/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 #include "supervisor/shared/board.h"
 
 void reset_board(void) {

--- a/ports/raspberrypi/boards/ugame22/board.c
+++ b/ports/raspberrypi/boards/ugame22/board.c
@@ -7,7 +7,7 @@
 #include "supervisor/board.h"
 
 #include "shared-bindings/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 
 #include "shared-bindings/busio/SPI.h"
 #include "shared-bindings/fourwire/FourWire.h"

--- a/ports/raspberrypi/boards/wk-50/board.c
+++ b/ports/raspberrypi/boards/wk-50/board.c
@@ -6,7 +6,7 @@
 
 #include "supervisor/board.h"
 #include "shared-bindings/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 #include "supervisor/shared/board.h"
 
 void reset_board(void) {

--- a/ports/raspberrypi/boards/zrichard_rp2.65-f/board.c
+++ b/ports/raspberrypi/boards/zrichard_rp2.65-f/board.c
@@ -6,7 +6,7 @@
 
 #include "supervisor/board.h"
 #include "shared-bindings/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 #include "supervisor/shared/board.h"
 
 void reset_board(void) {

--- a/ports/raspberrypi/boot_stage2/RP2040.c.jinja
+++ b/ports/raspberrypi/boot_stage2/RP2040.c.jinja
@@ -1,7 +1,7 @@
-#include "sdk/src/rp2040/hardware_structs/include/hardware/structs/ssi.h"
-#include "sdk/src/rp2040/hardware_structs/include/hardware/structs/pads_qspi.h"
-#include "sdk/src/rp2040/hardware_regs/include/hardware/regs/addressmap.h"
-#include "sdk/src/rp2040/hardware_regs/include/hardware/regs/m0plus.h"
+#include "hardware/structs/ssi.h"
+#include "hardware/structs/pads_qspi.h"
+#include "hardware/regs/addressmap.h"
+#include "hardware/regs/m0plus.h"
 
 // "Mode bits" are 8 special bits sent immediately after
 // the address bits in a "Read Data Fast Quad I/O" command sequence.

--- a/ports/raspberrypi/common-hal/analogbufio/BufferedIn.c
+++ b/ports/raspberrypi/common-hal/analogbufio/BufferedIn.c
@@ -11,9 +11,9 @@
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared/runtime/interrupt_char.h"
 #include "py/runtime.h"
-#include "src/rp2_common/hardware_adc/include/hardware/adc.h"
-#include "src/rp2_common/hardware_dma/include/hardware/dma.h"
-#include "src/common/pico_stdlib_headers/include/pico/stdlib.h"
+#include "hardware/adc.h"
+#include "hardware/dma.h"
+#include "pico/stdlib.h"
 
 #define ADC_FIRST_PIN_NUMBER 26
 #define ADC_PIN_COUNT 4

--- a/ports/raspberrypi/common-hal/analogbufio/BufferedIn.h
+++ b/ports/raspberrypi/common-hal/analogbufio/BufferedIn.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "common-hal/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_dma/include/hardware/dma.h"
+#include "hardware/dma.h"
 
 #include "py/obj.h"
 

--- a/ports/raspberrypi/common-hal/analogio/AnalogIn.c
+++ b/ports/raspberrypi/common-hal/analogio/AnalogIn.c
@@ -10,7 +10,7 @@
 #include "shared-bindings/microcontroller/Pin.h"
 #include "py/runtime.h"
 
-#include "src/rp2_common/hardware_adc/include/hardware/adc.h"
+#include "hardware/adc.h"
 
 #define ADC_PIN_COUNT (NUM_ADC_CHANNELS - 1)
 

--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -20,8 +20,8 @@
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/Processor.h"
 
-#include "src/rp2040/hardware_structs/include/hardware/structs/dma.h"
-#include "src/rp2_common/hardware_pwm/include/hardware/pwm.h"
+#include "hardware/structs/dma.h"
+#include "hardware/pwm.h"
 
 // The PWM clock frequency is base_clock_rate / PWM_TOP, typically 125_000_000 / PWM_TOP.
 // We pick BITS_PER_SAMPLE so we get a clock frequency that is above what would cause aliasing.

--- a/ports/raspberrypi/common-hal/busio/I2C.c
+++ b/ports/raspberrypi/common-hal/busio/I2C.c
@@ -13,7 +13,7 @@
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/bitbangio/I2C.h"
 
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 
 // Synopsys  DW_apb_i2c  (v2.01)  IP
 

--- a/ports/raspberrypi/common-hal/busio/I2C.h
+++ b/ports/raspberrypi/common-hal/busio/I2C.h
@@ -11,7 +11,7 @@
 
 #include "py/obj.h"
 
-#include "src/rp2_common/hardware_i2c/include/hardware/i2c.h"
+#include "hardware/i2c.h"
 
 typedef struct {
     mp_obj_base_t base;

--- a/ports/raspberrypi/common-hal/busio/SPI.c
+++ b/ports/raspberrypi/common-hal/busio/SPI.c
@@ -14,8 +14,8 @@
 #include "common-hal/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-#include "src/rp2_common/hardware_dma/include/hardware/dma.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/dma.h"
+#include "hardware/gpio.h"
 
 #define NO_INSTANCE 0xff
 

--- a/ports/raspberrypi/common-hal/busio/SPI.h
+++ b/ports/raspberrypi/common-hal/busio/SPI.h
@@ -10,7 +10,7 @@
 
 #include "py/obj.h"
 
-#include "src/rp2_common/hardware_spi/include/hardware/spi.h"
+#include "hardware/spi.h"
 
 typedef struct {
     mp_obj_base_t base;

--- a/ports/raspberrypi/common-hal/busio/UART.c
+++ b/ports/raspberrypi/common-hal/busio/UART.c
@@ -14,8 +14,8 @@
 #include "common-hal/microcontroller/Pin.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-#include "src/rp2_common/hardware_irq/include/hardware/irq.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/irq.h"
+#include "hardware/gpio.h"
 
 #define NO_PIN 0xff
 

--- a/ports/raspberrypi/common-hal/busio/UART.h
+++ b/ports/raspberrypi/common-hal/busio/UART.h
@@ -9,7 +9,7 @@
 #include "py/obj.h"
 #include "py/ringbuf.h"
 
-#include "src/rp2_common/hardware_uart/include/hardware/uart.h"
+#include "hardware/uart.h"
 
 typedef struct {
     mp_obj_base_t base;

--- a/ports/raspberrypi/common-hal/countio/Counter.c
+++ b/ports/raspberrypi/common-hal/countio/Counter.c
@@ -13,9 +13,9 @@
 #include "shared-bindings/digitalio/Pull.h"
 #include "common-hal/pwmio/PWMOut.h"
 
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
-#include "src/rp2_common/hardware_pwm/include/hardware/pwm.h"
-#include "src/rp2_common/hardware_irq/include/hardware/irq.h"
+#include "hardware/gpio.h"
+#include "hardware/pwm.h"
+#include "hardware/irq.h"
 
 
 void common_hal_countio_counter_construct(countio_counter_obj_t *self,

--- a/ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
+++ b/ports/raspberrypi/common-hal/digitalio/DigitalInOut.c
@@ -14,7 +14,7 @@
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/digitalio/DigitalInOut.h"
 
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 
 #if CIRCUITPY_CYW43
 #include "pico/cyw43_arch.h"

--- a/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.c
+++ b/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.c
@@ -14,7 +14,7 @@
 #include "shared-bindings/microcontroller/Pin.h"
 #include "py/runtime.h"
 
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 
 static i2c_inst_t *i2c[2] = {i2c0, i2c1};
 

--- a/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.h
+++ b/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.h
@@ -8,7 +8,7 @@
 
 #include "py/obj.h"
 #include "common-hal/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_i2c/include/hardware/i2c.h"
+#include "hardware/i2c.h"
 
 typedef struct {
     mp_obj_base_t base;

--- a/ports/raspberrypi/common-hal/imagecapture/ParallelImageCapture.c
+++ b/ports/raspberrypi/common-hal/imagecapture/ParallelImageCapture.c
@@ -18,8 +18,8 @@
 #include "shared-bindings/microcontroller/Processor.h"
 #include "shared-bindings/microcontroller/__init__.h"
 
-#include "src/rp2_common/hardware_pio/include/hardware/pio.h"
-#include "src/rp2_common/hardware_pio/include/hardware/pio_instructions.h"
+#include "hardware/pio.h"
+#include "hardware/pio_instructions.h"
 
 // Define this to (1), and you can scope the instruction-pointer of the state machine on D26..28 (note the weird encoding though!)
 #define DEBUG_STATE_MACHINE (0)

--- a/ports/raspberrypi/common-hal/max3421e/Max3421E.c
+++ b/ports/raspberrypi/common-hal/max3421e/Max3421E.c
@@ -10,7 +10,7 @@
 #include "shared-bindings/busio/SPI.h"
 #include "supervisor/usb.h"
 
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 
 static max3421e_max3421e_obj_t *active_max = NULL;
 

--- a/ports/raspberrypi/common-hal/microcontroller/Pin.c
+++ b/ports/raspberrypi/common-hal/microcontroller/Pin.c
@@ -9,7 +9,7 @@
 #include "common-hal/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/Pin.h"
 
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 
 static uint64_t gpio_bank0_pin_claimed;
 

--- a/ports/raspberrypi/common-hal/microcontroller/Processor.c
+++ b/ports/raspberrypi/common-hal/microcontroller/Processor.c
@@ -15,26 +15,21 @@
 #include "shared-bindings/time/__init__.h"
 
 #include "pico/stdlib.h"
-#include "src/rp2_common/hardware_adc/include/hardware/adc.h"
-#include "src/rp2_common/hardware_clocks/include/hardware/clocks.h"
-#include "src/rp2_common/hardware_vreg/include/hardware/vreg.h"
-#include "src/rp2_common/hardware_watchdog/include/hardware/watchdog.h"
+#include "hardware/adc.h"
+#include "hardware/clocks.h"
+#include "hardware/vreg.h"
+#include "hardware/watchdog.h"
 
 #ifdef PICO_RP2040
-#include "src/rp2040/hardware_regs/include/hardware/regs/vreg_and_chip_reset.h"
+#include "hardware/regs/vreg_and_chip_reset.h"
+#include "hardware/structs/vreg_and_chip_reset.h"
 #endif
 #ifdef PICO_RP2350
-#include "src/rp2350/hardware_regs/include/hardware/regs/powman.h"
+#include "hardware/regs/powman.h"
+#include "hardware/structs/powman.h"
 #endif
-#include "src/rp2040/hardware_regs/include/hardware/regs/watchdog.h"
-
-#ifdef PICO_RP2040
-#include "src/rp2040/hardware_structs/include/hardware/structs/vreg_and_chip_reset.h"
-#endif
-#ifdef PICO_RP2350
-#include "src/rp2350/hardware_structs/include/hardware/structs/powman.h"
-#endif
-#include "src/rp2040/hardware_structs/include/hardware/structs/watchdog.h"
+#include "hardware/regs/watchdog.h"
+#include "hardware/structs/watchdog.h"
 
 float common_hal_mcu_processor_get_temperature(void) {
     adc_init();

--- a/ports/raspberrypi/common-hal/microcontroller/Processor.h
+++ b/ports/raspberrypi/common-hal/microcontroller/Processor.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "src/rp2_common/pico_unique_id/include/pico/unique_id.h"
+#include "pico/unique_id.h"
 
 #define COMMON_HAL_MCU_PROCESSOR_UID_LENGTH PICO_UNIQUE_BOARD_ID_SIZE_BYTES
 

--- a/ports/raspberrypi/common-hal/microcontroller/__init__.c
+++ b/ports/raspberrypi/common-hal/microcontroller/__init__.c
@@ -19,8 +19,8 @@
 #include "supervisor/port.h"
 #include "supervisor/shared/safe_mode.h"
 
-#include "src/rp2040/hardware_structs/include/hardware/structs/sio.h"
-#include "src/rp2_common/hardware_sync/include/hardware/sync.h"
+#include "hardware/structs/sio.h"
+#include "hardware/sync.h"
 
 #include "hardware/watchdog.h"
 #include "hardware/irq.h"
@@ -51,7 +51,7 @@ void common_hal_mcu_enable_interrupts(void) {
     asm volatile ("cpsie i" : : : "memory");
 }
 #else
-#include "src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Include/RP2350.h"
+#include "RP2350.h"
 #define PICO_ELEVATED_IRQ_PRIORITY (0x60) // between PICO_DEFAULT and PIOCO_HIGHEST_IRQ_PRIORITY
 static uint32_t oldBasePri = 0; // 0 (default) masks nothing, other values mask equal-or-larger priority values
 void common_hal_mcu_disable_interrupts(void) {

--- a/ports/raspberrypi/common-hal/microcontroller/__init__.h
+++ b/ports/raspberrypi/common-hal/microcontroller/__init__.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "src/rp2040/hardware_regs/include/hardware/platform_defs.h"
+#include "hardware/platform_defs.h"
 #include "peripherals/pins.h"
 
 const mcu_pin_obj_t *mcu_get_pin_by_number(int);

--- a/ports/raspberrypi/common-hal/nvm/ByteArray.c
+++ b/ports/raspberrypi/common-hal/nvm/ByteArray.c
@@ -10,7 +10,7 @@
 #include <string.h>
 
 #include "py/runtime.h"
-#include "src/rp2_common/hardware_flash/include/hardware/flash.h"
+#include "hardware/flash.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "supervisor/internal_flash.h"
 

--- a/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2040.c
+++ b/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2040.c
@@ -13,13 +13,13 @@
 #include "common-hal/rp2pio/StateMachine.h"
 #include "supervisor/port.h"
 
-#include "src/common/pico_stdlib_headers/include/pico/stdlib.h"
-#include "src/rp2040/hardware_structs/include/hardware/structs/mpu.h"
-#include "src/rp2_common/cmsis/stub/CMSIS/Device/RP2040/Include/RP2040.h"
-#include "src/rp2_common/hardware_clocks/include/hardware/clocks.h"
-#include "src/rp2_common/hardware_pwm/include/hardware/pwm.h"
-#include "src/rp2_common/hardware_vreg/include/hardware/vreg.h"
-#include "src/rp2_common/pico_multicore/include/pico/multicore.h"
+#include "pico/stdlib.h"
+#include "hardware/structs/mpu.h"
+#include "RP2040.h" // (cmsis)
+#include "hardware/clocks.h"
+#include "hardware/pwm.h"
+#include "hardware/vreg.h"
+#include "pico/multicore.h"
 
 #include "lib/PicoDVI/software/libdvi/tmds_encode.h"
 

--- a/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2350.c
+++ b/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2350.c
@@ -31,14 +31,14 @@
 #include "shared-bindings/time/__init__.h"
 #include "supervisor/port.h"
 
-#include "src/common/pico_stdlib_headers/include/pico/stdlib.h"
+#include "pico/stdlib.h"
 
 // This is from: https://github.com/raspberrypi/pico-examples-rp2350/blob/a1/hstx/dvi_out_hstx_encoder/dvi_out_hstx_encoder.c
 
-#include "sdk/src/rp2_common/hardware_dma/include/hardware/dma.h"
-#include "sdk/src/rp2350/hardware_structs/include/hardware/structs/bus_ctrl.h"
-#include "sdk/src/rp2350/hardware_structs/include/hardware/structs/hstx_ctrl.h"
-#include "sdk/src/rp2350/hardware_structs/include/hardware/structs/hstx_fifo.h"
+#include "hardware/dma.h"
+#include "hardware/structs/bus_ctrl.h"
+#include "hardware/structs/hstx_ctrl.h"
+#include "hardware/structs/hstx_fifo.h"
 
 // ----------------------------------------------------------------------------
 // DVI constants

--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.c
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
+#include "hardware/gpio.h"
 
 #include <stdint.h>
 

--- a/ports/raspberrypi/common-hal/pulseio/PulseIn.h
+++ b/ports/raspberrypi/common-hal/pulseio/PulseIn.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "common-hal/microcontroller/Pin.h"
-#include "src/rp2_common/hardware_pio/include/hardware/pio.h"
+#include "hardware/pio.h"
 #include "common-hal/rp2pio/StateMachine.h"
 
 #include "py/obj.h"

--- a/ports/raspberrypi/common-hal/pulseio/PulseOut.c
+++ b/ports/raspberrypi/common-hal/pulseio/PulseOut.c
@@ -14,9 +14,9 @@
 #include "shared-bindings/microcontroller/__init__.h"
 #include "common-hal/pwmio/PWMOut.h"
 #include "hardware/structs/pwm.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
-#include "src/rp2_common/hardware_pwm/include/hardware/pwm.h"
-#include "src/common/pico_time/include/pico/time.h"
+#include "hardware/gpio.h"
+#include "hardware/pwm.h"
+#include "pico/time.h"
 
 volatile alarm_id_t cur_alarm = 0;
 

--- a/ports/raspberrypi/common-hal/pulseio/PulseOut.h
+++ b/ports/raspberrypi/common-hal/pulseio/PulseOut.h
@@ -8,7 +8,7 @@
 
 #include "common-hal/microcontroller/Pin.h"
 #include "common-hal/pwmio/PWMOut.h"
-#include "src/common/pico_time/include/pico/time.h"
+#include "pico/time.h"
 
 #include "py/obj.h"
 

--- a/ports/raspberrypi/common-hal/pwmio/PWMOut.c
+++ b/ports/raspberrypi/common-hal/pwmio/PWMOut.c
@@ -12,10 +12,10 @@
 #include "shared-bindings/pwmio/PWMOut.h"
 #include "shared-bindings/microcontroller/Processor.h"
 
-#include "src/rp2040/hardware_regs/include/hardware/platform_defs.h"
-#include "src/rp2_common/hardware_clocks/include/hardware/clocks.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
-#include "src/rp2_common/hardware_pwm/include/hardware/pwm.h"
+#include "hardware/platform_defs.h"
+#include "hardware/clocks.h"
+#include "hardware/gpio.h"
+#include "hardware/pwm.h"
 
 uint32_t target_slice_frequencies[NUM_PWM_SLICES];
 uint32_t slice_variable_frequency;

--- a/ports/raspberrypi/common-hal/rgbmatrix/RGBMatrix.c
+++ b/ports/raspberrypi/common-hal/rgbmatrix/RGBMatrix.c
@@ -12,8 +12,8 @@
 #include "shared-bindings/pwmio/PWMOut.h"
 #include "shared-module/rgbmatrix/RGBMatrix.h"
 
-#include "src/rp2_common/hardware_pwm/include/hardware/pwm.h"
-#include "src/rp2_common/hardware_irq/include/hardware/irq.h"
+#include "hardware/pwm.h"
+#include "hardware/irq.h"
 
 void *common_hal_rgbmatrix_timer_allocate(rgbmatrix_rgbmatrix_obj_t *self) {
     // Choose a PWM channel based on the first RGB pin

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -14,18 +14,12 @@
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-bindings/memorymap/AddressRange.h"
 
-#if defined(PICO_RP2040)
-#include "src/rp2040/hardware_regs/include/hardware/platform_defs.h"
-#include "src/rp2040/hardware_structs/include/hardware/structs/iobank0.h"
-#elif defined(PICO_RP2350)
-#include "src/rp2350/hardware_regs/include/hardware/platform_defs.h"
-#include "src/rp2350/hardware_structs/include/hardware/structs/iobank0.h"
-#endif
-
-#include "src/rp2_common/hardware_clocks/include/hardware/clocks.h"
-#include "src/rp2_common/hardware_dma/include/hardware/dma.h"
-#include "src/rp2_common/hardware_pio/include/hardware/pio_instructions.h"
-#include "src/rp2_common/hardware_irq/include/hardware/irq.h"
+#include "hardware/platform_defs.h"
+#include "hardware/structs/iobank0.h"
+#include "hardware/clocks.h"
+#include "hardware/dma.h"
+#include "hardware/pio_instructions.h"
+#include "hardware/irq.h"
 
 #include "shared/runtime/interrupt_char.h"
 #include "py/obj.h"

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.h
@@ -10,7 +10,7 @@
 
 #include "common-hal/microcontroller/Pin.h"
 #include "common-hal/memorymap/AddressRange.h"
-#include "src/rp2_common/hardware_pio/include/hardware/pio.h"
+#include "hardware/pio.h"
 
 // pio_pinmask_t can hold ANY pin masks, so it is used before selection of gpiobase
 #if NUM_BANK0_GPIOS > 32

--- a/ports/raspberrypi/common-hal/rtc/RTC.c
+++ b/ports/raspberrypi/common-hal/rtc/RTC.c
@@ -11,8 +11,8 @@
 #include "py/runtime.h"
 #include "shared/timeutils/timeutils.h"
 
-#include "src/common/pico_util/include/pico/util/datetime.h"
-#include "src/rp2_common/pico_aon_timer/include/pico/aon_timer.h"
+#include "pico/util/datetime.h"
+#include "pico/aon_timer.h"
 
 void common_hal_rtc_init(void) {
     // We start the RTC at 0 which mark as January 1, 2000.

--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -35,7 +35,7 @@
 #include "lwip/timeouts.h"
 #include "lwip/udp.h"
 
-#include "sdk/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h"
+#include "pico/cyw43_arch.h"
 
 mp_obj_t socketpool_ip_addr_to_str(const ip_addr_t *addr) {
     char ip_str[IPADDR_STRLEN_MAX]; // big enough for any supported address type

--- a/ports/raspberrypi/common-hal/usb_host/Port.c
+++ b/ports/raspberrypi/common-hal/usb_host/Port.c
@@ -11,17 +11,16 @@
 #include "supervisor/shared/serial.h"
 #include "supervisor/usb.h"
 
-#include "src/common/pico_time/include/pico/time.h"
+#include "pico/time.h"
+#include "hardware/structs/mpu.h"
 #ifdef PICO_RP2040
-#include "src/rp2040/hardware_structs/include/hardware/structs/mpu.h"
-#include "src/rp2_common/cmsis/stub/CMSIS/Device/RP2040/Include/RP2040.h"
+#include "RP2040.h" // (cmsis)
 #endif
 #ifdef PICO_RP2350
-#include "src/rp2350/hardware_structs/include/hardware/structs/mpu.h"
-#include "src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Include/RP2350.h"
+#include "RP2350.h" // (cmsis)
 #endif
-#include "src/rp2_common/hardware_dma/include/hardware/dma.h"
-#include "src/rp2_common/pico_multicore/include/pico/multicore.h"
+#include "hardware/dma.h"
+#include "pico/multicore.h"
 
 #include "py/runtime.h"
 

--- a/ports/raspberrypi/cyw43_configport.h
+++ b/ports/raspberrypi/cyw43_configport.h
@@ -12,7 +12,7 @@
 
 #include "supervisor/port.h"
 
-#include "sdk/src/rp2_common/pico_cyw43_driver/include/cyw43_configport.h"
+#include_next "cyw43_configport.h"
 
 #define CYW43_NETUTILS                  (1)
 

--- a/ports/raspberrypi/mphalport.c
+++ b/ports/raspberrypi/mphalport.c
@@ -19,7 +19,7 @@
 #include "mphalport.h"
 #include "supervisor/shared/tick.h"
 
-#include "src/rp2_common/hardware_timer/include/hardware/timer.h"
+#include "hardware/timer.h"
 
 extern uint32_t common_hal_mcu_processor_get_frequency(void);
 

--- a/ports/raspberrypi/supervisor/internal_flash.c
+++ b/ports/raspberrypi/supervisor/internal_flash.c
@@ -24,11 +24,11 @@
 #include "supervisor/usb.h"
 
 #ifdef PICO_RP2350
-#include "src/rp2350/hardware_structs/include/hardware/structs/qmi.h"
+#include "hardware/structs/qmi.h"
 #endif
-#include "src/rp2040/hardware_structs/include/hardware/structs/sio.h"
-#include "src/rp2_common/hardware_flash/include/hardware/flash.h"
-#include "src/common/pico_binary_info/include/pico/binary_info.h"
+#include "hardware/structs/sio.h"
+#include "hardware/flash.h"
+#include "pico/binary_info.h"
 
 #if !defined(TOTAL_FLASH_MINIMUM)
 #define TOTAL_FLASH_MINIMUM (2 * 1024 * 1024)

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -37,23 +37,23 @@
 #include "supervisor/shared/stack.h"
 #include "supervisor/shared/tick.h"
 
-#include "src/rp2040/hardware_structs/include/hardware/structs/watchdog.h"
-#include "src/rp2_common/hardware_gpio/include/hardware/gpio.h"
-#include "src/rp2_common/hardware_uart/include/hardware/uart.h"
-#include "src/rp2_common/hardware_sync/include/hardware/sync.h"
-#include "src/rp2_common/hardware_timer/include/hardware/timer.h"
+#include "hardware/structs/watchdog.h"
+#include "hardware/gpio.h"
+#include "hardware/uart.h"
+#include "hardware/sync.h"
+#include "hardware/timer.h"
 #if CIRCUITPY_CYW43
 #include "py/mphal.h"
 #include "pico/cyw43_arch.h"
 #endif
-#include "src/common/pico_time/include/pico/time.h"
-#include "src/common/pico_binary_info/include/pico/binary_info.h"
+#include "pico/time.h"
+#include "pico/binary_info.h"
 
 #include "pico/bootrom.h"
 #include "hardware/watchdog.h"
 
 #ifdef PICO_RP2350
-#include "src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Include/RP2350.h"
+#include "RP2350.h" // CMSIS
 #endif
 
 #include "supervisor/shared/serial.h"
@@ -95,10 +95,10 @@ static size_t _psram_size = 0;
 
 #ifdef CIRCUITPY_PSRAM_CHIP_SELECT
 
-#include "src/rp2350/hardware_regs/include/hardware/regs/qmi.h"
-#include "src/rp2350/hardware_regs/include/hardware/regs/xip.h"
-#include "src/rp2350/hardware_structs/include/hardware/structs/qmi.h"
-#include "src/rp2350/hardware_structs/include/hardware/structs/xip_ctrl.h"
+#include "hardware/regs/qmi.h"
+#include "hardware/regs/xip.h"
+#include "hardware/structs/qmi.h"
+#include "hardware/structs/xip_ctrl.h"
 
 static void __no_inline_not_in_flash_func(setup_psram)(void) {
     gpio_set_function(CIRCUITPY_PSRAM_CHIP_SELECT->number, GPIO_FUNC_XIP_CS1);

--- a/ports/raspberrypi/supervisor/usb.c
+++ b/ports/raspberrypi/supervisor/usb.c
@@ -7,9 +7,9 @@
 #include "lib/tinyusb/src/device/usbd.h"
 #include "supervisor/background_callback.h"
 #include "supervisor/usb.h"
-#include "src/rp2_common/hardware_irq/include/hardware/irq.h"
+#include "hardware/irq.h"
 #include "pico/platform.h"
-#include "src/rp2040/hardware_regs/include/hardware/regs/intctrl.h"
+#include "hardware/regs/intctrl.h"
 
 void init_usb_hardware(void) {
 }


### PR DESCRIPTION
This lets each MCU type get the correct definitions. It also simplifies paths at include sites.

Closes: #10181