### PR TITLE
Fixed compile error to enable removal of blue flash sequence (BLE) and speed up board start

### DIFF
--- a/ports/espressif/common-hal/_bleio/PacketBuffer.c
+++ b/ports/espressif/common-hal/_bleio/PacketBuffer.c
@@ -159,7 +159,13 @@ static int packet_buffer_on_ble_client_evt(struct ble_gap_event *event, void *pa
     return false;
 }
 
+#if CIRCUITPY_SERIAL_BLE || CIRCUITPY_BLE_FILE_SERVICE
+// Exposed via shared-bindings header when enabled
 void _common_hal_bleio_packet_buffer_construct(
+#else
+// Internal static helper when disabled (avoids "missing prototype" error)
+static void _common_hal_bleio_packet_buffer_construct(
+#endif
     bleio_packet_buffer_obj_t *self, bleio_characteristic_obj_t *characteristic,
     uint32_t *incoming_buffer, size_t incoming_buffer_size,
     uint32_t *outgoing_buffer1, uint32_t *outgoing_buffer2, size_t max_packet_size,

--- a/shared-bindings/_bleio/PacketBuffer.h
+++ b/shared-bindings/_bleio/PacketBuffer.h
@@ -25,7 +25,7 @@ void common_hal_bleio_packet_buffer_construct(
 void _common_hal_bleio_packet_buffer_construct(
     bleio_packet_buffer_obj_t *self, bleio_characteristic_obj_t *characteristic,
     uint32_t *incoming_buffer, size_t incoming_buffer_size,
-    uint32_t *outgoing_buffer1, uint32_t *outgoing_buffer2, size_t outgoing_buffer_size,
+    uint32_t *outgoing_buffer1, uint32_t *outgoing_buffer2, size_t max_packet_size,
     ble_event_handler_t *static_handler_entry);
 #endif
 mp_int_t common_hal_bleio_packet_buffer_write(bleio_packet_buffer_obj_t *self, const uint8_t *data, size_t len, uint8_t *header, size_t header_len);


### PR DESCRIPTION
This fix makes it possible to disable BLE file services and remove the flashing blue light start-up sequence. That speeds up the overall start up procedure significantly for users who don't use these services.

It works well in combination with "CIRCUITPY_SKIP_SAFE_MODE_WAIT = 0" to remove both the flashing yellow and flashing blue start up sequences.

mpconfigboard.mk:
CIRCUITPY_BLE_FILE_SERVICE = 0
CIRCUITPY_SERIAL_BLE = 0

Fixed issues:
-Conditional compilation of prototype in header file without adjusting source file
-Variable name mismatch between header and source file

"PacketBuffer.c:162:6: error: no previous prototype for '_common_hal_bleio_packet_buffer_construct' [-Werror=missing-prototypes]"