### PR TITLE
Update pins.c

### DIFF
--- a/ports/espressif/boards/waveshare_esp32_s3_zero/pins.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_zero/pins.c
@@ -152,8 +152,7 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_D21), MP_ROM_PTR(&pin_GPIO21) },
     { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO21) },
 
-    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
-    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
+    // UART - using TX RX on silkscreen
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) }
 };
 MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);


### PR DESCRIPTION
The waveshare_esp32_s3_zero/mpconfigboard.h
file does not have SPI nor IC2 defined. I suspect this board was built off another board and while the SPI and IC2 definitions were correctly removed from the mpconfigboard.h file, they were accidentally left in the pins.c file. So if you call a board.I2C or board.SPI you get an error even though they show up in 'dir (board)'.

The board does not have any silkscreen for these busses nor are the specifically called out in the schematic. https://www.waveshare.com/wiki/ESP32-S3-Zero

