### PR TITLE
Fix DVI blanking during SPI transactions

### DIFF
--- a/ports/raspberrypi/common-hal/busio/SPI.c
+++ b/ports/raspberrypi/common-hal/busio/SPI.c
@@ -182,7 +182,10 @@ static bool _transfer(busio_spi_obj_t *self,
         chan_tx = dma_claim_unused_channel(false);
         chan_rx = dma_claim_unused_channel(false);
     }
-    bool use_dma = chan_rx >= 0 && chan_tx >= 0;
+    bool has_dma_channels = chan_rx >= 0 && chan_tx >= 0;
+    // Only use DMA if both data buffers are in SRAM. Otherwise, we'll stall the DMA with PSRAM or flash cache misses.
+    bool data_in_sram = data_in >= (uint8_t *)SRAM_BASE && data_out >= (uint8_t *)SRAM_BASE;
+    bool use_dma = has_dma_channels && data_in_sram;
     if (use_dma) {
         dma_channel_config c = dma_channel_get_default_config(chan_tx);
         channel_config_set_transfer_data_size(&c, DMA_SIZE_8);


### PR DESCRIPTION
SPI was using DMA to transfer to PSRAM. When a cache miss occurs, the DMA can't switch to another transfer and throws off DVI timing.

So, only use DMA with SPI when the buffers are in SRAM. This will slow down SPI transactions when the FIFOs are empty and the CPU is busy running a background task. It will still be correct though since we control the SPI clock.

Fixes #10557
