### PR TITLE
update CI actions to latest versions, to use Node.24

### DIFF
--- a/.github/actions/deps/ports/espressif/action.yml
+++ b/.github/actions/deps/ports/espressif/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
 
     - name: Cache IDF submodules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           .git/modules/ports/espressif/esp-idf
@@ -27,7 +27,7 @@ runs:
         key: submodules-idf-${{ steps.idf-commit.outputs.commit }}
 
     - name: Cache IDF tools
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ env.IDF_TOOLS_PATH }}
         key: ${{ runner.os }}-${{ env.pythonLocation }}-tools-idf-${{ steps.idf-commit.outputs.commit }}

--- a/.github/actions/deps/python/action.yml
+++ b/.github/actions/deps/python/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Cache python dependencies
       id: cache-python-deps
       if: inputs.action == 'cache'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .cp_tools
         key: ${{ runner.os }}-${{ env.pythonLocation }}-tools-cp-${{ hashFiles('requirements-dev.txt') }}
@@ -24,7 +24,7 @@ runs:
     - name: Restore python dependencies
       id: restore-python-deps
       if: inputs.action == 'restore'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .cp_tools
         key: ${{ runner.os }}-${{ env.pythonLocation }}-tools-cp-${{ hashFiles('requirements-dev.txt') }}

--- a/.github/actions/deps/submodules/action.yml
+++ b/.github/actions/deps/submodules/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - name: Cache submodules
       if: ${{ inputs.action == 'cache' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ".git/modules/\n${{ join(fromJSON(steps.create-submodule-status.outputs.submodules), '\n') }}"
         key: submodules-common-${{ hashFiles('submodule_status') }}
@@ -56,7 +56,7 @@ runs:
 
     - name: Restore submodules
       if: ${{ inputs.action == 'restore' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ".git/modules/\n${{ join(fromJSON(steps.create-submodule-status.outputs.submodules), '\n') }}"
         key: submodules-common-${{ hashFiles('submodule_status') }}

--- a/.github/actions/mpy_cross/action.yml
+++ b/.github/actions/mpy_cross/action.yml
@@ -16,7 +16,7 @@ runs:
       id: download-mpy-cross
       if: inputs.download == 'true'
       continue-on-error: true
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: mpy-cross
         path: mpy-cross/build
@@ -36,7 +36,7 @@ runs:
     - name: Upload mpy-cross
       if: inputs.download == 'false' || steps.download-mpy-cross.outcome == 'failure'
       continue-on-error: true
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mpy-cross
         path: mpy-cross/build/mpy-cross

--- a/.github/workflows/build-board-custom.yml
+++ b/.github/workflows/build-board-custom.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         > custom-build && git add custom-build
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.x
     - name: Board to port
@@ -124,7 +124,7 @@ jobs:
       run: make -j4 $FLAGS BOARD="$BOARD" DEBUG=$DEBUG TRANSLATION="$TRANSLATION"
       working-directory: ports/${{ steps.board-to-port.outputs.port }}
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.board }}-${{ inputs.language }}-${{ inputs.version }}${{ inputs.flags != '' && '-custom' || '' }}${{ inputs.debug && '-debug' || '' }}
         path: ports/${{ steps.board-to-port.outputs.port }}/build-${{ inputs.board }}/firmware.*

--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -29,7 +29,7 @@ jobs:
         board: ${{ fromJSON(inputs.boards) }}
     steps:
     - name: Set up repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
         show-progress: false
@@ -37,7 +37,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.x
 
@@ -87,7 +87,7 @@ jobs:
         HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.board }}
         path: bin/${{ matrix.board }}

--- a/.github/workflows/build-mpy-cross.yml
+++ b/.github/workflows/build-mpy-cross.yml
@@ -28,14 +28,14 @@ jobs:
       OS_static-raspbian: linux-raspbian
     steps:
     - name: Set up repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
         show-progress: false
         fetch-depth: 1
         persist-credentials: false
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.x
     - name: Set up submodules
@@ -66,7 +66,7 @@ jobs:
         echo >> $GITHUB_ENV "OS=$OS"
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mpy-cross.${{ env.EX }}
         path: mpy-cross/build-${{ matrix.mpy-cross }}/mpy-cross.${{ env.EX }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,14 +28,14 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
     - name: Set up repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
         show-progress: false
         fetch-depth: 1
         persist-credentials: false
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.x
     - name: Duplicate USB VID/PID check
@@ -114,14 +114,14 @@ jobs:
       CP_VERSION: ${{ needs.scheduler.outputs.cp-version }}
     steps:
     - name: Set up repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
         show-progress: false
         fetch-depth: 1
         persist-credentials: false
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.x
     - name: Set up submodules
@@ -133,7 +133,7 @@ jobs:
         msgfmt --version
     - name: Build mpy-cross (arm64)
       run: make -C mpy-cross -j4 -f Makefile.m1 V=2
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: mpy-cross-macos-arm64
         path: mpy-cross/build-arm64/mpy-cross-arm64
@@ -156,14 +156,14 @@ jobs:
       CP_VERSION: ${{ needs.scheduler.outputs.cp-version }}
     steps:
     - name: Set up repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
         show-progress: false
         fetch-depth: 1
         persist-credentials: false
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.x
     - name: Set up submodules
@@ -177,20 +177,20 @@ jobs:
         pip install -r requirements-doc.txt
     - name: Build and Validate Stubs
       run: make check-stubs -j4
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: stubs
         path: circuitpython-stubs/dist/*
     - name: Test Documentation Build (HTML)
       run: sphinx-build -E -W -b html -D version="$CP_VERSION" -D release="$CP_VERSION" . _build/html
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: docs-html
         path: _build/html
     - name: Test Documentation Build (LaTeX/PDF)
       run: |
         make latexpdf
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: docs-latexpdf
         path: _build/latex
@@ -260,7 +260,7 @@ jobs:
         which python; python --version; python -c "import cascadetoml"
         which python3; python3 --version; python3 -c "import cascadetoml"
     - name: Set up repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
         show-progress: false
@@ -295,13 +295,13 @@ jobs:
       CP_VERSION: ${{ needs.scheduler.outputs.cp-version }}
     steps:
     - name: Set up repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
         show-progress: false
         fetch-depth: 1
         persist-credentials: false
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.13'
     - name: Set up Zephyr

--- a/.github/workflows/bundle_cron.yml
+++ b/.github/workflows/bundle_cron.yml
@@ -29,18 +29,18 @@ jobs:
     if: startswith(github.repository, 'adafruit/')
     steps:
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
     - name: Load contributor cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: "contributor-cache"
         path: "contributors.json"
     - name: Versions
       run: |
         python3 --version
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         repository: 'adafruit/adabot'
         submodules: true

--- a/.github/workflows/create-website-pr.yml
+++ b/.github/workflows/create-website-pr.yml
@@ -17,14 +17,14 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
     - name: Set up repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
         show-progress: false
         fetch-depth: 1
         persist-credentials: false
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.x
     - name: Set up submodules

--- a/.github/workflows/learn_cron.yml
+++ b/.github/workflows/learn_cron.yml
@@ -26,7 +26,7 @@ jobs:
     # default branches).
     if: ${{ (github.repository_owner == 'adafruit') }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         repository: ${{ github.repository_owner }}/Adafruit_Learning_System_Guides
         token: ${{ secrets.ADABOT_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Set up repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
         show-progress: false
         fetch-depth: 1
         persist-credentials: false
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.x
     - name: Set up submodules
@@ -42,7 +42,7 @@ jobs:
       run: git diff > ~/pre-commit.patch
     - name: Upload patch
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: patch
         path: ~/pre-commit.patch

--- a/.github/workflows/reports_cron.yml
+++ b/.github/workflows/reports_cron.yml
@@ -38,13 +38,13 @@ jobs:
       BIGQUERY_CLIENT_EMAIL: ${{ secrets.BIGQUERY_CLIENT_EMAIL }}
     steps:
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
       - name: Versions
         run: |
           python3 --version
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: 'adafruit/adabot'
           submodules: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,13 +24,13 @@ jobs:
       TEST_native_mpy: --via-mpy --emit native -d basics float micropython
     steps:
       - name: Set up repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
           show-progress: false
           fetch-depth: 1
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - name: Set up submodules
@@ -75,13 +75,13 @@ jobs:
       CP_VERSION: ${{ inputs.cp-version }}
     steps:
       - name: Set up repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
           show-progress: false
           fetch-depth: 1
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13
       - name: Set up Zephyr


### PR DESCRIPTION
- Fixes #10888.

Update GitHub CI actions to latest major versions, to update Node.24.
https://github.com/carlosperate/arm-none-eabi-gcc-action/issues/86 updated a non-`github` action we also use: no version bump was required.

I'll ask for a review after I see the builds work :)