### PR TITLE
fixed I2C pins

### DIFF
--- a/ports/raspberrypi/boards/pimoroni_inky_frame_5_7/mpconfigboard.h
+++ b/ports/raspberrypi/boards/pimoroni_inky_frame_5_7/mpconfigboard.h
@@ -14,8 +14,8 @@
 
 #define MICROPY_HW_LED_STATUS   (&pin_GPIO6)
 
-#define DEFAULT_I2C_BUS_SCL (&pin_GPIO4)
-#define DEFAULT_I2C_BUS_SDA (&pin_GPIO5)
+#define DEFAULT_I2C_BUS_SDA (&pin_GPIO4)
+#define DEFAULT_I2C_BUS_SCL (&pin_GPIO5)
 
 #define DEFAULT_UART_BUS_TX (&pin_GPIO0)
 #define DEFAULT_UART_BUS_RX (&pin_GPIO1)

--- a/ports/raspberrypi/boards/pimoroni_inky_frame_7_3/mpconfigboard.h
+++ b/ports/raspberrypi/boards/pimoroni_inky_frame_7_3/mpconfigboard.h
@@ -14,8 +14,8 @@
 
 #define MICROPY_HW_LED_STATUS   (&pin_GPIO6)
 
-#define DEFAULT_I2C_BUS_SCL (&pin_GPIO4)
-#define DEFAULT_I2C_BUS_SDA (&pin_GPIO5)
+#define DEFAULT_I2C_BUS_SDA (&pin_GPIO4)
+#define DEFAULT_I2C_BUS_SCL (&pin_GPIO5)
 
 #define DEFAULT_UART_BUS_TX (&pin_GPIO0)
 #define DEFAULT_UART_BUS_RX (&pin_GPIO1)


### PR DESCRIPTION
Fix pin definitions for these two board. The respective definitions within `pins.c` for `board.SDA` and `board.SCL` are correct btw.
