### PR TITLE
For atmel-samd release SERCOM on I2C deinit

### DIFF
--- a/.devcontainer/cortex-m-toolchain.sh
+++ b/.devcontainer/cortex-m-toolchain.sh
@@ -14,7 +14,7 @@ echo -e "[cortex-m-toolchain.sh] downloading and installing gcc-arm-non-eabi too
 cd /workspaces
 
 wget -qO gcc-arm-none-eabi.tar.xz \
-  https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz
+  https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz
 
 tar -xJf gcc-arm-none-eabi.tar.xz
 ln -s arm-gnu-toolchain-14.2.Rel1-x86_64-arm-none-eabi gcc-arm-none-eabi

--- a/ports/atmel-samd/common-hal/busio/I2C.c
+++ b/ports/atmel-samd/common-hal/busio/I2C.c
@@ -135,6 +135,7 @@ void common_hal_busio_i2c_deinit(busio_i2c_obj_t *self) {
     if (common_hal_busio_i2c_deinited(self)) {
         return;
     }
+    allow_reset_sercom(self->i2c_desc.device.hw);
 
     i2c_m_sync_disable(&self->i2c_desc);
     i2c_m_sync_deinit(&self->i2c_desc);


### PR DESCRIPTION
This PR corrects an issue where creating a new `board.I2C` object after a VM reset would throw a `ValueError: Invalid pins`.

This PR also fixes a minor typo in the https address of the current ARM Cortex toolchain.