### PR TITLE
picogame: validate the original object when the display cast yields NULL

### DIFF
--- a/shared-bindings/picogame/Display.c
+++ b/shared-bindings/picogame/Display.c
@@ -44,8 +44,9 @@ static mp_obj_t picogame_display_make_new(const mp_obj_type_t *type, size_t n_ar
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     mp_obj_t native = mp_obj_cast_to_native_base(args[ARG_display].u_obj, &busdisplay_busdisplay_type);
-    if (!mp_obj_is_type(native, &busdisplay_busdisplay_type)) {
-        mp_arg_validate_type(native, &busdisplay_busdisplay_type, MP_QSTR_display);
+    // MP_OBJ_NULL for a non-BusDisplay: validate the ORIGINAL object (NULL's type is unreadable).
+    if (native == MP_OBJ_NULL || !mp_obj_is_type(native, &busdisplay_busdisplay_type)) {
+        mp_arg_validate_type(args[ARG_display].u_obj, &busdisplay_busdisplay_type, MP_QSTR_display);
     }
     picogame_display_obj_t *self = mp_obj_malloc(picogame_display_obj_t, type);
     common_hal_picogame_display_construct(self, MP_OBJ_TO_PTR(native), args[ARG_rgb444].u_bool);

--- a/shared-bindings/picogame/Scene.c
+++ b/shared-bindings/picogame/Scene.c
@@ -64,8 +64,9 @@ static mp_obj_t scene_resolve_target(mp_obj_t disp, bool *fast, bool *fb_target)
     // Plain busdisplay: accept a subclass by casting to its native base; the portable
     // renderer treats self->display as a busdisplay_busdisplay_obj_t directly.
     mp_obj_t native = mp_obj_cast_to_native_base(disp, &busdisplay_busdisplay_type);
-    if (!mp_obj_is_type(native, &busdisplay_busdisplay_type)) {
-        mp_arg_validate_type(native, &busdisplay_busdisplay_type, MP_QSTR_display);
+    // MP_OBJ_NULL for a non-BusDisplay: validate the ORIGINAL object (NULL's type is unreadable).
+    if (native == MP_OBJ_NULL || !mp_obj_is_type(native, &busdisplay_busdisplay_type)) {
+        mp_arg_validate_type(disp, &busdisplay_busdisplay_type, MP_QSTR_display);
     }
     return native;
 }

--- a/shared-bindings/picogame/__init__.c
+++ b/shared-bindings/picogame/__init__.c
@@ -55,8 +55,10 @@ static busdisplay_busdisplay_obj_t *pg_get_display(mp_obj_t obj) {
     }
     #endif
     mp_obj_t native = mp_obj_cast_to_native_base(obj, &busdisplay_busdisplay_type);
-    if (!mp_obj_is_type(native, &busdisplay_busdisplay_type)) {
-        mp_arg_validate_type(native, &busdisplay_busdisplay_type, MP_QSTR_display);
+    // The cast yields MP_OBJ_NULL for a non-BusDisplay: validate the ORIGINAL object so the
+    // error names its real type (reading the type of NULL is a hard fault on RP2350).
+    if (native == MP_OBJ_NULL || !mp_obj_is_type(native, &busdisplay_busdisplay_type)) {
+        mp_arg_validate_type(obj, &busdisplay_busdisplay_type, MP_QSTR_display);
     }
     return MP_OBJ_TO_PTR(native);
 }


### PR DESCRIPTION
`pg_get_display()`, `scene_resolve_target()` and `Display()` pass the result of `mp_obj_cast_to_native_base()` to `mp_arg_validate_type()` when the argument is not a `BusDisplay` (eg. framebuffer). The cast returns `MP_OBJ_NULL` in that case and the error path dereferences it - on RP2350 a bus fault and a reset into safe mode instead of a `TypeError`.

Check for `MP_OBJ_NULL` and validate the object the caller passed, so the error names its real type (`TypeError: display must be of type BusDisplay, not FramebufferDisplay`). No change for valid arguments. Verified on a Fruit Jam.