### PR TITLE
fix for Nx1 sized Terminal

### DIFF
--- a/shared-bindings/terminalio/Terminal.c
+++ b/shared-bindings/terminalio/Terminal.c
@@ -88,8 +88,7 @@ static mp_obj_t terminalio_terminal_make_new(const mp_obj_type_t *type, size_t n
 
     fontio_builtinfont_t *font = mp_arg_validate_type(args[ARG_font].u_obj, &fontio_builtinfont_type, MP_QSTR_font);
 
-    mp_arg_validate_int_min(scroll_area->width_in_tiles, 2, MP_QSTR_scroll_area_width);
-    mp_arg_validate_int_min(scroll_area->height_in_tiles, 2, MP_QSTR_scroll_area_height);
+    mp_arg_validate_int_min(scroll_area->width_in_tiles * scroll_area->height_in_tiles, 2, MP_QSTR_scroll_area_area);
 
     terminalio_terminal_obj_t *self = mp_obj_malloc(terminalio_terminal_obj_t, &terminalio_terminal_type);
 


### PR DESCRIPTION
This forum post https://forums.adafruit.com/viewtopic.php?p=1051479#p1051479 reports an exception raised by the code from this learn guide: https://learn.adafruit.com/infinite-text-adventure/overview. 

The code is attempting to create a Terminal instance with height 1 https://github.com/adafruit/Adafruit_Learning_System_Guides/blob/main/CircuitPython_Zorque_Text_Game_openai/code.py#L106-L111

The current validation of width and height >=2 was added here: https://github.com/adafruit/circuitpython/pull/7892 but the actual implementation used differs subtly from what the referenced issue had asked for
> Terminal should verify that the tilegrid is more than 1x1 and raise an exception if not. 

The current implementation also raises an exception in the Nx1 case which is what the learn guide is doing. 

This PR changes the validation to multiply width and height first so that we are validating the total area rather than each axis size independently. 

I tested on a PyPortal Titano successfully with this code:
```
import supervisor
import terminalio
import displayio

bbox = terminalio.FONT.get_bounding_box()
main_group = displayio.Group(scale=1)
display = supervisor.runtime.display
display.root_group = main_group

palette = displayio.Palette(2)
palette[0] = 0x444444
palette[1] = 0xFFFFFF

def terminal_label(text, width_in_chars, palette, x, y):
    label = displayio.TileGrid(terminalio.FONT.bitmap, pixel_shader=palette,
                               width=width_in_chars, height=1, tile_width=bbox[0],
                               tile_height=bbox[1])
    label.x = x
    label.y = y
    term = terminalio.Terminal(label, terminalio.FONT)
    term.write(f"{text}")
    return label

main_group.append(terminal_label("Hello World"*2, display.width // bbox[0], palette, 2,2))

while True:
    pass
```
I also verified that 1x1 does still raise an exception