### PR TITLE
Add guards to common_hal_pulseio_pulse(in|out)_deinit to prevent doub…

### DIFF
--- a/ports/espressif/common-hal/pulseio/PulseIn.c
+++ b/ports/espressif/common-hal/pulseio/PulseIn.c
@@ -127,6 +127,9 @@ bool common_hal_pulseio_pulsein_deinited(pulseio_pulsein_obj_t *self) {
 }
 
 void common_hal_pulseio_pulsein_deinit(pulseio_pulsein_obj_t *self) {
+    if (common_hal_pulseio_pulsein_deinited(self)) {
+        return;
+    }
     rmt_disable(self->channel);
     reset_pin_number(self->pin->number);
     rmt_del_channel(self->channel);

--- a/ports/espressif/common-hal/pulseio/PulseOut.c
+++ b/ports/espressif/common-hal/pulseio/PulseOut.c
@@ -54,6 +54,9 @@ bool common_hal_pulseio_pulseout_deinited(pulseio_pulseout_obj_t *self) {
 }
 
 void common_hal_pulseio_pulseout_deinit(pulseio_pulseout_obj_t *self) {
+    if (common_hal_pulseio_pulseout_deinited(self)) {
+        return;
+    }
     rmt_disable(self->channel);
     rmt_del_encoder(self->encoder);
     rmt_del_channel(self->channel);


### PR DESCRIPTION
Add guards to `common_hal_pulseio_pulsein_deinit()` and `common_hal_pusleio_pusleout_deinit()` to prevent double release of the `pulseio_pulse(in|out)` object's resources.

Fixed same issue in  `pulseout`.

Resolves #10004.