### PR TITLE
build-boards: use Python 3.13 for zephyr-cp board jobs

### DIFF
--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.x
+        python-version: ${{ inputs.port == 'zephyr-cp' && '3.13' || '3.x' }}
 
     - name: Set up port
       id: set-up-port


### PR DESCRIPTION
The zephyr-cp board jobs spend about 5 minutes each in west packages pip --install. The cause is the Python version: python-version: 3.x now resolves to 3.14, and for 3.14 several of the Zephyr build requirements have not published wheels yet. A wheel is a prebuilt package that pip only has to unpack; without one, pip downloads the source and compiles it on the runner, which for C extensions such as grpcio_tools takes minutes. With 3.13 the wheels exist, so the same install is a download.