### PR TITLE
Fix build error from #10811

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/PacketBuffer.h
+++ b/devices/ble_hci/common-hal/_bleio/PacketBuffer.h
@@ -28,4 +28,7 @@ typedef struct {
     bool packet_queued;
 } bleio_packet_buffer_obj_t;
 
+// Unused, but needed for _common_hal_bleio_packet_buffer_construct()
+typedef void *ble_event_handler_t;
+
 void bleio_packet_buffer_update(bleio_packet_buffer_obj_t *self, mp_buffer_info_t *bufinfo);


### PR DESCRIPTION
The 10.1.0-rc.0 build failed. The #10811 PR did not build everything, and so missed a build error for boards that include BLE HCI.

So I will discard 10.1.0-rc.0 and make a 10.1.0-rc.1.