### PR TITLE
zephyr-cp deps: install the 32-bit SDL2 packages only for native_sim

### DIFF
--- a/.github/actions/deps/ports/action.yml
+++ b/.github/actions/deps/ports/action.yml
@@ -30,3 +30,5 @@ runs:
     - name: Set up Zephyr
       if: inputs.port == 'zephyr-cp'
       uses: ./.github/actions/deps/ports/zephyr-cp
+      with:
+        sdl: ${{ startsWith(inputs.board, 'native_') }}

--- a/.github/actions/deps/ports/zephyr-cp/action.yml
+++ b/.github/actions/deps/ports/zephyr-cp/action.yml
@@ -1,5 +1,11 @@
 name: Fetch Zephyr port deps
 
+inputs:
+  sdl:
+    description: 'Install the 32-bit SDL2 packages native_sim needs'
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
@@ -8,9 +14,14 @@ runs:
       run: |
         echo "--- cpu model ---"
         grep "model name" /proc/cpuinfo | head -1
-        sudo dpkg --add-architecture i386
         sudo apt-get update
         sudo apt-get install -y libusb-1.0-0-dev libudev-dev pkg-config mtools
+      shell: bash
+    - name: Get SDL2 for native_sim
+      if: runner.os == 'Linux' && inputs.sdl == 'true'
+      run: |
+        sudo dpkg --add-architecture i386
+        sudo apt-get update
         # We have to hold python3 so the following install works. See https://github.com/actions/runner-images/issues/13803
         sudo apt-mark hold python3
         sudo apt-get install -y libsdl2-dev:i386 libsdl2-image-dev:i386

--- a/.github/workflows/run-zephyr-tests.yml
+++ b/.github/workflows/run-zephyr-tests.yml
@@ -27,6 +27,8 @@ jobs:
           python-version: 3.13
       - name: Set up Zephyr
         uses: ./.github/actions/deps/ports/zephyr-cp
+        with:
+          sdl: true
       - name: Set up submodules
         id: set-up-submodules
         uses: ./.github/actions/deps/submodules


### PR DESCRIPTION
Every zephyr-cp board job installs libsdl2-dev:i386 and libsdl2-image-dev:i386, about 136 MB of i386 packages plus the apt-mark hold python3 workaround, roughly 30 s per job. Only native_sim uses SDL (CONFIG_SDL_DISPLAY, CONFIG_I2S_SDL); the other 26 boards in the matrix never touch it. The packages become an input of the action, on for the zephyr-tests job and the native_* boards, off for the rest.