### PR TITLE
I2SIn streaming protocol changes

### DIFF
--- a/ports/espressif/common-hal/audioi2sin/I2SIn.c
+++ b/ports/espressif/common-hal/audioi2sin/I2SIn.c
@@ -65,7 +65,6 @@ void common_hal_audioi2sin_i2sin_construct(audioi2sin_i2sin_obj_t *self,
     self->mclk = main_clock;
     self->sample_rate = sample_rate;
     self->bit_depth = bit_depth;
-    self->output_bit_depth = output_bit_depth;
     self->mono = mono;
     self->samples_signed = samples_signed;
 
@@ -222,11 +221,11 @@ uint32_t common_hal_audioi2sin_i2sin_record_to_buffer(audioi2sin_i2sin_obj_t *se
         element_size = 4;
     }
 
-    if (self->output_bit_depth != self->bit_depth) {
+    if (self->base.bits_per_sample != self->bit_depth) {
         // Bit-depth conversion path: always read at input width into scratch,
         // convert each sample into the user's buffer at output width.
         const uint8_t in_depth = self->bit_depth;
-        const uint8_t out_depth = self->output_bit_depth;
+        const uint8_t out_depth = self->base.bits_per_sample;
         const bool samples_signed = self->samples_signed;
         uint8_t scratch[256];
         const size_t in_frame_bytes = 2 * element_size;
@@ -313,10 +312,6 @@ uint8_t common_hal_audioi2sin_i2sin_get_bit_depth(audioi2sin_i2sin_obj_t *self) 
     return self->bit_depth;
 }
 
-uint8_t common_hal_audioi2sin_i2sin_get_output_bit_depth(audioi2sin_i2sin_obj_t *self) {
-    return self->output_bit_depth;
-}
-
 uint32_t common_hal_audioi2sin_i2sin_get_sample_rate(audioi2sin_i2sin_obj_t *self) {
     return self->sample_rate;
 }
@@ -351,7 +346,7 @@ static void i2sin_fill_silence(void *buffer, uint32_t idx, uint32_t count,
 void common_hal_audioi2sin_i2sin_fill_buffer(audioi2sin_i2sin_obj_t *self,
     uint8_t *buffer, uint32_t frames) {
     const uint8_t in_depth = self->bit_depth;
-    const uint8_t out_depth = self->output_bit_depth;
+    const uint8_t out_depth = self->base.bits_per_sample;
     const bool samples_signed = self->samples_signed;
     const bool stereo = !self->mono;
     const uint8_t channel_count = stereo ? 2 : 1;
@@ -406,7 +401,7 @@ void common_hal_audioi2sin_i2sin_reset_buffer(audioi2sin_i2sin_obj_t *self,
     (void)channel;
     // The audio pipeline only carries 8- or 16-bit samples; 24/32-bit modes can
     // still record() but cannot stream.
-    if (self->output_bit_depth != 8 && self->output_bit_depth != 16) {
+    if (self->base.bits_per_sample != 8 && self->base.bits_per_sample != 16) {
         mp_raise_ValueError_varg(
             MP_ERROR_TEXT("%q must be 8 or 16"), MP_QSTR_output_bit_depth);
     }
@@ -426,7 +421,7 @@ audioio_get_buffer_result_t common_hal_audioi2sin_i2sin_get_buffer(
     uint8_t *out = self->output_buffer + half * self->output_index;
     self->output_index = 1 - self->output_index;
 
-    uint32_t bytes_per_sample = self->output_bit_depth / 8;
+    uint32_t bytes_per_sample = self->base.bits_per_sample / 8;
     uint32_t frames = half / (bytes_per_sample * self->base.channel_count);
     common_hal_audioi2sin_i2sin_fill_buffer(self, out, frames);
 

--- a/ports/espressif/common-hal/audioi2sin/I2SIn.h
+++ b/ports/espressif/common-hal/audioi2sin/I2SIn.h
@@ -21,7 +21,7 @@
 #define AUDIOI2SIN_STREAM_FRAMES (256)
 
 typedef struct {
-    // MUST be first so I2SIn can be used directly as an audiosample source.
+    // so I2SIn can be used directly as an audiosample source.
     audiosample_base_t base;
     i2s_chan_handle_t rx_chan;
     const mcu_pin_obj_t *bit_clock;
@@ -30,7 +30,6 @@ typedef struct {
     const mcu_pin_obj_t *mclk;
     uint32_t sample_rate;
     uint8_t bit_depth;
-    uint8_t output_bit_depth;
     bool mono;
     bool samples_signed;
     // Owned double-buffer of converted (output-depth, interleaved) samples,

--- a/ports/raspberrypi/common-hal/audioi2sin/I2SIn.c
+++ b/ports/raspberrypi/common-hal/audioi2sin/I2SIn.c
@@ -267,7 +267,6 @@ void common_hal_audioi2sin_i2sin_construct(audioi2sin_i2sin_obj_t *self,
     uint32_t actual_frequency = common_hal_rp2pio_statemachine_get_frequency(&self->state_machine);
     self->sample_rate = actual_frequency / pio_clocks_per_frame;
     self->bit_depth = bit_depth;
-    self->output_bit_depth = output_bit_depth;
     self->mono = mono;
     self->samples_signed = samples_signed;
     self->left_justified = left_justified;
@@ -362,10 +361,6 @@ uint8_t common_hal_audioi2sin_i2sin_get_bit_depth(audioi2sin_i2sin_obj_t *self) 
     return self->bit_depth;
 }
 
-uint8_t common_hal_audioi2sin_i2sin_get_output_bit_depth(audioi2sin_i2sin_obj_t *self) {
-    return self->output_bit_depth;
-}
-
 uint32_t common_hal_audioi2sin_i2sin_get_sample_rate(audioi2sin_i2sin_obj_t *self) {
     return self->sample_rate;
 }
@@ -456,7 +451,7 @@ uint32_t common_hal_audioi2sin_i2sin_record_to_buffer(audioi2sin_i2sin_obj_t *se
     // convention. The default (no-conversion) path applies the flip to the
     // raw FIFO word before splitting into channels; the conversion path
     // applies the flip per output sample at output bit width.
-    const bool convert = self->output_bit_depth != self->bit_depth;
+    const bool convert = self->base.bits_per_sample != self->bit_depth;
     const uint32_t flip16 = (!convert && !self->samples_signed) ? 0x80008000u : 0u;
     const uint32_t flip32 = (!convert && !self->samples_signed)
         ? (self->bit_depth == 24 ? 0x800000u : 0x80000000u)
@@ -466,7 +461,7 @@ uint32_t common_hal_audioi2sin_i2sin_record_to_buffer(audioi2sin_i2sin_obj_t *se
         && self->samples_signed
         && !self->left_justified;
     const uint8_t in_depth = self->bit_depth;
-    const uint8_t out_depth = self->output_bit_depth;
+    const uint8_t out_depth = self->base.bits_per_sample;
     const bool left_justified = self->left_justified;
     const bool samples_signed = self->samples_signed;
 
@@ -633,7 +628,7 @@ void common_hal_audioi2sin_i2sin_fill_buffer(audioi2sin_i2sin_obj_t *self,
     const size_t ring_size = self->ring_size;
     const size_t half_size = self->half_size;
     const uint8_t in_depth = self->bit_depth;
-    const uint8_t out_depth = self->output_bit_depth;
+    const uint8_t out_depth = self->base.bits_per_sample;
     const bool samples_signed = self->samples_signed;
     const bool left_justified = self->left_justified;
     const bool stereo = !self->mono;
@@ -701,7 +696,7 @@ void common_hal_audioi2sin_i2sin_reset_buffer(audioi2sin_i2sin_obj_t *self,
     // The audio pipeline only carries 8- or 16-bit samples. 24/32-bit modes can
     // still record() but cannot stream; fail clearly the first time playback is
     // set up rather than emitting garbage.
-    if (self->output_bit_depth != 8 && self->output_bit_depth != 16) {
+    if (self->base.bits_per_sample != 8 && self->base.bits_per_sample != 16) {
         mp_raise_ValueError_varg(
             MP_ERROR_TEXT("%q must be 8 or 16"), MP_QSTR_output_bit_depth);
     }
@@ -731,7 +726,7 @@ audioio_get_buffer_result_t common_hal_audioi2sin_i2sin_get_buffer(
     uint8_t *out = self->output_buffer + half * self->output_index;
     self->output_index = 1 - self->output_index;
 
-    uint32_t bytes_per_sample = self->output_bit_depth / 8;
+    uint32_t bytes_per_sample = self->base.bits_per_sample / 8;
     uint32_t frames = half / (bytes_per_sample * self->base.channel_count);
     common_hal_audioi2sin_i2sin_fill_buffer(self, out, frames);
 

--- a/ports/raspberrypi/common-hal/audioi2sin/I2SIn.h
+++ b/ports/raspberrypi/common-hal/audioi2sin/I2SIn.h
@@ -20,11 +20,10 @@
 #define AUDIOI2SIN_STREAM_FRAMES (256)
 
 typedef struct {
-    // MUST be first so I2SIn can be used directly as an audiosample source.
+    // so I2SIn can be used directly as an audiosample source.
     audiosample_base_t base;
     uint32_t sample_rate;
     uint8_t bit_depth;
-    uint8_t output_bit_depth;
     bool mono;
     bool samples_signed;
     bool left_justified;

--- a/shared-bindings/audioi2sin/I2SIn.c
+++ b/shared-bindings/audioi2sin/I2SIn.c
@@ -206,7 +206,7 @@ static mp_obj_t audioi2sin_i2sin_obj_record(mp_obj_t self_obj, mp_obj_t destinat
     if (bufinfo.len / mp_binary_get_size('@', bufinfo.typecode, NULL) < length) {
         mp_raise_ValueError(MP_ERROR_TEXT("Destination capacity is smaller than destination_length."));
     }
-    uint8_t output_bit_depth = common_hal_audioi2sin_i2sin_get_output_bit_depth(self);
+    uint8_t output_bit_depth = self->base.bits_per_sample;
     char error_type = ' ';
     bool samples_signed = common_hal_audioi2sin_i2sin_get_samples_signed(self);
     if (samples_signed) {
@@ -242,12 +242,11 @@ MP_DEFINE_CONST_FUN_OBJ_3(audioi2sin_i2sin_record_obj, audioi2sin_i2sin_obj_reco
 //|     """The configured (nominal) sample rate, in Hz. This is the rate reported to
 //|     the audio pipeline so it matches the output/consumer it is played into. The
 //|     true capture rate may differ from this by a fraction of a Hz due to internal
-//|     clock limitations. (Provided by the audiosample protocol via
-//|     ``AUDIOSAMPLE_FIELDS``.)"""
+//|     clock limitations."""
 //|
 //|     bits_per_sample: int
-//|     """The number of bits per sample as it is streamed through the audio pipeline,
-//|     i.e. ``output_bit_depth``. (read-only)"""
+//|     """The number of bits per sample as it is streamed through the audio pipeline.
+//|     (read-only)"""
 //|
 //|     channel_count: int
 //|     """The number of channels (1 for mono, 2 for stereo). (read-only)"""
@@ -267,20 +266,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(audioi2sin_i2sin_get_bit_depth_obj, audioi2sin_i2sin_o
 MP_PROPERTY_GETTER(audioi2sin_i2sin_bit_depth_obj,
     (mp_obj_t)&audioi2sin_i2sin_get_bit_depth_obj);
 
-//|     output_bit_depth: int
-//|     """The bit depth of samples written to the destination buffer. Equals ``bit_depth`` when
-//|     ``output_bit_depth`` was not supplied (or was ``None``) at construction time. (read-only)"""
-//|
-//|
-static mp_obj_t audioi2sin_i2sin_obj_get_output_bit_depth(mp_obj_t self_in) {
-    audioi2sin_i2sin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    check_for_deinit(self);
-    return MP_OBJ_NEW_SMALL_INT(common_hal_audioi2sin_i2sin_get_output_bit_depth(self));
-}
-MP_DEFINE_CONST_FUN_OBJ_1(audioi2sin_i2sin_get_output_bit_depth_obj, audioi2sin_i2sin_obj_get_output_bit_depth);
-
-MP_PROPERTY_GETTER(audioi2sin_i2sin_output_bit_depth_obj,
-    (mp_obj_t)&audioi2sin_i2sin_get_output_bit_depth_obj);
 
 //|     samples_signed: bool
 //|     """True if recorded samples are signed PCM, False for unsigned. (read-only)"""
@@ -296,20 +281,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(audioi2sin_i2sin_get_samples_signed_obj, audioi2sin_i2
 MP_PROPERTY_GETTER(audioi2sin_i2sin_samples_signed_obj,
     (mp_obj_t)&audioi2sin_i2sin_get_samples_signed_obj);
 
-// Thin wrappers exposing the common-hal streaming functions to the audiosample
-// protocol. get_buffer() runs in the output backend's refill interrupt, so it is
-// not exposed to Python.
-static void audioi2sin_i2sin_reset_buffer(audioi2sin_i2sin_obj_t *self,
-    bool single_channel_output, uint8_t channel) {
-    common_hal_audioi2sin_i2sin_reset_buffer(self, single_channel_output, channel);
-}
-
-static audioio_get_buffer_result_t audioi2sin_i2sin_get_buffer(audioi2sin_i2sin_obj_t *self,
-    bool single_channel_output, uint8_t channel, uint8_t **buffer, uint32_t *buffer_length) {
-    return common_hal_audioi2sin_i2sin_get_buffer(self, single_channel_output, channel,
-        buffer, buffer_length);
-}
-
 static const mp_rom_map_elem_t audioi2sin_i2sin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&audioi2sin_i2sin_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&audioi2sin_i2sin_deinit_obj) },
@@ -320,15 +291,14 @@ static const mp_rom_map_elem_t audioi2sin_i2sin_locals_dict_table[] = {
     // protocol's shared property getters.
     AUDIOSAMPLE_FIELDS,
     { MP_ROM_QSTR(MP_QSTR_bit_depth), MP_ROM_PTR(&audioi2sin_i2sin_bit_depth_obj) },
-    { MP_ROM_QSTR(MP_QSTR_output_bit_depth), MP_ROM_PTR(&audioi2sin_i2sin_output_bit_depth_obj) },
     { MP_ROM_QSTR(MP_QSTR_samples_signed), MP_ROM_PTR(&audioi2sin_i2sin_samples_signed_obj) },
 };
 static MP_DEFINE_CONST_DICT(audioi2sin_i2sin_locals_dict, audioi2sin_i2sin_locals_dict_table);
 
 static const audiosample_p_t audioi2sin_i2sin_proto = {
     MP_PROTO_IMPLEMENT(MP_QSTR_protocol_audiosample)
-    .reset_buffer = (audiosample_reset_buffer_fun)audioi2sin_i2sin_reset_buffer,
-    .get_buffer = (audiosample_get_buffer_fun)audioi2sin_i2sin_get_buffer,
+    .reset_buffer = (audiosample_reset_buffer_fun)common_hal_audioi2sin_i2sin_reset_buffer,
+    .get_buffer = (audiosample_get_buffer_fun)common_hal_audioi2sin_i2sin_get_buffer,
 };
 #endif // CIRCUITPY_AUDIOI2SIN
 

--- a/shared-bindings/audioi2sin/I2SIn.h
+++ b/shared-bindings/audioi2sin/I2SIn.h
@@ -26,7 +26,6 @@ bool common_hal_audioi2sin_i2sin_deinited(audioi2sin_i2sin_obj_t *self);
 uint32_t common_hal_audioi2sin_i2sin_record_to_buffer(audioi2sin_i2sin_obj_t *self,
     void *buffer, uint32_t length);
 uint8_t common_hal_audioi2sin_i2sin_get_bit_depth(audioi2sin_i2sin_obj_t *self);
-uint8_t common_hal_audioi2sin_i2sin_get_output_bit_depth(audioi2sin_i2sin_obj_t *self);
 uint32_t common_hal_audioi2sin_i2sin_get_sample_rate(audioi2sin_i2sin_obj_t *self);
 bool common_hal_audioi2sin_i2sin_get_samples_signed(audioi2sin_i2sin_obj_t *self);
 


### PR DESCRIPTION
Implements changes from feedback in https://github.com/adafruit/circuitpython/pull/11064

- Remove wrapper functions for get and reset buffer
- Remove `output_bit_depth` property in favor of `bits_per_sample` that comes from the streaming interface
- Cleaned up docstrings, correct references to order and remove reference to internal var name.


The change to use `self->base.sample_rate` instead of `self->sample_rate` could work in the espressif port I think, but in raspberrypi port those values end up differing slightly. [See comment and code link in 11064](https://github.com/adafruit/circuitpython/pull/11064#discussion_r3467820243) for details.  For now I've just left them alone for both so that the classes in the different ports are the same. I'm open to ideas on how best to handle it.


