### PR TITLE
raspberrypi/I2CTarget: Fixed bug where I2C starts were seen as restarts.

### DIFF
--- a/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.h
+++ b/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.h
@@ -21,3 +21,5 @@ typedef struct {
     uint8_t scl_pin;
     uint8_t sda_pin;
 } i2ctarget_i2c_target_obj_t;
+
+int common_hal_i2ctarget_i2c_target_is_stop(i2ctarget_i2c_target_obj_t *self);


### PR DESCRIPTION
The Rasperry Pi Pico, based on the RP2040, has a register that maintains the status of I2C interrupt flags called IC_INTR_STAT. The bits of this register are set by hardware and cleared by software. Before this commit, the I2CTarget library did not clear the restart bit (R_RESTART_DET) in this register after an I2C transaction ended, causing the is_restart field of the i2ctarget_i2c_target_request_obj_t struct to always be true after the first I2C transaction that involved a restart. This commit causes the restart and stop bits to get cleared when the I2C transaction ends.
