### PR TITLE
espressif: read the MAC from efuse in port_boot_info

### DIFF
--- a/ports/espressif/supervisor/port.c
+++ b/ports/espressif/supervisor/port.c
@@ -16,6 +16,7 @@
 #include "py/mpprint.h"
 #include "py/runtime.h"
 
+#include "esp_mac.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -521,7 +522,12 @@ void port_idle_until_interrupt(void) {
 #if CIRCUITPY_WIFI
 void port_boot_info(void) {
     uint8_t mac[6];
-    esp_wifi_get_mac(WIFI_IF_STA, mac);
+    // This runs before esp_wifi_init(), so esp_wifi_get_mac() fails with
+    // ESP_ERR_WIFI_NOT_INIT and leaves mac[] untouched. esp_read_mac() reads
+    // efuse directly and does not need the WiFi driver started.
+    if (esp_read_mac(mac, ESP_MAC_WIFI_STA) != ESP_OK) {
+        return;
+    }
     mp_printf(&mp_plat_print, "MAC");
     for (int i = 0; i < 6; i++) {
         mp_printf(&mp_plat_print, ":%02X", mac[i]);


### PR DESCRIPTION
## What

`port_boot_info()` gets the MAC with `esp_wifi_get_mac()`, but it runs before `esp_wifi_init()`. The call fails with `ESP_ERR_WIFI_NOT_INIT` and leaves the stack buffer untouched, so `boot_out.txt` prints whatever was there. Switch to `esp_read_mac()`, which reads efuse and does not need the WiFi driver started.

## Why

Metro ESP32-S2 on current main prints `MAC:00:00:00:00:00:00`, while `wifi.radio.mac_address` on the same board returns the correct `7c:df:a1:1a:0b:b4`.

I tested four espressif chips and only the S2 is wrong. The S2 is also the only one of the four with BLE compiled out (`# No BLE in hw` in `mpconfigport.mk`), so something on the BLE path appears to leave a usable MAC behind before `port_boot_info()` runs. I did not chase that down, since `esp_wifi_get_mac()` is in the closed per-chip blob and the call is wrong either way. If that correlation holds, 2MB flash boards that drop BLE for space would show it too.

Introduced in 32d35eff4b. Not present on 10.2.x, so main is the only affected branch.

## Hardware tested

All four boards flashed with both builds, ESP-IDF v6.0.1, Linux host.

| Board | Chip | Before (`cd3da4a5d8`) | After (`d3b0447611`) |
|---|---|---|---|
| Metro ESP32-S2 | ESP32-S2 | `00:00:00:00:00:00` | `7C:DF:A1:1A:0B:B4` |
| Metro ESP32-S3 | ESP32-S3 | `14:C1:9F:2F:AD:04` | `14:C1:9F:2F:AD:04` |
| Feather ESP32-C6 | ESP32-C6 | `9C:9E:6E:5B:86:4C` | `9C:9E:6E:5B:86:4C` |
| Feather ESP32 V2 | ESP32 | `E8:9F:6D:31:9E:54` | `E8:9F:6D:31:9E:54` |

Every value matches that board's `wifi.radio.mac_address`.

Built but not run: QT Py ESP32-C3. Not tested: H2, P4, or AP mode.

## How I tested it

`boot_out.txt` on the S2 after the change:

```
Adafruit CircuitPython 10.3.0-alpha.3-93-gd3b0447611 on 2026-08-24; Adafruit Metro ESP32S2 with ESP32S2
Board ID:adafruit_metro_esp32s2
UID:C7FD1AA1B04B
MAC:7C:DF:A1:1A:0B:B4
```

Same board at the REPL:

```python
>>> import wifi, binascii
>>> binascii.hexlify(wifi.radio.mac_address)
b'7cdfa11a0bb4'
```

## Behavior change

If `esp_read_mac()` fails the MAC line is omitted rather than printed with undefined contents. Happy to print a zero MAC instead if you would rather keep the line unconditional.

## AI assistance

Used Claude Code to trace the call path and write the patch. I reviewed the diff, ran `pre-commit`, and took every reading in the table above off my own boards.
