### PR TITLE
Fix espressif TouchIn regression 

### DIFF
--- a/ports/espressif/peripherals/touch.c
+++ b/ports/espressif/peripherals/touch.c
@@ -128,19 +128,21 @@ uint16_t peripherals_touch_read(int channel_id) {
         return 0;
     }
     return UINT16_MAX - (uint16_t)touch_value;
-    touch_channel_read_data(touch_channels[idx], TOUCH_CHAN_DATA_TYPE_RAW, &touch_value);
-    return UINT16_MAX - (uint16_t)touch_value;
+
     #elif SOC_TOUCH_SENSOR_VERSION == 2
+    touch_channel_read_data(touch_channels[idx], TOUCH_CHAN_DATA_TYPE_RAW, &touch_value);
     if (touch_value > UINT16_MAX) {
         return UINT16_MAX;
     }
     return (uint16_t)touch_value;
+
     #elif SOC_TOUCH_SENSOR_VERSION == 3
     touch_channel_read_data(touch_channels[idx], TOUCH_CHAN_DATA_TYPE_SMOOTH, &touch_value);
     if (touch_value > UINT16_MAX) {
         return UINT16_MAX;
     }
     return (uint16_t)touch_value;
+
     #else
     #error bad SOC_TOUCH_SENSOR_VERSION
     #endif


### PR DESCRIPTION
- Fixes #11285 (uf2dvw)

I did some bad editing in #11056, which caused the common case to not read a touch value at all. Fixes that. I added some blank lines to make it more readable as well.

Tested on a Metro S3. Now gives same kind of results as in 10.2.1.