### PR TITLE
RP2xxx: put LWIP storage ops in a critical section

### DIFF
--- a/ports/raspberrypi/lwip_src/lwip_mem.c
+++ b/ports/raspberrypi/lwip_src/lwip_mem.c
@@ -8,14 +8,20 @@
 #include <string.h>
 #include "lib/tlsf/tlsf.h"
 #include "lwip_mem.h"
+#include "shared-bindings/microcontroller/__init__.h"
 #include "supervisor/port_heap.h"
 
 void *lwip_heap_malloc(size_t size) {
-    return port_malloc(size, true);
+    common_hal_mcu_disable_interrupts();
+    void *ptr = port_malloc(size, true);
+    common_hal_mcu_enable_interrupts();
+    return ptr;
 }
 
 void lwip_heap_free(void *ptr) {
+    common_hal_mcu_disable_interrupts();
     port_free(ptr);
+    common_hal_mcu_enable_interrupts();
 }
 
 void *lwip_heap_calloc(size_t num, size_t size) {


### PR DESCRIPTION
- Fixes #10455 

#10027 (added in 9.2.5) considerably improved network performance on Pi Pico by using dynamic storage allocation in LWIP. However, it turns out LWIP can do heap operations during interrupts. Thus the operations need to be guarded in critical sections. Otherwise there are storage-related crashes at random intervals, and I saw storage assertion violations in gdb when a crash happened.

Tested on a Pico W, with a simple test program that did an HTTP fetch from a local server 10 times a second.

On a Pico 2 W, I was unable to cause the original problem before a fix, but the fix doesn't seem to break things either.

@gsexton, @anecdata, and/or @bablokb would you be willing to do some stress testing on this? I did a little other testing but I don't have many interesting test programs. Thanks. And @gsexton could you see if it fixes the original problem you saw?

