### PR TITLE
restore ESPNow to some functionality

### DIFF
--- a/ports/espressif/bindings/espnow/ESPNow.c
+++ b/ports/espressif/bindings/espnow/ESPNow.c
@@ -40,6 +40,8 @@ static void espnow_check_for_deinit(espnow_obj_t *self) {
 //|         :param int buffer_size: The size of the internal ring buffer. Default: 526 bytes.
 //|         :param int phy_rate: The ESP-NOW physical layer rate. Default: 1 Mbps.
 //|             `wifi_phy_rate_t <https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/api-reference/network/esp_wifi.html#_CPPv415wifi_phy_rate_t>`_
+//|
+//|         **Limitations:** Currently, setting ``phy_rate`` does nothing. The rate is always 1 Mbps.
 //|         """
 //|         ...
 //|
@@ -231,6 +233,8 @@ MP_PROPERTY_GETTER(espnow_buffer_size_obj,
 //|     phy_rate: int
 //|     """The ESP-NOW physical layer rate.
 //|     `wifi_phy_rate_t <https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/api-reference/network/esp_wifi.html#_CPPv415wifi_phy_rate_t>`_
+//|
+//|     **Limitations:** Currently, setting ``phy_rate`` does nothing. The rate is always 1 Mbps.
 //|     """
 //|
 static mp_obj_t espnow_get_phy_rate(const mp_obj_t self_in) {

--- a/ports/espressif/common-hal/espnow/ESPNow.c
+++ b/ports/espressif/common-hal/espnow/ESPNow.c
@@ -120,15 +120,20 @@ void common_hal_espnow_init(espnow_obj_t *self) {
         common_hal_wifi_radio_set_enabled(&common_hal_wifi_radio_obj, true);
     }
 
-    esp_now_rate_config_t rate_config = {
-        .phymode = WIFI_PHY_MODE_LR,
-        .rate = self->phy_rate,
-        .ersu = false,
-        .dcm = false,
-    };
-    CHECK_ESP_RESULT(esp_now_set_peer_rate_config(NULL, &rate_config));
-
     CHECK_ESP_RESULT(esp_now_init());
+
+    // esp_now_set_peer_rate_config() is poorly documented, and we haven't figured out
+    // what the esp_now_rate_config_t settings should be. For now, just ignore phy_rate.
+    // Note that esp_now_set_peer_rate_config() must be called after esp_now-init().
+    //
+    // esp_now_rate_config_t rate_config = {
+    //     .phymode = WIFI_PHY_MODE_LR,
+    //     .rate = self->phy_rate,
+    //     .ersu = false,
+    //     .dcm = false,
+    // };
+    // CHECK_ESP_RESULT(esp_now_set_peer_rate_config(NULL, &rate_config));
+
     CHECK_ESP_RESULT(esp_now_register_send_cb(send_cb));
     CHECK_ESP_RESULT(esp_now_register_recv_cb(recv_cb));
 }


### PR DESCRIPTION
- Fixes #9276.

ESPNow was broken on ESP32-S3 as of the ESP-IDF v6.0.1 upgrade, and was failing on other boards earlier.

This restores it to working at least to some extent.

The new way to set the `phy_rate` is with `esp_now_set_peer_rate_config()`. However, this function is poorly documented (I opened https://github.com/espressif/esp-idf/issues/18766), and the settings for the passed struct are not documented.

To fix this for now, I just commented out the ability to set the `phy_rate`, leaving it at the default 1Mbps. I added documentation to point out setting the `phy_rate` does nothing for now.

Also note that `esp_now_set_peer_rate_config()` should be called after `esp_now_init()`. It was being called before.

I tested with an ESP32-S3 broadcasting and and ESP32-C6 receiving, using the example code in https://learn.adafruit.com/esp-now-in-circuitpython/code-esp-now.

@todbot for interest.