### PR TITLE
raspberrypi: derive QMI PSRAM timings from clk_sys

### DIFF
--- a/ports/raspberrypi/common-hal/microcontroller/Processor.c
+++ b/ports/raspberrypi/common-hal/microcontroller/Processor.c
@@ -10,6 +10,7 @@
 #include "py/mphal.h"
 #include "py/runtime.h"
 #include "common-hal/microcontroller/Processor.h"
+#include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/microcontroller/Processor.h"
 #include "shared-bindings/microcontroller/ResetReason.h"
 #include "shared-bindings/time/__init__.h"
@@ -19,6 +20,11 @@
 #include "hardware/clocks.h"
 #include "hardware/vreg.h"
 #include "hardware/watchdog.h"
+
+#ifdef CIRCUITPY_PSRAM_CHIP_SELECT
+#include "hardware/regs/qmi.h"
+#include "hardware/structs/qmi.h"
+#endif
 
 #if PICO_RP2040
 #include "hardware/regs/vreg_and_chip_reset.h"
@@ -50,6 +56,26 @@ uint32_t common_hal_mcu_processor_get_frequency(void) {
     return clock_get_hz(clk_sys);
 }
 
+#ifdef CIRCUITPY_PSRAM_CHIP_SELECT
+void __no_inline_not_in_flash_func(common_hal_mcu_processor_update_psram_timing)(uint32_t sys_clk_khz) {
+    // MAX_SELECT is in units of 64 system clock cycles; PSRAM allows 8 us max CS
+    // assertion. Use 7.5 us so there is margin at any clk_sys.
+    uint32_t max_select = (75 * sys_clk_khz) / 640000;
+    // MIN_DESELECT is in system clock cycles; PSRAM needs 50 ns min CS
+    // deassertion. Round up so we are never under.
+    uint32_t min_deselect = (sys_clk_khz + 19999) / 20000;
+
+    qmi_hw->m[1].timing =
+        QMI_M0_TIMING_PAGEBREAK_VALUE_1024 << QMI_M0_TIMING_PAGEBREAK_LSB | // Break between pages.
+            3 << QMI_M0_TIMING_SELECT_HOLD_LSB | // Delay releasing CS for 3 extra system cycles.
+            1 << QMI_M0_TIMING_COOLDOWN_LSB |
+            1 << QMI_M0_TIMING_RXDELAY_LSB |
+            max_select << QMI_M0_TIMING_MAX_SELECT_LSB |
+            min_deselect << QMI_M0_TIMING_MIN_DESELECT_LSB |
+            2 << QMI_M0_TIMING_CLKDIV_LSB;
+}
+#endif
+
 void common_hal_mcu_processor_set_frequency(mcu_processor_obj_t *self, uint32_t frequency) {
     uint vco, postdiv1, postdiv2;
     uint32_t freq_khz = frequency / 1000;
@@ -68,7 +94,17 @@ void common_hal_mcu_processor_set_frequency(mcu_processor_obj_t *self, uint32_t 
     vreg_set_voltage(voltage);
     // Wait for a stable voltage
     common_hal_time_delay_ms(10);
+
+    #ifdef CIRCUITPY_PSRAM_CHIP_SELECT
+    // Prevent interrupt handlers from accessing PSRAM until its timing matches
+    // the new system clock.
+    common_hal_mcu_disable_interrupts();
+    #endif
     set_sys_clock_khz(freq_khz, false);
+    #ifdef CIRCUITPY_PSRAM_CHIP_SELECT
+    common_hal_mcu_processor_update_psram_timing(freq_khz);
+    common_hal_mcu_enable_interrupts();
+    #endif
 }
 
 void common_hal_mcu_processor_get_uid(uint8_t raw_id[]) {

--- a/ports/raspberrypi/common-hal/microcontroller/Processor.c
+++ b/ports/raspberrypi/common-hal/microcontroller/Processor.c
@@ -57,7 +57,7 @@ uint32_t common_hal_mcu_processor_get_frequency(void) {
 }
 
 #ifdef CIRCUITPY_PSRAM_CHIP_SELECT
-void __no_inline_not_in_flash_func(common_hal_mcu_processor_update_psram_timing)(uint32_t sys_clk_khz) {
+void __no_inline_not_in_flash_func(mcu_processor_update_psram_timing)(uint32_t sys_clk_khz) {
     // MAX_SELECT is in units of 64 system clock cycles; PSRAM allows 8 us max CS
     // assertion. Use 7.5 us so there is margin at any clk_sys.
     uint32_t max_select = (75 * sys_clk_khz) / 640000;
@@ -102,7 +102,7 @@ void common_hal_mcu_processor_set_frequency(mcu_processor_obj_t *self, uint32_t 
     #endif
     set_sys_clock_khz(freq_khz, false);
     #ifdef CIRCUITPY_PSRAM_CHIP_SELECT
-    common_hal_mcu_processor_update_psram_timing(freq_khz);
+    mcu_processor_update_psram_timing(freq_khz);
     common_hal_mcu_enable_interrupts();
     #endif
 }

--- a/ports/raspberrypi/common-hal/microcontroller/Processor.h
+++ b/ports/raspberrypi/common-hal/microcontroller/Processor.h
@@ -18,5 +18,5 @@ typedef struct {
 } mcu_processor_obj_t;
 
 #ifdef CIRCUITPY_PSRAM_CHIP_SELECT
-void common_hal_mcu_processor_update_psram_timing(uint32_t sys_clk_khz);
+void mcu_processor_update_psram_timing(uint32_t sys_clk_khz);
 #endif

--- a/ports/raspberrypi/common-hal/microcontroller/Processor.h
+++ b/ports/raspberrypi/common-hal/microcontroller/Processor.h
@@ -16,3 +16,7 @@ typedef struct {
     mp_obj_base_t base;
     // Stores no state currently.
 } mcu_processor_obj_t;
+
+#ifdef CIRCUITPY_PSRAM_CHIP_SELECT
+void common_hal_mcu_processor_update_psram_timing(uint32_t sys_clk_khz);
+#endif

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -47,6 +47,7 @@
 #include "supervisor/shared/stack.h"
 #include "supervisor/shared/tick.h"
 
+#include "hardware/clocks.h"
 #include "hardware/structs/scb.h"
 #include "hardware/structs/watchdog.h"
 #include "hardware/gpio.h"
@@ -152,6 +153,9 @@ static size_t _psram_size = 0;
 #include "hardware/structs/xip_ctrl.h"
 
 static void __no_inline_not_in_flash_func(setup_psram)(void) {
+    // Read the system clock before QMI goes into direct mode; clock_get_hz() is
+    // in flash and XIP is reconfigured below.
+    uint32_t sys_clk_mhz = clock_get_hz(clk_sys) / 1000000;
     gpio_set_function(CIRCUITPY_PSRAM_CHIP_SELECT->number, GPIO_FUNC_XIP_CS1);
     _psram_size = 0;
     common_hal_mcu_disable_interrupts();
@@ -237,13 +241,20 @@ static void __no_inline_not_in_flash_func(setup_psram)(void) {
     // Disable direct csr.
     qmi_hw->direct_csr &= ~(QMI_DIRECT_CSR_ASSERT_CS1N_BITS | QMI_DIRECT_CSR_EN_BITS);
 
+    // MAX_SELECT is in units of 64 system clock cycles; PSRAM allows 8us max CS
+    // assertion. Use 7.5us so there is margin at any clk_sys.
+    uint32_t max_select = (75 * sys_clk_mhz) / 10 / 64;
+    // MIN_DESELECT is in system clock cycles; PSRAM needs 50ns min CS
+    // deassertion. Round up so we are never under.
+    uint32_t min_deselect = (50 * sys_clk_mhz + 999) / 1000;
+
     qmi_hw->m[1].timing =
         QMI_M0_TIMING_PAGEBREAK_VALUE_1024 << QMI_M0_TIMING_PAGEBREAK_LSB | // Break between pages.
             3 << QMI_M0_TIMING_SELECT_HOLD_LSB | // Delay releasing CS for 3 extra system cycles.
             1 << QMI_M0_TIMING_COOLDOWN_LSB |
             1 << QMI_M0_TIMING_RXDELAY_LSB |
-            16 << QMI_M0_TIMING_MAX_SELECT_LSB | // In units of 64 system clock cycles. PSRAM says 8us max. 8 / 0.00752 / 64 = 16.62
-            7 << QMI_M0_TIMING_MIN_DESELECT_LSB | // In units of system clock cycles. PSRAM says 50ns.50 / 7.52 = 6.64
+            max_select << QMI_M0_TIMING_MAX_SELECT_LSB |
+            min_deselect << QMI_M0_TIMING_MIN_DESELECT_LSB |
             2 << QMI_M0_TIMING_CLKDIV_LSB;
     qmi_hw->m[1].rfmt = (QMI_M0_RFMT_PREFIX_WIDTH_VALUE_Q << QMI_M0_RFMT_PREFIX_WIDTH_LSB |
             QMI_M0_RFMT_ADDR_WIDTH_VALUE_Q << QMI_M0_RFMT_ADDR_WIDTH_LSB |

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -155,7 +155,7 @@ static size_t _psram_size = 0;
 static void __no_inline_not_in_flash_func(setup_psram)(void) {
     // Read the system clock before QMI goes into direct mode; clock_get_hz() is
     // in flash and XIP is reconfigured below.
-    uint32_t sys_clk_mhz = clock_get_hz(clk_sys) / 1000000;
+    uint32_t sys_clk_khz = clock_get_hz(clk_sys) / 1000;
     gpio_set_function(CIRCUITPY_PSRAM_CHIP_SELECT->number, GPIO_FUNC_XIP_CS1);
     _psram_size = 0;
     common_hal_mcu_disable_interrupts();
@@ -241,21 +241,7 @@ static void __no_inline_not_in_flash_func(setup_psram)(void) {
     // Disable direct csr.
     qmi_hw->direct_csr &= ~(QMI_DIRECT_CSR_ASSERT_CS1N_BITS | QMI_DIRECT_CSR_EN_BITS);
 
-    // MAX_SELECT is in units of 64 system clock cycles; PSRAM allows 8us max CS
-    // assertion. Use 7.5us so there is margin at any clk_sys.
-    uint32_t max_select = (75 * sys_clk_mhz) / 10 / 64;
-    // MIN_DESELECT is in system clock cycles; PSRAM needs 50ns min CS
-    // deassertion. Round up so we are never under.
-    uint32_t min_deselect = (50 * sys_clk_mhz + 999) / 1000;
-
-    qmi_hw->m[1].timing =
-        QMI_M0_TIMING_PAGEBREAK_VALUE_1024 << QMI_M0_TIMING_PAGEBREAK_LSB | // Break between pages.
-            3 << QMI_M0_TIMING_SELECT_HOLD_LSB | // Delay releasing CS for 3 extra system cycles.
-            1 << QMI_M0_TIMING_COOLDOWN_LSB |
-            1 << QMI_M0_TIMING_RXDELAY_LSB |
-            max_select << QMI_M0_TIMING_MAX_SELECT_LSB |
-            min_deselect << QMI_M0_TIMING_MIN_DESELECT_LSB |
-            2 << QMI_M0_TIMING_CLKDIV_LSB;
+    common_hal_mcu_processor_update_psram_timing(sys_clk_khz);
     qmi_hw->m[1].rfmt = (QMI_M0_RFMT_PREFIX_WIDTH_VALUE_Q << QMI_M0_RFMT_PREFIX_WIDTH_LSB |
             QMI_M0_RFMT_ADDR_WIDTH_VALUE_Q << QMI_M0_RFMT_ADDR_WIDTH_LSB |
             QMI_M0_RFMT_SUFFIX_WIDTH_VALUE_Q << QMI_M0_RFMT_SUFFIX_WIDTH_LSB |

--- a/ports/raspberrypi/supervisor/port.c
+++ b/ports/raspberrypi/supervisor/port.c
@@ -241,7 +241,7 @@ static void __no_inline_not_in_flash_func(setup_psram)(void) {
     // Disable direct csr.
     qmi_hw->direct_csr &= ~(QMI_DIRECT_CSR_ASSERT_CS1N_BITS | QMI_DIRECT_CSR_EN_BITS);
 
-    common_hal_mcu_processor_update_psram_timing(sys_clk_khz);
+    mcu_processor_update_psram_timing(sys_clk_khz);
     qmi_hw->m[1].rfmt = (QMI_M0_RFMT_PREFIX_WIDTH_VALUE_Q << QMI_M0_RFMT_PREFIX_WIDTH_LSB |
             QMI_M0_RFMT_ADDR_WIDTH_VALUE_Q << QMI_M0_RFMT_ADDR_WIDTH_LSB |
             QMI_M0_RFMT_SUFFIX_WIDTH_VALUE_Q << QMI_M0_RFMT_SUFFIX_WIDTH_LSB |


### PR DESCRIPTION
## What

Derive the RP2350 QMI PSRAM timing fields from the actual `clk_sys` frequency at boot and whenever `microcontroller.cpu.frequency` changes.

## Why

The existing QMI values encode absolute-time PSRAM requirements in clock cycles calculated for a 7.52 ns cycle. At the RP2350 port's 150 MHz clock, the fixed `MIN_DESELECT` value becomes 46.7 ns, below the PSRAM's 50 ns minimum; higher clocks shorten it further.

This belongs in the Raspberry Pi port because it programs the RP2350-specific QMI timing register. `MAX_SELECT` targets 7.5 us to leave margin below the 8 us ceiling, while `MIN_DESELECT` rounds up so it stays at or above 50 ns. The calculation keeps kHz precision so valid fractional-MHz clocks remain safe.

[Forum report](https://forums.adafruit.com/viewtopic.php?t=224739)

## Calculated timings

These values are calculated from the register settings; they are not hardware measurements.

| `clk_sys` | `MAX_SELECT` | CS assertion | `MIN_DESELECT` | CS deassertion |
| ---: | ---: | ---: | ---: | ---: |
| 133 MHz | 15 | 7.22 us | 7 | 52.6 ns |
| 140.5 MHz | 16 | 7.29 us | 8 | 56.9 ns |
| 150 MHz | 17 | 7.25 us | 8 | 53.3 ns |
| 200 MHz | 23 | 7.36 us | 10 | 50.0 ns |
| 252 MHz | 29 | 7.37 us | 13 | 51.6 ns |
| 264 MHz | 30 | 7.27 us | 14 | 53.0 ns |

For comparison, the old fixed values give 46.7 ns at 150 MHz and 27.8 ns at 252 MHz.

## Hardware tested

Not run on hardware; no Fruit Jam or other `CIRCUITPY_PSRAM` device was connected. In particular, the `gc.mem_free()` regression check and runtime frequency-change test still need hardware confirmation.

## How I tested it

- Built `adafruit_fruit_jam` successfully: 919,152 bytes flash, 74,312 bytes RAM.
- Passed CircuitPython formatting, spelling, and diff checks on the changed files.
- Passed the linked-image core1 flash-reachability check.
- Inspected `firmware.elf`: boot reads `clk_sys` before QMI direct-mode access; the timing updater is RAM-resident and has no function calls; the runtime path masks interrupts, changes the clock, updates QMI timing, and restores interrupts in that order.

## Scope

This PR only corrects QMI PSRAM timing across boot and runtime system-clock changes. The separate DVI vertical-back-porch issue mentioned in the forum discussion is deliberately excluded.

## AI assistance

I used Codex from a detailed task prompt that identified the suspected fixed-clock timing bug, source area, timing formulas, expected clock table, build target, and forum report. The agent reviewed the implementation and pinned Pico SDK register definitions, built the Fruit Jam target, inspected the linked image for RAM safety and call ordering, and incorporated automated review feedback. No hardware test results were generated or inferred.
