### PR TITLE
Fix dirty palette never being cleaned by vector shapes

### DIFF
--- a/shared-module/vectorio/VectorShape.c
+++ b/shared-module/vectorio/VectorShape.c
@@ -539,6 +539,7 @@ displayio_area_t *vectorio_vector_shape_get_refresh_areas(vectorio_vector_shape_
             self->ephemeral_dirty_area.next = tail;
             tail = &self->ephemeral_dirty_area;
         } else {
+            self->current_area_dirty = true;
             self->current_area.next = tail;
             tail = &self->current_area;
             VECTORIO_SHAPE_DEBUG("%p get_refresh_area: redrawing current: {(%3d,%3d), (%3d,%3d)}\n", self, self->current_area.x1, self->current_area.y1, self->current_area.x2, self->current_area.y2);


### PR DESCRIPTION
Fix #9666

Implements the fix I mention in https://github.com/adafruit/circuitpython/issues/9666#issuecomment-2781484747
Tilegrid/Bitmap using a `displayio.Palette` don't have the same issue and don't need a fix.