### PR TITLE
picogame: enable on pimoroni_picosystem

### DIFF
--- a/ports/raspberrypi/boards/pimoroni_picosystem/mpconfigboard.mk
+++ b/ports/raspberrypi/boards/pimoroni_picosystem/mpconfigboard.mk
@@ -12,7 +12,13 @@ CIRCUITPY__EVE = 1
 
 CIRCUITPY_KEYPAD = 1
 CIRCUITPY_STAGE = 1
+CIRCUITPY_PICOGAME = 1
+CIRCUITPY_PICOGAME_FAST_DISPLAY = 1
 
 CIRCUITPY_AUDIOIO = 1
 
 FROZEN_MPY_DIRS += $(TOP)/frozen/circuitpython-stage/picosystem
+
+# The default is -O3. picogame does not fit at -O3; these loop passes keep the render
+# kernels within 1% of it.
+OPTIMIZATION_FLAGS = -O2 -funswitch-loops -fpredictive-commoning -fgcse-after-reload -ftree-partial-pre -fsplit-paths


### PR DESCRIPTION
Enables picogame on pimoroni_picosystem: a 240x240 ST7789 over four-wire SPI, buttons and audio, which picogame's fast display path drives as it comes.

It does not fit at -O3: the firmware is at 95.3% of the 1020 KB partition and the engine needs another 50 KB. It builds at -O2 with five loop passes, which leaves 140 KB free and measures within 1% of -O3 on this M0+.