### PR TITLE
bitmaptools.arrayblit fix: make x2,y2 optional and update docstring

### DIFF
--- a/shared-bindings/bitmaptools/__init__.c
+++ b/shared-bindings/bitmaptools/__init__.c
@@ -691,7 +691,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(bitmaptools_draw_polygon_obj, 0, bitmaptools_obj_draw
 //|     available in the destination bitmap.
 //|
 //|     If x1 or y1 are not specified, they are taken as 0.  If x2 or y2
-//|     are not specified, or are given as -1, they are taken as the width
+//|     are not specified, or are given as None, they are taken as the width
 //|     and height of the image.
 //|
 //|     The coordinates affected by the blit are ``x1 <= x < x2`` and ``y1 <= y < y2``.
@@ -719,7 +719,7 @@ static mp_obj_t bitmaptools_arrayblit(size_t n_args, const mp_obj_t *pos_args, m
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_bitmap, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_data, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
-        ALLOWED_ARGS_X1_Y1_X2_Y2(0, MP_ARG_REQUIRED),
+        ALLOWED_ARGS_X1_Y1_X2_Y2(0, 0),
         { MP_QSTR_skip_index, MP_ARG_OBJ, {.u_obj = mp_const_none } },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];


### PR DESCRIPTION
This function's docstrings don't match its behavior in two ways. 

1) Currently if you pass `-1` for x2 or y2 as specified in the docstring it will raise an exception `ValueError: x2 must be 0-80`

We could update the validation to accept `-1` but this same validation helper in used in multiple other places and I'm not sure if all of them share the same support for and meaning of `-1` value. 

In any case the current code already provides `None` as a value that does make it get taken as the width and/or height of the image. I think there is no need to have two different argument values that lead to that same behavior. So I've just updated the docstring to indicate `None` instead of `-1`.

2) if x2 and y2 are omitted as the docstrings say they can be the code raises an exception `TypeError: 'x2' argument required`. This is resolved by removing the ARG_REQUIRED flag from for `if_required2` argument to the validation helper call. 

Tested on a pyportal with this code:
```
import math

import bitmaptools
import supervisor
import displayio
import ulab.numpy as np

# Make the display context. Change size if you want
display = supervisor.runtime.display
display.auto_refresh = False

# Make the display context
main_group = displayio.Group(scale=4)
display.root_group = main_group

bmp = displayio.Bitmap(320//4, 240//4, 16)
palette = displayio.Palette(16)
palette[0] = 0x000000
palette[1] = 0xffffff
palette[2] = 0xff0000
palette[3] = 0x00ff00
palette[4] = 0x0000ff
palette[5] = 0xffff00
palette[6] = 0x00ffff
palette[7] = 0xff00ff

bmp.fill(3)

tg = displayio.TileGrid(bmp, pixel_shader=palette)
main_group.append(tg)
rows = []
for y in range(bmp.height):
    for x in range(bmp.width):
        rows.extend([(y*bmp.width + x + y) % 8])
array_2d = np.array(rows, dtype=np.uint8)
bitmaptools.arrayblit(bmp, array_2d)
while True:
    pass
```