### PR TITLE
dotclockframebuffer: fix gpio_data range validation

### DIFF
--- a/shared-bindings/dotclockframebuffer/__init__.c
+++ b/shared-bindings/dotclockframebuffer/__init__.c
@@ -104,7 +104,7 @@ static mp_obj_t ioexpander_send_init_sequence(size_t n_args, const mp_obj_t *pos
     mp_arg_validate_int_range(cs_bit, 0, max_bit, MP_QSTR_cs_bit);
     mp_arg_validate_int_range(mosi_bit, 0, max_bit, MP_QSTR_mosi_bit);
     mp_arg_validate_int_range(clk_bit, 0, max_bit, MP_QSTR_clk_bit);
-    mp_arg_validate_int_range(gpio_data, 0, (1 << (max_bit * 8)) - 1, MP_QSTR_gpio_data);
+    mp_arg_validate_int_range(gpio_data, 0, (1 << (gpio_data_len * 8)) - 1, MP_QSTR_gpio_data);
     mp_int_t reset_mask = 0;
     if (args[ARG_reset_bit].u_obj != MP_ROM_NONE) {
         mp_int_t reset_bit = mp_arg_validate_int_range(mp_arg_validate_type_int(args[ARG_reset_bit].u_obj, MP_QSTR_reset_bit), 0, max_bit, MP_QSTR_reset_bit);


### PR DESCRIPTION
Closes #11029

## Bug

In `shared-bindings/dotclockframebuffer/__init__.c` around line 107:

```c
mp_arg_validate_int_range(gpio_data, 0, (1 << (max_bit * 8)) - 1, MP_QSTR_gpio_data);
```

`max_bit` is computed earlier as `gpio_data_len * 8 - 1` (the highest
valid bit index within the gpio_data field). The validator above
mistakenly multiplies `max_bit` by 8 a second time instead of using
`gpio_data_len * 8`.

For the common `gpio_data_len = 1` case, `max_bit = 7` and the upper
bound becomes:

```
(1 << (7 * 8)) - 1   ==   (1 << 56) - 1
```

That's undefined behavior on a 32-bit `mp_int_t` and in practice
the shift wraps such that the upper bound ends up as `1`. As a
result, any `gpio_data` value greater than 1 raises:

```
ValueError: gpio_data must be 0..1
```

even though a full byte is legitimate.

## Impact

This blocks initializing displays through
`dotclockframebuffer.ioexpander_send_init_sequence(...)` whenever the
init sequence contains real one-byte register writes. Concretely, an
Adafruit Qualia ESP32-S3 driving a 4" 480x480 round TFT (via
`adafruit_qualia`) crashes during display init the moment a
non-trivial command byte is sent.

Note: the original test snippet in the introducing commit (`4b41fdb`,
"Fast(ish) special purpose bitbang spi over i2c") uses
`gpio_data=0xff` with `gpio_data_len=1`, which would have hit the
broken validator immediately — suggesting the bug crept in after
that snippet was written and was never re-exercised.

## Fix

Use `gpio_data_len` (the field width in bytes) directly:

```c
mp_arg_validate_int_range(gpio_data, 0, (1 << (gpio_data_len * 8)) - 1, MP_QSTR_gpio_data);
```

For `gpio_data_len = 1` this yields the correct `(1 << 8) - 1 = 255`
upper bound; for wider fields it scales appropriately.

One-line change, no behavior change for any input that previously
passed validation.

## Verification

Built `BOARD=adafruit_qualia_s3_rgb666 TRANSLATION=en_US` with this
patch applied and confirmed the Qualia successfully completes display
init and runs CircuitPython sketches that use
`Displays.SQUARE40_480X480`. Without the patch, display init aborts
with the `ValueError` quoted above.

