### PR TITLE
fixed path of extracted directory

### DIFF
--- a/.devcontainer/cortex-m-toolchain.sh
+++ b/.devcontainer/cortex-m-toolchain.sh
@@ -17,7 +17,7 @@ wget -qO gcc-arm-none-eabi.tar.xz \
   https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz
 
 tar -xJf gcc-arm-none-eabi.tar.xz
-ln -s arm-gnu-toolchain-14.2.Rel1-x86_64-arm-none-eabi gcc-arm-none-eabi
+ln -s arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi gcc-arm-none-eabi
 rm -f gcc-arm-none-eabi.tar.xz
 
 echo -e "[cortex-m-toolchain.sh] update PATH in environment"


### PR DESCRIPTION
The toplevel pathname within `gcc-arm-none-eabi.tar.xz` was changed by the maintainers. This PR fixes the link created by the script.