### PR TITLE
Require encryption to write the CCCD of an encrypted characteristic (espressif)

### DIFF
--- a/ports/espressif/common-hal/_bleio/Characteristic.c
+++ b/ports/espressif/common-hal/_bleio/Characteristic.c
@@ -62,11 +62,18 @@ void common_hal_bleio_characteristic_construct(bleio_characteristic_obj_t *self,
         read_perm == SECURITY_MODE_SIGNED_WITH_MITM || write_perm == SECURITY_MODE_SIGNED_WITH_MITM) {
         mp_raise_NotImplementedError(MP_ERROR_TEXT("MITM security not supported"));
     }
+    // The BLE_GATT_CHR_F_NOTIFY_INDICATE_* flags are set below to require encryption or
+    // authentication when writing the auto-generated CCCD, if reading the
+    // characteristic requires it. This matches the nordic port behavior.
+    // Without the flags, NimBLE registers the CCCD as writable on an unencrypted link,
+    // so an unpaired central can subscribe and nothing ever requires it to pair.
+    //
+    // TODO: This behavior was fixed in NimBLE 1.10.0. ESP-IDF 6.0.1 uses a fork of NimBLE.
     if (read_perm == SECURITY_MODE_ENC_NO_MITM) {
-        self->flags |= BLE_GATT_CHR_F_READ_ENC;
+        self->flags |= BLE_GATT_CHR_F_READ_ENC | BLE_GATT_CHR_F_NOTIFY_INDICATE_ENC;
     }
     if (read_perm == SECURITY_MODE_SIGNED_NO_MITM) {
-        self->flags |= BLE_GATT_CHR_F_READ_AUTHEN;
+        self->flags |= BLE_GATT_CHR_F_READ_AUTHEN | BLE_GATT_CHR_F_NOTIFY_INDICATE_AUTHEN;
     }
     if (write_perm == SECURITY_MODE_ENC_NO_MITM) {
         self->flags |= BLE_GATT_CHR_F_WRITE_ENC;


### PR DESCRIPTION
Claude found this bug and wrote the fix. I reworked this explanation for clarity.

(Part of the series of small PRs replacing #11178. Independent of the others.)

#### The problem

NimBLE (used on Espressif) derives the auto-generated CCCD's permissions only from the `BLE_GATT_CHR_F_NOTIFY_INDICATE_ENC/AUTHEN` flags. Those flags were not set by us, so the CCCD of an encryption-requiring characteristic was writable on an unencrypted link. This meant an unpaired central could subscribe without having to pair.

By contrast, the nordic port rejects the unencrypted CCCD write with Insufficient Authentication, and that rejection then makes the OS pair.

Since no pairing happened, subsequent web workflow commands, which sent BLE Write Commands, were dropped with no error. This caused the client to just hang waiting for some file transfer results.

(Note that Write Requests can return an error because the server sends a response, but Write Commands get no response. The BLE ATT protocol requires the server to silently ignore those Write Commands when unauthorized.)

#### The fix

Set `BLE_GATT_CHR_F_NOTIFY_INDICATE_ENC` (or `_AUTHEN`) whenever the characteristic's read permission requires encryption (or authentication), so the CCCD write permission follows the characteristic read permission, matching the nordic port.

Note that upstream NimBLE made this inheritance automatic in https://github.com/apache/mynewt-nimble/commit/bfde0dce9e031a2a660f6a940549b5f18e1628da (July 2026, first released in NimBLE 1.10.0), calling the old behavior a security bypass. But the NimBLE fork pinned by ESP-IDF 6.0.x is 1.6.0, so it doesn't include this fix.

#### Testing

Tested on a Metro ESP32-S3 with the web editor on Linux, verified with btmon: the CCCD Write Request is now rejected with Insufficient Authentication (0x05), which triggers SMP pairing and encryption, after which the retried write succeeds and file transfer works. Open characteristics still work without pairing, and a bonded reconnect resumes without a new pairing prompt.
