### PR TITLE
Tweak flaky test

### DIFF
--- a/ports/zephyr-cp/tests/bsim/conftest.py
+++ b/ports/zephyr-cp/tests/bsim/conftest.py
@@ -97,7 +97,9 @@ def bsim_phy(request, bsim_phy_binary, native_sim_env, sim_id):
         sample_device_id = int(sample_marker.kwargs.get("device_id", 1))
         devices = max(devices, sample_device_id + 1)
 
-    sim_length_us = int(duration * 1e6)
+    # Do not pass -sim_length: if the PHY exits on simulated time, device 0 can
+    # still be flushing UART output and test output can get truncated. Instead,
+    # let pytest own process lifetime and terminate the PHY at fixture teardown.
     cmd = [
         "stdbuf",
         "-oL",
@@ -105,7 +107,6 @@ def bsim_phy(request, bsim_phy_binary, native_sim_env, sim_id):
         "-v=9",  # Cleaning up level is on 9. Connecting is 7.
         f"-s={sim_id}",
         f"-D={devices}",
-        f"-sim_length={sim_length_us}",
     ]
     print("Running:", " ".join(cmd))
     proc = subprocess.Popen(

--- a/ports/zephyr-cp/zephyr-config/west.yml
+++ b/ports/zephyr-cp/zephyr-config/west.yml
@@ -4,7 +4,7 @@ manifest:
   projects:
     - name: nrf_hw_models
       url: https://github.com/tannewt/ext_nRF_hw_models
-      revision: 24de78c485dce1a6048f8ae1c69a8d70c93b8cdd
+      revision: bb351cef9e5ab4d175fe3cb7c4d6761d837bac20
       path: modules/bsim_hw_models/nrf_hw_models
     - name: zephyr
       url: https://github.com/adafruit/zephyr


### PR DESCRIPTION
Now the bsim PHY will stay active until the test harness terminates it. This requires the CircuitPython device process to exit correctly first but is backed up by wall clock timeouts in the harness. (Sim timeouts were in simulated time.)
