### PR TITLE
Fix RP2xxx I2SOut reversed channels

### DIFF
--- a/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+++ b/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
@@ -19,7 +19,9 @@
 #include "bindings/rp2pio/StateMachine.h"
 
 const uint16_t i2s_program[] = {
-/*
+
+/* From i2s.pio:
+
 .program i2s
 .side_set 2
 
@@ -55,7 +57,8 @@ bitloop0:
 
 
 const uint16_t i2s_program_left_justified[] = {
-/*
+/* From i2s_left.pio:
+
 .program i2s
 .side_set 2
 
@@ -91,7 +94,8 @@ bitloop0:
 
 // Another version of i2s_program with the LRCLC and BCLK pin swapped
 const uint16_t i2s_program_swap[] = {
-/*
+/* From i2s_swap.pio:
+
 .program i2s
 .side_set 2
 
@@ -128,7 +132,8 @@ bitloop0:
 // Another version of i2s_program_left_justified with the LRCLC and BCLK pin
 // swapped.
 const uint16_t i2s_program_left_justified_swap[] = {
-/*
+/* From i2s_swap_left.pio:
+
 .program i2s
 .side_set 2
 

--- a/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+++ b/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
@@ -27,30 +27,30 @@ const uint16_t i2s_program[] = {
                     ;        /--- LRCLK
                     ;        |/-- BCLK
                     ;        ||
-    pull noblock      side 0b01 ; Loads OSR with the next FIFO value or X
-    mov x osr         side 0b01 ; Save the new value in case we need it again
-    set y 14          side 0b01
+    pull noblock      side 0b11 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b11 ; Save the new value in case we need it again
+    set y 14          side 0b11
 bitloop1:
-    out pins 1        side 0b00 [2]
-    jmp y-- bitloop1  side 0b01 [2]
     out pins 1        side 0b10 [2]
-    set y 14          side 0b11 [2]
+    jmp y-- bitloop1  side 0b11 [2]
+    out pins 1        side 0b00 [2]
+    set y 14          side 0b01 [2]
 bitloop0:
-    out pins 1        side 0b10 [2]
-    jmp y-- bitloop0  side 0b11 [2]
     out pins 1        side 0b00 [2]
+    jmp y-- bitloop0  side 0b01 [2]
+    out pins 1        side 0b10 [2]
 */
     // Above assembled with pioasm.
-    0x8880, //  0: pull   noblock         side 1
-    0xa827, //  1: mov    x, osr          side 1
-    0xe84e, //  2: set    y, 14           side 1
-    0x6201, //  3: out    pins, 1         side 0 [2]
-    0x0a83, //  4: jmp    y--, 3          side 1 [2]
-    0x7201, //  5: out    pins, 1         side 2 [2]
-    0xfa4e, //  6: set    y, 14           side 3 [2]
-    0x7201, //  7: out    pins, 1         side 2 [2]
-    0x1a87, //  8: jmp    y--, 7          side 3 [2]
-    0x6201, //  9: out    pins, 1         side 0 [2]
+    0x9880, //  0: pull   noblock         side 3
+    0xb827, //  1: mov    x, osr          side 3
+    0xf84e, //  2: set    y, 14           side 3
+    0x7201, //  3: out    pins, 1         side 2 [2]
+    0x1a83, //  4: jmp    y--, 3          side 3 [2]
+    0x6201, //  5: out    pins, 1         side 0 [2]
+    0xea4e, //  6: set    y, 14           side 1 [2]
+    0x6201, //  7: out    pins, 1         side 0 [2]
+    0x0a87, //  8: jmp    y--, 7          side 1 [2]
+    0x7201, //  9: out    pins, 1         side 2 [2]
 };
 
 
@@ -63,30 +63,30 @@ const uint16_t i2s_program_left_justified[] = {
                      ;        /--- LRCLK
                      ;        |/-- BCLK
                      ;        ||
-    pull noblock      side 0b11 ; Loads OSR with the next FIFO value or X
-    mov x osr         side 0b11 ; Save the new value in case we need it again
-    set y 14          side 0b11
+    pull noblock      side 0b01 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b01 ; Save the new value in case we need it again
+    set y 14          side 0b01
 bitloop1:
-    out pins 1        side 0b00 [2]
-    jmp y-- bitloop1  side 0b01 [2]
-    out pins 1        side 0b00 [2]
-    set y 14          side 0b01 [2]
+    out pins 1        side 0b10 [2]
+    jmp y-- bitloop1  side 0b11 [2]
+    out pins 1        side 0b10 [2]
+    set y 14          side 0b11 [2]
 bitloop0:
-    out pins 1        side 0b10 [2]
-    jmp y-- bitloop0  side 0b11 [2]
-    out pins 1        side 0b10 [2]
+    out pins 1        side 0b00 [2]
+    jmp y-- bitloop0  side 0b01 [2]
+    out pins 1        side 0b00 [2]
 */
     // Above assembled with pioasm.
-    0x9880, //  0: pull   noblock         side 3
-    0xb827, //  1: mov    x, osr          side 3
-    0xf84e, //  2: set    y, 14           side 3
-    0x6201, //  3: out    pins, 1         side 0 [2]
-    0x0a83, //  4: jmp    y--, 3          side 1 [2]
-    0x6201, //  5: out    pins, 1         side 0 [2]
-    0xea4e, //  6: set    y, 14           side 1 [2]
-    0x7201, //  7: out    pins, 1         side 2 [2]
-    0x1a87, //  8: jmp    y--, 7          side 3 [2]
-    0x7201, //  9: out    pins, 1         side 2 [2]
+    0x8880, //  0: pull   noblock         side 1
+    0xa827, //  1: mov    x, osr          side 1
+    0xe84e, //  2: set    y, 14           side 1
+    0x7201, //  3: out    pins, 1         side 2 [2]
+    0x1a83, //  4: jmp    y--, 3          side 3 [2]
+    0x7201, //  5: out    pins, 1         side 2 [2]
+    0xfa4e, //  6: set    y, 14           side 3 [2]
+    0x6201, //  7: out    pins, 1         side 0 [2]
+    0x0a87, //  8: jmp    y--, 7          side 1 [2]
+    0x6201, //  9: out    pins, 1         side 0 [2]
 };
 
 // Another version of i2s_program with the LRCLC and BCLK pin swapped
@@ -99,31 +99,30 @@ const uint16_t i2s_program_swap[] = {
                     ;        /--- BCLK
                     ;        |/-- LRCLK
                     ;        ||
-    pull noblock      side 0b10 ; Loads OSR with the next FIFO value or X
-    mov x osr         side 0b10 ; Save the new value in case we need it again
-    set y 14          side 0b10
+    pull noblock      side 0b11 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b11 ; Save the new value in case we need it again
+    set y 14          side 0b11
 bitloop1:
-    out pins 1        side 0b00 [2]
-    jmp y-- bitloop1  side 0b10 [2]
     out pins 1        side 0b01 [2]
-    set y 14          side 0b11 [2]
+    jmp y-- bitloop1  side 0b11 [2]
+    out pins 1        side 0b00 [2]
+    set y 14          side 0b10 [2]
 bitloop0:
-    out pins 1        side 0b01 [2]
-    jmp y-- bitloop0  side 0b11 [2]
     out pins 1        side 0b00 [2]
+    jmp y-- bitloop0  side 0b10 [2]
+    out pins 1        side 0b01 [2]
 */
     // Above assembled with pioasm.
-    0x9080, //  0: pull   noblock         side 2
-    0xb027, //  1: mov    x, osr          side 2
-    0xf04e, //  2: set    y, 14           side 2
-    0x6201, //  3: out    pins, 1         side 0 [2]
-    0x1283, //  4: jmp    y--, 3          side 2 [2]
-    0x6a01, //  5: out    pins, 1         side 1 [2]
-    0xfa4e, //  6: set    y, 14           side 3 [2]
-    0x6a01, //  7: out    pins, 1         side 1 [2]
-    0x1a87, //  8: jmp    y--, 7          side 3 [2]
-    0x6201, //  9: out    pins, 1         side 0 [2]
-
+    0x9880, //  0: pull   noblock         side 3
+    0xb827, //  1: mov    x, osr          side 3
+    0xf84e, //  2: set    y, 14           side 3
+    0x6a01, //  3: out    pins, 1         side 1 [2]
+    0x1a83, //  4: jmp    y--, 3          side 3 [2]
+    0x6201, //  5: out    pins, 1         side 0 [2]
+    0xf24e, //  6: set    y, 14           side 2 [2]
+    0x6201, //  7: out    pins, 1         side 0 [2]
+    0x1287, //  8: jmp    y--, 7          side 2 [2]
+    0x6a01, //  9: out    pins, 1         side 1 [2]
 };
 
 // Another version of i2s_program_left_justified with the LRCLC and BCLK pin
@@ -137,30 +136,30 @@ const uint16_t i2s_program_left_justified_swap[] = {
                     ;        /--- BCLK
                     ;        |/-- LRCLK
                     ;        ||
-    pull noblock      side 0b11 ; Loads OSR with the next FIFO value or X
-    mov x osr         side 0b11 ; Save the new value in case we need it again
-    set y 14          side 0b11
+    pull noblock      side 0b10 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b10 ; Save the new value in case we need it again
+    set y 14          side 0b10
 bitloop1:
-    out pins 1        side 0b00 [2]
-    jmp y-- bitloop1  side 0b10 [2]
-    out pins 1        side 0b00 [2]
-    set y 14          side 0b10 [2]
+    out pins 1        side 0b01 [2]
+    jmp y-- bitloop1  side 0b11 [2]
+    out pins 1        side 0b01 [2]
+    set y 14          side 0b11 [2]
 bitloop0:
-    out pins 1        side 0b01 [2]
-    jmp y-- bitloop0  side 0b11 [2]
-    out pins 1        side 0b01 [2]
+    out pins 1        side 0b00 [2]
+    jmp y-- bitloop0  side 0b10 [2]
+    out pins 1        side 0b00 [2]
 */
     // Above assembled with pioasm.
-    0x9880, //  0: pull   noblock         side 3
-    0xb827, //  1: mov    x, osr          side 3
-    0xf84e, //  2: set    y, 14           side 3
-    0x6201, //  3: out    pins, 1         side 0 [2]
-    0x1283, //  4: jmp    y--, 3          side 2 [2]
-    0x6201, //  5: out    pins, 1         side 0 [2]
-    0xf24e, //  6: set    y, 14           side 2 [2]
-    0x6a01, //  7: out    pins, 1         side 1 [2]
-    0x1a87, //  8: jmp    y--, 7          side 3 [2]
-    0x6a01, //  9: out    pins, 1         side 1 [2]
+    0x9080, //  0: pull   noblock         side 2
+    0xb027, //  1: mov    x, osr          side 2
+    0xf04e, //  2: set    y, 14           side 2
+    0x6a01, //  3: out    pins, 1         side 1 [2]
+    0x1a83, //  4: jmp    y--, 3          side 3 [2]
+    0x6a01, //  5: out    pins, 1         side 1 [2]
+    0xfa4e, //  6: set    y, 14           side 3 [2]
+    0x6201, //  7: out    pins, 1         side 0 [2]
+    0x1287, //  8: jmp    y--, 7          side 2 [2]
+    0x6201, //  9: out    pins, 1         side 0 [2]
 };
 
 void i2sout_reset(void) {

--- a/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+++ b/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
@@ -19,122 +19,148 @@
 #include "bindings/rp2pio/StateMachine.h"
 
 const uint16_t i2s_program[] = {
-// ; Load the next set of samples
-//                     ;        /--- LRCLK
-//                     ;        |/-- BCLK
-//                     ;        ||
-//     pull noblock      side 0b01 ; Loads OSR with the next FIFO value or X
-    0x8880,
-//     mov x osr         side 0b01 ; Save the new value in case we need it again
-    0xa827,
-//     set y 14          side 0b01
-    0xe84e,
-// bitloop1:
-//     out pins 1        side 0b00 [2]
-    0x6201,
-//     jmp y-- bitloop1  side 0b01 [2]
-    0x0a83,
-//     out pins 1        side 0b10 [2]
-    0x7201,
-//     set y 14          side 0b11 [2]
-    0xfa4e,
-// bitloop0:
-//     out pins 1        side 0b10 [2]
-    0x7201,
-//     jmp y-- bitloop0  side 0b11 [2]
-    0x1a87,
-//     out pins 1        side 0b00 [2]
-    0x6201
+/*
+.program i2s
+.side_set 2
+
+; Load the next set of samples
+                    ;        /--- LRCLK
+                    ;        |/-- BCLK
+                    ;        ||
+    pull noblock      side 0b01 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b01 ; Save the new value in case we need it again
+    set y 14          side 0b01
+bitloop1:
+    out pins 1        side 0b00 [2]
+    jmp y-- bitloop1  side 0b01 [2]
+    out pins 1        side 0b10 [2]
+    set y 14          side 0b11 [2]
+bitloop0:
+    out pins 1        side 0b10 [2]
+    jmp y-- bitloop0  side 0b11 [2]
+    out pins 1        side 0b00 [2]
+*/
+    // Above assembled with pioasm.
+    0x8880, //  0: pull   noblock         side 1
+    0xa827, //  1: mov    x, osr          side 1
+    0xe84e, //  2: set    y, 14           side 1
+    0x6201, //  3: out    pins, 1         side 0 [2]
+    0x0a83, //  4: jmp    y--, 3          side 1 [2]
+    0x7201, //  5: out    pins, 1         side 2 [2]
+    0xfa4e, //  6: set    y, 14           side 3 [2]
+    0x7201, //  7: out    pins, 1         side 2 [2]
+    0x1a87, //  8: jmp    y--, 7          side 3 [2]
+    0x6201, //  9: out    pins, 1         side 0 [2]
 };
 
+
 const uint16_t i2s_program_left_justified[] = {
-// ; Load the next set of samples
-//                     ;        /--- LRCLK
-//                     ;        |/-- BCLK
-//                     ;        ||
-//     pull noblock      side 0b11 ; Loads OSR with the next FIFO value or X
-    0x9880,
-//     mov x osr         side 0b11 ; Save the new value in case we need it again
-    0xb827,
-//     set y 14          side 0b11
-    0xf84e,
-// bitloop1:
-//     out pins 1        side 0b00 [2]
-    0x6201,
-//     jmp y-- bitloop1  side 0b01 [2]
-    0x0a83,
-//     out pins 1        side 0b00 [2]
-    0x6201,
-//     set y 14          side 0b01 [2]
-    0xea4e,
-// bitloop0:
-//     out pins 1        side 0b10 [2]
-    0x7201,
-//     jmp y-- bitloop0  side 0b11 [2]
-    0x1a87,
-//     out pins 1        side 0b10 [2]
-    0x7201
+/*
+.program i2s
+.side_set 2
+
+; Load the next set of samples
+                     ;        /--- LRCLK
+                     ;        |/-- BCLK
+                     ;        ||
+    pull noblock      side 0b11 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b11 ; Save the new value in case we need it again
+    set y 14          side 0b11
+bitloop1:
+    out pins 1        side 0b00 [2]
+    jmp y-- bitloop1  side 0b01 [2]
+    out pins 1        side 0b00 [2]
+    set y 14          side 0b01 [2]
+bitloop0:
+    out pins 1        side 0b10 [2]
+    jmp y-- bitloop0  side 0b11 [2]
+    out pins 1        side 0b10 [2]
+*/
+    // Above assembled with pioasm.
+    0x9880, //  0: pull   noblock         side 3
+    0xb827, //  1: mov    x, osr          side 3
+    0xf84e, //  2: set    y, 14           side 3
+    0x6201, //  3: out    pins, 1         side 0 [2]
+    0x0a83, //  4: jmp    y--, 3          side 1 [2]
+    0x6201, //  5: out    pins, 1         side 0 [2]
+    0xea4e, //  6: set    y, 14           side 1 [2]
+    0x7201, //  7: out    pins, 1         side 2 [2]
+    0x1a87, //  8: jmp    y--, 7          side 3 [2]
+    0x7201, //  9: out    pins, 1         side 2 [2]
 };
 
 // Another version of i2s_program with the LRCLC and BCLK pin swapped
 const uint16_t i2s_program_swap[] = {
-// ; Load the next set of samples
-//                     ;        /--- BCLK
-//                     ;        |/-- LRCLK
-//                     ;        ||
-//     pull noblock      side 0b11 ; Loads OSR with the next FIFO value or X
-    0x9880,
-//     mov x osr         side 0b11 ; Save the new value in case we need it again
-    0xb827,
-//     set y 14          side 0b11
-    0xf84e,
-// bitloop1:
-//     out pins 1        side 0b01 [2]
-    0x6a01,
-//     jmp y-- bitloop1  side 0b11 [2]
-    0x1a83,
-//     out pins 1        side 0b00 [2]
-    0x6201,
-//     set y 14          side 0b10 [2]
-    0xf24e,
-// bitloop0:
-//     out pins 1        side 0b00 [2]
-    0x6201,
-//     jmp y-- bitloop0  side 0b10 [2]
-    0x1287,
-//     out pins 1        side 0b01 [2]
-    0x6a01
+/*
+.program i2s
+.side_set 2
+
+; Load the next set of samples
+                    ;        /--- BCLK
+                    ;        |/-- LRCLK
+                    ;        ||
+    pull noblock      side 0b10 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b10 ; Save the new value in case we need it again
+    set y 14          side 0b10
+bitloop1:
+    out pins 1        side 0b00 [2]
+    jmp y-- bitloop1  side 0b10 [2]
+    out pins 1        side 0b01 [2]
+    set y 14          side 0b11 [2]
+bitloop0:
+    out pins 1        side 0b01 [2]
+    jmp y-- bitloop0  side 0b11 [2]
+    out pins 1        side 0b00 [2]
+*/
+    // Above assembled with pioasm.
+    0x9080, //  0: pull   noblock         side 2
+    0xb027, //  1: mov    x, osr          side 2
+    0xf04e, //  2: set    y, 14           side 2
+    0x6201, //  3: out    pins, 1         side 0 [2]
+    0x1283, //  4: jmp    y--, 3          side 2 [2]
+    0x6a01, //  5: out    pins, 1         side 1 [2]
+    0xfa4e, //  6: set    y, 14           side 3 [2]
+    0x6a01, //  7: out    pins, 1         side 1 [2]
+    0x1a87, //  8: jmp    y--, 7          side 3 [2]
+    0x6201, //  9: out    pins, 1         side 0 [2]
+
 };
 
 // Another version of i2s_program_left_justified with the LRCLC and BCLK pin
 // swapped.
 const uint16_t i2s_program_left_justified_swap[] = {
-// ; Load the next set of samples
-//                     ;        /--- BCLK
-//                     ;        |/-- LRCLK
-//                     ;        ||
-//     pull noblock      side 0b11 ; Loads OSR with the next FIFO value or X
-    0x9880,
-//     mov x osr         side 0b11 ; Save the new value in case we need it again
-    0xb827,
-//     set y 14          side 0b11
-    0xf84e,
-// bitloop1:
-//     out pins 1        side 0b00 [2]
-    0x6201,
-//     jmp y-- bitloop1  side 0b10 [2]
-    0x1283,
-//     out pins 1        side 0b00 [2]
-    0x6201,
-//     set y 14          side 0b10 [2]
-    0xf24e,
-// bitloop0:
-//     out pins 1        side 0b01 [2]
-    0x6a01,
-//     jmp y-- bitloop0  side 0b11 [2]
-    0x1a87,
-//     out pins 1        side 0b01 [2]
-    0x6a01
+/*
+.program i2s
+.side_set 2
+
+; Load the next set of samples
+                    ;        /--- BCLK
+                    ;        |/-- LRCLK
+                    ;        ||
+    pull noblock      side 0b11 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b11 ; Save the new value in case we need it again
+    set y 14          side 0b11
+bitloop1:
+    out pins 1        side 0b00 [2]
+    jmp y-- bitloop1  side 0b10 [2]
+    out pins 1        side 0b00 [2]
+    set y 14          side 0b10 [2]
+bitloop0:
+    out pins 1        side 0b01 [2]
+    jmp y-- bitloop0  side 0b11 [2]
+    out pins 1        side 0b01 [2]
+*/
+    // Above assembled with pioasm.
+    0x9880, //  0: pull   noblock         side 3
+    0xb827, //  1: mov    x, osr          side 3
+    0xf84e, //  2: set    y, 14           side 3
+    0x6201, //  3: out    pins, 1         side 0 [2]
+    0x1283, //  4: jmp    y--, 3          side 2 [2]
+    0x6201, //  5: out    pins, 1         side 0 [2]
+    0xf24e, //  6: set    y, 14           side 2 [2]
+    0x6a01, //  7: out    pins, 1         side 1 [2]
+    0x1a87, //  8: jmp    y--, 7          side 3 [2]
+    0x6a01, //  9: out    pins, 1         side 1 [2]
 };
 
 void i2sout_reset(void) {

--- a/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+++ b/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
@@ -31,12 +31,12 @@ const uint16_t i2s_program[] = {
     mov x osr         side 0b11 ; Save the new value in case we need it again
     set y 14          side 0b11
 bitloop1:
-    out pins 1        side 0b10 [2]
+    out pins 1        side 0b10 [2] ; Right channel first
     jmp y-- bitloop1  side 0b11 [2]
     out pins 1        side 0b00 [2]
     set y 14          side 0b01 [2]
 bitloop0:
-    out pins 1        side 0b00 [2]
+    out pins 1        side 0b00 [2] ; Then left channel
     jmp y-- bitloop0  side 0b01 [2]
     out pins 1        side 0b10 [2]
 */
@@ -67,12 +67,12 @@ const uint16_t i2s_program_left_justified[] = {
     mov x osr         side 0b01 ; Save the new value in case we need it again
     set y 14          side 0b01
 bitloop1:
-    out pins 1        side 0b10 [2]
+    out pins 1        side 0b10 [2] ; Right channel first
     jmp y-- bitloop1  side 0b11 [2]
     out pins 1        side 0b10 [2]
     set y 14          side 0b11 [2]
 bitloop0:
-    out pins 1        side 0b00 [2]
+    out pins 1        side 0b00 [2] ; Then left channel
     jmp y-- bitloop0  side 0b01 [2]
     out pins 1        side 0b00 [2]
 */
@@ -103,12 +103,12 @@ const uint16_t i2s_program_swap[] = {
     mov x osr         side 0b11 ; Save the new value in case we need it again
     set y 14          side 0b11
 bitloop1:
-    out pins 1        side 0b01 [2]
+    out pins 1        side 0b01 [2] ; Right channel first
     jmp y-- bitloop1  side 0b11 [2]
     out pins 1        side 0b00 [2]
     set y 14          side 0b10 [2]
 bitloop0:
-    out pins 1        side 0b00 [2]
+    out pins 1        side 0b00 [2] ; Then left channel
     jmp y-- bitloop0  side 0b10 [2]
     out pins 1        side 0b01 [2]
 */
@@ -140,12 +140,12 @@ const uint16_t i2s_program_left_justified_swap[] = {
     mov x osr         side 0b10 ; Save the new value in case we need it again
     set y 14          side 0b10
 bitloop1:
-    out pins 1        side 0b01 [2]
+    out pins 1        side 0b01 [2] ; Right channel first
     jmp y-- bitloop1  side 0b11 [2]
     out pins 1        side 0b01 [2]
     set y 14          side 0b11 [2]
 bitloop0:
-    out pins 1        side 0b00 [2]
+    out pins 1        side 0b00 [2] ; Then left channel
     jmp y-- bitloop0  side 0b10 [2]
     out pins 1        side 0b00 [2]
 */

--- a/ports/raspberrypi/common-hal/audiobusio/README.pio
+++ b/ports/raspberrypi/common-hal/audiobusio/README.pio
@@ -1,0 +1,1 @@
+.pio files right now are compiled by hand with pico-sdk/tools/pioasm and inserted into I2SOut.c

--- a/ports/raspberrypi/common-hal/audiobusio/README.pio
+++ b/ports/raspberrypi/common-hal/audiobusio/README.pio
@@ -1,1 +1,7 @@
 .pio files right now are compiled by hand with pico-sdk/tools/pioasm and inserted into I2SOut.c
+
+i2s.pio           regular pin order, not left_justified
+i2s_left.pio      regular pin order, left_justified
+
+i2s_swap.pio      swapped pin order, not left_justified
+i2s_swap_left.pio swapped pin order, left_justified

--- a/ports/raspberrypi/common-hal/audiobusio/i2s.pio
+++ b/ports/raspberrypi/common-hal/audiobusio/i2s.pio
@@ -15,11 +15,11 @@
     mov x osr         side 0b11 ; Save the new value in case we need it again
     set y 14          side 0b11
 bitloop1:
-    out pins 1        side 0b10 [2]
+    out pins 1        side 0b10 [2] ; Right channel first
     jmp y-- bitloop1  side 0b11 [2]
     out pins 1        side 0b00 [2]
     set y 14          side 0b01 [2]
 bitloop0:
-    out pins 1        side 0b00 [2]
+    out pins 1        side 0b00 [2] ; Then left channel
     jmp y-- bitloop0  side 0b01 [2]
     out pins 1        side 0b10 [2]

--- a/ports/raspberrypi/common-hal/audiobusio/i2s.pio
+++ b/ports/raspberrypi/common-hal/audiobusio/i2s.pio
@@ -1,0 +1,25 @@
+; This file is part of the CircuitPython project: https://circuitpython.org
+;
+; SPDX-FileCopyrightText: Copyright (c) 2025 Dan Halbert for Adafruit Industries
+;
+; SPDX-License-Identifier: MIT
+
+.program i2s
+.side_set 2
+
+; Load the next set of samples
+                    ;        /--- LRCLK
+                    ;        |/-- BCLK
+                    ;        ||
+    pull noblock      side 0b11 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b11 ; Save the new value in case we need it again
+    set y 14          side 0b11
+bitloop1:
+    out pins 1        side 0b10 [2]
+    jmp y-- bitloop1  side 0b11 [2]
+    out pins 1        side 0b00 [2]
+    set y 14          side 0b01 [2]
+bitloop0:
+    out pins 1        side 0b00 [2]
+    jmp y-- bitloop0  side 0b01 [2]
+    out pins 1        side 0b10 [2]

--- a/ports/raspberrypi/common-hal/audiobusio/i2s_left.pio
+++ b/ports/raspberrypi/common-hal/audiobusio/i2s_left.pio
@@ -1,0 +1,25 @@
+; This file is part of the CircuitPython project: https://circuitpython.org
+;
+; SPDX-FileCopyrightText: Copyright (c) 2025 Dan Halbert for Adafruit Industries
+;
+; SPDX-License-Identifier: MIT
+
+.program i2s
+.side_set 2
+
+; Load the next set of samples
+                     ;        /--- LRCLK
+                     ;        |/-- BCLK
+                     ;        ||
+    pull noblock      side 0b01 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b01 ; Save the new value in case we need it again
+    set y 14          side 0b01
+bitloop1:
+    out pins 1        side 0b10 [2]
+    jmp y-- bitloop1  side 0b11 [2]
+    out pins 1        side 0b10 [2]
+    set y 14          side 0b11 [2]
+bitloop0:
+    out pins 1        side 0b00 [2]
+    jmp y-- bitloop0  side 0b01 [2]
+    out pins 1        side 0b00 [2]

--- a/ports/raspberrypi/common-hal/audiobusio/i2s_left.pio
+++ b/ports/raspberrypi/common-hal/audiobusio/i2s_left.pio
@@ -15,11 +15,11 @@
     mov x osr         side 0b01 ; Save the new value in case we need it again
     set y 14          side 0b01
 bitloop1:
-    out pins 1        side 0b10 [2]
+    out pins 1        side 0b10 [2] ; Right channel first
     jmp y-- bitloop1  side 0b11 [2]
     out pins 1        side 0b10 [2]
     set y 14          side 0b11 [2]
 bitloop0:
-    out pins 1        side 0b00 [2]
+    out pins 1        side 0b00 [2] ; Then left channel
     jmp y-- bitloop0  side 0b01 [2]
     out pins 1        side 0b00 [2]

--- a/ports/raspberrypi/common-hal/audiobusio/i2s_swap.pio
+++ b/ports/raspberrypi/common-hal/audiobusio/i2s_swap.pio
@@ -1,0 +1,25 @@
+; This file is part of the CircuitPython project: https://circuitpython.org
+;
+; SPDX-FileCopyrightText: Copyright (c) 2025 Dan Halbert for Adafruit Industries
+;
+; SPDX-License-Identifier: MIT
+
+.program i2s
+.side_set 2
+
+; Load the next set of samples
+                    ;        /--- BCLK
+                    ;        |/-- LRCLK
+                    ;        ||
+    pull noblock      side 0b11 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b11 ; Save the new value in case we need it again
+    set y 14          side 0b11
+bitloop1:
+    out pins 1        side 0b01 [2]
+    jmp y-- bitloop1  side 0b11 [2]
+    out pins 1        side 0b00 [2]
+    set y 14          side 0b10 [2]
+bitloop0:
+    out pins 1        side 0b00 [2]
+    jmp y-- bitloop0  side 0b10 [2]
+    out pins 1        side 0b01 [2]

--- a/ports/raspberrypi/common-hal/audiobusio/i2s_swap.pio
+++ b/ports/raspberrypi/common-hal/audiobusio/i2s_swap.pio
@@ -15,11 +15,11 @@
     mov x osr         side 0b11 ; Save the new value in case we need it again
     set y 14          side 0b11
 bitloop1:
-    out pins 1        side 0b01 [2]
+    out pins 1        side 0b01 [2] ; Right channel first
     jmp y-- bitloop1  side 0b11 [2]
     out pins 1        side 0b00 [2]
     set y 14          side 0b10 [2]
 bitloop0:
-    out pins 1        side 0b00 [2]
+    out pins 1        side 0b00 [2] ; Then left channel
     jmp y-- bitloop0  side 0b10 [2]
     out pins 1        side 0b01 [2]

--- a/ports/raspberrypi/common-hal/audiobusio/i2s_swap_left.pio
+++ b/ports/raspberrypi/common-hal/audiobusio/i2s_swap_left.pio
@@ -15,11 +15,11 @@
     mov x osr         side 0b10 ; Save the new value in case we need it again
     set y 14          side 0b10
 bitloop1:
-    out pins 1        side 0b01 [2]
+    out pins 1        side 0b01 [2] ; Right channel first
     jmp y-- bitloop1  side 0b11 [2]
     out pins 1        side 0b01 [2]
     set y 14          side 0b11 [2]
 bitloop0:
-    out pins 1        side 0b00 [2]
+    out pins 1        side 0b00 [2] ; Then left channel
     jmp y-- bitloop0  side 0b10 [2]
     out pins 1        side 0b00 [2]

--- a/ports/raspberrypi/common-hal/audiobusio/i2s_swap_left.pio
+++ b/ports/raspberrypi/common-hal/audiobusio/i2s_swap_left.pio
@@ -1,0 +1,25 @@
+; This file is part of the CircuitPython project: https://circuitpython.org
+;
+; SPDX-FileCopyrightText: Copyright (c) 2025 Dan Halbert for Adafruit Industries
+;
+; SPDX-License-Identifier: MIT
+
+.program i2s
+.side_set 2
+
+; Load the next set of samples
+                    ;        /--- BCLK
+                    ;        |/-- LRCLK
+                    ;        ||
+    pull noblock      side 0b10 ; Loads OSR with the next FIFO value or X
+    mov x osr         side 0b10 ; Save the new value in case we need it again
+    set y 14          side 0b10
+bitloop1:
+    out pins 1        side 0b01 [2]
+    jmp y-- bitloop1  side 0b11 [2]
+    out pins 1        side 0b01 [2]
+    set y 14          side 0b11 [2]
+bitloop0:
+    out pins 1        side 0b00 [2]
+    jmp y-- bitloop0  side 0b10 [2]
+    out pins 1        side 0b00 [2]


### PR DESCRIPTION
- Fixes #10230.

The left and right stereo channels were reversed for most cases of `audiobusio.I2SOut` on `raspberrypi`. See the table in https://github.com/adafruit/circuitpython/issues/10230#issuecomment-2797995431 for details.

This was not a problem for `audiopwmio.PWMAudioOut`, and not a problem for Espressif on SAMD `I2SOut`. The problem was that the data was in the opposite channel order expected. Interestingly, the sample programin 

Fixed by flipping the LRCLK in three out of the four PIO programs. Also I put the PIO programs into separate files which are checked in, for convenience. They are not yet built automatically -- we could do that later.

Tested on a Metro RP2040 with an Adafruit Speaker Bonnet.

@VinceParsons FYI
