### PR TITLE
fix flash size on zephyr feather rp2040

### DIFF
--- a/ports/zephyr-cp/boards/adafruit_feather_rp2040.overlay
+++ b/ports/zephyr-cp/boards/adafruit_feather_rp2040.overlay
@@ -26,7 +26,7 @@
 
 		circuitpy_partition: partition@181000 {
 			label = "circuitpy";
-			reg = <0x181000 (DT_SIZE_M(2) - 0x181000)>;
+			reg = <0x181000 (DT_SIZE_M(8) - 0x181000)>;
 		};
 	};
 };


### PR DESCRIPTION
I mostly copied the original feather rp2040 board def from rpi pico and did not adjust the flash amount.

My understanding is upstream zephyr uses `(DT_SIZE_M(8)` for this device here: https://github.com/zephyrproject-rtos/zephyr/blob/d67ec272cc6f86250e6e29eadc4590f865d76c2b/boards/adafruit/feather_rp2040/adafruit_feather_rp2040.dts#L73

With this change my OS reports ~6.8mb total size of the drive as compared to under 2mb like it is without the change.

One tricky bit with this is that `storage` is not currently enabled in the zephyr port so it is not as easy to get the change to take effect on the device. I had to use the flash nuke UF2 and then load the new build from this branch in order to get the adjusted size.