### PR TITLE
Add heap stat tracking to native_sim

### DIFF
--- a/ports/zephyr-cp/supervisor/port.c
+++ b/ports/zephyr-cp/supervisor/port.c
@@ -16,6 +16,7 @@
 #include <zephyr/autoconf.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/reboot.h>
+#include <zephyr/sys/util.h>
 
 #if defined(CONFIG_ARCH_POSIX)
 #include <limits.h>
@@ -29,7 +30,16 @@
 #include "lib/tlsf/tlsf.h"
 #include <zephyr/device.h>
 
+#if defined(CONFIG_TRACING_PERFETTO) && defined(CONFIG_BOARD_NATIVE_SIM)
+#include "perfetto_encoder.h"
+#include <zephyr/sys/mem_stats.h>
+#define CIRCUITPY_PERFETTO_TRACK_GROUP_UUID 0x3000ULL
+#define CIRCUITPY_PERFETTO_VM_HEAP_USED_UUID 0x3001ULL
+#define CIRCUITPY_PERFETTO_OUTER_HEAP_USED_UUID 0x3002ULL
+#endif
+
 static tlsf_t heap;
+static size_t tlsf_heap_used = 0;
 
 // Auto generated in pins.c
 extern const struct device *const rams[];
@@ -72,12 +82,60 @@ static void native_sim_register_cmdline_opts(void) {
 NATIVE_TASK(native_sim_register_cmdline_opts, PRE_BOOT_1, 0);
 #endif
 
+#if defined(CONFIG_TRACING_PERFETTO) && defined(CONFIG_BOARD_NATIVE_SIM)
+static bool perfetto_circuitpython_tracks_emitted;
+
+static void perfetto_emit_outer_heap_stats(void) {
+    if (!perfetto_start()) {
+        return;
+    }
+    size_t total = tlsf_heap_used;
+    #if defined(CONFIG_COMMON_LIBC_MALLOC) && defined(CONFIG_SYS_HEAP_RUNTIME_STATS)
+    extern int malloc_runtime_stats_get(struct sys_memory_stats *stats);
+    struct sys_memory_stats stats;
+    if (malloc_runtime_stats_get(&stats) == 0) {
+        total += stats.allocated_bytes;
+    }
+    #endif
+    perfetto_emit_counter(CIRCUITPY_PERFETTO_OUTER_HEAP_USED_UUID, (int64_t)total);
+    Z_SPIN_DELAY(1);
+}
+
+static void perfetto_emit_circuitpython_tracks(void) {
+    if (perfetto_circuitpython_tracks_emitted) {
+        return;
+    }
+    if (!perfetto_start()) {
+        return;
+    }
+    perfetto_emit_track_descriptor(CIRCUITPY_PERFETTO_TRACK_GROUP_UUID,
+        perfetto_get_process_uuid(),
+        "CircuitPython");
+    perfetto_emit_counter_track_descriptor(CIRCUITPY_PERFETTO_VM_HEAP_USED_UUID,
+        CIRCUITPY_PERFETTO_TRACK_GROUP_UUID,
+        "VM Heap Used",
+        PERFETTO_COUNTER_UNIT_BYTES);
+    perfetto_emit_counter_track_descriptor(CIRCUITPY_PERFETTO_OUTER_HEAP_USED_UUID,
+        CIRCUITPY_PERFETTO_TRACK_GROUP_UUID,
+        "Outer Heap Used",
+        PERFETTO_COUNTER_UNIT_BYTES);
+    perfetto_circuitpython_tracks_emitted = true;
+}
+#else
+static inline void perfetto_emit_outer_heap_stats(void) {
+}
+
+static inline void perfetto_emit_circuitpython_tracks(void) {
+}
+#endif
+
 static void _tick_function(struct k_timer *timer_id) {
     supervisor_tick();
 }
 
 safe_mode_t port_init(void) {
     k_timer_init(&tick_timer, _tick_function, NULL);
+    perfetto_emit_circuitpython_tracks();
     return SAFE_MODE_NONE;
 }
 
@@ -233,6 +291,7 @@ void port_heap_init(void) {
         }
         valid_pool_count++;
     }
+    perfetto_emit_outer_heap_stats();
     #if !DT_HAS_CHOSEN(zephyr_sram)
     #error "No SRAM!"
     #endif
@@ -243,30 +302,54 @@ void *port_malloc(size_t size, bool dma_capable) {
     if (valid_pool_count > 0) {
         block = tlsf_malloc(heap, size);
     }
+    if (block != NULL) {
+        tlsf_heap_used += tlsf_block_size(block);
+    }
     #ifdef CONFIG_COMMON_LIBC_MALLOC
     if (block == NULL) {
         block = malloc(size);
     }
     #endif
+    if (block != NULL) {
+        perfetto_emit_outer_heap_stats();
+    }
     return block;
 }
 
 void port_free(void *ptr) {
-    if (valid_pool_count > 0 && !(ptr >= zephyr_malloc_bottom && ptr < zephyr_malloc_top)) {
-        tlsf_free(heap, ptr);
+    if (ptr == NULL) {
         return;
     }
-    #ifdef CONFIG_COMMON_LIBC_MALLOC
-    free(ptr);
-    #endif
+    if (valid_pool_count > 0 && !(ptr >= zephyr_malloc_bottom && ptr < zephyr_malloc_top)) {
+        tlsf_heap_used -= tlsf_block_size(ptr);
+        tlsf_free(heap, ptr);
+    } else {
+        #ifdef CONFIG_COMMON_LIBC_MALLOC
+        free(ptr);
+        #endif
+    }
+    perfetto_emit_outer_heap_stats();
 }
 
 void *port_realloc(void *ptr, size_t size, bool dma_capable) {
+    if (ptr == NULL) {
+        return port_malloc(size, dma_capable);
+    }
     if (valid_pool_count > 0 && !(ptr >= zephyr_malloc_bottom && ptr < zephyr_malloc_top)) {
-        return tlsf_realloc(heap, ptr, size);
+        size_t old_size = tlsf_block_size(ptr);
+        void *new_block = tlsf_realloc(heap, ptr, size);
+        if (new_block != NULL) {
+            tlsf_heap_used = tlsf_heap_used - old_size + tlsf_block_size(new_block);
+            perfetto_emit_outer_heap_stats();
+        }
+        return new_block;
     }
     #ifdef CONFIG_COMMON_LIBC_MALLOC
-    return realloc(ptr, size);
+    void *new_block = realloc(ptr, size);
+    if (new_block != NULL) {
+        perfetto_emit_outer_heap_stats();
+    }
+    return new_block;
     #endif
     return NULL;
 }

--- a/ports/zephyr-cp/zephyr-config/west.yml
+++ b/ports/zephyr-cp/zephyr-config/west.yml
@@ -8,6 +8,6 @@ manifest:
       path: modules/bsim_hw_models/nrf_hw_models
     - name: zephyr
       url: https://github.com/adafruit/zephyr
-      revision: 5351284ac926b1352ab98f5ae692a21f38068beb
+      revision: 589b2139926017d4d98724bac653ceb30802be9f
       clone-depth: 100
       import: true

--- a/py/gc.c
+++ b/py/gc.c
@@ -32,6 +32,12 @@
 #include "py/gc.h"
 #include "py/runtime.h"
 
+#if defined(__ZEPHYR__)
+#include <zephyr/autoconf.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+#endif
+
 #if MICROPY_DEBUG_VALGRIND
 #include <valgrind/memcheck.h>
 #endif
@@ -43,6 +49,12 @@
 
 #if CIRCUITPY_MEMORYMONITOR
 #include "shared-module/memorymonitor/__init__.h"
+#endif
+
+#if defined(__ZEPHYR__) && defined(CONFIG_TRACING_PERFETTO) && defined(CONFIG_BOARD_NATIVE_SIM)
+#include "perfetto_encoder.h"
+#define CIRCUITPY_PERFETTO_VM_HEAP_USED_UUID 0x3001ULL
+#define CIRCUITPY_PERFETTO_VM_HEAP_MAX_FREE_UUID 0x3002ULL
 #endif
 
 #if MICROPY_ENABLE_GC
@@ -156,6 +168,32 @@ void __attribute__ ((noinline)) gc_log_change(uint32_t start_block, uint32_t len
     change_me += length; // Break on this line.
 }
 #pragma GCC pop_options
+#endif
+
+#if defined(__ZEPHYR__) && defined(CONFIG_TRACING_PERFETTO) && defined(CONFIG_BOARD_NATIVE_SIM)
+static void gc_perfetto_emit_heap_stats(void) {
+    if (!perfetto_start()) {
+        return;
+    }
+    gc_info_t info;
+    gc_info(&info);
+    perfetto_emit_counter(CIRCUITPY_PERFETTO_VM_HEAP_USED_UUID, (int64_t)info.used);
+    Z_SPIN_DELAY(1);
+}
+
+static void gc_perfetto_emit_heap_stopped(void) {
+    if (!perfetto_start()) {
+        return;
+    }
+    perfetto_emit_counter(CIRCUITPY_PERFETTO_VM_HEAP_USED_UUID, 0);
+    Z_SPIN_DELAY(1);
+}
+#else
+static inline void gc_perfetto_emit_heap_stats(void) {
+}
+
+static inline void gc_perfetto_emit_heap_stopped(void) {
+}
 #endif
 
 // Static functions for individual steps of the GC mark/sweep sequence
@@ -284,6 +322,7 @@ void gc_init(void *start, void *end) {
     #endif
 
     GC_MUTEX_INIT();
+    gc_perfetto_emit_heap_stats();
 }
 
 #if MICROPY_GC_SPLIT_HEAP
@@ -425,6 +464,7 @@ void gc_deinit(void) {
     // Run any finalisers before we stop using the heap. This will also free
     // any additional heap areas (but not the first.)
     gc_sweep_all();
+    gc_perfetto_emit_heap_stopped();
     memset(&MP_STATE_MEM(area), 0, sizeof(MP_STATE_MEM(area)));
 }
 
@@ -654,6 +694,7 @@ void gc_collect_end(void) {
     }
     MP_STATE_THREAD(gc_lock_depth) &= ~GC_COLLECT_FLAG;
     GC_EXIT();
+    gc_perfetto_emit_heap_stats();
 }
 
 static void gc_deal_with_stack_overflow(void) {
@@ -1069,6 +1110,8 @@ found:
     memorymonitor_track_allocation(end_block - start_block + 1);
     #endif
 
+    gc_perfetto_emit_heap_stats();
+
     return ret_ptr;
 }
 
@@ -1150,6 +1193,7 @@ void gc_free(void *ptr) {
     } while (ATB_GET_KIND(area, block) == AT_TAIL);
 
     GC_EXIT();
+    gc_perfetto_emit_heap_stats();
 
     #if EXTENSIVE_HEAP_PROFILING
     gc_dump_alloc_table(&mp_plat_print);
@@ -1290,6 +1334,8 @@ void *gc_realloc(void *ptr_in, size_t n_bytes, bool allow_move) {
         memorymonitor_track_allocation(new_blocks);
         #endif
 
+        gc_perfetto_emit_heap_stats();
+
         return ptr_in;
     }
 
@@ -1326,6 +1372,8 @@ void *gc_realloc(void *ptr_in, size_t n_bytes, bool allow_move) {
         #if CIRCUITPY_MEMORYMONITOR
         memorymonitor_track_allocation(new_blocks);
         #endif
+
+        gc_perfetto_emit_heap_stats();
 
         return ptr_in;
     }


### PR DESCRIPTION
This adds two tracks "Outer Heap Used" and "VM Heap Used" to the output perfetto trace.

<img width="2218" height="1807" alt="image" src="https://github.com/user-attachments/assets/d682e63f-295c-44fd-a729-11fbe46fe77c" />
