### PR TITLE
Improve usb.core.Device error handling REV 2

### DIFF
--- a/shared-module/usb/core/Device.c
+++ b/shared-module/usb/core/Device.c
@@ -355,7 +355,11 @@ mp_int_t common_hal_usb_core_device_ctrl_transfer(usb_core_device_obj_t *self,
         .complete_cb = _transfer_done_cb,
     };
 
+    // Prepare for transfer. Unless there is a timeout, these static globals will
+    // get modified by the _transfer_done_cb() callback when tinyusb finishes the
+    // transfer or encounters an error condition.
     _xfer_result = XFER_RESULT_INVALID;
+    _actual_len = 0;
 
     if (!tuh_control_xfer(&xfer)) {
         mp_raise_usb_core_USBError(NULL);
@@ -377,7 +381,7 @@ mp_int_t common_hal_usb_core_device_ctrl_transfer(usb_core_device_obj_t *self,
     _xfer_result = XFER_RESULT_INVALID;
     switch (result) {
         case XFER_RESULT_SUCCESS:
-            return len;
+            return _actual_len;
         case XFER_RESULT_FAILED:
             break;
         case XFER_RESULT_STALLED:

--- a/shared-module/usb/core/Device.c
+++ b/shared-module/usb/core/Device.c
@@ -132,7 +132,7 @@ static size_t _handle_timed_transfer_callback(tuh_xfer_t *xfer, mp_int_t timeout
         tuh_edpt_abort_xfer(xfer->daddr, xfer->ep_addr);
         return 0;
     }
-    // Handle control transfer result code from TinyUSB
+    // Handle transfer result code from TinyUSB
     xfer_result_t result = _xfer_result;
     _xfer_result = XFER_RESULT_INVALID;
     switch (result) {

--- a/shared-module/usb/core/Device.c
+++ b/shared-module/usb/core/Device.c
@@ -1,6 +1,7 @@
 // This file is part of the CircuitPython project: https://circuitpython.org
 //
 // SPDX-FileCopyrightText: Copyright (c) 2022 Scott Shawcroft for Adafruit Industries
+// SPDX-FileCopyrightText: Copyright (c) 2025 Sam Blenny
 //
 // SPDX-License-Identifier: MIT
 
@@ -70,14 +71,18 @@ void common_hal_usb_core_device_deinit(usb_core_device_obj_t *self) {
 uint16_t common_hal_usb_core_device_get_idVendor(usb_core_device_obj_t *self) {
     uint16_t vid;
     uint16_t pid;
-    tuh_vid_pid_get(self->device_address, &vid, &pid);
+    if (!tuh_vid_pid_get(self->device_address, &vid, &pid)) {
+        mp_raise_usb_core_USBError(NULL);
+    }
     return vid;
 }
 
 uint16_t common_hal_usb_core_device_get_idProduct(usb_core_device_obj_t *self) {
     uint16_t vid;
     uint16_t pid;
-    tuh_vid_pid_get(self->device_address, &vid, &pid);
+    if (!tuh_vid_pid_get(self->device_address, &vid, &pid)) {
+        mp_raise_usb_core_USBError(NULL);
+    }
     return pid;
 }
 


### PR DESCRIPTION
This is a second attempt at
- https://github.com/adafruit/circuitpython/pull/10611

with a smaller set of changes to usb.core.Device error handling:
1. Instances where `0xff` (not a valid enum value) was assigned to the `static xfer_result_t _xfer_result;` variable (an enum type) are converted to using `XFER_RESULT_INVALID` (a valid enum value). Both values were used to indicate the condition of waiting for a callback to finish. This change makes usage in usb.core.Device consistent with usage in the TinyUSB implementation.
2. Callback result code checks are converted from partial coverage using `if` statements to a `switch` statement that fully covers all the possible enum values. In particular, this new code will raise a `USBError` exception in the case of `result == XFER_RESULT_FAILED` (old behavior was to return the buffer's previous contents -- all zeros for a freshly allocated array or undefined garbage for a previously used array -- without indicating any error condition).
3. Factor out timeout and result checking code that was previously duplicated in `_xfer()` and `common_hal_usb_core_device_ctrl_transfer()`.
4. Fix control transfer return value to give actual length (was returning requested length)
5. Fix missing error handling for `usb.core.Device.idVendor` and `usb.core.Device.idProduct`
6. [**edit 9/6**] Fix missing error handling for `usb.core.Device.product`, `usb.core.Device.manufacturer`, and `usb.core.Device.serial_number`

Checks:
- [x] pre-commit
- [x] build & run for Fruit Jam

## Testing

### Test Code:
```python
import displayio
import gc
import usb
import time
from usb.core import USBError, USBTimeoutError

def test_unplug_during_find():
    # This tests how repeated calls to usb.core.find() behave in the
    # context of unplugging a USB device.
    cache = {}
    print("Finding USB devices...")
    while True:
        try:
            for device in usb.core.find(find_all=True):
                # Read 18 byte device descriptor
                desc = bytearray(18)
                device.ctrl_transfer(0x80, 6, 0x01 << 8, 0, desc, 300)
                # Validate descriptor
                key_ = tuple(desc)
                all_zero = all([b==0 for b in desc])
                if all_zero:
                    # Got bad data
                    print("bad data:", key_)
                    continue
                elif key_ in cache:
                    # Descriptor is valid but cached, skip device
                    continue
                # Otherwise, print properties and add to cache
                cache[key_] = True
                print_descriptor_properties(device)
                print(cache)
        except USBTimeoutError as e:
            print("USBTimeoutError: '%s'" % str(e))
        except USBError as e:
            print(f"USBError: '%s'; clear cache, sleep 20ms" % str(e))
            cache.clear()
            # This delay allows TinyUSB to recover from failures
            time.sleep(0.02)

def print_descriptor_properties(device):
    print()
    print(f"idVendor      {device.idVendor:04x}")
    print(f"idProduct     {device.idProduct:04x}")
    print(f"product       {device.product}")
    print(f"manufacturer  {device.manufacturer}")
    print(f"serial_number {device.serial_number}")

displayio.release_displays()
gc.collect()
test_unplug_during_find()
```

### Test Hardware:
- Adafruit Fruit Jam rev D
- 8BitDo SN30 pro gamepad (as shown in example below)
- Various other USB devices including the Adafruit generic SNES style gamepad

### Test Results Before Changes (10.0.0-beta.3):
```
Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
Finding USB devices...

idVendor      045e
idProduct     028e
product       Controller
manufacturer  Controller
serial_number Controller
{(18, 1, 0, 2, 255, 255, 255, 64, 94, 4, 142, 2, 20, 1, 1, 2, 3, 1): True}
bad data: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
bad data: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
bad data: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
bad data: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
bad data: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
bad data: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
...
```
Note how usb.core.Device.ctrl_transfer() begins returning all zero result buffers. This continues for as long as I let it run.

### Test Results After Changes:

```
Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
Finding USB devices...

idVendor      045e
idProduct     028e
product       Controller
manufacturer  Controller
serial_number Controller
{(18, 1, 0, 2, 255, 255, 255, 64, 94, 4, 142, 2, 20, 1, 1, 2, 3, 1): True}
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms

idVendor      057e
idProduct     2009
product       Pro Controller
manufacturer  Nintendo Co., Ltd.
serial_number 000000000001
{(18, 1, 0, 2, 0, 0, 0, 64, 126, 5, 9, 32, 0, 2, 1, 2, 3, 1): True}
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms

idVendor      045e
idProduct     028e
product       Controller
manufacturer  Controller
serial_number Controller
{(18, 1, 0, 2, 255, 255, 255, 64, 94, 4, 142, 2, 20, 1, 1, 2, 3, 1): True}
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms

idVendor      081f
idProduct     e401
product       USB gamepad           
manufacturer  None
serial_number None
{(18, 1, 0, 1, 0, 0, 0, 8, 31, 8, 1, 228, 6, 1, 0, 2, 0, 1): True}
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms
USBError: ''; clear cache, sleep 20ms
```

In this case, I plugged in an SN30 pro which has a weird startup sequence where it disconnects itself and swaps device descriptors a couple times. The first 3 descriptor info prints are from plugging in the SN30 pro. After that, I unplugged it, producing a series of 3 USBErrors. After that, I plugged in an Adafruit generic SNES style gamepad.

Note how there isn't any bad data, and the code can let TinyUSB auto-recover from unplugged (or self-disconnected) devices by sleeping for 20ms after it gets a USBError.

[**edit 9/6**: added `serial_number` to test code and test results]