### PR TITLE
Tweak audio playback on RP2

### DIFF
--- a/ports/raspberrypi/audio_dma.h
+++ b/ports/raspberrypi/audio_dma.h
@@ -38,6 +38,7 @@ typedef struct {
     bool unsigned_to_signed;
     bool output_signed;
     bool playing_in_progress;
+    bool paused;
     bool swap_channel;
 } audio_dma_t;
 


### PR DESCRIPTION
This will hopefully make it more reliable. I think the failure to play was due to a latent interrupt from the previously interrupted playback.