### PR TITLE
Fix incorrectly named pin

### DIFF
--- a/ports/espressif/boards/waveshare_esp32_s3_matrix/pins.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_matrix/pins.c
@@ -35,7 +35,7 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_A2), MP_ROM_PTR(&pin_GPIO2) },
     { MP_ROM_QSTR(MP_QSTR_D2), MP_ROM_PTR(&pin_GPIO2) },
 
-    { MP_ROM_QSTR(MP_QSTR_I01), MP_ROM_PTR(&pin_GPIO1) },
+    { MP_ROM_QSTR(MP_QSTR_IO1), MP_ROM_PTR(&pin_GPIO1) },
     { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_GPIO1) },
     { MP_ROM_QSTR(MP_QSTR_D1), MP_ROM_PTR(&pin_GPIO1) },
 


### PR DESCRIPTION
Hello! This only changes the naming of a single pin on the Waveshare ESP32-S3-Matrix: When I tried did something simple like:

```
import board
help(board.IO1)
```

I would get an error like:

```
AttributeError: 'module' object has no attribute 'IO1'
```

I eventually figured out that this pin is misnamed I01 (that is, I *zero* one), rather than IO1 (like input/output 1).

This PR corrects that mistake. This is the only pin on this board that appears incorrectly named like this. 