### PR TITLE
Increase CFG_TUH_ENUMERATION_BUFSIZE so that USB devices with long descriptors are recognized

### DIFF
--- a/supervisor/shared/usb/tusb_config.h
+++ b/supervisor/shared/usb/tusb_config.h
@@ -173,7 +173,7 @@ extern "C" {
 
 // Size of buffer to hold descriptors and other data used for enumeration
 #ifndef CFG_TUH_ENUMERATION_BUFSIZE
-#define CFG_TUH_ENUMERATION_BUFSIZE 256
+#define CFG_TUH_ENUMERATION_BUFSIZE 512
 #endif
 
 #if CIRCUITPY_USB_KEYBOARD_WORKFLOW


### PR DESCRIPTION
Some devices have very long USB configuration descriptors due to the number of interfaces they offer. For instance, enabling the USB CDC data stream on CircuitPython (`usb_cdc.enable(console=True, data=True)`) pushes the descriptor to 284 bytes, which is greater than CircuitPython currently allocates. This change will allow devices with long descriptors to be recognized by the USB host module.

Tested on a Feather RP2040 with USB Type A Host.

The downside is that this uses more memory. It would be nice if this buffer could be dynamically allocated, but TinyUSB doesn't use malloc so I'm not sure how you'd do this.