### PR TITLE
switch back to https://github.com/sekigon-gonnoc/Pico-PIO-USB

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -346,7 +346,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Wave.git
 [submodule "ports/raspberrypi/lib/Pico-PIO-USB"]
 	path = ports/raspberrypi/lib/Pico-PIO-USB
-	url = https://github.com/adafruit/Pico-PIO-USB.git
+	url = https://github.com/sekigon-gonnoc/Pico-PIO-USB.git
 	branch = main
 [submodule "lib/micropython-lib"]
 	path = lib/micropython-lib


### PR DESCRIPTION
https://github.com/sekigon-gonnoc/Pico-PIO-USB merged https://github.com/sekigon-gonnoc/Pico-PIO-USB/pull/204, which was on our `adafruit` fork. Switch back to upstream.