### PR TITLE
Don't NORETURN MP_WEAK functions

### DIFF
--- a/shared-bindings/alarm/time/TimeAlarm.c
+++ b/shared-bindings/alarm/time/TimeAlarm.c
@@ -14,7 +14,7 @@
 #include "shared-bindings/time/__init__.h"
 
 #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-NORETURN mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
+mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
     mp_raise_RuntimeError(MP_ERROR_TEXT("RTC is not supported on this board"));
 }
 #endif

--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -172,7 +172,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(time_not_implemented_obj, time_not_implemented);
 #endif
 
 #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-NORETURN mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
+mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
     mp_raise_RuntimeError(MP_ERROR_TEXT("RTC is not supported on this board"));
 }
 


### PR DESCRIPTION
- Fixes #10274 

As described in #10274, #10260 added `NORETURN` to some `MP_WEAK` functions, which were not always `NORETURN`. Only the `NotImplementedError` versions of these functions were `NORETURN`. This caused crashes.

Note there was already one `MP_WEAK` `NORETURN` functions, `common_hal_socketpool_socketpool_raise_gaierror_noname()`, but it always raises, so it's always `NORETURN`.

Tested with https://github.com/adafruit/circuitpython/pull/10271#issuecomment-2817392221 test script and no longer crashes.
