### PR TITLE
Fix Zephyr BLE name

### DIFF
--- a/devices/ble_hci/common-hal/_bleio/Adapter.c
+++ b/devices/ble_hci/common-hal/_bleio/Adapter.c
@@ -629,11 +629,8 @@ uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self,
 
     // Copy peer address, if supplied.
     if (directed_to) {
-        mp_buffer_info_t bufinfo;
-        if (mp_get_buffer(directed_to->bytes, &bufinfo, MP_BUFFER_READ)) {
-            peer_addr.type = directed_to->type;
-            memcpy(&peer_addr.a.val, bufinfo.buf, sizeof(peer_addr.a.val));
-        }
+        peer_addr.type = directed_to->type;
+        memcpy(&peer_addr.a.val, directed_to->bytes, sizeof(peer_addr.a.val));
     }
 
     bool extended =

--- a/devices/ble_hci/common-hal/_bleio/Adapter.c
+++ b/devices/ble_hci/common-hal/_bleio/Adapter.c
@@ -29,10 +29,6 @@
 #include "shared-bindings/_bleio/ScanEntry.h"
 #include "shared-bindings/time/__init__.h"
 
-#if CIRCUITPY_SETTINGS_TOML
-#include "shared-bindings/os/__init__.h"
-#endif
-
 #define MSEC_TO_UNITS(TIME, RESOLUTION) (((TIME) * 1000) / (RESOLUTION))
 #define SEC_TO_UNITS(TIME, RESOLUTION) (((TIME) * 1000000) / (RESOLUTION))
 #define UNITS_TO_SEC(TIME, RESOLUTION) (((TIME)*(RESOLUTION)) / 1000000)
@@ -247,9 +243,6 @@ static void check_enabled(bleio_adapter_obj_t *adapter) {
 //     return true;
 // }
 
-// Includes trailing null.
-char default_ble_name[] = { 'C', 'I', 'R', 'C', 'U', 'I', 'T', 'P', 'Y', 0, 0, 0, 0, 0};
-
 static void _adapter_set_name(bleio_adapter_obj_t *self, mp_obj_str_t *name_obj) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(name_obj, &bufinfo, MP_BUFFER_READ);
@@ -261,29 +254,7 @@ static void _adapter_set_name(bleio_adapter_obj_t *self, mp_obj_str_t *name_obj)
 static void bleio_adapter_hci_init(bleio_adapter_obj_t *self) {
     self->name = NULL;
 
-    mp_int_t name_len = 0;
-
-    #if CIRCUITPY_SETTINGS_TOML
-    mp_obj_t name = common_hal_os_getenv("CIRCUITPY_BLE_NAME", mp_const_none);
-    if (name != mp_const_none) {
-        mp_arg_validate_type_string(name, MP_QSTR_CIRCUITPY_BLE_NAME);
-        self->name = name;
-    }
-    #endif
-
-    if (!self->name) {
-        name_len = sizeof(default_ble_name) - 1;
-        bt_addr_t addr;
-        hci_check_error(hci_read_bd_addr(&addr));
-
-        default_ble_name[name_len - 4] = nibble_to_hex_lower[addr.val[1] >> 4 & 0xf];
-        default_ble_name[name_len - 3] = nibble_to_hex_lower[addr.val[1] & 0xf];
-        default_ble_name[name_len - 2] = nibble_to_hex_lower[addr.val[0] >> 4 & 0xf];
-        default_ble_name[name_len - 1] = nibble_to_hex_lower[addr.val[0] & 0xf];
-        // default_ble_name[name_len] will be zero.
-        self->name = mp_obj_new_str(default_ble_name, (uint8_t)name_len);
-    }
-    _adapter_set_name(self, self->name);
+    bleio_adapter_reset_name(self);
 
     // Get version information.
     if (hci_read_local_version(&self->hci_version, &self->hci_revision, &self->lmp_version,
@@ -396,18 +367,14 @@ bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_obj_t *s
     bt_addr_t addr;
     hci_check_error(hci_read_bd_addr(&addr));
 
-    bleio_address_obj_t *address = mp_obj_malloc(bleio_address_obj_t, &bleio_address_type);
-
-    common_hal_bleio_address_construct(address, addr.val, BT_ADDR_LE_PUBLIC);
-    return address;
+    // The cached address is refreshed on every call.
+    common_hal_bleio_address_construct(&self->address, addr.val, BT_ADDR_LE_PUBLIC);
+    self->address.base.type = &bleio_address_type;
+    return &self->address;
 }
 
 bool common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, bleio_address_obj_t *address) {
-    mp_buffer_info_t bufinfo;
-    if (!mp_get_buffer(address->bytes, &bufinfo, MP_BUFFER_READ)) {
-        return false;
-    }
-    return hci_le_set_random_address(bufinfo.buf) == HCI_OK;
+    return hci_le_set_random_address(address->bytes) == HCI_OK;
 }
 
 mp_obj_str_t *common_hal_bleio_adapter_get_name(bleio_adapter_obj_t *self) {

--- a/devices/ble_hci/common-hal/_bleio/Adapter.h
+++ b/devices/ble_hci/common-hal/_bleio/Adapter.h
@@ -11,6 +11,7 @@
 #include "py/obj.h"
 #include "py/objtuple.h"
 
+#include "shared-bindings/_bleio/Address.h"
 #include "shared-bindings/_bleio/Characteristic.h"
 #include "shared-bindings/_bleio/Connection.h"
 #include "shared-bindings/_bleio/ScanResults.h"
@@ -65,6 +66,10 @@ typedef struct _bleio_adapter_obj_t {
     // the service they belong to. This vets that.
     uint16_t last_added_service_handle;
     uint16_t last_added_characteristic_handle;
+    // Cached local address returned by common_hal_bleio_adapter_get_address().
+    // Stored inline so it never needs to allocate, even when read before the
+    // heap is available (e.g. from bleio_adapter_reset_name).
+    bleio_address_obj_t address;
 } bleio_adapter_obj_t;
 
 uint16_t bleio_adapter_add_attribute(bleio_adapter_obj_t *adapter, mp_obj_t *attribute);

--- a/ports/espressif/common-hal/_bleio/Adapter.c
+++ b/ports/espressif/common-hal/_bleio/Adapter.c
@@ -44,10 +44,6 @@
 #include "esp_nimble_hci.h"
 #include "nvs_flash.h"
 
-#if CIRCUITPY_SETTINGS_TOML
-#include "supervisor/shared/settings.h"
-#endif
-
 // Status variables used while busy-waiting for events.
 static volatile bool _nimble_sync;
 static volatile int _connection_status;
@@ -69,8 +65,6 @@ static void _on_sync(void) {
 
 // All examples have this. It'd make sense in a header.
 void ble_store_config_init(void);
-
-char default_ble_name[] = { 'C', 'I', 'R', 'C', 'U', 'I', 'T', 'P', 'Y', 0, 0, 0, 0, 0, 0, 0};
 
 void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enabled) {
     const bool is_enabled = common_hal_bleio_adapter_get_enabled(self);
@@ -105,27 +99,6 @@ void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enable
         ble_svc_gatt_init();
         ble_svc_ans_init();
 
-        #if CIRCUITPY_SETTINGS_TOML
-        char ble_name[1 + MYNEWT_VAL_BLE_SVC_GAP_DEVICE_NAME_MAX_LENGTH];
-        settings_err_t result = settings_get_str("CIRCUITPY_BLE_NAME", ble_name, sizeof(ble_name));
-        if (result == SETTINGS_OK) {
-            ble_svc_gap_device_name_set(ble_name);
-        } else
-        #endif
-        {
-            uint8_t mac[6];
-            esp_read_mac(mac, ESP_MAC_BT);
-            mp_int_t len = sizeof(default_ble_name) - 1;
-            default_ble_name[len - 6] = nibble_to_hex_lower[mac[3] >> 4 & 0xf];
-            default_ble_name[len - 5] = nibble_to_hex_lower[mac[3] & 0xf];
-            default_ble_name[len - 4] = nibble_to_hex_lower[mac[4] >> 4 & 0xf];
-            default_ble_name[len - 3] = nibble_to_hex_lower[mac[4] & 0xf];
-            default_ble_name[len - 2] = nibble_to_hex_lower[mac[5] >> 4 & 0xf];
-            default_ble_name[len - 1] = nibble_to_hex_lower[mac[5] & 0xf];
-            default_ble_name[len] = '\0'; // for now we add null for compatibility with C ASCIIZ strings
-            ble_svc_gap_device_name_set(default_ble_name);
-        }
-
         // Clear all of the internal connection objects.
         for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
             bleio_connection_internal_t *connection = &bleio_connections[i];
@@ -150,6 +123,8 @@ void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enable
         if (!_nimble_sync) {
             mp_raise_RuntimeError(MP_ERROR_TEXT("Update failed"));
         }
+
+        bleio_adapter_reset_name(self);
     } else {
         int ret = nimble_port_stop();
         while (xTaskGetHandle("nimble_host") != NULL && !mp_hal_is_interrupted()) {
@@ -175,20 +150,17 @@ bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_obj_t *s
         return NULL;
     }
 
-    bleio_address_obj_t *address = mp_obj_malloc(bleio_address_obj_t, &bleio_address_type);
-    common_hal_bleio_address_construct(address, address_bytes, BLEIO_ADDRESS_TYPE_RANDOM_STATIC);
-    return address;
+    // The cached address is refreshed on every call.
+    common_hal_bleio_address_construct(&self->address, address_bytes, BLEIO_ADDRESS_TYPE_RANDOM_STATIC);
+    self->address.base.type = &bleio_address_type;
+    return &self->address;
 }
 
 bool common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, bleio_address_obj_t *address) {
     if (address->type != BLEIO_ADDRESS_TYPE_RANDOM_STATIC) {
         return false;
     }
-    mp_buffer_info_t bufinfo;
-    if (!mp_get_buffer(address->bytes, &bufinfo, MP_BUFFER_READ)) {
-        return false;
-    }
-    int result = ble_hs_id_set_rnd(bufinfo.buf);
+    int result = ble_hs_id_set_rnd(address->bytes);
     return result == 0;
 }
 
@@ -318,9 +290,7 @@ void common_hal_bleio_adapter_stop_scan(bleio_adapter_obj_t *self) {
 
 static void _convert_address(const bleio_address_obj_t *address, ble_addr_t *nimble_address) {
     nimble_address->type = address->type;
-    mp_buffer_info_t address_buf_info;
-    mp_get_buffer_raise(address->bytes, &address_buf_info, MP_BUFFER_READ);
-    memcpy(nimble_address->val, (uint8_t *)address_buf_info.buf, NUM_BLEIO_ADDRESS_BYTES);
+    memcpy(nimble_address->val, address->bytes, NUM_BLEIO_ADDRESS_BYTES);
 }
 
 static int _mtu_reply(uint16_t conn_handle,

--- a/ports/espressif/common-hal/_bleio/Adapter.h
+++ b/ports/espressif/common-hal/_bleio/Adapter.h
@@ -11,6 +11,7 @@
 #include "py/obj.h"
 #include "py/objtuple.h"
 
+#include "shared-bindings/_bleio/Address.h"
 #include "shared-bindings/_bleio/Connection.h"
 #include "shared-bindings/_bleio/ScanResults.h"
 
@@ -31,6 +32,10 @@ typedef struct {
     mp_obj_tuple_t *connection_objs;
     background_callback_t background_callback;
     bool user_advertising;
+    // Cached local address returned by common_hal_bleio_adapter_get_address().
+    // Stored inline so it never needs to allocate, even when read before the
+    // heap is available (e.g. from bleio_adapter_reset_name).
+    bleio_address_obj_t address;
 } bleio_adapter_obj_t;
 
 void bleio_adapter_gc_collect(bleio_adapter_obj_t *adapter);

--- a/ports/nordic/common-hal/_bleio/Adapter.c
+++ b/ports/nordic/common-hal/_bleio/Adapter.c
@@ -32,10 +32,6 @@
 #include "supervisor/usb.h"
 #endif
 
-#if CIRCUITPY_SETTINGS_TOML
-#include "supervisor/shared/settings.h"
-#endif
-
 #define BLE_MIN_CONN_INTERVAL        MSEC_TO_UNITS(15, UNIT_0_625_MS)
 #define BLE_MAX_CONN_INTERVAL        MSEC_TO_UNITS(15, UNIT_0_625_MS)
 #define BLE_SLAVE_LATENCY            0
@@ -310,31 +306,6 @@ static void get_address(bleio_adapter_obj_t *self, ble_gap_addr_t *address) {
     check_nrf_error(sd_ble_gap_addr_get(address));
 }
 
-char default_ble_name[] = { 'C', 'I', 'R', 'C', 'U', 'I', 'T', 'P', 'Y', 0, 0, 0, 0, 0};
-
-static void bleio_adapter_reset_name(bleio_adapter_obj_t *self) {
-    // setup the default name
-    ble_gap_addr_t addr; // local_address
-    get_address(self, &addr);
-    mp_int_t len = sizeof(default_ble_name) - 1;
-    default_ble_name[len - 4] = nibble_to_hex_lower[addr.addr[1] >> 4 & 0xf];
-    default_ble_name[len - 3] = nibble_to_hex_lower[addr.addr[1] & 0xf];
-    default_ble_name[len - 2] = nibble_to_hex_lower[addr.addr[0] >> 4 & 0xf];
-    default_ble_name[len - 1] = nibble_to_hex_lower[addr.addr[0] & 0xf];
-    default_ble_name[len] = '\0'; // for now we add null for compatibility with C ASCIIZ strings
-
-    #if CIRCUITPY_SETTINGS_TOML
-    char ble_name[32];
-
-    settings_err_t result = settings_get_str("CIRCUITPY_BLE_NAME", ble_name, sizeof(ble_name));
-    if (result == SETTINGS_OK) {
-        common_hal_bleio_adapter_set_name(self, ble_name);
-        return;
-    }
-    #endif
-
-    common_hal_bleio_adapter_set_name(self, (char *)default_ble_name);
-}
 
 static void bluetooth_adapter_background(void *data) {
     supervisor_bluetooth_background();
@@ -408,20 +379,19 @@ bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_obj_t *s
     ble_gap_addr_t local_address;
     get_address(self, &local_address);
 
-    bleio_address_obj_t *address = mp_obj_malloc(bleio_address_obj_t, &bleio_address_type);
-
-    common_hal_bleio_address_construct(address, local_address.addr, local_address.addr_type);
-    return address;
+    // Return the address cached on the adapter so this can be called before
+    // the heap is available (e.g. from bleio_adapter_reset_name). The shared
+    // common_hal_bleio_address_construct() converts the raw address bytes
+    // into the Address object. The cached address is refreshed on every call.
+    common_hal_bleio_address_construct(&self->address, local_address.addr, local_address.addr_type);
+    self->address.base.type = &bleio_address_type;
+    return &self->address;
 }
 
 bool common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, bleio_address_obj_t *address) {
     ble_gap_addr_t local_address;
-    mp_buffer_info_t bufinfo;
-    if (!mp_get_buffer(address->bytes, &bufinfo, MP_BUFFER_READ)) {
-        return false;
-    }
     local_address.addr_type = address->type;
-    memcpy(local_address.addr, bufinfo.buf, NUM_BLEIO_ADDRESS_BYTES);
+    memcpy(local_address.addr, address->bytes, NUM_BLEIO_ADDRESS_BYTES);
     return sd_ble_gap_addr_set(&local_address) == NRF_SUCCESS;
 }
 
@@ -610,9 +580,7 @@ static bool connect_on_ble_evt(ble_evt_t *ble_evt, void *info_in) {
 
 static void _convert_address(const bleio_address_obj_t *address, ble_gap_addr_t *sd_address) {
     sd_address->addr_type = address->type;
-    mp_buffer_info_t address_buf_info;
-    mp_get_buffer_raise(address->bytes, &address_buf_info, MP_BUFFER_READ);
-    memcpy(sd_address->addr, (uint8_t *)address_buf_info.buf, NUM_BLEIO_ADDRESS_BYTES);
+    memcpy(sd_address->addr, address->bytes, NUM_BLEIO_ADDRESS_BYTES);
 }
 
 mp_obj_t common_hal_bleio_adapter_connect(bleio_adapter_obj_t *self, bleio_address_obj_t *address, mp_float_t timeout) {

--- a/ports/nordic/common-hal/_bleio/Adapter.h
+++ b/ports/nordic/common-hal/_bleio/Adapter.h
@@ -11,6 +11,7 @@
 #include "py/obj.h"
 #include "py/objtuple.h"
 
+#include "shared-bindings/_bleio/Address.h"
 #include "shared-bindings/_bleio/Connection.h"
 #include "shared-bindings/_bleio/ScanResults.h"
 
@@ -38,6 +39,10 @@ typedef struct {
     ble_drv_evt_handler_entry_t advertising_handler_entry;
     background_callback_t background_callback;
     bool user_advertising;
+    // Cached local address returned by common_hal_bleio_adapter_get_address().
+    // Stored inline so it never needs to allocate, even when read before the
+    // heap is available (e.g. from bleio_adapter_reset_name).
+    bleio_address_obj_t address;
 } bleio_adapter_obj_t;
 
 void bleio_adapter_gc_collect(bleio_adapter_obj_t *adapter);

--- a/ports/silabs/common-hal/_bleio/Adapter.c
+++ b/ports/silabs/common-hal/_bleio/Adapter.c
@@ -78,31 +78,16 @@ void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self,
     bool enabled) {
 
     const bool is_enabled = common_hal_bleio_adapter_get_enabled(self);
-    bd_addr get_address;
-    uint8_t address_type;
     uint8_t conn_index;
     bleio_connection_internal_t *connection;
-    sl_status_t sc = SL_STATUS_FAIL;
-    uint8_t device_name[DEVICE_NAME_LEN + 1];
-    memset(device_name, 0, DEVICE_NAME_LEN);
 
     // Don't enable or disable twice
     if (is_enabled == enabled) {
         return;
     }
 
-    sc = sl_bt_system_get_identity_address(&get_address, &address_type);
-    if (SL_STATUS_OK != sc) {
-        mp_raise_bleio_BluetoothError(MP_ERROR_TEXT("Get address fail."));
-    }
-    snprintf((char *)device_name, DEVICE_NAME_LEN + 1,
-        "CIRCUITPY-%X%X", get_address.addr[1], get_address.addr[0]);
-
     if (enabled) {
-        sl_bt_gatt_server_write_attribute_value(gattdb_device_name,
-            0,
-            DEVICE_NAME_LEN,
-            device_name);
+        bleio_adapter_reset_name(self);
 
         // Clear all of the internal connection objects.
         for (conn_index = 0; conn_index < BLEIO_TOTAL_CONNECTION_COUNT; conn_index++) {
@@ -120,17 +105,17 @@ bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_obj_t *s
     bd_addr get_address;
     uint8_t address_type;
     sl_status_t sc = SL_STATUS_FAIL;
-    bleio_address_obj_t *address;
 
     sc = sl_bt_system_get_identity_address(&get_address, &address_type);
     if (SL_STATUS_OK != sc) {
         return NULL;
     }
 
-    address = mp_obj_malloc(bleio_address_obj_t, &bleio_address_type);
-    common_hal_bleio_address_construct(address, get_address.addr,
+    // The cached address is refreshed on every call.
+    common_hal_bleio_address_construct(&self->address, get_address.addr,
         BLEIO_ADDRESS_TYPE_RANDOM_STATIC);
-    return address;
+    self->address.base.type = &bleio_address_type;
+    return &self->address;
 }
 
 // Set identity address
@@ -138,17 +123,13 @@ bool common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self,
     bleio_address_obj_t *address) {
 
     sl_status_t sc = SL_STATUS_FAIL;
-    mp_buffer_info_t bufinfo;
     bd_addr ble_addr;
 
     if (NULL == address) {
         return false;
     }
-    if (!mp_get_buffer(address->bytes, &bufinfo, MP_BUFFER_READ)) {
-        return false;
-    }
-    memcpy(ble_addr.addr, bufinfo.buf, 6);
-    sl_bt_system_set_identity_address(ble_addr, PUBLIC_ADDRESS);
+    memcpy(ble_addr.addr, address->bytes, 6);
+    sc = sl_bt_system_set_identity_address(ble_addr, PUBLIC_ADDRESS);
     return sc == SL_STATUS_OK;
 }
 
@@ -172,9 +153,13 @@ mp_obj_str_t *common_hal_bleio_adapter_get_name(bleio_adapter_obj_t *self) {
 // Set name of the BLE adapter
 void common_hal_bleio_adapter_set_name(bleio_adapter_obj_t *self,
     const char *name) {
+    size_t len = strlen(name);
+    if (len > DEVICE_NAME_LEN) {
+        len = DEVICE_NAME_LEN;
+    }
     sl_bt_gatt_server_write_attribute_value(gattdb_device_name,
         0,
-        DEVICE_NAME_LEN,
+        len,
         (const uint8_t *)name);
 }
 
@@ -453,10 +438,8 @@ bool common_hal_bleio_adapter_get_advertising(bleio_adapter_obj_t *self) {
 // Convert mac address of remote device to connect
 static void _convert_address(const bleio_address_obj_t *address,
     bd_addr *sd_address, uint8_t *addr_type) {
-    mp_buffer_info_t address_buf_info;
     *addr_type = address->type;
-    mp_get_buffer_raise(address->bytes, &address_buf_info, MP_BUFFER_READ);
-    memcpy(sd_address->addr, (uint8_t *)address_buf_info.buf, 6);
+    memcpy(sd_address->addr, address->bytes, 6);
 }
 
 // Add new connection into connection list

--- a/ports/silabs/common-hal/_bleio/Adapter.h
+++ b/ports/silabs/common-hal/_bleio/Adapter.h
@@ -29,6 +29,7 @@
 
 #include "py/obj.h"
 #include "py/objtuple.h"
+#include "shared-bindings/_bleio/Address.h"
 #include "shared-bindings/_bleio/Connection.h"
 #include "shared-bindings/_bleio/ScanResults.h"
 #include "supervisor/background_callback.h"
@@ -54,6 +55,10 @@ typedef struct {
     bool user_advertising;
     bool is_enable;
     uint8_t advertising_handle;
+    // Cached local address returned by common_hal_bleio_adapter_get_address().
+    // Stored inline so it never needs to allocate, even when read before the
+    // heap is available (e.g. from bleio_adapter_reset_name).
+    bleio_address_obj_t address;
 } bleio_adapter_obj_t;
 
 typedef struct {

--- a/ports/zephyr-cp/common-hal/_bleio/Adapter.c
+++ b/ports/zephyr-cp/common-hal/_bleio/Adapter.c
@@ -24,6 +24,7 @@
 #include "shared-bindings/_bleio/Address.h"
 #include "shared-module/_bleio/Address.h"
 #include "shared-module/_bleio/ScanResults.h"
+#include "supervisor/shared/bluetooth/bluetooth.h"
 #include "supervisor/shared/tick.h"
 
 bleio_connection_internal_t bleio_connections[BLEIO_TOTAL_CONNECTION_COUNT];
@@ -288,6 +289,18 @@ void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enable
             // bt_finalize_init() which sets BT_DEV_READY.
             settings_load();
         }
+        // Ensure a local identity exists so advertising/connections work and the
+        // name is stable across reboots. bt_id_create persists the identity when
+        // CONFIG_BT_SETTINGS is enabled. bleio_adapter_reset_name() reads the
+        // identity address back via common_hal_bleio_adapter_get_address().
+        bt_addr_le_t id_addrs[CONFIG_BT_ID_MAX];
+        size_t id_count = CONFIG_BT_ID_MAX;
+        bt_id_get(id_addrs, &id_count);
+        if (id_count == 0 || bt_addr_le_eq(&id_addrs[BT_ID_DEFAULT], BT_ADDR_LE_ANY)) {
+            (void)bt_id_create(NULL, NULL);
+            bt_id_get(id_addrs, &id_count);
+        }
+        bleio_adapter_reset_name(self);
         ble_adapter_enabled = true;
         return;
     }
@@ -350,7 +363,25 @@ void common_hal_bleio_adapter_set_tx_power(bleio_adapter_obj_t *self, mp_int_t t
 }
 
 bleio_address_obj_t *common_hal_bleio_adapter_get_address(bleio_adapter_obj_t *self) {
-    mp_raise_NotImplementedError(NULL);
+    // Report the local identity address, which is the same address used to
+    // derive the default adapter name in common_hal_bleio_adapter_set_enabled.
+    bt_addr_le_t id_addrs[CONFIG_BT_ID_MAX];
+    size_t id_count = CONFIG_BT_ID_MAX;
+    bt_id_get(id_addrs, &id_count);
+    if (id_count == 0 || bt_addr_le_eq(&id_addrs[BT_ID_DEFAULT], BT_ADDR_LE_ANY)) {
+        (void)bt_id_create(NULL, NULL);
+        bt_id_get(id_addrs, &id_count);
+    }
+
+    const bt_addr_le_t *addr = &id_addrs[BT_ID_DEFAULT];
+    // Cache the address on the adapter so this can be called before the heap
+    // is available (e.g. from bleio_adapter_reset_name). The shared
+    // common_hal_bleio_address_construct() converts the raw address bytes
+    // into the Address object.
+    common_hal_bleio_address_construct(&self->address, addr->a.val,
+        bleio_address_type_from_zephyr(addr));
+    self->address.base.type = &bleio_address_type;
+    return &self->address;
 }
 
 bool common_hal_bleio_adapter_set_address(bleio_adapter_obj_t *self, bleio_address_obj_t *address) {
@@ -590,13 +621,10 @@ mp_obj_t common_hal_bleio_adapter_connect(bleio_adapter_obj_t *self, bleio_addre
 
     const uint16_t timeout_units = bleio_validate_and_convert_timeout(timeout);
 
-    mp_buffer_info_t address_bufinfo;
-    mp_get_buffer_raise(address->bytes, &address_bufinfo, MP_BUFFER_READ);
-
     bt_addr_le_t peer = {
         .type = bleio_address_type_to_zephyr(address->type),
     };
-    memcpy(peer.a.val, address_bufinfo.buf, NUM_BLEIO_ADDRESS_BYTES);
+    memcpy(peer.a.val, address->bytes, NUM_BLEIO_ADDRESS_BYTES);
 
     struct bt_conn_le_create_param create_params = BT_CONN_LE_CREATE_PARAM_INIT(
         BT_CONN_LE_OPT_NONE,

--- a/ports/zephyr-cp/common-hal/_bleio/Adapter.h
+++ b/ports/zephyr-cp/common-hal/_bleio/Adapter.h
@@ -10,6 +10,7 @@
 #include "py/obj.h"
 #include "py/objtuple.h"
 
+#include "shared-bindings/_bleio/Address.h"
 #include "shared-bindings/_bleio/Connection.h"
 #include "shared-bindings/_bleio/ScanResults.h"
 
@@ -23,6 +24,10 @@ typedef struct {
     mp_obj_t name;
     mp_obj_tuple_t *connection_objs;
     bool user_advertising;
+    // Cached local address returned by common_hal_bleio_adapter_get_address().
+    // Stored inline so it never needs to allocate, even when read before the
+    // heap is available (e.g. from bleio_adapter_reset_name).
+    bleio_address_obj_t address;
 } bleio_adapter_obj_t;
 
 void bleio_adapter_gc_collect(bleio_adapter_obj_t *adapter);

--- a/ports/zephyr-cp/tests/bsim/test_bsim_ble_name.py
+++ b/ports/zephyr-cp/tests/bsim/test_bsim_ble_name.py
@@ -1,24 +1,126 @@
 # SPDX-FileCopyrightText: 2026 Scott Shawcroft for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
-"""BLE name tests for bsim."""
+"""BLE adapter name tests for bsim.
+
+Covers reading the default adapter name (derived from the device address),
+setting a custom name and reading it back, and verifying the default name is
+re-applied every time the adapter is re-enabled.
+"""
+
+import re
 
 import pytest
 
 
-BSIM_NAME_CODE = """\
+# The address prints as <Address aa:bb:cc:dd:ee:ff> in big-endian/expected order.
+# The default name is "CIRCUITPY" plus the last two octets (ee, ff) concatenated
+# without colons, e.g. an address of <Address ...:d2:24> -> "CIRCUITPYd224".
+ADDRESS_RE = re.compile(
+    r"<Address ([0-9a-f]{2}):([0-9a-f]{2}):([0-9a-f]{2}):"
+    r"([0-9a-f]{2}):([0-9a-f]{2}):([0-9a-f]{2})>"
+)
+
+# Strip ANSI/OSC escape sequences (e.g. terminal title updates) and carriage
+# returns that CircuitPython interleaves with code.py output.
+_ANSI_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def _clean(output: str) -> str:
+    return _ANSI_RE.sub("", output).replace("\r", "")
+
+
+def _expected_default_name(address_repr: str) -> str:
+    m = ADDRESS_RE.search(address_repr)
+    assert m is not None, f"unexpected address repr: {address_repr!r}"
+    return "CIRCUITPY" + m.group(5) + m.group(6)
+
+
+# --- Default name is derived from the adapter address ---
+
+BSIM_DEFAULT_NAME_CODE = """\
+import _bleio
+
+adapter = _bleio.adapter
+adapter.enabled = True
+print("default name", adapter.name)
+print("address", adapter.address)
+print("done")
+"""
+
+
+@pytest.mark.circuitpy_drive({"code.py": BSIM_DEFAULT_NAME_CODE})
+def test_bsim_default_name_matches_address(bsim_phy, circuitpython):
+    """The default name is CIRCUITPY plus the last two address octets."""
+    circuitpython.wait_until_done()
+
+    output = _clean(circuitpython.serial.all_output)
+    name = re.search(r"(?m)^default name (\S+)$", output).group(1)
+    address_repr = re.search(r"(?m)^address (.+)$", output).group(1).strip()
+
+    assert name == _expected_default_name(address_repr)
+    assert re.search(r"(?m)^done$", output) is not None
+
+
+# --- Set a custom name and read it back ---
+
+BSIM_SET_NAME_CODE = """\
 import _bleio
 
 adapter = _bleio.adapter
 adapter.enabled = True
 adapter.name = "CPNAME"
 print("name", adapter.name)
+print("done")
 """
 
 
-@pytest.mark.circuitpy_drive({"code.py": BSIM_NAME_CODE})
+@pytest.mark.circuitpy_drive({"code.py": BSIM_SET_NAME_CODE})
 def test_bsim_set_name(bsim_phy, circuitpython):
     """Set the BLE name and read it back on bsim."""
     circuitpython.wait_until_done()
 
-    assert "name CPNAME" in circuitpython.serial.all_output
+    output = _clean(circuitpython.serial.all_output)
+    assert re.search(r"(?m)^name CPNAME$", output) is not None
+    assert re.search(r"(?m)^done$", output) is not None
+
+
+# --- Re-enabling the adapter restores the default name ---
+
+BSIM_NAME_RESET_ON_ENABLE_CODE = """\
+import _bleio
+
+adapter = _bleio.adapter
+
+adapter.enabled = True
+print("default", adapter.name)
+
+adapter.name = "CUSTOM"
+print("custom", adapter.name)
+
+# Re-enabling re-applies the default name derived from the address.
+adapter.enabled = False
+adapter.enabled = True
+print("reset", adapter.name)
+print("address", adapter.address)
+print("done")
+"""
+
+
+@pytest.mark.circuitpy_drive({"code.py": BSIM_NAME_RESET_ON_ENABLE_CODE})
+def test_bsim_name_resets_on_enable(bsim_phy, circuitpython):
+    """Disabling and re-enabling the adapter restores the default name."""
+    circuitpython.wait_until_done()
+
+    output = _clean(circuitpython.serial.all_output)
+    default_name = re.search(r"(?m)^default (\S+)$", output).group(1)
+    assert re.search(r"(?m)^custom CUSTOM$", output) is not None
+    reset_name = re.search(r"(?m)^reset (\S+)$", output).group(1)
+    address_repr = re.search(r"(?m)^address (.+)$", output).group(1).strip()
+
+    # The custom name is gone and the address-derived default is back.
+    assert reset_name != "CUSTOM"
+    assert reset_name == _expected_default_name(address_repr)
+    # The re-applied default matches the boot-time default.
+    assert reset_name == default_name
+    assert re.search(r"(?m)^done$", output) is not None

--- a/shared-bindings/_bleio/Adapter.c
+++ b/shared-bindings/_bleio/Adapter.c
@@ -8,10 +8,15 @@
 #include <string.h>
 
 #include "py/objproperty.h"
+#include "py/objstr.h"
 #include "py/runtime.h"
 #include "shared-bindings/_bleio/__init__.h"
 #include "shared-bindings/_bleio/Address.h"
 #include "shared-bindings/_bleio/Adapter.h"
+
+#if CIRCUITPY_SETTINGS_TOML
+#include "supervisor/shared/settings.h"
+#endif
 
 #define ADV_INTERVAL_MIN (0.02f)
 #define ADV_INTERVAL_MIN_STRING "0.02"
@@ -134,8 +139,11 @@ MP_PROPERTY_GETSET(bleio_adapter_address_obj,
 
 //|     name: str
 //|     """name of the BLE adapter used once connected.
-//|     The name is "CIRCUITPY" + the last four hex digits of ``adapter.address``,
-//|     to make it easy to distinguish multiple CircuitPython boards."""
+//|     The default name is "CIRCUITPY" plus the last four hex digits of
+//|     ``adapter.address``, to make it easy to distinguish multiple
+//|     CircuitPython boards. Set ``CIRCUITPY_BLE_NAME`` in settings.toml to
+//|     override it. The default is re-applied each time the adapter is
+//|     enabled."""
 //|
 static mp_obj_t _bleio_adapter_get_name(mp_obj_t self) {
     return MP_OBJ_FROM_PTR(common_hal_bleio_adapter_get_name(self));
@@ -152,6 +160,37 @@ MP_DEFINE_CONST_FUN_OBJ_2(bleio_adapter_set_name_obj, bleio_adapter_set_name);
 MP_PROPERTY_GETSET(bleio_adapter_name_obj,
     (mp_obj_t)&bleio_adapter_get_name_obj,
     (mp_obj_t)&bleio_adapter_set_name_obj);
+
+void bleio_adapter_reset_name(bleio_adapter_obj_t *self) {
+    #if CIRCUITPY_SETTINGS_TOML
+    // Let the user override the default name from settings.toml. Use the
+    // allocation-free settings_get_str (not os.getenv), because ports call
+    // this from common_hal_bleio_adapter_set_enabled() which can run before
+    // the VM/gc heap is initialized.
+    char ble_name[32];
+    settings_err_t result = settings_get_str("CIRCUITPY_BLE_NAME", ble_name, sizeof(ble_name));
+    if (result == SETTINGS_OK) {
+        common_hal_bleio_adapter_set_name(self, ble_name);
+        return;
+    }
+    #endif
+
+    // Default to "CIRCUITPY" plus the last four hex digits of the adapter
+    // address so multiple boards are distinguishable. The address bytes are
+    // little-endian, so address[0] is the least-significant byte. If the port
+    // cannot provide an address, fall back to the literal "CIRCUITPYxxxx".
+    char default_ble_name[] = "CIRCUITPYxxxx";
+    bleio_address_obj_t *address = common_hal_bleio_adapter_get_address(self);
+    if (address != NULL) {
+        uint8_t addr_bytes[NUM_BLEIO_ADDRESS_BYTES];
+        common_hal_bleio_address_get_bytes(address, addr_bytes);
+        default_ble_name[ 9] = nibble_to_hex_lower[addr_bytes[1] >> 4 & 0xf];
+        default_ble_name[10] = nibble_to_hex_lower[addr_bytes[1] & 0xf];
+        default_ble_name[11] = nibble_to_hex_lower[addr_bytes[0] >> 4 & 0xf];
+        default_ble_name[12] = nibble_to_hex_lower[addr_bytes[0] & 0xf];
+    }
+    common_hal_bleio_adapter_set_name(self, default_ble_name);
+}
 
 //|     def start_advertising(
 //|         self,

--- a/shared-bindings/_bleio/Adapter.h
+++ b/shared-bindings/_bleio/Adapter.h
@@ -35,6 +35,13 @@ uint16_t bleio_adapter_get_name(char *buf, uint16_t len);
 extern mp_obj_str_t *common_hal_bleio_adapter_get_name(bleio_adapter_obj_t *self);
 extern void common_hal_bleio_adapter_set_name(bleio_adapter_obj_t *self, const char *name);
 
+// Resets the adapter's device name to the default: the CIRCUITPY_BLE_NAME setting value if
+// set, otherwise "CIRCUITPY" plus the last four hex digits of the adapter's address (read via
+// common_hal_bleio_adapter_get_address). Every port calls this from its
+// common_hal_bleio_adapter_set_enabled once the controller is ready, so the default name is
+// derived the same way everywhere.
+void bleio_adapter_reset_name(bleio_adapter_obj_t *self);
+
 // Returns 0 if ok, otherwise a BLE stack specific error code.
 extern uint32_t _common_hal_bleio_adapter_start_advertising(bleio_adapter_obj_t *self,
     bool connectable, bool anonymous, uint32_t timeout, float interval,

--- a/shared-bindings/_bleio/Address.c
+++ b/shared-bindings/_bleio/Address.c
@@ -108,10 +108,8 @@ static mp_obj_t bleio_address_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_o
                 bleio_address_obj_t *lhs = MP_OBJ_TO_PTR(lhs_in);
                 bleio_address_obj_t *rhs = MP_OBJ_TO_PTR(rhs_in);
                 return mp_obj_new_bool(
-                    mp_obj_equal(common_hal_bleio_address_get_address_bytes(lhs),
-                        common_hal_bleio_address_get_address_bytes(rhs)) &&
-                    common_hal_bleio_address_get_type(lhs) ==
-                    common_hal_bleio_address_get_type(rhs));
+                    lhs->type == rhs->type &&
+                    memcmp(lhs->bytes, rhs->bytes, NUM_BLEIO_ADDRESS_BYTES) == 0);
 
             } else {
                 return mp_const_false;
@@ -130,13 +128,9 @@ static mp_obj_t bleio_address_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
     switch (op) {
         // Two Addresses are equal if their address bytes and address_type are equal
         case MP_UNARY_OP_HASH: {
-            mp_obj_t bytes = common_hal_bleio_address_get_address_bytes(MP_OBJ_TO_PTR(self_in));
-            GET_STR_HASH(bytes, h);
-            if (h == 0) {
-                GET_STR_DATA_LEN(bytes, data, len);
-                h = qstr_compute_hash(data, len);
-            }
-            h ^= common_hal_bleio_address_get_type(MP_OBJ_TO_PTR(self_in));
+            bleio_address_obj_t *self = MP_OBJ_TO_PTR(self_in);
+            mp_int_t h = (mp_int_t)qstr_compute_hash(self->bytes, NUM_BLEIO_ADDRESS_BYTES);
+            h ^= self->type;
             return MP_OBJ_NEW_SMALL_INT(h);
         }
         default:
@@ -146,11 +140,7 @@ static mp_obj_t bleio_address_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 
 static void bleio_address_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     bleio_address_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_buffer_info_t buf_info;
-    mp_obj_t address_bytes = common_hal_bleio_address_get_address_bytes(self);
-    mp_get_buffer_raise(address_bytes, &buf_info, MP_BUFFER_READ);
-
-    const uint8_t *buf = (uint8_t *)buf_info.buf;
+    const uint8_t *buf = self->bytes;
     mp_printf(print, "<Address %02x:%02x:%02x:%02x:%02x:%02x>",
         buf[5], buf[4], buf[3], buf[2], buf[1], buf[0]);
 }

--- a/shared-bindings/_bleio/Address.h
+++ b/shared-bindings/_bleio/Address.h
@@ -20,6 +20,10 @@
 
 extern const mp_obj_type_t bleio_address_type;
 
-extern void common_hal_bleio_address_construct(bleio_address_obj_t *self, uint8_t *bytes, uint8_t address_type);
+extern void common_hal_bleio_address_construct(bleio_address_obj_t *self, const uint8_t *bytes, uint8_t address_type);
 extern mp_obj_t common_hal_bleio_address_get_address_bytes(bleio_address_obj_t *self);
 extern uint8_t common_hal_bleio_address_get_type(bleio_address_obj_t *self);
+// Copies the raw address bytes (little-endian BD_ADDR, NUM_BLEIO_ADDRESS_BYTES)
+// into the given buffer. Allocation-free, so it is safe to use before the heap
+// is initialized (e.g. when deriving the default adapter name).
+extern void common_hal_bleio_address_get_bytes(bleio_address_obj_t *self, uint8_t bytes[NUM_BLEIO_ADDRESS_BYTES]);

--- a/shared-module/_bleio/Address.c
+++ b/shared-module/_bleio/Address.c
@@ -7,17 +7,24 @@
 
 #include <string.h>
 
-#include "py/objstr.h"
+#include "py/obj.h"
 #include "shared-bindings/_bleio/Address.h"
 #include "shared-module/_bleio/Address.h"
 
-void common_hal_bleio_address_construct(bleio_address_obj_t *self, uint8_t *bytes, uint8_t address_type) {
-    self->bytes = mp_obj_new_bytes(bytes, NUM_BLEIO_ADDRESS_BYTES);
+void common_hal_bleio_address_construct(bleio_address_obj_t *self, const uint8_t *bytes, uint8_t address_type) {
+    memcpy(self->bytes, bytes, NUM_BLEIO_ADDRESS_BYTES);
     self->type = address_type;
 }
 
 mp_obj_t common_hal_bleio_address_get_address_bytes(bleio_address_obj_t *self) {
-    return self->bytes;
+    // Build a bytes object on demand. Address stores its bytes inline, so this
+    // is only reached from Python (e.g. ``address.address_bytes``) where the
+    // heap is available.
+    return mp_obj_new_bytes(self->bytes, NUM_BLEIO_ADDRESS_BYTES);
+}
+
+void common_hal_bleio_address_get_bytes(bleio_address_obj_t *self, uint8_t bytes[NUM_BLEIO_ADDRESS_BYTES]) {
+    memcpy(bytes, self->bytes, NUM_BLEIO_ADDRESS_BYTES);
 }
 
 uint8_t common_hal_bleio_address_get_type(bleio_address_obj_t *self) {

--- a/shared-module/_bleio/Address.h
+++ b/shared-module/_bleio/Address.h
@@ -14,5 +14,8 @@
 typedef struct {
     mp_obj_base_t base;
     uint8_t type;
-    mp_obj_t bytes;    // a bytes() object
+    // Little-endian BD_ADDR order: bytes[0] is the least-significant byte.
+    // Stored inline so an Address can live in static storage (e.g. embedded in
+    // an adapter) without allocating a separate bytes object.
+    uint8_t bytes[NUM_BLEIO_ADDRESS_BYTES];
 } bleio_address_obj_t;


### PR DESCRIPTION
And factor out the logic so it is shared amongst all BLE implementations.