### PR TITLE
alarm: validate epoch_time type in TimeAlarm constructor

### DIFF
--- a/shared-bindings/alarm/time/TimeAlarm.c
+++ b/shared-bindings/alarm/time/TimeAlarm.c
@@ -73,7 +73,7 @@ static mp_obj_t alarm_time_timealarm_make_new(const mp_obj_type_t *type,
         #if MICROPY_LONGINT_IMPL == MICROPY_LONGINT_IMPL_NONE
         mp_raise_ValueError(MP_ERROR_TEXT("epoch_time not supported on this board"));
         #else
-        mp_uint_t epoch_time_secs = mp_obj_int_get_checked(args[ARG_epoch_time].u_obj);
+        mp_uint_t epoch_time_secs = mp_arg_validate_type_int(args[ARG_epoch_time].u_obj, MP_QSTR_epoch_time);
 
         timeutils_struct_time_t tm;
         struct_time_to_tm(rtc_get_time_source_time(), &tm);


### PR DESCRIPTION
Passing a non-int to `alarm.time.TimeAlarm(epoch_time=...)`, for example the `struct_time` returned by `time.localtime()`, hard faults the board and drops it into safe mode. The constructor hands the object straight to `mp_obj_int_get_checked()`, which assumes it is already an int and reads the object memory as one.

This switches the read to `mp_arg_validate_type_int()`, the helper the rest of shared-bindings uses for int arguments, so a wrong type raises `TypeError: epoch_time must be of type int, not struct_time` instead. The `monotonic_time` path already goes through `mp_obj_get_float()`, which type-checks, so it is unchanged. There is no unix build of `alarm`, so this is reasoned rather than tested on hardware.

Fixes #11158
