### PR TITLE
espressif: check sleep memory reset reason only once per chip reset

### DIFF
--- a/ports/espressif/common-hal/alarm/SleepMemory.c
+++ b/ports/espressif/common-hal/alarm/SleepMemory.c
@@ -24,6 +24,15 @@ void alarm_sleep_memory_reset(void) {
     // reset, watchdog, panic, deep sleep wake). Clear on everything else —
     // after power-on, SRAM contents are undefined; after brown-out, the RTC
     // domain was reset by hardware (System Reset scope per TRM Figure 6.1-1).
+    //
+    // esp_reset_reason() does not change across supervisor reloads,
+    // so do this check only once per chip reset.
+    static bool checked_reset_reason = false;
+    if (checked_reset_reason) {
+        return;
+    }
+    checked_reset_reason = true;
+
     esp_reset_reason_t reason = esp_reset_reason();
     switch (reason) {
         case ESP_RST_SW:        // microcontroller.reset() / esp_restart()


### PR DESCRIPTION
## What
Check sleep memory reset reason once per chip reset, not every reload.

## Why
Fixes #11167. Reloads and fake deep sleep wake zeroed alarm.sleep_memory.

## Hardware tested
TimeAlarm fake deep sleep on 10.3.0-rc.0 and this patch.

| Board | power-on reset, rc.0 | power-on reset, patched | software reset, patched |
|---|---|---|---|
| Metro ESP32-S3 | fail | pass | pass |
| Metro ESP32-S2 | fail | pass | pass |
| ESP32-P4 | fail | pass | pass |

## How I tested it
Wrote pattern, slept 12s, read back after wake, serial below.

## Scope
Battery powered true deep sleep untested; all boards were USB powered.

## Notes
Port-local guard matches nordic and stm reload-idempotent reset functions.

## Test code and serial output

code.py, armed from the REPL with `microcontroller.nvm[0] = 1` then ctrl-D:

```python
import alarm
import microcontroller
import supervisor
import time

PATTERN = [11, 22, 33, 44, 55, 66, 77, 88]
mem = list(alarm.sleep_memory[0:8])
print("T11167 reset_reason:", microcontroller.cpu.reset_reason)
print("T11167 run_reason:", supervisor.runtime.run_reason)
print("T11167 wake_alarm:", alarm.wake_alarm)
print("T11167 mem:", mem)
phase = microcontroller.nvm[0]
print("T11167 phase:", phase)
if phase == 1:
    for i, v in enumerate(PATTERN):
        alarm.sleep_memory[i] = v
    microcontroller.nvm[0] = 2
    print("T11167 pattern written:", list(alarm.sleep_memory[0:8]))
    print("T11167 deep sleeping 12s")
    time.sleep(2)
    ta = alarm.time.TimeAlarm(monotonic_time=time.monotonic() + 12)
    alarm.exit_and_deep_sleep_until_alarms(ta)
elif phase == 2:
    microcontroller.nvm[0] = 0
    if mem == PATTERN:
        print("T11167 RESULT: PASS - sleep_memory preserved")
    else:
        print("T11167 RESULT: FAIL - sleep_memory corrupted, expected", PATTERN)
else:
    print("T11167 idle (set nvm[0]=1 and reload to run)")
```

Metro ESP32-S3, 10.3.0-rc.0, after hub port power cycle:

```
T11167 reset_reason: microcontroller.ResetReason.POWER_ON
T11167 run_reason: supervisor.RunReason.REPL_RELOAD
T11167 wake_alarm: None
T11167 mem: [0, 0, 0, 0, 0, 0, 0, 0]
T11167 phase: 1
T11167 pattern written: [11, 22, 33, 44, 55, 66, 77, 88]
T11167 deep sleeping 12s
Pretending to deep sleep until alarm, CTRL-C or file write.
Woken up by alarm.
T11167 reset_reason: microcontroller.ResetReason.POWER_ON
T11167 run_reason: supervisor.RunReason.STARTUP
T11167 wake_alarm: <TimeAlarm>
T11167 mem: [0, 0, 0, 0, 0, 0, 0, 0]
T11167 phase: 2
T11167 RESULT: FAIL - sleep_memory corrupted, expected [11, 22, 33, 44, 55, 66, 77, 88]
```

Metro ESP32-S3, this patch, after hub port power cycle:

```
T11167 reset_reason: microcontroller.ResetReason.POWER_ON
T11167 run_reason: supervisor.RunReason.REPL_RELOAD
T11167 wake_alarm: None
T11167 mem: [0, 0, 0, 0, 0, 0, 0, 0]
T11167 phase: 1
T11167 pattern written: [11, 22, 33, 44, 55, 66, 77, 88]
T11167 deep sleeping 12s
Pretending to deep sleep until alarm, CTRL-C or file write.
Woken up by alarm.
T11167 reset_reason: microcontroller.ResetReason.POWER_ON
T11167 run_reason: supervisor.RunReason.STARTUP
T11167 wake_alarm: <TimeAlarm>
T11167 mem: [11, 22, 33, 44, 55, 66, 77, 88]
T11167 phase: 2
T11167 RESULT: PASS - sleep_memory preserved
```

## AI assistance
Claude wrote the fix and ran hardware tests; diff reviewed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
