### PR TITLE
Refactor EPaperDisplay args into struct

### DIFF
--- a/ports/atmel-samd/boards/openbook_m4/board.c
+++ b/ports/atmel-samd/boards/openbook_m4/board.c
@@ -53,42 +53,24 @@ void board_init(void) {
 
     epaperdisplay_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &epaperdisplay_epaperdisplay_type;
-    common_hal_epaperdisplay_epaperdisplay_construct(display,
-        bus,
-        start_sequence,
-        sizeof(start_sequence),
-        0, // start up time
-        stop_sequence,
-        sizeof(stop_sequence),
-        300, // width
-        400, // height
-        300, // RAM width
-        400, // RAM height
-        0, // colstart
-        0, // rowstart
-        270, // rotation
-        NO_COMMAND, // set_column_window_command
-        NO_COMMAND, // set_row_window_command
-        NO_COMMAND, // set_current_column_command
-        NO_COMMAND, // set_current_row_command
-        0x13, // write_black_ram_command
-        false, // black_bits_inverted
-        NO_COMMAND, // write_color_ram_command (can add this for grayscale eventually)
-        false, // color_bits_inverted
-        0x000000, // highlight_color
-        0x000000, // highlight_color2
-        refresh_sequence, // refresh_display_sequence
-        sizeof(refresh_sequence),
-        40, // refresh_time
-        &pin_PA01, // busy_pin
-        false, // busy_state
-        5, // seconds_per_frame
-        false, // chip_select (don't always toggle chip select)
-        false, // grayscale
-        false, // acep
-        false, // spectra6
-        false, // two_byte_sequence_length
-        false); // address_little_endian
+    epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+    args.bus = bus;
+    args.start_sequence = start_sequence;
+    args.start_sequence_len = sizeof(start_sequence);
+    args.stop_sequence = stop_sequence;
+    args.stop_sequence_len = sizeof(stop_sequence);
+    args.width = 300;
+    args.height = 400;
+    args.ram_width = 300;
+    args.ram_height = 400;
+    args.rotation = 270;
+    args.write_black_ram_command = 0x13;
+    args.refresh_sequence = refresh_sequence;
+    args.refresh_sequence_len = sizeof(refresh_sequence);
+    args.refresh_time = 40.0;
+    args.busy_pin = &pin_PA01;
+    args.seconds_per_frame = 5.0;
+    common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
+++ b/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
@@ -217,75 +217,54 @@ void board_init(void) {
     display->base.type = &epaperdisplay_epaperdisplay_type;
 
     if (is_ssd1680) {
-        common_hal_epaperdisplay_epaperdisplay_construct(
-            display,
-            bus,
-            ssd1680_display_start_sequence, sizeof(ssd1680_display_start_sequence),
-            0, // start up time
-            ssd1680_display_stop_sequence, sizeof(ssd1680_display_stop_sequence),
-            296,  // width
-            128,  // height
-            250,  // ram_width
-            296,  // ram_height
-            0,  // colstart
-            0,  // rowstart
-            270,  // rotation
-            0x44,  // set_column_window_command
-            0x45,  // set_row_window_command
-            0x4e,  // set_current_column_command
-            0x4f,  // set_current_row_command
-            0x24,  // write_black_ram_command
-            false,  // black_bits_inverted
-            0x26,  // write_color_ram_command
-            false,  // color_bits_inverted
-            0x000000,  // highlight_color
-            0x000000,  // highlight_color2
-            ssd1680_display_refresh_sequence, sizeof(ssd1680_display_refresh_sequence),
-            1.0,  // refresh_time
-            &pin_GPIO5,  // busy_pin
-            true,  // busy_state
-            5.0, // seconds_per_frame
-            false,  // always_toggle_chip_select
-            true, // grayscale
-            false, // acep
-            false, // spectra6
-            true,  // two_byte_sequence_length
-            true); // address_little_endian
+        epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+        args.bus = bus;
+        args.start_sequence = ssd1680_display_start_sequence;
+        args.start_sequence_len = sizeof(ssd1680_display_start_sequence);
+        args.stop_sequence = ssd1680_display_stop_sequence;
+        args.stop_sequence_len = sizeof(ssd1680_display_stop_sequence);
+        args.width = 296;
+        args.height = 128;
+        args.ram_width = 250;
+        args.ram_height = 296;
+        args.rotation = 270;
+        args.set_column_window_command = 0x44;
+        args.set_row_window_command = 0x45;
+        args.set_current_column_command = 0x4e;
+        args.set_current_row_command = 0x4f;
+        args.write_black_ram_command = 0x24;
+        args.write_color_ram_command = 0x26;
+        args.refresh_sequence = ssd1680_display_refresh_sequence;
+        args.refresh_sequence_len = sizeof(ssd1680_display_refresh_sequence);
+        args.refresh_time = 1.0;
+        args.busy_pin = &pin_GPIO5;
+        args.busy_state = true;
+        args.seconds_per_frame = 5.0;
+        args.grayscale = true;
+        args.two_byte_sequence_length = true;
+        args.address_little_endian = true;
+        common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
     } else {
-        common_hal_epaperdisplay_epaperdisplay_construct(
-            display,
-            bus,
-            il0373_display_start_sequence, sizeof(il0373_display_start_sequence),
-            0, // start up time
-            il0373_display_stop_sequence, sizeof(il0373_display_stop_sequence),
-            296,  // width
-            128,  // height
-            160,  // ram_width
-            296,  // ram_height
-            0,  // colstart
-            0,  // rowstart
-            270,  // rotation
-            NO_COMMAND,  // set_column_window_command
-            NO_COMMAND,  // set_row_window_command
-            NO_COMMAND,  // set_current_column_command
-            NO_COMMAND,  // set_current_row_command
-            0x10,  // write_black_ram_command
-            false,  // black_bits_inverted
-            0x13,  // write_color_ram_command
-            false,  // color_bits_inverted
-            0x000000,  // highlight_color
-            0x000000,  // highlight_color2
-            il0373_display_refresh_sequence, sizeof(il0373_display_refresh_sequence),
-            1.0,  // refresh_time
-            &pin_GPIO5,  // busy_pin
-            false,  // busy_state
-            5.0, // seconds_per_frame
-            false,  // always_toggle_chip_select
-            true, // grayscale
-            false, // acep
-            false, // spectra6
-            false,  // two_byte_sequence_length
-            false); // address_little_endian
+        epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+        args.bus = bus;
+        args.start_sequence = il0373_display_start_sequence;
+        args.start_sequence_len = sizeof(il0373_display_start_sequence);
+        args.stop_sequence = il0373_display_stop_sequence;
+        args.stop_sequence_len = sizeof(il0373_display_stop_sequence);
+        args.width = 296;
+        args.height = 128;
+        args.ram_width = 160;
+        args.ram_height = 296;
+        args.rotation = 270;
+        args.write_black_ram_command = 0x10;
+        args.write_color_ram_command = 0x13;
+        args.refresh_sequence = il0373_display_refresh_sequence;
+        args.refresh_sequence_len = sizeof(il0373_display_refresh_sequence);
+        args.refresh_time = 1.0;
+        args.busy_pin = &pin_GPIO5;
+        args.seconds_per_frame = 5.0;
+        args.grayscale = true;
+        common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
     }
 }
 

--- a/ports/espressif/boards/elecrow_crowpanel_4_2_epaper/board.c
+++ b/ports/espressif/boards/elecrow_crowpanel_4_2_epaper/board.c
@@ -63,43 +63,30 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-// Set up the DisplayIO epaper object
+    // Set up the DisplayIO epaper object
     epaperdisplay_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &epaperdisplay_epaperdisplay_type;
-    common_hal_epaperdisplay_epaperdisplay_construct(
-        display,
-        bus,
-        display_start_sequence, sizeof(display_start_sequence),
-        1, // start up time
-        display_stop_sequence, sizeof(display_stop_sequence),
-        400, // width
-        300, // height
-        400, // ram_width
-        300, // ram_height
-        0, // colstart
-        0, // rowstart
-        0, // rotation
-        NO_COMMAND, // set_column_window_command
-        NO_COMMAND, // set_row_window_command
-        NO_COMMAND, // set_current_column_command
-        NO_COMMAND, // set_current_row_command
-        0x24, // write_black_ram_command
-        false, // black_bits_inverted
-        0x26, // write_color_ram_command
-        false, // color_bits_inverted
-        0x000000, // highlight_color
-        0x000000, // highlight_color2
-        refresh_sequence, sizeof(refresh_sequence), // refresh_display_command
-        1.0, // refresh_time
-        &pin_GPIO48, // busy_pin
-        true, // busy_state
-        2.0, // seconds_per_frame
-        false, // always_toggle_chip_select
-        false, // grayscale
-        false, // acep
-        false, // spectra6
-        false, // two_byte_sequence_length
-        false); // address_little_endian
+
+    epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+    args.bus = bus;
+    args.start_sequence = display_start_sequence;
+    args.start_sequence_len = sizeof(display_start_sequence);
+    args.start_up_time = 1.0;
+    args.stop_sequence = display_stop_sequence;
+    args.stop_sequence_len = sizeof(display_stop_sequence);
+    args.width = 400;
+    args.height = 300;
+    args.ram_width = 400;
+    args.ram_height = 300;
+    args.write_black_ram_command = 0x24;
+    args.write_color_ram_command = 0x26;
+    args.refresh_sequence = refresh_sequence;
+    args.refresh_sequence_len = sizeof(refresh_sequence);
+    args.refresh_time = 1.0;
+    args.busy_pin = &pin_GPIO48;
+    args.busy_state = true;
+    args.seconds_per_frame = 2.0;
+    common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
 }
 
 void board_deinit(void) {

--- a/ports/espressif/boards/heltec_vision_master_e290/board.c
+++ b/ports/espressif/boards/heltec_vision_master_e290/board.c
@@ -61,43 +61,37 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-// Set up the DisplayIO epaper object
+    // Set up the DisplayIO epaper object
     epaperdisplay_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &epaperdisplay_epaperdisplay_type;
-    common_hal_epaperdisplay_epaperdisplay_construct(
-        display,
-        bus,
-        display_start_sequence, sizeof(display_start_sequence),
-        0, // start up time
-        display_stop_sequence, sizeof(display_stop_sequence),
-        296, // width
-        128, // height
-        250, // ram_width
-        296, // ram_height
-        8, // colstart
-        0, // rowstart
-        90, // rotation
-        0x44, // set_column_window_command
-        0x45, // set_row_window_command
-        0x4E, // set_current_column_command
-        0x4F, // set_current_row_command
-        0x24, // write_black_ram_command
-        false, // black_bits_inverted
-        0x26, // write_color_ram_command
-        false, // color_bits_inverted
-        0xFF0000, // highlight_color
-        0x000000, // highlight_color2
-        refresh_sequence, sizeof(refresh_sequence), // refresh_display_command
-        1.0, // refresh_time
-        &pin_GPIO6, // busy_pin
-        true, // busy_state
-        2.0, // seconds_per_frame
-        false, // always_toggle_chip_select
-        false, // grayscale
-        false, // acep
-        false, // spectra6
-        false, // two_byte_sequence_length
-        true); // address_little_endian
+
+    epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+    args.bus = bus;
+    args.start_sequence = display_start_sequence;
+    args.start_sequence_len = sizeof(display_start_sequence);
+    args.stop_sequence = display_stop_sequence;
+    args.stop_sequence_len = sizeof(display_stop_sequence);
+    args.width = 296;
+    args.height = 128;
+    args.ram_width = 250;
+    args.ram_height = 296;
+    args.colstart = 8;
+    args.rotation = 90;
+    args.set_column_window_command = 0x44;
+    args.set_row_window_command = 0x45;
+    args.set_current_column_command = 0x4E;
+    args.set_current_row_command = 0x4F;
+    args.write_black_ram_command = 0x24;
+    args.write_color_ram_command = 0x26;
+    args.highlight_color = 0xFF0000;
+    args.refresh_sequence = refresh_sequence;
+    args.refresh_sequence_len = sizeof(refresh_sequence);
+    args.refresh_time = 1.0;
+    args.busy_pin = &pin_GPIO6;
+    args.busy_state = true;
+    args.seconds_per_frame = 2.0;
+    args.address_little_endian = true;
+    common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
 }
 
 void board_deinit(void) {

--- a/ports/espressif/boards/heltec_wireless_paper/board.c
+++ b/ports/espressif/boards/heltec_wireless_paper/board.c
@@ -101,43 +101,29 @@ void board_init(void) {
         0, // Polarity
         0); // Phase
 
-// Set up the DisplayIO epaper object
+    // Set up the DisplayIO epaper object
     epaperdisplay_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &epaperdisplay_epaperdisplay_type;
-    common_hal_epaperdisplay_epaperdisplay_construct(
-        display,
-        bus,
-        display_start_sequence, sizeof(display_start_sequence),
-        0, // start up time
-        display_stop_sequence, sizeof(display_stop_sequence),
-        250, // width
-        122, // height
-        128, // ram_width
-        296, // ram_height
-        0, // colstart
-        0, // rowstart
-        270, // rotation
-        NO_COMMAND, // set_column_window_command
-        NO_COMMAND, // set_row_window_command
-        NO_COMMAND, // set_current_column_command
-        NO_COMMAND, // set_current_row_command
-        0x13, // write_black_ram_command
-        false, // black_bits_inverted
-        0x10, // write_color_ram_command
-        false, // color_bits_inverted
-        0x000000, // highlight_color
-        0x000000, // highlight_color2
-        refresh_sequence, sizeof(refresh_sequence), // refresh_display_command
-        1.0, // refresh_time
-        &pin_GPIO7, // busy_pin
-        false, // busy_state
-        2.0, // seconds_per_frame
-        false, // always_toggle_chip_select
-        false, // grayscale
-        false, // acep
-        false, // spectra6
-        false, // two_byte_sequence_length
-        false); // address_little_endian
+
+    epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+    args.bus = bus;
+    args.start_sequence = display_start_sequence;
+    args.start_sequence_len = sizeof(display_start_sequence);
+    args.stop_sequence = display_stop_sequence;
+    args.stop_sequence_len = sizeof(display_stop_sequence);
+    args.width = 250;
+    args.height = 122;
+    args.ram_width = 128;
+    args.ram_height = 296;
+    args.rotation = 270;
+    args.write_black_ram_command = 0x13;
+    args.write_color_ram_command = 0x10;
+    args.refresh_sequence = refresh_sequence;
+    args.refresh_sequence_len = sizeof(refresh_sequence);
+    args.refresh_time = 1.0;
+    args.busy_pin = &pin_GPIO7;
+    args.seconds_per_frame = 2.0;
+    common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
 }
 
 void board_deinit(void) {

--- a/ports/espressif/boards/sqfmi_watchy/board.c
+++ b/ports/espressif/boards/sqfmi_watchy/board.c
@@ -160,41 +160,33 @@ void board_init(void) {
 
     epaperdisplay_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &epaperdisplay_epaperdisplay_type;
-    common_hal_epaperdisplay_epaperdisplay_construct(
-        display,
-        bus,
-        display_start_sequence, sizeof(display_start_sequence),
-        (double)0.01, // start up time
-        display_stop_sequence, sizeof(display_stop_sequence),
-        200,  // width
-        200,  // height
-        200,  // ram_width
-        296,  // ram_height
-        0,  // colstart
-        0,  // rowstart
-        0,  // rotation
-        0x44,  // set_column_window_command
-        0x45,  // set_row_window_command
-        0x4E,  // set_current_column_command
-        0x4F,  // set_current_row_command
-        0x24,  // write_black_ram_command
-        true,  // black_bits_inverted
-        0x26,  // write_color_ram_command
-        false,  // color_bits_inverted
-        0x000000,  // highlight_color
-        0x000000,  // highlight_color2
-        refresh_sequence, sizeof(refresh_sequence),
-        (double)1.0,  // refresh_time
-        &pin_GPIO19,  // busy_pin
-        true,  // busy_state
-        (double)5.0, // seconds_per_frame
-        false,  // always_toggle_chip_select
-        false, // grayscale
-        false, // acep
-        false, // spectra6
-        false,  // two_byte_sequence_length
-        true // address_little_endian
-        );
+
+    epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+    args.bus = bus;
+    args.start_sequence = display_start_sequence;
+    args.start_sequence_len = sizeof(display_start_sequence);
+    args.start_up_time = 0.01;
+    args.stop_sequence = display_stop_sequence;
+    args.stop_sequence_len = sizeof(display_stop_sequence);
+    args.width = 200;
+    args.height = 200;
+    args.ram_width = 200;
+    args.ram_height = 296;
+    args.set_column_window_command = 0x44;
+    args.set_row_window_command = 0x45;
+    args.set_current_column_command = 0x4E;
+    args.set_current_row_command = 0x4F;
+    args.write_black_ram_command = 0x24;
+    args.black_bits_inverted = true;
+    args.write_color_ram_command = 0x26;
+    args.refresh_sequence = refresh_sequence;
+    args.refresh_sequence_len = sizeof(refresh_sequence);
+    args.refresh_time = 1.0;
+    args.busy_pin = &pin_GPIO19;
+    args.busy_state = true;
+    args.seconds_per_frame = 5.0;
+    args.address_little_endian = true;
+    common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
 }
 
 bool board_requests_safe_mode(void) {

--- a/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/board.c
+++ b/ports/raspberrypi/boards/bradanlanestudio_explorer_rp2040/board.c
@@ -251,75 +251,62 @@ void board_init(void) {
     if ((vid_setting == 1) ||   // DCNextGen SSD1681 BWR rotated 270
         (vid_setting == 3) ||   // Explorer  SSD1681 BW  rotated 0
         (vid_setting == 4)) {   // Explorer  SSD1681 BWR rotated 0
-        common_hal_epaperdisplay_epaperdisplay_construct(
-            display,
-            bus,
-            _start_sequence_ssd1681, sizeof(_start_sequence_ssd1681),
-            1.0,         // start up time
-            _stop_sequence_ssd1681, sizeof(_stop_sequence_ssd1681),
-            WIDTH,                                                                                          // width
-            HEIGHT,                                                                                         // height
-            WIDTH,                                                                                          // ram_width
-            HEIGHT + 0x60,                                                                                  // ram_height RAM is actually only 200 bits high but we use 296 to match the 9 bits
-            0,                                                                                              // colstart
-            0,                                                                                              // rowstart
-            rotation,                                                                                       // rotation
-            SSD_SET_RAMXPOS,                                                                                // set_column_window_command
-            SSD_SET_RAMYPOS,                                                                                // set_row_window_command
-            SSD_SET_RAMXCOUNT,                                                                              // set_current_column_command
-            SSD_SET_RAMYCOUNT,                                                                              // set_current_row_command
-            SSD_WRITE_RAM_BLK,                                                                              // write_black_ram_command
-            false,                                                                                          // black_bits_inverted
-            SSD_WRITE_RAM_RED,                                                                              // write_color_ram_command
-            false,                                                                                          // color_bits_inverted
-            0xFF0000,                                                                                       // highlight_color (RED for tri-color display)
-            0x000000,                                                                                       // highlight_color2
-            _refresh_sequence_ssd1681, sizeof(_refresh_sequence_ssd1681),                                   // refresh_display_command
-            refresh_time,                                                                                   // refresh_time
-            &pin_GPIO9, // DEFAULT_SPI_BUS_BUSY,                                                            // busy_pin
-            true,                                                                                           // busy_state
-            seconds_per_frame,                                                                              // seconds_per_frame (does not seem the user can change this)
-            true,                                                                                           // always_toggle_chip_select
-            false,                                                                                          // not grayscale
-            false,                                                                                          // not acep
-            false,                                                                                          // not spectra6
-            false,                                                                                          // not two_byte_sequence_length
-            true);                                                                                          // address_little_endian
+        epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+        args.bus = bus;
+        args.start_sequence = _start_sequence_ssd1681;
+        args.start_sequence_len = sizeof(_start_sequence_ssd1681);
+        args.start_up_time = 1.0;
+        args.stop_sequence = _stop_sequence_ssd1681;
+        args.stop_sequence_len = sizeof(_stop_sequence_ssd1681);
+        args.width = WIDTH;
+        args.height = HEIGHT;
+        args.ram_width = WIDTH;
+        args.ram_height = HEIGHT + 0x60;
+        args.rotation = rotation;
+        args.set_column_window_command = SSD_SET_RAMXPOS;
+        args.set_row_window_command = SSD_SET_RAMYPOS;
+        args.set_current_column_command = SSD_SET_RAMXCOUNT;
+        args.set_current_row_command = SSD_SET_RAMYCOUNT;
+        args.write_black_ram_command = SSD_WRITE_RAM_BLK;
+        args.write_color_ram_command = SSD_WRITE_RAM_RED;
+        args.highlight_color = 0xFF0000;
+        args.refresh_sequence = _refresh_sequence_ssd1681;
+        args.refresh_sequence_len = sizeof(_refresh_sequence_ssd1681);
+        args.refresh_time = refresh_time;
+        args.busy_pin = &pin_GPIO9;
+        args.busy_state = true;
+        args.seconds_per_frame = seconds_per_frame;
+        args.always_toggle_chip_select = true;
+        args.address_little_endian = true;
+        common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
     } else if (vid_setting == 2) {  // Explorer SSD1608 BW
-        common_hal_epaperdisplay_epaperdisplay_construct(
-            display,
-            bus,
-            _start_sequence_ssd1608, sizeof(_start_sequence_ssd1608),
-            1.0,         // start up time
-            _stop_sequence_ssd1608, sizeof(_stop_sequence_ssd1608),
-            WIDTH,                                                                                          // width
-            HEIGHT,                                                                                         // height
-            WIDTH,                                                                                          // ram_width
-            HEIGHT /* + 0x60 */,                                                                             // ram_height RAM is actually only 200 bits high but we use 296 to match the 9 bits
-            0,                                                                                              // colstart
-            0,                                                                                              // rowstart
-            rotation,                                                                                       // rotation
-            SSD_SET_RAMXPOS,                                                                                // set_column_window_command
-            SSD_SET_RAMYPOS,                                                                                // set_row_window_command
-            SSD_SET_RAMXCOUNT,                                                                              // set_current_column_command
-            SSD_SET_RAMYCOUNT,                                                                              // set_current_row_command
-            SSD_WRITE_RAM_BLK,                                                                              // write_black_ram_command
-            false,                                                                                          // black_bits_inverted
-            NO_COMMAND,                                                                                     // write_color_ram_command
-            false,                                                                                          // color_bits_inverted
-            0x000000,                                                                                       // highlight_color (RED for tri-color display)
-            0x000000,                                                                                       // highlight_color2
-            _refresh_sequence_ssd1608, sizeof(_refresh_sequence_ssd1608),                                   // refresh_display_command
-            refresh_time,                                                                                   // refresh_time
-            &pin_GPIO9, // DEFAULT_SPI_BUS_BUSY,                                                            // busy_pin
-            true,                                                                                           // busy_state
-            seconds_per_frame,                                                                              // seconds_per_frame (does not seem the user can change this)
-            true,                                                                                           // always_toggle_chip_select
-            false,                                                                                          // not grayscale
-            false,                                                                                          // not acep
-            false,                                                                                          // not spectra6
-            false,                                                                                          // not two_byte_sequence_length
-            true);                                                                                          // address_little_endian
+        epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+        args.bus = bus;
+        args.start_sequence = _start_sequence_ssd1608;
+        args.start_sequence_len = sizeof(_start_sequence_ssd1608);
+        args.start_up_time = 1.0;
+        args.stop_sequence = _stop_sequence_ssd1608;
+        args.stop_sequence_len = sizeof(_stop_sequence_ssd1608);
+        args.width = WIDTH;
+        args.height = HEIGHT;
+        args.ram_width = WIDTH;
+        args.ram_height = HEIGHT;
+        args.rotation = rotation;
+        args.set_column_window_command = SSD_SET_RAMXPOS;
+        args.set_row_window_command = SSD_SET_RAMYPOS;
+        args.set_current_column_command = SSD_SET_RAMXCOUNT;
+        args.set_current_row_command = SSD_SET_RAMYCOUNT;
+        args.write_black_ram_command = SSD_WRITE_RAM_BLK;
+        args.write_color_ram_command = NO_COMMAND;
+        args.refresh_sequence = _refresh_sequence_ssd1608;
+        args.refresh_sequence_len = sizeof(_refresh_sequence_ssd1608);
+        args.refresh_time = refresh_time;
+        args.busy_pin = &pin_GPIO9;
+        args.busy_state = true;
+        args.seconds_per_frame = seconds_per_frame;
+        args.always_toggle_chip_select = true;
+        args.address_little_endian = true;
+        common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
     } else {
         // what should happen if this firmware is installed on some other board?
         // currently, we mark the display as None

--- a/ports/raspberrypi/boards/pimoroni_badger2040/board.c
+++ b/ports/raspberrypi/boards/pimoroni_badger2040/board.c
@@ -273,40 +273,27 @@ void board_init(void) {
     // Set up the DisplayIO epaper object
     epaperdisplay_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &epaperdisplay_epaperdisplay_type;
-    common_hal_epaperdisplay_epaperdisplay_construct(
-        display,
-        bus,
-        display_start_sequence, sizeof(display_start_sequence),
-        0, // start up time
-        display_stop_sequence, sizeof(display_stop_sequence),
-        296,  // width
-        128,  // height
-        160,  // ram_width
-        296,  // ram_height
-        0,  // colstart
-        0,  // rowstart
-        270,  // rotation
-        NO_COMMAND,  // set_column_window_command
-        NO_COMMAND,  // set_row_window_command
-        NO_COMMAND,  // set_current_column_command
-        NO_COMMAND,  // set_current_row_command
-        DTM2,  // write_black_ram_command
-        true,  // black_bits_inverted
-        DTM1,  // write_color_ram_command
-        false,  // color_bits_inverted
-        0x000000,  // highlight_color
-        0x000000,  // highlight_color2
-        refresh_sequence, sizeof(refresh_sequence),  // refresh_display_command
-        1.0,  // refresh_time
-        &pin_GPIO26,  // busy_pin
-        false,  // busy_state
-        2.0, // seconds_per_frame
-        false,  // always_toggle_chip_select
-        false, // grayscale
-        false, // acep
-        false, // spectra6
-        false,  // two_byte_sequence_length
-        false); // address_little_endian
+
+    epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+    args.bus = bus;
+    args.start_sequence = display_start_sequence;
+    args.start_sequence_len = sizeof(display_start_sequence);
+    args.stop_sequence = display_stop_sequence;
+    args.stop_sequence_len = sizeof(display_stop_sequence);
+    args.width = 296;
+    args.height = 128;
+    args.ram_width = 160;
+    args.ram_height = 296;
+    args.rotation = 270;
+    args.write_black_ram_command = DTM2;
+    args.black_bits_inverted = true;
+    args.write_color_ram_command = DTM1;
+    args.refresh_sequence = refresh_sequence;
+    args.refresh_sequence_len = sizeof(refresh_sequence);
+    args.refresh_time = 1.0;
+    args.busy_pin = &pin_GPIO26;
+    args.seconds_per_frame = 2.0;
+    common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
 }
 
 void board_deinit(void) {

--- a/ports/raspberrypi/boards/pimoroni_badger2040w/board.c
+++ b/ports/raspberrypi/boards/pimoroni_badger2040w/board.c
@@ -273,40 +273,27 @@ void board_init(void) {
     // Set up the DisplayIO epaper object
     epaperdisplay_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &epaperdisplay_epaperdisplay_type;
-    common_hal_epaperdisplay_epaperdisplay_construct(
-        display,
-        bus,
-        display_start_sequence, sizeof(display_start_sequence),
-        0, // start up time
-        display_stop_sequence, sizeof(display_stop_sequence),
-        296,  // width
-        128,  // height
-        160,  // ram_width
-        296,  // ram_height
-        0,  // colstart
-        0,  // rowstart
-        270,  // rotation
-        NO_COMMAND,  // set_column_window_command
-        NO_COMMAND,  // set_row_window_command
-        NO_COMMAND,  // set_current_column_command
-        NO_COMMAND,  // set_current_row_command
-        DTM2,  // write_black_ram_command
-        true,  // black_bits_inverted
-        DTM1,  // write_color_ram_command
-        false,  // color_bits_inverted
-        0x000000,  // highlight_color
-        0x000000,  // highlight_color2
-        refresh_sequence, sizeof(refresh_sequence),  // refresh_display_command
-        1.0,  // refresh_time
-        &pin_GPIO26,  // busy_pin
-        false,  // busy_state
-        2.0, // seconds_per_frame
-        false,  // always_toggle_chip_select
-        false, // grayscale
-        false, // acep
-        false, // spectra6
-        false,  // two_byte_sequence_length
-        false); // address_little_endian
+
+    epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+    args.bus = bus;
+    args.start_sequence = display_start_sequence;
+    args.start_sequence_len = sizeof(display_start_sequence);
+    args.stop_sequence = display_stop_sequence;
+    args.stop_sequence_len = sizeof(display_stop_sequence);
+    args.width = 296;
+    args.height = 128;
+    args.ram_width = 160;
+    args.ram_height = 296;
+    args.rotation = 270;
+    args.write_black_ram_command = DTM2;
+    args.black_bits_inverted = true;
+    args.write_color_ram_command = DTM1;
+    args.refresh_sequence = refresh_sequence;
+    args.refresh_sequence_len = sizeof(refresh_sequence);
+    args.refresh_time = 1.0;
+    args.busy_pin = &pin_GPIO26;
+    args.seconds_per_frame = 2.0;
+    common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
 }
 
 void board_deinit(void) {

--- a/ports/raspberrypi/boards/pimoroni_inky_frame_5_7/board.c
+++ b/ports/raspberrypi/boards/pimoroni_inky_frame_5_7/board.c
@@ -67,40 +67,26 @@ void board_init(void) {
 
     epaperdisplay_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &epaperdisplay_epaperdisplay_type;
-    common_hal_epaperdisplay_epaperdisplay_construct(
-        display,
-        bus,
-        display_start_sequence, sizeof(display_start_sequence),
-        1.0, // start up time
-        display_stop_sequence, sizeof(display_stop_sequence),
-        600,  // width
-        448,  // height
-        640,  // ram_width
-        480,  // ram_height
-        0,  // colstart
-        0,  // rowstart
-        0,  // rotation
-        NO_COMMAND,  // set_column_window_command
-        NO_COMMAND,  // set_row_window_command
-        NO_COMMAND,  // set_current_column_command
-        NO_COMMAND,  // set_current_row_command
-        0x10,  // write_black_ram_command
-        false,  // black_bits_inverted
-        NO_COMMAND,  // write_color_ram_command
-        false,  // color_bits_inverted
-        0x000000,  // highlight_color
-        0x000000,  // highlight_color2
-        refresh_sequence, sizeof(refresh_sequence),
-        28.0,  // refresh_time
-        NULL,  // busy_pin
-        false,  // busy_state
-        40.0, // seconds_per_frame
-        false,  // always_toggle_chip_select
-        false, // grayscale
-        true, // acep
-        false, // spectra6
-        false,  // two_byte_sequence_length
-        false); // address_little_endian
+
+    epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+    args.bus = bus;
+    args.start_sequence = display_start_sequence;
+    args.start_sequence_len = sizeof(display_start_sequence);
+    args.start_up_time = 1.0;
+    args.stop_sequence = display_stop_sequence;
+    args.stop_sequence_len = sizeof(display_stop_sequence);
+    args.width = 600;
+    args.height = 448;
+    args.ram_width = 640;
+    args.ram_height = 480;
+    args.write_black_ram_command = 0x10;
+    args.refresh_sequence = refresh_sequence;
+    args.refresh_sequence_len = sizeof(refresh_sequence);
+    args.refresh_time = 28.0;
+    args.busy_pin = NULL;
+    args.seconds_per_frame = 40.0;
+    args.acep = true;
+    common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/ports/raspberrypi/boards/pimoroni_inky_frame_7_3/board.c
+++ b/ports/raspberrypi/boards/pimoroni_inky_frame_7_3/board.c
@@ -126,40 +126,27 @@ void board_init(void) {
 
     epaperdisplay_epaperdisplay_obj_t *display = &allocate_display()->epaper_display;
     display->base.type = &epaperdisplay_epaperdisplay_type;
-    common_hal_epaperdisplay_epaperdisplay_construct(
-        display,
-        bus,
-        display_start_sequence, sizeof(display_start_sequence),
-        1.0, // start up time
-        display_stop_sequence, sizeof(display_stop_sequence),
-        800,  // width
-        480,  // height
-        800,  // ram_width
-        480,  // ram_height
-        0,  // colstart
-        0,  // rowstart
-        180,  // rotation
-        NO_COMMAND,  // set_column_window_command
-        NO_COMMAND,  // set_row_window_command
-        NO_COMMAND,  // set_current_column_command
-        NO_COMMAND,  // set_current_row_command
-        0x10,  // write_black_ram_command
-        false,  // black_bits_inverted
-        NO_COMMAND,  // write_color_ram_command
-        false,  // color_bits_inverted
-        0x000000,  // highlight_color
-        0x000000,  // highlight_color2
-        refresh_sequence, sizeof(refresh_sequence),
-        28.0,  // refresh_time
-        NULL,  // busy_pin
-        false,  // busy_state
-        30.0, // seconds_per_frame
-        false,  // always_toggle_chip_select
-        false, // grayscale
-        true, // acep
-        false, // spectra6
-        false,  // two_byte_sequence_length
-        false); // address_little_endian
+
+    epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+    args.bus = bus;
+    args.start_sequence = display_start_sequence;
+    args.start_sequence_len = sizeof(display_start_sequence);
+    args.start_up_time = 1.0;
+    args.stop_sequence = display_stop_sequence;
+    args.stop_sequence_len = sizeof(display_stop_sequence);
+    args.width = 800;
+    args.height = 480;
+    args.ram_width = 800;
+    args.ram_height = 480;
+    args.rotation = 180;
+    args.write_black_ram_command = 0x10;
+    args.refresh_sequence = refresh_sequence;
+    args.refresh_sequence_len = sizeof(refresh_sequence);
+    args.refresh_time = 28.0;
+    args.busy_pin = NULL;
+    args.seconds_per_frame = 30.0;
+    args.acep = true;
+    common_hal_epaperdisplay_epaperdisplay_construct(display, &args);
 }
 
 // Use the MP_WEAK supervisor/shared/board.c versions of routines not defined here.

--- a/shared-bindings/epaperdisplay/EPaperDisplay.c
+++ b/shared-bindings/epaperdisplay/EPaperDisplay.c
@@ -211,20 +211,43 @@ static mp_obj_t epaperdisplay_epaperdisplay_make_new(const mp_obj_type_t *type, 
     }
 
     self->base.type = &epaperdisplay_epaperdisplay_type;
-    common_hal_epaperdisplay_epaperdisplay_construct(
-        self,
-        display_bus,
-        start_bufinfo.buf, start_bufinfo.len, start_up_time, stop_bufinfo.buf, stop_bufinfo.len,
-        args[ARG_width].u_int, args[ARG_height].u_int, args[ARG_ram_width].u_int, args[ARG_ram_height].u_int,
-        args[ARG_colstart].u_int, args[ARG_rowstart].u_int, rotation,
-        args[ARG_set_column_window_command].u_int, args[ARG_set_row_window_command].u_int,
-        args[ARG_set_current_column_command].u_int, args[ARG_set_current_row_command].u_int,
-        args[ARG_write_black_ram_command].u_int, args[ARG_black_bits_inverted].u_bool, write_color_ram_command,
-        args[ARG_color_bits_inverted].u_bool, highlight_color, highlight_color2, refresh_buf, refresh_buf_len, refresh_time,
-        busy_pin, args[ARG_busy_state].u_bool, seconds_per_frame,
-        args[ARG_always_toggle_chip_select].u_bool, args[ARG_grayscale].u_bool, args[ARG_advanced_color_epaper].u_bool, args[ARG_spectra6].u_bool,
-        two_byte_sequence_length, args[ARG_address_little_endian].u_bool
-        );
+    epaperdisplay_construct_args_t construct_args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+    construct_args.bus = display_bus;
+    construct_args.start_sequence = start_bufinfo.buf;
+    construct_args.start_sequence_len = start_bufinfo.len;
+    construct_args.start_up_time = start_up_time;
+    construct_args.stop_sequence = stop_bufinfo.buf;
+    construct_args.stop_sequence_len = stop_bufinfo.len;
+    construct_args.width = args[ARG_width].u_int;
+    construct_args.height = args[ARG_height].u_int;
+    construct_args.ram_width = args[ARG_ram_width].u_int;
+    construct_args.ram_height = args[ARG_ram_height].u_int;
+    construct_args.colstart = args[ARG_colstart].u_int;
+    construct_args.rowstart = args[ARG_rowstart].u_int;
+    construct_args.rotation = rotation;
+    construct_args.set_column_window_command = args[ARG_set_column_window_command].u_int;
+    construct_args.set_row_window_command = args[ARG_set_row_window_command].u_int;
+    construct_args.set_current_column_command = args[ARG_set_current_column_command].u_int;
+    construct_args.set_current_row_command = args[ARG_set_current_row_command].u_int;
+    construct_args.write_black_ram_command = args[ARG_write_black_ram_command].u_int;
+    construct_args.black_bits_inverted = args[ARG_black_bits_inverted].u_bool;
+    construct_args.write_color_ram_command = write_color_ram_command;
+    construct_args.color_bits_inverted = args[ARG_color_bits_inverted].u_bool;
+    construct_args.highlight_color = highlight_color;
+    construct_args.highlight_color2 = highlight_color2;
+    construct_args.refresh_sequence = refresh_buf;
+    construct_args.refresh_sequence_len = refresh_buf_len;
+    construct_args.refresh_time = refresh_time;
+    construct_args.busy_pin = busy_pin;
+    construct_args.busy_state = args[ARG_busy_state].u_bool;
+    construct_args.seconds_per_frame = seconds_per_frame;
+    construct_args.always_toggle_chip_select = args[ARG_always_toggle_chip_select].u_bool;
+    construct_args.grayscale = args[ARG_grayscale].u_bool;
+    construct_args.acep = args[ARG_advanced_color_epaper].u_bool;
+    construct_args.spectra6 = args[ARG_spectra6].u_bool;
+    construct_args.two_byte_sequence_length = two_byte_sequence_length;
+    construct_args.address_little_endian = args[ARG_address_little_endian].u_bool;
+    common_hal_epaperdisplay_epaperdisplay_construct(self, &construct_args);
 
     return self;
 }

--- a/shared-bindings/epaperdisplay/EPaperDisplay.h
+++ b/shared-bindings/epaperdisplay/EPaperDisplay.h
@@ -15,19 +15,84 @@ extern const mp_obj_type_t epaperdisplay_epaperdisplay_type;
 
 #define NO_COMMAND 0x100
 
+typedef struct {
+    mp_obj_t bus;
+    const uint8_t *start_sequence;
+    uint16_t start_sequence_len;
+    mp_float_t start_up_time;
+    const uint8_t *stop_sequence;
+    uint16_t stop_sequence_len;
+    uint16_t width;
+    uint16_t height;
+    uint16_t ram_width;
+    uint16_t ram_height;
+    int16_t colstart;
+    int16_t rowstart;
+    uint16_t rotation;
+    uint16_t set_column_window_command;
+    uint16_t set_row_window_command;
+    uint16_t set_current_column_command;
+    uint16_t set_current_row_command;
+    uint16_t write_black_ram_command;
+    bool black_bits_inverted;
+    uint16_t write_color_ram_command;
+    bool color_bits_inverted;
+    uint32_t highlight_color;
+    uint32_t highlight_color2;
+    const uint8_t *refresh_sequence;
+    uint16_t refresh_sequence_len;
+    mp_float_t refresh_time;
+    const mcu_pin_obj_t *busy_pin;
+    bool busy_state;
+    mp_float_t seconds_per_frame;
+    bool always_toggle_chip_select;
+    bool grayscale;
+    bool acep;
+    bool spectra6;
+    bool two_byte_sequence_length;
+    bool address_little_endian;
+} epaperdisplay_construct_args_t;
+
+#define EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS { \
+        .bus = mp_const_none, \
+        .start_sequence = NULL, \
+        .start_sequence_len = 0, \
+        .start_up_time = 0.0, \
+        .stop_sequence = NULL, \
+        .stop_sequence_len = 0, \
+        .width = 0, \
+        .height = 0, \
+        .ram_width = 0, \
+        .ram_height = 0, \
+        .colstart = 0, \
+        .rowstart = 0, \
+        .rotation = 0, \
+        .set_column_window_command = NO_COMMAND, \
+        .set_row_window_command = NO_COMMAND, \
+        .set_current_column_command = NO_COMMAND, \
+        .set_current_row_command = NO_COMMAND, \
+        .write_black_ram_command = NO_COMMAND, \
+        .black_bits_inverted = false, \
+        .write_color_ram_command = NO_COMMAND, \
+        .color_bits_inverted = false, \
+        .highlight_color = 0x000000, \
+        .highlight_color2 = 0x000000, \
+        .refresh_sequence = NULL, \
+        .refresh_sequence_len = 0, \
+        .refresh_time = 0.0, \
+        .busy_pin = NULL, \
+        .busy_state = false, \
+        .seconds_per_frame = 0.0, \
+        .always_toggle_chip_select = false, \
+        .grayscale = false, \
+        .acep = false, \
+        .spectra6 = false, \
+        .two_byte_sequence_length = false, \
+        .address_little_endian = false \
+}
+
 void common_hal_epaperdisplay_epaperdisplay_construct(epaperdisplay_epaperdisplay_obj_t *self,
-    mp_obj_t bus, const uint8_t *start_sequence, uint16_t start_sequence_len, mp_float_t start_up_time,
-    const uint8_t *stop_sequence, uint16_t stop_sequence_len,
-    uint16_t width, uint16_t height, uint16_t ram_width, uint16_t ram_height,
-    int16_t colstart, int16_t rowstart, uint16_t rotation,
-    uint16_t set_column_window_command, uint16_t set_row_window_command,
-    uint16_t set_current_column_command, uint16_t set_current_row_command,
-    uint16_t write_black_ram_command, bool black_bits_inverted,
-    uint16_t write_color_ram_command, bool color_bits_inverted, uint32_t highlight_color, uint32_t highlight_color2,
-    const uint8_t *refresh_sequence, uint16_t refresh_sequence_len, mp_float_t refresh_time,
-    const mcu_pin_obj_t *busy_pin, bool busy_state, mp_float_t seconds_per_frame,
-    bool always_toggle_chip_select, bool grayscale, bool acep, bool spectra6, bool two_byte_sequence_length,
-    bool address_little_endian);
+    const epaperdisplay_construct_args_t *args);
 
 bool common_hal_epaperdisplay_epaperdisplay_refresh(epaperdisplay_epaperdisplay_obj_t *self);
 

--- a/shared-module/epaperdisplay/EPaperDisplay.c
+++ b/shared-module/epaperdisplay/EPaperDisplay.c
@@ -26,82 +26,73 @@
 #define DELAY 0x80
 
 void common_hal_epaperdisplay_epaperdisplay_construct(epaperdisplay_epaperdisplay_obj_t *self,
-    mp_obj_t bus, const uint8_t *start_sequence, uint16_t start_sequence_len, mp_float_t start_up_time,
-    const uint8_t *stop_sequence, uint16_t stop_sequence_len,
-    uint16_t width, uint16_t height, uint16_t ram_width, uint16_t ram_height,
-    int16_t colstart, int16_t rowstart, uint16_t rotation,
-    uint16_t set_column_window_command, uint16_t set_row_window_command,
-    uint16_t set_current_column_command, uint16_t set_current_row_command,
-    uint16_t write_black_ram_command, bool black_bits_inverted,
-    uint16_t write_color_ram_command, bool color_bits_inverted, uint32_t highlight_color, uint32_t highlight_color2,
-    const uint8_t *refresh_sequence, uint16_t refresh_sequence_len, mp_float_t refresh_time,
-    const mcu_pin_obj_t *busy_pin, bool busy_state, mp_float_t seconds_per_frame,
-    bool chip_select, bool grayscale, bool acep, bool spectra6, bool two_byte_sequence_length, bool address_little_endian) {
+    const epaperdisplay_construct_args_t *args) {
     uint16_t color_depth = 1;
     bool core_grayscale = true;
-    if (highlight_color != 0x000000) {
+    if (args->highlight_color != 0x000000) {
         self->core.colorspace.tricolor = true;
-        self->core.colorspace.tricolor_hue = displayio_colorconverter_compute_hue(highlight_color);
+        self->core.colorspace.tricolor_hue = displayio_colorconverter_compute_hue(args->highlight_color);
     } else {
         self->core.colorspace.tricolor = false;
     }
-    if (highlight_color != 0x000000 && highlight_color2 != 0x000000) {
+    if (args->highlight_color != 0x000000 && args->highlight_color2 != 0x000000) {
         self->core.colorspace.tricolor = false;
         self->core.colorspace.fourcolor = true;
-        self->core.colorspace.fourcolor_hue = displayio_colorconverter_compute_hue(highlight_color2);
+        self->core.colorspace.fourcolor_hue = displayio_colorconverter_compute_hue(args->highlight_color2);
     } else {
         self->core.colorspace.fourcolor = false;
     }
-    self->acep = acep || spectra6;
-    self->core.colorspace.sixcolor = spectra6;
-    self->core.colorspace.sevencolor = acep;
+    self->acep = args->acep || args->spectra6;
+    self->core.colorspace.sixcolor = args->spectra6;
+    self->core.colorspace.sevencolor = args->acep;
+    bool grayscale = args->grayscale;
     if (self->acep) {
         color_depth = 4; // bits. 7 colors + clean
         grayscale = false;
         core_grayscale = false;
     }
-    if ((highlight_color != 0x000000 || highlight_color2 != 0x000000) && write_color_ram_command == NO_COMMAND) {
+    if ((args->highlight_color != 0x000000 || args->highlight_color2 != 0x000000) && args->write_color_ram_command == NO_COMMAND) {
         color_depth = 2;
         core_grayscale = false;
         grayscale = false;
     }
 
-    displayio_display_core_construct(&self->core, width, height, rotation, color_depth, core_grayscale, true, 1, true, true);
-    displayio_display_bus_construct(&self->bus, bus, ram_width, ram_height,
-        colstart, rowstart,
-        set_column_window_command, set_row_window_command, set_current_column_command, set_current_row_command,
-        false /* data_as_commands */, chip_select,
-        false /* SH1107_addressing */, address_little_endian);
+    displayio_display_core_construct(&self->core, args->width, args->height, args->rotation, color_depth, core_grayscale, true, 1, true, true);
+    displayio_display_bus_construct(&self->bus, args->bus, args->ram_width, args->ram_height,
+        args->colstart, args->rowstart,
+        args->set_column_window_command, args->set_row_window_command, args->set_current_column_command, args->set_current_row_command,
+        false /* data_as_commands */, args->always_toggle_chip_select,
+        false /* SH1107_addressing */, args->address_little_endian);
 
-    self->write_black_ram_command = write_black_ram_command;
-    self->black_bits_inverted = black_bits_inverted;
-    self->write_color_ram_command = write_color_ram_command;
-    self->color_bits_inverted = color_bits_inverted;
-    self->refresh_time = refresh_time * 1000;
-    self->busy_state = busy_state;
+    self->write_black_ram_command = args->write_black_ram_command;
+    self->black_bits_inverted = args->black_bits_inverted;
+    self->write_color_ram_command = args->write_color_ram_command;
+    self->color_bits_inverted = args->color_bits_inverted;
+    self->refresh_time = args->refresh_time * 1000;
+    self->busy_state = args->busy_state;
     self->refreshing = false;
-    self->milliseconds_per_frame = seconds_per_frame * 1000;
-    self->chip_select = chip_select ? CHIP_SELECT_TOGGLE_EVERY_BYTE : CHIP_SELECT_UNTOUCHED;
+    self->milliseconds_per_frame = args->seconds_per_frame * 1000;
+    self->chip_select = args->always_toggle_chip_select ? CHIP_SELECT_TOGGLE_EVERY_BYTE : CHIP_SELECT_UNTOUCHED;
     self->grayscale = grayscale;
 
-    self->start_sequence = start_sequence;
-    self->start_sequence_len = start_sequence_len;
-    self->start_up_time_ms = start_up_time * 1000;
-    self->stop_sequence = stop_sequence;
-    self->stop_sequence_len = stop_sequence_len;
-    self->refresh_sequence = refresh_sequence;
-    self->refresh_sequence_len = refresh_sequence_len;
+    self->start_sequence = args->start_sequence;
+    self->start_sequence_len = args->start_sequence_len;
+    self->start_up_time_ms = args->start_up_time * 1000;
+    self->stop_sequence = args->stop_sequence;
+    self->stop_sequence_len = args->stop_sequence_len;
+    self->refresh_sequence = args->refresh_sequence;
+    self->refresh_sequence_len = args->refresh_sequence_len;
 
     self->busy.base.type = &mp_type_NoneType;
-    self->two_byte_sequence_length = two_byte_sequence_length;
-    if (busy_pin != NULL) {
+    self->two_byte_sequence_length = args->two_byte_sequence_length;
+    if (args->busy_pin != NULL) {
         self->busy.base.type = &digitalio_digitalinout_type;
-        common_hal_digitalio_digitalinout_construct(&self->busy, busy_pin);
-        common_hal_never_reset_pin(busy_pin);
+        common_hal_digitalio_digitalinout_construct(&self->busy, args->busy_pin);
+        common_hal_never_reset_pin(args->busy_pin);
     }
 
     // Clear the color memory if it isn't in use.
-    if (highlight_color == 0x00 && highlight_color2 == 0x00 && write_color_ram_command != NO_COMMAND) {
+    if (args->highlight_color == 0x00 && args->highlight_color2 == 0x00 && args->write_color_ram_command != NO_COMMAND) {
         // TODO: Clear
     }
 


### PR DESCRIPTION
Claude helped with initial prompt:

> Refactor common_hal_epaperdisplay_epaperdisplay_construct so that the current arguments are struct fields and then the function only takes the struct. Also add a macro that initializes it to default values.

And one follow up prompt before minor manual cleanup and testing:

> Clean up board files by removing settings that match the default. In particular bools that are false should be default, commands with NO_COMMAND and highlight color as 0.

For issue #10528
