### PR TITLE
Add APA102 and DEFAULT_I2C_BUS definitions to the lilygo_tdongle_s3

### DIFF
--- a/ports/espressif/boards/lilygo_tdongle_s3/mpconfigboard.h
+++ b/ports/espressif/boards/lilygo_tdongle_s3/mpconfigboard.h
@@ -11,5 +11,8 @@
 #define MICROPY_HW_BOARD_NAME       "LILYGO T-Dongle S3"
 #define MICROPY_HW_MCU_NAME         "ESP32S3"
 
-#define DEFAULT_UART_BUS_RX         (&pin_GPIO44)
-#define DEFAULT_UART_BUS_TX         (&pin_GPIO43)
+#define MICROPY_HW_APA102_MOSI   (&pin_GPIO40)
+#define MICROPY_HW_APA102_SCK    (&pin_GPIO39)
+
+#define DEFAULT_I2C_BUS_SCL  (&pin_GPIO44)
+#define DEFAULT_I2C_BUS_SDA  (&pin_GPIO43)


### PR DESCRIPTION
Change for the LILYGO T-Dongle-S3 pen drive board https://lilygo.cc/en-us/products/t-dongle-s3

* This change should enable `board.STEMMA_I2C `and the `APA102` status lights.
* I intend to test this against the build artifacts that I hope are created from this pull request
* This issue is discussed in https://forums.adafruit.com/viewtopic.php?p=1077490
