### PR TITLE
Add user LED to pins.c

### DIFF
--- a/ports/espressif/boards/seeed_xiao_esp32c6/pins.c
+++ b/ports/espressif/boards/seeed_xiao_esp32c6/pins.c
@@ -48,6 +48,7 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_LP_I2C_SDA), MP_ROM_PTR(&pin_GPIO6) },
 
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO15) },
+    { MP_ROM_QSTR(MP_QSTR_LED_INVERTED), MP_ROM_PTR(&pin_GPIO15) },
 
     { MP_ROM_QSTR(MP_QSTR_MTDO), MP_ROM_PTR(&pin_GPIO7) },
     { MP_ROM_QSTR(MP_QSTR_LP_I2C_SCL), MP_ROM_PTR(&pin_GPIO7) },

--- a/ports/espressif/boards/seeed_xiao_esp32c6/pins.c
+++ b/ports/espressif/boards/seeed_xiao_esp32c6/pins.c
@@ -47,6 +47,8 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_MTCK), MP_ROM_PTR(&pin_GPIO6) },
     { MP_ROM_QSTR(MP_QSTR_LP_I2C_SDA), MP_ROM_PTR(&pin_GPIO6) },
 
+    { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO15) },
+
     { MP_ROM_QSTR(MP_QSTR_MTDO), MP_ROM_PTR(&pin_GPIO7) },
     { MP_ROM_QSTR(MP_QSTR_LP_I2C_SCL), MP_ROM_PTR(&pin_GPIO7) },
 


### PR DESCRIPTION
Seeed Xiao ESP32-C6 has an LED on GPIO15 for general use in user programs. Commonly these LEDs are defined for the board. So would be good to add this LED pin definition. Schematic showing LED connected to GPIO15 (sheet4, zone D2) - https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32C6/XIAO-ESP32-C6_v1.0_SCH_PDF_24028.pdf

