### PR TITLE
Restore atmel-samd SD card USB presentation

### DIFF
--- a/ports/atmel-samd/mpconfigport.h
+++ b/ports/atmel-samd/mpconfigport.h
@@ -11,9 +11,6 @@
 
 // Definitions that control circuitpy_mpconfig.h:
 
-// On SAMD, presenting the SD card as a second LUN causes USB disconnect. This needs to be fixed eventually.
-#define CIRCUITPY_SDCARD_USB (0)
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #ifdef SAMD21


### PR DESCRIPTION
- Fixes #10669.

Now can be merged since #10668 was merged.

Tested on PyPortal on Linux and Windows. No longer disconnects when `code.py` mounts the SD card and it is presented via USB.
