### PR TITLE
zephyr-cp tests: let a capture test stop the simulator at its duration

### DIFF
--- a/ports/zephyr-cp/tests/conftest.py
+++ b/ports/zephyr-cp/tests/conftest.py
@@ -356,6 +356,10 @@ def circuitpython(request, board, sim_id, native_sim_binary, native_sim_env, tmp
                     f"--port-resets={port_resets}",
                 )
             )
+            # Capture tests hold their last frame forever; stop the simulator at the
+            # test's duration in simulated time instead of waiting out the timeout.
+            if capture_times_ns and not use_realtime:
+                cmd.append(f"-stop_at={timeout}")
 
         # Always preserve retained memory (e.g. the safe-mode saved word) in
         # in case of reboot.


### PR DESCRIPTION
A display test with scheduled captures holds its last frame in `while True: time.sleep(1)`, so native_sim never exits on its own and wait_until_done() waits out the whole wall-clock timeout: every capture test takes exactly its duration, 346 s for the 26 display tests.

Pass the duration as -stop_at so the simulator ends the run itself. In -no-rt the idle loop is fast-forwarded: gifio 60 s -> 2 s, the display suite 346 s -> 19 s, goldens unchanged. Realtime tests are left alone.

This fix was found after consulting with AI and testing multiple methods.