### PR TITLE
Fix analogbufio.BufferedIn pin validation on RP2350B

### DIFF
--- a/ports/raspberrypi/common-hal/analogbufio/BufferedIn.c
+++ b/ports/raspberrypi/common-hal/analogbufio/BufferedIn.c
@@ -20,11 +20,14 @@
 
 void common_hal_analogbufio_bufferedin_construct(analogbufio_bufferedin_obj_t *self, const mcu_pin_obj_t *pin, uint32_t sample_rate) {
     // Make sure pin number is in range for ADC
-    if ((pin->number < ADC_BASE_PIN) ||
-        (pin->number > ADC_BASE_PIN + NUM_ADC_CHANNELS - 1) ||
-        // On Pico W and Pico 2 W, GPIO29 is both a voltage monitor and used for SPI to the CYW43.
+    if ((pin->number < ADC_BASE_PIN)
+        || (pin->number > ADC_BASE_PIN + NUM_ADC_CHANNELS - 1)
+        // On many boards with a CYW43 radio co-processor, CYW43_DEFAULT_PIN_WL_CLOCK (usually GPIO29),
+        // is both a voltage monitor and also SPI SCK to the CYW43.
         // Disallow its use for BufferedIn.
-        (CIRCUITPY_CYW43 && pin->number == 29)
+        #if defined(CIRCUITPY_CYW43) && defined(CYW43_DEFAULT_PIN_WL_CLOCK)
+        || (pin->number == CYW43_DEFAULT_PIN_WL_CLOCK)
+        #endif
         ) {
         raise_ValueError_invalid_pin();
     }

--- a/ports/raspberrypi/common-hal/analogbufio/BufferedIn.c
+++ b/ports/raspberrypi/common-hal/analogbufio/BufferedIn.c
@@ -15,16 +15,18 @@
 #include "hardware/dma.h"
 #include "pico/stdlib.h"
 
-#define ADC_FIRST_PIN_NUMBER 26
-#define ADC_PIN_COUNT 4
-
 #define ADC_CLOCK_INPUT 48000000
 #define ADC_MAX_CLOCK_DIV (1 << (ADC_DIV_INT_MSB - ADC_DIV_INT_LSB + 1))
 
 void common_hal_analogbufio_bufferedin_construct(analogbufio_bufferedin_obj_t *self, const mcu_pin_obj_t *pin, uint32_t sample_rate) {
     // Make sure pin number is in range for ADC
-    if (pin->number < ADC_FIRST_PIN_NUMBER || pin->number >= (ADC_FIRST_PIN_NUMBER + ADC_PIN_COUNT)) {
-        raise_ValueError_invalid_pins();
+    if ((pin->number < ADC_BASE_PIN) ||
+        (pin->number > ADC_BASE_PIN + NUM_ADC_CHANNELS - 1) ||
+        // On Pico W and Pico 2 W, GPIO29 is both a voltage monitor and used for SPI to the CYW43.
+        // Disallow its use for BufferedIn.
+        (CIRCUITPY_CYW43 && pin->number == 29)
+        ) {
+        raise_ValueError_invalid_pin();
     }
 
     // Validate sample rate here
@@ -35,7 +37,7 @@ void common_hal_analogbufio_bufferedin_construct(analogbufio_bufferedin_obj_t *s
     claim_pin(pin);
 
     // TODO: find a way to accept ADC4 for temperature
-    self->chan = pin->number - ADC_FIRST_PIN_NUMBER;
+    self->chan = pin->number - ADC_BASE_PIN;
 
     // Init GPIO for analogue use: hi-Z, no pulls, disable digital input buffer.
     // TODO: Make sure we share the ADC well. Right now we just assume it is

--- a/ports/raspberrypi/common-hal/analogio/AnalogIn.c
+++ b/ports/raspberrypi/common-hal/analogio/AnalogIn.c
@@ -12,12 +12,12 @@
 
 #include "hardware/adc.h"
 
-// Voltage monitor is special on Pico W and Pico 2 W, because this pin is shared between the
-// voltage monitor function and the wifi function. Special handling is required
-// to read the analog voltage.
+// On many boards with a CYW43 radio co-processor, CYW43_DEFAULT_PIN_WL_CLOCK (usually GPIO29),
+// is both a voltage monitor and also SPI SCK to the CYW43.
+// Special handling is required to read the analog voltage.
 #if CIRCUITPY_CYW43
 #include "bindings/cyw43/__init__.h"
-#define SPECIAL_PIN(pin) (pin->number == 29)
+#define SPECIAL_PIN(pin) (pin->number == CYW43_DEFAULT_PIN_WL_CLOCK)
 
 const mcu_pin_obj_t *common_hal_analogio_analogin_validate_pin(mp_obj_t obj) {
     return validate_obj_is_free_pin_or_gpio29(obj, MP_QSTR_pin);

--- a/ports/raspberrypi/common-hal/analogio/AnalogIn.c
+++ b/ports/raspberrypi/common-hal/analogio/AnalogIn.c
@@ -12,15 +12,7 @@
 
 #include "hardware/adc.h"
 
-#define ADC_PIN_COUNT (NUM_ADC_CHANNELS - 1)
-
-#if ADC_PIN_COUNT == 4
-#define ADC_FIRST_PIN_NUMBER 26
-#else
-#define ADC_FIRST_PIN_NUMBER 40
-#endif
-
-// Voltage monitor is special on Pico W, because this pin is shared between the
+// Voltage monitor is special on Pico W and Pico 2 W, because this pin is shared between the
 // voltage monitor function and the wifi function. Special handling is required
 // to read the analog voltage.
 #if CIRCUITPY_CYW43
@@ -35,7 +27,7 @@ const mcu_pin_obj_t *common_hal_analogio_analogin_validate_pin(mp_obj_t obj) {
 #endif
 
 void common_hal_analogio_analogin_construct(analogio_analogin_obj_t *self, const mcu_pin_obj_t *pin) {
-    if (pin->number < ADC_FIRST_PIN_NUMBER || pin->number > ADC_FIRST_PIN_NUMBER + ADC_PIN_COUNT) {
+    if (pin->number < ADC_BASE_PIN || pin->number > ADC_BASE_PIN + NUM_ADC_CHANNELS - 1) {
         raise_ValueError_invalid_pin();
     }
 
@@ -70,7 +62,7 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
         uint32_t old_pad = pads_bank0_hw->io[self->pin->number];
         uint32_t old_ctrl = io_bank0_hw->io[self->pin->number].ctrl;
         adc_gpio_init(self->pin->number);
-        adc_select_input(self->pin->number - ADC_FIRST_PIN_NUMBER);
+        adc_select_input(self->pin->number - ADC_BASE_PIN);
         common_hal_mcu_delay_us(100);
         value = adc_read();
         gpio_init(self->pin->number);
@@ -78,7 +70,7 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
         io_bank0_hw->io[self->pin->number].ctrl = old_ctrl;
         common_hal_mcu_enable_interrupts();
     } else {
-        adc_select_input(self->pin->number - ADC_FIRST_PIN_NUMBER);
+        adc_select_input(self->pin->number - ADC_BASE_PIN);
         value = adc_read();
     }
     // Stretch 12-bit ADC reading to 16-bit range

--- a/shared-bindings/analogbufio/BufferedIn.c
+++ b/shared-bindings/analogbufio/BufferedIn.c
@@ -39,6 +39,9 @@
 //|     def __init__(self, pin: microcontroller.Pin, *, sample_rate: int) -> None:
 //|         """Create a `BufferedIn` on the given pin and given sample rate.
 //|
+//|         **Limitations**: On Pi Pico W and Pi Pico 2 W, pin ``board.A3`` is not supported
+//|         because it is also used to control the CYW43 radio module.
+//|
 //|         :param ~microcontroller.Pin pin: the pin to read from
 //|         :param ~int sample_rate: rate: sampling frequency, in samples per second"""
 //|         ...

--- a/shared-bindings/analogbufio/BufferedIn.c
+++ b/shared-bindings/analogbufio/BufferedIn.c
@@ -39,11 +39,13 @@
 //|     def __init__(self, pin: microcontroller.Pin, *, sample_rate: int) -> None:
 //|         """Create a `BufferedIn` on the given pin and given sample rate.
 //|
-//|         **Limitations**: On Pi Pico W and Pi Pico 2 W, pin ``board.A3`` is not supported
-//|         because it is also used to control the CYW43 radio module.
-//|
 //|         :param ~microcontroller.Pin pin: the pin to read from
-//|         :param ~int sample_rate: rate: sampling frequency, in samples per second"""
+//|         :param ~int sample_rate: rate: sampling frequency, in samples per second
+//|
+//|         **Limitations**: On many boards with a CYW43 radio module, such as Pico W,
+//|         GPIO29 (often ``board.A3``) is also used to control the CYW43,
+//|         and is therefore not available to use as the `BufferedIn` pin.
+//|         """
 //|         ...
 //|
 static mp_obj_t analogbufio_bufferedin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {


### PR DESCRIPTION
- Fixes #10201.

- Fix `analogbufio.BufferedIn` pin validation on RP2350B.
- Use`pico-sdk`-supplied `ADC_BASE_PIN` instead of figuring out the base pin ourselves.
- Disallow using `board.A3` (GPIO29) on Pico W and Pico 2 W for `analogbufio.BufferedIn`, and document that. GPIO29  pin has a voltage divider attached to monitor VSYS, and is also shared with SPI SCK connected to the radio module. `AnalogIn` special-cases `A3` to make it available, but that was complicated, and I think the use case for GPIO29 with `analogbufio` is limited. 