### PR TITLE
Fixes REPL not booting on heltec_esp32s3_wifi_lora_v3

### DIFF
--- a/ports/espressif/boards/heltec_esp32s3_wifi_lora_v3/board.c
+++ b/ports/espressif/boards/heltec_esp32s3_wifi_lora_v3/board.c
@@ -34,10 +34,10 @@ uint8_t display_init_sequence[] = { // SSD1306
 digitalio_digitalinout_obj_t display_on;
 
 static void display_init(void) {
-    // Need to bring GPIO21 high or the screen doesn't get power
+    // Need to bring GPIO36 high or the screen doesn't get power
     // & the board can't see the i2c bus at all.
-    common_hal_digitalio_digitalinout_construct(&display_on, &pin_GPIO21);
-    common_hal_digitalio_digitalinout_switch_to_output(&display_on, true, DRIVE_MODE_PUSH_PULL);
+    common_hal_digitalio_digitalinout_construct(&display_on, &pin_GPIO36);
+    common_hal_digitalio_digitalinout_switch_to_output(&display_on, false, DRIVE_MODE_PUSH_PULL);
     common_hal_digitalio_digitalinout_never_reset(&display_on);
 
     busio_i2c_obj_t *i2c = common_hal_board_create_i2c(0);
@@ -48,7 +48,7 @@ static void display_init(void) {
         bus,
         i2c,
         0x3c,
-        NULL
+        &pin_GPIO21  // broken-out on V3
         );
 
     busdisplay_busdisplay_obj_t *display = &allocate_display()->display;


### PR DESCRIPTION
Fixes #10407.

Changed the GPIO in board.c, which controls the rail for the OLED screen and I2C pull-ups. Also added RESET signal to busdisplay constructor. 

Tested with two Heltec WiFi LoRa V3 boards. On power-up the OLED shows the CircuitPython REPL. Opening serial port shows boot getting past `Serial console setup` and into the REPL. I was able to upload libraries and run code via `code.circuitpython.org`.

(Resubmission of PR #10408, I targeted the wrong branch.)