### PR TITLE
Fix filesystem writability from USB

### DIFF
--- a/extmod/vfs.h
+++ b/extmod/vfs.h
@@ -52,6 +52,8 @@
 #define MP_BLOCKDEV_FLAG_CONCURRENT_WRITE_PROTECTED (0x0020)
 // Bit set when something has claimed the right to mutate the blockdev.
 #define MP_BLOCKDEV_FLAG_LOCKED (0x0040)
+// Ignore write protections. Used to override other flags temporarily.
+#define MP_BLOCKDEV_FLAG_IGNORE_WRITE_PROTECTION (0x0080)
 
 // constants for block protocol ioctl
 #define MP_BLOCKDEV_IOCTL_INIT          (1)

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -427,13 +427,10 @@ static MP_DEFINE_CONST_FUN_OBJ_2(fat_vfs_statvfs_obj, fat_vfs_statvfs);
 static mp_obj_t vfs_fat_mount(mp_obj_t self_in, mp_obj_t readonly, mp_obj_t mkfs) {
     fs_user_mount_t *self = MP_OBJ_TO_PTR(self_in);
 
-    // Read-only device indicated by writeblocks[0] == MP_OBJ_NULL.
-    // User can specify read-only device by:
-    //  1. readonly=True keyword argument
-    //  2. nonexistent writeblocks method (then writeblocks[0] == MP_OBJ_NULL already)
-    if (mp_obj_is_true(readonly)) {
-        self->blockdev.writeblocks[0] = MP_OBJ_NULL;
-    }
+    // CIRCUITPY-CHANGE: Use MP_BLOCKDEV_FLAG_USB_WRITABLE instead of writeblocks[0] =/!= MP_OBJ_NULL
+    // to specify read-write.
+    // If readonly to Python, it's writable by USB and vice versa.
+    filesystem_set_writable_by_usb(self, mp_obj_is_true(readonly));
 
     // check if we need to make the filesystem
     FRESULT res = (self->blockdev.flags & MP_BLOCKDEV_FLAG_NO_FILESYSTEM) ? FR_NO_FILESYSTEM : FR_OK;

--- a/extmod/vfs_fat_diskio.c
+++ b/extmod/vfs_fat_diskio.c
@@ -43,6 +43,9 @@
 #include "lib/oofatfs/diskio.h"
 #include "extmod/vfs_fat.h"
 
+// CIRCUITPY-CHANGE
+#include "supervisor/filesystem.h"
+
 typedef void *bdev_t;
 static fs_user_mount_t *disk_get_device(void *bdev) {
     return (fs_user_mount_t *)bdev;
@@ -153,7 +156,8 @@ DRESULT disk_ioctl(
             if (ret != mp_const_none && MP_OBJ_SMALL_INT_VALUE(ret) != 0) {
                 // error initialising
                 stat = STA_NOINIT;
-            } else if (vfs->blockdev.writeblocks[0] == MP_OBJ_NULL) {
+                // CIRCUITPY-CHANGE: writability from Python check
+            } else if (!filesystem_is_writable_by_python(vfs)) {
                 stat = STA_PROTECT;
             } else {
                 stat = 0;

--- a/supervisor/filesystem.h
+++ b/supervisor/filesystem.h
@@ -21,6 +21,7 @@ void filesystem_set_internal_writable_by_usb(bool usb_writable);
 void filesystem_set_internal_concurrent_write_protection(bool concurrent_write_protection);
 void filesystem_set_writable_by_usb(fs_user_mount_t *vfs, bool usb_writable);
 void filesystem_set_concurrent_write_protection(fs_user_mount_t *vfs, bool concurrent_write_protection);
+void filesystem_set_ignore_write_protection(fs_user_mount_t *vfs, bool ignore_write_protection);
 
 // Whether user code can modify the filesystem. It doesn't depend on the state
 // of USB. Don't use this for a workflow. In workflows, grab the shared file

--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -248,12 +248,14 @@ void filesystem_set_writable_by_usb(fs_user_mount_t *vfs, bool usb_writable) {
 
 bool filesystem_is_writable_by_python(fs_user_mount_t *vfs) {
     return ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_CONCURRENT_WRITE_PROTECTED) == 0) ||
-           ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_USB_WRITABLE) == 0);
+           ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_USB_WRITABLE) == 0) ||
+           ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_IGNORE_WRITE_PROTECTION) != 0);
 }
 
 bool filesystem_is_writable_by_usb(fs_user_mount_t *vfs) {
     return ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_CONCURRENT_WRITE_PROTECTED) == 0) ||
-           ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_USB_WRITABLE) != 0);
+           ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_USB_WRITABLE) != 0) ||
+           ((vfs->blockdev.flags & MP_BLOCKDEV_FLAG_IGNORE_WRITE_PROTECTION) != 0);
 }
 
 void filesystem_set_internal_concurrent_write_protection(bool concurrent_write_protection) {
@@ -265,6 +267,14 @@ void filesystem_set_concurrent_write_protection(fs_user_mount_t *vfs, bool concu
         vfs->blockdev.flags |= MP_BLOCKDEV_FLAG_CONCURRENT_WRITE_PROTECTED;
     } else {
         vfs->blockdev.flags &= ~MP_BLOCKDEV_FLAG_CONCURRENT_WRITE_PROTECTED;
+    }
+}
+
+void filesystem_set_ignore_write_protection(fs_user_mount_t *vfs, bool ignore_write_protection) {
+    if (ignore_write_protection) {
+        vfs->blockdev.flags |= MP_BLOCKDEV_FLAG_IGNORE_WRITE_PROTECTION;
+    } else {
+        vfs->blockdev.flags &= ~MP_BLOCKDEV_FLAG_IGNORE_WRITE_PROTECTION;
     }
 }
 

--- a/supervisor/shared/usb/usb_msc_flash.c
+++ b/supervisor/shared/usb/usb_msc_flash.c
@@ -249,7 +249,7 @@ bool tud_msc_is_writable_cb(uint8_t lun) {
     if (vfs == NULL) {
         return false;
     }
-    if (vfs->blockdev.writeblocks[0] == MP_OBJ_NULL || !filesystem_is_writable_by_usb(vfs)) {
+    if (!filesystem_is_writable_by_usb(vfs)) {
         return false;
     }
     // Lock the blockdev once we say we're writable.


### PR DESCRIPTION
- Fixes #10657.

#10648 mistakenly prevented USB writes all the time. Fixing it was more complicated than one might think
- The old way of doing `self->blockdev.writeblocks[0] = MP_OBJ_NULL;` turns off write for everyone, and is not a good way of setting read-only for host but not CircuitPython or vice-versa. So use the `blockdev` `MP_BLOCKDEV_FLAG`s exclusively. via `filesystem_is_writable_by_python()` and `filesystem_is_writable_by_usb()`.
- The above change caused `boot_out.txt` not to be written in most cases, because now the read-write check on the flags is done at a lower level. So add a new flag `MP_BLOCKDEV_FLAG_IGNORE_WRITE_PROTECTION` to turn off write protection during `boot.py` execution. We can't just temporarily toggle `MP_BLOCKDEV_FLAG_USB_WRITABLE`, because `boot.py` might do a `storage.remount()`, which changes that flag, and we can't tell if it was changed in `main.c` or in the `boot.py` Python code.

Tested with all four combinations of {`CIRCUITPY`, `/sd`} x {read-write, readonly} on a Feather RP2040 with an Adalogger Featherwing. Also tested the three drives presented by Fruit Jam in their regular states to check proper read-only/read-write.