### PR TITLE
Fix several independent BLE bugs, split from #11178

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/PacketBuffer.c
+++ b/devices/ble_hci/common-hal/_bleio/PacketBuffer.c
@@ -245,6 +245,8 @@ void common_hal_bleio_packet_buffer_deinit(bleio_packet_buffer_obj_t *self) {
     if (!common_hal_bleio_packet_buffer_deinited(self)) {
         bleio_characteristic_clear_observer(self->characteristic);
         ringbuf_deinit(&self->ringbuf);
+        // Mark as deinited, so common_hal_bleio_packet_buffer_deinited() reports it.
+        self->characteristic = NULL;
     }
 }
 

--- a/ports/espressif/common-hal/_bleio/Adapter.c
+++ b/ports/espressif/common-hal/_bleio/Adapter.c
@@ -837,13 +837,13 @@ void bleio_adapter_reset(bleio_adapter_obj_t *adapter) {
 
     // Wait up to 125 ms (128 ticks) for disconnect to complete. This should be
     // greater than most connection intervals.
-    bool any_connected = false;
+    bool any_connected;
     uint64_t start_ticks = supervisor_ticks_ms64();
-    while (any_connected && supervisor_ticks_ms64() - start_ticks < 128) {
+    do {
         any_connected = false;
         for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
             bleio_connection_internal_t *connection = &bleio_connections[i];
             any_connected |= connection->conn_handle != BLEIO_HANDLE_INVALID;
         }
-    }
+    } while (any_connected && supervisor_ticks_ms64() - start_ticks < 128);
 }

--- a/ports/espressif/common-hal/_bleio/ble_events.c
+++ b/ports/espressif/common-hal/_bleio/ble_events.c
@@ -28,11 +28,14 @@ void ble_event_reset(void) {
 void ble_event_remove_heap_handlers(void) {
     ble_event_handler_entry_t *it = MP_STATE_VM(ble_event_handler_entries);
     while (it != NULL) {
-        // If the param is on the heap, then delete the handler.
-        if (gc_ptr_on_heap(it->param)) {
+        // Save it->next before removing, because removing clears it.
+        ble_event_handler_entry_t *next = it->next;
+        // Remove the handler if the entry or its param is on the heap, which is
+        // about to go away.
+        if (gc_ptr_on_heap(it) || gc_ptr_on_heap(it->param)) {
             ble_event_remove_handler(it->func, it->param);
         }
-        it = it->next;
+        it = next;
     }
 }
 

--- a/ports/nordic/bluetooth/ble_drv.c
+++ b/ports/nordic/bluetooth/ble_drv.c
@@ -141,11 +141,14 @@ void ble_drv_reset(void) {
 void ble_drv_remove_heap_handlers(void) {
     ble_drv_evt_handler_entry_t *it = MP_STATE_VM(ble_drv_evt_handler_entries);
     while (it != NULL) {
-        // If the param is on the heap, then delete the handler.
-        if (gc_ptr_on_heap(it->param)) {
+        // Save it->next before removing, because removing clears it.
+        ble_drv_evt_handler_entry_t *next = it->next;
+        // Remove the handler if the entry or its param is on the heap, which is
+        // about to go away.
+        if (gc_ptr_on_heap(it) || gc_ptr_on_heap(it->param)) {
             ble_drv_remove_event_handler(it->func, it->param);
         }
-        it = it->next;
+        it = next;
     }
 }
 

--- a/ports/nordic/common-hal/_bleio/Adapter.c
+++ b/ports/nordic/common-hal/_bleio/Adapter.c
@@ -794,7 +794,13 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self,
             // advertising. This prevents a potential race condition where we
             // fire off a beacon with the same advertising data but a new MAC
             // address just as we tear down the connection.
-            .private_addr_cycle_s = timeout + 1,
+            //
+            // For unlimited advertising, timeout + 1 would rotate the address
+            // every second, too fast for a central to resolve it and connect.
+            // Zero selects the SoftDevice default cycle of 15 minutes
+            // (BLE_GAP_DEFAULT_PRIVATE_ADDR_CYCLE_INTERVAL_S).
+            .private_addr_cycle_s =
+                timeout == BLE_GAP_ADV_TIMEOUT_GENERAL_UNLIMITED ? 0 : timeout + 1,
             .p_device_irk = NULL,
         };
         err_code = sd_ble_gap_privacy_set(&privacy);

--- a/ports/nordic/common-hal/_bleio/Adapter.c
+++ b/ports/nordic/common-hal/_bleio/Adapter.c
@@ -248,6 +248,15 @@ static bool adapter_on_ble_evt(ble_evt_t *ble_evt, void *self_in) {
             connection->connection_obj = mp_const_none;
             connection->pair_status = PAIR_NOT_PAIRED;
             connection->mtu = 0;
+            // Clear leftover bond state; connection slots are recycled. The
+            // SoftDevice fills in only the keys the new peer distributes, so a
+            // stale keyset could mix the previous peer's keys into this peer's
+            // stored bond, and a stale ediv or pending-save flag could file
+            // this connection's bond data under the previous peer's key.
+            connection->ediv = EDIV_INVALID;
+            connection->do_bond_cccds = false;
+            connection->do_bond_keys = false;
+            bonding_clear_keys(&connection->bonding_keys);
 
             ble_drv_add_event_handler_entry(&connection->handler_entry, connection_on_ble_evt, connection);
             self->connection_objs = NULL;

--- a/ports/nordic/common-hal/_bleio/Adapter.c
+++ b/ports/nordic/common-hal/_bleio/Adapter.c
@@ -998,13 +998,13 @@ void bleio_adapter_reset(bleio_adapter_obj_t *adapter) {
 
     // Wait up to 125 ms (128 ticks) for disconnect to complete. This should be
     // greater than most connection intervals.
-    bool any_connected = false;
+    bool any_connected;
     uint64_t start_ticks = supervisor_ticks_ms64();
-    while (any_connected && supervisor_ticks_ms64() - start_ticks < 128) {
+    do {
         any_connected = false;
         for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
             bleio_connection_internal_t *connection = &bleio_connections[i];
             any_connected |= connection->conn_handle != BLE_CONN_HANDLE_INVALID;
         }
-    }
+    } while (any_connected && supervisor_ticks_ms64() - start_ticks < 128);
 }

--- a/ports/nordic/common-hal/_bleio/PacketBuffer.c
+++ b/ports/nordic/common-hal/_bleio/PacketBuffer.c
@@ -483,6 +483,8 @@ void common_hal_bleio_packet_buffer_deinit(bleio_packet_buffer_obj_t *self) {
     if (!common_hal_bleio_packet_buffer_deinited(self)) {
         ble_drv_remove_event_handler(packet_buffer_on_ble_client_evt, self);
         ringbuf_deinit(&self->ringbuf);
+        // Mark as deinited, so common_hal_bleio_packet_buffer_deinited() reports it.
+        self->characteristic = NULL;
     }
 }
 

--- a/ports/nordic/common-hal/_bleio/PacketBuffer.c
+++ b/ports/nordic/common-hal/_bleio/PacketBuffer.c
@@ -481,7 +481,11 @@ bool common_hal_bleio_packet_buffer_deinited(bleio_packet_buffer_obj_t *self) {
 void common_hal_bleio_packet_buffer_deinit(bleio_packet_buffer_obj_t *self) {
 
     if (!common_hal_bleio_packet_buffer_deinited(self)) {
-        ble_drv_remove_event_handler(packet_buffer_on_ble_client_evt, self);
+        if (self->client) {
+            ble_drv_remove_event_handler(packet_buffer_on_ble_client_evt, self);
+        } else {
+            ble_drv_remove_event_handler(packet_buffer_on_ble_server_evt, self);
+        }
         ringbuf_deinit(&self->ringbuf);
         // Mark as deinited, so common_hal_bleio_packet_buffer_deinited() reports it.
         self->characteristic = NULL;

--- a/ports/silabs/common-hal/_bleio/Adapter.c
+++ b/ports/silabs/common-hal/_bleio/Adapter.c
@@ -640,11 +640,11 @@ void bleio_adapter_reset(bleio_adapter_obj_t *adapter) {
     // Wait up to 125 ms (128 ticks) for disconnect to complete. This should be
     // greater than most connection intervals.
     start_ticks = supervisor_ticks_ms64();
-    while (any_connected && supervisor_ticks_ms64() - start_ticks < 128) {
+    do {
         any_connected = false;
         for (conn_index = 0; conn_index < BLEIO_TOTAL_CONNECTION_COUNT; conn_index++) {
             connection = &bleio_connections[conn_index];
             any_connected |= connection->conn_handle != BLEIO_HANDLE_INVALID;
         }
-    }
+    } while (any_connected && supervisor_ticks_ms64() - start_ticks < 128);
 }

--- a/ports/silabs/common-hal/_bleio/PacketBuffer.c
+++ b/ports/silabs/common-hal/_bleio/PacketBuffer.c
@@ -387,6 +387,8 @@ bool common_hal_bleio_packet_buffer_deinited(bleio_packet_buffer_obj_t *self) {
 void common_hal_bleio_packet_buffer_deinit(bleio_packet_buffer_obj_t *self) {
     if (!common_hal_bleio_packet_buffer_deinited(self)) {
         ringbuf_deinit(&self->ringbuf);
+        // Mark as deinited, so common_hal_bleio_packet_buffer_deinited() reports it.
+        self->characteristic = NULL;
     }
 }
 

--- a/supervisor/shared/bluetooth/serial.c
+++ b/supervisor/shared/bluetooth/serial.c
@@ -133,7 +133,7 @@ void supervisor_start_bluetooth_serial(void) {
     _common_hal_bleio_characteristic_buffer_construct(&_rx_buffer,
         &supervisor_ble_circuitpython_rx_characteristic,
         0.1f,
-        (uint8_t *)_incoming, sizeof(_incoming) * sizeof(uint32_t),
+        (uint8_t *)_incoming, sizeof(_incoming),
         &rx_static_handler_entry,
         true /* watch for interrupt character */);
 


### PR DESCRIPTION
Claude found these bugs in the course of working on #11178.

- Incorrect `_incoming` buffer size passed to `_common_hal_bleio_characteristic_buffer_construct()`.
- Incorrect disconnect wait loop in `bleio_adapter_reset()` (nordic, espressif, silabs): while loop never ran because initial condition was false, so explicit disconnect didn't happen. The central saw a supervision timeout instead of a clean disconnect. Changed to do-while.
- Heap event handler cleanup loop didn't iterate over linked list properly (nordic `ble_drv.c`, espressif `ble_events.c`): only the first entry was removed.
- `common_hal_bleio_packet_buffer_deinited()` could never return true (nordic, silabs, ble_hci): `deinit()` did not clear `self->characteristic`, so the guards in `supervisor/shared/bluetooth/serial.c` never took effect.
- Nordic `packet_buffer_deinit()` removed the wrong event handler: it always removed the client-event handler, leaving a server packet buffer's handler registered and pointing at a freed buffer.
- Resolvable private address rotated too fast (nordic): with an unlimited advertising timeout, `private_addr_cycle_s = timeout + 1` was only one second. Changed to use the SoftDevice default of 15 minutes.
- Do more thorough cleanup on connection-slot reuse (nordic): before, a reused slot kept the previous peer's bonding keys, `ediv`, and pending bond-save flags, which could mix one peer's IRK with another's LTK or save bond data under the wrong `ediv`.

First of the series of small PRs replacing #11178, as discussed there. These are the independent bug fixes; the reset-logic and advertising-behavior changes will follow in separate PRs.

Tested on Nordic and Espressif. This does _not_ fix the primary bug that #11178 started to address. That will come later in a further PR.

@tannewt We can look for these issues in the zephyr BLE port, since it took inspiration from the other ports.
