### PR TITLE
Prevent `audiomixer.Mixer` from resetting all voices when played

### DIFF
--- a/shared-bindings/audiomixer/MixerVoice.h
+++ b/shared-bindings/audiomixer/MixerVoice.h
@@ -14,6 +14,7 @@ extern const mp_obj_type_t audiomixer_mixervoice_type;
 void common_hal_audiomixer_mixervoice_construct(audiomixer_mixervoice_obj_t *self);
 void common_hal_audiomixer_mixervoice_set_parent(audiomixer_mixervoice_obj_t *self, audiomixer_mixer_obj_t *parent);
 void common_hal_audiomixer_mixervoice_play(audiomixer_mixervoice_obj_t *self, mp_obj_t sample, bool loop);
+void common_hal_audiomixer_mixervoice_reset_buffer(audiomixer_mixervoice_obj_t *self);
 void common_hal_audiomixer_mixervoice_stop(audiomixer_mixervoice_obj_t *self);
 void common_hal_audiomixer_mixervoice_end(audiomixer_mixervoice_obj_t *self);
 mp_obj_t common_hal_audiomixer_mixervoice_get_level(audiomixer_mixervoice_obj_t *self);

--- a/shared-module/audiomixer/Mixer.c
+++ b/shared-module/audiomixer/Mixer.c
@@ -66,7 +66,7 @@ void audiomixer_mixer_reset_buffer(audiomixer_mixer_obj_t *self,
     bool single_channel_output,
     uint8_t channel) {
     for (uint8_t i = 0; i < self->voice_count; i++) {
-        common_hal_audiomixer_mixervoice_stop(self->voice[i]);
+        common_hal_audiomixer_mixervoice_reset_buffer(self->voice[i]);
     }
 }
 

--- a/shared-module/audiomixer/MixerVoice.c
+++ b/shared-module/audiomixer/MixerVoice.c
@@ -70,11 +70,17 @@ void common_hal_audiomixer_mixervoice_play(audiomixer_mixervoice_obj_t *self, mp
     self->sample = sample;
     self->loop = loop;
 
-    audiosample_reset_buffer(sample, false, 0);
-    audioio_get_buffer_result_t result = audiosample_get_buffer(sample, false, 0, (uint8_t **)&self->remaining_buffer, &self->buffer_length);
-    // Track length in terms of words.
-    self->buffer_length /= sizeof(uint32_t);
-    self->more_data = result == GET_BUFFER_MORE_DATA;
+    common_hal_audiomixer_mixervoice_reset_buffer(self);
+}
+
+void common_hal_audiomixer_mixervoice_reset_buffer(audiomixer_mixervoice_obj_t *self) {
+    if (self->sample != NULL) {
+        audiosample_reset_buffer(self->sample, false, 0);
+        audioio_get_buffer_result_t result = audiosample_get_buffer(self->sample, false, 0, (uint8_t **)&self->remaining_buffer, &self->buffer_length);
+        // Track length in terms of words.
+        self->buffer_length /= sizeof(uint32_t);
+        self->more_data = result == GET_BUFFER_MORE_DATA;
+    }
 }
 
 bool common_hal_audiomixer_mixervoice_get_playing(audiomixer_mixervoice_obj_t *self) {


### PR DESCRIPTION
The `..._reset_buffer` routine of `audiomixer.Mixer` (which is called when an audiosample API object plays a `Mixer` object) previously called the `audiomixer.MixerVoice.stop` on all voices which would disassociate the sample currently being played by each voice. Because of this, `audiomixer.MixerVoice.play` needed to be called after a mixer object is played. The common paradigm of chaining audiosample objects is broken by this issue. Ie: `audio.play(mixer.play(sample))`.

This update moves the reset buffer logic from `audiomixer.MixerVoice.play` into a dedicated function and calls that routine instead of `audiomixer.MixerVoice.stop` whenever the mixer object is played.

For interest, @dhalbert 

Fixes #11021