### PR TITLE
Add end() method to MixerVoice to allow samples to finish playing bef…

### DIFF
--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -83,7 +83,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_stop_obj, 1, audiomixer_mixervo
 
 //|     def end(self) -> None:
 //|     """ Sets looping to False if sample is playing, allowing current looped
-//|     sample to finish before looping again  ""
+//|     sample to finish before looping again  """
 //|     ...
 //|
 static mp_obj_t audiomixer_mixervoice_obj_end(mp_obj_t self_in) {

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -86,7 +86,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_stop_obj, 1, audiomixer_mixervo
 //|     sample to finish before looping again  ""
 //|     ...
 //|
-STATIC mp_obj_t audiomixer_mixervoice_obj_end(mp_obj_t self_in) {
+static mp_obj_t audiomixer_mixervoice_obj_end(mp_obj_t self_in) {
     audiomixer_mixervoice_obj_t *self = MP_OBJ_TO_PTR(self_in);
     common_hal_audiomixer_mixervoice_end(self);
     return mp_const_none;

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -81,6 +81,19 @@ static mp_obj_t audiomixer_mixervoice_obj_stop(size_t n_args, const mp_obj_t *po
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_stop_obj, 1, audiomixer_mixervoice_obj_stop);
 
+//|   def end() -> None
+//|     ""
+//|     Sets looping to False if sample is playing, allowing current looped
+//      sample to finish before looping again  ""
+//|
+STATIC mp_obj_t audiomixer_mixervoice_obj_end(mp_obj_t self_in) {
+    audiomixer_mixervoice_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    common_hal_audiomixer_mixervoice_end(self);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(audiomixer_mixervoice_end_obj, audiomixer_mixervoice_obj_end);
+
+
 //|     level: synthio.BlockInput
 //|     """The volume level of a voice, as a floating point number between 0 and 1. If your board
 //|     does not support synthio, this property will only accept a float value.
@@ -140,6 +153,7 @@ static const mp_rom_map_elem_t audiomixer_mixervoice_locals_dict_table[] = {
     // Methods
     { MP_ROM_QSTR(MP_QSTR_play), MP_ROM_PTR(&audiomixer_mixervoice_play_obj) },
     { MP_ROM_QSTR(MP_QSTR_stop), MP_ROM_PTR(&audiomixer_mixervoice_stop_obj) },
+    { MP_ROM_QSTR(MP_QSTR_end), MP_ROM_PTR(&audiomixer_mixervoice_end_obj)
 
     // Properties
     { MP_ROM_QSTR(MP_QSTR_playing), MP_ROM_PTR(&audiomixer_mixervoice_playing_obj) },

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -153,7 +153,7 @@ static const mp_rom_map_elem_t audiomixer_mixervoice_locals_dict_table[] = {
     // Methods
     { MP_ROM_QSTR(MP_QSTR_play), MP_ROM_PTR(&audiomixer_mixervoice_play_obj) },
     { MP_ROM_QSTR(MP_QSTR_stop), MP_ROM_PTR(&audiomixer_mixervoice_stop_obj) },
-    { MP_ROM_QSTR(MP_QSTR_end), MP_ROM_PTR(&audiomixer_mixervoice_end_obj)
+    { MP_ROM_QSTR(MP_QSTR_end), MP_ROM_PTR(&audiomixer_mixervoice_end_obj) },
 
       // Properties
       {

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -155,18 +155,17 @@ static const mp_rom_map_elem_t audiomixer_mixervoice_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_stop), MP_ROM_PTR(&audiomixer_mixervoice_stop_obj) },
     { MP_ROM_QSTR(MP_QSTR_end), MP_ROM_PTR(&audiomixer_mixervoice_end_obj) },
 
-      // Properties
-      {
-          MP_ROM_QSTR(MP_QSTR_playing), MP_ROM_PTR(&audiomixer_mixervoice_playing_obj)
-      },
-      { MP_ROM_QSTR(MP_QSTR_level), MP_ROM_PTR(&audiomixer_mixervoice_level_obj) },
-      { MP_ROM_QSTR(MP_QSTR_loop), MP_ROM_PTR(&audiomixer_mixervoice_loop_obj) }, };
-    static MP_DEFINE_CONST_DICT(audiomixer_mixervoice_locals_dict, audiomixer_mixervoice_locals_dict_table);
+    // Properties
+    { MP_ROM_QSTR(MP_QSTR_playing), MP_ROM_PTR(&audiomixer_mixervoice_playing_obj) },
+    { MP_ROM_QSTR(MP_QSTR_level), MP_ROM_PTR(&audiomixer_mixervoice_level_obj) },
+    { MP_ROM_QSTR(MP_QSTR_loop), MP_ROM_PTR(&audiomixer_mixervoice_loop_obj) },
+};
+static MP_DEFINE_CONST_DICT(audiomixer_mixervoice_locals_dict, audiomixer_mixervoice_locals_dict_table);
 
-    MP_DEFINE_CONST_OBJ_TYPE(
-        audiomixer_mixervoice_type,
-        MP_QSTR_MixerVoice,
-        MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
-        make_new, audiomixer_mixervoice_make_new,
-        locals_dict, &audiomixer_mixervoice_locals_dict
-        );
+MP_DEFINE_CONST_OBJ_TYPE(
+    audiomixer_mixervoice_type,
+    MP_QSTR_MixerVoice,
+    MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
+    make_new, audiomixer_mixervoice_make_new,
+    locals_dict, &audiomixer_mixervoice_locals_dict
+    );

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -81,10 +81,10 @@ static mp_obj_t audiomixer_mixervoice_obj_stop(size_t n_args, const mp_obj_t *po
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_stop_obj, 1, audiomixer_mixervoice_obj_stop);
 
-//|   def end() -> None
-//|     ""
-//|     Sets looping to False if sample is playing, allowing current looped
-//      sample to finish before looping again  ""
+//|     def end() -> None:
+//|     "" Sets looping to False if sample is playing, allowing current looped
+//|     sample to finish before looping again  ""
+//|     ...
 //|
 STATIC mp_obj_t audiomixer_mixervoice_obj_end(mp_obj_t self_in) {
     audiomixer_mixervoice_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -155,17 +155,18 @@ static const mp_rom_map_elem_t audiomixer_mixervoice_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_stop), MP_ROM_PTR(&audiomixer_mixervoice_stop_obj) },
     { MP_ROM_QSTR(MP_QSTR_end), MP_ROM_PTR(&audiomixer_mixervoice_end_obj)
 
-    // Properties
-    { MP_ROM_QSTR(MP_QSTR_playing), MP_ROM_PTR(&audiomixer_mixervoice_playing_obj) },
-    { MP_ROM_QSTR(MP_QSTR_level), MP_ROM_PTR(&audiomixer_mixervoice_level_obj) },
-    { MP_ROM_QSTR(MP_QSTR_loop), MP_ROM_PTR(&audiomixer_mixervoice_loop_obj) },
-};
-static MP_DEFINE_CONST_DICT(audiomixer_mixervoice_locals_dict, audiomixer_mixervoice_locals_dict_table);
+      // Properties
+      {
+          MP_ROM_QSTR(MP_QSTR_playing), MP_ROM_PTR(&audiomixer_mixervoice_playing_obj)
+      },
+      { MP_ROM_QSTR(MP_QSTR_level), MP_ROM_PTR(&audiomixer_mixervoice_level_obj) },
+      { MP_ROM_QSTR(MP_QSTR_loop), MP_ROM_PTR(&audiomixer_mixervoice_loop_obj) }, };
+    static MP_DEFINE_CONST_DICT(audiomixer_mixervoice_locals_dict, audiomixer_mixervoice_locals_dict_table);
 
-MP_DEFINE_CONST_OBJ_TYPE(
-    audiomixer_mixervoice_type,
-    MP_QSTR_MixerVoice,
-    MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
-    make_new, audiomixer_mixervoice_make_new,
-    locals_dict, &audiomixer_mixervoice_locals_dict
-    );
+    MP_DEFINE_CONST_OBJ_TYPE(
+        audiomixer_mixervoice_type,
+        MP_QSTR_MixerVoice,
+        MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
+        make_new, audiomixer_mixervoice_make_new,
+        locals_dict, &audiomixer_mixervoice_locals_dict
+        );

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -82,9 +82,9 @@ static mp_obj_t audiomixer_mixervoice_obj_stop(size_t n_args, const mp_obj_t *po
 MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_stop_obj, 1, audiomixer_mixervoice_obj_stop);
 
 //|     def end(self) -> None:
-//|     """ Sets looping to False if sample is playing, allowing current looped
-//|     sample to finish before looping again  """
-//|     ...
+//|         """ Sets looping to False if sample is playing. This allows the looped
+//|         sample to complete its current playback and end further looping  """
+//|         ...
 //|
 static mp_obj_t audiomixer_mixervoice_obj_end(mp_obj_t self_in) {
     audiomixer_mixervoice_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -82,7 +82,7 @@ static mp_obj_t audiomixer_mixervoice_obj_stop(size_t n_args, const mp_obj_t *po
 MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_stop_obj, 1, audiomixer_mixervoice_obj_stop);
 
 //|     def end(self) -> None:
-//|     "" Sets looping to False if sample is playing, allowing current looped
+//|     """ Sets looping to False if sample is playing, allowing current looped
 //|     sample to finish before looping again  ""
 //|     ...
 //|

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -81,7 +81,7 @@ static mp_obj_t audiomixer_mixervoice_obj_stop(size_t n_args, const mp_obj_t *po
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixervoice_stop_obj, 1, audiomixer_mixervoice_obj_stop);
 
-//|     def end() -> None:
+//|     def end(self) -> None:
 //|     "" Sets looping to False if sample is playing, allowing current looped
 //|     sample to finish before looping again  ""
 //|     ...

--- a/shared-bindings/audiomixer/MixerVoice.h
+++ b/shared-bindings/audiomixer/MixerVoice.h
@@ -15,6 +15,7 @@ void common_hal_audiomixer_mixervoice_construct(audiomixer_mixervoice_obj_t *sel
 void common_hal_audiomixer_mixervoice_set_parent(audiomixer_mixervoice_obj_t *self, audiomixer_mixer_obj_t *parent);
 void common_hal_audiomixer_mixervoice_play(audiomixer_mixervoice_obj_t *self, mp_obj_t sample, bool loop);
 void common_hal_audiomixer_mixervoice_stop(audiomixer_mixervoice_obj_t *self);
+void common_hal_audiomixer_mixervoice_end(audiomixer_mixervoice_obj_t *self);
 mp_obj_t common_hal_audiomixer_mixervoice_get_level(audiomixer_mixervoice_obj_t *self);
 void common_hal_audiomixer_mixervoice_set_level(audiomixer_mixervoice_obj_t *self, mp_obj_t gain);
 

--- a/shared-module/audiomixer/MixerVoice.c
+++ b/shared-module/audiomixer/MixerVoice.c
@@ -67,3 +67,9 @@ bool common_hal_audiomixer_mixervoice_get_playing(audiomixer_mixervoice_obj_t *s
 void common_hal_audiomixer_mixervoice_stop(audiomixer_mixervoice_obj_t *self) {
     self->sample = NULL;
 }
+
+void common_hal_audiomixer_mixervoice_end(audiomixer_mixervoice_obj_t *self) {
+    if (self->sample != NULL) {
+        self->loop = false;
+    }
+}


### PR DESCRIPTION
Added an `end` method to the MixerVoice class within the auidomixer library.

Calling this method will set the object's `loop` flag to `False`. This is different than the `stop` method, which ends the sample immediately, and instead allows any looping sample to play thorugh its entirety before ending. 

This feature was added to fix a problem where samples ended via `stop` created a loud clicking sound from the connected speaker. By allowing the samples to play out fully, the clicking does not exist. 

I have tested this on multiple looping audio samples. 
