### PR TITLE
zephyr-cp: size nvm and storage to a whole erase block on RP2040/RP2350

### DIFF
--- a/ports/zephyr-cp/boards/adafruit/feather_rp2040_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/adafruit/feather_rp2040_zephyr/board.overlay
@@ -17,26 +17,26 @@
 		code_partition: partition@100 {
 			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
-			reg = <0x100 (0x180000 - 0x100)>;
+			reg = <0x100 (0xfe000 - 0x100)>;
 			read-only;
 		};
 
-		nvm_partition: partition@180000 {
-			compatible = "zephyr,mapped-partition";
-			label = "nvm";
-			reg = <0x180000 0x1000>;
-		};
-
-		storage_partition: partition@181000 {
+		storage_partition: partition@fe000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x181000 0x1000>;
+			reg = <0xfe000 0x1000>;
 		};
 
-		circuitpy_partition: partition@182000 {
+		nvm_partition: partition@ff000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nvm";
+			reg = <0xff000 0x1000>;
+		};
+
+		circuitpy_partition: partition@100000 {
 			compatible = "zephyr,mapped-partition";
 			label = "circuitpy";
-			reg = <0x182000 (DT_SIZE_M(8) - 0x182000)>;
+			reg = <0x100000 (DT_SIZE_M(8) - 0x100000)>;
 		};
 	};
 };

--- a/ports/zephyr-cp/boards/adafruit/feather_rp2040_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/adafruit/feather_rp2040_zephyr/board.overlay
@@ -24,19 +24,19 @@
 		nvm_partition: partition@180000 {
 			compatible = "zephyr,mapped-partition";
 			label = "nvm";
-			reg = <0x180000 0x800>;
+			reg = <0x180000 0x1000>;
 		};
 
-		storage_partition: partition@180800 {
+		storage_partition: partition@181000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x180800 0x800>;
+			reg = <0x181000 0x1000>;
 		};
 
-		circuitpy_partition: partition@181000 {
+		circuitpy_partition: partition@182000 {
 			compatible = "zephyr,mapped-partition";
 			label = "circuitpy";
-			reg = <0x181000 (DT_SIZE_M(8) - 0x181000)>;
+			reg = <0x182000 (DT_SIZE_M(8) - 0x182000)>;
 		};
 	};
 };

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_w_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_w_zephyr/board.overlay
@@ -6,8 +6,14 @@
 		code_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
-			reg = <0x0 0x180000>;
+			reg = <0x0 0x17f000>;
 			read-only;
+		};
+
+		storage_partition: partition@17f000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x17f000 0x1000>;
 		};
 
 		nvm_partition: partition@180000 {
@@ -16,16 +22,10 @@
 			reg = <0x180000 0x1000>;
 		};
 
-		storage_partition: partition@181000 {
-			compatible = "zephyr,mapped-partition";
-			label = "storage";
-			reg = <0x181000 0x1000>;
-		};
-
-		circuitpy_partition: partition@182000 {
+		circuitpy_partition: partition@181000 {
 			compatible = "zephyr,mapped-partition";
 			label = "circuitpy";
-			reg = <0x182000 (DT_SIZE_M(4) - 0x182000)>;
+			reg = <0x181000 (DT_SIZE_M(4) - 0x181000)>;
 		};
 	};
 };

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_w_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_w_zephyr/board.overlay
@@ -13,19 +13,19 @@
 		nvm_partition: partition@180000 {
 			compatible = "zephyr,mapped-partition";
 			label = "nvm";
-			reg = <0x180000 0x800>;
+			reg = <0x180000 0x1000>;
 		};
 
-		storage_partition: partition@180800 {
+		storage_partition: partition@181000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x180800 0x800>;
+			reg = <0x181000 0x1000>;
 		};
 
-		circuitpy_partition: partition@181000 {
+		circuitpy_partition: partition@182000 {
 			compatible = "zephyr,mapped-partition";
 			label = "circuitpy";
-			reg = <0x181000 (DT_SIZE_M(4) - 0x181000)>;
+			reg = <0x182000 (DT_SIZE_M(4) - 0x182000)>;
 		};
 	};
 };

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_zephyr/board.overlay
@@ -6,26 +6,26 @@
 		code_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
-			reg = <0x0 0x180000>;
+			reg = <0x0 0xfe000>;
 			read-only;
 		};
 
-		nvm_partition: partition@180000 {
-			compatible = "zephyr,mapped-partition";
-			label = "nvm";
-			reg = <0x180000 0x1000>;
-		};
-
-		storage_partition: partition@181000 {
+		storage_partition: partition@fe000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x181000 0x1000>;
+			reg = <0xfe000 0x1000>;
 		};
 
-		circuitpy_partition: partition@182000 {
+		nvm_partition: partition@ff000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nvm";
+			reg = <0xff000 0x1000>;
+		};
+
+		circuitpy_partition: partition@100000 {
 			compatible = "zephyr,mapped-partition";
 			label = "circuitpy";
-			reg = <0x182000 (DT_SIZE_M(4) - 0x182000)>;
+			reg = <0x100000 (DT_SIZE_M(4) - 0x100000)>;
 		};
 	};
 };

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_zephyr/board.overlay
@@ -13,19 +13,19 @@
 		nvm_partition: partition@180000 {
 			compatible = "zephyr,mapped-partition";
 			label = "nvm";
-			reg = <0x180000 0x800>;
+			reg = <0x180000 0x1000>;
 		};
 
-		storage_partition: partition@180800 {
+		storage_partition: partition@181000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x180800 0x800>;
+			reg = <0x181000 0x1000>;
 		};
 
-		circuitpy_partition: partition@181000 {
+		circuitpy_partition: partition@182000 {
 			compatible = "zephyr,mapped-partition";
 			label = "circuitpy";
-			reg = <0x181000 (DT_SIZE_M(4) - 0x181000)>;
+			reg = <0x182000 (DT_SIZE_M(4) - 0x182000)>;
 		};
 	};
 };

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico_w_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico_w_zephyr/board.overlay
@@ -17,8 +17,14 @@
 		code_partition: partition@100 {
 			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
-			reg = <0x100 (0x180000 - 0x100)>;
+			reg = <0x100 (0x17f000 - 0x100)>;
 			read-only;
+		};
+
+		storage_partition: partition@17f000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
+			reg = <0x17f000 0x1000>;
 		};
 
 		nvm_partition: partition@180000 {
@@ -27,16 +33,10 @@
 			reg = <0x180000 0x1000>;
 		};
 
-		storage_partition: partition@181000 {
-			compatible = "zephyr,mapped-partition";
-			label = "storage";
-			reg = <0x181000 0x1000>;
-		};
-
-		circuitpy_partition: partition@182000 {
+		circuitpy_partition: partition@181000 {
 			compatible = "zephyr,mapped-partition";
 			label = "circuitpy";
-			reg = <0x182000 (DT_SIZE_M(2) - 0x182000)>;
+			reg = <0x181000 (DT_SIZE_M(2) - 0x181000)>;
 		};
 	};
 };

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico_w_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico_w_zephyr/board.overlay
@@ -24,19 +24,19 @@
 		nvm_partition: partition@180000 {
 			compatible = "zephyr,mapped-partition";
 			label = "nvm";
-			reg = <0x180000 0x800>;
+			reg = <0x180000 0x1000>;
 		};
 
-		storage_partition: partition@180800 {
+		storage_partition: partition@181000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x180800 0x800>;
+			reg = <0x181000 0x1000>;
 		};
 
-		circuitpy_partition: partition@181000 {
+		circuitpy_partition: partition@182000 {
 			compatible = "zephyr,mapped-partition";
 			label = "circuitpy";
-			reg = <0x181000 (DT_SIZE_M(2) - 0x181000)>;
+			reg = <0x182000 (DT_SIZE_M(2) - 0x182000)>;
 		};
 	};
 };

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico_zephyr/board.overlay
@@ -24,19 +24,19 @@
 		nvm_partition: partition@180000 {
 			compatible = "zephyr,mapped-partition";
 			label = "nvm";
-			reg = <0x180000 0x800>;
+			reg = <0x180000 0x1000>;
 		};
 
-		storage_partition: partition@180800 {
+		storage_partition: partition@181000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x180800 0x800>;
+			reg = <0x181000 0x1000>;
 		};
 
-		circuitpy_partition: partition@181000 {
+		circuitpy_partition: partition@182000 {
 			compatible = "zephyr,mapped-partition";
 			label = "circuitpy";
-			reg = <0x181000 (DT_SIZE_M(2) - 0x181000)>;
+			reg = <0x182000 (DT_SIZE_M(2) - 0x182000)>;
 		};
 	};
 };

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico_zephyr/board.overlay
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico_zephyr/board.overlay
@@ -17,26 +17,26 @@
 		code_partition: partition@100 {
 			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
-			reg = <0x100 (0x180000 - 0x100)>;
+			reg = <0x100 (0xfe000 - 0x100)>;
 			read-only;
 		};
 
-		nvm_partition: partition@180000 {
-			compatible = "zephyr,mapped-partition";
-			label = "nvm";
-			reg = <0x180000 0x1000>;
-		};
-
-		storage_partition: partition@181000 {
+		storage_partition: partition@fe000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x181000 0x1000>;
+			reg = <0xfe000 0x1000>;
 		};
 
-		circuitpy_partition: partition@182000 {
+		nvm_partition: partition@ff000 {
+			compatible = "zephyr,mapped-partition";
+			label = "nvm";
+			reg = <0xff000 0x1000>;
+		};
+
+		circuitpy_partition: partition@100000 {
 			compatible = "zephyr,mapped-partition";
 			label = "circuitpy";
-			reg = <0x182000 (DT_SIZE_M(2) - 0x182000)>;
+			reg = <0x100000 (DT_SIZE_M(2) - 0x100000)>;
 		};
 	};
 };


### PR DESCRIPTION
nvm_partition and storage_partition are 0x800 on all five RP2040/RP2350 boards, but the erase block on those chips is 4096.

common_hal_nvm_bytearray_set_bytes reads a whole erase page before modifying it, and takes that page size from the flash device rather than the partition, so it asks flash_area_read for 4096 bytes out of a 2048-byte area. flash_area_read bounds-checks and returns -EINVAL.

Measured on a picopad running zephyr-cp:

```
    >>> len(microcontroller.nvm)
    2048
    >>> microcontroller.nvm[0:4] = b"ABCD"
    RuntimeError: Unable to write to nvm.
```

The same test on the raspberrypi port, where nvm is a full 4096, writes and reads back fine.

Both partitions grow to one erase block, which shifts circuitpy_partition 4 KB up. The filesystem moves with it, so a board updating to this comes up with an empty CIRCUITPY drive...

