### PR TITLE
restrict Python cryptography version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,8 @@ intelhex
 # for building & testing natmods
 pyelftools
 
-cryptography
+# newer versions break ESP-IDF now
+cryptography<45
 
 # for web workflow minify
 minify_html


### PR DESCRIPTION
`cryptography` must be < version 45 to be compatible with ESP-IDF, but was attempted to be installed anyway. This broke the 10.0.2 build after an old python modules cache stopped being used. Thanks @tannewt for the diagnosis.