### PR TITLE
Remove `gc_nbytes` check during sd card LUN mapping

### DIFF
--- a/supervisor/shared/usb/usb_msc_flash.c
+++ b/supervisor/shared/usb/usb_msc_flash.c
@@ -141,7 +141,7 @@ static fs_user_mount_t *get_vfs(int lun) {
     if (lun == SDCARD_LUN) {
         const char *path_under_mount;
         fs_user_mount_t *sdcard = filesystem_for_path("/sd", &path_under_mount);
-        if (sdcard != root && (sdcard->blockdev.flags & MP_BLOCKDEV_FLAG_NATIVE) != 0 && gc_nbytes(sdcard) == 0) {
+        if (sdcard != root && (sdcard->blockdev.flags & MP_BLOCKDEV_FLAG_NATIVE) != 0) {
             return sdcard;
         } else {
             // Clear any ejected state so that a re-insert causes it to reappear.


### PR DESCRIPTION
Fixes #10342

SD cards where previously not populating into the second drive. This change fixes that issue and presents the drive as intended by removing the `gc_nbytes(...)` check on sdcard during LUN mapping.

@tannewt for interest