### PR TITLE
espressif: tear down espcamera before resetting board buses

### DIFF
--- a/main.c
+++ b/main.c
@@ -337,6 +337,9 @@ static void count_strn(void *data, const char *str, size_t len) {
 }
 
 static void cleanup_after_vm(mp_obj_t exception) {
+    // Do any port cleanup needed before anything else, including releasing board buses.
+    reset_port_early();
+
     // Get the traceback of any exception from this run off the heap.
     // MP_OBJ_SENTINEL means "this run does not contribute to traceback storage, don't touch it"
     // MP_OBJ_NULL (=0) means "this run completed successfully, clear any stored traceback"

--- a/ports/espressif/common-hal/espcamera/Camera.c
+++ b/ports/espressif/common-hal/espcamera/Camera.c
@@ -21,6 +21,11 @@
 #error espcamera only works on boards configured with spiram, disable it in mpconfigboard.mk
 #endif
 
+// The underlying esp-camera driver only handles a singleton camera.
+// Track it here so it can be reset, releasing its
+// device on the shared I2C bus, before the I2C bus is deinited.
+static espcamera_camera_obj_t *live_camera = NULL;
+
 static void i2c_lock(espcamera_camera_obj_t *self) {
     if (common_hal_busio_i2c_deinited(self->i2c)) {
         raise_deinited_error();
@@ -120,11 +125,29 @@ void common_hal_espcamera_camera_construct(
     i2c_unlock(self);
 
     CHECK_ESP_RESULT(result);
+
+    // Only record the camera once esp_camera_init() has succeeded, so a failed
+    // second construction doesn't overwrite the live singleton.
+    live_camera = self;
+}
+
+void espcamera_reset(void) {
+    if (live_camera != NULL) {
+        common_hal_espcamera_camera_deinit(live_camera);
+    }
 }
 
 extern void common_hal_espcamera_camera_deinit(espcamera_camera_obj_t *self) {
     if (common_hal_espcamera_camera_deinited(self)) {
         return;
+    }
+
+    // Only tear down the shared esp-camera driver if this object owns it. A
+    // second, failed construction leaves live_camera pointing at the first
+    // camera; deiniting that failed object must not destroy the live one.
+    bool was_live = (live_camera == self);
+    if (was_live) {
+        live_camera = NULL;
     }
 
     common_hal_pwmio_pwmout_deinit(&self->pwm);
@@ -143,7 +166,9 @@ extern void common_hal_espcamera_camera_deinit(espcamera_camera_obj_t *self) {
     reset_pin_number(self->camera_config.pin_d1);
     reset_pin_number(self->camera_config.pin_d0);
 
-    esp_camera_deinit();
+    if (was_live) {
+        esp_camera_deinit();
+    }
 
     reset_pin_number(self->camera_config.pin_pclk);
     reset_pin_number(self->camera_config.pin_vsync);

--- a/ports/espressif/common-hal/espcamera/Camera.h
+++ b/ports/espressif/common-hal/espcamera/Camera.h
@@ -18,3 +18,7 @@ typedef struct espcamera_camera_obj {
     pwmio_pwmout_obj_t pwm;
     busio_i2c_obj_t *i2c;
 } espcamera_obj_t;
+
+// Deinitialize the active camera, if any, so it releases its device on the
+// shared I2C bus. Called from reset_port_early().
+void espcamera_reset(void);

--- a/ports/espressif/supervisor/port.c
+++ b/ports/espressif/supervisor/port.c
@@ -52,7 +52,7 @@
 #endif
 
 #if CIRCUITPY_ESPCAMERA
-#include "esp_camera.h"
+#include "common-hal/espcamera/Camera.h"
 #endif
 
 #if CIRCUITPY_RCLCPY
@@ -346,11 +346,17 @@ size_t port_heap_get_largest_free_size(void) {
     return free_size;
 }
 
-void reset_port(void) {
-    // TODO deinit for esp32-camera
+void reset_port_early(void) {
+    // esp-camera adds an I2C device on the ESP I2C bus, and keeps it there. This
+    // is unlike busio.I2C, which adds and removes the device on each operation.
+    // So have the esp-camera API shut down the camera now, before reset_board_buses() tries to delete the I2C bus.
+    // Unfortunately, there is no I2C driver API to enumerate or delete all the devices.
     #if CIRCUITPY_ESPCAMERA
-    esp_camera_deinit();
+    espcamera_reset();
     #endif
+}
+
+void reset_port(void) {
 
     #if CIRCUITPY_SSL
     ssl_reset();

--- a/ports/espressif/tools/decode_backtrace.py
+++ b/ports/espressif/tools/decode_backtrace.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 
 board = sys.argv[1]
+# Allow `board-name` or `build-board-name/ as the arg, to allow simple tab completion of boardname.
+board = board.replace("build-", "").replace("/", "")
 print(board)
 
 elfs = [

--- a/supervisor/port.h
+++ b/supervisor/port.h
@@ -26,6 +26,9 @@ safe_mode_t port_init(void);
 // Reset the microcontroller completely.
 void reset_cpu(void) MP_NORETURN;
 
+// Reset port state that must be torn down before anything else is reset.
+void reset_port_early(void);
+
 // Reset the microcontroller state.
 void reset_port(void);
 

--- a/supervisor/shared/port.c
+++ b/supervisor/shared/port.c
@@ -21,6 +21,9 @@
 
 static tlsf_t heap;
 
+MP_WEAK void reset_port_early(void) {
+}
+
 MP_WEAK void port_wake_main_task(void) {
 }
 


### PR DESCRIPTION
- Fixes #11094

Code written by Claude, but closely supervised by me. I did the original diagnosis, and suggested some approaches. The PR description below was written by Claude and then edited by me for clarity. -- @dhalbert

When an `espcamera.Camera` is created with a `busio.I2C` bus (e.g. `board.I2C()`), esp-camera's SCCB reuses the CircuitPython-created I2C port and registers a sensor device on that bus via `i2c_master_bus_add_device()`.

At VM teardown, `cleanup_after_vm()` calls `reset_board_buses()` early, which deinits the I2C object and calls `i2c_del_master_bus()`. That failed with `ESP_ERR_INVALID_STATE` because the camera's device was still attached — the camera was only torn down later, by its GC finalizer.

The PR adds a `reset_port_early()` port hook, called at the very start of `cleanup_after_vm()`, before `reset_board_buses()`. On espressif, it deinits the active camera, so the camera releases its device from the I2C bus before the bus is deleted.

esp-camera is a driver-level singleton. But `espcamera.Camera` was not made aware it was a singleton. Code was added to cleanly fail on a second instanatiation.  The `live_camera` pointer tracks the one live instance. The pointer is used by `espcamera_reset()`, a new routine that is called in `reset_port_early`.

Tested on hardware: creating an `espcamera.Camera` on `board.I2C()` and reloading now tears down cleanly without the `i2c_del_master_bus()` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)