### PR TITLE
Fix S3 startup due to ble_gap_adv_active crash

### DIFF
--- a/ports/espressif/common-hal/_bleio/Adapter.c
+++ b/ports/espressif/common-hal/_bleio/Adapter.c
@@ -733,7 +733,7 @@ void common_hal_bleio_adapter_stop_advertising(bleio_adapter_obj_t *self) {
 }
 
 bool common_hal_bleio_adapter_get_advertising(bleio_adapter_obj_t *self) {
-    return ble_gap_adv_active();
+    return common_hal_bleio_adapter_get_enabled(self) && ble_gap_adv_active();
 }
 
 bool common_hal_bleio_adapter_get_connected(bleio_adapter_obj_t *self) {


### PR DESCRIPTION
ble_gap_adv_active() crashes now when BLE hasn't been init. This is likely due to internal memory allocations in esp-nimble.

So, check enabled before calling into it.

Fixes #10849
