### PR TITLE
unix: fix the coverage build on arm64

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -49,8 +49,9 @@ INC += -I$(BUILD)
 
 # compiler settings
 CWARN = -Wall -Werror
-// CIRCUITPY-CHANGE: add  -Wno-missing-field-initializers
+# CIRCUITPY-CHANGE: add  -Wno-missing-field-initializers
 CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith -Wdouble-promotion -Wfloat-conversion -Wno-missing-field-initializers
+# CIRCUITPY-CHANGE: use gnu11 instead of gnu99
 CFLAGS += $(INC) $(CWARN) -std=gnu11 -DUNIX $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
 
 # Force the use of 64-bits for file sizes in C library functions on 32-bit platforms.
@@ -262,6 +263,7 @@ CFLAGS += -DMPZ_DIG_SIZE=16 # force 16 bits to work on both 32 and 64 bit archs
 CFLAGS += -DMICROPY_MODULE_FROZEN_STR
 endif
 
+# CIRCUITPY-CHANGE: use gnu11 instead of gnu99
 CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu11,$(CFLAGS) $(CXXFLAGS_MOD))
 
 ifeq ($(MICROPY_FORCE_32BIT),1)

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -51,7 +51,7 @@ INC += -I$(BUILD)
 CWARN = -Wall -Werror
 // CIRCUITPY-CHANGE: add  -Wno-missing-field-initializers
 CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith -Wdouble-promotion -Wfloat-conversion -Wno-missing-field-initializers
-CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
+CFLAGS += $(INC) $(CWARN) -std=gnu11 -DUNIX $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
 
 # Force the use of 64-bits for file sizes in C library functions on 32-bit platforms.
 # This option has no effect on 64-bit builds.
@@ -262,7 +262,7 @@ CFLAGS += -DMPZ_DIG_SIZE=16 # force 16 bits to work on both 32 and 64 bit archs
 CFLAGS += -DMICROPY_MODULE_FROZEN_STR
 endif
 
-CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99,$(CFLAGS) $(CXXFLAGS_MOD))
+CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu11,$(CFLAGS) $(CXXFLAGS_MOD))
 
 ifeq ($(MICROPY_FORCE_32BIT),1)
 RUN_TESTS_MPY_CROSS_FLAGS = --mpy-cross-flags='-march=x86'

--- a/ports/unix/variants/coverage/mpconfigvariant.mk
+++ b/ports/unix/variants/coverage/mpconfigvariant.mk
@@ -150,6 +150,10 @@ SRC_C += $(addprefix lib/mp3/src/, \
 
 $(BUILD)/lib/mp3/src/buffers.o: CFLAGS += -include "shared-module/audiomp3/__init__.h" -D'MPDEC_ALLOCATOR(x)=malloc(x)' -D'MPDEC_FREE(x)=free(x)' -fwrapv
 
+# mp3dec.h only recognizes a fixed list of platforms and errors out on anything
+# else, including aarch64. Ask for the portable C code path, like espressif does.
+CFLAGS += -DMP3DEC_GENERIC
+
 CFLAGS += \
 	-DCIRCUITPY_AESIO=1 \
 	-DCIRCUITPY_AUDIOCORE=1 \

--- a/shared-bindings/audiomp3/MP3Decoder.h
+++ b/shared-bindings/audiomp3/MP3Decoder.h
@@ -19,5 +19,5 @@ void common_hal_audiomp3_mp3file_construct(audiomp3_mp3file_obj_t *self,
 
 void common_hal_audiomp3_mp3file_set_file(audiomp3_mp3file_obj_t *self, mp_obj_t stream);
 void common_hal_audiomp3_mp3file_deinit(audiomp3_mp3file_obj_t *self);
-float common_hal_audiomp3_mp3file_get_rms_level(audiomp3_mp3file_obj_t *self);
+mp_float_t common_hal_audiomp3_mp3file_get_rms_level(audiomp3_mp3file_obj_t *self);
 uint32_t common_hal_audiomp3_mp3file_get_samples_decoded(audiomp3_mp3file_obj_t *self);

--- a/shared-module/audiomp3/MP3Decoder.c
+++ b/shared-module/audiomp3/MP3Decoder.c
@@ -517,14 +517,14 @@ audioio_get_buffer_result_t audiomp3_mp3file_get_buffer(audiomp3_mp3file_obj_t *
     return result;
 }
 
-float common_hal_audiomp3_mp3file_get_rms_level(audiomp3_mp3file_obj_t *self) {
-    float sumsq = 0.f;
+mp_float_t common_hal_audiomp3_mp3file_get_rms_level(audiomp3_mp3file_obj_t *self) {
+    mp_float_t sumsq = MICROPY_FLOAT_CONST(0.0);
     // Assumes no DC component to the audio.  Is that a safe assumption?
     int16_t *buffer = (int16_t *)(void *)self->pcm_buffer[self->buffer_index];
     for (size_t i = 0; i < self->base.max_buffer_length / sizeof(int16_t); i++) {
-        sumsq += (float)buffer[i] * buffer[i];
+        sumsq += (mp_float_t)buffer[i] * buffer[i];
     }
-    return sqrtf(sumsq) / (self->base.max_buffer_length / sizeof(int16_t));
+    return MICROPY_FLOAT_C_FUN(sqrt)(sumsq) / (self->base.max_buffer_length / sizeof(int16_t));
 }
 
 uint32_t common_hal_audiomp3_mp3file_get_samples_decoded(audiomp3_mp3file_obj_t *self) {


### PR DESCRIPTION
The unix port still compiles as C99, and clang rejects a pattern the rest of the tree relies on: eight types that a bindings header forward-declares and the matching shared-module header typedefs again. That is valid C11, and gcc stays quiet, so it went unnoticed. Two more errors follow: the MP3 RMS level comes back as a float where mp_float_t is a double, and lib/mp3 has no case for aarch64 in its platform check.

So -std=gnu11, which every other port already uses, mp_float_t for the RMS level as suggested in the issue, and MP3DEC_GENERIC the way espressif sets it. gcc 13 and clang 18 both build clean on x86-64 Linux and the tests pass. I could not try arm64 itself.

Fixes #11039
