### PR TITLE
ESP32: Return correct deep sleep wakeup pin

### DIFF
--- a/ports/espressif/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/espressif/common-hal/alarm/pin/PinAlarm.c
@@ -108,7 +108,17 @@ mp_obj_t alarm_pin_pinalarm_record_wake_alarm(void) {
 
     #ifdef SOC_PM_SUPPORT_EXT0_WAKEUP
     if (cause == ESP_SLEEP_WAKEUP_EXT0) {
-        pin_number = REG_GET_FIELD(RTC_IO_EXT_WAKEUP0_REG, RTC_IO_EXT_WAKEUP0_SEL);
+        int rtc_io_pin_number = REG_GET_FIELD(RTC_IO_EXT_WAKEUP0_REG, RTC_IO_EXT_WAKEUP0_SEL);
+        // Look up the GPIO equivalent pin for this RTC GPIO pin. On ESP32, the numbering
+        // is different for RTC_GPIO and regular GPIO, and there's no mapping table.
+        // The RTC and GPIO pin numbers match for all other current chips, so we could skip this
+        // for those chips, but it's not expensive, and maybe there will be another mismatch in the future.
+        for (gpio_num_t gpio_num = 0; gpio_num < SOC_GPIO_PIN_COUNT; gpio_num++) {
+            if (rtc_io_number_get(gpio_num) == rtc_io_pin_number) {
+                pin_number = gpio_num;
+                break;
+            }
+        }
     } else {
     #endif
     #ifdef SOC_PM_SUPPORT_EXT1_WAKEUP


### PR DESCRIPTION
- Fixes #10498

On ESP32, `alarm.wake_alarm.pin` was wrong, because it was return the RTC_GPIO pin number, not the regular GPIO. On ESP32 only (at present), the RTC_GPIO numbers do not line up with the regular GPIO numbers. There is no direct mapping function or table to go from RTC_GPIO to GPIO, so I just wrote a search loop to find the right pin, using the supplied mapping function the other way.

Tested on Feather ESP32 V2, and tested that there was no regression on a Feather TFT ESP32-S2.

Thanks @keen101 for the bug report.