### PR TITLE
Fix radio union type hints

### DIFF
--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -99,7 +99,7 @@ MP_PROPERTY_GETSET(wifi_radio_enabled_obj,
     (mp_obj_t)&wifi_radio_get_enabled_obj,
     (mp_obj_t)&wifi_radio_set_enabled_obj);
 
-//|     hostname: Union[str | ReadableBuffer]
+//|     hostname: Union[str, ReadableBuffer]
 //|     """Hostname for wifi interface. When the hostname is altered after interface started/connected
 //|        the changes would only be reflected once the interface restarts/reconnects."""
 static mp_obj_t wifi_radio_get_hostname(mp_obj_t self_in) {
@@ -325,8 +325,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(wifi_radio_stop_station_obj, wifi_radio_stop_station);
 
 //|     def start_ap(
 //|         self,
-//|         ssid: Union[str | ReadableBuffer],
-//|         password: Union[str | ReadableBuffer] = b"",
+//|         ssid: Union[str, ReadableBuffer],
+//|         password: Union[str, ReadableBuffer] = b"",
 //|         *,
 //|         channel: int = 1,
 //|         authmode: Iterable[AuthMode] = (),
@@ -438,11 +438,11 @@ MP_PROPERTY_GETTER(wifi_radio_ap_active_obj,
 
 //|     def connect(
 //|         self,
-//|         ssid: Union[str | ReadableBuffer],
-//|         password: Union[str | ReadableBuffer] = b"",
+//|         ssid: Union[str, ReadableBuffer],
+//|         password: Union[str, ReadableBuffer] = b"",
 //|         *,
 //|         channel: int = 0,
-//|         bssid: Optional[Union[str | ReadableBuffer]] = None,
+//|         bssid: Optional[Union[str, ReadableBuffer]] = None,
 //|         timeout: Optional[float] = None,
 //|     ) -> None:
 //|         """Connects to the given ssid and waits for an ip address. Reconnections are handled


### PR DESCRIPTION
Hey team,

This PR fixes the syntax used to specify `Union` type hints used in `Radio`. `Union`s can be declared as either `Union[type1, type2]` or `type1 | type2` (after Python 3.10). This PR chooses the first option to stay consistent with the rest of the CircuitPython repo.

Thoughts?