### PR TITLE
picodvi: add Framebuffer.wait_for_vblank() for tear-free full repaints (RP2350)

### DIFF
--- a/ports/raspberrypi/bindings/picodvi/Framebuffer.c
+++ b/ports/raspberrypi/bindings/picodvi/Framebuffer.c
@@ -189,9 +189,27 @@ MP_DEFINE_CONST_FUN_OBJ_1(picodvi_framebuffer_get_color_depth_obj, picodvi_frame
 MP_PROPERTY_GETTER(picodvi_framebuffer_color_depth_obj,
     (mp_obj_t)&picodvi_framebuffer_get_color_depth_obj);
 
+//|     def wait_for_vblank(self) -> None:
+//|         """Block until the next frame boundary (vertical blank), then return. Call this right
+//|         before a full-framebuffer repaint so the repaint starts at the top of scanout and races
+//|         ahead of the beam, avoiding tearing without a second framebuffer. The repaint must
+//|         complete faster than one scanout sweep (~16 ms at 60 Hz) to stay ahead of the beam;
+//|         if it cannot (e.g. a full 640x480 ``displayio`` refresh), use a lower resolution or
+//|         repaint a smaller area. Bounded by a short timeout, so it is safe even if no DVI
+//|         signal is active. No-op on the RP2040 PIO-DVI path."""
+//|         ...
+static mp_obj_t picodvi_framebuffer_wait_for_vblank(mp_obj_t self_in) {
+    picodvi_framebuffer_obj_t *self = (picodvi_framebuffer_obj_t *)self_in;
+    check_for_deinit(self);
+    common_hal_picodvi_framebuffer_wait_for_vblank(self);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(picodvi_framebuffer_wait_for_vblank_obj, picodvi_framebuffer_wait_for_vblank);
+
 
 static const mp_rom_map_elem_t picodvi_framebuffer_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&picodvi_framebuffer_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_wait_for_vblank), MP_ROM_PTR(&picodvi_framebuffer_wait_for_vblank_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&picodvi_framebuffer_width_obj) },
     { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&picodvi_framebuffer_height_obj) },

--- a/ports/raspberrypi/bindings/picodvi/Framebuffer.h
+++ b/ports/raspberrypi/bindings/picodvi/Framebuffer.h
@@ -25,6 +25,7 @@ void common_hal_picodvi_framebuffer_construct(picodvi_framebuffer_obj_t *self,
 void common_hal_picodvi_framebuffer_deinit(picodvi_framebuffer_obj_t *self);
 bool common_hal_picodvi_framebuffer_deinited(picodvi_framebuffer_obj_t *self);
 void common_hal_picodvi_framebuffer_refresh(picodvi_framebuffer_obj_t *self);
+void common_hal_picodvi_framebuffer_wait_for_vblank(picodvi_framebuffer_obj_t *self);
 int common_hal_picodvi_framebuffer_get_width(picodvi_framebuffer_obj_t *self);
 int common_hal_picodvi_framebuffer_get_height(picodvi_framebuffer_obj_t *self);
 int common_hal_picodvi_framebuffer_get_row_stride(picodvi_framebuffer_obj_t *self);

--- a/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2040.c
+++ b/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2040.c
@@ -364,6 +364,11 @@ bool common_hal_picodvi_framebuffer_deinited(picodvi_framebuffer_obj_t *self) {
 void common_hal_picodvi_framebuffer_refresh(picodvi_framebuffer_obj_t *self) {
 }
 
+void common_hal_picodvi_framebuffer_wait_for_vblank(picodvi_framebuffer_obj_t *self) {
+    // No frame-boundary counter on the RP2040 PIO-DVI path; vblank sync is a no-op here (the
+    // tear-free full-repaint path is RP2350/HSTX, e.g. Fruit Jam). Present so the binding links.
+}
+
 int common_hal_picodvi_framebuffer_get_width(picodvi_framebuffer_obj_t *self) {
     return self->width;
 }

--- a/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2350.c
+++ b/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2350.c
@@ -29,6 +29,7 @@
 #include "py/gc.h"
 #include "py/runtime.h"
 #include "shared-bindings/time/__init__.h"
+#include "supervisor/background_callback.h"
 #include "supervisor/port.h"
 
 #include "pico/stdlib.h"
@@ -160,6 +161,11 @@ static uint32_t vactive_line720[VACTIVE_LEN] = {
 
 picodvi_framebuffer_obj_t *active_picodvi = NULL;
 
+// Incremented once per completed frame by the DMA frame-boundary IRQ, so refresh() can block
+// until the next frame starts (vblank sync). A full-framebuffer repaint that begins right after a
+// frame boundary then races ahead of scanout, avoiding tearing without a second framebuffer.
+static volatile uint32_t framebuffer_frame_count = 0;
+
 static void __not_in_flash_func(dma_irq_handler)(void) {
     if (active_picodvi == NULL) {
         return;
@@ -171,6 +177,7 @@ static void __not_in_flash_func(dma_irq_handler)(void) {
     // will trigger the pixel channel).
     dma_channel_hw_t *ch = &dma_hw->ch[active_picodvi->dma_command_channel];
     ch->al3_read_addr_trig = (uintptr_t)active_picodvi->dma_commands;
+    framebuffer_frame_count++;    // frame boundary: scanout has wrapped back to the top
 }
 
 bool common_hal_picodvi_framebuffer_preflight(
@@ -623,6 +630,23 @@ bool common_hal_picodvi_framebuffer_deinited(picodvi_framebuffer_obj_t *self) {
 }
 
 void common_hal_picodvi_framebuffer_refresh(picodvi_framebuffer_obj_t *self) {
+}
+
+void common_hal_picodvi_framebuffer_wait_for_vblank(picodvi_framebuffer_obj_t *self) {
+    // Block until the next frame boundary (vblank). A full-framebuffer repaint issued right after
+    // this returns starts at the top of scanout and stays ahead of the beam, so it does not tear
+    // mid-screen. Bounded by a timeout so a stopped or absent DVI signal can never hang the caller.
+    if (self != active_picodvi) {
+        return;
+    }
+    uint32_t start = framebuffer_frame_count;
+    uint64_t deadline = common_hal_time_monotonic_ms() + 30;    // ~2 frames @ 60 Hz
+    while (framebuffer_frame_count == start) {
+        RUN_BACKGROUND_TASKS;      // don't starve USB host / other tasks during the ~<16 ms wait
+        if (common_hal_time_monotonic_ms() >= deadline) {
+            break;
+        }
+    }
 }
 
 int common_hal_picodvi_framebuffer_get_width(picodvi_framebuffer_obj_t *self) {

--- a/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2350.c
+++ b/ports/raspberrypi/common-hal/picodvi/Framebuffer_RP2350.c
@@ -640,10 +640,10 @@ void common_hal_picodvi_framebuffer_wait_for_vblank(picodvi_framebuffer_obj_t *s
         return;
     }
     uint32_t start = framebuffer_frame_count;
-    uint64_t deadline = common_hal_time_monotonic_ms() + 30;    // ~2 frames @ 60 Hz
+    uint64_t timeout = common_hal_time_monotonic_ms() + 30;    // ~2 frames @ 60 Hz
     while (framebuffer_frame_count == start) {
         RUN_BACKGROUND_TASKS;      // don't starve USB host / other tasks during the ~<16 ms wait
-        if (common_hal_time_monotonic_ms() >= deadline) {
+        if (common_hal_time_monotonic_ms() >= timeout) {
             break;
         }
     }


### PR DESCRIPTION
On the RP2350 HSTX path there is currently no way to synchronize with scanout, so every repaint races the beam and can tear mid-screen. A second framebuffer as a workaround costs 150-300 KB of internal RAM.

This adds a frame counter to the existing per-frame DMA IRQ and an opt-in `Framebuffer.wait_for_vblank()` that blocks until the next frame starts. The wait is bounded by a ~30 ms timeout (no DVI signal can never hang the caller) and runs `RUN_BACKGROUND_TASKS` inside, so USB host keeps being serviced. `refresh()` stays a no-op and the normal path is untouched; the RP2040 backend stubs the method as a no-op.

This doesn't make a repaint faster - it only starts it at the top of the frame, so it still has to finish within one sweep (~16 ms at 60 Hz). A side benefit: the display runs at a fixed 60 Hz, so a loop that waits for it once per iteration is automatically paced to 60 fps.

Verified on an Adafruit Fruit Jam with firmware built from this branch: a column of sprites across the full screen height, identical loop and pacing in both phases, the only difference being the one added call - without it a rolling tear line sweeps the sprites, with it the image is solid at a locked 60 fps. The same setup also maps the limit: a full-height object at 320×240 can still tear in its top ~80 rows, because displayio's refresh spends ~5 ms in setup before pixels start flowing. RP2040 DVI builds compile with the no-op stub.

Watch (don't pay attention to the occasional image freezing, that's a capture issue) - green = wait on, red = wait off: https://player.mediadelivery.net/play/689358/17a47c6c-131c-487b-8449-f2c90aa8081f

AI generated tester: [test_wait_for_vblank.py](https://github.com/user-attachments/files/30909572/test_wait_for_vblank.py)
