### PR TITLE
espressif: pulseio.PulseIn - Use dma only when necessary

### DIFF
--- a/ports/espressif/common-hal/pulseio/PulseIn.c
+++ b/ports/espressif/common-hal/pulseio/PulseIn.c
@@ -74,14 +74,20 @@ static bool _done_callback(rmt_channel_handle_t rx_chan,
 
 void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu_pin_obj_t *pin,
     uint16_t maxlen, bool idle_state) {
+
+    // Only use dma when necessary, since dma-rmt might not be available.
+    // If dma is not available, this will raise an error below.
+    bool use_dma = maxlen > 128;
+
     self->buffer = (uint16_t *)m_malloc_without_collect(maxlen * sizeof(uint16_t));
     if (self->buffer == NULL) {
         m_malloc_fail(maxlen * sizeof(uint16_t));
     }
     // We add one to the maxlen version to ensure that two symbols at lease are
     // captured because we may skip the first portion of a symbol.
-    self->raw_symbols_size = MIN(64, maxlen / 2 + 1) * sizeof(rmt_symbol_word_t);
-    self->raw_symbols = (rmt_symbol_word_t *)m_malloc_without_collect(self->raw_symbols_size);
+    self->raw_symbols_size = (maxlen / 2 + 1) * sizeof(rmt_symbol_word_t);
+    // RMT DMA mode cannot access PSRAM -> ensure raw_symbols is in internal ram
+    self->raw_symbols = (rmt_symbol_word_t *)port_malloc(self->raw_symbols_size, use_dma);
     if (self->raw_symbols == NULL) {
         m_free(self->buffer);
         m_malloc_fail(self->raw_symbols_size);
@@ -109,17 +115,30 @@ void common_hal_pulseio_pulsein_construct(pulseio_pulsein_obj_t *self, const mcu
         .clk_src = RMT_CLK_SRC_DEFAULT,
         // 2 us resolution so we can capture 65ms pulses. The RMT period is only 15 bits.
         .resolution_hz = 1000000 / 2,
-        .mem_block_symbols = SOC_RMT_MEM_WORDS_PER_CHANNEL,
+        .mem_block_symbols = use_dma ? self->raw_symbols_size : SOC_RMT_MEM_WORDS_PER_CHANNEL,
+        .flags.with_dma = use_dma
     };
-    // If we fail here, the buffers allocated above will be garbage collected.
-    CHECK_ESP_RESULT(rmt_new_rx_channel(&config, &self->channel));
+    // If we fail here, the self->buffer will be garbage collected.
+    esp_err_t result = rmt_new_rx_channel(&config, &self->channel);
+    if (result != ESP_OK) {
+        port_free(self->raw_symbols);
+        if (result == ESP_ERR_NOT_SUPPORTED) {
+            mp_raise_ValueError_varg(MP_ERROR_TEXT("Invalid %q"), MP_QSTR_maxlen);
+        } else {
+            raise_esp_error(result);
+        }
+    }
 
     rmt_rx_event_callbacks_t rx_callback = {
         .on_recv_done = _done_callback
     };
     rmt_rx_register_event_callbacks(self->channel, &rx_callback, self);
     rmt_enable(self->channel);
-    rmt_receive(self->channel, self->raw_symbols, self->raw_symbols_size, &rx_config);
+    result = rmt_receive(self->channel, self->raw_symbols, self->raw_symbols_size, &rx_config);
+    if (result != ESP_OK) {
+        port_free(self->raw_symbols);
+        raise_esp_error(result);
+    }
 }
 
 bool common_hal_pulseio_pulsein_deinited(pulseio_pulsein_obj_t *self) {

--- a/shared-bindings/pulseio/PulseIn.c
+++ b/shared-bindings/pulseio/PulseIn.c
@@ -33,6 +33,10 @@
 //|         :param bool idle_state: Idle state of the pin. At start and after `resume`
 //|           the first recorded pulse will the opposite state from idle.
 //|
+//|         **Limitations**: The `maxlen` parameter is limited depending on the specific board.
+//|         On most ESP32 variants the limit is 128. On ESP32-S3 and ESP32-P4 the first `PulseIn` instance
+//|         can use `maxlen` up to available RAM; all subsequent instances are limited to 128.
+//|
 //|         Read a short series of pulses::
 //|
 //|           import pulseio


### PR DESCRIPTION
This is a second attempt at allowing longer pulse sequences to be recorded using `pulseio.PulseIn` on espressif ports using the DMA backend of the RMT hardware.

This is essentially the same code as in the original PR https://github.com/adafruit/circuitpython/pull/10397, but the new logic is now only activated in cases where the existing logic didn't work, i.e. if `maxlen > 128`. I believe this fixes all issues raised in https://github.com/adafruit/circuitpython/issues/10466 and https://github.com/adafruit/circuitpython/pull/10470:

- If `maxlen <= 128`, then the old logic works fine on all ports.
- If `maxlen > 128` and the DMA backend is available (i.e. the hardware supports it and it is not allocated), then recording longer pulse sequences works.
- If `maxlen > 128` and the DMA backend is NOT available (i.e. the hardware doesn't support it or it is already allocated, e.g. due to an existing `PulseIn` object), then a `"Invalid maxlen"` error is raised. In this case, using `maxlen <= 128` still works.

I tested all of this on a Lolin-S2-mini and a Waveshare-S3-Zero and added a sentence to the documentation regarding this.

Notes:
1. This is a breaking change to anyone previously using `maxlen > 128` on a variant that did not support it. Previously this silently just returned shorter sequences, now this raises an error.
2. I think it might be possible to get `maxlen > 128` to work also on variants without DMA hardware because the documentation says: 
   > Usually, only one block of 64 x 32-bit worth of data can be sent or received in channel n. If the data size is larger than this block size, users can configure the channel [...] to use more blocks by setting RMT_MEM_SIZE_CHn
  
   But this might introduce more limitations regarding use of multiple `PulseIn` and `PulseOut`, which is a can-of-worms I did not want to open in this PR.
4. Strictly speaking the value of 128 above should be replaced by  `2*SOC_RMT_MEM_WORDS_PER_CHANNEL`. But since this was previously hard-coded to a maximum of 128 pulses (with only worked due to Note 2), and changing this would be another breaking change, I left this at 128.

Maybe @jbrelwof and @bill88t want to try this out before it gets merged.