### PR TITLE
Revert #10397

### DIFF
--- a/ports/espressif/common-hal/pulseio/PulseIn.c
+++ b/ports/espressif/common-hal/pulseio/PulseIn.c
@@ -82,7 +82,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
     // captured because we may skip the first portion of a symbol.
     self->raw_symbols_size = (maxlen / 2 + 1) * sizeof(rmt_symbol_word_t);
     // RMT DMA mode cannot access PSRAM -> ensure raw_symbols is in internal ram
-    self->raw_symbols = (rmt_symbol_word_t *)port_malloc(self->raw_symbols_size, true);
+    self->raw_symbols = (rmt_symbol_word_t *)heap_caps_malloc(self->raw_symbols_size, MALLOC_CAP_INTERNAL);
     if (self->raw_symbols == NULL) {
         m_free(self->buffer);
         m_malloc_fail(self->raw_symbols_size);
@@ -116,7 +116,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
     // If we fail here, the self->buffer will be garbage collected.
     esp_err_t result = rmt_new_rx_channel(&config, &self->channel);
     if (result != ESP_OK) {
-        port_free(self->raw_symbols);
+        heap_caps_free(self->raw_symbols);
         raise_esp_error(result);
     }
 
@@ -127,7 +127,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
     rmt_enable(self->channel);
     result = rmt_receive(self->channel, self->raw_symbols, self->raw_symbols_size, &rx_config);
     if (result != ESP_OK) {
-        port_free(self->raw_symbols);
+        heap_caps_free(self->raw_symbols);
         raise_esp_error(result);
     }
 }

--- a/ports/espressif/common-hal/pulseio/PulseIn.c
+++ b/ports/espressif/common-hal/pulseio/PulseIn.c
@@ -115,7 +115,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
     };
     // If we fail here, the self->buffer will be garbage collected.
     esp_err_t result = rmt_new_rx_channel(&config, &self->channel);
-    if (result != ESP_OK) {
+    if (result != ESP_OK){
         heap_caps_free(self->raw_symbols);
         raise_esp_error(result);
     }
@@ -126,7 +126,7 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
     rmt_rx_register_event_callbacks(self->channel, &rx_callback, self);
     rmt_enable(self->channel);
     result = rmt_receive(self->channel, self->raw_symbols, self->raw_symbols_size, &rx_config);
-    if (result != ESP_OK) {
+    if (result != ESP_OK){
         heap_caps_free(self->raw_symbols);
         raise_esp_error(result);
     }

--- a/ports/espressif/common-hal/pulseio/PulseIn.c
+++ b/ports/espressif/common-hal/pulseio/PulseIn.c
@@ -80,9 +80,8 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
     }
     // We add one to the maxlen version to ensure that two symbols at lease are
     // captured because we may skip the first portion of a symbol.
-    self->raw_symbols_size = (maxlen / 2 + 1) * sizeof(rmt_symbol_word_t);
-    // RMT DMA mode cannot access PSRAM -> ensure raw_symbols is in internal ram
-    self->raw_symbols = (rmt_symbol_word_t *)heap_caps_malloc(self->raw_symbols_size, MALLOC_CAP_INTERNAL);
+    self->raw_symbols_size = MIN(64, maxlen / 2 + 1) * sizeof(rmt_symbol_word_t);
+    self->raw_symbols = (rmt_symbol_word_t *)m_malloc_without_collect(self->raw_symbols_size);
     if (self->raw_symbols == NULL) {
         m_free(self->buffer);
         m_malloc_fail(self->raw_symbols_size);
@@ -110,26 +109,17 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
         .clk_src = RMT_CLK_SRC_DEFAULT,
         // 2 us resolution so we can capture 65ms pulses. The RMT period is only 15 bits.
         .resolution_hz = 1000000 / 2,
-        .mem_block_symbols = self->raw_symbols_size,
-        .flags.with_dma = 1
+        .mem_block_symbols = SOC_RMT_MEM_WORDS_PER_CHANNEL,
     };
-    // If we fail here, the self->buffer will be garbage collected.
-    esp_err_t result = rmt_new_rx_channel(&config, &self->channel);
-    if (result != ESP_OK){
-        heap_caps_free(self->raw_symbols);
-        raise_esp_error(result);
-    }
+    // If we fail here, the buffers allocated above will be garbage collected.
+    CHECK_ESP_RESULT(rmt_new_rx_channel(&config, &self->channel));
 
     rmt_rx_event_callbacks_t rx_callback = {
         .on_recv_done = _done_callback
     };
     rmt_rx_register_event_callbacks(self->channel, &rx_callback, self);
     rmt_enable(self->channel);
-    result = rmt_receive(self->channel, self->raw_symbols, self->raw_symbols_size, &rx_config);
-    if (result != ESP_OK){
-        heap_caps_free(self->raw_symbols);
-        raise_esp_error(result);
-    }
+    rmt_receive(self->channel, self->raw_symbols, self->raw_symbols_size, &rx_config);
 }
 
 bool common_hal_pulseio_pulsein_deinited(pulseio_pulsein_obj_t *self) {

--- a/ports/espressif/supervisor/port.c
+++ b/ports/espressif/supervisor/port.c
@@ -308,18 +308,18 @@ void port_heap_init(void) {
 }
 
 void *port_malloc(size_t size, bool dma_capable) {
-    size_t caps = MALLOC_CAP_8BIT;
     if (dma_capable) {
-        caps |= MALLOC_CAP_DMA;
+        // SPIRAM is not DMA-capable, so don't bother to ask for it.
+        return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA);
     }
 
     void *ptr = NULL;
-    // Try SPIRAM first when available.
+    // Try SPIRAM first if available.
     #ifdef CONFIG_SPIRAM
-    ptr = heap_caps_malloc(size, caps | MALLOC_CAP_SPIRAM);
+    ptr = heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
     #endif
     if (ptr == NULL) {
-        ptr = heap_caps_malloc(size, caps);
+        ptr = heap_caps_malloc(size, MALLOC_CAP_8BIT);
     }
     return ptr;
 }

--- a/ports/espressif/supervisor/port.c
+++ b/ports/espressif/supervisor/port.c
@@ -308,18 +308,18 @@ void port_heap_init(void) {
 }
 
 void *port_malloc(size_t size, bool dma_capable) {
+    size_t caps = MALLOC_CAP_8BIT;
     if (dma_capable) {
-        // SPIRAM is not DMA-capable, so don't bother to ask for it.
-        return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_DMA);
+        caps |= MALLOC_CAP_DMA;
     }
 
     void *ptr = NULL;
-    // Try SPIRAM first if available.
+    // Try SPIRAM first when available.
     #ifdef CONFIG_SPIRAM
-    ptr = heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
+    ptr = heap_caps_malloc(size, caps | MALLOC_CAP_SPIRAM);
     #endif
     if (ptr == NULL) {
-        ptr = heap_caps_malloc(size, MALLOC_CAP_8BIT);
+        ptr = heap_caps_malloc(size, caps);
     }
     return ptr;
 }


### PR DESCRIPTION
This patch reverts #10397. See #10466.
I don't think the code the feature can be kept.

Ideally the underlying code could **try** to do it and fallback to the old behavior if it explodes,
but that would also require a good bit of documentation and testing for when and how it works.
(i.e. only first PulseIn object, only if maxlen > 128, on these chips)