### PR TITLE
fix CIRCUITPY_ flags that should be #if, not #ifdef

### DIFF
--- a/ports/analog/supervisor/port.c
+++ b/ports/analog/supervisor/port.c
@@ -126,7 +126,7 @@ safe_mode_t port_init(void) {
     ;
 
     // enable TRNG (true random number generator)
-    #ifdef CIRCUITPY_RANDOM
+    #if CIRCUITPY_RANDOM
     MXC_TRNG_Init();
     #endif
 

--- a/ports/atmel-samd/background.c
+++ b/ports/atmel-samd/background.c
@@ -14,7 +14,7 @@
 #include "supervisor/shared/stack.h"
 #include "supervisor/port.h"
 
-#ifdef CIRCUITPY_DISPLAYIO
+#if CIRCUITPY_DISPLAYIO
 #include "shared-module/displayio/__init__.h"
 #endif
 

--- a/shared-bindings/displayio/TileGrid.c
+++ b/shared-bindings/displayio/TileGrid.c
@@ -17,7 +17,7 @@
 #include "shared-bindings/displayio/ColorConverter.h"
 #include "shared-bindings/displayio/OnDiskBitmap.h"
 #include "shared-bindings/displayio/Palette.h"
-#ifdef CIRCUITPY_TILEPALETTEMAPPER
+#if CIRCUITPY_TILEPALETTEMAPPER
 #include "shared-bindings/tilepalettemapper/TilePaletteMapper.h"
 #endif
 


### PR DESCRIPTION
While looking at a PR that was using `#ifdef` by mistake, I found some existiing `#ifdef CIRCUITPY_xxx` tests that should be `#if CIRCUITPY_xxx`.