### PR TITLE
atmel-samd SPI: don't mark_deinit before resetting pin

### DIFF
--- a/ports/atmel-samd/common-hal/busio/SPI.c
+++ b/ports/atmel-samd/common-hal/busio/SPI.c
@@ -194,14 +194,14 @@ void common_hal_busio_spi_deinit(busio_spi_obj_t *self) {
     }
     allow_reset_sercom(self->spi_desc.dev.prvt);
 
-    // Mark as deinit early in case we are used in an interrupt.
-    common_hal_busio_spi_mark_deinit(self);
-
     spi_m_sync_disable(&self->spi_desc);
     spi_m_sync_deinit(&self->spi_desc);
     reset_pin_number(self->clock_pin);
     reset_pin_number(self->MOSI_pin);
     reset_pin_number(self->MISO_pin);
+
+    // This smashes self->clock_pin, so don't do it before resetting the pin above.
+    common_hal_busio_spi_mark_deinit(self);
 }
 
 bool common_hal_busio_spi_configure(busio_spi_obj_t *self,


### PR DESCRIPTION
`atmel-samd` `SPI` objects were not being deinited properly. The clock pin was set to `NO_PIN` prematurely, and the pin The second time this program ran, after a ctrl-C and restart, it would stop with `SCK in use`.

It has to be being used by a `FourWire`; just creating `spi` does not provoke the bug. `FourWire` makes the SPI bus pins "never reset", and the "never reset" state was not being cleared.

```py
import board
import busio
import displayio
from fourwire import FourWire
import os
import time

from adafruit_hx8357 import HX8357

displayio.release_displays()

print("starting in 3 seconds")
time.sleep(3)
spi = busio.SPI(clock=board.SCK, MOSI=board.MOSI, MISO=board.MISO)

display_bus = FourWire(spi, command=board.D10, chip_select=board.D9, reset=None)
display = HX8357(display_bus, width=480, height=320)

for i in range(1000):
    print(i)
    time.sleep(1)
```

The `    // Mark as deinit early in case we are used in an interrupt.` should not be necessary. That was taken from `espressif`, and I don't believe it is applicable here.

I looked at the other ports and I didn't see a similar bug, so I think this is just `atmel-samd`.