### PR TITLE
Run background tasks during display refresh

### DIFF
--- a/shared-module/busdisplay/BusDisplay.c
+++ b/shared-module/busdisplay/BusDisplay.c
@@ -296,8 +296,11 @@ static bool _refresh_area(busdisplay_busdisplay_obj_t *self, const displayio_are
         _send_pixels(self, (uint8_t *)buffer, subrectangle_size_bytes);
         displayio_display_bus_end_transaction(&self->bus);
 
-        // TODO(tannewt): Make refresh displays faster so we don't starve other
-        // background tasks.
+        // Run background tasks so they can run during an explicit refresh.
+        // Auto-refresh won't run background tasks here because it is a background task itself.
+        RUN_BACKGROUND_TASKS;
+
+        // Run USB background tasks so they can run during an implicit refresh.
         #if CIRCUITPY_TINYUSB
         usb_background();
         #endif

--- a/shared-module/epaperdisplay/EPaperDisplay.c
+++ b/shared-module/epaperdisplay/EPaperDisplay.c
@@ -360,8 +360,11 @@ static bool epaperdisplay_epaperdisplay_refresh_area(epaperdisplay_epaperdisplay
             self->bus.send(self->bus.bus, DISPLAY_DATA, self->chip_select, (uint8_t *)buffer, subrectangle_size_bytes);
             displayio_display_bus_end_transaction(&self->bus);
 
-            // TODO(tannewt): Make refresh displays faster so we don't starve other
-            // background tasks.
+            // Run background tasks so they can run during an explicit refresh.
+            // Auto-refresh won't run background tasks here because it is a background task itself.
+            RUN_BACKGROUND_TASKS;
+
+            // Run USB background tasks so they can run during an implicit refresh.
             #if CIRCUITPY_TINYUSB
             usb_background();
             #endif

--- a/shared-module/framebufferio/FramebufferDisplay.c
+++ b/shared-module/framebufferio/FramebufferDisplay.c
@@ -200,9 +200,11 @@ static bool _refresh_area(framebufferio_framebufferdisplay_obj_t *self, const di
             dest += rowstride;
             src += rowsize;
         }
+        // Run background tasks so they can run during an explicit refresh.
+        // Auto-refresh won't run background tasks here because it is a background task itself.
+        RUN_BACKGROUND_TASKS;
 
-        // TODO(tannewt): Make refresh displays faster so we don't starve other
-        // background tasks.
+        // Run USB background tasks so they can run during an implicit refresh.
         #if CIRCUITPY_TINYUSB
         usb_background();
         #endif


### PR DESCRIPTION
This allows audio buffers to be filled during display refresh. However, this only works during explicit refreshes though because background tasks cannot be recursive.

Also, on RP2, disable a finished audio DMA so it isn't accidentally triggered and restart the channels if needed.