### PR TITLE
fix deque implementation from upstream

### DIFF
--- a/py/objdeque.c
+++ b/py/objdeque.c
@@ -208,7 +208,7 @@ static mp_obj_t deque_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
 
     size_t offset = mp_get_index(self->base.type, deque_len(self), index, false);
     size_t index_val = self->i_get + offset;
-    if (index_val > self->alloc) {
+    if (index_val >= self->alloc) {
         index_val -= self->alloc;
     }
 

--- a/tests/basics/deque2.py
+++ b/tests/basics/deque2.py
@@ -31,6 +31,16 @@ print(d[0], d[1], d[-1])
 d[3] = 5
 print(d[3])
 
+# Access the last element via index, when the last element is at various locations
+d = deque((), 2)
+for i in range(4):
+    d.append(i)
+    print(i, d[-1])
+
+# Write the last element then access all elements from the end
+d[-1] = 4
+print(d[-2], d[-1])
+
 # Accessing indices out of bounds raises IndexError
 try:
     d[4]


### PR DESCRIPTION
This is a verbatim upstream patch for the implementation of deques, see https://github.com/micropython/micropython/pull/16108.

I know upstream is merged once in a while, but this bug basically makes deques unusable, so please consider merging it now.

Tested with a Pico using the code from the original PR.