### PR TITLE
Fix synthio_biquad_filter_reset() clearing only half the filter state

### DIFF
--- a/shared-module/synthio/Biquad.c
+++ b/shared-module/synthio/Biquad.c
@@ -194,7 +194,7 @@ void common_hal_synthio_biquad_tick(mp_obj_t self_in) {
 }
 
 void synthio_biquad_filter_reset(biquad_filter_state *st) {
-    memset(&st->x, 0, 4 * sizeof(int16_t));
+    memset(st, 0, sizeof(*st));
 }
 
 static inline int32_t biquad_filter_sample(int32_t input, int32_t a1, int32_t a2, int32_t b0, int32_t b1, int32_t b2, int32_t x0, int32_t x1, int32_t y0, int32_t y1) {

--- a/tests/circuitpython/audiofilter_filter_reset_buffer.py
+++ b/tests/circuitpython/audiofilter_filter_reset_buffer.py
@@ -1,0 +1,43 @@
+# audiofilters.Filter.reset_buffer() should leave no audio behind: a biquad
+# reset should clear both its input and output history, not just the input.
+import array
+import math
+from audiocore import get_buffer, reset_buffer, RawSample
+from audiofilters import Filter
+from synthio import Biquad, FilterMode
+
+RATE = 48000
+FRAMES = 1024
+
+
+def s16(data):
+    out = []
+    for index in range(0, len(data) - 1, 2):
+        value = data[index] | (data[index + 1] << 8)
+        out.append(value - 65536 if value >= 32768 else value)
+    return out
+
+
+loud = array.array(
+    "h", [int(30000 * math.sin(2 * math.pi * 200 * frame / RATE)) for frame in range(FRAMES)]
+)
+silence = array.array("h", [0] * FRAMES)
+
+biquad = Biquad(FilterMode.LOW_PASS, 800.0)
+node = Filter(
+    filter=biquad,
+    sample_rate=RATE,
+    channel_count=1,
+    bits_per_sample=16,
+    samples_signed=True,
+    buffer_size=FRAMES * 2,
+)
+
+node.play(RawSample(loud, sample_rate=RATE, channel_count=1), loop=True)
+for _ in range(4):
+    get_buffer(node)  # fill the filter's memory
+
+node.play(RawSample(silence, sample_rate=RATE, channel_count=1), loop=True)
+reset_buffer(node)  # what an AudioOut does on play()
+first = s16(bytes(get_buffer(node)[1]))
+print("peak after reset_buffer:", max(abs(value) for value in first))

--- a/tests/circuitpython/audiofilter_filter_reset_buffer.py.exp
+++ b/tests/circuitpython/audiofilter_filter_reset_buffer.py.exp
@@ -1,0 +1,1 @@
+peak after reset_buffer: 0


### PR DESCRIPTION
Fixes #11268.

`shared-module/synthio/Biquad.h` defines the filter state as four
`int32_t`:

    typedef struct {
        int32_t x[2], y[2];
    } biquad_filter_state;

but `shared-module/synthio/Biquad.c` only clears the first two:

    void synthio_biquad_filter_reset(biquad_filter_state *st) {
        memset(&st->x, 0, 4 * sizeof(int16_t));
    }

The struct is 16 bytes; `4 * sizeof(int16_t)` is 8. `x[0]` and `x[1]` get
cleared, but `y[0]` and `y[1]` -- the feedback history -- do not.
`biquad_filter_sample()` reads all four members as `int32_t`, so the
`int16_t` sizing looks like a leftover from an earlier, narrower state
layout.

A biquad's `y` history is what the recursion runs on, so what survives a
"reset" is not a cosmetic detail: feeding a reset filter pure silence
produces a decaying tail of whatever it played before, and for a low-pass
with poles near the unit circle that tail starts close to full scale.
Both callers -- `audiofilters_filter_reset_buffer()` (called when an
`AudioOut` starts playback) and `synthio.Note`'s filter (re)initialisation
-- want the full reset.

### Repro

An 800 Hz low-pass fed a loud 200 Hz tone for four blocks, then
`reset_buffer()`, then silence. Peak of the first "silent" block, unix
coverage build of `main`:

|        | peak out (int16) |
|--------|-------------------|
| before | 28082 (-1.3 dBFS) |
| after  | 0                 |

Includes a regression test
(`tests/circuitpython/audiofilter_filter_reset_buffer.py`) with the same
scenario; it fails on current `main` and passes with the fix.
