### PR TITLE
Update 42. Keebs Frood to version 9

### DIFF
--- a/ports/raspberrypi/boards/42keebs_frood/pins.c
+++ b/ports/raspberrypi/boards/42keebs_frood/pins.c
@@ -49,6 +49,9 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D15), MP_ROM_PTR(&pin_GPIO15) },
     { MP_ROM_QSTR(MP_QSTR_D16), MP_ROM_PTR(&pin_GPIO16) },
 
+    { MP_ROM_QSTR(MP_QSTR_D10), MP_ROM_PTR(&pin_GPIO10) },
+    { MP_ROM_QSTR(MP_QSTR_D11), MP_ROM_PTR(&pin_GPIO11) },
+
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pin_GPIO17) },
     { MP_ROM_QSTR(MP_QSTR_D17), MP_ROM_PTR(&pin_GPIO17) },
     { MP_ROM_QSTR(MP_QSTR_VBUS_SENSE), MP_ROM_PTR(&pin_GPIO19) },


### PR DESCRIPTION
This adds support for the extra two optional I/O pins on the Frood Rev9 - D10 (GPIO10) and D11 (GPIO11).