### PR TITLE
allow filename for mp3decoder.file property

### DIFF
--- a/shared-bindings/audiomp3/MP3Decoder.c
+++ b/shared-bindings/audiomp3/MP3Decoder.c
@@ -139,8 +139,8 @@ static void check_for_deinit(audiomp3_mp3file_obj_t *self) {
 //|
 //  Provided by context manager helper.
 
-//|     file: Union[str, typing.BinaryIO] The name of a mp3 file (preferred) or an already opened mp3 file.
-//|     """File to play back."""
+//|     file: Union[str, typing.BinaryIO]
+//|     """The name of a mp3 file (preferred) or an already opened mp3 file."""
 //|
 static mp_obj_t audiomp3_mp3file_obj_get_file(mp_obj_t self_in) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);

--- a/shared-bindings/audiomp3/MP3Decoder.c
+++ b/shared-bindings/audiomp3/MP3Decoder.c
@@ -139,7 +139,7 @@ static void check_for_deinit(audiomp3_mp3file_obj_t *self) {
 //|
 //  Provided by context manager helper.
 
-//|     file: typing.BinaryIO
+//|     file: Union[str, typing.BinaryIO] The name of a mp3 file (preferred) or an already opened mp3 file.
 //|     """File to play back."""
 //|
 static mp_obj_t audiomp3_mp3file_obj_get_file(mp_obj_t self_in) {
@@ -152,6 +152,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiomp3_mp3file_get_file_obj, audiomp3_mp3file_obj_ge
 static mp_obj_t audiomp3_mp3file_obj_set_file(mp_obj_t self_in, mp_obj_t stream) {
     audiomp3_mp3file_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
+    if (mp_obj_is_str(stream)) {
+        stream = mp_call_function_2(MP_OBJ_FROM_PTR(&mp_builtin_open_obj), stream, MP_ROM_QSTR(MP_QSTR_rb));
+    }
     const mp_stream_p_t *stream_p = mp_get_stream_raise(stream, MP_STREAM_OP_READ);
 
     if (stream_p->is_text) {


### PR DESCRIPTION
The learn guide here: https://learn.adafruit.com/circuitpython-essentials/circuitpython-mp3-audio mentions:
> Because creating an MP3Decoder object takes a lot of memory, it's best to do this just once when your program starts, and then update the .file property of the MP3Decoder when you want to play a different file.  Otherwise, you may encounter the dreaded MemoryError.

And the constructor of MP3Decoder notes about the `file` argument https://docs.circuitpython.org/en/latest/shared-bindings/audiomp3/index.html#audiomp3.MP3Decoder
> file (Union[[str](https://docs.python.org/3/library/stdtypes.html#str), [BinaryIO](https://docs.python.org/3/library/typing.html#typing.BinaryIO)]) – The name of a mp3 file (preferred) or an already opened mp3 file

So the learn guide recommends to use `.file` property if you will be playing more than one different mp3 file, and the MP3Decoder constructor docs recommend to use a string instead of an open file. But currently the `.file` property only allows an open file to be set, not a string with a filename.

This PR updates the `.file` property to allow it to accept a string with the filename the same way that the constructor does so that both recommendations can be followed by user code. 

Originally noticed here: https://github.com/adafruit/Adafruit_CircuitPython_FruitJam/pull/15 I will update the code there to make use of this functionality if this gets merged. 