### PR TITLE
change pin to IR on sparkle motion stick

### DIFF
--- a/ports/espressif/boards/adafruit_sparkle_motion_stick/pins.c
+++ b/ports/espressif/boards/adafruit_sparkle_motion_stick/pins.c
@@ -13,7 +13,7 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_PTR(&pin_GPIO0) },
     { MP_ROM_QSTR(MP_QSTR_D0), MP_ROM_PTR(&pin_GPIO0) },
 
-    { MP_ROM_QSTR(MP_QSTR_IR_RX), MP_ROM_PTR(&pin_GPIO10) },
+    { MP_ROM_QSTR(MP_QSTR_IR), MP_ROM_PTR(&pin_GPIO10) },
     { MP_ROM_QSTR(MP_QSTR_D10), MP_ROM_PTR(&pin_GPIO10) },
     { MP_ROM_QSTR(MP_QSTR_D12), MP_ROM_PTR(&pin_GPIO12) },
     { MP_ROM_QSTR(MP_QSTR_D13), MP_ROM_PTR(&pin_GPIO13) },


### PR DESCRIPTION
updates the IR pin name on the Sparkle Motion Stick to use `IR` which matches the name used on the original Sparkle Motion: https://github.com/adafruit/circuitpython/blob/main/ports/espressif/boards/adafruit_sparkle_motion/pins.c#L13