### PR TITLE
Mounted filesystems USB write protection

### DIFF
--- a/main.c
+++ b/main.c
@@ -211,14 +211,22 @@ static void start_mp(safe_mode_t safe_mode) {
 
 static void stop_mp(void) {
     #if MICROPY_VFS
-    mp_vfs_mount_t *vfs = MP_STATE_VM(vfs_mount_table);
 
     // Unmount all heap allocated vfs mounts.
-    while (gc_ptr_on_heap(vfs)) {
+    mp_vfs_mount_t *vfs = MP_STATE_VM(vfs_mount_table);
+    do {
+        if (gc_ptr_on_heap(vfs)) {
+            // mp_vfs_umount will splice out an unmounted vfs from the vfs_mount_table linked list.
+            mp_vfs_umount(vfs->obj);
+            // Start over at the beginning of the list since the first entry may have been removed.
+            vfs = MP_STATE_VM(vfs_mount_table);
+            continue;
+        }
         vfs = vfs->next;
-    }
-    MP_STATE_VM(vfs_mount_table) = vfs;
+    } while (vfs != NULL);
+
     // The last vfs is CIRCUITPY and the root directory.
+    vfs = MP_STATE_VM(vfs_mount_table);
     while (vfs->next != NULL) {
         vfs = vfs->next;
     }

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -345,6 +345,9 @@ typedef long mp_off_t;
 #endif
 
 
+// For easy debugging printf's.
+#define PLAT_PRINTF(...) mp_printf(&mp_plat_print, __VA_ARGS__)
+
 #if MICROPY_PY_ASYNC_AWAIT && !CIRCUITPY_TRACEBACK
 #error CIRCUITPY_ASYNCIO requires CIRCUITPY_TRACEBACK
 #endif

--- a/shared-bindings/storage/__init__.c
+++ b/shared-bindings/storage/__init__.c
@@ -54,15 +54,23 @@ static mp_obj_t storage_mount(size_t n_args, const mp_obj_t *pos_args, mp_map_t 
     // get the mount point
     const char *mnt_str = mp_obj_str_get_str(args[ARG_mount_path].u_obj);
 
+
+    mp_obj_t vfs_obj = args[ARG_filesystem].u_obj;
+
+    // Currently, the only supported filesystem is VfsFat.
+    mp_arg_validate_type(vfs_obj, &mp_fat_vfs_type, MP_QSTR_filesystem);
+
+    // Add this back if/when we start supporting other filesystems.
+    #if 0
     // Make sure we're given an object we can mount.
     // TODO(tannewt): Make sure we have all the methods we need to operating it
     // as a file system.
-    mp_obj_t vfs_obj = args[ARG_filesystem].u_obj;
     mp_obj_t dest[2];
     mp_load_method_maybe(vfs_obj, MP_QSTR_mount, dest);
     if (dest[0] == MP_OBJ_NULL) {
         mp_raise_ValueError(MP_ERROR_TEXT("filesystem must provide mount method"));
     }
+    #endif
 
     common_hal_storage_mount(vfs_obj, mnt_str, args[ARG_readonly].u_bool);
 

--- a/shared-module/storage/__init__.c
+++ b/shared-module/storage/__init__.c
@@ -126,6 +126,11 @@ void common_hal_storage_mount(mp_obj_t vfs_obj, const char *mount_path, bool rea
     // call the underlying object to do any mounting operation
     mp_vfs_proxy_call(vfs, MP_QSTR_mount, 2, (mp_obj_t *)&args);
 
+    fs_user_mount_t *vfs_fat = MP_OBJ_TO_PTR(vfs_obj);
+    // Filesystem is read-only to USB if writable by CircuitPython, and vice versa.
+    filesystem_set_writable_by_usb(vfs_fat, readonly);
+    filesystem_set_concurrent_write_protection(vfs_fat, true);
+
     // Insert the vfs into the mount table by pushing it onto the front of the
     // mount table.
     mp_vfs_mount_t **vfsp = &MP_STATE_VM(vfs_mount_table);

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -247,13 +247,13 @@ void filesystem_set_writable_by_usb(fs_user_mount_t *vfs, bool usb_writable) {
 }
 
 bool filesystem_is_writable_by_python(fs_user_mount_t *vfs) {
-    return (vfs->blockdev.flags & MP_BLOCKDEV_FLAG_CONCURRENT_WRITE_PROTECTED) == 0 ||
-           (vfs->blockdev.flags & MP_BLOCKDEV_FLAG_USB_WRITABLE) == 0;
+    return ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_CONCURRENT_WRITE_PROTECTED) == 0) ||
+           ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_USB_WRITABLE) == 0);
 }
 
 bool filesystem_is_writable_by_usb(fs_user_mount_t *vfs) {
-    return (vfs->blockdev.flags & MP_BLOCKDEV_FLAG_CONCURRENT_WRITE_PROTECTED) == 0 ||
-           (vfs->blockdev.flags & MP_BLOCKDEV_FLAG_USB_WRITABLE) != 0;
+    return ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_CONCURRENT_WRITE_PROTECTED) == 0) ||
+           ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_USB_WRITABLE) != 0);
 }
 
 void filesystem_set_internal_concurrent_write_protection(bool concurrent_write_protection) {


### PR DESCRIPTION
- Fixes #10510 
---
- Ensure that a filesystem visible via USB is read-only to the host if it is read-write to CircuitPython and vice-versa.
- Type-check `storage.mount(filesystem=, ...)` argument to ensure it is a `VfsFat` object.
  - Currently it only checks that it implements `mount`. But elsewhere in the code there are assumptions it is an `fs_user_mount_t`, which is a `VfsFat.
  - If/when we provide other filesystem types (as MicroPython does), we will relax this. I left the old validation code in as `#if 0` for that reason, instead of just deleting this.
- `stop_mp()` unmounts user-mounted Vfs filesystems on VM shutdown. This used to assume that the user-mounted filesystems all came last. I think that is currently the case, but made this code more robust in case they are intermixed with non-user-mounted ones. Tested on a Fruit Jam with autmounted filesystems and on an nRF52840 with a user-mounted SD card.
- Add some clarifying parentheses on a bool expression.
- Add `#define PLAT_PRINTF(...) mp_printf(&mp_plat_print, __VA_ARGS__)` in `circuitpy_mpconfig.h`. There are similar macros elsewhere, but only in specific files. I got tired of typing `&mp_plat_print`. I chose the name for minimal typing for auto-completion.
