### PR TITLE
web_workflow: reply 409 Conflict instead of 500 when filesystem is write-protected

### DIFF
--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -1040,7 +1040,7 @@ static void _write_file_and_reply(socketpool_socket_obj_t *socket, _request *req
     if (result == FR_NO_FILE) {
         new_file = true;
         result = f_open(fs, &active_file, path, FA_WRITE | FA_OPEN_ALWAYS);
-    } else {
+    } else if (result == FR_OK) {
         old_length = f_size(&active_file);
     }
 
@@ -1049,6 +1049,18 @@ static void _write_file_and_reply(socketpool_socket_obj_t *socket, _request *req
         filesystem_unlock(fs_mount);
         _discard_incoming(socket, request->content_length);
         _reply_missing(socket, request);
+        return;
+    }
+    if (result == FR_WRITE_PROTECTED) {
+        // The filesystem is held by something else with write access (most
+        // commonly USB-MSC: the host has CIRCUITPY mounted, so CircuitPython
+        // can't write through FatFS). Match the mkdir/move/delete paths and
+        // reply 409 Conflict so clients can show an actionable message
+        // ("eject CIRCUITPY / disable USB MSC") instead of a generic 500.
+        override_fattime(0);
+        filesystem_unlock(fs_mount);
+        _discard_incoming(socket, request->content_length);
+        _reply_conflict(socket, request);
         return;
     }
     if (result != FR_OK) {


### PR DESCRIPTION
## Summary

When the host has CIRCUITPY mounted over USB Mass Storage, the
CircuitPython side of FatFS sees `STA_PROTECT` on the block device,
and `f_open(..., FA_WRITE)` returns `FR_WRITE_PROTECTED`.

`_write_file_and_reply` in `supervisor/shared/web_workflow/web_workflow.c`
was lumping this into the generic `result != FR_OK` branch and replying
**HTTP 500 Internal Server Error**, which looks to clients like the
device crashed.

The other write paths in the same file — `DELETE`, `MOVE`, and the
directory-creating `PUT` — already check `FR_WRITE_PROTECTED` explicitly
and reply **HTTP 409 Conflict**. This PR makes the file-writing `PUT`
match.

## Why this matters

This is the root cause behind
[circuitpython/web-editor#460](https://github.com/circuitpython/web-editor/issues/460).
Users on multiple boards (Qualia ESP32-S3, S3 Reverse TFT Feather)
reported "Saving `code.py` failed" with no clear cause. The 500
response gave the editor no signal that the cause was "host owns the
filesystem"; with 409, the editor can show an actionable message
("eject CIRCUITPY / disable USB MSC in `boot.py`") instead of a
generic retry-loop / failure dialog.

It also brings PUT into line with the rest of the web workflow's
error contract:

| Method | Already returned 409 on `FR_WRITE_PROTECTED`? |
| --- | --- |
| `DELETE /fs/…` | ✅ |
| `MOVE /fs/…` | ✅ |
| `PUT /fs/<dir>/` (mkdir) | ✅ |
| `PUT /fs/<file>` (write) | ❌ → returned 500. **Fixed here.** |

## Reproduction

**Before this PR:**

1. Connect a board running CircuitPython with web workflow active.
2. Plug it into a computer via USB so the host mounts CIRCUITPY (this
   is the default for any board that hasn't disabled USB MSC in
   `boot.py`).
3. From the web editor (or `curl`), `PUT /fs/code.py` with a body.
4. Device responds **`500 Internal Server Error`**.

**After this PR:** same flow returns **`409 Conflict`**, matching the
existing behavior of DELETE / MOVE / mkdir-PUT against the same
filesystem-owned-by-host condition.

Confirmed locally that disabling USB MSC in `boot.py` makes the PUT
succeed (since the host no longer holds the block device), so the
underlying `FR_WRITE_PROTECTED` origin is verified.

## Secondary fix

The original code:

```c
if (result == FR_NO_FILE) {
    new_file = true;
    result = f_open(fs, &active_file, path, FA_WRITE | FA_OPEN_ALWAYS);
} else {
    old_length = f_size(&active_file);
}
```

The `else` branch ran for **any** non-`FR_NO_FILE` result, including
`FR_WRITE_PROTECTED`, `FR_DISK_ERR`, `FR_INVALID_NAME`, etc., where
`f_open` never initialized `active_file`. Calling `f_size()` on an
uninitialized `FIL` reads garbage. Tightened the guard to
`else if (result == FR_OK)`. `old_length` stays zero in error paths,
but it's only used after the `result != FR_OK` early-returns anyway,
so this is purely a "don't read uninitialized memory" tidy.

## Risk / compatibility

- No public API change. Only the HTTP status code for one specific
  failure mode changes (500 → 409).
- Behavior under any other `f_open` failure is unchanged (still 500).
- Behavior on successful write is unchanged (201 Created for new
  files, 204 No Content for overwrites).
- The 409 response uses the existing `_reply_conflict` helper, which
  already emits the correct CORS headers — same code path the
  `filesystem_lock()` failure inside this same function uses.

## Test plan

- Manually verified the failing scenario reproduces on a board with
  USB MSC enabled (S3 Reverse TFT Feather, confirmed by the web-editor
  #460 reporter).
- The change is a straight branch addition that mirrors three existing
  call sites in the same file, all of which have been live in the
  shipped firmware.
