### PR TITLE
Validate sample with audiosample_check() in all audio play paths

### DIFF
--- a/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
+++ b/ports/atmel-samd/common-hal/audiobusio/I2SOut.c
@@ -211,6 +211,9 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t *self,
     if (common_hal_audiobusio_i2sout_get_playing(self)) {
         common_hal_audiobusio_i2sout_stop(self);
     }
+
+    audiosample_check(sample);
+
     #ifdef SAMD21
     if ((I2S->CTRLA.vec.CKEN & (1 << self->clock_unit)) == 1) {
         mp_raise_RuntimeError(MP_ERROR_TEXT("Clock unit in use"));

--- a/ports/atmel-samd/common-hal/audioio/AudioOut.c
+++ b/ports/atmel-samd/common-hal/audioio/AudioOut.c
@@ -331,6 +331,9 @@ void common_hal_audioio_audioout_play(audioio_audioout_obj_t *self,
     if (common_hal_audioio_audioout_get_playing(self)) {
         common_hal_audioio_audioout_stop(self);
     }
+
+    audiosample_check(sample);
+
     audio_dma_result result = AUDIO_DMA_OK;
     uint32_t sample_rate = audiosample_get_sample_rate(sample);
     #ifdef SAMD21

--- a/ports/espressif/common-hal/audiobusio/__init__.c
+++ b/ports/espressif/common-hal/audiobusio/__init__.c
@@ -157,6 +157,7 @@ void port_i2s_deinit(i2s_t *self) {
 }
 
 void port_i2s_play(i2s_t *self, mp_obj_t sample, bool loop) {
+    audiosample_check(sample);
     // Pause to disable the I2S channel so we can adjust the clock.
     port_i2s_pause(self);
     self->sample = sample;

--- a/ports/espressif/common-hal/audioio/AudioOut.c
+++ b/ports/espressif/common-hal/audioio/AudioOut.c
@@ -573,6 +573,8 @@ void common_hal_audioio_audioout_play(audioio_audioout_obj_t *self,
         mp_raise_RuntimeError(MP_ERROR_TEXT("already playing"));
     }
 
+    audiosample_check(sample);
+
     size_t samples_size;
     uint8_t channel_count;
     bool samples_signed;

--- a/ports/mimxrt10xx/common-hal/audiobusio/__init__.c
+++ b/ports/mimxrt10xx/common-hal/audiobusio/__init__.c
@@ -372,6 +372,7 @@ static void set_sai_clocking_for_sample_rate(uint32_t sample_rate) {
 }
 
 void port_i2s_play(i2s_t *self, mp_obj_t sample, bool loop) {
+    audiosample_check(sample);
     self->sample = sample;
     self->loop = loop;
     self->bytes_per_sample = audiosample_get_bits_per_sample(sample) / 8;

--- a/ports/nordic/common-hal/audiobusio/I2SOut.c
+++ b/ports/nordic/common-hal/audiobusio/I2SOut.c
@@ -245,6 +245,8 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t *self,
         common_hal_audiobusio_i2sout_stop(self);
     }
 
+    audiosample_check(sample);
+
     self->sample = sample;
     self->loop = loop;
     uint32_t sample_rate = audiosample_get_sample_rate(sample);

--- a/ports/nordic/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/nordic/common-hal/audiopwmio/PWMAudioOut.c
@@ -236,6 +236,9 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, 
     if (common_hal_audiopwmio_pwmaudioout_get_playing(self)) {
         common_hal_audiopwmio_pwmaudioout_stop(self);
     }
+
+    audiosample_check(sample);
+
     self->sample = sample;
     self->loop = loop;
 

--- a/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
+++ b/ports/raspberrypi/common-hal/audiobusio/I2SOut.c
@@ -262,6 +262,8 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t *self,
         common_hal_audiobusio_i2sout_stop(self);
     }
 
+    audiosample_check(sample);
+
     uint8_t bits_per_sample = audiosample_get_bits_per_sample(sample);
     // Make sure we transmit a minimum of 16 bits.
     // TODO: Maybe we need an intermediate object to upsample instead. This is

--- a/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/raspberrypi/common-hal/audiopwmio/PWMAudioOut.c
@@ -160,6 +160,8 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, 
         common_hal_audiopwmio_pwmaudioout_stop(self);
     }
 
+    audiosample_check(sample);
+
     // TODO: Share pacing timers based on frequency.
     size_t pacing_timer = NUM_DMA_TIMERS;
     for (size_t i = 0; i < NUM_DMA_TIMERS; i++) {

--- a/ports/raspberrypi/common-hal/mcp4822/MCP4822.c
+++ b/ports/raspberrypi/common-hal/mcp4822/MCP4822.c
@@ -216,6 +216,8 @@ void common_hal_mcp4822_mcp4822_play(mcp4822_mcp4822_obj_t *self,
         common_hal_mcp4822_mcp4822_stop(self);
     }
 
+    audiosample_check(sample);
+
     uint8_t bits_per_sample = audiosample_get_bits_per_sample(sample);
     if (bits_per_sample < 16) {
         bits_per_sample = 16;

--- a/ports/stm/common-hal/audiopwmio/PWMAudioOut.c
+++ b/ports/stm/common-hal/audiopwmio/PWMAudioOut.c
@@ -255,6 +255,9 @@ void common_hal_audiopwmio_pwmaudioout_play(audiopwmio_pwmaudioout_obj_t *self, 
     if (active_audio) {
         mp_raise_RuntimeError(MP_ERROR_TEXT("Another PWMAudioOut is already active")); // TODO
     }
+
+    audiosample_check(sample);
+
     self->sample = sample;
     self->loop = loop;
 

--- a/ports/zephyr-cp/common-hal/audiobusio/I2SOut.c
+++ b/ports/zephyr-cp/common-hal/audiobusio/I2SOut.c
@@ -149,6 +149,8 @@ void common_hal_audiobusio_i2sout_play(audiobusio_i2sout_obj_t *self,
         common_hal_audiobusio_i2sout_stop(self);
     }
 
+    audiosample_check(sample);
+
     // Get sample information
     uint8_t bits_per_sample = audiosample_get_bits_per_sample(sample);
     uint32_t sample_rate = audiosample_get_sample_rate(sample);


### PR DESCRIPTION
- Fixes #11067

Add missing calls to `audiosample_check()` in places that needed to validate the incoming object was an `audiosample`. 

I found the original bug in the RP2040 `I2SOut` play logic (#11067), and then asked Claude to see if there were other missing arg validations for `audiosample`-protocol objects. It found a bunch.

Rest is written by Claude and slightly edited.

Most `play()` entry points passed the user-supplied object straight to the non-validating audiosample getters (`audiosample_get_sample_rate()`, `audiosample_get_bits_per_sample()`, `audiosample_get_channel_count()`, `audiosample_get_buffer_structure()`), which cast the object to `audiosample_base_t *` without checking it implements the audiosample protocol. Passing a non-sample object dereferenced arbitrary memory instead of raising an error.

Paths fixed:
- espressif & mimxrt10xx `port_i2s_play()` (mimxrt covers both `I2SOut` and `PWMAudioOut`)
- atmel-samd `AudioOut` & `I2SOut`
- nordic `I2SOut` & `PWMAudioOut`
- raspberrypi `I2SOut`, `PWMAudioOut`, `mcp4822`
- stm `PWMAudioOut`
- zephyr-cp `I2SOut`
- espressif `AudioOut` (was safe only by call ordering; made explicit for consistency)

Already-correct paths (unchanged): stm `AudioOut`, all shared-module effects and `audiomixer.Mixer`/`MixerVoice` (via `audiosample_must_match()`), and `audiospeed`/`audiofilewriter`/`usb_audio` (explicit checks). `play()` was the only entry point with the missing check.