### PR TITLE
zephyr-cp: read the vendor index from the vendor directory

### DIFF
--- a/ports/zephyr-cp/cptools/zephyr2cp.py
+++ b/ports/zephyr-cp/cptools/zephyr2cp.py
@@ -517,7 +517,15 @@ def zephyr_dts_to_cp_board(board_id, portdir, builddir, zephyrbuilddir, mpconfig
     else:
         board_yaml = board_yaml["board"]
     board_info["vendor_id"] = board_yaml["vendor"]
-    vendor_index = zephyr_board_dir.parent / "index.rst"
+    # Most vendors put boards directly in boards/<vendor>/<board>, but some group
+    # them further, like boards/silabs/dev_kits/<board>. Walk up to the directory
+    # named for the vendor so we read the vendor's index.rst and not a category's.
+    vendor_dir = zephyr_board_dir.parent
+    for parent in zephyr_board_dir.parents:
+        if parent.name == board_info["vendor_id"]:
+            vendor_dir = parent
+            break
+    vendor_index = vendor_dir / "index.rst"
     if vendor_index.exists():
         vendor_index = vendor_index.read_text()
         vendor_index = vendor_index.split("\n")


### PR DESCRIPTION
## What
`zephyr_dts_to_cp_board()` takes the board directory's parent as the vendor directory and reads its `index.rst` for the vendor name:

```python
vendor_index = zephyr_board_dir.parent / "index.rst"
```

That holds for `boards/<vendor>/<board>`, but some vendors group boards a level deeper. Silicon Labs uses `boards/silabs/dev_kits/<board>`, and also `explorer_kits`, `radio_boards` and `starter_kits`. For those the parent is a category, not the vendor:

| index.rst read | line 3 |
| --- | --- |
| `boards/silabs/index.rst` | `Silicon Labs` |
| `boards/silabs/dev_kits/index.rst` | `Dev Kits and Thunderboards` |

The name is written to `autogen_board_info.toml`, which `docs/shared_bindings_matrix.py` reads for the board's branded name, so the wrong value is what the website would show.

## How
`board_yaml["vendor"]` is already read one line above, so walk up to the ancestor directory named for it. Flat layouts are unaffected, since the first parent matches immediately.

No board currently in tree is affected, because none of them live under a nested vendor directory yet.

## Testing
Hardware: two Silicon Labs SiWx917-DK2605A, Zephyr board `siwx917_dk2605a`, on separate hosts. CircuitPython `b9d03f12f` with the Zephyr pin at `62e7a3764`.

That board is not in the tree yet, so this was tested with the board definition applied on top, along with #11210 which it needs to build. All three applied cleanly and built together.

Before, the build rewrites the generated name:

```
name = "Dev Kits and Thunderboards SiWx917 Wi-Fi 6 and Bluetooth LE SoC Dev Kit (BRD2605A)"
```

After, it stays correct across a rebuild:

```
name = "Silicon Labs SiWx917 Wi-Fi 6 and Bluetooth LE SoC Dev Kit (BRD2605A)"
```

The resulting firmware was flashed to both boards and both boot:

```
Adafruit CircuitPython 10.3.0-alpha.4-48-gb9d03f12f-dirty on 2026-08-20; SiWx917 Wi-Fi 6 and Bluetooth LE SoC Dev Kit (BRD2605A) with siwg917m111mgtba
>>>
```

and both expose the generated pin names:

```
>>> import board
>>> [n for n in dir(board) if n.startswith("KEY")]
['KEY_0', 'KEY_1']
```

## Scope
One lookup. No behavior change for boards laid out as `boards/<vendor>/<board>`.

## AI assistance
Written with Claude Code. I ran the hardware myself. The generated values and REPL output above are from the boards, not from a model.
