### PR TITLE
Add RP2 support for dma_capable

### DIFF
--- a/ports/espressif/supervisor/port.c
+++ b/ports/espressif/supervisor/port.c
@@ -324,8 +324,12 @@ void port_free(void *ptr) {
     heap_caps_free(ptr);
 }
 
-void *port_realloc(void *ptr, size_t size) {
-    return heap_caps_realloc(ptr, size, MALLOC_CAP_8BIT);
+void *port_realloc(void *ptr, size_t size, bool dma_capable) {
+    size_t caps = MALLOC_CAP_8BIT;
+    if (dma_capable) {
+        caps |= MALLOC_CAP_DMA;
+    }
+    return heap_caps_realloc(ptr, size, caps);
 }
 
 size_t port_heap_get_largest_free_size(void) {

--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -227,12 +227,7 @@ audio_dma_result audio_dma_setup_playback(
         max_buffer_length /= dma->sample_spacing;
     }
 
-    dma->buffer[0] = (uint8_t *)m_realloc(dma->buffer[0],
-        #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
-        dma->buffer_length[0], // Old size
-        #endif
-        max_buffer_length);
-
+    dma->buffer[0] = (uint8_t *)port_realloc(dma->buffer[0], max_buffer_length, true);
     dma->buffer_length[0] = max_buffer_length;
 
     if (dma->buffer[0] == NULL) {
@@ -240,12 +235,7 @@ audio_dma_result audio_dma_setup_playback(
     }
 
     if (!single_buffer) {
-        dma->buffer[1] = (uint8_t *)m_realloc(dma->buffer[1],
-            #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
-            dma->buffer_length[1], // Old size
-            #endif
-            max_buffer_length);
-
+        dma->buffer[1] = (uint8_t *)port_realloc(dma->buffer[1], max_buffer_length, true);
         dma->buffer_length[1] = max_buffer_length;
 
         if (dma->buffer[1] == NULL) {
@@ -439,21 +429,11 @@ void audio_dma_init(audio_dma_t *dma) {
 }
 
 void audio_dma_deinit(audio_dma_t *dma) {
-    #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
-    m_free(dma->buffer[0], dma->buffer_length[0]);
-    #else
-    m_free(dma->buffer[0]);
-    #endif
-
+    port_free(dma->buffer[0]);
     dma->buffer[0] = NULL;
     dma->buffer_length[0] = 0;
 
-    #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
-    m_free(dma->buffer[1], dma->buffer_length[1]);
-    #else
-    m_free(dma->buffer[1]);
-    #endif
-
+    port_free(dma->buffer[1]);
     dma->buffer[1] = NULL;
     dma->buffer_length[1] = 0;
 }

--- a/ports/raspberrypi/audio_dma.h
+++ b/ports/raspberrypi/audio_dma.h
@@ -20,7 +20,7 @@ typedef enum {
 
 typedef struct {
     mp_obj_t sample;
-    uint8_t *buffer[2];
+    uint8_t *buffer[2]; // Allocated through port_malloc so they are dma-able
     size_t buffer_length[2];
     uint32_t channels_to_load_mask;
     uint32_t output_register_address;

--- a/ports/stm/supervisor/port.c
+++ b/ports/stm/supervisor/port.c
@@ -227,7 +227,7 @@ void port_free(void *ptr) {
     tlsf_free(_heap, ptr);
 }
 
-void *port_realloc(void *ptr, size_t size) {
+void *port_realloc(void *ptr, size_t size, bool dma_capable) {
     return tlsf_realloc(_heap, ptr, size);
 }
 #endif

--- a/ports/zephyr-cp/supervisor/port.c
+++ b/ports/zephyr-cp/supervisor/port.c
@@ -151,7 +151,7 @@ void port_free(void *ptr) {
     tlsf_free(heap, ptr);
 }
 
-void *port_realloc(void *ptr, size_t size) {
+void *port_realloc(void *ptr, size_t size, bool dma_capable) {
     return tlsf_realloc(heap, ptr, size);
 }
 

--- a/shared-module/bitmapfilter/__init__.c
+++ b/shared-module/bitmapfilter/__init__.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #define port_free free
 #define port_malloc(sz, hint) (malloc(sz))
-#define port_realloc realloc
+#define port_realloc(ptr, size, dma_capable) realloc(ptr, size)
 #else
 #include "supervisor/port_heap.h"
 #endif
@@ -48,7 +48,7 @@ static void *scratchpad_alloc(size_t sz) {
     } else {
         if (scratchpad) {
             if (sz > scratchpad_size) {
-                void *tmp = port_realloc(scratchpad, sz);
+                void *tmp = port_realloc(scratchpad, sz, false);
                 if (!tmp) {
                     port_free(scratchpad);
                     scratchpad = NULL;

--- a/supervisor/port_heap.h
+++ b/supervisor/port_heap.h
@@ -24,6 +24,6 @@ void *port_malloc(size_t size, bool dma_capable);
 
 void port_free(void *ptr);
 
-void *port_realloc(void *ptr, size_t size);
+void *port_realloc(void *ptr, size_t size, bool dma_capable);
 
 size_t port_heap_get_largest_free_size(void);

--- a/supervisor/shared/port.c
+++ b/supervisor/shared/port.c
@@ -42,7 +42,7 @@ MP_WEAK void port_free(void *ptr) {
     tlsf_free(heap, ptr);
 }
 
-MP_WEAK void *port_realloc(void *ptr, size_t size) {
+MP_WEAK void *port_realloc(void *ptr, size_t size, bool dma_capable) {
     return tlsf_realloc(heap, ptr, size);
 }
 


### PR DESCRIPTION
This places the VM heap in PSRAM by default. audio_dma now directly allocates its buffers to ensure they are dma_capable.