### PR TITLE
Fix synthio oscillator wrapping one sample late

### DIFF
--- a/shared-module/synthio/__init__.c
+++ b/shared-module/synthio/__init__.c
@@ -238,7 +238,7 @@ static bool synth_note_into_buffer(synthio_synth_t *synth, int chan, int32_t *ou
     for (uint16_t i = 0; i < dur; i++) {
         accum += dds_rate;
         // because dds_rate is low enough, the subtraction is guaranteed to go back into range, no expensive modulo needed
-        if (accum > lim) {
+        if (accum >= lim) {
             accum = accum - lim + offset;
         }
         int16_t idx = accum >> SYNTHIO_FREQUENCY_SHIFT;
@@ -266,7 +266,7 @@ static bool synth_note_into_buffer(synthio_synth_t *synth, int chan, int32_t *ou
         for (uint16_t i = 0; i < dur; i++) {
             accum += ring_dds_rate;
             // because dds_rate is low enough, the subtraction is guaranteed to go back into range, no expensive modulo needed
-            if (accum > lim) {
+            if (accum >= lim) {
                 accum = accum - lim + offset;
             }
             int16_t idx = accum >> SYNTHIO_FREQUENCY_SHIFT;

--- a/tests/circuitpython/synthio_oscillator_loop_end.py
+++ b/tests/circuitpython/synthio_oscillator_loop_end.py
@@ -1,0 +1,33 @@
+# A note whose loop end is reached exactly (accum == lim) should wrap back
+# to the loop start on that same sample, not read one sample past the loop.
+import array
+from audiocore import get_buffer
+from synthio import Note, Synthesizer
+
+RATE = 8000
+LOOP = 256
+
+# 512 samples: the loop is [0, 256) and is silent; sample 256 is a marker
+# the oscillator should never reach.
+table = array.array("h", [0] * 512)
+table[LOOP] = 30000
+
+synth = Synthesizer(sample_rate=RATE, channel_count=1)
+note = Note(
+    frequency=RATE / LOOP,  # exactly one table step per output sample
+    waveform=table,
+    waveform_loop_start=0,
+    waveform_loop_end=LOOP,
+    envelope=None,
+)
+synth.press(note)
+
+out = []
+for _ in range(4):
+    data = bytes(get_buffer(synth)[1])
+    for index in range(0, len(data) - 1, 2):
+        value = data[index] | (data[index + 1] << 8)
+        out.append(value - 65536 if value >= 32768 else value)
+
+hits = [i for i, v in enumerate(out) if abs(v) > 1000]
+print("marker hits:", hits)

--- a/tests/circuitpython/synthio_oscillator_loop_end.py.exp
+++ b/tests/circuitpython/synthio_oscillator_loop_end.py.exp
@@ -1,0 +1,1 @@
+marker hits: []


### PR DESCRIPTION
Fixes #11266.

`synth_note_into_buffer()` in `shared-module/synthio/__init__.c` wraps the
DDS accumulator on

    if (accum > lim) {
        accum = accum - lim + offset;
    }

but `lim` is the **exclusive** end of the waveform loop -- the readable
samples are `[offset, lim)`. Wrapping on `>` rather than `>=` lets the
accumulator land exactly on `lim`, and that iteration indexes
`waveform[waveform_length]`: one past the loop, and for the common case of a
note looping the whole table, one past the buffer itself. The ring-modulator
loop just below has the identical bug with `ring_waveform`.

Any note whose `dds_rate` divides `lim` hits the boundary on a schedule --
a table played at exactly one sample per output sample hits it every
`waveform_length` samples. When the loop covers the whole buffer, the read
is genuinely out of bounds, so **the same script with the same events does
not render the same audio twice**.

### Repro

A table with a loop end short of the buffer end, so the extra read stays
in-bounds and lands on a marker value instead of undefined memory
(`waveform_loop_end=256` of a 512-sample table, `frequency` set so the
oscillator advances exactly one table step per output sample):

Measured on a unix coverage build of `main`, four blocks of 256 samples
(1024 total), marker at index 256:

|                  | before                    | after |
|------------------|---------------------------|-------|
| marker hits      | `[255, 511, 767, 1023]`   | `[]`  |

Includes a regression test
(`tests/circuitpython/synthio_oscillator_loop_end.py`) built the same way;
it fails on current `main` and passes with the fix. The neighboring
biquad/filter tests that pass on unmodified `main` in the same environment
still pass.
