### PR TITLE
ci: run the Zephyr tests as three jobs, one per board family

### DIFF
--- a/.github/workflows/run-zephyr-tests.yml
+++ b/.github/workflows/run-zephyr-tests.yml
@@ -10,8 +10,22 @@ on:
 jobs:
   zephyr:
     runs-on: ubuntu-24.04
+    name: ${{ matrix.shard }}
     strategy:
       fail-fast: false
+      # One job per board family, so the bsim suites, which take the longest, run
+      # side by side instead of after each other.
+      matrix:
+        include:
+          - shard: native_sim
+            boards: native_native_sim native_native_sim_asan
+            pytest_args: tests/ --ignore=tests/bsim
+          - shard: nrf5340bsim
+            boards: native_nrf5340bsim
+            pytest_args: tests/bsim -k native_nrf5340bsim
+          - shard: nrf54lm20bsim
+            boards: native_nrf54lm20bsim
+            pytest_args: tests/bsim -k native_nrf54lm20bsim
     env:
       CP_VERSION: ${{ inputs.cp-version }}
     steps:
@@ -36,14 +50,9 @@ jobs:
           target: zephyr-cp
       - name: Set up external
         uses: ./.github/actions/deps/external
-      - name: Build native sim target
-        run: make -C ports/zephyr-cp -j$(nproc) BOARD=native_native_sim
       - name: Build bsim
+        if: contains(matrix.shard, 'bsim')
         run: make -j $(nproc) everything
         working-directory: ports/zephyr-cp/tools/bsim
-      - name: Build native_nrf5340bsim
-        run: make -C ports/zephyr-cp -j$(nproc) BOARD=native_nrf5340bsim
-      - name: Build native_nrf54lm20bsim
-        run: make -C ports/zephyr-cp -j$(nproc) BOARD=native_nrf54lm20bsim
       - name: Run Zephyr tests
-        run: make -C ports/zephyr-cp test
+        run: make -C ports/zephyr-cp test TEST_BOARDS="${{ matrix.boards }}" PYTEST_ARGS="${{ matrix.pytest_args }}"

--- a/ports/zephyr-cp/Makefile
+++ b/ports/zephyr-cp/Makefile
@@ -139,6 +139,10 @@ test-build-$(1):
 endef
 $(foreach board,$(TEST_BOARDS),$(eval $(call test_board_rule,$(board))))
 
+# CI runs this as three jobs, one per board family, narrowing TEST_BOARDS and
+# PYTEST_ARGS; see .github/workflows/run-zephyr-tests.yml.
+PYTEST_ARGS ?= tests/
+
 test: $(TEST_BOARDS:%=test-build-%)
 	pytest cptools/tests
-	pytest tests/ -v
+	pytest -v $(PYTEST_ARGS)


### PR DESCRIPTION
Most of zephyr-tests is the bsim BLE suite, run once per bsim board, one board after the other. Split by board family: native_sim (both builds), nrf5340bsim and nrf54lm20bsim, each job building only its boards and running only its tests through the same `make test`, with `TEST_BOARDS` and `PYTEST_ARGS` narrowing it.

On my fork: 15, 19.5 and 25 minutes against 46 today, 204 + 59 + 59 tests. Two more setups per run, about 9 minutes of machine time.