### PR TITLE
MagTag SSD1680 FPC-7519rev.b new variant add colstart offset

### DIFF
--- a/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
+++ b/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
@@ -145,12 +145,16 @@ typedef enum {
 static display_type_t detect_display_type(void) {
     // Bitbang 4-wire SPI with a bidirectional data line to read the first word of register 0x2e,
     // which is the 10-byte USER ID.
+    // NOTE: the SSD1680 drives its response back on the MOSI/DATA line (GPIO35) in half-duplex
+    // mode, NOT on the separate MISO line (GPIO37). Read with GPIO35 switched to input.
     // On the IL0373 it will return 0xff because it's not a valid register.
-    // With SSD1680, we have seen two types:
+    // With SSD1680, we have seen three types:
     // 1. The first batch of displays, labeled "FPC-A005 20.06.15 TRX", which needs colstart=0.
-    //    These have 10 byes of zeros in the User ID
+    //    These have 10 bytes of zeros in the User ID.
     // 2. Second batch, labeled "FPC-7619rev.b", which needs colstart=8.
     //    The USER ID for these boards is [0x44, 0x0, 0x4, 0x0, 0x25, 0x0, 0x1, 0x78, 0x2b, 0xe]
+    // 3. Third batch, labeled "FPC-7519rev.b", which needs colstart=8.
+    //    The USER ID for these boards is [0xca, 0xfe, 0x0, 0x16, 0x80, 0x0, 0x75, 0x1, 0x0, 0x98]
     // So let's distinguish just by the first byte.
     digitalio_digitalinout_obj_t data;
     digitalio_digitalinout_obj_t clock;
@@ -213,6 +217,8 @@ static display_type_t detect_display_type(void) {
         case 0x00:
             return DISPLAY_SSD1680_COLSTART_0;
         case 0x44:
+            return DISPLAY_SSD1680_COLSTART_8;
+        case 0xca:
             return DISPLAY_SSD1680_COLSTART_8;
     }
 }

--- a/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
+++ b/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
@@ -143,7 +143,7 @@ typedef enum {
 } display_type_t;
 
 static display_type_t detect_display_type(void) {
-    // Bitbang 4-wire SPI with a bidirectional data line to read the first word of register 0x2e,
+    // Bitbang 4-wire SPI with a bidirectional data line to read the first byte of register 0x2e,
     // which is the 10-byte USER ID.
     // NOTE: the SSD1680 drives its response back on the MOSI/DATA line (GPIO35) in half-duplex
     // mode, NOT on the separate MISO line (GPIO37). Read with GPIO35 switched to input.

--- a/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
+++ b/ports/espressif/boards/adafruit_magtag_2.9_grayscale/board.c
@@ -217,7 +217,6 @@ static display_type_t detect_display_type(void) {
         case 0x00:
             return DISPLAY_SSD1680_COLSTART_0;
         case 0x44:
-            return DISPLAY_SSD1680_COLSTART_8;
         case 0xca:
             return DISPLAY_SSD1680_COLSTART_8;
     }


### PR DESCRIPTION
A new MagTag SSD1680 panel variant (FPC-7519rev.b, User ID first byte 0xca) is shipping (batch W42972-E). It requires colstart=8, the same
as FPC-7619rev.b. Adds one case to the detection switch in board.c.

[forum issue](https://forums.adafruit.com/viewtopic.php?t=223682)

```
Panel                    | User ID byte 0 | colstart | Approx. era                  | CP fix
-------------------------|----------------|----------|------------------------------|----------------
IL0373                   | 0xff           | N/A      | 2020 – mid 2025              | always worked
FPC-A005 20.06.15 TRX    | 0x00           | 0        | Mid 2025 (first SSD1680)     | always worked
FPC-7619rev.b            | 0x44           | 8        | early 2026                   | fixed in 10.1.3
FPC-7519rev.b            | 0xca           | 8        | Spring 2026 – present        | this PR
```

CP 10.2.0 running [Hello World](https://learn.adafruit.com/creating-magtag-projects-with-circuitpython/code-examples#full-example-code-3079705) example:

<img width="480" height="360" alt="IMG_0301" src="https://github.com/user-attachments/assets/c0d4ceff-d7f4-4e8c-b859-33e5700d563f" />

CP 10.3.0 (main tree) with this PR applied.

<img width="480" height="360" alt="IMG_0302" src="https://github.com/user-attachments/assets/47c9d30f-dfff-44ed-ae0e-561c4b3f1269" />

```
Adafruit CircuitPython 10.3.0-alpha.1-4-g5f6f96aa93-dirty on 2026-05-07; Adafruit MagTag with ESP32S2
```

