### PR TITLE
Add watchdog reset reason check in start_web_workflow

### DIFF
--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -342,6 +342,7 @@ bool supervisor_start_web_workflow(void) {
     if (reset_reason != RESET_REASON_POWER_ON &&
         reset_reason != RESET_REASON_RESET_PIN &&
         reset_reason != RESET_REASON_DEEP_SLEEP_ALARM &&
+        reset_reason != RESET_REASON_WATCHDOG &&
         reset_reason != RESET_REASON_UNKNOWN &&
         reset_reason != RESET_REASON_SOFTWARE) {
         return false;


### PR DESCRIPTION
Suggested change from Scott.
Closes https://github.com/adafruit/circuitpython/issues/10054