### PR TITLE
circuitpython_setboard: handle new location of importlib Traversable

### DIFF
--- a/tools/board_stubs/circuitpython_setboard/__init__.py
+++ b/tools/board_stubs/circuitpython_setboard/__init__.py
@@ -12,7 +12,12 @@ import argparse
 import shutil
 from collections import defaultdict
 from importlib import resources
-from importlib.abc import Traversable
+
+try:
+    from importlib.resources.abc import Traversable
+except ModuleNotFoundError:
+    # 3.10 and earlier.
+    from importlib.abc import Traversable
 
 
 def get_definitions_or_exit(board: str) -> Traversable:


### PR DESCRIPTION
- Fixes #10660 (@alec-bike)

```py
from importlib.abc import Traversable
```
was made available as
```py
from importlib.resources.abc import Traversable
```
in Python 3.11. The old location was deprecated with a warning in 3.13 and removed in 3.14. We support back to 3.9, so try to import in both places.