### PR TITLE
zephyr-cp/wifi: route diagnostic output through the log subsystem

### DIFF
--- a/ports/zephyr-cp/common-hal/wifi/Radio.c
+++ b/ports/zephyr-cp/common-hal/wifi/Radio.c
@@ -25,6 +25,7 @@
 #include "bindings/zephyr_kernel/__init__.h"
 
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/net/hostname.h>
 #include <zephyr/net/wifi.h>
 #include <zephyr/net/wifi_mgmt.h>
@@ -32,6 +33,8 @@
 #if CIRCUITPY_MDNS
 #include "common-hal/mdns/Server.h"
 #endif
+
+LOG_MODULE_DECLARE(cp_wifi);
 
 #define MAC_ADDRESS_LENGTH 6
 
@@ -85,7 +88,7 @@ void common_hal_wifi_radio_set_enabled(wifi_radio_obj_t *self, bool enabled) {
         //     #if CIRCUITPY_MDNS
         //     mdns_server_deinit_singleton();
         //     #endif
-        printk("net_if_down\n");
+        LOG_DBG("net_if_down");
         int res = net_if_down(self->sta_netif);
         if (res < 0 && res != -EALREADY) {
             raise_zephyr_error(res);
@@ -94,7 +97,7 @@ void common_hal_wifi_radio_set_enabled(wifi_radio_obj_t *self, bool enabled) {
         return;
     }
     if (!self->started && enabled) {
-        printk("net_if_up\n");
+        LOG_DBG("net_if_up");
         int res = net_if_up(self->sta_netif);
         if (res < 0 && res != -EALREADY) {
             raise_zephyr_error(res);
@@ -214,13 +217,11 @@ void common_hal_wifi_radio_set_mac_address_ap(wifi_radio_obj_t *self, const uint
 }
 
 mp_obj_t common_hal_wifi_radio_start_scanning_networks(wifi_radio_obj_t *self, uint8_t start_channel, uint8_t stop_channel) {
-    printk("common_hal_wifi_radio_start_scanning_networks\n");
+    LOG_DBG("common_hal_wifi_radio_start_scanning_networks");
     if (self->current_scan != NULL) {
-        printk("Already scanning for wifi networks\n");
         mp_raise_RuntimeError(MP_ERROR_TEXT("Already scanning for wifi networks"));
     }
     if (!common_hal_wifi_radio_get_enabled(self)) {
-        printk("WiFi is not enabled\n");
         mp_raise_RuntimeError(MP_ERROR_TEXT("WiFi is not enabled"));
     }
 
@@ -246,12 +247,12 @@ mp_obj_t common_hal_wifi_radio_start_scanning_networks(wifi_radio_obj_t *self, u
         K_POLL_MODE_NOTIFY_ONLY,
         &scan->msgq);
     wifi_scannednetworks_scan_next_channel(scan);
-    printk("common_hal_wifi_radio_start_scanning_networks done %p\n", scan);
+    LOG_DBG("common_hal_wifi_radio_start_scanning_networks done %p", scan);
     return scan;
 }
 
 void common_hal_wifi_radio_stop_scanning_networks(wifi_radio_obj_t *self) {
-    printk("common_hal_wifi_radio_stop_scanning_networks\n");
+    LOG_DBG("common_hal_wifi_radio_stop_scanning_networks");
     // Return early if self->current_scan is NULL to avoid hang
     if (self->current_scan == NULL) {
         return;

--- a/ports/zephyr-cp/common-hal/wifi/ScannedNetworks.c
+++ b/ports/zephyr-cp/common-hal/wifi/ScannedNetworks.c
@@ -19,12 +19,15 @@
 #include "bindings/zephyr_kernel/__init__.h"
 
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/net/wifi_mgmt.h>
+
+LOG_MODULE_DECLARE(cp_wifi);
 
 
 void wifi_scannednetworks_scan_result(wifi_scannednetworks_obj_t *self, struct wifi_scan_result *result) {
     if (k_msgq_put(&self->msgq, result, K_NO_WAIT) != 0) {
-        printk("Dropping scan result!\n");
+        LOG_WRN("Dropping scan result");
     }
 }
 
@@ -104,7 +107,7 @@ void wifi_scannednetworks_scan_next_channel(wifi_scannednetworks_obj_t *self) {
     } else {
         int res = net_mgmt(NET_REQUEST_WIFI_SCAN, self->netif, &params, sizeof(params));
         if (res != 0) {
-            printk("Failed to start wifi scan %d\n", res);
+            LOG_ERR("Failed to start wifi scan %d", res);
             raise_zephyr_error(res);
             wifi_scannednetworks_done(self);
         } else {

--- a/ports/zephyr-cp/common-hal/wifi/__init__.c
+++ b/ports/zephyr-cp/common-hal/wifi/__init__.c
@@ -278,6 +278,7 @@ void common_hal_wifi_init(bool user_initiated) {
     // self->ap_mode = 0;
 
     net_mgmt_init_event_callback(&wifi_cb, _event_handler,
+        NET_EVENT_WIFI_SCAN_RESULT |
         NET_EVENT_WIFI_SCAN_DONE |
         NET_EVENT_WIFI_CONNECT_RESULT |
         NET_EVENT_WIFI_DISCONNECT_RESULT |

--- a/ports/zephyr-cp/common-hal/wifi/__init__.c
+++ b/ports/zephyr-cp/common-hal/wifi/__init__.c
@@ -31,11 +31,14 @@ wifi_radio_obj_t common_hal_wifi_radio_obj;
 #endif
 
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/net/wifi_mgmt.h>
 
 #include <inttypes.h>
 
 #define MAC_ADDRESS_LENGTH 6
+
+LOG_MODULE_REGISTER(cp_wifi, CONFIG_LOG_DEFAULT_LEVEL);
 
 static void schedule_background_on_cp_core(void *arg) {
     #if CIRCUITPY_STATUS_BAR
@@ -56,7 +59,7 @@ static void _event_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_eve
 
     switch (mgmt_event) {
         case NET_EVENT_WIFI_SCAN_RESULT: {
-            printk("NET_EVENT_WIFI_SCAN_RESULT\n");
+            LOG_DBG("NET_EVENT_WIFI_SCAN_RESULT");
             const struct wifi_scan_result *result = cb->info;
             if (result != NULL && self->current_scan != NULL) {
                 wifi_scannednetworks_scan_result(self->current_scan, result);
@@ -64,7 +67,7 @@ static void _event_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_eve
             break;
         }
         case NET_EVENT_WIFI_SCAN_DONE:
-            printk("NET_EVENT_WIFI_SCAN_DONE (thread: %s prio=%d)\n",
+            LOG_DBG("NET_EVENT_WIFI_SCAN_DONE (thread: %s prio=%d)",
                 k_thread_name_get(k_current_get()),
                 k_thread_priority_get(k_current_get()));
             if (self->current_scan != NULL) {
@@ -72,46 +75,55 @@ static void _event_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_eve
             }
             break;
         case NET_EVENT_WIFI_CONNECT_RESULT:
-            printk("NET_EVENT_WIFI_CONNECT_RESULT\n");
+            LOG_DBG("NET_EVENT_WIFI_CONNECT_RESULT");
             break;
         case NET_EVENT_WIFI_DISCONNECT_RESULT:
-            printk("NET_EVENT_WIFI_DISCONNECT_RESULT\n");
+            LOG_DBG("NET_EVENT_WIFI_DISCONNECT_RESULT");
             break;
         case NET_EVENT_WIFI_IFACE_STATUS:
-            printk("NET_EVENT_WIFI_IFACE_STATUS\n");
+            LOG_DBG("NET_EVENT_WIFI_IFACE_STATUS");
             break;
         case NET_EVENT_WIFI_TWT:
-            printk("NET_EVENT_WIFI_TWT\n");
+            LOG_DBG("NET_EVENT_WIFI_TWT");
             break;
         case NET_EVENT_WIFI_TWT_SLEEP_STATE:
-            printk("NET_EVENT_WIFI_TWT_SLEEP_STATE\n");
+            LOG_DBG("NET_EVENT_WIFI_TWT_SLEEP_STATE");
             break;
         case NET_EVENT_WIFI_RAW_SCAN_RESULT:
-            printk("NET_EVENT_WIFI_RAW_SCAN_RESULT\n");
+            LOG_DBG("NET_EVENT_WIFI_RAW_SCAN_RESULT");
             break;
         case NET_EVENT_WIFI_DISCONNECT_COMPLETE:
-            printk("NET_EVENT_WIFI_DISCONNECT_COMPLETE\n");
+            LOG_DBG("NET_EVENT_WIFI_DISCONNECT_COMPLETE");
             break;
         case NET_EVENT_WIFI_SIGNAL_CHANGE:
-            printk("NET_EVENT_WIFI_SIGNAL_CHANGE\n");
+            LOG_DBG("NET_EVENT_WIFI_SIGNAL_CHANGE");
             break;
         case NET_EVENT_WIFI_NEIGHBOR_REP_COMP:
-            printk("NET_EVENT_WIFI_NEIGHBOR_REP_COMP\n");
+            LOG_DBG("NET_EVENT_WIFI_NEIGHBOR_REP_COMP");
             break;
         case NET_EVENT_WIFI_AP_ENABLE_RESULT:
-            printk("NET_EVENT_WIFI_AP_ENABLE_RESULT\n");
+            LOG_DBG("NET_EVENT_WIFI_AP_ENABLE_RESULT");
             break;
         case NET_EVENT_WIFI_AP_DISABLE_RESULT:
-            printk("NET_EVENT_WIFI_AP_DISABLE_RESULT\n");
+            LOG_DBG("NET_EVENT_WIFI_AP_DISABLE_RESULT");
             break;
         case NET_EVENT_WIFI_AP_STA_CONNECTED:
-            printk("NET_EVENT_WIFI_AP_STA_CONNECTED\n");
+            LOG_DBG("NET_EVENT_WIFI_AP_STA_CONNECTED");
             break;
         case NET_EVENT_WIFI_AP_STA_DISCONNECTED:
-            printk("NET_EVENT_WIFI_AP_STA_DISCONNECTED\n");
+            LOG_DBG("NET_EVENT_WIFI_AP_STA_DISCONNECTED");
+            break;
+        case NET_EVENT_IPV4_ADDR_ADD:
+            // DHCP bound, or a static address was configured. The address is read
+            // live by the ipv4_address getter, so nothing is stored here; the
+            // status bar just needs a refresh or it keeps showing "No IP".
+            LOG_DBG("NET_EVENT_IPV4_ADDR_ADD");
+            schedule_background_on_cp_core(NULL);
             break;
         default:
-            printk("unhandled net event %x\n", mgmt_event);
+            // Print all 64 bits. The layer lives in the high bits, so a 32-bit
+            // print collapses every unhandled event in a layer to one value.
+            LOG_DBG("unhandled net event %llx", (unsigned long long)mgmt_event);
             break;
     }
 }
@@ -196,7 +208,7 @@ static bool wifi_user_initiated;
 
 void common_hal_wifi_init(bool user_initiated) {
     wifi_radio_obj_t *self = &common_hal_wifi_radio_obj;
-    printk("common_hal_wifi_init\n");
+    LOG_DBG("common_hal_wifi_init");
 
     if (wifi_inited) {
         if (user_initiated && !wifi_user_initiated) {
@@ -223,8 +235,8 @@ void common_hal_wifi_init(bool user_initiated) {
     // }
     self->sta_netif = net_if_get_wifi_sta();
     self->ap_netif = net_if_get_wifi_sap();
-    printk("sta_netif %p\n", self->sta_netif);
-    printk("ap_netif %p\n", self->ap_netif);
+    LOG_DBG("sta_netif %p", self->sta_netif);
+    LOG_DBG("ap_netif %p", self->ap_netif);
 
 
     struct wifi_iface_status status = { 0 };
@@ -232,39 +244,39 @@ void common_hal_wifi_init(bool user_initiated) {
         CHECK_ZEPHYR_RESULT(net_mgmt(NET_REQUEST_WIFI_IFACE_STATUS, self->sta_netif, &status,
             sizeof(struct wifi_iface_status)));
         if (net_if_is_up(self->sta_netif)) {
-            printk("STA is up\n");
+            LOG_DBG("STA is up");
         } else {
-            printk("STA is down\n");
+            LOG_DBG("STA is down");
         }
         if (net_if_is_carrier_ok(self->sta_netif)) {
-            printk("STA carrier is ok\n");
+            LOG_DBG("STA carrier is ok");
         } else {
-            printk("STA carrier is not ok\n");
+            LOG_DBG("STA carrier is not ok");
         }
         if (net_if_is_dormant(self->sta_netif)) {
-            printk("STA is dormant\n");
+            LOG_DBG("STA is dormant");
         } else {
-            printk("STA is not dormant\n");
+            LOG_DBG("STA is not dormant");
         }
     }
     if (self->ap_netif != NULL) {
         int res = net_mgmt(NET_REQUEST_WIFI_IFACE_STATUS, self->ap_netif, &status,
             sizeof(struct wifi_iface_status));
-        printk("AP status request response %d\n", res);
+        LOG_DBG("AP status request response %d", res);
         if (net_if_is_up(self->ap_netif)) {
-            printk("AP is up\n");
+            LOG_DBG("AP is up");
         } else {
-            printk("AP is down\n");
+            LOG_DBG("AP is down");
         }
         if (net_if_is_carrier_ok(self->ap_netif)) {
-            printk("AP carrier is ok\n");
+            LOG_DBG("AP carrier is ok");
         } else {
-            printk("AP carrier is not ok\n");
+            LOG_DBG("AP carrier is not ok");
         }
         if (net_if_is_dormant(self->ap_netif)) {
-            printk("AP is dormant\n");
+            LOG_DBG("AP is dormant");
         } else {
-            printk("AP is not dormant\n");
+            LOG_DBG("AP is not dormant");
         }
     }
 
@@ -318,21 +330,21 @@ void common_hal_wifi_init(bool user_initiated) {
         char cpy_default_hostname[board_len + (MAC_ADDRESS_LENGTH * 2) + 6];
         struct net_linkaddr *mac = net_if_get_link_addr(self->sta_netif);
         if (mac->len < MAC_ADDRESS_LENGTH) {
-            printk("MAC address too short");
+            LOG_ERR("MAC address too short");
         }
         snprintf(cpy_default_hostname, sizeof(cpy_default_hostname), "cpy-%s-%02x%02x%02x%02x%02x%02x", CIRCUITPY_BOARD_ID + board_trim, mac->addr[0], mac->addr[1], mac->addr[2], mac->addr[3], mac->addr[4], mac->addr[5]);
 
         CHECK_ZEPHYR_RESULT(net_hostname_set(cpy_default_hostname, strlen(cpy_default_hostname)));
     }
     #else
-    printk("Hostname support disabled in Zephyr config\n");
+    LOG_WRN("Hostname support disabled in Zephyr config");
     #endif
     // set station mode to avoid the default SoftAP
     common_hal_wifi_radio_start_station(self);
     // start wifi
     common_hal_wifi_radio_set_enabled(self, true);
 
-    printk("common_hal_wifi_init done\n");
+    LOG_DBG("common_hal_wifi_init done");
 }
 
 void wifi_user_reset(void) {
@@ -343,7 +355,7 @@ void wifi_user_reset(void) {
 }
 
 void wifi_reset(void) {
-    printk("wifi_reset\n");
+    LOG_DBG("wifi_reset");
     if (!wifi_inited) {
         return;
     }


### PR DESCRIPTION
## What

Routes the zephyr-cp Wi-Fi common-hal's diagnostic output through Zephyr's log
subsystem instead of raw `printk`, and fixes two defects that conversion exposed.

## Why

The Wi-Fi path printed unconditionally on every net event. That output cannot be
turned down per module, and it corrupts the serial handshake that raw-REPL
tooling relies on, which makes REPL automation on this port flaky.

Two real bugs came out of the conversion:

- **The unhandled-event print truncated to 32 bits.** `mgmt_event` is a
  `uint64_t` and was printed with `%x`. The event layer lives in the high bits,
  so every unhandled Wi-Fi event aliased to the same value.
- **`NET_EVENT_IPV4_ADDR_ADD` had no `case`.** The callback for it was already
  registered upstream, so the event arrived and fell through to the
  unhandled-event path. The status bar therefore kept reading `Wi-Fi: No IP`
  after DHCP had bound, while `wifi.radio.ipv4_address` returned the real lease.

Two `printk`s in `start_scanning_networks()` only restated the message raised on
the next line, so they are deleted rather than converted.

`LOG_MODULE_REGISTER(cp_wifi, CONFIG_LOG_DEFAULT_LEVEL)` follows the existing
precedent in `ports/zephyr-cp/supervisor/usb.c`.

## Hardware tested

- SiWx917-DK2605A (Zephyr board `siwx917_dk2605a`, SoC SiWG917M111MGTBA), two
  boards, one on macOS 15 and one on Ubuntu 24.04.
- Verified as part of the full stack, on top of the SiWx917-DK2605A board
  definition from #11218 (not yet merged).

Not tested: any other zephyr-cp board. This file builds for every Wi-Fi board in
the port, so CI is the check for the rest.

## How I tested it

Console output is quiet by default now instead of printing per event, and the
status bar shows the address once DHCP binds rather than `No IP`.

## Scope

Only `ports/zephyr-cp/common-hal/wifi/`. `printk` is still used elsewhere in the
port; converting those is out of scope here.

## Notes

No new translatable strings, and `locale/circuitpython.pot` is unchanged.

This is the first of three PRs splitting up the zephyr-cp Wi-Fi work. It is
stacked on #11223, so until that merges this diff also shows its one-line scan
subscription change.

## AI assistance

Written with Claude Code. I reviewed the diff myself and verified the behaviour
on the hardware listed above.
