### PR TITLE
supervisor/web_workflow: check the listener socket calls for failure

### DIFF
--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -398,14 +398,33 @@ bool supervisor_start_web_workflow(void) {
 
         if (common_hal_socketpool_socket_get_closed(&listening)) {
             #if CIRCUITPY_SOCKETPOOL_IPV6
-            socketpool_socket(&pool, SOCKETPOOL_AF_INET6, SOCKETPOOL_SOCK_STREAM, 0, &listening);
+            bool opened = socketpool_socket(&pool, SOCKETPOOL_AF_INET6, SOCKETPOOL_SOCK_STREAM, 0, &listening);
             #else
-            socketpool_socket(&pool, SOCKETPOOL_AF_INET, SOCKETPOOL_SOCK_STREAM, 0, &listening);
+            bool opened = socketpool_socket(&pool, SOCKETPOOL_AF_INET, SOCKETPOOL_SOCK_STREAM, 0, &listening);
             #endif
+            // Ports with an offloaded network stack can refuse to create a
+            // socket until the interface has an address (this board returns
+            // ENOTCONN before DHCP completes). Binding and listening on the
+            // unset descriptor then fails with EBADF, and reporting success
+            // leaves the supervisor polling a socket that was never opened.
+            //
+            // Returning false avoids that but is not a retry: the background
+            // callback never re-enters this function, so the next attempt is
+            // the next supervisor_workflow_reset(), i.e. a VM restart. A board
+            // that only gets an address after boot will not bring the workflow
+            // up on its own until then.
+            if (!opened) {
+                return false;
+            }
             common_hal_socketpool_socket_settimeout(&listening, 0);
-            // Bind to any ip. (Not checking for failures)
-            common_hal_socketpool_socket_bind(&listening, "", 0, web_api_port);
-            common_hal_socketpool_socket_listen(&listening, 1);
+            if (common_hal_socketpool_socket_bind(&listening, "", 0, web_api_port) != 0) {
+                common_hal_socketpool_socket_close(&listening);
+                return false;
+            }
+            if (!common_hal_socketpool_socket_listen(&listening, 1)) {
+                common_hal_socketpool_socket_close(&listening);
+                return false;
+            }
         }
         // Wake polling thread (maybe)
         socketpool_socket_poll_resume();


### PR DESCRIPTION
## What
`supervisor_start_web_workflow()` created the listening socket, bound it and called `listen()` without checking any of them, with an explicit `// Bind to any ip. (Not checking for failures)` comment on the bind. On a port whose network stack can refuse to create a socket, the descriptor stays unset, `bind()` and `listen()` run on -1 and fail with `EBADF`, and the function still returns true.

The caller takes that as success and installs the background callback, so the supervisor polls a socket that was never opened. Nothing is served and there is no diagnostic.

## Why
This is shared supervisor code, so it affects every port that has web workflow: espressif, raspberrypi and zephyr-cp. `CIRCUITPY_WEB_WORKFLOW ?= $(CIRCUITPY_WIFI)`, so atmel-samd, stm and nordic do not compile this file and are unaffected.

Not specific to the port where it was found. #10054 reports web workflow unreachable after a watchdog reset on several ESP32 boards, and the attempted fix in #10948 moved port 80 from closed to filtered, that is bound but never serving, which is the same end state this produces.

## Hardware tested

Two parts: the original failure on zephyr-cp, and a no regression check on the two ports that already ship web workflow.

### Failure case

Silicon Labs SiWx917-DK2605A, Zephyr board `siwx917_dk2605a`, zephyr-cp port, host on the same LAN. Serial output before the change:

```
socket() ok=0 num=-1 errno=107   ENOTCONN
bind port 80 -> 9 errno=9        EBADF
listen -> 0 errno=9 closed=1
(returns true)
```

With the change the workflow either starts or reports failure, rather than reporting success on a socket that was never opened. Verified serving afterwards: `/cp/version.json` 200, `/fs/` 401 without credentials and 200 with, PUT 201, GET 200, DELETE 204.

### No regression on espressif and raspberrypi

Three boards flashed with this patch, blank `CIRCUITPY_WEB_API_PASSWORD`, all on the same LAN. REPL banners:

```
Adafruit CircuitPython 10.3.0-alpha.4-41-g444e5f951e-dirty on 2026-08-17; Adafruit Metro ESP32S2 with ESP32S2
Adafruit CircuitPython 10.3.0-alpha.4-41-g444e5f951e-dirty on 2026-08-17; Adafruit Metro ESP32S3 with ESP32S3
Adafruit CircuitPython 10.3.0-alpha.4-41-g444e5f951e-dirty on 2026-08-17; Raspberry Pi Pico 2 W with rp2350a
```

| Board | Port | `/cp/version.json` | `/cp/devices.json` | `/fs/` |
| --- | --- | --- | --- | --- |
| Metro ESP32-S2 | espressif | 200 | 200 | 401 |
| Metro ESP32-S3 | espressif | 200 | 200 | 401 |
| Raspberry Pi Pico 2 W | raspberrypi | 200 | 200 | 401 |

401 on `/fs/` is the expected response with a blank password.

Beyond the scripted checks above, I opened the web workflow page on each of the three boards from a browser on the same LAN, running the build in those banners, and confirmed it loads and serves. No regression on either port.

Also built for `renesas_ek_ra8d1`, a zephyr-cp board CI builds today.

The `-dirty` suffix is a build host artifact. `ports/espressif/esp-idf` is a symlink to a shared checkout at the pinned commit `2b900d12`, which git reports as a typechange. No source file is modified.

## Scope
Error checking only. Deliberately **not** a retry: the next attempt is the next `supervisor_workflow_reset()`. Bringing the workflow up once the interface acquires an address later is a separate change and is not attempted here.

## AI assistance
Written with Claude Code. I ran the hardware myself and checked the web workflow by hand in a browser on all three boards. The serial output, REPL banners and HTTP results above are from the boards, not from a model.

