### PR TITLE
Fix M5Stack CoreS3 boot crash

### DIFF
--- a/ports/espressif/boards/m5stack_cores3/board.c
+++ b/ports/espressif/boards/m5stack_cores3/board.c
@@ -38,8 +38,10 @@ uint8_t display_init_sequence[] = {
 };
 
 static bool display_init(void) {
-    busio_spi_obj_t *spi = common_hal_board_create_spi(0);
     fourwire_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
+    common_hal_busio_spi_construct(spi, &pin_GPIO36, &pin_GPIO37, NULL, false);
+    common_hal_busio_spi_never_reset(spi);
     bus->base.type = &fourwire_fourwire_type;
 
     common_hal_fourwire_fourwire_construct(

--- a/ports/espressif/boards/m5stack_cores3/mpconfigboard.h
+++ b/ports/espressif/boards/m5stack_cores3/mpconfigboard.h
@@ -17,7 +17,10 @@
 
 #define DEFAULT_SPI_BUS_SCK (&pin_GPIO36)
 #define DEFAULT_SPI_BUS_MOSI (&pin_GPIO37)
-#define DEFAULT_SPI_BUS_MISO (&pin_GPIO35)
+// GPIO35 is shared between the TF card MISO and the TFT D/C signal. The display
+// claims it as D/C during board_init(), so board.SPI() must not also claim it.
+#define CIRCUITPY_BOARD_SPI     (1)
+#define CIRCUITPY_BOARD_SPI_PIN {{.clock = DEFAULT_SPI_BUS_SCK, .mosi = DEFAULT_SPI_BUS_MOSI, .miso = NULL}}
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO18)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO17)

--- a/ports/espressif/boards/m5stack_cores3/mpconfigboard.h
+++ b/ports/espressif/boards/m5stack_cores3/mpconfigboard.h
@@ -15,12 +15,5 @@
 #define CIRCUITPY_BOARD_I2C_PIN     {{.scl = &pin_GPIO11, .sda = &pin_GPIO12}, \
                                      {.scl = &pin_GPIO1, .sda = &pin_GPIO2}}
 
-#define DEFAULT_SPI_BUS_SCK (&pin_GPIO36)
-#define DEFAULT_SPI_BUS_MOSI (&pin_GPIO37)
-// GPIO35 is shared between the TF card MISO and the TFT D/C signal. The display
-// claims it as D/C during board_init(), so board.SPI() must not also claim it.
-#define CIRCUITPY_BOARD_SPI     (1)
-#define CIRCUITPY_BOARD_SPI_PIN {{.clock = DEFAULT_SPI_BUS_SCK, .mosi = DEFAULT_SPI_BUS_MOSI, .miso = NULL}}
-
 #define DEFAULT_UART_BUS_RX (&pin_GPIO18)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO17)

--- a/ports/espressif/boards/m5stack_cores3/pins.c
+++ b/ports/espressif/boards/m5stack_cores3/pins.c
@@ -29,10 +29,8 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
 
     // M5 Bus (except I2S)
-    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_GPIO37) },
-    { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_GPIO35) },
-    { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_GPIO36) },
-
+    // The SPI bus MISO is also used for the TFT D/C signal, so it is not available for general use
+    // therefore the SPI bus is not listed on the M5 Bus
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO44) },
     { MP_ROM_QSTR(MP_QSTR_D44), MP_ROM_PTR(&pin_GPIO44) },
 
@@ -99,6 +97,8 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_CAMERA_XCLK), MP_ROM_PTR(&pin_GPIO2) },
 
     // Display
+    { MP_ROM_QSTR(MP_QSTR_TFT_MOSI), MP_ROM_PTR(&pin_GPIO37) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_SCK), MP_ROM_PTR(&pin_GPIO36) },
     { MP_ROM_QSTR(MP_QSTR_TFT_CS), MP_ROM_PTR(&pin_GPIO3) },
     { MP_ROM_QSTR(MP_QSTR_TFT_DC), MP_ROM_PTR(&pin_GPIO35) },
 
@@ -109,7 +109,6 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_PORTA_I2C), MP_ROM_PTR(&board_porta_i2c_obj) },
-    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display)}

--- a/ports/espressif/boards/m5stack_cores3_se/board.c
+++ b/ports/espressif/boards/m5stack_cores3_se/board.c
@@ -39,8 +39,10 @@ uint8_t display_init_sequence[] = {
 };
 
 static bool display_init(void) {
-    busio_spi_obj_t *spi = common_hal_board_create_spi(0);
     fourwire_fourwire_obj_t *bus = &allocate_display_bus()->fourwire_bus;
+    busio_spi_obj_t *spi = &bus->inline_bus;
+    common_hal_busio_spi_construct(spi, &pin_GPIO36, &pin_GPIO37, NULL, false);
+    common_hal_busio_spi_never_reset(spi);
     bus->base.type = &fourwire_fourwire_type;
 
     common_hal_fourwire_fourwire_construct(

--- a/ports/espressif/boards/m5stack_cores3_se/mpconfigboard.h
+++ b/ports/espressif/boards/m5stack_cores3_se/mpconfigboard.h
@@ -19,7 +19,10 @@
 
 #define DEFAULT_SPI_BUS_SCK (&pin_GPIO36)
 #define DEFAULT_SPI_BUS_MOSI (&pin_GPIO37)
-#define DEFAULT_SPI_BUS_MISO (&pin_GPIO35)
+// GPIO35 is shared between the TF card MISO and the TFT D/C signal. The display
+// claims it as D/C during board_init(), so board.SPI() must not also claim it.
+#define CIRCUITPY_BOARD_SPI     (1)
+#define CIRCUITPY_BOARD_SPI_PIN {{.clock = DEFAULT_SPI_BUS_SCK, .mosi = DEFAULT_SPI_BUS_MOSI, .miso = NULL}}
 
 #define DEFAULT_UART_BUS_RX (&pin_GPIO18)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO17)

--- a/ports/espressif/boards/m5stack_cores3_se/mpconfigboard.h
+++ b/ports/espressif/boards/m5stack_cores3_se/mpconfigboard.h
@@ -17,12 +17,5 @@
 #define CIRCUITPY_BOARD_I2C_PIN     {{.scl = &pin_GPIO11, .sda = &pin_GPIO12}, \
                                      {.scl = &pin_GPIO1, .sda = &pin_GPIO2}}
 
-#define DEFAULT_SPI_BUS_SCK (&pin_GPIO36)
-#define DEFAULT_SPI_BUS_MOSI (&pin_GPIO37)
-// GPIO35 is shared between the TF card MISO and the TFT D/C signal. The display
-// claims it as D/C during board_init(), so board.SPI() must not also claim it.
-#define CIRCUITPY_BOARD_SPI     (1)
-#define CIRCUITPY_BOARD_SPI_PIN {{.clock = DEFAULT_SPI_BUS_SCK, .mosi = DEFAULT_SPI_BUS_MOSI, .miso = NULL}}
-
 #define DEFAULT_UART_BUS_RX (&pin_GPIO18)
 #define DEFAULT_UART_BUS_TX (&pin_GPIO17)

--- a/ports/espressif/boards/m5stack_cores3_se/pins.c
+++ b/ports/espressif/boards/m5stack_cores3_se/pins.c
@@ -13,10 +13,8 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
 
     // M5 Bus (except I2S)
-    { MP_ROM_QSTR(MP_QSTR_MOSI), MP_ROM_PTR(&pin_GPIO37) },
-    { MP_ROM_QSTR(MP_QSTR_MISO), MP_ROM_PTR(&pin_GPIO35) },
-    { MP_ROM_QSTR(MP_QSTR_SCK), MP_ROM_PTR(&pin_GPIO36) },
-
+    // The SPI bus MISO is also used for the TFT D/C signal, so it is not available for general use
+    // therefore the SPI bus is not listed on the M5 Bus
     { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO44) },
     { MP_ROM_QSTR(MP_QSTR_D44), MP_ROM_PTR(&pin_GPIO44) },
 
@@ -69,6 +67,8 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_I2S_MASTER_CLOCK), MP_ROM_PTR(&pin_GPIO0) },
 
     // Display
+    { MP_ROM_QSTR(MP_QSTR_TFT_MOSI), MP_ROM_PTR(&pin_GPIO37) },
+    { MP_ROM_QSTR(MP_QSTR_TFT_SCK), MP_ROM_PTR(&pin_GPIO36) },
     { MP_ROM_QSTR(MP_QSTR_TFT_CS), MP_ROM_PTR(&pin_GPIO3) },
     { MP_ROM_QSTR(MP_QSTR_TFT_DC), MP_ROM_PTR(&pin_GPIO35) },
 
@@ -79,7 +79,6 @@ static const mp_rom_map_elem_t board_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
     { MP_ROM_QSTR(MP_QSTR_PORTA_I2C), MP_ROM_PTR(&board_porta_i2c_obj) },
-    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
     { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_DISPLAY), MP_ROM_PTR(&displays[0].display)}


### PR DESCRIPTION
This PR fixes the issue adafruit/circuitpython#11009
The problem was the SPI bus definition. The GPIO35 is either the MISO pin on the M5Bus but also the display DC signal.
I have changed the SPI definition removing the MISO pin.
I made the same change also for the CoreS3 SE
