### PR TITLE
rp2040/rp2350: Support multicast TTL socket option

### DIFF
--- a/ports/raspberrypi/common-hal/socketpool/Socket.c
+++ b/ports/raspberrypi/common-hal/socketpool/Socket.c
@@ -1226,6 +1226,20 @@ int common_hal_socketpool_socket_setsockopt(socketpool_socket_obj_t *self, int l
     bool enable = optlen == sizeof(&zero) && memcmp(value, &zero, optlen);
 
     switch (level) {
+        case SOCKETPOOL_IPPROTO_IP:
+            switch (optname) {
+                case SOCKETPOOL_IP_MULTICAST_TTL:
+                    if (self->type != SOCKETPOOL_SOCK_DGRAM) {
+                        return -MP_EOPNOTSUPP;
+                    }
+                    if (self->pcb.udp == NULL || optlen < sizeof(uint8_t)) {
+                        return -MP_EINVAL;
+                    }
+                    udp_set_multicast_ttl(self->pcb.udp, *(const uint8_t *)value);
+                    return 0;
+            }
+            break;
+
         case SOCKETPOOL_IPPROTO_TCP:
             switch (optname) {
                 case SOCKETPOOL_TCP_NODELAY:


### PR DESCRIPTION
Closes #9938.

The Raspberry Pi port uses lwIP's raw API rather than its socket API, so it cannot delegate this option to `lwip_setsockopt()` as the Espressif port does. Handle `IPPROTO_IP` / `IP_MULTICAST_TTL` for UDP sockets by updating the UDP PCB's multicast TTL directly.

The implementation also:
- returns `EOPNOTSUPP` for non-datagram sockets;
- returns `EINVAL` for a closed UDP PCB or an empty option value;
- follows lwIP's one-byte `IP_MULTICAST_TTL` representation.

Testing:
- `pre-commit run --files ports/raspberrypi/common-hal/socketpool/Socket.c`
- `gmake -C ports/raspberrypi BOARD=raspberry_pi_pico_w -j4`
- `gmake -C ports/raspberrypi BOARD=raspberry_pi_pico2_w -j4`
- inspected both generated objects to confirm the option path writes one byte to `udp_pcb.mcast_ttl`

Both builds produced `firmware.uf2`. I do not have a Pico W/Pico 2 W connected, so I have not performed an on-device multicast packet capture.
