### PR TITLE
zephyr-cp/wifi: subscribe to NET_EVENT_WIFI_SCAN_RESULT

### DIFF
--- a/ports/zephyr-cp/common-hal/wifi/__init__.c
+++ b/ports/zephyr-cp/common-hal/wifi/__init__.c
@@ -278,6 +278,7 @@ void common_hal_wifi_init(bool user_initiated) {
     // self->ap_mode = 0;
 
     net_mgmt_init_event_callback(&wifi_cb, _event_handler,
+        NET_EVENT_WIFI_SCAN_RESULT |
         NET_EVENT_WIFI_SCAN_DONE |
         NET_EVENT_WIFI_CONNECT_RESULT |
         NET_EVENT_WIFI_DISCONNECT_RESULT |


### PR DESCRIPTION
Wi-Fi scanning on zephyr-cp returns zero networks on every board.

`_event_handler` in `ports/zephyr-cp/common-hal/wifi/__init__.c` has a `NET_EVENT_WIFI_SCAN_RESULT` case that queues each AP as it arrives, but that event is not in the mask passed to `net_mgmt_init_event_callback`. The case has never run, so nothing is ever queued and every scan comes back empty.

`NET_EVENT_WIFI_RAW_SCAN_RESULT` is in the mask, which is probably how this went unnoticed, but it is not a substitute. It carries raw beacon frames and only fires when `CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS` is enabled, which it is not by default.

## Testing

Raspberry Pi Pico 2 W, in-tree board `raspberrypi_rpi_pico2_w_zephyr`, built from 069144c66 on Linux and flashed over SWD with pyOCD via a CMSIS-DAP Debug Probe.

```python
import wifi
len([1 for n in wifi.radio.start_scanning_networks()])
```

| build | result |
| --- | --- |
| main | 0 |
| main + this patch | 204 |

Same board, same probe, same script. The before run is this commit reverted and rebuilt, nothing else changed. Both returned promptly to the prompt.

Anyone with a Pico 2 W can reproduce this, no vendor hardware needed.

## Notes

This is the root cause behind #11214, which I opened earlier and have closed. That one bounded the scan wait instead of fixing why no results arrive, and @tannewt was right to push back on it.

AI assistance was used to draft this change. I ran the hardware testing above myself and confirmed the before and after numbers on my own board.
