### PR TITLE
audiofilters.Distortion(soft_clip=False) enables soft clipping

### DIFF
--- a/shared-bindings/audiofilters/Distortion.c
+++ b/shared-bindings/audiofilters/Distortion.c
@@ -152,7 +152,7 @@ static mp_obj_t audiofilters_distortion_make_new(const mp_obj_type_t *type, size
         args[ARG_pre_gain].u_obj,
         args[ARG_post_gain].u_obj,
         mode,
-        args[ARG_soft_clip].u_obj,
+        args[ARG_soft_clip].u_bool,
         args[ARG_mix].u_obj,
         args[ARG_buffer_size].u_int,
         bits_per_sample,

--- a/tests/circuitpython/audiofilter_distortion_soft_clip.py
+++ b/tests/circuitpython/audiofilter_distortion_soft_clip.py
@@ -1,0 +1,14 @@
+# soft_clip is declared MP_ARG_BOOL; asking for False should give back False,
+# not whatever happened to be on the stack under the argument union.
+from audiofilters import Distortion
+
+RATE = 8000
+
+
+def make(soft_clip):
+    return Distortion(soft_clip=soft_clip, sample_rate=RATE).soft_clip
+
+
+print("default          ", Distortion(sample_rate=RATE).soft_clip)
+print("soft_clip=False  ", make(False))
+print("soft_clip=True   ", make(True))

--- a/tests/circuitpython/audiofilter_distortion_soft_clip.py.exp
+++ b/tests/circuitpython/audiofilter_distortion_soft_clip.py.exp
@@ -1,0 +1,3 @@
+default           False
+soft_clip=False   False
+soft_clip=True    True


### PR DESCRIPTION
Fixes #11267.

`shared-bindings/audiofilters/Distortion.c` declares `soft_clip` as a bool
argument:

    { MP_QSTR_soft_clip, MP_ARG_BOOL | MP_ARG_KW_ONLY, {.u_bool = false} },

but reads it back through the wrong union member:

    common_hal_audiofilters_distortion_construct(self,
        ...
        args[ARG_soft_clip].u_obj,        // should be .u_bool
        ...

`common_hal_audiofilters_distortion_construct()` takes `bool soft_clip`, so
this converts an `mp_obj_t` to `bool` -- effectively "is this pointer
non-null" -- instead of reading the bool that `mp_arg_parse_all()` actually
wrote into that argument slot.

`args` is an uninitialised local (`mp_arg_val_t args[MP_ARRAY_SIZE(...)]`),
and `py/argcheck.c` only writes the `.u_bool` byte of an `MP_ARG_BOOL` slot
when the argument is supplied; the rest of the union is whatever was on the
stack. Reading `.u_obj` back is undefined behaviour, and in practice comes
out non-null (true) whenever those leftover bytes are non-zero -- which
`soft_clip=False` does not prevent, since only the low byte gets cleared.
`soft_clip=False` is the one call that cannot be right except by luck.

### Repro

```python
import audiofilters


def make(soft_clip):
    return audiofilters.Distortion(soft_clip=soft_clip, sample_rate=8000).soft_clip


print("default        ", audiofilters.Distortion(sample_rate=8000).soft_clip)
print("soft_clip=False", make(False))
print("soft_clip=True ", make(True))
```

Measured on a unix coverage build of `main`:

|                   | before | after |
|-------------------|--------|-------|
| default           | False  | False |
| `soft_clip=False` | **True**   | False |
| `soft_clip=True`  | True   | True  |

Includes a regression test
(`tests/circuitpython/audiofilter_distortion_soft_clip.py`) with the same
three cases; it fails on current `main` and passes with the fix.
