### PR TITLE
espressif/common-hal/frequencyio/FrequencyIn.c: fix heap_caps_malloc() arg order

### DIFF
--- a/ports/espressif/common-hal/frequencyio/FrequencyIn.c
+++ b/ports/espressif/common-hal/frequencyio/FrequencyIn.c
@@ -117,7 +117,7 @@ void common_hal_frequencyio_frequencyin_construct(frequencyio_frequencyin_obj_t 
 
     self->pin = pin->number;
     self->capture_period_ms = capture_period_ms;
-    self->internal_data = heap_caps_malloc(MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL, sizeof(_internal_data_t));
+    self->internal_data = heap_caps_malloc(sizeof(_internal_data_t), MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
     if (self->internal_data == NULL) {
         raise_esp_error(ESP_ERR_NO_MEM);
     }


### PR DESCRIPTION
- Fixes #10394

The arguments to `heap_caps_malloc()` were in the wrong order. Thanks @sola85 for spotting this.

Tested. Jumpered A0 and A1 on a QT Py ESP32-S3:
```py

>>> import pwmio, frequencyio, board
>>> a0 = pwmio.PWMOut(board.A0, frequency=123456)
>>> a0.duty_cycle=32768
>>> a1 = frequencyio.FrequencyIn(board.A1)
>>> a1.value
123450
```
Note that it also "worked" before this fix, but the size allocation was all wrong.