### PR TITLE
Add Waveshare ESP32-S3-ETH-8DI-8RO board definition

### DIFF
--- a/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/board.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/board.c
@@ -1,0 +1,19 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2019 Scott Shawcroft for Adafruit Industries
+//
+// SPDX-License-Identifier: MIT
+
+#include "supervisor/board.h"
+#include "mpconfigboard.h"
+#include "shared-bindings/microcontroller/Pin.h"
+
+void board_init(void) {
+}
+
+bool board_requests_safe_mode(void) {
+    return false;
+}
+
+void reset_board(void) {
+}

--- a/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/mpconfigboard.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/mpconfigboard.h
@@ -1,0 +1,25 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2019 Scott Shawcroft for Adafruit Industries
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+// Micropython setup
+
+#define MICROPY_HW_BOARD_NAME       "Waveshare ESP32-S3-ETH-8DI-8RO"
+#define MICROPY_HW_MCU_NAME         "ESP32S3"
+
+#define MICROPY_HW_NEOPIXEL         (&pin_GPIO38)
+#define MICROPY_HW_NEOPIXEL_ORDER_GRB (1)
+
+#define DEFAULT_I2C_BUS_SCL         (&pin_GPIO41)
+#define DEFAULT_I2C_BUS_SDA         (&pin_GPIO42)
+
+#define DEFAULT_UART_BUS_RX         (&pin_GPIO18)
+#define DEFAULT_UART_BUS_TX         (&pin_GPIO17)
+
+#define DEFAULT_SPI_BUS_SCK         (&pin_GPIO15)
+#define DEFAULT_SPI_BUS_MOSI        (&pin_GPIO13)
+#define DEFAULT_SPI_BUS_MISO        (&pin_GPIO14)

--- a/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/mpconfigboard.mk
+++ b/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/mpconfigboard.mk
@@ -1,0 +1,29 @@
+USB_VID = 0x303a
+USB_PID = 0x83A2
+USB_PRODUCT = "ESP32-S3-ETH-8DI-8RO"
+USB_MANUFACTURER = "Waveshare"
+
+IDF_TARGET = esp32s3
+
+# Include these Python libraries in firmware.
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Pixelbuf
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_SD
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Register
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Wiznet5k
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Ticks
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Requests
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_FakeRequests
+FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_ConnectionManager
+FROZEN_MPY_DIRS += $(TOP)/frozen/circuitpython-pcf85063a
+
+CIRCUITPY_I2CIOEXPANDER = 1
+
+CIRCUITPY_ESP_FLASH_MODE = qio
+CIRCUITPY_ESP_FLASH_FREQ = 80m
+CIRCUITPY_ESP_FLASH_SIZE = 16MB
+
+CIRCUITPY_ESP_PSRAM_MODE = opi
+CIRCUITPY_ESP_PSRAM_FREQ = 80m
+CIRCUITPY_ESP_PSRAM_SIZE = 8MB

--- a/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/mpconfigboard.mk
+++ b/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/mpconfigboard.mk
@@ -7,7 +7,6 @@ IDF_TARGET = esp32s3
 
 # Include these Python libraries in firmware.
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_NeoPixel
-FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Pixelbuf
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_SD
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_BusDevice
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Register
@@ -17,6 +16,7 @@ FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_Requests
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_FakeRequests
 FROZEN_MPY_DIRS += $(TOP)/frozen/Adafruit_CircuitPython_ConnectionManager
 FROZEN_MPY_DIRS += $(TOP)/frozen/circuitpython-pcf85063a
+FROZEN_MPY_DIRS += $(TOP)/frozen/circuitpython_ef_music
 
 CIRCUITPY_I2CIOEXPANDER = 1
 

--- a/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/pins.c
+++ b/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/pins.c
@@ -1,0 +1,74 @@
+// This file is part of the CircuitPython project: https://circuitpython.org
+//
+// SPDX-FileCopyrightText: Copyright (c) 2020 Scott Shawcroft for Adafruit Industries
+//
+// SPDX-License-Identifier: MIT
+
+#include "shared-bindings/board/__init__.h"
+
+static const mp_rom_map_elem_t board_module_globals_table[] = {
+    CIRCUITPYTHON_BOARD_DICT_STANDARD_ITEMS
+
+    // I2C
+    { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_PTR(&pin_GPIO42) },
+    { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_PTR(&pin_GPIO41) },
+    { MP_ROM_QSTR(MP_QSTR_I2C), MP_ROM_PTR(&board_i2c_obj) },
+
+    // Buzzer
+    { MP_ROM_QSTR(MP_QSTR_BUZZER), MP_ROM_PTR(&pin_GPIO46) },
+
+    // NeoPixel
+    { MP_ROM_QSTR(MP_QSTR_NEOPIXEL), MP_ROM_PTR(&pin_GPIO38) },
+
+    // SD Card (sdioio)
+    { MP_ROM_QSTR(MP_QSTR_SDIO_CLOCK), MP_ROM_PTR(&pin_GPIO48) },
+    { MP_ROM_QSTR(MP_QSTR_SDIO_COMMAND), MP_ROM_PTR(&pin_GPIO47) },
+    { MP_ROM_QSTR(MP_QSTR_SDIO_DATA0), MP_ROM_PTR(&pin_GPIO45) },
+
+    // RTC
+    { MP_ROM_QSTR(MP_QSTR_RTC_INT), MP_ROM_PTR(&pin_GPIO40) },
+
+    // USB
+    { MP_ROM_QSTR(MP_QSTR_DN), MP_ROM_PTR(&pin_GPIO19) },
+    { MP_ROM_QSTR(MP_QSTR_DP), MP_ROM_PTR(&pin_GPIO20) },
+    { MP_ROM_QSTR(MP_QSTR_USB_D_N), MP_ROM_PTR(&pin_GPIO19) },
+    { MP_ROM_QSTR(MP_QSTR_USB_D_P), MP_ROM_PTR(&pin_GPIO20) },
+
+    // Analog / general I/O
+    { MP_ROM_QSTR(MP_QSTR_IO1), MP_ROM_PTR(&pin_GPIO0) },
+    { MP_ROM_QSTR(MP_QSTR_A1), MP_ROM_PTR(&pin_GPIO1) },
+    { MP_ROM_QSTR(MP_QSTR_A2), MP_ROM_PTR(&pin_GPIO2) },
+    { MP_ROM_QSTR(MP_QSTR_A3), MP_ROM_PTR(&pin_GPIO3) },
+
+    // Touch-capable pins (ESP32-S3)
+    { MP_ROM_QSTR(MP_QSTR_TOUCH1), MP_ROM_PTR(&pin_GPIO1) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH2), MP_ROM_PTR(&pin_GPIO2) },
+    { MP_ROM_QSTR(MP_QSTR_TOUCH3), MP_ROM_PTR(&pin_GPIO3) },
+
+    // Isolated Digital Inputs
+    { MP_ROM_QSTR(MP_QSTR_DI1), MP_ROM_PTR(&pin_GPIO4) },
+    { MP_ROM_QSTR(MP_QSTR_DI2), MP_ROM_PTR(&pin_GPIO5) },
+    { MP_ROM_QSTR(MP_QSTR_DI3), MP_ROM_PTR(&pin_GPIO6) },
+    { MP_ROM_QSTR(MP_QSTR_DI4), MP_ROM_PTR(&pin_GPIO7) },
+    { MP_ROM_QSTR(MP_QSTR_DI5), MP_ROM_PTR(&pin_GPIO8) },
+    { MP_ROM_QSTR(MP_QSTR_DI6), MP_ROM_PTR(&pin_GPIO9) },
+    { MP_ROM_QSTR(MP_QSTR_DI7), MP_ROM_PTR(&pin_GPIO10) },
+    { MP_ROM_QSTR(MP_QSTR_DI8), MP_ROM_PTR(&pin_GPIO11) },
+
+    // RS485 Serial
+    { MP_ROM_QSTR(MP_QSTR_RX), MP_ROM_PTR(&pin_GPIO18) },
+    { MP_ROM_QSTR(MP_QSTR_TX), MP_ROM_PTR(&pin_GPIO17) },
+    { MP_ROM_QSTR(MP_QSTR_UART), MP_ROM_PTR(&board_uart_obj) },
+
+    // Ethernet (W5500)
+    { MP_ROM_QSTR(MP_QSTR_W5K_INT), MP_ROM_PTR(&pin_GPIO12) },
+    { MP_ROM_QSTR(MP_QSTR_W5K_MOSI), MP_ROM_PTR(&pin_GPIO13) },
+    { MP_ROM_QSTR(MP_QSTR_W5K_MISO), MP_ROM_PTR(&pin_GPIO14) },
+    { MP_ROM_QSTR(MP_QSTR_W5K_SCK), MP_ROM_PTR(&pin_GPIO15) },
+    { MP_ROM_QSTR(MP_QSTR_W5K_CS), MP_ROM_PTR(&pin_GPIO16) },
+    { MP_ROM_QSTR(MP_QSTR_W5K_SPI), MP_ROM_PTR(&board_spi_obj) },
+
+    // Normal SPI alias
+    { MP_ROM_QSTR(MP_QSTR_SPI), MP_ROM_PTR(&board_spi_obj) },
+};
+MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);

--- a/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/sdkconfig
+++ b/ports/espressif/boards/waveshare_esp32_s3_eth_8di_8ro/sdkconfig
@@ -1,0 +1,14 @@
+#
+# Espressif IoT Development Framework Configuration
+#
+#
+# Component config
+#
+#
+# LWIP
+#
+# end of LWIP
+
+# end of Component config
+
+# end of Espressif IoT Development Framework Configuration


### PR DESCRIPTION
Adding board definitions for a Waveshare ESP32-S3 based relay board:

product page: https://www.waveshare.com/esp32-s3-eth-8di-8ro.htm?sku=30838

I've tested all included i2c devices (RTC, GPIO Expander), the buzzer, RGB led, SPI Ethernet adapter and UART-RS485 converter, and isolated digital inputs via a CircuitPython script. Because the S3 has abundant memory, I've frozen relevant sensor and networking libraries.

---

_Aside:_ My hope is to add more boards with industrial / ruggedized features. I've been conducting workshops for small/medium sized farm automation in Arduino. I feel that CircuitPython may be a better match for folks new to programming hoping to build moderately complex control logic. 

One shortcoming is the lack of a frozen ModBus RTU library. Sensors using this protocol over RS485 are common in industrial controls/ HVAC. I note that existing libraries are large and contain GPL licensed code. Is it possible to freeze this library in a board's build: [TwinDimension-CircuitPython-Modbus](https://github.com/luispichio/TwinDimension-CircuitPython-Modbus), or would it be of value for me to start work on a minimal, MIT licensed Modbus RTU library?