### PR TITLE
docs(sdcardio): replace init-order note with the real shared-SPI CS invariant

### DIFF
--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -38,10 +38,18 @@
 //|         the microcontroller)
 //|
 //|         .. important::
-//|            If the same SPI bus is shared with other peripherals, it is important that
-//|            the SD card be initialized before accessing any other peripheral on the bus.
-//|            Failure to do so can prevent the SD card from being recognized until it is
-//|            powered off or re-inserted.
+//|            When the SPI bus is shared with other peripherals, every CS pin on
+//|            the bus must be in a known HIGH (deselected) state before any SPI
+//|            transaction occurs. This is normally guaranteed by a hardware
+//|            pull-up on each CS line, but on boards where a co-resident
+//|            peripheral's CS floats (for example the Feather RP2040 RFM, whose
+//|            ``RFM_CS`` has no pull-up), that CS must be driven HIGH in
+//|            software before the SD card is initialized. If any CS is allowed
+//|            to float low, the SPI bus can be corrupted during SD card init
+//|            and the card may not be recognized until it is powered off or
+//|            re-inserted. The order in which peripherals are constructed is
+//|            secondary; what matters is that all CS lines are deselected
+//|            before any SPI transaction.
 //|
 //|         Example usage:
 //|

--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -48,7 +48,7 @@
 //|            to float low, the SPI bus can be corrupted during SD card init
 //|            and the card may not be recognized until it is powered off or
 //|            re-inserted. The order in which peripherals are constructed is
-//|            secondary; what matters is that all CS lines are deselected
+//|            secondary; what matters is that all CS lines are HIGH (deselected)
 //|            before any SPI transaction.
 //|
 //|         Example usage:

--- a/shared-bindings/sdcardio/SDCard.c
+++ b/shared-bindings/sdcardio/SDCard.c
@@ -43,13 +43,6 @@
 //|            Failure to do so can prevent the SD card from being recognized until it is
 //|            powered off or re-inserted.
 //|
-//|            Exception: on boards where another SPI peripheral has a floating CS
-//|            pin with no hardware pull-up (such as the Feather RP2040 RFM), that
-//|            peripheral's CS must be driven HIGH before SD card initialization.
-//|            Failure to do so will corrupt the SPI bus during SD card init. In
-//|            these cases, initialize and drive the other peripheral's CS high
-//|            first, then initialize the SD card.
-//|
 //|         Example usage:
 //|
 //|         .. code-block:: python


### PR DESCRIPTION
Supersedes #10947 and #10961. Per @dhalbert's note on #10961, folding the revert and the rewrite into one PR so we don't run two merge builds.

**What this does**

- First commit reverts #10947 (the "SD-first with an exception for floating CS" framing).
- Second commit rewrites the existing `.. important::` note on `sdcardio.SDCard.__init__` to describe the actual invariant on a shared SPI bus.

**Why**

The previous note said the SD card must be initialized before any other peripheral on a shared SPI bus. That rule worked in practice because every co-resident CS line on the supported boards had a hardware pull-up silently keeping the bus clean at boot — not because SD card init has to come first. As @bablokb pointed out on #10947, the real invariant is that every CS pin on the shared bus must be in a known HIGH (deselected) state before any SPI transaction, whether guaranteed by a hardware pull-up or driven HIGH in software. Init order is secondary.

The Feather RP2040 RFM is the board that exposes the gap: `RFM_CS` has no pull-up, so it floats and corrupts the bus during SD init unless the user drives it HIGH first. #10947 tried to document this as an "exception to the SD-first rule" — but the SD-first rule itself was only ever a proxy for the real CS-state invariant, so documenting the invariant directly is the correct fix.

**Context**

- Forum thread that prompted the investigation: https://forums.adafruit.com/viewtopic.php?t=223438
- Prior PR being replaced: #10947
- Revert-only PR now superseded: #10961