### PR TITLE
mp3decoder inbuf update fix

### DIFF
--- a/shared-module/audiomp3/MP3Decoder.c
+++ b/shared-module/audiomp3/MP3Decoder.c
@@ -109,6 +109,8 @@ static void stream_set_blocking(audiomp3_mp3file_obj_t *self, bool block_ok) {
     mp_call_method_n_kw(1, 0, self->settimeout_args);
 }
 
+static bool mp3file_update_inbuf_always_impl(audiomp3_mp3file_obj_t *self, bool block_ok);
+
 /** Fill the input buffer unconditionally.
  *
  * Returns true if the input buffer contains any useful data,
@@ -120,6 +122,13 @@ static void stream_set_blocking(audiomp3_mp3file_obj_t *self, bool block_ok) {
  * Sets self->eof if any read of the file returns 0 bytes
  */
 static bool mp3file_update_inbuf_always(audiomp3_mp3file_obj_t *self, bool block_ok) {
+    background_callback_prevent();
+    bool result = mp3file_update_inbuf_always_impl(self, block_ok);
+    background_callback_allow();
+    return result;
+}
+
+static bool mp3file_update_inbuf_always_impl(audiomp3_mp3file_obj_t *self, bool block_ok) {
     if (self->eof || INPUT_BUFFER_SPACE(self->inbuf) == 0) {
         return INPUT_BUFFER_AVAILABLE(self->inbuf) > 0;
     }
@@ -135,7 +144,8 @@ static bool mp3file_update_inbuf_always(audiomp3_mp3file_obj_t *self, bool block
         self->inbuf.read_off = 0;
     }
 
-    for (size_t to_read; !self->eof && (to_read = INPUT_BUFFER_SPACE(self->inbuf)) > 0;) {
+    for (size_t to_read; !self->eof && INPUT_BUFFER_SPACE(self->inbuf) > 0 &&
+         (to_read = (size_t)INPUT_BUFFER_SPACE(self->inbuf)) > 0;) {
         uint8_t *write_ptr = self->inbuf.buf + self->inbuf.write_off;
         ssize_t n_read = stream_read(self->stream, write_ptr, to_read);
 

--- a/shared-module/audiomp3/MP3Decoder.c
+++ b/shared-module/audiomp3/MP3Decoder.c
@@ -109,8 +109,6 @@ static void stream_set_blocking(audiomp3_mp3file_obj_t *self, bool block_ok) {
     mp_call_method_n_kw(1, 0, self->settimeout_args);
 }
 
-static bool mp3file_update_inbuf_always_impl(audiomp3_mp3file_obj_t *self, bool block_ok);
-
 /** Fill the input buffer unconditionally.
  *
  * Returns true if the input buffer contains any useful data,
@@ -123,12 +121,7 @@ static bool mp3file_update_inbuf_always_impl(audiomp3_mp3file_obj_t *self, bool 
  */
 static bool mp3file_update_inbuf_always(audiomp3_mp3file_obj_t *self, bool block_ok) {
     background_callback_prevent();
-    bool result = mp3file_update_inbuf_always_impl(self, block_ok);
-    background_callback_allow();
-    return result;
-}
 
-static bool mp3file_update_inbuf_always_impl(audiomp3_mp3file_obj_t *self, bool block_ok) {
     if (self->eof || INPUT_BUFFER_SPACE(self->inbuf) == 0) {
         return INPUT_BUFFER_AVAILABLE(self->inbuf) > 0;
     }
@@ -170,7 +163,10 @@ static bool mp3file_update_inbuf_always_impl(audiomp3_mp3file_obj_t *self, bool 
     }
 
     // Return true iff there are at least some useful bytes in the buffer
-    return INPUT_BUFFER_AVAILABLE(self->inbuf) > 0;
+    bool result = INPUT_BUFFER_AVAILABLE(self->inbuf) > 0;
+
+    background_callback_allow();
+    return result;
 }
 
 /** Update the inbuf from a background callback.

--- a/shared-module/audiomp3/MP3Decoder.c
+++ b/shared-module/audiomp3/MP3Decoder.c
@@ -120,10 +120,13 @@ static void stream_set_blocking(audiomp3_mp3file_obj_t *self, bool block_ok) {
  * Sets self->eof if any read of the file returns 0 bytes
  */
 static bool mp3file_update_inbuf_always(audiomp3_mp3file_obj_t *self, bool block_ok) {
+    // Every return from this function must be preceded by background_callback_allow();
     background_callback_prevent();
 
     if (self->eof || INPUT_BUFFER_SPACE(self->inbuf) == 0) {
-        return INPUT_BUFFER_AVAILABLE(self->inbuf) > 0;
+        bool result = INPUT_BUFFER_AVAILABLE(self->inbuf) > 0;
+        background_callback_allow();
+        return result;
     }
 
     stream_set_blocking(self, block_ok);
@@ -148,6 +151,7 @@ static bool mp3file_update_inbuf_always(audiomp3_mp3file_obj_t *self, bool block
                 break;
             }
             self->eof = true;
+            background_callback_allow();
             mp_raise_OSError(errcode);
         }
 


### PR DESCRIPTION
This fixes an issue that can arise when the MP3Decoder is reading from a source that runs background tasks during the read. No such source exists today but #11217 adds one. The EMMC driver implemented in that PR runs background tasks, so decoding an MP3 from it caused it to call `mp3file_update_inbuf_cb()` again while in the middle of the previous read.

INPUT_BUFFER_SPACE() is signed but `to_read` is not, so a negative space would wrap and be passed to `stream_read()`

Fixed by preventing background tasks while mp3 decoder fills inbuff and clamping logic for `to_read`. 

I confirmed that this fixes the issue with decoding mp3s from  the sp1emmc module in #11217. I think this fix stands aside from the SP-1 support because it would bite any other source that runs runs background tasks while getting the file data.