### PR TITLE
allow HID usage of zero; at least one device does this

### DIFF
--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -98,7 +98,7 @@ static mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type, size_t n_args
     const uint16_t usage_page = usage_page_arg;
 
     const mp_int_t usage_arg = args[ARG_usage].u_int;
-    mp_arg_validate_int_range(usage_arg, 1, 0xFFFF, MP_QSTR_usage);
+    mp_arg_validate_int_range(usage_arg, 0, 0xFFFF, MP_QSTR_usage);
     const uint16_t usage = usage_arg;
 
     mp_obj_t report_ids = args[ARG_report_ids].u_obj;


### PR DESCRIPTION
- Fixes #10576.

Allow an HID usage of zero, even though it is "Undefined" in the HID spec: https://www.usb.org/sites/default/files/hut1_4.pdf. At least one known device has a usage of zero.
