### PR TITLE
espressif: fix I2S audio under IDF v6 (dma_buf is the buffer pointer)

### DIFF
--- a/ports/espressif/common-hal/audiobusio/__init__.c
+++ b/ports/espressif/common-hal/audiobusio/__init__.c
@@ -108,7 +108,7 @@ static void i2s_callback_fun(void *self_in) {
 static bool i2s_event_interrupt(i2s_chan_handle_t handle, i2s_event_data_t *event, void *self_in) {
     i2s_t *self = self_in;
     self->underrun = self->underrun || self->next_buffer != NULL;
-    self->next_buffer = *(int16_t **)event->dma_buf;
+    self->next_buffer = (int16_t *)event->dma_buf;
     self->next_buffer_size = event->size;
     background_callback_add(&self->callback, i2s_callback_fun, self_in);
     return false;


### PR DESCRIPTION
Fixes #11070

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

Fixes I2S audio on espressif under ESP-IDF v6: it was dropping into safe mode with a NULL-pointer crash in `audiosample_convert_u16m_s16s`, and otherwise playing only short bursts of tone separated by silence. Regressed with the IDF v6.0 migration (#10922).

## Root cause

The migration commit `6a34aa1010` mechanically renamed the I2S event field `data` → `dma_buf` but kept an extra pointer dereference.

- In IDF v5.x, `i2s_event_data_t.data` pointed *to* the buffer pointer (`&finish_desc->buf`), so `*(int16_t **)event->data` was correct.
- In IDF v6, `dma_buf` **is** the buffer pointer directly (`i2s_common.c`: `.dma_buf = curr_buf`; the header documents it as "the first level pointer of DMA buffer").

The stale double-dereference reinterpreted the first bytes of audio data as an address, so `next_buffer` became garbage/NULL — causing the NULL-pointer safe mode crash and DMA buffers that were never refilled (tone-then-silence).

## Fix

```c
-    self->next_buffer = *(int16_t **)event->dma_buf;
+    self->next_buffer = (int16_t *)event->dma_buf;
```

## Testing

Verified on affected hardware: a tone now plays continuously with no safe mode and no gaps.