### PR TITLE
Fix NULL pointer dereference in STM32 SPI construct

### DIFF
--- a/ports/stm/common-hal/busio/SPI.c
+++ b/ports/stm/common-hal/busio/SPI.c
@@ -136,11 +136,12 @@ void common_hal_busio_spi_construct(busio_spi_obj_t *self,
     const mcu_pin_obj_t *sck, const mcu_pin_obj_t *mosi,
     const mcu_pin_obj_t *miso, bool half_duplex) {
 
+    // Ensure the object starts in its deinit state before check_pins sets
+    // self->sck, self->mosi, and self->miso.
+    common_hal_busio_spi_mark_deinit(self);
+
     int periph_index = check_pins(self, sck, mosi, miso);
     SPI_TypeDef *SPIx = mcu_spi_banks[periph_index - 1];
-
-    // Ensure the object starts in its deinit state.
-    common_hal_busio_spi_mark_deinit(self);
 
     // Start GPIO for each pin
     GPIO_InitTypeDef GPIO_InitStruct = {0};


### PR DESCRIPTION
## Summary
- Fixes a NULL pointer dereference in `common_hal_busio_spi_construct()` on the STM32 port that crashed all STM32 boards using SPI (including STM32F405 boards whose CIRCUITPY filesystem lives on external SPI flash).
- The `common_hal_busio_spi_mark_deinit(self)` call (added in 6b458a907e) was placed **after** `check_pins()`, which sets `self->sck`. `mark_deinit` then NULLed `self->sck`, and the immediately following `self->sck->altfn_index` dereference caused a crash.
- The fix moves `mark_deinit()` **before** `check_pins()`, aligning the STM port with every other port (espressif, nordic, raspberrypi, atmel-samd, mimxrt10xx, etc.) which all call `mark_deinit` first.

Fixes #10866

## Test plan
- [x] Built firmware for `feather_stm32f405_express` — compiles cleanly
- [x] Flashed to hardware — board boots, CIRCUITPY drive mounts (previously failed with "CIRCUITPY drive could not be found or created")
- [x] Verified filesystem access via `storage.getmount('/')`, `os.listdir('/')`, `os.statvfs('/')`
- [x] Verified `busio.SPI(board.SCK, board.MOSI, board.MISO)` construct/deinit works

🤖 Generated with [Claude Code](https://claude.com/claude-code)