### PR TITLE
zephyr-cp: add ranges; to three rebuilt partitions nodes

### DIFF
--- a/ports/zephyr-cp/boards/adafruit/feather_rp2040_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/adafruit/feather_rp2040_zephyr/board.overlay
@@ -2,6 +2,7 @@
 	/delete-node/ partitions;
 
 	partitions {
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico_w_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico_w_zephyr/board.overlay
@@ -2,6 +2,7 @@
 	/delete-node/ partitions;
 
 	partitions {
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 

--- a/ports/zephyr-cp/boards/st/stm32wba65i_dk1/board.overlay
+++ b/ports/zephyr-cp/boards/st/stm32wba65i_dk1/board.overlay
@@ -2,6 +2,7 @@
     /delete-node/ partitions;
 
     partitions {
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 


### PR DESCRIPTION
Follow-up to #11234, which fixed rpi_pico_zephyr. Three more overlays have the same problem.

Measured before and after on stm32wba65i_dk1:

| | without ranges; | with ranges; |
|---|---|---|
| boot | 0x0 | 0x08000000 |
| slot0 | 0x10000 | 0x08010000 |
| circuitpy | 0x108000 | 0x08108000 |
| storage | 0x1e0000 | 0x081e0000 |

Each board's own DTS declares ranges; on the partitions node, so this only restores what the overlay dropped. Offsets and sizes are unchanged.

I swept every overlay in the port that rebuilds a partitions node; these three are the only ones affected.