### PR TITLE
Update issue-labeled-ping to v3

### DIFF
--- a/.github/workflows/notify-on-issue-label.yml
+++ b/.github/workflows/notify-on-issue-label.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
         issues: write
     steps:
-        - uses: tekktrik/issue-labeled-ping@v2
+        - uses: tekktrik/issue-labeled-ping@v3
           with:
                 github-token: ${{ secrets.GITHUB_TOKEN }}
                 user: v923z


### PR DESCRIPTION
Bumping `tekktrik/issue-labeled-ping` to the newly available major revision (updating dependencies).
