### PR TITLE
Add missing linker fragment `esp32c3.rom.eco3_bt_funcs.ld`

### DIFF
--- a/ports/espressif/Makefile
+++ b/ports/espressif/Makefile
@@ -265,6 +265,7 @@ else ifeq ($(IDF_TARGET),esp32c3)
 LDFLAGS += \
 	-Tesp32c3.rom.newlib.ld \
 	-Tesp32c3.rom.version.ld \
+	-Tesp32c3.rom.eco3_bt_funcs.ld \
 	-Tesp32c3.rom.eco3.ld \
 	-Tesp32c3.rom.bt_funcs.ld
 


### PR DESCRIPTION
Add missing linker fragment `esp32c3.rom.eco3_bt_funcs.ld` to resolve early crashes and boot loops on boards with ESP32-C3.

Resolves issues #10016 and #10002.

Tested on espressif_esp32c3_devkitm_1_n4 with:
```
CIRCUITPY_LEGACY_4MB_FLASH_LAYOUT = 0
CIRCUITPY_BLEIO_NATIVE =1
```

Also tested with `DEBUG=1`.
