### PR TITLE
Use dummy SDL video driver for native sim

### DIFF
--- a/main.c
+++ b/main.c
@@ -647,6 +647,11 @@ static bool __attribute__((noinline)) run_code_py(safe_mode_t safe_mode, bool *s
             print_safe_mode_message(safe_mode);
             serial_write("\r\n");
             serial_write_compressed(MP_ERROR_TEXT("Press any key to enter the REPL. Use CTRL-D to reload.\n"));
+            if (safe_mode != SAFE_MODE_NONE) {
+                // Reset the port again in safe mode. It doesn't usually do much but
+                // the Zephyr native_sim tests use it for tracking test completion.
+                reset_port();
+            }
             printed_press_any_key = true;
         }
         if (!serial_connected()) {

--- a/ports/zephyr-cp/boards/native/native_sim/board.conf
+++ b/ports/zephyr-cp/boards/native/native_sim/board.conf
@@ -20,6 +20,8 @@ CONFIG_I2C_EMUL=y
 # Display emulation for display/terminal golden tests.
 CONFIG_DISPLAY=y
 CONFIG_SDL_DISPLAY=y
+# Don't require hardware acceleration so the software renderer can be used.
+CONFIG_SDL_DISPLAY_USE_HARDWARE_ACCELERATOR=n
 
 # EEPROM emulation for testing
 CONFIG_EEPROM=y

--- a/ports/zephyr-cp/common-hal/microcontroller/Processor.c
+++ b/ports/zephyr-cp/common-hal/microcontroller/Processor.c
@@ -81,6 +81,21 @@ void common_hal_mcu_processor_get_uid(uint8_t raw_id[]) {
 }
 
 mcu_reset_reason_t common_hal_mcu_processor_get_reset_reason(void) {
-    mcu_reset_reason_t r = MCU_RESET_REASON_UNKNOWN;
-    return r;
+    #if defined(CONFIG_HWINFO)
+    uint32_t cause = 0;
+    if (hwinfo_get_reset_cause(&cause) == 0) {
+        if (cause & RESET_POR) {
+            return MCU_RESET_REASON_POWER_ON;
+        } else if (cause & RESET_SOFTWARE) {
+            return MCU_RESET_REASON_SOFTWARE;
+        } else if (cause & RESET_WATCHDOG) {
+            return MCU_RESET_REASON_WATCHDOG;
+        } else if (cause & RESET_BROWNOUT) {
+            return MCU_RESET_REASON_BROWNOUT;
+        } else if (cause & RESET_PIN) {
+            return MCU_RESET_REASON_RESET_PIN;
+        }
+    }
+    #endif
+    return MCU_RESET_REASON_UNKNOWN;
 }

--- a/ports/zephyr-cp/supervisor/port.c
+++ b/ports/zephyr-cp/supervisor/port.c
@@ -64,31 +64,35 @@ static struct k_timer tick_timer;
 // Number of VM runs before exiting.
 // <= 0 means run forever.
 // INT32_MAX means option was not provided.
-static int32_t native_sim_vm_runs = INT32_MAX;
+static int32_t native_sim_port_resets = INT32_MAX;
 static uint32_t native_sim_reset_port_count = 0;
 
 // Path to a file used to preserve retained memory across the execv reboot, or
 // NULL if disabled. Set with --retained-memory=<path> (see
-// cp_saved_word_save/restore()). Currently persists the safe-mode saved word;
-// intended to also preserve sleep RAM in the future.
+// cp_retained_save/restore()).
 static const char *native_sim_retained_memory;
+
+typedef struct {
+    uint32_t saved_word;
+    uint32_t port_reset_count;
+} cp_retained_data_t;
 
 static struct args_struct_t native_sim_port_args[] = {
     {
-        .option = "vm-runs",
+        .option = "port-resets",
         .name = "count",
         .type = 'i',
-        .dest = &native_sim_vm_runs,
-        .descript = "Exit native_sim after this many VM runs. "
-            "Example: --vm-runs=2"
+        .dest = &native_sim_port_resets,
+        .descript = "Exit native_sim after this many port_reset() calls. "
+            "Example: --port-resets=2"
     },
     {
         .option = "retained-memory",
         .name = "path",
         .type = 's',
         .dest = (void *)&native_sim_retained_memory,
-        .descript = "File used to preserve retained memory (e.g. the safe-mode "
-            "saved word) across the process re-exec reboot. "
+        .descript = "File used to preserve some state"
+            " across the process re-exec reboot. "
             "Example: --retained-memory=/tmp/cp_retained.bin"
     },
     ARG_TABLE_ENDMARKER
@@ -163,10 +167,10 @@ uint32_t port_get_saved_word(void) {
     return cp_saved_word;
 }
 
-// Save and restore retained memory across the native_sim/bsim reboot.
-// Opt in with --retained-memory=<path>.
+// Save and restore retained memory across the native_sim/bsim reboot. Opt in
+// with --retained-memory=<path>.
 #if defined(CONFIG_ARCH_POSIX)
-static void cp_saved_word_save(void) {
+static void cp_retained_save(void) {
     const char *path = native_sim_retained_memory;
     if (path == NULL || path[0] == '\0') {
         return;
@@ -175,12 +179,15 @@ static void cp_saved_word_save(void) {
     if (fd < 0) {
         return;
     }
-    uint32_t value = cp_saved_word;
-    (void)nsi_host_write(fd, &value, sizeof(value));
+    cp_retained_data_t data = {
+        .saved_word = cp_saved_word,
+        .port_reset_count = native_sim_reset_port_count,
+    };
+    (void)nsi_host_write(fd, &data, sizeof(data));
     (void)nsi_host_close(fd);
 }
 
-static void cp_saved_word_restore(void) {
+static void cp_retained_restore(void) {
     const char *path = native_sim_retained_memory;
     if (path == NULL || path[0] == '\0') {
         return;
@@ -189,17 +196,17 @@ static void cp_saved_word_restore(void) {
     if (fd < 0) {
         return; // First boot: no save file yet.
     }
-    uint32_t value = 0;
-    (void)nsi_host_read(fd, &value, sizeof(value));
+    cp_retained_data_t data = { 0 };
+    (void)nsi_host_read(fd, &data, sizeof(data));
     (void)nsi_host_close(fd);
-    cp_saved_word = value;
+    cp_saved_word = data.saved_word;
+    native_sim_reset_port_count = data.port_reset_count;
 }
 #endif
 
 safe_mode_t port_init(void) {
     #if defined(CONFIG_ARCH_POSIX)
-    // Restore the saved word (if any) before wait_for_safe_mode_reset reads it.
-    cp_saved_word_restore();
+    cp_retained_restore();
     #endif
 
     // We run CircuitPython at the lowest priority (just higher than idle.)
@@ -213,8 +220,7 @@ safe_mode_t port_init(void) {
 // Reset the microcontroller completely.
 void reset_cpu(void) {
     #if defined(CONFIG_ARCH_POSIX)
-    // Persist the saved word across the process re-exec reboot.
-    cp_saved_word_save();
+    cp_retained_save();
     #endif
 
     // Try a warm reboot first. It won't return if it works but isn't always
@@ -233,10 +239,10 @@ void reset_port(void) {
 
     #if defined(CONFIG_ARCH_POSIX)
     native_sim_reset_port_count++;
-    if (native_sim_vm_runs != INT32_MAX &&
-        native_sim_vm_runs > 0 &&
-        native_sim_reset_port_count >= (uint32_t)(native_sim_vm_runs + 1)) {
-        printk("posix: exiting after %d VM runs\n", native_sim_vm_runs);
+    if (native_sim_port_resets != INT32_MAX &&
+        native_sim_port_resets > 0 &&
+        native_sim_reset_port_count >= (uint32_t)(native_sim_port_resets + 1)) {
+        printk("posix: exiting after %d port resets\n", native_sim_port_resets);
         posix_exit(0);
     }
     #endif

--- a/ports/zephyr-cp/tests/bsim/test_bsim_ble_adapter.py
+++ b/ports/zephyr-cp/tests/bsim/test_bsim_ble_adapter.py
@@ -91,7 +91,7 @@ print("done")
 """
 
 
-@pytest.mark.code_py_runs(2)
+@pytest.mark.port_resets(3)
 @pytest.mark.circuitpy_drive({"code.py": BSIM_ENABLE_RELOAD_CODE})
 def test_bsim_adapter_state_after_reload(bsim_phy, circuitpython):
     """Adapter state is clean after soft reload."""

--- a/ports/zephyr-cp/tests/bsim/test_bsim_ble_advertising.py
+++ b/ports/zephyr-cp/tests/bsim/test_bsim_ble_advertising.py
@@ -145,7 +145,7 @@ def test_bsim_advertise_and_scan(bsim_phy, circuitpython, zephyr_sample):
 
 
 @pytest.mark.zephyr_sample("tests/bsim/samples/observer")
-@pytest.mark.code_py_runs(2)
+@pytest.mark.port_resets(3)
 @pytest.mark.duration(60)
 @pytest.mark.circuitpy_drive({"code.py": BSIM_ADV_INTERRUPT_RELOAD_CODE})
 def test_bsim_advertise_ctrl_c_reload(bsim_phy, circuitpython, zephyr_sample):

--- a/ports/zephyr-cp/tests/bsim/test_bsim_ble_connect.py
+++ b/ports/zephyr-cp/tests/bsim/test_bsim_ble_connect.py
@@ -92,7 +92,7 @@ def test_bsim_connect_zephyr_peripheral(bsim_phy, circuitpython, zephyr_sample):
 
 
 @pytest.mark.zephyr_sample("bluetooth/peripheral_sc_only")
-@pytest.mark.code_py_runs(2)
+@pytest.mark.port_resets(3)
 @pytest.mark.duration(26)
 @pytest.mark.circuitpy_drive({"code.py": BSIM_RECONNECT_CODE})
 def test_bsim_reconnect_zephyr_peripheral(bsim_phy, circuitpython, zephyr_sample):

--- a/ports/zephyr-cp/tests/bsim/test_bsim_ble_scan.py
+++ b/ports/zephyr-cp/tests/bsim/test_bsim_ble_scan.py
@@ -110,7 +110,7 @@ def test_bsim_scan_zephyr_beacon(bsim_phy, circuitpython, zephyr_sample):
 
 
 @pytest.mark.zephyr_sample("bluetooth/beacon")
-@pytest.mark.code_py_runs(2)
+@pytest.mark.port_resets(3)
 @pytest.mark.duration(20)
 @pytest.mark.circuitpy_drive({"code.py": BSIM_SCAN_RELOAD_CODE})
 def test_bsim_scan_zephyr_beacon_reload(bsim_phy, circuitpython, zephyr_sample):

--- a/ports/zephyr-cp/tests/conftest.py
+++ b/ports/zephyr-cp/tests/conftest.py
@@ -49,7 +49,7 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "code_py_runs(count): stop native_sim after count code.py runs (default: 1)",
+        "port_resets(count): stop native_sim after count port_reset()s (default: 2)",
     )
     config.addinivalue_line(
         "markers",
@@ -172,7 +172,12 @@ def native_sim_binary(request, board):
 
 @pytest.fixture
 def native_sim_env() -> dict[str, str]:
-    return {}
+    env = {}
+    # Always pick the video driver explicitly. Always using dummy works in a
+    # bubblewrap sandbox and avoids GL teardown issues on GitHub Actions.
+    if not os.environ.get("SDL_VIDEODRIVER"):
+        env["SDL_VIDEODRIVER"] = "dummy"
+    return env
 
 
 PIXEL_FORMAT_BITMASK = {
@@ -231,11 +236,13 @@ def circuitpython(request, board, sim_id, native_sim_binary, native_sim_env, tmp
     else:
         timeout = marker.args[0]
 
-    runs_marker = request.node.get_closest_marker("code_py_runs")
-    if runs_marker is None:
-        code_py_runs = 1
+    resets_marker = request.node.get_closest_marker("port_resets")
+    # Main does one reset on start up and then one on each VM clean up. It also
+    # does one after printing the safe mode message.
+    if resets_marker is None:
+        port_resets = 2
     else:
-        code_py_runs = int(runs_marker.args[0])
+        port_resets = int(resets_marker.args[0])
 
     display_marker = request.node.get_closest_marker("display")
     if display_marker is None:
@@ -334,12 +341,11 @@ def circuitpython(request, board, sim_id, native_sim_binary, native_sim_env, tmp
                     # encryption tests pass -RealEncryption=1 for the same
                     # reason.
                     "-RealEncryption=1",
-                    f"--vm-runs={code_py_runs + 1}",
+                    f"--port-resets={port_resets}",
                 )
             )
         else:
             cmd = [str(native_sim_binary), f"--flash={flash}"]
-            # native_sim vm-runs includes the boot VM setup run.
             realtime_flag = "-rt" if use_realtime else "-no-rt"
             cmd.extend(
                 (
@@ -347,7 +353,7 @@ def circuitpython(request, board, sim_id, native_sim_binary, native_sim_env, tmp
                     "-display_headless",
                     "-i2s_earless",
                     "-wait_uart",
-                    f"--vm-runs={code_py_runs + 1}",
+                    f"--port-resets={port_resets}",
                 )
             )
 

--- a/ports/zephyr-cp/tests/test_audiobusio.py
+++ b/ports/zephyr-cp/tests/test_audiobusio.py
@@ -144,7 +144,7 @@ print("exiting")
 
 
 @pytest.mark.duration(15)
-@pytest.mark.code_py_runs(2)
+@pytest.mark.port_resets(3)
 @pytest.mark.circuitpy_drive({"code.py": I2S_PLAY_NO_STOP_CODE})
 def test_i2s_stops_on_code_exit(circuitpython):
     """Test I2S is stopped by reset_port when code.py exits without explicit stop."""

--- a/ports/zephyr-cp/tests/test_basics.py
+++ b/ports/zephyr-cp/tests/test_basics.py
@@ -101,7 +101,7 @@ print("done")
 
 
 @pytest.mark.circuitpy_drive({"code.py": RELOAD_CODE})
-@pytest.mark.code_py_runs(2)
+@pytest.mark.port_resets(3)
 def test_ctrl_d_soft_reload(circuitpython):
     """Test sending Ctrl+D (0x04) to trigger soft reload."""
     circuitpython.serial.wait_for("first run")

--- a/ports/zephyr-cp/tests/test_nvm.py
+++ b/ports/zephyr-cp/tests/test_nvm.py
@@ -58,7 +58,7 @@ print("done")
 
 
 @pytest.mark.circuitpy_drive({"code.py": NVM_PERSIST_CODE})
-@pytest.mark.code_py_runs(2)
+@pytest.mark.port_resets(3)
 def test_nvm_persists_across_reload(circuitpython):
     """Test that NVM data persists across soft reloads."""
     circuitpython.serial.wait_for("wrote marker")

--- a/ports/zephyr-cp/tests/test_reset.py
+++ b/ports/zephyr-cp/tests/test_reset.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 Scott Shawcroft for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""Test that a plain microcontroller.reset() reboots back into CircuitPython.
+
+This is like the safe-mode test (test_saved_word.py) but without changing the
+run mode: no sentinel is armed, so the reboot should be a normal boot that
+runs code.py again instead of entering safe mode.
+"""
+
+import pytest
+
+
+RESET_CODE = """\
+import microcontroller
+reason = microcontroller.cpu.reset_reason
+print("reset reason:", reason)
+if reason == microcontroller.ResetReason.POWER_ON:
+    print("resetting")
+    microcontroller.reset()
+else:
+    print("not resetting")
+"""
+
+
+@pytest.mark.circuitpy_drive({"code.py": RESET_CODE})
+@pytest.mark.duration(30)
+@pytest.mark.port_resets(4)  # Two startups and two code.py
+def test_plain_reset_reboots_into_circuitpython(circuitpython):
+    """microcontroller.reset() reboots into code.py and reports a software reset."""
+    circuitpython.serial.wait_for("resetting", timeout=30)
+
+    assert circuitpython.reconnect_serial(timeout=30), "simulator did not reboot"
+
+    circuitpython.serial.wait_for("not resetting", timeout=30)
+
+    all_output = circuitpython.serial.all_output
+    assert "reset reason: microcontroller.ResetReason.SOFTWARE" in all_output
+    assert "Running in safe mode" not in all_output

--- a/ports/zephyr-cp/tests/test_saved_word.py
+++ b/ports/zephyr-cp/tests/test_saved_word.py
@@ -1,32 +1,25 @@
 # SPDX-FileCopyrightText: 2025 Scott Shawcroft for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
-"""Test that the safe-mode saved word survives a hard reboot on native_sim/bsim.
-
-native_sim and the bsim boards reboot by re-executing the process (execv),
-which wipes RAM (including .noinit). supervisor/port.c works around that by
-persisting retained memory to a file across the reboot (the --retained-memory
-flag); currently that holds the safe-mode saved word.
-
-The saved word drives safe-mode detection: ``microcontroller.on_next_reset(
-RunMode.SAFE_MODE)`` arms the sentinel in the saved word, and a subsequent
-``microcontroller.reset()`` reboots. If the word persisted, the next boot reads
-the sentinel and enters safe mode (printed as "Running in safe mode!").
-"""
+"""Test that the safe-mode saved word survives a hard reboot on native_sim/bsim."""
 
 import pytest
 
 
 SAFE_MODE_RESET_CODE = """\
 import microcontroller
-microcontroller.on_next_reset(microcontroller.RunMode.SAFE_MODE)
-print("resetting")
-microcontroller.reset()
+if microcontroller.cpu.reset_reason == microcontroller.ResetReason.POWER_ON:
+    microcontroller.on_next_reset(microcontroller.RunMode.SAFE_MODE)
+    print("resetting")
+    microcontroller.reset()
+else:
+    print("not resetting")
 """
 
 
 @pytest.mark.circuitpy_drive({"code.py": SAFE_MODE_RESET_CODE})
 @pytest.mark.duration(30)
+@pytest.mark.port_resets(4)
 def test_saved_word_survives_reboot_into_safe_mode(circuitpython):
     """The saved word persists across a hard reboot and triggers safe mode."""
     circuitpython.serial.wait_for("resetting", timeout=30)

--- a/ports/zephyr-cp/tests/test_storage.py
+++ b/ports/zephyr-cp/tests/test_storage.py
@@ -108,7 +108,7 @@ print("done")
 
 
 @pytest.mark.circuitpy_drive({"code.py": REMOUNT_PERSISTS_CODE})
-@pytest.mark.code_py_runs(2)
+@pytest.mark.port_resets(3)
 def test_storage_remount_persists_across_reload(circuitpython):
     """Data written after remount(readonly=False) persists across soft reload."""
     circuitpython.serial.wait_for("wrote persist.txt")

--- a/ports/zephyr-cp/zephyr-config/west.yml
+++ b/ports/zephyr-cp/zephyr-config/west.yml
@@ -8,6 +8,6 @@ manifest:
       path: modules/bsim_hw_models/nrf_hw_models
     - name: zephyr
       url: https://github.com/adafruit/zephyr
-      revision: 499310df6e4da5ca54165c4b4c4c714771acb84c
+      revision: 52dc937c7cda06a1c18ff6adec281bbeb096b3d4
       clone-depth: 100
       import: true


### PR DESCRIPTION
On github actions, the offscreen driver exposed a thread teardown race condition. The driver switch avoids it but the zephyr commit also manages it.

Also tweak the reset_port() exit count to be more explicit and include the safe mode message print.

Fixes #11300