### PR TITLE
zephyr-cp/_bleio: don't let an unsupported Tx power command block advertising

### DIFF
--- a/ports/zephyr-cp/common-hal/_bleio/Adapter.c
+++ b/ports/zephyr-cp/common-hal/_bleio/Adapter.c
@@ -328,13 +328,16 @@ mp_int_t common_hal_bleio_adapter_get_tx_power(bleio_adapter_obj_t *self) {
     return power;
 }
 
-void common_hal_bleio_adapter_set_tx_power(bleio_adapter_obj_t *self, mp_int_t tx_power) {
+// Returns a Zephyr error code rather than raising, so callers can treat setting
+// Tx power as best-effort. BT_HCI_OP_VS_WRITE_TX_POWER_LEVEL is a Zephyr
+// vendor-specific command that not every controller implements.
+static int _try_set_tx_power(mp_int_t tx_power) {
     struct bt_hci_cp_vs_write_tx_power_level *cp;
     struct net_buf *buf, *rsp = NULL;
 
     buf = bt_hci_cmd_alloc(K_MSEC(3000));
     if (!buf) {
-        mp_raise_msg(&mp_type_MemoryError, NULL);
+        return -ENOMEM;
     }
     cp = net_buf_add(buf, sizeof(*cp));
     cp->handle_type = BT_HCI_VS_LL_HANDLE_TYPE_ADV;
@@ -343,10 +346,19 @@ void common_hal_bleio_adapter_set_tx_power(bleio_adapter_obj_t *self, mp_int_t t
 
     int err = bt_hci_cmd_send_sync(BT_HCI_OP_VS_WRITE_TX_POWER_LEVEL, buf, &rsp);
     if (err) {
-        raise_zephyr_error(err);
+        return err;
     }
 
     net_buf_unref(rsp);
+    return 0;
+}
+
+void common_hal_bleio_adapter_set_tx_power(bleio_adapter_obj_t *self, mp_int_t tx_power) {
+    int err = _try_set_tx_power(tx_power);
+    if (err == -ENOMEM) {
+        mp_raise_msg(&mp_type_MemoryError, NULL);
+    }
+    raise_zephyr_error(err);
 }
 
 bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_obj_t *self) {
@@ -454,7 +466,10 @@ void common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self,
             NULL);
     }
 
-    common_hal_bleio_adapter_set_tx_power(self, tx_power);
+    // Best-effort: a controller that does not implement Zephyr's vendor-specific
+    // Tx power command must still be able to advertise. tx_power defaults to 0,
+    // so reporting the rejection here would print on every start_advertising().
+    _try_set_tx_power(tx_power);
 
     raise_zephyr_error(bt_le_adv_start(&adv_params,
         adv_data,


### PR DESCRIPTION
## What

`start_advertising()` on zephyr-cp could not advertise at all on a controller that does not implement Zephyr's vendor-specific Tx power command. It now treats the Tx power write as best-effort and advertises anyway. An explicit `adapter.tx_power = n` still raises on failure.

## Why

`common_hal_bleio_adapter_start_advertising()` calls `set_tx_power()` unconditionally before `bt_le_adv_start()`. That sends `BT_HCI_OP_VS_WRITE_TX_POWER_LEVEL` (`0xfc0e`), a Zephyr vendor-specific HCI command rather than a Bluetooth spec one. A controller without Zephyr's VS extensions rejects it, the call returns `-EIO`, and `start_advertising()` raised before it ever reached `bt_le_adv_start()`.

On a SiWx917-DK2605A (Zephyr board `siwx917_dk2605a`), whose controller has its own vendor command at `0xfc06` for RF power:

```
<wrn> bt_hci_core: opcode 0xfc0e status 0x01   (Unknown HCI Command)
OSError: [Errno 5] Input/output error
```

This affects any controller lacking Zephyr's VS HCI commands, not only that one. The shared-bindings default is `tx_power=0`, so every `adafruit_ble` program hits this path on every `start_advertising()`.

The fix splits the command into a non-raising `_try_set_tx_power()`. `common_hal_bleio_adapter_set_tx_power()` still raises, so a deliberate Tx power assignment fails loudly. `start_advertising()` calls the non-raising form and continues at the controller default. There is no log line on rejection because it would print on every `start_advertising()` on such a controller.

## Hardware tested

- SiWx917-DK2605A, SoC SiWG917M111MGTBA, zephyr-cp. Before: `OSError: [Errno 5]` from `start_advertising()`, zero scanner hits. After: the board advertises and is discoverable by name from an external BLE scanner. That test was done at the end of July on the SiWx917 bring-up tree; the change has been rebased onto current `main` and recompiled, not re-run on hardware today.
- `adafruit_feather_nrf52840_zephyr`: build only, on current `main` with this change. Not run on an nRF52840.

Not tested: a controller that implements the VS command. The only behaviour change for those is that a failure of the command no longer aborts advertising.

## Scope

This is older work from the SiWx917 bring-up. An LLM review pass over the zephyr-cp `_bleio` work in progress flagged it as relevant to the BLE workflow effort, so it is being filed now on its own rather than waiting for the SiWx917 board PR (#11218). It does not depend on that PR.

## AI assistance

Written with Claude Code. I verified the failure and the fix on the DK2605A myself, reviewed the diff by hand, and confirmed the rebased change compiles for `adafruit_feather_nrf52840_zephyr` on current `main`.
