### PR TITLE
Fix ESP32-S2/S3 raw-REPL paste corruption

### DIFF
--- a/ports/espressif/supervisor/usb.c
+++ b/ports/espressif/supervisor/usb.c
@@ -51,11 +51,11 @@ static void usb_device_task(void *param) {
     while (1) {
         // tinyusb device task
         if (tusb_inited()) {
-            // Time out so the ring buffer is drained even when no USB event arrives.
+            // Time out so console input left in the fifo while the ringbuf was full is moved in.
             tud_task_ext(10, false);
             tud_cdc_write_flush();
             #if CIRCUITPY_USB_CDC
-            usb_cdc_rx_background();
+            usb_cdc_rx_drain();
             #endif
         }
         // Yield with zero delay to switch to any other tasks at same priority.

--- a/ports/espressif/supervisor/usb.c
+++ b/ports/espressif/supervisor/usb.c
@@ -51,8 +51,12 @@ static void usb_device_task(void *param) {
     while (1) {
         // tinyusb device task
         if (tusb_inited()) {
-            tud_task();
+            // Time out so the ring buffer is drained even when no USB event arrives.
+            tud_task_ext(10, false);
             tud_cdc_write_flush();
+            #if CIRCUITPY_USB_CDC
+            usb_cdc_rx_background();
+            #endif
         }
         // Yield with zero delay to switch to any other tasks at same priority.
         port_task_yield();

--- a/shared-module/usb_cdc/Serial.c
+++ b/shared-module/usb_cdc/Serial.c
@@ -6,10 +6,28 @@
 
 #include "shared/runtime/interrupt_char.h"
 #include "shared-bindings/usb_cdc/Serial.h"
+#include "shared-module/usb_cdc/__init__.h"
 #include "shared-module/usb_cdc/Serial.h"
 #include "supervisor/shared/tick.h"
+#include "supervisor/usb.h"
 
 #include "tusb.h"
+
+#if CFG_TUSB_OS == OPT_OS_FREERTOS
+// On espressif, console input is read from the ringbuf in supervisor/shared/usb/usb_device.c.
+static bool _console_uses_ringbuf(usb_cdc_serial_obj_t *self) {
+    return self->idx == 0 && usb_cdc_console_enabled();
+}
+#endif
+
+static uint32_t _read(usb_cdc_serial_obj_t *self, uint8_t *data, size_t len) {
+    #if CFG_TUSB_OS == OPT_OS_FREERTOS
+    if (_console_uses_ringbuf(self)) {
+        return usb_cdc_rx_read(data, len);
+    }
+    #endif
+    return tud_cdc_n_read(self->idx, data, len);
+}
 
 size_t common_hal_usb_cdc_serial_read(usb_cdc_serial_obj_t *self, uint8_t *data, size_t len, int *errcode) {
 
@@ -19,7 +37,7 @@ size_t common_hal_usb_cdc_serial_read(usb_cdc_serial_obj_t *self, uint8_t *data,
     // Read up to len bytes immediately.
     // The number of bytes read will not be larger than what is already in the TinyUSB FIFO.
     uint32_t total_num_read = 0;
-    total_num_read = tud_cdc_n_read(self->idx, data, len);
+    total_num_read = _read(self, data, len);
 
     if (wait_forever || wait_for_timeout) {
         // Continue filling the buffer past what we already read.
@@ -46,7 +64,7 @@ size_t common_hal_usb_cdc_serial_read(usb_cdc_serial_obj_t *self, uint8_t *data,
             data += num_read;
 
             // Try to read another batch of bytes.
-            num_read = tud_cdc_n_read(self->idx, data, len);
+            num_read = _read(self, data, len);
             total_num_read += num_read;
         }
     }
@@ -98,6 +116,11 @@ size_t common_hal_usb_cdc_serial_write(usb_cdc_serial_obj_t *self, const uint8_t
 }
 
 uint32_t common_hal_usb_cdc_serial_get_in_waiting(usb_cdc_serial_obj_t *self) {
+    #if CFG_TUSB_OS == OPT_OS_FREERTOS
+    if (_console_uses_ringbuf(self)) {
+        return usb_cdc_rx_available();
+    }
+    #endif
     return tud_cdc_n_available(self->idx);
 }
 
@@ -108,6 +131,11 @@ uint32_t common_hal_usb_cdc_serial_get_out_waiting(usb_cdc_serial_obj_t *self) {
 
 void common_hal_usb_cdc_serial_reset_input_buffer(usb_cdc_serial_obj_t *self) {
     tud_cdc_n_read_flush(self->idx);
+    #if CFG_TUSB_OS == OPT_OS_FREERTOS
+    if (_console_uses_ringbuf(self)) {
+        usb_cdc_rx_clear();
+    }
+    #endif
 }
 
 uint32_t common_hal_usb_cdc_serial_reset_output_buffer(usb_cdc_serial_obj_t *self) {

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -327,8 +327,8 @@ char serial_read(void) {
         return -1;
     }
     #endif
-    #if CIRCUITPY_TINYUSB && CIRCUITPY_USB_DEVICE
-    return (char)tud_cdc_read_char();
+    #if CIRCUITPY_TINYUSB && CIRCUITPY_USB_DEVICE && CIRCUITPY_USB_CDC
+    return (char)usb_cdc_rx_get();
     #endif
 
     return -1;
@@ -362,7 +362,7 @@ uint32_t serial_bytes_available(void) {
 
     #if CIRCUITPY_TINYUSB && CIRCUITPY_USB_DEVICE && CIRCUITPY_USB_CDC
     if (usb_cdc_console_enabled()) {
-        count += tud_cdc_available();
+        count += usb_cdc_rx_available();
     }
     #endif
 

--- a/supervisor/shared/serial.c
+++ b/supervisor/shared/serial.c
@@ -327,8 +327,15 @@ char serial_read(void) {
         return -1;
     }
     #endif
-    #if CIRCUITPY_TINYUSB && CIRCUITPY_USB_DEVICE && CIRCUITPY_USB_CDC
-    return (char)usb_cdc_rx_get();
+    #if CIRCUITPY_TINYUSB && CIRCUITPY_USB_DEVICE
+    #if CIRCUITPY_USB_CDC && CFG_TUSB_OS == OPT_OS_FREERTOS
+    uint8_t c;
+    if (usb_cdc_rx_read(&c, 1) == 1) {
+        return c;
+    }
+    #else
+    return (char)tud_cdc_read_char();
+    #endif
     #endif
 
     return -1;
@@ -362,7 +369,11 @@ uint32_t serial_bytes_available(void) {
 
     #if CIRCUITPY_TINYUSB && CIRCUITPY_USB_DEVICE && CIRCUITPY_USB_CDC
     if (usb_cdc_console_enabled()) {
+        #if CFG_TUSB_OS == OPT_OS_FREERTOS
         count += usb_cdc_rx_available();
+        #else
+        count += tud_cdc_available();
+        #endif
     }
     #endif
 

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -161,9 +161,6 @@ void usb_background(void) {
     if (usb_enabled()) {
         #if CFG_TUSB_OS == OPT_OS_NONE || CFG_TUSB_OS == OPT_OS_PICO
         tud_task();
-        #if CIRCUITPY_USB_DEVICE && CIRCUITPY_USB_CDC
-        usb_cdc_rx_background();
-        #endif
         #if CIRCUITPY_USB_HOST || CIRCUITPY_MAX3421E
         tuh_task();
         #endif

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -161,6 +161,9 @@ void usb_background(void) {
     if (usb_enabled()) {
         #if CFG_TUSB_OS == OPT_OS_NONE || CFG_TUSB_OS == OPT_OS_PICO
         tud_task();
+        #if CIRCUITPY_USB_DEVICE && CIRCUITPY_USB_CDC
+        usb_cdc_rx_background();
+        #endif
         #if CIRCUITPY_USB_HOST || CIRCUITPY_MAX3421E
         tuh_task();
         #endif

--- a/supervisor/shared/usb/usb_device.c
+++ b/supervisor/shared/usb/usb_device.c
@@ -173,6 +173,7 @@ void tud_cdc_rx_wanted_cb(uint8_t itf, char wanted_char) {
     // Compare mp_interrupt_char with wanted_char and ignore if not matched
     if (mp_interrupt_char == wanted_char) {
         tud_cdc_n_read_flush(itf);    // flush read fifo
+        usb_cdc_rx_clear();
         mp_sched_keyboard_interrupt();
     }
 }
@@ -184,10 +185,71 @@ void tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms) {
     }
 }
 
+#endif // MICROPY_KBD_EXCEPTION && CIRCUITPY_USB_CDC
+
+#if CIRCUITPY_USB_CDC
+// Console input is moved out of TinyUSB's fifo here, on the task that runs
+// tud_task(). Reading it from the VM task instead re-arms the OUT endpoint while
+// TinyUSB may still be copying the previous packet into its fifo
+// (hathach/tinyusb#1292): one packet is lost and the next one repeated. Only
+// espressif runs tud_task() in its own task, but the ring buffer is harmless
+// elsewhere. Single producer (tud_task) and single consumer (the VM), so the
+// two indices need no lock.
+#define CDC_RX_RING_SIZE (256)
+static uint8_t _cdc_rx_buf[CDC_RX_RING_SIZE];
+static volatile uint16_t _cdc_rx_head;   // written by the producer only
+static volatile uint16_t _cdc_rx_tail;   // written by the consumer only
+static volatile bool _cdc_rx_pending;    // fifo still holds bytes the ring could not take
+
+static inline uint16_t _cdc_rx_count(void) {
+    return (uint16_t)(_cdc_rx_head - _cdc_rx_tail);
+}
+
+void usb_cdc_rx_drain(void) {
+    while (tud_cdc_available() > 0) {
+        if (_cdc_rx_count() >= CDC_RX_RING_SIZE) {
+            _cdc_rx_pending = true;
+            return;
+        }
+        int c = tud_cdc_read_char();
+        if (c < 0) {
+            break;
+        }
+        _cdc_rx_buf[_cdc_rx_head % CDC_RX_RING_SIZE] = (uint8_t)c;
+        _cdc_rx_head++;
+    }
+    _cdc_rx_pending = false;
+}
+
+void usb_cdc_rx_background(void) {
+    if (_cdc_rx_pending) {
+        usb_cdc_rx_drain();
+    }
+}
+
+int usb_cdc_rx_get(void) {
+    if (_cdc_rx_count() == 0) {
+        return -1;
+    }
+    uint8_t c = _cdc_rx_buf[_cdc_rx_tail % CDC_RX_RING_SIZE];
+    _cdc_rx_tail++;
+    return c;
+}
+
+size_t usb_cdc_rx_available(void) {
+    return _cdc_rx_count();
+}
+
+void usb_cdc_rx_clear(void) {
+    _cdc_rx_tail = _cdc_rx_head;
+}
+
 void tud_cdc_rx_cb(uint8_t itf) {
-    (void)itf;
-    // Workaround for "press any key to enter REPL" response being delayed on espressif.
-    // Wake main task when any key is pressed.
+    if (itf == 0) {
+        usb_cdc_rx_drain();
+    }
+    // Wake the main task so it sees the input right away. On espressif it is a
+    // different FreeRTOS task from the one running TinyUSB.
     port_wake_main_task();
 }
-#endif
+#endif // CIRCUITPY_USB_CDC

--- a/supervisor/shared/usb/usb_device.c
+++ b/supervisor/shared/usb/usb_device.c
@@ -14,6 +14,8 @@
 #endif
 
 #if CIRCUITPY_USB_CDC
+#include "py/ringbuf.h"
+#include "shared-bindings/microcontroller/__init__.h"
 #include "shared-module/usb_cdc/__init__.h"
 #include "lib/tinyusb/src/class/cdc/cdc_device.h"
 #endif
@@ -188,36 +190,32 @@ void tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms) {
 #endif // MICROPY_KBD_EXCEPTION && CIRCUITPY_USB_CDC
 
 #if CIRCUITPY_USB_CDC
-// Console input is moved out of TinyUSB's fifo here, on the task that runs
-// tud_task(). Reading it from the VM task instead re-arms the OUT endpoint while
-// TinyUSB may still be copying the previous packet into its fifo
-// (hathach/tinyusb#1292): one packet is lost and the next one repeated. Only
-// espressif runs tud_task() in its own task, but the ring buffer is harmless
-// elsewhere. Single producer (tud_task) and single consumer (the VM), so the
-// two indices need no lock.
-#define CDC_RX_RING_SIZE (256)
-static uint8_t _cdc_rx_buf[CDC_RX_RING_SIZE];
-static volatile uint16_t _cdc_rx_head;   // written by the producer only
-static volatile uint16_t _cdc_rx_tail;   // written by the consumer only
-static volatile bool _cdc_rx_pending;    // fifo still holds bytes the ring could not take
-static volatile bool _cdc_rx_flush;      // set on Ctrl-C by the producer, applied by the consumer
-
-static inline uint16_t _cdc_rx_count(void) {
-    return (uint16_t)(_cdc_rx_head - _cdc_rx_tail);
-}
+// Console input is copied out of TinyUSB's fifo on the task that runs tud_task().
+// On espressif that is its own FreeRTOS task, and a read from the VM task can
+// re-arm the OUT endpoint while the previous packet is still being copied.
+// The ringbuf is shared by the two tasks, so guard it with interrupts disabled.
+static uint8_t _cdc_rx_buf[256];
+static ringbuf_t _cdc_rx_ringbuf = { .buf = _cdc_rx_buf, .size = sizeof(_cdc_rx_buf) };
+static volatile bool _cdc_rx_pending;
 
 void usb_cdc_rx_drain(void) {
+    uint8_t chunk[CFG_TUD_CDC_RX_EPSIZE];
     while (tud_cdc_available() > 0) {
-        if (_cdc_rx_count() >= CDC_RX_RING_SIZE) {
+        common_hal_mcu_disable_interrupts();
+        size_t room = ringbuf_num_empty(&_cdc_rx_ringbuf);
+        common_hal_mcu_enable_interrupts();
+        if (room == 0) {
             _cdc_rx_pending = true;
             return;
         }
-        int c = tud_cdc_read_char();
-        if (c < 0) {
+        // tud_cdc_read() takes TinyUSB's fifo mutex, so it runs outside the critical section.
+        uint32_t count = tud_cdc_read(chunk, MIN(room, sizeof(chunk)));
+        if (count == 0) {
             break;
         }
-        _cdc_rx_buf[_cdc_rx_head % CDC_RX_RING_SIZE] = (uint8_t)c;
-        _cdc_rx_head++;
+        common_hal_mcu_disable_interrupts();
+        ringbuf_put_n(&_cdc_rx_ringbuf, chunk, count);
+        common_hal_mcu_enable_interrupts();
     }
     _cdc_rx_pending = false;
 }
@@ -228,39 +226,31 @@ void usb_cdc_rx_background(void) {
     }
 }
 
-// Called by the consumer only, so the tail keeps a single writer.
-static inline void _cdc_rx_apply_flush(void) {
-    if (_cdc_rx_flush) {
-        _cdc_rx_flush = false;
-        _cdc_rx_tail = _cdc_rx_head;
-    }
-}
-
 int usb_cdc_rx_get(void) {
-    _cdc_rx_apply_flush();
-    if (_cdc_rx_count() == 0) {
-        return -1;
-    }
-    uint8_t c = _cdc_rx_buf[_cdc_rx_tail % CDC_RX_RING_SIZE];
-    _cdc_rx_tail++;
+    common_hal_mcu_disable_interrupts();
+    int c = ringbuf_get(&_cdc_rx_ringbuf);
+    common_hal_mcu_enable_interrupts();
     return c;
 }
 
 size_t usb_cdc_rx_available(void) {
-    _cdc_rx_apply_flush();
-    return _cdc_rx_count();
+    common_hal_mcu_disable_interrupts();
+    size_t count = ringbuf_num_filled(&_cdc_rx_ringbuf);
+    common_hal_mcu_enable_interrupts();
+    return count;
 }
 
 void usb_cdc_rx_clear(void) {
-    _cdc_rx_flush = true;
+    common_hal_mcu_disable_interrupts();
+    ringbuf_clear(&_cdc_rx_ringbuf);
+    common_hal_mcu_enable_interrupts();
 }
 
 void tud_cdc_rx_cb(uint8_t itf) {
     if (itf == 0) {
         usb_cdc_rx_drain();
     }
-    // Wake the main task so it sees the input right away. On espressif it is a
-    // different FreeRTOS task from the one running TinyUSB.
+    // Wake the main task so it sees the input right away.
     port_wake_main_task();
 }
 #endif // CIRCUITPY_USB_CDC

--- a/supervisor/shared/usb/usb_device.c
+++ b/supervisor/shared/usb/usb_device.c
@@ -14,8 +14,6 @@
 #endif
 
 #if CIRCUITPY_USB_CDC
-#include "py/ringbuf.h"
-#include "shared-bindings/microcontroller/__init__.h"
 #include "shared-module/usb_cdc/__init__.h"
 #include "lib/tinyusb/src/class/cdc/cdc_device.h"
 #endif
@@ -25,6 +23,11 @@
 #endif
 
 #include "tusb.h"
+
+#if CIRCUITPY_USB_CDC && CFG_TUSB_OS == OPT_OS_FREERTOS
+#include "py/ringbuf.h"
+#include "shared-bindings/microcontroller/__init__.h"
+#endif
 
 #if CIRCUITPY_USB_VENDOR
 #include "usb_vendor_descriptors.h"
@@ -151,6 +154,54 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
 #endif // CIRCUITPY_USB_VENDOR
 
 
+#if CIRCUITPY_USB_CDC && CFG_TUSB_OS == OPT_OS_FREERTOS
+// Console input is moved from the TinyUSB fifo into this ringbuf on the task that
+// runs tud_task(), and read from the ringbuf on the VM task. Both tasks use the
+// ringbuf, so every access is made with interrupts disabled.
+static uint8_t _cdc_rx_buf[256];
+static ringbuf_t _cdc_rx_ringbuf = { .buf = _cdc_rx_buf, .size = sizeof(_cdc_rx_buf) };
+
+void usb_cdc_rx_drain(void) {
+    if (!usb_cdc_console_enabled()) {
+        return;
+    }
+    uint8_t chunk[64];
+    while (tud_cdc_available() > 0) {
+        common_hal_mcu_disable_interrupts();
+        size_t room = ringbuf_num_empty(&_cdc_rx_ringbuf);
+        common_hal_mcu_enable_interrupts();
+        if (room == 0) {
+            return;
+        }
+        // tud_cdc_read() can wait on the TinyUSB fifo mutex, so it runs with interrupts enabled.
+        uint32_t count = tud_cdc_read(chunk, MIN(room, sizeof(chunk)));
+        common_hal_mcu_disable_interrupts();
+        ringbuf_put_n(&_cdc_rx_ringbuf, chunk, count);
+        common_hal_mcu_enable_interrupts();
+    }
+}
+
+size_t usb_cdc_rx_read(uint8_t *data, size_t len) {
+    common_hal_mcu_disable_interrupts();
+    size_t count = ringbuf_get_n(&_cdc_rx_ringbuf, data, len);
+    common_hal_mcu_enable_interrupts();
+    return count;
+}
+
+size_t usb_cdc_rx_available(void) {
+    common_hal_mcu_disable_interrupts();
+    size_t count = ringbuf_num_filled(&_cdc_rx_ringbuf);
+    common_hal_mcu_enable_interrupts();
+    return count;
+}
+
+void usb_cdc_rx_clear(void) {
+    common_hal_mcu_disable_interrupts();
+    ringbuf_clear(&_cdc_rx_ringbuf);
+    common_hal_mcu_enable_interrupts();
+}
+#endif
+
 #if MICROPY_KBD_EXCEPTION && CIRCUITPY_USB_CDC
 
 // The CDC RX buffer impacts monitoring for ctrl-c. TinyUSB will only ask for
@@ -175,7 +226,9 @@ void tud_cdc_rx_wanted_cb(uint8_t itf, char wanted_char) {
     // Compare mp_interrupt_char with wanted_char and ignore if not matched
     if (mp_interrupt_char == wanted_char) {
         tud_cdc_n_read_flush(itf);    // flush read fifo
+        #if CFG_TUSB_OS == OPT_OS_FREERTOS
         usb_cdc_rx_clear();
+        #endif
         mp_sched_keyboard_interrupt();
     }
 }
@@ -187,70 +240,13 @@ void tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms) {
     }
 }
 
-#endif // MICROPY_KBD_EXCEPTION && CIRCUITPY_USB_CDC
-
-#if CIRCUITPY_USB_CDC
-// Console input is copied out of TinyUSB's fifo on the task that runs tud_task().
-// On espressif that is its own FreeRTOS task, and a read from the VM task can
-// re-arm the OUT endpoint while the previous packet is still being copied.
-// The ringbuf is shared by the two tasks, so guard it with interrupts disabled.
-static uint8_t _cdc_rx_buf[256];
-static ringbuf_t _cdc_rx_ringbuf = { .buf = _cdc_rx_buf, .size = sizeof(_cdc_rx_buf) };
-static volatile bool _cdc_rx_pending;
-
-void usb_cdc_rx_drain(void) {
-    uint8_t chunk[CFG_TUD_CDC_RX_EPSIZE];
-    while (tud_cdc_available() > 0) {
-        common_hal_mcu_disable_interrupts();
-        size_t room = ringbuf_num_empty(&_cdc_rx_ringbuf);
-        common_hal_mcu_enable_interrupts();
-        if (room == 0) {
-            _cdc_rx_pending = true;
-            return;
-        }
-        // tud_cdc_read() takes TinyUSB's fifo mutex, so it runs outside the critical section.
-        uint32_t count = tud_cdc_read(chunk, MIN(room, sizeof(chunk)));
-        if (count == 0) {
-            break;
-        }
-        common_hal_mcu_disable_interrupts();
-        ringbuf_put_n(&_cdc_rx_ringbuf, chunk, count);
-        common_hal_mcu_enable_interrupts();
-    }
-    _cdc_rx_pending = false;
-}
-
-void usb_cdc_rx_background(void) {
-    if (_cdc_rx_pending) {
-        usb_cdc_rx_drain();
-    }
-}
-
-int usb_cdc_rx_get(void) {
-    common_hal_mcu_disable_interrupts();
-    int c = ringbuf_get(&_cdc_rx_ringbuf);
-    common_hal_mcu_enable_interrupts();
-    return c;
-}
-
-size_t usb_cdc_rx_available(void) {
-    common_hal_mcu_disable_interrupts();
-    size_t count = ringbuf_num_filled(&_cdc_rx_ringbuf);
-    common_hal_mcu_enable_interrupts();
-    return count;
-}
-
-void usb_cdc_rx_clear(void) {
-    common_hal_mcu_disable_interrupts();
-    ringbuf_clear(&_cdc_rx_ringbuf);
-    common_hal_mcu_enable_interrupts();
-}
-
 void tud_cdc_rx_cb(uint8_t itf) {
-    if (itf == 0) {
-        usb_cdc_rx_drain();
-    }
-    // Wake the main task so it sees the input right away.
+    (void)itf;
+    #if CFG_TUSB_OS == OPT_OS_FREERTOS
+    usb_cdc_rx_drain();
+    #endif
+    // Workaround for "press any key to enter REPL" response being delayed on espressif.
+    // Wake main task when any key is pressed.
     port_wake_main_task();
 }
-#endif // CIRCUITPY_USB_CDC
+#endif

--- a/supervisor/shared/usb/usb_device.c
+++ b/supervisor/shared/usb/usb_device.c
@@ -200,6 +200,7 @@ static uint8_t _cdc_rx_buf[CDC_RX_RING_SIZE];
 static volatile uint16_t _cdc_rx_head;   // written by the producer only
 static volatile uint16_t _cdc_rx_tail;   // written by the consumer only
 static volatile bool _cdc_rx_pending;    // fifo still holds bytes the ring could not take
+static volatile bool _cdc_rx_flush;      // set on Ctrl-C by the producer, applied by the consumer
 
 static inline uint16_t _cdc_rx_count(void) {
     return (uint16_t)(_cdc_rx_head - _cdc_rx_tail);
@@ -227,7 +228,16 @@ void usb_cdc_rx_background(void) {
     }
 }
 
+// Called by the consumer only, so the tail keeps a single writer.
+static inline void _cdc_rx_apply_flush(void) {
+    if (_cdc_rx_flush) {
+        _cdc_rx_flush = false;
+        _cdc_rx_tail = _cdc_rx_head;
+    }
+}
+
 int usb_cdc_rx_get(void) {
+    _cdc_rx_apply_flush();
     if (_cdc_rx_count() == 0) {
         return -1;
     }
@@ -237,11 +247,12 @@ int usb_cdc_rx_get(void) {
 }
 
 size_t usb_cdc_rx_available(void) {
+    _cdc_rx_apply_flush();
     return _cdc_rx_count();
 }
 
 void usb_cdc_rx_clear(void) {
-    _cdc_rx_tail = _cdc_rx_head;
+    _cdc_rx_flush = true;
 }
 
 void tud_cdc_rx_cb(uint8_t itf) {

--- a/supervisor/usb.h
+++ b/supervisor/usb.h
@@ -19,15 +19,13 @@ void usb_background(void);
 // Schedule usb background
 void usb_background_schedule(void);
 
-#if CIRCUITPY_USB_CDC
-// Console (CDC itf 0) input ring buffer, filled from tud_cdc_rx_cb on the task
-// that runs tud_task() and read by the VM. See usb_device.c.
+// Console input ringbuf, used where tud_task() runs in its own task (espressif).
+// usb_cdc_rx_drain() runs on that task, the others on the VM task.
+// usb_cdc_rx_read() and usb_cdc_rx_available() return a byte count, 0 when empty.
 void usb_cdc_rx_drain(void);
-void usb_cdc_rx_background(void);
-int usb_cdc_rx_get(void);
+size_t usb_cdc_rx_read(uint8_t *data, size_t len);
 size_t usb_cdc_rx_available(void);
 void usb_cdc_rx_clear(void);
-#endif
 
 // Ports must call this from their particular USB IRQ handler
 void usb_irq_handler(int instance);

--- a/supervisor/usb.h
+++ b/supervisor/usb.h
@@ -19,6 +19,16 @@ void usb_background(void);
 // Schedule usb background
 void usb_background_schedule(void);
 
+#if CIRCUITPY_USB_CDC
+// Console (CDC itf 0) input ring buffer, filled from tud_cdc_rx_cb on the task
+// that runs tud_task() and read by the VM. See usb_device.c.
+void usb_cdc_rx_drain(void);
+void usb_cdc_rx_background(void);
+int usb_cdc_rx_get(void);
+size_t usb_cdc_rx_available(void);
+void usb_cdc_rx_clear(void);
+#endif
+
 // Ports must call this from their particular USB IRQ handler
 void usb_irq_handler(int instance);
 


### PR DESCRIPTION
Fixes raw-REPL paste corruption on ESP32-S2/S3: console input is now read on the TinyUSB task, not the VM task.

## Cause

On espressif `tud_task()` runs in its own FreeRTOS task, so a VM read can re-arm the endpoint mid-copy.

| Step | Where |
|---|---|
| XFER_COMPLETE clears BUSY/CLAIMED on the OUT endpoint | `lib/tinyusb/src/device/usbd.c` |
| `cdcd_xfer_cb` then copies `ep_buf` into the RX fifo | `lib/tinyusb/src/class/cdc/cdc_device.c` |
| Meanwhile the VM's `tud_cdc_read_char()` re-arms DMA into the same `ep_buf` | `lib/tinyusb/src/tusb.c` `tu_edpt_stream_read_xfer` |
| Result: one 64-byte packet lost, the next repeated, length preserved | |

## Change

Espressif only (`CFG_TUSB_OS == OPT_OS_FREERTOS`). Other ports read the fifo directly, unchanged from main.

| File | Change |
|---|---|
| `supervisor/shared/usb/usb_device.c` | 256-byte `py/ringbuf`, filled on the TinyUSB task, every access inside `common_hal_mcu_disable_interrupts()` like espressif `_bleio/CharacteristicBuffer.c` |
| `ports/espressif/supervisor/usb.c` | drain on every usbd pass; `tud_task_ext(10, false)` so fifo input held back by a full ringbuf moves in without a new USB event (the loop's existing `tud_cdc_write_flush()` now runs too) |
| `supervisor/shared/serial.c` | REPL reads the ringbuf |
| `shared-module/usb_cdc/Serial.c` | `usb_cdc.console` read, `in_waiting`, `reset_input_buffer()` use the ringbuf |

## Hardware tested

Raw-REPL paste harness, 40 tests x 50 iterations per row. Host: Ubuntu 24.04.5 LTS.

| Board | Firmware | Failed pastes / 2000 |
|---|---|---|
| Metro ESP32-S3 | stock 10.3.0 | 14 |
| Metro ESP32-S3 | main 201776a6d2 | 25 |
| Metro ESP32-S3 | **this PR** | **0** |
| Metro ESP32-S2 | main + v1.29 merge (#11349), three runs | 4, 6, 2 |
| Metro ESP32-S2 | **this PR** | **0** |

| Check, this PR | Metro ESP32-S3 | Metro ESP32-S2 |
|---|---|---|
| Fresh connection: prompt, echo, Ctrl-C into busy loop | OK | OK |
| `usb_cdc.console.in_waiting` / `read()` from a REPL loop | OK | OK |
| `usb_cdc.enable(console=False, data=True)`, echo on `usb_cdc.data` | OK | OK |

| Non-espressif, this PR | 40-test burn | Ctrl-C | 2 KB and 4 KB raw REPL burst |
|---|---|---|---|
| Metro RP2350 | 40/40 | OK | OK |
| Metro M0 Express | 40/40 | OK | OK |

| Build check, this PR | Result |
|---|---|
| ESP32-P4 `adafruit_p4gpio`, ESP32-C3 (no native USB) | build, not run |
| Flash use, same-tree builds of `bless_dev_board_multi_sensor`, `circuitbrains_deluxe_m4`, `kicksat-sprite` | identical to main |

## Not covered

`usb_cdc.data` reads still come from the VM task on espressif. Same race class, separate change.

| CI job | Note |
|---|---|
| `zephyr-tests / nrf54lm20bsim` | BLE NUS test fails on main too (42af95d52e), unrelated |

## AI assistance

Written with Claude Code. I verified the mechanism in the source and ran every measurement above on my test boards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
