### PR TITLE
zephyr-cp: build ulab, and let boards opt out

### DIFF
--- a/ports/zephyr-cp/boards/nordic/nrf7002dk/circuitpython.toml
+++ b/ports/zephyr-cp/boards/nordic/nrf7002dk/circuitpython.toml
@@ -3,3 +3,7 @@ USB_VID=0x239A
 USB_PID=0x8168
 BLOBS=["nrf_wifi"]
 DISABLED_MODULES=["aesio", "adafruit_bus_device", "zlib", "jpegio", "tilepalettemapper", "gifio"]
+
+# ulab is on by default. This board has under 3 KB of flash headroom, and
+# ulab costs about 90 KB, so it opts out.
+CIRCUITPY_ULAB = false

--- a/ports/zephyr-cp/boards/st/nucleo_n657x0_q/circuitpython.toml
+++ b/ports/zephyr-cp/boards/st/nucleo_n657x0_q/circuitpython.toml
@@ -1,1 +1,5 @@
 CIRCUITPY_BUILD_EXTENSIONS = ["hex"]
+
+# This part executes from RAM and is already at 93% of it, so it cannot
+# absorb the roughly 90 KB ulab adds.
+CIRCUITPY_ULAB = false

--- a/ports/zephyr-cp/cptools/build_circuitpython.py
+++ b/ports/zephyr-cp/cptools/build_circuitpython.py
@@ -634,7 +634,23 @@ async def build_circuitpython():  # noqa: C901
         enabled = mpflag in DEFAULT_MODULES
         circuitpython_flags.append(f"-DCIRCUITPY_{mpflag.upper()}={1 if enabled else 0}")
 
+    # ulab is on by default and boards that cannot spare the flash set
+    # CIRCUITPY_ULAB = false in their circuitpython.toml. Flags mirror py/py.mk.
+    ulab_enabled = mpconfigboard.get("CIRCUITPY_ULAB", True)
+    circuitpython_flags.append(f"-DCIRCUITPY_ULAB={1 if ulab_enabled else 0}")
+    if ulab_enabled:
+        circuitpython_flags.extend(
+            (
+                "-DMODULE_ULAB_ENABLED=1",
+                "-DULAB_HAS_USER_MODULE=0",
+                "-iquote",
+                str(top / "extmod" / "ulab" / "code"),
+            )
+        )
+
     source_files = supervisor_source + hal_source + ["extmod/vfs.c"]
+    if ulab_enabled:
+        source_files.extend(sorted((top / "extmod" / "ulab" / "code").rglob("*.c")))
     assembly_files = []
     for file in top.glob("py/*.c"):
         source_files.append(file)


### PR DESCRIPTION
## What

Builds `ulab` on zephyr-cp and adds `CIRCUITPY_ULAB` so boards that cannot spare the flash can turn it off. On by default; two boards opt out.

## Why

zephyr-cp builds without `py/circuitpy_mpconfig.mk`, so the ulab wiring every other port gets from `py/py.mk` does not exist here and `ulab` could not be built at all. This adds the flags and sources the same way `py.mk` does.

It costs roughly 90 KB, so the two boards without room set `CIRCUITPY_ULAB = false` in their `circuitpython.toml`:

- `nordic_nrf7002dk` is at 99.73% of flash, under 3 KB free.
- `st_nucleo_n657x0_q` has no internal user flash and executes from RAM, which is already 93% full. CI caught this one; ulab overflowed it by 56520 bytes.

Every other board has at least 135 KB of headroom in whichever region holds code.

## Hardware tested

Build only, which is the whole surface of this change. On `silabs_siwx917_dk2605a`:

| build | flash |
| --- | --- |
| `main` | 799136 B, 76.21% |
| this PR, ulab off | 799136 B, byte-identical to baseline |
| this PR, ulab on | 890168 B, 84.89%, +91032 B, 163 ulab sources |

Both opt-out boards were built locally to confirm they link, and the full CI matrix is green.

Not tested: importing `ulab` on hardware.

## Scope

Build plumbing and two board opt-outs. No docs change.

## AI assistance

Written with Claude Code. I ran the builds and compared the figures myself.
