### PR TITLE
fix crash from deinit'd sample objects

### DIFF
--- a/shared-module/audiocore/__init__.c
+++ b/shared-module/audiocore/__init__.c
@@ -8,6 +8,7 @@
 
 #include "py/obj.h"
 #include "py/runtime.h"
+#include "shared-bindings/audiocore/__init__.h"
 #include "shared-bindings/audiocore/RawSample.h"
 #include "shared-bindings/audiocore/WaveFile.h"
 #include "shared-module/audiocore/RawSample.h"
@@ -20,8 +21,17 @@
 #include "shared-bindings/audiomixer/Mixer.h"
 #include "shared-module/audiomixer/Mixer.h"
 
+// Need to confirm that a sample is not deinited before using it, otherwise we
+// we read and write through NULL points and fault
+static bool audiosample_dispatch_ok(mp_obj_t sample_obj) {
+    return !audiosample_deinited((const audiosample_base_t *)MP_OBJ_TO_PTR(sample_obj));
+}
+
 void audiosample_reset_buffer(mp_obj_t sample_obj, bool single_channel_output, uint8_t audio_channel) {
     const audiosample_p_t *proto = mp_proto_get_or_throw(MP_QSTR_protocol_audiosample, sample_obj);
+    if (!audiosample_dispatch_ok(sample_obj)) {
+        return;
+    }
     proto->reset_buffer(MP_OBJ_TO_PTR(sample_obj), single_channel_output, audio_channel);
 }
 
@@ -30,6 +40,11 @@ audioio_get_buffer_result_t audiosample_get_buffer(mp_obj_t sample_obj,
     uint8_t channel,
     uint8_t **buffer, uint32_t *buffer_length) {
     const audiosample_p_t *proto = mp_proto_get_or_throw(MP_QSTR_protocol_audiosample, sample_obj);
+    if (!audiosample_dispatch_ok(sample_obj)) {
+        *buffer = NULL;
+        *buffer_length = 0;
+        return GET_BUFFER_ERROR;
+    }
     return proto->get_buffer(MP_OBJ_TO_PTR(sample_obj), single_channel_output, channel, buffer, buffer_length);
 }
 
@@ -202,6 +217,10 @@ void audiosample_convert_s16s_u8s(uint8_t *buffer_out, const int16_t *buffer_in,
 
 void audiosample_must_match(audiosample_base_t *self, mp_obj_t other_in, bool allow_mono_to_stereo) {
     const audiosample_base_t *other = audiosample_check(other_in);
+    // Attaching a sample that has already been deinited would leave the caller
+    // playing something that can never produce audio.
+    audiosample_check_for_deinit(other);
+
     #if !CIRCUITPY_AUDIOSPEED
     if (other->sample_rate != self->sample_rate) {
     #else

--- a/shared-module/audiocore/__init__.c
+++ b/shared-module/audiocore/__init__.c
@@ -21,15 +21,9 @@
 #include "shared-bindings/audiomixer/Mixer.h"
 #include "shared-module/audiomixer/Mixer.h"
 
-// Need to confirm that a sample is not deinited before using it, otherwise we
-// we read and write through NULL points and fault
-static bool audiosample_dispatch_ok(mp_obj_t sample_obj) {
-    return !audiosample_deinited((const audiosample_base_t *)MP_OBJ_TO_PTR(sample_obj));
-}
-
 void audiosample_reset_buffer(mp_obj_t sample_obj, bool single_channel_output, uint8_t audio_channel) {
     const audiosample_p_t *proto = mp_proto_get_or_throw(MP_QSTR_protocol_audiosample, sample_obj);
-    if (!audiosample_dispatch_ok(sample_obj)) {
+    if (audiosample_deinited(audiosample_cast_obj(sample_obj))) {
         return;
     }
     proto->reset_buffer(MP_OBJ_TO_PTR(sample_obj), single_channel_output, audio_channel);
@@ -40,7 +34,7 @@ audioio_get_buffer_result_t audiosample_get_buffer(mp_obj_t sample_obj,
     uint8_t channel,
     uint8_t **buffer, uint32_t *buffer_length) {
     const audiosample_p_t *proto = mp_proto_get_or_throw(MP_QSTR_protocol_audiosample, sample_obj);
-    if (!audiosample_dispatch_ok(sample_obj)) {
+    if (audiosample_deinited(audiosample_cast_obj(sample_obj))) {
         *buffer = NULL;
         *buffer_length = 0;
         return GET_BUFFER_ERROR;
@@ -217,10 +211,7 @@ void audiosample_convert_s16s_u8s(uint8_t *buffer_out, const int16_t *buffer_in,
 
 void audiosample_must_match(audiosample_base_t *self, mp_obj_t other_in, bool allow_mono_to_stereo) {
     const audiosample_base_t *other = audiosample_check(other_in);
-    // Attaching a sample that has already been deinited would leave the caller
-    // playing something that can never produce audio.
     audiosample_check_for_deinit(other);
-
     #if !CIRCUITPY_AUDIOSPEED
     if (other->sample_rate != self->sample_rate) {
     #else

--- a/shared-module/audiocore/__init__.h
+++ b/shared-module/audiocore/__init__.h
@@ -114,3 +114,5 @@ void audiosample_convert_u16m_u8s(uint8_t *buffer_out, const uint16_t *buffer_in
 void audiosample_convert_u16s_u8s(uint8_t *buffer_out, const uint16_t *buffer_in, size_t nframes);
 void audiosample_convert_s16m_u8s(uint8_t *buffer_out, const int16_t *buffer_in, size_t nframes);
 void audiosample_convert_s16s_u8s(uint8_t *buffer_out, const int16_t *buffer_in, size_t nframes);
+
+#define audiosample_cast_obj(obj) ((audiosample_base_t *)MP_OBJ_TO_PTR(obj))

--- a/shared-module/audiodelays/Chorus.c
+++ b/shared-module/audiodelays/Chorus.c
@@ -218,9 +218,17 @@ audioio_get_buffer_result_t audiodelays_chorus_get_buffer(audiodelays_chorus_obj
             if (self->sample) {
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
-                // Track length in terms of words.
-                self->sample_buffer_length /= (self->base.bits_per_sample / 8);
-                self->more_data = result == GET_BUFFER_MORE_DATA;
+                if (result == GET_BUFFER_ERROR) {
+                    // The sample cannot be read from any more, it was
+                    // deinited while we were playing it.
+                    self->sample = NULL;
+                    self->sample_buffer_length = 0;
+                    self->more_data = false;
+                } else {
+                    // Track length in terms of words.
+                    self->sample_buffer_length /= (self->base.bits_per_sample / 8);
+                    self->more_data = result == GET_BUFFER_MORE_DATA;
+                }
             }
         }
 

--- a/shared-module/audiodelays/Chorus.c
+++ b/shared-module/audiodelays/Chorus.c
@@ -219,8 +219,6 @@ audioio_get_buffer_result_t audiodelays_chorus_get_buffer(audiodelays_chorus_obj
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
                 if (result == GET_BUFFER_ERROR) {
-                    // The sample cannot be read from any more, it was
-                    // deinited while we were playing it.
                     self->sample = NULL;
                     self->sample_buffer_length = 0;
                     self->more_data = false;

--- a/shared-module/audiodelays/Echo.c
+++ b/shared-module/audiodelays/Echo.c
@@ -260,8 +260,6 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
                 if (result == GET_BUFFER_ERROR) {
-                    // The sample cannot be read from any more, it was
-                    // deinited while we were playing it.
                     self->sample = NULL;
                     self->sample_buffer_length = 0;
                     self->more_data = false;

--- a/shared-module/audiodelays/Echo.c
+++ b/shared-module/audiodelays/Echo.c
@@ -259,9 +259,17 @@ audioio_get_buffer_result_t audiodelays_echo_get_buffer(audiodelays_echo_obj_t *
             if (self->sample) {
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
-                // Track length in terms of words.
-                self->sample_buffer_length /= (self->base.bits_per_sample / 8);
-                self->more_data = result == GET_BUFFER_MORE_DATA;
+                if (result == GET_BUFFER_ERROR) {
+                    // The sample cannot be read from any more, it was
+                    // deinited while we were playing it.
+                    self->sample = NULL;
+                    self->sample_buffer_length = 0;
+                    self->more_data = false;
+                } else {
+                    // Track length in terms of words.
+                    self->sample_buffer_length /= (self->base.bits_per_sample / 8);
+                    self->more_data = result == GET_BUFFER_MORE_DATA;
+                }
             }
         }
 

--- a/shared-module/audiodelays/GranularPitchShift.c
+++ b/shared-module/audiodelays/GranularPitchShift.c
@@ -308,9 +308,17 @@ audioio_get_buffer_result_t audiodelays_granular_pitch_shift_get_buffer(audiodel
             if (self->sample) {
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
-                // Track length in terms of words.
-                self->sample_buffer_length /= (self->base.bits_per_sample / 8);
-                self->more_data = result == GET_BUFFER_MORE_DATA;
+                if (result == GET_BUFFER_ERROR) {
+                    // The sample cannot be read from any more, it was
+                    // deinited while we were playing it.
+                    self->sample = NULL;
+                    self->sample_buffer_length = 0;
+                    self->more_data = false;
+                } else {
+                    // Track length in terms of words.
+                    self->sample_buffer_length /= (self->base.bits_per_sample / 8);
+                    self->more_data = result == GET_BUFFER_MORE_DATA;
+                }
             }
         }
 

--- a/shared-module/audiodelays/GranularPitchShift.c
+++ b/shared-module/audiodelays/GranularPitchShift.c
@@ -309,8 +309,6 @@ audioio_get_buffer_result_t audiodelays_granular_pitch_shift_get_buffer(audiodel
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
                 if (result == GET_BUFFER_ERROR) {
-                    // The sample cannot be read from any more, it was
-                    // deinited while we were playing it.
                     self->sample = NULL;
                     self->sample_buffer_length = 0;
                     self->more_data = false;

--- a/shared-module/audiodelays/MultiTapDelay.c
+++ b/shared-module/audiodelays/MultiTapDelay.c
@@ -349,8 +349,6 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
                 if (result == GET_BUFFER_ERROR) {
-                    // The sample cannot be read from any more, it was
-                    // deinited while we were playing it.
                     self->sample = NULL;
                     self->sample_buffer_length = 0;
                     self->more_data = false;

--- a/shared-module/audiodelays/MultiTapDelay.c
+++ b/shared-module/audiodelays/MultiTapDelay.c
@@ -348,9 +348,17 @@ audioio_get_buffer_result_t audiodelays_multi_tap_delay_get_buffer(audiodelays_m
             if (self->sample) {
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
-                // Track length in terms of words.
-                self->sample_buffer_length /= (self->base.bits_per_sample / 8);
-                self->more_data = result == GET_BUFFER_MORE_DATA;
+                if (result == GET_BUFFER_ERROR) {
+                    // The sample cannot be read from any more, it was
+                    // deinited while we were playing it.
+                    self->sample = NULL;
+                    self->sample_buffer_length = 0;
+                    self->more_data = false;
+                } else {
+                    // Track length in terms of words.
+                    self->sample_buffer_length /= (self->base.bits_per_sample / 8);
+                    self->more_data = result == GET_BUFFER_MORE_DATA;
+                }
             }
         }
 

--- a/shared-module/audiodelays/PitchShift.c
+++ b/shared-module/audiodelays/PitchShift.c
@@ -206,8 +206,6 @@ audioio_get_buffer_result_t audiodelays_pitch_shift_get_buffer(audiodelays_pitch
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
                 if (result == GET_BUFFER_ERROR) {
-                    // The sample cannot be read from any more, it was
-                    // deinited while we were playing it.
                     self->sample = NULL;
                     self->sample_buffer_length = 0;
                     self->more_data = false;

--- a/shared-module/audiodelays/PitchShift.c
+++ b/shared-module/audiodelays/PitchShift.c
@@ -205,9 +205,17 @@ audioio_get_buffer_result_t audiodelays_pitch_shift_get_buffer(audiodelays_pitch
             if (self->sample) {
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
-                // Track length in terms of words.
-                self->sample_buffer_length /= (self->base.bits_per_sample / 8);
-                self->more_data = result == GET_BUFFER_MORE_DATA;
+                if (result == GET_BUFFER_ERROR) {
+                    // The sample cannot be read from any more, it was
+                    // deinited while we were playing it.
+                    self->sample = NULL;
+                    self->sample_buffer_length = 0;
+                    self->more_data = false;
+                } else {
+                    // Track length in terms of words.
+                    self->sample_buffer_length /= (self->base.bits_per_sample / 8);
+                    self->more_data = result == GET_BUFFER_MORE_DATA;
+                }
             }
         }
 

--- a/shared-module/audiofilters/Distortion.c
+++ b/shared-module/audiofilters/Distortion.c
@@ -192,9 +192,17 @@ audioio_get_buffer_result_t audiofilters_distortion_get_buffer(audiofilters_dist
             if (self->sample) {
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
-                // Track length in terms of words.
-                self->sample_buffer_length /= (self->base.bits_per_sample / 8);
-                self->more_data = result == GET_BUFFER_MORE_DATA;
+                if (result == GET_BUFFER_ERROR) {
+                    // The sample cannot be read from any more, it was
+                    // deinited while we were playing it.
+                    self->sample = NULL;
+                    self->sample_buffer_length = 0;
+                    self->more_data = false;
+                } else {
+                    // Track length in terms of words.
+                    self->sample_buffer_length /= (self->base.bits_per_sample / 8);
+                    self->more_data = result == GET_BUFFER_MORE_DATA;
+                }
             }
         }
 

--- a/shared-module/audiofilters/Distortion.c
+++ b/shared-module/audiofilters/Distortion.c
@@ -193,8 +193,6 @@ audioio_get_buffer_result_t audiofilters_distortion_get_buffer(audiofilters_dist
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
                 if (result == GET_BUFFER_ERROR) {
-                    // The sample cannot be read from any more, it was
-                    // deinited while we were playing it.
                     self->sample = NULL;
                     self->sample_buffer_length = 0;
                     self->more_data = false;

--- a/shared-module/audiofilters/Filter.c
+++ b/shared-module/audiofilters/Filter.c
@@ -196,8 +196,6 @@ audioio_get_buffer_result_t audiofilters_filter_get_buffer(audiofilters_filter_o
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
                 if (result == GET_BUFFER_ERROR) {
-                    // The sample cannot be read from any more, it was
-                    // deinited while we were playing it.
                     self->sample = NULL;
                     self->sample_buffer_length = 0;
                     self->more_data = false;

--- a/shared-module/audiofilters/Filter.c
+++ b/shared-module/audiofilters/Filter.c
@@ -195,9 +195,17 @@ audioio_get_buffer_result_t audiofilters_filter_get_buffer(audiofilters_filter_o
             if (self->sample) {
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
-                // Track length in terms of words.
-                self->sample_buffer_length /= (self->base.bits_per_sample / 8);
-                self->more_data = result == GET_BUFFER_MORE_DATA;
+                if (result == GET_BUFFER_ERROR) {
+                    // The sample cannot be read from any more, it was
+                    // deinited while we were playing it.
+                    self->sample = NULL;
+                    self->sample_buffer_length = 0;
+                    self->more_data = false;
+                } else {
+                    // Track length in terms of words.
+                    self->sample_buffer_length /= (self->base.bits_per_sample / 8);
+                    self->more_data = result == GET_BUFFER_MORE_DATA;
+                }
             }
         }
 

--- a/shared-module/audiofilters/Phaser.c
+++ b/shared-module/audiofilters/Phaser.c
@@ -182,9 +182,17 @@ audioio_get_buffer_result_t audiofilters_phaser_get_buffer(audiofilters_phaser_o
             if (self->sample) {
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
-                // Track length in terms of words.
-                self->sample_buffer_length /= (self->base.bits_per_sample / 8);
-                self->more_data = result == GET_BUFFER_MORE_DATA;
+                if (result == GET_BUFFER_ERROR) {
+                    // The sample cannot be read from any more, it was
+                    // deinited while we were playing it.
+                    self->sample = NULL;
+                    self->sample_buffer_length = 0;
+                    self->more_data = false;
+                } else {
+                    // Track length in terms of words.
+                    self->sample_buffer_length /= (self->base.bits_per_sample / 8);
+                    self->more_data = result == GET_BUFFER_MORE_DATA;
+                }
             }
         }
 

--- a/shared-module/audiofilters/Phaser.c
+++ b/shared-module/audiofilters/Phaser.c
@@ -183,8 +183,6 @@ audioio_get_buffer_result_t audiofilters_phaser_get_buffer(audiofilters_phaser_o
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
                 if (result == GET_BUFFER_ERROR) {
-                    // The sample cannot be read from any more, it was
-                    // deinited while we were playing it.
                     self->sample = NULL;
                     self->sample_buffer_length = 0;
                     self->more_data = false;

--- a/shared-module/audiofreeverb/Freeverb.c
+++ b/shared-module/audiofreeverb/Freeverb.c
@@ -242,8 +242,6 @@ audioio_get_buffer_result_t audiofreeverb_freeverb_get_buffer(audiofreeverb_free
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
                 if (result == GET_BUFFER_ERROR) {
-                    // The sample cannot be read from any more, it was
-                    // deinited while we were playing it.
                     self->sample = NULL;
                     self->sample_buffer_length = 0;
                     self->more_data = false;

--- a/shared-module/audiofreeverb/Freeverb.c
+++ b/shared-module/audiofreeverb/Freeverb.c
@@ -241,9 +241,17 @@ audioio_get_buffer_result_t audiofreeverb_freeverb_get_buffer(audiofreeverb_free
             if (self->sample) {
                 // Load another sample buffer to play
                 audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->sample_remaining_buffer, &self->sample_buffer_length);
-                // Track length in terms of words.
-                self->sample_buffer_length /= (self->base.bits_per_sample / 8);
-                self->more_data = result == GET_BUFFER_MORE_DATA;
+                if (result == GET_BUFFER_ERROR) {
+                    // The sample cannot be read from any more, it was
+                    // deinited while we were playing it.
+                    self->sample = NULL;
+                    self->sample_buffer_length = 0;
+                    self->more_data = false;
+                } else {
+                    // Track length in terms of words.
+                    self->sample_buffer_length /= (self->base.bits_per_sample / 8);
+                    self->more_data = result == GET_BUFFER_MORE_DATA;
+                }
             }
         }
 

--- a/shared-module/audiomixer/Mixer.c
+++ b/shared-module/audiomixer/Mixer.c
@@ -192,6 +192,14 @@ static void mix_down_one_voice(audiomixer_mixer_obj_t *self,
             if (voice->sample) {
                 // Load another buffer
                 audioio_get_buffer_result_t result = audiosample_get_buffer(voice->sample, false, 0, (uint8_t **)&voice->remaining_buffer, &voice->buffer_length);
+                if (result == GET_BUFFER_ERROR) {
+                    // The sample cannot be read from any more, it was
+                    // deinited while this voice was playing it. Stop the voice.
+                    voice->sample = NULL;
+                    voice->buffer_length = 0;
+                    voice->more_data = false;
+                    break;
+                }
                 // Track length in terms of words.
                 voice->buffer_length /= sizeof(uint32_t);
                 voice->more_data = result == GET_BUFFER_MORE_DATA;

--- a/shared-module/audiomixer/Mixer.c
+++ b/shared-module/audiomixer/Mixer.c
@@ -193,8 +193,6 @@ static void mix_down_one_voice(audiomixer_mixer_obj_t *self,
                 // Load another buffer
                 audioio_get_buffer_result_t result = audiosample_get_buffer(voice->sample, false, 0, (uint8_t **)&voice->remaining_buffer, &voice->buffer_length);
                 if (result == GET_BUFFER_ERROR) {
-                    // The sample cannot be read from any more, it was
-                    // deinited while this voice was playing it. Stop the voice.
                     voice->sample = NULL;
                     voice->buffer_length = 0;
                     voice->more_data = false;


### PR DESCRIPTION
resolves: #11151

Fixed by confirming the sample hasn't been deinited before use, and checking the result for `GET_BUFFER_ERROR` to handle appropriately inside of the sample objects.

Tested successfully on Metro RP2350 using the reproducer code from the issue. The device no longer crashes or locks up.