### PR TITLE
.github/actions/deps/ports/nordic/action.yml: Change URL for nrfutil

### DIFF
--- a/.github/actions/deps/ports/nordic/action.yml
+++ b/.github/actions/deps/ports/nordic/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Get nrfutil 7+
       run: |
-        wget https://developer.nordicsemi.com/.pc-tools/nrfutil/x64-linux/nrfutil
+        wget https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
         chmod +x nrfutil
         ./nrfutil install nrf5sdk-tools
         mkdir -p $HOME/.local/bin


### PR DESCRIPTION
https://developer.nordicsemi.com started blocking `wget` as a `User-Agent` very recently. A Nordic DevZone user gave me an alternate URL that still works.

This broke the nordic builds on the 10.0.0-beta.1 release :frowning_face: . I am building them on a local machine.

See https://devzone.nordicsemi.com/f/nordic-q-a/123372/https-developer-nordicsemi-com-is-blocking-some-user-agent-values-on-downloads