### PR TITLE
Restrict Build CI push trigger to main and *.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ name: Build CI
 
 on:
   push:
+    branches:
+      - main
+      - '*.x'
   pull_request:
   release:
     types: [published]


### PR DESCRIPTION
This PR was written by Copilot, not me.

## Summary
- limit `Build CI` push runs to `main` and `*.x`
- keep `pull_request` and `release` behavior unchanged
- avoid duplicate board and release builds triggered from the same SHA

## Why
`Build CI` currently runs on both `push` and `pull_request`.

For a PR branch in `adafruit/circuitpython`, the same commits generate both events in the upstream repo, so the board matrix runs twice. Fork PRs do not have this problem in the upstream repo because the fork push happens in the fork, while the upstream repo only runs the `pull_request` workflow.

Releases currently duplicate as well: publishing a release triggers the `release` event, and the associated tag push also triggers `push`, producing two `Build CI` runs for the same SHA.

Restricting `push` to `main` and maintenance branches fixes both cases while preserving branch-push CI where it is most useful.

## Effect on fork PRs
Regular PR builds from forks still work normally. The upstream repo still runs this workflow on `pull_request`; this change only narrows which upstream `push` events trigger it.

## Release behavior
Release-specific behavior still works because the workflow continues to run on `release: published`, and the publish/upload steps already key off release events.