### PR TITLE
sdcardio: fix card size for SDXC cards > 32 GB (forward-port of #11013 to main)

### DIFF
--- a/shared-module/sdcardio/SDCard.c
+++ b/shared-module/sdcardio/SDCard.c
@@ -318,7 +318,7 @@ static mp_rom_error_text_t init_card(sdcardio_sdcard_obj_t *self) {
         }
 
         if (csd_version == 1) {
-            self->sectors = (((uint32_t)(csd[7] & 0x3F) << 16 | (uint32_t)csd[8] << 8 | csd[9]) + 1) * 1024;
+            self->sectors = (((csd[7] & 0x3F) << 16 | csd[8] << 8 | csd[9]) + 1) * 1024;
         } else {
             uint32_t block_length = 1 << (csd[5] & 0xF);
             uint32_t c_size = ((csd[6] & 0x3) << 10) | (csd[7] << 2) | ((csd[8] & 0xC) >> 6);

--- a/shared-module/sdcardio/SDCard.c
+++ b/shared-module/sdcardio/SDCard.c
@@ -318,7 +318,7 @@ static mp_rom_error_text_t init_card(sdcardio_sdcard_obj_t *self) {
         }
 
         if (csd_version == 1) {
-            self->sectors = ((csd[8] << 8 | csd[9]) + 1) * 1024;
+            self->sectors = (((uint32_t)(csd[7] & 0x3F) << 16 | (uint32_t)csd[8] << 8 | csd[9]) + 1) * 1024;
         } else {
             uint32_t block_length = 1 << (csd[5] & 0xF);
             uint32_t c_size = ((csd[6] & 0x3) << 10) | (csd[7] << 2) | ((csd[8] & 0xC) >> 6);


### PR DESCRIPTION
## What

Forward-port of #11013 to main. Reads all 22 bits of the CSD v2.0 C_SIZE field instead of the bottom 16, so SDXC cards over 32 GB report their real capacity. Both 10.2.x commits are cherry-picked with -x, including @dhalbert's cast cleanup, so the decode line here is identical to 10.2.x.

## Why

#11012 (same fix, targeted at main) was closed in favor of #11013 on 10.2.x, expecting the routine 10.2.x to main merge. That merge has not happened since May, so 10.3.0 alphas still truncate. `git log main..10.2.x` is 10 commits and this fix is the only substantive change missing from main, the rest is 10.2.1 release mechanics and backports of commits already on main. Happy to close this if you would rather do the branch merge instead.

Related context, no file overlap: #11240 (Memento CIRCUITPY_SDCARD_USB default), since SD over USB is where users see the wrong size.

## Hardware tested

Adafruit MEMENTO (adafruit_esp32s3_camera), 64 GB SDXC card formatted exFAT, macOS 26.6.2 host, `CIRCUITPY_SDCARD_USB = true`. A/B builds from main tip 8caf4ca68e and from this branch, same card, same host, 2026-08-24. Not tested: CSD v1 cards (that path is untouched) and other boards.

## How I tested it

```python
import board, sdcardio, storage, os, displayio, digitalio
displayio.release_displays()
tft = digitalio.DigitalInOut(board.TFT_CS)
tft.switch_to_output(value=True)
sd = sdcardio.SDCard(board.SPI(), board.CARD_CS, baudrate=20_000_000)
storage.mount(storage.VfsFat(sd), "/sd")
print("count:", sd.count())
```

| | main tip (no fix) | this branch |
|---|---|---|
| sd.count() on device | not read | 123596800 |
| diskutil partition size over USB MSC | 28.9 GB (56485888 sectors) | 63.3 GB (123594752 sectors) |
| macOS mounts the volume | yes | yes |
| md5 of all 138 files on card via USB | all read clean | all read clean, checksums identical to no-fix run |

56485888 sectors is exactly the truncated decode of this card's C_SIZE (0x1D779 with the top bits dropped). The failure mode without the fix is quiet: macOS mounts the volume and df shows the exFAT structures' 63 GB, but the device only offers 28.9 GB of sectors over USB, so anything stored past that boundary is unreachable from the host and host-side tools see free space that does not exist.

## AI assistance

The original fix and this forward-port were done with Claude assistance (commit trailer retained from 10.2.x). The capacity numbers, diskutil output, and checksum runs above are from the card and board on my desk, verified by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
