### PR TITLE
py/builtinimport.c: always name module in error msg when an import fails

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -451,7 +451,9 @@ static mp_obj_t process_import_at_level(qstr full_mod_name, qstr level_mod_name,
 
     if (stat == MP_IMPORT_STAT_NO_EXIST) {
         // Not found -- fail.
-        #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
+        // CIRCUITPY-CHANGE: always the use more verbose error message that names missing module.
+        // Otherwise `import a` where `a` imports `b`, but `b` is missing will give a confusing error.
+        #if 0 && (MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE)
         mp_raise_msg(&mp_type_ImportError, MP_ERROR_TEXT("module not found"));
         #else
         mp_raise_msg_varg(&mp_type_ImportError, MP_ERROR_TEXT("no module named '%q'"), full_mod_name);


### PR DESCRIPTION
On the smallest boards, we use terse error messages to save space. Usually this is fine, but the `module not found` error is confusing, because on casual glance it can make it appear that a module being imported is missing, instead of some subsequent import being missing. Use the regular more verbose message instead, which names the missing module.

I've seen several users be confused by this and resort to asking a support question. This happened most recently in discord.

Example and test:

Old way, which causes a number of users to say, "but I _did_ add neopixel as a library":
```py
Adafruit CircuitPython 10.0.0-beta.3 on 2025-08-29; Adafruit Gemma M0 with samd21e18
>>> import neopixel
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "neopixel.py", line 17, in <module>
ImportError: module not found
```
Clearer message:
```py
Adafruit CircuitPython 10.0.0-beta.3-12-gc382b55a6d-dirty on 2025-09-11; Adafruit Gemma M0 with samd21e18
>>> import neopixel
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "neopixel.py", line 17, in <module>
ImportError: no module named 'adafruit_pixelbuf'
```
