### PR TITLE
rp2pio mov_status_type and mov_status_n

### DIFF
--- a/ports/raspberrypi/bindings/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/bindings/rp2pio/StateMachine.c
@@ -29,8 +29,8 @@
 //| """A type representing one of the strings ``"auto"``, ``"txrx"``, ``"tx"``, or ``"rx"``. These values are supported on both RP2350 and RP2040. For type-checking only, not actually defined in CircuitPython."""
 //| MovStatusType = Literal["txfifo", "rxfifo", "irq"]
 //| """A type representing one of the strings ``"txfifo"``, ``"rxfifo"``, or ``"irq"``. These values are supported on RP2350. For type-checking only, not actually defined in CircuitPython."""
-//| MovStatusType_piov0 = Literal["txfifo"]
-//| """A type representing the string ``"txfifo"``. This value is supported on RP2350 and RP2040. For type-checking only, not actually defined in CircuitPython."""
+//| MovStatusType_piov0 = Literal["txfifo", "rxfifo"]
+//| """A type representing one of the strings ``"txfifo"``, ``"rxfifo"``. These values are supported on RP2350 and RP2040. For type-checking only, not actually defined in CircuitPython."""
 //|
 //|
 //| class StateMachine:

--- a/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
+++ b/ports/raspberrypi/common-hal/rp2pio/StateMachine.c
@@ -465,8 +465,9 @@ bool rp2pio_statemachine_construct(rp2pio_statemachine_obj_t *self,
 
     sm_config_set_fifo_join(&c, join);
 
+    sm_config_set_mov_status(&c, mov_status_type, mov_status_n);
+
     // TODO: these arguments
-    // int mov_status_type, int mov_status_n,
     // int set_count, int out_count
 
     self->sm_config = c;


### PR DESCRIPTION
Looks like this is the last bit needed to actually setup mov_status_type and mov_status_n for a state machine.

I've been successfully using it with Adafruit_CircuitPython_PIO_UART modified to support RTS/CTS hardware flow control.

mov_status_type can also be 'rxfifo' on the RP2040.