### PR TITLE
Update monotonic function docstring for clarity

### DIFF
--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -22,12 +22,12 @@
 //|
 //|
 //| def monotonic() -> float:
-//|     """Returns an always increasing value of time (in fractional **seconds**) with an unknown reference
+//|     """Returns an always increasing value of time, in fractional seconds, with an unknown reference
 //|     point. Only use it to compare against other values from `time.monotonic()`
 //|     during the same code run.
 //|
 //|     On most boards, `time.monotonic()` converts a 64-bit millisecond tick counter
-//|     to a float. Floats on most boards are encoded in 30 bits internally, with
+//|     to seconds, as a float. Floats on most boards are encoded in 30 bits internally, with
 //|     effectively 22 bits of precision. The float returned by `time.monotonic()` will
 //|     accurately represent time to millisecond precision only up to 2**22 milliseconds
 //|     (about 1.165 hours).


### PR DESCRIPTION
Clarify the return value of the monotonic function to specify it returns fractional seconds.

looking at cpython's time.monotonic() documentation, one sees in the first line "Return the value (in fractional seconds) of a monotonic clock" - 

I would have expected a similar introduction when reading that for circuitpython at https://docs.circuitpython.org/en/latest/shared-bindings/time/

I see there is a fall back that says "For more information, refer to the original CPython documentation"

but would it have hurt to have mention that the units of the float returned by time.monotomic was in seconds?  ( there are 7 mentions of millisecond(s),

---
