### PR TITLE
Fix rp2 MDNS wifi hostname

### DIFF
--- a/ports/raspberrypi/common-hal/mdns/Server.c
+++ b/ports/raspberrypi/common-hal/mdns/Server.c
@@ -46,11 +46,19 @@ void mdns_server_construct(mdns_server_obj_t *self, bool workflow) {
     self->num_txt_records = 0;
     self->txt_storage = NULL;
 
-    uint8_t mac[6];
-    wifi_radio_get_mac_address(&common_hal_wifi_radio_obj, mac);
-    char default_hostname[sizeof("cpy-XXXXXX")];
-    snprintf(default_hostname, sizeof(default_hostname), "cpy-%02x%02x%02x", mac[3], mac[4], mac[5]);
-    common_hal_mdns_server_set_hostname(self, default_hostname);
+    // Seed the mDNS hostname from the netif hostname configured via
+    // CIRCUITPY_WIFI_HOSTNAME.  Fall back to the historical MAC-based
+    // cpy-XXXXXX name when the user hasn't set one, so existing default
+    // hostnames keep working.
+    if (common_hal_wifi_radio_obj.hostname[0] != '\0') {
+        common_hal_mdns_server_set_hostname(self, common_hal_wifi_radio_obj.hostname);
+    } else {
+        uint8_t mac[6];
+        wifi_radio_get_mac_address(&common_hal_wifi_radio_obj, mac);
+        char default_hostname[sizeof("cpy-XXXXXX")];
+        snprintf(default_hostname, sizeof(default_hostname), "cpy-%02x%02x%02x", mac[3], mac[4], mac[5]);
+        common_hal_mdns_server_set_hostname(self, default_hostname);
+    }
 
     if (workflow) {
         // Add a second host entry to respond to "circuitpython.local" queries as well.


### PR DESCRIPTION
Wasn't sure what release to submit under and saw a lot of other commits to main so decided to submit there.

I noticed that my Raspberry PI Pico 2 W was not getting the mDNS hostname set when using CIRCUITPY_WIFI_HOSTNAME like the ESP32 systems were.  This caused hostname.local to fail and the hostname in the Web Workflow to show up as CPY-xxxxxx.

It turns out that the code to set the mDNS hostname from the new settings.toml variable on the Raspberry PI branch was missing.

I added the code, built a local copy and tested on my Pico 2W.  It runs without regressions and removing the CIRCUITPY_WIFI_HOSTNAME reverts to the CPY-xxxxxx hostname that it returned previously.

I don't own a Pico 1W so I was not able to test that but the change is minimal so I don't think it would be adversely affected.

Here is some before and after REPL:

**With 10.3.0 and CIRCUITPY_WIFI_HOSTNAME="gpsclock"**
```
DIdn't capture the CP REPL header -- this is from my boardid script
Adafruit CircuitPython 10.3.0 on 2026-08-31
Raspberry Pi Pico 2 W with rp2350a
Board: raspberry_pi_pico2_w
Platform: RP2350
Chip Family: rp2350a

>>> import os, wifi, mdns
>>> m = mdns.Server(wifi.radio)
>>> m.hostname
'cpy-132a7a'
```

**With my patched code CIRCUITPY_WIFI_HOSTNAME="gpsclock"**
```
Adafruit CircuitPython 10.3.0-20-g9209e83598-dirty on 2026-09-03; Raspberry Pi Pico 2 W with rp2350a
>>> import os, wifi, mdns
>>> m = mdns.Server(wifi.radio)
>>> m.hostname
'gpsclock'
```

**With my patched code and no CIRCUITPY_WIFI_HOSTNAME defined -- original behavior**
```
Adafruit CircuitPython 10.3.0-20-g9209e83598-dirty on 2026-09-03; Raspberry Pi Pico 2 W with rp2350a
>>> 
>>> import os, wifi, mdns
>>> m = mdns.Server(wifi.radio)
>>> m.hostname
'cpy-132a7a'
>>> 
```