### PR TITLE
shared/usb: correctly report the USB MSC drives as removable media

### DIFF
--- a/supervisor/shared/usb/usb_msc_flash.c
+++ b/supervisor/shared/usb/usb_msc_flash.c
@@ -214,8 +214,22 @@ int32_t tud_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer, u
 
     switch (scsi_cmd[0]) {
         case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
-            // Host is about to read/write etc ... better not to disconnect disk
-            resplen = 0;
+            #ifdef SDCARD_LUN
+            if (lun == SDCARD_LUN) {
+                // Removable media (SD card). Respond "unsupported" so macOS
+                // keeps sending TEST_UNIT_READY periodically to detect card
+                // insertion/removal. Responding OK here causes macOS to skip
+                // TUR polling and miss media-present events on the SD LUN.
+                // See the discussion in adafruit/circuitpython#6555.
+                tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);
+                resplen = -1;
+            } else
+            #endif
+            {
+                // Non-removable media (internal flash, SAVES). OK is fine;
+                // host assumes medium always present and skips TUR polling.
+                resplen = 0;
+            }
             break;
 
         default:

--- a/supervisor/shared/usb/usb_msc_flash.c
+++ b/supervisor/shared/usb/usb_msc_flash.c
@@ -204,25 +204,25 @@ uint8_t tud_msc_get_maxlun_cb(void) {
     return LUN_COUNT;
 }
 
+// PREVENT ALLOW MEDIUM REMOVAL: TinyUSB routes this to its own dedicated callback,
+// NOT tud_msc_scsi_cb. Reply unsupported on all LUNs so the host keeps TUR polling
+// on every LUN — eject/storage.remount() works uniformly across CIRCUITPY, SAVES, SD.
+bool tud_msc_prevent_allow_medium_removal_cb(uint8_t lun, uint8_t prohibit_removal, uint8_t control) {
+    (void)prohibit_removal;
+    (void)control;
+    tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);
+    return false;
+}
+
 // Callback invoked when received an SCSI command not in built-in list below
 // - READ_CAPACITY10, READ_FORMAT_CAPACITY, INQUIRY, TEST_UNIT_READY, START_STOP_UNIT, MODE_SENSE6, REQUEST_SENSE
-// - READ10 and WRITE10 have their own callbacks
+// - PREVENT_ALLOW_MEDIUM_REMOVAL, READ10, WRITE10 have their own callbacks
 int32_t tud_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer, uint16_t bufsize) {
     // Note that no command uses a response right now.
     const void *response = NULL;
     int32_t resplen = 0;
 
     switch (scsi_cmd[0]) {
-        case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
-            // All LUNs advertise is_removable=1 in INQUIRY (tinyusb default).
-            // Reply "unsupported" so the host keeps polling TUR and can
-            // re-mount after an eject. Responding OK tells the host to skip
-            // TUR polling, which breaks re-mount and can miss SD insertion
-            // events at boot. See adafruit/circuitpython#6555.
-            tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);
-            resplen = -1;
-            break;
-
         default:
             // Set Sense = Invalid Command Operation
             tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);

--- a/supervisor/shared/usb/usb_msc_flash.c
+++ b/supervisor/shared/usb/usb_msc_flash.c
@@ -214,22 +214,13 @@ int32_t tud_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer, u
 
     switch (scsi_cmd[0]) {
         case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
-            #ifdef SDCARD_LUN
-            if (lun == SDCARD_LUN) {
-                // Removable media (SD card). Respond "unsupported" so macOS
-                // keeps sending TEST_UNIT_READY periodically to detect card
-                // insertion/removal. Responding OK here causes macOS to skip
-                // TUR polling and miss media-present events on the SD LUN.
-                // See the discussion in adafruit/circuitpython#6555.
-                tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);
-                resplen = -1;
-            } else
-            #endif
-            {
-                // Non-removable media (internal flash, SAVES). OK is fine;
-                // host assumes medium always present and skips TUR polling.
-                resplen = 0;
-            }
+            // All LUNs advertise is_removable=1 in INQUIRY (tinyusb default).
+            // Reply "unsupported" so the host keeps polling TUR and can
+            // re-mount after an eject. Responding OK tells the host to skip
+            // TUR polling, which breaks re-mount and can miss SD insertion
+            // events at boot. See adafruit/circuitpython#6555.
+            tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);
+            resplen = -1;
             break;
 
         default:


### PR DESCRIPTION
## What was wrong

The SD card exposed as a USB MSC LUN doesn't mount on macOS. `ioreg` shows the SCSI nub appears but never progresses to publishing an `IOMedia`. Linux handles the same firmware fine.

Why: CircuitPython was telling the host "this LUN's medium is always present" for every LUN, including the SD card. On macOS that means "skip `TEST_UNIT_READY` polling" — so if the SD wasn't ready at the one-shot enumeration probe, macOS never re-checked and gave up on the LUN. Linux ignored the hint and kept polling, which is why it worked there.

@hathach documented this exact macOS behavior back in #6555; the per-LUN distinction wasn't applied at the time.

## What changed

Report the SD LUN as removable media, report internal flash and SAVES as non-removable. macOS now keeps polling TUR on the SD LUN and correctly picks up card insertion and removal.

~10 lines in `supervisor/shared/usb/usb_msc_flash.c` — per-LUN branch on the existing `PREVENT_ALLOW_MEDIUM_REMOVAL` handler. No RAM or flash cost.

## Tested on

| Board | Result |
|---|---|
| Feather RP2040 Adalogger (with SD pin defines from #10968) | SD mounts first try on macOS 26.x |
| Metro RP2040 (with SD pin defines from #10968) | SD mounts |
| Metro RP2350 | SD mounts, no regression |
| Fruit Jam (3-LUN: flash + CPSAVES + SD) | All three mount; CPSAVES correctly stays non-removable |
| Linux (Ubuntu 24.04) | `/dev/sdc` + `/dev/sdd` correct sizes, no regression |

Windows not tested.

## Related

- Fixes #10965
- Companion: #10963 (automount at filesystem init)
- Companion: #10968 (SD pin defines for Metro RP2040 + Feather RP2040 Adalogger)
- Historical context: #6555
- Supersedes the workaround in #10964 (closed)

Credit to @dhalbert for pointing at #6555 and @hathach for the original analysis.
