### PR TITLE
Scale current duration when `MidiTrack.tempo` is set

### DIFF
--- a/shared-module/synthio/MidiTrack.c
+++ b/shared-module/synthio/MidiTrack.c
@@ -122,6 +122,7 @@ mp_int_t common_hal_synthio_miditrack_get_tempo(synthio_miditrack_obj_t *self) {
 
 void common_hal_synthio_miditrack_set_tempo(synthio_miditrack_obj_t *self, mp_int_t value) {
     mp_int_t val = mp_arg_validate_int_min(value, 1, MP_QSTR_tempo);
+    self->synth.span.dur = (uint32_t)self->synth.span.dur * self->tempo / val;
     self->tempo = val;
 }
 


### PR DESCRIPTION
This is a minor bug fix for the changes introduced in https://github.com/adafruit/circuitpython/pull/10567.

When adjusting the tempo on a MidiTrack source that is actively playing, the current note (or pause) is set to a duration defined by the previous tempo value until it runs out and a new note (or pause) is played and the duration is recalculated. This can cause de-synchronization if two MidiTrack sources are playing concurrently.

This update simply scales the remaining duration (which is decremented with each sample) so that it is adjusted to the new tempo value.

The following example demonstrates this issue. The two tracks will eventually begin to drift away from each other while their tempo set to a random value every 2 seconds. After the update, they will remain in synchronization. This example is written for the Adafruit Fruit Jam using the onboard speaker.

``` python
# Adafruit CircuitPython 10.0.0-alpha.6-84-g56bff43e84-dirty on 2025-08-22; Adafruit Fruit Jam with rp2350b

import audiobusio
import audiomixer
import board
import displayio
import synthio
import random
import time

import adafruit_tlv320

TEMPO = 240
TEST = True

MIDI = (
    b'\x00\x90E\x7f\x81p\x80E\x00\x00\x90C\x7f\x81p\x80C\x00\x00\x90A\x7f\x81p\x80A\x00\x00\x90>\x7f\x81p\x80>\x00\x00\xff/\x00',
    b'\x00\x90>`\x81p\x80>\x00\x81p\x90;`\x81p\x80;\x00x\x907`x\x807\x00\x00\xff/\x00'
)

# disable REPL output over DVI
displayio.release_displays()

# setup dac
i2c = board.I2C()
dac = adafruit_tlv320.TLV320DAC3100(i2c)
dac.configure_clocks(sample_rate=22050, bit_depth=16)
dac.speaker_output = True
dac.dac_volume = 0

# setup audio
audio = audiobusio.I2SOut(board.I2S_BCLK, board.I2S_WS, board.I2S_DIN)
mixer = audiomixer.Mixer(voice_count=len(MIDI), channel_count=1, sample_rate=dac.sample_rate, bits_per_sample=dac.bit_depth)
audio.play(mixer)

# create midi tracks
tracks = [synthio.MidiTrack(x, tempo=TEMPO, sample_rate=dac.sample_rate) for x in MIDI]

# play
for i, track in enumerate(tracks):
    mixer.play(track, voice=i, loop=True)

while True:
    for i in range(2):
        tempo = random.randint(TEMPO//2, TEMPO*2)
        for track in tracks:
            track.tempo = tempo
        print(tempo)
        time.sleep(2)
```