### PR TITLE
memento: turn off presenting SD card on USB by default

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -134,7 +134,8 @@ CIRCUITPY_SDCARD_USB (boolean)
 Present a mounted SD card as a USB MSC device. If the board has default pins for an SD card socket,
 the card is mounted automatically on startup.
 Only one card can be presented.
-Defaults to ``true``.
+Defaults to ``true``, except on the Adafruit Memento board, where it defaults to ``false``
+for now to avoid a bug.
 SD card presentation can slow down board startup,
 so set this to ``false`` if you don't need this feature.
 

--- a/ports/espressif/boards/adafruit_esp32s3_camera/mpconfigboard.h
+++ b/ports/espressif/boards/adafruit_esp32s3_camera/mpconfigboard.h
@@ -20,3 +20,7 @@
 #define DEFAULT_SPI_BUS_MISO (&pin_GPIO37)
 
 #define DOUBLE_TAP_PIN (&pin_GPIO42)
+
+// Turn off presenting SD card to USB by default. Changes settings.toml default for this setting.
+// Workaround for https://github.com/adafruit/circuitpython/issues/11109.
+#define CIRCUITPY_SDCARD_USB (false)

--- a/py/circuitpy_mpconfig.h
+++ b/py/circuitpy_mpconfig.h
@@ -530,6 +530,11 @@ void background_callback_run_all(void);
 #ifndef CIRCUITPY_SDCARD_USB
 #if CIRCUITPY_USB_DEVICE
 #define CIRCUITPY_SDCARD_USB (CIRCUITPY_SDCARDIO && CIRCUITPY_USB_MSC)
+// Default value of CIRCUITPY_SDCARD_USB in settings.toml.
+#ifndef CIRCUITPY_SDCARD_USB_DEFAULT
+// True for most boards.
+#define CIRCUITPY_SDCARD_USB_DEFAULT (true)
+#endif
 #else
 #define CIRCUITPY_SDCARD_USB (0)
 #endif

--- a/supervisor/shared/usb/usb_msc_flash.c
+++ b/supervisor/shared/usb/usb_msc_flash.c
@@ -379,7 +379,8 @@ static sdcard_usb_setting_state_t _sdcard_usb_setting_state = SDCARD_USB_SETTING
 // Read only once to save file access time.
 static bool sdcard_usb_enabled(void) {
     if (_sdcard_usb_setting_state == SDCARD_USB_SETTING_NOT_YET_READ) {
-        bool setting = true;
+        // Can be changed per board. Most boards would leave this as true (default in circuitpy_mpconfig.h).
+        bool setting = CIRCUITPY_SDCARD_USB_DEFAULT;
         (void)settings_get_bool("CIRCUITPY_SDCARD_USB", &setting);
         _sdcard_usb_setting_state = setting ? SDCARD_USB_SETTING_TRUE : SDCARD_USB_SETTING_FALSE;
     }


### PR DESCRIPTION
- Workaround (not a long-term fix) for #11109 

#11109 reports SD card write errors when saving pictures on Adafruit Memento. This may have started appearing when USB SD card presentation started, or it may have started after the rewrite of a bunch of that code recently.

As a temporary fix, make the default for Memento for be that `CIRCUITPY_SDCARD_USB=false` for the `settings.toml` environment value.

I needed to create a simple build mechanism to allow the value to be defaulted and overriden per board.
