### PR TITLE
Convert completely to new displayio bus bindings; remove warnings

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -17,12 +17,6 @@
 // Always 1: defined in circuitpy_mpconfig.mk
 // #define CIRCUITPY (1)
 
-// Can be removed once CircuitPython 10 is released.
-// Print warnings or not about deprecated names. See objmodule.c.
-#ifndef CIRCUITPY_9_10_WARNINGS
-#define CIRCUITPY_9_10_WARNINGS (1)
-#endif
-
 // REPR_C encodes qstrs, 31-bit ints, and 30-bit floats in a single 32-bit word.
 #ifndef MICROPY_OBJ_REPR
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -67,33 +67,6 @@ static void module_attr_try_delegation(mp_obj_t self_in, qstr attr, mp_obj_t *de
 static void module_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     mp_obj_module_t *self = MP_OBJ_TO_PTR(self_in);
     if (dest[0] == MP_OBJ_NULL) {
-        // CIRCUITPY-CHANGE
-        #if CIRCUITPY_9_10_WARNINGS && CIRCUITPY_DISPLAYIO && CIRCUITPY_WARNINGS
-        if (self == &displayio_module) {
-            #if CIRCUITPY_BUSDISPLAY
-            if (attr == MP_QSTR_Display) {
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q moved from %q to %q"), MP_QSTR_Display, MP_QSTR_displayio, MP_QSTR_busdisplay);
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q renamed %q"), MP_QSTR_Display, MP_QSTR_BusDisplay);
-            }
-            #endif
-            #if CIRCUITPY_EPAPERDISPLAY
-            if (attr == MP_QSTR_EPaperDisplay) {
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q moved from %q to %q"), MP_QSTR_EPaperDisplay, MP_QSTR_displayio, MP_QSTR_epaperdisplay);
-            }
-            #endif
-            #if CIRCUITPY_FOURWIRE
-            if (attr == MP_QSTR_FourWire) {
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q moved from %q to %q"), MP_QSTR_FourWire, MP_QSTR_displayio, MP_QSTR_fourwire);
-            }
-            #endif
-            #if CIRCUITPY_I2CDISPLAYBUS
-            if (attr == MP_QSTR_I2CDisplay) {
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q moved from %q to %q"), MP_QSTR_I2CDisplay, MP_QSTR_displayio, MP_QSTR_i2cdisplaybus);
-                warnings_warn(&mp_type_FutureWarning, MP_ERROR_TEXT("%q renamed %q"), MP_QSTR_I2CDisplay, MP_QSTR_I2CDisplayBus);
-            }
-            #endif
-        }
-        #endif
         // load attribute
         mp_map_elem_t *elem = mp_map_lookup(&self->globals->map, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP);
         if (elem != NULL) {

--- a/shared-bindings/displayio/__init__.c
+++ b/shared-bindings/displayio/__init__.c
@@ -100,21 +100,8 @@ static const mp_rom_map_elem_t displayio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_Palette), MP_ROM_PTR(&displayio_palette_type) },
     { MP_ROM_QSTR(MP_QSTR_TileGrid), MP_ROM_PTR(&displayio_tilegrid_type) },
 
-    // Remove these in CircuitPython 10
-    #if CIRCUITPY_BUSDISPLAY
-    { MP_ROM_QSTR(MP_QSTR_Display), MP_ROM_PTR(&busdisplay_busdisplay_type) },
-    #endif
-    #if CIRCUITPY_EPAPERDISPLAY
-    { MP_ROM_QSTR(MP_QSTR_EPaperDisplay), MP_ROM_PTR(&epaperdisplay_epaperdisplay_type) },
-    #endif
-    #if CIRCUITPY_FOURWIRE
-    { MP_ROM_QSTR(MP_QSTR_FourWire), MP_ROM_PTR(&fourwire_fourwire_type) },
-    #endif
-    #if CIRCUITPY_I2CDISPLAYBUS
-    { MP_ROM_QSTR(MP_QSTR_I2CDisplay), MP_ROM_PTR(&i2cdisplaybus_i2cdisplaybus_type) },
-    #endif
-
     { MP_ROM_QSTR(MP_QSTR_release_displays), MP_ROM_PTR(&displayio_release_displays_obj) },
+
     { MP_ROM_QSTR(MP_QSTR_CIRCUITPYTHON_TERMINAL), MP_ROM_PTR(&circuitpython_splash) },
 };
 static MP_DEFINE_CONST_DICT(displayio_module_globals, displayio_module_globals_table);


### PR DESCRIPTION
- Fixes #10138

This removes the ability to use the old displayio bus bindings, and also removes `CIRCUITPY_9_10_WARNINGS` and the associated warnings.

@tannewt It was my understanding it's OK to remove these warnings now, because they were meant to be present in 9.x.x (though we messed up on that a bit). If this is wrong, I can restore them.

There are no more uses of the old bindings in the library bundle.

Tested on a PyPortal Titano with the NASA image project.

