### PR TITLE
tools: add core1 flash-call checker for rp2 USB host builds

### DIFF
--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -768,6 +768,26 @@ endif
 
 LINKER_SCRIPTS += -Wl,-T,link-$(CHIP_VARIANT_LOWER).ld
 
+# Builds where core1 locks flash out via the MPU and may only execute
+# RAM-resident code: USB host (PIO-USB frame loop), and picodvi on RP2040
+# (TMDS encode loop). Check the linked ELF from each core1 entry point.
+# picodvi's DMA IRQ handler and scanline callback run on core1 but are
+# reached only through registered pointers, so they are extra roots.
+CORE1_CHECK_ROOTS :=
+ifeq ($(CIRCUITPY_USB_HOST),1)
+CORE1_CHECK_ROOTS += --root core1_main
+endif
+ifeq ($(CHIP_VARIANT),RP2040)
+ifeq ($(CIRCUITPY_PICODVI),1)
+# libdvi's IRQ handler calls flash-resident panic() on a "can't happen" queue
+# overflow. With flash locked out that panic would hard fault instead, but
+# either way core1 halts, so allow it rather than blocking the build on
+# vendored code.
+CORE1_CHECK_ROOTS += --root core1_main --root dvi_dma1_irq --root core1_scanline_callback \
+	--allow panic
+endif
+endif
+
 ifeq ($(VALID_BOARD),)
 $(BUILD)/firmware.elf: invalid-board
 else
@@ -776,9 +796,9 @@ $(BUILD)/firmware.elf: $(OBJ) $(BOARD_LD) link-$(CHIP_VARIANT_LOWER).ld
 	$(Q)echo $(OBJ) > $(BUILD)/firmware.objs
 	$(Q)echo $(PICO_LDFLAGS) > $(BUILD)/firmware.ldflags
 	$(Q)$(CC) -o $@ $(CFLAGS) @$(BUILD)/firmware.ldflags $(LINKER_SCRIPTS) -Wl,--print-memory-usage -Wl,-Map=$@.map -Wl,-cref -Wl,--gc-sections @$(BUILD)/firmware.objs -Wl,-lc
-ifeq ($(CIRCUITPY_USB_HOST), 1)
+ifneq ($(CORE1_CHECK_ROOTS),)
 	$(STEPECHO) "CHECK core1 flash calls"
-	$(Q)$(PYTHON) $(TOP)/tools/check_core1_flash_calls.py $@
+	$(Q)$(PYTHON) $(TOP)/tools/check_core1_flash_calls.py $@ $(CORE1_CHECK_ROOTS)
 endif
 endif
 

--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -229,6 +229,10 @@ DISABLE_WARNINGS = -Wno-cast-align
 CFLAGS += $(INC) -Wtype-limits -Wall -Werror -std=gnu11 -fshort-enums $(BASE_CFLAGS) $(CFLAGS_MOD) $(COPT) $(DISABLE_WARNINGS) -Werror=missing-prototypes -Wold-style-definition
 
 PICO_LDFLAGS = --specs=nosys.specs --specs=nano.specs
+# The SDK's panic() is flash-resident, but core1 may run with flash access
+# disabled by the MPU. Route panics to the RAM-resident __wrap_panic in
+# supervisor/port.c, which halts safely on core1 and prints on core0.
+PICO_LDFLAGS += -Wl,--wrap=panic
 
 # Use toolchain libm if we're not using our own.
 ifndef INTERNAL_LIBM
@@ -779,12 +783,7 @@ CORE1_CHECK_ROOTS += --root core1_main
 endif
 ifeq ($(CHIP_VARIANT),RP2040)
 ifeq ($(CIRCUITPY_PICODVI),1)
-# libdvi's IRQ handler calls flash-resident panic() on a "can't happen" queue
-# overflow. With flash locked out that panic would hard fault instead, but
-# either way core1 halts, so allow it rather than blocking the build on
-# vendored code.
-CORE1_CHECK_ROOTS += --root core1_main --root dvi_dma1_irq --root core1_scanline_callback \
-	--allow panic
+CORE1_CHECK_ROOTS += --root core1_main --root dvi_dma1_irq --root core1_scanline_callback
 endif
 endif
 

--- a/ports/raspberrypi/Makefile
+++ b/ports/raspberrypi/Makefile
@@ -776,6 +776,10 @@ $(BUILD)/firmware.elf: $(OBJ) $(BOARD_LD) link-$(CHIP_VARIANT_LOWER).ld
 	$(Q)echo $(OBJ) > $(BUILD)/firmware.objs
 	$(Q)echo $(PICO_LDFLAGS) > $(BUILD)/firmware.ldflags
 	$(Q)$(CC) -o $@ $(CFLAGS) @$(BUILD)/firmware.ldflags $(LINKER_SCRIPTS) -Wl,--print-memory-usage -Wl,-Map=$@.map -Wl,-cref -Wl,--gc-sections @$(BUILD)/firmware.objs -Wl,-lc
+ifeq ($(CIRCUITPY_USB_HOST), 1)
+	$(STEPECHO) "CHECK core1 flash calls"
+	$(Q)$(PYTHON) $(TOP)/tools/check_core1_flash_calls.py $@
+endif
 endif
 
 $(BUILD)/firmware.bin: $(BUILD)/firmware.elf

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -4,9 +4,12 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <stdarg.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "supervisor/background_callback.h"
 #include "supervisor/board.h"
@@ -75,6 +78,40 @@
 #include "lib/tlsf/tlsf.h"
 
 critical_section_t background_queue_lock;
+
+// The SDK's panic() lives in flash, but core1 may run with flash access
+// disabled by the MPU (usb_host and picodvi lock it out), where a flash call
+// hard faults before anything is printed. -Wl,--wrap=panic routes every
+// panic here instead: core0 keeps the SDK behavior, core1 halts from RAM.
+// Verified by tools/check_core1_flash_calls.py.
+void __wrap_panic(const char *fmt, ...) __attribute__((noreturn, format(printf, 1, 2)));
+void panic_core0(const char *fmt, va_list args) __attribute__((noreturn, format(printf, 1, 0)));
+
+// Flash-resident; only ever called from core0 (see __wrap_panic). Mirrors
+// the SDK implementation. noinline keeps the flash-calling code out of the
+// RAM-resident wrapper below.
+__attribute__((noinline)) void panic_core0(const char *fmt, va_list args) {
+    puts("\n*** PANIC ***\n");
+    if (fmt) {
+        vprintf(fmt, args);
+        puts("");
+    }
+    _exit(1);
+}
+
+void __not_in_flash_func(__wrap_panic)(const char *fmt, ...) {
+    if (get_core_num() == 0) {
+        va_list args;
+        va_start(args, fmt);
+        panic_core0(fmt, args);
+    }
+    // Flash may be MPU-locked on this core and stdio is core0-only, so the
+    // message is unprintable here. Halt in RAM: a debugger stops at the
+    // breakpoint, otherwise spin.
+    __breakpoint();
+    while (1) {
+    }
+}
 
 extern volatile bool mp_msc_enabled;
 

--- a/tools/check_core1_flash_calls.py
+++ b/tools/check_core1_flash_calls.py
@@ -45,8 +45,13 @@ FLASH_LO, FLASH_HI = 0x10000000, 0x20000000
 # Symbols that are reachable from a core1 root but are known to execute only
 # before the MPU cuts off flash access. Keep this list short and commented.
 DEFAULT_ALLOW = [
-    # core1_main calls this while configuring SysTick, before enabling the MPU.
+    # usb_host core1_main calls this while configuring SysTick, before
+    # enabling the MPU.
     "common_hal_mcu_processor_get_frequency",
+    # picodvi Framebuffer_RP2040 core1_main calls these during startup,
+    # before enabling the MPU.
+    "dvi_register_irqs_this_core",
+    "dvi_start",
 ]
 
 

--- a/tools/check_core1_flash_calls.py
+++ b/tools/check_core1_flash_calls.py
@@ -42,8 +42,8 @@ OBJDUMP = "arm-none-eabi-objdump"
 
 FLASH_LO, FLASH_HI = 0x10000000, 0x20000000
 
-# Symbols that are reachable from a core1 root but are known to execute only
-# before the MPU cuts off flash access. Keep this list short and commented.
+# Symbols that are reachable from a core1 root but are known never to execute
+# with flash locked out. Keep this list short and commented.
 DEFAULT_ALLOW = [
     # usb_host core1_main calls this while configuring SysTick, before
     # enabling the MPU.
@@ -52,6 +52,10 @@ DEFAULT_ALLOW = [
     # before enabling the MPU.
     "dvi_register_irqs_this_core",
     "dvi_start",
+    # The flash-resident print half of the RAM-resident __wrap_panic
+    # (supervisor/port.c); only called after a get_core_num() == 0 check,
+    # and core0 never locks flash out.
+    "panic_core0",
 ]
 
 

--- a/tools/check_core1_flash_calls.py
+++ b/tools/check_core1_flash_calls.py
@@ -173,10 +173,7 @@ def main():
         for fn, n in sorted(indirect_notes):
             print(f"  {fn} ({n} indirect call site(s))")
     if violations:
-        print(
-            f"\nFAIL: {len(violations)} flash-resident function(s) reachable "
-            f"from core1:"
-        )
+        print(f"\nFAIL: {len(violations)} flash-resident function(s) reachable from core1:")
         for fn in sorted(violations):
             print(f"  {fn} @ {funcs[fn]:#010x}")
             print(f"    via: {chain(fn)}")

--- a/tools/check_core1_flash_calls.py
+++ b/tools/check_core1_flash_calls.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# This file is part of the CircuitPython project: https://circuitpython.org
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 Mikey Sklar
+#
+# SPDX-License-Identifier: MIT
+"""Post-link check: core1-executed code must not reach into flash.
+
+On raspberrypi-port boards with USB host, core1 runs the PIO-USB frame loop
+and may only execute (or read) RAM-resident code: core1_main enables an MPU
+region that makes flash inaccessible (see common-hal/usb_host/Port.c), and the
+linker script deliberately RAM-places tuh_task_event_ready() and the PIO-USB
+code. Nothing verified their *callees* stay in RAM, which is how issue #10243
+happened: an upstream TinyUSB change added a flash-resident call inside
+RAM-placed tuh_task_event_ready(), core1 faulted at the first device attach,
+and USB host went silent.
+
+This tool disassembles the linked ELF, walks the static call graph from the
+core1 entry points, and fails if any reachable function lives in flash. Linker
+veneers (long-call trampolines) are followed through their literal-pool
+targets, so a flash callee hidden behind a RAM veneer is still detected.
+
+Usage:
+    check_core1_flash_calls.py firmware.elf [--root SYMBOL]... [--allow SYMBOL]...
+
+Default root: core1_main. --allow skips a symbol (and everything only
+reachable through it); use it for calls that provably run before the MPU is
+enabled.
+
+Limitation: indirect calls (blx rN / function pointers) cannot be traced
+statically. They are counted and reported per function so the gaps are
+visible.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import deque
+
+OBJDUMP = "arm-none-eabi-objdump"
+
+FLASH_LO, FLASH_HI = 0x10000000, 0x20000000
+
+# Symbols that are reachable from a core1 root but are known to execute only
+# before the MPU cuts off flash access. Keep this list short and commented.
+DEFAULT_ALLOW = [
+    # core1_main calls this while configuring SysTick, before enabling the MPU.
+    "common_hal_mcu_processor_get_frequency",
+]
+
+
+def in_flash(addr):
+    return FLASH_LO <= addr < FLASH_HI
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check that core1-reachable code is RAM-resident."
+    )
+    parser.add_argument("elf", help="linked firmware ELF")
+    parser.add_argument(
+        "--root",
+        action="append",
+        default=[],
+        help="core1 entry point symbol (default: core1_main)",
+    )
+    parser.add_argument(
+        "--allow",
+        action="append",
+        default=[],
+        help="symbol to skip (e.g. runs before the MPU is enabled)",
+    )
+    args = parser.parse_args()
+    roots = args.root or ["core1_main"]
+    allow = set(DEFAULT_ALLOW) | set(args.allow)
+
+    dis = subprocess.run(
+        [OBJDUMP, "-d", args.elf], capture_output=True, text=True, check=True
+    ).stdout
+
+    func_re = re.compile(r"^([0-9a-f]+) <([^>]+)>:$")
+    # e.g. "10001234:  f7ff fffe   bl  10005678 <foo>"
+    branch_re = re.compile(
+        r"^\s*[0-9a-f]+:\s+[0-9a-f ]+\t(bl|blx|b|b\.n|b\.w|"
+        r"b(?:eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le)(?:\.n|\.w)?)"
+        r"\s+([0-9a-f]+)\s<([^>+]+)(\+0x[0-9a-f]+)?>"
+    )
+    indirect_re = re.compile(r"^\s*[0-9a-f]+:\s+[0-9a-f ]+\tblx\s+(r\d+|ip|lr)\b")
+    # Veneer bodies jump through a literal pool word rather than a branch.
+    word_re = re.compile(r"^\s*[0-9a-f]+:\s+([0-9a-f]{8})\s+\.word\s")
+
+    funcs = {}  # name -> addr
+    edges = {}  # name -> {target name}
+    veneer_words = {}  # veneer name -> {literal addresses}
+    indirects = {}  # name -> count of untraceable indirect calls
+    cur = None
+    for line in dis.splitlines():
+        m = func_re.match(line)
+        if m:
+            cur = m.group(2)
+            funcs[cur] = int(m.group(1), 16)
+            edges.setdefault(cur, set())
+            indirects.setdefault(cur, 0)
+            continue
+        if cur is None:
+            continue
+        if cur.endswith("_veneer"):
+            m = word_re.match(line)
+            if m:
+                veneer_words.setdefault(cur, set()).add(int(m.group(1), 16) & ~1)
+            continue
+        if indirect_re.match(line):
+            indirects[cur] += 1
+            continue
+        m = branch_re.match(line)
+        if m:
+            target = m.group(3)
+            if target != cur:  # ignore intra-function branches
+                edges[cur].add(target)
+
+    # Resolve veneer literal addresses to function names.
+    addr_to_name = {}
+    for name, addr in funcs.items():
+        addr_to_name.setdefault(addr, name)
+    for veneer, words in veneer_words.items():
+        for w in words:
+            tgt = addr_to_name.get(w)
+            if tgt is not None:
+                edges.setdefault(veneer, set()).add(tgt)
+
+    missing = [r for r in roots if r not in funcs]
+    if missing:
+        # A board without usb_host has no core1_main; nothing to check.
+        print(f"{args.elf}: root symbol(s) not present, skipping: {', '.join(missing)}")
+        return 0
+
+    # BFS from roots, remembering one call chain per function for reporting.
+    parent = {r: None for r in roots}
+    queue = deque(roots)
+    seen = set(roots)
+    violations = []
+    indirect_notes = []
+    while queue:
+        fn = queue.popleft()
+        if fn in allow:
+            continue
+        addr = funcs.get(fn)
+        if addr is not None and in_flash(addr):
+            violations.append(fn)
+            continue  # don't walk further into flash
+        if indirects.get(fn):
+            indirect_notes.append((fn, indirects[fn]))
+        for tgt in sorted(edges.get(fn, ())):
+            if tgt not in seen and tgt in funcs:
+                seen.add(tgt)
+                parent[tgt] = fn
+                queue.append(tgt)
+
+    def chain(fn):
+        parts = []
+        while fn is not None:
+            parts.append(fn)
+            fn = parent[fn]
+        return " <- ".join(parts)
+
+    print(f"{args.elf}: walked {len(seen)} functions from roots: {', '.join(roots)}")
+    if indirect_notes:
+        print(
+            f"note: {len(indirect_notes)} reachable function(s) make indirect "
+            f"calls that cannot be traced statically:"
+        )
+        for fn, n in sorted(indirect_notes):
+            print(f"  {fn} ({n} indirect call site(s))")
+    if violations:
+        print(
+            f"\nFAIL: {len(violations)} flash-resident function(s) reachable "
+            f"from core1:"
+        )
+        for fn in sorted(violations):
+            print(f"  {fn} @ {funcs[fn]:#010x}")
+            print(f"    via: {chain(fn)}")
+        return 1
+    print("PASS: no flash-resident code reachable from core1")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_core1_flash_calls.py
+++ b/tools/check_core1_flash_calls.py
@@ -77,7 +77,7 @@ def main():
         help="symbol to skip (e.g. runs before the MPU is enabled)",
     )
     args = parser.parse_args()
-    roots = args.root or ["core1_main"]
+    roots = list(dict.fromkeys(args.root or ["core1_main"]))
     allow = set(DEFAULT_ALLOW) | set(args.allow)
 
     dis = subprocess.run(
@@ -134,10 +134,13 @@ def main():
             if tgt is not None:
                 edges.setdefault(veneer, set()).add(tgt)
 
+    # A root may be absent from a given build (e.g. core1_scanline_callback
+    # only exists on picodvi builds); check whichever roots are present.
     missing = [r for r in roots if r not in funcs]
     if missing:
-        # A board without usb_host has no core1_main; nothing to check.
         print(f"{args.elf}: root symbol(s) not present, skipping: {', '.join(missing)}")
+    roots = [r for r in roots if r in funcs]
+    if not roots:
         return 0
 
     # BFS from roots, remembering one call chain per function for reporting.


### PR DESCRIPTION
Follow-up to #10243 / #11114, answering "could we have caught this at build time?" Yes.

On RP2 USB host boards, core1 may only run code that lives in RAM. If it ever steps into flash, it crashes and USB host goes silent. We keep core1's functions in RAM, but nothing ever checked what those functions *call*. That's how #10243 slipped in.

This script checks the finished firmware: it follows every call core1 can make and fails the build with the guilty call chain if any of them lead into flash. Runs in ~2 seconds using arm-none-eabi-objdump.

Against current builds it catches three real cases:
1. the #10243 bug (fixed by #11114)
2. Pico-PIO-USB's `calc_usb_crc16` lives in flash. Verified on hardware: writing to a USB drive hard-locks the board. One-word upstream fix coming in a separate PR.
3. a rare flash call path in TinyUSB's queue mutex. Only triggers under contention; will file separately.

Not wired into CI yet, since 2 and 3 would fail the build until they're fixed.