### PR TITLE
shared-bindings/sdioio/SDCard.c: fix example use of `board.SDIO_DATA`

### DIFF
--- a/shared-bindings/sdioio/SDCard.c
+++ b/shared-bindings/sdioio/SDCard.c
@@ -55,7 +55,10 @@
 //|             sd = sdioio.SDCard(
 //|                 clock=board.SDIO_CLOCK,
 //|                 command=board.SDIO_COMMAND,
-//|                 data=[board.SDIO_DATA],
+//|                 # Note that board.SDIO_DATA is a tuple of four pins, not an individual pin.
+//|                 data=board.SDIO_DATA,
+//|                 # On some boards, the data pins are named individually. Use this line instead.
+//|                 #data=(board.SDIO_DATA0, board.SDIO_DATA1, board.SDIO_DATA2, board.SDIO_DATA3),
 //|                 frequency=25000000)
 //|             vfs = storage.VfsFat(sd)
 //|             storage.mount(vfs, '/sd')


### PR DESCRIPTION
`board.SDIO_DATA` on a number of boards is a tuple of four pins for use with `sdioio.SDCARD(..., data=...)`

The example in `sdioio` incorrectly put it in square brackets: `[board.SDIO_DATA]`. Remove those to use the intended tuple, and also include a sample line for boards that do not have this tuple but have `board.SDIO_DATA0, board.SDIO_DATA1, board.SDIO_DATA2, board.SDIO_DATA3` pins instead.

Thanks `Seth K` in discord for discovering the doc problem.

I've also updated some examples in Learn Guides to point out `board.SDIO_DATA` is a tuple.

Maybe the tuple should be called `board.SDIO_DATA_PINS`, but good documentation will help for now.