### PR TITLE
use PYEXEC_UNHANDLED_EXCEPTION; remove PYEXEC_EXCEPTION

### DIFF
--- a/main.c
+++ b/main.c
@@ -267,9 +267,10 @@ void supervisor_execution_status(void) {
     mp_obj_exception_t *exception = MP_OBJ_TO_PTR(_exec_result.exception);
     if (_current_executing_filename != NULL) {
         serial_write(_current_executing_filename);
-    } else if ((_exec_result.return_code & PYEXEC_EXCEPTION) != 0 &&
-               _exec_result.exception_line > 0 &&
-               exception != NULL) {
+    } else if (
+        (_exec_result.return_code == PYEXEC_UNHANDLED_EXCEPTION) &&
+        (_exec_result.exception_line > 0) &&
+        exception != NULL) {
         mp_printf(&mp_plat_print, "%d@%s %q", _exec_result.exception_line, _exec_result.exception_filename, exception->base.type->name);
     } else {
         serial_write_compressed(MP_ERROR_TEXT("Done"));
@@ -576,7 +577,7 @@ static bool __attribute__((noinline)) run_code_py(safe_mode_t safe_mode, bool *s
         blink_count = 0;
     } else
     #endif
-    if (_exec_result.return_code != PYEXEC_EXCEPTION) {
+    if (_exec_result.return_code != PYEXEC_UNHANDLED_EXCEPTION) {
         if (safe_mode == SAFE_MODE_NONE) {
             color = ALL_DONE;
             blink_count = ALL_DONE_BLINKS;

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -772,8 +772,8 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
     // printf("total bytes = %d\n", m_get_total_bytes_allocated());
 
-    // CIRCUITPY-CHANGE: handle PYEXEC_EXCEPTION
-    if (ret & PYEXEC_EXCEPTION) {
+    // CIRCUITPY-CHANGE: handle PYEXEC_UNHANDLED_EXCEPTION
+    if (ret == PYEXEC_UNHANDLED_EXCEPTION) {
         // Return exit status code 1 so the invoker knows there was an uncaught exception.
         return 1;
     } else {

--- a/shared/runtime/pyexec.h
+++ b/shared/runtime/pyexec.h
@@ -47,7 +47,6 @@ extern pyexec_mode_kind_t pyexec_mode_kind;
 
 #define PYEXEC_FORCED_EXIT (0x100)
 // CIRCUITPY-CHANGE: additional flags
-#define PYEXEC_EXCEPTION   (0x200)
 #define PYEXEC_DEEP_SLEEP  (0x400)
 #define PYEXEC_RELOAD      (0x800)
 


### PR DESCRIPTION
- Fixes #11287 (@gallaugher)

Regression in handling of return_codes due to `MICROPY_PYEXEC_ENABLE_EXIT_CODE_HANDLING` change in recent MicroPython merge. This caused status line to be wrong and blinks to be wrong when there was an unhandled exception.

Tested on RP2350 and CPX.

Thanks @gallaugher for diagnosis and fix. Removed `PYEXEC_EXCEPTION`  Also I needed to fix `ports/unix/main.c`.