### PR TITLE
claim usb_host pins on construction

### DIFF
--- a/ports/mimxrt10xx/common-hal/usb_host/Port.c
+++ b/ports/mimxrt10xx/common-hal/usb_host/Port.c
@@ -47,5 +47,8 @@ usb_host_port_obj_t *common_hal_usb_host_port_construct(const mcu_pin_obj_t *dp,
     self->dp = dp;
     self->dm = dm;
 
+    claim_pin(dp);
+    claim_pin(dm);
+
     return self;
 }

--- a/ports/raspberrypi/common-hal/usb_host/Port.c
+++ b/ports/raspberrypi/common-hal/usb_host/Port.c
@@ -146,6 +146,8 @@ usb_host_port_obj_t *common_hal_usb_host_port_construct(const mcu_pin_obj_t *dp,
     self->base.type = &usb_host_port_type;
     self->dp = dp;
     self->dm = dm;
+    claim_pin(dp);
+    claim_pin(dm);
 
     PIO pio = pio_get_instance(pio_cfg.pio_tx_num);
 


### PR DESCRIPTION
-- Fixes #10533 

On Fruit Jam and Metro RP2350, a `usb_host.Port` object is always created on restart, using `board.USB_HOST_DATA_MINUS` and `board.USB_HOST_DATA_PLUS`. However, the pins were not claimed in ` common_hal_usb_host_port_construct()`. This made them accidentally available for other uses, such as trying to create an `I2C` object, and could cause crashes.

This PR claims the pins so they can never be used for anything else, and prevents crashes. Perhaps it should be possible to `deinit()` the `usb_host.Port`, so you can use the pins for other purposes.  When the board is start, TinyUSB is initialized to use those pins as a USB host. I'm not sure whether it's possible to reverse the TinyUSB setup. There _is_ an `hcd_deinit()`, so maybe it is. Any comments on this welcome.

I tested that trying to the use pins for some other purpose raises an exception like `ValueError: USB_HOST_DATA_MINUS in use`.

EDIT: I started doing this by adding a `usb_host.port` (kind of like `microcontroller.cpu`) and added `usb_host.Port.deinit()`, but ran into some dilemmas about how to handle the "never reset" on the pins.

Since this fixes a bug where trying to reuse the pins for non-host purposes would already fail, we could leave this alone and open another issue to allow pin reuse later, after 10.0.0.



