### PR TITLE
Further LWIP-related fixes

### DIFF
--- a/ports/espressif/common-hal/socketpool/Socket.c
+++ b/ports/espressif/common-hal/socketpool/Socket.c
@@ -483,7 +483,7 @@ void common_hal_socketpool_socket_connect(socketpool_socket_obj_t *self,
         socklen_t socklen = sizeof(error_code);
         result = getsockopt(self->num, SOL_SOCKET, SO_ERROR, &error_code, &socklen);
         if (result < 0 || error_code != 0) {
-            mp_raise_OSError(errno);
+            mp_raise_OSError(error_code);
         }
         self->connected = true;
         return;

--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -89,7 +89,7 @@ static mp_obj_t socketpool_ip_addr_and_port_to_tuple(const ip_addr_t *addr, int 
 // socket API.
 
 // Extension to lwIP error codes
-// Matches lwIP 2.0.3
+// Matches lwIP 2.2.1
 #undef _ERR_BADF
 #define _ERR_BADF -17
 static const int error_lookup_table[] = {
@@ -473,7 +473,12 @@ static mp_uint_t lwip_tcp_send(socketpool_socket_obj_t *socket, const byte *buf,
 
     MICROPY_PY_LWIP_ENTER
 
-    u16_t available = tcp_sndbuf(socket->pcb.tcp);
+    // If the socket is still connecting then don't let data be written to it.
+    // Otherwise, get the number of available bytes in the output buffer.
+    u16_t available = 0;
+    if (socket->state != STATE_CONNECTING) {
+        available = tcp_sndbuf(socket->pcb.tcp);
+    }
 
     if (available == 0) {
         // Non-blocking socket
@@ -490,7 +495,8 @@ static mp_uint_t lwip_tcp_send(socketpool_socket_obj_t *socket, const byte *buf,
         // If peer fully closed socket, we would have socket->state set to ERR_RST (connection
         // reset) by error callback.
         // Avoid sending too small packets, so wait until at least 16 bytes available
-        while (socket->state >= STATE_CONNECTED && (available = tcp_sndbuf(socket->pcb.tcp)) < 16) {
+        while (socket->state == STATE_CONNECTING
+               || (socket->state >= STATE_CONNECTED && (available = tcp_sndbuf(socket->pcb.tcp)) < 16)) {
             MICROPY_PY_LWIP_EXIT
             if (socket->timeout != (unsigned)-1 && mp_hal_ticks_ms() - start > socket->timeout) {
                 *_errno = MP_ETIMEDOUT;
@@ -531,9 +537,10 @@ static mp_uint_t lwip_tcp_send(socketpool_socket_obj_t *socket, const byte *buf,
         MICROPY_PY_LWIP_REENTER
     }
 
-    // If the output buffer is getting full then send the data to the lower layers
-    if (err == ERR_OK && tcp_sndbuf(socket->pcb.tcp) < TCP_SND_BUF / 4) {
-        err = tcp_output(socket->pcb.tcp);
+    // Use nagle algorithm to determine when to send segment buffer (can be
+    // disabled with TCP_NODELAY socket option)
+    if (err == ERR_OK) {
+        err = tcp_output_nagle(socket->pcb.tcp);
     }
 
     MICROPY_PY_LWIP_EXIT
@@ -550,6 +557,12 @@ static mp_uint_t lwip_tcp_send(socketpool_socket_obj_t *socket, const byte *buf,
 static mp_uint_t lwip_tcp_receive(socketpool_socket_obj_t *socket, byte *buf, mp_uint_t len, int *_errno) {
     // Check for any pending errors
     STREAM_ERROR_CHECK(socket);
+
+    if (socket->state == STATE_LISTENING) {
+        // original socket in listening state, not the accepted connection.
+        *_errno = MP_ENOTCONN;
+        return -1;
+    }
 
     if (socket->incoming.pbuf == NULL) {
 

--- a/ports/raspberrypi/lwip_src/lwip_mem.c
+++ b/ports/raspberrypi/lwip_src/lwip_mem.c
@@ -12,16 +12,12 @@
 #include "supervisor/port_heap.h"
 
 void *lwip_heap_malloc(size_t size) {
-    common_hal_mcu_disable_interrupts();
     void *ptr = port_malloc(size, true);
-    common_hal_mcu_enable_interrupts();
     return ptr;
 }
 
 void lwip_heap_free(void *ptr) {
-    common_hal_mcu_disable_interrupts();
     port_free(ptr);
-    common_hal_mcu_enable_interrupts();
 }
 
 void *lwip_heap_calloc(size_t num, size_t size) {

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -264,31 +264,42 @@ void port_heap_init(void) {
 
 void *port_malloc(size_t size, bool dma_capable) {
     if (!dma_capable && _psram_size > 0) {
+        common_hal_mcu_disable_interrupts();
         void *block = tlsf_malloc(_psram_heap, size);
+        common_hal_mcu_enable_interrupts();
         if (block) {
             return block;
         }
     }
+    common_hal_mcu_disable_interrupts();
     void *block = tlsf_malloc(_heap, size);
+    common_hal_mcu_enable_interrupts();
     return block;
 }
 
 void port_free(void *ptr) {
+    common_hal_mcu_disable_interrupts();
     if (((size_t)ptr) < SRAM_BASE) {
         tlsf_free(_psram_heap, ptr);
     } else {
         tlsf_free(_heap, ptr);
     }
+    common_hal_mcu_enable_interrupts();
 }
 
 void *port_realloc(void *ptr, size_t size, bool dma_capable) {
     if (_psram_size > 0 && ((ptr != NULL && ((size_t)ptr) < SRAM_BASE) || (ptr == NULL && !dma_capable))) {
+        common_hal_mcu_disable_interrupts();
         void *block = tlsf_realloc(_psram_heap, ptr, size);
+        common_hal_mcu_enable_interrupts();
         if (block) {
             return block;
         }
     }
-    return tlsf_realloc(_heap, ptr, size);
+    common_hal_mcu_disable_interrupts();
+    void *new_ptr = tlsf_realloc(_heap, ptr, size);
+    common_hal_mcu_enable_interrupts();
+    return new_ptr;
 }
 
 static bool max_size_walker(void *ptr, size_t size, int used, void *user) {


### PR DESCRIPTION
- Fixes #10618 

---

- Make all `port_*` storage operations use critical sections, not just those for LWIP.
- Fix a bug in espressif that was raising the wrong error code on a `connect()` failure. Discovered in passing.

This is a draft for now because there still seem to be occasional crashes on CYW43, and I want to understand why a connect failure is ECONNRESET instead of ECONNREFUSED, as it is on Linux.

@anecdata FYI