### PR TITLE
nordic: Fix BLE HID to work after deep sleep

### DIFF
--- a/main.c
+++ b/main.c
@@ -582,8 +582,8 @@ static bool __attribute__((noinline)) run_code_py(safe_mode_t safe_mode, bool *s
     size_t total_time = blink_time + LED_SLEEP_TIME_MS;
     #endif
 
-    // This loop is waits after code completes. It waits for fake sleeps to
-    // finish, user input or autoreloads.
+    // This loop is run after code completes. It waits for fake sleeps to
+    // finish, waits for user input, or waits for an autoreload.
     #if CIRCUITPY_ALARM
     bool fake_sleeping = false;
     #endif

--- a/ports/nordic/boards/circuitplayground_bluefruit/mpconfigboard.h
+++ b/ports/nordic/boards/circuitplayground_bluefruit/mpconfigboard.h
@@ -50,3 +50,7 @@
 #define DEFAULT_UART_BUS_TX         (&pin_P0_14)
 
 #define SPEAKER_ENABLE_PIN          (&pin_P1_04)
+
+// Uncomment to allow debugging over console UART
+// #define CIRCUITPY_CONSOLE_UART_TX (&pin_P0_14)
+// #define CIRCUITPY_CONSOLE_UART_RX (&pin_P0_30)

--- a/ports/nordic/common-hal/alarm/__init__.h
+++ b/ports/nordic/common-hal/alarm/__init__.h
@@ -13,7 +13,7 @@
 #include "common-hal/alarm/touch/TouchAlarm.h"
 
 typedef enum {
-    NRF_SLEEP_WAKEUP_UNDEFINED,
+    NRF_SLEEP_WAKEUP_UNDEFINED = 0,
     NRF_SLEEP_WAKEUP_GPIO,
     NRF_SLEEP_WAKEUP_TIMER,
     NRF_SLEEP_WAKEUP_TOUCHPAD,
@@ -33,8 +33,9 @@ extern const alarm_sleep_memory_obj_t alarm_sleep_memory_obj;
 
 enum {
     SLEEPMEM_WAKEUP_BY_NONE  = 0,
-    SLEEPMEM_WAKEUP_BY_PIN   = 1,
-    SLEEPMEM_WAKEUP_BY_TIMER = 2,
+    SLEEPMEM_WAKEUP_BY_PIN,
+    SLEEPMEM_WAKEUP_BY_TIMER,
+    SLEEPMEM_WAKEUP_BY_TOUCH,
 };
 #define WAKEUP_PIN_UNDEF 0xFF
 extern uint8_t sleepmem_wakeup_event;

--- a/supervisor/shared/bluetooth/bluetooth.c
+++ b/supervisor/shared/bluetooth/bluetooth.c
@@ -189,6 +189,7 @@ void supervisor_bluetooth_init(void) {
     boot_in_discovery_mode = false;
     if (reset_reason != RESET_REASON_POWER_ON &&
         reset_reason != RESET_REASON_RESET_PIN &&
+        reset_reason != RESET_REASON_DEEP_SLEEP_ALARM &&
         reset_reason != RESET_REASON_UNKNOWN &&
         reset_reason != RESET_REASON_SOFTWARE) {
         return;


### PR DESCRIPTION
- Fixes #10348  (fyi @bradanlane)

- Re-initializes BLE properly after a deep sleep.
- Copy-edit a comment in `main.c`.
- Clean up some enums a bit and add a constant for future `TouchAlarm` support (EDIT: though I think that may be impossible for hw reasons, after reviewing the original PR).

I think maybe eventually the `nordic` sleep code could be further simplified. The `NRF_SLEEP_WAKEUP...` and the `SLEEPMEM_WAKEUP...` enums could probably be merged. In the long run `nordic` maybe could do real deep sleep, which it does not do now: it's a lighter sleep:  #5318, etc.