### PR TITLE
Rpi port i2ctarget fixes

### DIFF
--- a/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.c
+++ b/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.c
@@ -85,7 +85,12 @@ void common_hal_i2ctarget_i2c_target_deinit(i2ctarget_i2c_target_obj_t *self) {
 }
 
 int common_hal_i2ctarget_i2c_target_is_addressed(i2ctarget_i2c_target_obj_t *self, uint8_t *address, bool *is_read, bool *is_restart) {
-    common_hal_i2ctarget_i2c_target_is_stop(self);
+    // Interrupt bits must be cleared by software. Clear the STOP and
+    // RESTART interrupt bits after an I2C transaction finishes.
+    if (self->peripheral->hw->raw_intr_stat & I2C_IC_INTR_STAT_R_STOP_DET_BITS) {
+        self->peripheral->hw->clr_stop_det;
+        self->peripheral->hw->clr_restart_det;
+    }
 
     if (!((self->peripheral->hw->raw_intr_stat & I2C_IC_INTR_STAT_R_RX_FULL_BITS) || (self->peripheral->hw->raw_intr_stat & I2C_IC_INTR_STAT_R_RD_REQ_BITS))) {
         return 0;
@@ -100,12 +105,20 @@ int common_hal_i2ctarget_i2c_target_is_addressed(i2ctarget_i2c_target_obj_t *sel
 }
 
 int common_hal_i2ctarget_i2c_target_read_byte(i2ctarget_i2c_target_obj_t *self, uint8_t *data) {
-    if (self->peripheral->hw->status & I2C_IC_STATUS_RFNE_BITS) {
-        *data = (uint8_t)self->peripheral->hw->data_cmd;
-        return 1;
-    } else {
-        return 0;
+    // Wait for data to arrive or a STOP condition indicating the transfer is over.
+    // Without this wait, the CPU can drain the FIFO faster than bytes arrive on the
+    // I2C bus, causing transfers to be split into multiple partial reads.
+    for (int t = 0; t < 100; t++) {
+        if (self->peripheral->hw->status & I2C_IC_STATUS_RFNE_BITS) {
+            *data = (uint8_t)self->peripheral->hw->data_cmd;
+            return 1;
+        }
+        if (self->peripheral->hw->raw_intr_stat & I2C_IC_INTR_STAT_R_STOP_DET_BITS) {
+            break;
+        }
+        mp_hal_delay_us(10);
     }
+    return 0;
 }
 
 int common_hal_i2ctarget_i2c_target_write_byte(i2ctarget_i2c_target_obj_t *self, uint8_t data) {
@@ -123,19 +136,6 @@ int common_hal_i2ctarget_i2c_target_write_byte(i2ctarget_i2c_target_obj_t *self,
     } else {
         return 0;
     }
-}
-
-int common_hal_i2ctarget_i2c_target_is_stop(i2ctarget_i2c_target_obj_t *self) {
-    // Interrupt bits must be cleared by software. Clear the STOP and
-    // RESTART interrupt bits after an I2C transaction finishes.
-    if (self->peripheral->hw->raw_intr_stat & I2C_IC_INTR_STAT_R_STOP_DET_BITS) {
-        self->peripheral->hw->clr_stop_det;
-        self->peripheral->hw->clr_restart_det;
-        return 1;
-    } else {
-        return 0;
-    }
-
 }
 
 void common_hal_i2ctarget_i2c_target_ack(i2ctarget_i2c_target_obj_t *self, bool ack) {

--- a/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.h
+++ b/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.h
@@ -21,3 +21,5 @@ typedef struct {
     uint8_t scl_pin;
     uint8_t sda_pin;
 } i2ctarget_i2c_target_obj_t;
+
+int common_hal_i2ctarget_i2c_target_is_stop(i2ctarget_i2c_target_obj_t *self);

--- a/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.h
+++ b/ports/raspberrypi/common-hal/i2ctarget/I2CTarget.h
@@ -21,5 +21,3 @@ typedef struct {
     uint8_t scl_pin;
     uint8_t sda_pin;
 } i2ctarget_i2c_target_obj_t;
-
-int common_hal_i2ctarget_i2c_target_is_stop(i2ctarget_i2c_target_obj_t *self);


### PR DESCRIPTION
This supercedes #10474. It contains the original commit from 10474 and a new commit that resolves the changes that were requested on that PR. 

This also resolves #10423. While looking into this and testing the refactored fix I found this issue and the reproducer code in it and took a quick shot at resolving it with help from claude.

The root cause of 10423 is read_byte was checking the RX FIFO status (RFNE) once and returning 0 immediately if empty. At I2C bus speeds (even 400kHz), the CPU runs much faster than bytes arrive on the wire. So after reading the first 1-2 bytes, the CPU would check the FIFO, find it momentarily empty (the next byte hasn't clocked in yet), return 0, and the shared-bindings read() loop would break — splitting a single 4-byte transfer into two 2-byte reads.

I tested with the reproducer code in the issue and with this fix the pico side is now able to successfully read messages larger than 1 or two bytes. The 4 from the original code work fine and I tested 16 bytes and found it working as well.