### PR TITLE
ports/zephyr-cp: add `ranges;` to the rpi_pico flash partitions

### DIFF
--- a/ports/zephyr-cp/boards/rpi_pico_rp2040.overlay
+++ b/ports/zephyr-cp/boards/rpi_pico_rp2040.overlay
@@ -2,12 +2,6 @@
 	/delete-node/ partitions;
 
 	partitions {
-		/*
-		 * Without `ranges;` the addresses below stay flash-relative: the code partition resolves
-		 * to 0x100 instead of 0x10000100, so RP2_REQUIRES_SECOND_STAGE_BOOT is not selected (its
-		 * Kconfig tests for 0x10000100) and the image ships without a second-stage bootloader,
-		 * while the generated UF2 targets 0x00000100. Neither is loadable by the RP2040 boot ROM.
-		 */
 		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/ports/zephyr-cp/boards/rpi_pico_rp2040.overlay
+++ b/ports/zephyr-cp/boards/rpi_pico_rp2040.overlay
@@ -2,6 +2,13 @@
 	/delete-node/ partitions;
 
 	partitions {
+		/*
+		 * Without `ranges;` the addresses below stay flash-relative: the code partition resolves
+		 * to 0x100 instead of 0x10000100, so RP2_REQUIRES_SECOND_STAGE_BOOT is not selected (its
+		 * Kconfig tests for 0x10000100) and the image ships without a second-stage bootloader,
+		 * while the generated UF2 targets 0x00000100. Neither is loadable by the RP2040 boot ROM.
+		 */
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 


### PR DESCRIPTION
Without `ranges;` the partition addresses stay flash-relative and never translate to the XIP window:

- CONFIG_RP2_REQUIRES_SECOND_STAGE_BOOT is not selected (its Kconfig check expects the code partition at 0x10000100), so the image has no second-stage bootloader.
- The generated UF2 targets 0x00000100 instead of 0x10000000.

Verified: the UF2 first block moves 0x00000100 -> 0x10000000, RP2_REQUIRES_SECOND_STAGE_BOOT=y, and the image boots from UF2 on an RP2040 board.