### PR TITLE
Fix latex docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,9 @@ epub:
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
 latex:
+	$(PYTHON) docs/prepare_readme_for_latex.py
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	mv README.rst.bak README.rst
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
@@ -164,14 +166,18 @@ latex:
 
 # seems to be malfunctioning
 latexpdf:
+	$(PYTHON) docs/prepare_readme_for_latex.py
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	mv README.rst.bak README.rst
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 # seems to be malfunctioning
 latexpdfja:
+	$(PYTHON) docs/prepare_readme_for_latex.py
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	mv README.rst.bak README.rst
 	@echo "Running LaTeX files through platex and dvipdfmx..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."

--- a/docs/prepare_readme_for_latex.py
+++ b/docs/prepare_readme_for_latex.py
@@ -1,0 +1,18 @@
+import shutil
+
+with open("README.rst", "r") as f:
+    readme_content = f.read()
+
+shutil.copyfile("README.rst", "README.rst.bak")
+
+# turn badge into text only
+modified_readme_content = readme_content.replace("|Weblate|", "Weblate", 1)
+
+# remove image link
+badge_link_lines = """.. |Weblate| image:: https://hosted.weblate.org/widgets/circuitpython/-/svg-badge.svg
+   :target: https://hosted.weblate.org/engage/circuitpython/?utm_source=widget"""
+
+modified_readme_content = modified_readme_content.replace(badge_link_lines, "")
+
+with open("README.rst", "w") as f:
+    f.write(modified_readme_content)


### PR DESCRIPTION
Resolves: #10314 

Temporarily remove the weblate badge from the readme file before building latex versions of docs and replace the original readme afterward.

I've made this against main, I'm not sure if it needs to be made for `9.2.x`, maybe not if the PDF gets created at release time and then cached somewhere. I'm not certain where all this PDF ends up or when the published ones gets generated. If it gets regenerated in-between releases then we may want to have the same fix for `9.2.x` though.