### PR TITLE
Fix neopixel colors GRB on waveshare_esp32_c6_lcd_1_47

### DIFF
--- a/ports/espressif/boards/waveshare_esp32_c6_lcd_1_47/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_c6_lcd_1_47/mpconfigboard.h
@@ -12,6 +12,7 @@
 #define MICROPY_HW_MCU_NAME         "ESP32-C6FH4"
 
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO8)
+#define MICROPY_HW_NEOPIXEL_ORDER_GRB (1)
 
 // I2C
 #define CIRCUITPY_BOARD_I2C         (1)


### PR DESCRIPTION
This makes the LED properly blink green on script end and red on error (yellow and blue are unchanged).
May be of interest to @bwshockley who contributed the board.
Note that this does not impact user code at all, which still needs to use `pixel_order`:
```py
pixel = neopixel.NeoPixel(board.NEOPIXEL, 1, pixel_order="RGB")
```
