### PR TITLE
Accept re-pairing from a bonded peer (espressif)

### DIFF
--- a/ports/espressif/common-hal/_bleio/Connection.c
+++ b/ports/espressif/common-hal/_bleio/Connection.c
@@ -34,6 +34,7 @@
 #include "freertos/queue.h"
 
 #include "host/ble_att.h"
+#include "host/ble_store.h"
 
 // Uncomment to turn on debug logging just in this file.
 // #undef CIRCUITPY_VERBOSE_BLE
@@ -80,6 +81,22 @@ int bleio_connection_event_cb(struct ble_gap_event *event, void *connection_in) 
                 connection->pair_status = PAIR_PAIRED;
             }
             break;
+        }
+        case BLE_GAP_EVENT_REPEAT_PAIRING: {
+            // The peer is asking to pair even though we still have a bond with it.
+            // This means it no longer has its own copy of that bond. Discard our bond
+            // and tell the BLE stack to carry on pairing. Otherwise NimBLE silently
+            // ignores the request, and a central that has forgotten this device can
+            // never pair again without erasing the bonds on the board. The
+            // nordic port likewise replaces the stored keys when a peer re-pairs.
+            struct ble_gap_conn_desc desc;
+            if (ble_gap_conn_find(event->repeat_pairing.conn_handle, &desc) != 0) {
+                return BLE_GAP_REPEAT_PAIRING_IGNORE;
+            }
+            ble_store_util_delete_peer(&desc.peer_id_addr);
+            // The BLE stack checks that the bond is really gone before retrying, and
+            // reports this event again if it is not.
+            return BLE_GAP_REPEAT_PAIRING_RETRY;
         }
         case BLE_GAP_EVENT_MTU: {
             if (event->mtu.conn_handle != connection->conn_handle) {


### PR DESCRIPTION
Claude found this deficiency (not an outright bug) and wrote the fix.

(Part of the series of small PRs replacing #11178. Independent of the others.)

#### The problem

A central will ask to pair again when it no longer has its own copy of the bond. This happens whenever the user forgets the device in their OS Bluetooth settings, or the bonding info has otherwise gone away.

In this situation, before this fix, when the central asked to pair again, NimBLE reported `BLE_GAP_EVENT_REPEAT_PAIRING` to _bleio. But we did not handle that event, and nothing was sent back to the central. The board therefore could not be paired with again at all, and had to have its bonds erased with a blue-flash reset.

#### The fix

Handle the `BLE_GAP_EVENT_REPEAT_PAIRING` event by deleting the stale bond with `ble_store_util_delete_peer()` and returning `BLE_GAP_REPEAT_PAIRING_RETRY`. This idiom is used in NimBLE's own bleprph example. The nordic port already behaves this way: it clears the stored keys on `BLE_GAP_EVT_SEC_PARAMS_REQUEST` and lets the new pairing replace them.

ESP-IDF also offers `CONFIG_BT_NIMBLE_HANDLE_REPEAT_PAIRING_DELETION`, which makes the stack delete the bond itself. But we didn't use that because Claude's analysis showed the code enabled by that config option is not resilient to the connection going away.

#### Testing

Tested on a Metro ESP32-S3 with the web editor on Linux. Paired and transferred files, then removed the bond on the host only, leaving the board's bond in place, and reconnected: before this change nothing happened and no pairing prompt appeared, and now the central pairs and the session works.

Note that the reverse case cannot be fixed here. If the board's bonds are erased while the host keeps its key, the host offers a key the board no longer knows, encryption fails with PIN or Key Missing, and the host has to forget the device.

#### Other ports

As noted, this is not needed on nordic. I'll file separate issues for the other ports.
