### PR TITLE
increase default PYSTACK size from 1536 to 2048

### DIFF
--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -100,6 +100,11 @@
 #define CIRCUITPY_DEFAULT_STACK_SIZE                3584
 #endif
 
+#ifndef CIRCUITPY_PYSTACK_SIZE
+// Default for most boards is 2048 starting with CircuitPython 10, but on SAMD21, keep it at previous lower value.
+#define CIRCUITPY_PYSTACK_SIZE 1536
+#endif
+
 #ifndef SAMD21_BOD33_LEVEL
 // Set brownout detection to ~2.7V. Default from factory is 1.7V,
 // which is too low for proper operation of external SPI flash chips

--- a/ports/nordic/boards/TG-Watch/mpconfigboard.h
+++ b/ports/nordic/boards/TG-Watch/mpconfigboard.h
@@ -13,7 +13,7 @@
 #define MICROPY_HW_MCU_NAME         "nRF52840"
 
 // TG-Gui requires a deeper call stack than normal CircuitPython, this is intentional overkill
-#define CIRCUITPY_PYSTACK_SIZE 8192 // 1536 is the normal size, (32 bytes/frame * 48 frames)
+#define CIRCUITPY_PYSTACK_SIZE 8192
 
 // the board has a 32mhz crystal but NOT a 32khz one
 #define BOARD_HAS_32KHZ_XTAL 0

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -452,7 +452,7 @@ void background_callback_run_all(void);
 #endif
 
 #ifndef CIRCUITPY_PYSTACK_SIZE
-#define CIRCUITPY_PYSTACK_SIZE 1536
+#define CIRCUITPY_PYSTACK_SIZE 2048
 #endif
 
 // The VM heap starts at this size and doubles in size as needed until it runs


### PR DESCRIPTION
- Fixes #10235.
- Fixes #10189.

Increase default CIRCUITPY_PYSTACK_SIZE from 1536 to 2048, except on SAMD21. This fixes pystack-exhausted errors for several PyPortal projects, and doesn't use up too much RAM.