### PR TITLE
Fix compressed translation qstr ids

### DIFF
--- a/py/maketranslationdata.py
+++ b/py/maketranslationdata.py
@@ -532,17 +532,17 @@ def parse_qstrs(infile):
     )
     content = infile.read()
     matches = rx.finditer(content)
-    static_qstrs = []
-    dynamic_qstrs = []
+    qdef0_qstrs = []
+    qdef1_qstrs = []
     for match in matches:
         qstr = eval(match.group("cstr"))
         if match.group("pool") == "0":
-            static_qstrs.append(qstr)
+            qdef0_qstrs.append(qstr)
         else:
-            dynamic_qstrs.append(qstr)
-    for i, qstr in enumerate(static_qstrs):
+            qdef1_qstrs.append(qstr)
+    for i, qstr in enumerate(qdef0_qstrs):
         r[qstr] = i
-    for i, qstr in enumerate(dynamic_qstrs, start=len(static_qstrs)):
+    for i, qstr in enumerate(qdef1_qstrs, start=len(qdef0_qstrs)):
         r[qstr] = i
     return r
 

--- a/py/maketranslationdata.py
+++ b/py/maketranslationdata.py
@@ -527,11 +527,23 @@ def qstr_escape(qst):
 
 def parse_qstrs(infile):
     r = {}
-    rx = re.compile(r'QDEF[01]\([A-Za-z0-9_]+,\s*\d+,\s*\d+,\s*(?P<cstr>"(?:[^"\\\\]*|\\.)")\)')
+    rx = re.compile(
+        r'QDEF(?P<pool>[01])\([A-Za-z0-9_]+,\s*\d+,\s*\d+,\s*(?P<cstr>"(?:[^"\\\\]|\\.)*")\)'
+    )
     content = infile.read()
-    for i, mat in enumerate(rx.findall(content, re.M)):
-        mat = eval(mat)
-        r[mat] = i
+    matches = rx.finditer(content)
+    static_qstrs = []
+    dynamic_qstrs = []
+    for match in matches:
+        qstr = eval(match.group("cstr"))
+        if match.group("pool") == "0":
+            static_qstrs.append(qstr)
+        else:
+            dynamic_qstrs.append(qstr)
+    for i, qstr in enumerate(static_qstrs):
+        r[qstr] = i
+    for i, qstr in enumerate(dynamic_qstrs, start=len(static_qstrs)):
+        r[qstr] = i
     return r
 
 

--- a/supervisor/shared/translate/translate.c
+++ b/supervisor/shared/translate/translate.c
@@ -114,7 +114,7 @@ static void decompress_vstr(mp_rom_error_text_t compressed, vstr_t *decompressed
         }
         int v = values[searched_length + bits - max_code];
         if (v == 1) {
-            qstr q = get_nbits(&b, translation_qstr_bits) + 1; // honestly no idea why "+1"...
+            qstr q = get_nbits(&b, translation_qstr_bits);
             vstr_add_str(decompressed, qstr_str(q));
         } else {
             put_utf8(decompressed, v);


### PR DESCRIPTION
- Fixes #10259

The error message `Bitmap size and bits per value must match` was not being decoded properly. The failing decode caused that error to print when raised as `RuntimeError:`, because the failed decoding caused a storage problem.

### Changes

- `maketranslationdata.py` was not producing the correct offsets for QDEF1 qstrs. It needed to assign all the QDEF0 ones, and then all the QDEF1 ones, but they were interleaved. So a message with a QDEF1 qstr would get the wrong offset, but this was rare. 
- There was a specious `+1` qstr offset in the decoder with the comment `// honestly no idea why "+1"...`. The `+1` compensated for failing to accommodate  the null qstr slot. So handling the null slot properly made it possible to remove the `+1`.

### Debugging process

Before using Copilot, I added some instrumentation to print the the qstr numbers and saw that `Bitmap` was being decoded as `__rmul__` which was one byte longer, which caused the storage problem.

After some headscratching, I told Copilot about this. It caught the `+1`, but I already knew removing that was not a fix. After I gave it my instrumentation output, it figured out the QDEF0/QDEF1 problem, and produced the fixes here. I then successfully tested its fixes.

The comments above were written by dhalbert, not Copilot. "I" means dhalbert.
