### PR TITLE
fix audiospeed.SpeedChanger direct playback, fixes #11020

### DIFF
--- a/shared-module/audiospeed/SpeedChanger.c
+++ b/shared-module/audiospeed/SpeedChanger.c
@@ -33,7 +33,7 @@ void common_hal_audiospeed_speedchanger_construct(audiospeed_speedchanger_obj_t 
     self->base.channel_count = src_base->channel_count;
     self->base.bits_per_sample = src_base->bits_per_sample;
     self->base.samples_signed = src_base->samples_signed;
-    self->base.single_buffer = true;
+    self->base.single_buffer = false;
 
     uint8_t bytes_per_frame = (src_base->bits_per_sample / 8) * src_base->channel_count;
     self->output_buffer_length = OUTPUT_BUFFER_FRAMES * bytes_per_frame;


### PR DESCRIPTION
Fix by setting "single_buffer = false".

When single_buffer = true, the DMA driver sets up a hardware loop that resets the read address back to buffer[0] at full DMA speed, never calling get_buffer again. This caused SpeedChanger to replay its first 128-frame output buffer indefinitely when connected directly to audioio/audiobusio.

Setting single_buffer = false enables the double-buffering path w/ DMA interrupts, which keeps calling get_buffer() so the phase accumulator can advance through the source audio correctly.

Using AudioMixer as an intermediary masks the bug since Mixer/mix_down_one_voice() calls get_buffer() on its voices directly, bypassing the single_buffer optimization.
