### PR TITLE
ports/zephyr-cp: enable LOAD_ATTR_FAST_PATH and MAP_LOOKUP_CACHE

### DIFF
--- a/ports/zephyr-cp/cptools/build_circuitpython.py
+++ b/ports/zephyr-cp/cptools/build_circuitpython.py
@@ -369,6 +369,12 @@ async def build_circuitpython():  # noqa: C901
     lto = cmake_args.get("LTO", "n") == "y"
     circuitpython_flags.append(f"-DCIRCUITPY_ENABLE_MPY_NATIVE={1 if enable_mpy_native else 0}")
     circuitpython_flags.append(f"-DCIRCUITPY_FULL_BUILD={1 if full_build else 0}")
+    # These two are set by py/circuitpy_mpconfig.mk on the make-based ports (LOAD_ATTR_FAST_PATH
+    # defaults to 1, MAP_LOOKUP_CACHE to CIRCUITPY_FULL_BUILD). This port does not include that
+    # makefile, so they were never defined - and py/vm.c and py/map.c test them with #if, where an
+    # undefined identifier is 0. Both interpreter optimisations were therefore off here.
+    circuitpython_flags.append("-DCIRCUITPY_OPT_LOAD_ATTR_FAST_PATH=1")
+    circuitpython_flags.append(f"-DCIRCUITPY_OPT_MAP_LOOKUP_CACHE={1 if full_build else 0}")
     circuitpython_flags.append(f"-DCIRCUITPY_SETTINGS_TOML={1 if full_build else 0}")
     circuitpython_flags.append(f"-DMICROPY_PY_ASYNC_AWAIT={1 if full_build else 0}")
     circuitpython_flags.append(f"-DMICROPY_PY_ASYNCIO={1 if full_build else 0}")

--- a/ports/zephyr-cp/cptools/build_circuitpython.py
+++ b/ports/zephyr-cp/cptools/build_circuitpython.py
@@ -369,10 +369,6 @@ async def build_circuitpython():  # noqa: C901
     lto = cmake_args.get("LTO", "n") == "y"
     circuitpython_flags.append(f"-DCIRCUITPY_ENABLE_MPY_NATIVE={1 if enable_mpy_native else 0}")
     circuitpython_flags.append(f"-DCIRCUITPY_FULL_BUILD={1 if full_build else 0}")
-    # These two are set by py/circuitpy_mpconfig.mk on the make-based ports (LOAD_ATTR_FAST_PATH
-    # defaults to 1, MAP_LOOKUP_CACHE to CIRCUITPY_FULL_BUILD). This port does not include that
-    # makefile, so they were never defined - and py/vm.c and py/map.c test them with #if, where an
-    # undefined identifier is 0. Both interpreter optimisations were therefore off here.
     circuitpython_flags.append("-DCIRCUITPY_OPT_LOAD_ATTR_FAST_PATH=1")
     circuitpython_flags.append(f"-DCIRCUITPY_OPT_MAP_LOOKUP_CACHE={1 if full_build else 0}")
     circuitpython_flags.append(f"-DCIRCUITPY_SETTINGS_TOML={1 if full_build else 0}")


### PR DESCRIPTION
ports/zephyr-cp builds without `py/circuitpy_mpconfig.mk`, so two interpreter options every other port gets - `MICROPY_OPT_LOAD_ATTR_FAST_PATH` and `MICROPY_OPT_MAP_LOOKUP_CACHE` - are never defined and silently default to off.

This defines them in build_circuitpython.py with the same values the other ports use (fast path always on, map lookup cache on full builds).

Measured on an RP2040 (PicoPad), same firmware otherwise: method call + attribute store 26.68 us -> 22.72 us (-15 %), a bytearray(64) loop -14 % (its LOAD_GLOBAL hits the map cache), 32 moving sprites 39.0 -> 42.4 fps. Costs +144B flash and +128B RAM.