### PR TITLE
espressif/boards/lilygo_tdongle_s3/board.c: flip brightness sense

### DIFF
--- a/ports/espressif/boards/lilygo_tdongle_s3/board.c
+++ b/ports/espressif/boards/lilygo_tdongle_s3/board.c
@@ -97,7 +97,7 @@ static void display_init(void) {
         false,          // data_as_commands
         true,           // auto_refresh
         60,             // native_frames_per_second
-        true,           // backlight_on_high
+        false,          // backlight_on_high
         false,          // SH1107_addressing
         50000           // backlight pwm frequency
         );


### PR DESCRIPTION
- Fixes #10749.

@Mandred @freemansoft Could you check the [artifact](https://github.com/adafruit/circuitpython/actions/runs/28718009010/artifacts/8085136902) from this PR? I don't have this board to test. Thanks.
