### PR TITLE
Optional softdevice in nordic port

### DIFF
--- a/ports/nordic/Makefile
+++ b/ports/nordic/Makefile
@@ -6,9 +6,7 @@
 
 include ../../py/circuitpy_mkenv.mk
 
-# The SoftDevice paths are built from MCU_VARIANT and SOFTDEV_VERSION, which
-# only exist once boards/$(BOARD)/mpconfigboard.mk has set MCU_CHIP. Skip when
-# the rule requested is not board-specific like fetch-port-submodules.
+# Skip when the make command is not board-specific i.e. fetch-port-submodules.
 ifneq ($(VALID_BOARD),)
 ifneq ($(SD), )
 	include bluetooth/bluetooth_common.mk

--- a/ports/nordic/Makefile
+++ b/ports/nordic/Makefile
@@ -8,9 +8,7 @@ include ../../py/circuitpy_mkenv.mk
 
 # The SoftDevice paths are built from MCU_VARIANT and SOFTDEV_VERSION, which
 # only exist once boards/$(BOARD)/mpconfigboard.mk has set MCU_CHIP. Skip when
-# the rule requested is not board-specific (e.g. fetch-port-submodules), or the
-# stack-missing check looks for an unexpanded path and fails on a tree where
-# nothing is actually missing.
+# the rule requested is not board-specific like fetch-port-submodules.
 ifneq ($(VALID_BOARD),)
 ifneq ($(SD), )
 	include bluetooth/bluetooth_common.mk

--- a/ports/nordic/Makefile
+++ b/ports/nordic/Makefile
@@ -6,8 +6,15 @@
 
 include ../../py/circuitpy_mkenv.mk
 
+# The SoftDevice paths are built from MCU_VARIANT and SOFTDEV_VERSION, which
+# only exist once boards/$(BOARD)/mpconfigboard.mk has set MCU_CHIP. Skip when
+# the rule requested is not board-specific (e.g. fetch-port-submodules), or the
+# stack-missing check looks for an unexpanded path and fails on a tree where
+# nothing is actually missing.
+ifneq ($(VALID_BOARD),)
 ifneq ($(SD), )
 	include bluetooth/bluetooth_common.mk
+endif
 endif
 
 CROSS_COMPILE = arm-none-eabi-
@@ -115,10 +122,15 @@ SRC_C += \
 	boards/$(BOARD)/board.c \
 	boards/$(BOARD)/pins.c \
 	device/$(MCU_VARIANT)/startup_$(MCU_SUB_VARIANT).c \
+	nrfx/mdk/system_$(MCU_SUB_VARIANT).c \
+
+ifneq ($(SD), )
+SRC_C += \
 	bluetooth/ble_drv.c \
 	common-hal/_bleio/bonding.c \
-	nrfx/mdk/system_$(MCU_SUB_VARIANT).c \
 	sd_mutex.c \
+
+endif
 
 SRC_PERIPHERALS := \
 	peripherals/nrf/cache.c \
@@ -177,7 +189,13 @@ UF2_FAMILY_ID_nrf52840 = 0xADA52840
 UF2_FAMILY_ID_nrf52833 = 0x621E937A
 
 
+ifneq ($(SD), )
 all: $(BUILD)/firmware.bin $(BUILD)/firmware.uf2 $(BUILD)/firmware.combined.hex
+else
+# firmware.combined.hex merges in the SoftDevice hex; without one there is
+# nothing to combine.
+all: $(BUILD)/firmware.bin $(BUILD)/firmware.uf2 $(BUILD)/firmware.hex
+endif
 
 ifeq ($(VALID_BOARD),)
 $(BUILD)/firmware.elf: invalid-board

--- a/ports/nordic/Makefile
+++ b/ports/nordic/Makefile
@@ -8,7 +8,7 @@ include ../../py/circuitpy_mkenv.mk
 
 # Skip when the make command is not board-specific i.e. fetch-port-submodules.
 ifneq ($(VALID_BOARD),)
-ifneq ($(SD), )
+ifeq ($(CIRCUITPY_BLEIO_NATIVE),1)
 	include bluetooth/bluetooth_common.mk
 endif
 endif
@@ -120,7 +120,7 @@ SRC_C += \
 	device/$(MCU_VARIANT)/startup_$(MCU_SUB_VARIANT).c \
 	nrfx/mdk/system_$(MCU_SUB_VARIANT).c \
 
-ifneq ($(SD), )
+ifeq ($(CIRCUITPY_BLEIO_NATIVE),1)
 SRC_C += \
 	bluetooth/ble_drv.c \
 	common-hal/_bleio/bonding.c \
@@ -185,7 +185,7 @@ UF2_FAMILY_ID_nrf52840 = 0xADA52840
 UF2_FAMILY_ID_nrf52833 = 0x621E937A
 
 
-ifneq ($(SD), )
+ifeq ($(CIRCUITPY_BLEIO_NATIVE),1)
 all: $(BUILD)/firmware.bin $(BUILD)/firmware.uf2 $(BUILD)/firmware.combined.hex
 else
 # firmware.combined.hex merges in the SoftDevice hex; without one there is

--- a/ports/nordic/common-hal/alarm/pin/PinAlarm.c
+++ b/ports/nordic/common-hal/alarm/pin/PinAlarm.c
@@ -17,7 +17,9 @@
 #include "nrfx.h"
 #include "nrf_gpio.h"
 #include "nrfx_gpiote.h"
+#ifdef BLUETOOTH_SD
 #include "nrf_soc.h"
+#endif
 #include <string.h>
 
 #define WPIN_UNUSED 0xFF

--- a/ports/nordic/common-hal/microcontroller/__init__.c
+++ b/ports/nordic/common-hal/microcontroller/__init__.c
@@ -24,7 +24,9 @@
 #include "supervisor/port.h"
 #include "supervisor/shared/safe_mode.h"
 #include "nrfx_glue.h"
+#ifdef BLUETOOTH_SD
 #include "nrf_nvic.h"
+#endif
 #include "nrf_power.h"
 
 // This routine should work even when interrupts are disabled. Used by OneWire
@@ -45,7 +47,14 @@ void common_hal_mcu_disable_interrupts(void) {
         // This only disables interrupts of priority 2 through 7; levels 0, 1,
         // and 4, are exclusive to softdevice and should never be used, so
         // this limitation is not important.
+        #ifdef BLUETOOTH_SD
         sd_nvic_critical_region_enter(&is_nested_critical_region);
+        #else
+        // With no SoftDevice to leave room for, mask everything. Record whether
+        // interrupts were already masked so the matching exit leaves them so.
+        is_nested_critical_region = __get_PRIMASK() ? 1 : 0;
+        __disable_irq();
+        #endif
     }
     __DMB();
     nesting_count++;
@@ -61,7 +70,13 @@ void common_hal_mcu_enable_interrupts(void) {
         return;
     }
     __DMB();
+    #ifdef BLUETOOTH_SD
     sd_nvic_critical_region_exit(is_nested_critical_region);
+    #else
+    if (!is_nested_critical_region) {
+        __enable_irq();
+    }
+    #endif
 }
 
 void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
@@ -70,11 +85,16 @@ void common_hal_mcu_on_next_reset(mcu_runmode_t runmode) {
     if (runmode == RUNMODE_BOOTLOADER || runmode == RUNMODE_UF2) {
         new_value = DFU_MAGIC_UF2_RESET;
     }
+    #ifdef BLUETOOTH_SD
     int err_code = sd_power_gpregret_set(0, DFU_MAGIC_UF2_RESET);
     if (err_code != NRF_SUCCESS) {
         // Set it without the soft device if the SD failed. (It may be off.)
         nrf_power_gpregret_set(NRF_POWER, new_value);
     }
+    #else
+    // No SoftDevice, so write GPREGRET directly.
+    nrf_power_gpregret_set(NRF_POWER, new_value);
+    #endif
     if (runmode == RUNMODE_SAFE_MODE) {
         safe_mode_on_next_reset(SAFE_MODE_PROGRAMMATIC);
     }

--- a/ports/nordic/common-hal/neopixel_write/__init__.c
+++ b/ports/nordic/common-hal/neopixel_write/__init__.c
@@ -125,7 +125,9 @@ void common_hal_neopixel_write(const digitalio_digitalinout_obj_t *digitalinout,
             pixels_pattern = (uint16_t *)stack_pixels;
         } else {
             uint8_t sd_en = 0;
+            #ifdef BLUETOOTH_SD
             (void)sd_softdevice_is_enabled(&sd_en);
+            #endif
 
             if (pixels_pattern_heap_size < pattern_size) {
                 // Current heap buffer is too small.

--- a/ports/nordic/device/nrf52/startup_nrf52840.c
+++ b/ports/nordic/device/nrf52/startup_nrf52840.c
@@ -27,8 +27,23 @@ void Default_Handler(void) {
     }
 }
 
+extern const func __Vectors[];
+
+#ifndef BLUETOOTH_SD
+// SCB->VTOR, addressed directly so the startup file need not pull in CMSIS.
+#define SCB_VTOR (*(volatile uint32_t *)0xE000ED08UL)
+#endif
+
 extern void Reset_Handler(void);
 void Reset_Handler(void) {
+    #ifndef BLUETOOTH_SD
+    // With a SoftDevice, the MBR at 0x0 owns the vector table and forwards
+    // interrupts to us, so VTOR is already pointing at our table by the time we
+    // run. Without one, nothing has set it.
+    SCB_VTOR = (uint32_t)&__Vectors[0];
+    __asm volatile ("dsb 0xF" ::: "memory");
+    #endif
+
     uint32_t *p_src = &_sidata;
     uint32_t *p_dest = &_sdata;
 

--- a/ports/nordic/device/nrf52/startup_nrf52840.c
+++ b/ports/nordic/device/nrf52/startup_nrf52840.c
@@ -39,7 +39,7 @@ void Reset_Handler(void) {
     #ifndef BLUETOOTH_SD
     // With a SoftDevice, the MBR at 0x0 owns the vector table and forwards
     // interrupts to us, so VTOR is already pointing at our table by the time we
-    // run. Without one, nothing has set it.
+    // run.
     SCB_VTOR = (uint32_t)&__Vectors[0];
     __asm volatile ("dsb 0xF" ::: "memory");
     #endif

--- a/ports/nordic/mpconfigport.h
+++ b/ports/nordic/mpconfigport.h
@@ -122,6 +122,7 @@
 
 #define CIRCUITPY_INTERNAL_NVM_START_ADDR (CIRCUITPY_INTERNAL_FLASH_FILESYSTEM_START_ADDR - CIRCUITPY_INTERNAL_NVM_SIZE)
 
+// 32kiB for bonding, etc.
 #ifndef CIRCUITPY_BLE_CONFIG_SIZE
 #define CIRCUITPY_BLE_CONFIG_SIZE       (32 * 1024)
 #endif
@@ -175,9 +176,7 @@
 #ifdef BLUETOOTH_SD
 #define SOFTDEVICE_RAM_SIZE         (56 * 1024)
 #else
-// No SoftDevice, so none of the low RAM is reserved for it. The SPIM3 buffer
-// then sits at the very bottom of RAM, still inside the first 64kB as the
-// hardware workaround requires.
+
 #define SOFTDEVICE_RAM_SIZE         (0)
 #endif
 #endif

--- a/ports/nordic/mpconfigport.h
+++ b/ports/nordic/mpconfigport.h
@@ -13,8 +13,6 @@
 #include "nrf_mbr.h"  // for MBR_SIZE
 #include "nrf_sdm.h"  // for SD_FLASH_SIZE
 #else
-// No SoftDevice: its headers are not on the include path at all, and neither the
-// MBR nor the SoftDevice occupy any flash.
 #define MBR_SIZE      (0)
 #define SD_FLASH_SIZE (0)
 #endif

--- a/ports/nordic/mpconfigport.h
+++ b/ports/nordic/mpconfigport.h
@@ -7,10 +7,18 @@
 
 #pragma once
 
+#ifdef BLUETOOTH_SD
 #include "ble_drv.h"
 
 #include "nrf_mbr.h"  // for MBR_SIZE
 #include "nrf_sdm.h"  // for SD_FLASH_SIZE
+#else
+// No SoftDevice: its headers are not on the include path at all, and neither the
+// MBR nor the SoftDevice occupy any flash.
+#define MBR_SIZE      (0)
+#define SD_FLASH_SIZE (0)
+#endif
+
 #include "peripherals/nrf/nvm.h" // for FLASH_PAGE_SIZE
 
 #define MICROPY_PY_SYS_STDIO_BUFFER              (1)
@@ -108,9 +116,13 @@
 
 #define CIRCUITPY_INTERNAL_NVM_START_ADDR (CIRCUITPY_INTERNAL_FLASH_FILESYSTEM_START_ADDR - CIRCUITPY_INTERNAL_NVM_SIZE)
 
-// 32kiB for bonding, etc.
+// 32kiB for bonding, etc. Nothing to store without a SoftDevice.
 #ifndef CIRCUITPY_BLE_CONFIG_SIZE
+#ifdef BLUETOOTH_SD
 #define CIRCUITPY_BLE_CONFIG_SIZE       (32 * 1024)
+#else
+#define CIRCUITPY_BLE_CONFIG_SIZE       (0)
+#endif
 #endif
 #define CIRCUITPY_BLE_CONFIG_START_ADDR (CIRCUITPY_INTERNAL_NVM_START_ADDR - CIRCUITPY_BLE_CONFIG_SIZE)
 
@@ -159,7 +171,14 @@
 // high enough to work and then check the mutation of the value done by sd_ble_enable().
 // See common.template.ld.
 #ifndef SOFTDEVICE_RAM_SIZE
+#ifdef BLUETOOTH_SD
 #define SOFTDEVICE_RAM_SIZE         (56 * 1024)
+#else
+// No SoftDevice, so none of the low RAM is reserved for it. The SPIM3 buffer
+// then sits at the very bottom of RAM, still inside the first 64kB as the
+// hardware workaround requires.
+#define SOFTDEVICE_RAM_SIZE         (0)
+#endif
 #endif
 
 

--- a/ports/nordic/mpconfigport.h
+++ b/ports/nordic/mpconfigport.h
@@ -12,9 +12,6 @@
 
 #include "nrf_mbr.h"  // for MBR_SIZE
 #include "nrf_sdm.h"  // for SD_FLASH_SIZE
-#else
-#define MBR_SIZE      (0)
-#define SD_FLASH_SIZE (0)
 #endif
 
 #include "peripherals/nrf/nvm.h" // for FLASH_PAGE_SIZE
@@ -49,6 +46,17 @@
 #include "py/circuitpy_mpconfig.h"
 
 // Definitions that might be overridden by mpconfigboard.h
+
+#ifndef BLUETOOTH_SD
+
+#ifndef MBR_SIZE
+#define MBR_SIZE      (0x1000)
+#endif
+
+#ifndef SD_FLASH_SIZE
+#define SD_FLASH_SIZE (0)
+#endif
+#endif
 
 #ifndef CIRCUITPY_INTERNAL_NVM_SIZE
 #define CIRCUITPY_INTERNAL_NVM_SIZE (8 * 1024)
@@ -114,13 +122,8 @@
 
 #define CIRCUITPY_INTERNAL_NVM_START_ADDR (CIRCUITPY_INTERNAL_FLASH_FILESYSTEM_START_ADDR - CIRCUITPY_INTERNAL_NVM_SIZE)
 
-// 32kiB for bonding, etc. Nothing to store without a SoftDevice.
 #ifndef CIRCUITPY_BLE_CONFIG_SIZE
-#ifdef BLUETOOTH_SD
 #define CIRCUITPY_BLE_CONFIG_SIZE       (32 * 1024)
-#else
-#define CIRCUITPY_BLE_CONFIG_SIZE       (0)
-#endif
 #endif
 #define CIRCUITPY_BLE_CONFIG_START_ADDR (CIRCUITPY_INTERNAL_NVM_START_ADDR - CIRCUITPY_BLE_CONFIG_SIZE)
 

--- a/ports/nordic/mpconfigport.mk
+++ b/ports/nordic/mpconfigport.mk
@@ -125,7 +125,7 @@ endif
 endif
 endif
 
-# Cannot have BLEIO without a SoftDevice.
+# no BLEIO without a SoftDevice.
 ifeq ($(SD), )
 CIRCUITPY_BLEIO_NATIVE = 0
 CIRCUITPY_BLE_FILE_SERVICE = 0

--- a/ports/nordic/mpconfigport.mk
+++ b/ports/nordic/mpconfigport.mk
@@ -125,9 +125,7 @@ endif
 endif
 endif
 
-# no BLEIO without a SoftDevice.
-ifeq ($(SD), )
-CIRCUITPY_BLEIO_NATIVE = 0
+ifneq ($(CIRCUITPY_BLEIO_NATIVE),1)
 CIRCUITPY_BLE_FILE_SERVICE = 0
 CIRCUITPY_BLE_SERIAL_SERVICE = 0
 endif

--- a/ports/nordic/mpconfigport.mk
+++ b/ports/nordic/mpconfigport.mk
@@ -124,3 +124,10 @@ ifeq ($(INTERNAL_FLASH_FILESYSTEM),1)
 endif
 endif
 endif
+
+# Cannot have BLEIO without a SoftDevice.
+ifeq ($(SD), )
+CIRCUITPY_BLEIO_NATIVE = 0
+CIRCUITPY_BLE_FILE_SERVICE = 0
+CIRCUITPY_BLE_SERIAL_SERVICE = 0
+endif

--- a/ports/nordic/peripherals/nrf/nvm.h
+++ b/ports/nordic/peripherals/nrf/nvm.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-// Without a SoftDevice these do not arrive via nrf_sdm.h's include chain.
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/ports/nordic/peripherals/nrf/nvm.h
+++ b/ports/nordic/peripherals/nrf/nvm.h
@@ -7,9 +7,13 @@
 
 #pragma once
 
+// Without a SoftDevice these do not arrive via nrf_sdm.h's include chain.
+#include <stdbool.h>
+#include <stdint.h>
+
 #define FLASH_PAGE_SIZE (4096)
 
-#if BLUETOOTH_SD
+#ifdef BLUETOOTH_SD
 bool sd_flash_page_erase_sync(uint32_t page_number);
 bool sd_flash_write_sync(uint32_t *dest_words, uint32_t *src_words, uint32_t num_words);
 #endif

--- a/ports/nordic/supervisor/port.c
+++ b/ports/nordic/supervisor/port.c
@@ -22,7 +22,6 @@
 #include "nrf/power.h"
 #include "nrf/timers.h"
 
-// The SoftDevice headers (nrf_sdm.h / nrf_soc.h) come in via mpconfigport.h.
 #ifdef BLUETOOTH_SD
 #include "nrf_nvic.h"
 #endif

--- a/ports/nordic/supervisor/port.c
+++ b/ports/nordic/supervisor/port.c
@@ -22,7 +22,10 @@
 #include "nrf/power.h"
 #include "nrf/timers.h"
 
+// The SoftDevice headers (nrf_sdm.h / nrf_soc.h) come in via mpconfigport.h.
+#ifdef BLUETOOTH_SD
 #include "nrf_nvic.h"
+#endif
 
 #include "common-hal/microcontroller/Pin.h"
 #include "common-hal/alarm/time/TimeAlarm.h"
@@ -34,7 +37,6 @@
 #include "common-hal/watchdog/WatchDogTimer.h"
 #include "common-hal/alarm/__init__.h"
 
-#include "shared-bindings/_bleio/__init__.h"
 #include "shared-bindings/microcontroller/__init__.h"
 #include "shared-bindings/rtc/__init__.h"
 
@@ -323,6 +325,7 @@ void port_idle_until_interrupt(void) {
         (void)__get_FPSCR();
         NVIC_ClearPendingIRQ(FPU_IRQn);
     }
+    #ifdef BLUETOOTH_SD
     uint8_t sd_enabled;
 
     sd_softdevice_is_enabled(&sd_enabled);
@@ -330,7 +333,10 @@ void port_idle_until_interrupt(void) {
         if (!background_callback_pending()) {
             sd_app_evt_wait();
         }
-    } else {
+        return;
+    }
+    #endif
+    {
         // Call wait for interrupt ourselves if the SD isn't enabled.
         // Note that `wfi` should be called with interrupts disabled,
         // to ensure that the queue is properly drained.  The `wfi`


### PR DESCRIPTION
This change adds a build flag to disable SoftDevice, set `SD=` in mpconfigboard.mk file to disable. 

My testing was performed on a CircuitPlayground bluefruit and the LED Glasses driver device. 

Flashing the UF2 file from a no SD build will wipe the SD from flash. Afterwards, flashing back to a normal with a SD-enabled UF2 file does not work. It flashes but the resulting firmware can't boot successfully. Getting back to a functional SD-enabled firmware requires using SWD to erase, and flash the bootloader+sd hex, then a standard release UF2 can be used to load CircuitPython and bring the device back to normal.