### PR TITLE
espressif: don't do ble resets if adapter is not enabled; can cause crashes

### DIFF
--- a/ports/espressif/common-hal/_bleio/Adapter.c
+++ b/ports/espressif/common-hal/_bleio/Adapter.c
@@ -819,6 +819,9 @@ void bleio_adapter_gc_collect(bleio_adapter_obj_t *adapter) {
 }
 
 void bleio_adapter_reset(bleio_adapter_obj_t *adapter) {
+    if (!common_hal_bleio_adapter_get_enabled(&common_hal_bleio_adapter_obj)) {
+        return;
+    }
     common_hal_bleio_adapter_stop_scan(adapter);
     common_hal_bleio_adapter_stop_advertising(adapter);
 

--- a/ports/espressif/common-hal/_bleio/__init__.c
+++ b/ports/espressif/common-hal/_bleio/__init__.c
@@ -32,6 +32,9 @@ static uint64_t _timeout_start_time;
 background_callback_t bleio_background_callback;
 
 void bleio_user_reset(void) {
+    if (!common_hal_bleio_adapter_get_enabled(&common_hal_bleio_adapter_obj)) {
+        return;
+    }
     // Stop any user scanning or advertising, and stop all connections.
     // TODO: Don't stop BLE workflow connection.
     bleio_adapter_reset(&common_hal_bleio_adapter_obj);


### PR DESCRIPTION
- This fixes #11052, a regression caused by #11036.


Aspects of `_bleio.Adapter` were being reset when the adapter was not enabled. In particular, this caused connection cleanup to be done without `connection->CONN_HANDLE == BLEIO_HANDLE_INVALID`. This caused memory errors. #11036 added the connection cleanup, exposing this bug.

Tested on Metro ESP32-S3.