### PR TITLE
tests: allow a sys.platform containing spaces in detect_test_platform

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -418,8 +418,9 @@ def detect_test_platform(pyb, args):
     output = run_feature_check(pyb, args, "target_info.py")
     if output.endswith(b"CRASH"):
         raise ValueError("cannot detect platform: {}".format(output))
+    # CIRCUITPY-CHANGE: sys.platform is the first field and can contain spaces ("Atmel SAMD21").
     platform, arch, arch_flags, build, thread, float_prec, unicode = (
-        str(output, "ascii").strip().split()
+        str(output, "ascii").strip().rsplit(None, 6)
     )
     if arch == "None":
         arch = None


### PR DESCRIPTION
## What

`detect_test_platform()` unpacks `target_info.py` output into exactly 7 whitespace-separated fields. `sys.platform` is the first of them, and on atmel-samd it contains a space, so the split yields 8 and the unpack raises before any test runs. Split from the right instead.

## Why

Found while running the standard test suite across an 8-board HIL farm, wanting real cross-architecture numbers out of `tests/` rather than hand-rolled checks. Six boards ran. Both SAMD boards aborted immediately:

```
ValueError: too many values to unpack (expected 7)
```

`target_info.py` prints 8 fields on those boards, not 7:

```
Atmel SAMD21 None 0 metro_m0_express None 30 True
MicroChip SAMD51 None 0 metro_m4_airlift_lite None 30 True
```

The platform strings are CircuitPython's, and no MicroPython port reports one containing a space, so there is nothing to reproduce upstream. Tagged `CIRCUITPY-CHANGE` to match the other local changes in this file.

## Hardware tested

CircuitPython 10.3.0-alpha.3-92-gcd3da4a5d8, Linux host, `./run-tests.py -t <port> -d basics`.

| Board | Before | After |
|---|---|---|
| Metro M0 Express | aborts, 0 tests run | 496 pass, 57 skip, 18 fail |
| Metro M4 AirLift Lite | aborts, 0 tests run | 533 pass, 21 skip, 17 fail |

Unchanged before and after, still passing at the same counts: Metro RP2040, Metro RP2350, Metro ESP32-S2, Metro ESP32-S3, Feather nRF52840, Feather STM32F405.

The remaining failures on the two SAMD boards are pre-existing and unrelated to this change. Most are shared by all 8 boards, and the M0-specific two are the small build lacking `io` and `__globals__`.

Not tested: Windows or macOS hosts, and ports other than the eight boards above.

## AI assistance

Used Claude Code to diagnose and write the patch. I confirmed the 8-field output on both boards myself, ran the suite before and after on all eight, and ran `pre-commit`.
