### PR TITLE
restore mpy-cross STATIC_BUILD checking

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -25,6 +25,12 @@ CFLAGS += -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables
 # CIRCUITPY-CHANGE
 CFLAGS += -DCIRCUITPY
 
+# Build a static executable.
+# Useful for builds that must run on multiple operating system versions. Used for published mpy-cross versions.
+ifdef STATIC_BUILD
+CFLAGS += -static -static-libgcc -static-libstdc++
+endif
+
 # Debugging/Optimization
 ifdef DEBUG
 CFLAGS += -g
@@ -46,6 +52,10 @@ else
 LDFLAGS_ARCH = -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 endif
 LDFLAGS += $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
+
+ifdef STATIC_BUILD
+LDFLAGS += -static -static-libgcc -static-libstdc++
+endif
 
 # source files
 # CIRCUITPY-CHANGE: extra files


### PR DESCRIPTION
-- Fixes #10387.

mpy-cross `STATIC_BUILD` flag checking from #1013 and #2551 was lost in #8481. Restore it.

I'll check the artifacts after they're built.
