### PR TITLE
Fix imx microcontroller.pin

### DIFF
--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1011/pin_names.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1011/pin_names.h
@@ -6,8 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-#pragma once
-
+// OK to include more than once because FORMAT_PIN may be different.
 
 // define FORMAT_PIN(pin_name) and then include this file.
 

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1015/pin_names.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1015/pin_names.h
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-#pragma once
+// OK to include more than once because FORMAT_PIN may be different.
 
 
 // define FORMAT_PIN(pin_name) and then include this file.

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1021/pin_names.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1021/pin_names.h
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-#pragma once
+// OK to include more than once because FORMAT_PIN may be different.
 
 
 // define FORMAT_PIN(pin_name) and then include this file.

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1042/pin_names.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1042/pin_names.h
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-#pragma once
+// OK to include more than once because FORMAT_PIN may be different.
 
 
 // define FORMAT_PIN(pin_name) and then include this file.

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1052/pin_names.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1052/pin_names.h
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-#pragma once
+// OK to include more than once because FORMAT_PIN may be different.
 
 
 // define FORMAT_PIN(pin_name) and then include this file.

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1062/pin_names.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1062/pin_names.h
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-#pragma once
+// OK to include more than once because FORMAT_PIN may be different.
 
 
 // define FORMAT_PIN(pin_name) and then include this file.

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1176/pin_names.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/MIMXRT1176/pin_names.h
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-#pragma once
+// OK to include more than once because FORMAT_PIN may be different.
 
 
 // define FORMAT_PIN(pin_name) and then include this file.

--- a/ports/mimxrt10xx/peripherals/mimxrt10xx/pin_names.h
+++ b/ports/mimxrt10xx/peripherals/mimxrt10xx/pin_names.h
@@ -5,8 +5,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-#pragma once
-
 // OK to include more than once because FORMAT_PIN may be different.
 
 #ifdef MIMXRT1011_SERIES


### PR DESCRIPTION
We need to be able to include pin_names.h more than once for it to work.

Broken by #9260. Fixes #9957