### PR TITLE
zephyr-cp/nrf7002dk: give slot0 the unused 32 KB storage partition

### DIFF
--- a/ports/zephyr-cp/boards/nordic/nrf7002dk/board.conf
+++ b/ports/zephyr-cp/boards/nordic/nrf7002dk/board.conf
@@ -8,3 +8,6 @@ CONFIG_LOG=n
 CONFIG_ASSERT=n
 CONFIG_TEST_RANDOM_GENERATOR=y
 CONFIG_BT=n
+# Settings only stores BT bond keys here. With BT off, its NVS backend would
+# still need storage_partition, which board.overlay removes.
+CONFIG_SETTINGS=n

--- a/ports/zephyr-cp/boards/nordic/nrf7002dk/board.overlay
+++ b/ports/zephyr-cp/boards/nordic/nrf7002dk/board.overlay
@@ -1,8 +1,9 @@
-/* Remove slot1 (OTA), expand slot0 to use the space.
- * CircuitPython doesn't use OTA updates. */
+/* Remove slot1 (OTA) and storage, expand slot0 to use the space.
+ * CircuitPython doesn't use OTA updates, and nothing here uses the settings
+ * NVS: CONFIG_BT=n, and CIRCUITPY lives on the external mx25r64. */
 &slot0_partition {
-	/* Shrink mcuboot to 48KB, absorb slot1 + gap before storage */
-	reg = <0x0000C000 0x000EC000>;
+	/* Shrink mcuboot to 48KB, absorb slot1 and storage, run to end of flash */
+	reg = <0x0000C000 0x000F4000>;
 };
 
 &boot_partition {
@@ -10,5 +11,6 @@
 };
 
 /delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
 
 #include "../../../app.overlay"


### PR DESCRIPTION
## What
Delete the unused 32 KB `storage_partition` on `nordic_nrf7002dk` and give it to slot0. Settings is turned off to match.

| Partition | Before | After |
|---|---|---|
| boot | 0x000000 + 0x00C000 | unchanged |
| slot0 | 0x00C000 + 0x0EC000 | 0x00C000 + **0x0F4000** |
| slot1 | deleted | deleted |
| storage | 0x0F8000 + 0x008000 | deleted |

## Why
This board is the port's flash ceiling. CI builds it for nearly every core PR, so additions get gated here.

| PR | Turned off on nrf7002dk |
|---|---|
| #11229 | `radio.ping()` |
| #11245 | ulab |
| #11309 | `connect()` with a scan result |
| #11334 | msgpack, 176 B short, to be reverted after this |

## How I tested it
Built on Linux against the pinned Zephyr. CI's `nordic_nrf7002dk` build also passes.

| Build | Result |
|---|---|
| Without `CONFIG_SETTINGS=n` | fails in `settings_nvs.c`, `storage_partition` undeclared |
| With it | builds, 965,896 B image in 999,424 B slot0 |
| `.config` diff | only `SETTINGS` and its 12 sub-options change |
| Kconfig | one new non-fatal warning, `SETTINGS_NVS_SECTOR_COUNT` from `prj.conf` |

## Hardware tested
None. I don't have an nRF7002 DK, so this needs someone with the board to boot it. Ordered board 9/10. Expected hardware test on 9/11.

## Scope
Settings stays on port-wide. This is the first board without `storage_partition`; the nRF52840 Zephyr boards move it.

## AI assistance
Claude traced the CI failure, wrote the `board.conf` change and ran the build on my Linux machine.
