### PR TITLE
clear reference to BLE name on Adapter reset

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/Adapter.c
+++ b/devices/ble_hci/common-hal/_bleio/Adapter.c
@@ -259,6 +259,8 @@ static void _adapter_set_name(bleio_adapter_obj_t *self, mp_obj_str_t *name_obj)
 // Get various values and limits set by the adapter.
 // Set event mask.
 static void bleio_adapter_hci_init(bleio_adapter_obj_t *self) {
+    self->name = NULL;
+
     mp_int_t name_len = 0;
 
     #if CIRCUITPY_SETTINGS_TOML
@@ -950,7 +952,6 @@ void bleio_adapter_reset(bleio_adapter_obj_t *adapter) {
         }
         connection->connection_obj = mp_const_none;
     }
-
 }
 
 void bleio_adapter_background(bleio_adapter_obj_t *adapter) {


### PR DESCRIPTION
- Fixes #9412.

There could have been a stale reference to the `name` object when the adapter was initialized.

Tested on an AirLift. Works after hard reset, as expected, and also works after ctrl-C, ctrl-D.