### PR TITLE
improve keypad doc re RP2350 E-9 erratum

### DIFF
--- a/shared-bindings/keypad/KeyMatrix.c
+++ b/shared-bindings/keypad/KeyMatrix.c
@@ -67,6 +67,14 @@
 //|           in the respective state for ``debounce_threshold`` times on average.
 //|           Successive measurements are spaced apart by ``interval`` seconds.
 //|           The default is 1, which resolves immediately. The maximum is 127.
+//|
+//|         .. warning:: On Raspberry Pi RP2350, using ``columns_to_anodes=False``
+//|            normally depends on the internal pull-down resistors.
+//|            This will not work, due to an RP2350 issue.
+//|            The easiest fix is simply to swap the ``row_pins`` and ```column_pins`` and to set
+//|            ``columns_to_anodes=True``. This requires no external components.
+//|            An alternative is to add external pull-downs of 8.2 kohms or less, but that will draw more current.
+//|            See the Warning in `digitalio` for more information.
 //|         """
 //|         ...
 //|

--- a/shared-bindings/keypad/Keys.c
+++ b/shared-bindings/keypad/Keys.c
@@ -69,6 +69,12 @@
 //|           in the respective state for ``debounce_threshold`` times on average.
 //|           Successive measurements are spaced apart by ``interval`` seconds.
 //|           The default is 1, which resolves immediately. The maximum is 127.
+//|
+//|         .. warning:: On Raspberry Pi RP2350, using ``value_when_pressed=True`` and ``pull=True``,
+//|            to enable using the internal pull-down resistor, will not work, due to an RP2350
+//|            hardware issue. Instead, wire the switch to be ``value_when_pressed=False``, or add
+//|            an external pull-down resistor of 8.2 kohms or less.
+//|            See the Warning in `digitalio` for more information.
 //|         """
 //|         ...
 //|

--- a/shared-bindings/keypad/__init__.c
+++ b/shared-bindings/keypad/__init__.c
@@ -65,7 +65,7 @@ MP_PROPERTY_GETTER(keypad_generic_events_obj,
 //|    due to a GPIO hardware issue that causes excessive leakage current (~120uA).
 //|    A pin can read as high even when driven or pulled low, if the input signal is high
 //|    impedance or if an attached pull-down resistor is too weak (has too high a value).
-//|    See the warning in `digitalio` for more information.
+//|    See the warnings in `keypad.Keys`, `keypad.KeyMatrix`, and `digitalio` for workarounds and more information.
 //|
 //| .. jinja
 //| """


### PR DESCRIPTION
Add more information about the RP2350 E-9 erratum as it applies to `keypad`. This is meant to convey more or less the same info as https://learn.adafruit.com/key-pad-matrix-scanning-in-circuitpython/raspberry-pi-rp2350-erratum-workarounds
