### PR TITLE
raspberrypi: make tusb_time_millis_api RAM-resident; core1 calls it

### DIFF
--- a/ports/raspberrypi/supervisor/usb.c
+++ b/ports/raspberrypi/supervisor/usb.c
@@ -6,12 +6,28 @@
 
 #include "lib/tinyusb/src/device/usbd.h"
 #include "supervisor/background_callback.h"
+#include "supervisor/linker.h"
 #include "supervisor/usb.h"
 #include "hardware/irq.h"
+#include "hardware/timer.h"
 #include "pico/platform.h"
 #include "hardware/regs/intctrl.h"
 
 void init_usb_hardware(void) {
+}
+
+// Override the shared implementation with one that is safe to call from core1.
+// TinyUSB's tuh_task_event_ready() calls this, and usb_host polls
+// tuh_task_event_ready() from core1's PIO-USB frame loop (see
+// common-hal/usb_host/Port.c). tuh_task_event_ready() is deliberately placed in
+// RAM by link-rp2*.ld, and everything it calls must be RAM-resident too: on
+// RP2350, core1 sets an MPU region that makes flash execute-never, and on
+// RP2040 flash may be unavailable while core0 writes to it. time_us_32() is a
+// static-inline register read. >>10 yields ~1.024 ms units rather than exact
+// milliseconds, which is fine because TinyUSB only uses this API for relative
+// delay arithmetic and every use goes through this same function.
+uint32_t PLACE_IN_ITCM(tusb_time_millis_api)(void) {
+    return time_us_32() >> 10;
 }
 
 static void _usb_irq_wrapper(void) {

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -184,7 +184,10 @@ void usb_background(void) {
     }
 }
 
-uint32_t tusb_time_millis_api(void) {
+// Ports may override this with a RAM-resident version when TinyUSB code that
+// calls it must not execute from flash (e.g. raspberrypi polls
+// tuh_task_event_ready(), which calls this, from core1).
+MP_WEAK uint32_t tusb_time_millis_api(void) {
     return supervisor_ticks_ms32();
 }
 


### PR DESCRIPTION
Fixes the USB host regression from #11093, reported in #10243. Fixes #10243.

On RP2 boards, core1 drives the PIO-USB host and must only run code that lives in RAM, never flash. The TinyUSB update ([hathach/tinyusb@3a262cb6e](https://github.com/hathach/tinyusb/commit/3a262cb6ea8b070bd2fb6e32d2f754315077bd42), from [#3566](https://github.com/hathach/tinyusb/pull/3566)) made core1 ask "what time is it?" via `tusb_time_millis_api()` and that function lived in flash. Core1 crashed at the first device attach, so no USB host device was ever detected.

Fix: move `tusb_time_millis_api()` into RAM for this port (weak shared default, `PLACE_IN_ITCM` override reading the timer directly).

Tested on Feather RP2040 USB Host and Fruit Jam with a flash drive: never detected on main, enumerates immediately with this change. TinyUSB submodule unchanged.