### PR TITLE
busio.SPI: treat baudrate as a ceiling, not nearest

### DIFF
--- a/ports/analog/common-hal/busio/SPI.c
+++ b/ports/analog/common-hal/busio/SPI.c
@@ -157,7 +157,6 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
     mxc_spi_clkmode_t clk_mode;
     int ret;
 
-    self->baudrate = baudrate;
     self->polarity = polarity;
     self->phase = phase;
     self->bits = bits;
@@ -185,6 +184,29 @@ bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
         mp_raise_ValueError_varg(MP_ERROR_TEXT("%q out of range"), MP_QSTR_baudrate);
         return false;
     }
+
+    // MXC_SPI_SetFrequency() floors the clock divisor, so the actual rate can be
+    // HIGHER than requested. Treat baudrate as a ceiling: if the hardware
+    // overshoots, bisect downward on the requested target for the highest rate
+    // that does not exceed baudrate. MXC_SPI_GetFrequency() reports the actual
+    // configured rate, so we don't depend on the divisor internals.
+    uint32_t actual = MXC_SPI_GetFrequency(self->spi_regs);
+    if (actual > baudrate) {
+        uint32_t lo = 1;         // f(lo) <= baudrate
+        uint32_t hi = baudrate;  // f(hi) > baudrate (just measured)
+        while (hi - lo > 1) {
+            uint32_t mid = lo + (hi - lo) / 2;
+            MXC_SPI_SetFrequency(self->spi_regs, mid);
+            if (MXC_SPI_GetFrequency(self->spi_regs) <= baudrate) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        MXC_SPI_SetFrequency(self->spi_regs, lo);
+        actual = MXC_SPI_GetFrequency(self->spi_regs);
+    }
+    self->baudrate = actual;
     ret = MXC_SPI_SetDataSize(self->spi_regs, bits);
     if (ret == E_BAD_PARAM) {
         mp_raise_ValueError_varg(MP_ERROR_TEXT("%q out of range"), MP_QSTR_bits);

--- a/ports/cxd56/common-hal/busio/SPI.c
+++ b/ports/cxd56/common-hal/busio/SPI.c
@@ -72,8 +72,27 @@ void common_hal_busio_spi_mark_deinit(busio_spi_obj_t *self) {
 bool common_hal_busio_spi_configure(busio_spi_obj_t *self, uint32_t baudrate, uint8_t polarity, uint8_t phase, uint8_t bits) {
     uint8_t mode;
 
-    self->frequency = baudrate;
-    SPI_SETFREQUENCY(self->spi_dev, baudrate);
+    // SPI_SETFREQUENCY() picks the nearest available frequency and returns it,
+    // which can be HIGHER than requested (it overshoots at low frequencies).
+    // Treat baudrate as a ceiling: if the driver overshoots, bisect downward on
+    // the requested target for the highest available frequency that does not
+    // exceed baudrate. The driver returns the actual frequency each call, so we
+    // don't depend on its divisor internals.
+    uint32_t actual = SPI_SETFREQUENCY(self->spi_dev, baudrate);
+    if (actual > baudrate) {
+        uint32_t lo = 1;         // f(lo) <= baudrate
+        uint32_t hi = baudrate;  // f(hi) > baudrate (just measured)
+        while (hi - lo > 1) {
+            uint32_t mid = lo + (hi - lo) / 2;
+            if (SPI_SETFREQUENCY(self->spi_dev, mid) <= baudrate) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        actual = SPI_SETFREQUENCY(self->spi_dev, lo);
+    }
+    self->frequency = actual;
 
     if (polarity == 0) {
         if (phase == 0) {

--- a/ports/espressif/common-hal/busio/SPI.c
+++ b/ports/espressif/common-hal/busio/SPI.c
@@ -22,22 +22,70 @@ static bool spi_bus_is_free(spi_host_device_t host_id) {
     return spi_bus_get_attr(host_id) == NULL;
 }
 
+// Add a throwaway device at the given target clock, ask the driver what
+// frequency it would actually produce, then remove it. Returns the actual
+// frequency in Hz, or -1 if a device could not be added at that target.
+static int spi_probe_actual_freq(busio_spi_obj_t *self,
+    spi_device_interface_config_t *device_config, int target_hz) {
+    device_config->clock_speed_hz = target_hz;
+    spi_device_handle_t handle;
+    if (spi_bus_add_device(self->host_id, device_config, &handle) != ESP_OK) {
+        return -1;
+    }
+    int freq_khz = 0;
+    spi_device_get_actual_freq(handle, &freq_khz);
+    spi_bus_remove_device(handle);
+    return freq_khz * 1000;
+}
+
 static void set_spi_config(busio_spi_obj_t *self,
     uint32_t baudrate, uint8_t polarity, uint8_t phase, uint8_t bits) {
-    // 128 is a 50% duty cycle.
-    const int closest_clock = spi_get_actual_clock(APB_CLK_FREQ, baudrate, 128);
-    const spi_device_interface_config_t device_config = {
-        .clock_speed_hz = closest_clock,
+    spi_device_interface_config_t device_config = {
+        .clock_speed_hz = baudrate,
         .mode = phase | (polarity << 1),
         .spics_io_num = -1, // No CS pin
         .queue_size = MAX_SPI_TRANSACTIONS,
         .pre_cb = NULL
     };
+
+    // The ESP-IDF driver rounds clock_speed_hz to the nearest frequency it can
+    // produce, which may be HIGHER than requested. Treat baudrate as a ceiling:
+    // probe candidate targets (each time adding a throwaway device, asking the
+    // driver what it actually produced, and removing it) and keep the highest
+    // target whose actual frequency does not exceed baudrate. We don't inspect
+    // divisor internals -- those vary between Espressif chips -- only the
+    // public add/measure/remove API.
+    int target = baudrate;
+    int actual = spi_probe_actual_freq(self, &device_config, target);
+    if (actual < 0 || actual > (int)baudrate) {
+        // Bisect for the highest target whose actual frequency is <= baudrate.
+        // Stop refining once the interval is within 1 kHz, the resolution that
+        // spi_device_get_actual_freq reports.
+        int lo = 1;
+        int hi = baudrate;
+        while (hi - lo > 1000) {
+            int mid = lo + (hi - lo) / 2;
+            int mid_actual = spi_probe_actual_freq(self, &device_config, mid);
+            if (mid_actual >= 0 && mid_actual <= (int)baudrate) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        target = lo;
+    }
+
+    device_config.clock_speed_hz = target;
     esp_err_t result = spi_bus_add_device(self->host_id, &device_config, &spi_handle[self->host_id]);
     if (result != ESP_OK) {
         mp_raise_RuntimeError(MP_ERROR_TEXT("SPI configuration failed"));
     }
-    self->baudrate = closest_clock;
+
+    // Report the frequency the driver actually settled on for the real device.
+    int actual_khz = 0;
+    spi_device_get_actual_freq(spi_handle[self->host_id], &actual_khz);
+    self->baudrate = actual_khz * 1000;
+    self->requested_baudrate = baudrate;
     self->polarity = polarity;
     self->phase = phase;
     self->bits = bits;
@@ -146,7 +194,7 @@ void common_hal_busio_spi_deinit(busio_spi_obj_t *self) {
 
 bool common_hal_busio_spi_configure(busio_spi_obj_t *self,
     uint32_t baudrate, uint8_t polarity, uint8_t phase, uint8_t bits) {
-    if (baudrate == self->baudrate &&
+    if (baudrate == self->requested_baudrate &&
         polarity == self->polarity &&
         phase == self->phase &&
         bits == self->bits) {

--- a/ports/espressif/common-hal/busio/SPI.h
+++ b/ports/espressif/common-hal/busio/SPI.h
@@ -21,7 +21,8 @@ typedef struct {
     uint8_t bits;
     uint8_t phase;
     uint8_t polarity;
-    uint32_t baudrate;
+    uint32_t baudrate;            // Actual frequency, reported by the frequency property.
+    uint32_t requested_baudrate;  // Value passed to configure(); used for the cache-hit check.
 
     SemaphoreHandle_t mutex;
 } busio_spi_obj_t;

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -157,8 +157,10 @@ static void check_for_deinit(busio_spi_obj_t *self) {
 //|     ) -> None:
 //|         """Configures the SPI bus. The SPI object must be locked.
 //|
-//|         :param int baudrate: the desired clock rate in Hertz. The actual clock rate may be higher or lower
-//|           due to the granularity of available clock settings.
+//|         :param int baudrate: the desired clock rate in Hertz. The actual clock rate may be lower
+//|           due to the granularity of available clock settings, but it will not exceed the
+//|           requested rate: the value is treated as a ceiling, so the clock is set to the
+//|           requested rate or the nearest lower available rate.
 //|           Check the `frequency` attribute for the actual clock rate.
 //|         :param int polarity: the base state of the clock line (0 or 1)
 //|         :param int phase: the edge of the clock that data is captured. First (0)
@@ -445,8 +447,8 @@ static mp_obj_t busio_spi_write_readinto(size_t n_args, const mp_obj_t *pos_args
 MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_write_readinto_obj, 1, busio_spi_write_readinto);
 
 //|     frequency: int
-//|     """The actual SPI bus frequency. This may not match the frequency requested
-//|     due to internal limitations."""
+//|     """The actual SPI bus frequency. This may be lower than the frequency requested
+//|     due to internal limitations, but it will not be higher."""
 //|
 //|
 

--- a/shared-bindings/busio/SPI.c
+++ b/shared-bindings/busio/SPI.c
@@ -157,11 +157,12 @@ static void check_for_deinit(busio_spi_obj_t *self) {
 //|     ) -> None:
 //|         """Configures the SPI bus. The SPI object must be locked.
 //|
-//|         :param int baudrate: the desired clock rate in Hertz. The actual clock rate may be lower
-//|           due to the granularity of available clock settings, but it will not exceed the
-//|           requested rate: the value is treated as a ceiling, so the clock is set to the
-//|           requested rate or the nearest lower available rate.
+//|         :param int baudrate: the desired clock rate in Hertz. The value is treated as a ceiling:
+//|           the actual clock rate may be lower due to the granularity of available clock settings,
+//|           but it will not exceed the given value.
 //|           Check the `frequency` attribute for the actual clock rate.
+//|           **Limitations**: On Zephyr, the ceiling behavior may be violated, and
+//|           the `frequency` value does not reflect the actual baudrate.
 //|         :param int polarity: the base state of the clock line (0 or 1)
 //|         :param int phase: the edge of the clock that data is captured. First (0)
 //|           or second (1). Rising or falling depends on clock polarity.
@@ -170,13 +171,7 @@ static void check_for_deinit(busio_spi_obj_t *self) {
 //|         .. note:: On the SAMD21, it is possible to set the baudrate to 24 MHz, but that
 //|            speed is not guaranteed to work. 12 MHz is the next available lower speed, and is
 //|            within spec for the SAMD21.
-//|
-//|         .. note:: On the nRF52840, these baudrates are available: 125kHz, 250kHz, 1MHz, 2MHz, 4MHz,
-//|           and 8MHz.
-//|           If you pick a a baudrate other than one of these, the nearest lower
-//|           baudrate will be chosen, with a minimum of 125kHz.
-//|           Two SPI objects may be created, except on the Circuit Playground Bluefruit,
-//|           which allows only one (to allow for an additional I2C object)."""
+//|         """
 //|         ...
 //|
 
@@ -448,8 +443,13 @@ MP_DEFINE_CONST_FUN_OBJ_KW(busio_spi_write_readinto_obj, 1, busio_spi_write_read
 
 //|     frequency: int
 //|     """The actual SPI bus frequency. This may be lower than the frequency requested
-//|     due to internal limitations, but it will not be higher."""
+//|     due to internal limitations, but it will not be higher.
 //|
+//|     **Limitations**: On Zephyr, the returned value does not reflect the actual baudrate,
+//|     because there is `no way to fetch the actual chosen frequency
+//|     <https://github.com/zephyrproject-rtos/zephyr/issues/77922>`_.
+//|     In addition, on Zephyr, the ceiling behavior described in `configure` may be violated.
+//|     """
 //|
 
 static mp_obj_t busio_spi_obj_get_frequency(mp_obj_t self_in) {


### PR DESCRIPTION
- Fixes #11079

**Note:** This PR description was mostly written by Claude (Claude Code), and touched up by me (@dhalbert).

## Summary

`busio.SPI` documents `baudrate` as a desired clock rate, and most ports already pick the requested rate or the nearest *lower* available rate. But several ports rounded to the *nearest* available rate (or worse), so the actual SPI clock could come out **higher** than requested and overclock a device. This PR makes the requested `baudrate` a **ceiling** consistently: the resulting clock is the requested rate or the nearest lower available rate, never higher.

## Per-port status

| Port | Before | Change |
|------|--------|--------|
| atmel-samd | rounded to nearest (`(f_ref/(2·baud)) − 0.5`) | ceiling divisor `ceil(f_ref/(2·baud)) − 1` (in the `samd-peripherals` submodule) |
| espressif | nearest (ESP-IDF `spi_get_actual_clock`, abs-error min) | probe via `spi_bus_add_device`→`spi_device_get_actual_freq`→`spi_bus_remove_device`, bisecting downward |
| cxd56 | nearest (NuttX `SPI_SETFREQUENCY` overshoots at low freqs) | bisect downward using the actual frequency it returns |
| analog | overshoots (`MXC_SPI_SetFrequency` floors the divisor) | bisect downward using `MXC_SPI_GetFrequency` readback |
| broadcom, mimxrt10xx, nordic, raspberrypi, silabs, stm | already floor | no change |

None of the fixes depend on chip-specific divisor internals; each uses the port's public "set then read back the actual rate" path (or, for atmel-samd, the documented BAUD formula).

## Submodule

The atmel-samd fix lives in `samd-peripherals` (adafruit/samd-peripherals#49, merged); this PR bumps the submodule pointer to pick it up.

## Docs

`shared-bindings/busio/SPI.c` now documents the ceiling behavior on both the `configure()` `baudrate` parameter and the `frequency` attribute. [I reworked some of this to be less verbose and clearer. --@dhalbert]

## Testing

- **atmel-samd** — tested on Metro M4.
- **espressif** — tested on ESP32-S3, ESP32-C6, and ESP32: no frequency exceeds the request.
- **cxd56** — tested on SPRESENSE (CXD5602): no frequency exceeds the request.
- **analog** — **not** tested on hardware (no MAX32xxx board available); the logic mirrors the cxd56/espressif fixes.

## Known limitation: Zephyr

The `zephyr-cp` port is **not** addressed. Zephyr's `struct spi_config` only takes a requested `frequency` and provides **no API to read back the achieved rate** (https://github.com/zephyrproject-rtos/zephyr/issues/77922), so the read-back-and-bisect approach used by the other ports is not available. Behavior is per-driver: nRF, STM32, Renesas RA8, and Smartbond already floor, but the RP2040/RP2350 PIO, NXP flexcomm (MCXN947/RW612), and NXP ecspi (MIMXRT1170) drivers round to nearest and can exceed the request. This is now documented as a limitation in the `busio.SPI.configure()` documentation.