### PR TITLE
Fix esp32-camera support after ESP-IDF v6 upgrade

### DIFF
--- a/ports/espressif/bindings/espcamera/Camera.c
+++ b/ports/espressif/bindings/espcamera/Camera.c
@@ -179,7 +179,7 @@ static void check_for_deinit(espcamera_camera_obj_t *self) {
 static mp_obj_t espcamera_camera_frame_available_get(const mp_obj_t self_in) {
     espcamera_camera_obj_t *self = MP_OBJ_TO_PTR(self_in);
     check_for_deinit(self);
-    return mp_obj_new_bool(esp_camera_fb_available());
+    return mp_obj_new_bool(common_hal_espcamera_camera_available(self));
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(espcamera_camera_frame_available_get_obj, espcamera_camera_frame_available_get);
 

--- a/ports/espressif/common-hal/busio/I2C.c
+++ b/ports/espressif/common-hal/busio/I2C.c
@@ -10,6 +10,7 @@
 #include "py/runtime.h"
 
 #include "driver/gpio.h"
+#include "soc/soc_caps.h"
 
 #include "bindings/espidf/__init__.h"
 #include "shared-bindings/microcontroller/__init__.h"
@@ -87,6 +88,19 @@ void common_hal_busio_i2c_construct(busio_i2c_obj_t *self,
         mp_raise_ValueError(MP_ERROR_TEXT("All I2C peripherals are in use"));
     }
     CHECK_ESP_RESULT(result);
+
+    // Record which port the auto-selected bus landed on. There is no public accessor to map
+    // a bus handle back to its port, so match the handle against each initialized port.
+    // Other code (e.g. espcamera) needs the port number to reuse this same bus rather than
+    // create a second master bus on the same pins.
+    self->port = -1;
+    for (i2c_port_num_t port = 0; port < (int)SOC_HP_I2C_NUM; port++) {
+        i2c_master_bus_handle_t bus_handle;
+        if (i2c_master_get_bus_handle(port, &bus_handle) == ESP_OK && bus_handle == self->handle) {
+            self->port = port;
+            break;
+        }
+    }
 
     self->xSemaphore = xSemaphoreCreateMutex();
     if (self->xSemaphore == NULL) {

--- a/ports/espressif/common-hal/busio/I2C.h
+++ b/ports/espressif/common-hal/busio/I2C.h
@@ -22,6 +22,7 @@ typedef struct {
     size_t timeout_ms;
     size_t frequency;
     i2c_master_bus_handle_t handle;
+    i2c_port_num_t port;
     SemaphoreHandle_t xSemaphore;
     bool has_lock;
 } busio_i2c_obj_t;

--- a/ports/espressif/common-hal/espcamera/Camera.c
+++ b/ports/espressif/common-hal/espcamera/Camera.c
@@ -86,8 +86,11 @@ void common_hal_espcamera_camera_construct(
     self->camera_config.pin_reset = reset_pin ? common_hal_mcu_pin_number(reset_pin) : NO_PIN;
     self->camera_config.pin_xclk = external_clock_pin ? common_hal_mcu_pin_number(external_clock_pin) : NO_PIN;
 
-    self->camera_config.pin_sccb_sda = common_hal_mcu_pin_number(i2c->sda_pin);
-    self->camera_config.pin_sccb_scl = common_hal_mcu_pin_number(i2c->scl_pin);
+    // Reuse the I2C bus that CircuitPython already created on these pins instead of letting
+    // esp32-camera create a second master bus on the same pins, which doesn't work.
+    self->camera_config.pin_sccb_sda = -1;
+    self->camera_config.pin_sccb_scl = -1;
+    self->camera_config.sccb_i2c_port = i2c->port;
 
     self->camera_config.pin_d7 = data_pins[7];
     self->camera_config.pin_d6 = data_pins[6];
@@ -154,7 +157,7 @@ bool common_hal_espcamera_camera_deinited(espcamera_camera_obj_t *self) {
 }
 
 bool common_hal_espcamera_camera_available(espcamera_camera_obj_t *self) {
-    return esp_camera_fb_available();
+    return esp_camera_available_frames();
 }
 
 camera_fb_t *common_hal_espcamera_camera_take(espcamera_camera_obj_t *self, int timeout_ms) {


### PR DESCRIPTION
- Fixes #11031 

Before ESP-IDF v6.0, the espcamera API shared the I2C bus that CircuitPython had already created, by passing its handle to esp-camera:
```c
self->camera_config.sccb_i2c_master_bus_handle = self->i2c->handle;
```
The bus handle went away in recent version of `esp32-camera`, so the sharing needed to happen a different way. `busio/I2C.c` was changed to record the port of a created `I2C` object, and that port is now passed to esp32-camera:
```c
self->camera_config.sccb_i2c_port = i2c->port;
```
Before this change, `esp32-camera` created a second I2C instance on the same pins, which caused the I2C device known to CircuitPython to be different from the one used by `esp32-camera`.

I also updated the `esp32-camera` submodule to v2.1.7 on the `adafruit` fork, merging in our changes. I removed some additions we had made because some equivalent changes were made upstream.

I tested on a Memento, which now works fine and takes pictures.

Claude Code helped with this diagnosis and fix. I thought it might be an issue with SCCB support due to I2C driver changes, but that was incorrect.

