### PR TITLE
cxd56: make os.urandom() raise NotImplementedError

### DIFF
--- a/ports/cxd56/common-hal/os/__init__.c
+++ b/ports/cxd56/common-hal/os/__init__.c
@@ -10,17 +10,7 @@
 #include "py/objstr.h"
 #include "py/objtuple.h"
 
+// No HW TRNG.
 bool common_hal_os_urandom(uint8_t *buffer, mp_uint_t length) {
-    uint32_t i = 0;
-
-    while (i < length) {
-        uint32_t new_random = rand();
-        for (int j = 0; j < 4 && i < length; j++) {
-            buffer[i] = new_random & 0xff;
-            i++;
-            new_random >>= 8;
-        }
-    }
-
-    return true;
+    return false;
 }


### PR DESCRIPTION
The `cxd56` implementation of `os.urandom()` used `rand()`, but `os.urandom()` requires a TRNG, and the chip has no support for that. Make `os.urandom()` raise `NotImplementedError`.