### PR TITLE
Fix arm register unload area size.

### DIFF
--- a/supervisor/shared/cpu_regs.h
+++ b/supervisor/shared/cpu_regs.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #ifdef __arm__
-#define INTEGER_REGS 8
+#define INTEGER_REGS 10
 #ifdef __ARM_FP
 #define FLOATING_POINT_REGS 16
 #endif


### PR DESCRIPTION
The register unload area for Arm thumb 1 processor cores (Cortex M0/M0+/M1/M23) was undersized by 8 bytes causing stack corruption.

Resolves #10355.