### PR TITLE
Allow microcontroller.nvm to be bigger than 64k

### DIFF
--- a/shared-bindings/nvm/ByteArray.c
+++ b/shared-bindings/nvm/ByteArray.c
@@ -35,7 +35,7 @@
 //|
 static mp_obj_t nvm_bytearray_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     nvm_bytearray_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    uint16_t len = common_hal_nvm_bytearray_get_length(self);
+    uint32_t len = common_hal_nvm_bytearray_get_length(self);
     switch (op) {
         case MP_UNARY_OP_BOOL:
             return mp_obj_new_bool(len != 0);


### PR DESCRIPTION
## Fix

This PR allows NVM to be bigger than 64kBytes.

## Bug

Assume `mpconfigboard.h` specifies: `#define CIRCUITPY_INTERNAL_NVM_SIZE (136*1024)`.

But `len(microcontroller.nvm)` will return 8192 as the `uint16_t` wraps.

```python
# Wrap uint16_t (wrong)
>>> (136*1024)%(2**16)
8192
# No wrap uin32_t (correct, this PR)
>>> (136*1024)%(2**32)
139264
```

With this PR applied, `len(microcontroller.nvm)` will return 139264 which is, as expected,  136*1024.

## Test

I tested this PR on a nordic pca10059 using `#define CIRCUITPY_INTERNAL_NVM_SIZE (136*1024)`.