### PR TITLE
zephyr-cp: check that a board's layout matches its non-Zephyr build

### DIFF
--- a/ports/zephyr-cp/boards/adafruit/clue_nrf52840_zephyr/circuitpython.toml
+++ b/ports/zephyr-cp/boards/adafruit/clue_nrf52840_zephyr/circuitpython.toml
@@ -2,3 +2,6 @@ CIRCUITPY_BUILD_EXTENSIONS = ["hex", "uf2"]
 USB_VID=0x239A
 USB_PID=0x8072
 NAME="CLUE nRF52840 Express"
+
+# Non-Zephyr build of the same board; nvm and CIRCUITPY must sit where it puts them.
+counterpart = "nordic/clue_nrf52840_express"

--- a/ports/zephyr-cp/boards/adafruit/feather_nrf52840_sense_zephyr/circuitpython.toml
+++ b/ports/zephyr-cp/boards/adafruit/feather_nrf52840_sense_zephyr/circuitpython.toml
@@ -2,3 +2,6 @@ CIRCUITPY_BUILD_EXTENSIONS = ["elf", "uf2"]
 USB_VID=0x239A
 USB_PID=0x8088
 NAME="Feather Bluefruit Sense"
+
+# Non-Zephyr build of the same board; nvm and CIRCUITPY must sit where it puts them.
+counterpart = "nordic/feather_bluefruit_sense"

--- a/ports/zephyr-cp/boards/adafruit/feather_nrf52840_zephyr/circuitpython.toml
+++ b/ports/zephyr-cp/boards/adafruit/feather_nrf52840_zephyr/circuitpython.toml
@@ -2,3 +2,6 @@ CIRCUITPY_BUILD_EXTENSIONS = ["elf", "uf2"]
 USB_VID=0x239A
 USB_PID=0x802A
 NAME="Feather nRF52840 Express"
+
+# Non-Zephyr build of the same board; nvm and CIRCUITPY must sit where it puts them.
+counterpart = "nordic/feather_nrf52840_express"

--- a/ports/zephyr-cp/boards/adafruit/feather_rp2040_zephyr/circuitpython.toml
+++ b/ports/zephyr-cp/boards/adafruit/feather_rp2040_zephyr/circuitpython.toml
@@ -1,1 +1,4 @@
 CIRCUITPY_BUILD_EXTENSIONS = ["elf", "uf2"]
+
+# Non-Zephyr build of the same board; nvm and CIRCUITPY must sit where it puts them.
+counterpart = "raspberrypi/adafruit_feather_rp2040"

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_w_zephyr/circuitpython.toml
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_w_zephyr/circuitpython.toml
@@ -1,2 +1,5 @@
 CIRCUITPY_BUILD_EXTENSIONS = ["elf", "uf2"]
 BLOBS=["hal_infineon"]
+
+# Non-Zephyr build of the same board; nvm and CIRCUITPY must sit where it puts them.
+counterpart = "raspberrypi/raspberry_pi_pico2_w"

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_zephyr/circuitpython.toml
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico2_zephyr/circuitpython.toml
@@ -1,1 +1,4 @@
 CIRCUITPY_BUILD_EXTENSIONS = ["elf", "uf2"]
+
+# Non-Zephyr build of the same board; nvm and CIRCUITPY must sit where it puts them.
+counterpart = "raspberrypi/raspberry_pi_pico2"

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico_w_zephyr/circuitpython.toml
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico_w_zephyr/circuitpython.toml
@@ -1,2 +1,5 @@
 CIRCUITPY_BUILD_EXTENSIONS = ["elf", "uf2"]
 BLOBS=["hal_infineon"]
+
+# Non-Zephyr build of the same board; nvm and CIRCUITPY must sit where it puts them.
+counterpart = "raspberrypi/raspberry_pi_pico_w"

--- a/ports/zephyr-cp/boards/raspberrypi/rpi_pico_zephyr/circuitpython.toml
+++ b/ports/zephyr-cp/boards/raspberrypi/rpi_pico_zephyr/circuitpython.toml
@@ -1,1 +1,4 @@
 CIRCUITPY_BUILD_EXTENSIONS = ["elf", "uf2"]
+
+# Non-Zephyr build of the same board; nvm and CIRCUITPY must sit where it puts them.
+counterpart = "raspberrypi/raspberry_pi_pico"

--- a/ports/zephyr-cp/cptools/check_partitions.py
+++ b/ports/zephyr-cp/cptools/check_partitions.py
@@ -11,12 +11,20 @@ What changes is anything keyed off the address -- on RP2040,
 0x10000100, so a partition left at 0x100 silently turns it off and the UF2 is
 built for the wrong address with no second stage bootloader linked in.
 
+A board that CircuitPython also builds from another port (``counterpart`` in its
+``circuitpython.toml``) is additionally compared with that build: nvm and the
+CIRCUITPY drive must sit exactly where ``ports/<port>`` puts them, or switching
+firmware between the two builds loses the user's data. The expected placement
+is derived from the counterpart's configuration files the same way its
+``mpconfigport.h`` derives it.
+
 This reads the ``edt.pickle`` a build already produced, so it costs no build
 time -- point it at build directories after building, or run it with no
 arguments to check every build directory in the port.
 
     python cptools/check_partitions.py                       # every build-* dir
     python cptools/check_partitions.py build-raspberrypi_rpi_pico_zephyr
+    python cptools/check_partitions.py --board raspberrypi_rpi_pico_zephyr build-x
 
 Exits non-zero when a layout has problems.
 """
@@ -24,10 +32,30 @@ Exits non-zero when a layout has problems.
 import argparse
 import pathlib
 import pickle
+import re
 import sys
+import tomllib
+
+import board_tools
 
 PORT_DIR = pathlib.Path(__file__).resolve().parent.parent
+TOP = PORT_DIR.parent.parent
 EDT_MODULE = PORT_DIR / "zephyr" / "scripts" / "dts" / "python-devicetree" / "src"
+
+# Parity with the non-Zephyr build. A board that CircuitPython also builds from another
+# port (ports/raspberrypi, ports/nordic) names it in circuitpython.toml:
+#
+#     counterpart = "raspberrypi/raspberry_pi_pico_w"
+#
+# The nvm and CIRCUITPY drive of the Zephyr build then have to sit exactly where that
+# build puts them, so that switching firmware between the two never loses user data.
+# The expected placement is derived from the counterpart's own configuration files, the
+# same way its mpconfigport.h derives it, rather than copied into the overlay by hand.
+DEFINE_RE = re.compile(r"^\s*#\s*define\s+([A-Za-z_]\w*)\s+(.+?)\s*(?://.*|/\*.*)?$", re.MULTILINE)
+CFLAG_DEFINE_RE = re.compile(r"-D([A-Za-z_]\w*)=(?:'([^']*)'|\"([^\"]*)\"|(\S+))")
+MK_ASSIGN_RE = re.compile(r"^\s*([A-Za-z_]\w*)\s*[?:+]?=\s*(.*?)\s*$", re.MULTILINE)
+IDENTIFIER_RE = re.compile(r"(?<!\w)[A-Za-z_]\w*")
+SAFE_EXPR_RE = re.compile(r"^[\s0-9a-fA-FxX()*+\-/<>]+$")
 
 
 def load_edt(build_dir):
@@ -165,12 +193,193 @@ def check_layout(edt):
     return problems
 
 
+def read_defines(paths):
+    """Collect ``#define``s, ``-D`` flags and make assignments from configuration files.
+
+    The first definition of a name wins, and files earlier in ``paths`` take
+    precedence, so list the board's files before the port's defaults.
+    """
+    defines = {}
+    for path in paths:
+        if not path.is_file():
+            continue
+        text = path.read_text()
+        if path.suffix == ".mk":
+            for match in CFLAG_DEFINE_RE.finditer(text):
+                value = next(v for v in match.groups()[1:] if v is not None)
+                defines.setdefault(match.group(1), value)
+            for match in MK_ASSIGN_RE.finditer(text):
+                defines.setdefault(match.group(1), match.group(2))
+        else:
+            for match in DEFINE_RE.finditer(text):
+                defines.setdefault(match.group(1), match.group(2))
+    return defines
+
+
+def evaluate(defines, name, default=None):
+    """Integer value of a define, following references to other defines.
+
+    Returns ``default`` when the name is undefined and None when it cannot be
+    evaluated, so that a layout is never declared correct on a guess.
+    """
+    expr = defines.get(name)
+    if expr is None:
+        return default
+    for ident in sorted(set(IDENTIFIER_RE.findall(expr)), key=len, reverse=True):
+        value = evaluate(defines, ident)
+        if value is None:
+            return None
+        expr = re.sub(rf"(?<!\w){ident}(?!\w)", str(value), expr)
+    if not SAFE_EXPR_RE.match(expr):
+        return None
+    return int(eval(expr, {"__builtins__": {}}, {}))
+
+
+def reference_layout(counterpart, flash_size):
+    """Where the non-Zephyr build of ``counterpart`` keeps nvm and the CIRCUITPY drive.
+
+    ``counterpart`` is ``<port>/<board>`` under ``ports/`` and ``flash_size`` the
+    size of the internal flash. Returns ``{"nvm": (offset, size), "circuitpy":
+    (offset, size)}``; ``"circuitpy"`` is the string ``"external"`` when that
+    build uses a whole external flash chip as the drive. Raises ValueError when
+    the port's rules are unknown or a value cannot be derived.
+    """
+    port, _, board = counterpart.partition("/")
+    port_dir = TOP / "ports" / port
+    board_dir = port_dir / "boards" / board
+    if not board_dir.is_dir():
+        raise ValueError(f"{counterpart}: no such board under ports/")
+    defines = read_defines(
+        [
+            board_dir / "mpconfigboard.mk",
+            board_dir / "mpconfigboard.h",
+            port_dir / "mpconfigport.mk",
+            port_dir / "mpconfigport.h",
+        ]
+    )
+
+    def value(name, default=None):
+        result = evaluate(defines, name, default)
+        if result is None:
+            raise ValueError(f"{counterpart}: cannot evaluate {name}")
+        return result
+
+    if port == "raspberrypi":
+        # ports/raspberrypi/mpconfigport.h: nvm directly follows the firmware region,
+        # the drive follows nvm (and the saves partition on boards that have one).
+        firmware = value("CIRCUITPY_FIRMWARE_SIZE")
+        nvm_size = value("CIRCUITPY_INTERNAL_NVM_SIZE")
+        drive = firmware + nvm_size + value("CIRCUITPY_SAVES_PARTITION_SIZE", 0)
+        return {"nvm": (firmware, nvm_size), "circuitpy": (drive, flash_size - drive)}
+    if port == "nordic":
+        # ports/nordic/mpconfigport.h: the bootloader sits at the top of flash, an
+        # internal filesystem (when there is one) directly below it and nvm below that.
+        bootloader = (
+            flash_size
+            - value("BOOTLOADER_SIZE")
+            - value("BOOTLOADER_SETTINGS_SIZE")
+            - value("BOOTLOADER_MBR_SIZE")
+        )
+        external = any(
+            defines.get(flag, "0").strip() == "1"
+            for flag in ("QSPI_FLASH_FILESYSTEM", "SPI_FLASH_FILESYSTEM")
+        )
+        fs_size = 0 if external else value("CIRCUITPY_INTERNAL_FLASH_FILESYSTEM_SIZE")
+        fs_start = bootloader - fs_size
+        nvm_size = value("CIRCUITPY_INTERNAL_NVM_SIZE")
+        return {
+            "nvm": (fs_start - nvm_size, nvm_size),
+            "circuitpy": "external" if external else (fs_start, fs_size),
+        }
+    raise ValueError(f"{counterpart}: no layout rules known for port {port}")
+
+
+def is_internal_flash(node):
+    return "soc-nv-flash" in getattr(node, "compats", [])
+
+
+def is_external_flash(node):
+    return node.props.get("size") is not None and any(
+        "nor" in compat for compat in getattr(node, "compats", [])
+    )
+
+
+def check_parity(edt, counterpart):
+    """Return problems where the layout differs from the non-Zephyr ``counterpart``."""
+    internal = [node for node in edt.nodes if is_internal_flash(node)]
+    if not internal:
+        return [f"no soc-nv-flash device to compare with {counterpart}"]
+    try:
+        expected = reference_layout(counterpart, device_size(internal[0]))
+    except ValueError as e:
+        return [str(e)]
+
+    partitions = {}
+    for node, dev, offset, size, mapped in iter_partitions(edt):
+        label = node.labels[0] if node.labels else node.name
+        partitions[label] = (dev, offset, size)
+
+    problems = []
+
+    def compare(label, want):
+        found = partitions.get(label)
+        if found is None:
+            problems.append(
+                f"{label}: missing, {counterpart} has it at 0x{want[0]:x}+0x{want[1]:x}"
+            )
+            return
+        dev, offset, size = found
+        if not is_internal_flash(dev):
+            problems.append(f"{label}: not on the internal flash, unlike {counterpart}")
+        if (offset, size) != want:
+            problems.append(
+                f"{label}: 0x{offset:x}+0x{size:x}, {counterpart} has it at "
+                f"0x{want[0]:x}+0x{want[1]:x}"
+            )
+
+    compare("nvm_partition", expected["nvm"])
+    if expected["circuitpy"] == "external":
+        # supervisor/flash.c uses the first flash device no partition covers as the
+        # drive, which is the whole chip only while the chip carries no partitions.
+        if "circuitpy_partition" in partitions:
+            problems.append(
+                f"circuitpy_partition: declared, but {counterpart} uses the whole "
+                f"external flash as the drive"
+            )
+        external = [node for node in edt.nodes if is_external_flash(node)]
+        if not external:
+            problems.append(f"no external flash, but {counterpart} keeps the drive on one")
+        for dev, offset, size in partitions.values():
+            if is_external_flash(dev):
+                problems.append(
+                    f"{dev.labels[0] if dev.labels else dev.name}: carries partitions, "
+                    f"but {counterpart} uses the whole chip as the drive"
+                )
+                break
+    else:
+        compare("circuitpy_partition", expected["circuitpy"])
+    return problems
+
+
+def counterpart_of(board_id):
+    """The ``counterpart`` a board declares in its circuitpython.toml, if any."""
+    toml_path = board_tools.find_mpconfigboard(PORT_DIR, board_id) if board_id else None
+    if toml_path is None:
+        return None
+    with toml_path.open("rb") as f:
+        return tomllib.load(f).get("counterpart")
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(
         "build_dirs",
         nargs="*",
         help="Build directories to check (default: every build-* in the port)",
+    )
+    parser.add_argument(
+        "--board",
+        help="Board built in the (single) build directory; default: taken from its name",
     )
     args = parser.parse_args()
 
@@ -180,6 +389,8 @@ def main():
     if not dirs:
         print("No build directories found; build a board first.", file=sys.stderr)
         return 1
+    if args.board and len(dirs) != 1:
+        parser.error("--board applies to exactly one build directory")
 
     failed = []
     checked = 0
@@ -190,6 +401,10 @@ def main():
         checked += 1
         n_parts = sum(1 for _ in iter_partitions(edt))
         problems = check_layout(edt)
+        board = args.board or build_dir.name.removeprefix("build-")
+        counterpart = counterpart_of(board)
+        if counterpart:
+            problems += check_parity(edt, counterpart)
         if problems:
             failed.append(build_dir.name)
             print(f"{build_dir.name}:")
@@ -199,7 +414,8 @@ def main():
             # Say how much was inspected: a board whose overlay defines no
             # partitions at all would otherwise be indistinguishable from a
             # verified-good one.
-            print(f"{build_dir.name}: ok ({n_parts} partitions checked)")
+            parity = f", matches ports/{counterpart}" if counterpart else ""
+            print(f"{build_dir.name}: ok ({n_parts} partitions checked{parity})")
 
     if not checked:
         print("No build directory held an edt.pickle; build a board first.", file=sys.stderr)

--- a/ports/zephyr-cp/cptools/tests/test_check_partitions.py
+++ b/ports/zephyr-cp/cptools/tests/test_check_partitions.py
@@ -18,7 +18,15 @@ from devicetree import edtlib  # noqa: E402
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 
-from check_partitions import check_layout, device_size, iter_partitions  # noqa: E402
+from check_partitions import (  # noqa: E402
+    check_layout,
+    check_parity,
+    device_size,
+    evaluate,
+    iter_partitions,
+    read_defines,
+    reference_layout,
+)
 
 BINDINGS = [str(portdir / "zephyr/dts/bindings")]
 
@@ -292,3 +300,99 @@ class TestEmptyLayout:
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))
+
+
+class TestParity:
+    """Agreement with the non-Zephyr build of the same board.
+
+    The reference values are what ports/raspberrypi/mpconfigport.h and
+    ports/nordic/mpconfigport.h derive for these boards; the tests read the real
+    board files so a change there is caught here.
+    """
+
+    def test_evaluate_follows_references(self):
+        defines = {"A": "(2 * B)", "B": "(512 * 1024)", "C": "A + UNKNOWN"}
+        assert evaluate(defines, "A") == 1024 * 1024
+        assert evaluate(defines, "B") == 512 * 1024
+        assert evaluate(defines, "C") is None
+        assert evaluate(defines, "MISSING", 7) == 7
+
+    def test_read_defines_precedence(self, tmp_path):
+        mk = tmp_path / "mpconfigboard.mk"
+        mk.write_text(
+            "CFLAGS += -DCIRCUITPY_FIRMWARE_SIZE='(1536 * 1024)'\nQSPI_FLASH_FILESYSTEM = 1\n"
+        )
+        header = tmp_path / "mpconfigport.h"
+        header.write_text(
+            "#ifndef CIRCUITPY_FIRMWARE_SIZE\n#define CIRCUITPY_FIRMWARE_SIZE (1020 * 1024)\n#endif\n"
+        )
+        defines = read_defines([mk, header])
+        assert evaluate(defines, "CIRCUITPY_FIRMWARE_SIZE") == 1536 * 1024
+        assert defines["QSPI_FLASH_FILESYSTEM"] == "1"
+
+    def test_raspberrypi_default_firmware_size(self):
+        layout = reference_layout("raspberrypi/raspberry_pi_pico", 0x200000)
+        assert layout["nvm"] == (0xFF000, 0x1000)
+        assert layout["circuitpy"] == (0x100000, 0x100000)
+
+    def test_raspberrypi_board_firmware_size(self):
+        layout = reference_layout("raspberrypi/raspberry_pi_pico_w", 0x200000)
+        assert layout["nvm"] == (0x180000, 0x1000)
+        assert layout["circuitpy"] == (0x181000, 0x7F000)
+
+    def test_nordic_external_drive(self):
+        layout = reference_layout("nordic/feather_nrf52840_express", 0x100000)
+        assert layout["nvm"] == (0xF2000, 0x2000)
+        assert layout["circuitpy"] == "external"
+
+    def test_unknown_port_and_board_rejected(self):
+        with pytest.raises(ValueError):
+            reference_layout("espressif/adafruit_feather_esp32s3", 0x400000)
+        with pytest.raises(ValueError):
+            reference_layout("raspberrypi/no_such_board", 0x200000)
+
+    def rp2040_layout(self, nvm_offset):
+        return xip_flash(
+            f"""
+            code_partition: partition@100 {{
+                compatible = "zephyr,mapped-partition";
+                reg = <0x100 0xfdf00>;
+            }};
+            nvm_partition: partition@{nvm_offset:x} {{
+                compatible = "zephyr,mapped-partition";
+                label = "nvm";
+                reg = <0x{nvm_offset:x} 0x1000>;
+            }};
+            circuitpy_partition: partition@100000 {{
+                compatible = "zephyr,mapped-partition";
+                label = "circuitpy";
+                reg = <0x100000 0x100000>;
+            }};
+            """
+        )
+
+    def test_parity_matches(self):
+        edt = parse_dts_string(self.rp2040_layout(0xFF000))
+        assert check_parity(edt, "raspberrypi/raspberry_pi_pico") == []
+
+    def test_parity_reports_moved_nvm(self):
+        edt = parse_dts_string(self.rp2040_layout(0xFE000))
+        problems = check_parity(edt, "raspberrypi/raspberry_pi_pico")
+        assert len(problems) == 1
+        assert "nvm_partition" in problems[0]
+        assert "0xfe000" in problems[0] and "0xff000" in problems[0]
+
+    def test_parity_reports_missing_partition(self):
+        edt = parse_dts_string(
+            xip_flash(
+                """
+            code_partition: partition@100 {
+                compatible = "zephyr,mapped-partition";
+                reg = <0x100 0xfdf00>;
+            };
+            """
+            )
+        )
+        problems = check_parity(edt, "raspberrypi/raspberry_pi_pico")
+        assert any(p.startswith("nvm_partition: missing") for p in problems)
+        assert any(p.startswith("circuitpy_partition: missing") for p in problems)


### PR DESCRIPTION
This extends cptools/check_partitions.py from #11273 with a comparison against the non-Zephyr build of the same board. Users switch between the two builds, so nvm and the CIRCUITPY drive should have the same place and size in both to keep user's data.

The Zephyr board names its twin in circuitpython.toml (counterpart = "raspberrypi/raspberry_pi_pico_w"). The check reads the twin's mpconfigboard.mk/.h and mpconfigport.h, works out where that build puts nvm and CIRCUITPY, and compares it with the devicetree. The eight boards with a twin declare it. #11272 verified the RP2 placement on hardware; this keeps it there without the hardware. --board names the board for build directories not called build-<board>.

Run over all 29 boards on main (west build --cmake-only per board, ~10 s, no compile):

full output:

```
adafruit_clue_nrf52840_zephyr: ok (5 partitions checked, matches ports/nordic/clue_nrf52840_express)
adafruit_feather_nrf52840_sense_zephyr:
  FAIL  nvm_partition: 0xf2000+0x2000, nordic/feather_bluefruit_sense has it at 0xf3000+0x1000
adafruit_feather_nrf52840_zephyr: ok (5 partitions checked, matches ports/nordic/feather_nrf52840_express)
adafruit_feather_rp2040_zephyr: ok (5 partitions checked, matches ports/raspberrypi/adafruit_feather_rp2040)
native_native_sim: ok (3 partitions checked)
native_nrf5340bsim: ok (2 partitions checked)
native_nrf54lm20bsim: ok (2 partitions checked)
nordic_nrf5340dk: ok (3 partitions checked)
nordic_nrf54h20dk:
  FAIL  cpuapp_slot0_partition (ends 0xe4000) overlaps cpurad_slot0_partition (starts 0x92000) on mram1x
nordic_nrf54l15dk: ok (4 partitions checked)
nordic_nrf54l15tag: ok (4 partitions checked)
nordic_nrf54lm20dk: ok (5 partitions checked)
nordic_nrf7002dk: ok (3 partitions checked)
nxp_frdm_mcxn947: ok (5 partitions checked)
nxp_frdm_rw612: ok (6 partitions checked)
nxp_mimxrt1170_evk: ok (5 partitions checked)
raspberrypi_rpi_pico2_w_zephyr: ok (4 partitions checked, matches ports/raspberrypi/raspberry_pi_pico2_w)
raspberrypi_rpi_pico2_zephyr: ok (4 partitions checked, matches ports/raspberrypi/raspberry_pi_pico2)
raspberrypi_rpi_pico_w_zephyr: ok (5 partitions checked, matches ports/raspberrypi/raspberry_pi_pico_w)
raspberrypi_rpi_pico_zephyr: ok (5 partitions checked, matches ports/raspberrypi/raspberry_pi_pico)
renesas_da14695_dk_usb: ok (4 partitions checked)
renesas_ek_ra6m5: ok (1 partitions checked)
renesas_ek_ra8d1: ok (1 partitions checked)
silabs_siwx917_dk2605a: ok (11 partitions checked)
st_nucleo_n657x0_q: ok (1 partitions checked)
st_nucleo_u575zi_q: ok (4 partitions checked)
st_stm32h750b_dk:
  FAIL  storage_partition: resolves to 0x7800000, outside ext_flash (0x90000000-0x98000000) -- address translation is broken; does the partitions node declare ranges;?
  FAIL  circuitpy_partition: resolves to 0x7808000, outside ext_flash (0x90000000-0x98000000) -- address translation is broken; does the partitions node declare ranges;?
st_stm32h7b3i_dk: ok (2 partitions checked)
st_stm32wba65i_dk1:
  FAIL  circuitpy_partition (ends 0x200000) overlaps storage_partition (starts 0x1e0000) on flash0
```

25 boards pass, 4 don't:

- `adafruit_feather_nrf52840_sense_zephyr`: nvm 0xf2000+0x2000 copied from the Express; feather_bluefruit_sense/mpconfigboard.h sets CIRCUITPY_INTERNAL_NVM_SIZE (4096), so that build has it at 0xf3000+0x1000.
- `st_stm32h750b_dk`: partitions node without ranges;, both partitions resolve outside ext_flash; the base partition@0 (128 MB) is not deleted either.
- `st_stm32wba65i_dk1`: circuitpy_partition runs 64 KB into storage_partition at 0x1e0000.
- `nordic_nrf54h20dk`: the overlay grows slot0_partition to 656 KB to take the slot1 space, but cpurad_slot0_partition sits at 0x92000, between the two app slots; the app image overlaps the radio core's slot by 328 KB.

I can fix the first three (Sense nvm, h750b ranges; + partition@0, wba65i overlap) here on in follow-up PRs. `nrf54h20dk` needs your decision: with CONFIG_BT=n no radio, PPR or FLPR image is built, so the app could take 656 KB (drop cpurad_slot0, what the overlay meant), 768 KB (PPR/FLPR too) or up to 1424 KB (both radio slots), depending on whether a BLE controller on cpurad is planned.

Once the four are fixed, the check can run in CI: either one line in the Makefile after west build, which covers every board build, or a separate job doing west build --cmake-only plus the check for all boards. Today either would fail on them.

The script was made with AI assistance.