### PR TITLE
Add RTC module to ports/analog for MAX32690_apard

### DIFF
--- a/ports/analog/common-hal/rtc/RTC.c
+++ b/ports/analog/common-hal/rtc/RTC.c
@@ -1,0 +1,42 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2019 Nick Moore for Adafruit Industries
+// SPDX-FileCopyrightText: Copyright (c) 2019 Artur Pacholec
+// SPDX-FileCopyrightText: Copyright (c) 2025 Peggy Zhu, Analog Devices, Inc.
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdlib.h>
+
+#include "py/obj.h"
+#include "py/runtime.h"
+#include "shared/timeutils/timeutils.h"
+#include "supervisor/port.h"
+
+// This is the time in seconds since 2000 that the RTC was started.
+// TODO: Change the offset to ticks so that it can be a subsecond adjustment.
+static uint32_t rtc_offset = 0;
+
+void common_hal_rtc_get_time(timeutils_struct_time_t *tm) {
+    uint64_t ticks_s = port_get_raw_ticks(NULL) / 1024;
+    timeutils_seconds_since_2000_to_struct_time(rtc_offset + ticks_s, tm);
+}
+
+void common_hal_rtc_set_time(timeutils_struct_time_t *tm) {
+    uint64_t ticks_s = port_get_raw_ticks(NULL) / 1024;
+    uint32_t epoch_s = timeutils_seconds_since_2000(
+        tm->tm_year, tm->tm_mon, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec
+        );
+    rtc_offset = epoch_s - ticks_s;
+}
+
+// the calibration function will be implemented in near future
+// the RTC oscillator on my MAX32690-APARD is only off by 0.001 second
+// the inaccuracy is still tolerable
+int common_hal_rtc_get_calibration(void) {
+    return 0;
+}
+
+void common_hal_rtc_set_calibration(int calibration) {
+    mp_raise_NotImplementedError_varg(MP_ERROR_TEXT("%q"), MP_QSTR_calibration);
+}

--- a/ports/analog/common-hal/rtc/RTC.h
+++ b/ports/analog/common-hal/rtc/RTC.h
@@ -1,0 +1,11 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2018 Noralf Trønnes
+// SPDX-FileCopyrightText: Copyright (c) 2019 Artur Pacholec
+// SPDX-FileCopyrightText: Copyright (c) 2025 Peggy Zhu, Analog Devices, Inc.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+extern void rtc_reset(void);

--- a/ports/analog/common-hal/rtc/__init__.c
+++ b/ports/analog/common-hal/rtc/__init__.c
@@ -1,0 +1,6 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2024 Adafruit Industries LLC
+// SPDX-FileCopyrightText: Copyright (c) 2025 Peggy Zhu, Analog Devices, Inc.
+//
+// SPDX-License-Identifier: MIT

--- a/ports/analog/mpconfigport.mk
+++ b/ports/analog/mpconfigport.mk
@@ -24,7 +24,7 @@ INTERNAL_FLASH_FILESYSTEM = 1
 
 # Plan to implement
 CIRCUITPY_BUSIO ?= 0
-CIRCUITPY_RTC ?= 0
+CIRCUITPY_RTC ?= 1
 
 # Other modules (may or may not implement):
 CIRCUITPY_ANALOGIO ?= 0


### PR DESCRIPTION
# Summary
I added a port-specific module, RTC to ports/analog. Now the analog port can handle `rtc.set_time_source()`, `rtc.RTC()` and `r.datetime()`. Note that the RTC calibration functions (`common_hal_rtc_get_calibration()` and `common_hal_rtc_set_calibration()`) are not implemented and are planned for the near future.

The implementation in the RTC module also enables two functions in the time module, which are `time.time()` and `time.localtime()`.

The following example prints the current time once per second:
```
import time
import rtc

r = rtc.RTC)
r.datetime = time.struct_time((2000, 1, 1, 1, 1, 1, 0, -1, -1))

while(True):
    current_time = r.datetime
    print(current_time)
    time.sleep(1)
```
The expected output is:
```
struct_time(tm_year=2000, tm_mon=1, tm_mday=1, tm_hour=1, tm_min=1, tm_sec=1, tm_wday=5, tm_yday=1, tm_isdst=-1)
struct_time(tm_year=2000, tm_mon=1, tm_mday=1, tm_hour=1, tm_min=1, tm_sec=2, tm_wday=5, tm_yday=1, tm_isdst=-1)
struct_time(tm_year=2000, tm_mon=1, tm_mday=1, tm_hour=1, tm_min=1, tm_sec=3, tm_wday=5, tm_yday=1, tm_isdst=-1)
struct_time(tm_year=2000, tm_mon=1, tm_mday=1, tm_hour=1, tm_min=1, tm_sec=4, tm_wday=5, tm_yday=1, tm_isdst=-1)
struct_time(tm_year=2000, tm_mon=1, tm_mday=1, tm_hour=1, tm_min=1, tm_sec=5, tm_wday=5, tm_yday=1, tm_isdst=-1)
struct_time(tm_year=2000, tm_mon=1, tm_mday=1, tm_hour=1, tm_min=1, tm_sec=6, tm_wday=5, tm_yday=1, tm_isdst=-1)
struct_time(tm_year=2000, tm_mon=1, tm_mday=1, tm_hour=1, tm_min=1, tm_sec=7, tm_wday=5, tm_yday=1, tm_isdst=-1)
```

The following example call functions from the time module that rely on the RTC module. Successful execution confirms that the newly integrated RTC module enables these related functions in the time module.
```
import time
import rtc

r = rtc.RTC()
r.datetime = time.struct_time((2000, 1, 1, 1, 1, 1, 0, -1, -1))
rtc.set_time_source(r)

time.time() // should return the current time in seconds since Jan 1, 1970
time.local(time) // should return the current time
```
An example of the expected output is:
```
946688527
struct_time(tm_year=2000, tm_mon=1, tm_mday=1, tm_hour=1, tm_min=2, tm_sec=27, tm_wday=5, tm_yday=1, tm_isdst=-1)
```

# Testing
After I finished implementing the module, I built and flashed the project in the `ports/analog` directory using OpenOCD with a J-Link device. After flashing `firmware.elf` to an [AD-APARD32690-SL](https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/ad-apard32690-sl.html), I ran the code snippets in both code.py and REPL and received expected results.