### PR TITLE
fix return type doc in I2C.probe()

### DIFF
--- a/shared-bindings/busio/I2C.c
+++ b/shared-bindings/busio/I2C.c
@@ -112,7 +112,7 @@ static void check_lock(busio_i2c_obj_t *self) {
     }
 }
 
-//|     def probe(self, address: int) -> List[int]:
+//|     def probe(self, address: int) -> bool:
 //|         """Check if a device at the specified address responds.
 //|
 //|         :param int address: 7-bit device address


### PR DESCRIPTION
The return type `List[int]` and declared `:rtype: bool` in the docstring differ. 

This changes the type annotation to match the correct type `bool`

Confirmed proper type in REPL:
```
>>> board.I2C().try_lock()
True
>>> board.I2C().probe(0x39)
True
```


