### PR TITLE
ci_fetch_deps: mimxrt10xx needs lib/mp3

### DIFF
--- a/tools/ci_fetch_deps.py
+++ b/tools/ci_fetch_deps.py
@@ -66,7 +66,7 @@ PORT_DEPS = {
         "lib/tinyusb/",
     ],
     "litex": ["extmod/ulab/", "lib/tinyusb/", "lib/tlsf"],
-    "mimxrt10xx": ["extmod/ulab/", "lib/tinyusb/", "lib/tlsf", "data/nvm.toml/"],
+    "mimxrt10xx": ["extmod/ulab/", "lib/mp3/", "lib/tinyusb/", "lib/tlsf", "data/nvm.toml/"],
     "nordic": [
         "extmod/ulab/",
         "lib/mbedtls/",


### PR DESCRIPTION
`ports/mimxrt10xx/mpconfigport.mk` turns on `CIRCUITPY_AUDIOMP3`, but the port's dependency list didn't have `lib/mp3`. The boards build anyway because the common submodule cache happens to contain it - a board job that misses that cache fails on `lib/mp3/src/mp3common.h`. Found while testing a per-port submodule cache on my fork (PR #11345).
