### PR TITLE
zephyr-cp: disable the unmaintained PSRAM data cache on siwx91x

### DIFF
--- a/ports/zephyr-cp/supervisor/port.c
+++ b/ports/zephyr-cp/supervisor/port.c
@@ -17,6 +17,9 @@
 
 #include <zephyr/autoconf.h>
 #include <zephyr/kernel.h>
+#if defined(CONFIG_SOC_FAMILY_SILABS_SIWX91X)
+#include <zephyr/sys/barrier.h>
+#endif
 #include <zephyr/sys/reboot.h>
 #include <zephyr/sys/util.h>
 
@@ -255,8 +258,45 @@ void port_idle_until_interrupt(void) {
     next_timepoint = sys_timepoint_calc(next_timeout);
 }
 
+#if defined(CONFIG_SOC_FAMILY_SILABS_SIWX91X)
+// SiWx917 PSRAM data cache, family reference manual rev 1.2 section 5.4.5. It
+// sits on the QSPI2 path and has no devicetree node and no Zephyr driver, so
+// the register offsets are spelled out here rather than derived from either.
+#define SIWX91X_PSRAM_DCACHE_BASE 0x44040000u
+#define SIWX91X_PSRAM_DCACHE_CTRL (SIWX91X_PSRAM_DCACHE_BASE + 0x010u)
+#define SIWX91X_PSRAM_DCACHE_CTRL_ENABLE BIT(0)
+
+// The bootloader leaves this cache enabled and half-configured, and nothing in
+// a Zephyr build can maintain it:
+//
+//   - WiseConnect's own PSRAM init clears the HPROT allocate signal right after
+//     enabling the cache. That step never runs here: SL_SI91X_D_CACHE_ENABLE is
+//     never defined, and the macros it needs (DCACHE_CTRL_AND_STATUS,
+//     HPORT_ALLOCATE_SIGNAL) are absent from the vendored HAL entirely.
+//   - Zephyr cannot maintain it either. cache_siwx91x.c asserts the SoC has no
+//     data cache, CPU_HAS_DCACHE is never selected, and sys_cache_data_* return
+//     -ENOTSUP.
+//
+// That leaves an unmaintained write-allocate cache in front of memory the
+// network processor also writes. Disable it before any heap exists there.
+//
+// Only the enable bit clears; bit 1 is sticky on this silicon. Do not poll the
+// maintenance-status register for zero, which is what the vendor's disable path
+// does: it settles at 0x100 and the wait never returns.
+static void siwx91x_disable_psram_dcache(void) {
+    volatile uint32_t *ctrl = (volatile uint32_t *)SIWX91X_PSRAM_DCACHE_CTRL;
+    *ctrl &= ~SIWX91X_PSRAM_DCACHE_CTRL_ENABLE;
+    barrier_dsync_fence_full();
+    barrier_isync_fence_full();
+}
+#endif
+
 // Zephyr doesn't maintain one multi-heap. So, make our own using TLSF.
 void port_heap_init(void) {
+    #if defined(CONFIG_SOC_FAMILY_SILABS_SIWX91X)
+    siwx91x_disable_psram_dcache();
+    #endif
+
     // Do a test malloc to determine if Zephyr has an outer heap that may
     // overlap with a memory region we've identified in ram_bounds. We'll
     // corrupt each other if we both use it.


### PR DESCRIPTION
**Draft: the behaviour is verified, the placement is the open question.**

## What

Disables the SiWx917's PSRAM data cache in `port_heap_init()`, before any TLSF pool is built in that memory.

## Why

The SiWG917 has a 16 KB data cache dedicated to PSRAM (family RM rev 1.2 §5.4.5) on the QSPI2 path. The bootloader leaves it enabled and half-configured, and nothing in a Zephyr build can maintain it:

- WiseConnect's PSRAM init clears the HPROT allocate signal right after enabling the cache. That never runs here: `SL_SI91X_D_CACHE_ENABLE` is never defined, and the macros it needs are absent from the vendored HAL.
- Zephyr can't either: `cache_siwx91x.c` asserts the SoC has no data cache, `CPU_HAS_DCACHE` is never selected, `sys_cache_data_*` return `-ENOTSUP`.

So an unmaintained write-allocate cache sits in front of memory the network processor also writes. Python objects corrupt under allocation churn, never cleanly: ints reading back as functions, bytearrays with wrong lengths, garbled qstrs, MPU faults through pointers loaded from PSRAM.

Only the enable bit clears. Bit 1 is sticky and the maintenance-status register settles at `0x100`, so the vendor's disable path, which polls it for zero, hangs on this silicon. This doesn't poll.

## Hardware tested

SiWx917-DK2605A, board `siwx917_dk2605a`. Builds clean on current `main`: 799168 B, 76.21% flash, 32 bytes over baseline.

The corruption reproduction predates #11218 landing and I have not re-run the allocation-churn soak since. **I'll do that before taking this out of draft** rather than imply evidence I haven't refreshed.

## The question

`port_heap_init()` is port-wide; this is SoC-specific behind `#if defined(CONFIG_SOC_FAMILY_SILABS_SIWX91X)`. Where would you rather it live?

1. Here, guarded, as written.
2. A SiWx917 SoC init hook in this port.
3. Upstream in Zephyr's `soc/silabs/` — most correct, slowest, and no help here until a pin bump.

Addresses are literals because there's no devicetree node and no driver to derive them from. If (3) is your answer I'll take it there instead.

## Scope

A workaround, not a fix. The fix is a real cache driver or clearing HPROT allocate as the vendor intended.

## AI assistance

Written with Claude Code. Register probing and the corruption reproduction were done on hardware by me.
