### PR TITLE
clean up .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,19 +4,33 @@
 
 # CIRCUITPY-CHANGE: CircuitPython-specific.
 
+# Note that by default, pre-commit hooks do not look inside submodules.
+# So you don't need to exclude submodules explicitly here.
+
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-        exclude: '^(tests/.*\.exp|tests/cmdline/.*|tests/.*/data/.*|ports/mimxrt10xx/sdk|ports/raspberrypi/sdk|lib/tinyusb)'
-    -   id: trailing-whitespace
-        exclude: '^(tests/.*\.exp|tests/cmdline/.*|tests/.*/data/.*|lib/mbedtls_errors/generate_errors.diff|ports/raspberrypi/sdk|ports/mimxrt10xx/sdk|lib/tinyusb)'
--   repo: https://github.com/codespell-project/codespell
+      - id: check-yaml
+      - id: end-of-file-fixer
+        exclude: |
+          (?x)^(
+            tests/.*\.exp|
+            tests/cmdline/.*|
+            tests/.*/data/.*
+          )
+      - id: trailing-whitespace
+        exclude: |
+          (?x)^(
+            tests/.*\.exp|
+            tests/cmdline/.*|
+            tests/.*/data/.*|
+            lib/mbedtls_errors/generate_errors.diff
+          )
+  - repo: https://github.com/codespell-project/codespell
     rev: v2.2.4
     hooks:
-    -   id: codespell
+      - id: codespell
         args: [-w]
         exclude: |
           (?x)^(
@@ -25,38 +39,30 @@ repos:
             tests/unicode/data/utf-8_invalid.txt|
             tests/extmod/data/qr.pgm|
             tests/basics/bytearray_byte_operations.py|
-            ports/raspberrypi/sdk|
             ports/zephyr-cp/cptools/compat2driver.py
           )
--   repo: local
+  - repo: local
     hooks:
-    -   id: translations
+      - id: translations
         name: Translations
         entry: sh -c "if ! make check-translate; then make translate; fi"
         types: [c]
         pass_filenames: false
         language: system
-    -   id: formatting
+      - id: formatting
         name: Formatting
-        entry: python3 tools/codeformat.py
-        types: [c]
-        language: system
-        exclude: |
-          (?x)^(
-            lib/tinyusb|
-            ports/raspberrypi/sdk
-          )
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.9.4
-  hooks:
-    # Run the linter.
-    - id: ruff
-      args: [ --fix ]
-    # Run the formatter.
-    - id: ruff-format
-- repo: https://github.com/tox-dev/pyproject-fmt
-  rev: "v2.5.0"
-  hooks:
-    - id: pyproject-fmt
-      exclude: '^(ports/mimxrt10xx/sdk)'
+        entry: python3 tools/codeformat.py -v -c
+        language: python
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.9.4
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: "v2.5.0"
+    hooks:
+      - id: pyproject-fmt


### PR DESCRIPTION
[In #10156 I tried to fix some spurious reformatting of .py code in the `mimxrt1011/sdk` when pre-commit was run. It didn't actually work. This should fix that.

- Fix some strange indentation in `.pre-commit-config-yaml`.
- Remove some incorrect settings
- Format only C code using `tools/codeformat.py`. Use the ruff pre-commit actions to format Python.
- Make the `exclude:` settings easier to read, and remove unneeded excludes.