### PR TITLE
fix swapped argument required vars in bitmaptools args helper

### DIFF
--- a/shared-bindings/bitmaptools/__init__.h
+++ b/shared-bindings/bitmaptools/__init__.h
@@ -80,8 +80,8 @@ typedef struct {
 #define ARGS_X1_Y1_X2_Y2 ARG_x1, ARG_y1, ARG_x2, ARG_y2
 #define ALLOWED_ARGS_X1_Y1_X2_Y2(if_required1, if_required2) \
     {MP_QSTR_x1, if_required1 | MP_ARG_OBJ, {.u_obj = MP_ROM_INT(0)}}, \
-    {MP_QSTR_y1, if_required2 | MP_ARG_OBJ, {.u_obj = MP_ROM_INT(0)}}, \
-    {MP_QSTR_x2, if_required1 | MP_ARG_OBJ, {.u_obj = MP_ROM_NONE}}, \
+    {MP_QSTR_y1, if_required1 | MP_ARG_OBJ, {.u_obj = MP_ROM_INT(0)}}, \
+    {MP_QSTR_x2, if_required2 | MP_ARG_OBJ, {.u_obj = MP_ROM_NONE}}, \
     {MP_QSTR_y2, if_required2 | MP_ARG_OBJ, {.u_obj = MP_ROM_NONE}}
 
 bitmaptools_rect_t bitmaptools_validate_coord_range_pair(const mp_arg_val_t in[4], int width, int height);


### PR DESCRIPTION
I believe the intention of this helper function is to have `if_required1` be relvant for `x1` and `y1` and have `if_required2` be relevant for `x2` and `y2`.

That would mean that it is possible to control the required-ness of x1,y1  and x2,y2 independently. 

As it is written now instead `if_required1` is relevant for `x1` and `x2` and `if_required2` is relevant for `y1` and `y2`. If this functionality does match the intention then I would propose `if_requiredX` and `if_requiredY` as more descriptive variable names. 

But I believe the x1,y1  and x2,y2 delineation was likely the original intention as it's plausible there could be a function that requires one coordinate point, but has the second one be optional. And seems less plausible to me that a function would have x1,x2 required and y1,y2 optional or vice versa for instance. 

The only place where this helper function is called that the `if_required` arguments actually differ is here: https://github.com/adafruit/circuitpython/blob/main/shared-bindings/bitmaptools/__init__.c#L722 

Using this statement which calls the affected function:
```
bitmaptools.arrayblit(bmp, array_2d, x2=32, y2=32)
```
under `10.0.0-alpha.2` results in this exception:
```
TypeError: 'y1' argument required
```

using this PR branch instead successfully runs as the docstrings indicate it should if x1 and y1 are omitted. 


I do also believe there are other issues with the arrayblit() arg validation and/or docstrings, but it's separate from this issue with the swapped values in the helper function here, it just so happens to make use of this.