### PR TITLE
Fix left justified implementation on I2SIn with external clock

### DIFF
--- a/ports/raspberrypi/common-hal/audioi2sin/I2SIn.c
+++ b/ports/raspberrypi/common-hal/audioi2sin/I2SIn.c
@@ -235,7 +235,7 @@ static size_t build_i2sin_ext_clock_program(uint16_t *prog, uint8_t bclk, uint8_
     size_t len = 0;
     prog[len++] = 0x2000 | ws;  // wait 0 gpio W
     prog[len++] = 0x2080 | ws;  // wait 1 gpio W
-    if (left_justified) {
+    if (!left_justified) {
         prog[len++] = wait_1_bclk;  // one more BCLK of skew
     }
     const size_t bitloop = len + 1;


### PR DESCRIPTION
The newly merged I2SIn bidirectional support implements left justified operation incorrectly when it is acting as a secondary device (`external_clock=True`). This update fixes that by inverting the logic in the PIO generation method so that normal operation occurs one clock cycle offset from the word clock and left justified occurs immediately when the word clock changes.