### PR TITLE
stubs release fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ stubs:
 	@$(PYTHON) tools/extract_pyi.py extmod/ulab/code/ $(STUBDIR)/ulab
 	@for d in ports/*/bindings; do \
 	    $(PYTHON) tools/extract_pyi.py "$$d" $(STUBDIR); done
-	@sed -e "s,__version__,`python -msetuptools_scm`," < setup.py-stubs > circuitpython-stubs/setup.py
+	@sed -e "s,__version__,`python -msetuptools_scm | cut -d. -f1-3`," < setup.py-stubs > circuitpython-stubs/setup.py
 	@cp README.rst-stubs circuitpython-stubs/README.rst
 	@cp MANIFEST.in-stubs circuitpython-stubs/MANIFEST.in
 	@$(PYTHON) tools/board_stubs/build_board_specific_stubs/board_stub_builder.py


### PR DESCRIPTION
I think this should fix #10361

`python -msetuptools_scm` returns a full version string which seems to include some hex hashes and a `dev` number i.e. `10.0.0a8.dev3+g25132775c1.d20250618`, but pypi does not like all of this being included in the name when we attempt to upload it for stubs release. 

This change uses `cut` to omit the 3rd period and anything that follows it, so we end up with a value like `10.0.0a8` which matches how the versions used to be the last time this succeeded with alpha4.