### PR TITLE
.github: remove Windows builds

### DIFF
--- a/.github/actions/deps/external/action.yml
+++ b/.github/actions/deps/external/action.yml
@@ -26,7 +26,6 @@ runs:
         inputs.port != 'zephyr-cp'
       uses: carlosperate/arm-none-eabi-gcc-action@v1
       with:
-        # When changing this update what Windows grabs too!
         release: '15.2.Rel1'
 
     # espressif

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
     outputs:
       docs: ${{ steps.set-matrix.outputs.docs }}
       ports: ${{ steps.set-matrix.outputs.ports }}
-      windows: ${{ steps.set-matrix.outputs.windows }}
       cp-version: ${{ steps.set-up-submodules.outputs.version }}
     steps:
     - name: Dump GitHub context
@@ -213,113 +212,6 @@ jobs:
         # python -m build was run by 'make stubs'
         [ -z "$TWINE_USERNAME" ] || echo "Uploading dev release to PyPi"
         [ -z "$TWINE_USERNAME" ] || twine upload circuitpython-stubs/dist/*
-
-  windows:
-    runs-on: windows-2022
-    needs: scheduler
-    if: needs.scheduler.outputs.windows == 'True'
-    env:
-      CP_VERSION: ${{ needs.scheduler.outputs.cp-version }}
-    defaults:
-      run:
-        # We define a custom shell script here, although `msys2.cmd` does neither exist nor is it available in the PATH yet
-        shell: msys2 {0}
-    steps:
-    # We want to change the configuration of the git command that actions/checkout will be using
-    # (since it is not possible to set autocrlf through the action yet, see actions/checkout#226).
-    - run: git config --global core.autocrlf input
-      shell: bash
-    - name: Check python coding (cmd)
-      run: python -c "import sys, locale; print(sys.getdefaultencoding(), locale.getpreferredencoding(False))"
-      shell: cmd
-    # We use a JS Action, which calls the system terminal or other custom terminals directly, if required
-    - uses: msys2/setup-msys2@v2
-      with:
-        install: base-devel git wget unzip gcc python-pip
-    # The goal of this was to test how things worked when the default file encoding (locale.getpreferedencoding())
-    # was not UTF-8. However, msys2 python does use utf-8 as the preferred file encoding, and using actions/setup-python
-    # python3.8 gave a broken build, so we're not really testing what we wanted to test.
-    # However, commandline length limits are being tested so that does some good.
-    - name: Check python coding (msys2)
-      run: |
-        locale -v
-        which python; python --version
-        python -c "import sys, locale; print(sys.getdefaultencoding(), locale.getpreferredencoding(False))"
-        which python3; python3 --version
-        python3 -c "import sys, locale; print(sys.getdefaultencoding(), locale.getpreferredencoding(False))"
-    - name: Install dependencies
-      run: |
-        wget --no-verbose -O gcc-arm.zip https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-mingw-w64-i686-arm-none-eabi.zip
-        unzip -q -d /tmp/arm-gnu-toolchain gcc-arm.zip
-        tar -C /tmp/arm-gnu-toolchain -cf - . | tar -C /usr/local -xf -
-        # We could use a venv instead, but that requires entering the venv on each run step
-        # that runs in its own shell. There are some actions that help with that, but not for msys2
-        # that I can find. (dhalbert)
-        pip install --break-system-packages wheel
-        # requirements-dev.txt doesn't install on windows. (with msys2 python)
-        # instead, pick a subset for what we want to do
-        # jsonschema is needed by mbedtls' generate_driver_wrappers.py. Pin it below 4.18:
-        # 4.18 and later depend on rpds-py, a Rust extension with no wheel for msys2 python
-        # (SOABI cpython-3xx-x86_64-cygwin), and maturin refuses to build it from source
-        # ("Unsupported platform: x86_64-cygwin"). 4.17.3 uses attrs and pyrsistent instead,
-        # both of which install without a Rust toolchain.
-        pip install --break-system-packages cascadetoml jinja2 typer click intelhex 'jsonschema<4.18'
-        # check that installed packages work....?
-        which python; python --version; python -c "import cascadetoml"
-        which python3; python3 --version; python3 -c "import cascadetoml"
-    - name: Set up repository
-      uses: actions/checkout@v6
-      with:
-        submodules: false
-        show-progress: false
-        fetch-depth: 1
-        persist-credentials: false
-    - name: Set up submodules
-      uses: ./.github/actions/deps/submodules
-    - name: build mpy-cross
-      run: make -j4 -C mpy-cross
-    - name: build rp2040
-      run: make -j4 -C ports/raspberrypi BOARD=adafruit_feather_rp2040 TRANSLATION=de_DE
-    - name: build samd21
-      run: make -j4 -C ports/atmel-samd BOARD=feather_m0_express TRANSLATION=zh_Latn_pinyin
-    - name: build samd51
-      run: make -j4 -C ports/atmel-samd BOARD=feather_m4_express TRANSLATION=es
-    - name: build nordic
-      run: make -j4 -C ports/nordic BOARD=feather_nrf52840_express TRANSLATION=fr
-    - name: build stm
-      run: make -j4 -C ports/stm BOARD=feather_stm32f405_express TRANSLATION=pt_BR
-    # I gave up trying to do esp builds on windows when I saw
-    # ERROR: Platform MINGW64_NT-10.0-17763-x86_64 appears to be unsupported
-    # https://github.com/espressif/esp-idf/issues/7062
-
-  windows-zephyr:
-    strategy:
-      matrix:
-        os: [windows-2022, windows-2025]
-    runs-on: ${{ matrix.os }}
-    needs: scheduler
-    if: needs.scheduler.outputs.windows == 'True'
-    env:
-      CP_VERSION: ${{ needs.scheduler.outputs.cp-version }}
-    steps:
-    - name: Set up repository
-      uses: actions/checkout@v6
-      with:
-        submodules: false
-        show-progress: false
-        fetch-depth: 1
-        persist-credentials: false
-    - uses: actions/setup-python@v6
-      with:
-        python-version: '3.13'
-    - name: Set up Zephyr
-      uses: ./.github/actions/deps/ports/zephyr-cp
-    - name: Set up submodules
-      uses: ./.github/actions/deps/submodules
-    - name: build mpy-cross
-      run: make -j4 -C mpy-cross
-    - name: build ek_ra8d1
-      run: make -j4 -C ports/zephyr-cp BOARD=renesas_ek_ra8d1
 
   ports:
     needs: [scheduler, mpy-cross, tests]


### PR DESCRIPTION
- Fixes #11160 

Remove Windows build that tried building several boards to verify that the Windows build was still possible.

Note that `mpy-cross` is still built for Windows.