### PR TITLE
make jpegio unsupported format error more helpful

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -159,10 +159,6 @@ msgstr ""
 msgid "%q length must be >= %d"
 msgstr ""
 
-#: py/runtime.c
-msgid "%q moved from %q to %q"
-msgstr ""
-
 #: py/argcheck.c
 msgid "%q must be %d"
 msgstr ""
@@ -1644,10 +1640,6 @@ msgstr ""
 msgid "Not playing"
 msgstr ""
 
-#: shared-module/jpegio/JpegDecoder.c
-msgid "Not supported JPEG standard"
-msgstr ""
-
 #: ports/espressif/common-hal/paralleldisplaybus/ParallelBus.c
 #: ports/espressif/common-hal/sdioio/SDCard.c
 #, c-format
@@ -2369,6 +2361,10 @@ msgstr ""
 msgid ""
 "Unspecified issue. Can be that the pairing prompt on the other device was "
 "declined or ignored."
+msgstr ""
+
+#: shared-module/jpegio/JpegDecoder.c
+msgid "Unsupported JPEG (may be progressive)"
 msgstr ""
 
 #: shared-bindings/bitmaptools/__init__.c
@@ -3172,10 +3168,6 @@ msgstr ""
 
 #: shared-bindings/traceback/__init__.c
 msgid "file write is not available"
-msgstr ""
-
-#: shared-bindings/storage/__init__.c
-msgid "filesystem must provide mount method"
 msgstr ""
 
 #: extmod/ulab/code/numpy/vector.c

--- a/shared-module/jpegio/JpegDecoder.c
+++ b/shared-module/jpegio/JpegDecoder.c
@@ -46,7 +46,7 @@ static void check_jresult(JRESULT j) {
             msg = MP_ERROR_TEXT("Right format but not supported");
             break;
         case JDR_FMT3:
-            msg = MP_ERROR_TEXT("Not supported JPEG standard");
+            msg = MP_ERROR_TEXT("Unsupported JPEG (may be progressive)");
             break;
     }
     mp_raise_RuntimeError(msg);


### PR DESCRIPTION
I'm resubmitting #10686 against 10.0.x

This PR adds the progressive hint from the core comment to the reported gifio error. 