### PR TITLE
Mount SD card at filesystem init so macOS can see it via USB MSC

### DIFF
--- a/supervisor/shared/filesystem.c
+++ b/supervisor/shared/filesystem.c
@@ -219,6 +219,13 @@ bool filesystem_init(bool create_allowed, bool force_create) {
 
     #if CIRCUITPY_SDCARDIO
     sdcardio_init();
+    #if defined(DEFAULT_SD_CARD_DETECT) && CIRCUITPY_SDCARD_USB
+    // Mount the SD card now so it's ready when USB enumerates.
+    // Lazy mount from tud_msc_test_unit_ready_cb can lose races with
+    // macOS's probe timing. Gated on CIRCUITPY_SDCARD_USB to match the
+    // existing call site in usb_msc_flash.c (guarded by SDCARD_LUN).
+    automount_sd_card();
+    #endif
     #endif
 
     return true;


### PR DESCRIPTION
The SD card is currently mounted lazily when macOS sends the first TEST UNIT READY. That can lose a race: macOS sees NOT_READY, gives up, and never retries. Mounting at `filesystem_init` (right after `sdcardio_init`) means the card is live before USB enumerates.

### Tested

| Board | CP version | Result |
|---|---|---|
| [Feather RP2040 Adalogger](https://www.adafruit.com/product/5980) | 10.2.0-rc.0 | macOS mounts SD first try |
| [Metro RP2350](https://www.adafruit.com/product/6003) | 10.1.4 stable | No regression, SD still mounts |
| [Fruit Jam](https://www.adafruit.com/product/6200) (3-LUN: CIRCUITPY + CPSAVES + SD) | 10.1.4 stable | No regression |

Host OSes: macOS 26.x (Apple Silicon M2), Ubuntu 24.04 (kernel 6.17). Linux is fine.

### Related

- #10457 (merged) — complementary no-card NULL-check
- #10645, #10887 — SD-over-USB feature track
- #10965 — root issue tracked
- #10967 — companion per-LUN PREVENT_ALLOW fix
- #10968 — companion SD pin defines for Metro RP2040 + Feather RP2040 Adalogger

Three-line diff in `filesystem.c`.
