### PR TITLE
ci: run the Zephyr tests only when a change can reach them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       docs: ${{ steps.set-matrix.outputs.docs }}
+      zephyr-tests: ${{ steps.set-matrix.outputs.zephyr-tests }}
       ports: ${{ steps.set-matrix.outputs.ports }}
       cp-version: ${{ steps.set-up-submodules.outputs.version }}
     steps:
@@ -102,6 +103,7 @@ jobs:
 
   zephyr-tests:
     needs: scheduler
+    if: needs.scheduler.outputs.zephyr-tests == 'True'
     uses: ./.github/workflows/run-zephyr-tests.yml
     with:
       cp-version: ${{ needs.scheduler.outputs.cp-version }}

--- a/tools/ci_set_matrix.py
+++ b/tools/ci_set_matrix.py
@@ -71,6 +71,11 @@ PATTERN_DOCS = (
 
 GITHUB_MATRIX_LIMIT = 256
 
+# The Zephyr tests build native_sim and the two bsim boards out of the shared sources, so a
+# change confined to these cannot reach them: another port, a translation, a frozen library
+# (this port has none), documentation or the unix test suite.
+PATTERN_ZEPHYR_TESTS_IGNORE = re.compile(r"^(?:docs|frozen|locale|tests)/|^ports/(?!zephyr-cp/)")
+
 PATTERN_WINDOWS = {
     ".github/",
     "extmod/",
@@ -321,6 +326,21 @@ def set_docs(run: bool):
     set_output("docs", run)
 
 
+def set_zephyr_tests(run: bool):
+    if not run:
+        if any(job.startswith("zephyr-tests") for job in last_failed_jobs):
+            run = True
+        else:
+            for file in changed_files:
+                if not PATTERN_ZEPHYR_TESTS_IGNORE.match(file):
+                    run = True
+                    break
+
+    # Set the step outputs
+    print("Running Zephyr tests:", run)
+    set_output("zephyr-tests", run)
+
+
 def set_windows(run: bool):
     if not run:
         if last_failed_jobs.get("windows"):
@@ -347,6 +367,7 @@ def main():
     print("Running: " + ("all" if run_all else "conditionally"))
     # Set jobs
     set_docs(run_all)
+    set_zephyr_tests(run_all)
     set_windows(run_all)
     set_boards(run_all)
 


### PR DESCRIPTION
A first attempt at not running the Zephyr tests on pull requests that don't need them.

zephyr-tests has no condition, so it runs on every pull request, and takes about 30 minutes. Of the last 60 merged pull requests 23 changed nothing it builds - another port, a translation, a frozen library, a board definition.

The rule is written as what cannot reach the tests: `docs/`, `frozen/`, `locale/`, `tests/` and ports other than zephyr-cp. Everything else runs them, so an unknown path never turns them off. A zephyr-tests failure on an earlier commit of the PR also runs them.

`frozen/` is the one I'm least sure about - the port has no frozen modules today, but that could change.