### PR TITLE
handle CIRCUITPY_SAFE_MODE_DELAY in settings.toml

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -205,6 +205,13 @@ Example: Configure the display to 640x480 black and white (1 bit per pixel):
 `Adafruit Feather RP2350 <https://circuitpython.org/board/adafruit_feather_rp2350/>`_
 `Adafruit Metro RP2350 <https://circuitpython.org/board/adafruit_metro_rp2350/>`_
 
+CIRCUITPY_SAFEMODE_DELAY
+~~~~~~~~~~~~~~~~~~~~~~~~
+Wait for the specified amount of time, in seconds (as a float), for the user to press the reset button
+to initiate safe mode after a hard reset.
+The status LED blinks during this time.
+If not specified, use the default delay, which is one second.
+
 CIRCUITPY_TERMINAL_SCALE
 ~~~~~~~~~~~~~~~~~~~~~~~~
 Allows the entry of a display scaling factor used during the terminalio console construction.

--- a/main.c
+++ b/main.c
@@ -1022,17 +1022,11 @@ int __attribute__((used)) main(void) {
     serial_early_init();
     mp_hal_stdout_tx_str(line_clear);
 
-    // Wait briefly to give a reset window where we'll enter safe mode after the reset.
-    if (get_safe_mode() == SAFE_MODE_NONE) {
-        set_safe_mode(wait_for_safe_mode_reset());
-    }
-
     stack_init();
 
     #if CIRCUITPY_STATUS_BAR
     supervisor_status_bar_init();
     #endif
-
 
     #if !INTERNAL_FLASH_FILESYSTEM
     // Set up anything that might need to get done before we try to use SPI flash
@@ -1048,6 +1042,13 @@ int __attribute__((used)) main(void) {
     // since we haven't run user code yet.
     if (!filesystem_init(get_safe_mode() == SAFE_MODE_NONE, false)) {
         set_safe_mode(SAFE_MODE_NO_CIRCUITPY);
+    }
+
+    // Wait briefly to give a reset window where we'll enter safe mode after the reset.
+    // Do this after mounting the filesystem because settings.toml can contain
+    // CIRCUITPY_SAFE_MODE_DELAY to change the default delay.
+    if (get_safe_mode() == SAFE_MODE_NONE) {
+        set_safe_mode(wait_for_safe_mode_reset());
     }
 
     #if CIRCUITPY_BLEIO

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -18,6 +18,10 @@
 #include "supervisor/shared/translate/translate.h"
 #include "supervisor/shared/tick.h"
 
+#if CIRCUITPY_SETTINGS_TOML
+#include "supervisor/shared/settings.h"
+#endif
+
 #ifdef __ZEPHYR__
 #include <zephyr/kernel.h>
 #endif
@@ -65,10 +69,22 @@ safe_mode_t wait_for_safe_mode_reset(void) {
     #if CIRCUITPY_STATUS_LED
     status_led_init();
     #endif
+
+    uint32_t safe_mode_delay_msecs = 1000;
+
+    #if CIRCUITPY_SETTINGS_TOML
+    mp_float_t safe_mode_delay_secs = 1.0f;
+    // Will update delay_secs if setting is present.
+    settings_get_float("CIRCUITPY_SAFE_MODE_DELAY", &safe_mode_delay_secs);
+    if (safe_mode_delay_secs >= 0.0f && safe_mode_delay_secs <= (mp_float_t)UINT32_MAX) {
+        safe_mode_delay_msecs = safe_mode_delay_secs * 1000;
+    }
+    #endif
+
     uint64_t start_ticks = supervisor_ticks_ms64();
     uint64_t diff = 0;
     bool boot_in_safe_mode = false;
-    while (diff < 1000) {
+    while (diff < safe_mode_delay_msecs) {
         #if CIRCUITPY_STATUS_LED
         // Blink on for 100, off for 100
         bool led_on = (diff % 250) < 125;


### PR DESCRIPTION
Fixes #8709, in a somewhat different way.

Add `CIRCUITPY_SAFE_MODE_DELAY` to `settings.toml`. If specified, it allows the user to change the length of the safe mode delay, during which a second press of the reset button goes into safe mode. The value is specifed as a float number of seconds. If the delay is 0, it effectively turns off the feature.

This required moving the safe-mode wait until after CIRCUITPY is mounted, so `settings.toml` can be read. I think this is OK, but if you think of a problem, let me know.