### PR TITLE
fix MICROPY_HW_MCU_NAME

### DIFF
--- a/ports/raspberrypi/boards/pimoroni_plasma2350/mpconfigboard.h
+++ b/ports/raspberrypi/boards/pimoroni_plasma2350/mpconfigboard.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MIT
 
 #define MICROPY_HW_BOARD_NAME "Pimoroni Plasma 2350"
-#define MICROPY_HW_MCU_NAME "rp2350b"
+#define MICROPY_HW_MCU_NAME "rp2350a"
 
 #define CIRCUITPY_RGB_STATUS_INVERTED_PWM
 #define CIRCUITPY_RGB_STATUS_R (&pin_GPIO16)

--- a/ports/raspberrypi/boards/pimoroni_plasma2350w/mpconfigboard.h
+++ b/ports/raspberrypi/boards/pimoroni_plasma2350w/mpconfigboard.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MIT
 
 #define MICROPY_HW_BOARD_NAME "Pimoroni Plasma 2350W"
-#define MICROPY_HW_MCU_NAME "rp2350A"
+#define MICROPY_HW_MCU_NAME "rp2350a"
 
 #define CIRCUITPY_RGB_STATUS_INVERTED_PWM
 #define CIRCUITPY_RGB_STATUS_R (&pin_GPIO16)


### PR DESCRIPTION
This fixes the MICROPY_HW_MCU_NAME for two Pimoroni boards. One was wrong, one used a capital 'A' instead of 'a' like the other boards.

Note that for all of the Waveshare-boards, the name is just 'rp2350'. If this is relevant, someone should look up the boards and fix it.
