### PR TITLE
fix tilegrid.contains for subclasses

### DIFF
--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -316,7 +316,7 @@ MP_PROPERTY_GETSET(displayio_tilegrid_transpose_xy_obj,
 //|         inside the tilegrid rectangle bounds."""
 //|
 static mp_obj_t displayio_tilegrid_obj_contains(mp_obj_t self_in, mp_obj_t touch_tuple) {
-    displayio_tilegrid_t *self = MP_OBJ_TO_PTR(self_in);
+    displayio_tilegrid_t *self = native_tilegrid(self_in);
 
     mp_obj_t *touch_tuple_items;
     mp_obj_get_array_fixed_n(touch_tuple, 3, &touch_tuple_items);


### PR DESCRIPTION
Tested successfully on Fruit Jam with the Set card game that I am working on, as well as this more simple reproducer code:
```
from displayio import TileGrid, Bitmap, Palette

palette = Palette(1)
palette[0] = 0x0

bmp = Bitmap(100, 100, 1)
tg = TileGrid(bitmap=bmp, pixel_shader=palette, tile_width=100, tile_height=100)
print(tg.contains((50, 50, 0)))

class SpecialTileGrid(TileGrid):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)

special_tile_grid = SpecialTileGrid(bitmap=bmp, pixel_shader=palette,tile_width=100, tile_height=100)
print(special_tile_grid.width, special_tile_grid.height)
print(special_tile_grid.contains((50, 50, 0)))
```