### PR TITLE
zephyr-cp: name gpio-keys from zephyr,code when there is no label

### DIFF
--- a/ports/zephyr-cp/cptools/zephyr2cp.py
+++ b/ports/zephyr-cp/cptools/zephyr2cp.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+import re
 
 import cpbuild
 import yaml
@@ -451,6 +452,33 @@ def find_ram_regions(device_tree):
     return rams
 
 
+# gpio-keys nodes identify a key with `zephyr,code` rather than the optional and
+# deprecated `label`, so the code is the only name a modern board gives.
+INPUT_KEY_NAMES = {}
+
+
+def _populate_input_key_names():
+    header = (
+        pathlib.Path(__file__).parent.parent
+        / "zephyr"
+        / "include"
+        / "zephyr"
+        / "dt-bindings"
+        / "input"
+        / "input-event-codes.h"
+    )
+    if not header.exists():
+        return
+    pattern = re.compile(r"^#define\s+INPUT_(?P<name>KEY_\w+)\s+(?P<code>\d+)")
+    for line in header.read_text().splitlines():
+        match = pattern.match(line)
+        if match:
+            INPUT_KEY_NAMES.setdefault(int(match.group("code")), match.group("name"))
+
+
+_populate_input_key_names()
+
+
 @cpbuild.run_in_thread
 def zephyr_dts_to_cp_board(board_id, portdir, builddir, zephyrbuilddir, mpconfigboard=None):  # noqa: C901
     board_dir = builddir / "board"
@@ -677,7 +705,15 @@ def zephyr_dts_to_cp_board(board_id, portdir, builddir, zephyrbuilddir, mpconfig
 
                 if (ioport, num) not in board_names:
                     board_names[(ioport, num)] = []
-                board_names[(ioport, num)].append(props["label"].to_string())
+                # `label` is optional and deprecated on gpio-keys. Modern
+                # boards identify keys with `zephyr,code`, so fall back to the
+                # name of that code.
+                if "label" in props:
+                    board_names[(ioport, num)].append(props["label"].to_string())
+                elif "zephyr,code" in props:
+                    key_code = props["zephyr,code"].to_num()
+                    if key_code in INPUT_KEY_NAMES:
+                        board_names[(ioport, num)].append(INPUT_KEY_NAMES[key_code])
                 if key in node2alias:
                     if "sw0" in node2alias[key]:
                         board_names[(ioport, num)].append("BUTTON")


### PR DESCRIPTION
## What
`zephyr_dts_to_cp_board()` dereferenced `props["label"]` unconditionally for `gpio-keys` nodes:

```python
board_names[(ioport, num)].append(props["label"].to_string())
```

`label` is optional and deprecated on `gpio-keys`. Zephyr's current convention is `zephyr,code`. Any board whose keys omit `label` fails board generation with `KeyError: 'label'`.

## Why
This is not specific to one board. Adafruit's own MacroPad RP2040, in the pinned Zephyr tree at `boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts`, has no labels on its keys:

```dts
compatible = "gpio-keys";

key0: key_0 {
        gpios = <&gpio0 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
        zephyr,code = <INPUT_KEY_F1>;
};
```

`arduino/giga_r1`, `arduino/opta` and `arduino/nano_matter` are the same, and there are more.

## How
Guard the lookup the way the `gpio-leds` handler in the same function already does, and fall back to the name of the key's `zephyr,code` so the board gains a usable name rather than losing one. Codes come from Zephyr's own `include/zephyr/dt-bindings/input/input-event-codes.h`, read once and cached.

A board whose code is not in that header simply gets no name for that key, which is the same as before this change and not an error.

## Testing
Hardware: Silicon Labs SiWx917-DK2605A, Zephyr board `siwx917_dk2605a`, SoC SiWG917M111MGTBA. CircuitPython `10.3.0-alpha.4-63-g88c0b27e1a-dirty` built 2026-08-19, flashed with Simplicity Commander over the onboard J-Link.

Its keys carry no label:

```dts
button0: button_0 { gpios = <&uulpgpio 0x2 0x1>; zephyr,code = <0xb>; };
button1: button_1 { gpios = <&gpiod 0x1 0x1>;    zephyr,code = <0x2>; };
```

Before the change, board generation fails:

```
  File "cptools/zephyr2cp.py", line 692, in zephyr_dts_to_cp_board
    board_names[(ioport, num)].append(props["label"].to_string())
                                      ~~~~~^^^^^^^^^
KeyError: 'label'
```

After, generation succeeds and emits the mapped names:

```c
{ MP_ROM_QSTR(MP_QSTR_KEY_1), MP_ROM_PTR(&pin_PGPIOD_01) },
{ MP_ROM_QSTR(MP_QSTR_KEY_0), MP_ROM_PTR(&pin_PUULPGPIO_02) },
```

which matches the devicetree: `0xb` is `INPUT_KEY_0` on `uulpgpio 0x2`, `0x2` is `INPUT_KEY_1` on `gpiod 0x1`.

On the board, the names exist and the pins work:

```
>>> import board, digitalio
>>> [n for n in dir(board) if n.startswith("KEY")]
['KEY_0', 'KEY_1']
>>> d = digitalio.DigitalInOut(board.KEY_0)
>>> d.switch_to_input(pull=digitalio.Pull.UP)
>>> d.value
True
```

## Scope
One guard plus the code lookup. No behavior change for boards that set `label`.

## AI assistance
Written with Claude Code. I ran the hardware myself. The generated output and REPL session above are from the board, not from a model.

