### PR TITLE
cursor_x and cursor_y properties on Terminal

### DIFF
--- a/shared-bindings/terminalio/Terminal.c
+++ b/shared-bindings/terminalio/Terminal.c
@@ -136,6 +136,30 @@ static mp_uint_t terminalio_terminal_write(mp_obj_t self_in, const void *buf_in,
     return common_hal_terminalio_terminal_write(self, buf, size, errcode);
 }
 
+//|     cursor_x: int
+//|     """The x position of the cursor."""
+//|
+static mp_obj_t terminalio_terminal_obj_get_cursor_x(mp_obj_t self_in) {
+    terminalio_terminal_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(common_hal_terminalio_terminal_get_cursor_x(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(terminalio_terminal_get_cursor_x_obj, terminalio_terminal_obj_get_cursor_x);
+
+MP_PROPERTY_GETTER(terminalio_terminal_cursor_x_obj,
+    (mp_obj_t)&terminalio_terminal_get_cursor_x_obj);
+
+//|     cursor_y: int
+//|     """The y position of the cursor."""
+//|
+static mp_obj_t terminalio_terminal_obj_get_cursor_y(mp_obj_t self_in) {
+    terminalio_terminal_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return MP_OBJ_NEW_SMALL_INT(common_hal_terminalio_terminal_get_cursor_y(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(terminalio_terminal_get_cursor_y_obj, terminalio_terminal_obj_get_cursor_y);
+
+MP_PROPERTY_GETTER(terminalio_terminal_cursor_y_obj,
+    (mp_obj_t)&terminalio_terminal_get_cursor_y_obj);
+
 static mp_uint_t terminalio_terminal_ioctl(mp_obj_t self_in, mp_uint_t request, mp_uint_t arg, int *errcode) {
     terminalio_terminal_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_uint_t ret;
@@ -155,6 +179,8 @@ static mp_uint_t terminalio_terminal_ioctl(mp_obj_t self_in, mp_uint_t request, 
 static const mp_rom_map_elem_t terminalio_terminal_locals_dict_table[] = {
     // Standard stream methods.
     { MP_ROM_QSTR(MP_QSTR_write),    MP_ROM_PTR(&mp_stream_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_cursor_x), MP_ROM_PTR(&terminalio_terminal_cursor_x_obj) },
+    { MP_ROM_QSTR(MP_QSTR_cursor_y), MP_ROM_PTR(&terminalio_terminal_cursor_y_obj) },
 };
 static MP_DEFINE_CONST_DICT(terminalio_terminal_locals_dict, terminalio_terminal_locals_dict_table);
 
@@ -168,7 +194,7 @@ static const mp_stream_p_t terminalio_terminal_stream_p = {
 MP_DEFINE_CONST_OBJ_TYPE(
     terminalio_terminal_type,
     MP_QSTR_Terminal,
-    MP_TYPE_FLAG_ITER_IS_ITERNEXT,
+    MP_TYPE_FLAG_ITER_IS_ITERNEXT | MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS,
     make_new, terminalio_terminal_make_new,
     locals_dict, (mp_obj_dict_t *)&terminalio_terminal_locals_dict,
     iter, mp_stream_unbuffered_iter,

--- a/shared-bindings/terminalio/Terminal.h
+++ b/shared-bindings/terminalio/Terminal.h
@@ -19,4 +19,7 @@ extern void common_hal_terminalio_terminal_construct(terminalio_terminal_obj_t *
 extern size_t common_hal_terminalio_terminal_write(terminalio_terminal_obj_t *self,
     const uint8_t *data, size_t len, int *errcode);
 
+extern uint16_t common_hal_terminalio_terminal_get_cursor_x(terminalio_terminal_obj_t *self);
+extern uint16_t common_hal_terminalio_terminal_get_cursor_y(terminalio_terminal_obj_t *self);
+
 extern bool common_hal_terminalio_terminal_ready_to_tx(terminalio_terminal_obj_t *self);

--- a/shared-module/terminalio/Terminal.c
+++ b/shared-module/terminalio/Terminal.c
@@ -453,6 +453,13 @@ size_t common_hal_terminalio_terminal_write(terminalio_terminal_obj_t *self, con
     return i - data;
 }
 
+uint16_t common_hal_terminalio_terminal_get_cursor_x(terminalio_terminal_obj_t *self) {
+    return self->cursor_x;
+}
+uint16_t common_hal_terminalio_terminal_get_cursor_y(terminalio_terminal_obj_t *self) {
+    return self->cursor_y;
+}
+
 bool common_hal_terminalio_terminal_ready_to_tx(terminalio_terminal_obj_t *self) {
     return self->scroll_area != NULL;
 }


### PR DESCRIPTION
Terminal already has these values internally, this change exposes them to python. 

My intention is to utilize these with a custom wrapper of Terminal class that adds support for ANSI color escapes. Having access to the cursor position makes it easy to know where in the TileGrid the colors need to get changed when an escape code is encountered. 

If this overflows builds one option is try to make these available only if the tilepalettemapper module is enabled if that's possible. It's turned off for the tight builds. The two features aren't intrinsically linked, but I have no current intentions to use cursor position without tpm so it could save space and still allow my use-case.