### PR TITLE
LED feedback for safe mode and BLE discovery mode on boot-button boards

### DIFF
--- a/supervisor/shared/bluetooth/bluetooth.c
+++ b/supervisor/shared/bluetooth/bluetooth.c
@@ -252,6 +252,11 @@ void supervisor_bluetooth_init(void) {
         }
         #endif // !CIRCUITPY_USB_DEVICE
 
+        // A press must begin inside this interval. The safe mode interval just before
+        // this one also uses the boot button, and a press meant for safe mode can
+        // still be held down when this interval starts; entering discovery mode from
+        // it would erase bonding unasked. Require a release first.
+        bool button_released = !port_boot_button_pressed();
         while (diff < 1000) {
             #if CIRCUITPY_STATUS_LED
             // Blink on for 50 and off for 100
@@ -262,9 +267,14 @@ void supervisor_bluetooth_init(void) {
                 new_status_color(BLACK);
             }
             #endif
-            if (port_boot_button_pressed()) {
+            if (!port_boot_button_pressed()) {
+                button_released = true;
+            } else if (button_released && !boot_in_discovery_mode) {
                 boot_in_discovery_mode = true;
-                break;
+                // Restart the interval so the LED shows solid blue for the full
+                // 1000 ms, as feedback that the press was accepted and bonding
+                // will be erased.
+                start_ticks = supervisor_ticks_ms64();
             }
             diff = supervisor_ticks_ms64() - start_ticks;
         }

--- a/supervisor/shared/safe_mode.c
+++ b/supervisor/shared/safe_mode.c
@@ -70,11 +70,13 @@ safe_mode_t wait_for_safe_mode_reset(void) {
     status_led_init();
     #endif
 
-    uint32_t safe_mode_delay_msecs = 1000;
+    #define DEFAULT_SAFE_MODE_DELAY_MSECS (1000)
+    #define DEFAULT_SAFE_MODE_DELAY_SECS (((mp_float_t)DEFAULT_SAFE_MODE_DELAY_MSECS) / 1000.0f)
+    uint32_t safe_mode_delay_msecs = DEFAULT_SAFE_MODE_DELAY_MSECS;
 
     #if CIRCUITPY_SETTINGS_TOML
-    mp_float_t safe_mode_delay_secs = 1.0f;
-    // Will update delay_secs if setting is present.
+    mp_float_t safe_mode_delay_secs = DEFAULT_SAFE_MODE_DELAY_SECS;
+    // Will update safe_mode_delay_secs if setting is present.
     settings_get_float("CIRCUITPY_SAFE_MODE_DELAY", &safe_mode_delay_secs);
     if (safe_mode_delay_secs >= 0.0f && safe_mode_delay_secs <= (mp_float_t)UINT32_MAX) {
         safe_mode_delay_msecs = safe_mode_delay_secs * 1000;
@@ -86,17 +88,20 @@ safe_mode_t wait_for_safe_mode_reset(void) {
     bool boot_in_safe_mode = false;
     while (diff < safe_mode_delay_msecs) {
         #if CIRCUITPY_STATUS_LED
-        // Blink on for 100, off for 100
-        bool led_on = (diff % 250) < 125;
+        // Blink on for 125, off for 125
+        bool led_on = boot_in_safe_mode || (diff % 250) < 125;
         if (led_on) {
             new_status_color(SAFE_MODE);
         } else {
             new_status_color(BLACK);
         }
         #endif
-        if (port_boot_button_pressed()) {
+        if (!boot_in_safe_mode && port_boot_button_pressed()) {
             boot_in_safe_mode = true;
-            break;
+            // Show solid yellow as feedback that the press was accepted, for the
+            // default duration.
+            start_ticks = supervisor_ticks_ms64();
+            safe_mode_delay_msecs = DEFAULT_SAFE_MODE_DELAY_MSECS;
         }
         diff = supervisor_ticks_ms64() - start_ticks;
     }


### PR DESCRIPTION
On boards using the BOOT button to enter safe mode or BLE discovery, there was no LED feedback that the user's BOOT button press was successful.

- Now a boot button press during the safe mode yellow flash or the BLE discovery blue flash restarts the interval, and the status LED shows solid yellow or blue for a second as user feedback.
- The two intervals run consecutively and both polled the button by level, so a click during the yellow flash was often still detected when the BLE discovery interval started, causing the board to enter discovery mode and erase bonding unasked. The discovery interval now requires the button to be released beforehand.

Tested on a Metro ESP32-S3. Also built for feather_nrf52840_express and tested for any regression with double-click reset mode changes.

Claude wrote the code. I tested and found the overlap problem, and had it fix that. I rewrote the comments and the text here for clarity.
