### PR TITLE
raspberrypi: wake core 0 from idle when core 1 posts USB host events

### DIFF
--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -13,6 +13,7 @@
 
 #include "supervisor/background_callback.h"
 #include "supervisor/board.h"
+#include "supervisor/linker.h"
 #include "supervisor/port.h"
 
 #include "bindings/rp2pio/StateMachine.h"
@@ -45,6 +46,7 @@
 #include "supervisor/shared/stack.h"
 #include "supervisor/shared/tick.h"
 
+#include "hardware/structs/scb.h"
 #include "hardware/structs/watchdog.h"
 #include "hardware/gpio.h"
 #include "hardware/uart.h"
@@ -421,6 +423,16 @@ safe_mode_t port_init(void) {
     common_hal_rtc_init();
     #endif
 
+    // Send-event-on-pend, so the WFE in port_idle_until_interrupt wakes on a
+    // pending interrupt (as WFI did) in addition to waking on SEV — including
+    // the SEV core 1 sends via port_wake_main_task() when it queues USB host
+    // work.
+    #if PICO_RP2040
+    scb_hw->scr |= M0PLUS_SCR_SEVONPEND_BITS;
+    #else
+    scb_hw->scr |= M33_SCR_SEVONPEND_BITS;
+    #endif
+
     // For the tick.
     hardware_alarm_claim(0);
     hardware_alarm_set_callback(0, _tick_callback);
@@ -600,7 +612,11 @@ void port_idle_until_interrupt(void) {
     if (!background_callback_pending() && !tud_task_event_ready() && !_woken_up) {
         #endif
         __DSB();
-        __WFI();
+        // WFE, not WFI: the event register is sticky, so a SEV from core 1
+        // (port_wake_main_task, e.g. a USB host event) that lands between the
+        // checks above and here still terminates the wait. Pending interrupts
+        // wake it too, via SEVONPEND (set in port_init).
+        __wfe();
     }
     common_hal_mcu_enable_interrupts();
     #else
@@ -619,7 +635,8 @@ void port_idle_until_interrupt(void) {
     if (!background_callback_pending() && !tud_task_event_ready() && !_woken_up) {
         #endif
         __DSB();
-        __WFI();
+        // WFE, not WFI: see the RP2040 branch above.
+        __wfe();
     }
 
     // and restore basepri before reenabling interrupts
@@ -628,6 +645,20 @@ void port_idle_until_interrupt(void) {
 
     restore_interrupts(state);
     #endif
+}
+
+// Called whenever a background callback is queued, including from core 1
+// (which runs the PIO-USB host and posts its events here). SEV is broadcast
+// to both cores and latches in the event register, so it reliably ends the
+// WFE in port_idle_until_interrupt even if it arrives before the WFE starts.
+// Without this, core 0 sleeps through host events for the remainder of a
+// time.sleep(): device removal processing and enumeration stall until the
+// next unrelated wakeup.
+// PLACE_IN_ITCM: core 1 runs with flash execute-never, so this must live in
+// RAM like its background_callback_add_core caller (__sev inlines to a bare
+// instruction).
+void PLACE_IN_ITCM(port_wake_main_task)(void) {
+    __sev();
 }
 
 /**


### PR DESCRIPTION
On rp2, the TinyUSB host task only runs when core 0 drains the background callback queue. The PIO USB host runs on core 1 and posts its events there, but `port_wake_main_task()` was a no-op, so core 1 could not wake core 0 out of the WFI in `port_idle_until_interrupt()`. While a program is in `time.sleep()`, core 0 stays parked in that WFI for the whole sleep, so host events never get serviced. A device plugged in while a program sleeps can fail to enumerate at all.

Implement `port_wake_main_task()` as SEV and idle with WFE instead of WFI, so core 1 can wake core 0. SEVONPEND keeps the old wake on pending interrupt behavior. It lives in shared `port.c`, so it covers both rp2040 and rp2350. 12 lines of code.

Start this with nothing in the host port, then hot-plug a USB device while it runs:

```python
import time
import usb.core

print("plug a device into the host port now")
while True:
    devices = list(usb.core.find(find_all=True))
    if devices:
        print("enumerated:", devices[0].product)
        break
    time.sleep(0.5)
```

On the current main it never prints `enumerated`, the device never shows up while the program sleeps (over 50 seconds):

With this PR it enumerates within one loop iteration:

```
plug a device into the host port now
enumerated: Macropad RP2040
```

Confirmed on a Fruit Jam (RP2350) and a Feather RP2040 USB Host (RP2040).
