### PR TITLE
tools: skip check suites with no workflowRun in ci_changes_per_commit.py

### DIFF
--- a/tools/ci_changes_per_commit.py
+++ b/tools/ci_changes_per_commit.py
@@ -155,6 +155,11 @@ def get_commit_depth_and_check_suite(query_commits):
                 check_suites = commit["checkSuites"]
                 if check_suites["totalCount"] > 0:
                     for check_suite in check_suites["nodes"]:
+                        # workflowRun is null for check suites not attached to
+                        # a workflow run, such as one that was deleted or one
+                        # belonging to an app integration.
+                        if check_suite["workflowRun"] is None:
+                            continue
                         if check_suite["workflowRun"]["workflow"]["name"] == "Build CI":
                             return [
                                 {"sha": commit_sha, "depth": commit_depth},


### PR DESCRIPTION
## What

`check_suite["workflowRun"]` is null for check suites not attached to a workflow run, such as one whose run was deleted or one belonging to an app integration. `get_commit_depth_and_check_suite()` indexes into it unconditionally at `tools/ci_changes_per_commit.py:158`:

```python
if check_suite["workflowRun"]["workflow"]["name"] == "Build CI":
```

so the scheduler job's "Get last commit with checks" step fails:

```
Traceback (most recent call last):
  File "tools/ci_changes_per_commit.py", line 241, in <module>
  File "tools/ci_changes_per_commit.py", line 218, in main
  File "tools/ci_changes_per_commit.py", line 158, in get_commit_depth_and_check_suite
TypeError: 'NoneType' object is not subscriptable
```

When scheduler fails, every downstream job is skipped, so the PR gets no build coverage at all.

## Why

An entry with no workflow run can never match "Build CI", so skipping it is the whole fix.

## How I tested it

The traceback above is from a real scheduler run on my fork. With the guard, scheduler completes and the downstream jobs run.

No hardware involved. I could not reproduce it on demand, since it depends on which check suites GitHub returns for a given commit.

## Scope

One guard, one file. No change to which commit is selected when `workflowRun` is present.

## AI assistance

Written with Claude Code. I reproduced the failure and verified the fix on my own CI.
