### PR TITLE
wifi: scan 5GHz channels on dual-band radios

### DIFF
--- a/ports/espressif/common-hal/wifi/Radio.c
+++ b/ports/espressif/common-hal/wifi/Radio.c
@@ -25,6 +25,7 @@
 
 #include "components/esp_netif/include/esp_netif_net_stack.h"
 #include "components/esp_wifi/include/esp_wifi.h"
+#include "soc/soc_caps.h"
 #include "components/lwip/include/apps/ping/ping_sock.h"
 #include "lwip/sockets.h"
 
@@ -94,6 +95,11 @@ void common_hal_wifi_radio_set_enabled(wifi_radio_obj_t *self, bool enabled) {
     }
     if (!self->started && enabled) {
         ESP_ERROR_CHECK(esp_wifi_start());
+        #if defined(SOC_WIFI_SUPPORT_5G) && SOC_WIFI_SUPPORT_5G
+        // Dual-band radios default to 2.4 GHz only. Enable both bands so that
+        // 5 GHz networks are visible to scans and can be connected to.
+        ESP_ERROR_CHECK(esp_wifi_set_band_mode(WIFI_BAND_MODE_AUTO));
+        #endif
         self->started = true;
         common_hal_wifi_radio_set_tx_power(self, CIRCUITPY_WIFI_DEFAULT_TX_POWER);
         return;

--- a/ports/espressif/common-hal/wifi/ScannedNetworks.c
+++ b/ports/espressif/common-hal/wifi/ScannedNetworks.c
@@ -18,6 +18,7 @@
 #include "shared-bindings/wifi/ScannedNetworks.h"
 
 #include "components/esp_wifi/include/esp_wifi.h"
+#include "soc/soc_caps.h"
 
 static void wifi_scannednetworks_done(wifi_scannednetworks_obj_t *self) {
     self->done = true;
@@ -111,29 +112,38 @@ mp_obj_t common_hal_wifi_scannednetworks_next(wifi_scannednetworks_obj_t *self) 
 }
 
 // We don't do a linear scan so that we look at a variety of spectrum up front.
+#if defined(SOC_WIFI_SUPPORT_5G) && SOC_WIFI_SUPPORT_5G
+// 2.4 GHz first, then the 5 GHz U-NII bands. DFS channels are omitted:
+// they require radar detection before transmitting.
+static uint8_t scan_pattern[] = {6, 1, 11, 3, 9, 13, 2, 4, 8, 12, 5, 7, 10, 14,
+                                 36, 40, 44, 48, 149, 153, 157, 161, 165, 0};
+#else
 static uint8_t scan_pattern[] = {6, 1, 11, 3, 9, 13, 2, 4, 8, 12, 5, 7, 10, 14, 0};
+#endif
 
 void wifi_scannednetworks_scan_next_channel(wifi_scannednetworks_obj_t *self) {
-    // There is no channel 0, so use that as a flag to indicate we've run out of channels to scan.
-    uint8_t next_channel = 0;
-    while (self->current_channel_index < sizeof(scan_pattern)) {
-        next_channel = scan_pattern[self->current_channel_index];
-        self->current_channel_index++;
-        // Scan only channels that are in the specified range.
-        if (self->start_channel <= next_channel && next_channel <= self->end_channel) {
-            break;
+    while (true) {
+        // There is no channel 0, so use that as a flag to indicate we've run out of channels to scan.
+        uint8_t next_channel = 0;
+        while (self->current_channel_index < sizeof(scan_pattern)) {
+            next_channel = scan_pattern[self->current_channel_index];
+            self->current_channel_index++;
+            // Scan only channels that are in the specified range.
+            if (self->start_channel <= next_channel && next_channel <= self->end_channel) {
+                break;
+            }
         }
-    }
-    wifi_scan_config_t config = { 0 };
-    config.channel = next_channel;
-    if (next_channel == 0) {
-        wifi_scannednetworks_done(self);
-    } else {
-        esp_err_t result = esp_wifi_scan_start(&config, false);
-        if (result != ESP_OK) {
+        if (next_channel == 0) {
             wifi_scannednetworks_done(self);
-        } else {
+            return;
+        }
+        wifi_scan_config_t config = { 0 };
+        config.channel = next_channel;
+        // The radio rejects channels outside the band it is set to. Skip those
+        // rather than ending the scan, so the rest of the pattern still runs.
+        if (esp_wifi_scan_start(&config, false) == ESP_OK) {
             self->channel_scan_in_progress = true;
+            return;
         }
     }
 }

--- a/shared-bindings/wifi/Radio.c
+++ b/shared-bindings/wifi/Radio.c
@@ -254,9 +254,12 @@ MP_PROPERTY_GETTER(wifi_radio_mac_address_ap_obj,
 #endif
 
 //|     def start_scanning_networks(
-//|         self, *, start_channel: int = 1, stop_channel: int = 11
+//|         self, *, start_channel: int = 1, stop_channel: int = 165
 //|     ) -> Iterable[Network]:
 //|         """Scans for available wifi networks over the given channel range. Make sure the channels are allowed in your country.
+//|
+//|         On dual-band radios, 5 GHz channels (36 and above) may also be given.
+//|         Channel numbers that the radio does not support are skipped.
 //|
 //|         .. note::
 //|
@@ -268,17 +271,19 @@ static mp_obj_t wifi_radio_start_scanning_networks(size_t n_args, const mp_obj_t
     enum { ARG_start_channel, ARG_stop_channel };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_start_channel, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
-        { MP_QSTR_stop_channel, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 11} },
+        { MP_QSTR_stop_channel, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 165} },
     };
 
     wifi_radio_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
+    // 165 is the highest channel in the scan pattern. Channels the radio
+    // doesn't support are skipped while scanning rather than rejected here.
     uint8_t start_channel =
-        (uint8_t)mp_arg_validate_int_range(args[ARG_start_channel].u_int, 1, 14, MP_QSTR_start_channel);
+        (uint8_t)mp_arg_validate_int_range(args[ARG_start_channel].u_int, 1, 165, MP_QSTR_start_channel);
     uint8_t stop_channel =
-        (uint8_t)mp_arg_validate_int_range(args[ARG_stop_channel].u_int, 1, 14, MP_QSTR_stop_channel);
+        (uint8_t)mp_arg_validate_int_range(args[ARG_stop_channel].u_int, 1, 165, MP_QSTR_stop_channel);
     // Swap if in reverse order, without complaining.
     if (start_channel > stop_channel) {
         uint8_t temp = stop_channel;


### PR DESCRIPTION
Stacked on #11297. Base is `esp32c5-board`, so only the top commit is new here.

### What

Lets `wifi.radio.start_scanning_networks()` reach 5 GHz on dual-band radios.

### Why

Three things blocked it:

| Problem | Fix |
|---|---|
| `scan_pattern` stopped at channel 14 | Added the U-NII channels, gated on `SOC_WIFI_SUPPORT_5G` |
| A rejected channel ended the whole scan | Skip it, keep scanning the rest of the pattern |
| `stop_channel` defaulted to 11 | Raised to 165 |

DFS channels are left out. They need radar detection before transmitting.

### Open question

Raising the default from 11 to 165 also changes 2.4 GHz boards, which now
scan channels 12, 13 and 14. 11 is the FCC-legal maximum, so that may have
been deliberate. Happy to make the default band-dependent instead.

### Hardware tested

ESP32-C5-DevKitC-1-N8R8, `10.3.0-22-ge514194c68-dirty`, host Ubuntu 24.04.
That is the stack tip, so it also carries #11309, which does not touch scanning.

```python
def scan(**kw):
    ch = set()
    for net in wifi.radio.start_scanning_networks(**kw):
        ch.add(net.channel)
    wifi.radio.stop_scanning_networks()
    return sorted(ch)
```

| Call | Channels seen | Nets | Secs |
|---|---|---|---|
| `scan()` | 1, 2, 5, 6, 8, 10, 36, 44, 48, 149, 153 | 19 | 3.57 |
| `scan(start_channel=1, stop_channel=165)` | 1, 2, 5, 6, 8, 10, 36, 40, 44, 48, 149, 153 | 21 | 3.57 |
| `scan(start_channel=1, stop_channel=11)` | 2, 5, 6, 10 | 6 | 1.35 |
| `scan(start_channel=36, stop_channel=165)` | 36, 40, 44, 48, 149, 153 | 12 | 1.13 |
| `scan(stop_channel=166)` | `ValueError: stop_channel must be 1-165` | | |

The 36-165 row is the skip fix: it starts above the 2.4 GHz part of the pattern,
and the scan completes instead of ending at the first rejected channel.

Not tested: a 2.4 GHz only board. The `scan_pattern` change is gated on
`SOC_WIFI_SUPPORT_5G`, but the `stop_channel` default of 165 applies everywhere.

### Scan channels

Channel numbers are 20 MHz primary channels. An AP on a wider channel beacons
on its primary, so it is still found, and the scan record carries its real
width in `bandwidth`, `second` and `vht_ch_freq1`.

`wifi_scan_config_t` has no width field, and CircuitPython exposes no bandwidth
or protocol control, so the driver default applies. Last came up in #9790.

### AI assistance

Claude wrote the scan-skip loop and the docstring. I found both defects on
hardware, ran the scans, and verified the channel lists myself.

