### PR TITLE
Migrate to modern datetime inteface

### DIFF
--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -43,8 +43,9 @@ def make_version_header(repo_path, filename):
 
     build_date = datetime.date.today()
     if "SOURCE_DATE_EPOCH" in os.environ:
-        build_date = datetime.datetime.utcfromtimestamp(
-            int(os.environ["SOURCE_DATE_EPOCH"])
+        build_date = datetime.datetime.fromtimestamp(
+            int(os.environ["SOURCE_DATE_EPOCH"]),
+            datetime.timezone.utc
         ).date()
 
     # Generate the file with the git and version info

--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -44,8 +44,7 @@ def make_version_header(repo_path, filename):
     build_date = datetime.date.today()
     if "SOURCE_DATE_EPOCH" in os.environ:
         build_date = datetime.datetime.fromtimestamp(
-            int(os.environ["SOURCE_DATE_EPOCH"]),
-            datetime.timezone.utc
+            int(os.environ["SOURCE_DATE_EPOCH"]), datetime.timezone.utc
         ).date()
 
     # Generate the file with the git and version info


### PR DESCRIPTION
## Summary
This small PR resolves the `datetime` library warnings:
```python
DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```