### PR TITLE
Bls coin m0

### DIFF
--- a/ports/atmel-samd/boards/bradanlanestudio_coin_m0/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/bradanlanestudio_coin_m0/mpconfigboard.mk
@@ -38,7 +38,7 @@ CIRCUITPY_ROTARYIO = 0
 CIRCUITPY_RTC = 0
 CIRCUITPY_USB_HID = 1
 CIRCUITPY_USB_MIDI = 0
-
+CIRCUITPY_NEOPIXEL_WRITE = 1
 
 # Include these Python libraries in firmware.
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_HID

--- a/ports/atmel-samd/boards/bradanlanestudio_coin_m0/mpconfigboard.mk
+++ b/ports/atmel-samd/boards/bradanlanestudio_coin_m0/mpconfigboard.mk
@@ -39,6 +39,7 @@ CIRCUITPY_RTC = 0
 CIRCUITPY_USB_HID = 1
 CIRCUITPY_USB_MIDI = 0
 CIRCUITPY_NEOPIXEL_WRITE = 1
+CIRCUITPY_PIXELBUF = 1
 
 # Include these Python libraries in firmware.
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_HID


### PR DESCRIPTION
This pull request is to add the `neopixel_write` and `pixelbuf` modules to the build for the COIN_M0. This is to enable 'out of the box' support for neopixels ~(which is already a frozen library for the board)_.

A full new CircuitPython 10 build environment was used to build and deploy. The contents of `boot_out.txt` are provided for reference:
```
Adafruit CircuitPython 10.0.0-beta.2-23-g4b2624a27b on 2025-08-29; Bradán Lane STUDIO Coin M0 with samd21g18
Board ID:bradanlanestudio_coin_m0
UID:296759F1464A305020312E46273314FF
```