### PR TITLE
socketpool: let ports raise gaierror with the real error code

### DIFF
--- a/ports/zephyr-cp/common-hal/socketpool/Socket.c
+++ b/ports/zephyr-cp/common-hal/socketpool/Socket.c
@@ -27,6 +27,7 @@
 #include <string.h>
 
 #include <zephyr/kernel.h>
+#include <zephyr/net/dns_resolve.h>
 #include <zephyr/net/socket.h>
 
 #define SOCKETPOOL_IP_STR_LEN 48
@@ -82,7 +83,12 @@ static void socketpool_resolve_host_or_throw(int family, int type, const char *h
 
     int error = zsock_getaddrinfo(hostname, service_buf, &hints, &result_i);
     if (error != 0 || result_i == NULL) {
-        common_hal_socketpool_socketpool_raise_gaierror_noname();
+        // Report what the resolver said. A null result with no error is the
+        // one case that really is "not found".
+        if (error == 0) {
+            error = DNS_EAI_NONAME;
+        }
+        common_hal_socketpool_socketpool_raise_gaierror(error);
     }
 
     memcpy(addr, result_i->ai_addr, sizeof(struct sockaddr_storage));

--- a/ports/zephyr-cp/common-hal/socketpool/SocketPool.c
+++ b/ports/zephyr-cp/common-hal/socketpool/SocketPool.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include <zephyr/net/socket.h>
+#include <zephyr/net/dns_resolve.h>
 
 void common_hal_socketpool_socketpool_construct(socketpool_socketpool_obj_t *self, mp_obj_t radio) {
     bool is_wifi = false;
@@ -104,7 +105,10 @@ mp_obj_t common_hal_socketpool_getaddrinfo_raise(socketpool_socketpool_obj_t *se
     struct zsock_addrinfo *res = NULL;
     int err = socketpool_getaddrinfo_common(host, port, &hints, &res);
     if (err != 0 || res == NULL) {
-        common_hal_socketpool_socketpool_raise_gaierror_noname();
+        if (err == 0) {
+            err = DNS_EAI_NONAME;
+        }
+        common_hal_socketpool_socketpool_raise_gaierror(err);
     }
 
     nlr_buf_t nlr;

--- a/shared-bindings/socketpool/SocketPool.c
+++ b/shared-bindings/socketpool/SocketPool.c
@@ -190,15 +190,27 @@ MP_DEFINE_CONST_OBJ_TYPE(
     );
 
 MP_WEAK MP_NORETURN
-void common_hal_socketpool_socketpool_raise_gaierror_noname(void) {
+void common_hal_socketpool_socketpool_raise_gaierror(int err) {
     vstr_t vstr;
     mp_print_t print;
     vstr_init_print(&vstr, 64, &print);
-    mp_printf(&print, "%S", MP_ERROR_TEXT("Name or service not known"));
+    // Only EAI_NONAME means the name was not found. Other codes cover
+    // unrelated failures, such as an unsupported family, so use the generic
+    // message for those rather than one that would be misleading.
+    if (err == SOCKETPOOL_EAI_NONAME) {
+        mp_printf(&print, "%S", MP_ERROR_TEXT("Name or service not known"));
+    } else {
+        mp_cprintf(&print, MP_ERROR_TEXT("%q failure: %d"), MP_QSTR_getaddrinfo, err);
+    }
 
     mp_obj_t exc_args[] = {
-        MP_OBJ_NEW_SMALL_INT(SOCKETPOOL_EAI_NONAME),
+        MP_OBJ_NEW_SMALL_INT(err),
         mp_obj_new_str_from_vstr(&vstr),
     };
     nlr_raise(mp_obj_new_exception_args(&mp_type_gaierror, MP_ARRAY_SIZE(exc_args), exc_args));
+}
+
+MP_WEAK MP_NORETURN
+void common_hal_socketpool_socketpool_raise_gaierror_noname(void) {
+    common_hal_socketpool_socketpool_raise_gaierror(SOCKETPOOL_EAI_NONAME);
 }

--- a/shared-bindings/socketpool/SocketPool.h
+++ b/shared-bindings/socketpool/SocketPool.h
@@ -26,5 +26,6 @@ bool socketpool_socket(socketpool_socketpool_obj_t *self,
     int proto, socketpool_socket_obj_t *sock);
 
 MP_NORETURN void common_hal_socketpool_socketpool_raise_gaierror_noname(void);
+MP_NORETURN void common_hal_socketpool_socketpool_raise_gaierror(int err);
 
 mp_obj_t common_hal_socketpool_getaddrinfo_raise(socketpool_socketpool_obj_t *self, const char *host, int port, int family, int type, int proto, int flags);


### PR DESCRIPTION
## What
`common_hal_socketpool_socketpool_raise_gaierror_noname()` was the only way for a port to raise `gaierror`, so every `getaddrinfo()` failure surfaced as `EAI_NONAME` regardless of what actually went wrong. A lookup that failed because of an unsupported address family looked identical to one for a name that does not exist.

## How
Add `common_hal_socketpool_socketpool_raise_gaierror(int err)`, which puts the real code in `args[0]` where callers can act on it, and express the existing `_noname()` helper in terms of it:

```c
MP_WEAK MP_NORETURN
void common_hal_socketpool_socketpool_raise_gaierror_noname(void) {
    common_hal_socketpool_socketpool_raise_gaierror(SOCKETPOOL_EAI_NONAME);
}
```

Existing callers are unchanged. espressif and raspberrypi still use `_noname()` and behave exactly as before.

No new translatable strings. `EAI_NONAME` keeps `"Name or service not known"`; anything else uses the existing generic `"%q failure: %d"` with `MP_QSTR_getaddrinfo`. That needs `mp_cprintf()` rather than `mp_printf()`, since `MP_ERROR_TEXT` yields `mp_rom_error_text_t` and not `const char *`.

zephyr-cp is the first user. Both of its resolver call sites had the real error in hand and discarded it: `getaddrinfo()` in `SocketPool.c`, and the host lookup behind `socket.connect()` in `Socket.c`.

## Behaviour change
`socket.connect()` to a host that fails to resolve now raises the resolver's actual code instead of always `EAI_NONAME`. This is the intended fix, but it is user visible.

## Testing

Hardware: one Silicon Labs SiWx917-DK2605A, Zephyr board `siwx917_dk2605a`, SoC SiWG917M111MGTBA, on a live network. CircuitPython `10.3.0-alpha.4-63-g88c0b27e1a-dirty` built 2026-08-19, flashed with Simplicity Commander over the onboard J-Link. Every row below was run on the board, before and after the change.

| call | before | after |
| --- | --- | --- |
| `getaddrinfo("", 80)` | -11 | -11 |
| `getaddrinfo(".", 80)` | -4 | -4 |
| `getaddrinfo("example.com", 80, AF_INET6)` | -9 | -9 |
| `getaddrinfo("nope-zz-qq.invalid", 80)` | -4 | -4 |
| `getaddrinfo("a.b.c.d.e.nonexistenttld", 80)` | -4 | -4 |
| `getaddrinfo("0.0.0.0", 80)` | resolves | resolves |
| `socket.connect(("nope-zz-qq.invalid", 80))` | **-2** | **-4** |

Only the `connect()` row moves, which is the `Socket.c` call site this change fixes. The `getaddrinfo` rows are identical before and after.

Before, from the REPL, with `_noname()` hardcoding the code and the message:

```
>>> sk.connect(("nope-zz-qq.invalid", 80))
gaierror: (-2, 'Name or service not known')
```

After, reporting what the resolver returned:

```
>>> import wifi, socketpool
>>> pool = socketpool.SocketPool(wifi.radio)
>>> pool.getaddrinfo("no-such-host-xyz.invalid", 80)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
gaierror: (-4, 'getaddrinfo failure: -4')
>>>
```

Codes are Zephyr's, from `zephyr/net/dns_resolve.h`: -4 `DNS_EAI_FAIL`, -9 `DNS_EAI_ADDRFAMILY`, -11 `DNS_EAI_SYSTEM`.

Also built `adafruit_metro_esp32s3` on the espressif port to exercise the shared-bindings change against an existing consumer.

**Not tested:** the `EAI_NONAME` path on zephyr-cp. Both call sites now pass the resolver's code, and this resolver never returned -2 for any input tried. The synthesized `err == 0 && res == NULL` case remains as a guard but I could not trigger it. Results are from a single board.

## Scope
Adds one function, refactors one, and updates the two zephyr-cp call sites. No change to espressif or raspberrypi behaviour.

## AI assistance
Written with Claude Code. I ran the hardware myself. The codes and REPL output above are from the board, not from a model.

