### PR TITLE
Add `synthio.MidiTrack.tempo` property

### DIFF
--- a/shared-bindings/synthio/MidiTrack.c
+++ b/shared-bindings/synthio/MidiTrack.c
@@ -115,6 +115,27 @@ static void check_for_deinit(synthio_miditrack_obj_t *self) {
 //|     """32 bit value that tells how quickly samples are played in Hertz (cycles per second)."""
 //|
 
+//|     tempo: int
+//|     """Tempo of the streamed events, in MIDI ticks per second."""
+//|
+static mp_obj_t synthio_miditrack_obj_get_tempo(mp_obj_t self_in) {
+    synthio_miditrack_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    check_for_deinit(self);
+    return mp_obj_new_int(common_hal_synthio_miditrack_get_tempo(self));
+}
+MP_DEFINE_CONST_FUN_OBJ_1(synthio_miditrack_get_tempo_obj, synthio_miditrack_obj_get_tempo);
+
+static mp_obj_t synthio_miditrack_obj_set_tempo(mp_obj_t self_in, mp_obj_t arg) {
+    synthio_miditrack_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    check_for_deinit(self);
+    common_hal_synthio_miditrack_set_tempo(self, mp_obj_get_int(arg));
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_2(synthio_miditrack_set_tempo_obj, synthio_miditrack_obj_set_tempo);
+MP_PROPERTY_GETSET(synthio_miditrack_tempo_obj,
+    (mp_obj_t)&synthio_miditrack_get_tempo_obj,
+    (mp_obj_t)&synthio_miditrack_set_tempo_obj);
+
 //|     error_location: Optional[int]
 //|     """Offset, in bytes within the midi data, of a decoding error"""
 //|
@@ -141,6 +162,7 @@ static const mp_rom_map_elem_t synthio_miditrack_locals_dict_table[] = {
 
     // Properties
     { MP_ROM_QSTR(MP_QSTR_error_location), MP_ROM_PTR(&synthio_miditrack_error_location_obj) },
+    { MP_ROM_QSTR(MP_QSTR_tempo), MP_ROM_PTR(&synthio_miditrack_tempo_obj) },
     AUDIOSAMPLE_FIELDS,
 };
 static MP_DEFINE_CONST_DICT(synthio_miditrack_locals_dict, synthio_miditrack_locals_dict_table);

--- a/shared-bindings/synthio/MidiTrack.h
+++ b/shared-bindings/synthio/MidiTrack.h
@@ -15,3 +15,6 @@ void common_hal_synthio_miditrack_construct(synthio_miditrack_obj_t *self, const
 
 void common_hal_synthio_miditrack_deinit(synthio_miditrack_obj_t *self);
 mp_int_t common_hal_synthio_miditrack_get_error_location(synthio_miditrack_obj_t *self);
+
+mp_int_t common_hal_synthio_miditrack_get_tempo(synthio_miditrack_obj_t *self);
+void common_hal_synthio_miditrack_set_tempo(synthio_miditrack_obj_t *self, mp_int_t value);

--- a/shared-module/synthio/MidiTrack.c
+++ b/shared-module/synthio/MidiTrack.c
@@ -116,6 +116,15 @@ mp_int_t common_hal_synthio_miditrack_get_error_location(synthio_miditrack_obj_t
     return self->error_location;
 }
 
+mp_int_t common_hal_synthio_miditrack_get_tempo(synthio_miditrack_obj_t *self) {
+    return self->tempo;
+}
+
+void common_hal_synthio_miditrack_set_tempo(synthio_miditrack_obj_t *self, mp_int_t value) {
+    mp_int_t val = mp_arg_validate_int_min(value, 1, MP_QSTR_tempo);
+    self->tempo = val;
+}
+
 void synthio_miditrack_reset_buffer(synthio_miditrack_obj_t *self,
     bool single_channel_output, uint8_t channel) {
     synthio_synth_reset_buffer(&self->synth, single_channel_output, channel);


### PR DESCRIPTION
This update allows the tempo of a `synthio.MidiTrack` object to be manipulated after it has been constructed.

In my use case, I wanted to gradually increase the speed of a song within a game as it progresses.

Here is a demonstration of this property written for the Fruit Jam:
``` python3
import audiobusio
import audiomixer
import board
import synthio
import time

import adafruit_tlv320

# configure dac
i2c = board.I2C()
dac = adafruit_tlv320.TLV320DAC3100(i2c)
dac.configure_clocks(sample_rate=44100, bit_depth=16)

# use headphones
dac.headphone_output = True
dac.headphone_volume = -15  # dB

# setup audio output
audio = audiobusio.I2SOut(board.I2S_BCLK, board.I2S_WS, board.I2S_DIN)

# load melody
melody = synthio.MidiTrack(b"\0\x90H\0*\x80H\0\6\x90J\0*\x80J\0\6\x90L\0*\x80L\0\6\x90J\0" +
                           b"*\x80J\0\6\x90H\0*\x80H\0\6\x90J\0*\x80J\0\6\x90L\0T\x80L\0" +
                           b"\x0c\x90H\0T\x80H\0\x0c\x90H\0T\x80H\0",
                           tempo=640, sample_rate=dac.sample_rate)
audio.play(melody, loop=True)

# increase tempo by 2% every second
while True:
    time.sleep(1)
    melody.tempo = int(melody.tempo * 1.02)
```