### PR TITLE
ESP: add MAC address to boot_out.txt (for wifi boards)

### DIFF
--- a/ports/espressif/supervisor/port.c
+++ b/ports/espressif/supervisor/port.c
@@ -493,6 +493,18 @@ void port_idle_until_interrupt(void) {
     }
 }
 
+#if CIRCUITPY_WIFI
+void port_boot_info(void) {
+    uint8_t mac[6];
+    esp_wifi_get_mac(ESP_IF_WIFI_STA, mac);
+    mp_printf(&mp_plat_print, "MAC");
+    for (int i = 0; i < 6; i++) {
+        mp_printf(&mp_plat_print, ":%02X", mac[i]);
+    }
+    mp_printf(&mp_plat_print, "\n");
+}
+#endif
+
 void port_post_boot_py(bool heap_valid) {
     if (!heap_valid && filesystem_present()) {
     }


### PR DESCRIPTION
Writes the wifi MAC address in the `boot_out.txt` making it better documented and discoverable.
This is what is done on pico W. P4 and H2 are excluded by testing for the wifi module.
The ESP already uses the MAC as UID, but with nibbles in a different order and it's not made clear that it is.
