### PR TITLE
Add missing quote in `hashlib.new` docstring

### DIFF
--- a/shared-bindings/hashlib/__init__.c
+++ b/shared-bindings/hashlib/__init__.c
@@ -20,7 +20,7 @@
 //|
 //| def new(name: str, data: bytes = b"") -> hashlib.Hash:
 //|     """Returns a Hash object setup for the named algorithm. Raises ValueError when the named
-//|     algorithm is unsupported. Supported algorithms for ``name`` are ``'sha1`` and ``'sha256'``.
+//|     algorithm is unsupported. Supported algorithms for ``name`` are ``'sha1'`` and ``'sha256'``.
 //|
 //|     :return: a hash object for the given algorithm
 //|     :rtype: hashlib.Hash"""


### PR DESCRIPTION
While reviewing [the latest documentation for `hashlib.new`](https://docs.circuitpython.org/en/latest/shared-bindings/hashlib/index.html#hashlib.new), I noticed there's a missing single quote, which this PR resolves