### PR TITLE
Add TouchIn "pull_dir" option, touchio works for RP2350

### DIFF
--- a/ports/raspberrypi/mpconfigport.mk
+++ b/ports/raspberrypi/mpconfigport.mk
@@ -66,7 +66,7 @@ CIRCUITPY_PICODVI ?= 1
 
 # Our generic touchio uses a pull down and RP2350 A2 hardware doesn't work correctly.
 # So, turn touchio off because it doesn't work.
-CIRCUITPY_TOUCHIO = 0
+#CIRCUITPY_TOUCHIO = 0
 
 # delay in ms before calling cyw43_arch_init_with_country
 CIRCUITPY_CYW43_INIT_DELAY ?= 0

--- a/shared-bindings/touchio/TouchIn.c
+++ b/shared-bindings/touchio/TouchIn.c
@@ -31,22 +31,33 @@
 //|                print("touched!")"""
 //|
 
-//|     def __init__(self, pin: microcontroller.Pin) -> None:
+//|     def __init__(self, pin: microcontroller.Pin, pulldir: bool -> False) -> None:
 //|         """Use the TouchIn on the given pin.
 //|
 //|         :param ~microcontroller.Pin pin: the pin to read from"""
+//|         :param ~bool pulldir: kind of external pull resistor, false = pulldown, true = pullup
 //|         ...
 //|
-static mp_obj_t touchio_touchin_make_new(const mp_obj_type_t *type,
-    size_t n_args, size_t n_kw, const mp_obj_t *args) {
+//static mp_obj_t touchio_touchin_make_new(const mp_obj_type_t *type,
+//    size_t n_args, size_t n_kw, const mp_obj_t *args) {
     // check number of arguments
-    mp_arg_check_num(n_args, n_kw, 1, 1, false);
-
+    /// mp_arg_check_num(n_args, n_kw, 1, 1, false);
+static mp_obj_t touchio_touchin_make_new(const mp_obj_type_t *type,
+                                         size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    enum { ARG_pin, ARG_pulldir };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_pin,     MP_ARG_OBJ | MP_ARG_REQUIRED },
+        { MP_QSTR_pulldir, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    
     // 1st argument is the pin
-    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[0], MP_QSTR_pin);
+    const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
+    const bool pulldir = args[ARG_pulldir].u_bool;
 
     touchio_touchin_obj_t *self = mp_obj_malloc(touchio_touchin_obj_t, &touchio_touchin_type);
-    common_hal_touchio_touchin_construct(self, pin);
+    common_hal_touchio_touchin_construct(self, pin, pulldir);
 
     return (mp_obj_t)self;
 }

--- a/shared-bindings/touchio/TouchIn.h
+++ b/shared-bindings/touchio/TouchIn.h
@@ -16,7 +16,7 @@
 
 extern const mp_obj_type_t touchio_touchin_type;
 
-void common_hal_touchio_touchin_construct(touchio_touchin_obj_t *self, const mcu_pin_obj_t *pin);
+void common_hal_touchio_touchin_construct(touchio_touchin_obj_t *self, const mcu_pin_obj_t *pin, const bool pulldir);
 void common_hal_touchio_touchin_deinit(touchio_touchin_obj_t *self);
 bool common_hal_touchio_touchin_deinited(touchio_touchin_obj_t *self);
 bool common_hal_touchio_touchin_get_value(touchio_touchin_obj_t *self);

--- a/shared-module/touchio/TouchIn.c
+++ b/shared-module/touchio/TouchIn.c
@@ -28,18 +28,19 @@
 static uint16_t get_raw_reading(touchio_touchin_obj_t *self) {
 
     uint16_t ticks = 0;
-
+    const pulldir = self->pulldir;
+    
     for (uint16_t i = 0; i < N_SAMPLES; i++) {
-        // set pad to digital output high for 10us to charge it
+        // set pad to digital output "high" for 10us to charge it (dpending on pulldir)
 
-        common_hal_digitalio_digitalinout_switch_to_output(self->digitalinout, true, DRIVE_MODE_PUSH_PULL);
+        common_hal_digitalio_digitalinout_switch_to_output(self->digitalinout, !pulldir, DRIVE_MODE_PUSH_PULL);
         mp_hal_delay_us(10);
 
         // set pad back to an input and take some samples
 
         common_hal_digitalio_digitalinout_switch_to_input(self->digitalinout, PULL_NONE);
 
-        while (common_hal_digitalio_digitalinout_get_value(self->digitalinout)) {
+        while (common_hal_digitalio_digitalinout_get_value(self->digitalinout) != pulldir) {
             if (ticks >= TIMEOUT_TICKS) {
                 return TIMEOUT_TICKS;
             }
@@ -49,16 +50,21 @@ static uint16_t get_raw_reading(touchio_touchin_obj_t *self) {
     return ticks;
 }
 
-void common_hal_touchio_touchin_construct(touchio_touchin_obj_t *self, const mcu_pin_obj_t *pin) {
+void common_hal_touchio_touchin_construct(touchio_touchin_obj_t *self, const mcu_pin_obj_t *pin, const bool pulldir) {
     common_hal_mcu_pin_claim(pin);
     self->digitalinout = mp_obj_malloc(digitalio_digitalinout_obj_t, &digitalio_digitalinout_type);
-
+    self->pulldir = pulldir;
+    
     common_hal_digitalio_digitalinout_construct(self->digitalinout, pin);
 
     uint16_t raw_reading = get_raw_reading(self);
     if (raw_reading == TIMEOUT_TICKS) {
         common_hal_touchio_touchin_deinit(self);
-        mp_raise_ValueError(MP_ERROR_TEXT("No pulldown on pin; 1Mohm recommended"));
+        if (self->pulldir) {
+          mp_raise_ValueError(MP_ERROR_TEXT("No pullup on pin; 1Mohm recommended"));
+        } else { 
+          mp_raise_ValueError(MP_ERROR_TEXT("No pulldown on pin; 1Mohm recommended"));
+        }
     }
     self->threshold = raw_reading * 1.05 + 100;
 }

--- a/shared-module/touchio/TouchIn.c
+++ b/shared-module/touchio/TouchIn.c
@@ -28,7 +28,7 @@
 static uint16_t get_raw_reading(touchio_touchin_obj_t *self) {
 
     uint16_t ticks = 0;
-    const pulldir = self->pulldir;
+    const bool pulldir = self->pulldir;
     
     for (uint16_t i = 0; i < N_SAMPLES; i++) {
         // set pad to digital output "high" for 10us to charge it (dpending on pulldir)

--- a/shared-module/touchio/TouchIn.h
+++ b/shared-module/touchio/TouchIn.h
@@ -16,6 +16,7 @@ typedef struct {
     mp_obj_base_t base;
     digitalio_digitalinout_obj_t *digitalinout;
     uint16_t threshold;
+    bool pulldir;
 } touchio_touchin_obj_t;
 
 void touchin_reset(void);


### PR DESCRIPTION
Following up on https://github.com/adafruit/circuitpython/issues/9541, I decided to look into getting `touchio` working for RP2350 without causing too much API change. 

Here's a first attempt. It adds a new boolean `pull_dir` parameter to `touchio.TouchIn`. Defaulting to `pull_dir=False`, `TouchIn` acts as before. If `pull_dir=True` and an external 1M pull-up is wired, `TouchIn` will now also work on RP2350.

I believe this is similar to what DanH was imagining, but much simpler. (It felt odd to me to reuse `digitalio.DigitalInOut.Pull` that has a strong association with *built-in* pull resistors)

Tested on RP2350 and RP2040.