### PR TITLE
Remove duplicate `port_realloc` call on double-buffered audio dma

### DIFF
--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -256,7 +256,6 @@ audio_dma_result audio_dma_setup_playback(
             #endif
             max_buffer_length);
         #endif
-        dma->buffer[1] = (uint8_t *)port_realloc(dma->buffer[1], max_buffer_length, true);
         dma->buffer_length[1] = max_buffer_length;
 
         if (dma->buffer[1] == NULL) {


### PR DESCRIPTION
Another bug introduced in #10278. Likely didn't incur a noticeable effect on RP2350, but could potentially cause buffer allocation issues on RP2040 devices.