### PR TITLE
add port_yield from #10795 only on zephyr to fix #10822

### DIFF
--- a/supervisor/shared/background_callback.c
+++ b/supervisor/shared/background_callback.c
@@ -61,7 +61,10 @@ static int background_prevention_count;
 void PLACE_IN_ITCM(background_callback_run_all)(void) {
     port_background_task();
     if (!background_callback_pending()) {
+        // TEMPORARY to fix #10822
+        #ifdef __ZEPHYR__
         port_yield();
+        #endif
         return;
     }
     CALLBACK_CRITICAL_BEGIN;
@@ -88,7 +91,10 @@ void PLACE_IN_ITCM(background_callback_run_all)(void) {
     }
     --background_prevention_count;
     CALLBACK_CRITICAL_END;
+    // TEMPORARY to fix #10822
+    #ifdef __ZEPHYR__
     port_yield();
+    #endif
 }
 
 void background_callback_prevent(void) {

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -82,7 +82,10 @@ safe_mode_t wait_for_safe_mode_reset(void) {
             boot_in_safe_mode = true;
             break;
         }
+        // TEMPORARY to fix #10822
+        #ifdef __ZEPHYR__
         port_yield();
+        #endif
         diff = supervisor_ticks_ms64() - start_ticks;
     }
     #if CIRCUITPY_STATUS_LED


### PR DESCRIPTION
-- Fixes #10822 

Disables calls added to #10795 to `port_yield()`, except on zephyr port.

Thank you @daniel-alsen.
