### PR TITLE
call reset_all_pins() in main() after port_init()

### DIFF
--- a/main.c
+++ b/main.c
@@ -1020,7 +1020,11 @@ int __attribute__((used)) main(void) {
     // initialise the cpu and peripherals
     set_safe_mode(port_init());
 
+    // All ports need pins reset, after never-reset pins are marked in port_init();
+    reset_all_pins();
+
     port_heap_init();
+
 
     // Turn on RX and TX LEDs if we have them.
     init_rxtx_leds();

--- a/ports/atmel-samd/supervisor/port.c
+++ b/ports/atmel-samd/supervisor/port.c
@@ -339,10 +339,8 @@ safe_mode_t port_init(void) {
     init_shared_dma();
 
     // Reset everything into a known state before board_init.
+    // Pins are reset in main() after this routine returns.
     reset_port();
-
-    // Reset the pins too.
-    reset_all_pins();
 
     #ifdef SAMD21
     if (PM->RCAUSE.bit.BOD33 == 1 || PM->RCAUSE.bit.BOD12 == 1) {


### PR DESCRIPTION
- Fixes #10841.

Before #10699, `reset_all_pins()` was called in `reset_port()`. That PR changed things to reset all pins in `main()`
after the finalizers ran. However, that change only handled pin reset after the VM stopped, and not on power-up or hard reset.

This caused #10841, because the power control pin for Feather S3 TFT was not powering the display as
required before the display was reset. (It's not clear why this only affected older boards, but it may have to do with the some better power-on state of the display on newer boards.)

- Add a call to `reset_all_pins()` early in `main()` to now make sure that pins are reset properly.
- Remove a now-redundant call in `atmel-samd` `port_init()`.

It is worth testing this on various boards with various special pin behaviors to make sure it doesn't break things like deep sleep pin preservation and pin alarm reporting. I will do some testing on MagTag with deep sleep.