### PR TITLE
Fix BusDisplay transaction handling

### DIFF
--- a/shared-module/displayio/bus_core.h
+++ b/shared-module/displayio/bus_core.h
@@ -47,7 +47,7 @@ bool displayio_display_bus_is_free(displayio_display_bus_t *self);
 bool displayio_display_bus_begin_transaction(displayio_display_bus_t *self);
 void displayio_display_bus_end_transaction(displayio_display_bus_t *self);
 
-void displayio_display_bus_set_region_to_update(displayio_display_bus_t *self, displayio_display_core_t *display, displayio_area_t *area);
+bool displayio_display_bus_set_region_to_update(displayio_display_bus_t *self, displayio_display_core_t *display, displayio_area_t *area);
 
 void release_display_bus(displayio_display_bus_t *self);
 


### PR DESCRIPTION
Fixes #10569

I've tested on a m5stack_cores3 with no apparent regressions on display handling. This strangely does not resolve #10536 so some other issue must also be present, however I can see on an oscilloscope that the SPI bus is now being shared correctly between busdisplay and sdcardio. One thing to note is running spi = board.SPI(); spi.try_lock() will now prevent the screen from being updated until the lock is released - this is a limitation of the the hardware.

I have also applied the same/similar fixes to EPaperDisplay - however I do not have hardware to verify this.