### PR TITLE
Fix lvfontio full width glyphs

### DIFF
--- a/shared-module/lvfontio/OnDiskFont.c
+++ b/shared-module/lvfontio/OnDiskFont.c
@@ -226,23 +226,22 @@ static bool load_font_header(lvfontio_ondiskfont_t *self, FIL *file, size_t *max
                 // Throw away the bitmap bits.
                 read_bits(file, self->header.bits_per_pixel * bbox_w * bbox_h, &byte_val, &remaining_bits, NULL);
 
-                // Ignore zero-advance glyphs when inferring the terminal cell width.
-                // Some fonts include placeholders/control glyphs with zero advance,
-                // which would otherwise skew default_advance_width too small.
-                if (glyph_advance > 0) {
-                    if (advances[0] == glyph_advance) {
-                        advance_count[0]++;
-                    } else if (advances[1] == glyph_advance) {
-                        advance_count[1]++;
-                    } else if (advance_count[0] == 0) {
-                        advances[0] = glyph_advance;
-                        advance_count[0] = 1;
-                    } else if (advance_count[1] == 0) {
-                        advances[1] = glyph_advance;
-                        advance_count[1] = 1;
-                    } else {
-                        break;
-                    }
+                if (glyph_advance == 0) {
+                    // Ignore zero-advance glyphs when inferring the terminal cell width.
+                    // Some fonts include placeholders/control glyphs with zero advance,
+                    // which would otherwise skew default_advance_width too small.
+                } else if (advances[0] == glyph_advance) {
+                    advance_count[0]++;
+                } else if (advances[1] == glyph_advance) {
+                    advance_count[1]++;
+                } else if (advance_count[0] == 0) {
+                    advances[0] = glyph_advance;
+                    advance_count[0] = 1;
+                } else if (advance_count[1] == 0) {
+                    advances[1] = glyph_advance;
+                    advance_count[1] = 1;
+                } else {
+                    break;
                 }
                 cid++;
             }
@@ -592,12 +591,12 @@ int16_t common_hal_lvfontio_ondiskfont_cache_glyph(lvfontio_ondiskfont_t *self, 
         self->reference_counts[existing_slot]++;
 
         // Check if this is a full-width character by looking for a second slot
-        // with the same codepoint right after this one
-        bool cached_is_full_width = existing_slot + 1 < self->max_glyphs &&
-            self->codepoints[existing_slot + 1] == codepoint;
+        // with the same codepoint right after this one, wrapping at the end.
+        uint16_t next_slot = (existing_slot + 1) % self->max_glyphs;
+        bool cached_is_full_width = self->codepoints[next_slot] == codepoint;
 
         if (cached_is_full_width) {
-            self->reference_counts[existing_slot + 1]++;
+            self->reference_counts[next_slot]++;
         }
 
         if (is_full_width != NULL) {
@@ -756,10 +755,13 @@ static bool slot_has_active_full_width_partner(lvfontio_ondiskfont_t *self, uint
     }
 
     // Don't evict one half of a full-width pair while the other half is still in use.
-    if (slot > 0 && self->codepoints[slot - 1] == codepoint && self->reference_counts[slot - 1] > 0) {
+    uint16_t prev_slot = (slot + self->max_glyphs - 1) % self->max_glyphs;
+    uint16_t next_slot = (slot + 1) % self->max_glyphs;
+
+    if (self->codepoints[prev_slot] == codepoint && self->reference_counts[prev_slot] > 0) {
         return true;
     }
-    if (slot + 1 < self->max_glyphs && self->codepoints[slot + 1] == codepoint && self->reference_counts[slot + 1] > 0) {
+    if (self->codepoints[next_slot] == codepoint && self->reference_counts[next_slot] > 0) {
         return true;
     }
 


### PR DESCRIPTION
This PR has 3 fixes for lvfontio. 

- Fix `header.default_advance_width` from getting set to the wrong value. With Unifont 8x16/16x16 font the value of this was ending up as `4` which caused the right half of full-width glyphs not to render properly. Resolves: #10864. Fixed by ignoring zero advance glyphs when inferring the cell width.
- Fix a call to f_read() with `NULL` last parameter. The LLM suggested this fix without explicit prompt while working on this file. I am unsure about it, but I did find that all of the other instances of f_read() in this file use the same kind of `bytes_read` var for this argument, so the fix makes this instance match the rest.
- Fix right side slot possibly being overwritten by `find_free_slot()`. This one I even less sure about, but was also suggested by the LLM as a potential fix for only the left half of the glyphs showing, albeit not actually fixing that issue in practice. Resolved by adding `slot_has_active_full_width_partner()` and checking it before returning the slot. 


Tested fix on Fruit Jam and confirmed it now shows the full width glyph:
<img width="568" height="270" alt="image" src="https://github.com/user-attachments/assets/25a9d698-ec6c-4be2-9a09-ab8871dc0c03" />

Debugging and the proposed fix for this issue were done with help from LLM