### PR TITLE
Fix handling of stereo audio within `audiodelays.Delay` when `freq_shift=True`

### DIFF
--- a/shared-module/audiodelays/Echo.c
+++ b/shared-module/audiodelays/Echo.c
@@ -136,16 +136,12 @@ void recalculate_delay(audiodelays_echo_obj_t *self, mp_float_t f_delay_ms) {
         // Calculate the current echo buffer length in bytes
         uint32_t new_echo_buffer_len = (uint32_t)(self->base.sample_rate / MICROPY_FLOAT_CONST(1000.0) * f_delay_ms) * (self->base.channel_count * sizeof(uint16_t));
 
-        // Check if our new echo is too long for our maximum buffer
+        // Limit to valid range
         if (new_echo_buffer_len > self->max_echo_buffer_len) {
-            return;
-        } else if (new_echo_buffer_len < 0.0) { // or too short!
-            return;
-        }
-
-        // If the echo buffer is larger then our audio buffer weird things happen
-        if (new_echo_buffer_len < self->buffer_len) {
-            return;
+            new_echo_buffer_len = self->max_echo_buffer_len;
+        } else if (new_echo_buffer_len < self->buffer_len) {
+            // If the echo buffer is smaller than our audio buffer, weird things happen
+            new_echo_buffer_len = self->buffer_len;
         }
 
         self->echo_buffer_len = new_echo_buffer_len;

--- a/shared-module/audiodelays/Echo.c
+++ b/shared-module/audiodelays/Echo.c
@@ -98,11 +98,10 @@ void common_hal_audiodelays_echo_construct(audiodelays_echo_obj_t *self, uint32_
 
     // read is where we read previous echo from delay_ms ago to play back now
     // write is where the store the latest playing sample to echo back later
-    self->echo_buffer_read_pos = self->buffer_len / sizeof(uint16_t);
-    self->echo_buffer_write_pos = 0;
+    self->echo_buffer_pos = 0;
 
-    // where we read the previous echo from delay_ms ago to play back now (for freq shift)
-    self->echo_buffer_left_pos = self->echo_buffer_right_pos = 0;
+    // use a separate buffer position for the right channel when using freq_shift
+    self->echo_buffer_right_pos = 0;
 }
 
 void common_hal_audiodelays_echo_deinit(audiodelays_echo_obj_t *self) {
@@ -131,7 +130,8 @@ void recalculate_delay(audiodelays_echo_obj_t *self, mp_float_t f_delay_ms) {
     if (self->freq_shift) {
         // Calculate the rate of iteration over the echo buffer with 8 sub-bits
         self->echo_buffer_rate = (uint32_t)MAX(self->max_delay_ms / f_delay_ms * MICROPY_FLOAT_CONST(256.0), MICROPY_FLOAT_CONST(1.0));
-        self->echo_buffer_len = self->max_echo_buffer_len;
+        // Only use half of the buffer per channel if stereo
+        self->echo_buffer_len = self->max_echo_buffer_len >> (self->base.channel_count - 1);
     } else {
         // Calculate the current echo buffer length in bytes
         uint32_t new_echo_buffer_len = (uint32_t)(self->base.sample_rate / MICROPY_FLOAT_CONST(1000.0) * f_delay_ms) * (self->base.channel_count * sizeof(uint16_t));
@@ -174,6 +174,12 @@ bool common_hal_audiodelays_echo_get_freq_shift(audiodelays_echo_obj_t *self) {
 }
 
 void common_hal_audiodelays_echo_set_freq_shift(audiodelays_echo_obj_t *self, bool freq_shift) {
+    // Clear the echo buffer and reset buffer position if changing freq_shift modes
+    if (self->freq_shift != freq_shift) {
+        memset(self->echo_buffer, 0, self->max_echo_buffer_len);
+        self->echo_buffer_pos = 0;
+        self->echo_buffer_right_pos = 0;
+    }
     self->freq_shift = freq_shift;
     uint32_t delay_ms = (uint32_t)synthio_block_slot_get(&self->delay_ms);
     recalculate_delay(self, delay_ms);
@@ -275,12 +281,9 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
         uint32_t echo_buf_len = self->echo_buffer_len / sizeof(uint16_t);
 
         // Set our echo buffer position accounting for stereo
-        uint32_t echo_buffer_pos = 0;
-        if (self->freq_shift) {
-            echo_buffer_pos = self->echo_buffer_left_pos;
-            if (channel == 1) {
-                echo_buffer_pos = self->echo_buffer_right_pos;
-            }
+        uint32_t echo_buffer_pos = self->echo_buffer_pos;
+        if (self->freq_shift && channel == 1) {
+            echo_buffer_pos = self->echo_buffer_right_pos;
         }
 
         // If we have no sample keep the echo echoing
@@ -304,19 +307,20 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
                 for (uint32_t i = 0; i < length; i++) {
                     int16_t echo, word = 0;
                     uint32_t next_buffer_pos = 0;
+                    uint32_t echo_buffer_offset = echo_buf_len * (self->freq_shift && (channel == 1 || (i % self->base.channel_count) == 1));
 
                     if (self->freq_shift) {
-                        echo = echo_buffer[echo_buffer_pos >> 8];
+                        echo = echo_buffer[(echo_buffer_pos >> 8) + echo_buffer_offset];
                         next_buffer_pos = echo_buffer_pos + self->echo_buffer_rate;
 
                         for (uint32_t j = echo_buffer_pos >> 8; j < next_buffer_pos >> 8; j++) {
-                            word = (int16_t)(echo_buffer[j % echo_buf_len] * decay);
-                            echo_buffer[j % echo_buf_len] = word;
+                            word = (int16_t)(echo_buffer[(j % echo_buf_len) + echo_buffer_offset] * decay);
+                            echo_buffer[(j % echo_buf_len) + echo_buffer_offset] = word;
                         }
                     } else {
-                        echo = echo_buffer[self->echo_buffer_read_pos++];
+                        echo = echo_buffer[echo_buffer_pos];
                         word = (int16_t)(echo * decay);
-                        echo_buffer[self->echo_buffer_write_pos++] = word;
+                        echo_buffer[echo_buffer_pos++] = word;
                     }
 
                     word = (int16_t)(echo * mix);
@@ -333,15 +337,10 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
                         }
                     }
 
-                    if (self->freq_shift) {
+                    if (self->freq_shift && (single_channel_output || echo_buffer_offset)) {
                         echo_buffer_pos = next_buffer_pos % (echo_buf_len << 8);
-                    } else {
-                        if (self->echo_buffer_read_pos >= echo_buf_len) {
-                            self->echo_buffer_read_pos = 0;
-                        }
-                        if (self->echo_buffer_write_pos >= echo_buf_len) {
-                            self->echo_buffer_write_pos = 0;
-                        }
+                    } else if (!self->freq_shift && echo_buffer_pos >= echo_buf_len) {
+                        echo_buffer_pos = 0;
                     }
                 }
             }
@@ -376,37 +375,39 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
 
                     int32_t echo, word = 0;
                     uint32_t next_buffer_pos = 0;
+                    uint32_t echo_buffer_offset = echo_buf_len * (self->freq_shift && (channel == 1 || (i % self->base.channel_count) == 1));
+
                     if (self->freq_shift) {
-                        echo = echo_buffer[echo_buffer_pos >> 8];
+                        echo = echo_buffer[(echo_buffer_pos >> 8) + echo_buffer_offset];
                         next_buffer_pos = echo_buffer_pos + self->echo_buffer_rate;
                     } else {
-                        echo = echo_buffer[self->echo_buffer_read_pos++];
+                        echo = echo_buffer[echo_buffer_pos];
                         word = (int32_t)(echo * decay + sample_word);
                     }
 
                     if (MP_LIKELY(self->base.bits_per_sample == 16)) {
                         if (self->freq_shift) {
                             for (uint32_t j = echo_buffer_pos >> 8; j < next_buffer_pos >> 8; j++) {
-                                word = (int32_t)(echo_buffer[j % echo_buf_len] * decay + sample_word);
+                                word = (int32_t)(echo_buffer[(j % echo_buf_len) + echo_buffer_offset] * decay + sample_word);
                                 word = synthio_mix_down_sample(word, SYNTHIO_MIX_DOWN_SCALE(2));
-                                echo_buffer[j % echo_buf_len] = (int16_t)word;
+                                echo_buffer[(j % echo_buf_len) + echo_buffer_offset] = (int16_t)word;
                             }
                         } else {
                             word = synthio_mix_down_sample(word, SYNTHIO_MIX_DOWN_SCALE(2));
-                            echo_buffer[self->echo_buffer_write_pos++] = (int16_t)word;
+                            echo_buffer[echo_buffer_pos++] = (int16_t)word;
                         }
                     } else {
                         if (self->freq_shift) {
                             for (uint32_t j = echo_buffer_pos >> 8; j < next_buffer_pos >> 8; j++) {
-                                word = (int32_t)(echo_buffer[j % echo_buf_len] * decay + sample_word);
+                                word = (int32_t)(echo_buffer[(j % echo_buf_len) + echo_buffer_offset] * decay + sample_word);
                                 // Do not have mix_down for 8 bit so just hard cap samples into 1 byte
                                 word = MIN(MAX(word, -128), 127);
-                                echo_buffer[j % echo_buf_len] = (int8_t)word;
+                                echo_buffer[(j % echo_buf_len) + echo_buffer_offset] = (int8_t)word;
                             }
                         } else {
                             // Do not have mix_down for 8 bit so just hard cap samples into 1 byte
                             word = MIN(MAX(word, -128), 127);
-                            echo_buffer[self->echo_buffer_write_pos++] = (int8_t)word;
+                            echo_buffer[echo_buffer_pos++] = (int8_t)word;
                         }
                     }
 
@@ -427,15 +428,10 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
                         }
                     }
 
-                    if (self->freq_shift) {
+                    if (self->freq_shift && (single_channel_output || echo_buffer_offset)) {
                         echo_buffer_pos = next_buffer_pos % (echo_buf_len << 8);
-                    } else {
-                        if (self->echo_buffer_read_pos >= echo_buf_len) {
-                            self->echo_buffer_read_pos = 0;
-                        }
-                        if (self->echo_buffer_write_pos >= echo_buf_len) {
-                            self->echo_buffer_write_pos = 0;
-                        }
+                    } else if (!self->freq_shift && echo_buffer_pos >= echo_buf_len) {
+                        echo_buffer_pos = 0;
                     }
                 }
             }
@@ -448,12 +444,11 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
             self->sample_buffer_length -= n;
         }
 
-        if (self->freq_shift) {
-            if (channel == 0) {
-                self->echo_buffer_left_pos = echo_buffer_pos;
-            } else if (channel == 1) {
-                self->echo_buffer_right_pos = echo_buffer_pos;
-            }
+        // Update buffer position
+        if (self->freq_shift && channel == 1) {
+            self->echo_buffer_right_pos = echo_buffer_pos;
+        } else {
+            self->echo_buffer_pos = echo_buffer_pos;
         }
     }
 

--- a/shared-module/audiodelays/Echo.c
+++ b/shared-module/audiodelays/Echo.c
@@ -307,7 +307,7 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
                 for (uint32_t i = 0; i < length; i++) {
                     int16_t echo, word = 0;
                     uint32_t next_buffer_pos = 0;
-                    uint32_t echo_buffer_offset = echo_buf_len * (self->freq_shift && (channel == 1 || (i % self->base.channel_count) == 1));
+                    uint32_t echo_buffer_offset = echo_buf_len * (self->freq_shift && ((single_channel_output && channel == 1) || (!single_channel_output && (i % self->base.channel_count) == 1)));
 
                     if (self->freq_shift) {
                         echo = echo_buffer[(echo_buffer_pos >> 8) + echo_buffer_offset];
@@ -337,7 +337,7 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
                         }
                     }
 
-                    if (self->freq_shift && (single_channel_output || echo_buffer_offset)) {
+                    if (self->freq_shift && (self->base.channel_count == 1 || single_channel_output || (!single_channel_output && (i % self->base.channel_count) == 1))) {
                         echo_buffer_pos = next_buffer_pos % (echo_buf_len << 8);
                     } else if (!self->freq_shift && echo_buffer_pos >= echo_buf_len) {
                         echo_buffer_pos = 0;
@@ -375,7 +375,7 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
 
                     int32_t echo, word = 0;
                     uint32_t next_buffer_pos = 0;
-                    uint32_t echo_buffer_offset = echo_buf_len * (self->freq_shift && (channel == 1 || (i % self->base.channel_count) == 1));
+                    uint32_t echo_buffer_offset = echo_buf_len * (self->freq_shift && ((single_channel_output && channel == 1) || (!single_channel_output && (i % self->base.channel_count) == 1)));
 
                     if (self->freq_shift) {
                         echo = echo_buffer[(echo_buffer_pos >> 8) + echo_buffer_offset];
@@ -428,7 +428,7 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
                         }
                     }
 
-                    if (self->freq_shift && (single_channel_output || echo_buffer_offset)) {
+                    if (self->freq_shift && (self->base.channel_count == 1 || single_channel_output || (!single_channel_output && (i % self->base.channel_count) == 1))) {
                         echo_buffer_pos = next_buffer_pos % (echo_buf_len << 8);
                     } else if (!self->freq_shift && echo_buffer_pos >= echo_buf_len) {
                         echo_buffer_pos = 0;

--- a/shared-module/audiodelays/Echo.h
+++ b/shared-module/audiodelays/Echo.h
@@ -37,8 +37,8 @@ typedef struct {
     uint32_t echo_buffer_len; // bytes
     uint32_t max_echo_buffer_len; // bytes
 
-    uint32_t echo_buffer_pos; // words (<< 8 when freq_shift=True)
-    uint32_t echo_buffer_right_pos; // words << 8
+    uint32_t echo_buffer_left_pos; // words (<< 8 when freq_shift=True)
+    uint32_t echo_buffer_right_pos; // words (<< 8 when freq_shift=True)
     uint32_t echo_buffer_rate; // words << 8
 
     mp_obj_t sample;

--- a/shared-module/audiodelays/Echo.h
+++ b/shared-module/audiodelays/Echo.h
@@ -37,12 +37,9 @@ typedef struct {
     uint32_t echo_buffer_len; // bytes
     uint32_t max_echo_buffer_len; // bytes
 
-    uint32_t echo_buffer_read_pos; // words
-    uint32_t echo_buffer_write_pos; // words
-
-    uint32_t echo_buffer_rate; // words << 8
-    uint32_t echo_buffer_left_pos; // words << 8
+    uint32_t echo_buffer_pos; // words (<< 8 when freq_shift=True)
     uint32_t echo_buffer_right_pos; // words << 8
+    uint32_t echo_buffer_rate; // words << 8
 
     mp_obj_t sample;
 } audiodelays_echo_obj_t;


### PR DESCRIPTION
@gamblor21 @dhalbert for interest.

> This PR has been rewritten and resubmitted from its original state (https://github.com/adafruit/circuitpython/pull/9876) for compatibility with 9.2.x and to fix conflicts with other recent changes to `audiodelays.Delay`.

This has been an issue that I've been aware of since the inclusion of `audiodelays` in 9.2.0. Echo buffer positions weren't being properly managed when handling stereo input/output. I've resolved this issue by separating the echo buffer into two halves (left + right) and offsetting the buffer where necessary. I've done my best to support `single_channel_output` as well, but I'm not exactly sure how to test that (I2SOut uses left/right pairs).

I've also found a minor bug when constructing `audiodelays.Echo` with `delay_ms <= 0 || delay_ms > max_delay_ms` where `echo_buffer_length` would not be set and remain as the default of 0. The effect of this issue wasn't too major, but I've resolved it by always setting `echo_buffer_length` during `recalculate_delay` and limiting it to the acceptable range.

Because each `freq_shift` mode handles the buffer differently now, I've added it so that the full `echo_buffer` and buffer positions are reset whenever the mode is changed to avoid potential audio abnormalities.

The example in https://github.com/adafruit/circuitpython/issues/9874 now does not exhibit any issues. I've also tested this code with variable `delay_ms` values, and the frequency shifting works with full channel separation.

Fixes https://github.com/adafruit/circuitpython/issues/9874.