### PR TITLE
Mark functions as NORETURN

### DIFF
--- a/ports/atmel-samd/common-hal/alarm/touch/TouchAlarm.c
+++ b/ports/atmel-samd/common-hal/alarm/touch/TouchAlarm.c
@@ -7,6 +7,6 @@
 #include "shared-bindings/alarm/touch/TouchAlarm.h"
 #include "shared-bindings/microcontroller/__init__.h"
 
-void common_hal_alarm_touch_touchalarm_construct(alarm_touch_touchalarm_obj_t *self, const mcu_pin_obj_t *pin) {
+NORETURN void common_hal_alarm_touch_touchalarm_construct(alarm_touch_touchalarm_obj_t *self, const mcu_pin_obj_t *pin) {
     mp_raise_NotImplementedError_varg(MP_ERROR_TEXT("%q"), MP_QSTR_TouchAlarm);
 }

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -686,7 +686,7 @@ void port_idle_until_interrupt(void) {
 /**
  * \brief Default interrupt handler for unused IRQs.
  */
-__attribute__((used)) void HardFault_Handler(void) {
+__attribute__((used)) NORETURN void HardFault_Handler(void) {
     #ifdef ENABLE_MICRO_TRACE_BUFFER
     // Turn off the micro trace buffer so we don't fill it up in the infinite
     // loop below.

--- a/ports/broadcom/common-hal/microcontroller/__init__.c
+++ b/ports/broadcom/common-hal/microcontroller/__init__.c
@@ -11,6 +11,7 @@
 #include "common-hal/microcontroller/__init__.h"
 #include "peripherals/broadcom/defines.h"
 #include "peripherals/broadcom/interrupts.h"
+#include "supervisor/port.h"
 
 #include "mphalport.h"
 
@@ -39,6 +40,7 @@ void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
 }
 
 void common_hal_mcu_reset(void) {
+    reset_cpu();
 }
 
 // The singleton microcontroller.Processor object, bound to microcontroller.cpu

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -572,7 +572,7 @@ void port_idle_until_interrupt(void) {
 /**
  * \brief Default interrupt handler for unused IRQs.
  */
-extern void isr_hardfault(void); // provide a prototype to avoid a missing-prototypes diagnostic
+extern NORETURN void isr_hardfault(void); // provide a prototype to avoid a missing-prototypes diagnostic
 __attribute__((used)) void __not_in_flash_func(isr_hardfault)(void) {
     // Only safe mode from core 0 which is running CircuitPython. Core 1 faulting
     // should not be fatal to CP. (Fingers crossed.)

--- a/shared-bindings/alarm/time/TimeAlarm.c
+++ b/shared-bindings/alarm/time/TimeAlarm.c
@@ -14,7 +14,7 @@
 #include "shared-bindings/time/__init__.h"
 
 #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
+NORETURN mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
     mp_raise_RuntimeError(MP_ERROR_TEXT("RTC is not supported on this board"));
 }
 #endif

--- a/shared-bindings/microcontroller/__init__.h
+++ b/shared-bindings/microcontroller/__init__.h
@@ -20,7 +20,7 @@ extern void common_hal_mcu_disable_interrupts(void);
 extern void common_hal_mcu_enable_interrupts(void);
 
 extern void common_hal_mcu_on_next_reset(mcu_runmode_t runmode);
-extern void common_hal_mcu_reset(void);
+NORETURN extern void common_hal_mcu_reset(void);
 
 extern const mp_obj_dict_t mcu_pin_globals;
 

--- a/shared-bindings/storage/__init__.h
+++ b/shared-bindings/storage/__init__.h
@@ -16,7 +16,7 @@ void common_hal_storage_umount_path(const char *path);
 void common_hal_storage_umount_object(mp_obj_t vfs_obj);
 void common_hal_storage_remount(const char *path, bool readonly, bool disable_concurrent_write_protection);
 mp_obj_t common_hal_storage_getmount(const char *path);
-void common_hal_storage_erase_filesystem(bool extended);
+NORETURN void common_hal_storage_erase_filesystem(bool extended);
 
 bool common_hal_storage_disable_usb_drive(void);
 bool common_hal_storage_enable_usb_drive(void);

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -172,7 +172,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(time_not_implemented_obj, time_not_implemented);
 #endif
 
 #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
+NORETURN mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
     mp_raise_RuntimeError(MP_ERROR_TEXT("RTC is not supported on this board"));
 }
 

--- a/shared-bindings/util.h
+++ b/shared-bindings/util.h
@@ -9,6 +9,6 @@
 #include "py/mpprint.h"
 #include "py/runtime.h"
 
-void raise_deinited_error(void);
+NORETURN void raise_deinited_error(void);
 void properties_print_helper(const mp_print_t *print, mp_obj_t self_in, const mp_arg_t *properties, size_t n_properties);
 void properties_construct_helper(mp_obj_t self_in, const mp_arg_t *args, const mp_arg_val_t *vals, size_t n_properties);


### PR DESCRIPTION
Surprisingly this leads to some code size savings on itsybitsym4, even though LTO optimization should have let the compiler deduce (almost) all of this.

When a compiler knows a call can never return, it is possibly able to avoid emitting code, such as saving caller-saved registers to the stack, or doing _ANYTHING_ affter the function returns, explaining why code size savings is possible with this attribute.

With the exception of raise_deinited_error, these were found by checking the functions found by `-Wmissing-noreturn` and making a case by case decision. However, this dignostic can't be enabled unconditionally as it has false positives, functions we do NOT want to mark as noreturn.

Testing performed: built itsybitsy m4, flash size savings 128 bytes. I didn't test on hardware as none came on this trip with me.