### PR TITLE
Espressif BLE fixes: advertising duration, _bleio.adapter.connected

### DIFF
--- a/ports/espressif/Makefile
+++ b/ports/espressif/Makefile
@@ -839,16 +839,18 @@ ifeq ($(ENABLE_JTAG), 1)
 	CFLAGS += -DENABLE_JTAG=1
 endif
 
-SDKCONFIGS := esp-idf-config/sdkconfig.defaults;$(DEBUG_SDKCONFIG);$(FLASH_SIZE_SDKCONFIG);$(FLASH_MODE_SDKCONFIG);$(FLASH_SPEED_SDKCONFIG);$(PSRAM_SDKCONFIG);$(PSRAM_SIZE_SDKCONFIG);$(PSRAM_MODE_SDKCONFIG);$(PSRAM_SPEED_SDKCONFIG);$(TARGET_SDKCONFIG);boards/$(BOARD)/sdkconfig
 ifneq ($(CIRCUITPY_BLEIO_NATIVE),0)
-	SDKCONFIGS := esp-idf-config/sdkconfig-ble.defaults;$(SDKCONFIGS)
+	BLE_SDKCONFIG := ;esp-idf-config/sdkconfig-ble.defaults
 endif
+
+SDKCONFIGS := esp-idf-config/sdkconfig.defaults;$(DEBUG_SDKCONFIG);$(FLASH_SIZE_SDKCONFIG);$(FLASH_MODE_SDKCONFIG);$(FLASH_SPEED_SDKCONFIG);$(PSRAM_SDKCONFIG);$(PSRAM_SIZE_SDKCONFIG);$(PSRAM_MODE_SDKCONFIG);$(PSRAM_SPEED_SDKCONFIG);$(BLE_SDKCONFIG);$(TARGET_SDKCONFIG);boards/$(BOARD)/sdkconfig
+
 # create the config headers
 .PHONY: do-sdkconfig
 do-sdkconfig: $(BUILD)/esp-idf/config/sdkconfig.h
 QSTR_GLOBAL_REQUIREMENTS += $(BUILD)/esp-idf/config/sdkconfig.h
 $(BUILD)/esp-idf/config/sdkconfig.h: boards/$(BOARD)/sdkconfig boards/$(BOARD)/mpconfigboard.mk CMakeLists.txt | $(BUILD)/esp-idf
-	$(STEPECHO) "LINK $@"
+	$(STEPECHO) "Create $@"
 	$(Q)env IDF_PATH=$(IDF_PATH) IDF_COMPONENT_MANAGER=0 cmake -S . -B $(BUILD)/esp-idf -DSDKCONFIG=$(BUILD)/esp-idf/sdkconfig -DSDKCONFIG_DEFAULTS="$(SDKCONFIGS)" -DCMAKE_TOOLCHAIN_FILE=$(IDF_PATH)/tools/cmake/toolchain-$(IDF_TARGET).cmake -DIDF_TARGET=$(IDF_TARGET) -GNinja
 	$(Q)$(PYTHON) tools/check-sdkconfig.py \
 		CIRCUITPY_DUALBANK=$(CIRCUITPY_DUALBANK) \

--- a/ports/espressif/common-hal/_bleio/Adapter.c
+++ b/ports/espressif/common-hal/_bleio/Adapter.c
@@ -561,10 +561,6 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self,
     bool high_duty_directed = directed_to != NULL && interval <= 3.5 && timeout <= 1; // Really 1.3, but it's an int
 
     uint32_t timeout_ms = timeout * 1000;
-    if (timeout_ms == 0) {
-        timeout_ms = BLE_HS_FOREVER;
-    }
-
 
     #if MYNEWT_VAL(BLE_EXT_ADV)
     bool extended = advertising_data_len > BLE_ADV_LEGACY_DATA_MAX_LEN ||
@@ -626,8 +622,12 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self,
         }
     }
 
+    // If timeout_ms is zero, it means advertise forever. This is different than ble_gap_adv_start().
     rc = ble_gap_ext_adv_start(0, timeout_ms, 0);
+
     #else
+    // Extended advertising not enabled.
+
     uint8_t conn_mode = connectable ? BLE_GAP_CONN_MODE_UND : BLE_GAP_CONN_MODE_NON;
     if (directed_to != NULL) {
         conn_mode = BLE_GAP_CONN_MODE_DIR;
@@ -654,8 +654,10 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self,
             return rc;
         }
     }
-    rc = ble_gap_adv_start(own_addr_type, directed_to != NULL ? &peer: NULL,
-        timeout_ms,
+    // If timeout_ms is BLE_HS_FOREVER, it means advertise forever. This is different than ble_gap_ext_adv_start().
+    rc = ble_gap_adv_start(own_addr_type,
+        directed_to != NULL ? &peer: NULL,
+        timeout_ms == 0 ? BLE_HS_FOREVER : timeout_ms,
         &adv_params,
         _advertising_event, self);
     #endif
@@ -739,7 +741,7 @@ bool common_hal_bleio_adapter_get_advertising(bleio_adapter_obj_t *self) {
 bool common_hal_bleio_adapter_get_connected(bleio_adapter_obj_t *self) {
     for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
         bleio_connection_internal_t *connection = &bleio_connections[i];
-        if (connection->conn_handle != BLEIO_HANDLE_INVALID && connection->mtu != 0) {
+        if (connection->conn_handle != BLEIO_HANDLE_INVALID) {
             return true;
         }
     }
@@ -754,7 +756,7 @@ mp_obj_t common_hal_bleio_adapter_get_connections(bleio_adapter_obj_t *self) {
     mp_obj_t items[BLEIO_TOTAL_CONNECTION_COUNT];
     for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
         bleio_connection_internal_t *connection = &bleio_connections[i];
-        if (connection->conn_handle != BLEIO_HANDLE_INVALID && connection->mtu != 0) {
+        if (connection->conn_handle != BLEIO_HANDLE_INVALID) {
             if (connection->connection_obj == mp_const_none) {
                 connection->connection_obj = bleio_connection_new_from_internal(connection);
             }

--- a/ports/espressif/common-hal/_bleio/Adapter.c
+++ b/ports/espressif/common-hal/_bleio/Adapter.c
@@ -820,9 +820,7 @@ void bleio_adapter_gc_collect(bleio_adapter_obj_t *adapter) {
 
 void bleio_adapter_reset(bleio_adapter_obj_t *adapter) {
     common_hal_bleio_adapter_stop_scan(adapter);
-    if (common_hal_bleio_adapter_get_advertising(adapter)) {
-        common_hal_bleio_adapter_stop_advertising(adapter);
-    }
+    common_hal_bleio_adapter_stop_advertising(adapter);
 
     adapter->connection_objs = NULL;
     for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {

--- a/ports/espressif/common-hal/_bleio/__init__.c
+++ b/ports/espressif/common-hal/_bleio/__init__.c
@@ -32,9 +32,9 @@ static uint64_t _timeout_start_time;
 background_callback_t bleio_background_callback;
 
 void bleio_user_reset(void) {
-    // Stop any user scanning or advertising.
-    common_hal_bleio_adapter_stop_scan(&common_hal_bleio_adapter_obj);
-    common_hal_bleio_adapter_stop_advertising(&common_hal_bleio_adapter_obj);
+    // Stop any user scanning or advertising, and stop all connections.
+    // TODO: Don't stop BLE workflow connection.
+    bleio_adapter_reset(&common_hal_bleio_adapter_obj);
 
     ble_event_remove_heap_handlers();
 


### PR DESCRIPTION
I think this may fix #10007.

### Advertising duration
The advertising duration value for "forever" is different for `ble_gap_adv_start()` and `ble_gap_ext_adv_start()`. It is `BLE_HS_FOREVER` and `0`, respectively. The code was using `BLE_HS_FOREVER` In 6.0.1, this value is actually checked, and gives a parameter range error.

### `connected` state check
Code was added in #9289 that required that the MTU value be non-zero when returning `true` for `_bleio.adapter.connected`.
https://github.com/adafruit/circuitpython/blob/7a273661826cbdadf6908a50f7b6add416e879a0/ports/espressif/common-hal/_bleio/Adapter.c#L666
https://github.com/adafruit/circuitpython/blob/d6fd51fbd7794a7231ff6e8b694322a94180abfb/ports/espressif/common-hal/_bleio/Adapter.c#L742
The MTU is zero when a connection has first been made but the MTU is not yet negotiated.

The MTU check above causes a brief interval, for both `ble.connected()` and `ble.advertising()` to be `False`. The transition between advertising and connected did not appear atomic. This compares with the `nordic` implementation where this glitch is not present.

I removed this MTU check and connections still work. I was testing with an HID keyboard example (derived from https://learn.adafruit.com/ble-hid-keyboard-buttons-with-circuitpython) which requires pairing. It is necessary to forget the CircuitPython device on the central side if its firmware is reloaded, at least for an iOS central.

@tannewt Do you remember why you added the MTU check in #9289? It's true that the connection is not complete until the MTU is negotiated. But we have a lot of example code something like this:
```py
ble.start_advertising(advertisement)

while True:
    if not ble.connected and not ble.advertising:
        print("BLE disconnected, restarting advertising...")
        ble.start_advertising(advertisement)
    ...
```
So what happens is that when the central has connected initially but the MTU is not yet negotiated, the `if` statement is briefly `False`, which makes the program think erroneously that there was a disconnect, and it starts advertising again. On Espressif, this quickly causes _"Nimble: out of memory"_.

If there was a `ble.connection_initiated` `ble.connection_in_progress` that could be used instead. But otherwise there's no state available to know that. And we'd have to change a lot of code.