### PR TITLE
add settings.toml CIRCUITPY_WIFI_HOSTNAME

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -75,7 +75,8 @@ Keys that affect CircuitPython behavior
 
 CIRCUITPY_BLE_NAME
 ~~~~~~~~~~~~~~~~~~
-Default BLE name the board advertises as, including for the BLE workflow.
+If supplied, sets the BLE name the board advertises as, including for the BLE workflow.
+Otherwise, defaults to ``CIRCUITPYxxxx``, where ``xxxx`` varies per board.
 
 CIRCUITPY_HEAP_START_SIZE
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -103,16 +104,23 @@ TCP port number used for the Web Workflow HTTP API. Defaults to 80 when omitted.
 
 CIRCUITPY_WEB_INSTANCE_NAME
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Hostname the board advertises as, using mDNS, for the Web Workflow.
-Defaults to a semi-unique name if omitted.
+Human-friendly name the board advertises over mDNS for the Web Workflow.
+Defaults to the human-readable board name if omitted.
+This is not the hostname.
 
 CIRCUITPY_WIFI_SSID
 ~~~~~~~~~~~~~~~~~~~
 CIRCUITPY_WIFI_PASSWORD
 ~~~~~~~~~~~~~~~~~~~~~~~
-If these values are specified,
-CircuitPython will connect automatically to a local WiFi network using the supplied SSID
-and password before ``boot.py`` and/or ``code.py`` are run.
+If these values are supplied, connects automatically to a local WiFi network
+with the specified SSID and password before ``boot.py`` and/or ``code.py`` are run.
+
+CIRCUITPY_WIFI_HOSTNAME
+~~~~~~~~~~~~~~~~~~~~~~~
+If supplied, sets the initial ``wifi.radio.hostname`` to the given value.
+Otherwise, the default value is ``cpy-<board_name>-<mac_address>``,
+with some shortening for length if necessary.
+If the supplied value is an invalid hostname or is too long, it is ignored.
 
 CIRCUITPY_SDCARD_USB
 ^^^^^^^^^^^^^^^^^^^^

--- a/ports/espressif/common-hal/wifi/__init__.c
+++ b/ports/espressif/common-hal/wifi/__init__.c
@@ -30,6 +30,10 @@ wifi_radio_obj_t common_hal_wifi_radio_obj;
 
 #include "lwip/sockets.h"
 
+#if CIRCUITPY_SETTINGS_TOML
+#include "supervisor/shared/settings.h"
+#endif
+
 #if CIRCUITPY_STATUS_BAR
 #include "supervisor/shared/status_bar.h"
 #endif
@@ -507,23 +511,36 @@ void common_hal_wifi_init(bool user_initiated) {
         ESP_LOGE(TAG, "WiFi error code: %x", result);
         return;
     }
-    // Set the default lwip_local_hostname capped at 32 characters. We trim off
-    // the start of the board name (likely manufacturer) because the end is
-    // often more unique to the board.
-    size_t board_len = MIN(32 - ((MAC_ADDRESS_LENGTH * 2) + 6), strlen(CIRCUITPY_BOARD_ID));
-    size_t board_trim = strlen(CIRCUITPY_BOARD_ID) - board_len;
-    // Avoid double _ in the hostname.
-    if (CIRCUITPY_BOARD_ID[board_trim] == '_') {
-        board_trim++;
+
+    #if CIRCUITPY_SETTINGS_TOML
+    char hostname[CONFIG_LWIP_DHCPS_MAX_HOSTNAME_LEN];
+    if (settings_get_str("CIRCUITPY_WIFI_HOSTNAME", hostname, sizeof(hostname)) == SETTINGS_OK) {
+        ESP_ERROR_CHECK(esp_netif_set_hostname(self->netif, hostname));
+    }
+    #else
+    if (false) {
+    }
+    #endif
+    else {
+        // Set the default lwip_local_hostname capped at 32 characters. We trim off
+        // the start of the board name (likely manufacturer) because the end is
+        // often more unique to the board.
+        size_t board_len = MIN(32 - ((MAC_ADDRESS_LENGTH * 2) + 6), strlen(CIRCUITPY_BOARD_ID));
+        size_t board_trim = strlen(CIRCUITPY_BOARD_ID) - board_len;
+        // Avoid double _ in the hostname.
+        if (CIRCUITPY_BOARD_ID[board_trim] == '_') {
+            board_trim++;
+        }
+
+        char cpy_default_hostname[board_len + (MAC_ADDRESS_LENGTH * 2) + 6];
+        uint8_t mac[MAC_ADDRESS_LENGTH];
+        esp_wifi_get_mac(WIFI_IF_STA, mac);
+        snprintf(cpy_default_hostname, sizeof(cpy_default_hostname), "cpy-%s-%02x%02x%02x%02x%02x%02x", CIRCUITPY_BOARD_ID + board_trim, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+
+        const char *default_lwip_local_hostname = cpy_default_hostname;
+        ESP_ERROR_CHECK(esp_netif_set_hostname(self->netif, default_lwip_local_hostname));
     }
 
-    char cpy_default_hostname[board_len + (MAC_ADDRESS_LENGTH * 2) + 6];
-    uint8_t mac[MAC_ADDRESS_LENGTH];
-    esp_wifi_get_mac(WIFI_IF_STA, mac);
-    snprintf(cpy_default_hostname, sizeof(cpy_default_hostname), "cpy-%s-%02x%02x%02x%02x%02x%02x", CIRCUITPY_BOARD_ID + board_trim, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-
-    const char *default_lwip_local_hostname = cpy_default_hostname;
-    ESP_ERROR_CHECK(esp_netif_set_hostname(self->netif, default_lwip_local_hostname));
     // set station mode to avoid the default SoftAP
     common_hal_wifi_radio_start_station(self);
     // start wifi

--- a/ports/raspberrypi/common-hal/wifi/__init__.c
+++ b/ports/raspberrypi/common-hal/wifi/__init__.c
@@ -15,6 +15,10 @@
 #include "py/mpstate.h"
 #include "py/runtime.h"
 
+#if CIRCUITPY_SETTINGS_TOML
+#include "supervisor/shared/settings.h"
+#endif
+
 wifi_radio_obj_t common_hal_wifi_radio_obj;
 
 #include "supervisor/port.h"
@@ -45,6 +49,15 @@ void common_hal_wifi_init(bool user_initiated) {
 
     // set station mode to avoid the default SoftAP
     common_hal_wifi_radio_start_station(self);
+
+    #if CIRCUITPY_SETTINGS_TOML
+    // Must be set after station starts.
+    char hostname[sizeof(self->hostname)];
+    if (settings_get_str("CIRCUITPY_WIFI_HOSTNAME", hostname, sizeof(hostname)) == SETTINGS_OK) {
+        common_hal_wifi_radio_set_hostname(self, hostname);
+    }
+    #endif
+
     // start wifi
     common_hal_wifi_radio_set_enabled(self, true);
 }

--- a/ports/zephyr-cp/common-hal/wifi/__init__.c
+++ b/ports/zephyr-cp/common-hal/wifi/__init__.c
@@ -22,6 +22,10 @@ wifi_radio_obj_t common_hal_wifi_radio_obj;
 #include "supervisor/port.h"
 #include "supervisor/workflow.h"
 
+#if CIRCUITPY_SETTINGS_TOML
+#include "supervisor/shared/settings.h"
+#endif
+
 #if CIRCUITPY_STATUS_BAR
 #include "supervisor/shared/status_bar.h"
 #endif
@@ -300,14 +304,25 @@ void common_hal_wifi_init(bool user_initiated) {
         board_trim++;
     }
 
-    char cpy_default_hostname[board_len + (MAC_ADDRESS_LENGTH * 2) + 6];
-    struct net_linkaddr *mac = net_if_get_link_addr(self->sta_netif);
-    if (mac->len < MAC_ADDRESS_LENGTH) {
-        printk("MAC address too short");
+    #if CIRCUITPY_SETTINGS_TOML
+    char hostname[NET_HOSTNAME_MAX_LEN];
+    if (settings_get_str("CIRCUITPY_WIFI_HOSTNAME", hostname, sizeof(hostname)) == SETTINGS_OK) {
+        CHECK_ZEPHYR_RESULT(net_hostname_set(hostname, strlen(hostname)));
     }
-    snprintf(cpy_default_hostname, sizeof(cpy_default_hostname), "cpy-%s-%02x%02x%02x%02x%02x%02x", CIRCUITPY_BOARD_ID + board_trim, mac->addr[0], mac->addr[1], mac->addr[2], mac->addr[3], mac->addr[4], mac->addr[5]);
+    #else
+    if (false) {
+    }
+    #endif
+    else {
+        char cpy_default_hostname[board_len + (MAC_ADDRESS_LENGTH * 2) + 6];
+        struct net_linkaddr *mac = net_if_get_link_addr(self->sta_netif);
+        if (mac->len < MAC_ADDRESS_LENGTH) {
+            printk("MAC address too short");
+        }
+        snprintf(cpy_default_hostname, sizeof(cpy_default_hostname), "cpy-%s-%02x%02x%02x%02x%02x%02x", CIRCUITPY_BOARD_ID + board_trim, mac->addr[0], mac->addr[1], mac->addr[2], mac->addr[3], mac->addr[4], mac->addr[5]);
 
-    CHECK_ZEPHYR_RESULT(net_hostname_set(cpy_default_hostname, strlen(cpy_default_hostname)));
+        CHECK_ZEPHYR_RESULT(net_hostname_set(cpy_default_hostname, strlen(cpy_default_hostname)));
+    }
     #else
     printk("Hostname support disabled in Zephyr config\n");
     #endif


### PR DESCRIPTION
- Fixes #10033 

Add support for `CIRCUITPY_WIFI_HOSTNAME = "some-hostname"` in `settings.toml`.

Add documentation for option and also touch up some other `settings.toml` documentation.

Tested on ESP32-S3 and Pico W. I'm not sure how to test on zephyr or even if there's a build that can test it.