### PR TITLE
Use `-j$(nproc)` for builds

### DIFF
--- a/.github/actions/deps/ports/broadcom/action.yml
+++ b/.github/actions/deps/ports/broadcom/action.yml
@@ -16,7 +16,7 @@ runs:
         tar -xaf dosfstools-4.2.tar.gz
         cd dosfstools-4.2
         ./configure
-        make -j4
+        make -j$(nproc)
         cd src
         echo >> $GITHUB_PATH $(pwd)
       shell: bash

--- a/.github/actions/mpy_cross/action.yml
+++ b/.github/actions/mpy_cross/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Build mpy-cross
       if: inputs.download == 'false' || steps.download-mpy-cross.outcome == 'failure'
-      run: make -C mpy-cross -j4
+      run: make -C mpy-cross -j$(nproc)
       shell: bash
       env:
         CP_VERSION: ${{ inputs.cp-version }}

--- a/.github/workflows/build-board-custom.yml
+++ b/.github/workflows/build-board-custom.yml
@@ -121,7 +121,7 @@ jobs:
         BOARD: ${{ inputs.board }}
         FLAGS: ${{ inputs.flags }}
         DEBUG: ${{ inputs.debug && '1' || '0' }}
-      run: make -j4 $FLAGS BOARD="$BOARD" DEBUG=$DEBUG TRANSLATION="$TRANSLATION"
+      run: make -j$(nproc) $FLAGS BOARD="$BOARD" DEBUG=$DEBUG TRANSLATION="$TRANSLATION"
       working-directory: ports/${{ steps.board-to-port.outputs.port }}
     - name: Upload artifact
       uses: actions/upload-artifact@v7

--- a/.github/workflows/build-mpy-cross.yml
+++ b/.github/workflows/build-mpy-cross.yml
@@ -55,7 +55,7 @@ jobs:
         sudo apt-get install -y mingw-w64
 
     - name: Build mpy-cross.${{ matrix.mpy-cross }}
-      run: make -C mpy-cross -j4 -f Makefile.${{ matrix.mpy-cross }}
+      run: make -C mpy-cross -j$(nproc) -f Makefile.${{ matrix.mpy-cross }}
 
     - name: Set output
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
         python3 --version
         msgfmt --version
     - name: Build mpy-cross (arm64)
-      run: make -C mpy-cross -j4 -f Makefile.m1 V=2
+      run: make -C mpy-cross -j$(sysctl -n hw.ncpu) -f Makefile.m1 V=2
     - uses: actions/upload-artifact@v7
       with:
         name: mpy-cross-macos-arm64
@@ -184,7 +184,7 @@ jobs:
         sudo apt-get install -y latexmk librsvg2-bin texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra
         pip install -r requirements-doc.txt
     - name: Build and Validate Stubs
-      run: make check-stubs -j4
+      run: make check-stubs -j$(nproc)
     - uses: actions/upload-artifact@v7
       with:
         name: stubs

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,12 +45,12 @@ jobs:
         with:
           cp-version: ${{ inputs.cp-version }}
       - name: Build unix port
-        run: make -C ports/unix VARIANT=coverage -j4
+        run: make -C ports/unix VARIANT=coverage -j$(nproc)
       - name: Run tests
-        run: ./run-tests.py -j4 ${{ env[format('TEST_{0}', matrix.test)] }}
+        run: ./run-tests.py -j$(nproc) ${{ env[format('TEST_{0}', matrix.test)] }}
         working-directory: tests
       - name: Print failure info
-        run: ./run-tests.py -j4 --print-failures
+        run: ./run-tests.py -j$(nproc) --print-failures
         if: failure()
         working-directory: tests
       - name: Build native modules

--- a/.github/workflows/run-zephyr-tests.yml
+++ b/.github/workflows/run-zephyr-tests.yml
@@ -35,13 +35,13 @@ jobs:
       - name: Set up external
         uses: ./.github/actions/deps/external
       - name: Build native sim target
-        run: make -C ports/zephyr-cp -j2 BOARD=native_native_sim
+        run: make -C ports/zephyr-cp -j4 BOARD=native_native_sim
       - name: Build bsim
-        run: make -j 2 everything
+        run: make -j 4 everything
         working-directory: ports/zephyr-cp/tools/bsim
       - name: Build native_nrf5340bsim
-        run: make -C ports/zephyr-cp -j2 BOARD=native_nrf5340bsim
+        run: make -C ports/zephyr-cp -j4 BOARD=native_nrf5340bsim
       - name: Build native_nrf54lm20bsim
-        run: make -C ports/zephyr-cp -j2 BOARD=native_nrf54lm20bsim
+        run: make -C ports/zephyr-cp -j4 BOARD=native_nrf54lm20bsim
       - name: Run Zephyr tests
         run: make -C ports/zephyr-cp test

--- a/.github/workflows/run-zephyr-tests.yml
+++ b/.github/workflows/run-zephyr-tests.yml
@@ -35,13 +35,13 @@ jobs:
       - name: Set up external
         uses: ./.github/actions/deps/external
       - name: Build native sim target
-        run: make -C ports/zephyr-cp -j4 BOARD=native_native_sim
+        run: make -C ports/zephyr-cp -j$(nproc) BOARD=native_native_sim
       - name: Build bsim
-        run: make -j 4 everything
+        run: make -j $(nproc) everything
         working-directory: ports/zephyr-cp/tools/bsim
       - name: Build native_nrf5340bsim
-        run: make -C ports/zephyr-cp -j4 BOARD=native_nrf5340bsim
+        run: make -C ports/zephyr-cp -j$(nproc) BOARD=native_nrf5340bsim
       - name: Build native_nrf54lm20bsim
-        run: make -C ports/zephyr-cp -j4 BOARD=native_nrf54lm20bsim
+        run: make -C ports/zephyr-cp -j$(nproc) BOARD=native_nrf54lm20bsim
       - name: Run Zephyr tests
         run: make -C ports/zephyr-cp test


### PR DESCRIPTION
The native_sim, bsim and the two bsim board builds in this job run with -j2 on a runner with 4 vCPUs, and ninja inherits the limit through the jobserver. Half the machine is idle for the build phase, about 11 of the job's 42 minutes (3.3 + 1.1 + 3.3 + 3.0). -j4 is what the other workflows use.