### PR TITLE
Better error when mistakenly importing MicroPython .mpy file

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1394,6 +1394,10 @@ msgstr ""
 msgid "Mapping must be a tuple"
 msgstr ""
 
+#: py/persistentcode.c
+msgid "MicroPython .mpy file; use CircuitPython mpy-cross"
+msgstr ""
+
 #: ports/raspberrypi/bindings/rp2pio/StateMachine.c
 #: ports/raspberrypi/common-hal/rp2pio/StateMachine.c
 msgid "Mismatched data size"

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -471,6 +471,9 @@ void mp_raw_code_load(mp_reader_t *reader, mp_compiled_module_t *cm) {
     read_bytes(reader, header, sizeof(header));
     byte arch = MPY_FEATURE_DECODE_ARCH(header[2]);
     // CIRCUITPY-CHANGE: 'C', not 'M'
+    if (header[0] == 'M') {
+        mp_raise_ValueError(MP_ERROR_TEXT("MicroPython .mpy file; use CircuitPython mpy-cross"));
+    }
     if (header[0] != 'C'
         || header[1] != MPY_VERSION
         || (arch != MP_NATIVE_ARCH_NONE && MPY_FEATURE_DECODE_SUB_VERSION(header[2]) != MPY_SUB_VERSION)


### PR DESCRIPTION
User `mephistophomin` in discord installed the MicroPython mpy-cross, and could not figure why their .mpy files were incompatible.

Test for `M` in the header, and give a better error.

Tested with a MicroPython .mpy file on a QT Py RP2040.
