### PR TITLE
espressif: Don't run out of BLE CCCDs

### DIFF
--- a/ports/espressif/common-hal/_bleio/Adapter.c
+++ b/ports/espressif/common-hal/_bleio/Adapter.c
@@ -31,8 +31,8 @@
 #include "nimble/nimble_port.h"
 #include "nimble/nimble_port_freertos.h"
 #include "host/ble_gap.h"
+#include "host/ble_gatt.h"
 #include "host/util/util.h"
-#include "services/ans/ble_svc_ans.h"
 #include "services/gap/ble_svc_gap.h"
 #include "services/gatt/ble_svc_gatt.h"
 
@@ -66,6 +66,61 @@ static void _on_sync(void) {
 // All examples have this. It'd make sense in a header.
 void ble_store_config_init(void);
 
+// NimBLE sizes its client characteristic configuration (CCCD) pool once, in
+// ble_gatts_start(), from the services counted by ble_gatts_count_cfg().
+// But every CircuitPython service is registered afterwards, using
+// ble_gatts_add_dynamic_svcs(), which does not do its own counting,
+// and does not resize the CCCD pool.
+//
+// So services added at runtime get no CCCDs of their own added to the pool.
+// The CCCDs themselves can allocate on the NimBLE heap if needed,
+// but ble_gatts_conn_can_alloc() still tests the CCCD pool size, and NimBLE refuses
+// connectable advertising once the pool is empty. This is an oversight in the API.
+// NimBLE returns BLE_HS_ENOMEM, which is reported as a MemoryError from
+// start_advertising() as soon as the BLE workflow, a user service, and a
+// connection together need more CCCDs than the built-in services reserved.
+//
+// To get around this, we'll make the CCCD pool larger, by calling ble_gatts_count_cfg()
+// on a bulky dummy service that is never registered, just to force the pool to a
+// good size. Two of the reserved CCCDs cover the BLE workflow's own notifying
+// characteristics; the rest are for user services.
+#define RESERVED_CCCD_COUNT (18)
+
+// Never called: the definition below is counted, not registered. NimBLE only
+// requires that the callback not be NULL.
+static int _reserved_cccd_access_cb(uint16_t conn_handle, uint16_t attr_handle,
+    struct ble_gatt_access_ctxt *ctxt, void *arg) {
+    return BLE_ATT_ERR_UNLIKELY;
+}
+
+// Likewise unused, but must not be NULL.
+static const ble_uuid16_t _reserved_cccd_uuid = BLE_UUID16_INIT(0xffff);
+
+// Reserve CCCDs for the services registered at runtime. NimBLE needs one CCCD
+// per subscribable characteristic per connection, plus one for its cache;
+// ble_gatts_count_cfg() applies that multiplier itself.
+//
+// Call this before nimble_port_freertos_init(): ble_gatts_start() sizes the pool
+// on the nimble_host task, and counting afterwards is too late.
+static void _reserve_cccds(void) {
+    // ble_gatts_count_cfg() only reads these definitions and keeps no pointers
+    // into them, so they can live on the stack and then be discarded.
+    struct ble_gatt_chr_def chr_defs[RESERVED_CCCD_COUNT + 1] = { 0 };
+    for (size_t i = 0; i < RESERVED_CCCD_COUNT; i++) {
+        chr_defs[i].uuid = &_reserved_cccd_uuid.u;
+        chr_defs[i].access_cb = _reserved_cccd_access_cb;
+        // Only NOTIFY or INDICATE characteristics get a CCCD.
+        chr_defs[i].flags = BLE_GATT_CHR_F_NOTIFY;
+    }
+
+    struct ble_gatt_svc_def svc_defs[2] = { 0 };
+    svc_defs[0].type = BLE_GATT_SVC_TYPE_PRIMARY;
+    svc_defs[0].uuid = &_reserved_cccd_uuid.u;
+    svc_defs[0].characteristics = chr_defs;
+
+    CHECK_NIMBLE_ERROR(ble_gatts_count_cfg(svc_defs));
+}
+
 void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enabled) {
     const bool is_enabled = common_hal_bleio_adapter_get_enabled(self);
 
@@ -97,7 +152,8 @@ void common_hal_bleio_adapter_set_enabled(bleio_adapter_obj_t *self, bool enable
 
         ble_svc_gap_init();
         ble_svc_gatt_init();
-        ble_svc_ans_init();
+        // Grow the CCCD pool so it's not too small.
+        _reserve_cccds();
 
         // Clear all of the internal connection objects.
         for (size_t i = 0; i < BLEIO_TOTAL_CONNECTION_COUNT; i++) {


### PR DESCRIPTION
Code written by Claude Code, guided and corrected by @dhalbert. Also I edited this post for clarity and length.

#### The problem

It is too easy to get `MemoryError: Nimble out of memory` when doing BLE workflow and a couple of other BLE things at the same time. The reason is that NimBLE sizes its internal CCCD pool when it starts, based on information about services passed to `ble_gatts_count_cfg()`. But CircuitPython registers all its services dynamically, after that point, so none of them are counted: the pool ends up sized only by the built-in NimBLE services that CircuitPython enables.

CCCDs can actually get allocated on the heap if the pool is too small. So services and their characteristics can allocate their CCCDs successfully. But `ble_gatts_conn_can_alloc()` still only tests the CCCD pool size, and NimBLE refuses connectable advertising once the pool is empty. `Adapter.connect()` fails the same way, because the central connect path does the same check. This appears to be an error in the dynamic services extensions that ESP-IDF added to NimBLE.

On a Metro ESP32-S3 the pool held 12 blocks: the three built-in CCCDs (GATT Service Changed, two from ANS) times `BT_NIMBLE_MAX_CONNECTIONS + 1`. The BLE workflow's file transfer and serial TX characteristics bring the total to 5 configurable characteristics, so doing just one connection uses `5 cache + 5 connection` = 10. A single user service with one NOTIFY characteristic makes it 12 of 12. We hit the limit, and the next advertisement is refused.

#### The fix

To get around this, we'll make the CCCD pool a good size in advance, by calling `ble_gatts_count_cfg()` on a bulky dummy service that is never registered, reserving 18 CCCDs. Two cover the workflow's own notifying characteristics; the rest are for user services. `ble_gatts_count_resources()` only reads the service definition and keeps no pointers into it, so it is built on the stack and discarded.

This also stops the pool size from depending on which built-in services happen to be enabled, which it did before, by accident.

#### Also, remove unused Alert Notification Service

We discovered that a call to `ble_svc_ans_init()` was part of BLE startup on Espressif since the first PR. This is for ANS, the Alert Notification Service. It was probably copied from the Espressif examples. But nothing in CircuitPython uses it, and it is not advertised. We just removed it.

#### Memory cost

About 1.35 KB of RAM is reserved by counting up the things in the dummy service: roughly 600 bytes of CCCD pool and 1.1 KB of ATT entries, less about 350 bytes given back by dropping ANS. The ATT entries are memory user services already allocate one at a time from the heap.

#### Testing

Metro ESP32-S3 with Bluefruit Connect. Advertising a UART service, connecting, then importing a second service raised `MemoryError` before this change and succeeds after it. Instrumentation confirmed `pool_num_free` reaching 0 on the failing call.
