### PR TITLE
Fix hardcrash from activating watchdog in boot.py on nordic

### DIFF
--- a/ports/nordic/common-hal/watchdog/WatchDogTimer.c
+++ b/ports/nordic/common-hal/watchdog/WatchDogTimer.c
@@ -75,9 +75,6 @@ void common_hal_watchdog_feed(watchdog_watchdogtimer_obj_t *self) {
 
 void common_hal_watchdog_deinit(watchdog_watchdogtimer_obj_t *self) {
     if (self->mode == WATCHDOGMODE_RESET) {
-        if (gc_alloc_possible()) {
-            mp_raise_RuntimeError(MP_ERROR_TEXT("WatchDogTimer cannot be deinitialized once mode is set to RESET"));
-        }
         // Don't change anything because RESET cannot be undone.
         return;
     }
@@ -164,6 +161,10 @@ void common_hal_watchdog_set_mode(watchdog_watchdogtimer_obj_t *self, watchdog_w
         }
         nrfx_wdt_enable(&wdt);
         nrfx_wdt_feed(&wdt);
+    } else if (current_mode == WATCHDOGMODE_RESET) {
+        // raise exception on attempt to set mode back from RESET to None
+        mp_raise_RuntimeError(MP_ERROR_TEXT("WatchDogTimer cannot be deinitialized once mode is set to RESET"));
+
     }
 
     // If we just switched away from RAISE, disable the timmer.

--- a/ports/nordic/common-hal/watchdog/WatchDogTimer.c
+++ b/ports/nordic/common-hal/watchdog/WatchDogTimer.c
@@ -161,7 +161,7 @@ void common_hal_watchdog_set_mode(watchdog_watchdogtimer_obj_t *self, watchdog_w
         }
         nrfx_wdt_enable(&wdt);
         nrfx_wdt_feed(&wdt);
-    } else if (current_mode == WATCHDOGMODE_RESET) {
+    } else if (new_mode == WATCHDOGMODE_NONE && current_mode == WATCHDOGMODE_RESET) {
         // raise exception on attempt to set mode back from RESET to None
         mp_raise_RuntimeError(MP_ERROR_TEXT("WatchDogTimer cannot be deinitialized once mode is set to RESET"));
 


### PR DESCRIPTION
On nordic port it is not possible to stop the watchdog peripheral after it has been activated in RESET mode. 

The existing implementation has two issues: 

1) It is trying to to handle raising an exception to the user from deinit(), but nothing in the python API was ever calling deinit(). Setting `mode = None` was seeming to succeed, it doesn't raise, and checking `mode` after setting to `None` does indeed return it as `None` but the watchdog is still activated and the bite will still reset.

2) The way that the exception handling that is in deinit() works causes the path that calls it when the watchdog is activated from boot.py to hard crash with this error after boot.py runs:
```
You are in safe mode because:
CircuitPython core code crashed hard. Whoops!
NLR jump failed. Likely memory corruption.
Please file an issue with your program at github.com/adafruit/circuitpython/issues.
Press reset to exit safe mode.
```

At this point the watchdog is still activated and the impending bite will reset the device again into safemode with reason WATCHDOG which will then prevent boot.py from running stopping the execution.

Fixed by removing the handling from `deinit()` and instead do it if/when the user attempts to set `mode = None`. With this change the user now gets a proper exception raised when they attempt to deactivate the watchdog from RESET mode, and the deinit() that happens after boot.py no longer causes the hard crash.
