### PR TITLE
Update adafruit_qtpy_esp32s3_* boards wifi power settings to fix common wifi connectivity issues

### DIFF
--- a/ports/espressif/boards/adafruit_qtpy_esp32s3_4mbflash_2mbpsram/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s3_4mbflash_2mbpsram/mpconfigboard.h
@@ -25,3 +25,6 @@
 #define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO5, .rx = &pin_GPIO16}}
 
 #define DOUBLE_TAP_PIN (&pin_GPIO10)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s3_nopsram/mpconfigboard.h
@@ -25,3 +25,6 @@
 #define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO5, .rx = &pin_GPIO16}}
 
 #define DOUBLE_TAP_PIN (&pin_GPIO10)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)


### PR DESCRIPTION
- Fixes #10914.

This matches the setting for [adafruit_qtpy_esp32c3](https://github.com/adafruit/circuitpython/blob/main/ports/espressif/boards/adafruit_qtpy_esp32c3/mpconfigboard.h)