### PR TITLE
Allow for audio chaining by returning `self` object from audio effects and audio mixer

### DIFF
--- a/shared-bindings/audiodelays/Chorus.c
+++ b/shared-bindings/audiodelays/Chorus.c
@@ -206,7 +206,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_chorus_get_playing_obj, audiodelays_chorus
 MP_PROPERTY_GETTER(audiodelays_chorus_playing_obj,
     (mp_obj_t)&audiodelays_chorus_get_playing_obj);
 
-//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> Chorus:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
@@ -228,7 +228,7 @@ static mp_obj_t audiodelays_chorus_obj_play(size_t n_args, const mp_obj_t *pos_a
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiodelays_chorus_play(self, sample, args[ARG_loop].u_bool);
 
-    return mp_const_none;
+    return pos_args[0];
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_chorus_play_obj, 1, audiodelays_chorus_obj_play);
 

--- a/shared-bindings/audiodelays/Chorus.c
+++ b/shared-bindings/audiodelays/Chorus.c
@@ -210,7 +210,11 @@ MP_PROPERTY_GETTER(audiodelays_chorus_playing_obj,
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         The sample must match the encoding settings given in the constructor."""
+//|         The sample must match the encoding settings given in the constructor.
+//|
+//|         :return: The effect object itself. Can be used for chaining, ie:
+//|           ``audio.play(effect.play(sample))``.
+//|         :rtype: Chorus"""
 //|         ...
 //|
 static mp_obj_t audiodelays_chorus_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/audiodelays/Chorus.c
+++ b/shared-bindings/audiodelays/Chorus.c
@@ -228,7 +228,7 @@ static mp_obj_t audiodelays_chorus_obj_play(size_t n_args, const mp_obj_t *pos_a
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiodelays_chorus_play(self, sample, args[ARG_loop].u_bool);
 
-    return pos_args[0];
+    return MP_OBJ_FROM_PTR(self);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_chorus_play_obj, 1, audiodelays_chorus_obj_play);
 

--- a/shared-bindings/audiodelays/Echo.c
+++ b/shared-bindings/audiodelays/Echo.c
@@ -230,7 +230,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_echo_get_playing_obj, audiodelays_echo_obj
 MP_PROPERTY_GETTER(audiodelays_echo_playing_obj,
     (mp_obj_t)&audiodelays_echo_get_playing_obj);
 
-//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> Echo:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
@@ -252,7 +252,7 @@ static mp_obj_t audiodelays_echo_obj_play(size_t n_args, const mp_obj_t *pos_arg
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiodelays_echo_play(self, sample, args[ARG_loop].u_bool);
 
-    return mp_const_none;
+    return pos_args[0];
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_echo_play_obj, 1, audiodelays_echo_obj_play);
 

--- a/shared-bindings/audiodelays/Echo.c
+++ b/shared-bindings/audiodelays/Echo.c
@@ -252,7 +252,7 @@ static mp_obj_t audiodelays_echo_obj_play(size_t n_args, const mp_obj_t *pos_arg
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiodelays_echo_play(self, sample, args[ARG_loop].u_bool);
 
-    return pos_args[0];
+    return MP_OBJ_FROM_PTR(self);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_echo_play_obj, 1, audiodelays_echo_obj_play);
 

--- a/shared-bindings/audiodelays/Echo.c
+++ b/shared-bindings/audiodelays/Echo.c
@@ -234,7 +234,11 @@ MP_PROPERTY_GETTER(audiodelays_echo_playing_obj,
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         The sample must match the encoding settings given in the constructor."""
+//|         The sample must match the encoding settings given in the constructor.
+//|
+//|         :return: The effect object itself. Can be used for chaining, ie:
+//|           ``audio.play(effect.play(sample))``.
+//|         :rtype: Echo"""
 //|         ...
 //|
 static mp_obj_t audiodelays_echo_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/audiodelays/MultiTapDelay.c
+++ b/shared-bindings/audiodelays/MultiTapDelay.c
@@ -233,7 +233,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiodelays_multi_tap_delay_get_playing_obj, audiodela
 MP_PROPERTY_GETTER(audiodelays_multi_tap_delay_playing_obj,
     (mp_obj_t)&audiodelays_multi_tap_delay_get_playing_obj);
 
-//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> MultiTapDelay:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
@@ -255,7 +255,7 @@ static mp_obj_t audiodelays_multi_tap_delay_obj_play(size_t n_args, const mp_obj
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiodelays_multi_tap_delay_play(self, sample, args[ARG_loop].u_bool);
 
-    return mp_const_none;
+    return pos_args[0];
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_multi_tap_delay_play_obj, 1, audiodelays_multi_tap_delay_obj_play);
 

--- a/shared-bindings/audiodelays/MultiTapDelay.c
+++ b/shared-bindings/audiodelays/MultiTapDelay.c
@@ -237,7 +237,11 @@ MP_PROPERTY_GETTER(audiodelays_multi_tap_delay_playing_obj,
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         The sample must match the encoding settings given in the constructor."""
+//|         The sample must match the encoding settings given in the constructor.
+//|
+//|         :return: The effect object itself. Can be used for chaining, ie:
+//|           ``audio.play(effect.play(sample))``.
+//|         :rtype: MultiTapDelay"""
 //|         ...
 //|
 static mp_obj_t audiodelays_multi_tap_delay_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/audiodelays/MultiTapDelay.c
+++ b/shared-bindings/audiodelays/MultiTapDelay.c
@@ -255,7 +255,7 @@ static mp_obj_t audiodelays_multi_tap_delay_obj_play(size_t n_args, const mp_obj
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiodelays_multi_tap_delay_play(self, sample, args[ARG_loop].u_bool);
 
-    return pos_args[0];
+    return MP_OBJ_FROM_PTR(self);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_multi_tap_delay_play_obj, 1, audiodelays_multi_tap_delay_obj_play);
 

--- a/shared-bindings/audiodelays/PitchShift.c
+++ b/shared-bindings/audiodelays/PitchShift.c
@@ -194,7 +194,11 @@ MP_PROPERTY_GETTER(audiodelays_pitch_shift_playing_obj,
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         The sample must match the encoding settings given in the constructor."""
+//|         The sample must match the encoding settings given in the constructor.
+//|
+//|         :return: The effect object itself. Can be used for chaining, ie:
+//|           ``audio.play(effect.play(sample))``.
+//|         :rtype: PitchShift"""
 //|         ...
 //|
 static mp_obj_t audiodelays_pitch_shift_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/audiodelays/PitchShift.c
+++ b/shared-bindings/audiodelays/PitchShift.c
@@ -211,7 +211,7 @@ static mp_obj_t audiodelays_pitch_shift_obj_play(size_t n_args, const mp_obj_t *
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiodelays_pitch_shift_play(self, sample, args[ARG_loop].u_bool);
 
-    return pos_args[0];
+    return MP_OBJ_FROM_PTR(self);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_pitch_shift_play_obj, 1, audiodelays_pitch_shift_obj_play);
 

--- a/shared-bindings/audiodelays/PitchShift.c
+++ b/shared-bindings/audiodelays/PitchShift.c
@@ -190,7 +190,7 @@ MP_PROPERTY_GETTER(audiodelays_pitch_shift_playing_obj,
     (mp_obj_t)&audiodelays_pitch_shift_get_playing_obj);
 
 
-//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> PitchShift:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
@@ -211,7 +211,7 @@ static mp_obj_t audiodelays_pitch_shift_obj_play(size_t n_args, const mp_obj_t *
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiodelays_pitch_shift_play(self, sample, args[ARG_loop].u_bool);
 
-    return mp_const_none;
+    return pos_args[0];
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiodelays_pitch_shift_play_obj, 1, audiodelays_pitch_shift_obj_play);
 

--- a/shared-bindings/audiofilters/Distortion.c
+++ b/shared-bindings/audiofilters/Distortion.c
@@ -331,7 +331,7 @@ static mp_obj_t audiofilters_distortion_obj_play(size_t n_args, const mp_obj_t *
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiofilters_distortion_play(self, sample, args[ARG_loop].u_bool);
 
-    return pos_args[0];
+    return MP_OBJ_FROM_PTR(self);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_distortion_play_obj, 1, audiofilters_distortion_obj_play);
 

--- a/shared-bindings/audiofilters/Distortion.c
+++ b/shared-bindings/audiofilters/Distortion.c
@@ -313,7 +313,11 @@ MP_PROPERTY_GETTER(audiofilters_distortion_playing_obj,
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         The sample must match the encoding settings given in the constructor."""
+//|         The sample must match the encoding settings given in the constructor.
+//|
+//|         :return: The effect object itself. Can be used for chaining, ie:
+//|           ``audio.play(effect.play(sample))``.
+//|         :rtype: Distortion"""
 //|         ...
 //|
 static mp_obj_t audiofilters_distortion_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/audiofilters/Distortion.c
+++ b/shared-bindings/audiofilters/Distortion.c
@@ -309,7 +309,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiofilters_distortion_get_playing_obj, audiofilters_
 MP_PROPERTY_GETTER(audiofilters_distortion_playing_obj,
     (mp_obj_t)&audiofilters_distortion_get_playing_obj);
 
-//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> Distortion:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
@@ -331,7 +331,7 @@ static mp_obj_t audiofilters_distortion_obj_play(size_t n_args, const mp_obj_t *
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiofilters_distortion_play(self, sample, args[ARG_loop].u_bool);
 
-    return mp_const_none;
+    return pos_args[0];
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_distortion_play_obj, 1, audiofilters_distortion_obj_play);
 

--- a/shared-bindings/audiofilters/Filter.c
+++ b/shared-bindings/audiofilters/Filter.c
@@ -183,7 +183,11 @@ MP_PROPERTY_GETTER(audiofilters_filter_playing_obj,
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         The sample must match the encoding settings given in the constructor."""
+//|         The sample must match the encoding settings given in the constructor.
+//|
+//|         :return: The effect object itself. Can be used for chaining, ie:
+//|           ``audio.play(effect.play(sample))``.
+//|         :rtype: Filter"""
 //|         ...
 //|
 static mp_obj_t audiofilters_filter_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/audiofilters/Filter.c
+++ b/shared-bindings/audiofilters/Filter.c
@@ -179,7 +179,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiofilters_filter_get_playing_obj, audiofilters_filt
 MP_PROPERTY_GETTER(audiofilters_filter_playing_obj,
     (mp_obj_t)&audiofilters_filter_get_playing_obj);
 
-//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> Filter:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
@@ -201,7 +201,7 @@ static mp_obj_t audiofilters_filter_obj_play(size_t n_args, const mp_obj_t *pos_
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiofilters_filter_play(self, sample, args[ARG_loop].u_bool);
 
-    return mp_const_none;
+    return pos_args[0];
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_filter_play_obj, 1, audiofilters_filter_obj_play);
 

--- a/shared-bindings/audiofilters/Filter.c
+++ b/shared-bindings/audiofilters/Filter.c
@@ -201,7 +201,7 @@ static mp_obj_t audiofilters_filter_obj_play(size_t n_args, const mp_obj_t *pos_
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiofilters_filter_play(self, sample, args[ARG_loop].u_bool);
 
-    return pos_args[0];
+    return MP_OBJ_FROM_PTR(self);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_filter_play_obj, 1, audiofilters_filter_obj_play);
 

--- a/shared-bindings/audiofilters/Phaser.c
+++ b/shared-bindings/audiofilters/Phaser.c
@@ -236,7 +236,7 @@ static mp_obj_t audiofilters_phaser_obj_play(size_t n_args, const mp_obj_t *pos_
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiofilters_phaser_play(self, sample, args[ARG_loop].u_bool);
 
-    return pos_args[0];
+    return MP_OBJ_FROM_PTR(self);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_phaser_play_obj, 1, audiofilters_phaser_obj_play);
 

--- a/shared-bindings/audiofilters/Phaser.c
+++ b/shared-bindings/audiofilters/Phaser.c
@@ -214,7 +214,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiofilters_phaser_get_playing_obj, audiofilters_phas
 MP_PROPERTY_GETTER(audiofilters_phaser_playing_obj,
     (mp_obj_t)&audiofilters_phaser_get_playing_obj);
 
-//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> Phaser:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
@@ -236,7 +236,7 @@ static mp_obj_t audiofilters_phaser_obj_play(size_t n_args, const mp_obj_t *pos_
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiofilters_phaser_play(self, sample, args[ARG_loop].u_bool);
 
-    return mp_const_none;
+    return pos_args[0];
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiofilters_phaser_play_obj, 1, audiofilters_phaser_obj_play);
 

--- a/shared-bindings/audiofilters/Phaser.c
+++ b/shared-bindings/audiofilters/Phaser.c
@@ -218,7 +218,11 @@ MP_PROPERTY_GETTER(audiofilters_phaser_playing_obj,
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         The sample must match the encoding settings given in the constructor."""
+//|         The sample must match the encoding settings given in the constructor.
+//|
+//|         :return: The effect object itself. Can be used for chaining, ie:
+//|           ``audio.play(effect.play(sample))``.
+//|         :rtype: Phaser"""
 //|         ...
 //|
 static mp_obj_t audiofilters_phaser_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/audiofreeverb/Freeverb.c
+++ b/shared-bindings/audiofreeverb/Freeverb.c
@@ -200,7 +200,11 @@ MP_PROPERTY_GETTER(audiofreeverb_freeverb_playing_obj,
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
-//|         The sample must match the encoding settings given in the constructor."""
+//|         The sample must match the encoding settings given in the constructor.
+//|
+//|         :return: The effect object itself. Can be used for chaining, ie:
+//|           ``audio.play(effect.play(sample))``.
+//|         :rtype: Freeverb"""
 //|         ...
 //|
 static mp_obj_t audiofreeverb_freeverb_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/audiofreeverb/Freeverb.c
+++ b/shared-bindings/audiofreeverb/Freeverb.c
@@ -218,7 +218,7 @@ static mp_obj_t audiofreeverb_freeverb_obj_play(size_t n_args, const mp_obj_t *p
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiofreeverb_freeverb_play(self, sample, args[ARG_loop].u_bool);
 
-    return pos_args[0];
+    return MP_OBJ_FROM_PTR(self);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiofreeverb_freeverb_play_obj, 1, audiofreeverb_freeverb_obj_play);
 

--- a/shared-bindings/audiofreeverb/Freeverb.c
+++ b/shared-bindings/audiofreeverb/Freeverb.c
@@ -196,7 +196,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(audiofreeverb_freeverb_get_playing_obj, audiofreeverb_
 MP_PROPERTY_GETTER(audiofreeverb_freeverb_playing_obj,
     (mp_obj_t)&audiofreeverb_freeverb_get_playing_obj);
 
-//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> None:
+//|     def play(self, sample: circuitpython_typing.AudioSample, *, loop: bool = False) -> Freeverb:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
@@ -218,7 +218,7 @@ static mp_obj_t audiofreeverb_freeverb_obj_play(size_t n_args, const mp_obj_t *p
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiofreeverb_freeverb_play(self, sample, args[ARG_loop].u_bool);
 
-    return mp_const_none;
+    return pos_args[0];
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiofreeverb_freeverb_play_obj, 1, audiofreeverb_freeverb_obj_play);
 

--- a/shared-bindings/audiomixer/Mixer.c
+++ b/shared-bindings/audiomixer/Mixer.c
@@ -166,7 +166,11 @@ MP_PROPERTY_GETTER(audiomixer_mixer_voice_obj,
 //|
 //|         Sample must be an `audiocore.WaveFile`, `audiocore.RawSample`, `audiomixer.Mixer` or `audiomp3.MP3Decoder`.
 //|
-//|         The sample must match the Mixer's encoding settings given in the constructor."""
+//|         The sample must match the Mixer's encoding settings given in the constructor.
+//|
+//|         :return: The mixer object itself. Can be used for chaining, ie:
+//|           ``audio.play(mixer.play(sample))``.
+//|         :rtype: Chorus"""
 //|         ...
 //|
 static mp_obj_t audiomixer_mixer_obj_play(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/shared-bindings/audiomixer/Mixer.c
+++ b/shared-bindings/audiomixer/Mixer.c
@@ -189,7 +189,7 @@ static mp_obj_t audiomixer_mixer_obj_play(size_t n_args, const mp_obj_t *pos_arg
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiomixer_mixervoice_play(voice, sample, args[ARG_loop].u_bool);
 
-    return pos_args[0];
+    return MP_OBJ_FROM_PTR(self);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixer_play_obj, 1, audiomixer_mixer_obj_play);
 

--- a/shared-bindings/audiomixer/Mixer.c
+++ b/shared-bindings/audiomixer/Mixer.c
@@ -160,7 +160,7 @@ MP_PROPERTY_GETTER(audiomixer_mixer_voice_obj,
 
 //|     def play(
 //|         self, sample: circuitpython_typing.AudioSample, *, voice: int = 0, loop: bool = False
-//|     ) -> None:
+//|     ) -> Mixer:
 //|         """Plays the sample once when loop=False and continuously when loop=True.
 //|         Does not block. Use `playing` to block.
 //|
@@ -189,7 +189,7 @@ static mp_obj_t audiomixer_mixer_obj_play(size_t n_args, const mp_obj_t *pos_arg
     mp_obj_t sample = args[ARG_sample].u_obj;
     common_hal_audiomixer_mixervoice_play(voice, sample, args[ARG_loop].u_bool);
 
-    return mp_const_none;
+    return pos_args[0];
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(audiomixer_mixer_play_obj, 1, audiomixer_mixer_obj_play);
 


### PR DESCRIPTION
The idea of audio effect/mixer chaining was theorized in one of the first audio effects PRs, https://github.com/adafruit/circuitpython/pull/9640#issuecomment-2389776124, but never actually implemented.

The updates in this PR are relatively simple. Instead of returning `None` within `play(...)` methods of audio objects which allow both input and output (effects and mixer), it instead returns a reference to itself.

With this minor update, rather than building audio chains the old way:

``` python
effect.play(sample)
mixer.play(effect)
dac.play(mixer)
```

You can instead directly chain each source into its destination:

``` python
dac.play(mixer.play(effect.play(sample)))
```

_Note: The only method that is missing this chaining ability is `audiomixer.MixerVoice.play`. I felt that it made sense to allow `audiomixer.Mixer.play` to support this but thought it would result in confusing implementation to support `MixerVoice`. (ie: `dac.play(mixer.voice[0].play(sample))` vs `dac.play(mixer.play(sample))`._