### PR TITLE
sdcardio: fix card size for SDXC cards > 32 GB

### DIFF
--- a/shared-module/sdcardio/SDCard.c
+++ b/shared-module/sdcardio/SDCard.c
@@ -316,7 +316,7 @@ static mp_rom_error_text_t init_card(sdcardio_sdcard_obj_t *self) {
         }
 
         if (csd_version == 1) {
-            self->sectors = ((csd[8] << 8 | csd[9]) + 1) * 1024;
+            self->sectors = (((uint32_t)(csd[7] & 0x3F) << 16 | (uint32_t)csd[8] << 8 | csd[9]) + 1) * 1024;
         } else {
             uint32_t block_length = 1 << (csd[5] & 0xF);
             uint32_t c_size = ((csd[6] & 0x3) << 10) | (csd[7] << 2) | ((csd[8] & 0xC) >> 6);

--- a/shared-module/sdcardio/SDCard.c
+++ b/shared-module/sdcardio/SDCard.c
@@ -316,7 +316,7 @@ static mp_rom_error_text_t init_card(sdcardio_sdcard_obj_t *self) {
         }
 
         if (csd_version == 1) {
-            self->sectors = (((uint32_t)(csd[7] & 0x3F) << 16 | (uint32_t)csd[8] << 8 | csd[9]) + 1) * 1024;
+            self->sectors = (((csd[7] & 0x3F) << 16 | csd[8] << 8 | csd[9]) + 1) * 1024;
         } else {
             uint32_t block_length = 1 << (csd[5] & 0xF);
             uint32_t c_size = ((csd[6] & 0x3) << 10) | (csd[7] << 2) | ((csd[8] & 0xC) >> 6);


### PR DESCRIPTION
Backport of #11012 to 10.2.x.

SDXC cards larger than 32 GB were reporting roughly half their actual block count
over USB MSC. The CSD v2.0 C_SIZE field is 22 bits but only the bottom 16 were
being read — the fix reads all 22.

## Test results — Metro RP2350, 64 GB exFAT SDXC

| | Before | After |
|---|---|---|
| macOS disk size | 28.9 GB | 63.3 GB ✓ |
| Linux disk size | 26.9 GiB | 58.9 GiB ✓ |

Regression tested with a 16 GB FAT32 SDHC card — size correct on both platforms,
no impact on cards ≤ 32 GB.

Before:
```
$ lsblk -o NAME,SIZE,FSTYPE,LABEL
sdc     26.9G
└─sdc1  26.9G exfat    SDXC
```

After:
```
$ lsblk -o NAME,SIZE,FSTYPE,LABEL
sdc     58.9G
└─sdc1  58.9G exfat    SDXC
```