### PR TITLE
usb_audio: refill the mic FIFO from tud_audio_tx_done_isr()

### DIFF
--- a/ports/espressif/mpconfigport.mk
+++ b/ports/espressif/mpconfigport.mk
@@ -422,7 +422,12 @@ USB_NUM_IN_ENDPOINTS = 5
 # affect existing boards. Freeing one IN endpoint (usb_hid.disable()) is then the
 # only thing a user needs, with no custom build.
 ifeq ($(IDF_TARGET),esp32s3)
+# It needs the TinyUSB device stack and audiocore, so leave it off for boards
+# that turn either off. The S3 has no AUDIOIO and no AUDIOPWMIO, so audiocore
+# follows CIRCUITPY_AUDIOBUSIO here.
+ifeq ($(filter 0,$(CIRCUITPY_USB_DEVICE) $(CIRCUITPY_AUDIOCORE) $(CIRCUITPY_AUDIOBUSIO)),)
 CIRCUITPY_USB_AUDIO ?= 1
+endif
 endif
 
 # Usually lots of flash space available

--- a/ports/espressif/mpconfigport.mk
+++ b/ports/espressif/mpconfigport.mk
@@ -417,5 +417,13 @@ endif
 USB_NUM_ENDPOINT_PAIRS = 7
 USB_NUM_IN_ENDPOINTS = 5
 
+# usb_audio is compiled in on the S3 but claims no endpoints until
+# usb_audio.enable() is called from boot.py, so enabling it by default does not
+# affect existing boards. Freeing one IN endpoint (usb_hid.disable()) is then the
+# only thing a user needs, with no custom build.
+ifeq ($(IDF_TARGET),esp32s3)
+CIRCUITPY_USB_AUDIO ?= 1
+endif
+
 # Usually lots of flash space available
 CIRCUITPY_MESSAGE_COMPRESSION_LEVEL ?= 1

--- a/shared-module/usb_audio/__init__.c
+++ b/shared-module/usb_audio/__init__.c
@@ -18,6 +18,7 @@
 #include "py/mphal.h"
 #include "py/runtime.h"
 #include "supervisor/shared/tick.h"
+#include "supervisor/usb.h"
 #include "tusb.h"
 
 static bool usb_audio_is_enabled = false;
@@ -465,7 +466,30 @@ bool tud_audio_set_itf_cb(uint8_t rhport, tusb_control_request_t const *p_reques
         usb_audio_usbspeaker_streaming_reset();
     } else if (itf == usb_audio_mic_as_itf) {
         usb_audio_mic_streaming = streaming;
+        if (streaming) {
+            // Prime the FIFO for the first frame; after that each completed
+            // transfer schedules the next refill via tud_audio_tx_done_isr().
+            usb_background_schedule();
+        }
     }
+    return true;
+}
+
+// Invoked from the audio class transfer-complete path once the next packet has
+// been loaded into the EP IN buffer. TinyUSB services audio completions in ISR
+// context, so they never queue a USB event. A port that pumps the optional class
+// tasks from a task loop sitting behind tud_task() therefore never refills the
+// microphone FIFO. Scheduling the refill here keeps usb_audio independent of how
+// a port drives TinyUSB.
+bool tud_audio_tx_done_isr(uint8_t rhport, uint16_t n_bytes_sent, uint8_t func_id,
+    uint8_t ep_in, uint8_t cur_alt_setting) {
+    (void)rhport;
+    (void)n_bytes_sent;
+    (void)func_id;
+    (void)ep_in;
+    (void)cur_alt_setting;
+
+    usb_background_schedule();
     return true;
 }
 


### PR DESCRIPTION
Jumped in on a [usb_audio PR# 11102](https://github.com/adafruit/circuitpython/pull/11102) that @relic-se @FoamyGuy had been working on. This is to add ESP32-S2 and S3 usb_audio support. It already worked on
RP2040, RP2350 and nRF52840. On ESP32 the device enumerated as a correct UAC2
microphone, the host opened the stream, and then nothing came out.

I put a Cynthion on the bus to see what the host was actually doing. It was
behaving perfectly:

| | before | after |
|---|---|---|
| stream held open | 578 ms, host gave up | 4.01 s, normal close |
| IN tokens on the audio endpoint | 573 | 4007 |
| full size packets | 8 | 4006 |
| zero length packets | 564 | 0 |
| CRC16 errors | 0 | 0 |
| `arecord -d 4` | EIO, 44 bytes | full length capture |

The host polled every 1 ms for 578 ms and only then gave up. Nothing was corrupt.
The device sent 8 real frames and then zero length packets for the remaining 565.

TinyUSB handles audio completions in the ISR, so they never wake `tud_task()`. On
espressif the class tasks run after `tud_task()`, so they never run either and the
FIFO is filled once. `tud_audio_tx_done_isr()` is TinyUSB's hook for exactly this,
and refilling from there needs no port changes.

Also here: `CIRCUITPY_USB_AUDIO ?= 1` on esp32s3, which claims no endpoints until
`enable()` is called. esp32s2 stays off by default.

S2 and S3 allow five IN endpoints including EP0 and the default build uses all
five, so one has to be freed:

```python
# boot.py
import usb_hid, usb_audio
usb_hid.disable()
usb_audio.enable(sample_rate=48000, channel_count=1, microphone=True, speaker=False)
```

```python
# code.py, 1 kHz tone
import array, math, audiocore, usb_audio
N = 480
buf = array.array("h", [int(18000 * math.sin(2 * math.pi * 10 * i / N)) for i in range(N)])
sample = audiocore.RawSample(buf, channel_count=1, sample_rate=48000)
usb_audio.usb_microphone.play(sample, loop=True)
```

Tested on Metro ESP32-S3 and Metro ESP32-S2 against this branch.

```
arecord -f S16_LE -r 48000 -c 1 -d 4
```

writes 384044 bytes on both.
