### PR TITLE
espressif: Don't drop Characteristic.value notifications under load

### DIFF
--- a/locale/circuitpython.pot
+++ b/locale/circuitpython.pot
@@ -1198,7 +1198,8 @@ msgid "Value length > max_length"
 msgstr ""
 
 #: ports/espressif/common-hal/_bleio/Characteristic.c
-msgid "Too many descriptors"
+#: ports/espressif/common-hal/_bleio/Service.c
+msgid "Too many %q"
 msgstr ""
 
 #: ports/espressif/common-hal/_bleio/Characteristic.c

--- a/ports/espressif/common-hal/_bleio/Adapter.c
+++ b/ports/espressif/common-hal/_bleio/Adapter.c
@@ -331,6 +331,7 @@ static void _new_connection(uint16_t conn_handle, bool user_owned) {
     connection->conn_handle = conn_handle;
     connection->connection_obj = mp_const_none;
     connection->pair_status = PAIR_NOT_PAIRED;
+    connection->indicate_outstanding = false;
     connection->mtu = 0;
     connection->user_owned = user_owned;
 

--- a/ports/espressif/common-hal/_bleio/Adapter.h
+++ b/ports/espressif/common-hal/_bleio/Adapter.h
@@ -17,9 +17,13 @@
 
 #include "supervisor/background_callback.h"
 
+#include "sdkconfig.h"
+
 #ifndef BLEIO_TOTAL_CONNECTION_COUNT
-#define BLEIO_TOTAL_CONNECTION_COUNT 5
+#define BLEIO_TOTAL_CONNECTION_COUNT CONFIG_BT_NIMBLE_MAX_CONNECTIONS
 #endif
+// Do not allow more connections than NimBLE was configured for.
+MP_STATIC_ASSERT(BLEIO_TOTAL_CONNECTION_COUNT <= CONFIG_BT_NIMBLE_MAX_CONNECTIONS);
 
 #define BLEIO_HANDLE_INVALID     0xffff
 

--- a/ports/espressif/common-hal/_bleio/Characteristic.c
+++ b/ports/espressif/common-hal/_bleio/Characteristic.c
@@ -443,7 +443,7 @@ void common_hal_bleio_characteristic_add_descriptor(bleio_characteristic_obj_t *
     bleio_descriptor_obj_t *descriptor) {
     size_t i = self->descriptor_list->len;
     if (i >= MAX_DESCRIPTORS) {
-        mp_raise_bleio_BluetoothError(MP_ERROR_TEXT("Too many descriptors"));
+        mp_raise_bleio_BluetoothError(MP_ERROR_TEXT("Too many %q"), MP_QSTR_descriptors);
     }
 
     mp_obj_list_append(MP_OBJ_FROM_PTR(self->descriptor_list),

--- a/ports/espressif/common-hal/_bleio/Characteristic.c
+++ b/ports/espressif/common-hal/_bleio/Characteristic.c
@@ -23,6 +23,98 @@
 
 static int characteristic_on_ble_gap_evt(struct ble_gap_event *event, void *param);
 
+// A local characteristic that can notify or indicate registers an event handler
+// whose storage is the characteristic object itself. NimBLE's GATT table
+// holds a pointer to the object as its access-callback arg. Both stay valid
+// because the characteristic's Service is retained while NimBLE knows about
+// it, and the Service holds its characteristics; see Service.c.
+
+// Remember or forget a peer's subscription. NimBLE reports cur_notify and
+// cur_indicate both clear when the peer writes zero to the CCCD and when the
+// connection ends, so this handles disconnects too.
+static void characteristic_set_subscription(bleio_characteristic_obj_t *self,
+    uint16_t conn_handle, bool notify, bool indicate) {
+    size_t free_slot = BLEIO_TOTAL_CONNECTION_COUNT;
+    for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
+        if (self->subscribers[i].conn_handle == conn_handle) {
+            if (notify || indicate) {
+                self->subscribers[i].notify = notify;
+                self->subscribers[i].indicate = indicate;
+            } else {
+                self->subscribers[i].conn_handle = BLEIO_HANDLE_INVALID;
+            }
+            return;
+        }
+        if (free_slot == BLEIO_TOTAL_CONNECTION_COUNT &&
+            self->subscribers[i].conn_handle == BLEIO_HANDLE_INVALID) {
+            free_slot = i;
+        }
+    }
+    if ((notify || indicate) && free_slot < BLEIO_TOTAL_CONNECTION_COUNT) {
+        self->subscribers[free_slot].conn_handle = conn_handle;
+        self->subscribers[free_slot].notify = notify;
+        self->subscribers[free_slot].indicate = indicate;
+    }
+}
+
+// Send one notification or indication. The send may return BLE_HS_ENOMEM, which
+// could mean an empty mbuf pool or exhausted controller buffers.
+// Both are transient and go away once the radio finishes sending other
+// data, so wait them out instead of losing the value.
+// NimBLE consumes the mbuf even when the send fails, so we need to build
+// a fresh one for each attempt.
+// The retry makes progress even from a background callback,
+// because the draining is done by the nimble_host task, not by background callbacks.
+static void characteristic_notify_indicate(bleio_characteristic_obj_t *self,
+    uint16_t conn_handle, mp_buffer_info_t *bufinfo, bool indicate) {
+    while (!mp_hal_is_interrupted()) {
+        struct os_mbuf *om = ble_hs_mbuf_from_flat(bufinfo->buf, bufinfo->len);
+        if (om != NULL) {
+            bleio_connection_internal_t *connection = NULL;
+            if (indicate) {
+                // NimBLE allows only one outstanding indication per connection and
+                // does not check in ble_gatts_indicate_custom(): a second one
+                // trips BLE_HS_DBG_ASSERT and corrupts the acknowledgment
+                // bookkeeping, so don't send a second one.
+                // Wait for the previous acknowledgment.
+                connection = bleio_conn_handle_to_connection(conn_handle);
+                if (connection == NULL) {
+                    os_mbuf_free_chain(om);
+                    return;
+                }
+                while (connection->indicate_outstanding &&
+                       connection->conn_handle == conn_handle &&
+                       !mp_hal_is_interrupted()) {
+                    RUN_BACKGROUND_TASKS;
+                }
+                if (connection->conn_handle != conn_handle || mp_hal_is_interrupted()) {
+                    os_mbuf_free_chain(om);
+                    return;
+                }
+                // Set before submitting: the acknowledgment can preempt this
+                // task the moment the indication is on the air.
+                connection->indicate_outstanding = true;
+            }
+            const int rc = indicate
+                ? ble_gatts_indicate_custom(conn_handle, self->handle, om)
+                : ble_gatts_notify_custom(conn_handle, self->handle, om);
+            if (indicate && rc != NIMBLE_OK) {
+                // Never submitted, so no acknowledgment will clear it.
+                connection->indicate_outstanding = false;
+            }
+            if (rc == NIMBLE_OK) {
+                return;
+            }
+            if (rc != BLE_HS_ENOMEM) {
+                // Not a transient memory shortage. The peer is gone, or refused.
+                // These failures are not reported back to Python.
+                return;
+            }
+        }
+        RUN_BACKGROUND_TASKS;
+    }
+}
+
 void common_hal_bleio_characteristic_construct(bleio_characteristic_obj_t *self, bleio_service_obj_t *service,
     uint16_t handle, bleio_uuid_obj_t *uuid, bleio_characteristic_properties_t props,
     bleio_attribute_security_mode_t read_perm, bleio_attribute_security_mode_t write_perm,
@@ -33,6 +125,9 @@ void common_hal_bleio_characteristic_construct(bleio_characteristic_obj_t *self,
     self->handle = BLEIO_HANDLE_INVALID;
     self->cccd_handle = BLEIO_HANDLE_INVALID;
     self->sccd_handle = BLEIO_HANDLE_INVALID;
+    for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
+        self->subscribers[i].conn_handle = BLEIO_HANDLE_INVALID;
+    }
     self->props = props;
     self->read_perm = read_perm;
     self->write_perm = write_perm;
@@ -115,6 +210,11 @@ void common_hal_bleio_characteristic_construct(bleio_characteristic_obj_t *self,
         ble_event_add_handler_entry(&self->event_handler_entry, characteristic_on_ble_gap_evt, self);
     } else {
         common_hal_bleio_service_add_characteristic(self->service, self, initial_value_bufinfo, user_description);
+        if ((props & (CHAR_PROP_NOTIFY | CHAR_PROP_INDICATE)) != 0) {
+            // Remember who subscribes: BLE_GAP_EVENT_SUBSCRIBE is the only report
+            // of that, and set_value() notifies subscribers and no one else.
+            ble_event_add_handler_entry(&self->event_handler_entry, characteristic_on_ble_gap_evt, self);
+        }
     }
 }
 
@@ -126,6 +226,12 @@ void common_hal_bleio_characteristic_deinit(bleio_characteristic_obj_t *self) {
     if (common_hal_bleio_characteristic_deinited(self)) {
         return;
     }
+    // Take the characteristic off the event list before cleaning up the object.
+    ble_event_remove_handler(characteristic_on_ble_gap_evt, self);
+    for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
+        self->subscribers[i].conn_handle = BLEIO_HANDLE_INVALID;
+    }
+
     if (self->current_value != NULL) {
         if (gc_ptr_on_heap(self->current_value)) {
             m_free(self->current_value);
@@ -200,7 +306,25 @@ void common_hal_bleio_characteristic_set_value(bleio_characteristic_obj_t *self,
         self->current_value_len = bufinfo->len;
         memcpy(self->current_value, bufinfo->buf, self->current_value_len);
 
-        ble_gatts_chr_updated(self->handle);
+        // Notify and indicate subscribers here rather than by using
+        // ble_gatts_chr_updated(). That function cannot report a failed send,
+        // so we can't tell whether we succeeded or not.
+        //
+        // Unlike ble_gatts_chr_updated(), this does not persist a "changed"
+        // flag for bonded peers that are currently disconnected, so they are
+        // not notified on reconnect. This matches the nordic port.
+        for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {
+            const uint16_t conn_handle = self->subscribers[i].conn_handle;
+            if (conn_handle == BLEIO_HANDLE_INVALID) {
+                continue;
+            }
+            if (self->subscribers[i].notify && (self->props & CHAR_PROP_NOTIFY) != 0) {
+                characteristic_notify_indicate(self, conn_handle, bufinfo, false);
+            }
+            if (self->subscribers[i].indicate && (self->props & CHAR_PROP_INDICATE) != 0) {
+                characteristic_notify_indicate(self, conn_handle, bufinfo, true);
+            }
+        }
     }
 }
 
@@ -232,7 +356,26 @@ static int characteristic_on_ble_gap_evt(struct ble_gap_event *event, void *para
             }
             break;
         }
+        case BLE_GAP_EVENT_NOTIFY_TX:
+            // For indications only: BLE_HS_EDONE is the peer's acknowledgment
+            // and BLE_HS_ETIMEOUT is the stack giving up on getting one. Either way,
+            // the connection's single indication slot is free again.
+            if (event->notify_tx.indication != 0 &&
+                event->notify_tx.attr_handle == self->handle &&
+                (event->notify_tx.status == BLE_HS_EDONE ||
+                 event->notify_tx.status == BLE_HS_ETIMEOUT)) {
+                bleio_connection_internal_t *connection =
+                    bleio_conn_handle_to_connection(event->notify_tx.conn_handle);
+                if (connection != NULL) {
+                    connection->indicate_outstanding = false;
+                }
+            }
+            break;
         case BLE_GAP_EVENT_SUBSCRIBE:
+            if (event->subscribe.attr_handle == self->handle) {
+                characteristic_set_subscription(self, event->subscribe.conn_handle,
+                    event->subscribe.cur_notify != 0, event->subscribe.cur_indicate != 0);
+            }
             break;
         default:
             return 0;

--- a/ports/espressif/common-hal/_bleio/Characteristic.h
+++ b/ports/espressif/common-hal/_bleio/Characteristic.h
@@ -10,6 +10,7 @@
 #include "shared-bindings/_bleio/Attribute.h"
 #include "common-hal/_bleio/Descriptor.h"
 #include "shared-module/_bleio/Characteristic.h"
+#include "common-hal/_bleio/Adapter.h"
 #include "common-hal/_bleio/ble_events.h"
 #include "common-hal/_bleio/Service.h"
 #include "common-hal/_bleio/UUID.h"
@@ -40,6 +41,18 @@ typedef struct _bleio_characteristic_obj {
     uint16_t user_desc_handle;
     uint16_t cccd_handle;
     uint16_t sccd_handle;
+    // Track currently subscribed peers. NimBLE in the current ESP-IDF offers
+    // no way to read a peer's CCCD, and notifying without checking would
+    // send to peers that never asked. NimBLE reports subscriptions with both
+    // flags clear on CCCD clears and on disconnect, so entries free themselves.
+    // One subscription per connection at most, hence BLEIO_TOTAL_CONNECTION_COUNT.
+    // TODO when NimBLE is updated to 1.9.0 or later: ble_gatts_read_cccd()
+    // reads the CCCD directly, and this table can go away.
+    struct {
+        uint16_t conn_handle;
+        bool notify;
+        bool indicate;
+    } subscribers[BLEIO_TOTAL_CONNECTION_COUNT];
     ble_event_handler_entry_t event_handler_entry;
     // The actual structure is managed by the service because it needs to have
     // an array.

--- a/ports/espressif/common-hal/_bleio/Connection.h
+++ b/ports/espressif/common-hal/_bleio/Connection.h
@@ -36,6 +36,10 @@ typedef struct {
     // connections are disconnected when the VM resets; the BLE workflow connection
     // is not user-owned and stays up.
     bool user_owned;
+    // An indication we sent from characteristic_notify_indicate() awaits its
+    // acknowledgment or timeout. NimBLE allows one outstanding indication per
+    // connection, shared across all characteristics.
+    volatile bool indicate_outstanding;
     // Remote services discovered when this peripheral is acting as a client.
     mp_obj_list_t *remote_service_list;
     // The advertising data and scan response buffers are held by us, not by the SD, so we must

--- a/ports/espressif/common-hal/_bleio/PacketBuffer.c
+++ b/ports/espressif/common-hal/_bleio/PacketBuffer.c
@@ -603,13 +603,15 @@ void common_hal_bleio_packet_buffer_deinit(bleio_packet_buffer_obj_t *self) {
     if (common_hal_bleio_packet_buffer_deinited(self)) {
         return;
     }
+    // Take the packet buffer off the event list before changing anything
+    // inside the object.
+    ble_event_remove_handler(packet_buffer_on_ble_client_evt, self);
     bleio_characteristic_clear_observer(self->characteristic);
     self->characteristic = NULL;
-    // A still-queued retry_send_callback sees the NULL characteristic
-    // (deinited) and does nothing.
+    // A still-queued retry_send_callback checks deinited(), so it sees the
+    // NULL characteristic and does nothing.
     self->pending_size = 0;
     self->packet_queued = false;
-    ble_event_remove_handler(packet_buffer_on_ble_client_evt, self);
     ringbuf_deinit(&self->ringbuf);
 }
 

--- a/ports/espressif/common-hal/_bleio/Service.c
+++ b/ports/espressif/common-hal/_bleio/Service.c
@@ -8,6 +8,7 @@
 #include "py/gc.h"
 #include "py/runtime.h"
 #include "common-hal/_bleio/__init__.h"
+#include "shared-bindings/_bleio/__init__.h"
 #include "shared-bindings/_bleio/Characteristic.h"
 #include "shared-bindings/_bleio/Descriptor.h"
 #include "shared-bindings/_bleio/Service.h"
@@ -150,13 +151,18 @@ void common_hal_bleio_service_add_characteristic(bleio_service_obj_t *self,
     bleio_characteristic_obj_t *characteristic,
     mp_buffer_info_t *initial_value_bufinfo,
     const char *user_description) {
+    // Don't overflow chr_defs table.
+    size_t i = self->characteristic_list->len;
+    if (i >= MAX_CHARACTERISTIC_COUNT) {
+        mp_raise_bleio_BluetoothError(MP_ERROR_TEXT("Too many %q"), MP_QSTR_characteristics);
+    }
+
     mp_obj_list_append(self->characteristic_list, MP_OBJ_FROM_PTR(characteristic));
 
     if (user_description != NULL) {
         mp_raise_NotImplementedError_varg(MP_ERROR_TEXT("Invalid %q"), MP_QSTR_user_description);
     }
 
-    size_t i = self->characteristic_list->len - 1;
     self->chr_defs[i].uuid = &characteristic->uuid->nimble_ble_uuid.u;
     self->chr_defs[i].access_cb = bleio_characteristic_access_cb;
     self->chr_defs[i].arg = characteristic;

--- a/ports/espressif/common-hal/_bleio/Service.c
+++ b/ports/espressif/common-hal/_bleio/Service.c
@@ -5,6 +5,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include "py/gc.h"
 #include "py/runtime.h"
 #include "common-hal/_bleio/__init__.h"
 #include "shared-bindings/_bleio/Characteristic.h"
@@ -13,6 +14,51 @@
 #include "shared-bindings/_bleio/Adapter.h"
 
 #include "host/ble_gatt.h"
+
+// NimBLE's GATT table keeps raw pointers into a registered local service and
+// everything under it: the chr_defs array lives inside the service object, each
+// characteristic and descriptor is an access-callback argument, and every UUID
+// is referenced by address. Collecting any of them would leave those dangling,
+// so retain a heap Service here for as long as NimBLE knows about it.
+// Retaining the service is enough because it holds its characteristics,
+// which hold their descriptors. Services in static storage, like the BLE workflow's,
+// cannot be collected and are skipped.
+static bleio_service_obj_t *_retained_services;
+
+static void service_retain(bleio_service_obj_t *self) {
+    if (!gc_ptr_on_heap((void *)self)) {
+        return;
+    }
+    for (bleio_service_obj_t *it = _retained_services; it != NULL; it = it->next_retained) {
+        if (it == self) {
+            return;
+        }
+    }
+    self->next_retained = _retained_services;
+    _retained_services = self;
+}
+
+static void service_release(bleio_service_obj_t *self) {
+    bleio_service_obj_t **prev = &_retained_services;
+    for (bleio_service_obj_t *it = *prev; it != NULL; it = it->next_retained) {
+        if (it == self) {
+            *prev = it->next_retained;
+            it->next_retained = NULL;
+            return;
+        }
+        prev = &it->next_retained;
+    }
+}
+
+void bleio_service_forget_retained(void) {
+    _retained_services = NULL;
+}
+
+// Mark the retained services. One pointer is enough: the GC traces
+// next_retained through the rest of the chain from the head.
+void bleio_service_gc_collect(void) {
+    gc_collect_ptr(_retained_services);
+}
 
 uint32_t _common_hal_bleio_service_construct(bleio_service_obj_t *self, bleio_uuid_obj_t *uuid, bool is_secondary, mp_obj_list_t *characteristic_list) {
     self->handle = 0xFFFF;
@@ -27,6 +73,8 @@ uint32_t _common_hal_bleio_service_construct(bleio_service_obj_t *self, bleio_uu
     self->service_def.includes = NULL;
     self->service_def.characteristics = self->chr_defs;
     self->next_svc_type = 0;
+    self->next_retained = NULL;
+    self->registered = false;
 
     // Don't add the service yet because we don't have any characteristics.
     return 0;
@@ -38,9 +86,21 @@ void common_hal_bleio_service_construct(bleio_service_obj_t *self, bleio_uuid_ob
 }
 
 void common_hal_bleio_service_deinit(bleio_service_obj_t *self) {
-    // Delete the old version of the service.
-    if (self->characteristic_list->len > 1) {
+    // Take the service out of NimBLE's GATT table first, so nothing torn down
+    // below is still reachable from it.
+    if (self->registered) {
         ble_gatts_delete_svc(&self->uuid->nimble_ble_uuid.u);
+        self->registered = false;
+    }
+    // NimBLE no longer refers to this service, so stop retaining it, and deinit
+    // the characteristics: a local one that can notify or indicate holds an
+    // event handler that must come off the event list with it.
+    service_release(self);
+    if (!self->is_remote) {
+        for (size_t i = 0; i < self->characteristic_list->len; i++) {
+            common_hal_bleio_characteristic_deinit(
+                MP_OBJ_TO_PTR(self->characteristic_list->items[i]));
+        }
     }
     self->service_def.type = 0;
 }
@@ -50,6 +110,7 @@ void bleio_service_from_connection(bleio_service_obj_t *self, mp_obj_t connectio
     self->uuid = NULL;
     self->characteristic_list = mp_obj_new_list(0, NULL);
     self->is_remote = true;
+    self->registered = false;
     self->is_secondary = false;
     self->connection = connection;
 }
@@ -70,13 +131,18 @@ bool common_hal_bleio_service_get_is_secondary(bleio_service_obj_t *self) {
     return self->is_secondary;
 }
 
-// Used by characteristics to update their descriptors.
+// Register the service, or register it again after its definition changed:
+// NimBLE cannot amend a service that is already in its GATT table, so the old
+// version is deleted and the whole service added again.
 void bleio_service_readd(bleio_service_obj_t *self) {
-    // Delete the old version of the service.
-    if (self->characteristic_list->len > 1) {
+    if (self->registered) {
         ble_gatts_delete_svc(&self->uuid->nimble_ble_uuid.u);
+        self->registered = false;
     }
     CHECK_NIMBLE_ERROR(ble_gatts_add_dynamic_svcs(&self->service_def));
+    self->registered = true;
+    // NimBLE now refers to this service and everything under it.
+    service_retain(self);
 }
 
 
@@ -90,10 +156,6 @@ void common_hal_bleio_service_add_characteristic(bleio_service_obj_t *self,
         mp_raise_NotImplementedError_varg(MP_ERROR_TEXT("Invalid %q"), MP_QSTR_user_description);
     }
 
-    // Delete the old version of the service.
-    if (self->characteristic_list->len > 1) {
-        ble_gatts_delete_svc(&self->uuid->nimble_ble_uuid.u);
-    }
     size_t i = self->characteristic_list->len - 1;
     self->chr_defs[i].uuid = &characteristic->uuid->nimble_ble_uuid.u;
     self->chr_defs[i].access_cb = bleio_characteristic_access_cb;
@@ -106,5 +168,5 @@ void common_hal_bleio_service_add_characteristic(bleio_service_obj_t *self,
     self->chr_defs[i + 1].uuid = NULL;
     characteristic->chr_def = &self->chr_defs[i];
 
-    CHECK_NIMBLE_ERROR(ble_gatts_add_dynamic_svcs(&self->service_def));
+    bleio_service_readd(self);
 }

--- a/ports/espressif/common-hal/_bleio/Service.h
+++ b/ports/espressif/common-hal/_bleio/Service.h
@@ -21,6 +21,9 @@ typedef struct bleio_service_obj {
     // True if created during discovery.
     bool is_remote;
     bool is_secondary;
+    // True while NimBLE's GATT table holds this service: it must be deleted
+    // before the definition is changed or the service is torn down.
+    bool registered;
     bleio_uuid_obj_t *uuid;
     // The connection object is set only when this is a remote service.
     // A local service doesn't know the connection.
@@ -33,7 +36,17 @@ typedef struct bleio_service_obj {
     // Include a spot for terminating the service def array.
     uint8_t next_svc_type;
     struct ble_gatt_chr_def chr_defs[MAX_CHARACTERISTIC_COUNT + 1];
+    // Link in the list of services retained while NimBLE's GATT table refers
+    // to them; see Service.c. NULL when not on that list.
+    struct bleio_service_obj *next_retained;
 } bleio_service_obj_t;
 
 void bleio_service_from_connection(bleio_service_obj_t *self, mp_obj_t connection);
 void bleio_service_readd(bleio_service_obj_t *self);
+
+// Stop retaining every service. Call when the heap they live on is about to go
+// away.
+void bleio_service_forget_retained(void);
+
+// Mark the retained services as reachable during a GC pass.
+void bleio_service_gc_collect(void);

--- a/ports/espressif/common-hal/_bleio/__init__.c
+++ b/ports/espressif/common-hal/_bleio/__init__.c
@@ -61,6 +61,9 @@ void bleio_user_reset(void) {
 
     // Also clean up event handlers that are on the heap.
     ble_event_remove_heap_handlers();
+    // And stop retaining heap services, whose characteristics' handler entries
+    // the call above just removed.
+    bleio_service_forget_retained();
 
     // Maybe start advertising the BLE workflow.
     supervisor_bluetooth_background();
@@ -128,6 +131,7 @@ void common_hal_bleio_init(void) {
 
 void common_hal_bleio_gc_collect(void) {
     bleio_adapter_gc_collect(&common_hal_bleio_adapter_obj);
+    bleio_service_gc_collect();
 }
 
 void check_nimble_error(int rc, const char *file, size_t line) {

--- a/ports/espressif/common-hal/_bleio/ble_events.c
+++ b/ports/espressif/common-hal/_bleio/ble_events.c
@@ -11,6 +11,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#include "freertos/FreeRTOS.h"
+
 #include "py/gc.h"
 #include "py/misc.h"
 #include "py/mpstate.h"
@@ -20,15 +22,21 @@
 #include "supervisor/shared/bluetooth/serial.h"
 #endif
 
+// Do event list manipulation in a critical section.
+static portMUX_TYPE handler_list_mutex = portMUX_INITIALIZER_UNLOCKED;
+
 void ble_event_reset(void) {
     // Linked list items will be gc'd.
+    portENTER_CRITICAL(&handler_list_mutex);
     MP_STATE_VM(ble_event_handler_entries) = NULL;
+    portEXIT_CRITICAL(&handler_list_mutex);
 }
 
 void ble_event_remove_heap_handlers(void) {
     ble_event_handler_entry_t *it = MP_STATE_VM(ble_event_handler_entries);
     while (it != NULL) {
-        // Save it->next before removing, because removing clears it.
+        // Save it->next before removing: the entry may be reused and relinked
+        // once it is off the list.
         ble_event_handler_entry_t *next = it->next;
         // Remove the handler if the entry or its param is on the heap, which is
         // about to go away.
@@ -41,10 +49,12 @@ void ble_event_remove_heap_handlers(void) {
 
 void ble_event_add_handler_entry(ble_event_handler_entry_t *entry,
     ble_gap_event_fn *func, void *param) {
+    portENTER_CRITICAL(&handler_list_mutex);
     ble_event_handler_entry_t *it = MP_STATE_VM(ble_event_handler_entries);
     while (it != NULL) {
         // If event handler and its corresponding param are already on the list, don't add again.
         if ((it->func == func) && (it->param == param)) {
+            portEXIT_CRITICAL(&handler_list_mutex);
             return;
         }
         it = it->next;
@@ -54,12 +64,17 @@ void ble_event_add_handler_entry(ble_event_handler_entry_t *entry,
     entry->func = func;
 
     MP_STATE_VM(ble_event_handler_entries) = entry;
+    portEXIT_CRITICAL(&handler_list_mutex);
 }
 
 void ble_event_add_handler(ble_gap_event_fn *func, void *param) {
+    // Not in a critical section on purpose: this scan only avoids the
+    // allocation below when the handler is already registered.
+    // ble_event_add_handler_entry() repeats it in the critical section and is
+    // the one that decides. The allocation must stay outside, because it can
+    // collect or raise.
     ble_event_handler_entry_t *it = MP_STATE_VM(ble_event_handler_entries);
     while (it != NULL) {
-        // If event handler and its corresponding param are already on the list, don't add again.
         if ((it->func == func) && (it->param == param)) {
             return;
         }
@@ -72,19 +87,23 @@ void ble_event_add_handler(ble_gap_event_fn *func, void *param) {
 }
 
 void ble_event_remove_handler(ble_gap_event_fn *func, void *param) {
+    portENTER_CRITICAL(&handler_list_mutex);
     ble_event_handler_entry_t *it = MP_STATE_VM(ble_event_handler_entries);
     ble_event_handler_entry_t **prev = &MP_STATE_VM(ble_event_handler_entries);
     while (it != NULL) {
         if ((it->func == func) && (it->param == param)) {
-            // Splice out the matching handler.
+            // Splice out the matching handler. Leave its next pointer alone:
+            // another walk in progress may already be holding this node as its
+            // cursor. Clearing next would end that walk here, dropping the
+            // event for every handler after it.
             *prev = it->next;
-            // Clear next of the removed node so it's clearly not in a list.
-            it->next = NULL;
+            portEXIT_CRITICAL(&handler_list_mutex);
             return;
         }
         prev = &(it->next);
         it = it->next;
     }
+    portEXIT_CRITICAL(&handler_list_mutex);
 }
 
 int ble_event_run_handlers(struct ble_gap_event *event) {
@@ -96,12 +115,20 @@ int ble_event_run_handlers(struct ble_gap_event *event) {
     mp_printf(&mp_plat_print, "BLE GAP event: 0x%04x\n", event->type);
     #endif
 
+    portENTER_CRITICAL(&handler_list_mutex);
     ble_event_handler_entry_t *it = MP_STATE_VM(ble_event_handler_entries);
+    portEXIT_CRITICAL(&handler_list_mutex);
     bool done = false;
     while (it != NULL) {
-        // Capture next before calling the function in case it removes itself from the list.
+        // Take a consistent snapshot of the node, including next, before
+        // calling the function: the function may remove itself from the list,
+        // and so may the VM task while the call runs.
+        portENTER_CRITICAL(&handler_list_mutex);
         ble_event_handler_entry_t *next = it->next;
-        done = it->func(event, it->param) || done;
+        ble_gap_event_fn *func = it->func;
+        void *param = it->param;
+        portEXIT_CRITICAL(&handler_list_mutex);
+        done = func(event, param) || done;
         it = next;
     }
     #if CIRCUITPY_BLE_SERIAL_SERVICE && CIRCUITPY_VERBOSE_BLE


### PR DESCRIPTION
Code written by Claude Code, guided and corrected by @dhalbert.

@dhalbert says: I rewrote this post heavily for length and clarity, so it's worth reading. I also reviewed the code and rephrased the comments in the same way. The changes here have gone through four quite different solutions before arriving at what was done here.  (The commit message is up to date, but was not edited, and contains gory details for posterity.)

#### The problem

On espressif, setting `Characteristic.value` on a local characteristic with NOTIFY or INDICATE silently drops values whenever other BLE traffic interferes. For example, when `ble_uart_echo_test.py` echos to the Bluefruit Connect app, it only sends the first two characters of, say, "1234", because the REPL's own output over the BLE workflow is competing for the radio's buffers.

This is a long-standing bug on espressif. It's not a problem on nordic, because the nordic code sends each assigned value itself and retries while the SoftDevice's buffers are full.

On espressif, setting `.value` currently uses `ble_gatts_chr_updated()`. That routine is optimistic: it clears its per-characteristic "modified" flag before attempting the send and also does not look at whether the send succeeded. If the radio is busy, the send will get a transient `BLE_HS_ENOMEM`. So the value change is silently lost.

#### The fix

Do what nordic does: send notifications and indications for the new bytes explicitly. If there's a `BLE_HS_ENOMEM`, retry until it succeeds. Wait for each indication acknowledgment before sending the next one. For indications, use `ble_gatts_indicate_custom()`.

To do this we also have to know about INDICATE and NOTIFY subscriptions from the remote peer. Unfortunately, there's no API in the NimBLE version ESP-IDF uses to get that info. So the fix records subscriptions itself, per characteristic, from the subscribe events NimBLE does report. It also retains a heap-allocated `Service` for as long as NimBLE's GATT table refers to it.

(In Nimble 1.9.0, there _is_ an API to read a peer's CCCD, so we wouldn't have to record subscriptions ourselves. But ESP-IDF is on Nimble 1.6.0 and shows no signs of an imminent update.)

Also in this PR, because we needed these things to make the changes correct and fix existing related bugs:
- New code to deinit the `Characteristic`s and their `Descriptor`s when the `Service` that holds them is deinited. Before this, Characteristics were not deinited, and would accumulate until the VM shut down.
- A `Service` now records whether NimBLE has it registered, instead of inferring that from its characteristic count.
- Take objects off the BLE event handler list first in their deinit() routines, to avoid any races.
- Add critical sections to BLE event handler list manipulation.
- `BLEIO_TOTAL_CONNECTION_COUNT` now comes from `CONFIG_BT_NIMBLE_MAX_CONNECTIONS`.

#### Behavior change

`ble_gatts_chr_updated()` also persisted a "changed" flag so a bonded peer that was disconnected at assignment time would be notified on reconnect. With this PR, that no longer happens. Nordic never did either, so the ports now agree.

#### Testing

Metro ESP32-S3 with Bluefruit Connect:
- `ble_uart_echo_test.py` now sends every character, even when REPL print traffic is also being sent.
- Repeatedly interrupting one copy of the echo program and importing another copy with the peer still connected no longer hard faults; it does raise `MemoryError: Nimble out of memory`. That is a different problem we know about and may address later.
- Reload and reconnect work.
