### PR TITLE
supervisor/web_workflow: keep serving after a watchdog reset (#10054)

### DIFF
--- a/supervisor/shared/web_workflow/web_workflow.c
+++ b/supervisor/shared/web_workflow/web_workflow.c
@@ -340,7 +340,6 @@ bool supervisor_start_web_workflow(void) {
     // Skip starting the workflow if the reset reason reflects a problem.
     const mcu_reset_reason_t reset_reason = common_hal_mcu_processor_get_reset_reason();
     if (reset_reason == MCU_RESET_REASON_BROWNOUT ||
-        reset_reason == MCU_RESET_REASON_WATCHDOG ||
         reset_reason == MCU_RESET_REASON_RESCUE_DEBUG) {
         return false;
     }


### PR DESCRIPTION
Fixes #10054. @neradoc Would you mind retesting the CI asset (if you're able).

Longstanding issue where a firing of WDT stopped workflow from working.  Only a reset would bring it back.  

In a comment @tannewt suggested excluding WDT from the check that stops workflow restarts: https://github.com/adafruit/circuitpython/issues/10054#issuecomment-4238102874

Later @dhalbert flpped the check to being an include only list on this commit:
https://github.com/adafruit/circuitpython/blob/480b99450627367105d478a35882f29f6609c1e8/supervisor/shared/web_workflow/web_workflow.c#L340-L346

This change just removes the one line WDT entry which is the equivalent of adding it in the earlier suggestion by Scott.

@tyeth I'm not sure why #10948 didn't seem to fix at the time.  Either my testing was flawed or other changes have contibuted to the final fix.  This is your fix reapplied to current main (with the flipped logic due to the change in the code).

I should mention that the same check is in safe_mode.c and bluetooth.c.  I don't have a strong opinion whether they should also exclude WATCHDOG_RESET from their check only that Web Workflow shouldn't stop working after a reset.

Tested on a UM TinyS2 before with 10.3.0 and after with this fix and this change fixes #10054.  Also tested successfully on a QtPy ESP32-S3 N4R2.

---
