### PR TITLE
extmod/modasyncio.c: remove push_head, push_sorted, pop_head

### DIFF
--- a/extmod/modasyncio.c
+++ b/extmod/modasyncio.c
@@ -160,11 +160,6 @@ static const mp_rom_map_elem_t task_queue_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_push), MP_ROM_PTR(&task_queue_push_obj) },
     { MP_ROM_QSTR(MP_QSTR_pop), MP_ROM_PTR(&task_queue_pop_obj) },
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&task_queue_remove_obj) },
-
-    // CIRCUITPY-CHANGE: Remove these in CircuitPython 10.0.0
-    { MP_ROM_QSTR(MP_QSTR_push_head), MP_ROM_PTR(&task_queue_push_obj) },
-    { MP_ROM_QSTR(MP_QSTR_push_sorted), MP_ROM_PTR(&task_queue_push_obj) },
-    { MP_ROM_QSTR(MP_QSTR_pop_head), MP_ROM_PTR(&task_queue_pop_obj) },
 };
 static MP_DEFINE_CONST_DICT(task_queue_locals_dict, task_queue_locals_dict_table);
 


### PR DESCRIPTION
- Fixes #9595.
- Related to https://github.com/adafruit/Adafruit_CircuitPython_asyncio/pull/71

Remove deprecated task queue operations. Use the shorter names instead: 
- `push_head` -> `push`
- `push_sorted` -> `push`
- `pop_head` -> `pop`

I'm going to make this a draft for now. When https://github.com/adafruit/Adafruit_CircuitPython_asyncio/pull/71 is merged and released, I will update the frozen libraries so we get the new versions and can run the tests.
