### PR TITLE
ports/espressif/common-hal/socketpool/SocketPool.c: remove old workaround for lwip issue

### DIFF
--- a/ports/espressif/common-hal/socketpool/SocketPool.c
+++ b/ports/espressif/common-hal/socketpool/SocketPool.c
@@ -24,18 +24,6 @@ void common_hal_socketpool_socketpool_construct(socketpool_socketpool_obj_t *sel
 // common_hal_socketpool_socket is in socketpool/Socket.c to centralize open socket tracking.
 
 int socketpool_getaddrinfo_common(const char *host, int service, const struct addrinfo *hints, struct addrinfo **res) {
-    // As of 2022, the version of lwip in esp-idf does not handle the
-    // trailing-dot syntax of domain names, so emulate it.
-    // Remove this once https://github.com/espressif/esp-idf/issues/10013 has
-    // been implemented
-    if (host) {
-        size_t strlen_host = strlen(host);
-        if (strlen_host && host[strlen_host - 1] == '.') {
-            mp_obj_t nodot = mp_obj_new_str(host, strlen_host - 1);
-            host = mp_obj_str_get_str(nodot);
-        }
-    }
-
     char service_buf[6];
     snprintf(service_buf, sizeof(service_buf), "%d", service);
 


### PR DESCRIPTION
- Fixes #10460 

Remove some code that removed trailing dots from hostnames to compensate for an lwip issue. This was fixed long ago.

Tested on a Metro ESP32-S3 with:
```py
import wifi, socketpool

pool = socketpool.SocketPool(wifi.radio)
print(pool.getaddrinfo("adafruit.com.", 80))
```