### PR TITLE
Update rasbperrypi and zephyr-cp to use a full Mozilla root certificate bundle

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -655,7 +655,7 @@ CFLAGS += \
 	  -isystem $(TOP)/lib/mbedtls/include \
 	  -DMBEDTLS_CONFIG_FILE='"$(TOP)/lib/mbedtls_config/mbedtls_config.h"' \
 
-$(BUILD)/x509_crt_bundle.S: $(TOP)/lib/certificates/data/roots.pem $(TOP)/tools/gen_crt_bundle.py
+$(BUILD)/x509_crt_bundle.S: $(TOP)/lib/certificates/data/roots-full.pem $(TOP)/tools/gen_crt_bundle.py
 	$(Q)$(PYTHON) $(TOP)/tools/gen_crt_bundle.py -i $< -o $@ --asm
 OBJ_MBEDTLS := $(BUILD)/x509_crt_bundle.o
 $(patsubst %.c,$(BUILD)/%.o,$(SRC_MBEDTLS))): CFLAGS += -Wno-suggest-attribute=format

--- a/ports/zephyr-cp/cptools/build_circuitpython.py
+++ b/ports/zephyr-cp/cptools/build_circuitpython.py
@@ -530,7 +530,7 @@ async def build_circuitpython():
 
         if "ssl" in enabled_modules:
             crt_bundle = builddir / "x509_crt_bundle.S"
-            roots_pem = srcdir / "lib/certificates/data/roots.pem"
+            roots_pem = srcdir / "lib/certificates/data/roots-full.pem"
             generator = srcdir / "tools/gen_crt_bundle.py"
             tg.create_task(
                 cpbuild.run_command(


### PR DESCRIPTION
- Fixes #10488 
- Fixes #10489 

Change the `raspberrypi` and `zephyr-cp` wifi builds to use the full Mozilla certificate bundle from https://github.com/adafruit/certificates. Now all our wifi builds use the full bundle.

This update required https://github.com/adafruit/certificates/pull/10 to work. When i was testing this, the RP2 builds mysteriously did not work for an https://api.github.com HTTPS fetch. This was because the Comodo "AAA Certificate Sevices" root had recently been removed from the Mozilla bundle. For most hosts this is fine, because there was a cross-signed certificate in their chain that used another root certificate. But `mbedtls` does not inherently support cross-signing, so the Comodo certificate had to be put back.

This was not an existing problem on the `espressif` builds, because the complete Mozilla bundle provided by ESP-IDF and used now on those builds still has that certificate. For background on Espressif's own diagnosis and fix of this same problem, see:
- https://newreleases.io/project/github/espressif/esp-idf/release/v5.4.1
  > ESP Cert Bundle
  > - Added entry for "Sectigo - Comodo AAA Services root" in the common CA cert authority list. This fixes problem with server verification with GitHub endpoint. Regression introduced in [e174fc9](https://github.com/espressif/esp-idf/commit/e174fc967e28fce326a91518954c34700d64df45). ([74eadef](https://github.com/espressif/esp-idf/commit/74eadefb1a3ae4b625a9acaa7d7f700dd89d1fb7))
- https://github.com/espressif/esp-idf/commit/03433aad49169183b9619626ecc42b18eb5b4411 fix(mbedtls): re-include Starfield Class 2 CA
- https://github.com/espressif/esp-idf/commit/6fe38c7efdc471174d8e0efb62f39985d7752334 fix(mbedtls): re-include Comodo AAA Services root

Also note ESP-IDF recently implemented cross-signing support in their `master` for their upcoming v6.0 release:
https://github.com/espressif/esp-idf/commit/cabb5009f2f27e716dc9286809ce34ac00e34b74.
