### PR TITLE
usb_hid: honor a boot protocol request that arrives after startup

### DIFF
--- a/shared-bindings/usb_hid/Device.c
+++ b/shared-bindings/usb_hid/Device.c
@@ -156,6 +156,10 @@ static mp_obj_t usb_hid_device_make_new(const mp_obj_type_t *type, size_t n_args
 //|         The ``report`` itself will be discarded, to prevent unwanted extraneous characters,
 //|         mouse clicks, etc.
 //|
+//|         If the host has put the interface in boot protocol, the boot device sends its report
+//|         without a report ID, and `send_report()` on any other device discards the report,
+//|         because the host reads only the boot device.
+//|
 //|         Note: Host operating systems allow enabling and disabling specific devices
 //|         and kinds of devices to do wakeup.
 //|         The defaults are different for different operating systems.

--- a/shared-bindings/usb_hid/__init__.c
+++ b/shared-bindings/usb_hid/__init__.c
@@ -25,6 +25,10 @@
 //| the `devices` tuple is **replaced** when ``code.py`` starts with a single-element tuple
 //| containing a `Device` that describes the boot device chosen (keyboard or mouse).
 //| The request for a boot device overrides any other HID devices.
+//|
+//| If the host requests a boot device after ``code.py`` has started, `devices` is not replaced.
+//| The boot device then sends reports in the boot format, with no report ID, and
+//| `Device.send_report()` on any other device does nothing, because the host ignores it.
 //| """
 //|
 //|

--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -130,10 +130,10 @@ void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t *
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("USB busy"));
         }
 
-        if (tud_hid_get_protocol() == HID_PROTOCOL_BOOT) {
+        const uint8_t boot_device = usb_hid_boot_device();
+        if (boot_device != 0 && tud_hid_get_protocol() == HID_PROTOCOL_BOOT) {
             // In boot protocol the host reads the fixed boot report, which carries no report ID,
             // and ignores every device other than the boot device.
-            uint8_t boot_device = usb_hid_boot_device();
             if (self->usage_page == HID_USAGE_PAGE_DESKTOP &&
                 ((boot_device == 1 && self->usage == HID_USAGE_DESKTOP_KEYBOARD) ||
                  (boot_device == 2 && self->usage == HID_USAGE_DESKTOP_MOUSE))) {

--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -119,16 +119,6 @@ void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t *
 
     mp_arg_validate_length(len, self->in_report_lengths[id_idx], MP_QSTR_report);
 
-    // The host can enter boot protocol mid-run, after the setup-time swap.
-    const uint8_t boot_device = usb_hid_boot_device();
-    if (report_id != 0 &&
-        self->usage_page == HID_USAGE_PAGE_DESKTOP &&
-        ((boot_device == 1 && self->usage == HID_USAGE_DESKTOP_KEYBOARD) ||
-         (boot_device == 2 && self->usage == HID_USAGE_DESKTOP_MOUSE)) &&
-        tud_hid_get_protocol() == HID_PROTOCOL_BOOT) {
-        report_id = 0;
-    }
-
     // Wait until interface is ready, timeout = 2 seconds
     uint64_t end_ticks = supervisor_ticks_ms64() + 2000;
     while ((supervisor_ticks_ms64() < end_ticks) && !tud_hid_ready()) {
@@ -138,6 +128,19 @@ void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t *
     if (!tud_suspended()) {
         if (!tud_hid_ready()) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("USB busy"));
+        }
+
+        if (tud_hid_get_protocol() == HID_PROTOCOL_BOOT) {
+            // In boot protocol the host reads the fixed boot report, which carries no report ID,
+            // and ignores every device other than the boot device.
+            uint8_t boot_device = usb_hid_boot_device();
+            if (self->usage_page == HID_USAGE_PAGE_DESKTOP &&
+                ((boot_device == 1 && self->usage == HID_USAGE_DESKTOP_KEYBOARD) ||
+                 (boot_device == 2 && self->usage == HID_USAGE_DESKTOP_MOUSE))) {
+                report_id = 0;
+            } else {
+                return;
+            }
         }
 
         if (!tud_hid_report(report_id, report, len)) {

--- a/shared-module/usb_hid/Device.c
+++ b/shared-module/usb_hid/Device.c
@@ -119,6 +119,16 @@ void common_hal_usb_hid_device_send_report(usb_hid_device_obj_t *self, uint8_t *
 
     mp_arg_validate_length(len, self->in_report_lengths[id_idx], MP_QSTR_report);
 
+    // The host can enter boot protocol mid-run, after the setup-time swap.
+    const uint8_t boot_device = usb_hid_boot_device();
+    if (report_id != 0 &&
+        self->usage_page == HID_USAGE_PAGE_DESKTOP &&
+        ((boot_device == 1 && self->usage == HID_USAGE_DESKTOP_KEYBOARD) ||
+         (boot_device == 2 && self->usage == HID_USAGE_DESKTOP_MOUSE)) &&
+        tud_hid_get_protocol() == HID_PROTOCOL_BOOT) {
+        report_id = 0;
+    }
+
     // Wait until interface is ready, timeout = 2 seconds
     uint64_t end_ticks = supervisor_ticks_ms64() + 2000;
     while ((supervisor_ticks_ms64() < end_ticks) && !tud_hid_ready()) {


### PR DESCRIPTION
## What

In boot protocol the boot device sends without a report ID, and other devices do not send.

## Why

`usb_hid_setup_devices()` swaps in the boot device only at VM start, so a later `SET_PROTOCOL(boot)` is missed.

Reports keep their report ID, and a boot-protocol host reads that byte as modifiers.

A phantom modifier results: `01` reads as left Ctrl, `03` from `CONSUMER_CONTROL` as Ctrl+Shift. Fixes #1136.

## Hardware tested

Feather RP2040. Real `SET_PROTOCOL(boot)` over usbfs on Ubuntu 26.04.1, three trials per build.

| in boot protocol | baseline `d897c15` | this branch |
|---|---|---|
| keyboard | 9 bytes, `01` prefix | 8 bytes |
| consumer control | 3 bytes, `03` prefix | not sent |

Report protocol is byte-identical before and after, and the default configuration still enumerates and runs.

Also checked at a macOS pre-boot screen on an M2, same either way, so those reports have another cause.

Not tested against a real BIOS, GRUB or KVM.

## AI assistance

Written with an LLM agent (Claude). I ran the boards myself; numbers are from the usbfs harness.
