### PR TITLE
lower tx_power to 15 for boards with chip antennas

### DIFF
--- a/ports/espressif/boards/adafruit_qtpy_esp32_pico/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32_pico/mpconfigboard.h
@@ -26,3 +26,6 @@
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)
 #define CIRCUITPY_CONSOLE_UART_RX (&pin_GPIO3)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/adafruit_qtpy_esp32s2/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s2/mpconfigboard.h
@@ -25,3 +25,6 @@
 #define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO5, .rx = &pin_GPIO16}}
 
 #define DOUBLE_TAP_PIN (&pin_GPIO10)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/atmegazero_esp32s2/mpconfigboard.h
+++ b/ports/espressif/boards/atmegazero_esp32s2/mpconfigboard.h
@@ -22,3 +22,6 @@
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
 
 #define MICROPY_HW_NEOPIXEL (&pin_GPIO40)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/cezerio_dev_ESP32C6/mpconfigboard.h
+++ b/ports/espressif/boards/cezerio_dev_ESP32C6/mpconfigboard.h
@@ -25,3 +25,6 @@
 
 // For entering safe mode, use BOOT button
 #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO9)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/circuitart_zero_s3/mpconfigboard.h
+++ b/ports/espressif/boards/circuitart_zero_s3/mpconfigboard.h
@@ -32,3 +32,6 @@
 #define DEFAULT_TFT_CS (&pin_GPIO39)
 #define DEFAULT_TFT_DC (&pin_GPIO5)
 #define DEFAULT_TFT_RST (&pin_GPIO40)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/lilygo_tdongle_s3/mpconfigboard.h
+++ b/ports/espressif/boards/lilygo_tdongle_s3/mpconfigboard.h
@@ -16,3 +16,6 @@
 
 #define DEFAULT_I2C_BUS_SCL  (&pin_GPIO44)
 #define DEFAULT_I2C_BUS_SDA  (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/lilygo_ttgo_t-oi-plus/mpconfigboard.h
+++ b/ports/espressif/boards/lilygo_ttgo_t-oi-plus/mpconfigboard.h
@@ -16,3 +16,6 @@
 
 #define CIRCUITPY_CONSOLE_UART_RX     DEFAULT_UART_BUS_RX
 #define CIRCUITPY_CONSOLE_UART_TX     DEFAULT_UART_BUS_TX
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/lolin_c3_pico/mpconfigboard.h
+++ b/ports/espressif/boards/lolin_c3_pico/mpconfigboard.h
@@ -26,3 +26,6 @@
 
 #define CIRCUITPY_BOARD_UART        (1)
 #define CIRCUITPY_BOARD_UART_PIN    {{.tx = &pin_GPIO21, .rx = &pin_GPIO20}}
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/lolin_s3_mini_pro/mpconfigboard.h
+++ b/ports/espressif/boards/lolin_s3_mini_pro/mpconfigboard.h
@@ -22,3 +22,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/makergo_esp32c6_supermini/mpconfigboard.h
+++ b/ports/espressif/boards/makergo_esp32c6_supermini/mpconfigboard.h
@@ -17,3 +17,6 @@
 // Default bus pins
 #define DEFAULT_UART_BUS_TX         (&pin_GPIO17)
 #define DEFAULT_UART_BUS_RX         (&pin_GPIO16)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/microdev_micro_s2/mpconfigboard.h
+++ b/ports/espressif/boards/microdev_micro_s2/mpconfigboard.h
@@ -25,3 +25,6 @@
 
 #define DEFAULT_UART_BUS_TX         (&pin_GPIO43)
 #define DEFAULT_UART_BUS_RX         (&pin_GPIO44)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/seeed_xiao_esp32c6/mpconfigboard.h
+++ b/ports/espressif/boards/seeed_xiao_esp32c6/mpconfigboard.h
@@ -17,3 +17,6 @@
 
 // For entering safe mode, use BOOT button
 #define CIRCUITPY_BOOT_BUTTON       (&pin_GPIO9)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_bling/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_bling/mpconfigboard.h
@@ -25,3 +25,6 @@
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
 
 #define DOUBLE_TAP_PIN (&pin_GPIO47)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_blizzard_s3/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_blizzard_s3/mpconfigboard.h
@@ -25,3 +25,6 @@
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
 
 #define DOUBLE_TAP_PIN (&pin_GPIO47)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_edges3d/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_edges3d/mpconfigboard.h
@@ -21,3 +21,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_feathers2/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_feathers2/mpconfigboard.h
@@ -25,3 +25,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_feathers2_neo/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_feathers2_neo/mpconfigboard.h
@@ -25,3 +25,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_feathers2_prerelease/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_feathers2_prerelease/mpconfigboard.h
@@ -25,3 +25,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_feathers3/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_feathers3/mpconfigboard.h
@@ -28,3 +28,6 @@
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
 
 #define DOUBLE_TAP_PIN (&pin_GPIO47)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_feathers3_neo/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_feathers3_neo/mpconfigboard.h
@@ -27,3 +27,6 @@
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
 
 // #define DOUBLE_TAP_PIN (&pin_GPIO47)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_nanos3/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_nanos3/mpconfigboard.h
@@ -23,3 +23,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_omgs3/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_omgs3/mpconfigboard.h
@@ -24,3 +24,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_pros3/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_pros3/mpconfigboard.h
@@ -25,3 +25,6 @@
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
 
 #define DOUBLE_TAP_PIN (&pin_GPIO47)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_rgbtouch_mini/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_rgbtouch_mini/mpconfigboard.h
@@ -17,3 +17,6 @@
 
 #define DEFAULT_I2C_BUS_SCL (&pin_GPIO9)
 #define DEFAULT_I2C_BUS_SDA (&pin_GPIO8)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_tinyc6/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_tinyc6/mpconfigboard.h
@@ -23,3 +23,6 @@
 
 #define DEFAULT_UART_BUS_RX         (&pin_GPIO17)
 #define DEFAULT_UART_BUS_TX         (&pin_GPIO16)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_tinypico/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_tinypico/mpconfigboard.h
@@ -18,3 +18,6 @@
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)
 #define CIRCUITPY_CONSOLE_UART_RX (&pin_GPIO3)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_tinypico_nano/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_tinypico_nano/mpconfigboard.h
@@ -18,3 +18,6 @@
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)
 #define CIRCUITPY_CONSOLE_UART_RX (&pin_GPIO3)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_tinys2/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_tinys2/mpconfigboard.h
@@ -23,3 +23,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_tinys3/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_tinys3/mpconfigboard.h
@@ -25,3 +25,6 @@
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
 
 #define DOUBLE_TAP_PIN (&pin_GPIO47)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/unexpectedmaker_tinywatch_s3/mpconfigboard.h
+++ b/ports/espressif/boards/unexpectedmaker_tinywatch_s3/mpconfigboard.h
@@ -21,3 +21,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_c6_lcd_1_47/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_c6_lcd_1_47/mpconfigboard.h
@@ -31,3 +31,6 @@
 
 // Explanation of how a user got into safe mode
 #define BOARD_USER_SAFE_MODE_ACTION MP_ERROR_TEXT("You pressed the BOOT button at start up.")
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/mpconfigboard.h
@@ -20,3 +20,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_amoled_241/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_amoled_241/mpconfigboard.h
@@ -32,3 +32,6 @@
 // Default UART bus
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_eth/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_eth/mpconfigboard.h
@@ -15,3 +15,6 @@
 
 #define DEFAULT_UART_BUS_RX         (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX         (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_geek/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_geek/mpconfigboard.h
@@ -20,3 +20,6 @@
 #define CIRCUITPY_BOARD_SPI         (2)
 #define CIRCUITPY_BOARD_SPI_PIN     {{.clock = &pin_GPIO12, .mosi = &pin_GPIO11}, \
                                      {.clock = &pin_GPIO36, .mosi = &pin_GPIO35, .miso = &pin_GPIO37}}
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_lcd_1_28/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_lcd_1_28/mpconfigboard.h
@@ -23,3 +23,6 @@
 
 #define CIRCUITPY_CONSOLE_UART_RX DEFAULT_UART_BUS_RX
 #define CIRCUITPY_CONSOLE_UART_TX DEFAULT_UART_BUS_TX
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_lcd_1_47/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_lcd_1_47/mpconfigboard.h
@@ -20,3 +20,6 @@
 #define CIRCUITPY_BOARD_SPI         (2)
 #define CIRCUITPY_BOARD_SPI_PIN     {{.clock = &pin_GPIO40, .mosi = &pin_GPIO45}, \
                                      {.clock = &pin_GPIO14, .mosi = &pin_GPIO15, .miso = &pin_GPIO16}}
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_matrix/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_matrix/mpconfigboard.h
@@ -13,3 +13,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_pico/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_pico/mpconfigboard.h
@@ -23,3 +23,6 @@
 #define DEFAULT_SPI_BUS_SCK (&pin_GPIO36)
 #define DEFAULT_SPI_BUS_MOSI (&pin_GPIO35)
 #define DEFAULT_SPI_BUS_MISO (&pin_GPIO37)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_tiny/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_tiny/mpconfigboard.h
@@ -17,3 +17,6 @@
 
 #define DEFAULT_UART_BUS_RX         (&pin_GPIO19)
 #define DEFAULT_UART_BUS_TX         (&pin_GPIO20)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_tiny_n8r8/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_tiny_n8r8/mpconfigboard.h
@@ -17,3 +17,6 @@
 
 #define DEFAULT_UART_BUS_RX         (&pin_GPIO19)
 #define DEFAULT_UART_BUS_TX         (&pin_GPIO20)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_touch_lcd_1_47/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_touch_lcd_1_47/mpconfigboard.h
@@ -20,3 +20,6 @@
 #define CIRCUITPY_BOARD_SPI         (2)
 #define CIRCUITPY_BOARD_SPI_PIN     {{.clock = &pin_GPIO38, .mosi = &pin_GPIO39}, /* for LCD display */ \
                                      {.clock = &pin_GPIO16, .mosi = &pin_GPIO15, .miso = &pin_GPIO17} /* for SD Card */}
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_touch_lcd_2/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_touch_lcd_2/mpconfigboard.h
@@ -17,3 +17,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_touch_lcd_2_8/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_touch_lcd_2_8/mpconfigboard.h
@@ -17,3 +17,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32_s3_zero/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_zero/mpconfigboard.h
@@ -16,3 +16,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/waveshare_esp32s2_pico/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32s2_pico/mpconfigboard.h
@@ -23,3 +23,6 @@
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO44)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO43)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)

--- a/ports/espressif/boards/wemos_lolin32_lite/mpconfigboard.h
+++ b/ports/espressif/boards/wemos_lolin32_lite/mpconfigboard.h
@@ -20,3 +20,6 @@
 // UART pins attached to the USB-serial converter chip
 #define CIRCUITPY_CONSOLE_UART_TX (&pin_GPIO1)
 #define CIRCUITPY_CONSOLE_UART_RX (&pin_GPIO3)
+
+// Reduce wifi.radio.tx_power due to the antenna design of this board
+#define CIRCUITPY_WIFI_DEFAULT_TX_POWER   (15)


### PR DESCRIPTION
- Fixes #11071 

I went through all the boards in circuitpython.org that looked like they might have chip antennas based on their pictures (or lack of evidence contrary in their pictures, and tracked down whether they really did. Those boards had their default `tx_power` set to 15 dBm instead of the default 20. A few were already set, and one was already set to 11 dBm, which I left alone.

I can't see the pass I did was perfect, but I think I got all or nearly all.

Interesetingly, may of the M5Stack boards use a slot metal antenna which is compact but not a chip antenna. I left those alone.

I have asked @UnexpectedMaker if this value makes sense for his boards, all of which seem to use chip antennas. This PR is draft until then.