### PR TITLE
pajenicko_picopad: request 62.5MHz for the ST7789, not 60MHz

### DIFF
--- a/ports/raspberrypi/boards/pajenicko_picopad/board.c
+++ b/ports/raspberrypi/boards/pajenicko_picopad/board.c
@@ -54,7 +54,8 @@ void board_init(void) {
         MP_OBJ_FROM_PTR(&pin_GPIO17), // TFT_DC Command or data
         MP_OBJ_FROM_PTR(&pin_GPIO21), // TFT_CS Chip select
         MP_OBJ_FROM_PTR(&pin_GPIO20), // TFT_RST Reset
-        60000000, // Baudrate
+        62500000, // Baudrate: exactly clk_peri/2 (125MHz/2). Requesting 60MHz makes the
+                  // PL022 divider round DOWN to 31.25MHz - half the display bandwidth.
         0, // Polarity
         0); // Phase
 


### PR DESCRIPTION
The SPI clock can only be `clk_peri` (125 MHz) divided by an even number - 62.5, 31.25, 20.8 MHz, and the SDK picks the fastest of those that does not exceed what the board asked for. Asking for 60 MHz therefore runs the display at 31.25 MHz, half the bandwidth it could have. The panel has been running reliably at 62.5 MHz on this board for a long time, and at that rate a full-screen 320x240 push drops from 47.4 ms to about 20 ms.