### PR TITLE
ble_hci: use the LE packet boundary flag for outgoing ACL data

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/hci.c
+++ b/devices/ble_hci/common-hal/_bleio/hci.c
@@ -489,7 +489,9 @@ hci_result_t hci_send_acl_pkt(uint16_t handle, uint8_t cid, uint16_t data_len, u
     acl_data_t *acl_data = (acl_data_t *)acl_pkt->data;
     acl_pkt->pkt_type = H4_ACL;
     acl_pkt->handle = handle;
-    acl_pkt->pb = ACL_DATA_PB_FIRST_FLUSH;
+    // On an LE link the first fragment of an L2CAP PDU is
+    // non-automatically-flushable. ACL_DATA_PB_FIRST_FLUSH is the BR/EDR value.
+    acl_pkt->pb = ACL_DATA_PB_FIRST_NON_FLUSH;
     acl_pkt->bc = 0;
     acl_pkt->data_len = (uint16_t)(sizeof(acl_data_t) + data_len);
     acl_data->acl_data_len = data_len;


### PR DESCRIPTION
`hci_send_acl_pkt()` marks the first fragment of every outgoing L2CAP PDU as `ACL_DATA_PB_FIRST_FLUSH`:

```c
acl_pkt->pb = ACL_DATA_PB_FIRST_FLUSH;
```

That is the BR/EDR value, "first automatically flushable" (`0b10`). On an LE-U link the first fragment of a higher layer message is non-automatically-flushable, `ACL_DATA_PB_FIRST_NON_FLUSH` (`0b00`). See Core Specification Vol 4, Part E, 5.4.2.

### Symptom

Nordic's SoftDevice Controller accepts a packet marked `0b10`, returning success from `sdc_hci_data_put()`, and then never transmits it. Measured on an nRF52840 over SWD:

- No Number Of Completed Packets event ever arrived, for any packet.
- The peer waited for a reply that never came and disconnected with reason `0x13`, remote user terminated — not `0x08`, which a supervision timeout would give.
- A client hung indefinitely on "discovering services" and eventually timed out.

With the LE value, the same connection completes service discovery and stays up.

### Scope, and what I could not test

This is the packet boundary flag for LE links, so it applies to every board using the HCI `_bleio` host, not only the one I was working on.

I could only test against one controller: Nordic's SoftDevice Controller driven on-chip. I have no AirLift hardware, so I have not verified the ESP32 co-processor boards that are the usual users of this backend. Their controllers evidently tolerate `0b10` today, since those boards work. The change makes the value spec-correct rather than relying on that tolerance, but it would be worth a second pair of eyes from someone with an AirLift board before merging.
