### PR TITLE
ci: cache a port's submodules in an entry of their own

### DIFF
--- a/.github/actions/deps/submodules/action.yml
+++ b/.github/actions/deps/submodules/action.yml
@@ -12,6 +12,12 @@ inputs:
     default: '["extmod/ulab", "lib/", "tools/"]'
     type: string
 
+  port:
+    description: 'Also cache the submodules of this port, in their own entry'
+    required: false
+    default: ''
+    type: string
+
   action:
     description: 'The cache action to use'
     required: false
@@ -62,8 +68,27 @@ runs:
         key: submodules-common-${{ hashFiles('submodule_status') }}
         enableCrossOsArchive: true
 
+    - name: Port submodule status
+      id: port-submodule-status
+      # The ports whose board jobs clone the most over the network: 29 CMSIS and HAL
+      # repositories on stm, the sdk and lwip on raspberrypi and mimxrt10xx. espressif
+      # and zephyr-cp fetch theirs in their own way; the rest have little to gain.
+      if: ${{ contains(fromJSON('["stm", "raspberrypi", "mimxrt10xx"]'), inputs.port) }}
+      run: |
+        git submodule status ports/${{ inputs.port }} > port_submodule_status
+        echo $(cut -d ' ' -f 2 port_submodule_status) | echo "submodules=[\"$(sed "s/ /\", \"/g")\"]" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Cache port submodules
+      if: ${{ steps.port-submodule-status.outcome == 'success' }}
+      uses: actions/cache@v5
+      with:
+        path: ".git/modules/ports/${{ inputs.port }}\n${{ join(fromJSON(steps.port-submodule-status.outputs.submodules), '\n') }}"
+        key: submodules-${{ inputs.port }}-${{ hashFiles('port_submodule_status') }}
+        enableCrossOsArchive: true
+
     - name: Remove submodule status
-      run: rm submodule_status
+      run: rm -f submodule_status port_submodule_status
       shell: bash
 
     - name: CircuitPython dependencies

--- a/.github/workflows/build-boards.yml
+++ b/.github/workflows/build-boards.yml
@@ -51,6 +51,8 @@ jobs:
     - name: Set up submodules
       id: set-up-submodules
       uses: ./.github/actions/deps/submodules
+      with:
+        port: ${{ inputs.port }}
 
     - name: Set up external
       uses: ./.github/actions/deps/external


### PR DESCRIPTION
every board job of a port clones the port's submodules over the network: stm's 29 CMSIS and HAL repositories take 59 seconds a job, raspberrypi's sdk, lwip, cyw43 and PicoDVI 17 seconds, 159 times per full run. The submodule cache holds `extmod/ulab`, `lib/` and `tools/` only.

Board jobs of stm, raspberrypi and mimxrt10xx now get a second entry, `submodules-<port>-<hash>`, with `.git/modules/ports/<port>` and the port's submodule paths. The first job of a port to miss saves it, the rest read it. The common cache stays as it is.

Measured on my fork, warm:

| port | before | after | entry |
|---|---|---|---|
| stm | 59 s | 9 s | 203 MB |
| raspberrypi | 17 s | 5 s | 49 MB |
| mimxrt10xx | 22 s | 8 s | 126 MB |

espressif keeps its own `submodules-idf` cache for now; it could move to this mechanism in a follow-up if you want.