### PR TITLE
Set default MagTag SSD1680 colstart to 8 instead of 0

### DIFF
--- a/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
+++ b/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
@@ -11,6 +11,8 @@
 #include "shared-bindings/fourwire/FourWire.h"
 #include "shared-bindings/microcontroller/Pin.h"
 #include "shared-module/displayio/__init__.h"
+#include "shared-module/os/__init__.h"
+
 #include "supervisor/shared/board.h"
 
 #include "esp_log.h"
@@ -218,6 +220,13 @@ void board_init(void) {
 
     if (is_ssd1680) {
         epaperdisplay_construct_args_t args = EPAPERDISPLAY_CONSTRUCT_ARGS_DEFAULTS;
+
+        // Newer SSD1680 MagTags need a colstart of 8. Older ones need 0.
+        mp_int_t colstart = 8;
+        // If the value is in settings.toml, it will be set.
+        (void)common_hal_os_getenv_int("CIRCUITPY_MAGTAG_SSD1680_COLSTART", &colstart);
+        args.colstart = (int16_t)colstart;
+
         args.bus = bus;
         args.start_sequence = ssd1680_display_start_sequence;
         args.start_sequence_len = sizeof(ssd1680_display_start_sequence);


### PR DESCRIPTION
The MagTag 2025 has a SSD1680-based e-ink display. Unfortunately, there are at least two slightly different versions of this display on MagTag 2025 boards. The newer boards need a `colstart` of 8; older boards need `0`. (There was some thought it needed `-8`, but that's not true.)

Examples. See user picture at bottom of this post.
https://forums.adafruit.com/viewtopic.php?t=222540
https://forums.adafruit.com/viewtopic.php?t=222605

This fix sets the default `colstart` to 8, to match the latest boards, but makes changeable in `settings.toml` by providing an optional parameter. For older 2025 MagTag boards, add this line to `settings.toml`:
```
CIRCUITPY_MAGTAG_SSD1680_COLSTART = 0
```

Note that this value is read only after a hard reset, so if you change it, reset or power cycle the board. Power-cycling when testing is good because it makes the display come up with random bits in the tell-tale stripe at the bottom.

I waffled a bit on the name. Originally I had `CIRCUITPY_DISPLAY_SSD1680_COLSTART`, but it's not generally applicable -- it's just for the MagTag. So I think `CIRCUITPY_MAGTAG_SSD1680_COLSTART` is the most accurate.

I spent some time trying to read something from the various config registers on the SSD1680 to see if there was anything distinguishing between display versions. However, I could only read zeros from the registers I tried, including the user ID register. I'm not sure if my program is bad or there's nothing there. 

I tested with the Weather program, and this simple test program:
```py
import displayio
import os
from adafruit_magtag.magtag import MagTag

magtag = MagTag()

print("set background")
# Use a random value so any previous stripe will not be the same

magtag.graphics.set_background(int.from_bytes(os.urandom(3)))
magtag.display.refresh()
while True:
    pass
```
<img width="545" height="800" alt="image" src="https://github.com/user-attachments/assets/4cfb7215-376c-4d71-a4f5-c605a9de6d8e" />
