### PR TITLE
raspberrypi: Fix PDMIn

### DIFF
--- a/ports/raspberrypi/common-hal/audiobusio/PDMIn.c
+++ b/ports/raspberrypi/common-hal/audiobusio/PDMIn.c
@@ -65,6 +65,7 @@ void common_hal_audiobusio_pdmin_construct(audiobusio_pdmin_obj_t *self,
         PIO_MOV_STATUS_DEFAULT, PIO_MOV_N_DEFAULT);
     uint32_t actual_frequency = common_hal_rp2pio_statemachine_get_frequency(&self->state_machine);
     if (actual_frequency < 2 * MIN_MIC_CLOCK) { // 2 PIO samples per audio clock
+        common_hal_audiobusio_pdmin_deinit(self);
         mp_raise_ValueError(MP_ERROR_TEXT("sampling rate out of range"));
     }
 


### PR DESCRIPTION
Between 7.1.1 and 7.2.0, a change was made to PDMIn that caused the passed-in sample rate to be used, instead of the fixed value 44100. When the sample rate 16000 was actually used, an underlying problem was exposed: The PIO clock was determined incorrectly.

Some problems in the same area were also resolved: The PIO frequency check was also wrong by a factor of two, and when a too-low sample rate led to the exception being thrown, the incomplete PDMIn object was not correctly deallocated, leading to an error that the pin objects were still in use.

After this change, I get plausible RMS noise level values changing from under 200 in a "quiet room" and up to 6000+ when I make noise directly next to the mic.

I did my testing on a Metro RP2350 with the adafruit PDM mic board, using pins 22 and 23 at a specified frequency of 16000. I also used my scope and checked that a sample rate of 16000 actually gives a PDM "CLK" frequency of 64*16kHz (1.024MHz) after the change, and that significantly smaller sample rate values such as 8000 are correctly rejected and can be tried again without resetting.

Closes: #10799