### PR TITLE
Resolve Python Logger warnings

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -434,11 +434,11 @@ def generate_redirects(app):
         return
 
     if not isinstance(app.builder, builders.StandaloneHTMLBuilder):
-        logging.warn(
+        logging.warning(
             "The 'sphinxcontib-redirects' plugin is only supported "
             "by the 'html' builder and subclasses. Skipping..."
         )
-        logging.warn(f"Builder is {app.builder.name} ({type(app.builder)})")
+        logging.warning(f"Builder is {app.builder.name} ({type(app.builder)})")
         return
 
     with open(path) as redirects:

--- a/ports/zephyr-cp/cptools/cpbuild.py
+++ b/ports/zephyr-cp/cptools/cpbuild.py
@@ -24,7 +24,7 @@ if _last_build_times.exists():
         LAST_BUILD_TIMES = json.load(f)
     logger.info("Build times loaded.")
 else:
-    logger.warn(
+    logger.warning(
         "No last build times found. This is normal if you're running this for the first time."
     )
 


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```