### PR TITLE
Audio Effect Multi-Tap Delay

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -102,6 +102,10 @@ msgstr ""
 msgid "%q failure: %d"
 msgstr ""
 
+#: shared-module/audiodelays/MultiTapDelay.c
+msgid "%q in %q must be of type %q or %q, not %q"
+msgstr ""
+
 #: py/argcheck.c shared-module/audiofilters/Filter.c
 msgid "%q in %q must be of type %q, not %q"
 msgstr ""
@@ -224,7 +228,8 @@ msgid "%q must be of type %q, %q, or %q, not %q"
 msgstr ""
 
 #: py/argcheck.c py/runtime.c shared-bindings/bitmapfilter/__init__.c
-#: shared-module/synthio/Note.c shared-module/synthio/__init__.c
+#: shared-module/audiodelays/MultiTapDelay.c shared-module/synthio/Note.c
+#: shared-module/synthio/__init__.c
 msgid "%q must be of type %q, not %q"
 msgstr ""
 
@@ -2587,6 +2592,7 @@ msgid "bits must be 32 or less"
 msgstr ""
 
 #: shared-bindings/audiodelays/Chorus.c shared-bindings/audiodelays/Echo.c
+#: shared-bindings/audiodelays/MultiTapDelay.c
 #: shared-bindings/audiodelays/PitchShift.c
 #: shared-bindings/audiofilters/Distortion.c
 #: shared-bindings/audiofilters/Filter.c shared-bindings/audiomixer/Mixer.c

--- a/ports/unix/variants/coverage/mpconfigvariant.mk
+++ b/ports/unix/variants/coverage/mpconfigvariant.mk
@@ -36,6 +36,7 @@ SRC_BITMAP := \
 	shared-bindings/audiodelays/Echo.c \
 	shared-bindings/audiodelays/Chorus.c \
 	shared-bindings/audiodelays/PitchShift.c \
+	shared-bindings/audiodelays/MultiTapDelay.c \
 	shared-bindings/audiodelays/__init__.c \
 	shared-bindings/audiofilters/Distortion.c \
 	shared-bindings/audiofilters/Filter.c \
@@ -80,6 +81,7 @@ SRC_BITMAP := \
 	shared-module/audiodelays/Echo.c \
 	shared-module/audiodelays/Chorus.c \
 	shared-module/audiodelays/PitchShift.c \
+	shared-module/audiodelays/MultiTapDelay.c \
 	shared-module/audiodelays/__init__.c \
 	shared-module/audiofilters/Distortion.c \
 	shared-module/audiofilters/Filter.c \

--- a/py/circuitpy_defns.mk
+++ b/py/circuitpy_defns.mk
@@ -666,6 +666,7 @@ SRC_SHARED_MODULE_ALL = \
 	audiodelays/Echo.c \
 	audiodelays/Chorus.c \
 	audiodelays/PitchShift.c \
+	audiodelays/MultiTapDelay.c \
 	audiodelays/__init__.c \
 	audiofilters/Distortion.c \
 	audiofilters/Filter.c \

--- a/shared-bindings/audiodelays/MultiTapDelay.c
+++ b/shared-bindings/audiodelays/MultiTapDelay.c
@@ -26,7 +26,7 @@
 //|         delay_ms: synthio.BlockInput = 250.0,
 //|         decay: synthio.BlockInput = 0.7,
 //|         mix: synthio.BlockInput = 0.25,
-//|         taps: Tuple[float|Tuple[float, float], ...] = None,
+//|         taps: Optional[Tuple[float|Tuple[float, float], ...]] = None,
 //|         buffer_size: int = 512,
 //|         sample_rate: int = 8000,
 //|         bits_per_sample: int = 16,

--- a/shared-bindings/audiodelays/MultiTapDelay.c
+++ b/shared-bindings/audiodelays/MultiTapDelay.c
@@ -1,0 +1,278 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2025 Cooper Dalrymple
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdint.h>
+
+#include "shared-bindings/audiodelays/MultiTapDelay.h"
+#include "shared-bindings/audiocore/__init__.h"
+#include "shared-module/audiodelays/MultiTapDelay.h"
+
+#include "shared/runtime/context_manager_helpers.h"
+#include "py/binary.h"
+#include "py/objproperty.h"
+#include "py/runtime.h"
+#include "shared-bindings/util.h"
+#include "shared-module/synthio/block.h"
+
+//| class MultiTapDelay:
+//|     """A delay with multiple buffer positions to create a rhythmic effect."""
+//|
+//|     def __init__(
+//|         self,
+//|         max_delay_ms: int = 500,
+//|         delay_ms: synthio.BlockInput = 250.0,
+//|         decay: synthio.BlockInput = 0.7,
+//|         mix: synthio.BlockInput = 0.25,
+//|         buffer_size: int = 512,
+//|         sample_rate: int = 8000,
+//|         bits_per_sample: int = 16,
+//|         samples_signed: bool = True,
+//|         channel_count: int = 1,
+//|     ) -> None:
+//|         """Create a MultiTapDelay effect where you hear the original sample play back, at a lesser volume after
+//|            a set number of millisecond delay. The delay timing of the echo can be changed at runtime
+//|            with the delay_ms parameter but the delay can never exceed the max_delay_ms parameter. The
+//|            maximum delay you can set is limited by available memory.
+//|
+//|            Each time the echo plays back the volume is reduced by the decay setting (echo * decay).
+//|
+//|            The mix parameter allows you to change how much of the unchanged sample passes through to
+//|            the output to how much of the effect audio you hear as the output.
+//|
+//|         :param int max_delay_ms: The maximum time the echo can be in milliseconds
+//|         :param float delay_ms: The current time of the echo delay in milliseconds. Must be less the max_delay_ms
+//|         :param synthio.BlockInput decay: The rate the echo fades. 0.0 = instant; 1.0 = never.
+//|         :param synthio.BlockInput mix: The mix as a ratio of the sample (0.0) to the effect (1.0).
+//|         :param int buffer_size: The total size in bytes of each of the two playback buffers to use
+//|         :param int sample_rate: The sample rate to be used
+//|         :param int channel_count: The number of channels the source samples contain. 1 = mono; 2 = stereo.
+//|         :param int bits_per_sample: The bits per sample of the effect
+//|         :param bool samples_signed: Effect is signed (True) or unsigned (False)
+//|
+//|         Playing adding a multi-tap delay to a synth::
+//|
+//|           import time
+//|           import board
+//|           import audiobusio
+//|           import synthio
+//|           import audiodelays
+//|
+//|           audio = audiobusio.I2SOut(bit_clock=board.GP20, word_select=board.GP21, data=board.GP22)
+//|           synth = synthio.Synthesizer(channel_count=1, sample_rate=44100)
+//|           effect = audiodelays.MultiTapDelay(max_delay_ms=1000, delay_ms=850, decay=0.65, buffer_size=1024, channel_count=1, sample_rate=44100, mix=0.7, freq_shift=False)
+//|           effect.play(synth)
+//|           audio.play(effect)
+//|
+//|           note = synthio.Note(261)
+//|           while True:
+//|               synth.press(note)
+//|               time.sleep(0.25)
+//|               synth.release(note)
+//|               time.sleep(5)"""
+//|         ...
+//|
+static mp_obj_t audiodelays_multi_tap_delay_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    enum { ARG_max_delay_ms, ARG_delay_ms, ARG_decay, ARG_mix, ARG_buffer_size, ARG_sample_rate, ARG_bits_per_sample, ARG_samples_signed, ARG_channel_count, ARG_freq_shift, };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_max_delay_ms, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 500 } },
+        { MP_QSTR_delay_ms, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = MP_ROM_INT(250) } },
+        { MP_QSTR_decay, MP_ARG_OBJ | MP_ARG_KW_ONLY,  {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_mix, MP_ARG_OBJ | MP_ARG_KW_ONLY,  {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_buffer_size, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 512} },
+        { MP_QSTR_sample_rate, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 8000} },
+        { MP_QSTR_bits_per_sample, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 16} },
+        { MP_QSTR_samples_signed, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = true} },
+        { MP_QSTR_channel_count, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 1 } },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    mp_int_t max_delay_ms = mp_arg_validate_int_range(args[ARG_max_delay_ms].u_int, 1, 4000, MP_QSTR_max_delay_ms);
+
+    mp_int_t channel_count = mp_arg_validate_int_range(args[ARG_channel_count].u_int, 1, 2, MP_QSTR_channel_count);
+    mp_int_t sample_rate = mp_arg_validate_int_min(args[ARG_sample_rate].u_int, 1, MP_QSTR_sample_rate);
+    mp_int_t bits_per_sample = args[ARG_bits_per_sample].u_int;
+    if (bits_per_sample != 8 && bits_per_sample != 16) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bits_per_sample must be 8 or 16"));
+    }
+
+    audiodelays_multi_tap_delay_obj_t *self = mp_obj_malloc(audiodelays_multi_tap_delay_obj_t, &audiodelays_multi_tap_delay_type);
+    common_hal_audiodelays_multi_tap_delay_construct(self, max_delay_ms, args[ARG_delay_ms].u_obj, args[ARG_decay].u_obj, args[ARG_mix].u_obj, args[ARG_buffer_size].u_int, bits_per_sample, args[ARG_samples_signed].u_bool, channel_count, sample_rate);
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+//|     def deinit(self) -> None:
+//|         """Deinitialises the MultiTapDelay."""
+//|         ...
+//|
+static mp_obj_t audiodelays_multi_tap_delay_deinit(mp_obj_t self_in) {
+    audiodelays_multi_tap_delay_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_audiodelays_multi_tap_delay_deinit(self);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_multi_tap_delay_deinit_obj, audiodelays_multi_tap_delay_deinit);
+
+static void check_for_deinit(audiodelays_multi_tap_delay_obj_t *self) {
+    audiosample_check_for_deinit(&self->base);
+}
+
+//|     def __enter__(self) -> MultiTapDelay:
+//|         """No-op used by Context Managers."""
+//|         ...
+//|
+//  Provided by context manager helper.
+
+//|     def __exit__(self) -> None:
+//|         """Automatically deinitializes when exiting a context. See
+//|         :ref:`lifetime-and-contextmanagers` for more info."""
+//|         ...
+//|
+//  Provided by context manager helper.
+
+
+//|     delay_ms: float
+//|     """Maximum time to delay the incoming signal in milliseconds."""
+//|
+static mp_obj_t audiodelays_multi_tap_delay_obj_get_delay_ms(mp_obj_t self_in) {
+    audiodelays_multi_tap_delay_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_float(common_hal_audiodelays_multi_tap_delay_get_delay_ms(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_multi_tap_delay_get_delay_ms_obj, audiodelays_multi_tap_delay_obj_get_delay_ms);
+
+static mp_obj_t audiodelays_multi_tap_delay_obj_set_delay_ms(mp_obj_t self_in, mp_obj_t delay_ms_in) {
+    audiodelays_multi_tap_delay_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_audiodelays_multi_tap_delay_set_delay_ms(self, delay_ms_in);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(audiodelays_multi_tap_delay_set_delay_ms_obj, audiodelays_multi_tap_delay_obj_set_delay_ms);
+
+MP_PROPERTY_GETSET(audiodelays_multi_tap_delay_delay_ms_obj,
+    (mp_obj_t)&audiodelays_multi_tap_delay_get_delay_ms_obj,
+    (mp_obj_t)&audiodelays_multi_tap_delay_set_delay_ms_obj);
+
+//|     decay: synthio.BlockInput
+//|     """The rate the echo fades between 0 and 1 where 0 is instant and 1 is never."""
+static mp_obj_t audiodelays_multi_tap_delay_obj_get_decay(mp_obj_t self_in) {
+    return common_hal_audiodelays_multi_tap_delay_get_decay(self_in);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_multi_tap_delay_get_decay_obj, audiodelays_multi_tap_delay_obj_get_decay);
+
+static mp_obj_t audiodelays_multi_tap_delay_obj_set_decay(mp_obj_t self_in, mp_obj_t decay_in) {
+    audiodelays_multi_tap_delay_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_audiodelays_multi_tap_delay_set_decay(self, decay_in);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(audiodelays_multi_tap_delay_set_decay_obj, audiodelays_multi_tap_delay_obj_set_decay);
+
+MP_PROPERTY_GETSET(audiodelays_multi_tap_delay_decay_obj,
+    (mp_obj_t)&audiodelays_multi_tap_delay_get_decay_obj,
+    (mp_obj_t)&audiodelays_multi_tap_delay_set_decay_obj);
+
+//|     mix: synthio.BlockInput
+//|     """The rate the echo mix between 0 and 1 where 0 is only sample, 0.5 is an equal mix of the sample and the effect and 1 is all effect."""
+static mp_obj_t audiodelays_multi_tap_delay_obj_get_mix(mp_obj_t self_in) {
+    return common_hal_audiodelays_multi_tap_delay_get_mix(self_in);
+}
+MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_multi_tap_delay_get_mix_obj, audiodelays_multi_tap_delay_obj_get_mix);
+
+static mp_obj_t audiodelays_multi_tap_delay_obj_set_mix(mp_obj_t self_in, mp_obj_t mix_in) {
+    audiodelays_multi_tap_delay_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_audiodelays_multi_tap_delay_set_mix(self, mix_in);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(audiodelays_multi_tap_delay_set_mix_obj, audiodelays_multi_tap_delay_obj_set_mix);
+
+MP_PROPERTY_GETSET(audiodelays_multi_tap_delay_mix_obj,
+    (mp_obj_t)&audiodelays_multi_tap_delay_get_mix_obj,
+    (mp_obj_t)&audiodelays_multi_tap_delay_set_mix_obj);
+
+
+
+//|     playing: bool
+//|     """True when the effect is playing a sample. (read-only)"""
+//|
+static mp_obj_t audiodelays_multi_tap_delay_obj_get_playing(mp_obj_t self_in) {
+    audiodelays_multi_tap_delay_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    check_for_deinit(self);
+    return mp_obj_new_bool(common_hal_audiodelays_multi_tap_delay_get_playing(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_multi_tap_delay_get_playing_obj, audiodelays_multi_tap_delay_obj_get_playing);
+
+MP_PROPERTY_GETTER(audiodelays_multi_tap_delay_playing_obj,
+    (mp_obj_t)&audiodelays_multi_tap_delay_get_playing_obj);
+
+//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> None:
+//|         """Plays the sample once when loop=False and continuously when loop=True.
+//|         Does not block. Use `playing` to block.
+//|
+//|         The sample must match the encoding settings given in the constructor."""
+//|         ...
+//|
+static mp_obj_t audiodelays_multi_tap_delay_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_sample, ARG_loop };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_sample,    MP_ARG_OBJ | MP_ARG_REQUIRED, {} },
+        { MP_QSTR_loop,      MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
+    };
+    audiodelays_multi_tap_delay_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    check_for_deinit(self);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+
+    mp_obj_t sample = args[ARG_sample].u_obj;
+    common_hal_audiodelays_multi_tap_delay_play(self, sample, args[ARG_loop].u_bool);
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_multi_tap_delay_play_obj, 1, audiodelays_multi_tap_delay_obj_play);
+
+//|     def stop(self) -> None:
+//|         """Stops playback of the sample. The echo continues playing."""
+//|         ...
+//|
+//|
+static mp_obj_t audiodelays_multi_tap_delay_obj_stop(mp_obj_t self_in) {
+    audiodelays_multi_tap_delay_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    common_hal_audiodelays_multi_tap_delay_stop(self);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_multi_tap_delay_stop_obj, audiodelays_multi_tap_delay_obj_stop);
+
+static const mp_rom_map_elem_t audiodelays_multi_tap_delay_locals_dict_table[] = {
+    // Methods
+    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&audiodelays_multi_tap_delay_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&default___enter___obj) },
+    { MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&default___exit___obj) },
+    { MP_ROM_QSTR(MP_QSTR_play), MP_ROM_PTR(&audiodelays_multi_tap_delay_play_obj) },
+    { MP_ROM_QSTR(MP_QSTR_stop), MP_ROM_PTR(&audiodelays_multi_tap_delay_stop_obj) },
+
+    // Properties
+    { MP_ROM_QSTR(MP_QSTR_playing), MP_ROM_PTR(&audiodelays_multi_tap_delay_playing_obj) },
+    { MP_ROM_QSTR(MP_QSTR_delay_ms), MP_ROM_PTR(&audiodelays_multi_tap_delay_delay_ms_obj) },
+    { MP_ROM_QSTR(MP_QSTR_decay), MP_ROM_PTR(&audiodelays_multi_tap_delay_decay_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mix), MP_ROM_PTR(&audiodelays_multi_tap_delay_mix_obj) },
+    AUDIOSAMPLE_FIELDS,
+};
+static MP_DEFINE_CONST_DICT(audiodelays_multi_tap_delay_locals_dict, audiodelays_multi_tap_delay_locals_dict_table);
+
+static const audiosample_p_t audiodelays_multi_tap_delay_proto = {
+    MP_PROTO_IMPLEMENT(MP_QSTR_protocol_audiosample)
+    .reset_buffer = (audiosample_reset_buffer_fun)audiodelays_multi_tap_delay_reset_buffer,
+    .get_buffer = (audiosample_get_buffer_fun)audiodelays_multi_tap_delay_get_buffer,
+};
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    audiodelays_multi_tap_delay_type,
+    MP_QSTR_MultiTapDelay,
+    MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
+    make_new, audiodelays_multi_tap_delay_make_new,
+    locals_dict, &audiodelays_multi_tap_delay_locals_dict,
+    protocol, &audiodelays_multi_tap_delay_proto
+    );

--- a/shared-bindings/audiodelays/MultiTapDelay.h
+++ b/shared-bindings/audiodelays/MultiTapDelay.h
@@ -1,0 +1,31 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2025 Cooper Dalrymple
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "shared-module/audiodelays/MultiTapDelay.h"
+
+extern const mp_obj_type_t audiodelays_multi_tap_delay_type;
+
+void common_hal_audiodelays_multi_tap_delay_construct(audiodelays_multi_tap_delay_obj_t *self, uint32_t max_delay_ms,
+    mp_obj_t delay_ms, mp_obj_t decay, mp_obj_t mix,
+    uint32_t buffer_size, uint8_t bits_per_sample, bool samples_signed,
+    uint8_t channel_count, uint32_t sample_rate);
+
+void common_hal_audiodelays_multi_tap_delay_deinit(audiodelays_multi_tap_delay_obj_t *self);
+
+mp_float_t common_hal_audiodelays_multi_tap_delay_get_delay_ms(audiodelays_multi_tap_delay_obj_t *self);
+void common_hal_audiodelays_multi_tap_delay_set_delay_ms(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t delay_ms);
+
+mp_obj_t common_hal_audiodelays_multi_tap_delay_get_decay(audiodelays_multi_tap_delay_obj_t *self);
+void common_hal_audiodelays_multi_tap_delay_set_decay(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t decay);
+
+mp_obj_t common_hal_audiodelays_multi_tap_delay_get_mix(audiodelays_multi_tap_delay_obj_t *self);
+void common_hal_audiodelays_multi_tap_delay_set_mix(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t arg);
+
+bool common_hal_audiodelays_multi_tap_delay_get_playing(audiodelays_multi_tap_delay_obj_t *self);
+void common_hal_audiodelays_multi_tap_delay_play(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t sample, bool loop);
+void common_hal_audiodelays_multi_tap_delay_stop(audiodelays_multi_tap_delay_obj_t *self);

--- a/shared-bindings/audiodelays/MultiTapDelay.h
+++ b/shared-bindings/audiodelays/MultiTapDelay.h
@@ -11,7 +11,7 @@
 extern const mp_obj_type_t audiodelays_multi_tap_delay_type;
 
 void common_hal_audiodelays_multi_tap_delay_construct(audiodelays_multi_tap_delay_obj_t *self, uint32_t max_delay_ms,
-    mp_obj_t delay_ms, mp_obj_t decay, mp_obj_t mix,
+    mp_obj_t delay_ms, mp_obj_t decay, mp_obj_t mix, mp_obj_t taps,
     uint32_t buffer_size, uint8_t bits_per_sample, bool samples_signed,
     uint8_t channel_count, uint32_t sample_rate);
 
@@ -24,7 +24,10 @@ mp_obj_t common_hal_audiodelays_multi_tap_delay_get_decay(audiodelays_multi_tap_
 void common_hal_audiodelays_multi_tap_delay_set_decay(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t decay);
 
 mp_obj_t common_hal_audiodelays_multi_tap_delay_get_mix(audiodelays_multi_tap_delay_obj_t *self);
-void common_hal_audiodelays_multi_tap_delay_set_mix(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t arg);
+void common_hal_audiodelays_multi_tap_delay_set_mix(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t mix);
+
+mp_obj_t common_hal_audiodelays_multi_tap_delay_get_taps(audiodelays_multi_tap_delay_obj_t *self);
+void common_hal_audiodelays_multi_tap_delay_set_taps(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t taps);
 
 bool common_hal_audiodelays_multi_tap_delay_get_playing(audiodelays_multi_tap_delay_obj_t *self);
 void common_hal_audiodelays_multi_tap_delay_play(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t sample, bool loop);

--- a/shared-bindings/audiodelays/__init__.c
+++ b/shared-bindings/audiodelays/__init__.c
@@ -13,6 +13,7 @@
 #include "shared-bindings/audiodelays/Echo.h"
 #include "shared-bindings/audiodelays/Chorus.h"
 #include "shared-bindings/audiodelays/PitchShift.h"
+#include "shared-bindings/audiodelays/MultiTapDelay.h"
 
 //| """Support for audio delay effects
 //|
@@ -25,6 +26,7 @@ static const mp_rom_map_elem_t audiodelays_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_Echo), MP_ROM_PTR(&audiodelays_echo_type) },
     { MP_ROM_QSTR(MP_QSTR_Chorus), MP_ROM_PTR(&audiodelays_chorus_type) },
     { MP_ROM_QSTR(MP_QSTR_PitchShift), MP_ROM_PTR(&audiodelays_pitch_shift_type) },
+    { MP_ROM_QSTR(MP_QSTR_MultiTapDelay), MP_ROM_PTR(&audiodelays_multi_tap_delay_type) },
 };
 
 static MP_DEFINE_CONST_DICT(audiodelays_module_globals, audiodelays_module_globals_table);

--- a/shared-module/audiodelays/MultiTapDelay.c
+++ b/shared-module/audiodelays/MultiTapDelay.c
@@ -400,7 +400,7 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
                 for (size_t j = 0; j < self->tap_len; j++) {
                     tap_pos = (delay_buffer_pos + delay_buffer_len - self->tap_offsets[j]) % delay_buffer_len;
                     delay_word = delay_buffer[tap_pos + delay_buffer_offset];
-                    word += delay_word * self->tap_levels[j];
+                    word += (int32_t)(delay_word * self->tap_levels[j]);
                 }
 
                 if (self->tap_len > 1) {
@@ -417,7 +417,7 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
             }
 
             // Apply decay and add sample
-            delay_word = (int32_t)(delay_word * decay + sample_word);
+            delay_word = (int32_t)(delay_word * decay) + sample_word;
 
             if (MP_LIKELY(self->base.bits_per_sample == 16)) {
                 delay_word = synthio_mix_down_sample(delay_word, SYNTHIO_MIX_DOWN_SCALE(2));

--- a/shared-module/audiodelays/MultiTapDelay.c
+++ b/shared-module/audiodelays/MultiTapDelay.c
@@ -410,6 +410,13 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
 
             // Update delay buffer with sample and decay
             delay_word = delay_buffer[delay_buffer_pos + delay_buffer_offset];
+
+            // If no taps are provided, use as standard delay
+            if (!self->tap_len) {
+                word = delay_word;
+            }
+
+            // Apply decay and add sample
             delay_word = (int32_t)(delay_word * decay + sample_word);
 
             if (MP_LIKELY(self->base.bits_per_sample == 16)) {

--- a/shared-module/audiodelays/MultiTapDelay.c
+++ b/shared-module/audiodelays/MultiTapDelay.c
@@ -11,7 +11,7 @@
 #include <math.h>
 
 void common_hal_audiodelays_multi_tap_delay_construct(audiodelays_multi_tap_delay_obj_t *self, uint32_t max_delay_ms,
-    mp_obj_t delay_ms, mp_obj_t decay, mp_obj_t mix,
+    mp_obj_t delay_ms, mp_obj_t decay, mp_obj_t mix, mp_obj_t taps,
     uint32_t buffer_size, uint8_t bits_per_sample,
     bool samples_signed, uint8_t channel_count, uint32_t sample_rate) {
 
@@ -67,11 +67,7 @@ void common_hal_audiodelays_multi_tap_delay_construct(audiodelays_multi_tap_dela
     }
     synthio_block_assign_slot(mix, &self->mix, MP_QSTR_mix);
 
-    // Many effects may need buffers of what was played this shows how it was done for the echo
-    // A maximum length buffer was created and then the current echo length can be dynamically changes
-    // without having to reallocate a large chunk of memory.
-
-    // Allocate the echo buffer for the max possible delay, echo is always 16-bit
+    // Allocate the delay buffer for the max possible delay, delay is always 16-bit
     self->max_delay_ms = max_delay_ms;
     self->max_delay_buffer_len = (uint32_t)(self->base.sample_rate / MICROPY_FLOAT_CONST(1000.0) * max_delay_ms) * (self->base.channel_count * sizeof(uint16_t)); // bytes
     self->delay_buffer = m_malloc_maybe(self->max_delay_buffer_len);
@@ -86,8 +82,15 @@ void common_hal_audiodelays_multi_tap_delay_construct(audiodelays_multi_tap_dela
 
     // calculate everything needed for the current delay
     common_hal_audiodelays_multi_tap_delay_set_delay_ms(self, delay_ms);
-
     self->delay_buffer_pos = 0;
+    self->delay_buffer_right_pos = 0;
+
+    // Initialize our tap values
+    self->tap_positions = NULL;
+    self->tap_levels = NULL;
+    self->tap_offsets = NULL;
+    self->tap_len = 0;
+    common_hal_audiodelays_multi_tap_delay_set_taps(self, taps);
 }
 
 void common_hal_audiodelays_multi_tap_delay_deinit(audiodelays_multi_tap_delay_obj_t *self) {
@@ -95,6 +98,10 @@ void common_hal_audiodelays_multi_tap_delay_deinit(audiodelays_multi_tap_delay_o
     self->delay_buffer = NULL;
     self->buffer[0] = NULL;
     self->buffer[1] = NULL;
+
+    self->tap_positions = NULL;
+    self->tap_levels = NULL;
+    self->tap_offsets = NULL;
 }
 
 mp_float_t common_hal_audiodelays_multi_tap_delay_get_delay_ms(audiodelays_multi_tap_delay_obj_t *self) {
@@ -107,19 +114,22 @@ void common_hal_audiodelays_multi_tap_delay_set_delay_ms(audiodelays_multi_tap_d
     // Require that delay is at least 1 sample long
     self->delay_ms = MAX(self->delay_ms, self->sample_ms);
 
-    // Calculate the current echo buffer length in bytes
+    // Calculate the current delay buffer length in bytes
     self->delay_buffer_len = (uint32_t)(self->base.sample_rate / MICROPY_FLOAT_CONST(1000.0) * self->delay_ms) * (self->base.channel_count * sizeof(uint16_t));
 
     // Limit to valid range
     if (self->delay_buffer_len > self->max_delay_buffer_len) {
         self->delay_buffer_len = self->max_delay_buffer_len;
     } else if (self->delay_buffer_len < self->buffer_len) {
-        // If the echo buffer is smaller than our audio buffer, weird things happen
+        // If the delay buffer is smaller than our audio buffer, weird things happen
         self->delay_buffer_len = self->buffer_len;
     }
 
     // Clear the now unused part of the buffer or some weird artifacts appear
     memset(self->delay_buffer + self->delay_buffer_len, 0, self->max_delay_buffer_len - self->delay_buffer_len);
+
+    // Update tap offsets if we have any
+    recalculate_tap_offsets(self);
 }
 
 mp_obj_t common_hal_audiodelays_multi_tap_delay_get_decay(audiodelays_multi_tap_delay_obj_t *self) {
@@ -134,8 +144,112 @@ mp_obj_t common_hal_audiodelays_multi_tap_delay_get_mix(audiodelays_multi_tap_de
     return self->mix.obj;
 }
 
-void common_hal_audiodelays_multi_tap_delay_set_mix(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t arg) {
-    synthio_block_assign_slot(arg, &self->mix, MP_QSTR_mix);
+void common_hal_audiodelays_multi_tap_delay_set_mix(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t mix) {
+    synthio_block_assign_slot(mix, &self->mix, MP_QSTR_mix);
+}
+
+mp_obj_t common_hal_audiodelays_multi_tap_delay_get_taps(audiodelays_multi_tap_delay_obj_t *self) {
+    if (!self->tap_len) {
+        return mp_const_none;
+    } else {
+        mp_obj_tuple_t *taps = mp_obj_new_tuple(self->tap_len, NULL);
+        for (size_t i = 0; i < self->tap_len; i++) {
+            mp_obj_tuple_t *pair = mp_obj_new_tuple(2, NULL);
+            pair->items[0] = mp_obj_new_float(self->tap_positions[i]);
+            pair->items[1] = mp_obj_new_float(self->tap_levels[i]);
+            taps->items[i] = pair;
+        }
+        return taps;
+    }
+}
+
+void common_hal_audiodelays_multi_tap_delay_set_taps(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t taps_in) {
+    if (taps_in != mp_const_none && !MP_OBJ_TYPE_HAS_SLOT(mp_obj_get_type(taps_in), iter)) {
+        mp_raise_TypeError_varg(
+            MP_ERROR_TEXT("%q must be of type %q, not %q"),
+            MP_QSTR_taps, MP_QSTR_iterable, mp_obj_get_type(taps_in)->name);
+    }
+
+    size_t len, i;
+    mp_obj_t *items;
+
+    if (taps_in == mp_const_none) {
+        len = 0;
+        items = NULL;
+    } else {
+        // convert object to tuple if it wasn't before
+        taps_in = MP_OBJ_TYPE_GET_SLOT(&mp_type_tuple, make_new)(
+            &mp_type_tuple, 1, 0, &taps_in);
+
+        mp_obj_tuple_get(taps_in, &len, &items);
+        mp_arg_validate_length_min(len, 1, MP_QSTR_items);
+
+        for (i = 0; i < len; i++) {
+            mp_obj_t item = items[i];
+            if (mp_obj_is_tuple_compatible(item)) {
+                size_t len1;
+                mp_obj_t *items1;
+                mp_obj_tuple_get(item, &len1, &items1);
+                mp_arg_validate_length(len1, 2, MP_QSTR_items);
+
+                for (size_t j = 0; j < len1; j++) {
+                    mp_arg_validate_obj_float_range(items1[j], 0, 1, j ? MP_QSTR_level : MP_QSTR_position);
+                }
+            } else if (mp_obj_is_float(item)) {
+                mp_arg_validate_obj_float_range(item, 0, 1, MP_QSTR_position);
+            } else {
+                mp_raise_TypeError_varg(
+                    MP_ERROR_TEXT("%q in %q must be of type %q or %q, not %q"),
+                    MP_QSTR_object,
+                    MP_QSTR_taps,
+                    MP_QSTR_iterable,
+                    MP_QSTR_float,
+                    mp_obj_get_type(item)->name);
+            }
+
+        }
+    }
+
+    self->tap_positions = m_renew(mp_float_t,
+        self->tap_positions,
+        self->tap_len,
+        len);
+    self->tap_levels = m_renew(mp_float_t,
+        self->tap_levels,
+        self->tap_len,
+        len);
+    self->tap_offsets = m_renew(uint32_t,
+        self->tap_offsets,
+        self->tap_len,
+        len);
+    self->tap_len = len;
+
+    for (i = 0; i < len; i++) {
+        mp_obj_t item = items[i];
+        if (mp_obj_is_float(item)) {
+            self->tap_positions[i] = mp_obj_float_get(item);
+            self->tap_levels[i] = MICROPY_FLOAT_CONST(1.0);
+        } else if (mp_obj_is_tuple_compatible(item)) {
+            size_t len1;
+            mp_obj_t *items1;
+            mp_obj_tuple_get(item, &len1, &items1);
+            self->tap_positions[i] = mp_obj_float_get(items1[0]);
+            self->tap_levels[i] = mp_obj_float_get(items1[1]);
+        }
+    }
+
+    recalculate_tap_offsets(self);
+}
+
+void recalculate_tap_offsets(audiodelays_multi_tap_delay_obj_t *self) {
+    if (!self->tap_len) {
+        return;
+    }
+
+    uint32_t delay_buffer_len = self->delay_buffer_len / self->base.channel_count / sizeof(uint16_t);
+    for (size_t i = 0; i < self->tap_len; i++) {
+        self->tap_offsets[i] = (uint32_t)(delay_buffer_len * self->tap_positions[i]);
+    }
 }
 
 void audiodelays_multi_tap_delay_reset_buffer(audiodelays_multi_tap_delay_obj_t *self,
@@ -170,7 +284,7 @@ void common_hal_audiodelays_multi_tap_delay_play(audiodelays_multi_tap_delay_obj
 
 void common_hal_audiodelays_multi_tap_delay_stop(audiodelays_multi_tap_delay_obj_t *self) {
     // When the sample is set to stop playing do any cleanup here
-    // For echo we clear the sample but the echo continues until the object reading our effect stops
+    // For delay we clear the sample but the delay continues until the object reading our effect stops
     self->sample = NULL;
     return;
 }
@@ -190,9 +304,16 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
     int8_t *hword_buffer = self->buffer[self->last_buf_idx];
     uint32_t length = self->buffer_len / (self->base.bits_per_sample / 8);
 
-    // The echo buffer is always stored as a 16-bit value internally
+    // The delay buffer is always stored as a 16-bit value internally
     int16_t *delay_buffer = (int16_t *)self->delay_buffer;
-    uint32_t delay_buffer_len = self->delay_buffer_len / sizeof(uint16_t);
+    uint32_t delay_buffer_len = self->delay_buffer_len / self->base.channel_count / sizeof(uint16_t);
+
+    uint32_t delay_buffer_pos = self->delay_buffer_pos;
+    if (single_channel_output && channel == 1) {
+        delay_buffer_pos = self->delay_buffer_right_pos;
+    }
+
+    int32_t mix_down_scale = SYNTHIO_MIX_DOWN_SCALE(self->tap_len);
 
     // Loop over the entire length of our buffer to fill it, this may require several calls to get data from the sample
     while (length != 0) {
@@ -201,7 +322,7 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
             if (!self->more_data) { // The sample has indicated it has no more data to play
                 if (self->loop && self->sample) { // If we are supposed to loop reset the sample to the start
                     audiosample_reset_buffer(self->sample, false, 0);
-                } else { // If we were not supposed to loop the sample, stop playing it but we still need to play the echo
+                } else { // If we were not supposed to loop the sample, stop playing it but we still need to play the delay
                     self->sample = NULL;
                 }
             }
@@ -230,12 +351,14 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
         int16_t *sample_src = NULL;
         int8_t *sample_hsrc = NULL;
         if (self->sample != NULL) {
-            // we have a sample to play and echo
+            // we have a sample to play and delay
             sample_src = (int16_t *)self->sample_remaining_buffer; // for 16-bit samples
             sample_hsrc = (int8_t *)self->sample_remaining_buffer; // for 8-bit samples
         }
 
         for (uint32_t i = 0; i < n; i++) {
+            uint32_t delay_buffer_offset = delay_buffer_len * ((single_channel_output && channel == 1) || (!single_channel_output && (i % self->base.channel_count) == 1));
+
             int32_t sample_word = 0;
             if (self->sample != NULL) {
                 if (MP_LIKELY(self->base.bits_per_sample == 16)) {
@@ -250,21 +373,38 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
                 }
             }
 
-            int32_t echo, word = 0;
-            echo = delay_buffer[self->delay_buffer_pos];
-            word = (int32_t)(echo * decay + sample_word);
+            // Pull words from delay buffer at tap positions, apply level and mix down
+            int32_t word = 0;
+            int32_t delay_word;
+            if (self->tap_len) {
+                size_t tap_pos;
+                for (size_t j = 0; j < self->tap_len; j++) {
+                    tap_pos = (delay_buffer_pos + delay_buffer_len - self->tap_offsets[j]) % delay_buffer_len;
+                    delay_word = delay_buffer[tap_pos + delay_buffer_offset];
+                    word += delay_word * self->tap_levels[j];
+                }
 
-            if (MP_LIKELY(self->base.bits_per_sample == 16)) {
-                word = synthio_mix_down_sample(word, SYNTHIO_MIX_DOWN_SCALE(2));
-                delay_buffer[self->delay_buffer_pos] = (int16_t)word;
-            } else {
-                // Do not have mix_down for 8 bit so just hard cap samples into 1 byte
-                word = MIN(MAX(word, -128), 127);
-                delay_buffer[self->delay_buffer_pos] = (int8_t)word;
+                if (self->tap_len > 1) {
+                    word = synthio_mix_down_sample(word, mix_down_scale);
+                }
             }
 
+            // Update delay buffer with sample and decay
+            delay_word = delay_buffer[delay_buffer_pos + delay_buffer_offset];
+            delay_word = (int32_t)(delay_word * decay + sample_word);
+
+            if (MP_LIKELY(self->base.bits_per_sample == 16)) {
+                delay_word = synthio_mix_down_sample(delay_word, SYNTHIO_MIX_DOWN_SCALE(2));
+                delay_buffer[delay_buffer_pos + delay_buffer_offset] = (int16_t)word;
+            } else {
+                // Do not have mix_down for 8 bit so just hard cap samples into 1 byte
+                delay_word = MIN(MAX(delay_word, -128), 127);
+                delay_buffer[delay_buffer_pos + delay_buffer_offset] = (int8_t)delay_word;
+            }
+
+            // Mix sample with tap output
             word = (int32_t)((sample_word * MIN(MICROPY_FLOAT_CONST(2.0) - mix, MICROPY_FLOAT_CONST(1.0)))
-                + (echo * MIN(mix, MICROPY_FLOAT_CONST(1.0))));
+                + (word * MIN(mix, MICROPY_FLOAT_CONST(1.0))));
             word = synthio_mix_down_sample(word, SYNTHIO_MIX_DOWN_SCALE(2));
 
             if (MP_LIKELY(self->base.bits_per_sample == 16)) {
@@ -281,8 +421,9 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
                 }
             }
 
-            if (++self->delay_buffer_pos >= delay_buffer_len) {
-                self->delay_buffer_pos = 0;
+            if ((self->base.channel_count == 1 || single_channel_output || (!single_channel_output && (i % self->base.channel_count) == 1))
+                && ++delay_buffer_pos >= delay_buffer_len) {
+                delay_buffer_pos = 0;
             }
         }
 
@@ -294,6 +435,12 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
             self->sample_remaining_buffer += (n * (self->base.bits_per_sample / 8));
             self->sample_buffer_length -= n;
         }
+    }
+
+    if (single_channel_output && channel == 1) {
+        self->delay_buffer_right_pos = delay_buffer_pos;
+    } else {
+        self->delay_buffer_pos = delay_buffer_pos;
     }
 
     // Finally pass our buffer and length to the calling audio function

--- a/shared-module/audiodelays/MultiTapDelay.c
+++ b/shared-module/audiodelays/MultiTapDelay.c
@@ -1,0 +1,305 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2025 Cooper Dalrymple
+//
+// SPDX-License-Identifier: MIT
+#include "shared-bindings/audiodelays/MultiTapDelay.h"
+#include "shared-bindings/audiocore/__init__.h"
+
+#include <stdint.h>
+#include "py/runtime.h"
+#include <math.h>
+
+void common_hal_audiodelays_multi_tap_delay_construct(audiodelays_multi_tap_delay_obj_t *self, uint32_t max_delay_ms,
+    mp_obj_t delay_ms, mp_obj_t decay, mp_obj_t mix,
+    uint32_t buffer_size, uint8_t bits_per_sample,
+    bool samples_signed, uint8_t channel_count, uint32_t sample_rate) {
+
+    // Basic settings every effect and audio sample has
+    // These are the effects values, not the source sample(s)
+    self->base.bits_per_sample = bits_per_sample; // Most common is 16, but 8 is also supported in many places
+    self->base.samples_signed = samples_signed; // Are the samples we provide signed (common is true)
+    self->base.channel_count = channel_count; // Channels can be 1 for mono or 2 for stereo
+    self->base.sample_rate = sample_rate; // Sample rate for the effect, this generally needs to match all audio objects
+    self->base.single_buffer = false;
+    self->base.max_buffer_length = buffer_size;
+
+    // To smooth things out as CircuitPython is doing other tasks most audio objects have a buffer
+    // A double buffer is set up here so the audio output can use DMA on buffer 1 while we
+    // write to and create buffer 2.
+    // This buffer is what is passed to the audio component that plays the effect.
+    // Samples are set sequentially. For stereo audio they are passed L/R/L/R/...
+    self->buffer_len = buffer_size; // in bytes
+
+    self->buffer[0] = m_malloc_maybe(self->buffer_len);
+    if (self->buffer[0] == NULL) {
+        common_hal_audiodelays_multi_tap_delay_deinit(self);
+        m_malloc_fail(self->buffer_len);
+    }
+    memset(self->buffer[0], 0, self->buffer_len);
+
+    self->buffer[1] = m_malloc_maybe(self->buffer_len);
+    if (self->buffer[1] == NULL) {
+        common_hal_audiodelays_multi_tap_delay_deinit(self);
+        m_malloc_fail(self->buffer_len);
+    }
+    memset(self->buffer[1], 0, self->buffer_len);
+
+    self->last_buf_idx = 1; // Which buffer to use first, toggle between 0 and 1
+
+    // Initialize other values most effects will need.
+    self->sample = NULL; // The current playing sample
+    self->sample_remaining_buffer = NULL; // Pointer to the start of the sample buffer we have not played
+    self->sample_buffer_length = 0; // How many samples do we have left to play (these may be 16 bit!)
+    self->loop = false; // When the sample is done do we loop to the start again or stop (e.g. in a wav file)
+    self->more_data = false; // Is there still more data to read from the sample or did we finish
+
+    // The below section sets up the multi-tap delay effect's starting values. For a different effect this section will change
+
+    // If we did not receive a BlockInput we need to create a default float value
+    if (decay == MP_OBJ_NULL) {
+        decay = mp_obj_new_float(MICROPY_FLOAT_CONST(0.7));
+    }
+    synthio_block_assign_slot(decay, &self->decay, MP_QSTR_decay);
+
+    if (mix == MP_OBJ_NULL) {
+        mix = mp_obj_new_float(MICROPY_FLOAT_CONST(0.25));
+    }
+    synthio_block_assign_slot(mix, &self->mix, MP_QSTR_mix);
+
+    // Many effects may need buffers of what was played this shows how it was done for the echo
+    // A maximum length buffer was created and then the current echo length can be dynamically changes
+    // without having to reallocate a large chunk of memory.
+
+    // Allocate the echo buffer for the max possible delay, echo is always 16-bit
+    self->max_delay_ms = max_delay_ms;
+    self->max_delay_buffer_len = (uint32_t)(self->base.sample_rate / MICROPY_FLOAT_CONST(1000.0) * max_delay_ms) * (self->base.channel_count * sizeof(uint16_t)); // bytes
+    self->delay_buffer = m_malloc_maybe(self->max_delay_buffer_len);
+    if (self->delay_buffer == NULL) {
+        common_hal_audiodelays_multi_tap_delay_deinit(self);
+        m_malloc_fail(self->max_delay_buffer_len);
+    }
+    memset(self->delay_buffer, 0, self->max_delay_buffer_len);
+
+    // calculate the length of a single sample in milliseconds
+    self->sample_ms = MICROPY_FLOAT_CONST(1000.0) / self->base.sample_rate;
+
+    // calculate everything needed for the current delay
+    common_hal_audiodelays_multi_tap_delay_set_delay_ms(self, delay_ms);
+
+    self->delay_buffer_pos = 0;
+}
+
+void common_hal_audiodelays_multi_tap_delay_deinit(audiodelays_multi_tap_delay_obj_t *self) {
+    audiosample_mark_deinit(&self->base);
+    self->delay_buffer = NULL;
+    self->buffer[0] = NULL;
+    self->buffer[1] = NULL;
+}
+
+mp_float_t common_hal_audiodelays_multi_tap_delay_get_delay_ms(audiodelays_multi_tap_delay_obj_t *self) {
+    return self->delay_ms;
+}
+
+void common_hal_audiodelays_multi_tap_delay_set_delay_ms(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t delay_ms) {
+    self->delay_ms = mp_obj_get_float(delay_ms);
+
+    // Require that delay is at least 1 sample long
+    self->delay_ms = MAX(self->delay_ms, self->sample_ms);
+
+    // Calculate the current echo buffer length in bytes
+    self->delay_buffer_len = (uint32_t)(self->base.sample_rate / MICROPY_FLOAT_CONST(1000.0) * self->delay_ms) * (self->base.channel_count * sizeof(uint16_t));
+
+    // Limit to valid range
+    if (self->delay_buffer_len > self->max_delay_buffer_len) {
+        self->delay_buffer_len = self->max_delay_buffer_len;
+    } else if (self->delay_buffer_len < self->buffer_len) {
+        // If the echo buffer is smaller than our audio buffer, weird things happen
+        self->delay_buffer_len = self->buffer_len;
+    }
+
+    // Clear the now unused part of the buffer or some weird artifacts appear
+    memset(self->delay_buffer + self->delay_buffer_len, 0, self->max_delay_buffer_len - self->delay_buffer_len);
+}
+
+mp_obj_t common_hal_audiodelays_multi_tap_delay_get_decay(audiodelays_multi_tap_delay_obj_t *self) {
+    return self->decay.obj;
+}
+
+void common_hal_audiodelays_multi_tap_delay_set_decay(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t decay) {
+    synthio_block_assign_slot(decay, &self->decay, MP_QSTR_decay);
+}
+
+mp_obj_t common_hal_audiodelays_multi_tap_delay_get_mix(audiodelays_multi_tap_delay_obj_t *self) {
+    return self->mix.obj;
+}
+
+void common_hal_audiodelays_multi_tap_delay_set_mix(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t arg) {
+    synthio_block_assign_slot(arg, &self->mix, MP_QSTR_mix);
+}
+
+void audiodelays_multi_tap_delay_reset_buffer(audiodelays_multi_tap_delay_obj_t *self,
+    bool single_channel_output,
+    uint8_t channel) {
+
+    memset(self->buffer[0], 0, self->buffer_len);
+    memset(self->buffer[1], 0, self->buffer_len);
+    memset(self->delay_buffer, 0, self->max_delay_buffer_len);
+}
+
+bool common_hal_audiodelays_multi_tap_delay_get_playing(audiodelays_multi_tap_delay_obj_t *self) {
+    return self->sample != NULL;
+}
+
+void common_hal_audiodelays_multi_tap_delay_play(audiodelays_multi_tap_delay_obj_t *self, mp_obj_t sample, bool loop) {
+    audiosample_must_match(&self->base, sample);
+
+    self->sample = sample;
+    self->loop = loop;
+
+    audiosample_reset_buffer(self->sample, false, 0);
+    audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
+
+    // Track remaining sample length in terms of bytes per sample
+    self->sample_buffer_length /= (self->base.bits_per_sample / 8);
+    // Store if we have more data in the sample to retrieve
+    self->more_data = result == GET_BUFFER_MORE_DATA;
+
+    return;
+}
+
+void common_hal_audiodelays_multi_tap_delay_stop(audiodelays_multi_tap_delay_obj_t *self) {
+    // When the sample is set to stop playing do any cleanup here
+    // For echo we clear the sample but the echo continues until the object reading our effect stops
+    self->sample = NULL;
+    return;
+}
+
+audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_multi_tap_delay_obj_t *self, bool single_channel_output, uint8_t channel,
+    uint8_t **buffer, uint32_t *buffer_length) {
+
+    if (!single_channel_output) {
+        channel = 0;
+    }
+
+    // Switch our buffers to the other buffer
+    self->last_buf_idx = !self->last_buf_idx;
+
+    // If we are using 16 bit samples we need a 16 bit pointer, 8 bit needs an 8 bit pointer
+    int16_t *word_buffer = (int16_t *)self->buffer[self->last_buf_idx];
+    int8_t *hword_buffer = self->buffer[self->last_buf_idx];
+    uint32_t length = self->buffer_len / (self->base.bits_per_sample / 8);
+
+    // The echo buffer is always stored as a 16-bit value internally
+    int16_t *delay_buffer = (int16_t *)self->delay_buffer;
+    uint32_t delay_buffer_len = self->delay_buffer_len / sizeof(uint16_t);
+
+    // Loop over the entire length of our buffer to fill it, this may require several calls to get data from the sample
+    while (length != 0) {
+        // Check if there is no more sample to play, we will either load more data, reset the sample if loop is on or clear the sample
+        if (self->sample_buffer_length == 0) {
+            if (!self->more_data) { // The sample has indicated it has no more data to play
+                if (self->loop && self->sample) { // If we are supposed to loop reset the sample to the start
+                    audiosample_reset_buffer(self->sample, false, 0);
+                } else { // If we were not supposed to loop the sample, stop playing it but we still need to play the echo
+                    self->sample = NULL;
+                }
+            }
+            if (self->sample) {
+                // Load another sample buffer to play
+                audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
+                // Track length in terms of words.
+                self->sample_buffer_length /= (self->base.bits_per_sample / 8);
+                self->more_data = result == GET_BUFFER_MORE_DATA;
+            }
+        }
+
+        // Determine how many bytes we can process to our buffer, the less of the sample we have left and our buffer remaining
+        uint32_t n;
+        if (self->sample == NULL) {
+            n = MIN(length, SYNTHIO_MAX_DUR * self->base.channel_count);
+        } else {
+            n = MIN(MIN(self->sample_buffer_length, length), SYNTHIO_MAX_DUR * self->base.channel_count);
+        }
+
+        // get the effect values we need from the BlockInput. These may change at run time so you need to do bounds checking if required
+        shared_bindings_synthio_lfo_tick(self->base.sample_rate, n / self->base.channel_count);
+        mp_float_t mix = synthio_block_slot_get_limited(&self->mix, MICROPY_FLOAT_CONST(0.0), MICROPY_FLOAT_CONST(1.0)) * MICROPY_FLOAT_CONST(2.0);
+        mp_float_t decay = synthio_block_slot_get_limited(&self->decay, MICROPY_FLOAT_CONST(0.0), MICROPY_FLOAT_CONST(1.0));
+
+        int16_t *sample_src = NULL;
+        int8_t *sample_hsrc = NULL;
+        if (self->sample != NULL) {
+            // we have a sample to play and echo
+            sample_src = (int16_t *)self->sample_remaining_buffer; // for 16-bit samples
+            sample_hsrc = (int8_t *)self->sample_remaining_buffer; // for 8-bit samples
+        }
+
+        for (uint32_t i = 0; i < n; i++) {
+            int32_t sample_word = 0;
+            if (self->sample != NULL) {
+                if (MP_LIKELY(self->base.bits_per_sample == 16)) {
+                    sample_word = sample_src[i];
+                } else {
+                    if (self->base.samples_signed) {
+                        sample_word = sample_hsrc[i];
+                    } else {
+                        // Be careful here changing from an 8 bit unsigned to signed into a 32-bit signed
+                        sample_word = (int8_t)(((uint8_t)sample_hsrc[i]) ^ 0x80);
+                    }
+                }
+            }
+
+            int32_t echo, word = 0;
+            echo = delay_buffer[self->delay_buffer_pos];
+            word = (int32_t)(echo * decay + sample_word);
+
+            if (MP_LIKELY(self->base.bits_per_sample == 16)) {
+                word = synthio_mix_down_sample(word, SYNTHIO_MIX_DOWN_SCALE(2));
+                delay_buffer[self->delay_buffer_pos] = (int16_t)word;
+            } else {
+                // Do not have mix_down for 8 bit so just hard cap samples into 1 byte
+                word = MIN(MAX(word, -128), 127);
+                delay_buffer[self->delay_buffer_pos] = (int8_t)word;
+            }
+
+            word = (int32_t)((sample_word * MIN(MICROPY_FLOAT_CONST(2.0) - mix, MICROPY_FLOAT_CONST(1.0)))
+                + (echo * MIN(mix, MICROPY_FLOAT_CONST(1.0))));
+            word = synthio_mix_down_sample(word, SYNTHIO_MIX_DOWN_SCALE(2));
+
+            if (MP_LIKELY(self->base.bits_per_sample == 16)) {
+                word_buffer[i] = (int16_t)word;
+                if (!self->base.samples_signed) {
+                    word_buffer[i] ^= 0x8000;
+                }
+            } else {
+                int8_t mixed = (int16_t)word;
+                if (self->base.samples_signed) {
+                    hword_buffer[i] = mixed;
+                } else {
+                    hword_buffer[i] = (uint8_t)mixed ^ 0x80;
+                }
+            }
+
+            if (++self->delay_buffer_pos >= delay_buffer_len) {
+                self->delay_buffer_pos = 0;
+            }
+        }
+
+        // Update the remaining length and the buffer positions based on how much we wrote into our buffer
+        length -= n;
+        word_buffer += n;
+        hword_buffer += n;
+        if (self->sample != NULL) {
+            self->sample_remaining_buffer += (n * (self->base.bits_per_sample / 8));
+            self->sample_buffer_length -= n;
+        }
+    }
+
+    // Finally pass our buffer and length to the calling audio function
+    *buffer = (uint8_t *)self->buffer[self->last_buf_idx];
+    *buffer_length = self->buffer_len;
+
+    // MultiTapDelay always returns more data but some effects may return GET_BUFFER_DONE or GET_BUFFER_ERROR (see audiocore/__init__.h)
+    return GET_BUFFER_MORE_DATA;
+}

--- a/shared-module/audiodelays/MultiTapDelay.c
+++ b/shared-module/audiodelays/MultiTapDelay.c
@@ -395,7 +395,7 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
 
             if (MP_LIKELY(self->base.bits_per_sample == 16)) {
                 delay_word = synthio_mix_down_sample(delay_word, SYNTHIO_MIX_DOWN_SCALE(2));
-                delay_buffer[delay_buffer_pos + delay_buffer_offset] = (int16_t)word;
+                delay_buffer[delay_buffer_pos + delay_buffer_offset] = (int16_t)delay_word;
             } else {
                 // Do not have mix_down for 8 bit so just hard cap samples into 1 byte
                 delay_word = MIN(MAX(delay_word, -128), 127);

--- a/shared-module/audiodelays/MultiTapDelay.h
+++ b/shared-module/audiodelays/MultiTapDelay.h
@@ -1,0 +1,50 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2025 Cooper Dalrymple
+//
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "py/obj.h"
+
+#include "shared-module/audiocore/__init__.h"
+#include "shared-module/synthio/__init__.h"
+#include "shared-module/synthio/block.h"
+
+extern const mp_obj_type_t audiodelays_multi_tap_delay_type;
+
+typedef struct {
+    audiosample_base_t base;
+    uint32_t max_delay_ms;
+    mp_float_t delay_ms;
+    mp_float_t sample_ms;
+    synthio_block_slot_t decay;
+    synthio_block_slot_t mix;
+
+    int8_t *buffer[2];
+    uint8_t last_buf_idx;
+    uint32_t buffer_len; // max buffer in bytes
+
+    uint8_t *sample_remaining_buffer;
+    uint32_t sample_buffer_length;
+
+    bool loop;
+    bool more_data;
+
+    int8_t *delay_buffer;
+    uint32_t delay_buffer_len; // bytes
+    uint32_t max_delay_buffer_len; // bytes
+    uint32_t delay_buffer_pos;
+
+    mp_obj_t sample;
+} audiodelays_multi_tap_delay_obj_t;
+
+void audiodelays_multi_tap_delay_reset_buffer(audiodelays_multi_tap_delay_obj_t *self,
+    bool single_channel_output,
+    uint8_t channel);
+
+audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_multi_tap_delay_obj_t *self,
+    bool single_channel_output,
+    uint8_t channel,
+    uint8_t **buffer,
+    uint32_t *buffer_length);  // length in bytes

--- a/shared-module/audiodelays/MultiTapDelay.h
+++ b/shared-module/audiodelays/MultiTapDelay.h
@@ -21,6 +21,11 @@ typedef struct {
     synthio_block_slot_t decay;
     synthio_block_slot_t mix;
 
+    mp_float_t *tap_positions;
+    mp_float_t *tap_levels;
+    uint32_t *tap_offsets;
+    size_t tap_len;
+
     int8_t *buffer[2];
     uint8_t last_buf_idx;
     uint32_t buffer_len; // max buffer in bytes
@@ -35,9 +40,12 @@ typedef struct {
     uint32_t delay_buffer_len; // bytes
     uint32_t max_delay_buffer_len; // bytes
     uint32_t delay_buffer_pos;
+    uint32_t delay_buffer_right_pos;
 
     mp_obj_t sample;
 } audiodelays_multi_tap_delay_obj_t;
+
+void recalculate_tap_offsets(audiodelays_multi_tap_delay_obj_t *self);
 
 void audiodelays_multi_tap_delay_reset_buffer(audiodelays_multi_tap_delay_obj_t *self,
     bool single_channel_output,

--- a/shared-module/audiodelays/MultiTapDelay.h
+++ b/shared-module/audiodelays/MultiTapDelay.h
@@ -45,6 +45,8 @@ typedef struct {
     mp_obj_t sample;
 } audiodelays_multi_tap_delay_obj_t;
 
+void validate_tap_value(mp_obj_t item, qstr arg_name);
+mp_float_t get_tap_value(mp_obj_t item);
 void recalculate_tap_offsets(audiodelays_multi_tap_delay_obj_t *self);
 
 void audiodelays_multi_tap_delay_reset_buffer(audiodelays_multi_tap_delay_obj_t *self,


### PR DESCRIPTION
Adding a variation of a standard digital delay (no frequency shifting) which allows for multiple "tap" positions to draw from the delay buffer. Rhythmic delay effects can be achieved by using irregular tap positions, ie: dotted quarter notes.

Notes:
- I've tried to make the `taps` parameter flexible, but any suggestions are welcome.
- `synthio.BlockInput` is not supported at this time. I don't see any immediate benefits from adding in that feature.
- This feature could be included into the `audiodelays.Echo` effect instead of its own, but doing so might add too much complexity.
- ~~Currently, `taps=None` results in silent output. An alternative would be to have it act as a standard delay in this circumstance.~~
- I've re-written the `..._get_buffer(...)` slightly to reduce complexity and flash usage. There are some performance drawbacks when not playing a sample through this effect directly, but that scenario is uncommon and the performance hit should be minimal. Another benefit is that trailing delays after a sample has ended should act properly.