### PR TITLE
MAX3421E: reduce default SPI freq to 20 MHz to accomodate granularity on ESP32

### DIFF
--- a/ports/espressif/mpconfigport.mk
+++ b/ports/espressif/mpconfigport.mk
@@ -219,7 +219,7 @@ CIRCUITPY_SDIOIO = 0
 CIRCUITPY_USB_DEVICE = 0
 CIRCUITPY_ESP_USB_SERIAL_JTAG ?= 1
 
-#### esp32c6 ##########################################################
+#### esp32c61 ##########################################################
 else ifeq ($(IDF_TARGET),esp32c61)
 # Modules
 CIRCUITPY_ESPCAMERA = 0

--- a/shared-bindings/max3421e/Max3421E.c
+++ b/shared-bindings/max3421e/Max3421E.c
@@ -19,7 +19,7 @@
 //|         *,
 //|         chip_select: microcontroller.Pin,
 //|         irq: microcontroller.Pin,
-//|         baudrate: int = 26000000,
+//|         baudrate: int = 20000000,
 //|     ) -> None:
 //|         """Create a Max3421E object associated with the given pins.
 //|
@@ -29,7 +29,13 @@
 //|         :param busio.SPI spi_bus: The SPI bus that make up the clock and data lines
 //|         :param microcontroller.Pin chip_select: Chip select pin
 //|         :param microcontroller.Pin irq: Interrupt pin
-//|         :param int baudrate: Maximum baudrate to talk to the Max chip in Hz"""
+//|         :param int baudrate: Maximum baudrate to talk to the Max chip in Hz
+//|
+//|         Note: The specified maximum frequency for the MAX3421E is 26 MHz.
+//|         Due to SPI frequency granularity on various chips, this frequency
+//|         may be exceeded when the specified frequency is > 20 MHz.
+//|         So 20 MHz is the default.
+//|         """
 //|         ...
 //|
 static mp_obj_t max3421e_max3421e_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
@@ -38,7 +44,7 @@ static mp_obj_t max3421e_max3421e_make_new(const mp_obj_type_t *type, size_t n_a
         { MP_QSTR_spi_bus, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_chip_select, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
         { MP_QSTR_irq, MP_ARG_OBJ | MP_ARG_KW_ONLY | MP_ARG_REQUIRED },
-        { MP_QSTR_baudrate, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 24000000} },
+        { MP_QSTR_baudrate, MP_ARG_INT | MP_ARG_KW_ONLY, {.u_int = 20000000} },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);


### PR DESCRIPTION
- Fixes #10053

The problem here is that the default SPI frequency for the MAX3421E is 24 MHz. However, the SPI frequency ("baudrate") has different granularity on different Espressif chips. On ESP32-C6, 24 MHz is actually 20 MHz. On ESP32, 24 MHz is actually ~26.67 MHz (26.666...). On ESP32-S2, it's also 26.67 MHz.

The max spec of the MAX3421E is 26 MHz, so it's at the hairy edge. On S2 it works some of the time, but not ESP32; I'm not sure why. but in any case, it's too high.

20 MHz is OK  on all, so I've changed the default from 24 MHz to 20 MHz, and documented this. I re-tested on ESP32 and other chips.

Also fixed a tiny typo in `espressif/mpconfigport.mk`.

Claude Code was helpful on this. It started out on incorrect theories, but was good at instrumenting whether the MAX3421E setup was working or not. It suggested lower baudrates as a test at one point, and that set me on a quest of which baud rates actually worked. I then discovered the different quantization of the baudrates.

This raises a long-term issue of whether SPI clock rates (and similar) should round down or not. I'll open an issue about that.