### PR TITLE
docs(sdcardio): clarify SD-first init rule for boards with floating C…

### DIFF
--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -43,6 +43,12 @@
 //|            Failure to do so can prevent the SD card from being recognized until it is
 //|            powered off or re-inserted.
 //|
+//|         Exception: on boards where another SPI peripheral has a floating CS
+//|         pin with no hardware pull-up (such as the Feather RP2040 RFM), that
+//|         peripheral's CS must be driven HIGH before SD card initialization.
+//|         Failure to do so will corrupt the SPI bus during SD card init. In
+//|         these cases, initialize and drive the other peripheral's CS high
+//|         first, then initialize the SD card.
 //|         Example usage:
 //|
 //|         .. code-block:: python

--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -49,6 +49,7 @@
 //|            Failure to do so will corrupt the SPI bus during SD card init. In
 //|            these cases, initialize and drive the other peripheral's CS high
 //|            first, then initialize the SD card.
+//|
 //|         Example usage:
 //|
 //|         .. code-block:: python

--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -43,12 +43,12 @@
 //|            Failure to do so can prevent the SD card from being recognized until it is
 //|            powered off or re-inserted.
 //|
-//|         Exception: on boards where another SPI peripheral has a floating CS
-//|         pin with no hardware pull-up (such as the Feather RP2040 RFM), that
-//|         peripheral's CS must be driven HIGH before SD card initialization.
-//|         Failure to do so will corrupt the SPI bus during SD card init. In
-//|         these cases, initialize and drive the other peripheral's CS high
-//|         first, then initialize the SD card.
+//|            Exception: on boards where another SPI peripheral has a floating CS
+//|            pin with no hardware pull-up (such as the Feather RP2040 RFM), that
+//|            peripheral's CS must be driven HIGH before SD card initialization.
+//|            Failure to do so will corrupt the SPI bus during SD card init. In
+//|            these cases, initialize and drive the other peripheral's CS high
+//|            first, then initialize the SD card.
 //|         Example usage:
 //|
 //|         .. code-block:: python


### PR DESCRIPTION
Documentation change only.

The `.. important::` note in `SDCard.__init__` says to always initialize the SD card before other SPI peripherals. This is correct in most cases, but on boards with a floating CS pin (e.g. Feather RP2040 RFM, where RFM_CS has no pull-up), the other peripheral's CS must be driven HIGH first to avoid corrupting the bus during SD init.

Adds an exception note to the existing important block for this case.

[forum thread](https://forums.adafruit.com/viewtopic.php?t=223438) credit ThoMue for pointing this out... 