### PR TITLE
zephyr-cp tests: read serial output in chunks instead of one byte at a time

### DIFF
--- a/ports/zephyr-cp/tests/__init__.py
+++ b/ports/zephyr-cp/tests/__init__.py
@@ -28,6 +28,14 @@ class StdSerial:
             self.stdin.close()
         self.stdout.close()
 
+    def read_some(self, limit=65536):
+        # read1() hands back whatever is already buffered and does at most one
+        # read on the pipe, so it blocks only when nothing has arrived yet.
+        data = self.stdout.read1(limit)
+        if data == b"":
+            raise EOFError("stdout closed")
+        return data
+
     @property
     def in_waiting(self):
         if self.stdout is None:
@@ -47,13 +55,22 @@ class SerialSaver:
         self._stop = threading.Event()
         self._lock = threading.Lock()
         self._cv = threading.Condition(self._lock)
+        self._read_some = getattr(serial_obj, "read_some", None)
         self._reader = threading.Thread(target=self._reader_loop, daemon=True)
         self._reader.start()
 
     def _reader_loop(self):
         while not self._stop.is_set():
             try:
-                read = self.serial.read(1)
+                if self._read_some is not None:
+                    read = self._read_some()
+                else:
+                    read = self.serial.read(1)
+                    # in_waiting is a non-blocking check on a real serial port,
+                    # so draining it here is free.
+                    waiting = self.serial.in_waiting
+                    if waiting:
+                        read += self.serial.read(waiting)
             except Exception:
                 # Serial port closed or device disconnected.
                 break

--- a/ports/zephyr-cp/tests/bsim/test_bsim_ble_packet_buffer.py
+++ b/ports/zephyr-cp/tests/bsim/test_bsim_ble_packet_buffer.py
@@ -604,7 +604,6 @@ print("done")
 """
 
 
-@pytest.mark.duration(5)
 @pytest.mark.circuitpy_drive({"code.py": BSIM_PB_LENGTHS_CODE})
 def test_bsim_packet_buffer_packet_lengths(bsim_phy, circuitpython):
     """incoming_packet_length and outgoing_packet_length properties."""


### PR DESCRIPTION
SerialSaver's reader thread read one byte at a time and appended it to an attribute, so each byte copied the whole string: 993 KB took 9.4 s, 1.99 MB took 35.6 s. Each bsim test pipes about 1.1 MB of phy output through it, against a wall-clock budget.

It now reads whatever is already buffered. The bsim suite (118 tests) goes from 554.7 s to 109.6 s idle. The two files that fail most on CI go from 144 s to 26 s, and under load from 340 s with 2 of 3 runs failing to 57 s, all green. This may also be behind the intermittent `Low level communication with phy failed errors`.

The second commit drops `duration(5)` from one bsim test, the only one below the default 10 s. It failed at 5 s under load and passed at 10 s.