### PR TITLE
Force inline critical_section_{enter,exit} from SDK

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -172,7 +172,8 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_SimpleMath
 [submodule "ports/raspberrypi/sdk"]
 	path = ports/raspberrypi/sdk
-	url = https://github.com/raspberrypi/pico-sdk.git
+	url = https://github.com/adafruit/pico-sdk.git
+	branch = force_inline_critical_section
 [submodule "data/nvm.toml"]
 	path = data/nvm.toml
 	url = https://github.com/adafruit/nvm.toml.git


### PR DESCRIPTION
These are used by USB host on core 1 and must be in RAM to work. The softer `inline` keyword allows the compiler to ignore it and put the function in flash instead. Core 1 will crash then.

Upstream PR is here: https://github.com/raspberrypi/pico-sdk/pull/2393