### PR TITLE
Updates to PR #10325

### DIFF
--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -91,9 +91,8 @@ static int parse_compile_execute(const void *source, mp_parse_input_kind_t input
     nlr_buf_t nlr;
     nlr.ret_val = NULL;
     if (nlr_push(&nlr) == 0) {
-        // CIRCUITPY-CHANGE: Made volatile to prevent gcc from re-ordering store of function pointer into stack frame
-        // after call to gc_collect. For RISC-V this was causing free of the compiled function before execution.
-        volatile mp_obj_t module_fun = mp_const_none;
+        // CIRCUITPY-CHANGE
+        mp_obj_t module_fun = mp_const_none;
         // CIRCUITPY-CHANGE
         #if CIRCUITPY_ATEXIT
         if (!(exec_flags & EXEC_FLAG_SOURCE_IS_ATEXIT))

--- a/supervisor/shared/cpu_regs.h
+++ b/supervisor/shared/cpu_regs.h
@@ -20,6 +20,13 @@
 #endif
 #endif
 
+#ifdef __riscv
+#define INTEGER_REGS 12
+#ifdef __riscv_vector
+#define FLOATING_POINT_REGS 12
+#endif
+#endif
+
 #ifndef INTEGER_REGS
 #define INTEGER_REGS 0
 #endif


### PR DESCRIPTION
This PR makes these update to PR #10325:

- Fixes omission of `SAVED_REGISTER_COUNT` calculation for RISC-V builds that caused stack corruption in `gc_collect` and a crash.
- Reverts PR #10301 which is obsoleted by PR #10325.

Tested on ESP32-C3.