### PR TITLE
use python 3.12 to build docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.x
+        python-version: 3.12
     - name: Set up submodules
       uses: ./.github/actions/deps/submodules
       with:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ version: 2
 build:
     os: ubuntu-24.04
     tools:
-        python: "3"
+        python: "3.12"
     jobs:
         post_install:
             - python tools/ci_fetch_deps.py docs


### PR DESCRIPTION
This should let us work around: https://github.com/adafruit/Adafruit_Blinka/issues/974 for now.

The hope is that eventually lgpio will get updated to be installable via pip under py3.13 and then should be able to go back to it.