### PR TITLE
SleepMemory is supported on RP2040

### DIFF
--- a/shared-bindings/alarm/SleepMemory.c
+++ b/shared-bindings/alarm/SleepMemory.c
@@ -20,8 +20,6 @@
 //|     instance of :class:`SleepMemory` is available at
 //|     :attr:`alarm.sleep_memory`.
 //|
-//|     **Limitations:** Not supported on RP2040.
-//|
 //|     Usage::
 //|
 //|        import alarm


### PR DESCRIPTION
SleepMemory was implemented on RP2040 in https://github.com/adafruit/circuitpython/pull/8015