### PR TITLE
Fix typo in time.monotonic_ns() docstring

### DIFF
--- a/shared-bindings/time/__init__.c
+++ b/shared-bindings/time/__init__.c
@@ -206,7 +206,7 @@ MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
 //| def monotonic_ns() -> int:
 //|     """Return the time of the monotonic clock, which cannot go backward, in nanoseconds.
 //|     Not available on boards without long integer support.
-//|     Only use it to compare against other values from `time.monotonic()`
+//|     Only use it to compare against other values from `time.monotonic_ns()`
 //|     during a single code run.
 //|
 //|     :return: the current time


### PR DESCRIPTION
## Summary
- The docstring for `time.monotonic_ns()` said to compare against other values from `time.monotonic()`, but those two functions return different units (seconds vs. nanoseconds). Fixed it to reference `time.monotonic_ns()` instead.

Fixes #10946

## Test plan
- [x] Docstring-only change; no behavior impact.