### PR TITLE
TilePaletteMapper memory fix

### DIFF
--- a/shared-module/tilepalettemapper/TilePaletteMapper.c
+++ b/shared-module/tilepalettemapper/TilePaletteMapper.c
@@ -18,7 +18,7 @@ void common_hal_tilepalettemapper_tilepalettemapper_construct(tilepalettemapper_
     self->input_color_count = input_color_count;
     self->needs_refresh = false;
     int mappings_len = width * height;
-    self->tile_mappings = (uint32_t **)m_malloc_without_collect(mappings_len * sizeof(uint32_t *));
+    self->tile_mappings = (uint32_t **)m_malloc(mappings_len * sizeof(uint32_t *));
     for (int i = 0; i < mappings_len; i++) {
         self->tile_mappings[i] = (uint32_t *)m_malloc_without_collect(input_color_count * sizeof(uint32_t));
         if (mp_obj_is_type(self->pixel_shader, &displayio_palette_type)) {


### PR DESCRIPTION
resolves: #10305 

I'm not certain if this is the proper fix, but it does seem to successfully make TilePaletteMapper behave as expected. If it would be better to use `m_malloc_helper` or something else I'm happy to change this to whatever is best.

I wouldn't say that I have a complete understanding of the recent memory / GC improvements, but I think that I understand the basic gist of it. My theory is that `self->tile_mappings` was changed to being allocated as "without pointers" but it does actually hold pointers that point to more pointers of u_int32s so it needed to be allocated the opposite way. 