### PR TITLE
remove improper clearing of callback state for web workflow background callback

### DIFF
--- a/supervisor/shared/background_callback.c
+++ b/supervisor/shared/background_callback.c
@@ -14,9 +14,7 @@
 #include "supervisor/shared/tick.h"
 #include "shared-bindings/microcontroller/__init__.h"
 
-static volatile background_callback_t *volatile callback_head = NULL;
-static volatile background_callback_t *volatile callback_tail = NULL;
-;
+static volatile background_callback_t *volatile callback_head, *volatile callback_tail;
 
 #ifndef CALLBACK_CRITICAL_BEGIN
 #define CALLBACK_CRITICAL_BEGIN (common_hal_mcu_disable_interrupts())
@@ -30,26 +28,15 @@ MP_WEAK void PLACE_IN_ITCM(port_wake_main_task)(void) {
 
 void PLACE_IN_ITCM(background_callback_add_core)(background_callback_t * cb) {
     CALLBACK_CRITICAL_BEGIN;
-    // next_callback_on_list is volatile only to match callback_head declaration.
-    volatile background_callback_t *next_callback_on_list = callback_head;
-    // Add cb only if it is not already on the callback list.
-    while (next_callback_on_list) {
-        if (cb == next_callback_on_list) {
-            // Already on the list. Don't add.
-            CALLBACK_CRITICAL_END;
-            return;
-        }
-        next_callback_on_list = next_callback_on_list->next;
+    if (cb->prev || callback_head == cb) {
+        CALLBACK_CRITICAL_END;
+        return;
     }
-
-    // Add the cb to the end of the list.
     cb->next = 0;
     cb->prev = (background_callback_t *)callback_tail;
     if (callback_tail) {
         callback_tail->next = cb;
     }
-
-    // If the callback list was empty, record that cb is the first item.
     if (!callback_head) {
         callback_head = cb;
     }

--- a/supervisor/shared/background_callback.c
+++ b/supervisor/shared/background_callback.c
@@ -14,7 +14,9 @@
 #include "supervisor/shared/tick.h"
 #include "shared-bindings/microcontroller/__init__.h"
 
-static volatile background_callback_t *volatile callback_head, *volatile callback_tail;
+static volatile background_callback_t *volatile callback_head = NULL;
+static volatile background_callback_t *volatile callback_tail = NULL;
+;
 
 #ifndef CALLBACK_CRITICAL_BEGIN
 #define CALLBACK_CRITICAL_BEGIN (common_hal_mcu_disable_interrupts())
@@ -28,15 +30,26 @@ MP_WEAK void PLACE_IN_ITCM(port_wake_main_task)(void) {
 
 void PLACE_IN_ITCM(background_callback_add_core)(background_callback_t * cb) {
     CALLBACK_CRITICAL_BEGIN;
-    if (cb->prev || callback_head == cb) {
-        CALLBACK_CRITICAL_END;
-        return;
+    // next_callback_on_list is volatile only to match callback_head declaration.
+    volatile background_callback_t *next_callback_on_list = callback_head;
+    // Add cb only if it is not already on the callback list.
+    while (next_callback_on_list) {
+        if (cb == next_callback_on_list) {
+            // Already on the list. Don't add.
+            CALLBACK_CRITICAL_END;
+            return;
+        }
+        next_callback_on_list = next_callback_on_list->next;
     }
+
+    // Add the cb to the end of the list.
     cb->next = 0;
     cb->prev = (background_callback_t *)callback_tail;
     if (callback_tail) {
         callback_tail->next = cb;
     }
+
+    // If the callback list was empty, record that cb is the first item.
     if (!callback_head) {
         callback_head = cb;
     }

--- a/supervisor/shared/workflow.c
+++ b/supervisor/shared/workflow.c
@@ -45,6 +45,7 @@ void supervisor_workflow_reset(void) {
     bool result = supervisor_start_web_workflow();
     if (result) {
         if (!workflow_background_cb.fun) {
+            // Enable background callbacks if web_workflow startup successful.
             workflow_background_cb.fun = supervisor_web_workflow_background;
         }
         supervisor_workflow_request_background();

--- a/supervisor/shared/workflow.c
+++ b/supervisor/shared/workflow.c
@@ -45,7 +45,6 @@ void supervisor_workflow_reset(void) {
     bool result = supervisor_start_web_workflow();
     if (result) {
         if (!workflow_background_cb.fun) {
-            memset(&workflow_background_cb, 0, sizeof(workflow_background_cb));
             workflow_background_cb.fun = supervisor_web_workflow_background;
         }
         supervisor_workflow_request_background();
@@ -108,7 +107,6 @@ void supervisor_workflow_start(void) {
     #if CIRCUITPY_WEB_WORKFLOW
     if (supervisor_start_web_workflow()) {
         // Enable background callbacks if web_workflow startup successful.
-        memset(&workflow_background_cb, 0, sizeof(workflow_background_cb));
         workflow_background_cb.fun = supervisor_web_workflow_background;
         // Kick the first background run now that the callback is installed.
         supervisor_workflow_request_background();


### PR DESCRIPTION
- Fixes #10957

@grgrant could you test? Thanks. You can use the artifact builds when they finish.

There were two issues here:
- `background_callback_add_core()` was not checking the whole list of callbacks to see if the one being added was a duplicate. It was only checking the first one. It was also checking `cb->prev` for `NULL`, for reasons that I don't believe made sense.
- The web workflow background callback was being zero'd out in `supervisor/shared/workflow.c` before it was added as a background callback. This meant that if it was already on the background callback list, its `next` and `prev` fields were being smashed, and that damaged the list structure

These problems only started being visible after #10840, the ESP-IDF v5.5.3 update, for unknown reasons (maybe some subtle FreeRTOS or wifi changes) and got worse with `10.2.0-rc.0`, perhaps because of some workflow changes for Zephyr.

@grgrant I tested with a couple of different programs, to make it easier to wait long enough to see what was going on. One waits 15 seconds, and the other waits for a button push.

```py
import time
import microcontroller

for i in range(15, 0, -1):
    print(i)
    time.sleep(1)

microcontroller.reset()
```
```py
import time
import board
import digitalio
import microcontroller

button = digitalio.DigitalInOut(board.A0)
button.pull = digitalio.Pull.DOWN

for i in range(10000):
    print(i)
    if button.value:
        microcontroller.reset()
    time.sleep(1)
```