### PR TITLE
Validate frequency arg for ParallelBus to prevent crash on 0

### DIFF
--- a/shared-bindings/paralleldisplaybus/ParallelBus.c
+++ b/shared-bindings/paralleldisplaybus/ParallelBus.c
@@ -85,14 +85,16 @@ static mp_obj_t paralleldisplaybus_parallelbus_make_new(const mp_obj_type_t *typ
         mp_raise_ValueError(MP_ERROR_TEXT("Specify exactly one of data0 or data_pins"));
     }
 
+    uint32_t frequency = (uint32_t)mp_arg_validate_int_min(args[ARG_frequency].u_int, 1, MP_QSTR_frequency);
+
     if (specified_data0) {
         const mcu_pin_obj_t *data0 = validate_obj_is_free_pin(args[ARG_data0].u_obj, MP_QSTR_data0);
-        common_hal_paralleldisplaybus_parallelbus_construct(self, data0, command, chip_select, write, read, reset, args[ARG_frequency].u_int);
+        common_hal_paralleldisplaybus_parallelbus_construct(self, data0, command, chip_select, write, read, reset, frequency);
     } else {
         uint8_t num_pins;
         const mcu_pin_obj_t *data_pins[16];
         validate_list_is_free_pins(MP_QSTR_data_pins, data_pins, (mp_int_t)MP_ARRAY_SIZE(data_pins), args[ARG_data_pins].u_obj, &num_pins);
-        common_hal_paralleldisplaybus_parallelbus_construct_nonsequential(self, num_pins, data_pins, command, chip_select, write, read, reset, args[ARG_frequency].u_int);
+        common_hal_paralleldisplaybus_parallelbus_construct_nonsequential(self, num_pins, data_pins, command, chip_select, write, read, reset, frequency);
     }
     return self;
 }


### PR DESCRIPTION
- Fixes #10685 

`ParallelBus` was not validating the `frequency` arg. If it was `0`, there was an internal error in ESP-IDF (probably a divide by zero), which caused a hard crash. Require `frequency` to be >= `1`.

Tested on a UM ProS3 with the original test code.