### PR TITLE
DRAFT: Removing keyboard support to work on Cardputer  ADV

### DIFF
--- a/ports/espressif/boards/m5stack_cardputer/mpconfigboard.mk
+++ b/ports/espressif/boards/m5stack_cardputer/mpconfigboard.mk
@@ -13,4 +13,5 @@ CIRCUITPY_ESP_FLASH_SIZE = 8MB
 CIRCUITPY_ESPCAMERA = 0
 CIRCUITPY_MAX3421E = 0
 
-SRC_C += module/cardputer_keyboard.c
+# Disabling keyboard support for Cardputer ADV
+#SRC_C += module/cardputer_keyboard.c


### PR DESCRIPTION
Keyboard support for ADV can be written in python land, removing this code should free the GPIO from the matrix scanning so that I2C can be used.

This could be a first step to do a cardputer ADV board, a bit downgraded but with display working by default.