### PR TITLE
ci: get ninja from the IDF tools instead of apt

### DIFF
--- a/.github/actions/deps/external/action.yml
+++ b/.github/actions/deps/external/action.yml
@@ -29,16 +29,11 @@ runs:
         release: '15.2.Rel1'
 
     # espressif
-    - name: Get espressif toolchain
-      if: inputs.port == 'espressif'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y ninja-build
-      shell: bash
     - name: Install IDF tools
       if: inputs.port == 'espressif'
       run: |
         $IDF_PATH/install.sh
+        $IDF_PATH/tools/idf_tools.py install ninja
         rm -rf $IDF_TOOLS_PATH/dist
       shell: bash
     - name: Set environment

--- a/.github/actions/deps/ports/espressif/action.yml
+++ b/.github/actions/deps/ports/espressif/action.yml
@@ -30,7 +30,7 @@ runs:
       uses: actions/cache@v5
       with:
         path: ${{ env.IDF_TOOLS_PATH }}
-        key: ${{ runner.os }}-${{ env.pythonLocation }}-tools-idf-${{ steps.idf-commit.outputs.commit }}
+        key: ${{ runner.os }}-${{ env.pythonLocation }}-tools-idf-${{ steps.idf-commit.outputs.commit }}-20260911
 
     - name: Initialize IDF submodules
       run: git submodule update --init --depth=1 --recursive $IDF_PATH


### PR DESCRIPTION
Every espressif board job runs `apt-get update` and installs ninja-build, about 10 of the job's 50 seconds of setup, 257 times per full run. ninja is one of the IDF tools (`on_request` in tools.json), so `idf_tools.py install ninja` puts it next to the toolchain where `export.sh` already looks, and the apt step goes away.

The tools cache key doesn't change, so until the next IDF bump each job downloads the 120 KB ninja zip. After that it comes from the cache like everything else.
