### PR TITLE
show 4 spaces in place of tab in Terminal

### DIFF
--- a/shared-module/terminalio/Terminal.c
+++ b/shared-module/terminalio/Terminal.c
@@ -226,7 +226,11 @@ size_t common_hal_terminalio_terminal_write(terminalio_terminal_obj_t *self, con
         if (c < 0x20) {
             if (c == '\r') {
                 self->cursor_x = 0;
-            } else if (c == '\n') {
+            } else if (c == '\t'){
+              for (uint8_t space_i = 0; space_i < 4; space_i++){
+                terminalio_terminal_set_tile(self, false, ' ', true);
+              }
+            }else if (c == '\n') {
                 self->cursor_y++;
                 // Commands below are used by MicroPython in the REPL
             } else if (c == '\b') {

--- a/shared-module/terminalio/Terminal.c
+++ b/shared-module/terminalio/Terminal.c
@@ -226,11 +226,11 @@ size_t common_hal_terminalio_terminal_write(terminalio_terminal_obj_t *self, con
         if (c < 0x20) {
             if (c == '\r') {
                 self->cursor_x = 0;
-            } else if (c == '\t'){
-              for (uint8_t space_i = 0; space_i < 4; space_i++){
-                terminalio_terminal_set_tile(self, false, ' ', true);
-              }
-            }else if (c == '\n') {
+            } else if (c == '\t') {
+                for (uint8_t space_i = 0; space_i < 4; space_i++) {
+                    terminalio_terminal_set_tile(self, false, ' ', true);
+                }
+            } else if (c == '\n') {
                 self->cursor_y++;
                 // Commands below are used by MicroPython in the REPL
             } else if (c == '\b') {


### PR DESCRIPTION
Resolves: #10319 

We could maybe use `->  ` if we wanted to try to mimic the little arrows that some IDEs use to show tabs. 

I have only done very basic testing with the REPL reproducer from the issue so far.

With this change: 
![image](https://github.com/user-attachments/assets/230151d2-1aa0-4e15-84ce-1848ca27d89d)

without this change:
![image](https://github.com/user-attachments/assets/bf357510-fd24-4847-a34c-8409b16db2a7)

It still differs visually from my tio showing the serial console, in my local terminal at least. It seems  mine is replacing tabs with 8 spaces perhaps. I don't necessarily think that difference is meaningful though. 