### PR TITLE
Fix uses of PICO_RP2040 and PICO_RP2350

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -346,7 +346,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Wave.git
 [submodule "ports/raspberrypi/lib/Pico-PIO-USB"]
 	path = ports/raspberrypi/lib/Pico-PIO-USB
-	url = https://github.com/sekigon-gonnoc/Pico-PIO-USB.git
+	url = https://github.com/adafruit/Pico-PIO-USB.git
 	branch = main
 [submodule "lib/micropython-lib"]
 	path = lib/micropython-lib

--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -407,8 +407,7 @@ CFLAGS += \
 	-msoft-float \
 	-mfloat-abi=soft
 
-CFLAGS += \
-	-DPICO_RP2040
+CFLAGS += -DPICO_RP2040=1 -DPICO_RP2350=0
 
 SRC_SDK_CHIP_VARIANT := \
 	src/rp2_common/hardware_rtc/rtc.c \
@@ -451,7 +450,7 @@ DOUBLE_EABI = dcp
 INC += \
 	-isystem sdk/src/rp2_common/hardware_dcp/include/
 
-CFLAGS += -DPICO_RP2350=1
+CFLAGS += -DPICO_RP2040=0 -DPICO_RP2350=1
 
 SRC_SDK_CHIP_VARIANT := \
 	src/rp2_common/hardware_powman/powman.c \

--- a/ports/raspberrypi/audio_dma.c
+++ b/ports/raspberrypi/audio_dma.c
@@ -233,7 +233,7 @@ audio_dma_result audio_dma_setup_playback(
         max_buffer_length /= dma->sample_spacing;
     }
 
-    #ifdef PICO_RP2350
+    #if PICO_RP2350
     dma->buffer[0] = (uint8_t *)port_realloc(dma->buffer[0], max_buffer_length, true);
     #else
     dma->buffer[0] = (uint8_t *)m_realloc(dma->buffer[0],
@@ -249,7 +249,7 @@ audio_dma_result audio_dma_setup_playback(
     }
 
     if (!single_buffer) {
-        #ifdef PICO_RP2350
+        #if PICO_RP2350
         dma->buffer[1] = (uint8_t *)port_realloc(dma->buffer[1], max_buffer_length, true);
         #else
         dma->buffer[1] = (uint8_t *)m_realloc(dma->buffer[1],
@@ -460,7 +460,7 @@ void audio_dma_init(audio_dma_t *dma) {
 }
 
 void audio_dma_deinit(audio_dma_t *dma) {
-    #ifdef PICO_RP2350
+    #if PICO_RP2350
     port_free(dma->buffer[0]);
     #else
     #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
@@ -472,7 +472,7 @@ void audio_dma_deinit(audio_dma_t *dma) {
     dma->buffer[0] = NULL;
     dma->buffer_length[0] = 0;
 
-    #ifdef PICO_RP2350
+    #if PICO_RP2350
     port_free(dma->buffer[1]);
     #else
     #if MICROPY_MALLOC_USES_ALLOCATED_SIZE

--- a/ports/raspberrypi/common-hal/busio/UART.c
+++ b/ports/raspberrypi/common-hal/busio/UART.c
@@ -50,7 +50,7 @@ static void pin_check(const uint8_t uart, const mcu_pin_obj_t *pin, const uint8_
     if (pins_uart != uart) {
         raise_ValueError_invalid_pins();
     }
-    #ifdef PICO_RP2350
+    #if PICO_RP2350
     if ((pin_type == 0 && pin->number % 4 == 2) ||
         (pin_type == 1 && pin->number % 4 == 3)) {
         return;
@@ -67,7 +67,7 @@ static uint8_t pin_init(const uint8_t uart, const mcu_pin_obj_t *pin, const uint
     }
     claim_pin(pin);
     gpio_function_t function = GPIO_FUNC_UART;
-    #ifdef PICO_RP2350
+    #if PICO_RP2350
     if ((pin_type == 0 && pin->number % 4 == 2) ||
         (pin_type == 1 && pin->number % 4 == 3)) {
         function = GPIO_FUNC_UART_AUX;

--- a/ports/raspberrypi/common-hal/memorymap/AddressRange.c
+++ b/ports/raspberrypi/common-hal/memorymap/AddressRange.c
@@ -14,7 +14,7 @@
 #include "hardware/regs/addressmap.h"
 
 // RP2 address map ranges, must be arranged in order by ascending start address
-#ifdef PICO_RP2040
+#if PICO_RP2040
 addressmap_rp2_range_t rp2_ranges[] = {
     {(uint8_t *)ROM_BASE,           0x00004000, ROM},        // boot ROM
     {(uint8_t *)XIP_BASE,           0x00100000, XIP},        // XIP normal cache operation
@@ -36,7 +36,7 @@ addressmap_rp2_range_t rp2_ranges[] = {
     {(uint8_t *)PPB_BASE,           0x00004000, IO}          // PPB registers
 };
 #endif
-#ifdef PICO_RP2350
+#if PICO_RP2350
 addressmap_rp2_range_t rp2_ranges[] = {
     {(uint8_t *)ROM_BASE,           0x00004000, ROM},        // boot ROM
     {(uint8_t *)XIP_BASE,           0x00100000, XIP},        // XIP normal cache operation

--- a/ports/raspberrypi/common-hal/microcontroller/Processor.c
+++ b/ports/raspberrypi/common-hal/microcontroller/Processor.c
@@ -20,11 +20,11 @@
 #include "hardware/vreg.h"
 #include "hardware/watchdog.h"
 
-#ifdef PICO_RP2040
+#if PICO_RP2040
 #include "hardware/regs/vreg_and_chip_reset.h"
 #include "hardware/structs/vreg_and_chip_reset.h"
 #endif
-#ifdef PICO_RP2350
+#if PICO_RP2350
 #include "hardware/regs/powman.h"
 #include "hardware/structs/powman.h"
 #endif
@@ -80,7 +80,7 @@ void common_hal_mcu_processor_get_uid(uint8_t raw_id[]) {
 mcu_reset_reason_t common_hal_mcu_processor_get_reset_reason(void) {
     mcu_reset_reason_t reason = RESET_REASON_UNKNOWN;
 
-    #ifdef PICO_RP2040
+    #if PICO_RP2040
     uint32_t chip_reset_reg = vreg_and_chip_reset_hw->chip_reset;
 
     if (chip_reset_reg & VREG_AND_CHIP_RESET_CHIP_RESET_HAD_PSM_RESTART_BITS) {
@@ -96,7 +96,7 @@ mcu_reset_reason_t common_hal_mcu_processor_get_reset_reason(void) {
         reason = RESET_REASON_POWER_ON;
     }
     #endif
-    #ifdef PICO_RP2350
+    #if PICO_RP2350
     uint32_t chip_reset_reg = powman_hw->chip_reset;
 
     if (chip_reset_reg & POWMAN_CHIP_RESET_HAD_RESCUE_BITS) {

--- a/ports/raspberrypi/common-hal/microcontroller/__init__.c
+++ b/ports/raspberrypi/common-hal/microcontroller/__init__.c
@@ -30,7 +30,7 @@ void common_hal_mcu_delay_us(uint32_t delay) {
 }
 
 volatile uint32_t nesting_count = 0;
-#ifdef PICO_RP2040
+#if PICO_RP2040
 void common_hal_mcu_disable_interrupts(void) {
     // We don't use save_and_disable_interrupts() from the sdk because we don't want to worry about PRIMASK.
     // This is what we do on the SAMD21 via CMSIS.

--- a/ports/raspberrypi/common-hal/picodvi/Framebuffer.h
+++ b/ports/raspberrypi/common-hal/picodvi/Framebuffer.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#ifdef PICO_RP2040
+#if PICO_RP2040
 #include "Framebuffer_RP2040.h"
 #else
 #include "Framebuffer_RP2350.h"

--- a/ports/raspberrypi/common-hal/usb_host/Port.c
+++ b/ports/raspberrypi/common-hal/usb_host/Port.c
@@ -13,10 +13,10 @@
 
 #include "pico/time.h"
 #include "hardware/structs/mpu.h"
-#ifdef PICO_RP2040
+#if PICO_RP2040
 #include "RP2040.h" // (cmsis)
 #endif
-#ifdef PICO_RP2350
+#if PICO_RP2350
 #include "RP2350.h" // (cmsis)
 #endif
 #include "hardware/dma.h"

--- a/ports/raspberrypi/mpconfigport.h
+++ b/ports/raspberrypi/mpconfigport.h
@@ -8,11 +8,11 @@
 
 #include "hardware/platform_defs.h"
 
-#ifdef PICO_RP2040
+#if PICO_RP2040
 #define MICROPY_PY_SYS_PLATFORM             "RP2040"
 #endif
 
-#ifdef PICO_RP2350
+#if PICO_RP2350
 #define MICROPY_PY_SYS_PLATFORM             "RP2350"
 
 // PSRAM can require more stack space for GC.

--- a/ports/raspberrypi/supervisor/internal_flash.c
+++ b/ports/raspberrypi/supervisor/internal_flash.c
@@ -23,7 +23,7 @@
 #include "supervisor/flash.h"
 #include "supervisor/usb.h"
 
-#ifdef PICO_RP2350
+#if PICO_RP2350
 #include "hardware/structs/qmi.h"
 #endif
 #include "hardware/structs/sio.h"

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -53,7 +53,7 @@
 #include "pico/bootrom.h"
 #include "hardware/watchdog.h"
 
-#ifdef PICO_RP2350
+#if PICO_RP2350
 #include "RP2350.h" // CMSIS
 #endif
 
@@ -336,10 +336,10 @@ safe_mode_t port_init(void) {
     // Load from the XIP memory space that doesn't cache. That way we don't
     // evict anything else. The code we're loading is linked to the RAM address
     // anyway.
-    #ifdef PICO_RP2040
+    #if PICO_RP2040
     size_t nocache = 0x03000000;
     #endif
-    #ifdef PICO_RP2350
+    #if PICO_RP2350
     size_t nocache = 0x04000000;
     #endif
 
@@ -547,7 +547,7 @@ void port_interrupt_after_ticks(uint32_t ticks) {
 }
 
 void port_idle_until_interrupt(void) {
-    #ifdef PICO_RP2040
+    #if PICO_RP2040
     common_hal_mcu_disable_interrupts();
     #if CIRCUITPY_USB_HOST
     if (!background_callback_pending() && !tud_task_event_ready() && !tuh_task_event_ready() && !_woken_up) {


### PR DESCRIPTION
- Fixes #10141

Code taken from https://github.com/eightycc/circuitpython/tree/fix-defines.

- Define `PICO_RP2040` and `PICO_RP2350` properly for all builds, as `0` or `1`.
- Use `#if` instead of the incorrect `#ifdef` for these cpp macros.
- Use a fork of `Pico-PIO-USB` that also corrects the use of the macro.