### PR TITLE
Fix -Wold-style-definion errors in the raspberrypi port

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/__init__.c
+++ b/devices/ble_hci/common-hal/_bleio/__init__.c
@@ -40,13 +40,13 @@ bool vm_used_ble;
 void common_hal_bleio_init(void) {
 }
 
-void bleio_user_reset() {
+void bleio_user_reset(void) {
     // HCI doesn't support the BLE workflow so just do a full reset.
     bleio_reset();
 }
 
 // Turn off BLE on a reset or reload.
-void bleio_reset() {
+void bleio_reset(void) {
     // Create a UUID object for all CCCD's.
     cccd_uuid.base.type = &bleio_uuid_type;
     common_hal_bleio_uuid_construct(&cccd_uuid, BLE_UUID_CCCD, NULL);

--- a/main.c
+++ b/main.c
@@ -1180,7 +1180,7 @@ void gc_collect(void) {
 }
 
 // Ports may provide an implementation of this function if it is needed
-MP_WEAK void port_gc_collect() {
+MP_WEAK void port_gc_collect(void) {
 }
 
 size_t gc_get_max_new_split(void) {

--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -223,7 +223,7 @@ endif
 
 DISABLE_WARNINGS = -Wno-cast-align
 
-CFLAGS += $(INC) -Wtype-limits -Wall -Werror -std=gnu11 -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT) $(DISABLE_WARNINGS) -Werror=missing-prototypes
+CFLAGS += $(INC) -Wtype-limits -Wall -Werror -std=gnu11 -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT) $(DISABLE_WARNINGS) -Werror=missing-prototypes -Wold-style-definition
 
 PICO_LDFLAGS = --specs=nosys.specs --specs=nano.specs
 
@@ -562,11 +562,14 @@ SRC_C += \
 	common-hal/picodvi/Framebuffer_$(CHIP_VARIANT).c \
 
 ifeq ($(CHIP_VARIANT),RP2040)
-SRC_C += \
+SRC_PICODVI := \
 	lib/PicoDVI/software/libdvi/dvi.c \
 	lib/PicoDVI/software/libdvi/dvi_serialiser.c \
 	lib/PicoDVI/software/libdvi/dvi_timing.c \
 	lib/PicoDVI/software/libdvi/tmds_encode.c \
+
+SRC_C += $(SRC_PICODVI)
+$(patsubst %.c,$(BUILD)/%.o,$(SRC_PICODVI))): CFLAGS += -Wno-old-style-definition
 
 endif
 

--- a/ports/raspberrypi/bindings/cyw43/__init__.c
+++ b/ports/raspberrypi/bindings/cyw43/__init__.c
@@ -43,7 +43,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
     print, shared_bindings_microcontroller_pin_print
     );
 
-uint32_t cyw43_get_power_management_value() {
+uint32_t cyw43_get_power_management_value(void) {
     return power_management_value;
 }
 
@@ -103,7 +103,7 @@ static MP_DEFINE_CONST_FUN_OBJ_1(cyw43_set_power_management_obj, cyw43_set_power
 //|     """Retrieve the power management register"""
 //|
 //|
-static mp_obj_t cyw43_get_power_management() {
+static mp_obj_t cyw43_get_power_management(void) {
     return mp_obj_new_int(power_management_value);
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(cyw43_get_power_management_obj, cyw43_get_power_management);

--- a/ports/raspberrypi/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/raspberrypi/common-hal/alarm/pin/PinAlarm.c
@@ -39,7 +39,7 @@ static void gpio_callback(uint gpio, uint32_t events) {
     }
 }
 
-void alarm_pin_pinalarm_entering_deep_sleep() {
+void alarm_pin_pinalarm_entering_deep_sleep(void) {
     _not_yet_deep_sleeping = false;
 }
 

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -584,7 +584,7 @@ __attribute__((used)) void __not_in_flash_func(isr_hardfault)(void) {
     }
 }
 
-void port_yield() {
+void port_yield(void) {
     #if CIRCUITPY_CYW43
     cyw43_arch_poll();
     #endif

--- a/shared-module/touchio/TouchIn.c
+++ b/shared-module/touchio/TouchIn.c
@@ -86,7 +86,7 @@ void common_hal_touchio_touchin_deinit(touchio_touchin_obj_t *self) {
     self->digitalinout = MP_OBJ_NULL;
 }
 
-void touchin_reset() {
+void touchin_reset(void) {
 }
 
 bool common_hal_touchio_touchin_get_value(touchio_touchin_obj_t *self) {

--- a/supervisor/shared/background_callback.c
+++ b/supervisor/shared/background_callback.c
@@ -58,7 +58,7 @@ inline bool background_callback_pending(void) {
 
 static int background_prevention_count;
 
-void PLACE_IN_ITCM(background_callback_run_all)() {
+void PLACE_IN_ITCM(background_callback_run_all)(void) {
     port_background_task();
     if (!background_callback_pending()) {
         return;
@@ -89,13 +89,13 @@ void PLACE_IN_ITCM(background_callback_run_all)() {
     CALLBACK_CRITICAL_END;
 }
 
-void background_callback_prevent() {
+void background_callback_prevent(void) {
     CALLBACK_CRITICAL_BEGIN;
     ++background_prevention_count;
     CALLBACK_CRITICAL_END;
 }
 
-void background_callback_allow() {
+void background_callback_allow(void) {
     CALLBACK_CRITICAL_BEGIN;
     --background_prevention_count;
     CALLBACK_CRITICAL_END;
@@ -103,7 +103,7 @@ void background_callback_allow() {
 
 
 // Filter out queued callbacks if they are allocated on the heap.
-void background_callback_reset() {
+void background_callback_reset(void) {
     background_callback_t *new_head = NULL;
     background_callback_t **previous_next = &new_head;
     background_callback_t *new_tail = NULL;

--- a/supervisor/shared/reload.c
+++ b/supervisor/shared/reload.c
@@ -35,16 +35,16 @@ void reload_initiate(supervisor_run_reason_t run_reason) {
     port_wake_main_task();
 }
 
-void autoreload_reset() {
+void autoreload_reset(void) {
     last_autoreload_trigger = 0;
 }
 
-void autoreload_enable() {
+void autoreload_enable(void) {
     autoreload_enabled = true;
     last_autoreload_trigger = 0;
 }
 
-void autoreload_disable() {
+void autoreload_disable(void) {
     autoreload_enabled = false;
 }
 
@@ -56,11 +56,11 @@ void autoreload_resume(uint32_t suspend_reason_mask) {
     autoreload_suspended &= ~suspend_reason_mask;
 }
 
-inline bool autoreload_is_enabled() {
+inline bool autoreload_is_enabled(void) {
     return autoreload_enabled;
 }
 
-void autoreload_trigger() {
+void autoreload_trigger(void) {
     if (!autoreload_enabled || autoreload_suspended != 0) {
         return;
     }
@@ -78,7 +78,7 @@ void autoreload_trigger() {
     }
 }
 
-bool autoreload_ready() {
+bool autoreload_ready(void) {
     if (last_autoreload_trigger == 0 || autoreload_suspended != 0) {
         return false;
     }

--- a/supervisor/shared/status_leds.c
+++ b/supervisor/shared/status_leds.c
@@ -112,7 +112,7 @@ static uint32_t current_status_color = 0;
 #endif
 
 static bool status_led_init_in_progress = false;
-void status_led_init() {
+void status_led_init(void) {
     if (status_led_init_in_progress) {
         // Avoid recursion.
         return;
@@ -186,7 +186,7 @@ void status_led_init() {
     status_led_init_in_progress = false;
 }
 
-void status_led_deinit() {
+void status_led_deinit(void) {
     #ifdef MICROPY_HW_NEOPIXEL
     // Make sure the pin stays low for the reset period. The pin reset may pull
     // it up and stop the reset period.

--- a/supervisor/shared/tick.c
+++ b/supervisor/shared/tick.c
@@ -92,14 +92,14 @@ static uint64_t _get_raw_subticks(void) {
     return (ticks << 5) | subticks;
 }
 
-uint64_t supervisor_ticks_ms64() {
+uint64_t supervisor_ticks_ms64(void) {
     uint64_t result;
     result = port_get_raw_ticks(NULL);
     result = result * 1000 / 1024;
     return result;
 }
 
-uint32_t supervisor_ticks_ms32() {
+uint32_t supervisor_ticks_ms32(void) {
     return supervisor_ticks_ms64();
 }
 


### PR DESCRIPTION
This mostly means changing `void foo()` to `void foo(void)` at the function definition site. This was previously only an error if the declaration site didn't have `(void)`, but the unix coverage build enables the more strict warning and there's little difficulty in resolving these diagnostics.

.. other ports can be done too, if desired.