### PR TITLE
Support bt820 REGION instruction

### DIFF
--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -639,8 +639,7 @@ void background_callback_run_all(void);
 #define MICROPY_PY_BUILTINS_COMPILE (1)
 
 #ifndef CIRCUITPY_MIN_GCC_VERSION
-// #define CIRCUITPY_MIN_GCC_VERSION 14
-#define CIRCUITPY_MIN_GCC_VERSION 11
+#define CIRCUITPY_MIN_GCC_VERSION 14
 #endif
 
 #ifndef CIRCUITPY_SAVES_PARTITION_SIZE
@@ -656,7 +655,6 @@ void background_callback_run_all(void);
 #error "CIRCUITPY_BOOT_BUTTON and CIRCUITPY_BOOT_BUTTON_NO_GPIO are mutually exclusive"
 #endif
 
-/*
 #if defined(__GNUC__) && !defined(__ZEPHYR__)
 #if __GNUC__ < CIRCUITPY_MIN_GCC_VERSION
 // (the 3 level scheme here is required to get expansion & stringization
@@ -668,4 +666,3 @@ void background_callback_run_all(void);
 DO_ERROR(CIRCUITPY_MIN_GCC_VERSION);
 #endif
 #endif
-*/

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -639,7 +639,8 @@ void background_callback_run_all(void);
 #define MICROPY_PY_BUILTINS_COMPILE (1)
 
 #ifndef CIRCUITPY_MIN_GCC_VERSION
-#define CIRCUITPY_MIN_GCC_VERSION 14
+// #define CIRCUITPY_MIN_GCC_VERSION 14
+#define CIRCUITPY_MIN_GCC_VERSION 11
 #endif
 
 #ifndef CIRCUITPY_SAVES_PARTITION_SIZE
@@ -655,6 +656,7 @@ void background_callback_run_all(void);
 #error "CIRCUITPY_BOOT_BUTTON and CIRCUITPY_BOOT_BUTTON_NO_GPIO are mutually exclusive"
 #endif
 
+/*
 #if defined(__GNUC__) && !defined(__ZEPHYR__)
 #if __GNUC__ < CIRCUITPY_MIN_GCC_VERSION
 // (the 3 level scheme here is required to get expansion & stringization
@@ -666,3 +668,4 @@ void background_callback_run_all(void);
 DO_ERROR(CIRCUITPY_MIN_GCC_VERSION);
 #endif
 #endif
+*/

--- a/shared-bindings/_eve/__init__.c
+++ b/shared-bindings/_eve/__init__.c
@@ -970,6 +970,7 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(vertex2ii_obj, 3, 5, _vertex2ii);
     { MP_ROM_QSTR(MP_QSTR_PaletteSource), MP_ROM_PTR(&palettesource_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_PaletteSourceH), MP_ROM_PTR(&palettesourceh_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_PointSize), MP_ROM_PTR(&pointsize_obj) }, \
+    { MP_ROM_QSTR(MP_QSTR_Region), MP_ROM_PTR(&region_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_RestoreContext), MP_ROM_PTR(&restorecontext_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_Return), MP_ROM_PTR(&return_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_SaveContext), MP_ROM_PTR(&savecontext_obj) }, \
@@ -1061,7 +1062,28 @@ static mp_obj_t _pointsize(mp_obj_t self, mp_obj_t a0) {
     common_hal__eve_PointSize(EVEHAL(self), size);
     return mp_const_none;
 }
+
 static MP_DEFINE_CONST_FUN_OBJ_2(pointsize_obj, _pointsize);
+
+//|     def Region(self, y: int: h: int, dest: int) -> None:
+//|         """Specify a cull region in the display list
+//|
+//|         :param int y: Starting Y band in the render buffer. Range 0-63
+//|         :param int h: Y height in the render buffer. Range 0-63
+//|         :param int dest: destination address in the display list if the raster is outside the region
+//|
+//|         """
+//|         ...
+//|
+
+static mp_obj_t _region(size_t n_args, const mp_obj_t *args) {
+    uint32_t y = mp_obj_get_int_truncated(args[1]);
+    uint32_t h = mp_obj_get_int_truncated(args[2]);
+    uint32_t dest = mp_obj_get_int_truncated(args[3]);
+    common_hal__eve_Region(EVEHAL(args[0]), y, h, dest);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(region_obj, 4, 4, _region);
 
 //|     def VertexTranslateX(self, x: float) -> None:
 //|         """Set the vertex transformation's x translation component

--- a/shared-bindings/_eve/__init__.c
+++ b/shared-bindings/_eve/__init__.c
@@ -1065,7 +1065,7 @@ static mp_obj_t _pointsize(mp_obj_t self, mp_obj_t a0) {
 
 static MP_DEFINE_CONST_FUN_OBJ_2(pointsize_obj, _pointsize);
 
-//|     def Region(self, y: int: h: int, dest: int) -> None:
+//|     def Region(self, y: int, h: int, dest: int) -> None:
 //|         """Specify a cull region in the display list
 //|
 //|         :param int y: Starting Y band in the render buffer. Range 0-63

--- a/shared-bindings/_eve/__init__.h
+++ b/shared-bindings/_eve/__init__.h
@@ -49,6 +49,7 @@ void common_hal__eve_Nop(common_hal__eve_t *eve);
 void common_hal__eve_PaletteSource(common_hal__eve_t *eve, uint32_t addr);
 void common_hal__eve_PaletteSourceH(common_hal__eve_t *eve, uint32_t addr);
 void common_hal__eve_PointSize(common_hal__eve_t *eve, mp_float_t size);
+void common_hal__eve_Region(common_hal__eve_t *eve, uint32_t y, uint32_t h, uint32_t dest);
 void common_hal__eve_RestoreContext(common_hal__eve_t *eve);
 void common_hal__eve_Return(common_hal__eve_t *eve);
 void common_hal__eve_SaveContext(common_hal__eve_t *eve);

--- a/shared-module/_eve/__init__.c
+++ b/shared-module/_eve/__init__.c
@@ -246,6 +246,11 @@ void common_hal__eve_PointSize(common_hal__eve_t *eve, mp_float_t size) {
 }
 
 
+void common_hal__eve_Region(common_hal__eve_t *eve, uint32_t y, uint32_t h, uint32_t dest) {
+    C4(eve, ((52 << 24) | ((y & 0x3f) << 18) | ((h & 0x3f) << 12) | (dest & 0xfff)));
+}
+
+
 void common_hal__eve_RestoreContext(common_hal__eve_t *eve) {
     C4(eve, ((35 << 24)));
 }


### PR DESCRIPTION
This adds support in _eve for the REGION instruction on the new bt820 hardware. REGION is a conditional branch over a segment of the display list, an optimization.

Tested with local test suite on rp2040.
