### PR TITLE
nordic analogio fix

### DIFF
--- a/ports/nordic/common-hal/analogio/AnalogIn.c
+++ b/ports/nordic/common-hal/analogio/AnalogIn.c
@@ -109,7 +109,6 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
 
     nrf_saadc_disable(NRF_SAADC);
 
-    asm volatile ("" : : : "memory");
 
     // Disconnect ADC from pin.
     nrf_saadc_channel_input_set(NRF_SAADC, CHANNEL_NO, NRF_SAADC_INPUT_DISABLED, NRF_SAADC_INPUT_DISABLED);

--- a/ports/nordic/common-hal/analogio/AnalogIn.c
+++ b/ports/nordic/common-hal/analogio/AnalogIn.c
@@ -23,6 +23,9 @@ void analogin_init(void) {
     while (nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_CALIBRATEDONE) == 0) {
     }
     nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_CALIBRATEDONE);
+    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_END);
+    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_DONE);
+    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_RESULTDONE);
     nrf_saadc_disable(NRF_SAADC);
 }
 
@@ -56,7 +59,8 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
     // Something else might have used the ADC in a different way,
     // so we completely re-initialize it.
 
-    nrf_saadc_value_t value = 0;
+    static volatile nrf_saadc_value_t value __attribute__((aligned(4)));
+    value = 0;
 
     const nrf_saadc_channel_config_t config = {
         .resistor_p = NRF_SAADC_RESISTOR_DISABLED,
@@ -78,7 +82,12 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
 
     nrf_saadc_channel_init(NRF_SAADC, CHANNEL_NO, &config);
     nrf_saadc_channel_input_set(NRF_SAADC, CHANNEL_NO, self->pin->adc_channel, self->pin->adc_channel);
-    nrf_saadc_buffer_init(NRF_SAADC, &value, 1);
+    nrf_saadc_buffer_init(NRF_SAADC, (nrf_saadc_value_t *)&value, 1);
+    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_STARTED);
+    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_END);
+    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_DONE);
+    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_RESULTDONE);
+    nrf_saadc_event_clear(NRF_SAADC, NRF_SAADC_EVENT_STOPPED);
 
     nrf_saadc_task_trigger(NRF_SAADC, NRF_SAADC_TASK_START);
     while (nrf_saadc_event_check(NRF_SAADC, NRF_SAADC_EVENT_STARTED) == 0) {
@@ -100,23 +109,21 @@ uint16_t common_hal_analogio_analogin_get_value(analogio_analogin_obj_t *self) {
 
     nrf_saadc_disable(NRF_SAADC);
 
-    // Adding the "asm volatile" memory fence here or anywhere after the declaration of `value`
-    // fixes an issue with gcc13 which causes `value` to always be zero.
-    // Compiling with gcc10 or gcc12 is fine.
-    // It can also be fixed by declaring `value` to be static.
-    // I think I'd like to declare `value` as volatile, but that causes type errors.
     asm volatile ("" : : : "memory");
 
     // Disconnect ADC from pin.
     nrf_saadc_channel_input_set(NRF_SAADC, CHANNEL_NO, NRF_SAADC_INPUT_DISABLED, NRF_SAADC_INPUT_DISABLED);
 
+    // Read the DMA'd result exactly once.
+    int32_t result = value;
+
     // value is signed and might be (slightly) < 0, even on single-ended conversions, so force to 0.
-    if (value < 0) {
-        value = 0;
+    if (result < 0) {
+        result = 0;
     }
 
     // Stretch 14-bit ADC reading to 16-bit range
-    return (value << 2) | (value >> 12);
+    return (result << 2) | (result >> 12);
 }
 
 float common_hal_analogio_analogin_get_reference_voltage(analogio_analogin_obj_t *self) {


### PR DESCRIPTION
Fixes an issue in nordic AnalogIn with `value` being `0`.

Honestly this issue and the fix a little over my head. I will include output from agent at relevant sections of the code.

My understanding is that this issue was previously attributed to an issue with different versions of gcc, a prior comment from @danh in this file mentioned that. While working on the SP-1 I ran into the same symptoms (with the pre-existing work-around in place). Troubleshooting on the SP-1 to get faders and buttons working led to this fix.

My understanding now is that the `0` for `value` was caused by mismanaged state of nrf_saadc_events and the prior attribution to gcc versions may not have been correct. This fixes the state management, and leaves the original `asm volatile` as well.

I tested this fix successfully on a CPB with a potentiometer, and on the SP-1 device.