### PR TITLE
bump MSC buffer for RP2040 boards exposing SD-over-USB

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -200,9 +200,21 @@ CFLAGS += \
 	-DCFG_TUD_CDC_RX_BUFSIZE=256 \
 	-DCFG_TUD_MIDI_TX_BUFSIZE=128 \
 	-DCFG_TUD_CDC_TX_BUFSIZE=256 \
-	-DCFG_TUD_MSC_BUFSIZE=1024 \
 	-DPICO_RP2040_USB_DEVICE_UFRAME_FIX=1 \
 	-DPICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1 \
+
+# CFG_TUD_MSC_BUFSIZE: 1024 bytes is enough for internal flash MSC but
+# causes macOS bulk-IN endpoint stalls on RP2040 during multi-sector SD
+# card READ(10) probes. Boards that expose an SD card over USB MSC can
+# opt into a larger buffer by setting CIRCUITPY_USB_MSC_LARGE_BUFFER = 1
+# in their mpconfigboard.mk. Costs ~15 KB RAM; only worth enabling when
+# the board actually has SD hardware exposed over USB MSC.
+# Root cause tracked at hathach/tinyusb.
+ifeq ($(CIRCUITPY_USB_MSC_LARGE_BUFFER),1)
+CFLAGS += -DCFG_TUD_MSC_BUFSIZE=16384
+else
+CFLAGS += -DCFG_TUD_MSC_BUFSIZE=1024
+endif
 
 # option to override default optimization level, set in boards/$(BOARD)/mpconfigboard.mk
 CFLAGS += $(OPTIMIZATION_FLAGS)


### PR DESCRIPTION
Workaround for macOS bulk-IN endpoint stalls on RP2040 during multi-sector SD `READ(10)` probes with the default 1024-byte MSC buffer. SD card never mounts on macOS; Linux works. Bumping the buffer to 16 KB clears the stall.

Applied only when `CHIP_VARIANT=RP2040` and `CIRCUITPY_SDCARDIO=1`. No RAM cost for RP2350 boards or non-SD RP2040 boards.

### Tested (CP 10.1.4 stable)

| Board | Chip | Default 1024 B | This PR (16 KB on RP2040+SD) |
|---|---|---|---|
| [Feather RP2040 Adalogger](https://www.adafruit.com/product/5980) | RP2040 | macOS stalls, gives up after ~5 min | Mounts first try |
| [Metro RP2040](https://www.adafruit.com/product/5786) | RP2040 | LUN 1 never probed (separate bug — #10965) | LUN 1 still never probed (separate bug — #10965) |
| [Metro RP2350](https://www.adafruit.com/product/6003) | RP2350 | Works | Not applied (unchanged) |
| [Fruit Jam](https://www.adafruit.com/product/6200) (3-LUN) | RP2350 | Works | Not applied (unchanged) |

Host OSes: macOS 26.x on Apple Silicon M2 (both Mac mini and MacBook Air), Ubuntu 24.04 (kernel 6.17). Linux is unaffected in every cell.

### This is a stopgap

Metro RP2350 and Fruit Jam handle the same macOS traffic fine at 1024. The root cause is almost certainly in tinyusb's `rp2` device driver or the RP2040 USB peripheral itself. Root-cause ticket: hathach/tinyusb#3607. Once fixed upstream, this conditional can be reverted.

### Related

- hathach/tinyusb#3607 — root-cause ticket for the RP2040 bulk-IN stall
- #10965 — separate Metro RP2040 LUN 1 probe bug (not addressed by this PR)
- adafruit/Adafruit_TinyUSB_Arduino#455 — prior Arduino-side report
- #10457 — complementary no-card NULL-check
- #10963 — companion PR, moves SD automount to filesystem init
