### PR TITLE
Support pin IO41 (aka ANTENNA_SWITCH)

### DIFF
--- a/ports/espressif/boards/unexpectedmaker_feathers3/pins.c
+++ b/ports/espressif/boards/unexpectedmaker_feathers3/pins.c
@@ -128,6 +128,10 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_LDO2), MP_ROM_PTR(&pin_GPIO39) },
     { MP_ROM_QSTR(MP_QSTR_IO39), MP_ROM_PTR(&pin_GPIO39) },
 
+    // built-in vs uFL antenna switch (LOW=built-in, HIGH=uFL, default=built-in)
+    { MP_ROM_QSTR(MP_QSTR_ANTENNA_SWITCH), MP_ROM_PTR(&pin_GPIO41) },
+    { MP_ROM_QSTR(MP_QSTR_IO41), MP_ROM_PTR(&pin_GPIO41) },
+
     // I2C
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_STEMMA_I2C), MP_ROM_PTR(&board_i2c_obj) },


### PR DESCRIPTION
Support pin IO41 (aka ANTENNA_SWITCH), which allows a user to switch from the built-in antenna to the uFL antenna. This pin is only on the "D" series of Unexpected Maker S3 series of boards.

https://unexpectedmaker.com/shop.html#!/FeatherS3-D/p/759221736
