### PR TITLE
turbo: STM32F4 boards loader enable native .mpy default

### DIFF
--- a/ports/stm/mpconfigport.mk
+++ b/ports/stm/mpconfigport.mk
@@ -21,6 +21,7 @@ ifeq ($(MCU_VARIANT),STM32F407xx)
 endif
 
 ifeq ($(MCU_SERIES),F4)
+        CIRCUITPY_LOAD_NATIVE ?= 1
         # Audio via PWM (F405/F407 also supports DAC-based audioio; set above)
         CIRCUITPY_AUDIOIO ?= 0
         CIRCUITPY_AUDIOCORE ?= 1


### PR DESCRIPTION
## What

Enables the turbo loader (`CIRCUITPY_LOAD_NATIVE`) by default on STM32F4. 

All 16 boards fit.

Follow-up to #11332 (RP2). 

## Hardware tested

Feather STM32F405 Express 

`10.3.0-66-g55984e753c`, which includes this commit. 

| Board | vsum bytecode | vsum viper `.mpy` | pixels viper `.mpy` | pixels `@native` `.mpy` |
|---|---|---|---|---|
| Feather STM32F405 Express | 149.1 ms | 9.9 ms | 437 ms | 2,777 ms |

## How I tested it

All 24 stm boards built in their tightest CI language with GCC 15.2.1. 

Hardware used `vsum.py` from #11332 plus `pixels.py`.

| Tightest F4 boards | Language | Flash free with the loader |
|---|---|---|
| `meowbit_v121` | `ja` | 76 B |
| `espruino_pico` | `ja` | 16,844 B |
| `pyb_nano_v2` | `ja` | 18,892 B |
| `thunderpack_v11` | `ja` | 25,968 B |
| `thunderpack_v12` | `ja` | 36,332 B |
| other 11 F4 boards | | 37 to 443 KB |

## Scope

nRF52, SAMx5x and Xtensa loader support will be separate PRs.

## AI assistance

Claude Code was used.
