### PR TITLE
simplify startup message printing

### DIFF
--- a/main.c
+++ b/main.c
@@ -441,17 +441,6 @@ static void print_code_py_status_message(safe_mode_t safe_mode) {
 }
 
 static bool __attribute__((noinline)) run_code_py(safe_mode_t safe_mode, bool *simulate_reset) {
-    bool serial_connected_at_start = serial_connected();
-    bool printed_safe_mode_message = false;
-    #if CIRCUITPY_AUTORELOAD_DELAY_MS > 0
-    if (serial_connected_at_start) {
-        serial_write("\r\n");
-        print_code_py_status_message(safe_mode);
-        print_safe_mode_message(safe_mode);
-        printed_safe_mode_message = true;
-    }
-    #endif
-
     bool skip_repl = false;
     bool skip_wait = false;
     bool found_main = false;
@@ -651,20 +640,13 @@ static bool __attribute__((noinline)) run_code_py(safe_mode_t safe_mode, bool *s
 
         // If messages haven't been printed yet, print them
         if (!printed_press_any_key && serial_connected() && !autoreload_pending()) {
-            if (!serial_connected_at_start) {
-                print_code_py_status_message(safe_mode);
-            }
-
-            if (!printed_safe_mode_message) {
-                print_safe_mode_message(safe_mode);
-                printed_safe_mode_message = true;
-            }
+            print_code_py_status_message(safe_mode);
+            print_safe_mode_message(safe_mode);
             serial_write("\r\n");
             serial_write_compressed(MP_ERROR_TEXT("Press any key to enter the REPL. Use CTRL-D to reload.\n"));
             printed_press_any_key = true;
         }
         if (!serial_connected()) {
-            serial_connected_at_start = false;
             printed_press_any_key = false;
         }
 


### PR DESCRIPTION
- Fixes #10445

Print startup messages later so they can be suppressed if desired. Also simplifies the logic of printing them.

I tested on two Metro M0's: the messages still seem to be printed in the same order, and if I go into user-initiated safe mode, they are still the same. I also wrote a blink program on both and tested with USB power only but no data, and they still work. Also `boot.py` content is still the same.'

I am not sure why the original code was more complicated and what case the code after` #if CIRCUITPY_AUTORELOAD_DELAY_MS > 0` was trying to handle that the current code may not, but it seems OK with the changes.

@mikeysklar could you review test on Macropad or similar to see if this allows what the original issue desired?