### PR TITLE
Fix audio DMA buffer allocation on RP2040

### DIFF
--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -227,7 +227,15 @@ audio_dma_result audio_dma_setup_playback(
         max_buffer_length /= dma->sample_spacing;
     }
 
+    #ifdef PICO_RP2350
     dma->buffer[0] = (uint8_t *)port_realloc(dma->buffer[0], max_buffer_length, true);
+    #else
+    dma->buffer[0] = (uint8_t *)m_realloc(dma->buffer[0],
+        #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+        dma->buffer_length[0], // Old size
+        #endif
+        max_buffer_length);
+    #endif
     dma->buffer_length[0] = max_buffer_length;
 
     if (dma->buffer[0] == NULL) {
@@ -235,6 +243,15 @@ audio_dma_result audio_dma_setup_playback(
     }
 
     if (!single_buffer) {
+        #ifdef PICO_RP2350
+        dma->buffer[1] = (uint8_t *)port_realloc(dma->buffer[0], max_buffer_length, true);
+        #else
+        dma->buffer[1] = (uint8_t *)m_realloc(dma->buffer[0],
+            #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+            dma->buffer_length[1], // Old size
+            #endif
+            max_buffer_length);
+        #endif
         dma->buffer[1] = (uint8_t *)port_realloc(dma->buffer[1], max_buffer_length, true);
         dma->buffer_length[1] = max_buffer_length;
 
@@ -429,11 +446,27 @@ void audio_dma_init(audio_dma_t *dma) {
 }
 
 void audio_dma_deinit(audio_dma_t *dma) {
+    #ifdef PICO_RP2350
     port_free(dma->buffer[0]);
+    #else
+    #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+    m_free(dma->buffer[0], dma->buffer_length[0]);
+    #else
+    m_free(dma->buffer[0]);
+    #endif
+    #endif
     dma->buffer[0] = NULL;
     dma->buffer_length[0] = 0;
 
+    #ifdef PICO_RP2350
     port_free(dma->buffer[1]);
+    #else
+    #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+    m_free(dma->buffer[1], dma->buffer_length[1]);
+    #else
+    m_free(dma->buffer[1]);
+    #endif
+    #endif
     dma->buffer[1] = NULL;
     dma->buffer_length[1] = 0;
 }

--- a/ports/raspberrypi/audio_dma.h
+++ b/ports/raspberrypi/audio_dma.h
@@ -20,7 +20,7 @@ typedef enum {
 
 typedef struct {
     mp_obj_t sample;
-    uint8_t *buffer[2]; // Allocated through port_malloc so they are dma-able
+    uint8_t *buffer[2]; // Allocated through port_malloc on RP2350 so they are dma-able
     size_t buffer_length[2];
     uint32_t channels_to_load_mask;
     uint32_t output_register_address;


### PR DESCRIPTION
Recent additions in #10240 throw buffer allocation errors on RP2040 devices. The exact cause is unknown, but is likely "due to the Python VM heap taking up most of the outer heap (allocated via port_malloc using tlsf)." @tannewt

The RP2040 does not support PSRAM, so `port_malloc` should be unnecessary in this case. All relevant code is reverted to the original implementation if compiling for an RP2040-based device.

Tested on a Waveshare RP2040-Zero and Pimoroni Pico Plus 2 with I2S audio output.

Fixes https://github.com/adafruit/circuitpython/issues/10256