### PR TITLE
fourwire_construct no reset pin must be mp_const_none, not NULL

### DIFF
--- a/ports/atmel-samd/boards/ugame10/board.c
+++ b/ports/atmel-samd/boards/ugame10/board.c
@@ -55,7 +55,7 @@ void board_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_PA09), // Command or data
         MP_OBJ_FROM_PTR(&pin_PA08), // Chip select
-        MP_OBJ_NULL, // Reset
+        mp_const_none,              // Reset
         24000000, // Baudrate
         0, // Polarity
         0); // Phase

--- a/ports/espressif/boards/elecrow_crowpanel_3.5/board.c
+++ b/ports/espressif/boards/elecrow_crowpanel_3.5/board.c
@@ -54,9 +54,9 @@ void board_init(void) {
     bus->base.type = &fourwire_fourwire_type;
     common_hal_fourwire_fourwire_construct(bus,
         spi,
-        MP_OBJ_FROM_PTR(&pin_GPIO2), // TFT_DC Command or data
+        MP_OBJ_FROM_PTR(&pin_GPIO2),  // TFT_DC Command or data
         MP_OBJ_FROM_PTR(&pin_GPIO15), // TFT_CS Chip select
-        NULL, // TFT_RST Reset
+        mp_const_none,                // TFT_RST Reset
         20000000, // Baudrate
         0, // Polarity
         0); // Phase

--- a/ports/espressif/boards/espressif_esp32s3_eye/board.c
+++ b/ports/espressif/boards/espressif_esp32s3_eye/board.c
@@ -58,7 +58,7 @@ void board_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO43),    // DC
         MP_OBJ_FROM_PTR(&pin_GPIO44),    // CS
-        NULL,           // no reset pin
+        mp_const_none,                   // no reset pin
         40000000,       // baudrate
         0,              // polarity
         0               // phase

--- a/ports/espressif/boards/hardkernel_odroid_go/board.c
+++ b/ports/espressif/boards/hardkernel_odroid_go/board.c
@@ -52,8 +52,8 @@ void board_init(void) {
     common_hal_fourwire_fourwire_construct(bus,
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO21), // TFT_DC Command or data
-        MP_OBJ_FROM_PTR(&pin_GPIO5), // TFT_CS Chip select
-        NULL, // TFT_RST Reset
+        MP_OBJ_FROM_PTR(&pin_GPIO5),  // TFT_CS Chip select
+        mp_const_none,                // TFT_RST Reset
         40000000, // Baudrate
         0, // Polarity
         0); // Phase

--- a/ports/espressif/boards/hiibot_iots2/board.c
+++ b/ports/espressif/boards/hiibot_iots2/board.c
@@ -64,7 +64,7 @@ static void display_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO35),    // DC
         MP_OBJ_FROM_PTR(&pin_GPIO36),    // CS
-        NULL,           // NO RST ?
+        mp_const_none,                   // NO RST ?
         40000000,       // baudrate
         0,              // polarity
         0               // phase

--- a/ports/espressif/boards/lilygo_tdeck/board.c
+++ b/ports/espressif/boards/lilygo_tdeck/board.c
@@ -34,7 +34,7 @@ void board_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO11), // TFT_DC Command or data
         MP_OBJ_FROM_PTR(&pin_GPIO12), // TFT_CS Chip select
-        NULL, // TFT_RST Reset
+        mp_const_none, // TFT_RST Reset
         60000000, // Baudrate
         0, // Polarity
         0); // Phase

--- a/ports/espressif/boards/lilygo_twatch_2020_v3/board.c
+++ b/ports/espressif/boards/lilygo_twatch_2020_v3/board.c
@@ -48,7 +48,7 @@ static void display_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO27),    // DC
         MP_OBJ_FROM_PTR(&pin_GPIO5),     // CS
-        NULL,           // RST
+        mp_const_none,           // RST
         24000000,       // baudrate
         0,              // polarity
         0               // phase

--- a/ports/espressif/boards/lilygo_twatch_s3/board.c
+++ b/ports/espressif/boards/lilygo_twatch_s3/board.c
@@ -110,7 +110,7 @@ void board_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO38),    // DC
         MP_OBJ_FROM_PTR(&pin_GPIO12),    // CS
-        NULL,           // RST
+        mp_const_none,           // RST
         40000000,       // baudrate
         0,              // polarity
         0               // phase

--- a/ports/espressif/boards/m5stack_core2/board.c
+++ b/ports/espressif/boards/m5stack_core2/board.c
@@ -320,7 +320,7 @@ static bool display_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO15),    // DC
         MP_OBJ_FROM_PTR(&pin_GPIO5),     // CS
-        MP_OBJ_NULL,           // RST
+        mp_const_none,           // RST
         32000000,       // baudrate
         0,              // polarity
         0               // phase

--- a/ports/espressif/boards/m5stack_cores3/board.c
+++ b/ports/espressif/boards/m5stack_cores3/board.c
@@ -47,7 +47,7 @@ static bool display_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO35),    // DC
         MP_OBJ_FROM_PTR(&pin_GPIO3),     // CS
-        MP_OBJ_NULL,           // RST
+        mp_const_none,           // RST
         40000000,       // baudrate
         0,              // polarity
         0               // phase

--- a/ports/espressif/boards/m5stack_cores3_se/board.c
+++ b/ports/espressif/boards/m5stack_cores3_se/board.c
@@ -48,7 +48,7 @@ static bool display_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO35),    // DC
         MP_OBJ_FROM_PTR(&pin_GPIO3),     // CS
-        NULL,           // RST
+        mp_const_none,           // RST
         40000000,       // baudrate
         0,              // polarity
         0               // phase

--- a/ports/espressif/boards/sunton_esp32_2424S012/board.c
+++ b/ports/espressif/boards/sunton_esp32_2424S012/board.c
@@ -107,7 +107,7 @@ static void display_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO2),    // DC
         MP_OBJ_FROM_PTR(&pin_GPIO10),     // CS
-        MP_OBJ_NULL,           // RST
+        mp_const_none,           // RST
         80000000,       // baudrate
         0,              // polarity
         0               // phase

--- a/ports/espressif/boards/sunton_esp32_2432S024C/board.c
+++ b/ports/espressif/boards/sunton_esp32_2432S024C/board.c
@@ -53,7 +53,7 @@ static void display_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO2), // TFT_DC Command or data
         MP_OBJ_FROM_PTR(&pin_GPIO15), // TFT_CS Chip select
-        MP_OBJ_NULL, // TFT_RST Reset
+        mp_const_none, // TFT_RST Reset
         6000000, // Baudrate
         0, // Polarity
         0); // Phase

--- a/ports/espressif/boards/sunton_esp32_2432S028/board.c
+++ b/ports/espressif/boards/sunton_esp32_2432S028/board.c
@@ -53,7 +53,7 @@ static void display_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO2), // TFT_DC Command or data
         MP_OBJ_FROM_PTR(&pin_GPIO15), // TFT_CS Chip select
-        MP_OBJ_NULL, // TFT_RST Reset
+        mp_const_none, // TFT_RST Reset
         6000000, // Baudrate
         0, // Polarity
         0); // Phase

--- a/ports/espressif/boards/sunton_esp32_2432S032C/board.c
+++ b/ports/espressif/boards/sunton_esp32_2432S032C/board.c
@@ -45,7 +45,7 @@ static void display_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO2),  // TFT_DC
         MP_OBJ_FROM_PTR(&pin_GPIO15),  // TFT_CS
-        MP_OBJ_NULL,  // TFT_RST
+        mp_const_none,  // TFT_RST
         26600000, // Baudrate
         0, // Polarity
         0 // Phase

--- a/ports/espressif/boards/vidi_x/board.c
+++ b/ports/espressif/boards/vidi_x/board.c
@@ -53,7 +53,7 @@ void board_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO21), // TFT_DC Command or data
         MP_OBJ_FROM_PTR(&pin_GPIO5), // TFT_CS Chip select
-        MP_OBJ_NULL, // TFT_RST Reset
+        mp_const_none, // TFT_RST Reset
         40000000, // Baudrate
         0, // Polarity
         0); // Phase

--- a/ports/nordic/boards/espruino_banglejs2/board.c
+++ b/ports/nordic/boards/espruino_banglejs2/board.c
@@ -9,7 +9,6 @@
 #include "mpconfigboard.h"
 
 #include "shared-bindings/busio/SPI.h"
-#include "shared-bindings/fourwire/FourWire.h"
 #include "shared-bindings/framebufferio/FramebufferDisplay.h"
 #include "shared-bindings/sharpdisplay/SharpMemoryFramebuffer.h"
 #include "shared-module/displayio/__init__.h"

--- a/ports/nordic/boards/hiibot_bluefi/board.c
+++ b/ports/nordic/boards/hiibot_bluefi/board.c
@@ -36,7 +36,7 @@ void board_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_P0_27), // TFT_DC Command or data
         MP_OBJ_FROM_PTR(&pin_P0_05), // TFT_CS Chip select
-        MP_OBJ_NULL, // no  TFT_RST Reset
+        mp_const_none, // no  TFT_RST Reset
         // &pin_P1_14, // TFT_RST Reset
         60000000, // Baudrate
         0, // Polarity

--- a/ports/raspberrypi/boards/adafruit_floppsy_rp2040/board.c
+++ b/ports/raspberrypi/boards/adafruit_floppsy_rp2040/board.c
@@ -36,7 +36,7 @@ void board_init(void) {
         spi,
         MP_OBJ_FROM_PTR(CIRCUITPY_BOARD_TFT_DC),
         MP_OBJ_FROM_PTR(CIRCUITPY_BOARD_TFT_CS),
-        MP_OBJ_NULL, // TFT_RESET Reset
+        mp_const_none, // TFT_RESET Reset
         40000000, // Baudrate
         0, // Polarity
         0); // Phase

--- a/ports/raspberrypi/boards/heiafr_picomo_v2/board.c
+++ b/ports/raspberrypi/boards/heiafr_picomo_v2/board.c
@@ -53,7 +53,7 @@ void board_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO16), // TFT_DC Command or data
         MP_OBJ_FROM_PTR(&pin_GPIO17), // TFT_CS Chip select
-        MP_OBJ_NULL, // TFT_RST Reset
+        mp_const_none, // TFT_RST Reset
         62500000, // Baudrate
         0, // Polarity
         0); // Phase

--- a/ports/raspberrypi/boards/heiafr_picomo_v3/board.c
+++ b/ports/raspberrypi/boards/heiafr_picomo_v3/board.c
@@ -53,7 +53,7 @@ void board_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO16), // TFT_DC Command or data
         MP_OBJ_FROM_PTR(&pin_GPIO17), // TFT_CS Chip select
-        MP_OBJ_NULL, // TFT_RST Reset
+        mp_const_none, // TFT_RST Reset
         62500000, // Baudrate
         0, // Polarity
         0); // Phase

--- a/ports/raspberrypi/boards/lilygo_t_display_rp2040/board.c
+++ b/ports/raspberrypi/boards/lilygo_t_display_rp2040/board.c
@@ -65,7 +65,7 @@ static void display_init(void) {
         spi,
         MP_OBJ_FROM_PTR(&pin_GPIO1),     // DC
         MP_OBJ_FROM_PTR(&pin_GPIO5),     // CS
-        MP_OBJ_NULL,           // RST (Reset pin tie to 0, do not set here)
+        mp_const_none,                   // RST (Reset pin tie to 0, do not set here)
         40000000,       // baudrate
         1,              // polarity
         0               // phase


### PR DESCRIPTION
- Fixes #10993.

`common_hal_fourwire_fourwire_construct()` was changed in #10783 to take objects in general rather than only pin objects. If the display reset pin was not present, it expected `mp_const_none`, not the previous NULL or MP_OBJ_NULL (both are zero). This caused a crash on all boards that did not use a reset pin for the display.

Thanks @oenone for tracking down the exact commit, which made the diagnosis easy.
