### PR TITLE
in `*_make_new()`, allocate obj only after all validations

### DIFF
--- a/shared-bindings/_bleio/Address.c
+++ b/shared-bindings/_bleio/Address.c
@@ -37,8 +37,6 @@ static mp_obj_t bleio_address_make_new(const mp_obj_type_t *type, size_t n_args,
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    bleio_address_obj_t *self = mp_obj_malloc(bleio_address_obj_t, &bleio_address_type);
-
     const mp_obj_t address = args[ARG_address].u_obj;
     mp_buffer_info_t buf_info;
     mp_get_buffer_raise(address, &buf_info, MP_BUFFER_READ);
@@ -51,6 +49,7 @@ static mp_obj_t bleio_address_make_new(const mp_obj_type_t *type, size_t n_args,
         mp_arg_error_invalid(MP_QSTR_address_type);
     }
 
+    bleio_address_obj_t *self = mp_obj_malloc(bleio_address_obj_t, &bleio_address_type);
     common_hal_bleio_address_construct(self, buf_info.buf, address_type);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/_bleio/UUID.c
+++ b/shared-bindings/_bleio/UUID.c
@@ -34,8 +34,6 @@
 static mp_obj_t bleio_uuid_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
 
-    bleio_uuid_obj_t *self = mp_obj_malloc(bleio_uuid_obj_t, &bleio_uuid_type);
-
     const mp_obj_t value = all_args[0];
     uint8_t uuid128[16];
 
@@ -46,8 +44,10 @@ static mp_obj_t bleio_uuid_make_new(const mp_obj_type_t *type, size_t n_args, si
         }
 
         // NULL means no 128-bit value.
+        bleio_uuid_obj_t *self = mp_obj_malloc(bleio_uuid_obj_t, &bleio_uuid_type);
         common_hal_bleio_uuid_construct(self, uuid16, NULL);
 
+        return MP_OBJ_FROM_PTR(self);
     } else {
         if (mp_obj_is_str(value)) {
             // 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
@@ -93,10 +93,12 @@ static mp_obj_t bleio_uuid_make_new(const mp_obj_type_t *type, size_t n_args, si
         uint32_t uuid16 = (uuid128[13] << 8) | uuid128[12];
         uuid128[12] = 0;
         uuid128[13] = 0;
-        common_hal_bleio_uuid_construct(self, uuid16, uuid128);
-    }
 
-    return MP_OBJ_FROM_PTR(self);
+        bleio_uuid_obj_t *self = mp_obj_malloc(bleio_uuid_obj_t, &bleio_uuid_type);
+        common_hal_bleio_uuid_construct(self, uuid16, uuid128);
+
+        return MP_OBJ_FROM_PTR(self);
+    }
 }
 
 //|     uuid16: int

--- a/shared-bindings/_stage/Layer.c
+++ b/shared-bindings/_stage/Layer.c
@@ -38,37 +38,37 @@ static mp_obj_t layer_make_new(const mp_obj_type_t *type, size_t n_args,
     size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 4, 5, false);
 
+    mp_uint_t width = mp_arg_validate_int_min(mp_obj_get_int(args[0]), 0, MP_QSTR_width);
+    mp_uint_t height = mp_arg_validate_int_min(mp_obj_get_int(args[1]), 0, MP_QSTR_height);
+
+    mp_buffer_info_t graphic_bufinfo;
+    mp_get_buffer_raise(args[2], &graphic_bufinfo, MP_BUFFER_READ);
+    mp_arg_validate_length(graphic_bufinfo.len, 2048, MP_QSTR_graphic);
+
+    mp_buffer_info_t palette_bufinfo;
+    mp_get_buffer_raise(args[3], &palette_bufinfo, MP_BUFFER_READ);
+    mp_arg_validate_length(palette_bufinfo.len, 32, MP_QSTR_palette);
+
+    mp_buffer_info_t map_bufinfo = { .buf = NULL };
+    if (n_args > 4) {
+        mp_get_buffer_raise(args[4], &map_bufinfo, MP_BUFFER_READ);
+        if (map_bufinfo.len < (width * height) / 2) {
+            mp_raise_ValueError(MP_ERROR_TEXT("map buffer too small"));
+        }
+    }
+
+    // Only allocate after validation is finished.
     layer_obj_t *self = mp_obj_malloc(layer_obj_t, type);
 
-    self->width = mp_obj_get_int(args[0]);
-    self->height = mp_obj_get_int(args[1]);
+    self->width = width;
+    self->height = height;
     self->x = 0;
     self->y = 0;
     self->frame = 0;
     self->rotation = false;
-
-    mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
-    self->graphic = bufinfo.buf;
-    if (bufinfo.len != 2048) {
-        mp_raise_ValueError(MP_ERROR_TEXT("graphic must be 2048 bytes long"));
-    }
-
-    mp_get_buffer_raise(args[3], &bufinfo, MP_BUFFER_READ);
-    self->palette = bufinfo.buf;
-    if (bufinfo.len != 32) {
-        mp_raise_ValueError(MP_ERROR_TEXT("palette must be 32 bytes long"));
-    }
-
-    if (n_args > 4) {
-        mp_get_buffer_raise(args[4], &bufinfo, MP_BUFFER_READ);
-        self->map = bufinfo.buf;
-        if (bufinfo.len < (self->width * self->height) / 2) {
-            mp_raise_ValueError(MP_ERROR_TEXT("map buffer too small"));
-        }
-    } else {
-        self->map = NULL;
-    }
+    self->graphic = graphic_bufinfo.buf;
+    self->palette = palette_bufinfo.buf;
+    self->map = map_bufinfo.buf;
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/_stage/Text.c
+++ b/shared-bindings/_stage/Text.c
@@ -38,31 +38,31 @@ static mp_obj_t text_make_new(const mp_obj_type_t *type, size_t n_args,
     size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 5, 5, false);
 
-    text_obj_t *self = mp_obj_malloc(text_obj_t, type);
+    mp_uint_t width = mp_arg_validate_int_min(mp_obj_get_int(args[0]), 0, MP_QSTR_width);
+    mp_uint_t height = mp_arg_validate_int_min(mp_obj_get_int(args[1]), 0, MP_QSTR_height);
 
-    self->width = mp_obj_get_int(args[0]);
-    self->height = mp_obj_get_int(args[1]);
-    self->x = 0;
-    self->y = 0;
+    mp_buffer_info_t font_bufinfo;
+    mp_get_buffer_raise(args[2], &font_bufinfo, MP_BUFFER_READ);
+    mp_arg_validate_length(font_bufinfo.len, 2048, MP_QSTR_font);
 
-    mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args[2], &bufinfo, MP_BUFFER_READ);
-    self->font = bufinfo.buf;
-    if (bufinfo.len != 2048) {
-        mp_raise_ValueError(MP_ERROR_TEXT("font must be 2048 bytes long"));
-    }
+    mp_buffer_info_t palette_bufinfo;
+    mp_get_buffer_raise(args[3], &palette_bufinfo, MP_BUFFER_READ);
+    mp_arg_validate_length(font_bufinfo.len, 32, MP_QSTR_palette);
 
-    mp_get_buffer_raise(args[3], &bufinfo, MP_BUFFER_READ);
-    self->palette = bufinfo.buf;
-    if (bufinfo.len != 32) {
-        mp_raise_ValueError(MP_ERROR_TEXT("palette must be 32 bytes long"));
-    }
-
-    mp_get_buffer_raise(args[4], &bufinfo, MP_BUFFER_READ);
-    self->chars = bufinfo.buf;
-    if (bufinfo.len < self->width * self->height) {
+    mp_buffer_info_t chars_bufinfo;
+    mp_get_buffer_raise(args[4], &chars_bufinfo, MP_BUFFER_READ);
+    if (chars_bufinfo.len < width * height) {
         mp_raise_ValueError(MP_ERROR_TEXT("chars buffer too small"));
     }
+
+    text_obj_t *self = mp_obj_malloc(text_obj_t, type);
+    self->width = width;
+    self->height = height;
+    self->x = 0;
+    self->y = 0;
+    self->font = font_bufinfo.buf;
+    self->palette = palette_bufinfo.buf;
+    self->chars = chars_bufinfo.buf;
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/adafruit_bus_device/i2c_device/I2CDevice.c
+++ b/shared-bindings/adafruit_bus_device/i2c_device/I2CDevice.c
@@ -47,8 +47,6 @@
 //|     ...
 //|
 static mp_obj_t adafruit_bus_device_i2cdevice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    adafruit_bus_device_i2cdevice_obj_t *self =
-        mp_obj_malloc(adafruit_bus_device_i2cdevice_obj_t, &adafruit_bus_device_i2cdevice_type);
     enum { ARG_i2c, ARG_device_address, ARG_probe };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -60,12 +58,14 @@ static mp_obj_t adafruit_bus_device_i2cdevice_make_new(const mp_obj_type_t *type
 
     mp_obj_t *i2c = args[ARG_i2c].u_obj;
 
+    adafruit_bus_device_i2cdevice_obj_t *self =
+        mp_obj_malloc(adafruit_bus_device_i2cdevice_obj_t, &adafruit_bus_device_i2cdevice_type);
     common_hal_adafruit_bus_device_i2cdevice_construct(MP_OBJ_TO_PTR(self), i2c, args[ARG_device_address].u_int);
     if (args[ARG_probe].u_bool == true) {
         common_hal_adafruit_bus_device_i2cdevice_probe_for_device(self);
     }
 
-    return (mp_obj_t)self;
+    return MP_OBJ_FROM_PTR(self);
 }
 
 //|     def __enter__(self) -> I2CDevice:

--- a/shared-bindings/adafruit_bus_device/spi_device/SPIDevice.c
+++ b/shared-bindings/adafruit_bus_device/spi_device/SPIDevice.c
@@ -59,8 +59,6 @@
 //|     ...
 //|
 static mp_obj_t adafruit_bus_device_spidevice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    adafruit_bus_device_spidevice_obj_t *self =
-        mp_obj_malloc(adafruit_bus_device_spidevice_obj_t, &adafruit_bus_device_spidevice_type);
     enum { ARG_spi, ARG_chip_select, ARG_cs_active_value, ARG_baudrate, ARG_polarity, ARG_phase, ARG_extra_clocks };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_spi, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -78,12 +76,11 @@ static mp_obj_t adafruit_bus_device_spidevice_make_new(const mp_obj_type_t *type
 
     mp_arg_validate_type_or_none(args[ARG_chip_select].u_obj, &digitalio_digitalinout_type, MP_QSTR_chip_select);
 
-    common_hal_adafruit_bus_device_spidevice_construct(MP_OBJ_TO_PTR(self), spi, args[ARG_chip_select].u_obj, args[ARG_cs_active_value].u_bool, args[ARG_baudrate].u_int, args[ARG_polarity].u_int,
-        args[ARG_phase].u_int, args[ARG_extra_clocks].u_int);
-
     if (args[ARG_chip_select].u_obj != mp_const_none) {
-        digitalinout_result_t result = common_hal_digitalio_digitalinout_switch_to_output(MP_OBJ_TO_PTR(args[ARG_chip_select].u_obj),
-            true, DRIVE_MODE_PUSH_PULL);
+        digitalinout_result_t result =
+            common_hal_digitalio_digitalinout_switch_to_output(MP_OBJ_TO_PTR(args[ARG_chip_select].u_obj),
+                true,
+                DRIVE_MODE_PUSH_PULL);
         #if CIRCUITPY_DIGITALIO_HAVE_INPUT_ONLY
         if (result == DIGITALINOUT_INPUT_ONLY) {
             mp_raise_NotImplementedError(MP_ERROR_TEXT("Pin is input only"));
@@ -93,7 +90,19 @@ static mp_obj_t adafruit_bus_device_spidevice_make_new(const mp_obj_type_t *type
         #endif
     }
 
-    return (mp_obj_t)self;
+    adafruit_bus_device_spidevice_obj_t *self =
+        mp_obj_malloc(adafruit_bus_device_spidevice_obj_t, &adafruit_bus_device_spidevice_type);
+    common_hal_adafruit_bus_device_spidevice_construct(MP_OBJ_TO_PTR(self),
+        spi,
+        args[ARG_chip_select].u_obj,
+        args[ARG_cs_active_value].u_bool,
+        args[ARG_baudrate].u_int,
+        args[ARG_polarity].u_int,
+        args[ARG_phase].u_int,
+        args[ARG_extra_clocks].u_int);
+
+
+    return MP_OBJ_FROM_PTR(self);
 }
 
 //|     def __enter__(self) -> busio.SPI:

--- a/shared-bindings/aesio/aes.c
+++ b/shared-bindings/aesio/aes.c
@@ -55,8 +55,6 @@
 
 static mp_obj_t aesio_aes_make_new(const mp_obj_type_t *type, size_t n_args,
     size_t n_kw, const mp_obj_t *all_args) {
-    aesio_aes_obj_t *self = mp_obj_malloc(aesio_aes_obj_t, &aesio_aes_type);
-
     enum { ARG_key, ARG_mode, ARG_IV, ARG_counter, ARG_segment_size };
     static const mp_arg_t allowed_args[] = {
         {MP_QSTR_key, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_obj = MP_OBJ_NULL} },
@@ -100,8 +98,10 @@ static mp_obj_t aesio_aes_make_new(const mp_obj_type_t *type, size_t n_args,
         iv = bufinfo.buf;
     }
 
+    aesio_aes_obj_t *self = mp_obj_malloc(aesio_aes_obj_t, &aesio_aes_type);
     common_hal_aesio_aes_construct(self, key, key_length, iv, mode,
         args[ARG_counter].u_int);
+
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/alarm/pin/PinAlarm.c
+++ b/shared-bindings/alarm/pin/PinAlarm.c
@@ -42,7 +42,6 @@
 //|         ...
 //|
 static mp_obj_t alarm_pin_pinalarm_make_new(const mp_obj_type_t *type, mp_uint_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    alarm_pin_pinalarm_obj_t *self = mp_obj_malloc(alarm_pin_pinalarm_obj_t, &alarm_pin_pinalarm_type);
     enum { ARG_pin, ARG_value, ARG_edge, ARG_pull };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pin, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -55,6 +54,7 @@ static mp_obj_t alarm_pin_pinalarm_make_new(const mp_obj_type_t *type, mp_uint_t
 
     const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
 
+    alarm_pin_pinalarm_obj_t *self = mp_obj_malloc(alarm_pin_pinalarm_obj_t, &alarm_pin_pinalarm_type);
     common_hal_alarm_pin_pinalarm_construct(self,
         pin,
         args[ARG_value].u_bool,

--- a/shared-bindings/alarm/time/TimeAlarm.c
+++ b/shared-bindings/alarm/time/TimeAlarm.c
@@ -46,8 +46,6 @@ mp_obj_t MP_WEAK rtc_get_time_source_time(void) {
 //|
 static mp_obj_t alarm_time_timealarm_make_new(const mp_obj_type_t *type,
     size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    alarm_time_timealarm_obj_t *self = mp_obj_malloc(alarm_time_timealarm_obj_t, &alarm_time_timealarm_type);
-
     enum { ARG_monotonic_time, ARG_epoch_time };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_monotonic_time, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
@@ -92,6 +90,7 @@ static mp_obj_t alarm_time_timealarm_make_new(const mp_obj_type_t *type,
         mp_raise_ValueError(MP_ERROR_TEXT("Time is in the past."));
     }
 
+    alarm_time_timealarm_obj_t *self = mp_obj_malloc(alarm_time_timealarm_obj_t, &alarm_time_timealarm_type);
     common_hal_alarm_time_timealarm_construct(self, monotonic_time);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/alarm/touch/TouchAlarm.c
+++ b/shared-bindings/alarm/touch/TouchAlarm.c
@@ -26,8 +26,6 @@
 //|
 static mp_obj_t alarm_touch_touchalarm_make_new(const mp_obj_type_t *type,
     size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    alarm_touch_touchalarm_obj_t *self = mp_obj_malloc(alarm_touch_touchalarm_obj_t, &alarm_touch_touchalarm_type);
-
     enum { ARG_pin };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pin, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -38,6 +36,7 @@ static mp_obj_t alarm_touch_touchalarm_make_new(const mp_obj_type_t *type,
 
     const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
 
+    alarm_touch_touchalarm_obj_t *self = mp_obj_malloc(alarm_touch_touchalarm_obj_t, &alarm_touch_touchalarm_type);
     common_hal_alarm_touch_touchalarm_construct(self, pin);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/analogbufio/BufferedIn.c
+++ b/shared-bindings/analogbufio/BufferedIn.c
@@ -60,10 +60,8 @@ static mp_obj_t analogbufio_bufferedin_make_new(const mp_obj_type_t *type, size_
     // Validate Pin
     const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
 
-    // Create local object
-    analogbufio_bufferedin_obj_t *self = mp_obj_malloc_with_finaliser(analogbufio_bufferedin_obj_t, &analogbufio_bufferedin_type);
-
-    // Call local interface in ports/common-hal/analogbufio
+    analogbufio_bufferedin_obj_t *self =
+        mp_obj_malloc_with_finaliser(analogbufio_bufferedin_obj_t, &analogbufio_bufferedin_type);
     common_hal_analogbufio_bufferedin_construct(self, pin, args[ARG_sample_rate].u_int);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/audiobusio/PDMIn.c
+++ b/shared-bindings/audiobusio/PDMIn.c
@@ -96,9 +96,6 @@ static mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_ar
     const mcu_pin_obj_t *clock_pin = validate_obj_is_free_pin(args[ARG_clock_pin].u_obj, MP_QSTR_clock_pin);
     const mcu_pin_obj_t *data_pin = validate_obj_is_free_pin(args[ARG_data_pin].u_obj, MP_QSTR_data_pin);
 
-    // create PDMIn object from the given pin
-    audiobusio_pdmin_obj_t *self = mp_obj_malloc_with_finaliser(audiobusio_pdmin_obj_t, &audiobusio_pdmin_type);
-
     uint32_t sample_rate = args[ARG_sample_rate].u_int;
     uint8_t bit_depth = args[ARG_bit_depth].u_int;
     if (bit_depth % 8 != 0) {
@@ -115,6 +112,7 @@ static mp_obj_t audiobusio_pdmin_make_new(const mp_obj_type_t *type, size_t n_ar
         : mp_obj_get_float(args[ARG_startup_delay].u_obj);
     mp_arg_validate_float_range(startup_delay, 0.0f, 1.0f, MP_QSTR_startup_delay);
 
+    audiobusio_pdmin_obj_t *self = mp_obj_malloc_with_finaliser(audiobusio_pdmin_obj_t, &audiobusio_pdmin_type);
     common_hal_audiobusio_pdmin_construct(self, clock_pin, data_pin, sample_rate,
         bit_depth, mono, oversample);
 

--- a/shared-bindings/audiocore/RawSample.c
+++ b/shared-bindings/audiocore/RawSample.c
@@ -90,7 +90,6 @@ static mp_obj_t audioio_rawsample_make_new(const mp_obj_type_t *type, size_t n_a
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    audioio_rawsample_obj_t *self = mp_obj_malloc(audioio_rawsample_obj_t, &audioio_rawsample_type);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_READ);
     uint8_t bytes_per_sample = 1;
@@ -103,9 +102,16 @@ static mp_obj_t audioio_rawsample_make_new(const mp_obj_type_t *type, size_t n_a
     if (!args[ARG_single_buffer].u_bool && bufinfo.len % (bytes_per_sample * args[ARG_channel_count].u_int * 2) != 0) {
         mp_raise_ValueError_varg(MP_ERROR_TEXT("Length of %q must be an even multiple of channel_count * type_size"), MP_QSTR_buffer);
     }
-    common_hal_audioio_rawsample_construct(self, ((uint8_t *)bufinfo.buf), bufinfo.len,
-        bytes_per_sample, signed_samples, args[ARG_channel_count].u_int,
-        args[ARG_sample_rate].u_int, args[ARG_single_buffer].u_bool);
+
+    audioio_rawsample_obj_t *self = mp_obj_malloc(audioio_rawsample_obj_t, &audioio_rawsample_type);
+    common_hal_audioio_rawsample_construct(self,
+        ((uint8_t *)bufinfo.buf),
+        bufinfo.len,
+        bytes_per_sample,
+        signed_samples,
+        args[ARG_channel_count].u_int,
+        args[ARG_sample_rate].u_int,
+        args[ARG_single_buffer].u_bool);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/audiocore/WaveFile.c
+++ b/shared-bindings/audiocore/WaveFile.c
@@ -60,7 +60,6 @@ static mp_obj_t audioio_wavefile_make_new(const mp_obj_type_t *type, size_t n_ar
         arg = mp_call_function_2(MP_OBJ_FROM_PTR(&mp_builtin_open_obj), arg, MP_ROM_QSTR(MP_QSTR_rb));
     }
 
-    audioio_wavefile_obj_t *self = mp_obj_malloc(audioio_wavefile_obj_t, &audioio_wavefile_type);
     if (!mp_obj_is_type(arg, &mp_type_vfs_fat_fileio)) {
         mp_raise_TypeError(MP_ERROR_TEXT("file must be a file opened in byte mode"));
     }
@@ -72,6 +71,8 @@ static mp_obj_t audioio_wavefile_make_new(const mp_obj_type_t *type, size_t n_ar
         buffer = bufinfo.buf;
         buffer_size = mp_arg_validate_length_range(bufinfo.len, 8, 1024, MP_QSTR_buffer);
     }
+
+    audioio_wavefile_obj_t *self = mp_obj_malloc(audioio_wavefile_obj_t, &audioio_wavefile_type);
     common_hal_audioio_wavefile_construct(self, MP_OBJ_TO_PTR(arg),
         buffer, buffer_size);
 

--- a/shared-bindings/audiodelays/PitchShift.c
+++ b/shared-bindings/audiodelays/PitchShift.c
@@ -94,8 +94,18 @@ static mp_obj_t audiodelays_pitch_shift_make_new(const mp_obj_type_t *type, size
         mp_raise_ValueError(MP_ERROR_TEXT("bits_per_sample must be 8 or 16"));
     }
 
-    audiodelays_pitch_shift_obj_t *self = mp_obj_malloc(audiodelays_pitch_shift_obj_t, &audiodelays_pitch_shift_type);
-    common_hal_audiodelays_pitch_shift_construct(self, args[ARG_semitones].u_obj, args[ARG_mix].u_obj, args[ARG_window].u_int, args[ARG_overlap].u_int, args[ARG_buffer_size].u_int, bits_per_sample, args[ARG_samples_signed].u_bool, channel_count, sample_rate);
+    audiodelays_pitch_shift_obj_t *self =
+        mp_obj_malloc(audiodelays_pitch_shift_obj_t, &audiodelays_pitch_shift_type);
+    common_hal_audiodelays_pitch_shift_construct(self,
+        args[ARG_semitones].u_obj,
+        args[ARG_mix].u_obj,
+        args[ARG_window].u_int,
+        args[ARG_overlap].u_int,
+        args[ARG_buffer_size].u_int,
+        bits_per_sample,
+        args[ARG_samples_signed].u_bool,
+        channel_count,
+        sample_rate);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/audiofilters/Distortion.c
+++ b/shared-bindings/audiofilters/Distortion.c
@@ -145,8 +145,21 @@ static mp_obj_t audiofilters_distortion_make_new(const mp_obj_type_t *type, size
         mode = validate_distortion_mode(args[ARG_mode].u_obj, MP_QSTR_mode);
     }
 
-    audiofilters_distortion_obj_t *self = mp_obj_malloc(audiofilters_distortion_obj_t, &audiofilters_distortion_type);
-    common_hal_audiofilters_distortion_construct(self, args[ARG_drive].u_obj, args[ARG_pre_gain].u_obj, args[ARG_post_gain].u_obj, mode, args[ARG_soft_clip].u_obj, args[ARG_mix].u_obj, args[ARG_buffer_size].u_int, bits_per_sample, args[ARG_samples_signed].u_bool, channel_count, sample_rate);
+    audiofilters_distortion_obj_t *self =
+        mp_obj_malloc(audiofilters_distortion_obj_t, &audiofilters_distortion_type);
+    common_hal_audiofilters_distortion_construct(self,
+        args[ARG_drive].u_obj,
+        args[ARG_pre_gain].u_obj,
+        args[ARG_post_gain].u_obj,
+        mode,
+        args[ARG_soft_clip].u_obj,
+        args[ARG_mix].u_obj,
+        args[ARG_buffer_size].u_int,
+        bits_per_sample,
+        args[ARG_samples_signed].u_bool,
+        channel_count,
+        sample_rate);
+
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/audiofilters/Filter.c
+++ b/shared-bindings/audiofilters/Filter.c
@@ -91,7 +91,14 @@ static mp_obj_t audiofilters_filter_make_new(const mp_obj_type_t *type, size_t n
     }
 
     audiofilters_filter_obj_t *self = mp_obj_malloc(audiofilters_filter_obj_t, &audiofilters_filter_type);
-    common_hal_audiofilters_filter_construct(self, args[ARG_filter].u_obj, args[ARG_mix].u_obj, args[ARG_buffer_size].u_int, bits_per_sample, args[ARG_samples_signed].u_bool, channel_count, sample_rate);
+    common_hal_audiofilters_filter_construct(self,
+        args[ARG_filter].u_obj,
+        args[ARG_mix].u_obj,
+        args[ARG_buffer_size].u_int,
+        bits_per_sample,
+        args[ARG_samples_signed].u_bool,
+        channel_count,
+        sample_rate);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/audiofilters/Phaser.c
+++ b/shared-bindings/audiofilters/Phaser.c
@@ -91,7 +91,16 @@ static mp_obj_t audiofilters_phaser_make_new(const mp_obj_type_t *type, size_t n
     }
 
     audiofilters_phaser_obj_t *self = mp_obj_malloc(audiofilters_phaser_obj_t, &audiofilters_phaser_type);
-    common_hal_audiofilters_phaser_construct(self, args[ARG_frequency].u_obj, args[ARG_feedback].u_obj, args[ARG_mix].u_obj, args[ARG_stages].u_int, args[ARG_buffer_size].u_int, bits_per_sample, args[ARG_samples_signed].u_bool, channel_count, sample_rate);
+    common_hal_audiofilters_phaser_construct(self,
+        args[ARG_frequency].u_obj,
+        args[ARG_feedback].u_obj,
+        args[ARG_mix].u_obj,
+        args[ARG_stages].u_int,
+        args[ARG_buffer_size].u_int,
+        bits_per_sample,
+        args[ARG_samples_signed].u_bool,
+        channel_count,
+        sample_rate);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/audioio/AudioOut.c
+++ b/shared-bindings/audioio/AudioOut.c
@@ -103,7 +103,10 @@ static mp_obj_t audioio_audioout_make_new(const mp_obj_type_t *type, size_t n_ar
 
     // create AudioOut object from the given pin
     audioio_audioout_obj_t *self = mp_obj_malloc_with_finaliser(audioio_audioout_obj_t, &audioio_audioout_type);
-    common_hal_audioio_audioout_construct(self, left_channel_pin, right_channel_pin, args[ARG_quiescent_value].u_int);
+    common_hal_audioio_audioout_construct(self,
+        left_channel_pin,
+        right_channel_pin,
+        args[ARG_quiescent_value].u_int);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/audiomixer/MixerVoice.c
+++ b/shared-bindings/audiomixer/MixerVoice.c
@@ -29,8 +29,8 @@
 // TODO: support mono or stereo voices
 static mp_obj_t audiomixer_mixervoice_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
-    audiomixer_mixervoice_obj_t *self = mp_obj_malloc(audiomixer_mixervoice_obj_t, &audiomixer_mixervoice_type);
 
+    audiomixer_mixervoice_obj_t *self = mp_obj_malloc(audiomixer_mixervoice_obj_t, &audiomixer_mixervoice_type);
     common_hal_audiomixer_mixervoice_construct(self);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/audiomp3/MP3Decoder.c
+++ b/shared-bindings/audiomp3/MP3Decoder.c
@@ -91,8 +91,6 @@ static mp_obj_t audiomp3_mp3file_make_new(const mp_obj_type_t *type, size_t n_ar
         stream = mp_call_function_2(MP_OBJ_FROM_PTR(&mp_builtin_open_obj), stream, MP_ROM_QSTR(MP_QSTR_rb));
     }
 
-    audiomp3_mp3file_obj_t *self = mp_obj_malloc_with_finaliser(audiomp3_mp3file_obj_t, &audiomp3_mp3file_type);
-
     const mp_stream_p_t *stream_p = mp_get_stream_raise(stream, MP_STREAM_OP_READ);
 
     if (stream_p->is_text) {
@@ -106,6 +104,8 @@ static mp_obj_t audiomp3_mp3file_make_new(const mp_obj_type_t *type, size_t n_ar
         buffer = bufinfo.buf;
         buffer_size = bufinfo.len;
     }
+
+    audiomp3_mp3file_obj_t *self = mp_obj_malloc_with_finaliser(audiomp3_mp3file_obj_t, &audiomp3_mp3file_type);
     common_hal_audiomp3_mp3file_construct(self, stream, buffer, buffer_size);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/audiopwmio/PWMAudioOut.c
+++ b/shared-bindings/audiopwmio/PWMAudioOut.c
@@ -100,8 +100,10 @@ static mp_obj_t audiopwmio_pwmaudioout_make_new(const mp_obj_type_t *type, size_
     // create AudioOut object from the given pin
     // The object is created with a finaliser as some ports use these (rather than 'reset' functions)
     // to ensure resources are collected at interpreter shutdown.
-    audiopwmio_pwmaudioout_obj_t *self = mp_obj_malloc_with_finaliser(audiopwmio_pwmaudioout_obj_t, &audiopwmio_pwmaudioout_type);
-    common_hal_audiopwmio_pwmaudioout_construct(self, left_channel_pin, right_channel_pin, args[ARG_quiescent_value].u_int);
+    audiopwmio_pwmaudioout_obj_t *self =
+        mp_obj_malloc_with_finaliser(audiopwmio_pwmaudioout_obj_t, &audiopwmio_pwmaudioout_type);
+    common_hal_audiopwmio_pwmaudioout_construct(self,
+        left_channel_pin, right_channel_pin, args[ARG_quiescent_value].u_int);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/bitbangio/I2C.c
+++ b/shared-bindings/bitbangio/I2C.c
@@ -59,7 +59,8 @@ static mp_obj_t bitbangio_i2c_make_new(const mp_obj_type_t *type, size_t n_args,
 
     bitbangio_i2c_obj_t *self = mp_obj_malloc_with_finaliser(bitbangio_i2c_obj_t, &bitbangio_i2c_type);
     shared_module_bitbangio_i2c_construct(self, args[ARG_scl].u_obj, args[ARG_sda].u_obj, args[ARG_frequency].u_int, args[ARG_timeout].u_int);
-    return (mp_obj_t)self;
+
+    return MP_OBJ_FROM_PTR(self);
 }
 
 //|     def deinit(self) -> None:

--- a/shared-bindings/bitbangio/SPI.c
+++ b/shared-bindings/bitbangio/SPI.c
@@ -67,7 +67,7 @@ static mp_obj_t bitbangio_spi_make_new(const mp_obj_type_t *type, size_t n_args,
 
     bitbangio_spi_obj_t *self = mp_obj_malloc(bitbangio_spi_obj_t, &bitbangio_spi_type);
     shared_module_bitbangio_spi_construct(self, args[ARG_clock].u_obj, args[ARG_MOSI].u_obj, args[ARG_MISO].u_obj);
-    return (mp_obj_t)self;
+    return MP_OBJ_FROM_PTR(self);
 }
 
 //|     def deinit(self) -> None:

--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -67,7 +67,7 @@ static mp_obj_t busio_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     busio_i2c_obj_t *self = mp_obj_malloc_with_finaliser(busio_i2c_obj_t, &busio_i2c_type);
     common_hal_busio_i2c_construct(self, scl, sda, args[ARG_frequency].u_int, args[ARG_timeout].u_int);
-    return (mp_obj_t)self;
+    return MP_OBJ_FROM_PTR(self);
     #else
     mp_raise_NotImplementedError(NULL);
     #endif // CIRCUITPY_BUSIO_I2C

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -88,7 +88,6 @@
 // TODO(tannewt): Support LSB SPI.
 static mp_obj_t busio_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     #if CIRCUITPY_BUSIO_SPI
-    busio_spi_obj_t *self = mp_obj_malloc_with_finaliser(busio_spi_obj_t, &busio_spi_type);
     enum { ARG_clock, ARG_MOSI, ARG_MISO, ARG_half_duplex };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_clock, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -107,6 +106,7 @@ static mp_obj_t busio_spi_make_new(const mp_obj_type_t *type, size_t n_args, siz
         mp_raise_ValueError(MP_ERROR_TEXT("Must provide MISO or MOSI pin"));
     }
 
+    busio_spi_obj_t *self = mp_obj_malloc_with_finaliser(busio_spi_obj_t, &busio_spi_type);
     common_hal_busio_spi_construct(self, clock, mosi, miso, args[ARG_half_duplex].u_bool);
     return MP_OBJ_FROM_PTR(self);
     #else

--- a/shared-bindings/busio/UART.c
+++ b/shared-bindings/busio/UART.c
@@ -157,7 +157,7 @@ static mp_obj_t busio_uart_make_new(const mp_obj_type_t *type, size_t n_args, si
     common_hal_busio_uart_construct(self, tx, rx, rts, cts, rs485_dir, rs485_invert,
         args[ARG_baudrate].u_int, bits, parity, stop, timeout,
         buffer_size, NULL, false);
-    return (mp_obj_t)self;
+    return MP_OBJ_FROM_PTR(self);
     #else
     mp_raise_NotImplementedError(NULL);
     #endif  // CIRCUITPY_BUSIO_UART

--- a/shared-bindings/camera/Camera.c
+++ b/shared-bindings/camera/Camera.c
@@ -41,10 +41,10 @@
 //|         ...
 //|
 static mp_obj_t camera_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    camera_obj_t *self = mp_obj_malloc(camera_obj_t, &camera_type);
     // No arguments
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
 
+    camera_obj_t *self = mp_obj_malloc(camera_obj_t, &camera_type);
     common_hal_camera_construct(self);
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/canio/Match.c
+++ b/shared-bindings/canio/Match.c
@@ -47,7 +47,8 @@ static mp_obj_t canio_match_make_new(const mp_obj_type_t *type, size_t n_args, s
 
     canio_match_obj_t *self = mp_obj_malloc(canio_match_obj_t, &canio_match_type);
     common_hal_canio_match_construct(self, id, mask, args[ARG_extended].u_bool);
-    return self;
+
+    return MP_OBJ_FROM_PTR(self);
 }
 
 //|     id: int

--- a/shared-bindings/canio/Message.c
+++ b/shared-bindings/canio/Message.c
@@ -41,7 +41,8 @@ static mp_obj_t canio_message_make_new(const mp_obj_type_t *type, size_t n_args,
 
     canio_message_obj_t *self = mp_obj_malloc(canio_message_obj_t, &canio_message_type);
     common_hal_canio_message_construct(self, args[ARG_id].u_int, data.buf, data.len, args[ARG_extended].u_bool);
-    return self;
+
+    return MP_OBJ_FROM_PTR(self);
 }
 
 //|     id: int

--- a/shared-bindings/canio/RemoteTransmissionRequest.c
+++ b/shared-bindings/canio/RemoteTransmissionRequest.c
@@ -42,7 +42,8 @@ static mp_obj_t canio_remote_transmission_request_make_new(const mp_obj_type_t *
     canio_remote_transmission_request_obj_t *self =
         mp_obj_malloc(canio_remote_transmission_request_obj_t, &canio_remote_transmission_request_type);
     common_hal_canio_remote_transmission_request_construct(self, args[ARG_id].u_int, length, args[ARG_extended].u_bool);
-    return self;
+
+    return MP_OBJ_FROM_PTR(self);
 }
 
 

--- a/shared-bindings/countio/Counter.c
+++ b/shared-bindings/countio/Counter.c
@@ -66,8 +66,8 @@ static mp_obj_t countio_counter_make_new(const mp_obj_type_t *type, size_t n_arg
     const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
     const countio_edge_t edge = validate_edge(args[ARG_edge].u_obj, MP_QSTR_edge);
     const digitalio_pull_t pull = validate_pull(args[ARG_pull].u_obj, MP_QSTR_pull);
-    countio_counter_obj_t *self = mp_obj_malloc_with_finaliser(countio_counter_obj_t, &countio_counter_type);
 
+    countio_counter_obj_t *self = mp_obj_malloc_with_finaliser(countio_counter_obj_t, &countio_counter_type);
     common_hal_countio_counter_construct(self, pin, edge, pull);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/digitalio/DigitalInOut.c
+++ b/shared-bindings/digitalio/DigitalInOut.c
@@ -71,9 +71,9 @@ static mp_obj_t digitalio_digitalinout_make_new(const mp_obj_type_t *type,
     size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
 
-    digitalio_digitalinout_obj_t *self = mp_obj_malloc(digitalio_digitalinout_obj_t, &digitalio_digitalinout_type);
-
     const mcu_pin_obj_t *pin = common_hal_digitalio_validate_pin(args[0]);
+
+    digitalio_digitalinout_obj_t *self = mp_obj_malloc(digitalio_digitalinout_obj_t, &digitalio_digitalinout_type);
     common_hal_digitalio_digitalinout_construct(self, pin);
 
     return MP_OBJ_FROM_PTR(self);
@@ -191,9 +191,9 @@ static mp_obj_t digitalio_digitalinout_obj_get_direction(mp_obj_t self_in) {
     check_for_deinit(self);
     digitalio_direction_t direction = common_hal_digitalio_digitalinout_get_direction(self);
     if (direction == DIRECTION_INPUT) {
-        return (mp_obj_t)&digitalio_direction_input_obj;
+        return MP_OBJ_FROM_PTR(&digitalio_direction_input_obj);
     }
-    return (mp_obj_t)&digitalio_direction_output_obj;
+    return MP_OBJ_FROM_PTR(&digitalio_direction_output_obj);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(digitalio_digitalinout_get_direction_obj, digitalio_digitalinout_obj_get_direction);
 
@@ -255,9 +255,9 @@ static mp_obj_t digitalio_digitalinout_obj_get_drive_mode(mp_obj_t self_in) {
     }
     digitalio_drive_mode_t drive_mode = common_hal_digitalio_digitalinout_get_drive_mode(self);
     if (drive_mode == DRIVE_MODE_PUSH_PULL) {
-        return (mp_obj_t)&digitalio_drive_mode_push_pull_obj;
+        return MP_OBJ_FROM_PTR(&digitalio_drive_mode_push_pull_obj);
     }
-    return (mp_obj_t)&digitalio_drive_mode_open_drain_obj;
+    return MP_OBJ_FROM_PTR(&digitalio_drive_mode_open_drain_obj);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(digitalio_digitalinout_get_drive_mode_obj, digitalio_digitalinout_obj_get_drive_mode);
 

--- a/shared-bindings/displayio/ColorConverter.c
+++ b/shared-bindings/displayio/ColorConverter.c
@@ -39,7 +39,6 @@ static mp_obj_t displayio_colorconverter_make_new(const mp_obj_type_t *type, siz
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     displayio_colorconverter_t *self = mp_obj_malloc(displayio_colorconverter_t, &displayio_colorconverter_type);
-
     common_hal_displayio_colorconverter_construct(self, args[ARG_dither].u_bool, (displayio_colorspace_t)cp_enum_value(&displayio_colorspace_type, args[ARG_input_colorspace].u_obj, MP_QSTR_input_colorspace));
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -133,6 +133,7 @@ static mp_obj_t displayio_tilegrid_make_new(const mp_obj_type_t *type, size_t n_
         bitmap_width / tile_width, bitmap_height / tile_height,
         pixel_shader, args[ARG_width].u_int, args[ARG_height].u_int,
         tile_width, tile_height, x, y, args[ARG_default_tile].u_int);
+
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/gnss/GNSS.c
+++ b/shared-bindings/gnss/GNSS.c
@@ -38,7 +38,6 @@
 //|         ...
 //|
 static mp_obj_t gnss_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    gnss_obj_t *self = mp_obj_malloc(gnss_obj_t, &gnss_type);
     enum { ARG_system };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_system, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -63,7 +62,9 @@ static mp_obj_t gnss_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
         mp_raise_TypeError(MP_ERROR_TEXT("System entry must be gnss.SatelliteSystem"));
     }
 
+    gnss_obj_t *self = mp_obj_malloc(gnss_obj_t, &gnss_type);
     common_hal_gnss_construct(self, selection);
+
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/i2cioexpander/IOExpander.c
+++ b/shared-bindings/i2cioexpander/IOExpander.c
@@ -72,8 +72,6 @@ static mp_obj_t i2cioexpander_ioexpander_make_new(const mp_obj_type_t *type, siz
         mp_raise_ValueError(MP_ERROR_TEXT("num_pins must be 8 or 16"));
     }
 
-    i2cioexpander_ioexpander_obj_t *self = mp_obj_malloc(i2cioexpander_ioexpander_obj_t, &i2cioexpander_ioexpander_type);
-
     // Convert and validate register parameters
     uint16_t set_value_reg = NO_REGISTER;
     if (args[ARG_set_value_reg].u_obj != mp_const_none) {
@@ -96,6 +94,8 @@ static mp_obj_t i2cioexpander_ioexpander_make_new(const mp_obj_type_t *type, siz
         set_direction_reg = reg;
     }
 
+    i2cioexpander_ioexpander_obj_t *self =
+        mp_obj_malloc(i2cioexpander_ioexpander_obj_t, &i2cioexpander_ioexpander_type);
     common_hal_i2cioexpander_ioexpander_construct(
         self,
         i2c,

--- a/shared-bindings/i2ctarget/I2CTarget.c
+++ b/shared-bindings/i2ctarget/I2CTarget.c
@@ -26,7 +26,8 @@ static mp_obj_t mp_obj_new_i2ctarget_i2c_target_request(i2ctarget_i2c_target_obj
     self->address = address;
     self->is_read = is_read;
     self->is_restart = is_restart;
-    return (mp_obj_t)self;
+
+    return MP_OBJ_FROM_PTR(self);
 }
 
 //| class I2CTarget:
@@ -50,7 +51,6 @@ static mp_obj_t mp_obj_new_i2ctarget_i2c_target_request(i2ctarget_i2c_target_obj
 //|         ...
 //|
 static mp_obj_t i2ctarget_i2c_target_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    i2ctarget_i2c_target_obj_t *self = mp_obj_malloc_with_finaliser(i2ctarget_i2c_target_obj_t, &i2ctarget_i2c_target_type);
     enum { ARG_scl, ARG_sda, ARG_addresses, ARG_smbus };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -78,8 +78,10 @@ static mp_obj_t i2ctarget_i2c_target_make_new(const mp_obj_type_t *type, size_t 
         mp_raise_ValueError(MP_ERROR_TEXT("addresses is empty"));
     }
 
+    i2ctarget_i2c_target_obj_t *self = mp_obj_malloc_with_finaliser(i2ctarget_i2c_target_obj_t, &i2ctarget_i2c_target_type);
     common_hal_i2ctarget_i2c_target_construct(self, scl, sda, addresses, i, args[ARG_smbus].u_bool);
-    return (mp_obj_t)self;
+
+    return MP_OBJ_FROM_PTR(self);
 }
 
 //|     def deinit(self) -> None:

--- a/shared-bindings/imagecapture/ParallelImageCapture.c
+++ b/shared-bindings/imagecapture/ParallelImageCapture.c
@@ -58,7 +58,6 @@ static mp_obj_t imagecapture_parallelimagecapture_make_new(const mp_obj_type_t *
 
     imagecapture_parallelimagecapture_obj_t *self =
         mp_obj_malloc(imagecapture_parallelimagecapture_obj_t, &imagecapture_parallelimagecapture_type);
-
     common_hal_imagecapture_parallelimagecapture_construct(self, pins, pin_count, clock, vsync, href);
 
     return self;

--- a/shared-bindings/ipaddress/IPv4Address.c
+++ b/shared-bindings/ipaddress/IPv4Address.c
@@ -59,7 +59,6 @@ static mp_obj_t ipaddress_ipv4address_make_new(const mp_obj_type_t *type, size_t
 
 
     ipaddress_ipv4address_obj_t *self = mp_obj_malloc(ipaddress_ipv4address_obj_t, &ipaddress_ipv4address_type);
-
     common_hal_ipaddress_ipv4address_construct(self, buf, 4);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/is31fl3741/IS31FL3741.c
+++ b/shared-bindings/is31fl3741/IS31FL3741.c
@@ -38,7 +38,6 @@ static mp_obj_t is31fl3741_IS31FL3741_make_new(const mp_obj_type_t *type, size_t
     mp_obj_t i2c = mp_arg_validate_type(args[ARG_i2c].u_obj, &busio_i2c_type, MP_QSTR_i2c_bus);
 
     is31fl3741_IS31FL3741_obj_t *self = mp_obj_malloc(is31fl3741_IS31FL3741_obj_t, &is31fl3741_IS31FL3741_type);
-
     common_hal_is31fl3741_IS31FL3741_construct(self,
         MP_OBJ_TO_PTR(i2c),
         args[ARG_addr].u_int

--- a/shared-bindings/jpegio/JpegDecoder.c
+++ b/shared-bindings/jpegio/JpegDecoder.c
@@ -43,7 +43,6 @@ static mp_obj_t jpegio_jpegdecoder_make_new(const mp_obj_type_t *type, size_t n_
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     jpegio_jpegdecoder_obj_t *self = mp_obj_malloc(jpegio_jpegdecoder_obj_t, &jpegio_jpegdecoder_type);
-    self->base.type = &jpegio_jpegdecoder_type;
     common_hal_jpegio_jpegdecoder_construct(self);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/keypad/Event.c
+++ b/shared-bindings/keypad/Event.c
@@ -26,7 +26,6 @@
 //|         ...
 //|
 static mp_obj_t keypad_event_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    keypad_event_obj_t *self = mp_obj_malloc(keypad_event_obj_t, &keypad_event_type);
     enum { ARG_key_number, ARG_pressed, ARG_timestamp };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_key_number, MP_ARG_INT, {.u_int = 0} },
@@ -45,7 +44,9 @@ static mp_obj_t keypad_event_make_new(const mp_obj_type_t *type, size_t n_args, 
     }
 
     (void)mp_obj_get_int_truncated(timestamp); // ensure that timestamp is an integer
+    keypad_event_obj_t *self = mp_obj_malloc(keypad_event_obj_t, &keypad_event_type);
     common_hal_keypad_event_construct(self, key_number, args[ARG_pressed].u_bool, timestamp);
+
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/keypad/KeyMatrix.c
+++ b/shared-bindings/keypad/KeyMatrix.c
@@ -81,7 +81,6 @@
 
 static mp_obj_t keypad_keymatrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     #if CIRCUITPY_KEYPAD_KEYMATRIX
-    keypad_keymatrix_obj_t *self = mp_obj_malloc(keypad_keymatrix_obj_t, &keypad_keymatrix_type);
     enum { ARG_row_pins, ARG_column_pins, ARG_columns_to_anodes, ARG_interval, ARG_max_events, ARG_debounce_threshold };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_row_pins, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -123,7 +122,9 @@ static mp_obj_t keypad_keymatrix_make_new(const mp_obj_type_t *type, size_t n_ar
         column_pins_array[column] = pin;
     }
 
+    keypad_keymatrix_obj_t *self = mp_obj_malloc(keypad_keymatrix_obj_t, &keypad_keymatrix_type);
     common_hal_keypad_keymatrix_construct(self, num_row_pins, row_pins_array, num_column_pins, column_pins_array, args[ARG_columns_to_anodes].u_bool, interval, max_events, debounce_threshold);
+
     return MP_OBJ_FROM_PTR(self);
     #else
     mp_raise_NotImplementedError_varg(MP_ERROR_TEXT("%q"), MP_QSTR_KeyMatrix);

--- a/shared-bindings/keypad/Keys.c
+++ b/shared-bindings/keypad/Keys.c
@@ -81,7 +81,6 @@
 
 static mp_obj_t keypad_keys_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     #if CIRCUITPY_KEYPAD_KEYS
-    keypad_keys_obj_t *self = mp_obj_malloc(keypad_keys_obj_t, &keypad_keys_type);
     enum { ARG_pins, ARG_value_when_pressed, ARG_pull, ARG_interval, ARG_max_events, ARG_debounce_threshold };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pins, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -112,6 +111,7 @@ static mp_obj_t keypad_keys_make_new(const mp_obj_type_t *type, size_t n_args, s
             validate_obj_is_free_pin(mp_obj_subscr(pins, MP_OBJ_NEW_SMALL_INT(i), MP_OBJ_SENTINEL), MP_QSTR_pin);
     }
 
+    keypad_keys_obj_t *self = mp_obj_malloc(keypad_keys_obj_t, &keypad_keys_type);
     common_hal_keypad_keys_construct(self, num_pins, pins_array, value_when_pressed, args[ARG_pull].u_bool, interval, max_events, debounce_threshold);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/keypad/ShiftRegisterKeys.c
+++ b/shared-bindings/keypad/ShiftRegisterKeys.c
@@ -88,8 +88,6 @@
 
 static mp_obj_t keypad_shiftregisterkeys_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     #if CIRCUITPY_KEYPAD_SHIFTREGISTERKEYS
-    keypad_shiftregisterkeys_obj_t *self =
-        mp_obj_malloc(keypad_shiftregisterkeys_obj_t, &keypad_shiftregisterkeys_type);
     enum { ARG_clock, ARG_data, ARG_latch, ARG_value_to_latch, ARG_key_count, ARG_value_when_pressed, ARG_interval, ARG_max_events, ARG_debounce_threshold };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_clock, MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -160,6 +158,8 @@ static mp_obj_t keypad_shiftregisterkeys_make_new(const mp_obj_type_t *type, siz
     const size_t max_events = (size_t)mp_arg_validate_int_min(args[ARG_max_events].u_int, 1, MP_QSTR_max_events);
     const uint8_t debounce_threshold = (uint8_t)mp_arg_validate_int_range(args[ARG_debounce_threshold].u_int, 1, 127, MP_QSTR_debounce_threshold);
 
+    keypad_shiftregisterkeys_obj_t *self =
+        mp_obj_malloc(keypad_shiftregisterkeys_obj_t, &keypad_shiftregisterkeys_type);
     common_hal_keypad_shiftregisterkeys_construct(
         self, clock, num_data_pins, data_pins_array, latch, value_to_latch, num_key_counts, key_count_array, value_when_pressed, interval, max_events, debounce_threshold);
 

--- a/shared-bindings/keypad_demux/DemuxKeyMatrix.c
+++ b/shared-bindings/keypad_demux/DemuxKeyMatrix.c
@@ -80,7 +80,6 @@
 //|
 
 static mp_obj_t keypad_demux_demuxkeymatrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    keypad_demux_demuxkeymatrix_obj_t *self = mp_obj_malloc(keypad_demux_demuxkeymatrix_obj_t, &keypad_demux_demuxkeymatrix_type);
     enum { ARG_row_addr_pins, ARG_column_pins, ARG_columns_to_anodes, ARG_transpose, ARG_interval, ARG_max_events, ARG_debounce_threshold };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_row_addr_pins, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -123,8 +122,10 @@ static mp_obj_t keypad_demux_demuxkeymatrix_make_new(const mp_obj_type_t *type, 
         column_pins_array[column] = pin;
     }
 
+    keypad_demux_demuxkeymatrix_obj_t *self = mp_obj_malloc(keypad_demux_demuxkeymatrix_obj_t, &keypad_demux_demuxkeymatrix_type);
     // Last arg is use_gc_allocator, true during VM use.
     common_hal_keypad_demux_demuxkeymatrix_construct(self, num_row_addr_pins, row_addr_pins_array, num_column_pins, column_pins_array, args[ARG_columns_to_anodes].u_bool, args[ARG_transpose].u_bool, interval, max_events, debounce_threshold, true);
+
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/memorymap/AddressRange.c
+++ b/shared-bindings/memorymap/AddressRange.c
@@ -92,7 +92,6 @@ static mp_obj_t memorymap_addressrange_make_new(const mp_obj_type_t *type, size_
     }
 
     memorymap_addressrange_obj_t *self = mp_obj_malloc(memorymap_addressrange_obj_t, &memorymap_addressrange_type);
-
     common_hal_memorymap_addressrange_construct(self, (uint8_t *)start, length);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/memorymonitor/AllocationAlarm.c
+++ b/shared-bindings/memorymonitor/AllocationAlarm.c
@@ -48,7 +48,6 @@ static mp_obj_t memorymonitor_allocationalarm_make_new(const mp_obj_type_t *type
 
     memorymonitor_allocationalarm_obj_t *self =
         mp_obj_malloc(memorymonitor_allocationalarm_obj_t, &memorymonitor_allocationalarm_type);
-
     common_hal_memorymonitor_allocationalarm_construct(self, minimum_block_count);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/msgpack/ExtType.c
+++ b/shared-bindings/msgpack/ExtType.c
@@ -18,7 +18,6 @@
 //|         :param bytes data: representation."""
 //|
 static mp_obj_t mod_msgpack_exttype_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    mod_msgpack_extype_obj_t *self = mp_obj_malloc(mod_msgpack_extype_obj_t, &mod_msgpack_exttype_type);
     enum { ARG_code, ARG_data };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_code, MP_ARG_INT | MP_ARG_REQUIRED },
@@ -28,11 +27,12 @@ static mp_obj_t mod_msgpack_exttype_make_new(const mp_obj_type_t *type, size_t n
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     int code = mp_arg_validate_int_range(args[ARG_code].u_int, 0, 127, MP_QSTR_code);
-
-    self->code = code;
-
     mp_obj_t data = args[ARG_data].u_obj;
+
+    mod_msgpack_extype_obj_t *self = mp_obj_malloc(mod_msgpack_extype_obj_t, &mod_msgpack_exttype_type);
+    self->code = code;
     self->data = data;
+
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/onewireio/OneWire.c
+++ b/shared-bindings/onewireio/OneWire.c
@@ -43,8 +43,8 @@ static mp_obj_t onewireio_onewire_make_new(const mp_obj_type_t *type, size_t n_a
     const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
 
     onewireio_onewire_obj_t *self = mp_obj_malloc(onewireio_onewire_obj_t, &onewireio_onewire_type);
-
     common_hal_onewireio_onewire_construct(self, pin);
+
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/os/__init__.c
+++ b/shared-bindings/os/__init__.c
@@ -67,7 +67,7 @@ static MP_DEFINE_ATTRTUPLE(
     );
 
 static mp_obj_t os_uname(void) {
-    return (mp_obj_t)&os_uname_info_obj;
+    return MP_OBJ_FROM_PTR(&os_uname_info_obj);
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(os_uname_obj, os_uname);
 

--- a/shared-bindings/ps2io/Ps2.c
+++ b/shared-bindings/ps2io/Ps2.c
@@ -58,7 +58,6 @@ static mp_obj_t ps2io_ps2_make_new(const mp_obj_type_t *type, size_t n_args, siz
     const mcu_pin_obj_t *data_pin = validate_obj_is_free_pin(args[ARG_data_pin].u_obj, MP_QSTR_data_pin);
 
     ps2io_ps2_obj_t *self = mp_obj_malloc(ps2io_ps2_obj_t, &ps2io_ps2_type);
-
     common_hal_ps2io_ps2_construct(self, data_pin, clock_pin);
 
     return MP_OBJ_FROM_PTR(self);

--- a/shared-bindings/pulseio/PulseIn.c
+++ b/shared-bindings/pulseio/PulseIn.c
@@ -69,7 +69,6 @@ static mp_obj_t pulseio_pulsein_make_new(const mp_obj_type_t *type, size_t n_arg
     const mcu_pin_obj_t *pin = validate_obj_is_free_pin(args[ARG_pin].u_obj, MP_QSTR_pin);
 
     pulseio_pulsein_obj_t *self = mp_obj_malloc_with_finaliser(pulseio_pulsein_obj_t, &pulseio_pulsein_type);
-
     common_hal_pulseio_pulsein_construct(self, pin, args[ARG_maxlen].u_int,
         args[ARG_idle_state].u_bool);
 

--- a/shared-bindings/pulseio/PulseOut.c
+++ b/shared-bindings/pulseio/PulseOut.c
@@ -62,6 +62,7 @@ static mp_obj_t pulseio_pulseout_make_new(const mp_obj_type_t *type, size_t n_ar
 
     pulseio_pulseout_obj_t *self = mp_obj_malloc_with_finaliser(pulseio_pulseout_obj_t, &pulseio_pulseout_type);
     common_hal_pulseio_pulseout_construct(self, pin, frequency, duty_cycle);
+
     return MP_OBJ_FROM_PTR(self);
     #else
     mp_raise_NotImplementedError(NULL);

--- a/shared-bindings/qrio/QRDecoder.c
+++ b/shared-bindings/qrio/QRDecoder.c
@@ -34,7 +34,7 @@ static mp_obj_t qrio_qrdecoder_make_new(const mp_obj_type_t *type, size_t n_args
     qrio_qrdecoder_obj_t *self = mp_obj_malloc(qrio_qrdecoder_obj_t, &qrio_qrdecoder_type_obj);
     shared_module_qrio_qrdecoder_construct(self, args[ARG_width].u_int, args[ARG_height].u_int);
 
-    return self;
+    return MP_OBJ_FROM_PTR(self);
 }
 
 

--- a/shared-bindings/rclcpy/Node.c
+++ b/shared-bindings/rclcpy/Node.c
@@ -50,7 +50,8 @@ static mp_obj_t rclcpy_node_make_new(const mp_obj_type_t *type, size_t n_args, s
 
     rclcpy_node_obj_t *self = mp_obj_malloc_with_finaliser(rclcpy_node_obj_t, &rclcpy_node_type);
     common_hal_rclcpy_node_construct(self, node_name, namespace);
-    return (mp_obj_t)self;
+
+    return MP_OBJ_FROM_PTR(self);
 }
 
 //|     def deinit(self) -> None:
@@ -90,7 +91,7 @@ static mp_obj_t rclcpy_node_create_publisher(mp_obj_t self_in, mp_obj_t topic) {
 
     rclcpy_publisher_obj_t *publisher = mp_obj_malloc_with_finaliser(rclcpy_publisher_obj_t, &rclcpy_publisher_type);
     common_hal_rclcpy_publisher_construct(publisher, self, topic_name);
-    return (mp_obj_t)publisher;
+    return MP_OBJ_FROM_PTR(publisher);
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(rclcpy_node_create_publisher_obj, rclcpy_node_create_publisher);
 

--- a/shared-bindings/rclcpy/__init__.c
+++ b/shared-bindings/rclcpy/__init__.c
@@ -112,7 +112,8 @@ static mp_obj_t rclcpy_create_node(size_t n_args, const mp_obj_t *pos_args, mp_m
 
     rclcpy_node_obj_t *self = mp_obj_malloc_with_finaliser(rclcpy_node_obj_t, &rclcpy_node_type);
     common_hal_rclcpy_node_construct(self, node_name, namespace);
-    return (mp_obj_t)self;
+
+    return MP_OBJ_FROM_PTR(self);
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(rclcpy_create_node_obj, 2, rclcpy_create_node);
 

--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -82,10 +82,9 @@ static mp_obj_t sdcardio_sdcard_make_new(const mp_obj_type_t *type, size_t n_arg
     const mcu_pin_obj_t *cs = validate_obj_is_free_pin(args[ARG_cs].u_obj, MP_QSTR_cs);
 
     sdcardio_sdcard_obj_t *self = mp_obj_malloc_with_finaliser(sdcardio_sdcard_obj_t, &sdcardio_SDCard_type);
-
     common_hal_sdcardio_sdcard_construct(self, spi, cs, args[ARG_baudrate].u_int);
 
-    return self;
+    return MP_OBJ_FROM_PTR(self);
 }
 
 

--- a/shared-bindings/sdioio/SDCard.c
+++ b/shared-bindings/sdioio/SDCard.c
@@ -67,7 +67,6 @@
 //|
 
 static mp_obj_t sdioio_sdcard_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    sdioio_sdcard_obj_t *self = mp_obj_malloc(sdioio_sdcard_obj_t, &sdioio_SDCard_type);
     enum { ARG_clock, ARG_command, ARG_data, ARG_frequency, NUM_ARGS };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_clock, MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ },
@@ -86,6 +85,7 @@ static mp_obj_t sdioio_sdcard_make_new(const mp_obj_type_t *type, size_t n_args,
     uint8_t num_data;
     validate_list_is_free_pins(MP_QSTR_data, data_pins, MP_ARRAY_SIZE(data_pins), args[ARG_data].u_obj, &num_data);
 
+    sdioio_sdcard_obj_t *self = mp_obj_malloc(sdioio_sdcard_obj_t, &sdioio_SDCard_type);
     common_hal_sdioio_sdcard_construct(self, clock, command, num_data, data_pins, args[ARG_frequency].u_int);
     return MP_OBJ_FROM_PTR(self);
 }

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -36,9 +36,9 @@
 static mp_obj_t socketpool_socketpool_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
 
-    socketpool_socketpool_obj_t *s = mp_obj_malloc_with_finaliser(socketpool_socketpool_obj_t, &socketpool_socketpool_type);
     mp_obj_t radio = args[0];
 
+    socketpool_socketpool_obj_t *s = mp_obj_malloc_with_finaliser(socketpool_socketpool_obj_t, &socketpool_socketpool_type);
     common_hal_socketpool_socketpool_construct(s, radio);
 
     return MP_OBJ_FROM_PTR(s);

--- a/shared-bindings/spitarget/SPITarget.c
+++ b/shared-bindings/spitarget/SPITarget.c
@@ -33,7 +33,6 @@
 //|         ...
 //|
 static mp_obj_t spitarget_spi_target_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    spitarget_spi_target_obj_t *self = mp_obj_malloc(spitarget_spi_target_obj_t, &spitarget_spi_target_type);
     enum { ARG_sck, ARG_mosi, ARG_miso, ARG_ss };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_sck, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -49,7 +48,9 @@ static mp_obj_t spitarget_spi_target_make_new(const mp_obj_type_t *type, size_t 
     const mcu_pin_obj_t *miso = validate_obj_is_free_pin(args[ARG_miso].u_obj, MP_QSTR_miso);
     const mcu_pin_obj_t *ss = validate_obj_is_free_pin(args[ARG_ss].u_obj, MP_QSTR_ss);
 
+    spitarget_spi_target_obj_t *self = mp_obj_malloc(spitarget_spi_target_obj_t, &spitarget_spi_target_type);
     common_hal_spitarget_spi_target_construct(self, sck, mosi, miso, ss);
+
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/ssl/SSLContext.c
+++ b/shared-bindings/ssl/SSLContext.c
@@ -26,7 +26,6 @@ static mp_obj_t ssl_sslcontext_make_new(const mp_obj_type_t *type, size_t n_args
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
 
     ssl_sslcontext_obj_t *s = mp_obj_malloc(ssl_sslcontext_obj_t, &ssl_sslcontext_type);
-
     common_hal_ssl_sslcontext_construct(s);
 
     return MP_OBJ_FROM_PTR(s);

--- a/shared-bindings/ssl/__init__.c
+++ b/shared-bindings/ssl/__init__.c
@@ -27,9 +27,9 @@
 
 static mp_obj_t ssl_create_default_context(void) {
     ssl_sslcontext_obj_t *s = mp_obj_malloc(ssl_sslcontext_obj_t, &ssl_sslcontext_type);
-
     common_hal_ssl_create_default_context(s);
-    return s;
+
+    return MP_OBJ_FROM_PTR(s);
 }
 MP_DEFINE_CONST_FUN_OBJ_0(ssl_create_default_context_obj, ssl_create_default_context);
 

--- a/shared-bindings/synthio/LFO.c
+++ b/shared-bindings/synthio/LFO.c
@@ -103,17 +103,17 @@ static mp_obj_t synthio_lfo_make_new(const mp_obj_type_t *type_in, size_t n_args
     }
     self->waveform_obj = args[ARG_waveform].u_obj;
 
-    mp_obj_t result = MP_OBJ_FROM_PTR(self);
-    properties_construct_helper(result, lfo_properties + 1, args + 1, MP_ARRAY_SIZE(lfo_properties) - 1);
+    mp_obj_t self_obj = MP_OBJ_FROM_PTR(self);
+    properties_construct_helper(self_obj, lfo_properties + 1, args + 1, MP_ARRAY_SIZE(lfo_properties) - 1);
 
     // Force computation of the LFO's initial output
     synthio_global_rate_scale = 0;
     self->base.last_tick = synthio_global_tick - 1;
     synthio_block_slot_t slot;
-    synthio_block_assign_slot(MP_OBJ_FROM_PTR(result), &slot, MP_QSTR_self);
+    synthio_block_assign_slot(self_obj, &slot, MP_QSTR_self);
     (void)synthio_block_slot_get(&slot);
 
-    return result;
+    return self_obj;
 };
 
 //|     waveform: Optional[ReadableBuffer]

--- a/shared-bindings/synthio/Math.c
+++ b/shared-bindings/synthio/Math.c
@@ -157,10 +157,10 @@ static mp_obj_t synthio_math_make_new_common(mp_arg_val_t args[MP_ARRAY_SIZE(mat
 
     self->base.last_tick = synthio_global_tick;
 
-    mp_obj_t result = MP_OBJ_FROM_PTR(self);
-    properties_construct_helper(result, math_properties, args, MP_ARRAY_SIZE(math_properties));
+    mp_obj_t self_obj = MP_OBJ_FROM_PTR(self);
+    properties_construct_helper(self_obj, math_properties, args, MP_ARRAY_SIZE(math_properties));
 
-    return result;
+    return self_obj;
 };
 
 //|     a: BlockInput

--- a/shared-bindings/synthio/MidiTrack.c
+++ b/shared-bindings/synthio/MidiTrack.c
@@ -70,7 +70,6 @@ static mp_obj_t synthio_miditrack_make_new(const mp_obj_type_t *type, size_t n_a
     mp_get_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_READ);
 
     synthio_miditrack_obj_t *self = mp_obj_malloc(synthio_miditrack_obj_t, &synthio_miditrack_type);
-
     common_hal_synthio_miditrack_construct(self,
         (uint8_t *)bufinfo.buf, bufinfo.len,
         args[ARG_tempo].u_int,

--- a/shared-bindings/synthio/Note.c
+++ b/shared-bindings/synthio/Note.c
@@ -61,11 +61,11 @@ static mp_obj_t synthio_note_make_new(const mp_obj_type_t *type_in, size_t n_arg
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(note_properties), note_properties, args);
 
     synthio_note_obj_t *self = mp_obj_malloc(synthio_note_obj_t, &synthio_note_type);
+    mp_obj_t self_obj = MP_OBJ_FROM_PTR(self);
 
-    mp_obj_t result = MP_OBJ_FROM_PTR(self);
-    properties_construct_helper(result, note_properties, args, MP_ARRAY_SIZE(note_properties));
+    properties_construct_helper(self_obj, note_properties, args, MP_ARRAY_SIZE(note_properties));
 
-    return result;
+    return self_obj;
 };
 
 //|     frequency: float

--- a/shared-bindings/synthio/Synthesizer.c
+++ b/shared-bindings/synthio/Synthesizer.c
@@ -62,7 +62,6 @@ static mp_obj_t synthio_synthesizer_make_new(const mp_obj_type_t *type, size_t n
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     synthio_synthesizer_obj_t *self = mp_obj_malloc(synthio_synthesizer_obj_t, &synthio_synthesizer_type);
-
     common_hal_synthio_synthesizer_construct(self,
         args[ARG_sample_rate].u_int,
         args[ARG_channel_count].u_int,

--- a/shared-bindings/synthio/__init__.c
+++ b/shared-bindings/synthio/__init__.c
@@ -252,7 +252,6 @@ static mp_obj_t synthio_from_file(size_t n_args, const mp_obj_t *pos_args, mp_ma
     }
 
     synthio_miditrack_obj_t *result = mp_obj_malloc(synthio_miditrack_obj_t, &synthio_miditrack_type);
-
     common_hal_synthio_miditrack_construct(result, buffer, track_size,
         tempo, args[ARG_sample_rate].u_int, args[ARG_waveform].u_obj,
         mp_const_none,

--- a/shared-bindings/terminalio/Terminal.c
+++ b/shared-bindings/terminalio/Terminal.c
@@ -176,8 +176,8 @@ static mp_obj_t terminalio_terminal_make_new(const mp_obj_type_t *type, size_t n
     mp_arg_validate_int_min(scroll_area->width_in_tiles * scroll_area->height_in_tiles, 2, MP_QSTR_scroll_area_area);
 
     terminalio_terminal_obj_t *self = mp_obj_malloc(terminalio_terminal_obj_t, &terminalio_terminal_type);
-
     common_hal_terminalio_terminal_construct(self, scroll_area, font, status_bar);
+
     return MP_OBJ_FROM_PTR(self);
 }
 

--- a/shared-bindings/tilepalettemapper/TilePaletteMapper.c
+++ b/shared-bindings/tilepalettemapper/TilePaletteMapper.c
@@ -45,7 +45,6 @@ static mp_obj_t tilepalettemapper_tilepalettemapper_make_new(const mp_obj_type_t
         mp_raise_TypeError_varg(MP_ERROR_TEXT("unsupported %q type"), MP_QSTR_pixel_shader);
     }
 
-
     tilepalettemapper_tilepalettemapper_t *self = mp_obj_malloc(tilepalettemapper_tilepalettemapper_t, &tilepalettemapper_tilepalettemapper_type);
     common_hal_tilepalettemapper_tilepalettemapper_construct(self, pixel_shader, args[ARG_input_color_count].u_int);
 

--- a/shared-bindings/touchio/TouchIn.c
+++ b/shared-bindings/touchio/TouchIn.c
@@ -56,7 +56,7 @@ static mp_obj_t touchio_touchin_make_new(const mp_obj_type_t *type,
     touchio_touchin_obj_t *self = mp_obj_malloc(touchio_touchin_obj_t, &touchio_touchin_type);
     common_hal_touchio_touchin_construct(self, pin, pull);
 
-    return (mp_obj_t)self;
+    return MP_OBJ_FROM_PTR(self);
 }
 
 //|     def deinit(self) -> None:

--- a/shared-bindings/usb/core/__init__.c
+++ b/shared-bindings/usb/core/__init__.c
@@ -90,9 +90,10 @@ static mp_obj_t _next_device(usb_core_devices_obj_t *iter) {
         // We passed the filters. Now make a properly allocated object to
         // return to the user.
         usb_core_device_obj_t *self = mp_obj_malloc(usb_core_device_obj_t, &usb_core_device_type);
-
         common_hal_usb_core_device_construct(self, i);
+
         iter->next_index = i + 1;
+
         return MP_OBJ_FROM_PTR(self);
     }
     // Iter is done.

--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -75,7 +75,6 @@
 //|
 
 static mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    usb_hid_device_obj_t *self = mp_obj_malloc(usb_hid_device_obj_t, &usb_hid_device_type);
     enum { ARG_report_descriptor, ARG_usage_page, ARG_usage, ARG_report_ids, ARG_in_report_lengths, ARG_out_report_lengths };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_report_descriptor, MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -141,9 +140,10 @@ static mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type, size_t n_args
         mp_raise_ValueError_varg(MP_ERROR_TEXT("%q length must be %d"), MP_QSTR_report_id_space_0, 1);
     }
 
+    usb_hid_device_obj_t *self = mp_obj_malloc(usb_hid_device_obj_t, &usb_hid_device_type);
     common_hal_usb_hid_device_construct(
         self, descriptor, usage_page, usage, report_ids_count, report_ids_array, in_report_lengths_array, out_report_lengths_array);
-    return (mp_obj_t)self;
+    return MP_OBJ_FROM_PTR(self);
 }
 
 

--- a/shared-bindings/usb_host/Port.c
+++ b/shared-bindings/usb_host/Port.c
@@ -42,7 +42,7 @@ static mp_obj_t usb_host_port_make_new(const mp_obj_type_t *type,
 
     usb_host_port_obj_t *self = common_hal_usb_host_port_construct(dp, dm);
 
-    return (mp_obj_t)self;
+    return MP_OBJ_FROM_PTR(self);
 }
 
 static const mp_rom_map_elem_t usb_host_port_locals_dict_table[] = {

--- a/shared-bindings/vectorio/VectorShape.c
+++ b/shared-bindings/vectorio/VectorShape.c
@@ -69,7 +69,7 @@ mp_obj_t vectorio_vector_shape_make_new(const mp_obj_t shape, const mp_obj_t pix
     } else if (mp_obj_is_type(shape, &vectorio_circle_type)) {
         common_hal_vectorio_circle_set_on_dirty(self->ishape.shape, on_dirty);
     } else {
-        mp_raise_TypeError_varg(MP_ERROR_TEXT("unsupported %q type"), MP_QSTR_shape);
+        // Already excluded due to previous else-if chain.
     }
 
     return MP_OBJ_FROM_PTR(self);


### PR DESCRIPTION
A number of `*_make_new()` functions were calling `mp_obj_alloc()` or `mp_obj_alloc_with_finaliser()` before all the argument validation was done. For objects with finalisers which had a validation exception, this meant that a discarded object in a bad state might have a finaliser called on it. For non-finaliser objects, it just mean that garbage was generated.

The general guideline is to allocate as late as possible before the call to `*_construct()`.

Fixing this after diagnosing a specific safe-mode crash with SPI objects for `FourWire` displays that were copied between VM instantiations. `SPI.c` was creating the object really early; this had been true for years. Now there is no crash, though there's still an issue with those SPI objects I'll fix separately.

I also did some style cleanup, mostly using `MP_OBJ_PTR()` consistently, and making the code prettier and more consistent.

LLM notes: I diagnosed the problem myself and had Claude fix a bunch of them, which it did fine. However, it missed some more obscure cases, and that's why I ended up doing the style cleanup too.

This may be the cause of some errors we are seeing in, say #10830, but there are other problems there too, which I am working on separately.

