### PR TITLE
Improve resolution of mp_hal_delay_ms() to subticks.

### DIFF
--- a/ports/broadcom/supervisor/port.c
+++ b/ports/broadcom/supervisor/port.c
@@ -143,7 +143,11 @@ uint64_t port_get_raw_ticks(uint8_t *subticks) {
     }
     COMPLETE_MEMORY_READS;
     uint64_t microseconds = hi << 32 | lo;
-    return 1024 * (microseconds / 1000000) + (microseconds % 1000000) / 977;
+    int64_t all_subticks = microseconds * 512 / 15625;
+    if (subticks != NULL) {
+        *subticks = all_subticks % 32;
+    }
+    return all_subticks / 32;
 }
 
 void TIMER_1_IRQHandler(void) {

--- a/ports/cxd56/supervisor/port.c
+++ b/ports/cxd56/supervisor/port.c
@@ -124,7 +124,9 @@ void board_timerhook(void) {
 
 uint64_t port_get_raw_ticks(uint8_t *subticks) {
     uint64_t count = cxd56_rtc_count();
-    *subticks = count % 32;
+    if (subticks != NULL) {
+        *subticks = count % 32;
+    }
 
     return count / 32;
 }

--- a/ports/litex/supervisor/port.c
+++ b/ports/litex/supervisor/port.c
@@ -114,6 +114,9 @@ uint64_t port_get_raw_ticks(uint8_t *subticks) {
     common_hal_mcu_disable_interrupts();
     uint64_t raw_tick_snapshot = raw_ticks;
     common_hal_mcu_enable_interrupts();
+    if (subticks != NULL) {
+        *subticks = 0;
+    }
     return raw_tick_snapshot;
 }
 

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -491,11 +491,11 @@ static volatile bool ticks_enabled;
 static volatile bool _woken_up;
 
 uint64_t port_get_raw_ticks(uint8_t *subticks) {
-    uint64_t microseconds = time_us_64();
+    int64_t all_subticks = time_us_64() * 512 / 15625;
     if (subticks != NULL) {
-        *subticks = (uint8_t)(((microseconds % 1000000) % 977) / 31);
+        *subticks = all_subticks % 32;
     }
-    return 1024 * (microseconds / 1000000) + (microseconds % 1000000) / 977;
+    return all_subticks / 32;
 }
 
 static void _tick_callback(uint alarm_num) {

--- a/supervisor/shared/tick.h
+++ b/supervisor/shared/tick.h
@@ -33,6 +33,13 @@ extern uint32_t supervisor_ticks_ms32(void);
  */
 extern uint64_t supervisor_ticks_ms64(void);
 
+/** @brief Get 64-bit current time in subticks
+ *
+ * Time is returned as a 64-bit count of subticks where each subtick is 1/32768
+ * of a second.
+ */
+extern uint64_t supervisor_get_raw_subticks(void);
+
 extern void supervisor_enable_tick(void);
 extern void supervisor_disable_tick(void);
 


### PR DESCRIPTION
Improves resolution of mp_hal_delay_ms() from ticks (1/1024 sec.) to subticks (1/32768). This PR also corrects port_get_raw_ticks() for these ports:

- broadcom: Adds calculation and return of subticks. Adopts calculation used for Espressif port.
- cxd56: Returns subticks only when pointer parameter is non-null.
- litex: Return zero for subticks when parameter is non-null. This port does not resolve time below integral ticks.
- raspberrypi: Correct tick/subtick calculation. Adopts calculation used for Espressif port.