### PR TITLE
Fix Intermittent ESP32 Crashes by Wrapping `longjmp`

### DIFF
--- a/ports/espressif/Makefile
+++ b/ports/espressif/Makefile
@@ -202,21 +202,24 @@ else
 endif
 
 ifeq ($(IDF_TARGET_ARCH),xtensa)
-# Remove the last two flags once TinyUSB is updated with the `#include <xtensa_api.h>` instead of
-# `#include "xtensa/xtensa_api.h"`.
+	# Remove the last two flags once TinyUSB is updated with the `#include <xtensa_api.h>` instead of
+	# `#include "xtensa/xtensa_api.h"`.
 
-CFLAGS += -mlongcalls -isystem esp-idf/components/xtensa/deprecated_include/ -Wno-error=cpp
+	CFLAGS += -mlongcalls -isystem esp-idf/components/xtensa/deprecated_include/ -Wno-error=cpp
+
+	# Wrap longjmp with a patched version that protects register window update with a critical section
+	LDFLAGS += -Wl,--wrap=longjmp
 else ifeq ($(IDF_TARGET_ARCH),riscv)
 
-ifeq ($(IDF_TARGET),esp32p4)
-CFLAGS += -march=rv32imafc_zicsr_zifencei_xesppie -mabi=ilp32f
-else
-CFLAGS += -march=rv32imac_zicsr_zifencei
-endif
+	ifeq ($(IDF_TARGET),esp32p4)
+		CFLAGS += -march=rv32imafc_zicsr_zifencei_xesppie -mabi=ilp32f
+	else
+		CFLAGS += -march=rv32imac_zicsr_zifencei
+	endif
 
-LDFLAGS += \
-	-Lesp-idf/components/riscv/ld \
-	-Trom.api.ld
+	LDFLAGS += \
+		-Lesp-idf/components/riscv/ld \
+		-Trom.api.ld
 endif
 
 $(BUILD)/lib/tlsf/tlsf.o: CFLAGS += -Wno-cast-align
@@ -543,6 +546,10 @@ ifeq ($(DEBUG), 1)
 	DEBUG_SDKCONFIG = esp-idf-config/sdkconfig-debug.defaults
 else
 	DEBUG_SDKCONFIG = esp-idf-config/sdkconfig-opt.defaults
+endif
+
+ifeq ($(ENABLE_JTAG), 1)
+	CFLAGS += -DENABLE_JTAG=1
 endif
 
 SDKCONFIGS := esp-idf-config/sdkconfig.defaults;$(DEBUG_SDKCONFIG);$(FLASH_SIZE_SDKCONFIG);$(FLASH_MODE_SDKCONFIG);$(FLASH_SPEED_SDKCONFIG);$(PSRAM_SDKCONFIG);$(PSRAM_SIZE_SDKCONFIG);$(PSRAM_MODE_SDKCONFIG);$(PSRAM_SPEED_SDKCONFIG);$(TARGET_SDKCONFIG);boards/$(BOARD)/sdkconfig


### PR DESCRIPTION
This PR resolves issues where Espressif parts with Xtensa cores would crash intermittently, typically while idling with socket polling taking place. Crashes were most often double-faults or WDT timeouts. The root cause of the crashes was use of a version of `longjmp` in ROM that exposed a window of about 6 instructions that manipulated register windowing control registers. If an interrupt occurred inside this window, a register windowing control register could become corrupted due to interaction with a FreeRTOS context switch.

This PR:

- Wraps the faulty `longjmp` with an Espressif provided `__wrap_longjmp` function that creates a critical section for the register window manipulation instructions. It does this by briefly disabling interrupts.
- Adds support for JTAG debugging by allowing use of `ENABLE_JTAG=1` when building.

Resolves #9937 and #9428. May also resolve #9003 and #9460.

Tested by running test from #9428 for more than 36 hours without failure. This test typically failed in 2 to 12 hours.
