### PR TITLE
Fix `struct_time` and `time.localtime()` type hints

### DIFF
--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -83,6 +83,16 @@ static mp_obj_t struct_time_make_new(const mp_obj_type_t *type, size_t n_args, s
 }
 
 //| class struct_time:
+//|     tm_year: int
+//|     tm_mon: int
+//|     tm_mday: int
+//|     tm_hour: int
+//|     tm_min: int
+//|     tm_sec: int
+//|     tm_wday: int
+//|     tm_yday: int
+//|     tm_isdst: int
+//|
 //|     def __init__(self, time_tuple: Sequence[int]) -> None:
 //|         """Structure used to capture a date and time.  Can be constructed from a `struct_time`, `tuple`, `list`, or `namedtuple` with 9 elements.
 //|
@@ -210,7 +220,7 @@ static mp_obj_t time_monotonic_ns(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(time_monotonic_ns_obj, time_monotonic_ns);
 
-//| def localtime(secs: int) -> struct_time:
+//| def localtime(secs: Optional[int] = None) -> struct_time:
 //|     """Convert a time expressed in seconds since Jan 1, 1970 to a struct_time in
 //|     local time. If secs is not provided or None, the current time as returned
 //|     by time() is used.


### PR DESCRIPTION
Hey again team,

This PR fixes the type hints for `struct_time` and `time.localtime()`. 

### `struct_time` type error

<img width="776" height="353" alt="Captura de pantalla 2025-08-31 a la(s) 00 33 38" src="https://github.com/user-attachments/assets/96c89604-3ad5-43b2-be73-3ba95e702939" />

### `time.localtime()` type error
<img width="567" height="155" alt="Captura de pantalla 2025-08-31 a la(s) 00 33 26" src="https://github.com/user-attachments/assets/705abb42-92ef-4442-a3d7-9efe357606a4" />

⚠️ This requires a new import (`Optional`) and I'm not sure where to specify that or if it's autodetected when generating the timehints?

Thoughts?