### PR TITLE
implement spectra6 support

### DIFF
--- a/ports/atmel-samd/boards/openbook_m4/board.c
+++ b/ports/atmel-samd/boards/openbook_m4/board.c
@@ -85,6 +85,7 @@ void board_init(void) {
         false, // chip_select (don't always toggle chip select)
         false, // grayscale
         false, // acep
+        false, // spectra6
         false, // two_byte_sequence_length
         false); // address_little_endian
 }

--- a/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
+++ b/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
@@ -141,6 +141,7 @@ void board_init(void) {
         false,  // always_toggle_chip_select
         true, // grayscale
         false, // acep
+        false, // spectra6
         false,  // two_byte_sequence_length
         false); // address_little_endian
 }

--- a/ports/espressif/boards/elecrow_crowpanel_4_2_epaper/board.c
+++ b/ports/espressif/boards/elecrow_crowpanel_4_2_epaper/board.c
@@ -96,6 +96,7 @@ void board_init(void) {
         false, // always_toggle_chip_select
         false, // grayscale
         false, // acep
+        false, // spectra6
         false, // two_byte_sequence_length
         false); // address_little_endian
 }

--- a/ports/espressif/boards/heltec_vision_master_e290/board.c
+++ b/ports/espressif/boards/heltec_vision_master_e290/board.c
@@ -94,6 +94,7 @@ void board_init(void) {
         false, // always_toggle_chip_select
         false, // grayscale
         false, // acep
+        false, // spectra6
         false, // two_byte_sequence_length
         true); // address_little_endian
 }

--- a/ports/espressif/boards/heltec_wireless_paper/board.c
+++ b/ports/espressif/boards/heltec_wireless_paper/board.c
@@ -134,6 +134,7 @@ void board_init(void) {
         false, // always_toggle_chip_select
         false, // grayscale
         false, // acep
+        false, // spectra6
         false, // two_byte_sequence_length
         false); // address_little_endian
 }

--- a/ports/espressif/boards/m5stack_m5paper/board.c
+++ b/ports/espressif/boards/m5stack_m5paper/board.c
@@ -74,6 +74,7 @@ void board_init(void) {
     //     false,  // always_toggle_chip_select
     //     false, // grayscale
     //     true, // acep
+    //     false, // spectra6
     //     false,  // two_byte_sequence_length
     //     false  // address_little_endian
     // );

--- a/ports/espressif/boards/sqfmi_watchy/board.c
+++ b/ports/espressif/boards/sqfmi_watchy/board.c
@@ -190,6 +190,7 @@ void board_init(void) {
         false,  // always_toggle_chip_select
         false, // grayscale
         false, // acep
+        false, // spectra6
         false,  // two_byte_sequence_length
         true // address_little_endian
         );

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/board.c
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/board.c
@@ -281,6 +281,7 @@ void board_init(void) {
             true,                                                                                           // always_toggle_chip_select
             false,                                                                                          // not grayscale
             false,                                                                                          // not acep
+            false,                                                                                          // not spectra6
             false,                                                                                          // not two_byte_sequence_length
             true);                                                                                          // address_little_endian
     } else if (vid_setting == 2) {  // Explorer SSD1608 BW
@@ -314,6 +315,7 @@ void board_init(void) {
             true,                                                                                           // always_toggle_chip_select
             false,                                                                                          // not grayscale
             false,                                                                                          // not acep
+            false,                                                                                          // not spectra6
             false,                                                                                          // not two_byte_sequence_length
             true);                                                                                          // address_little_endian
     } else {

--- a/ports/raspberrypi/boards/pimoroni_badger2040/board.c
+++ b/ports/raspberrypi/boards/pimoroni_badger2040/board.c
@@ -303,6 +303,7 @@ void board_init(void) {
         false,  // always_toggle_chip_select
         false, // grayscale
         false, // acep
+        false, // spectra6
         false,  // two_byte_sequence_length
         false); // address_little_endian
 }

--- a/ports/raspberrypi/boards/pimoroni_badger2040w/board.c
+++ b/ports/raspberrypi/boards/pimoroni_badger2040w/board.c
@@ -303,6 +303,7 @@ void board_init(void) {
         false,  // always_toggle_chip_select
         false, // grayscale
         false, // acep
+        false, // spectra6
         false,  // two_byte_sequence_length
         false); // address_little_endian
 }

--- a/ports/raspberrypi/boards/pimoroni_inky_frame_5_7/board.c
+++ b/ports/raspberrypi/boards/pimoroni_inky_frame_5_7/board.c
@@ -97,6 +97,7 @@ void board_init(void) {
         false,  // always_toggle_chip_select
         false, // grayscale
         true, // acep
+        false, // spectra6
         false,  // two_byte_sequence_length
         false); // address_little_endian
 }

--- a/ports/raspberrypi/boards/pimoroni_inky_frame_7_3/board.c
+++ b/ports/raspberrypi/boards/pimoroni_inky_frame_7_3/board.c
@@ -156,6 +156,7 @@ void board_init(void) {
         false,  // always_toggle_chip_select
         false, // grayscale
         true, // acep
+        false, // spectra6
         false,  // two_byte_sequence_length
         false); // address_little_endian
 }

--- a/shared-bindings/epaperdisplay/EPaperDisplay.c
+++ b/shared-bindings/epaperdisplay/EPaperDisplay.c
@@ -62,6 +62,7 @@
 //|         always_toggle_chip_select: bool = False,
 //|         grayscale: bool = False,
 //|         advanced_color_epaper: bool = False,
+//|         spectra6: bool = False,
 //|         two_byte_sequence_length: bool = False,
 //|         start_up_time: float = 0,
 //|         address_little_endian: bool = False,
@@ -104,6 +105,7 @@
 //|         :param bool always_toggle_chip_select: When True, chip select is toggled every byte
 //|         :param bool grayscale: When true, the color ram is the low bit of 2-bit grayscale
 //|         :param bool advanced_color_epaper: When true, the display is a 7-color advanced color epaper (ACeP)
+//|         :param bool spectra6: When true, the display is a 6-color spectra6 epaper
 //|         :param bool two_byte_sequence_length: When true, use two bytes to define sequence length
 //|         :param float start_up_time: Time to wait after reset before sending commands
 //|         :param bool address_little_endian: Send the least significant byte (not bit) of multi-byte addresses first. Ignored when ram is addressed with one byte
@@ -117,7 +119,7 @@ static mp_obj_t epaperdisplay_epaperdisplay_make_new(const mp_obj_type_t *type, 
            ARG_set_current_row_command, ARG_write_black_ram_command, ARG_black_bits_inverted,
            ARG_write_color_ram_command, ARG_color_bits_inverted, ARG_highlight_color,
            ARG_refresh_display_command,  ARG_refresh_time, ARG_busy_pin, ARG_busy_state,
-           ARG_seconds_per_frame, ARG_always_toggle_chip_select, ARG_grayscale, ARG_advanced_color_epaper,
+           ARG_seconds_per_frame, ARG_always_toggle_chip_select, ARG_grayscale, ARG_advanced_color_epaper, ARG_spectra6,
            ARG_two_byte_sequence_length, ARG_start_up_time, ARG_address_little_endian };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_display_bus, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -147,6 +149,7 @@ static mp_obj_t epaperdisplay_epaperdisplay_make_new(const mp_obj_type_t *type, 
         { MP_QSTR_always_toggle_chip_select, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
         { MP_QSTR_grayscale, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
         { MP_QSTR_advanced_color_epaper, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
+        { MP_QSTR_spectra6, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
         { MP_QSTR_two_byte_sequence_length, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
         { MP_QSTR_start_up_time, MP_ARG_OBJ | MP_ARG_KW_ONLY, {.u_obj = MP_OBJ_NEW_SMALL_INT(0)} },
         { MP_QSTR_address_little_endian, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },
@@ -215,7 +218,7 @@ static mp_obj_t epaperdisplay_epaperdisplay_make_new(const mp_obj_type_t *type, 
         args[ARG_write_black_ram_command].u_int, args[ARG_black_bits_inverted].u_bool, write_color_ram_command,
         args[ARG_color_bits_inverted].u_bool, highlight_color, refresh_buf, refresh_buf_len, refresh_time,
         busy_pin, args[ARG_busy_state].u_bool, seconds_per_frame,
-        args[ARG_always_toggle_chip_select].u_bool, args[ARG_grayscale].u_bool, args[ARG_advanced_color_epaper].u_bool,
+        args[ARG_always_toggle_chip_select].u_bool, args[ARG_grayscale].u_bool, args[ARG_advanced_color_epaper].u_bool,args[ARG_spectra6].u_bool,
         two_byte_sequence_length, args[ARG_address_little_endian].u_bool
         );
 

--- a/shared-bindings/epaperdisplay/EPaperDisplay.c
+++ b/shared-bindings/epaperdisplay/EPaperDisplay.c
@@ -218,7 +218,7 @@ static mp_obj_t epaperdisplay_epaperdisplay_make_new(const mp_obj_type_t *type, 
         args[ARG_write_black_ram_command].u_int, args[ARG_black_bits_inverted].u_bool, write_color_ram_command,
         args[ARG_color_bits_inverted].u_bool, highlight_color, refresh_buf, refresh_buf_len, refresh_time,
         busy_pin, args[ARG_busy_state].u_bool, seconds_per_frame,
-        args[ARG_always_toggle_chip_select].u_bool, args[ARG_grayscale].u_bool, args[ARG_advanced_color_epaper].u_bool,args[ARG_spectra6].u_bool,
+        args[ARG_always_toggle_chip_select].u_bool, args[ARG_grayscale].u_bool, args[ARG_advanced_color_epaper].u_bool, args[ARG_spectra6].u_bool,
         two_byte_sequence_length, args[ARG_address_little_endian].u_bool
         );
 

--- a/shared-bindings/epaperdisplay/EPaperDisplay.h
+++ b/shared-bindings/epaperdisplay/EPaperDisplay.h
@@ -26,7 +26,7 @@ void common_hal_epaperdisplay_epaperdisplay_construct(epaperdisplay_epaperdispla
     uint16_t write_color_ram_command, bool color_bits_inverted, uint32_t highlight_color,
     const uint8_t *refresh_sequence, uint16_t refresh_sequence_len, mp_float_t refresh_time,
     const mcu_pin_obj_t *busy_pin, bool busy_state, mp_float_t seconds_per_frame,
-    bool always_toggle_chip_select, bool grayscale, bool acep, bool two_byte_sequence_length,
+    bool always_toggle_chip_select, bool grayscale, bool acep, bool spectra6, bool two_byte_sequence_length,
     bool address_little_endian);
 
 bool common_hal_epaperdisplay_epaperdisplay_refresh(epaperdisplay_epaperdisplay_obj_t *self);

--- a/shared-module/displayio/ColorConverter.c
+++ b/shared-module/displayio/ColorConverter.c
@@ -91,6 +91,40 @@ uint8_t displayio_colorconverter_compute_hue(uint32_t color_rgb888) {
     return hue;
 }
 
+uint8_t displayio_colorconverter_compute_sixcolor(uint32_t color_rgb888) {
+    // This is DDX=1, the default for the displays.
+    uint8_t chroma = displayio_colorconverter_compute_chroma(color_rgb888);
+    if (chroma >= 64) {
+        uint8_t hue = displayio_colorconverter_compute_hue(color_rgb888);
+        // Red 0
+        if (hue < 10) {
+            return 0x3;
+        }
+        // Yellow 42
+        if (hue < 42 + 21) {
+            return 0x2;
+        }
+        // Green 85
+        if (hue < 85 + 42) {
+            return 0x6;
+        }
+        // Blue 170
+        if (hue < 170 + 42) {
+            return 0x5;
+        }
+
+        // The rest is red to 255
+        return 0x3;
+    } else {
+        uint8_t luma = displayio_colorconverter_compute_luma(color_rgb888);
+        if (luma >= 128) {
+            return 0x1; // White
+        } else {
+            return 0x0; // Black
+        }
+    }
+}
+
 uint8_t displayio_colorconverter_compute_sevencolor(uint32_t color_rgb888) {
     // This is DDX=1, the default for the displays.
     uint8_t chroma = displayio_colorconverter_compute_chroma(color_rgb888);
@@ -309,7 +343,9 @@ void displayio_convert_color(const _displayio_colorspace_t *colorspace, bool dit
         return;
     } else if (colorspace->depth == 4) {
         uint8_t packed;
-        if (colorspace->sevencolor) {
+        if (colorspace->sixcolor) {
+            packed = displayio_colorconverter_compute_sixcolor(pixel);
+        } else if (colorspace->sevencolor) {
             packed = displayio_colorconverter_compute_sevencolor(pixel);
         } else {
             packed = displayio_colorconverter_compute_rgbd(pixel);

--- a/shared-module/displayio/ColorConverter.h
+++ b/shared-module/displayio/ColorConverter.h
@@ -41,5 +41,6 @@ uint8_t displayio_colorconverter_compute_rgbd(uint32_t color_rgb888);
 uint8_t displayio_colorconverter_compute_luma(uint32_t color_rgb888);
 uint8_t displayio_colorconverter_compute_chroma(uint32_t color_rgb888);
 uint8_t displayio_colorconverter_compute_hue(uint32_t color_rgb888);
+uint8_t displayio_colorconverter_compute_sixcolor(uint32_t color_rgb888);
 uint8_t displayio_colorconverter_compute_sevencolor(uint32_t color_rgb888);
 void displayio_colorconverter_compute_tricolor(const _displayio_colorspace_t *colorspace, uint8_t pixel_hue, uint32_t *color);

--- a/shared-module/displayio/Palette.h
+++ b/shared-module/displayio/Palette.h
@@ -19,6 +19,7 @@ typedef struct {
     uint8_t grayscale_bit; // The lowest grayscale bit. Normally 8 - depth.
     bool grayscale;
     bool tricolor;
+    bool sixcolor; // Spectra6 e-ink screens.
     bool sevencolor; // Acep e-ink screens.
     bool pixels_in_byte_share_row;
     bool reverse_pixels_in_byte;

--- a/shared-module/epaperdisplay/EPaperDisplay.c
+++ b/shared-module/epaperdisplay/EPaperDisplay.c
@@ -36,7 +36,7 @@ void common_hal_epaperdisplay_epaperdisplay_construct(epaperdisplay_epaperdispla
     uint16_t write_color_ram_command, bool color_bits_inverted, uint32_t highlight_color,
     const uint8_t *refresh_sequence, uint16_t refresh_sequence_len, mp_float_t refresh_time,
     const mcu_pin_obj_t *busy_pin, bool busy_state, mp_float_t seconds_per_frame,
-    bool chip_select, bool grayscale, bool acep, bool two_byte_sequence_length, bool address_little_endian) {
+    bool chip_select, bool grayscale, bool acep, bool spectra6, bool two_byte_sequence_length, bool address_little_endian) {
     uint16_t color_depth = 1;
     bool core_grayscale = true;
     if (highlight_color != 0x000000) {
@@ -46,9 +46,10 @@ void common_hal_epaperdisplay_epaperdisplay_construct(epaperdisplay_epaperdispla
     } else {
         self->core.colorspace.tricolor = false;
     }
-    self->acep = acep;
+    self->acep = acep || spectra6;
+    self->core.colorspace.sixcolor = spectra6;
     self->core.colorspace.sevencolor = acep;
-    if (acep) {
+    if (self->acep) {
         color_depth = 4; // bits. 7 colors + clean
         grayscale = false;
         core_grayscale = false;
@@ -338,7 +339,7 @@ static bool epaperdisplay_epaperdisplay_refresh_area(epaperdisplay_epaperdisplay
                 } else if (self->core.colorspace.tricolor) {
                     self->core.colorspace.grayscale = false;
                     displayio_display_core_fill_area(&self->core, &subrectangle, mask, buffer);
-                } else if (self->core.colorspace.sevencolor) {
+                } else if (self->core.colorspace.sixcolor || self->core.colorspace.sevencolor) {
                     displayio_display_core_fill_area(&self->core, &subrectangle, mask, buffer);
                 }
             } else {


### PR DESCRIPTION
This PR adds support for the new generation of six-color e-ink displays ("Spectra6").

Tested with a Pico2W and the [Pimoroni InkyImpression 7.3 (2025)](https://shop.pimoroni.com/products/inky-impression-7-3?variant=55186435244411). I will publish the actual driver once the six-color support is merged into CP.
